### PR TITLE
feat(nl): AMPL imported (external) function support (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,31 @@ test:
   with adaptive ν clamped by `sqp_l1_penalty_safety` /
   `sqp_l1_penalty_max`. SNOPT-style behaviour.
 
+### Added — AMPL imported (external) function support (issue #49)
+
+`.nl` files that declare imported functions in their `F` segments
+and call them via `f<id> <nargs>` tokens are now solved end-to-end.
+Set `AMPLFUNC` to a newline-separated list of shared-library paths;
+pounce loads each library via the standard AMPL `funcadd_ASL` ABI,
+binds every referenced funcall id to a `(library, name)` pair, and
+emits `TapeOp::Funcall` nodes that participate in full forward /
+reverse / Hessian sweeps (first- and second-derivative requests
+are issued back through the library on demand, with the packed
+upper-triangular Hessian indexed as `hes[lo + hi*(hi+1)/2]`).
+
+Tested against the IDAES `general_helmholtz_external.dylib`
+fixture from the issue report — pounce reaches
+`EXIT: Optimal Solution Found` on the 3-variable Helmholtz
+problem. Without `AMPLFUNC` set, problems that need external
+functions fail with a clear error naming the offending function
+and pointing at `AMPLFUNC`.
+
+Limitations: only the `Tape` (default) AD path supports external
+functions. The `HybridTape` partial-separability path and the
+JIT-style `HessianProgram` path panic on `TapeOp::Funcall` — both
+are alternative routes not on `NlTnlp::new`'s critical path, so
+the current production flow is unaffected.
+
 ### Added — Phase 5a `pounce-qp` crate
 
 Standalone sparse parametric active-set QP solver. Drives the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,10 +152,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "log"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "matrixmultiply"
@@ -298,6 +314,8 @@ dependencies = [
 name = "pounce-cli"
 version = "0.2.0"
 dependencies = [
+ "libloading",
+ "log",
  "pounce-algorithm",
  "pounce-common",
  "pounce-feral",
@@ -701,6 +719,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "zmij"

--- a/README.md
+++ b/README.md
@@ -147,6 +147,23 @@ A `.sol` is written even when the solve fails, so the
 (`--problem …`) have no `.nl` stub, so they only produce a `.sol`
 when `--sol-output` is given explicitly.
 
+### AMPL imported (external) functions
+
+`.nl` files that import functions from a shared library (declared in
+`F` segments, called via `f<id>` expression tokens) are supported.
+Set `AMPLFUNC` to a newline-separated list of library paths — the
+same convention upstream Ipopt uses — and pounce loads each library
+through the standard AMPL `funcadd_ASL` ABI:
+
+```sh
+AMPLFUNC=$HOME/.idaes/bin/general_helmholtz_external.dylib \
+  pounce helmholtz.nl
+```
+
+Multiple libraries: `AMPLFUNC=$(printf '%s\n%s\n' /path/lib1 /path/lib2) pounce …`.
+Without `AMPLFUNC` set, problems that need external functions fail
+with a clear error naming the offending function.
+
 ### Pyomo
 
 Because pounce speaks the AMPL NL/SOL protocol, it drops into

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -39,6 +39,8 @@ pounce-linalg.workspace = true
 pounce-sensitivity.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+libloading = "0.8"
+log = "0.4"
 
 [features]
 default = []

--- a/crates/pounce-cli/src/lib.rs
+++ b/crates/pounce-cli/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod builtin;
 pub mod cli;
 pub mod counting_tnlp;
+pub mod nl_external;
 pub mod nl_hessian_program;
 pub mod nl_reader;
 pub mod nl_tape;

--- a/crates/pounce-cli/src/nl_external.rs
+++ b/crates/pounce-cli/src/nl_external.rs
@@ -64,10 +64,13 @@ impl ExternalResolver {
                 .to_string()
         })?;
         let mut libs: Vec<Arc<ExternalLibrary>> = Vec::new();
-        for path_str in amplfunc.split('\n').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+        for path_str in amplfunc
+            .split('\n')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+        {
             let path = std::path::Path::new(path_str);
-            let lib = ExternalLibrary::load(path)
-                .map_err(|e| format!("AMPLFUNC: {e}"))?;
+            let lib = ExternalLibrary::load(path).map_err(|e| format!("AMPLFUNC: {e}"))?;
             libs.push(Arc::new(lib));
         }
 
@@ -141,20 +144,20 @@ pub const FUNCADD_RANDOM_VALUED: i32 = 4;
 /// The `arglist` struct from AMPL's `funcadd.h`. Layout must match exactly.
 #[repr(C)]
 pub struct Arglist {
-    pub n: c_int,                        // number of args
-    pub nr: c_int,                       // number of real input args
-    pub at: *mut c_int,                  // argument types
-    pub ra: *mut f64,                    // pure real args (IN/OUT/INOUT)
-    pub sa: *mut *const c_char,          // symbolic IN args
-    pub derivs: *mut f64,                // partial derivatives (if non-null)
-    pub hes: *mut f64,                   // second partials (if non-null)
-    pub dig: *mut c_char,                // skip-derivatives flags
-    pub funcinfo: *mut c_void,           // per-function cookie (set by Addfunc)
-    pub ae: *mut AmplExports,            // points back at our AmplExports
-    pub f: *mut c_void,                  // AMPL-internal
-    pub tva: *mut c_void,                // AMPL-internal
-    pub errmsg: *mut c_char,             // error description set by the function
-    pub tmi: *mut c_void,                // Tempmem cookie
+    pub n: c_int,               // number of args
+    pub nr: c_int,              // number of real input args
+    pub at: *mut c_int,         // argument types
+    pub ra: *mut f64,           // pure real args (IN/OUT/INOUT)
+    pub sa: *mut *const c_char, // symbolic IN args
+    pub derivs: *mut f64,       // partial derivatives (if non-null)
+    pub hes: *mut f64,          // second partials (if non-null)
+    pub dig: *mut c_char,       // skip-derivatives flags
+    pub funcinfo: *mut c_void,  // per-function cookie (set by Addfunc)
+    pub ae: *mut AmplExports,   // points back at our AmplExports
+    pub f: *mut c_void,         // AMPL-internal
+    pub tva: *mut c_void,       // AMPL-internal
+    pub errmsg: *mut c_char,    // error description set by the function
+    pub tmi: *mut c_void,       // Tempmem cookie
     pub private: *mut c_char,
     pub nin: c_int,
     pub nout: c_int,
@@ -180,18 +183,11 @@ pub type AddfuncFn = unsafe extern "C" fn(
 pub type RandSeedSetter = unsafe extern "C" fn(*mut c_void, std::os::raw::c_ulong);
 
 /// Pointer to the `Addrandinit` callback.
-pub type AddrandinitFn = unsafe extern "C" fn(
-    ae: *mut AmplExports,
-    setter: RandSeedSetter,
-    v: *mut c_void,
-);
+pub type AddrandinitFn =
+    unsafe extern "C" fn(ae: *mut AmplExports, setter: RandSeedSetter, v: *mut c_void);
 
 /// Pointer to the `AtReset` callback.
-pub type AtResetFn = unsafe extern "C" fn(
-    ae: *mut AmplExports,
-    f: *mut c_void,
-    v: *mut c_void,
-);
+pub type AtResetFn = unsafe extern "C" fn(ae: *mut AmplExports, f: *mut c_void, v: *mut c_void);
 
 /// The `AmplExports` struct from AMPL's `funcadd.h`. Layout must match
 /// exactly. Function pointers we don't implement are held as `*mut c_void`
@@ -402,7 +398,10 @@ impl ExternalLibrary {
         // has somewhere to deposit them without capturing Rust state.
         REGISTRY_SINK.with(|sink| {
             let mut guard = sink.borrow_mut();
-            assert!(guard.is_none(), "nested ExternalLibrary::load is not supported");
+            assert!(
+                guard.is_none(),
+                "nested ExternalLibrary::load is not supported"
+            );
             *guard = Some(HashMap::new());
         });
 
@@ -515,7 +514,11 @@ impl ExternalLibrary {
         } else {
             0
         };
-        let mut hes_buf: Vec<f64> = if want_hes { vec![0.0; hes_len] } else { Vec::new() };
+        let mut hes_buf: Vec<f64> = if want_hes {
+            vec![0.0; hes_len]
+        } else {
+            Vec::new()
+        };
 
         // Space for a library-set error message.
         let mut errmsg_buf: Vec<c_char> = vec![0; 1024];
@@ -670,11 +673,7 @@ unsafe extern "C" fn trampoline_addfunc(
 
 /// Stub — some libraries ask us to register an AtReset callback. Pyomo logs a
 /// warning and does nothing. We do the same.
-unsafe extern "C" fn trampoline_atreset(
-    _ae: *mut AmplExports,
-    _f: *mut c_void,
-    _v: *mut c_void,
-) {
+unsafe extern "C" fn trampoline_atreset(_ae: *mut AmplExports, _f: *mut c_void, _v: *mut c_void) {
     log::debug!("external library registered an AtReset callback; ignoring");
 }
 
@@ -694,8 +693,7 @@ mod tests {
 
     fn idaes_dylib() -> Option<std::path::PathBuf> {
         let home = std::env::var_os("HOME")?;
-        let p = std::path::PathBuf::from(home)
-            .join(".idaes/bin/general_helmholtz_external.dylib");
+        let p = std::path::PathBuf::from(home).join(".idaes/bin/general_helmholtz_external.dylib");
         if p.exists() {
             Some(p)
         } else {

--- a/crates/pounce-cli/src/nl_external.rs
+++ b/crates/pounce-cli/src/nl_external.rs
@@ -1,0 +1,827 @@
+//! AMPL imported (external) function support via the `funcadd_ASL` ABI.
+//!
+//! This module implements enough of AMPL's `funcadd.h` ABI to:
+//!
+//! 1. `dlopen` a user-supplied shared library;
+//! 2. resolve the `funcadd_ASL` symbol and call it;
+//! 3. receive registration callbacks of the form `Addfunc(name, rfunc, type,
+//!    nargs, funcinfo, ae)` and record them;
+//! 4. later call back into the registered `rfunc` with an `arglist` to obtain
+//!    function values, gradients, and Hessians.
+//!
+//! The `AmplExports` and `Arglist` struct layouts are taken from
+//! AMPL-MP/ASL `funcadd.h`; cross-checked against the ctypes mapping in
+//! `pyomo.core.base.external`. Fields we don't populate are left null —
+//! Pyomo does the same and it is sufficient for IDAES's Helmholtz library
+//! (see issue #15).
+//!
+//! All unsafe FFI is contained in this module. Public surface is safe.
+
+use std::collections::HashMap;
+use std::ffi::{c_char, c_int, c_long, c_void, CStr, CString};
+use std::path::Path;
+use std::ptr;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use libloading::{Library, Symbol};
+
+use crate::nl_reader::{Expr, FuncallArg, ImportedFunc};
+
+/// Resolved AMPL imported function: shared library + registered name.
+/// `NlProblem` carries one of these per `ImportedFunc` id when external
+/// functions are wired up at problem-build time. The same `Arc<ExternalLibrary>`
+/// may be shared across many funcall ids (one library typically registers
+/// several functions).
+#[derive(Default, Clone)]
+pub struct ExternalResolver {
+    /// `Funcall { id }` -> (library, registered function name).
+    pub funcs_by_id: HashMap<usize, (Arc<ExternalLibrary>, String)>,
+}
+
+impl ExternalResolver {
+    pub fn is_empty(&self) -> bool {
+        self.funcs_by_id.is_empty()
+    }
+
+    /// Build a resolver for every `ImportedFunc` declared in the `.nl` file
+    /// that is *actually referenced* somewhere in the problem's expressions.
+    ///
+    /// Library paths are resolved through the `AMPLFUNC` environment variable
+    /// (a `\n`-separated list of shared-library paths, matching AMPL/IPOPT
+    /// conventions). Each path is loaded once and queried for every name we
+    /// need. Returns an error if a referenced name cannot be found in any
+    /// listed library, or if `AMPLFUNC` is missing.
+    pub fn build_for_problem(
+        imported_funcs: &[ImportedFunc],
+        referenced_ids: &std::collections::BTreeSet<usize>,
+    ) -> Result<Self, String> {
+        if referenced_ids.is_empty() {
+            return Ok(Self::default());
+        }
+        let amplfunc = std::env::var("AMPLFUNC").map_err(|_| {
+            "problem uses external functions but AMPLFUNC is not set; \
+             set AMPLFUNC to a newline-separated list of AMPL shared-library paths"
+                .to_string()
+        })?;
+        let mut libs: Vec<Arc<ExternalLibrary>> = Vec::new();
+        for path_str in amplfunc.split('\n').map(|s| s.trim()).filter(|s| !s.is_empty()) {
+            let path = std::path::Path::new(path_str);
+            let lib = ExternalLibrary::load(path)
+                .map_err(|e| format!("AMPLFUNC: {e}"))?;
+            libs.push(Arc::new(lib));
+        }
+
+        let mut funcs_by_id: HashMap<usize, (Arc<ExternalLibrary>, String)> = HashMap::new();
+        for id in referenced_ids {
+            let decl = imported_funcs
+                .iter()
+                .find(|f| f.id == *id)
+                .ok_or_else(|| format!("funcall id {id} has no F<{id}> declaration"))?;
+            let found = libs
+                .iter()
+                .find(|lib| lib.get(&decl.name).is_some())
+                .ok_or_else(|| {
+                    format!(
+                        "external function '{}' (id {}) not found in any library on AMPLFUNC",
+                        decl.name, decl.id
+                    )
+                })?;
+            funcs_by_id.insert(*id, (found.clone(), decl.name.clone()));
+        }
+        Ok(Self { funcs_by_id })
+    }
+}
+
+/// Walk an `Expr` and collect every funcall id it references (including
+/// through CSEs). Used to build an `ExternalResolver` covering exactly the
+/// functions a problem actually uses.
+pub fn collect_funcall_ids(e: &Expr, out: &mut std::collections::BTreeSet<usize>) {
+    match e {
+        Expr::Const(_) | Expr::Var(_) => {}
+        Expr::Binary(_, a, b) => {
+            collect_funcall_ids(a, out);
+            collect_funcall_ids(b, out);
+        }
+        Expr::Unary(_, a) => collect_funcall_ids(a, out),
+        Expr::Sum(args) => {
+            for a in args {
+                collect_funcall_ids(a, out);
+            }
+        }
+        Expr::Cse(body) => collect_funcall_ids(body, out),
+        Expr::Funcall { id, args } => {
+            out.insert(*id);
+            for arg in args {
+                if let FuncallArg::Real(e) = arg {
+                    collect_funcall_ids(e, out);
+                }
+            }
+        }
+    }
+}
+
+/// Process-wide lock serialising every call that crosses the AMPL external
+/// ABI. Real AMPL libraries (e.g. IDAES general_helmholtz) keep mutable
+/// global state (cached parameters, tabulated lookups) and are not safe for
+/// concurrent entry. Python's `pyomo.core.base.external` relies on the GIL
+/// for the same guarantee.
+fn ampl_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// FUNCADD_TYPE bits (mirrors `funcadd.h`).
+pub const FUNCADD_REAL_VALUED: i32 = 0;
+/// Set if the function consumes string arguments. Value is still real.
+pub const FUNCADD_STRING_ARGS: i32 = 1;
+/// Set if the function is allowed to have a variable number of args.
+pub const FUNCADD_OUTPUT_ARGS: i32 = 2;
+pub const FUNCADD_RANDOM_VALUED: i32 = 4;
+
+/// The `arglist` struct from AMPL's `funcadd.h`. Layout must match exactly.
+#[repr(C)]
+pub struct Arglist {
+    pub n: c_int,                        // number of args
+    pub nr: c_int,                       // number of real input args
+    pub at: *mut c_int,                  // argument types
+    pub ra: *mut f64,                    // pure real args (IN/OUT/INOUT)
+    pub sa: *mut *const c_char,          // symbolic IN args
+    pub derivs: *mut f64,                // partial derivatives (if non-null)
+    pub hes: *mut f64,                   // second partials (if non-null)
+    pub dig: *mut c_char,                // skip-derivatives flags
+    pub funcinfo: *mut c_void,           // per-function cookie (set by Addfunc)
+    pub ae: *mut AmplExports,            // points back at our AmplExports
+    pub f: *mut c_void,                  // AMPL-internal
+    pub tva: *mut c_void,                // AMPL-internal
+    pub errmsg: *mut c_char,             // error description set by the function
+    pub tmi: *mut c_void,                // Tempmem cookie
+    pub private: *mut c_char,
+    pub nin: c_int,
+    pub nout: c_int,
+    pub nsin: c_int,
+    pub nsout: c_int,
+}
+
+/// Pointer to a user-defined real-valued function, matching
+/// `typedef real (*rfunc)(arglist*)`.
+pub type Rfunc = unsafe extern "C" fn(*mut Arglist) -> f64;
+
+/// Pointer to the `Addfunc` callback provided by the caller.
+pub type AddfuncFn = unsafe extern "C" fn(
+    name: *const c_char,
+    f: Rfunc,
+    ty: c_int,
+    nargs: c_int,
+    funcinfo: *mut c_void,
+    ae: *mut AmplExports,
+);
+
+/// Pointer to the `RandSeedSetter` callback.
+pub type RandSeedSetter = unsafe extern "C" fn(*mut c_void, std::os::raw::c_ulong);
+
+/// Pointer to the `Addrandinit` callback.
+pub type AddrandinitFn = unsafe extern "C" fn(
+    ae: *mut AmplExports,
+    setter: RandSeedSetter,
+    v: *mut c_void,
+);
+
+/// Pointer to the `AtReset` callback.
+pub type AtResetFn = unsafe extern "C" fn(
+    ae: *mut AmplExports,
+    f: *mut c_void,
+    v: *mut c_void,
+);
+
+/// The `AmplExports` struct from AMPL's `funcadd.h`. Layout must match
+/// exactly. Function pointers we don't implement are held as `*mut c_void`
+/// (null) — AMPL's ABI does not require a caller to populate them unless the
+/// loaded library actually invokes them.
+#[repr(C)]
+pub struct AmplExports {
+    pub std_err: *mut c_void,
+    pub addfunc: Option<AddfuncFn>,
+    pub asl_date: c_long,
+    pub fprintf: *mut c_void,
+    pub printf: *mut c_void,
+    pub sprintf: *mut c_void,
+    pub vfprintf: *mut c_void,
+    pub vsprintf: *mut c_void,
+    pub strtod: *mut c_void,
+    pub crypto: *mut c_void,
+    pub asl: *mut c_char,
+    pub at_exit: *mut c_void,
+    pub at_reset: Option<AtResetFn>,
+    pub tempmem: *mut c_void,
+    pub add_table_handler: *mut c_void,
+    pub private_ae: *mut c_char,
+    pub qsortv: *mut c_void,
+
+    pub std_in: *mut c_void,
+    pub std_out: *mut c_void,
+    pub clearerr: *mut c_void,
+    pub fclose: *mut c_void,
+    pub fdopen: *mut c_void,
+    pub feof: *mut c_void,
+    pub ferror: *mut c_void,
+    pub fflush: *mut c_void,
+    pub fgetc: *mut c_void,
+    pub fgets: *mut c_void,
+    pub fileno: *mut c_void,
+    pub fopen: *mut c_void,
+    pub fputc: *mut c_void,
+    pub fputs: *mut c_void,
+    pub fread: *mut c_void,
+    pub freopen: *mut c_void,
+    pub fscanf: *mut c_void,
+    pub fseek: *mut c_void,
+    pub ftell: *mut c_void,
+    pub fwrite: *mut c_void,
+    pub pclose: *mut c_void,
+    pub perror: *mut c_void,
+    pub popen: *mut c_void,
+    pub puts: *mut c_void,
+    pub rewind: *mut c_void,
+    pub scanf: *mut c_void,
+    pub setbuf: *mut c_void,
+    pub setvbuf: *mut c_void,
+    pub sscanf: *mut c_void,
+    pub tempnam: *mut c_void,
+    pub tmpfile: *mut c_void,
+    pub tmpnam: *mut c_void,
+    pub ungetc: *mut c_void,
+    pub ai: *mut c_void,
+    pub getenv: *mut c_void,
+    pub breakfunc: *mut c_void,
+    pub breakarg: *mut c_char,
+
+    // Items available with ASLdate >= 20020501.
+    pub snprintf: *mut c_void,
+    pub vsnprintf: *mut c_void,
+
+    pub addrand: *mut c_void,
+    pub addrandinit: Option<AddrandinitFn>,
+}
+
+// SAFETY: AmplExports itself contains only raw pointers and integers. The
+// library never reads/writes it from another thread concurrently with us
+// (AMPL's model is single-threaded per problem), and we never share it
+// across threads. The Send/Sync bounds only matter because we box the
+// registry inside Arcs.
+unsafe impl Send for AmplExports {}
+unsafe impl Sync for AmplExports {}
+
+/// A function registered by a library via `Addfunc`. Mirrors the ASL
+/// `FUNCADD_TYPE` bits in `funcadd.h`.
+#[derive(Debug, Clone)]
+pub struct RegisteredFunc {
+    pub name: String,
+    pub rfunc: Rfunc,
+    /// OR of FUNCADD_TYPE bits.
+    pub ty: i32,
+    /// Declared arg count. >=0 means exactly that many, <=-1 means "at least
+    /// -(nargs+1) args".
+    pub nargs: i32,
+    /// Cookie set by the library; must be passed through to arglist.funcinfo.
+    pub funcinfo: *mut c_void,
+}
+
+// SAFETY: funcinfo is an opaque cookie owned by the library. We never
+// dereference it; we only pass it back to the library's functions, which
+// expect it. No thread-safety contract is violated by sending the struct.
+unsafe impl Send for RegisteredFunc {}
+unsafe impl Sync for RegisteredFunc {}
+
+impl std::fmt::Debug for ExternalLibrary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExternalLibrary")
+            .field("funcs", &self.funcs.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+/// A loaded external-function library plus its registered functions.
+pub struct ExternalLibrary {
+    /// Keep the library alive — it owns the code pages the function pointers
+    /// reference. Arc so `LoadedExternals` can share it.
+    _lib: Arc<Library>,
+    /// The AmplExports we handed to `funcadd_ASL`. Must be kept alive (pinned
+    /// in a Box) because some libraries may capture its address for later
+    /// use (e.g. for `AtReset` bookkeeping).
+    _ae: Box<AmplExports>,
+    /// Registrations collected during `funcadd_ASL`.
+    funcs: HashMap<String, RegisteredFunc>,
+}
+
+impl ExternalLibrary {
+    /// Open a shared library at `path` and invoke its `funcadd_ASL` entry
+    /// point, collecting all functions it registers.
+    pub fn load(path: &Path) -> Result<Self, String> {
+        // Serialise all ABI crossings: library init code and registration
+        // may touch global state that isn't safe under concurrent entry.
+        let _guard = ampl_lock().lock().unwrap_or_else(|e| e.into_inner());
+        // SAFETY: libloading::Library::new is unsafe because it can run
+        // arbitrary initialisers from the shared object. We trust the user's
+        // AMPLFUNC path the same way AMPL/IPOPT do.
+        let lib = unsafe { Library::new(path) }
+            .map_err(|e| format!("failed to open '{}': {}", path.display(), e))?;
+
+        // Resolve `funcadd_ASL`. AMPL's macro `#define funcadd funcadd_ASL`
+        // means every conforming library exports this symbol.
+        type FuncaddFn = unsafe extern "C" fn(*mut AmplExports);
+        let funcadd: Symbol<FuncaddFn> = unsafe { lib.get(b"funcadd_ASL\0") }
+            .map_err(|e| format!("no funcadd_ASL in '{}': {}", path.display(), e))?;
+
+        // Build an AmplExports. Most fields null — the library doesn't call
+        // them (same assumption Pyomo makes). Only the three hooks we can
+        // realistically service are set.
+        let mut ae = Box::new(AmplExports {
+            std_err: ptr::null_mut(),
+            addfunc: Some(trampoline_addfunc),
+            // ASLdate >= 20020501 unlocks the SnprintF/VsnprintF slots.
+            // Pyomo uses 20160307; mirror that.
+            asl_date: 20160307,
+            fprintf: ptr::null_mut(),
+            printf: ptr::null_mut(),
+            sprintf: ptr::null_mut(),
+            vfprintf: ptr::null_mut(),
+            vsprintf: ptr::null_mut(),
+            strtod: ptr::null_mut(),
+            crypto: ptr::null_mut(),
+            asl: ptr::null_mut(),
+            at_exit: ptr::null_mut(),
+            at_reset: Some(trampoline_atreset),
+            tempmem: ptr::null_mut(),
+            add_table_handler: ptr::null_mut(),
+            private_ae: ptr::null_mut(),
+            qsortv: ptr::null_mut(),
+            std_in: ptr::null_mut(),
+            std_out: ptr::null_mut(),
+            clearerr: ptr::null_mut(),
+            fclose: ptr::null_mut(),
+            fdopen: ptr::null_mut(),
+            feof: ptr::null_mut(),
+            ferror: ptr::null_mut(),
+            fflush: ptr::null_mut(),
+            fgetc: ptr::null_mut(),
+            fgets: ptr::null_mut(),
+            fileno: ptr::null_mut(),
+            fopen: ptr::null_mut(),
+            fputc: ptr::null_mut(),
+            fputs: ptr::null_mut(),
+            fread: ptr::null_mut(),
+            freopen: ptr::null_mut(),
+            fscanf: ptr::null_mut(),
+            fseek: ptr::null_mut(),
+            ftell: ptr::null_mut(),
+            fwrite: ptr::null_mut(),
+            pclose: ptr::null_mut(),
+            perror: ptr::null_mut(),
+            popen: ptr::null_mut(),
+            puts: ptr::null_mut(),
+            rewind: ptr::null_mut(),
+            scanf: ptr::null_mut(),
+            setbuf: ptr::null_mut(),
+            setvbuf: ptr::null_mut(),
+            sscanf: ptr::null_mut(),
+            tempnam: ptr::null_mut(),
+            tmpfile: ptr::null_mut(),
+            tmpnam: ptr::null_mut(),
+            ungetc: ptr::null_mut(),
+            ai: ptr::null_mut(),
+            getenv: ptr::null_mut(),
+            breakfunc: ptr::null_mut(),
+            breakarg: ptr::null_mut(),
+            snprintf: ptr::null_mut(),
+            vsnprintf: ptr::null_mut(),
+            addrand: ptr::null_mut(),
+            addrandinit: Some(trampoline_addrandinit),
+        });
+
+        // Drive registrations into a thread-local sink so the C trampoline
+        // has somewhere to deposit them without capturing Rust state.
+        REGISTRY_SINK.with(|sink| {
+            let mut guard = sink.borrow_mut();
+            assert!(guard.is_none(), "nested ExternalLibrary::load is not supported");
+            *guard = Some(HashMap::new());
+        });
+
+        // SAFETY: funcadd is a valid C function from the loaded library; we
+        // pass it a correctly-shaped AmplExports.
+        unsafe { funcadd(ae.as_mut()) };
+
+        let funcs = REGISTRY_SINK
+            .with(|sink| sink.borrow_mut().take())
+            .unwrap_or_default();
+
+        Ok(ExternalLibrary {
+            _lib: Arc::new(lib),
+            _ae: ae,
+            funcs,
+        })
+    }
+
+    /// Names of all functions registered by this library.
+    pub fn function_names(&self) -> impl Iterator<Item = &str> {
+        self.funcs.keys().map(|s| s.as_str())
+    }
+
+    /// Look up a registered function by name.
+    pub fn get(&self, name: &str) -> Option<&RegisteredFunc> {
+        self.funcs.get(name)
+    }
+
+    /// Evaluate a registered function with the given positional arguments.
+    ///
+    /// Arguments are encoded per the AMPL `arglist` ABI: real args are stored
+    /// in `ra[]`, string args in `sa[]`, and `at[i]` maps argument position
+    /// `i` to either a real-slot index (`at[i] >= 0`) or a string-slot index
+    /// (`at[i] < 0`, decoded as `-(at[i]+1)`).
+    ///
+    /// If `want_derivs` is set, a length-`nr` derivative buffer is allocated
+    /// and returned on success. If `want_hes` is set, a length-`nr*(nr+1)/2`
+    /// Hessian buffer is also allocated and returned. The library is told to
+    /// fill both by the non-null `arglist.derivs` / `arglist.hes` pointers.
+    pub fn eval(
+        &self,
+        name: &str,
+        args: &[ExternalArg<'_>],
+        want_derivs: bool,
+        want_hes: bool,
+    ) -> Result<EvalResult, String> {
+        let rf = self
+            .funcs
+            .get(name)
+            .ok_or_else(|| format!("no such external function '{name}'"))?;
+
+        // Validate arity against the registered signature.
+        let n = args.len() as i32;
+        if rf.nargs >= 0 {
+            if rf.nargs != n {
+                return Err(format!(
+                    "external '{name}' expects {} args, got {}",
+                    rf.nargs, n
+                ));
+            }
+        } else {
+            // Negative: minimum -(nargs+1) args.
+            let min_args = -(rf.nargs + 1);
+            if n < min_args {
+                return Err(format!(
+                    "external '{name}' expects at least {min_args} args, got {n}"
+                ));
+            }
+        }
+
+        // Bucket args: build at[], ra[], sa[] in lockstep with their indices.
+        let mut at_vec: Vec<c_int> = Vec::with_capacity(args.len());
+        let mut ra_vec: Vec<f64> = Vec::new();
+        let mut sa_owned: Vec<CString> = Vec::new();
+        for a in args {
+            match a {
+                ExternalArg::Real(x) => {
+                    at_vec.push(ra_vec.len() as c_int);
+                    ra_vec.push(*x);
+                }
+                ExternalArg::Str(s) => {
+                    let cs = CString::new(*s)
+                        .map_err(|_| format!("external '{name}' string arg contains NUL"))?;
+                    at_vec.push(-(sa_owned.len() as c_int + 1));
+                    sa_owned.push(cs);
+                }
+            }
+        }
+        let nr = ra_vec.len() as c_int;
+        let sa_ptrs: Vec<*const c_char> = sa_owned.iter().map(|s| s.as_ptr()).collect();
+
+        // If the library declared FUNCADD_STRING_ARGS we let it see sa; if it
+        // did not, the library shouldn't be called with strings. Surface that.
+        let has_strings = !sa_owned.is_empty();
+        if has_strings && (rf.ty & FUNCADD_STRING_ARGS) == 0 {
+            return Err(format!(
+                "external '{name}' is not declared FUNCADD_STRING_ARGS but was \
+                 called with string arguments"
+            ));
+        }
+
+        // Optional output buffers.
+        let mut derivs_buf: Vec<f64> = if want_derivs {
+            vec![0.0; nr as usize]
+        } else {
+            Vec::new()
+        };
+        let hes_len = if want_hes {
+            (nr as usize) * ((nr as usize) + 1) / 2
+        } else {
+            0
+        };
+        let mut hes_buf: Vec<f64> = if want_hes { vec![0.0; hes_len] } else { Vec::new() };
+
+        // Space for a library-set error message.
+        let mut errmsg_buf: Vec<c_char> = vec![0; 1024];
+
+        // Build the arglist. Pointers into Rust-owned buffers are valid for
+        // the duration of the call since we hold those Vecs in this stack
+        // frame and the callee runs synchronously.
+        let mut al = Arglist {
+            n,
+            nr,
+            at: if at_vec.is_empty() {
+                ptr::null_mut()
+            } else {
+                at_vec.as_mut_ptr()
+            },
+            ra: if ra_vec.is_empty() {
+                ptr::null_mut()
+            } else {
+                ra_vec.as_mut_ptr()
+            },
+            sa: if sa_ptrs.is_empty() {
+                ptr::null_mut()
+            } else {
+                sa_ptrs.as_ptr() as *mut *const c_char
+            },
+            derivs: if want_derivs {
+                derivs_buf.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            hes: if want_hes {
+                hes_buf.as_mut_ptr()
+            } else {
+                ptr::null_mut()
+            },
+            dig: ptr::null_mut(),
+            funcinfo: rf.funcinfo,
+            // Some libraries read arglist.ae (e.g. to call fprintf); point at
+            // the same AmplExports we handed to funcadd_ASL.
+            ae: self._ae_ptr(),
+            f: ptr::null_mut(),
+            tva: ptr::null_mut(),
+            errmsg: errmsg_buf.as_mut_ptr(),
+            tmi: ptr::null_mut(),
+            private: ptr::null_mut(),
+            nin: 0,
+            nout: 0,
+            nsin: 0,
+            nsout: 0,
+        };
+
+        // SAFETY: rfunc is a valid extern "C" function pointer provided by
+        // the loaded library; arglist layout matches funcadd.h exactly.
+        // The AMPL lock serialises concurrent entry into the library.
+        let _guard = ampl_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let value = unsafe { (rf.rfunc)(&mut al as *mut Arglist) };
+        drop(_guard);
+
+        // If the library wrote into errmsg, surface that. AMPL convention:
+        // if errmsg[0] != 0 after the call, treat as error.
+        if errmsg_buf[0] != 0 {
+            // SAFETY: errmsg_buf is a NUL-terminated C buffer (we allocated
+            // and zeroed it); the library only writes a C string there.
+            let msg = unsafe { CStr::from_ptr(errmsg_buf.as_ptr()) }
+                .to_string_lossy()
+                .into_owned();
+            return Err(format!("external '{name}' reported: {msg}"));
+        }
+
+        Ok(EvalResult {
+            value,
+            derivs: if want_derivs { Some(derivs_buf) } else { None },
+            hessian: if want_hes { Some(hes_buf) } else { None },
+        })
+    }
+
+    // Raw mutable pointer to the owned AmplExports. Used when building an
+    // arglist so the library can call back through the same table it was
+    // registered with. The Box is pinned for the lifetime of self.
+    fn _ae_ptr(&self) -> *mut AmplExports {
+        // Cast away the const; we never mutate the AmplExports ourselves.
+        (&*self._ae as *const AmplExports) as *mut AmplExports
+    }
+}
+
+/// One positional argument to an external function.
+#[derive(Debug, Clone, Copy)]
+pub enum ExternalArg<'a> {
+    Real(f64),
+    Str(&'a str),
+}
+
+/// Return value from [`ExternalLibrary::eval`].
+#[derive(Debug, Clone)]
+pub struct EvalResult {
+    /// Function value.
+    pub value: f64,
+    /// `df/dx_i` for each real argument, in `ra[]` order, if `want_derivs`.
+    pub derivs: Option<Vec<f64>>,
+    /// Packed upper-triangular Hessian in AMPL's convention,
+    /// `hes[i + j*(j+1)/2]` for `0 <= i <= j < nr`, if `want_hes`.
+    pub hessian: Option<Vec<f64>>,
+}
+
+// ---------------------------------------------------------------------------
+// Registration trampoline.
+//
+// `funcadd_ASL` can call Addfunc multiple times (once per registered name).
+// Rust closures can't be converted to `extern "C"` function pointers, so we
+// route each call through a free function that deposits into a thread-local
+// sink populated by `ExternalLibrary::load`.
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static REGISTRY_SINK: std::cell::RefCell<Option<HashMap<String, RegisteredFunc>>> =
+        std::cell::RefCell::new(None);
+}
+
+/// C-callable trampoline that receives Addfunc calls from the shared library.
+unsafe extern "C" fn trampoline_addfunc(
+    name: *const c_char,
+    f: Rfunc,
+    ty: c_int,
+    nargs: c_int,
+    funcinfo: *mut c_void,
+    _ae: *mut AmplExports,
+) {
+    if name.is_null() {
+        return;
+    }
+    // SAFETY: AMPL guarantees name is a NUL-terminated C string.
+    let cname = unsafe { CStr::from_ptr(name) };
+    let name_str = match cname.to_str() {
+        Ok(s) => s.to_owned(),
+        Err(_) => return, // non-UTF8 name — skip; real libs use ASCII.
+    };
+    REGISTRY_SINK.with(|sink| {
+        if let Some(map) = sink.borrow_mut().as_mut() {
+            map.insert(
+                name_str.clone(),
+                RegisteredFunc {
+                    name: name_str,
+                    rfunc: f,
+                    ty: ty as i32,
+                    nargs: nargs as i32,
+                    funcinfo,
+                },
+            );
+        }
+    });
+}
+
+/// Stub — some libraries ask us to register an AtReset callback. Pyomo logs a
+/// warning and does nothing. We do the same.
+unsafe extern "C" fn trampoline_atreset(
+    _ae: *mut AmplExports,
+    _f: *mut c_void,
+    _v: *mut c_void,
+) {
+    log::debug!("external library registered an AtReset callback; ignoring");
+}
+
+/// Stub — invoked by libraries that use random-valued externals. We just
+/// seed with 1 (matches Pyomo's default; no randomness in KKT paths).
+unsafe extern "C" fn trampoline_addrandinit(
+    _ae: *mut AmplExports,
+    setter: RandSeedSetter,
+    v: *mut c_void,
+) {
+    unsafe { setter(v, 1) };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn idaes_dylib() -> Option<std::path::PathBuf> {
+        let home = std::env::var_os("HOME")?;
+        let p = std::path::PathBuf::from(home)
+            .join(".idaes/bin/general_helmholtz_external.dylib");
+        if p.exists() {
+            Some(p)
+        } else {
+            None
+        }
+    }
+
+    fn idaes_params_dir() -> Option<String> {
+        let home = std::env::var_os("HOME")?;
+        let p = std::path::PathBuf::from(home).join(
+            "Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/\
+             models/properties/general_helmholtz/components/parameters/",
+        );
+        if p.exists() {
+            p.to_str().map(|s| s.to_owned())
+        } else {
+            None
+        }
+    }
+
+    /// Opening the IDAES Helmholtz dylib (when present locally) should
+    /// surface the three functions used by the issue #15 fixture.
+    #[test]
+    fn load_idaes_helmholtz_dylib_registers_known_functions() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load should succeed");
+        let names: Vec<String> = lib.function_names().map(|s| s.to_owned()).collect();
+
+        for required in &["vf_hp", "h_liq_hp", "h_vap_hp"] {
+            assert!(
+                names.iter().any(|n| n == required),
+                "expected {required} in registered names: {names:?}"
+            );
+        }
+    }
+
+    /// Evaluate vf_hp at the NL fixture's initial guess. We don't assert the
+    /// exact numeric value (that's an IDAES invariant, not a ripopt one), but
+    /// the return value must be finite and the call must not set errmsg.
+    #[test]
+    fn eval_vf_hp_at_fixture_initial_point() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+        let Some(params_dir) = idaes_params_dir() else {
+            eprintln!("skipping: IDAES parameters directory not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load");
+        // Fixture initial guess: h = 1878.71 kJ/kg-scaled, p = 101.325 kPa
+        // (the scaled values actually passed through the v3/v4 slots are
+        // 1878.71 * 0.0555... and 101325 * 0.001 respectively; using raw
+        // values here, the function should still return a finite number).
+        let args = [
+            ExternalArg::Str("h2o"),
+            ExternalArg::Real(1878.71 * 0.055508472036052976),
+            ExternalArg::Real(101325.0 * 0.001),
+            ExternalArg::Str(&params_dir),
+        ];
+        let res = lib.eval("vf_hp", &args, false, false).expect("eval");
+        assert!(
+            res.value.is_finite(),
+            "vf_hp returned non-finite value {}",
+            res.value
+        );
+    }
+
+    /// Same call path, but asking for first derivatives. derivs must be a
+    /// length-2 buffer (nr=2) of finite values.
+    #[test]
+    fn eval_vf_hp_with_derivatives() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+        let Some(params_dir) = idaes_params_dir() else {
+            eprintln!("skipping: IDAES parameters directory not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let args = [
+            ExternalArg::Str("h2o"),
+            ExternalArg::Real(1878.71 * 0.055508472036052976),
+            ExternalArg::Real(101325.0 * 0.001),
+            ExternalArg::Str(&params_dir),
+        ];
+        let res = lib.eval("vf_hp", &args, true, false).expect("eval");
+        let derivs = res.derivs.expect("derivs requested");
+        assert_eq!(derivs.len(), 2, "nr=2 reals -> 2 derivatives");
+        for (i, d) in derivs.iter().enumerate() {
+            assert!(d.is_finite(), "derivs[{i}] = {d} not finite");
+        }
+    }
+
+    /// Also request the packed Hessian. For nr=2 reals, that's 3 entries
+    /// (H00, H01, H11) in AMPL's packed upper-triangular layout.
+    #[test]
+    fn eval_vf_hp_with_hessian() {
+        let Some(path) = idaes_dylib() else {
+            eprintln!("skipping: IDAES dylib not present");
+            return;
+        };
+        let Some(params_dir) = idaes_params_dir() else {
+            eprintln!("skipping: IDAES parameters directory not present");
+            return;
+        };
+
+        let lib = ExternalLibrary::load(&path).expect("load");
+        let args = [
+            ExternalArg::Str("h2o"),
+            ExternalArg::Real(1878.71 * 0.055508472036052976),
+            ExternalArg::Real(101325.0 * 0.001),
+            ExternalArg::Str(&params_dir),
+        ];
+        let res = lib.eval("vf_hp", &args, true, true).expect("eval");
+        let hes = res.hessian.expect("hessian requested");
+        assert_eq!(hes.len(), 3, "nr=2 -> packed Hessian of length 3");
+        for (i, h) in hes.iter().enumerate() {
+            assert!(h.is_finite(), "hes[{i}] = {h} not finite");
+        }
+    }
+}

--- a/crates/pounce-cli/src/nl_hessian_program.rs
+++ b/crates/pounce-cli/src/nl_hessian_program.rs
@@ -453,6 +453,10 @@ impl HessianProgram {
                     dst,
                     a: v_slot(a as u32),
                 },
+                TapeOp::Funcall { .. } => panic!(
+                    "HessianProgram path does not support AMPL external functions; \
+                     use the Tape (build_with_externals) path instead."
+                ),
             };
             ops.push(op);
         }
@@ -564,6 +568,10 @@ impl HessianProgram {
                         dot_a: dot_slot(a as u32),
                         va: v_slot(a as u32),
                     },
+                    TapeOp::Funcall { .. } => panic!(
+                        "HessianProgram path does not support AMPL external functions; \
+                         use the Tape (build_with_externals) path instead."
+                    ),
                 };
                 ops.push(dot_op);
             }
@@ -709,6 +717,10 @@ impl HessianProgram {
                         va: v_slot(a as u32),
                         dot_a: dot_slot(a as u32),
                     },
+                    TapeOp::Funcall { .. } => panic!(
+                        "HessianProgram path does not support AMPL external functions; \
+                         use the Tape (build_with_externals) path instead."
+                    ),
                 };
                 ops.push(rev_op);
             }
@@ -1180,6 +1192,10 @@ fn reachable_to_output(tape: &Tape) -> Vec<bool> {
             | TapeOp::Cos(a) => {
                 r[a] = true;
             }
+            TapeOp::Funcall { .. } => panic!(
+                "HessianProgram path does not support AMPL external functions; \
+                 use the Tape (build_with_externals) path instead."
+            ),
         }
     }
     r
@@ -1209,6 +1225,10 @@ fn depends_on_var(tape: &Tape, j: usize) -> Vec<bool> {
             | TapeOp::Log10(a)
             | TapeOp::Sin(a)
             | TapeOp::Cos(a) => d[a],
+            TapeOp::Funcall { .. } => panic!(
+                "HessianProgram path does not support AMPL external functions; \
+                 use the Tape (build_with_externals) path instead."
+            ),
         };
     }
     d

--- a/crates/pounce-cli/src/nl_reader.rs
+++ b/crates/pounce-cli/src/nl_reader.rs
@@ -62,6 +62,31 @@ pub enum Expr {
     /// chain rule), so eval/grad/collect_vars just recurse into the
     /// inner `Expr`.
     Cse(Rc<Expr>),
+    /// AMPL imported (external) function call. `id` matches an entry in
+    /// `NlProblem.imported_funcs`; resolution to a live shared library
+    /// happens when the tape is built (see `nl_external::ExternalResolver`).
+    Funcall { id: usize, args: Vec<FuncallArg> },
+}
+
+/// One positional argument to an AMPL imported function call. AMPL splits
+/// arguments into reals (carried by `ra[]`) and strings (carried by `sa[]`);
+/// `FuncallArg` mirrors that split. Real args are arbitrary expressions.
+#[derive(Debug, Clone)]
+pub enum FuncallArg {
+    Real(Expr),
+    Str(String),
+}
+
+/// An AMPL imported (external) function declaration from a top-level
+/// `F<id> <type> <nargs> <name>` segment.
+#[derive(Debug, Clone)]
+pub struct ImportedFunc {
+    pub id: usize,
+    /// 0 = real-valued, 1 = string-args (per AMPL's funcadd ABI).
+    pub kind: usize,
+    /// Declared arg count. >=0 exact arity; <=-1 means at least `-(nargs+1)`.
+    pub nargs: i64,
+    pub name: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,6 +138,10 @@ pub struct NlProblem {
     /// <https://ampl.com/REFS/hooking2.pdf> §6 and the upstream `.nl`
     /// reader in `ref/Ipopt/src/Apps/AmplSolver/AmplTNLP.cpp`.
     pub suffixes: NlSuffixes,
+    /// AMPL imported (external) functions declared via top-level `F` segments.
+    /// Empty unless the `.nl` file calls compiled-C user functions (typically
+    /// emitted by IDAES property packages — see issue #49).
+    pub imported_funcs: Vec<ImportedFunc>,
 }
 
 /// Suffix data parsed out of `S`-segments. Sparse entries are scattered
@@ -167,6 +196,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
     let mut x0 = vec![0.0; n];
     let mut lambda0 = vec![0.0; m];
     let mut suffixes = NlSuffixes::default();
+    let mut imported_funcs: Vec<ImportedFunc> = Vec::new();
 
     while let Some(line) = p.peek_segment_line() {
         let tag = line
@@ -296,7 +326,26 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
             'S' => {
                 parse_suffix_segment(&mut p, n, m, num_obj, &mut suffixes)?;
             }
-            'F' => return Err("F (imported function) segments are not supported".into()),
+            'F' => {
+                // AMPL imported (external) function declaration:
+                // `F<k> <type> <nargs> <name>`.
+                let (hdr, _rest) = p.eat_segment_header()?;
+                let parts: Vec<&str> = hdr.split_whitespace().collect();
+                if parts.is_empty() {
+                    return Err(format!("malformed F-segment header: '{hdr}'"));
+                }
+                let id = parse_segment_index(parts[0], 'F')?;
+                let kind: usize = parts
+                    .get(1)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let nargs: i64 = parts
+                    .get(2)
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                let name = parts.get(3).copied().unwrap_or("").to_string();
+                imported_funcs.push(ImportedFunc { id, kind, nargs, name });
+            }
             other => return Err(format!("unknown .nl segment tag '{other}'")),
         }
     }
@@ -318,6 +367,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
         x0,
         lambda0,
         suffixes,
+        imported_funcs,
     })
 }
 
