### PR TITLE
Add predictor–corrector path following and inverse-map ODE recipe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,45 @@ jobs:
       - name: Test
         run: cargo test --workspace --exclude pounce-hsl --verbose
 
+  # Exercise the Python surface (the `pounce.jax` differentiable /
+  # sensitivity / path-following APIs) on every PR. The Rust `test` job
+  # above covers the solver core, and `wheel-smoke` only imports the
+  # package — neither runs pytest, so without this job the entire
+  # Python feature surface lands untested in CI. Builds the wheel the
+  # same way wheel-smoke does, then installs the jax + diffrax extras
+  # and runs the test suite.
+  python-test:
+    name: Python tests (jax)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Checkout feral sibling
+        run: git clone --depth 1 https://github.com/jkitchin/feral.git ../feral
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          target: x86_64
+          manylinux: manylinux2014
+          args: --release --out dist
+          sccache: "true"
+          # Same feral sibling bind-mount as wheel-smoke so cargo
+          # resolves the `[patch.crates-io] feral = { path = "../feral" }`
+          # entry inside the manylinux container.
+          docker-options: |
+            -v ${{ github.workspace }}/../feral:${{ github.workspace }}/../feral
+      - name: Install wheel + test deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install python/dist/*.whl pytest scipy "jax[cpu]" diffrax
+      - name: Run Python tests
+        run: python -m pytest python/tests -q
+
   # Smoke-build the `pounce-solver` wheel on every PR so packaging
   # regressions surface here, not at tag time. Runs only on Linux
   # x86_64; the full multi-platform matrix lives in release-pounce.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # mdbook render output — `make book` regenerates it from docs/src/.
 /docs/book
 
+# Local Python venv used to build/test the native extension
+# (`maturin develop`). Machine-specific build artifact.
+/.venv
+
 # Local cargo config — holds a machine-specific CoinHSL rpath for the
 # optional `ma57` feature. Set COINHSL_DIR instead (see crates/pounce-hsl).
 /.cargo/config.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ changes.
 
 ## Unreleased
 
+### Added — Inverse-map ODE recipe over a sensitivity RHS (pounce#91)
+
+`pounce.jax.inverse_map_rhs(jp, dy_ds, *, output=None, x0=None)` builds
+the right-hand side of the Alves–Kitchin–Lima inverse / uncertainty
+mapping ODE (pounce#84, Eq. 3):
+
+```
+dθ/ds = (∂y/∂θ)^{-1} · dy/ds
+```
+
+where ``y = output(x*(θ), θ)`` is an output of the embedded optimizer.
+POUNCE supplies the RHS; an off-the-shelf adaptive integrator (diffrax,
+scipy) does the stepping — *no NLP inversion*.
+
+- The inverse map is a **linear solve against** the total output
+  sensitivity ``∂y/∂θ = (∂h/∂x) J + ∂h/∂θ`` (with ``J = ∂x*/∂θ`` from
+  the held factor), not a Jacobian-vector product — so it wants the full
+  ``J`` and ``jnp.linalg.solve``.
+- The whole evaluation rides one `jax.pure_callback`, so the RHS is
+  JAX-traceable and composes under `jax.jit` and diffrax (which
+  jit-compiles the vector field).
+- Worked example `python/examples/inverse_map_diffrax.py` integrates a
+  closed output boundary with diffrax Dopri5 and round-trips back through
+  the optimizer onto the boundary (~1e-7). `diffrax` is an optional
+  extra (`pip install pounce[diffrax]`); the example falls back to RK4
+  if it's absent.
+- Switch to `PathFollower` when the path folds or the active set changes.
+
+Also fixes the build-once / stacked path for **unconstrained** problems
+(``g=None``, ``m=0``): the constraint callbacks no longer dereference the
+(``None``) constraint-Jacobian jit, so `JaxProblem.solve` /
+`solve_with_jacobian` / the batched solves now work with no constraints.
+
 ### Added — Predictor–corrector path-following engine (pounce#90)
 
 `pounce.jax.PathFollower` traces a solution path of a parametric NLP by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ scipy) does the stepping — *no NLP inversion*.
   the optimizer onto the boundary (~1e-7). `diffrax` is an optional
   extra (`pip install pounce[diffrax]`); the example falls back to RK4
   if it's absent.
+- `inverse_map_rhs(..., warm=True)` warm-starts each inner solve from the
+  previous evaluation's primal/duals/μ (pounce#86). Result-invariant (up
+  to solver tolerance); a *modest* lever — ~1.4-1.7× fewer IPM iterations,
+  ~1.3× wall-clock, roughly flat in problem size (interior-point
+  warm-start ceiling + per-eval Jacobian-build overhead). Benchmark:
+  `python/benchmarks/inverse_map_warm.py`. For a real speedup on a smooth
+  map, prefer `PathFollower` (it skips solves, not just cheapens them).
 - Switch to `PathFollower` when the path folds or the active set changes.
 - Worked notebook `python/notebooks/14_path_following.ipynb` tours the
   whole family (sensitivity → margin → continuation → fold → inverse map).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ changes.
 
 ## Unreleased
 
