### PR TITLE
Add PyTorch frontend (pounce#109)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,44 @@ jobs:
       - name: Run Python tests
         run: python -m pytest python/tests -q
 
+  # Exercise the PyTorch frontend (`pounce.torch`, pounce#109) on every
+  # PR. Mirrors `python-test` but installs the CPU torch wheel alongside
+  # jax so both the torch suite and the JAX↔Torch parity fixtures run.
+  python-test-torch:
+    name: Python tests (torch)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Checkout feral sibling
+        run: git clone --depth 1 https://github.com/jkitchin/feral.git ../feral
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          target: x86_64
+          manylinux: manylinux2014
+          args: --release --out dist
+          sccache: "true"
+          docker-options: |
+            -v ${{ github.workspace }}/../feral:${{ github.workspace }}/../feral
+      - name: Install wheel + test deps
+        run: |
+          python -m pip install --upgrade pip
+          # CPU torch wheel — pounce solves on the host, no CUDA needed.
+          python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install python/dist/*.whl pytest scipy "jax[cpu]"
+      - name: Run Python torch + parity tests
+        run: |
+          python -m pytest python/tests/test_torch.py \
+            python/tests/test_qp_torch.py \
+            python/tests/test_socp_torch.py \
+            python/tests/test_parity_jax_torch.py -q
+
   # Smoke-build the `pounce-solver` wheel on every PR so packaging
   # regressions surface here, not at tag time. Runs only on Linux
   # x86_64; the full multi-platform matrix lives in release-pounce.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ changes.
 
 ## [Unreleased]
 
+### Added — PyTorch frontend for the differentiable solver (`pounce.torch`)
+
+A PyTorch frontend mirroring `pounce.jax`: a solve is a
+`torch.autograd.Function` you can drop inside a learned model and backprop
+through, with the same constraint-satisfaction guarantee. This is a thin
+adapter, not a second solver — the Rust IPM core and the
+implicit-function-theorem backward are framework-agnostic; only the array
+namespace differs. Because PyTorch is eager, the adapter is smaller than the
+JAX one (no `pure_callback` / `ShapeDtypeStruct`, no host-callback registry or
+single-thread executor pin), and float64 is requested per tensor rather than
+via a global flag.
+
+Surface (parity with `pounce.jax`):
+
+- `from_torch` — build a `Problem` from `torch.func`-traced `f` / `g`
+  (`grad` / `jacrev` / `jacfwd` / `hessian`; CPR colored AD for `sparse=`,
+  via the shared detection/coloring helpers now in `pounce._ad_common`).
+- `solve` / `solve_with_warm` — `autograd.Function` + KKT implicit-diff
+  backward, with dual + barrier-μ warm-start threading.
+- `vmap_solve` / `vmap_solve_parallel` — sequential / threadpool batches.
+- `TorchProblem` — build-once handle with k_aug-style factor-reuse backward
+  (`Solver.kkt_solve_many`), stacked block-diagonal batched solve, and the
+  anchor / sensitivity / jvp_from_state / vjp_from_state / active_set_margin
+  post-solve API.
+- `solve_qp` / `solve_qp_batch` / `solve_socp` / `QpLayer` — OptNet-style
+  differentiable conic layers (feasible-by-construction).
+- `PathFollower` / `inverse_map_rhs` — predictor–corrector path following.
+
+PyTorch is an optional dependency (`pip install pounce-solver[torch]`,
+torch ≥ 2.2). See the [PyTorch integration guide](docs/src/python.md).
+
 ### Added — Convex QCQP auto-routes to the conic (SOCP) solver
 
 The `auto` router now recognizes a convex **quadratically-constrained QP** and

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -16,7 +16,8 @@ Optional extras:
 
 ```sh
 pip install -e .[jax]        # JAX integration
-pip install -e .[dev]        # tests + jax + scipy
+pip install -e .[torch]      # PyTorch integration
+pip install -e .[dev]        # tests + jax + torch + scipy
 ```
 
 ## cyipopt-style interface
@@ -681,6 +682,83 @@ handle is garbage-collected without `close()`. A worked example —
 projection layer, full Jacobian, JVP/VJP-from-state, and the lifetime
 patterns — is in
 [`notebooks/13_post_solve_jacobian.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/13_post_solve_jacobian.ipynb).
+
+## PyTorch integration
+
+The `pounce.torch` subpackage is a PyTorch frontend mirroring
+`pounce.jax`, one-for-one. It is a thin **adapter**, not a second solver:
+the numerical core (the Rust IPM) and the implicit-function-theorem
+backward are framework-agnostic — only the array namespace differs. A
+solve is a `torch.autograd.Function` you can drop inside a `torch.nn`
+model and backprop through, with the same constraint-satisfaction
+guarantee the JAX path gives. Install with `pip install pounce[torch]`
+(`torch.func` requires torch ≥ 2.2).
+
+Because PyTorch is eager, the adapter is *smaller* than the JAX one:
+there is no `pure_callback` / `ShapeDtypeStruct` machinery (the forward
+calls `problem.solve(...)` directly), no host-callback registry or
+single-thread executor (the converged `Solver` is stashed on the
+autograd `ctx` / `AnchorState` and read back in the backward on the same
+thread), and no global `jax_enable_x64` flag — float64 tensors are
+requested explicitly (`torch.set_default_dtype(torch.float64)` or
+`.double()` your inputs; the implicit-diff and KKT solves need double
+precision and the layers validate it).
+
+| JAX surface | PyTorch equivalent |
+|---|---|
+| `from_jax(f, g, …)` | `from_torch(f, g, …)` |
+| `solve(p, …)` | `solve(p, …)` (`torch.autograd.Function` + KKT backward) |
+| `solve_with_warm(p, …, warm_start=)` | `solve_with_warm(…)` (dual triple + barrier-μ, pounce#86) |
+| `vmap_solve` / `vmap_solve_parallel` | `vmap_solve` / `vmap_solve_parallel` |
+| `JaxProblem(…)` | `TorchProblem(…)` (build-once, factor-reuse backward) |
+| `solve_qp` / `solve_qp_batch` / `solve_socp` / `QpLayer` | same names |
+| `PathFollower` / `inverse_map_rhs` | same names |
+
+```python
+import torch
+torch.set_default_dtype(torch.float64)
+from pounce.torch import solve as psolve
+
+def f(x, p): return torch.sum((x - p) ** 2)
+def g(x, p): return torch.stack([x[0] + x[1] - 1.0])   # equality
+
+p = torch.tensor([0.3, 0.7], requires_grad=True)
+x_star = psolve(
+    p, f=f, g=g, x0=torch.zeros(2), n=2, m=1,
+    lb=torch.full((2,), -10.0), ub=torch.full((2,), 10.0),
+    cl=torch.zeros(1), cu=torch.zeros(1),
+    options={"tol": 1e-10, "print_level": 0},
+)
+(x_star ** 2).sum().backward()   # dL/dp via the implicit function theorem
+print(p.grad)
+```
+
+The differentiable conic layers are feasible-by-construction (the same
+"one roof" as cvxpylayers/theseus, off one core):
+
+```python
+from pounce.torch import solve_qp
+P = torch.eye(2); c = torch.tensor([-4.0, -4.0], requires_grad=True)
+G = torch.tensor([[1.0, 1.0]]); h = torch.tensor([0.5])
+x = solve_qp(P=P, c=c, G=G, h=h)   # min ½xᵀPx+cᵀx s.t. Gx ≤ h
+x.sum().backward()                  # OptNet implicit-diff gradients
+```
+
+Validation. Every layer is checked with `torch.autograd.gradcheck`
+against finite differences, and a JAX↔Torch **parity** suite asserts both
+frontends agree on `x*` and `dL/dp` to tolerance on shared fixtures
+(`python/tests/test_torch.py`, `test_qp_torch.py`, `test_socp_torch.py`,
+`test_parity_jax_torch.py`).
+
+> Thread-safety note. `torch.func` transforms share a process-global
+> layer stack and are not thread-safe; `vmap_solve_parallel` therefore
+> serializes the (already GIL-bound) Python derivative callbacks with a
+> lock while the Rust IPM linear algebra still runs concurrently
+> (GIL released). Double-backward is supported on the conic layers but
+> not guaranteed on the NLP implicit-diff path (the parameter
+> sensitivities are taken with `torch.func`, outside the autograd graph)
+> — set `factor_reuse=False` on `TorchProblem` for the in-framework dense
+> backward if you need higher-order behaviour.
 
 ## Notebooks
 

--- a/python/pounce/_ad_common.py
+++ b/python/pounce/_ad_common.py
@@ -1,0 +1,121 @@
+"""Framework-neutral autodiff-bridge helpers shared by the JAX and
+PyTorch frontends (pounce#109).
+
+The numerical core (the Rust IPM, exposed via :class:`pounce._pounce.Problem`)
+and the sparsity-detection / CPR-coloring bookkeeping around it are
+autodiff-framework-agnostic — they operate on plain NumPy arrays. Both
+``pounce.jax`` and ``pounce.torch`` build a cyipopt-shaped problem object
+from traced ``f(x)`` / ``g(x)``; the only piece that differs between them
+is the *array namespace* used to evaluate the derivatives. Everything
+here is pure NumPy and is imported by both adapters so the sparsity
+pattern detection and column coloring live in exactly one place.
+
+* :func:`_detect_pattern_2d_multi` / :func:`_detect_pattern_lower_multi`
+  turn a set of dense probe matrices into ``(rows, cols)`` nonzero
+  patterns (cyipopt convention).
+* :func:`_color_columns` is the CPR (Curtis–Powell–Reid) distance-1
+  greedy coloring of the column-intersection graph used to compress the
+  sparse Jacobian / Hessian into one directional derivative per color
+  (issue #83).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import numpy as np
+
+# Threshold below which a Jacobian/Hessian entry is treated as
+# structurally zero during the pattern probe. Tight enough to reject
+# genuine zeros from constant terms, loose enough that random probe
+# values don't accidentally hit a numerical cancellation that would
+# drop a real entry.
+_SPARSITY_EPS = 1e-12
+
+
+def _to_np(a) -> np.ndarray:
+    return np.asarray(a, dtype=np.float64)
+
+
+def _union_mask(denses) -> np.ndarray:
+    """Boolean nonzero mask over one or more dense probe matrices.
+
+    A nonzero in *any* probe is treated as structurally nonzero, so a
+    value-dependent zero that a single probe happens to hit doesn't
+    drop a real entry from the pattern.
+    """
+    mask = None
+    for dense in denses:
+        m = np.abs(np.asarray(dense)) > _SPARSITY_EPS
+        mask = m if mask is None else (mask | m)
+    return mask
+
+
+def _detect_pattern_2d_multi(denses) -> tuple[np.ndarray, np.ndarray]:
+    rows, cols = np.nonzero(_union_mask(denses))
+    return rows.astype(np.int64), cols.astype(np.int64)
+
+
+def _detect_pattern_lower_multi(denses) -> tuple[np.ndarray, np.ndarray]:
+    """Lower-triangle sparsity pattern of a symmetric matrix, unioned
+    across probes."""
+    mask = _union_mask(denses)
+    n = mask.shape[0]
+    rows, cols = np.tril_indices(n)
+    keep = mask[rows, cols]
+    return rows[keep].astype(np.int64), cols[keep].astype(np.int64)
+
+
+def _detect_pattern_2d(dense: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    return _detect_pattern_2d_multi([dense])
+
+
+def _detect_pattern_lower(dense: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Lower-triangle sparsity pattern of a symmetric matrix."""
+    return _detect_pattern_lower_multi([dense])
+
+
+def _color_columns(
+    rows: np.ndarray, cols: np.ndarray, n: int,
+) -> tuple[np.ndarray, int]:
+    """Greedy distance-1 coloring of the column-intersection graph.
+
+    Two columns *conflict* (must get different colors) when they share
+    a nonzero row. Columns that share a color are therefore structurally
+    orthogonal: a single directional derivative seeded on all of them at
+    once recovers each column's entries unambiguously by row, because no
+    row receives a contribution from more than one of them.
+
+    This is the CPR (Curtis–Powell–Reid) compression used for both the
+    sparse Jacobian and (on the symmetrized pattern) the sparse Hessian.
+    Greedy coloring is not optimal but is cheap and gives ``k`` close to
+    the maximum number of nonzeros in any row, which is what bounds the
+    AD-pass count.
+
+    Returns ``(colors, num_colors)`` where ``colors[j]`` is the color of
+    column ``j`` (columns with no nonzeros get color 0).
+    """
+    cols_in_row: dict[int, list[int]] = defaultdict(list)
+    rows_of_col: dict[int, list[int]] = defaultdict(list)
+    for r, c in zip(rows.tolist(), cols.tolist()):
+        cols_in_row[r].append(c)
+        rows_of_col[c].append(r)
+
+    colors = np.full(int(n), -1, dtype=np.int64)
+    num_colors = 0
+    for j in range(int(n)):
+        forbidden: set[int] = set()
+        for r in rows_of_col.get(j, ()):
+            for c2 in cols_in_row[r]:
+                cc = colors[c2]
+                if c2 != j and cc >= 0:
+                    forbidden.add(int(cc))
+        c = 0
+        while c in forbidden:
+            c += 1
+        colors[j] = c
+        if c + 1 > num_colors:
+            num_colors = c + 1
+    # Empty matrix: still report one (unused) color so seed shapes are
+    # well-defined.
+    return colors, max(num_colors, 1)

--- a/python/pounce/jax/_build.py
+++ b/python/pounce/jax/_build.py
@@ -51,103 +51,20 @@ import jax.numpy as jnp
 import numpy as np
 
 from .._pounce import Problem
-
-# Threshold below which a Jacobian/Hessian entry is treated as
-# structurally zero during the pattern probe. Tight enough to reject
-# genuine zeros from constant terms, loose enough that random probe
-# values don't accidentally hit a numerical cancellation that would
-# drop a real entry.
-_SPARSITY_EPS = 1e-12
-
-
-def _union_mask(denses) -> np.ndarray:
-    """Boolean nonzero mask over one or more dense probe matrices.
-
-    A nonzero in *any* probe is treated as structurally nonzero, so a
-    value-dependent zero that a single probe happens to hit doesn't
-    drop a real entry from the pattern.
-    """
-    mask = None
-    for dense in denses:
-        m = np.abs(np.asarray(dense)) > _SPARSITY_EPS
-        mask = m if mask is None else (mask | m)
-    return mask
-
-
-def _detect_pattern_2d_multi(denses) -> tuple[np.ndarray, np.ndarray]:
-    rows, cols = np.nonzero(_union_mask(denses))
-    return rows.astype(np.int64), cols.astype(np.int64)
-
-
-def _detect_pattern_lower_multi(denses) -> tuple[np.ndarray, np.ndarray]:
-    """Lower-triangle sparsity pattern of a symmetric matrix, unioned
-    across probes."""
-    mask = _union_mask(denses)
-    n = mask.shape[0]
-    rows, cols = np.tril_indices(n)
-    keep = mask[rows, cols]
-    return rows[keep].astype(np.int64), cols[keep].astype(np.int64)
-
-
-def _detect_pattern_2d(dense: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    return _detect_pattern_2d_multi([dense])
-
-
-def _detect_pattern_lower(dense: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-    """Lower-triangle sparsity pattern of a symmetric matrix."""
-    return _detect_pattern_lower_multi([dense])
-
-
-def _to_np(a) -> np.ndarray:
-    return np.asarray(a, dtype=np.float64)
-
-
-def _color_columns(
-    rows: np.ndarray, cols: np.ndarray, n: int,
-) -> tuple[np.ndarray, int]:
-    """Greedy distance-1 coloring of the column-intersection graph.
-
-    Two columns *conflict* (must get different colors) when they share
-    a nonzero row. Columns that share a color are therefore structurally
-    orthogonal: a single directional derivative seeded on all of them at
-    once recovers each column's entries unambiguously by row, because no
-    row receives a contribution from more than one of them.
-
-    This is the CPR (Curtis–Powell–Reid) compression used for both the
-    sparse Jacobian and (on the symmetrized pattern) the sparse Hessian.
-    Greedy coloring is not optimal but is cheap and gives ``k`` close to
-    the maximum number of nonzeros in any row, which is what bounds the
-    AD-pass count.
-
-    Returns ``(colors, num_colors)`` where ``colors[j]`` is the color of
-    column ``j`` (columns with no nonzeros get color 0).
-    """
-    from collections import defaultdict
-
-    cols_in_row: dict[int, list[int]] = defaultdict(list)
-    rows_of_col: dict[int, list[int]] = defaultdict(list)
-    for r, c in zip(rows.tolist(), cols.tolist()):
-        cols_in_row[r].append(c)
-        rows_of_col[c].append(r)
-
-    colors = np.full(int(n), -1, dtype=np.int64)
-    num_colors = 0
-    for j in range(int(n)):
-        forbidden: set[int] = set()
-        for r in rows_of_col.get(j, ()):
-            for c2 in cols_in_row[r]:
-                cc = colors[c2]
-                if c2 != j and cc >= 0:
-                    forbidden.add(int(cc))
-        c = 0
-        while c in forbidden:
-            c += 1
-        colors[j] = c
-        if c + 1 > num_colors:
-            num_colors = c + 1
-    # Empty matrix: still report one (unused) color so seed shapes are
-    # well-defined.
-    return colors, max(num_colors, 1)
+# Framework-neutral sparsity helpers shared with the PyTorch frontend
+# (pounce#109). Re-exported from this module so existing
+# ``from pounce.jax._build import _color_columns`` style imports (and the
+# test-suite's direct use of them) keep working unchanged.
+from .._ad_common import (  # noqa: F401
+    _SPARSITY_EPS,
+    _color_columns,
+    _detect_pattern_2d,
+    _detect_pattern_2d_multi,
+    _detect_pattern_lower,
+    _detect_pattern_lower_multi,
+    _to_np,
+    _union_mask,
+)
 
 
 def _seed_matrix(colors: np.ndarray, num_colors: int, n: int) -> jnp.ndarray:

--- a/python/pounce/torch/__init__.py
+++ b/python/pounce/torch/__init__.py
@@ -1,0 +1,83 @@
+"""PyTorch integration for pounce (pounce#109).
+
+A PyTorch frontend for pounce's differentiable solver, mirroring the
+:mod:`pounce.jax` subpackage. A solve is a :class:`torch.autograd.Function`
+you can drop inside a learned model and backprop through, with the same
+constraint-satisfaction guarantee the JAX path gives.
+
+This is a **frontend/adapter**, not a second solver. The numerical core
+(the Rust IPM, exposed via :class:`pounce._pounce.Problem`) and the
+implicit-function-theorem backward math are autodiff-framework-agnostic;
+only a thin wrapper layer differs. Because PyTorch is eager, that layer
+is *smaller* than the JAX one (no ``pure_callback`` / ``ShapeDtypeStruct``
+machinery) — the forward calls ``problem.solve(...)`` directly and the
+backward runs the KKT solve in-framework with ``torch.linalg.solve``.
+
+Layers, each independently useful:
+
+1. :func:`from_torch` — build a :class:`pounce.Problem` from
+   PyTorch-traced ``f(x)`` and ``g(x)``. Gradient / Jacobian (with
+   detected sparsity) / Lagrangian Hessian are auto-derived with
+   ``torch.func.grad`` / ``jacrev`` / ``jacfwd`` / ``hessian``.
+
+2. :func:`solve` / :func:`solve_with_warm` — wrap ``Problem.solve`` in a
+   ``torch.autograd.Function`` so a ``loss(p)`` that calls into the
+   solver can be differentiated. The backward uses the implicit-function
+   theorem on the KKT system at ``x*``.
+
+3. :func:`vmap_solve` / :func:`vmap_solve_parallel` — batched solves
+   (sequential loop / threadpool).
+
+4. :class:`TorchProblem` — a build-once, solve-many stateful handle that
+   caches the compiled AD artefacts, sparsity, and (optionally) reuses the
+   IPM's converged KKT factor for the backward.
+
+5. :func:`solve_qp` / :func:`solve_qp_batch` / :func:`solve_socp` /
+   :class:`QpLayer` — differentiable conic layers (feasible-by-construction).
+
+6. :class:`PathFollower` / :func:`inverse_map_rhs` — predictor–corrector
+   path following over a :class:`TorchProblem`.
+
+PyTorch is an optional dependency. Importing this module without PyTorch
+installed raises a useful error. ``torch.func`` requires torch ≥ 2.0; the
+``pounce[torch]`` extra pins ≥ 2.2 for a stable surface.
+
+pounce is a double-precision solver, and the implicit-diff and
+``from_torch`` paths assume float64 throughout (Newton convergence stalls
+in float32, and the KKT solve in the VJP needs the extra precision). The
+adapters request float64 tensors explicitly — there is no global flag as
+in JAX's ``jax_enable_x64``.
+"""
+
+from __future__ import annotations
+
+try:
+    import torch  # noqa: F401
+except ImportError as e:  # pragma: no cover
+    raise ImportError(
+        "pounce.torch requires PyTorch; install with "
+        "`pip install pounce[torch]`."
+    ) from e
+
+from ._build import from_torch
+from ._diff import solve, solve_with_warm, vmap_solve, vmap_solve_parallel
+from ._problem import AnchorState, TorchProblem
+from ._path import PathFollower, PathTrace, inverse_map_rhs
+from ._qp import QpLayer, solve_qp, solve_qp_batch, solve_socp
+
+__all__ = [
+    "from_torch",
+    "solve",
+    "solve_with_warm",
+    "vmap_solve",
+    "vmap_solve_parallel",
+    "TorchProblem",
+    "AnchorState",
+    "PathFollower",
+    "PathTrace",
+    "inverse_map_rhs",
+    "solve_qp",
+    "solve_qp_batch",
+    "solve_socp",
+    "QpLayer",
+]

--- a/python/pounce/torch/_build.py
+++ b/python/pounce/torch/_build.py
@@ -1,0 +1,328 @@
+"""Build a :class:`pounce.Problem` from PyTorch-traced ``f(x)`` and
+``g(x)`` (pounce#109).
+
+PyTorch frontend mirror of :mod:`pounce.jax._build`. The user supplies
+the problem in mathematical form and we derive:
+
+* ``gradient`` = ``torch.func.grad(f)``
+* ``jacobian`` = derivative of ``g`` projected onto the precomputed
+  sparsity pattern of nonzero entries
+* ``hessian`` = Hessian of the Lagrangian
+  ``L(x, λ, σ) = σ f(x) + λᵀ g(x)``
+
+``torch.func`` (functorch, merged into core) mirrors JAX's functional AD
+API, so the port is near-mechanical: ``jax.grad`` → ``torch.func.grad``,
+``jax.jacrev`` / ``jax.jacfwd`` → ``torch.func.jacrev`` / ``jacfwd``,
+``jax.hessian`` → ``torch.func.hessian``, ``jax.jvp`` →
+``torch.func.jvp``, ``jax.vmap`` → ``torch.func.vmap``.
+
+There are two ways the Jacobian / Hessian get computed per evaluation,
+selected by the ``sparse`` flag on :func:`from_torch`:
+
+* **dense (default).** ``jacrev`` / ``jacfwd`` / ``hessian`` produce the
+  full dense matrix, which we then slice to the nonzeros. The *direction*
+  (``jacrev`` vs ``jacfwd``) is chosen to minimise the number of AD
+  passes: ``jacrev`` costs ~``m`` passes, ``jacfwd`` ~``n``, so we pick
+  ``jacfwd`` when ``n < m`` (issue #83, option A).
+
+* **compressed (``sparse=True``).** CPR-style colored AD (issue #83,
+  option B). Structurally-orthogonal columns are colored, one JVP/HVP is
+  taken per color (``k ≪ n`` colors), ``vmap``'d over the seeds, and the
+  result scattered back to the known nonzeros.
+
+dtype. pounce is a double-precision solver, and the Newton / KKT solves
+need float64 throughout (convergence stalls in float32). Every traced
+evaluation runs on ``torch.float64`` tensors; :func:`from_torch`
+validates that any user-supplied bounds are finite-or-inf float64 and the
+cyipopt callbacks coerce the incoming NumPy buffers to float64. There is
+no global x64 flag as in JAX — float64 is requested per tensor.
+
+All eval methods return ``numpy.ndarray`` (via ``.numpy()``) so the Rust
+bridge receives a contiguous CPU buffer; PyTorch CPU tensors are
+zero-copy to/from NumPy.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+import numpy as np
+import torch
+from torch.func import grad, hessian, jacfwd, jacrev, jvp, vmap
+
+from .._pounce import Problem
+# Framework-neutral sparsity helpers shared with the JAX frontend.
+from .._ad_common import (
+    _color_columns,
+    _detect_pattern_2d_multi,
+    _detect_pattern_lower_multi,
+)
+
+# Real (CPU, float64) tensor dtype used throughout the frontend.
+_DT = torch.float64
+
+# ``torch.func`` (functorch) transforms push/pop a *process-global*
+# dynamic-layer stack, which is NOT thread-safe: concurrent
+# grad/jacrev/jacfwd/jvp/hessian evaluations from different threads
+# corrupt the nesting ("Trying to access a forward AD level with an
+# invalid index"). The parallel batched path (vmap_solve_parallel)
+# dispatches solves across a ThreadPoolExecutor whose per-iteration
+# cyipopt callbacks evaluate these transforms, so we serialize the AD
+# evaluations with this lock. The genuine parallelism — the Rust IPM
+# linear algebra — runs in ``py.allow_threads`` (GIL released, no Python,
+# no lock held), so the lock only orders the (already GIL-bound) Python
+# derivative callbacks. In the single-threaded path the lock is
+# uncontended and costs only an uncontended acquire.
+_FUNC_LOCK = threading.RLock()
+
+
+def _t(a) -> torch.Tensor:
+    """Coerce array-like to a contiguous float64 CPU tensor."""
+    if isinstance(a, torch.Tensor):
+        return a.to(dtype=_DT)
+    return torch.as_tensor(np.asarray(a, dtype=np.float64), dtype=_DT)
+
+
+def _to_np(a) -> np.ndarray:
+    """Detach a tensor (or array-like) to a float64 NumPy array."""
+    if isinstance(a, torch.Tensor):
+        return a.detach().to(dtype=_DT).cpu().numpy().astype(np.float64)
+    return np.asarray(a, dtype=np.float64)
+
+
+def _seed_matrix(colors: np.ndarray, num_colors: int, n: int) -> torch.Tensor:
+    """``(num_colors, n)`` 0/1 seed matrix: row ``c`` selects every
+    column assigned color ``c``. Seeding a JVP/HVP with row ``c`` sums
+    the structurally-orthogonal columns of that color."""
+    S = np.zeros((num_colors, int(n)), dtype=np.float64)
+    S[colors, np.arange(int(n))] = 1.0
+    return torch.as_tensor(S, dtype=_DT)
+
+
+class _TorchProblem:
+    """Cyipopt-shaped problem object backed by ``torch.func``-AD callables."""
+
+    def __init__(
+        self,
+        f: Callable,
+        g: Callable | None,
+        n: int,
+        m: int,
+        seed: int = 0,
+        sparse: bool = False,
+        n_probes: int = 1,
+    ):
+        self._f = f
+        self._grad_f = grad(f)
+        self._n = n
+        self._m = m
+        self._sparse = sparse
+
+        # --- dense AD callables (always built; used for the probe and,
+        # when sparse=False, for per-eval Jacobian/Hessian) ---
+        if g is not None and m > 0:
+            self._g = g
+            # Option A: jacrev costs ~m passes, jacfwd ~n. Pick the
+            # cheaper direction for the dense path.
+            self._jac_g_dense = jacfwd(g) if n < m else jacrev(g)
+
+            def lagrangian(x, lam, sigma):
+                return sigma * f(x) + torch.dot(lam, g(x))
+
+            self._lagrangian = lagrangian
+            self._hess_lag_dense = hessian(lagrangian, argnums=0)
+        else:
+            self._g = None
+            self._jac_g_dense = None
+
+            def lagrangian_unc(x, sigma):
+                return sigma * f(x)
+
+            self._lagrangian = lagrangian_unc
+            self._hess_lag_dense = hessian(lagrangian_unc, argnums=0)
+
+        # --- detect sparsity from a union of random probes ---
+        # The probe evaluates torch.func transforms, which share a
+        # process-global layer stack — guard with _FUNC_LOCK so workers
+        # building _TorchProblems concurrently (vmap_solve_parallel) don't
+        # corrupt each other's AD level nesting.
+        rng = np.random.default_rng(seed)
+        n_probes = max(1, int(n_probes))
+        x_probes = [_t(rng.standard_normal(n)) for _ in range(n_probes)]
+        with _FUNC_LOCK:
+            if m > 0:
+                lam_probes = [_t(rng.standard_normal(m)) for _ in range(n_probes)]
+                jac_denses = [_to_np(self._jac_g_dense(xp)) for xp in x_probes]
+                self._jac_rows, self._jac_cols = _detect_pattern_2d_multi(jac_denses)
+                hess_denses = [
+                    _to_np(self._hess_lag_dense(xp, lp, _t(1.0)))
+                    for xp, lp in zip(x_probes, lam_probes)
+                ]
+            else:
+                self._jac_rows = np.zeros(0, dtype=np.int64)
+                self._jac_cols = np.zeros(0, dtype=np.int64)
+                hess_denses = [
+                    _to_np(self._hess_lag_dense(xp, _t(1.0))) for xp in x_probes
+                ]
+        self._hess_rows, self._hess_cols = _detect_pattern_lower_multi(hess_denses)
+
+        # --- compressed (colored) AD callables, when requested ---
+        if sparse:
+            self._build_compressed()
+
+    def _build_compressed(self) -> None:
+        """Build the colored JVP (Jacobian) and HVP (Hessian) callables
+        and the scatter indices that map compressed columns back to the
+        stored ``(rows, cols)`` nonzeros (issue #83, option B)."""
+        n = self._n
+
+        # Jacobian: color columns of the (m, n) pattern, one JVP per
+        # color. For nonzero (i, j) the value lives at
+        # compressed[color[j], i].
+        if self._m > 0:
+            jac_colors, k_jac = _color_columns(self._jac_rows, self._jac_cols, n)
+            S_jac = _seed_matrix(jac_colors, k_jac, n)
+            self._jac_seed_cols = jac_colors[self._jac_cols]
+            g = self._g
+
+            def jac_compressed(x):
+                # vmap one forward-mode JVP per seed column → (k, m).
+                return vmap(lambda s: jvp(g, (x,), (s,))[1])(S_jac)
+
+            self._jac_compressed = jac_compressed
+        else:
+            self._jac_seed_cols = np.zeros(0, dtype=np.int64)
+            self._jac_compressed = None
+
+        # Hessian: symmetric, so color the *full* pattern (both
+        # triangles) — a column's compressed value sums contributions
+        # from every row, including the upper triangle we don't store.
+        full_rows = np.concatenate([self._hess_rows, self._hess_cols])
+        full_cols = np.concatenate([self._hess_cols, self._hess_rows])
+        hess_colors, k_hess = _color_columns(full_rows, full_cols, n)
+        S_hess = _seed_matrix(hess_colors, k_hess, n)
+        self._hess_seed_cols = hess_colors[self._hess_cols]
+
+        # HVP via jvp of the Lagrangian gradient: H @ s. (k, n).
+        lag = self._lagrangian
+        grad_L = grad(lag, argnums=0)
+        if self._m > 0:
+            def hess_compressed(x, lam, sigma):
+                return vmap(
+                    lambda s: jvp(
+                        lambda xx: grad_L(xx, lam, sigma), (x,), (s,)
+                    )[1]
+                )(S_hess)
+        else:
+            def hess_compressed(x, sigma):
+                return vmap(
+                    lambda s: jvp(lambda xx: grad_L(xx, sigma), (x,), (s,))[1]
+                )(S_hess)
+
+        self._hess_compressed = hess_compressed
+
+    # --- cyipopt-shaped methods ---
+
+    def objective(self, x):
+        return float(self._f(_t(x)))
+
+    def gradient(self, x):
+        with _FUNC_LOCK:
+            return _to_np(self._grad_f(_t(x)))
+
+    def constraints(self, x):
+        return _to_np(self._g(_t(x)))
+
+    def jacobianstructure(self):
+        return (self._jac_rows, self._jac_cols)
+
+    def jacobian(self, x):
+        with _FUNC_LOCK:
+            if self._sparse:
+                # Compressed (k, m); scatter back: J[rows, cols] lives at
+                # comp[color(cols), rows].
+                comp = _to_np(self._jac_compressed(_t(x)))
+                return comp[self._jac_seed_cols, self._jac_rows]
+            J = _to_np(self._jac_g_dense(_t(x)))
+            return J[self._jac_rows, self._jac_cols]
+
+    def hessianstructure(self):
+        return (self._hess_rows, self._hess_cols)
+
+    def hessian(self, x, lam, obj_factor):
+        sigma = _t(float(obj_factor))
+        with _FUNC_LOCK:
+            if self._sparse:
+                # Compressed (k, n); H[r, c] lives at comp[color(c), r].
+                if self._m > 0:
+                    comp = _to_np(self._hess_compressed(_t(x), _t(lam), sigma))
+                else:
+                    comp = _to_np(self._hess_compressed(_t(x), sigma))
+                return comp[self._hess_seed_cols, self._hess_rows]
+            if self._m > 0:
+                H = _to_np(self._hess_lag_dense(_t(x), _t(lam), sigma))
+            else:
+                H = _to_np(self._hess_lag_dense(_t(x), sigma))
+            return H[self._hess_rows, self._hess_cols]
+
+
+def from_torch(
+    f: Callable,
+    g: Callable | None = None,
+    *,
+    n: int,
+    m: int = 0,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    seed: int = 0,
+    sparse: bool = False,
+    n_probes: int | None = None,
+) -> Problem:
+    """Build a pounce :class:`Problem` from PyTorch-traced functions.
+
+    PyTorch mirror of :func:`pounce.jax.from_jax`.
+
+    Parameters
+    ----------
+    f : callable
+        Objective. Takes a 1-D float64 tensor of length ``n`` and returns
+        a scalar tensor. Must be traceable by ``torch.func``.
+    g : callable or None
+        Constraint function. Takes ``x`` of length ``n`` and returns a
+        1-D tensor of length ``m``. Required when ``m > 0``.
+    n, m : int
+        Variable / constraint counts.
+    lb, ub, cl, cu : array-like or None
+        Variable bounds and constraint bounds; same convention as
+        :class:`Problem`.
+    seed : int
+        Seed for the random probe(s) used to detect sparsity patterns.
+    sparse : bool
+        When ``True``, compute the Jacobian and Lagrangian Hessian with
+        CPR-style colored AD (one JVP/HVP per color) instead of forming
+        the dense matrix and slicing (issue #83). The reported structure
+        is identical either way. Defaults to ``False``.
+    n_probes : int or None
+        Number of random probes whose nonzero patterns are unioned to
+        detect sparsity. ``None`` (default) uses 1 probe for the dense
+        path and 3 for ``sparse=True``.
+
+    Returns
+    -------
+    Problem
+        With the user object built from ``torch.func`` AD. Pass options
+        via ``problem.add_option(...)`` and call ``problem.solve(x0)``.
+    """
+    if m > 0 and g is None:
+        raise ValueError("g must be provided when m > 0")
+    if n_probes is None:
+        n_probes = 3 if sparse else 1
+    obj = _TorchProblem(
+        f=f, g=g, n=n, m=m, seed=seed, sparse=sparse, n_probes=n_probes,
+    )
+    return Problem(
+        n=n, m=m, problem_obj=obj, lb=lb, ub=ub, cl=cl, cu=cu,
+    )

--- a/python/pounce/torch/_diff.py
+++ b/python/pounce/torch/_diff.py
@@ -1,0 +1,536 @@
+"""Differentiate through the solver via implicit differentiation
+(PyTorch frontend, pounce#109).
+
+PyTorch mirror of :mod:`pounce.jax._diff`. Because PyTorch is eager, the
+adapter is *smaller* than the JAX one: there is no ``pure_callback`` /
+``ShapeDtypeStruct`` machinery — the forward simply calls
+``problem.solve(...)`` directly inside ``torch.autograd.Function.forward``
+and the backward runs the KKT implicit-function solve in-framework with
+``torch.linalg.solve``.
+
+Setup. For a parametric NLP
+
+    min_x  f(x, p)
+    s.t.   g(x, p) = 0
+           x_L <= x <= x_U,
+
+the implicit-function theorem on the KKT system at ``x*(p)`` gives, for a
+cotangent ``v`` on ``x*``,
+
+    ⎡ H_xx   J_gxᵀ ⎤ ⎡ u_x ⎤   ⎡ v ⎤
+    ⎣ J_gx     0   ⎦ ⎣ u_λ ⎦ = ⎣ 0 ⎦,
+    then    dL/dp = - u_xᵀ (∂_p ∇_x L) - u_λᵀ (∂_p g).
+
+Active variable bounds reduce ``dx/dp`` to zero on the active
+coordinates: we detect activity from the optimizer's bound multipliers
+``mult_x_L`` / ``mult_x_U`` and identity-augment the KKT block on the
+active set. Slack inequality rows (``cl[i] < cu[i]`` and ``|λ_i|`` below
+``active_tol``) are dropped from the block via the same trick — including
+a slack row as if it were ``g_i(x) = 0`` over-constrains ``dx*/dp`` and
+silently returns the wrong gradient (pounce#73). This is the same
+active-set logic as the JAX path, ported line-for-line.
+
+dtype. Inputs must be float64 (the Newton + KKT solves stall in float32);
+:func:`solve` validates this and raises a clear error rather than
+silently returning a meaningless gradient.
+
+For large sparse problems the right move is the held-factor back-solve
+exposed by :class:`pounce.torch.TorchProblem` (factor reuse via the
+Rust-side ``Solver.kkt_solve``); this module assembles a dense KKT and
+``torch.linalg.solve``s it, matching the top-level JAX ``solve``.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+
+import numpy as np
+import torch
+from torch.func import grad, hessian, jacrev
+
+from ._build import _TorchProblem, _DT
+from .._pounce import Problem
+
+_ACTIVE_TOL = 1e-6
+
+
+def _require_f64(name, t):
+    if isinstance(t, torch.Tensor) and t.dtype != _DT:
+        raise TypeError(
+            f"pounce.torch: {name} must be float64 (got {t.dtype}); the "
+            "Newton and KKT solves need double precision. Cast with "
+            f"`{name}.double()`."
+        )
+
+
+def _solve_once(
+    f: Callable,
+    g: Callable | None,
+    p: torch.Tensor,
+    x0: torch.Tensor,
+    n: int,
+    m: int,
+    lb,
+    ub,
+    cl,
+    cu,
+    options: dict | None,
+) -> tuple[np.ndarray, dict]:
+    """Forward solve. ``p`` is closed over by ``f`` / ``g``."""
+
+    def f_of_x(x):
+        return f(x, p)
+
+    if g is not None:
+        def g_of_x(x):
+            return g(x, p)
+    else:
+        g_of_x = None
+
+    obj = _TorchProblem(f=f_of_x, g=g_of_x, n=n, m=m)
+    problem = Problem(n=n, m=m, problem_obj=obj, lb=lb, ub=ub, cl=cl, cu=cu)
+    if options:
+        for k, v in options.items():
+            problem.add_option(k, v)
+    x_np, info = problem.solve(x0=np.asarray(x0.detach().cpu(), dtype=np.float64))
+    return np.asarray(x_np, dtype=np.float64), info
+
+
+def _kkt_backward(
+    f: Callable,
+    g: Callable | None,
+    n: int,
+    m: int,
+    cl,
+    cu,
+    p: torch.Tensor,
+    x_star: torch.Tensor,
+    lam: torch.Tensor,
+    mult_xL: torch.Tensor,
+    mult_xU: torch.Tensor,
+    v: torch.Tensor,
+) -> torch.Tensor:
+    """Implicit-function-theorem VJP at a single ``(p, x*, λ*)``.
+
+    Mirror of :func:`pounce.jax._diff` / ``_bwd_single_kkt`` — one shared
+    source of truth for the active-set handling (pounce#73 fix), in the
+    ``torch`` array namespace. Returns ``dL/dp`` with the shape of ``p``.
+    """
+    active = (mult_xL > _ACTIVE_TOL) | (mult_xU > _ACTIVE_TOL)
+
+    def lagrangian(x, p_):
+        base = f(x, p_)
+        if g is not None and m > 0:
+            base = base + torch.dot(lam, g(x, p_))
+        return base
+
+    H = hessian(lagrangian, argnums=0)(x_star, p)
+    grad_L_of_p = lambda p_: grad(lagrangian, argnums=0)(x_star, p_)  # noqa: E731
+    dgradL_dp = jacrev(grad_L_of_p)(p)  # shape (n, *p_shape)
+
+    if g is not None and m > 0:
+        J = jacrev(g, argnums=0)(x_star, p)
+        dg_dp = jacrev(lambda p_: g(x_star, p_))(p)  # (m, *p_shape)
+        cl_arr = torch.as_tensor(np.asarray(cl, dtype=np.float64), dtype=H.dtype)
+        cu_arr = torch.as_tensor(np.asarray(cu, dtype=np.float64), dtype=H.dtype)
+        is_equality = cl_arr == cu_arr
+        cons_active = is_equality | (torch.abs(lam) > _ACTIVE_TOL)
+        cons_inactive = ~cons_active
+    else:
+        J = torch.zeros((0, n), dtype=H.dtype)
+        dg_dp = torch.zeros((0,) + tuple(p.shape), dtype=H.dtype)
+        cons_inactive = torch.zeros((0,), dtype=torch.bool)
+
+    # Identity-augment on the active set: zero rows/cols of active vars,
+    # put 1 on their diagonal so the system stays invertible, zero the
+    # RHS there. Slack inequality rows drop out via diag(cons_inactive).
+    active_mat = torch.diag(active.to(H.dtype))
+    H_eff = torch.where(
+        active[:, None] | active[None, :],
+        torch.zeros((), dtype=H.dtype), H,
+    ) + active_mat
+    J_eff = torch.where(
+        cons_inactive[:, None] | active[None, :],
+        torch.zeros((), dtype=H.dtype), J,
+    )
+    v_eff = torch.where(active, torch.zeros((), dtype=H.dtype), v)
+
+    if m > 0:
+        cons_inactive_diag = torch.diag(cons_inactive.to(H.dtype))
+        top = torch.cat([H_eff, J_eff.T], dim=1)
+        bot = torch.cat([J_eff, cons_inactive_diag], dim=1)
+        K = torch.cat([top, bot], dim=0)
+        rhs = torch.cat([v_eff, torch.zeros(m, dtype=H.dtype)])
+        u = torch.linalg.solve(K, rhs)
+        u_x, u_lam = u[:n], u[n:]
+    else:
+        u_x = torch.linalg.solve(H_eff, v_eff)
+        u_lam = torch.zeros(0, dtype=H.dtype)
+
+    dL_dp = -torch.tensordot(u_x, dgradL_dp, dims=1)
+    if m > 0:
+        dL_dp = dL_dp - torch.tensordot(u_lam, dg_dp, dims=1)
+    return dL_dp
+
+
+def _make_solve_fn(f, g, n, m, lb, ub, cl, cu, options):
+    """Build a :class:`torch.autograd.Function` closing over the static
+    problem definition; only the tensors ``(p, x0)`` are differentiable
+    inputs (``x0`` carries no gradient, like the JAX path)."""
+
+    class _SolveFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, p, x0):
+            x_np, info = _solve_once(f, g, p, x0, n, m, lb, ub, cl, cu, options)
+            x_star = torch.as_tensor(x_np, dtype=_DT)
+            lam = (
+                torch.as_tensor(np.asarray(info["mult_g"]), dtype=_DT)
+                if m > 0 else torch.zeros(0, dtype=_DT)
+            )
+            mult_xL = torch.as_tensor(np.asarray(info["mult_x_L"]), dtype=_DT)
+            mult_xU = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)
+            # Save the live ``p`` (not detached) so the in-framework
+            # backward stays a function of it.
+            ctx.save_for_backward(p, x_star, lam, mult_xL, mult_xU)
+            return x_star
+
+        @staticmethod
+        def backward(ctx, v):
+            p, x_star, lam, mult_xL, mult_xU = ctx.saved_tensors
+            dL_dp = _kkt_backward(
+                f, g, n, m, cl, cu, p, x_star, lam, mult_xL, mult_xU, v,
+            )
+            # x0 input has no sensitivity through x* at the optimum.
+            return dL_dp, None
+
+    return _SolveFn
+
+
+def solve(
+    p,
+    *,
+    f: Callable,
+    g: Callable | None = None,
+    x0,
+    n: int,
+    m: int = 0,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    options: dict | None = None,
+):
+    """Parametric solve. ``x* = solve(p, f=..., g=..., x0=..., ...)``.
+
+    Differentiable w.r.t. ``p`` via the implicit-function rule on the KKT
+    system at ``x*(p)``. Not differentiable w.r.t. ``x0``.
+
+    ``f`` and ``g`` must take ``(x, p)`` and be ``torch.func``-traceable.
+    ``p`` (and ``x0``) must be float64.
+    """
+    p = torch.as_tensor(p, dtype=_DT) if not isinstance(p, torch.Tensor) else p
+    _require_f64("p", p)
+    x0 = torch.as_tensor(x0, dtype=_DT) if not isinstance(x0, torch.Tensor) else x0
+    fn = _make_solve_fn(f, g, n, m, lb, ub, cl, cu, options)
+    return fn.apply(p, x0)
+
+
+# ----- warm-started solve (dual + barrier-μ threading, pounce#86) -----
+
+
+def _solve_once_warm(
+    f, g, p, x0, n, m, lb, ub, cl, cu, options,
+    lam_warm, zL_warm, zU_warm, mu_warm,
+):
+    """Forward solve with user-supplied dual (and optional μ) warm-start."""
+
+    def f_of_x(x):
+        return f(x, p)
+
+    if g is not None:
+        def g_of_x(x):
+            return g(x, p)
+    else:
+        g_of_x = None
+
+    obj = _TorchProblem(f=f_of_x, g=g_of_x, n=n, m=m)
+    problem = Problem(n=n, m=m, problem_obj=obj, lb=lb, ub=ub, cl=cl, cu=cu)
+    merged = dict(options or {})
+    merged.setdefault("warm_start_init_point", "yes")
+    if np.isfinite(mu_warm):
+        # Seed the barrier from the previous solve's converged μ so the
+        # corrector resumes near the central path (pounce#86).
+        merged.setdefault("mu_init", float(mu_warm))
+        merged.setdefault("warm_start_target_mu", float(mu_warm))
+    for k, v in merged.items():
+        problem.add_option(k, v)
+    x_np, info = problem.solve(
+        x0=np.asarray(x0.detach().cpu(), dtype=np.float64),
+        lagrange=np.asarray(lam_warm, dtype=np.float64),
+        zl=np.asarray(zL_warm, dtype=np.float64),
+        zu=np.asarray(zU_warm, dtype=np.float64),
+    )
+    return (
+        np.asarray(x_np, dtype=np.float64),
+        np.asarray(info["mult_g"], dtype=np.float64),
+        np.asarray(info["mult_x_L"], dtype=np.float64),
+        np.asarray(info["mult_x_U"], dtype=np.float64),
+        float(info["mu"]),
+        info,
+    )
+
+
+def _make_solve_with_warm_fn(f, g, n, m, lb, ub, cl, cu, options):
+    class _WarmSolveFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, p, x0, lam_warm, zL_warm, zU_warm, mu_warm):
+            x_np, lam_out, zL_out, zU_out, mu_out, _info = _solve_once_warm(
+                f, g, p, x0, n, m, lb, ub, cl, cu, options,
+                np.asarray(lam_warm.detach().cpu()),
+                np.asarray(zL_warm.detach().cpu()),
+                np.asarray(zU_warm.detach().cpu()),
+                float(mu_warm.detach().cpu()),
+            )
+            x_star = torch.as_tensor(x_np, dtype=_DT)
+            lam_t = torch.as_tensor(lam_out, dtype=_DT)
+            zL_t = torch.as_tensor(zL_out, dtype=_DT)
+            zU_t = torch.as_tensor(zU_out, dtype=_DT)
+            mu_t = torch.as_tensor(mu_out, dtype=_DT)
+            ctx.save_for_backward(p, x_star, lam_t, zL_t, zU_t)
+            # Warm/dual/μ outputs are not differentiable — mark so.
+            ctx.mark_non_differentiable(lam_t, zL_t, zU_t, mu_t)
+            return x_star, lam_t, zL_t, zU_t, mu_t
+
+        @staticmethod
+        def backward(ctx, v, *_drop):
+            # Only the x* cotangent carries gradient w.r.t. p; cotangents
+            # on (lam, zL, zU, mu) are dropped — same convention the JAX
+            # warm path uses (they're consequences of the active set and
+            # the barrier homotopy, not inputs to dx*/dp).
+            p, x_star, lam, mult_xL, mult_xU = ctx.saved_tensors
+            dL_dp = _kkt_backward(
+                f, g, n, m, cl, cu, p, x_star, lam, mult_xL, mult_xU, v,
+            )
+            return dL_dp, None, None, None, None, None
+
+    return _WarmSolveFn
+
+
+def solve_with_warm(
+    p,
+    *,
+    f: Callable,
+    g: Callable | None = None,
+    x0,
+    n: int,
+    m: int = 0,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    options: dict | None = None,
+    warm_start: tuple | None = None,
+):
+    """Parametric solve that consumes and returns dual warm-state.
+
+    Mirror of :func:`pounce.jax.solve_with_warm`:
+
+    * ``warm_start=(lam, zL, zU)`` seeds the solver's dual variables via
+      ``warm_start_init_point=yes``. ``None`` starts from zeros.
+    * ``warm_start=(lam, zL, zU, mu)`` additionally seeds the barrier μ
+      (pounce#86); pass ``mu=None`` inside the 4-tuple to skip the μ seed
+      but still receive the converged μ on output.
+    * Returns ``(x*, (lam_out, zL_out, zU_out))`` for a 3-tuple / ``None``
+      warm-start, or ``(x*, (lam_out, zL_out, zU_out, mu_out))`` for a
+      4-tuple — the returned arity matches the input.
+
+    Differentiable w.r.t. ``p`` only; cotangents on the warm duals / μ
+    are dropped (zero), matching how :func:`solve` handles ``x0``.
+    """
+    p = torch.as_tensor(p, dtype=_DT) if not isinstance(p, torch.Tensor) else p
+    _require_f64("p", p)
+    x0 = torch.as_tensor(x0, dtype=_DT) if not isinstance(x0, torch.Tensor) else x0
+
+    want_mu = warm_start is not None and len(warm_start) == 4
+    if warm_start is None:
+        lam_warm = torch.zeros(m, dtype=_DT)
+        zL_warm = torch.zeros(n, dtype=_DT)
+        zU_warm = torch.zeros(n, dtype=_DT)
+        mu_warm = torch.as_tensor(float("nan"), dtype=_DT)
+    else:
+        if want_mu:
+            lam_warm, zL_warm, zU_warm, mu_seed = warm_start
+        else:
+            lam_warm, zL_warm, zU_warm = warm_start
+            mu_seed = None
+        lam_warm = torch.as_tensor(lam_warm, dtype=_DT)
+        zL_warm = torch.as_tensor(zL_warm, dtype=_DT)
+        zU_warm = torch.as_tensor(zU_warm, dtype=_DT)
+        mu_warm = torch.as_tensor(
+            float("nan") if mu_seed is None else float(mu_seed), dtype=_DT,
+        )
+
+    fn = _make_solve_with_warm_fn(f, g, n, m, lb, ub, cl, cu, options)
+    x_star, lam_out, zL_out, zU_out, mu_out = fn.apply(
+        p, x0, lam_warm, zL_warm, zU_warm, mu_warm,
+    )
+    if want_mu:
+        return x_star, (lam_out, zL_out, zU_out, mu_out)
+    return x_star, (lam_out, zL_out, zU_out)
+
+
+# ----- batched solves -----
+
+
+def vmap_solve(
+    p_batch,
+    *,
+    f: Callable,
+    g: Callable | None = None,
+    x0,
+    n: int,
+    m: int = 0,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    options: dict | None = None,
+):
+    """Sequential batched solve over the leading axis of ``p_batch``.
+
+    The pounce solver is single-threaded and stateful, so this loops in
+    Python over :func:`solve` (which keeps each element differentiable via
+    its own ``autograd.Function``) and stacks the results. ``x0`` may be a
+    single ``(n,)`` vector (broadcast) or a ``(B, n)`` batch.
+    """
+    p_batch = torch.as_tensor(p_batch, dtype=_DT)
+    _require_f64("p_batch", p_batch)
+    B = p_batch.shape[0]
+    x0_arr = torch.as_tensor(x0, dtype=_DT)
+    if x0_arr.ndim == 1:
+        x0_arr = x0_arr.expand(B, n)
+    outs = [
+        solve(
+            p_batch[i], f=f, g=g, x0=x0_arr[i], n=n, m=m,
+            lb=lb, ub=ub, cl=cl, cu=cu, options=options,
+        )
+        for i in range(B)
+    ]
+    return torch.stack(outs, dim=0)
+
+
+def _solve_batch_threadpool(
+    f, g, p_batch_np, x0_np, n, m, lb, ub, cl, cu, options, workers,
+):
+    """Dispatch ``B`` independent solves across a ``ThreadPoolExecutor``.
+
+    Each worker builds its own ``Problem`` (no shared state) and runs
+    ``Problem.solve``. Genuine parallelism is unlocked by the
+    ``py.allow_threads`` block around the IPM iteration in ``pounce-py``
+    — the GIL is released across the iteration so threads run
+    concurrently on the Rust side. ``torch.func`` callbacks for ``f`` /
+    ``g`` reacquire the GIL the usual way; that's serialized but small
+    relative to the linear algebra.
+    """
+    B = p_batch_np.shape[0]
+    n_workers = workers or min(B, 8)
+    x_out = np.empty((B, n), dtype=np.float64)
+    lam_out = np.empty((B, m), dtype=np.float64)
+    zL_out = np.empty((B, n), dtype=np.float64)
+    zU_out = np.empty((B, n), dtype=np.float64)
+
+    def one(i):
+        p_i = torch.as_tensor(p_batch_np[i], dtype=_DT)
+        x0_i = torch.as_tensor(
+            x0_np[i] if x0_np.ndim == 2 else x0_np, dtype=_DT,
+        )
+        x_np, info = _solve_once(
+            f, g, p_i, x0_i, n, m, lb, ub, cl, cu, options,
+        )
+        x_out[i] = x_np
+        lam_out[i] = (
+            np.asarray(info["mult_g"], dtype=np.float64) if m > 0
+            else np.zeros(0)
+        )
+        zL_out[i] = np.asarray(info["mult_x_L"], dtype=np.float64)
+        zU_out[i] = np.asarray(info["mult_x_U"], dtype=np.float64)
+
+    if n_workers <= 1 or B <= 1:
+        for i in range(B):
+            one(i)
+    else:
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            list(pool.map(one, range(B)))
+    return x_out, lam_out, zL_out, zU_out
+
+
+def _make_vmap_solve_parallel_fn(f, g, n, m, lb, ub, cl, cu, options, workers):
+    class _ParallelSolveFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, p_batch, x0_batch):
+            p_np = np.asarray(p_batch.detach().cpu(), dtype=np.float64)
+            x0_np = np.asarray(x0_batch.detach().cpu(), dtype=np.float64)
+            x_out, lam_out, zL_out, zU_out = _solve_batch_threadpool(
+                f, g, p_np, x0_np, n, m, lb, ub, cl, cu, options, workers,
+            )
+            x_star = torch.as_tensor(x_out, dtype=_DT)
+            lam = torch.as_tensor(lam_out, dtype=_DT)
+            mxL = torch.as_tensor(zL_out, dtype=_DT)
+            mxU = torch.as_tensor(zU_out, dtype=_DT)
+            ctx.save_for_backward(p_batch, x_star, lam, mxL, mxU)
+            return x_star
+
+        @staticmethod
+        def backward(ctx, v_batch):
+            p_batch, x_star, lam, mxL, mxU = ctx.saved_tensors
+            B = p_batch.shape[0]
+            grads = [
+                _kkt_backward(
+                    f, g, n, m, cl, cu,
+                    p_batch[i], x_star[i],
+                    lam[i] if m > 0 else lam,
+                    mxL[i], mxU[i], v_batch[i],
+                )
+                for i in range(B)
+            ]
+            return torch.stack(grads, dim=0), None
+
+    return _ParallelSolveFn
+
+
+def vmap_solve_parallel(
+    p_batch,
+    *,
+    f: Callable,
+    g: Callable | None = None,
+    x0,
+    n: int,
+    m: int = 0,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    options: dict | None = None,
+    workers: int | None = None,
+):
+    """Parallel batched solve. Drop-in for :func:`vmap_solve`.
+
+    Each of the ``B`` elements of ``p_batch`` is dispatched to a worker in
+    a ``ThreadPoolExecutor`` of size ``workers`` (default ``min(B, 8)``).
+    Each worker owns an independent ``Problem`` so there's no shared
+    state, and the ``py.allow_threads`` GIL release around the IPM
+    iteration lets threads run concurrently on the Rust side.
+
+    Differentiable w.r.t. ``p_batch`` via per-element implicit function
+    theorem. ``x0`` may be a single ``(n,)`` vector (broadcast) or a
+    ``(B, n)`` batch.
+    """
+    p_batch = torch.as_tensor(p_batch, dtype=_DT)
+    _require_f64("p_batch", p_batch)
+    B = p_batch.shape[0]
+    x0_arr = torch.as_tensor(x0, dtype=_DT)
+    if x0_arr.ndim == 1:
+        x0_arr = x0_arr.expand(B, n).contiguous()
+    fn = _make_vmap_solve_parallel_fn(f, g, n, m, lb, ub, cl, cu, options, workers)
+    return fn.apply(p_batch, x0_arr)