@@ -527,6 +577,8 @@ struct Parser<'a> {
     n: usize,
     m: usize,
     num_obj: usize,
+    /// Number of AMPL imported (external) functions declared in the header.
+    n_funcs: usize,
     /// Common subexpressions (`V` segments). Index in this vec is the
     /// CSE-local index, i.e. the global `.nl` index minus `n`.
     cses: Vec<Rc<Expr>>,
@@ -541,6 +593,7 @@ impl<'a> Parser<'a> {
             n: 0,
             m: 0,
             num_obj: 0,
+            n_funcs: 0,
             cses: Vec::new(),
         }
     }
@@ -587,8 +640,19 @@ impl<'a> Parser<'a> {
         self.m = nums[1].parse().map_err(|e| format!("m: {e}"))?;
         self.num_obj = nums[2].parse().map_err(|e| format!("num_obj: {e}"))?;
 
-        // Lines 3..10 are metadata we don't need — skip 8 more lines.
-        for _ in 0..8 {
+        // Lines 3..5 are metadata we skip.
+        for _ in 0..3 {
+            self.next_data_line()?;
+        }
+        // Line 5 (0-indexed from `g`-header): `nwv nfunc arith flags`
+        let l5 = self.next_data_line()?;
+        let nums5: Vec<&str> = l5.split_whitespace().collect();
+        self.n_funcs = nums5
+            .get(1)
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(0);
+        // Lines 6..10 are metadata we don't need — skip 4 more lines.
+        for _ in 0..4 {
             self.next_data_line()?;
         }
         Ok(())
@@ -642,10 +706,61 @@ impl<'a> Parser<'a> {
                     .map_err(|e| format!("opcode: {e}"))?;
                 self.parse_opcode(code)
             }
-            'f' | 't' | 'u' => Err(format!("unsupported expression token '{tok}'")),
+            'f' => {
+                // AMPL imported (external) function call: `f<id> <nargs>`
+                // followed by nargs child expressions (or string literals).
+                let rest = &tok[1..];
+                let mut parts = rest.split_whitespace();
+                let id_str = parts
+                    .next()
+                    .ok_or_else(|| format!("missing function id in '{tok}'"))?;
+                let nargs_str = parts
+                    .next()
+                    .ok_or_else(|| format!("missing nargs in '{tok}'"))?;
+                let id: usize = id_str
+                    .parse()
+                    .map_err(|e| format!("bad function id '{id_str}': {e}"))?;
+                let nargs: usize = nargs_str
+                    .parse()
+                    .map_err(|e| format!("bad funcall nargs '{nargs_str}': {e}"))?;
+                let mut args: Vec<FuncallArg> = Vec::with_capacity(nargs);
+                for _ in 0..nargs {
+                    args.push(self.parse_funcall_arg()?);
+                }
+                Ok(Expr::Funcall { id, args })
+            }
+            't' | 'u' => Err(format!("unsupported expression token '{tok}'")),
             other => Err(format!(
                 "unexpected expression token start '{other}': '{tok}'"
             )),
+        }
+    }
+
+    /// Parse one argument to an AMPL imported function. An argument
+    /// is either a normal expression (real-valued) or a string literal
+    /// in the form `h<len>:<chars>`. AMPL emits string args only when the
+    /// function was declared `FUNCADD_STRING_ARGS` (e.g. component name
+    /// or a parameters-directory path for IDAES Helmholtz functions).
+    fn parse_funcall_arg(&mut self) -> Result<FuncallArg, String> {
+        // Peek the next non-blank line so we can route `h...` differently.
+        let saved = self.pos;
+        let raw = self
+            .next_line()
+            .ok_or_else(|| "expected funcall argument".to_string())?;
+        let tok = strip_comment(raw).trim().to_string();
+        let first = tok.chars().next().ok_or("empty funcall arg token")?;
+        if first == 'h' {
+            // `h<len>:<chars>` — strip the `<len>:` prefix.
+            let rest = &tok[1..];
+            let s = match rest.find(':') {
+                Some(i) => rest[i + 1..].to_string(),
+                None => String::new(),
+            };
+            Ok(FuncallArg::Str(s))
+        } else {
+            // Rewind: parse_expr re-consumes the line we just peeked.
+            self.pos = saved;
+            Ok(FuncallArg::Real(self.parse_expr()?))
         }
     }
 
