### PR TITLE
feat(algorithm): wire tier-A wave-4 warm-start options (#15)

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -161,6 +161,48 @@ pub struct AlgorithmBuilder {
     pub mu: MuOptions,
     pub line_search: LineSearchOptions,
     pub output: OutputOptions,
+    pub warm: WarmStartOptions,
+}
+
+/// Knobs read off `OptionsList` and baked into
+/// [`WarmStartIterateInitializer`]. Defaults mirror
+/// `IpWarmStartIterateInitializer.cpp:RegisterOptions`.
+///
+/// Wired today: `mult_init_max` (clamps |y_c|, |y_d| and caps z/v
+/// blocks) and `target_mu` (overrides `data.curr_mu` at iter 0).
+/// The remaining knobs (`bound_push`, `bound_frac`, `slack_bound_push`,
+/// `slack_bound_frac`, `mult_bound_push`, `entire_iterate`,
+/// `same_structure`) are stored on the initializer but not yet
+/// consumed — `WarmStartIterateInitializer::set_initial_iterates`
+/// currently trusts the caller-populated `data.curr` rather than
+/// re-running the upstream `push_variables` machinery.
+#[derive(Debug, Clone)]
+pub struct WarmStartOptions {
+    pub bound_push: Number,
+    pub bound_frac: Number,
+    pub slack_bound_push: Number,
+    pub slack_bound_frac: Number,
+    pub mult_bound_push: Number,
+    pub mult_init_max: Number,
+    pub target_mu: Number,
+    pub entire_iterate: bool,
+    pub same_structure: bool,
+}
+
+impl Default for WarmStartOptions {
+    fn default() -> Self {
+        Self {
+            bound_push: 1e-3,
+            bound_frac: 1e-3,
+            slack_bound_push: 1e-3,
+            slack_bound_frac: 1e-3,
+            mult_bound_push: 1e-3,
+            mult_init_max: 1e6,
+            target_mu: 0.0,
+            entire_iterate: false,
+            same_structure: false,
+        }
+    }
 }
 
 /// Knobs read off `OptionsList` and baked into the assembled
@@ -257,6 +299,7 @@ impl Default for AlgorithmBuilder {
             mu: MuOptions::default(),
             line_search: LineSearchOptions::default(),
             output: OutputOptions::default(),
+            warm: WarmStartOptions::default(),
         }
     }
 }
@@ -354,7 +397,7 @@ impl AlgorithmBuilder {
 
         let init: Box<dyn crate::init::r#trait::IterateInitializer> = if self.warm_start_init_point
         {
-            Box::new(WarmStartIterateInitializer::new())
+            Box::new(WarmStartIterateInitializer::with_options(self.warm.clone()))
         } else {
             Box::new(DefaultIterateInitializer::with_eq_mult_calculator(
                 Box::new(LeastSquareMults::new()),
@@ -483,6 +526,7 @@ mod tests {
                                 mu: MuOptions::default(),
                                 line_search: LineSearchOptions::default(),
                                 output: OutputOptions::default(),
+                                warm: WarmStartOptions::default(),
                             }
                             .build();
                         }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -750,6 +750,48 @@ impl IpoptApplication {
                 builder.output.inf_pr_output_internal = v == "internal";
             }
         }
+
+        // Warm-start options — consumed by `WarmStartIterateInitializer`
+        // (port of `IpWarmStartIterateInitializer.cpp:RegisterOptions`).
+        // `warm_start_init_point` is the toggle that picks between the
+        // default (cold) and warm-start initializers; the remaining
+        // knobs are baked onto the chosen initializer at build time.
+        if let Ok((v, found)) = self.options.get_bool_value("warm_start_init_point", "") {
+            if found {
+                builder.warm_start_init_point = v;
+            }
+        }
+        if let Ok((v, found)) = self.options.get_bool_value("warm_start_same_structure", "") {
+            if found {
+                builder.warm.same_structure = v;
+            }
+        }
+        if let Some(v) = read_num("warm_start_bound_push") {
+            builder.warm.bound_push = v;
+        }
+        if let Some(v) = read_num("warm_start_bound_frac") {
+            builder.warm.bound_frac = v;
+        }
+        if let Some(v) = read_num("warm_start_slack_bound_push") {
+            builder.warm.slack_bound_push = v;
+        }
+        if let Some(v) = read_num("warm_start_slack_bound_frac") {
+            builder.warm.slack_bound_frac = v;
+        }
+        if let Some(v) = read_num("warm_start_mult_bound_push") {
+            builder.warm.mult_bound_push = v;
+        }
+        if let Some(v) = read_num("warm_start_mult_init_max") {
+            builder.warm.mult_init_max = v;
+        }
+        if let Some(v) = read_num("warm_start_target_mu") {
+            builder.warm.target_mu = v;
+        }
+        if let Ok((v, found)) = self.options.get_string_value("warm_start_entire_iterate", "") {
+            if found {
+                builder.warm.entire_iterate = v == "yes";
+            }
+        }
         builder
     }
 }

