### PR TITLE
Add post-solve Jacobian and sensitivity API from held KKT factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes.
 
 ## Unreleased
 
+### Added — Post-solve Jacobian / sensitivity API from the held KKT factor (pounce#82)
+
+`JaxProblem` now exposes a first-class post-solve sensitivity surface
+that reuses the held FERAL stacked KKT factor instead of round-tripping
+through `jax.vjp` / `jax.jacrev`:
+
+```python
+x_star, (lam, zL, zU), J, state = jp.batched_solve_with_jacobian(
+    p_batch, x0,
+    wrt_cols=slice(0, ny),   # optional parameter-column selection (1-D p)
+    return_state=True,
+)
+dp_bar = jp.batched_vjp_from_state(state, x_bar)   # J^T @ x_bar
+state.close()
+```
+
+- **`batched_solve_with_jacobian(...)`** returns the full per-block
+  primal Jacobian `J` of shape `(B, n, p_dim)` (or `(B, n, len(wrt_cols))`)
+  alongside `x_star` and the `(lam, zL, zU)` duals (same contract as
+  `batched_solve_with_warm`). The Jacobian is assembled by evaluating the
+  existing factor-reuse backward over the `n×n` identity output basis —
+  one multi-RHS `Solver.kkt_solve_many` against the held LDLᵀ factor, no
+  NLP re-solve.
+- **`anchor(p_batch, x0, *, wrt_cols=None)`** solves once and pins the
+  factor, returning an **`AnchorState`** handle for reuse across several
+  post-solve sensitivity calls (linear-update pattern).
+- **`batched_vjp_from_state(state, x_bar)`** is the public reverse-mode
+  product `Jᵀ x̄` against a held factor.
+- **`AnchorState`** lifetime: works as a context manager
+  (`with jp.anchor(...) as state:`) *and* supports explicit ownership
+  (`state.close()`, `state.reanchor(...)`) for handles that outlive a
+  lexical block. Pinned factors are exempt from the LRU but capped
+  (`_pinned_capacity`, default 16) with a loud overflow error, and a
+  `weakref` finalizer reclaims the factor if a handle is dropped without
+  `close()`.
+
+JVP-from-state (forward-mode `J @ dp`, the cheaper path for linear
+updates that never materialise full `J`) is the next step.
+
 ### Added — Structured logging + colored iteration table (pounce#71)
 
 POUNCE now emits diagnostics through the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ state.close()
   post-solve sensitivity calls (linear-update pattern).
 - **`batched_vjp_from_state(state, x_bar)`** is the public reverse-mode
   product `Jᵀ x̄` against a held factor.
+- **`batched_jvp_from_state(state, dp)`** is the forward-mode product
+  `J @ dp` — the cheap path for linear updates that never materialise the
+  full `J`. It assembles the parameter-side RHS `[∂²L/∂x∂p · dp;
+  ∂g/∂p · dp]` into the compound x- and constraint-blocks and back-solves
+  once against the held factor. Accepts a reduced `dp` when the state was
+  anchored with `wrt_cols`.
 - **`AnchorState`** lifetime: works as a context manager
   (`with jp.anchor(...) as state:`) *and* supports explicit ownership
   (`state.close()`, `state.reanchor(...)`) for handles that outlive a
@@ -44,9 +50,6 @@ state.close()
   (`_pinned_capacity`, default 16) with a loud overflow error, and a
   `weakref` finalizer reclaims the factor if a handle is dropped without
   `close()`.
-
-JVP-from-state (forward-mode `J @ dp`, the cheaper path for linear
-updates that never materialise full `J`) is the next step.
 
 ### Added — Structured logging + colored iteration table (pounce#71)
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -396,6 +396,51 @@ Problems are cached per (thread, B) in a tiny LRU (cap 4), so
 calls in a loop with one or two batch sizes pay the build cost at
 most once per worker.
 
+### Post-solve Jacobian and sensitivities (`batched_solve_with_jacobian`)
+
+When you need the explicit per-block Jacobian `J[k] = ∂x^(k)*/∂p^(k)`
+as a first-class result — for validation, linear-update layers, or
+diagnostics — `batched_solve_with_jacobian` returns it directly from
+the held KKT factor instead of wrapping `batched_solve` in
+`jax.jacrev`:
+
+```python
+x_star, (lam, zL, zU), J = jp.batched_solve_with_jacobian(p_batch, x0)
+# x_star : (B, n)   J : (B, n, p_dim)   duals match batched_solve_with_warm
+```
+
+`J`'s row `i` is the reverse-mode VJP at cotangent `e_i` (the KKT
+system is symmetric), so the whole Jacobian is one multi-RHS back-solve
+against the held LDLᵀ factor — no NLP re-solve, no repeated public
+`jax.vjp` calls. Pass `wrt_cols` (1-D `p` only) to keep just the
+parameter columns you care about, e.g. `wrt_cols=slice(0, ny)` to drop
+context columns; `J` then has trailing dim `len(wrt_cols)`.
+
+For the linear-update pattern — anchor once, then apply several nearby
+sensitivity products — pin the factor with an `AnchorState` and reuse it:
+
+```python
+with jp.anchor(p_batch, x0, wrt_cols=slice(0, ny)) as state:
+    dp_bar = jp.batched_vjp_from_state(state, x_bar)   # J^T @ x_bar
+```
+
+`anchor(...)` (and `batched_solve_with_jacobian(..., return_state=True)`)
+return an `AnchorState` that holds the factor across calls. Prefer the
+context-manager form; for handles that must outlive a single block
+(e.g. stored on a projection layer), use explicit ownership:
+
+```python
+state = jp.anchor(p_batch, x0)
+...                          # later calls reuse `state`
+state.reanchor(p_new, x0)    # swap the solve in place (closes prior pin)
+state.close()                # release the held factor
+```
+
+Pinned factors are exempt from the backward LRU but capped
+(`_pinned_capacity`, default 16) so a missed `close()` fails loudly
+rather than leaking; a `weakref` finalizer reclaims the factor if a
+handle is garbage-collected without `close()`.
+
 ## Notebooks
 
 The notebooks under

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -448,7 +448,10 @@ state.close()                # release the held factor
 Pinned factors are exempt from the backward LRU but capped
 (`_pinned_capacity`, default 16) so a missed `close()` fails loudly
 rather than leaking; a `weakref` finalizer reclaims the factor if a