@@ -819,6 +934,10 @@ pub fn eval_expr(e: &Expr, x: &[Number]) -> Number {
         }
         Expr::Sum(args) => args.iter().map(|a| eval_expr(a, x)).sum(),
         Expr::Cse(body) => eval_expr(body, x),
+        Expr::Funcall { .. } => panic!(
+            "eval_expr: AMPL imported function called without an external resolver; \
+             evaluate through the tape AD path (Tape::build_with_externals) instead"
+        ),
     }
 }
 
@@ -887,6 +1006,9 @@ pub fn grad_expr(e: &Expr, x: &[Number], seed: Number, grad: &mut [Number]) {
             }
         }
         Expr::Cse(body) => grad_expr(body, x, seed, grad),
+        Expr::Funcall { .. } => panic!(
+            "grad_expr: AMPL imported function called without an external resolver"
+        ),
     }
 }
 
@@ -908,6 +1030,13 @@ pub fn collect_vars(e: &Expr, out: &mut BTreeSet<usize>) {
             }
         }
         Expr::Cse(body) => collect_vars(body, out),
+        Expr::Funcall { args, .. } => {
+            for a in args {
+                if let FuncallArg::Real(e) = a {
+                    collect_vars(e, out);
+                }
+            }
+        }
     }
 }
 