--- a/python/pounce/torch/_path.py
+++ b/python/pounce/torch/_path.py
@@ -1,0 +1,417 @@
+"""Numerical-continuation / predictor–corrector path following on the
+held KKT factor (pounce#90), PyTorch frontend (pounce#109).
+
+PyTorch mirror of :mod:`pounce.jax._path`. Traces a solution path of a
+parametric NLP
+
+    min_x  f(x, θ)   s.t.  g(x, θ) = 0,  lb ≤ x ≤ ub
+
+by *composing* the post-solve sensitivity primitives rather than
+re-solving the NLP at every step:
+
+* **predict** — extrapolate along the held-factor sensitivity
+  ``∂x*/∂θ`` (:meth:`TorchProblem.jvp_from_state`);
+* **monitor** (no solve) — the KKT residual at the predicted point plus
+  the active-set margin (:meth:`TorchProblem.active_set_margin`);
+* **correct** — only when the monitor trips: a warm-started, barrier-μ
+  seeded re-solve that re-anchors the factor in one solve
+  (:meth:`TorchProblem.warm_anchor`).
+
+Because PyTorch is eager, the inverse-map RHS is a plain Python callable
+(no ``jax.pure_callback`` wrapper needed) — drop it straight into a
+``scipy.integrate`` / ``torchdiffeq`` vector field.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+import torch
+from torch.func import grad, jacrev
+
+from ._build import _DT, _t, _to_np
+
+_OK_STATUS = ("Solve_Succeeded", "Solved_To_Acceptable_Level")
+
+
+def _require_equality_constraints(tp, where):
+    """Guard: path continuation here assumes a fixed active set in which
+    every general constraint is an equality (``cl == cu``)."""
+    if tp._m > 0:
+        cl = np.asarray(tp._cl_for_classify)
+        cu = np.asarray(tp._cu_for_classify)
+        if np.any(cl != cu):
+            raise ValueError(
+                f"{where} supports equality constraints (cl == cu) and "
+                "variable bounds only; this problem has two-sided inequality "
+                "constraints (cl != cu), for which the active-set monitor and "
+                "KKT residual are not yet valid. Reformulate the inequalities "
+                "with slack equalities, or remove them."
+            )
+
+
+def inverse_map_rhs(tp, dy_ds, *, output=None, x0=None, warm=False):
+    """Build the right-hand side of the inverse / uncertainty-mapping ODE
+    (Alves–Kitchin–Lima):
+
+    .. math::  \\frac{d\\theta}{ds} = \\Big(\\frac{\\partial y}{\\partial
+        \\theta}\\Big)^{-1} \\frac{dy}{ds},
+
+    where ``y = output(x*(θ), θ)`` is an output of the embedded optimizer
+    ``x*(θ) = argmin_x f(x, θ) s.t. …``. With ``J = ∂x*/∂θ`` from the held
+    KKT factor and the output Jacobians ``∂h/∂x``, ``∂h/∂θ`` by autodiff,
+
+    .. math::  \\frac{\\partial y}{\\partial \\theta}
+        = \\frac{\\partial h}{\\partial x} J + \\frac{\\partial h}{\\partial \\theta},
+        \\qquad \\frac{d\\theta}{ds}
+        = \\Big(\\frac{\\partial y}{\\partial \\theta}\\Big)^{-1} \\frac{dy}{ds}.
+
+    The output and parameter dimensions must match (square ``∂y/∂θ``).
+
+    Parameters mirror :func:`pounce.jax.inverse_map_rhs`. Returns a plain
+    callable ``f(s, theta) -> dtheta_ds`` of shape ``(p,)`` — drop-in for a
+    ``scipy.integrate`` / ``torchdiffeq`` RHS.
+    """
+    if len(tp._p_shape) != 1:
+        raise ValueError(
+            f"inverse_map_rhs requires a 1-D θ (p_shape={tp._p_shape})."
+        )
+    n = tp._n
+    p = tp._p_shape[0]
+    x0_arr = torch.zeros(n, dtype=_DT) if x0 is None else _t(x0)
+    h = output if output is not None else (lambda x, theta: x)
+
+    # ∂y/∂θ must be square (k == p). Probe the output dimension up front.
+    if output is None:
+        k = n
+    else:
+        out = h(torch.zeros(n, dtype=_DT), torch.zeros(p, dtype=_DT))
+        if out.ndim != 1:
+            raise ValueError(
+                f"inverse_map_rhs output h(x, θ) must be 1-D; got {tuple(out.shape)}."
+            )
+        k = out.shape[0]
+    if k != p:
+        detail = (
+            " (the default identity output ⇒ k = n, so this needs n == p)"
+            if output is None else ""
+        )
+        raise ValueError(
+            "inverse_map_rhs requires a square output sensitivity ∂y/∂θ: the "
+            f"output dimension k={k} must equal the parameter dimension "
+            f"p={p}{detail}."
+        )
+
+    cache = {"x": _to_np(x0_arr), "duals": None, "mu": None}
+
+    def _solve(theta):
+        if not warm:
+            x_star, _duals, J = tp.solve_with_jacobian(theta, x0_arr)
+            return x_star, J
+        state, info = tp.warm_anchor(
+            theta, torch.as_tensor(cache["x"], dtype=_DT),
+            duals=cache["duals"], mu=cache["mu"],
+        )
+        try:
+            x_star = state.x_star[0]
+            J = tp.sensitivity(state)
+            cache["x"] = _to_np(x_star)
+            cache["duals"] = tuple(_to_np(d[0]) for d in state.duals)
+            cache["mu"] = float(info["mu"])
+        finally:
+            state.close()
+        return x_star, J
+
+    def f(s, theta):
+        theta_t = _t(theta)
+        x_star, J = _solve(theta_t)
+        h_x = jacrev(lambda xx: h(xx, theta_t))(x_star)       # (k, n)
+        h_th = jacrev(lambda th: h(x_star, th))(theta_t)      # (k, p)
+        dy_dtheta = h_x @ J + h_th
+        v = dy_ds(s) if callable(dy_ds) else dy_ds
+        dtheta_ds = torch.linalg.solve(dy_dtheta, _t(v))
+        return dtheta_ds
+
+    return f
+
+
+@dataclass
+class PathTrace:
+    """Result of a path-following run (mirror of the JAX dataclass)."""
+
+    s: np.ndarray
+    theta: np.ndarray
+    x: np.ndarray
+    lam: np.ndarray
+    n_steps: int
+    n_correctors: int
+    n_accepts: int
+    active_set_changes: list = field(default_factory=list)
+    turning_points: list = field(default_factory=list)
+    status: str = "ok"
+
+
+class PathFollower:
+    """Predictor–corrector path follower over a :class:`TorchProblem`
+    (pounce#90). Mirror of :class:`pounce.jax.PathFollower`."""
+
+    def __init__(
+        self,
+        tp,
+        *,
+        monitor_tol: float = 1e-6,
+        active_margin_tol: float = 1e-4,
+        ds0: float = 0.05,
+        ds_min: float = 1e-4,
+        ds_max: float = 0.25,
+        grow: float = 1.5,
+        shrink: float = 0.5,
+        max_steps: int = 100_000,
+    ):
+        self._tp = tp
+        self._monitor_tol = float(monitor_tol)
+        self._active_margin_tol = float(active_margin_tol)
+        self._ds0 = float(ds0)
+        self._ds_min = float(ds_min)
+        self._ds_max = float(ds_max)
+        self._grow = float(grow)
+        self._shrink = float(shrink)
+        self._max_steps = int(max_steps)
+
+    # ----- monitors -----
+
+    def _kkt_residual(self, x, theta, lam, zL, zU) -> float:
+        tp = self._tp
+        m = tp._m
+        gradf = grad(lambda xx: tp._f(xx, theta))(x)
+        stat = gradf - zL + zU
+        cviol = 0.0
+        if m > 0:
+            gx = tp._g(x, theta)
+            Jg = jacrev(lambda xx: tp._g(xx, theta))(x)
+            stat = stat + Jg.T @ lam
+            cviol = float(torch.max(torch.abs(gx)))
+        r = float(torch.max(torch.abs(stat))) + cviol
+        if tp._lb is not None:
+            r += float(torch.clamp(_t(tp._lb) - x, min=0.0).max())
+        if tp._ub is not None:
+            r += float(torch.clamp(x - _t(tp._ub), min=0.0).max())
+        return r
+
+    def _margin_at(self, x, lam, zL, zU, theta) -> float:
+        r = self._tp._margin_arrays(
+            x[None], lam[None], zL[None], zU[None], _t(theta)[None], 1,
+        )
+        return float(r["margin"][0])
+
+    def _active_signature(self, lam, zL, zU, active_tol=1e-6):
+        tp = self._tp
+        sig = (
+            tuple(bool(v) for v in _to_np(zL > active_tol))
+            + tuple(bool(v) for v in _to_np(zU > active_tol))
+        )
+        if tp._m > 0:
+            cl = np.asarray(tp._cl_for_classify)
+            cu = np.asarray(tp._cu_for_classify)
+            is_ineq = cl != cu
+            lam_np = _to_np(lam)
+            sig = sig + tuple(
+                bool(is_ineq[i] and abs(lam_np[i]) > active_tol)
+                for i in range(tp._m)
+            )
+        return sig
+
+    # ----- parameter continuation -----
+
+    def follow(self, theta_of_s, s_span, x0) -> PathTrace:
+        """Trace ``x*(θ(s))`` for a prescribed path ``θ(s)`` (pounce#90)."""
+        tp = self._tp
+        _require_equality_constraints(tp, "PathFollower.follow")
+        s0, s1 = float(s_span[0]), float(s_span[1])
+        if not (s1 > s0):
+            raise ValueError("s_span must have s1 > s0")
+
+        def th(s):
+            return _t(theta_of_s(s))
+
+        state, info = tp.warm_anchor(th(s0), _t(x0))
+        if info["status_msg"] not in _OK_STATUS:
+            state.close()
+            raise RuntimeError(
+                f"pounce.torch: anchor solve failed at s0 ({info['status_msg']})."
+            )
+        x = state.x_star[0]
+        lam, zL, zU = (d[0] for d in state.duals)
+        mu = float(info["mu"])
+        sig = self._active_signature(lam, zL, zU)
+
+        S = [s0]; TH = [_to_np(th(s0))]; X = [_to_np(x)]; LAM = [_to_np(lam)]
+        n_corr = n_acc = n_steps = 0
+        as_changes: list = []
+        status = "ok"
+
+        s = s0
+        ds = self._ds0
+        while s < s1 - 1e-12 and n_steps < self._max_steps:
+            n_steps += 1
+            ds = min(ds, s1 - s)
+            s_new = s + ds
+            th_cur = th(s)
+            th_new = th(s_new)
+            dth = th_new - th_cur
+
+            if tp._m > 0:
+                dx, dlam = tp.jvp_from_state(state, dth, with_duals=True)
+                lam_pred = lam + dlam
+            else:
+                dx = tp.jvp_from_state(state, dth)
+                lam_pred = lam
+            x_pred = x + dx
+
+            r = self._kkt_residual(x_pred, th_new, lam_pred, zL, zU)
+            margin = self._margin_at(x_pred, lam_pred, zL, zU, th_new)
+
+            if r <= self._monitor_tol and margin > self._active_margin_tol:
+                x = x_pred
+                lam = lam_pred
+                s = s_new
+                n_acc += 1
+                S.append(s); TH.append(_to_np(th_new)); X.append(_to_np(x)); LAM.append(_to_np(lam))
+                ds = min(ds * self._grow, self._ds_max)
+                continue
+
+            new_state, cinfo = tp.warm_anchor(
+                th_new, x_pred, duals=(lam_pred, zL, zU), mu=mu,
+            )
+            if cinfo["status_msg"] not in _OK_STATUS:
+                new_state.close()
+                ds *= self._shrink
+                if ds < self._ds_min:
+                    status = "corrector_failed"
+                    break
+                continue
+
+            state.close()
+            state = new_state
+            x = state.x_star[0]
+            lam, zL, zU = (d[0] for d in state.duals)
+            mu = float(cinfo["mu"])
+            n_corr += 1
+            s = s_new
+
+            new_sig = self._active_signature(lam, zL, zU)
+            if new_sig != sig:
+                as_changes.append(s)
+                sig = new_sig
+                ds = min(self._ds0, max(ds * self._shrink, self._ds_min))
+            else:
+                iters = int(cinfo["iter_count"])
+                if iters <= 3:
+                    ds = min(ds * self._grow, self._ds_max)
+                elif iters >= 10:
+                    ds = max(ds * self._shrink, self._ds_min)
+
+            S.append(s); TH.append(_to_np(th_new)); X.append(_to_np(x)); LAM.append(_to_np(lam))
+
+        state.close()
+        if n_steps >= self._max_steps and s < s1 - 1e-12:
+            status = "max_steps"
+        return PathTrace(
+            s=np.asarray(S), theta=np.asarray(TH), x=np.asarray(X), lam=np.asarray(LAM),
+            n_steps=n_steps, n_correctors=n_corr, n_accepts=n_acc,
+            active_set_changes=as_changes, turning_points=[], status=status,
+        )
+
+    # ----- pseudo-arclength continuation (folds) -----
+
+    def trace_arclength(
+        self, x0, theta0, *, ds: float = 0.05, n_steps: int = 200,
+        direction: float = 1.0, newton_tol: float = 1e-9, newton_max: int = 40,
+    ) -> PathTrace:
+        """Pseudo-arclength continuation of the solution curve for a
+        **scalar** parameter ``θ``, tracing *past folds* (pounce#90)."""
+        tp = self._tp
+        n, m = tp._n, tp._m
+        if len(tp._p_shape) != 0 and tp._p_shape != (1,):
+            raise ValueError(
+                "trace_arclength supports a scalar parameter only "
+                f"(p_shape={tp._p_shape}); use follow(...) for a path."
+            )
+        _require_equality_constraints(tp, "PathFollower.trace_arclength")
+        d = n + m
+
+        def _theta_arg(theta_scalar):
+            return theta_scalar if tp._p_shape == () else theta_scalar[None]
+
+        def R(u):
+            x = u[:n]
+            theta = _theta_arg(u[d])
+            gradf = grad(lambda xx: tp._f(xx, theta))(x)
+            if m > 0:
+                lam = u[n:d]
+                Jg = jacrev(lambda xx: tp._g(xx, theta))(x)
+                return torch.cat([gradf + Jg.T @ lam, tp._g(x, theta)])
+            return gradf
+
+        dR = jacrev(R)
+
+        u = torch.cat([
+            _t(x0), torch.zeros(m, dtype=_DT), torch.tensor([float(theta0)], dtype=_DT),
+        ])
+
+        for _ in range(newton_max):
+            res = R(u)
+            if float(torch.max(torch.abs(res))) < newton_tol:
+                break
+            A = dR(u)[:, :d]
+            u = u.clone()
+            u[:d] = u[:d] - torch.linalg.solve(A, res)
+
+        def tangent(u_at, t_prev):
+            A = dR(u_at)
+            _, _, Vh = torch.linalg.svd(A)
+            t = Vh[-1]
+            t = t / torch.linalg.norm(t)
+            if t_prev is None:
+                if float(t[d]) * direction < 0:
+                    t = -t
+            elif float(torch.dot(t, t_prev)) < 0:
+                t = -t
+            return t
+
+        t = tangent(u, None)
+        X = [_to_np(u[:n])]; TH = [float(u[d])]; LAM = [_to_np(u[n:d])]
+        turning: list = []
+        status = "ok"
+
+        for _ in range(n_steps):
+            u_pred = u + ds * t
+            uc = u_pred
+            ok = False
+            for _ in range(newton_max):
+                res = R(uc)
+                arc = torch.dot(t, uc - u_pred)
+                F = torch.cat([res, arc.reshape(1)])
+                if float(torch.max(torch.abs(F))) < newton_tol:
+                    ok = True
+                    break
+                A = dR(uc)
+                Aaug = torch.cat([A, t[None, :]], dim=0)
+                uc = uc - torch.linalg.solve(Aaug, F)
+            if not ok:
+                status = "corrector_failed"
+                break
+            u = uc
+            t_new = tangent(u, t)
+            if float(t[d]) * float(t_new[d]) < 0:
+                turning.append(float(u[d]))
+            t = t_new
+            X.append(_to_np(u[:n])); TH.append(float(u[d])); LAM.append(_to_np(u[n:d]))
+
+        K = len(X)
+        return PathTrace(
+            s=np.arange(K) * ds, theta=np.asarray(TH), x=np.asarray(X), lam=np.asarray(LAM),
+            n_steps=K - 1, n_correctors=K - 1, n_accepts=0,
+            active_set_changes=[], turning_points=turning, status=status,
+        )

--- a/python/pounce/torch/_problem.py
+++ b/python/pounce/torch/_problem.py
@@ -59,9 +59,20 @@ from .._ad_common import (
     _detect_pattern_lower_multi,
 )
 from ._build import _DT, _seed_matrix, _t, _to_np
-from ._diff import _kkt_backward
+from ._diff import _kkt_backward, _require_f64
 
 _ACTIVE_TOL = 1e-6
+
+
+def _coerce_param(p, name="p"):
+    """Coerce a user parameter to a float64 tensor, raising on an explicit
+    float32 tensor rather than silently upcasting — mirrors the dtype guard
+    in :func:`pounce.torch._diff.solve` so both surfaces reject a
+    precision-losing input the same way. Non-tensors (lists / NumPy arrays)
+    are coerced as before."""
+    if isinstance(p, torch.Tensor):
+        _require_f64(name, p)
+    return _t(p)
 
 
 # ----- cyipopt-shaped problem objects (closures owned by a TorchProblem) ---
@@ -807,7 +818,7 @@ class TorchProblem:
 
     def solve(self, p, x0):
         """Differentiable forward solve at parameter ``p``. Returns ``x*``."""
-        p = _t(p)
+        p = _coerce_param(p)
         x0 = _t(x0)
         tp = self
         factor_reuse = self._factor_reuse
@@ -845,7 +856,7 @@ class TorchProblem:
         """Differentiable forward solve with dual warm-start.
 
         Returns ``(x*, (lam_out, zL_out, zU_out))``."""
-        p = _t(p)
+        p = _coerce_param(p)
         x0 = _t(x0)
         n, m = self._n, self._m
         if warm_start is None:
@@ -868,11 +879,15 @@ class TorchProblem:
                 mxU = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)
                 ctx.save_for_backward(p, x_star, lam, mxL, mxU)
                 ctx.solver = solver