-handle is garbage-collected without `close()`.
+handle is garbage-collected without `close()`. A worked example —
+projection layer, full Jacobian, JVP/VJP-from-state, and the lifetime
+patterns — is in
+[`notebooks/13_post_solve_jacobian.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/13_post_solve_jacobian.ipynb).
 
 ## Notebooks
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -421,8 +421,17 @@ sensitivity products — pin the factor with an `AnchorState` and reuse it:
 
 ```python
 with jp.anchor(p_batch, x0, wrt_cols=slice(0, ny)) as state:
-    dp_bar = jp.batched_vjp_from_state(state, x_bar)   # J^T @ x_bar
+    dx     = jp.batched_jvp_from_state(state, dp)      # J @ dp   (forward)
+    dp_bar = jp.batched_vjp_from_state(state, x_bar)   # J^T @ x_bar (reverse)
 ```
+
+`batched_jvp_from_state` is the cheap path for linear updates that only
+need the directional sensitivity `delta_x = J @ delta_p` and never the
+full `J`: it assembles the parameter-side RHS `[∂²L/∂x∂p · dp; ∂g/∂p · dp]`
+and back-solves once against the held factor. When the state was anchored
+with `wrt_cols`, pass the reduced `dp` (one entry per selected column);
+otherwise pass a full `(B,) + p_shape` perturbation (zero out the columns
+you don't want to move).
 
 `anchor(...)` (and `batched_solve_with_jacobian(..., return_state=True)`)
 return an `AnchorState` that holds the factor across calls. Prefer the

--- a/python/notebooks/13_post_solve_jacobian.ipynb
+++ b/python/notebooks/13_post_solve_jacobian.ipynb
@@ -1,0 +1,502 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "49401b4c",
+   "metadata": {},
+   "source": [
+    "# Post-solve Jacobian & sensitivities from the held KKT factor (pounce#82)\n",
+    "\n",
+    "`JaxProblem.batched_solve` is a differentiable, stacked block-diagonal\n",
+    "batched solve (pounce#76). Its `custom_vjp` backward already reuses the\n",
+    "IPM's converged FERAL compound KKT factor. This notebook shows the\n",
+    "**public, first-class** post-solve sensitivity surface built on that\n",
+    "held factor (pounce#82), so downstream code (e.g. a differentiable\n",
+    "projection layer) can:\n",
+    "\n",
+    "- request the **full Jacobian** `J = ∂x*/∂p` directly, instead of\n",
+    "  wrapping `batched_solve` in `jax.jacrev`;\n",
+    "- **anchor** a solve once and reuse the held factor across several\n",
+    "  post-solve products without re-solving or risking LRU eviction;\n",
+    "- compute a **directional sensitivity** `Δx = J @ Δp` for a linear\n",
+    "  update *without* ever materialising `J`.\n",
+    "\n",
+    "The API is four pieces:\n",
+    "\n",
+    "| call | returns | mode |\n",
+    "|------|---------|------|\n",
+    "| `batched_solve_with_jacobian(p, x0)` | `x*, (lam, zL, zU), J` | full Jacobian |\n",
+    "| `anchor(p, x0)` → `AnchorState` | a held-factor handle | — |\n",
+    "| `batched_jvp_from_state(state, dp)` | `J @ dp`, shape `(B, n)` | forward |\n",
+    "| `batched_vjp_from_state(state, x_bar)` | `Jᵀ x̄`, shape `(B, p_dim)` | reverse |\n",
+    "\n",
+    "All of them reuse the held LDLᵀ factor via one multi-RHS\n",
+    "`Solver.kkt_solve_many` — one Rust crossing, no NLP re-solve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "b0e61458",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:52:57.195671Z",
+     "iopub.status.busy": "2026-06-01T19:52:57.195291Z",
+     "iopub.status.idle": "2026-06-01T19:52:57.754027Z",
+     "shell.execute_reply": "2026-06-01T19:52:57.752193Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "\n",
+    "from pounce.jax import JaxProblem"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "641ac65e",
+   "metadata": {},
+   "source": [
+    "## 1. A small projection layer\n",
+    "\n",
+    "Mirroring the `optlayer` use case: project a predicted point\n",
+    "$\\hat y$ onto a context-dependent feasible set. The parameter packs\n",
+    "the prediction and the context, `p = [ŷ (ny), ctx (n_ctx)]`:\n",
+    "\n",
+    "$$\n",
+    "x^*(p) = \\arg\\min_x \\tfrac12\\|x - \\hat y\\|^2 \\quad\\text{s.t.}\\quad\n",
+    "\\textstyle\\sum_i x_i = \\mathrm{ctx}_0,\\;\\; x_0 - x_1 \\le \\mathrm{ctx}_1,\\;\\;\n",
+    "0 \\le x \\le 1.\n",
+    "$$\n",
+    "\n",
+    "Only the prediction block $\\hat y = p_{:ny}$ carries the layer\n",
+    "Jacobian we care about — the context columns just shape the feasible\n",
+    "region."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a326d27f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:52:57.757114Z",
+     "iopub.status.busy": "2026-06-01T19:52:57.756774Z",
+     "iopub.status.idle": "2026-06-01T19:52:58.163130Z",
+     "shell.execute_reply": "2026-06-01T19:52:58.161241Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ny, n_ctx = 3, 2\n",
+    "\n",
+    "\n",
+    "def f(x, p):\n",
+    "    y_hat = p[:ny]\n",
+    "    return jnp.sum((x - y_hat) ** 2)\n",
+    "\n",
+    "\n",
+    "def g(x, p):\n",
+    "    ctx = p[ny:]\n",
+    "    # equality: total mass = ctx[0];  inequality: x[0] - x[1] <= ctx[1]\n",
+    "    return jnp.stack([jnp.sum(x) - ctx[0], x[0] - x[1] - ctx[1]])\n",
+    "\n",
+    "\n",
+    "jp = JaxProblem(\n",
+    "    f=f, g=g, n=ny, m=2, p_example=jnp.zeros(ny + n_ctx),\n",
+    "    lb=jnp.zeros(ny), ub=jnp.ones(ny),\n",
+    "    cl=jnp.array([0.0, -1e19]), cu=jnp.array([0.0, 0.0]),\n",
+    "    options={\"tol\": 1e-10, \"print_level\": 0, \"sb\": \"yes\"},\n",
+    ")\n",
+    "\n",
+    "# A minibatch of (y_hat, ctx) pairs.\n",
+    "p_batch = jnp.array([\n",
+    "    [0.6, 0.1, 0.5, 1.0, 0.3],\n",
+    "    [0.2, 0.7, 0.2, 1.0, 0.1],\n",
+    "])\n",
+    "x0 = jnp.full(ny, 1.0 / ny)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e6a8da1",
+   "metadata": {},
+   "source": [
+    "## 2. Full Jacobian in one call\n",
+    "\n",
+    "`batched_solve_with_jacobian` returns the primal solution, the\n",
+    "`(lam, zL, zU)` duals (same contract as `batched_solve_with_warm`),\n",
+    "and the per-block Jacobian `J`. `wrt_cols=slice(0, ny)` keeps only the\n",
+    "prediction columns, so `J` is `(B, ny, ny)` instead of `(B, ny, p_dim)`.\n",
+    "\n",
+    "The Jacobian is assembled from the held factor (one multi-RHS\n",
+    "back-solve over the identity output basis), so it agrees with\n",
+    "`jax.jacrev` over `batched_solve` to machine precision."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f02eedd8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:52:58.166065Z",
+     "iopub.status.busy": "2026-06-01T19:52:58.165801Z",
+     "iopub.status.idle": "2026-06-01T19:53:04.498209Z",
+     "shell.execute_reply": "2026-06-01T19:53:04.496633Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x_star\n",
+      " [[0.43333334 0.13333333 0.43333333]\n",
+      " [0.16666667 0.66666667 0.16666667]]\n",
+      "\n",
+      "J (∂x*/∂ŷ) shape: (2, 3, 3)\n",
+      "[[[ 0.16666667  0.16666667 -0.33333333]\n",
+      "  [ 0.16666667  0.16666667 -0.33333333]\n",
+      "  [-0.33333333 -0.33333333  0.66666667]]\n",
+      "\n",
+      " [[ 0.66666667 -0.33333333 -0.33333333]\n",
+      "  [-0.33333333  0.66666667 -0.33333333]\n",
+      "  [-0.33333333 -0.33333333  0.66666667]]]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "max |J - jacrev|: 0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "x_star, (lam, zL, zU), J = jp.batched_solve_with_jacobian(\n",
+    "    p_batch, x0, wrt_cols=slice(0, ny),\n",
+    ")\n",
+    "\n",
+    "print(\"x_star\\n\", np.asarray(x_star))\n",
+    "print(\"\\nJ (∂x*/∂ŷ) shape:\", J.shape)\n",
+    "print(np.asarray(J))\n",
+    "\n",
+    "# Cross-check against jax.jacrev over the full parameter, then slice the\n",
+    "# block-diagonal (∂x^(k)/∂p^(j) = 0 for k != j) and the prediction cols.\n",
+    "J_full = jax.jacrev(lambda P: jp.batched_solve(P, x0))(p_batch)\n",
+    "J_ref = jnp.stack([J_full[k, :, k, :ny] for k in range(p_batch.shape[0])])\n",
+    "print(\"\\nmax |J - jacrev|:\", float(jnp.max(jnp.abs(J - J_ref))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "939cabd2",
+   "metadata": {},
+   "source": [
+    "## 3. Anchor once, reuse the factor — use the context manager\n",
+    "\n",
+    "For the linear-update pattern you solve once at an anchor point and\n",
+    "then apply several nearby sensitivity products against the *same* held\n",
+    "factor. `anchor(...)` pins that factor and hands back an `AnchorState`.\n",
+    "\n",
+    "**Prefer the context manager** — it releases the factor\n",
+    "deterministically on block exit, even if an exception is raised:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cd64cbf3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:53:04.501455Z",
+     "iopub.status.busy": "2026-06-01T19:53:04.501152Z",
+     "iopub.status.idle": "2026-06-01T19:53:05.889698Z",
+     "shell.execute_reply": "2026-06-01T19:53:05.888361Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "inside `with`, held factors: 1\n",
+      "after `with`, held factors: 0\n",
+      "state.closed: True\n",
+      "\n",
+      "Δx = J @ Δŷ:\n",
+      " [[ 0.005       0.005      -0.01      ]\n",
+      " [-0.00666667  0.02333333 -0.01666667]]\n",
+      "max |Δx - J@Δŷ|: 4.336808689942018e-18\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A small perturbation of the prediction block only.\n",
+    "dy = jnp.array([\n",
+    "    [0.05, -0.02, 0.0],\n",
+    "    [0.00,  0.03, -0.01],\n",
+    "])\n",
+    "x_bar = jnp.array([\n",
+    "    [1.0, 0.0, 0.0],\n",
+    "    [0.0, 1.0, 0.0],\n",
+    "])\n",
+    "\n",
+    "with jp.anchor(p_batch, x0, wrt_cols=slice(0, ny)) as state:\n",
+    "    # forward: directional sensitivity Δx = J @ Δŷ  (never builds J)\n",
+    "    dx = jp.batched_jvp_from_state(state, dy)\n",
+    "    # reverse: Δp_bar = Jᵀ @ x_bar\n",
+    "    dp_bar = jp.batched_vjp_from_state(state, x_bar)\n",
+    "    print(\"inside `with`, held factors:\", len(jp._pinned_solvers))\n",
+    "\n",
+    "# Factor is released on exit.\n",
+    "print(\"after `with`, held factors:\", len(jp._pinned_solvers))\n",
+    "print(\"state.closed:\", state.closed)\n",
+    "\n",
+    "print(\"\\nΔx = J @ Δŷ:\\n\", np.asarray(dx))\n",
+    "# The JVP equals the Jacobian contraction (machine precision) ...\n",
+    "print(\"max |Δx - J@Δŷ|:\", float(jnp.max(jnp.abs(dx - jnp.einsum(\"knp,kp->kn\", J, dy)))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1e72d9f",
+   "metadata": {},
+   "source": [
+    "### Sanity check: JVP vs finite differences\n",
+    "\n",
+    "`batched_solve` is a `custom_vjp`, so `jax.jvp` can't trace it; a\n",
+    "central finite-difference directional derivative confirms the sign and\n",
+    "magnitude of `J @ dp`. We pad the prediction perturbation with zeros in\n",
+    "the context columns to make a full-`p` direction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "bc0e6204",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:53:05.892700Z",
+     "iopub.status.busy": "2026-06-01T19:53:05.892392Z",
+     "iopub.status.idle": "2026-06-01T19:53:06.347826Z",
+     "shell.execute_reply": "2026-06-01T19:53:06.346278Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "max |Δx - finite-difference|: 3.877048682099371e-11\n"
+     ]
+    }
+   ],
+   "source": [
+    "dp_full = jnp.concatenate([dy, jnp.zeros((p_batch.shape[0], n_ctx))], axis=1)\n",
+    "eps = 1e-6\n",
+    "dx_fd = (jp.batched_solve(p_batch + eps * dp_full, x0)\n",
+    "         - jp.batched_solve(p_batch - eps * dp_full, x0)) / (2 * eps)\n",
+    "print(\"max |Δx - finite-difference|:\", float(jnp.max(jnp.abs(dx - dx_fd))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1374a42",
+   "metadata": {},
+   "source": [
+    "## 4. Explicit lifetime across calls\n",
+    "\n",
+    "Sometimes the anchor must outlive a single lexical block — e.g. the\n",
+    "handle is stored on a projection layer and reused across several\n",
+    "user-level calls before the next re-anchor. The same `AnchorState`\n",
+    "supports explicit ownership: keep it, reuse it, and `close()` when done.\n",
+    "\n",
+    "Re-anchoring by overwriting the attribute *without* closing would leak\n",
+    "the held factor (the pinned registry keeps it alive). Use\n",
+    "`state.reanchor(...)`, which closes the prior pin before taking the new\n",
+    "one — the held-factor count stays at 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "363d7a50",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:53:06.350676Z",
+     "iopub.status.busy": "2026-06-01T19:53:06.350320Z",
+     "iopub.status.idle": "2026-06-01T19:53:06.908195Z",
+     "shell.execute_reply": "2026-06-01T19:53:06.906305Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "held factors after anchor: 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  scale=1.0:  Δx[0] = [ 0.005  0.005 -0.01 ]\n",
+      "  scale=2.0:  Δx[0] = [ 0.01  0.01 -0.02]\n",
+      "  scale=3.0:  Δx[0] = [ 0.015  0.015 -0.03 ]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "held factors after reanchor: 1\n",
+      "held factors after close: 0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Anchor and stash the handle (as a layer would).\n",
+    "state = jp.anchor(p_batch, x0, wrt_cols=slice(0, ny))\n",
+    "print(\"held factors after anchor:\", len(jp._pinned_solvers))\n",
+    "\n",
+    "# Several linear updates reuse the same factor.\n",
+    "for scale in (1.0, 2.0, 3.0):\n",
+    "    dx_s = jp.batched_jvp_from_state(state, scale * dy)\n",
+    "    print(f\"  scale={scale}:  Δx[0] = {np.asarray(dx_s)[0]}\")\n",
+    "\n",
+    "# Move the anchor to a new operating point without leaking the old factor.\n",
+    "state.reanchor(p_batch.at[:, :ny].add(0.05), x0)\n",
+    "print(\"held factors after reanchor:\", len(jp._pinned_solvers))\n",
+    "\n",
+    "# Release when the chain is rejected / the layer is reset.\n",
+    "state.close()\n",
+    "print(\"held factors after close:\", len(jp._pinned_solvers))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76db07d3",
+   "metadata": {},
+   "source": [
+    "## 5. Safety nets\n",
+    "\n",
+    "The held factor is owned by the caller, so a missed `close()` would\n",
+    "leak it. Three guardrails make the unmanaged path safe-by-default:\n",
+    "\n",
+    "- **`weakref` finalizer** — if a handle is garbage-collected without\n",
+    "  `close()`, the pin is still reclaimed.\n",
+    "- **Capacity cap** (`jp._pinned_capacity`, default 16) — too many live\n",
+    "  anchors raise loudly rather than growing unbounded.\n",
+    "- **Closed-handle guard** — a from-state call on a released handle\n",
+    "  raises a clear error instead of silently using a stale factor.\n",
+    "\n",
+    "Still, **prefer the context manager**; reach for explicit `close()` /\n",
+    "`reanchor()` only when the handle genuinely has to span calls."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2daa1f1c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T19:53:06.911013Z",
+     "iopub.status.busy": "2026-06-01T19:53:06.910737Z",
+     "iopub.status.idle": "2026-06-01T19:53:07.219079Z",
+     "shell.execute_reply": "2026-06-01T19:53:07.217278Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "before drop: 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "after GC:    0\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "closed handle raises: pounce.jax: AnchorState is closed; its held factor has been released. Re-anchor with jp.anchor(...) / jp.batched_solve_with_jacobian(..., return_state=True).\n"
+     ]
+    }
+   ],
+   "source": [
+    "import gc\n",
+    "\n",
+    "# Dropped without close() — the finalizer reclaims the factor on GC.\n",
+    "tmp = jp.anchor(p_batch, x0)\n",
+    "print(\"before drop:\", len(jp._pinned_solvers))\n",
+    "del tmp\n",
+    "gc.collect()\n",
+    "print(\"after GC:   \", len(jp._pinned_solvers))\n",
+    "\n",
+    "# Closed-handle guard.\n",
+    "st = jp.anchor(p_batch, x0)\n",
+    "st.close()\n",
+    "try:\n",
+    "    jp.batched_jvp_from_state(st, dy)\n",
+    "except RuntimeError as e:\n",
+    "    print(\"closed handle raises:\", str(e).splitlines()[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4990b919",
+   "metadata": {},
+   "source": [
+    "## When to reach for which\n",
+    "\n",
+    "- **Training** — nothing changes: `jax.grad` / `jax.value_and_grad`\n",
+    "  through `batched_solve` already reuses the factor in its `custom_vjp`\n",
+    "  backward.\n",
+    "- **Validation / diagnostics** — `batched_solve_with_jacobian` when you\n",
+    "  want the explicit `J` (and the duals) as a first-class result.\n",
+    "- **Linear updates** — `anchor(...)` + `batched_jvp_from_state` when you\n",
+    "  only need `Δx = J @ Δp` for nearby perturbations and never want to\n",
+    "  pay for the full `J`. This is the cheapest path.\n",
+    "- **Custom reverse-mode plumbing** — `batched_vjp_from_state` exposes\n",
+    "  `Jᵀ x̄` against the held factor without going through `jax.vjp`.\n",
+    "\n",
+    "All four share one held FERAL factor per anchor — one batched NLP solve,\n",
+    "one factorisation, many cheap multi-RHS sensitivity solves."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/pounce/jax/__init__.py
+++ b/python/pounce/jax/__init__.py
@@ -44,7 +44,7 @@ _jax_config.update("jax_enable_x64", True)
 
 from ._build import from_jax
 from ._diff import solve, solve_with_warm, vmap_solve, vmap_solve_parallel
-from ._problem import JaxProblem
+from ._problem import AnchorState, JaxProblem
 
 __all__ = [
     "from_jax",
@@ -53,4 +53,5 @@ __all__ = [
     "vmap_solve",
     "vmap_solve_parallel",
     "JaxProblem",
+    "AnchorState",
 ]

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -708,6 +708,117 @@ def _kkt_backsolve_batched_pure_callback(
     )
 
 
+def _kkt_jvp_batched_pure_callback(
+    jp: "JaxProblem",
+    B: int,
+    sid: jnp.ndarray,
+    rhs_x_batch: jnp.ndarray,
+    rhs_g_batch: jnp.ndarray,
+    n: int,
+    m: int,
+):
+    """Forward (JVP) multi-RHS solve against the held stacked factor
+    (pounce#82 Phase 2).
+
+    Where the reverse back-solve (:func:`_kkt_backsolve_batched_pure_callback`)
+    sets the compound RHS to ``[v; 0]`` (cotangent on the x-block only)
+    and *reads* the constraint sub-blocks of the solution, the forward
+    JVP does the transpose: it *packs* the parameter-side RHS
+
+    ::
+
+        rhs = M · dp = [ ∂²L/∂x∂p · dp ;  ∂g/∂p · dp ]
+
+    into the x-block (``rhs_x_batch``) **and** the equality/inequality
+    constraint blocks (``rhs_g_batch``, scattered from user g-order into
+    the stacked block-major y_c / y_d blocks), back-solves ``K w = rhs``
+    once against the held LDLᵀ factor, and returns just the x-block of
+    ``w``. The caller forms ``J @ dp = -w_x``. The bound-multiplier
+    blocks stay zero on the RHS — the compound factor already encodes
+    active/inactive bound behaviour, same as the reverse path relies on.
+
+    Inputs are per-block, leading-batch (``rhs_x_batch (B, n)``,
+    ``rhs_g_batch (B, m)``); ``vmap_method="broadcast_all"`` also accepts
+    a leading direction axis so the JVP can be vmapped over several
+    ``dp`` directions in one FFI hop. Returns ``w_x_batch (B, n)``.
+    """
+    result_shapes = jax.ShapeDtypeStruct((B, n), jnp.float64)
+
+    def host_call(sid_h, rx_h, rg_h):
+        sid_int = int(np.asarray(sid_h).reshape(-1)[0])
+        solver = jp._lookup_solver(sid_int)
+        if solver is None:
+            raise RuntimeError(
+                f"pounce.jax: missing stacked Solver for batched JVP "
+                f"(id={sid_int}). The held factor was released — the "
+                "AnchorState was closed or evicted. Re-anchor with "
+                "jp.anchor(...) before calling batched_jvp_from_state."
+            )
+        rx = np.asarray(rx_h, dtype=np.float64)
+        rg = np.asarray(rg_h, dtype=np.float64)
+        squeeze = rx.ndim == 2  # (B, n) unbatched; (N, B, n) batched
+        if squeeze:
+            rx = rx[None, ...]
+            rg = rg[None, ...]
+        N = rx.shape[0]
+
+        def _do_kkt():
+            dims = solver.block_dims
+            if dims is None:
+                raise RuntimeError(
+                    "pounce.jax: JVP-from-state requires a converged IPM "
+                    "factor on the anchor solve, but the stacked IPM did "
+                    "not produce one. Tighten the anchor solve or rebuild "
+                    "the problem."
+                )
+            n_x_, n_s_, n_y_c_, n_y_d_ = dims[0], dims[1], dims[2], dims[3]
+            kkt_dim_ = solver.kkt_dim
+            if n_x_ != B * n:
+                raise RuntimeError(
+                    f"pounce.jax: stacked solver n_x={n_x_} != B*n={B * n} "
+                    f"(B={B}, n={n}). Internal invariant violated."
+                )
+            rhs_flat = np.zeros((N, kkt_dim_), dtype=np.float64)
+            rhs_flat[:, :n_x_] = rx.reshape(N, B * n)
+            if m > 0:
+                # Scatter the constraint-side RHS from user g-order into
+                # the stacked block-major y_c / y_d blocks — the inverse
+                # of the reverse path's de-interleave.
+                cl_arr = jp._cl_for_classify
+                cu_arr = jp._cu_for_classify
+                is_eq = cl_arr == cu_arr
+                n_c_per = int(np.sum(is_eq))
+                y_c_off = n_x_ + n_s_
+                y_d_off = y_c_off + n_y_c_
+                rg_arr = rg.reshape(N, B, m)
+                if n_c_per > 0:
+                    c_idx = np.flatnonzero(is_eq)
+                    rhs_flat[:, y_c_off : y_c_off + n_y_c_] = (
+                        rg_arr[:, :, c_idx].reshape(N, n_y_c_)
+                    )
+                if (m - n_c_per) > 0:
+                    d_idx = np.flatnonzero(~is_eq)
+                    rhs_flat[:, y_d_off : y_d_off + n_y_d_] = (
+                        rg_arr[:, :, d_idx].reshape(N, n_y_d_)
+                    )
+            w_flat = np.asarray(
+                solver.kkt_solve_many(rhs_flat.reshape(-1), N),
+                dtype=np.float64,
+            ).reshape(N, kkt_dim_)
+            return n_x_, w_flat
+
+        n_x, w_mat = jp._run_pinned(_do_kkt)
+        w_x_batch = w_mat[:, :n_x].reshape(N, B, n).copy()
+        if squeeze:
+            return w_x_batch[0]
+        return w_x_batch
+
+    return jax.pure_callback(
+        host_call, result_shapes, sid, rhs_x_batch, rhs_g_batch,
+        vmap_method="broadcast_all",
+    )
+
+
 def _bwd_single_kkt(
     f: Callable,
     g: Callable | None,
@@ -785,9 +896,9 @@ class AnchorState:
     Returned by :meth:`JaxProblem.anchor` and (with ``return_state=True``)
     :meth:`JaxProblem.batched_solve_with_jacobian`. Pins the converged
     stacked LDLᵀ factor so several post-solve sensitivity calls
-    (:meth:`JaxProblem.batched_vjp_from_state` and, once landed, the
-    JVP-from-state forward path) reuse one factorisation without a
-    re-solve and without risking LRU eviction between calls.
+    (:meth:`JaxProblem.batched_vjp_from_state` /
+    :meth:`JaxProblem.batched_jvp_from_state`) reuse one factorisation
+    without a re-solve and without risking LRU eviction between calls.
 
     Lifetime. The factor is held until :meth:`close` (or, as a safety
     net, until the handle is garbage-collected — a :func:`weakref.finalize`
@@ -2022,6 +2133,86 @@ class JaxProblem:
             state._p_batch, state._x_star, state._lam, state._sid, x_bar,
         )
         return self._slice_cols(dp, state._wrt_cols)
+
+    def batched_jvp_from_state(self, state: AnchorState, dp_batch):
+        """Jacobian-vector product ``J @ dp`` against a held factor
+        (pounce#82 Phase 2). The cheap path for linear updates: it never
+        materialises the full ``J`` — only the directional sensitivity
+        ``delta_x = J @ delta_p``.
+
+        Forward mode by the implicit function theorem: with the compound
+        KKT factor ``K`` held, ``J @ dp = -w_x`` where ``K w = M · dp``
+        and ``M = [∂²L/∂x∂p ; ∂g/∂p]`` is the parameter-side RHS. Per
+        block, the contraction ``M_k · dp_k`` is autodiff over the user's
+        ``f`` / ``g``; the single multi-block back-solve reuses the held
+        factor via ``Solver.kkt_solve_many`` (one FFI hop, no re-solve).
+
+        Parameters
+        ----------
+        state : AnchorState
+        dp_batch : ``(B,) + p_shape`` (or ``(B, len(wrt_cols))`` if the
+            state was anchored with ``wrt_cols``)
+            Per-block parameter perturbation. For an ``optlayer`` linear
+            update over the predicted block, fill the context columns
+            with zeros (or anchor with ``wrt_cols`` and pass only the
+            predicted columns).
+
+        Returns
+        -------
+        ``(B, n)`` — the per-block primal sensitivity ``delta_x``.
+        """
+        if state._jp is not self:
+            raise ValueError(
+                "pounce.jax: AnchorState belongs to a different "
+                "JaxProblem."
+            )
+        state._check_open()
+        f, g, n, m = self._f, self._g, self._n, self._m
+        cols = state._wrt_cols
+        dp = jnp.asarray(dp_batch, dtype=jnp.float64)
+        if dp.shape[0] != state._B:
+            raise ValueError(
+                f"pounce.jax: dp_batch leading dim {dp.shape[0]} != "
+                f"batch B={state._B}."
+            )
+        expected = (
+            self._p_shape if cols is None else (int(cols.shape[0]),)
+        )
+        if dp.shape[1:] != tuple(expected):
+            raise ValueError(
+                f"pounce.jax: dp_batch per-block shape {dp.shape[1:]} != "
+                f"expected {tuple(expected)} (anchor wrt_cols="
+                f"{'set' if cols is not None else 'None'})."
+            )
+
+        p_batch, x_star, lam = state._p_batch, state._x_star, state._lam
+
+        def per_block(p_k, x_k, lam_k, dp_k):
+            def lagrangian(x, p_):
+                base = f(x, p_)
+                if g is not None and m > 0:
+                    base = base + jnp.dot(lam_k, g(x, p_))
+                return base
+
+            grad_L_of_p = lambda p_: jax.grad(lagrangian, argnums=0)(x_k, p_)
+            dgradL_dp = jax.jacrev(grad_L_of_p)(p_k)      # (n,) + p_shape
+            if cols is not None:
+                dgradL_dp = jnp.take(dgradL_dp, cols, axis=-1)
+            r_x = jnp.tensordot(dgradL_dp, dp_k, axes=dp_k.ndim)  # (n,)
+            if g is not None and m > 0:
+                dg_dp = jax.jacrev(lambda p_: g(x_k, p_))(p_k)    # (m,) + p_shape
+                if cols is not None:
+                    dg_dp = jnp.take(dg_dp, cols, axis=-1)
+                r_g = jnp.tensordot(dg_dp, dp_k, axes=dp_k.ndim)  # (m,)
+            else:
+                r_g = jnp.zeros((0,), dtype=jnp.float64)
+            return r_x, r_g
+
+        r_x_batch, r_g_batch = jax.vmap(per_block)(p_batch, x_star, lam, dp)
+        w_x = _kkt_jvp_batched_pure_callback(
+            self, state._B, state._sid, r_x_batch, r_g_batch, n, m,
+        )
+        return -w_x
 
     # ----- custom_vjp factories -----
 

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 import itertools
 import threading
 import warnings
+import weakref
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from typing import Callable
@@ -778,6 +779,118 @@ def _bwd_single_kkt(
     return dL_dp
 
 
+class AnchorState:
+    """Caller-owned handle to a held FERAL stacked KKT factor (pounce#82).
+
+    Returned by :meth:`JaxProblem.anchor` and (with ``return_state=True``)
+    :meth:`JaxProblem.batched_solve_with_jacobian`. Pins the converged
+    stacked LDLᵀ factor so several post-solve sensitivity calls
+    (:meth:`JaxProblem.batched_vjp_from_state` and, once landed, the
+    JVP-from-state forward path) reuse one factorisation without a
+    re-solve and without risking LRU eviction between calls.
+
+    Lifetime. The factor is held until :meth:`close` (or, as a safety
+    net, until the handle is garbage-collected — a :func:`weakref.finalize`
+    releases the pin). Prefer the context-manager form, which closes
+    deterministically on block exit::
+
+        with jp.anchor(p_batch, x0) as state:
+            dp_bar = jp.batched_vjp_from_state(state, x_bar)
+
+    The explicit form is for the cross-call case where the handle must
+    outlive a single lexical block (e.g. stored on a projection layer
+    across several user-level calls)::
+
+        state = jp.anchor(p_batch, x0)
+        ...                                   # later calls reuse `state`
+        state.close()                         # on re-anchor / reset
+
+    Re-anchoring by overwrite (``self.state = jp.anchor(...)``) without
+    closing the prior handle would leak its factor; use :meth:`reanchor`
+    to swap the underlying solve in place, which closes the old pin
+    first.
+    """
+
+    __slots__ = (
+        "_jp", "_sid", "_B", "_p_batch", "_x_star", "_lam",
+        "_duals", "_wrt_cols", "_finalize", "__weakref__",
+    )
+
+    def __init__(self, jp, sid, B, p_batch, x_star, lam, duals, wrt_cols):
+        self._jp = jp
+        self._sid = sid
+        self._B = B
+        self._p_batch = p_batch
+        self._x_star = x_star
+        self._lam = lam
+        self._duals = duals
+        self._wrt_cols = wrt_cols
+        # Reclaim the pin if the handle is dropped without close(). The
+        # finalizer must not close over `self` (that would keep it
+        # alive), so it captures only (jp, sid).
+        self._finalize = weakref.finalize(self, jp._release_pinned, sid)
+
+    @property
+    def sid(self) -> int:
+        """Integer id of the held factor in the pinned registry."""
+        return self._sid
+
+    @property
+    def x_star(self):
+        """Primal solution ``(B, n)`` captured at anchor time."""
+        return self._x_star
+
+    @property
+    def duals(self):
+        """``(lam, zL, zU)`` captured at anchor time."""
+        return self._duals
+
+    @property
+    def closed(self) -> bool:
+        """Whether the held factor has been released."""
+        return not self._finalize.alive
+
+    def _check_open(self) -> None:
+        if self.closed:
+            raise RuntimeError(
+                "pounce.jax: AnchorState is closed; its held factor has "
+                "been released. Re-anchor with jp.anchor(...) / "
+                "jp.batched_solve_with_jacobian(..., return_state=True)."
+            )
+
+    def close(self) -> None:
+        """Release the held factor. Idempotent; safe to call repeatedly
+        and via the context manager."""
+        # finalize() runs the release exactly once and then reports
+        # ``alive == False`` — so this is naturally idempotent.
+        self._finalize()
+
+    def reanchor(self, p_batch, x0) -> "AnchorState":
+        """Swap the held factor to a fresh solve in place, closing the
+        prior pin first. Avoids the overwrite-leak trap when an anchor is
+        stored on a long-lived object and periodically re-solved.
+        Returns ``self`` for chaining."""
+        self.close()
+        x_star, duals, sid, (pb, xs, lam) = self._jp._anchor_forward(
+            p_batch, x0,
+        )
+        self._sid = sid
+        self._p_batch, self._x_star, self._lam = pb, xs, lam
+        self._duals = duals
+        self._finalize = weakref.finalize(self, self._jp._release_pinned, sid)
+        return self
+
+    def __enter__(self) -> "AnchorState":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        state = "closed" if self.closed else f"open sid={self._sid}"
+        return f"AnchorState(B={self._B}, {state})"
+
+
 class JaxProblem:
     """Reusable, differentiable parametric solve (pounce#75).
 
@@ -1067,6 +1180,19 @@ class JaxProblem:
         pinning.
         """
         self._solver_registry: "OrderedDict[int, Solver]" = OrderedDict()
+        # Pinned registry for caller-owned :class:`AnchorState` handles
+        # (pounce#82). Unlike ``_solver_registry``, entries here are
+        # *exempt from LRU eviction* — they survive across arbitrarily
+        # many post-solve sensitivity calls until the owning handle is
+        # ``close()``d (or GC-reclaimed via its weakref finalizer). The
+        # ownership inversion (caller holds lifetime, not the bounded
+        # cache) means a missed close would leak the held factor, so the
+        # count is capped at ``_pinned_capacity`` and overflow raises
+        # loudly rather than growing without bound. Shares the integer
+        # id space with ``_solver_registry`` (same counter) so a single
+        # ``_lookup_solver`` resolves either.
+        self._pinned_solvers: dict[int, Solver] = {}
+        self._pinned_capacity = 16
         self._solver_id_counter = itertools.count(1)
         # Lock guards concurrent register/lookup against
         # vmap_solve_parallel worker threads.
@@ -1074,9 +1200,10 @@ class JaxProblem:
         # Per-thread (obj, Problem) cache. Built lazily on first solve
         # from the calling thread.
         self._tls = threading.local()
+        self._factor_thread_prefix = f"pounce-jp-factor-{id(self)}"
         self._factor_executor = ThreadPoolExecutor(
             max_workers=1,
-            thread_name_prefix=f"pounce-jp-factor-{id(self)}",
+            thread_name_prefix=self._factor_thread_prefix,
         )
 
     # Attributes that don't survive a process boundary: drop on
@@ -1085,7 +1212,7 @@ class JaxProblem:
     _PICKLE_DROP = (
         "_f_jit", "_grad_f_jit", "_g_jit", "_jac_g_jit", "_hess_lag_jit",
         "_registry_lock", "_tls", "_factor_executor",
-        "_solver_registry", "_solver_id_counter",
+        "_solver_registry", "_pinned_solvers", "_solver_id_counter",
     )
 
     def __getstate__(self):
@@ -1262,12 +1389,82 @@ class JaxProblem:
 
     def _lookup_solver(self, sid: int) -> Solver | None:
         """LRU-touching lookup. Refreshes the entry's recency so an
-        actively used factor doesn't get evicted while still in use."""
+        actively used factor doesn't get evicted while still in use.
+
+        Falls back to the pinned registry (pounce#82) so a back-solve
+        driven from a caller-owned :class:`AnchorState` resolves the
+        same way as one driven from a ``custom_vjp`` residual."""
         with self._registry_lock:
             s = self._solver_registry.get(sid)
             if s is not None:
                 self._solver_registry.move_to_end(sid)
-            return s
+                return s
+            return self._pinned_solvers.get(sid)
+
+    def _check_pinned_capacity(self) -> None:
+        """Raise if the pinned registry is full (pounce#82). Called as a
+        pre-check *before* the anchor solve so we never build a factor
+        only to reject it — building then raising would strand the
+        unsendable Solver on the executor thread's frame and drop it on
+        the caller's thread when the traceback is collected. A missed
+        ``close()`` should fail loudly rather than leak factors unbounded
+        in a long loop."""
+        with self._registry_lock:
+            if len(self._pinned_solvers) >= self._pinned_capacity:
+                raise RuntimeError(
+                    "pounce.jax: too many live anchored factors "
+                    f"({len(self._pinned_solvers)} >= "
+                    f"{self._pinned_capacity}). An AnchorState was likely "
+                    "re-anchored or dropped without close(); use a `with "
+                    "jp.anchor(...) as state:` block, call state.close() "
+                    "when done, or raise jp._pinned_capacity if you truly "
+                    "need this many simultaneous anchors."
+                )
+
+    def _register_pinned_solver(self, solver: Solver) -> int:
+        """Pin a converged Solver for a caller-owned :class:`AnchorState`
+        (pounce#82). Returns a unique integer id, shared with the LRU id
+        space. The entry is exempt from LRU eviction and only dropped by
+        :meth:`_release_pinned`. Runs inside :meth:`_run_pinned` so the
+        unsendable Solver stays on its creating thread. Capacity is
+        enforced by :meth:`_check_pinned_capacity` before the solve."""
+        with self._registry_lock:
+            sid = next(self._solver_id_counter)
+            self._pinned_solvers[sid] = solver
+        return sid
+
+    def _release_pinned(self, sid: int) -> None:
+        """Drop a pinned factor (see :meth:`_register_pinned_solver`).
+        The Rust ``Rc`` frees the factor when this last reference drops.
+        Idempotent: releasing an already-gone id is a no-op.
+
+        The held :class:`pounce.Solver` is ``#[pyclass(unsendable)]`` and
+        must be *dropped on the thread that built it* — the factor
+        executor (same constraint LRU eviction satisfies by running
+        inside :meth:`_run_pinned`). So the ``pop`` (and the decref/drop
+        of the popped Solver) is routed onto the executor thread. Handles
+        two edge cases the weakref finalizer can hit:
+
+        * re-entrancy — if a GC-triggered finalizer fires while we are
+          already on the executor thread, run inline rather than
+          deadlocking on the single worker;
+        * interpreter teardown — if the executor is already shut down,
+          a leaked pin is moot, so swallow the failure.
+        """
+        def _drop():
+            with self._registry_lock:
+                # Bare statement: the popped Solver (if any) is decref'd
+                # here, on this thread.
+                self._pinned_solvers.pop(sid, None)
+
+        if threading.current_thread().name.startswith(self._factor_thread_prefix):
+            _drop()
+            return
+        try:
+            self._factor_executor.submit(_drop).result()
+        except RuntimeError:
+            # Executor already shut down (interpreter teardown).
+            pass
 
     def clear_solver_cache(self) -> None:
         """Drop all cached IPM factors held for backward passes.
@@ -1362,7 +1559,13 @@ class JaxProblem:
         info_out["solver_id"] = sid
         return x_np, info_out
 
-    def _host_batched_solve(self, p_batch_np: np.ndarray, x0_batch_np: np.ndarray):
+    def _host_batched_solve(
+        self,
+        p_batch_np: np.ndarray,
+        x0_batch_np: np.ndarray,
+        *,
+        pin: bool = False,
+    ):
         """Forward solve for the stacked block-diagonal problem
         (pounce#76 (A), composes with (B) when ``factor_reuse=True``).
 
@@ -1388,14 +1591,23 @@ class JaxProblem:
         # Initial X is the per-block ``x0`` tiled / concatenated.
         X0 = np.asarray(x0_batch_np, dtype=np.float64).reshape(B * n)
 
-        do_register = self._factor_reuse
+        # ``pin=True`` (pounce#82 anchor path) always holds the factor in
+        # the eviction-exempt pinned registry, regardless of
+        # ``factor_reuse`` — the whole point of an anchor is to reuse the
+        # held factor for post-solve sensitivities.
+        do_register = self._factor_reuse or pin
 
         def _do():
             obj, prob = self._thread_stacked_problem(B)
             obj._P = jnp.asarray(p_batch_np)
             solver = Solver(prob)
             X_np, info = solver.solve(x0=X0)
-            sid = self._register_solver(solver) if do_register else 0
+            if not do_register:
+                sid = 0
+            elif pin:
+                sid = self._register_pinned_solver(solver)
+            else:
+                sid = self._register_solver(solver)
             return X_np, info, sid
 
         # Pin every batched_solve dispatch (pounce#77) — TLS cache
@@ -1635,6 +1847,181 @@ class JaxProblem:
             p_batch, x0_arr, lam_warm, zL_warm, zU_warm,
         )
         return x_star, (lam_out, zL_out, zU_out)
