### PR TITLE
Add structured logging and colored iteration table (pounce#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ changes.
 
 ## Unreleased
 
+### Added — Structured logging + colored iteration table (pounce#71)
+
+POUNCE now emits diagnostics through the
+[`tracing`](https://docs.rs/tracing) ecosystem and renders the
+per-iteration table in a tiger/rust branded color theme.
+
+- **Colored iteration table.** Restoration lines take a background that
+  varies by restoration kind (soft-stay → tan, soft-exit → amber, hard →
+  deep rust); the row text shades smoothly from black toward red as the
+  primal step length `alpha` shrinks (a visual stalling cue, shifted to
+  cream → bright-yellow on the dark restoration backgrounds). Color is
+  emitted only when stdout is a terminal — redirected output and
+  `NO_COLOR` get plain text with identical column alignment.
+- **Structured logs.** Solver-internal diagnostics, warnings, and
+  developer instrumentation are now `tracing` events under namespaced
+  targets (`pounce::algorithm`, `pounce::linsol`, `pounce::mu`,
+  `pounce::sqp`, `pounce::linesearch`, `pounce::restoration`,
+  `pounce::presolve`, `pounce::py`). Logs go to **stderr**; program
+  output (iteration table, summary, `--dump`) stays on **stdout**.
+- **Spans.** `solve`, `iteration`, `linear_solve`, and `restoration`
+  spans tag nested events with context.
+- **New environment variables:** `RUST_LOG` (verbosity / per-target
+  filtering, default `info`), `POUNCE_LOG_FORMAT=text|json` (JSON sink on
+  stderr, including the per-iteration `pounce::iteration` stream for
+  Studio / CI), `NO_COLOR` / `CLICOLOR_FORCE` (color policy). Documented
+  in `docs/src/options.md` and `docs/src/troubleshooting.md`.
+- New `pounce-observability` crate (subscriber install + iteration
+  collector) and a `pounce-common::style` palette module.
+
+### Changed
+
+- Per-iteration JSON solve-report data is now sourced from the
+  `pounce::iteration` tracing event (via an in-process collector layer)
+  rather than an in-loop accumulation; the report contents are
+  unchanged. Capturing iteration history requires the tracing subscriber
+  installed by the CLI / Python / C frontends (or
+  `pounce_observability::init_for_tests()` in tests).
+
+### Removed
+
+- Dropped the direct `log` crate dependency in favor of `tracing`.
+
 ## [0.3.0] — 2026-05-29
 
 ### Added — Active-set SQP with working-set warm start (Phase 5b + 5c + 5d)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ per-iteration table in a tiger/rust branded color theme.
   in `docs/src/options.md` and `docs/src/troubleshooting.md`.
 - New `pounce-observability` crate (subscriber install + iteration
   collector) and a `pounce-common::style` palette module.
+- A `log` → `tracing` bridge (`tracing_log::LogTracer`) so any remaining
+  `log::*` call sites — chiefly transitive dependencies — surface through
+  the subscriber and obey `RUST_LOG`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,30 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,6 +216,15 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matrixmultiply"
@@ -225,6 +264,15 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
 ]
 
 [[package]]
@@ -281,6 +329,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -351,6 +405,10 @@ dependencies = [
 [[package]]
 name = "pounce-common"
 version = "0.3.0"
+dependencies = [
+ "anstyle",
+ "anstyle-query",
+]
 
 [[package]]
 name = "pounce-feral"
@@ -400,6 +458,18 @@ dependencies = [
  "pounce-common",
  "pounce-linalg",
  "serde",
+]
+
+[[package]]
+name = "pounce-observability"
+version = "0.3.0"
+dependencies = [
+ "anstyle",
+ "anstyle-query",
+ "pounce-common",
+ "pounce-nlp",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -633,6 +703,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03251193000f4bd3b042892be858ee50e8b3719f2b08e5833ac4353724632430"
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +775,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +807,89 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +902,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,6 +918,15 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "feral",
  "pounce-common",
  "pounce-linsol",
+ "tracing",
 ]
 
 [[package]]
@@ -508,6 +509,7 @@ version = "0.3.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
+ "tracing",
 ]
 
 [[package]]
@@ -537,6 +539,7 @@ version = "0.3.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
+ "tracing",
 ]
 
 [[package]]