@@ -1078,18 +1207,48 @@ fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32
 
 impl NlTnlp {
     pub fn new(prob: NlProblem) -> Self {
+        // Resolve any AMPL imported (external) functions. Walk every
+        // nonlinear expression to collect the funcall ids actually
+        // referenced; load the libraries named in $AMPLFUNC and bind
+        // each id to its (library, registered-name) pair so the tape
+        // builder can emit live `TapeOp::Funcall` ops.
+        let mut referenced: BTreeSet<usize> = BTreeSet::new();
+        super::nl_external::collect_funcall_ids(&prob.obj_nonlinear, &mut referenced);
+        for c in &prob.con_nonlinear {
+            super::nl_external::collect_funcall_ids(c, &mut referenced);
+        }
+        let resolver = if referenced.is_empty() {
+            super::nl_external::ExternalResolver::default()
+        } else {
+            super::nl_external::ExternalResolver::build_for_problem(
+                &prob.imported_funcs,
+                &referenced,
+            )
+            .unwrap_or_else(|e| {
+                panic!("failed to resolve AMPL external functions: {e}")
+            })
+        };
+
         // Flatten objective and each constraint into independent
         // summands. Each summand becomes its own `Tape` (CSE bodies
         // are deduplicated within a tape via Rc identity in
         // `Tape::build`; bodies shared across summands are
         // duplicated, which we accept as a simplicity tradeoff).
         let obj_summands = split_top_sums(&prob.obj_nonlinear);
-        let obj_tapes: Vec<Tape> = obj_summands.iter().map(Tape::build).collect();
+        let obj_tapes: Vec<Tape> = obj_summands
+            .iter()
+            .map(|e| Tape::build_with_externals(e, &resolver))
+            .collect();
 
         let mut con_tapes: Vec<Vec<Tape>> = Vec::with_capacity(prob.m);
         for k in 0..prob.m {
             let summands = split_top_sums(&prob.con_nonlinear[k]);
-            con_tapes.push(summands.iter().map(Tape::build).collect());
+            con_tapes.push(
+                summands
+                    .iter()
+                    .map(|e| Tape::build_with_externals(e, &resolver))
+                    .collect(),
+            );
         }
 
         // Hessian-of-Lagrangian sparsity: union of each tape's own

--- a/crates/pounce-cli/src/nl_reader.rs
+++ b/crates/pounce-cli/src/nl_reader.rs
@@ -335,16 +335,15 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                     return Err(format!("malformed F-segment header: '{hdr}'"));
                 }
                 let id = parse_segment_index(parts[0], 'F')?;
-                let kind: usize = parts
-                    .get(1)
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0);
-                let nargs: i64 = parts
-                    .get(2)
-                    .and_then(|s| s.parse().ok())
-                    .unwrap_or(0);
+                let kind: usize = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+                let nargs: i64 = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
                 let name = parts.get(3).copied().unwrap_or("").to_string();
