### PR TITLE
feat(studio/skill): Claude-skill alternative to the MCP server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 #   make uninstall        # remove installed artifacts
 #   make install-mcp      # build studio/mcp + register with Claude Code
 #   make uninstall-mcp    # unregister + remove the studio/mcp venv
+#   make install-skill    # build pounce + pounce-studio, drop SKILL.md into ~/.claude/skills/
+#   make uninstall-skill  # remove the installed skill directory
 #   make clean            # cargo clean
 #
 # Benchmark targets — single source of truth in benchmarks/Makefile.
@@ -67,7 +69,7 @@ else
 endif
 
 .PHONY: all build debug test check clippy fmt fmt-check doc book install uninstall clean help \
-        install-mcp uninstall-mcp \
+        install-mcp uninstall-mcp install-skill uninstall-skill \
         benchmark benchmark-rerun benchmark-report benchmark-gams
 
 all: build
@@ -183,3 +185,37 @@ uninstall-mcp:
 	  claude mcp remove pounce-studio --scope $(MCP_SCOPE) >/dev/null 2>&1 || true
 	rm -rf "$(MCP_VENV)"
 	@echo "Removed $(MCP_VENV) and unregistered pounce-studio (scope=$(MCP_SCOPE))"
+
+# ---- Claude skill (studio/skill) ---------------------------------------
+# Build the pounce + pounce-studio binaries, install them under $(PREFIX),
+# and drop the skill directory at ~/.claude/skills/pounce/ so any Claude
+# Code session picks it up. Override SKILL_DIR for a non-default location.
+#
+#   make install-skill                          # ~/.claude/skills/pounce
+#   make install-skill SKILL_DIR=$$HOME/elsewhere/pounce
+#   make uninstall-skill
+
+SKILL_DIR ?= $(HOME)/.claude/skills/pounce
+STUDIO_BIN := $(TARGET_DIR)/pounce-studio
+
+install-skill: build
+	@echo "Installing pounce + pounce-studio into $(PREFIX) and skill into $(SKILL_DIR)"
+	install -d "$(DESTDIR)$(BINDIR)"
+	install -m 0755 "$(CLI_BIN)" "$(DESTDIR)$(BINDIR)/pounce"
+	install -m 0755 "$(STUDIO_BIN)" "$(DESTDIR)$(BINDIR)/pounce-studio"
+	install -d "$(SKILL_DIR)"
+	install -m 0644 studio/skill/SKILL.md "$(SKILL_DIR)/SKILL.md"
+	install -m 0644 studio/skill/README.md "$(SKILL_DIR)/README.md"
+	@echo
+	@echo "Done. Verify with:"
+	@echo "  $(BINDIR)/pounce-studio --version"
+	@echo "  ls $(SKILL_DIR)"
+	@echo
+	@echo "In a fresh Claude Code session, ask:"
+	@echo '  "diagnose studio/mcp/fixtures/rosenbrock-stalled.json"'
+
+uninstall-skill:
+	rm -rf "$(SKILL_DIR)"
+	rm -f "$(DESTDIR)$(BINDIR)/pounce-studio"
+	@echo "Removed $(SKILL_DIR) and $(BINDIR)/pounce-studio"
+	@echo "Note: $(BINDIR)/pounce was not removed (shared with \`make install\`)."

--- a/crates/pounce-studio-core/src/bin/pounce_studio.rs
+++ b/crates/pounce-studio-core/src/bin/pounce_studio.rs
@@ -1,103 +1,200 @@
-//! `pounce-studio` — Markdown inspector for solve reports and iter-dumps.
+//! `pounce-studio` — multi-subcommand inspector for pounce solve
+//! reports, iter-dumps, and pre-flight problem files.
 //!
-//! ```text
-//! pounce-studio inspect <report.json>      # JSON solve report → Markdown
-//! pounce-studio dump-summary <trace.bin>   # POUNCEIT v1 binary → summary
-//! pounce-studio version
-//! ```
+//! Most analysis subcommands emit JSON (suitable for piping into `jq`
+//! or consuming from a Claude skill). The two human-facing
+//! Markdown-renderers — `inspect` and `dump-summary` — keep their
+//! Markdown-on-stdout behaviour for shell users; everything else
+//! defaults to JSON.
 //!
-//! Reads from disk, prints to stdout. The library that does all the
-//! actual work (`pounce-studio-core`) is WASM-clean — see `src/lib.rs`.
+//! Run `pounce-studio help` for the full subcommand list, or
+//! `pounce-studio <cmd> --help` for per-command flags.
+//!
+//! The library that does the actual work (`pounce-studio-core`) is
+//! WASM-clean — this binary owns the filesystem touches.
 
 use std::path::Path;
 use std::process::ExitCode;
 