+
+    # ----- post-solve Jacobian / sensitivity API (pounce#82) -----
+
+    def _normalize_cols(self, wrt_cols):
+        """Resolve a ``wrt_cols`` selector into either ``None`` (full
+        parameter space) or a 1-D int index array over the (flat)
+        parameter axis. Column selection is only defined for 1-D ``p``;
+        a multi-axis ``p`` with ``wrt_cols`` is rejected rather than
+        guessed at."""
+        if wrt_cols is None:
+            return None
+        if len(self._p_shape) != 1:
+            raise ValueError(
+                "pounce.jax: wrt_cols is only supported for 1-D p "
+                f"(got p_shape={self._p_shape}). Pass wrt_cols=None and "
+                "slice the returned Jacobian yourself."
+            )
+        p_dim = self._p_shape[0]
+        idx = np.arange(p_dim)[wrt_cols] if isinstance(wrt_cols, slice) \
+            else np.asarray(wrt_cols, dtype=np.int64)
+        return jnp.asarray(np.atleast_1d(idx))
+
+    def _anchor_forward(self, p_batch, x0):
+        """Run the stacked forward and pin the converged factor
+        (pounce#82). Returns ``(x_star, (lam, zL, zU), sid, residuals)``
+        where ``residuals = (p_batch, x_star, lam)`` are the jnp arrays
+        the from-state back-solves contract against."""
+        # Pre-check before solving so a full registry never strands a
+        # freshly built (unsendable) factor on the wrong thread.
+        self._check_pinned_capacity()
+        p_arr = jnp.asarray(p_batch, dtype=jnp.float64)
+        B = p_arr.shape[0]
+        x0_arr = jnp.asarray(x0, dtype=jnp.float64)
+        if x0_arr.ndim == 1:
+            x0_arr = jnp.broadcast_to(x0_arr, (B, self._n))
+        x_batch, lam_batch, mxL_batch, mxU_batch, sid = self._host_batched_solve(
+            np.asarray(p_arr), np.asarray(x0_arr), pin=True,
+        )
+        x_star = jnp.asarray(x_batch)
+        lam = jnp.asarray(lam_batch)
+        duals = (lam, jnp.asarray(mxL_batch), jnp.asarray(mxU_batch))
+        return x_star, duals, sid, (p_arr, x_star, lam)
+
+    def _slice_cols(self, arr, cols):
+        """Slice the trailing parameter axis of a sensitivity array by a
+        resolved ``cols`` index array (no-op when ``cols is None``)."""
+        if cols is None:
+            return arr
+        return jnp.take(arr, cols, axis=-1)
+
+    def anchor(self, p_batch, x0, *, wrt_cols=None) -> AnchorState:
+        """Solve once and pin the held FERAL stacked KKT factor for
+        reuse across post-solve sensitivity calls (pounce#82).
+
+        Unlike :meth:`batched_solve_with_jacobian`, this does *not*
+        materialise the full Jacobian — it is the lightweight entry point
+        for the linear-update pattern where you only need products
+        against the held factor (e.g. :meth:`batched_vjp_from_state`).
+
+        Returns an :class:`AnchorState` handle. Prefer the context
+        manager (``with jp.anchor(...) as state:``); see
+        :class:`AnchorState` for the explicit-lifetime form.
+
+        ``wrt_cols`` (1-D ``p`` only) restricts the parameter space of
+        subsequent from-state products to the selected columns, e.g.
+        ``slice(0, ny)`` to keep only the predicted block and drop
+        context columns.
+        """
+        cols = self._normalize_cols(wrt_cols)
+        x_star, duals, sid, (pb, xs, lam) = self._anchor_forward(p_batch, x0)
+        return AnchorState(self, sid, pb.shape[0], pb, xs, lam, duals, cols)
+
+    def batched_solve_with_jacobian(
+        self,
+        p_batch,
+        x0,
+        *,
+        wrt_cols=None,
+        return_state=False,
+    ):
+        """Solve the stacked batch and return the full primal Jacobian
+        from the held FERAL KKT factor (pounce#82).
+
+        Computes ``J[k] = ∂x^(k)*/∂p^(k)`` for every block by reusing the
+        held stacked LDLᵀ factor: the Jacobian's row ``i`` is exactly the
+        reverse-mode VJP with cotangent ``e_i`` (the KKT system is
+        symmetric), so ``J`` is the existing factor-reuse backward
+        (:func:`_bwd_batched_factor_reuse`) evaluated over the ``n×n``
+        identity output basis — packed into one multi-RHS back-solve via
+        ``Solver.kkt_solve_many`` rather than an NLP re-solve or repeated
+        public ``jax.vjp`` calls.
+
+        Parameters
+        ----------
+        p_batch : ``(B,) + p_shape``
+        x0 : ``(n,)`` or ``(B, n)``
+        wrt_cols : slice / index array / None
+            Parameter columns to keep (1-D ``p`` only). ``optlayer``
+            passes ``slice(0, ny)`` to keep only the predicted block. When
+            given, ``J`` has trailing dim ``len(wrt_cols)`` instead of
+            ``p_dim``; when ``None`` the full ``p`` axis is returned.
+        return_state : bool
+            If True, also pin the factor and return an
+            :class:`AnchorState` for follow-up from-state products.
+
+        Returns
+        -------
+        ``(x_star, (lam, zL, zU), J)`` or, if ``return_state``,
+        ``(x_star, (lam, zL, zU), J, state)``.
+
+        * ``x_star`` : ``(B, n)``
+        * duals : ``(lam (B, m), zL (B, n), zU (B, n))`` — same contract
+          as :meth:`batched_solve_with_warm`.
+        * ``J`` : ``(B, n, p_dim)`` (or ``(B, n, len(wrt_cols))``).
+        """
+        f, g, n, m = self._f, self._g, self._n, self._m
+        cols = self._normalize_cols(wrt_cols)
+        # Always pin for the duration of the Jacobian build so the
+        # back-solve resolves regardless of ``factor_reuse``; if the
+        # caller does not want the handle, release the pin before
+        # returning.
+        x_star, duals, sid, (p_arr, xs, lam) = self._anchor_forward(p_batch, x0)
+        B = p_arr.shape[0]
+
+        # J[:, i, :] = (e_i)^T J = VJP at cotangent e_i (broadcast over
+        # blocks). vmapping the held-factor backward over the identity
+        # output basis packs all n directions into one kkt_solve_many.
+        basis = jnp.eye(n, dtype=jnp.float64)
+
+        def jac_row(e_i):
+            v = jnp.broadcast_to(e_i, (B, n))
+            return _bwd_batched_factor_reuse(
+                f, g, n, m, self, B, p_arr, xs, lam, sid, v,
+            )
+
+        J_rows = jax.vmap(jac_row)(basis)          # (n, B, p_dim)
+        J = jnp.transpose(J_rows, (1, 0, 2))        # (B, n, p_dim)
+        J = self._slice_cols(J, cols)
+
+        if return_state:
+            state = AnchorState(self, sid, B, p_arr, xs, lam, duals, cols)
+            return x_star, duals, J, state
+        self._release_pinned(sid)
+        return x_star, duals, J
+
+    def batched_vjp_from_state(self, state: AnchorState, x_bar_batch):
+        """Vector-Jacobian product ``J^T @ x_bar`` against a held factor
+        (pounce#82). Public form of the reverse-mode path the
+        ``custom_vjp`` backward already uses internally — one multi-RHS
+        back-solve against the pinned LDLᵀ factor, no NLP re-solve.
+
+        Parameters
+        ----------
+        state : AnchorState
+        x_bar_batch : ``(B, n)``
+            Output-space cotangent per block.
+
+        Returns
+        -------
+        ``(B, p_dim)`` (or ``(B, len(wrt_cols))`` if the state was
+        anchored with ``wrt_cols``) — the parameter-space cotangent.
+        """
+        if state._jp is not self:
+            raise ValueError(
+                "pounce.jax: AnchorState belongs to a different "
+                "JaxProblem."
+            )
+        state._check_open()
+        f, g, n, m = self._f, self._g, self._n, self._m
+        x_bar = jnp.asarray(x_bar_batch, dtype=jnp.float64).reshape(state._B, n)
+        dp = _bwd_batched_factor_reuse(
+            f, g, n, m, self, state._B,
+            state._p_batch, state._x_star, state._lam, state._sid, x_bar,
+        )
+        return self._slice_cols(dp, state._wrt_cols)
 
     # ----- custom_vjp factories -----
 

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1113,3 +1113,254 @@ def test_batched_solve_with_warm_warm_inputs_are_stop_gradient_pounce_78():
     for arr, name in [(g_x0, "x0"), (g_lam, "lam_warm"),
                        (g_zL, "zL_warm"), (g_zU, "zU_warm")]:
         np.testing.assert_array_equal(np.asarray(arr), np.zeros_like(np.asarray(arr)))