-                imported_funcs.push(ImportedFunc { id, kind, nargs, name });
+                imported_funcs.push(ImportedFunc {
+                    id,
+                    kind,
+                    nargs,
+                    name,
+                });
             }
             other => return Err(format!("unknown .nl segment tag '{other}'")),
         }
@@ -647,10 +646,7 @@ impl<'a> Parser<'a> {
         // Line 5 (0-indexed from `g`-header): `nwv nfunc arith flags`
         let l5 = self.next_data_line()?;
         let nums5: Vec<&str> = l5.split_whitespace().collect();
-        self.n_funcs = nums5
-            .get(1)
-            .and_then(|s| s.parse().ok())
-            .unwrap_or(0);
+        self.n_funcs = nums5.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
         // Lines 6..10 are metadata we don't need — skip 4 more lines.
         for _ in 0..4 {
             self.next_data_line()?;
@@ -1006,9 +1002,9 @@ pub fn grad_expr(e: &Expr, x: &[Number], seed: Number, grad: &mut [Number]) {
             }
         }
         Expr::Cse(body) => grad_expr(body, x, seed, grad),
-        Expr::Funcall { .. } => panic!(
-            "grad_expr: AMPL imported function called without an external resolver"
-        ),
+        Expr::Funcall { .. } => {
+            panic!("grad_expr: AMPL imported function called without an external resolver")
+        }
     }
 }
 
@@ -1224,9 +1220,7 @@ impl NlTnlp {
                 &prob.imported_funcs,
                 &referenced,
             )
-            .unwrap_or_else(|e| {
-                panic!("failed to resolve AMPL external functions: {e}")
-            })
+            .unwrap_or_else(|e| panic!("failed to resolve AMPL external functions: {e}"))
         };
 
         // Flatten objective and each constraint into independent

--- a/crates/pounce-cli/src/nl_tape.rs
+++ b/crates/pounce-cli/src/nl_tape.rs
@@ -24,8 +24,10 @@
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::rc::Rc;
+use std::sync::Arc;
 
-use super::nl_reader::{BinOp, Expr, UnaryOp};
+use super::nl_external::{ExternalArg, ExternalLibrary, ExternalResolver};
+use super::nl_reader::{BinOp, Expr, FuncallArg, UnaryOp};
 
 /// One operation in the flattened tape. Operand fields are tape-slot
 /// indices into the same tape; `Var(i)` references problem variable
@@ -47,6 +49,33 @@ pub enum TapeOp {
     Log10(usize),
     Sin(usize),
     Cos(usize),
+    /// AMPL imported (external) function call. The library is kept alive by
+    /// the `Arc`; `name` is the registered function name; `args` carries
+    /// positional arguments where real-valued args reference earlier tape
+    /// slots and string args are inline literals.
+    Funcall {
+        lib: Arc<ExternalLibrary>,
+        name: String,
+        args: Vec<TapeFuncallArg>,
+    },
+}
+
+/// One argument of a `TapeOp::Funcall`. Real arguments are tape-slot indices
+/// (their values come from the running `vals[]` during forward); string
+/// arguments are owned literals (AMPL `h<len>:<chars>` tokens).
+#[derive(Debug, Clone)]
+pub enum TapeFuncallArg {
+    Tape(usize),
+    Str(String),
+}
+
+fn funcall_to_ext_args<'a>(args: &'a [TapeFuncallArg], vals: &[f64]) -> Vec<ExternalArg<'a>> {
+    args.iter()
+        .map(|a| match a {
+            TapeFuncallArg::Tape(idx) => ExternalArg::Real(vals[*idx]),
+            TapeFuncallArg::Str(s) => ExternalArg::Str(s.as_str()),
+        })
+        .collect()
 }
 
 /// A flattened expression tape. The result of evaluation is the value
@@ -57,13 +86,21 @@ pub struct Tape {
 }
 
 impl Tape {
-    /// Build a tape from an `Expr` tree. CSE bodies (`Expr::Cse(rc)`)
-    /// are cached by `Rc` pointer identity so each body is emitted
-    /// once even when referenced many times.
+    /// Build a tape from an `Expr` tree (no AMPL external functions). CSE
+    /// bodies (`Expr::Cse(rc)`) are cached by `Rc` pointer identity so each
+    /// body is emitted once even when referenced many times.
     pub fn build(expr: &Expr) -> Self {
+        Self::build_with_externals(expr, &ExternalResolver::default())
+    }
+
+    /// Build a tape from an `Expr` tree, resolving any `Expr::Funcall`
+    /// nodes through `resolver`. Panics if the expression references a
+    /// funcall id that is not in the resolver — `NlProblem::resolve_externals`
+    /// must populate the resolver before tape construction.
+    pub fn build_with_externals(expr: &Expr, resolver: &ExternalResolver) -> Self {
         let mut ops = Vec::new();
         let mut cache: HashMap<*const Expr, usize> = HashMap::new();
-        build_recursive(expr, &mut ops, &mut cache);
+        build_recursive(expr, &mut ops, &mut cache, resolver);
         Tape { ops }
     }
 
@@ -88,6 +125,13 @@ impl Tape {
                 TapeOp::Log10(a) => vals[*a].log10(),
                 TapeOp::Sin(a) => vals[*a].sin(),
                 TapeOp::Cos(a) => vals[*a].cos(),
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_to_ext_args(args, &vals);
+                    let res = lib.eval(name, &call_args, false, false).unwrap_or_else(|e| {
+                        panic!("external function '{name}' forward eval failed: {e}")
+                    });
+                    res.value
+                }
             };
             vals.push(v);
         }
@@ -184,6 +228,20 @@ impl Tape {
                 TapeOp::Cos(j) => {
                     adj[*j] -= a * vals[*j].sin();
                 }
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_to_ext_args(args, vals);
+                    let res = lib.eval(name, &call_args, true, false).unwrap_or_else(|e| {
+                        panic!("external function '{name}' reverse eval failed: {e}")
+                    });
+                    let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                    let mut k = 0usize;
+                    for arg in args {
+                        if let TapeFuncallArg::Tape(idx) = arg {
+                            adj[*idx] += a * derivs[k];
+                            k += 1;
+                        }
+                    }
+                }
             }
         }
     }
@@ -258,6 +316,22 @@ impl Tape {
                 TapeOp::Log10(a) => dot[*a] / (vals[*a] * std::f64::consts::LN_10),
                 TapeOp::Sin(a) => dot[*a] * vals[*a].cos(),
                 TapeOp::Cos(a) => -dot[*a] * vals[*a].sin(),
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_to_ext_args(args, vals);
+                    let res = lib.eval(name, &call_args, true, false).unwrap_or_else(|e| {
+                        panic!("external function '{name}' tangent eval failed: {e}")
+                    });
+                    let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                    let mut acc = 0.0;
+                    let mut k = 0usize;
+                    for arg in args {
+                        if let TapeFuncallArg::Tape(idx) = arg {
+                            acc += derivs[k] * dot[*idx];
+                            k += 1;
+                        }
+                    }
+                    acc
+                }
             };
         }
     }
@@ -285,6 +359,13 @@ impl Tape {
                 TapeOp::Log10(a) => vals[*a].log10(),
                 TapeOp::Sin(a) => vals[*a].sin(),
                 TapeOp::Cos(a) => vals[*a].cos(),
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_to_ext_args(args, &*vals);
+                    let res = lib.eval(name, &call_args, false, false).unwrap_or_else(|e| {
+                        panic!("external function '{name}' forward_into failed: {e}")
+                    });
+                    res.value
+                }
             };
         }
     }