--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -2,25 +2,51 @@
 //! `IpWarmStartIterateInitializer.{hpp,cpp}`. Used when a previous
 //! solve has left a trial point that should be reused.
 //!
-//! Phase-7 stub: trusts that the caller has already populated
-//! `data.curr` with the warm-start iterate (which is what upstream's
-//! `IpoptApplication::ReOptimizeTNLP` does before invoking the
-//! algorithm). The full version invalidates `iter_count` and copies
-//! the previous solution's bound multipliers.
+//! Trusts that the caller (typically `IpoptApplication::ReOptimizeTNLP`)
+//! has populated `data.curr` with the warm-start iterate. Beyond that,
+//! we honor two of the eight upstream `warm_start_*` options:
+//!
+//! * `warm_start_mult_init_max` — caps the magnitude of every
+//!   multiplier block on `data.curr`. Equality multipliers (`y_c`,
+//!   `y_d`) are clipped to `[-cap, +cap]`; bound multipliers (`z_l`,
+//!   `z_u`, `v_l`, `v_u`) are clipped to `[0, cap]`. Mirrors the
+//!   per-block clamps at `IpWarmStartIterateInitializer.cpp:148-181`
+//!   (the `have_iterate` branch).
+//! * `warm_start_target_mu` — when positive, overrides `data.curr_mu`
+//!   at iter 0 so the barrier sub-problem starts at the user-requested
+//!   value rather than `mu_init`.
+//!
+//! The remaining knobs (`bound_push`, `bound_frac`,
+//! `slack_bound_push`, `slack_bound_frac`, `mult_bound_push`,
+//! `entire_iterate`, `same_structure`) are stored on the initializer
+//! but not yet consumed — full `push_variables` semantics land with
+//! the rest of the warm-start path.
 
+use crate::alg_builder::WarmStartOptions;
 use crate::init::r#trait::IterateInitializer;
 use crate::ipopt_cq::IpoptCqHandle;
 use crate::ipopt_data::IpoptDataHandle;
 use crate::ipopt_nlp::IpoptNlp;
+use crate::iterates_vector::IteratesVector;
 use crate::kkt::aug_system_solver::AugSystemSolver;
+use pounce_linalg::dense_vector::DenseVector;
+use pounce_linalg::Vector;
 use std::cell::RefCell;
 use std::rc::Rc;
 
-pub struct WarmStartIterateInitializer;
+pub struct WarmStartIterateInitializer {
+    opts: WarmStartOptions,
+}
 
 impl WarmStartIterateInitializer {
     pub fn new() -> Self {
-        Self
+        Self {
+            opts: WarmStartOptions::default(),
+        }
+    }
+
+    pub fn with_options(opts: WarmStartOptions) -> Self {
+        Self { opts }
     }
 }
 
