### PR TITLE
Implement low-rank Sherman-Morrison-Woodbury Hessian for L-BFGS

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -26,6 +26,8 @@ use crate::hess::exact::ExactHessianUpdater;
 use crate::hess::lim_mem_quasi_newton::{LimMemQuasiNewtonUpdater, UpdateType};
 use crate::init::default::DefaultIterateInitializer;
 use crate::init::warm_start::WarmStartIterateInitializer;
+use crate::kkt::aug_system_solver::AugSystemSolver;
+use crate::kkt::low_rank_aug_system_solver::LowRankAugSystemSolver;
 use crate::kkt::pd_full_space_solver::PdFullSpaceSolver;
 use crate::kkt::pd_search_dir_calc::PdSearchDirCalc;
 use crate::kkt::perturbation_handler::PdPerturbationHandler;
@@ -542,9 +544,20 @@ impl AlgorithmBuilder {
                 }
             };
         let linsol = TSymLinearSolver::new(backend, scaling, self.linear_scaling_on_demand);
-        let aug_solver = StdAugSystemSolver::new(linsol);
+        let inner_aug = StdAugSystemSolver::new(linsol);
+        // Limited-memory mode publishes the Hessian as a
+        // `LowRankUpdateSymMatrix`; wrap the standard solver in the
+        // Sherman-Morrison-Woodbury low-rank solver so the augmented
+        // system factorizes only the diagonal `B0` and the quasi-Newton
+        // update is applied as a rank-`m` correction (`O(n·m)` memory).
+        let aug_solver: Box<dyn AugSystemSolver> =
+            if matches!(self.hessian_approximation, HessianApproxChoice::LimitedMemory) {
+                Box::new(LowRankAugSystemSolver::new(Box::new(inner_aug)))
+            } else {
+                Box::new(inner_aug)
+            };
         let perturb = Rc::new(RefCell::new(PdPerturbationHandler::new()));
-        let pd_solver = PdFullSpaceSolver::new(Box::new(aug_solver), perturb);
+        let pd_solver = PdFullSpaceSolver::new(aug_solver, perturb);
         let mut search_dir = PdSearchDirCalc::new(pd_solver);
         search_dir.mehrotra_algorithm = self.mehrotra_algorithm;
         self.build_inner(Some(search_dir))

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -550,12 +550,14 @@ impl AlgorithmBuilder {
         // Sherman-Morrison-Woodbury low-rank solver so the augmented
         // system factorizes only the diagonal `B0` and the quasi-Newton
         // update is applied as a rank-`m` correction (`O(n·m)` memory).
-        let aug_solver: Box<dyn AugSystemSolver> =
-            if matches!(self.hessian_approximation, HessianApproxChoice::LimitedMemory) {
-                Box::new(LowRankAugSystemSolver::new(Box::new(inner_aug)))
-            } else {
-                Box::new(inner_aug)
-            };
+        let aug_solver: Box<dyn AugSystemSolver> = if matches!(
+            self.hessian_approximation,
+            HessianApproxChoice::LimitedMemory
+        ) {
+            Box::new(LowRankAugSystemSolver::new(Box::new(inner_aug)))
+        } else {
+            Box::new(inner_aug)
+        };
         let perturb = Rc::new(RefCell::new(PdPerturbationHandler::new()));
         let pd_solver = PdFullSpaceSolver::new(aug_solver, perturb);
         let mut search_dir = PdSearchDirCalc::new(pd_solver);

--- a/crates/pounce-algorithm/src/hess/lim_mem_quasi_newton.rs
+++ b/crates/pounce-algorithm/src/hess/lim_mem_quasi_newton.rs
@@ -4,18 +4,25 @@
 //! Update strategy is selected by the `limited_memory_update_type`
 //! option (`bfgs` or `sr1`) per `MAIN_LOOP.md`.
 //!
-//! Phase 8a (this cut) ships a **dense-rebuild** assembler: at every
+//! Phase 8 publishes the limited-memory Hessian as `data.w` via the
+//! **low-rank** assembler, for every problem size. At each
 //! `update_hessian` call we walk the curvature-pair history (oldest to
-//! newest) applying the rank-2 BFGS / rank-1 SR1 formulas in place on a
-//! dense `n×n` work buffer, then project the result onto the
-//! [`SymTMatrixSpace`] sparsity that [`crate::kkt::std_aug_system_solver`]
-//! pinned at the first solve. The dense walk is `O(m · n²)` per
-//! iteration (with `m = max_history`); for the small-NLP gold suite
-//! that's negligible. The Sherman-Morrison-Woodbury / `LowRankUpdateSymMatrix`
-//! shortcut wired through [`crate::kkt::low_rank_aug_system_solver`] is
-//! the Phase-8b optimisation; mathematically the two paths agree on the
-//! action of `B`, so HS071-class problems converge identically with
-//! either backend.
+//! newest) applying the rank-2 BFGS / rank-1 SR1 formulas to build the
+//! compact factors of `B = σ I + V Vᵀ − U Uᵀ`, then publish a
+//! [`pounce_linalg::low_rank_update_sym_matrix::LowRankUpdateSymMatrix`]
+//! as `data.w`. No dense `n×n` buffer is ever formed: the walk is
+//! `O(n · m)` per pair and `O(n · m²)` total (with `m = max_history`),
+//! and storage is `O(n · m)`, so the limited-memory path scales to
+//! arbitrarily large `n`. [`crate::kkt::low_rank_aug_system_solver`]
+//! applies the Hessian's inverse action via the Sherman-Morrison-Woodbury
+//! identity, factorizing only the diagonal `B0`. This removes the
+//! `eval_h` requirement (the user no longer needs to declare a Hessian
+//! sparsity pattern) and the former `O(n²)` memory cliff.
+//!
+//! `LowRankAugSystemSolver` wraps the standard augmented-system solver and
+//! forwards the Hessian-free init / equality-multiplier solves (which
+//! carry a non-low-rank `W`) straight through, so a single solver
+//! instance serves the whole iteration.
 //!
 //! Update kernels:
 //!   - [`initial_hessian_scalar`] (sigma per `LIM_MEM_INIT`)
@@ -27,8 +34,9 @@ use crate::hess::r#trait::HessianUpdater;
 use crate::ipopt_cq::IpoptCqHandle;
 use crate::ipopt_data::IpoptDataHandle;
 use pounce_common::types::{Index, Number};
-use pounce_linalg::dense_vector::DenseVector;
-use pounce_linalg::triplet::{SymTMatrix, SymTMatrixSpace};
+use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
+use pounce_linalg::low_rank_update_sym_matrix::LowRankUpdateSymMatrixSpace;
+use pounce_linalg::multi_vector_matrix::{MultiVectorMatrix, MultiVectorMatrixSpace};
 use pounce_linalg::Vector;
 use std::rc::Rc;
 
@@ -82,15 +90,6 @@ pub struct LimMemQuasiNewtonUpdater {
     /// (NOT `y_c_prev`).
     pub last_jac_c: Option<Rc<dyn pounce_linalg::matrix::Matrix>>,
     pub last_jac_d: Option<Rc<dyn pounce_linalg::matrix::Matrix>>,
-    /// Cached `SymTMatrixSpace` we reuse to publish `data.w`. Filled
-    /// lazily on the first `update_hessian` call by snapshotting the
-    /// space of `cq.curr_exact_hessian()` so our matrices share the
-    /// sparsity that the aug-system solver pinned during the
-    /// least-square-multipliers init pass. Phase-8a limitation: when
-    /// the user-declared sparsity is sparser than full-dense, the
-    /// dense L-BFGS approximation is projected onto it (entries
-    /// outside the declared pattern are dropped).
-    pub h_space: Option<Rc<SymTMatrixSpace>>,
 }
 
 impl Default for LimMemQuasiNewtonUpdater {
@@ -106,7 +105,6 @@ impl Default for LimMemQuasiNewtonUpdater {
             last_grad_f: None,
             last_jac_c: None,
             last_jac_d: None,
-            h_space: None,
         }
     }
 }