@@ -373,6 +454,22 @@ impl Tape {
                 TapeOp::Log10(a) => dot[*a] / (vals[*a] * std::f64::consts::LN_10),
                 TapeOp::Sin(a) => vals[*a].cos() * dot[*a],
                 TapeOp::Cos(a) => -vals[*a].sin() * dot[*a],
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_to_ext_args(args, vals);
+                    let res = lib.eval(name, &call_args, true, false).unwrap_or_else(|e| {
+                        panic!("external function '{name}' tangent eval failed: {e}")
+                    });
+                    let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                    let mut acc = 0.0;
+                    let mut k = 0usize;
+                    for arg in args {
+                        if let TapeFuncallArg::Tape(idx) = arg {
+                            acc += derivs[k] * dot[*idx];
+                            k += 1;
+                        }
+                    }
+                    acc
+                }
             };
         }
 
@@ -509,6 +606,31 @@ impl Tape {
                     let su = u.sin();
                     adj[*a] -= w * su;
                     adj_dot[*a] += wd * (-su) + w * (-u.cos()) * dot[*a];
+                }
+                TapeOp::Funcall { lib, name, args } => {
+                    let call_args = funcall_to_ext_args(args, vals);
+                    let res = lib.eval(name, &call_args, true, true).unwrap_or_else(|e| {
+                        panic!("external function '{name}' 2nd-order eval failed: {e}")
+                    });
+                    let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                    let hes = res.hessian.expect("want_hes=true returns hessian");
+                    let real_tape: Vec<usize> = args
+                        .iter()
+                        .filter_map(|a| match a {
+                            TapeFuncallArg::Tape(t) => Some(*t),
+                            TapeFuncallArg::Str(_) => None,
+                        })
+                        .collect();
+                    for (k, &tk) in real_tape.iter().enumerate() {
+                        adj[tk] += w * derivs[k];
+                        let mut second_term = 0.0;
+                        for (l, &tl) in real_tape.iter().enumerate() {
+                            let (lo, hi) = if k <= l { (k, l) } else { (l, k) };
+                            let h_kl = hes[lo + hi * (hi + 1) / 2];
+                            second_term += h_kl * dot[tl];
+                        }
+                        adj_dot[tk] += wd * derivs[k] + w * second_term;
+                    }
                 }
             }
         }
@@ -680,6 +802,31 @@ impl Tape {
                         adj[*a] -= w * su;
                         adj_dot[*a] += wd * (-su) + w * (-u.cos()) * dot[*a];
                     }
+                    TapeOp::Funcall { lib, name, args } => {
+                        let call_args = funcall_to_ext_args(args, &v);
+                        let res = lib.eval(name, &call_args, true, true).unwrap_or_else(|e| {
+                            panic!("external function '{name}' 2nd-order eval failed: {e}")
+                        });
+                        let derivs = res.derivs.expect("want_derivs=true returns derivs");
+                        let hes = res.hessian.expect("want_hes=true returns hessian");
+                        let real_tape: Vec<usize> = args
+                            .iter()
+                            .filter_map(|a| match a {
+                                TapeFuncallArg::Tape(t) => Some(*t),
+                                TapeFuncallArg::Str(_) => None,
+                            })
+                            .collect();
+                        for (k, &tk) in real_tape.iter().enumerate() {
+                            adj[tk] += w * derivs[k];
+                            let mut second_term = 0.0;
+                            for (l, &tl) in real_tape.iter().enumerate() {
+                                let (lo, hi) = if k <= l { (k, l) } else { (l, k) };
+                                let h_kl = hes[lo + hi * (hi + 1) / 2];
+                                second_term += h_kl * dot[tl];
+                            }
+                            adj_dot[tk] += wd * derivs[k] + w * second_term;
+                        }
+                    }
                 }
             }
         }
@@ -749,6 +896,18 @@ impl Tape {
                     emit_self(&var_sets[*a], &mut pairs);
                     var_sets[*a].clone()
                 }
+                TapeOp::Funcall { args, .. } => {
+                    let mut combined: BTreeSet<usize> = BTreeSet::new();
+                    for arg in args {
+                        if let TapeFuncallArg::Tape(t) = arg {
+                            for &vv in &var_sets[*t] {
+                                combined.insert(vv);
+                            }
+                        }
+                    }
+                    emit_self(&combined, &mut pairs);
+                    combined
+                }
             };
             var_sets.push(vset);
         }
@@ -760,6 +919,7 @@ fn build_recursive(
     expr: &Expr,
     ops: &mut Vec<TapeOp>,
     cache: &mut HashMap<*const Expr, usize>,
+    resolver: &ExternalResolver,
 ) -> usize {
     match expr {
         Expr::Const(c) => {
@@ -782,13 +942,13 @@ fn build_recursive(
             // through the much cheaper `Mul`/`Sqrt` arms.
             if let BinOp::Pow = op {
                 if let Some(c) = peek_const(b) {
-                    if let Some(idx) = try_emit_const_pow(a, c, ops, cache) {
+                    if let Some(idx) = try_emit_const_pow(a, c, ops, cache, resolver) {
                         return idx;
                     }
                 }
             }
-            let l = build_recursive(a, ops, cache);
-            let r = build_recursive(b, ops, cache);
+            let l = build_recursive(a, ops, cache, resolver);
+            let r = build_recursive(b, ops, cache, resolver);
             let idx = ops.len();
             ops.push(match op {
                 BinOp::Add => TapeOp::Add(l, r),
@@ -800,7 +960,7 @@ fn build_recursive(
             idx
         }
         Expr::Unary(op, a) => {
-            let v = build_recursive(a, ops, cache);
+            let v = build_recursive(a, ops, cache, resolver);
             let idx = ops.len();
             ops.push(match op {
                 UnaryOp::Neg => TapeOp::Neg(v),
@@ -820,9 +980,9 @@ fn build_recursive(
                 ops.push(TapeOp::Const(0.0));
                 return idx;
             }
-            let mut acc = build_recursive(&args[0], ops, cache);
+            let mut acc = build_recursive(&args[0], ops, cache, resolver);
             for a in &args[1..] {
-                let next = build_recursive(a, ops, cache);
+                let next = build_recursive(a, ops, cache, resolver);
                 let idx = ops.len();
                 ops.push(TapeOp::Add(acc, next));
                 acc = idx;
@@ -840,10 +1000,32 @@ fn build_recursive(
             if let Some(&idx) = cache.get(&key) {
                 idx
             } else {
-                let idx = build_recursive(body, ops, cache);
+                let idx = build_recursive(body, ops, cache, resolver);
                 cache.insert(key, idx);
                 idx
             }
+        }
+        Expr::Funcall { id, args } => {
+            let (lib, name) = resolver
+                .funcs_by_id
+                .get(id)
+                .unwrap_or_else(|| panic!("unresolved AMPL funcall id {id}"));
+            let tape_args: Vec<TapeFuncallArg> = args
+                .iter()
+                .map(|a| match a {
+                    FuncallArg::Real(e) => {
+                        TapeFuncallArg::Tape(build_recursive(e, ops, cache, resolver))
+                    }
+                    FuncallArg::Str(s) => TapeFuncallArg::Str(s.clone()),
+                })
+                .collect();
+            let idx = ops.len();
+            ops.push(TapeOp::Funcall {
+                lib: Arc::clone(lib),
+                name: name.clone(),
+                args: tape_args,
+            });
+            idx
         }
     }
 }
@@ -871,6 +1053,7 @@ fn try_emit_const_pow(
     c: f64,
     ops: &mut Vec<TapeOp>,
     cache: &mut HashMap<*const Expr, usize>,
+    resolver: &ExternalResolver,
 ) -> Option<usize> {
     if c == 0.0 {
         let idx = ops.len();
@@ -878,10 +1061,10 @@ fn try_emit_const_pow(
         return Some(idx);
     }
     if c == 1.0 {
-        return Some(build_recursive(base_expr, ops, cache));
+        return Some(build_recursive(base_expr, ops, cache, resolver));
     }
     if c == 0.5 {
-        let b = build_recursive(base_expr, ops, cache);
+        let b = build_recursive(base_expr, ops, cache, resolver);
         let idx = ops.len();
         ops.push(TapeOp::Sqrt(b));
         return Some(idx);
@@ -898,7 +1081,7 @@ fn try_emit_const_pow(
             ops.push(TapeOp::Const(1.0));
             return Some(idx);
         }
-        let b = build_recursive(base_expr, ops, cache);
+        let b = build_recursive(base_expr, ops, cache, resolver);
         let pos = emit_int_pow(b, n, ops);
         if c < 0.0 {
             // x^-n = 1 / x^n. Saves the powf and its ln branch in
@@ -1328,6 +1511,13 @@ fn count_cse_appearances(
                 count_cse_appearances(body, seen_in_root, counts);
             }
         }
+        Expr::Funcall { args, .. } => {
+            for arg in args {
+                if let FuncallArg::Real(e) = arg {
+                    count_cse_appearances(e, seen_in_root, counts);
+                }
+            }
+        }
     }
 }
 
@@ -1432,7 +1622,7 @@ fn build_into_summand(
                 // `build_recursive(expr, ...)` hits the Cse arm,
                 // emits the body once into prelude, and caches it
                 // in `prelude_map` keyed by this Rc pointer.
-                let pslot = build_recursive(expr, prelude, prelude_map);
+                let pslot = build_recursive(expr, prelude, prelude_map, &ExternalResolver::default());
                 let li = local.len();
                 local.push(SummandOp::Shared(pslot));
                 local_cache.insert(key, li);
@@ -1443,6 +1633,13 @@ fn build_into_summand(
                 local_cache.insert(key, li);
                 li
             }
+        }
+        Expr::Funcall { .. } => {
+            panic!(
+                "HybridTape: AMPL external function calls are not supported on the \
+                 hybrid (partial-separability) tape path. Build with Tape::build_with_externals \
+                 instead."
+            );
         }
     }
 }
@@ -1632,6 +1829,10 @@ fn compute_var_sets(ops: &[TapeOp]) -> Vec<BTreeSet<usize>> {
             | TapeOp::Log10(a)
             | TapeOp::Sin(a)
             | TapeOp::Cos(a) => out[*a].clone(),
+            TapeOp::Funcall { .. } => unreachable!(
+                "HybridTape prelude cannot contain TapeOp::Funcall; \
+                 build_into_summand panics on Expr::Funcall."
+            ),
         };
         out.push(vs);
     }
@@ -1704,6 +1905,10 @@ fn summand_sparsity(
                     emit_self(&var_sets[*a], pairs);
                     var_sets[*a].clone()
                 }
+                TapeOp::Funcall { .. } => unreachable!(
+                    "HybridTape summand cannot contain TapeOp::Funcall; \
+                     build_into_summand panics on Expr::Funcall."
+                ),
             },
         };
         var_sets.push(vset);
@@ -1729,6 +1934,7 @@ fn op_operands(op: &TapeOp) -> (Option<usize>, Option<usize>) {
         | TapeOp::Log10(a)
         | TapeOp::Sin(a)
         | TapeOp::Cos(a) => (Some(*a), None),
+        TapeOp::Funcall { .. } => (None, None),
     }
 }
 
@@ -1762,6 +1968,13 @@ fn fwd_step(op: &TapeOp, x: &[f64], vals: &[f64]) -> f64 {
         TapeOp::Log10(a) => vals[*a].log10(),
         TapeOp::Sin(a) => vals[*a].sin(),
         TapeOp::Cos(a) => vals[*a].cos(),
+        TapeOp::Funcall { lib, name, args } => {
+            let call_args = funcall_to_ext_args(args, vals);
+            let res = lib
+                .eval(name, &call_args, false, false)
+                .unwrap_or_else(|e| panic!("external function '{name}' eval failed: {e}"));
+            res.value
+        }
     }
 }
 
@@ -1830,6 +2043,22 @@ fn rev_step(op: &TapeOp, i: usize, vals: &[f64], adj: &mut [f64], a: f64, grad: 
         TapeOp::Cos(j) => {
             adj[*j] -= a * vals[*j].sin();
         }
+        TapeOp::Funcall { lib, name, args } => {
+            let call_args = funcall_to_ext_args(args, vals);
+            let res = lib
+                .eval(name, &call_args, true, false)
+                .unwrap_or_else(|e| panic!("external function '{name}' reverse eval failed: {e}"));
+            let derivs = res.derivs.expect("want_derivs=true returns derivs");
+            let mut k = 0usize;
+            for arg in args {
+                if let TapeFuncallArg::Tape(idx) = arg {
+                    adj[*idx] += a * derivs[k];
+                    k += 1;
+                }
+            }
+            let _ = i;
+            let _ = grad;
+        }
     }
 }
 
@@ -1886,6 +2115,23 @@ fn fwd_tan_step(op: &TapeOp, seed_var: usize, vals: &[f64], dot: &[f64], i: usiz
         TapeOp::Log10(a) => dot[*a] / (vals[*a] * std::f64::consts::LN_10),
         TapeOp::Sin(a) => dot[*a] * vals[*a].cos(),
         TapeOp::Cos(a) => -dot[*a] * vals[*a].sin(),
+        TapeOp::Funcall { lib, name, args } => {
+            let call_args = funcall_to_ext_args(args, vals);
+            let res = lib.eval(name, &call_args, true, false).unwrap_or_else(|e| {
+                panic!("external function '{name}' tangent eval failed: {e}")
+            });
+            let derivs = res.derivs.expect("want_derivs=true returns derivs");
+            let mut acc = 0.0;
+            let mut k = 0usize;
+            for arg in args {
+                if let TapeFuncallArg::Tape(idx) = arg {
+                    acc += derivs[k] * dot[*idx];
+                    k += 1;
+                }
+            }
+            let _ = seed_var;
+            acc
+        }
     }
 }
 
@@ -2024,6 +2270,36 @@ fn ror_step(
             adj[*a] -= w * su;
             adj_dot[*a] += wd * (-su) + w * (-u.cos()) * dot[*a];
         }
+        TapeOp::Funcall { lib, name, args } => {
+            let call_args = funcall_to_ext_args(args, vals);
+            let res = lib.eval(name, &call_args, true, true).unwrap_or_else(|e| {
+                panic!("external function '{name}' 2nd-order eval failed: {e}")
+            });
+            let derivs = res.derivs.expect("want_derivs=true returns derivs");
+            let hes = res.hessian.expect("want_hes=true returns hessian");
+            let real_tape: Vec<usize> = args
+                .iter()
+                .filter_map(|a| match a {
+                    TapeFuncallArg::Tape(t) => Some(*t),
+                    TapeFuncallArg::Str(_) => None,
+                })
+                .collect();
+            for (k, &tk) in real_tape.iter().enumerate() {
+                adj[tk] += w * derivs[k];
+                let mut second_term = 0.0;
+                for (l, &tl) in real_tape.iter().enumerate() {
+                    let (lo, hi) = if k <= l { (k, l) } else { (l, k) };
+                    let h_kl = hes[lo + hi * (hi + 1) / 2];
+                    second_term += h_kl * dot[tl];
+                }
+                adj_dot[tk] += wd * derivs[k] + w * second_term;
+            }
+            let _ = seed_var;
+            let _ = hess_map;
+            let _ = values;
+            let _ = weight;
+            let _ = i;
+        }
     }
 }
 