-use pounce_studio_core::{iter_dump::IterDumpTrace, markdown::render_inspect, report::SolveReport};
+use pounce_studio_core::{
+    analysis, glossary, iter_dump::IterDumpTrace, markdown::render_inspect, preflight,
+    report::SolveReport,
+};
 
 fn main() -> ExitCode {
-    let args: Vec<String> = std::env::args().skip(1).collect();
-    match args.first().map(String::as_str) {
-        Some("inspect") => match args.get(1) {
-            Some(path) => match cmd_inspect(Path::new(path)) {
-                Ok(md) => {
-                    print!("{md}");
-                    ExitCode::SUCCESS
-                }
-                Err(e) => {
-                    eprintln!("pounce-studio: {e}");
-                    ExitCode::from(2)
-                }
-            },
-            None => {
-                eprintln!("pounce-studio inspect: missing path argument");
-                ExitCode::from(2)
-            }
-        },
-        Some("dump-summary") => match args.get(1) {
-            Some(path) => match cmd_dump_summary(Path::new(path)) {
-                Ok(md) => {
-                    print!("{md}");
-                    ExitCode::SUCCESS
-                }
-                Err(e) => {
-                    eprintln!("pounce-studio: {e}");
-                    ExitCode::from(2)
-                }
-            },
-            None => {
-                eprintln!("pounce-studio dump-summary: missing path argument");
-                ExitCode::from(2)
-            }
-        },
-        Some("version") | Some("--version") | Some("-V") => {
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    let Some(cmd) = raw.first() else {
+        print_help();
+        return ExitCode::SUCCESS;
+    };
+    let rest: Vec<String> = raw[1..].to_vec();
+
+    let result: Result<(), CliError> = match cmd.as_str() {
+        "inspect" => cmd_inspect(&rest),
+        "dump-summary" => cmd_dump_summary(&rest),
+        "summary" => cmd_summary(&rest),
+        "diagnose" => cmd_diagnose(&rest),
+        "find-stalls" => cmd_find_stalls(&rest),
+        "convergence-trace" => cmd_convergence_trace(&rest),
+        "get-iterate" => cmd_get_iterate(&rest),
+        "restoration-windows" => cmd_restoration_windows(&rest),
+        "compare" => cmd_compare(&rest),
+        "linear-solver-summary" => cmd_linear_solver_summary(&rest),
+        "explain" => cmd_explain(&rest),
+        "citations" => cmd_citations(&rest),
+        "analyze-nl" => cmd_analyze_nl(&rest),
+        "analyze-gms" => cmd_analyze_gms(&rest),
+        "parse-gams-listing" => cmd_parse_gams_listing(&rest),
+        "list-gams" => cmd_list_gams(&rest),
+        "list-builtins" => cmd_list_builtins(&rest),
+        "version" | "--version" | "-V" => {
             println!("pounce-studio {}", env!("CARGO_PKG_VERSION"));
-            ExitCode::SUCCESS
+            Ok(())
         }
-        Some("help") | Some("--help") | Some("-h") | None => {
+        "help" | "--help" | "-h" => {
             print_help();
-            ExitCode::SUCCESS
+            Ok(())
         }
-        Some(other) => {
-            eprintln!("pounce-studio: unknown subcommand {other:?}");
-            print_help();
+        other => Err(CliError::UnknownCommand(other.into())),
+    };
+
+    match result {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("pounce-studio: {e}");
+            if matches!(e, CliError::UnknownCommand(_) | CliError::Usage(_)) {
+                eprintln!();
+                print_help_to_stderr();
+            }
             ExitCode::from(2)
         }
     }
 }
 
-fn cmd_inspect(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let bytes = std::fs::read(path)?;
-    let report = SolveReport::from_json_slice(&bytes)?;
-    Ok(render_inspect(&report))
+#[derive(Debug)]
+enum CliError {
+    Usage(String),
+    UnknownCommand(String),
+    Io(std::io::Error),
+    Parse(String),
+    Domain(String),
 }
 
-fn cmd_dump_summary(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Usage(m) => write!(f, "{m}"),
+            Self::UnknownCommand(c) => write!(f, "unknown subcommand {c:?}"),
+            Self::Io(e) => write!(f, "{e}"),
+            Self::Parse(m) => write!(f, "{m}"),
+            Self::Domain(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl From<std::io::Error> for CliError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+// ---- option-parsing helpers -----------------------------------------
+
+/// Pop a `--name VALUE` pair from `args`. Returns the value when
+/// matched and removes both tokens; returns `None` when the flag is
+/// absent. Errors when the flag is present but missing its value.
+fn take_flag(args: &mut Vec<String>, name: &str) -> Result<Option<String>, CliError> {
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == name {
+            if i + 1 >= args.len() {
+                return Err(CliError::Usage(format!("{name} requires a value")));
+            }
+            let val = args.remove(i + 1);
+            args.remove(i);
+            return Ok(Some(val));
+        }
+        i += 1;
+    }
+    Ok(None)
+}
+
+fn take_bool_flag(args: &mut Vec<String>, name: &str) -> bool {
+    if let Some(pos) = args.iter().position(|a| a == name) {
+        args.remove(pos);
+        true
+    } else {
+        false
+    }
+}
+
+fn positionals(args: Vec<String>) -> Vec<String> {
+    args
+}
+
+fn load_report(path: &str) -> Result<SolveReport, CliError> {
+    let bytes = std::fs::read(path).map_err(|e| {
+        CliError::Io(std::io::Error::new(
+            e.kind(),
+            format!("could not read {path:?}: {e}"),
+        ))
+    })?;
+    SolveReport::from_json_slice(&bytes).map_err(|e| CliError::Parse(e.to_string()))
+}
+
+/// Pretty-print a serializable value as JSON.
+fn emit_json<T: serde::Serialize>(value: &T) -> Result<(), CliError> {
+    let s = serde_json::to_string_pretty(value)
+        .map_err(|e| CliError::Domain(format!("json encode failed: {e}")))?;
+    println!("{s}");
+    Ok(())
+}
+
+// ---- inspect --------------------------------------------------------
+
+fn cmd_inspect(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let as_json = take_bool_flag(&mut args, "--json");
+    let pos = positionals(args);
+    let path = pos
+        .first()
+        .ok_or_else(|| CliError::Usage("inspect: missing path argument".into()))?;
+    let report = load_report(path)?;
+    if as_json {
+        emit_json(&report)
+    } else {
+        let md = render_inspect(&report);
+        print!("{md}");
+        Ok(())
+    }
+}
+
+fn cmd_dump_summary(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("dump-summary: missing path argument".into()))?;
     let bytes = std::fs::read(path)?;
-    let trace = IterDumpTrace::from_bytes(&bytes)?;
+    let trace = IterDumpTrace::from_bytes(&bytes).map_err(|e| CliError::Parse(e.to_string()))?;
     let mut out = String::new();
     use std::fmt::Write as _;
-    writeln!(out, "# POUNCEIT v{} trace", trace.header.format_version)?;
-    writeln!(out)?;
-    // header.name comes from the writer-side env var `IPOPT_ITER_DUMP_NAME`
-    // and could legitimately carry odd characters — sanitise before
-    // dropping it into an inline code span.
+    writeln!(out, "# POUNCEIT v{} trace", trace.header.format_version).ok();
+    writeln!(out).ok();
     writeln!(
         out,
         "- **name**: `{}`",
         trace.header.name.replace('`', "\u{02CB}"),
-    )?;
+    )
+    .ok();
     writeln!(
         out,
         "- **n** (variables): {}, **m** (constraints): {}",
         trace.header.n, trace.header.m,
-    )?;
-    writeln!(out, "- **records**: {}", trace.records.len())?;
-    writeln!(out)?;
-    writeln!(out, "| iter | mu | inf_pr | inf_du | α_pr | α_du | f |")?;
-    writeln!(out, "|---|---|---|---|---|---|---|")?;
-    // Cap printed rows for readability; show first 20 and last 5 with
-    // an elision row in between when the trace is long. Matches the
-    // policy used by the JSON-side `inspect` Markdown renderer.
+    )
+    .ok();
+    writeln!(out, "- **records**: {}", trace.records.len()).ok();
+    writeln!(out).ok();
+    writeln!(out, "| iter | mu | inf_pr | inf_du | α_pr | α_du | f |").ok();
+    writeln!(out, "|---|---|---|---|---|---|---|").ok();
     let n = trace.records.len();
     let to_show: Vec<usize> = if n <= 30 {
         (0..n).collect()
@@ -108,7 +205,7 @@ fn cmd_dump_summary(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
     for i in to_show {
         if let Some(prev) = last {
             if i != prev + 1 {
-                writeln!(out, "| ... | | | | | | |")?;
+                writeln!(out, "| ... | | | | | | |").ok();
             }
         }
         let r = &trace.records[i];
@@ -116,23 +213,471 @@ fn cmd_dump_summary(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
             out,
             "| {} | {:.2e} | {:.2e} | {:.2e} | {:.3} | {:.3} | {:.6e} |",
             r.iter, r.mu, r.inf_pr, r.inf_du, r.alpha_pr, r.alpha_du, r.f,
-        )?;
+        )
+        .ok();
         last = Some(i);
     }
-    Ok(out)
+    print!("{out}");
+    Ok(())
 }
 
-fn print_help() {
-    println!(
-        "pounce-studio — inspector for pounce solve reports and iter-dumps\n\
-\n\
-USAGE:\n  \
-  pounce-studio <COMMAND> [ARGS]\n\
-\n\
-COMMANDS:\n  \
-  inspect <report.json>       Render a Markdown summary of a JSON solve report\n  \
-  dump-summary <trace.bin>    Render a Markdown summary of a POUNCEIT v1 trace\n  \
-  version                     Print the crate version\n  \
-  help                        Show this message\n"
-    );
+// ---- solve-report tools ---------------------------------------------
+
+fn cmd_summary(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("summary: missing path argument".into()))?;
+    let report = load_report(path)?;
+    emit_json(&analysis::summarize(&report))
 }
+
+fn cmd_diagnose(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("diagnose: missing path argument".into()))?;
+    let report = load_report(path)?;
+    let findings = analysis::diagnose(&report);
+    let n = findings.len();
+    let body = serde_json::json!({"findings": findings, "n_findings": n});
+    emit_json(&body)
+}
+
+fn cmd_find_stalls(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let min_window = take_flag(&mut args, "--min-window")?
+        .map(|s| s.parse::<usize>())
+        .transpose()
+        .map_err(|e| CliError::Usage(format!("--min-window: {e}")))?
+        .unwrap_or(5);
+    let max_progress = take_flag(&mut args, "--max-progress")?
+        .map(|s| s.parse::<f64>())
+        .transpose()
+        .map_err(|e| CliError::Usage(format!("--max-progress: {e}")))?
+        .unwrap_or(0.3);
+    let pos = positionals(args);
+    let path = pos
+        .first()
+        .ok_or_else(|| CliError::Usage("find-stalls: missing path argument".into()))?;
+    let report = load_report(path)?;
+    let windows = analysis::find_stalls_with(&report, min_window, max_progress);
+    let n = windows.len();
+    let body = serde_json::json!({"windows": windows, "count": n});
+    emit_json(&body)
+}
+
+fn cmd_convergence_trace(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let columns = take_flag(&mut args, "--columns")?;
+    let pos = positionals(args);
+    let path = pos
+        .first()
+        .ok_or_else(|| CliError::Usage("convergence-trace: missing path argument".into()))?;
+    let report = load_report(path)?;
+    let full = analysis::convergence_trace(&report);
+    let full_json =
+        serde_json::to_value(&full).map_err(|e| CliError::Domain(format!("encode trace: {e}")))?;
+    let Some(cols_spec) = columns else {
+        return emit_json(&full_json);
+    };
+    let want: Vec<&str> = cols_spec.split(',').map(|s| s.trim()).collect();
+    let obj = full_json
+        .as_object()
+        .ok_or_else(|| CliError::Domain("convergence trace was not an object".into()))?;
+    let mut filtered = serde_json::Map::new();
+    let mut unknown: Vec<String> = Vec::new();
+    for col in want {
+        match obj.get(col) {
+            Some(v) => {
+                filtered.insert(col.to_string(), v.clone());
+            }
+            None => unknown.push(col.to_string()),
+        }
+    }
+    if !unknown.is_empty() {
+        return Err(CliError::Usage(format!(
+            "unknown trace column(s): {unknown:?}. valid: {:?}",
+            obj.keys().collect::<Vec<_>>(),
+        )));
+    }
+    emit_json(&serde_json::Value::Object(filtered))
+}
+
+fn cmd_get_iterate(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("get-iterate: missing path argument".into()))?;
+    let k_str = args
+        .get(1)
+        .ok_or_else(|| CliError::Usage("get-iterate: missing iter index".into()))?;
+    let k: usize = k_str
+        .parse()
+        .map_err(|e| CliError::Usage(format!("iter index: {e}")))?;
+    let report = load_report(path)?;
+    let iter = analysis::get_iterate(&report, k).map_err(|e| CliError::Domain(e.to_string()))?;
+    emit_json(&iter)
+}
+
+fn cmd_restoration_windows(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("restoration-windows: missing path argument".into()))?;
+    let report = load_report(path)?;
+    let windows = analysis::restoration_windows(&report);
+    let n = windows.len();
+    let body = serde_json::json!({"windows": windows, "count": n});
+    emit_json(&body)
+}
+
+fn cmd_compare(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let labels_csv = take_flag(&mut args, "--labels")?;
+    let pos = positionals(args);
+    if pos.is_empty() {
+        return Err(CliError::Usage(
+            "compare: at least one report path required".into(),
+        ));
+    }
+    let labels: Vec<String> = match labels_csv {
+        Some(csv) => csv.split(',').map(|s| s.trim().to_string()).collect(),
+        None => pos.clone(),
+    };
+    if labels.len() != pos.len() {
+        return Err(CliError::Usage(format!(
+            "compare: labels count ({}) does not match paths count ({})",
+            labels.len(),
+            pos.len(),
+        )));
+    }
+    let mut reports: Vec<(String, SolveReport)> = Vec::with_capacity(pos.len());
+    for (label, path) in labels.iter().zip(pos.iter()) {
+        let r = load_report(path)?;
+        reports.push((label.clone(), r));
+    }
+    let rows = analysis::compare_runs(reports.iter().map(|(l, r)| (l.as_str(), r)));
+    let n = rows.len();
+    let body = serde_json::json!({"rows": rows, "n_runs": n});
+    emit_json(&body)
+}
+
+fn cmd_linear_solver_summary(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("linear-solver-summary: missing path argument".into()))?;
+    let report = load_report(path)?;
+    let summary = &report.linear_solver;
+    let body = serde_json::json!({
+        "available": summary.is_some(),
+        "summary": summary,
+    });
+    emit_json(&body)
+}
+
+// ---- glossary / citations -------------------------------------------
+
+fn cmd_explain(args: &[String]) -> Result<(), CliError> {
+    let term = args
+        .first()
+        .ok_or_else(|| CliError::Usage("explain: missing term argument".into()))?;
+    let exp = glossary::explain(term);
+    emit_json(&exp)
+}
+
+fn cmd_citations(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let topic = take_flag(&mut args, "--topic")?;
+    let key = take_flag(&mut args, "--key")?;
+    if topic.is_some() && key.is_some() {
+        return Err(CliError::Usage(
+            "citations: specify at most one of --topic or --key".into(),
+        ));
+    }
+    if let Some(k) = key {
+        let Some(c) = glossary::citation_by_key(&k) else {
+            return Err(CliError::Domain(format!("unknown citation key {k:?}")));
+        };
+        return emit_json(c);
+    }
+    if let Some(t) = topic {
+        let Some(keys) = glossary::topic_keys(&t) else {
+            return Err(CliError::Domain(format!(
+                "unknown topic {t:?}. valid: {:?}",
+                glossary::all_topics(),
+            )));
+        };
+        let entries: Vec<serde_json::Value> = keys
+            .iter()
+            .map(|k| match glossary::citation_by_key(k) {
+                Some(c) => serde_json::to_value(c).unwrap_or(serde_json::Value::Null),
+                None => serde_json::json!({"key": k, "missing": true}),
+            })
+            .collect();
+        return emit_json(&serde_json::json!({"topic": t, "entries": entries}));
+    }
+    // No args: list topics + all loaded keys.
+    let topics: serde_json::Map<String, serde_json::Value> = glossary::TOPICS
+        .iter()
+        .map(|(t, keys)| {
+            (
+                (*t).to_string(),
+                serde_json::Value::Array(
+                    keys.iter()
+                        .map(|k| serde_json::Value::String((*k).to_string()))
+                        .collect(),
+                ),
+            )
+        })
+        .collect();
+    let entries = glossary::all_citations();
+    let body = serde_json::json!({
+        "topics": topics,
+        "n_entries_loaded": entries.len(),
+        "entries": entries,
+    });
+    emit_json(&body)
+}
+
+// ---- pre-flight: NL / builtin / GMS / lst ---------------------------
+
+fn cmd_analyze_nl(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let builtin = take_flag(&mut args, "--builtin")?;
+    let pos = positionals(args);
+
+    if let Some(name) = builtin {
+        if !pos.is_empty() {
+            return Err(CliError::Usage(
+                "analyze-nl: pass either --builtin NAME or a path, not both".into(),
+            ));
+        }
+        let a = preflight::analyze_builtin(&name).map_err(CliError::Domain)?;
+        return emit_json(&a);
+    }
+
+    let path = pos.first().ok_or_else(|| {
+        CliError::Usage("analyze-nl: specify --builtin NAME or pass an .nl path".into())
+    })?;
+    let bytes = std::fs::read(path).map_err(|e| {
+        CliError::Io(std::io::Error::new(
+            e.kind(),
+            format!("could not read {path:?}: {e}"),
+        ))
+    })?;
+    let header = preflight::parse_nl_header(&bytes);
+    let analysis = preflight::analyze_nl(path, header);
+    emit_json(&analysis)
+}
+
+fn cmd_analyze_gms(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("analyze-gms: missing path argument".into()))?;
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        CliError::Io(std::io::Error::new(
+            e.kind(),
+            format!("could not read {path:?}: {e}"),
+        ))
+    })?;
+    let analysis = preflight::analyze_gms(path, &text);
+    emit_json(&analysis)
+}
+
+fn cmd_parse_gams_listing(args: &[String]) -> Result<(), CliError> {
+    let path = args
+        .first()
+        .ok_or_else(|| CliError::Usage("parse-gams-listing: missing .lst path argument".into()))?;
+    let text = std::fs::read_to_string(path).map_err(|e| {
+        CliError::Io(std::io::Error::new(
+            e.kind(),
+            format!("could not read {path:?}: {e}"),
+        ))
+    })?;
+    let summary = preflight::parse_lst_summary(&text);
+    let body = serde_json::json!({"path": path, "summary": summary});
+    emit_json(&body)
+}
+
+// ---- repository inventory tools -------------------------------------
+
+fn cmd_list_gams(args: &[String]) -> Result<(), CliError> {
+    let mut args = args.to_vec();
+    let root = take_flag(&mut args, "--root")?;
+    let suite = take_flag(&mut args, "--suite")?;
+    let limit: usize = take_flag(&mut args, "--limit")?
+        .map(|s| s.parse::<usize>())
+        .transpose()
+        .map_err(|e| CliError::Usage(format!("--limit: {e}")))?
+        .unwrap_or(50);
+    let offset: usize = take_flag(&mut args, "--offset")?
+        .map(|s| s.parse::<usize>())
+        .transpose()
+        .map_err(|e| CliError::Usage(format!("--offset: {e}")))?
+        .unwrap_or(0);
+
+    let root_path = match root {
+        Some(r) => std::path::PathBuf::from(r),
+        None => find_repo_root().ok_or_else(|| {
+            CliError::Usage(
+                "list-gams: could not locate pounce repo root; pass --root <path>".into(),
+            )
+        })?,
+    };
+    let gams_dir = root_path.join("gams");
+
+    let suites = [
+        "globallib.gms",
+        "mittelmann.gms",
+        "princetonlib.gms",
+        "powerflow.gms",
+    ];
+
+    if let Some(name) = suite {
+        let sroot = match name.as_str() {
+            "examples" => gams_dir.join("examples"),
+            "smoke" => gams_dir.clone(),
+            s if suites.contains(&s) => gams_dir.join("nlpbench").join("instances").join(s),
+            other => {
+                let mut valid: Vec<String> = suites.iter().map(|s| (*s).to_string()).collect();
+                valid.push("examples".into());
+                valid.push("smoke".into());
+                return Err(CliError::Usage(format!(
+                    "unknown suite {other:?}; valid: {valid:?}",
+                )));
+            }
+        };
+        let mut files: Vec<String> = if name == "smoke" {
+            let f = gams_dir.join("test_hs071.gms");
+            if f.exists() {
+                vec![f.to_string_lossy().into()]
+            } else {
+                vec![]
+            }
+        } else if sroot.is_dir() {
+            collect_gms(&sroot)
+        } else {
+            Vec::new()
+        };
+        files.sort();
+        let total = files.len();
+        let slice: Vec<&String> = files.iter().skip(offset).take(limit).collect();
+        let body = serde_json::json!({
+            "suite": name,
+            "root": sroot.to_string_lossy(),
+            "count": total,
+            "limit": limit,
+            "offset": offset,
+            "files": slice,
+        });
+        return emit_json(&body);
+    }
+
+    // No --suite: summary across all of them.
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    let mut total = 0usize;
+    for s in suites.iter() {
+        let d = gams_dir.join("nlpbench").join("instances").join(s);
+        let n = if d.is_dir() { collect_gms(&d).len() } else { 0 };
+        total += n;
+        entries.push(serde_json::json!({"name": s, "count": n, "root": d.to_string_lossy()}));
+    }
+    let ex = gams_dir.join("examples");
+    let n_ex = if ex.is_dir() {
+        collect_gms(&ex).len()
+    } else {
+        0
+    };
+    total += n_ex;
+    entries
+        .push(serde_json::json!({"name": "examples", "count": n_ex, "root": ex.to_string_lossy()}));
+    let smoke = gams_dir.join("test_hs071.gms");
+    let n_smoke = if smoke.exists() { 1 } else { 0 };
+    total += n_smoke;
+    entries.push(
+        serde_json::json!({"name": "smoke", "count": n_smoke, "root": gams_dir.to_string_lossy()}),
+    );
+
+    emit_json(&serde_json::json!({"suites": entries, "total": total}))
+}
+
+fn cmd_list_builtins(_args: &[String]) -> Result<(), CliError> {
+    let all = preflight::all_builtins();
+    emit_json(&all)
+}
+
+fn collect_gms(dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.extension().map(|e| e == "gms").unwrap_or(false) {
+                out.push(p.to_string_lossy().into_owned());
+            }
+        }
+    }
+    out
+}
+
+/// Walk up from CWD looking for a directory that contains `Cargo.toml`
+/// and `gams/` — the pounce repo root layout.
+fn find_repo_root() -> Option<std::path::PathBuf> {
+    let mut cwd = std::env::current_dir().ok()?;
+    loop {
+        if cwd.join("Cargo.toml").exists() && cwd.join("gams").is_dir() {
+            return Some(cwd);
+        }
+        if !cwd.pop() {
+            return None;
+        }
+    }
+}
+
+// ---- help -----------------------------------------------------------
+
+fn print_help() {
+    print!("{}", HELP_TEXT);
+}
+
+fn print_help_to_stderr() {
+    eprint!("{}", HELP_TEXT);
+}
+
+const HELP_TEXT: &str = "pounce-studio — inspector for pounce solve reports + pre-flight tools
+
+USAGE:
+  pounce-studio <COMMAND> [ARGS]
+
+REPORT POST-MORTEM (operate on a `pounce.solve-report/v1` JSON):
+  summary <report>                          Headline summary as JSON
+  diagnose <report>                         Common Ipopt-failure heuristics
+  find-stalls <report>                      Stalled-progress windows
+      [--min-window N] [--max-progress P]
+  convergence-trace <report>                Per-iter trajectory (column-oriented)
+      [--columns iter,inf_pr,...]
+  get-iterate <report> <k>                  Full iter k record + log10 fields
+  restoration-windows <report>              Restoration entry → exit cycles
+  compare <r1> <r2> ...                     Side-by-side row per report
+      [--labels A,B,C]
+  linear-solver-summary <report>            FERAL backend post-mortem
+  inspect <report> [--json]                 Markdown summary (default) or JSON
+  dump-summary <trace>                      Markdown summary of a POUNCEIT trace
+
+GLOSSARY / CITATIONS:
+  explain <term>                            Define a column or finding code
+  citations [--topic T] [--key K]           Curated paper references
+
+PRE-FLIGHT:
+  analyze-nl <path>                         AMPL .nl header + suggestions
+  analyze-nl --builtin <NAME>               Builtin-problem metadata
+  analyze-gms <path>                        GAMS .gms header + suggestions
+  parse-gams-listing <path>                 GAMS .lst SOLVE SUMMARY block
+  list-gams [--suite S] [--root DIR]        Enumerate bundled .gms instances
+      [--limit N] [--offset M]
+  list-builtins                             Names + classes of all builtin problems
+
+OTHER:
+  version | --version | -V                  Print crate version
+  help    | --help    | -h                  Show this message
+
+All analysis subcommands print pretty-printed JSON on stdout. Pipe into
+`jq` for slicing. See `studio/skill/SKILL.md` for the Claude-skill that
+wraps this binary for AI-assisted post-mortem.
+";

