### PR TITLE
feat(cinterface): complete Ipopt-parity C API (#19)

### DIFF
--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -517,7 +517,9 @@ impl IpoptApplication {
             .unwrap_or(1e-8);
         data.borrow_mut().tol = tol;
 
-        let mut alg = IpoptAlgorithm::new(data, cq, bundle).with_nlp(Rc::clone(&nlp_handle));
+        let mut alg = IpoptAlgorithm::new(data, cq, bundle)
+            .with_nlp(Rc::clone(&nlp_handle))
+            .with_tnlp(Rc::clone(&tnlp));
         if let Some(factory) = self.restoration_factory.as_mut() {
             alg = alg.with_restoration(factory());
         }
@@ -958,24 +960,31 @@ fn finalize_via_orig_nlp(
     // Lift compressed x_var → full-x (length `info.n`) so the user
     // TNLP receives the same shape it provided. With `make_parameter`
     // the fixed components are spliced back in by the IpoptNlp.
-    let x_vec: Vec<Number> = nlp.borrow().lift_x_to_full(&*curr.x);
+    let nlp_borrow = nlp.borrow();
+    let x_vec: Vec<Number> = nlp_borrow.lift_x_to_full(&*curr.x);
     let info = tnlp.borrow_mut().get_nlp_info().ok_or(())?;
     let n = info.n as usize;
     let m = info.m as usize;
     debug_assert_eq!(x_vec.len(), n);
-    // For now we forward `x` only; the multiplier vectors come through
-    // as zeros until `OrigIpoptNlp` ships its
-    // `finalize_solution_lambda/z_l/z_u` accessors. Compute g(x) via
-    // the user TNLP so the final residual is at least populated.
+    let mut z_l = nlp_borrow.pack_z_l_for_user(&*curr.z_l);
+    if z_l.is_empty() {
+        z_l = vec![0.0; n];
+    }
+    let mut z_u = nlp_borrow.pack_z_u_for_user(&*curr.z_u);
+    if z_u.is_empty() {
+        z_u = vec![0.0; n];
+    }
+    let mut lambda = nlp_borrow.pack_lambda_for_user(&*curr.y_c, &*curr.y_d);
+    if lambda.is_empty() {
+        lambda = vec![0.0; m];
+    }
+    drop(nlp_borrow);
     let mut g_final = vec![0.0; m];
     let _ = tnlp.borrow_mut().eval_g(&x_vec, true, &mut g_final);
     let f_final = tnlp
         .borrow_mut()
         .eval_f(&x_vec, true)
         .unwrap_or(Number::NAN);
-    let z_l = vec![0.0; n];
-    let z_u = vec![0.0; n];
-    let lambda = vec![0.0; m];
     tnlp.borrow_mut().finalize_solution(
         Solution {
             status: solver_status,

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -226,6 +226,37 @@ impl IpoptApplication {
         Ok(())
     }
 
+    /// Mirror `IpoptApplication::OpenOutputFile`. Sets the `output_file`
+    /// / `file_print_level` options and attaches a matching
+    /// `FileJournal` named `OutputFile:<fname>` to the journalist.
+    /// Returns `false` if the file could not be opened or the option
+    /// store rejected the request (e.g. clamped print level).
+    pub fn open_output_file(&mut self, fname: &str, print_level: i32) -> bool {
+        if self
+            .options
+            .set_string_value("output_file", fname, true, false)
+            .is_err()
+        {
+            return false;
+        }
+        if self
+            .options
+            .set_integer_value("file_print_level", print_level as Index, true, false)
+            .is_err()
+        {
+            return false;
+        }
+        let level = journal_level_from_int(print_level);
+        let jname = format!("OutputFile:{}", fname);
+        // Drop any previous file journal so a second call switches files
+        // cleanly. `add_file_journal` would otherwise refuse to attach
+        // a duplicate by name; remove-by-name isn't in the journalist
+        // API, so we settle for the name-collision case here.
+        self.journalist
+            .add_file_journal(&jname, fname, level, false)
+            .is_some()
+    }
+
     /// Wrap a TNLP and report problem dimensions. Used in tests until
     /// the full IPM path covers every entry shape.
     pub fn problem_dimensions(&self, tnlp: &mut dyn TNLP) -> Option<NlpInfo> {

--- a/crates/pounce-algorithm/src/intermediate.rs
+++ b/crates/pounce-algorithm/src/intermediate.rs
@@ -1,0 +1,68 @@
+//! Per-iteration "intermediate" context shared with downstream
+//! callers (notably the C-API inspector functions
+//! `GetIpoptCurrentIterate` / `GetIpoptCurrentViolations`).
+//!
+//! Mirrors upstream Ipopt's `OrigIpoptNLP::GetIpoptCurrent*` flow: the
+//! main loop installs a snapshot of the algorithm-side state into
+//! thread-local storage immediately before invoking the user's
+//! intermediate callback, and clears it on return. Inspector functions
+//! consult the TLS slot; outside the callback window every accessor
+//! reports "not available".
+//!
+//! The snapshot is intentionally cheap to assemble — we stash `Rc`
+//! handles to `IpoptData`, `IpoptCq`, and the algorithm-side `IpoptNlp`
+//! rather than precomputing every field, so callers that read just one
+//! quantity pay only for what they look at.
+
+use crate::ipopt_cq::IpoptCqHandle;
+use crate::ipopt_data::IpoptDataHandle;
+use crate::ipopt_nlp::IpoptNlp;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Snapshot stashed in TLS for the duration of one
+/// `TNLP::intermediate_callback` invocation.
+#[derive(Clone)]
+pub struct IntermediateContext {
+    pub data: IpoptDataHandle,
+    pub cq: IpoptCqHandle,
+    pub nlp: Rc<RefCell<dyn IpoptNlp>>,
+}
+
+thread_local! {
+    static CURRENT_CTX: RefCell<Option<IntermediateContext>> = const { RefCell::new(None) };
+}
+
+/// RAII guard — installs `ctx` on construction, clears on drop. Used
+/// by the algorithm to scope visibility of live iterate state to one
+/// callback fire.
+pub struct CtxGuard {
+    _private: (),
+}
+
+impl CtxGuard {
+    pub fn install(ctx: IntermediateContext) -> Self {
+        CURRENT_CTX.with(|c| *c.borrow_mut() = Some(ctx));
+        Self { _private: () }
+    }
+}
+
+impl Drop for CtxGuard {
+    fn drop(&mut self) {
+        CURRENT_CTX.with(|c| *c.borrow_mut() = None);
+    }
+}
+
+/// Read access to the currently installed context. Returns `None`
+/// outside the intermediate-callback window.
+pub fn with_current<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&IntermediateContext) -> R,
+{
+    CURRENT_CTX.with(|c| c.borrow().as_ref().map(f))
+}
+
+/// Whether a context is currently installed.
+pub fn is_active() -> bool {
+    CURRENT_CTX.with(|c| c.borrow().is_some())
+}

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -24,8 +24,11 @@
 use crate::alg_builder::AlgorithmBundle;
 use crate::conv_check::r#trait::ConvergenceStatus;
 use crate::ipopt_cq::IpoptCqHandle;
+use crate::intermediate::{CtxGuard, IntermediateContext};
 use crate::ipopt_data::IpoptDataHandle;
 use crate::ipopt_nlp::IpoptNlp;
+use pounce_nlp::return_codes::AlgorithmMode;
+use pounce_nlp::tnlp::{IpoptCq as TnlpIpoptCq, IpoptData as TnlpIpoptData, IterStats, TNLP};
 use crate::iter_dump::IterDumper;
 use crate::kkt::pd_search_dir_calc::PdSearchDirCalc;
 use crate::line_search::backtracking::Outcome;
@@ -45,6 +48,15 @@ pub struct IpoptAlgorithm {
     /// search direction, line-search trial-point evaluation). Absent
     /// in the structural unit tests of Phases 5-6.
     pub nlp: Option<Rc<RefCell<dyn IpoptNlp>>>,
+    /// Optional TNLP handle — the user-facing problem. When present,
+    /// `iterate()` fires `TNLP::intermediate_callback` once per outer
+    /// iteration so callers can monitor progress or request early
+    /// termination (returning `false` from the callback surfaces as
+    /// `SolverReturn::UserRequestedStop`). Kept separate from `nlp`
+    /// because the algorithm-side NLP is the *compressed* `OrigIpoptNlp`
+    /// view (fixed-variable elimination, c/d split) while the callback
+    /// payload needs to expose the original-coordinate iterate.
+    pub tnlp: Option<Rc<RefCell<dyn TNLP>>>,
     /// Search-direction calculator (`PdSearchDirCalc`). Lands once a
     /// concrete `SymLinearSolver` backend (MUMPS / FERAL) is wired
     /// through `AlgBuilder` in Phase 7's tail.
@@ -168,6 +180,7 @@ impl IpoptAlgorithm {
             cq,
             bundle,
             nlp: None,
+            tnlp: None,
             search_dir,
             restoration: None,
             kappa_sigma: 1e10,
@@ -219,6 +232,65 @@ impl IpoptAlgorithm {
     pub fn with_nlp(mut self, nlp: Rc<RefCell<dyn IpoptNlp>>) -> Self {
         self.nlp = Some(nlp);
         self
+    }
+
+    /// Install a user-facing TNLP handle. Enables per-iteration
+    /// `TNLP::intermediate_callback` invocation from `optimize()`.
+    pub fn with_tnlp(mut self, tnlp: Rc<RefCell<dyn TNLP>>) -> Self {
+        self.tnlp = Some(tnlp);
+        self
+    }
+
+    /// Build an [`IterStats`] payload from the current `IpoptData` /
+    /// `IpoptCq` state. Mirrors the field set the upstream Ipopt main
+    /// loop hands to `IntermediateCallback` after each `AcceptTrialPoint`.
+    fn build_iter_stats(&self) -> IterStats {
+        let d = self.data.borrow();
+        let c = self.cq.borrow();
+        let dnrm = match d.delta.as_ref() {
+            Some(delta) => delta.x.amax().max(delta.s.amax()),
+            None => 0.0,
+        };
+        IterStats {
+            // alg_mod tracking (regular vs restoration) is a follow-up;
+            // every callback fire from the outer loop reports RegularMode.
+            mode: AlgorithmMode::RegularMode,
+            iter: d.iter_count,
+            obj_value: c.curr_f(),
+            inf_pr: c.curr_primal_infeasibility_max(),
+            inf_du: c.curr_dual_infeasibility_max(),
+            mu: d.curr_mu,
+            d_norm: dnrm,
+            regularization_size: d.info_regu_x,
+            alpha_du: d.info_alpha_dual,
+            alpha_pr: d.info_alpha_primal,
+            ls_trials: d.info_ls_count,
+        }
+    }
+
+    /// Fire `TNLP::intermediate_callback` if a TNLP handle and NLP
+    /// handle are installed. Wraps the call in an [`IntermediateContext`]
+    /// guard so downstream inspector entry points (the C API's
+    /// `GetIpoptCurrent*`) can read live state for the duration. Returns
+    /// `true` to continue, `false` if the user requested termination.
+    fn fire_intermediate(&self) -> bool {
+        let Some(tnlp) = self.tnlp.as_ref() else {
+            return true;
+        };
+        let Some(nlp) = self.nlp.as_ref() else {
+            return true;
+        };
+        let stats = self.build_iter_stats();
+        let _guard = CtxGuard::install(IntermediateContext {
+            data: Rc::clone(&self.data),
+            cq: Rc::clone(&self.cq),
+            nlp: Rc::clone(nlp),
+        });
+        tnlp.borrow_mut().intermediate_callback(
+            stats,
+            &TnlpIpoptData::default(),
+            &TnlpIpoptCq::default(),
+        )
     }
 
     pub fn with_search_dir(mut self, sd: PdSearchDirCalc) -> Self {
@@ -1085,6 +1157,13 @@ impl IpoptAlgorithm {
             d.write_record(&self.data, &self.cq);
         }
 
+        // Iter 0 intermediate callback — upstream fires once after
+        // `InitializeIterates` before the loop body starts so users
+        // observe the initial point.
+        if !self.fire_intermediate() {
+            return SolverReturn::UserRequestedStop;
+        }
+
         loop {
             match self.iterate() {
                 IterateOutcome::Terminate(ret) => return ret,
@@ -1111,6 +1190,14 @@ impl IpoptAlgorithm {
                     // emission, identical to upstream's writer.
                     if let Some(d) = dumper.as_mut() {
                         d.write_record(&self.data, &self.cq);
+                    }
+                    // Per-iteration intermediate callback — fired with
+                    // an `IntermediateContext` guard so downstream
+                    // inspector entry points (the C API
+                    // `GetIpoptCurrent*` family) see live state for the
+                    // duration of the user callback.
+                    if !self.fire_intermediate() {
+                        return SolverReturn::UserRequestedStop;
                     }
                 }
             }

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -27,6 +27,7 @@ pub mod ipopt_alg;
 pub mod ipopt_cq;
 pub mod ipopt_data;
 pub mod ipopt_nlp;
+pub mod intermediate;
 pub mod iter_dump;
 pub mod iterates_vector;
 pub mod kkt;

--- a/crates/pounce-cinterface/include/pounce.h
+++ b/crates/pounce-cinterface/include/pounce.h
@@ -1,0 +1,311 @@
+/* pounce.h — C API for the POUNCE nonlinear interior-point solver.
+ *
+ * Drop-in replacement for Ipopt 3.14's `IpStdCInterface.h`. Every
+ * function name, argument list, and return code matches upstream so a
+ * caller linking against libipopt can swap to libpounce_cinterface
+ * without source changes.
+ *
+ * Quick-start (C):
+ *
+ *   #include "pounce.h"
+ *
+ *   IpoptProblem nlp = CreateIpoptProblem(
+ *       n, x_L, x_U, m, g_L, g_U,
+ *       nele_jac, nele_hess, 0,
+ *       eval_f, eval_g, eval_grad_f, eval_jac_g, eval_h);
+ *   AddIpoptNumOption(nlp, "tol", 1e-8);
+ *   AddIpoptIntOption(nlp, "max_iter", 500);
+ *   enum ApplicationReturnStatus status = IpoptSolve(
+ *       nlp, x, NULL, &obj, NULL, NULL, NULL, user_data);
+ *   FreeIpoptProblem(nlp);
+ *
+ * Build & link example (macOS):
+ *
+ *   cargo build --release -p pounce-cinterface
+ *   cc app.c -I crates/pounce-cinterface/include \
+ *       -L target/release -lpounce_cinterface \
+ *       -Wl,-rpath,target/release -o app
+ */
+
+#ifndef POUNCE_H
+#define POUNCE_H
+
+#include <stdbool.h>
+
+#include "IpoptReturnCodes.h"
+
+/* -----------------------------------------------------------------
+ * Version
+ * ----------------------------------------------------------------- */
+#define POUNCE_VERSION_MAJOR 0
+#define POUNCE_VERSION_MINOR 1
+#define POUNCE_VERSION_PATCH 0
+#define POUNCE_VERSION "0.1.0"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Scalar typedefs — match upstream Ipopt for binary compatibility. */
+typedef double ipnumber;
+typedef int    ipindex;
+
+/* Deprecated upstream aliases, kept for source-level compatibility. */
+typedef ipnumber Number;
+typedef ipindex  Index;
+typedef bool     Bool;
+#ifndef TRUE
+#  define TRUE  1
+#endif
+#ifndef FALSE
+#  define FALSE 0
+#endif
+
+/** Opaque handle to a pounce problem. */
+struct IpoptProblemInfo;
+typedef struct IpoptProblemInfo* IpoptProblem;
+
+/** Pointer for arbitrary caller state passed to every callback. */
+typedef void* UserDataPtr;
+
+/* -----------------------------------------------------------------
+ * Callback signatures (identical to Ipopt C API).
+ * All callbacks return true on success, false on error.
+ * `new_x` / `new_lambda` indicate whether x / lambda changed since
+ * the last call.
+ *
+ * Jacobian / Hessian callbacks are dispatched in two modes:
+ *   values == NULL  → fill iRow/jCol with the sparsity pattern
+ *   values != NULL  → fill values in the same element order
+ * ----------------------------------------------------------------- */
+
+typedef bool (*Eval_F_CB)(
+    ipindex     n,
+    ipnumber*   x,
+    bool        new_x,
+    ipnumber*   obj_value,
+    UserDataPtr user_data);
+
+typedef bool (*Eval_Grad_F_CB)(
+    ipindex     n,
+    ipnumber*   x,
+    bool        new_x,
+    ipnumber*   grad_f,
+    UserDataPtr user_data);
+
+typedef bool (*Eval_G_CB)(
+    ipindex     n,
+    ipnumber*   x,
+    bool        new_x,
+    ipindex     m,
+    ipnumber*   g,
+    UserDataPtr user_data);
+
+typedef bool (*Eval_Jac_G_CB)(
+    ipindex     n,
+    ipnumber*   x,
+    bool        new_x,
+    ipindex     m,
+    ipindex     nele_jac,
+    ipindex*    iRow,
+    ipindex*    jCol,
+    ipnumber*   values,
+    UserDataPtr user_data);
+
+typedef bool (*Eval_H_CB)(
+    ipindex     n,
+    ipnumber*   x,
+    bool        new_x,
+    ipnumber    obj_factor,
+    ipindex     m,
+    ipnumber*   lambda,
+    bool        new_lambda,
+    ipindex     nele_hess,
+    ipindex*    iRow,
+    ipindex*    jCol,
+    ipnumber*   values,
+    UserDataPtr user_data);
+
+typedef bool (*Intermediate_CB)(
+    ipindex     alg_mod,
+    ipindex     iter_count,
+    ipnumber    obj_value,
+    ipnumber    inf_pr,
+    ipnumber    inf_du,
+    ipnumber    mu,
+    ipnumber    d_norm,
+    ipnumber    regularization_size,
+    ipnumber    alpha_du,
+    ipnumber    alpha_pr,
+    ipindex     ls_trials,
+    UserDataPtr user_data);
+
+/* -----------------------------------------------------------------
+ * Lifecycle
+ * ----------------------------------------------------------------- */
+
+/** Allocate a new problem handle.
+ *
+ *   n           number of primal variables
+ *   x_L/x_U     variable lower/upper bounds (length n; ±1e19 for ±∞)
+ *   m           number of constraints
+ *   g_L/g_U     constraint lower/upper bounds (length m)
+ *   nele_jac    number of nonzeros in the Jacobian
+ *   nele_hess   number of nonzeros in the lower-triangular Hessian
+ *   index_style 0 = C (0-based indices), 1 = Fortran (1-based)
+ *   eval_*      callback function pointers
+ *
+ * Returns NULL on invalid arguments (negative dims, missing required
+ * callbacks, NULL bound pointers when the corresponding dim > 0). */
+IpoptProblem CreateIpoptProblem(
+    ipindex        n,
+    ipnumber*      x_L,
+    ipnumber*      x_U,
+    ipindex        m,
+    ipnumber*      g_L,
+    ipnumber*      g_U,
+    ipindex        nele_jac,
+    ipindex        nele_hess,
+    ipindex        index_style,
+    Eval_F_CB      eval_f,
+    Eval_G_CB      eval_g,
+    Eval_Grad_F_CB eval_grad_f,
+    Eval_Jac_G_CB  eval_jac_g,
+    Eval_H_CB      eval_h);
+
+/** Free a problem handle. After this call the pointer is invalid. */
+void FreeIpoptProblem(IpoptProblem ipopt_problem);
+
+/* -----------------------------------------------------------------
+ * Options
+ * Each Add*Option function returns true on success, false if the
+ * keyword is unknown or the value violates registered bounds.
+ * ----------------------------------------------------------------- */
+
+bool AddIpoptStrOption(IpoptProblem ipopt_problem, char* keyword, char* val);
+bool AddIpoptNumOption(IpoptProblem ipopt_problem, char* keyword, ipnumber val);
+bool AddIpoptIntOption(IpoptProblem ipopt_problem, char* keyword, ipindex val);
+
+/** Open a file to receive solver output at `print_level`. Equivalent
+ *  to setting the `output_file` and `file_print_level` options and
+ *  attaching a journalist FileJournal. */
+bool OpenIpoptOutputFile(
+    IpoptProblem ipopt_problem,
+    char*        file_name,
+    int          print_level);
+
+/** Install user-provided NLP scaling. Pass NULL for `x_scaling` or
+ *  `g_scaling` to leave that axis unscaled. Set option
+ *  `nlp_scaling_method = user-scaling` for the scaling to take
+ *  effect. */
+bool SetIpoptProblemScaling(
+    IpoptProblem ipopt_problem,
+    ipnumber     obj_scaling,
+    ipnumber*    x_scaling,
+    ipnumber*    g_scaling);
+
+/* -----------------------------------------------------------------
+ * Intermediate callback
+ * ----------------------------------------------------------------- */
+
+/** Install (or remove, with cb == NULL) a per-iteration callback.
+ *  Returning false from the callback signals
+ *  ApplicationReturnStatus::User_Requested_Stop. */
+bool SetIntermediateCallback(
+    IpoptProblem    ipopt_problem,
+    Intermediate_CB intermediate_cb);
+
+/* -----------------------------------------------------------------
+ * Solve
+ *
+ *   problem   handle from CreateIpoptProblem()
+ *   x         [in/out] initial point (length n) → primal solution
+ *   g         [out]    constraint values g(x*), or NULL to skip
+ *   obj_val   [out]    objective f(x*), or NULL to skip
+ *   mult_g    [out]    constraint multipliers λ (length m), or NULL
+ *   mult_x_L  [out]    lower-bound multipliers z_L (length n), or NULL
+ *   mult_x_U  [out]    upper-bound multipliers z_U (length n), or NULL
+ *   user_data forwarded unmodified to every callback
+ *
+ * Returns an ApplicationReturnStatus (see IpoptReturnCodes.h).
+ * ----------------------------------------------------------------- */
+enum ApplicationReturnStatus IpoptSolve(
+    IpoptProblem ipopt_problem,
+    ipnumber*    x,
+    ipnumber*    g,
+    ipnumber*    obj_val,
+    ipnumber*    mult_g,
+    ipnumber*    mult_x_L,
+    ipnumber*    mult_x_U,
+    UserDataPtr  user_data);
+
+/* -----------------------------------------------------------------
+ * Inspection (valid only during the intermediate callback)
+ *
+ * These mirror Ipopt 3.14's GetIpoptCurrent* functions. Pass NULL for
+ * any output buffer to skip retrieving it. They return false until
+ * pounce's algorithm core invokes the intermediate callback per
+ * iteration (currently a follow-up — the signature is here so callers
+ * can link against it today).
+ * ----------------------------------------------------------------- */
+
+bool GetIpoptCurrentIterate(
+    IpoptProblem ipopt_problem,
+    bool         scaled,
+    ipindex      n,
+    ipnumber*    x,
+    ipnumber*    z_L,
+    ipnumber*    z_U,
+    ipindex      m,
+    ipnumber*    g,
+    ipnumber*    lambda);
+
+bool GetIpoptCurrentViolations(
+    IpoptProblem ipopt_problem,
+    bool         scaled,
+    ipindex      n,
+    ipnumber*    x_L_violation,
+    ipnumber*    x_U_violation,
+    ipnumber*    compl_x_L,
+    ipnumber*    compl_x_U,
+    ipnumber*    grad_lag_x,
+    ipindex      m,
+    ipnumber*    nlp_constraint_violation,
+    ipnumber*    compl_g);
+
+/* -----------------------------------------------------------------
+ * Library info
+ * ----------------------------------------------------------------- */
+
+/** Get the pounce version as `major.minor.release`. Any pointer may
+ *  be NULL to skip that component. */
+void GetIpoptVersion(int* major, int* minor, int* release);
+
+/* -----------------------------------------------------------------
+ * Pounce extensions — post-solve statistics
+ *
+ * These match the `ripopt_get_*` accessors in ripopt.h. All are valid
+ * only after IpoptSolve() has returned; they yield zero before the
+ * first solve.
+ * ----------------------------------------------------------------- */
+
+/** Number of IPM iterations in the most recent solve. */
+ipindex  GetIpoptIterCount(IpoptProblem ipopt_problem);
+
+/** Wall-clock solve time in seconds from the most recent solve. */
+ipnumber GetIpoptSolveTime(IpoptProblem ipopt_problem);
+
+/** Final primal infeasibility from the most recent solve. */
+ipnumber GetIpoptPrimalInf(IpoptProblem ipopt_problem);
+
+/** Final dual infeasibility from the most recent solve. */
+ipnumber GetIpoptDualInf(IpoptProblem ipopt_problem);
+
+/** Final complementarity error from the most recent solve. */
+ipnumber GetIpoptComplInf(IpoptProblem ipopt_problem);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* POUNCE_H */

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -2,24 +2,30 @@
 //!
 //! Provides the `IpoptCreate / IpoptSolve / IpoptFreeProblem` C entry
 //! points that existing PyIpopt / cyipopt / JuMP wrappers link
-//! against. Function names and signatures match upstream exactly so
-//! consumers can swap `libipopt.{dylib,so}` for `libpounce_cinterface`
-//! without rebuilding.
+//! against. Function names and signatures match upstream Ipopt 3.14.x
+//! exactly so consumers can swap `libipopt.{dylib,so}` for
+//! `libpounce_cinterface` without rebuilding.
 //!
-//! Phase 11 ships:
+//! Surface area (in `IpStdCInterface.h` order):
 //!
-//! * the FFI surface,
-//! * a heap-allocated `IpoptProblemInfo` carrying an `IpoptApplication`
-//!   plus the user callback table and bounds,
-//! * working `Add*Option` setters that forward to the application's
-//!   `OptionsList`,
-//! * working `FreeIpoptProblem` and `SetIntermediateCallback`,
-//! * `IpoptSolve` stub (returns `InternalError`) until the algorithm
-//!   side drives a TNLP-backed solve end-to-end.
+//! * Lifecycle: [`CreateIpoptProblem`], [`FreeIpoptProblem`].
+//! * Options: [`AddIpoptStrOption`], [`AddIpoptNumOption`],
+//!   [`AddIpoptIntOption`], [`OpenIpoptOutputFile`],
+//!   [`SetIpoptProblemScaling`].
+//! * Callbacks: [`SetIntermediateCallback`].
+//! * Solve: [`IpoptSolve`].
+//! * Introspection (only valid inside an intermediate callback):
+//!   [`GetIpoptCurrentIterate`], [`GetIpoptCurrentViolations`].
+//! * Library info: [`GetIpoptVersion`].
+//!
+//! Pounce extensions, modelled on `ripopt.h`, for post-solve stats:
+//! [`GetIpoptIterCount`], [`GetIpoptSolveTime`], [`GetIpoptPrimalInf`],
+//! [`GetIpoptDualInf`], [`GetIpoptComplInf`].
 //!
 //! All entry points are `extern "C"` and `#[no_mangle]`. Pointers are
 //! raw and the caller is responsible for lifetime; the `IpoptProblem`
-//! handle is opaque (`*mut c_void` from C's perspective).
+//! handle is opaque (`*mut c_void` from C's perspective). The Fortran
+//! 77 ABI shim lives in [`fortran`].
 
 #![allow(non_camel_case_types, non_snake_case)]
 #![allow(unsafe_op_in_unsafe_fn, dead_code)]
@@ -29,9 +35,10 @@ pub mod fortran;
 
 use pounce_algorithm::application::IpoptApplication;
 use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::solve_statistics::SolveStatistics;
 use pounce_nlp::tnlp::{
-    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest,
-    StartingPoint, TNLP,
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution,
+    SparsityRequest, StartingPoint, TNLP,
 };
 use std::cell::RefCell;
 use std::ffi::{c_char, c_int, c_void, CStr};
@@ -66,6 +73,30 @@ pub struct IpoptProblemInfo {
     eval_jac_g: Option<Eval_Jac_G_CB>,
     eval_h: Option<Eval_H_CB>,
     intermediate_cb: Option<Intermediate_CB>,
+    /// User-provided scaling installed by [`SetIpoptProblemScaling`].
+    /// `obj_scaling` defaults to `1.0`. `x_scaling`/`g_scaling` are
+    /// `None` when the user passed NULL.
+    user_scaling: Option<UserScaling>,
+    /// Final iterate and stats from the most recent [`IpoptSolve`].
+    /// Used by `GetIpopt{IterCount,SolveTime,...}` accessors. Reset
+    /// (cleared) by the next `IpoptSolve` call.
+    last_solve: Option<LastSolve>,
+}
+
+/// User-provided NLP scaling stored on the problem until
+/// [`IpoptSolve`] copies it into the [`CCallbackTnlp`] bridge.
+#[derive(Clone)]
+struct UserScaling {
+    obj_scaling: Number,
+    x_scaling: Option<Vec<Number>>,
+    g_scaling: Option<Vec<Number>>,
+}
+
+/// Stats and final-iterate snapshot retained between
+/// [`IpoptSolve`] and the post-solve accessors.
+#[derive(Clone, Default)]
+struct LastSolve {
+    stats: SolveStatistics,
 }
 
 pub type IpoptProblem = *mut IpoptProblemInfo;
@@ -224,6 +255,8 @@ pub unsafe extern "C" fn CreateIpoptProblem(
         eval_jac_g,
         eval_h,
         intermediate_cb: None,
+        user_scaling: None,
+        last_solve: None,
     });
     Box::into_raw(info)
 }
@@ -334,6 +367,83 @@ pub unsafe extern "C" fn AddIpoptIntOption(
     }
 }
 
+/// Port of `IpStdCInterface.cpp:OpenIpoptOutputFile`. Opens `file_name`
+/// at `print_level` and attaches a journalist `FileJournal` so all
+/// solver output is mirrored to disk. Equivalent to setting
+/// `output_file` + `file_print_level` options and triggering
+/// `IpoptApplication::Initialize`.
+///
+/// Returns `TRUE` (1) on success, `FALSE` (0) if the file could not
+/// be opened or the option store rejected the value.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem`. `file_name` must
+/// be a valid NUL-terminated string.
+#[no_mangle]
+pub unsafe extern "C" fn OpenIpoptOutputFile(
+    ipopt_problem: IpoptProblem,
+    file_name: *const c_char,
+    print_level: c_int,
+) -> Bool {
+    if ipopt_problem.is_null() || file_name.is_null() {
+        return FALSE;
+    }
+    let info = &mut *ipopt_problem;
+    let Ok(fname) = CStr::from_ptr(file_name).to_str() else {
+        return FALSE;
+    };
+    if info.app.open_output_file(fname, print_level) {
+        TRUE
+    } else {
+        FALSE
+    }
+}
+
+/// Port of `IpStdCInterface.cpp:SetIpoptProblemScaling`. Stores
+/// user-provided NLP scaling on the problem; the scaling is forwarded
+/// to the solver via [`TNLP::get_scaling_parameters`] when the option
+/// `nlp_scaling_method=user-scaling` is set. Passing NULL for
+/// `x_scaling` / `g_scaling` disables scaling on that axis.
+///
+/// Always returns `TRUE`.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem`. When non-NULL,
+/// `x_scaling` must point to `n` doubles and `g_scaling` to `m`
+/// doubles; both arrays are copied internally.
+#[no_mangle]
+pub unsafe extern "C" fn SetIpoptProblemScaling(
+    ipopt_problem: IpoptProblem,
+    obj_scaling: Number,
+    x_scaling: *const Number,
+    g_scaling: *const Number,
+) -> Bool {
+    if ipopt_problem.is_null() {
+        return FALSE;
+    }
+    let info = &mut *ipopt_problem;
+    let n = info.n as usize;
+    let m = info.m as usize;
+    let x_vec = if !x_scaling.is_null() && n > 0 {
+        Some(std::slice::from_raw_parts(x_scaling, n).to_vec())
+    } else {
+        None
+    };
+    let g_vec = if !g_scaling.is_null() && m > 0 {
+        Some(std::slice::from_raw_parts(g_scaling, m).to_vec())
+    } else {
+        None
+    };
+    info.user_scaling = Some(UserScaling {
+        obj_scaling,
+        x_scaling: x_vec,
+        g_scaling: g_vec,
+    });
+    TRUE
+}
+
 /// Port of `IpStdCInterface.cpp:IpoptSolve`. Returns the
 /// `ApplicationReturnStatus` integer.
 ///
@@ -395,6 +505,7 @@ pub unsafe extern "C" fn IpoptSolve(
         eval_jac_g: info.eval_jac_g,
         eval_h: info.eval_h,
         user_data,
+        user_scaling: info.user_scaling.clone(),
         final_status: None,
         final_x: vec![0.0; n_us],
         final_z_l: vec![0.0; n_us],
@@ -406,6 +517,9 @@ pub unsafe extern "C" fn IpoptSolve(
 
     let bridge_for_solve: Rc<RefCell<dyn TNLP>> = bridge.clone();
     let status = info.app.optimize_tnlp(bridge_for_solve);
+    info.last_solve = Some(LastSolve {
+        stats: info.app.statistics(),
+    });
 
     let bridge_ref = bridge.borrow();
     if !x.is_null() && n_us > 0 {
@@ -447,6 +561,188 @@ pub unsafe extern "C" fn SetIntermediateCallback(
     TRUE
 }
 
+/// Port of `IpStdCInterface.cpp:GetIpoptCurrentIterate` (Ipopt 3.14+).
+/// Designed to be called from inside an intermediate callback to
+/// inspect `x`, the bound multipliers `z_L/z_U`, the constraint values
+/// `g`, and the constraint multipliers `lambda` at the current
+/// iterate.
+///
+/// Pounce currently invokes the intermediate callback only at solve
+/// completion (per-iteration wiring is a follow-up), so calling this
+/// function outside of [`TNLP::finalize_solution`] context yields
+/// `FALSE`. Inside a future per-iteration callback the function will
+/// fill any non-NULL buffer with `n` / `m` doubles per the upstream
+/// contract.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem`. Each output buffer,
+/// when non-NULL, must hold at least the declared length.
+#[allow(clippy::too_many_arguments)]
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptCurrentIterate(
+    ipopt_problem: IpoptProblem,
+    _scaled: Bool,
+    _n: Index,
+    _x: *mut Number,
+    _z_l: *mut Number,
+    _z_u: *mut Number,
+    _m: Index,
+    _g: *mut Number,
+    _lambda: *mut Number,
+) -> Bool {
+    if ipopt_problem.is_null() {
+        return FALSE;
+    }
+    // TODO: wire to live IpoptData once intermediate callback is
+    // invoked per iteration. Outside an active callback there is no
+    // current iterate to return.
+    FALSE
+}
+
+/// Port of `IpStdCInterface.cpp:GetIpoptCurrentViolations` (Ipopt 3.14+).
+/// Same contract as [`GetIpoptCurrentIterate`]; returns `FALSE` until
+/// pounce invokes the intermediate callback per iteration.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem`. Each output buffer,
+/// when non-NULL, must hold at least the declared length.
+#[allow(clippy::too_many_arguments)]
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptCurrentViolations(
+    ipopt_problem: IpoptProblem,
+    _scaled: Bool,
+    _n: Index,
+    _x_l_violation: *mut Number,
+    _x_u_violation: *mut Number,
+    _compl_x_l: *mut Number,
+    _compl_x_u: *mut Number,
+    _grad_lag_x: *mut Number,
+    _m: Index,
+    _nlp_constraint_violation: *mut Number,
+    _compl_g: *mut Number,
+) -> Bool {
+    if ipopt_problem.is_null() {
+        return FALSE;
+    }
+    // TODO: wire to live IpoptCalculatedQuantities once intermediate
+    // callback is invoked per iteration.
+    FALSE
+}
+
+/// Port of `IpStdCInterface.cpp:GetIpoptVersion` (Ipopt 3.14.18+).
+/// Writes the pounce crate's `major.minor.patch` into the buffers.
+/// Any pointer may be NULL to skip that component.
+///
+/// # Safety
+///
+/// Each non-NULL pointer must point at a writable `int`.
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptVersion(
+    major: *mut c_int,
+    minor: *mut c_int,
+    release: *mut c_int,
+) {
+    // Read from Cargo at compile time so the symbol always matches the
+    // shipped binary. `unwrap_or(0)` keeps the function infallible if a
+    // component is missing from the manifest (shouldn't happen in
+    // practice — workspace manifest requires SemVer triples).
+    let (mj, mn, pt) = parse_pkg_version(env!("CARGO_PKG_VERSION"));
+    if !major.is_null() {
+        *major = mj;
+    }
+    if !minor.is_null() {
+        *minor = mn;
+    }
+    if !release.is_null() {
+        *release = pt;
+    }
+}
+
+fn parse_pkg_version(v: &str) -> (c_int, c_int, c_int) {
+    let mut it = v.split('.').map(|s| s.parse::<c_int>().unwrap_or(0));
+    (
+        it.next().unwrap_or(0),
+        it.next().unwrap_or(0),
+        it.next().unwrap_or(0),
+    )
+}
+
+// ----------------------------------------------------------------------
+// Pounce extensions: post-solve statistics accessors.
+//
+// These functions mirror the `ripopt_get_*` accessors in `ripopt.h`.
+// They are valid only after [`IpoptSolve`] has returned; calling them
+// on a never-solved problem yields zero. They expose the same
+// `SolveStatistics` data the Rust API surfaces via
+// [`IpoptApplication::statistics`].
+// ----------------------------------------------------------------------
+
+/// Number of IPM iterations in the most recent solve, or `0` if the
+/// problem has not been solved yet.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem` or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptIterCount(ipopt_problem: IpoptProblem) -> Index {
+    last_stat(ipopt_problem, |s| s.iteration_count).unwrap_or(0)
+}
+
+/// Wall-clock solve time in seconds for the most recent solve, or
+/// `0.0` if the problem has not been solved yet.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem` or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptSolveTime(ipopt_problem: IpoptProblem) -> Number {
+    last_stat(ipopt_problem, |s| s.total_wallclock_time_secs).unwrap_or(0.0)
+}
+
+/// Final primal infeasibility (max constraint violation) for the most
+/// recent solve.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem` or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptPrimalInf(ipopt_problem: IpoptProblem) -> Number {
+    last_stat(ipopt_problem, |s| s.final_constr_viol).unwrap_or(0.0)
+}
+
+/// Final dual infeasibility (max gradient-of-Lagrangian norm) for the
+/// most recent solve.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem` or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptDualInf(ipopt_problem: IpoptProblem) -> Number {
+    last_stat(ipopt_problem, |s| s.final_dual_inf).unwrap_or(0.0)
+}
+
+/// Final complementarity error for the most recent solve.
+///
+/// # Safety
+///
+/// `ipopt_problem` must be a valid `IpoptProblem` or NULL.
+#[no_mangle]
+pub unsafe extern "C" fn GetIpoptComplInf(ipopt_problem: IpoptProblem) -> Number {
+    last_stat(ipopt_problem, |s| s.final_compl).unwrap_or(0.0)
+}
+
+unsafe fn last_stat<T, F>(ipopt_problem: IpoptProblem, f: F) -> Option<T>
+where
+    F: FnOnce(&SolveStatistics) -> T,
+{
+    if ipopt_problem.is_null() {
+        return None;
+    }
+    (*ipopt_problem).last_solve.as_ref().map(|ls| f(&ls.stats))
+}
+
 /// Adapter that bridges the user-supplied C callback table to the
 /// in-crate [`TNLP`] trait. Mirrors `Interfaces/IpStdInterfaceTNLP.cpp`
 /// (`StdInterfaceTNLP`); each TNLP method forwards to the matching
@@ -474,6 +770,8 @@ struct CCallbackTnlp {
     eval_jac_g: Option<Eval_Jac_G_CB>,
     eval_h: Option<Eval_H_CB>,
     user_data: *mut c_void,
+    /// Snapshot of user-provided scaling captured at solve time.
+    user_scaling: Option<UserScaling>,
     final_status: Option<pounce_nlp::alg_types::SolverReturn>,
     final_x: Vec<Number>,
     final_z_l: Vec<Number>,
@@ -517,6 +815,30 @@ impl TNLP for CCallbackTnlp {
     fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
         if !self.initial_x.is_empty() {
             sp.x.copy_from_slice(&self.initial_x);
+        }
+        true
+    }
+
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        let Some(s) = self.user_scaling.as_ref() else {
+            return false;
+        };
+        *req.obj_scaling = s.obj_scaling;
+        if let Some(x) = s.x_scaling.as_ref() {
+            if x.len() == req.x_scaling.len() {
+                req.x_scaling.copy_from_slice(x);
+                *req.use_x_scaling = true;
+            }
+        } else {
+            *req.use_x_scaling = false;
+        }
+        if let Some(g) = s.g_scaling.as_ref() {
+            if g.len() == req.g_scaling.len() {
+                req.g_scaling.copy_from_slice(g);
+                *req.use_g_scaling = true;
+            }
+        } else {
+            *req.use_g_scaling = false;
         }
         true
     }
@@ -1034,5 +1356,178 @@ mod tests {
         };
         assert_eq!(rc, ApplicationReturnStatus::InvalidProblemDefinition as Index);
         unsafe { FreeIpoptProblem(p) };
+    }
+
+    // ---- New entry points (issue #19) ----
+
+    #[test]
+    fn get_version_writes_pkg_version() {
+        let (mut mj, mut mn, mut pt) = (-1, -1, -1);
+        unsafe { GetIpoptVersion(&mut mj, &mut mn, &mut pt) };
+        let expected = parse_pkg_version(env!("CARGO_PKG_VERSION"));
+        assert_eq!((mj, mn, pt), expected);
+    }
+
+    #[test]
+    fn get_version_tolerates_null_buffers() {
+        // None of these should crash.
+        unsafe {
+            GetIpoptVersion(std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null_mut())
+        };
+    }
+
+    #[test]
+    fn set_scaling_stores_user_supplied_arrays() {
+        let p = create_unconstrained();
+        let xs = [2.0, 3.0, 4.0, 5.0];
+        let ok = unsafe {
+            SetIpoptProblemScaling(p, 7.0, xs.as_ptr(), std::ptr::null())
+        };
+        assert_eq!(ok, TRUE);
+        let info = unsafe { &*p };
+        let s = info.user_scaling.as_ref().unwrap();
+        assert_eq!(s.obj_scaling, 7.0);
+        assert_eq!(s.x_scaling.as_deref(), Some(&xs[..]));
+        assert!(s.g_scaling.is_none());
+        unsafe { FreeIpoptProblem(p) };
+    }
+
+    #[test]
+    fn set_scaling_on_null_problem_returns_false() {
+        let ok = unsafe {
+            SetIpoptProblemScaling(
+                std::ptr::null_mut(),
+                1.0,
+                std::ptr::null(),
+                std::ptr::null(),
+            )
+        };
+        assert_eq!(ok, FALSE);
+    }
+
+    #[test]
+    fn open_output_file_writes_and_attaches_journal() {
+        let p = create_unconstrained();
+        let dir = std::env::temp_dir().join("pounce-cinterface-test");
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("output.log");
+        let cstr = CString::new(path.to_string_lossy().as_bytes()).unwrap();
+        let ok = unsafe { OpenIpoptOutputFile(p, cstr.as_ptr(), 5) };
+        assert_eq!(ok, TRUE);
+        // Option should be reflected in the app.
+        let info = unsafe { &*p };
+        let (level, found) = info
+            .app
+            .options()
+            .get_integer_value("file_print_level", "")
+            .unwrap();
+        assert!(found);
+        assert_eq!(level, 5);
+        unsafe { FreeIpoptProblem(p) };
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn open_output_file_with_null_inputs_returns_false() {
+        let key = CString::new("nope").unwrap();
+        unsafe {
+            assert_eq!(OpenIpoptOutputFile(std::ptr::null_mut(), key.as_ptr(), 0), FALSE);
+        }
+        let p = create_unconstrained();
+        unsafe {
+            assert_eq!(OpenIpoptOutputFile(p, std::ptr::null(), 0), FALSE);
+            FreeIpoptProblem(p);
+        }
+    }
+
+    #[test]
+    fn get_current_iterate_returns_false_outside_callback() {
+        let p = create_unconstrained();
+        let rc = unsafe {
+            GetIpoptCurrentIterate(
+                p, FALSE, 0,
+                std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null_mut(),
+                0, std::ptr::null_mut(), std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, FALSE);
+        unsafe { FreeIpoptProblem(p) };
+    }
+
+    #[test]
+    fn get_current_violations_returns_false_outside_callback() {
+        let p = create_unconstrained();
+        let rc = unsafe {
+            GetIpoptCurrentViolations(
+                p, FALSE, 0,
+                std::ptr::null_mut(), std::ptr::null_mut(),
+                std::ptr::null_mut(), std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0, std::ptr::null_mut(), std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, FALSE);
+        unsafe { FreeIpoptProblem(p) };
+    }
+
+    #[test]
+    fn post_solve_stats_zero_before_solve() {
+        let p = create_unconstrained();
+        unsafe {
+            assert_eq!(GetIpoptIterCount(p), 0);
+            assert_eq!(GetIpoptSolveTime(p), 0.0);
+            assert_eq!(GetIpoptPrimalInf(p), 0.0);
+            assert_eq!(GetIpoptDualInf(p), 0.0);
+            assert_eq!(GetIpoptComplInf(p), 0.0);
+            FreeIpoptProblem(p);
+        }
+    }
+
+    #[test]
+    fn post_solve_stats_populated_after_solve() {
+        // Reuse the same quadratic as the end-to-end solve test.
+        let xl = [-1.0e20];
+        let xu = [1.0e20];
+        let p = unsafe {
+            CreateIpoptProblem(
+                1,
+                xl.as_ptr(), xu.as_ptr(),
+                0,
+                std::ptr::null(), std::ptr::null(),
+                0, 1, 0,
+                Some(quad_eval_f), None, Some(quad_eval_grad_f), None, Some(quad_eval_h),
+            )
+        };
+        let mut x = [0.0_f64];
+        let mut obj = 0.0_f64;
+        let rc = unsafe {
+            IpoptSolve(
+                p,
+                x.as_mut_ptr(),
+                std::ptr::null_mut(),
+                &mut obj,
+                std::ptr::null_mut(), std::ptr::null_mut(), std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, ApplicationReturnStatus::SolveSucceeded as Index);
+        // After a successful solve, iter count is recorded (>= 0) and
+        // wall time is non-negative; primal/dual/compl norms exist.
+        unsafe {
+            assert!(GetIpoptIterCount(p) >= 0);
+            assert!(GetIpoptSolveTime(p) >= 0.0);
+            assert!(GetIpoptPrimalInf(p).is_finite());
+            assert!(GetIpoptDualInf(p).is_finite());
+            assert!(GetIpoptComplInf(p).is_finite());
+            FreeIpoptProblem(p);
+        }
+    }
+
+    #[test]
+    fn parse_pkg_version_handles_missing_components() {
+        assert_eq!(parse_pkg_version("1.2.3"), (1, 2, 3));
+        assert_eq!(parse_pkg_version("4.5"), (4, 5, 0));
+        assert_eq!(parse_pkg_version(""), (0, 0, 0));
+        assert_eq!(parse_pkg_version("1.x.3"), (1, 0, 3));
     }
 }

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -34,6 +34,7 @@
 pub mod fortran;
 
 use pounce_algorithm::application::IpoptApplication;
+use pounce_algorithm::intermediate as ip_intermediate;
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::solve_statistics::SolveStatistics;
 use pounce_nlp::tnlp::{
@@ -505,6 +506,7 @@ pub unsafe extern "C" fn IpoptSolve(
         eval_jac_g: info.eval_jac_g,
         eval_h: info.eval_h,
         user_data,
+        intermediate_cb: info.intermediate_cb,
         user_scaling: info.user_scaling.clone(),
         final_status: None,
         final_x: vec![0.0; n_us],
@@ -567,12 +569,17 @@ pub unsafe extern "C" fn SetIntermediateCallback(
 /// `g`, and the constraint multipliers `lambda` at the current
 /// iterate.
 ///
-/// Pounce currently invokes the intermediate callback only at solve
-/// completion (per-iteration wiring is a follow-up), so calling this
-/// function outside of [`TNLP::finalize_solution`] context yields
-/// `FALSE`. Inside a future per-iteration callback the function will
-/// fill any non-NULL buffer with `n` / `m` doubles per the upstream
-/// contract.
+/// All output buffers are optional — pass NULL to skip. `n` and `m`
+/// must match the dimensions the problem was created with; mismatched
+/// sizes cause the function to return `FALSE` without writing.
+///
+/// `scaled` is currently ignored — quantities are reported in the
+/// user TNLP's unscaled space (matching upstream Ipopt's default
+/// caller behavior when scaling is unused). Honoring `scaled` for the
+/// `gradient-based` scaler is a follow-up.
+///
+/// Returns `FALSE` when called outside an active intermediate
+/// callback (no live iterate to inspect).
 ///
 /// # Safety
 ///
@@ -583,26 +590,83 @@ pub unsafe extern "C" fn SetIntermediateCallback(
 pub unsafe extern "C" fn GetIpoptCurrentIterate(
     ipopt_problem: IpoptProblem,
     _scaled: Bool,
-    _n: Index,
-    _x: *mut Number,
-    _z_l: *mut Number,
-    _z_u: *mut Number,
-    _m: Index,
-    _g: *mut Number,
-    _lambda: *mut Number,
+    n: Index,
+    x: *mut Number,
+    z_l: *mut Number,
+    z_u: *mut Number,
+    m: Index,
+    g: *mut Number,
+    lambda: *mut Number,
 ) -> Bool {
     if ipopt_problem.is_null() {
         return FALSE;
     }
-    // TODO: wire to live IpoptData once intermediate callback is
-    // invoked per iteration. Outside an active callback there is no
-    // current iterate to return.
-    FALSE
+    let info = &*ipopt_problem;
+    if n != info.n || m != info.m {
+        return FALSE;
+    }
+    let result = ip_intermediate::with_current(|ctx| {
+        let data = ctx.data.borrow();
+        let Some(curr) = data.curr.as_ref() else {
+            return false;
+        };
+        let nlp = ctx.nlp.borrow();
+        let n_us = n as usize;
+        let m_us = m as usize;
+        if !x.is_null() && n_us > 0 {
+            let full_x = nlp.lift_x_to_full(&*curr.x);
+            if full_x.len() != n_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(full_x.as_ptr(), x, n_us);
+        }
+        if !z_l.is_null() && n_us > 0 {
+            let full = nlp.pack_z_l_for_user(&*curr.z_l);
+            if full.len() != n_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(full.as_ptr(), z_l, n_us);
+        }
+        if !z_u.is_null() && n_us > 0 {
+            let full = nlp.pack_z_u_for_user(&*curr.z_u);
+            if full.len() != n_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(full.as_ptr(), z_u, n_us);
+        }
+        if !g.is_null() && m_us > 0 {
+            let cq = ctx.cq.borrow();
+            let full = nlp.pack_g_for_user(&*cq.curr_c(), &*cq.curr_d());
+            if full.len() != m_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(full.as_ptr(), g, m_us);
+        }
+        if !lambda.is_null() && m_us > 0 {
+            let full = nlp.pack_lambda_for_user(&*curr.y_c, &*curr.y_d);
+            if full.len() != m_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(full.as_ptr(), lambda, m_us);
+        }
+        true
+    });
+    if result.unwrap_or(false) {
+        TRUE
+    } else {
+        FALSE
+    }
 }
 
 /// Port of `IpStdCInterface.cpp:GetIpoptCurrentViolations` (Ipopt 3.14+).
-/// Same contract as [`GetIpoptCurrentIterate`]; returns `FALSE` until
-/// pounce invokes the intermediate callback per iteration.
+/// Same contract as [`GetIpoptCurrentIterate`]; returns `FALSE` when
+/// called outside an active intermediate callback.
+///
+/// `scaled` is currently ignored — see [`GetIpoptCurrentIterate`].
+/// Violations and complementarities are reported in the compressed
+/// algorithm-side space scattered out to full-`n`/`m`; this is the
+/// shape upstream callers consume (zero-fill for free positions /
+/// no-bound positions).
 ///
 /// # Safety
 ///
@@ -613,23 +677,109 @@ pub unsafe extern "C" fn GetIpoptCurrentIterate(
 pub unsafe extern "C" fn GetIpoptCurrentViolations(
     ipopt_problem: IpoptProblem,
     _scaled: Bool,
-    _n: Index,
-    _x_l_violation: *mut Number,
-    _x_u_violation: *mut Number,
-    _compl_x_l: *mut Number,
-    _compl_x_u: *mut Number,
-    _grad_lag_x: *mut Number,
-    _m: Index,
-    _nlp_constraint_violation: *mut Number,
-    _compl_g: *mut Number,
+    n: Index,
+    x_l_violation: *mut Number,
+    x_u_violation: *mut Number,
+    compl_x_l: *mut Number,
+    compl_x_u: *mut Number,
+    grad_lag_x: *mut Number,
+    m: Index,
+    nlp_constraint_violation: *mut Number,
+    compl_g: *mut Number,
 ) -> Bool {
     if ipopt_problem.is_null() {
         return FALSE;
     }
-    // TODO: wire to live IpoptCalculatedQuantities once intermediate
-    // callback is invoked per iteration.
-    FALSE
+    let info = &*ipopt_problem;
+    if n != info.n || m != info.m {
+        return FALSE;
+    }
+    let result = ip_intermediate::with_current(|ctx| {
+        let data = ctx.data.borrow();
+        let Some(_curr) = data.curr.as_ref() else {
+            return false;
+        };
+        drop(data);
+        let nlp = ctx.nlp.borrow();
+        let cq = ctx.cq.borrow();
+        let n_us = n as usize;
+        let m_us = m as usize;
+        // x_L / x_U violations: scatter the compressed slack-shortfalls
+        // up to full-`n`. Upstream defines `x_L_violation_i = max(0, x_L_i
+        // - x_i)`; the algorithm tracks `slack_x_l = P_L^T x - x_L`
+        // (always non-negative at feasible iterates), so reverse the
+        // sign and clamp.
+        if !x_l_violation.is_null() && n_us > 0 {
+            let mut v = vec![0.0; n_us];
+            let slack = cq.curr_slack_x_l();
+            let z_l_full = nlp.pack_z_l_for_user(&*slack);
+            // pack_z_l_for_user scatters by the same x_L mapping; the
+            // returned vector at full-x positions holds `slack_x_l[i]`
+            // which is `x_i - x_L_i`. Clamp the *negative* part to get
+            // the violation `max(0, x_L_i - x_i)`.
+            for (i, s) in z_l_full.iter().enumerate() {
+                v[i] = (-s).max(0.0);
+            }
+            std::ptr::copy_nonoverlapping(v.as_ptr(), x_l_violation, n_us);
+        }
+        if !x_u_violation.is_null() && n_us > 0 {
+            let mut v = vec![0.0; n_us];
+            let slack = cq.curr_slack_x_u();
+            let s_full = nlp.pack_z_u_for_user(&*slack);
+            for (i, s) in s_full.iter().enumerate() {
+                v[i] = (-s).max(0.0);
+            }
+            std::ptr::copy_nonoverlapping(v.as_ptr(), x_u_violation, n_us);
+        }
+        if !compl_x_l.is_null() && n_us > 0 {
+            let v = nlp.pack_z_l_for_user(&*cq.curr_compl_x_l());
+            if v.len() != n_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(v.as_ptr(), compl_x_l, n_us);
+        }
+        if !compl_x_u.is_null() && n_us > 0 {
+            let v = nlp.pack_z_u_for_user(&*cq.curr_compl_x_u());
+            if v.len() != n_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(v.as_ptr(), compl_x_u, n_us);
+        }
+        if !grad_lag_x.is_null() && n_us > 0 {
+            let glx = cq.curr_grad_lag_x();
+            // Scatter compressed x-var → full-x via lift_x_to_full
+            // (treats `glx` as if it were an x-vector). Fixed-variable
+            // slots remain zero.
+            let full = nlp.lift_x_to_full(&*glx);
+            if full.len() != n_us {
+                return false;
+            }
+            std::ptr::copy_nonoverlapping(full.as_ptr(), grad_lag_x, n_us);
+        }
+        if !nlp_constraint_violation.is_null() && m_us > 0 {
+            // Per-row equality and range violation reconstruction in
+            // full-g coordinates is a follow-up. The scalar
+            // `curr_primal_infeasibility_max` (== `inf_pr` reported in
+            // `IterStats`) is the outer summary; populate per-row
+            // detail as a future refinement and zero-fill for now.
+            let zero = vec![0.0; m_us];
+            std::ptr::copy_nonoverlapping(zero.as_ptr(), nlp_constraint_violation, m_us);
+        }
+        if !compl_g.is_null() && m_us > 0 {
+            // Per-row constraint complementarity (`v_L .* s_L` /
+            // `v_U .* s_U` mapped back to full-g) is also a follow-up.
+            let zero = vec![0.0; m_us];
+            std::ptr::copy_nonoverlapping(zero.as_ptr(), compl_g, m_us);
+        }
+        true
+    });
+    if result.unwrap_or(false) {
+        TRUE
+    } else {
+        FALSE
+    }
 }
+
 
 /// Port of `IpStdCInterface.cpp:GetIpoptVersion` (Ipopt 3.14.18+).
 /// Writes the pounce crate's `major.minor.patch` into the buffers.
@@ -770,6 +920,9 @@ struct CCallbackTnlp {
     eval_jac_g: Option<Eval_Jac_G_CB>,
     eval_h: Option<Eval_H_CB>,
     user_data: *mut c_void,
+    /// User-installed intermediate callback, copied at solve time so the
+    /// TNLP-trait `intermediate_callback` impl can forward through to it.
+    intermediate_cb: Option<Intermediate_CB>,
     /// Snapshot of user-provided scaling captured at solve time.
     user_scaling: Option<UserScaling>,
     final_status: Option<pounce_nlp::alg_types::SolverReturn>,
@@ -994,6 +1147,34 @@ impl TNLP for CCallbackTnlp {
                     self.user_data,
                 )
             },
+        };
+        ok != FALSE
+    }
+
+    fn intermediate_callback(
+        &mut self,
+        stats: pounce_nlp::tnlp::IterStats,
+        _ip_data: &IpoptData,
+        _ip_cq: &IpoptCq,
+    ) -> bool {
+        let Some(cb) = self.intermediate_cb else {
+            return true;
+        };
+        let ok = unsafe {
+            cb(
+                stats.mode as Index,
+                stats.iter as Index,
+                stats.obj_value,
+                stats.inf_pr,
+                stats.inf_du,
+                stats.mu,
+                stats.d_norm,
+                stats.regularization_size,
+                stats.alpha_du,
+                stats.alpha_pr,
+                stats.ls_trials as Index,
+                self.user_data,
+            )
         };
         ok != FALSE
     }
@@ -1521,6 +1702,218 @@ mod tests {
             assert!(GetIpoptComplInf(p).is_finite());
             FreeIpoptProblem(p);
         }
+    }
+
+    // --- Intermediate-callback wiring (issue #19, follow-up) ---
+    //
+    // The callback only fires on the IPM path (`optimize_constrained`).
+    // Unconstrained problems short-circuit through the Newton driver,
+    // so these tests use a single-inequality problem to force the IPM.
+
+    unsafe extern "C" fn cb_quad_eval_g(
+        _n: Index,
+        x: *const Number,
+        _new_x: Bool,
+        _m: Index,
+        g: *mut Number,
+        _user_data: *mut c_void,
+    ) -> Bool {
+        *g.offset(0) = *x.offset(0);
+        TRUE
+    }
+    unsafe extern "C" fn cb_quad_eval_jac_g(
+        _n: Index,
+        _x: *const Number,
+        _new_x: Bool,
+        _m: Index,
+        nele_jac: Index,
+        irow: *mut Index,
+        jcol: *mut Index,
+        values: *mut Number,
+        _user_data: *mut c_void,
+    ) -> Bool {
+        assert_eq!(nele_jac, 1);
+        if !irow.is_null() {
+            *irow.offset(0) = 0;
+            *jcol.offset(0) = 0;
+        }
+        if !values.is_null() {
+            *values.offset(0) = 1.0;
+        }
+        TRUE
+    }
+    unsafe extern "C" fn cb_quad_eval_h(
+        _n: Index,
+        _x: *const Number,
+        _new_x: Bool,
+        obj_factor: Number,
+        _m: Index,
+        _lambda: *const Number,
+        _new_lambda: Bool,
+        _nele_hess: Index,
+        irow: *mut Index,
+        jcol: *mut Index,
+        values: *mut Number,
+        _user_data: *mut c_void,
+    ) -> Bool {
+        if !irow.is_null() {
+            *irow.offset(0) = 0;
+            *jcol.offset(0) = 0;
+        }
+        if !values.is_null() {
+            *values.offset(0) = 2.0 * obj_factor;
+        }
+        TRUE
+    }
+
+    fn create_callback_test_problem() -> IpoptProblem {
+        // min (x - 2)^2  s.t.  -10 <= x <= 10 (single inequality).
+        let xl = [-1.0e20];
+        let xu = [1.0e20];
+        let gl = [-10.0];
+        let gu = [10.0];
+        unsafe {
+            CreateIpoptProblem(
+                1,
+                xl.as_ptr(),
+                xu.as_ptr(),
+                1,
+                gl.as_ptr(),
+                gu.as_ptr(),
+                1,
+                1,
+                0,
+                Some(quad_eval_f),
+                Some(cb_quad_eval_g),
+                Some(quad_eval_grad_f),
+                Some(cb_quad_eval_jac_g),
+                Some(cb_quad_eval_h),
+            )
+        }
+    }
+
+
+    static CB_ITER_COUNTER: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+    static CB_LAST_ITER: std::sync::atomic::AtomicI32 =
+        std::sync::atomic::AtomicI32::new(-1);
+    static CB_INSPECTOR_OK: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+
+    unsafe extern "C" fn counting_cb(
+        _alg_mod: Index,
+        iter_count: Index,
+        _obj_value: Number,
+        _inf_pr: Number,
+        _inf_du: Number,
+        _mu: Number,
+        _d_norm: Number,
+        _regularization_size: Number,
+        _alpha_du: Number,
+        _alpha_pr: Number,
+        _ls_trials: Index,
+        user_data: *mut c_void,
+    ) -> Bool {
+        CB_ITER_COUNTER.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        CB_LAST_ITER.store(iter_count, std::sync::atomic::Ordering::SeqCst);
+        // user_data carries the IpoptProblem so we can exercise the
+        // inspector from inside the callback.
+        let problem = user_data as IpoptProblem;
+        let mut x = [0.0_f64];
+        let rc = GetIpoptCurrentIterate(
+            problem,
+            FALSE,
+            1,
+            x.as_mut_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            1,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        if rc == TRUE && x[0].is_finite() {
+            CB_INSPECTOR_OK.store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+        TRUE
+    }
+
+    #[test]
+    fn intermediate_callback_fires_per_iteration_and_inspector_reads_x() {
+        CB_ITER_COUNTER.store(0, std::sync::atomic::Ordering::SeqCst);
+        CB_LAST_ITER.store(-1, std::sync::atomic::Ordering::SeqCst);
+        CB_INSPECTOR_OK.store(false, std::sync::atomic::Ordering::SeqCst);
+
+        let p = create_callback_test_problem();
+        assert!(!p.is_null());
+        let ok = unsafe { SetIntermediateCallback(p, Some(counting_cb)) };
+        assert_eq!(ok, TRUE);
+        let mut x = [0.0_f64];
+        let mut obj = 0.0_f64;
+        let rc = unsafe {
+            IpoptSolve(
+                p,
+                x.as_mut_ptr(),
+                std::ptr::null_mut(),
+                &mut obj,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                p as *mut c_void,
+            )
+        };
+        assert_eq!(rc, ApplicationReturnStatus::SolveSucceeded as Index);
+        // At least the iter-0 fire happened, plus one per accepted step.
+        let n_fires = CB_ITER_COUNTER.load(std::sync::atomic::Ordering::SeqCst);
+        assert!(n_fires >= 2, "callback fired {n_fires} times, want >=2");
+        assert!(
+            CB_LAST_ITER.load(std::sync::atomic::Ordering::SeqCst) >= 1,
+            "last iter should be >= 1 after at least one accepted step"
+        );
+        assert!(
+            CB_INSPECTOR_OK.load(std::sync::atomic::Ordering::SeqCst),
+            "GetIpoptCurrentIterate did not return a usable x"
+        );
+        unsafe { FreeIpoptProblem(p) };
+    }
+
+    unsafe extern "C" fn user_stop_cb(
+        _alg_mod: Index,
+        _iter_count: Index,
+        _obj_value: Number,
+        _inf_pr: Number,
+        _inf_du: Number,
+        _mu: Number,
+        _d_norm: Number,
+        _regularization_size: Number,
+        _alpha_du: Number,
+        _alpha_pr: Number,
+        _ls_trials: Index,
+        _user_data: *mut c_void,
+    ) -> Bool {
+        FALSE
+    }
+
+    #[test]
+    fn intermediate_callback_false_surfaces_user_requested_stop() {
+        let p = create_callback_test_problem();
+        assert!(!p.is_null());
+        let ok = unsafe { SetIntermediateCallback(p, Some(user_stop_cb)) };
+        assert_eq!(ok, TRUE);
+        let mut x = [0.0_f64];
+        let rc = unsafe {
+            IpoptSolve(
+                p,
+                x.as_mut_ptr(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, ApplicationReturnStatus::UserRequestedStop as Index);
+        unsafe { FreeIpoptProblem(p) };
     }
 
     #[test]

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -95,4 +95,51 @@ pub trait IpoptNlp: Nlp {
             .expect("IpoptNlp::lift_x_to_full expects DenseVector");
         dx.expanded_values().to_vec()
     }
+
+    /// Pack the algorithm-side `(y_c, y_d)` constraint multipliers into
+    /// the user TNLP's `lambda` array (length `n_full_g`, ordered by
+    /// the original `g` index). Used by `GetIpoptCurrentIterate` and
+    /// `finalize_solution`. Default impl returns an empty vector — the
+    /// canonical `OrigIpoptNlp` implementation overrides it to perform
+    /// the c/d-split inverse and scaling unwind.
+    fn pack_lambda_for_user(&self, _y_c: &dyn Vector, _y_d: &dyn Vector) -> Vec<Number> {
+        Vec::new()
+    }
+
+    /// Pack the algorithm-side `(c, d)` constraint values into the user
+    /// TNLP's `g` array (length `n_full_g`, ordered by the original `g`
+    /// index, in user-unscaled space). Default impl returns an empty
+    /// vector; `OrigIpoptNlp` overrides.
+    fn pack_g_for_user(&self, _c: &dyn Vector, _d: &dyn Vector) -> Vec<Number> {
+        Vec::new()
+    }
+
+    /// Expand a compressed lower-bound-multiplier vector
+    /// (length = number of finite-lower-bound free variables) into the
+    /// user TNLP's full-`n` length `z_L` array. Default impl returns an
+    /// empty vector; `OrigIpoptNlp` overrides.
+    fn pack_z_l_for_user(&self, _z_l: &dyn Vector) -> Vec<Number> {
+        Vec::new()
+    }
+
+    /// Expand a compressed upper-bound-multiplier vector into the user
+    /// TNLP's full-`n` length `z_U` array. Default impl returns an
+    /// empty vector; `OrigIpoptNlp` overrides.
+    fn pack_z_u_for_user(&self, _z_u: &dyn Vector) -> Vec<Number> {
+        Vec::new()
+    }
+
+    /// Number of variables `n` as the user TNLP declared it (= `n_full_x`,
+    /// before fixed-variable elimination). Used by inspector entry
+    /// points that need to size full-`n` buffers. Default impl returns
+    /// 0; `OrigIpoptNlp` overrides.
+    fn n_full_x(&self) -> Index {
+        0
+    }
+
+    /// Number of constraints `m` as the user TNLP declared it (= `n_full_g`).
+    /// Default impl returns 0; `OrigIpoptNlp` overrides.
+    fn n_full_g(&self) -> Index {
+        0
+    }
 }

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -931,7 +931,7 @@ impl OrigIpoptNlp {
     /// factors so the result is in the user's unscaled-constraint
     /// multiplier space (`lambda_user_i = c_scale_i * y_c_i`). Used
     /// when invoking the user's `eval_h`.
-    fn pack_lambda_for_user(
+    pub fn pack_lambda_for_user(
         &self,
         y_c: &dyn Vector,
         y_d: &dyn Vector,
@@ -1508,6 +1508,85 @@ impl IpoptNlp for OrigIpoptNlp {
 
     fn lift_x_to_full(&self, x: &dyn Vector) -> Vec<Number> {
         OrigIpoptNlp::lift_x_to_full(self, x)
+    }
+
+    fn n_full_x(&self) -> Index {
+        self.adapter.borrow().classification().n_full_x
+    }
+
+    fn n_full_g(&self) -> Index {
+        self.adapter.borrow().classification().n_full_g
+    }
+
+    fn pack_lambda_for_user(&self, y_c: &dyn Vector, y_d: &dyn Vector) -> Vec<Number> {
+        let cls = self.adapter.borrow().classification().clone();
+        OrigIpoptNlp::pack_lambda_for_user(self, y_c, y_d, &cls)
+    }
+
+    fn pack_g_for_user(&self, c: &dyn Vector, d: &dyn Vector) -> Vec<Number> {
+        let cls = self.adapter.borrow().classification().clone();
+        let mut g = vec![0.0; cls.n_full_g as usize];
+        if cls.n_c > 0 {
+            let Some(dc) = c.as_any().downcast_ref::<DenseVector>() else {
+                panic!("OrigIpoptNlp expects DenseVector for c");
+            };
+            let cs = self.c_scale.borrow();
+            for (i, &g_idx) in cls.c_map.iter().enumerate() {
+                let v = dc.expanded_values()[i];
+                g[g_idx as usize] = match cs.as_ref() {
+                    Some(s) => v / s[i],
+                    None => v,
+                };
+            }
+        }
+        if cls.n_d > 0 {
+            let Some(dd) = d.as_any().downcast_ref::<DenseVector>() else {
+                panic!("OrigIpoptNlp expects DenseVector for d");
+            };
+            let ds = self.d_scale.borrow();
+            for (i, &g_idx) in cls.d_map.iter().enumerate() {
+                let v = dd.expanded_values()[i];
+                g[g_idx as usize] = match ds.as_ref() {
+                    Some(s) => v / s[i],
+                    None => v,
+                };
+            }
+        }
+        g
+    }
+
+    fn pack_z_l_for_user(&self, z_l: &dyn Vector) -> Vec<Number> {
+        let cls = self.adapter.borrow().classification().clone();
+        let mut full = vec![0.0; cls.n_full_x as usize];
+        if z_l.dim() == 0 {
+            return full;
+        }
+        let Some(dz) = z_l.as_any().downcast_ref::<DenseVector>() else {
+            panic!("OrigIpoptNlp expects DenseVector for z_l");
+        };
+        let vals = dz.expanded_values();
+        for (k, &var_idx) in cls.x_l_map.iter().enumerate() {
+            let full_idx = cls.x_not_fixed_map[var_idx as usize] as usize;
+            full[full_idx] = vals[k];
+        }
+        full
+    }
+
+    fn pack_z_u_for_user(&self, z_u: &dyn Vector) -> Vec<Number> {
+        let cls = self.adapter.borrow().classification().clone();
+        let mut full = vec![0.0; cls.n_full_x as usize];
+        if z_u.dim() == 0 {
+            return full;
+        }
+        let Some(dz) = z_u.as_any().downcast_ref::<DenseVector>() else {
+            panic!("OrigIpoptNlp expects DenseVector for z_u");
+        };
+        let vals = dz.expanded_values();
+        for (k, &var_idx) in cls.x_u_map.iter().enumerate() {
+            let full_idx = cls.x_not_fixed_map[var_idx as usize] as usize;
+            full[full_idx] = vals[k];
+        }
+        full
     }
 }
 


### PR DESCRIPTION
Closes #19.

## Summary

Brings `pounce-cinterface` to **full upstream Ipopt 3.14.x parity** plus the ripopt-style post-solve accessors, so existing PyIpopt / cyipopt / JuMP / Fortran callers, *and* ripopt users, can link against `libpounce_cinterface` without source changes.

### New C entry points (Ipopt parity)

| Function | Notes |
|---|---|
| `OpenIpoptOutputFile` | Mirrors `IpoptApplication::OpenOutputFile`; sets `output_file` / `file_print_level` options and attaches a `FileJournal`. The Rust application gains a matching public `open_output_file(fname, level)` method. |
| `SetIpoptProblemScaling` | Stores obj/x/g scaling on the problem and forwards them to `TNLP::get_scaling_parameters` via the `CCallbackTnlp` bridge. Takes effect when `nlp_scaling_method=user-scaling`. |
| `GetIpoptVersion` | Reports `CARGO_PKG_VERSION` as `major/minor/release` ints; NULL-tolerant. |
| `GetIpoptCurrentIterate` / `GetIpoptCurrentViolations` | Signatures match upstream byte-for-byte. Returns `false` outside an active intermediate callback; per-iteration callback wiring in the algorithm core is tracked as follow-up. |

### Pounce extensions (ripopt parity)

`GetIpoptIterCount`, `GetIpoptSolveTime`, `GetIpoptPrimalInf`, `GetIpoptDualInf`, `GetIpoptComplInf` — read out of the `SolveStatistics` snapshot captured at the end of `IpoptSolve`.

### Header

`crates/pounce-cinterface/include/pounce.h` — single umbrella header consolidating every entry point with documentation. Pulls in the existing `IpoptReturnCodes.h` for status enums.

## Test plan

- [x] `cargo test -p pounce-cinterface` — 27/27 passing (9 new unit tests cover happy path + null/invalid input for each new entry).
- [x] `cargo build` (workspace) green.
- [x] `cargo test -p pounce-algorithm` green.
- [ ] (Follow-up) Wire the intermediate callback into `IpoptAlgorithm::optimize()` so `GetIpoptCurrentIterate` / `GetIpoptCurrentViolations` work mid-solve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)