@@ -2089,6 +2365,18 @@ fn hessian_sparsity_impl(ops: &[TapeOp]) -> BTreeSet<(usize, usize)> {
             | TapeOp::Cos(a) => {
                 emit_self(&var_sets[*a], &mut pairs);
                 var_sets[*a].clone()
+            }
+            TapeOp::Funcall { args, .. } => {
+                let mut combined: BTreeSet<usize> = BTreeSet::new();
+                for arg in args {
+                    if let TapeFuncallArg::Tape(t) = arg {
+                        for &vv in &var_sets[*t] {
+                            combined.insert(vv);
+                        }
+                    }
+                }
+                emit_self(&combined, &mut pairs);
+                combined
             }
         };
         var_sets.push(vset);

--- a/crates/pounce-cli/src/nl_tape.rs
+++ b/crates/pounce-cli/src/nl_tape.rs
@@ -127,9 +127,11 @@ impl Tape {
                 TapeOp::Cos(a) => vals[*a].cos(),
                 TapeOp::Funcall { lib, name, args } => {
                     let call_args = funcall_to_ext_args(args, &vals);
-                    let res = lib.eval(name, &call_args, false, false).unwrap_or_else(|e| {
-                        panic!("external function '{name}' forward eval failed: {e}")
-                    });
+                    let res = lib
+                        .eval(name, &call_args, false, false)
+                        .unwrap_or_else(|e| {
+                            panic!("external function '{name}' forward eval failed: {e}")
+                        });
                     res.value
                 }
             };
@@ -361,9 +363,11 @@ impl Tape {
                 TapeOp::Cos(a) => vals[*a].cos(),
                 TapeOp::Funcall { lib, name, args } => {
                     let call_args = funcall_to_ext_args(args, &*vals);
-                    let res = lib.eval(name, &call_args, false, false).unwrap_or_else(|e| {
-                        panic!("external function '{name}' forward_into failed: {e}")
-                    });
+                    let res = lib
+                        .eval(name, &call_args, false, false)
+                        .unwrap_or_else(|e| {
+                            panic!("external function '{name}' forward_into failed: {e}")
+                        });
                     res.value
                 }
             };
@@ -1622,7 +1626,8 @@ fn build_into_summand(
                 // `build_recursive(expr, ...)` hits the Cse arm,
                 // emits the body once into prelude, and caches it
                 // in `prelude_map` keyed by this Rc pointer.
-                let pslot = build_recursive(expr, prelude, prelude_map, &ExternalResolver::default());
+                let pslot =
+                    build_recursive(expr, prelude, prelude_map, &ExternalResolver::default());
                 let li = local.len();
                 local.push(SummandOp::Shared(pslot));
                 local_cache.insert(key, li);
@@ -2117,9 +2122,9 @@ fn fwd_tan_step(op: &TapeOp, seed_var: usize, vals: &[f64], dot: &[f64], i: usiz
         TapeOp::Cos(a) => -dot[*a] * vals[*a].sin(),
         TapeOp::Funcall { lib, name, args } => {
             let call_args = funcall_to_ext_args(args, vals);
-            let res = lib.eval(name, &call_args, true, false).unwrap_or_else(|e| {
-                panic!("external function '{name}' tangent eval failed: {e}")
-            });
+            let res = lib
+                .eval(name, &call_args, true, false)
+                .unwrap_or_else(|e| panic!("external function '{name}' tangent eval failed: {e}"));
             let derivs = res.derivs.expect("want_derivs=true returns derivs");
             let mut acc = 0.0;
             let mut k = 0usize;

--- a/crates/pounce-cli/tests/fixtures_issue_49/generate_helmholtz_nl.py
+++ b/crates/pounce-cli/tests/fixtures_issue_49/generate_helmholtz_nl.py
@@ -1,0 +1,90 @@
+"""Generate the IDAES Helmholtz external-function NL fixture for issue #15.
+
+Original script written with GPT 5.4 and validated locally by CMarcher on
+https://github.com/jkitchin/ripopt/issues/15. Saved here so the fixture can
+be regenerated whenever IDAES + the general_helmholtz_external shared library
+are available.
+
+Running the script:
+    python tests/fixtures/issue_15/generate_helmholtz_nl.py
+
+Requires IDAES 2.x with `idaes get-extensions` already run so that
+`~/.idaes/bin/general_helmholtz_external.{dylib,so,dll}` exists. Writes the
+`.nl` file to tests/fixtures/issue_15/idaes_helmholtz.nl.
+"""
+
+from pathlib import Path
+import shutil
+
+import idaes
+from idaes.core import FlowsheetBlock
+from idaes.models.properties.general_helmholtz import (
+    HelmholtzParameterBlock,
+    PhaseType,
+    StateVars,
+    AmountBasis,
+)
+from idaes.models.unit_models.heater import Heater
+from idaes.core.util.model_statistics import degrees_of_freedom
+from pyomo.environ import ConcreteModel, SolverFactory, assert_optimal_termination, value
+
+
+FIXTURE_NL = Path(__file__).with_name("idaes_helmholtz.nl")
+
+
+def build_model():
+    m = ConcreteModel()
+    m.fs = FlowsheetBlock(dynamic=False)
+    m.fs.properties = HelmholtzParameterBlock(
+        pure_component="h2o",
+        phase_presentation=PhaseType.LG,
+        state_vars=StateVars.PH,
+        amount_basis=AmountBasis.MOLE,
+    )
+
+    m.fs.heater = Heater(property_package=m.fs.properties)
+    m.fs.heater.heat_duty.fix(0)
+    m.fs.heater.inlet.flow_mol.fix(1)
+    m.fs.heater.inlet.enth_mol.fix(1878.71)
+    m.fs.heater.inlet.pressure.fix(101325)
+    return m
+
+
+def solve_with_ipopt(model):
+    ipopt_path = Path(idaes.bin_directory) / "ipopt"
+    if not ipopt_path.exists():
+        raise FileNotFoundError(f"Expected ipopt at {ipopt_path}")
+
+    solver = SolverFactory("ipopt", executable=str(ipopt_path))
+    results = solver.solve(
+        model,
+        tee=False,
+        keepfiles=True,
+        symbolic_solver_labels=True,
+    )
+    assert_optimal_termination(results)
+
+    nl_source = Path(solver._problem_files[0])
+    shutil.copy2(nl_source, FIXTURE_NL)
+    return nl_source
+
+
+def main():
+    model = build_model()
+    dof = degrees_of_freedom(model)
+    if dof != 0:
+        raise AssertionError(f"Expected 0 degrees of freedom, got {dof}")
+
+    model.fs.heater.initialize()
+    nl_source = solve_with_ipopt(model)
+
+    outlet_temp = value(model.fs.heater.control_volume.properties_out[0].temperature)
+    if abs(outlet_temp - 298.0) > 1e-2:
+        raise AssertionError(f"Unexpected outlet temperature: {outlet_temp}")
+
+    print(f"IPOPT_NL_SOURCE={nl_source}")
+    print(f"FIXTURE_NL={FIXTURE_NL}")
+
+
+if __name__ == "__main__":
+    main()

--- a/crates/pounce-cli/tests/fixtures_issue_49/idaes_helmholtz.nl
+++ b/crates/pounce-cli/tests/fixtures_issue_49/idaes_helmholtz.nl
@@ -1,0 +1,109 @@
+g3 1 1 0	# problem unknown
+ 3 3 0 0 3 	# vars, constraints, objectives, ranges, eqns
+ 2 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 3 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 3 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 7 0 	# nonzeros in Jacobian, obj. gradient
+ 51 53	# max name lengths: constraints, variables
+ 0 5 0 6 0	# common exprs: b,c,o,c1,o1
+F0 1 -1 vf_hp
+F1 1 -1 h_liq_hp
+F2 1 -1 h_vap_hp
+V3 1 0	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+1 0.055508472036052976
+n0
+V4 1 0	#fs.heater.control_volume.properties_out[0.0].p_kPa
+2 0.001
+n0
+V5 0 0	#fs.heater.control_volume.properties_out[0.0].vapor_frac
+f0 4	#vf_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V6 0 0	#fs.heater.control_volume.properties_out[0.0].phase_frac[Liq]
+o0	#+
+o16	#-
+v5	#fs.heater.control_volume.properties_out[0.0].vapor_frac
+n1.0
+V7 0 0	#fs.heater.control_volume.properties_out[0.0].phase_frac[Vap]
+f0 4	#vf_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V8 0 1	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Liq]
+o2	#*
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+v6	#fs.heater.control_volume.properties_out[0.0].phase_frac[Liq]
+V9 0 1	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Vap]
+o2	#*
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+v7	#fs.heater.control_volume.properties_out[0.0].phase_frac[Vap]
+C0	#fs.heater.control_volume.material_balances[0.0,h2o]
+o16	#-
+o0	#+
+v8	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Liq]
+v9	#fs.heater.control_volume.properties_out[0.0].material_flow_terms[Vap]
+V10 0 2	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Liq]
+o2	#*
+n18.015268000000003
+f1 4	#h_liq_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V11 0 2	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Liq]
+o2	#*
+o2	#*
+v10	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Liq]
+v6	#fs.heater.control_volume.properties_out[0.0].phase_frac[Liq]
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+V12 0 2	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Vap]
+o2	#*
+n18.015268000000003
+f2 4	#h_vap_hp_func
+h3:h2o
+v3	#fs.heater.control_volume.properties_out[0.0].h_kJ_per_kg
+v4	#fs.heater.control_volume.properties_out[0.0].p_kPa
+h126:/Users/jkitchin/Dropbox/uv/.venv/lib/python3.12/site-packages/idaes/models/properties/general_helmholtz/components/parameters/
+V13 0 2	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Vap]
+o2	#*
+o2	#*
+v12	#fs.heater.control_volume.properties_out[0.0].enth_mol_phase[Vap]
+v7	#fs.heater.control_volume.properties_out[0.0].phase_frac[Vap]
+v0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+C1	#fs.heater.control_volume.enthalpy_balances[0.0]
+o16	#-
+o0	#+
+v11	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Liq]
+v13	#fs.heater.control_volume.properties_out[0.0].enthalpy_flow_terms[Vap]
+C2	#fs.heater.control_volume.pressure_balance[0.0]
+n0
+x3	# initial guess
+0 1.0	#fs.heater.control_volume.properties_out[0.0].flow_mol
+1 1878.71	#fs.heater.control_volume.properties_out[0.0].enth_mol
+2 101325.0	#fs.heater.control_volume.properties_out[0.0].pressure
+r	#3 ranges (rhs's)
+4 -1.0	#fs.heater.control_volume.material_balances[0.0,h2o]
+4 -1878.7099999999614	#fs.heater.control_volume.enthalpy_balances[0.0]
+4 -101325	#fs.heater.control_volume.pressure_balance[0.0]
+b	#3 bounds (on variables)
+3	#fs.heater.control_volume.properties_out[0.0].flow_mol
+0 0.011021386931383999 80765.34157807355	#fs.heater.control_volume.properties_out[0.0].enth_mol
+0 1.0000000000000002e-06 1100000000.0	#fs.heater.control_volume.properties_out[0.0].pressure
+k2	#intermediate Jacobian column lengths
+2
+4
+J0 3	#fs.heater.control_volume.material_balances[0.0,h2o]
+0 0
+1 0
+2 0
+J1 3	#fs.heater.control_volume.enthalpy_balances[0.0]
+0 0
+1 0
+2 0
+J2 1	#fs.heater.control_volume.pressure_balance[0.0]
+2 -1

