### PR TITLE
feat(algorithm): wire tier-A wave-1 convergence options (#15)

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -21,6 +21,7 @@
 //! `IpoptAlgorithm` lands once each strategy's arithmetic does.
 
 use crate::conv_check::opt_error::OptErrorConvCheck;
+use pounce_common::types::{Index, Number};
 use crate::eq_mult::least_square::LeastSquareMults;
 use crate::hess::exact::ExactHessianUpdater;
 use crate::hess::lim_mem_quasi_newton::{LimMemQuasiNewtonUpdater, UpdateType};
@@ -103,6 +104,46 @@ pub struct AlgorithmBundle {
     pub search_dir: Option<PdSearchDirCalc>,
 }
 
+/// Knobs read off `OptionsList` and baked into the assembled
+/// `OptErrorConvCheck`. Defaults mirror
+/// `IpOptErrorConvCheck.cpp:RegisterOptions`.
+#[derive(Debug, Clone)]
+pub struct ConvCheckOptions {
+    pub tol: Number,
+    pub dual_inf_tol: Number,
+    pub constr_viol_tol: Number,
+    pub compl_inf_tol: Number,
+    pub acceptable_tol: Number,
+    pub acceptable_dual_inf_tol: Number,
+    pub acceptable_constr_viol_tol: Number,
+    pub acceptable_compl_inf_tol: Number,
+    pub acceptable_obj_change_tol: Number,
+    pub acceptable_iter: Index,
+    pub max_iter: Index,
+    pub max_cpu_time: Number,
+    pub max_wall_time: Number,
+}
+
+impl Default for ConvCheckOptions {
+    fn default() -> Self {
+        Self {
+            tol: 1e-8,
+            dual_inf_tol: 1.0,
+            constr_viol_tol: 1e-4,
+            compl_inf_tol: 1e-4,
+            acceptable_tol: 1e-6,
+            acceptable_dual_inf_tol: 1e10,
+            acceptable_constr_viol_tol: 1e-2,
+            acceptable_compl_inf_tol: 1e-2,
+            acceptable_obj_change_tol: 1e20,
+            acceptable_iter: 15,
+            max_iter: 3000,
+            max_cpu_time: 1e6,
+            max_wall_time: 1e6,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct AlgorithmBuilder {
     pub linear_solver: LinearSolverChoice,
@@ -116,6 +157,7 @@ pub struct AlgorithmBuilder {
     pub line_search_method: LineSearchChoice,
     pub nlp_scaling_method: NlpScalingChoice,
     pub warm_start_init_point: bool,
+    pub conv_check: ConvCheckOptions,
 }
 
 impl Default for AlgorithmBuilder {
@@ -129,6 +171,7 @@ impl Default for AlgorithmBuilder {
             line_search_method: LineSearchChoice::Filter,
             nlp_scaling_method: NlpScalingChoice::GradientBased,
             warm_start_init_point: false,
+            conv_check: ConvCheckOptions::default(),
         }
     }
 }
@@ -179,7 +222,23 @@ impl AlgorithmBuilder {
         let line_search = BacktrackingLineSearch::new(acceptor);
 
         let conv_check: Box<dyn crate::conv_check::r#trait::ConvCheck> =
-            Box::new(OptErrorConvCheck::new());
+            Box::new(OptErrorConvCheck {
+                tol: self.conv_check.tol,
+                dual_inf_tol: self.conv_check.dual_inf_tol,
+                constr_viol_tol: self.conv_check.constr_viol_tol,
+                compl_inf_tol: self.conv_check.compl_inf_tol,
+                acceptable_tol: self.conv_check.acceptable_tol,
+                acceptable_dual_inf_tol: self.conv_check.acceptable_dual_inf_tol,
+                acceptable_constr_viol_tol: self.conv_check.acceptable_constr_viol_tol,
+                acceptable_compl_inf_tol: self.conv_check.acceptable_compl_inf_tol,
+                acceptable_obj_change_tol: self.conv_check.acceptable_obj_change_tol,
+                acceptable_iter: self.conv_check.acceptable_iter,
+                max_iter: self.conv_check.max_iter,
+                max_cpu_time: self.conv_check.max_cpu_time,
+                max_wall_time: self.conv_check.max_wall_time,
+                acceptable_count: 0,
+                last_acceptable_obj: None,
+            });
 
         let init: Box<dyn crate::init::r#trait::IterateInitializer> = if self.warm_start_init_point
         {
@@ -293,6 +352,7 @@ mod tests {
                                 line_search_method,
                                 nlp_scaling_method,
                                 warm_start_init_point: false,
+                                conv_check: ConvCheckOptions::default(),
                             }
                             .build();
                         }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -573,6 +573,61 @@ impl IpoptApplication {
                 _ => LinearSolverChoice::Feral,
             };
         }
+
+        // Convergence tolerances (port of `IpOptErrorConvCheck.cpp`'s
+        // `RegisterOptions` consumers). Defaults already match upstream
+        // — only override when the user set the key explicitly.
+        let read_num = |key: &str| -> Option<f64> {
+            self.options
+                .get_numeric_value(key, "")
+                .ok()
+                .and_then(|(v, f)| f.then_some(v))
+        };
+        let read_int = |key: &str| -> Option<i32> {
+            self.options
+                .get_integer_value(key, "")
+                .ok()
+                .and_then(|(v, f)| f.then_some(v))
+        };
+        if let Some(v) = read_num("tol") {
+            builder.conv_check.tol = v;
+        }
+        if let Some(v) = read_num("dual_inf_tol") {
+            builder.conv_check.dual_inf_tol = v;
+        }
+        if let Some(v) = read_num("constr_viol_tol") {
+            builder.conv_check.constr_viol_tol = v;
+        }
+        if let Some(v) = read_num("compl_inf_tol") {
+            builder.conv_check.compl_inf_tol = v;
+        }
+        if let Some(v) = read_int("max_iter") {
+            builder.conv_check.max_iter = v;
+        }
+        if let Some(v) = read_num("max_cpu_time") {
+            builder.conv_check.max_cpu_time = v;
+        }
+        if let Some(v) = read_num("max_wall_time") {
+            builder.conv_check.max_wall_time = v;
+        }
+        if let Some(v) = read_num("acceptable_tol") {
+            builder.conv_check.acceptable_tol = v;
+        }
+        if let Some(v) = read_num("acceptable_dual_inf_tol") {
+            builder.conv_check.acceptable_dual_inf_tol = v;
+        }
+        if let Some(v) = read_num("acceptable_constr_viol_tol") {
+            builder.conv_check.acceptable_constr_viol_tol = v;
+        }
+        if let Some(v) = read_num("acceptable_compl_inf_tol") {
+            builder.conv_check.acceptable_compl_inf_tol = v;
+        }
+        if let Some(v) = read_num("acceptable_obj_change_tol") {
+            builder.conv_check.acceptable_obj_change_tol = v;
+        }
+        if let Some(v) = read_int("acceptable_iter") {
+            builder.conv_check.acceptable_iter = v;
+        }
         builder
     }
 }

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -1,24 +1,41 @@
 //! Optimal-error convergence check — port of
 //! `Algorithm/IpOptErrorConvCheck.{hpp,cpp}`.
 //!
-//! Tolerance state machine over `(nlp_err, iter_count)`. The caller
-//! (the main loop) pulls `nlp_err` from
-//! `IpoptCalculatedQuantities::curr_nlp_error()` and `iter_count`
-//! from `IpoptData::iter_count` before each check. CPU/wall time
-//! gates land alongside `TimingStatistics` wiring; until then the
-//! relevant fields are stored but not consulted.
+//! Tolerance state machine over `(nlp_err, iter_count)` plus
+//! per-component infeasibilities pulled directly from
+//! [`IpoptCalculatedQuantities`]. The scalar
+//! [`Self::check_convergence`] entry point only gates on
+//! `nlp_err <= tol` (matching upstream when the per-component
+//! tolerances are at their `+∞` sentinels); the state-aware
+//! [`Self::check_convergence_with_state`] adds the
+//! `dual_inf_tol` / `constr_viol_tol` / `compl_inf_tol` gates that
+//! mirror upstream `OptimalityErrorConvergenceCheck::CheckConvergence`.
 
 use crate::conv_check::r#trait::{ConvCheck, ConvergenceStatus};
+use crate::ipopt_cq::IpoptCqHandle;
+use crate::ipopt_data::IpoptDataHandle;
 use pounce_common::types::{Index, Number};
 
 pub struct OptErrorConvCheck {
     pub tol: Number,
+    pub dual_inf_tol: Number,
+    pub constr_viol_tol: Number,
+    pub compl_inf_tol: Number,
     pub acceptable_tol: Number,
+    pub acceptable_dual_inf_tol: Number,
+    pub acceptable_constr_viol_tol: Number,
+    pub acceptable_compl_inf_tol: Number,
+    pub acceptable_obj_change_tol: Number,
     pub acceptable_iter: Index,
     pub max_iter: Index,
     pub max_cpu_time: Number,
     pub max_wall_time: Number,
     pub acceptable_count: Index,
+    /// Objective value at the last iterate the main loop stashed via
+    /// `set_curr_acceptable_obj`. Used by the
+    /// `acceptable_obj_change_tol` cross-check. `None` until an
+    /// acceptable point has been recorded.
+    pub last_acceptable_obj: Option<Number>,
 }
 
 impl Default for OptErrorConvCheck {
@@ -26,12 +43,20 @@ impl Default for OptErrorConvCheck {
         // Defaults from `IpOptErrorConvCheck.cpp:RegisterOptions`.
         Self {
             tol: 1e-8,
+            dual_inf_tol: 1.0,
+            constr_viol_tol: 1e-4,
+            compl_inf_tol: 1e-4,
             acceptable_tol: 1e-6,
+            acceptable_dual_inf_tol: 1e10,
+            acceptable_constr_viol_tol: 1e-2,
+            acceptable_compl_inf_tol: 1e-2,
+            acceptable_obj_change_tol: 1e20,
             acceptable_iter: 15,
             max_iter: 3000,
             max_cpu_time: 1e6,
             max_wall_time: 1e6,
             acceptable_count: 0,
+            last_acceptable_obj: None,
         }
     }
 }
@@ -39,6 +64,63 @@ impl Default for OptErrorConvCheck {
 impl OptErrorConvCheck {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Pure helper for the per-component upstream gate. Returns `true`
+    /// iff every supplied residual sits at or below its tolerance.
+    /// Factored out so tests can exercise the gating logic without
+    /// constructing a full `IpoptCq`.
+    fn passes_component_tols(
+        &self,
+        overall: Number,
+        dual_inf: Number,
+        constr_viol: Number,
+        compl_inf: Number,
+    ) -> bool {
+        overall <= self.tol
+            && dual_inf <= self.dual_inf_tol
+            && constr_viol <= self.constr_viol_tol
+            && compl_inf <= self.compl_inf_tol
+    }
+
+    /// Pure helper mirroring upstream
+    /// `OptimalityErrorConvergenceCheck::CurrentIsAcceptable`. Tests
+    /// the per-component `acceptable_*_tol` triplet plus the optional
+    /// `acceptable_obj_change_tol` stability cross-check.
+    fn passes_acceptable_tols(
+        &self,
+        overall: Number,
+        dual_inf: Number,
+        constr_viol: Number,
+        compl_inf: Number,
+        curr_f: Number,
+    ) -> bool {
+        if !overall.is_finite() {
+            return false;
+        }
+        let component_ok = overall <= self.acceptable_tol
+            && dual_inf <= self.acceptable_dual_inf_tol
+            && constr_viol <= self.acceptable_constr_viol_tol
+            && compl_inf <= self.acceptable_compl_inf_tol;
+        if !component_ok {
+            return false;
+        }
+        // Upstream `IpOptErrorConvCheck.cpp:CurrentIsAcceptable` — when
+        // an acceptable point has already been recorded and the user
+        // tightened `acceptable_obj_change_tol` below the 1e20
+        // sentinel, the iterate is only re-acceptable if `f` has moved
+        // by less than `tol * max(1, |f|)` relative to the recorded
+        // value. Skipped when no prior point exists or the cross-check
+        // is disabled.
+        if self.acceptable_obj_change_tol < 1e20 {
+            if let Some(prev) = self.last_acceptable_obj {
+                let denom = curr_f.abs().max(1.0);
+                if (prev - curr_f).abs() >= self.acceptable_obj_change_tol * denom {
+                    return false;
+                }
+            }
+        }
+        true
     }
 }
 
@@ -61,20 +143,85 @@ impl ConvCheck for OptErrorConvCheck {
         ConvergenceStatus::Continue
     }
 
+    fn check_convergence_with_state(
+        &mut self,
+        nlp_err: Number,
+        iter_count: Index,
+        data: &IpoptDataHandle,
+        cq: &IpoptCqHandle,
+    ) -> ConvergenceStatus {
+        // Mirror upstream `IpOptErrorConvCheck.cpp::CheckConvergence`:
+        // the scaled scalar `nlp_err` must drop below `tol` AND each
+        // unscaled component must sit under its own tolerance. The
+        // `acceptable_*` machinery still runs off the scalar; that
+        // expansion lands with the `acceptable_*` option wiring.
+        let cq_ref = cq.borrow();
+        let dual_inf = cq_ref.curr_dual_infeasibility_max();
+        let constr_viol = cq_ref.curr_primal_infeasibility_max();
+        let compl_inf = cq_ref.curr_complementarity_max();
+        let curr_f = cq_ref.curr_f();
+        drop(cq_ref);
+
+        if self.passes_component_tols(nlp_err, dual_inf, constr_viol, compl_inf) {
+            return ConvergenceStatus::Converged;
+        }
+        if self.passes_acceptable_tols(nlp_err, dual_inf, constr_viol, compl_inf, curr_f) {
+            self.acceptable_count += 1;
+            if self.acceptable_count >= self.acceptable_iter {
+                return ConvergenceStatus::Converged;
+            }
+        } else {
+            self.acceptable_count = 0;
+        }
+        if iter_count >= self.max_iter {
+            return ConvergenceStatus::MaxIterExceeded;
+        }
+        // Time-budget gates. Upstream
+        // `IpOptErrorConvCheck.cpp::CheckConvergence` reads the
+        // application-level start time; pounce piggybacks on
+        // `data.timing.overall_alg`, which `IpoptApplication` starts
+        // at the top of `optimize_constrained`. `live_*` returns the
+        // running elapsed without forcing a `start/end` cycle.
+        let timing = &data.borrow().timing;
+        if timing.overall_alg.live_cpu_time() >= self.max_cpu_time {
+            return ConvergenceStatus::CpuTimeExceeded;
+        }
+        if timing.overall_alg.live_wallclock_time() >= self.max_wall_time {
+            return ConvergenceStatus::WallTimeExceeded;
+        }
+        ConvergenceStatus::Continue
+    }
+
     fn tol_or_default(&self) -> Number {
         self.tol
     }
 
     fn current_is_acceptable(&self, nlp_err: Number) -> bool {
-        // Mirrors upstream
-        // `OptimalityErrorConvergenceCheck::CurrentIsAcceptable`
-        // (`IpOptErrorConvCheck.cpp`): the iterate is "acceptable" iff
-        // the NLP optimality error is at or below the looser
-        // acceptable tolerance. Upstream cross-checks the unscaled
-        // primal/dual residuals against `acceptable_constr_viol_tol`
-        // and friends; we approximate with the scalar nlp_err since
-        // pounce's `curr_nlp_error` already aggregates those.
+        // Scalar fallback used when the caller has no `IpoptCq` handle
+        // (e.g. unit tests). The state-aware variant
+        // [`Self::current_is_acceptable_with_state`] mirrors upstream
+        // more faithfully by gating on the per-component
+        // `acceptable_*_tol` triplet plus the obj-change cross-check.
         nlp_err.is_finite() && nlp_err <= self.acceptable_tol
+    }
+
+    fn current_is_acceptable_with_state(
+        &self,
+        nlp_err: Number,
+        _data: &IpoptDataHandle,
+        cq: &IpoptCqHandle,
+    ) -> bool {
+        let cq_ref = cq.borrow();
+        let dual_inf = cq_ref.curr_dual_infeasibility_max();
+        let constr_viol = cq_ref.curr_primal_infeasibility_max();
+        let compl_inf = cq_ref.curr_complementarity_max();
+        let curr_f = cq_ref.curr_f();
+        drop(cq_ref);
+        self.passes_acceptable_tols(nlp_err, dual_inf, constr_viol, compl_inf, curr_f)
+    }
+
+    fn set_curr_acceptable_obj(&mut self, obj: Number) {
+        self.last_acceptable_obj = Some(obj);
     }
 }
 
@@ -112,6 +259,74 @@ mod tests {
         assert_eq!(c.check_convergence(1e-7, 2), ConvergenceStatus::Continue);
         assert_eq!(c.check_convergence(1e-7, 3), ConvergenceStatus::Continue);
         assert_eq!(c.check_convergence(1e-7, 4), ConvergenceStatus::Converged);
+    }
+
+    #[test]
+    fn passes_acceptable_tols_gates_on_per_component_triplet() {
+        let c = OptErrorConvCheck {
+            acceptable_tol: 1e-6,
+            acceptable_dual_inf_tol: 1e-3,
+            acceptable_constr_viol_tol: 1e-3,
+            acceptable_compl_inf_tol: 1e-3,
+            ..Default::default()
+        };
+        assert!(c.passes_acceptable_tols(1e-7, 1e-4, 1e-4, 1e-4, 0.0));
+        // dual_inf above its acceptable threshold blocks.
+        assert!(!c.passes_acceptable_tols(1e-7, 1.0, 1e-4, 1e-4, 0.0));
+        // overall above acceptable_tol blocks.
+        assert!(!c.passes_acceptable_tols(1e-5, 1e-4, 1e-4, 1e-4, 0.0));
+    }
+
+    #[test]
+    fn passes_acceptable_tols_honors_obj_change_tol() {
+        let mut c = OptErrorConvCheck {
+            acceptable_tol: 1e-6,
+            acceptable_dual_inf_tol: 1.0,
+            acceptable_constr_viol_tol: 1.0,
+            acceptable_compl_inf_tol: 1.0,
+            acceptable_obj_change_tol: 0.1,
+            ..Default::default()
+        };
+        // First call always acceptable (no prior obj).
+        assert!(c.passes_acceptable_tols(1e-7, 0.0, 0.0, 0.0, 10.0));
+        c.set_curr_acceptable_obj(10.0);
+        // Same f → change well under threshold → still acceptable.
+        assert!(c.passes_acceptable_tols(1e-7, 0.0, 0.0, 0.0, 10.0));
+        // f moved by 2.0 with threshold 0.1 * max(1, |11.0|) = 1.1 →
+        // absolute change 1.0 < 1.1: acceptable.
+        assert!(c.passes_acceptable_tols(1e-7, 0.0, 0.0, 0.0, 11.0));
+        // f moved by 5.0 — absolute change 5.0 > 1.5 = 0.1 * 15 →
+        // rejected (the stability cross-check fires).
+        assert!(!c.passes_acceptable_tols(1e-7, 0.0, 0.0, 0.0, 15.0));
+    }
+
+    use crate::conv_check::r#trait::ConvCheck;
+
+    #[test]
+    fn set_curr_acceptable_obj_records_for_cross_check() {
+        let mut c = OptErrorConvCheck::new();
+        assert!(c.last_acceptable_obj.is_none());
+        ConvCheck::set_curr_acceptable_obj(&mut c, 4.2);
+        assert_eq!(c.last_acceptable_obj, Some(4.2));
+    }
+
+    #[test]
+    fn passes_component_tols_requires_all_under_threshold() {
+        let c = OptErrorConvCheck {
+            tol: 1e-8,
+            dual_inf_tol: 1.0,
+            constr_viol_tol: 1e-4,
+            compl_inf_tol: 1e-4,
+            ..Default::default()
+        };
+        // All under threshold → converged.
+        assert!(c.passes_component_tols(1e-9, 0.5, 1e-5, 1e-5));
+        // dual_inf above its tolerance blocks even when nlp_err is tiny.
+        assert!(!c.passes_component_tols(1e-12, 2.0, 1e-5, 1e-5));
+        // compl_inf above its tolerance blocks.
+        assert!(!c.passes_component_tols(1e-12, 0.0, 0.0, 1e-2));
+        // constr_viol above its tolerance blocks.
+        assert!(!c.passes_component_tols(1e-12, 0.0, 1e-2, 0.0));
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/conv_check/trait.rs
+++ b/crates/pounce-algorithm/src/conv_check/trait.rs
@@ -21,6 +21,12 @@ pub enum ConvergenceStatus {
     Continue,
     Converged,
     MaxIterExceeded,
+    /// `max_cpu_time` budget reached. Maps to
+    /// `SolverReturn::CpuTimeExceeded` → `MaximumCpuTimeExceeded`.
+    CpuTimeExceeded,
+    /// `max_wall_time` budget reached. Maps to
+    /// `SolverReturn::WallTimeExceeded` → `MaximumWallTimeExceeded`.
+    WallTimeExceeded,
     Failed,
 }
 
@@ -54,6 +60,29 @@ pub trait ConvCheck {
     fn current_is_acceptable(&self, _nlp_err: Number) -> bool {
         false
     }
+
+    /// State-aware acceptance check. Mirrors upstream
+    /// `OptimalityErrorConvergenceCheck::CurrentIsAcceptable` which
+    /// reads the per-component residuals and current `f` to gate the
+    /// `acceptable_dual_inf_tol` / `acceptable_constr_viol_tol` /
+    /// `acceptable_compl_inf_tol` / `acceptable_obj_change_tol`
+    /// triplet. Default delegates to the scalar [`Self::current_is_acceptable`].
+    fn current_is_acceptable_with_state(
+        &self,
+        nlp_err: Number,
+        _data: &IpoptDataHandle,
+        _cq: &IpoptCqHandle,
+    ) -> bool {
+        self.current_is_acceptable(nlp_err)
+    }
+
+    /// Record the current objective at the iterate the main loop just
+    /// stashed as the latest "acceptable point" — mirrors upstream
+    /// `OptimalityErrorConvergenceCheck::SetCurrAcceptableF`. The
+    /// recorded value feeds the `acceptable_obj_change_tol` stability
+    /// cross-check on subsequent iterates. Default no-op for policies
+    /// that don't track acceptable points.
+    fn set_curr_acceptable_obj(&mut self, _obj: Number) {}
 
     /// Outer NLP convergence tolerance, as used by the main loop's
     /// almost-feasible bypass guard (port of

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -303,19 +303,36 @@ impl IpoptAlgorithm {
                 timing.check_convergence.end();
                 return IterateOutcome::Terminate(SolverReturn::MaxiterExceeded);
             }
+            ConvergenceStatus::CpuTimeExceeded => {
+                timing.check_convergence.end();
+                return IterateOutcome::Terminate(SolverReturn::CpuTimeExceeded);
+            }
+            ConvergenceStatus::WallTimeExceeded => {
+                timing.check_convergence.end();
+                return IterateOutcome::Terminate(SolverReturn::WallTimeExceeded);
+            }
             ConvergenceStatus::Failed => {
                 timing.check_convergence.end();
                 return IterateOutcome::Terminate(SolverReturn::InternalError);
             }
         }
 
-        // Stash the iterate if it satisfies `acceptable_tol`. Mirrors
-        // upstream `IpBacktrackingLineSearch.cpp:282-289` — checked at
-        // the top of every line-search call so the most recent
-        // acceptable iterate is always available as a rollback target
-        // if restoration later fails.
-        if self.bundle.conv_check.current_is_acceptable(nlp_err) {
+        // Stash the iterate if it satisfies the per-component
+        // `acceptable_*_tol` triplet. Mirrors upstream
+        // `IpBacktrackingLineSearch.cpp:282-289` — checked at the top
+        // of every line-search call so the most recent acceptable
+        // iterate is always available as a rollback target if
+        // restoration later fails. The recorder feeds
+        // `acceptable_obj_change_tol`'s stability cross-check on
+        // subsequent iterates.
+        if self
+            .bundle
+            .conv_check
+            .current_is_acceptable_with_state(nlp_err, &self.data, &self.cq)
+        {
             self.store_acceptable_point();
+            let curr_f = self.cq.borrow().curr_f();
+            self.bundle.conv_check.set_curr_acceptable_obj(curr_f);
         }
         timing.check_convergence.end();
 

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -796,6 +796,21 @@ impl IpoptCalculatedQuantities {
         if acc.is_infinite() { 0.0 } else { acc }
     }
 
+    /// Max-norm of the unbarriered complementarity blocks
+    /// `max_i |s_i · z_i|` across all four `(x_L, x_U, s_L, s_U)`
+    /// pairs. Mirrors upstream
+    /// `IpIpoptCalculatedQuantities.cpp:CurrComplementarity(0., NORM_MAX)`
+    /// — used by `OptimalityErrorConvergenceCheck` to gate the
+    /// per-component `compl_inf_tol` test independently of the scaled
+    /// scalar `curr_nlp_error`.
+    pub fn curr_complementarity_max(&self) -> Number {
+        self.curr_compl_x_l()
+            .amax()
+            .max(self.curr_compl_x_u().amax())
+            .max(self.curr_compl_s_l().amax())
+            .max(self.curr_compl_s_u().amax())
+    }
+
     /// Centrality measure `ξ = min_i(s_i z_i) / avrg(s · z)`. Mirrors
     /// `IpIpoptCalculatedQuantities.cpp:CurrCentralityMeasure`. Used
     /// by [`crate::mu::oracle::loqo::LoqoMuOracle`] to bias σ toward

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -284,6 +284,155 @@ fn hs071_solves_with_adaptive_mu_quality_function_oracle() {
     );
 }
 
+/// Setting `dual_inf_tol` and `compl_inf_tol` impossibly small must
+/// block the scaled-error convergence path. Baseline HS71 reports
+/// `SolveSucceeded` in single-digit iters; with the per-component
+/// gate set to 1e-20 the solver can't claim success on the same
+/// iterate, so it exits through the tiny-step / max-iter side
+/// instead. Demonstrates that the per-component gate from
+/// `OptimalityErrorConvergenceCheck::CheckConvergence` is wired
+/// through end-to-end.
+#[test]
+fn hs071_dual_inf_tol_blocks_convergence() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_numeric_value("dual_inf_tol", 1e-20, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("compl_inf_tol", 1e-20, true, false)
+        .unwrap();
+    // Disable the acceptable-streak fallback so the only way out is
+    // SearchDirectionBecomesTooSmall / MaximumIterationsExceeded.
+    app.options_mut()
+        .set_integer_value("acceptable_iter", 9999, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("max_iter", 25, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(Hs071::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    eprintln!(
+        "HS71 strict dual/compl: status={:?} iter={}",
+        status, stats.iteration_count,
+    );
+    assert!(
+        !matches!(status, ApplicationReturnStatus::SolveSucceeded),
+        "per-component gate ignored: status = {status:?}",
+    );
+}
+
+/// Tightening `tol` past machine precision and pairing it with a
+/// generous `acceptable_tol = 1e-4` plus `acceptable_iter = 1` must
+/// route HS71 through `SolvedToAcceptableLevel`. Demonstrates that
+/// the `acceptable_*` triplet is wired through `OptionsList`.
+#[test]
+fn hs071_acceptable_tol_triggers_acceptable_level_status() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_numeric_value("tol", 1e-30, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_numeric_value("acceptable_tol", 1e-4, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("acceptable_iter", 1, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("max_iter", 25, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(Hs071::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    eprintln!(
+        "HS71 acceptable: status={:?} iter={} obj={}",
+        status, stats.iteration_count, stats.final_objective,
+    );
+    // The streak fires inside the conv-check (returns Converged), so
+    // the application maps it to SolveSucceeded — same return code
+    // upstream uses when the acceptable streak supplies the
+    // termination. The pounce-side `SolvedToAcceptableLevel` status
+    // is reserved for the restore-acceptable-on-restoration-failure
+    // path. Either way, the run must succeed without hitting
+    // max_iter.
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+    assert!(
+        stats.iteration_count < 25,
+        "iter_count = {} (expected < 25)",
+        stats.iteration_count,
+    );
+    assert!(
+        (stats.final_objective - 17.014017).abs() < 1e-3,
+        "final_objective = {}",
+        stats.final_objective,
+    );
+}
+
+/// `max_wall_time` set to effectively zero must short-circuit the
+/// solver before the first real iterate test. Maps to
+/// `MaximumWallTimeExceeded` per upstream.
+#[test]
+fn hs071_max_wall_time_terminates() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_numeric_value("max_wall_time", 1e-12, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(Hs071::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    eprintln!(
+        "HS71 wall budget: status={:?} iter={} wall_s={:.6}",
+        status, stats.iteration_count, stats.total_wallclock_time_secs,
+    );
+    assert!(
+        matches!(status, ApplicationReturnStatus::MaximumWallTimeExceeded),
+        "unexpected status: {status:?}",
+    );
+}
+
+/// `max_cpu_time` analogue.
+#[test]
+fn hs071_max_cpu_time_terminates() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_numeric_value("max_cpu_time", 1e-12, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(Hs071::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    eprintln!(
+        "HS71 cpu budget: status={:?} iter={}",
+        status, stats.iteration_count,
+    );
+    assert!(
+        matches!(status, ApplicationReturnStatus::MaximumCpuTimeExceeded),
+        "unexpected status: {status:?}",
+    );
+}
+
 #[test]
 fn hs071_solves_with_adaptive_mu_probing_oracle() {
     let mut app = IpoptApplication::new();

--- a/crates/pounce-common/src/timing.rs
+++ b/crates/pounce-common/src/timing.rs
@@ -84,6 +84,29 @@ impl TimedTask {
     pub fn total_sys_time(&self) -> Number { self.total_sys.get() }
     pub fn total_wallclock_time(&self) -> Number { self.total_wall.get() }
 
+    /// Running wallclock seconds since `start()` plus accumulated total
+    /// from prior start/end cycles. When the task is not currently
+    /// started this is the same as [`Self::total_wallclock_time`].
+    /// Used by `OptErrorConvCheck` to gate `max_wall_time` mid-solve
+    /// without forcing a `start()`/`end()` round-trip every iter.
+    pub fn live_wallclock_time(&self) -> Number {
+        if self.enabled.get() && self.start_called.get() {
+            self.total_wall.get() + wallclock_time() - self.start_wall.get()
+        } else {
+            self.total_wall.get()
+        }
+    }
+
+    /// Live counterpart of [`Self::total_cpu_time`]; see
+    /// [`Self::live_wallclock_time`] for the contract.
+    pub fn live_cpu_time(&self) -> Number {
+        if self.enabled.get() && self.start_called.get() {
+            self.total_cpu.get() + cpu_time() - self.start_cpu.get()
+        } else {
+            self.total_cpu.get()
+        }
+    }
+
     /// RAII-style guard: start the timer immediately, end it when the
     /// returned value is dropped (or when [`TimedGuard::stop`] is
     /// called). Survives early returns / `?` in the caller scope.

--- a/docs/issue-15-tier-a-wave-1.md
+++ b/docs/issue-15-tier-a-wave-1.md
@@ -1,0 +1,200 @@
+# Issue #15 — Tier A, Wave 1: option wiring notes
+
+**Status: wired.** All ten options below now drive solver behavior.
+
+Scope: wire the lowest-effort / highest-impact stub options identified in
+issue #15. Three groups:
+
+1. `max_cpu_time`, `max_wall_time` — time-budget termination
+2. `dual_inf_tol`, `compl_inf_tol` — fill out the convergence-tolerance triplet
+3. `acceptable_*` (6 options) — relaxed-convergence acceptance
+
+This file is a working reference: where each option is registered, where
+the comparable live option is consumed today, what to edit, and what to
+test. Citations are `file:line` against pounce HEAD at the time of writing.
+
+## Summary of what landed
+
+- `crates/pounce-common/src/timing.rs` — added
+  `TimedTask::live_wallclock_time` / `live_cpu_time` so the conv check
+  can read elapsed time mid-solve.
+- `crates/pounce-algorithm/src/ipopt_cq.rs` — added
+  `curr_complementarity_max` (max-norm of unbarriered complementarity
+  blocks) to support the per-component compl gate.
+- `crates/pounce-algorithm/src/conv_check/trait.rs` — extended
+  `ConvergenceStatus` with `CpuTimeExceeded` / `WallTimeExceeded`;
+  added `current_is_acceptable_with_state` and
+  `set_curr_acceptable_obj` trait methods.
+- `crates/pounce-algorithm/src/conv_check/opt_error.rs` — new fields
+  (`dual_inf_tol`, `constr_viol_tol`, `compl_inf_tol`, plus the four
+  `acceptable_*` per-component tolerances, plus
+  `last_acceptable_obj`); `check_convergence_with_state` now enforces
+  the upstream per-component gate + time budgets; the
+  `passes_component_tols` / `passes_acceptable_tols` pure helpers are
+  unit-tested.
+- `crates/pounce-algorithm/src/alg_builder.rs` — new
+  `ConvCheckOptions` struct on `AlgorithmBuilder`; `build_inner`
+  bakes its fields into the assembled `OptErrorConvCheck`.
+- `crates/pounce-algorithm/src/application.rs` — reads each option
+  off `OptionsList` and pushes it into the builder's
+  `ConvCheckOptions`.
+- `crates/pounce-algorithm/src/ipopt_alg.rs` — main loop now maps the
+  two new convergence statuses; `current_is_acceptable_with_state`
+  replaces the scalar call; the obj at the stashed iterate is
+  recorded via `set_curr_acceptable_obj`.
+- Tests: 4 new unit tests in `opt_error.rs`; 4 new integration tests
+  in `tests/optimize_hs71.rs` covering the dual/compl gate, both time
+  budgets, and the acceptable-streak success path.
+
+## 1. Where the options are registered
+
+All ten options are already registered in
+`crates/pounce-algorithm/src/upstream_options.rs` under the "Termination"
+category (line 213):
+
+| Line | Option                       | Type   | Default |
+|-----:|------------------------------|--------|--------:|
+| 215  | `max_wall_time`              | number | `1e20`  |
+| 216  | `max_cpu_time`               | number | `1e20`  |
+| 217  | `dual_inf_tol`               | number | `1.0`   |
+| 219  | `compl_inf_tol`              | number | `1e-4`  |
+| 220  | `acceptable_tol`             | number | `1e-6`  |
+| 221  | `acceptable_iter`            | int    | `15`    |
+| 222  | `acceptable_dual_inf_tol`    | number | `1e10`  |
+| 223  | `acceptable_constr_viol_tol` | number | `1e-2`  |
+| 224  | `acceptable_compl_inf_tol`   | number | `1e-2`  |
+| 225  | `acceptable_obj_change_tol`  | number | `1e20`  |
+
+Defaults mirror upstream Ipopt 3.14. No changes needed in `upstream_options.rs`.
+
+## 2. How a live option is consumed today (reference pattern)
+
+`tol` (live):
+- read at `crates/pounce-algorithm/src/application.rs:431` via
+  `get_numeric_value("tol", "")` (default `1e-8`)
+- assigned into `data.borrow_mut().tol` at line 435
+
+`constr_viol_tol` (live):
+- read at `crates/pounce-algorithm/src/application.rs:323`
+  (default `1e-4`)
+- consumed by `orig_nlp.relax_bounds(bound_relax_factor, constr_viol_tol)`
+  at line 327
+
+Pattern: read options in `IpoptApplication::optimize_tnlp`, push the
+values into the struct(s) used at iterate time. The wave-1 work follows
+this pattern.
+
+## 3. Existing convergence-check infrastructure
+
+`OptErrorConvCheck` (`crates/pounce-algorithm/src/conv_check/opt_error.rs:14-22`)
+already carries the fields we need:
+
+```text
+tol, acceptable_tol, acceptable_iter, max_iter,
+max_cpu_time, max_wall_time, acceptable_count
+```
+
+`max_cpu_time` / `max_wall_time` fields exist but the main loop never
+checks them. `acceptable_tol` and `acceptable_iter` exist but are
+populated from hard-coded defaults, not from `OptionsList`.
+
+Acceptance probe (`current_is_acceptable`,
+`crates/pounce-algorithm/src/conv_check/opt_error.rs:68-78`) currently
+gates only on `nlp_err <= acceptable_tol`. Upstream's
+`OptimalityErrorConvergenceCheck::CurrentIsAcceptable` also checks the
+per-criterion tolerances (`acceptable_dual_inf_tol`,
+`acceptable_constr_viol_tol`, `acceptable_compl_inf_tol`) and the
+objective-change tolerance (`acceptable_obj_change_tol`). Wave 1 expands
+the probe to match.
+
+Call site for the acceptance probe:
+`crates/pounce-algorithm/src/ipopt_alg.rs:317` — decides whether to call
+`store_acceptable_point()`.
+
+Return code plumbing already exists:
+- `pounce-nlp/src/return_codes.rs:15` — `SolvedToAcceptableLevel`
+- `pounce-algorithm/src/application.rs:638` — maps to
+  `StopAtAcceptablePoint`
+
+## 4. Where the main loop lives
+
+`IpoptAlgorithm::optimize` main loop:
+`crates/pounce-algorithm/src/ipopt_alg.rs:1071-1100`
+
+Convergence call inside `iterate`:
+`crates/pounce-algorithm/src/ipopt_alg.rs:290-295`
+```rust
+self.bundle.conv_check.check_convergence_with_state(
+    nlp_err, iter_count, &self.data, &self.cq)
+```
+
+Termination match: `ipopt_alg.rs:296-310`
+(`Continue | Converged | MaxIterExceeded | Failed`).
+
+`MaxIter` is currently checked inside `check_convergence_with_state`
+against the hard-coded value at line 1087. We'll need a parallel
+`MaxCpuTimeExceeded` / `MaxWallTimeExceeded` branch (or fold into
+`MaxIterExceeded`-style "stop now" status with the right return code).
+
+## 5. Time tracking
+
+No elapsed-since-start field on `IpoptData` today. Timing infrastructure
+exists:
+
+- `IpoptData.timing: Rc<TimingStatistics>`
+  (`crates/pounce-algorithm/src/ipopt_data.rs:33-103`, field at 102)
+- `TimingStatistics`
+  (`crates/pounce-common/src/timing.rs:129-153`)
+- `overall_alg: TimedTask` is started in
+  `crates/pounce-algorithm/src/application.rs:281`
+- `TimedTask::total_wallclock_time()` / `total_cpu_time()` already give
+  elapsed seconds (`pounce-common/src/timing.rs:14-94`)
+
+Wave 1 plan: read `overall_alg.total_wallclock_time()` and
+`.total_cpu_time()` from inside `check_convergence_with_state`. No new
+state needed.
+
+Upstream return codes:
+- `MaximumCpuTimeExceeded`
+- `MaximumWallTimeExceeded`
+
+Confirm both exist in `pounce-nlp/src/return_codes.rs` before wiring; add
+if missing.
+
+## 6. Tests
+
+Integration tests: `crates/pounce-algorithm/tests/*.rs`
+Examples to mirror:
+- `optimize_hs71.rs:144` — `hs071_solves_via_application`
+- `optimize_hs71.rs:195` — `hs071_solves_with_penalty_line_search`
+
+Unit tests live alongside implementation, e.g.
+`crates/pounce-algorithm/src/conv_check/opt_error.rs:81-105`.
+
+Wave 1 should add at minimum:
+
+- `max_cpu_time=1e-9` → solve returns `MaximumCpuTimeExceeded` (or wall
+  equivalent) immediately
+- Non-default `acceptable_tol` triggers `SolvedToAcceptableLevel` on a
+  problem that doesn't reach `tol`
+- `dual_inf_tol` / `compl_inf_tol` set tight enough to *prevent*
+  convergence on a problem that otherwise converges; loose enough to
+  allow it.
+
+## 7. Order of work
+
+1. `dual_inf_tol` / `compl_inf_tol` — smallest change; modifies the
+   convergence struct's per-criterion gate.
+2. `max_cpu_time` / `max_wall_time` — adds two new termination branches;
+   needs return-code additions if missing.
+3. `acceptable_*` — wire the six options through application → conv
+   check, expand `current_is_acceptable` to match upstream.
+
+Each step is one commit with its test.
+
+## Out of scope (wave 1)
+
+- Output / logging options (wave 2)
+- `mu_init` / `mu_max` / `mu_min` / `mu_target` (wave 2)
+- Watchdog options (wave 2)
+- Anything in tier B / C / D


### PR DESCRIPTION
## Summary

Wires ten Ipopt-compatible options from tier-A wave 1 of #15 so they actually drive solver behavior instead of being silently ignored.

- **Time budgets** — `max_cpu_time`, `max_wall_time` terminate the main loop via new `ConvergenceStatus::{CpuTimeExceeded, WallTimeExceeded}` variants. `TimedTask` gains `live_wallclock_time` / `live_cpu_time` so the conv check can read elapsed time mid-solve.
- **Per-component convergence gate** — `dual_inf_tol`, `compl_inf_tol`, and (as a convergence gate, not just `relax_bounds`) `constr_viol_tol` are now enforced alongside the scalar `tol`, mirroring upstream `OptimalityErrorConvergenceCheck::CheckConvergence`. `IpoptCalculatedQuantities` gains `curr_complementarity_max`.
- **Acceptable level** — `acceptable_tol`, `acceptable_iter`, `acceptable_dual_inf_tol`, `acceptable_constr_viol_tol`, `acceptable_compl_inf_tol`, and `acceptable_obj_change_tol` implement the full upstream `CurrentIsAcceptable` (per-component triplet + obj-stability cross-check). The `set_curr_acceptable_obj` recorder is hooked into `store_acceptable_point`.

Plumbing: `AlgorithmBuilder` gains a `ConvCheckOptions` struct populated by `application.rs` from `OptionsList`.

Per-option semantics match upstream's `IpOptErrorConvCheck.cpp::RegisterOptions` defaults and `CheckConvergence` / `CurrentIsAcceptable` logic.

## Test plan

- [x] 4 new unit tests in `conv_check/opt_error.rs` for `passes_component_tols`, `passes_acceptable_tols` (per-component + obj-change), and `set_curr_acceptable_obj`.
- [x] 4 new integration tests in `tests/optimize_hs71.rs`: `dual_inf_tol` impossibly small blocks scalar-tol convergence; `max_cpu_time=1e-12` and `max_wall_time=1e-12` return the correct status; `acceptable_tol=1e-4` + `acceptable_iter=1` triggers the acceptable-streak path.
- [x] Full workspace `cargo test` passes (no existing tests regressed).

Implementation notes in `docs/issue-15-tier-a-wave-1.md`.

Closes part of #15 (tier A, wave 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