+### Added — Predictor–corrector path-following engine (pounce#90)
+
+`pounce.jax.PathFollower` traces a solution path of a parametric NLP by
+*composing* the post-solve sensitivity primitives instead of re-solving
+at every step:
+
+```python
+from pounce.jax import PathFollower
+pf = PathFollower(jp, monitor_tol=1e-6, ds0=0.05)
+trace = pf.follow(theta_of_s, (0.0, 1.0), x0)   # parameter continuation
+# trace.x, trace.theta, trace.s, trace.lam,
+# trace.n_correctors, trace.n_accepts, trace.active_set_changes
+```
+
+- **predict** — extrapolate primal *and duals* along the held-factor
+  sensitivity (`jvp_from_state(..., with_duals=True)`); **monitor**
+  (no solve) — KKT residual + active-set margin (#89) at the predicted
+  point; **correct** — only when the monitor trips, a warm-μ re-solve
+  that also re-anchors the factor in one solve (`warm_anchor`, #86).
+- Adaptive step size; detects and records active-set changes and
+  re-anchors on the new active set.
+- `PathFollower.trace_arclength(...)` — pseudo-arclength continuation for
+  a scalar-parameter, equality/unconstrained family, tracing **past
+  folds** where `∂x*/∂θ` is singular (parameter continuation cannot).
+  Reports turning points. Bifurcation/branch-switching and
+  inequality-active folds are out of scope for v1.
+- On a linear-response NLP the predictor is exact, so the whole path is
+  traced with **zero correctors** (one anchor solve vs one cold solve
+  per step); nonlinear paths correct adaptively and still trace to
+  tolerance.
+
+New supporting public surface:
+
+- `JaxProblem.warm_anchor(p, x0, *, duals=None, mu=None)` — a warm-started,
+  μ-seeded re-solve that pins the converged factor and returns a `B=1`
+  `AnchorState` (the corrector + anchor in one solve). Threads μ through
+  the reusable build-once path (the #86 follow-up).
+- `JaxProblem.jvp_from_state(..., with_duals=True)` /
+  `batched_jvp_from_state(..., with_duals=True)` — also return the dual
+  sensitivity `∂λ*/∂θ · dp` from the same held-factor back-solve.
+
 ### Added — Active-set-proximity monitor (pounce#89)
 
 `JaxProblem.active_set_margin(state)` reports the distance to an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ changes.
 
 ## Unreleased
 
+### Added — Active-set-proximity monitor (pounce#89)
+
+`JaxProblem.active_set_margin(state)` reports the distance to an
+active-set change at the anchor point — the "predictor is about to
+become invalid" signal for predictor–corrector path following. The
+post-solve sensitivity is a derivative on a *fixed* active set; this
+flags when a bound / inequality is about to cross its critical-region
+boundary (where the sensitivity is discontinuous).
+
+```python
+r = jp.active_set_margin(state)
+# r["margin"], r["min_mult"], r["min_slack"]  — each (B,)
+```
+
+- By complementarity: an **active** bound/inequality (multiplier `>
+  active_tol`) is about to leave the set — its *multiplier* heads to
+  zero; an **inactive** one is about to enter — its *slack* heads to
+  zero. `min_mult` / `min_slack` track each; `margin = min(min_mult,
+  min_slack)`.
+- Equalities (`cl == cu`) are excluded (always active); `±inf` bounds
+  and the slack side of a one-sided inequality drop out naturally.
+  An unconstrained interior point returns `inf`.
+- Pure-JAX reduction over state the `AnchorState` already holds — no
+  solve, no back-solve. Pairs with the caller-side KKT-residual
+  (smooth-drift) monitor: re-anchor when either trips.
+
 ### Added — Single-problem ergonomic sensitivity wrappers (pounce#88)
 
 Thin un-batched wrappers over the `batched_*` post-solve sensitivity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ changes.
 
 ## Unreleased
 
+### Added — Single-problem ergonomic sensitivity wrappers (pounce#88)
+
+Thin un-batched wrappers over the `batched_*` post-solve sensitivity
+methods, for the scalar / path-following user (one NLP at a time):
+
+```python
+x_star, (lam, zL, zU), J = jp.solve_with_jacobian(theta, x0)   # J: (n, p)
+state = jp.anchor(theta, x0)             # un-batched point → B=1 state
+J  = jp.sensitivity(state)               # (n, p) from the held factor
+dx = jp.jvp_from_state(state, dtheta)    # J @ dtheta  -> (n,)
+dp = jp.vjp_from_state(state, x_bar)     # J^T @ x_bar -> (p,)
+```
+
+- `solve_with_jacobian` / `sensitivity` / `jvp_from_state` /
+  `vjp_from_state` accept and return un-batched shapes, delegating to
+  the batched methods with `B=1` and squeezing — no new numerics.
+- `anchor` now accepts a single un-batched point (`p_shape`) in addition
+  to a batch (`(B,) + p_shape`); a single point yields a `B=1`
+  `AnchorState`. The single-problem from-state wrappers reject a `B>1`
+  state rather than silently mis-shaping.
+- Implemented as `JaxProblem` methods (mirroring the `batched_*` names)
+  rather than free functions, for consistency with the existing surface.
+
 ### Added — Exact post-solve sensitivity at a supplied point (pounce#87)
 
 `JaxProblem.sensitivity_at(x_star, theta, duals, *, wrt_cols=None)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ changes.
 
 ## Unreleased
 
+### Added — Barrier-μ warm start for predictor–corrector correctors (pounce#86)
+
+The interior-point barrier parameter μ is now reported on every solve and
+can be threaded into a warm-started re-solve, so a predictor–corrector
+corrector resumes near the central path instead of re-walking the barrier
+homotopy from the default initial μ.
+
+- **`info["mu"]`** — every `Problem.solve` / `Solver.solve` /
+  `solve_with_sens` info dict now carries the converged barrier parameter
+  (`0.0` on the barrier-free SQP path).
+- **`pounce.jax.solve_with_warm`** accepts a 4-element warm-state
+  `(lam, zL, zU, mu)` that seeds `mu_init` / `warm_start_target_mu`, and
+  returns the converged μ in a matching 4-tuple. The 3-tuple form is
+  unchanged; passing `mu=None` inside a 4-tuple reports μ out without
+  seeding it in. Differentiability w.r.t. `p` is preserved (the μ
+  input/output are stop-gradient, like the duals).
+
+On a small parametric NLP, seeding μ from the previous solve's converged
+barrier cut a warm-started corrector from 5 interior-point iterations to
+1 (same optimum). The `mu_init` / `warm_start_target_mu` algorithm
+options already existed; this exposes the converged μ needed to drive
+them along a path.
+
 ### Added — Post-solve Jacobian / sensitivity API from the held KKT factor (pounce#82)
 
 `JaxProblem` now exposes a first-class post-solve sensitivity surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ scipy) does the stepping — *no NLP inversion*.
   extra (`pip install pounce[diffrax]`); the example falls back to RK4
   if it's absent.
 - Switch to `PathFollower` when the path folds or the active set changes.
+- Worked notebook `python/notebooks/14_path_following.ipynb` tours the
+  whole family (sensitivity → margin → continuation → fold → inverse map).
 
 Also fixes the build-once / stacked path for **unconstrained** problems
 (``g=None``, ``m=0``): the constraint callbacks no longer dereference the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ changes.
 
 ## Unreleased
 
+### Added — Exact post-solve sensitivity at a supplied point (pounce#87)
+
+`JaxProblem.sensitivity_at(x_star, theta, duals, *, wrt_cols=None)`
+returns the exact primal sensitivity `∂x*/∂θ` evaluated at a
+caller-supplied primal-dual point, by re-assembling and factoring the
+KKT system *there* — no IPM re-solve.
+
+```python
+J = jp.sensitivity_at(x_star, theta, (lam, zL, zU))   # (n, p_dim)
+```
+
+- **Re-factor, not reuse.** A held FERAL factor encodes the anchor
+  point's `H` / `J`, so back-solving it at a moved `x_star` gives a
+  first-order-stale sensitivity. `sensitivity_at` assembles the dense
+  `(n+m)×(n+m)` KKT at the supplied point, which is exact there
+  (assuming a KKT point for `theta`). The cheap-but-local reuse path
+  stays as the predictor `batched_jvp_from_state`; this is its
+  exact-refresh complement.
+- Active set is read from the supplied bound multipliers `(zL, zU)`,
+  exactly like the `custom_vjp` backward — the caller passes the duals
+  the anchoring solve / `solve_with_warm` returned at this point.
+- Pure-JAX, so itself differentiable (second-order sensitivities work);
+  matches `jax.jacobian` over a fresh solve to ~1e-6 at every point
+  along a swept path, including a binding bound.
+
+This is the exact-refresh primitive for the inverse map, where `x*`
+traces a known output boundary and the sensitivity must be evaluated at
+the known point without paying a full re-solve per RK stage.
+
 ### Added — Barrier-μ warm start for predictor–corrector correctors (pounce#86)
 
 The interior-point barrier parameter μ is now reported on every solve and

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1238,11 +1238,14 @@ impl IpoptApplication {
         // Drain counters / iter count off the algorithm.
         {
             let mut stats = self.statistics.borrow_mut();
-            stats.iteration_count = alg.data.borrow().iter_count;
-            // Converged barrier parameter μ — threaded forward into a
-            // warm-started corrector's `mu_init` / `warm_start_target_mu`
-            // for predictor–corrector path following (pounce#86).
-            stats.final_mu = alg.data.borrow().curr_mu;
+            {
+                let d = alg.data.borrow();
+                stats.iteration_count = d.iter_count;
+                // Converged barrier parameter μ — threaded forward into a
+                // warm-started corrector's `mu_init` / `warm_start_target_mu`
+                // for predictor–corrector path following (pounce#86).
+                stats.final_mu = d.curr_mu;
+            }
             stats.total_wallclock_time_secs = t_start.elapsed().as_secs_f64();
             // Restoration-phase audit counters (pounce#12). Zero on
             // problems where restoration never fires; populated by

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1239,6 +1239,10 @@ impl IpoptApplication {
         {
             let mut stats = self.statistics.borrow_mut();
             stats.iteration_count = alg.data.borrow().iter_count;
+            // Converged barrier parameter μ — threaded forward into a
+            // warm-started corrector's `mu_init` / `warm_start_target_mu`
+            // for predictor–corrector path following (pounce#86).
+            stats.final_mu = alg.data.borrow().curr_mu;
             stats.total_wallclock_time_secs = t_start.elapsed().as_secs_f64();
             // Restoration-phase audit counters (pounce#12). Zero on
             // problems where restoration never fires; populated by

--- a/crates/pounce-nlp/src/solve_statistics.rs
+++ b/crates/pounce-nlp/src/solve_statistics.rs
@@ -64,6 +64,13 @@ pub struct SolveStatistics {
     pub final_constr_viol: Number,
     pub final_compl: Number,
     pub final_kkt_error: Number,
+    /// Final barrier parameter μ at termination (the IPM's `curr_mu`
+    /// after the last iterate). Lets a caller thread the converged
+    /// barrier into a warm-started re-solve's `mu_init` /
+    /// `warm_start_target_mu` for predictor–corrector path following
+    /// (pounce#86). `0.0` on the barrier-free SQP path, where μ has
+    /// no meaning.
+    pub final_mu: Number,
 
     // ---- Restoration-phase audit counters (pounce#12). ----
     //

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -317,7 +317,13 @@ impl PyProblem {
         // Pick up any working set the SQP path produced; surface
         // it in the info dict and stash on the Problem instance.
         self.last_working_set = app.last_sqp_working_set().cloned();
-        let info = build_info_dict(py, &bridge.borrow(), status, stats.iteration_count)?;
+        let info = build_info_dict(
+            py,
+            &bridge.borrow(),
+            status,
+            stats.iteration_count,
+            stats.final_mu,
+        )?;
         let ws_obj: PyObject = match &self.last_working_set {
             Some(ws) => encode_working_set(py, ws).into_any().unbind(),
             None => py.None(),
@@ -493,7 +499,13 @@ impl PyProblem {
         let result = builder.run(&mut app, bridge_for_solve);
         let stats = app.statistics();
 
-        let info = build_info_dict(py, &bridge.borrow(), result.status, stats.iteration_count)?;
+        let info = build_info_dict(
+            py,
+            &bridge.borrow(),
+            result.status,
+            stats.iteration_count,
+            stats.final_mu,
+        )?;
         let dx_obj: PyObject = match result.dx {
             Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
             None => py.None(),
@@ -675,6 +687,7 @@ pub(crate) fn build_info_dict<'py>(
     bridge: &PyTnlp,
     status: ApplicationReturnStatus,
     iter_count: i32,
+    final_mu: Number,
 ) -> PyResult<Bound<'py, PyDict>> {
     let info = PyDict::new_bound(py);
     info.set_item("status", status as i32)?;
@@ -694,6 +707,11 @@ pub(crate) fn build_info_dict<'py>(
         bridge.state.final_z_u.clone().into_pyarray_bound(py),
     )?;
     info.set_item("iter_count", iter_count)?;
+    // Converged barrier parameter μ. Thread this into the next
+    // warm-started solve's `mu_init` / `warm_start_target_mu` to seed
+    // the corrector in predictor–corrector path following (pounce#86).
+    // `0.0` on the barrier-free SQP path.
+    info.set_item("mu", final_mu)?;
     Ok(info)
 }
 

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -79,7 +79,13 @@ impl PySolver {
         let mut inner = RustSolver::new(app, bridge_for_solver);
         let status: ApplicationReturnStatus = inner.solve();
         let stats = inner.app().statistics();
-        let info = build_info_dict(py, &bridge.borrow(), status, stats.iteration_count)?;
+        let info = build_info_dict(
+            py,
+            &bridge.borrow(),
+            status,
+            stats.iteration_count,
+            stats.final_mu,
+        )?;
         let x_out = bridge.borrow().state.final_x.clone().into_pyarray_bound(py);
         let _ = bridge; // alive via inner's Rc<RefCell<dyn TNLP>> clone
         self.state = Some(SessionState { inner, m });

--- a/python/benchmarks/inverse_map_warm.py
+++ b/python/benchmarks/inverse_map_warm.py
@@ -1,0 +1,110 @@
+"""Benchmark: warm- vs cold-started inner solves in the inverse-map ODE
+RHS (pounce#91, follow-up to the warm= option).
+
+The pure inverse-map ODE (`inverse_map_rhs`) solves the embedded NLP at
+*every* integrator stage. `warm=True` seeds each solve from the previous
+evaluation's converged primal / duals / barrier μ (pounce#86) instead of
+a cold start. This harness quantifies the payoff — both the
+size-independent **iteration** reduction and the end-to-end **wall-clock**
+— across NLP sizes, so the recipe's guidance is grounded in numbers
+rather than a guess.
+
+Headline finding (run on this machine; see the printed table):
+
+* Warm-starting cuts IPM **iterations** by ~1.4-1.7x, roughly flat in n.
+  This is the known interior-point warm-start ceiling: the barrier
+  homotopy resists a boundary-proximate seed, so the win is modest
+  (active-set / SQP methods warm-start far better).
+* **Wall-clock** speedup is smaller still (~1.2-1.3x) and does *not* grow
+  with n at these scales, because each RHS evaluation also rebuilds the
+  full Jacobian `J = ∂x*/∂θ` (n held-factor back-solves) and pays
+  per-call FFI / callback overhead — costs warm-starting doesn't touch.
+
+Takeaway: `warm=True` is a minor tweak, worth flipping on for expensive
+solves but never transformative. For a real speedup on a smooth map with
+expensive solves, reach for `PathFollower`, whose predictor *skips* most
+solves entirely instead of just making each one cheaper.
+
+Run:
+    python python/benchmarks/inverse_map_warm.py
+"""
+
+from __future__ import annotations
+
+import time
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+jax.config.update("jax_enable_x64", True)
+
+from pounce.jax import JaxProblem, inverse_map_rhs
+
+
+def _make(n: int, c: float = 0.05) -> JaxProblem:
+    # Convex, banded-nonlinear NLP; square inverse map (output = identity,
+    # p = n). The quartic ring coupling makes the IPM take several
+    # iterations cold (so warm-starting has something to save).
+    def f(x, p):
+        return jnp.sum((x - p) ** 2) + c * jnp.sum((x[:-1] * x[1:]) ** 2)
+
+    return JaxProblem(
+        f=f, g=None, n=n, m=0, p_example=jnp.zeros(n),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+
+
+def _iteration_counts(jp: JaxProblem, thetas) -> tuple[int, int]:
+    """Total IPM iterations along the θ sweep, cold vs warm — the
+    size-independent lever, measured directly via warm_anchor."""
+    n = jp._n
+    cold = 0
+    for th in thetas:
+        st, info = jp.warm_anchor(th, jnp.zeros(n))
+        cold += int(info["iter_count"])
+        st.close()
+    warm = 0
+    x = np.zeros(n)
+    duals = None
+    mu = None
+    for th in thetas:
+        st, info = jp.warm_anchor(th, x, duals=duals, mu=mu)
+        warm += int(info["iter_count"])
+        x = np.asarray(st.x_star[0])
+        duals = tuple(np.asarray(d[0]) for d in st.duals)
+        mu = float(info["mu"])
+        st.close()
+    return cold, warm
+
+
+def _wall(jp: JaxProblem, thetas, *, warm: bool) -> float:
+    rhs = inverse_map_rhs(jp, lambda s: jnp.ones(jp._n), warm=warm)
+    rhs(0.0, thetas[0])                       # warm up / JIT the callback
+    t0 = time.time()
+    for k, th in enumerate(thetas):
+        rhs(k / len(thetas), th)
+    return time.time() - t0
+
+
+def main() -> None:
+    K = 16
+    print(f"{'n':>4}  {'iters cold/warm':>16}  {'iter x':>7}  "
+          f"{'wall cold/warm (s)':>20}  {'wall x':>7}")
+    print("-" * 66)
+    for n in (2, 20, 60, 120):
+        jp = _make(n)
+        base = jnp.full(n, 0.2)
+        thetas = [base + (0.5 * k / K) * jnp.ones(n) for k in range(K)]
+        ci, wi = _iteration_counts(jp, thetas)
+        tc = _wall(jp, thetas, warm=False)
+        tw = _wall(jp, thetas, warm=True)
+        print(f"{n:>4}  {f'{ci}/{wi}':>16}  {ci / max(wi, 1):>6.2f}x  "
+              f"{f'{tc:.2f}/{tw:.2f}':>20}  {tc / max(tw, 1e-9):>6.2f}x")
+    print("\nWarm-start is a modest, roughly size-flat tweak (IPM warm-start "
+          "ceiling + Jacobian-build overhead). Use PathFollower to skip "
+          "solves outright when the map is smooth and solves are expensive.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/inverse_map_diffrax.py
+++ b/python/examples/inverse_map_diffrax.py
@@ -149,6 +149,8 @@ def main() -> None:
 
     # POUNCE supplies the RHS; the output is the optimizer's solution
     # itself (identity), so ∂y/∂θ = ∂x*/∂θ and dθ/ds = J^{-1} dy/ds.
+    # Pass warm=True to warm-start each inner solve from the previous
+    # one (a modest ~1.3x; see python/benchmarks/inverse_map_warm.py).
     rhs = inverse_map_rhs(jp, output_velocity)
 
     y0 = output_path(0.0)

--- a/python/examples/inverse_map_diffrax.py
+++ b/python/examples/inverse_map_diffrax.py
@@ -1,0 +1,185 @@
+"""Inverse / uncertainty mapping as an ODE, integrated with diffrax over
+a POUNCE sensitivity right-hand side (pounce#91; companion to notebook
+13 from pounce#82).
+
+The inverse-mapping method of Alves, Kitchin & Lima (AIChE J. 2023
+e18119; 2025 e18940) maps a closed boundary in the **output** space of
+an embedded optimizer back to the **input** (parameter) space by
+integrating
+
+    dθ/ds = (∂y/∂θ)^{-1} · dy/ds          (Eq. 3, 2025 paper)
+
+along the prescribed output path ``y(s)`` — *no NLP inversion, no brute
+force*. The right-hand side is a **parametric NLP sensitivity**: with
+``y = output(x*(θ), θ)`` and ``x*(θ) = argmin_x f(x, θ)``, POUNCE supplies
+``∂x*/∂θ`` from the held KKT factor and an off-the-shelf adaptive ODE
+integrator (here diffrax) does the stepping.
+
+The division of labour:
+
+* POUNCE owns the **RHS** — :func:`pounce.jax.inverse_map_rhs` builds a
+  ``f(s, θ) -> dθ/ds`` callable that, per evaluation, solves the NLP and
+  reads ``∂x*/∂θ`` off the held factor
+  (:meth:`JaxProblem.solve_with_jacobian`), then forms ``(∂y/∂θ)^{-1}
+  dy/ds``. Note this is a **linear solve against** the sensitivity, not a
+  ``J @ v`` product.
+* diffrax owns the **stepping** — adaptive Dopri5 with a PID controller
+  and dense output. The POUNCE solve inside the RHS rides a
+  ``jax.pure_callback``, so it composes cleanly under the integrator.
+
+When to reach for this vs. :class:`pounce.jax.PathFollower`: use this
+smooth-ODE recipe when ``∂y/∂θ`` stays non-singular and the optimizer's
+active set is fixed along the path. Switch to the predictor–corrector
+``PathFollower`` when the path folds (``∂y/∂θ`` singular) or the active
+set changes — it monitors both.
+
+Run::
+
+    python inverse_map_diffrax.py
+
+Requires ``diffrax`` for the adaptive integration; falls back to a fixed
+RK4 (and says so) if diffrax isn't installed, so the round-trip still
+runs.
+"""
+
+from __future__ import annotations
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from jax import config
+
+config.update("jax_enable_x64", True)
+
+from pounce.jax import JaxProblem, inverse_map_rhs
+
+
+def build_problem() -> JaxProblem:
+    """A small, smooth, *nonlinearly coupled* embedded optimizer.
+
+    ``min_x (x0 - θ0)^2 + (x1 - θ1)^2 + 0.15 x0^2 x1^2`` — unconstrained,
+    so the solution ``x*(θ)`` is 2-D and ``∂x*/∂θ`` is generically
+    invertible (the inverse map is well-posed). The coupling term makes
+    ``∂x*/∂θ`` vary along the path, so the sensitivity genuinely changes
+    from step to step.
+    """
+    def f(x, p):
+        return (x[0] - p[0]) ** 2 + (x[1] - p[1]) ** 2 + 0.15 * x[0] ** 2 * x[1] ** 2
+
+    return JaxProblem(
+        f=f, g=None, n=2, m=0, p_example=jnp.zeros(2),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+
+
+def output_path(s):
+    """Prescribed closed boundary in OUTPUT space: an ellipse traced once
+    over ``s ∈ [0, 1]``."""
+    ang = 2.0 * jnp.pi * s
+    return jnp.array([0.6 + 0.35 * jnp.cos(ang), 0.4 + 0.25 * jnp.sin(ang)])
+
+
+def output_velocity(s):
+    """``dy/ds`` of :func:`output_path`."""
+    ang = 2.0 * jnp.pi * s
+    w = 2.0 * jnp.pi
+    return jnp.array([-0.35 * w * jnp.sin(ang), 0.25 * w * jnp.cos(ang)])
+
+
+def seed_theta(jp: JaxProblem, y0) -> jnp.ndarray:
+    """Find θ0 with ``x*(θ0) = y0`` — the anchor for the ODE. A couple of
+    Newton steps on ``x*(θ) − y0`` using the held-factor sensitivity
+    ``∂x*/∂θ`` (which is the inverse-map RHS machinery, reused)."""
+    theta = jnp.asarray(y0, dtype=jnp.float64)
+    for _ in range(10):
+        x_star, _duals, J = jp.solve_with_jacobian(theta, jnp.zeros(2))
+        resid = x_star - jnp.asarray(y0)
+        if float(jnp.max(jnp.abs(resid))) < 1e-12:
+            break
+        theta = theta - jnp.linalg.solve(J, resid)
+    return theta
+
+
+def integrate_diffrax(rhs, theta0):
+    """Adaptive Dopri5 over the POUNCE sensitivity RHS. Returns the dense
+    solution sampled on a uniform grid, or ``None`` if diffrax is absent."""
+    try:
+        import diffrax
+    except ImportError:
+        return None
+
+    def vf(s, theta, args):
+        return rhs(s, theta)
+
+    term = diffrax.ODETerm(vf)
+    solver = diffrax.Dopri5()
+    controller = diffrax.PIDController(rtol=1e-9, atol=1e-11)
+    ts = jnp.linspace(0.0, 1.0, 121)
+    sol = diffrax.diffeqsolve(
+        term, solver, t0=0.0, t1=1.0, dt0=0.01,
+        y0=jnp.asarray(theta0),
+        stepsize_controller=controller,
+        saveat=diffrax.SaveAt(ts=ts),
+        max_steps=100_000,
+    )
+    return np.asarray(ts), np.asarray(sol.ys)
+
+
+def integrate_rk4(rhs, theta0, n_steps=240):
+    """Fixed-step RK4 fallback (no external dependency)."""
+    h = 1.0 / n_steps
+    th = jnp.asarray(theta0, dtype=jnp.float64)
+    ts = [0.0]
+    ys = [np.asarray(th)]
+    for i in range(n_steps):
+        s = i * h
+        k1 = rhs(s, th)
+        k2 = rhs(s + h / 2, th + h / 2 * k1)
+        k3 = rhs(s + h / 2, th + h / 2 * k2)
+        k4 = rhs(s + h, th + h * k3)
+        th = th + h / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        ts.append((i + 1) * h)
+        ys.append(np.asarray(th))
+    return np.asarray(ts), np.asarray(ys)
+
+
+def main() -> None:
+    jp = build_problem()
+
+    # POUNCE supplies the RHS; the output is the optimizer's solution
+    # itself (identity), so ∂y/∂θ = ∂x*/∂θ and dθ/ds = J^{-1} dy/ds.
+    rhs = inverse_map_rhs(jp, output_velocity)
+
+    y0 = output_path(0.0)
+    theta0 = seed_theta(jp, y0)
+
+    out = integrate_diffrax(rhs, theta0)
+    if out is None:
+        print("diffrax not installed — using fixed-step RK4 fallback.\n")
+        ts, thetas = integrate_rk4(rhs, theta0)
+    else:
+        print("Integrated with diffrax Dopri5 (adaptive, rtol=1e-9).\n")
+        ts, thetas = out
+
+    # Validation 1 — closed output loop ⇒ closed input loop.
+    loop_gap = float(np.max(np.abs(thetas[-1] - thetas[0])))
+
+    # Validation 2 — round-trip: push the recovered input path θ(s) back
+    # through the optimizer and check it lands on the output boundary y(s).
+    rt = 0.0
+    for k in range(len(ts)):
+        x_star, *_ = jp.solve_with_jacobian(jnp.asarray(thetas[k]), jnp.zeros(2))
+        rt = max(rt, float(np.max(np.abs(np.asarray(x_star) - np.asarray(output_path(ts[k]))))))
+
+    print(f"recovered input loop closes to   : {loop_gap:.2e}")
+    print(f"round-trip onto output boundary  : {rt:.2e}")
+    print(f"input-space θ extent             : "
+          f"θ0∈[{thetas[:,0].min():.3f}, {thetas[:,0].max():.3f}], "
+          f"θ1∈[{thetas[:,1].min():.3f}, {thetas[:,1].max():.3f}]")
+    print("\nThe inverse map ran on POUNCE's KKT sensitivity as the ODE "
+          "RHS — no NLP inversion, one solve + back-solve per RHS eval.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/notebooks/14_path_following.ipynb
+++ b/python/notebooks/14_path_following.ipynb
@@ -1,0 +1,475 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-00",
+   "metadata": {},
+   "source": [
+    "# Predictor–corrector path following & inverse mapping (pounce#84 family)\n",
+    "\n",
+    "This notebook tours the path-following toolkit built on POUNCE's\n",
+    "post-solve KKT sensitivity (companion to notebook 13, which covers the\n",
+    "held-factor Jacobian itself). The pieces:\n",
+    "\n",
+    "- **`sensitivity_at`** (#87) — exact `∂x*/∂θ` at a *supplied* primal-dual\n",
+    "  point, by re-factoring the KKT there.\n",
+    "- **single-problem wrappers** (#88) — `solve_with_jacobian`,\n",
+    "  `sensitivity`, `jvp_from_state`, `vjp_from_state`, un-batched.\n",
+    "- **`active_set_margin`** (#89) — distance to an active-set change; the\n",
+    "  \"predictor about to become invalid\" monitor.\n",
+    "- **`PathFollower`** (#90) — predict (sensitivity) → monitor (no solve) →\n",
+    "  correct (warm-μ re-solve), with a pseudo-arclength mode for folds.\n",
+    "- **`inverse_map_rhs`** (#91) — the inverse/uncertainty-mapping ODE RHS\n",
+    "  for integration with diffrax / scipy.\n",
+    "\n",
+    "The common engine underneath is one symmetric-indefinite KKT factor,\n",
+    "reused across steps via `kkt_solve_many` — no NLP re-solve on a predict\n",
+    "step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "cell-01",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:02.333718Z",
+     "iopub.status.busy": "2026-06-01T22:31:02.333508Z",
+     "iopub.status.idle": "2026-06-01T22:31:02.747663Z",
+     "shell.execute_reply": "2026-06-01T22:31:02.746526Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "\n",
+    "from pounce.jax import JaxProblem, PathFollower, inverse_map_rhs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "## A parametric NLP\n",
+    "\n",
+    "A tiny projection: `min_x ||x - θ||²  s.t.  x0 + x1 = 1`, with box\n",
+    "bounds. The parameter `θ` is the point being projected onto the line.\n",
+    "The solution `x*(θ)` and its sensitivity `∂x*/∂θ` are what we trace."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "cell-03",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:02.750322Z",
+     "iopub.status.busy": "2026-06-01T22:31:02.750011Z",
+     "iopub.status.idle": "2026-06-01T22:31:03.063504Z",
+     "shell.execute_reply": "2026-06-01T22:31:03.062230Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def f(x, p):\n",
+    "    return jnp.sum((x - p) ** 2)\n",
+    "\n",
+    "def g(x, p):\n",
+    "    return jnp.stack([x[0] + x[1] - 1.0])\n",
+    "\n",
+    "jp = JaxProblem(\n",
+    "    f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),\n",
+    "    lb=jnp.full(2, -5.0), ub=jnp.full(2, 5.0),\n",
+    "    cl=jnp.zeros(1), cu=jnp.zeros(1),\n",
+    "    options={\"tol\": 1e-9, \"print_level\": 0, \"sb\": \"yes\"},\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-04",
+   "metadata": {},
+   "source": [
+    "## 1. Post-solve sensitivity at a point (#87, #88)\n",
+    "\n",
+    "`solve_with_jacobian` returns the solution, its duals, and the full\n",
+    "primal Jacobian `J = ∂x*/∂θ` from the held factor — un-batched. The same\n",
+    "`J` can be recomputed at any *supplied* KKT point with `sensitivity_at`\n",
+    "(it re-factors the KKT there, no re-solve), and directional products come\n",
+    "from `jvp_from_state` / `vjp_from_state`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cell-05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:03.065915Z",
+     "iopub.status.busy": "2026-06-01T22:31:03.065705Z",
+     "iopub.status.idle": "2026-06-01T22:31:08.392043Z",
+     "shell.execute_reply": "2026-06-01T22:31:08.390673Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "x*  = [0.3 0.7]\n",
+      "J   = [[0.49999999999811673, -0.4999999999981167], [-0.4999999999981167, 0.4999999999981167]]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sensitivity_at == J : True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "J @ dθ = [ 0.075 -0.075]\n"
+     ]
+    }
+   ],
+   "source": [
+    "theta = jnp.array([0.3, 0.7])\n",
+    "x_star, (lam, zL, zU), J = jp.solve_with_jacobian(theta, jnp.zeros(2))\n",
+    "print(\"x*  =\", np.asarray(x_star))\n",
+    "print(\"J   =\", np.asarray(J).tolist())\n",
+    "\n",
+    "# Exact sensitivity at the supplied (x*, duals, θ) — matches J.\n",
+    "J_at = jp.sensitivity_at(x_star, theta, (lam, zL, zU))\n",
+    "print(\"sensitivity_at == J :\", bool(np.allclose(J, J_at, atol=1e-8)))\n",
+    "\n",
+    "# Directional: J @ dθ from the held factor (one back-solve, no re-solve).\n",
+    "with jp.anchor(theta, jnp.zeros(2)) as state:\n",
+    "    dx = jp.jvp_from_state(state, jnp.array([0.1, -0.05]))\n",
+    "print(\"J @ dθ =\", np.asarray(dx))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "## 2. The active-set monitor (#89)\n",
+    "\n",
+    "The sensitivity is a derivative on a *fixed* active set. `active_set_margin`\n",
+    "reports how close we are to a change: the smallest active multiplier\n",
+    "(about to leave the set) or inactive slack (about to enter). A small\n",
+    "margin means the predictor is about to become invalid. Here the bounds\n",
+    "are slack and only the equality is active, so the margin is the distance\n",
+    "of `x` to its nearest bound."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "cell-07",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:08.394744Z",
+     "iopub.status.busy": "2026-06-01T22:31:08.394424Z",
+     "iopub.status.idle": "2026-06-01T22:31:08.940819Z",
+     "shell.execute_reply": "2026-06-01T22:31:08.939726Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'margin': 4.30000000000075, 'min_mult': inf, 'min_slack': 4.30000000000075}\n"
+     ]
+    }
+   ],
+   "source": [
+    "with jp.anchor(theta, jnp.zeros(2)) as state:\n",
+    "    m = jp.active_set_margin(state)\n",
+    "print({k: float(np.asarray(v)[0]) for k, v in m.items()})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-08",
+   "metadata": {},
+   "source": [
+    "## 3. Predictor–corrector path following (#90)\n",
+    "\n",
+    "`PathFollower.follow` traces `x*(θ(s))` along a prescribed path. Each\n",
+    "step **predicts** with the held-factor sensitivity, **monitors** the KKT\n",
+    "residual + active-set margin *without solving*, and only **corrects**\n",
+    "(a warm-μ re-solve that re-anchors the factor) when the monitor trips.\n",
+    "\n",
+    "For this linear-response NLP the predictor is exact, so the whole loop is\n",
+    "traced with **zero correctors** — one anchor solve instead of one cold\n",
+    "solve per step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cell-09",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:08.943114Z",
+     "iopub.status.busy": "2026-06-01T22:31:08.942909Z",
+     "iopub.status.idle": "2026-06-01T22:31:10.153826Z",
+     "shell.execute_reply": "2026-06-01T22:31:10.152710Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "steps=7  correctors=0  accepts=7\n",
+      "engine solves = 1 + 0 = 1   (naive: 8)\n",
+      "closed loop |x(1) - x(0)| = 1.60e-16\n"
+     ]
+    }
+   ],
+   "source": [
+    "def circle(s):\n",
+    "    a = 2.0 * jnp.pi * s\n",
+    "    return jnp.array([0.5 + 0.4 * jnp.cos(a), 0.4 * jnp.sin(a)])\n",
+    "\n",
+    "pf = PathFollower(jp, monitor_tol=1e-6, ds0=0.05)\n",
+    "tr = pf.follow(circle, (0.0, 1.0), jnp.zeros(2))\n",
+    "print(f\"steps={tr.n_steps}  correctors={tr.n_correctors}  accepts={tr.n_accepts}\")\n",
+    "print(f\"engine solves = 1 + {tr.n_correctors} = {1 + tr.n_correctors}   \"\n",
+    "      f\"(naive: {tr.n_steps + 1})\")\n",
+    "print(f\"closed loop |x(1) - x(0)| = {np.max(np.abs(tr.x[0] - tr.x[-1])):.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-10",
+   "metadata": {},
+   "source": [
+    "### Curvature: the monitor trades accuracy for solves\n",
+    "\n",
+    "With a nonlinear objective the linear predictor drifts, so the monitor\n",
+    "fires correctors. Loosening `monitor_tol` accepts more predictor steps\n",
+    "between (warm) re-solves — fewer solves at a controlled error, exactly\n",
+    "the predictor–corrector lever."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cell-11",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:10.156402Z",
+     "iopub.status.busy": "2026-06-01T22:31:10.156151Z",
+     "iopub.status.idle": "2026-06-01T22:31:14.411743Z",
+     "shell.execute_reply": "2026-06-01T22:31:14.410416Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tol=1e-03: solves= 9 (naive 12), accepts=3, max err=2.3e-04\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "tol=5e-03: solves= 5 (naive 12), accepts=7, max err=8.7e-04\n"
+     ]
+    }
+   ],
+   "source": [
+    "def f_nl(x, p):\n",
+    "    return jnp.sum((x - p) ** 2) + 0.02 * jnp.sum(x ** 4)\n",
+    "\n",
+    "jp_nl = JaxProblem(\n",
+    "    f=f_nl, g=g, n=2, m=1, p_example=jnp.zeros(2),\n",
+    "    lb=jnp.full(2, -5.0), ub=jnp.full(2, 5.0),\n",
+    "    cl=jnp.zeros(1), cu=jnp.zeros(1),\n",
+    "    options={\"tol\": 1e-9, \"print_level\": 0, \"sb\": \"yes\"},\n",
+    ")\n",
+    "for tol in (1e-3, 5e-3):\n",
+    "    t = PathFollower(jp_nl, monitor_tol=tol, ds0=0.05, ds_max=0.1).follow(\n",
+    "        circle, (0.0, 1.0), jnp.zeros(2))\n",
+    "    err = max(\n",
+    "        float(np.max(np.abs(t.x[k] - np.asarray(\n",
+    "            jp_nl.solve_with_jacobian(jnp.asarray(t.theta[k]), jnp.zeros(2))[0]))))\n",
+    "        for k in range(len(t.s)))\n",
+    "    print(f\"tol={tol:5.0e}: solves={1 + t.n_correctors:2d} (naive {t.n_steps + 1}), \"\n",
+    "          f\"accepts={t.n_accepts}, max err={err:.1e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "## 4. Tracing past a fold (pseudo-arclength)\n",
+    "\n",
+    "When the path *folds* — `∂x*/∂θ` singular — parameter continuation\n",
+    "stalls. `trace_arclength` parametrises the solution curve by arclength\n",
+    "and Newton-corrects the augmented KKT, passing through turning points.\n",
+    "The stationarity of `f = x⁴/4 − x²/2 − θx` is `θ = x³ − x`, which folds\n",
+    "at `x = ±1/√3` (`θ = ∓0.385`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "cell-13",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:14.414436Z",
+     "iopub.status.busy": "2026-06-01T22:31:14.414135Z",
+     "iopub.status.idle": "2026-06-01T22:31:15.381418Z",
+     "shell.execute_reply": "2026-06-01T22:31:15.380086Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "turning points (θ): [0.3843, -0.3805]\n",
+      "x range: -1.1597048527648892 → 1.6534582542846283\n"
+     ]
+    }
+   ],
+   "source": [
+    "def f_cubic(x, p):\n",
+    "    th = p[0]\n",
+    "    return x[0] ** 4 / 4.0 - x[0] ** 2 / 2.0 - th * x[0]\n",
+    "\n",
+    "jp_c = JaxProblem(f=f_cubic, g=None, n=1, m=0, p_example=jnp.zeros(1),\n",
+    "                  options={\"tol\": 1e-10, \"print_level\": 0, \"sb\": \"yes\"})\n",
+    "trc = PathFollower(jp_c).trace_arclength(jnp.array([-1.3]), -0.4,\n",
+    "                                         ds=0.05, n_steps=120)\n",
+    "print(\"turning points (θ):\", [round(t, 4) for t in trc.turning_points])\n",
+    "print(\"x range:\", float(trc.x[:, 0].min()), \"→\", float(trc.x[:, 0].max()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-14",
+   "metadata": {},
+   "source": [
+    "## 5. Inverse / uncertainty mapping as an ODE (#91)\n",
+    "\n",
+    "The Alves–Kitchin–Lima inverse map sends a closed boundary in *output*\n",
+    "space back to *input* space by integrating\n",
+    "\n",
+    "$$\\frac{d\\theta}{ds} = \\Big(\\frac{\\partial y}{\\partial\\theta}\\Big)^{-1}\\frac{dy}{ds},$$\n",
+    "\n",
+    "where the output `y = output(x*(θ), θ)` is an output of the embedded\n",
+    "optimizer. `inverse_map_rhs` builds this RHS from the POUNCE sensitivity;\n",
+    "hand it to diffrax or scipy. Note it is a **linear solve against** the\n",
+    "sensitivity, not a `J @ v`. Here `output = x*`, so for\n",
+    "`f = (x−θ)² + 0.05x⁴` the map is explicit (`θ = y + 0.1y³`), giving an\n",
+    "analytic check."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "cell-15",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-01T22:31:15.384210Z",
+     "iopub.status.busy": "2026-06-01T22:31:15.383983Z",
+     "iopub.status.idle": "2026-06-01T22:32:14.254771Z",
+     "shell.execute_reply": "2026-06-01T22:32:14.253399Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "closed input loop : 2.0750068330244176e-12\n",
+      "vs analytic θ     : 7.286880501777837e-08\n"
+     ]
+    }
+   ],
+   "source": [
+    "def f_inv(x, p):\n",
+    "    return (x[0] - p[0]) ** 2 + 0.05 * x[0] ** 4\n",
+    "\n",
+    "jp_inv = JaxProblem(f=f_inv, g=None, n=1, m=0, p_example=jnp.zeros(1),\n",
+    "                    options={\"tol\": 1e-11, \"print_level\": 0, \"sb\": \"yes\"})\n",
+    "\n",
+    "y_of_s  = lambda s: jnp.array([0.5 + 0.3 * jnp.sin(2 * jnp.pi * s)])\n",
+    "dy_ds   = lambda s: jnp.array([0.3 * 2 * jnp.pi * jnp.cos(2 * jnp.pi * s)])\n",
+    "rhs = inverse_map_rhs(jp_inv, dy_ds)   # f(s, θ) -> dθ/ds; jit/diffrax-ready\n",
+    "\n",
+    "# Integrate the closed output loop with a simple RK4 (swap in\n",
+    "# diffrax.diffeqsolve for adaptive stepping — see\n",
+    "# examples/inverse_map_diffrax.py).\n",
+    "y0 = float(y_of_s(0.0)[0])\n",
+    "th = jnp.array([y0 + 0.1 * y0 ** 3])   # θ0 with x*(θ0) = y(0)\n",
+    "h, TH = 1.0 / 200, [float(th[0])]\n",
+    "for i in range(200):\n",
+    "    s = i * h\n",
+    "    k1 = rhs(s, th); k2 = rhs(s + h/2, th + h/2*k1)\n",
+    "    k3 = rhs(s + h/2, th + h/2*k2); k4 = rhs(s + h, th + h*k3)\n",
+    "    th = th + h/6 * (k1 + 2*k2 + 2*k3 + k4); TH.append(float(th[0]))\n",
+    "\n",
+    "S = np.linspace(0, 1, len(TH)); ys = 0.5 + 0.3 * np.sin(2*np.pi*S)\n",
+    "print(\"closed input loop :\", abs(TH[-1] - TH[0]))\n",
+    "print(\"vs analytic θ     :\", float(np.max(np.abs(np.array(TH) - (ys + 0.1*ys**3)))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-16",
+   "metadata": {},
+   "source": [
+    "## When to use which\n",
+    "\n",
+    "- **`PathFollower.follow`** — robust default: the optimizer's active set\n",
+    "  may change along the path; the monitor + warm-μ corrector handle it.\n",
+    "- **`PathFollower.trace_arclength`** — the path folds (singular\n",
+    "  `∂x*/∂θ`), scalar-parameter equality/unconstrained branch.\n",
+    "- **`inverse_map_rhs` + an ODE integrator** — the map is smooth, the\n",
+    "  active set is fixed, and you want adaptive stepping / dense output from\n",
+    "  diffrax or scipy. Switch to `PathFollower` if it folds or the active\n",
+    "  set changes.\n",
+    "\n",
+    "All three run on the same held KKT factor; a predict step is one\n",
+    "`kkt_solve_many` back-solve, never an NLP re-solve."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/pounce/jax/__init__.py
+++ b/python/pounce/jax/__init__.py
@@ -45,6 +45,7 @@ _jax_config.update("jax_enable_x64", True)
 from ._build import from_jax
 from ._diff import solve, solve_with_warm, vmap_solve, vmap_solve_parallel
 from ._problem import AnchorState, JaxProblem
+from ._path import PathFollower, PathTrace
 
 __all__ = [
     "from_jax",
@@ -54,4 +55,6 @@ __all__ = [
     "vmap_solve_parallel",
     "JaxProblem",
     "AnchorState",
+    "PathFollower",
+    "PathTrace",
 ]

--- a/python/pounce/jax/__init__.py
+++ b/python/pounce/jax/__init__.py
@@ -45,7 +45,7 @@ _jax_config.update("jax_enable_x64", True)
 from ._build import from_jax
 from ._diff import solve, solve_with_warm, vmap_solve, vmap_solve_parallel
 from ._problem import AnchorState, JaxProblem
-from ._path import PathFollower, PathTrace
+from ._path import PathFollower, PathTrace, inverse_map_rhs
 
 __all__ = [
     "from_jax",
@@ -57,4 +57,5 @@ __all__ = [
     "AnchorState",
     "PathFollower",
     "PathTrace",
+    "inverse_map_rhs",
 ]

--- a/python/pounce/jax/_diff.py
+++ b/python/pounce/jax/_diff.py
@@ -292,8 +292,17 @@ def _solve_once_warm(
     lam_warm: np.ndarray,
     zL_warm: np.ndarray,
     zU_warm: np.ndarray,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, dict]:
-    """Forward solve with user-supplied dual warm-start."""
+    mu_warm: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float, dict]:
+    """Forward solve with user-supplied dual (and optional μ) warm-start.
+
+    ``mu_warm`` seeds the interior-point barrier parameter for the
+    corrector in predictor–corrector path following (pounce#86): when
+    finite it is fed to both ``mu_init`` (the monotone-strategy initial
+    μ) and ``warm_start_target_mu`` (the warm-start initializer's
+    target). ``NaN`` means "no μ seed" — fall back to the solver's
+    default initial barrier.
+    """
 
     def f_of_x(x):
         return f(x, p)
@@ -308,6 +317,12 @@ def _solve_once_warm(
     problem = Problem(n=n, m=m, problem_obj=obj, lb=lb, ub=ub, cl=cl, cu=cu)
     merged = dict(options or {})
     merged.setdefault("warm_start_init_point", "yes")
+    if np.isfinite(mu_warm):
+        # Seed the barrier from the previous solve's converged μ so the
+        # corrector resumes near the central path instead of re-walking
+        # the homotopy from the default initial μ (pounce#86).
+        merged.setdefault("mu_init", float(mu_warm))
+        merged.setdefault("warm_start_target_mu", float(mu_warm))
     for k, v in merged.items():
         problem.add_option(k, v)
     x_np, info = problem.solve(
@@ -321,40 +336,44 @@ def _solve_once_warm(
         np.asarray(info["mult_g"], dtype=np.float64),
         np.asarray(info["mult_x_L"], dtype=np.float64),
         np.asarray(info["mult_x_U"], dtype=np.float64),
+        float(info["mu"]),
         info,
     )
 
 
 def _pure_callback_warm_solve(
     f, g, p, x0, n, m, lb, ub, cl, cu, options,
-    lam_warm, zL_warm, zU_warm,
+    lam_warm, zL_warm, zU_warm, mu_warm,
 ):
     """Pure-callback wrapper around :func:`_solve_once_warm`.
 
-    Returns ``(x*, lam_out, zL_out, zU_out)`` — the four arrays the
-    bwd needs (lam_out, the bound multipliers) and the warm-state
-    triple the user threads into the next call.
+    Returns ``(x*, lam_out, zL_out, zU_out, mu_out)`` — the arrays the
+    bwd needs (lam_out, the bound multipliers), the warm-state triple
+    the user threads into the next call, and the converged barrier
+    parameter ``mu_out`` (pounce#86).
     """
     result_shapes = (
         jax.ShapeDtypeStruct((n,), jnp.float64),
         jax.ShapeDtypeStruct((m,), jnp.float64),
         jax.ShapeDtypeStruct((n,), jnp.float64),
         jax.ShapeDtypeStruct((n,), jnp.float64),
+        jax.ShapeDtypeStruct((), jnp.float64),
     )
 
-    def host_call(p_h, x0_h, lam_h, zL_h, zU_h):
-        x_np, lam_out, zL_out, zU_out, _info = _solve_once_warm(
+    def host_call(p_h, x0_h, lam_h, zL_h, zU_h, mu_h):
+        x_np, lam_out, zL_out, zU_out, mu_out, _info = _solve_once_warm(
             f=f, g=g,
             p=jnp.asarray(p_h),
             x0=jnp.asarray(x0_h),
             n=n, m=m, lb=lb, ub=ub, cl=cl, cu=cu,
             options=options,
             lam_warm=lam_h, zL_warm=zL_h, zU_warm=zU_h,
+            mu_warm=float(np.asarray(mu_h)),
         )
-        return x_np, lam_out, zL_out, zU_out
+        return x_np, lam_out, zL_out, zU_out, np.float64(mu_out)
 
     return jax.pure_callback(
-        host_call, result_shapes, p, x0, lam_warm, zL_warm, zU_warm,
+        host_call, result_shapes, p, x0, lam_warm, zL_warm, zU_warm, mu_warm,
     )
 
 
@@ -370,30 +389,31 @@ def _make_solve_with_warm_custom_vjp(
     options: dict | None,
 ):
     @jax.custom_vjp
-    def solve_fn(p, x0, lam_warm, zL_warm, zU_warm):
-        x_star, lam_out, zL_out, zU_out = _pure_callback_warm_solve(
+    def solve_fn(p, x0, lam_warm, zL_warm, zU_warm, mu_warm):
+        x_star, lam_out, zL_out, zU_out, mu_out = _pure_callback_warm_solve(
             f, g, p, x0, n, m, lb, ub, cl, cu, options,
-            lam_warm, zL_warm, zU_warm,
+            lam_warm, zL_warm, zU_warm, mu_warm,
         )
-        return x_star, lam_out, zL_out, zU_out
+        return x_star, lam_out, zL_out, zU_out, mu_out
 
-    def fwd(p, x0, lam_warm, zL_warm, zU_warm):
-        x_star, lam_out, zL_out, zU_out = _pure_callback_warm_solve(
+    def fwd(p, x0, lam_warm, zL_warm, zU_warm, mu_warm):
+        x_star, lam_out, zL_out, zU_out, mu_out = _pure_callback_warm_solve(
             f, g, p, x0, n, m, lb, ub, cl, cu, options,
-            lam_warm, zL_warm, zU_warm,
+            lam_warm, zL_warm, zU_warm, mu_warm,
         )
         return (
-            (x_star, lam_out, zL_out, zU_out),
+            (x_star, lam_out, zL_out, zU_out, mu_out),
             (p, x_star, lam_out, zL_out, zU_out),
         )
 
     def bwd(residuals, cotangents):
         p, x_star, lam, mult_xL, mult_xU = residuals
         # Only the x* cotangent contributes a gradient w.r.t. p.
-        # Cotangents on (lam_out, zL_out, zU_out) are dropped — same
-        # pattern existing `solve` uses for x0: warm dual outputs
-        # don't carry differentiable info back to p in the implicit
-        # rule (they're consequences of the active set, not inputs).
+        # Cotangents on (lam_out, zL_out, zU_out, mu_out) are dropped —
+        # same pattern existing `solve` uses for x0: warm dual / barrier
+        # outputs don't carry differentiable info back to p in the
+        # implicit rule (they're consequences of the active set and the
+        # barrier homotopy, not inputs).
         v = cotangents[0]
 
         active = (mult_xL > _ACTIVE_TOL) | (mult_xU > _ACTIVE_TOL)
@@ -453,6 +473,7 @@ def _make_solve_with_warm_custom_vjp(
             jnp.zeros((m,), dtype=jnp.float64),
             jnp.zeros((n,), dtype=jnp.float64),
             jnp.zeros((n,), dtype=jnp.float64),
+            jnp.zeros((), dtype=jnp.float64),
         )
 
     solve_fn.defvjp(fwd, bwd)
@@ -483,39 +504,62 @@ def solve_with_warm(
       ``None`` to start from zeros (still warm-starts the option,
       but with no informative duals — useful for the *first* call
       in a sequence where you want a uniform code path).
-    * Returns ``(x*, (lam_out, zL_out, zU_out))`` so the caller
-      can thread the dual triple into the next call.
+    * ``warm_start=(lam, zL, zU, mu)`` *additionally* seeds the
+      interior-point barrier parameter μ (pounce#86): the corrector
+      resumes near the central path at the supplied μ rather than
+      re-walking the barrier homotopy from the default initial μ.
+      Pass ``mu=None`` inside the 4-tuple to skip the μ seed but still
+      receive the converged μ on output (report-only).
+    * Returns ``(x*, (lam_out, zL_out, zU_out))`` for a 3-tuple /
+      ``None`` warm-start, or ``(x*, (lam_out, zL_out, zU_out,
+      mu_out))`` for a 4-tuple warm-start — the returned warm-state
+      arity matches the input, so threading μ in gives μ back out.
 
     The forward call is differentiable w.r.t. ``p`` only — cotangents
-    on the warm-output duals and the warm-input duals are dropped
+    on the warm-output duals/μ and the warm-input duals/μ are dropped
     (zero), matching how :func:`solve` handles ``x0``. This is the
-    implicit-function-theorem fix point: at the optimum the duals
-    are a function of ``p`` and the active set, not an independent
-    input feeding into ``dx*/dp``.
+    implicit-function-theorem fix point: at the optimum the duals and
+    the barrier are functions of ``p`` and the active set, not
+    independent inputs feeding into ``dx*/dp``.
 
-    Typical use::
+    Typical use (predictor–corrector corrector, with μ threading)::
 
-        x0, lam, zL, zU = init_state(...)
+        x0, lam, zL, zU, mu = init_state(...)
         for p_k in trajectory:
-            x_star, (lam, zL, zU) = solve_with_warm(
+            x_star, (lam, zL, zU, mu) = solve_with_warm(
                 p_k, f=f, g=g, x0=x0, n=n, m=m,
                 lb=lb, ub=ub, cl=cl, cu=cu,
-                warm_start=(lam, zL, zU),
+                warm_start=(lam, zL, zU, mu),
             )
             x0 = x_star  # primal warm-start for free
     """
+    want_mu = warm_start is not None and len(warm_start) == 4
     if warm_start is None:
         lam_warm = jnp.zeros(m, dtype=jnp.float64)
         zL_warm = jnp.zeros(n, dtype=jnp.float64)
         zU_warm = jnp.zeros(n, dtype=jnp.float64)
+        mu_warm = jnp.asarray(jnp.nan, dtype=jnp.float64)
     else:
-        lam_warm, zL_warm, zU_warm = warm_start
+        if want_mu:
+            lam_warm, zL_warm, zU_warm, mu_seed = warm_start
+        else:
+            lam_warm, zL_warm, zU_warm = warm_start
+            mu_seed = None
         lam_warm = jnp.asarray(lam_warm, dtype=jnp.float64)
         zL_warm = jnp.asarray(zL_warm, dtype=jnp.float64)
         zU_warm = jnp.asarray(zU_warm, dtype=jnp.float64)
+        # A ``None`` μ inside a 4-tuple means "report μ out, don't seed
+        # it in" — pass NaN to the host so it skips the mu_init seed.
+        mu_warm = jnp.asarray(
+            jnp.nan if mu_seed is None else mu_seed, dtype=jnp.float64
+        )
 
     fn = _make_solve_with_warm_custom_vjp(f, g, n, m, lb, ub, cl, cu, options)
-    x_star, lam_out, zL_out, zU_out = fn(p, x0, lam_warm, zL_warm, zU_warm)
+    x_star, lam_out, zL_out, zU_out, mu_out = fn(
+        p, x0, lam_warm, zL_warm, zU_warm, mu_warm,
+    )
+    if want_mu:
+        return x_star, (lam_out, zL_out, zU_out, mu_out)
     return x_star, (lam_out, zL_out, zU_out)
 
 

--- a/python/pounce/jax/_path.py
+++ b/python/pounce/jax/_path.py
@@ -46,6 +46,101 @@ import numpy as np
 _OK_STATUS = ("Solve_Succeeded", "Solved_To_Acceptable_Level")
 
 
+def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None):
+    """Build the right-hand side of the inverse / uncertainty-mapping ODE
+    (Alves–Kitchin–Lima, pounce#84 Eq. 3; pounce#91):
+
+    .. math::  \\frac{d\\theta}{ds} = \\Big(\\frac{\\partial y}{\\partial
+        \\theta}\\Big)^{-1} \\frac{dy}{ds},
+
+    where ``y = output(x*(θ), θ)`` is an output of the *embedded
+    optimizer* ``x*(θ) = argmin_x f(x, θ) s.t. …``. The map output→input
+    is traced by integrating this ODE along a prescribed output path
+    ``y(s)`` — *no NLP inversion, no brute force*; pounce supplies the
+    sensitivity RHS and an off-the-shelf integrator (diffrax, scipy) does
+    the stepping.
+
+    The inverse map is a **linear solve against** the total output
+    sensitivity, not a Jacobian-vector product: with ``J = ∂x*/∂θ`` from
+    the held KKT factor (:meth:`JaxProblem.solve_with_jacobian`) and the
+    output Jacobians ``∂h/∂x``, ``∂h/∂θ`` by autodiff,
+
+    .. math::  \\frac{\\partial y}{\\partial \\theta}
+        = \\frac{\\partial h}{\\partial x} J
+        + \\frac{\\partial h}{\\partial \\theta},
+        \\qquad
+        \\frac{d\\theta}{ds}
+        = \\Big(\\frac{\\partial y}{\\partial \\theta}\\Big)^{-1}
+        \\frac{dy}{ds}.
+
+    So the output and parameter dimensions must match (square
+    ``∂y/∂θ``). For the common case ``output = x*`` (identity), this is
+    exactly ``dθ/ds = J^{-1} dy/ds`` and requires ``n == p``.
+
+    Parameters
+    ----------
+    jp : JaxProblem
+        The embedded optimizer. ``θ`` must be 1-D (``p_shape == (p,)``).
+    dy_ds : callable or array
+        The prescribed output-path velocity ``dy/ds``: either a callable
+        ``s (float) -> (k,)`` or a constant ``(k,)`` array.
+    output : callable or None
+        ``h(x, θ) -> (k,)``; defaults to the identity ``h(x, θ) = x``
+        (the optimizer's solution itself is the output, ``k == n``).
+    x0 : (n,) or None
+        Initial guess for the inner solve at each RHS evaluation
+        (defaults to zeros). Each evaluation is an independent cold
+        solve — the integrator owns the stepping.
+
+    Returns
+    -------
+    callable ``f(s, theta) -> dtheta_ds`` of shape ``(p,)`` — drop-in for
+    a ``diffrax.ODETerm`` or ``scipy.integrate`` RHS. The whole
+    evaluation (NLP solve, ``∂x*/∂θ`` from the held factor, the output
+    Jacobians, and the linear solve) runs inside one ``jax.pure_callback``
+    on the host, so the callable is JAX-traceable and composes under
+    ``jax.jit`` and diffrax (which jit-compiles the vector field).
+
+    Notes
+    -----
+    When the path crosses a point where ``∂y/∂θ`` is singular (a fold) or
+    the optimizer's active set changes, the pure ODE is no longer
+    well-posed — switch to :class:`PathFollower` (predictor–corrector),
+    which monitors both conditions. This recipe is for the smooth,
+    fixed-active-set regime.
+    """
+    if len(jp._p_shape) != 1:
+        raise ValueError(
+            "inverse_map_rhs requires a 1-D θ "
+            f"(p_shape={jp._p_shape})."
+        )
+    n = jp._n
+    p = jp._p_shape[0]
+    x0_arr = jnp.zeros(n, dtype=jnp.float64) if x0 is None \
+        else jnp.asarray(x0, dtype=jnp.float64)
+    h = output if output is not None else (lambda x, theta: x)
+    result_shape = jax.ShapeDtypeStruct((p,), jnp.float64)
+
+    def _host(s_h, theta_h):
+        # Concrete (untraced) host evaluation: solve the NLP, read
+        # ∂x*/∂θ off the held factor, form ∂y/∂θ, and return
+        # (∂y/∂θ)^{-1} dy/ds. Wrapped in a pure_callback below so the
+        # callable composes under jit / diffrax.
+        theta = jnp.asarray(theta_h, dtype=jnp.float64)
+        x_star, _duals, J = jp.solve_with_jacobian(theta, x0_arr)   # J: (n, p)
+        h_x = jax.jacobian(lambda xx: h(xx, theta))(x_star)         # (k, n)
+        h_th = jax.jacobian(lambda th: h(x_star, th))(theta)        # (k, p)
+        dy_dtheta = h_x @ J + h_th                                  # (k, p)
+        v = dy_ds(s_h) if callable(dy_ds) else dy_ds
+        dtheta_ds = jnp.linalg.solve(dy_dtheta, jnp.asarray(v, dtype=jnp.float64))
+        return np.asarray(dtheta_ds, dtype=np.float64)
+
+    def f(s, theta):
+        return jax.pure_callback(_host, result_shape, s, theta)
+
+    return f
+
+
 @dataclass
 class PathTrace:
     """Result of a path-following run.

--- a/python/pounce/jax/_path.py
+++ b/python/pounce/jax/_path.py
@@ -1,0 +1,489 @@
+"""Numerical-continuation / predictor–corrector path following on the
+held KKT factor (pounce#90).
+
+Traces a solution path of a parametric NLP
+
+    min_x  f(x, θ)   s.t.  g(x, θ) = 0,  lb ≤ x ≤ ub
+
+by *composing* the post-solve sensitivity primitives rather than
+re-solving the NLP at every step:
+
+* **predict** — extrapolate ``x`` along the held-factor sensitivity
+  ``∂x*/∂θ`` (:meth:`JaxProblem.jvp_from_state`, pounce#82/#88);
+* **monitor** (no solve) — the KKT residual at the predicted point plus
+  the active-set margin (:meth:`JaxProblem.active_set_margin`, pounce#89);
+* **correct** — only when the monitor trips: a warm-started, barrier-μ
+  seeded re-solve that also re-anchors the factor in one solve
+  (:meth:`JaxProblem.warm_anchor`, pounce#86).
+
+Two entry points:
+
+* :meth:`PathFollower.follow` — *parameter continuation* along a
+  prescribed ``θ(s)``, ``s ∈ [s0, s1]``. This is the inverse /
+  uncertainty-mapping and operability-tracing case: the path parameter
+  ``s`` is prescribed and monotone, so there is no fold in ``s``.
+* :meth:`PathFollower.trace_arclength` — *pseudo-arclength continuation*
+  of the solution curve of a **scalar-parameter**, equality /
+  unconstrained family, which traces **past turning points (folds)** in
+  ``θ`` where ``∂x*/∂θ`` is singular and parameter continuation cannot
+  proceed.
+
+Scope (v1). Bifurcation / branch switching, Hopf detection, and general
+DAE continuation are out of scope. The arclength mode handles folds for
+equality / unconstrained scalar-θ systems (no inequality active-set
+changes along the traced branch); inequality-active folds are not
+covered.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+_OK_STATUS = ("Solve_Succeeded", "Solved_To_Acceptable_Level")
+
+
+@dataclass
+class PathTrace:
+    """Result of a path-following run.
+
+    Attributes
+    ----------
+    s : (K,)
+        Path parameter at each recorded point (arclength in the
+        arclength mode).
+    theta : (K,) + p_shape
+        Parameter value at each point.
+    x : (K, n)
+        Primal solution at each point.
+    lam : (K, m)
+        Equality/inequality multipliers at each point.
+    n_steps, n_correctors, n_accepts : int
+        Total steps taken, of which corrected (a solve) vs. accepted on
+        the predictor alone (no solve). ``n_correctors`` is the solve
+        count beyond the initial anchor.
+    active_set_changes : list[float]
+        Path-parameter values at which the active set changed (parameter
+        mode).
+    turning_points : list[float]
+        θ values at detected folds (arclength mode).
+    status : str
+        ``"ok"`` on a full traverse, or a reason string on early stop.
+    """
+
+    s: np.ndarray
+    theta: np.ndarray
+    x: np.ndarray
+    lam: np.ndarray
+    n_steps: int
+    n_correctors: int
+    n_accepts: int
+    active_set_changes: list = field(default_factory=list)
+    turning_points: list = field(default_factory=list)
+    status: str = "ok"
+
+
+class PathFollower:
+    """Predictor–corrector path follower over a :class:`JaxProblem`
+    (pounce#90).
+
+    Parameters
+    ----------
+    jp : JaxProblem
+        The parametric NLP to trace.
+    monitor_tol : float
+        KKT-residual threshold at the predicted point; above it the step
+        is corrected (a warm re-solve), below it accepted on the
+        predictor alone.
+    active_margin_tol : float
+        Active-set margin (pounce#89) threshold; a predicted point closer
+        than this to a critical-region boundary forces a correction so
+        the predictor never extrapolates across a discontinuity.
+    ds0, ds_min, ds_max : float
+        Initial / minimum / maximum step in the path parameter.
+    grow, shrink : float
+        Step-size adaptation factors (on accept / easy correction vs.
+        hard or failed correction).
+    max_steps : int
+        Safety cap on the number of steps.
+    """
+
+    def __init__(
+        self,
+        jp,
+        *,
+        monitor_tol: float = 1e-6,
+        active_margin_tol: float = 1e-4,
+        ds0: float = 0.05,
+        ds_min: float = 1e-4,
+        ds_max: float = 0.25,
+        grow: float = 1.5,
+        shrink: float = 0.5,
+        max_steps: int = 100_000,
+    ):
+        self._jp = jp
+        self._monitor_tol = float(monitor_tol)
+        self._active_margin_tol = float(active_margin_tol)
+        self._ds0 = float(ds0)
+        self._ds_min = float(ds_min)
+        self._ds_max = float(ds_max)
+        self._grow = float(grow)
+        self._shrink = float(shrink)
+        self._max_steps = int(max_steps)
+
+    # ----- monitors -----
+
+    def _kkt_residual(self, x, theta, lam, zL, zU) -> float:
+        """First-order optimality residual at ``(x, θ)`` with the given
+        multipliers — the smooth-drift monitor. No solve."""
+        jp = self._jp
+        m = jp._m
+        gradf = jax.grad(lambda xx: jp._f(xx, theta))(x)
+        stat = gradf - zL + zU
+        cviol = 0.0
+        if m > 0:
+            gx = jp._g(x, theta)
+            Jg = jax.jacobian(lambda xx: jp._g(xx, theta))(x)
+            stat = stat + Jg.T @ lam
+            cviol = float(jnp.max(jnp.abs(gx)))
+        r = float(jnp.max(jnp.abs(stat))) + cviol
+        if jp._lb is not None:
+            r += float(jnp.max(jnp.maximum(0.0, jnp.asarray(jp._lb) - x)))
+        if jp._ub is not None:
+            r += float(jnp.max(jnp.maximum(0.0, x - jnp.asarray(jp._ub))))
+        return r
+
+    def _margin_at(self, x, lam, zL, zU, theta) -> float:
+        """Active-set margin at an explicit predicted point (pounce#89)."""
+        r = self._jp._margin_arrays(
+            x[None], lam[None], zL[None], zU[None],
+            jnp.asarray(theta)[None], 1,
+        )
+        return float(r["margin"][0])
+
+    def _active_signature(self, lam, zL, zU, active_tol=1e-6):
+        """Boolean active-set fingerprint: which bounds / inequalities are
+        active. Used to detect active-set changes across corrections."""
+        jp = self._jp
+        sig = (
+            tuple(bool(v) for v in np.asarray(zL > active_tol))
+            + tuple(bool(v) for v in np.asarray(zU > active_tol))
+        )
+        if jp._m > 0:
+            cl = np.asarray(jp._cl_for_classify)
+            cu = np.asarray(jp._cu_for_classify)
+            is_ineq = cl != cu
+            lam_np = np.asarray(lam)
+            sig = sig + tuple(
+                bool(is_ineq[i] and abs(lam_np[i]) > active_tol)
+                for i in range(jp._m)
+            )
+        return sig
+
+    # ----- parameter continuation -----
+
+    def follow(self, theta_of_s, s_span, x0) -> PathTrace:
+        """Trace ``x*(θ(s))`` for a prescribed path ``θ(s)``,
+        ``s ∈ [s0, s1]`` (pounce#90).
+
+        Anchors once with a cold solve at ``θ(s0)``, then steps: predict
+        with the held-factor sensitivity, monitor (KKT residual +
+        active-set margin) with no solve, and correct (warm-μ re-solve +
+        re-anchor) only when the monitor trips. The step size adapts to
+        the corrector effort and backs off near active-set boundaries.
+
+        Parameters
+        ----------
+        theta_of_s : callable
+            ``s (float) -> θ`` (shape ``p_shape``).
+        s_span : (float, float)
+            ``(s0, s1)`` with ``s1 > s0``.
+        x0 : (n,)
+            Primal initial guess for the anchor solve.
+
+        Returns
+        -------
+        PathTrace
+        """
+        jp = self._jp
+        s0, s1 = float(s_span[0]), float(s_span[1])
+        if not (s1 > s0):
+            raise ValueError("s_span must have s1 > s0")
+
+        def th(s):
+            return jnp.asarray(theta_of_s(s), dtype=jnp.float64)
+
+        # Anchor: cold solve at s0 (no dual / μ seed).
+        state, info = jp.warm_anchor(th(s0), jnp.asarray(x0, dtype=jnp.float64))
+        if info["status_msg"] not in _OK_STATUS:
+            state.close()
+            raise RuntimeError(
+                f"pounce.jax: anchor solve failed at s0 "
+                f"({info['status_msg']})."
+            )
+        x = jnp.asarray(state.x_star[0])
+        lam, zL, zU = (jnp.asarray(d[0]) for d in state.duals)
+        mu = float(info["mu"])
+        sig = self._active_signature(lam, zL, zU)
+
+        S = [s0]
+        TH = [np.asarray(th(s0))]
+        X = [np.asarray(x)]
+        LAM = [np.asarray(lam)]
+        n_corr = 0
+        n_acc = 0
+        n_steps = 0
+        as_changes: list = []
+        status = "ok"
+
+        s = s0
+        ds = self._ds0
+        while s < s1 - 1e-12 and n_steps < self._max_steps:
+            n_steps += 1
+            ds = min(ds, s1 - s)
+            s_new = s + ds
+            th_cur = th(s)
+            th_new = th(s_new)
+            dth = th_new - th_cur
+
+            # PREDICT: step both primal and duals along the sensitivity
+            # (∂x*/∂θ, ∂λ*/∂θ) · dθ — a held-factor back-solve. Predicting
+            # the multipliers too is what lets the KKT-residual monitor
+            # recognise an accurate predictor (a stale λ would otherwise
+            # inflate the residual even at an exact x_pred).
+            if jp._m > 0:
+                dx, dlam = jp.jvp_from_state(state, dth, with_duals=True)
+                lam_pred = lam + dlam
+            else:
+                dx = jp.jvp_from_state(state, dth)
+                lam_pred = lam
+            x_pred = x + dx
+
+            # MONITOR (no solve): residual + active-set margin at the
+            # predicted point.
+            r = self._kkt_residual(x_pred, th_new, lam_pred, zL, zU)
+            margin = self._margin_at(x_pred, lam_pred, zL, zU, th_new)
+
+            if r <= self._monitor_tol and margin > self._active_margin_tol:
+                # Accept on the predictor — no solve. Carry the predicted
+                # primal and duals forward; the next predictor keeps
+                # extrapolating from the same held factor.
+                x = x_pred
+                lam = lam_pred
+                s = s_new
+                n_acc += 1
+                S.append(s)
+                TH.append(np.asarray(th_new))
+                X.append(np.asarray(x))
+                LAM.append(np.asarray(lam))
+                ds = min(ds * self._grow, self._ds_max)
+                continue
+
+            # CORRECT: warm-μ re-solve from the predicted point, which
+            # also re-anchors the held factor for the next predictor.
+            new_state, cinfo = jp.warm_anchor(
+                th_new, x_pred, duals=(lam, zL, zU), mu=mu,
+            )
+            if cinfo["status_msg"] not in _OK_STATUS:
+                # Back off and retry a shorter step from the same anchor.
+                new_state.close()
+                ds *= self._shrink
+                if ds < self._ds_min:
+                    status = "corrector_failed"
+                    break
+                continue
+
+            state.close()
+            state = new_state
+            x = jnp.asarray(state.x_star[0])
+            lam, zL, zU = (jnp.asarray(d[0]) for d in state.duals)
+            mu = float(cinfo["mu"])
+            n_corr += 1
+            s = s_new
+
+            new_sig = self._active_signature(lam, zL, zU)
+            if new_sig != sig:
+                as_changes.append(s)
+                sig = new_sig
+                # Resolve the region near the change finely.
+                ds = min(self._ds0, max(ds * self._shrink, self._ds_min))
+            else:
+                iters = int(cinfo["iter_count"])
+                if iters <= 3:
+                    ds = min(ds * self._grow, self._ds_max)
+                elif iters >= 10:
+                    ds = max(ds * self._shrink, self._ds_min)
+
+            S.append(s)
+            TH.append(np.asarray(th_new))
+            X.append(np.asarray(x))
+            LAM.append(np.asarray(lam))
+
+        state.close()
+        if n_steps >= self._max_steps and s < s1 - 1e-12:
+            status = "max_steps"
+        return PathTrace(
+            s=np.asarray(S),
+            theta=np.asarray(TH),
+            x=np.asarray(X),
+            lam=np.asarray(LAM),
+            n_steps=n_steps,
+            n_correctors=n_corr,
+            n_accepts=n_acc,
+            active_set_changes=as_changes,
+            turning_points=[],
+            status=status,
+        )
+
+    # ----- pseudo-arclength continuation (folds) -----
+
+    def trace_arclength(
+        self,
+        x0,
+        theta0,
+        *,
+        ds: float = 0.05,
+        n_steps: int = 200,
+        direction: float = 1.0,
+        newton_tol: float = 1e-9,
+        newton_max: int = 40,
+    ) -> PathTrace:
+        """Pseudo-arclength continuation of the solution curve for a
+        **scalar** parameter ``θ``, tracing *past folds* (pounce#90).
+
+        Solves the stationarity / feasibility system ``R(x, λ, θ) = 0``
+        — ``R = [∇_x f + J_gᵀλ ; g]`` — along the arclength of its
+        solution curve in ``(x, λ, θ)`` space, with a tangent predictor
+        and a Newton corrector on the augmented system ``[R ; arclength]``.
+        Because the curve is parametrised by arclength rather than ``θ``,
+        it passes through turning points where ``∂x*/∂θ`` is singular
+        (the fold), which parameter continuation cannot.
+
+        Restricted to equality / unconstrained problems (the active set is
+        fixed along the traced branch). Bounds / inequality-active folds
+        are out of scope for v1.
+
+        Parameters
+        ----------
+        x0 : (n,)
+            Primal guess near a point on the curve; projected onto
+            ``R = 0`` at ``θ0`` before tracing.
+        theta0 : float
+            Starting (scalar) parameter value.
+        ds : float
+            Arclength step.
+        n_steps : int
+            Number of arclength steps.
+        direction : float
+            Sign of the initial step in ``θ`` (+1 increasing).
+        newton_tol, newton_max : float, int
+            Corrector Newton tolerance and iteration cap.
+
+        Returns
+        -------
+        PathTrace  (``turning_points`` lists the θ values at detected folds)
+        """
+        jp = self._jp
+        n, m = jp._n, jp._m
+        if len(jp._p_shape) != 0 and jp._p_shape != (1,):
+            raise ValueError(
+                "trace_arclength supports a scalar parameter only "
+                f"(p_shape={jp._p_shape}); use follow(...) for a path."
+            )
+        d = n + m  # number of equations in R
+
+        def _theta_arg(theta_scalar):
+            # Present θ to the user callables in their declared shape.
+            return theta_scalar if jp._p_shape == () else theta_scalar[None]
+
+        def R(u):
+            x = u[:n]
+            theta = _theta_arg(u[d])
+            gradf = jax.grad(lambda xx: jp._f(xx, theta))(x)
+            if m > 0:
+                lam = u[n:d]
+                Jg = jax.jacobian(lambda xx: jp._g(xx, theta))(x)
+                return jnp.concatenate([gradf + Jg.T @ lam, jp._g(x, theta)])
+            return gradf
+
+        R_jit = jax.jit(R)
+        dR_jit = jax.jit(jax.jacobian(R))  # (d, d+1)
+
+        f64 = jnp.float64
+        u = jnp.concatenate([
+            jnp.asarray(x0, dtype=f64),
+            jnp.zeros(m, dtype=f64),
+            jnp.asarray([float(theta0)], dtype=f64),
+        ])
+
+        # Project the initial point onto R = 0 at fixed θ0 (Newton on the
+        # first d coordinates).
+        for _ in range(newton_max):
+            res = R_jit(u)
+            if float(jnp.max(jnp.abs(res))) < newton_tol:
+                break
+            A = dR_jit(u)[:, :d]
+            u = u.at[:d].add(-jnp.linalg.solve(A, res))
+
+        def tangent(u_at, t_prev):
+            A = dR_jit(u_at)                 # (d, d+1)
+            _, _, Vt = jnp.linalg.svd(A)
+            t = Vt[-1]
+            t = t / jnp.linalg.norm(t)
+            if t_prev is None:
+                if float(t[d]) * direction < 0:
+                    t = -t
+            elif float(jnp.dot(t, t_prev)) < 0:
+                t = -t
+            return t
+
+        t = tangent(u, None)
+        X = [np.asarray(u[:n])]
+        TH = [float(u[d])]
+        LAM = [np.asarray(u[n:d])]
+        turning: list = []
+        status = "ok"
+
+        for _ in range(n_steps):
+            u_pred = u + ds * t
+            uc = u_pred
+            ok = False
+            for _ in range(newton_max):
+                res = R_jit(uc)
+                arc = jnp.dot(t, uc - u_pred)
+                F = jnp.concatenate([res, jnp.asarray([arc])])
+                if float(jnp.max(jnp.abs(F))) < newton_tol:
+                    ok = True
+                    break
+                A = dR_jit(uc)                       # (d, d+1)
+                Aaug = jnp.concatenate([A, t[None, :]], axis=0)  # (d+1, d+1)
+                uc = uc - jnp.linalg.solve(Aaug, F)
+            if not ok:
+                status = "corrector_failed"
+                break
+            u = uc
+            t_new = tangent(u, t)
+            # Fold = the θ-component of the tangent changes sign.
+            if float(t[d]) * float(t_new[d]) < 0:
+                turning.append(float(u[d]))
+            t = t_new
+            X.append(np.asarray(u[:n]))
+            TH.append(float(u[d]))
+            LAM.append(np.asarray(u[n:d]))
+
+        K = len(X)
+        return PathTrace(
+            s=np.arange(K) * ds,
+            theta=np.asarray(TH),
+            x=np.asarray(X),
+            lam=np.asarray(LAM),
+            n_steps=K - 1,
+            n_correctors=K - 1,
+            n_accepts=0,
+            active_set_changes=[],
+            turning_points=turning,
+            status=status,
+        )

--- a/python/pounce/jax/_path.py
+++ b/python/pounce/jax/_path.py
@@ -378,9 +378,11 @@ class PathFollower:
                 continue
 
             # CORRECT: warm-μ re-solve from the predicted point, which
-            # also re-anchors the held factor for the next predictor.
+            # also re-anchors the held factor for the next predictor. Seed
+            # the duals with the *predicted* multipliers (lam_pred) — a
+            # better warm start than the pre-prediction lam.
             new_state, cinfo = jp.warm_anchor(
-                th_new, x_pred, duals=(lam, zL, zU), mu=mu,
+                th_new, x_pred, duals=(lam_pred, zL, zU), mu=mu,
             )
             if cinfo["status_msg"] not in _OK_STATUS:
                 # Back off and retry a shorter step from the same anchor.

--- a/python/pounce/jax/_path.py
+++ b/python/pounce/jax/_path.py
@@ -46,7 +46,7 @@ import numpy as np
 _OK_STATUS = ("Solve_Succeeded", "Solved_To_Acceptable_Level")
 
 
-def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None):
+def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None, warm=False):
     """Build the right-hand side of the inverse / uncertainty-mapping ODE
     (Alves–Kitchin–Lima, pounce#84 Eq. 3; pounce#91):
 
@@ -88,9 +88,32 @@ def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None):
         ``h(x, θ) -> (k,)``; defaults to the identity ``h(x, θ) = x``
         (the optimizer's solution itself is the output, ``k == n``).
     x0 : (n,) or None
-        Initial guess for the inner solve at each RHS evaluation
-        (defaults to zeros). Each evaluation is an independent cold
-        solve — the integrator owns the stepping.
+        Initial guess for the inner solve (defaults to zeros). With
+        ``warm=False`` it seeds *every* evaluation; with ``warm=True`` it
+        seeds only the first.
+    warm : bool
+        When ``True``, warm-start each inner solve from the previous
+        evaluation's converged primal, duals, and barrier μ (pounce#86)
+        instead of a cold solve from ``x0``. The converged ``x*(θ)`` is
+        unique, so the **result is unchanged up to solver tolerance**;
+        only the iteration count differs (and, for a nonconvex problem,
+        warm-starting tracks the local branch — usually what you want for
+        a continuous map). The warm cache is a perf heuristic internal to
+        the returned callable and is robust to the integrator's call
+        order (RK stages, rejected steps): any nearby seed still
+        converges to the same point.
+
+        Expect a **modest** saving — measured ~1.4–1.7× fewer IPM
+        iterations on smooth scalar/low-dim maps. Interior-point methods
+        warm-start weakly (the barrier homotopy resists a
+        boundary-proximate seed), so the win is far smaller than the
+        active-set/SQP warm-start regime. The wall-clock benefit scales
+        with per-solve cost: marginal on tiny NLPs (iterations are
+        already cheap), meaningful on flowsheet-scale NLPs where each IPM
+        iteration is an expensive factorization. If your NLP is expensive
+        *and* the map is smooth, prefer :class:`PathFollower`, whose
+        predictor skips most solves entirely rather than just making each
+        one cheaper.
 
     Returns
     -------
@@ -121,13 +144,39 @@ def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None):
     h = output if output is not None else (lambda x, theta: x)
     result_shape = jax.ShapeDtypeStruct((p,), jnp.float64)
 
+    # Mutable warm cache (perf-only): last converged primal / duals / μ.
+    # The result is invariant to it — only the inner solve's iteration
+    # count depends on the seed — so reordered / repeated callback
+    # invocations from the integrator are safe.
+    cache = {"x": np.asarray(x0_arr), "duals": None, "mu": None}
+
+    def _solve(theta):
+        """Return ``(x_star, J)`` at ``theta`` — cold or warm-started."""
+        if not warm:
+            x_star, _duals, J = jp.solve_with_jacobian(theta, x0_arr)
+            return x_star, J
+        # Warm path: one warm-μ solve that also pins the factor, then read
+        # J off it and refresh the cache for the next evaluation.
+        state, info = jp.warm_anchor(
+            theta, cache["x"], duals=cache["duals"], mu=cache["mu"],
+        )
+        try:
+            x_star = state.x_star[0]
+            J = jp.sensitivity(state)
+            cache["x"] = np.asarray(x_star)
+            cache["duals"] = tuple(np.asarray(d[0]) for d in state.duals)
+            cache["mu"] = float(info["mu"])
+        finally:
+            state.close()
+        return x_star, J
+
     def _host(s_h, theta_h):
         # Concrete (untraced) host evaluation: solve the NLP, read
         # ∂x*/∂θ off the held factor, form ∂y/∂θ, and return
         # (∂y/∂θ)^{-1} dy/ds. Wrapped in a pure_callback below so the
         # callable composes under jit / diffrax.
         theta = jnp.asarray(theta_h, dtype=jnp.float64)
-        x_star, _duals, J = jp.solve_with_jacobian(theta, x0_arr)   # J: (n, p)
+        x_star, J = _solve(theta)                                   # J: (n, p)
         h_x = jax.jacobian(lambda xx: h(xx, theta))(x_star)         # (k, n)
         h_th = jax.jacobian(lambda th: h(x_star, th))(theta)        # (k, p)
         dy_dtheta = h_x @ J + h_th                                  # (k, p)

--- a/python/pounce/jax/_path.py
+++ b/python/pounce/jax/_path.py
@@ -46,6 +46,26 @@ import numpy as np
 _OK_STATUS = ("Solve_Succeeded", "Solved_To_Acceptable_Level")
 
 
+def _require_equality_constraints(jp, where):
+    """Guard: path continuation here assumes a fixed active set in which every
+    general constraint is an equality (``cl == cu``). For a two-sided
+    inequality (``cl != cu``) the smooth-drift monitor's constraint residual
+    (``max|g|``, valid only at ``g = 0``) and the arclength system ``R`` (which
+    treats every row as ``g = 0``) are wrong, so reject it explicitly rather
+    than silently over-correct / mis-trace."""
+    if jp._m > 0:
+        cl = np.asarray(jp._cl_for_classify)
+        cu = np.asarray(jp._cu_for_classify)
+        if np.any(cl != cu):
+            raise ValueError(
+                f"{where} supports equality constraints (cl == cu) and "
+                "variable bounds only; this problem has two-sided inequality "
+                "constraints (cl != cu), for which the active-set monitor and "
+                "KKT residual are not yet valid. Reformulate the inequalities "
+                "with slack equalities, or remove them."
+            )
+
+
 def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None, warm=False):
     """Build the right-hand side of the inverse / uncertainty-mapping ODE
     (Alves–Kitchin–Lima, pounce#84 Eq. 3; pounce#91):
@@ -142,6 +162,33 @@ def inverse_map_rhs(jp, dy_ds, *, output=None, x0=None, warm=False):
     x0_arr = jnp.zeros(n, dtype=jnp.float64) if x0 is None \
         else jnp.asarray(x0, dtype=jnp.float64)
     h = output if output is not None else (lambda x, theta: x)
+
+    # ∂y/∂θ must be square (output dim k == parameter dim p) for the linear
+    # solve dθ/ds = (∂y/∂θ)^{-1} dy/ds to be well-posed. Check the output
+    # dimension up front (via shape inference — no NLP solve) so a mismatch
+    # raises a clear error here, not an opaque LinAlgError inside the callback.
+    if output is None:
+        k = n
+    else:
+        out_shape = jax.eval_shape(
+            h, jnp.zeros(n, dtype=jnp.float64), jnp.zeros(p, dtype=jnp.float64)
+        )
+        if len(out_shape.shape) != 1:
+            raise ValueError(
+                "inverse_map_rhs output h(x, θ) must be 1-D; got shape "
+                f"{out_shape.shape}."
+            )
+        k = out_shape.shape[0]
+    if k != p:
+        detail = (
+            " (the default identity output ⇒ k = n, so this needs n == p)"
+            if output is None else ""
+        )
+        raise ValueError(
+            "inverse_map_rhs requires a square output sensitivity ∂y/∂θ: the "
+            f"output dimension k={k} must equal the parameter dimension "
+            f"p={p}{detail}."
+        )
     result_shape = jax.ShapeDtypeStruct((p,), jnp.float64)
 
     # Mutable warm cache (perf-only): last converged primal / duals / μ.
@@ -353,6 +400,7 @@ class PathFollower:
         PathTrace
         """
         jp = self._jp
+        _require_equality_constraints(jp, "PathFollower.follow")
         s0, s1 = float(s_span[0]), float(s_span[1])
         if not (s1 > s0):
             raise ValueError("s_span must have s1 > s0")
@@ -539,6 +587,7 @@ class PathFollower:
                 "trace_arclength supports a scalar parameter only "
                 f"(p_shape={jp._p_shape}); use follow(...) for a path."
             )
+        _require_equality_constraints(jp, "PathFollower.trace_arclength")
         d = n + m  # number of equations in R
 
         def _theta_arg(theta_scalar):

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -2025,9 +2025,19 @@ class JaxProblem:
         subsequent from-state products to the selected columns, e.g.
         ``slice(0, ny)`` to keep only the predicted block and drop
         context columns.
+
+        Accepts either a batched ``p_batch`` (``(B,) + p_shape``) or a
+        single un-batched point (``p_shape``) — a single point yields a
+        ``B=1`` state for the single-problem wrappers (pounce#88:
+        :meth:`jvp_from_state` / :meth:`vjp_from_state` /
+        :meth:`sensitivity`).
         """
         cols = self._normalize_cols(wrt_cols)
-        x_star, duals, sid, (pb, xs, lam) = self._anchor_forward(p_batch, x0)
+        p_arr = jnp.asarray(p_batch, dtype=jnp.float64)
+        # Un-batched single point (ndim matches p_shape) → wrap to B=1.
+        if p_arr.ndim == len(self._p_shape):
+            p_arr = p_arr[None]
+        x_star, duals, sid, (pb, xs, lam) = self._anchor_forward(p_arr, x0)
         return AnchorState(self, sid, pb.shape[0], pb, xs, lam, duals, cols)
 
     def batched_solve_with_jacobian(
@@ -2292,6 +2302,89 @@ class JaxProblem:
 
         J = jax.vmap(jac_row)(basis)          # (n,) + p_shape
         return self._slice_cols(J, cols)
+
+    # ----- single-problem ergonomic wrappers (pounce#88) -----
+    #
+    # Thin sugar over the batched_* methods for the scalar /
+    # path-following user (one NLP at a time, e.g. the inverse-map
+    # continuation): accept and return un-batched shapes, delegate to a
+    # ``B=1`` batched call, squeeze. No new numerics — the batched
+    # methods remain the canonical surface.
+
+    def _require_single(self, state: "AnchorState", who: str) -> None:
+        if state._B != 1:
+            raise ValueError(
+                f"pounce.jax: {who} is the single-problem form (B=1); the "
+                f"state was anchored with B={state._B}. Use the batched_* "
+                "method, or anchor a single point."
+            )
+
+    def solve_with_jacobian(self, p, x0, *, wrt_cols=None, return_state=False):
+        """Single-problem :meth:`batched_solve_with_jacobian` (pounce#88).
+
+        Solve at one ``p`` and return the full primal sensitivity
+        ``J = ∂x*/∂p`` of shape ``(n, p_dim)`` (or ``(n, len(wrt_cols))``)
+        from the held KKT factor — no leading batch axis. Thin sugar:
+        delegates to the batched method with ``B=1`` and squeezes.
+
+        Returns ``(x_star (n,), (lam (m,), zL (n,), zU (n,)), J)`` or,
+        with ``return_state=True``, also a ``B=1`` :class:`AnchorState`
+        for follow-up :meth:`jvp_from_state` / :meth:`vjp_from_state`.
+        """
+        p1 = jnp.asarray(p, dtype=jnp.float64)[None]
+        out = self.batched_solve_with_jacobian(
+            p1, x0, wrt_cols=wrt_cols, return_state=return_state,
+        )
+        if return_state:
+            x_star, (lam, zL, zU), J, state = out
+            return x_star[0], (lam[0], zL[0], zU[0]), J[0], state
+        x_star, (lam, zL, zU), J = out
+        return x_star[0], (lam[0], zL[0], zU[0]), J[0]
+
+    def sensitivity(self, state: "AnchorState"):
+        """Full primal sensitivity ``∂x*/∂p`` (shape ``(n, p_dim)``, or
+        ``(n, len(wrt_cols))`` if the state was anchored with
+        ``wrt_cols``) from a held single-problem state — one multi-RHS
+        back-solve over the held factor, no re-solve (pounce#88).
+
+        Single-problem analog of :meth:`batched_solve_with_jacobian`'s
+        ``J`` for an already-anchored state: row ``i`` is the VJP at
+        cotangent ``e_i`` (the KKT is symmetric). For the sensitivity at
+        a *different* supplied point use :meth:`sensitivity_at`
+        (re-factor); this evaluates at the state's own anchor point via
+        the held factor.
+        """
+        self._require_single(state, "sensitivity")
+        f, g, n, m = self._f, self._g, self._n, self._m
+        basis = jnp.eye(n, dtype=jnp.float64)
+
+        def jac_row(e_i):
+            v = jnp.broadcast_to(e_i, (state._B, n))
+            return _bwd_batched_factor_reuse(
+                f, g, n, m, self, state._B,
+                state._p_batch, state._x_star, state._lam, state._sid, v,
+            )
+
+        J_rows = jax.vmap(jac_row)(basis)        # (n, 1, p_dim)
+        J = jnp.transpose(J_rows, (1, 0, 2))      # (1, n, p_dim)
+        return self._slice_cols(J, state._wrt_cols)[0]
+
+    def jvp_from_state(self, state: "AnchorState", dp):
+        """Single-problem :meth:`batched_jvp_from_state` — ``J @ dp`` for
+        a state anchored at one point. ``dp`` has shape ``p_shape`` (or
+        ``(len(wrt_cols),)`` if the state was anchored with ``wrt_cols``)
+        and the result is ``(n,)`` (pounce#88)."""
+        self._require_single(state, "jvp_from_state")
+        dp1 = jnp.asarray(dp, dtype=jnp.float64)[None]
+        return self.batched_jvp_from_state(state, dp1)[0]
+
+    def vjp_from_state(self, state: "AnchorState", x_bar):
+        """Single-problem :meth:`batched_vjp_from_state` — ``J^T @ x_bar``
+        for a state anchored at one point. ``x_bar`` has shape ``(n,)``;
+        the result is ``(p_dim,)`` (or ``(len(wrt_cols),)``) (pounce#88)."""
+        self._require_single(state, "vjp_from_state")
+        xb1 = jnp.asarray(x_bar, dtype=jnp.float64)[None]
+        return self.batched_vjp_from_state(state, xb1)[0]
 
     # ----- custom_vjp factories -----
 

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -164,6 +164,8 @@ class _StackedJaxNlp:
 
     def constraints(self, X):
         n, m = self._jp._n, self._jp._m
+        if m == 0:
+            return np.zeros(0, dtype=np.float64)
         X_2d = jnp.asarray(X).reshape(self._B, n)
         G_2d = jax.vmap(self._jp._g_jit, in_axes=(0, 0))(X_2d, self._P)
         return _to_np(G_2d).reshape(self._B * m)
@@ -176,6 +178,8 @@ class _StackedJaxNlp:
         # nonzeros at the per-block sparsity pattern. We never assemble
         # the dense stacked Jacobian (would be (B*m, B*n)); the gather
         # below is order ``B * nnz_per_block`` work.
+        if self._jp._m == 0:
+            return np.zeros(0, dtype=np.float64)
         n = self._jp._n
         X_2d = jnp.asarray(X).reshape(self._B, n)
         J_3d = jax.vmap(self._jp._jac_g_jit, in_axes=(0, 0))(X_2d, self._P)
@@ -232,12 +236,16 @@ class _ReusableJaxNlp:
         return _to_np(self._jp._grad_f_jit(jnp.asarray(x), self._p))
 
     def constraints(self, x):
+        if self._jp._m == 0:
+            return np.zeros(0, dtype=np.float64)
         return _to_np(self._jp._g_jit(jnp.asarray(x), self._p))
 
     def jacobianstructure(self):
         return (self._jp._jac_rows, self._jp._jac_cols)
 
     def jacobian(self, x):
+        if self._jp._m == 0:
+            return np.zeros(0, dtype=np.float64)
         J = _to_np(self._jp._jac_g_jit(jnp.asarray(x), self._p))
         return J[self._jp._jac_rows, self._jp._jac_cols]
 

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -2386,6 +2386,105 @@ class JaxProblem:
         xb1 = jnp.asarray(x_bar, dtype=jnp.float64)[None]
         return self.batched_vjp_from_state(state, xb1)[0]
 
+    def active_set_margin(self, state: "AnchorState", *, active_tol=_ACTIVE_TOL):
+        """Distance to an active-set change at the anchor point (pounce#89).
+
+        The post-solve sensitivity ``∂x*/∂θ`` is a derivative on a *fixed*
+        active set; along a path it stays valid until a bound /
+        inequality crosses its critical-region boundary, where the
+        sensitivity is **discontinuous**. This is the monitor that says
+        "the predictor is about to become invalid": it reduces the held
+        state's multipliers and slacks to the smallest distance-to-zero,
+        with no solve and no back-solve — a pure reduction over state the
+        :class:`AnchorState` already holds.
+
+        Two ways the active set flips, by complementarity:
+
+        * an **active** bound / inequality (multiplier ``> active_tol``)
+          is about to leave the set — its *multiplier* heads to zero;
+        * an **inactive** bound / inequality is about to enter the set —
+          its *slack* heads to zero.
+
+        Equalities (``cl == cu``) are always active and never change set,
+        so they are excluded. Bounds at ``±inf`` (and the slack side of a
+        one-sided inequality) contribute ``inf`` and drop out naturally.
+
+        Pairs with the smooth-drift monitor (the KKT residual at the
+        predicted point, which the caller forms directly): re-solve /
+        re-anchor when *either* the residual grows *or* this margin gets
+        small.
+
+        Parameters
+        ----------
+        state : AnchorState
+        active_tol : float
+            Multiplier threshold for classifying a bound / inequality as
+            active. Matches the ``custom_vjp`` backward's
+            ``_ACTIVE_TOL``.
+
+        Returns
+        -------
+        dict of ``(B,)`` arrays:
+
+        * ``"margin"`` — ``min(min_mult, min_slack)`` per block; small ⇒
+          an active-set change is imminent. ``inf`` when no constraint is
+          active *and* none inactive-with-finite-slack (unconstrained at
+          this point).
+        * ``"min_mult"`` — smallest active multiplier (closest to
+          *leaving* the active set); ``inf`` when nothing is active.
+        * ``"min_slack"`` — smallest inactive slack (closest to
+          *entering* the active set); ``inf`` when nothing is inactive
+          with a finite bound.
+        """
+        n, m = self._n, self._m
+        B = state._B
+        INF = jnp.inf
+
+        x = jnp.asarray(state._x_star, dtype=jnp.float64).reshape(B, n)
+        lam_b, zL_b, zU_b = state.duals
+        zL = jnp.asarray(zL_b, dtype=jnp.float64).reshape(B, n)
+        zU = jnp.asarray(zU_b, dtype=jnp.float64).reshape(B, n)
+
+        def _bound(arr, fill):
+            if arr is None:
+                return jnp.full((B, n), fill, dtype=jnp.float64)
+            a = jnp.asarray(arr, dtype=jnp.float64)
+            return jnp.broadcast_to(a, (B, n))
+
+        lb = _bound(self._lb, -INF)
+        ub = _bound(self._ub, INF)
+
+        # Lower / upper bounds: active → its multiplier is the margin;
+        # inactive → its slack (x − lb / ub − x) is the margin.
+        act_L = zL > active_tol
+        act_U = zU > active_tol
+        mult_L = jnp.where(act_L, zL, INF)
+        mult_U = jnp.where(act_U, zU, INF)
+        slack_L = jnp.where(act_L, INF, x - lb)
+        slack_U = jnp.where(act_U, INF, ub - x)
+
+        mult_cols = [mult_L, mult_U]
+        slack_cols = [slack_L, slack_U]
+
+        if m > 0:
+            lam = jnp.asarray(lam_b, dtype=jnp.float64).reshape(B, m)
+            cl = jnp.asarray(self._cl_for_classify, dtype=jnp.float64)
+            cu = jnp.asarray(self._cu_for_classify, dtype=jnp.float64)
+            is_ineq = (cl != cu)[None, :]                         # (1, m)
+            p_batch = jnp.asarray(state._p_batch, dtype=jnp.float64)
+            g_val = jax.vmap(self._g_jit, in_axes=(0, 0))(x, p_batch)  # (B, m)
+            # Two-sided slack: the binding side; the ±inf side drops out.
+            ineq_slack = jnp.minimum(g_val - cl[None, :], cu[None, :] - g_val)
+            act_g = is_ineq & (jnp.abs(lam) > active_tol)
+            inact_g = is_ineq & ~act_g
+            mult_cols.append(jnp.where(act_g, jnp.abs(lam), INF))
+            slack_cols.append(jnp.where(inact_g, ineq_slack, INF))
+
+        min_mult = jnp.min(jnp.concatenate(mult_cols, axis=1), axis=1)   # (B,)
+        min_slack = jnp.min(jnp.concatenate(slack_cols, axis=1), axis=1)  # (B,)
+        margin = jnp.minimum(min_mult, min_slack)
+        return {"margin": margin, "min_mult": min_mult, "min_slack": min_slack}
+
     # ----- custom_vjp factories -----
 
     def _solve_fn(self):

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -52,6 +52,7 @@ rationale on the bounded LRU.
 from __future__ import annotations
 
 import itertools
+import math
 import threading
 import warnings
 import weakref
@@ -740,9 +741,16 @@ def _kkt_jvp_batched_pure_callback(
     Inputs are per-block, leading-batch (``rhs_x_batch (B, n)``,
     ``rhs_g_batch (B, m)``); ``vmap_method="broadcast_all"`` also accepts
     a leading direction axis so the JVP can be vmapped over several
-    ``dp`` directions in one FFI hop. Returns ``w_x_batch (B, n)``.
+    ``dp`` directions in one FFI hop. Returns ``(w_x_batch (B, n),
+    w_g_batch (B, m))`` — the primal block and the constraint-multiplier
+    block of ``w`` (the latter scattered back to user-g order), so the
+    caller can form both ``J @ dp = -w_x`` and the dual sensitivity
+    ``∂λ*/∂θ · dp = -w_g`` (pounce#90 predicts the duals too).
     """
-    result_shapes = jax.ShapeDtypeStruct((B, n), jnp.float64)
+    result_shapes = (
+        jax.ShapeDtypeStruct((B, n), jnp.float64),
+        jax.ShapeDtypeStruct((B, m), jnp.float64),
+    )
 
     def host_call(sid_h, rx_h, rg_h):
         sid_int = int(np.asarray(sid_h).reshape(-1)[0])
@@ -805,13 +813,34 @@ def _kkt_jvp_batched_pure_callback(
                 solver.kkt_solve_many(rhs_flat.reshape(-1), N),
                 dtype=np.float64,
             ).reshape(N, kkt_dim_)
-            return n_x_, w_flat
+            return n_x_, n_s_, n_y_c_, n_y_d_, w_flat
 
-        n_x, w_mat = jp._run_pinned(_do_kkt)
+        n_x, n_s, n_y_c, n_y_d, w_mat = jp._run_pinned(_do_kkt)
         w_x_batch = w_mat[:, :n_x].reshape(N, B, n).copy()
+
+        # De-interleave the constraint-multiplier blocks (block-major,
+        # like the reverse path) and scatter back to user-g order.
+        w_g_batch = np.zeros((N, B, m), dtype=np.float64)
+        if m > 0:
+            cl_arr = jp._cl_for_classify
+            cu_arr = jp._cu_for_classify
+            is_eq = cl_arr == cu_arr
+            n_c_per = int(np.sum(is_eq))
+            y_c_off = n_x + n_s
+            y_d_off = y_c_off + n_y_c
+            if n_c_per > 0:
+                w_y_c = w_mat[:, y_c_off : y_c_off + n_y_c].reshape(
+                    N, B, n_c_per
+                )
+                w_g_batch[:, :, np.flatnonzero(is_eq)] = w_y_c
+            if (m - n_c_per) > 0:
+                w_y_d = w_mat[:, y_d_off : y_d_off + n_y_d].reshape(
+                    N, B, m - n_c_per
+                )
+                w_g_batch[:, :, np.flatnonzero(~is_eq)] = w_y_d
         if squeeze:
-            return w_x_batch[0]
-        return w_x_batch
+            return w_x_batch[0], w_g_batch[0]
+        return w_x_batch, w_g_batch
 
     return jax.pure_callback(
         host_call, result_shapes, sid, rhs_x_batch, rhs_g_batch,
@@ -1447,6 +1476,24 @@ class JaxProblem:
             self._tls.pair_warm = cached
         return cached
 
+    def _thread_problem_corrector(self) -> tuple[_ReusableJaxNlp, Problem]:
+        """Per-thread warm-started Problem dedicated to the
+        predictor–corrector engine's corrector (pounce#90).
+
+        Separate from :meth:`_thread_problem_warm` because the corrector
+        sets the barrier-μ options (``mu_init`` / ``warm_start_target_mu``)
+        per call (pounce#86); keeping its own cached Problem prevents
+        those numeric options from leaking into the differentiable
+        ``solve_with_warm`` path that shares ``pair_warm``.
+        """
+        cached = getattr(self._tls, "pair_corrector", None)
+        if cached is None:
+            obj, prob = self._build_problem()
+            prob.add_option("warm_start_init_point", "yes")
+            cached = (obj, prob)
+            self._tls.pair_corrector = cached
+        return cached
+
     def _thread_stacked_problem_warm(self, B: int) -> tuple[_StackedJaxNlp, Problem]:
         """Per-thread LRU of *warm-started* stacked Problems keyed by
         batch size B (pounce#78). Mirrors :meth:`_thread_stacked_problem`
@@ -2040,6 +2087,100 @@ class JaxProblem:
         x_star, duals, sid, (pb, xs, lam) = self._anchor_forward(p_arr, x0)
         return AnchorState(self, sid, pb.shape[0], pb, xs, lam, duals, cols)
 
+    def warm_anchor(self, p, x0, *, duals=None, mu=None, wrt_cols=None):
+        """Warm-started, barrier-μ-seeded re-solve that *also* pins the
+        converged factor — the corrector + anchor of predictor–corrector
+        path following in one solve (pounce#90).
+
+        Composes the family's primitives: it warm-starts the primal
+        (``x0``), the duals (``duals=(lam, zL, zU)``), and the barrier μ
+        (pounce#86), then holds the converged KKT factor as a ``B=1``
+        :class:`AnchorState` so the next predictor's
+        :meth:`jvp_from_state` / :meth:`sensitivity` reuse it with no
+        further solve. A single NLP solve serves both the correction and
+        the next anchor.
+
+        Not differentiable — this is the host-side engine corrector, not
+        a ``custom_vjp`` surface (use :func:`solve_with_warm` /
+        :meth:`solve_with_jacobian` for differentiable warm solves).
+
+        Parameters
+        ----------
+        p : ``p_shape``
+            Parameter value (single, un-batched).
+        x0 : ``(n,)``
+            Primal warm start (e.g. the predictor's extrapolated point).
+        duals : ``(lam, zL, zU)`` or None
+            Dual warm start. ``None`` starts the duals from zero (the
+            uninformed first/anchor call).
+        mu : float or None
+            Barrier-μ seed (pounce#86). ``None`` uses the solver default
+            initial μ. Thread the previous step's converged μ
+            (``info["mu"]``) here to resume near the central path.
+        wrt_cols : slice / index array / None
+            Parameter-column selection carried on the returned state.
+
+        Returns
+        -------
+        ``(state, info)`` — a ``B=1`` :class:`AnchorState` (with
+        ``state.duals`` the converged ``(lam, zL, zU)``) and the solve
+        ``info`` dict (``info["mu"]``, ``info["iter_count"]``,
+        ``info["status_msg"]``, …). Close the state when done (or let the
+        engine swap it via re-anchor).
+        """
+        n, m = self._n, self._m
+        cols = self._normalize_cols(wrt_cols)
+        p_arr = jnp.asarray(p, dtype=jnp.float64)
+        if p_arr.ndim != len(self._p_shape):
+            raise ValueError(
+                "pounce.jax: warm_anchor takes a single (un-batched) p; "
+                f"got shape {p_arr.shape} for p_shape {self._p_shape}."
+            )
+        x0_np = np.asarray(x0, dtype=np.float64)
+        if duals is None:
+            lam_np = np.zeros(m, dtype=np.float64)
+            zL_np = np.zeros(n, dtype=np.float64)
+            zU_np = np.zeros(n, dtype=np.float64)
+        else:
+            lam_in, zL_in, zU_in = duals
+            lam_np = np.asarray(lam_in, dtype=np.float64)
+            zL_np = np.asarray(zL_in, dtype=np.float64)
+            zU_np = np.asarray(zU_in, dtype=np.float64)
+        mu_f = float("nan") if mu is None else float(mu)
+
+        self._check_pinned_capacity()
+        p_host = np.asarray(p_arr)
+
+        def _do():
+            obj, prob = self._thread_problem_corrector()
+            obj._p = jnp.asarray(p_host)
+            # Barrier-μ seed (pounce#86). Always set explicitly so a
+            # prior call's value never lingers on the cached Problem;
+            # NaN/None → restore the solver defaults.
+            if math.isfinite(mu_f):
+                prob.add_option("mu_init", mu_f)
+                prob.add_option("warm_start_target_mu", mu_f)
+            else:
+                prob.add_option("mu_init", 0.1)
+                prob.add_option("warm_start_target_mu", 0.0)
+            solver = Solver(prob)
+            x_np, info = solver.solve(
+                x0=x0_np, lagrange=lam_np, zl=zL_np, zu=zU_np,
+            )
+            sid = self._register_pinned_solver(solver)
+            return x_np, info, sid
+
+        x_np, info, sid = self._run_pinned(_do)
+        x_star = jnp.asarray(x_np, dtype=jnp.float64)[None]
+        lam_out = jnp.asarray(info["mult_g"], dtype=jnp.float64)[None]
+        zL_out = jnp.asarray(info["mult_x_L"], dtype=jnp.float64)[None]
+        zU_out = jnp.asarray(info["mult_x_U"], dtype=jnp.float64)[None]
+        duals_out = (lam_out, zL_out, zU_out)
+        state = AnchorState(
+            self, sid, 1, p_arr[None], x_star, lam_out, duals_out, cols,
+        )
+        return state, dict(info)
+
     def batched_solve_with_jacobian(
         self,
         p_batch,
@@ -2144,7 +2285,8 @@ class JaxProblem:
         )
         return self._slice_cols(dp, state._wrt_cols)
 
-    def batched_jvp_from_state(self, state: AnchorState, dp_batch):
+    def batched_jvp_from_state(self, state: AnchorState, dp_batch, *,
+                               with_duals: bool = False):
         """Jacobian-vector product ``J @ dp`` against a held factor
         (pounce#82 Phase 2). The cheap path for linear updates: it never
         materialises the full ``J`` — only the directional sensitivity
@@ -2169,7 +2311,10 @@ class JaxProblem:
 
         Returns
         -------
-        ``(B, n)`` — the per-block primal sensitivity ``delta_x``.
+        ``(B, n)`` — the per-block primal sensitivity ``delta_x``. With
+        ``with_duals=True``, returns ``(delta_x (B, n), delta_lam
+        (B, m))`` where ``delta_lam = ∂λ*/∂θ · dp`` — used by the
+        path-following predictor to step the multipliers too (pounce#90).
         """
         if state._jp is not self:
             raise ValueError(
@@ -2219,9 +2364,11 @@ class JaxProblem:
             return r_x, r_g
 
         r_x_batch, r_g_batch = jax.vmap(per_block)(p_batch, x_star, lam, dp)
-        w_x = _kkt_jvp_batched_pure_callback(
+        w_x, w_g = _kkt_jvp_batched_pure_callback(
             self, state._B, state._sid, r_x_batch, r_g_batch, n, m,
         )
+        if with_duals:
+            return -w_x, -w_g
         return -w_x
 
     def sensitivity_at(self, x_star, theta, duals, *, wrt_cols=None):
@@ -2369,13 +2516,19 @@ class JaxProblem:
         J = jnp.transpose(J_rows, (1, 0, 2))      # (1, n, p_dim)
         return self._slice_cols(J, state._wrt_cols)[0]
 
-    def jvp_from_state(self, state: "AnchorState", dp):
+    def jvp_from_state(self, state: "AnchorState", dp, *, with_duals: bool = False):
         """Single-problem :meth:`batched_jvp_from_state` — ``J @ dp`` for
         a state anchored at one point. ``dp`` has shape ``p_shape`` (or
         ``(len(wrt_cols),)`` if the state was anchored with ``wrt_cols``)
-        and the result is ``(n,)`` (pounce#88)."""
+        and the result is ``(n,)`` (pounce#88).
+
+        With ``with_duals=True`` returns ``(dx (n,), dlam (m,))`` — the
+        primal and dual sensitivity steps (pounce#90)."""
         self._require_single(state, "jvp_from_state")
         dp1 = jnp.asarray(dp, dtype=jnp.float64)[None]
+        if with_duals:
+            dx, dlam = self.batched_jvp_from_state(state, dp1, with_duals=True)
+            return dx[0], dlam[0]
         return self.batched_jvp_from_state(state, dp1)[0]
 
     def vjp_from_state(self, state: "AnchorState", x_bar):
@@ -2436,12 +2589,23 @@ class JaxProblem:
           *entering* the active set); ``inf`` when nothing is inactive
           with a finite bound.
         """
-        n, m = self._n, self._m
         B = state._B
+        lam_b, zL_b, zU_b = state.duals
+        return self._margin_arrays(
+            state._x_star, lam_b, zL_b, zU_b, state._p_batch, B,
+            active_tol=active_tol,
+        )
+
+    def _margin_arrays(self, x_b, lam_b, zL_b, zU_b, p_b, B, *,
+                       active_tol=_ACTIVE_TOL):
+        """Active-set margin from explicit ``(B, ·)`` primal/dual arrays
+        (pounce#89). Shared by :meth:`active_set_margin` (held state) and
+        the path-following monitor, which evaluates the margin at a
+        *predicted* point that has no anchored state yet (pounce#90)."""
+        n, m = self._n, self._m
         INF = jnp.inf
 
-        x = jnp.asarray(state._x_star, dtype=jnp.float64).reshape(B, n)
-        lam_b, zL_b, zU_b = state.duals
+        x = jnp.asarray(x_b, dtype=jnp.float64).reshape(B, n)
         zL = jnp.asarray(zL_b, dtype=jnp.float64).reshape(B, n)
         zU = jnp.asarray(zU_b, dtype=jnp.float64).reshape(B, n)
 
@@ -2471,7 +2635,9 @@ class JaxProblem:
             cl = jnp.asarray(self._cl_for_classify, dtype=jnp.float64)
             cu = jnp.asarray(self._cu_for_classify, dtype=jnp.float64)
             is_ineq = (cl != cu)[None, :]                         # (1, m)
-            p_batch = jnp.asarray(state._p_batch, dtype=jnp.float64)
+            p_batch = jnp.asarray(p_b, dtype=jnp.float64).reshape(
+                (B,) + self._p_shape
+            )
             g_val = jax.vmap(self._g_jit, in_axes=(0, 0))(x, p_batch)  # (B, m)
             # Two-sided slack: the binding side; the ±inf side drops out.
             ineq_slack = jnp.minimum(g_val - cl[None, :], cu[None, :] - g_val)

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -2214,6 +2214,85 @@ class JaxProblem:
         )
         return -w_x
 
+    def sensitivity_at(self, x_star, theta, duals, *, wrt_cols=None):
+        """Exact ``∂x*/∂θ`` at a **supplied** primal-dual point — by
+        re-assembling and factoring the KKT *there*, with no IPM
+        re-solve (pounce#87).
+
+        Use this to refresh the sensitivity at a known point along a
+        path — e.g. the inverse map where ``x*`` traces a known output
+        boundary — where the requested point is not the one the solver
+        last converged at.
+
+        Why re-factor rather than reuse a held factor. The held FERAL
+        factor from :meth:`anchor` / :meth:`batched_solve_with_jacobian`
+        encodes the Hessian / Jacobian at the *anchor* point, so
+        back-solving it at a moved ``x_star`` returns a first-order-stale
+        sensitivity. This method instead assembles the dense
+        ``(n+m)×(n+m)`` KKT block at the supplied ``(x_star, duals,
+        theta)`` and solves it, which is **exact** at that point
+        (assuming it is a KKT point for ``theta``). The cost is one
+        dense factorisation per call — fine for the small/medium NLPs
+        path-following targets. It stays pure-JAX, so it is itself
+        differentiable (second-order sensitivities work).
+
+        The reuse path (cheap, locally valid, stale once the point
+        moves) is the predictor :meth:`batched_jvp_from_state` against a
+        held factor; this method is the exact-refresh complement.
+
+        Parameters
+        ----------
+        x_star : ``(n,)``
+            Primal point to evaluate at — must be (within the backward's
+            ``active_tol``) a KKT point for ``theta``.
+        theta : ``p_shape``
+            Parameter value.
+        duals : ``(lam, zL, zU)``
+            Multipliers at ``x_star``: equality/inequality multipliers
+            ``lam`` ``(m,)`` and bound multipliers ``zL`` / ``zU``
+            ``(n,)``. The active set is read from ``zL`` / ``zU`` exactly
+            as the ``custom_vjp`` backward does, so pass the values the
+            anchoring solve / :func:`solve_with_warm` returned at this
+            point.
+        wrt_cols : slice / index array / None
+            Parameter-column selection (1-D ``theta`` only), same
+            contract as :meth:`batched_solve_with_jacobian`.
+
+        Returns
+        -------
+        ``(n, p_dim)`` (or ``(n, len(wrt_cols))``) — the primal
+        sensitivity ``∂x*/∂θ`` at the supplied point.
+        """
+        f, g, n, m = self._f, self._g, self._n, self._m
+        cl, cu = self._cl, self._cu
+        cols = self._normalize_cols(wrt_cols)
+        x_star = jnp.asarray(x_star, dtype=jnp.float64)
+        theta = jnp.asarray(theta, dtype=jnp.float64)
+        if len(duals) != 3:
+            raise ValueError(
+                "pounce.jax: sensitivity_at requires duals=(lam, zL, zU); "
+                f"got a {len(duals)}-tuple."
+            )
+        lam, zL, zU = duals
+        lam = jnp.asarray(lam, dtype=jnp.float64)
+        zL = jnp.asarray(zL, dtype=jnp.float64)
+        zU = jnp.asarray(zU, dtype=jnp.float64)
+
+        # Row i of J is the VJP with cotangent e_i (the KKT is
+        # symmetric), so vmapping the single-point KKT backward over the
+        # identity output basis recovers the full Jacobian. XLA shares
+        # the dense factorisation across the n right-hand sides — one
+        # assemble-and-factor, n back-substitutions.
+        basis = jnp.eye(n, dtype=jnp.float64)
+
+        def jac_row(e_i):
+            return _bwd_single_kkt(
+                f, g, n, m, cl, cu, theta, x_star, lam, zL, zU, e_i,
+            )
+
+        J = jax.vmap(jac_row)(basis)          # (n,) + p_shape
+        return self._slice_cols(J, cols)
+
     # ----- custom_vjp factories -----
 
     def _solve_fn(self):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -38,6 +38,9 @@ pounce = "pounce._cli:main"
 [project.optional-dependencies]
 jax = ["jax>=0.4.30", "jaxlib>=0.4.30"]
 scipy = ["scipy>=1.11"]
+# diffrax is only needed to run the inverse-map ODE example/recipe
+# (pounce#91); the inverse_map_rhs helper itself depends only on jax.
+diffrax = ["diffrax>=0.5"]
 dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30"]
 
 [project.urls]

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -2122,3 +2122,36 @@ def test_pathfollower_corrector_failed_status_pounce_90():
     pf = PathFollower(jp, monitor_tol=1e-6, ds0=0.5, ds_min=0.4, shrink=0.5)
     tr = pf.follow(theta, (0.0, 1.0), jnp.zeros(2))
     assert tr.status == "corrector_failed"
+
+
+def test_inverse_map_rhs_warm_matches_cold_pounce_91():
+    """Issue #91: warm=True changes only the inner solve's starting point,
+    not the result — the warm and cold inverse maps agree up to solver
+    tolerance, and warm is jittable."""
+    from pounce.jax import JaxProblem, inverse_map_rhs
+
+    def f(x, p):
+        return (x[0] - p[0]) ** 2 + 0.05 * x[0] ** 4
+
+    jp = JaxProblem(
+        f=f, g=None, n=1, m=0, p_example=jnp.zeros(1),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+
+    def y_of_s(s):
+        return jnp.array([0.5 + 0.3 * jnp.sin(2 * jnp.pi * s)])
+
+    def dy_ds(s):
+        return jnp.array([0.3 * 2 * jnp.pi * jnp.cos(2 * jnp.pi * s)])
+
+    y0 = float(y_of_s(0.0)[0])
+    theta0 = jnp.array([y0 + 0.1 * y0 ** 3])
+
+    TH_cold = _rk4(inverse_map_rhs(jp, dy_ds, warm=False), theta0, n_steps=120)
+    TH_warm = _rk4(inverse_map_rhs(jp, dy_ds, warm=True), theta0, n_steps=120)
+    assert float(np.max(np.abs(TH_cold - TH_warm))) < 1e-6
+
+    # Still jittable with the warm cache in the loop.
+    rhs_w = inverse_map_rhs(jp, dy_ds, warm=True)
+    jit_val = jax.jit(rhs_w)(0.3, theta0)
+    assert np.all(np.isfinite(np.asarray(jit_val)))

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1709,3 +1709,227 @@ def test_batched_jvp_rejects_closed_and_foreign_state_pounce_82():
     with jp1.anchor(p_batch, x0) as state:
         with pytest.raises(ValueError, match="different"):
             jp2.batched_jvp_from_state(state, jnp.zeros((2, 2)))
+
+
+# ----- predictor–corrector path following (pounce#90) -----
+
+
+def _circle_theta(s, c=0.5, r=0.4):
+    import jax.numpy as _jnp
+    ang = 2.0 * _jnp.pi * s
+    return _jnp.array([c + r * _jnp.cos(ang), r * _jnp.sin(ang)])
+
+
+def test_pathfollower_linear_qp_zero_correctors_pounce_90():
+    """Issue #90: on a linear-response NLP the sensitivity predictor is
+    exact, so the monitor accepts every step and the engine traces the
+    whole path with ZERO correctors (one anchor solve vs one cold solve
+    per step). Closes the loop and matches the per-point solver."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp, monitor_tol=1e-6, ds0=0.05)
+    tr = pf.follow(_circle_theta, (0.0, 1.0), jnp.zeros(2))
+
+    assert tr.status == "ok"
+    assert tr.n_correctors == 0          # predictor exact → no re-solves
+    assert tr.n_accepts == tr.n_steps
+    # Closed loop: end returns to start.
+    np.testing.assert_allclose(tr.x[0], tr.x[-1], atol=1e-9)
+    # Every traced point is the true optimum at its θ.
+    for k in range(len(tr.s)):
+        x_true, *_ = jp.solve_with_jacobian(jnp.asarray(tr.theta[k]), jnp.zeros(2))
+        np.testing.assert_allclose(tr.x[k], np.asarray(x_true), atol=1e-7)
+
+
+def test_pathfollower_nonlinear_traces_accurately_pounce_90():
+    """Issue #90: a nonlinear NLP traces accurately via correction; the
+    engine never does more solves than one-per-step."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2) + 0.1 * jnp.sum(x ** 4)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp, monitor_tol=1e-5, ds0=0.02, ds_max=0.1)
+    tr = pf.follow(_circle_theta, (0.0, 1.0), jnp.zeros(2))
+
+    assert tr.status == "ok"
+    assert tr.n_correctors <= tr.n_steps
+    for k in range(len(tr.s)):
+        x_true, *_ = jp.solve_with_jacobian(jnp.asarray(tr.theta[k]), jnp.zeros(2))
+        np.testing.assert_allclose(tr.x[k], np.asarray(x_true), atol=1e-6)
+
+
+def test_pathfollower_skips_solves_pounce_90():
+    """Issue #90: with a loose monitor tolerance the predictor carries
+    several steps between corrections — strictly fewer solves than the
+    naive one-cold-solve-per-step baseline."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2) + 0.02 * jnp.sum(x ** 4)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp, monitor_tol=1e-3, ds0=0.05, ds_max=0.1)
+    tr = pf.follow(_circle_theta, (0.0, 1.0), jnp.zeros(2))
+
+    assert tr.status == "ok"
+    assert tr.n_accepts > 0
+    # Total NLP solves = 1 anchor + n_correctors; naive = n_steps + 1.
+    assert (1 + tr.n_correctors) < (tr.n_steps + 1)
+    for k in range(len(tr.s)):
+        x_true, *_ = jp.solve_with_jacobian(jnp.asarray(tr.theta[k]), jnp.zeros(2))
+        np.testing.assert_allclose(tr.x[k], np.asarray(x_true), atol=2e-3)
+
+
+def test_pathfollower_active_set_change_pounce_90():
+    """Issue #90: a path that drives a bound in and out of the active set
+    is traced correctly, the change is detected/recorded, and the engine
+    re-anchors on the new active set (no stepping through the
+    discontinuity)."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    # Upper bound on x0 binds over part of the circle.
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.array([0.6, 10.0]),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp, monitor_tol=1e-6, active_margin_tol=1e-3, ds0=0.03)
+    tr = pf.follow(_circle_theta, (0.0, 1.0), jnp.zeros(2))
+
+    assert tr.status == "ok"
+    assert len(tr.active_set_changes) >= 2   # bound activates then releases
+    for k in range(len(tr.s)):
+        x_true, *_ = jp.solve_with_jacobian(jnp.asarray(tr.theta[k]), jnp.zeros(2))
+        np.testing.assert_allclose(tr.x[k], np.asarray(x_true), atol=1e-6)
+        assert tr.x[k][0] <= 0.6 + 1e-7      # respects the bound
+
+
+def test_trace_arclength_cubic_fold_pounce_90():
+    """Issue #90: pseudo-arclength continuation traces a cubic fold curve
+    past both turning points (where ∂x*/∂θ is singular), which parameter
+    continuation cannot. Stationarity of f = x⁴/4 − x²/2 − θx gives
+    θ = x³ − x, folds at x = ±1/√3 → θ = ∓0.3849."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        th = p[0]
+        return x[0] ** 4 / 4.0 - x[0] ** 2 / 2.0 - th * x[0]
+
+    jp = JaxProblem(
+        f=f, g=None, n=1, m=0, p_example=jnp.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp)
+    tr = pf.trace_arclength(jnp.array([-1.3]), -0.4, ds=0.05, n_steps=120,
+                            direction=1.0)
+
+    assert tr.status == "ok"
+    # Two folds detected near |θ| = 1/√3·(2/3) = 0.3849.
+    assert len(tr.turning_points) == 2
+    fold_mag = sorted(abs(t) for t in tr.turning_points)
+    np.testing.assert_allclose(fold_mag, [0.3849, 0.3849], atol=5e-3)
+    # The traced curve actually satisfies stationarity θ = x³ − x.
+    resid = tr.theta - (tr.x[:, 0] ** 3 - tr.x[:, 0])
+    assert float(np.max(np.abs(resid))) < 1e-7
+    # It passes the fold: x sweeps from below −1/√3 to above +1/√3.
+    assert tr.x[:, 0].min() < -0.7 and tr.x[:, 0].max() > 0.7
+
+
+def test_jvp_from_state_with_duals_pounce_90():
+    """Issue #90: jvp_from_state(with_duals=True) returns the dual
+    sensitivity ∂λ*/∂θ·dp. For f=Σ(x−p)² s.t. x0+x1=1, λ*(p)=p0+p1−1, so
+    ∂λ/∂p=[1,1] and the dual step equals dp0+dp1."""
+    from pounce.jax import JaxProblem
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    state, _ = jp.warm_anchor(jnp.array([0.3, 0.7]), jnp.zeros(2))
+    dp = jnp.array([0.1, -0.05])
+    dx, dlam = jp.jvp_from_state(state, dp, with_duals=True)
+    assert dx.shape == (2,) and dlam.shape == (1,)
+    np.testing.assert_allclose(np.asarray(dlam), [float(dp[0] + dp[1])], atol=1e-6)
+    # Primal-only call still returns just dx (backward compatible).
+    dx_only = jp.jvp_from_state(state, dp)
+    np.testing.assert_allclose(np.asarray(dx_only), np.asarray(dx), atol=1e-12)
+    state.close()
+
+
+def test_warm_anchor_corrector_uses_mu_pounce_90():
+    """Issue #90/#86: warm_anchor seeds μ and warm duals; a corrector
+    from a near-optimal point with the previous μ converges in fewer
+    iterations than a cold anchor."""
+    from pounce.jax import JaxProblem
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2) + 0.05 * jnp.sum(x ** 4)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    st0, i0 = jp.warm_anchor(jnp.array([0.3, 0.7]), jnp.zeros(2))
+    duals0 = tuple(np.asarray(d[0]) for d in st0.duals)
+    # Corrector at a nearby θ from the (near-optimal) previous primal +
+    # duals + μ.
+    st1, i1 = jp.warm_anchor(
+        jnp.array([0.32, 0.68]), st0.x_star[0],
+        duals=duals0, mu=i0["mu"],
+    )
+    assert i1["status_msg"] in ("Solve_Succeeded", "Solved_To_Acceptable_Level")
+    assert i1["iter_count"] <= i0["iter_count"]
+    # The corrected point is the true optimum.
+    x_true, *_ = jp.solve_with_jacobian(jnp.array([0.32, 0.68]), jnp.zeros(2))
+    np.testing.assert_allclose(np.asarray(st1.x_star[0]), np.asarray(x_true), atol=1e-6)
+    st0.close(); st1.close()

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1933,3 +1933,120 @@ def test_warm_anchor_corrector_uses_mu_pounce_90():
     x_true, *_ = jp.solve_with_jacobian(jnp.array([0.32, 0.68]), jnp.zeros(2))
     np.testing.assert_allclose(np.asarray(st1.x_star[0]), np.asarray(x_true), atol=1e-6)
     st0.close(); st1.close()
+
+
+# ----- inverse-map ODE recipe (pounce#91) -----
+
+
+def test_jaxproblem_unconstrained_build_once_pounce_91():
+    """Issue #91 (prereq): the build-once / stacked path handles an
+    unconstrained problem (g=None, m=0) — the constraint callbacks must
+    not dereference the (None) jacobian jit."""
+    from pounce.jax import JaxProblem
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2) + 0.05 * jnp.sum(x ** 4)
+
+    jp = JaxProblem(
+        f=f, g=None, n=2, m=0, p_example=jnp.zeros(2),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    theta = jnp.array([0.4, -0.3])
+    x_star, duals, J = jp.solve_with_jacobian(theta, jnp.zeros(2))
+    Jref = jax.jacobian(lambda p: jp.solve(p, jnp.zeros(2)))(theta)
+    np.testing.assert_allclose(np.asarray(J), np.asarray(Jref), atol=1e-6)
+    assert duals[0].shape == (0,)        # no equality multipliers
+
+
+def _rk4(rhs, theta0, n_steps=160):
+    h = 1.0 / n_steps
+    th = jnp.asarray(theta0, dtype=jnp.float64)
+    out = [np.asarray(th)]
+    for i in range(n_steps):
+        s = i * h
+        k1 = rhs(s, th)
+        k2 = rhs(s + h / 2, th + h / 2 * k1)
+        k3 = rhs(s + h / 2, th + h / 2 * k2)
+        k4 = rhs(s + h, th + h * k3)
+        th = th + h / 6 * (k1 + 2 * k2 + 2 * k3 + k4)
+        out.append(np.asarray(th))
+    return np.asarray(out)
+
+
+def test_inverse_map_rhs_round_trip_pounce_91():
+    """Issue #91: integrating dθ/ds = (∂x*/∂θ)^{-1} dy/ds along a closed
+    output loop recovers the input path and round-trips back through the
+    optimizer onto the output boundary. For f=(x−θ)²+0.05x⁴ the inverse
+    map is explicit (θ = y + 0.1y³, since x*=y), giving an analytic
+    cross-check."""
+    from pounce.jax import JaxProblem, inverse_map_rhs
+
+    def f(x, p):
+        return (x[0] - p[0]) ** 2 + 0.05 * x[0] ** 4
+
+    jp = JaxProblem(
+        f=f, g=None, n=1, m=0, p_example=jnp.zeros(1),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+
+    def y_of_s(s):
+        return jnp.array([0.5 + 0.3 * jnp.sin(2 * jnp.pi * s)])
+
+    def dy_ds(s):
+        return jnp.array([0.3 * 2 * jnp.pi * jnp.cos(2 * jnp.pi * s)])
+
+    rhs = inverse_map_rhs(jp, dy_ds)               # output = identity
+
+    y0 = float(y_of_s(0.0)[0])
+    theta0 = jnp.array([y0 + 0.1 * y0 ** 3])       # x*(θ0) = y0
+    TH = _rk4(rhs, theta0, n_steps=160)            # (K, 1)
+
+    S = np.linspace(0.0, 1.0, TH.shape[0])
+    ys = 0.5 + 0.3 * np.sin(2 * np.pi * S)
+    theta_analytic = ys + 0.1 * ys ** 3
+
+    # Integrated input path matches the explicit inverse map.
+    assert float(np.max(np.abs(TH[:, 0] - theta_analytic))) < 1e-5
+    # Closed output loop ⇒ closed input loop.
+    assert abs(TH[-1, 0] - TH[0, 0]) < 1e-6
+    # Round-trip: pushing θ(s) back through the optimizer recovers y(s).
+    rt = 0.0
+    for k in range(0, len(S), 16):
+        x_star, *_ = jp.solve_with_jacobian(jnp.array([TH[k, 0]]), jnp.zeros(1))
+        rt = max(rt, abs(float(x_star[0]) - ys[k]))
+    assert rt < 1e-5
+
+
+def test_inverse_map_rhs_requires_1d_theta_pounce_91():
+    """Issue #91: the inverse-map RHS is defined for a 1-D parameter."""
+    from pounce.jax import JaxProblem, inverse_map_rhs
+
+    def f(x, p):
+        return jnp.sum((x - p.reshape(-1)) ** 2)
+
+    jp = JaxProblem(
+        f=f, g=None, n=4, m=0, p_example=jnp.zeros((2, 2)),
+        options={"print_level": 0, "sb": "yes"},
+    )
+    with pytest.raises(ValueError, match="1-D"):
+        inverse_map_rhs(jp, jnp.zeros(4))
+
+
+def test_inverse_map_rhs_is_jittable_pounce_91():
+    """Issue #91: the RHS composes under jax.jit (the solve rides a
+    pure_callback) — diffrax jit-compiles the vector field, so an
+    eager-only RHS would break integration."""
+    from pounce.jax import JaxProblem, inverse_map_rhs
+
+    def f(x, p):
+        return (x[0] - p[0]) ** 2 + 0.05 * x[0] ** 4
+
+    jp = JaxProblem(
+        f=f, g=None, n=1, m=0, p_example=jnp.zeros(1),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+    rhs = inverse_map_rhs(jp, lambda s: jnp.array([1.0]))
+    theta = jnp.array([0.5])
+    eager = rhs(0.3, theta)
+    jitted = jax.jit(rhs)(0.3, theta)
+    np.testing.assert_allclose(np.asarray(jitted), np.asarray(eager), atol=1e-9)

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1244,6 +1244,63 @@ def test_batched_solve_with_jacobian_wrt_cols_pounce_82():
     np.testing.assert_allclose(np.asarray(Jidx), np.asarray(J0), atol=1e-12)
 
 
+@pytest.mark.parametrize("bounded", [False, True])
+def test_sensitivity_at_matches_jacobian_pounce_87(bounded):
+    """Issue #87: exact ``∂x*/∂θ`` re-factored at a supplied point must
+    equal the ground-truth ``jax.jacobian`` over a fresh solve — at the
+    solver's own converged point and at *other* parameter values along a
+    path. Covers a binding upper bound so the active-set read off the
+    supplied bound multipliers is exercised."""
+    jp = _build_jac_qp(bounded=bounded)
+    x0 = jnp.zeros(2)
+
+    # Sweep several θ as if walking a path. For each, get the converged
+    # primal + duals, then re-factor the sensitivity at that supplied
+    # point with no held factor in play.
+    for theta in (jnp.array([0.3, 0.7]),
+                  jnp.array([0.5, 0.5]),
+                  jnp.array([-0.1, 0.4])):
+        x_star, (lam, zL, zU), _ = jp.batched_solve_with_jacobian(
+            theta[None, :], x0,
+        )
+        J = jp.sensitivity_at(
+            x_star[0], theta, (lam[0], zL[0], zU[0]),
+        )
+        # Ground truth: jacobian through a single solve at this θ.
+        Jref = jax.jacobian(lambda p: jp.solve(p, x0))(theta)
+        assert J.shape == (2, 2)
+        np.testing.assert_allclose(np.asarray(J), np.asarray(Jref), atol=1e-6)
+
+
+def test_sensitivity_at_wrt_cols_pounce_87():
+    """Issue #87: ``wrt_cols`` selects parameter columns of the
+    re-factored sensitivity, matching the corresponding slice."""
+    jp = _build_jac_qp()
+    x0 = jnp.zeros(2)
+    theta = jnp.array([0.3, 0.7])
+    x_star, (lam, zL, zU), _ = jp.batched_solve_with_jacobian(theta[None, :], x0)
+    duals = (lam[0], zL[0], zU[0])
+
+    J = jp.sensitivity_at(x_star[0], theta, duals)
+    J0 = jp.sensitivity_at(x_star[0], theta, duals, wrt_cols=slice(0, 1))
+    assert J0.shape == (2, 1)
+    np.testing.assert_allclose(np.asarray(J0), np.asarray(J[:, :1]), atol=1e-12)
+
+    Jidx = jp.sensitivity_at(x_star[0], theta, duals, wrt_cols=[1])
+    np.testing.assert_allclose(np.asarray(Jidx), np.asarray(J[:, 1:2]), atol=1e-12)
+
+
+def test_sensitivity_at_requires_dual_triple_pounce_87():
+    """Issue #87: the duals argument must be the full ``(lam, zL, zU)``
+    triple — the active set is read from the bound multipliers."""
+    jp = _build_jac_qp()
+    x0 = jnp.zeros(2)
+    theta = jnp.array([0.3, 0.7])
+    x_star, (lam, zL, zU), _ = jp.batched_solve_with_jacobian(theta[None, :], x0)
+    with pytest.raises(ValueError, match="lam, zL, zU"):
+        jp.sensitivity_at(x_star[0], theta, (lam[0], zL[0]))
+
+
 def test_batched_vjp_from_state_matches_jax_vjp_pounce_82():
     """Issue #82: ``batched_vjp_from_state`` equals ``jax.vjp`` over
     ``batched_solve`` (J^T @ x_bar), and equals J^T @ x_bar from the

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -2155,3 +2155,84 @@ def test_inverse_map_rhs_warm_matches_cold_pounce_91():
     rhs_w = inverse_map_rhs(jp, dy_ds, warm=True)
     jit_val = jax.jit(rhs_w)(0.3, theta0)
     assert np.all(np.isfinite(np.asarray(jit_val)))
+
+
+def test_inverse_map_rhs_nonidentity_output_pounce_91():
+    """Issue #91: a NON-identity output exercises the
+    ``∂y/∂θ = ∂h/∂x · J + ∂h/∂θ`` branch — the general case the identity
+    round-trip test never touches (and a non-square ``n != p``: here ``n=1``,
+    ``p=2``, output dim ``k=2``).
+
+    Inner ``min_x (x − θ0)²`` ⇒ ``x*(θ) = θ0`` (so ``J = ∂x*/∂θ = [1, 0]``).
+    Output ``h = [x + θ1, x − θ1]`` ⇒ ``y = [θ0+θ1, θ0−θ1] = A θ`` with
+    ``A = [[1,1],[1,−1]]`` (and ``∂y/∂θ = A``), so the inverse map is the
+    constant linear solve ``θ(s) = A⁻¹ y(s)`` — an exact analytic check that
+    both the ``∂h/∂x · J`` and the ``∂h/∂θ`` terms are formed correctly.
+    """
+    from pounce.jax import JaxProblem, inverse_map_rhs
+
+    def f(x, p):
+        return (x[0] - p[0]) ** 2
+
+    jp = JaxProblem(
+        f=f, g=None, n=1, m=0, p_example=jnp.zeros(2),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+
+    def output(x, theta):
+        return jnp.array([x[0] + theta[1], x[0] - theta[1]])
+
+    A = np.array([[1.0, 1.0], [1.0, -1.0]])
+    Ainv = np.linalg.inv(A)
+    y0 = np.array([0.3, -0.2])
+    y1 = np.array([1.0, 0.4])
+
+    # Straight-line output path y(s) = y0 + s (y1 − y0) ⇒ dy/ds constant.
+    rhs = inverse_map_rhs(jp, jnp.asarray(y1 - y0), output=output)
+    TH = _rk4(rhs, jnp.asarray(Ainv @ y0), n_steps=80)        # (K, 2)
+
+    S = np.linspace(0.0, 1.0, TH.shape[0])
+    ys = y0[None, :] + S[:, None] * (y1 - y0)                 # (K, 2)
+    theta_analytic = ys @ Ainv.T                              # θ = A⁻¹ y
+    assert float(np.max(np.abs(TH - theta_analytic))) < 1e-6
+    assert float(np.max(np.abs(TH[-1] - Ainv @ y1))) < 1e-6
+
+
+def test_inverse_map_rhs_requires_square_output_pounce_91():
+    """Issue #91: ``∂y/∂θ`` must be square (output dim ``k == p``). The default
+    identity output with ``n != p`` is non-square and is rejected up front with
+    a clear error, rather than a low-level LinAlgError inside the callback."""
+    from pounce.jax import JaxProblem, inverse_map_rhs
+
+    def f(x, p):
+        return jnp.sum((x - p[0]) ** 2)
+
+    jp = JaxProblem(
+        f=f, g=None, n=3, m=0, p_example=jnp.zeros(2),
+        options={"print_level": 0, "sb": "yes"},
+    )
+    with pytest.raises(ValueError, match="square"):
+        inverse_map_rhs(jp, jnp.zeros(3))               # identity ⇒ k=n=3 ≠ p=2
+
+
+def test_follow_rejects_inequality_constraints_pounce_90():
+    """Issue #90: ``follow`` / ``trace_arclength`` assume a fixed active set of
+    equalities; a two-sided inequality (``cl != cu``) makes the monitor's
+    ``max|g|`` residual invalid, so it is rejected explicitly."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):
+        return jnp.array([x[0] + x[1]])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1,
+        cl=jnp.array([-1.0]), cu=jnp.array([1.0]),     # inequality: cl != cu
+        p_example=jnp.zeros(2),
+        options={"print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp)
+    with pytest.raises(ValueError, match="inequality"):
+        pf.follow(lambda s: jnp.array([s, s]), (0.0, 1.0), jnp.zeros(2))

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -2050,3 +2050,75 @@ def test_inverse_map_rhs_is_jittable_pounce_91():
     eager = rhs(0.3, theta)
     jitted = jax.jit(rhs)(0.3, theta)
     np.testing.assert_allclose(np.asarray(jitted), np.asarray(eager), atol=1e-9)
+
+
+def test_pathfollower_unconstrained_follow_pounce_90():
+    """Issue #90: follow() works for an unconstrained (m=0) problem —
+    the m=0 branch of the predictor (no dual step) and the corrector."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)        # x*(θ) = θ, J = I
+
+    jp = JaxProblem(
+        f=f, g=None, n=2, m=0, p_example=jnp.zeros(2),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp, monitor_tol=1e-6, ds0=0.05)
+    tr = pf.follow(_circle_theta, (0.0, 1.0), jnp.zeros(2))
+    assert tr.status == "ok"
+    assert tr.n_correctors == 0             # predictor exact (J = I)
+    # x*(θ) = θ, so the traced primal equals the parameter path.
+    np.testing.assert_allclose(tr.x, tr.theta, atol=1e-6)
+
+
+def test_pathfollower_max_steps_status_pounce_90():
+    """Issue #90: hitting the step cap before s1 reports status
+    'max_steps' and a partial trace."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] - 1.0])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -5.0), ub=jnp.full(2, 5.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(jp, ds0=0.05, max_steps=2)
+    tr = pf.follow(_circle_theta, (0.0, 1.0), jnp.zeros(2))
+    assert tr.status == "max_steps"
+    assert tr.n_steps == 2
+    assert tr.s[-1] < 1.0
+
+
+def test_pathfollower_corrector_failed_status_pounce_90():
+    """Issue #90: a step into an infeasible region whose corrector can't
+    converge backs off to ds_min and reports 'corrector_failed'."""
+    from pounce.jax import JaxProblem, PathFollower
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    # Equality x0 = θ0 with x0 ≤ 1 → infeasible once θ0 > 1.
+    def g(x, p):
+        return jnp.stack([x[0] - p[0]])
+
+    jp = JaxProblem(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -5.0), ub=jnp.array([1.0, 5.0]),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-9, "print_level": 0, "sb": "yes"},
+    )
+
+    def theta(s):                       # θ0: 0.5 (feasible) → 2.5 (infeasible)
+        return jnp.array([0.5 + 2.0 * s, 0.0])
+
+    # ds_min high + shrink so the first failed corrector trips the floor.
+    pf = PathFollower(jp, monitor_tol=1e-6, ds0=0.5, ds_min=0.4, shrink=0.5)
+    tr = pf.follow(theta, (0.0, 1.0), jnp.zeros(2))
+    assert tr.status == "corrector_failed"

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1301,6 +1301,69 @@ def test_sensitivity_at_requires_dual_triple_pounce_87():
         jp.sensitivity_at(x_star[0], theta, (lam[0], zL[0]))
 
 
+def test_single_solve_with_jacobian_matches_batched_pounce_88():
+    """Issue #88: the single-problem ``solve_with_jacobian`` returns
+    un-batched shapes equal to the ``B=1`` batched call (and matches
+    ``jax.jacobian``)."""
+    jp = _build_jac_qp()
+    x0 = jnp.zeros(2)
+    theta = jnp.array([0.3, 0.7])
+
+    x_star, (lam, zL, zU), J = jp.solve_with_jacobian(theta, x0)
+    assert x_star.shape == (2,)
+    assert lam.shape == (1,) and zL.shape == (2,) and zU.shape == (2,)
+    assert J.shape == (2, 2)
+
+    xb, (lb, zlb, zub), Jb = jp.batched_solve_with_jacobian(theta[None, :], x0)
+    np.testing.assert_allclose(np.asarray(x_star), np.asarray(xb[0]), atol=1e-12)
+    np.testing.assert_allclose(np.asarray(J), np.asarray(Jb[0]), atol=1e-12)
+    Jref = jax.jacobian(lambda p: jp.solve(p, x0))(theta)
+    np.testing.assert_allclose(np.asarray(J), np.asarray(Jref), atol=1e-6)
+
+
+def test_single_anchor_sensitivity_and_from_state_pounce_88():
+    """Issue #88: ``anchor`` accepts an un-batched point; ``sensitivity``
+    / ``jvp_from_state`` / ``vjp_from_state`` return un-batched results
+    consistent with the full Jacobian."""
+    jp = _build_jac_qp()
+    x0 = jnp.zeros(2)
+    theta = jnp.array([0.5, 0.5])
+
+    state = jp.anchor(theta, x0)          # single point → B=1
+    assert state._B == 1
+
+    J = jp.sensitivity(state)
+    assert J.shape == (2, 2)
+    Jref = jax.jacobian(lambda p: jp.solve(p, x0))(theta)
+    np.testing.assert_allclose(np.asarray(J), np.asarray(Jref), atol=1e-6)
+
+    # jvp: J @ dp, un-batched (n,).
+    dp = jnp.array([1.0, -2.0])
+    dx = jp.jvp_from_state(state, dp)
+    assert dx.shape == (2,)
+    np.testing.assert_allclose(np.asarray(dx), np.asarray(J @ dp), atol=1e-6)
+
+    # vjp: J^T @ x_bar, un-batched (p,).
+    x_bar = jnp.array([0.7, -0.3])
+    dpb = jp.vjp_from_state(state, x_bar)
+    assert dpb.shape == (2,)
+    np.testing.assert_allclose(np.asarray(dpb), np.asarray(J.T @ x_bar), atol=1e-6)
+    state.close()
+
+
+def test_single_wrappers_reject_batched_state_pounce_88():
+    """Issue #88: the single-problem from-state wrappers reject a state
+    anchored with B>1 rather than silently mis-shaping."""
+    jp = _build_jac_qp()
+    x0 = jnp.zeros(2)
+    p_batch = jnp.array([[0.3, 0.7], [0.5, 0.5]])
+    state = jp.anchor(p_batch, x0)        # B=2
+    assert state._B == 2
+    with pytest.raises(ValueError, match="single-problem form"):
+        jp.jvp_from_state(state, jnp.array([1.0, 0.0]))
+    state.close()
+
+
 def test_batched_vjp_from_state_matches_jax_vjp_pounce_82():
     """Issue #82: ``batched_vjp_from_state`` equals ``jax.vjp`` over
     ``batched_solve`` (J^T @ x_bar), and equals J^T @ x_bar from the

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -1364,6 +1364,69 @@ def test_single_wrappers_reject_batched_state_pounce_88():
     state.close()
 
 
+def test_active_set_margin_binding_bound_pounce_89():
+    """Issue #89: with a binding upper bound, `min_mult` reflects the
+    active bound's multiplier and the margin equals min(min_mult,
+    min_slack). Equalities are excluded; the margin is positive at a
+    clean (non-degenerate) solution."""
+    jp = _build_jac_qp(bounded=True)     # ub[0] = 0.2, equality x0+x1=1
+    x0 = jnp.zeros(2)
+    theta = jnp.array([0.6, 0.4])        # pulls x0 against its upper bound
+    state = jp.anchor(theta, x0)
+    x_star, (lam, zL, zU), _ = jp.batched_solve_with_jacobian(theta[None, :], x0)
+
+    r = jp.active_set_margin(state)
+    for key in ("margin", "min_mult", "min_slack"):
+        assert r[key].shape == (1,)
+
+    # The upper bound on x0 binds → its multiplier is the active one.
+    assert float(zU[0, 0]) > 1e-6
+    np.testing.assert_allclose(
+        float(r["min_mult"][0]), float(zU[0, 0]), atol=1e-6
+    )
+    # Clean solution: a strictly positive distance to an active-set change.
+    assert float(r["margin"][0]) > 0.0
+    np.testing.assert_allclose(
+        float(r["margin"][0]),
+        min(float(r["min_mult"][0]), float(r["min_slack"][0])),
+        atol=1e-12,
+    )
+    state.close()
+
+
+def test_active_set_margin_interior_is_inf_pounce_89():
+    """Issue #89: an unconstrained interior solution (no active bound,
+    no finite inactive bound) has an infinite margin — no active-set
+    change is imminent."""
+    from pounce.jax import JaxProblem
+
+    def f(x, p):
+        return jnp.sum((x - p) ** 2)
+
+    # No bounds, no constraints: the optimum is x* = p, interior.
+    jp = JaxProblem(
+        f=f, g=None, n=2, m=0, p_example=jnp.zeros(2),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    state = jp.anchor(jnp.array([0.3, -0.4]), jnp.zeros(2))
+    r = jp.active_set_margin(state)
+    assert not np.isfinite(float(r["min_mult"][0]))   # nothing active
+    assert not np.isfinite(float(r["margin"][0]))
+    state.close()
+
+
+def test_active_set_margin_batched_pounce_89():
+    """Issue #89: the margin is computed per block for a B>1 state."""
+    jp = _build_jac_qp(bounded=True)
+    x0 = jnp.zeros(2)
+    p_batch = jnp.array([[0.6, 0.4], [0.5, 0.5]])
+    state = jp.anchor(p_batch, x0)
+    r = jp.active_set_margin(state)
+    assert r["margin"].shape == (2,)
+    assert np.all(np.asarray(r["margin"]) > 0.0)
+    state.close()
+
+
 def test_batched_vjp_from_state_matches_jax_vjp_pounce_82():
     """Issue #82: ``batched_vjp_from_state`` equals ``jax.vjp`` over
     ``batched_solve`` (J^T @ x_bar), and equals J^T @ x_bar from the

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -162,6 +162,58 @@ def test_solve_with_warm_reduces_iterations_pounce_74():
     np.testing.assert_allclose(grad, np.array([0.0, 4.0, -6.0]), atol=1e-6)
 
 
+def test_solve_with_warm_threads_barrier_mu_pounce_86():
+    """A 4-element warm-state `(lam, zL, zU, mu)` seeds the barrier and
+    returns the converged μ, so a predictor–corrector loop can thread it
+    forward; the 3-tuple path is unchanged (pounce#86)."""
+    from pounce.jax import solve_with_warm
+
+    n, m, B = 3, 1, 0.5
+
+    def f(x, p):
+        d = x - p
+        return jnp.dot(d, d)
+
+    def g(x, p):
+        return jnp.stack([x[0]])
+
+    def forward(p, warm):
+        return solve_with_warm(
+            p, f=f, g=g, x0=jnp.zeros(n), n=n, m=m,
+            lb=jnp.full(n, -1e19), ub=jnp.full(n, 1e19),
+            cl=jnp.array([-1e19]), cu=jnp.array([B]),
+            options={"tol": 1e-10, "print_level": 0},
+            warm_start=warm,
+        )
+
+    p0 = jnp.array([2.0, 2.0, -3.0])  # active inequality
+
+    # 3-tuple / None warm-start: backward-compatible 3-element state.
+    x0_star, warm3 = forward(p0, warm=None)
+    assert len(warm3) == 3
+
+    # Report-only 4-tuple (mu=None): get μ out without seeding it in.
+    x_ro, warm_ro = forward(p0, warm=(*warm3, None))
+    assert len(warm_ro) == 4
+    mu_out = float(np.asarray(warm_ro[3]))
+    assert np.isfinite(mu_out) and 0.0 < mu_out < 1e-6
+
+    # Seed μ back in (full 4-tuple) — same optimum, μ still round-trips.
+    lam, zL, zU = warm3
+    x_seed, warm_seed = forward(p0, warm=(lam, zL, zU, mu_out))
+    assert len(warm_seed) == 4
+    np.testing.assert_allclose(np.asarray(x_seed), np.asarray(x0_star), atol=1e-8)
+    assert np.isfinite(float(np.asarray(warm_seed[3])))
+
+    # Differentiability w.r.t. p is preserved through the μ-threaded path.
+    def loss(p):
+        x_star, _ = forward(p, warm=(lam, zL, zU, mu_out))
+        return jnp.sum(x_star ** 2)
+
+    grad = np.asarray(jax.grad(loss)(p0))
+    np.testing.assert_allclose(grad, np.array([0.0, 4.0, -6.0]), atol=1e-6)
+
+
 def test_vmap_solve_parallel_matches_vmap_solve_pounce_74():
     """Parallel batched solve must agree numerically with the sequential
     `vmap_solve` reference, both for the forward x* and for `jax.grad`

--- a/python/tests/test_warm_start.py
+++ b/python/tests/test_warm_start.py
@@ -101,3 +101,88 @@ def test_warm_start_dual_seeds_accepted():
     assert info["status_msg"] == "Solve_Succeeded"
     assert len(x) == n
     assert len(info["mult_g"]) == m
+
+
+# ---- Barrier-μ warm start (pounce#86) ----
+#
+# A tiny parametric NLP: min  c·x0 + (x1 - 2)²  s.t.  x0 + x1 = 3,
+# 0 ≤ x ≤ 10. The objective coefficient `c` is the path parameter.
+
+
+def _make_parametric(c, opts=None):
+    class Obj:
+        def objective(self, x):
+            return float(c * x[0] + (x[1] - 2.0) ** 2)
+
+        def gradient(self, x):
+            return np.array([c, 2.0 * (x[1] - 2.0)])
+
+        def constraints(self, x):
+            return np.array([x[0] + x[1]])
+
+        def jacobianstructure(self):
+            return (np.array([0, 0]), np.array([0, 1]))
+
+        def jacobian(self, x):
+            return np.array([1.0, 1.0])
+
+        def hessianstructure(self):
+            return (np.array([1]), np.array([1]))
+
+        def hessian(self, x, lam, obj_factor):
+            return np.array([2.0 * obj_factor])
+
+    prob = pounce.Problem(
+        n=2, m=1, problem_obj=Obj(),
+        lb=[0.0, 0.0], ub=[10.0, 10.0], cl=[3.0], cu=[3.0],
+    )
+    prob.add_option("tol", 1e-8)
+    prob.add_option("print_level", 0)
+    for k, v in (opts or {}).items():
+        prob.add_option(k, v)
+    return prob
+
+
+def test_info_reports_converged_mu_pounce_86():
+    """`info["mu"]` surfaces the converged barrier parameter so a
+    caller can thread it into a warm-started corrector (pounce#86)."""
+    x, info = _make_parametric(1.0).solve(x0=np.array([1.0, 1.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    assert "mu" in info
+    mu = info["mu"]
+    assert np.isfinite(mu)
+    # Converged barrier sits near the tolerance floor — positive and
+    # well below the default initial μ (0.1).
+    assert 0.0 < mu < 1e-6
+
+
+def test_mu_seed_reduces_corrector_iterations_pounce_86():
+    """Seeding `mu_init` / `warm_start_target_mu` from the previous
+    solve's converged μ resumes the corrector near the central path,
+    cutting iterations vs. a dual-only warm start (pounce#86)."""
+    # Anchor solve at c = 1.0 — record duals + converged μ.
+    x0, i0 = _make_parametric(1.0).solve(x0=np.array([1.0, 1.0]))
+    assert i0["status_msg"] == "Solve_Succeeded"
+    mu0 = i0["mu"]
+    lam = np.asarray(i0["mult_g"], dtype=np.float64)
+    zl = np.asarray(i0["mult_x_L"], dtype=np.float64)
+    zu = np.asarray(i0["mult_x_U"], dtype=np.float64)
+
+    def corrector(seed_mu):
+        opts = {"warm_start_init_point": "yes"}
+        if seed_mu is not None:
+            opts["mu_init"] = float(seed_mu)
+            opts["warm_start_target_mu"] = float(seed_mu)
+        return _make_parametric(1.2, opts).solve(
+            x0=x0, lagrange=lam, zl=zl, zu=zu,
+        )
+
+    x_no_mu, i_no_mu = corrector(None)
+    x_mu, i_mu = corrector(mu0)
+    assert i_no_mu["status_msg"] == "Solve_Succeeded"
+    assert i_mu["status_msg"] == "Solve_Succeeded"
+    # Same optimum either way — μ seeding is a convergence-path lever,
+    # not a different answer.
+    np.testing.assert_allclose(x_mu, x_no_mu, atol=1e-6)
+    # The μ seed strictly cuts corrector iterations.
+    assert i_mu["iter_count"] < i_no_mu["iter_count"]


### PR DESCRIPTION
## Summary

This PR adds two major path-tracing capabilities to pounce.jax:

1. **Predictor–corrector path-following engine** (`PathFollower`) that traces solution paths of parametric NLPs by composing post-solve sensitivity primitives rather than re-solving at every step
2. **Inverse-map ODE recipe** (`inverse_map_rhs`) that builds the right-hand side of the Alves–Kitchin–Lima inverse/uncertainty-mapping ODE for integration with adaptive ODE solvers

## Key Changes

### Path Following (pounce#90)
- **`PathFollower` class**: Implements predictor–corrector stepping with:
  - **Predict**: Extrapolate primal and duals along held-factor sensitivity
  - **Monitor**: Check KKT residual and active-set margin (no solve)
  - **Correct**: Warm-μ re-solve only when monitor trips, re-anchoring the factor
  - Adaptive step-size control with grow/shrink factors
  - Active-set change detection and recording
  
- **`PathFollower.follow()`**: Parameter continuation along prescribed `θ(s)` path
- **`PathFollower.trace_arclength()`**: Pseudo-arclength continuation for scalar-parameter families, tracing **past folds** where `∂x*/∂θ` is singular

- **`JaxProblem.warm_anchor()`**: Warm-started, barrier-μ-seeded re-solve that pins the converged KKT factor and returns a `B=1` `AnchorState` (corrector + anchor in one solve)

- **Dual sensitivity in JVP**: `jvp_from_state(..., with_duals=True)` and `batched_jvp_from_state(..., with_duals=True)` now return `∂λ*/∂θ · dp` from the held-factor back-solve

### Active-Set Monitoring (pounce#89)
- **`JaxProblem.active_set_margin()`**: Reports distance to active-set changes via:
  - `margin`: minimum of active multiplier and slack to nearest boundary
  - `min_mult`: smallest active multiplier
  - `min_slack`: smallest slack to an inactive bound
  - Returns `inf` for interior solutions with no active constraints

### Barrier-μ Threading (pounce#86)
- **`solve_with_warm()` and `warm_anchor()`**: Accept optional `mu` parameter to seed the interior-point barrier
- **`info["mu"]`**: Solver now reports converged barrier parameter for threading through corrector loops
- Separate cached `Problem` instance for corrector to prevent μ options from leaking into differentiable paths

### Inverse-Map ODE (pounce#91)
- **`inverse_map_rhs()`**: Builds RHS for `dθ/ds = (∂y/∂θ)^{-1} · dy/ds` ODE
  - Solves NLP and reads `∂x*/∂θ` from held factor per evaluation
  - Forms total output sensitivity `∂y/∂θ = (∂h/∂x) J + ∂h/∂θ`
  - Performs linear solve (not JVP) against the sensitivity
  - Wrapped in `jax.pure_callback` for JAX composability
  - Works with diffrax and scipy integrators

- **Example**: `python/examples/inverse_map_diffrax.py` demonstrates closed-boundary tracing with adaptive Dopri5 integration

### Supporting Changes
- **Unconstrained problem support**: Fixed constraint callbacks to handle `g=None` (no constraints) in batched solves
- **Dual sensitivity in KKT JVP**: `_kkt_jvp_batched_pure_callback` now returns both primal and constraint-multiplier blocks, enabling dual prediction
- **`PathTrace` dataclass**: Result container with step counts, active-set changes, turning points, and status
- **Single-problem wrappers** (p

https://claude.ai/code/session_0141rVjpXL5VktnYVyobySfC