-                ctx.extra = (lam, mxL, mxU)
-                return x_star
+                # Dual outputs ride out of the same forward but are not
+                # differentiated (they're consequences of the active set /
+                # barrier homotopy, not inputs to dx*/dp) — same convention
+                # as pounce.torch._diff.solve_with_warm.
+                ctx.mark_non_differentiable(lam, mxL, mxU)
+                return x_star, lam, mxL, mxU
 
             @staticmethod
-            def backward(ctx, v):
+            def backward(ctx, v, *_drop):
                 p, x_star, lam, mxL, mxU = ctx.saved_tensors
                 if factor_reuse:
                     dL_dp = _bwd_factor_reuse_single(tp, ctx.solver, p, x_star, lam, v)
@@ -883,21 +898,16 @@ class TorchProblem:
                     )
                 return dL_dp, None
 
-        # Run forward once to also recover the dual outputs to thread out.
-        x_np, info, _solver = self._host_solve_warm(p, x0, lam_w, zL_w, zU_w)
-        x_star = _WarmFn.apply(p, x0)
-        lam_out = (
-            torch.as_tensor(np.asarray(info["mult_g"]), dtype=_DT)
-            if m > 0 else torch.zeros(0, dtype=_DT)
-        )
-        zL_out = torch.as_tensor(np.asarray(info["mult_x_L"]), dtype=_DT)
-        zU_out = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)
+        # Single solve: x* stays differentiable w.r.t. p while the dual
+        # outputs are threaded out of the same forward as non-differentiable
+        # tensors.
+        x_star, lam_out, zL_out, zU_out = _WarmFn.apply(p, x0)
         return x_star, (lam_out, zL_out, zU_out)
 
     def vmap_solve(self, p_batch, x0):
         """Sequential batched solve. Differentiable via per-element
         :meth:`solve`. ``x0`` may be ``(n,)`` (broadcast) or ``(B, n)``."""
-        p_batch = _t(p_batch)
+        p_batch = _coerce_param(p_batch, "p_batch")
         B = p_batch.shape[0]
         x0_arr = _t(x0)
         if x0_arr.ndim == 1:
@@ -909,7 +919,7 @@ class TorchProblem:
         per-element dense backward (no shared factor across threads)."""
         from ._diff import _solve_batch_threadpool
 
-        p_batch = _t(p_batch)
+        p_batch = _coerce_param(p_batch, "p_batch")
         B = p_batch.shape[0]
         n, m = self._n, self._m
         x0_arr = _t(x0)
@@ -959,7 +969,7 @@ class TorchProblem:
         ``x_batch`` of shape ``(B, n)``. Differentiable; the backward
         reuses the held stacked factor when ``factor_reuse=True``, else
         the per-block dense KKT solve."""
-        p_batch = _t(p_batch)
+        p_batch = _coerce_param(p_batch, "p_batch")
         B = p_batch.shape[0]
         x0_arr = _t(x0)
         if x0_arr.ndim == 1:
@@ -1004,7 +1014,7 @@ class TorchProblem:
     def batched_solve_with_warm(self, p_batch, x0, warm_start: tuple | None = None):
         """Warm-started stacked batched solve (pounce#78). Returns
         ``(x_batch, (lam_batch, zL_batch, zU_batch))``."""
-        p_batch = _t(p_batch)
+        p_batch = _coerce_param(p_batch, "p_batch")
         B = p_batch.shape[0]
         n, m = self._n, self._m
         x0_arr = _t(x0)
@@ -1019,10 +1029,6 @@ class TorchProblem:
         tp = self
         factor_reuse = self._factor_reuse
 
-        x_b, lam_b, mxL, mxU, _solver, info = self._host_batched_solve_warm(
-            p_batch, x0_arr, lam_w, zL_w, zU_w,
-        )
-
         class _BatchedWarmFn(torch.autograd.Function):
             @staticmethod
             def forward(ctx, p_batch, x0_batch):
@@ -1030,15 +1036,18 @@ class TorchProblem:
                     p_batch, x0_batch, lam_w, zL_w, zU_w,
                 )
                 x_star = torch.as_tensor(xb, dtype=_DT)
-                ctx.save_for_backward(
-                    p_batch, x_star, torch.as_tensor(lamb, dtype=_DT),
-                    torch.as_tensor(mxl, dtype=_DT), torch.as_tensor(mxu, dtype=_DT),
-                )
+                lam_t = torch.as_tensor(lamb, dtype=_DT)
+                mxL_t = torch.as_tensor(mxl, dtype=_DT)
+                mxU_t = torch.as_tensor(mxu, dtype=_DT)
+                ctx.save_for_backward(p_batch, x_star, lam_t, mxL_t, mxU_t)
                 ctx.solver = solver
-                return x_star
+                # Dual outputs threaded out but not differentiated (same
+                # convention as solve_with_warm).
+                ctx.mark_non_differentiable(lam_t, mxL_t, mxU_t)
+                return x_star, lam_t, mxL_t, mxU_t
 
             @staticmethod
-            def backward(ctx, v_batch):
+            def backward(ctx, v_batch, *_drop):
                 p_b, x_star, lam_b, mxl, mxu = ctx.saved_tensors
                 if factor_reuse:
                     dL = _bwd_factor_reuse_batched(
@@ -1054,10 +1063,9 @@ class TorchProblem:
                     ], dim=0)
                 return dL, None
 
-        x_star = _BatchedWarmFn.apply(p_batch, x0_arr)
-        lam_out = torch.as_tensor(lam_b, dtype=_DT)
-        zL_out = torch.as_tensor(mxL, dtype=_DT)
-        zU_out = torch.as_tensor(mxU, dtype=_DT)
+        # Single solve: x* differentiable w.r.t. p_batch; dual outputs ride
+        # out of the same forward as non-differentiable tensors.
+        x_star, lam_out, zL_out, zU_out = _BatchedWarmFn.apply(p_batch, x0_arr)
         return x_star, (lam_out, zL_out, zU_out)
 
     # ----- post-solve sensitivity API (pounce#82) -----

