### PR TITLE
feat(diagnostics,cli): add --dump CLI flag and KKT dump path (#15)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "feral"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -39,6 +39,7 @@ use crate::restoration::RestorationPhase;
 /// internally reuses caches across builds.
 pub type RestorationFactory = Box<dyn FnMut() -> Box<dyn RestorationPhase>>;
 use pounce_linalg::dense_vector::DenseVectorSpace;
+use pounce_common::diagnostics::DiagnosticsState;
 use pounce_common::exception::{ExceptionKind, SolverException};
 use pounce_common::journalist::{JournalLevel, Journalist};
 use pounce_common::options_list::OptionsList;
@@ -82,6 +83,12 @@ pub struct IpoptApplication {
     /// `RestorationFailure` as soon as the line-search would otherwise
     /// jump into restoration.
     restoration_factory: Option<RestorationFactory>,
+    /// Shared diagnostic-dump state, installed by the CLI when the
+    /// user passes `--dump <cat>:<spec>`. When set, the application
+    /// propagates an `Rc<DiagnosticsState>` into [`IpoptAlgorithm`]
+    /// via [`IpoptAlgorithm::with_diagnostics`] so the KKT solver and
+    /// other dump sites can consult per-iter gating.
+    diagnostics: Option<Rc<DiagnosticsState>>,
 }
 
 impl fmt::Debug for IpoptApplication {
@@ -121,6 +128,7 @@ impl IpoptApplication {
             timing: RefCell::new(Rc::new(TimingStatistics::new())),
             linear_backend_factory: None,
             restoration_factory: None,
+            diagnostics: None,
         }
     }
 
@@ -158,6 +166,21 @@ impl IpoptApplication {
     /// factory at the application boundary.
     pub fn set_restoration_factory(&mut self, factory: RestorationFactory) {
         self.restoration_factory = Some(factory);
+    }
+
+    /// Install the shared diagnostics state. Once set, every
+    /// subsequent `optimize_tnlp` call forwards the state into the
+    /// algorithm via [`IpoptAlgorithm::with_diagnostics`] so the KKT
+    /// solver can emit `--dump kkt:...` artifacts.
+    pub fn set_diagnostics(&mut self, diag: Rc<DiagnosticsState>) {
+        self.diagnostics = Some(diag);
+    }
+
+    /// Read-side accessor for the installed diagnostics state, if any.
+    /// Lets the CLI write the top-level manifest/timing files after
+    /// the solve completes.
+    pub fn diagnostics(&self) -> Option<Rc<DiagnosticsState>> {
+        self.diagnostics.as_ref().map(Rc::clone)
     }
 
     /// Read an `ipopt.opt`-format options file. Equivalent to
@@ -522,6 +545,9 @@ impl IpoptApplication {
             .with_tnlp(Rc::clone(&tnlp));
         if let Some(factory) = self.restoration_factory.as_mut() {
             alg = alg.with_restoration(factory());
+        }
+        if let Some(diag) = self.diagnostics.as_ref() {
+            alg = alg.with_diagnostics(Rc::clone(diag));
         }
         alg.max_iter = max_iter;
 

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -33,6 +33,7 @@ use crate::iter_dump::IterDumper;
 use crate::kkt::pd_search_dir_calc::PdSearchDirCalc;
 use crate::line_search::backtracking::Outcome;
 use crate::restoration::{RestorationOutcome, RestorationPhase};
+use pounce_common::diagnostics::DiagnosticsState;
 use pounce_common::types::{Index, Number};
 use pounce_linalg::Vector;
 use pounce_nlp::alg_types::SolverReturn;
@@ -167,6 +168,11 @@ pub struct IpoptAlgorithm {
     /// satisfies the acceptable predicate.
     acceptable_iterate: Option<crate::iterates_vector::IteratesVector>,
     acceptable_iter_number: Index,
+    /// Shared per-solve diagnostics state. `None` unless the CLI
+    /// requested `--dump <cat>:<spec>`. When set, the outer loop
+    /// advances the state's iter counter and the augmented-system
+    /// solver consults it to gate KKT dumps.
+    diagnostics: Option<Rc<DiagnosticsState>>,
 }
 
 impl IpoptAlgorithm {
@@ -198,6 +204,7 @@ impl IpoptAlgorithm {
             resto_near_feasible_count: 0,
             acceptable_iterate: None,
             acceptable_iter_number: 0,
+            diagnostics: None,
         }
     }
 
@@ -300,6 +307,14 @@ impl IpoptAlgorithm {
 
     pub fn with_restoration(mut self, resto: Box<dyn RestorationPhase>) -> Self {
         self.restoration = Some(resto);
+        self
+    }
+
+    /// Install the shared diagnostics state. The state is propagated
+    /// to the augmented-system solver at the top of [`Self::optimize`]
+    /// so dump sites can consult per-iter gating.
+    pub fn with_diagnostics(mut self, diag: Rc<DiagnosticsState>) -> Self {
+        self.diagnostics = Some(diag);
         self
     }
 
@@ -1099,10 +1114,17 @@ impl IpoptAlgorithm {
         // Install the shared accumulator on the augmented-system solver
         // so its factor / back-solve calls are attributed to
         // `linear_system_factorization` / `linear_system_back_solve`.
+        // Same pattern for the diagnostics state when present, so KKT
+        // dump sites can consult per-iter gating.
         if let Some(sd) = self.search_dir.as_mut() {
             sd.pd_solver_mut()
                 .aug_solver_mut()
                 .set_timing_stats(std::rc::Rc::clone(&timing));
+            if let Some(diag) = self.diagnostics.as_ref() {
+                sd.pd_solver_mut()
+                    .aug_solver_mut()
+                    .set_diagnostics(Rc::clone(diag));
+            }
         }
 
         // 0a. Strategy initialization — port of upstream's
@@ -1157,6 +1179,14 @@ impl IpoptAlgorithm {
             d.write_record(&self.data, &self.cq);
         }
 
+        // Advance the diagnostics iter counter so the first `iterate()`
+        // body reports as iter 0 (matches `data.iter_count`). Subsequent
+        // bumps live at the bottom of the loop alongside the iter_count
+        // bookkeeping.
+        if let Some(diag) = self.diagnostics.as_ref() {
+            diag.bump_iter();
+        }
+
         // Iter 0 intermediate callback — upstream fires once after
         // `InitializeIterates` before the loop body starts so users
         // observe the initial point.
@@ -1184,6 +1214,12 @@ impl IpoptAlgorithm {
                         return SolverReturn::MaxiterExceeded;
                     }
                     self.data.borrow_mut().iter_count = iter_count;
+                    // Keep the diagnostics counter in lock-step with
+                    // `data.iter_count` so KKT-dump gating reflects the
+                    // about-to-execute iteration.
+                    if let Some(diag) = self.diagnostics.as_ref() {
+                        diag.bump_iter();
+                    }
                     // Per-iteration record — emitted after the
                     // iter_count bump so the recorded `iter` field
                     // matches `IpData().iter_count()` at the moment of

--- a/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
@@ -92,6 +92,12 @@ pub trait AugSystemSolver {
     /// (LowRank) forward to their inner solver.
     fn set_timing_stats(&mut self, _timing: Rc<TimingStatistics>) {}
 
+    /// Install the shared per-solve diagnostics state so KKT-dump
+    /// sites can consult per-iter gating. Default impl is a no-op
+    /// (diagnostics disabled); the standard solver overrides to wire
+    /// in the dump path.
+    fn set_diagnostics(&mut self, _diag: Rc<pounce_common::diagnostics::DiagnosticsState>) {}
+
     /// One factor + back-substitution for the full 4×4 block system.
     /// `check_neg_evals=true` asks the linsol to verify that the
     /// observed inertia equals `num_neg_evals`; on mismatch the

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -27,6 +27,7 @@
 //! flattening (used by L-BFGS in Phase 8) is deferred.
 
 use crate::kkt::aug_system_solver::{AugSysCoeffs, AugSysRhs, AugSysSol, AugSystemSolver};
+use pounce_common::diagnostics::{DiagCategory, DiagnosticsState};
 use pounce_common::timing::TimingStatistics;
 use pounce_common::types::{Index, Number};
 use pounce_linalg::compound_vector::CompoundVector;
@@ -79,6 +80,13 @@ pub struct StdAugSystemSolver {
     /// algorithm installs it via [`AugSystemSolver::set_timing_stats`];
     /// when `None`, both `solve` and `resolve` skip the timing bumps.
     timing: Option<Rc<TimingStatistics>>,
+
+    /// Shared per-solve diagnostics state. `None` unless the
+    /// application requested KKT dumps via the CLI's `--dump` flag.
+    /// When set, every successful `solve()` may emit a JSONL record
+    /// to `<dump_dir>/iter_NNN/kkt_solve_MMM.jsonl`, gated by the
+    /// configured iter-spec for [`DiagCategory::Kkt`].
+    diagnostics: Option<Rc<DiagnosticsState>>,
 }
 
 impl std::fmt::Debug for StdAugSystemSolver {
@@ -119,6 +127,7 @@ impl StdAugSystemSolver {
             last_status: None,
             have_factor: false,
             timing: None,
+            diagnostics: None,
         }
     }
 
@@ -389,10 +398,39 @@ impl AugSystemSolver for StdAugSystemSolver {
             self.have_factor = true;
         }
 
-        // Diagnostic dump: when POUNCE_DUMP_KKT is set, append the
-        // augmented system to that JSONL path. Used by the offline
-        // FERAL/MA57/LAPACK comparison tool.
+        // Diagnostic dump: structured `--dump kkt:...` surface, then
+        // the legacy `POUNCE_DUMP_KKT=<path>` env-var fallback. The
+        // two paths share `write_kkt_record` so the JSON line is bit-
+        // identical regardless of how the dump was requested.
+        if let Some(diag) = self.diagnostics.clone() {
+            if diag.want(DiagCategory::Kkt) {
+                let solve_idx = diag.next_solve_index();
+                let filename = format!("kkt_solve_{solve_idx:03}.jsonl");
+                if let Some(mut w) = diag.open_writer(&filename) {
+                    let _ = write_kkt_record(
+                        &mut w,
+                        self.dim,
+                        &self.irn,
+                        &self.jcn,
+                        &self.vals,
+                        &dump_rhs,
+                        &packed,
+                        check_neg_evals,
+                        num_neg_evals,
+                        status,
+                        self.last_neg_evals,
+                    );
+                }
+            }
+        }
         if let Ok(path) = std::env::var("POUNCE_DUMP_KKT") {
+            use std::sync::atomic::{AtomicBool, Ordering};
+            static WARNED: AtomicBool = AtomicBool::new(false);
+            if !WARNED.swap(true, Ordering::SeqCst) {
+                eprintln!(
+                    "warning: POUNCE_DUMP_KKT is deprecated; prefer `--dump kkt:<iter-spec>` (see pounce --help)"
+                );
+            }
             dump_kkt(
                 &path,
                 self.dim,
@@ -449,6 +487,10 @@ impl AugSystemSolver for StdAugSystemSolver {
         status
     }
 
+    fn set_diagnostics(&mut self, diag: Rc<DiagnosticsState>) {
+        self.diagnostics = Some(diag);
+    }
+
     fn set_timing_stats(&mut self, timing: Rc<TimingStatistics>) {
         self.timing = Some(timing);
     }
@@ -457,8 +499,12 @@ impl AugSystemSolver for StdAugSystemSolver {
 // ---------------- helpers ----------------
 
 #[allow(clippy::too_many_arguments)]
-fn dump_kkt(
-    path: &str,
+/// Serialize one KKT solve as a single JSONL record. Shared by the
+/// `--dump kkt:...` path (one file per solve under `iter_NNN/`) and
+/// the legacy `POUNCE_DUMP_KKT` path (one append-mode file across
+/// the whole run).
+fn write_kkt_record(
+    w: &mut dyn std::io::Write,
     dim: Index,
     irn: &[Index],
     jcn: &[Index],
@@ -469,9 +515,8 @@ fn dump_kkt(
     num_neg_evals: Index,
     status: ESymSolverStatus,
     last_neg_evals: Index,
-) {
+) -> std::io::Result<()> {
     use std::fmt::Write as _;
-    use std::io::Write as _;
 
     let mut line = String::with_capacity(64 * vals.len());
     line.push('{');
@@ -508,12 +553,40 @@ fn dump_kkt(
     }
     line.push_str("]}\n");
 
+    w.write_all(line.as_bytes())
+}
+
+fn dump_kkt(
+    path: &str,
+    dim: Index,
+    irn: &[Index],
+    jcn: &[Index],
+    vals: &[Number],
+    rhs: &[Number],
+    sol: &[Number],
+    check_neg_evals: bool,
+    num_neg_evals: Index,
+    status: ESymSolverStatus,
+    last_neg_evals: Index,
+) {
     if let Ok(mut f) = std::fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(path)
     {
-        let _ = f.write_all(line.as_bytes());
+        let _ = write_kkt_record(
+            &mut f,
+            dim,
+            irn,
+            jcn,
+            vals,
+            rhs,
+            sol,
+            check_neg_evals,
+            num_neg_evals,
+            status,
+            last_neg_evals,
+        );
     }
 }
 

--- a/crates/pounce-algorithm/tests/diagnostics_kkt_dump.rs
+++ b/crates/pounce-algorithm/tests/diagnostics_kkt_dump.rs
@@ -1,0 +1,188 @@
+//! Integration test for the `--dump kkt:...` surface.
+//!
+//! Solves HS071 with a [`DiagnosticsState`] installed on the
+//! application asking for KKT dumps over iters 1-2, then verifies:
+//!
+//! * the dump directory tree has the expected `iter_NNN/kkt_solve_001.jsonl`
+//!   files (and only those iters),
+//! * each dumped record is parseable as one JSONL line with the
+//!   expected top-level fields,
+//! * the top-level `manifest.json` helper works.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::diagnostics::{
+    DiagCategory, DiagnosticsConfig, DiagnosticsState, IterSpec,
+};
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::fs;
+use std::rc::Rc;
+
+#[derive(Default)]
+struct Hs071;
+
+impl TNLP for Hs071 {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo { n: 4, m: 2, nnz_jac_g: 8, nnz_h_lag: 10, index_style: IndexStyle::C })
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[1.0; 4]);
+        b.x_u.copy_from_slice(&[5.0; 4]);
+        b.g_l.copy_from_slice(&[25.0, 40.0]);
+        b.g_u.copy_from_slice(&[2.0e19, 40.0]);
+        true
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[1.0, 5.0, 5.0, 1.0]);
+        true
+    }
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2])
+    }
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[3] * (2.0 * x[0] + x[1] + x[2]);
+        g[1] = x[0] * x[3];
+        g[2] = x[0] * x[3] + 1.0;
+        g[3] = x[0] * (x[0] + x[1] + x[2]);
+        true
+    }
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] * x[1] * x[2] * x[3];
+        g[1] = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] + x[3] * x[3];
+        true
+    }
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 0, 0, 1, 1, 1, 1]);
+                jcol.copy_from_slice(&[0, 1, 2, 3, 0, 1, 2, 3]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_jac_g(Values) without x");
+                values[0] = x[1] * x[2] * x[3];
+                values[1] = x[0] * x[2] * x[3];
+                values[2] = x[0] * x[1] * x[3];
+                values[3] = x[0] * x[1] * x[2];
+                values[4] = 2.0 * x[0];
+                values[5] = 2.0 * x[1];
+                values[6] = 2.0 * x[2];
+                values[7] = 2.0 * x[3];
+            }
+        }
+        true
+    }
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1, 2, 2, 2, 3, 3, 3, 3]);
+                jcol.copy_from_slice(&[0, 0, 1, 0, 1, 2, 0, 1, 2, 3]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_h(Values) without x");
+                let lam = lambda.expect("eval_h(Values) without lambda");
+                let of = obj_factor;
+                let l0 = lam[0];
+                let l1 = lam[1];
+                values[0] = of * (2.0 * x[3]) + l1 * 2.0;
+                values[1] = of * x[3] + l0 * (x[2] * x[3]);
+                values[2] = l1 * 2.0;
+                values[3] = of * x[3] + l0 * (x[1] * x[3]);
+                values[4] = l0 * (x[0] * x[3]);
+                values[5] = l1 * 2.0;
+                values[6] = of * (2.0 * x[0] + x[1] + x[2]) + l0 * (x[1] * x[2]);
+                values[7] = of * x[0] + l0 * (x[0] * x[2]);
+                values[8] = of * x[0] + l0 * (x[0] * x[1]);
+                values[9] = l1 * 2.0;
+            }
+        }
+        true
+    }
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn tempdir(tag: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!(
+        "pounce-diag-it-{}-{}-{}",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&p).unwrap();
+    p
+}
+
+#[test]
+fn kkt_dump_produces_per_iter_files_and_manifest() {
+    let dump_dir = tempdir("kkt");
+
+    let cfg = DiagnosticsConfig::new(dump_dir.clone())
+        .with_category(DiagCategory::Kkt, IterSpec::Range(Some(1), Some(2)));
+    let diag = Rc::new(DiagnosticsState::new(cfg).unwrap());
+
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    app.set_diagnostics(Rc::clone(&diag));
+
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071));
+    let status = app.optimize_tnlp(tnlp);
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+
+    // Iters 1 and 2 should each have at least one kkt dump.
+    for iter in [1, 2] {
+        let dir = dump_dir.join(format!("iter_{iter:03}"));
+        assert!(dir.is_dir(), "missing dump dir for iter {iter}: {dir:?}");
+        let solve = dir.join("kkt_solve_001.jsonl");
+        assert!(solve.is_file(), "missing dump file: {solve:?}");
+        let body = fs::read_to_string(&solve).unwrap();
+        assert!(body.starts_with('{') && body.contains("\"n\":"), "bad record: {body}");
+        assert!(body.contains("\"vals\":["), "missing vals field");
+        assert!(body.contains("\"sol\":["), "missing sol field");
+        assert!(body.ends_with("]}\n"), "missing terminator: {body}");
+    }
+
+    // Out-of-range iter should not have produced a kkt file (the
+    // directory only gets created on demand by `iter_dir()`).
+    let out_of_range = dump_dir.join("iter_000");
+    if out_of_range.exists() {
+        let entries: Vec<_> = fs::read_dir(&out_of_range).unwrap().collect();
+        assert!(
+            entries.is_empty(),
+            "iter_000 should not contain kkt files (range was 1-2)",
+        );
+    }
+
+    // The top-level writer helper drops files at `dump_dir`.
+    diag.write_top_level("manifest.json", "{\"hello\":\"world\"}\n").unwrap();
+    let manifest = fs::read_to_string(dump_dir.join("manifest.json")).unwrap();
+    assert!(manifest.contains("\"hello\":\"world\""));
+
+    fs::remove_dir_all(&dump_dir).ok();
+}

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -23,6 +23,17 @@ pub struct Args {
     /// `--about`: print build metadata, compiled-in features, available
     /// linear solvers, and runtime paths. Used for bug reports.
     pub about: bool,
+    /// `--dump <cat>[:<iter-spec>]`, repeatable. Each entry asks the
+    /// solver to dump one diagnostic category at the specified iter
+    /// range (`all`, `N`, `N-M`, `N-`, `-M`); omitting the spec is
+    /// equivalent to `:all`. Forwarded to
+    /// [`pounce_common::diagnostics::DiagnosticsConfig`].
+    pub dump_specs: Vec<(String, String)>,
+    /// `--dump-dir <path>`: override the dump root. Defaults to
+    /// `./pounce-dump-<unix-secs>`, picked at solve-start time.
+    pub dump_dir: Option<PathBuf>,
+    /// `--dump-format <fmt>`: dump file format. Currently only `jsonl`.
+    pub dump_format: Option<String>,
 }
 
 impl Args {
@@ -51,6 +62,15 @@ Options:
   --version, -V             print version and exit
   --about                   print version, build info, features,
                             linear solvers, and runtime paths
+  --dump <cat>[:<spec>]     dump diagnostic category to per-iter files.
+                            Repeatable. Categories: kkt, iterate, step,
+                            mu, ls, resto, convergence, timing.
+                            Iter-spec grammar: all | N | N-M | N- | -M
+                            (default: all). Examples:
+                              --dump kkt:5
+                              --dump kkt:2-10 --dump iterate:all
+  --dump-dir <path>         override dump root (default ./pounce-dump-<ts>)
+  --dump-format <fmt>       dump format (default: jsonl)
 "
     }
 