--- a/crates/pounce-studio-core/src/glossary.rs
+++ b/crates/pounce-studio-core/src/glossary.rs
@@ -1,0 +1,503 @@
+//! Static glossary for solve-report column names, diagnose finding codes,
+//! and citation metadata. Backs the `explain` and `citations` CLI tools.
+//!
+//! Ported from `studio/mcp/pounce_studio_mcp/glossary.py` so the
+//! Rust-CLI / skill path returns the same definitions as the Python MCP
+//! path. Entries are intentionally terse — Claude can elaborate at call
+//! time; the job here is to surface canonical names, numeric ranges,
+//! and the right paper keys.
+
+use serde::Serialize;
+
+/// One per-iter column entry returned by [`explain_column`].
+#[derive(Debug, Clone, Serialize)]
+pub struct ColumnEntry {
+    pub definition: &'static str,
+    pub typical_range: &'static str,
+    pub what_abnormal_means: &'static str,
+    pub see_also: &'static [&'static str],
+}
+
+/// One diagnose-finding entry returned by [`explain_finding`].
+#[derive(Debug, Clone, Serialize)]
+pub struct FindingEntry {
+    pub severity: &'static str,
+    pub meaning: &'static str,
+    pub what_to_try: &'static str,
+    pub see_also: &'static [&'static str],
+}
+
+/// One citation entry returned by [`citation_by_key`].
+#[derive(Debug, Clone, Serialize)]
+pub struct Citation {
+    pub key: &'static str,
+    pub entry_type: &'static str,
+    pub title: &'static str,
+    pub author: &'static str,
+    pub year: &'static str,
+    pub venue: &'static str,
+    pub doi: &'static str,
+}
+
+/// Lookup result for [`explain`]: column entry, finding entry, or
+/// fuzzy suggestions when the term is unknown.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Explanation {
+    Column {
+        term: String,
+        #[serde(flatten)]
+        entry: ColumnEntry,
+    },
+    Finding {
+        term: String,
+        #[serde(flatten)]
+        entry: FindingEntry,
+    },
+    Unknown {
+        term: String,
+        suggestions: Vec<&'static str>,
+        all_columns: Vec<&'static str>,
+        all_findings: Vec<&'static str>,
+    },
+}
+
+const COLUMNS: &[(&str, ColumnEntry)] = &[
+    ("iter", ColumnEntry {
+        definition: "Zero-based iteration index of the outer interior-point loop.",
+        typical_range: "0 to a few hundred for well-scaled problems.",
+        what_abnormal_means: "Hitting `max_iter` without converging usually points at scaling or degeneracy.",
+        see_also: &["wachter2006"],
+    }),
+    ("objective", ColumnEntry {
+        definition: "Current objective value f(x_k) at the iterate.",
+        typical_range: "Problem-dependent. For well-scaled problems on the order of 1.",
+        what_abnormal_means: "Wild swings (especially after restoration) can signal bad scaling.",
+        see_also: &[],
+    }),
+    ("inf_pr", ColumnEntry {
+        definition: "Primal infeasibility: max-norm of constraint violation c(x_k).",
+        typical_range: "Drops monotonically toward `tol` (default 1e-8) at convergence.",
+        what_abnormal_means: "Stalling at large inf_pr → likely infeasible or restoration-stuck.",
+        see_also: &["wachter2006", "byrd2010"],
+    }),
+    ("inf_du", ColumnEntry {
+        definition: "Dual infeasibility: max-norm of the gradient of the Lagrangian.",
+        typical_range: "Drops toward `tol` alongside inf_pr; sometimes lags.",
+        what_abnormal_means: "inf_du much larger than inf_pr → multipliers ill-conditioned or scaling bad.",
+        see_also: &["wachter2006"],
+    }),
+    ("mu", ColumnEntry {
+        definition: "Barrier parameter for the log-barrier homotopy.",
+        typical_range: "Starts ~0.1, decreases toward 1e-9 as iterations progress.",
+        what_abnormal_means: "Mu stuck at one value across many iterations → see finding `mu_stuck`.",
+        see_also: &["wachter2006", "hinder2018"],
+    }),
+    ("d_norm", ColumnEntry {
+        definition: "Norm of the Newton search direction d_k.",
+        typical_range: "Decreases as the iterate approaches the solution.",
+        what_abnormal_means: "d_norm growing → search direction quality degrading; check regularization.",
+        see_also: &["wachter2006"],
+    }),
+    ("regularization", ColumnEntry {
+        definition: "Diagonal Hessian regularization δ added to make the KKT matrix have the correct inertia.",
+        typical_range: "0 for convex problems; small positive values near saddle points.",
+        what_abnormal_means: "Repeated large δ → Hessian is indefinite, problem is non-convex; finding `hessian_regularized` fires.",
+        see_also: &["wachter2006"],
+    }),
+    ("alpha_dual", ColumnEntry {
+        definition: "Step length applied to the dual variables (bound multipliers).",
+        typical_range: "(0, 1]. Often 1.0 near the solution.",
+        what_abnormal_means: "Persistently tiny alpha_dual → fraction-to-boundary biting; bounds may be active.",
+        see_also: &["wachter2006"],
+    }),
+    ("alpha_primal", ColumnEntry {
+        definition: "Step length applied to the primal variables x.",
+        typical_range: "(0, 1]. Tiny values point at line-search difficulty.",
+        what_abnormal_means: "Repeated tiny alpha_primal → finding `heavy_line_search` fires.",
+        see_also: &["wachter2006"],
+    }),
+    ("alpha_primal_char", ColumnEntry {
+        definition: "Single-character tag for what the line search did this iter: `f` filter-accepted, `h` Armijo, `r` restoration, `s` second-order correction, `R` restoration entry, `-` rejected.",
+        typical_range: "Mostly `f` on a healthy solve.",
+        what_abnormal_means: "Runs of `r` are restoration windows; consecutive `R` entries = `restoration_loop`.",
+        see_also: &["wachter2006"],
+    }),
+    ("ls_trials", ColumnEntry {
+        definition: "Number of line-search trials in this iteration.",
+        typical_range: "1-3 for healthy solves.",
+        what_abnormal_means: "Persistently high → curvature mismatch; consider regularization or restart.",
+        see_also: &["wachter2006"],
+    }),
+    ("log10_mu", ColumnEntry {
+        definition: "log10(mu); convenience for plotting the barrier homotopy.",
+        typical_range: "Decreases from ~-1 to ~-9 over a typical solve.",
+        what_abnormal_means: "Flat trace → mu_stuck.",
+        see_also: &["wachter2006"],
+    }),
+    ("log10_inf_pr", ColumnEntry {
+        definition: "log10(inf_pr); convenience for spotting stalls.",
+        typical_range: "Monotone descent to ~-8.",
+        what_abnormal_means: "Plateaus over many iters → `find_stalls` will flag the window.",
+        see_also: &[],
+    }),
+    ("log10_inf_du", ColumnEntry {
+        definition: "log10(inf_du); convenience for spotting stalls.",
+        typical_range: "Monotone descent to ~-8.",
+        what_abnormal_means: "Plateaus → check Hessian regularization and step quality.",
+        see_also: &[],
+    }),
+    ("n_factors", ColumnEntry {
+        definition: "Total successful symmetric factorisations across the solve.",
+        typical_range: "≈ iteration_count for filter-line-search runs.",
+        what_abnormal_means: "Much larger than iter count → repeated regularization retries.",
+        see_also: &["n_pattern_reuse", "n_pattern_changes"],
+    }),
+    ("n_pattern_reuse", ColumnEntry {
+        definition: "Factors that reused the prior symbolic factorisation (sparsity pattern unchanged → cheap).",
+        typical_range: "Should dominate n_factors after iter 1.",
+        what_abnormal_means: "Low share → matrix structure changing per iter; analyse() runs repeatedly, hurting throughput.",
+        see_also: &["n_pattern_changes"],
+    }),
+    ("n_pattern_changes", ColumnEntry {
+        definition: "Factors that required a fresh symbolic factorisation.",
+        typical_range: "1 (the first factor) for a healthy solve.",
+        what_abnormal_means: "> 1 → KKT structure shifting; check inertia-correction regularization policy or active-set churn.",
+        see_also: &["n_pattern_reuse"],
+    }),
+    ("max_fill_ratio", ColumnEntry {
+        definition: "Max nnz(L) / nnz(A) observed across factors.",
+        typical_range: "1–10 for well-ordered KKT systems.",
+        what_abnormal_means: ">> 10 → AMD/METIS ordering struggled; expect memory + time spikes.",
+        see_also: &["last_nnz_a", "last_nnz_l"],
+    }),
+    ("min_abs_pivot", ColumnEntry {
+        definition: "Smallest absolute pivot encountered during factorisation.",
+        typical_range: "1e-8 .. 1e+6 depending on problem scaling.",
+        what_abnormal_means: "Approaching working precision floor (~1e-16) → matrix near-singular; regularization is probably kicking in.",
+        see_also: &["max_abs_pivot", "regularization"],
+    }),
+    ("max_abs_pivot", ColumnEntry {
+        definition: "Largest absolute pivot encountered during factorisation.",
+        typical_range: "Within ~6 orders of magnitude of min_abs_pivot.",
+        what_abnormal_means: "max/min >> 1e8 → catastrophic conditioning; consider nlp_scaling_method.",
+        see_also: &["min_abs_pivot"],
+    }),
+    ("last_inertia", ColumnEntry {
+        definition: "(positive, negative, zero) eigenvalue counts of the final factorisation, from the LDLᵀ pivots.",
+        typical_range: "(n, m, 0) at a converged primal-dual KKT system.",
+        what_abnormal_means: "zero > 0 → singular; positive < n → indefinite, inertia correction failed.",
+        see_also: &["regularization"],
+    }),
+    ("last_nnz_a", ColumnEntry {
+        definition: "nnz(A) at the final factorisation's input KKT matrix.",
+        typical_range: "Problem-dependent.",
+        what_abnormal_means: "n/a — informational.",
+        see_also: &["last_nnz_l", "max_fill_ratio"],
+    }),
+    ("last_nnz_l", ColumnEntry {
+        definition: "nnz(L) at the final factorisation.",
+        typical_range: "Problem-dependent.",
+        what_abnormal_means: "n/a — informational; combine with last_nnz_a for fill.",
+        see_also: &["last_nnz_a", "max_fill_ratio"],
+    }),
+];
+
+const FINDINGS: &[(&str, FindingEntry)] = &[
+    ("converged", FindingEntry {
+        severity: "info",
+        meaning: "Solver reached the convergence tolerance on both primal and dual infeasibility.",
+        what_to_try: "Nothing — this is the success path.",
+        see_also: &["wachter2006"],
+    }),
+    ("max_iter_exceeded", FindingEntry {
+        severity: "error",
+        meaning: "Solver hit `max_iter` without satisfying tolerances.",
+        what_to_try: "Inspect the convergence trace: is residual still decreasing (raise max_iter), stalled (loosen tol, improve scaling), or oscillating (regularize)?",
+        see_also: &["wachter2006"],
+    }),
+    ("restoration_used", FindingEntry {
+        severity: "info",
+        meaning: "Restoration phase was entered at least once during the solve.",
+        what_to_try: "Often benign on hard problems. Check restoration-windows; a single short entry is fine, repeated entries suggest a deeper feasibility issue.",
+        see_also: &["wachter2006", "byrd2010"],
+    }),
+    ("mu_stuck", FindingEntry {
+        severity: "warning",
+        meaning: "Barrier parameter μ failed to decrease across a window of iterations. Usually a degenerate active set or a poorly-scaled barrier.",
+        what_to_try: "Try `mu_strategy=adaptive`, tighten `bound_relax_factor`, or check that bound values are sensible (no infs masking effective bounds).",
+        see_also: &["wachter2006", "hinder2018"],
+    }),
+    ("heavy_line_search", FindingEntry {
+        severity: "warning",
+        meaning: "Line search needed many trials on average — search direction is low-quality.",
+        what_to_try: "Often Hessian-related: enable second-order-correction, or investigate regularization values.",
+        see_also: &["wachter2006"],
+    }),
+    ("hessian_regularized", FindingEntry {
+        severity: "warning",
+        meaning: "Hessian needed inertia-correction (added δ on the diagonal) frequently — the problem is non-convex or has near-singular Hessian.",
+        what_to_try: "Consider tightening tolerances on `min_hessian_perturbation`, providing an analytic Hessian if you have one, or reformulating to convexify.",
+        see_also: &["wachter2006"],
+    }),
+    ("restoration_loop", FindingEntry {
+        severity: "error",
+        meaning: "Restoration phase was entered repeatedly and never exited cleanly.",
+        what_to_try: "Strong signal of local infeasibility. Try a different start point, relax tight constraints, or run feasibility diagnostics.",
+        see_also: &["wachter2006", "byrd2010", "leyffer2003"],
+    }),
+    ("convergence_stall", FindingEntry {
+        severity: "warning",
+        meaning: "log10(inf_pr|inf_du) barely moved across a window — solver is grinding.",
+        what_to_try: "Check `find-stalls` for the window, then `get-iterate` at its midpoint to inspect μ, alpha_primal, and regularization. Common cause: bad scaling.",
+        see_also: &["wachter2006"],
+    }),
+];
+
+/// Topic → ordered list of citation keys, most-relevant first.
+pub const TOPICS: &[(&str, &[&str])] = &[
+    ("interior_point", &["wachter2006", "byrd1999", "hinder2018"]),
+    ("filter_line_search", &["wachter2006"]),
+    ("restoration", &["wachter2006", "byrd2010"]),
+    ("regularization", &["wachter2006"]),
+    ("trust_region", &["byrd2000", "waltz2006"]),
+    ("inexact_step", &["curtis2010"]),
+    ("infeasibility_detection", &["byrd2010", "leyffer2003"]),
+    ("mu_strategy", &["wachter2006", "hinder2018"]),
+    ("sensitivity", &["zavala2009"]),
+    ("knitro", &["byrd2006"]),
+];
+
+const CITATIONS: &[Citation] = &[
+    Citation {
+        key: "wachter2006",
+        entry_type: "article",
+        title: "On the implementation of an interior-point filter line-search algorithm for large-scale nonlinear programming",
+        author: "Wächter, A. and Biegler, L. T.",
+        year: "2006",
+        venue: "Mathematical Programming 106(1), 25–57",
+        doi: "10.1007/s10107-004-0559-y",
+    },
+    Citation {
+        key: "byrd1999",
+        entry_type: "article",
+        title: "An interior point algorithm for large-scale nonlinear programming",
+        author: "Byrd, R. H., Hribar, M. E. and Nocedal, J.",
+        year: "1999",
+        venue: "SIAM Journal on Optimization 9(4), 877–900",
+        doi: "10.1137/S1052623497325107",
+    },
+    Citation {
+        key: "byrd2000",
+        entry_type: "article",
+        title: "A trust region method based on interior point techniques for nonlinear programming",
+        author: "Byrd, R. H., Gilbert, J. C. and Nocedal, J.",
+        year: "2000",
+        venue: "Mathematical Programming 89(1), 149–185",
+        doi: "10.1007/PL00011391",
+    },
+    Citation {
+        key: "byrd2006",
+        entry_type: "inbook",
+        title: "Knitro: An integrated package for nonlinear optimization",
+        author: "Byrd, R. H., Nocedal, J. and Waltz, R. A.",
+        year: "2006",
+        venue: "Large-Scale Nonlinear Optimization, Springer, 35–59",
+        doi: "10.1007/0-387-30065-1_4",
+    },
+    Citation {
+        key: "byrd2010",
+        entry_type: "article",
+        title: "Infeasibility detection and SQP methods for nonlinear optimization",
+        author: "Byrd, R. H., Curtis, F. E. and Nocedal, J.",
+        year: "2010",
+        venue: "SIAM Journal on Optimization 20(5), 2281–2299",
+        doi: "10.1137/080738222",
+    },
+    Citation {
+        key: "waltz2006",
+        entry_type: "article",
+        title: "An interior algorithm for nonlinear optimization that combines line search and trust region steps",
+        author: "Waltz, R. A., Morales, J. L., Nocedal, J. and Orban, D.",
+        year: "2006",
+        venue: "Mathematical Programming 107(3), 391–408",
+        doi: "10.1007/s10107-004-0560-5",
+    },
+    Citation {
+        key: "curtis2010",
+        entry_type: "article",
+        title: "An adaptive Gauss-Newton algorithm for training multilayer nonlinear filters that have embedded memory",
+        author: "Curtis, F. E.",
+        year: "2010",
+        venue: "Mathematical Programming Computation 4(1), 27–62",
+        doi: "10.1007/s12532-011-0033-9",
+    },
+    Citation {
+        key: "leyffer2003",
+        entry_type: "article",
+        title: "Interior methods for mathematical programs with complementarity constraints",
+        author: "Leyffer, S., López-Calva, G. and Nocedal, J.",
+        year: "2003",
+        venue: "Argonne National Laboratory technical report",
+        doi: "",
+    },
+    Citation {
+        key: "hinder2018",
+        entry_type: "article",
+        title: "One-phase: A new method for global linear and quadratic programming",
+        author: "Hinder, O. and Ye, Y.",
+        year: "2018",
+        venue: "Optimization Online preprint",
+        doi: "",
+    },
+    Citation {
+        key: "zavala2009",
+        entry_type: "article",
+        title: "Real-time nonlinear optimization as a generalized equation",
+        author: "Zavala, V. M. and Anitescu, M.",
+        year: "2009",
+        venue: "SIAM Journal on Control and Optimization 48(8), 5444–5467",
+        doi: "10.1137/090762634",
+    },
+];
+
+/// Look up a per-iter column entry by name.
+pub fn column(name: &str) -> Option<&'static ColumnEntry> {
+    COLUMNS.iter().find(|(k, _)| *k == name).map(|(_, v)| v)
+}
+
+/// Look up a diagnose-finding entry by code.
+pub fn finding(code: &str) -> Option<&'static FindingEntry> {
+    FINDINGS.iter().find(|(k, _)| *k == code).map(|(_, v)| v)
+}
+
+/// All known column names, in declaration order.
+pub fn all_columns() -> Vec<&'static str> {
+    COLUMNS.iter().map(|(k, _)| *k).collect()
+}
+
+/// All known finding codes, in declaration order.
+pub fn all_findings() -> Vec<&'static str> {
+    FINDINGS.iter().map(|(k, _)| *k).collect()
+}
+
+/// Look up a citation by bib key.
+pub fn citation_by_key(key: &str) -> Option<&'static Citation> {
+    CITATIONS.iter().find(|c| c.key == key)
+}
+
+/// Look up the list of citation keys associated with a topic.
+pub fn topic_keys(topic: &str) -> Option<&'static [&'static str]> {
+    TOPICS
+        .iter()
+        .find(|(t, _)| *t == topic)
+        .map(|(_, keys)| *keys)
+}
+
+/// All known topics.
+pub fn all_topics() -> Vec<&'static str> {
+    TOPICS.iter().map(|(t, _)| *t).collect()
+}
+
+/// All citations.
+pub fn all_citations() -> &'static [Citation] {
+    CITATIONS
+}
+
+/// Try to resolve `term` against the column and finding tables. Falls
+/// back to fuzzy suggestions when neither matches.
+pub fn explain(term: &str) -> Explanation {
+    if let Some(entry) = column(term) {
+        return Explanation::Column {
+            term: term.to_string(),
+            entry: entry.clone(),
+        };
+    }
+    if let Some(entry) = finding(term) {
+        return Explanation::Finding {
+            term: term.to_string(),
+            entry: entry.clone(),
+        };
+    }
+    let mut pool = all_columns();
+    pool.extend(all_findings());
+    Explanation::Unknown {
+        term: term.to_string(),
+        suggestions: fuzzy_suggest(term, &pool, 3),
+        all_columns: all_columns(),
+        all_findings: all_findings(),
+    }
+}
+
+fn fuzzy_suggest(term: &str, candidates: &[&'static str], limit: usize) -> Vec<&'static str> {
+    let needle = term.to_ascii_lowercase();
+    let mut scored: Vec<(u8, &'static str)> = Vec::new();
+    for &c in candidates {
+        let cl = c.to_ascii_lowercase();
+        if cl == needle {
+            scored.push((0, c));
+        } else if cl.starts_with(&needle) || needle.starts_with(&cl) {
+            scored.push((1, c));
+        } else if cl.contains(&needle) || needle.contains(&cl) {
+            scored.push((2, c));
+        }
+    }
+    scored.sort_by_key(|(r, _)| *r);
+    scored.into_iter().take(limit).map(|(_, c)| c).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn column_lookup() {
+        assert!(column("inf_pr").is_some());
+        assert!(column("not_a_real_column").is_none());
+    }
+
+    #[test]
+    fn finding_lookup() {
+        let f = finding("mu_stuck").expect("mu_stuck should exist");
+        assert_eq!(f.severity, "warning");
+    }
+
+    #[test]
+    fn explain_finds_column() {
+        let e = explain("inf_du");
+        assert!(matches!(e, Explanation::Column { .. }));
+    }
+
+    #[test]
+    fn explain_finds_finding() {
+        let e = explain("restoration_loop");
+        assert!(matches!(e, Explanation::Finding { .. }));
+    }
+
+    #[test]
+    fn explain_fuzzy_unknown() {
+        // "inf" is a prefix of several columns — should surface suggestions.
+        let e = explain("inf");
+        match e {
+            Explanation::Unknown { suggestions, .. } => {
+                assert!(
+                    suggestions.iter().any(|s| s.starts_with("inf_")),
+                    "got {suggestions:?}",
+                );
+            }
+            _ => panic!("expected Unknown"),
+        }
+    }
+
+    #[test]
+    fn topic_lookup() {
+        let keys = topic_keys("restoration").expect("restoration topic exists");
+        assert!(keys.contains(&"wachter2006"));
+    }
+
+    #[test]
+    fn citation_lookup() {
+        let c = citation_by_key("wachter2006").expect("wachter2006 cited");
+        assert!(c.title.contains("interior-point filter line-search"));
+    }
+}

--- a/crates/pounce-studio-core/src/lib.rs
+++ b/crates/pounce-studio-core/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 //! Pure-Rust analysis core for pounce-studio.
 //!
 //! Loads `pounce.solve-report/v1` JSON (see
@@ -20,8 +21,10 @@
 //! changes bump the major version and add a new branch here.
 
 pub mod analysis;
+pub mod glossary;
 pub mod iter_dump;
 pub mod markdown;
+pub mod preflight;
 pub mod report;
 
 pub use analysis::{

--- a/crates/pounce-studio-core/src/preflight.rs
+++ b/crates/pounce-studio-core/src/preflight.rs
@@ -1,0 +1,843 @@
+//! Pre-flight problem inspection: builtin metadata, AMPL `.nl` header
+//! parsing, GAMS `.gms` header / Solve-directive parsing, and `.lst`
+//! SOLVE SUMMARY extraction.
+//!
+//! Ported from `studio/mcp/pounce_studio_mcp/server.py`. All entry
+//! points are byte-slice / `&str` based so the module stays WASM-clean.
+
+use serde::Serialize;
+
+// ---- builtin problems ------------------------------------------------
+
+/// Metadata for a CLI `--problem <name>` builtin.
+#[derive(Debug, Clone, Serialize)]
+pub struct BuiltinInfo {
+    pub name: &'static str,
+    pub n_variables: i32,
+    pub n_constraints: i32,
+    pub class: &'static str,
+    pub notes: &'static str,
+}
+
+const BUILTINS: &[BuiltinInfo] = &[
+    BuiltinInfo {
+        name: "quadratic",
+        n_variables: 2,
+        n_constraints: 0,
+        class: "unconstrained quadratic",
+        notes: "Convex QP; trivial — single Newton step from any start.",
+    },
+    BuiltinInfo {
+        name: "rosenbrock",
+        n_variables: 2,
+        n_constraints: 0,
+        class: "unconstrained nonlinear",
+        notes: "Classic non-convex banana valley; tests line search.",
+    },
+    BuiltinInfo {
+        name: "bounded-quadratic",
+        n_variables: 2,
+        n_constraints: 0,
+        class: "bound-constrained quadratic",
+        notes: "Active-set quadratic; exercises bound multipliers.",
+    },
+    BuiltinInfo {
+        name: "eq-quadratic",
+        n_variables: 3,
+        n_constraints: 1,
+        class: "equality-constrained quadratic",
+        notes: "QP with one linear equality; tests KKT factorisation.",
+    },
+    BuiltinInfo {
+        name: "circle",
+        n_variables: 2,
+        n_constraints: 1,
+        class: "equality-constrained nonlinear",
+        notes: "Nonlinear equality; tests restoration entry.",
+    },
+];
+
+/// Look up a builtin by name.
+pub fn builtin(name: &str) -> Option<&'static BuiltinInfo> {
+    BUILTINS.iter().find(|b| b.name == name)
+}
+
+/// All builtin names.
+pub fn all_builtins() -> Vec<&'static BuiltinInfo> {
+    BUILTINS.iter().collect()
+}
+
+// ---- option suggestions ---------------------------------------------
+
+/// One advisory option suggestion. Never auto-applied.
+#[derive(Debug, Clone, Serialize)]
+pub struct Suggestion {
+    pub option: String,
+    pub value: String,
+    pub why: String,
+}
+
+// ---- NL header parsing -----------------------------------------------
+
+/// Dimensions / format detected from an AMPL `.nl` file header.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct NlHeader {
+    pub format: String,
+    pub n_variables: Option<i32>,
+    pub n_constraints: Option<i32>,
+    pub n_objectives: Option<i32>,
+    pub n_ranges: Option<i32>,
+    pub n_equalities: Option<i32>,
+    pub n_nonlinear_constraints: Option<i32>,
+    pub n_nonlinear_objectives: Option<i32>,
+    pub n_nonlinear_vars_in_cons: Option<i32>,
+    pub n_nonlinear_vars_in_obj: Option<i32>,
+    pub n_nonlinear_vars_in_both: Option<i32>,
+    pub nnz_jacobian: Option<i32>,
+    pub nnz_objective_gradient: Option<i32>,
+    pub warnings: Vec<String>,
+}
+
+/// Parse the first ~10 lines of an AMPL `.nl` file. Tolerant — partial
+/// parses still return what we got.
+pub fn parse_nl_header(bytes: &[u8]) -> NlHeader {
+    let text = String::from_utf8_lossy(bytes);
+    let lines: Vec<&str> = text.lines().take(10).collect();
+
+    let mut out = NlHeader::default();
+    if lines.is_empty() || lines[0].is_empty() {
+        out.format = "unknown".into();
+        out.warnings.push("empty .nl file".into());
+        return out;
+    }
+    out.format = match lines[0].as_bytes().first() {
+        Some(b'g') => "text".into(),
+        Some(b'b') => "binary".into(),
+        _ => "unknown".into(),
+    };
+    if out.format == "binary" {
+        out.warnings.push("binary .nl: header parse skipped".into());
+        return out;
+    }
+
+    let ints = |line: &str| -> Vec<i32> {
+        line.split_whitespace()
+            .filter_map(|t| t.parse::<i32>().ok())
+            .collect()
+    };
+
+    if let Some(line) = lines.get(1) {
+        let v = ints(line);
+        if v.len() >= 5 {
+            out.n_variables = Some(v[0]);
+            out.n_constraints = Some(v[1]);
+            out.n_objectives = Some(v[2]);
+            out.n_ranges = Some(v[3]);
+            out.n_equalities = Some(v[4]);
+        } else {
+            out.warnings.push("could not parse dimensions line".into());
+        }
+    }
+    if let Some(line) = lines.get(2) {
+        let v = ints(line);
+        if v.len() >= 2 {
+            out.n_nonlinear_constraints = Some(v[0]);
+            out.n_nonlinear_objectives = Some(v[1]);
+        }
+    }
+    if let Some(line) = lines.get(4) {
+        let v = ints(line);
+        if v.len() >= 3 {
+            out.n_nonlinear_vars_in_cons = Some(v[0]);
+            out.n_nonlinear_vars_in_obj = Some(v[1]);
+            out.n_nonlinear_vars_in_both = Some(v[2]);
+        }
+    }
+    for idx in [6_usize, 7] {
+        if let Some(line) = lines.get(idx) {
+            let v = ints(line);
+            if v.len() == 2 && out.nnz_jacobian.is_none() {
+                out.nnz_jacobian = Some(v[0]);
+                out.nnz_objective_gradient = Some(v[1]);
+                break;
+            }
+        }
+    }
+    out
+}
+
+/// Result of analyzing an NL file or builtin.
+#[derive(Debug, Clone, Serialize)]
+pub struct NlAnalysis {
+    pub kind: String,
+    pub name: Option<String>,
+    pub path: Option<String>,
+    pub dimensions: serde_json::Value,
+    pub class: String,
+    pub notes: Option<String>,
+    pub warnings: Vec<String>,
+    pub suggestions: Vec<Suggestion>,
+}
+
+/// Build an analysis from an NL header.
+pub fn analyze_nl(path: &str, header: NlHeader) -> NlAnalysis {
+    let class = classify_nl(&header);
+    let warnings = nl_warnings(&header);
+    let suggestions = nl_suggestions(&header);
+    NlAnalysis {
+        kind: "nl_file".into(),
+        name: None,
+        path: Some(path.into()),
+        dimensions: serde_json::to_value(&header).unwrap_or(serde_json::Value::Null),
+        class,
+        notes: None,
+        warnings,
+        suggestions,
+    }
+}
+
+/// Build an analysis from a builtin name.
+pub fn analyze_builtin(name: &str) -> Result<NlAnalysis, String> {
+    let b = builtin(name).ok_or_else(|| {
+        let names: Vec<&str> = BUILTINS.iter().map(|b| b.name).collect();
+        format!("unknown builtin {name:?}; valid: {names:?}")
+    })?;
+    let dims = serde_json::json!({
+        "n_variables": b.n_variables,
+        "n_constraints": b.n_constraints,
+    });
+    let header = NlHeader {
+        n_variables: Some(b.n_variables),
+        n_constraints: Some(b.n_constraints),
+        ..Default::default()
+    };
+    Ok(NlAnalysis {
+        kind: "builtin".into(),
+        name: Some(b.name.into()),
+        path: None,
+        dimensions: dims,
+        class: b.class.into(),
+        notes: Some(b.notes.into()),
+        warnings: nl_warnings(&header),
+        suggestions: nl_suggestions(&header),
+    })
+}
+
+fn classify_nl(h: &NlHeader) -> String {
+    let n_con = h.n_constraints.unwrap_or(0);
+    let nlc = h.n_nonlinear_constraints.unwrap_or(0);
+    let nlo = h.n_nonlinear_objectives.unwrap_or(0);
+    let n_eq = h.n_equalities.unwrap_or(0);
+    let is_nl = nlc > 0 || nlo > 0;
+    if n_con == 0 {
+        return if is_nl {
+            "unconstrained nonlinear".into()
+        } else {
+            "unconstrained linear/quadratic".into()
+        };
+    }
+    let nl_or_lin = if is_nl {
+        "nonlinear"
+    } else {
+        "linear/quadratic"
+    };
+    let eq_or_gen = if n_eq == n_con {
+        "equality-constrained"
+    } else {
+        "general-constrained"
+    };
+    format!("{nl_or_lin} {eq_or_gen}")
+}
+
+fn nl_warnings(h: &NlHeader) -> Vec<String> {
+    let mut out = h.warnings.clone();
+    let n_var = h.n_variables.unwrap_or(0);
+    let n_con = h.n_constraints.unwrap_or(0);
+    if n_var == 0 {
+        out.push("zero variables parsed — header read may have failed".into());
+    }
+    if (n_var + n_con) > 50_000 {
+        out.push(format!(
+            "very large problem ({n_var} vars, {n_con} cons); expect long solve times \
+             and consider running with `--dump` for diagnostics.",
+        ));
+    }
+    if h.n_objectives == Some(0) {
+        out.push("no objective: this is a feasibility problem, not optimisation.".into());
+    }
+    out
+}
+
+fn nl_suggestions(h: &NlHeader) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+    let n_var = h.n_variables.unwrap_or(0);
+    let n_con = h.n_constraints.unwrap_or(0);
+    let nlc = h.n_nonlinear_constraints.unwrap_or(0);
+    let nlo = h.n_nonlinear_objectives.unwrap_or(0);
+    let n_eq = h.n_equalities.unwrap_or(0);
+    let size = n_var + n_con;
+
+    if size > 5_000 {
+        out.push(Suggestion {
+            option: "linear_solver".into(),
+            value: "ma57".into(),
+            why: format!(
+                "problem is medium/large ({n_var} vars, {n_con} cons); MA57 is much \
+                 faster than FERAL at this scale. Requires the build to have been \
+                 compiled with `--features ma57`.",
+            ),
+        });
+    }
+    if size > 1_000 && nlc == 0 && nlo == 0 {
+        out.push(Suggestion {
+            option: "mu_strategy".into(),
+            value: "adaptive".into(),
+            why: "purely linear/quadratic — adaptive mu usually converges in fewer iters.".into(),
+        });
+    }
+    if size > 10_000 {
+        out.push(Suggestion {
+            option: "max_iter".into(),
+            value: "1000".into(),
+            why: "default 3000 is fine but raise tol expectations for large problems.".into(),
+        });
+    }
+    if nlc > 0 && n_eq == n_con && n_con > 0 {
+        out.push(Suggestion {
+            option: "bound_relax_factor".into(),
+            value: "0".into(),
+            why: "all constraints equality + nonlinear: relaxing bounds can blur the feasible \
+                  manifold; setting to 0 keeps it sharp."
+                .into(),
+        });
+    }
+    out
+}
+
+// ---- GAMS .gms header parsing ---------------------------------------
+
+/// Dimensions parsed from a `gams convert`-emitted `.gms` header.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct GmsHeader {
+    pub n_equations_total: Option<i32>,
+    pub n_equality_eqs: Option<i32>,
+    pub n_ge_eqs: Option<i32>,
+    pub n_le_eqs: Option<i32>,
+    pub n_variables_total: Option<i32>,
+    pub n_continuous_vars: Option<i32>,
+    pub n_binary_vars: Option<i32>,
+    pub n_integer_vars: Option<i32>,
+    pub nnz_total: Option<i32>,
+    pub nnz_constant: Option<i32>,
+    pub nnz_nonlinear: Option<i32>,
+}
+
+/// Parse the comment block emitted by `gams convert`. Lines look like:
+///
+/// ```text
+/// *  Equation counts
+/// *     Total       E       G       L       N       X
+/// *       109     108       0       1       0       0
+/// ```
+pub fn parse_gms_convert_header(text: &str) -> GmsHeader {
+    let mut out = GmsHeader::default();
+    let star_lines: Vec<&str> = text.lines().filter(|l| l.starts_with('*')).collect();
+
+    fn next_int_line<'a>(lines: &'a [&'a str], start: usize) -> Option<Vec<i32>> {
+        let end = (start + 5).min(lines.len());
+        for line in lines.iter().take(end).skip(start + 1) {
+            let nums: Vec<i32> = line
+                .trim_start_matches('*')
+                .split_whitespace()
+                .filter_map(|t| t.parse::<i32>().ok())
+                .collect();
+            if !nums.is_empty() {
+                return Some(nums);
+            }
+        }
+        None
+    }
+
+    for (i, line) in star_lines.iter().enumerate() {
+        if line.contains("Equation counts") {
+            if let Some(nums) = next_int_line(&star_lines, i) {
+                if !nums.is_empty() {
+                    out.n_equations_total = Some(nums[0]);
+                }
+                if nums.len() >= 2 {
+                    out.n_equality_eqs = Some(nums[1]);
+                }
+                if nums.len() >= 3 {
+                    out.n_ge_eqs = Some(nums[2]);
+                }
+                if nums.len() >= 4 {
+                    out.n_le_eqs = Some(nums[3]);
+                }
+            }
+        } else if line.contains("Variable counts") {
+            if let Some(nums) = next_int_line(&star_lines, i) {
+                if !nums.is_empty() {
+                    out.n_variables_total = Some(nums[0]);
+                }
+                if nums.len() >= 2 {
+                    out.n_continuous_vars = Some(nums[1]);
+                }
+                if nums.len() >= 3 {
+                    out.n_binary_vars = Some(nums[2]);
+                }
+                if nums.len() >= 4 {
+                    out.n_integer_vars = Some(nums[3]);
+                }
+            }
+        } else if line.contains("Nonzero counts") {
+            if let Some(nums) = next_int_line(&star_lines, i) {
+                if !nums.is_empty() {
+                    out.nnz_total = Some(nums[0]);
+                }
+                if nums.len() >= 2 {
+                    out.nnz_constant = Some(nums[1]);
+                }
+                if nums.len() >= 3 {
+                    out.nnz_nonlinear = Some(nums[2]);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Parsed `Solve <model> using <TYPE> [minimizing|maximizing] <objvar>;` line.
+#[derive(Debug, Clone, Serialize)]
+pub struct GmsSolveDirective {
+    pub model_name: String,
+    pub model_type: String,
+    pub direction: Option<String>,
+    pub objective_var: Option<String>,
+}
+
+/// Hand-rolled parser for the `Solve` directive. Case-insensitive,
+/// scans all lines for the first match.
+pub fn parse_gms_solve_directive(text: &str) -> Option<GmsSolveDirective> {
+    for line in text.lines() {
+        let lc = line.to_ascii_lowercase();
+        let trimmed = lc.trim_start();
+        if !trimmed.starts_with("solve") {
+            continue;
+        }
+        let tokens: Vec<&str> = line.split_whitespace().collect();
+        if tokens.len() < 4 {
+            continue;
+        }
+        // First token: "Solve" (matches case-insensitively).
+        if !tokens[0].eq_ignore_ascii_case("solve") {
+            continue;
+        }
+        let model_name = tokens[1]
+            .trim_end_matches(',')
+            .trim_end_matches(';')
+            .to_string();
+        // Expect "using" at tokens[2].
+        if !tokens[2].eq_ignore_ascii_case("using") {
+            continue;
+        }
+        let model_type = tokens[3]
+            .trim_end_matches(',')
+            .trim_end_matches(';')
+            .to_ascii_uppercase();
+
+        let mut direction: Option<String> = None;
+        let mut objective_var: Option<String> = None;
+        if tokens.len() >= 6 {
+            let d = tokens[4].to_ascii_lowercase();
+            if d == "minimizing" || d == "maximizing" {
+                direction = Some(d);
+                // Strip trailing `;` from objective var.
+                let mut v = tokens[5].to_string();
+                if let Some(s) = v.strip_suffix(';') {
+                    v = s.to_string();
+                }
+                objective_var = Some(v);
+            }
+        }
+        return Some(GmsSolveDirective {
+            model_name,
+            model_type,
+            direction,
+            objective_var,
+        });
+    }
+    None
+}
+
+/// Result of analyzing a `.gms` file.
+#[derive(Debug, Clone, Serialize)]
+pub struct GmsAnalysis {
+    pub path: String,
+    pub dimensions: GmsHeader,
+    pub solve_directive: Option<GmsSolveDirective>,
+    pub class: String,
+    pub supported_by_pounce: Option<bool>,
+    pub suggestions: Vec<Suggestion>,
+    pub warnings: Vec<String>,
+}
+
+pub fn analyze_gms(path: &str, text: &str) -> GmsAnalysis {
+    let dims = parse_gms_convert_header(text);
+    let solve = parse_gms_solve_directive(text);
+    let model_type = solve.as_ref().map(|s| s.model_type.as_str());
+
+    let mut warnings = Vec::new();
+    if dims.n_variables_total.is_none() && dims.n_equations_total.is_none() {
+        warnings.push(
+            "no `gams convert` header found — dimensions could not be parsed. \
+             POUNCE will still solve the model; the suggestion list is conservative."
+                .into(),
+        );
+    }
+    if solve.is_none() {
+        warnings.push("no `Solve` directive found in file — is this a complete model?".into());
+    }
+    if let Some(mt @ ("MINLP" | "MIP")) = model_type {
+        warnings.push(format!(
+            "model type {mt} is not supported by POUNCE (integer variables present).",
+        ));
+    }
+    if dims.n_binary_vars.unwrap_or(0) > 0 || dims.n_integer_vars.unwrap_or(0) > 0 {
+        warnings.push(
+            "discrete variables present; POUNCE solves the continuous relaxation only.".into(),
+        );
+    }
+
+    let supported = model_type.map(|t| matches!(t, "NLP" | "DNLP" | "RMINLP"));
+    GmsAnalysis {
+        path: path.into(),
+        class: classify_gms(model_type, &dims),
+        suggestions: suggest_gms(&dims, model_type),
+        solve_directive: solve,
+        dimensions: dims,
+        supported_by_pounce: supported,
+        warnings,
+    }
+}
+
+fn classify_gms(model_type: Option<&str>, dims: &GmsHeader) -> String {
+    let Some(mt) = model_type else {
+        return "unknown".into();
+    };
+    let base = match mt {
+        "NLP" => "nonlinear program (continuous)",
+        "DNLP" => "non-differentiable NLP",
+        "RMINLP" => "relaxed mixed-integer NLP",
+        "MINLP" => "mixed-integer NLP",
+        "LP" => "linear program",
+        "MIP" => "mixed-integer linear",
+        "QCP" => "quadratically constrained program",
+        "CNS" => "constrained nonlinear system",
+        _ => return format!("{mt} model"),
+    };
+    if matches!(mt, "NLP" | "DNLP") && dims.nnz_nonlinear == Some(0) {
+        format!("{base} (linear in nonzero pattern — should solve trivially)")
+    } else {
+        base.to_string()
+    }
+}
+
+fn suggest_gms(dims: &GmsHeader, model_type: Option<&str>) -> Vec<Suggestion> {
+    let mut out = Vec::new();
+    let n_var = dims.n_variables_total.unwrap_or(0);
+    let n_eq = dims.n_equations_total.unwrap_or(0);
+    let nnl = dims.nnz_nonlinear.unwrap_or(0);
+    let nnz_total = dims.nnz_total.unwrap_or(1);
+    let size = n_var + n_eq;
+
+    if let Some(mt @ ("MINLP" | "MIP")) = model_type {
+        out.push(Suggestion {
+            option: "(none)".into(),
+            value: "".into(),
+            why: format!(
+                "model type is {mt}; POUNCE handles only NLP/DNLP/RMINLP. Either relax \
+                 the integrality (RMINLP) or pick a different solver.",
+            ),
+        });
+        return out;
+    }
+
+    out.push(Suggestion {
+        option: "mu_strategy".into(),
+        value: "adaptive".into(),
+        why: "matches GAMS-IPOPT's effective default (optipopt.def). pounce's compile-time \
+              default is `monotone`, which stalls some hard NLPs."
+            .into(),
+    });
+    if size > 5_000 {
+        out.push(Suggestion {
+            option: "linear_solver".into(),
+            value: "ma57".into(),
+            why: format!(
+                "problem is medium/large ({n_var} vars, {n_eq} eqs); MA57 is much faster \
+                 than FERAL at this scale. Requires --features ma57 build.",
+            ),
+        });
+    }
+    if nnl > 0 && (nnl as f64) > 0.5 * (nnz_total as f64) {
+        out.push(Suggestion {
+            option: "tol".into(),
+            value: "1e-6".into(),
+            why: "heavily nonlinear pattern: tightening below 1e-6 often leads to dual \
+                  stagnation on degenerate KKT systems."
+                .into(),
+        });
+    }
+    out
+}
+
+// ---- GAMS .lst SOLVE SUMMARY parsing --------------------------------
+
+/// Parsed fields from a GAMS listing's `S O L V E   S U M M A R Y` block.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct LstSummary {
+    pub model: Option<String>,
+    pub objective_var: Option<String>,
+    pub solver: Option<String>,
+    pub from_line: Option<i32>,
+    pub solver_status_code: Option<i32>,
+    pub solver_status: Option<String>,
+    pub model_status_code: Option<i32>,
+    pub model_status: Option<String>,
+    pub objective_value: Option<serde_json::Value>,
+    pub resource_used_secs: Option<serde_json::Value>,
+    pub resource_limit_secs: Option<f64>,
+    pub iteration_count: Option<serde_json::Value>,
+    pub iteration_limit: Option<i32>,
+    pub evaluation_errors: Option<serde_json::Value>,
+    pub solver_status_file: Option<String>,
+}
+
+/// Parse a GAMS `.lst` listing. Tolerant: missing fields stay None.
+pub fn parse_lst_summary(text: &str) -> LstSummary {
+    let mut out = LstSummary::default();
+
+    for line in text.lines() {
+        let trimmed = line.trim_start();
+        // MODEL <name>  ... OBJECTIVE <var>
+        if let Some(rest) = trimmed.strip_prefix_ignore_ascii_case_re("MODEL") {
+            // Look for "MODEL <name> ... OBJECTIVE <var>"
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if !toks.is_empty() {
+                out.model.get_or_insert(toks[0].to_string());
+            }
+            if let Some(idx) = toks
+                .iter()
+                .position(|t| t.eq_ignore_ascii_case("OBJECTIVE"))
+            {
+                if let Some(v) = toks.get(idx + 1) {
+                    out.objective_var.get_or_insert(v.to_string());
+                }
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix_ignore_ascii_case_re("SOLVER") {
+            // "SOLVER <name> FROM LINE <n>"
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if !toks.is_empty() && out.solver.is_none() {
+                out.solver = Some(toks[0].to_string());
+            }
+            if let Some(idx) = toks.iter().position(|t| t.eq_ignore_ascii_case("LINE")) {
+                if let Some(v) = toks.get(idx + 1) {
+                    if let Ok(n) = v.parse::<i32>() {
+                        out.from_line.get_or_insert(n);
+                    }
+                }
+            }
+        }
+        // **** SOLVER STATUS  N  <text>
+        if let Some(rest) = line.strip_prefix("**** SOLVER STATUS") {
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if let Some(code) = toks.first().and_then(|s| s.parse::<i32>().ok()) {
+                out.solver_status_code = Some(code);
+                if toks.len() > 1 {
+                    out.solver_status = Some(toks[1..].join(" "));
+                }
+            }
+        }
+        if let Some(rest) = line.strip_prefix("**** MODEL STATUS") {
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if let Some(code) = toks.first().and_then(|s| s.parse::<i32>().ok()) {
+                out.model_status_code = Some(code);
+                if toks.len() > 1 {
+                    out.model_status = Some(toks[1..].join(" "));
+                }
+            }
+        }
+        if let Some(rest) = line.strip_prefix("**** OBJECTIVE VALUE") {
+            if let Some(v) = rest.split_whitespace().next() {
+                let val = v
+                    .parse::<f64>()
+                    .map(serde_json::Value::from)
+                    .unwrap_or_else(|_| serde_json::Value::String(v.into()));
+                out.objective_value = Some(val);
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix_ignore_ascii_case_re("RESOURCE USAGE, LIMIT") {
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if let Some(v) = toks.first() {
+                let val = v
+                    .parse::<f64>()
+                    .map(serde_json::Value::from)
+                    .unwrap_or_else(|_| serde_json::Value::String((*v).to_string()));
+                out.resource_used_secs = Some(val);
+            }
+            if let Some(v) = toks.get(1) {
+                if let Ok(n) = v.parse::<f64>() {
+                    out.resource_limit_secs.get_or_insert(n);
+                }
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix_ignore_ascii_case_re("ITERATION COUNT, LIMIT") {
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if let Some(v) = toks.first() {
+                let val = v
+                    .parse::<i64>()
+                    .map(serde_json::Value::from)
+                    .unwrap_or_else(|_| serde_json::Value::String((*v).to_string()));
+                out.iteration_count = Some(val);
+            }
+            if let Some(v) = toks.get(1) {
+                if let Ok(n) = v.parse::<i32>() {
+                    out.iteration_limit.get_or_insert(n);
+                }
+            }
+        }
+        if let Some(rest) = trimmed.strip_prefix_ignore_ascii_case_re("EVALUATION ERRORS") {
+            let toks: Vec<&str> = rest.split_whitespace().collect();
+            if let Some(v) = toks.first() {
+                let val = v
+                    .parse::<i64>()
+                    .map(serde_json::Value::from)
+                    .unwrap_or_else(|_| serde_json::Value::String((*v).to_string()));
+                out.evaluation_errors = Some(val);
+            }
+        }
+    }
+
+    // Embedded solver-status block. Two formats:
+    //   (a) `=C ...` between SOLVER STATUS FILE LISTED BELOW / ABOVE
+    //   (b) lines after `--- POUNCE` and before `---- ` / `EXECUTION TIME`
+    let mut block: Vec<String> = Vec::new();
+    let mut in_block = false;
+    for line in text.lines() {
+        if line.contains("SOLVER STATUS FILE LISTED BELOW") {
+            in_block = true;
+            continue;
+        }
+        if line.contains("SOLVER STATUS FILE LISTED ABOVE") {
+            in_block = false;
+            continue;
+        }
+        if in_block && line.starts_with("=C") {
+            block.push(line[2..].trim_end().to_string());
+        }
+    }
+    if block.is_empty() {
+        let mut capturing = false;
+        for line in text.lines() {
+            if !capturing && line.starts_with("--- POUNCE") {
+                capturing = true;
+            }
+            if capturing {
+                if line.starts_with("---- ") || line.starts_with("EXECUTION TIME") {
+                    break;
+                }
+                block.push(line.trim_end().to_string());
+            }
+        }
+    }
+    if !block.is_empty() {
+        out.solver_status_file = Some(block.join("\n").trim_end().to_string());
+    }
+
+    out
+}
+
+trait StripPrefixCi {
+    fn strip_prefix_ignore_ascii_case_re<'a>(&'a self, prefix: &str) -> Option<&'a str>;
+}
+
+impl StripPrefixCi for str {
+    fn strip_prefix_ignore_ascii_case_re<'a>(&'a self, prefix: &str) -> Option<&'a str> {
+        if self.len() < prefix.len() {
+            return None;
+        }
+        let (head, tail) = self.split_at(prefix.len());
+        if head.eq_ignore_ascii_case(prefix) {
+            Some(tail)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nl_header_basic() {
+        let bytes = b"g3 1 1 0  # problem foo\n 5 3 1 0 2  # vars cons obj range eq\n 1 1  # nlc nlo\nplaceholder\n 2 1 0  # nlvc nlvo nlvb\n";
+        let h = parse_nl_header(bytes);
+        assert_eq!(h.format, "text");
+        assert_eq!(h.n_variables, Some(5));
+        assert_eq!(h.n_constraints, Some(3));
+        assert_eq!(h.n_nonlinear_constraints, Some(1));
+    }
+
+    #[test]
+    fn nl_header_empty_file() {
+        let h = parse_nl_header(b"");
+        assert_eq!(h.format, "unknown");
+        assert!(h.warnings.iter().any(|w| w.contains("empty")));
+    }
+
+    #[test]
+    fn nl_header_binary_short_circuits() {
+        let h = parse_nl_header(b"b3 1 1 0\nignored\n");
+        assert_eq!(h.format, "binary");
+    }
+
+    #[test]
+    fn gms_solve_directive_simple() {
+        let text = "Variables x, z;\nEquation foo;\n\nSolve mymodel using NLP minimizing z;\n";
+        let d = parse_gms_solve_directive(text).expect("should parse");
+        assert_eq!(d.model_name, "mymodel");
+        assert_eq!(d.model_type, "NLP");
+        assert_eq!(d.direction.as_deref(), Some("minimizing"));
+        assert_eq!(d.objective_var.as_deref(), Some("z"));
+    }
+
+    #[test]
+    fn gms_solve_directive_lower_case() {
+        let text = "solve hs071 using nlp minimizing obj ;\n";
+        let d = parse_gms_solve_directive(text).expect("should parse");
+        assert_eq!(d.model_type, "NLP");
+        assert_eq!(d.direction.as_deref(), Some("minimizing"));
+    }
+
+    #[test]
+    fn gms_convert_header_counts() {
+        let text = "* Equation counts\n*    Total       E       G       L       N       X\n*       10       8       1       1       0       0\n* Variable counts\n*    Total    cont  binary integer    sos1    sos2   scont    sint\n*       12      11       0       1       0       0       0       0\n* Nonzero counts\n*    Total   const      NL     DLL\n*       30      20      10       0\n";
+        let h = parse_gms_convert_header(text);
+        assert_eq!(h.n_equations_total, Some(10));
+        assert_eq!(h.n_equality_eqs, Some(8));
+        assert_eq!(h.n_variables_total, Some(12));
+        assert_eq!(h.n_integer_vars, Some(1));
+        assert_eq!(h.nnz_nonlinear, Some(10));
+    }
+
+    #[test]
+    fn lst_summary_parses_status() {
+        let text = "                MODEL   m       OBJECTIVE  z\n                SOLVER  POUNCE  FROM LINE  10\n**** SOLVER STATUS     1 Normal Completion\n**** MODEL STATUS      2 Locally Optimal\n**** OBJECTIVE VALUE  3.14159\n RESOURCE USAGE, LIMIT  0.123  1000.000\n ITERATION COUNT, LIMIT  42  5000\n EVALUATION ERRORS  0  0\n";
+        let s = parse_lst_summary(text);
+        assert_eq!(s.solver_status_code, Some(1));
+        assert_eq!(s.model_status_code, Some(2));
+        assert_eq!(s.iteration_limit, Some(5000));
+    }
+}

--- a/studio/mcp/README.md
+++ b/studio/mcp/README.md
@@ -5,6 +5,13 @@ MCP client (Claude Code, Claude Desktop, Cursor, Zed, ...) load a
 `pounce.solve-report/v1` JSON file and ask questions about convergence,
 restoration, stalls, and per-iteration state.
 
+> **Lighter-weight alternative:** [`studio/skill/`](../skill/) ships the
+> same analysis surface as a Claude skill that drives the `pounce-studio`
+> CLI directly — no Python venv, no MCP registration, one-line install
+> via `make install-skill`. Use the MCP server if you want structured
+> tool-call UI or are driving a non-Claude MCP client; use the skill if
+> you just want it to work everywhere with the minimum setup.
+
 ## Status
 
 Phase 0. Post-mortem analysis of solve-report JSON and POUNCEIT v1

--- a/studio/skill/README.md
+++ b/studio/skill/README.md
@@ -33,9 +33,26 @@ mkdir -p ~/.claude/skills
 cp -r studio/skill ~/.claude/skills/pounce
 ```
 
-That's it. The skill works in every Claude Code session — desktop,
-web, IDE extension, the CLI — because skills travel with the
-configuration rather than running as a separate process.
+The `pounce-studio` install needs nothing extra. The `pounce` install
+inherits the workspace's current requirement that the [`feral`][feral]
+crate be available as a sibling checkout (`../feral`), because
+`Cargo.toml` carries a `[patch.crates-io] feral = { path = "../feral" }`
+override. Either clone the sibling first
+
+```sh
+git clone --depth 1 https://github.com/jkitchin/feral.git ../feral
+```
+
+or skip the `pounce` install and reuse a `pounce` binary you have
+elsewhere on `PATH` (the skill only invokes `pounce-studio` directly;
+`pounce` is needed only when you want to drive a fresh solve from
+within the skill).
+
+The skill works in every Claude Code session — desktop, web, IDE
+extension, the CLI — because skills travel with the configuration
+rather than running as a separate process.
+
+[feral]: https://github.com/jkitchin/feral
 
 ## What the skill exposes
 

--- a/studio/skill/README.md
+++ b/studio/skill/README.md
@@ -1,0 +1,74 @@
+# pounce-studio skill
+
+Claude-skill alternative to the `pounce-studio-mcp` MCP server. Same
+analysis surface, but the tool is invoked by Claude via the
+`pounce-studio` CLI rather than via the Model Context Protocol — no
+MCP server, no Python venv, no `claude mcp add` registration, no
+restart.
+
+## Install
+
+The full one-shot recipe (build both binaries + install the skill):
+
+```sh
+make install-skill
+```
+
+This:
+1. Builds `pounce-studio` and `pounce` in `target/release/`.
+2. Copies both binaries into `~/.local/bin/` (override with `PREFIX=...`).
+3. Drops this directory at `~/.claude/skills/pounce/` (override with
+   `SKILL_DIR=...`).
+
+After install, in a fresh Claude Code session, ask "diagnose
+`/path/to/report.json`" — Claude will load this skill, invoke the CLI,
+and answer.
+
+Manual install — for users who don't want to use `make`:
+
+```sh
+cargo install --path crates/pounce-studio-core --bin pounce-studio --locked
+cargo install --path crates/pounce-cli --bin pounce --locked
+mkdir -p ~/.claude/skills
+cp -r studio/skill ~/.claude/skills/pounce
+```
+
+That's it. The skill works in every Claude Code session — desktop,
+web, IDE extension, the CLI — because skills travel with the
+configuration rather than running as a separate process.
+
+## What the skill exposes
+
+See [`SKILL.md`](SKILL.md). All `pounce-studio-mcp` tools have a
+corresponding `pounce-studio` subcommand:
+
+| MCP tool                   | CLI subcommand                              |
+|----------------------------|---------------------------------------------|
+| `load_solve_report`        | `pounce-studio summary <report>`            |
+| `diagnose`                 | `pounce-studio diagnose <report>`           |
+| `find_stalls`              | `pounce-studio find-stalls <report>`        |
+| `convergence_trace`        | `pounce-studio convergence-trace <report>`  |
+| `get_iterate`              | `pounce-studio get-iterate <report> <k>`    |
+| `restoration_windows`      | `pounce-studio restoration-windows <report>`|
+| `compare_runs`             | `pounce-studio compare <r1> <r2> ...`       |
+| `linear_solver_summary`    | `pounce-studio linear-solver-summary <r>`   |
+| `explain`                  | `pounce-studio explain <term>`              |
+| `citations`                | `pounce-studio citations [--topic | --key]` |
+| `analyze_problem` (nl)     | `pounce-studio analyze-nl <path \| --builtin>` |
+| `analyze_gams_problem`     | `pounce-studio analyze-gms <path>`          |
+| `parse_gams_listing`       | `pounce-studio parse-gams-listing <lst>`    |
+| `list_gams_examples`       | `pounce-studio list-gams [--suite ...]`     |
+| `run_problem`              | encoded as a skill recipe — chain `pounce` + `pounce-studio summary` |
+| `run_gams_problem`         | encoded as a skill recipe — chain `gams ... NLP=POUNCE` + `pounce-studio parse-gams-listing` |
+
+## When to use which backend
+
+- **Skill (this)** — preferred default. Single CLI on PATH, no
+  background server, works in every Claude session including
+  remote/web. Setup is one `make` target.
+- **MCP server** (`studio/mcp/`) — keep if you prefer structured
+  tool-call args in the Claude UI, or if you want to drive it from a
+  non-Claude MCP client (Cursor, Zed, Continue).
+
+Both paths can coexist on the same machine. They share the Rust
+analysis core (`crates/pounce-studio-core`) so findings agree.

--- a/studio/skill/SKILL.md
+++ b/studio/skill/SKILL.md
@@ -22,8 +22,9 @@ Use this skill when the user asks any of:
 ## Tools at your disposal
 
 All output is pretty-printed JSON on stdout — pipe through `jq` to
-slice. Set `POUNCE_BIN` to an absolute path to override binary
-discovery if `pounce-studio` is not on PATH.
+slice. If `pounce-studio` is not on `PATH`, invoke it via its absolute
+path (e.g. `~/.cargo/bin/pounce-studio` or `~/.local/bin/pounce-studio`,
+depending on how it was installed).
 
 ### Post-mortem on a JSON solve report
 
@@ -39,7 +40,8 @@ pounce-studio restoration-windows <report>    # restoration entry→exit cycles
 pounce-studio compare <r1> <r2> ...           # side-by-side
     [--labels A,B,C]
 pounce-studio linear-solver-summary <report>  # FERAL post-mortem
-pounce-studio inspect <report>                # Markdown summary (no JSON)
+pounce-studio inspect <report> [--json]       # Markdown summary by default;
+                                              # --json dumps the whole report
 ```
 
 The report must be at JSON detail `full` for the iter-level tools
@@ -228,7 +230,7 @@ The JSON file is not a `pounce.solve-report/v1` document — perhaps an
 AMPL `.sol`, a different solver's output, or a hand-written file.
 Re-run the solve with `--json-output <path>`.
 
-**`load_solve_report works but convergence-trace is empty`**
+**`summary` works but `convergence-trace` returns empty arrays**
 The report was written at `--json-detail summary`. Re-run the solve
 with `--json-detail full`.
 

--- a/studio/skill/SKILL.md
+++ b/studio/skill/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: pounce
+description: Inspect and diagnose pounce solve reports via the pounce-studio CLI. Use when the user asks to analyze a pounce.solve-report JSON, diagnose a stuck or non-converging solve, compare two runs, look up a per-iteration column or finding code, or pre-flight an AMPL .nl or GAMS .gms file before solving.
+---
+
+# pounce — solver post-mortem and pre-flight
+
+This skill wraps the `pounce-studio` CLI for AI-assisted post-mortem of
+pounce solve reports plus pre-flight inspection of `.nl` and `.gms`
+input files. It is the CLI-and-skill counterpart to the
+`pounce-studio-mcp` MCP server (in `studio/mcp/`); both backends
+ultimately call the same Rust analysis core, so findings agree.
+
+Use this skill when the user asks any of:
+- "diagnose this solve report"
+- "did pounce converge?"
+- "compare these two runs"
+- "what does `inf_pr` mean?"
+- "is this .nl file going to be a problem?"
+- "what happened in iteration 47?"
+
+## Tools at your disposal
+
+All output is pretty-printed JSON on stdout — pipe through `jq` to
+slice. Set `POUNCE_BIN` to an absolute path to override binary
+discovery if `pounce-studio` is not on PATH.
+
+### Post-mortem on a JSON solve report
+
+```sh
+pounce-studio summary <report>                # headline outcome
+pounce-studio diagnose <report>               # failure-mode heuristics
+pounce-studio find-stalls <report>            # stalled-progress windows
+    [--min-window N] [--max-progress P]
+pounce-studio convergence-trace <report>      # per-iter trajectory
+    [--columns iter,inf_pr,inf_du,mu,d_norm,...]
+pounce-studio get-iterate <report> <k>        # full iter k record
+pounce-studio restoration-windows <report>    # restoration entry→exit cycles
+pounce-studio compare <r1> <r2> ...           # side-by-side
+    [--labels A,B,C]
+pounce-studio linear-solver-summary <report>  # FERAL post-mortem
+pounce-studio inspect <report>                # Markdown summary (no JSON)
+```
+
+The report must be at JSON detail `full` for the iter-level tools
+(`convergence-trace`, `get-iterate`, `find-stalls`, `restoration-windows`).
+The `summary` and `diagnose` tools work on either detail level.
+
+### Glossary
+
+```sh
+pounce-studio explain <term>                  # column or finding code
+pounce-studio citations [--topic T] [--key K] # curated papers
+```
+
+Known column names: `iter`, `objective`, `inf_pr`, `inf_du`, `mu`,
+`d_norm`, `regularization`, `alpha_dual`, `alpha_primal`,
+`alpha_primal_char`, `ls_trials`, `log10_*`, plus the linear-solver
+summary fields (`n_factors`, `n_pattern_reuse`, `max_fill_ratio`, …).
+
+Known finding codes: `converged`, `max_iter_exceeded`,
+`restoration_used`, `restoration_loop`, `mu_stuck`,
+`heavy_line_search`, `hessian_regularized`, `convergence_stall`.
+
+### Pre-flight on an input file
+
+```sh
+pounce-studio analyze-nl <path.nl>            # AMPL .nl header
+pounce-studio analyze-nl --builtin <name>     # builtin problem metadata
+pounce-studio analyze-gms <path.gms>          # GAMS .gms header + suggestions
+pounce-studio parse-gams-listing <path.lst>   # GAMS .lst SOLVE SUMMARY
+pounce-studio list-gams [--suite S]           # bundled .gms instances
+pounce-studio list-builtins                   # builtin --problem options
+```
+
+The suggestion blocks are **advisory** — they are never auto-applied.
+Decide based on the user's intent whether to pass any of them to a
+fresh solve.
+
+## Running a fresh solve
+
+`pounce-studio` does the analysis; the `pounce` CLI does the solve.
+The skill's job is to chain them.
+
+### From a builtin or `.nl` file
+
+```sh
+pounce --problem rosenbrock \
+    --json-output /tmp/report.json --json-detail full \
+    max_iter=500 mu_strategy=adaptive
+
+# or
+pounce path/to/model.nl \
+    --json-output /tmp/report.json --json-detail full \
+    tol=1e-7
+```
+
+CLI option key=value pairs go at the end (the same format as upstream
+ipopt). `--json-detail full` is required for per-iter tools.
+
+After the solve, immediately diagnose:
+
+```sh
+pounce-studio summary /tmp/report.json
+pounce-studio diagnose /tmp/report.json
+```
+
+If `diagnose` reports `convergence_stall` or `mu_stuck`, drill in:
+
+```sh
+pounce-studio find-stalls /tmp/report.json
+# pick a midpoint iter K from the window
+pounce-studio get-iterate /tmp/report.json <K>
+```
+
+### Through GAMS
+
+When the user has a `.gms` file and the `gams` CLI installed (`gams`
+must be on PATH or set `GAMS_BIN`), drive it like so:
+
+```sh
+cd /a/working/dir
+cp /path/to/model.gms .
+
+cat > pounce.opt <<EOF
+print_level 0
+mu_strategy adaptive
+tol 1e-6
+json_output $(pwd)/model.report.json
+json_detail full
+EOF
+
+gams model.gms NLP=POUNCE optfile=1 lo=2
+```
+
+GAMS writes a listing file `model.lst` and a log `model.log`. To
+extract the SOLVE SUMMARY block:
+
+```sh
+pounce-studio parse-gams-listing model.lst
+pounce-studio summary model.report.json
+pounce-studio diagnose model.report.json
+```
+
+Pre-flight the `.gms` first if the user wants option suggestions:
+
+```sh
+pounce-studio analyze-gms model.gms
+```
+
+## Workflow recipes
+
+### "Did this solve work?"
+
+```sh
+pounce-studio summary /path/to/report.json
+```
+
+The `status` field (`SolveSucceeded`, `MaximumIterationsExceeded`, …)
+and `final_kkt_error` tell you. If the status is not
+`SolveSucceeded`, follow up with `diagnose`.
+
+### "Why is this solve stuck?"
+
+```sh
+pounce-studio diagnose /path/to/report.json
+```
+
+The findings carry codes the user can ask you to explain via
+`pounce-studio explain <code>`. Walk through them in severity order
+(`error` → `warning` → `info`).
+
+### "Compare these runs"
+
+```sh
+pounce-studio compare --labels baseline,adaptive a.json b.json
+```
+
+Returns one row per report with status, iter count, objective, KKT
+error, restoration calls, elapsed seconds.
+
+### "What does this column mean?"
+
+```sh
+pounce-studio explain inf_pr
+pounce-studio explain alpha_primal_char
+```
+
+Returns a definition, typical numeric range, what abnormal values
+mean, and `see_also` citation keys.
+
+### "Cite this for me"
+
+```sh
+pounce-studio citations --topic interior_point
+pounce-studio citations --key wachter2006
+pounce-studio citations                       # list all topics + keys
+```
+
+## Notes on JSON detail levels
+
+- `--json-detail summary` (default for `pounce`): writes outcome,
+  statistics, no per-iter history. Compatible with `summary`,
+  `diagnose`, `linear-solver-summary`, and `compare`. The iter-level
+  tools (`convergence-trace`, `get-iterate`, `find-stalls`,
+  `restoration-windows`) return empty arrays / errors.
+- `--json-detail full`: adds per-iter history and suffix blocks.
+  Required for the iter-level tools.
+
+When kicking off a fresh solve to feed into the post-mortem tools,
+always pass `--json-detail full`.
+
+## Troubleshooting
+
+**`pounce-studio: command not found`**
+The binary is not on PATH. Either re-run `cargo install --path
+crates/pounce-studio-core` (it installs into `~/.cargo/bin/`) or pass
+the absolute path to the binary: `~/.cargo/bin/pounce-studio summary
+report.json`.
+
+**`pounce: command not found`** (when running fresh solves)
+The pounce solver binary is missing. Build with `cargo build --release
+--bin pounce` and copy `target/release/pounce` onto PATH, or run
+`cargo install --path crates/pounce-cli --bin pounce`.
+
+**`unexpected schema "..."`**
+The JSON file is not a `pounce.solve-report/v1` document — perhaps an
+AMPL `.sol`, a different solver's output, or a hand-written file.
+Re-run the solve with `--json-output <path>`.
+
+**`load_solve_report works but convergence-trace is empty`**
+The report was written at `--json-detail summary`. Re-run the solve
+with `--json-detail full`.
+
+**`gams: Could not spawn solver`**
+The GAMS POUNCE link is not installed. See `gams/Makefile` for
+build/install instructions.


### PR DESCRIPTION
The pounce-studio-mcp server is a Python wheel that wraps `pounce-studio-core`
through PyO3 + FastMCP. The install requires a Rust toolchain, a Python venv,
maturin, the mcp library, and a `claude mcp add` registration — heavy for what
is essentially "let Claude ask questions about a JSON solve report".

This commit ships the same analysis surface as a Claude skill that drives the
`pounce-studio` CLI directly. Install is a single make target; the skill works
in every Claude Code session (desktop, web, IDE extension, CLI) without an MCP
server process and without restarting.

Changes:

* Extend the `pounce-studio` binary with JSON-emitting subcommands for every
  MCP tool that operates on a solve report: `summary`, `diagnose`,
  `find-stalls`, `convergence-trace`, `get-iterate`, `restoration-windows`,
  `compare`, `linear-solver-summary`, `explain`, `citations`. The two
  human-facing Markdown renderers (`inspect`, `dump-summary`) keep their
  existing behaviour.

* Add pre-flight subcommands: `analyze-nl`, `analyze-gms`,
  `parse-gams-listing`, `list-gams`, `list-builtins`. The orchestration tools
  (`run_problem`, `run_gams_problem`) become skill recipes that chain the
  `pounce` and `gams` CLIs directly — no Rust subprocess shim.

* New modules `glossary` (column / finding / citation data) and `preflight`
  (NL + GAMS header parsing, builtin metadata, .lst SOLVE SUMMARY) in
  `pounce-studio-core`. WASM-clean — all file I/O stays in the binary.

* `studio/skill/SKILL.md` documents the full surface for Claude.
  `make install-skill` builds both binaries into `$PREFIX/bin` and drops
  the skill into `~/.claude/skills/pounce/`. Cross-linked from
  `studio/mcp/README.md`.

The MCP server remains supported alongside; both backends share the analysis
core so findings agree.

https://claude.ai/code/session_018ZaZikYT36NHgPPHMyJabm