### PR TITLE
feat(algorithm,cli): wire tier-A wave-3 iter-output toggles (#15)

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -220,6 +220,15 @@ impl Default for LineSearchOptions {
 pub struct OutputOptions {
     pub print_frequency_iter: Index,
     pub print_frequency_time: Number,
+    /// `print_info_string` (default `false`). When on, the iter row
+    /// ends with the contents of `IpoptData::info_string` so users
+    /// can read the per-iteration diagnostic tags.
+    pub print_info_string: bool,
+    /// `inf_pr_output` — `"original"` (default) prints the unscaled
+    /// NLP primal infeasibility; `"internal"` prints the internal
+    /// reformulated violation. Only meaningful once NLP-side scaling
+    /// is in play; until then both modes produce the same number.
+    pub inf_pr_output_internal: bool,
 }
 
 impl Default for OutputOptions {
@@ -227,6 +236,8 @@ impl Default for OutputOptions {
         Self {
             print_frequency_iter: 1,
             print_frequency_time: 0.0,
+            print_info_string: false,
+            inf_pr_output_internal: false,
         }
     }
 }
@@ -362,9 +373,20 @@ impl AlgorithmBuilder {
         };
 
         let iter_output: Box<dyn crate::output::r#trait::IterationOutput> = {
+            use crate::output::orig::{InfPrTag, PrintInfoString};
             let mut o = OrigIterationOutput::new();
             o.print_frequency_iter = self.output.print_frequency_iter;
             o.print_frequency_time = self.output.print_frequency_time;
+            o.print_info_string = if self.output.print_info_string {
+                PrintInfoString::Yes
+            } else {
+                PrintInfoString::No
+            };
+            o.inf_pr_output = if self.output.inf_pr_output_internal {
+                InfPrTag::Internal
+            } else {
+                InfPrTag::Original
+            };
             Box::new(o)
         };
 

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -310,6 +310,19 @@ impl IpoptApplication {
     fn optimize_constrained(&mut self, tnlp: Rc<RefCell<dyn TNLP>>) -> ApplicationReturnStatus {
         let t_start = Instant::now();
 
+        // `print_user_options yes` — dump the OptionsList before the
+        // solve. Mirrors `IpoptApplication::call_optimize` (upstream
+        // calls `Jnlst().Printf(.., "%s", options_->PrintUserOptions())`).
+        let print_opts = self
+            .options
+            .get_bool_value("print_user_options", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(false);
+        if print_opts {
+            print!("\nList of user-set options:\n\n{}", self.options.print_user_options());
+        }
+
         // Mint a fresh `TimingStatistics` for this solve — shared (via
         // `Rc`) with the data and the NLP below so every `eval_*` and
         // every iterate-phase records into the same accumulator. The
@@ -726,6 +739,16 @@ impl IpoptApplication {
         }
         if let Some(v) = read_num("print_frequency_time") {
             builder.output.print_frequency_time = v;
+        }
+        if let Ok((v, found)) = self.options.get_bool_value("print_info_string", "") {
+            if found {
+                builder.output.print_info_string = v;
+            }
+        }
+        if let Ok((v, found)) = self.options.get_string_value("inf_pr_output", "") {
+            if found {
+                builder.output.inf_pr_output_internal = v == "internal";
+            }
         }
         builder
     }

--- a/crates/pounce-algorithm/src/output/orig.rs
+++ b/crates/pounce-algorithm/src/output/orig.rs
@@ -98,7 +98,7 @@ impl IterationOutput for OrigIterationOutput {
         let alpha_char = d.info_alpha_primal_char;
         let ls_count = d.info_ls_count;
 
-        format!(
+        let mut row = format!(
             "{:>4} {:14.7e} {:7.2e} {:7.2e} {:5.1} {:7.2e} {:>5} {:7.2e} {:7.2e}{}{:>3}",
             iter,
             unscaled_f,
@@ -111,7 +111,18 @@ impl IterationOutput for OrigIterationOutput {
             alpha_primal,
             alpha_char,
             ls_count,
-        )
+        );
+        // `print_info_string` (upstream
+        // `IpOrigIterationOutput.cpp:WriteOutputImpl`): append the
+        // per-iter diagnostic-tag string accumulated on `IpoptData`
+        // (e.g. soft-resto / watchdog / corrector markers). The string
+        // is cleared by the algorithm at the start of each outer
+        // iteration via `clear_info_string`.
+        if self.print_info_string == PrintInfoString::Yes && !d.info_string.is_empty() {
+            row.push(' ');
+            row.push_str(&d.info_string);
+        }
+        row
     }
 }
 

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -496,6 +496,37 @@ fn hs071_solves_with_nondefault_mu_init() {
     );
 }
 
+/// `print_info_string yes` + `inf_pr_output = internal` flow through
+/// `algorithm_builder_from_options` into `OrigIterationOutput`. The
+/// solve must still converge; this is a smoke test that the option
+/// wiring doesn't break the iter-row format.
+#[test]
+fn hs071_solves_with_iter_diagnostic_options() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_bool_value("print_info_string", true, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("inf_pr_output", "internal", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_bool_value("print_user_options", true, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(Hs071::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+}
+
 /// `print_frequency_iter = 100` makes pounce skip per-iter output
 /// rows but the solve itself must still converge cleanly. Smokes the
 /// option wiring without trying to assert against captured stdout.

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -192,7 +192,18 @@ fn main() -> ExitCode {
             _ => "FERAL",
         }
     };
-    print::print_banner(backend_tag);
+    // `sb yes` skips the copyright banner. Mirrors upstream
+    // `IpoptApplication::Initialize` which also reads `sb` and gates
+    // the banner. Problem-stats and iter rows are unaffected.
+    let suppress_banner = app
+        .options()
+        .get_bool_value("sb", "")
+        .ok()
+        .and_then(|(v, f)| f.then_some(v))
+        .unwrap_or(false);
+    if !suppress_banner {
+        print::print_banner(backend_tag);
+    }
     if let Some(stats) = print::collect_stats(&tnlp) {
         print::print_problem_stats(&stats);
     }


### PR DESCRIPTION
## Summary

Wave 3 wraps up the cosmetic tier-A output toggles from issue #15
that have existing infrastructure. Four more options wired:

- **`print_info_string`** — appends `IpoptData.info_string` to the
  iter row when on. `OrigIterationOutput` had the field but
  `format_row` never appended; both the plumbing and the suffix are
  now in.
- **`inf_pr_output`** (`"original"` | `"internal"`) — selects which
  primal infeasibility number lands in the `inf_pr` column. The
  field existed; only the `OptionsList → builder` hop was missing.
- **`print_user_options`** — dumps user-set options before the
  solve, mirroring upstream `IpoptApplication::call_optimize`.
- **`sb`** — suppresses pounce-cli's copyright banner. Wired in
  `pounce-cli/main.rs`; the algorithm crate is unaffected.

New `OutputOptions` fields (`print_info_string`,
`inf_pr_output_internal`) keep the wave-2 grouped-options pattern.

Tier-A cumulative progress after this PR: **29 of the originally
stubbed tier-A options** are now live; the remaining 7 are the
`print_options_documentation` / `print_options_mode` /
`print_advanced_options` docs-walker trio (out of scope — pounce-cli's
`--about` covers that need) and the 9 warm-start options (coupled to
#7, sIPOPT port — out of scope per the original plan).

## Test plan

- [x] `cargo test -p pounce-algorithm` — 168 lib + 13 hs71
  integration tests, all green.
- [x] `cargo test -p pounce-cli` — 53 tests, unchanged.
- [x] New `hs071_solves_with_iter_diagnostic_options` test exercises
  `print_info_string`, `inf_pr_output`, and `print_user_options`
  in one solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