--- a/crates/pounce-cli/tests/issue_49_external_funcs.rs
+++ b/crates/pounce-cli/tests/issue_49_external_funcs.rs
@@ -31,7 +31,11 @@ fn fixture_path() -> PathBuf {
 fn helmholtz_dylib() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     let dylib = PathBuf::from(home).join(".idaes/bin/general_helmholtz_external.dylib");
-    if dylib.exists() { Some(dylib) } else { None }
+    if dylib.exists() {
+        Some(dylib)
+    } else {
+        None
+    }
 }
 
 #[test]
@@ -39,9 +43,7 @@ fn pounce_solves_idaes_helmholtz_with_external_functions() {
     let dylib = match helmholtz_dylib() {
         Some(p) => p,
         None => {
-            eprintln!(
-                "skipping: ~/.idaes/bin/general_helmholtz_external.dylib not installed"
-            );
+            eprintln!("skipping: ~/.idaes/bin/general_helmholtz_external.dylib not installed");
             return;
         }
     };
@@ -82,8 +84,7 @@ fn pounce_rejects_external_function_problem_without_amplfunc() {
         String::from_utf8_lossy(&out.stderr)
     );
     assert!(
-        combined.contains("AMPLFUNC")
-            || combined.to_lowercase().contains("external function"),
+        combined.contains("AMPLFUNC") || combined.to_lowercase().contains("external function"),
         "error should mention AMPLFUNC or external functions, got: {combined}"
     );
 }

--- a/crates/pounce-cli/tests/issue_49_external_funcs.rs
+++ b/crates/pounce-cli/tests/issue_49_external_funcs.rs
@@ -1,0 +1,89 @@
+//! Integration test for issue #49: AMPL imported (external) functions.
+//!
+//! Drives the `pounce` binary on `idaes_helmholtz.nl`, a real-world
+//! fixture from the IDAES general-Helmholtz example that calls three
+//! externally-defined AMPL functions (`vf_hp`, `h_liq_hp`, `h_vap_hp`).
+//! With `AMPLFUNC` pointing at the installed Helmholtz dylib, pounce
+//! must (a) parse the F/funcall tokens, (b) load the library via
+//! `funcadd_ASL`, (c) build a tape whose `TapeOp::Funcall` nodes
+//! evaluate through the live ABI, and (d) drive the IPM to a clean
+//! `EXIT: Optimal Solution Found`.
+//!
+//! The test is skipped when the Helmholtz dylib isn't installed
+//! locally — this is an integration-with-real-library check, not a
+//! ripopt-style minimal unit test.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture_path() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures_issue_49");
+    p.push("idaes_helmholtz.nl");
+    p
+}
+
+fn helmholtz_dylib() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    let dylib = PathBuf::from(home).join(".idaes/bin/general_helmholtz_external.dylib");
+    if dylib.exists() { Some(dylib) } else { None }
+}
+
+#[test]
+fn pounce_solves_idaes_helmholtz_with_external_functions() {
+    let dylib = match helmholtz_dylib() {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "skipping: ~/.idaes/bin/general_helmholtz_external.dylib not installed"
+            );
+            return;
+        }
+    };
+
+    let out = Command::new(pounce_exe())
+        .env("AMPLFUNC", dylib.as_os_str())
+        .arg(fixture_path())
+        .arg("max_iter=50")
+        .arg("print_level=0")
+        .output()
+        .expect("spawn pounce binary");
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+
+    assert!(
+        out.status.success(),
+        "pounce exited non-zero:\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+    assert!(
+        stdout.contains("Optimal Solution Found"),
+        "expected optimal exit, got:\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+}
+
+#[test]
+fn pounce_rejects_external_function_problem_without_amplfunc() {
+    let out = Command::new(pounce_exe())
+        .env_remove("AMPLFUNC")
+        .arg(fixture_path())
+        .output()
+        .expect("spawn pounce binary");
+
+    assert!(!out.status.success(), "pounce should fail without AMPLFUNC");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("AMPLFUNC")
+            || combined.to_lowercase().contains("external function"),
+        "error should mention AMPLFUNC or external functions, got: {combined}"
+    );
+}

--- a/dev-notes/issue-49-ampl-external-functions.md
+++ b/dev-notes/issue-49-ampl-external-functions.md
@@ -1,0 +1,118 @@
+# issue #49 — AMPL imported (external) functions
+
+Status: implemented in `crates/pounce-cli` on
+`worktree-issue-49-external-functions`.
+
+## What this is
+
+AMPL `.nl` files can declare imported (a.k.a. external) functions:
+
+```
+F0 1 -1 vf_hp        # F-segment: id=0, kind=1 (real), nargs=-1 (variadic), name
+...
+f0 4                 # expression node: call function id 0 with 4 args
+h3:h2o               # string-literal arg (h<len>:<chars>)
+v3                   # real arg
+v4                   # real arg
+h126:/path/to/...    # second string-literal arg
+```
+
+The function is implemented in a shared library named via the
+`AMPLFUNC` environment variable (newline-separated list). The
+library exposes a `funcadd_ASL(AmplExports*)` symbol that registers
+each function through an `Addfunc` callback; pounce then calls back
+with `Arglist` structs requesting value-only, value+gradient, or
+value+gradient+packed-upper-Hessian.
+
+Before this change pounce failed at the parser with
+`Unknown expression token: 'f0 4'` on any such file.
+
+## Design
+
+Two new modules / types:
+
+- `crates/pounce-cli/src/nl_external.rs` — libloading wrapper around
+  the `funcadd_ASL` ABI. `ExternalLibrary` owns the loaded library
+  and a heap-pinned `AmplExports`; `eval(name, args, want_derivs,
+  want_hes)` is the single entry point and is serialised on a
+  process-wide `Mutex` (AMPL's ABI is not thread-safe). The
+  `ExternalResolver` maps funcall ids to `(Arc<ExternalLibrary>,
+  String)` pairs.
+
+- `nl_reader::Expr::Funcall { id, args: Vec<FuncallArg> }` —
+  expression node. `FuncallArg::Real(Expr)` is a sub-expression;
+  `FuncallArg::Str(String)` is an inline literal.
+
+- `nl_tape::TapeOp::Funcall { lib: Arc<ExternalLibrary>, name,
+  args: Vec<TapeFuncallArg> }` — tape op. `TapeFuncallArg::Tape(usize)`
+  references a tape slot; `TapeFuncallArg::Str(String)` is the literal
+  carried through.
+
+### NlTnlp::new wiring
+
+`NlTnlp::new` walks every nonlinear expression (`obj_nonlinear` plus
+each constraint's `con_nonlinear`) collecting referenced funcall ids,
+calls `ExternalResolver::build_for_problem`, then uses
+`Tape::build_with_externals` instead of `Tape::build`. If no funcall
+ids are referenced the resolver is empty and the path collapses to
+the old `Tape::build` behaviour (zero overhead).
+
+### AD sweeps with `Funcall`
+
+For `F: R^nr → R` with `p_k = ∂F/∂ra[k]` and packed Hessian
+`H_kl = ∂²F/∂ra[k]∂ra[l]`:
+
+- **forward**: `vals[i] = F(call_args)`. Library called with
+  `want_derivs=false, want_hes=false`.
+- **reverse**: `adj[arg_k] += a * p_k`. Library called with
+  `want_derivs=true, want_hes=false`.
+- **forward_tangent**: `dot[i] = sum_k p_k * dot[arg_k]`. Library
+  called with `want_derivs=true`.
+- **hessian_accumulate / hessian_directional** (forward-over-reverse):
+  - `adj[arg_k] += w * p_k`
+  - `adj_dot[arg_k] += wd * p_k + w * sum_l H_kl * dot[arg_l]`
+  - Library called with `want_derivs=true, want_hes=true`. Packed
+    indexing: `hes[lo + hi*(hi+1)/2]` with `lo=min(k,l)`,
+    `hi=max(k,l)`.
+- **hessian_sparsity**: emit `emit_self(union of arg var-sets)` —
+  every pair of real args contributes a structural Hessian entry.
+
+### Paths that don't support `Funcall`
+
+These panic on `TapeOp::Funcall`, because they're alternative AD
+routes not used by `NlTnlp::new`:
+
+- `nl_tape::HybridTape` (per-summand local tapes + shared CSE
+  prelude — partial-separability optimization).
+- `nl_hessian_program::HessianProgram` (JIT-style flat program for
+  per-color Hessian directional derivatives).
+
+If those paths are ever wired into the main flow, they'll need the
+same Funcall arms the basic `Tape` path now carries.
+
+## Tested against
+
+`crates/pounce-cli/tests/issue_49_external_funcs.rs` runs the
+`pounce` binary on a real IDAES Helmholtz fixture (3 vars, 3
+equality constraints, 3 imported functions: `vf_hp`, `h_liq_hp`,
+`h_vap_hp`) with `AMPLFUNC` pointed at
+`~/.idaes/bin/general_helmholtz_external.dylib`. Expectations:
+
+1. Optimal exit (`Optimal Solution Found`) — exercises full
+   forward + reverse + Hessian through the live library.
+2. Failure without `AMPLFUNC` — non-zero exit, message names
+   `AMPLFUNC` / external functions.
+
+Test is skipped when the dylib isn't installed locally; the
+ripopt-style minimal `myfunc`-on-x0 fixture remains a unit-level
+parser smoke test.
+
+## Open items
+
+- Errors from the resolver currently surface as a `panic!` from
+  `NlTnlp::new` rather than a clean `Result` returned by the CLI
+  layer. Acceptable because the panic message is precise, but a
+  follow-up to make this a graceful CLI exit would be nicer.
+- Coverage is one library (IDAES Helmholtz). Adding a second
+  smaller library (e.g. an `amplgsl`-style trig function) would
+  catch ABI regressions sooner.


### PR DESCRIPTION
## Summary

- `.nl` files that declare imported functions in `F` segments and call them via `f<id>` tokens now solve end-to-end. `AMPLFUNC` is read on `NlTnlp::new`, libraries are loaded via the standard `funcadd_ASL` ABI, and `TapeOp::Funcall` nodes participate in full forward / reverse / forward-over-reverse Hessian sweeps (packed upper-triangular Hessian indexing).
- Verified end-to-end against the IDAES `general_helmholtz_external.dylib` from issue #49's report — `pounce idaes_helmholtz.nl` reaches `Optimal Solution Found` in 7 iterations with the Hessian-of-Lagrangian routed through the live library.
- Without `AMPLFUNC` set, problems that need external functions fail with a clear message naming the offending function.

Closes #49.

## Scope notes

- Only the basic `Tape` (default) AD path supports external functions. `HybridTape` (partial-separability) and `HessianProgram` (JIT-style) panic on `TapeOp::Funcall` — both are alternative routes not on `NlTnlp::new`'s critical path, so the production flow is unaffected. Documented in `dev-notes/issue-49-ampl-external-functions.md`.
- Resolver errors currently surface as a `panic!` from `NlTnlp::new` rather than a graceful CLI `Result`. The panic message is precise (names the function, points at `AMPLFUNC`); turning it into a clean exit code is a follow-up.

## Test plan

- [x] Full `cargo test -p pounce-cli` — 89 unit + 7 integration including 2 new tests for issue #49 (one solves through real dylib; one verifies graceful failure without `AMPLFUNC`).
- [x] Full `cargo test --workspace` (excluding `pounce-hsl` which needs `COINHSL_DIR`) — no regressions.
- [x] Manual end-to-end: `AMPLFUNC=~/.idaes/bin/general_helmholtz_external.dylib pounce idaes_helmholtz.nl max_iter=50` reaches optimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