@@ -161,11 +159,10 @@ impl LimMemQuasiNewtonUpdater {
 impl HessianUpdater for LimMemQuasiNewtonUpdater {
     /// Snapshot the current `(x, ∇_x L)` pair, build `s = x − x_prev`
     /// and `y = ∇L − ∇L_prev`, ingest into history (skip per the
-    /// BFGS / SR1 acceptance criterion), then rebuild `B = σ I + Σ
-    /// rank-2 updates` from the rolling history and publish it as
-    /// `data.w`. Mirrors `IpLimMemQuasiNewtonUpdater::Update` minus the
-    /// SMW shortcut (Phase-8a; the `LowRankUpdateSymMatrix` path lands
-    /// in Phase-8b).
+    /// BFGS / SR1 acceptance criterion), then build the low-rank factors
+    /// of `B = σ I + V Vᵀ − U Uᵀ` from the rolling history and publish a
+    /// [`pounce_linalg::low_rank_update_sym_matrix::LowRankUpdateSymMatrix`]
+    /// as `data.w`. Mirrors `IpLimMemQuasiNewtonUpdater::Update`.
     fn update_hessian(&mut self, data: &IpoptDataHandle, cq: &IpoptCqHandle) -> bool {
         let (curr_x, curr_y_c, curr_y_d) = match data.borrow().curr.as_ref() {
             Some(c) => (c.x.clone(), c.y_c.clone(), c.y_d.clone()),
@@ -174,19 +171,6 @@ impl HessianUpdater for LimMemQuasiNewtonUpdater {
         let curr_grad_f = cq.borrow().curr_grad_f();
         let curr_jac_c = cq.borrow().curr_jac_c();
         let curr_jac_d = cq.borrow().curr_jac_d();
-
-        // Lazily snapshot the SymTMatrix space pinned by upstream's
-        // first aug-system call (least-square-multipliers init), so our
-        // rebuilt `W` matrices reuse exactly the irow/jcol pattern the
-        // solver already committed to.
-        if self.h_space.is_none() {
-            let h = cq.borrow().curr_exact_hessian();
-            if let Some(symt) = h.as_any().downcast_ref::<SymTMatrix>() {
-                self.h_space = Some(Rc::clone(symt.space()));
-            } else {
-                self.h_space = Some(make_full_lower_triangle_space(curr_x.dim()));
-            }
-        }
 
         // Upstream y formula (`IpLimMemQuasiNewtonUpdater.cpp:284-308`):
         //   y = (∇f_curr − ∇f_last)
@@ -223,36 +207,38 @@ impl HessianUpdater for LimMemQuasiNewtonUpdater {
         self.last_jac_c = Some(Rc::clone(&curr_jac_c));
         self.last_jac_d = Some(Rc::clone(&curr_jac_d));
 
-        let n = curr_x.dim() as usize;
+        let n_idx = curr_x.dim();
+        let nu = n_idx as usize;
         let sigma = match self.update_type {
             UpdateType::Bfgs => self.compute_sigma_bfgs(),
-            // SR1 always uses identity start unless the user picked
-            // `Scalar1`/`Scalar2`. Upstream's SR1 path matches BFGS for
-            // the `LIM_MEM_INIT` sigma source.
+            // SR1 uses the same `LIM_MEM_INIT` sigma source as BFGS for
+            // the diagonal `B0`; the rank-1 corrections carry the sign.
             UpdateType::Sr1 => self.compute_sigma_bfgs(),
         };
-        let mut dense = vec![0.0_f64; n * n];
-        for i in 0..n {
-            dense[i * n + i] = sigma;
+
+        // Build the compact factors of  B = σ I + V Vᵀ − U Uᵀ  by walking
+        // the curvature history. No dense `n×n` is ever formed: the walk
+        // is `O(n · history_len)` per pair. Publishing a
+        // `LowRankUpdateSymMatrix` lets `LowRankAugSystemSolver` apply the
+        // Hessian via Sherman-Morrison-Woodbury with `O(n · m)` storage
+        // for arbitrarily large `n`.
+        let (v_cols, u_cols) = self.build_low_rank(sigma, nu);
+
+        let col_space = DenseVectorSpace::new(n_idx);
+        let mut diag = col_space.make_new_dense();
+        diag.set_values(&vec![sigma; nu]);
+
+        let lr_space = LowRankUpdateSymMatrixSpace::new(n_idx, None, false);
+        let mut lr = lr_space.make_new_low_rank();
+        lr.set_diag(Rc::new(diag) as Rc<dyn Vector>);
+        if let Some(mvm) = build_multi_vector(&col_space, &v_cols) {
+            lr.set_v(Rc::new(mvm));
         }
-        match self.update_type {
-            UpdateType::Bfgs => apply_bfgs_history(&mut dense, n, &self.history),
-            UpdateType::Sr1 => apply_sr1_history(&mut dense, n, &self.history),
+        if let Some(mvm) = build_multi_vector(&col_space, &u_cols) {
+            lr.set_u(Rc::new(mvm));
         }
 
-        let space = Rc::clone(self.h_space.as_ref().unwrap());
-        let mut mat = SymTMatrix::new(Rc::clone(&space));
-        let irows = space.irows();
-        let jcols = space.jcols();
-        let mut vals = vec![0.0_f64; irows.len()];
-        for k in 0..irows.len() {
-            // Triplet indices are 1-based per upstream / MUMPS convention.
-            let i = (irows[k] - 1) as usize;
-            let j = (jcols[k] - 1) as usize;
-            vals[k] = dense[i * n + j];
-        }
-        mat.set_values(&vals);
-        data.borrow_mut().w = Some(Rc::new(mat));
+        data.borrow_mut().w = Some(Rc::new(lr));
         true
     }
 }
@@ -274,23 +260,106 @@ impl LimMemQuasiNewtonUpdater {
             self.init_val_max,
         )
     }
+
+    /// Walk the curvature-pair history oldest→newest, applying the BFGS
+    /// rank-2 / SR1 rank-1 recurrences against the running approximation
+    /// `B = σ I + V Vᵀ − U Uᵀ` to grow the dense column lists `V` and
+    /// `U`. Returns `(v_cols, u_cols)` in full primal space.
+    ///
+    /// For BFGS, each accepted pair `(s, y)` appends one positive column
+    /// `r/√(sᵀr)` (the `r rᵀ/(sᵀr)` term, `r = θ y + (1−θ) Bs` after
+    /// Powell damping) and one negative column `Bs/√(sᵀBs)` (the
+    /// `−(Bs)(Bs)ᵀ/(sᵀBs)` term). For SR1 each pair appends a single
+    /// column `(y−Bs)/√|denom|` to `V` (denom > 0) or `U` (denom < 0).
+    /// This reproduces, column for column, the action of the former
+    /// dense rebuild while never materializing an `n×n` buffer.
+    fn build_low_rank(&self, sigma: Number, n: usize) -> (Vec<Vec<Number>>, Vec<Vec<Number>>) {
+        let mut v_cols: Vec<Vec<Number>> = Vec::new();
+        let mut u_cols: Vec<Vec<Number>> = Vec::new();
+        if n == 0 {
+            return (v_cols, u_cols);
+        }
+        for pair in &self.history {
+            let s = dense_from_vec(pair.s.as_ref(), n);
+            let y = dense_from_vec(pair.y.as_ref(), n);
+
+            // bs = B s = σ s + Σ_v (vᵀs) v − Σ_u (uᵀs) u.
+            let mut bs: Vec<Number> = s.iter().map(|&si| sigma * si).collect();
+            for v in &v_cols {
+                let c: Number = (0..n).map(|i| v[i] * s[i]).sum();
+                for i in 0..n {
+                    bs[i] += c * v[i];
+                }
+            }
+            for u in &u_cols {
+                let c: Number = (0..n).map(|i| u[i] * s[i]).sum();
+                for i in 0..n {
+                    bs[i] -= c * u[i];
+                }
+            }
+
+            match self.update_type {
+                UpdateType::Bfgs => {
+                    let s_bs: Number = (0..n).map(|i| s[i] * bs[i]).sum();
+                    if s_bs <= 0.0 {
+                        continue;
+                    }
+                    let sy = pair.s_dot_y;
+                    let theta = powell_damping_theta(sy, s_bs);
+                    let sr = theta * sy + (1.0 - theta) * s_bs;
+                    if sr <= 0.0 {
+                        continue;
+                    }
+                    let r_scale = 1.0 / sr.sqrt();
+                    let bs_scale = 1.0 / s_bs.sqrt();
+                    // r rᵀ / sr  →  positive column r/√sr.
+                    v_cols.push(
+                        (0..n)
+                            .map(|i| (theta * y[i] + (1.0 - theta) * bs[i]) * r_scale)
+                            .collect(),
+                    );
+                    // −(Bs)(Bs)ᵀ / s_bs  →  negative column Bs/√s_bs.
+                    u_cols.push(bs.iter().map(|&bi| bi * bs_scale).collect());
+                }
+                UpdateType::Sr1 => {
+                    let yms: Vec<Number> = (0..n).map(|i| y[i] - bs[i]).collect();
+                    let denom: Number = (0..n).map(|i| yms[i] * s[i]).sum();
+                    let yms_norm: Number = yms.iter().map(|&w| w * w).sum::<Number>().sqrt();
+                    if !sr1_denominator_ok(denom, pair.s_norm, yms_norm) {
+                        continue;
+                    }
+                    let scale = 1.0 / denom.abs().sqrt();
+                    let col: Vec<Number> = yms.iter().map(|&w| w * scale).collect();
+                    if denom > 0.0 {
+                        v_cols.push(col);
+                    } else {
+                        u_cols.push(col);
+                    }
+                }
+            }
+        }
+        (v_cols, u_cols)
+    }
 }
 
-/// Construct a `SymTMatrixSpace` whose pattern is the full lower
-/// triangle (1-based) of an `n × n` matrix. Used as a fallback when
-/// `cq.curr_exact_hessian()` cannot supply a `SymTMatrix` (e.g. the
-/// TNLP elects not to implement `eval_h`).
-fn make_full_lower_triangle_space(n: Index) -> Rc<SymTMatrixSpace> {
-    let nz = (n as usize) * ((n as usize) + 1) / 2;
-    let mut irows: Vec<Index> = Vec::with_capacity(nz);
-    let mut jcols: Vec<Index> = Vec::with_capacity(nz);
-    for i in 1..=n {
-        for j in 1..=i {
-            irows.push(i);
-            jcols.push(j);
-        }
+/// Pack dense column data into a [`MultiVectorMatrix`] over `col_space`.
+/// Returns `None` when there are no columns, so the caller leaves the
+/// corresponding V/U slot of the [`LowRankUpdateSymMatrix`] unset.
+fn build_multi_vector(
+    col_space: &Rc<DenseVectorSpace>,
+    cols: &[Vec<Number>],
+) -> Option<MultiVectorMatrix> {
+    if cols.is_empty() {
+        return None;
     }
-    SymTMatrixSpace::new(n, irows, jcols)
+    let space = MultiVectorMatrixSpace::new(cols.len() as Index, Rc::clone(col_space));
+    let mut mvm = space.make_new_multi_vector();
+    for (k, col) in cols.iter().enumerate() {
+        let mut cv = col_space.make_new_dense();
+        cv.set_values(col);
+        mvm.set_vector(k as Index, Rc::new(cv) as Rc<dyn Vector>);
+    }
+    Some(mvm)
 }
 
 fn dense_from_vec(v: &dyn Vector, n: usize) -> Vec<Number> {
@@ -302,94 +371,6 @@ fn dense_from_vec(v: &dyn Vector, n: usize) -> Vec<Number> {
     panic!("LimMemQuasiNewtonUpdater: curvature pairs must be DenseVector-backed");
 }
 
-/// In-place BFGS history walk on a column-major-or-row-major (it
-/// doesn't matter; B is symmetric) dense `n × n` buffer. For each
-/// curvature pair `(s, y)`, applies Powell damping when the curvature
-/// is too negative, then writes
-/// `B ← B + (r r^T)/(s^T r) − (B s)(B s)^T / (s^T B s)`
-/// where `r = θ y + (1−θ) B s`. Mirrors
-/// `IpLimMemQuasiNewtonUpdater.cpp::Update_BFGS` semantics.
-fn apply_bfgs_history(b: &mut [Number], n: usize, history: &[CurvaturePair]) {
-    if n == 0 {
-        return;
-    }
-    let mut bs = vec![0.0_f64; n];
-    let mut r = vec![0.0_f64; n];
-    for pair in history {
-        let s = dense_from_vec(pair.s.as_ref(), n);
-        let y = dense_from_vec(pair.y.as_ref(), n);
-        // bs = B s.
-        for i in 0..n {
-            let row = &b[i * n..(i + 1) * n];
-            let mut acc = 0.0;
-            for j in 0..n {
-                acc += row[j] * s[j];
-            }
-            bs[i] = acc;
-        }
-        let s_bs: Number = (0..n).map(|i| s[i] * bs[i]).sum();
-        if s_bs <= 0.0 {
-            continue;
-        }
-        let sy = pair.s_dot_y;
-        let theta = powell_damping_theta(sy, s_bs);
-        for i in 0..n {
-            r[i] = theta * y[i] + (1.0 - theta) * bs[i];
-        }
-        let sr: Number = theta * sy + (1.0 - theta) * s_bs;
-        if sr <= 0.0 {
-            continue;
-        }
-        for i in 0..n {
-            let r_i = r[i];
-            let bs_i = bs[i];
-            let row = &mut b[i * n..(i + 1) * n];
-            for j in 0..n {
-                row[j] += r_i * r[j] / sr - bs_i * bs[j] / s_bs;
-            }
-        }
-    }
-}
-
-/// In-place SR1 history walk: applies the rank-1 update
-/// `B ← B + ((y − Bs)(y − Bs)^T) / ((y − Bs)^T s)` for each curvature
-/// pair, skipping when `|denom|` falls below `1e-8 ||s|| ||y − Bs||`
-/// per [`sr1_denominator_ok`]. Mirrors
-/// `IpLimMemQuasiNewtonUpdater.cpp::Update_SR1`.
-fn apply_sr1_history(b: &mut [Number], n: usize, history: &[CurvaturePair]) {
-    if n == 0 {
-        return;
-    }
-    let mut bs = vec![0.0_f64; n];
-    let mut yms = vec![0.0_f64; n];
-    for pair in history {
-        let s = dense_from_vec(pair.s.as_ref(), n);
-        let y = dense_from_vec(pair.y.as_ref(), n);
-        for i in 0..n {
-            let row = &b[i * n..(i + 1) * n];
-            let mut acc = 0.0;
-            for j in 0..n {
-                acc += row[j] * s[j];
-            }
-            bs[i] = acc;
-        }
-        for i in 0..n {
-            yms[i] = y[i] - bs[i];
-        }
-        let denom: Number = (0..n).map(|i| yms[i] * s[i]).sum();
-        let yms_norm: Number = (0..n).map(|i| yms[i] * yms[i]).sum::<Number>().sqrt();
-        if !sr1_denominator_ok(denom, pair.s_norm, yms_norm) {
-            continue;
-        }
-        for i in 0..n {
-            let yms_i = yms[i];
-            let row = &mut b[i * n..(i + 1) * n];
-            for j in 0..n {
-                row[j] += yms_i * yms[j] / denom;
-            }
-        }
-    }
-}
 
 /// Initial Hessian scalar used as the diagonal of `B_0` before the
 /// rank-2 updates are applied. Mirrors upstream's three options
@@ -603,60 +584,85 @@ mod tests {
         }
     }
 
-    #[test]
-    fn bfgs_quadratic_recovers_hessian() {
-        // For a strictly-convex quadratic f(x) = ½ xᵀ A x with A SPD,
-        // a single BFGS update from B₀ = I along a curvature pair
-        // (s, y = A s) reproduces A on the s-direction:
-        //   B₁ s = y = A s.
-        // Use A = diag(2, 5), s = (1, 1), so y = (2, 5).
-        let mut b = vec![1.0, 0.0, 0.0, 1.0]; // 2x2 identity
-        let p = pair(&[1.0, 1.0], &[2.0, 5.0]);
-        apply_bfgs_history(&mut b, 2, std::slice::from_ref(&p));
-        // (B s)[0] should equal y[0]=2, (B s)[1] should equal y[1]=5.
-        let bs0 = b[0] * 1.0 + b[1] * 1.0;
-        let bs1 = b[2] * 1.0 + b[3] * 1.0;
-        assert!((bs0 - 2.0).abs() < 1e-12, "Bs[0]={}", bs0);
-        assert!((bs1 - 5.0).abs() < 1e-12, "Bs[1]={}", bs1);
+    /// Reconstruct the dense `B = σ I + V Vᵀ − U Uᵀ` from the low-rank
+    /// factors so we can check the Hessian *action* the SMW solver sees.
+    fn reconstruct_b(n: usize, sigma: Number, v: &[Vec<Number>], u: &[Vec<Number>]) -> Vec<Number> {
+        let mut b = vec![0.0_f64; n * n];
+        for i in 0..n {
+            b[i * n + i] = sigma;
+        }
+        for col in v {
+            for i in 0..n {
+                for j in 0..n {
+                    b[i * n + j] += col[i] * col[j];
+                }
+            }
+        }
+        for col in u {
+            for i in 0..n {
+                for j in 0..n {
+                    b[i * n + j] -= col[i] * col[j];
+                }
+            }
+        }
+        b
+    }
+
+    fn mat_vec(b: &[Number], n: usize, x: &[Number]) -> Vec<Number> {
+        (0..n)
+            .map(|i| (0..n).map(|j| b[i * n + j] * x[j]).sum())
+            .collect()
     }
 
     #[test]
-    fn bfgs_history_keeps_symmetry() {
-        let mut b = vec![3.0, 0.0, 0.0, 3.0];
-        let pairs = vec![
-            pair(&[1.0, 0.5], &[2.0, 1.0]),
-            pair(&[0.7, 1.2], &[1.0, 2.5]),
-        ];
-        apply_bfgs_history(&mut b, 2, &pairs);
+    fn bfgs_low_rank_recovers_hessian_action() {
+        // For a strictly-convex quadratic f(x) = ½ xᵀ A x with A SPD,
+        // a single BFGS update from B₀ = I along a curvature pair
+        // (s, y = A s) reproduces A on the s-direction:  B₁ s = y = A s.
+        // Use A = diag(2, 5), s = (1, 1), so y = (2, 5).
+        let mut up = LimMemQuasiNewtonUpdater::new();
+        up.history.push(pair(&[1.0, 1.0], &[2.0, 5.0]));
+        let (v, u) = up.build_low_rank(1.0, 2);
+        let b = reconstruct_b(2, 1.0, &v, &u);
+        let bs = mat_vec(&b, 2, &[1.0, 1.0]);
+        assert!((bs[0] - 2.0).abs() < 1e-12, "Bs[0]={}", bs[0]);
+        assert!((bs[1] - 5.0).abs() < 1e-12, "Bs[1]={}", bs[1]);
+    }
+
+    #[test]
+    fn bfgs_low_rank_keeps_symmetry() {
+        let mut up = LimMemQuasiNewtonUpdater::new();
+        up.history.push(pair(&[1.0, 0.5], &[2.0, 1.0]));
+        up.history.push(pair(&[0.7, 1.2], &[1.0, 2.5]));
+        let (v, u) = up.build_low_rank(3.0, 2);
+        let b = reconstruct_b(2, 3.0, &v, &u);
+        // VVᵀ and UUᵀ are symmetric by construction, so B must be too.
         assert!((b[1] - b[2]).abs() < 1e-12);
     }
 
     #[test]
-    fn sr1_quadratic_one_pair_recovers_hessian_action() {
+    fn sr1_low_rank_recovers_hessian_action() {
         // SR1 update with B₀ = I, s = (1, 1), y = (2, 5):
-        // y - B s = (1, 4); denom = (1, 4)·(1, 1) = 5;
-        // ΔB = (1, 4)(1, 4)ᵀ / 5 = [[0.2, 0.8], [0.8, 3.2]]
-        // B₁ = [[1.2, 0.8], [0.8, 4.2]]; B₁ s = (2.0, 5.0) = y. ✓
-        let mut b = vec![1.0, 0.0, 0.0, 1.0];
-        let p = pair(&[1.0, 1.0], &[2.0, 5.0]);
-        apply_sr1_history(&mut b, 2, std::slice::from_ref(&p));
-        let bs0 = b[0] + b[1];
-        let bs1 = b[2] + b[3];
-        assert!((bs0 - 2.0).abs() < 1e-12);
-        assert!((bs1 - 5.0).abs() < 1e-12);
+        // y - B s = (1, 4); denom = (1, 4)·(1, 1) = 5 > 0 → one V column.
+        // ΔB = (1, 4)(1, 4)ᵀ / 5; B₁ s = (2.0, 5.0) = y. ✓
+        let mut up = LimMemQuasiNewtonUpdater {
+            update_type: UpdateType::Sr1,
+            ..LimMemQuasiNewtonUpdater::default()
+        };
+        up.history.push(pair(&[1.0, 1.0], &[2.0, 5.0]));
+        let (v, u) = up.build_low_rank(1.0, 2);
+        assert_eq!(v.len(), 1, "positive denom routes to V");
+        assert!(u.is_empty());
+        let b = reconstruct_b(2, 1.0, &v, &u);
+        let bs = mat_vec(&b, 2, &[1.0, 1.0]);
+        assert!((bs[0] - 2.0).abs() < 1e-12);
+        assert!((bs[1] - 5.0).abs() < 1e-12);
     }
 
     #[test]
-    fn full_lower_triangle_space_has_n_n_plus_1_over_2() {
-        let s = make_full_lower_triangle_space(4);
-        assert_eq!(s.dim(), 4);
-        assert_eq!(s.nonzeros(), 10);
-        // First few entries: (1,1), (2,1), (2,2), (3,1), ...
-        assert_eq!(s.irows()[0], 1);
-        assert_eq!(s.jcols()[0], 1);
-        assert_eq!(s.irows()[1], 2);
-        assert_eq!(s.jcols()[1], 1);
-        assert_eq!(s.irows()[2], 2);
-        assert_eq!(s.jcols()[2], 2);
+    fn empty_history_yields_no_columns() {
+        let up = LimMemQuasiNewtonUpdater::new();
+        let (v, u) = up.build_low_rank(1.0, 4);
+        assert!(v.is_empty() && u.is_empty());
     }
 }

--- a/crates/pounce-algorithm/src/hess/lim_mem_quasi_newton.rs
+++ b/crates/pounce-algorithm/src/hess/lim_mem_quasi_newton.rs
@@ -371,7 +371,6 @@ fn dense_from_vec(v: &dyn Vector, n: usize) -> Vec<Number> {
     panic!("LimMemQuasiNewtonUpdater: curvature pairs must be DenseVector-backed");
 }
 
-
 /// Initial Hessian scalar used as the diagonal of `B_0` before the
 /// rank-2 updates are applied. Mirrors upstream's three options
 /// (`limited_memory_initialization` in

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -604,16 +604,47 @@ impl AugSystemSolver for LowRankAugSystemSolver {
         // (`eq_mult`) drive this same solver with their own zero W block
         // and `w_factor = 0` — there is no low-rank update to apply, so
         // bypass the SMW machinery and solve directly through the inner
-        // augmented-system solver with the original coefficients.
-        // `data.w` only carries a `LowRankUpdateSymMatrix` for the main
-        // primal-dual solves (always `w_factor = 1`).
+        // augmented-system solver. `data.w` only carries a
+        // `LowRankUpdateSymMatrix` for the main primal-dual solves
+        // (always `w_factor = 1`).
         let lr_w_opt = coeffs
             .w
             .and_then(|w| w.as_any().downcast_ref::<LowRankUpdateSymMatrix>());
         let Some(lr_w) = lr_w_opt else {
-            let status = self
-                .inner
-                .solve(coeffs, rhs, sol, check_neg_evals, num_neg_evals);
+            // Stable-W-structure optimization. These Hessian-free solves
+            // carry `w_factor = 0`, so their W block contributes nothing.
+            // Rather than forward the original `zero_w` — whose sparsity
+            // (the declared/empty exact-Hessian pattern) differs from the
+            // `n`-diagonal `B0` the SMW main solves feed the inner — we
+            // substitute a zero `n`-diagonal `DiagMatrix`. The inner
+            // solver then sees one unchanging triplet structure across the
+            // whole iteration and factorizes the symbolic pattern *once*,
+            // instead of re-running the symbolic analysis every time the
+            // W pattern alternates between `zero_w` and `B0`. Numerically
+            // identical (W·0 = 0); purely a performance fix.
+            let n_x = rhs.rhs_x.dim();
+            let zspace = DenseVectorSpace::new(n_x);
+            let mut zdiag = zspace.make_new_dense();
+            zdiag.set(0.0);
+            let mut zero_w = DiagMatrix::new(n_x);
+            zero_w.set_diag(Rc::new(zdiag) as Rc<dyn Vector>);
+            let stable_coeffs = AugSysCoeffs {
+                w: Some(&zero_w as &dyn SymMatrix),
+                w_factor: 0.0,
+                d_x: coeffs.d_x,
+                delta_x: coeffs.delta_x,
+                d_s: coeffs.d_s,
+                delta_s: coeffs.delta_s,
+                j_c: coeffs.j_c,
+                d_c: coeffs.d_c,
+                delta_c: coeffs.delta_c,
+                j_d: coeffs.j_d,
+                d_d: coeffs.d_d,
+                delta_d: coeffs.delta_d,
+            };
+            let status =
+                self.inner
+                    .solve(&stable_coeffs, rhs, sol, check_neg_evals, num_neg_evals);
             if self.inner.provides_inertia() {
                 self.num_neg_evals = self.inner.number_of_neg_evals();
             }

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -37,7 +37,6 @@ use pounce_linalg::{Matrix, SymMatrix, Vector};
 use pounce_linsol::ESymSolverStatus;
 use std::rc::Rc;
 
-
 pub struct LowRankAugSystemSolver {
     /// Inner solver that owns the diagonal factorization.
     inner: Box<dyn AugSystemSolver>,

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -921,6 +921,76 @@ mod tests {
     }
 
     #[test]
+    fn smw_reports_wrong_inertia_on_indefinite_negative_update() {
+        // 1×1 system: W = b0 − u² with u² > b0, so B = 2 − 4 = −2 is
+        // genuinely indefinite — the SR1 negative-curvature regime. The
+        // SMW middle matrix M2 = 1 − Utilde2ᵀU = 1 − u²/b0 = −1 is then
+        // not positive definite, so its Cholesky must fail and the solver
+        // must report `WrongInertia` — the signal the perturbation handler
+        // keys on to correct the step — rather than silently returning a
+        // garbage solve. (`number_of_neg_evals` is not asserted here: with
+        // a real inertia-providing inner solver it delegates to the inner;
+        // the mock reports 0.)
+        let space_x = DenseVectorSpace::new(1);
+        let space_zero = DenseVectorSpace::new(0);
+        let lr_space = LowRankUpdateSymMatrixSpace::new(1, None, false);
+        let mut lr = lr_space.make_new_low_rank();
+        lr.set_diag(dvec_rc(&space_x, &[2.0]));
+        let u_space = MultiVectorMatrixSpace::new(1, Rc::clone(&space_x));
+        let mut u_mvm = u_space.make_new_multi_vector();
+        u_mvm.set_vector(0, dvec_rc(&space_x, &[2.0]) as Rc<dyn Vector>);
+        lr.set_u(Rc::new(u_mvm));
+        let lr_rc: Rc<LowRankUpdateSymMatrix> = Rc::new(lr);
+
+        let mut solver = LowRankAugSystemSolver::new(Box::new(DiagInner {
+            calls: Cell::new(0),
+        }));
+
+        let j_c_space = pounce_linalg::dense_gen_matrix::DenseGenMatrixSpace::new(0, 1);
+        let j_d_space = pounce_linalg::dense_gen_matrix::DenseGenMatrixSpace::new(0, 1);
+        let j_c = j_c_space.make_new_dense_gen();
+        let j_d = j_d_space.make_new_dense_gen();
+
+        let coeffs = AugSysCoeffs {
+            w: Some(lr_rc.as_ref() as &dyn SymMatrix),
+            w_factor: 1.0,
+            d_x: None,
+            delta_x: 0.0,
+            d_s: None,
+            delta_s: 0.0,
+            j_c: &j_c as &dyn Matrix,
+            d_c: None,
+            delta_c: 0.0,
+            j_d: &j_d as &dyn Matrix,
+            d_d: None,
+            delta_d: 0.0,
+        };
+
+        let rhs_x = dvec(&space_x, &[1.0]);
+        let rhs_s = dvec(&space_zero, &[]);
+        let rhs_c = dvec(&space_zero, &[]);
+        let rhs_d = dvec(&space_zero, &[]);
+        let rhs = AugSysRhs {
+            rhs_x: &rhs_x,
+            rhs_s: &rhs_s,
+            rhs_c: &rhs_c,
+            rhs_d: &rhs_d,
+        };
+        let mut sol_x = dvec(&space_x, &[0.0]);
+        let mut sol_s = dvec(&space_zero, &[]);
+        let mut sol_c = dvec(&space_zero, &[]);
+        let mut sol_d = dvec(&space_zero, &[]);
+        let mut sol = AugSysSol {
+            sol_x: &mut sol_x,
+            sol_s: &mut sol_s,
+            sol_c: &mut sol_c,
+            sol_d: &mut sol_d,
+        };
+        let status = solver.solve(&coeffs, &rhs, &mut sol, false, 0);
+        assert_eq!(status, ESymSolverStatus::WrongInertia);
+    }
+
+    #[test]
     fn smw_with_v_and_u_combines_corrections() {
         // 1×1 system: W = b0 + v² − u² (rank-2 update). Solve checks
         // both correction passes compose correctly.

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -37,6 +37,7 @@ use pounce_linalg::{Matrix, SymMatrix, Vector};
 use pounce_linsol::ESymSolverStatus;
 use std::rc::Rc;
 
+
 pub struct LowRankAugSystemSolver {
     /// Inner solver that owns the diagonal factorization.
     inner: Box<dyn AugSystemSolver>,
@@ -386,7 +387,10 @@ impl LowRankAugSystemSolver {
                 ut_d.add_right_mult_matrix(-1.0, vt1_d, &c_mat, 1.0);
             }
 
-            // 6. M2 = I − Utilde2_x^T · U_x; J2 = chol(M2).
+            // 6. M2 = I − Utilde2_x^T · U_x; J2 = chol(M2). A non-positive
+            //    pivot means the `−UUᵀ` correction drove the reduced
+            //    Hessian indefinite: a genuine wrong-inertia signal that
+            //    the perturbation handler should act on.
             let m2_space = DenseSymMatrixSpace::new(n_u);
             let mut m2 = m2_space.make_new_dense_sym();
             m2.fill_identity(1.0);
@@ -595,14 +599,29 @@ impl AugSystemSolver for LowRankAugSystemSolver {
             check_neg_evals = false;
         }
 
+        // Hessian-free / non-low-rank W: the least-square-multiplier
+        // initialization (`init`) and the equality-multiplier estimates
+        // (`eq_mult`) drive this same solver with their own zero W block
+        // and `w_factor = 0` — there is no low-rank update to apply, so
+        // bypass the SMW machinery and solve directly through the inner
+        // augmented-system solver with the original coefficients.
+        // `data.w` only carries a `LowRankUpdateSymMatrix` for the main
+        // primal-dual solves (always `w_factor = 1`).
+        let lr_w_opt = coeffs
+            .w
+            .and_then(|w| w.as_any().downcast_ref::<LowRankUpdateSymMatrix>());
+        let Some(lr_w) = lr_w_opt else {
+            let status = self
+                .inner
+                .solve(coeffs, rhs, sol, check_neg_evals, num_neg_evals);
+            if self.inner.provides_inertia() {
+                self.num_neg_evals = self.inner.number_of_neg_evals();
+            }
+            return status;
+        };
+
         let needs_rebuild = self.first_call || self.augmented_system_requires_change(coeffs);
         if needs_rebuild {
-            let lr_w = match coeffs.w {
-                Some(w) => w.as_any().downcast_ref::<LowRankUpdateSymMatrix>().expect(
-                    "LowRankAugSystemSolver requires a LowRankUpdateSymMatrix as its W block",
-                ),
-                None => panic!("LowRankAugSystemSolver requires a non-None W"),
-            };
             let status =
                 self.update_factorization(lr_w, coeffs, rhs, check_neg_evals, num_neg_evals);
             if status != ESymSolverStatus::Success {

--- a/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/low_rank_aug_system_solver.rs
@@ -604,47 +604,16 @@ impl AugSystemSolver for LowRankAugSystemSolver {
         // (`eq_mult`) drive this same solver with their own zero W block
         // and `w_factor = 0` — there is no low-rank update to apply, so
         // bypass the SMW machinery and solve directly through the inner
-        // augmented-system solver. `data.w` only carries a
-        // `LowRankUpdateSymMatrix` for the main primal-dual solves
-        // (always `w_factor = 1`).
+        // augmented-system solver with the original coefficients.
+        // `data.w` only carries a `LowRankUpdateSymMatrix` for the main
+        // primal-dual solves (always `w_factor = 1`).
         let lr_w_opt = coeffs
             .w
             .and_then(|w| w.as_any().downcast_ref::<LowRankUpdateSymMatrix>());
         let Some(lr_w) = lr_w_opt else {
-            // Stable-W-structure optimization. These Hessian-free solves
-            // carry `w_factor = 0`, so their W block contributes nothing.
-            // Rather than forward the original `zero_w` — whose sparsity
-            // (the declared/empty exact-Hessian pattern) differs from the
-            // `n`-diagonal `B0` the SMW main solves feed the inner — we
-            // substitute a zero `n`-diagonal `DiagMatrix`. The inner
-            // solver then sees one unchanging triplet structure across the
-            // whole iteration and factorizes the symbolic pattern *once*,
-            // instead of re-running the symbolic analysis every time the
-            // W pattern alternates between `zero_w` and `B0`. Numerically
-            // identical (W·0 = 0); purely a performance fix.
-            let n_x = rhs.rhs_x.dim();
-            let zspace = DenseVectorSpace::new(n_x);
-            let mut zdiag = zspace.make_new_dense();
-            zdiag.set(0.0);
-            let mut zero_w = DiagMatrix::new(n_x);
-            zero_w.set_diag(Rc::new(zdiag) as Rc<dyn Vector>);
-            let stable_coeffs = AugSysCoeffs {
-                w: Some(&zero_w as &dyn SymMatrix),
-                w_factor: 0.0,
-                d_x: coeffs.d_x,
-                delta_x: coeffs.delta_x,
-                d_s: coeffs.d_s,
-                delta_s: coeffs.delta_s,
-                j_c: coeffs.j_c,
-                d_c: coeffs.d_c,
-                delta_c: coeffs.delta_c,
-                j_d: coeffs.j_d,
-                d_d: coeffs.d_d,
-                delta_d: coeffs.delta_d,
-            };
-            let status =
-                self.inner
-                    .solve(&stable_coeffs, rhs, sol, check_neg_evals, num_neg_evals);
+            let status = self
+                .inner
+                .solve(coeffs, rhs, sol, check_neg_evals, num_neg_evals);
             if self.inner.provides_inertia() {
                 self.num_neg_evals = self.inner.number_of_neg_evals();
             }

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -32,6 +32,7 @@ use pounce_common::timing::TimingStatistics;
 use pounce_common::types::{Index, Number};
 use pounce_linalg::compound_vector::CompoundVector;
 use pounce_linalg::dense_vector::DenseVector;
+use pounce_linalg::diag_matrix::DiagMatrix;
 use pounce_linalg::triplet::{GenTMatrix, SymTMatrix};
 use pounce_linalg::Vector;
 use pounce_linsol::{ESymSolverStatus, FactorPattern, SymLinearSolver, TSymLinearSolver};
@@ -44,6 +45,15 @@ pub struct StdAugSystemSolver {
 
     /// `true` once the triplet structure has been pinned.
     initialized: bool,
+    /// Structural fingerprint `(w_nnz, jc_nnz, jd_nnz, n_x, n_c, n_d)` of
+    /// the coefficients the current pinned structure was built from. When
+    /// the next solve presents a different fingerprint — e.g. the
+    /// limited-memory `LowRankAugSystemSolver` driving this same inner
+    /// solver alternately with a Hessian-free `zero_w` block and an
+    /// `n`-diagonal quasi-Newton `B0`, which have different W nnz — the
+    /// triplet structure (and the backend's symbolic factor) is rebuilt
+    /// rather than silently reusing a stale pattern.
+    struct_sig: Option<(usize, usize, usize, Index, Index, Index)>,
     n_x: Index,
     n_s: Index,
     n_c: Index,
@@ -107,6 +117,7 @@ impl StdAugSystemSolver {
         Self {
             linsol,
             initialized: false,
+            struct_sig: None,
             n_x: 0,
             n_s: 0,
             n_c: 0,
@@ -140,7 +151,7 @@ impl StdAugSystemSolver {
 
         let w_nnz = match coeffs.w {
             None => 0_usize,
-            Some(w) => sym_t_downcast(w).nonzeros() as usize,
+            Some(w) => w_nonzeros(w),
         };
         let jc_nnz = gen_t_downcast(coeffs.j_c).nonzeros() as usize;
         let jd_nnz = gen_t_downcast(coeffs.j_d).nonzeros() as usize;
@@ -161,9 +172,20 @@ impl StdAugSystemSolver {
         // ---- (1,1) block: W ----
         let w_start = self.irn.len();
         if let Some(w) = coeffs.w {
-            let w = sym_t_downcast(w);
-            self.irn.extend_from_slice(w.irows());
-            self.jcn.extend_from_slice(w.jcols());
+            if let Some(t) = w.as_any().downcast_ref::<SymTMatrix>() {
+                self.irn.extend_from_slice(t.irows());
+                self.jcn.extend_from_slice(t.jcols());
+            } else if let Some(dm) = w.as_any().downcast_ref::<DiagMatrix>() {
+                // Diagonal W (e.g. the quasi-Newton `B0` substituted by
+                // `LowRankAugSystemSolver`): one (i, i) entry per row.
+                let n = w_diag_dim(dm);
+                for i in 0..n {
+                    self.irn.push(i + 1);
+                    self.jcn.push(i + 1);
+                }
+            } else {
+                unreachable!("StdAugSystemSolver: W must be a SymTMatrix or DiagMatrix in v1.0")
+            }
         }
         self.w_range = w_start..self.irn.len();
 
@@ -256,10 +278,18 @@ impl StdAugSystemSolver {
             let Some(w_dyn) = coeffs.w else {
                 unreachable!("structure pinned with W; W cannot be None now")
             };
-            let w = sym_t_downcast(w_dyn);
             let dst = &mut self.vals[self.w_range.clone()];
-            for (d, &v) in dst.iter_mut().zip(w.values().iter()) {
-                *d = coeffs.w_factor * v;
+            if let Some(t) = w_dyn.as_any().downcast_ref::<SymTMatrix>() {
+                for (d, &v) in dst.iter_mut().zip(t.values().iter()) {
+                    *d = coeffs.w_factor * v;
+                }
+            } else if let Some(dm) = w_dyn.as_any().downcast_ref::<DiagMatrix>() {
+                let diag = w_diag_values(dm);
+                for (d, &v) in dst.iter_mut().zip(diag.iter()) {
+                    *d = coeffs.w_factor * v;
+                }
+            } else {
+                unreachable!("StdAugSystemSolver: W must be a SymTMatrix or DiagMatrix in v1.0")
             }
         }
         // (1,1) diag: D_x + δ_x
@@ -361,12 +391,33 @@ impl AugSystemSolver for StdAugSystemSolver {
         check_neg_evals: bool,
         num_neg_evals: Index,
     ) -> ESymSolverStatus {
-        if !self.initialized {
+        // Rebuild the triplet structure (and the backend symbolic factor)
+        // whenever the coefficients' structural fingerprint changes, not
+        // just on the first call. The limited-memory low-rank solver
+        // drives this inner solver with W blocks of different sparsity
+        // (`zero_w` for Hessian-free init/multiplier solves vs an
+        // `n`-diagonal `B0` for the main solves); reusing a stale pinned
+        // structure would drop the W block entirely.
+        let sig = {
+            let w_nnz = coeffs.w.map(w_nonzeros).unwrap_or(0);
+            let jc_nnz = gen_t_downcast(coeffs.j_c).nonzeros() as usize;
+            let jd_nnz = gen_t_downcast(coeffs.j_d).nonzeros() as usize;
+            (
+                w_nnz,
+                jc_nnz,
+                jd_nnz,
+                coeffs.j_c.n_cols(),
+                coeffs.j_c.n_rows(),
+                coeffs.j_d.n_rows(),
+            )
+        };
+        if !self.initialized || self.struct_sig != Some(sig) {
             let s = self.build_structure(coeffs);
             if s != ESymSolverStatus::Success {
                 self.last_status = Some(s);
                 return s;
             }
+            self.struct_sig = Some(sig);
         }
         self.refill_values(coeffs);
 
@@ -685,11 +736,32 @@ fn dump_kkt(
     }
 }
 
-fn sym_t_downcast(m: &dyn pounce_linalg::SymMatrix) -> &SymTMatrix {
-    let Some(t) = m.as_any().downcast_ref::<SymTMatrix>() else {
-        unreachable!("StdAugSystemSolver: W must be a SymTMatrix in v1.0")
-    };
-    t
+/// Triplet-entry count the (1,1) `W` block contributes, supporting both
+/// an explicit [`SymTMatrix`] and a diagonal [`DiagMatrix`] (the latter
+/// is what [`crate::kkt::low_rank_aug_system_solver`] substitutes for the
+/// limited-memory quasi-Newton `B0`).
+fn w_nonzeros(w: &dyn pounce_linalg::SymMatrix) -> usize {
+    if let Some(t) = w.as_any().downcast_ref::<SymTMatrix>() {
+        t.nonzeros() as usize
+    } else if let Some(dm) = w.as_any().downcast_ref::<DiagMatrix>() {
+        w_diag_dim(dm) as usize
+    } else {
+        unreachable!("StdAugSystemSolver: W must be a SymTMatrix or DiagMatrix in v1.0")
+    }
+}
+
+fn w_diag_dim(dm: &DiagMatrix) -> Index {
+    dm.get_diag()
+        .expect("DiagMatrix W has no diagonal set")
+        .dim()
+}
+
+fn w_diag_values(dm: &DiagMatrix) -> Vec<Number> {
+    let diag = dm.get_diag().expect("DiagMatrix W has no diagonal set");
+    diag.as_any()
+        .downcast_ref::<DenseVector>()
+        .expect("StdAugSystemSolver: DiagMatrix W diagonal must be DenseVector in v1.0")
+        .expanded_values()
 }
 
 fn gen_t_downcast(m: &dyn pounce_linalg::Matrix) -> &GenTMatrix {
@@ -1012,6 +1084,191 @@ mod tests {
         }
         for v in sd.values() {
             assert!((v - 1.0).abs() < 1e-10, "sol_d = {v}");
+        }
+    }
+
+    /// End-to-end equivalence: solving the augmented system with an
+    /// explicit dense `W = σ I + v vᵀ − u uᵀ` (a `SymTMatrix`) through
+    /// `StdAugSystemSolver` must produce the *same* solution as solving
+    /// it with the matching `LowRankUpdateSymMatrix` through
+    /// `LowRankAugSystemSolver` wrapping `StdAugSystemSolver`. This is
+    /// the integration the limited-memory path relies on: it exercises
+    /// the constrained SMW path with both a positive (V) and a negative
+    /// (U) curvature column, and the `DiagMatrix`-W branch of
+    /// `StdAugSystemSolver`. `DenseMock` gives an exact LU oracle.
+    #[test]
+    fn lowrank_smw_matches_dense_w_on_constrained_system() {
+        use crate::kkt::low_rank_aug_system_solver::LowRankAugSystemSolver;
+        use pounce_linalg::diag_matrix::DiagMatrix;
+        use pounce_linalg::low_rank_update_sym_matrix::LowRankUpdateSymMatrixSpace;
+        use pounce_linalg::multi_vector_matrix::MultiVectorMatrixSpace;
+
+        let n = 4usize;
+        let sigma = 2.0;
+        // Three V columns and three U columns in R⁴ — six vectors in
+        // 4-space, the exact L-BFGS situation (2·history columns) that
+        // the single-column-only mock tests never exercised. Magnitudes
+        // kept modest so B = σI + Σvvᵀ − Σuuᵀ stays SPD.
+        let vcols = [
+            vec![0.6, 0.1, -0.2, 0.3],
+            vec![0.2, 0.5, 0.1, -0.1],
+            vec![-0.1, 0.2, 0.4, 0.2],
+            vec![0.3, -0.2, 0.1, 0.4],
+            vec![0.15, 0.25, -0.3, 0.1],
+            vec![-0.2, 0.1, 0.2, 0.35],
+        ];
+        let ucols = [
+            vec![0.3, -0.1, 0.2, 0.1],
+            vec![0.1, 0.3, -0.2, 0.2],
+            vec![0.2, 0.1, 0.1, -0.3],
+            vec![-0.1, 0.2, 0.15, 0.1],
+            vec![0.25, -0.15, 0.1, 0.2],
+            vec![0.1, 0.2, -0.25, 0.15],
+        ];
+        // Dense W = σI + Σ vᵢvᵢᵀ − Σ uᵢuᵢᵀ (full lower triangle triplet).
+        let mut wfull = vec![0.0_f64; n * n];
+        for i in 0..n {
+            wfull[i * n + i] = sigma;
+        }
+        for c in vcols.iter() {
+            for i in 0..n {
+                for j in 0..n {
+                    wfull[i * n + j] += c[i] * c[j];
+                }
+            }
+        }
+        for c in ucols.iter() {
+            for i in 0..n {
+                for j in 0..n {
+                    wfull[i * n + j] -= c[i] * c[j];
+                }
+            }
+        }
+
+        // J_c = [1 1 1 1]; no inequalities (n_d = n_s = 0).
+        let make_jc = || {
+            let sp = GenTMatrixSpace::new(1, 4, vec![1, 1, 1, 1], vec![1, 2, 3, 4]);
+            let mut m = GenTMatrix::new(sp);
+            m.set_values(&[1.0, 1.0, 1.0, 1.0]);
+            m
+        };
+        // One inequality row → n_d = n_s = 1 (a slack block), matching
+        // HS071's structure. The mock + single-column tests never had a
+        // slack block; the SMW s/d-block path went uncovered.
+        let make_jd = || {
+            let sp = GenTMatrixSpace::new(1, 4, vec![1, 1], vec![1, 3]);
+            let mut m = GenTMatrix::new(sp);
+            m.set_values(&[1.0, 1.0]);
+            m
+        };
+
+        let xs = DenseVectorSpace::new(4);
+        let cs = DenseVectorSpace::new(1);
+        let mk = |sp: &Rc<DenseVectorSpace>, vals: &[Number]| {
+            let mut d = sp.make_new_dense();
+            d.set_values(vals);
+            d
+        };
+
+        let solve_with = |w: &dyn pounce_linalg::SymMatrix,
+                          aug: &mut dyn AugSystemSolver|
+         -> (Vec<Number>, Vec<Number>) {
+            let j_c = make_jc();
+            let j_d = make_jd();
+            let rx = mk(&xs, &[1.0, 2.0, -1.0, 0.5]);
+            let rs = mk(&cs, &[0.4]);
+            let rc = mk(&cs, &[3.0]);
+            let rd = mk(&cs, &[0.7]);
+            let mut sx = mk(&xs, &[0.0, 0.0, 0.0, 0.0]);
+            let mut ss = mk(&cs, &[0.0]);
+            let mut sc = mk(&cs, &[0.0]);
+            let mut sd = mk(&cs, &[0.0]);
+            let d_s = mk(&cs, &[1.5]);
+            let coeffs = AugSysCoeffs {
+                w: Some(w),
+                w_factor: 1.0,
+                d_x: None,
+                delta_x: 0.0,
+                d_s: Some(&d_s),
+                delta_s: 0.0,
+                j_c: &j_c,
+                d_c: None,
+                delta_c: 0.0,
+                j_d: &j_d,
+                d_d: None,
+                delta_d: 0.0,
+            };
+            let rhs = AugSysRhs {
+                rhs_x: &rx,
+                rhs_s: &rs,
+                rhs_c: &rc,
+                rhs_d: &rd,
+            };
+            let mut sol = AugSysSol {
+                sol_x: &mut sx,
+                sol_s: &mut ss,
+                sol_c: &mut sc,
+                sol_d: &mut sd,
+            };
+            let status = aug.solve(&coeffs, &rhs, &mut sol, false, 1);
+            assert_eq!(status, ESymSolverStatus::Success);
+            (sx.expanded_values(), sc.expanded_values())
+        };
+
+        // Dense reference: full lower-triangle triplet of `wfull`.
+        let mut wi = Vec::new();
+        let mut wj = Vec::new();
+        let mut wv = Vec::new();
+        for i in 0..n {
+            for j in 0..=i {
+                wi.push(i as Index + 1);
+                wj.push(j as Index + 1);
+                wv.push(wfull[i * n + j]);
+            }
+        }
+        let w_space = SymTMatrixSpace::new(4, wi, wj);
+        let mut w_dense = SymTMatrix::new(w_space);
+        w_dense.set_values(&wv);
+        let mut std_solver = StdAugSystemSolver::new(TSymLinearSolver::new(
+            Box::new(pounce_feral::FeralSolverInterface::new()),
+            None,
+            false,
+        ));
+        let (ref_x, ref_c) = solve_with(&w_dense, &mut std_solver);
+
+        // Low-rank SMW path: same B as a LowRankUpdateSymMatrix.
+        let lr_space = LowRankUpdateSymMatrixSpace::new(4, None, false);
+        let mut lr = lr_space.make_new_low_rank();
+        let mut diag = xs.make_new_dense();
+        diag.set_values(&[sigma; 4]);
+        lr.set_diag(Rc::new(diag) as Rc<dyn Vector>);
+        let build_mvm = |cols: &[Vec<Number>]| {
+            let sp = MultiVectorMatrixSpace::new(cols.len() as Index, Rc::clone(&xs));
+            let mut mvm = sp.make_new_multi_vector();
+            for (k, c) in cols.iter().enumerate() {
+                let mut cv = xs.make_new_dense();
+                cv.set_values(c);
+                mvm.set_vector(k as Index, Rc::new(cv) as Rc<dyn Vector>);
+            }
+            mvm
+        };
+        lr.set_v(Rc::new(build_mvm(&vcols)));
+        lr.set_u(Rc::new(build_mvm(&ucols)));
+        let _ = DiagMatrix::new(4); // ensure DiagMatrix path is linked
+
+        let mut lr_solver =
+            LowRankAugSystemSolver::new(Box::new(StdAugSystemSolver::new(TSymLinearSolver::new(
+                Box::new(pounce_feral::FeralSolverInterface::new()),
+                None,
+                false,
+            ))));
+        let (lr_x, lr_c) = solve_with(&lr, &mut lr_solver);
+
+        for (a, b) in ref_x.iter().zip(lr_x.iter()) {
+            assert!((a - b).abs() < 1e-9, "sol_x mismatch: dense={a} smw={b}");
+        }
+        for (a, b) in ref_c.iter().zip(lr_c.iter()) {
+            assert!((a - b).abs() < 1e-9, "sol_c mismatch: dense={a} smw={b}");
         }
     }
 }

--- a/crates/pounce-algorithm/tests/large_lbfgs_lowrank.rs
+++ b/crates/pounce-algorithm/tests/large_lbfgs_lowrank.rs
@@ -1,0 +1,136 @@
+//! Large-`n` limited-memory L-BFGS through the low-rank
+//! Sherman-Morrison-Woodbury path.
+//!
+//! `LimMemQuasiNewtonUpdater` publishes a `LowRankUpdateSymMatrix` and the
+//! solve goes through `LowRankAugSystemSolver` — no dense `n×n` is ever
+//! formed. At `n = 2500` this guards that the limited-memory path scales:
+//! a dense Hessian rebuild here would be `O(n²)`, and the point of the
+//! low-rank assembler is `O(n·m)` storage. The problem is a
+//! well-conditioned separable convex quadratic with a single equality
+//! constraint and an interior optimum, so it converges in a handful of
+//! iterations and the test stays fast.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const N: usize = 2500;
+
+fn target(i: usize) -> Number {
+    0.5 * (0.1 * i as Number).sin()
+}
+
+#[derive(Default)]
+struct SeparableQp {
+    final_obj: Option<Number>,
+    final_x0: Option<Number>,
+}
+
+impl TNLP for SeparableQp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: N as i32,
+            m: 1,
+            nnz_jac_g: N as i32,
+            nnz_h_lag: 0,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.iter_mut().for_each(|v| *v = -10.0);
+        b.x_u.iter_mut().for_each(|v| *v = 10.0);
+        // Equality: Σ x_i = Σ a_i (so x* = a is feasible and optimal).
+        let rhs: Number = (0..N).map(target).sum();
+        b.g_l[0] = rhs;
+        b.g_u[0] = rhs;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.iter_mut().for_each(|v| *v = 0.0);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(0.5 * (0..N).map(|i| (x[i] - target(i)).powi(2)).sum::<Number>())
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..N {
+            g[i] = x[i] - target(i);
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x.iter().sum();
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for j in 0..N {
+                    irow[j] = 0;
+                    jcol[j] = j as i32;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                values.iter_mut().for_each(|v| *v = 1.0);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_obj = Some(sol.obj_value);
+        if !sol.x.is_empty() {
+            self.final_x0 = Some(sol.x[0]);
+        }
+    }
+}
+
+#[test]
+fn large_separable_qp_solves_with_lbfgs_lowrank() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("hessian_approximation", "limited-memory", true, true)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(SeparableQp::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+
+    let stats = app.statistics();
+    eprintln!(
+        "large L-BFGS (n={N}): status={:?} iter={} obj={}",
+        status, stats.iteration_count, stats.final_objective,
+    );
+
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+    // Optimum is x* = a, objective 0.
+    let obj = tnlp_concrete.borrow().final_obj.unwrap();
+    assert!(obj < 1e-6, "final objective {obj} not near 0");
+    let x0 = tnlp_concrete.borrow().final_x0.unwrap();
+    assert!((x0 - target(0)).abs() < 1e-3, "x[0]={x0} expected {}", target(0));
+}

--- a/crates/pounce-algorithm/tests/large_lbfgs_lowrank.rs
+++ b/crates/pounce-algorithm/tests/large_lbfgs_lowrank.rs
@@ -132,7 +132,11 @@ fn large_separable_qp_solves_with_lbfgs_lowrank() {
     let obj = tnlp_concrete.borrow().final_obj.unwrap();
     assert!(obj < 1e-6, "final objective {obj} not near 0");
     let x0 = tnlp_concrete.borrow().final_x0.unwrap();
-    assert!((x0 - target(0)).abs() < 1e-3, "x[0]={x0} expected {}", target(0));
+    assert!(
+        (x0 - target(0)).abs() < 1e-3,
+        "x[0]={x0} expected {}",
+        target(0)
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -244,7 +248,10 @@ fn large_bound_active_qp_solves_with_lbfgs_lowrank() {
     );
 
     // Closed-form optimum: xᵢ* = clamp(aᵢ, 0, 1).
-    let obj_star: Number = 0.5 * (0..M).map(|i| (clamp01(a_of(i)) - a_of(i)).powi(2)).sum::<Number>();
+    let obj_star: Number = 0.5
+        * (0..M)
+            .map(|i| (clamp01(a_of(i)) - a_of(i)).powi(2))
+            .sum::<Number>();
     let obj = tnlp_concrete.borrow().final_obj.unwrap();
     assert!(
         (obj - obj_star).abs() < 1e-4,
@@ -258,6 +265,16 @@ fn large_bound_active_qp_solves_with_lbfgs_lowrank() {
     // i=10: a≈1.78  → upper-active, x*≈1.
     // i=35: a≈-0.88 → lower-active, x*≈0.
     assert!((x[0] - clamp01(a_of(0))).abs() < 1e-3, "x[0]={}", x[0]);
-    assert!(x[10] > 1.0 - 1e-4, "upper-active x[10]={} (a={})", x[10], a_of(10));
-    assert!(x[35] < 1e-4, "lower-active x[35]={} (a={})", x[35], a_of(35));
+    assert!(
+        x[10] > 1.0 - 1e-4,
+        "upper-active x[10]={} (a={})",
+        x[10],
+        a_of(10)
+    );
+    assert!(
+        x[35] < 1e-4,
+        "lower-active x[35]={} (a={})",
+        x[35],
+        a_of(35)
+    );
 }

--- a/crates/pounce-algorithm/tests/large_lbfgs_lowrank.rs
+++ b/crates/pounce-algorithm/tests/large_lbfgs_lowrank.rs
@@ -134,3 +134,130 @@ fn large_separable_qp_solves_with_lbfgs_lowrank() {
     let x0 = tnlp_concrete.borrow().final_x0.unwrap();
     assert!((x0 - target(0)).abs() < 1e-3, "x[0]={x0} expected {}", target(0));
 }
+
+// ---------------------------------------------------------------------------
+// Large-n with *active bounds* at the solution — the ill-conditioned regime.
+//
+// minimize 0.5 Σ (xᵢ − aᵢ)²  s.t.  0 ≤ xᵢ ≤ 1,  with aᵢ ∈ [−2, 2].
+//
+// The unconstrained minimizer aᵢ lies outside [0,1] for most i, so the
+// optimum is xᵢ* = clamp(aᵢ, 0, 1): a large fraction of the bounds are
+// active, driving the corresponding slacks → 0 and the barrier terms
+// (Σ_l, Σ_u) → ∞ as μ → 0. This is exactly the near-singular reduced
+// Hessian I worried the indirect SMW step/inertia computation might not
+// handle at scale. The known closed-form optimum lets us assert the
+// solve lands on it, not merely that it converges.
+
+const M: usize = 2500;
+
+fn a_of(i: usize) -> Number {
+    2.0 * (0.1 * (i as Number + 1.0)).sin()
+}
+
+fn clamp01(v: Number) -> Number {
+    v.clamp(0.0, 1.0)
+}
+
+#[derive(Default)]
+struct BoundActiveQp {
+    final_obj: Option<Number>,
+    final_x: Option<Vec<Number>>,
+}
+
+impl TNLP for BoundActiveQp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: M as i32,
+            m: 0,
+            nnz_jac_g: 0,
+            nnz_h_lag: 0,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.iter_mut().for_each(|v| *v = 0.0);
+        b.x_u.iter_mut().for_each(|v| *v = 1.0);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.iter_mut().for_each(|v| *v = 0.5);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(0.5 * (0..M).map(|i| (x[i] - a_of(i)).powi(2)).sum::<Number>())
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..M {
+            g[i] = x[i] - a_of(i);
+        }
+        true
+    }
+
+    fn eval_g(&mut self, _x: &[Number], _new_x: bool, _g: &mut [Number]) -> bool {
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        _mode: SparsityRequest<'_>,
+    ) -> bool {
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_obj = Some(sol.obj_value);
+        self.final_x = Some(sol.x.to_vec());
+    }
+}
+
+#[test]
+fn large_bound_active_qp_solves_with_lbfgs_lowrank() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("hessian_approximation", "limited-memory", true, true)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let tnlp_concrete = Rc::new(RefCell::new(BoundActiveQp::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp_concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+
+    let stats = app.statistics();
+    eprintln!(
+        "large bound-active L-BFGS (n={M}): status={:?} iter={} obj={}",
+        status, stats.iteration_count, stats.final_objective,
+    );
+
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+
+    // Closed-form optimum: xᵢ* = clamp(aᵢ, 0, 1).
+    let obj_star: Number = 0.5 * (0..M).map(|i| (clamp01(a_of(i)) - a_of(i)).powi(2)).sum::<Number>();
+    let obj = tnlp_concrete.borrow().final_obj.unwrap();
+    assert!(
+        (obj - obj_star).abs() < 1e-4,
+        "final objective {obj} != closed-form {obj_star}",
+    );
+
+    let x = tnlp_concrete.borrow().final_x.clone().unwrap();
+    // Spot-check one variable in each regime (bounds are interior-point,
+    // so active vars approach the bound to within barrier tolerance).
+    // i=0:  a≈0.20  → interior, x*≈0.20.
+    // i=10: a≈1.78  → upper-active, x*≈1.
+    // i=35: a≈-0.88 → lower-active, x*≈0.
+    assert!((x[0] - clamp01(a_of(0))).abs() < 1e-3, "x[0]={}", x[0]);
+    assert!(x[10] > 1.0 - 1e-4, "upper-active x[10]={} (a={})", x[10], a_of(10));
+    assert!(x[35] < 1e-4, "lower-active x[35]={} (a={})", x[35], a_of(35));
+}


### PR DESCRIPTION
## Summary

This PR implements a low-rank Sherman-Morrison-Woodbury (SMW) path for the limited-memory quasi-Newton Hessian approximation, enabling the limited-memory L-BFGS method to scale to arbitrarily large problem sizes without forming dense `n×n` matrices.

## Key Changes

- **LimMemQuasiNewtonUpdater refactoring**: Replaced the dense `n×n` Hessian rebuild with a low-rank factorization approach that builds compact factors `B = σI + VVᵀ − UUᵀ` by walking the curvature history. The new `build_low_rank()` method constructs column lists for V and U matrices with `O(n·m)` storage and `O(n·m²)` time complexity (where `m = max_history`), eliminating the former `O(n²)` memory cliff.

- **LowRankUpdateSymMatrix publishing**: The Hessian is now published as a `LowRankUpdateSymMatrix` (via `data.w`) instead of a dense `SymTMatrix`, removing the requirement for users to declare a Hessian sparsity pattern (`eval_h`).

- **StdAugSystemSolver enhancement**: Extended to support both `SymTMatrix` and `DiagMatrix` W blocks. Added structural fingerprinting (`struct_sig`) to detect when the W block's sparsity changes (e.g., between Hessian-free init/multiplier solves with zero W and main solves with diagonal `B0`), triggering structure rebuilds rather than silently reusing stale patterns.

- **LowRankAugSystemSolver integration**: Implemented bypass logic for non-low-rank W blocks (Hessian-free initialization and equality-multiplier solves) to forward directly to the inner solver, allowing a single solver instance to serve the entire iteration.

- **BFGS/SR1 column generation**: Replaced `apply_bfgs_history()` and `apply_sr1_history()` dense-matrix functions with inline low-rank column construction in `build_low_rank()`. For BFGS, each pair appends one positive column (the `rrᵀ/(sᵀr)` term with Powell damping) and one negative column (the `−(Bs)(Bs)ᵀ/(sᵀBs)` term). For SR1, each pair appends a single column to V or U depending on denominator sign.

- **Test coverage**: Added `large_lbfgs_lowrank.rs` with two large-scale tests (`n=2500`) validating the low-rank path on a separable quadratic and a bound-active quadratic with interior-point barrier terms. Added `lowrank_smw_matches_dense_w_on_constrained_system()` integration test verifying SMW solution equivalence with dense W on a constrained system with both V and U columns and slack blocks.

## Implementation Details

- The low-rank factors are built incrementally as the history is walked, computing `Bs = σs + Σ(vᵀs)v − Σ(uᵀs)u` for each pair without materializing the full matrix.
- Powell damping and SR1 denominator acceptance criteria are preserved from the original dense implementation.
- The `MultiVectorMatrix` wrapper packs column data for efficient SMW application via the Sherman-Morrison-Woodbury identity in the augmented-system solver.
- Structural fingerprinting in `StdAugSystemSolver` ensures correct handling of alternating W blocks with different sparsity patterns during a single optimization run.

https://claude.ai/code/session_01FQucLrLF6YYY71xrxvb3mA