+
+
+# --------------------------------------------------------------------------
+# pounce#82: post-solve Jacobian / sensitivity API from the held KKT factor
+# --------------------------------------------------------------------------
+
+
+def _build_jac_qp(reuse=True, bounded=False):
+    """min ||x - p||² s.t. x[0] + x[1] = 1, optionally with a binding
+    upper bound (to exercise the zU multiplier block)."""
+    from pounce.jax import JaxProblem
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    ub = jnp.array([0.2, 10.0]) if bounded else jnp.full(2, 10.0)
+    return JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=ub,
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+        factor_reuse=reuse,
+    )
+
+
+def _jacrev_block_diag(jp, p_batch, x0):
+    """Reference per-block Jacobian via jax.jacrev over batched_solve."""
+    J_full = jax.jacrev(lambda P: jp.batched_solve(P, x0))(p_batch)
+    B = p_batch.shape[0]
+    return jnp.stack([J_full[k, :, k, :] for k in range(B)])
+
+
+@pytest.mark.parametrize("bounded", [False, True])
+@pytest.mark.parametrize("reuse", [True, False])
+def test_batched_solve_with_jacobian_matches_jacrev_pounce_82(bounded, reuse):
+    """Issue #82: the full Jacobian from the held factor must equal
+    ``jax.jacrev`` over ``batched_solve`` (the KKT system is symmetric,
+    so J's row i is the VJP at cotangent e_i). Covers a binding upper
+    bound (zU block participates) and both ``factor_reuse`` settings —
+    the anchor path forces a held factor regardless."""
+    jp = _build_jac_qp(reuse=reuse, bounded=bounded)
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5], [-0.1, 0.4]])
+    x0 = jnp.zeros(2)
+
+    x_star, (lam, zL, zU), J = jp.batched_solve_with_jacobian(p_batch, x0)
+
+    # Forward agrees with batched_solve.
+    np.testing.assert_allclose(
+        np.asarray(x_star), np.asarray(jp.batched_solve(p_batch, x0)), atol=1e-9
+    )
+    # Jacobian agrees with jacrev.
+    Jref = _jacrev_block_diag(jp, p_batch, x0)
+    np.testing.assert_allclose(np.asarray(J), np.asarray(Jref), atol=1e-6)
+    # Duals have the documented shapes.
+    assert lam.shape == (3, 1)
+    assert zL.shape == (3, 2)
+    assert zU.shape == (3, 2)
+
+
+def test_batched_solve_with_jacobian_wrt_cols_pounce_82():
+    """Issue #82: ``wrt_cols`` selects parameter columns and matches the
+    corresponding slice of the full Jacobian."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    _, _, J = jp.batched_solve_with_jacobian(p_batch, x0)
+    _, _, J0 = jp.batched_solve_with_jacobian(p_batch, x0, wrt_cols=slice(0, 1))
+    assert J0.shape == (2, 2, 1)
+    np.testing.assert_allclose(np.asarray(J0), np.asarray(J[..., :1]), atol=1e-12)
+
+    # Index-array form selects the same column.
+    _, _, Jidx = jp.batched_solve_with_jacobian(p_batch, x0, wrt_cols=[0])
+    np.testing.assert_allclose(np.asarray(Jidx), np.asarray(J0), atol=1e-12)
+
+
+def test_batched_vjp_from_state_matches_jax_vjp_pounce_82():
+    """Issue #82: ``batched_vjp_from_state`` equals ``jax.vjp`` over
+    ``batched_solve`` (J^T @ x_bar), and equals J^T @ x_bar from the
+    materialised Jacobian."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5], [-0.1, 0.4]])
+    x0 = jnp.zeros(2)
+    x_bar = jnp.array([[1.0, 0.0], [0.0, 1.0], [0.5, 0.5]])
+
+    x_star, duals, J, state = jp.batched_solve_with_jacobian(
+        p_batch, x0, return_state=True
+    )
+    try:
+        dp = jp.batched_vjp_from_state(state, x_bar)
+
+        _, vjp_fn = jax.vjp(lambda P: jp.batched_solve(P, x0), p_batch)
+        dp_ref = vjp_fn(x_bar)[0]
+        np.testing.assert_allclose(np.asarray(dp), np.asarray(dp_ref), atol=1e-6)
+
+        dp_fromJ = jnp.einsum("knp,kn->kp", J, x_bar)
+        np.testing.assert_allclose(np.asarray(dp), np.asarray(dp_fromJ), atol=1e-9)
+    finally:
+        state.close()
+
+
+def test_vjp_from_state_respects_wrt_cols_pounce_82():
+    """Issue #82: a state anchored with ``wrt_cols`` returns the reduced
+    parameter cotangent from ``batched_vjp_from_state``."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+    x_bar = jnp.array([[1.0, 0.0], [0.0, 1.0]])
+
+    with jp.anchor(p_batch, x0, wrt_cols=slice(0, 1)) as state:
+        dp = jp.batched_vjp_from_state(state, x_bar)
+    assert dp.shape == (2, 1)
+
+    with jp.anchor(p_batch, x0) as state_full:
+        dp_full = jp.batched_vjp_from_state(state_full, x_bar)
+    np.testing.assert_allclose(np.asarray(dp), np.asarray(dp_full[..., :1]), atol=1e-9)
+
+
+def test_jacobian_duals_match_batched_solve_with_warm_pounce_82():
+    """Issue #82: the (lam, zL, zU) contract matches
+    ``batched_solve_with_warm`` on the same problem."""
+    jp = _build_jac_qp(bounded=True)
+    p_batch = jnp.array([[0.3, 0.7], [0.9, 0.1]])
+    x0 = jnp.zeros(2)
+
+    _, (lam, zL, zU) = jp.batched_solve_with_warm(p_batch, x0)
+    _, (lam2, zL2, zU2), _J = jp.batched_solve_with_jacobian(p_batch, x0)
+    np.testing.assert_allclose(np.asarray(lam2), np.asarray(lam), atol=1e-7)
+    np.testing.assert_allclose(np.asarray(zL2), np.asarray(zL), atol=1e-7)
+    np.testing.assert_allclose(np.asarray(zU2), np.asarray(zU), atol=1e-7)
+
+
+def test_anchor_lifetime_context_manager_pounce_82():
+    """Issue #82: context manager releases the pinned factor on exit."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    with jp.anchor(p_batch, x0) as state:
+        assert not state.closed
+        assert len(jp._pinned_solvers) == 1
+    assert state.closed
+    assert len(jp._pinned_solvers) == 0
+
+
+def test_anchor_explicit_close_idempotent_and_raises_when_closed_pounce_82():
+    """Issue #82: explicit close frees the pin, is idempotent, and a
+    from-state op on a closed handle raises."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+    x_bar = jnp.zeros((2, 2))
+
+    state = jp.anchor(p_batch, x0)
+    assert len(jp._pinned_solvers) == 1
+    state.close()
+    assert len(jp._pinned_solvers) == 0
+    state.close()  # idempotent
+    assert state.closed
+    with pytest.raises(RuntimeError, match="closed"):
+        jp.batched_vjp_from_state(state, x_bar)
+
+
+def test_anchor_survives_beyond_lru_capacity_pounce_82():
+    """Issue #82 core requirement: a pinned anchor outlives LRU eviction.
+    With the LRU bounded at 1, many intervening batched_solve calls would
+    evict an ordinary cached factor — the pinned one must remain usable."""
+    jp = _build_jac_qp()
+    jp._solver_registry_capacity = 1  # force aggressive LRU eviction
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+    x_bar = jnp.array([[1.0, 0.0], [0.0, 1.0]])
+
+    with jp.anchor(p_batch, x0) as state:
+        # Hammer the LRU with unrelated forward+backward solves.
+        for _ in range(5):
+            jax.grad(lambda P: jnp.sum(jp.batched_solve(P, x0) ** 2))(p_batch)
+        # The pinned factor is still resolvable.
+        dp = jp.batched_vjp_from_state(state, x_bar)
+        _, vjp_fn = jax.vjp(lambda P: jp.batched_solve(P, x0), p_batch)
+        np.testing.assert_allclose(
+            np.asarray(dp), np.asarray(vjp_fn(x_bar)[0]), atol=1e-6
+        )
+
+
+def test_anchor_gc_finalizer_reclaims_pounce_82():
+    """Issue #82: dropping a handle without close() still reclaims the
+    pinned factor via the weakref finalizer."""
+    import gc
+
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    state = jp.anchor(p_batch, x0)
+    assert len(jp._pinned_solvers) == 1
+    del state
+    gc.collect()
+    assert len(jp._pinned_solvers) == 0
+
+
+def test_anchor_reanchor_swaps_without_leak_pounce_82():
+    """Issue #82: reanchor closes the prior pin before taking a new one,
+    so the pinned count stays at 1 (no overwrite leak)."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    state = jp.anchor(p_batch, x0)
+    sid1 = state.sid
+    state.reanchor(p_batch * 1.1, x0)
+    assert state.sid != sid1
+    assert len(jp._pinned_solvers) == 1
+    state.close()
+    assert len(jp._pinned_solvers) == 0
+
+
+def test_anchor_capacity_raises_loudly_pounce_82():
+    """Issue #82: exceeding the pinned-handle cap raises rather than
+    growing unbounded, and does not leak a factor on the failed call."""
+    jp = _build_jac_qp()
+    jp._pinned_capacity = 3
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    states = [jp.anchor(p_batch, x0) for _ in range(3)]
+    try:
+        assert len(jp._pinned_solvers) == 3
+        with pytest.raises(RuntimeError, match="too many live anchored"):
+            jp.anchor(p_batch, x0)
+        # Failed anchor did not add a pin.
+        assert len(jp._pinned_solvers) == 3
+    finally:
+        for s in states:
+            s.close()
+    assert len(jp._pinned_solvers) == 0
+
+
+def test_vjp_from_state_rejects_foreign_state_pounce_82():
+    """Issue #82: a state from one JaxProblem can't be used with another."""
+    jp1 = _build_jac_qp()
+    jp2 = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    with jp1.anchor(p_batch, x0) as state:
+        with pytest.raises(ValueError, match="different"):
+            jp2.batched_vjp_from_state(state, jnp.zeros((2, 2)))

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1364,3 +1364,113 @@ def test_vjp_from_state_rejects_foreign_state_pounce_82():
     with jp1.anchor(p_batch, x0) as state:
         with pytest.raises(ValueError, match="different"):
             jp2.batched_vjp_from_state(state, jnp.zeros((2, 2)))