--- a/python/pounce/torch/_problem.py
+++ b/python/pounce/torch/_problem.py
@@ -1,0 +1,1313 @@
+"""Build-once, solve-many PyTorch problem (pounce#109, mirroring
+:mod:`pounce.jax._problem`).
+
+The top-level :func:`pounce.torch.solve` / :func:`vmap_solve_parallel` /
+:func:`solve_with_warm` rebuild a fresh ``_TorchProblem`` (re-trace of the
+``torch.func`` derivatives plus the one-shot random sparsity probe) and a
+fresh :class:`pounce.Problem` on every call. For an iterative outer loop
+that solves the same-structure problem many times — a differentiable
+constrained layer in a training loop, a parametric sweep — that rebuild
+dominates wall-clock.
+
+:class:`TorchProblem` is the build-once handle: do the AD tracing and
+sparsity probe in ``__init__``, then expose :meth:`solve`,
+:meth:`solve_with_warm`, :meth:`vmap_solve`, :meth:`vmap_solve_parallel`,
+:meth:`batched_solve` as methods that reuse the prebuilt state.
+
+Eager-mode simplifications over the JAX port. PyTorch runs eagerly, so a
+great deal of the JAX ``JaxProblem`` machinery is unnecessary here:
+
+* **No host-callback registry / LRU.** The JAX backward crosses the host
+  boundary with ``jax.pure_callback``, so it must stash the converged
+  :class:`pounce.Solver` in a bounded-LRU table keyed by an integer id
+  (the factor can't ride inside the XLA trace). In eager PyTorch the
+  forward and backward are plain Python on the same thread, so the
+  forward simply stashes the ``Solver`` on the ``autograd.Function``
+  ``ctx`` (or on the :class:`AnchorState`) and the backward reads it
+  back. The factor lives exactly as long as the ``ctx`` / handle.
+
+* **No single-thread executor pin (pounce#77).** That existed only
+  because XLA dispatches ``pure_callback`` on unstable worker threads and
+  ``PySolver`` is ``#[pyclass(unsendable)]``. Eager autograd runs the
+  backward on the thread that called ``.backward()``, which is also the
+  thread that built the factor in the forward, so no pinning is needed.
+
+* **No ``ShapeDtypeStruct`` plumbing.** Shapes are concrete.
+
+The factor-reuse backward (``factor_reuse=True``, default) reuses the
+IPM's converged compound KKT factor (the same one ``k_aug`` uses for
+parametric sensitivity) via ``Solver.kkt_solve_many`` — avoiding the
+dense ``(n+m)×(n+m)`` back-solve and dropping the explicit active-set
+masking (the barrier rows on the bound / slack multipliers already encode
+it). ``factor_reuse=False`` falls back to the dense in-framework KKT
+solve (:func:`pounce.torch._diff._kkt_backward`), which stays
+differentiable for higher-order use.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+import torch
+from torch.func import grad, hessian, jacfwd, jacrev, jvp, vmap
+
+from .._pounce import Problem, Solver
+from .._ad_common import (
+    _color_columns,
+    _detect_pattern_2d_multi,
+    _detect_pattern_lower_multi,
+)
+from ._build import _DT, _seed_matrix, _t, _to_np
+from ._diff import _kkt_backward
+
+_ACTIVE_TOL = 1e-6
+
+
+# ----- cyipopt-shaped problem objects (closures owned by a TorchProblem) ---
+
+
+class _ReusableTorchNlp:
+    """Cyipopt-shaped object whose ``torch.func`` callables are owned by a
+    parent :class:`TorchProblem`. Closes over a mutable ``_p`` the parent
+    updates between solves so the same Rust :class:`Problem` can serve a
+    sequence of solves at different ``p``."""
+
+    __slots__ = ("_tp", "_p")
+
+    def __init__(self, tp: "TorchProblem"):
+        self._tp = tp
+        self._p = None
+
+    def objective(self, x):
+        return float(self._tp._f(_t(x), self._p))
+
+    def gradient(self, x):
+        return _to_np(self._tp._grad_f(_t(x), self._p))
+
+    def constraints(self, x):
+        if self._tp._m == 0:
+            return np.zeros(0, dtype=np.float64)
+        return _to_np(self._tp._g(_t(x), self._p))
+
+    def jacobianstructure(self):
+        return (self._tp._jac_rows, self._tp._jac_cols)
+
+    def jacobian(self, x):
+        if self._tp._m == 0:
+            return np.zeros(0, dtype=np.float64)
+        if self._tp._sparse:
+            comp = _to_np(self._tp._jac_compressed(_t(x), self._p))
+            return comp[self._tp._jac_seed_cols, self._tp._jac_rows]
+        J = _to_np(self._tp._jac_g_dense(_t(x), self._p))
+        return J[self._tp._jac_rows, self._tp._jac_cols]
+
+    def hessianstructure(self):
+        return (self._tp._hess_rows, self._tp._hess_cols)
+
+    def hessian(self, x, lam, obj_factor):
+        sigma = _t(float(obj_factor))
+        if self._tp._sparse:
+            if self._tp._m > 0:
+                comp = _to_np(
+                    self._tp._hess_compressed(_t(x), _t(lam), sigma, self._p)
+                )
+            else:
+                comp = _to_np(self._tp._hess_compressed(_t(x), sigma, self._p))
+            return comp[self._tp._hess_seed_cols, self._tp._hess_rows]
+        if self._tp._m > 0:
+            H = _to_np(self._tp._hess_lag(_t(x), _t(lam), sigma, self._p))
+        else:
+            H = _to_np(self._tp._hess_lag(_t(x), sigma, self._p))
+        return H[self._tp._hess_rows, self._tp._hess_cols]
+
+
+class _StackedTorchNlp:
+    """Cyipopt-shaped object wrapping B replicas of a parent
+    :class:`TorchProblem` into one block-diagonal NLP (pounce#76 (A)).
+
+    Variables ``X = [x^(1); …; x^(B)]`` of size ``B*n``, constraints
+    ``G(X, P) = concat(g(x^(k), p^(k)))`` of size ``B*m``, objective
+    ``F = Σ_k f(x^(k), p^(k))``. The Jacobian and Lagrangian Hessian are
+    block-diagonal."""
+
+    __slots__ = ("_tp", "_B", "_P", "_jac_rows_per", "_jac_cols_per",
+                 "_hess_rows_per", "_hess_cols_per", "_jac_rows_stacked",
+                 "_jac_cols_stacked", "_hess_rows_stacked",
+                 "_hess_cols_stacked")
+
+    def __init__(self, tp: "TorchProblem", B: int):
+        self._tp = tp
+        self._B = B
+        self._P = None
+        self._jac_rows_per = np.asarray(tp._jac_rows, dtype=np.int64)
+        self._jac_cols_per = np.asarray(tp._jac_cols, dtype=np.int64)
+        self._hess_rows_per = np.asarray(tp._hess_rows, dtype=np.int64)
+        self._hess_cols_per = np.asarray(tp._hess_cols, dtype=np.int64)
+        n, m = tp._n, tp._m
+        block_idx = np.arange(B, dtype=np.int64)[:, None]
+        if self._jac_rows_per.size > 0 and m > 0:
+            self._jac_rows_stacked = (
+                self._jac_rows_per[None, :] + block_idx * m
+            ).reshape(-1)
+            self._jac_cols_stacked = (
+                self._jac_cols_per[None, :] + block_idx * n
+            ).reshape(-1)
+        else:
+            self._jac_rows_stacked = np.zeros(0, dtype=np.int64)
+            self._jac_cols_stacked = np.zeros(0, dtype=np.int64)
+        self._hess_rows_stacked = (
+            self._hess_rows_per[None, :] + block_idx * n
+        ).reshape(-1)
+        self._hess_cols_stacked = (
+            self._hess_cols_per[None, :] + block_idx * n
+        ).reshape(-1)
+
+    def objective(self, X):
+        n = self._tp._n
+        X_2d = _t(X).reshape(self._B, n)
+        return float(vmap(self._tp._f)(X_2d, self._P).sum())
+
+    def gradient(self, X):
+        n = self._tp._n
+        X_2d = _t(X).reshape(self._B, n)
+        G_2d = vmap(self._tp._grad_f)(X_2d, self._P)
+        return _to_np(G_2d).reshape(-1)
+
+    def constraints(self, X):
+        n, m = self._tp._n, self._tp._m
+        if m == 0:
+            return np.zeros(0, dtype=np.float64)
+        X_2d = _t(X).reshape(self._B, n)
+        G_2d = vmap(self._tp._g)(X_2d, self._P)
+        return _to_np(G_2d).reshape(self._B * m)
+
+    def jacobianstructure(self):
+        return (self._jac_rows_stacked, self._jac_cols_stacked)
+
+    def jacobian(self, X):
+        if self._tp._m == 0:
+            return np.zeros(0, dtype=np.float64)
+        n = self._tp._n
+        X_2d = _t(X).reshape(self._B, n)
+        if self._tp._sparse:
+            comp = vmap(self._tp._jac_compressed)(X_2d, self._P)
+            vals = comp[:, self._tp._jac_seed_cols, self._jac_rows_per]
+            return _to_np(vals).reshape(-1)
+        J_3d = vmap(self._tp._jac_g_dense)(X_2d, self._P)
+        vals = J_3d[:, self._jac_rows_per, self._jac_cols_per]
+        return _to_np(vals).reshape(-1)
+
+    def hessianstructure(self):
+        return (self._hess_rows_stacked, self._hess_cols_stacked)
+
+    def hessian(self, X, lam, obj_factor):
+        n, m = self._tp._n, self._tp._m
+        X_2d = _t(X).reshape(self._B, n)
+        sigma = _t(float(obj_factor))
+        if self._tp._sparse:
+            if m > 0:
+                Lam_2d = _t(lam).reshape(self._B, m)
+                comp = vmap(
+                    lambda x, lm, P: self._tp._hess_compressed(x, lm, sigma, P)
+                )(X_2d, Lam_2d, self._P)
+            else:
+                comp = vmap(
+                    lambda x, P: self._tp._hess_compressed(x, sigma, P)
+                )(X_2d, self._P)
+            vals = comp[:, self._tp._hess_seed_cols, self._hess_rows_per]
+            return _to_np(vals).reshape(-1)
+        if m > 0:
+            Lam_2d = _t(lam).reshape(self._B, m)
+            H_3d = vmap(
+                lambda x, lm, P: self._tp._hess_lag(x, lm, sigma, P)
+            )(X_2d, Lam_2d, self._P)
+        else:
+            H_3d = vmap(lambda x, P: self._tp._hess_lag(x, sigma, P))(X_2d, self._P)
+        vals = H_3d[:, self._hess_rows_per, self._hess_cols_per]
+        return _to_np(vals).reshape(-1)
+
+
+# ----- held-factor (k_aug-style) back-solve helpers -----
+
+
+def _factor_backsolve(solver: Solver, v_x: np.ndarray, n_x: int):
+    """Multi-RHS back-solve against the held compound KKT factor.
+
+    ``v_x`` is ``(N, n_x)``; the compound RHS embeds it in the x-block and
+    zeros elsewhere (bounds / slacks don't depend on ``p`` here, and the
+    factor already encodes active/inactive behaviour). Returns
+    ``(u_x (N, n_x), u_y_c (N, n_y_c), u_y_d (N, n_y_d))`` — the primal
+    block and the equality / inequality multiplier blocks of the solution
+    in the solver's classified layout."""
+    dims = solver.block_dims
+    if dims is None:
+        raise RuntimeError(
+            "pounce.torch: factor-reuse backward requires a converged IPM "
+            "factor, but the forward solve did not produce one (the IPM "
+            "terminated without an acceptable factorisation). Tighten the "
+            "solve (loosen `tol`, supply a better `x0`, rescale), or build "
+            "the TorchProblem with `factor_reuse=False` to use the dense "
+            "backward, which doesn't depend on the held factor."
+        )
+    n_x_, n_s_, n_y_c_, n_y_d_ = dims[0], dims[1], dims[2], dims[3]
+    kkt_dim = solver.kkt_dim
+    if v_x.shape[1] != n_x_:
+        raise RuntimeError(
+            f"pounce.torch: cotangent length {v_x.shape[1]} != Solver "
+            f"n_x={n_x_} (fixed-variable treatment is not supported)."
+        )
+    N = v_x.shape[0]
+    rhs = np.zeros((N, kkt_dim), dtype=np.float64)
+    rhs[:, :n_x_] = v_x
+    u = np.asarray(
+        solver.kkt_solve_many(rhs.reshape(-1), N), dtype=np.float64,
+    ).reshape(N, kkt_dim)
+    y_c_off = n_x_ + n_s_
+    y_d_off = y_c_off + n_y_c_
+    u_x = u[:, :n_x_]
+    u_y_c = u[:, y_c_off : y_c_off + n_y_c_]
+    u_y_d = u[:, y_d_off : y_d_off + n_y_d_]
+    return u_x, u_y_c, u_y_d
+
+
+def _scatter_y_to_g(u_y_c, u_y_d, is_eq, m):
+    """Scatter classified ``(y_c, y_d)`` multiplier blocks back to user
+    g-order (``c_map``/``d_map`` preserve user order within each group)."""
+    N = u_y_c.shape[0]
+    out = np.zeros((N, m), dtype=np.float64)
+    if m > 0:
+        c_idx = np.flatnonzero(is_eq)
+        d_idx = np.flatnonzero(~is_eq)
+        out[:, c_idx] = u_y_c
+        out[:, d_idx] = u_y_d
+    return out
+
+
+def _gather_g_to_y(rg, is_eq, n_y_c, n_y_d):
+    """Inverse of :func:`_scatter_y_to_g` for the JVP RHS: user g-order
+    ``(N, m)`` → classified ``(y_c (N, n_y_c), y_d (N, n_y_d))``."""
+    N = rg.shape[0]
+    c_idx = np.flatnonzero(is_eq)
+    d_idx = np.flatnonzero(~is_eq)
+    y_c = rg[:, c_idx] if n_y_c > 0 else np.zeros((N, 0))
+    y_d = rg[:, d_idx] if n_y_d > 0 else np.zeros((N, 0))
+    return y_c, y_d
+
+
+def _bwd_factor_reuse_single(tp, solver, p, x_star, lam, v):
+    """Single-solve k_aug VJP: reuse the converged factor for the KKT
+    back-solve, autodiff the parameter sensitivities. Returns dL/dp."""
+    f, g, n, m = tp._f, tp._g, tp._n, tp._m
+
+    def lagrangian(x, p_):
+        base = f(x, p_)
+        if g is not None and m > 0:
+            base = base + torch.dot(lam, g(x, p_))
+        return base
+
+    grad_L_of_p = lambda p_: grad(lagrangian, argnums=0)(x_star, p_)  # noqa: E731
+    dgradL_dp = jacrev(grad_L_of_p)(p)
+    if g is not None and m > 0:
+        dg_dp = jacrev(lambda p_: g(x_star, p_))(p)
+    else:
+        dg_dp = torch.zeros((0,) + tuple(p.shape), dtype=_DT)
+
+    v_np = _to_np(v)[None, :]
+    u_x, u_y_c, u_y_d = _factor_backsolve(solver, v_np, n)
+    u_x_t = torch.as_tensor(u_x[0], dtype=_DT)
+    u_g_t = torch.as_tensor(
+        _scatter_y_to_g(u_y_c, u_y_d, tp._is_eq, m)[0], dtype=_DT,
+    )
+    dL_dp = -torch.tensordot(u_x_t, dgradL_dp, dims=1)
+    if m > 0:
+        dL_dp = dL_dp - torch.tensordot(u_g_t, dg_dp, dims=1)
+    return dL_dp
+
+
+def _bwd_factor_reuse_batched(tp, solver, B, p_batch, x_star_batch, lam_batch, v_batch):
+    """Stacked (A)+(B) VJP: one back-solve over the held stacked factor,
+    per-block contraction with the autodiff parameter sensitivities.
+    Returns ``(B,) + p_shape``."""
+    f, g, n, m = tp._f, tp._g, tp._n, tp._m
+    v_np = _to_np(v_batch).reshape(1, B * n)
+    u_x, u_y_c, u_y_d = _factor_backsolve(solver, v_np, B * n)
+    u_x_b = torch.as_tensor(u_x[0].reshape(B, n), dtype=_DT)
+    # Stacked y_c / y_d are block-major; de-interleave then scatter.
+    n_c_per = int(np.sum(tp._is_eq))
+    n_d_per = m - n_c_per
+    u_y_c_b = u_y_c[0].reshape(B, n_c_per) if n_c_per > 0 else np.zeros((B, 0))
+    u_y_d_b = u_y_d[0].reshape(B, n_d_per) if n_d_per > 0 else np.zeros((B, 0))
+    u_g_b = torch.as_tensor(
+        _scatter_y_to_g(u_y_c_b, u_y_d_b, tp._is_eq, m), dtype=_DT,
+    )
+
+    grads = []
+    for k in range(B):
+        lam_k = lam_batch[k] if m > 0 else lam_batch
+        def lagrangian(x, p_, lam_k=lam_k):
+            base = f(x, p_)
+            if g is not None and m > 0:
+                base = base + torch.dot(lam_k, g(x, p_))
+            return base
+        dgradL_dp = jacrev(lambda p_: grad(lagrangian, argnums=0)(x_star_batch[k], p_))(p_batch[k])
+        dL = -torch.tensordot(u_x_b[k], dgradL_dp, dims=1)
+        if m > 0:
+            dg_dp = jacrev(lambda p_: g(x_star_batch[k], p_))(p_batch[k])
+            dL = dL - torch.tensordot(u_g_b[k], dg_dp, dims=1)
+        grads.append(dL)
+    return torch.stack(grads, dim=0)
+
+
+def _jvp_factor_reuse_batched(tp, solver, B, p_batch, x_star_batch, lam_batch, dp_batch, cols):
+    """Stacked forward (JVP) ``J @ dp`` against the held factor. Returns
+    ``(delta_x (B, n), delta_lam (B, m))``."""
+    f, g, n, m = tp._f, tp._g, tp._n, tp._m
+    # Per-block parameter-side RHS: M_k · dp_k via autodiff.
+    rx = np.zeros((B, n), dtype=np.float64)
+    rg = np.zeros((B, m), dtype=np.float64)
+    for k in range(B):
+        lam_k = lam_batch[k] if m > 0 else lam_batch
+        def lagrangian(x, p_, lam_k=lam_k):
+            base = f(x, p_)
+            if g is not None and m > 0:
+                base = base + torch.dot(lam_k, g(x, p_))
+            return base
+        dgradL_dp = jacrev(lambda p_: grad(lagrangian, argnums=0)(x_star_batch[k], p_))(p_batch[k])
+        if cols is not None:
+            dgradL_dp = dgradL_dp[..., cols]
+        rx[k] = _to_np(torch.tensordot(dgradL_dp, dp_batch[k], dims=dp_batch[k].ndim))
+        if m > 0:
+            dg_dp = jacrev(lambda p_: g(x_star_batch[k], p_))(p_batch[k])
+            if cols is not None:
+                dg_dp = dg_dp[..., cols]
+            rg[k] = _to_np(torch.tensordot(dg_dp, dp_batch[k], dims=dp_batch[k].ndim))
+
+    dims = solver.block_dims
+    n_x_, n_s_, n_y_c_, n_y_d_ = dims[0], dims[1], dims[2], dims[3]
+    kkt_dim = solver.kkt_dim
+    rhs = np.zeros((1, kkt_dim), dtype=np.float64)
+    rhs[0, :n_x_] = rx.reshape(-1)
+    if m > 0:
+        y_c, y_d = _gather_g_to_y(rg, tp._is_eq, n_y_c_, n_y_d_)
+        y_c_off = n_x_ + n_s_
+        y_d_off = y_c_off + n_y_c_
+        if n_y_c_ > 0:
+            rhs[0, y_c_off : y_c_off + n_y_c_] = y_c.reshape(-1)
+        if n_y_d_ > 0:
+            rhs[0, y_d_off : y_d_off + n_y_d_] = y_d.reshape(-1)
+    w = np.asarray(solver.kkt_solve_many(rhs.reshape(-1), 1), dtype=np.float64).reshape(kkt_dim)
+    w_x = w[:n_x_].reshape(B, n)
+    delta_x = torch.as_tensor(-w_x, dtype=_DT)
+    if m > 0:
+        y_c_off = n_x_ + n_s_
+        y_d_off = y_c_off + n_y_c_
+        n_c_per = int(np.sum(tp._is_eq))
+        n_d_per = m - n_c_per
+        w_y_c = w[y_c_off : y_c_off + n_y_c_].reshape(B, n_c_per) if n_c_per > 0 else np.zeros((B, 0))
+        w_y_d = w[y_d_off : y_d_off + n_y_d_].reshape(B, n_d_per) if n_d_per > 0 else np.zeros((B, 0))
+        delta_lam = torch.as_tensor(
+            -_scatter_y_to_g(w_y_c, w_y_d, tp._is_eq, m), dtype=_DT,
+        )
+    else:
+        delta_lam = torch.zeros((B, 0), dtype=_DT)
+    return delta_x, delta_lam
+
+
+# ----- caller-owned held-factor handle (pounce#82) -----
+
+
+class AnchorState:
+    """Caller-owned handle to a held stacked KKT factor (pounce#82).
+
+    Returned by :meth:`TorchProblem.anchor`,
+    :meth:`TorchProblem.warm_anchor`, and (with ``return_state=True``)
+    :meth:`TorchProblem.batched_solve_with_jacobian`. Holds the converged
+    :class:`pounce.Solver` so several post-solve sensitivity calls reuse
+    one factorisation without a re-solve.
+
+    In eager PyTorch the factor lifetime is plain Python reference
+    counting: the ``Solver`` is held as an attribute and released when the
+    handle is :meth:`close`d (or garbage-collected). Prefer the context
+    manager::
+
+        with tp.anchor(p, x0) as state:
+            J = tp.sensitivity(state)
+    """
+
+    __slots__ = ("_tp", "_solver", "_B", "_p_batch", "_x_star", "_lam",
+                 "_duals", "_wrt_cols", "_closed")
+
+    def __init__(self, tp, solver, B, p_batch, x_star, lam, duals, wrt_cols):
+        self._tp = tp
+        self._solver = solver
+        self._B = B
+        self._p_batch = p_batch
+        self._x_star = x_star
+        self._lam = lam
+        self._duals = duals
+        self._wrt_cols = wrt_cols
+        self._closed = False
+
+    @property
+    def x_star(self):
+        """Primal solution ``(B, n)`` captured at anchor time."""
+        return self._x_star
+
+    @property
+    def duals(self):
+        """``(lam, zL, zU)`` captured at anchor time."""
+        return self._duals
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def _check_open(self):
+        if self._closed:
+            raise RuntimeError(
+                "pounce.torch: AnchorState is closed; re-anchor with "
+                "tp.anchor(...)."
+            )
+
+    def close(self) -> None:
+        """Release the held factor (idempotent)."""
+        self._solver = None
+        self._closed = True
+
+    def reanchor(self, p_batch, x0) -> "AnchorState":
+        """Swap the held factor to a fresh solve in place."""
+        self.close()
+        x_star, duals, solver, (pb, xs, lam) = self._tp._anchor_forward(p_batch, x0)
+        self._solver = solver
+        self._p_batch, self._x_star, self._lam = pb, xs, lam
+        self._duals = duals
+        self._closed = False
+        return self
+
+    def __enter__(self) -> "AnchorState":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        state = "closed" if self._closed else "open"
+        return f"AnchorState(B={self._B}, {state})"
+
+
+class TorchProblem:
+    """Reusable, differentiable parametric solve (PyTorch frontend).
+
+    Construct once with ``f(x, p)`` and ``g(x, p)``; solve many times at
+    different ``p`` without re-tracing the ``torch.func`` derivatives or
+    re-running the random sparsity probe. Mirror of
+    :class:`pounce.jax.JaxProblem`.
+
+    Parameters
+    ----------
+    f : callable
+        Objective ``f(x, p) -> scalar`` (tensors). ``torch.func``-traceable.
+    g : callable or None
+        Constraints ``g(x, p) -> (m,)``. Required when ``m > 0``.
+    n, m : int
+        Variable and constraint counts.
+    p_example : array-like
+        Example parameter (shape/dtype only) for the one-shot sparsity
+        probe. Any later ``p`` must share this shape.
+    lb, ub, cl, cu : array-like or None
+        Variable and constraint bounds; same convention as
+        :class:`pounce.Problem`.
+    options : dict or None
+        Pounce options applied via ``add_option`` at build time.
+    seed : int
+        Seed for the random sparsity probe(s).
+    factor_reuse : bool
+        When ``True`` (default), the differentiable backward reuses the
+        IPM's converged compound KKT factor (k_aug-style; pounce#76). Set
+        ``False`` for the dense in-framework backward (useful for
+        higher-order differentiation).
+    sparse : bool
+        Colored/compressed forward Jacobian & Hessian (issue #83).
+    n_probes : int or None
+        Probes whose nonzero patterns are unioned (default 1 dense / 3
+        sparse).
+    """
+
+    def __init__(
+        self,
+        *,
+        f: Callable,
+        g: Callable | None = None,
+        n: int,
+        m: int = 0,
+        p_example,
+        lb=None,
+        ub=None,
+        cl=None,
+        cu=None,
+        options: dict | None = None,
+        seed: int = 0,
+        factor_reuse: bool = True,
+        sparse: bool = False,
+        n_probes: int | None = None,
+    ):
+        if m > 0 and g is None:
+            raise ValueError("g must be provided when m > 0")
+        self._f = f
+        self._g = g
+        self._n = n
+        self._m = m
+        self._sparse = bool(sparse)
+        self._n_probes = max(1, int(n_probes if n_probes is not None
+                                    else (3 if sparse else 1)))
+        self._lb = lb
+        self._ub = ub
+        self._cl = cl
+        self._cu = cu
+        self._options = dict(options or {})
+        self._factor_reuse = bool(factor_reuse)
+
+        if m > 0:
+            self._cl_for_classify = np.asarray(cl, dtype=np.float64)
+            self._cu_for_classify = np.asarray(cu, dtype=np.float64)
+            self._is_eq = self._cl_for_classify == self._cu_for_classify
+        else:
+            self._cl_for_classify = np.zeros(0)
+            self._cu_for_classify = np.zeros(0)
+            self._is_eq = np.zeros(0, dtype=bool)
+
+        self._build_closures()
+
+        # Cached Problem instances (single-threaded reuse; the held
+        # Solver captures the factor independently of the mutable _p).
+        self._cached_pair = None
+        self._cached_warm_pair = None
+        self._cached_corrector_pair = None
+        self._stacked_cache: dict[int, tuple] = {}
+        self._stacked_warm_cache: dict[int, tuple] = {}
+
+        # One-shot sparsity probe.
+        p_arr = np.asarray(p_example, dtype=np.float64)
+        self._p_shape = p_arr.shape
+        rng = np.random.default_rng(seed)
+        x_probes = [_t(rng.standard_normal(n)) for _ in range(self._n_probes)]
+        p_probes = [_t(rng.standard_normal(p_arr.shape)) for _ in range(self._n_probes)]
+        if m > 0:
+            lam_probes = [_t(rng.standard_normal(m)) for _ in range(self._n_probes)]
+            jac_denses = [
+                _to_np(self._jac_g_dense(xp, pp))
+                for xp, pp in zip(x_probes, p_probes)
+            ]
+            self._jac_rows, self._jac_cols = _detect_pattern_2d_multi(jac_denses)
+            hess_denses = [
+                _to_np(self._hess_lag(xp, lp, _t(1.0), pp))
+                for xp, lp, pp in zip(x_probes, lam_probes, p_probes)
+            ]
+        else:
+            self._jac_rows = np.zeros(0, dtype=np.int64)
+            self._jac_cols = np.zeros(0, dtype=np.int64)
+            hess_denses = [
+                _to_np(self._hess_lag(xp, _t(1.0), pp))
+                for xp, pp in zip(x_probes, p_probes)
+            ]
+        self._hess_rows, self._hess_cols = _detect_pattern_lower_multi(hess_denses)
+
+        if self._sparse:
+            self._build_compressed_closures()
+
+    # ----- closure building -----
+
+    def _build_closures(self) -> None:
+        f, g, m = self._f, self._g, self._m
+        self._grad_f = grad(f, argnums=0)
+        if g is not None and m > 0:
+            self._jac_g_dense = (
+                jacfwd(g, argnums=0) if self._n < m else jacrev(g, argnums=0)
+            )
+
+            def lagrangian(x, lam, sigma, p):
+                return sigma * f(x, p) + torch.dot(lam, g(x, p))
+
+            self._hess_lag = hessian(lagrangian, argnums=0)
+        else:
+            self._jac_g_dense = None
+
+            def lagrangian_unc(x, sigma, p):
+                return sigma * f(x, p)
+
+            self._hess_lag = hessian(lagrangian_unc, argnums=0)
+
+    def _build_compressed_closures(self) -> None:
+        n, m = self._n, self._m
+        f, g = self._f, self._g
+        if m > 0:
+            jac_colors, k_jac = _color_columns(self._jac_rows, self._jac_cols, n)
+            S_jac = _seed_matrix(jac_colors, k_jac, n)
+            self._jac_seed_cols = jac_colors[self._jac_cols]
+
+            def jac_compressed(x, p):
+                return vmap(lambda s: jvp(lambda xx: g(xx, p), (x,), (s,))[1])(S_jac)
+
+            self._jac_compressed = jac_compressed
+        else:
+            self._jac_seed_cols = np.zeros(0, dtype=np.int64)
+            self._jac_compressed = None
+
+        full_rows = np.concatenate([self._hess_rows, self._hess_cols])
+        full_cols = np.concatenate([self._hess_cols, self._hess_rows])
+        hess_colors, k_hess = _color_columns(full_rows, full_cols, n)
+        S_hess = _seed_matrix(hess_colors, k_hess, n)
+        self._hess_seed_cols = hess_colors[self._hess_cols]
+
+        if m > 0:
+            def lagrangian(x, lam, sigma, p):
+                return sigma * f(x, p) + torch.dot(lam, g(x, p))
+            grad_L = grad(lagrangian, argnums=0)
+
+            def hess_compressed(x, lam, sigma, p):
+                return vmap(
+                    lambda s: jvp(lambda xx: grad_L(xx, lam, sigma, p), (x,), (s,))[1]
+                )(S_hess)
+        else:
+            def lagrangian_unc(x, sigma, p):
+                return sigma * f(x, p)
+            grad_L = grad(lagrangian_unc, argnums=0)
+
+            def hess_compressed(x, sigma, p):
+                return vmap(
+                    lambda s: jvp(lambda xx: grad_L(xx, sigma, p), (x,), (s,))[1]
+                )(S_hess)
+
+        self._hess_compressed = hess_compressed
+
+    # ----- Problem builders (cached) -----
+
+    def _build_problem(self):
+        obj = _ReusableTorchNlp(self)
+        prob = Problem(
+            n=self._n, m=self._m, problem_obj=obj,
+            lb=self._lb, ub=self._ub, cl=self._cl, cu=self._cu,
+        )
+        for k, v in self._options.items():
+            prob.add_option(k, v)
+        return obj, prob
+
+    def _get_pair(self):
+        if self._cached_pair is None:
+            self._cached_pair = self._build_problem()
+        return self._cached_pair
+
+    def _get_warm_pair(self):
+        if self._cached_warm_pair is None:
+            obj, prob = self._build_problem()
+            prob.add_option("warm_start_init_point", "yes")
+            self._cached_warm_pair = (obj, prob)
+        return self._cached_warm_pair
+
+    def _get_corrector_pair(self):
+        if self._cached_corrector_pair is None:
+            obj, prob = self._build_problem()
+            prob.add_option("warm_start_init_point", "yes")
+            self._cached_corrector_pair = (obj, prob)
+        return self._cached_corrector_pair
+
+    def _build_stacked_problem(self, B: int):
+        def tile(v, count):
+            if v is None:
+                return None
+            arr = np.asarray(v, dtype=np.float64)
+            return np.tile(arr, B) if count > 0 else np.zeros(0)
+        n, m = self._n, self._m
+        obj = _StackedTorchNlp(self, B)
+        prob = Problem(
+            n=B * n, m=B * m, problem_obj=obj,
+            lb=tile(self._lb, n), ub=tile(self._ub, n),
+            cl=tile(self._cl, m), cu=tile(self._cu, m),
+        )
+        for k, v in self._options.items():
+            prob.add_option(k, v)
+        return obj, prob
+
+    def _get_stacked_pair(self, B: int):
+        pair = self._stacked_cache.get(B)
+        if pair is None:
+            pair = self._build_stacked_problem(B)
+            self._stacked_cache[B] = pair
+        return pair
+
+    def _get_stacked_warm_pair(self, B: int):
+        pair = self._stacked_warm_cache.get(B)
+        if pair is None:
+            obj, prob = self._build_stacked_problem(B)
+            prob.add_option("warm_start_init_point", "yes")
+            pair = (obj, prob)
+            self._stacked_warm_cache[B] = pair
+        return pair
+
+    # ----- host-side solves -----
+
+    def _host_solve(self, p, x0):
+        obj, prob = self._get_pair()
+        obj._p = p
+        solver = Solver(prob)
+        x_np, info = solver.solve(x0=np.asarray(x0.detach().cpu(), dtype=np.float64))
+        return np.asarray(x_np, dtype=np.float64), info, solver
+
+    def _host_solve_warm(self, p, x0, lam, zL, zU):
+        obj, prob = self._get_warm_pair()
+        obj._p = p
+        solver = Solver(prob)
+        x_np, info = solver.solve(
+            x0=np.asarray(x0.detach().cpu(), dtype=np.float64),
+            lagrange=np.asarray(lam, dtype=np.float64),
+            zl=np.asarray(zL, dtype=np.float64),
+            zu=np.asarray(zU, dtype=np.float64),
+        )
+        return np.asarray(x_np, dtype=np.float64), info, solver
+
+    def _host_batched_solve(self, p_batch, x0_batch):
+        B = p_batch.shape[0]
+        n, m = self._n, self._m
+        obj, prob = self._get_stacked_pair(B)
+        obj._P = p_batch
+        X0 = np.asarray(x0_batch.detach().cpu(), dtype=np.float64).reshape(B * n)
+        solver = Solver(prob)
+        X_np, info = solver.solve(x0=X0)
+        x_batch = np.asarray(X_np, dtype=np.float64).reshape(B, n)
+        lam_batch = (
+            np.asarray(info["mult_g"], dtype=np.float64).reshape(B, m)
+            if m > 0 else np.zeros((B, 0))
+        )
+        mxL = np.asarray(info["mult_x_L"], dtype=np.float64).reshape(B, n)
+        mxU = np.asarray(info["mult_x_U"], dtype=np.float64).reshape(B, n)
+        return x_batch, lam_batch, mxL, mxU, solver, info
+
+    def _host_batched_solve_warm(self, p_batch, x0_batch, lam_b, zL_b, zU_b):
+        B = p_batch.shape[0]
+        n, m = self._n, self._m
+        obj, prob = self._get_stacked_warm_pair(B)
+        obj._P = p_batch
+        X0 = np.asarray(x0_batch.detach().cpu(), dtype=np.float64).reshape(B * n)
+        lam_stack = np.asarray(lam_b, dtype=np.float64).reshape(B * m) if m > 0 else np.zeros(0)
+        zL_stack = np.asarray(zL_b, dtype=np.float64).reshape(B * n)
+        zU_stack = np.asarray(zU_b, dtype=np.float64).reshape(B * n)
+        solver = Solver(prob)
+        X_np, info = solver.solve(x0=X0, lagrange=lam_stack, zl=zL_stack, zu=zU_stack)
+        x_batch = np.asarray(X_np, dtype=np.float64).reshape(B, n)
+        lam_batch = (
+            np.asarray(info["mult_g"], dtype=np.float64).reshape(B, m)
+            if m > 0 else np.zeros((B, 0))
+        )
+        mxL = np.asarray(info["mult_x_L"], dtype=np.float64).reshape(B, n)
+        mxU = np.asarray(info["mult_x_U"], dtype=np.float64).reshape(B, n)
+        return x_batch, lam_batch, mxL, mxU, solver, info
+
+    # ----- public differentiable solves -----
+
+    def solve(self, p, x0):
+        """Differentiable forward solve at parameter ``p``. Returns ``x*``."""
+        p = _t(p)
+        x0 = _t(x0)
+        tp = self
+        factor_reuse = self._factor_reuse
+
+        class _SolveFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, p, x0):
+                x_np, info, solver = tp._host_solve(p, x0)
+                x_star = torch.as_tensor(x_np, dtype=_DT)
+                lam = (
+                    torch.as_tensor(np.asarray(info["mult_g"]), dtype=_DT)
+                    if tp._m > 0 else torch.zeros(0, dtype=_DT)
+                )
+                mxL = torch.as_tensor(np.asarray(info["mult_x_L"]), dtype=_DT)
+                mxU = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)
+                ctx.save_for_backward(p, x_star, lam, mxL, mxU)
+                ctx.solver = solver
+                return x_star
+
+            @staticmethod
+            def backward(ctx, v):
+                p, x_star, lam, mxL, mxU = ctx.saved_tensors
+                if factor_reuse:
+                    dL_dp = _bwd_factor_reuse_single(tp, ctx.solver, p, x_star, lam, v)
+                else:
+                    dL_dp = _kkt_backward(
+                        tp._f, tp._g, tp._n, tp._m, tp._cl, tp._cu,
+                        p, x_star, lam, mxL, mxU, v,
+                    )
+                return dL_dp, None
+
+        return _SolveFn.apply(p, x0)
+
+    def solve_with_warm(self, p, x0, warm_start: tuple | None = None):
+        """Differentiable forward solve with dual warm-start.
+
+        Returns ``(x*, (lam_out, zL_out, zU_out))``."""
+        p = _t(p)
+        x0 = _t(x0)
+        n, m = self._n, self._m
+        if warm_start is None:
+            lam_w = np.zeros(m); zL_w = np.zeros(n); zU_w = np.zeros(n)
+        else:
+            lam_w, zL_w, zU_w = (np.asarray(_to_np(_t(a))) for a in warm_start)
+        tp = self
+        factor_reuse = self._factor_reuse
+
+        class _WarmFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, p, x0):
+                x_np, info, solver = tp._host_solve_warm(p, x0, lam_w, zL_w, zU_w)
+                x_star = torch.as_tensor(x_np, dtype=_DT)
+                lam = (
+                    torch.as_tensor(np.asarray(info["mult_g"]), dtype=_DT)
+                    if m > 0 else torch.zeros(0, dtype=_DT)
+                )
+                mxL = torch.as_tensor(np.asarray(info["mult_x_L"]), dtype=_DT)
+                mxU = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)
+                ctx.save_for_backward(p, x_star, lam, mxL, mxU)
+                ctx.solver = solver
+                ctx.extra = (lam, mxL, mxU)
+                return x_star
+
+            @staticmethod
+            def backward(ctx, v):
+                p, x_star, lam, mxL, mxU = ctx.saved_tensors
+                if factor_reuse:
+                    dL_dp = _bwd_factor_reuse_single(tp, ctx.solver, p, x_star, lam, v)
+                else:
+                    dL_dp = _kkt_backward(
+                        tp._f, tp._g, n, m, tp._cl, tp._cu,
+                        p, x_star, lam, mxL, mxU, v,
+                    )
+                return dL_dp, None
+
+        # Run forward once to also recover the dual outputs to thread out.
+        x_np, info, _solver = self._host_solve_warm(p, x0, lam_w, zL_w, zU_w)
+        x_star = _WarmFn.apply(p, x0)
+        lam_out = (
+            torch.as_tensor(np.asarray(info["mult_g"]), dtype=_DT)
+            if m > 0 else torch.zeros(0, dtype=_DT)
+        )
+        zL_out = torch.as_tensor(np.asarray(info["mult_x_L"]), dtype=_DT)
+        zU_out = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)
+        return x_star, (lam_out, zL_out, zU_out)
+
+    def vmap_solve(self, p_batch, x0):
+        """Sequential batched solve. Differentiable via per-element
+        :meth:`solve`. ``x0`` may be ``(n,)`` (broadcast) or ``(B, n)``."""
+        p_batch = _t(p_batch)
+        B = p_batch.shape[0]
+        x0_arr = _t(x0)
+        if x0_arr.ndim == 1:
+            x0_arr = x0_arr.expand(B, self._n)
+        return torch.stack([self.solve(p_batch[i], x0_arr[i]) for i in range(B)], dim=0)
+
+    def vmap_solve_parallel(self, p_batch, x0, workers: int | None = None):
+        """Parallel batched solve via a threadpool. Differentiable via the
+        per-element dense backward (no shared factor across threads)."""
+        from ._diff import _solve_batch_threadpool
+
+        p_batch = _t(p_batch)
+        B = p_batch.shape[0]
+        n, m = self._n, self._m
+        x0_arr = _t(x0)
+        if x0_arr.ndim == 1:
+            x0_arr = x0_arr.expand(B, n).contiguous()
+        tp = self
+
+        # Wrap f/g to (x, p) signature already; reuse _diff threadpool with
+        # the TorchProblem's own f/g and options.
+        def f(x, p):
+            return tp._f(x, p)
+        g = (lambda x, p: tp._g(x, p)) if (tp._g is not None and m > 0) else None
+
+        class _ParFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, p_batch, x0_batch):
+                p_np = np.asarray(p_batch.detach().cpu(), dtype=np.float64)
+                x0_np = np.asarray(x0_batch.detach().cpu(), dtype=np.float64)
+                x_out, lam_out, zL_out, zU_out = _solve_batch_threadpool(
+                    f, g, p_np, x0_np, n, m, tp._lb, tp._ub, tp._cl, tp._cu,
+                    tp._options, workers,
+                )
+                x_star = torch.as_tensor(x_out, dtype=_DT)
+                ctx.save_for_backward(
+                    p_batch, x_star, torch.as_tensor(lam_out, dtype=_DT),
+                    torch.as_tensor(zL_out, dtype=_DT),
+                    torch.as_tensor(zU_out, dtype=_DT),
+                )
+                return x_star
+
+            @staticmethod
+            def backward(ctx, v_batch):
+                p_b, x_star, lam, mxL, mxU = ctx.saved_tensors
+                grads = [
+                    _kkt_backward(
+                        f, g, n, m, tp._cl, tp._cu, p_b[i], x_star[i],
+                        lam[i] if m > 0 else lam, mxL[i], mxU[i], v_batch[i],
+                    )
+                    for i in range(p_b.shape[0])
+                ]
+                return torch.stack(grads, dim=0), None
+
+        return _ParFn.apply(p_batch, x0_arr)
+
+    def batched_solve(self, p_batch, x0):
+        """Stacked block-diagonal batched solve (pounce#76 (A)). Returns
+        ``x_batch`` of shape ``(B, n)``. Differentiable; the backward
+        reuses the held stacked factor when ``factor_reuse=True``, else
+        the per-block dense KKT solve."""
+        p_batch = _t(p_batch)
+        B = p_batch.shape[0]
+        x0_arr = _t(x0)
+        if x0_arr.ndim == 1:
+            x0_arr = x0_arr.expand(B, self._n).contiguous()
+        tp = self
+        n, m = self._n, self._m
+        factor_reuse = self._factor_reuse
+
+        class _BatchedFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, p_batch, x0_batch):
+                x_b, lam_b, mxL, mxU, solver, _info = tp._host_batched_solve(
+                    p_batch, x0_batch,
+                )
+                x_star = torch.as_tensor(x_b, dtype=_DT)
+                ctx.save_for_backward(
+                    p_batch, x_star, torch.as_tensor(lam_b, dtype=_DT),
+                    torch.as_tensor(mxL, dtype=_DT), torch.as_tensor(mxU, dtype=_DT),
+                )
+                ctx.solver = solver
+                return x_star
+
+            @staticmethod
+            def backward(ctx, v_batch):
+                p_b, x_star, lam_b, mxL, mxU = ctx.saved_tensors
+                if factor_reuse:
+                    dL = _bwd_factor_reuse_batched(
+                        tp, ctx.solver, p_b.shape[0], p_b, x_star, lam_b, v_batch,
+                    )
+                else:
+                    dL = torch.stack([
+                        _kkt_backward(
+                            tp._f, tp._g, n, m, tp._cl, tp._cu, p_b[i], x_star[i],
+                            lam_b[i] if m > 0 else lam_b, mxL[i], mxU[i], v_batch[i],
+                        )
+                        for i in range(p_b.shape[0])
+                    ], dim=0)
+                return dL, None
+
+        return _BatchedFn.apply(p_batch, x0_arr)
+
+    def batched_solve_with_warm(self, p_batch, x0, warm_start: tuple | None = None):
+        """Warm-started stacked batched solve (pounce#78). Returns
+        ``(x_batch, (lam_batch, zL_batch, zU_batch))``."""
+        p_batch = _t(p_batch)
+        B = p_batch.shape[0]
+        n, m = self._n, self._m
+        x0_arr = _t(x0)
+        if x0_arr.ndim == 1:
+            x0_arr = x0_arr.expand(B, n).contiguous()
+        if warm_start is None:
+            lam_w = np.zeros((B, m)); zL_w = np.zeros((B, n)); zU_w = np.zeros((B, n))
+        else:
+            lam_w = _to_np(_t(warm_start[0])).reshape(B, m)
+            zL_w = _to_np(_t(warm_start[1])).reshape(B, n)
+            zU_w = _to_np(_t(warm_start[2])).reshape(B, n)
+        tp = self
+        factor_reuse = self._factor_reuse
+
+        x_b, lam_b, mxL, mxU, _solver, info = self._host_batched_solve_warm(
+            p_batch, x0_arr, lam_w, zL_w, zU_w,
+        )
+
+        class _BatchedWarmFn(torch.autograd.Function):
+            @staticmethod
+            def forward(ctx, p_batch, x0_batch):
+                xb, lamb, mxl, mxu, solver, _i = tp._host_batched_solve_warm(
+                    p_batch, x0_batch, lam_w, zL_w, zU_w,
+                )
+                x_star = torch.as_tensor(xb, dtype=_DT)
+                ctx.save_for_backward(
+                    p_batch, x_star, torch.as_tensor(lamb, dtype=_DT),
+                    torch.as_tensor(mxl, dtype=_DT), torch.as_tensor(mxu, dtype=_DT),
+                )
+                ctx.solver = solver
+                return x_star
+
+            @staticmethod
+            def backward(ctx, v_batch):
+                p_b, x_star, lam_b, mxl, mxu = ctx.saved_tensors
+                if factor_reuse:
+                    dL = _bwd_factor_reuse_batched(
+                        tp, ctx.solver, p_b.shape[0], p_b, x_star, lam_b, v_batch,
+                    )
+                else:
+                    dL = torch.stack([
+                        _kkt_backward(
+                            tp._f, tp._g, n, m, tp._cl, tp._cu, p_b[i], x_star[i],
+                            lam_b[i] if m > 0 else lam_b, mxl[i], mxu[i], v_batch[i],
+                        )
+                        for i in range(p_b.shape[0])
+                    ], dim=0)
+                return dL, None
+
+        x_star = _BatchedWarmFn.apply(p_batch, x0_arr)
+        lam_out = torch.as_tensor(lam_b, dtype=_DT)
+        zL_out = torch.as_tensor(mxL, dtype=_DT)
+        zU_out = torch.as_tensor(mxU, dtype=_DT)
+        return x_star, (lam_out, zL_out, zU_out)
+
+    # ----- post-solve sensitivity API (pounce#82) -----
+
+    def _normalize_cols(self, wrt_cols):
+        if wrt_cols is None:
+            return None
+        if len(self._p_shape) != 1:
+            raise ValueError(
+                "pounce.torch: wrt_cols is only supported for 1-D p "
+                f"(got p_shape={self._p_shape})."
+            )
+        p_dim = self._p_shape[0]
+        idx = np.arange(p_dim)[wrt_cols] if isinstance(wrt_cols, slice) \
+            else np.asarray(wrt_cols, dtype=np.int64)
+        return torch.as_tensor(np.atleast_1d(idx), dtype=torch.long)
+
+    def _anchor_forward(self, p_batch, x0):
+        p_arr = _t(p_batch)
+        B = p_arr.shape[0]
+        x0_arr = _t(x0)
+        if x0_arr.ndim == 1:
+            x0_arr = x0_arr.expand(B, self._n).contiguous()
+        x_b, lam_b, mxL, mxU, solver, _info = self._host_batched_solve(p_arr, x0_arr)
+        x_star = torch.as_tensor(x_b, dtype=_DT)
+        lam = torch.as_tensor(lam_b, dtype=_DT)
+        duals = (lam, torch.as_tensor(mxL, dtype=_DT), torch.as_tensor(mxU, dtype=_DT))
+        return x_star, duals, solver, (p_arr, x_star, lam)
+
+    def _slice_cols(self, arr, cols):
+        if cols is None:
+            return arr
+        return torch.index_select(arr, -1, cols)
+
+    def anchor(self, p_batch, x0, *, wrt_cols=None) -> AnchorState:
+        """Solve once and hold the stacked KKT factor for reuse across
+        post-solve sensitivity calls (pounce#82). Accepts a batched
+        ``p_batch`` (``(B,) + p_shape``) or a single point (``p_shape`` →
+        ``B=1``)."""
+        cols = self._normalize_cols(wrt_cols)
+        p_arr = _t(p_batch)
+        if p_arr.ndim == len(self._p_shape):
+            p_arr = p_arr[None]
+        x_star, duals, solver, (pb, xs, lam) = self._anchor_forward(p_arr, x0)
+        return AnchorState(self, solver, pb.shape[0], pb, xs, lam, duals, cols)
+
+    def warm_anchor(self, p, x0, *, duals=None, mu=None, wrt_cols=None):
+        """Warm-started, barrier-μ-seeded re-solve that also holds the
+        converged factor as a ``B=1`` :class:`AnchorState` (pounce#90).
+        Not differentiable (host-side corrector). Returns ``(state, info)``."""
+        import math
+        n, m = self._n, self._m
+        cols = self._normalize_cols(wrt_cols)
+        p_arr = _t(p)
+        if p_arr.ndim != len(self._p_shape):
+            raise ValueError(
+                "pounce.torch: warm_anchor takes a single (un-batched) p."
+            )
+        x0_np = np.asarray(_to_np(_t(x0)), dtype=np.float64)
+        if duals is None:
+            lam_np = np.zeros(m); zL_np = np.zeros(n); zU_np = np.zeros(n)
+        else:
+            lam_np = _to_np(_t(duals[0])); zL_np = _to_np(_t(duals[1])); zU_np = _to_np(_t(duals[2]))
+        mu_f = float("nan") if mu is None else float(mu)
+
+        obj, prob = self._get_corrector_pair()
+        obj._p = p_arr
+        if math.isfinite(mu_f):
+            prob.add_option("mu_init", mu_f)
+            prob.add_option("warm_start_target_mu", mu_f)
+        else:
+            prob.add_option("mu_init", 0.1)
+            prob.add_option("warm_start_target_mu", 0.0)
+        solver = Solver(prob)
+        x_np, info = solver.solve(
+            x0=x0_np, lagrange=lam_np, zl=zL_np, zu=zU_np,
+        )
+        x_star = torch.as_tensor(np.asarray(x_np), dtype=_DT)[None]
+        lam_out = torch.as_tensor(np.asarray(info["mult_g"]), dtype=_DT)[None]
+        zL_out = torch.as_tensor(np.asarray(info["mult_x_L"]), dtype=_DT)[None]
+        zU_out = torch.as_tensor(np.asarray(info["mult_x_U"]), dtype=_DT)[None]
+        duals_out = (lam_out, zL_out, zU_out)
+        state = AnchorState(self, solver, 1, p_arr[None], x_star, lam_out, duals_out, cols)
+        return state, dict(info)
+
+    def batched_solve_with_jacobian(self, p_batch, x0, *, wrt_cols=None, return_state=False):
+        """Solve the stacked batch and return the full primal Jacobian
+        ``J[k] = ∂x^(k)*/∂p^(k)`` from the held factor (pounce#82)."""
+        n, m = self._n, self._m
+        cols = self._normalize_cols(wrt_cols)
+        x_star, duals, solver, (p_arr, xs, lam) = self._anchor_forward(p_batch, x0)
+        B = p_arr.shape[0]
+        basis = torch.eye(n, dtype=_DT)
+        J_rows = []
+        for i in range(n):
+            v = basis[i].expand(B, n)
+            J_rows.append(
+                _bwd_factor_reuse_batched(self, solver, B, p_arr, xs, lam, v)
+            )
+        J = torch.stack(J_rows, dim=1)  # (B, n, p_dim)
+        J = self._slice_cols(J, cols)
+        if return_state:
+            state = AnchorState(self, solver, B, p_arr, xs, lam, duals, cols)
+            return x_star, duals, J, state
+        return x_star, duals, J
+
+    def batched_vjp_from_state(self, state: AnchorState, x_bar_batch):
+        """``J^T @ x_bar`` against the held factor. Returns ``(B, p_dim)``."""
+        if state._tp is not self:
+            raise ValueError("AnchorState belongs to a different TorchProblem.")
+        state._check_open()
+        n = self._n
+        x_bar = _t(x_bar_batch).reshape(state._B, n)
+        dp = _bwd_factor_reuse_batched(
+            self, state._solver, state._B, state._p_batch, state._x_star,
+            state._lam, x_bar,
+        )
+        return self._slice_cols(dp, state._wrt_cols)
+
+    def batched_jvp_from_state(self, state: AnchorState, dp_batch, *, with_duals=False):
+        """``J @ dp`` against the held factor. Returns ``(B, n)`` (or
+        ``(delta_x, delta_lam)`` with ``with_duals=True``)."""
+        if state._tp is not self:
+            raise ValueError("AnchorState belongs to a different TorchProblem.")
+        state._check_open()
+        dp = _t(dp_batch)
+        delta_x, delta_lam = _jvp_factor_reuse_batched(
+            self, state._solver, state._B, state._p_batch, state._x_star,
+            state._lam, dp, state._wrt_cols,
+        )
+        if with_duals:
+            return delta_x, delta_lam
+        return delta_x
+
+    # ----- single-problem ergonomic wrappers (pounce#88) -----
+
+    def _require_single(self, state, who):
+        if state._B != 1:
+            raise ValueError(
+                f"pounce.torch: {who} is the single-problem form (B=1); the "
+                f"state was anchored with B={state._B}."
+            )
+
+    def solve_with_jacobian(self, p, x0, *, wrt_cols=None, return_state=False):
+        """Single-problem :meth:`batched_solve_with_jacobian` (pounce#88)."""
+        p1 = _t(p)[None]
+        out = self.batched_solve_with_jacobian(
+            p1, x0, wrt_cols=wrt_cols, return_state=return_state,
+        )
+        if return_state:
+            x_star, (lam, zL, zU), J, state = out
+            return x_star[0], (lam[0], zL[0], zU[0]), J[0], state
+        x_star, (lam, zL, zU), J = out
+        return x_star[0], (lam[0], zL[0], zU[0]), J[0]
+
+    def sensitivity(self, state: AnchorState):
+        """Full primal sensitivity ``∂x*/∂p`` from a held single-problem
+        state (pounce#88)."""
+        self._require_single(state, "sensitivity")
+        n = self._n
+        basis = torch.eye(n, dtype=_DT)
+        J_rows = []
+        for i in range(n):
+            v = basis[i].expand(state._B, n)
+            J_rows.append(
+                _bwd_factor_reuse_batched(
+                    self, state._solver, state._B, state._p_batch,
+                    state._x_star, state._lam, v,
+                )
+            )
+        J = torch.stack(J_rows, dim=1)  # (1, n, p_dim)
+        return self._slice_cols(J, state._wrt_cols)[0]
+
+    def jvp_from_state(self, state: AnchorState, dp, *, with_duals=False):
+        """Single-problem :meth:`batched_jvp_from_state` (pounce#88)."""
+        self._require_single(state, "jvp_from_state")
+        dp1 = _t(dp)[None]
+        if with_duals:
+            dx, dlam = self.batched_jvp_from_state(state, dp1, with_duals=True)
+            return dx[0], dlam[0]
+        return self.batched_jvp_from_state(state, dp1)[0]
+
+    def vjp_from_state(self, state: AnchorState, x_bar):
+        """Single-problem :meth:`batched_vjp_from_state` (pounce#88)."""
+        self._require_single(state, "vjp_from_state")
+        xb1 = _t(x_bar)[None]
+        return self.batched_vjp_from_state(state, xb1)[0]
+
+    def sensitivity_at(self, x_star, theta, duals, *, wrt_cols=None):
+        """Exact ``∂x*/∂θ`` at a supplied primal-dual point by re-assembling
+        and solving the dense KKT there (pounce#87) — no IPM re-solve. Stays
+        in-framework (differentiable)."""
+        f, g, n, m = self._f, self._g, self._n, self._m
+        cl, cu = self._cl, self._cu
+        cols = self._normalize_cols(wrt_cols)
+        x_star = _t(x_star)
+        theta = _t(theta)
+        lam, zL, zU = (_t(d) for d in duals)
+        basis = torch.eye(n, dtype=_DT)
+        J_rows = [
+            _kkt_backward(f, g, n, m, cl, cu, theta, x_star, lam, zL, zU, basis[i])
+            for i in range(n)
+        ]
+        J = torch.stack(J_rows, dim=0)  # (n,) + p_shape
+        return self._slice_cols(J, cols)
+
+    def active_set_margin(self, state: AnchorState, *, active_tol=_ACTIVE_TOL):
+        """Distance to an active-set change at the anchor point (pounce#89)."""
+        B = state._B
+        lam_b, zL_b, zU_b = state.duals
+        return self._margin_arrays(
+            state._x_star, lam_b, zL_b, zU_b, state._p_batch, B, active_tol=active_tol,
+        )
+
+    def _margin_arrays(self, x_b, lam_b, zL_b, zU_b, p_b, B, *, active_tol=_ACTIVE_TOL):
+        n, m = self._n, self._m
+        INF = float("inf")
+        x = _t(x_b).reshape(B, n)
+        zL = _t(zL_b).reshape(B, n)
+        zU = _t(zU_b).reshape(B, n)
+
+        def _bound(arr, fill):
+            if arr is None:
+                return torch.full((B, n), fill, dtype=_DT)
+            return _t(arr).expand(B, n)
+
+        lb = _bound(self._lb, -INF)
+        ub = _bound(self._ub, INF)
+        act_L = zL > active_tol
+        act_U = zU > active_tol
+        inf_t = torch.full((), INF, dtype=_DT)
+        mult_L = torch.where(act_L, zL, inf_t)
+        mult_U = torch.where(act_U, zU, inf_t)
+        slack_L = torch.where(act_L, inf_t, x - lb)
+        slack_U = torch.where(act_U, inf_t, ub - x)
+        mult_cols = [mult_L, mult_U]
+        slack_cols = [slack_L, slack_U]
+        if m > 0:
+            lam = _t(lam_b).reshape(B, m)
+            cl = torch.as_tensor(self._cl_for_classify, dtype=_DT)
+            cu = torch.as_tensor(self._cu_for_classify, dtype=_DT)
+            is_ineq = (cl != cu)[None, :]
+            p_batch = _t(p_b).reshape((B,) + self._p_shape)
+            g_val = vmap(self._g)(x, p_batch)
+            ineq_slack = torch.minimum(g_val - cl[None, :], cu[None, :] - g_val)
+            act_g = is_ineq & (torch.abs(lam) > active_tol)
+            inact_g = is_ineq & ~act_g
+            mult_cols.append(torch.where(act_g, torch.abs(lam), inf_t))
+            slack_cols.append(torch.where(inact_g, ineq_slack, inf_t))
+        min_mult = torch.cat(mult_cols, dim=1).min(dim=1).values
+        min_slack = torch.cat(slack_cols, dim=1).min(dim=1).values
+        margin = torch.minimum(min_mult, min_slack)
+        return {"margin": margin, "min_mult": min_mult, "min_slack": min_slack}