@@ -38,8 +64,125 @@ impl IterateInitializer for WarmStartIterateInitializer {
         _nlp: &Rc<RefCell<dyn IpoptNlp>>,
         _aug_solver: &mut dyn AugSystemSolver,
     ) -> bool {
-        // Warm-start path leaves whatever was placed on `data.curr`
-        // by the application driver alone. We only signal success.
-        data.borrow().curr.is_some()
+        // The caller is expected to have placed the warm-start iterate
+        // on `data.curr`; bail out early if that hasn't happened.
+        let mut borrow = data.borrow_mut();
+        if borrow.curr.is_none() {
+            return false;
+        }
+
+        if self.opts.mult_init_max > 0.0 {
+            // Rebuild `curr` with clamped multipliers. Components are
+            // shared via `Rc` with previous solves, so we make fresh
+            // copies before mutating to avoid clobbering downstream
+            // borrowers.
+            let curr = borrow.curr.as_ref().unwrap();
+            let cap = self.opts.mult_init_max;
+            let new_curr = IteratesVector::new(
+                Rc::clone(&curr.x),
+                Rc::clone(&curr.s),
+                clone_clamped(&curr.y_c, -cap, cap),
+                clone_clamped(&curr.y_d, -cap, cap),
+                clone_clamped(&curr.z_l, 0.0, cap),
+                clone_clamped(&curr.z_u, 0.0, cap),
+                clone_clamped(&curr.v_l, 0.0, cap),
+                clone_clamped(&curr.v_u, 0.0, cap),
+            );
+            borrow.set_curr(new_curr);
+        }
+
+        if self.opts.target_mu > 0.0 {
+            borrow.curr_mu = self.opts.target_mu;
+        }
+
+        true
+    }
+}
+
+/// Clone `v` into a fresh owned vector and clamp every entry to
+/// `[lo, hi]` componentwise. Empty vectors short-circuit. Vectors that
+/// were never written to (the application's placeholder seed iterates
+/// before any solve ran) collapse to a zero-initialized vector — `0`
+/// is inside every well-formed warm-start clamp range, so this matches
+/// upstream's behavior when a multiplier block has no carry-over
+/// value.
+fn clone_clamped(v: &Rc<dyn Vector>, lo: f64, hi: f64) -> Rc<dyn Vector> {
+    let n = v.dim();
+    if n == 0 {
+        return Rc::clone(v);
+    }
+    let mut out = v.make_new();
+    let initialized = v
+        .as_any()
+        .downcast_ref::<DenseVector>()
+        .map(|d| d.is_initialized())
+        .unwrap_or(true);
+    if initialized {
+        out.copy(&**v);
+    } else {
+        out.set(0.0);
+    }
+    let mut cap_hi = v.make_new();
+    cap_hi.set(hi);
+    out.element_wise_min(&*cap_hi);
+    let mut cap_lo = v.make_new();
+    cap_lo.set(lo);
+    out.element_wise_max(&*cap_lo);
+    Rc::from(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pounce_linalg::dense_vector::DenseVectorSpace;
+
+    fn dense(n: i32, fill: f64) -> Rc<dyn Vector> {
+        let space = DenseVectorSpace::new(n);
+        let mut v = space.make_new_dense();
+        v.set(fill);
+        Rc::new(v)
+    }
+
+    #[test]
+    fn clamps_multipliers_to_cap() {
+        let v = dense(3, 1e10);
+        let out = clone_clamped(&v, 0.0, 1e6);
+        assert_eq!(out.amax(), 1e6);
+        let v2 = dense(3, -1e10);
+        let out2 = clone_clamped(&v2, -1e6, 1e6);
+        assert_eq!(out2.amax(), 1e6);
+    }
+
+    #[test]
+    fn clamps_bound_mults_nonneg() {
+        let v = dense(3, -5.0);
+        let out = clone_clamped(&v, 0.0, 1e6);
+        assert_eq!(out.amax(), 0.0);
+    }
+
+    #[test]
+    fn empty_vector_short_circuits() {
+        let v = dense(0, 0.0);
+        let out = clone_clamped(&v, 0.0, 1.0);
+        assert_eq!(out.dim(), 0);
+    }
+
+    #[test]
+    fn in_range_values_pass_through_untouched() {
+        let v = dense(3, 0.5);
+        let out = clone_clamped(&v, 0.0, 1.0);
+        assert!((out.max() - 0.5).abs() < 1e-15);
+        assert!((out.min() - 0.5).abs() < 1e-15);
+    }
+
+    #[test]
+    fn uninitialized_source_collapses_to_zero() {
+        // Application's placeholder seed iterate: vector allocated but
+        // never written. `clone_clamped` must fall back to zero instead
+        // of tripping the dense-vector "must be initialized" assert.
+        let space = DenseVectorSpace::new(4);
+        let v: Rc<dyn Vector> = Rc::new(space.make_new_dense());
+        let out = clone_clamped(&v, 0.0, 1e6);
+        assert_eq!(out.amax(), 0.0);
     }
 }

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -232,6 +232,15 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
     r.add_bool_option("honor_original_bounds", "Indicates whether final points should be projected into original bounds.", false, "Ipopt might relax the bounds during the optimization (see, e.g., option \"bound_relax_factor\"). This option determines whether the final point should be projected back into the user-provide original bounds after the optimization. Note that violations of constraints and complementarity reported by Ipopt at the end of the solution process are for the non-projected point.")?;
     r.set_registering_category("Warm Start");
     r.add_bool_option("warm_start_same_structure", "Indicates whether a problem with a structure identical to the previous one is to be solved.", false, "If enabled, then the algorithm assumes that an NLP is now to be solved whose structure is identical to one that already was considered (with the same NLP object).")?;
+    // Upstream registers `warm_start_init_point` in
+    // `IpDefaultIterateInitializer.cpp:RegisterOptions`, alongside the
+    // regular (cold) initializer. Pounce's `DefaultIterateInitializer`
+    // doesn't pull it from `OptionsList` directly — `AlgBuilder` reads
+    // it to pick between `DefaultIterateInitializer` and
+    // `WarmStartIterateInitializer` — but the option still needs to
+    // appear in the registry so `--option warm_start_init_point=yes`
+    // type-checks.
+    r.add_bool_option("warm_start_init_point", "Warm-start for initial point", false, "Indicates whether this optimization should use a warm start initialization, where values of primal and dual variables are given (e.g., from a previous optimization of a related problem.)")?;
     r.set_registering_category("NLP");
     r.add_bool_option("check_derivatives_for_naninf", "Indicates whether it is desired to check for Nan/Inf in derivative matrices", false, "Activating this option will cause an error if an invalid number is detected in the constraint Jacobians or the Lagrangian Hessian. If this is not activated, the test is skipped, and the algorithm might proceed with invalid numbers and fail. If test is activated and an invalid number is detected, the matrix is written to output with print_level corresponding to J_MOREDETAILED (7); so beware of large output!")?;
     r.add_bool_option("grad_f_constant", "Indicates whether to assume that the objective function is linear", false, "Activating this option will cause Ipopt to ask for the Gradient of the objective function only once from the NLP and reuse this information later.")?;

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -590,3 +590,40 @@ fn hs071_output_file_captures_timing_report() {
     );
     let _ = std::fs::remove_file(&path);
 }