+
+
+# --------------------------------------------------------------------------
+# pounce#82 Phase 2: forward-mode JVP from the held factor (J @ dp)
+# --------------------------------------------------------------------------
+
+
+def _fd_jvp(jp, p_batch, x0, dp, eps=1e-6):
+    """Central finite-difference directional derivative of batched_solve.
+    (batched_solve is a custom_vjp, so jax.jvp can't trace it directly.)"""
+    xp = jp.batched_solve(p_batch + eps * dp, x0)
+    xm = jp.batched_solve(p_batch - eps * dp, x0)
+    return (xp - xm) / (2.0 * eps)
+
+
+@pytest.mark.parametrize("bounded", [False, True])
+@pytest.mark.parametrize("reuse", [True, False])
+def test_batched_jvp_from_state_matches_jacobian_pounce_82(bounded, reuse):
+    """Issue #82 Phase 2: ``J @ dp`` from the forward path equals the
+    contraction of the materialised Jacobian (machine precision) and a
+    finite-difference directional derivative (loose)."""
+    jp = _build_jac_qp(reuse=reuse, bounded=bounded)
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5], [-0.05, 0.4]])
+    x0 = jnp.zeros(2)
+    dp = jnp.array([[1.0, 0.0], [0.2, -0.3], [0.5, 0.5]])
+
+    x_star, _, J, state = jp.batched_solve_with_jacobian(
+        p_batch, x0, return_state=True
+    )
+    try:
+        dx = jp.batched_jvp_from_state(state, dp)
+    finally:
+        state.close()
+
+    assert dx.shape == (3, 2)
+    dx_fromJ = jnp.einsum("knp,kp->kn", J, dp)
+    np.testing.assert_allclose(np.asarray(dx), np.asarray(dx_fromJ), atol=1e-10)
+    dx_fd = _fd_jvp(jp, p_batch, x0, dp)
+    np.testing.assert_allclose(np.asarray(dx), np.asarray(dx_fd), atol=1e-6)
+
+
+def test_batched_jvp_unconstrained_pounce_82():
+    """Issue #82 Phase 2: for ``min ||x - p||²`` (x* = p) the directional
+    derivative is the identity, so ``J @ dp = dp``."""
+    from pounce.jax import JaxProblem
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    jp = JaxProblem(
+        f=f, g=None, n=3, m=0, p_example=jnp.zeros(3),
+        lb=jnp.full(3, -10.0), ub=jnp.full(3, 10.0),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    p_batch = jnp.array([[0.1, 0.2, 0.3], [-1.0, 0.5, 2.0]])
+    dp = jnp.array([[1.0, 2.0, 3.0], [0.5, 0.0, -1.0]])
+    x0 = jnp.zeros(3)
+
+    with jp.anchor(p_batch, x0) as state:
+        dx = jp.batched_jvp_from_state(state, dp)
+    np.testing.assert_allclose(np.asarray(dx), np.asarray(dp), atol=1e-7)
+
+
+def test_batched_jvp_respects_wrt_cols_pounce_82():
+    """Issue #82 Phase 2: a state anchored with ``wrt_cols`` takes a
+    reduced ``dp`` and matches the full-space JVP with zeros elsewhere."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    with jp.anchor(p_batch, x0, wrt_cols=slice(0, 1)) as state:
+        dx_red = jp.batched_jvp_from_state(state, jnp.array([[1.0], [0.4]]))
+    dx_fd = _fd_jvp(jp, p_batch, x0, jnp.array([[1.0, 0.0], [0.4, 0.0]]))
+    np.testing.assert_allclose(np.asarray(dx_red), np.asarray(dx_fd), atol=1e-6)
+
+
+def test_batched_jvp_shape_validation_pounce_82():
+    """Issue #82 Phase 2: a dp_batch with the wrong per-block shape or
+    batch size is rejected with a clear error."""
+    jp = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    with jp.anchor(p_batch, x0) as state:
+        with pytest.raises(ValueError, match="per-block shape"):
+            jp.batched_jvp_from_state(state, jnp.zeros((2, 3)))
+        with pytest.raises(ValueError, match="leading dim"):
+            jp.batched_jvp_from_state(state, jnp.zeros((3, 2)))
+    # wrt_cols state expects the reduced width.
+    with jp.anchor(p_batch, x0, wrt_cols=slice(0, 1)) as state:
+        with pytest.raises(ValueError, match="per-block shape"):
+            jp.batched_jvp_from_state(state, jnp.zeros((2, 2)))
+
+
+def test_batched_jvp_rejects_closed_and_foreign_state_pounce_82():
+    """Issue #82 Phase 2: JVP-from-state guards lifetime and ownership
+    like the VJP path."""
+    jp1 = _build_jac_qp()
+    jp2 = _build_jac_qp()
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    x0 = jnp.zeros(2)
+
+    state = jp1.anchor(p_batch, x0)
+    state.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        jp1.batched_jvp_from_state(state, jnp.zeros((2, 2)))
+
+    with jp1.anchor(p_batch, x0) as state:
+        with pytest.raises(ValueError, match="different"):
+            jp2.batched_jvp_from_state(state, jnp.zeros((2, 2)))


### PR DESCRIPTION
## Summary

Implements pounce#82: a first-class post-solve sensitivity surface that reuses the held FERAL stacked KKT factor for computing Jacobians and directional sensitivities without re-solving or risking LRU eviction.

## Key Changes

- **New `AnchorState` class**: A caller-owned handle to a pinned KKT factor with deterministic lifetime management via context manager or explicit `close()` / `reanchor()` methods. Includes safety nets: weakref finalizer for GC-based reclamation, capacity cap to prevent unbounded leaks, and closed-handle guards.

- **Pinned solver registry**: Added `_pinned_solvers` dict and `_pinned_capacity` (default 16) to hold factors exempt from LRU eviction. Shares the integer id space with the LRU registry so a single `_lookup_solver` resolves either. Includes `_check_pinned_capacity()` pre-check before anchor solves and `_release_pinned()` for thread-safe cleanup.

- **`batched_solve_with_jacobian(p_batch, x0, *, wrt_cols=None, return_state=False)`**: Returns the full per-block Jacobian `J` of shape `(B, n, p_dim)` (or `(B, n, len(wrt_cols))` with column selection) alongside `x_star` and duals. Optionally returns an `AnchorState` for reuse. The Jacobian is assembled by evaluating the held factor over the `n×n` identity output basis via one multi-RHS back-solve.

- **`anchor(p_batch, x0, *, wrt_cols=None)`**: Solves once and pins the factor, returning an `AnchorState` for reuse across several post-solve sensitivity calls (linear-update pattern).

- **`batched_vjp_from_state(state, x_bar)`**: Computes `J^T @ x_bar` by back-solving the cotangent RHS against the held factor. Respects `wrt_cols` from the anchor.

- **`batched_jvp_from_state(state, dp)` (Phase 2)**: Computes `J @ dp` by assembling the parameter-side RHS `[∂²L/∂x∂p · dp; ∂g/∂p · dp]` and forward-solving once against the held factor. Supports vmap over multiple directions in one FFI hop via `_kkt_jvp_batched_pure_callback`.

- **`_normalize_cols()` helper**: Resolves `wrt_cols` selectors into index arrays for 1-D parameters.

- **`_anchor_forward()` and `_host_batched_solve(..., pin=True)`**: Internal methods to run the stacked forward and pin the converged factor. The `pin` flag forces registration in the pinned registry regardless of `factor_reuse`.

## Implementation Details

- The pinned registry is guarded by `_registry_lock` and entries are dropped only on the factor executor thread to respect the `#[pyclass(unsendable)]` constraint of the Rust `Solver`.

- `_release_pinned()` handles re-entrancy (GC finalizer firing on the executor thread) and interpreter teardown gracefully.

- `_kkt_jvp_batched_pure_callback` scatters the constraint-side RHS from user g-order into the stacked block-major y_c / y_d blocks (inverse of the reverse path's de-interleave).

- All post-solve calls validate that the state belongs to the calling `JaxProblem` instance.

- Added comprehensive test coverage including bounded constraints, LRU eviction survival, GC finalizer reclamation, capacity overflow, and finite-difference validation of JVP.

- Updated documentation and added a detailed Jupyter notebook (`13_post_solve_jacobian.ipynb`) demonstrating the full API with examples.

https://claude.ai/code/session_01PQyqyKy67h91vc9BM54sb9