### PR TITLE
Add interactive solver debugger (`--debug` / `--debug-json`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ Full guide in `docs/src/debugger.md`. Zero effect on the solve when not
 attached.
 
 - **Checkpoints & stepping:** pauses at `iter_start`, the sub-iteration
-  phases (`after_mu` / `after_search_dir` / `after_step`), around
-  restoration (`pre_/post_restoration_entry/exit`), and `terminated`.
+  phases (`after_mu` / `after_search_dir` / `after_step`), `step_rejected`
+  (line search gave up, before restoration), around restoration
+  (`pre_/post_restoration_entry/exit`), and `terminated`.
   `step` / `stepi` / `continue` / `run N` / `stop-at <cp>` / `detach` /
   `quit`. The same debugger **steps into the restoration inner IPM**
   (pauses flagged `in_restoration`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ changes.
 
 ## Unreleased
 
+### Added — Interactive solver debugger (`--debug` / `--debug-json`)
+
+A "pdb for the interior-point loop." `pounce <problem> --debug` opens a
+branded REPL that pauses the solve to inspect and **mutate** live state;
+`--debug-json` speaks a newline-delimited JSON protocol so an LLM agent,
+a script, or a visual debugger (VS Code DAP / webview) can drive it.
+Full guide in `docs/src/debugger.md`. Zero effect on the solve when not
+attached.
+
+- **Checkpoints & stepping:** pauses at `iter_start`, the sub-iteration
+  phases (`after_mu` / `after_search_dir` / `after_step`), around
+  restoration (`pre_/post_restoration_entry/exit`), and `terminated`.
+  `step` / `stepi` / `continue` / `run N` / `stop-at <cp>` / `detach` /
+  `quit`. The same debugger **steps into the restoration inner IPM**
+  (pauses flagged `in_restoration`).
+- **Breakpoints:** by iteration (`break N`, one-shot `tbreak N`),
+  conditional with `&&`/`||`, on a solver **event** (`break on
+  regularized|resto_entered|tiny_step|ls_rejected|mu_stalled|nan`), and
+  **watchpoints** (`watchpoint x[3]`). `commands N …` auto-runs a list on
+  hit.
+- **Inspect:** `info`; `print` of blocks, search-direction blocks (`dx`),
+  scalars (`mu obj inf_pr inf_du err compl iter`), `kkt` (inertia +
+  regularization), and `active`; `watch`/`display`; `diff`.
+- **Mutate / what-if:** `set mu`, `set x[i]`, `set opt`; `goto`/`restart`
+  (soft rewind) and `resolve` (re-solve from the current point).
+- **Visualize:** `viz kkt`/`viz L`/`viz <block>` open via `pounce-dbg-viz`
+  — an interactive Plotly viewer (spy/heatmap for the KKT matrix & LDLᵀ
+  factor, bars for vectors); `save` dumps the iterate. `pip install
+  'pounce-solver[viz]'`.
+- **Attach & drive:** `--debug-on-error` (post-mortem), `--debug-on-
+  interrupt` / Ctrl-C / in-band `{"cmd":"pause"}` (async pause),
+  `--debug-script` / `source`, option discovery + Tab completion, `ask`
+  (consult Claude Code), and a branded REPL banner reusing the project
+  wordmark with a command cheat-sheet.
+- **JSON protocol:** `hello` → `pause` → `result` (with `request_id`) →
+  `progress` → `terminated`. Engine in `pounce-algorithm::debug`; front
+  end in `pounce-cli::debug_repl`.
+
 ## [0.3.0] — 2026-06-02
 
 ### Added — Multiple-minima & critical-point global search (PR #94)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-diff"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "serde_json",
 ]
@@ -490,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-algorithm"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "anstream",
  "anstyle",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cinterface"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -525,7 +525,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cli"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "anstream",
  "anstyle",
@@ -551,7 +551,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-common"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-feral"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "feral",
  "pounce-common",
@@ -569,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-hsl"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -578,7 +578,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-l1penalty"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -586,14 +586,14 @@ dependencies = [
 
 [[package]]
 name = "pounce-linalg"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
 ]
 
 [[package]]
 name = "pounce-linsol"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nlp"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -611,7 +611,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-observability"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -625,7 +625,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-presolve"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -634,7 +634,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-py"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "numpy",
  "pounce-algorithm",
@@ -652,7 +652,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-qp"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-feral",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-restoration"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -675,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-sensitivity"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-solve-report"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-common",
  "pounce-linsol",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-core"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "serde",
  "serde_json",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-pyo3"
-version = "0.3.0"
+version = "0.3.1-dev"
 dependencies = [
  "pounce-studio-core",
  "pyo3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -84,6 +84,21 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "colorchoice"
@@ -121,6 +136,39 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "feral"
@@ -203,6 +251,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "indoc"
 version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,6 +314,12 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
@@ -314,12 +377,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -446,6 +530,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "libloading",
+ "nix",
  "pounce-algorithm",
  "pounce-common",
  "pounce-feral",
@@ -458,6 +543,7 @@ dependencies = [
  "pounce-restoration",
  "pounce-sensitivity",
  "pounce-solve-report",
+ "rustyline",
  "serde",
  "serde_json",
  "tracing",
@@ -731,6 +817,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,10 +891,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "rustyline"
+version = "14.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "rustyline-derive",
+ "unicode-segmentation",
+ "unicode-width",
+ "utf8parse",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustyline-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5af959c8bf6af1aff6d2b463a57f71aae53d1332da58419e30ad8dc7011d951"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde"
@@ -965,6 +1108,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -996,12 +1151,94 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "zmij"

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -128,6 +128,12 @@ pub struct IpoptApplication {
     /// via [`IpoptAlgorithm::with_diagnostics`] so the KKT solver and
     /// other dump sites can consult per-iter gating.
     diagnostics: Option<Rc<DiagnosticsState>>,
+    /// Optional interactive debugger hook. When set, it is moved into
+    /// the main [`IpoptAlgorithm`] for the next `optimize_*` call via
+    /// [`IpoptAlgorithm::with_debug_hook`], so a REPL or agent can pause
+    /// at each iteration to inspect / mutate live state. Consumed on use
+    /// (one solve per installed hook).
+    debug_hook: Option<Box<dyn crate::debug::DebugHook>>,
     /// Provider for the BNW outer loop (pounce#10 Phase 3). When set,
     /// `optimize_constrained` consults the provider before each inner
     /// solve, replacing `restoration_factory` with a fresh one so
@@ -203,6 +209,7 @@ impl IpoptApplication {
             linear_backend_factory: None,
             restoration_factory: None,
             diagnostics: None,
+            debug_hook: None,
             restoration_factory_provider: None,
             on_converged: None,
             record_iter_history: false,
@@ -254,6 +261,13 @@ impl IpoptApplication {
     /// solver can emit `--dump kkt:...` artifacts.
     pub fn set_diagnostics(&mut self, diag: Rc<DiagnosticsState>) {
         self.diagnostics = Some(diag);
+    }
+
+    /// Install an interactive debugger hook for the next `optimize_*`
+    /// call. The hook is moved into the main [`IpoptAlgorithm`] and
+    /// consumed by that solve; reinstall it to debug a subsequent solve.
+    pub fn set_debug_hook(&mut self, hook: Box<dyn crate::debug::DebugHook>) {
+        self.debug_hook = Some(hook);
     }
 
     /// Read-side accessor for the installed diagnostics state, if any.
@@ -1193,6 +1207,12 @@ impl IpoptApplication {
         }
         if let Some(diag) = self.diagnostics.as_ref() {
             alg = alg.with_diagnostics(Rc::clone(diag));
+        }
+        // Move the interactive debugger hook (if any) into the main
+        // algorithm. Taken — not cloned — so it drives exactly this
+        // solve; a subsequent solve must reinstall it.
+        if let Some(hook) = self.debug_hook.take() {
+            alg = alg.with_debug_hook(hook);
         }
         alg.max_iter = max_iter;
         // Honor `print_level == 0`: suppress the per-iteration table

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -133,7 +133,7 @@ pub struct IpoptApplication {
     /// [`IpoptAlgorithm::with_debug_hook`], so a REPL or agent can pause
     /// at each iteration to inspect / mutate live state. Consumed on use
     /// (one solve per installed hook).
-    debug_hook: Option<Box<dyn crate::debug::DebugHook>>,
+    debug_hook: Option<std::rc::Rc<std::cell::RefCell<dyn crate::debug::DebugHook>>>,
     /// Provider for the BNW outer loop (pounce#10 Phase 3). When set,
     /// `optimize_constrained` consults the provider before each inner
     /// solve, replacing `restoration_factory` with a fresh one so
@@ -266,7 +266,10 @@ impl IpoptApplication {
     /// Install an interactive debugger hook for the next `optimize_*`
     /// call. The hook is moved into the main [`IpoptAlgorithm`] and
     /// consumed by that solve; reinstall it to debug a subsequent solve.
-    pub fn set_debug_hook(&mut self, hook: Box<dyn crate::debug::DebugHook>) {
+    pub fn set_debug_hook(
+        &mut self,
+        hook: std::rc::Rc<std::cell::RefCell<dyn crate::debug::DebugHook>>,
+    ) {
         self.debug_hook = Some(hook);
     }
 

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -279,6 +279,21 @@ impl DebugCtx {
         self.cq_scalar(|c| c.curr_avrg_compl())
     }
 
+    /// Slacks to a bound category — `x_l` / `x_u` / `s_l` / `s_u` — i.e.
+    /// the distance of each (lower/upper-bounded) variable or inequality
+    /// slack from its bound. A small entry ⇒ that bound is near-active.
+    pub fn bound_slack(&self, which: &str) -> Option<Vec<Number>> {
+        let c = self.cq.as_ref()?.borrow();
+        let v = match which {
+            "x_l" => c.curr_slack_x_l(),
+            "x_u" => c.curr_slack_x_u(),
+            "s_l" => c.curr_slack_s_l(),
+            "s_u" => c.curr_slack_s_u(),
+            _ => return None,
+        };
+        Some(crate::ipopt_alg::flat_read_owned(v.as_ref()))
+    }
+
     /// Primal regularization δ_w applied to the KKT system this
     /// iteration (0 when none was needed). Nonzero ⇒ inertia correction.
     pub fn regularization(&self) -> Number {

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -273,6 +273,12 @@ impl DebugCtx {
         self.cq_scalar(|c| c.curr_nlp_error())
     }
 
+    /// Average complementarity (mean slack·multiplier over all bounds) —
+    /// the IPM's "distance from the central path" gauge; should track μ.
+    pub fn complementarity(&self) -> Number {
+        self.cq_scalar(|c| c.curr_avrg_compl())
+    }
+
     /// Primal regularization δ_w applied to the KKT system this
     /// iteration (0 when none was needed). Nonzero ⇒ inertia correction.
     pub fn regularization(&self) -> Number {

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -34,12 +34,18 @@ pub enum Checkpoint {
     /// multipliers, and μ all reflect the *accepted* point from the
     /// previous iteration.
     IterStart,
+    /// The solve has finished (or is about to): fired once before
+    /// `optimize` returns, at the final iterate, carrying the outcome
+    /// via [`DebugCtx::status`]. Lets a debugger drop in for a
+    /// post-mortem at the failing (or final) point.
+    Terminated,
 }
 
 impl Checkpoint {
     pub fn as_str(self) -> &'static str {
         match self {
             Checkpoint::IterStart => "iter_start",
+            Checkpoint::Terminated => "terminated",
         }
     }
 }
@@ -68,6 +74,29 @@ pub struct DebugCtx {
     /// the CQ-derived scalar accessors report `NaN`.
     cq: Option<IpoptCqHandle>,
     cp: Checkpoint,
+    /// Solve outcome, set only for the [`Checkpoint::Terminated`] fire.
+    status: Option<String>,
+}
+
+/// A cheap, correct snapshot of the primal-dual state at one step.
+///
+/// Accepted iterates are immutable frozen [`IteratesVector`]s, so this is
+/// just an `Rc` clone plus a few scalars. It captures the iterate, μ, τ,
+/// and the iteration index — **not** strategy history (filter, adaptive-μ
+/// oracle, quasi-Newton memory), so restoring and continuing is an
+/// approximate "resume from here", not a bit-exact rewind.
+#[derive(Clone)]
+pub struct IterateSnapshot {
+    pub iter: i32,
+    pub mu: Number,
+    pub tau: Number,
+    curr: crate::iterates_vector::IteratesVector,
+}
+
+impl IterateSnapshot {
+    pub fn iter(&self) -> i32 {
+        self.iter
+    }
 }
 
 impl DebugCtx {
@@ -76,13 +105,54 @@ impl DebugCtx {
             data,
             cq: Some(cq),
             cp,
+            status: None,
         }
+    }
+
+    /// Attach a solve-outcome string (used for the terminal checkpoint).
+    pub fn with_status(mut self, status: String) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    /// Solve outcome, present only at [`Checkpoint::Terminated`].
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
     }
 
     /// Test-only constructor without a CQ. CQ-derived scalars are `NaN`.
     #[cfg(test)]
     fn new_data_only(data: IpoptDataHandle, cp: Checkpoint) -> Self {
-        Self { data, cq: None, cp }
+        Self {
+            data,
+            cq: None,
+            cp,
+            status: None,
+        }
+    }
+
+    /// Capture the current primal-dual state for later [`Self::restore`].
+    /// `None` before the iterate is set.
+    pub fn snapshot(&self) -> Option<IterateSnapshot> {
+        let d = self.data.borrow();
+        let curr = d.curr.as_ref()?.clone();
+        Some(IterateSnapshot {
+            iter: d.iter_count,
+            mu: d.curr_mu,
+            tau: d.curr_tau,
+            curr,
+        })
+    }
+
+    /// Restore a previously captured snapshot: rewinds the iterate, μ, τ,
+    /// and iteration index so the next `iterate()` resumes from that
+    /// point. Strategy history is not rewound (see [`IterateSnapshot`]).
+    pub fn restore(&mut self, snap: &IterateSnapshot) {
+        let mut d = self.data.borrow_mut();
+        d.set_curr(snap.curr.clone());
+        d.curr_mu = snap.mu;
+        d.curr_tau = snap.tau;
+        d.iter_count = snap.iter;
     }
 
     fn cq_scalar(
@@ -333,6 +403,23 @@ mod tests {
         assert!(ctx.set_block("x", &[1.0, 2.0, 3.0]).is_err());
         assert!(ctx.set_block("x", &[3.0, 4.0]).is_ok());
         assert_eq!(ctx.block("x"), Some(vec![3.0, 4.0]));
+    }
+
+    #[test]
+    fn snapshot_then_restore_round_trips_iterate_and_mu() {
+        let mut ctx = ctx_with(&[1.0, 2.0]);
+        let snap = ctx.snapshot().expect("snapshot");
+        assert_eq!(snap.iter(), 0);
+        // Mutate away from the snapshot.
+        ctx.set_component("x", 0, 99.0).unwrap();
+        ctx.set_mu(0.5).unwrap();
+        assert_eq!(ctx.block("x"), Some(vec![99.0, 2.0]));
+        assert_eq!(ctx.mu(), 0.5);
+        // Restore brings back the captured state.
+        ctx.restore(&snap);
+        assert_eq!(ctx.block("x"), Some(vec![1.0, 2.0]));
+        assert_eq!(ctx.mu(), 0.1);
+        assert_eq!(ctx.iter(), 0);
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -34,6 +34,16 @@ pub enum Checkpoint {
     /// multipliers, and μ all reflect the *accepted* point from the
     /// previous iteration.
     IterStart,
+    /// After the barrier parameter μ was updated for this iteration
+    /// (before the search direction is computed).
+    AfterBarrierUpdate,
+    /// After the primal-dual Newton step was computed — the search
+    /// direction `δ` (`data.delta`), the applied regularization, and the
+    /// KKT factorization are available.
+    AfterSearchDirection,
+    /// After the line search chose a step length and the trial point was
+    /// accepted — α (`info_alpha_*`) and the new iterate are in place.
+    AfterStep,
     /// The solve has finished (or is about to): fired once before
     /// `optimize` returns, at the final iterate, carrying the outcome
     /// via [`DebugCtx::status`]. Lets a debugger drop in for a
@@ -45,8 +55,22 @@ impl Checkpoint {
     pub fn as_str(self) -> &'static str {
         match self {
             Checkpoint::IterStart => "iter_start",
+            Checkpoint::AfterBarrierUpdate => "after_mu",
+            Checkpoint::AfterSearchDirection => "after_search_dir",
+            Checkpoint::AfterStep => "after_step",
             Checkpoint::Terminated => "terminated",
         }
+    }
+
+    /// Sub-iteration checkpoints (everything between `IterStart` and the
+    /// next `IterStart`).
+    pub fn is_sub_iteration(self) -> bool {
+        matches!(
+            self,
+            Checkpoint::AfterBarrierUpdate
+                | Checkpoint::AfterSearchDirection
+                | Checkpoint::AfterStep
+        )
     }
 }
 

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -237,6 +237,24 @@ impl DebugCtx {
         self.cq_scalar(|c| c.curr_nlp_error())
     }
 
+    /// Primal regularization δ_w applied to the KKT system this
+    /// iteration (0 when none was needed). Nonzero ⇒ inertia correction.
+    pub fn regularization(&self) -> Number {
+        self.data.borrow().info_regu_x
+    }
+
+    /// Number of line-search trial points tried for the accepted step
+    /// (1 ⇒ full step accepted first try).
+    pub fn ls_count(&self) -> i32 {
+        self.data.borrow().info_ls_count
+    }
+
+    /// Accepted primal / dual step lengths (α_pr, α_du).
+    pub fn alpha(&self) -> (Number, Number) {
+        let d = self.data.borrow();
+        (d.info_alpha_primal, d.info_alpha_dual)
+    }
+
     // ---- vector reads --------------------------------------------------
 
     /// Dimensions of every named block, in [`BLOCK_NAMES`] order.

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -1,0 +1,346 @@
+//! Interactive solver debugger — a "pdb for the interior-point loop".
+//!
+//! The main loop ([`crate::ipopt_alg::IpoptAlgorithm::optimize`]) fires
+//! a [`DebugHook`] at well-defined checkpoints. A hook receives a
+//! [`DebugCtx`] — a live, *mutable* view of the algorithm state — and
+//! returns a [`DebugAction`] telling the loop whether to keep solving
+//! or stop. This is the engine; the user-facing REPL / agent protocol
+//! lives in the CLI (`pounce --debug`), which implements [`DebugHook`].
+//!
+//! Two design points make mutation safe:
+//!
+//!   * [`DebugCtx`] holds cheap `Rc` clones of the same `IpoptData` /
+//!     `IpoptCq` handles the loop uses, so reads and writes go through
+//!     the identical `RefCell` path — there is no shadow copy to drift.
+//!   * Overwriting the iterate rebuilds a *fresh* [`IteratesVector`]
+//!     (via `deep_copy().freeze()`), which mints a new vector tag. The
+//!     CQ caches are tag-keyed (see `ipopt_cq.rs`), so a mutated iterate
+//!     transparently invalidates every derived quantity — exactly as if
+//!     the line search had produced the new point.
+//!
+//! Only the [`Checkpoint::IterStart`] site is wired today; the enum is
+//! deliberately open so finer-grained stops (post-search-direction,
+//! pre-line-search) can be added without touching the trait.
+
+use crate::ipopt_cq::IpoptCqHandle;
+use crate::ipopt_data::IpoptDataHandle;
+use pounce_common::types::Number;
+
+/// Where in the main loop a checkpoint fired.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Checkpoint {
+    /// Top of an outer iteration — after the intermediate callback,
+    /// before this iteration's Newton step is computed. The iterate,
+    /// multipliers, and μ all reflect the *accepted* point from the
+    /// previous iteration.
+    IterStart,
+}
+
+impl Checkpoint {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Checkpoint::IterStart => "iter_start",
+        }
+    }
+}
+
+/// What the algorithm should do after a [`DebugHook`] returns.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DebugAction {
+    /// Keep solving.
+    Resume,
+    /// Stop the solve now. Surfaces to the caller as
+    /// `SolverReturn::UserRequestedStop`.
+    Stop,
+}
+
+/// The eight primal/dual blocks of an iterate, addressable by name.
+pub const BLOCK_NAMES: [&str; 8] = ["x", "s", "y_c", "y_d", "z_l", "z_u", "v_l", "v_u"];
+
+/// Live, mutable view of solver state handed to a [`DebugHook`].
+///
+/// Cheap to construct (two `Rc` clones); every accessor borrows the
+/// shared `RefCell`s on demand.
+pub struct DebugCtx {
+    data: IpoptDataHandle,
+    /// Always `Some` in production (the main loop has a live CQ). Left
+    /// `None` only by the data-only unit-test constructor, in which case
+    /// the CQ-derived scalar accessors report `NaN`.
+    cq: Option<IpoptCqHandle>,
+    cp: Checkpoint,
+}
+
+impl DebugCtx {
+    pub fn new(data: IpoptDataHandle, cq: IpoptCqHandle, cp: Checkpoint) -> Self {
+        Self {
+            data,
+            cq: Some(cq),
+            cp,
+        }
+    }
+
+    /// Test-only constructor without a CQ. CQ-derived scalars are `NaN`.
+    #[cfg(test)]
+    fn new_data_only(data: IpoptDataHandle, cp: Checkpoint) -> Self {
+        Self { data, cq: None, cp }
+    }
+
+    fn cq_scalar(
+        &self,
+        f: impl FnOnce(&crate::ipopt_cq::IpoptCalculatedQuantities) -> Number,
+    ) -> Number {
+        match self.cq.as_ref() {
+            Some(cq) => f(&cq.borrow()),
+            None => Number::NAN,
+        }
+    }
+
+    /// Which checkpoint we are paused at.
+    pub fn checkpoint(&self) -> Checkpoint {
+        self.cp
+    }
+
+    // ---- scalar reads --------------------------------------------------
+
+    /// Current outer iteration counter.
+    pub fn iter(&self) -> i32 {
+        self.data.borrow().iter_count
+    }
+
+    /// Current barrier parameter μ.
+    pub fn mu(&self) -> Number {
+        self.data.borrow().curr_mu
+    }
+
+    /// Unscaled objective at the current iterate.
+    pub fn objective(&self) -> Number {
+        self.cq_scalar(|c| c.unscaled_curr_f())
+    }
+
+    /// Max-norm primal infeasibility.
+    pub fn inf_pr(&self) -> Number {
+        self.cq_scalar(|c| c.curr_primal_infeasibility_max())
+    }
+
+    /// Max-norm dual infeasibility.
+    pub fn inf_du(&self) -> Number {
+        self.cq_scalar(|c| c.curr_dual_infeasibility_max())
+    }
+
+    /// Scaled overall NLP error driving convergence.
+    pub fn nlp_error(&self) -> Number {
+        self.cq_scalar(|c| c.curr_nlp_error())
+    }
+
+    // ---- vector reads --------------------------------------------------
+
+    /// Dimensions of every named block, in [`BLOCK_NAMES`] order.
+    pub fn block_dims(&self) -> Vec<(&'static str, usize)> {
+        let d = self.data.borrow();
+        let Some(curr) = d.curr.as_ref() else {
+            return BLOCK_NAMES.iter().map(|&n| (n, 0)).collect();
+        };
+        BLOCK_NAMES
+            .iter()
+            .map(|&n| (n, block_ref(curr, n).map(|v| v.dim() as usize).unwrap_or(0)))
+            .collect()
+    }
+
+    /// Read a named block of the current iterate as a flat `f64` vec.
+    /// Returns `None` for an unknown name or before the iterate is set.
+    pub fn block(&self, name: &str) -> Option<Vec<Number>> {
+        let d = self.data.borrow();
+        let curr = d.curr.as_ref()?;
+        let v = block_ref(curr, name)?;
+        Some(crate::ipopt_alg::flat_read_owned(v.as_ref()))
+    }
+
+    /// Read a named block of the most recent search direction δ.
+    pub fn delta_block(&self, name: &str) -> Option<Vec<Number>> {
+        let d = self.data.borrow();
+        let delta = d.delta.as_ref()?;
+        let v = block_ref(delta, name)?;
+        Some(crate::ipopt_alg::flat_read_owned(v.as_ref()))
+    }
+
+    // ---- mutation ------------------------------------------------------
+
+    /// Overwrite the barrier parameter μ. Takes effect on the next
+    /// `update_barrier_parameter` consult (the monotone updater treats
+    /// it as the current value; adaptive updaters re-derive from it).
+    pub fn set_mu(&mut self, mu: Number) -> Result<(), String> {
+        if !mu.is_finite() || mu <= 0.0 {
+            return Err(format!("mu must be finite and positive, got {mu}"));
+        }
+        self.data.borrow_mut().curr_mu = mu;
+        Ok(())
+    }
+
+    /// Overwrite an entire named block of the current iterate.
+    ///
+    /// Rebuilds `curr` from a deep copy with a fresh vector tag, so all
+    /// tag-keyed CQ caches invalidate and downstream quantities recompute
+    /// from the new point.
+    pub fn set_block(&mut self, name: &str, vals: &[Number]) -> Result<(), String> {
+        if !BLOCK_NAMES.contains(&name) {
+            return Err(format!(
+                "unknown block `{name}` (expected one of {BLOCK_NAMES:?})"
+            ));
+        }
+        let mut d = self.data.borrow_mut();
+        let curr = d.curr.as_ref().ok_or("no current iterate yet")?;
+        let mut m = curr.deep_copy();
+        let blk = block_ref_mut(&mut m, name).expect("name checked above");
+        let dim = blk.dim() as usize;
+        if vals.len() != dim {
+            return Err(format!(
+                "block `{name}` has dimension {dim}, got {} value(s)",
+                vals.len()
+            ));
+        }
+        crate::ipopt_alg::flat_write_into(blk.as_mut(), vals);
+        let frozen = m.freeze();
+        d.set_curr(frozen);
+        Ok(())
+    }
+
+    /// Overwrite a single component of a named block.
+    pub fn set_component(&mut self, name: &str, idx: usize, val: Number) -> Result<(), String> {
+        let mut vals = self
+            .block(name)
+            .ok_or_else(|| format!("unknown block `{name}` or no iterate yet"))?;
+        if idx >= vals.len() {
+            return Err(format!(
+                "index {idx} out of range for block `{name}` (dimension {})",
+                vals.len()
+            ));
+        }
+        vals[idx] = val;
+        self.set_block(name, &vals)
+    }
+}
+
+/// Borrow a named block of an [`IteratesVector`].
+fn block_ref<'a>(
+    iv: &'a crate::iterates_vector::IteratesVector,
+    name: &str,
+) -> Option<&'a std::rc::Rc<dyn pounce_linalg::Vector>> {
+    Some(match name {
+        "x" => &iv.x,
+        "s" => &iv.s,
+        "y_c" => &iv.y_c,
+        "y_d" => &iv.y_d,
+        "z_l" => &iv.z_l,
+        "z_u" => &iv.z_u,
+        "v_l" => &iv.v_l,
+        "v_u" => &iv.v_u,
+        _ => return None,
+    })
+}
+
+/// Borrow a named block of a mutable [`IteratesVectorMut`].
+fn block_ref_mut<'a>(
+    iv: &'a mut crate::iterates_vector::IteratesVectorMut,
+    name: &str,
+) -> Option<&'a mut Box<dyn pounce_linalg::Vector>> {
+    Some(match name {
+        "x" => &mut iv.x,
+        "s" => &mut iv.s,
+        "y_c" => &mut iv.y_c,
+        "y_d" => &mut iv.y_d,
+        "z_l" => &mut iv.z_l,
+        "z_u" => &mut iv.z_u,
+        "v_l" => &mut iv.v_l,
+        "v_u" => &mut iv.v_u,
+        _ => return None,
+    })
+}
+
+/// A consumer that the main loop pauses at each checkpoint. The CLI's
+/// REPL / agent driver is the production implementation.
+pub trait DebugHook {
+    /// Called at every [`Checkpoint`]. Inspect and/or mutate via `ctx`,
+    /// then return whether to keep solving.
+    fn at_checkpoint(&mut self, ctx: &mut DebugCtx) -> DebugAction;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipopt_data::IpoptData;
+    use crate::iterates_vector::IteratesVector;
+    use pounce_linalg::dense_vector::DenseVectorSpace;
+    use pounce_linalg::Vector;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    fn iv(xvals: &[f64]) -> IteratesVector {
+        let dense = |vals: &[f64]| {
+            let mut v = DenseVectorSpace::new(vals.len() as i32).make_new_dense();
+            v.set_values(vals);
+            Rc::new(v) as Rc<dyn Vector>
+        };
+        let z = |n| dense(&vec![0.0; n]);
+        IteratesVector::new(dense(xvals), z(1), z(1), z(1), z(2), z(2), z(1), z(1))
+    }
+
+    fn ctx_with(xvals: &[f64]) -> DebugCtx {
+        let mut data = IpoptData::new();
+        data.set_curr(iv(xvals));
+        data.curr_mu = 0.1;
+        let data = Rc::new(RefCell::new(data));
+        DebugCtx::new_data_only(data, Checkpoint::IterStart)
+    }
+
+    #[test]
+    fn reads_block_and_mu() {
+        let ctx = ctx_with(&[1.0, 2.0]);
+        assert_eq!(ctx.mu(), 0.1);
+        assert_eq!(ctx.block("x"), Some(vec![1.0, 2.0]));
+        assert_eq!(ctx.block("nope"), None);
+    }
+
+    #[test]
+    fn set_component_rebuilds_iterate_with_fresh_tag() {
+        let mut ctx = ctx_with(&[1.0, 2.0]);
+        let before = ctx
+            .data
+            .borrow()
+            .curr
+            .as_ref()
+            .unwrap()
+            .x
+            .as_tagged()
+            .get_tag();
+        ctx.set_component("x", 1, 9.0).unwrap();
+        let after = ctx
+            .data
+            .borrow()
+            .curr
+            .as_ref()
+            .unwrap()
+            .x
+            .as_tagged()
+            .get_tag();
+        assert_eq!(ctx.block("x"), Some(vec![1.0, 9.0]));
+        assert_ne!(before, after, "mutating the iterate must mint a new tag");
+    }
+
+    #[test]
+    fn set_block_dim_mismatch_is_rejected() {
+        let mut ctx = ctx_with(&[1.0, 2.0]);
+        assert!(ctx.set_block("x", &[1.0]).is_err());
+        assert!(ctx.set_block("x", &[1.0, 2.0, 3.0]).is_err());
+        assert!(ctx.set_block("x", &[3.0, 4.0]).is_ok());
+        assert_eq!(ctx.block("x"), Some(vec![3.0, 4.0]));
+    }
+
+    #[test]
+    fn set_mu_rejects_nonpositive() {
+        let mut ctx = ctx_with(&[1.0]);
+        assert!(ctx.set_mu(-1.0).is_err());
+        assert!(ctx.set_mu(0.0).is_err());
+        assert!(ctx.set_mu(1e-3).is_ok());
+        assert_eq!(ctx.mu(), 1e-3);
+    }
+}

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -313,6 +313,40 @@ impl DebugCtx {
         })
     }
 
+    /// The assembled KKT matrix triplets `(dim, irn, jcn, vals)` (1-based
+    /// lower triangle) for `viz kkt`, if captured this iteration.
+    pub fn kkt_matrix(&self) -> Option<(i32, Vec<i32>, Vec<i32>, Vec<Number>)> {
+        self.data.borrow().kkt_debug.as_ref()?.matrix.clone()
+    }
+
+    /// The `LDLᵀ` factor (`n`, `perm`, strict-lower `l_irn`/`l_jcn` and
+    /// optional `l_vals`) for `viz L`, if captured. Capture is opt-in —
+    /// call [`Self::request_l_factor`] first (it's the expensive piece).
+    #[allow(clippy::type_complexity)]
+    pub fn kkt_l_factor(&self) -> Option<(usize, Vec<usize>, Vec<i32>, Vec<i32>, Option<Vec<Number>>)> {
+        let d = self.data.borrow();
+        let f = d.kkt_debug.as_ref()?.l_factor.as_ref()?;
+        Some((
+            f.n,
+            f.perm.clone(),
+            f.l_irn.clone(),
+            f.l_jcn.clone(),
+            f.l_vals.clone(),
+        ))
+    }
+
+    /// Ask the solver to capture the `LDLᵀ` factor on subsequent solves
+    /// (so `viz L` has data). Returns whether it's already available now.
+    pub fn request_l_factor(&mut self) -> bool {
+        self.data.borrow_mut().want_l_factor = true;
+        self.data
+            .borrow()
+            .kkt_debug
+            .as_ref()
+            .map(|k| k.l_factor.is_some())
+            .unwrap_or(false)
+    }
+
     // ---- vector reads --------------------------------------------------
 
     /// Dimensions of every named block, in [`BLOCK_NAMES`] order.

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -158,6 +158,16 @@ impl IterateSnapshot {
     pub fn iter(&self) -> i32 {
         self.iter
     }
+
+    pub fn mu(&self) -> Number {
+        self.mu
+    }
+
+    /// Read a named block of the snapshotted iterate as a flat `f64` vec.
+    pub fn block(&self, name: &str) -> Option<Vec<Number>> {
+        let v = block_ref(&self.curr, name)?;
+        Some(crate::ipopt_alg::flat_read_owned(v.as_ref()))
+    }
 }
 
 impl DebugCtx {

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -18,9 +18,11 @@
 //!     transparently invalidates every derived quantity — exactly as if
 //!     the line search had produced the new point.
 //!
-//! Only the [`Checkpoint::IterStart`] site is wired today; the enum is
-//! deliberately open so finer-grained stops (post-search-direction,
-//! pre-line-search) can be added without touching the trait.
+//! Checkpoints fire at the iteration top, the sub-iteration phases
+//! (`after_mu` / `after_search_dir` / `after_step`), around restoration
+//! entry/exit, and at termination. The same hook is shared
+//! (`Rc<RefCell<…>>`) with the restoration inner IPM, so one debugger
+//! steps both the outer and inner solves.
 
 use crate::ipopt_cq::IpoptCqHandle;
 use crate::ipopt_data::IpoptDataHandle;
@@ -321,15 +323,9 @@ impl DebugCtx {
         let d = self.data.borrow();
         let k = d.kkt_debug.as_ref()?;
         let curr = d.curr.as_ref();
-        let expected_neg = curr
-            .map(|c| c.y_c.dim() + c.y_d.dim())
-            .unwrap_or(0);
+        let expected_neg = curr.map(|c| c.y_c.dim() + c.y_d.dim()).unwrap_or(0);
         // n+ = dim − n− (assuming a non-singular KKT, n0 = 0).
-        let n_pos = if k.n_neg >= 0 {
-            k.dim - k.n_neg
-        } else {
-            -1
-        };
+        let n_pos = if k.n_neg >= 0 { k.dim - k.n_neg } else { -1 };
         let inertia_correct = k.provides_inertia && k.n_neg == expected_neg;
         Some(KktReport {
             dim: k.dim,
@@ -354,7 +350,9 @@ impl DebugCtx {
     /// optional `l_vals`) for `viz L`, if captured. Capture is opt-in —
     /// call [`Self::request_l_factor`] first (it's the expensive piece).
     #[allow(clippy::type_complexity)]
-    pub fn kkt_l_factor(&self) -> Option<(usize, Vec<usize>, Vec<i32>, Vec<i32>, Option<Vec<Number>>)> {
+    pub fn kkt_l_factor(
+        &self,
+    ) -> Option<(usize, Vec<usize>, Vec<i32>, Vec<i32>, Option<Vec<Number>>)> {
         let d = self.data.borrow();
         let f = d.kkt_debug.as_ref()?.l_factor.as_ref()?;
         Some((

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -98,6 +98,32 @@ pub enum DebugAction {
 /// The eight primal/dual blocks of an iterate, addressable by name.
 pub const BLOCK_NAMES: [&str; 8] = ["x", "s", "y_c", "y_d", "z_l", "z_u", "v_l", "v_u"];
 
+/// KKT-factorization report (see [`DebugCtx::kkt`]). The inertia of a
+/// well-posed primal-dual system is `(n_pos = n, n_neg = m, n_zero = 0)`;
+/// a mismatch (or nonzero regularization) is the classic signal that the
+/// step is being stabilized.
+#[derive(Clone, Debug)]
+pub struct KktReport {
+    /// Augmented-system dimension (n + m).
+    pub dim: i32,
+    /// Negative eigenvalues reported (-1 if the backend has no inertia).
+    pub n_neg: i32,
+    /// Positive eigenvalues = `dim − n_neg` (-1 if unknown).
+    pub n_pos: i32,
+    /// Expected negatives = number of equality + inequality multipliers.
+    pub expected_neg: i32,
+    /// Whether the backend reports inertia.
+    pub provides_inertia: bool,
+    /// `true` when reported inertia matches the expected `(n, m, 0)`.
+    pub inertia_correct: bool,
+    /// Primal regularization δ_w applied to the (1,1) block.
+    pub delta_w: Number,
+    /// Dual regularization δ_c applied to the (3,3)/(4,4) blocks.
+    pub delta_c: Number,
+    /// Factorization status (debug string).
+    pub status: String,
+}
+
 /// Live, mutable view of solver state handed to a [`DebugHook`].
 ///
 /// Cheap to construct (two `Rc` clones); every accessor borrows the
@@ -253,6 +279,38 @@ impl DebugCtx {
     pub fn alpha(&self) -> (Number, Number) {
         let d = self.data.borrow();
         (d.info_alpha_primal, d.info_alpha_dual)
+    }
+
+    /// KKT-factorization report for the current iteration, if a search
+    /// direction has been computed this iteration (i.e. at/after the
+    /// `after_search_dir` checkpoint). Combines the captured inertia with
+    /// the applied regularization and the *expected* inertia derived from
+    /// the multiplier dimensions.
+    pub fn kkt(&self) -> Option<KktReport> {
+        let d = self.data.borrow();
+        let k = d.kkt_debug.as_ref()?;
+        let curr = d.curr.as_ref();
+        let expected_neg = curr
+            .map(|c| c.y_c.dim() + c.y_d.dim())
+            .unwrap_or(0);
+        // n+ = dim − n− (assuming a non-singular KKT, n0 = 0).
+        let n_pos = if k.n_neg >= 0 {
+            k.dim - k.n_neg
+        } else {
+            -1
+        };
+        let inertia_correct = k.provides_inertia && k.n_neg == expected_neg;
+        Some(KktReport {
+            dim: k.dim,
+            n_neg: k.n_neg,
+            n_pos,
+            expected_neg,
+            provides_inertia: k.provides_inertia,
+            inertia_correct,
+            delta_w: d.perturbations.delta_x,
+            delta_c: d.perturbations.delta_c,
+            status: k.status.clone(),
+        })
     }
 
     // ---- vector reads --------------------------------------------------

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -44,6 +44,13 @@ pub enum Checkpoint {
     /// After the line search chose a step length and the trial point was
     /// accepted — α (`info_alpha_*`) and the new iterate are in place.
     AfterStep,
+    /// Just before the algorithm switches into the restoration phase —
+    /// the iterate that tripped restoration is intact. The most-requested
+    /// "why did this go to restoration?" stop.
+    PreRestoration,
+    /// Just after the restoration phase returns, so its effect on the
+    /// iterate can be inspected.
+    PostRestoration,
     /// The solve has finished (or is about to): fired once before
     /// `optimize` returns, at the final iterate, carrying the outcome
     /// via [`DebugCtx::status`]. Lets a debugger drop in for a
@@ -58,6 +65,8 @@ impl Checkpoint {
             Checkpoint::AfterBarrierUpdate => "after_mu",
             Checkpoint::AfterSearchDirection => "after_search_dir",
             Checkpoint::AfterStep => "after_step",
+            Checkpoint::PreRestoration => "pre_restoration_entry",
+            Checkpoint::PostRestoration => "post_restoration_exit",
             Checkpoint::Terminated => "terminated",
         }
     }
@@ -70,6 +79,8 @@ impl Checkpoint {
             Checkpoint::AfterBarrierUpdate
                 | Checkpoint::AfterSearchDirection
                 | Checkpoint::AfterStep
+                | Checkpoint::PreRestoration
+                | Checkpoint::PostRestoration
         )
     }
 }

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -46,6 +46,13 @@ pub enum Checkpoint {
     /// After the line search chose a step length and the trial point was
     /// accepted — α (`info_alpha_*`) and the new iterate are in place.
     AfterStep,
+    /// The line search *rejected* this iteration's step — it hit the tiny-step
+    /// floor or exhausted its backtracks without an acceptable point, and the
+    /// solver is about to fall into restoration. The search direction `δ` and
+    /// the un-accepted current iterate are intact for inspection. The "why did
+    /// the line search give up here?" stop, distinct from the restoration entry
+    /// that follows.
+    StepRejected,
     /// Just before the algorithm switches into the restoration phase —
     /// the iterate that tripped restoration is intact. The most-requested
     /// "why did this go to restoration?" stop.
@@ -56,17 +63,25 @@ pub enum Checkpoint {
     /// The solve has finished (or is about to): fired once before
     /// `optimize` returns, at the final iterate, carrying the outcome
     /// via [`DebugCtx::status`]. Lets a debugger drop in for a
-    /// post-mortem at the failing (or final) point.
+    /// post-mortem at the failing (or final) point. The [`DebugAction`]
+    /// returned at this checkpoint is **ignored** — the solve is already
+    /// over, so there is nothing left to resume or stop.
     Terminated,
 }
 
 impl Checkpoint {
+    /// The stable wire/CLI protocol name for this checkpoint. These strings
+    /// are intentionally **not** the variant identifiers (`AfterBarrierUpdate`
+    /// → `"after_mu"`, `PreRestoration` → `"pre_restoration_entry"`) — they're
+    /// the names the JSON protocol and `stop-at` use, so match on the variant,
+    /// not the string. Locked by the `checkpoint_as_str_is_stable` test.
     pub fn as_str(self) -> &'static str {
         match self {
             Checkpoint::IterStart => "iter_start",
             Checkpoint::AfterBarrierUpdate => "after_mu",
             Checkpoint::AfterSearchDirection => "after_search_dir",
             Checkpoint::AfterStep => "after_step",
+            Checkpoint::StepRejected => "step_rejected",
             Checkpoint::PreRestoration => "pre_restoration_entry",
             Checkpoint::PostRestoration => "post_restoration_exit",
             Checkpoint::Terminated => "terminated",
@@ -81,6 +96,7 @@ impl Checkpoint {
             Checkpoint::AfterBarrierUpdate
                 | Checkpoint::AfterSearchDirection
                 | Checkpoint::AfterStep
+                | Checkpoint::StepRejected
                 | Checkpoint::PreRestoration
                 | Checkpoint::PostRestoration
         )
@@ -610,6 +626,39 @@ mod tests {
         assert!(ctx.set_block("x", &[1.0, 2.0, 3.0]).is_err());
         assert!(ctx.set_block("x", &[3.0, 4.0]).is_ok());
         assert_eq!(ctx.block("x"), Some(vec![3.0, 4.0]));
+    }
+
+    #[test]
+    fn block_names_all_resolve_in_block_ref() {
+        // Locks `BLOCK_NAMES` to the `block_ref` / `block_ref_mut` match arms:
+        // every name must resolve in both, or `set_block`'s
+        // `expect("name checked above")` could panic on a name that's in the
+        // array but missing from a match arm.
+        let mut ctx = ctx_with(&[1.0, 2.0]);
+        for name in BLOCK_NAMES {
+            let cur = ctx
+                .block(name)
+                .unwrap_or_else(|| panic!("block_ref does not resolve `{name}`"));
+            // Round-trips through `block_ref_mut` (dimension-correct values).
+            ctx.set_block(name, &cur)
+                .unwrap_or_else(|e| panic!("block_ref_mut does not resolve `{name}`: {e}"));
+        }
+    }
+
+    #[test]
+    fn checkpoint_as_str_is_stable() {
+        // These strings are the wire/CLI protocol names — intentionally
+        // distinct from the variant identifiers (e.g. `AfterBarrierUpdate` →
+        // `"after_mu"`). Locked here so a rename is a deliberate,
+        // protocol-breaking change rather than a silent one.
+        assert_eq!(Checkpoint::IterStart.as_str(), "iter_start");
+        assert_eq!(Checkpoint::AfterBarrierUpdate.as_str(), "after_mu");
+        assert_eq!(Checkpoint::AfterSearchDirection.as_str(), "after_search_dir");
+        assert_eq!(Checkpoint::AfterStep.as_str(), "after_step");
+        assert_eq!(Checkpoint::StepRejected.as_str(), "step_rejected");
+        assert_eq!(Checkpoint::PreRestoration.as_str(), "pre_restoration_entry");
+        assert_eq!(Checkpoint::PostRestoration.as_str(), "post_restoration_exit");
+        assert_eq!(Checkpoint::Terminated.as_str(), "terminated");
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/debug.rs
+++ b/crates/pounce-algorithm/src/debug.rs
@@ -296,8 +296,12 @@ impl DebugCtx {
         Some(crate::ipopt_alg::flat_read_owned(v.as_ref()))
     }
 
-    /// Primal regularization δ_w applied to the KKT system this
-    /// iteration (0 when none was needed). Nonzero ⇒ inertia correction.
+    /// Primal regularization δ_w **as recorded for this iteration's info**
+    /// (`info_regu_x`) — the value reported in the iteration table's `lg(rg)`
+    /// column, reset to 0 at the start of each iteration. This is distinct
+    /// from [`Self::kkt`]'s `delta_w`, which reads the *live* perturbation
+    /// (`perturbations.delta_x`) applied during the inertia-correction loop;
+    /// the two can differ by timing at a given checkpoint.
     pub fn regularization(&self) -> Number {
         self.data.borrow().info_regu_x
     }
@@ -318,7 +322,10 @@ impl DebugCtx {
     /// direction has been computed this iteration (i.e. at/after the
     /// `after_search_dir` checkpoint). Combines the captured inertia with
     /// the applied regularization and the *expected* inertia derived from
-    /// the multiplier dimensions.
+    /// the multiplier dimensions. `delta_w`/`delta_c` are the **live**
+    /// primal/dual perturbations (`perturbations.delta_x/delta_c`) applied
+    /// during inertia correction — distinct from [`Self::regularization`]'s
+    /// recorded per-iteration info value (see its note).
     pub fn kkt(&self) -> Option<KktReport> {
         let d = self.data.borrow();
         let k = d.kkt_debug.as_ref()?;
@@ -376,6 +383,20 @@ impl DebugCtx {
             .unwrap_or(false)
     }
 
+    /// Ask the solver to assemble the KKT matrix triplets on subsequent
+    /// solves (so `viz kkt`/`save` has the matrix). Off by default so an
+    /// attached debugger doesn't pay the O(nnz) assembly every iteration.
+    /// Returns whether the triplets are already available now.
+    pub fn request_kkt_matrix(&mut self) -> bool {
+        self.data.borrow_mut().want_matrix = true;
+        self.data
+            .borrow()
+            .kkt_debug
+            .as_ref()
+            .map(|k| k.matrix.is_some())
+            .unwrap_or(false)
+    }
+
     // ---- vector reads --------------------------------------------------
 
     /// Dimensions of every named block, in [`BLOCK_NAMES`] order.
@@ -425,6 +446,18 @@ impl DebugCtx {
     /// Rebuilds `curr` from a deep copy with a fresh vector tag, so all
     /// tag-keyed CQ caches invalidate and downstream quantities recompute
     /// from the new point.
+    ///
+    /// **No invariant enforcement.** Only the dimension is checked. Mutating
+    /// the slacks (`s`) to ≤ 0, or the bound/inequality multipliers
+    /// (`z_l`/`z_u`/`v_l`/`v_u`) to ≤ 0, or pushing `x` past a bound, breaks
+    /// the interior-point feasibility invariant (`s > 0, z > 0`) — the next
+    /// step's σ = z/s and fraction-to-the-boundary rule can then produce
+    /// `NaN`/`Inf` or a non-descent direction rather than erroring here. The
+    /// solver's strategy history (filter, adaptive-μ oracle, quasi-Newton
+    /// memory) is **not** rewound to the mutated point either, so a resumed
+    /// solve may behave inconsistently. This is a debugging tool: "wrong"
+    /// states are allowed on purpose — it's on the caller to keep the point
+    /// sane if they intend to continue the solve.
     pub fn set_block(&mut self, name: &str, vals: &[Number]) -> Result<(), String> {
         if !BLOCK_NAMES.contains(&name) {
             return Err(format!(

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -903,6 +903,7 @@ impl IpoptAlgorithm {
         // for the debugger before the line search runs. Only when a
         // debugger is installed — pulls nothing otherwise.
         if self.debug.is_some() {
+            let want_l = self.data.borrow().want_l_factor;
             let info = self.search_dir.as_ref().map(|sd| {
                 let pd = sd.pd_solver_mut();
                 let aug = pd.aug_solver();
@@ -912,6 +913,9 @@ impl IpoptAlgorithm {
                     n_neg: if provides { aug.number_of_neg_evals() } else { -1 },
                     provides_inertia: provides,
                     status: format!("{:?}", aug.last_solve_status()),
+                    matrix: aug.kkt_triplets(),
+                    // The factor is the expensive piece — only when asked.
+                    l_factor: if want_l { aug.l_factor(true) } else { None },
                 }
             });
             self.data.borrow_mut().kkt_debug = info;

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -378,6 +378,20 @@ impl IpoptAlgorithm {
         hook.at_checkpoint(&mut ctx)
     }
 
+    /// Fire a sub-iteration checkpoint from inside [`Self::iterate`].
+    /// Returns `Some(Terminate(UserRequestedStop))` if the debugger asked
+    /// to stop, so the caller can `return` it; `None` to continue.
+    fn debug_stop(&mut self, cp: crate::debug::Checkpoint) -> Option<IterateOutcome> {
+        if self.debug.is_none() {
+            return None;
+        }
+        if self.fire_debug(cp) == crate::debug::DebugAction::Stop {
+            Some(IterateOutcome::Terminate(SolverReturn::UserRequestedStop))
+        } else {
+            None
+        }
+    }
+
     /// Fire the terminal post-mortem checkpoint (if a debugger is set),
     /// carrying the solve outcome so the hook can decide whether to pause
     /// at the final iterate. The action is advisory — the loop returns
@@ -648,6 +662,11 @@ impl IpoptAlgorithm {
             self.bundle.line_search.reset();
         }
 
+        // Sub-iteration checkpoint: μ has been updated for this iteration.
+        if let Some(o) = self.debug_stop(crate::debug::Checkpoint::AfterBarrierUpdate) {
+            return o;
+        }
+
         // 5. Search direction. Skipped without an NLP + search_dir.
         // (Hessian was updated in step 3 above before the barrier-μ
         // oracle so that adaptive-μ uses W(curr_N), not stale W.)
@@ -865,6 +884,13 @@ impl IpoptAlgorithm {
             }
         }
 
+        // Sub-iteration checkpoint: the Newton step `δ` (data.delta) and
+        // the applied regularization are now available, before the line
+        // search consumes them.
+        if let Some(o) = self.debug_stop(crate::debug::Checkpoint::AfterSearchDirection) {
+            return o;
+        }
+
         // 6. Acceptable trial point — run the line search if we have a
         //    primal/dual step on `data.delta`. Wrap in a guard so all
         //    early-return paths (ErrorInStepComputation, InternalError,
@@ -985,6 +1011,14 @@ impl IpoptAlgorithm {
 
         // 8. Bound multiplier kappa_sigma reset.
         self.correct_bound_multiplier();
+
+        // Sub-iteration checkpoint: the trial point was accepted; α and
+        // the new iterate are in place (before the loop's iter bookkeeping
+        // and the next `IterStart`).
+        drop(_accept_guard);
+        if let Some(o) = self.debug_stop(crate::debug::Checkpoint::AfterStep) {
+            return o;
+        }
 
         IterateOutcome::Continue
     }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -910,6 +910,7 @@ impl IpoptAlgorithm {
         // debugger is installed — pulls nothing otherwise.
         if self.debug.is_some() {
             let want_l = self.data.borrow().want_l_factor;
+            let want_matrix = self.data.borrow().want_matrix;
             let info = self.search_dir.as_ref().map(|sd| {
                 let pd = sd.pd_solver_mut();
                 let aug = pd.aug_solver();
@@ -923,7 +924,11 @@ impl IpoptAlgorithm {
                     },
                     provides_inertia: provides,
                     status: format!("{:?}", aug.last_solve_status()),
-                    matrix: aug.kkt_triplets(),
+                    // Triplet assembly is O(nnz) — only when `viz kkt`/`save`
+                    // armed it, so attaching the debugger to a big problem
+                    // doesn't tax every iteration. (Inertia/status above are
+                    // cheap and always captured.)
+                    matrix: if want_matrix { aug.kkt_triplets() } else { None },
                     // The factor is the expensive piece — only when asked.
                     l_factor: if want_l { aug.l_factor(true) } else { None },
                 }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -378,6 +378,21 @@ impl IpoptAlgorithm {
         hook.at_checkpoint(&mut ctx)
     }
 
+    /// Run the restoration phase, bracketed by the `PreRestoration` /
+    /// `PostRestoration` debug checkpoints so a debugger can inspect the
+    /// iterate just before entry and just after exit. With no debugger
+    /// installed this is exactly `invoke_restoration()`.
+    fn invoke_restoration_debugged(&mut self) -> IterateOutcome {
+        if let Some(o) = self.debug_stop(crate::debug::Checkpoint::PreRestoration) {
+            return o;
+        }
+        let outcome = self.invoke_restoration();
+        if let Some(o) = self.debug_stop(crate::debug::Checkpoint::PostRestoration) {
+            return o;
+        }
+        outcome
+    }
+
     /// Fire a sub-iteration checkpoint from inside [`Self::iterate`].
     /// Returns `Some(Terminate(UserRequestedStop))` if the debugger asked
     /// to stop, so the caller can `return` it; `None` to continue.
@@ -636,7 +651,7 @@ impl IpoptAlgorithm {
         };
         if request_resto {
             if self.restoration.is_some() {
-                return self.invoke_restoration();
+                return self.invoke_restoration_debugged();
             } else {
                 tracing::warn!(target: "pounce::algorithm",
                     "[POUNCE] probing-oracle iterate-quality guard fired \
@@ -709,7 +724,7 @@ impl IpoptAlgorithm {
                 // fallback is available does upstream throw
                 // `STEP_COMPUTATION_FAILED`.
                 if self.restoration.is_some() {
-                    return self.invoke_restoration();
+                    return self.invoke_restoration_debugged();
                 }
                 return IterateOutcome::Terminate(SolverReturn::ErrorInStepComputation);
             }
@@ -989,7 +1004,7 @@ impl IpoptAlgorithm {
                         // `alpha_min` or all retries reject, which in
                         // turn triggers `ActivateLineSearch` →
                         // restoration.
-                        return self.invoke_restoration();
+                        return self.invoke_restoration_debugged();
                     }
                 }
             }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -174,11 +174,11 @@ pub struct IpoptAlgorithm {
     /// advances the state's iter counter and the augmented-system
     /// solver consults it to gate KKT dumps.
     diagnostics: Option<Rc<DiagnosticsState>>,
-    /// Optional interactive debugger. When installed, the outer loop
-    /// fires it at every [`crate::debug::Checkpoint`] (today: the top
-    /// of each iteration) so a REPL or agent can inspect and mutate
-    /// live state before the next Newton step. See `crate::debug`.
-    debug: Option<Box<dyn crate::debug::DebugHook>>,
+    /// Optional interactive debugger. Shared (`Rc<RefCell<…>>`) so the
+    /// same debugger instance also drives the restoration inner IPM —
+    /// one debugger sees both levels. Fired at every
+    /// [`crate::debug::Checkpoint`]. See `crate::debug`.
+    debug: Option<Rc<RefCell<dyn crate::debug::DebugHook>>>,
 
     // ---- Restoration-phase audit counters (pounce#12). ----
     //
@@ -361,9 +361,15 @@ impl IpoptAlgorithm {
     /// Install an interactive debugger hook. Fired at each checkpoint
     /// in [`Self::optimize`]; returning [`crate::debug::DebugAction::Stop`]
     /// ends the solve with `SolverReturn::UserRequestedStop`.
-    pub fn with_debug_hook(mut self, hook: Box<dyn crate::debug::DebugHook>) -> Self {
+    pub fn with_debug_hook(mut self, hook: Rc<RefCell<dyn crate::debug::DebugHook>>) -> Self {
         self.debug = Some(hook);
         self
+    }
+
+    /// Shared handle to the installed debugger, if any — used to forward
+    /// it into the restoration inner IPM.
+    pub fn debug_hook(&self) -> Option<Rc<RefCell<dyn crate::debug::DebugHook>>> {
+        self.debug.as_ref().map(Rc::clone)
     }
 
     /// Fire the debugger hook (if installed) at `cp`, building a live
@@ -371,11 +377,11 @@ impl IpoptAlgorithm {
     /// requested action, defaulting to `Resume` when no hook is set.
     fn fire_debug(&mut self, cp: crate::debug::Checkpoint) -> crate::debug::DebugAction {
         use crate::debug::{DebugAction, DebugCtx};
-        let Some(hook) = self.debug.as_mut() else {
+        let Some(hook) = self.debug.as_ref() else {
             return DebugAction::Resume;
         };
         let mut ctx = DebugCtx::new(Rc::clone(&self.data), Rc::clone(&self.cq), cp);
-        hook.at_checkpoint(&mut ctx)
+        hook.borrow_mut().at_checkpoint(&mut ctx)
     }
 
     /// Run the restoration phase, bracketed by the `PreRestoration` /
@@ -413,7 +419,7 @@ impl IpoptAlgorithm {
     /// `result` regardless — so the hook just gets a last look.
     fn fire_debug_terminal(&mut self, result: SolverReturn) {
         use crate::debug::{Checkpoint, DebugCtx};
-        let Some(hook) = self.debug.as_mut() else {
+        let Some(hook) = self.debug.as_ref() else {
             return;
         };
         let mut ctx = DebugCtx::new(
@@ -422,7 +428,7 @@ impl IpoptAlgorithm {
             Checkpoint::Terminated,
         )
         .with_status(format!("{result:?}"));
-        let _ = hook.at_checkpoint(&mut ctx);
+        let _ = hook.borrow_mut().at_checkpoint(&mut ctx);
     }
 
     /// One iteration body — port of `Optimize()`'s inner loop.
@@ -910,7 +916,11 @@ impl IpoptAlgorithm {
                 let provides = aug.provides_inertia();
                 crate::ipopt_data::KktDebug {
                     dim: aug.system_dim(),
-                    n_neg: if provides { aug.number_of_neg_evals() } else { -1 },
+                    n_neg: if provides {
+                        aug.number_of_neg_evals()
+                    } else {
+                        -1
+                    },
                     provides_inertia: provides,
                     status: format!("{:?}", aug.last_solve_status()),
                     matrix: aug.kkt_triplets(),
@@ -1282,6 +1292,8 @@ impl IpoptAlgorithm {
             return IterateOutcome::Terminate(SolverReturn::RestorationFailure);
         };
         resto.set_orig_progress_check(orig_progress_cb);
+        // Forward the shared debugger so it can step the inner solve.
+        resto.set_debug_hook(self.debug.as_ref().map(Rc::clone));
         let mut pd_guard = sd.pd_solver_mut();
         let aug = pd_guard.aug_solver_mut();
         // Audit counters (pounce#12). Increment call count + outer-iter

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -378,6 +378,24 @@ impl IpoptAlgorithm {
         hook.at_checkpoint(&mut ctx)
     }
 
+    /// Fire the terminal post-mortem checkpoint (if a debugger is set),
+    /// carrying the solve outcome so the hook can decide whether to pause
+    /// at the final iterate. The action is advisory — the loop returns
+    /// `result` regardless — so the hook just gets a last look.
+    fn fire_debug_terminal(&mut self, result: SolverReturn) {
+        use crate::debug::{Checkpoint, DebugCtx};
+        let Some(hook) = self.debug.as_mut() else {
+            return;
+        };
+        let mut ctx = DebugCtx::new(
+            Rc::clone(&self.data),
+            Rc::clone(&self.cq),
+            Checkpoint::Terminated,
+        )
+        .with_status(format!("{result:?}"));
+        let _ = hook.at_checkpoint(&mut ctx);
+    }
+
     /// One iteration body — port of `Optimize()`'s inner loop.
     /// Returns either `Continue` to keep iterating or a terminal
     /// [`SolverReturn`] mirroring upstream's exception → return-code
@@ -1421,9 +1439,9 @@ impl IpoptAlgorithm {
             return SolverReturn::UserRequestedStop;
         }
 
-        loop {
+        let result = loop {
             match self.iterate() {
-                IterateOutcome::Terminate(ret) => return ret,
+                IterateOutcome::Terminate(ret) => break ret,
                 IterateOutcome::Continue => {
                     // Source the local counter from `data.iter_count`
                     // each pass so a pre-seeded counter (e.g. the inner
@@ -1438,7 +1456,7 @@ impl IpoptAlgorithm {
                     let mut iter_count: Index = self.data.borrow().iter_count;
                     iter_count += 1;
                     if iter_count >= self.max_iter {
-                        return SolverReturn::MaxiterExceeded;
+                        break SolverReturn::MaxiterExceeded;
                     }
                     self.data.borrow_mut().iter_count = iter_count;
                     // Keep the diagnostics counter in lock-step with
@@ -1463,16 +1481,24 @@ impl IpoptAlgorithm {
                     // `GetIpoptCurrent*` family) see live state for the
                     // duration of the user callback.
                     if !self.fire_intermediate() {
-                        return SolverReturn::UserRequestedStop;
+                        break SolverReturn::UserRequestedStop;
                     }
                     if self.fire_debug(crate::debug::Checkpoint::IterStart)
                         == crate::debug::DebugAction::Stop
                     {
-                        return SolverReturn::UserRequestedStop;
+                        break SolverReturn::UserRequestedStop;
                     }
                 }
             }
+        };
+
+        // Terminal post-mortem checkpoint. Skipped when the user already
+        // asked to stop (they were just at a prompt); otherwise the
+        // debugger gets a last look at the final/failing iterate.
+        if !matches!(result, SolverReturn::UserRequestedStop) {
+            self.fire_debug_terminal(result);
         }
+        result
     }
 }
 

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -899,6 +899,24 @@ impl IpoptAlgorithm {
             }
         }
 
+        // Capture KKT-factorization diagnostics (dim, inertia, status)
+        // for the debugger before the line search runs. Only when a
+        // debugger is installed — pulls nothing otherwise.
+        if self.debug.is_some() {
+            let info = self.search_dir.as_ref().map(|sd| {
+                let pd = sd.pd_solver_mut();
+                let aug = pd.aug_solver();
+                let provides = aug.provides_inertia();
+                crate::ipopt_data::KktDebug {
+                    dim: aug.system_dim(),
+                    n_neg: if provides { aug.number_of_neg_evals() } else { -1 },
+                    provides_inertia: provides,
+                    status: format!("{:?}", aug.last_solve_status()),
+                }
+            });
+            self.data.borrow_mut().kkt_debug = info;
+        }
+
         // Sub-iteration checkpoint: the Newton step `δ` (data.delta) and
         // the applied regularization are now available, before the line
         // search consumes them.

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -1036,6 +1036,16 @@ impl IpoptAlgorithm {
                         // the limit.
                     }
                     Outcome::TinyStep | Outcome::Failed => {
+                        // Debugger stop: the line search rejected the step
+                        // (tiny-step floor or all backtracks failed), before
+                        // we fall into restoration. Lets a "why did the line
+                        // search give up?" inspection happen at the failing
+                        // point distinctly from the restoration entry.
+                        if let Some(o) =
+                            self.debug_stop(crate::debug::Checkpoint::StepRejected)
+                        {
+                            return o;
+                        }
                         // Upstream `IpBacktrackingLineSearch.cpp` raises
                         // `LINE_SEARCH_FAILED` when α drops below
                         // `alpha_min` or all retries reject, which in

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -174,6 +174,11 @@ pub struct IpoptAlgorithm {
     /// advances the state's iter counter and the augmented-system
     /// solver consults it to gate KKT dumps.
     diagnostics: Option<Rc<DiagnosticsState>>,
+    /// Optional interactive debugger. When installed, the outer loop
+    /// fires it at every [`crate::debug::Checkpoint`] (today: the top
+    /// of each iteration) so a REPL or agent can inspect and mutate
+    /// live state before the next Newton step. See `crate::debug`.
+    debug: Option<Box<dyn crate::debug::DebugHook>>,
 
     // ---- Restoration-phase audit counters (pounce#12). ----
     //
@@ -234,6 +239,7 @@ impl IpoptAlgorithm {
             acceptable_iterate: None,
             acceptable_iter_number: 0,
             diagnostics: None,
+            debug: None,
             resto_calls: 0,
             resto_inner_iters: 0,
             resto_outer_iters: 0,
@@ -350,6 +356,26 @@ impl IpoptAlgorithm {
     pub fn with_diagnostics(mut self, diag: Rc<DiagnosticsState>) -> Self {
         self.diagnostics = Some(diag);
         self
+    }
+
+    /// Install an interactive debugger hook. Fired at each checkpoint
+    /// in [`Self::optimize`]; returning [`crate::debug::DebugAction::Stop`]
+    /// ends the solve with `SolverReturn::UserRequestedStop`.
+    pub fn with_debug_hook(mut self, hook: Box<dyn crate::debug::DebugHook>) -> Self {
+        self.debug = Some(hook);
+        self
+    }
+
+    /// Fire the debugger hook (if installed) at `cp`, building a live
+    /// [`crate::debug::DebugCtx`] over cheap handle clones. Returns the
+    /// requested action, defaulting to `Resume` when no hook is set.
+    fn fire_debug(&mut self, cp: crate::debug::Checkpoint) -> crate::debug::DebugAction {
+        use crate::debug::{DebugAction, DebugCtx};
+        let Some(hook) = self.debug.as_mut() else {
+            return DebugAction::Resume;
+        };
+        let mut ctx = DebugCtx::new(Rc::clone(&self.data), Rc::clone(&self.cq), cp);
+        hook.at_checkpoint(&mut ctx)
     }
 
     /// One iteration body — port of `Optimize()`'s inner loop.
@@ -1391,6 +1417,9 @@ impl IpoptAlgorithm {
         if !self.fire_intermediate() {
             return SolverReturn::UserRequestedStop;
         }
+        if self.fire_debug(crate::debug::Checkpoint::IterStart) == crate::debug::DebugAction::Stop {
+            return SolverReturn::UserRequestedStop;
+        }
 
         loop {
             match self.iterate() {
@@ -1434,6 +1463,11 @@ impl IpoptAlgorithm {
                     // `GetIpoptCurrent*` family) see live state for the
                     // duration of the user callback.
                     if !self.fire_intermediate() {
+                        return SolverReturn::UserRequestedStop;
+                    }
+                    if self.fire_debug(crate::debug::Checkpoint::IterStart)
+                        == crate::debug::DebugAction::Stop
+                    {
                         return SolverReturn::UserRequestedStop;
                     }
                 }
@@ -1516,7 +1550,7 @@ fn clamp_against_slack(
     Rc::from(out)
 }
 
-fn flat_read_into(v: &dyn Vector, dst: &mut [Number]) {
+pub(crate) fn flat_read_into(v: &dyn Vector, dst: &mut [Number]) {
     if let Some(dv) = v
         .as_any()
         .downcast_ref::<pounce_linalg::dense_vector::DenseVector>()
@@ -1543,13 +1577,13 @@ fn flat_read_into(v: &dyn Vector, dst: &mut [Number]) {
     panic!("clamp_against_slack: unsupported Vector kind");
 }
 
-fn flat_read_owned(v: &dyn Vector) -> Vec<Number> {
+pub(crate) fn flat_read_owned(v: &dyn Vector) -> Vec<Number> {
     let mut out = vec![0.0; v.dim() as usize];
     flat_read_into(v, &mut out);
     out
 }
 
-fn flat_write_into(v: &mut dyn Vector, src: &[Number]) {
+pub(crate) fn flat_write_into(v: &mut dyn Vector, src: &[Number]) {
     if let Some(dv) = v
         .as_any_mut()
         .downcast_mut::<pounce_linalg::dense_vector::DenseVector>()

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -28,6 +28,22 @@ pub struct PdPerturbations {
     pub delta_d: Number,
 }
 
+/// KKT-factorization diagnostics captured for the interactive debugger
+/// after a search-direction solve. Only populated when a debugger is
+/// installed (see `IpoptAlgorithm`); inspected via `DebugCtx::kkt`.
+#[derive(Clone, Debug, Default)]
+pub struct KktDebug {
+    /// Dimension of the augmented system (n + m).
+    pub dim: i32,
+    /// Negative eigenvalues reported by the factorization (-1 if the
+    /// backend doesn't provide inertia).
+    pub n_neg: i32,
+    /// Whether the backend reports inertia at all.
+    pub provides_inertia: bool,
+    /// Debug string of the last factorization status.
+    pub status: String,
+}
+
 /// Mutable state passed down through the algorithm. Owned by
 /// `IpoptAlgorithm`; strategies access via `Rc<RefCell<IpoptData>>`.
 pub struct IpoptData {
@@ -52,6 +68,10 @@ pub struct IpoptData {
     pub tol: Number,
 
     pub perturbations: PdPerturbations,
+
+    /// KKT-factorization diagnostics for the debugger (set after a
+    /// search-direction solve when a debugger is installed).
+    pub kkt_debug: Option<KktDebug>,
 
     /// Set after a successful trial-acceptance step in the line
     /// search. Cleared on accept.
@@ -130,6 +150,7 @@ impl IpoptData {
             curr_tau: 0.99,
             tol: 1e-8,
             perturbations: PdPerturbations::default(),
+            kkt_debug: None,
             info_alpha_primal: 0.0,
             info_alpha_dual: 0.0,
             info_regu_x: 0.0,

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -42,6 +42,12 @@ pub struct KktDebug {
     pub provides_inertia: bool,
     /// Debug string of the last factorization status.
     pub status: String,
+    /// Assembled KKT triplets `(dim, irn, jcn, vals)`, 1-based lower
+    /// triangle — for `viz kkt`. Captured when a debugger is attached.
+    pub matrix: Option<(i32, Vec<i32>, Vec<i32>, Vec<f64>)>,
+    /// `LDLᵀ` factor pattern (+ values) — for `viz L`. Captured only
+    /// after the debugger opts in (it's the expensive piece).
+    pub l_factor: Option<pounce_linsol::FactorPattern>,
 }
 
 /// Mutable state passed down through the algorithm. Owned by
@@ -72,6 +78,9 @@ pub struct IpoptData {
     /// KKT-factorization diagnostics for the debugger (set after a
     /// search-direction solve when a debugger is installed).
     pub kkt_debug: Option<KktDebug>,
+    /// Set by the debugger to request the (expensive) `LDLᵀ` factor be
+    /// captured into `kkt_debug.l_factor` on the next solve.
+    pub want_l_factor: bool,
 
     /// Set after a successful trial-acceptance step in the line
     /// search. Cleared on accept.
@@ -151,6 +160,7 @@ impl IpoptData {
             tol: 1e-8,
             perturbations: PdPerturbations::default(),
             kkt_debug: None,
+            want_l_factor: false,
             info_alpha_primal: 0.0,
             info_alpha_dual: 0.0,
             info_regu_x: 0.0,

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -81,6 +81,11 @@ pub struct IpoptData {
     /// Set by the debugger to request the (expensive) `LDLᵀ` factor be
     /// captured into `kkt_debug.l_factor` on the next solve.
     pub want_l_factor: bool,
+    /// Set by the debugger to request the assembled KKT matrix triplets be
+    /// captured into `kkt_debug.matrix` on the next solve. Off by default so
+    /// merely attaching the debugger doesn't pay an O(nnz) triplet assembly
+    /// every iteration — only armed when `viz kkt` / `save` needs them.
+    pub want_matrix: bool,
 
     /// Set after a successful trial-acceptance step in the line
     /// search. Cleared on accept.
@@ -161,6 +166,7 @@ impl IpoptData {
             perturbations: PdPerturbations::default(),
             kkt_debug: None,
             want_l_factor: false,
+            want_matrix: false,
             info_alpha_primal: 0.0,
             info_alpha_dual: 0.0,
             info_regu_x: 0.0,

--- a/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
@@ -78,6 +78,13 @@ pub trait AugSystemSolver {
     /// factorization. Caller checks `provides_inertia()` first.
     fn number_of_neg_evals(&self) -> Index;
 
+    /// Dimension of the assembled augmented (KKT) system. Used by the
+    /// interactive debugger to report inertia; default 0 for backends
+    /// that don't track it.
+    fn system_dim(&self) -> Index {
+        0
+    }
+
     /// Ask the underlying solver for higher-quality pivoting.
     fn increase_quality(&mut self) -> bool;
 

--- a/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/aug_system_solver.rs
@@ -18,7 +18,7 @@
 use pounce_common::timing::TimingStatistics;
 use pounce_common::types::{Index, Number};
 use pounce_linalg::{Matrix, SymMatrix, Vector};
-use pounce_linsol::ESymSolverStatus;
+use pounce_linsol::{ESymSolverStatus, FactorPattern};
 use std::rc::Rc;
 
 /// Bundle of the matrices/vectors that define one augmented-system
@@ -83,6 +83,19 @@ pub trait AugSystemSolver {
     /// that don't track it.
     fn system_dim(&self) -> Index {
         0
+    }
+
+    /// Triplets of the assembled KKT matrix `(dim, irn, jcn, vals)`
+    /// (1-based lower triangle), for the debugger's `viz kkt`. Default
+    /// `None` for backends that don't expose them.
+    fn kkt_triplets(&self) -> Option<(Index, Vec<Index>, Vec<Index>, Vec<Number>)> {
+        None
+    }
+
+    /// The `LDLᵀ` factor pattern (and optionally values) of the most
+    /// recent factorization, for the debugger's `viz L`. Default `None`.
+    fn l_factor(&self, _want_values: bool) -> Option<FactorPattern> {
+        None
     }
 
     /// Ask the underlying solver for higher-quality pivoting.

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -379,7 +379,12 @@ impl AugSystemSolver for StdAugSystemSolver {
         if self.irn.is_empty() {
             return None;
         }
-        Some((self.dim, self.irn.clone(), self.jcn.clone(), self.vals.clone()))
+        Some((
+            self.dim,
+            self.irn.clone(),
+            self.jcn.clone(),
+            self.vals.clone(),
+        ))
     }
 
     fn l_factor(&self, want_values: bool) -> Option<FactorPattern> {

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -375,6 +375,17 @@ impl AugSystemSolver for StdAugSystemSolver {
         self.dim
     }
 
+    fn kkt_triplets(&self) -> Option<(Index, Vec<Index>, Vec<Index>, Vec<Number>)> {
+        if self.irn.is_empty() {
+            return None;
+        }
+        Some((self.dim, self.irn.clone(), self.jcn.clone(), self.vals.clone()))
+    }
+
+    fn l_factor(&self, want_values: bool) -> Option<FactorPattern> {
+        self.linsol.factor_pattern(want_values)
+    }
+
     fn increase_quality(&mut self) -> bool {
         // Quality bump → pivtol changed → next solve must refactor.
         // `resolve` would silently hand back stale numbers; force the

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -371,6 +371,10 @@ impl AugSystemSolver for StdAugSystemSolver {
         self.last_neg_evals
     }
 
+    fn system_dim(&self) -> Index {
+        self.dim
+    }
+
     fn increase_quality(&mut self) -> bool {
         // Quality bump → pivtol changed → next solve must refactor.
         // `resolve` would silently hand back stale numbers; force the

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -23,6 +23,7 @@
 pub mod alg_builder;
 pub mod application;
 pub mod conv_check;
+pub mod debug;
 pub mod eq_mult;
 pub mod hess;
 pub mod init;

--- a/crates/pounce-algorithm/src/restoration.rs
+++ b/crates/pounce-algorithm/src/restoration.rs
@@ -87,6 +87,14 @@ pub trait RestorationPhase {
         RestorationOutcome::Failed
     }
 
+    /// Forward the outer interactive debugger onto the restoration inner
+    /// IPM so the same debugger can step the sub-solve. Default no-op.
+    fn set_debug_hook(
+        &mut self,
+        _hook: Option<std::rc::Rc<std::cell::RefCell<dyn crate::debug::DebugHook>>>,
+    ) {
+    }
+
     /// Inject the orig-progress callback the inner IPM should consult at
     /// every iteration. Mirrors upstream
     /// `IpRestoFilterConvCheck::SetOrigLSAcceptor` (the outer line

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -49,6 +49,9 @@ anstyle.workspace = true
 # Ctrl-R search, and Tab completion. Only used on an interactive TTY;
 # piped input and `--debug-json` fall back to a plain line reader.
 rustyline = { version = "14", features = ["derive"] }
+# SIGINT handler so Ctrl-C during a debug run breaks into the debugger
+# at the next iteration (second Ctrl-C aborts). Already in the tree.
+nix = { version = "0.28", features = ["signal"] }
 
 [features]
 default = []

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -45,6 +45,10 @@ libloading = "0.8"
 tracing.workspace = true
 anstream.workspace = true
 anstyle.workspace = true
+# Line editing for the interactive debugger REPL (`--debug`): history,
+# Ctrl-R search, and Tab completion. Only used on an interactive TTY;
+# piped input and `--debug-json` fall back to a plain line reader.
+rustyline = { version = "14", features = ["derive"] }
 
 [features]
 default = []

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -83,6 +83,11 @@ pub struct Args {
     /// front end; `Json` speaks newline-delimited JSON so an LLM agent
     /// (or any program) can drive the loop. `None` disables it.
     pub debug: Option<DebugMode>,
+    /// `--debug-on-error` — don't pause every iteration; instead run
+    /// freely and only drop into the debugger at the terminal checkpoint
+    /// *if the solve did not succeed*, for a post-mortem at the failing
+    /// iterate. Implies `--debug` (REPL) when no `--debug*` mode is given.
+    pub debug_on_error: bool,
 }
 
 /// Front end for the interactive solver debugger (`--debug*`).
@@ -147,6 +152,10 @@ Options:
   --debug-json              same loop, but speak newline-delimited JSON on
                             stdin/stdout so an LLM agent or program can
                             drive it (one JSON state object per pause).
+  --debug-on-error          don't pause every iteration; run freely and
+                            drop into the debugger only if the solve fails,
+                            for a post-mortem at the final iterate. Implies
+                            --debug when no --debug* mode is given.
   --list-problems           print available built-in problems and exit
   -AMPL                     AMPL solver-protocol mode (for Pyomo / AMPL
                             drivers): convey termination via the .sol
@@ -202,6 +211,7 @@ Options:
         let mut compute_red_hessian = false;
         let mut rh_eigendecomp = false;
         let mut debug: Option<DebugMode> = None;
+        let mut debug_on_error = false;
 
         let mut it = argv.into_iter().skip(1);
         while let Some(arg) = it.next() {
@@ -283,6 +293,7 @@ Options:
                 }
                 "--debug" => debug = Some(DebugMode::Repl),
                 "--debug-json" => debug = Some(DebugMode::Json),
+                "--debug-on-error" => debug_on_error = true,
                 "--compute-red-hessian" => compute_red_hessian = true,
                 "--rh-eigendecomp" => {
                     rh_eigendecomp = true;
@@ -314,6 +325,11 @@ Options:
             std::process::exit(0);
         }
 
+        // `--debug-on-error` without an explicit mode implies the REPL.
+        if debug_on_error && debug.is_none() {
+            debug = Some(DebugMode::Repl);
+        }
+
         if !help && !version && !about {
             let problem = problem.ok_or_else(|| {
                 "missing problem: pass a positional .nl path, --nl-file, or --problem".to_string()
@@ -338,6 +354,7 @@ Options:
                 compute_red_hessian,
                 rh_eigendecomp,
                 debug,
+                debug_on_error,
             });
         }
 
@@ -361,6 +378,7 @@ Options:
             compute_red_hessian,
             rh_eigendecomp,
             debug,
+            debug_on_error,
         })
     }
 }

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -88,6 +88,10 @@ pub struct Args {
     /// *if the solve did not succeed*, for a post-mortem at the failing
     /// iterate. Implies `--debug` (REPL) when no `--debug*` mode is given.
     pub debug_on_error: bool,
+    /// `--debug-on-interrupt` — run normally but install a Ctrl-C handler
+    /// that drops into the debugger at the next iteration. No automatic
+    /// pauses. Implies `--debug` (REPL) when no `--debug*` mode is given.
+    pub debug_on_interrupt: bool,
 }
 
 /// Front end for the interactive solver debugger (`--debug*`).
@@ -156,6 +160,10 @@ Options:
                             drop into the debugger only if the solve fails,
                             for a post-mortem at the final iterate. Implies
                             --debug when no --debug* mode is given.
+  --debug-on-interrupt      run normally but install a Ctrl-C handler that
+                            drops into the debugger at the next iteration
+                            (second Ctrl-C aborts). Implies --debug when no
+                            --debug* mode is given.
   --list-problems           print available built-in problems and exit
   -AMPL                     AMPL solver-protocol mode (for Pyomo / AMPL
                             drivers): convey termination via the .sol
@@ -212,6 +220,7 @@ Options:
         let mut rh_eigendecomp = false;
         let mut debug: Option<DebugMode> = None;
         let mut debug_on_error = false;
+        let mut debug_on_interrupt = false;
 
         let mut it = argv.into_iter().skip(1);
         while let Some(arg) = it.next() {
@@ -294,6 +303,7 @@ Options:
                 "--debug" => debug = Some(DebugMode::Repl),
                 "--debug-json" => debug = Some(DebugMode::Json),
                 "--debug-on-error" => debug_on_error = true,
+                "--debug-on-interrupt" => debug_on_interrupt = true,
                 "--compute-red-hessian" => compute_red_hessian = true,
                 "--rh-eigendecomp" => {
                     rh_eigendecomp = true;
@@ -325,8 +335,9 @@ Options:
             std::process::exit(0);
         }
 
-        // `--debug-on-error` without an explicit mode implies the REPL.
-        if debug_on_error && debug.is_none() {
+        // `--debug-on-error` / `--debug-on-interrupt` without an explicit
+        // mode imply the REPL.
+        if (debug_on_error || debug_on_interrupt) && debug.is_none() {
             debug = Some(DebugMode::Repl);
         }
 
@@ -355,6 +366,7 @@ Options:
                 rh_eigendecomp,
                 debug,
                 debug_on_error,
+                debug_on_interrupt,
             });
         }
 
@@ -379,6 +391,7 @@ Options:
             rh_eigendecomp,
             debug,
             debug_on_error,
+            debug_on_interrupt,
         })
     }
 }

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -78,6 +78,20 @@ pub struct Args {
     /// reduced Hessian. Implies `--compute-red-hessian`. Mirrors
     /// upstream `rh_eigendecomp`.
     pub rh_eigendecomp: bool,
+    /// `--debug` / `--debug-json` — drop into the interactive solver
+    /// debugger at each iteration. `Repl` is the human line-oriented
+    /// front end; `Json` speaks newline-delimited JSON so an LLM agent
+    /// (or any program) can drive the loop. `None` disables it.
+    pub debug: Option<DebugMode>,
+}
+
+/// Front end for the interactive solver debugger (`--debug*`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DebugMode {
+    /// Human-facing line REPL on stdin/stdout.
+    Repl,
+    /// Newline-delimited JSON protocol for an agent / program.
+    Json,
 }
 
 impl Args {
@@ -125,6 +139,14 @@ Options:
                             tagged by the `red_hessian` integer var-suffix
   --rh-eigendecomp          also compute the reduced-Hessian eigendecomp;
                             implies --compute-red-hessian
+  --debug                   drop into the interactive solver debugger (a
+                            pdb-for-the-IPM): pause each iteration to
+                            inspect/mutate x, multipliers, mu, set
+                            breakpoints, step/continue. Type `help` at
+                            the pounce-dbg> prompt for commands.
+  --debug-json              same loop, but speak newline-delimited JSON on
+                            stdin/stdout so an LLM agent or program can
+                            drive it (one JSON state object per pause).
   --list-problems           print available built-in problems and exit
   -AMPL                     AMPL solver-protocol mode (for Pyomo / AMPL
                             drivers): convey termination via the .sol
@@ -179,6 +201,7 @@ Options:
         let mut sens_bound_eps: f64 = 1e-3;
         let mut compute_red_hessian = false;
         let mut rh_eigendecomp = false;
+        let mut debug: Option<DebugMode> = None;
 
         let mut it = argv.into_iter().skip(1);
         while let Some(arg) = it.next() {
@@ -258,6 +281,8 @@ Options:
                         .map_err(|e| format!("--sens-bound-eps: {e}"))?;
                     sens_boundcheck = true;
                 }
+                "--debug" => debug = Some(DebugMode::Repl),
+                "--debug-json" => debug = Some(DebugMode::Json),
                 "--compute-red-hessian" => compute_red_hessian = true,
                 "--rh-eigendecomp" => {
                     rh_eigendecomp = true;
@@ -312,6 +337,7 @@ Options:
                 sens_bound_eps,
                 compute_red_hessian,
                 rh_eigendecomp,
+                debug,
             });
         }
 
@@ -334,6 +360,7 @@ Options:
             sens_bound_eps,
             compute_red_hessian,
             rh_eigendecomp,
+            debug,
         })
     }
 }

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -92,6 +92,10 @@ pub struct Args {
     /// that drops into the debugger at the next iteration. No automatic
     /// pauses. Implies `--debug` (REPL) when no `--debug*` mode is given.
     pub debug_on_interrupt: bool,
+    /// `--debug-script <file>` — run debugger commands from a file at the
+    /// first pause (e.g. set breakpoints then `continue`). Implies
+    /// `--debug` when no `--debug*` mode is given.
+    pub debug_script: Option<PathBuf>,
 }
 
 /// Front end for the interactive solver debugger (`--debug*`).
@@ -164,6 +168,9 @@ Options:
                             drops into the debugger at the next iteration
                             (second Ctrl-C aborts). Implies --debug when no
                             --debug* mode is given.
+  --debug-script <file>     run debugger commands from a file at the first
+                            pause (e.g. set breakpoints then continue).
+                            Implies --debug when no --debug* mode is given.
   --list-problems           print available built-in problems and exit
   -AMPL                     AMPL solver-protocol mode (for Pyomo / AMPL
                             drivers): convey termination via the .sol
@@ -221,6 +228,7 @@ Options:
         let mut debug: Option<DebugMode> = None;
         let mut debug_on_error = false;
         let mut debug_on_interrupt = false;
+        let mut debug_script: Option<PathBuf> = None;
 
         let mut it = argv.into_iter().skip(1);
         while let Some(arg) = it.next() {
@@ -304,6 +312,12 @@ Options:
                 "--debug-json" => debug = Some(DebugMode::Json),
                 "--debug-on-error" => debug_on_error = true,
                 "--debug-on-interrupt" => debug_on_interrupt = true,
+                "--debug-script" => {
+                    let v = it
+                        .next()
+                        .ok_or_else(|| "--debug-script requires a value".to_string())?;
+                    debug_script = Some(PathBuf::from(v));
+                }
                 "--compute-red-hessian" => compute_red_hessian = true,
                 "--rh-eigendecomp" => {
                     rh_eigendecomp = true;
@@ -335,9 +349,9 @@ Options:
             std::process::exit(0);
         }
 
-        // `--debug-on-error` / `--debug-on-interrupt` without an explicit
-        // mode imply the REPL.
-        if (debug_on_error || debug_on_interrupt) && debug.is_none() {
+        // `--debug-on-error` / `--debug-on-interrupt` / `--debug-script`
+        // without an explicit mode imply the REPL.
+        if (debug_on_error || debug_on_interrupt || debug_script.is_some()) && debug.is_none() {
             debug = Some(DebugMode::Repl);
         }
 
@@ -367,6 +381,7 @@ Options:
                 debug,
                 debug_on_error,
                 debug_on_interrupt,
+                debug_script,
             });
         }
 
@@ -392,6 +407,7 @@ Options:
             debug,
             debug_on_error,
             debug_on_interrupt,
+            debug_script,
         })
     }
 }

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -57,8 +57,8 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "stepi", "continue", "run", "break", "stop-at", "set", "opt",
-    "complete", "viz", "save", "goto", "restart", "resolve", "ask", "watch", "source", "progress",
-    "detach", "quit",
+    "complete", "viz", "save", "goto", "restart", "resolve", "ask", "watch", "diff", "source",
+    "progress", "detach", "quit",
 ];
 
 /// Events a user can `break on` (advertised in `hello.events`). Each is
@@ -415,6 +415,17 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
             v
         }
         ["set", "opt"] | ["opt"] | ["options"] => opt_names(),
+        // After `set opt <name>`, complete the option's valid values.
+        ["set", "opt", name] => reg
+            .and_then(|r| r.get_option(name))
+            .map(|o| {
+                o.valid_strings
+                    .iter()
+                    .map(|e| e.value.clone())
+                    .filter(|v| v.starts_with(word) && v != "*")
+                    .collect()
+            })
+            .unwrap_or_default(),
         ["stop-at"] | ["stopat"] => starts(CHECKPOINTS),
         ["break", "if"] | ["b", "if"] => starts(METRICS),
         ["break", "on"] | ["b", "on"] => starts(EVENTS),
@@ -733,6 +744,7 @@ impl SolverDebugger {
             "resolve" | "re-solve" => self.cmd_resolve(ctx),
             "ask" | "explain" | "claude" => self.cmd_ask(rest, ctx),
             "watch" | "display" => self.cmd_watch(rest),
+            "diff" => self.cmd_diff(ctx),
             "source" => self.cmd_source(rest, ctx),
             "detach" => {
                 self.detached = true;
@@ -777,6 +789,7 @@ impl SolverDebugger {
             "  resolve                  re-solve from the current x with staged `set opt`s".into(),
             "  ask [question]           ask Claude Code (claude -p / $POUNCE_DBG_LLM) about the state".into(),
             "  watch [target|clear|del] auto-print a `print` target at every pause".into(),
+            "  diff                     what changed in the iterate since the last iteration".into(),
             "  source <file>            run debugger commands from a file".into(),
             "  detach                   stop pausing; solve to completion".into(),
             "  quit | q                 stop the solve now".into(),
@@ -1167,28 +1180,16 @@ impl SolverDebugger {
         CmdOut::ok(lines).with_data(serde_json::json!({"options": data}))
     }
 
+    /// `complete <line…>` — context-sensitive completion candidates for
+    /// the last token, using the same engine as TTY Tab. The preceding
+    /// tokens form the context (so `complete set opt mu` completes option
+    /// names, `complete set opt mu_strategy a` completes valid values).
     fn cmd_complete(&self, rest: &[&str]) -> CmdOut {
-        let prefix = rest.first().copied().unwrap_or("");
-        let mut cands: Vec<String> = COMMANDS
-            .iter()
-            .filter(|c| c.starts_with(prefix))
-            .map(|c| c.to_string())
-            .collect();
-        // Block names and option names also complete (handy after `set`).
-        for b in BLOCK_NAMES {
-            if b.starts_with(prefix) {
-                cands.push(b.to_string());
-            }
-        }
-        if let Some(reg) = self.reg.as_ref() {
-            if prefix.len() >= 2 {
-                for o in reg.registered_options_in_order() {
-                    if o.name.starts_with(prefix) {
-                        cands.push(o.name.clone());
-                    }
-                }
-            }
-        }
+        let (before, word) = match rest.split_last() {
+            Some((w, pre)) => (pre.join(" "), *w),
+            None => (String::new(), ""),
+        };
+        let mut cands = completion_candidates(self.reg.as_deref(), &before, word);
         cands.sort();
         cands.dedup();
         CmdOut::ok(vec![cands.join(" ")]).with_data(serde_json::json!({"candidates": cands}))
@@ -1339,6 +1340,52 @@ impl SolverDebugger {
             }
             _ => CmdOut::err("usage: watch [<target> | clear | del <target>]"),
         }
+    }
+
+    /// `diff` — what changed in the iterate since the previous captured
+    /// iteration: per-block max |Δ| (and where), plus Δμ.
+    fn cmd_diff(&self, ctx: &DebugCtx) -> CmdOut {
+        let iter = ctx.iter();
+        let Some((&piter, prev)) = self.snapshots.range(..iter).next_back() else {
+            return CmdOut::err("no previous iterate to diff against");
+        };
+        let mut lines = vec![format!("Δ since iter {piter}:")];
+        let dmu = ctx.mu() - prev.mu();
+        lines.push(format!("  mu  = {:.6e}  (Δ {:+.3e})", ctx.mu(), dmu));
+        let mut blocks = serde_json::Map::new();
+        for b in BLOCK_NAMES {
+            let (Some(cur), Some(old)) = (ctx.block(b), prev.block(b)) else {
+                continue;
+            };
+            if cur.is_empty() || cur.len() != old.len() {
+                continue;
+            }
+            let mut amax = 0.0_f64;
+            let mut imax = 0usize;
+            for (i, (c, o)) in cur.iter().zip(&old).enumerate() {
+                let d = (c - o).abs();
+                if d > amax {
+                    amax = d;
+                    imax = i;
+                }
+            }
+            if amax > 0.0 {
+                lines.push(format!(
+                    "  {b}: max|Δ|={amax:.3e} at [{imax}]  ({:.4e} → {:.4e})",
+                    old[imax], cur[imax]
+                ));
+                blocks.insert(
+                    b.to_string(),
+                    serde_json::json!({"max_abs_change": amax, "argmax": imax}),
+                );
+            }
+        }
+        if lines.len() == 2 {
+            lines.push("  (no change)".into());
+        }
+        CmdOut::ok(lines).with_data(
+            serde_json::json!({"from_iter": piter, "to_iter": iter, "dmu": dmu, "blocks": blocks}),
+        )
     }
 
     /// `source <file>` — run debugger commands from a file (one per line;

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -1,0 +1,799 @@
+//! Interactive solver debugger front end — "pdb for the IPM".
+//!
+//! Implements [`pounce_algorithm::debug::DebugHook`]. The core fires us
+//! at every checkpoint (today: the top of each outer iteration); we
+//! pause, hand the user (or an agent) a command prompt, and apply
+//! inspect / mutate / flow commands against the live [`DebugCtx`] before
+//! returning [`DebugAction::Resume`] or [`DebugAction::Stop`].
+//!
+//! Two front ends share one command engine ([`SolverDebugger::dispatch`]):
+//!
+//!   * [`DebugMode::Repl`] — a human line REPL. Prompts and command
+//!     output go to **stderr** so they never interleave with the
+//!     solver's iteration table on stdout.
+//!   * [`DebugMode::Json`] — a newline-delimited JSON protocol on
+//!     stdin/stdout for an LLM agent or any program. Each pause emits one
+//!     `{"event":"pause",…}` object; each command yields one
+//!     `{"event":"result",…}` object. The solver's own stdout table is
+//!     suppressed in this mode (the caller sets `print_level=0`).
+//!
+//! Flow model: the debugger pauses at the *first* checkpoint (so you get
+//! control at iter 0), then only when re-armed — by `step` (pause next
+//! iteration), `break N` (pause at iter N), or `run N` (pause at iter
+//! ≥ N). `continue` clears all one-shot arming and runs to the next
+//! breakpoint; `detach` disables pausing entirely; `quit` stops the
+//! solve.
+
+use crate::cli::DebugMode;
+use pounce_algorithm::debug::{DebugAction, DebugCtx, DebugHook, BLOCK_NAMES};
+use pounce_common::reg_options::{DefaultValue, OptionType, RegisteredOptions};
+use std::io::Write;
+use std::rc::Rc;
+
+/// All command verbs, for `help` and `complete`.
+const COMMANDS: &[&str] = &[
+    "help", "info", "print", "step", "continue", "run", "break", "set", "opt", "complete", "viz",
+    "detach", "quit",
+];
+
+/// What to do after a command runs.
+enum Flow {
+    /// Stay paused; keep reading commands.
+    Stay,
+    /// Resume solving.
+    Resume,
+    /// Stop the solve.
+    Stop,
+}
+
+/// Outcome of one command: human lines + optional structured payload.
+struct CmdOut {
+    ok: bool,
+    lines: Vec<String>,
+    data: Option<serde_json::Value>,
+    flow: Flow,
+}
+
+impl CmdOut {
+    fn ok(lines: Vec<String>) -> Self {
+        Self {
+            ok: true,
+            lines,
+            data: None,
+            flow: Flow::Stay,
+        }
+    }
+    fn err(msg: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            lines: vec![msg.into()],
+            data: None,
+            flow: Flow::Stay,
+        }
+    }
+    fn with_data(mut self, data: serde_json::Value) -> Self {
+        self.data = Some(data);
+        self
+    }
+    fn flow(mut self, flow: Flow) -> Self {
+        self.flow = flow;
+        self
+    }
+}
+
+pub struct SolverDebugger {
+    mode: DebugMode,
+    reg: Option<Rc<RegisteredOptions>>,
+    /// Pause at the next checkpoint (one-shot, re-armed by `step`).
+    step: bool,
+    /// Pause once iteration ≥ this value.
+    run_to: Option<i32>,
+    /// Iterations to break at.
+    breaks: Vec<i32>,
+    /// Once true, never pause again (`detach`).
+    detached: bool,
+    /// Option edits accepted at the prompt. Validated against the
+    /// registry; surfaced to the caller after the solve. Not applied to
+    /// already-built strategies mid-solve (see `staged_options`).
+    staged: Vec<(String, String)>,
+}
+
+impl SolverDebugger {
+    pub fn new(mode: DebugMode, reg: Option<Rc<RegisteredOptions>>) -> Self {
+        Self {
+            mode,
+            reg,
+            // Pause at the very first checkpoint so the user has control
+            // before iteration 0's step is computed.
+            step: true,
+            run_to: None,
+            breaks: Vec::new(),
+            detached: false,
+            staged: Vec::new(),
+        }
+    }
+
+    /// Option edits accepted at the prompt (validated). The caller may
+    /// re-run the solve with these applied.
+    pub fn staged_options(&self) -> &[(String, String)] {
+        &self.staged
+    }
+
+    fn should_pause(&mut self, iter: i32) -> bool {
+        if self.detached {
+            return false;
+        }
+        if self.step {
+            return true;
+        }
+        if let Some(t) = self.run_to {
+            if iter >= t {
+                self.run_to = None;
+                return true;
+            }
+        }
+        self.breaks.contains(&iter)
+    }
+
+    // ---- command engine -----------------------------------------------
+
+    fn dispatch(&mut self, line: &str, ctx: &mut DebugCtx) -> CmdOut {
+        let toks: Vec<&str> = line.split_whitespace().collect();
+        let Some(&verb) = toks.first() else {
+            return CmdOut::ok(vec![]); // empty line: reprompt
+        };
+        let rest = &toks[1..];
+        match verb {
+            "help" | "h" | "?" => self.cmd_help(),
+            "info" | "i" => self.cmd_info(ctx),
+            "print" | "p" => self.cmd_print(rest, ctx),
+            "step" | "s" | "n" | "next" => {
+                self.step = true;
+                CmdOut::ok(vec!["stepping one iteration".into()]).flow(Flow::Resume)
+            }
+            "continue" | "c" | "cont" => {
+                self.step = false;
+                self.run_to = None;
+                CmdOut::ok(vec!["continuing".into()]).flow(Flow::Resume)
+            }
+            "run" | "r" => self.cmd_run(rest),
+            "break" | "b" => self.cmd_break(rest),
+            "set" => self.cmd_set(rest, ctx),
+            "opt" | "options" => self.cmd_opt(rest),
+            "complete" => self.cmd_complete(rest),
+            "viz" | "plot" => self.cmd_viz(rest, ctx),
+            "detach" => {
+                self.detached = true;
+                self.step = false;
+                self.run_to = None;
+                CmdOut::ok(vec!["detached — solving to completion".into()]).flow(Flow::Resume)
+            }
+            "quit" | "q" | "exit" => CmdOut::ok(vec!["stopping solve".into()]).flow(Flow::Stop),
+            other => CmdOut::err(format!("unknown command `{other}` (try `help`)")),
+        }
+    }
+
+    fn cmd_help(&self) -> CmdOut {
+        let lines = vec![
+            "commands:".into(),
+            "  info | i                 summary of the current iterate".into(),
+            "  print | p <what>         x|s|y_c|y_d|z_l|z_u|v_l|v_u | dx (step) |".into(),
+            "                           mu|obj|inf_pr|inf_du|err|iter".into(),
+            "  step | s | n             run one iteration, pause again".into(),
+            "  continue | c             run to the next breakpoint".into(),
+            "  run | r <N>              run until iteration N".into(),
+            "  break | b [N|clear|del N] set/list/clear breakpoints".into(),
+            "  set mu <v>               overwrite the barrier parameter".into(),
+            "  set <blk>[<i>] <v>       overwrite one component (e.g. set x[2] 1.5)".into(),
+            "  set <blk> <v0,v1,...>    overwrite a whole block".into(),
+            "  set opt <name> <value>   stage a solver option (validated)".into(),
+            "  opt [filter]             list solver options (name/type/default)".into(),
+            "  complete <prefix>        completion candidates (commands + options)".into(),
+            "  viz <x|s|dx|...|kkt|L>   open the artifact in an external viewer".into(),
+            "  detach                   stop pausing; solve to completion".into(),
+            "  quit | q                 stop the solve now".into(),
+        ];
+        CmdOut::ok(lines)
+    }
+
+    fn cmd_info(&self, ctx: &DebugCtx) -> CmdOut {
+        let dims: Vec<_> = ctx.block_dims();
+        let dims_json: serde_json::Map<String, serde_json::Value> = dims
+            .iter()
+            .map(|(n, d)| ((*n).to_string(), serde_json::json!(d)))
+            .collect();
+        let lines = vec![
+            format!("iter      = {}", ctx.iter()),
+            format!("mu        = {:.6e}", ctx.mu()),
+            format!("objective = {:.8e}", ctx.objective()),
+            format!("inf_pr    = {:.6e}", ctx.inf_pr()),
+            format!("inf_du    = {:.6e}", ctx.inf_du()),
+            format!("nlp_error = {:.6e}", ctx.nlp_error()),
+            format!(
+                "dims      = {}",
+                dims.iter()
+                    .map(|(n, d)| format!("{n}:{d}"))
+                    .collect::<Vec<_>>()
+                    .join(" ")
+            ),
+        ];
+        CmdOut::ok(lines).with_data(serde_json::json!({
+            "iter": ctx.iter(),
+            "mu": ctx.mu(),
+            "objective": ctx.objective(),
+            "inf_pr": ctx.inf_pr(),
+            "inf_du": ctx.inf_du(),
+            "nlp_error": ctx.nlp_error(),
+            "dims": dims_json,
+        }))
+    }
+
+    fn cmd_print(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
+        let Some(&what) = rest.first() else {
+            return self.cmd_info(ctx);
+        };
+        // step / delta blocks: `dx`, `ds`, ... or `delta_x`.
+        let delta = what.strip_prefix("d").filter(|b| BLOCK_NAMES.contains(b));
+        if BLOCK_NAMES.contains(&what) {
+            match ctx.block(what) {
+                Some(v) => CmdOut::ok(vec![fmt_vec(what, &v)])
+                    .with_data(serde_json::json!({"name": what, "values": v})),
+                None => CmdOut::err(format!("no iterate yet for block `{what}`")),
+            }
+        } else if let Some(blk) = delta {
+            match ctx.delta_block(blk) {
+                Some(v) => CmdOut::ok(vec![fmt_vec(&format!("d{blk}"), &v)])
+                    .with_data(serde_json::json!({"name": format!("d{blk}"), "values": v})),
+                None => CmdOut::err(format!("no search direction available for `d{blk}` yet")),
+            }
+        } else {
+            let val = match what {
+                "mu" => ctx.mu(),
+                "obj" | "objective" => ctx.objective(),
+                "inf_pr" => ctx.inf_pr(),
+                "inf_du" => ctx.inf_du(),
+                "err" | "nlp_error" => ctx.nlp_error(),
+                "iter" => ctx.iter() as f64,
+                _ => {
+                    return CmdOut::err(format!(
+                        "don't know how to print `{what}` (try a block name or mu|obj|inf_pr|inf_du|err|iter)"
+                    ))
+                }
+            };
+            CmdOut::ok(vec![format!("{what} = {val:.10e}")])
+                .with_data(serde_json::json!({"name": what, "value": val}))
+        }
+    }
+
+    fn cmd_run(&mut self, rest: &[&str]) -> CmdOut {
+        match rest.first().and_then(|s| s.parse::<i32>().ok()) {
+            Some(n) => {
+                self.run_to = Some(n);
+                self.step = false;
+                CmdOut::ok(vec![format!("running until iteration {n}")]).flow(Flow::Resume)
+            }
+            None => CmdOut::err("usage: run <iteration>"),
+        }
+    }
+
+    fn cmd_break(&mut self, rest: &[&str]) -> CmdOut {
+        match rest {
+            [] => {
+                let mut bs = self.breaks.clone();
+                bs.sort_unstable();
+                CmdOut::ok(vec![format!("breakpoints: {bs:?}")])
+                    .with_data(serde_json::json!({"breakpoints": bs}))
+            }
+            ["clear"] => {
+                self.breaks.clear();
+                CmdOut::ok(vec!["cleared all breakpoints".into()])
+            }
+            ["del", n] | ["delete", n] => match n.parse::<i32>() {
+                Ok(n) => {
+                    self.breaks.retain(|&b| b != n);
+                    CmdOut::ok(vec![format!("removed breakpoint {n}")])
+                }
+                Err(_) => CmdOut::err("usage: break del <iteration>"),
+            },
+            [n] => match n.parse::<i32>() {
+                Ok(n) => {
+                    if !self.breaks.contains(&n) {
+                        self.breaks.push(n);
+                    }
+                    CmdOut::ok(vec![format!("breakpoint at iteration {n}")])
+                }
+                Err(_) => CmdOut::err("usage: break <iteration>"),
+            },
+            _ => CmdOut::err("usage: break [N | clear | del N]"),
+        }
+    }
+
+    fn cmd_set(&mut self, rest: &[&str], ctx: &mut DebugCtx) -> CmdOut {
+        match rest {
+            ["mu", v] => match v.parse::<f64>() {
+                Ok(mu) => match ctx.set_mu(mu) {
+                    Ok(()) => CmdOut::ok(vec![format!("mu := {mu:.6e}")]),
+                    Err(e) => CmdOut::err(e),
+                },
+                Err(_) => CmdOut::err("usage: set mu <value>"),
+            },
+            ["opt", name, value] => self.cmd_set_opt(name, value),
+            [target, value] => self.cmd_set_block(target, value, ctx),
+            _ => CmdOut::err(
+                "usage: set mu <v> | set <blk>[<i>] <v> | set <blk> <v0,v1,..> | set opt <name> <v>",
+            ),
+        }
+    }
+
+    /// `set x[2] 1.5` (component) or `set x 1,2,3` (whole block).
+    fn cmd_set_block(&mut self, target: &str, value: &str, ctx: &mut DebugCtx) -> CmdOut {
+        // Component form: name[idx]
+        if let Some(open) = target.find('[') {
+            if !target.ends_with(']') {
+                return CmdOut::err("malformed component target (expected name[idx])");
+            }
+            let name = &target[..open];
+            let idx_str = &target[open + 1..target.len() - 1];
+            let Ok(idx) = idx_str.parse::<usize>() else {
+                return CmdOut::err(format!("bad index `{idx_str}`"));
+            };
+            let Ok(val) = value.parse::<f64>() else {
+                return CmdOut::err(format!("bad value `{value}`"));
+            };
+            return match ctx.set_component(name, idx, val) {
+                Ok(()) => CmdOut::ok(vec![format!("{name}[{idx}] := {val:.6e}")]),
+                Err(e) => CmdOut::err(e),
+            };
+        }
+        // Whole-block form: comma-separated values.
+        let parsed: Result<Vec<f64>, _> =
+            value.split(',').map(|s| s.trim().parse::<f64>()).collect();
+        match parsed {
+            Ok(vals) => match ctx.set_block(target, &vals) {
+                Ok(()) => CmdOut::ok(vec![format!("{target} := {} value(s)", vals.len())]),
+                Err(e) => CmdOut::err(e),
+            },
+            Err(_) => CmdOut::err("could not parse comma-separated values"),
+        }
+    }
+
+    fn cmd_set_opt(&mut self, name: &str, value: &str) -> CmdOut {
+        let Some(reg) = self.reg.as_ref() else {
+            return CmdOut::err("no options registry available");
+        };
+        let Some(opt) = reg.get_option(name) else {
+            return CmdOut::err(format!("unknown option `{name}` (try `opt {name}`)"));
+        };
+        // Validate against the registered type/bounds.
+        let valid = match opt.option_type {
+            OptionType::OT_Number => value
+                .parse::<f64>()
+                .map(|v| opt.is_valid_number(v))
+                .unwrap_or(false),
+            OptionType::OT_Integer => value
+                .parse::<i32>()
+                .map(|v| opt.is_valid_integer(v))
+                .unwrap_or(false),
+            OptionType::OT_String => opt.is_valid_string(value),
+            OptionType::OT_Unknown => true,
+        };
+        if !valid {
+            return CmdOut::err(format!("`{value}` is not a valid value for `{name}`"));
+        }
+        self.staged.retain(|(k, _)| k != name);
+        self.staged.push((name.to_string(), value.to_string()));
+        CmdOut::ok(vec![format!(
+            "staged {name} = {value}  (validated; applied on next solve — built strategies don't re-read mid-solve)"
+        )])
+        .with_data(serde_json::json!({"option": name, "value": value, "staged": true}))
+    }
+
+    fn cmd_opt(&self, rest: &[&str]) -> CmdOut {
+        let Some(reg) = self.reg.as_ref() else {
+            return CmdOut::err("no options registry available");
+        };
+        let filter = rest.first().copied().unwrap_or("");
+        let mut lines = Vec::new();
+        let mut data = Vec::new();
+        for o in reg.registered_options_in_order() {
+            if !filter.is_empty()
+                && !o.name.contains(filter)
+                && !o
+                    .category
+                    .to_ascii_lowercase()
+                    .contains(&filter.to_ascii_lowercase())
+            {
+                continue;
+            }
+            let ty = type_str(o.option_type);
+            let def = default_str(&o.default);
+            lines.push(format!(
+                "  {:<28} {:<7} default={:<12} {}",
+                o.name, ty, def, o.short_description
+            ));
+            data.push(serde_json::json!({
+                "name": o.name,
+                "type": ty,
+                "default": def,
+                "category": o.category,
+                "short": o.short_description,
+                "valid": o.valid_strings.iter().map(|e| e.value.clone()).collect::<Vec<_>>(),
+            }));
+        }
+        if lines.is_empty() {
+            return CmdOut::ok(vec![format!("no options match `{filter}`")]);
+        }
+        // For a single exact match, also show the long description.
+        if data.len() == 1 {
+            if let Some(o) = reg.get_option(filter) {
+                if !o.long_description.is_empty() {
+                    lines.push(String::new());
+                    lines.push(o.long_description.clone());
+                }
+            }
+        }
+        CmdOut::ok(lines).with_data(serde_json::json!({"options": data}))
+    }
+
+    fn cmd_complete(&self, rest: &[&str]) -> CmdOut {
+        let prefix = rest.first().copied().unwrap_or("");
+        let mut cands: Vec<String> = COMMANDS
+            .iter()
+            .filter(|c| c.starts_with(prefix))
+            .map(|c| c.to_string())
+            .collect();
+        // Block names and option names also complete (handy after `set`).
+        for b in BLOCK_NAMES {
+            if b.starts_with(prefix) {
+                cands.push(b.to_string());
+            }
+        }
+        if let Some(reg) = self.reg.as_ref() {
+            if prefix.len() >= 2 {
+                for o in reg.registered_options_in_order() {
+                    if o.name.starts_with(prefix) {
+                        cands.push(o.name.clone());
+                    }
+                }
+            }
+        }
+        cands.sort();
+        cands.dedup();
+        CmdOut::ok(vec![cands.join(" ")]).with_data(serde_json::json!({"candidates": cands}))
+    }
+
+    fn cmd_viz(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
+        let Some(&target) = rest.first() else {
+            return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
+        };
+        // Live KKT / L factor are assembled inside the search-direction
+        // solver during compute_search_direction, not at the iteration
+        // checkpoint, so they are not reachable from here yet.
+        if target == "kkt" || target == "L" {
+            return CmdOut::err(
+                "live KKT/L visualization needs the factored augmented system, which isn't \
+                 exposed at the iteration checkpoint yet. For now, re-run with \
+                 `--dump kkt:<iter>+L+Lvals --dump-dir DIR` and open the per-iter dump.",
+            );
+        }
+        // Resolve the vector to visualize.
+        let (label, vals) = if BLOCK_NAMES.contains(&target) {
+            match ctx.block(target) {
+                Some(v) => (target.to_string(), v),
+                None => return CmdOut::err(format!("no data for block `{target}`")),
+            }
+        } else if let Some(blk) = target.strip_prefix("d").filter(|b| BLOCK_NAMES.contains(b)) {
+            match ctx.delta_block(blk) {
+                Some(v) => (format!("d{blk}"), v),
+                None => return CmdOut::err(format!("no search direction for `d{blk}`")),
+            }
+        } else {
+            return CmdOut::err(format!("don't know how to visualize `{target}`"));
+        };
+        match write_and_open(&label, ctx.iter(), &vals) {
+            Ok((path, viewer)) => CmdOut::ok(vec![format!(
+                "wrote {} ({} values); opened with `{}`",
+                path,
+                vals.len(),
+                viewer
+            )])
+            .with_data(serde_json::json!({"path": path, "viewer": viewer, "n": vals.len()})),
+            Err(e) => CmdOut::err(e),
+        }
+    }
+
+    // ---- front ends ----------------------------------------------------
+
+    /// Emit the pause banner / state for the current front end.
+    fn emit_pause(&self, ctx: &DebugCtx) {
+        match self.mode {
+            DebugMode::Repl => {
+                eprintln!(
+                    "\n── pounce-dbg ── iter {}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
+                    ctx.iter(),
+                    ctx.mu(),
+                    ctx.objective(),
+                    ctx.inf_pr(),
+                    ctx.inf_du(),
+                );
+            }
+            DebugMode::Json => {
+                let dims: serde_json::Map<String, serde_json::Value> = ctx
+                    .block_dims()
+                    .into_iter()
+                    .map(|(n, d)| (n.to_string(), serde_json::json!(d)))
+                    .collect();
+                let ev = serde_json::json!({
+                    "event": "pause",
+                    "checkpoint": ctx.checkpoint().as_str(),
+                    "iter": ctx.iter(),
+                    "mu": ctx.mu(),
+                    "objective": ctx.objective(),
+                    "inf_pr": ctx.inf_pr(),
+                    "inf_du": ctx.inf_du(),
+                    "nlp_error": ctx.nlp_error(),
+                    "dims": dims,
+                    "breakpoints": self.breaks,
+                });
+                emit_json(&ev);
+            }
+        }
+    }
+
+    /// Emit a command result for the current front end.
+    fn emit_result(&self, command: &str, out: &CmdOut) {
+        match self.mode {
+            DebugMode::Repl => {
+                let stderr = std::io::stderr();
+                let mut h = stderr.lock();
+                for l in &out.lines {
+                    let _ = writeln!(h, "{l}");
+                }
+                if !out.ok {
+                    let _ = writeln!(h, "(error)");
+                }
+            }
+            DebugMode::Json => {
+                let ev = serde_json::json!({
+                    "event": "result",
+                    "command": command,
+                    "ok": out.ok,
+                    "output": out.lines,
+                    "data": out.data,
+                });
+                emit_json(&ev);
+            }
+        }
+    }
+
+    fn prompt(&self) {
+        if let DebugMode::Repl = self.mode {
+            let _ = write!(std::io::stderr(), "pounce-dbg> ");
+            let _ = std::io::stderr().flush();
+        }
+    }
+}
+
+impl DebugHook for SolverDebugger {
+    fn at_checkpoint(&mut self, ctx: &mut DebugCtx) -> DebugAction {
+        let iter = ctx.iter();
+        if !self.should_pause(iter) {
+            return DebugAction::Resume;
+        }
+        // Consume the one-shot step arming; commands re-arm as needed.
+        self.step = false;
+        self.emit_pause(ctx);
+
+        let stdin = std::io::stdin();
+        loop {
+            self.prompt();
+            let mut line = String::new();
+            match stdin.read_line(&mut line) {
+                Ok(0) => {
+                    // EOF: detach and let the solve finish.
+                    self.detached = true;
+                    return DebugAction::Resume;
+                }
+                Ok(_) => {}
+                Err(_) => return DebugAction::Resume,
+            }
+            let cmd = parse_command(&line, self.mode);
+            let cmd = cmd.trim().to_string();
+            if cmd.is_empty() {
+                continue;
+            }
+            let out = self.dispatch(&cmd, ctx);
+            self.emit_result(&cmd, &out);
+            match out.flow {
+                Flow::Stay => continue,
+                Flow::Resume => return DebugAction::Resume,
+                Flow::Stop => return DebugAction::Stop,
+            }
+        }
+    }
+}
+
+/// In JSON mode a command line may be a bare string or a JSON object
+/// `{"cmd": "...", "args": [...]}`. Returns the resolved command string.
+fn parse_command(line: &str, mode: DebugMode) -> String {
+    let trimmed = line.trim();
+    if let DebugMode::Json = mode {
+        if trimmed.starts_with('{') {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(trimmed) {
+                let cmd = v.get("cmd").and_then(|c| c.as_str()).unwrap_or("");
+                let mut s = cmd.to_string();
+                if let Some(args) = v.get("args").and_then(|a| a.as_array()) {
+                    for a in args {
+                        if let Some(a) = a.as_str() {
+                            s.push(' ');
+                            s.push_str(a);
+                        } else {
+                            s.push(' ');
+                            s.push_str(&a.to_string());
+                        }
+                    }
+                }
+                return s;
+            }
+        }
+    }
+    trimmed.to_string()
+}
+
+fn emit_json(v: &serde_json::Value) {
+    let stdout = std::io::stdout();
+    let mut h = stdout.lock();
+    let _ = writeln!(h, "{v}");
+    let _ = h.flush();
+}
+
+fn fmt_vec(name: &str, v: &[f64]) -> String {
+    const MAX: usize = 12;
+    if v.len() <= MAX {
+        format!(
+            "{name} = [{}]",
+            v.iter()
+                .map(|x| format!("{x:.6e}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    } else {
+        let head = v[..MAX]
+            .iter()
+            .map(|x| format!("{x:.6e}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("{name} = [{head}, … ({} total)]", v.len())
+    }
+}
+
+fn type_str(t: OptionType) -> &'static str {
+    match t {
+        OptionType::OT_Number => "Number",
+        OptionType::OT_Integer => "Integer",
+        OptionType::OT_String => "String",
+        OptionType::OT_Unknown => "Unknown",
+    }
+}
+
+fn default_str(d: &DefaultValue) -> String {
+    match d {
+        DefaultValue::None => "-".into(),
+        DefaultValue::Number(v) => format!("{v}"),
+        DefaultValue::Integer(v) => format!("{v}"),
+        DefaultValue::String(s) => s.clone(),
+    }
+}
+
+/// Write `vals` to a temp JSON file and open it in an external viewer.
+/// The viewer command comes from `POUNCE_DBG_VIEWER` (a template where
+/// `{}` is replaced by the path; if absent, the path is appended), else
+/// the platform default (`xdg-open` on Linux, `open` on macOS).
+fn write_and_open(label: &str, iter: i32, vals: &[f64]) -> Result<(String, String), String> {
+    let dir = std::env::temp_dir();
+    let path = dir.join(format!("pounce-dbg-{label}-iter{iter}.json"));
+    let payload = serde_json::json!({"label": label, "iter": iter, "values": vals});
+    std::fs::write(&path, payload.to_string()).map_err(|e| format!("write failed: {e}"))?;
+    let path_s = path.to_string_lossy().to_string();
+
+    let (program, args): (String, Vec<String>) = match std::env::var("POUNCE_DBG_VIEWER") {
+        Ok(tmpl) if !tmpl.trim().is_empty() => {
+            let mut parts = tmpl
+                .split_whitespace()
+                .map(|s| s.to_string())
+                .collect::<Vec<_>>();
+            let prog = parts.remove(0);
+            let mut replaced = false;
+            for a in parts.iter_mut() {
+                if a.contains("{}") {
+                    *a = a.replace("{}", &path_s);
+                    replaced = true;
+                }
+            }
+            if !replaced {
+                parts.push(path_s.clone());
+            }
+            (prog, parts)
+        }
+        _ => {
+            let prog = if cfg!(target_os = "macos") {
+                "open"
+            } else {
+                "xdg-open"
+            };
+            (prog.to_string(), vec![path_s.clone()])
+        }
+    };
+    let viewer = format!("{program} {}", args.join(" "));
+    match std::process::Command::new(&program).args(&args).spawn() {
+        Ok(_) => Ok((path_s, viewer)),
+        Err(e) => Err(format!(
+            "wrote {path_s} but could not launch `{program}`: {e} \
+             (set POUNCE_DBG_VIEWER to a command, e.g. `python my_plot.py {{}}`)"
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dbg(mode: DebugMode) -> SolverDebugger {
+        SolverDebugger::new(mode, None)
+    }
+
+    #[test]
+    fn json_command_object_is_flattened() {
+        assert_eq!(
+            parse_command("{\"cmd\":\"print x\"}", DebugMode::Json),
+            "print x"
+        );
+        assert_eq!(
+            parse_command(
+                "{\"cmd\":\"set\",\"args\":[\"x[0]\",\"1.5\"]}",
+                DebugMode::Json
+            ),
+            "set x[0] 1.5"
+        );
+        // Bare strings pass through in either mode.
+        assert_eq!(parse_command("step\n", DebugMode::Json), "step");
+        assert_eq!(parse_command("  print x \n", DebugMode::Repl), "print x");
+    }
+
+    #[test]
+    fn pauses_at_first_checkpoint_then_only_when_rearmed() {
+        let mut d = dbg(DebugMode::Repl);
+        // Fresh debugger is armed (step=true) so it pauses at iter 0.
+        assert!(d.should_pause(0));
+        // After consuming the arming (as at_checkpoint does), no pause.
+        d.step = false;
+        assert!(!d.should_pause(1));
+        assert!(!d.should_pause(2));
+    }
+
+    #[test]
+    fn breakpoints_and_run_to_arm_pauses() {
+        let mut d = dbg(DebugMode::Repl);
+        d.step = false;
+        d.breaks = vec![3, 7];
+        assert!(!d.should_pause(2));
+        assert!(d.should_pause(3));
+        assert!(d.should_pause(7));
+        // run_to fires once at/after target, then disarms.
+        d.run_to = Some(5);
+        assert!(!d.should_pause(4));
+        assert!(d.should_pause(5));
+        assert_eq!(d.run_to, None);
+        assert!(!d.should_pause(6));
+    }
+
+    #[test]
+    fn detach_disables_all_pausing() {
+        let mut d = dbg(DebugMode::Repl);
+        d.detached = true;
+        d.step = true;
+        d.breaks = vec![1];
+        assert!(!d.should_pause(0));
+        assert!(!d.should_pause(1));
+    }
+}

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -66,6 +66,8 @@ const CHECKPOINTS: &[&str] = &[
     "after_mu",
     "after_search_dir",
     "after_step",
+    "pre_restoration_entry",
+    "post_restoration_exit",
     "terminated",
 ];
 
@@ -780,6 +782,8 @@ impl SolverDebugger {
                 "mu" | "after_mu" => Some("after_mu"),
                 "kkt" | "search_dir" | "after_search_dir" => Some("after_search_dir"),
                 "step" | "after_step" => Some("after_step"),
+                "resto" | "restoration" | "pre_restoration_entry" => Some("pre_restoration_entry"),
+                "resto_exit" | "post_restoration_exit" => Some("post_restoration_exit"),
                 "iter" | "iter_start" => Some("iter_start"),
                 "terminated" => Some("terminated"),
                 _ => None,

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -57,7 +57,7 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "stepi", "continue", "run", "break", "stop-at", "set", "opt",
-    "complete", "viz", "save", "goto", "restart", "resolve", "detach", "quit",
+    "complete", "viz", "save", "goto", "restart", "resolve", "progress", "detach", "quit",
 ];
 
 /// Checkpoint names a user can `stop-at` (matches `Checkpoint::as_str`).
@@ -402,6 +402,9 @@ pub struct SolverDebugger {
     terminal_only_on_error: bool,
     /// Honor a pending SIGINT (Ctrl-C) by pausing at the next iteration.
     interruptible: bool,
+    /// Emit a per-iteration `progress` event (JSON mode) when running
+    /// between pauses, so a visual debugger can show live progress.
+    emit_progress: bool,
     /// One-shot: pause at the very next checkpoint of *any* kind (set by
     /// `stepi`, for walking through sub-iteration phases).
     sub_step: bool,
@@ -444,6 +447,7 @@ impl SolverDebugger {
             pause_terminal: true,
             terminal_only_on_error: false,
             interruptible: true,
+            emit_progress: true,
             sub_step: false,
             stop_at: HashSet::new(),
             snapshots: BTreeMap::new(),
@@ -530,6 +534,15 @@ impl SolverDebugger {
             "help" | "h" | "?" => self.cmd_help(),
             "info" | "i" => self.cmd_info(ctx),
             "print" | "p" => self.cmd_print(rest, ctx),
+            // `step` → next iter_start; `step sub` (or `stepi`/`si`) →
+            // next checkpoint of any kind (issue #72's step ["sub"]).
+            "step" | "s" | "n" | "next" if rest.first() == Some(&"sub") => {
+                self.sub_step = true;
+                CmdOut::ok(vec![
+                    "stepping to the next checkpoint (sub-iteration)".into()
+                ])
+                .flow(Flow::Resume)
+            }
             "step" | "s" | "n" | "next" => {
                 self.step = true;
                 CmdOut::ok(vec!["stepping one iteration".into()]).flow(Flow::Resume)
@@ -550,6 +563,17 @@ impl SolverDebugger {
             "run" | "r" => self.cmd_run(rest),
             "break" | "b" => self.cmd_break(rest),
             "stop-at" | "stopat" => self.cmd_stop_at(rest),
+            "progress" => match rest.first().copied() {
+                Some("on") | None => {
+                    self.emit_progress = true;
+                    CmdOut::ok(vec!["progress events on".into()])
+                }
+                Some("off") => {
+                    self.emit_progress = false;
+                    CmdOut::ok(vec!["progress events off".into()])
+                }
+                _ => CmdOut::err("usage: progress [on|off]"),
+            },
             "set" => self.cmd_set(rest, ctx),
             "opt" | "options" => self.cmd_opt(rest),
             "complete" => self.cmd_complete(rest),
@@ -579,7 +603,8 @@ impl SolverDebugger {
             "  print | p <what>         x|s|y_c|y_d|z_l|z_u|v_l|v_u | dx (step) |".into(),
             "                           mu|obj|inf_pr|inf_du|err|iter".into(),
             "  step | s | n             run one iteration, pause again".into(),
-            "  stepi | si               run to the next checkpoint (into sub-iteration phases)".into(),
+            "  stepi | si | step sub    run to the next checkpoint (into sub-iteration phases)".into(),
+            "  progress [on|off]        toggle per-iteration progress events (JSON mode)".into(),
             "  stop-at <cp>             always pause at a checkpoint: after_mu|after_search_dir|after_step".into(),
             "  continue | c             run to the next breakpoint".into(),
             "  run | r <N>              run until iteration N".into(),
@@ -1138,6 +1163,20 @@ impl SolverDebugger {
         }
     }
 
+    /// Emit a per-iteration `progress` event (JSON mode only). Same
+    /// scalars as `pause`; fired while running between pauses.
+    fn emit_progress_event(&self, ctx: &DebugCtx) {
+        let ev = serde_json::json!({
+            "event": "progress",
+            "iter": ctx.iter(),
+            "mu": ctx.mu(),
+            "inf_pr": ctx.inf_pr(),
+            "inf_du": ctx.inf_du(),
+            "obj": ctx.objective(),
+        });
+        emit_json(&ev);
+    }
+
     /// Emit a command result for the current front end. `req_id` is the
     /// client's request id (JSON mode), echoed for response correlation.
     fn emit_result(&self, command: &str, out: &CmdOut, req_id: Option<&serde_json::Value>) {
@@ -1179,7 +1218,8 @@ impl SolverDebugger {
                 "inspect": true,
                 "mutate_iterate": true,
                 "mutate_mu": true,
-                "conditional_breakpoints": true,
+                // "single" today; becomes "compound" once &&/|| land (#72 §4).
+                "conditional_breakpoints": "single",
                 "request_ids": true,
                 "viz": ["block", "delta"],
                 "save": true,
@@ -1187,6 +1227,9 @@ impl SolverDebugger {
                 "resolve": self.restart.is_some(),
                 "terminal_checkpoint": true,
                 "interruptible": self.interruptible,
+                // #72 §1 / §5.
+                "progress_events": self.emit_progress,
+                "async_pause": if self.interruptible { "checkpoint" } else { "none" },
             },
             "checkpoints": CHECKPOINTS,
             "commands": COMMANDS,
@@ -1325,6 +1368,12 @@ impl DebugHook for SolverDebugger {
         }
 
         if !pause {
+            // Not pausing: in JSON mode emit a per-iteration `progress`
+            // event (once per outer iter) so a visual debugger isn't blind
+            // during a long `continue`. Issue #72 §1.
+            if is_iter_start && self.emit_progress && matches!(self.mode, DebugMode::Json) {
+                self.emit_progress_event(ctx);
+            }
             return DebugAction::Resume;
         }
         // Consume one-shot arming; commands re-arm as needed.

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -49,7 +49,7 @@ use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
 use rustyline::{Context, Editor, Helper, Highlighter, Hinter, Validator};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -515,6 +515,9 @@ pub struct SolverDebugger {
     editor: Option<Editor<DbgHelper, FileHistory>>,
     /// Where REPL history is persisted, if a home directory was found.
     hist_path: Option<PathBuf>,
+    /// Background stdin reader (JSON mode) enabling async `{"cmd":"pause"}`
+    /// during a run. `None` in REPL mode.
+    pump: Option<StdinPump>,
     /// Option edits accepted at the prompt. Validated against the
     /// registry; surfaced to the caller after the solve. Not applied to
     /// already-built strategies mid-solve (see `staged_options`).
@@ -548,6 +551,7 @@ impl SolverDebugger {
             restart: None,
             editor: None,
             hist_path: None,
+            pump: None,
             staged: Vec::new(),
         }
     }
@@ -718,6 +722,9 @@ impl SolverDebugger {
                 self.run_to = None;
                 CmdOut::ok(vec!["detached — solving to completion".into()]).flow(Flow::Resume)
             }
+            // A `pause` received while already paused is a no-op; the
+            // meaningful use is async, consumed mid-run by `try_take_pause`.
+            "pause" => CmdOut::ok(vec!["already paused".into()]),
             "quit" | "q" | "exit" => CmdOut::ok(vec!["stopping solve".into()]).flow(Flow::Stop),
             other => CmdOut::err(format!("unknown command `{other}` (try `help`)")),
         }
@@ -1475,7 +1482,10 @@ impl SolverDebugger {
                 "interruptible": self.interruptible,
                 // #72 §1 / §5.
                 "progress_events": self.emit_progress,
-                "async_pause": if self.interruptible { "checkpoint" } else { "none" },
+                "async_pause": "checkpoint",
+                // Both transports for async pause: SIGINT and the in-band
+                // `{"cmd":"pause"}` (JSON mode).
+                "pause_command": true,
             },
             "checkpoints": CHECKPOINTS,
             "events": EVENTS,
@@ -1536,8 +1546,11 @@ impl SolverDebugger {
             }
             let _ = write!(std::io::stderr(), "pounce-dbg> ");
             let _ = std::io::stderr().flush();
+            return read_stdin_line();
         }
-        read_stdin_line()
+        // JSON mode reads through the background pump (so async pause can
+        // peek the same stream); lazily start it.
+        self.pump.get_or_insert_with(StdinPump::start).next()
     }
 }
 
@@ -1548,6 +1561,82 @@ fn read_stdin_line() -> Option<String> {
         Ok(0) => None,
         Ok(_) => Some(line),
         Err(_) => None,
+    }
+}
+
+/// Whether a command line is an in-band pause request (`pause`, or a JSON
+/// `{"cmd":"pause"}`), used for the async-pause-while-running path.
+fn is_pause_command(line: &str) -> bool {
+    parse_command(line, DebugMode::Json).command.trim() == "pause"
+}
+
+/// Background stdin reader for JSON mode. A thread reads newline-delimited
+/// commands into a shared queue so the running loop can *peek* for an
+/// async `{"cmd":"pause"}` between iterations (no signals — the
+/// Windows-friendly path) while the prompt still pops commands blocking.
+struct StdinPump {
+    inner: std::sync::Arc<(
+        std::sync::Mutex<VecDeque<Option<String>>>,
+        std::sync::Condvar,
+    )>,
+}
+
+impl StdinPump {
+    fn start() -> Self {
+        let inner = std::sync::Arc::new((
+            std::sync::Mutex::new(VecDeque::new()),
+            std::sync::Condvar::new(),
+        ));
+        let w = std::sync::Arc::clone(&inner);
+        std::thread::spawn(move || {
+            use std::io::BufRead;
+            let stdin = std::io::stdin();
+            let mut lock = stdin.lock();
+            let (m, cv) = &*w;
+            loop {
+                let mut line = String::new();
+                let item = match lock.read_line(&mut line) {
+                    Ok(0) | Err(_) => None, // EOF / error sentinel
+                    Ok(_) => Some(line),
+                };
+                let done = item.is_none();
+                m.lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push_back(item);
+                cv.notify_one();
+                if done {
+                    break;
+                }
+            }
+        });
+        Self { inner }
+    }
+
+    /// Blocking pop of the next command line; `None` on EOF (sticky).
+    fn next(&self) -> Option<String> {
+        let (m, cv) = &*self.inner;
+        let mut q = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        loop {
+            match q.front() {
+                None => q = cv.wait(q).unwrap_or_else(std::sync::PoisonError::into_inner),
+                Some(None) => return None, // EOF — leave sentinel in place
+                Some(Some(_)) => return q.pop_front().flatten(),
+            }
+        }
+    }
+
+    /// Non-blocking: if a queued `pause` request is at the front, consume
+    /// it and return true. Leaves any other queued command in place.
+    fn try_take_pause(&self) -> bool {
+        let (m, _) = &*self.inner;
+        let mut q = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(Some(front)) = q.front() {
+            if is_pause_command(front) {
+                q.pop_front();
+                return true;
+            }
+        }
+        false
     }
 }
 
@@ -1610,6 +1699,14 @@ impl DebugHook for SolverDebugger {
             if self.interruptible && interrupt::take() {
                 pause = true;
                 reason = Some("interrupt (Ctrl-C)".into());
+            }
+            // In-band async pause: a `{"cmd":"pause"}` that arrived on
+            // stdin during the run (JSON mode, #72 §5 option b).
+            if let Some(p) = self.pump.as_ref() {
+                if p.try_take_pause() {
+                    pause = true;
+                    reason = Some("pause (requested)".into());
+                }
             }
             if self.pause_iters {
                 if self.should_pause(ctx.iter()) {

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -81,6 +81,115 @@ impl CmdOut {
     }
 }
 
+/// Metric names accepted in `break if …` (and shown by `help`).
+const METRICS: &[&str] = &["mu", "inf_pr", "inf_du", "obj", "err", "iter"];
+
+/// A scalar the solver exposes for conditional breakpoints.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Metric {
+    Mu,
+    InfPr,
+    InfDu,
+    Obj,
+    NlpError,
+    Iter,
+}
+
+impl Metric {
+    fn parse(s: &str) -> Option<Metric> {
+        Some(match s {
+            "mu" => Metric::Mu,
+            "inf_pr" => Metric::InfPr,
+            "inf_du" => Metric::InfDu,
+            "obj" | "objective" => Metric::Obj,
+            "err" | "nlp_error" => Metric::NlpError,
+            "iter" => Metric::Iter,
+            _ => return None,
+        })
+    }
+    fn eval(self, ctx: &DebugCtx) -> f64 {
+        match self {
+            Metric::Mu => ctx.mu(),
+            Metric::InfPr => ctx.inf_pr(),
+            Metric::InfDu => ctx.inf_du(),
+            Metric::Obj => ctx.objective(),
+            Metric::NlpError => ctx.nlp_error(),
+            Metric::Iter => ctx.iter() as f64,
+        }
+    }
+}
+
+/// Comparison operator for a conditional breakpoint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CmpOp {
+    Lt,
+    Le,
+    Gt,
+    Ge,
+    Eq,
+}
+
+impl CmpOp {
+    fn eval(self, lhs: f64, rhs: f64) -> bool {
+        match self {
+            CmpOp::Lt => lhs < rhs,
+            CmpOp::Le => lhs <= rhs,
+            CmpOp::Gt => lhs > rhs,
+            CmpOp::Ge => lhs >= rhs,
+            // Tolerant equality so float metrics aren't impossible to hit.
+            CmpOp::Eq => (lhs - rhs).abs() <= 1e-12 * rhs.abs().max(1.0),
+        }
+    }
+}
+
+/// A conditional breakpoint: pause when `metric op rhs` holds.
+#[derive(Clone, Debug)]
+struct Condition {
+    metric: Metric,
+    op: CmpOp,
+    rhs: f64,
+    /// Normalized source text, e.g. `inf_pr<1e-6`, for display / dedup.
+    raw: String,
+}
+
+impl Condition {
+    /// Parse a single `metric<op>value` expression (whitespace already
+    /// stripped by the caller). Operators: `<`, `<=`, `>`, `>=`, `==`.
+    fn parse(expr: &str) -> Result<Condition, String> {
+        let expr = expr.trim();
+        // Longest operators first so `<=` isn't truncated to `<`.
+        let (op, pos, oplen) = ["<=", ">=", "==", "<", ">"]
+            .iter()
+            .find_map(|o| expr.find(o).map(|p| (*o, p, o.len())))
+            .ok_or_else(|| format!("no comparison operator in `{expr}` (use < <= > >= ==)"))?;
+        let metric_s = expr[..pos].trim();
+        let rhs_s = expr[pos + oplen..].trim();
+        let metric = Metric::parse(metric_s)
+            .ok_or_else(|| format!("unknown metric `{metric_s}` (one of {METRICS:?})"))?;
+        let rhs = rhs_s
+            .parse::<f64>()
+            .map_err(|_| format!("bad threshold `{rhs_s}`"))?;
+        let cmp = match op {
+            "<" => CmpOp::Lt,
+            "<=" => CmpOp::Le,
+            ">" => CmpOp::Gt,
+            ">=" => CmpOp::Ge,
+            "==" => CmpOp::Eq,
+            _ => unreachable!(),
+        };
+        Ok(Condition {
+            metric,
+            op: cmp,
+            rhs,
+            raw: format!("{metric_s}{op}{rhs_s}"),
+        })
+    }
+
+    fn holds(&self, ctx: &DebugCtx) -> bool {
+        self.op.eval(self.metric.eval(ctx), self.rhs)
+    }
+}
+
 pub struct SolverDebugger {
     mode: DebugMode,
     reg: Option<Rc<RegisteredOptions>>,
@@ -90,6 +199,8 @@ pub struct SolverDebugger {
     run_to: Option<i32>,
     /// Iterations to break at.
     breaks: Vec<i32>,
+    /// Conditional breakpoints (`break if mu<1e-4`): pause when any holds.
+    conds: Vec<Condition>,
     /// Once true, never pause again (`detach`).
     detached: bool,
     /// Option edits accepted at the prompt. Validated against the
@@ -108,6 +219,7 @@ impl SolverDebugger {
             step: true,
             run_to: None,
             breaks: Vec::new(),
+            conds: Vec::new(),
             detached: false,
             staged: Vec::new(),
         }
@@ -133,6 +245,18 @@ impl SolverDebugger {
             }
         }
         self.breaks.contains(&iter)
+    }
+
+    /// First conditional breakpoint that holds at the current state, if
+    /// any. Returns its source text (for the pause banner / event).
+    fn matched_condition(&self, ctx: &DebugCtx) -> Option<String> {
+        if self.detached {
+            return None;
+        }
+        self.conds
+            .iter()
+            .find(|c| c.holds(ctx))
+            .map(|c| c.raw.clone())
     }
 
     // ---- command engine -----------------------------------------------
@@ -183,6 +307,8 @@ impl SolverDebugger {
             "  continue | c             run to the next breakpoint".into(),
             "  run | r <N>              run until iteration N".into(),
             "  break | b [N|clear|del N] set/list/clear breakpoints".into(),
+            "  break if <m><op><v>      conditional bp; m in mu|inf_pr|inf_du|obj|err|iter,".into(),
+            "                           op in < <= > >= ==  (e.g. break if inf_pr<1e-6)".into(),
             "  set mu <v>               overwrite the barrier parameter".into(),
             "  set <blk>[<i>] <v>       overwrite one component (e.g. set x[2] 1.5)".into(),
             "  set <blk> <v0,v1,...>    overwrite a whole block".into(),
@@ -277,15 +403,47 @@ impl SolverDebugger {
     }
 
     fn cmd_break(&mut self, rest: &[&str]) -> CmdOut {
+        // Conditional breakpoint: `break if <metric><op><value>`. Tokens
+        // after `if` are concatenated so `inf_pr < 1e-6` and `inf_pr<1e-6`
+        // parse the same.
+        if rest.first().copied() == Some("if") {
+            let expr: String = rest[1..].concat();
+            if expr.is_empty() {
+                return CmdOut::err(
+                    "usage: break if <metric><op><value>  (e.g. break if inf_pr<1e-6)",
+                );
+            }
+            return match Condition::parse(&expr) {
+                Ok(c) => {
+                    let raw = c.raw.clone();
+                    if !self.conds.iter().any(|e| e.raw == raw) {
+                        self.conds.push(c);
+                    }
+                    CmdOut::ok(vec![format!("conditional breakpoint: {raw}")])
+                        .with_data(serde_json::json!({"condition": raw}))
+                }
+                Err(e) => CmdOut::err(e),
+            };
+        }
         match rest {
             [] => {
                 let mut bs = self.breaks.clone();
                 bs.sort_unstable();
-                CmdOut::ok(vec![format!("breakpoints: {bs:?}")])
-                    .with_data(serde_json::json!({"breakpoints": bs}))
+                let conds: Vec<String> = self.conds.iter().map(|c| c.raw.clone()).collect();
+                let mut lines = vec![format!("breakpoints: {bs:?}")];
+                if !conds.is_empty() {
+                    lines.push(format!("conditions: {}", conds.join(", ")));
+                }
+                CmdOut::ok(lines)
+                    .with_data(serde_json::json!({"breakpoints": bs, "conditions": conds}))
+            }
+            ["clear", "cond"] | ["clear", "conditions"] => {
+                self.conds.clear();
+                CmdOut::ok(vec!["cleared conditional breakpoints".into()])
             }
             ["clear"] => {
                 self.breaks.clear();
+                self.conds.clear();
                 CmdOut::ok(vec!["cleared all breakpoints".into()])
             }
             ["del", n] | ["delete", n] => match n.parse::<i32>() {
@@ -304,7 +462,7 @@ impl SolverDebugger {
                 }
                 Err(_) => CmdOut::err("usage: break <iteration>"),
             },
-            _ => CmdOut::err("usage: break [N | clear | del N]"),
+            _ => CmdOut::err("usage: break [N | if <m><op><v> | clear | clear cond | del N]"),
         }
     }
 
@@ -505,7 +663,7 @@ impl SolverDebugger {
     // ---- front ends ----------------------------------------------------
 
     /// Emit the pause banner / state for the current front end.
-    fn emit_pause(&self, ctx: &DebugCtx) {
+    fn emit_pause(&self, ctx: &DebugCtx, reason: Option<&str>) {
         match self.mode {
             DebugMode::Repl => {
                 eprintln!(
@@ -516,6 +674,9 @@ impl SolverDebugger {
                     ctx.inf_pr(),
                     ctx.inf_du(),
                 );
+                if let Some(r) = reason {
+                    eprintln!("   ↳ hit condition: {r}");
+                }
             }
             DebugMode::Json => {
                 let dims: serde_json::Map<String, serde_json::Value> = ctx
@@ -523,6 +684,7 @@ impl SolverDebugger {
                     .into_iter()
                     .map(|(n, d)| (n.to_string(), serde_json::json!(d)))
                     .collect();
+                let conds: Vec<String> = self.conds.iter().map(|c| c.raw.clone()).collect();
                 let ev = serde_json::json!({
                     "event": "pause",
                     "checkpoint": ctx.checkpoint().as_str(),
@@ -534,6 +696,8 @@ impl SolverDebugger {
                     "nlp_error": ctx.nlp_error(),
                     "dims": dims,
                     "breakpoints": self.breaks,
+                    "conditions": conds,
+                    "reason": reason,
                 });
                 emit_json(&ev);
             }
@@ -577,12 +741,17 @@ impl SolverDebugger {
 impl DebugHook for SolverDebugger {
     fn at_checkpoint(&mut self, ctx: &mut DebugCtx) -> DebugAction {
         let iter = ctx.iter();
-        if !self.should_pause(iter) {
+        // `should_pause` covers step / run / numeric breakpoints (and
+        // disarms `run_to`); conditional breakpoints are evaluated
+        // against the live state separately.
+        let num_hit = self.should_pause(iter);
+        let cond_hit = self.matched_condition(ctx);
+        if !num_hit && cond_hit.is_none() {
             return DebugAction::Resume;
         }
         // Consume the one-shot step arming; commands re-arm as needed.
         self.step = false;
-        self.emit_pause(ctx);
+        self.emit_pause(ctx, cond_hit.as_deref());
 
         let stdin = std::io::stdin();
         loop {
@@ -785,6 +954,43 @@ mod tests {
         assert!(d.should_pause(5));
         assert_eq!(d.run_to, None);
         assert!(!d.should_pause(6));
+    }
+
+    #[test]
+    fn condition_parses_metric_op_threshold() {
+        let c = Condition::parse("mu<1e-4").unwrap();
+        assert_eq!(c.metric, Metric::Mu);
+        assert_eq!(c.op, CmpOp::Lt);
+        assert_eq!(c.rhs, 1e-4);
+
+        // `<=` must not be truncated to `<`, and spaces are tolerated by
+        // the caller (tokens are concatenated before parse).
+        let c = Condition::parse("inf_pr<=1e-6").unwrap();
+        assert_eq!(c.metric, Metric::InfPr);
+        assert_eq!(c.op, CmpOp::Le);
+
+        let c = Condition::parse("iter==10").unwrap();
+        assert_eq!(c.metric, Metric::Iter);
+        assert_eq!(c.op, CmpOp::Eq);
+        assert_eq!(c.rhs, 10.0);
+    }
+
+    #[test]
+    fn condition_parse_rejects_garbage() {
+        assert!(Condition::parse("inf_pr 1e-6").is_err()); // no operator
+        assert!(Condition::parse("bogus<1").is_err()); // unknown metric
+        assert!(Condition::parse("mu<abc").is_err()); // bad threshold
+    }
+
+    #[test]
+    fn cmp_op_truth_table() {
+        assert!(CmpOp::Lt.eval(1.0, 2.0));
+        assert!(!CmpOp::Lt.eval(2.0, 2.0));
+        assert!(CmpOp::Le.eval(2.0, 2.0));
+        assert!(CmpOp::Gt.eval(3.0, 2.0));
+        assert!(CmpOp::Ge.eval(2.0, 2.0));
+        assert!(CmpOp::Eq.eval(2.0, 2.0));
+        assert!(!CmpOp::Eq.eval(2.0, 2.5));
     }
 
     #[test]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -2002,6 +2002,59 @@ fn read_stdin_line() -> Option<String> {
     }
 }
 
+/// Block-letter `POUNCE` for the open banner (forged-steel body; the
+/// claw slashes and molten underline are added with colour).
+const POUNCE_ART: [&str; 5] = [
+    "██████   ██████  ██    ██ ███    ██  ██████ ███████",
+    "██   ██ ██    ██ ██    ██ ████   ██ ██      ██",
+    "██████  ██    ██ ██    ██ ██ ██  ██ ██      █████",
+    "██      ██    ██ ██    ██ ██  ██ ██ ██      ██",
+    "██       ██████   ██████  ██   ████  ██████ ███████",
+];
+
+/// Print the branded open banner (human REPL only). Steel-grey `POUNCE`
+/// with lava-orange claw slashes and a molten underline, in the logo's
+/// palette. Colours only on a TTY and unless `NO_COLOR` is set.
+pub fn print_open_banner(mode: DebugMode) {
+    if !matches!(mode, DebugMode::Repl) {
+        return;
+    }
+    let color = std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none();
+    let paint = |r: u8, g: u8, b: u8, bold: bool, s: &str| -> String {
+        if color {
+            let w = if bold { "1;" } else { "" };
+            format!("\x1b[{w}38;2;{r};{g};{b}m{s}\x1b[0m")
+        } else {
+            s.to_string()
+        }
+    };
+    let steel = |s: &str| paint(0xC2, 0xCA, 0xD2, true, s);
+    let lava = |s: &str| paint(0xFF, 0x6A, 0x1A, true, s);
+    let ember = |s: &str| paint(0xFF, 0x45, 0x00, false, s);
+    let gold = |s: &str| paint(0xFF, 0xB0, 0x00, true, s);
+    let dim = |s: &str| paint(0x7A, 0x7E, 0x88, false, s);
+
+    let err = std::io::stderr();
+    let mut h = err.lock();
+    let _ = writeln!(h);
+    for (i, row) in POUNCE_ART.iter().enumerate() {
+        // Three claw slashes descend left-to-right for a swipe effect.
+        let claw = format!("{}╱╱╱", " ".repeat(i));
+        let _ = writeln!(h, "  {}{}", steel(&format!("{row:<52}")), lava(&claw));
+    }
+    let _ = writeln!(h, "  {}", ember(&"━".repeat(58)));
+    let _ = writeln!(
+        h,
+        "  {}   {}",
+        gold("interior-point debugger"),
+        dim(&format!(
+            "· pounce {} · pdb for the IPM · type `help`",
+            env!("CARGO_PKG_VERSION")
+        ))
+    );
+    let _ = writeln!(h);
+}
+
 /// Whether a command line is an in-band pause request (`pause`, or a JSON
 /// `{"cmd":"pause"}`), used for the async-pause-while-running path.
 fn is_pause_command(line: &str) -> bool {

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -2038,7 +2038,10 @@ pub fn print_open_banner(mode: DebugMode) {
         h,
         "  {}  {}",
         gold("interior-point debugger"),
-        dim(&format!("· pounce {} · pdb for the IPM", env!("CARGO_PKG_VERSION")))
+        dim(&format!(
+            "· pounce {} · pdb for the IPM",
+            env!("CARGO_PKG_VERSION")
+        ))
     );
     let _ = writeln!(h);
     // Most-common commands with their letter shortcuts.
@@ -2561,7 +2564,10 @@ fn write_json_and_open(
     let mut candidates: Vec<(String, Vec<String>)> = Vec::new();
     match std::env::var("POUNCE_DBG_VIEWER") {
         Ok(tmpl) if !tmpl.trim().is_empty() => {
-            let mut parts = tmpl.split_whitespace().map(String::from).collect::<Vec<_>>();
+            let mut parts = tmpl
+                .split_whitespace()
+                .map(String::from)
+                .collect::<Vec<_>>();
             let prog = parts.remove(0);
             let mut replaced = false;
             for a in parts.iter_mut() {

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -57,7 +57,7 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "stepi", "continue", "run", "break", "stop-at", "set", "opt",
-    "complete", "viz", "save", "goto", "restart", "resolve", "progress", "detach", "quit",
+    "complete", "viz", "save", "goto", "restart", "resolve", "ask", "progress", "detach", "quit",
 ];
 
 /// Events a user can `break on` (advertised in `hello.events`). Each is
@@ -711,6 +711,7 @@ impl SolverDebugger {
                 None => CmdOut::err("no snapshots captured yet"),
             },
             "resolve" | "re-solve" => self.cmd_resolve(ctx),
+            "ask" | "explain" | "claude" => self.cmd_ask(rest, ctx),
             "detach" => {
                 self.detached = true;
                 self.step = false;
@@ -749,6 +750,7 @@ impl SolverDebugger {
             "  save [path]              write the current iterate + residuals to JSON".into(),
             "  goto <k> | restart       rewind to a captured iteration (primal-dual only)".into(),
             "  resolve                  re-solve from the current x with staged `set opt`s".into(),
+            "  ask [question]           ask Claude Code (claude -p / $POUNCE_DBG_LLM) about the state".into(),
             "  detach                   stop pausing; solve to completion".into(),
             "  quit | q                 stop the solve now".into(),
         ];
@@ -1264,6 +1266,29 @@ impl SolverDebugger {
         .flow(Flow::Stop)
     }
 
+    /// `ask [question]` — hand the current solver state to Claude Code
+    /// (headless `claude -p`, or `$POUNCE_DBG_LLM`) and print its reply.
+    /// "Ask why this step looks wrong without leaving the debugger."
+    fn cmd_ask(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
+        let question = if rest.is_empty() {
+            "Explain the current state of this interior-point solve and suggest what to try next."
+                .to_string()
+        } else {
+            rest.join(" ")
+        };
+        let prompt = build_ask_prompt(ctx, &question);
+        match run_llm(&prompt) {
+            Ok(reply) => {
+                let lines: Vec<String> = reply.lines().map(|l| l.to_string()).collect();
+                CmdOut::ok(lines).with_data(serde_json::json!({
+                    "question": question,
+                    "reply": reply,
+                }))
+            }
+            Err(e) => CmdOut::err(e),
+        }
+    }
+
     fn cmd_viz(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
         let Some(&target) = rest.first() else {
             return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
@@ -1443,6 +1468,7 @@ impl SolverDebugger {
                 "viz": ["block", "delta"],
                 "save": true,
                 "kkt_inspect": true,
+                "llm_assist": true,
                 "rewind": "primal_dual",
                 "resolve": self.restart.is_some(),
                 "terminal_checkpoint": true,
@@ -1746,6 +1772,125 @@ fn write_and_open(label: &str, iter: i32, vals: &[f64]) -> Result<(String, Strin
     write_json_and_open(label, iter, &payload)
 }
 
+/// Build the prompt handed to the LLM by `ask`: a compact, self-contained
+/// description of the paused interior-point state plus the user question.
+fn build_ask_prompt(ctx: &DebugCtx, question: &str) -> String {
+    use std::fmt::Write as _;
+    let mut p = String::new();
+    p.push_str(
+        "You are helping debug a paused run of POUNCE, a pure-Rust port of the Ipopt \
+         interior-point NLP solver. The solve is stopped at a debugger checkpoint. \
+         Use the state below to answer concisely and suggest concrete next steps \
+         (options to try, what to inspect). State:\n\n",
+    );
+    let _ = writeln!(p, "checkpoint = {}", ctx.checkpoint().as_str());
+    if let Some(s) = ctx.status() {
+        let _ = writeln!(p, "status     = {s}");
+    }
+    let _ = writeln!(p, "iter       = {}", ctx.iter());
+    let _ = writeln!(p, "mu         = {:.6e}", ctx.mu());
+    let _ = writeln!(p, "objective  = {:.8e}", ctx.objective());
+    let _ = writeln!(p, "inf_pr     = {:.6e}", ctx.inf_pr());
+    let _ = writeln!(p, "inf_du     = {:.6e}", ctx.inf_du());
+    let _ = writeln!(p, "nlp_error  = {:.6e}", ctx.nlp_error());
+    let (ap, ad) = ctx.alpha();
+    let _ = writeln!(p, "alpha_pr   = {ap:.4e}, alpha_du = {ad:.4e}");
+    let _ = writeln!(p, "ls_trials  = {}", ctx.ls_count());
+    let dims: Vec<String> = ctx
+        .block_dims()
+        .into_iter()
+        .map(|(n, d)| format!("{n}:{d}"))
+        .collect();
+    let _ = writeln!(p, "dims       = {}", dims.join(" "));
+    if let Some(k) = ctx.kkt() {
+        let _ = writeln!(
+            p,
+            "kkt        = dim {} inertia n+={} n-={} (expected n-={}, {}) delta_w={:.3e} delta_c={:.3e} status={}",
+            k.dim,
+            k.n_pos,
+            k.n_neg,
+            k.expected_neg,
+            if k.inertia_correct { "correct" } else { "WRONG" },
+            k.delta_w,
+            k.delta_c,
+            k.status
+        );
+    }
+    let _ = write!(p, "\nQuestion: {question}\n");
+    p
+}
+
+/// Resolve the LLM command from `$POUNCE_DBG_LLM` (whitespace-split; `{}`
+/// substitutes the prompt as an argument), defaulting to `claude -p`. The
+/// bool is whether the prompt goes on stdin (true) or was substituted
+/// into an argument (false).
+fn llm_command(prompt: &str) -> (String, Vec<String>, bool) {
+    let tmpl = std::env::var("POUNCE_DBG_LLM").unwrap_or_default();
+    let tmpl = tmpl.trim();
+    if tmpl.is_empty() {
+        return ("claude".to_string(), vec!["-p".to_string()], true);
+    }
+    let mut parts = tmpl
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>();
+    let prog = parts.remove(0);
+    let mut substituted = false;
+    for a in parts.iter_mut() {
+        if a.contains("{}") {
+            *a = a.replace("{}", prompt);
+            substituted = true;
+        }
+    }
+    (prog, parts, !substituted)
+}
+
+/// Run the configured LLM command, feeding `prompt` on stdin (unless it
+/// was substituted into an argument), and return its stdout.
+fn run_llm(prompt: &str) -> Result<String, String> {
+    use std::io::Write as _;
+    use std::process::{Command, Stdio};
+    let (prog, args, on_stdin) = llm_command(prompt);
+    let mut cmd = Command::new(&prog);
+    cmd.args(&args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    cmd.stdin(if on_stdin {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
+    let mut child = cmd.spawn().map_err(|e| {
+        format!(
+            "could not launch `{prog}`: {e} \
+             (set POUNCE_DBG_LLM to an LLM command, e.g. `claude -p` or `llm`)"
+        )
+    })?;
+    if on_stdin {
+        // Write the prompt and close stdin so the child sees EOF.
+        if let Some(mut si) = child.stdin.take() {
+            let _ = si.write_all(prompt.as_bytes());
+        }
+    }
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("`{prog}` failed: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        return Err(format!(
+            "`{prog}` exited with {}: {}",
+            out.status,
+            err.trim()
+        ));
+    }
+    let reply = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if reply.is_empty() {
+        Err(format!("`{prog}` returned no output"))
+    } else {
+        Ok(reply)
+    }
+}
+
 /// Write a JSON artifact to a temp file and open it in an external viewer
 /// (`POUNCE_DBG_VIEWER`, else `xdg-open`/`open`). Shared by `viz`.
 fn write_json_and_open(
@@ -1965,6 +2110,29 @@ mod tests {
         // Clear empties the set.
         assert!(d.cmd_stop_at(&["clear"]).ok);
         assert!(d.stop_at.is_empty());
+    }
+
+    #[test]
+    fn llm_command_defaults_and_overrides() {
+        // Default is `claude -p`, prompt on stdin.
+        std::env::remove_var("POUNCE_DBG_LLM");
+        let (prog, args, on_stdin) = llm_command("hi");
+        assert_eq!(prog, "claude");
+        assert_eq!(args, vec!["-p".to_string()]);
+        assert!(on_stdin);
+
+        // `{}` substitution puts the prompt in an arg (no stdin).
+        std::env::set_var("POUNCE_DBG_LLM", "mytool --ask {}");
+        let (prog, args, on_stdin) = llm_command("why");
+        assert_eq!(prog, "mytool");
+        assert_eq!(args, vec!["--ask".to_string(), "why".to_string()]);
+        assert!(!on_stdin);
+
+        // No `{}` ⇒ prompt on stdin.
+        std::env::set_var("POUNCE_DBG_LLM", "llm -m gpt");
+        let (_, _, on_stdin) = llm_command("q");
+        assert!(on_stdin);
+        std::env::remove_var("POUNCE_DBG_LLM");
     }
 
     #[test]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -455,7 +455,7 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
         ["print"] | ["p"] | ["watch"] | ["display"] => {
             let mut v = starts(&BLOCK_NAMES);
             v.extend(starts(&[
-                "mu", "obj", "inf_pr", "inf_du", "err", "compl", "iter", "kkt",
+                "mu", "obj", "inf_pr", "inf_du", "err", "compl", "iter", "kkt", "active",
             ]));
             v
         }
@@ -863,7 +863,7 @@ impl SolverDebugger {
             "commands:".into(),
             "  info | i                 summary of the current iterate".into(),
             "  print | p <what>         x|s|y_c|y_d|z_l|z_u|v_l|v_u | dx (step) |".into(),
-            "                           mu|obj|inf_pr|inf_du|err|iter | kkt (inertia+reg)".into(),
+            "                           mu|obj|inf_pr|inf_du|err|compl|iter | kkt | active".into(),
             "  step | s | n             run one iteration, pause again".into(),
             "  stepi | si | step sub    run to the next checkpoint (into sub-iteration phases)".into(),
             "  progress [on|off]        toggle per-iteration progress events (JSON mode)".into(),
@@ -936,6 +936,9 @@ impl SolverDebugger {
         if what == "kkt" {
             return self.cmd_print_kkt(ctx);
         }
+        if what == "active" {
+            return self.cmd_print_active(ctx);
+        }
         // step / delta blocks: `dx`, `ds`, ... or `delta_x`.
         let delta = what.strip_prefix("d").filter(|b| BLOCK_NAMES.contains(b));
         if BLOCK_NAMES.contains(&what) {
@@ -968,6 +971,37 @@ impl SolverDebugger {
             CmdOut::ok(vec![format!("{what} = {val:.10e}")])
                 .with_data(serde_json::json!({"name": what, "value": val}))
         }
+    }
+
+    /// `print active` — bound-slack classification: how many of each
+    /// bound category are near-active (slack below `tol`), and the min
+    /// slack. Small slacks mark the bounds the iterate is pressing on.
+    fn cmd_print_active(&self, ctx: &DebugCtx) -> CmdOut {
+        let tol = 1e-6;
+        let mut lines = Vec::new();
+        let mut cats = serde_json::Map::new();
+        for cat in ["x_l", "x_u", "s_l", "s_u"] {
+            let Some(sl) = ctx.bound_slack(cat) else {
+                continue;
+            };
+            if sl.is_empty() {
+                continue;
+            }
+            let n = sl.len();
+            let min = sl.iter().copied().fold(f64::INFINITY, f64::min);
+            let near = sl.iter().filter(|&&s| s.abs() < tol).count();
+            lines.push(format!(
+                "{cat}: {n} bound(s), {near} near-active (slack<{tol:.0e}), min slack {min:.3e}"
+            ));
+            cats.insert(
+                cat.to_string(),
+                serde_json::json!({"n": n, "near_active": near, "min_slack": min}),
+            );
+        }
+        if lines.is_empty() {
+            lines.push("no bounded variables or inequality slacks".into());
+        }
+        CmdOut::ok(lines).with_data(serde_json::json!({"tol": tol, "categories": cats}))
     }
 
     /// `print kkt` — inertia + regularization of the factored augmented

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -2485,12 +2485,15 @@ fn write_json_and_open(
     std::fs::write(&path, payload.to_string()).map_err(|e| format!("write failed: {e}"))?;
     let path_s = path.to_string_lossy().to_string();
 
-    let (program, args): (String, Vec<String>) = match std::env::var("POUNCE_DBG_VIEWER") {
+    // Candidate viewers, tried in order until one launches:
+    //   1. $POUNCE_DBG_VIEWER (a command template; `{}` ← the path),
+    //   2. `pounce-dbg-viz` — the bundled interactive Plotly viewer
+    //      (`pip install 'pounce-solver[viz]'`), when on PATH,
+    //   3. the OS opener (xdg-open / open) on the raw JSON.
+    let mut candidates: Vec<(String, Vec<String>)> = Vec::new();
+    match std::env::var("POUNCE_DBG_VIEWER") {
         Ok(tmpl) if !tmpl.trim().is_empty() => {
-            let mut parts = tmpl
-                .split_whitespace()
-                .map(|s| s.to_string())
-                .collect::<Vec<_>>();
+            let mut parts = tmpl.split_whitespace().map(String::from).collect::<Vec<_>>();
             let prog = parts.remove(0);
             let mut replaced = false;
             for a in parts.iter_mut() {
@@ -2502,25 +2505,31 @@ fn write_json_and_open(
             if !replaced {
                 parts.push(path_s.clone());
             }
-            (prog, parts)
+            candidates.push((prog, parts));
         }
         _ => {
-            let prog = if cfg!(target_os = "macos") {
+            candidates.push(("pounce-dbg-viz".to_string(), vec![path_s.clone()]));
+            let opener = if cfg!(target_os = "macos") {
                 "open"
             } else {
                 "xdg-open"
             };
-            (prog.to_string(), vec![path_s.clone()])
+            candidates.push((opener.to_string(), vec![path_s.clone()]));
         }
-    };
-    let viewer = format!("{program} {}", args.join(" "));
-    match std::process::Command::new(&program).args(&args).spawn() {
-        Ok(_) => Ok((path_s, viewer)),
-        Err(e) => Err(format!(
-            "wrote {path_s} but could not launch `{program}`: {e} \
-             (set POUNCE_DBG_VIEWER to a command, e.g. `python my_plot.py {{}}`)"
-        )),
     }
+
+    let mut last_err = String::new();
+    for (program, args) in &candidates {
+        match std::process::Command::new(program).args(args).spawn() {
+            Ok(_) => return Ok((path_s, format!("{program} {}", args.join(" ")))),
+            Err(e) => last_err = format!("`{program}`: {e}"),
+        }
+    }
+    Err(format!(
+        "wrote {path_s} but could not launch a viewer ({last_err}). \
+         Install the interactive viewer (`pip install 'pounce-solver[viz]'`) \
+         or set POUNCE_DBG_VIEWER, e.g. `python my_plot.py {{}}`."
+    ))
 }
 
 #[cfg(test)]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -57,8 +57,22 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "continue", "run", "break", "set", "opt", "complete", "viz",
-    "save", "goto", "restart", "detach", "quit",
+    "save", "goto", "restart", "resolve", "detach", "quit",
 ];
+
+/// Request to re-run the solve from a captured point with new options.
+/// Written by the `resolve` command into the shared [`RestartCell`] and
+/// read by the CLI after the solve unwinds.
+pub struct RestartRequest {
+    /// Primal seed (the algorithm-space `x` at the time of `resolve`).
+    pub seed_x: Vec<f64>,
+    /// `set opt` edits staged during the session, to apply before re-solve.
+    pub options: Vec<(String, String)>,
+}
+
+/// Shared slot the debugger uses to hand a [`RestartRequest`] back to the
+/// CLI's re-solve loop.
+pub type RestartCell = Rc<std::cell::RefCell<Option<RestartRequest>>>;
 
 /// Cap on retained per-iteration snapshots (bounds rewind memory; oldest
 /// are evicted first).
@@ -381,6 +395,9 @@ pub struct SolverDebugger {
     /// Per-iteration primal-dual snapshots for `goto`/`restart`, keyed by
     /// iteration index. Capped at [`SNAPSHOT_CAP`] (oldest evicted).
     snapshots: BTreeMap<i32, IterateSnapshot>,
+    /// Shared slot for `resolve` to request a fresh solve from the
+    /// current point with staged options. `None` disables `resolve`.
+    restart: Option<RestartCell>,
     /// rustyline editor for the human REPL on a TTY (history + Tab +
     /// Ctrl-R). `None` for JSON mode or when stdin isn't a terminal, in
     /// which case a plain line reader is used.
@@ -413,10 +430,18 @@ impl SolverDebugger {
             terminal_only_on_error: false,
             interruptible: true,
             snapshots: BTreeMap::new(),
+            restart: None,
             editor: None,
             hist_path: None,
             staged: Vec::new(),
         }
+    }
+
+    /// Enable the `resolve` command, wiring the shared restart slot the
+    /// CLI's re-solve loop reads.
+    pub fn with_restart(mut self, cell: RestartCell) -> Self {
+        self.restart = Some(cell);
+        self
     }
 
     /// Post-mortem: run freely, then drop in at the terminal checkpoint
@@ -509,6 +534,7 @@ impl SolverDebugger {
                 Some(k) => self.restore_to(k, ctx),
                 None => CmdOut::err("no snapshots captured yet"),
             },
+            "resolve" | "re-solve" => self.cmd_resolve(ctx),
             "detach" => {
                 self.detached = true;
                 self.step = false;
@@ -541,6 +567,7 @@ impl SolverDebugger {
             "  viz <x|s|dx|...|kkt|L>   open the artifact in an external viewer".into(),
             "  save [path]              write the current iterate + residuals to JSON".into(),
             "  goto <k> | restart       rewind to a captured iteration (primal-dual only)".into(),
+            "  resolve                  re-solve from the current x with staged `set opt`s".into(),
             "  detach                   stop pausing; solve to completion".into(),
             "  quit | q                 stop the solve now".into(),
         ];
@@ -923,6 +950,27 @@ impl SolverDebugger {
         }
     }
 
+    /// `resolve` — capture the current primal `x` and the staged option
+    /// edits, then stop this solve so the CLI re-runs from that point with
+    /// the new options applied (a primal warm start). Needs a restart cell
+    /// (wired by the CLI); a no-op error otherwise.
+    fn cmd_resolve(&mut self, ctx: &DebugCtx) -> CmdOut {
+        let Some(cell) = self.restart.as_ref() else {
+            return CmdOut::err("re-solve is not available in this context");
+        };
+        let Some(seed_x) = ctx.block("x") else {
+            return CmdOut::err("no current iterate to seed from");
+        };
+        let options = self.staged.clone();
+        let n_opt = options.len();
+        *cell.borrow_mut() = Some(RestartRequest { seed_x, options });
+        CmdOut::ok(vec![format!(
+            "re-solving from current x with {n_opt} staged option override(s)…"
+        )])
+        .with_data(serde_json::json!({"resolve": true, "options": n_opt}))
+        .flow(Flow::Stop)
+    }
+
     fn cmd_viz(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
         let Some(&target) = rest.first() else {
             return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
@@ -1066,7 +1114,9 @@ impl SolverDebugger {
                 "viz": ["block", "delta"],
                 "save": true,
                 "rewind": "primal_dual",
+                "resolve": self.restart.is_some(),
                 "terminal_checkpoint": true,
+                "interruptible": self.interruptible,
             },
             "checkpoints": ["iter_start", "terminated"],
             "commands": COMMANDS,

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -2002,19 +2002,9 @@ fn read_stdin_line() -> Option<String> {
     }
 }
 
-/// Block-letter `POUNCE` for the open banner (forged-steel body; the
-/// claw slashes and molten underline are added with colour).
-const POUNCE_ART: [&str; 5] = [
-    "██████   ██████  ██    ██ ███    ██  ██████ ███████",
-    "██   ██ ██    ██ ██    ██ ████   ██ ██      ██",
-    "██████  ██    ██ ██    ██ ██ ██  ██ ██      █████",
-    "██      ██    ██ ██    ██ ██  ██ ██ ██      ██",
-    "██       ██████   ██████  ██   ████  ██████ ███████",
-];
-
-/// Print the branded open banner (human REPL only). Steel-grey `POUNCE`
-/// with lava-orange claw slashes and a molten underline, in the logo's
-/// palette. Colours only on a TTY and unless `NO_COLOR` is set.
+/// Print the branded open banner (human REPL only): the project POUNCE
+/// wordmark (shared with the solve header) over a brief command cheat
+/// sheet. Colour only on a TTY and unless `NO_COLOR` is set.
 pub fn print_open_banner(mode: DebugMode) {
     if !matches!(mode, DebugMode::Repl) {
         return;
@@ -2028,29 +2018,54 @@ pub fn print_open_banner(mode: DebugMode) {
             s.to_string()
         }
     };
-    let steel = |s: &str| paint(0xC2, 0xCA, 0xD2, true, s);
-    let lava = |s: &str| paint(0xFF, 0x6A, 0x1A, true, s);
-    let ember = |s: &str| paint(0xFF, 0x45, 0x00, false, s);
+    // Project palette: tiger-orange accents, gold highlight, dim text.
+    let orange = |s: &str| paint(0xE8, 0x7A, 0x1E, true, s);
     let gold = |s: &str| paint(0xFF, 0xB0, 0x00, true, s);
     let dim = |s: &str| paint(0x7A, 0x7E, 0x88, false, s);
+    // One cheat-sheet item: orange key (with shortcut) + dim gloss.
+    let item = |key: &str, gloss: &str| format!("{} {}", orange(key), dim(gloss));
 
     let err = std::io::stderr();
     let mut h = err.lock();
     let _ = writeln!(h);
-    for (i, row) in POUNCE_ART.iter().enumerate() {
-        // Three claw slashes descend left-to-right for a swipe effect.
-        let claw = format!("{}╱╱╱", " ".repeat(i));
-        let _ = writeln!(h, "  {}{}", steel(&format!("{row:<52}")), lava(&claw));
+    // The official wordmark (steel sheen + molten claws), shared with the
+    // solve header, rendered to stderr with a small indent.
+    for row in crate::print::logo_rows(color) {
+        let _ = writeln!(h, "  {row}");
     }
-    let _ = writeln!(h, "  {}", ember(&"━".repeat(58)));
+    let _ = writeln!(h);
     let _ = writeln!(
         h,
-        "  {}   {}",
+        "  {}  {}",
         gold("interior-point debugger"),
-        dim(&format!(
-            "· pounce {} · pdb for the IPM · type `help`",
-            env!("CARGO_PKG_VERSION")
-        ))
+        dim(&format!("· pounce {} · pdb for the IPM", env!("CARGO_PKG_VERSION")))
+    );
+    let _ = writeln!(h);
+    // Most-common commands with their letter shortcuts.
+    let _ = writeln!(
+        h,
+        "  {}   {}   {}   {}   {}",
+        item("s", "step"),
+        item("c", "continue"),
+        item("b", "N break"),
+        item("r", "N run"),
+        item("q", "quit"),
+    );
+    let _ = writeln!(
+        h,
+        "  {}   {}   {}   {}   {}",
+        item("p", "x print"),
+        item("i", "info"),
+        item("set", "x[i] v"),
+        item("watch", "x"),
+        item("viz", "kkt"),
+    );
+    let _ = writeln!(
+        h,
+        "  {} {} {}",
+        dim("type"),
+        gold("help"),
+        dim("for all commands · `ask` to consult Claude · Ctrl-C breaks in"),
     );
     let _ = writeln!(h);
 }

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -57,7 +57,8 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "stepi", "continue", "run", "break", "stop-at", "set", "opt",
-    "complete", "viz", "save", "goto", "restart", "resolve", "ask", "progress", "detach", "quit",
+    "complete", "viz", "save", "goto", "restart", "resolve", "ask", "watch", "source", "progress",
+    "detach", "quit",
 ];
 
 /// Events a user can `break on` (advertised in `hello.events`). Each is
@@ -155,6 +156,7 @@ pub mod interrupt {
 }
 
 /// What to do after a command runs.
+#[derive(Clone, Copy)]
 enum Flow {
     /// Stay paused; keep reading commands.
     Stay,
@@ -417,7 +419,7 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
         ["break", "if"] | ["b", "if"] => starts(METRICS),
         ["break", "on"] | ["b", "on"] => starts(EVENTS),
         ["break"] | ["b"] => starts(&["if", "on", "clear", "del"]),
-        ["print"] | ["p"] => {
+        ["print"] | ["p"] | ["watch"] | ["display"] => {
             let mut v = starts(&BLOCK_NAMES);
             v.extend(starts(&[
                 "mu", "obj", "inf_pr", "inf_du", "err", "iter", "kkt",
@@ -518,6 +520,12 @@ pub struct SolverDebugger {
     /// Background stdin reader (JSON mode) enabling async `{"cmd":"pause"}`
     /// during a run. `None` in REPL mode.
     pump: Option<StdinPump>,
+    /// Expressions to auto-print at every pause (`watch`). Each is a
+    /// `print` target (block, `dx`, scalar, `kkt`).
+    watches: Vec<String>,
+    /// A debugger script (file path) to run once at the first pause
+    /// (`--debug-script`); consumed on use.
+    pending_script: Option<String>,
     /// Option edits accepted at the prompt. Validated against the
     /// registry; surfaced to the caller after the solve. Not applied to
     /// already-built strategies mid-solve (see `staged_options`).
@@ -552,8 +560,16 @@ impl SolverDebugger {
             editor: None,
             hist_path: None,
             pump: None,
+            watches: Vec::new(),
+            pending_script: None,
             staged: Vec::new(),
         }
+    }
+
+    /// Queue a debugger script to run once at the first pause.
+    pub fn with_script(mut self, path: String) -> Self {
+        self.pending_script = Some(path);
+        self
     }
 
     /// Enable the `resolve` command, wiring the shared restart slot the
@@ -716,6 +732,8 @@ impl SolverDebugger {
             },
             "resolve" | "re-solve" => self.cmd_resolve(ctx),
             "ask" | "explain" | "claude" => self.cmd_ask(rest, ctx),
+            "watch" | "display" => self.cmd_watch(rest),
+            "source" => self.cmd_source(rest, ctx),
             "detach" => {
                 self.detached = true;
                 self.step = false;
@@ -758,6 +776,8 @@ impl SolverDebugger {
             "  goto <k> | restart       rewind to a captured iteration (primal-dual only)".into(),
             "  resolve                  re-solve from the current x with staged `set opt`s".into(),
             "  ask [question]           ask Claude Code (claude -p / $POUNCE_DBG_LLM) about the state".into(),
+            "  watch [target|clear|del] auto-print a `print` target at every pause".into(),
+            "  source <file>            run debugger commands from a file".into(),
             "  detach                   stop pausing; solve to completion".into(),
             "  quit | q                 stop the solve now".into(),
         ];
@@ -1296,6 +1316,65 @@ impl SolverDebugger {
         }
     }
 
+    /// `watch [target|clear|del <target>]` — auto-print a `print` target
+    /// (block, `dx`, scalar, `kkt`) at every pause.
+    fn cmd_watch(&mut self, rest: &[&str]) -> CmdOut {
+        match rest {
+            [] => CmdOut::ok(vec![format!("watches: {:?}", self.watches)])
+                .with_data(serde_json::json!({"watches": self.watches})),
+            ["clear"] => {
+                self.watches.clear();
+                CmdOut::ok(vec!["cleared watches".into()])
+            }
+            ["del", w] | ["delete", w] => {
+                self.watches.retain(|x| x != w);
+                CmdOut::ok(vec![format!("unwatched {w}")])
+            }
+            [w] => {
+                let w = w.to_string();
+                if !self.watches.contains(&w) {
+                    self.watches.push(w.clone());
+                }
+                CmdOut::ok(vec![format!("watching {w}")])
+            }
+            _ => CmdOut::err("usage: watch [<target> | clear | del <target>]"),
+        }
+    }
+
+    /// `source <file>` — run debugger commands from a file (one per line;
+    /// `#` comments and blank lines skipped). Stops early if a command
+    /// resumes or stops the solve, propagating that control flow.
+    fn cmd_source(&mut self, rest: &[&str], ctx: &mut DebugCtx) -> CmdOut {
+        let Some(&path) = rest.first() else {
+            return CmdOut::err("usage: source <file>");
+        };
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => return CmdOut::err(format!("cannot read `{path}`: {e}")),
+        };
+        let mut lines = Vec::new();
+        let mut flow = Flow::Stay;
+        for raw in content.lines() {
+            let cmd = raw.trim();
+            if cmd.is_empty() || cmd.starts_with('#') || cmd.starts_with("//") {
+                continue;
+            }
+            lines.push(format!("[source] {cmd}"));
+            let out = self.dispatch(cmd, ctx);
+            lines.extend(out.lines);
+            if !matches!(out.flow, Flow::Stay) {
+                flow = out.flow;
+                break;
+            }
+        }
+        CmdOut {
+            ok: true,
+            lines,
+            data: None,
+            flow,
+        }
+    }
+
     fn cmd_viz(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
         let Some(&target) = rest.first() else {
             return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
@@ -1387,8 +1466,22 @@ impl SolverDebugger {
                 if let Some(r) = reason {
                     eprintln!("   ↳ {r}");
                 }
+                for w in &self.watches {
+                    let out = self.cmd_print(&[w.as_str()], ctx);
+                    for l in &out.lines {
+                        eprintln!("   watch {l}");
+                    }
+                }
             }
             DebugMode::Json => {
+                let watches: Vec<serde_json::Value> = self
+                    .watches
+                    .iter()
+                    .map(|w| {
+                        let out = self.cmd_print(&[w.as_str()], ctx);
+                        serde_json::json!({"expr": w, "ok": out.ok, "output": out.lines, "data": out.data})
+                    })
+                    .collect();
                 let dims: serde_json::Map<String, serde_json::Value> = ctx
                     .block_dims()
                     .into_iter()
@@ -1409,6 +1502,7 @@ impl SolverDebugger {
                     "breakpoints": self.breaks,
                     "conditions": conds,
                     "reason": reason,
+                    "watches": watches,
                 });
                 emit_json(&ev);
             }
@@ -1618,7 +1712,11 @@ impl StdinPump {
         let mut q = m.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         loop {
             match q.front() {
-                None => q = cv.wait(q).unwrap_or_else(std::sync::PoisonError::into_inner),
+                None => {
+                    q = cv
+                        .wait(q)
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                }
                 Some(None) => return None, // EOF — leave sentinel in place
                 Some(Some(_)) => return q.pop_front().flatten(),
             }
@@ -1740,6 +1838,17 @@ impl DebugHook for SolverDebugger {
 impl SolverDebugger {
     /// Read and dispatch commands until one resumes or stops the solve.
     fn prompt_loop(&mut self, ctx: &mut DebugCtx) -> DebugAction {
+        // Run a `--debug-script` once, at the first pause, before reading
+        // any interactive command. It may itself resume / stop the solve.
+        if let Some(path) = self.pending_script.take() {
+            let out = self.cmd_source(&[path.as_str()], ctx);
+            self.emit_result("source", &out, None);
+            match out.flow {
+                Flow::Resume => return DebugAction::Resume,
+                Flow::Stop => return DebugAction::Stop,
+                Flow::Stay => {}
+            }
+        }
         loop {
             let line = match self.next_command_line() {
                 Some(l) => l,

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -56,9 +56,9 @@ use std::rc::Rc;
 
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
-    "help", "info", "print", "step", "stepi", "continue", "run", "break", "stop-at", "set", "opt",
-    "complete", "viz", "save", "goto", "restart", "resolve", "ask", "watch", "diff", "source",
-    "progress", "detach", "quit",
+    "help", "info", "print", "step", "stepi", "continue", "run", "break", "tbreak", "watchpoint",
+    "stop-at", "set", "opt", "complete", "viz", "save", "goto", "restart", "resolve", "ask",
+    "watch", "diff", "source", "progress", "detach", "quit",
 ];
 
 /// Events a user can `break on` (advertised in `hello.events`). Each is
@@ -69,8 +69,26 @@ const EVENTS: &[&str] = &[
     "regularized",
     "tiny_step",
     "ls_rejected",
+    "mu_stalled",
     "nan",
 ];
+
+/// μ is "stalled" once it has held (to relative tolerance) for this many
+/// consecutive iterations.
+const MU_STALL_ITERS: u32 = 3;
+
+/// A data watchpoint: pause when a watched value changes by more than
+/// `threshold` between iterations.
+#[derive(Clone)]
+struct WatchPoint {
+    /// Source text, e.g. `x` or `x[3]`, for display.
+    raw: String,
+    block: String,
+    idx: Option<usize>,
+    threshold: f64,
+    /// Last observed value(s); `None` until first seen.
+    last: Option<Vec<f64>>,
+}
 
 /// Checkpoint names a user can `stop-at` (matches `Checkpoint::as_str`).
 const CHECKPOINTS: &[&str] = &[
@@ -430,6 +448,7 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
         ["break", "if"] | ["b", "if"] => starts(METRICS),
         ["break", "on"] | ["b", "on"] => starts(EVENTS),
         ["break"] | ["b"] => starts(&["if", "on", "clear", "del"]),
+        ["watchpoint"] | ["wp"] => starts(&BLOCK_NAMES),
         ["print"] | ["p"] | ["watch"] | ["display"] => {
             let mut v = starts(&BLOCK_NAMES);
             v.extend(starts(&[
@@ -490,8 +509,15 @@ pub struct SolverDebugger {
     run_to: Option<i32>,
     /// Iterations to break at.
     breaks: Vec<i32>,
+    /// One-shot iteration breakpoints (`tbreak`), removed when hit.
+    temp_breaks: Vec<i32>,
     /// Conditional breakpoints (`break if mu<1e-4`): pause when any holds.
     conds: Vec<Condition>,
+    /// Data watchpoints (`watchpoint x[3]`): pause when a value changes.
+    watchpoints: Vec<WatchPoint>,
+    /// μ-stall tracking for the `mu_stalled` event.
+    last_mu: Option<f64>,
+    mu_stall: u32,
     /// Once true, never pause again (`detach`).
     detached: bool,
     /// Whether the JSON `hello` handshake has been emitted (once per
@@ -555,7 +581,11 @@ impl SolverDebugger {
             step: true,
             run_to: None,
             breaks: Vec::new(),
+            temp_breaks: Vec::new(),
             conds: Vec::new(),
+            watchpoints: Vec::new(),
+            last_mu: None,
+            mu_stall: 0,
             detached: false,
             hello_sent: false,
             pause_iters: true,
@@ -632,7 +662,15 @@ impl SolverDebugger {
                 return true;
             }
         }
-        self.breaks.contains(&iter)
+        if self.breaks.contains(&iter) {
+            return true;
+        }
+        // One-shot breakpoints fire once then delete themselves.
+        if let Some(pos) = self.temp_breaks.iter().position(|&b| b == iter) {
+            self.temp_breaks.remove(pos);
+            return true;
+        }
+        false
     }
 
     /// First conditional breakpoint that holds at the current state, if
@@ -673,10 +711,57 @@ impl SolverDebugger {
                                 .unwrap_or(false)
                     }
                     "ls_rejected" => cp == Checkpoint::AfterStep && ctx.ls_count() > 1,
+                    "mu_stalled" => cp == Checkpoint::IterStart && self.mu_stall >= MU_STALL_ITERS,
                     "nan" => !ctx.nlp_error().is_finite() || !ctx.objective().is_finite(),
                     _ => false,
                 }
         })
+    }
+
+    /// Update μ-stall tracking once per iteration (drives `mu_stalled`).
+    fn update_mu_stall(&mut self, mu: f64) {
+        if let Some(last) = self.last_mu {
+            if (mu - last).abs() <= 1e-12 * last.abs().max(1.0) {
+                self.mu_stall += 1;
+            } else {
+                self.mu_stall = 0;
+            }
+        }
+        self.last_mu = Some(mu);
+    }
+
+    /// First watchpoint whose value changed (beyond its threshold) since
+    /// the previous iteration. Updates the stored baselines.
+    fn matched_watchpoint(&mut self, ctx: &DebugCtx) -> Option<String> {
+        if self.detached {
+            return None;
+        }
+        let mut hit = None;
+        for wp in self.watchpoints.iter_mut() {
+            let Some(full) = ctx.block(&wp.block) else {
+                continue;
+            };
+            let cur: Vec<f64> = match wp.idx {
+                Some(i) => match full.get(i) {
+                    Some(&v) => vec![v],
+                    None => continue,
+                },
+                None => full,
+            };
+            if let Some(prev) = &wp.last {
+                if prev.len() == cur.len() {
+                    let changed = prev
+                        .iter()
+                        .zip(&cur)
+                        .any(|(p, c)| (p - c).abs() > wp.threshold);
+                    if changed && hit.is_none() {
+                        hit = Some(wp.raw.clone());
+                    }
+                }
+            }
+            wp.last = Some(cur);
+        }
+        hit
     }
 
     // ---- command engine -----------------------------------------------
@@ -719,6 +804,16 @@ impl SolverDebugger {
             }
             "run" | "r" => self.cmd_run(rest),
             "break" | "b" => self.cmd_break(rest),
+            "tbreak" | "tb" => match rest.first().and_then(|s| s.parse::<i32>().ok()) {
+                Some(n) => {
+                    if !self.temp_breaks.contains(&n) {
+                        self.temp_breaks.push(n);
+                    }
+                    CmdOut::ok(vec![format!("temporary breakpoint at iteration {n}")])
+                }
+                None => CmdOut::err("usage: tbreak <iteration>"),
+            },
+            "watchpoint" | "wp" => self.cmd_watchpoint(rest),
             "stop-at" | "stopat" => self.cmd_stop_at(rest),
             "progress" => match rest.first().copied() {
                 Some("on") | None => {
@@ -776,7 +871,9 @@ impl SolverDebugger {
             "  break if <m><op><v>      conditional bp; m in mu|inf_pr|inf_du|obj|err|iter,".into(),
             "                           op in < <= > >= ==  (e.g. break if inf_pr<1e-6)".into(),
             "  break on <event>         event bp: resto_entered|resto_exited|regularized|".into(),
-            "                           tiny_step|ls_rejected|nan".into(),
+            "                           tiny_step|ls_rejected|mu_stalled|nan".into(),
+            "  tbreak <N>               one-shot breakpoint (deletes after firing)".into(),
+            "  watchpoint <blk>[<i>] [τ] pause when a value changes by > τ (alias wp)".into(),
             "  set mu <v>               overwrite the barrier parameter".into(),
             "  set <blk>[<i>] <v>       overwrite one component (e.g. set x[2] 1.5)".into(),
             "  set <blk> <v0,v1,...>    overwrite a whole block".into(),
@@ -1342,6 +1439,58 @@ impl SolverDebugger {
         }
     }
 
+    /// `watchpoint <blk>[<i>] [threshold] | clear | del <spec>` — pause
+    /// when a watched value changes by more than `threshold` (default 0,
+    /// any change) between iterations.
+    fn cmd_watchpoint(&mut self, rest: &[&str]) -> CmdOut {
+        match rest {
+            [] => {
+                let v: Vec<&str> = self.watchpoints.iter().map(|w| w.raw.as_str()).collect();
+                CmdOut::ok(vec![format!("watchpoints: {v:?}")])
+                    .with_data(serde_json::json!({"watchpoints": v}))
+            }
+            ["clear"] => {
+                self.watchpoints.clear();
+                CmdOut::ok(vec!["cleared watchpoints".into()])
+            }
+            ["del", spec] | ["delete", spec] => {
+                self.watchpoints.retain(|w| w.raw != *spec);
+                CmdOut::ok(vec![format!("removed watchpoint {spec}")])
+            }
+            [spec, rest @ ..] => {
+                let threshold = rest
+                    .first()
+                    .and_then(|s| s.parse::<f64>().ok())
+                    .unwrap_or(0.0);
+                // Parse `block` or `block[idx]`.
+                let (block, idx) = match spec.find('[') {
+                    Some(open) if spec.ends_with(']') => {
+                        let b = &spec[..open];
+                        match spec[open + 1..spec.len() - 1].parse::<usize>() {
+                            Ok(i) => (b.to_string(), Some(i)),
+                            Err(_) => return CmdOut::err(format!("bad index in `{spec}`")),
+                        }
+                    }
+                    _ => (spec.to_string(), None),
+                };
+                if !BLOCK_NAMES.contains(&block.as_str()) {
+                    return CmdOut::err(format!("unknown block `{block}`"));
+                }
+                let raw = spec.to_string();
+                if !self.watchpoints.iter().any(|w| w.raw == raw) {
+                    self.watchpoints.push(WatchPoint {
+                        raw: raw.clone(),
+                        block,
+                        idx,
+                        threshold,
+                        last: None,
+                    });
+                }
+                CmdOut::ok(vec![format!("watchpoint on {raw} (Δ>{threshold:.3e})")])
+            }
+        }
+    }
+
     /// `diff` — what changed in the iterate since the previous captured
     /// iteration: per-block max |Δ| (and where), plus Δμ.
     fn cmd_diff(&self, ctx: &DebugCtx) -> CmdOut {
@@ -1847,6 +1996,8 @@ impl DebugHook for SolverDebugger {
                     self.snapshots.remove(&oldest);
                 }
             }
+            // Update μ-stall tracking before events are evaluated.
+            self.update_mu_stall(ctx.mu());
         }
 
         // Decide whether to pause. `stop-at` and a one-shot `stepi` apply
@@ -1884,6 +2035,12 @@ impl DebugHook for SolverDebugger {
                     pause = true;
                     reason = Some(c);
                 }
+            }
+            // Watchpoints fire regardless of pause_iters (explicit, like
+            // breakpoints); evaluated every iter to keep baselines fresh.
+            if let Some(w) = self.matched_watchpoint(ctx) {
+                pause = true;
+                reason = Some(format!("watchpoint: {w}"));
             }
         }
 

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -60,6 +60,17 @@ const COMMANDS: &[&str] = &[
     "complete", "viz", "save", "goto", "restart", "resolve", "progress", "detach", "quit",
 ];
 
+/// Events a user can `break on` (advertised in `hello.events`). Each is
+/// derived from observable state at the relevant checkpoint.
+const EVENTS: &[&str] = &[
+    "resto_entered",
+    "resto_exited",
+    "regularized",
+    "tiny_step",
+    "ls_rejected",
+    "nan",
+];
+
 /// Checkpoint names a user can `stop-at` (matches `Checkpoint::as_str`).
 const CHECKPOINTS: &[&str] = &[
     "iter_start",
@@ -249,20 +260,18 @@ impl CmpOp {
     }
 }
 
-/// A conditional breakpoint: pause when `metric op rhs` holds.
+/// A single comparison `metric op rhs`.
 #[derive(Clone, Debug)]
-struct Condition {
+struct Atom {
     metric: Metric,
     op: CmpOp,
     rhs: f64,
-    /// Normalized source text, e.g. `inf_pr<1e-6`, for display / dedup.
-    raw: String,
 }
 
-impl Condition {
-    /// Parse a single `metric<op>value` expression (whitespace already
-    /// stripped by the caller). Operators: `<`, `<=`, `>`, `>=`, `==`.
-    fn parse(expr: &str) -> Result<Condition, String> {
+impl Atom {
+    /// Parse one `metric<op>value` (whitespace already stripped by the
+    /// caller). Operators: `<`, `<=`, `>`, `>=`, `==`.
+    fn parse(expr: &str) -> Result<Atom, String> {
         let expr = expr.trim();
         // Longest operators first so `<=` isn't truncated to `<`.
         let (op, pos, oplen) = ["<=", ">=", "==", "<", ">"]
@@ -284,16 +293,93 @@ impl Condition {
             "==" => CmpOp::Eq,
             _ => unreachable!(),
         };
-        Ok(Condition {
+        Ok(Atom {
             metric,
             op: cmp,
             rhs,
-            raw: format!("{metric_s}{op}{rhs_s}"),
         })
     }
 
     fn holds(&self, ctx: &DebugCtx) -> bool {
         self.op.eval(self.metric.eval(ctx), self.rhs)
+    }
+}
+
+/// Boolean join between atoms (#72 §4).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Join {
+    And,
+    Or,
+}
+
+/// A conditional breakpoint: one or more [`Atom`]s joined by `&&`/`||`,
+/// evaluated strictly left-to-right (no operator precedence — matches the
+/// issue's minimal-viable spec; parentheses are stripped). Pause when the
+/// chain evaluates true.
+#[derive(Clone, Debug)]
+struct Condition {
+    first: Atom,
+    rest: Vec<(Join, Atom)>,
+    /// Normalized source text, for display / dedup.
+    raw: String,
+}
+
+impl Condition {
+    fn parse(expr: &str) -> Result<Condition, String> {
+        // Parentheses are advisory only (no precedence), so drop them.
+        let cleaned: String = expr.chars().filter(|c| !matches!(c, '(' | ')')).collect();
+        // Split into atoms, remembering the joiner before each.
+        let mut atoms: Vec<(Option<Join>, &str)> = Vec::new();
+        let bytes = cleaned.as_bytes();
+        let mut start = 0usize;
+        let mut i = 0usize;
+        let mut pending: Option<Join> = None;
+        while i + 1 < bytes.len() {
+            let two = &cleaned[i..i + 2];
+            let join = match two {
+                "&&" => Some(Join::And),
+                "||" => Some(Join::Or),
+                _ => None,
+            };
+            if let Some(j) = join {
+                atoms.push((pending, &cleaned[start..i]));
+                pending = Some(j);
+                i += 2;
+                start = i;
+            } else {
+                i += 1;
+            }
+        }
+        atoms.push((pending, &cleaned[start..]));
+
+        let mut iter = atoms.into_iter();
+        let Some((_, first_s)) = iter.next() else {
+            return Err("empty condition".into());
+        };
+        let first = Atom::parse(first_s)?;
+        let mut rest = Vec::new();
+        for (join, s) in iter {
+            let join = join.ok_or("malformed compound condition (dangling &&/||)")?;
+            rest.push((join, Atom::parse(s)?));
+        }
+        // The cleaned source (whitespace/parens removed) is the display form.
+        Ok(Condition {
+            first,
+            rest,
+            raw: cleaned,
+        })
+    }
+
+    fn holds(&self, ctx: &DebugCtx) -> bool {
+        let mut acc = self.first.holds(ctx);
+        for (join, atom) in &self.rest {
+            let v = atom.holds(ctx);
+            acc = match join {
+                Join::And => acc && v,
+                Join::Or => acc || v,
+            };
+        }
+        acc
     }
 }
 
@@ -329,7 +415,8 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
         ["set", "opt"] | ["opt"] | ["options"] => opt_names(),
         ["stop-at"] | ["stopat"] => starts(CHECKPOINTS),
         ["break", "if"] | ["b", "if"] => starts(METRICS),
-        ["break"] | ["b"] => starts(&["if", "clear", "del"]),
+        ["break", "on"] | ["b", "on"] => starts(EVENTS),
+        ["break"] | ["b"] => starts(&["if", "on", "clear", "del"]),
         ["print"] | ["p"] => {
             let mut v = starts(&BLOCK_NAMES);
             v.extend(starts(&["mu", "obj", "inf_pr", "inf_du", "err", "iter"]));
@@ -412,6 +499,8 @@ pub struct SolverDebugger {
     sub_step: bool,
     /// Checkpoint kinds (by name) to always pause at (`stop-at`).
     stop_at: HashSet<&'static str>,
+    /// Events to break on (`break on <event>`), from [`EVENTS`].
+    break_events: HashSet<&'static str>,
     /// Per-iteration primal-dual snapshots for `goto`/`restart`, keyed by
     /// iteration index. Capped at [`SNAPSHOT_CAP`] (oldest evicted).
     snapshots: BTreeMap<i32, IterateSnapshot>,
@@ -452,6 +541,7 @@ impl SolverDebugger {
             emit_progress: true,
             sub_step: false,
             stop_at: HashSet::new(),
+            break_events: HashSet::new(),
             snapshots: BTreeMap::new(),
             restart: None,
             editor: None,
@@ -522,6 +612,38 @@ impl SolverDebugger {
             .iter()
             .find(|c| c.holds(ctx))
             .map(|c| c.raw.clone())
+    }
+
+    /// First armed event that fires at the current checkpoint/state, if
+    /// any. Events are derived from observable state, so they're evaluated
+    /// at the checkpoint where the relevant quantity is meaningful.
+    fn matched_event(&self, ctx: &DebugCtx) -> Option<&'static str> {
+        if self.detached || self.break_events.is_empty() {
+            return None;
+        }
+        let cp = ctx.checkpoint();
+        // Tiny-step threshold mirrors the solver's own scale.
+        let tiny = 1e-10;
+        EVENTS.iter().copied().find(|&e| {
+            self.break_events.contains(e)
+                && match e {
+                    "resto_entered" => cp == Checkpoint::PreRestoration,
+                    "resto_exited" => cp == Checkpoint::PostRestoration,
+                    "regularized" => {
+                        cp == Checkpoint::AfterSearchDirection && ctx.regularization() > 0.0
+                    }
+                    "tiny_step" => {
+                        cp == Checkpoint::AfterSearchDirection
+                            && ctx
+                                .delta_block("x")
+                                .map(|v| v.iter().fold(0.0_f64, |m, &x| m.max(x.abs())) < tiny)
+                                .unwrap_or(false)
+                    }
+                    "ls_rejected" => cp == Checkpoint::AfterStep && ctx.ls_count() > 1,
+                    "nan" => !ctx.nlp_error().is_finite() || !ctx.objective().is_finite(),
+                    _ => false,
+                }
+        })
     }
 
     // ---- command engine -----------------------------------------------
@@ -613,6 +735,8 @@ impl SolverDebugger {
             "  break | b [N|clear|del N] set/list/clear breakpoints".into(),
             "  break if <m><op><v>      conditional bp; m in mu|inf_pr|inf_du|obj|err|iter,".into(),
             "                           op in < <= > >= ==  (e.g. break if inf_pr<1e-6)".into(),
+            "  break on <event>         event bp: resto_entered|resto_exited|regularized|".into(),
+            "                           tiny_step|ls_rejected|nan".into(),
             "  set mu <v>               overwrite the barrier parameter".into(),
             "  set <blk>[<i>] <v>       overwrite one component (e.g. set x[2] 1.5)".into(),
             "  set <blk> <v0,v1,...>    overwrite a whole block".into(),
@@ -732,25 +856,48 @@ impl SolverDebugger {
                 Err(e) => CmdOut::err(e),
             };
         }
+        // Event breakpoint: `break on <event>` (#72 §3).
+        if rest.first().copied() == Some("on") {
+            let Some(&name) = rest.get(1) else {
+                return CmdOut::err(format!("usage: break on <event>  (one of {EVENTS:?})"));
+            };
+            let Some(&canon) = EVENTS.iter().find(|&&e| e == name) else {
+                return CmdOut::err(format!("unknown event `{name}` (one of {EVENTS:?})"));
+            };
+            self.break_events.insert(canon);
+            return CmdOut::ok(vec![format!("break on event `{canon}`")])
+                .with_data(serde_json::json!({"event": canon}));
+        }
         match rest {
             [] => {
                 let mut bs = self.breaks.clone();
                 bs.sort_unstable();
                 let conds: Vec<String> = self.conds.iter().map(|c| c.raw.clone()).collect();
+                let mut events: Vec<&str> = self.break_events.iter().copied().collect();
+                events.sort_unstable();
                 let mut lines = vec![format!("breakpoints: {bs:?}")];
                 if !conds.is_empty() {
                     lines.push(format!("conditions: {}", conds.join(", ")));
                 }
-                CmdOut::ok(lines)
-                    .with_data(serde_json::json!({"breakpoints": bs, "conditions": conds}))
+                if !events.is_empty() {
+                    lines.push(format!("events: {}", events.join(", ")));
+                }
+                CmdOut::ok(lines).with_data(
+                    serde_json::json!({"breakpoints": bs, "conditions": conds, "events": events}),
+                )
             }
             ["clear", "cond"] | ["clear", "conditions"] => {
                 self.conds.clear();
                 CmdOut::ok(vec!["cleared conditional breakpoints".into()])
             }
+            ["clear", "events"] => {
+                self.break_events.clear();
+                CmdOut::ok(vec!["cleared event breakpoints".into()])
+            }
             ["clear"] => {
                 self.breaks.clear();
                 self.conds.clear();
+                self.break_events.clear();
                 CmdOut::ok(vec!["cleared all breakpoints".into()])
             }
             ["del", n] | ["delete", n] => match n.parse::<i32>() {
@@ -1222,8 +1369,7 @@ impl SolverDebugger {
                 "inspect": true,
                 "mutate_iterate": true,
                 "mutate_mu": true,
-                // "single" today; becomes "compound" once &&/|| land (#72 §4).
-                "conditional_breakpoints": "single",
+                "conditional_breakpoints": "compound",
                 "request_ids": true,
                 "viz": ["block", "delta"],
                 "save": true,
@@ -1236,6 +1382,7 @@ impl SolverDebugger {
                 "async_pause": if self.interruptible { "checkpoint" } else { "none" },
             },
             "checkpoints": CHECKPOINTS,
+            "events": EVENTS,
             "commands": COMMANDS,
             "blocks": BLOCK_NAMES,
             "metrics": METRICS,
@@ -1354,6 +1501,14 @@ impl DebugHook for SolverDebugger {
         // Ctrl-C only at the iteration top.
         let mut reason: Option<String> = None;
         let mut pause = self.sub_step || self.stop_at.contains(cp.as_str());
+
+        // Event breakpoints fire at whatever checkpoint makes them
+        // observable (e.g. `regularized` at after_search_dir), so check
+        // them at every checkpoint, not just iter_start.
+        if let Some(ev) = self.matched_event(ctx) {
+            pause = true;
+            reason = Some(format!("event: {ev}"));
+        }
 
         if is_iter_start {
             if self.interruptible && interrupt::take() {
@@ -1620,29 +1775,46 @@ mod tests {
     }
 
     #[test]
-    fn condition_parses_metric_op_threshold() {
-        let c = Condition::parse("mu<1e-4").unwrap();
-        assert_eq!(c.metric, Metric::Mu);
-        assert_eq!(c.op, CmpOp::Lt);
-        assert_eq!(c.rhs, 1e-4);
+    fn atom_parses_metric_op_threshold() {
+        let a = Atom::parse("mu<1e-4").unwrap();
+        assert_eq!(a.metric, Metric::Mu);
+        assert_eq!(a.op, CmpOp::Lt);
+        assert_eq!(a.rhs, 1e-4);
 
-        // `<=` must not be truncated to `<`, and spaces are tolerated by
-        // the caller (tokens are concatenated before parse).
-        let c = Condition::parse("inf_pr<=1e-6").unwrap();
-        assert_eq!(c.metric, Metric::InfPr);
-        assert_eq!(c.op, CmpOp::Le);
+        // `<=` must not be truncated to `<`.
+        let a = Atom::parse("inf_pr<=1e-6").unwrap();
+        assert_eq!(a.metric, Metric::InfPr);
+        assert_eq!(a.op, CmpOp::Le);
 
-        let c = Condition::parse("iter==10").unwrap();
-        assert_eq!(c.metric, Metric::Iter);
-        assert_eq!(c.op, CmpOp::Eq);
-        assert_eq!(c.rhs, 10.0);
+        let a = Atom::parse("iter==10").unwrap();
+        assert_eq!(a.metric, Metric::Iter);
+        assert_eq!(a.op, CmpOp::Eq);
+        assert_eq!(a.rhs, 10.0);
     }
 
     #[test]
-    fn condition_parse_rejects_garbage() {
-        assert!(Condition::parse("inf_pr 1e-6").is_err()); // no operator
-        assert!(Condition::parse("bogus<1").is_err()); // unknown metric
-        assert!(Condition::parse("mu<abc").is_err()); // bad threshold
+    fn atom_parse_rejects_garbage() {
+        assert!(Atom::parse("inf_pr 1e-6").is_err()); // no operator
+        assert!(Atom::parse("bogus<1").is_err()); // unknown metric
+        assert!(Atom::parse("mu<abc").is_err()); // bad threshold
+    }
+
+    #[test]
+    fn compound_condition_parses_and_evaluates_left_to_right() {
+        // Chain length + joins.
+        let c = Condition::parse("mu<1e-4&&inf_pr>1e-3").unwrap();
+        assert_eq!(c.rest.len(), 1);
+        assert_eq!(c.rest[0].0, Join::And);
+
+        // Parens are stripped; `||` recognized.
+        let c = Condition::parse("iter>10&&(inf_du>1e-2||obj<0)").unwrap();
+        assert_eq!(c.rest.len(), 2);
+        assert_eq!(c.rest[0].0, Join::And);
+        assert_eq!(c.rest[1].0, Join::Or);
+        assert_eq!(c.raw, "iter>10&&inf_du>1e-2||obj<0");
+
+        // A bad atom anywhere fails the whole parse.
+        assert!(Condition::parse("mu<1e-4&&bogus>0").is_err());
     }
 
     #[test]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -49,15 +49,24 @@ use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
 use rustyline::{Context, Editor, Helper, Highlighter, Hinter, Validator};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
 
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
-    "help", "info", "print", "step", "continue", "run", "break", "set", "opt", "complete", "viz",
-    "save", "goto", "restart", "resolve", "detach", "quit",
+    "help", "info", "print", "step", "stepi", "continue", "run", "break", "stop-at", "set", "opt",
+    "complete", "viz", "save", "goto", "restart", "resolve", "detach", "quit",
+];
+
+/// Checkpoint names a user can `stop-at` (matches `Checkpoint::as_str`).
+const CHECKPOINTS: &[&str] = &[
+    "iter_start",
+    "after_mu",
+    "after_search_dir",
+    "after_step",
+    "terminated",
 ];
 
 /// Request to re-run the solve from a captured point with new options.
@@ -316,6 +325,7 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
             v
         }
         ["set", "opt"] | ["opt"] | ["options"] => opt_names(),
+        ["stop-at"] | ["stopat"] => starts(CHECKPOINTS),
         ["break", "if"] | ["b", "if"] => starts(METRICS),
         ["break"] | ["b"] => starts(&["if", "clear", "del"]),
         ["print"] | ["p"] => {
@@ -392,6 +402,11 @@ pub struct SolverDebugger {
     terminal_only_on_error: bool,
     /// Honor a pending SIGINT (Ctrl-C) by pausing at the next iteration.
     interruptible: bool,
+    /// One-shot: pause at the very next checkpoint of *any* kind (set by
+    /// `stepi`, for walking through sub-iteration phases).
+    sub_step: bool,
+    /// Checkpoint kinds (by name) to always pause at (`stop-at`).
+    stop_at: HashSet<&'static str>,
     /// Per-iteration primal-dual snapshots for `goto`/`restart`, keyed by
     /// iteration index. Capped at [`SNAPSHOT_CAP`] (oldest evicted).
     snapshots: BTreeMap<i32, IterateSnapshot>,
@@ -429,6 +444,8 @@ impl SolverDebugger {
             pause_terminal: true,
             terminal_only_on_error: false,
             interruptible: true,
+            sub_step: false,
+            stop_at: HashSet::new(),
             snapshots: BTreeMap::new(),
             restart: None,
             editor: None,
@@ -517,13 +534,22 @@ impl SolverDebugger {
                 self.step = true;
                 CmdOut::ok(vec!["stepping one iteration".into()]).flow(Flow::Resume)
             }
+            "stepi" | "si" => {
+                self.sub_step = true;
+                CmdOut::ok(vec![
+                    "stepping to the next checkpoint (sub-iteration)".into()
+                ])
+                .flow(Flow::Resume)
+            }
             "continue" | "c" | "cont" => {
                 self.step = false;
+                self.sub_step = false;
                 self.run_to = None;
                 CmdOut::ok(vec!["continuing".into()]).flow(Flow::Resume)
             }
             "run" | "r" => self.cmd_run(rest),
             "break" | "b" => self.cmd_break(rest),
+            "stop-at" | "stopat" => self.cmd_stop_at(rest),
             "set" => self.cmd_set(rest, ctx),
             "opt" | "options" => self.cmd_opt(rest),
             "complete" => self.cmd_complete(rest),
@@ -553,6 +579,8 @@ impl SolverDebugger {
             "  print | p <what>         x|s|y_c|y_d|z_l|z_u|v_l|v_u | dx (step) |".into(),
             "                           mu|obj|inf_pr|inf_du|err|iter".into(),
             "  step | s | n             run one iteration, pause again".into(),
+            "  stepi | si               run to the next checkpoint (into sub-iteration phases)".into(),
+            "  stop-at <cp>             always pause at a checkpoint: after_mu|after_search_dir|after_step".into(),
             "  continue | c             run to the next breakpoint".into(),
             "  run | r <N>              run until iteration N".into(),
             "  break | b [N|clear|del N] set/list/clear breakpoints".into(),
@@ -715,6 +743,47 @@ impl SolverDebugger {
                 Err(_) => CmdOut::err("usage: break <iteration>"),
             },
             _ => CmdOut::err("usage: break [N | if <m><op><v> | clear | clear cond | del N]"),
+        }
+    }
+
+    /// `stop-at [name|clear]` — pause at a sub-iteration checkpoint every
+    /// time it fires. Names: after_mu, after_search_dir, after_step
+    /// (also iter_start / terminated). Aliases: mu, kkt/search_dir, step.
+    fn cmd_stop_at(&mut self, rest: &[&str]) -> CmdOut {
+        let canon = |s: &str| -> Option<&'static str> {
+            match s {
+                "mu" | "after_mu" => Some("after_mu"),
+                "kkt" | "search_dir" | "after_search_dir" => Some("after_search_dir"),
+                "step" | "after_step" => Some("after_step"),
+                "iter" | "iter_start" => Some("iter_start"),
+                "terminated" => Some("terminated"),
+                _ => None,
+            }
+        };
+        match rest {
+            [] => {
+                let mut v: Vec<&str> = self.stop_at.iter().copied().collect();
+                v.sort_unstable();
+                CmdOut::ok(vec![format!(
+                    "stop-at: {v:?}  (available: {CHECKPOINTS:?})"
+                )])
+                .with_data(serde_json::json!({"stop_at": v, "available": CHECKPOINTS}))
+            }
+            ["clear"] => {
+                self.stop_at.clear();
+                CmdOut::ok(vec!["cleared stop-at checkpoints".into()])
+            }
+            [name] => match canon(name) {
+                Some(c) => {
+                    self.stop_at.insert(c);
+                    CmdOut::ok(vec![format!("will stop at checkpoint `{c}`")])
+                        .with_data(serde_json::json!({"stop_at_added": c}))
+                }
+                None => CmdOut::err(format!(
+                    "unknown checkpoint `{name}` (one of {CHECKPOINTS:?})"
+                )),
+            },
+            _ => CmdOut::err("usage: stop-at [<checkpoint> | clear]"),
         }
     }
 
@@ -1029,8 +1098,9 @@ impl SolverDebugger {
                     );
                 } else {
                     eprintln!(
-                        "\n── pounce-dbg ── iter {}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
+                        "\n── pounce-dbg ── iter {} @{}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
                         ctx.iter(),
+                        ctx.checkpoint().as_str(),
                         ctx.mu(),
                         ctx.objective(),
                         ctx.inf_pr(),
@@ -1038,7 +1108,7 @@ impl SolverDebugger {
                     );
                 }
                 if let Some(r) = reason {
-                    eprintln!("   ↳ hit condition: {r}");
+                    eprintln!("   ↳ {r}");
                 }
             }
             DebugMode::Json => {
@@ -1118,7 +1188,7 @@ impl SolverDebugger {
                 "terminal_checkpoint": true,
                 "interruptible": self.interruptible,
             },
-            "checkpoints": ["iter_start", "terminated"],
+            "checkpoints": CHECKPOINTS,
             "commands": COMMANDS,
             "blocks": BLOCK_NAMES,
             "metrics": METRICS,
@@ -1214,46 +1284,54 @@ impl DebugHook for SolverDebugger {
             return self.prompt_loop(ctx);
         }
 
-        // IterStart: capture a snapshot every iteration (cheap — Rc
-        // clone) so `goto` can reach any seen iteration, not only paused
-        // ones. Bound memory by evicting the oldest beyond the cap.
-        if let Some(snap) = ctx.snapshot() {
-            self.snapshots.insert(snap.iter(), snap);
-            while self.snapshots.len() > SNAPSHOT_CAP {
-                let Some(&oldest) = self.snapshots.keys().next() else {
-                    break;
-                };
-                self.snapshots.remove(&oldest);
+        let cp = ctx.checkpoint();
+        let is_iter_start = matches!(cp, Checkpoint::IterStart);
+
+        // At each iteration top, snapshot the primal-dual state (cheap —
+        // Rc clone) so `goto` can reach any seen iteration. Bound memory
+        // by evicting the oldest beyond the cap.
+        if is_iter_start {
+            if let Some(snap) = ctx.snapshot() {
+                self.snapshots.insert(snap.iter(), snap);
+                while self.snapshots.len() > SNAPSHOT_CAP {
+                    let Some(&oldest) = self.snapshots.keys().next() else {
+                        break;
+                    };
+                    self.snapshots.remove(&oldest);
+                }
             }
         }
 
-        // A pending Ctrl-C forces a pause regardless of `pause_iters`.
-        let interrupted = self.interruptible && interrupt::take();
+        // Decide whether to pause. `stop-at` and a one-shot `stepi` apply
+        // at every checkpoint; step / run / breakpoints / conditions /
+        // Ctrl-C only at the iteration top.
+        let mut reason: Option<String> = None;
+        let mut pause = self.sub_step || self.stop_at.contains(cp.as_str());
 
-        let iter = ctx.iter();
-        // `should_pause` covers step / run / numeric breakpoints (and
-        // disarms `run_to`); conditional breakpoints are evaluated
-        // against the live state separately. `--debug-on-error` /
-        // `--debug-on-interrupt` keep `pause_iters` false so we only
-        // stop here on a Ctrl-C.
-        let num_hit = self.pause_iters && self.should_pause(iter);
-        let cond_hit = if self.pause_iters {
-            self.matched_condition(ctx)
-        } else {
-            None
-        };
-        if !interrupted && !num_hit && cond_hit.is_none() {
+        if is_iter_start {
+            if self.interruptible && interrupt::take() {
+                pause = true;
+                reason = Some("interrupt (Ctrl-C)".into());
+            }
+            if self.pause_iters {
+                if self.should_pause(ctx.iter()) {
+                    pause = true;
+                }
+                if let Some(c) = self.matched_condition(ctx) {
+                    pause = true;
+                    reason = Some(c);
+                }
+            }
+        }
+
+        if !pause {
             return DebugAction::Resume;
         }
-        // Consume the one-shot step arming; commands re-arm as needed.
+        // Consume one-shot arming; commands re-arm as needed.
         self.step = false;
+        self.sub_step = false;
         self.ensure_editor();
-        let reason = cond_hit.as_deref().or(if interrupted {
-            Some("interrupt (Ctrl-C)")
-        } else {
-            None
-        });
-        self.emit_pause(ctx, reason);
+        self.emit_pause(ctx, reason.as_deref());
         self.prompt_loop(ctx)
     }
 }
@@ -1565,6 +1643,23 @@ mod tests {
         assert!(!d.pause_terminal, "on-interrupt does not pause at terminal");
         assert!(d.interruptible, "on-interrupt honors Ctrl-C");
         assert!(!d.step, "on-interrupt starts un-armed");
+    }
+
+    #[test]
+    fn stop_at_accepts_names_and_aliases() {
+        let mut d = SolverDebugger::new(DebugMode::Repl, None);
+        assert!(d.cmd_stop_at(&["after_search_dir"]).ok);
+        assert!(d.stop_at.contains("after_search_dir"));
+        // Aliases canonicalize.
+        assert!(d.cmd_stop_at(&["mu"]).ok);
+        assert!(d.stop_at.contains("after_mu"));
+        assert!(d.cmd_stop_at(&["kkt"]).ok);
+        assert!(d.stop_at.contains("after_search_dir"));
+        // Unknown name is rejected.
+        assert!(!d.cmd_stop_at(&["bogus"]).ok);
+        // Clear empties the set.
+        assert!(d.cmd_stop_at(&["clear"]).ok);
+        assert!(d.stop_at.is_empty());
     }
 
     #[test]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -41,12 +41,15 @@
 //! Every non-kill path ends with a `terminated` event in JSON mode.
 
 use crate::cli::DebugMode;
-use pounce_algorithm::debug::{DebugAction, DebugCtx, DebugHook, BLOCK_NAMES};
+use pounce_algorithm::debug::{
+    Checkpoint, DebugAction, DebugCtx, DebugHook, IterateSnapshot, BLOCK_NAMES,
+};
 use pounce_common::reg_options::{DefaultValue, OptionType, RegisteredOptions};
 use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
 use rustyline::{Context, Editor, Helper, Highlighter, Hinter, Validator};
+use std::collections::BTreeMap;
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -54,8 +57,18 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "continue", "run", "break", "set", "opt", "complete", "viz",
-    "detach", "quit",
+    "save", "goto", "restart", "detach", "quit",
 ];
+
+/// Cap on retained per-iteration snapshots (bounds rewind memory; oldest
+/// are evicted first).
+const SNAPSHOT_CAP: usize = 2000;
+
+/// SolverReturn debug strings that count as a successful solve (so
+/// `--debug-on-error` does *not* pause at the terminal checkpoint).
+fn is_success_status(s: &str) -> bool {
+    matches!(s, "Success" | "StopAtAcceptablePoint")
+}
 
 /// What to do after a command runs.
 enum Flow {
@@ -308,6 +321,16 @@ pub struct SolverDebugger {
     /// Whether the JSON `hello` handshake has been emitted (once per
     /// session, at the first checkpoint).
     hello_sent: bool,
+    /// Pause at iteration checkpoints (false for `--debug-on-error`,
+    /// which runs freely until the terminal checkpoint).
+    pause_iters: bool,
+    /// Pause at the terminal (post-mortem) checkpoint.
+    pause_terminal: bool,
+    /// At the terminal checkpoint, pause only when the solve failed.
+    terminal_only_on_error: bool,
+    /// Per-iteration primal-dual snapshots for `goto`/`restart`, keyed by
+    /// iteration index. Capped at [`SNAPSHOT_CAP`] (oldest evicted).
+    snapshots: BTreeMap<i32, IterateSnapshot>,
     /// rustyline editor for the human REPL on a TTY (history + Tab +
     /// Ctrl-R). `None` for JSON mode or when stdin isn't a terminal, in
     /// which case a plain line reader is used.
@@ -321,6 +344,8 @@ pub struct SolverDebugger {
 }
 
 impl SolverDebugger {
+    /// Fully interactive: pause at the first iteration and at the
+    /// terminal checkpoint.
     pub fn new(mode: DebugMode, reg: Option<Rc<RegisteredOptions>>) -> Self {
         Self {
             mode,
@@ -333,9 +358,24 @@ impl SolverDebugger {
             conds: Vec::new(),
             detached: false,
             hello_sent: false,
+            pause_iters: true,
+            pause_terminal: true,
+            terminal_only_on_error: false,
+            snapshots: BTreeMap::new(),
             editor: None,
             hist_path: None,
             staged: Vec::new(),
+        }
+    }
+
+    /// Post-mortem: run freely, then drop in at the terminal checkpoint
+    /// only if the solve did not succeed (`--debug-on-error`).
+    pub fn on_error(mode: DebugMode, reg: Option<Rc<RegisteredOptions>>) -> Self {
+        Self {
+            step: false,
+            pause_iters: false,
+            terminal_only_on_error: true,
+            ..Self::new(mode, reg)
         }
     }
 
@@ -400,6 +440,12 @@ impl SolverDebugger {
             "opt" | "options" => self.cmd_opt(rest),
             "complete" => self.cmd_complete(rest),
             "viz" | "plot" => self.cmd_viz(rest, ctx),
+            "save" => self.cmd_save(rest, ctx),
+            "goto" | "jump" => self.cmd_goto(rest, ctx),
+            "restart" => match self.snapshots.keys().next().copied() {
+                Some(k) => self.restore_to(k, ctx),
+                None => CmdOut::err("no snapshots captured yet"),
+            },
             "detach" => {
                 self.detached = true;
                 self.step = false;
@@ -430,6 +476,8 @@ impl SolverDebugger {
             "  opt [filter]             list solver options (name/type/default)".into(),
             "  complete <prefix>        completion candidates (commands + options)".into(),
             "  viz <x|s|dx|...|kkt|L>   open the artifact in an external viewer".into(),
+            "  save [path]              write the current iterate + residuals to JSON".into(),
+            "  goto <k> | restart       rewind to a captured iteration (primal-dual only)".into(),
             "  detach                   stop pausing; solve to completion".into(),
             "  quit | q                 stop the solve now".into(),
         ];
@@ -734,6 +782,84 @@ impl SolverDebugger {
         CmdOut::ok(vec![cands.join(" ")]).with_data(serde_json::json!({"candidates": cands}))
     }
 
+    /// `save [path]` — dump the full current iterate (all blocks +
+    /// search-direction blocks) and residual scalars to a JSON file for
+    /// external analysis. Defaults to a temp path keyed by iteration.
+    fn cmd_save(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
+        let iter = ctx.iter();
+        let path = rest
+            .first()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| std::env::temp_dir().join(format!("pounce-dbg-iter{iter}.json")));
+        let collect = |delta: bool| -> serde_json::Map<String, serde_json::Value> {
+            let mut m = serde_json::Map::new();
+            for &b in BLOCK_NAMES.iter() {
+                let v = if delta {
+                    ctx.delta_block(b)
+                } else {
+                    ctx.block(b)
+                };
+                if let Some(v) = v {
+                    if !v.is_empty() {
+                        let key = if delta {
+                            format!("d{b}")
+                        } else {
+                            b.to_string()
+                        };
+                        m.insert(key, serde_json::json!(v));
+                    }
+                }
+            }
+            m
+        };
+        let payload = serde_json::json!({
+            "iter": iter,
+            "mu": ctx.mu(),
+            "objective": ctx.objective(),
+            "inf_pr": ctx.inf_pr(),
+            "inf_du": ctx.inf_du(),
+            "nlp_error": ctx.nlp_error(),
+            "iterate": collect(false),
+            "delta": collect(true),
+        });
+        match std::fs::write(&path, format!("{payload}\n")) {
+            Ok(()) => {
+                let p = path.to_string_lossy().to_string();
+                CmdOut::ok(vec![format!("saved iterate to {p}")])
+                    .with_data(serde_json::json!({"path": p}))
+            }
+            Err(e) => CmdOut::err(format!("save failed: {e}")),
+        }
+    }
+
+    /// `goto <k>` — rewind to a captured iteration.
+    fn cmd_goto(&mut self, rest: &[&str], ctx: &mut DebugCtx) -> CmdOut {
+        match rest.first().and_then(|s| s.parse::<i32>().ok()) {
+            Some(k) => self.restore_to(k, ctx),
+            None => CmdOut::err("usage: goto <iteration>"),
+        }
+    }
+
+    /// Restore the snapshot for iteration `k` (primal-dual state only;
+    /// strategy history is not rewound). Stays paused so the user can
+    /// inspect / re-tune before `continue`/`step`.
+    fn restore_to(&mut self, k: i32, ctx: &mut DebugCtx) -> CmdOut {
+        match self.snapshots.get(&k) {
+            Some(snap) => {
+                ctx.restore(snap);
+                CmdOut::ok(vec![format!(
+                    "rewound to iter {k} (primal-dual only; strategy history not restored). \
+                     `continue`/`step` to resume."
+                )])
+                .with_data(serde_json::json!({"restored_iter": k}))
+            }
+            None => {
+                let have: Vec<i32> = self.snapshots.keys().copied().collect();
+                CmdOut::err(format!("no snapshot for iter {k} (captured: {have:?})"))
+            }
+        }
+    }
+
     fn cmd_viz(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
         let Some(&target) = rest.first() else {
             return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
@@ -778,16 +904,28 @@ impl SolverDebugger {
 
     /// Emit the pause banner / state for the current front end.
     fn emit_pause(&self, ctx: &DebugCtx, reason: Option<&str>) {
+        let terminal = matches!(ctx.checkpoint(), Checkpoint::Terminated);
         match self.mode {
             DebugMode::Repl => {
-                eprintln!(
-                    "\n── pounce-dbg ── iter {}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
-                    ctx.iter(),
-                    ctx.mu(),
-                    ctx.objective(),
-                    ctx.inf_pr(),
-                    ctx.inf_du(),
-                );
+                if terminal {
+                    eprintln!(
+                        "\n── pounce-dbg ── TERMINATED ({})  iter {}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
+                        ctx.status().unwrap_or("?"),
+                        ctx.iter(),
+                        ctx.objective(),
+                        ctx.inf_pr(),
+                        ctx.inf_du(),
+                    );
+                } else {
+                    eprintln!(
+                        "\n── pounce-dbg ── iter {}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
+                        ctx.iter(),
+                        ctx.mu(),
+                        ctx.objective(),
+                        ctx.inf_pr(),
+                        ctx.inf_du(),
+                    );
+                }
                 if let Some(r) = reason {
                     eprintln!("   ↳ hit condition: {r}");
                 }
@@ -802,6 +940,7 @@ impl SolverDebugger {
                 let ev = serde_json::json!({
                     "event": "pause",
                     "checkpoint": ctx.checkpoint().as_str(),
+                    "status": ctx.status(),
                     "iter": ctx.iter(),
                     "mu": ctx.mu(),
                     "objective": ctx.objective(),
@@ -862,8 +1001,11 @@ impl SolverDebugger {
                 "conditional_breakpoints": true,
                 "request_ids": true,
                 "viz": ["block", "delta"],
+                "save": true,
+                "rewind": "primal_dual",
+                "terminal_checkpoint": true,
             },
-            "checkpoints": ["iter_start"],
+            "checkpoints": ["iter_start", "terminated"],
             "commands": COMMANDS,
             "blocks": BLOCK_NAMES,
             "metrics": METRICS,
@@ -944,12 +1086,43 @@ impl DebugHook for SolverDebugger {
             self.emit_hello();
             self.hello_sent = true;
         }
+        // Terminal post-mortem checkpoint: pause if configured (and, for
+        // `--debug-on-error`, only when the solve failed). Snapshots /
+        // rewinding don't apply — the solve is over.
+        if let Checkpoint::Terminated = ctx.checkpoint() {
+            let failed = ctx.status().map(|s| !is_success_status(s)).unwrap_or(false);
+            let should =
+                self.pause_terminal && !self.detached && (!self.terminal_only_on_error || failed);
+            if !should {
+                return DebugAction::Resume;
+            }
+            self.ensure_editor();
+            self.emit_pause(ctx, None);
+            return self.prompt_loop(ctx);
+        }
+
+        // IterStart: capture a snapshot every iteration (cheap — Rc
+        // clone) so `goto` can reach any seen iteration, not only paused
+        // ones. Bound memory by evicting the oldest beyond the cap.
+        if let Some(snap) = ctx.snapshot() {
+            self.snapshots.insert(snap.iter(), snap);
+            while self.snapshots.len() > SNAPSHOT_CAP {
+                let oldest = *self.snapshots.keys().next().unwrap();
+                self.snapshots.remove(&oldest);
+            }
+        }
+
         let iter = ctx.iter();
         // `should_pause` covers step / run / numeric breakpoints (and
         // disarms `run_to`); conditional breakpoints are evaluated
-        // against the live state separately.
-        let num_hit = self.should_pause(iter);
-        let cond_hit = self.matched_condition(ctx);
+        // against the live state separately. `--debug-on-error` keeps
+        // `pause_iters` false so we never stop here.
+        let num_hit = self.pause_iters && self.should_pause(iter);
+        let cond_hit = if self.pause_iters {
+            self.matched_condition(ctx)
+        } else {
+            None
+        };
         if !num_hit && cond_hit.is_none() {
             return DebugAction::Resume;
         }
@@ -957,7 +1130,13 @@ impl DebugHook for SolverDebugger {
         self.step = false;
         self.ensure_editor();
         self.emit_pause(ctx, cond_hit.as_deref());
+        self.prompt_loop(ctx)
+    }
+}
 
+impl SolverDebugger {
+    /// Read and dispatch commands until one resumes or stops the solve.
+    fn prompt_loop(&mut self, ctx: &mut DebugCtx) -> DebugAction {
         loop {
             let line = match self.next_command_line() {
                 Some(l) => l,

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -320,10 +320,23 @@ impl Atom {
     /// caller). Operators: `<`, `<=`, `>`, `>=`, `==`.
     fn parse(expr: &str) -> Result<Atom, String> {
         let expr = expr.trim();
-        // Longest operators first so `<=` isn't truncated to `<`.
-        let (op, pos, oplen) = ["<=", ">=", "==", "<", ">"]
-            .iter()
-            .find_map(|o| expr.find(o).map(|p| (*o, p, o.len())))
+        // Scan left-to-right for the *first* comparison operator, preferring
+        // the two-char form at each position so `<=` isn't truncated to `<`
+        // (and so we split on the leftmost op, not whichever the array lists
+        // first).
+        let mut found: Option<(&str, usize, usize)> = None;
+        for (i, _) in expr.char_indices() {
+            let rest = &expr[i..];
+            if rest.starts_with("<=") || rest.starts_with(">=") || rest.starts_with("==") {
+                found = Some((&expr[i..i + 2], i, 2));
+                break;
+            }
+            if rest.starts_with('<') || rest.starts_with('>') {
+                found = Some((&expr[i..i + 1], i, 1));
+                break;
+            }
+        }
+        let (op, pos, oplen) = found
             .ok_or_else(|| format!("no comparison operator in `{expr}` (use < <= > >= ==)"))?;
         let metric_s = expr[..pos].trim();
         let rhs_s = expr[pos + oplen..].trim();
@@ -1701,10 +1714,17 @@ impl SolverDebugger {
                     "no KKT factorization yet — stop at `after_search_dir` (e.g. `stop-at kkt`)",
                 );
             };
-            let matrix = ctx.kkt_matrix().map(|(dim, irn, jcn, vals)| {
-                serde_json::json!({"dim": dim, "irn": irn, "jcn": jcn, "vals": vals,
-                                   "format": "triplet_1based_lower"})
-            });
+            // Triplet capture is opt-in (O(nnz) assembly), so the first call
+            // arms it — same dance as `viz L`.
+            let Some((dim, irn, jcn, vals)) = ctx.kkt_matrix() else {
+                ctx.request_kkt_matrix();
+                return CmdOut::err(
+                    "KKT matrix capture enabled — re-run `viz kkt` after the next \
+                     `after_search_dir` stop (`stepi` or `continue`).",
+                );
+            };
+            let matrix = serde_json::json!({"dim": dim, "irn": irn, "jcn": jcn, "vals": vals,
+                                            "format": "triplet_1based_lower"});
             let payload = serde_json::json!({
                 "label": "kkt", "iter": ctx.iter(),
                 "dim": k.dim, "n_pos": k.n_pos, "n_neg": k.n_neg,

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -220,7 +220,7 @@ impl CmdOut {
 }
 
 /// Metric names accepted in `break if …` (and shown by `help`).
-const METRICS: &[&str] = &["mu", "inf_pr", "inf_du", "obj", "err", "iter"];
+const METRICS: &[&str] = &["mu", "inf_pr", "inf_du", "obj", "err", "compl", "iter"];
 
 /// A scalar the solver exposes for conditional breakpoints.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -230,6 +230,7 @@ enum Metric {
     InfDu,
     Obj,
     NlpError,
+    Compl,
     Iter,
 }
 
@@ -241,6 +242,7 @@ impl Metric {
             "inf_du" => Metric::InfDu,
             "obj" | "objective" => Metric::Obj,
             "err" | "nlp_error" => Metric::NlpError,
+            "compl" | "complementarity" => Metric::Compl,
             "iter" => Metric::Iter,
             _ => return None,
         })
@@ -252,6 +254,7 @@ impl Metric {
             Metric::InfDu => ctx.inf_du(),
             Metric::Obj => ctx.objective(),
             Metric::NlpError => ctx.nlp_error(),
+            Metric::Compl => ctx.complementarity(),
             Metric::Iter => ctx.iter() as f64,
         }
     }
@@ -452,7 +455,7 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
         ["print"] | ["p"] | ["watch"] | ["display"] => {
             let mut v = starts(&BLOCK_NAMES);
             v.extend(starts(&[
-                "mu", "obj", "inf_pr", "inf_du", "err", "iter", "kkt",
+                "mu", "obj", "inf_pr", "inf_du", "err", "compl", "iter", "kkt",
             ]));
             v
         }
@@ -954,10 +957,11 @@ impl SolverDebugger {
                 "inf_pr" => ctx.inf_pr(),
                 "inf_du" => ctx.inf_du(),
                 "err" | "nlp_error" => ctx.nlp_error(),
+                "compl" | "complementarity" => ctx.complementarity(),
                 "iter" => ctx.iter() as f64,
                 _ => {
                     return CmdOut::err(format!(
-                        "don't know how to print `{what}` (try a block name or mu|obj|inf_pr|inf_du|err|iter)"
+                        "don't know how to print `{what}` (try a block name or mu|obj|inf_pr|inf_du|err|compl|iter)"
                     ))
                 }
             };

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -56,9 +56,33 @@ use std::rc::Rc;
 
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
-    "help", "info", "print", "step", "stepi", "continue", "run", "break", "tbreak", "watchpoint",
-    "commands", "stop-at", "set", "opt", "complete", "viz", "save", "goto", "restart", "resolve",
-    "ask", "watch", "diff", "source", "progress", "detach", "quit",
+    "help",
+    "info",
+    "print",
+    "step",
+    "stepi",
+    "continue",
+    "run",
+    "break",
+    "tbreak",
+    "watchpoint",
+    "commands",
+    "stop-at",
+    "set",
+    "opt",
+    "complete",
+    "viz",
+    "save",
+    "goto",
+    "restart",
+    "resolve",
+    "ask",
+    "watch",
+    "diff",
+    "source",
+    "progress",
+    "detach",
+    "quit",
 ];
 
 /// Events a user can `break on` (advertised in `hello.events`). Each is
@@ -524,6 +548,9 @@ pub struct SolverDebugger {
     /// μ-stall tracking for the `mu_stalled` event.
     last_mu: Option<f64>,
     mu_stall: u32,
+    /// True while between `pre_restoration_entry` and
+    /// `post_restoration_exit` — marks pauses fired by the inner IPM.
+    in_restoration: bool,
     /// Once true, never pause again (`detach`).
     detached: bool,
     /// Whether the JSON `hello` handshake has been emitted (once per
@@ -593,6 +620,7 @@ impl SolverDebugger {
             watchpoints: Vec::new(),
             last_mu: None,
             mu_stall: 0,
+            in_restoration: false,
             detached: false,
             hello_sent: false,
             pause_iters: true,
@@ -1542,8 +1570,11 @@ impl SolverDebugger {
     fn cmd_commands(&mut self, rest: &[&str]) -> CmdOut {
         let Some(iter) = rest.first().and_then(|s| s.parse::<i32>().ok()) else {
             if rest.is_empty() {
-                let mut items: Vec<(i32, Vec<String>)> =
-                    self.bp_commands.iter().map(|(k, v)| (*k, v.clone())).collect();
+                let mut items: Vec<(i32, Vec<String>)> = self
+                    .bp_commands
+                    .iter()
+                    .map(|(k, v)| (*k, v.clone()))
+                    .collect();
                 items.sort_by_key(|(k, _)| *k);
                 let lines = if items.is_empty() {
                     vec!["no breakpoint command lists".into()]
@@ -1555,7 +1586,9 @@ impl SolverDebugger {
                 };
                 return CmdOut::ok(lines);
             }
-            return CmdOut::err("usage: commands <iter> <cmd> ; <cmd> …  (or: commands <iter> clear)");
+            return CmdOut::err(
+                "usage: commands <iter> <cmd> ; <cmd> …  (or: commands <iter> clear)",
+            );
         };
         let tail = rest[1..].join(" ");
         let tail = tail.trim();
@@ -1569,8 +1602,11 @@ impl SolverDebugger {
             .filter(|s| !s.is_empty())
             .collect();
         self.bp_commands.insert(iter, cmds.clone());
-        CmdOut::ok(vec![format!("commands for iter {iter}: {}", cmds.join(" ; "))])
-            .with_data(serde_json::json!({"iter": iter, "commands": cmds}))
+        CmdOut::ok(vec![format!(
+            "commands for iter {iter}: {}",
+            cmds.join(" ; ")
+        )])
+        .with_data(serde_json::json!({"iter": iter, "commands": cmds}))
     }
 
     /// `diff` — what changed in the iterate since the previous captured
@@ -1754,10 +1790,16 @@ impl SolverDebugger {
                         ctx.inf_du(),
                     );
                 } else {
+                    let resto = if self.in_restoration {
+                        " [restoration]"
+                    } else {
+                        ""
+                    };
                     eprintln!(
-                        "\n── pounce-dbg ── iter {} @{}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
+                        "\n── pounce-dbg ── iter {} @{}{}  mu={:.3e}  obj={:.6e}  inf_pr={:.2e}  inf_du={:.2e}",
                         ctx.iter(),
                         ctx.checkpoint().as_str(),
+                        resto,
                         ctx.mu(),
                         ctx.objective(),
                         ctx.inf_pr(),
@@ -1793,6 +1835,7 @@ impl SolverDebugger {
                     "event": "pause",
                     "checkpoint": ctx.checkpoint().as_str(),
                     "status": ctx.status(),
+                    "in_restoration": self.in_restoration,
                     "iter": ctx.iter(),
                     "mu": ctx.mu(),
                     "objective": ctx.objective(),
@@ -2063,6 +2106,12 @@ impl DebugHook for SolverDebugger {
         }
 
         let cp = ctx.checkpoint();
+        // Track the restoration bracket so inner-IPM pauses are flagged.
+        match cp {
+            Checkpoint::PreRestoration => self.in_restoration = true,
+            Checkpoint::PostRestoration => self.in_restoration = false,
+            _ => {}
+        }
         let is_iter_start = matches!(cp, Checkpoint::IterStart);
 
         // At each iteration top, snapshot the primal-dual state (cheap —

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -49,7 +49,7 @@ use rustyline::completion::{Completer, Pair};
 use rustyline::error::ReadlineError;
 use rustyline::history::FileHistory;
 use rustyline::{Context, Editor, Helper, Highlighter, Hinter, Validator};
-use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -57,8 +57,8 @@ use std::rc::Rc;
 /// All command verbs, for `help` and `complete`.
 const COMMANDS: &[&str] = &[
     "help", "info", "print", "step", "stepi", "continue", "run", "break", "tbreak", "watchpoint",
-    "stop-at", "set", "opt", "complete", "viz", "save", "goto", "restart", "resolve", "ask",
-    "watch", "diff", "source", "progress", "detach", "quit",
+    "commands", "stop-at", "set", "opt", "complete", "viz", "save", "goto", "restart", "resolve",
+    "ask", "watch", "diff", "source", "progress", "detach", "quit",
 ];
 
 /// Events a user can `break on` (advertised in `hello.events`). Each is
@@ -514,6 +514,9 @@ pub struct SolverDebugger {
     breaks: Vec<i32>,
     /// One-shot iteration breakpoints (`tbreak`), removed when hit.
     temp_breaks: Vec<i32>,
+    /// Command lists attached to iteration breakpoints (`commands N …`):
+    /// run automatically when iteration N is paused at.
+    bp_commands: HashMap<i32, Vec<String>>,
     /// Conditional breakpoints (`break if mu<1e-4`): pause when any holds.
     conds: Vec<Condition>,
     /// Data watchpoints (`watchpoint x[3]`): pause when a value changes.
@@ -585,6 +588,7 @@ impl SolverDebugger {
             run_to: None,
             breaks: Vec::new(),
             temp_breaks: Vec::new(),
+            bp_commands: HashMap::new(),
             conds: Vec::new(),
             watchpoints: Vec::new(),
             last_mu: None,
@@ -817,6 +821,7 @@ impl SolverDebugger {
                 None => CmdOut::err("usage: tbreak <iteration>"),
             },
             "watchpoint" | "wp" => self.cmd_watchpoint(rest),
+            "commands" => self.cmd_commands(rest),
             "stop-at" | "stopat" => self.cmd_stop_at(rest),
             "progress" => match rest.first().copied() {
                 Some("on") | None => {
@@ -877,6 +882,7 @@ impl SolverDebugger {
             "                           tiny_step|ls_rejected|mu_stalled|nan".into(),
             "  tbreak <N>               one-shot breakpoint (deletes after firing)".into(),
             "  watchpoint <blk>[<i>] [τ] pause when a value changes by > τ (alias wp)".into(),
+            "  commands <N> <c>;<c>…    auto-run commands when iter N's breakpoint hits".into(),
             "  set mu <v>               overwrite the barrier parameter".into(),
             "  set <blk>[<i>] <v>       overwrite one component (e.g. set x[2] 1.5)".into(),
             "  set <blk> <v0,v1,...>    overwrite a whole block".into(),
@@ -1529,6 +1535,44 @@ impl SolverDebugger {
         }
     }
 
+    /// `commands <iter> <cmd> ; <cmd> …` — attach an auto-run command
+    /// list to the breakpoint at iteration `iter` (e.g.
+    /// `commands 5 set mu 0.1 ; continue`). `commands <iter> clear`
+    /// removes it; `commands` lists all.
+    fn cmd_commands(&mut self, rest: &[&str]) -> CmdOut {
+        let Some(iter) = rest.first().and_then(|s| s.parse::<i32>().ok()) else {
+            if rest.is_empty() {
+                let mut items: Vec<(i32, Vec<String>)> =
+                    self.bp_commands.iter().map(|(k, v)| (*k, v.clone())).collect();
+                items.sort_by_key(|(k, _)| *k);
+                let lines = if items.is_empty() {
+                    vec!["no breakpoint command lists".into()]
+                } else {
+                    items
+                        .iter()
+                        .map(|(k, v)| format!("iter {k}: {}", v.join(" ; ")))
+                        .collect()
+                };
+                return CmdOut::ok(lines);
+            }
+            return CmdOut::err("usage: commands <iter> <cmd> ; <cmd> …  (or: commands <iter> clear)");
+        };
+        let tail = rest[1..].join(" ");
+        let tail = tail.trim();
+        if tail.is_empty() || tail == "clear" {
+            self.bp_commands.remove(&iter);
+            return CmdOut::ok(vec![format!("cleared commands for iteration {iter}")]);
+        }
+        let cmds: Vec<String> = tail
+            .split(';')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        self.bp_commands.insert(iter, cmds.clone());
+        CmdOut::ok(vec![format!("commands for iter {iter}: {}", cmds.join(" ; "))])
+            .with_data(serde_json::json!({"iter": iter, "commands": cmds}))
+    }
+
     /// `diff` — what changed in the iterate since the previous captured
     /// iteration: per-block max |Δ| (and where), plus Δμ.
     fn cmd_diff(&self, ctx: &DebugCtx) -> CmdOut {
@@ -2094,8 +2138,26 @@ impl DebugHook for SolverDebugger {
         // Consume one-shot arming; commands re-arm as needed.
         self.step = false;
         self.sub_step = false;
-        self.ensure_editor();
         self.emit_pause(ctx, reason.as_deref());
+
+        // Auto-run any command list attached to this iteration's
+        // breakpoint (`commands N …`). If it resumes/stops, honor that
+        // without dropping to the prompt.
+        if is_iter_start {
+            if let Some(cmds) = self.bp_commands.get(&ctx.iter()).cloned() {
+                for c in cmds {
+                    let out = self.dispatch(&c, ctx);
+                    self.emit_result(&c, &out, None);
+                    match out.flow {
+                        Flow::Resume => return DebugAction::Resume,
+                        Flow::Stop => return DebugAction::Stop,
+                        Flow::Stay => {}
+                    }
+                }
+            }
+        }
+
+        self.ensure_editor();
         self.prompt_loop(ctx)
     }
 }

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -25,6 +25,7 @@
 //!       4. `{"event":"terminated",…}` — emitted by the CLI after the
 //!          solve, carrying the final status, iteration count, objective,
 //!          and eval counts.
+//!
 //!     Commands may be a bare string or `{"cmd":…,"args":[…],"id":…}`.
 //!
 //! Flow / exit model: the debugger pauses at the *first* checkpoint (so
@@ -36,12 +37,18 @@
 //!   * `quit`     — stop now (surfaces as `UserRequestedStop`).
 //!   * stdin EOF  — REPL (Ctrl-D) detaches and finishes; JSON (pipe
 //!     closed → client gone) aborts the solve.
+//!
 //! Every non-kill path ends with a `terminated` event in JSON mode.
 
 use crate::cli::DebugMode;
 use pounce_algorithm::debug::{DebugAction, DebugCtx, DebugHook, BLOCK_NAMES};
 use pounce_common::reg_options::{DefaultValue, OptionType, RegisteredOptions};
-use std::io::Write;
+use rustyline::completion::{Completer, Pair};
+use rustyline::error::ReadlineError;
+use rustyline::history::FileHistory;
+use rustyline::{Context, Editor, Helper, Highlighter, Hinter, Validator};
+use std::io::{IsTerminal, Write};
+use std::path::PathBuf;
 use std::rc::Rc;
 
 /// All command verbs, for `help` and `complete`.
@@ -204,6 +211,87 @@ impl Condition {
     }
 }
 
+/// Context-sensitive completion candidates for the REPL line editor (and
+/// the `complete` command). `before` is the line text up to the start of
+/// the word being completed; `word` is that partial word. Pure so it can
+/// be unit-tested without a terminal.
+fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &str) -> Vec<String> {
+    let toks: Vec<&str> = before.split_whitespace().collect();
+    let starts = |opts: &[&str]| -> Vec<String> {
+        opts.iter()
+            .filter(|c| c.starts_with(word))
+            .map(|c| c.to_string())
+            .collect()
+    };
+    let opt_names = || -> Vec<String> {
+        reg.map(|r| {
+            r.registered_options_in_order()
+                .iter()
+                .map(|o| o.name.clone())
+                .filter(|n| n.starts_with(word))
+                .collect()
+        })
+        .unwrap_or_default()
+    };
+    match toks.as_slice() {
+        [] => starts(COMMANDS),
+        ["set"] => {
+            let mut v = starts(&["mu", "opt"]);
+            v.extend(starts(&BLOCK_NAMES));
+            v
+        }
+        ["set", "opt"] | ["opt"] | ["options"] => opt_names(),
+        ["break", "if"] | ["b", "if"] => starts(METRICS),
+        ["break"] | ["b"] => starts(&["if", "clear", "del"]),
+        ["print"] | ["p"] => {
+            let mut v = starts(&BLOCK_NAMES);
+            v.extend(starts(&["mu", "obj", "inf_pr", "inf_du", "err", "iter"]));
+            v
+        }
+        ["viz"] | ["plot"] => {
+            let mut v = starts(&BLOCK_NAMES);
+            v.extend(starts(&["kkt", "L"]));
+            v
+        }
+        ["complete"] => starts(COMMANDS),
+        _ => Vec::new(),
+    }
+}
+
+/// rustyline helper: supplies Tab completion against the live command /
+/// option vocabulary. Hinting / highlighting / validation are the
+/// no-op derived defaults.
+#[derive(Helper, Hinter, Highlighter, Validator)]
+struct DbgHelper {
+    reg: Option<Rc<RegisteredOptions>>,
+}
+
+impl Completer for DbgHelper {
+    type Candidate = Pair;
+    fn complete(
+        &self,
+        line: &str,
+        pos: usize,
+        _ctx: &Context<'_>,
+    ) -> rustyline::Result<(usize, Vec<Pair>)> {
+        let before = &line[..pos];
+        let start = before
+            .rfind(char::is_whitespace)
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let word = &before[start..];
+        let cands = completion_candidates(self.reg.as_deref(), &before[..start], word);
+        let pairs = cands
+            .into_iter()
+            .map(|c| Pair {
+                display: c.clone(),
+                replacement: c,
+            })
+            .collect();
+        Ok((start, pairs))
+    }
+}
+
 pub struct SolverDebugger {
     mode: DebugMode,
     reg: Option<Rc<RegisteredOptions>>,
@@ -220,6 +308,12 @@ pub struct SolverDebugger {
     /// Whether the JSON `hello` handshake has been emitted (once per
     /// session, at the first checkpoint).
     hello_sent: bool,
+    /// rustyline editor for the human REPL on a TTY (history + Tab +
+    /// Ctrl-R). `None` for JSON mode or when stdin isn't a terminal, in
+    /// which case a plain line reader is used.
+    editor: Option<Editor<DbgHelper, FileHistory>>,
+    /// Where REPL history is persisted, if a home directory was found.
+    hist_path: Option<PathBuf>,
     /// Option edits accepted at the prompt. Validated against the
     /// registry; surfaced to the caller after the solve. Not applied to
     /// already-built strategies mid-solve (see `staged_options`).
@@ -239,6 +333,8 @@ impl SolverDebugger {
             conds: Vec::new(),
             detached: false,
             hello_sent: false,
+            editor: None,
+            hist_path: None,
             staged: Vec::new(),
         }
     }
@@ -775,11 +871,68 @@ impl SolverDebugger {
         emit_json(&ev);
     }
 
-    fn prompt(&self) {
+    /// Lazily build the rustyline editor for an interactive REPL on a
+    /// TTY. No-op for JSON mode, non-terminal stdin, or if construction
+    /// fails — those paths fall back to a plain line reader.
+    fn ensure_editor(&mut self) {
+        if !matches!(self.mode, DebugMode::Repl)
+            || self.editor.is_some()
+            || !std::io::stdin().is_terminal()
+        {
+            return;
+        }
+        let mut ed: Editor<DbgHelper, FileHistory> = match Editor::new() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        ed.set_helper(Some(DbgHelper {
+            reg: self.reg.clone(),
+        }));
+        let path = std::env::var_os("HOME")
+            .or_else(|| std::env::var_os("USERPROFILE"))
+            .map(|h| PathBuf::from(h).join(".pounce_dbg_history"));
+        if let Some(p) = &path {
+            let _ = ed.load_history(p);
+        }
+        self.hist_path = path;
+        self.editor = Some(ed);
+    }
+
+    /// Read one command line. Returns `None` on EOF. Uses rustyline when
+    /// an editor is active (history / Tab / Ctrl-R); otherwise a plain
+    /// reader with a stderr prompt (REPL) or no prompt (JSON).
+    fn next_command_line(&mut self) -> Option<String> {
         if let DebugMode::Repl = self.mode {
+            if let Some(ed) = self.editor.as_mut() {
+                return match ed.readline("pounce-dbg> ") {
+                    Ok(l) => {
+                        let _ = ed.add_history_entry(l.as_str());
+                        if let Some(p) = &self.hist_path {
+                            let _ = ed.save_history(p);
+                        }
+                        Some(l)
+                    }
+                    // Ctrl-C: abandon the current line, reprompt.
+                    Err(ReadlineError::Interrupted) => Some(String::new()),
+                    // Ctrl-D / closed input: EOF.
+                    Err(ReadlineError::Eof) => None,
+                    Err(_) => None,
+                };
+            }
             let _ = write!(std::io::stderr(), "pounce-dbg> ");
             let _ = std::io::stderr().flush();
         }
+        read_stdin_line()
+    }
+}
+
+/// Plain blocking line read from stdin; `None` on EOF.
+fn read_stdin_line() -> Option<String> {
+    let mut line = String::new();
+    match std::io::stdin().read_line(&mut line) {
+        Ok(0) => None,
+        Ok(_) => Some(line),
+        Err(_) => None,
     }
 }
 
@@ -802,14 +955,13 @@ impl DebugHook for SolverDebugger {
         }
         // Consume the one-shot step arming; commands re-arm as needed.
         self.step = false;
+        self.ensure_editor();
         self.emit_pause(ctx, cond_hit.as_deref());
 
-        let stdin = std::io::stdin();
         loop {
-            self.prompt();
-            let mut line = String::new();
-            match stdin.read_line(&mut line) {
-                Ok(0) => {
+            let line = match self.next_command_line() {
+                Some(l) => l,
+                None => {
                     // EOF on stdin. REPL (Ctrl-D) means "let it run" —
                     // detach and finish, pdb-style. In JSON mode a closed
                     // pipe means the controlling client went away, so
@@ -822,9 +974,7 @@ impl DebugHook for SolverDebugger {
                         DebugMode::Json => DebugAction::Stop,
                     };
                 }
-                Ok(_) => {}
-                Err(_) => return DebugAction::Resume,
-            }
+            };
             let parsed = parse_command(&line, self.mode);
             let cmd = parsed.command.trim().to_string();
             if cmd.is_empty() {
@@ -1059,6 +1209,32 @@ mod tests {
         assert!(Condition::parse("inf_pr 1e-6").is_err()); // no operator
         assert!(Condition::parse("bogus<1").is_err()); // unknown metric
         assert!(Condition::parse("mu<abc").is_err()); // bad threshold
+    }
+
+    #[test]
+    fn completion_is_context_sensitive() {
+        // First token completes command verbs.
+        let c = completion_candidates(None, "", "co");
+        assert!(c.contains(&"continue".to_string()));
+        assert!(c.contains(&"complete".to_string()));
+        assert!(!c.contains(&"step".to_string()));
+
+        // After `set`, both mu/opt and block names are offered.
+        let c = completion_candidates(None, "set ", "");
+        assert!(c.contains(&"mu".to_string()));
+        assert!(c.contains(&"opt".to_string()));
+        assert!(c.contains(&"x".to_string()));
+
+        // After `break if`, metric names.
+        let c = completion_candidates(None, "break if ", "inf");
+        assert!(c.contains(&"inf_pr".to_string()));
+        assert!(c.contains(&"inf_du".to_string()));
+        assert!(!c.contains(&"mu".to_string()));
+
+        // `print` completes blocks + scalar keywords.
+        let c = completion_candidates(None, "print ", "");
+        assert!(c.contains(&"x".to_string()));
+        assert!(c.contains(&"obj".to_string()));
     }
 
     #[test]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -419,7 +419,9 @@ fn completion_candidates(reg: Option<&RegisteredOptions>, before: &str, word: &s
         ["break"] | ["b"] => starts(&["if", "on", "clear", "del"]),
         ["print"] | ["p"] => {
             let mut v = starts(&BLOCK_NAMES);
-            v.extend(starts(&["mu", "obj", "inf_pr", "inf_du", "err", "iter"]));
+            v.extend(starts(&[
+                "mu", "obj", "inf_pr", "inf_du", "err", "iter", "kkt",
+            ]));
             v
         }
         ["viz"] | ["plot"] => {
@@ -725,7 +727,7 @@ impl SolverDebugger {
             "commands:".into(),
             "  info | i                 summary of the current iterate".into(),
             "  print | p <what>         x|s|y_c|y_d|z_l|z_u|v_l|v_u | dx (step) |".into(),
-            "                           mu|obj|inf_pr|inf_du|err|iter".into(),
+            "                           mu|obj|inf_pr|inf_du|err|iter | kkt (inertia+reg)".into(),
             "  step | s | n             run one iteration, pause again".into(),
             "  stepi | si | step sub    run to the next checkpoint (into sub-iteration phases)".into(),
             "  progress [on|off]        toggle per-iteration progress events (JSON mode)".into(),
@@ -789,6 +791,9 @@ impl SolverDebugger {
         let Some(&what) = rest.first() else {
             return self.cmd_info(ctx);
         };
+        if what == "kkt" {
+            return self.cmd_print_kkt(ctx);
+        }
         // step / delta blocks: `dx`, `ds`, ... or `delta_x`.
         let delta = what.strip_prefix("d").filter(|b| BLOCK_NAMES.contains(b));
         if BLOCK_NAMES.contains(&what) {
@@ -820,6 +825,49 @@ impl SolverDebugger {
             CmdOut::ok(vec![format!("{what} = {val:.10e}")])
                 .with_data(serde_json::json!({"name": what, "value": val}))
         }
+    }
+
+    /// `print kkt` — inertia + regularization of the factored augmented
+    /// system. Only meaningful at/after `after_search_dir`.
+    fn cmd_print_kkt(&self, ctx: &DebugCtx) -> CmdOut {
+        let Some(k) = ctx.kkt() else {
+            return CmdOut::err(
+                "no KKT factorization yet — stop at `after_search_dir` (e.g. `stop-at kkt`)",
+            );
+        };
+        let inertia = if k.provides_inertia {
+            format!(
+                "n+={} n-={} (expected n-={}) → {}",
+                k.n_pos,
+                k.n_neg,
+                k.expected_neg,
+                if k.inertia_correct {
+                    "correct"
+                } else {
+                    "WRONG (step stabilized)"
+                }
+            )
+        } else {
+            "n/a (backend reports no inertia)".to_string()
+        };
+        let lines = vec![
+            format!("dim       = {}", k.dim),
+            format!("inertia   = {inertia}"),
+            format!("delta_w   = {:.6e}   (primal regularization)", k.delta_w),
+            format!("delta_c   = {:.6e}   (dual regularization)", k.delta_c),
+            format!("status    = {}", k.status),
+        ];
+        CmdOut::ok(lines).with_data(serde_json::json!({
+            "dim": k.dim,
+            "n_pos": k.n_pos,
+            "n_neg": k.n_neg,
+            "expected_neg": k.expected_neg,
+            "provides_inertia": k.provides_inertia,
+            "inertia_correct": k.inertia_correct,
+            "delta_w": k.delta_w,
+            "delta_c": k.delta_c,
+            "status": k.status,
+        }))
     }
 
     fn cmd_run(&mut self, rest: &[&str]) -> CmdOut {
@@ -1220,14 +1268,35 @@ impl SolverDebugger {
         let Some(&target) = rest.first() else {
             return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
         };
-        // Live KKT / L factor are assembled inside the search-direction
-        // solver during compute_search_direction, not at the iteration
-        // checkpoint, so they are not reachable from here yet.
-        if target == "kkt" || target == "L" {
+        // KKT inertia/regularization are available at `after_search_dir`
+        // and viz'd as a small JSON report. The full matrix / L-factor
+        // *pattern* (a heatmap) still comes from the offline dump, which
+        // already extracts it from the backend.
+        if target == "kkt" {
+            let Some(k) = ctx.kkt() else {
+                return CmdOut::err(
+                    "no KKT factorization yet — stop at `after_search_dir` (e.g. `stop-at kkt`)",
+                );
+            };
+            let payload = serde_json::json!({
+                "label": "kkt", "iter": ctx.iter(),
+                "dim": k.dim, "n_pos": k.n_pos, "n_neg": k.n_neg,
+                "expected_neg": k.expected_neg, "inertia_correct": k.inertia_correct,
+                "delta_w": k.delta_w, "delta_c": k.delta_c, "status": k.status,
+            });
+            return match write_json_and_open("kkt", ctx.iter(), &payload) {
+                Ok((path, viewer)) => {
+                    CmdOut::ok(vec![format!("wrote {path}; opened with `{viewer}`")])
+                        .with_data(serde_json::json!({"path": path, "viewer": viewer}))
+                }
+                Err(e) => CmdOut::err(e),
+            };
+        }
+        if target == "L" {
             return CmdOut::err(
-                "live KKT/L visualization needs the factored augmented system, which isn't \
-                 exposed at the iteration checkpoint yet. For now, re-run with \
-                 `--dump kkt:<iter>+L+Lvals --dump-dir DIR` and open the per-iter dump.",
+                "the L-factor pattern (heatmap) isn't captured at the checkpoint; re-run with \
+                 `--dump kkt:<iter>+L+Lvals --dump-dir DIR` and open the per-iter dump. \
+                 `print kkt` / `viz kkt` give the inertia + regularization here.",
             );
         }
         // Resolve the vector to visualize.
@@ -1373,6 +1442,7 @@ impl SolverDebugger {
                 "request_ids": true,
                 "viz": ["block", "delta"],
                 "save": true,
+                "kkt_inspect": true,
                 "rewind": "primal_dual",
                 "resolve": self.restart.is_some(),
                 "terminal_checkpoint": true,
@@ -1672,9 +1742,19 @@ fn default_str(d: &DefaultValue) -> String {
 /// `{}` is replaced by the path; if absent, the path is appended), else
 /// the platform default (`xdg-open` on Linux, `open` on macOS).
 fn write_and_open(label: &str, iter: i32, vals: &[f64]) -> Result<(String, String), String> {
+    let payload = serde_json::json!({"label": label, "iter": iter, "values": vals});
+    write_json_and_open(label, iter, &payload)
+}
+
+/// Write a JSON artifact to a temp file and open it in an external viewer
+/// (`POUNCE_DBG_VIEWER`, else `xdg-open`/`open`). Shared by `viz`.
+fn write_json_and_open(
+    label: &str,
+    iter: i32,
+    payload: &serde_json::Value,
+) -> Result<(String, String), String> {
     let dir = std::env::temp_dir();
     let path = dir.join(format!("pounce-dbg-{label}-iter{iter}.json"));
-    let payload = serde_json::json!({"label": label, "iter": iter, "values": vals});
     std::fs::write(&path, payload.to_string()).map_err(|e| format!("write failed: {e}"))?;
     let path_s = path.to_string_lossy().to_string();
 

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -120,6 +120,7 @@ const CHECKPOINTS: &[&str] = &[
     "after_mu",
     "after_search_dir",
     "after_step",
+    "step_rejected",
     "pre_restoration_entry",
     "post_restoration_exit",
     "terminated",
@@ -301,7 +302,11 @@ impl CmpOp {
             CmpOp::Le => lhs <= rhs,
             CmpOp::Gt => lhs > rhs,
             CmpOp::Ge => lhs >= rhs,
-            // Tolerant equality so float metrics aren't impossible to hit.
+            // Tolerant equality so float metrics aren't impossible to hit:
+            // |lhs − rhs| ≤ 1e-12·max(1, |rhs|). Note this is relative for
+            // large rhs but collapses to an absolute 1e-12 when rhs == 0, so
+            // `obj==0` means "|obj| ≤ 1e-12" and `iter==N` is exact for the
+            // integer-valued metrics.
             CmpOp::Eq => (lhs - rhs).abs() <= 1e-12 * rhs.abs().max(1.0),
         }
     }
@@ -1201,6 +1206,7 @@ impl SolverDebugger {
                 "mu" | "after_mu" => Some("after_mu"),
                 "kkt" | "search_dir" | "after_search_dir" => Some("after_search_dir"),
                 "step" | "after_step" => Some("after_step"),
+                "rejected" | "ls_rejected" | "step_rejected" => Some("step_rejected"),
                 "resto" | "restoration" | "pre_restoration_entry" => Some("pre_restoration_entry"),
                 "resto_exit" | "post_restoration_exit" => Some("post_restoration_exit"),
                 "iter" | "iter_start" => Some("iter_start"),
@@ -1831,8 +1837,15 @@ impl SolverDebugger {
                 }
                 for w in &self.watches {
                     let out = self.cmd_print(&[w.as_str()], ctx);
-                    for l in &out.lines {
-                        eprintln!("   watch {l}");
+                    if out.ok {
+                        for l in &out.lines {
+                            eprintln!("   watch {l}");
+                        }
+                    } else {
+                        // Don't spam the full error every pause for a target
+                        // that isn't available yet (e.g. `kkt` before a
+                        // factorization) — a compact note instead.
+                        eprintln!("   watch {w}: (n/a)");
                     }
                 }
             }

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -1375,25 +1375,28 @@ impl SolverDebugger {
         }
     }
 
-    fn cmd_viz(&self, rest: &[&str], ctx: &DebugCtx) -> CmdOut {
+    fn cmd_viz(&self, rest: &[&str], ctx: &mut DebugCtx) -> CmdOut {
         let Some(&target) = rest.first() else {
             return CmdOut::err("usage: viz <x|s|y_c|...|dx|kkt|L>");
         };
-        // KKT inertia/regularization are available at `after_search_dir`
-        // and viz'd as a small JSON report. The full matrix / L-factor
-        // *pattern* (a heatmap) still comes from the offline dump, which
-        // already extracts it from the backend.
+        // `viz kkt` writes the assembled augmented-system matrix (triplets
+        // → heatmap) plus the inertia/regularization summary.
         if target == "kkt" {
             let Some(k) = ctx.kkt() else {
                 return CmdOut::err(
                     "no KKT factorization yet — stop at `after_search_dir` (e.g. `stop-at kkt`)",
                 );
             };
+            let matrix = ctx.kkt_matrix().map(|(dim, irn, jcn, vals)| {
+                serde_json::json!({"dim": dim, "irn": irn, "jcn": jcn, "vals": vals,
+                                   "format": "triplet_1based_lower"})
+            });
             let payload = serde_json::json!({
                 "label": "kkt", "iter": ctx.iter(),
                 "dim": k.dim, "n_pos": k.n_pos, "n_neg": k.n_neg,
                 "expected_neg": k.expected_neg, "inertia_correct": k.inertia_correct,
                 "delta_w": k.delta_w, "delta_c": k.delta_c, "status": k.status,
+                "matrix": matrix,
             });
             return match write_json_and_open("kkt", ctx.iter(), &payload) {
                 Ok((path, viewer)) => {
@@ -1403,12 +1406,32 @@ impl SolverDebugger {
                 Err(e) => CmdOut::err(e),
             };
         }
+        // `viz L` writes the LDLᵀ factor triplets. Capture is opt-in (the
+        // factor is the expensive piece), so the first call arms it.
         if target == "L" {
-            return CmdOut::err(
-                "the L-factor pattern (heatmap) isn't captured at the checkpoint; re-run with \
-                 `--dump kkt:<iter>+L+Lvals --dump-dir DIR` and open the per-iter dump. \
-                 `print kkt` / `viz kkt` give the inertia + regularization here.",
-            );
+            match ctx.kkt_l_factor() {
+                Some((n, perm, l_irn, l_jcn, l_vals)) => {
+                    let payload = serde_json::json!({
+                        "label": "L", "iter": ctx.iter(), "n": n, "perm": perm,
+                        "l_irn": l_irn, "l_jcn": l_jcn, "l_vals": l_vals,
+                        "format": "strict_lower_1based_permuted",
+                    });
+                    return match write_json_and_open("L", ctx.iter(), &payload) {
+                        Ok((path, viewer)) => {
+                            CmdOut::ok(vec![format!("wrote {path}; opened with `{viewer}`")])
+                                .with_data(serde_json::json!({"path": path, "viewer": viewer}))
+                        }
+                        Err(e) => CmdOut::err(e),
+                    };
+                }
+                None => {
+                    ctx.request_l_factor();
+                    return CmdOut::err(
+                        "L-factor capture enabled — re-run `viz L` after the next \
+                         `after_search_dir` stop (`stepi` or `continue`).",
+                    );
+                }
+            }
         }
         // Resolve the vector to visualize.
         let (label, vals) = if BLOCK_NAMES.contains(&target) {

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -12,17 +12,31 @@
 //!     output go to **stderr** so they never interleave with the
 //!     solver's iteration table on stdout.
 //!   * [`DebugMode::Json`] — a newline-delimited JSON protocol on
-//!     stdin/stdout for an LLM agent or any program. Each pause emits one
-//!     `{"event":"pause",…}` object; each command yields one
-//!     `{"event":"result",…}` object. The solver's own stdout table is
-//!     suppressed in this mode (the caller sets `print_level=0`).
+//!     stdin/stdout for an LLM agent, visual debugger, or any program.
+//!     stdout is a *pure* protocol channel (the CLI routes the banner /
+//!     problem stats / summary to stderr and forces `print_level 0`), so
+//!     a GUI can consume it line-by-line. Session lifecycle:
+//!       1. `{"event":"hello",…}`  — once, up front: protocol version,
+//!          advertised capabilities, command / metric / block vocabulary.
+//!       2. `{"event":"pause",…}`  — at each stop: iter, μ, residuals,
+//!          dims, active breakpoints/conditions, and the firing `reason`.
+//!       3. `{"event":"result",…}` — one per command, echoing the
+//!          client's `request_id` for async correlation.
+//!       4. `{"event":"terminated",…}` — emitted by the CLI after the
+//!          solve, carrying the final status, iteration count, objective,
+//!          and eval counts.
+//!     Commands may be a bare string or `{"cmd":…,"args":[…],"id":…}`.
 //!
-//! Flow model: the debugger pauses at the *first* checkpoint (so you get
-//! control at iter 0), then only when re-armed — by `step` (pause next
-//! iteration), `break N` (pause at iter N), or `run N` (pause at iter
-//! ≥ N). `continue` clears all one-shot arming and runs to the next
-//! breakpoint; `detach` disables pausing entirely; `quit` stops the
-//! solve.
+//! Flow / exit model: the debugger pauses at the *first* checkpoint (so
+//! you get control at iter 0), then only when re-armed — by `step` (pause
+//! next iteration), `break N` (pause at iter N), `break if …` (pause on a
+//! condition), or `run N` (pause at iter ≥ N). Exit paths:
+//!   * `continue` — run to the next breakpoint, else to completion.
+//!   * `detach`   — stop pausing; run to completion.
+//!   * `quit`     — stop now (surfaces as `UserRequestedStop`).
+//!   * stdin EOF  — REPL (Ctrl-D) detaches and finishes; JSON (pipe
+//!     closed → client gone) aborts the solve.
+//! Every non-kill path ends with a `terminated` event in JSON mode.
 
 use crate::cli::DebugMode;
 use pounce_algorithm::debug::{DebugAction, DebugCtx, DebugHook, BLOCK_NAMES};
@@ -203,6 +217,9 @@ pub struct SolverDebugger {
     conds: Vec<Condition>,
     /// Once true, never pause again (`detach`).
     detached: bool,
+    /// Whether the JSON `hello` handshake has been emitted (once per
+    /// session, at the first checkpoint).
+    hello_sent: bool,
     /// Option edits accepted at the prompt. Validated against the
     /// registry; surfaced to the caller after the solve. Not applied to
     /// already-built strategies mid-solve (see `staged_options`).
@@ -221,6 +238,7 @@ impl SolverDebugger {
             breaks: Vec::new(),
             conds: Vec::new(),
             detached: false,
+            hello_sent: false,
             staged: Vec::new(),
         }
     }
@@ -704,8 +722,9 @@ impl SolverDebugger {
         }
     }
 
-    /// Emit a command result for the current front end.
-    fn emit_result(&self, command: &str, out: &CmdOut) {
+    /// Emit a command result for the current front end. `req_id` is the
+    /// client's request id (JSON mode), echoed for response correlation.
+    fn emit_result(&self, command: &str, out: &CmdOut, req_id: Option<&serde_json::Value>) {
         match self.mode {
             DebugMode::Repl => {
                 let stderr = std::io::stderr();
@@ -720,6 +739,7 @@ impl SolverDebugger {
             DebugMode::Json => {
                 let ev = serde_json::json!({
                     "event": "result",
+                    "request_id": req_id,
                     "command": command,
                     "ok": out.ok,
                     "output": out.lines,
@@ -728,6 +748,31 @@ impl SolverDebugger {
                 emit_json(&ev);
             }
         }
+    }
+
+    /// Emit the one-time JSON handshake: protocol version, the solver
+    /// version, advertised capabilities, and the command / metric
+    /// vocabulary — everything a visual debugger needs to configure its
+    /// UI before the first `pause`.
+    fn emit_hello(&self) {
+        let ev = serde_json::json!({
+            "event": "hello",
+            "protocol": "pounce-dbg/1",
+            "pounce_version": env!("CARGO_PKG_VERSION"),
+            "capabilities": {
+                "inspect": true,
+                "mutate_iterate": true,
+                "mutate_mu": true,
+                "conditional_breakpoints": true,
+                "request_ids": true,
+                "viz": ["block", "delta"],
+            },
+            "checkpoints": ["iter_start"],
+            "commands": COMMANDS,
+            "blocks": BLOCK_NAMES,
+            "metrics": METRICS,
+        });
+        emit_json(&ev);
     }
 
     fn prompt(&self) {
@@ -740,6 +785,12 @@ impl SolverDebugger {
 
 impl DebugHook for SolverDebugger {
     fn at_checkpoint(&mut self, ctx: &mut DebugCtx) -> DebugAction {
+        // One-time handshake so a JSON client learns the protocol /
+        // capabilities before the first pause.
+        if matches!(self.mode, DebugMode::Json) && !self.hello_sent {
+            self.emit_hello();
+            self.hello_sent = true;
+        }
         let iter = ctx.iter();
         // `should_pause` covers step / run / numeric breakpoints (and
         // disarms `run_to`); conditional breakpoints are evaluated
@@ -759,20 +810,28 @@ impl DebugHook for SolverDebugger {
             let mut line = String::new();
             match stdin.read_line(&mut line) {
                 Ok(0) => {
-                    // EOF: detach and let the solve finish.
-                    self.detached = true;
-                    return DebugAction::Resume;
+                    // EOF on stdin. REPL (Ctrl-D) means "let it run" —
+                    // detach and finish, pdb-style. In JSON mode a closed
+                    // pipe means the controlling client went away, so
+                    // abort the solve rather than run on headless.
+                    return match self.mode {
+                        DebugMode::Repl => {
+                            self.detached = true;
+                            DebugAction::Resume
+                        }
+                        DebugMode::Json => DebugAction::Stop,
+                    };
                 }
                 Ok(_) => {}
                 Err(_) => return DebugAction::Resume,
             }
-            let cmd = parse_command(&line, self.mode);
-            let cmd = cmd.trim().to_string();
+            let parsed = parse_command(&line, self.mode);
+            let cmd = parsed.command.trim().to_string();
             if cmd.is_empty() {
                 continue;
             }
             let out = self.dispatch(&cmd, ctx);
-            self.emit_result(&cmd, &out);
+            self.emit_result(&cmd, &out, parsed.id.as_ref());
             match out.flow {
                 Flow::Stay => continue,
                 Flow::Resume => return DebugAction::Resume,
@@ -782,9 +841,18 @@ impl DebugHook for SolverDebugger {
     }
 }
 
+/// A command read from the input stream: the resolved command string
+/// plus an optional client-supplied request id (echoed back as
+/// `request_id` so an async client can correlate responses).
+struct ParsedCmd {
+    command: String,
+    id: Option<serde_json::Value>,
+}
+
 /// In JSON mode a command line may be a bare string or a JSON object
-/// `{"cmd": "...", "args": [...]}`. Returns the resolved command string.
-fn parse_command(line: &str, mode: DebugMode) -> String {
+/// `{"cmd": "...", "args": [...], "id": <any>}`. Returns the resolved
+/// command string and the request id (if the object carried one).
+fn parse_command(line: &str, mode: DebugMode) -> ParsedCmd {
     let trimmed = line.trim();
     if let DebugMode::Json = mode {
         if trimmed.starts_with('{') {
@@ -802,11 +870,17 @@ fn parse_command(line: &str, mode: DebugMode) -> String {
                         }
                     }
                 }
-                return s;
+                return ParsedCmd {
+                    command: s,
+                    id: v.get("id").cloned(),
+                };
             }
         }
     }
-    trimmed.to_string()
+    ParsedCmd {
+        command: trimmed.to_string(),
+        id: None,
+    }
 }
 
 fn emit_json(v: &serde_json::Value) {
@@ -914,19 +988,24 @@ mod tests {
     #[test]
     fn json_command_object_is_flattened() {
         assert_eq!(
-            parse_command("{\"cmd\":\"print x\"}", DebugMode::Json),
+            parse_command("{\"cmd\":\"print x\"}", DebugMode::Json).command,
             "print x"
         );
-        assert_eq!(
-            parse_command(
-                "{\"cmd\":\"set\",\"args\":[\"x[0]\",\"1.5\"]}",
-                DebugMode::Json
-            ),
-            "set x[0] 1.5"
+        let p = parse_command(
+            "{\"cmd\":\"set\",\"args\":[\"x[0]\",\"1.5\"],\"id\":7}",
+            DebugMode::Json,
         );
-        // Bare strings pass through in either mode.
-        assert_eq!(parse_command("step\n", DebugMode::Json), "step");
-        assert_eq!(parse_command("  print x \n", DebugMode::Repl), "print x");
+        assert_eq!(p.command, "set x[0] 1.5");
+        // Request id is captured for response correlation.
+        assert_eq!(p.id, Some(serde_json::json!(7)));
+        // Bare strings pass through in either mode, with no id.
+        let s = parse_command("step\n", DebugMode::Json);
+        assert_eq!(s.command, "step");
+        assert!(s.id.is_none());
+        assert_eq!(
+            parse_command("  print x \n", DebugMode::Repl).command,
+            "print x"
+        );
     }
 
     #[test]

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -70,6 +70,54 @@ fn is_success_status(s: &str) -> bool {
     matches!(s, "Success" | "StopAtAcceptablePoint")
 }
 
+/// SIGINT → "break into the debugger at the next iteration". A first
+/// Ctrl-C sets a pending flag the hook consumes at the next checkpoint;
+/// a second Ctrl-C before that (or any Ctrl-C once detached) hard-exits,
+/// preserving the usual "abort" escape hatch.
+///
+/// At a rustyline prompt the terminal is in raw mode, so Ctrl-C arrives
+/// as input (handled as `Interrupted`, reprompt) rather than as SIGINT —
+/// this handler only fires while the solve is running.
+pub mod interrupt {
+    use nix::sys::signal::{self, SigHandler, Signal};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static PENDING: AtomicBool = AtomicBool::new(false);
+    static INSTALLED: AtomicBool = AtomicBool::new(false);
+
+    extern "C" fn handler(_sig: nix::libc::c_int) {
+        // `swap` returns the previous value: if a break was already
+        // pending and unconsumed, the user pressed Ctrl-C twice — abort.
+        if PENDING.swap(true, Ordering::SeqCst) {
+            // _exit is async-signal-safe; 130 = 128 + SIGINT.
+            unsafe { nix::libc::_exit(130) };
+        }
+    }
+
+    /// Install the handler once (idempotent). Call only when a debugger
+    /// is active, so a normal run keeps default Ctrl-C behavior.
+    pub fn install() {
+        if INSTALLED.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        // SAFETY: `handler` only touches an atomic and `_exit`.
+        unsafe {
+            let _ = signal::signal(Signal::SIGINT, SigHandler::Handler(handler));
+        }
+    }
+
+    /// Consume a pending break request (clears it).
+    pub fn take() -> bool {
+        PENDING.swap(false, Ordering::SeqCst)
+    }
+
+    /// Test-only: simulate a Ctrl-C without raising a real signal.
+    #[cfg(test)]
+    pub fn set_pending_for_test() {
+        PENDING.store(true, Ordering::SeqCst);
+    }
+}
+
 /// What to do after a command runs.
 enum Flow {
     /// Stay paused; keep reading commands.
@@ -328,6 +376,8 @@ pub struct SolverDebugger {
     pause_terminal: bool,
     /// At the terminal checkpoint, pause only when the solve failed.
     terminal_only_on_error: bool,
+    /// Honor a pending SIGINT (Ctrl-C) by pausing at the next iteration.
+    interruptible: bool,
     /// Per-iteration primal-dual snapshots for `goto`/`restart`, keyed by
     /// iteration index. Capped at [`SNAPSHOT_CAP`] (oldest evicted).
     snapshots: BTreeMap<i32, IterateSnapshot>,
@@ -361,6 +411,7 @@ impl SolverDebugger {
             pause_iters: true,
             pause_terminal: true,
             terminal_only_on_error: false,
+            interruptible: true,
             snapshots: BTreeMap::new(),
             editor: None,
             hist_path: None,
@@ -375,6 +426,18 @@ impl SolverDebugger {
             step: false,
             pause_iters: false,
             terminal_only_on_error: true,
+            ..Self::new(mode, reg)
+        }
+    }
+
+    /// Attach-on-demand: run normally and only drop in when the user
+    /// presses Ctrl-C (`--debug-on-interrupt`). No automatic iter or
+    /// terminal pauses.
+    pub fn on_interrupt(mode: DebugMode, reg: Option<Rc<RegisteredOptions>>) -> Self {
+        Self {
+            step: false,
+            pause_iters: false,
+            pause_terminal: false,
             ..Self::new(mode, reg)
         }
     }
@@ -1107,29 +1170,40 @@ impl DebugHook for SolverDebugger {
         if let Some(snap) = ctx.snapshot() {
             self.snapshots.insert(snap.iter(), snap);
             while self.snapshots.len() > SNAPSHOT_CAP {
-                let oldest = *self.snapshots.keys().next().unwrap();
+                let Some(&oldest) = self.snapshots.keys().next() else {
+                    break;
+                };
                 self.snapshots.remove(&oldest);
             }
         }
 
+        // A pending Ctrl-C forces a pause regardless of `pause_iters`.
+        let interrupted = self.interruptible && interrupt::take();
+
         let iter = ctx.iter();
         // `should_pause` covers step / run / numeric breakpoints (and
         // disarms `run_to`); conditional breakpoints are evaluated
-        // against the live state separately. `--debug-on-error` keeps
-        // `pause_iters` false so we never stop here.
+        // against the live state separately. `--debug-on-error` /
+        // `--debug-on-interrupt` keep `pause_iters` false so we only
+        // stop here on a Ctrl-C.
         let num_hit = self.pause_iters && self.should_pause(iter);
         let cond_hit = if self.pause_iters {
             self.matched_condition(ctx)
         } else {
             None
         };
-        if !num_hit && cond_hit.is_none() {
+        if !interrupted && !num_hit && cond_hit.is_none() {
             return DebugAction::Resume;
         }
         // Consume the one-shot step arming; commands re-arm as needed.
         self.step = false;
         self.ensure_editor();
-        self.emit_pause(ctx, cond_hit.as_deref());
+        let reason = cond_hit.as_deref().or(if interrupted {
+            Some("interrupt (Ctrl-C)")
+        } else {
+            None
+        });
+        self.emit_pause(ctx, reason);
         self.prompt_loop(ctx)
     }
 }
@@ -1425,6 +1499,22 @@ mod tests {
         assert!(CmpOp::Ge.eval(2.0, 2.0));
         assert!(CmpOp::Eq.eval(2.0, 2.0));
         assert!(!CmpOp::Eq.eval(2.0, 2.5));
+    }
+
+    #[test]
+    fn interrupt_is_consumed_once() {
+        interrupt::set_pending_for_test();
+        assert!(interrupt::take(), "first take sees the pending Ctrl-C");
+        assert!(!interrupt::take(), "second take is clear (consumed once)");
+    }
+
+    #[test]
+    fn on_interrupt_constructor_runs_free_but_interruptible() {
+        let d = SolverDebugger::on_interrupt(DebugMode::Repl, None);
+        assert!(!d.pause_iters, "on-interrupt does not pause each iter");
+        assert!(!d.pause_terminal, "on-interrupt does not pause at terminal");
+        assert!(d.interruptible, "on-interrupt honors Ctrl-C");
+        assert!(!d.step, "on-interrupt starts un-armed");
     }
 
     #[test]

--- a/crates/pounce-cli/src/lib.rs
+++ b/crates/pounce-cli/src/lib.rs
@@ -14,5 +14,6 @@ pub mod nl_reader;
 pub mod nl_tape;
 pub mod nl_writer;
 pub mod print;
+pub mod seeded_tnlp;
 pub mod sens;
 pub mod solve_report;

--- a/crates/pounce-cli/src/lib.rs
+++ b/crates/pounce-cli/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod builtin;
 pub mod cli;
 pub mod counting_tnlp;
+pub mod debug_repl;
 pub mod nl_external;
 pub mod nl_fbbt_translate;
 pub mod nl_hessian_program;

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -113,14 +113,14 @@ pub fn main() -> ExitCode {
             let _ = app.options_mut().read_from_str("print_level 0\n", true);
         }
         let reg = Some(std::rc::Rc::clone(app.registered_options()));
-        app.set_debug_hook(Box::new(build_debugger(
+        app.set_debug_hook(std::rc::Rc::new(std::cell::RefCell::new(build_debugger(
             mode,
             args.debug_on_error,
             args.debug_on_interrupt,
             args.debug_script.as_deref(),
             reg,
             restart_cell.clone(),
-        )));
+        ))));
         // Install the Ctrl-C → break-into-debugger handler. All debug
         // modes are interruptible; this only changes Ctrl-C behavior
         // when a debugger is active.
@@ -534,14 +534,14 @@ pub fn main() -> ExitCode {
             let reg = Some(std::rc::Rc::clone(app.registered_options()));
             // No script on re-solve — it ran once at the original first
             // pause; the user now drives the re-solve interactively.
-            app.set_debug_hook(Box::new(build_debugger(
+            app.set_debug_hook(std::rc::Rc::new(std::cell::RefCell::new(build_debugger(
                 mode,
                 args.debug_on_error,
                 args.debug_on_interrupt,
                 None,
                 reg,
                 restart_cell.clone(),
-            )));
+            ))));
         }
         eprintln!(
             "pounce: re-solving from saved point with {} option override(s)…",

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -110,14 +110,22 @@ pub fn main() -> ExitCode {
             let _ = app.options_mut().read_from_str("print_level 0\n", true);
         }
         let reg = Some(std::rc::Rc::clone(app.registered_options()));
-        app.set_debug_hook(Box::new(pounce_cli::debug_repl::SolverDebugger::new(
-            mode, reg,
-        )));
+        let dbg = if args.debug_on_error {
+            pounce_cli::debug_repl::SolverDebugger::on_error(mode, reg)
+        } else {
+            pounce_cli::debug_repl::SolverDebugger::new(mode, reg)
+        };
+        app.set_debug_hook(Box::new(dbg));
         eprintln!(
-            "pounce: interactive debugger enabled ({}). Type `help` at the prompt.",
+            "pounce: interactive debugger enabled ({}{}). Type `help` at the prompt.",
             match mode {
                 pounce_cli::cli::DebugMode::Repl => "repl",
                 pounce_cli::cli::DebugMode::Json => "json",
+            },
+            if args.debug_on_error {
+                ", on-error"
+            } else {
+                ""
             }
         );
     }

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -100,12 +100,13 @@ pub fn main() -> ExitCode {
     }
 
     // Interactive solver debugger (`--debug` / `--debug-json`). Installs
-    // a hook that pauses at each iteration. In JSON mode the solver's
-    // own per-iteration table on stdout would corrupt the protocol
-    // stream, so force `print_level 0` to silence it; the debugger emits
-    // structured pause/result events instead.
+    // a hook that pauses at each iteration. In JSON mode stdout becomes a
+    // pure protocol channel: the per-iteration table, banner, problem
+    // stats, and final summary are all silenced (the debugger and the
+    // post-solve `terminated` event carry that information instead).
+    let json_dbg = matches!(args.debug, Some(pounce_cli::cli::DebugMode::Json));
     if let Some(mode) = args.debug {
-        if matches!(mode, pounce_cli::cli::DebugMode::Json) {
+        if json_dbg {
             let _ = app.options_mut().read_from_str("print_level 0\n", true);
         }
         let reg = Some(std::rc::Rc::clone(app.registered_options()));
@@ -182,7 +183,7 @@ pub fn main() -> ExitCode {
         .ok()
         .and_then(|(v, f)| f.then_some(v))
         .unwrap_or(false);
-    if !suppress_banner {
+    if !suppress_banner && !json_dbg {
         print::print_logo();
         print::print_banner(backend_tag);
     }
@@ -236,7 +237,9 @@ pub fn main() -> ExitCode {
             }
         },
         ProblemSource::NlFile(path) => {
-            println!("Reading {}...", path.display());
+            if !json_dbg {
+                println!("Reading {}...", path.display());
+            }
             let t0 = std::time::Instant::now();
             match nl_reader::read_nl_file(path) {
                 Ok(prob) => {
@@ -248,10 +251,12 @@ pub fn main() -> ExitCode {
                         as Rc<RefCell<dyn pounce_nlp::expression_provider::ExpressionProvider>>);
                     let t: Rc<RefCell<dyn TNLP>> = nl_rc;
                     if let Some(info) = t.borrow_mut().get_nlp_info() {
-                        println!(
-                            "Parsed {} vars, {} cons, jac_nnz={}, h_nnz={} in {:.2}s",
-                            info.n, info.m, info.nnz_jac_g, info.nnz_h_lag, elapsed
-                        );
+                        if !json_dbg {
+                            println!(
+                                "Parsed {} vars, {} cons, jac_nnz={}, h_nnz={} in {:.2}s",
+                                info.n, info.m, info.nnz_jac_g, info.nnz_h_lag, elapsed
+                            );
+                        }
                     }
                     t
                 }
@@ -409,15 +414,19 @@ pub fn main() -> ExitCode {
                 .licq_verdict()
                 .map(|v| format!("{v:?}"))
                 .unwrap_or_else(|| "off".into());
-            println!(
-                "Presolve: tightened {} bounds ({} newly-finite), dropped {} redundant rows, LICQ={}",
-                tr.n_tightened, tr.n_new_finite, dropped, licq
-            );
-            if let Some(fr) = h.fbbt_report() {
+            if !json_dbg {
                 println!(
-                    "Presolve FBBT: {} sweeps, {} variable tightenings (Σ|Δ|={:.3e})",
-                    fr.iterations, fr.bound_updates, fr.total_tightening
+                    "Presolve: tightened {} bounds ({} newly-finite), dropped {} redundant rows, LICQ={}",
+                    tr.n_tightened, tr.n_new_finite, dropped, licq
                 );
+            }
+            if let Some(fr) = h.fbbt_report() {
+                if !json_dbg {
+                    println!(
+                        "Presolve FBBT: {} sweeps, {} variable tightenings (Σ|Δ|={:.3e})",
+                        fr.iterations, fr.bound_updates, fr.total_tightening
+                    );
+                }
                 if let Some(witness) = fr.infeasibility_witness {
                     eprintln!("pounce: FBBT detected infeasibility (witness constraint {witness})");
                 }
@@ -438,8 +447,11 @@ pub fn main() -> ExitCode {
 
     // Problem statistics. (The branded logo + copyright banner print
     // up-front, before the problem is read — see near the top of `run`.)
-    if let Some(stats) = print::collect_stats(&tnlp) {
-        print::print_problem_stats(&stats);
+    // Suppressed in JSON-debug mode so stdout stays a pure protocol stream.
+    if !json_dbg {
+        if let Some(stats) = print::collect_stats(&tnlp) {
+            print::print_problem_stats(&stats);
+        }
     }
 
     // Build diagnostics state from `--dump …` flags. None of these
@@ -458,16 +470,18 @@ pub fn main() -> ExitCode {
         }
     };
     if let Some(diag) = diagnostics_handle.as_ref() {
-        println!(
-            "Diagnostics: dumping to {} ({} categor{} configured)",
-            diag.dump_dir().display(),
-            diag.config.categories.len(),
-            if diag.config.categories.len() == 1 {
-                "y"
-            } else {
-                "ies"
-            },
-        );
+        if !json_dbg {
+            println!(
+                "Diagnostics: dumping to {} ({} categor{} configured)",
+                diag.dump_dir().display(),
+                diag.config.categories.len(),
+                if diag.config.categories.len() == 1 {
+                    "y"
+                } else {
+                    "ies"
+                },
+            );
+        }
         app.set_diagnostics(Rc::clone(diag));
     }
 
@@ -480,7 +494,28 @@ pub fn main() -> ExitCode {
     let status = app.optimize_tnlp(Rc::clone(&tnlp));
     let solve_stats = app.statistics();
     let counters = counting.borrow();
-    print::print_summary(status, &solve_stats, &counters);
+    if json_dbg {
+        // Pure protocol channel: emit a `terminated` lifecycle event in
+        // place of the human summary, so a visual debugger gets a clean
+        // end-of-session signal with the final status and stats.
+        let ev = serde_json::json!({
+            "event": "terminated",
+            "status": format!("{status:?}"),
+            "status_message": print::status_message(status),
+            "iterations": solve_stats.iteration_count,
+            "objective": solve_stats.final_objective,
+            "evals": {
+                "obj": counters.n_obj.get(),
+                "obj_grad": counters.n_grad_f.get(),
+                "constr": counters.n_g.get(),
+                "constr_jac": counters.n_jac_g.get(),
+                "hess": counters.n_h.get(),
+            },
+        });
+        println!("{ev}");
+    } else {
+        print::print_summary(status, &solve_stats, &counters);
+    }
     drop(counters); // release before JSON block (which re-borrows the wrapped TNLP).
 
     // Reduced Hessian: print to stderr (informational), mirroring

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -105,19 +105,21 @@ pub fn main() -> ExitCode {
     // stats, and final summary are all silenced (the debugger and the
     // post-solve `terminated` event carry that information instead).
     let json_dbg = matches!(args.debug, Some(pounce_cli::cli::DebugMode::Json));
+    // Shared slot the debugger's `resolve` command writes to; the
+    // post-solve loop below reads it to re-run with new options.
+    let restart_cell: pounce_cli::debug_repl::RestartCell = Rc::new(RefCell::new(None));
     if let Some(mode) = args.debug {
         if json_dbg {
             let _ = app.options_mut().read_from_str("print_level 0\n", true);
         }
         let reg = Some(std::rc::Rc::clone(app.registered_options()));
-        let dbg = if args.debug_on_error {
-            pounce_cli::debug_repl::SolverDebugger::on_error(mode, reg)
-        } else if args.debug_on_interrupt {
-            pounce_cli::debug_repl::SolverDebugger::on_interrupt(mode, reg)
-        } else {
-            pounce_cli::debug_repl::SolverDebugger::new(mode, reg)
-        };
-        app.set_debug_hook(Box::new(dbg));
+        app.set_debug_hook(Box::new(build_debugger(
+            mode,
+            args.debug_on_error,
+            args.debug_on_interrupt,
+            reg,
+            restart_cell.clone(),
+        )));
         // Install the Ctrl-C → break-into-debugger handler. All debug
         // modes are interruptible; this only changes Ctrl-C behavior
         // when a debugger is active.
@@ -508,7 +510,40 @@ pub fn main() -> ExitCode {
     // wrapper yet.
     let nlp_info_snapshot = tnlp.borrow_mut().get_nlp_info();
 
-    let status = app.optimize_tnlp(Rc::clone(&tnlp));
+    // Solve, with a re-solve loop: the debugger's `resolve` command stops
+    // the current solve and leaves a `RestartRequest` in `restart_cell`.
+    // We then apply the staged option overrides, seed the next solve from
+    // the captured `x` (via `SeededTnlp`), re-install a fresh debugger,
+    // and run again. Without `resolve`, this runs exactly once.
+    let mut solve_tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp);
+    let status = loop {
+        let st = app.optimize_tnlp(Rc::clone(&solve_tnlp));
+        let req = restart_cell.borrow_mut().take();
+        let Some(req) = req else { break st };
+        for (k, v) in &req.options {
+            if let Err(e) = app.options_mut().read_from_str(&format!("{k} {v}\n"), true) {
+                eprintln!("pounce: re-solve could not set {k}={v}: {e}");
+            }
+        }
+        solve_tnlp = Rc::new(RefCell::new(pounce_cli::seeded_tnlp::SeededTnlp::new(
+            Rc::clone(&tnlp),
+            req.seed_x,
+        )));
+        if let Some(mode) = args.debug {
+            let reg = Some(std::rc::Rc::clone(app.registered_options()));
+            app.set_debug_hook(Box::new(build_debugger(
+                mode,
+                args.debug_on_error,
+                args.debug_on_interrupt,
+                reg,
+                restart_cell.clone(),
+            )));
+        }
+        eprintln!(
+            "pounce: re-solving from saved point with {} option override(s)…",
+            req.options.len()
+        );
+    };
     let solve_stats = app.statistics();
     let counters = counting.borrow();
     if json_dbg {
@@ -701,6 +736,26 @@ pub fn main() -> ExitCode {
         _ if args.ampl => ExitCode::SUCCESS,
         _ => ExitCode::from(1),
     }
+}
+
+/// Build a `SolverDebugger` for the requested mode/flags, wired to the
+/// shared restart cell. Used for the first install and each re-solve.
+fn build_debugger(
+    mode: pounce_cli::cli::DebugMode,
+    on_error: bool,
+    on_interrupt: bool,
+    reg: Option<Rc<pounce_common::reg_options::RegisteredOptions>>,
+    cell: pounce_cli::debug_repl::RestartCell,
+) -> pounce_cli::debug_repl::SolverDebugger {
+    use pounce_cli::debug_repl::SolverDebugger;
+    let dbg = if on_error {
+        SolverDebugger::on_error(mode, reg)
+    } else if on_interrupt {
+        SolverDebugger::on_interrupt(mode, reg)
+    } else {
+        SolverDebugger::new(mode, reg)
+    };
+    dbg.with_restart(cell)
 }
 
 /// Translate the CLI's `--dump …` flags into a live `DiagnosticsState`.

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -112,21 +112,30 @@ pub fn main() -> ExitCode {
         let reg = Some(std::rc::Rc::clone(app.registered_options()));
         let dbg = if args.debug_on_error {
             pounce_cli::debug_repl::SolverDebugger::on_error(mode, reg)
+        } else if args.debug_on_interrupt {
+            pounce_cli::debug_repl::SolverDebugger::on_interrupt(mode, reg)
         } else {
             pounce_cli::debug_repl::SolverDebugger::new(mode, reg)
         };
         app.set_debug_hook(Box::new(dbg));
+        // Install the Ctrl-C → break-into-debugger handler. All debug
+        // modes are interruptible; this only changes Ctrl-C behavior
+        // when a debugger is active.
+        pounce_cli::debug_repl::interrupt::install();
+        let extra = if args.debug_on_error {
+            ", on-error"
+        } else if args.debug_on_interrupt {
+            ", on-interrupt"
+        } else {
+            ""
+        };
         eprintln!(
-            "pounce: interactive debugger enabled ({}{}). Type `help` at the prompt.",
+            "pounce: interactive debugger enabled ({}{}). Type `help` at the prompt; Ctrl-C breaks in.",
             match mode {
                 pounce_cli::cli::DebugMode::Repl => "repl",
                 pounce_cli::cli::DebugMode::Json => "json",
             },
-            if args.debug_on_error {
-                ", on-error"
-            } else {
-                ""
-            }
+            extra
         );
     }
 

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -125,6 +125,8 @@ pub fn main() -> ExitCode {
         // modes are interruptible; this only changes Ctrl-C behavior
         // when a debugger is active.
         pounce_cli::debug_repl::interrupt::install();
+        // Branded open banner (human REPL only).
+        pounce_cli::debug_repl::print_open_banner(mode);
         let extra = if args.debug_on_error {
             ", on-error"
         } else if args.debug_on_interrupt {

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -117,6 +117,7 @@ pub fn main() -> ExitCode {
             mode,
             args.debug_on_error,
             args.debug_on_interrupt,
+            args.debug_script.as_deref(),
             reg,
             restart_cell.clone(),
         )));
@@ -531,10 +532,13 @@ pub fn main() -> ExitCode {
         )));
         if let Some(mode) = args.debug {
             let reg = Some(std::rc::Rc::clone(app.registered_options()));
+            // No script on re-solve — it ran once at the original first
+            // pause; the user now drives the re-solve interactively.
             app.set_debug_hook(Box::new(build_debugger(
                 mode,
                 args.debug_on_error,
                 args.debug_on_interrupt,
+                None,
                 reg,
                 restart_cell.clone(),
             )));
@@ -744,6 +748,7 @@ fn build_debugger(
     mode: pounce_cli::cli::DebugMode,
     on_error: bool,
     on_interrupt: bool,
+    script: Option<&std::path::Path>,
     reg: Option<Rc<pounce_common::reg_options::RegisteredOptions>>,
     cell: pounce_cli::debug_repl::RestartCell,
 ) -> pounce_cli::debug_repl::SolverDebugger {
@@ -754,8 +759,12 @@ fn build_debugger(
         SolverDebugger::on_interrupt(mode, reg)
     } else {
         SolverDebugger::new(mode, reg)
-    };
-    dbg.with_restart(cell)
+    }
+    .with_restart(cell);
+    match script {
+        Some(p) => dbg.with_script(p.to_string_lossy().into_owned()),
+        None => dbg,
+    }
 }
 
 /// Translate the CLI's `--dump …` flags into a live `DiagnosticsState`.

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -108,19 +108,26 @@ pub fn main() -> ExitCode {
     // Shared slot the debugger's `resolve` command writes to; the
     // post-solve loop below reads it to re-run with new options.
     let restart_cell: pounce_cli::debug_repl::RestartCell = Rc::new(RefCell::new(None));
+    // Held across `resolve` re-solves so the SAME debugger is reused rather
+    // than rebuilt — keeps its single stdin-reader thread (no leak/contention),
+    // its already-sent `hello`, and its breakpoints. The `--debug-script` is
+    // consumed at the first pause, so reuse won't re-run it.
+    let mut debug_hook: Option<Rc<RefCell<pounce_cli::debug_repl::SolverDebugger>>> = None;
     if let Some(mode) = args.debug {
         if json_dbg {
             let _ = app.options_mut().read_from_str("print_level 0\n", true);
         }
         let reg = Some(std::rc::Rc::clone(app.registered_options()));
-        app.set_debug_hook(std::rc::Rc::new(std::cell::RefCell::new(build_debugger(
+        let hook = Rc::new(RefCell::new(build_debugger(
             mode,
             args.debug_on_error,
             args.debug_on_interrupt,
             args.debug_script.as_deref(),
             reg,
             restart_cell.clone(),
-        ))));
+        )));
+        app.set_debug_hook(hook.clone());
+        debug_hook = Some(hook);
         // Install the Ctrl-C → break-into-debugger handler. All debug
         // modes are interruptible; this only changes Ctrl-C behavior
         // when a debugger is active.
@@ -532,18 +539,12 @@ pub fn main() -> ExitCode {
             Rc::clone(&tnlp),
             req.seed_x,
         )));
-        if let Some(mode) = args.debug {
-            let reg = Some(std::rc::Rc::clone(app.registered_options()));
-            // No script on re-solve — it ran once at the original first
-            // pause; the user now drives the re-solve interactively.
-            app.set_debug_hook(std::rc::Rc::new(std::cell::RefCell::new(build_debugger(
-                mode,
-                args.debug_on_error,
-                args.debug_on_interrupt,
-                None,
-                reg,
-                restart_cell.clone(),
-            ))));
+        if let Some(hook) = debug_hook.as_ref() {
+            // Re-arm the SAME debugger for the next solve (the hook is consumed
+            // per `optimize_tnlp`). Reusing it — rather than building a fresh
+            // one — preserves the stdin pump, the `hello` handshake, and any
+            // breakpoints, and avoids leaking a second stdin-reader thread.
+            app.set_debug_hook(hook.clone());
         }
         eprintln!(
             "pounce: re-solving from saved point with {} option override(s)…",

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -99,6 +99,28 @@ pub fn main() -> ExitCode {
         }
     }
 
+    // Interactive solver debugger (`--debug` / `--debug-json`). Installs
+    // a hook that pauses at each iteration. In JSON mode the solver's
+    // own per-iteration table on stdout would corrupt the protocol
+    // stream, so force `print_level 0` to silence it; the debugger emits
+    // structured pause/result events instead.
+    if let Some(mode) = args.debug {
+        if matches!(mode, pounce_cli::cli::DebugMode::Json) {
+            let _ = app.options_mut().read_from_str("print_level 0\n", true);
+        }
+        let reg = Some(std::rc::Rc::clone(app.registered_options()));
+        app.set_debug_hook(Box::new(pounce_cli::debug_repl::SolverDebugger::new(
+            mode, reg,
+        )));
+        eprintln!(
+            "pounce: interactive debugger enabled ({}). Type `help` at the prompt.",
+            match mode {
+                pounce_cli::cli::DebugMode::Repl => "repl",
+                pounce_cli::cli::DebugMode::Json => "json",
+            }
+        );
+    }
+
     // Wire the restoration phase. Without this, any line-search failure
     // surfaces as `RestorationFailure` instead of falling back into the
     // ℓ1-feasibility sub-IPM. Mirrors what upstream's `IpAlgBuilder`

--- a/crates/pounce-cli/src/print.rs
+++ b/crates/pounce-cli/src/print.rs
@@ -164,13 +164,32 @@ const BANNER_WIDTH: usize = 80;
 /// 256-color downgrade on non-truecolor terminals. The metallic letters
 /// are tuned for a dark terminal background.
 pub fn print_logo() {
-    use pounce_common::style::{downgrade, truecolor_enabled, ALPHA_HOT, BRIGHT_YEL, TIGER_ORANGE};
     use std::io::Write as _;
+    let width = LOGO.iter().map(|l| l.chars().count()).max().unwrap_or(1).max(2);
+    let mut out = anstream::stdout();
+    // Leading rule matching the copyright banner's width, then a blank
+    // line, then the centered wordmark. The rule is left in the terminal's
+    // default color (like the banner's own rules) so it stays distinct on
+    // any background. `anstream` strips the styling when stdout isn't a TTY.
+    let _ = writeln!(out, "{}", "*".repeat(BANNER_WIDTH));
+    let _ = writeln!(out);
+    let pad = " ".repeat(BANNER_WIDTH.saturating_sub(width) / 2);
+    for row in logo_rows(true) {
+        let _ = writeln!(out, "{pad}{row}");
+    }
+    let _ = writeln!(out);
+}
+
+/// Render the POUNCE wordmark as styled rows (one `String` per line):
+/// steel-sheen letters with three molten claw slashes, in the project
+/// palette. Emits ANSI styling only when `color`; otherwise plain
+/// `#`/`/` block characters. Shared by the solve header ([`print_logo`])
+/// and the interactive debugger's open banner (rendered to stderr).
+pub fn logo_rows(color: bool) -> Vec<String> {
+    use pounce_common::style::{downgrade, truecolor_enabled, ALPHA_HOT, BRIGHT_YEL, TIGER_ORANGE};
 
     fn lerp(a: u8, b: u8, t: f64) -> u8 {
-        (a as f64 + (b as f64 - a as f64) * t)
-            .round()
-            .clamp(0.0, 255.0) as u8
+        (a as f64 + (b as f64 - a as f64) * t).round().clamp(0.0, 255.0) as u8
     }
     fn mix(a: anstyle::RgbColor, b: anstyle::RgbColor, t: f64) -> anstyle::RgbColor {
         anstyle::RgbColor(lerp(a.0, b.0, t), lerp(a.1, b.1, t), lerp(a.2, b.2, t))
@@ -181,20 +200,8 @@ pub fn print_logo() {
     const STEEL_LO: anstyle::RgbColor = anstyle::RgbColor(0x5c, 0x60, 0x68);
 
     let rows = LOGO.len();
-    let width = LOGO
-        .iter()
-        .map(|l| l.chars().count())
-        .max()
-        .unwrap_or(1)
-        .max(2);
-    let vfrac = |r: usize| {
-        if rows <= 1 {
-            0.0
-        } else {
-            r as f64 / (rows - 1) as f64
-        }
-    };
-    // Molten color for a claw cell at row `r` (0 = top, hottest).
+    let width = LOGO.iter().map(|l| l.chars().count()).max().unwrap_or(1).max(2);
+    let vfrac = |r: usize| if rows <= 1 { 0.0 } else { r as f64 / (rows - 1) as f64 };
     let molten = |r: usize| {
         let t = vfrac(r);
         if t < 0.5 {
@@ -204,8 +211,6 @@ pub fn print_logo() {
         }
     };
 
-    // Cell grid: letters take the steel sheen by row; the molten claws
-    // overwrite the cells they cross.
     let mut grid: Vec<Vec<Option<(char, anstyle::RgbColor)>>> = vec![vec![None; width]; rows];
     for (r, line) in LOGO.iter().enumerate() {
         let steel = mix(STEEL_HI, STEEL_LO, vfrac(r));
@@ -226,31 +231,31 @@ pub fn print_logo() {
     }
 
     let truecolor = truecolor_enabled();
-    let mut out = anstream::stdout();
-    // Leading rule matching the copyright banner's width, then a blank
-    // line, then the centered wordmark. The rule is left in the terminal's
-    // default color (like the banner's own rules) so it stays distinct on
-    // any background.
-    let _ = writeln!(out, "{}", "*".repeat(BANNER_WIDTH));
-    let _ = writeln!(out);
-    let pad = " ".repeat(BANNER_WIDTH.saturating_sub(width) / 2);
-    for row in &grid {
-        let mut rendered = pad.clone();
-        for cell in row {
-            match cell {
-                Some((ch, rgb)) => {
-                    let style = anstyle::Style::new()
-                        .bold()
-                        .fg_color(Some(downgrade(*rgb, truecolor)));
-                    rendered.push_str(&format!("{}{}{}", style.render(), ch, style.render_reset()));
+    grid.iter()
+        .map(|row| {
+            let mut rendered = String::new();
+            for cell in row {
+                match cell {
+                    Some((ch, rgb)) if color => {
+                        let style = anstyle::Style::new()
+                            .bold()
+                            .fg_color(Some(downgrade(*rgb, truecolor)));
+                        rendered.push_str(&format!(
+                            "{}{}{}",
+                            style.render(),
+                            ch,
+                            style.render_reset()
+                        ));
+                    }
+                    Some((ch, _)) => rendered.push(*ch),
+                    None => rendered.push(' '),
                 }
-                None => rendered.push(' '),
             }
-        }
-        let _ = writeln!(out, "{}", rendered.trim_end());
-    }
-    let _ = writeln!(out);
+            rendered.trim_end().to_string()
+        })
+        .collect()
 }
+
 
 pub fn print_banner(linear_solver: &str) {
     use std::io::IsTerminal as _;

--- a/crates/pounce-cli/src/print.rs
+++ b/crates/pounce-cli/src/print.rs
@@ -165,7 +165,12 @@ const BANNER_WIDTH: usize = 80;
 /// are tuned for a dark terminal background.
 pub fn print_logo() {
     use std::io::Write as _;
-    let width = LOGO.iter().map(|l| l.chars().count()).max().unwrap_or(1).max(2);
+    let width = LOGO
+        .iter()
+        .map(|l| l.chars().count())
+        .max()
+        .unwrap_or(1)
+        .max(2);
     let mut out = anstream::stdout();
     // Leading rule matching the copyright banner's width, then a blank
     // line, then the centered wordmark. The rule is left in the terminal's
@@ -189,7 +194,9 @@ pub fn logo_rows(color: bool) -> Vec<String> {
     use pounce_common::style::{downgrade, truecolor_enabled, ALPHA_HOT, BRIGHT_YEL, TIGER_ORANGE};
 
     fn lerp(a: u8, b: u8, t: f64) -> u8 {
-        (a as f64 + (b as f64 - a as f64) * t).round().clamp(0.0, 255.0) as u8
+        (a as f64 + (b as f64 - a as f64) * t)
+            .round()
+            .clamp(0.0, 255.0) as u8
     }
     fn mix(a: anstyle::RgbColor, b: anstyle::RgbColor, t: f64) -> anstyle::RgbColor {
         anstyle::RgbColor(lerp(a.0, b.0, t), lerp(a.1, b.1, t), lerp(a.2, b.2, t))
@@ -200,8 +207,19 @@ pub fn logo_rows(color: bool) -> Vec<String> {
     const STEEL_LO: anstyle::RgbColor = anstyle::RgbColor(0x5c, 0x60, 0x68);
 
     let rows = LOGO.len();
-    let width = LOGO.iter().map(|l| l.chars().count()).max().unwrap_or(1).max(2);
-    let vfrac = |r: usize| if rows <= 1 { 0.0 } else { r as f64 / (rows - 1) as f64 };
+    let width = LOGO
+        .iter()
+        .map(|l| l.chars().count())
+        .max()
+        .unwrap_or(1)
+        .max(2);
+    let vfrac = |r: usize| {
+        if rows <= 1 {
+            0.0
+        } else {
+            r as f64 / (rows - 1) as f64
+        }
+    };
     let molten = |r: usize| {
         let t = vfrac(r);
         if t < 0.5 {
@@ -255,7 +273,6 @@ pub fn logo_rows(color: bool) -> Vec<String> {
         })
         .collect()
 }
-
 
 pub fn print_banner(linear_solver: &str) {
     use std::io::IsTerminal as _;

--- a/crates/pounce-cli/src/seeded_tnlp.rs
+++ b/crates/pounce-cli/src/seeded_tnlp.rs
@@ -1,0 +1,107 @@
+//! TNLP wrapper that overrides the starting point with a seed captured
+//! by the interactive debugger, so `resolve` can re-run the solve from
+//! the current iterate with new options (a primal warm start).
+//!
+//! Every method forwards to the inner TNLP exactly like
+//! [`crate::counting_tnlp::CountingTnlp`]; only [`TNLP::get_starting_point`]
+//! is overridden. The seed is applied **only when its length matches the
+//! starting-point buffer** — if presolve or fixed-variable elimination
+//! changed the coordinate count, we fall back to the problem's own start
+//! rather than seed into the wrong space.
+
+use pounce_common::types::{Index, Number};
+use pounce_nlp::tnlp::{
+    BoundsInfo, IpoptCq, IpoptData, IterStats, MetaData, NlpInfo, ScalingRequest, Solution,
+    SparsityRequest, StartingPoint, TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+pub struct SeededTnlp {
+    inner: Rc<RefCell<dyn TNLP>>,
+    seed_x: Vec<Number>,
+}
+
+impl SeededTnlp {
+    pub fn new(inner: Rc<RefCell<dyn TNLP>>, seed_x: Vec<Number>) -> Self {
+        Self { inner, seed_x }
+    }
+}
+
+impl TNLP for SeededTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        self.inner.borrow_mut().get_nlp_info()
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        self.inner.borrow_mut().get_bounds_info(b)
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        if self.seed_x.len() == sp.x.len() {
+            // `init_x` / `init_z` / `init_lambda` are inputs (which
+            // buffers the solver wants); for the initial point the solver
+            // always reads `x`, so writing the primal seed here suffices.
+            // We don't have warm duals, so we leave z/lambda untouched.
+            sp.x.copy_from_slice(&self.seed_x);
+            true
+        } else {
+            // Coordinate count changed (presolve / fixed-variable
+            // elimination); fall back to the problem's own start.
+            self.inner.borrow_mut().get_starting_point(sp)
+        }
+    }
+    fn eval_f(&mut self, x: &[Number], new_x: bool) -> Option<Number> {
+        self.inner.borrow_mut().eval_f(x, new_x)
+    }
+    fn eval_grad_f(&mut self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool {
+        self.inner.borrow_mut().eval_grad_f(x, new_x, grad_f)
+    }
+    fn eval_g(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+        self.inner.borrow_mut().eval_g(x, new_x, g)
+    }
+    fn eval_jac_g(&mut self, x: Option<&[Number]>, new_x: bool, mode: SparsityRequest<'_>) -> bool {
+        self.inner.borrow_mut().eval_jac_g(x, new_x, mode)
+    }
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        self.inner
+            .borrow_mut()
+            .eval_h(x, new_x, obj_factor, lambda, new_lambda, mode)
+    }
+    fn finalize_solution(&mut self, sol: Solution<'_>, ip_data: &IpoptData, ip_cq: &IpoptCq) {
+        self.inner
+            .borrow_mut()
+            .finalize_solution(sol, ip_data, ip_cq)
+    }
+    fn get_var_con_metadata(&mut self, var: &mut MetaData, con: &mut MetaData) -> bool {
+        self.inner.borrow_mut().get_var_con_metadata(var, con)
+    }
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        self.inner.borrow_mut().get_scaling_parameters(req)
+    }
+    fn get_number_of_nonlinear_variables(&mut self) -> Index {
+        self.inner.borrow_mut().get_number_of_nonlinear_variables()
+    }
+    fn get_list_of_nonlinear_variables(&mut self, pos: &mut [Index]) -> bool {
+        self.inner.borrow_mut().get_list_of_nonlinear_variables(pos)
+    }
+    fn intermediate_callback(
+        &mut self,
+        stats: IterStats,
+        ip_data: &IpoptData,
+        ip_cq: &IpoptCq,
+    ) -> bool {
+        self.inner
+            .borrow_mut()
+            .intermediate_callback(stats, ip_data, ip_cq)
+    }
+    fn finalize_metadata(&mut self, var: &MetaData, con: &MetaData) {
+        self.inner.borrow_mut().finalize_metadata(var, con)
+    }
+}

--- a/crates/pounce-restoration/src/min_c_1nrm.rs
+++ b/crates/pounce-restoration/src/min_c_1nrm.rs
@@ -100,6 +100,9 @@ pub type RestoInnerSolver = Box<
         // false. Outer driver forwards `print_level == 0` via
         // `RestorationPhase::set_print_iter_output`.
         bool,
+        // Shared interactive debugger, forwarded onto the inner IPM so the
+        // same debugger can step the restoration sub-solve.
+        Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
     ) -> Option<RestoSolveResult>,
 >;
 
@@ -130,6 +133,9 @@ pub struct MinC1NormRestoration {
     /// `print_level == 0` actually silences the restoration `r`-row
     /// table instead of leaking it to stdout.
     pub(crate) print_iter_output: bool,
+    /// Shared debugger forwarded onto the inner IPM (set by the outer
+    /// driver via `RestorationPhase::set_debug_hook`).
+    pub(crate) debug_hook: Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
 }
 
 impl Default for MinC1NormRestoration {
@@ -141,10 +147,11 @@ impl Default for MinC1NormRestoration {
             expect_infeasible_problem: false,
             start_with_resto: false,
             eq_mult: Box::new(LeastSquareMults::new()),
-            inner_solver: Box::new(|_, _, _, _, _| None),
+            inner_solver: Box::new(|_, _, _, _, _, _| None),
             orig_progress: None,
             last_inner_iter_count: 0,
             print_iter_output: true,
+            debug_hook: None,
         }
     }
 }
@@ -189,6 +196,13 @@ impl RestorationPhase for MinC1NormRestoration {
         self.print_iter_output = enabled;
     }
 
+    fn set_debug_hook(
+        &mut self,
+        hook: Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
+    ) {
+        self.debug_hook = hook;
+    }
+
     fn perform_restoration(
         &mut self,
         data: &IpoptDataHandle,
@@ -224,7 +238,14 @@ impl RestorationPhase for MinC1NormRestoration {
         // mu/tau, matching upstream.
         let saved_mu = data.borrow().curr_mu;
         let saved_tau = data.borrow().curr_tau;
-        let Some(result) = (self.inner_solver)(data, cq, nlp, cb, self.print_iter_output) else {
+        let Some(result) = (self.inner_solver)(
+            data,
+            cq,
+            nlp,
+            cb,
+            self.print_iter_output,
+            self.debug_hook.clone(),
+        ) else {
             return RestorationOutcome::Failed;
         };
         self.last_inner_iter_count = result.iter_count;

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -77,7 +77,7 @@ pub fn make_resto_inner_solver(
     mut backend_factory_factory: InnerBackendFactoryFactory,
 ) -> crate::min_c_1nrm::RestoInnerSolver {
     Box::new(
-        move |outer_data, outer_cq, outer_nlp, orig_progress_cb, print_iter_output| {
+        move |outer_data, outer_cq, outer_nlp, orig_progress_cb, print_iter_output, debug_hook| {
             run_inner_resto(
                 outer_data,
                 outer_cq,
@@ -87,6 +87,7 @@ pub fn make_resto_inner_solver(
                 backend_factory_factory(),
                 orig_progress_cb,
                 print_iter_output,
+                debug_hook,
             )
         },
     )
@@ -168,6 +169,7 @@ pub fn run_inner_resto(
     backend_factory: LinearBackendFactory,
     orig_progress_cb: Option<pounce_algorithm::restoration::OrigProgressCallback>,
     print_iter_output: bool,
+    debug_hook: Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
 ) -> Option<RestoSolveResult> {
     // ---- 1. Snapshot outer iterate. ---------------------------------
     let snap = build_outer_snapshot(outer_data, outer_cq)?;
@@ -403,6 +405,11 @@ pub fn run_inner_resto(
     let mut alg = IpoptAlgorithm::new(inner_data, inner_cq, alg_bundle)
         .with_nlp(Rc::clone(&resto_nlp_rc))
         .with_restoration(resto_of_resto);
+    // Forward the shared debugger so the same session can step the inner
+    // restoration solve (its DebugCtx exposes the resto sub-NLP iterate).
+    if let Some(h) = debug_hook {
+        alg = alg.with_debug_hook(h);
+    }
     // Forward the outer `print_level == 0` gate. Suppresses the
     // restoration `r`-suffixed iter table; the resto-of-resto level
     // also inherits the same flag (its `RestorationPhase` impl is the

--- a/crates/pounce-restoration/tests/restoration_triggers.rs
+++ b/crates/pounce-restoration/tests/restoration_triggers.rs
@@ -134,7 +134,7 @@ fn line_search_failure_invokes_user_supplied_restoration_phase() {
 
     let factory: RestorationFactory = Box::new(move || {
         let count = Rc::clone(&count_for_factory);
-        let hook: RestoInnerSolver = Box::new(move |_, _, _, _, _| {
+        let hook: RestoInnerSolver = Box::new(move |_, _, _, _, _, _| {
             *count.borrow_mut() += 1;
             // Returning `None` makes `MinC1NormRestoration` surface
             // `RestorationOutcome::Failed`, so the outer algorithm

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -16,6 +16,7 @@
   - [Schema v1 Reference](schema/solve-report-v1.md)
 - [Sensitivity Analysis](sensitivity.md)
 - [Sessions: Factor-Once / Solve-Many](sessions.md)
+- [Interactive Debugger](debugger.md)
 
 # Integrations
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -31,6 +31,7 @@
 # Reference
 
 - [Algorithm & Workspace](algorithm.md)
+- [Color Theme](color-theme.md)
 - [Scaling](scaling.md)
 - [Feasibility-Based Bound Tightening](fbbt.md)
 - [Auxiliary-Equality Preprocessing](auxiliary-presolve.md)

--- a/docs/src/color-theme.md
+++ b/docs/src/color-theme.md
@@ -1,0 +1,121 @@
+# Color Theme
+
+POUNCE's terminal output uses one **tiger / rust / warm** palette across
+every colored surface — the iteration table, the branded wordmark, and
+the interactive debugger. This page is the single reference for *what the
+colors mean*; the palette itself lives in
+[`pounce-common::style`](https://github.com/jkitchin/pounce/blob/main/crates/pounce-common/src/style.rs)
+(a pure, unit-tested module — no I/O, no globals).
+
+For the environment variables that turn color on/off (`NO_COLOR`,
+`CLICOLOR_FORCE`, `RUST_LOG`, `POUNCE_LOG_FORMAT`) see
+[Solver Options → Logging and colored output](options.md#logging-and-colored-output).
+
+## The palette
+
+| Name | Hex | Role |
+|---|---|---|
+| `ALPHA_COOL` | `#000000` | iteration-row text at α = 1 (full Newton step) |
+| `ALPHA_HOT` | `#cc2200` | iteration-row text at α → 0 (stalling); molten-claw base |
+| `TAN` | `#8a6d3b` | restoration **soft-stay** row background (`s`) |
+| `AMBER` | `#b56a12` | restoration **soft-exit** row background (`S`) |
+| `RUST_DEEP` | `#6e260e` | restoration **hard** row background (`R` / resto-phase rows) |
+| `CREAM` | `#f5e6c8` | restoration-row text at α = 1 |
+| `BRIGHT_YEL` | `#ffe03a` | restoration-row text at α → 0; molten-claw top |
+| `TIGER_ORANGE` | `#e87a1e` | `WARN` logs, banner accents, molten-claw mid |
+
+Two further surfaces reuse these or a small extension:
+
+| Name | Hex | Role |
+|---|---|---|
+| steel-hi → steel-lo | `#d2d6dc` → `#5c6068` | wordmark letter sheen, top row → bottom row |
+| gold | `#ffb000` | debugger banner highlight (`interior-point debugger`, `help`) |
+| dim | `#7a7e88` | debugger banner gloss text |
+
+## Where the colors appear
+
+### The iteration table
+
+Two orthogonal channels encode solver state on each row:
+
+- **Background = restoration kind**, keyed off the row's
+  `alpha_primal_char` tag:
+  - `s` soft-stay → **tan**, `S` soft-exit → **amber**, `R` hard (and the
+    dedicated restoration phase's `r`-suffixed rows) → **deep rust**.
+  - Normal (non-restoration) rows have no background.
+  - Tiny-step tags (`t`/`T`) deliberately get *no* background — that
+    stall is shown by the foreground instead.
+- **Foreground = a smooth gradient on the primal step length α ∈ [0, 1]**
+  (a visual stalling cue):
+  - Normal rows: **black** (α = 1, full step) → **hot red** (α → 0).
+  - Restoration rows: **cream** (α = 1) → **bright yellow** (α → 0), so
+    the text stays legible on the dark background.
+  - α is clamped to `[0, 1]`; a non-finite α is treated as a full step
+    (no false stalling alarm).
+
+So at a glance: a **dark row** means restoration (its shade tells you
+which kind), and **redder / yellower text** means a shorter step (the
+solver is struggling to move).
+
+### The branded wordmark (`pounce` logo)
+
+Printed atop a normal solve and at the top of the debugger REPL. The
+`POUNCE` block letters carry a top-lit **steel sheen** (light silver
+`#d2d6dc` at the top row fading to dark steel `#5c6068` at the bottom),
+and three diagonal **molten claw slashes** rake across them, glowing
+**bright yellow → tiger-orange → deep red** top-to-bottom — the project
+logo's forged-metal-with-lava look.
+
+### The interactive debugger
+
+The REPL open banner (`--debug`) reuses the same wordmark, then a command
+cheat-sheet whose shortcut keys are **tiger-orange**, the
+`interior-point debugger` line and the `help` hint are **gold**, and the
+descriptive gloss is **dim grey**. Pause banners and command output are
+otherwise uncolored. (`--debug-json` emits no color — its stdout is a
+pure JSON channel.)
+
+`viz kkt` / `viz L` open in the external Plotly viewer
+([`pounce-dbg-viz`](debugger.md#interactive-figures-pounce-dbg-viz)),
+which is a *separate* visual language: the sparse-matrix heatmaps use a
+diverging **red–blue** scale keyed on entry *value* (sign + magnitude),
+not the terminal palette.
+
+### Logs
+
+`WARN`-level log lines (on stderr) take the **tiger-orange** accent;
+other levels use the subscriber's defaults.
+
+## Terminal support & downgrade
+
+- **Truecolor** (24-bit) is used when the terminal advertises it via
+  `COLORTERM` — every color above is emitted as exact RGB.
+- **256-color** terminals get a graceful fallback: each RGB color snaps
+  to the nearest xterm 6×6×6 cube color (`downgrade` /
+  `nearest_ansi256`). The theme still reads correctly, just quantized.
+
+## When color is emitted
+
+Color is opt-out and TTY-aware:
+
+- The **iteration table** is colored only when **stdout** is a terminal
+  (via `anstream::AutoStream`, which strips escapes from redirected
+  output while keeping identical column alignment).
+- The **debugger banner** is colored only when **stderr** is a terminal.
+- `NO_COLOR` (any value) disables color everywhere; `CLICOLOR_FORCE`
+  forces it even into a non-terminal sink. See
+  [Solver Options](options.md#logging-and-colored-output).
+
+Because the policy is consistent, redirected logs/output are always plain
+text — safe to diff, grep, and ingest.
+
+## For contributors
+
+Add or change colors in `pounce-common::style`, never with inline ANSI:
+the constants, the α-gradient (`alpha_gradient_rgb`), the restoration
+mapping (`resto_background_rgb`), the composed `iteration_row_style`, and
+the truecolor `downgrade` all live there and are unit-tested without a
+TTY. Print sites style through `anstyle` + `anstream` (or, for the
+debugger banner on stderr, gate on `stderr().is_terminal()` and
+`NO_COLOR`). Keep the two iteration-table channels — background =
+*restoration kind*, foreground = *step length* — orthogonal.

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -101,6 +101,14 @@ By default the debugger only *stops* at `iter_start` (and `terminated`).
 The sub-iteration checkpoints fire every iteration but resume immediately
 unless you ask to stop at them.
 
+**Stepping into restoration.** The same debugger drives the restoration
+*inner* IPM: when the solve enters restoration, the inner solve's
+checkpoints fire too. A `step`/`stepi` that lands on an inner iteration
+pauses there with `in_restoration: true` (REPL banner shows
+`[restoration]`), and `print x` shows the restoration sub-NLP iterate.
+`stop-at resto` (`pre_restoration_entry`) is the easy way to catch the
+hand-off and then step inward.
+
 ### Stepping
 
 | Command | Effect |

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -136,10 +136,24 @@ Three kinds, all reported in `break` and surfaced as the pause `reason`.
 
 ```text
 break 12            # pause at iteration 12   (alias: b 12)
+tbreak 12           # one-shot: pause at 12, then delete itself (alias: tb)
 break               # list all breakpoints
 break del 12        # remove
 break clear         # remove everything (iters + conditions + events)
 ```
+
+### Watchpoints (data breakpoints)
+
+```text
+watchpoint x[3]        # pause when x[3] changes (alias: wp)
+watchpoint x 1e-3      # pause when any x component moves by > 1e-3
+watchpoint             # list; watchpoint del x[3]; watchpoint clear
+```
+
+Distinct from `watch` (which only *displays*): a watchpoint *pauses* the
+solve when the watched value changes by more than its threshold (default
+0 = any change) between iterations. Useful for a component expected to
+stay put (e.g. a variable pinned at a bound).
 
 ### Conditional (with compound predicates)
 
@@ -175,6 +189,7 @@ break clear events
 | `regularized` | the KKT system needed regularization (δ_w > 0 — inertia correction) |
 | `tiny_step` | the primal step is numerically negligible (‖dx‖∞ < 1e-10) |
 | `ls_rejected` | the line search tried more than one trial point |
+| `mu_stalled` | μ held (to tolerance) for 3 consecutive iterations |
 | `nan` | the NLP error or objective became non-finite |
 
 Events fire at whatever checkpoint makes them observable (e.g.
@@ -466,6 +481,9 @@ Every non-kill path ends with a `terminated` event in JSON mode.
 | `viz <target>` | open an artifact in a viewer |
 | `save [path]` | dump the iterate to JSON |
 | `watch <target>` (`display`) | auto-print a target at every pause |
+| `tbreak N` (`tb`) | one-shot iteration breakpoint |
+| `watchpoint <blk>[<i>] [τ]` (`wp`) | pause when a value changes by > τ |
+| `diff` | what changed in the iterate since the last iteration |
 | `source <file>` | run debugger commands from a file |
 | `goto N` / `restart` | soft-rewind to a captured iteration |
 | `resolve` | re-solve from current x with staged options |

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -206,6 +206,7 @@ print x              # a primal/dual block (alias: p x)
 print dx             # a search-direction block (d + block name)
 print mu             # a scalar: mu|obj|inf_pr|inf_du|err|compl|iter
 print kkt            # KKT inertia + regularization (see below)
+print active         # which bound categories are near-active (small slack)
 watch mu             # auto-print a target at every pause (alias: display)
 watch                # list watches; watch del mu; watch clear
 ```

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -518,11 +518,17 @@ command.
 
 ### Async pause
 
-A running `continue` is interrupted by sending **SIGINT** to the process
-(`process.kill(pid, "SIGINT")`); the debugger pauses at the next
-checkpoint with `reason: "interrupt (Ctrl-C)"`. This is what a Debug
-Adapter's pause button maps to. (`hello.capabilities.async_pause` is
-`"checkpoint"`.)
+A running `continue` can be interrupted two ways, both pausing at the
+next checkpoint with a `reason`:
+
+- **SIGINT** — `process.kill(pid, "SIGINT")` (or Ctrl-C). This is what a
+  Debug Adapter's pause button maps to. Reason: `"interrupt (Ctrl-C)"`.
+- **In-band command** — send `{"cmd":"pause"}` on stdin while the solve
+  is running (JSON mode). No signals, so it works on Windows. Reason:
+  `"pause (requested)"`.
+
+`hello.capabilities.async_pause` is `"checkpoint"`, and
+`pause_command` is `true`.
 
 ---
 
@@ -605,7 +611,5 @@ for line in p.stdout:                # progress … pause … terminated
   (see [Running Solves](cli.md)).
 - **Soft rewind only.** `goto`/`restart` restore the primal-dual state,
   not strategy history (see the caveat above).
-- **Async pause is SIGINT-based.** An in-band `{"cmd":"pause"}` (for
-  platforms without convenient signals) is not yet wired.
 - **`set opt` is staged, not hot-applied** to a running solve; it takes
   effect on `resolve` / the next solve.

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -93,6 +93,7 @@ via its `checkpoint` field):
 | `after_mu` | μ updated for this iteration | the new barrier parameter |
 | `after_search_dir` | Newton step `δ` solved | the step (`dx` …), regularization, **KKT inertia** |
 | `after_step` | trial accepted | the step lengths α, the new iterate |
+| `step_rejected` | line search gave up (tiny step / all backtracks failed), before restoration | the search direction `δ` and the un-accepted iterate |
 | `pre_restoration_entry` | just before restoration | the iterate that tripped restoration |
 | `post_restoration_exit` | restoration returned | what restoration produced |
 | `terminated` | once, before the solve returns | the final / failing iterate + status |

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -235,8 +235,22 @@ The augmented (KKT) system has expected inertia `(n₊ = n, n₋ = m,
 n₀ = 0)` where `m` is the number of equality + inequality multipliers.
 A mismatch — or a nonzero `delta_w`/`delta_c` — is the classic signal
 that the step is being stabilized (the solver added regularization to
-fix the inertia). The full KKT-matrix and L-factor *heatmap* aren't
-captured here; see [Limitations](#limitations).
+fix the inertia).
+
+For the matrix and factor themselves:
+
+```text
+viz kkt     # the assembled augmented-system matrix (triplets) + inertia
+viz L       # the LDLᵀ factor (strict-lower triplets + values)
+```
+
+`viz kkt` writes the KKT matrix as 1-based lower-triangle triplets
+(`dim`, `irn`, `jcn`, `vals`) alongside the inertia summary — point
+`$POUNCE_DBG_VIEWER` at a heatmap script. `viz L` writes the `LDLᵀ`
+factor (`n`, fill-reducing `perm`, strict-lower `l_irn`/`l_jcn`/`l_vals`
+in permuted coordinates). Because reconstructing the factor is the
+expensive piece, **`viz L` capture is opt-in**: the first call arms it
+and the factor is available at the next `after_search_dir` stop.
 
 ---
 
@@ -639,11 +653,6 @@ for line in p.stdout:                # progress … pause … terminated
 
 ## Limitations
 
-- **No live KKT-matrix / L-factor heatmap.** `print kkt` / `viz kkt`
-  give the inertia and regularization *scalars*; the full sparse matrix
-  and its `LDLᵀ` factor pattern are not captured at the checkpoint. Use
-  the offline dump for those: `--dump kkt:<iter>+L+Lvals --dump-dir DIR`
-  (see [Running Solves](cli.md)).
 - **Soft rewind only.** `goto`/`restart` restore the primal-dual state,
   not strategy history (see the caveat above).
 - **`set opt` is staged, not hot-applied** to a running solve; it takes

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -155,6 +155,23 @@ solve when the watched value changes by more than its threshold (default
 0 = any change) between iterations. Useful for a component expected to
 stay put (e.g. a variable pinned at a bound).
 
+### Breakpoint command lists
+
+Attach commands to a breakpoint that run automatically when it hits —
+semicolon-separated, ending with a flow command to auto-resume:
+
+```text
+break 5
+commands 5 print kkt ; set mu 0.1 ; continue   # at iter 5: inspect, tweak μ, go
+commands 5 clear                               # remove
+commands                                       # list all
+```
+
+When iteration 5 is reached, the debugger emits the `pause`, runs the
+attached commands (each `result` is reported), and if one of them
+resumes/stops, honors it without dropping to the prompt — otherwise it
+falls through to the interactive prompt as usual.
+
 ### Conditional (with compound predicates)
 
 ```text

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -204,7 +204,7 @@ Events fire at whatever checkpoint makes them observable (e.g.
 info                 # one-line summary: iter, mu, obj, inf_pr, inf_du, nlp_error, dims
 print x              # a primal/dual block (alias: p x)
 print dx             # a search-direction block (d + block name)
-print mu             # a scalar: mu|obj|inf_pr|inf_du|err|iter
+print mu             # a scalar: mu|obj|inf_pr|inf_du|err|compl|iter
 print kkt            # KKT inertia + regularization (see below)
 watch mu             # auto-print a target at every pause (alias: display)
 watch                # list watches; watch del mu; watch clear

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -392,13 +392,30 @@ viz kkt              # the KKT inertia/regularization report
 residual scalars (`iter`, `mu`, `objective`, `inf_pr`, `inf_du`,
 `nlp_error`) — a self-contained artifact for external analysis.
 
-`viz` opens the artifact with `$POUNCE_DBG_VIEWER` (a command template
-where `{}` is replaced by the file path) if set, otherwise the platform
-opener (`xdg-open` / `open`). For a plot, point it at a script:
+### Interactive figures (`pounce-dbg-viz`)
+
+`viz` writes a JSON artifact and hands it to a viewer. The Python package
+ships an interactive **Plotly** viewer that renders these properly —
+a spy/heatmap for `viz kkt` (the augmented matrix, colored by value, with
+the inertia/regularization in the title) and `viz L` (the LDLᵀ factor),
+and a bar chart for vector blocks (`viz x`, `viz dx`):
 
 ```sh
-export POUNCE_DBG_VIEWER='python my_plot.py {}'
+pip install 'pounce-solver[viz]'    # installs the `pounce-dbg-viz` script
 ```
+
+When `pounce-dbg-viz` is on `PATH`, `viz` uses it automatically (opening
+an interactive figure in your browser). The launch order is:
+
+1. `$POUNCE_DBG_VIEWER` — a command template (`{}` ← the artifact path),
+   if set;
+2. `pounce-dbg-viz` — the bundled Plotly viewer, if installed;
+3. the OS opener (`xdg-open` / `open`) on the raw JSON.
+
+So `export POUNCE_DBG_VIEWER='python my_plot.py {}'` overrides with your
+own plotter, and with nothing set + the `viz` extra installed it just
+works. The same `pounce-dbg-viz <file.json>` also renders a `save`
+artifact (the full iterate).
 
 ---
 

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -340,6 +340,36 @@ export POUNCE_DBG_VIEWER='python my_plot.py {}'
 
 ---
 
+## Ask Claude about the state
+
+`ask [question]` packages the current paused state — checkpoint,
+residuals, step lengths, dimensions, and the KKT inertia/regularization —
+into a prompt and runs it through **Claude Code** (`claude -p`, headless
+print mode), printing the reply inline. It's AI-assisted debugging
+without leaving the loop:
+
+```text
+pounce-dbg> stop-at kkt
+pounce-dbg> continue
+pounce-dbg> ask why is the dual infeasibility stalling?
+# → Claude's analysis of the state + suggested options to try
+```
+
+With no question it defaults to "explain the current state and suggest
+what to try next." The command is configurable via `$POUNCE_DBG_LLM`
+(default `claude -p`); the prompt is fed on the tool's stdin, or
+substituted into a `{}` placeholder if the template has one:
+
+```sh
+export POUNCE_DBG_LLM='claude -p'          # default
+export POUNCE_DBG_LLM='llm -m claude-opus' # any prompt-on-stdin CLI
+export POUNCE_DBG_LLM='mytool --ask {}'    # prompt as an argument
+```
+
+In JSON mode the reply comes back in the `result` event's `data.reply`.
+
+---
+
 ## Attaching to a run
 
 You don't have to single-step from iteration 0.
@@ -390,6 +420,7 @@ Every non-kill path ends with a `terminated` event in JSON mode.
 | `save [path]` | dump the iterate to JSON |
 | `goto N` / `restart` | soft-rewind to a captured iteration |
 | `resolve` | re-solve from current x with staged options |
+| `ask [question]` | ask Claude Code (`claude -p` / `$POUNCE_DBG_LLM`) about the state |
 | `progress [on/off]` | toggle JSON progress events |
 | `detach` | stop pausing; run to completion |
 | `quit` (`q`, `exit`) | stop the solve |

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -1,0 +1,580 @@
+# Interactive Solver Debugger
+
+POUNCE ships an interactive debugger for the interior-point loop — a
+*pdb for the IPM*. You can pause the solve at well-defined points,
+inspect and **mutate** the live mathematical state (the iterate,
+multipliers, the barrier parameter μ), set breakpoints (by iteration, on
+a numeric condition, or on a solver *event*), step through an iteration's
+internal phases, rewind to an earlier iterate, re-solve from a saved
+point with new options, and drop in automatically when a solve fails.
+
+It has two front ends sharing one command engine:
+
+- a **human REPL** (`--debug`) with history, Ctrl-R search, and Tab
+  completion, and
+- a **newline-delimited JSON protocol** (`--debug-json`) that an LLM
+  agent, a script, or a visual debugger (e.g. a VS Code Debug Adapter)
+  can drive programmatically.
+
+No production NLP solver ships anything like this; if you have used
+`ipopt` you have had `print_level` and a log. This is a live debugger.
+
+> The debugger has **zero effect on the solve when it is not attached**.
+> The checkpoint fire-sites short-circuit when no debugger is installed,
+> so the standard regression suite is bit-for-bit identical with and
+> without the feature compiled in.
+
+---
+
+## Quick start
+
+```sh
+pounce problem.nl --debug          # human REPL, pauses at iteration 0
+pounce problem.nl --debug-json     # JSON protocol on stdin/stdout
+pounce problem.nl --debug-on-error # run freely; drop in only if it fails
+pounce problem.nl --debug-on-interrupt   # run; Ctrl-C drops you in
+```
+
+A 30-second session (human REPL):
+
+```text
+$ pounce --problem rosenbrock --debug
+
+── pounce-dbg ── iter 0 @iter_start  mu=1.000e-1  obj=2.420000e1  inf_pr=0.00e0  inf_du=1.00e2
+pounce-dbg> info
+iter      = 0
+mu        = 1.000000e-1
+objective = 2.42000000e1
+...
+pounce-dbg> print x
+x = [-1.200000e0, 1.000000e0]
+pounce-dbg> break if inf_du<1e-6
+conditional breakpoint: inf_du<1e-6
+pounce-dbg> continue
+... solver runs ...
+── pounce-dbg ── iter 21 @iter_start  mu=...  inf_du=8.7e-7
+   ↳ inf_du<1e-6
+pounce-dbg> quit
+```
+
+The prompt is on **stderr**; the solver's own iteration table stays on
+stdout, so a redirected log is unaffected.
+
+---
+
+## The two front ends
+
+| | `--debug` (REPL) | `--debug-json` |
+|---|---|---|
+| Audience | human at a terminal | agent / script / GUI |
+| Channel | prompt + output on stderr | pure JSON on stdout |
+| Line editing | rustyline: history (`~/.pounce_dbg_history`), Ctrl-R, **Tab** completion | n/a (caller supplies UI) |
+| Solver table | shown on stdout | suppressed (`print_level 0`) |
+| Commands | bare strings | bare strings *or* `{"cmd":…,"args":[…],"id":…}` |
+
+On a non-TTY stdin (a pipe), the REPL falls back to a plain line reader
+(no history/Tab) but otherwise behaves identically — handy for scripted
+tests.
+
+The JSON protocol is documented in full [below](#the-json-protocol).
+
+---
+
+## Pausing and flow control
+
+### Checkpoints
+
+The loop fires the debugger at these points (a `pause` reports which one
+via its `checkpoint` field):
+
+| Checkpoint | Fires | What's fresh |
+|---|---|---|
+| `iter_start` | top of each outer iteration | the accepted iterate from the previous step |
+| `after_mu` | μ updated for this iteration | the new barrier parameter |
+| `after_search_dir` | Newton step `δ` solved | the step (`dx` …), regularization, **KKT inertia** |
+| `after_step` | trial accepted | the step lengths α, the new iterate |
+| `pre_restoration_entry` | just before restoration | the iterate that tripped restoration |
+| `post_restoration_exit` | restoration returned | what restoration produced |
+| `terminated` | once, before the solve returns | the final / failing iterate + status |
+
+By default the debugger only *stops* at `iter_start` (and `terminated`).
+The sub-iteration checkpoints fire every iteration but resume immediately
+unless you ask to stop at them.
+
+### Stepping
+
+| Command | Effect |
+|---|---|
+| `step` / `s` / `n` | run to the next `iter_start` |
+| `step sub` / `stepi` / `si` | run to the next checkpoint of *any* kind (walk an iteration's phases) |
+| `continue` / `c` | run to the next breakpoint (or to completion) |
+| `run N` / `r N` | run until iteration `N` |
+| `stop-at <cp>` | always pause at checkpoint `<cp>` |
+| `detach` | stop pausing; run to completion |
+| `quit` / `q` | stop the solve now |
+
+`stop-at` takes a checkpoint name or a friendly alias:
+
+```text
+stop-at after_search_dir     # or:  stop-at kkt
+stop-at pre_restoration_entry   # or:  stop-at resto
+stop-at                      # list active stop-at checkpoints
+stop-at clear
+```
+
+Aliases: `mu` → `after_mu`, `kkt`/`search_dir` → `after_search_dir`,
+`step` → `after_step`, `resto` → `pre_restoration_entry`, `resto_exit` →
+`post_restoration_exit`.
+
+---
+
+## Breakpoints
+
+Three kinds, all reported in `break` and surfaced as the pause `reason`.
+
+### By iteration
+
+```text
+break 12            # pause at iteration 12   (alias: b 12)
+break               # list all breakpoints
+break del 12        # remove
+break clear         # remove everything (iters + conditions + events)
+```
+
+### Conditional (with compound predicates)
+
+```text
+break if inf_pr<1e-6
+break if mu<1e-4 && inf_pr>1e-3
+break if iter>10 && (inf_du>1e-2 || obj<0)
+break clear cond
+```
+
+- **Metrics:** `mu`, `inf_pr`, `inf_du`, `obj`, `err` (overall NLP
+  error), `iter`.
+- **Operators:** `<`, `<=`, `>`, `>=`, `==` (`==` is float-tolerant).
+- **Compound:** `&&` and `||`, evaluated strictly **left-to-right with no
+  precedence**; parentheses are accepted but stripped (they don't group).
+  For real grouping, register several conditions — any one that holds
+  fires.
+
+Conditions are evaluated at `iter_start`.
+
+### On a solver event
+
+```text
+break on regularized
+break on resto_entered
+break clear events
+```
+
+| Event | Fires when |
+|---|---|
+| `resto_entered` | the algorithm enters restoration |
+| `resto_exited` | restoration returns |
+| `regularized` | the KKT system needed regularization (δ_w > 0 — inertia correction) |
+| `tiny_step` | the primal step is numerically negligible (‖dx‖∞ < 1e-10) |
+| `ls_rejected` | the line search tried more than one trial point |
+| `nan` | the NLP error or objective became non-finite |
+
+Events fire at whatever checkpoint makes them observable (e.g.
+`regularized` at `after_search_dir`), and pause with
+`reason: "event: <name>"`.
+
+---
+
+## Inspecting state
+
+```text
+info                 # one-line summary: iter, mu, obj, inf_pr, inf_du, nlp_error, dims
+print x              # a primal/dual block (alias: p x)
+print dx             # a search-direction block (d + block name)
+print mu             # a scalar: mu|obj|inf_pr|inf_du|err|iter
+print kkt            # KKT inertia + regularization (see below)
+```
+
+**Blocks** (the eight components of the primal-dual iterate):
+
+| Name | Meaning |
+|---|---|
+| `x` | primal variables |
+| `s` | inequality slacks |
+| `y_c` | equality-constraint multipliers |
+| `y_d` | inequality-constraint multipliers |
+| `z_l`, `z_u` | bound multipliers on `x` |
+| `v_l`, `v_u` | bound multipliers on `s` |
+
+Prefix any block with `d` (`dx`, `dz_l`, …) to print the corresponding
+block of the most recent Newton step.
+
+### `print kkt` — inertia and regularization
+
+Available at/after `after_search_dir` (use `stop-at kkt`). This is the
+view a solver expert reaches for when a step looks wrong:
+
+```text
+pounce-dbg> stop-at kkt
+pounce-dbg> continue
+── pounce-dbg ── iter 3 @after_search_dir ...
+pounce-dbg> print kkt
+dim       = 3
+inertia   = n+=2 n-=1 (expected n-=1) → correct
+delta_w   = 0.000000e0   (primal regularization)
+delta_c   = 0.000000e0   (dual regularization)
+status    = Success
+```
+
+The augmented (KKT) system has expected inertia `(n₊ = n, n₋ = m,
+n₀ = 0)` where `m` is the number of equality + inequality multipliers.
+A mismatch — or a nonzero `delta_w`/`delta_c` — is the classic signal
+that the step is being stabilized (the solver added regularization to
+fix the inertia). The full KKT-matrix and L-factor *heatmap* aren't
+captured here; see [Limitations](#limitations).
+
+---
+
+## Mutating state
+
+Mutations feed straight back into the solve.
+
+```text
+set mu 0.5           # overwrite the barrier parameter
+set x[2] 1.5         # overwrite one component of a block
+set x 1.0,2.0,3.0    # overwrite a whole block (comma-separated)
+```
+
+Setting any block works (`set z_l[0] 1e-3`, …). Iterate edits rebuild the
+iterate with a fresh change-tag, so the cached derived quantities
+(`curr_f`, slacks, σ, …) invalidate correctly and the next step is
+computed from the new point — exactly as if the line search had produced
+it.
+
+Staging a solver option (validated against the registry):
+
+```text
+set opt mu_strategy adaptive
+set opt linear_solver ma57
+```
+
+Staged options are **not** applied to the strategies already built for
+the running solve (they don't re-read options mid-iteration). They take
+effect on a [`resolve`](#re-solve-from-a-saved-point) or the next solve.
+
+---
+
+## Discovering options
+
+```text
+opt                  # list every registered option
+opt mu               # filter by name/category substring
+complete pri         # completion candidates for a prefix
+```
+
+`opt <exact-name>` also prints the long description. In the REPL, **Tab**
+completes command verbs, block names, metric names (after `break if`),
+checkpoint names (after `stop-at`), event names (after `break on`), and
+option names (after `set opt` / `opt`).
+
+---
+
+## Time travel
+
+### Rewind (`goto` / `restart`)
+
+The debugger snapshots the primal-dual state (`x`, `s`, multipliers, μ,
+τ) every iteration. `goto` rewinds to a captured iteration and stays
+paused so you can re-tune before resuming:
+
+```text
+goto 3               # rewind to the start of iteration 3
+restart              # rewind to the earliest snapshot
+```
+
+> **Caveat — this is a *soft* rewind.** Only the primal-dual state is
+> restored; strategy *history* (the filter, the adaptive-μ oracle, the
+> quasi-Newton memory) is **not** rolled back. So continuing from a
+> rewound point is "resume from here," not a bit-exact replay of the
+> original run.
+
+### Re-solve from a saved point
+
+`resolve` re-runs the solve from the **current** `x` with any
+`set opt` edits applied — a primal warm start with new options. Use it
+for "what if I change `mu_strategy` from here?":
+
+```text
+pounce-dbg> set opt mu_strategy adaptive
+pounce-dbg> resolve
+re-solving from current x with 1 staged option override(s)…
+── pounce-dbg ── iter 0 @iter_start ...   # fresh solve, seeded from the captured x
+```
+
+Because each solve rebuilds its strategies from the options, the changes
+*do* take effect on the re-solve. The seed is dropped (falling back to
+the problem's own start) if presolve / fixed-variable elimination changed
+the coordinate count.
+
+---
+
+## Saving and visualizing artifacts
+
+```text
+save                 # write the current iterate + residuals to a temp JSON
+save /tmp/iter3.json # explicit path
+viz x                # write a block and open it in an external viewer
+viz dx               # a search-direction block
+viz kkt              # the KKT inertia/regularization report
+```
+
+`save` writes every non-empty block, the search-direction blocks, and the
+residual scalars (`iter`, `mu`, `objective`, `inf_pr`, `inf_du`,
+`nlp_error`) — a self-contained artifact for external analysis.
+
+`viz` opens the artifact with `$POUNCE_DBG_VIEWER` (a command template
+where `{}` is replaced by the file path) if set, otherwise the platform
+opener (`xdg-open` / `open`). For a plot, point it at a script:
+
+```sh
+export POUNCE_DBG_VIEWER='python my_plot.py {}'
+```
+
+---
+
+## Attaching to a run
+
+You don't have to single-step from iteration 0.
+
+- **Drop in on failure** — `--debug-on-error` runs the solve freely and
+  pauses at the `terminated` checkpoint **only if the solve did not
+  succeed**, leaving you at the failing iterate for a post-mortem. (Plain
+  `--debug` also pauses at `terminated` for a final-point inspect.)
+- **Attach with Ctrl-C** — `--debug-on-interrupt` runs normally but
+  installs a SIGINT handler; a first Ctrl-C drops you in at the next
+  iteration (`reason: "interrupt (Ctrl-C)"`), a second Ctrl-C aborts.
+  Ctrl-C also breaks into any other debug mode mid-`continue`. (At a
+  rustyline prompt, Ctrl-C is an ordinary line-cancel, not a signal.)
+
+---
+
+## Exit model
+
+| Path | Result |
+|---|---|
+| `quit` | stops now → `UserRequestedStop` |
+| `continue` / `detach` | run to natural completion |
+| stdin EOF, REPL (Ctrl-D) | detach and finish (pdb convention) |
+| stdin EOF, JSON (pipe closed) | abort — the controlling client is gone |
+| external SIGKILL | process dies (no `terminated` event) |
+
+Every non-kill path ends with a `terminated` event in JSON mode.
+
+---
+
+## Command reference
+
+| Command (aliases) | Summary |
+|---|---|
+| `help` (`h`, `?`) | list commands |
+| `info` (`i`) | current-iterate summary |
+| `print <what>` (`p`) | block, `d`-block, scalar, or `kkt` |
+| `step` (`s`, `n`) | run to next `iter_start` |
+| `step sub` / `stepi` (`si`) | run to next checkpoint of any kind |
+| `continue` (`c`) | run to next breakpoint |
+| `run N` (`r`) | run until iteration N |
+| `break …` (`b`) | iteration / `if` / `on` breakpoints; list; `clear`; `del N` |
+| `stop-at <cp>` | always pause at a checkpoint |
+| `set mu/x/<block>/opt …` | mutate μ, the iterate, or stage an option |
+| `opt [filter]` | list/search registered options |
+| `complete <prefix>` | completion candidates |
+| `viz <target>` | open an artifact in a viewer |
+| `save [path]` | dump the iterate to JSON |
+| `goto N` / `restart` | soft-rewind to a captured iteration |
+| `resolve` | re-solve from current x with staged options |
+| `progress [on/off]` | toggle JSON progress events |
+| `detach` | stop pausing; run to completion |
+| `quit` (`q`, `exit`) | stop the solve |
+
+---
+
+## The JSON protocol
+
+`--debug-json` makes **stdout a pure stream of newline-delimited JSON
+objects** (the banner, problem stats, and final summary are routed to
+stderr, and `print_level` is forced to 0). A program reads one JSON
+object per line.
+
+### Session lifecycle
+
+1. `hello` — emitted once, up front. The handshake.
+2. `pause` — at each stop.
+3. `result` — one per command, echoing the client's `request_id`.
+4. `progress` — one per iteration while running between pauses.
+5. `terminated` — once, after the solve.
+
+### Commands
+
+Write one per line to stdin, either a bare string or an object:
+
+```json
+{"cmd": "print", "args": ["x"], "id": 7}
+{"cmd": "break if inf_pr<1e-6", "id": 8}
+"continue"
+```
+
+`id` (any JSON value) is echoed back as `request_id` on the matching
+`result`, for async correlation.
+
+### `hello`
+
+```json
+{"event":"hello","protocol":"pounce-dbg/1","pounce_version":"0.2.0",
+ "capabilities":{"inspect":true,"mutate_iterate":true,"mutate_mu":true,
+   "conditional_breakpoints":"compound","request_ids":true,
+   "viz":["block","delta"],"save":true,"kkt_inspect":true,
+   "rewind":"primal_dual","resolve":true,"terminal_checkpoint":true,
+   "interruptible":true,"progress_events":true,"async_pause":"checkpoint"},
+ "checkpoints":["iter_start","after_mu","after_search_dir","after_step",
+                "pre_restoration_entry","post_restoration_exit","terminated"],
+ "events":["resto_entered","resto_exited","regularized","tiny_step",
+           "ls_rejected","nan"],
+ "commands":[…],"blocks":[…],"metrics":[…]}
+```
+
+A client should **feature-detect off `capabilities` / `checkpoints` /
+`events`** rather than the protocol string — those lists are additive as
+the debugger grows.
+
+### `pause`
+
+```json
+{"event":"pause","checkpoint":"iter_start","status":null,
+ "iter":3,"mu":2.0e-2,"objective":5.05,"inf_pr":0.0,"inf_du":2.7e-14,
+ "nlp_error":0.0237,"dims":{"x":2,"s":0,"y_c":0,"y_d":0,"z_l":2,"z_u":2,
+ "v_l":0,"v_u":0},"breakpoints":[],"conditions":[],"reason":"mu<0.05"}
+```
+
+`status` is non-null only at the `terminated` checkpoint. `reason`
+carries the firing breakpoint / condition / event / interrupt.
+
+### `result`
+
+```json
+{"event":"result","request_id":7,"command":"print x","ok":true,
+ "output":["x = [-1.18e0, 1.38e0]"],"data":{"name":"x","values":[-1.18,1.38]}}
+```
+
+`output` is human-readable lines; `data` is the structured payload
+(present for inspection commands).
+
+### `progress`
+
+```json
+{"event":"progress","iter":42,"mu":1.0e-5,"inf_pr":3.2e-7,"inf_du":1.1e-6,"obj":12.34}
+```
+
+Emitted once per outer iteration during a `continue`, so a UI can show
+live progress instead of a hang. Default on; toggle with the `progress`
+command.
+
+### `terminated`
+
+```json
+{"event":"terminated","status":"SolveSucceeded",
+ "status_message":"Optimal Solution Found.","iterations":6,
+ "objective":4.9999999,"evals":{"obj":7,"obj_grad":7,"constr":1,
+ "constr_jac":12,"hess":6}}
+```
+
+### Async pause
+
+A running `continue` is interrupted by sending **SIGINT** to the process
+(`process.kill(pid, "SIGINT")`); the debugger pauses at the next
+checkpoint with `reason: "interrupt (Ctrl-C)"`. This is what a Debug
+Adapter's pause button maps to. (`hello.capabilities.async_pause` is
+`"checkpoint"`.)
+
+---
+
+## Tutorials
+
+### 1. Why did this problem go to restoration?
+
+```text
+$ pounce hard.nl --debug-json
+{"cmd":"break on resto_entered"}
+{"cmd":"continue"}
+# → pause at checkpoint "pre_restoration_entry", reason "event: resto_entered"
+{"cmd":"info"}                # how infeasible is the iterate?
+{"cmd":"print kkt"}           # was the KKT singular / heavily regularized?
+{"cmd":"print x"}
+```
+
+### 2. Catch a step that gets regularized
+
+```text
+break on regularized
+continue
+# → pause at after_search_dir when delta_w > 0
+print kkt        # inertia n- vs expected; delta_w / delta_c
+print dx         # the (stabilized) Newton step
+```
+
+### 3. What-if: try a different μ strategy from here
+
+```text
+break 5
+continue                 # stop at iteration 5
+set opt mu_strategy adaptive
+resolve                  # re-solve from the iter-5 point with adaptive μ
+```
+
+### 4. Post-mortem on a failure
+
+```sh
+pounce maybe-infeasible.nl --debug-on-error
+```
+
+Runs unattended; if the solve returns anything but success you land at
+the final iterate:
+
+```text
+── pounce-dbg ── TERMINATED (LocalInfeasibility)  iter 11  obj=1.13e0  inf_pr=5.0e-1  inf_du=1.2e-8
+pounce-dbg> print x
+pounce-dbg> print kkt
+```
+
+### 5. Drive it from a program / agent
+
+```python
+import subprocess, json
+p = subprocess.Popen(["pounce", "hs071.nl", "--debug-json"],
+                     stdin=subprocess.PIPE, stdout=subprocess.PIPE, text=True)
+
+def send(cmd, **kw): p.stdin.write(json.dumps({"cmd": cmd, **kw}) + "\n"); p.stdin.flush()
+def recv():          return json.loads(p.stdout.readline())
+
+hello = recv()                       # capabilities / vocabulary
+print(recv())                        # initial pause
+send("break if inf_du<1e-6", id=1)
+print(recv())                        # result, request_id=1
+send("continue")
+for line in p.stdout:                # progress … pause … terminated
+    ev = json.loads(line)
+    if ev["event"] == "terminated": break
+```
+
+---
+
+## Limitations
+
+- **No live KKT-matrix / L-factor heatmap.** `print kkt` / `viz kkt`
+  give the inertia and regularization *scalars*; the full sparse matrix
+  and its `LDLᵀ` factor pattern are not captured at the checkpoint. Use
+  the offline dump for those: `--dump kkt:<iter>+L+Lvals --dump-dir DIR`
+  (see [Running Solves](cli.md)).
+- **Soft rewind only.** `goto`/`restart` restore the primal-dual state,
+  not strategy history (see the caveat above).
+- **Async pause is SIGINT-based.** An in-band `{"cmd":"pause"}` (for
+  platforms without convenient signals) is not yet wired.
+- **`set opt` is staged, not hot-applied** to a running solve; it takes
+  effect on `resolve` / the next solve.

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -191,7 +191,14 @@ print x              # a primal/dual block (alias: p x)
 print dx             # a search-direction block (d + block name)
 print mu             # a scalar: mu|obj|inf_pr|inf_du|err|iter
 print kkt            # KKT inertia + regularization (see below)
+watch mu             # auto-print a target at every pause (alias: display)
+watch                # list watches; watch del mu; watch clear
 ```
+
+`watch <target>` registers any `print` target (block, `dx`, scalar,
+`kkt`) to be shown automatically at every subsequent pause — the
+debugger's equivalent of gdb's `display`. In JSON mode the values arrive
+in the pause event's `watches` array.
 
 **Blocks** (the eight components of the primal-dual iterate):
 
@@ -386,6 +393,32 @@ You don't have to single-step from iteration 0.
 
 ---
 
+## Scripting
+
+Run a sequence of debugger commands from a file — one per line, `#` and
+`//` comments and blank lines skipped:
+
+```text
+# warmup.pdbg
+break if inf_pr<1e-6
+watch mu
+stop-at after_search_dir
+continue
+```
+
+```sh
+pounce problem.nl --debug-script warmup.pdbg        # run at the first pause
+```
+
+```text
+pounce-dbg> source warmup.pdbg                       # or interactively
+```
+
+A script runs top-to-bottom and stops early if a command resumes or
+stops the solve (so ending with `continue` hands control back at the
+first breakpoint). `--debug-script` implies `--debug` when no `--debug*`
+mode is given, and runs once at the first pause (not on a `resolve`).
+
 ## Exit model
 
 | Path | Result |
@@ -418,6 +451,8 @@ Every non-kill path ends with a `terminated` event in JSON mode.
 | `complete <prefix>` | completion candidates |
 | `viz <target>` | open an artifact in a viewer |
 | `save [path]` | dump the iterate to JSON |
+| `watch <target>` (`display`) | auto-print a target at every pause |
+| `source <file>` | run debugger commands from a file |
 | `goto N` / `restart` | soft-rewind to a captured iteration |
 | `resolve` | re-solve from current x with staged options |
 | `ask [question]` | ask Claude Code (`claude -p` / `$POUNCE_DBG_LLM`) about the state |

--- a/python/pounce/_debug_viz.py
+++ b/python/pounce/_debug_viz.py
@@ -1,0 +1,171 @@
+"""Interactive viewer for the POUNCE debugger's `viz` / `save` artifacts.
+
+The interactive debugger (`pounce --debug` / `--debug-json`) writes a JSON
+artifact and launches the command in ``$POUNCE_DBG_VIEWER``. Point that at
+this viewer to get **interactive Plotly** figures instead of raw JSON::
+
+    export POUNCE_DBG_VIEWER='pounce-dbg-viz {}'
+
+then, at the ``pounce-dbg>`` prompt::
+
+    stop-at kkt
+    continue
+    viz kkt      # → spy/heatmap of the augmented (KKT) matrix + inertia
+    viz L        # → spy/heatmap of the LDLᵀ factor
+    viz x        # → bar chart of the primal block
+
+It also renders `save` artifacts (the full iterate) and any vector block.
+Requires plotly (``pip install 'pounce-solver[viz]'``).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+def _require_plotly():
+    try:
+        import plotly.graph_objects as go  # noqa: F401
+
+        return go
+    except ImportError:
+        sys.stderr.write(
+            "pounce-dbg-viz: plotly is required.\n"
+            "    pip install 'pounce-solver[viz]'   (or: pip install plotly)\n"
+        )
+        raise SystemExit(2)
+
+
+def _spy(go, rows, cols, vals, n, title, *, symmetric=False, unit_diag=False):
+    """A spy/heatmap scatter: one marker per nonzero, colored by value,
+    hover shows (row, col, value). 1-based row/col inputs."""
+    r = list(rows)
+    c = list(cols)
+    v = list(vals) if vals is not None else [1.0] * len(r)
+    if symmetric:
+        # Mirror the strict lower triangle to the upper triangle.
+        for i in range(len(rows)):
+            if rows[i] != cols[i]:
+                r.append(cols[i])
+                c.append(rows[i])
+                v.append(v[i])
+    if unit_diag:
+        for i in range(1, n + 1):
+            r.append(i)
+            c.append(i)
+            v.append(1.0)
+    has_vals = any(x not in (0.0, 1.0) for x in v) or vals is not None
+    fig = go.Figure(
+        go.Scatter(
+            x=c,
+            y=r,
+            mode="markers",
+            marker=dict(
+                size=max(4, min(18, int(420 / max(n, 1)))),
+                symbol="square",
+                color=v if has_vals else "#3b6",
+                colorscale="RdBu" if has_vals else None,
+                cmid=0 if has_vals else None,
+                showscale=has_vals,
+                line=dict(width=0),
+            ),
+            text=[f"({rr},{cc}) = {vv:.6g}" for rr, cc, vv in zip(r, c, v)],
+            hoverinfo="text",
+        )
+    )
+    fig.update_yaxes(autorange="reversed", scaleanchor="x", constrain="domain")
+    fig.update_xaxes(constrain="domain")
+    fig.update_layout(
+        title=title,
+        xaxis_title="column",
+        yaxis_title="row",
+        width=720,
+        height=720,
+        template="plotly_white",
+    )
+    return fig
+
+
+def _bar(go, values, title):
+    fig = go.Figure(go.Bar(x=list(range(len(values))), y=values))
+    fig.update_layout(
+        title=title,
+        xaxis_title="index",
+        yaxis_title="value",
+        template="plotly_white",
+        height=420,
+    )
+    return fig
+
+
+def figure_for(go, art: dict[str, Any]):
+    """Build a Plotly figure for one debugger artifact."""
+    label = art.get("label", "")
+    it = art.get("iter")
+
+    # KKT matrix (symmetric augmented system).
+    if label == "kkt" and isinstance(art.get("matrix"), dict):
+        m = art["matrix"]
+        n = m["dim"]
+        inertia = (
+            f"n+={art.get('n_pos')} n-={art.get('n_neg')} "
+            f"(expected n-={art.get('expected_neg')}, "
+            f"{'correct' if art.get('inertia_correct') else 'WRONG'})"
+        )
+        title = (
+            f"KKT matrix — iter {it}, dim {n}<br>"
+            f"<sub>{inertia} | δ_w={art.get('delta_w'):.2e} "
+            f"δ_c={art.get('delta_c'):.2e} | {art.get('status')}</sub>"
+        )
+        return _spy(go, m["irn"], m["jcn"], m["vals"], n, title, symmetric=True)
+
+    # LDLᵀ factor (strict lower, unit diagonal implicit).
+    if label == "L" and "l_irn" in art:
+        n = art["n"]
+        title = f"LDLᵀ factor L — iter {it}, n {n} (unit diagonal implicit)"
+        return _spy(
+            go, art["l_irn"], art["l_jcn"], art.get("l_vals"), n, title, unit_diag=True
+        )
+
+    # A single vector block (`viz x`, `viz dx`, …).
+    if "values" in art:
+        return _bar(go, art["values"], f"{label} — iter {it}")
+
+    # A `save` artifact: the full iterate. Plot the primal x by default.
+    if isinstance(art.get("iterate"), dict):
+        iterate = art["iterate"]
+        block = "x" if "x" in iterate else next(iter(iterate), None)
+        if block is not None:
+            return _bar(go, iterate[block], f"iterate[{block}] — iter {it}")
+
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if not argv:
+        sys.stderr.write("usage: pounce-dbg-viz <artifact.json>\n")
+        return 2
+    go = _require_plotly()
+    path = argv[0]
+    try:
+        with open(path) as fh:
+            art = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"pounce-dbg-viz: cannot read {path}: {e}\n")
+        return 1
+    fig = figure_for(go, art)
+    if fig is None:
+        sys.stderr.write(
+            f"pounce-dbg-viz: don't know how to visualize this artifact "
+            f"(label={art.get('label')!r}); keys: {sorted(art)}\n"
+        )
+        return 1
+    fig.show()  # opens an interactive figure in the browser
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = ["numpy>=1.23"]
 # shim prints a helpful message in that case.
 [project.scripts]
 pounce = "pounce._cli:main"
+# Interactive viewer for the debugger's `viz`/`save` artifacts. Point the
+# debugger at it with: export POUNCE_DBG_VIEWER='pounce-dbg-viz {}'
+pounce-dbg-viz = "pounce._debug_viz:main"
 
 [project.optional-dependencies]
 jax = ["jax>=0.4.30", "jaxlib>=0.4.30"]
@@ -41,7 +44,8 @@ scipy = ["scipy>=1.11"]
 # diffrax is only needed to run the inverse-map ODE example/recipe
 # (pounce#91); the inverse_map_rhs helper itself depends only on jax.
 diffrax = ["diffrax>=0.5"]
-dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30"]
+viz = ["plotly>=5"]
+dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30", "plotly>=5"]
 
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"

--- a/python/tests/test_debug_viz.py
+++ b/python/tests/test_debug_viz.py
@@ -1,0 +1,78 @@
+"""Tests for the interactive debugger-artifact viewer (`pounce-dbg-viz`).
+
+Loads the module by file path so it doesn't require the compiled
+`pounce._pounce` extension; skips if plotly isn't installed.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+pytest.importorskip("plotly")
+import plotly.graph_objects as go  # noqa: E402
+
+_MOD = pathlib.Path(__file__).resolve().parent.parent / "pounce" / "_debug_viz.py"
+_spec = importlib.util.spec_from_file_location("_pounce_debug_viz", _MOD)
+dv = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(dv)
+
+
+def test_kkt_artifact_builds_symmetric_spy():
+    art = {
+        "label": "kkt",
+        "iter": 0,
+        "n_pos": 2,
+        "n_neg": 1,
+        "expected_neg": 1,
+        "inertia_correct": True,
+        "delta_w": 0.0,
+        "delta_c": 0.0,
+        "status": "Success",
+        "matrix": {
+            "dim": 3,
+            "irn": [1, 2, 3, 3],
+            "jcn": [1, 2, 1, 3],
+            "vals": [2.0, 2.0, 1.0, -1.0],
+            "format": "triplet_1based_lower",
+        },
+    }
+    fig = dv.figure_for(go, art)
+    assert fig is not None and len(fig.data) == 1
+    # Off-diagonal (3,1) is mirrored to (1,3): 4 stored + 1 mirror = 5.
+    assert len(fig.data[0].x) == 5
+    assert "KKT matrix" in fig.layout.title.text
+
+
+def test_l_factor_adds_unit_diagonal():
+    art = {
+        "label": "L",
+        "iter": 1,
+        "n": 2,
+        "perm": [0, 1],
+        "l_irn": [2],
+        "l_jcn": [1],
+        "l_vals": [0.5],
+        "format": "strict_lower_1based_permuted",
+    }
+    fig = dv.figure_for(go, art)
+    assert fig is not None
+    # one strict-lower entry + 2 implicit unit-diagonal markers.
+    assert len(fig.data[0].x) == 3
+
+
+def test_vector_block_builds_bar():
+    fig = dv.figure_for(go, {"label": "x", "iter": 3, "values": [1.0, -2.0, 3.0]})
+    assert fig is not None
+    assert list(fig.data[0].y) == [1.0, -2.0, 3.0]
+
+
+def test_save_artifact_plots_primal():
+    art = {"iter": 4, "mu": 0.1, "iterate": {"x": [1.0, 2.0], "z_l": [0.1, 0.2]}}
+    fig = dv.figure_for(go, art)
+    assert fig is not None
+    assert list(fig.data[0].y) == [1.0, 2.0]
+
+
+def test_unknown_artifact_returns_none():
+    assert dv.figure_for(go, {"label": "mystery"}) is None


### PR DESCRIPTION
## Summary

Introduces a comprehensive interactive debugger for the interior-point loop — a "pdb for the IPM" — with two user-facing front ends: a human REPL (`--debug`) and a newline-delimited JSON protocol (`--debug-json`) for programmatic control by agents or scripts.

## Key Changes

**Core debugger engine** (`crates/pounce-algorithm/src/debug.rs`):
- New `DebugHook` trait and `DebugCtx` for live, mutable inspection of algorithm state
- Seven checkpoint types (`IterStart`, `AfterBarrierUpdate`, `AfterSearchDirection`, `AfterStep`, `PreRestoration`, `PostRestoration`, `Terminated`)
- `KktReport` struct capturing KKT factorization diagnostics (inertia, regularization)
- Safe mutation via `Rc<RefCell<>>` sharing and tag-keyed cache invalidation

**CLI integration** (`crates/pounce-cli/src/debug_repl.rs`):
- Human REPL with rustyline (history, Ctrl-R search, Tab completion)
- JSON protocol parser for agent-driven debugging
- Breakpoint system: by iteration, conditional watchpoints, and command lists
- Commands: `step`, `continue`, `break`, `print`, `watch`, `set`, `resolve` (warm-start re-solve), `viz`/`save` (artifact export)
- Ctrl-C handler for breaking into debugger mid-solve
- Restoration inner-IPM stepping (same debugger drives both levels)

**Algorithm integration**:
- `IpoptAlgorithm::with_debug_hook()` and `set_debug_hook()` methods
- Checkpoint firing at all major loop phases
- Restoration phase forwards debugger to inner solver
- Zero overhead when debugger not attached (short-circuit at fire-sites)

**Visualization** (`python/pounce/_debug_viz.py`):
- Interactive Plotly viewer for debugger artifacts (`viz kkt`, `viz L`, `viz x`, etc.)
- Spy/heatmap plots for matrices, bar charts for vectors
- Launched via `$POUNCE_DBG_VIEWER` environment variable

**Documentation** (`docs/src/debugger.md`):
- 720-line comprehensive guide covering quick start, both front ends, checkpoints, stepping, breakpoints, and the JSON protocol
- Color theme reference (`docs/src/color-theme.md`)

**Supporting changes**:
- `SeededTnlp` wrapper for warm-start re-solves from captured iterates
- KKT solver interface extensions (`system_dim()`, `kkt_triplets()`) for debugger introspection
- CLI argument parsing for `--debug`, `--debug-on-error`, `--debug-on-interrupt`, `--debug-script`
- Conditional `print_level 0` in JSON mode to keep stdout clean for protocol

## Notable Implementation Details

- **Mutation safety**: Debugger writes go through the same `RefCell` path as the main loop; overwriting the iterate rebuilds a fresh `IteratesVector` with a new tag, transparently invalidating CQ caches.
- **Shared restoration debugging**: The same `Rc<RefCell<dyn DebugHook>>` is passed to the restoration inner IPM, enabling unified stepping across both solves.
- **Zero-cost abstraction**: Checkpoint fire-sites short-circuit when no debugger is installed; regression suite is bit-for-bit identical with/without the feature.
- **Dual protocols**: REPL and JSON share one command engine; JSON mode suppresses solver output to keep stdout a pure protocol channel.

https://claude.ai/code/session_01KGVf4yQfFTB9LHTSXVfFZw