@@ -62,6 +82,9 @@ Options:
         let mut version = false;
         let mut about = false;
         let mut list_problems = false;
+        let mut dump_specs: Vec<(String, String)> = Vec::new();
+        let mut dump_dir: Option<PathBuf> = None;
+        let mut dump_format: Option<String> = None;
 
         let mut it = argv.into_iter().skip(1);
         while let Some(arg) = it.next() {
@@ -87,6 +110,28 @@ Options:
                         .next()
                         .ok_or_else(|| "--options-file requires a value".to_string())?;
                     options_file = Some(PathBuf::from(v));
+                }
+                "--dump" => {
+                    let v = it
+                        .next()
+                        .ok_or_else(|| "--dump requires a value (cat[:spec])".to_string())?;
+                    let (cat, spec) = match v.split_once(':') {
+                        Some((c, s)) => (c.to_string(), s.to_string()),
+                        None => (v, "all".to_string()),
+                    };
+                    dump_specs.push((cat, spec));
+                }
+                "--dump-dir" => {
+                    let v = it
+                        .next()
+                        .ok_or_else(|| "--dump-dir requires a value".to_string())?;
+                    dump_dir = Some(PathBuf::from(v));
+                }
+                "--dump-format" => {
+                    let v = it
+                        .next()
+                        .ok_or_else(|| "--dump-format requires a value".to_string())?;
+                    dump_format = Some(v);
                 }
                 other if !other.starts_with('-') => {
                     // `key=value` forms an option pair (matches upstream
@@ -120,6 +165,9 @@ Options:
                 help,
                 version,
                 about,
+                dump_specs,
+                dump_dir,
+                dump_format,
             });
         }
 