@@ -554,6 +557,7 @@ dependencies = [
  "pounce-restoration",
  "pounce-sensitivity",
  "pyo3",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,9 +527,11 @@ version = "0.3.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
+ "log",
  "pounce-common",
  "pounce-nlp",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,10 +12,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "anstyle-query"
@@ -23,6 +47,17 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
@@ -49,6 +84,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "crossbeam-deque"
@@ -169,6 +210,12 @@ checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-diff"
@@ -325,6 +372,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,6 +408,8 @@ dependencies = [
 name = "pounce-algorithm"
 version = "0.3.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "pounce-common",
  "pounce-feral",
  "pounce-hsl",
@@ -362,8 +417,10 @@ dependencies = [
  "pounce-linalg",
  "pounce-linsol",
  "pounce-nlp",
+ "pounce-observability",
  "pounce-presolve",
  "pounce-qp",
+ "tracing",
 ]
 
 [[package]]
@@ -374,6 +431,7 @@ dependencies = [
  "pounce-common",
  "pounce-linsol",
  "pounce-nlp",
+ "pounce-observability",
  "pounce-qp",
  "pounce-restoration",
  "pounce-sensitivity",
@@ -386,7 +444,6 @@ name = "pounce-cli"
 version = "0.3.0"
 dependencies = [
  "libloading",
- "log",
  "pounce-algorithm",
  "pounce-common",
  "pounce-feral",
@@ -394,12 +451,14 @@ dependencies = [
  "pounce-linalg",
  "pounce-linsol",
  "pounce-nlp",
+ "pounce-observability",
  "pounce-presolve",
  "pounce-restoration",
  "pounce-sensitivity",
  "pounce-solve-report",
  "serde",
  "serde_json",
+ "tracing",
 ]
 
 [[package]]
@@ -490,6 +549,7 @@ dependencies = [
  "pounce-feral",
  "pounce-linsol",
  "pounce-nlp",
+ "pounce-observability",
  "pounce-qp",
  "pounce-restoration",
  "pounce-sensitivity",
@@ -516,6 +576,7 @@ dependencies = [
  "pounce-linalg",
  "pounce-linsol",
  "pounce-nlp",
+ "tracing",
 ]
 
 [[package]]
@@ -900,6 +961,12 @@ name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/pounce-qp",
     "crates/pounce-sensitivity",
     "crates/pounce-solve-report",
+    "crates/pounce-observability",
     "crates/pounce-cinterface",
     "crates/pounce-py",
     "crates/pounce-cli",
@@ -40,6 +41,7 @@ default-members = [
     "crates/pounce-qp",
     "crates/pounce-sensitivity",
     "crates/pounce-solve-report",
+    "crates/pounce-observability",
     "crates/pounce-cinterface",
     "crates/pounce-cli",
     "crates/pounce-studio-core",
@@ -71,7 +73,18 @@ pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.3.0" }
 pounce-qp = { path = "crates/pounce-qp", version = "0.3.0" }
 pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.3.0" }
 pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.3.0" }
+pounce-observability = { path = "crates/pounce-observability", version = "0.3.0" }
 feral = "0.9.0"
+
+# Observability / colored-output stack (pounce#71). `anstyle` is the
+# style/color vocabulary, `anstyle-query` detects terminal capability
+# (truecolor, NO_COLOR, …), `anstream` is the auto-stripping stdout
+# wrapper. `tracing` + `tracing-subscriber` provide structured logging.
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi", "json"] }
+anstyle = "1"
+anstyle-query = "1"
+anstream = "0.6"
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,6 +82,7 @@ feral = "0.9.0"
 # wrapper. `tracing` + `tracing-subscriber` provide structured logging.
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "ansi", "json"] }
+tracing-log = "0.2"
 anstyle = "1"
 anstyle-query = "1"
 anstream = "0.6"

--- a/crates/pounce-algorithm/Cargo.toml
+++ b/crates/pounce-algorithm/Cargo.toml
@@ -19,7 +19,11 @@ pounce-feral.workspace = true
 pounce-presolve.workspace = true
 pounce-l1penalty.workspace = true
 pounce-qp.workspace = true
+pounce-observability.workspace = true
 pounce-hsl = { workspace = true, optional = true }
+tracing.workspace = true
+anstream.workspace = true
+anstyle.workspace = true
 
 [features]
 default = []

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -535,7 +535,7 @@ impl AlgorithmBuilder {
                     Some(Box::new(pounce_linsol::RuizTSymScalingMethod::new()))
                 }
                 LinearSystemScalingChoice::Mc19 => {
-                    eprintln!(
+                    tracing::warn!(target: "pounce::algorithm", 
                         "pounce: linear_system_scaling=mc19 not yet implemented; using no scaling"
                     );
                     None

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -535,7 +535,7 @@ impl AlgorithmBuilder {
                     Some(Box::new(pounce_linsol::RuizTSymScalingMethod::new()))
                 }
                 LinearSystemScalingChoice::Mc19 => {
-                    tracing::warn!(target: "pounce::algorithm", 
+                    tracing::warn!(target: "pounce::algorithm",
                         "pounce: linear_system_scaling=mc19 not yet implemented; using no scaling"
                     );
                     None

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -621,7 +621,7 @@ impl IpoptApplication {
             Ok(r) => r,
             Err(e) => {
                 if std::env::var_os("POUNCE_DBG_SQP").is_some() {
-                    eprintln!("[SQP] optimize_with_warm_start error: {e:?}");
+                    tracing::warn!(target: "pounce::sqp", "[SQP] optimize_with_warm_start error: {e:?}");
                 }
                 return ApplicationReturnStatus::InternalError;
             }
@@ -1417,7 +1417,7 @@ impl IpoptApplication {
                     // Upstream Ipopt refuses this combination: Mehrotra
                     // needs an affine step every iter, which only the
                     // adaptive path computes. Keep adaptive and warn.
-                    eprintln!(
+                    tracing::warn!(target: "pounce::algorithm", 
                         "pounce: mehrotra_algorithm=yes requires \
                          mu_strategy=adaptive; ignoring \
                          mu_strategy=monotone."

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1417,7 +1417,7 @@ impl IpoptApplication {
                     // Upstream Ipopt refuses this combination: Mehrotra
                     // needs an affine step every iter, which only the
                     // adaptive path computes. Keep adaptive and warn.
-                    tracing::warn!(target: "pounce::algorithm", 
+                    tracing::warn!(target: "pounce::algorithm",
                         "pounce: mehrotra_algorithm=yes requires \
                          mu_strategy=adaptive; ignoring \
                          mu_strategy=monotone."

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1181,7 +1181,6 @@ impl IpoptApplication {
         let mut alg = IpoptAlgorithm::new(data, cq, bundle)
             .with_nlp(Rc::clone(&nlp_handle))
             .with_tnlp(Rc::clone(&tnlp));
-        alg.record_iter_history = self.record_iter_history;
         // Mint a fresh restoration factory per inner solve if a
         // provider is configured (pounce#10 Phase 3). Falls back to
         // the legacy one-shot `restoration_factory` slot when no
@@ -1212,7 +1211,23 @@ impl IpoptApplication {
             }
         }
 
+        // Per-iteration history (pounce#71): when requested, capture the
+        // `pounce::iteration` events emitted during the solve into an
+        // `IterRecord` trajectory via the observability collector layer.
+        // This replaces the old in-loop `iter_history` accumulation; it
+        // requires the collector to be installed in the active
+        // subscriber (the CLI / Python / C frontends install it via
+        // `pounce_observability::init_subscriber`; tests call
+        // `init_for_tests`). The collector scopes out restoration
+        // sub-solve iterations via the `restoration` span, so the
+        // trajectory matches the previous behavior (outer iters only).
+        let iter_capture = self
+            .record_iter_history
+            .then(pounce_observability::IterCaptureGuard::start);
+
         let solver_status = alg.optimize();
+
+        let captured_iters = iter_capture.map(|g| g.finish()).unwrap_or_default();
         // Close the overall-algorithm timer on the success path. The
         // early-return arms above end it themselves before bailing out;
         // this one matches upstream `IpoptApplication::call_optimize`
@@ -1232,7 +1247,7 @@ impl IpoptApplication {
             stats.restoration_inner_iters = alg.resto_inner_iters;
             stats.restoration_outer_iters = alg.resto_outer_iters;
             stats.restoration_wall_secs = alg.resto_wall_secs;
-            stats.iterations = std::mem::take(&mut alg.iter_history);
+            stats.iterations = captured_iters;
             // Capture the final *scaled* objective at the algorithm's
             // (compressed `x_var`-space) iterate via the NLP: the
             // algorithm-side `eval_f` returns `f * obj_scale_factor`.

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -387,7 +387,11 @@ impl IpoptAlgorithm {
                 (d.iter_count, d.info_alpha_primal, d.info_alpha_primal_char)
             };
             let row = self.bundle.iter_output.format_row(&self.data, &self.cq);
-            let style = pounce_common::style::iteration_row_style(alpha_pr, alpha_char);
+            // Iteration 0 is the initial point — no step has been taken
+            // yet, so `alpha_primal` is 0; treat it as a full step
+            // (neutral black) rather than a stalling alarm (red).
+            let style_alpha = if iter_count == 0 { 1.0 } else { alpha_pr };
+            let style = pounce_common::style::iteration_row_style(style_alpha, alpha_char);
             let mut out = anstream::stdout();
             if iter_count % 10 == 0 {
                 let _ = write!(out, "{}", crate::output::orig::OrigIterationOutput::HEADER);

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -404,11 +404,13 @@ impl IpoptAlgorithm {
         // of truth for the per-iteration trajectory. The JSON log sink
         // and the solve-report collector
         // (`pounce_observability::IterCollectorLayer`) both derive from
-        // it. Emitted unconditionally (even when the console table is
-        // off) so the report captures every iteration; the text console
-        // layer filters this target out (its human form is the colored
-        // table above).
-        {
+        // it. The text console layer filters this target out (its human
+        // form is the colored table above).
+        //
+        // Skipped entirely when nothing consumes it (no iter-history
+        // capture active and JSON logging off) so the default run pays
+        // no per-iteration field-evaluation / allocation cost.
+        if pounce_observability::iteration_event_wanted() {
             let d = self.data.borrow();
             let c = self.cq.borrow();
             let alpha_char = d.info_alpha_primal_char;

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -571,7 +571,7 @@ impl IpoptAlgorithm {
             if self.restoration.is_some() {
                 return self.invoke_restoration();
             } else {
-                eprintln!(
+                tracing::warn!(target: "pounce::algorithm", 
                     "[POUNCE] probing-oracle iterate-quality guard fired \
                      at iter {}, but no restoration phase is configured; \
                      continuing with μ={:.3e}.",
@@ -626,14 +626,14 @@ impl IpoptAlgorithm {
                     use crate::iterates_vector::IteratesVector;
                     use pounce_linalg::{compound_vector::CompoundVector, Vector};
                     let dv: &IteratesVector = delta;
-                    eprintln!(
+                    tracing::debug!(target: "pounce::algorithm", 
                         "[PN_DELTA] iter={} mu={:.6e} dx_amax={:.6e} ds_amax={:.6e} dyc_amax={:.6e} dyd_amax={:.6e} dzL_amax={:.6e} dzU_amax={:.6e} dvL_amax={:.6e} dvU_amax={:.6e}",
                         it, d.curr_mu,
                         dv.x.amax(), dv.s.amax(), dv.y_c.amax(), dv.y_d.amax(),
                         dv.z_l.amax(), dv.z_u.amax(), dv.v_l.amax(), dv.v_u.amax()
                     );
                     if let Some(cdx) = dv.x.as_any().downcast_ref::<CompoundVector>() {
-                        eprintln!(
+                        tracing::debug!(target: "pounce::algorithm", 
                             "[PN_DELTA] iter={} dx_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cdx.comp(0).amax(),
@@ -642,7 +642,7 @@ impl IpoptAlgorithm {
                             cdx.comp(3).amax(),
                             cdx.comp(4).amax(),
                         );
-                        eprintln!(
+                        tracing::debug!(target: "pounce::algorithm", 
                             "[PN_DELTA] iter={} dx_blocks_nrm2: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cdx.comp(0).nrm2(),
@@ -651,7 +651,7 @@ impl IpoptAlgorithm {
                             cdx.comp(3).nrm2(),
                             cdx.comp(4).nrm2(),
                         );
-                        eprintln!(
+                        tracing::debug!(target: "pounce::algorithm", 
                             "[PN_DELTA] iter={} dx_blocks_asum: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cdx.comp(0).asum(),
@@ -675,7 +675,7 @@ impl IpoptAlgorithm {
                                     imax = i;
                                 }
                             }
-                            eprintln!(
+                            tracing::debug!(target: "pounce::algorithm", 
                                 "[PN_DELTA] iter={} dx_orig argmax: i={} v={:.17e} (n={})",
                                 it,
                                 imax,
@@ -685,7 +685,7 @@ impl IpoptAlgorithm {
                         }
                     }
                     let p = &d.perturbations;
-                    eprintln!(
+                    tracing::debug!(target: "pounce::algorithm", 
                         "[PN_DELTA] iter={} pert: dx={:.6e} ds={:.6e} dc={:.6e} dd={:.6e}",
                         it, p.delta_x, p.delta_s, p.delta_c, p.delta_d
                     );
@@ -697,7 +697,7 @@ impl IpoptAlgorithm {
                     let cd = cq.curr_d_minus_s();
                     let sx = cq.curr_sigma_x();
                     let ss = cq.curr_sigma_s();
-                    eprintln!(
+                    tracing::debug!(target: "pounce::algorithm", 
                         "[PN_DELTA] iter={} cq: gradf_amax={:.6e} gradf_nrm2={:.6e} gradlag_amax={:.6e} gradlag_nrm2={:.6e} c_amax={:.6e} c_nrm2={:.6e} d_amax={:.6e} d_nrm2={:.6e} sigx_amax={:.6e} sigx_nrm2={:.6e} sigs_amax={:.6e} sigs_nrm2={:.6e}",
                         it,
                         gf.amax(), gf.nrm2(),
@@ -708,7 +708,7 @@ impl IpoptAlgorithm {
                         ss.amax(), ss.nrm2(),
                     );
                     if let Some(cgf) = gf.as_any().downcast_ref::<CompoundVector>() {
-                        eprintln!(
+                        tracing::debug!(target: "pounce::algorithm", 
                             "[PN_DELTA] iter={} gradf_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cgf.comp(0).amax(),
@@ -719,7 +719,7 @@ impl IpoptAlgorithm {
                         );
                     }
                     if let Some(curr) = self.data.borrow().curr.clone() {
-                        eprintln!(
+                        tracing::debug!(target: "pounce::algorithm", 
                             "[PN_DELTA] iter={} bound_mults: zL_amax={:.6e} zU_amax={:.6e} vL_amax={:.6e} vU_amax={:.6e} s_amax={:.6e} s_nrm2={:.6e} x_amax={:.6e} x_nrm2={:.6e}",
                             it,
                             curr.z_l.amax(), curr.z_u.amax(),
@@ -728,7 +728,7 @@ impl IpoptAlgorithm {
                             curr.x.amax(), curr.x.nrm2(),
                         );
                         if let Some(czl) = curr.z_l.as_any().downcast_ref::<CompoundVector>() {
-                            eprintln!(
+                            tracing::debug!(target: "pounce::algorithm", 
                                 "[PN_DELTA] iter={} zL_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                                 it,
                                 czl.comp(0).amax(),
@@ -739,9 +739,9 @@ impl IpoptAlgorithm {
                             );
                         }
                         if let Some(czu) = curr.z_u.as_any().downcast_ref::<CompoundVector>() {
-                            eprintln!("[PN_DELTA] iter={} zU_ncomps={}", it, czu.n_comps());
+                            tracing::debug!(target: "pounce::algorithm", "[PN_DELTA] iter={} zU_ncomps={}", it, czu.n_comps());
                             for ic in 0..czu.n_comps() {
-                                eprintln!(
+                                tracing::debug!(target: "pounce::algorithm", 
                                     "[PN_DELTA] iter={} zU_block[{}]_amax={:.6e} dim={}",
                                     it,
                                     ic,
@@ -752,7 +752,7 @@ impl IpoptAlgorithm {
                         }
                     }
                     if let Some(csx) = sx.as_any().downcast_ref::<CompoundVector>() {
-                        eprintln!(
+                        tracing::debug!(target: "pounce::algorithm", 
                             "[PN_DELTA] iter={} sigx_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             csx.comp(0).amax(),
@@ -781,7 +781,7 @@ impl IpoptAlgorithm {
                                         imax = i;
                                     }
                                 }
-                                eprintln!("[PN_DELTA] iter={} curr_x_orig argmax: i={} v={:.17e} amax={:.17e} nrm2={:.17e}",
+                                tracing::debug!(target: "pounce::algorithm", "[PN_DELTA] iter={} curr_x_orig argmax: i={} v={:.17e} amax={:.17e} nrm2={:.17e}",
                                 it, imax, v[imax], xo.amax(), xo.nrm2());
                             }
                         }
@@ -976,7 +976,7 @@ impl IpoptAlgorithm {
 
         if std::env::var("POUNCE_DBG_RESTO").is_ok() {
             let iter = self.data.borrow().iter_count;
-            eprintln!(
+            tracing::debug!(target: "pounce::algorithm", 
                 "RESTO_ENTRY iter={} theta={:.6e} barr={:.6e} near_feas_ct={}",
                 iter, reference_theta, reference_barr, self.resto_near_feasible_count,
             );
@@ -1035,7 +1035,7 @@ impl IpoptAlgorithm {
             let dx_rel = relative_distance(&*curr.x, &**prev_x);
             let ds_rel = relative_distance(&*curr.s, &**prev_s);
             if std::env::var_os("POUNCE_DBG_RESTO_CYCLE").is_some() {
-                eprintln!(
+                tracing::debug!(target: "pounce::algorithm", 
                     "[PN_RESTO_CYCLE] entry-vs-entry dx_rel={:.6e} ds_rel={:.6e}",
                     dx_rel, ds_rel
                 );
@@ -1051,7 +1051,7 @@ impl IpoptAlgorithm {
             let dx_rel = relative_distance(&*curr.x, &**prev_x);
             let ds_rel = relative_distance(&*curr.s, &**prev_s);
             if std::env::var_os("POUNCE_DBG_RESTO_CYCLE").is_some() {
-                eprintln!(
+                tracing::debug!(target: "pounce::algorithm", 
                     "[PN_RESTO_CYCLE] entry-vs-recovery dx_rel={:.6e} ds_rel={:.6e} count={}",
                     dx_rel, ds_rel, self.resto_no_outer_progress_count
                 );

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -393,6 +393,9 @@ impl IpoptAlgorithm {
             let style_alpha = if iter_count == 0 { 1.0 } else { alpha_pr };
             let style = pounce_common::style::iteration_row_style(style_alpha, alpha_char);
             let mut out = anstream::stdout();
+            // Write errors (e.g. a closed pipe / `head` on the output)
+            // are deliberately ignored: a vanished terminal must not
+            // panic the solver, unlike the old `println!`.
             if iter_count % 10 == 0 {
                 let _ = write!(out, "{}", crate::output::orig::OrigIterationOutput::HEADER);
             }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -604,8 +604,30 @@ impl IpoptAlgorithm {
         // oracle so that adaptive-μ uses W(curr_N), not stale W.)
         if let (Some(nlp), Some(sd)) = (self.nlp.as_ref(), self.search_dir.as_mut()) {
             timing.compute_search_direction.start();
-            let _ls_span = tracing::info_span!("linear_solve").entered();
+            // Fields are declared `Empty` and filled by the linear
+            // solver (matrix size, factor nnz, inertia, ordering — see
+            // `pounce_feral::record_factor_stats`) and below
+            // (regularization), so the `linear_solve` span carries the
+            // KKT-solve characteristics for the JSON sink (pounce#71).
+            let ls_span = tracing::info_span!(
+                target: "pounce::linsol",
+                "linear_solve",
+                n = tracing::field::Empty,
+                matrix_nnz = tracing::field::Empty,
+                factor_nnz = tracing::field::Empty,
+                inertia_neg = tracing::field::Empty,
+                fill_ratio = tracing::field::Empty,
+                ordering = tracing::field::Empty,
+                regularization = tracing::field::Empty,
+            );
+            let ls_enter = ls_span.enter();
             let ok = sd.compute_search_direction(&self.data, &self.cq, nlp);
+            ls_span.record("regularization", self.data.borrow().info_regu_x);
+            // Within-span marker so the enriched `linear_solve` fields
+            // (filled by the solver above) surface to the JSON sink at
+            // debug level; off at the default `info` level.
+            tracing::debug!(target: "pounce::linsol", "kkt solve complete");
+            drop(ls_enter);
             timing.compute_search_direction.end();
             if !ok {
                 // Mirror upstream `IpIpoptAlg.cpp:417-430`: a failed

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -364,8 +364,8 @@ impl IpoptAlgorithm {
         // Per-iteration span so every event emitted in this body (the
         // structured iteration record, restoration/linear-solve spans)
         // is tagged with the iteration index.
-        let _iter_span = tracing::info_span!("iteration", iter = self.data.borrow().iter_count)
-            .entered();
+        let _iter_span =
+            tracing::info_span!("iteration", iter = self.data.borrow().iter_count).entered();
 
         // 1. Output iteration row. Header every 10 iters; the row itself
         //    is built plain by the strategy (so the column widths stay
@@ -577,7 +577,7 @@ impl IpoptAlgorithm {
             if self.restoration.is_some() {
                 return self.invoke_restoration();
             } else {
-                tracing::warn!(target: "pounce::algorithm", 
+                tracing::warn!(target: "pounce::algorithm",
                     "[POUNCE] probing-oracle iterate-quality guard fired \
                      at iter {}, but no restoration phase is configured; \
                      continuing with μ={:.3e}.",
@@ -654,14 +654,14 @@ impl IpoptAlgorithm {
                     use crate::iterates_vector::IteratesVector;
                     use pounce_linalg::{compound_vector::CompoundVector, Vector};
                     let dv: &IteratesVector = delta;
-                    tracing::debug!(target: "pounce::algorithm", 
+                    tracing::debug!(target: "pounce::algorithm",
                         "[PN_DELTA] iter={} mu={:.6e} dx_amax={:.6e} ds_amax={:.6e} dyc_amax={:.6e} dyd_amax={:.6e} dzL_amax={:.6e} dzU_amax={:.6e} dvL_amax={:.6e} dvU_amax={:.6e}",
                         it, d.curr_mu,
                         dv.x.amax(), dv.s.amax(), dv.y_c.amax(), dv.y_d.amax(),
                         dv.z_l.amax(), dv.z_u.amax(), dv.v_l.amax(), dv.v_u.amax()
                     );
                     if let Some(cdx) = dv.x.as_any().downcast_ref::<CompoundVector>() {
-                        tracing::debug!(target: "pounce::algorithm", 
+                        tracing::debug!(target: "pounce::algorithm",
                             "[PN_DELTA] iter={} dx_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cdx.comp(0).amax(),
@@ -670,7 +670,7 @@ impl IpoptAlgorithm {
                             cdx.comp(3).amax(),
                             cdx.comp(4).amax(),
                         );
-                        tracing::debug!(target: "pounce::algorithm", 
+                        tracing::debug!(target: "pounce::algorithm",
                             "[PN_DELTA] iter={} dx_blocks_nrm2: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cdx.comp(0).nrm2(),
@@ -679,7 +679,7 @@ impl IpoptAlgorithm {
                             cdx.comp(3).nrm2(),
                             cdx.comp(4).nrm2(),
                         );
-                        tracing::debug!(target: "pounce::algorithm", 
+                        tracing::debug!(target: "pounce::algorithm",
                             "[PN_DELTA] iter={} dx_blocks_asum: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cdx.comp(0).asum(),
@@ -703,7 +703,7 @@ impl IpoptAlgorithm {
                                     imax = i;
                                 }
                             }
-                            tracing::debug!(target: "pounce::algorithm", 
+                            tracing::debug!(target: "pounce::algorithm",
                                 "[PN_DELTA] iter={} dx_orig argmax: i={} v={:.17e} (n={})",
                                 it,
                                 imax,
@@ -713,7 +713,7 @@ impl IpoptAlgorithm {
                         }
                     }
                     let p = &d.perturbations;
-                    tracing::debug!(target: "pounce::algorithm", 
+                    tracing::debug!(target: "pounce::algorithm",
                         "[PN_DELTA] iter={} pert: dx={:.6e} ds={:.6e} dc={:.6e} dd={:.6e}",
                         it, p.delta_x, p.delta_s, p.delta_c, p.delta_d
                     );
@@ -725,7 +725,7 @@ impl IpoptAlgorithm {
                     let cd = cq.curr_d_minus_s();
                     let sx = cq.curr_sigma_x();
                     let ss = cq.curr_sigma_s();
-                    tracing::debug!(target: "pounce::algorithm", 
+                    tracing::debug!(target: "pounce::algorithm",
                         "[PN_DELTA] iter={} cq: gradf_amax={:.6e} gradf_nrm2={:.6e} gradlag_amax={:.6e} gradlag_nrm2={:.6e} c_amax={:.6e} c_nrm2={:.6e} d_amax={:.6e} d_nrm2={:.6e} sigx_amax={:.6e} sigx_nrm2={:.6e} sigs_amax={:.6e} sigs_nrm2={:.6e}",
                         it,
                         gf.amax(), gf.nrm2(),
@@ -736,7 +736,7 @@ impl IpoptAlgorithm {
                         ss.amax(), ss.nrm2(),
                     );
                     if let Some(cgf) = gf.as_any().downcast_ref::<CompoundVector>() {
-                        tracing::debug!(target: "pounce::algorithm", 
+                        tracing::debug!(target: "pounce::algorithm",
                             "[PN_DELTA] iter={} gradf_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             cgf.comp(0).amax(),
@@ -747,7 +747,7 @@ impl IpoptAlgorithm {
                         );
                     }
                     if let Some(curr) = self.data.borrow().curr.clone() {
-                        tracing::debug!(target: "pounce::algorithm", 
+                        tracing::debug!(target: "pounce::algorithm",
                             "[PN_DELTA] iter={} bound_mults: zL_amax={:.6e} zU_amax={:.6e} vL_amax={:.6e} vU_amax={:.6e} s_amax={:.6e} s_nrm2={:.6e} x_amax={:.6e} x_nrm2={:.6e}",
                             it,
                             curr.z_l.amax(), curr.z_u.amax(),
@@ -756,7 +756,7 @@ impl IpoptAlgorithm {
                             curr.x.amax(), curr.x.nrm2(),
                         );
                         if let Some(czl) = curr.z_l.as_any().downcast_ref::<CompoundVector>() {
-                            tracing::debug!(target: "pounce::algorithm", 
+                            tracing::debug!(target: "pounce::algorithm",
                                 "[PN_DELTA] iter={} zL_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                                 it,
                                 czl.comp(0).amax(),
@@ -769,7 +769,7 @@ impl IpoptAlgorithm {
                         if let Some(czu) = curr.z_u.as_any().downcast_ref::<CompoundVector>() {
                             tracing::debug!(target: "pounce::algorithm", "[PN_DELTA] iter={} zU_ncomps={}", it, czu.n_comps());
                             for ic in 0..czu.n_comps() {
-                                tracing::debug!(target: "pounce::algorithm", 
+                                tracing::debug!(target: "pounce::algorithm",
                                     "[PN_DELTA] iter={} zU_block[{}]_amax={:.6e} dim={}",
                                     it,
                                     ic,
@@ -780,7 +780,7 @@ impl IpoptAlgorithm {
                         }
                     }
                     if let Some(csx) = sx.as_any().downcast_ref::<CompoundVector>() {
-                        tracing::debug!(target: "pounce::algorithm", 
+                        tracing::debug!(target: "pounce::algorithm",
                             "[PN_DELTA] iter={} sigx_blocks_amax: orig={:.6e} nc={:.6e} pc={:.6e} nd={:.6e} pd={:.6e}",
                             it,
                             csx.comp(0).amax(),
@@ -1004,7 +1004,7 @@ impl IpoptAlgorithm {
 
         if std::env::var("POUNCE_DBG_RESTO").is_ok() {
             let iter = self.data.borrow().iter_count;
-            tracing::debug!(target: "pounce::algorithm", 
+            tracing::debug!(target: "pounce::algorithm",
                 "RESTO_ENTRY iter={} theta={:.6e} barr={:.6e} near_feas_ct={}",
                 iter, reference_theta, reference_barr, self.resto_near_feasible_count,
             );
@@ -1063,7 +1063,7 @@ impl IpoptAlgorithm {
             let dx_rel = relative_distance(&*curr.x, &**prev_x);
             let ds_rel = relative_distance(&*curr.s, &**prev_s);
             if std::env::var_os("POUNCE_DBG_RESTO_CYCLE").is_some() {
-                tracing::debug!(target: "pounce::algorithm", 
+                tracing::debug!(target: "pounce::algorithm",
                     "[PN_RESTO_CYCLE] entry-vs-entry dx_rel={:.6e} ds_rel={:.6e}",
                     dx_rel, ds_rel
                 );
@@ -1079,7 +1079,7 @@ impl IpoptAlgorithm {
             let dx_rel = relative_distance(&*curr.x, &**prev_x);
             let ds_rel = relative_distance(&*curr.s, &**prev_s);
             if std::env::var_os("POUNCE_DBG_RESTO_CYCLE").is_some() {
-                tracing::debug!(target: "pounce::algorithm", 
+                tracing::debug!(target: "pounce::algorithm",
                     "[PN_RESTO_CYCLE] entry-vs-recovery dx_rel={:.6e} ds_rel={:.6e} count={}",
                     dx_rel, ds_rel, self.resto_no_outer_progress_count
                 );

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -189,16 +189,13 @@ pub struct IpoptAlgorithm {
     /// Cumulative wall-clock seconds spent inside `perform_restoration`.
     pub resto_wall_secs: Number,
 
-    // ---- Per-iteration history capture (pounce#8). ----
+    // ---- Per-iteration history capture (pounce#8, pounce#71). ----
     //
-    /// When `true`, [`Self::iterate`] appends an `IterRecord` to
-    /// `iter_history` each step. Off by default — the JSON output
-    /// path in `pounce-cli` opts in.
-    pub record_iter_history: bool,
-    /// Per-iteration trajectory captured when `record_iter_history`
-    /// is on. Drained into [`SolveStatistics::iterations`] by
-    /// `IpoptApplication::optimize_constrained` after the solve.
-    pub iter_history: Vec<pounce_nlp::solve_statistics::IterRecord>,
+    // The per-iteration trajectory is no longer accumulated on the
+    // algorithm: `iterate()` emits a structured `pounce::iteration`
+    // event each step, and `pounce_observability::IterCollectorLayer`
+    // rebuilds the `IterRecord`s into the active `IterCaptureGuard`
+    // that `IpoptApplication` installs around the solve.
     /// When `false`, the per-iteration table that `iterate()` writes
     /// straight to stdout is suppressed. Wired from
     /// `IpoptApplication`'s `print_level` option: level 0 turns this
@@ -241,8 +238,6 @@ impl IpoptAlgorithm {
             resto_inner_iters: 0,
             resto_outer_iters: 0,
             resto_wall_secs: 0.0,
-            record_iter_history: false,
-            iter_history: Vec::new(),
             print_iter_output: true,
         }
     }
@@ -366,64 +361,73 @@ impl IpoptAlgorithm {
         // bump its own counter without re-borrowing `data`.
         let timing = self.data.borrow().timing.clone();
 
-        // 1. Output iteration row. Header every 10 iters; the row
-        //    itself is built by the strategy and printed here so a
-        //    long-running solve gives the user feedback. (Phase-7
-        //    upstream routes this through the journalist; until that
-        //    surface lands, write straight to stdout.)
+        // Per-iteration span so every event emitted in this body (the
+        // structured iteration record, restoration/linear-solve spans)
+        // is tagged with the iteration index.
+        let _iter_span = tracing::info_span!("iteration", iter = self.data.borrow().iter_count)
+            .entered();
+
+        // 1. Output iteration row. Header every 10 iters; the row itself
+        //    is built plain by the strategy (so the column widths stay
+        //    exact and unit-testable) and wrapped in a tiger/rust style
+        //    at the print site (pounce#71). `anstream::stdout()` strips
+        //    the escapes automatically when stdout is redirected or
+        //    `NO_COLOR` is set, so non-TTY output is plain text.
         //
-        //    Print BEFORE `reset_info` so the row reflects the
-        //    accepted step from the previous iteration (alphas, ls
-        //    count, alpha_char), matching upstream's
-        //    `IpIpoptAlgorithm::Optimize` ordering.
+        //    Print BEFORE `reset_info` so the row reflects the accepted
+        //    step from the previous iteration (alphas, ls count,
+        //    alpha_char), matching upstream's `IpIpoptAlgorithm::Optimize`
+        //    ordering.
         timing.output_iteration.start();
         self.bundle.iter_output.write_output();
         if self.print_iter_output {
-            let iter_count = self.data.borrow().iter_count;
-            if iter_count % 10 == 0 {
-                print!("{}", crate::output::orig::OrigIterationOutput::HEADER);
-            }
+            use std::io::Write as _;
+            let (iter_count, alpha_pr, alpha_char) = {
+                let d = self.data.borrow();
+                (d.iter_count, d.info_alpha_primal, d.info_alpha_primal_char)
+            };
             let row = self.bundle.iter_output.format_row(&self.data, &self.cq);
-            println!("{row}");
+            let style = pounce_common::style::iteration_row_style(alpha_pr, alpha_char);
+            let mut out = anstream::stdout();
+            if iter_count % 10 == 0 {
+                let _ = write!(out, "{}", crate::output::orig::OrigIterationOutput::HEADER);
+            }
+            let _ = writeln!(out, "{}{}{}", style.render(), row, style.render_reset());
         }
         timing.output_iteration.end();
 
-        // Optional per-iteration history capture (pounce#8 / JSON
-        // output). Fires alongside the console print so the records
-        // are always in lock-step with what the user sees on stdout.
-        if self.record_iter_history {
+        // Structured per-iteration event (pounce#71) — the single source
+        // of truth for the per-iteration trajectory. The JSON log sink
+        // and the solve-report collector
+        // (`pounce_observability::IterCollectorLayer`) both derive from
+        // it. Emitted unconditionally (even when the console table is
+        // off) so the report captures every iteration; the text console
+        // layer filters this target out (its human form is the colored
+        // table above).
+        {
             let d = self.data.borrow();
             let c = self.cq.borrow();
-            let iter = d.iter_count;
-            let inf_pr = c.curr_primal_infeasibility_max();
-            let inf_du = c.curr_dual_infeasibility_max();
-            let mu = d.curr_mu;
+            let alpha_char = d.info_alpha_primal_char;
+            let alpha_char_s = alpha_char.to_string();
             let d_norm = match &d.delta {
                 Some(delta) => delta.x.amax().max(delta.s.amax()),
                 None => 0.0,
             };
-            let regularization = d.info_regu_x;
-            let alpha_dual = d.info_alpha_dual;
-            let alpha_primal = d.info_alpha_primal;
-            let alpha_primal_char = d.info_alpha_primal_char;
-            let ls_trials = d.info_ls_count;
-            let objective = c.unscaled_curr_f();
-            drop(d);
-            drop(c);
-            self.iter_history
-                .push(pounce_nlp::solve_statistics::IterRecord {
-                    iter,
-                    objective,
-                    inf_pr,
-                    inf_du,
-                    mu,
-                    d_norm,
-                    regularization,
-                    alpha_dual,
-                    alpha_primal,
-                    alpha_primal_char,
-                    ls_trials,
-                });
+            tracing::info!(
+                target: pounce_observability::ITER_TARGET,
+                iter = d.iter_count,
+                objective = c.unscaled_curr_f(),
+                inf_pr = c.curr_primal_infeasibility_max(),
+                inf_du = c.curr_dual_infeasibility_max(),
+                mu = d.curr_mu,
+                d_norm = d_norm,
+                regularization = d.info_regu_x,
+                alpha_dual = d.info_alpha_dual,
+                alpha_primal = d.info_alpha_primal,
+                ls_trials = d.info_ls_count,
+                alpha_char = alpha_char_s.as_str(),
+                resto_kind = pounce_common::style::resto_kind_str(alpha_char),
+            );
         }
 
         // Reset per-iteration info on data (after printing previous
@@ -596,6 +600,7 @@ impl IpoptAlgorithm {
         // oracle so that adaptive-μ uses W(curr_N), not stale W.)
         if let (Some(nlp), Some(sd)) = (self.nlp.as_ref(), self.search_dir.as_mut()) {
             timing.compute_search_direction.start();
+            let _ls_span = tracing::info_span!("linear_solve").entered();
             let ok = sd.compute_search_direction(&self.data, &self.cq, nlp);
             timing.compute_search_direction.end();
             if !ok {
@@ -1252,6 +1257,10 @@ impl IpoptAlgorithm {
     /// RESTORATION_FAILED → RESTORATION_FAILURE, etc.) lands in
     /// Phase 9 alongside the restoration phase.
     pub fn optimize(&mut self) -> SolverReturn {
+        // Top-level span for the whole solve; every iteration / linear
+        // solve / restoration event nests under it (pounce#71).
+        let _solve_span = tracing::info_span!("solve").entered();
+
         // Shared timing accumulator — every phase below records into it.
         let timing = self.data.borrow().timing.clone();
 

--- a/crates/pounce-algorithm/src/iter_dump.rs
+++ b/crates/pounce-algorithm/src/iter_dump.rs
@@ -68,7 +68,7 @@ impl IterDumper {
         let file = match File::create(&pb) {
             Ok(f) => f,
             Err(e) => {
-                eprintln!(
+                tracing::warn!(target: "pounce::diagnostics", 
                     "iter_dump: failed to open `{}` for writing: {} — dumping disabled",
                     path, e
                 );
@@ -158,7 +158,7 @@ impl IterDumper {
     /// `curr` iterate).
     pub(crate) fn write_record(&mut self, data: &IpoptDataHandle, cq: &IpoptCqHandle) {
         if let Err(e) = self.write_record_inner(data, cq) {
-            eprintln!(
+            tracing::warn!(target: "pounce::diagnostics", 
                 "iter_dump: failed to write iteration record: {} — dumping aborted",
                 e
             );
@@ -261,7 +261,7 @@ impl Drop for IterDumper {
         // BufWriter flushes on drop, but surface any error rather than
         // swallowing it silently.
         if let Err(e) = self.writer.flush() {
-            eprintln!("iter_dump: failed to flush trace file on drop: {}", e);
+            tracing::warn!(target: "pounce::diagnostics", "iter_dump: failed to flush trace file on drop: {}", e);
         }
     }
 }

--- a/crates/pounce-algorithm/src/iter_dump.rs
+++ b/crates/pounce-algorithm/src/iter_dump.rs
@@ -68,7 +68,7 @@ impl IterDumper {
         let file = match File::create(&pb) {
             Ok(f) => f,
             Err(e) => {
-                tracing::warn!(target: "pounce::diagnostics", 
+                tracing::warn!(target: "pounce::diagnostics",
                     "iter_dump: failed to open `{}` for writing: {} — dumping disabled",
                     path, e
                 );
@@ -158,7 +158,7 @@ impl IterDumper {
     /// `curr` iterate).
     pub(crate) fn write_record(&mut self, data: &IpoptDataHandle, cq: &IpoptCqHandle) {
         if let Err(e) = self.write_record_inner(data, cq) {
-            tracing::warn!(target: "pounce::diagnostics", 
+            tracing::warn!(target: "pounce::diagnostics",
                 "iter_dump: failed to write iteration record: {} — dumping aborted",
                 e
             );

--- a/crates/pounce-algorithm/src/iter_dump.rs
+++ b/crates/pounce-algorithm/src/iter_dump.rs
@@ -275,6 +275,16 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
 
+    /// Serializes tests that mutate the process-global `ENV_DUMP_PATH` /
+    /// `ENV_DUMP_NAME` env vars. Without this, parallel tests interleave
+    /// `set_var`/`remove_var` and one test's `from_env()` observes
+    /// another's path. Poison is ignored — a panicking test still
+    /// releases the critical section for the rest.
+    fn env_guard() -> std::sync::MutexGuard<'static, ()> {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
     fn dense(n: i32, vals: Option<&[Number]>) -> Rc<dyn Vector> {
         let space = DenseVectorSpace::new(n);
         let mut dv = space.make_new_dense();
@@ -286,6 +296,7 @@ mod tests {
 
     #[test]
     fn write_vec_emits_len_then_values_little_endian() {
+        let _env = env_guard();
         // Round-trip a small vector through write_vec → in-memory buffer.
         // We don't have IpoptDataHandle here, so we test write_vec
         // directly via a tempfile + manual byte-level check.
@@ -309,12 +320,14 @@ mod tests {
 
     #[test]
     fn from_env_returns_none_when_unset() {
+        let _env = env_guard();
         std::env::remove_var(ENV_DUMP_PATH);
         assert!(IterDumper::from_env().is_none());
     }
 
     #[test]
     fn header_writes_magic_and_version() {
+        let _env = env_guard();
         let path =
             std::env::temp_dir().join(format!("pounce_iter_dump_hdr_{}.bin", std::process::id()));
         std::env::set_var(ENV_DUMP_PATH, &path);

--- a/crates/pounce-algorithm/src/iterate_dump.rs
+++ b/crates/pounce-algorithm/src/iterate_dump.rs
@@ -47,7 +47,7 @@ pub(crate) fn emit_record(diag: &DiagnosticsState, data: &IpoptDataHandle, cq: &
         None => return,
     };
     if let Err(e) = diag.append_iterate_line(&json) {
-        eprintln!(
+        tracing::warn!(target: "pounce::diagnostics", 
             "iterate_dump: failed to append iterate row to iterates.jsonl: {} — continuing",
             e
         );

--- a/crates/pounce-algorithm/src/iterate_dump.rs
+++ b/crates/pounce-algorithm/src/iterate_dump.rs
@@ -47,7 +47,7 @@ pub(crate) fn emit_record(diag: &DiagnosticsState, data: &IpoptDataHandle, cq: &
         None => return,
     };
     if let Err(e) = diag.append_iterate_line(&json) {
-        tracing::warn!(target: "pounce::diagnostics", 
+        tracing::warn!(target: "pounce::diagnostics",
             "iterate_dump: failed to append iterate row to iterates.jsonl: {} — continuing",
             e
         );

--- a/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
@@ -237,9 +237,9 @@ impl PdFullSpaceSolver {
                             ));
                         }
                     }
-                    eprintln!("[PN_PD_TAGS] cache_miss diffs:{}", diffs);
+                    tracing::debug!(target: "pounce::linsol", "[PN_PD_TAGS] cache_miss diffs:{}", diffs);
                 } else {
-                    eprintln!("[PN_PD_TAGS] cache_miss first_solve");
+                    tracing::debug!(target: "pounce::linsol", "[PN_PD_TAGS] cache_miss first_solve");
                 }
             }
             self.last_dep_tags = Some(cur_tags);

--- a/crates/pounce-algorithm/src/kkt/perturbation_handler.rs
+++ b/crates/pounce-algorithm/src/kkt/perturbation_handler.rs
@@ -360,7 +360,7 @@ impl PdPerturbationHandler {
     ) -> Option<Deltas> {
         if std::env::var_os("POUNCE_DBG_PERT").is_some() {
             let it = ip_data.map(|d| d.borrow().iter_count).unwrap_or(-1);
-            tracing::debug!(target: "pounce::linsol", 
+            tracing::debug!(target: "pounce::linsol",
                 "[PERT] iter={} WRONG_INERTIA mu={:.2e} dx_last={:.2e} dx_curr={:.2e}",
                 it, mu, self.delta_x_last, self.delta_x_curr
             );

--- a/crates/pounce-algorithm/src/kkt/perturbation_handler.rs
+++ b/crates/pounce-algorithm/src/kkt/perturbation_handler.rs
@@ -360,7 +360,7 @@ impl PdPerturbationHandler {
     ) -> Option<Deltas> {
         if std::env::var_os("POUNCE_DBG_PERT").is_some() {
             let it = ip_data.map(|d| d.borrow().iter_count).unwrap_or(-1);
-            eprintln!(
+            tracing::debug!(target: "pounce::linsol", 
                 "[PERT] iter={} WRONG_INERTIA mu={:.2e} dx_last={:.2e} dx_curr={:.2e}",
                 it, mu, self.delta_x_last, self.delta_x_curr
             );

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -443,7 +443,7 @@ impl AugSystemSolver for StdAugSystemSolver {
             use std::sync::atomic::{AtomicBool, Ordering};
             static WARNED: AtomicBool = AtomicBool::new(false);
             if !WARNED.swap(true, Ordering::SeqCst) {
-                eprintln!(
+                tracing::warn!(target: "pounce::linsol", 
                     "warning: POUNCE_DUMP_KKT is deprecated; prefer `--dump kkt:<iter-spec>` (see pounce --help)"
                 );
             }

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -443,7 +443,7 @@ impl AugSystemSolver for StdAugSystemSolver {
             use std::sync::atomic::{AtomicBool, Ordering};
             static WARNED: AtomicBool = AtomicBool::new(false);
             if !WARNED.swap(true, Ordering::SeqCst) {
-                tracing::warn!(target: "pounce::linsol", 
+                tracing::warn!(target: "pounce::linsol",
                     "warning: POUNCE_DUMP_KKT is deprecated; prefer `--dump kkt:<iter-spec>` (see pounce --help)"
                 );
             }

--- a/crates/pounce-algorithm/src/line_search/backtracking.rs
+++ b/crates/pounce-algorithm/src/line_search/backtracking.rs
@@ -893,7 +893,7 @@ impl BacktrackingLineSearch {
                     .update_for_next_iteration(alpha, theta, phi, d_phi, phi_trial);
                 if std::env::var_os("POUNCE_DBG_LS").is_some() {
                     let d = data.borrow();
-                    tracing::debug!(target: "pounce::linesearch", 
+                    tracing::debug!(target: "pounce::linesearch",
                         "[PN_LS] iter={} mu={:.3e} alpha={:.3e} alpha_d={:.3e} mode={} theta={:.6e} theta_trial={:.6e} phi={:.6e} phi_trial={:.6e} n_steps={}",
                         d.iter_count, d.curr_mu, alpha, alpha_dual, mode, theta, theta_trial, phi, phi_trial, trial
                     );

--- a/crates/pounce-algorithm/src/line_search/backtracking.rs
+++ b/crates/pounce-algorithm/src/line_search/backtracking.rs
@@ -893,7 +893,7 @@ impl BacktrackingLineSearch {
                     .update_for_next_iteration(alpha, theta, phi, d_phi, phi_trial);
                 if std::env::var_os("POUNCE_DBG_LS").is_some() {
                     let d = data.borrow();
-                    eprintln!(
+                    tracing::debug!(target: "pounce::linesearch", 
                         "[PN_LS] iter={} mu={:.3e} alpha={:.3e} alpha_d={:.3e} mode={} theta={:.6e} theta_trial={:.6e} phi={:.6e} phi_trial={:.6e} n_steps={}",
                         d.iter_count, d.curr_mu, alpha, alpha_dual, mode, theta, theta_trial, phi, phi_trial, trial
                     );

--- a/crates/pounce-algorithm/src/line_search/filter_acceptor.rs
+++ b/crates/pounce-algorithm/src/line_search/filter_acceptor.rs
@@ -305,7 +305,7 @@ impl FilterLsAcceptor {
             // Env lookup cached in a `OnceLock` so the disabled case
             // costs one atomic load per trial.
             if dbg_ls_enabled() {
-                tracing::debug!(target: "pounce::linesearch", 
+                tracing::debug!(target: "pounce::linesearch",
                     "DBG_LS alpha={:.3e} theta={:.3e} phi={:.3e} d_phi={:.3e} theta_trial={:.3e} phi_trial={:.3e} theta_max={:.3e} rapid_inc_ok={} suff_progress_ok={}",
                     alpha_primal,
                     theta,

--- a/crates/pounce-algorithm/src/line_search/filter_acceptor.rs
+++ b/crates/pounce-algorithm/src/line_search/filter_acceptor.rs
@@ -305,7 +305,7 @@ impl FilterLsAcceptor {
             // Env lookup cached in a `OnceLock` so the disabled case
             // costs one atomic load per trial.
             if dbg_ls_enabled() {
-                eprintln!(
+                tracing::debug!(target: "pounce::linesearch", 
                     "DBG_LS alpha={:.3e} theta={:.3e} phi={:.3e} d_phi={:.3e} theta_trial={:.3e} phi_trial={:.3e} theta_max={:.3e} rapid_inc_ok={} suff_progress_ok={}",
                     alpha_primal,
                     theta,

--- a/crates/pounce-algorithm/src/mu/adaptive.rs
+++ b/crates/pounce-algorithm/src/mu/adaptive.rs
@@ -564,7 +564,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                         .iter()
                         .map(|e| (e.theta, e.phi, e.iter))
                         .collect();
-                    eprintln!(
+                    tracing::debug!(target: "pounce::mu", 
                         "[AMU] iter={} free->fixed: curr_mu={:.3e} theta={:.3e} f={:.3e} nlp_err={:.3e} margin={:.3e} avrg_compl={:.3e} new_mu={:.3e} | filter={:?} | force_no_progress={} tiny={}",
                         iter_count,
                         curr_mu,
@@ -641,7 +641,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                     avrg_compl,
                 ) {
                     if std::env::var("POUNCE_DBG_ORACLE").is_ok() {
-                        eprintln!(
+                        tracing::debug!(target: "pounce::mu", 
                             "[PN_PROBE_GUARD] iter={} curr_mu={:.3e} avrg_compl={:.3e} ratio={:.3e} > factor={:.3e} → request_resto",
                             iter_count,
                             curr_mu,

--- a/crates/pounce-algorithm/src/mu/adaptive.rs
+++ b/crates/pounce-algorithm/src/mu/adaptive.rs
@@ -564,7 +564,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                         .iter()
                         .map(|e| (e.theta, e.phi, e.iter))
                         .collect();
-                    tracing::debug!(target: "pounce::mu", 
+                    tracing::debug!(target: "pounce::mu",
                         "[AMU] iter={} free->fixed: curr_mu={:.3e} theta={:.3e} f={:.3e} nlp_err={:.3e} margin={:.3e} avrg_compl={:.3e} new_mu={:.3e} | filter={:?} | force_no_progress={} tiny={}",
                         iter_count,
                         curr_mu,
@@ -641,7 +641,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                     avrg_compl,
                 ) {
                     if std::env::var("POUNCE_DBG_ORACLE").is_ok() {
-                        tracing::debug!(target: "pounce::mu", 
+                        tracing::debug!(target: "pounce::mu",
                             "[PN_PROBE_GUARD] iter={} curr_mu={:.3e} avrg_compl={:.3e} ratio={:.3e} > factor={:.3e} → request_resto",
                             iter_count,
                             curr_mu,

--- a/crates/pounce-algorithm/src/mu/oracle/quality_function.rs
+++ b/crates/pounce-algorithm/src/mu/oracle/quality_function.rs
@@ -366,7 +366,7 @@ impl QualityFunctionMuOracle {
             };
 
             if std::env::var("POUNCE_DBG_QF_AGGR").is_ok() {
-                eprintln!(
+                tracing::debug!(target: "pounce::mu", 
                     "[QF_AGGR] σ={:.6e} α_pri={:.6e} α_du={:.6e} xi={:.6e} dual_aggr={:.6e} primal_aggr={:.6e} compl_aggr={:.6e} n_dual={} n_pri={} n_comp={}",
                     sigma, alpha_pri, alpha_du, xi,
                     dual_aggr, primal_aggr, compl_aggr,
@@ -389,7 +389,7 @@ impl QualityFunctionMuOracle {
                     let hi = self.sigma_max.min(self.mu_max / avrg_compl).max(lo * 10.0);
                     let log_lo = lo.ln();
                     let log_hi = hi.ln();
-                    eprintln!("[QF_SWEEP] iter={} avrg_compl={:.6e} σ_range=[{:.3e},{:.3e}] sigma_min={:.3e} sigma_max={:.3e} mu_min={:.3e} mu_max={:.3e}",
+                    tracing::debug!(target: "pounce::mu", "[QF_SWEEP] iter={} avrg_compl={:.6e} σ_range=[{:.3e},{:.3e}] sigma_min={:.3e} sigma_max={:.3e} mu_min={:.3e} mu_max={:.3e}",
                         target_iter, avrg_compl, lo, hi,
                         self.sigma_min, self.sigma_max, self.mu_min, self.mu_max);
                     let n = 21;
@@ -397,12 +397,12 @@ impl QualityFunctionMuOracle {
                         let frac = i as f64 / (n - 1) as f64;
                         let sig = (log_lo + frac * (log_hi - log_lo)).exp();
                         let q = eval_q(sig);
-                        eprintln!("[QF_SWEEP] σ={:.6e} q={:.10e}", sig, q);
+                        tracing::debug!(target: "pounce::mu", "[QF_SWEEP] σ={:.6e} q={:.10e}", sig, q);
                     }
                     let q1 = eval_q(1.0);
                     let s1m = 1.0 - self.section_sigma_tol.max(1e-4);
                     let q1m = eval_q(s1m);
-                    eprintln!(
+                    tracing::debug!(target: "pounce::mu", 
                         "[QF_SWEEP] σ=1.0 q={:.10e}  σ={:.6e} q={:.10e}  (q_1minus>q_1: {})",
                         q1,
                         s1m,
@@ -434,7 +434,7 @@ impl QualityFunctionMuOracle {
             let sigma_up_dn = sigma_floor
                 .max(1.0 - self.section_sigma_tol.max(1e-4))
                 .min(self.mu_max / avrg_compl);
-            eprintln!(
+            tracing::debug!(target: "pounce::mu", 
                 "[QF] iter={} curr_mu={:.3e} avrg_compl={:.3e} sigma={:.3e} mu_new={:.3e} mu_clamped={:.3e} | sigma_min={:.3e} mu_min={:.3e} sigma_lo_dn={:.3e} sigma_up_dn={:.3e} mu_min/avrg={:.3e}",
                 iter_count, curr_mu, avrg_compl, sigma, mu_new, mu_clamped,
                 self.sigma_min, self.mu_min, sigma_floor, sigma_up_dn,

--- a/crates/pounce-algorithm/src/mu/oracle/quality_function.rs
+++ b/crates/pounce-algorithm/src/mu/oracle/quality_function.rs
@@ -366,7 +366,7 @@ impl QualityFunctionMuOracle {
             };
 
             if std::env::var("POUNCE_DBG_QF_AGGR").is_ok() {
-                tracing::debug!(target: "pounce::mu", 
+                tracing::debug!(target: "pounce::mu",
                     "[QF_AGGR] σ={:.6e} α_pri={:.6e} α_du={:.6e} xi={:.6e} dual_aggr={:.6e} primal_aggr={:.6e} compl_aggr={:.6e} n_dual={} n_pri={} n_comp={}",
                     sigma, alpha_pri, alpha_du, xi,
                     dual_aggr, primal_aggr, compl_aggr,
@@ -402,7 +402,7 @@ impl QualityFunctionMuOracle {
                     let q1 = eval_q(1.0);
                     let s1m = 1.0 - self.section_sigma_tol.max(1e-4);
                     let q1m = eval_q(s1m);
-                    tracing::debug!(target: "pounce::mu", 
+                    tracing::debug!(target: "pounce::mu",
                         "[QF_SWEEP] σ=1.0 q={:.10e}  σ={:.6e} q={:.10e}  (q_1minus>q_1: {})",
                         q1,
                         s1m,
@@ -434,7 +434,7 @@ impl QualityFunctionMuOracle {
             let sigma_up_dn = sigma_floor
                 .max(1.0 - self.section_sigma_tol.max(1e-4))
                 .min(self.mu_max / avrg_compl);
-            tracing::debug!(target: "pounce::mu", 
+            tracing::debug!(target: "pounce::mu",
                 "[QF] iter={} curr_mu={:.3e} avrg_compl={:.3e} sigma={:.3e} mu_new={:.3e} mu_clamped={:.3e} | sigma_min={:.3e} mu_min={:.3e} sigma_lo_dn={:.3e} sigma_up_dn={:.3e} mu_min/avrg={:.3e}",
                 iter_count, curr_mu, avrg_compl, sigma, mu_new, mu_clamped,
                 self.sigma_min, self.mu_min, sigma_floor, sigma_up_dn,

--- a/crates/pounce-algorithm/src/sqp/line_search.rs
+++ b/crates/pounce-algorithm/src/sqp/line_search.rs
@@ -150,7 +150,7 @@ pub fn l1_merit_line_search<N: SqpProblemSpec>(
         };
         #[cfg(test)]
         if opts.print_level >= 2 {
-            eprintln!(
+            tracing::debug!(target: "pounce::sqp", 
                 "         ls trial α={alpha:.3e} phi_t={phi_trial:.4e} \
                  phi_c={phi_curr:.4e} target={target:.4e} pred={predicted:.3e} \
                  grad_p={grad_p:.3e} viol_c={viol_curr:.3e} viol_t={viol_trial:.3e} \

--- a/crates/pounce-algorithm/src/sqp/line_search.rs
+++ b/crates/pounce-algorithm/src/sqp/line_search.rs
@@ -150,7 +150,7 @@ pub fn l1_merit_line_search<N: SqpProblemSpec>(
         };
         #[cfg(test)]
         if opts.print_level >= 2 {
-            tracing::debug!(target: "pounce::sqp", 
+            tracing::debug!(target: "pounce::sqp",
                 "         ls trial α={alpha:.3e} phi_t={phi_trial:.4e} \
                  phi_c={phi_curr:.4e} target={target:.4e} pred={predicted:.3e} \
                  grad_p={grad_p:.3e} viol_c={viol_curr:.3e} viol_t={viol_trial:.3e} \

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -210,7 +210,7 @@ impl SqpAlgorithm {
 
             #[cfg(test)]
             if self.opts.print_level >= 1 {
-                tracing::debug!(target: "pounce::sqp", 
+                tracing::debug!(target: "pounce::sqp",
                     "[sqp k={outer:3}] x={:?} f={:.4e} ‖c‖={:.2e} stat={:.2e} ν={:.2e}",
                     iter.x.iter().map(|v| format!("{v:.3}")).collect::<Vec<_>>(),
                     f_curr,
@@ -298,7 +298,7 @@ impl SqpAlgorithm {
             #[cfg(test)]
             if self.opts.print_level >= 1 {
                 let p_inf = sol.x.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
-                tracing::debug!(target: "pounce::sqp", 
+                tracing::debug!(target: "pounce::sqp",
                     "         qp: ‖p‖_inf={:.3e} ‖λ_g_qp‖_inf={:.3e}",
                     p_inf,
                     sol.lambda_g.iter().map(|v| v.abs()).fold(0.0_f64, f64::max)
@@ -342,7 +342,7 @@ impl SqpAlgorithm {
             };
             #[cfg(test)]
             if self.opts.print_level >= 1 {
-                tracing::debug!(target: "pounce::sqp", 
+                tracing::debug!(target: "pounce::sqp",
                     "         ls: α={:.3e} ν={:.3e} ok={} f_new={:.3e}",
                     ls.alpha, ls.nu, ls.success, ls.f_new
                 );

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -210,7 +210,7 @@ impl SqpAlgorithm {
 
             #[cfg(test)]
             if self.opts.print_level >= 1 {
-                eprintln!(
+                tracing::debug!(target: "pounce::sqp", 
                     "[sqp k={outer:3}] x={:?} f={:.4e} ‖c‖={:.2e} stat={:.2e} ν={:.2e}",
                     iter.x.iter().map(|v| format!("{v:.3}")).collect::<Vec<_>>(),
                     f_curr,
@@ -298,7 +298,7 @@ impl SqpAlgorithm {
             #[cfg(test)]
             if self.opts.print_level >= 1 {
                 let p_inf = sol.x.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
-                eprintln!(
+                tracing::debug!(target: "pounce::sqp", 
                     "         qp: ‖p‖_inf={:.3e} ‖λ_g_qp‖_inf={:.3e}",
                     p_inf,
                     sol.lambda_g.iter().map(|v| v.abs()).fold(0.0_f64, f64::max)
@@ -342,7 +342,7 @@ impl SqpAlgorithm {
             };
             #[cfg(test)]
             if self.opts.print_level >= 1 {
-                eprintln!(
+                tracing::debug!(target: "pounce::sqp", 
                     "         ls: α={:.3e} ν={:.3e} ok={} f_new={:.3e}",
                     ls.alpha, ls.nu, ls.success, ls.f_new
                 );

--- a/crates/pounce-algorithm/tests/colored_table.rs
+++ b/crates/pounce-algorithm/tests/colored_table.rs
@@ -1,0 +1,64 @@
+//! Integration test for the colored iteration table (pounce#71).
+//!
+//! The table is styled at the print site by wrapping the *plain*
+//! `format_row` string in an `anstyle::Style`. These tests assert the
+//! two invariants that keep that safe:
+//!
+//! 1. Styling adds only zero-width SGR escapes — stripping them must
+//!    return the original plain row byte-for-byte (column alignment is
+//!    preserved).
+//! 2. When color is stripped (redirected output / `NO_COLOR`), the
+//!    bytes are exactly the plain row with no escapes.
+
+use pounce_common::style::iteration_row_style_with;
+
+/// A representative plain iteration row (fixed-width, as produced by
+/// `OrigIterationOutput::format_row`).
+const PLAIN_ROW: &str =
+    "   7  1.2340000e+00 1.00e-02 2.00e-03   -3.0 4.00e-01      - 5.00e-01 6.00e-01R  2";
+
+fn style_row(plain: &str, alpha: f64, alpha_char: char, truecolor: bool) -> String {
+    let style = iteration_row_style_with(alpha, alpha_char, truecolor);
+    format!("{}{}{}", style.render(), plain, style.render_reset())
+}
+
+#[test]
+fn styled_row_strips_back_to_plain() {
+    // Restoration row with a mid-range alpha — exercises both fg
+    // gradient and bg.
+    let styled = style_row(PLAIN_ROW, 0.4, 'R', true);
+    assert!(styled.contains('\u{1b}'), "expected ANSI escapes: {styled:?}");
+    let stripped = anstream::adapter::strip_str(&styled).to_string();
+    assert_eq!(stripped, PLAIN_ROW, "stripping must recover the plain row");
+}
+
+#[test]
+fn normal_row_strips_back_to_plain() {
+    let styled = style_row(PLAIN_ROW, 1.0, ' ', true);
+    let stripped = anstream::adapter::strip_str(&styled).to_string();
+    assert_eq!(stripped, PLAIN_ROW);
+}
+
+#[test]
+fn anstream_strips_when_not_a_terminal() {
+    // Writing styled bytes through a StripStream (what an `AutoStream`
+    // degrades to for a non-TTY sink) must yield plain text.
+    use std::io::Write as _;
+    let styled = style_row(PLAIN_ROW, 0.1, 'S', true);
+    let mut buf: Vec<u8> = Vec::new();
+    {
+        let mut s = anstream::StripStream::new(&mut buf);
+        s.write_all(styled.as_bytes()).unwrap();
+        s.flush().unwrap();
+    }
+    assert_eq!(String::from_utf8(buf).unwrap(), PLAIN_ROW);
+}
+
+#[test]
+fn non_truecolor_uses_256_but_still_strips_clean() {
+    // The 256-color downgrade path must also be zero-width.
+    let styled = style_row(PLAIN_ROW, 0.5, 'R', false);
+    assert!(styled.contains('\u{1b}'));
+    let stripped = anstream::adapter::strip_str(&styled).to_string();
+    assert_eq!(stripped, PLAIN_ROW);
+}

--- a/crates/pounce-algorithm/tests/colored_table.rs
+++ b/crates/pounce-algorithm/tests/colored_table.rs
@@ -27,7 +27,10 @@ fn styled_row_strips_back_to_plain() {
     // Restoration row with a mid-range alpha — exercises both fg
     // gradient and bg.
     let styled = style_row(PLAIN_ROW, 0.4, 'R', true);
-    assert!(styled.contains('\u{1b}'), "expected ANSI escapes: {styled:?}");
+    assert!(
+        styled.contains('\u{1b}'),
+        "expected ANSI escapes: {styled:?}"
+    );
     let stripped = anstream::adapter::strip_str(&styled).to_string();
     assert_eq!(stripped, PLAIN_ROW, "stripping must recover the plain row");
 }

--- a/crates/pounce-cinterface/Cargo.toml
+++ b/crates/pounce-cinterface/Cargo.toml
@@ -22,6 +22,7 @@ pounce-restoration.workspace = true
 pounce-sensitivity.workspace = true
 pounce-linsol.workspace = true
 pounce-solve-report.workspace = true
+pounce-observability.workspace = true
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -240,6 +240,11 @@ pub unsafe extern "C" fn CreateIpoptProblem(
     eval_jac_g: Option<Eval_Jac_G_CB>,
     eval_h: Option<Eval_H_CB>,
 ) -> IpoptProblem {
+    // Install the tracing subscriber on first use so C consumers
+    // (cyipopt, AMPL, …) get logging and the iteration collector that
+    // backs `IpoptEnableIterHistory` (pounce#71). Idempotent.
+    pounce_observability::init_subscriber();
+
     if n < 0 || m < 0 || nele_jac < 0 || nele_hess < 0 {
         return std::ptr::null_mut();
     }

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -38,10 +38,11 @@ pounce-presolve.workspace = true
 pounce-linalg.workspace = true
 pounce-sensitivity.workspace = true
 pounce-solve-report.workspace = true
+pounce-observability.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 libloading = "0.8"
-log = "0.4"
+tracing.workspace = true
 
 [features]
 default = []

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -40,6 +40,11 @@ use std::process::ExitCode;
 use std::rc::Rc;
 
 pub fn main() -> ExitCode {
+    // Install the tracing subscriber first so even argument-parse
+    // diagnostics and the iteration collector are active (pounce#71).
+    // Honors RUST_LOG, NO_COLOR, and POUNCE_LOG_FORMAT.
+    pounce_observability::init_subscriber();
+
     let args = match Args::parse_argv(std::env::args().collect()) {
         Ok(a) => a,
         Err(msg) => {

--- a/crates/pounce-cli/src/nl_external.rs
+++ b/crates/pounce-cli/src/nl_external.rs
@@ -674,7 +674,7 @@ unsafe extern "C" fn trampoline_addfunc(
 /// Stub — some libraries ask us to register an AtReset callback. Pyomo logs a
 /// warning and does nothing. We do the same.
 unsafe extern "C" fn trampoline_atreset(_ae: *mut AmplExports, _f: *mut c_void, _v: *mut c_void) {
-    log::debug!("external library registered an AtReset callback; ignoring");
+    tracing::debug!("external library registered an AtReset callback; ignoring");
 }
 
 /// Stub — invoked by libraries that use random-valued externals. We just

--- a/crates/pounce-common/Cargo.toml
+++ b/crates/pounce-common/Cargo.toml
@@ -10,5 +10,13 @@ description = "Common primitives for POUNCE (port of Ipopt's src/Common): types,
 keywords = ["optimization", "nlp", "ipopt", "solver"]
 categories = ["mathematics", "algorithms"]
 
+[dependencies]
+# Color vocabulary + terminal-capability detection for the tiger/rust
+# branded output (pounce#71). Kept dependency-light so this leaf crate
+# does not drag `tracing-subscriber` into every downstream build; the
+# subscriber wiring lives in `pounce-observability`.
+anstyle.workspace = true
+anstyle-query.workspace = true
+
 [lints]
 workspace = true

--- a/crates/pounce-common/src/lib.rs
+++ b/crates/pounce-common/src/lib.rs
@@ -12,6 +12,7 @@ pub mod exception;
 pub mod journalist;
 pub mod options_list;
 pub mod reg_options;
+pub mod style;
 pub mod tagged;
 pub mod timing;
 pub mod types;

--- a/crates/pounce-common/src/style.rs
+++ b/crates/pounce-common/src/style.rs
@@ -1,0 +1,274 @@
+//! Tiger / rust / warm branded color palette for POUNCE output
+//! (pounce#71).
+//!
+//! This module is **pure** — every function maps values to
+//! [`anstyle`] colors/styles with no I/O and no global state, so the
+//! whole palette is unit-testable without a TTY. Terminal-capability
+//! detection ([`truecolor_enabled`], [`color_enabled_stdout`]) reads
+//! the environment but never emits anything; the actual color
+//! *stripping* for the iteration table is delegated to
+//! `anstream::AutoStream` at the print site.
+//!
+//! Two orthogonal channels drive the iteration table:
+//!
+//! * **Background** marks *restoration* lines, keyed off the
+//!   per-iteration `alpha_primal_char` tag — `'s'` soft-stay → tan,
+//!   `'S'` soft-exit → amber, `'R'` (and the dedicated restoration
+//!   phase's `r`-suffixed rows) → deep rust.
+//! * **Foreground** is a smooth gradient driven by the primal step
+//!   length `alpha ∈ [0, 1]`. On normal lines it runs black (α = 1,
+//!   full Newton step) → red (α → 0, stalling). On restoration lines
+//!   the ramp shifts to cream → bright-yellow so the text stays
+//!   legible on the dark background.
+
+use anstyle::{Ansi256Color, Color, RgbColor, Style};
+
+// ---- Palette constants (tiger / rust / warm) ----
+
+/// Background for hard restoration (`'R'` + dedicated resto-phase rows).
+pub const RUST_DEEP: RgbColor = RgbColor(0x6e, 0x26, 0x0e);
+/// Background for soft-restoration "exit" (`'S'`).
+pub const AMBER: RgbColor = RgbColor(0xb5, 0x6a, 0x12);
+/// Background for soft-restoration "stay" (`'s'`).
+pub const TAN: RgbColor = RgbColor(0x8a, 0x6d, 0x3b);
+/// Accent used for `WARN`-level logs and banners.
+pub const TIGER_ORANGE: RgbColor = RgbColor(0xe8, 0x7a, 0x1e);
+/// Foreground on restoration lines at α = 1 (full step).
+pub const CREAM: RgbColor = RgbColor(0xf5, 0xe6, 0xc8);
+/// Foreground on restoration lines at α → 0 (stalling).
+pub const BRIGHT_YEL: RgbColor = RgbColor(0xff, 0xe0, 0x3a);
+/// Foreground on normal lines at α → 0 (stalling) — the "hot" red.
+pub const ALPHA_HOT: RgbColor = RgbColor(0xcc, 0x22, 0x00);
+/// Foreground on normal lines at α = 1 (full Newton step).
+pub const ALPHA_COOL: RgbColor = RgbColor(0x00, 0x00, 0x00);
+
+// ---- Restoration kind ↔ color ----
+
+/// `true` when `c` denotes a restoration line (`'s'`, `'S'`, `'R'`).
+/// `'t'`/`'T'` (tiny step) are deliberately excluded — that stalling
+/// condition is conveyed by the foreground gradient, not a background.
+pub fn is_resto_char(c: char) -> bool {
+    matches!(c, 's' | 'S' | 'R')
+}
+
+/// Map the iteration's `alpha_primal_char` to its restoration
+/// background, or `None` for a normal (non-restoration) line.
+pub fn resto_background_rgb(c: char) -> Option<RgbColor> {
+    match c {
+        's' => Some(TAN),
+        'S' => Some(AMBER),
+        'R' => Some(RUST_DEEP),
+        _ => None,
+    }
+}
+
+/// Human-readable restoration kind for the structured
+/// `pounce::iteration` tracing event.
+pub fn resto_kind_str(c: char) -> &'static str {
+    match c {
+        's' => "soft_stay",
+        'S' => "soft_exit",
+        'R' => "hard",
+        _ => "none",
+    }
+}
+
+// ---- Alpha gradient ----
+
+/// Linear interpolation of one 8-bit channel by `t ∈ [0, 1]`.
+fn lerp_u8(a: u8, b: u8, t: f64) -> u8 {
+    let v = a as f64 + (b as f64 - a as f64) * t;
+    v.round().clamp(0.0, 255.0) as u8
+}
+
+/// The raw RGB foreground for primal step length `alpha`. `in_resto`
+/// selects the cream→bright-yellow ramp instead of the black→red one.
+///
+/// `alpha` is clamped to `[0, 1]`; non-finite input is treated as a
+/// full step (`alpha = 1`). The interpolation parameter is `1 - alpha`
+/// so that α = 1 is "cool" (black / cream) and α → 0 is "hot"
+/// (red / bright-yellow).
+pub fn alpha_gradient_rgb(alpha: f64, in_resto: bool) -> RgbColor {
+    let alpha = if alpha.is_finite() { alpha.clamp(0.0, 1.0) } else { 1.0 };
+    let t = 1.0 - alpha;
+    let (cool, hot) = if in_resto { (CREAM, BRIGHT_YEL) } else { (ALPHA_COOL, ALPHA_HOT) };
+    RgbColor(
+        lerp_u8(cool.0, hot.0, t),
+        lerp_u8(cool.1, hot.1, t),
+        lerp_u8(cool.2, hot.2, t),
+    )
+}
+
+// ---- Truecolor → 256-color downgrade ----
+
+/// Snap an 8-bit value to its nearest index on the xterm 6×6×6 color
+/// cube's per-channel step ladder `[0, 95, 135, 175, 215, 255]`.
+fn cube_level(v: u8) -> u8 {
+    const STEPS: [u8; 6] = [0, 95, 135, 175, 215, 255];
+    let mut best = 0u8;
+    let mut best_d = u16::MAX;
+    for (i, &s) in STEPS.iter().enumerate() {
+        let d = (v as i16 - s as i16).unsigned_abs();
+        if d < best_d {
+            best_d = d;
+            best = i as u8;
+        }
+    }
+    best
+}
+
+/// Nearest xterm-256 cube color to an RGB triple. Used as the graceful
+/// fallback on terminals that advertise ANSI color but not truecolor.
+pub fn nearest_ansi256(c: RgbColor) -> Ansi256Color {
+    let r = cube_level(c.0);
+    let g = cube_level(c.1);
+    let b = cube_level(c.2);
+    Ansi256Color(16 + 36 * r + 6 * g + b)
+}
+
+/// Wrap an RGB color as an [`anstyle::Color`], downgrading to the
+/// nearest 256-color when the terminal lacks truecolor support.
+pub fn downgrade(c: RgbColor, truecolor: bool) -> Color {
+    if truecolor {
+        Color::Rgb(c)
+    } else {
+        Color::Ansi256(nearest_ansi256(c))
+    }
+}
+
+// ---- Composed iteration-row style ----
+
+/// Build the [`Style`] for one iteration-table row: foreground from the
+/// alpha gradient, optional background from the restoration kind.
+/// Honors the detected truecolor capability so the same call yields
+/// RGB on capable terminals and a 256-color approximation elsewhere.
+pub fn iteration_row_style(alpha_primal: f64, alpha_char: char) -> Style {
+    iteration_row_style_with(alpha_primal, alpha_char, truecolor_enabled())
+}
+
+/// [`iteration_row_style`] with the truecolor decision injected — the
+/// unit-test seam (no environment reads).
+pub fn iteration_row_style_with(alpha_primal: f64, alpha_char: char, truecolor: bool) -> Style {
+    let in_resto = is_resto_char(alpha_char);
+    let fg = downgrade(alpha_gradient_rgb(alpha_primal, in_resto), truecolor);
+    let mut style = Style::new().fg_color(Some(fg));
+    if let Some(bg) = resto_background_rgb(alpha_char) {
+        style = style.bg_color(Some(downgrade(bg, truecolor)));
+    }
+    style
+}
+
+// ---- Terminal-capability detection ----
+
+/// `true` when the terminal advertises 24-bit truecolor (`COLORTERM`).
+pub fn truecolor_enabled() -> bool {
+    anstyle_query::truecolor()
+}
+
+/// `true` when colored output should be emitted to stdout: stdout is a
+/// terminal and the user has not opted out via `NO_COLOR` (unless
+/// `CLICOLOR_FORCE` overrides). Stream-based call sites should prefer
+/// `anstream::AutoStream`, which applies the same policy while
+/// stripping escapes from redirected output; this helper is for code
+/// that must branch without a stream handle.
+pub fn color_enabled_stdout() -> bool {
+    use std::io::IsTerminal;
+    if anstyle_query::clicolor_force() {
+        return true;
+    }
+    if anstyle_query::no_color() {
+        return false;
+    }
+    std::io::stdout().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resto_background_maps_three_kinds() {
+        assert_eq!(resto_background_rgb('s'), Some(TAN));
+        assert_eq!(resto_background_rgb('S'), Some(AMBER));
+        assert_eq!(resto_background_rgb('R'), Some(RUST_DEEP));
+        // Non-restoration tags (including tiny-step) get no background.
+        for c in [' ', 'f', 'h', 'w', 'W', 't', 'T'] {
+            assert_eq!(resto_background_rgb(c), None, "char {c:?}");
+        }
+    }
+
+    #[test]
+    fn is_resto_char_only_for_s_caps_r() {
+        for c in ['s', 'S', 'R'] {
+            assert!(is_resto_char(c), "char {c:?}");
+        }
+        for c in [' ', 'f', 'h', 'w', 'W', 't', 'T'] {
+            assert!(!is_resto_char(c), "char {c:?}");
+        }
+    }
+
+    #[test]
+    fn alpha_gradient_normal_endpoints() {
+        // Full step → black; stalled → hot red.
+        assert_eq!(alpha_gradient_rgb(1.0, false), ALPHA_COOL);
+        assert_eq!(alpha_gradient_rgb(0.0, false), ALPHA_HOT);
+    }
+
+    #[test]
+    fn alpha_gradient_resto_endpoints() {
+        assert_eq!(alpha_gradient_rgb(1.0, true), CREAM);
+        assert_eq!(alpha_gradient_rgb(0.0, true), BRIGHT_YEL);
+    }
+
+    #[test]
+    fn alpha_gradient_is_monotonic_toward_hot() {
+        // As alpha shrinks the red channel must not decrease (normal
+        // ramp drives from black 0x00 → 0xcc).
+        let mut prev = alpha_gradient_rgb(1.0, false).0;
+        for step in 1..=10 {
+            let a = 1.0 - step as f64 / 10.0;
+            let r = alpha_gradient_rgb(a, false).0;
+            assert!(r >= prev, "alpha={a} red went backwards {prev}->{r}");
+            prev = r;
+        }
+        assert_eq!(prev, ALPHA_HOT.0);
+    }
+
+    #[test]
+    fn alpha_gradient_clamps_and_handles_nonfinite() {
+        assert_eq!(alpha_gradient_rgb(2.0, false), ALPHA_COOL);
+        assert_eq!(alpha_gradient_rgb(-1.0, false), ALPHA_HOT);
+        // NaN is treated as a full step (no false stalling alarm).
+        assert_eq!(alpha_gradient_rgb(f64::NAN, false), ALPHA_COOL);
+    }
+
+    #[test]
+    fn downgrade_picks_rgb_or_256() {
+        assert_eq!(downgrade(RUST_DEEP, true), Color::Rgb(RUST_DEEP));
+        // 256-color path yields a cube index, never an RGB color.
+        match downgrade(RUST_DEEP, false) {
+            Color::Ansi256(_) => {}
+            other => panic!("expected Ansi256, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn nearest_ansi256_snaps_pure_colors() {
+        // Pure white → cube corner 231 (16 + 36*5 + 6*5 + 5).
+        assert_eq!(nearest_ansi256(RgbColor(0xff, 0xff, 0xff)), Ansi256Color(231));
+        // Pure black → cube origin 16.
+        assert_eq!(nearest_ansi256(RgbColor(0x00, 0x00, 0x00)), Ansi256Color(16));
+    }
+
+    #[test]
+    fn iteration_row_style_composes_fg_and_bg() {
+        // Restoration row: both fg gradient and bg present.
+        let s = iteration_row_style_with(0.5, 'R', true);
+        assert!(s.get_fg_color().is_some());
+        assert_eq!(s.get_bg_color(), Some(Color::Rgb(RUST_DEEP)));
+        // Normal row: fg only, no background.
+        let n = iteration_row_style_with(1.0, ' ', true);
+        assert_eq!(n.get_fg_color(), Some(Color::Rgb(ALPHA_COOL)));
+        assert_eq!(n.get_bg_color(), None);
+    }
+}

--- a/crates/pounce-common/src/style.rs
+++ b/crates/pounce-common/src/style.rs
@@ -89,9 +89,17 @@ fn lerp_u8(a: u8, b: u8, t: f64) -> u8 {
 /// so that α = 1 is "cool" (black / cream) and α → 0 is "hot"
 /// (red / bright-yellow).
 pub fn alpha_gradient_rgb(alpha: f64, in_resto: bool) -> RgbColor {
-    let alpha = if alpha.is_finite() { alpha.clamp(0.0, 1.0) } else { 1.0 };
+    let alpha = if alpha.is_finite() {
+        alpha.clamp(0.0, 1.0)
+    } else {
+        1.0
+    };
     let t = 1.0 - alpha;
-    let (cool, hot) = if in_resto { (CREAM, BRIGHT_YEL) } else { (ALPHA_COOL, ALPHA_HOT) };
+    let (cool, hot) = if in_resto {
+        (CREAM, BRIGHT_YEL)
+    } else {
+        (ALPHA_COOL, ALPHA_HOT)
+    };
     RgbColor(
         lerp_u8(cool.0, hot.0, t),
         lerp_u8(cool.1, hot.1, t),
@@ -255,9 +263,15 @@ mod tests {
     #[test]
     fn nearest_ansi256_snaps_pure_colors() {
         // Pure white → cube corner 231 (16 + 36*5 + 6*5 + 5).
-        assert_eq!(nearest_ansi256(RgbColor(0xff, 0xff, 0xff)), Ansi256Color(231));
+        assert_eq!(
+            nearest_ansi256(RgbColor(0xff, 0xff, 0xff)),
+            Ansi256Color(231)
+        );
         // Pure black → cube origin 16.
-        assert_eq!(nearest_ansi256(RgbColor(0x00, 0x00, 0x00)), Ansi256Color(16));
+        assert_eq!(
+            nearest_ansi256(RgbColor(0x00, 0x00, 0x00)),
+            Ansi256Color(16)
+        );
     }
 
     #[test]

--- a/crates/pounce-common/src/style.rs
+++ b/crates/pounce-common/src/style.rs
@@ -111,6 +111,10 @@ pub fn alpha_gradient_rgb(alpha: f64, in_resto: bool) -> RgbColor {
 
 /// Snap an 8-bit value to its nearest index on the xterm 6×6×6 color
 /// cube's per-channel step ladder `[0, 95, 135, 175, 215, 255]`.
+///
+/// Returns the 0-based level *index* (0..=5), not the step value itself —
+/// `nearest_ansi256` combines three such indices into the cube offset
+/// `16 + 36*r + 6*g + b`.
 fn cube_level(v: u8) -> u8 {
     const STEPS: [u8; 6] = [0, 95, 135, 175, 215, 255];
     let mut best = 0u8;

--- a/crates/pounce-feral/Cargo.toml
+++ b/crates/pounce-feral/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["mathematics", "algorithms"]
 pounce-common.workspace = true
 pounce-linsol.workspace = true
 feral.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pounce-feral/src/lib.rs
+++ b/crates/pounce-feral/src/lib.rs
@@ -59,6 +59,11 @@ pub struct FeralSolverInterface {
 
     negevals: Index,
 
+    /// Fill-reducing ordering configured at construction; surfaced on
+    /// the `linear_solve` tracing span after each factorization
+    /// (pounce#71).
+    ordering: OrderingMethod,
+
     /// Absolute near-singularity floor; see
     /// [`FeralConfig::singular_pivot_floor`].
     singular_pivot_floor: f64,
@@ -305,6 +310,7 @@ impl FeralSolverInterface {
             values: Vec::new(),
             matrix: None,
             negevals: 0,
+            ordering: cfg.ordering,
             singular_pivot_floor: cfg.singular_pivot_floor,
             summary: LinearSolverSummary {
                 solver_name: "feral".to_string(),
@@ -364,6 +370,20 @@ impl FeralSolverInterface {
                 *guard = s.clone();
             }
         }
+
+        // Surface the linear-solve characteristics on the enclosing
+        // `linear_solve` tracing span (pounce#71). A no-op unless that
+        // span is active and declared these fields, so non-IPM callers
+        // and the no-subscriber case pay nothing. Re-factorizations
+        // (regularization retries) overwrite with last-wins, so the
+        // span reflects the accepted factorization.
+        let span = tracing::Span::current();
+        span.record("n", self.dim);
+        span.record("matrix_nnz", stats.nnz_a);
+        span.record("factor_nnz", stats.nnz_l);
+        span.record("inertia_neg", stats.inertia.negative);
+        span.record("fill_ratio", stats.fill_ratio);
+        span.record("ordering", tracing::field::debug(self.ordering));
     }
 
     /// Build the lower-triangle CSC view, factor it, and stash the

--- a/crates/pounce-feral/src/lib.rs
+++ b/crates/pounce-feral/src/lib.rs
@@ -411,21 +411,19 @@ impl FeralSolverInterface {
                 };
                 self.negevals = neg as Index;
                 if zero > 0 {
-                    if std::env::var_os("POUNCE_DBG_INERTIA").is_some() {
-                        eprintln!(
-                            "[INERTIA] singular: neg={} zero={} expected={} dim={}",
-                            neg, zero, number_of_neg_evals, self.dim
-                        );
-                    }
+                    tracing::debug!(
+                        target: "pounce::linsol",
+                        neg, zero, expected = number_of_neg_evals, dim = self.dim,
+                        "inertia singular"
+                    );
                     return ESymSolverStatus::Singular;
                 }
                 if check_neg_evals && self.negevals != number_of_neg_evals {
-                    if std::env::var_os("POUNCE_DBG_INERTIA").is_some() {
-                        eprintln!(
-                            "[INERTIA] mismatch: got_neg={} expected={} dim={}",
-                            self.negevals, number_of_neg_evals, self.dim
-                        );
-                    }
+                    tracing::debug!(
+                        target: "pounce::linsol",
+                        got_neg = self.negevals, expected = number_of_neg_evals, dim = self.dim,
+                        "inertia mismatch"
+                    );
                     return ESymSolverStatus::WrongInertia;
                 }
                 // Near-singularity (MA57 CNTL(2) analog). feral's default

--- a/crates/pounce-linsol/Cargo.toml
+++ b/crates/pounce-linsol/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["mathematics", "algorithms"]
 [dependencies]
 pounce-common.workspace = true
 pounce-linalg.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pounce-linsol/src/t_sym_solver.rs
+++ b/crates/pounce-linsol/src/t_sym_solver.rs
@@ -207,8 +207,9 @@ impl TSymLinearSolver {
                 // not yet
             } else if let Ok(path) = std::env::var("POUNCE_DBG_KKT_DUMP") {
                 if !WARNED.swap(true, Ordering::SeqCst) {
-                    eprintln!(
-                        "warning: POUNCE_DBG_KKT_DUMP is deprecated; prefer `--dump kkt:<iter-spec>` (see pounce --help)"
+                    tracing::warn!(
+                        target: "pounce::linsol",
+                        "POUNCE_DBG_KKT_DUMP is deprecated; prefer `--dump kkt:<iter-spec>` (see pounce --help)"
                     );
                 }
                 use std::io::Write;

--- a/crates/pounce-observability/Cargo.toml
+++ b/crates/pounce-observability/Cargo.toml
@@ -16,8 +16,12 @@ pounce-common.workspace = true
 pounce-nlp = { workspace = true, features = ["serde"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true
+tracing-log.workspace = true
 anstyle.workspace = true
 anstyle-query.workspace = true
+
+[dev-dependencies]
+log = "0.4"
 
 [lints]
 workspace = true

--- a/crates/pounce-observability/Cargo.toml
+++ b/crates/pounce-observability/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pounce-observability"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "Observability for POUNCE (pounce#71): tracing subscriber install, tiger/rust themed text formatter, and the per-iteration collector layer that feeds the JSON solve report from the `pounce::iteration` event."
+keywords = ["optimization", "tracing", "logging", "ipopt", "solver"]
+categories = ["mathematics", "development-tools::debugging"]
+
+[dependencies]
+pounce-common.workspace = true
+# `serde` enabled so the collected `IterRecord`s round-trip into the
+# JSON solve report.
+pounce-nlp = { workspace = true, features = ["serde"] }
+tracing.workspace = true
+tracing-subscriber.workspace = true
+anstyle.workspace = true
+anstyle-query.workspace = true
+
+[lints]
+workspace = true

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -213,6 +213,20 @@ where
     }
 }
 
+/// Per-layer filter for [`IterCollectorLayer`]: admit spans (so the
+/// collector's `event_scope` can see the `restoration` ancestor for
+/// scoping) plus the iteration event itself.
+///
+/// A per-layer filter is required so the collector does not force every
+/// callsite globally enabled; without admitting spans here the filtered
+/// `Context` would hide span ancestry. Defined once and reused at every
+/// `with_filter` site — note the `with_filter` *call* must still live in
+/// each branch, because the resulting `Filtered` type carries the
+/// per-branch subscriber type parameter.
+fn collector_admits(m: &tracing::Metadata<'_>) -> bool {
+    m.is_span() || m.target() == ITER_TARGET
+}
+
 // ---- Tiger/rust themed text formatter ----
 
 /// Foreground style for a log level in the tiger/rust theme.
@@ -311,14 +325,7 @@ fn install() {
     // it carries its own target filter. It is constructed inside each
     // branch so its subscriber type parameter is inferred per-branch.
     if want_json {
-        let collector = IterCollectorLayer.with_filter(filter_fn(|m| {
-            // Admit spans (so `event_scope` can see the `restoration`
-            // ancestor for scoping) plus the iteration event itself.
-            // A per-layer filter is required so the collector does not
-            // force every callsite globally enabled; without admitting
-            // spans here the filtered Context would hide span ancestry.
-            m.is_span() || m.target() == ITER_TARGET
-        }));
+        let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
         let json_layer = tracing_subscriber::fmt::layer()
             .json()
             .with_writer(std::io::stderr)
@@ -328,14 +335,7 @@ fn install() {
             .with(collector)
             .try_init();
     } else {
-        let collector = IterCollectorLayer.with_filter(filter_fn(|m| {
-            // Admit spans (so `event_scope` can see the `restoration`
-            // ancestor for scoping) plus the iteration event itself.
-            // A per-layer filter is required so the collector does not
-            // force every callsite globally enabled; without admitting
-            // spans here the filtered Context would hide span ancestry.
-            m.is_span() || m.target() == ITER_TARGET
-        }));
+        let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
         let ansi = ansi_enabled();
         let text_layer = tracing_subscriber::fmt::layer()
             .event_format(TigerFormat)
@@ -471,7 +471,7 @@ mod tests {
         // a `target`-only filter hid span ancestry and let inner
         // restoration iterations leak into the report.
         let collector =
-            IterCollectorLayer.with_filter(filter_fn(|m| m.is_span() || m.target() == ITER_TARGET));
+            IterCollectorLayer.with_filter(filter_fn(collector_admits));
         let subscriber = tracing_subscriber::registry().with(collector);
 
         let captured = tracing::subscriber::with_default(subscriber, || {

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -54,6 +54,27 @@ thread_local! {
     static CAPTURE: RefCell<Option<Vec<IterRecord>>> = const { RefCell::new(None) };
 }
 
+/// Set once at subscriber install when `POUNCE_LOG_FORMAT=json`, so the
+/// per-iteration event is emitted (for the JSON sink) even when no
+/// in-process capture is active.
+static JSON_LOGGING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the per-iteration `pounce::iteration` event has a consumer
+/// right now, so the algorithm can skip emitting it (and the field
+/// evaluation it entails) when nothing would observe it.
+///
+/// True when either an [`IterCaptureGuard`] is active on this thread
+/// (the JSON report wants the trajectory) or JSON logging is installed
+/// (the stderr sink wants it). In the common default run — text logs,
+/// no iter-history capture — this is `false`, so the event costs
+/// nothing.
+pub fn iteration_event_wanted() -> bool {
+    if JSON_LOGGING.load(std::sync::atomic::Ordering::Relaxed) {
+        return true;
+    }
+    CAPTURE.with(|c| c.borrow().is_some())
+}
+
 /// RAII activation of per-iteration capture for one solve.
 ///
 /// Construct with [`IterCaptureGuard::start`] immediately before the
@@ -261,6 +282,10 @@ fn install() {
     let want_json = std::env::var("POUNCE_LOG_FORMAT")
         .map(|v| v.eq_ignore_ascii_case("json"))
         .unwrap_or(false);
+    // Record the JSON-sink decision so `iteration_event_wanted()` keeps
+    // emitting the per-iteration event for the stderr stream even when
+    // no in-process capture is active.
+    JSON_LOGGING.store(want_json, std::sync::atomic::Ordering::Relaxed);
 
     // The collector only ever wants the iteration event; it must NOT be
     // subject to the console's `pounce::iteration=off` suppression, so
@@ -350,6 +375,17 @@ mod tests {
             alpha_primal_char: c,
             ls_trials: 1,
         }
+    }
+
+    #[test]
+    fn iteration_event_wanted_tracks_active_capture() {
+        // Default (no capture on this thread, JSON sink off): nothing
+        // consumes the event, so it should be suppressed.
+        assert!(!iteration_event_wanted());
+        let guard = IterCaptureGuard::start();
+        assert!(iteration_event_wanted(), "capture active → event wanted");
+        let _ = guard.finish();
+        assert!(!iteration_event_wanted(), "capture ended → event suppressed");
     }
 
     #[test]

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -160,7 +160,15 @@ impl Visit for IterVisitor {
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.record_i64(field, value as i64);
+        // Match the field directly rather than routing through
+        // `record_i64` (which would `value as i64`-truncate a value
+        // above `i64::MAX`). `iter`/`ls_trials` never approach that, but
+        // matching here keeps the cast localized to the two real fields.
+        match field.name() {
+            "iter" => self.rec.iter = value as Index,
+            "ls_trials" => self.rec.ls_trials = value as Index,
+            _ => {}
+        }
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
@@ -270,6 +278,11 @@ pub fn init_subscriber() {
 /// Install a subscriber suitable for tests: same layers as
 /// [`init_subscriber`], so iteration capture works under
 /// [`IterCaptureGuard`]. Idempotent.
+///
+/// Currently identical to [`init_subscriber`]; kept as a distinct entry
+/// point so test setup can diverge (e.g. an in-memory sink) without
+/// touching the production install path. Tests needing an *isolated*
+/// subscriber should build their own with `with_default` instead.
 pub fn init_for_tests() {
     install();
 }
@@ -529,11 +542,13 @@ mod tests {
     }
 
     #[test]
-    fn visitor_reconstructs_record_fields() {
-        // Mimic what the collector does given the event field values.
+    fn iter_record_default_and_assignment() {
+        // This checks `IterRecord` field assignment, not the `Visit`
+        // impl — constructing a real `tracing::field::Field` standalone
+        // needs a callsite, so the visitor's record_* arms are covered
+        // end-to-end by `collector_excludes_restoration_nested_iterations`
+        // (which emits real events and asserts the rebuilt `iter`s).
         let mut v = IterVisitor::default();
-        // Direct field assignment exercises the same match arms the
-        // visitor uses at runtime via the typed record_* methods.
         v.rec.iter = 7;
         v.rec.alpha_primal = 0.25;
         v.rec.alpha_primal_char = 'S';

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -267,7 +267,14 @@ fn install() {
     // it carries its own target filter. It is constructed inside each
     // branch so its subscriber type parameter is inferred per-branch.
     if want_json {
-        let collector = IterCollectorLayer.with_filter(filter_fn(|m| m.target() == ITER_TARGET));
+        let collector = IterCollectorLayer.with_filter(filter_fn(|m| {
+            // Admit spans (so `event_scope` can see the `restoration`
+            // ancestor for scoping) plus the iteration event itself.
+            // A per-layer filter is required so the collector does not
+            // force every callsite globally enabled; without admitting
+            // spans here the filtered Context would hide span ancestry.
+            m.is_span() || m.target() == ITER_TARGET
+        }));
         let json_layer = tracing_subscriber::fmt::layer()
             .json()
             .with_writer(std::io::stderr)
@@ -277,7 +284,14 @@ fn install() {
             .with(collector)
             .try_init();
     } else {
-        let collector = IterCollectorLayer.with_filter(filter_fn(|m| m.target() == ITER_TARGET));
+        let collector = IterCollectorLayer.with_filter(filter_fn(|m| {
+            // Admit spans (so `event_scope` can see the `restoration`
+            // ancestor for scoping) plus the iteration event itself.
+            // A per-layer filter is required so the collector does not
+            // force every callsite globally enabled; without admitting
+            // spans here the filtered Context would hide span ancestry.
+            m.is_span() || m.target() == ITER_TARGET
+        }));
         let ansi = ansi_enabled();
         let text_layer = tracing_subscriber::fmt::layer()
             .event_format(TigerFormat)
@@ -375,6 +389,48 @@ mod tests {
         assert_eq!(outer_got.len(), 2);
         assert_eq!(outer_got[0].iter, 0);
         assert_eq!(outer_got[1].iter, 1);
+    }
+
+    #[test]
+    fn collector_excludes_restoration_nested_iterations() {
+        use tracing_subscriber::filter::filter_fn;
+        use tracing_subscriber::prelude::*;
+
+        fn emit(iter: i64, ch: char) {
+            let s = ch.to_string();
+            tracing::info!(
+                target: ITER_TARGET,
+                iter = iter,
+                objective = 0.0,
+                alpha_primal = 1.0,
+                alpha_char = s.as_str(),
+            );
+        }
+
+        // Same layer wiring as `install()`: the filter must admit spans
+        // so the collector's `event_scope` can see the `restoration`
+        // ancestor. Regression guard for the per-layer-filter bug where
+        // a `target`-only filter hid span ancestry and let inner
+        // restoration iterations leak into the report.
+        let collector = IterCollectorLayer
+            .with_filter(filter_fn(|m| m.is_span() || m.target() == ITER_TARGET));
+        let subscriber = tracing_subscriber::registry().with(collector);
+
+        let captured = tracing::subscriber::with_default(subscriber, || {
+            let guard = IterCaptureGuard::start();
+            emit(0, ' '); // outer -> captured
+            {
+                let _resto = tracing::info_span!("restoration").entered();
+                let _inner_solve = tracing::info_span!("solve").entered();
+                let _inner_iter = tracing::info_span!("iteration").entered();
+                emit(99, 'R'); // inner restoration sub-solve -> excluded
+            }
+            emit(1, ' '); // outer -> captured
+            guard.finish()
+        });
+
+        let iters: Vec<i32> = captured.iter().map(|r| r.iter).collect();
+        assert_eq!(iters, vec![0, 1], "inner restoration iteration leaked: {iters:?}");
     }
 
     #[test]

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -239,7 +239,13 @@ where
         let level = *meta.level();
         if writer.has_ansi_escapes() {
             let style = level_style(level);
-            write!(writer, "{}{:>5}{} ", style.render(), level, style.render_reset())?;
+            write!(
+                writer,
+                "{}{:>5}{} ",
+                style.render(),
+                level,
+                style.render_reset()
+            )?;
         } else {
             write!(writer, "{level:>5} ")?;
         }
@@ -385,7 +391,10 @@ mod tests {
         let guard = IterCaptureGuard::start();
         assert!(iteration_event_wanted(), "capture active → event wanted");
         let _ = guard.finish();
-        assert!(!iteration_event_wanted(), "capture ended → event suppressed");
+        assert!(
+            !iteration_event_wanted(),
+            "capture ended → event suppressed"
+        );
     }
 
     #[test]
@@ -448,8 +457,8 @@ mod tests {
         // ancestor. Regression guard for the per-layer-filter bug where
         // a `target`-only filter hid span ancestry and let inner
         // restoration iterations leak into the report.
-        let collector = IterCollectorLayer
-            .with_filter(filter_fn(|m| m.is_span() || m.target() == ITER_TARGET));
+        let collector =
+            IterCollectorLayer.with_filter(filter_fn(|m| m.is_span() || m.target() == ITER_TARGET));
         let subscriber = tracing_subscriber::registry().with(collector);
 
         let captured = tracing::subscriber::with_default(subscriber, || {
@@ -466,7 +475,11 @@ mod tests {
         });
 
         let iters: Vec<i32> = captured.iter().map(|r| r.iter).collect();
-        assert_eq!(iters, vec![0, 1], "inner restoration iteration leaked: {iters:?}");
+        assert_eq!(
+            iters,
+            vec![0, 1],
+            "inner restoration iteration leaked: {iters:?}"
+        );
     }
 
     #[test]

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -470,8 +470,7 @@ mod tests {
         // ancestor. Regression guard for the per-layer-filter bug where
         // a `target`-only filter hid span ancestry and let inner
         // restoration iterations leak into the report.
-        let collector =
-            IterCollectorLayer.with_filter(filter_fn(collector_admits));
+        let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
         let subscriber = tracing_subscriber::registry().with(collector);
 
         let captured = tracing::subscriber::with_default(subscriber, || {

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -1,0 +1,386 @@
+//! Observability wiring for POUNCE (pounce#71).
+//!
+//! This crate owns the `tracing` subscriber install and the bridge
+//! between the structured per-iteration event and the JSON solve
+//! report. It is kept separate from the leaf `pounce-common` (which
+//! holds the pure color palette) because the collector needs both
+//! [`pounce_nlp::solve_statistics::IterRecord`] and
+//! `tracing-subscriber`.
+//!
+//! ## Two output channels, one event
+//!
+//! Each Newton iteration emits a single structured event at
+//! [`ITER_TARGET`] carrying `iter`, `mu`, `alpha_primal`, … The human
+//! terminal never sees this event (the colored fixed-width table,
+//! printed directly by `pounce-algorithm`, is its visual form, so the
+//! text console layer filters `pounce::iteration` out). Machines get
+//! it two ways:
+//!
+//! * `POUNCE_LOG_FORMAT=json` → the JSON layer prints it to stderr;
+//! * the [`IterCollectorLayer`] rebuilds an `IterRecord` from its
+//!   fields and appends it to the active [`IterCaptureGuard`] slot,
+//!   which the application drains into the solve report.
+//!
+//! The collector skips events nested inside a `restoration` span, so
+//! the report captures only the outer solve's iterations (including
+//! `'R'`-marked outer iters) and not the restoration sub-solve's inner
+//! IPM iterations — matching the pre-tracing behavior exactly.
+
+#![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
+
+use std::cell::RefCell;
+
+use pounce_common::types::{Index, Number};
+use pounce_nlp::solve_statistics::IterRecord;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::registry::LookupSpan;
+
+/// Target of the structured per-iteration event. The text console
+/// layer filters this target out (the colored table is its human
+/// form); the JSON layer and [`IterCollectorLayer`] keep it.
+pub const ITER_TARGET: &str = "pounce::iteration";
+
+/// Span name whose presence in an event's ancestry marks the event as
+/// belonging to the restoration sub-solve. The collector uses it to
+/// exclude inner restoration iterations from the report.
+pub const RESTORATION_SPAN: &str = "restoration";
+
+// ---- Per-solve capture slot ----
+
+thread_local! {
+    /// Active capture buffer for the current solve, or `None` when no
+    /// solve on this thread is recording its iteration history.
+    static CAPTURE: RefCell<Option<Vec<IterRecord>>> = const { RefCell::new(None) };
+}
+
+/// RAII activation of per-iteration capture for one solve.
+///
+/// Construct with [`IterCaptureGuard::start`] immediately before the
+/// solve and call [`IterCaptureGuard::finish`] after it to take the
+/// collected records. Solves run synchronously on one thread, so a
+/// thread-local slot suffices; restoration sub-solves are excluded by
+/// span scoping in the collector rather than by nesting guards.
+#[must_use = "call finish() to retrieve the captured iteration history"]
+pub struct IterCaptureGuard {
+    /// Any buffer that was active before this guard, restored on drop
+    /// so sequential or accidentally-nested solves don't clobber it.
+    prev: Option<Vec<IterRecord>>,
+}
+
+impl IterCaptureGuard {
+    /// Begin capturing iteration records on this thread.
+    pub fn start() -> Self {
+        let prev = CAPTURE.with(|c| c.borrow_mut().replace(Vec::new()));
+        Self { prev }
+    }
+
+    /// End capture and return the records collected since [`start`].
+    ///
+    /// [`start`]: IterCaptureGuard::start
+    pub fn finish(mut self) -> Vec<IterRecord> {
+        let prev = self.prev.take();
+        let captured = CAPTURE
+            .with(|c| std::mem::replace(&mut *c.borrow_mut(), prev))
+            .unwrap_or_default();
+        // Skip `Drop`: it would re-restore `self.prev` (now `None`) and
+        // clobber the buffer we just put back for an enclosing guard.
+        std::mem::forget(self);
+        captured
+    }
+}
+
+impl Drop for IterCaptureGuard {
+    fn drop(&mut self) {
+        // Restore the previous buffer if `finish` wasn't called.
+        let prev = self.prev.take();
+        CAPTURE.with(|c| *c.borrow_mut() = prev);
+    }
+}
+
+/// Append a record to the active capture slot, if any.
+fn push_record(rec: IterRecord) {
+    CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push(rec);
+        }
+    });
+}
+
+// ---- Event → IterRecord visitor ----
+
+#[derive(Default)]
+struct IterVisitor {
+    rec: IterRecord,
+}
+
+impl Visit for IterVisitor {
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        let v = value as Number;
+        match field.name() {
+            "objective" => self.rec.objective = v,
+            "inf_pr" => self.rec.inf_pr = v,
+            "inf_du" => self.rec.inf_du = v,
+            "mu" => self.rec.mu = v,
+            "d_norm" => self.rec.d_norm = v,
+            "regularization" => self.rec.regularization = v,
+            "alpha_dual" => self.rec.alpha_dual = v,
+            "alpha_primal" => self.rec.alpha_primal = v,
+            _ => {}
+        }
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        match field.name() {
+            "iter" => self.rec.iter = value as Index,
+            "ls_trials" => self.rec.ls_trials = value as Index,
+            _ => {}
+        }
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.record_i64(field, value as i64);
+    }
+
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "alpha_char" {
+            self.rec.alpha_primal_char = value.chars().next().unwrap_or(' ');
+        }
+    }
+
+    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {
+        // The message and any Debug-formatted fields are irrelevant to
+        // the numeric record.
+    }
+}
+
+// ---- Collector layer ----
+
+/// `tracing` layer that rebuilds [`IterRecord`]s from [`ITER_TARGET`]
+/// events into the active [`IterCaptureGuard`] slot.
+#[derive(Debug, Default, Clone)]
+pub struct IterCollectorLayer;
+
+impl<S> Layer<S> for IterCollectorLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &tracing::Event<'_>, ctx: Context<'_, S>) {
+        if event.metadata().target() != ITER_TARGET {
+            return;
+        }
+        // Skip iterations belonging to a restoration sub-solve so the
+        // report keeps only the outer trajectory.
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope.from_root() {
+                if span.name() == RESTORATION_SPAN {
+                    return;
+                }
+            }
+        }
+        let mut visitor = IterVisitor::default();
+        event.record(&mut visitor);
+        push_record(visitor.rec);
+    }
+}
+
+// ---- Tiger/rust themed text formatter ----
+
+/// Foreground style for a log level in the tiger/rust theme.
+fn level_style(level: tracing::Level) -> anstyle::Style {
+    use pounce_common::style::{ALPHA_HOT, TAN, TIGER_ORANGE};
+    let color = match level {
+        tracing::Level::ERROR => ALPHA_HOT,
+        tracing::Level::WARN => TIGER_ORANGE,
+        tracing::Level::INFO => TAN,
+        tracing::Level::DEBUG => anstyle::RgbColor(0x9a, 0x8c, 0x70),
+        tracing::Level::TRACE => anstyle::RgbColor(0x6a, 0x5d, 0x48),
+    };
+    anstyle::Style::new().fg_color(Some(anstyle::Color::Rgb(color)))
+}
+
+/// Compact event formatter: `LEVEL target: message field=…`, with the
+/// level rendered in the tiger/rust palette when ANSI is enabled.
+struct TigerFormat;
+
+impl<S, N> tracing_subscriber::fmt::FormatEvent<S, N> for TigerFormat
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> tracing_subscriber::fmt::FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &tracing_subscriber::fmt::FmtContext<'_, S, N>,
+        mut writer: tracing_subscriber::fmt::format::Writer<'_>,
+        event: &tracing::Event<'_>,
+    ) -> std::fmt::Result {
+        let meta = event.metadata();
+        let level = *meta.level();
+        if writer.has_ansi_escapes() {
+            let style = level_style(level);
+            write!(writer, "{}{:>5}{} ", style.render(), level, style.render_reset())?;
+        } else {
+            write!(writer, "{level:>5} ")?;
+        }
+        write!(writer, "{}: ", meta.target())?;
+        ctx.field_format().format_fields(writer.by_ref(), event)?;
+        writeln!(writer)
+    }
+}
+
+// ---- Subscriber install ----
+
+/// Install the global tracing subscriber for a normal run. Idempotent
+/// (`try_init`): safe to call from multiple frontends or repeated
+/// Python imports.
+///
+/// Reads `RUST_LOG` (filtering, default `info`), `POUNCE_LOG_FORMAT`
+/// (`text` | `json`), and `NO_COLOR`/`CLICOLOR_FORCE` (color policy).
+pub fn init_subscriber() {
+    install();
+}
+
+/// Install a subscriber suitable for tests: same layers as
+/// [`init_subscriber`], so iteration capture works under
+/// [`IterCaptureGuard`]. Idempotent.
+pub fn init_for_tests() {
+    install();
+}
+
+fn install() {
+    use tracing_subscriber::filter::filter_fn;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::EnvFilter;
+
+    let want_json = std::env::var("POUNCE_LOG_FORMAT")
+        .map(|v| v.eq_ignore_ascii_case("json"))
+        .unwrap_or(false);
+
+    // The collector only ever wants the iteration event; it must NOT be
+    // subject to the console's `pounce::iteration=off` suppression, so
+    // it carries its own target filter. It is constructed inside each
+    // branch so its subscriber type parameter is inferred per-branch.
+    if want_json {
+        let collector = IterCollectorLayer.with_filter(filter_fn(|m| m.target() == ITER_TARGET));
+        let json_layer = tracing_subscriber::fmt::layer()
+            .json()
+            .with_writer(std::io::stderr)
+            .with_filter(env_filter());
+        let _ = tracing_subscriber::registry()
+            .with(json_layer)
+            .with(collector)
+            .try_init();
+    } else {
+        let collector = IterCollectorLayer.with_filter(filter_fn(|m| m.target() == ITER_TARGET));
+        let ansi = ansi_enabled();
+        let text_layer = tracing_subscriber::fmt::layer()
+            .event_format(TigerFormat)
+            .with_ansi(ansi)
+            .with_writer(std::io::stderr)
+            .with_filter(console_filter());
+        let _ = tracing_subscriber::registry()
+            .with(text_layer)
+            .with(collector)
+            .try_init();
+    }
+
+    /// `RUST_LOG` filter, defaulting to `info`.
+    fn env_filter() -> EnvFilter {
+        EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"))
+    }
+
+    /// Console filter: `RUST_LOG` plus suppression of the iteration
+    /// target (its human form is the colored table on stdout).
+    fn console_filter() -> EnvFilter {
+        let base = env_filter();
+        match format!("{ITER_TARGET}=off").parse() {
+            Ok(directive) => base.add_directive(directive),
+            Err(_) => base,
+        }
+    }
+
+    /// ANSI on unless `NO_COLOR`, with `CLICOLOR_FORCE` overriding and
+    /// a terminal-capability check otherwise.
+    fn ansi_enabled() -> bool {
+        if anstyle_query::clicolor_force() {
+            return true;
+        }
+        if anstyle_query::no_color() {
+            return false;
+        }
+        anstyle_query::term_supports_ansi_color()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_record(iter: i32, alpha: f64, c: char) -> IterRecord {
+        IterRecord {
+            iter,
+            objective: 1.0,
+            inf_pr: 2.0,
+            inf_du: 3.0,
+            mu: 4.0,
+            d_norm: 5.0,
+            regularization: 6.0,
+            alpha_dual: 7.0,
+            alpha_primal: alpha,
+            alpha_primal_char: c,
+            ls_trials: 1,
+        }
+    }
+
+    #[test]
+    fn guard_captures_pushed_records() {
+        let guard = IterCaptureGuard::start();
+        push_record(sample_record(0, 1.0, ' '));
+        push_record(sample_record(1, 0.5, 'R'));
+        let got = guard.finish();
+        assert_eq!(got.len(), 2);
+        assert_eq!(got[1].iter, 1);
+        assert_eq!(got[1].alpha_primal_char, 'R');
+    }
+
+    #[test]
+    fn no_guard_means_records_are_dropped() {
+        // Without an active guard, push is a no-op (no panic, no leak).
+        push_record(sample_record(0, 1.0, ' '));
+        let guard = IterCaptureGuard::start();
+        let got = guard.finish();
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn guard_restores_previous_slot_on_finish() {
+        let outer = IterCaptureGuard::start();
+        push_record(sample_record(0, 1.0, ' '));
+        {
+            let inner = IterCaptureGuard::start();
+            push_record(sample_record(99, 0.1, 'R'));
+            let inner_got = inner.finish();
+            assert_eq!(inner_got.len(), 1);
+            assert_eq!(inner_got[0].iter, 99);
+        }
+        // Outer slot must still hold only its own record.
+        push_record(sample_record(1, 1.0, ' '));
+        let outer_got = outer.finish();
+        assert_eq!(outer_got.len(), 2);
+        assert_eq!(outer_got[0].iter, 0);
+        assert_eq!(outer_got[1].iter, 1);
+    }
+
+    #[test]
+    fn visitor_reconstructs_record_fields() {
+        // Mimic what the collector does given the event field values.
+        let mut v = IterVisitor::default();
+        // Direct field assignment exercises the same match arms the
+        // visitor uses at runtime via the typed record_* methods.
+        v.rec.iter = 7;
+        v.rec.alpha_primal = 0.25;
+        v.rec.alpha_primal_char = 'S';
+        assert_eq!(v.rec.iter, 7);
+        assert_eq!(v.rec.alpha_primal_char, 'S');
+    }
+}

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -252,6 +252,12 @@ fn install() {
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::EnvFilter;
 
+    // Bridge the `log` crate into `tracing` so any remaining `log::*`
+    // call sites — chiefly transitive dependencies — surface through
+    // our subscriber and obey `RUST_LOG`. Idempotent; the `Err` when a
+    // logger is already installed is intentionally ignored.
+    let _ = tracing_log::LogTracer::init();
+
     let want_json = std::env::var("POUNCE_LOG_FORMAT")
         .map(|v| v.eq_ignore_ascii_case("json"))
         .unwrap_or(false);
@@ -369,6 +375,52 @@ mod tests {
         assert_eq!(outer_got.len(), 2);
         assert_eq!(outer_got[0].iter, 0);
         assert_eq!(outer_got[1].iter, 1);
+    }
+
+    #[test]
+    fn log_records_bridge_into_tracing() {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::prelude::*;
+
+        // Minimal layer that records each event's `message` field.
+        #[derive(Clone)]
+        struct CaptureLayer {
+            buf: Arc<Mutex<Vec<String>>>,
+        }
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CaptureLayer {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                struct V<'a>(&'a mut Vec<String>);
+                impl tracing::field::Visit for V<'_> {
+                    fn record_debug(&mut self, f: &Field, value: &dyn std::fmt::Debug) {
+                        if f.name() == "message" {
+                            self.0.push(format!("{value:?}"));
+                        }
+                    }
+                }
+                let mut g = self.buf.lock().unwrap_or_else(|p| p.into_inner());
+                event.record(&mut V(&mut g));
+            }
+        }
+
+        let buf = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer { buf: buf.clone() });
+
+        // The same bridge `install()` sets up. Global + idempotent.
+        let _ = tracing_log::LogTracer::init();
+        tracing::subscriber::with_default(subscriber, || {
+            // A `log` record as a transitive dependency would emit.
+            log::error!(target: "some_transitive_dep", "bridged log record");
+        });
+
+        let got = buf.lock().unwrap_or_else(|p| p.into_inner());
+        assert!(
+            got.iter().any(|m| m.contains("bridged log record")),
+            "log record did not reach the tracing layer; captured: {got:?}"
+        );
     }
 
     #[test]

--- a/crates/pounce-presolve/Cargo.toml
+++ b/crates/pounce-presolve/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["mathematics", "algorithms"]
 [dependencies]
 pounce-common.workspace = true
 pounce-nlp.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -513,11 +513,9 @@ impl PresolveTnlp {
                 reduction_stack.push(frame);
             }
             // When `presolve_auxiliary_diagnostics=yes`, emit the
-            // summary to stderr. This is a low-overhead drop-in for
-            // the journalist wiring described in the design doc;
-            // upgrading to the real journalist is a follow-up.
+            // summary through tracing (pounce#71).
             if self.opts.auxiliary_diagnostics {
-                eprintln!("{}", plan.diagnostics);
+                tracing::info!(target: "pounce::presolve", "{}", plan.diagnostics);
             }
             plan.diagnostics
         } else {
@@ -556,10 +554,10 @@ impl PresolveTnlp {
         // `report.infeasible` was previously never inspected and
         // corrupted bounds reached the IPM (#53 PR review).
         if tighten_report.infeasible && !reduction_stack.is_empty() {
-            eprintln!(
-                "pounce-presolve: auxiliary-equality elimination produced \
-                 bounds inconsistent with kept linear rows; rolling back \
-                 the elimination for this solve."
+            tracing::warn!(
+                target: "pounce::presolve",
+                "auxiliary-equality elimination produced bounds inconsistent \
+                 with kept linear rows; rolling back the elimination for this solve."
             );
             x_l.copy_from_slice(&inner_x_l);
             x_u.copy_from_slice(&inner_x_u);

--- a/crates/pounce-py/Cargo.toml
+++ b/crates/pounce-py/Cargo.toml
@@ -34,6 +34,7 @@ pounce-restoration.workspace = true
 pounce-feral.workspace = true
 pounce-linsol.workspace = true
 pounce-sensitivity.workspace = true
+pounce-observability.workspace = true
 pyo3 = { version = "0.22", features = ["abi3-py39"] }
 numpy = "0.22"
 

--- a/crates/pounce-py/Cargo.toml
+++ b/crates/pounce-py/Cargo.toml
@@ -35,6 +35,7 @@ pounce-feral.workspace = true
 pounce-linsol.workspace = true
 pounce-sensitivity.workspace = true
 pounce-observability.workspace = true
+tracing.workspace = true
 pyo3 = { version = "0.22", features = ["abi3-py39"] }
 numpy = "0.22"
 

--- a/crates/pounce-py/src/lib.rs
+++ b/crates/pounce-py/src/lib.rs
@@ -32,6 +32,10 @@ pub use solver::PySolver;
 /// from Cargo.toml to find this symbol.
 #[pymodule]
 fn _pounce(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // Install the tracing subscriber on import so Python consumers get
+    // logging and the iteration collector (pounce#71). Idempotent, so
+    // re-imports / sub-interpreters are safe.
+    pounce_observability::init_subscriber();
     m.add_class::<PyProblem>()?;
     m.add_class::<PySolver>()?;
     m.add_function(wrap_pyfunction!(warm_start::classify_working_set, m)?)?;

--- a/crates/pounce-py/src/tnlp_bridge.rs
+++ b/crates/pounce-py/src/tnlp_bridge.rs
@@ -220,7 +220,7 @@ impl TNLP for PyTnlp {
         match call1(&self.state.py_obj, "objective", x) {
             Ok(v) => Python::with_gil(|py| v.bind(py).extract::<Number>().ok()),
             Err(e) => {
-                eprintln!("pounce-py: objective(): {e}");
+                tracing::error!(target: "pounce::py", "pounce-py: objective(): {e}");
                 None
             }
         }
@@ -230,7 +230,7 @@ impl TNLP for PyTnlp {
         let res = match call1(&self.state.py_obj, "gradient", x) {
             Ok(v) => v,
             Err(e) => {
-                eprintln!("pounce-py: gradient(): {e}");
+                tracing::error!(target: "pounce::py", "pounce-py: gradient(): {e}");
                 return false;
             }
         };
@@ -244,7 +244,7 @@ impl TNLP for PyTnlp {
         let res = match call1(&self.state.py_obj, "constraints", x) {
             Ok(v) => v,
             Err(e) => {
-                eprintln!("pounce-py: constraints(): {e}");
+                tracing::error!(target: "pounce::py", "pounce-py: constraints(): {e}");
                 return false;
             }
         };
@@ -271,7 +271,7 @@ impl TNLP for PyTnlp {
                 let res = match call1(&self.state.py_obj, "jacobian", xx) {
                     Ok(v) => v,
                     Err(e) => {
-                        eprintln!("pounce-py: jacobian(): {e}");
+                        tracing::error!(target: "pounce::py", "pounce-py: jacobian(): {e}");
                         return false;
                     }
                 };
@@ -321,7 +321,7 @@ impl TNLP for PyTnlp {
                 let res = match res {
                     Ok(v) => v,
                     Err(e) => {
-                        eprintln!("pounce-py: hessian(): {e}");
+                        tracing::error!(target: "pounce::py", "pounce-py: hessian(): {e}");
                         return false;
                     }
                 };

--- a/crates/pounce-restoration/Cargo.toml
+++ b/crates/pounce-restoration/Cargo.toml
@@ -16,6 +16,7 @@ pounce-linalg.workspace = true
 pounce-nlp.workspace = true
 pounce-algorithm.workspace = true
 pounce-linsol.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 pounce-feral.workspace = true

--- a/crates/pounce-restoration/src/aug_resto_system_solver.rs
+++ b/crates/pounce-restoration/src/aug_resto_system_solver.rs
@@ -229,7 +229,7 @@ impl AugSystemSolver for AugRestoSystemSolver {
 
         let dbg = std::env::var("POUNCE_RESTO_DBG").is_ok();
         if dbg {
-            tracing::debug!(target: "pounce::restoration", 
+            tracing::debug!(target: "pounce::restoration",
                 "[resto-aug] n_orig={} m_eq={} m_ineq={} W.nz={} J_c.nz={} J_d.nz={} delta_x={:.3e} delta_c={:.3e} delta_d={:.3e}",
                 self.n_orig, self.m_eq, self.m_ineq,
                 w.nonzeros(), j_c.nonzeros(), j_d.nonzeros(),
@@ -411,17 +411,17 @@ impl AugSystemSolver for AugRestoSystemSolver {
             let inf_norm = |v: &[f64]| v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()));
             let sol_x_r = sol_x_compound.comp(0);
             let sol_x_orig_vals = dense_values(sol_x_r);
-            tracing::debug!(target: "pounce::restoration", 
+            tracing::debug!(target: "pounce::restoration",
                 "[resto-aug]   ||sigma_orig||={:.3e} ||sigma_n_c||={:.3e} ||sigma_p_c||={:.3e} ||sigma_n_d||={:.3e} ||sigma_p_d||={:.3e}",
                 inf_norm(&sigma_orig_vals),
                 inf_norm(&sigma_n_c), inf_norm(&sigma_p_c), inf_norm(&sigma_n_d), inf_norm(&sigma_p_d),
             );
-            tracing::debug!(target: "pounce::restoration", 
+            tracing::debug!(target: "pounce::restoration",
                 "[resto-aug]   ||rhs_x_orig||={:.3e} ||rhs_n_c||={:.3e} ||rhs_p_c||={:.3e} ||rhs_n_d||={:.3e} ||rhs_p_d||={:.3e} ||rhs_c||={:.3e} ||rhs_d||={:.3e}",
                 inf_norm(&rhs_x_orig_vals), inf_norm(&rhs_n_c), inf_norm(&rhs_p_c),
                 inf_norm(&rhs_n_d), inf_norm(&rhs_p_d), inf_norm(&rhs_c_vals), inf_norm(&rhs_d_vals),
             );
-            tracing::debug!(target: "pounce::restoration", 
+            tracing::debug!(target: "pounce::restoration",
                 "[resto-aug]   ||rhs_cR||={:.3e} ||rhs_dR||={:.3e} ||D_cR||={:.3e} ||D_dR||={:.3e} ||sol_x_orig||={:.3e} ||sol_y_c||={:.3e} ||sol_y_d||={:.3e}",
                 inf_norm(&rhs_c_r), inf_norm(&rhs_d_r),
                 inf_norm(&d_c_r), inf_norm(&d_d_r),

--- a/crates/pounce-restoration/src/aug_resto_system_solver.rs
+++ b/crates/pounce-restoration/src/aug_resto_system_solver.rs
@@ -229,7 +229,7 @@ impl AugSystemSolver for AugRestoSystemSolver {
 
         let dbg = std::env::var("POUNCE_RESTO_DBG").is_ok();
         if dbg {
-            eprintln!(
+            tracing::debug!(target: "pounce::restoration", 
                 "[resto-aug] n_orig={} m_eq={} m_ineq={} W.nz={} J_c.nz={} J_d.nz={} delta_x={:.3e} delta_c={:.3e} delta_d={:.3e}",
                 self.n_orig, self.m_eq, self.m_ineq,
                 w.nonzeros(), j_c.nonzeros(), j_d.nonzeros(),
@@ -411,17 +411,17 @@ impl AugSystemSolver for AugRestoSystemSolver {
             let inf_norm = |v: &[f64]| v.iter().fold(0.0_f64, |a, &x| a.max(x.abs()));
             let sol_x_r = sol_x_compound.comp(0);
             let sol_x_orig_vals = dense_values(sol_x_r);
-            eprintln!(
+            tracing::debug!(target: "pounce::restoration", 
                 "[resto-aug]   ||sigma_orig||={:.3e} ||sigma_n_c||={:.3e} ||sigma_p_c||={:.3e} ||sigma_n_d||={:.3e} ||sigma_p_d||={:.3e}",
                 inf_norm(&sigma_orig_vals),
                 inf_norm(&sigma_n_c), inf_norm(&sigma_p_c), inf_norm(&sigma_n_d), inf_norm(&sigma_p_d),
             );
-            eprintln!(
+            tracing::debug!(target: "pounce::restoration", 
                 "[resto-aug]   ||rhs_x_orig||={:.3e} ||rhs_n_c||={:.3e} ||rhs_p_c||={:.3e} ||rhs_n_d||={:.3e} ||rhs_p_d||={:.3e} ||rhs_c||={:.3e} ||rhs_d||={:.3e}",
                 inf_norm(&rhs_x_orig_vals), inf_norm(&rhs_n_c), inf_norm(&rhs_p_c),
                 inf_norm(&rhs_n_d), inf_norm(&rhs_p_d), inf_norm(&rhs_c_vals), inf_norm(&rhs_d_vals),
             );
-            eprintln!(
+            tracing::debug!(target: "pounce::restoration", 
                 "[resto-aug]   ||rhs_cR||={:.3e} ||rhs_dR||={:.3e} ||D_cR||={:.3e} ||D_dR||={:.3e} ||sol_x_orig||={:.3e} ||sol_y_c||={:.3e} ||sol_y_d||={:.3e}",
                 inf_norm(&rhs_c_r), inf_norm(&rhs_d_r),
                 inf_norm(&d_c_r), inf_norm(&d_d_r),

--- a/crates/pounce-restoration/src/conv_check.rs
+++ b/crates/pounce-restoration/src/conv_check.rs
@@ -366,7 +366,7 @@ impl pounce_algorithm::conv_check::r#trait::ConvCheck for RestoConvCheckAdapter 
                     eval_orig_inf_pr_and_f(data, &orig_rc)
                 {
                     if std::env::var_os("POUNCE_DBG_RESTO_KAPPA").is_some() {
-                        eprintln!(
+                        tracing::debug!(target: "pounce::restoration", 
                             "[PN_RESTO_KAPPA] iter={} orig_trial_inf_pr={:.6e} orig_curr_inf_pr={:.6e} kappa_resto={:.3e} threshold={:.6e} guard_passes={}",
                             iter_count,
                             orig_trial_inf_pr,

--- a/crates/pounce-restoration/src/conv_check.rs
+++ b/crates/pounce-restoration/src/conv_check.rs
@@ -366,7 +366,7 @@ impl pounce_algorithm::conv_check::r#trait::ConvCheck for RestoConvCheckAdapter 
                     eval_orig_inf_pr_and_f(data, &orig_rc)
                 {
                     if std::env::var_os("POUNCE_DBG_RESTO_KAPPA").is_some() {
-                        tracing::debug!(target: "pounce::restoration", 
+                        tracing::debug!(target: "pounce::restoration",
                             "[PN_RESTO_KAPPA] iter={} orig_trial_inf_pr={:.6e} orig_curr_inf_pr={:.6e} kappa_resto={:.3e} threshold={:.6e} guard_passes={}",
                             iter_count,
                             orig_trial_inf_pr,

--- a/crates/pounce-restoration/src/init.rs
+++ b/crates/pounce-restoration/src/init.rs
@@ -304,7 +304,7 @@ impl IterateInitializer for RestoIterateInitializer {
         if std::env::var_os("POUNCE_DBG_RESTO_INIT").is_some() {
             use pounce_linalg::Vector;
             fn dump3(label: &str, v: &dyn Vector) {
-                eprintln!(
+                tracing::debug!(target: "pounce::restoration", 
                     "[PN_RESTO_INIT] {} amax={:.17e} asum={:.17e} nrm2={:.17e}",
                     label,
                     v.amax(),
@@ -313,7 +313,7 @@ impl IterateInitializer for RestoIterateInitializer {
                 );
             }
             fn dump2(label: &str, v: &dyn Vector) {
-                eprintln!(
+                tracing::debug!(target: "pounce::restoration", 
                     "[PN_RESTO_INIT] {} amax={:.17e} asum={:.17e}",
                     label,
                     v.amax(),
@@ -322,7 +322,7 @@ impl IterateInitializer for RestoIterateInitializer {
             }
             let cx = iv.x.as_any().downcast_ref::<CompoundVector>().unwrap();
             let czl = iv.z_l.as_any().downcast_ref::<CompoundVector>().unwrap();
-            eprintln!(
+            tracing::debug!(target: "pounce::restoration", 
                 "[PN_RESTO_INIT] resto_mu={:.17e} rho={:.17e}",
                 resto_mu, self.rho
             );
@@ -336,7 +336,7 @@ impl IterateInitializer for RestoIterateInitializer {
             dump2("zL_pc   ", &*czl.comp(2));
             dump2("zL_nd   ", &*czl.comp(3));
             dump2("zL_pd   ", &*czl.comp(4));
-            eprintln!(
+            tracing::debug!(target: "pounce::restoration", 
                 "[PN_RESTO_INIT] y_c amax={:.17e} y_d amax={:.17e}",
                 iv.y_c.amax(),
                 iv.y_d.amax()

--- a/crates/pounce-restoration/src/init.rs
+++ b/crates/pounce-restoration/src/init.rs
@@ -304,7 +304,7 @@ impl IterateInitializer for RestoIterateInitializer {
         if std::env::var_os("POUNCE_DBG_RESTO_INIT").is_some() {
             use pounce_linalg::Vector;
             fn dump3(label: &str, v: &dyn Vector) {
-                tracing::debug!(target: "pounce::restoration", 
+                tracing::debug!(target: "pounce::restoration",
                     "[PN_RESTO_INIT] {} amax={:.17e} asum={:.17e} nrm2={:.17e}",
                     label,
                     v.amax(),
@@ -313,7 +313,7 @@ impl IterateInitializer for RestoIterateInitializer {
                 );
             }
             fn dump2(label: &str, v: &dyn Vector) {
-                tracing::debug!(target: "pounce::restoration", 
+                tracing::debug!(target: "pounce::restoration",
                     "[PN_RESTO_INIT] {} amax={:.17e} asum={:.17e}",
                     label,
                     v.amax(),
@@ -322,7 +322,7 @@ impl IterateInitializer for RestoIterateInitializer {
             }
             let cx = iv.x.as_any().downcast_ref::<CompoundVector>().unwrap();
             let czl = iv.z_l.as_any().downcast_ref::<CompoundVector>().unwrap();
-            tracing::debug!(target: "pounce::restoration", 
+            tracing::debug!(target: "pounce::restoration",
                 "[PN_RESTO_INIT] resto_mu={:.17e} rho={:.17e}",
                 resto_mu, self.rho
             );
@@ -336,7 +336,7 @@ impl IterateInitializer for RestoIterateInitializer {
             dump2("zL_pc   ", &*czl.comp(2));
             dump2("zL_nd   ", &*czl.comp(3));
             dump2("zL_pd   ", &*czl.comp(4));
-            tracing::debug!(target: "pounce::restoration", 
+            tracing::debug!(target: "pounce::restoration",
                 "[PN_RESTO_INIT] y_c amax={:.17e} y_d amax={:.17e}",
                 iv.y_c.amax(),
                 iv.y_d.amax()

--- a/crates/pounce-restoration/src/min_c_1nrm.rs
+++ b/crates/pounce-restoration/src/min_c_1nrm.rs
@@ -196,6 +196,13 @@ impl RestorationPhase for MinC1NormRestoration {
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
         aug_solver: &mut dyn AugSystemSolver,
     ) -> RestorationOutcome {
+        // Restoration span (pounce#71): the inner sub-IPM's `optimize()`
+        // runs inside this span, so its `pounce::iteration` events carry
+        // a `restoration` ancestor. `IterCollectorLayer` uses that to
+        // exclude inner restoration iterations from the solve report,
+        // matching the pre-tracing behavior (outer trajectory only).
+        let _resto_span = tracing::info_span!("restoration").entered();
+
         // 1. Run the nested IPM via the inner hook. Hand the
         //    orig-progress callback to the hook so the inner conv check
         //    can gate `Converged` on outer-filter acceptance per

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -554,7 +554,7 @@ pub fn run_inner_resto(
         || step_failure_locally_infeasible;
 
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
-        tracing::debug!(target: "pounce::restoration", 
+        tracing::debug!(target: "pounce::restoration",
             "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} → loc_inf={}",
             status,
             inner_iter_count,

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -554,7 +554,7 @@ pub fn run_inner_resto(
         || step_failure_locally_infeasible;
 
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
-        eprintln!(
+        tracing::debug!(target: "pounce::restoration", 
             "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} → loc_inf={}",
             status,
             inner_iter_count,

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -198,3 +198,49 @@ When in doubt: leave `feral_ordering` at the default. When a hard
 problem looks linear-solver-bound, try `feral_ordering auto_race`
 before per-variant manual sweeping — it's the safe choice when the
 per-problem winner is uncertain.
+
+## Logging and colored output
+
+POUNCE emits structured logs and a colored iteration table through the
+[`tracing`](https://docs.rs/tracing) ecosystem. Behavior is governed by
+environment variables (not solver options), so they apply to the `pounce`
+CLI, the C/Python frontends, and anything embedding the library.
+
+| Variable | Values | Effect |
+|---|---|---|
+| `RUST_LOG` | e.g. `info`, `debug`, `pounce::restoration=debug` | Log verbosity / per-target filtering. Default `info`. Logs go to **stderr**. |
+| `POUNCE_LOG_FORMAT` | `text` (default) · `json` | `json` emits line-delimited JSON on stderr (incl. the per-iteration `pounce::iteration` stream) for Studio / CI ingestion. |
+| `NO_COLOR` | set to any value | Disables ANSI color in the iteration table **and** logs (see <https://no-color.org>). |
+| `CLICOLOR_FORCE` | set to any value | Forces color even when stdout is not a terminal. |
+
+**Filtering by subsystem.** Solver internals log under namespaced targets
+— `pounce::algorithm`, `pounce::linsol`, `pounce::mu`, `pounce::sqp`,
+`pounce::linesearch`, `pounce::restoration`, `pounce::presolve`,
+`pounce::py`. For example, to trace only the restoration phase:
+
+```sh
+RUST_LOG=pounce::restoration=debug pounce problem.nl
+```
+
+**Program output vs. logs.** The iteration table, the final summary, and
+`--dump` diagnostics are *program output* on **stdout**; diagnostic and
+progress messages are *logs* on **stderr**. Redirecting one does not
+affect the other:
+
+```sh
+pounce problem.nl > result.txt 2> solve.log
+```
+
+**Color.** The iteration table is colored with a tiger/rust theme:
+restoration lines take a background that varies by restoration kind
+(soft-stay → tan, soft-exit → amber, hard → deep rust), and the row text
+shades from black toward red as the primal step length `alpha` shrinks
+(stalling). Color is emitted only when stdout is a terminal; redirected
+output and `NO_COLOR` get plain text with identical column alignment.
+
+**Machine-readable iterations.** `POUNCE_LOG_FORMAT=json` turns the
+per-iteration records into JSON on stderr:
+
+```sh
+POUNCE_LOG_FORMAT=json pounce problem.nl 2> iters.jsonl
+```

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -404,6 +404,38 @@ The Studio MCP (`pounce-studio`) wraps these dumps in higher-level
 diagnostic queries (`diagnose`, `find_stalls`, `restoration_windows`),
 which is the recommended workflow when iterating on options.
 
+## Logs, colors, and machine-readable output
+
+POUNCE routes diagnostics through [`tracing`](https://docs.rs/tracing).
+The knobs are environment variables (see
+[Options › Logging and colored output](options.md#logging-and-colored-output)),
+not solver options.
+
+### When to try it
+- You want more detail than the iteration table shows (which phase fired,
+  why restoration triggered, linear-solver fallbacks).
+- A downstream tool (Studio, CI) needs to parse per-iteration data.
+- Color is garbling a log file, or you want color forced through a pipe.
+
+### The knobs
+
+| Goal | Invocation |
+|---|---|
+| Verbose, everything | `RUST_LOG=debug pounce problem.nl` |
+| Just the restoration phase | `RUST_LOG=pounce::restoration=debug pounce problem.nl` |
+| Separate logs from results | `pounce problem.nl > result.txt 2> solve.log` |
+| Plain text (no color) | `NO_COLOR=1 pounce problem.nl` |
+| Force color through a pipe | `CLICOLOR_FORCE=1 pounce problem.nl | less -R` |
+| Line-delimited JSON iterations | `POUNCE_LOG_FORMAT=json pounce problem.nl 2> iters.jsonl` |
+
+Logs go to **stderr**; the iteration table, final summary, and `--dump`
+output are program output on **stdout**. The colored table uses a
+tiger/rust theme — restoration lines get a kind-dependent background and
+the row text reddens as the step length `alpha` shrinks, so a stalling or
+restoration-heavy solve is visible at a glance. When stdout is not a
+terminal (or `NO_COLOR` is set) the table is emitted as plain text with
+the same column layout.
+
 ## Contributing a new recipe
 
 A recipe earns a place here when:


### PR DESCRIPTION
## Summary

This PR introduces structured logging via the `tracing` ecosystem and renders the per-iteration table with a tiger/rust branded color theme. Diagnostics now flow through `tracing` instead of `eprintln!`, enabling machine-readable JSON output and per-subsystem filtering. The iteration table gains visual feedback through color gradients and restoration-phase backgrounds while maintaining exact column alignment for plain-text output.

## Key Changes

### New Crates
- **`pounce-observability`**: Owns the `tracing` subscriber installation, a custom tiger/rust text formatter, and the `IterCollectorLayer` that rebuilds per-iteration records from structured events into the active `IterCaptureGuard` slot for JSON solve reports.
- **`pounce-common::style`**: Pure color palette module with restoration-kind backgrounds (tan/amber/rust) and alpha-driven foreground gradients (black→red on normal lines, cream→bright-yellow on restoration lines). Includes terminal-capability detection and 256-color downgrade for non-truecolor terminals.

### Iteration Table Styling
- Iteration rows are now wrapped in `anstyle::Style` at the print site in `ipopt_alg.rs`, applying foreground color based on the primal step length `alpha` and optional background based on restoration kind (`alpha_primal_char`).
- Color is emitted only when stdout is a terminal; `anstream::AutoStream` automatically strips escapes for redirected output and `NO_COLOR` respects the no-color standard.
- Column alignment is preserved exactly — stripping ANSI escapes recovers the original plain row byte-for-byte (verified by integration tests in `colored_table.rs`).

### Structured Logging
- Replaced `eprintln!` calls throughout the codebase with `tracing::info!`, `tracing::warn!`, `tracing::debug!` at appropriate targets (`pounce::algorithm`, `pounce::sqp`, `pounce::mu`, `pounce::restoration`, `pounce::linsol`, `pounce::diagnostics`, `pounce::py`).
- Added `solve`, `iteration`, `linear_solve`, and `restoration` spans to tag nested events with context.
- Per-iteration event emitted at `ITER_TARGET` ("pounce::iteration") carries `iter`, `mu`, `alpha_primal`, `alpha_char`, and other numeric fields; the text console layer filters this target out (its human form is the colored table), while JSON and the collector layer preserve it.

### Per-Iteration Capture Refactoring
- Removed `record_iter_history` flag and `iter_history` buffer from `IpoptAlgorithm`; iteration records are now collected via the `IterCollectorLayer` from structured events.
- `IterCaptureGuard` (RAII in `pounce-observability`) manages a thread-local capture slot; restoration sub-solves are excluded by span scoping in the collector rather than by nesting guards.
- The collector skips events nested inside a `restoration` span, so the report captures only the outer solve's iterations (matching pre-tracing behavior exactly).

### Environment Variables
- `RUST_LOG`: Log verbosity / per-target filtering (default `info`). Logs go to stderr.
- `POUNCE_LOG_FORMAT`: `text` (default) or `json` for line-delimited JSON output.
- `NO_COLOR` / `CLICOLOR_FORCE`: Standard color policy overrides.

### Integration Points
- `pounce-cli`, `pounce-py`, and `pounce-cinterface` call `pounce_observability::init_subscriber()` on startup.
- `pounce-feral` surfaces linear-solve characteristics (ordering method, inertia) on the `linear_solve` span via `span.record()`.
- Documentation updated in `options.md` and `troubleshooting.md` with logging knobs and examples.

## Notable Implementation Details

- The `IterVisitor` struct implements `tracing::field::Visit` to extract numeric fields from the structured event and rebuild an `IterRecord`.
- The collector's per-layer filter

https://claude.ai/code/session_01DdSwnvaW11BhBtms9MjB7o