+
+/// Wave-4 smoke: the eight `warm_start_*` knobs and the
+/// `warm_start_init_point` toggle parse through
+/// `algorithm_builder_from_options` without erroring. End-to-end
+/// behavior (the warm-started solve itself) isn't exercised here —
+/// it needs a populated `data.curr` from a prior solve, which the
+/// re-optimize workflow that drives this initializer doesn't yet
+/// surface. The unit tests in `init::warm_start` cover the clamp /
+/// target-mu semantics in isolation.
+#[test]
+fn warm_start_options_flow_through_builder() {
+    let mut app = IpoptApplication::new();
+    let opts = "\
+        warm_start_init_point yes\n\
+        warm_start_same_structure yes\n\
+        warm_start_bound_push 1e-2\n\
+        warm_start_bound_frac 1e-2\n\
+        warm_start_slack_bound_push 1e-2\n\
+        warm_start_slack_bound_frac 1e-2\n\
+        warm_start_mult_bound_push 1e-2\n\
+        warm_start_mult_init_max 1e3\n\
+        warm_start_target_mu 1e-2\n\
+        warm_start_entire_iterate yes\n\
+    ";
+    app.initialize_with_options_str(opts).unwrap();
+    // Every key the test set must be visible on the OptionsList; this
+    // smoke-tests the registry surface (e.g. proves
+    // `warm_start_init_point` registered correctly).
+    for key in [
+        "warm_start_init_point",
+        "warm_start_same_structure",
+        "warm_start_entire_iterate",
+    ] {
+        let (_, found) = app.options().get_string_value(key, "").unwrap();
+        assert!(found, "{key} did not parse through the registry");
+    }
+}


### PR DESCRIPTION
## Summary

Closes the warm-start half of tier-A on issue #15. Nine `warm_start_*` knobs now route from `OptionsList` through `AlgorithmBuilder` into `WarmStartIterateInitializer`.

- Registers `warm_start_init_point` (was missing — upstream registers it in `IpDefaultIterateInitializer.cpp`, not the warm-start file).
- Adds `WarmStartOptions` substruct on `AlgorithmBuilder`; `algorithm_builder_from_options` reads all eight numeric/string knobs + `warm_start_same_structure`.
- `WarmStartIterateInitializer` implements two pieces that don't depend on the full `push_variables` machinery:
  - `warm_start_mult_init_max` — clamps |y_c|, |y_d| and caps z/v bound-multiplier blocks
  - `warm_start_target_mu` — overrides `data.curr_mu` when positive
- Remaining knobs (`bound_push`/`bound_frac`, slack variants, `mult_bound_push`, `entire_iterate`, `same_structure`) are stored on the initializer but not yet consumed — those need a full `push_variables` port on top of an actual re-optimize workflow, which is out of scope here.

## Test plan

- [x] `cargo test -p pounce-algorithm` — 173 unit + integration tests green, including 5 new `init::warm_start::tests` cases (clamp semantics, in-range pass-through, empty-vector short-circuit, uninitialized-source fallback) and a registry-surface smoke test (`warm_start_options_flow_through_builder`).
- [x] `cargo build` — full workspace clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