@@ -130,6 +178,9 @@ Options:
             help,
             version,
             about,
+            dump_specs,
+            dump_dir,
+            dump_format,
         })
     }
 }
@@ -261,6 +312,43 @@ mod tests {
             _ => panic!("expected positional .nl"),
         }
         assert_eq!(a.set_options, vec![("print_level".into(), "8".into())]);
+    }
+
+    #[test]
+    fn dump_flag_captures_cat_and_spec() {
+        let a = Args::parse_argv(argv(&[
+            "--problem",
+            "x",
+            "--dump",
+            "kkt:2-10",
+            "--dump",
+            "iterate",
+        ]))
+        .unwrap();
+        assert_eq!(
+            a.dump_specs,
+            vec![
+                ("kkt".into(), "2-10".into()),
+                ("iterate".into(), "all".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dump_dir_and_format_captured() {
+        let a = Args::parse_argv(argv(&[
+            "--problem",
+            "x",
+            "--dump",
+            "kkt",
+            "--dump-dir",
+            "/tmp/d",
+            "--dump-format",
+            "jsonl",
+        ]))
+        .unwrap();
+        assert_eq!(a.dump_dir.unwrap().to_str(), Some("/tmp/d"));
+        assert_eq!(a.dump_format.as_deref(), Some("jsonl"));
     }
 
     #[test]

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -15,6 +15,9 @@ use pounce_cli::nl_reader;
 use pounce_cli::print;
 use pounce_algorithm::alg_builder::{AlgorithmBuilder, LinearBackendFactory, LinearSolverChoice};
 use pounce_algorithm::application::IpoptApplication;
+use pounce_common::diagnostics::{
+    DiagCategory, DiagnosticsConfig, DiagnosticsState, DumpFormat, IterSpec,
+};
 use pounce_linsol::sparse_sym_iface::SparseSymLinearSolverInterface;
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::tnlp::TNLP;
@@ -91,6 +94,13 @@ fn main() -> ExitCode {
         bff,
     );
     app.set_restoration_factory(resto_factory);
+
+    // Snapshot the problem source before the `match` consumes
+    // `args.problem` — needed downstream by the diagnostics manifest.
+    let problem_desc: String = match &args.problem {
+        ProblemSource::Builtin(s) => format!("builtin:{s}"),
+        ProblemSource::NlFile(p) => format!("nl:{}", p.display()),
+    };
 
     let inner_tnlp: Rc<RefCell<dyn TNLP>> = match args.problem {
         ProblemSource::Builtin(name) => match builtin::lookup(&name) {
@@ -208,16 +218,132 @@ fn main() -> ExitCode {
         print::print_problem_stats(&stats);
     }
 
+    // Build diagnostics state from `--dump …` flags. None of these
+    // flags is required, but `--dump-dir` / `--dump-format` on their
+    // own (no `--dump <cat>`) yields an empty config and we skip
+    // installation entirely — there's nothing to write.
+    let diagnostics_handle = match build_diagnostics(
+        &args.dump_specs,
+        args.dump_dir.as_ref(),
+        args.dump_format.as_deref(),
+    ) {
+        Ok(d) => d,
+        Err(msg) => {
+            eprintln!("pounce: {msg}");
+            return ExitCode::from(2);
+        }
+    };
+    if let Some(diag) = diagnostics_handle.as_ref() {
+        println!(
+            "Diagnostics: dumping to {} ({} categor{} configured)",
+            diag.dump_dir().display(),
+            diag.config.categories.len(),
+            if diag.config.categories.len() == 1 { "y" } else { "ies" },
+        );
+        app.set_diagnostics(Rc::clone(diag));
+    }
+
     let status = app.optimize_tnlp(Rc::clone(&tnlp));
     let solve_stats = app.statistics();
     let counters = counting.borrow();
     print::print_summary(status, &solve_stats, &counters);
+
+    // After the solve, drop a manifest + timing summary at the dump
+    // root so consumers (and humans) can tell which run produced
+    // which artifacts without reading the iter_NNN/ tree.
+    if let Some(diag) = diagnostics_handle.as_ref() {
+        write_diagnostics_manifest(diag, &problem_desc, status);
+        write_diagnostics_timing(diag, &app);
+    }
 
     match status {
         ApplicationReturnStatus::SolveSucceeded
         | ApplicationReturnStatus::SolvedToAcceptableLevel => ExitCode::SUCCESS,
         _ => ExitCode::from(1),
     }
+}
+
+/// Translate the CLI's `--dump …` flags into a live `DiagnosticsState`.
+/// Returns `Ok(None)` when no `--dump <cat>` was given (the `--dump-dir`
+/// / `--dump-format` flags alone don't activate dumping).
+fn build_diagnostics(
+    dump_specs: &[(String, String)],
+    dump_dir: Option<&std::path::PathBuf>,
+    dump_format: Option<&str>,
+) -> Result<Option<Rc<DiagnosticsState>>, String> {
+    if dump_specs.is_empty() {
+        if dump_dir.is_some() || dump_format.is_some() {
+            return Err(
+                "--dump-dir / --dump-format require at least one --dump <cat>[:spec]"
+                    .to_string(),
+            );
+        }
+        return Ok(None);
+    }
+
+    let dump_dir = dump_dir.cloned().unwrap_or_else(|| {
+        let secs = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        std::path::PathBuf::from(format!("pounce-dump-{secs}"))
+    });
+
+    let format = match dump_format {
+        Some(f) => DumpFormat::parse(f)?,
+        None => DumpFormat::Jsonl,
+    };
+
+    let mut config = DiagnosticsConfig::new(dump_dir);
+    config.format = format;
+    for (cat, spec) in dump_specs {
+        let cat = DiagCategory::parse(cat)?;
+        let spec = IterSpec::parse(spec)?;
+        config = config.with_category(cat, spec);
+    }
+
+    let state = DiagnosticsState::new(config)
+        .map_err(|e| format!("could not create dump directory: {e}"))?;
+    Ok(Some(Rc::new(state)))
+}
+
+/// Drop a minimal JSON manifest summarising the run. Lets downstream
+/// tools (and humans) join a dump directory back to its CLI args
+/// without re-reading the per-iter files.
+fn write_diagnostics_manifest(
+    diag: &DiagnosticsState,
+    problem_desc: &str,
+    status: ApplicationReturnStatus,
+) {
+    let mut cats: Vec<String> = diag
+        .config
+        .categories
+        .iter()
+        .map(|(c, s)| format!("\"{}\":\"{:?}\"", c.as_str(), s))
+        .collect();
+    cats.sort();
+    let manifest = format!(
+        "{{\n  \"pounce_version\": \"{ver}\",\n  \"git\": \"{git}\",\n  \"problem\": \"{problem}\",\n  \"status\": \"{status:?}\",\n  \"format\": \"{fmt:?}\",\n  \"categories\": {{ {cats} }}\n}}\n",
+        ver = env!("CARGO_PKG_VERSION"),
+        git = env!("POUNCE_BUILD_GIT"),
+        problem = problem_desc,
+        fmt = diag.config.format,
+        cats = cats.join(", "),
+    );
+    let _ = diag.write_top_level("manifest.json", &manifest);
+}
+
+/// Emit a sibling `timing.json` so dump consumers can correlate
+/// per-iter files with the solve's wall-clock budget.
+fn write_diagnostics_timing(diag: &DiagnosticsState, app: &IpoptApplication) {
+    let t = app.timing_stats();
+    let body = format!(
+        "{{\n  \"overall_alg_secs\": {a:.6},\n  \"linear_system_factorization_secs\": {f:.6},\n  \"linear_system_back_solve_secs\": {b:.6}\n}}\n",
+        a = t.overall_alg.total_wallclock_time(),
+        f = t.linear_system_factorization.total_wallclock_time(),
+        b = t.linear_system_back_solve.total_wallclock_time(),
+    );
+    let _ = diag.write_top_level("timing.json", &body);
 }
 
 /// `--about` output: version, build provenance, compiled-in features,

--- a/crates/pounce-common/src/diagnostics.rs
+++ b/crates/pounce-common/src/diagnostics.rs
@@ -1,0 +1,505 @@
+//! Diagnostic-dump infrastructure shared by the solver and the CLI.
+//!
+//! # Why this exists
+//!
+//! Debugging a stalled solve or a perf regression usually means
+//! capturing the inner state of the IPM at specific iterations:
+//! the augmented-system KKT matrix, the iterate, the search step,
+//! the line-search trace. Historically this lived as a scatter of
+//! `POUNCE_DBG_*` env-vars across the codebase, each with bespoke
+//! semantics. This module centralizes the surface so the CLI
+//! (`--dump kkt:5-10`) and the dump sites (deep in the linear
+//! solver) speak the same vocabulary.
+//!
+//! # Lifecycle
+//!
+//! 1. The CLI parses `--dump <cat>[:<spec>]` flags into a
+//!    [`DiagnosticsConfig`] and constructs a [`DiagnosticsState`].
+//! 2. The application installs the state via
+//!    `IpoptApplication::set_diagnostics`, then propagates an
+//!    `Rc<DiagnosticsState>` through the solve in the same way
+//!    [`crate::timing::TimingStatistics`] is propagated.
+//! 3. At the top of each outer iteration, the IPM calls
+//!    [`DiagnosticsState::bump_iter`] to advance the current-iter
+//!    counter and reset the per-iter solve index.
+//! 4. Every dump site (KKT solver, line search, μ oracle, ...) calls
+//!    [`DiagnosticsState::want`] to gate the dump, then
+//!    [`DiagnosticsState::open_writer`] to obtain a file handle in
+//!    the right `iter_NNN/` sub-directory.
+//!
+//! # File layout
+//!
+//! ```text
+//! <dump_dir>/
+//!   manifest.json
+//!   iter_005/
+//!     kkt_solve_001.jsonl
+//!     iterate.json
+//!   iter_006/...
+//!   resto/
+//!     parent_iter_007/
+//!       iter_000/kkt_solve_001.jsonl
+//!   timing.json
+//! ```
+//!
+//! The `solve_NNN` suffix disambiguates the multi-solve-per-iter case
+//! (second-order corrections and perturbation re-solves issue extra
+//! factorizations inside one outer iteration). The
+//! `resto/parent_iter_NNN/` hierarchy keeps the restoration sub-IPM
+//! trace separate from the main solve trace.
+
+use std::collections::HashMap;
+use std::fs;
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+
+/// Single diagnostic category the user can request.
+///
+/// Categories map roughly one-to-one to dump sites in the solver.
+/// `Kkt` is the only one actually wired in PR-A; the rest are
+/// declared up front so `--dump iterate:all` parses today and the
+/// follow-up PRs only need to flip the dump-site switch.
+#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy)]
+pub enum DiagCategory {
+    Kkt,
+    Iterate,
+    Step,
+    Mu,
+    Ls,
+    Resto,
+    Convergence,
+    Timing,
+}
+
+impl DiagCategory {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiagCategory::Kkt => "kkt",
+            DiagCategory::Iterate => "iterate",
+            DiagCategory::Step => "step",
+            DiagCategory::Mu => "mu",
+            DiagCategory::Ls => "ls",
+            DiagCategory::Resto => "resto",
+            DiagCategory::Convergence => "convergence",
+            DiagCategory::Timing => "timing",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "kkt" => Ok(DiagCategory::Kkt),
+            "iterate" => Ok(DiagCategory::Iterate),
+            "step" => Ok(DiagCategory::Step),
+            "mu" => Ok(DiagCategory::Mu),
+            "ls" => Ok(DiagCategory::Ls),
+            "resto" => Ok(DiagCategory::Resto),
+            "convergence" => Ok(DiagCategory::Convergence),
+            "timing" => Ok(DiagCategory::Timing),
+            other => Err(format!(
+                "unknown dump category '{other}' (expected one of: kkt, iterate, step, mu, ls, resto, convergence, timing)"
+            )),
+        }
+    }
+}
+
+/// Iteration filter attached to a category. `None` endpoints denote
+/// open-ended ranges (`N-` is `Range(Some(N), None)`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IterSpec {
+    All,
+    Single(i32),
+    Range(Option<i32>, Option<i32>),
+}
+
+impl IterSpec {
+    pub fn includes(&self, iter: i32) -> bool {
+        match self {
+            IterSpec::All => true,
+            IterSpec::Single(n) => iter == *n,
+            IterSpec::Range(lo, hi) => {
+                lo.map_or(true, |l| iter >= l) && hi.map_or(true, |h| iter <= h)
+            }
+        }
+    }
+
+    /// Parse the grammar `all | N | N-M | N- | -M`. Negative ints
+    /// aren't accepted — iter counts are non-negative by definition.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        let s = s.trim();
+        if s.is_empty() || s == "all" {
+            return Ok(IterSpec::All);
+        }
+        if let Some(rest) = s.strip_prefix('-') {
+            // "-M"
+            let hi: i32 = rest
+                .parse()
+                .map_err(|_| format!("invalid iter-spec '{s}': expected '-M' with non-negative integer M"))?;
+            if hi < 0 {
+                return Err(format!("invalid iter-spec '{s}': iter must be non-negative"));
+            }
+            return Ok(IterSpec::Range(None, Some(hi)));
+        }
+        if let Some((a, b)) = s.split_once('-') {
+            let lo: i32 = a
+                .parse()
+                .map_err(|_| format!("invalid iter-spec '{s}': '{a}' is not an integer"))?;
+            if lo < 0 {
+                return Err(format!("invalid iter-spec '{s}': iter must be non-negative"));
+            }
+            if b.is_empty() {
+                // "N-"
+                return Ok(IterSpec::Range(Some(lo), None));
+            }
+            // "N-M"
+            let hi: i32 = b
+                .parse()
+                .map_err(|_| format!("invalid iter-spec '{s}': '{b}' is not an integer"))?;
+            if hi < 0 {
+                return Err(format!("invalid iter-spec '{s}': iter must be non-negative"));
+            }
+            if hi < lo {
+                return Err(format!(
+                    "invalid iter-spec '{s}': end ({hi}) is below start ({lo})"
+                ));
+            }
+            return Ok(IterSpec::Range(Some(lo), Some(hi)));
+        }
+        // Bare "N"
+        let n: i32 = s
+            .parse()
+            .map_err(|_| format!("invalid iter-spec '{s}': expected 'all', 'N', 'N-M', 'N-', or '-M'"))?;
+        if n < 0 {
+            return Err(format!("invalid iter-spec '{s}': iter must be non-negative"));
+        }
+        Ok(IterSpec::Single(n))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DumpFormat {
+    /// Newline-delimited JSON records. One record per dump call.
+    /// Hackable from a shell one-liner; the default.
+    Jsonl,
+}
+
+impl DumpFormat {
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s {
+            "jsonl" => Ok(DumpFormat::Jsonl),
+            other => Err(format!(
+                "unknown dump format '{other}' (expected: jsonl)"
+            )),
+        }
+    }
+}
+
+/// Static configuration: where to dump, in what format, with what
+/// per-category iter filters. Constructed by the CLI, held by the
+/// application, frozen for the duration of a solve.
+#[derive(Debug, Clone)]
+pub struct DiagnosticsConfig {
+    pub dump_dir: PathBuf,
+    pub format: DumpFormat,
+    pub categories: HashMap<DiagCategory, IterSpec>,
+}
+
+impl DiagnosticsConfig {
+    pub fn new(dump_dir: PathBuf) -> Self {
+        Self {
+            dump_dir,
+            format: DumpFormat::Jsonl,
+            categories: HashMap::new(),
+        }
+    }
+
+    pub fn with_category(mut self, cat: DiagCategory, spec: IterSpec) -> Self {
+        self.categories.insert(cat, spec);
+        self
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.categories.is_empty()
+    }
+}
+
+/// Live state threaded through the solve via `Rc`. The IPM mutates
+/// `current_iter` and `solves_this_iter`; the dump sites read them.
+/// All fields use atomics so the type is `Send + Sync` even though
+/// the solver itself is single-threaded — keeps the door open for
+/// future parallel inner solvers without an ABI rewrite.
+pub struct DiagnosticsState {
+    pub config: DiagnosticsConfig,
+    current_iter: AtomicI32,
+    solves_this_iter: AtomicI32,
+    in_restoration: AtomicBool,
+    resto_parent_iter: AtomicI32,
+    resto_inner_iter: AtomicI32,
+    resto_solves_this_iter: AtomicI32,
+}
+
+impl DiagnosticsState {
+    /// Create a state and `mkdir -p` the dump directory. Failure to
+    /// create the directory bubbles up so the CLI can exit with a
+    /// clear error before the solve even starts.
+    pub fn new(config: DiagnosticsConfig) -> std::io::Result<Self> {
+        fs::create_dir_all(&config.dump_dir)?;
+        Ok(Self {
+            config,
+            current_iter: AtomicI32::new(-1),
+            solves_this_iter: AtomicI32::new(0),
+            in_restoration: AtomicBool::new(false),
+            resto_parent_iter: AtomicI32::new(-1),
+            resto_inner_iter: AtomicI32::new(-1),
+            resto_solves_this_iter: AtomicI32::new(0),
+        })
+    }
+
+    /// True if the caller should dump `cat` at the current iter.
+    pub fn want(&self, cat: DiagCategory) -> bool {
+        let iter = self.effective_iter();
+        if iter < 0 {
+            return false;
+        }
+        self.config
+            .categories
+            .get(&cat)
+            .map(|spec| spec.includes(iter))
+            .unwrap_or(false)
+    }
+
+    /// Advance the outer-iteration counter and reset the per-iter
+    /// solve index. Called by `IpoptAlgorithm::optimize` at the top
+    /// of each outer iteration.
+    pub fn bump_iter(&self) {
+        if self.in_restoration.load(Ordering::SeqCst) {
+            self.resto_inner_iter.fetch_add(1, Ordering::SeqCst);
+            self.resto_solves_this_iter.store(0, Ordering::SeqCst);
+        } else {
+            self.current_iter.fetch_add(1, Ordering::SeqCst);
+            self.solves_this_iter.store(0, Ordering::SeqCst);
+        }
+    }
+
+    /// Reserve the next per-iter solve index. Returned value is
+    /// 1-based to match the filenames (`kkt_solve_001.jsonl`).
+    pub fn next_solve_index(&self) -> i32 {
+        let counter = if self.in_restoration.load(Ordering::SeqCst) {
+            &self.resto_solves_this_iter
+        } else {
+            &self.solves_this_iter
+        };
+        counter.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Mark the start of a restoration sub-IPM run. `parent_iter` is
+    /// the outer iter that triggered restoration; dumps from the
+    /// resto sub-solve land under `resto/parent_iter_NNN/iter_MMM/`.
+    pub fn enter_restoration(&self) {
+        let parent = self.current_iter.load(Ordering::SeqCst);
+        self.resto_parent_iter.store(parent, Ordering::SeqCst);
+        self.resto_inner_iter.store(-1, Ordering::SeqCst);
+        self.resto_solves_this_iter.store(0, Ordering::SeqCst);
+        self.in_restoration.store(true, Ordering::SeqCst);
+    }
+
+    pub fn exit_restoration(&self) {
+        self.in_restoration.store(false, Ordering::SeqCst);
+    }
+
+    pub fn current_iter(&self) -> i32 {
+        self.effective_iter()
+    }
+
+    /// The iter counter that gates current dumps — resto inner iter
+    /// when in restoration, main outer iter otherwise.
+    fn effective_iter(&self) -> i32 {
+        if self.in_restoration.load(Ordering::SeqCst) {
+            self.resto_inner_iter.load(Ordering::SeqCst)
+        } else {
+            self.current_iter.load(Ordering::SeqCst)
+        }
+    }
+
+    /// Resolve the directory a category's dump file should live in,
+    /// creating it if necessary. Returns `None` if the directory
+    /// cannot be created (e.g., filesystem full) — callers should
+    /// silently skip the dump in that case rather than fail the
+    /// solve.
+    pub fn iter_dir(&self) -> Option<PathBuf> {
+        let dir = if self.in_restoration.load(Ordering::SeqCst) {
+            let parent = self.resto_parent_iter.load(Ordering::SeqCst);
+            let inner = self.resto_inner_iter.load(Ordering::SeqCst).max(0);
+            self.config.dump_dir.join(format!(
+                "resto/parent_iter_{parent:03}/iter_{inner:03}"
+            ))
+        } else {
+            let iter = self.current_iter.load(Ordering::SeqCst).max(0);
+            self.config.dump_dir.join(format!("iter_{iter:03}"))
+        };
+        fs::create_dir_all(&dir).ok()?;
+        Some(dir)
+    }
+
+    /// Open a writer for `<iter_dir>/<filename>`. Caller picks the
+    /// filename so callers that produce multi-solve traces can use
+    /// `next_solve_index` to disambiguate.
+    pub fn open_writer(&self, filename: &str) -> Option<BufWriter<fs::File>> {
+        let dir = self.iter_dir()?;
+        let path = dir.join(filename);
+        fs::File::create(path).ok().map(BufWriter::new)
+    }
+
+    /// Write a one-shot top-level file (manifest, timing summary).
+    /// Always lands directly under `dump_dir`, never under an iter
+    /// sub-directory.
+    pub fn write_top_level(&self, filename: &str, contents: &str) -> std::io::Result<()> {
+        let path = self.config.dump_dir.join(filename);
+        let mut f = fs::File::create(path)?;
+        f.write_all(contents.as_bytes())?;
+        f.flush()
+    }
+
+    pub fn dump_dir(&self) -> &Path {
+        &self.config.dump_dir
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iter_spec_parses_all_grammar_forms() {
+        assert_eq!(IterSpec::parse("").unwrap(), IterSpec::All);
+        assert_eq!(IterSpec::parse("all").unwrap(), IterSpec::All);
+        assert_eq!(IterSpec::parse("5").unwrap(), IterSpec::Single(5));
+        assert_eq!(
+            IterSpec::parse("5-10").unwrap(),
+            IterSpec::Range(Some(5), Some(10))
+        );
+        assert_eq!(
+            IterSpec::parse("5-").unwrap(),
+            IterSpec::Range(Some(5), None)
+        );
+        assert_eq!(
+            IterSpec::parse("-10").unwrap(),
+            IterSpec::Range(None, Some(10))
+        );
+    }
+
+    #[test]
+    fn iter_spec_rejects_malformed_input() {
+        assert!(IterSpec::parse("abc").is_err());
+        assert!(IterSpec::parse("5-3").is_err()); // end below start
+        assert!(IterSpec::parse("-x").is_err());
+        assert!(IterSpec::parse("5--10").is_err()); // doubled separator → "-10" tail parse fails
+    }
+
+    #[test]
+    fn iter_spec_includes_matches_grammar() {
+        assert!(IterSpec::All.includes(0));
+        assert!(IterSpec::All.includes(1000));
+        assert!(IterSpec::Single(5).includes(5));
+        assert!(!IterSpec::Single(5).includes(4));
+        let r = IterSpec::Range(Some(5), Some(10));
+        assert!(!r.includes(4));
+        assert!(r.includes(5));
+        assert!(r.includes(7));
+        assert!(r.includes(10));
+        assert!(!r.includes(11));
+        assert!(IterSpec::Range(Some(5), None).includes(1_000_000));
+        assert!(IterSpec::Range(None, Some(5)).includes(0));
+    }
+
+    #[test]
+    fn category_parses_known_names() {
+        assert_eq!(DiagCategory::parse("kkt").unwrap(), DiagCategory::Kkt);
+        assert_eq!(
+            DiagCategory::parse("iterate").unwrap(),
+            DiagCategory::Iterate
+        );
+        assert!(DiagCategory::parse("bogus").is_err());
+    }
+
+    #[test]
+    fn state_gates_on_iter_spec() {
+        let tmp = tempdir();
+        let cfg = DiagnosticsConfig::new(tmp.clone())
+            .with_category(DiagCategory::Kkt, IterSpec::Range(Some(2), Some(4)));
+        let state = DiagnosticsState::new(cfg).unwrap();
+
+        // Before bump_iter, current_iter == -1 → no dumps.
+        assert!(!state.want(DiagCategory::Kkt));
+
+        state.bump_iter(); // iter 0
+        assert!(!state.want(DiagCategory::Kkt));
+        state.bump_iter(); // 1
+        assert!(!state.want(DiagCategory::Kkt));
+        state.bump_iter(); // 2
+        assert!(state.want(DiagCategory::Kkt));
+        state.bump_iter(); // 3
+        assert!(state.want(DiagCategory::Kkt));
+        state.bump_iter(); // 4
+        assert!(state.want(DiagCategory::Kkt));
+        state.bump_iter(); // 5
+        assert!(!state.want(DiagCategory::Kkt));
+
+        // Other categories silently skipped (not configured).
+        assert!(!state.want(DiagCategory::Iterate));
+
+        fs::remove_dir_all(tmp).ok();
+    }
+
+    #[test]
+    fn state_emits_solve_indices_and_iter_dirs() {
+        let tmp = tempdir();
+        let cfg = DiagnosticsConfig::new(tmp.clone())
+            .with_category(DiagCategory::Kkt, IterSpec::All);
+        let state = DiagnosticsState::new(cfg).unwrap();
+        state.bump_iter(); // iter 0
+        assert_eq!(state.next_solve_index(), 1);
+        assert_eq!(state.next_solve_index(), 2);
+        state.bump_iter(); // iter 1
+        assert_eq!(state.next_solve_index(), 1);
+
+        let dir = state.iter_dir().unwrap();
+        assert!(dir.ends_with("iter_001"));
+        fs::remove_dir_all(tmp).ok();
+    }
+
+    #[test]
+    fn restoration_dumps_live_under_resto_subtree() {
+        let tmp = tempdir();
+        let cfg = DiagnosticsConfig::new(tmp.clone())
+            .with_category(DiagCategory::Kkt, IterSpec::All);
+        let state = DiagnosticsState::new(cfg).unwrap();
+        state.bump_iter(); // main iter 0
+        state.bump_iter(); // main iter 1
+        state.enter_restoration();
+        state.bump_iter(); // resto inner 0
+        let dir = state.iter_dir().unwrap();
+        assert!(
+            dir.ends_with("resto/parent_iter_001/iter_000"),
+            "got {dir:?}"
+        );
+        assert_eq!(state.next_solve_index(), 1);
+        state.exit_restoration();
+        let dir = state.iter_dir().unwrap();
+        assert!(dir.ends_with("iter_001"), "got {dir:?}");
+        fs::remove_dir_all(tmp).ok();
+    }
+
+    fn tempdir() -> PathBuf {
+        let p = std::env::temp_dir().join(format!(
+            "pounce-diag-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/crates/pounce-common/src/lib.rs
+++ b/crates/pounce-common/src/lib.rs
@@ -7,6 +7,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod cached;
+pub mod diagnostics;
 pub mod exception;
 pub mod journalist;
 pub mod options_list;
@@ -17,6 +18,9 @@ pub mod types;
 pub mod utils;
 
 pub use cached::Cache;
+pub use diagnostics::{
+    DiagCategory, DiagnosticsConfig, DiagnosticsState, DumpFormat, IterSpec,
+};
 pub use exception::{ExceptionKind, SolverException};
 pub use journalist::{
     FileJournal, Journal, Journalist, JournalCategory, JournalLevel, StringJournal,

--- a/crates/pounce-linsol/src/t_sym_solver.rs
+++ b/crates/pounce-linsol/src/t_sym_solver.rs
@@ -189,9 +189,15 @@ impl TSymLinearSolver {
         // binary record (dim, nnz, nrhs, ia[], ja[], vals[], rhs[]) on
         // the Nth multi_solve call (N = POUNCE_DBG_KKT_DUMP_SKIP, default 0),
         // then disables itself.
+        //
+        // DEPRECATED: superseded by the unified `--dump kkt:<spec>` CLI
+        // surface (see `pounce_common::diagnostics`). Kept for the
+        // existing offline FERAL/MA57/LAPACK binary-comparison tool;
+        // the env var emits a one-shot warning on first observation.
         {
-            use std::sync::atomic::{AtomicUsize, Ordering};
+            use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
             static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+            static WARNED: AtomicBool = AtomicBool::new(false);
             let n_call = CALL_COUNT.fetch_add(1, Ordering::SeqCst);
             let skip: usize = std::env::var("POUNCE_DBG_KKT_DUMP_SKIP")
                 .ok()
@@ -200,6 +206,11 @@ impl TSymLinearSolver {
             if n_call < skip {
                 // not yet
             } else if let Ok(path) = std::env::var("POUNCE_DBG_KKT_DUMP") {
+                if !WARNED.swap(true, Ordering::SeqCst) {
+                    eprintln!(
+                        "warning: POUNCE_DBG_KKT_DUMP is deprecated; prefer `--dump kkt:<iter-spec>` (see pounce --help)"
+                    );
+                }
                 use std::io::Write;
                 if let Ok(mut f) = std::fs::File::create(&path) {
                     let dim = self.dim as u64;


### PR DESCRIPTION
## Summary
- Introduces `pounce_common::diagnostics` (`DiagnosticsConfig`, `DiagnosticsState`, `IterSpec`, `DiagCategory`, `DumpFormat`)
- Adds CLI flags `--dump <cat>[:<spec>]` (repeatable), `--dump-dir`, `--dump-format`; iter-spec grammar: `all | N | N-M | N- | -M`
- Wires `kkt` category through `IpoptApplication` → `IpoptAlgorithm` → `StdAugSystemSolver`, emitting one JSONL record per solve under `<dump_dir>/iter_NNN/kkt_solve_MMM.jsonl`
- Refactors legacy `POUNCE_DUMP_KKT` to share the same serializer; both it and `POUNCE_DBG_KKT_DUMP` now emit a one-shot deprecation warning
- CLI drops `manifest.json` + `timing.json` at the dump root after each solve

## Test plan
- [x] `cargo test --workspace` green (incl. new `diagnostics_kkt_dump` integration test and CLI parser tests)
- [x] `cargo build --workspace` clean
- [ ] Smoke: `pounce --problem hs071 --dump kkt:0-2` produces three `iter_NNN/kkt_solve_*.jsonl` plus `manifest.json` / `timing.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)