--- a/python/pounce/torch/_qp.py
+++ b/python/pounce/torch/_qp.py
@@ -40,13 +40,13 @@ from ._build import _DT
 
 __all__ = ["solve_qp", "solve_qp_batch", "solve_socp", "QpLayer"]
 
-# Active-set tolerance kept for parity with the JAX layer (the backward
-# here reads the converged multipliers directly via the arrow/diag
-# scalings, so no explicit thresholding is needed).
-_ACTIVE_TOL = 1e-6
+# Note: unlike the NLP backward, the QP/SOCP backward reads the converged
+# multipliers directly via the arrow/diag scalings, so no active-set
+# thresholding constant is needed here (the JAX layer keeps one only for
+# parity).
 
 
-def _t(a, shape=None) -> torch.Tensor:
+def _t(a) -> torch.Tensor:
     out = torch.as_tensor(np.asarray(a, dtype=np.float64), dtype=_DT) \
         if not isinstance(a, torch.Tensor) else a.to(_DT)
     return out

--- a/python/pounce/torch/_qp.py
+++ b/python/pounce/torch/_qp.py
@@ -1,0 +1,595 @@
+"""Differentiable convex-QP / SOCP layers (OptNet-style implicit
+differentiation), PyTorch frontend (pounce#109).
+
+PyTorch mirror of :mod:`pounce.jax._qp`. Solves, and differentiates
+through, the convex QP
+
+.. code-block:: text
+
+    minimize    ½ xᵀP x + cᵀx
+    subject to  G x ≤ h
+                A x = b
+
+The forward solve calls the ``pounce-convex`` interior-point solver
+directly (eager — no host callback needed). The backward pass uses the
+implicit-function theorem on the KKT system at the optimum (Amos &
+Kolter, *OptNet*, 2017): the same KKT matrix that defines the solution
+also yields its sensitivities, so a single ``torch.linalg.solve`` gives
+the cotangents.
+
+Differentiable parameters. Gradients are provided w.r.t. **all** the
+parameters that enter the QP linearly through the optimum: the vectors
+``c``, ``b``, ``h`` and the matrices ``P``, ``G``, ``A`` (full OptNet
+matrix derivatives). ``P`` is differentiated as a **symmetric** matrix.
+
+Bounds ``lb ≤ x ≤ ub`` are folded into ``G``/``h`` before differentiation
+(the folded rows are constants, so no gradient flows to ``lb``/``ub``).
+
+dtype. All inputs are coerced to float64.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import numpy as np
+import torch
+
+from .. import _pounce
+from ._build import _DT
+
+__all__ = ["solve_qp", "solve_qp_batch", "solve_socp", "QpLayer"]
+
+# Active-set tolerance kept for parity with the JAX layer (the backward
+# here reads the converged multipliers directly via the arrow/diag
+# scalings, so no explicit thresholding is needed).
+_ACTIVE_TOL = 1e-6
+
+
+def _t(a, shape=None) -> torch.Tensor:
+    out = torch.as_tensor(np.asarray(a, dtype=np.float64), dtype=_DT) \
+        if not isinstance(a, torch.Tensor) else a.to(_DT)
+    return out
+
+
+def _np(a) -> np.ndarray:
+    if isinstance(a, torch.Tensor):
+        return a.detach().cpu().numpy().astype(np.float64)
+    return np.asarray(a, dtype=np.float64)
+
+
+def _expand_bounds(G, h, lb, ub, n):
+    """Fold finite variable bounds into G/h as extra rows.
+
+    Returns ``(G_full, h_full)`` as dense tensors. ``x_i ≤ ub_i`` and
+    ``−x_i ≤ −lb_i``."""
+    rows = []
+    rhs = []
+    if G is not None and G.shape[0] > 0:
+        rows.append(G)
+        rhs.append(h)
+    if ub is not None:
+        ub_np = np.asarray(ub, dtype=np.float64)
+        for i in range(n):
+            if np.isfinite(float(ub_np[i])):
+                e = torch.zeros(n, dtype=_DT)
+                e[i] = 1.0
+                rows.append(e[None, :])
+                rhs.append(_t(ub_np[i]).reshape(1))
+    if lb is not None:
+        lb_np = np.asarray(lb, dtype=np.float64)
+        for i in range(n):
+            if np.isfinite(float(lb_np[i])):
+                e = torch.zeros(n, dtype=_DT)
+                e[i] = -1.0
+                rows.append(e[None, :])
+                rhs.append((-_t(lb_np[i])).reshape(1))
+    if not rows:
+        return torch.zeros((0, n), dtype=_DT), torch.zeros((0,), dtype=_DT)
+    return torch.cat(rows, dim=0), torch.cat(rhs, dim=0)
+
+
+def _to_coo_lower(M):
+    """COO ``(rows, cols, vals)`` of the lower triangle of dense ``M``."""
+    r, cc = np.nonzero(M)
+    keep = r >= cc
+    return r[keep].tolist(), cc[keep].tolist(), M[r[keep], cc[keep]].tolist()
+
+
+def _to_coo(M):
+    """COO ``(rows, cols, vals)`` of dense ``M``."""
+    r, cc = np.nonzero(M)
+    return r.tolist(), cc.tolist(), M[r, cc].tolist()
+
+
+def _build_problem(P, c, G, h, A, b):
+    """Assemble a ``_pounce.QpProblem`` from dense numpy arrays."""
+    n = c.shape[0]
+    pr, pc, pv = _to_coo_lower(np.asarray(P))
+    gr, gc, gv = _to_coo(np.asarray(G))
+    ar, ac, av = _to_coo(np.asarray(A))
+    return _pounce.QpProblem(
+        n=n,
+        c=np.asarray(c).tolist(),
+        p_rows=pr, p_cols=pc, p_vals=pv,
+        a_rows=ar, a_cols=ac, a_vals=av,
+        b=np.asarray(b).tolist(),
+        g_rows=gr, g_cols=gc, g_vals=gv,
+        h=np.asarray(h).tolist(),
+    )
+
+
+_SUCCESS_STATUS = "optimal"
+
+
+def _check_status(status, where):
+    """Raise unless the convex solver reached an optimal solution.
+
+    A non-optimal iterate is not a KKT point, so the implicit-function
+    gradient would be meaningless — fail loudly rather than feed silent
+    NaNs/garbage into a downstream optimizer."""
+    if status != _SUCCESS_STATUS:
+        raise RuntimeError(
+            f"{where}: convex solver returned status {status!r}, not "
+            f"{_SUCCESS_STATUS!r}; the differentiable layer cannot produce a "
+            f"meaningful gradient for a non-optimal solve."
+        )
+
+
+def _split_duals(d, m_g, m_a):
+    lam = (
+        np.asarray(d["z"], dtype=np.float64) if m_g
+        else np.zeros((0,), dtype=np.float64)
+    )
+    nu = (
+        np.asarray(d["y"], dtype=np.float64) if m_a
+        else np.zeros((0,), dtype=np.float64)
+    )
+    return lam, nu
+
+
+def _forward_solve(P, c, G, h, A, b, tol, max_iter, warm_x=None):
+    """Host-side forward solve via pounce-convex. Returns (x, lam, nu)."""
+    m_g = G.shape[0]
+    m_a = A.shape[0]
+    prob = _build_problem(P, c, G, h, A, b)
+    warm = None
+    if warm_x is not None and np.asarray(warm_x).size == c.shape[0]:
+        warm = {"x": np.asarray(warm_x, dtype=np.float64).tolist()}
+    d = _pounce.solve_qp(prob, tol=tol, max_iter=max_iter, warm_start=warm)
+    _check_status(d["status"], "QpLayer forward solve")
+    x = np.asarray(d["x"], dtype=np.float64)
+    lam, nu = _split_duals(d, m_g, m_a)
+    return x, lam, nu
+
+
+def _forward_solve_batch(P, cs, G, hs, A, bs, tol, max_iter, warm_xs=None):
+    """Parallel host-side batch solve. Shared ``P``/``G``/``A``; per-row
+    ``cs``/``hs``/``bs``. Returns stacked (xs, lams, nus)."""
+    m_g = G.shape[0]
+    m_a = A.shape[0]
+    b_sz = cs.shape[0]
+    n = cs.shape[1]
+    probs = [_build_problem(P, cs[i], G, hs[i], A, bs[i]) for i in range(b_sz)]
+    warms = None
+    if warm_xs is not None and np.asarray(warm_xs).shape == (b_sz, n):
+        wx = np.asarray(warm_xs, dtype=np.float64)
+        warms = [{"x": wx[i].tolist()} for i in range(b_sz)]
+    dicts = _pounce.solve_qp_batch(
+        probs, tol=tol, max_iter=max_iter, warm_starts=warms,
+    )
+    for i, d in enumerate(dicts):
+        _check_status(d["status"], f"QpLayer batch forward solve (row {i})")
+    xs = np.stack([np.asarray(d["x"], dtype=np.float64) for d in dicts])
+    if m_g:
+        lams = np.stack([np.asarray(d["z"], dtype=np.float64) for d in dicts])
+    else:
+        lams = np.zeros((b_sz, 0), dtype=np.float64)
+    if m_a:
+        nus = np.stack([np.asarray(d["y"], dtype=np.float64) for d in dicts])
+    else:
+        nus = np.zeros((b_sz, 0), dtype=np.float64)
+    return xs, lams, nus
+
+
+def _kkt_backward(P, G, A, h, x, lam, nu, gx):
+    """One OptNet implicit-diff backward (Amos & Kolter 2017, §3).
+
+    At the optimum ``(x, λ, ν)`` of ``min ½xᵀPx+cᵀx s.t. Gx≤h, Ax=b`` the
+    KKT differential system is
+
+    .. code-block:: text
+
+        [ P        Gᵀ        Aᵀ ] [d_x]     [ g_x ]
+        [ D(λ)G    D(Gx−h)   0  ] [d_λ] = − [  0  ]
+        [ A        0         0  ] [d_ν]     [  0  ]
+
+    Solving for ``(d_x, d_λ, d_ν)``, the loss gradients are
+
+    .. code-block:: text
+
+        ∇_c = d_x          ∇_P = ½(d_x xᵀ + x d_xᵀ)
+        ∇_b = −d_ν         ∇_A = d_ν xᵀ + ν d_xᵀ
+        ∇_h = −d_λ         ∇_G = d_λ xᵀ + λ d_xᵀ
+    """
+    n = x.shape[0]
+    m_g = G.shape[0]
+    m_a = A.shape[0]
+
+    slack = G @ x - h
+    dlam_scale = torch.diag(lam)
+    zero_ga = torch.zeros((m_g, m_a), dtype=_DT)
+    zero_ag = torch.zeros((m_a, m_g), dtype=_DT)
+    zero_aa = torch.zeros((m_a, m_a), dtype=_DT)
+
+    top = torch.cat([P, G.T, A.T], dim=1)
+    mid = torch.cat([dlam_scale @ G, torch.diag(slack), zero_ga], dim=1)
+    bot = torch.cat([A, zero_ag, zero_aa], dim=1)
+    kkt = torch.cat([top, mid, bot], dim=0)
+
+    rhs = -torch.cat([gx, torch.zeros(m_g, dtype=_DT), torch.zeros(m_a, dtype=_DT)])
+    d = torch.linalg.solve(kkt, rhs)
+    d_x = d[:n]
+    d_lam = d[n : n + m_g]
+    d_nu = d[n + m_g :]
+
+    grad_c = d_x
+    grad_h = -d_lam
+    grad_b = -d_nu
+    grad_P = 0.5 * (torch.outer(d_x, x) + torch.outer(x, d_x))
+    grad_G = torch.outer(d_lam, x) + torch.outer(lam, d_x)
+    grad_A = torch.outer(d_nu, x) + torch.outer(nu, d_x)
+    return grad_P, grad_c, grad_G, grad_h, grad_A, grad_b
+
+
+def _make_qp_fn(n, m_g, m_a, tol, max_iter):
+    class _QpFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, P, c, G, h, A, b, warm_x):
+            x, lam, nu = _forward_solve(
+                _np(P), _np(c), _np(G), _np(h), _np(A), _np(b),
+                tol, max_iter, warm_x=_np(warm_x),
+            )
+            x_t = torch.as_tensor(x, dtype=_DT)
+            lam_t = torch.as_tensor(lam, dtype=_DT)
+            nu_t = torch.as_tensor(nu, dtype=_DT)
+            ctx.save_for_backward(P, G, A, h, x_t, lam_t, nu_t, warm_x)
+            return x_t
+
+        @staticmethod
+        def backward(ctx, gx):
+            P, G, A, h, x, lam, nu, warm_x = ctx.saved_tensors
+            gP, gc, gG, gh, gA, gb = _kkt_backward(P, G, A, h, x, lam, nu, gx)
+            return gP, gc, gG, gh, gA, gb, None
+
+    return _QpFn
+
+
+def _make_qp_batch_fn(n, m_g, m_a, tol, max_iter):
+    class _QpBatchFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, P, cs, G, hs, A, bs, warm_xs):
+            xs, lams, nus = _forward_solve_batch(
+                _np(P), _np(cs), _np(G), _np(hs), _np(A), _np(bs),
+                tol, max_iter, warm_xs=_np(warm_xs),
+            )
+            xs_t = torch.as_tensor(xs, dtype=_DT)
+            lams_t = torch.as_tensor(lams, dtype=_DT)
+            nus_t = torch.as_tensor(nus, dtype=_DT)
+            ctx.save_for_backward(P, G, A, hs, xs_t, lams_t, nus_t, warm_xs)
+            return xs_t
+
+        @staticmethod
+        def backward(ctx, gxs):
+            P, G, A, hs, xs, lams, nus, warm_xs = ctx.saved_tensors
+            B = xs.shape[0]
+            gPs, gcs, gGs, ghs, gAs, gbs = [], [], [], [], [], []
+            for i in range(B):
+                gP, gc, gG, gh, gA, gb = _kkt_backward(
+                    P, G, A, hs[i], xs[i], lams[i], nus[i], gxs[i],
+                )
+                gPs.append(gP); gcs.append(gc); gGs.append(gG)
+                ghs.append(gh); gAs.append(gA); gbs.append(gb)
+            # Shared matrices: sum cotangents over the batch. RHS stays
+            # per-row. Warm start is not differentiated.
+            return (
+                torch.stack(gPs).sum(dim=0),
+                torch.stack(gcs),
+                torch.stack(gGs).sum(dim=0),
+                torch.stack(ghs),
+                torch.stack(gAs).sum(dim=0),
+                torch.stack(gbs),
+                None,
+            )
+
+    return _QpBatchFn
+
+
+def _warm_primal(warm_start, n):
+    """Extract a warm-start primal ``x`` (length ``n``), returning an empty
+    tensor (cold start) when absent."""
+    if warm_start is None:
+        return torch.zeros((0,), dtype=_DT)
+    wx = getattr(warm_start, "x", None)
+    if wx is None:
+        wx = warm_start.get("x") if hasattr(warm_start, "get") else warm_start
+    if wx is None:
+        return torch.zeros((0,), dtype=_DT)
+    wx = _t(wx).reshape(-1)
+    return wx if wx.shape[0] == n else torch.zeros((0,), dtype=_DT)
+
+
+def solve_qp(
+    *,
+    P, c, G=None, h=None, A=None, b=None, lb=None, ub=None,
+    tol: Optional[float] = None,
+    max_iter: Optional[int] = None,
+    warm_start=None,
+):
+    """Differentiable convex-QP solve ``x*(P, c, G, h, A, b)``.
+
+    Solves ``min ½xᵀPx+cᵀx s.t. Gx≤h, Ax=b, lb≤x≤ub`` and is
+    differentiable w.r.t. ``P``, ``c``, ``G``, ``h``, ``A``, ``b`` via the
+    OptNet implicit-function rule (``∇P`` is the symmetric gradient).
+
+    Bounds are folded into the inequality block as constant rows (no
+    gradient flows to ``lb``/``ub``). ``warm_start`` supplies a previous
+    primal ``x`` to seed the iteration; it is not differentiated and only
+    reduces the iteration count.
+    """
+    P = _t(P)
+    c = _t(c)
+    n = c.shape[0]
+    G0 = torch.zeros((0, n), dtype=_DT) if G is None else _t(G)
+    h0 = torch.zeros((0,), dtype=_DT) if h is None else _t(h)
+    A0 = torch.zeros((0, n), dtype=_DT) if A is None else _t(A)
+    b0 = torch.zeros((0,), dtype=_DT) if b is None else _t(b)
+
+    G_full, h_full = _expand_bounds(G0, h0, lb, ub, n)
+    warm_x = _warm_primal(warm_start, n)
+
+    fn = _make_qp_fn(n, G_full.shape[0], A0.shape[0], tol, max_iter)
+    return fn.apply(P, c, G_full, h_full, A0, b0, warm_x)
+
+
+def _warm_primal_batch(warm_start, b_sz, n):
+    """Extract a ``(B, n)`` warm-start primal, returning an empty
+    ``(B, 0)`` tensor (cold) when absent or mismatched."""
+    if warm_start is None:
+        return torch.zeros((b_sz, 0), dtype=_DT)
+    arr = warm_start
+    if isinstance(warm_start, (list, tuple)):
+        rows = []
+        for w in warm_start:
+            wx = getattr(w, "x", None)
+            if wx is None:
+                wx = w.get("x") if hasattr(w, "get") else w
+            rows.append(_t(wx).reshape(-1))
+        arr = torch.stack(rows) if rows else torch.zeros((b_sz, 0), dtype=_DT)
+    arr = _t(arr)
+    return arr if tuple(arr.shape) == (b_sz, n) else torch.zeros((b_sz, 0), dtype=_DT)
+
+
+def solve_qp_batch(
+    *,
+    P, c, G=None, h=None, A=None, b=None, lb=None, ub=None,
+    tol: Optional[float] = None,
+    max_iter: Optional[int] = None,
+    warm_start=None,
+):
+    """Differentiable **parallel** batch of convex QPs sharing structure.
+
+    ``c`` is required and batched with shape ``(B, n)``. The matrices
+    ``P``, ``G``, ``A`` are shared across the batch. The RHS vectors ``h``
+    and ``b`` may be batched (``(B, ·)``) or shared. Returns ``xs`` of
+    shape ``(B, n)``. Gradients to the shared matrices sum over the batch;
+    gradients to ``c``/``h``/``b`` stay per-row. ``∇P`` is symmetric.
+    """
+    P = _t(P)
+    cs = _t(c)
+    if cs.ndim != 2:
+        raise ValueError(f"solve_qp_batch: `c` must be 2-D (B, n), got {tuple(cs.shape)}")
+    b_sz, n = cs.shape
+
+    G0 = torch.zeros((0, n), dtype=_DT) if G is None else _t(G)
+    A0 = torch.zeros((0, n), dtype=_DT) if A is None else _t(A)
+
+    G_full, h_bounds = _expand_bounds(G0, torch.zeros((G0.shape[0],), dtype=_DT), lb, ub, n)
+    m_g = G_full.shape[0]
+    n_user_rows = G0.shape[0]
+    bound_rows = m_g - n_user_rows
+
+    if h is None:
+        hs_user = torch.zeros((b_sz, n_user_rows), dtype=_DT)
+    else:
+        h_arr = _t(h)
+        hs_user = h_arr.expand(b_sz, n_user_rows) if h_arr.ndim == 1 else h_arr
+    hs_bounds = h_bounds[n_user_rows:].expand(b_sz, bound_rows)
+    hs = torch.cat([hs_user, hs_bounds], dim=1)
+
+    m_a = A0.shape[0]
+    if b is None:
+        bs = torch.zeros((b_sz, m_a), dtype=_DT)
+    else:
+        b_arr = _t(b)
+        bs = b_arr.expand(b_sz, m_a) if b_arr.ndim == 1 else b_arr
+
+    warm_xs = _warm_primal_batch(warm_start, b_sz, n)
+    fn = _make_qp_batch_fn(n, m_g, m_a, tol, max_iter)
+    return fn.apply(P, cs, G_full, hs, A0, bs, warm_xs)
+
+
+class QpLayer:
+    """A reusable differentiable QP layer with fixed structure.
+
+    Captures ``P, G, A`` (and bounds) once; calling the layer with
+    ``c``/``b``/``h`` solves and is differentiable w.r.t. those (and, via
+    :func:`solve_qp`, the captured matrices too). Suitable for use inside
+    a ``torch.nn`` model.
+    """
+
+    def __init__(self, P, G=None, A=None, lb=None, ub=None, *, tol=None, max_iter=None):
+        self._P = P
+        self._G = G
+        self._A = A
+        self._lb = lb
+        self._ub = ub
+        self._tol = tol
+        self._max_iter = max_iter
+
+    def __call__(self, c, *, b=None, h=None, warm_start=None):
+        return solve_qp(
+            P=self._P, c=c, G=self._G, h=h, A=self._A, b=b,
+            lb=self._lb, ub=self._ub, tol=self._tol, max_iter=self._max_iter,
+            warm_start=warm_start,
+        )
+
+    def batch(self, cs, *, b=None, h=None, warm_start=None):
+        """Solve a parallel batch sharing this layer's structure."""
+        return solve_qp_batch(
+            P=self._P, c=cs, G=self._G, h=h, A=self._A, b=b,
+            lb=self._lb, ub=self._ub, tol=self._tol, max_iter=self._max_iter,
+            warm_start=warm_start,
+        )
+
+
+# --- Differentiable SOCP (cone-aware OptNet implicit differentiation) ----
+#
+# Generalizes the QP backward to a product of nonnegative-orthant and
+# second-order cones. The only change in the KKT differential is the
+# complementarity row: the orthant's diagonal scalings become the cone's
+# **arrow operators** Arw(z), Arw(slack) (block-diagonal; an orthant block
+# stays diagonal). The forward solve calls the cone-capable
+# ``_pounce.solve_socp``.
+
+
+def _normalize_socp_cones(cones):
+    """Coerce cone specs into ``((is_soc, dim), …)`` (static) and the
+    ``[(kind, dim), …]`` form the binding wants. Ints are second-order."""
+    static = []
+    specs = []
+    for spec in cones:
+        if isinstance(spec, (tuple, list)) and len(spec) == 2:
+            kind, d = str(spec[0]).lower(), int(spec[1])
+        elif isinstance(spec, int):
+            kind, d = "soc", int(spec)
+        else:
+            raise ValueError(f"bad cone spec {spec!r}")
+        is_soc = kind in ("soc", "q", "secondorder")
+        static.append((is_soc, d))
+        specs.append(("soc" if is_soc else "nonneg", d))
+    return tuple(static), specs
+
+
+def _arrow(v):
+    """Arrow matrix ``Arw(v) = [[v₀, v₁ᵀ], [v₁, v₀ I]]`` of a cone block."""
+    m = v.shape[0]
+    if m == 1:
+        return v.reshape(1, 1)
+    v0, v1 = v[0], v[1:]
+    top = torch.cat([v0.reshape(1, 1), v1.reshape(1, -1)], dim=1)
+    bot = torch.cat([v1.reshape(-1, 1), v0 * torch.eye(m - 1, dtype=_DT)], dim=1)
+    return torch.cat([top, bot], dim=0)
+
+
+def _block_diag(blocks):
+    if not blocks:
+        return torch.zeros((0, 0), dtype=_DT)
+    return torch.block_diag(*blocks)
+
+
+def _scaling_blockdiag(v, cones):
+    """Block-diagonal cone scaling: ``Arw(v_block)`` for a second-order
+    block, ``diag(v_block)`` for an orthant block."""
+    blocks = []
+    off = 0
+    for is_soc, d in cones:
+        vb = v[off : off + d]
+        blocks.append(_arrow(vb) if is_soc else torch.diag(vb))
+        off += d
+    return _block_diag(blocks)
+
+
+def _socp_backward(P, G, A, h, x, lam, nu, gx, cones):
+    """Cone-aware OptNet backward (cf. :func:`_kkt_backward`). The
+    complementarity row uses the arrow operators of the cones."""
+    n = x.shape[0]
+    m_g = G.shape[0]
+    m_a = A.shape[0]
+    slack = G @ x - h
+    arw_z = _scaling_blockdiag(lam, cones)
+    arw_slack = _scaling_blockdiag(slack, cones)
+    zero_ga = torch.zeros((m_g, m_a), dtype=_DT)
+    zero_ag = torch.zeros((m_a, m_g), dtype=_DT)
+    zero_aa = torch.zeros((m_a, m_a), dtype=_DT)
+    top = torch.cat([P, G.T, A.T], dim=1)
+    mid = torch.cat([arw_z @ G, arw_slack, zero_ga], dim=1)
+    bot = torch.cat([A, zero_ag, zero_aa], dim=1)
+    kkt = torch.cat([top, mid, bot], dim=0)
+    rhs = -torch.cat([gx, torch.zeros(m_g, dtype=_DT), torch.zeros(m_a, dtype=_DT)])
+    d = torch.linalg.solve(kkt, rhs)
+    d_x = d[:n]
+    d_lam = d[n : n + m_g]
+    d_nu = d[n + m_g :]
+    grad_c = d_x
+    grad_h = -d_lam
+    grad_b = -d_nu
+    grad_P = 0.5 * (torch.outer(d_x, x) + torch.outer(x, d_x))
+    grad_G = torch.outer(d_lam, x) + torch.outer(lam, d_x)
+    grad_A = torch.outer(d_nu, x) + torch.outer(nu, d_x)
+    return grad_P, grad_c, grad_G, grad_h, grad_A, grad_b
+
+
+def _forward_solve_socp(P, c, G, h, A, b, specs, tol, max_iter):
+    """Host-side SOCP forward via pounce-convex. Returns (x, lam, nu)."""
+    m_g = G.shape[0]
+    m_a = A.shape[0]
+    prob = _build_problem(P, c, G, h, A, b)
+    d = _pounce.solve_socp(prob, specs, tol=tol, max_iter=max_iter)
+    _check_status(d["status"], "SOCP differentiable forward solve")
+    x = np.asarray(d["x"], dtype=np.float64)
+    lam, nu = _split_duals(d, m_g, m_a)
+    return x, lam, nu
+
+
+def _make_socp_fn(n, m_g, m_a, cones, specs, tol, max_iter):
+    class _SocpFn(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, P, c, G, h, A, b):
+            x, lam, nu = _forward_solve_socp(
+                _np(P), _np(c), _np(G), _np(h), _np(A), _np(b),
+                specs, tol, max_iter,
+            )
+            x_t = torch.as_tensor(x, dtype=_DT)
+            lam_t = torch.as_tensor(lam, dtype=_DT)
+            nu_t = torch.as_tensor(nu, dtype=_DT)
+            ctx.save_for_backward(P, G, A, h, x_t, lam_t, nu_t)
+            return x_t
+
+        @staticmethod
+        def backward(ctx, gx):
+            P, G, A, h, x, lam, nu = ctx.saved_tensors
+            return _socp_backward(P, G, A, h, x, lam, nu, gx, cones)
+
+    return _SocpFn
+
+
+def solve_socp(*, P, c, G, h, A=None, b=None, cones, tol=None, max_iter=None):
+    """Differentiable convex-SOCP solve over a product of cones.
+
+    Solves ``min ½xᵀPx+cᵀx s.t. Gx ⪯_K h, Ax=b`` where the inequality
+    block is partitioned by ``cones`` — a sequence of ``(kind, dim)``
+    specs (``"nonneg"``/``"soc"``; an int means a second-order cone).
+    Differentiable w.r.t. ``P, c, G, h, A, b`` via cone-aware OptNet
+    implicit differentiation (``diag`` → the cones' arrow operators).
+    """
+    P = _t(P)
+    c = _t(c)
+    n = c.shape[0]
+    G = _t(G)
+    h = _t(h)
+    A0 = torch.zeros((0, n), dtype=_DT) if A is None else _t(A)
+    b0 = torch.zeros((0,), dtype=_DT) if b is None else _t(b)
+    static, specs = _normalize_socp_cones(cones)
+    fn = _make_socp_fn(n, G.shape[0], A0.shape[0], static, specs, tol, max_iter)
+    return fn.apply(P, c, G, h, A0, b0)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -40,12 +40,16 @@ pounce-dbg-viz = "pounce._debug_viz:main"
 
 [project.optional-dependencies]
 jax = ["jax>=0.4.30", "jaxlib>=0.4.30"]
+# torch.func (functorch, merged into core) requires torch >= 2.0; pin
+# >= 2.2 for a stable torch.func surface (pounce#109). CPU wheels are
+# sufficient — pounce solves on the host.
+torch = ["torch>=2.2"]
 scipy = ["scipy>=1.11"]
 # diffrax is only needed to run the inverse-map ODE example/recipe
 # (pounce#91); the inverse_map_rhs helper itself depends only on jax.
 diffrax = ["diffrax>=0.5"]
 viz = ["plotly>=5"]
-dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30", "plotly>=5"]
+dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30", "torch>=2.2", "plotly>=5"]
 
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"

--- a/python/tests/test_parity_jax_torch.py
+++ b/python/tests/test_parity_jax_torch.py
@@ -1,0 +1,146 @@
+"""JAX ↔ Torch parity (pounce#109).
+
+The same numerical core (Rust IPM) under two autodiff frontends must
+produce the same ``x*`` and the same ``dL/dp`` on shared fixtures. This is
+the headline "one numerical backbone under any autodiff frontend" claim.
+Skipped unless *both* JAX and PyTorch are installed.
+"""
+
+import numpy as np
+import pytest
+
+jax = pytest.importorskip("jax")
+torch = pytest.importorskip("torch")
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp  # noqa: E402
+
+torch.set_default_dtype(torch.float64)
+
+
+def test_parity_unconstrained_solve_and_grad():
+    """min ||x - p||² + 0.1||x||⁴ : x* and dL/dp agree across frontends."""
+    from pounce.jax import solve as jsolve
+    from pounce.torch import solve as tsolve
+
+    def fj(x, p):
+        return jnp.sum((x - p) ** 2) + 0.1 * jnp.sum(x ** 4)
+
+    def ft(x, p):
+        return torch.sum((x - p) ** 2) + 0.1 * torch.sum(x ** 4)
+
+    p_np = np.array([0.5, -1.0, 2.0, 0.3])
+    opts = {"tol": 1e-11, "print_level": 0, "sb": "yes"}
+
+    xj = np.asarray(jsolve(jnp.asarray(p_np), f=fj, g=None, x0=jnp.zeros(4),
+                           n=4, m=0, options=opts))
+    xt = tsolve(torch.tensor(p_np), f=ft, g=None, x0=torch.zeros(4),
+                n=4, m=0, options=opts).detach().numpy()
+    np.testing.assert_allclose(xj, xt, atol=1e-8)
+
+    gj = np.asarray(jax.grad(
+        lambda p: jnp.sum(jsolve(p, f=fj, g=None, x0=jnp.zeros(4), n=4, m=0,
+                                 options=opts) ** 2)
+    )(jnp.asarray(p_np)))
+
+    pt_ = torch.tensor(p_np, requires_grad=True)
+    (tsolve(pt_, f=ft, g=None, x0=torch.zeros(4), n=4, m=0, options=opts) ** 2).sum().backward()
+    np.testing.assert_allclose(gj, pt_.grad.numpy(), atol=1e-6)
+
+
+def test_parity_constrained_solve_and_grad():
+    """Equality + slack inequality + active bound: full active-set logic."""
+    from pounce.jax import solve as jsolve
+    from pounce.torch import solve as tsolve
+
+    def fj(x, p):
+        return jnp.sum((x - p) ** 2) + 0.1 * jnp.sum(x ** 4)
+
+    def gj(x, p):  # noqa: ARG001
+        return jnp.stack([x[0] + x[1] + x[2] - 1.0, x[2]])
+
+    def ft(x, p):
+        return torch.sum((x - p) ** 2) + 0.1 * torch.sum(x ** 4)
+
+    def gt(x, p):  # noqa: ARG001
+        return torch.stack([x[0] + x[1] + x[2] - 1.0, x[2]])
+
+    p_np = np.array([-0.2, 0.5, 0.4])
+    common = dict(
+        n=3, m=2,
+        lb=np.array([0.4, -10.0, -10.0]), ub=np.array([10.0, 10.0, 10.0]),
+        cl=np.array([0.0, -1e20]), cu=np.array([0.0, 1e20]),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+
+    xj = np.asarray(jsolve(
+        jnp.asarray(p_np), f=fj, g=gj, x0=jnp.ones(3),
+        lb=jnp.asarray(common["lb"]), ub=jnp.asarray(common["ub"]),
+        cl=jnp.asarray(common["cl"]), cu=jnp.asarray(common["cu"]),
+        n=3, m=2, options=common["options"],
+    ))
+    xt = tsolve(
+        torch.tensor(p_np), f=ft, g=gt, x0=torch.ones(3),
+        lb=torch.tensor(common["lb"]), ub=torch.tensor(common["ub"]),
+        cl=torch.tensor(common["cl"]), cu=torch.tensor(common["cu"]),
+        n=3, m=2, options=common["options"],
+    ).detach().numpy()
+    np.testing.assert_allclose(xj, xt, atol=1e-7)
+
+    gj_grad = np.asarray(jax.grad(
+        lambda p: jnp.sum(jsolve(
+            p, f=fj, g=gj, x0=jnp.ones(3),
+            lb=jnp.asarray(common["lb"]), ub=jnp.asarray(common["ub"]),
+            cl=jnp.asarray(common["cl"]), cu=jnp.asarray(common["cu"]),
+            n=3, m=2, options=common["options"],
+        ) ** 2)
+    )(jnp.asarray(p_np)))
+
+    pt_ = torch.tensor(p_np, requires_grad=True)
+    (tsolve(
+        pt_, f=ft, g=gt, x0=torch.ones(3),
+        lb=torch.tensor(common["lb"]), ub=torch.tensor(common["ub"]),
+        cl=torch.tensor(common["cl"]), cu=torch.tensor(common["cu"]),
+        n=3, m=2, options=common["options"],
+    ) ** 2).sum().backward()
+    np.testing.assert_allclose(gj_grad, pt_.grad.numpy(), atol=1e-6)
+
+
+def test_parity_qp_grad():
+    """OptNet QP gradient w.r.t. c agrees across frontends."""
+    from pounce.jax import solve_qp as jqp
+    from pounce.torch import solve_qp as tqp
+
+    P = np.array([[2.0, 0.0], [0.0, 2.0]])
+    G = np.array([[1.0, 1.0], [-1.0, 0.0], [0.0, -1.0]])
+    h = np.array([10.0, 0.0, 0.0])
+    c_np = np.array([-0.5, -0.7])
+
+    gj = np.asarray(jax.grad(
+        lambda c: jnp.sum(jqp(P=jnp.asarray(P), c=c, G=jnp.asarray(G),
+                              h=jnp.asarray(h)) ** 2)
+    )(jnp.asarray(c_np)))
+
+    ct = torch.tensor(c_np, requires_grad=True)
+    (tqp(P=torch.tensor(P), c=ct, G=torch.tensor(G), h=torch.tensor(h)) ** 2).sum().backward()
+    np.testing.assert_allclose(gj, ct.grad.numpy(), atol=1e-6)
+
+
+def test_parity_socp_grad():
+    """Cone-aware OptNet SOCP gradient agrees across frontends."""
+    from pounce.jax import solve_socp as jsocp
+    from pounce.torch import solve_socp as tsocp
+
+    P = np.eye(3)
+    G = -np.eye(3)
+    h = np.zeros(3)
+    c_np = np.array([-1.0, -2.0, 0.3])
+
+    gj = np.asarray(jax.grad(
+        lambda c: jnp.sum(jsocp(P=jnp.asarray(P), c=c, G=jnp.asarray(G),
+                                h=jnp.asarray(h), cones=[("soc", 3)]) ** 2)
+    )(jnp.asarray(c_np)))
+
+    ct = torch.tensor(c_np, requires_grad=True)
+    (tsocp(P=torch.tensor(P), c=ct, G=torch.tensor(G), h=torch.tensor(h),
+           cones=[("soc", 3)]) ** 2).sum().backward()
+    np.testing.assert_allclose(gj, ct.grad.numpy(), atol=1e-6)

--- a/python/tests/test_qp_torch.py
+++ b/python/tests/test_qp_torch.py
@@ -1,0 +1,137 @@
+"""Differentiable convex-QP layer (pounce.torch.solve_qp / QpLayer).
+
+Validates the OptNet implicit-differentiation backward against finite
+differences and torch.autograd.gradcheck, and checks the batch path and
+QpLayer compose."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+torch.set_default_dtype(torch.float64)
+
+from pounce.torch import QpLayer, solve_qp, solve_qp_batch  # noqa: E402
+
+
+def _fd(fn, x, eps=1e-6):
+    x = np.asarray(x, float)
+    g = np.zeros_like(x)
+    for i in range(len(x)):
+        xp = x.copy(); xp[i] += eps
+        xm = x.copy(); xm[i] -= eps
+        g[i] = (float(fn(torch.tensor(xp))) - float(fn(torch.tensor(xm)))) / (2 * eps)
+    return g
+
+
+P = torch.tensor([[2.0, 0.0], [0.0, 2.0]])
+
+
+def test_grad_c_interior():
+    G = torch.tensor([[1.0, 1.0], [-1.0, 0.0], [0.0, -1.0]])
+    h = torch.tensor([10.0, 0.0, 0.0])
+    target = torch.tensor([0.3, 0.4])
+
+    def loss(c):
+        return torch.sum((solve_qp(P=P, c=c, G=G, h=h) - target) ** 2)
+
+    c0 = torch.tensor([-0.5, -0.7], requires_grad=True)
+    loss(c0).backward()
+    np.testing.assert_allclose(c0.grad.numpy(), _fd(loss, c0.detach()), atol=1e-4)
+
+
+def test_grad_h_active_inequality():
+    G = torch.tensor([[1.0, 1.0]])
+    c0 = torch.tensor([-4.0, -4.0])
+
+    def loss(h):
+        return torch.sum(solve_qp(P=P, c=c0, G=G, h=h) ** 2)
+
+    h0 = torch.tensor([1.0], requires_grad=True)
+    loss(h0).backward()
+    np.testing.assert_allclose(h0.grad.numpy(), _fd(loss, h0.detach()), atol=1e-4)
+
+
+def test_grad_c_and_b_equality():
+    A = torch.tensor([[1.0, 1.0]])
+
+    def loss_c(c):
+        return torch.sum(solve_qp(P=P, c=c, A=A, b=torch.tensor([2.0])) ** 2)
+
+    def loss_b(b):
+        return torch.sum(solve_qp(P=P, c=torch.tensor([-1.0, -3.0]), A=A, b=b) ** 2)
+
+    c0 = torch.tensor([-1.0, -3.0], requires_grad=True)
+    loss_c(c0).backward()
+    np.testing.assert_allclose(c0.grad.numpy(), _fd(loss_c, c0.detach()), atol=1e-4)
+
+    b0 = torch.tensor([2.0], requires_grad=True)
+    loss_b(b0).backward()
+    np.testing.assert_allclose(b0.grad.numpy(), _fd(loss_b, b0.detach()), atol=1e-4)
+
+
+def test_grad_matrices_P_G():
+    """Full OptNet matrix derivatives (∇P symmetric, ∇G) vs FD."""
+    G = torch.tensor([[1.0, 1.0]])
+    h = torch.tensor([0.5])
+    c0 = torch.tensor([-4.0, -4.0])
+
+    def loss_G(Gv):
+        return torch.sum(solve_qp(P=P, c=c0, G=Gv, h=h) ** 2)
+
+    G0 = torch.tensor([[1.0, 1.0]], requires_grad=True)
+    loss_G(G0).backward()
+    # FD over the (1,2) matrix.
+    g_fd = np.zeros((1, 2))
+    for j in range(2):
+        mp = G.clone(); mp[0, j] += 1e-6
+        mm = G.clone(); mm[0, j] -= 1e-6
+        g_fd[0, j] = (float(loss_G(mp)) - float(loss_G(mm))) / 2e-6
+    np.testing.assert_allclose(G0.grad.numpy(), g_fd, atol=1e-4)
+
+
+def test_gradcheck_qp():
+    """torch.autograd.gradcheck on solve_qp w.r.t. c (float64)."""
+    G = torch.tensor([[1.0, 1.0], [-1.0, 0.0], [0.0, -1.0]])
+    h = torch.tensor([10.0, 0.0, 0.0])
+
+    def fn(c):
+        return solve_qp(P=P, c=c, G=G, h=h)
+
+    c0 = torch.tensor([-0.5, -0.7], requires_grad=True)
+    assert torch.autograd.gradcheck(fn, (c0,), atol=1e-4, rtol=1e-3, eps=1e-6)
+
+
+def test_batch_matches_loop():
+    G = torch.tensor([[1.0, 1.0]])
+    h = torch.tensor([0.5])
+    cs = torch.tensor([[-4.0, -4.0], [-1.0, -2.0], [0.5, -0.5]])
+
+    xs = solve_qp_batch(P=P, c=cs, G=G, h=h)
+    for i in range(cs.shape[0]):
+        xi = solve_qp(P=P, c=cs[i], G=G, h=h)
+        np.testing.assert_allclose(xs[i].detach().numpy(), xi.detach().numpy(), atol=1e-7)
+
+
+def test_batch_grad_per_row_c():
+    G = torch.tensor([[1.0, 1.0]])
+    h = torch.tensor([0.5])
+    cs = torch.tensor([[-4.0, -4.0], [-1.0, -2.0]], requires_grad=True)
+    (solve_qp_batch(P=P, c=cs, G=G, h=h) ** 2).sum().backward()
+    assert cs.grad.shape == (2, 2)
+    assert torch.all(torch.isfinite(cs.grad))
+
+
+def test_qp_layer():
+    G = torch.tensor([[1.0, 1.0]])
+    layer = QpLayer(P=P, G=G)
+    c = torch.tensor([-4.0, -4.0], requires_grad=True)
+    x = layer(c, h=torch.tensor([0.5]))
+    (x ** 2).sum().backward()
+    assert torch.all(torch.isfinite(c.grad))
+
+
+def test_qp_bounds_folded():
+    """lb/ub folded into G/h; the solution respects them."""
+    c = torch.tensor([-5.0, -5.0])
+    x = solve_qp(P=P, c=c, lb=torch.tensor([-1.0, -1.0]), ub=torch.tensor([1.0, 1.0]))
+    np.testing.assert_allclose(x.detach().numpy(), [1.0, 1.0], atol=1e-6)

--- a/python/tests/test_socp_torch.py
+++ b/python/tests/test_socp_torch.py
@@ -1,0 +1,84 @@
+"""Differentiable SOCP layer (pounce.torch.solve_socp).
+
+Validates the cone-aware OptNet backward (arrow operators in the
+complementarity row) against finite differences for second-order and
+mixed orthant+SOC cones."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+torch.set_default_dtype(torch.float64)
+
+from pounce.torch import solve_socp  # noqa: E402
+
+
+def _fd(fn, x, eps=1e-6):
+    x = np.asarray(x, float)
+    g = np.zeros_like(x)
+    for i in range(len(x)):
+        xp = x.copy(); xp[i] += eps
+        xm = x.copy(); xm[i] -= eps
+        g[i] = (float(fn(torch.tensor(xp))) - float(fn(torch.tensor(xm)))) / (2 * eps)
+    return g
+
+
+P3 = torch.eye(3)
+G3 = -torch.eye(3)
+H3 = torch.zeros(3)
+
+
+def test_grad_c_soc_projection():
+    def loss(c):
+        return torch.sum(solve_socp(P=P3, c=c, G=G3, h=H3, cones=[("soc", 3)]) ** 2)
+
+    c0 = torch.tensor([-1.0, -2.0, 0.3], requires_grad=True)
+    loss(c0).backward()
+    np.testing.assert_allclose(c0.grad.numpy(), _fd(loss, c0.detach()), atol=1e-4)
+
+
+def test_grad_h_soc():
+    c0 = torch.tensor([-1.0, -2.0, 0.3])
+
+    def loss(h):
+        return torch.sum(solve_socp(P=P3, c=c0, G=G3, h=h, cones=[3]) ** 2)
+
+    h0 = torch.tensor([0.5, 0.0, 0.0], requires_grad=True)
+    loss(h0).backward()
+    np.testing.assert_allclose(h0.grad.numpy(), _fd(loss, h0.detach()), atol=1e-4)
+
+
+def test_grad_c_and_b_soc_with_equality():
+    A = torch.tensor([[1.0, 0.0, 0.0]])
+
+    def loss_c(c):
+        return torch.sum(
+            solve_socp(P=P3, c=c, G=G3, h=H3, A=A, b=torch.tensor([0.5]), cones=[3]) ** 2
+        )
+
+    def loss_b(b):
+        c0 = torch.tensor([0.0, -1.0, 0.0])
+        return torch.sum(solve_socp(P=P3, c=c0, G=G3, h=H3, A=A, b=b, cones=[3]) ** 2)
+
+    c0 = torch.tensor([0.0, -1.0, 0.0], requires_grad=True)
+    loss_c(c0).backward()
+    np.testing.assert_allclose(c0.grad.numpy(), _fd(loss_c, c0.detach()), atol=1e-4)
+
+    b0 = torch.tensor([0.5], requires_grad=True)
+    loss_b(b0).backward()
+    np.testing.assert_allclose(b0.grad.numpy(), _fd(loss_b, b0.detach()), atol=1e-4)
+
+
+def test_grad_mixed_orthant_and_soc():
+    G = torch.tensor([[1.0, 0.0], [0.0, 0.0], [0.0, -1.0]])
+    h = torch.tensor([1.0, 1.0, 0.0])
+
+    def loss(c):
+        return torch.sum(
+            solve_socp(P=torch.eye(2), c=c, G=G, h=h,
+                       cones=[("nonneg", 1), ("soc", 2)]) ** 2
+        )
+
+    c0 = torch.tensor([-0.5, -0.5], requires_grad=True)
+    loss(c0).backward()
+    np.testing.assert_allclose(c0.grad.numpy(), _fd(loss, c0.detach()), atol=1e-4)

--- a/python/tests/test_torch.py
+++ b/python/tests/test_torch.py
@@ -358,6 +358,94 @@ def test_torch_problem_grad_pounce_75():
     np.testing.assert_allclose(J.numpy(), np.eye(n), atol=5e-6)
 
 
+def _warm_problem():
+    """min ½‖x−p‖² s.t. Σx = 1, −10 ≤ x ≤ 10 — x*(p) projects p onto the
+    simplex hyperplane, so ∂x*/∂p = I − 11ᵀ/n and the equality multiplier
+    is λ = (Σp − 1)/n."""
+    n, m = 3, 1
+
+    def f(x, p):
+        d = x - p
+        return 0.5 * torch.dot(d, d)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([torch.sum(x) - 1.0])
+
+    from pounce.torch import TorchProblem
+
+    tp = TorchProblem(
+        f=f, g=g, n=n, m=m, p_example=torch.zeros(n),
+        lb=torch.full((n,), -10.0), ub=torch.full((n,), 10.0),
+        cl=torch.tensor([0.0]), cu=torch.tensor([0.0]),
+        options={"tol": 1e-10, "print_level": 0},
+    )
+    return tp, n, m
+
+
+def test_torch_problem_warm_single_solve_and_grad():
+    """`TorchProblem.solve_with_warm` / `batched_solve_with_warm` must run
+    the IPM exactly once per call (no redundant dual-recovery solve) and
+    stay correctly differentiable w.r.t. p (duals threaded out, not
+    differentiated)."""
+    tp, n, m = _warm_problem()
+    from pounce.torch import TorchProblem
+
+    calls = {"single": 0, "batched": 0}
+    orig_s = TorchProblem._host_solve_warm
+    orig_b = TorchProblem._host_batched_solve_warm
+    TorchProblem._host_solve_warm = lambda self, *a, **k: (
+        calls.__setitem__("single", calls["single"] + 1) or orig_s(self, *a, **k)
+    )
+    TorchProblem._host_batched_solve_warm = lambda self, *a, **k: (
+        calls.__setitem__("batched", calls["batched"] + 1) or orig_b(self, *a, **k)
+    )
+    try:
+        x0 = torch.zeros(n)
+        p = torch.tensor([0.2, 0.5, 0.9], requires_grad=True)
+        x_star, (lam, zL, zU) = tp.solve_with_warm(p, x0)
+        # x* lies on the equality hyperplane and the duals come back.
+        np.testing.assert_allclose(float(x_star.sum()), 1.0, atol=1e-8)
+        assert lam.shape == (m,) and zL.shape == (n,) and zU.shape == (n,)
+        assert not lam.requires_grad  # duals are non-differentiable outputs
+        (x_star ** 2).sum().backward()
+        # ∂x*/∂p = I − 11ᵀ/n  ⇒  grad of Σx*² is 2 (I − 11ᵀ/n) x*.
+        xs = x_star.detach()
+        expected = 2.0 * (xs - xs.mean())
+        np.testing.assert_allclose(p.grad.numpy(), expected.numpy(), atol=1e-6)
+        assert calls["single"] == 1, f"expected one solve, got {calls['single']}"
+
+        pb = torch.tensor([[0.2, 0.5, 0.9], [0.1, 0.1, 0.1]], requires_grad=True)
+        xb, (lamb, zLb, zUb) = tp.batched_solve_with_warm(pb, x0)
+        np.testing.assert_allclose(xb.sum(dim=1).detach().numpy(), [1.0, 1.0], atol=1e-8)
+        assert not lamb.requires_grad
+        (xb ** 2).sum().backward()
+        assert torch.isfinite(pb.grad).all()
+        assert calls["batched"] == 1, f"expected one batched solve, got {calls['batched']}"
+    finally:
+        TorchProblem._host_solve_warm = orig_s
+        TorchProblem._host_batched_solve_warm = orig_b
+
+
+def test_torch_problem_rejects_float32_param():
+    """The differentiable TorchProblem entry points reject an explicit
+    float32 parameter (precision-losing) the same way the top-level
+    `pounce.torch.solve` does, while still accepting lists / NumPy /
+    float64 tensors."""
+    tp, n, _ = _warm_problem()
+    x0 = torch.zeros(n)
+    with pytest.raises(TypeError, match="float64"):
+        tp.solve(torch.tensor([0.2, 0.5, 0.9], dtype=torch.float32), x0)
+    with pytest.raises(TypeError, match="float64"):
+        tp.vmap_solve(torch.tensor([[0.2, 0.5, 0.9]], dtype=torch.float32), x0)
+    # Non-tensor and float64 inputs are accepted (coerced) without error.
+    np.testing.assert_allclose(
+        float(tp.solve([0.2, 0.5, 0.9], x0).sum()), 1.0, atol=1e-8,
+    )
+    np.testing.assert_allclose(
+        float(tp.solve(np.array([0.2, 0.5, 0.9]), x0).sum()), 1.0, atol=1e-8,
+    )
+
+
 def test_factor_reuse_matches_dense_pounce_76():
     """The k_aug-style factor-reuse backward must agree with the dense
     KKT backward across equality, slack-inequality, and active-bound."""

--- a/python/tests/test_torch.py
+++ b/python/tests/test_torch.py
@@ -1,0 +1,556 @@
+"""Tests for the PyTorch integration (pounce#109). Skipped when PyTorch
+isn't installed."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+torch.set_default_dtype(torch.float64)
+
+
+# ----- from_torch build -----
+
+
+def test_from_torch_hs071():
+    from pounce.torch import from_torch
+
+    def f(x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def g(x):
+        return torch.stack([torch.prod(x), torch.dot(x, x)])
+
+    prob = from_torch(
+        f, g, n=4, m=2,
+        lb=np.array([1.0] * 4), ub=np.array([5.0] * 4),
+        cl=np.array([25.0, 40.0]), cu=np.array([2e19, 40.0]),
+    )
+    prob.add_option("tol", 1e-8)
+    prob.add_option("print_level", 0)
+    x, info = prob.solve(x0=np.array([1.0, 5.0, 5.0, 1.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(info["obj_val"], 17.0140172, rtol=1e-5)
+
+
+def _banded_problem(n):
+    def f(x):
+        return torch.sum(x ** 2) + torch.sum(torch.sin(x))
+
+    def g(x):
+        return x[:-1] * x[1:] - 1.0
+
+    return f, g, n, n - 1
+
+
+def test_from_torch_sparse_matches_dense_pounce_83():
+    from pounce.torch._build import _TorchProblem
+
+    def f_hs(x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def g_hs(x):
+        return torch.stack([torch.prod(x), torch.dot(x, x)])
+
+    cases = [(f_hs, g_hs, 4, 2), _banded_problem(60)]
+    for f, g, n, m in cases:
+        dense = _TorchProblem(f, g, n=n, m=m, sparse=False)
+        sparse = _TorchProblem(f, g, n=n, m=m, sparse=True, n_probes=3)
+
+        for a, b in zip(dense.jacobianstructure(), sparse.jacobianstructure()):
+            np.testing.assert_array_equal(a, b)
+        for a, b in zip(dense.hessianstructure(), sparse.hessianstructure()):
+            np.testing.assert_array_equal(a, b)
+
+        rng = np.random.default_rng(11)
+        for _ in range(3):
+            x = rng.standard_normal(n)
+            lam = rng.standard_normal(m)
+            np.testing.assert_allclose(
+                dense.jacobian(x), sparse.jacobian(x), rtol=1e-12, atol=1e-12,
+            )
+            np.testing.assert_allclose(
+                dense.hessian(x, lam, 0.7), sparse.hessian(x, lam, 0.7),
+                rtol=1e-12, atol=1e-12,
+            )
+
+
+def test_from_torch_sparse_solves_match_dense_pounce_83():
+    from pounce.torch import from_torch
+
+    def f(x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def g(x):
+        return torch.stack([torch.prod(x), torch.dot(x, x)])
+
+    results = {}
+    for sparse in (False, True):
+        prob = from_torch(
+            f, g, n=4, m=2,
+            lb=np.array([1.0] * 4), ub=np.array([5.0] * 4),
+            cl=np.array([25.0, 40.0]), cu=np.array([2e19, 40.0]),
+            sparse=sparse,
+        )
+        prob.add_option("tol", 1e-8)
+        prob.add_option("print_level", 0)
+        x, info = prob.solve(x0=np.array([1.0, 5.0, 5.0, 1.0]))
+        assert info["status_msg"] == "Solve_Succeeded"
+        results[sparse] = (np.asarray(x), info["obj_val"])
+
+    np.testing.assert_allclose(results[True][0], results[False][0], atol=1e-7)
+    np.testing.assert_allclose(results[True][1], results[False][1], rtol=1e-9)
+
+
+# ----- implicit diff (top-level solve) -----
+
+
+def test_implicit_diff_parametric():
+    """min ||x - p||² → x*(p) = p, dL/dp = 2p."""
+    from pounce.torch import solve
+
+    def f(x, p):
+        d = x - p
+        return torch.dot(d, d)
+
+    p = torch.tensor([1.0, -2.0, 3.0], requires_grad=True)
+    x_star = solve(p, f=f, g=None, x0=torch.zeros(3), n=3, m=0,
+                   options={"tol": 1e-10, "print_level": 0})
+    (x_star ** 2).sum().backward()
+    np.testing.assert_allclose(p.grad.numpy(), (2.0 * p.detach()).numpy(), atol=1e-4)
+
+
+def _solve_box_projection(p, *, n=3, B=0.5):
+    from pounce.torch import solve
+
+    def f(x, p_):
+        d = x - p_
+        return torch.dot(d, d)
+
+    def g(x, p_):  # noqa: ARG001
+        return torch.stack([x[0]])
+
+    return solve(
+        p, f=f, g=g, x0=torch.zeros(n), n=n, m=1,
+        lb=torch.full((n,), -1e19), ub=torch.full((n,), 1e19),
+        cl=torch.tensor([-1e19]), cu=torch.tensor([B]),
+        options={"tol": 1e-10, "print_level": 0},
+    )
+
+
+def _fd_jac(forward, p, eps=1e-6):
+    p_np = np.asarray(p.detach(), dtype=np.float64)
+    n_out = forward(torch.tensor(p_np)).numel()
+    J = np.zeros((n_out, p_np.size))
+    for j in range(p_np.size):
+        e = np.zeros_like(p_np)
+        e[j] = eps
+        J[:, j] = (
+            forward(torch.tensor(p_np + e)).detach().numpy()
+            - forward(torch.tensor(p_np - e)).detach().numpy()
+        ) / (2.0 * eps)
+    return J
+
+
+def test_implicit_diff_inactive_inequality_pounce_73():
+    """Slack inequality must not pin the sensitivity: dx*/dp = I."""
+    p = torch.tensor([-1.0, 2.0, -3.0])
+    analytic = torch.autograd.functional.jacobian(_solve_box_projection, p)
+    fd = _fd_jac(_solve_box_projection, p)
+    np.testing.assert_allclose(analytic.numpy(), fd, atol=5e-6)
+    np.testing.assert_allclose(analytic.numpy(), np.eye(3), atol=5e-6)
+
+
+def test_implicit_diff_active_inequality_pounce_73():
+    """When the inequality binds, dx*/dp must still match FD."""
+    p = torch.tensor([2.0, 2.0, -3.0])
+    analytic = torch.autograd.functional.jacobian(_solve_box_projection, p)
+    fd = _fd_jac(_solve_box_projection, p)
+    np.testing.assert_allclose(analytic.numpy(), fd, atol=5e-6)
+
+
+def test_solve_gradcheck():
+    """torch.autograd.gradcheck on the constrained solve (float64)."""
+    from pounce.torch import solve
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2) + 0.1 * torch.sum(x ** 4)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0] + x[1] + x[2] - 1.0])
+
+    def fn(p):
+        return solve(
+            p, f=f, g=g, x0=torch.ones(3), n=3, m=1,
+            lb=torch.full((3,), -5.0), ub=torch.full((3,), 5.0),
+            cl=torch.zeros(1), cu=torch.zeros(1),
+            options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+        )
+
+    p = torch.tensor([-0.2, 0.5, 0.4], requires_grad=True)
+    assert torch.autograd.gradcheck(fn, (p,), atol=1e-4, rtol=1e-3, eps=1e-6)
+
+
+# ----- warm start -----
+
+
+def test_solve_with_warm_pounce_74():
+    from pounce.torch import solve_with_warm
+
+    n, m, B = 3, 1, 0.5
+
+    def f(x, p):
+        d = x - p
+        return torch.dot(d, d)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0]])
+
+    def forward(p, warm):
+        return solve_with_warm(
+            p, f=f, g=g, x0=torch.zeros(n), n=n, m=m,
+            lb=torch.full((n,), -1e19), ub=torch.full((n,), 1e19),
+            cl=torch.tensor([-1e19]), cu=torch.tensor([B]),
+            options={"tol": 1e-10, "print_level": 0},
+            warm_start=warm,
+        )
+
+    p0 = torch.tensor([2.0, 2.0, -3.0])
+    x0_star, warm0 = forward(p0, warm=None)
+    np.testing.assert_allclose(x0_star.detach().numpy(), [B, 2.0, -3.0], atol=1e-6)
+
+    x1_star, (lam1, zL1, zU1) = forward(p0, warm=warm0)
+    np.testing.assert_allclose(x1_star.detach().numpy(), x0_star.detach().numpy(), atol=1e-8)
+    assert torch.all(torch.isfinite(lam1))
+
+    p_var = torch.tensor([2.0, 2.0, -3.0], requires_grad=True)
+    x_star, _ = forward(p_var, warm=warm0)
+    (x_star ** 2).sum().backward()
+    np.testing.assert_allclose(p_var.grad.numpy(), [0.0, 4.0, -6.0], atol=1e-6)
+
+
+def test_solve_with_warm_threads_mu_pounce_86():
+    from pounce.torch import solve_with_warm
+
+    n, m, B = 3, 1, 0.5
+
+    def f(x, p):
+        d = x - p
+        return torch.dot(d, d)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0]])
+
+    def forward(p, warm):
+        return solve_with_warm(
+            p, f=f, g=g, x0=torch.zeros(n), n=n, m=m,
+            lb=torch.full((n,), -1e19), ub=torch.full((n,), 1e19),
+            cl=torch.tensor([-1e19]), cu=torch.tensor([B]),
+            options={"tol": 1e-10, "print_level": 0},
+            warm_start=warm,
+        )
+
+    p0 = torch.tensor([2.0, 2.0, -3.0])
+    _x, warm3 = forward(p0, warm=None)
+    assert len(warm3) == 3
+
+    x_ro, warm_ro = forward(p0, warm=(*warm3, None))
+    assert len(warm_ro) == 4
+    mu_out = float(warm_ro[3])
+    assert np.isfinite(mu_out) and 0.0 < mu_out < 1e-6
+
+    lam, zL, zU = warm3
+    x_seed, warm_seed = forward(p0, warm=(lam, zL, zU, mu_out))
+    assert len(warm_seed) == 4
+    np.testing.assert_allclose(x_seed.detach().numpy(), x_ro.detach().numpy(), atol=1e-8)
+
+
+# ----- batched -----
+
+
+def test_vmap_solve_parallel_matches_serial_pounce_74():
+    from pounce.torch import solve as serial_solve
+    from pounce.torch import vmap_solve_parallel
+
+    n, B = 3, 4
+
+    def f(x, p):
+        d = x - p
+        return torch.dot(d, d)
+
+    rng = np.random.default_rng(0)
+    p_batch = torch.tensor(rng.standard_normal((B, n)))
+    x0 = torch.zeros(n)
+
+    x_parallel = vmap_solve_parallel(
+        p_batch, f=f, g=None, x0=x0, n=n, m=0,
+        options={"tol": 1e-10, "print_level": 0}, workers=4,
+    )
+    x_serial = torch.stack([
+        serial_solve(p_batch[i], f=f, g=None, x0=x0, n=n, m=0,
+                     options={"tol": 1e-10, "print_level": 0})
+        for i in range(B)
+    ])
+    np.testing.assert_allclose(x_parallel.detach().numpy(), x_serial.detach().numpy(), atol=1e-7)
+    np.testing.assert_allclose(x_parallel.detach().numpy(), p_batch.numpy(), atol=1e-7)
+
+    pb = p_batch.clone().requires_grad_(True)
+    xb = vmap_solve_parallel(
+        pb, f=f, g=None, x0=x0, n=n, m=0,
+        options={"tol": 1e-10, "print_level": 0}, workers=4,
+    )
+    (xb ** 2).sum().backward()
+    np.testing.assert_allclose(pb.grad.numpy(), 2.0 * p_batch.numpy(), atol=1e-6)
+
+
+# ----- TorchProblem (build-once) -----
+
+
+def test_torch_problem_build_once_pounce_75():
+    from pounce.torch import TorchProblem, solve as top_solve
+
+    n, m, B = 3, 1, 0.5
+
+    def f(x, p):
+        d = x - p
+        return torch.dot(d, d)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0]])
+
+    tp = TorchProblem(
+        f=f, g=g, n=n, m=m, p_example=torch.zeros(n),
+        lb=torch.full((n,), -1e19), ub=torch.full((n,), 1e19),
+        cl=torch.tensor([-1e19]), cu=torch.tensor([B]),
+        options={"tol": 1e-10, "print_level": 0},
+    )
+    for p in (torch.tensor([2.0, 2.0, -3.0]), torch.tensor([-1.0, 2.0, -3.0]),
+              torch.tensor([0.3, -0.5, 0.7])):
+        x_reuse = tp.solve(p, torch.zeros(n))
+        x_ref = top_solve(
+            p, f=f, g=g, x0=torch.zeros(n), n=n, m=m,
+            lb=torch.full((n,), -1e19), ub=torch.full((n,), 1e19),
+            cl=torch.tensor([-1e19]), cu=torch.tensor([B]),
+            options={"tol": 1e-10, "print_level": 0},
+        )
+        np.testing.assert_allclose(x_reuse.detach().numpy(), x_ref.detach().numpy(), atol=1e-8)
+
+
+def test_torch_problem_grad_pounce_75():
+    from pounce.torch import TorchProblem
+
+    n, m, B = 3, 1, 0.5
+
+    def f(x, p):
+        d = x - p
+        return torch.dot(d, d)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0]])
+
+    tp = TorchProblem(
+        f=f, g=g, n=n, m=m, p_example=torch.zeros(n),
+        lb=torch.full((n,), -1e19), ub=torch.full((n,), 1e19),
+        cl=torch.tensor([-1e19]), cu=torch.tensor([B]),
+        options={"tol": 1e-10, "print_level": 0},
+    )
+    p0 = torch.tensor([-1.0, 2.0, -3.0])
+    J = torch.autograd.functional.jacobian(lambda p: tp.solve(p, torch.zeros(n)), p0)
+    np.testing.assert_allclose(J.numpy(), np.eye(n), atol=5e-6)
+
+
+def test_factor_reuse_matches_dense_pounce_76():
+    """The k_aug-style factor-reuse backward must agree with the dense
+    KKT backward across equality, slack-inequality, and active-bound."""
+    from pounce.torch import TorchProblem
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2) + 0.1 * torch.sum(x ** 4)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0] + x[1] + x[2] - 1.0, x[2]])
+
+    kwargs = dict(
+        f=f, g=g, n=3, m=2, p_example=torch.zeros(3),
+        lb=torch.tensor([0.4, -10.0, -10.0]), ub=torch.full((3,), 10.0),
+        cl=torch.tensor([0.0, -1e20]), cu=torch.tensor([0.0, 1e20]),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    tp_new = TorchProblem(**kwargs, factor_reuse=True)
+    tp_old = TorchProblem(**kwargs, factor_reuse=False)
+
+    p = torch.tensor([-0.2, 0.5, 0.4], requires_grad=True)
+
+    def loss(tp, p):
+        return (tp.solve(p, torch.ones(3)) ** 2).sum()
+
+    pn = p.clone().detach().requires_grad_(True)
+    loss(tp_new, pn).backward()
+    po = p.clone().detach().requires_grad_(True)
+    loss(tp_old, po).backward()
+    np.testing.assert_allclose(pn.grad.numpy(), po.grad.numpy(), atol=1e-7)
+
+
+def test_factor_reuse_jacobian_pounce_76():
+    from pounce.torch import TorchProblem
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0] - x[1]])
+
+    tp = TorchProblem(
+        f=f, g=g, n=2, m=1, p_example=torch.zeros(2),
+        lb=torch.full((2,), -1e19), ub=torch.full((2,), 1e19),
+        cl=torch.zeros(1), cu=torch.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    p = torch.tensor([0.3, 0.7])
+    J = torch.autograd.functional.jacobian(lambda p: tp.solve(p, torch.zeros(2)), p)
+    np.testing.assert_allclose(J.numpy(), 0.5 * np.ones((2, 2)), atol=1e-6)
+
+
+def test_batched_solve_matches_parallel_pounce_76():
+    from pounce.torch import TorchProblem
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0] + x[1] - 1.0])
+
+    tp = TorchProblem(
+        f=f, g=g, n=2, m=1, p_example=torch.zeros(2),
+        lb=torch.full((2,), -10.0), ub=torch.full((2,), 10.0),
+        cl=torch.zeros(1), cu=torch.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    p_batch = torch.tensor([[0.3, 0.7], [0.5, 0.5], [-0.1, 0.4], [1.0, 2.0]])
+    x_b = tp.batched_solve(p_batch, x0=torch.zeros(2))
+    x_p = tp.vmap_solve_parallel(p_batch, x0=torch.zeros(2), workers=2)
+    np.testing.assert_allclose(x_b.detach().numpy(), x_p.detach().numpy(), atol=1e-8)
+
+
+def test_batched_solve_grad_factor_reuse_pounce_76():
+    from pounce.torch import TorchProblem
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0] + x[1] - 1.0])
+
+    def build(reuse):
+        return TorchProblem(
+            f=f, g=g, n=2, m=1, p_example=torch.zeros(2),
+            lb=torch.full((2,), -10.0), ub=torch.full((2,), 10.0),
+            cl=torch.zeros(1), cu=torch.zeros(1),
+            options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+            factor_reuse=reuse,
+        )
+
+    tp_reuse, tp_dense = build(True), build(False)
+    p_batch = torch.tensor([[0.3, 0.7], [0.5, 0.5], [-0.1, 0.4], [0.8, -0.2]])
+
+    pr = p_batch.clone().requires_grad_(True)
+    (tp_reuse.batched_solve(pr, x0=torch.zeros(2)) ** 2).sum().backward()
+    pd = p_batch.clone().requires_grad_(True)
+    (tp_dense.batched_solve(pd, x0=torch.zeros(2)) ** 2).sum().backward()
+    np.testing.assert_allclose(pr.grad.numpy(), pd.grad.numpy(), atol=1e-7)
+
+
+# ----- sensitivity / anchor / path-following -----
+
+
+def test_solve_with_jacobian_and_sensitivity():
+    from pounce.torch import TorchProblem
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([x[0] + x[1] - 1.0])
+
+    tp = TorchProblem(
+        f=f, g=g, n=2, m=1, p_example=torch.zeros(2),
+        lb=torch.full((2,), -10.0), ub=torch.full((2,), 10.0),
+        cl=torch.zeros(1), cu=torch.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    p = torch.tensor([0.3, 0.7])
+    x_star, duals, J = tp.solve_with_jacobian(p, torch.zeros(2))
+    # Project p onto x0+x1=1: dx*/dp = I - 0.5 * 11^T.
+    expected = np.eye(2) - 0.5 * np.ones((2, 2))
+    np.testing.assert_allclose(J.numpy(), expected, atol=1e-6)
+
+    with tp.anchor(p, torch.zeros(2)) as state:
+        # JVP against held factor matches J @ dp.
+        dp = torch.tensor([1.0, -2.0])
+        dx = tp.jvp_from_state(state, dp)
+        np.testing.assert_allclose(dx.numpy(), (J @ dp).numpy(), atol=1e-7)
+        # VJP against held factor matches J^T @ x_bar.
+        xbar = torch.tensor([0.5, 1.5])
+        dpar = tp.vjp_from_state(state, xbar)
+        np.testing.assert_allclose(dpar.numpy(), (J.T @ xbar).numpy(), atol=1e-7)
+
+
+def test_path_follower_linear_map():
+    """Trace x*(θ) for min ||x - θ||² along θ(s) = s·[1,1]; x* = θ."""
+    from pounce.torch import TorchProblem, PathFollower
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2)
+
+    tp = TorchProblem(
+        f=f, g=None, n=2, m=0, p_example=torch.zeros(2),
+        lb=torch.full((2,), -10.0), ub=torch.full((2,), 10.0),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(tp, monitor_tol=1e-6)
+    trace = pf.follow(lambda s: torch.tensor([s, s]), (0.0, 1.0), torch.zeros(2))
+    assert trace.status == "ok"
+    # Final point: x* = θ(1) = [1, 1].
+    np.testing.assert_allclose(trace.x[-1], [1.0, 1.0], atol=1e-5)
+
+
+def test_trace_arclength_fold():
+    """Pseudo-arclength continuation traces past a fold. Stationarity of
+    f(x, θ) = x⁴/4 − x²/2 − θ x gives R = x³ − x − θ = 0, an S-curve with
+    folds at x = ±1/√3 (θ = ∓2/(3√3))."""
+    from pounce.torch import TorchProblem, PathFollower
+
+    def f(x, p):
+        return 0.25 * x[0] ** 4 - 0.5 * x[0] ** 2 - p[0] * x[0]
+
+    tp = TorchProblem(
+        f=f, g=None, n=1, m=0, p_example=torch.zeros(1),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+    pf = PathFollower(tp)
+    trace = pf.trace_arclength(
+        x0=torch.tensor([-1.2]), theta0=-0.5, ds=0.05, n_steps=120, direction=1.0,
+    )
+    assert trace.status == "ok"
+    # Two folds expected near θ = ±2/(3√3) ≈ ±0.385.
+    assert len(trace.turning_points) >= 2
+    np.testing.assert_allclose(
+        sorted(abs(t) for t in trace.turning_points[:2]),
+        [2.0 / (3 * np.sqrt(3))] * 2, atol=2e-2,
+    )
+
+
+def test_inverse_map_rhs_identity():
+    """Identity output: dθ/ds = J^{-1} dy/ds; for x*=θ, J=I so dθ/ds=dy/ds."""
+    from pounce.torch import TorchProblem, inverse_map_rhs
+
+    def f(x, p):
+        return torch.sum((x - p) ** 2)
+
+    tp = TorchProblem(
+        f=f, g=None, n=2, m=0, p_example=torch.zeros(2),
+        lb=torch.full((2,), -10.0), ub=torch.full((2,), 10.0),
+        options={"tol": 1e-11, "print_level": 0, "sb": "yes"},
+    )
+    rhs = inverse_map_rhs(tp, dy_ds=torch.tensor([1.0, -1.0]))
+    out = rhs(0.0, torch.tensor([0.5, 0.5]))
+    np.testing.assert_allclose(out.numpy(), [1.0, -1.0], atol=1e-6)


### PR DESCRIPTION
Adds a complete PyTorch integration (`pounce.torch`) mirroring the existing JAX frontend (`pounce.jax`). This is a thin adapter layer over the shared Rust IPM numerical core, enabling differentiable constrained optimization in PyTorch models via `torch.autograd`.

## Key Changes

**New modules:**
- `python/pounce/torch/__init__.py` — Public API (`solve`, `solve_with_warm`, `vmap_solve`, `vmap_solve_parallel`, `from_torch`, `TorchProblem`, `QpLayer`, etc.)
- `python/pounce/torch/_build.py` — Problem construction from traced `f(x)` and `g(x)` using `torch.func` (grad, jacrev, jacfwd, hessian, vmap)
- `python/pounce/torch/_diff.py` — Implicit-function-theorem backward via KKT solve with `torch.linalg.solve`
- `python/pounce/torch/_problem.py` — Build-once `TorchProblem` handle for iterative outer loops; reusable factor-based backward via `Solver.kkt_solve_many`
- `python/pounce/torch/_qp.py` — Differentiable convex-QP/SOCP layers (OptNet-style implicit differentiation)
- `python/pounce/torch/_path.py` — Numerical-continuation path following on the held KKT factor

**Shared infrastructure:**
- `python/pounce/_ad_common.py` — Framework-neutral sparsity detection and CPR column coloring (used by both JAX and PyTorch)

**Tests:**
- `python/tests/test_torch.py` — Core PyTorch integration tests (from_torch, implicit diff, gradcheck, batched solve)
- `python/tests/test_qp_torch.py` — QP layer tests (gradient validation, batch path, composition)
- `python/tests/test_socp_torch.py` — SOCP layer tests (cone-aware backward)
- `python/tests/test_parity_jax_torch.py` — JAX ↔ PyTorch parity fixtures (same numerical core, different autodiff frontends)

**Documentation & CI:**
- Updated `docs/src/python.md` with PyTorch integration guide
- Updated `python/pyproject.toml` with torch extras and dependencies
- Added `.github/workflows/ci.yml` PyTorch test job (`python-test-torch`)

## Implementation Highlights

**Eager-mode simplifications over JAX:**
- No host-callback registry/LRU: forward/backward run on the same thread in eager PyTorch, so the converged `Solver` is stashed on `ctx` and read back in backward
- No single-thread executor pin: eager autograd runs backward on the thread that called `.backward()`, which is also the thread that built the factor
- No `ShapeDtypeStruct` plumbing: shapes are concrete

**Factor-reuse backward (default):**
- Reuses the IPM's converged compound KKT factor via `Solver.kkt_solve_many`, avoiding dense `(n+m)×(n+m)` back-solve
- Falls back to dense in-framework KKT solve (`_kkt_backward`) when `factor_reuse=False` for higher-order differentiation

**Sparsity handling:**
- Shared CPR-style colored AD (issue #83) for compressed Jacobian/Hessian evaluation
- Detects sparsity pattern via multi-probe and colors structurally-orthogonal columns
- One JVP/HVP per color, `vmap`'d over seeds, scattered back to known nonzeros

**Thread safety:**
- `torch.func` transforms use a process-global dynamic-layer stack (not thread-safe)
- Serializes AD evaluations with `_FUNC_LOCK` in parallel batched path; genuine parallelism (Rust IPM linear algebra) runs with GIL released

**dtype enforcement:**
- All inputs coerced to float64

https://claude.ai/code/session_01TfnMgexUvjCjhXM4vfJW6B