### PR TITLE
Add batched NLP solving (pounce#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ changes.
 
 ## [Unreleased]
 
-### Added — Batched NLP solving (`solve_nlp_batch`, native-Rust path) (#126)
+### Added — Batched NLP solving (`solve_nlp_batch`) (#126)
 
 Solve N independent NLPs in parallel on a Rayon pool — the general-NLP
 analog of `solve_qp_batch_parallel`, for parametric sweeps, multi-start,
@@ -18,24 +18,51 @@ differing only in tightened bounds).
 
 - **Rust** — `pounce_algorithm::solve_nlp_batch` /
   `solve_nlp_batch_parallel`: one fully-equipped `IpoptApplication` per
-  instance, built *inside* the worker via a `Sync` configure hook
-  (outer-parallel / inner-serial, like the QP batch;
-  `install_serial_feral_backend` sets up the per-worker serial factor).
-  Results return in input order with the captured final iterate,
-  multipliers, and per-instance `SolveStatistics`.
+  instance, built *inside* the worker via a `Sync` configure hook that
+  receives the instance index (outer-parallel / inner-serial, like the
+  QP batch; `install_serial_feral_backend` sets up the per-worker
+  serial factor). Results return in input order with the captured
+  final iterate, multipliers, and per-instance `SolveStatistics`.
 - **`pounce-nl`** — CSE `Expr` sharing switched from `Rc` to `Arc`, so
   `NlProblem` / `NlTnlp` are `Send` and an owned evaluator can move to a
   worker. `NlTnlp` is now `Clone`, and `NlTnlp::variant` /
   `NlVariation` build per-instance bound / starting-point overrides on
   one parsed model (tapes are cheap to clone).
 - **Python** — `pounce.solve_nlp_batch(problems, x0s=, options=,
-  parallel=)`: native `NlProblem` inputs (from `read_nl` or the new
-  `NlProblem.variant(...)`) solve in parallel with the GIL released;
-  callback-based `Problem` inputs fall back to a documented sequential
-  loop (the GIL serializes every callback — true callback batching is
-  tracked as #126 phase 2). One `(x, info)` pair per input, `info`
-  matching `Problem.solve`'s layout; `print_level` defaults to 0 for
-  the batch.
+  parallel=, warms=, share_structure=)`: native `NlProblem` inputs
+  (from `read_nl` or the new `NlProblem.variant(...)`) solve in
+  parallel with the GIL released. One `(x, info)` pair per input,
+  `info` matching `Problem.solve`'s layout; `print_level` defaults to
+  0 for the batch.
+- **Phase 2: parallel callback batching** — callback-based
+  `pounce.Problem` inputs also solve in parallel: each instance's
+  bridge (Python callables + pre-resolved sparsity) moves to a rayon
+  worker that owns the whole solve, re-acquiring the GIL transiently
+  per `eval_*` callback. The GIL serializes only the Python share, so
+  the speedup scales with the Rust/Python work ratio (~4x on 4 cores
+  for an n=800 banded NLP with NumPy-vectorized callbacks; tiny
+  callback-dominated problems won't speed up). Per-instance
+  `add_option` settings are honored, with `options=` as a batch-level
+  overlay; a raising callback degrades to that instance's failure
+  without poisoning the batch.
+- **Warm-started batches** — `solve_nlp_batch_parallel_warm` /
+  `solve_nlp_batch_warm` (Rust) and `warms=` (Python, both input
+  kinds): seed each instance from a previous result's iterate + duals
+  and thread the converged barrier μ into `mu_init`
+  (`warm_start_init_point=yes` forced; dimension mismatch falls back
+  to a cold start). Re-solving a perturbed 24-instance `.nl` sweep
+  warm cut total iterations 482 → 120.
+- **Identical-sparsity structure sharing** — `FeralBackendPool` /
+  `install_pooled_serial_feral_backend` (Rust) and
+  `share_structure=True` (Python): opt-in per-worker backend pooling
+  so FERAL's pattern-fingerprint symbolic cache (ordering + supernode
+  structure) carries across batch instances instead of being rebuilt
+  per instance. Always correct (pattern changes re-analyze); results
+  are within solver tolerance of — not guaranteed bit-identical to —
+  fresh-backend solves, which is why it is opt-in. Cross-*thread*
+  symbolic sharing stays future work (needs the `BackendPool`
+  ownership refactor documented in `dev-notes/backend-pool-resolve.md`
+  or a feral-side symbolic export API).
 
 ### Added — PyTorch frontend for the differentiable solver (`pounce.torch`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ changes.
 
 ## [Unreleased]
 
+### Added — Batched NLP solving (`solve_nlp_batch`, native-Rust path) (#126)
+
+Solve N independent NLPs in parallel on a Rayon pool — the general-NLP
+analog of `solve_qp_batch_parallel`, for parametric sweeps, multi-start,
+MPC chains, and branch-and-bound node relaxations (each sibling node
+differing only in tightened bounds).
+
+- **Rust** — `pounce_algorithm::solve_nlp_batch` /
+  `solve_nlp_batch_parallel`: one fully-equipped `IpoptApplication` per
+  instance, built *inside* the worker via a `Sync` configure hook
+  (outer-parallel / inner-serial, like the QP batch;
+  `install_serial_feral_backend` sets up the per-worker serial factor).
+  Results return in input order with the captured final iterate,
+  multipliers, and per-instance `SolveStatistics`.
+- **`pounce-nl`** — CSE `Expr` sharing switched from `Rc` to `Arc`, so
+  `NlProblem` / `NlTnlp` are `Send` and an owned evaluator can move to a
+  worker. `NlTnlp` is now `Clone`, and `NlTnlp::variant` /
+  `NlVariation` build per-instance bound / starting-point overrides on
+  one parsed model (tapes are cheap to clone).
+- **Python** — `pounce.solve_nlp_batch(problems, x0s=, options=,
+  parallel=)`: native `NlProblem` inputs (from `read_nl` or the new
+  `NlProblem.variant(...)`) solve in parallel with the GIL released;
+  callback-based `Problem` inputs fall back to a documented sequential
+  loop (the GIL serializes every callback — true callback batching is
+  tracked as #126 phase 2). One `(x, info)` pair per input, `info`
+  matching `Problem.solve`'s layout; `print_level` defaults to 0 for
+  the batch.
+
 ### Added — PyTorch frontend for the differentiable solver (`pounce.torch`)
 
 A PyTorch frontend mirroring `pounce.jax`: a solve is a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,6 +876,7 @@ dependencies = [
  "pounce-observability",
  "pounce-presolve",
  "pounce-qp",
+ "rayon",
  "tracing",
 ]
 

--- a/crates/pounce-algorithm/Cargo.toml
+++ b/crates/pounce-algorithm/Cargo.toml
@@ -22,6 +22,10 @@ pounce-qp.workspace = true
 pounce-observability.workspace = true
 pounce-hsl = { workspace = true, optional = true }
 faer.workspace = true
+# Batched NLP solving (`batch.rs`, pounce#126): instances run on
+# rayon's global pool, outer-parallel / inner-serial. Same dep the QP
+# batch in pounce-convex uses.
+rayon = "1"
 tracing.workspace = true
 anstream.workspace = true
 anstyle.workspace = true

--- a/crates/pounce-algorithm/src/batch.rs
+++ b/crates/pounce-algorithm/src/batch.rs
@@ -47,7 +47,8 @@
 //! `pounce-py`'s `Problem::prepare` for the full recipe.
 
 use crate::application::IpoptApplication;
-use pounce_common::types::Number;
+use pounce_common::types::{Index, Number};
+use pounce_linsol::{EMatrixFormat, ESymSolverStatus, SparseSymLinearSolverInterface};
 use pounce_nlp::alg_types::SolverReturn;
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::solve_statistics::SolveStatistics;
@@ -57,7 +58,10 @@ use pounce_nlp::tnlp::{
 };
 use rayon::prelude::*;
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::rc::Rc;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, ThreadId};
 
 /// Final iterate of one batch instance, captured from the
 /// `finalize_solution` callback (owned copies of the borrowed
@@ -191,14 +195,367 @@ pub fn install_serial_feral_backend(app: &mut IpoptApplication) {
     }));
 }
 
+/// Per-thread pool of serial FERAL backends for **identical-sparsity**
+/// batches (the issue-#126 "optional later optimization": reuse the
+/// symbolic analysis across instances).
+///
+/// FERAL's `Solver` keys its symbolic factorization (fill-reducing
+/// ordering + supernode structure) on a pattern fingerprint and reuses
+/// it across `factor()` calls — that is what already amortizes the
+/// symbolic cost over a single instance's IPM iterations. A fresh
+/// backend per instance throws that cache away between instances; this
+/// pool instead parks each worker thread's backend when its solve
+/// finishes and hands it to the next instance scheduled on that
+/// thread. When the next instance's KKT pattern is identical, its
+/// first factorization hits the cached symbolic; when it differs, the
+/// fingerprint mismatch triggers a fresh analysis — so pooling is
+/// *always correct*, just only *profitable* for shared-structure
+/// sweeps.
+///
+/// **Determinism caveat (why this is opt-in):** the pooled solver
+/// carries value-adjacent state across instances — most notably the
+/// MC64 scaling cache (reused only inside its validity bound) and any
+/// pivot-quality escalation a previous instance triggered. Solutions
+/// still satisfy the same tolerances, but are not guaranteed
+/// bit-identical to fresh-backend solves. The default batch entry
+/// points keep one fresh backend per instance.
+///
+/// Construct once per batch ([`Self::serial`]), share the `Arc` with
+/// each worker's `configure` via
+/// [`install_pooled_serial_feral_backend`]. Restoration-phase inner
+/// solves keep their own fresh backends. Pooled solvers (and their
+/// cached factors) free when the `Arc` drops.
+pub struct FeralBackendPool {
+    cfg: pounce_feral::FeralConfig,
+    slots: Mutex<HashMap<ThreadId, pounce_feral::FeralSolverInterface>>,
+}
+
+impl FeralBackendPool {
+    /// A pool minting inner-serial backends with `cfg` (its `parallel`
+    /// field is forced off — pooling exists for the outer-parallel /
+    /// inner-serial batch shape).
+    pub fn serial(mut cfg: pounce_feral::FeralConfig) -> Arc<Self> {
+        cfg.parallel = Some(false);
+        Arc::new(Self {
+            cfg,
+            slots: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Take this thread's parked backend (or mint a fresh one). The
+    /// returned guard parks it back on drop, on the same thread.
+    fn acquire(self: &Arc<Self>) -> PooledFeralBackend {
+        let recycled = self
+            .slots
+            .lock()
+            .ok()
+            .and_then(|mut s| s.remove(&thread::current().id()));
+        let inner = recycled
+            .unwrap_or_else(|| pounce_feral::FeralSolverInterface::with_config(self.cfg.clone()));
+        PooledFeralBackend {
+            inner: Some(inner),
+            pool: Arc::clone(self),
+        }
+    }
+}
+
+impl std::fmt::Debug for FeralBackendPool {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let parked = self.slots.lock().map(|s| s.len()).unwrap_or(0);
+        f.debug_struct("FeralBackendPool")
+            .field("parked", &parked)
+            .finish_non_exhaustive()
+    }
+}
+
+/// RAII guard around a pooled [`pounce_feral::FeralSolverInterface`]:
+/// delegates the backend trait verbatim and parks the solver back into
+/// its pool slot when the solve's ownership chain drops it. If the
+/// slot is already occupied (two live backends on one thread — e.g. a
+/// nested factory call), the extra solver is simply dropped: pooling
+/// degrades to fresh-per-instance, never to shared-mutable state.
+struct PooledFeralBackend {
+    inner: Option<pounce_feral::FeralSolverInterface>,
+    pool: Arc<FeralBackendPool>,
+}
+
+impl PooledFeralBackend {
+    fn get(&mut self) -> &mut pounce_feral::FeralSolverInterface {
+        // Invariant: `inner` is `Some` from construction until drop.
+        #[allow(clippy::expect_used)]
+        self.inner.as_mut().expect("pooled backend already taken")
+    }
+}
+
+impl Drop for PooledFeralBackend {
+    fn drop(&mut self) {
+        if let (Some(solver), Ok(mut slots)) = (self.inner.take(), self.pool.slots.lock()) {
+            slots.entry(thread::current().id()).or_insert(solver);
+        }
+    }
+}
+
+impl SparseSymLinearSolverInterface for PooledFeralBackend {
+    fn initialize_structure(
+        &mut self,
+        dim: Index,
+        nonzeros: Index,
+        ia: &[Index],
+        ja: &[Index],
+    ) -> ESymSolverStatus {
+        self.get().initialize_structure(dim, nonzeros, ia, ja)
+    }
+    fn values_array_mut(&mut self) -> &mut [Number] {
+        self.get().values_array_mut()
+    }
+    fn multi_solve(
+        &mut self,
+        new_matrix: bool,
+        ia: &[Index],
+        ja: &[Index],
+        nrhs: Index,
+        rhs_vals: &mut [Number],
+        check_neg_evals: bool,
+        number_of_neg_evals: Index,
+    ) -> ESymSolverStatus {
+        self.get().multi_solve(
+            new_matrix,
+            ia,
+            ja,
+            nrhs,
+            rhs_vals,
+            check_neg_evals,
+            number_of_neg_evals,
+        )
+    }
+    fn number_of_neg_evals(&self) -> Index {
+        match &self.inner {
+            Some(s) => s.number_of_neg_evals(),
+            None => 0,
+        }
+    }
+    fn increase_quality(&mut self) -> bool {
+        self.get().increase_quality()
+    }
+    fn provides_inertia(&self) -> bool {
+        self.inner.as_ref().is_some_and(|s| s.provides_inertia())
+    }
+    fn matrix_format(&self) -> EMatrixFormat {
+        match &self.inner {
+            Some(s) => s.matrix_format(),
+            None => EMatrixFormat::TripletFormat,
+        }
+    }
+    fn provides_degeneracy_detection(&self) -> bool {
+        self.inner
+            .as_ref()
+            .is_some_and(|s| s.provides_degeneracy_detection())
+    }
+    fn determine_dependent_rows(
+        &mut self,
+        ia: &[Index],
+        ja: &[Index],
+        c_deps: &mut Vec<Index>,
+    ) -> ESymSolverStatus {
+        self.get().determine_dependent_rows(ia, ja, c_deps)
+    }
+    fn factor_pattern(&self, want_values: bool) -> Option<pounce_linsol::FactorPattern> {
+        self.inner.as_ref().and_then(|s| s.factor_pattern(want_values))
+    }
+}
+
+/// Install a backend factory drawing from `pool` — the
+/// identical-sparsity batch optimization (see [`FeralBackendPool`] for
+/// the reuse semantics and the determinism caveat). Call from
+/// `configure` *instead of* [`install_serial_feral_backend`].
+pub fn install_pooled_serial_feral_backend(app: &mut IpoptApplication, pool: &Arc<FeralBackendPool>) {
+    let pool = Arc::clone(pool);
+    app.set_linear_backend_factory(Box::new(move |_choice| Box::new(pool.acquire())));
+}
+
+/// Per-instance warm-start iterate for [`solve_nlp_batch_parallel_warm`]:
+/// primal point plus the three dual vectors the IPM's warm-start
+/// initializer consumes via `TNLP::get_starting_point`. Build one from
+/// a previous batch's [`NlpBatchSolution`] (the `From` impl) for MPC /
+/// sequential-chaining workloads.
+#[derive(Debug, Clone, Default)]
+pub struct NlpWarmStart {
+    pub x: Vec<Number>,
+    /// Constraint multipliers λ.
+    pub lambda: Vec<Number>,
+    /// Lower / upper bound multipliers.
+    pub z_l: Vec<Number>,
+    pub z_u: Vec<Number>,
+    /// Barrier parameter μ to resume from — typically the previous
+    /// solve's final μ ([`SolveStatistics::final_mu`]). When `Some`,
+    /// the warm batch sets `mu_init` to it (floored at `1e-9`, and
+    /// only if the caller's `configure` didn't set `mu_init`
+    /// explicitly), so the IPM continues near the converged barrier
+    /// instead of recentering at the cold default `0.1` — without
+    /// this, a warm start from a near-optimal point can *gain*
+    /// iterations walking back out to the central path.
+    pub mu: Option<Number>,
+}
+
+impl From<&NlpBatchSolution> for NlpWarmStart {
+    fn from(sol: &NlpBatchSolution) -> Self {
+        Self {
+            x: sol.x.clone(),
+            lambda: sol.lambda.clone(),
+            z_l: sol.z_l.clone(),
+            z_u: sol.z_u.clone(),
+            mu: None,
+        }
+    }
+}
+
+/// Build a warm start from a full batch result: iterate + duals from
+/// the captured solution, μ from the statistics. An instance whose
+/// solve produced no solution yields an empty warm start, which the
+/// next solve treats as a cold start (dimension-mismatch fallback).
+impl From<&NlpBatchResult> for NlpWarmStart {
+    fn from(r: &NlpBatchResult) -> Self {
+        match &r.solution {
+            Some(sol) => Self {
+                mu: Some(r.stats.final_mu),
+                ..Self::from(sol)
+            },
+            None => Self::default(),
+        }
+    }
+}
+
+/// Floor for warm-start `mu_init` threading (see [`NlpWarmStart::mu`]).
+const WARM_MU_FLOOR: Number = 1e-9;
+
+/// Apply the warm-start options to a configured per-worker app:
+/// always force `warm_start_init_point=yes` (the point of the warm
+/// entry), and thread the instance's resumed μ into `mu_init` unless
+/// the caller's `configure` already set one explicitly.
+fn apply_warm_options(app: &mut IpoptApplication, mu: Option<Number>) {
+    let _ = app
+        .options_mut()
+        .set_string_value("warm_start_init_point", "yes", true, false);
+    if let Some(mu) = mu {
+        let user_set_mu = matches!(
+            app.options().get_numeric_value("mu_init", ""),
+            Ok((_, true))
+        );
+        if !user_set_mu {
+            let _ = app
+                .options_mut()
+                .set_numeric_value("mu_init", mu.max(WARM_MU_FLOOR), true, false);
+        }
+    }
+}
+
+/// Delegating wrapper that serves a [`NlpWarmStart`] from
+/// `get_starting_point` (primal always; duals when the initializer
+/// asks, i.e. under `warm_start_init_point=yes`). Any length mismatch
+/// against the wrapped problem falls back to the inner TNLP's own
+/// starting point — a per-instance cold start, mirroring the QP batch's
+/// warm-start contract. Every other method forwards unchanged.
+struct WarmStartTnlp<T: TNLP> {
+    inner: T,
+    warm: NlpWarmStart,
+}
+
+impl<T: TNLP> TNLP for WarmStartTnlp<T> {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        self.inner.get_nlp_info()
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        self.inner.get_bounds_info(b)
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        let dims_ok = self.warm.x.len() == sp.x.len()
+            && (!sp.init_lambda || self.warm.lambda.len() == sp.lambda.len())
+            && (!sp.init_z
+                || (self.warm.z_l.len() == sp.z_l.len() && self.warm.z_u.len() == sp.z_u.len()));
+        if !dims_ok {
+            return self.inner.get_starting_point(sp);
+        }
+        if sp.init_x {
+            sp.x.copy_from_slice(&self.warm.x);
+        }
+        if sp.init_z {
+            sp.z_l.copy_from_slice(&self.warm.z_l);
+            sp.z_u.copy_from_slice(&self.warm.z_u);
+        }
+        if sp.init_lambda {
+            sp.lambda.copy_from_slice(&self.warm.lambda);
+        }
+        true
+    }
+    fn eval_f(&mut self, x: &[Number], new_x: bool) -> Option<Number> {
+        self.inner.eval_f(x, new_x)
+    }
+    fn eval_grad_f(&mut self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool {
+        self.inner.eval_grad_f(x, new_x, grad_f)
+    }
+    fn eval_g(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+        self.inner.eval_g(x, new_x, g)
+    }
+    fn eval_jac_g(&mut self, x: Option<&[Number]>, new_x: bool, mode: SparsityRequest<'_>) -> bool {
+        self.inner.eval_jac_g(x, new_x, mode)
+    }
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        self.inner
+            .eval_h(x, new_x, obj_factor, lambda, new_lambda, mode)
+    }
+    fn finalize_solution(&mut self, sol: Solution<'_>, ip_data: &IpoptData, ip_cq: &IpoptCq) {
+        self.inner.finalize_solution(sol, ip_data, ip_cq)
+    }
+    fn get_var_con_metadata(&mut self, var: &mut MetaData, con: &mut MetaData) -> bool {
+        self.inner.get_var_con_metadata(var, con)
+    }
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        self.inner.get_scaling_parameters(req)
+    }
+    fn get_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.get_variables_linearity(types)
+    }
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.get_constraints_linearity(types)
+    }
+    fn get_number_of_nonlinear_variables(&mut self) -> pounce_common::types::Index {
+        self.inner.get_number_of_nonlinear_variables()
+    }
+    fn get_list_of_nonlinear_variables(
+        &mut self,
+        pos_nonlin_vars: &mut [pounce_common::types::Index],
+    ) -> bool {
+        self.inner.get_list_of_nonlinear_variables(pos_nonlin_vars)
+    }
+    fn intermediate_callback(
+        &mut self,
+        stats: IterStats,
+        ip_data: &IpoptData,
+        ip_cq: &IpoptCq,
+    ) -> bool {
+        self.inner.intermediate_callback(stats, ip_data, ip_cq)
+    }
+    fn finalize_metadata(&mut self, var: &MetaData, con: &MetaData) {
+        self.inner.finalize_metadata(var, con)
+    }
+}
+
 /// Solve one instance with a fresh, caller-configured application.
-fn solve_nlp_one<T, C>(tnlp: T, configure: &mut C) -> NlpBatchResult
+fn solve_nlp_one<T, C>(index: usize, tnlp: T, configure: &mut C) -> NlpBatchResult
 where
     T: TNLP + 'static,
-    C: FnMut(&mut IpoptApplication),
+    C: FnMut(usize, &mut IpoptApplication),
 {
     let mut app = IpoptApplication::new();
-    configure(&mut app);
+    configure(index, &mut app);
     let cap = Rc::new(RefCell::new(CaptureTnlp {
         inner: tnlp,
         captured: None,
@@ -215,18 +572,20 @@ where
 
 /// Solve a batch of independent NLPs **sequentially**, returning one
 /// result per input in input order. `configure` is called once per
-/// instance on a fresh [`IpoptApplication`] (set options / backend /
+/// instance (receiving the instance index, so per-instance options are
+/// possible) on a fresh [`IpoptApplication`] (set options / backend /
 /// restoration there — see the module docs). Predictable and
 /// contention-free; the right choice when each instance is large
 /// enough that the linear-solver backend parallelizes internally.
 pub fn solve_nlp_batch<T, C>(problems: Vec<T>, mut configure: C) -> Vec<NlpBatchResult>
 where
     T: TNLP + 'static,
-    C: FnMut(&mut IpoptApplication),
+    C: FnMut(usize, &mut IpoptApplication),
 {
     problems
         .into_iter()
-        .map(|t| solve_nlp_one(t, &mut configure))
+        .enumerate()
+        .map(|(i, t)| solve_nlp_one(i, t, &mut configure))
         .collect()
 }
 
@@ -240,18 +599,104 @@ where
 /// moves in, and the application, backend, and restoration strategy
 /// are all constructed *inside* the worker via `configure` (which must
 /// therefore be `Sync` — it is shared by reference and called once per
-/// instance). For the outer-parallel / inner-serial win, have
+/// instance, with the instance index so per-instance options are
+/// possible). For the outer-parallel / inner-serial win, have
 /// `configure` install an inner-serial backend —
 /// [`install_serial_feral_backend`] after setting options.
 pub fn solve_nlp_batch_parallel<T, C>(problems: Vec<T>, configure: C) -> Vec<NlpBatchResult>
 where
     T: TNLP + Send + 'static,
-    C: Fn(&mut IpoptApplication) + Sync,
+    C: Fn(usize, &mut IpoptApplication) + Sync,
 {
     problems
         .into_par_iter()
-        .map(|t| solve_nlp_one(t, &mut |app: &mut IpoptApplication| configure(app)))
+        .enumerate()
+        .map(|(i, t)| {
+            solve_nlp_one(i, t, &mut |i: usize, app: &mut IpoptApplication| {
+                configure(i, app)
+            })
+        })
         .collect()
+}
+
+/// Warm-started **sequential** batch — [`solve_nlp_batch`] seeded per
+/// instance from `warms`. See [`solve_nlp_batch_parallel_warm`] for
+/// the warm-start contract (option forcing, dimension-mismatch
+/// fallback).
+///
+/// # Panics
+/// Panics if `warms.len() != problems.len()`.
+pub fn solve_nlp_batch_warm<T, C>(
+    problems: Vec<T>,
+    warms: Vec<NlpWarmStart>,
+    mut configure: C,
+) -> Vec<NlpBatchResult>
+where
+    T: TNLP + 'static,
+    C: FnMut(usize, &mut IpoptApplication),
+{
+    assert_eq!(
+        warms.len(),
+        problems.len(),
+        "warms.len() ({}) must equal problems.len() ({})",
+        warms.len(),
+        problems.len()
+    );
+    let mus: Vec<Option<Number>> = warms.iter().map(|w| w.mu).collect();
+    let wrapped: Vec<WarmStartTnlp<T>> = problems
+        .into_iter()
+        .zip(warms)
+        .map(|(inner, warm)| WarmStartTnlp { inner, warm })
+        .collect();
+    solve_nlp_batch(wrapped, |i, app: &mut IpoptApplication| {
+        configure(i, app);
+        apply_warm_options(app, mus[i]);
+    })
+}
+
+/// Warm-started parallel batch: like [`solve_nlp_batch_parallel`] but
+/// each instance is seeded from the corresponding entry of `warms` —
+/// typically the previous step's [`NlpBatchSolution`]s for a sequence
+/// of nearby batches (receding-horizon MPC, sequential parameter
+/// continuation, B&B dives). The NLP analog of the QP batch's
+/// `solve_qp_batch_parallel_warm`.
+///
+/// Each worker forces `warm_start_init_point=yes` *after* `configure`
+/// runs (that option is the point of this entry; pair it with
+/// `mu_init` / `warm_start_target_mu` via `configure` for the full
+/// re-optimization effect), then serves the warm iterate through
+/// `get_starting_point`. A warm start only affects an instance's
+/// iteration count, not its solution; a per-instance dimension
+/// mismatch falls back to that instance's own (cold) starting point.
+///
+/// # Panics
+/// Panics if `warms.len() != problems.len()`.
+pub fn solve_nlp_batch_parallel_warm<T, C>(
+    problems: Vec<T>,
+    warms: Vec<NlpWarmStart>,
+    configure: C,
+) -> Vec<NlpBatchResult>
+where
+    T: TNLP + Send + 'static,
+    C: Fn(usize, &mut IpoptApplication) + Sync,
+{
+    assert_eq!(
+        warms.len(),
+        problems.len(),
+        "warms.len() ({}) must equal problems.len() ({})",
+        warms.len(),
+        problems.len()
+    );
+    let mus: Vec<Option<Number>> = warms.iter().map(|w| w.mu).collect();
+    let wrapped: Vec<WarmStartTnlp<T>> = problems
+        .into_iter()
+        .zip(warms)
+        .map(|(inner, warm)| WarmStartTnlp { inner, warm })
+        .collect();
+    solve_nlp_batch_parallel(wrapped, |i, app: &mut IpoptApplication| {
+        configure(i, app);
+        apply_warm_options(app, mus[i]);
+    })
 }
 
 #[cfg(test)]
@@ -361,7 +806,7 @@ mod tests {
         fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
     }
 
-    fn configure(app: &mut IpoptApplication) {
+    fn configure(_i: usize, app: &mut IpoptApplication) {
         let _ = app
             .options_mut()
             .set_integer_value("print_level", 0, true, false);
@@ -440,6 +885,110 @@ mod tests {
             ApplicationReturnStatus::SolveSucceeded,
             "infeasible instance must not report success"
         );
+    }
+
+    /// Warm-start chain (the MPC shape): solve a batch cold, perturb
+    /// each instance's data slightly, re-solve warm-seeded from the
+    /// previous solutions. Solutions must be correct, and the warm
+    /// solves must not iterate more than the cold solves of the same
+    /// perturbed instances.
+    #[test]
+    fn warm_started_batch_chains() {
+        let k = 4;
+        let cold = solve_nlp_batch_parallel(batch(k), configure);
+        let warms: Vec<NlpWarmStart> = cold.iter().map(NlpWarmStart::from).collect();
+
+        // Perturb each instance: shift the equality target slightly.
+        let perturbed = || -> Vec<ShiftedQuad> {
+            batch(k)
+                .into_iter()
+                .map(|mut p| {
+                    p.s += 0.01;
+                    p
+                })
+                .collect()
+        };
+        let warm = solve_nlp_batch_parallel_warm(perturbed(), warms, configure);
+        let cold2 = solve_nlp_batch_parallel(perturbed(), configure);
+        for i in 0..k {
+            assert_eq!(warm[i].status, ApplicationReturnStatus::SolveSucceeded);
+            let expect = perturbed()[i].expected();
+            let sol = warm[i].solution.as_ref().expect("warm solution");
+            assert!(
+                (sol.x[0] - expect[0]).abs() < 1e-5 && (sol.x[1] - expect[1]).abs() < 1e-5,
+                "instance {i}: warm solve must reach the perturbed optimum"
+            );
+            assert!(
+                warm[i].stats.iteration_count <= cold2[i].stats.iteration_count,
+                "instance {i}: warm start took {} iters vs cold {}",
+                warm[i].stats.iteration_count,
+                cold2[i].stats.iteration_count
+            );
+        }
+    }
+
+    /// A dimension-mismatched warm entry falls back to that instance's
+    /// own cold start instead of failing.
+    #[test]
+    fn warm_start_dimension_mismatch_falls_back_cold() {
+        let probs = batch(2);
+        let expected: Vec<[f64; 2]> = probs.iter().map(|p| p.expected()).collect();
+        let warms = vec![NlpWarmStart::default(), NlpWarmStart::default()];
+        let out = solve_nlp_batch_parallel_warm(probs, warms, configure);
+        for (i, r) in out.iter().enumerate() {
+            assert_eq!(r.status, ApplicationReturnStatus::SolveSucceeded);
+            let sol = r.solution.as_ref().expect("solution");
+            assert!(
+                (sol.x[0] - expected[i][0]).abs() < 1e-6
+                    && (sol.x[1] - expected[i][1]).abs() < 1e-6
+            );
+        }
+    }
+
+    /// The pool moves parked backends between threads (HashMap behind
+    /// the pool's mutex), so the backend must be `Send`; the pool
+    /// itself is shared by reference from the `Sync` configure hook.
+    #[test]
+    fn backend_pool_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<FeralBackendPool>();
+        fn assert_send<T: Send>() {}
+        assert_send::<pounce_feral::FeralSolverInterface>();
+    }
+
+    /// Pooled backends on an identical-structure batch: results match
+    /// the fresh-backend batch within solver tolerance, and the pool
+    /// ends up holding at most one parked solver per worker thread.
+    #[test]
+    fn pooled_backends_match_fresh_on_identical_structure() {
+        let k = 8;
+        let fresh = solve_nlp_batch_parallel(batch(k), configure);
+
+        let pool = FeralBackendPool::serial(pounce_feral::FeralConfig::default());
+        let pool_for_cfg = Arc::clone(&pool);
+        let pooled = solve_nlp_batch_parallel(batch(k), move |_i, app| {
+            let _ = app
+                .options_mut()
+                .set_integer_value("print_level", 0, true, false);
+            install_pooled_serial_feral_backend(app, &pool_for_cfg);
+        });
+        assert!(
+            pool.slots.lock().map(|s| !s.is_empty()).unwrap_or(false),
+            "at least one worker must have parked its backend"
+        );
+        for i in 0..k {
+            assert_eq!(pooled[i].status, ApplicationReturnStatus::SolveSucceeded);
+            let pf = fresh[i].solution.as_ref().expect("fresh");
+            let pp = pooled[i].solution.as_ref().expect("pooled");
+            for j in 0..2 {
+                assert!(
+                    (pf.x[j] - pp.x[j]).abs() < 1e-6,
+                    "instance {i} x[{j}]: pooled {} vs fresh {}",
+                    pp.x[j],
+                    pf.x[j]
+                );
+            }
+        }
     }
 
     /// Ragged convergence: mix trivially-easy instances with ones that

--- a/crates/pounce-algorithm/src/batch.rs
+++ b/crates/pounce-algorithm/src/batch.rs
@@ -360,7 +360,9 @@ impl SparseSymLinearSolverInterface for PooledFeralBackend {
         self.get().determine_dependent_rows(ia, ja, c_deps)
     }
     fn factor_pattern(&self, want_values: bool) -> Option<pounce_linsol::FactorPattern> {
-        self.inner.as_ref().and_then(|s| s.factor_pattern(want_values))
+        self.inner
+            .as_ref()
+            .and_then(|s| s.factor_pattern(want_values))
     }
 }
 
@@ -368,7 +370,10 @@ impl SparseSymLinearSolverInterface for PooledFeralBackend {
 /// identical-sparsity batch optimization (see [`FeralBackendPool`] for
 /// the reuse semantics and the determinism caveat). Call from
 /// `configure` *instead of* [`install_serial_feral_backend`].
-pub fn install_pooled_serial_feral_backend(app: &mut IpoptApplication, pool: &Arc<FeralBackendPool>) {
+pub fn install_pooled_serial_feral_backend(
+    app: &mut IpoptApplication,
+    pool: &Arc<FeralBackendPool>,
+) {
     let pool = Arc::clone(pool);
     app.set_linear_backend_factory(Box::new(move |_choice| Box::new(pool.acquire())));
 }
@@ -442,9 +447,9 @@ fn apply_warm_options(app: &mut IpoptApplication, mu: Option<Number>) {
             Ok((_, true))
         );
         if !user_set_mu {
-            let _ = app
-                .options_mut()
-                .set_numeric_value("mu_init", mu.max(WARM_MU_FLOOR), true, false);
+            let _ =
+                app.options_mut()
+                    .set_numeric_value("mu_init", mu.max(WARM_MU_FLOOR), true, false);
         }
     }
 }

--- a/crates/pounce-algorithm/src/batch.rs
+++ b/crates/pounce-algorithm/src/batch.rs
@@ -1,0 +1,467 @@
+//! Batched NLP solving (pounce#126) — N independent NLPs on a rayon
+//! pool.
+//!
+//! The NLP analog of `pounce-convex`'s `solve_qp_batch` /
+//! `solve_qp_batch_parallel`: solve a batch of independent problems
+//! (parametric sweeps, multi-start, branch-and-bound node relaxations)
+//! and return one result per input, in input order. Each instance runs
+//! the full filter-IPM end-to-end via its own [`IpoptApplication`].
+//!
+//! # Parallelism model: outer-parallel, inner-serial
+//!
+//! Same rationale as the QP batch (`pounce-convex/src/batch.rs`): each
+//! NLP solve is fully independent, so the batch is embarrassingly
+//! parallel *across instances* — but the default FERAL factorization
+//! backend is itself rayon-parallel *within* a factor, and running
+//! both levels oversubscribes the cores. [`solve_nlp_batch_parallel`]
+//! therefore builds everything per worker, and the `configure` hook
+//! should install an **inner-serial** linear-solver backend;
+//! [`install_serial_feral_backend`] does exactly that (it honors the
+//! app's `feral_*` options, forcing only `parallel = off` — a
+//! per-backend setting, not global state). Unlike the QP batch, NLP
+//! instances converge in wildly different iteration counts; that is
+//! fine for thread-per-instance rayon (a converged instance frees its
+//! worker — no lockstep), and no cross-instance KKT-structure sharing
+//! is attempted because general-NLP sparsity may differ per instance.
+//!
+//! # Construction happens on the worker
+//!
+//! `pounce-nlp`'s solver plumbing is single-threaded
+//! (`Rc<RefCell<…>>`), so nothing solver-side crosses a thread
+//! boundary: each worker receives one owned `T: TNLP + Send` (e.g. a
+//! `pounce_nl::nl_reader::NlTnlp`, which is `Send` since its CSE nodes
+//! went `Arc`), constructs its own [`IpoptApplication`] *inside* the
+//! worker closure, and only the plain-data [`NlpBatchResult`] comes
+//! back.
+//!
+//! # The `configure` hook
+//!
+//! `pounce-algorithm` cannot depend on `pounce-restoration` (the dep
+//! edge runs the other way), so the per-worker application is handed
+//! to a caller-supplied `configure` closure that should, at minimum,
+//! mirror what single-solve drivers do: set options, then install a
+//! linear-backend factory and a restoration-factory provider. Without
+//! a restoration provider an instance that needs the restoration
+//! phase returns `RestorationFailure` instead of recovering — same as
+//! a bare `IpoptApplication`. See `pounce-cli`'s solve setup or
+//! `pounce-py`'s `Problem::prepare` for the full recipe.
+
+use crate::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::alg_types::SolverReturn;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::solve_statistics::SolveStatistics;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IpoptCq, IpoptData, IterStats, Linearity, MetaData, NlpInfo, ScalingRequest,
+    Solution, SparsityRequest, StartingPoint, TNLP,
+};
+use rayon::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Final iterate of one batch instance, captured from the
+/// `finalize_solution` callback (owned copies of the borrowed
+/// buffers).
+#[derive(Debug, Clone)]
+pub struct NlpBatchSolution {
+    /// Algorithm-level termination status (finer-grained than the
+    /// application-level [`NlpBatchResult::status`]).
+    pub solver_status: SolverReturn,
+    pub x: Vec<Number>,
+    /// Lower / upper bound multipliers.
+    pub z_l: Vec<Number>,
+    pub z_u: Vec<Number>,
+    /// Constraint values `g(x)` at the final iterate.
+    pub g: Vec<Number>,
+    /// Constraint multipliers.
+    pub lambda: Vec<Number>,
+    pub obj: Number,
+}
+
+/// Outcome of one instance of a batched solve.
+#[derive(Debug, Clone)]
+pub struct NlpBatchResult {
+    pub status: ApplicationReturnStatus,
+    /// `None` when the solve aborted before `finalize_solution` ran
+    /// (e.g. `InvalidProblemDefinition`).
+    pub solution: Option<NlpBatchSolution>,
+    /// Per-instance solve statistics (iteration count, final KKT
+    /// error, timings, …).
+    pub stats: SolveStatistics,
+}
+
+/// Delegating wrapper that records the `finalize_solution` payload so
+/// the batch driver can return it as owned data. Every other `TNLP`
+/// method forwards to the wrapped instance unchanged.
+struct CaptureTnlp<T: TNLP> {
+    inner: T,
+    captured: Option<NlpBatchSolution>,
+}
+
+impl<T: TNLP> TNLP for CaptureTnlp<T> {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        self.inner.get_nlp_info()
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        self.inner.get_bounds_info(b)
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        self.inner.get_starting_point(sp)
+    }
+    fn eval_f(&mut self, x: &[Number], new_x: bool) -> Option<Number> {
+        self.inner.eval_f(x, new_x)
+    }
+    fn eval_grad_f(&mut self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool {
+        self.inner.eval_grad_f(x, new_x, grad_f)
+    }
+    fn eval_g(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+        self.inner.eval_g(x, new_x, g)
+    }
+    fn eval_jac_g(&mut self, x: Option<&[Number]>, new_x: bool, mode: SparsityRequest<'_>) -> bool {
+        self.inner.eval_jac_g(x, new_x, mode)
+    }
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        self.inner
+            .eval_h(x, new_x, obj_factor, lambda, new_lambda, mode)
+    }
+    fn finalize_solution(&mut self, sol: Solution<'_>, ip_data: &IpoptData, ip_cq: &IpoptCq) {
+        self.captured = Some(NlpBatchSolution {
+            solver_status: sol.status,
+            x: sol.x.to_vec(),
+            z_l: sol.z_l.to_vec(),
+            z_u: sol.z_u.to_vec(),
+            g: sol.g.to_vec(),
+            lambda: sol.lambda.to_vec(),
+            obj: sol.obj_value,
+        });
+        self.inner.finalize_solution(sol, ip_data, ip_cq);
+    }
+    fn get_var_con_metadata(&mut self, var: &mut MetaData, con: &mut MetaData) -> bool {
+        self.inner.get_var_con_metadata(var, con)
+    }
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        self.inner.get_scaling_parameters(req)
+    }
+    fn get_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.get_variables_linearity(types)
+    }
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.get_constraints_linearity(types)
+    }
+    fn get_number_of_nonlinear_variables(&mut self) -> pounce_common::types::Index {
+        self.inner.get_number_of_nonlinear_variables()
+    }
+    fn get_list_of_nonlinear_variables(
+        &mut self,
+        pos_nonlin_vars: &mut [pounce_common::types::Index],
+    ) -> bool {
+        self.inner.get_list_of_nonlinear_variables(pos_nonlin_vars)
+    }
+    fn intermediate_callback(
+        &mut self,
+        stats: IterStats,
+        ip_data: &IpoptData,
+        ip_cq: &IpoptCq,
+    ) -> bool {
+        self.inner.intermediate_callback(stats, ip_data, ip_cq)
+    }
+    fn finalize_metadata(&mut self, var: &MetaData, con: &MetaData) {
+        self.inner.finalize_metadata(var, con)
+    }
+}
+
+/// Install an inner-serial FERAL backend on `app`, honoring any
+/// `feral_*` options already set (read the options *before* calling
+/// this if `configure` sets them — i.e. set options first, then call
+/// this). The `parallel = off` toggle is per-backend; concurrent
+/// solves on other threads are unaffected.
+pub fn install_serial_feral_backend(app: &mut IpoptApplication) {
+    let mut cfg = crate::application::feral_config_from_options(app.options());
+    cfg.parallel = Some(false);
+    app.set_linear_backend_factory(Box::new(move |_choice| {
+        Box::new(pounce_feral::FeralSolverInterface::with_config(cfg.clone()))
+    }));
+}
+
+/// Solve one instance with a fresh, caller-configured application.
+fn solve_nlp_one<T, C>(tnlp: T, configure: &mut C) -> NlpBatchResult
+where
+    T: TNLP + 'static,
+    C: FnMut(&mut IpoptApplication),
+{
+    let mut app = IpoptApplication::new();
+    configure(&mut app);
+    let cap = Rc::new(RefCell::new(CaptureTnlp {
+        inner: tnlp,
+        captured: None,
+    }));
+    let status = app.optimize_tnlp(Rc::clone(&cap) as Rc<RefCell<dyn TNLP>>);
+    let stats = app.statistics();
+    let solution = cap.borrow_mut().captured.take();
+    NlpBatchResult {
+        status,
+        solution,
+        stats,
+    }
+}
+
+/// Solve a batch of independent NLPs **sequentially**, returning one
+/// result per input in input order. `configure` is called once per
+/// instance on a fresh [`IpoptApplication`] (set options / backend /
+/// restoration there — see the module docs). Predictable and
+/// contention-free; the right choice when each instance is large
+/// enough that the linear-solver backend parallelizes internally.
+pub fn solve_nlp_batch<T, C>(problems: Vec<T>, mut configure: C) -> Vec<NlpBatchResult>
+where
+    T: TNLP + 'static,
+    C: FnMut(&mut IpoptApplication),
+{
+    problems
+        .into_iter()
+        .map(|t| solve_nlp_one(t, &mut configure))
+        .collect()
+}
+
+/// Solve a batch of independent NLPs **in parallel across instances**
+/// on rayon's global pool, returning one result per input in input
+/// order regardless of completion order. Best for many small / medium
+/// instances where cross-instance throughput beats parallelizing each
+/// factor internally.
+///
+/// Each worker owns its instance end-to-end: the `T: TNLP + Send`
+/// moves in, and the application, backend, and restoration strategy
+/// are all constructed *inside* the worker via `configure` (which must
+/// therefore be `Sync` — it is shared by reference and called once per
+/// instance). For the outer-parallel / inner-serial win, have
+/// `configure` install an inner-serial backend —
+/// [`install_serial_feral_backend`] after setting options.
+pub fn solve_nlp_batch_parallel<T, C>(problems: Vec<T>, configure: C) -> Vec<NlpBatchResult>
+where
+    T: TNLP + Send + 'static,
+    C: Fn(&mut IpoptApplication) + Sync,
+{
+    problems
+        .into_par_iter()
+        .map(|t| solve_nlp_one(t, &mut |app: &mut IpoptApplication| configure(app)))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pounce_nlp::tnlp::IndexStyle;
+
+    /// `min (x0 - a)^2 + (x1 - b)^2  s.t. x0 + x1 = s` — a tiny
+    /// per-instance-parameterized equality-constrained QP with an
+    /// analytic solution: `x = (a, b) + ((s - a - b)/2) * (1, 1)`.
+    struct ShiftedQuad {
+        a: f64,
+        b: f64,
+        s: f64,
+        /// Optional variable bounds (default free).
+        x_l: [f64; 2],
+        x_u: [f64; 2],
+    }
+
+    impl ShiftedQuad {
+        fn new(a: f64, b: f64, s: f64) -> Self {
+            Self {
+                a,
+                b,
+                s,
+                x_l: [-1e19; 2],
+                x_u: [1e19; 2],
+            }
+        }
+        fn expected(&self) -> [f64; 2] {
+            let t = (self.s - self.a - self.b) / 2.0;
+            [self.a + t, self.b + t]
+        }
+    }
+
+    impl TNLP for ShiftedQuad {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 2,
+                m: 1,
+                nnz_jac_g: 2,
+                nnz_h_lag: 2,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l.copy_from_slice(&self.x_l);
+            b.x_u.copy_from_slice(&self.x_u);
+            b.g_l[0] = self.s;
+            b.g_u[0] = self.s;
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            sp.x[0] = 0.0;
+            sp.x[1] = 0.0;
+            true
+        }
+        fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+            Some((x[0] - self.a).powi(2) + (x[1] - self.b).powi(2))
+        }
+        fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, grad_f: &mut [Number]) -> bool {
+            grad_f[0] = 2.0 * (x[0] - self.a);
+            grad_f[1] = 2.0 * (x[1] - self.b);
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g[0] = x[0] + x[1];
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow.copy_from_slice(&[0, 0]);
+                    jcol.copy_from_slice(&[0, 1]);
+                }
+                SparsityRequest::Values { values } => {
+                    values.copy_from_slice(&[1.0, 1.0]);
+                }
+            }
+            true
+        }
+        fn eval_h(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            obj_factor: Number,
+            _lambda: Option<&[Number]>,
+            _new_lambda: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow.copy_from_slice(&[0, 1]);
+                    jcol.copy_from_slice(&[0, 1]);
+                }
+                SparsityRequest::Values { values } => {
+                    values.copy_from_slice(&[2.0 * obj_factor, 2.0 * obj_factor]);
+                }
+            }
+            true
+        }
+        fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+    }
+
+    fn configure(app: &mut IpoptApplication) {
+        let _ = app
+            .options_mut()
+            .set_integer_value("print_level", 0, true, false);
+        install_serial_feral_backend(app);
+    }
+
+    fn batch(k: usize) -> Vec<ShiftedQuad> {
+        (0..k)
+            .map(|i| ShiftedQuad::new(1.0 + i as f64, 2.0, 1.0 + (i % 3) as f64))
+            .collect()
+    }
+
+    #[test]
+    fn empty_batch_returns_empty() {
+        let out = solve_nlp_batch_parallel(Vec::<ShiftedQuad>::new(), configure);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_element_batch_solves() {
+        let probs = batch(1);
+        let expected = probs[0].expected();
+        let out = solve_nlp_batch_parallel(probs, configure);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].status, ApplicationReturnStatus::SolveSucceeded);
+        let sol = out[0].solution.as_ref().expect("solution captured");
+        assert!((sol.x[0] - expected[0]).abs() < 1e-6);
+        assert!((sol.x[1] - expected[1]).abs() < 1e-6);
+    }
+
+    #[test]
+    fn parallel_results_in_input_order_and_match_sequential() {
+        let k = 8;
+        let expected: Vec<[f64; 2]> = batch(k).iter().map(|p| p.expected()).collect();
+        let par = solve_nlp_batch_parallel(batch(k), configure);
+        let seq = solve_nlp_batch(batch(k), configure);
+        assert_eq!(par.len(), k);
+        for i in 0..k {
+            assert_eq!(
+                par[i].status,
+                ApplicationReturnStatus::SolveSucceeded,
+                "instance {i}"
+            );
+            let ps = par[i].solution.as_ref().expect("parallel solution");
+            let ss = seq[i].solution.as_ref().expect("sequential solution");
+            // Input order: each instance's analytic optimum.
+            assert!(
+                (ps.x[0] - expected[i][0]).abs() < 1e-6 && (ps.x[1] - expected[i][1]).abs() < 1e-6,
+                "instance {i}: got {:?}, expected {:?}",
+                ps.x,
+                expected[i]
+            );
+            // Parallel and sequential agree (same algorithm, same
+            // serial backend — bit-for-bit).
+            assert_eq!(ps.x, ss.x, "instance {i}");
+            assert_eq!(
+                par[i].stats.iteration_count, seq[i].stats.iteration_count,
+                "instance {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn infeasible_instance_mixed_in_does_not_poison_batch() {
+        // Middle instance has contradictory bounds vs. the equality
+        // row: x0 + x1 = 10 with x <= 1 componentwise.
+        let mut probs = batch(3);
+        probs[1].s = 10.0;
+        probs[1].x_u = [1.0; 2];
+        let out = solve_nlp_batch_parallel(probs, configure);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].status, ApplicationReturnStatus::SolveSucceeded);
+        assert_eq!(out[2].status, ApplicationReturnStatus::SolveSucceeded);
+        assert_ne!(
+            out[1].status,
+            ApplicationReturnStatus::SolveSucceeded,
+            "infeasible instance must not report success"
+        );
+    }
+
+    /// Ragged convergence: mix trivially-easy instances with ones that
+    /// start far away; per-instance iteration counts may differ and
+    /// every result still lands at its own optimum in input order.
+    #[test]
+    fn ragged_iteration_counts_keep_order() {
+        let probs: Vec<ShiftedQuad> = (0..6)
+            .map(|i| ShiftedQuad::new(10f64.powi(i - 3), 2.0, 1.0))
+            .collect();
+        let expected: Vec<[f64; 2]> = probs.iter().map(|p| p.expected()).collect();
+        let out = solve_nlp_batch_parallel(probs, configure);
+        for (i, r) in out.iter().enumerate() {
+            assert_eq!(r.status, ApplicationReturnStatus::SolveSucceeded);
+            let sol = r.solution.as_ref().expect("solution");
+            assert!(
+                (sol.x[0] - expected[i][0]).abs() < 1e-5
+                    && (sol.x[1] - expected[i][1]).abs() < 1e-5,
+                "instance {i}: got {:?}, expected {:?}",
+                sol.x,
+                expected[i]
+            );
+        }
+    }
+}

--- a/crates/pounce-algorithm/src/batch.rs
+++ b/crates/pounce-algorithm/src/batch.rs
@@ -554,6 +554,16 @@ impl<T: TNLP> TNLP for WarmStartTnlp<T> {
 }
 
 /// Solve one instance with a fresh, caller-configured application.
+///
+/// Panic-isolated: a Rust panic raised *during* the solve — a user
+/// `eval_*`/`intermediate_callback` that panics, or a backend assertion
+/// tripping on malformed structure — is caught here and reported as an
+/// [`ApplicationReturnStatus::InternalError`] row. Without this guard the
+/// panic would unwind out of the rayon `map`/`collect` (or the sequential
+/// `map`) and discard *every other instance's* result, so a single bad
+/// instance would poison the whole batch. (Solver-detected failures —
+/// infeasibility, invalid numbers, eval callbacks that *return* failure —
+/// are already reported as ordinary statuses and never reach this path.)
 fn solve_nlp_one<T, C>(index: usize, tnlp: T, configure: &mut C) -> NlpBatchResult
 where
     T: TNLP + 'static,
@@ -565,14 +575,24 @@ where
         inner: tnlp,
         captured: None,
     }));
-    let status = app.optimize_tnlp(Rc::clone(&cap) as Rc<RefCell<dyn TNLP>>);
-    let stats = app.statistics();
-    let solution = cap.borrow_mut().captured.take();
-    NlpBatchResult {
-        status,
-        solution,
-        stats,
-    }
+    // `AssertUnwindSafe`: on a caught panic we discard `app`/`cap` without
+    // observing them, so any broken interior-mutability invariant cannot
+    // leak out — only the freshly-built `InternalError` row is returned.
+    let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let status = app.optimize_tnlp(Rc::clone(&cap) as Rc<RefCell<dyn TNLP>>);
+        let stats = app.statistics();
+        let solution = cap.borrow_mut().captured.take();
+        NlpBatchResult {
+            status,
+            solution,
+            stats,
+        }
+    }));
+    outcome.unwrap_or_else(|_| NlpBatchResult {
+        status: ApplicationReturnStatus::InternalError,
+        solution: None,
+        stats: SolveStatistics::default(),
+    })
 }
 
 /// Solve a batch of independent NLPs **sequentially**, returning one
@@ -824,6 +844,62 @@ mod tests {
             .collect()
     }
 
+    /// A `ShiftedQuad` that panics inside `eval_f` when `boom` — stands in
+    /// for any Rust panic raised mid-solve (a buggy user callback, a backend
+    /// assertion). Used to prove panic isolation: the panicking instance must
+    /// fail only itself, not unwind the whole batch.
+    struct BoomQuad {
+        inner: ShiftedQuad,
+        boom: bool,
+    }
+
+    impl TNLP for BoomQuad {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            self.inner.get_nlp_info()
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            self.inner.get_bounds_info(b)
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            self.inner.get_starting_point(sp)
+        }
+        fn eval_f(&mut self, x: &[Number], new_x: bool) -> Option<Number> {
+            if self.boom {
+                panic!("boom: simulated mid-solve panic in eval_f");
+            }
+            self.inner.eval_f(x, new_x)
+        }
+        fn eval_grad_f(&mut self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool {
+            self.inner.eval_grad_f(x, new_x, grad_f)
+        }
+        fn eval_g(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+            self.inner.eval_g(x, new_x, g)
+        }
+        fn eval_jac_g(
+            &mut self,
+            x: Option<&[Number]>,
+            new_x: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            self.inner.eval_jac_g(x, new_x, mode)
+        }
+        fn eval_h(
+            &mut self,
+            x: Option<&[Number]>,
+            new_x: bool,
+            obj_factor: Number,
+            lambda: Option<&[Number]>,
+            new_lambda: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            self.inner
+                .eval_h(x, new_x, obj_factor, lambda, new_lambda, mode)
+        }
+        fn finalize_solution(&mut self, sol: Solution<'_>, d: &IpoptData, q: &IpoptCq) {
+            self.inner.finalize_solution(sol, d, q)
+        }
+    }
+
     #[test]
     fn empty_batch_returns_empty() {
         let out = solve_nlp_batch_parallel(Vec::<ShiftedQuad>::new(), configure);
@@ -890,6 +966,56 @@ mod tests {
             ApplicationReturnStatus::SolveSucceeded,
             "infeasible instance must not report success"
         );
+    }
+
+    #[test]
+    fn panicking_instance_does_not_poison_batch() {
+        // Middle instance panics inside `eval_f`; the surrounding good
+        // instances must still solve, the batch must keep input order, and
+        // the panicking row must surface as `InternalError` — not unwind the
+        // whole `collect()`. The default panic hook still prints the message;
+        // that is fine (and useful) — only the unwind is contained.
+        let good = batch(3);
+        let expected: Vec<[f64; 2]> = good.iter().map(|p| p.expected()).collect();
+        let probs: Vec<BoomQuad> = good
+            .into_iter()
+            .enumerate()
+            .map(|(i, inner)| BoomQuad {
+                inner,
+                boom: i == 1,
+            })
+            .collect();
+        let out = solve_nlp_batch_parallel(probs, configure);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[1].status, ApplicationReturnStatus::InternalError);
+        assert!(
+            out[1].solution.is_none(),
+            "a panicked instance carries no captured solution"
+        );
+        for i in [0, 2] {
+            assert_eq!(out[i].status, ApplicationReturnStatus::SolveSucceeded);
+            let sol = out[i].solution.as_ref().expect("solution");
+            assert!(
+                (sol.x[0] - expected[i][0]).abs() < 1e-6
+                    && (sol.x[1] - expected[i][1]).abs() < 1e-6,
+                "instance {i}: got {:?}, expected {:?}",
+                sol.x,
+                expected[i]
+            );
+        }
+        // The sequential path is panic-isolated too (same `solve_nlp_one`).
+        let probs_seq: Vec<BoomQuad> = batch(3)
+            .into_iter()
+            .enumerate()
+            .map(|(i, inner)| BoomQuad {
+                inner,
+                boom: i == 1,
+            })
+            .collect();
+        let seq = solve_nlp_batch(probs_seq, configure);
+        assert_eq!(seq[1].status, ApplicationReturnStatus::InternalError);
+        assert_eq!(seq[0].status, ApplicationReturnStatus::SolveSucceeded);
+        assert_eq!(seq[2].status, ApplicationReturnStatus::SolveSucceeded);
     }
 
     /// Warm-start chain (the MPC shape): solve a batch cold, perturb

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod alg_builder;
 pub mod application;
+pub mod batch;
 pub mod conv_check;
 pub mod debug;
 pub mod debug_rank;
@@ -47,6 +48,10 @@ pub mod timing_stats;
 pub mod upstream_options;
 
 pub use application::IpoptApplication;
+pub use batch::{
+    install_serial_feral_backend, solve_nlp_batch, solve_nlp_batch_parallel, NlpBatchResult,
+    NlpBatchSolution,
+};
 pub use ipopt_cq::{IpoptCalculatedQuantities, IpoptCqHandle};
 pub use ipopt_data::{IpoptData, IpoptDataHandle, PdPerturbations};
 pub use ipopt_nlp::{IpoptNlp, Nlp};

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -49,8 +49,9 @@ pub mod upstream_options;
 
 pub use application::IpoptApplication;
 pub use batch::{
-    install_serial_feral_backend, solve_nlp_batch, solve_nlp_batch_parallel, NlpBatchResult,
-    NlpBatchSolution,
+    install_pooled_serial_feral_backend, install_serial_feral_backend, solve_nlp_batch,
+    solve_nlp_batch_parallel, solve_nlp_batch_parallel_warm, solve_nlp_batch_warm,
+    FeralBackendPool, NlpBatchResult, NlpBatchSolution, NlpWarmStart,
 };
 pub use ipopt_cq::{IpoptCalculatedQuantities, IpoptCqHandle};
 pub use ipopt_data::{IpoptData, IpoptDataHandle, PdPerturbations};

--- a/crates/pounce-cli/src/nl_hessian_program.rs
+++ b/crates/pounce-cli/src/nl_hessian_program.rs
@@ -1350,7 +1350,7 @@ mod tests {
     use super::*;
     use crate::nl_reader::{BinOp, Expr, UnaryOp};
     use std::collections::BTreeSet;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     fn cnst(c: f64) -> Expr {
         Expr::Const(c)
@@ -1461,7 +1461,7 @@ mod tests {
 
     #[test]
     fn matches_through_cse() {
-        let body = Rc::new(add(var(0), var(1)));
+        let body = Arc::new(add(var(0), var(1)));
         let e = add(
             pow(Expr::Cse(body.clone()), cnst(2.0)),
             Expr::Cse(body.clone()),

--- a/crates/pounce-cli/tests/nlp_batch.rs
+++ b/crates/pounce-cli/tests/nlp_batch.rs
@@ -1,0 +1,145 @@
+//! End-to-end batched NLP solve (pounce#126) on a real `.nl` model.
+//!
+//! Exercises the full native-Rust path the issue targets: parse
+//! `tests/fixtures/parametric.nl` once, build per-instance [`NlTnlp`]
+//! variants (multi-start x0, tightened bounds — the branch-and-bound
+//! node shape), and solve them on rayon via
+//! [`pounce_algorithm::solve_nlp_batch_parallel`] with the same
+//! fully-equipped application recipe the CLI / Python bindings use
+//! (serial FERAL backend per worker + restoration-factory provider).
+//!
+//! Checks the acceptance criteria from the issue:
+//! - results come back in input order, one per instance;
+//! - the batch result for the unmodified model matches a
+//!   single-problem `optimize_tnlp` of the same instance bit-for-bit
+//!   (same algorithm, same deterministic serial backend);
+//! - a bound-tightened instance honors its own bounds while its
+//!   siblings are unaffected.
+
+use pounce_algorithm::application::{default_backend_factory, feral_config_from_options};
+use pounce_algorithm::{install_serial_feral_backend, solve_nlp_batch_parallel, IpoptApplication};
+use pounce_nl::nl_reader::{read_nl_file, NlTnlp, NlVariation};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::TNLP;
+use pounce_restoration::resto_alg_builder::RestoAlgorithmBuilder;
+use pounce_restoration::resto_inner_solver::{
+    make_default_restoration_factory_provider, InnerBackendFactoryFactory,
+};
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
+
+fn parametric_nl() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("parametric.nl");
+    p
+}
+
+/// The per-worker application recipe: quiet, inner-serial FERAL
+/// backend, and the default restoration-phase provider — the same
+/// wiring `pounce-cli`'s solve path and `pounce-py`'s
+/// `Problem::prepare` install for a single solve.
+fn configure(app: &mut IpoptApplication) {
+    let _ = app
+        .options_mut()
+        .set_integer_value("print_level", 0, true, false);
+    install_serial_feral_backend(app);
+    let mut feral_cfg = feral_config_from_options(app.options());
+    feral_cfg.parallel = Some(false);
+    let bff_mint = move || -> InnerBackendFactoryFactory {
+        let feral_cfg = feral_cfg.clone();
+        Box::new(move || default_backend_factory(feral_cfg.clone()))
+    };
+    let resto_provider = make_default_restoration_factory_provider(
+        RestoAlgorithmBuilder::new(),
+        app.algorithm_builder_from_options(),
+        bff_mint,
+    );
+    app.set_restoration_factory_provider(resto_provider);
+}
+
+#[test]
+fn nl_batch_matches_single_solve_and_honors_variants() {
+    let prob = read_nl_file(&parametric_nl()).expect("parse parametric.nl");
+    let base = NlTnlp::new(prob);
+    let n = base.problem().n;
+
+    // Reference: single-problem solve of the unmodified model.
+    let mut app = IpoptApplication::new();
+    configure(&mut app);
+    let single = Rc::new(RefCell::new(base.clone()));
+    let status = app.optimize_tnlp(Rc::clone(&single) as Rc<RefCell<dyn TNLP>>);
+    assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+    let single_x: Vec<f64> = single
+        .borrow()
+        .final_x()
+        .expect("single solve final x")
+        .to_vec();
+    let single_iters = app.statistics().iteration_count;
+
+    // Batch: [unmodified, multi-start x0, x0-tightened-bound node].
+    let mut x0_shift = base.problem().x0.clone();
+    for v in &mut x0_shift {
+        *v += 0.1;
+    }
+    let mut xu_tight = base.problem().x_u.clone();
+    xu_tight[0] = single_x[0] - 0.05; // force an active bound vs. instance 0
+    let variants = base
+        .variants(&[
+            NlVariation::default(),
+            NlVariation {
+                x0: Some(x0_shift),
+                ..Default::default()
+            },
+            NlVariation {
+                x_u: Some(xu_tight.clone()),
+                ..Default::default()
+            },
+        ])
+        .expect("variants");
+
+    let results = solve_nlp_batch_parallel(variants, configure);
+    assert_eq!(results.len(), 3, "one result per instance, input order");
+    for (i, r) in results.iter().enumerate() {
+        assert_eq!(
+            r.status,
+            ApplicationReturnStatus::SolveSucceeded,
+            "instance {i}"
+        );
+        let sol = r.solution.as_ref().expect("captured solution");
+        assert_eq!(sol.x.len(), n);
+    }
+
+    // Instance 0 (unmodified) reproduces the single solve bit-for-bit.
+    let batch0 = results[0].solution.as_ref().unwrap();
+    assert_eq!(
+        batch0.x, single_x,
+        "batched solve of the unmodified instance must match the single solve"
+    );
+    assert_eq!(results[0].stats.iteration_count, single_iters);
+
+    // Instance 1 (shifted multi-start) converges to the same optimum.
+    let batch1 = results[1].solution.as_ref().unwrap();
+    for j in 0..n {
+        assert!(
+            (batch1.x[j] - single_x[j]).abs() < 1e-5,
+            "multi-start instance must reach the same optimum (x[{j}])"
+        );
+    }
+
+    // Instance 2 (tightened upper bound on x0) honors its own bound
+    // and is genuinely different from instance 0.
+    let batch2 = results[2].solution.as_ref().unwrap();
+    assert!(
+        batch2.x[0] <= xu_tight[0] + 1e-8,
+        "tightened bound must be honored: x[0] = {} > {}",
+        batch2.x[0],
+        xu_tight[0]
+    );
+    assert!(
+        (batch2.x[0] - batch0.x[0]).abs() > 1e-6,
+        "bound-tightened instance must differ from the unmodified one"
+    );
+}

--- a/crates/pounce-cli/tests/nlp_batch.rs
+++ b/crates/pounce-cli/tests/nlp_batch.rs
@@ -41,7 +41,7 @@ fn parametric_nl() -> PathBuf {
 /// backend, and the default restoration-phase provider — the same
 /// wiring `pounce-cli`'s solve path and `pounce-py`'s
 /// `Problem::prepare` install for a single solve.
-fn configure(app: &mut IpoptApplication) {
+fn configure(_i: usize, app: &mut IpoptApplication) {
     let _ = app
         .options_mut()
         .set_integer_value("print_level", 0, true, false);
@@ -68,7 +68,7 @@ fn nl_batch_matches_single_solve_and_honors_variants() {
 
     // Reference: single-problem solve of the unmodified model.
     let mut app = IpoptApplication::new();
-    configure(&mut app);
+    configure(0, &mut app);
     let single = Rc::new(RefCell::new(base.clone()));
     let status = app.optimize_tnlp(Rc::clone(&single) as Rc<RefCell<dyn TNLP>>);
     assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);

--- a/crates/pounce-nl/src/nl_fbbt_translate.rs
+++ b/crates/pounce-nl/src/nl_fbbt_translate.rs
@@ -4,12 +4,12 @@
 //! The `Expr` tree pounce reads from a `.nl` file uses a richer
 //! operator set than FBBT supports (extern function calls,
 //! variable-exponent powers, AMPL `log10`, n-ary sums) and embeds
-//! common subexpressions via `Rc` sharing. This module flattens
+//! common subexpressions via `Arc` sharing. This module flattens
 //! the tree into a tape where:
 //!
 //! * Every `Expr::Cse(rc)` is emitted **once** and re-referenced by
 //!   slot index on every subsequent occurrence — matching the
-//!   per-Rc-pointer caching strategy `nl_tape::Tape::build` already
+//!   per-Arc-pointer caching strategy `nl_tape::Tape::build` already
 //!   uses for AD tapes.
 //! * Operators FBBT can reason about become the corresponding
 //!   [`FbbtOp`] variants.
@@ -26,7 +26,7 @@
 //! [#62]: https://github.com/jkitchin/pounce/issues/62
 
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 
 use pounce_common::types::Number;
 use pounce_nlp::expression_provider::{FbbtOp, FbbtTape};
@@ -36,7 +36,7 @@ use crate::nl_reader::{BinOp, Expr, UnaryOp};
 /// Result of translating one `Expr` into a tape.
 struct Builder {
     ops: Vec<FbbtOp>,
-    /// CSE cache: `Rc::as_ptr` → tape slot of the body.
+    /// CSE cache: `Arc::as_ptr` → tape slot of the body.
     cse_cache: HashMap<*const Expr, usize>,
 }
 
@@ -61,7 +61,7 @@ impl Builder {
             Expr::Const(v) => self.emit(FbbtOp::Const(*v)),
             Expr::Var(i) => self.emit(FbbtOp::Var(*i)),
             Expr::Cse(rc) => {
-                let key = Rc::as_ptr(rc);
+                let key = Arc::as_ptr(rc);
                 if let Some(&slot) = self.cse_cache.get(&key) {
                     return slot;
                 }
@@ -354,14 +354,14 @@ mod tests {
     #[test]
     fn cse_shared_body_emitted_once() {
         // body = x + 1; (body * 2) + body
-        let body = Rc::new(Expr::Binary(
+        let body = Arc::new(Expr::Binary(
             BinOp::Add,
             Box::new(Expr::Var(0)),
             Box::new(Expr::Const(1.0)),
         ));
         let two_body = Expr::Binary(
             BinOp::Mul,
-            Box::new(Expr::Cse(Rc::clone(&body))),
+            Box::new(Expr::Cse(Arc::clone(&body))),
             Box::new(Expr::Const(2.0)),
         );
         let total = Expr::Binary(BinOp::Add, Box::new(two_body), Box::new(Expr::Cse(body)));
@@ -421,10 +421,10 @@ mod tests {
     #[test]
     fn translated_tape_is_well_formed() {
         // A messy expression mixing CSEs, unary, binary, sums.
-        let body = Rc::new(Expr::Unary(UnaryOp::Exp, Box::new(Expr::Var(0))));
+        let body = Arc::new(Expr::Unary(UnaryOp::Exp, Box::new(Expr::Var(0))));
         let e = Expr::Binary(
             BinOp::Add,
-            Box::new(Expr::Cse(Rc::clone(&body))),
+            Box::new(Expr::Cse(Arc::clone(&body))),
             Box::new(Expr::Binary(
                 BinOp::Mul,
                 Box::new(Expr::Cse(body)),

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -41,6 +41,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 use std::rc::Rc;
+use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 pub enum Expr {
@@ -57,12 +58,15 @@ pub enum Expr {
     Sum(Vec<Expr>),
     /// Reference to a common subexpression (`.nl` `V` segment). The
     /// payload is a shared body; many references to the same CSE share
-    /// one `Rc`, so the parsed problem is a DAG. Walking through `Cse`
+    /// one `Arc`, so the parsed problem is a DAG. Walking through `Cse`
     /// is mathematically equivalent to inlining the body at each
     /// occurrence (every reference is an independent occurrence in the
     /// chain rule), so eval/grad/collect_vars just recurse into the
-    /// inner `Expr`.
-    Cse(Rc<Expr>),
+    /// inner `Expr`. The pointer is atomically refcounted (`Arc`, not
+    /// `Rc`) so a parsed problem — and the `NlTnlp` built from it —
+    /// is `Send` and can move to a rayon worker for batched solving
+    /// (pounce#126); sharing is still read-only after parse.
+    Cse(Arc<Expr>),
     /// AMPL imported (external) function call. `id` matches an entry in
     /// `NlProblem.imported_funcs`; resolution to a live shared library
     /// happens when the tape is built (see `nl_external::ExternalResolver`).
@@ -692,7 +696,7 @@ struct Parser<'a> {
     n_funcs: usize,
     /// Common subexpressions (`V` segments). Index in this vec is the
     /// CSE-local index, i.e. the global `.nl` index minus `n`.
-    cses: Vec<Rc<Expr>>,
+    cses: Vec<Arc<Expr>>,
 }
 
 impl<'a> Parser<'a> {
@@ -1061,7 +1065,7 @@ impl<'a> Parser<'a> {
                 self.n + self.cses.len()
             ));
         }
-        self.cses.push(Rc::new(combined));
+        self.cses.push(Arc::new(combined));
         Ok(())
     }
 }
@@ -1390,7 +1394,11 @@ struct ColorWrite {
     hess_idx: u32,
 }
 
-#[derive(Debug)]
+// `Clone` supports the batched-solve path (pounce#126): one parsed
+// model is cloned per batch instance (tapes are flat `Vec`s of ops, so
+// the clone is cheap relative to a solve) and each clone gets its own
+// bound / starting-point overrides via [`NlTnlp::variant`].
+#[derive(Debug, Clone)]
 pub struct NlTnlp {
     prob: NlProblem,
     /// Per-summand objective tapes (one `Tape` per top-level
@@ -2142,6 +2150,82 @@ impl NlTnlp {
     pub fn final_obj(&self) -> Number {
         self.final_obj
     }
+
+    /// The parsed problem this TNLP evaluates (bounds, starting point,
+    /// names, suffixes). Read-only; per-instance overrides go through
+    /// [`Self::variant`].
+    pub fn problem(&self) -> &NlProblem {
+        &self.prob
+    }
+
+    /// Clone this TNLP with per-instance overrides applied — the
+    /// "one structure, many bound / starting-point variations" case of
+    /// batched NLP solving (pounce#126). The AD tapes, sparsity, and
+    /// coloring are reused via `Clone` (they depend only on the model
+    /// structure, which a variation cannot change); only the values in
+    /// `prob.x0` / `prob.x_l` / `prob.x_u` / `prob.g_l` / `prob.g_u`
+    /// are replaced. Any stale `final_x` from a previous solve of
+    /// `self` is cleared on the clone.
+    ///
+    /// Errors when an override's length does not match the model
+    /// (`n` for `x0`/`x_l`/`x_u`, `m` for `g_l`/`g_u`).
+    pub fn variant(&self, v: &NlVariation) -> Result<Self, String> {
+        let check = |name: &str, got: usize, want: usize| -> Result<(), String> {
+            if got == want {
+                Ok(())
+            } else {
+                Err(format!(
+                    "NlVariation.{name} has length {got}, expected {want}"
+                ))
+            }
+        };
+        let mut out = self.clone();
+        out.final_x = None;
+        out.final_obj = 0.0;
+        if let Some(x0) = &v.x0 {
+            check("x0", x0.len(), self.prob.n)?;
+            out.prob.x0.clone_from(x0);
+        }
+        if let Some(x_l) = &v.x_l {
+            check("x_l", x_l.len(), self.prob.n)?;
+            out.prob.x_l.clone_from(x_l);
+        }
+        if let Some(x_u) = &v.x_u {
+            check("x_u", x_u.len(), self.prob.n)?;
+            out.prob.x_u.clone_from(x_u);
+        }
+        if let Some(g_l) = &v.g_l {
+            check("g_l", g_l.len(), self.prob.m)?;
+            out.prob.g_l.clone_from(g_l);
+        }
+        if let Some(g_u) = &v.g_u {
+            check("g_u", g_u.len(), self.prob.m)?;
+            out.prob.g_u.clone_from(g_u);
+        }
+        Ok(out)
+    }
+
+    /// Build one [`NlTnlp`] per variation, sharing this instance's
+    /// structure (see [`Self::variant`]). Returns instances in input
+    /// order; errors on the first length-mismatched variation.
+    pub fn variants(&self, vs: &[NlVariation]) -> Result<Vec<Self>, String> {
+        vs.iter().map(|v| self.variant(v)).collect()
+    }
+}
+
+/// Per-instance overrides for building a family of related NLP
+/// instances from one parsed `.nl` model (pounce#126): same structure
+/// and tapes, different starting point and/or bounds — parametric
+/// sweeps, multi-start, or branch-and-bound node relaxations where
+/// each node only tightens variable bounds. `None` keeps the base
+/// model's value.
+#[derive(Debug, Clone, Default)]
+pub struct NlVariation {
+    pub x0: Option<Vec<Number>>,
+    pub x_l: Option<Vec<Number>>,
+    pub x_u: Option<Vec<Number>>,
+    pub g_l: Option<Vec<Number>>,
+    pub g_u: Option<Vec<Number>>,
 }
 
 impl pounce_nlp::expression_provider::ExpressionProvider for NlTnlp {
@@ -2430,6 +2514,66 @@ pub fn load_nl_as_tnlp(path: &Path) -> Result<Rc<RefCell<dyn TNLP>>, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Compile-time guarantee for the batched-solve path (pounce#126):
+    /// a parsed problem and the TNLP built from it must be movable to a
+    /// rayon worker. Regresses if anyone reintroduces an `Rc` (or other
+    /// `!Send` state) into the `Expr` DAG / tape pipeline.
+    #[test]
+    fn nl_problem_and_tnlp_are_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<NlProblem>();
+        assert_send::<NlTnlp>();
+        assert_send::<Expr>();
+    }
+
+    /// `variant()` patches starting point / bounds on a clone and
+    /// validates override lengths; the base instance is untouched.
+    #[test]
+    fn variant_overrides_bounds_and_x0() {
+        let p = parse_nl_text(SIMPLE).expect("parse");
+        let mut base = NlTnlp::new(p);
+        let var = base
+            .variant(&NlVariation {
+                x0: Some(vec![3.0, 4.0]),
+                x_l: Some(vec![-1.0, -2.0]),
+                x_u: Some(vec![5.0, 6.0]),
+                ..Default::default()
+            })
+            .expect("variant");
+        let mut var = var;
+        let (mut x_l, mut x_u) = ([0.0; 2], [0.0; 2]);
+        let (mut g_l, mut g_u) = ([0.0; 0], [0.0; 0]);
+        assert!(var.get_bounds_info(BoundsInfo {
+            x_l: &mut x_l,
+            x_u: &mut x_u,
+            g_l: &mut g_l,
+            g_u: &mut g_u,
+        }));
+        assert_eq!(x_l, [-1.0, -2.0]);
+        assert_eq!(x_u, [5.0, 6.0]);
+        let mut x = [0.0; 2];
+        let (mut zl, mut zu, mut lam) = ([0.0; 2], [0.0; 2], [0.0; 0]);
+        assert!(var.get_starting_point(StartingPoint {
+            init_x: true,
+            x: &mut x,
+            init_z: false,
+            z_l: &mut zl,
+            z_u: &mut zu,
+            init_lambda: false,
+            lambda: &mut lam,
+        }));
+        assert_eq!(x, [3.0, 4.0]);
+        // Base keeps its parsed (free) bounds.
+        assert!(base.problem().x_l[0] < -1.0e18);
+        // Length mismatch is an error, not a panic.
+        assert!(base
+            .variant(&NlVariation {
+                x0: Some(vec![1.0]),
+                ..Default::default()
+            })
+            .is_err());
+    }
 
     /// `min (x0 - 1)^2 + (x1 - 2)^2` written in `.nl` ASCII form.
     /// Header values:

--- a/crates/pounce-nl/src/nl_tape.rs
+++ b/crates/pounce-nl/src/nl_tape.rs
@@ -16,14 +16,13 @@
 //! Lagrangian term lands in the right slot.
 //!
 //! Common subexpressions are tape-emitted **once**: when the recursive
-//! builder hits `Expr::Cse(rc)` it keys on the `Rc` pointer identity,
+//! builder hits `Expr::Cse(rc)` it keys on the `Arc` pointer identity,
 //! emitting the body the first time and returning the cached
 //! result-slot index on subsequent references. The forward pass then
 //! computes each CSE once and the reverse pass folds adjoints from
 //! every reference into a single slot — exact chain-rule behaviour.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::rc::Rc;
 use std::sync::Arc;
 
 use super::nl_external::{EvalResult, ExternalArg, ExternalLibrary, ExternalResolver};
@@ -176,7 +175,7 @@ pub struct Tape {
 
 impl Tape {
     /// Build a tape from an `Expr` tree (no AMPL external functions). CSE
-    /// bodies (`Expr::Cse(rc)`) are cached by `Rc` pointer identity so each
+    /// bodies (`Expr::Cse(rc)`) are cached by `Arc` pointer identity so each
     /// body is emitted once even when referenced many times.
     pub fn build(expr: &Expr) -> Self {
         Self::build_with_externals(expr, &ExternalResolver::default())
@@ -1639,13 +1638,13 @@ fn build_recursive(
             acc
         }
         Expr::Cse(body) => {
-            // Cache by Rc identity so each shared body is emitted into
+            // Cache by Arc identity so each shared body is emitted into
             // the tape exactly once and every reference resolves to the
             // same result-slot index. Forward computes the body once;
             // reverse-mode adjoint sums contributions from every ref
             // into that shared slot — exact chain rule for shared
             // sub-expressions.
-            let key = Rc::as_ptr(body) as *const Expr;
+            let key = Arc::as_ptr(body) as *const Expr;
             if let Some(&idx) = cache.get(&key) {
                 idx
             } else {
@@ -2199,7 +2198,7 @@ fn count_cse_appearances(
             count_cse_appearances(else_, seen_in_root, counts);
         }
         Expr::Cse(body) => {
-            let key = Rc::as_ptr(body) as *const Expr;
+            let key = Arc::as_ptr(body) as *const Expr;
             if seen_in_root.insert(key) {
                 *counts.entry(key).or_insert(0) += 1;
                 count_cse_appearances(body, seen_in_root, counts);
@@ -2219,7 +2218,7 @@ fn count_cse_appearances(
 /// (≥ 2 roots reference them per `cse_count`) get a single prelude
 /// emission via `build_recursive`; the summand records a Shared op
 /// pointing at the prelude slot. Non-promoted CSEs are inlined
-/// into the summand with intra-summand Rc-pointer dedup.
+/// into the summand with intra-summand Arc-pointer dedup.
 fn build_into_summand(
     expr: &Expr,
     local: &mut Vec<SummandOp>,
@@ -2317,7 +2316,7 @@ fn build_into_summand(
             acc
         }
         Expr::Cse(body) => {
-            let key = Rc::as_ptr(body) as *const Expr;
+            let key = Arc::as_ptr(body) as *const Expr;
             if let Some(&li) = local_cache.get(&key) {
                 return li;
             }
@@ -2326,7 +2325,7 @@ fn build_into_summand(
                 // Build (or reuse) the prelude slot for this CSE.
                 // `build_recursive(expr, ...)` hits the Cse arm,
                 // emits the body once into prelude, and caches it
-                // in `prelude_map` keyed by this Rc pointer.
+                // in `prelude_map` keyed by this Arc pointer.
                 let pslot =
                     build_recursive(expr, prelude, prelude_map, &ExternalResolver::default());
                 let li = local.len();
@@ -3490,8 +3489,8 @@ mod tests {
 
     #[test]
     fn cse_shared_body_evaluated_once() {
-        // body = x0 + x1, shared via Rc. f = body^2 + body.
-        let body = Rc::new(add(var(0), var(1)));
+        // body = x0 + x1, shared via Arc. f = body^2 + body.
+        let body = Arc::new(add(var(0), var(1)));
         let e = add(
             pow(Expr::Cse(body.clone()), cnst(2.0)),
             Expr::Cse(body.clone()),
@@ -4002,7 +4001,7 @@ mod tests {
     #[test]
     fn pow_const_through_cse_const() {
         // Exponent wrapped in Cse — peek_const should still see it.
-        let two = Rc::new(cnst(2.0));
+        let two = Arc::new(cnst(2.0));
         let e = Expr::Binary(BinOp::Pow, Box::new(var(0)), Box::new(Expr::Cse(two)));
         let t = Tape::build(&e);
         assert_eq!(count_op(&t, |o| matches!(o, TapeOp::Pow(..))), 0);
@@ -4037,7 +4036,7 @@ mod tests {
     fn hessian_sparsity_through_cse() {
         // body = x0+x1 (CSE). f = body^2 + body.
         // d²/dx² of body^2 couples (0,0), (1,0), (1,1).
-        let body = Rc::new(add(var(0), var(1)));
+        let body = Arc::new(add(var(0), var(1)));
         let e = add(
             pow(Expr::Cse(body.clone()), cnst(2.0)),
             Expr::Cse(body.clone()),

--- a/crates/pounce-py/src/lib.rs
+++ b/crates/pounce-py/src/lib.rs
@@ -20,6 +20,7 @@
 use pyo3::prelude::*;
 
 mod nl_problem;
+mod nlp_batch;
 mod problem;
 mod qp;
 mod solver;
@@ -45,6 +46,8 @@ fn _pounce(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySolver>()?;
     m.add_class::<PyNlProblem>()?;
     m.add_function(wrap_pyfunction!(read_nl, m)?)?;
+    // Batched NLP solving, native `.nl` path (pounce#126).
+    m.add_function(wrap_pyfunction!(nlp_batch::solve_nlp_batch, m)?)?;
     m.add_function(wrap_pyfunction!(warm_start::classify_working_set, m)?)?;
     // Convex LP/QP solver (pounce-convex) bindings.
     m.add_class::<PyQpProblem>()?;

--- a/crates/pounce-py/src/lib.rs
+++ b/crates/pounce-py/src/lib.rs
@@ -46,8 +46,10 @@ fn _pounce(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySolver>()?;
     m.add_class::<PyNlProblem>()?;
     m.add_function(wrap_pyfunction!(read_nl, m)?)?;
-    // Batched NLP solving, native `.nl` path (pounce#126).
+    // Batched NLP solving (pounce#126): native `.nl` path (phase 1)
+    // and callback-Problem path (phase 2).
     m.add_function(wrap_pyfunction!(nlp_batch::solve_nlp_batch, m)?)?;
+    m.add_function(wrap_pyfunction!(nlp_batch::solve_problem_batch, m)?)?;
     m.add_function(wrap_pyfunction!(warm_start::classify_working_set, m)?)?;
     // Convex LP/QP solver (pounce-convex) bindings.
     m.add_class::<PyQpProblem>()?;

--- a/crates/pounce-py/src/nl_problem.rs
+++ b/crates/pounce-py/src/nl_problem.rs
@@ -33,13 +33,16 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use pounce_common::types::{Index, Number};
-use pounce_nl::nl_reader::{read_nl_file, NlTnlp};
+use pounce_nl::nl_reader::{read_nl_file, NlTnlp, NlVariation};
 use pounce_nlp::tnlp::{SparsityRequest, TNLP};
 
 /// A `.nl` model loaded through pounce's reader, exposing its evaluators.
-// `NlTnlp` shares `Expr` nodes via `Rc` (CSE), so it is not `Send`; the
-// pyclass is `unsendable` and stays on the thread that created it (fine
-// under the GIL).
+// `NlTnlp` itself is `Send` (its CSE nodes went `Arc` for pounce#126's
+// batched solving), but the pyclass stays `unsendable`: per-object
+// thread affinity is the conservative default under the GIL, and the
+// batch path never moves the pyclass — `solve_nlp_batch` clones the
+// owned `NlTnlp` out (see `clone_tnlp`) and moves the clone to the
+// rayon worker.
 #[pyclass(unsendable, module = "pounce", name = "NlProblem")]
 pub struct PyNlProblem {
     tnlp: RefCell<NlTnlp>,
@@ -308,11 +311,93 @@ impl PyNlProblem {
         Ok(values.into_pyarray_bound(py))
     }
 
+    /// Clone this model with per-instance overrides applied — the
+    /// "one structure, many bound / starting-point variations" case of
+    /// batched solving (pounce#126): parametric sweeps, multi-start,
+    /// or branch-and-bound nodes that only tighten variable bounds.
+    /// The parsed expression DAG / AD tapes are shared structure and
+    /// cheap to clone; only the named vectors are replaced. Arguments
+    /// left as `None` keep this model's values.
+    #[pyo3(signature = (x0=None, x_l=None, x_u=None, g_l=None, g_u=None))]
+    fn variant(
+        &self,
+        x0: Option<&Bound<'_, PyAny>>,
+        x_l: Option<&Bound<'_, PyAny>>,
+        x_u: Option<&Bound<'_, PyAny>>,
+        g_l: Option<&Bound<'_, PyAny>>,
+        g_u: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyNlProblem> {
+        let dec = |v: Option<&Bound<'_, PyAny>>, len: usize, what: &str| {
+            v.map(|b| decode_vec(b, len, what)).transpose()
+        };
+        let variation = NlVariation {
+            x0: dec(x0, self.n, "variant: x0")?,
+            x_l: dec(x_l, self.n, "variant: x_l")?,
+            x_u: dec(x_u, self.n, "variant: x_u")?,
+            g_l: dec(g_l, self.m, "variant: g_l")?,
+            g_u: dec(g_u, self.m, "variant: g_u")?,
+        };
+        let tnlp = self
+            .tnlp
+            .borrow()
+            .variant(&variation)
+            .map_err(PyValueError::new_err)?;
+        PyNlProblem::from_tnlp(tnlp, "variant")
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "NlProblem(n={}, m={}, nnz_jac={}, nnz_hess={}, minimize={})",
             self.n, self.m, self.nnz_jac, self.nnz_h, self.minimize
         )
+    }
+}
+
+impl PyNlProblem {
+    /// Build the pyclass around an owned `NlTnlp`, capturing the
+    /// metadata the getters serve. `what` labels error messages.
+    pub(crate) fn from_tnlp(mut tnlp: NlTnlp, what: &str) -> PyResult<PyNlProblem> {
+        let info = tnlp
+            .get_nlp_info()
+            .ok_or_else(|| PyValueError::new_err(format!("{what}: get_nlp_info returned None")))?;
+        let prob = tnlp.problem();
+        let (n, m) = (prob.n, prob.m);
+        let minimize = prob.minimize;
+        let obj_constant = prob.obj_constant;
+        let x0 = prob.x0.clone();
+        let x_l = prob.x_l.clone();
+        let x_u = prob.x_u.clone();
+        let g_l = prob.g_l.clone();
+        let g_u = prob.g_u.clone();
+        let var_names = prob.var_names.clone();
+        let con_names = prob.con_names.clone();
+        Ok(PyNlProblem {
+            tnlp: RefCell::new(tnlp),
+            n,
+            m,
+            nnz_jac: info.nnz_jac_g as usize,
+            nnz_h: info.nnz_h_lag as usize,
+            minimize,
+            obj_constant,
+            x0,
+            x_l,
+            x_u,
+            g_l,
+            g_u,
+            var_names,
+            con_names,
+        })
+    }
+
+    /// Owned copy of the evaluator for the batch path: the clone (not
+    /// the pyclass) moves to a rayon worker. Cheap relative to a
+    /// solve — tapes are flat `Vec`s of ops.
+    pub(crate) fn clone_tnlp(&self) -> NlTnlp {
+        self.tnlp.borrow().clone()
+    }
+
+    pub(crate) fn dims(&self) -> (usize, usize) {
+        (self.n, self.m)
     }
 }
 
@@ -326,42 +411,10 @@ pub fn read_nl(path: &str) -> PyResult<PyNlProblem> {
     let prob = read_nl_file(std::path::Path::new(path))
         .map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
 
-    // Capture metadata before `prob` is consumed by `NlTnlp::try_new`.
-    let minimize = prob.minimize;
-    let obj_constant = prob.obj_constant;
-    let x0 = prob.x0.clone();
-    let x_l = prob.x_l.clone();
-    let x_u = prob.x_u.clone();
-    let g_l = prob.g_l.clone();
-    let g_u = prob.g_u.clone();
-    let var_names = prob.var_names.clone();
-    let con_names = prob.con_names.clone();
-    let n = prob.n;
-    let m = prob.m;
-
     // `try_new` (not `new`): a model that names an AMPL imported function with
     // no resolvable `$AMPLFUNC` library must raise a catchable Python error,
     // not panic across the pyo3 boundary as an uncatchable PanicException.
-    let mut tnlp =
+    let tnlp =
         NlTnlp::try_new(prob).map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
-    let info = tnlp
-        .get_nlp_info()
-        .ok_or_else(|| PyValueError::new_err("read_nl: get_nlp_info returned None"))?;
-
-    Ok(PyNlProblem {
-        tnlp: RefCell::new(tnlp),
-        n,
-        m,
-        nnz_jac: info.nnz_jac_g as usize,
-        nnz_h: info.nnz_h_lag as usize,
-        minimize,
-        obj_constant,
-        x0,
-        x_l,
-        x_u,
-        g_l,
-        g_u,
-        var_names,
-        con_names,
-    })
+    PyNlProblem::from_tnlp(tnlp, "read_nl")
 }

--- a/crates/pounce-py/src/nl_problem.rs
+++ b/crates/pounce-py/src/nl_problem.rs
@@ -414,7 +414,6 @@ pub fn read_nl(path: &str) -> PyResult<PyNlProblem> {
     // `try_new` (not `new`): a model that names an AMPL imported function with
     // no resolvable `$AMPLFUNC` library must raise a catchable Python error,
     // not panic across the pyo3 boundary as an uncatchable PanicException.
-    let tnlp =
-        NlTnlp::try_new(prob).map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
+    let tnlp = NlTnlp::try_new(prob).map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
     PyNlProblem::from_tnlp(tnlp, "read_nl")
 }

--- a/crates/pounce-py/src/nl_problem.rs
+++ b/crates/pounce-py/src/nl_problem.rs
@@ -399,6 +399,17 @@ impl PyNlProblem {
     pub(crate) fn dims(&self) -> (usize, usize) {
         (self.n, self.m)
     }
+
+    /// Per-constraint equality mask (`g_l[i] == g_u[i]`), used by the batch
+    /// info-dict builder to reproduce the single-solve `active_constraints`
+    /// classification (equalities are always active).
+    pub(crate) fn equality_mask(&self) -> Vec<bool> {
+        self.g_l
+            .iter()
+            .zip(&self.g_u)
+            .map(|(l, u)| l == u)
+            .collect()
+    }
 }
 
 /// Parse an AMPL `.nl` file and return its evaluable [`PyNlProblem`].

--- a/crates/pounce-py/src/nlp_batch.rs
+++ b/crates/pounce-py/src/nlp_batch.rs
@@ -212,14 +212,21 @@ fn decode_warms(
 }
 
 /// Build the per-instance `(x, info)` pair. Mirrors the key layout of
-/// `Problem.solve`'s info dict (status / status_msg / obj_val / g /
-/// mult_g / mult_x_L / mult_x_U / iter_count / mu / final_* metrics)
-/// so downstream code can treat both uniformly.
+/// `Problem.solve`'s info dict — status / status_msg / obj_val / g /
+/// mult_g / mult_x_L / mult_x_U / iter_count / mu / final_* metrics, plus
+/// the DiffHandoff active-set masks (pinned_vars / active_constraints /
+/// active_tol) — so downstream code (e.g. the JAX / torch backward passes)
+/// can read a batch result exactly as it reads `Problem.solve`'s.
+///
+/// `equality_mask[i]` is `g_l[i] == g_u[i]` for the instance's constraint
+/// rows, supplied by the caller from the (static) input problem since the
+/// captured solution carries the constraint *values* but not their bounds.
 fn build_result<'py>(
     py: Python<'py>,
     r: &NlpBatchResult,
     n: usize,
     m: usize,
+    equality_mask: &[bool],
 ) -> PyResult<(Bound<'py, PyArray1<Number>>, Bound<'py, PyDict>)> {
     let info = PyDict::new_bound(py);
     info.set_item("status", r.status as i32)?;
@@ -237,19 +244,37 @@ fn build_result<'py>(
             info.set_item("mult_g", sol.lambda.clone().into_pyarray_bound(py))?;
             info.set_item("mult_x_L", sol.z_l.clone().into_pyarray_bound(py))?;
             info.set_item("mult_x_U", sol.z_u.clone().into_pyarray_bound(py))?;
+            // Active-set masks, computed once here in the producer (same
+            // `masks` helper and `DEFAULT_ACTIVE_TOL` as single-solve).
+            let (pinned_vars, active_constraints) = pounce_sensitivity::DiffHandoff::masks(
+                &sol.z_l,
+                &sol.z_u,
+                &sol.lambda,
+                equality_mask,
+                pounce_sensitivity::DEFAULT_ACTIVE_TOL,
+            );
+            info.set_item("pinned_vars", pinned_vars.into_pyarray_bound(py))?;
+            info.set_item(
+                "active_constraints",
+                active_constraints.into_pyarray_bound(py),
+            )?;
             sol.x.clone()
         }
         // The solve aborted before `finalize_solution` ran (e.g. an
-        // invalid problem definition): no iterate to report.
+        // invalid problem definition): no iterate to report, and hence no
+        // active set — emit empty (all-false) masks of the right length.
         None => {
             info.set_item("obj_val", f64::NAN)?;
             info.set_item("g", vec![f64::NAN; m].into_pyarray_bound(py))?;
             info.set_item("mult_g", vec![f64::NAN; m].into_pyarray_bound(py))?;
             info.set_item("mult_x_L", vec![f64::NAN; n].into_pyarray_bound(py))?;
             info.set_item("mult_x_U", vec![f64::NAN; n].into_pyarray_bound(py))?;
+            info.set_item("pinned_vars", vec![false; n].into_pyarray_bound(py))?;
+            info.set_item("active_constraints", vec![false; m].into_pyarray_bound(py))?;
             vec![f64::NAN; n]
         }
     };
+    info.set_item("active_tol", pounce_sensitivity::DEFAULT_ACTIVE_TOL)?;
     Ok((x.into_pyarray_bound(py), info))
 }
 
@@ -310,6 +335,10 @@ pub fn solve_nlp_batch<'py>(
     };
 
     let dims: Vec<(usize, usize)> = problems.iter().map(|p| p.borrow().dims()).collect();
+    let eq_masks: Vec<Vec<bool>> = problems
+        .iter()
+        .map(|p| p.borrow().equality_mask())
+        .collect();
     let tnlps: Vec<_> = problems.iter().map(|p| p.borrow().clone_tnlp()).collect();
     let warm_starts = warms.map(|w| decode_warms(py, w, &dims)).transpose()?;
 
@@ -331,7 +360,8 @@ pub fn solve_nlp_batch<'py>(
     results
         .iter()
         .zip(dims)
-        .map(|(r, (n, m))| build_result(py, r, n, m))
+        .zip(&eq_masks)
+        .map(|((r, (n, m)), eq)| build_result(py, r, n, m, eq))
         .collect()
 }
 
@@ -381,6 +411,10 @@ pub fn solve_problem_batch<'py>(
     }
     let overlay = decode_options(options)?;
     let dims: Vec<(usize, usize)> = problems.iter().map(|p| p.borrow().dims()).collect();
+    let eq_masks: Vec<Vec<bool>> = problems
+        .iter()
+        .map(|p| p.borrow().equality_mask())
+        .collect();
     let warm_starts = warms.map(|w| decode_warms(py, w, &dims)).transpose()?;
     let pool = share_structure.then(|| {
         let mut probe = IpoptApplication::new();
@@ -445,7 +479,8 @@ pub fn solve_problem_batch<'py>(
     results
         .iter()
         .zip(dims)
-        .map(|(r, (n, m))| build_result(py, r, n, m))
+        .zip(&eq_masks)
+        .map(|((r, (n, m)), eq)| build_result(py, r, n, m, eq))
         .collect()
 }
 

--- a/crates/pounce-py/src/nlp_batch.rs
+++ b/crates/pounce-py/src/nlp_batch.rs
@@ -1,18 +1,22 @@
-//! Batched NLP solving from Python (pounce#126) — native `.nl` path.
+//! Batched NLP solving from Python (pounce#126).
 //!
-//! `solve_nlp_batch(problems, ...)` takes a list of [`PyNlProblem`]s
-//! (the native-Rust evaluators `read_nl` returns — reverse-mode AD
-//! tapes, no Python callbacks, no GIL during evaluation), clones each
-//! problem's owned `NlTnlp` out of its pyclass, releases the GIL, and
-//! runs `pounce_algorithm::solve_nlp_batch_parallel` on rayon's global
-//! pool (outer-parallel across instances, inner-serial FERAL factor
-//! per worker). One `(x, info)` pair per input, in input order.
+//! Two entry points, one per input kind:
 //!
-//! Callback-based `pounce.Problem` objects cannot take this path —
-//! every `eval_*` would re-acquire the GIL, serializing the batch (see
-//! the phase-2 discussion on pounce#126). The pure-Python
-//! `pounce.solve_nlp_batch` wrapper routes those to a documented
-//! sequential fallback instead.
+//! - [`solve_nlp_batch`] (phase 1) takes a list of [`PyNlProblem`]s —
+//!   the native-Rust evaluators `read_nl` returns (reverse-mode AD
+//!   tapes, no Python callbacks, no GIL during evaluation). It clones
+//!   each problem's owned `NlTnlp` out of its pyclass, releases the
+//!   GIL, and runs the batch on rayon's global pool (outer-parallel
+//!   across instances, inner-serial FERAL factor per worker).
+//! - [`solve_problem_batch`] (phase 2) takes callback-based
+//!   `pounce.Problem`s: each instance's bridge moves to a rayon worker
+//!   that owns the whole solve and re-acquires the GIL transiently per
+//!   `eval_*` callback, so only the Python share of the work
+//!   serializes.
+//!
+//! Both return one `(x, info)` pair per input, in input order, and
+//! support warm-start chaining (`warms=`) and opt-in identical-
+//! sparsity backend pooling (`share_structure=`).
 
 use numpy::{IntoPyArray, PyArray1};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
@@ -21,18 +25,18 @@ use pyo3::types::PyDict;
 
 use pounce_algorithm::application::{default_backend_factory, feral_config_from_options};
 use pounce_algorithm::batch::{
-    install_pooled_serial_feral_backend, install_serial_feral_backend, FeralBackendPool,
+    install_pooled_serial_feral_backend, install_serial_feral_backend,
     solve_nlp_batch as solve_batch_seq, solve_nlp_batch_parallel as solve_batch_par,
     solve_nlp_batch_parallel_warm as solve_batch_par_warm,
-    solve_nlp_batch_warm as solve_batch_seq_warm, NlpBatchResult, NlpWarmStart,
+    solve_nlp_batch_warm as solve_batch_seq_warm, FeralBackendPool, NlpBatchResult, NlpWarmStart,
 };
-use std::sync::Arc;
 use pounce_algorithm::IpoptApplication;
 use pounce_common::types::{Index, Number};
 use pounce_restoration::resto_alg_builder::RestoAlgorithmBuilder;
 use pounce_restoration::resto_inner_solver::{
     make_default_restoration_factory_provider, InnerBackendFactoryFactory,
 };
+use std::sync::Arc;
 
 use crate::nl_problem::PyNlProblem;
 use crate::problem::{extract_f64_vec, status_message, PyProblem};
@@ -58,9 +62,9 @@ fn decode_options(options: Option<&Bound<'_, PyDict>>) -> PyResult<BatchOptions>
         return Ok(out);
     };
     for (key, value) in dict.iter() {
-        let name: String = key.extract().map_err(|_| {
-            PyValueError::new_err("solve_nlp_batch: option names must be strings")
-        })?;
+        let name: String = key
+            .extract()
+            .map_err(|_| PyValueError::new_err("solve_nlp_batch: option names must be strings"))?;
         if value.is_instance_of::<pyo3::types::PyBool>() {
             if let Ok(b) = value.extract::<bool>() {
                 out.str_opts
@@ -301,7 +305,8 @@ pub fn solve_nlp_batch<'py>(
     let pool = {
         let mut probe = IpoptApplication::new();
         apply_options(&mut probe, &opts).map_err(PyRuntimeError::new_err)?;
-        share_structure.then(|| FeralBackendPool::serial(feral_config_from_options(probe.options())))
+        share_structure
+            .then(|| FeralBackendPool::serial(feral_config_from_options(probe.options())))
     };
 
     let dims: Vec<(usize, usize)> = problems.iter().map(|p| p.borrow().dims()).collect();

--- a/crates/pounce-py/src/nlp_batch.rs
+++ b/crates/pounce-py/src/nlp_batch.rs
@@ -21,9 +21,12 @@ use pyo3::types::PyDict;
 
 use pounce_algorithm::application::{default_backend_factory, feral_config_from_options};
 use pounce_algorithm::batch::{
-    install_serial_feral_backend, solve_nlp_batch as solve_batch_seq,
-    solve_nlp_batch_parallel as solve_batch_par, NlpBatchResult,
+    install_pooled_serial_feral_backend, install_serial_feral_backend, FeralBackendPool,
+    solve_nlp_batch as solve_batch_seq, solve_nlp_batch_parallel as solve_batch_par,
+    solve_nlp_batch_parallel_warm as solve_batch_par_warm,
+    solve_nlp_batch_warm as solve_batch_seq_warm, NlpBatchResult, NlpWarmStart,
 };
+use std::sync::Arc;
 use pounce_algorithm::IpoptApplication;
 use pounce_common::types::{Index, Number};
 use pounce_restoration::resto_alg_builder::RestoAlgorithmBuilder;
@@ -32,7 +35,8 @@ use pounce_restoration::resto_inner_solver::{
 };
 
 use crate::nl_problem::PyNlProblem;
-use crate::problem::status_message;
+use crate::problem::{extract_f64_vec, status_message, PyProblem};
+use crate::tnlp_bridge::PyTnlp;
 
 /// Options decoded from the user dict, in the three value classes the
 /// `OptionsList` distinguishes. Plain data — `Sync`, shared by the
@@ -107,14 +111,23 @@ fn apply_options(app: &mut IpoptApplication, opts: &BatchOptions) -> Result<(), 
 
 /// The per-worker application recipe — the batch analog of
 /// `Problem::prepare`: user options, a FERAL linear-solver backend
-/// (inner-serial when the batch is parallel), and the default
-/// restoration-phase provider. Options were validated on a probe app
-/// before the batch started, so rejections here are unreachable and
-/// ignored.
-fn configure_worker(app: &mut IpoptApplication, opts: &BatchOptions, parallel: bool) {
+/// (inner-serial when the batch is parallel; drawn from `pool` when
+/// the caller opted into cross-instance structure reuse), and the
+/// default restoration-phase provider. Options were validated on a
+/// probe app before the batch started, so rejections here are
+/// unreachable and ignored.
+fn configure_worker(
+    app: &mut IpoptApplication,
+    opts: &BatchOptions,
+    parallel: bool,
+    pool: Option<&Arc<FeralBackendPool>>,
+) {
     let _ = apply_options(app, opts);
     let mut feral_cfg = feral_config_from_options(app.options());
-    if parallel {
+    if let Some(pool) = pool {
+        install_pooled_serial_feral_backend(app, pool);
+        feral_cfg.parallel = Some(false);
+    } else if parallel {
         install_serial_feral_backend(app);
         feral_cfg.parallel = Some(false);
     } else {
@@ -136,6 +149,63 @@ fn configure_worker(app: &mut IpoptApplication, opts: &BatchOptions, parallel: b
 
 /// Per-instance `(x, info)` pairs, one per input, in input order.
 type BatchResults<'py> = Vec<(Bound<'py, PyArray1<Number>>, Bound<'py, PyDict>)>;
+
+/// Decode per-instance warm starts from previous batch results: a
+/// sequence of `(x, info)` pairs as returned by `solve_nlp_batch` /
+/// `solve_problem_batch` (or any dict carrying `mult_g` / `mult_x_L` /
+/// `mult_x_U`). Validated against each instance's dims so a mismatch
+/// is a Python error here, not a silent cold start.
+fn decode_warms(
+    py: Python<'_>,
+    warms: &Bound<'_, PyAny>,
+    dims: &[(usize, usize)],
+) -> PyResult<Vec<NlpWarmStart>> {
+    let mut out = Vec::with_capacity(dims.len());
+    for (i, item) in warms.iter()?.enumerate() {
+        let item = item?;
+        let (n, m) = *dims.get(i).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "warms: got more than the {} problems in the batch",
+                dims.len()
+            ))
+        })?;
+        let pair: (Py<PyAny>, Py<PyAny>) = item.extract().map_err(|_| {
+            PyValueError::new_err(format!(
+                "warms[{i}]: expected an (x, info) pair as returned by a previous batch solve"
+            ))
+        })?;
+        let x = extract_f64_vec(&pair.0, n, &format!("warms[{i}].x"))?;
+        let info = pair.1.bind(py);
+        let pull = |key: &str, len: usize| -> PyResult<Vec<Number>> {
+            let v = info.get_item(key).map_err(|_| {
+                PyValueError::new_err(format!("warms[{i}]: info dict is missing \"{key}\""))
+            })?;
+            extract_f64_vec(&v.unbind(), len, &format!("warms[{i}].{key}"))
+        };
+        // Resume from the previous solve's barrier parameter when the
+        // info dict carries one (`Problem.solve` and both batch paths
+        // emit "mu" for exactly this hand-off).
+        let mu = info
+            .get_item("mu")
+            .ok()
+            .and_then(|v| v.extract::<Number>().ok());
+        out.push(NlpWarmStart {
+            x,
+            lambda: pull("mult_g", m)?,
+            z_l: pull("mult_x_L", n)?,
+            z_u: pull("mult_x_U", n)?,
+            mu,
+        });
+    }
+    if out.len() != dims.len() {
+        return Err(PyValueError::new_err(format!(
+            "warms: got {} entries for {} problems",
+            out.len(),
+            dims.len()
+        )));
+    }
+    Ok(out)
+}
 
 /// Build the per-instance `(x, info)` pair. Mirrors the key layout of
 /// `Problem.solve`'s info dict (status / status_msg / obj_val / g /
@@ -192,13 +262,28 @@ fn build_result<'py>(
 /// `options` accepts the same IPOPT-style names and value coercion as
 /// `Problem.add_option`, applied identically to every instance.
 /// `print_level` defaults to 0 for the batch (explicit values win).
+///
+/// `warms` (optional) seeds each instance from a previous batch's
+/// `(x, info)` results (MPC / sequential-chaining);
+/// `warm_start_init_point=yes` is forced for the warm batch.
+///
+/// `share_structure=True` opts identical-sparsity batches into the
+/// per-worker backend pool: each worker keeps its FERAL solver across
+/// instances, so the symbolic analysis (fill-reducing ordering +
+/// supernode structure) is computed once per worker instead of once
+/// per instance. Always correct (a pattern change triggers a fresh
+/// analysis); only profitable when instances share their KKT
+/// sparsity, and results are then within solver tolerance of — but
+/// not guaranteed bit-identical to — fresh-backend solves.
 #[pyfunction]
-#[pyo3(signature = (problems, options=None, parallel=true))]
+#[pyo3(signature = (problems, options=None, parallel=true, warms=None, share_structure=false))]
 pub fn solve_nlp_batch<'py>(
     py: Python<'py>,
     problems: Vec<Bound<'py, PyNlProblem>>,
     options: Option<&Bound<'py, PyDict>>,
     parallel: bool,
+    warms: Option<&Bound<'py, PyAny>>,
+    share_structure: bool,
 ) -> PyResult<BatchResults<'py>> {
     let mut opts = decode_options(options)?;
     // Quiet by default: N workers interleaving per-iteration tables on
@@ -211,22 +296,30 @@ pub fn solve_nlp_batch<'py>(
     }
     // Validate the option set once, up front, so a typo is a Python
     // error here rather than something each worker silently drops.
-    {
+    // The probe also resolves the `feral_*` options the optional
+    // backend pool is configured with.
+    let pool = {
         let mut probe = IpoptApplication::new();
         apply_options(&mut probe, &opts).map_err(PyRuntimeError::new_err)?;
-    }
+        share_structure.then(|| FeralBackendPool::serial(feral_config_from_options(probe.options())))
+    };
 
     let dims: Vec<(usize, usize)> = problems.iter().map(|p| p.borrow().dims()).collect();
     let tnlps: Vec<_> = problems.iter().map(|p| p.borrow().clone_tnlp()).collect();
+    let warm_starts = warms.map(|w| decode_warms(py, w, &dims)).transpose()?;
 
     // The evaluators are native Rust (`NlTnlp: Send`) — no Python
     // callbacks — so the whole batch runs with the GIL released and
     // only plain-data results come back.
     let results: Vec<NlpBatchResult> = py.allow_threads(move || {
-        if parallel {
-            solve_batch_par(tnlps, |app| configure_worker(app, &opts, true))
-        } else {
-            solve_batch_seq(tnlps, |app| configure_worker(app, &opts, false))
+        let configure = |_i: usize, app: &mut IpoptApplication| {
+            configure_worker(app, &opts, parallel, pool.as_ref())
+        };
+        match (parallel, warm_starts) {
+            (true, None) => solve_batch_par(tnlps, configure),
+            (false, None) => solve_batch_seq(tnlps, configure),
+            (true, Some(ws)) => solve_batch_par_warm(tnlps, ws, configure),
+            (false, Some(ws)) => solve_batch_seq_warm(tnlps, ws, configure),
         }
     });
 
@@ -235,4 +328,131 @@ pub fn solve_nlp_batch<'py>(
         .zip(dims)
         .map(|(r, (n, m))| build_result(py, r, n, m))
         .collect()
+}
+
+/// Solve a batch of independent callback-based `pounce.Problem`s —
+/// pounce#126 **phase 2**.
+///
+/// Each instance's bridge (the Python callables plus pre-resolved
+/// sparsity) is assembled here under the GIL, then *moved* to a rayon
+/// worker that owns the whole solve; the GIL is released for the
+/// duration of the batch and re-acquired transiently inside every
+/// `objective` / `gradient` / `constraints` / `jacobian` / `hessian`
+/// callback. Correctness does not depend on timing — the GIL
+/// serializes the Python work — but the *speedup* does: only the
+/// solver's Rust share (KKT factorization, backsolves, line search)
+/// runs concurrently, so the win scales with the Rust/Python work
+/// ratio and tops out near zero for tiny problems whose callbacks
+/// dominate. Native `.nl` batches (`solve_nlp_batch`) don't have this
+/// ceiling.
+///
+/// Per-instance options are honored: each worker applies its
+/// `Problem`'s own `add_option` settings (plus the L-BFGS default when
+/// that instance lacks a Hessian callback), then the batch-level
+/// `options` overlay, then the batch's quiet `print_level` default.
+///
+/// `x0s` supplies one starting point per instance. With `warms`, the
+/// warm iterate (its `x` and duals) takes precedence and
+/// `warm_start_init_point=yes` is forced. `share_structure` — see
+/// [`solve_nlp_batch`]; the pool's FERAL configuration is resolved
+/// from the batch-level `options` overlay.
+#[pyfunction]
+#[pyo3(signature = (problems, x0s, options=None, parallel=true, warms=None, share_structure=false))]
+pub fn solve_problem_batch<'py>(
+    py: Python<'py>,
+    problems: Vec<Bound<'py, PyProblem>>,
+    x0s: Vec<Py<PyAny>>,
+    options: Option<&Bound<'py, PyDict>>,
+    parallel: bool,
+    warms: Option<&Bound<'py, PyAny>>,
+    share_structure: bool,
+) -> PyResult<BatchResults<'py>> {
+    if x0s.len() != problems.len() {
+        return Err(PyValueError::new_err(format!(
+            "solve_problem_batch: got {} problems but {} starting points",
+            problems.len(),
+            x0s.len()
+        )));
+    }
+    let overlay = decode_options(options)?;
+    let dims: Vec<(usize, usize)> = problems.iter().map(|p| p.borrow().dims()).collect();
+    let warm_starts = warms.map(|w| decode_warms(py, w, &dims)).transpose()?;
+    let pool = share_structure.then(|| {
+        let mut probe = IpoptApplication::new();
+        let _ = apply_options(&mut probe, &overlay);
+        FeralBackendPool::serial(feral_config_from_options(probe.options()))
+    });
+
+    // Per-instance option sets: the instance's own `add_option`
+    // settings first (after its L-BFGS default), then the batch
+    // overlay so the caller can globally override, then the quiet
+    // default. Validated on a probe app so a typo surfaces here.
+    let mut per_instance: Vec<BatchOptions> = Vec::with_capacity(problems.len());
+    for (i, p) in problems.iter().enumerate() {
+        let pb = p.borrow();
+        let mut o = BatchOptions::default();
+        if !pb.uses_exact_hessian() {
+            o.str_opts
+                .push(("hessian_approximation".into(), "limited-memory".into()));
+        }
+        let (s, num, int) = pb.option_sets();
+        o.str_opts.extend(s.iter().cloned());
+        o.num_opts.extend(num.iter().cloned());
+        o.int_opts.extend(int.iter().cloned());
+        o.str_opts.extend(overlay.str_opts.iter().cloned());
+        o.num_opts.extend(overlay.num_opts.iter().cloned());
+        o.int_opts.extend(overlay.int_opts.iter().cloned());
+        if !o.int_opts.iter().any(|(k, _)| k == "print_level")
+            && !o.str_opts.iter().any(|(k, _)| k == "print_level")
+        {
+            o.int_opts.push(("print_level".into(), 0));
+        }
+        let mut probe = IpoptApplication::new();
+        apply_options(&mut probe, &o)
+            .map_err(|e| PyRuntimeError::new_err(format!("problem {i}: {e}")))?;
+        per_instance.push(o);
+    }
+
+    // Assemble the bridges under the GIL (sparsity-structure callbacks
+    // run here, once per instance); each `PyTnlp` is plain data plus
+    // `Py<PyAny>` handles, hence `Send`, and moves to its worker.
+    let mut bridges: Vec<PyTnlp> = Vec::with_capacity(problems.len());
+    for (i, (p, x0)) in problems.iter().zip(&x0s).enumerate() {
+        let pb = p.borrow();
+        let (n, _m) = pb.dims();
+        let x0_vec = extract_f64_vec(x0, n, &format!("x0s[{i}]"))?;
+        let init = pb.build_tnlp_init(py, x0_vec, None, None, None)?;
+        bridges.push(PyTnlp::new(init));
+    }
+
+    let results: Vec<NlpBatchResult> = py.allow_threads(move || {
+        let configure = |i: usize, app: &mut IpoptApplication| {
+            configure_worker(app, &per_instance[i], parallel, pool.as_ref())
+        };
+        match (parallel, warm_starts) {
+            (true, None) => solve_batch_par(bridges, configure),
+            (false, None) => solve_batch_seq(bridges, configure),
+            (true, Some(ws)) => solve_batch_par_warm(bridges, ws, configure),
+            (false, Some(ws)) => solve_batch_seq_warm(bridges, ws, configure),
+        }
+    });
+
+    results
+        .iter()
+        .zip(dims)
+        .map(|(r, (n, m))| build_result(py, r, n, m))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    /// The phase-2 contract: a callback bridge must be movable to a
+    /// rayon worker (its `Py<PyAny>` handles are `Send`; everything
+    /// else is plain data). Regresses if `!Send` state lands in
+    /// `PyTnlp` / `PyTnlpInit`.
+    #[test]
+    fn py_tnlp_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::PyTnlp>();
+    }
 }

--- a/crates/pounce-py/src/nlp_batch.rs
+++ b/crates/pounce-py/src/nlp_batch.rs
@@ -1,0 +1,238 @@
+//! Batched NLP solving from Python (pounce#126) — native `.nl` path.
+//!
+//! `solve_nlp_batch(problems, ...)` takes a list of [`PyNlProblem`]s
+//! (the native-Rust evaluators `read_nl` returns — reverse-mode AD
+//! tapes, no Python callbacks, no GIL during evaluation), clones each
+//! problem's owned `NlTnlp` out of its pyclass, releases the GIL, and
+//! runs `pounce_algorithm::solve_nlp_batch_parallel` on rayon's global
+//! pool (outer-parallel across instances, inner-serial FERAL factor
+//! per worker). One `(x, info)` pair per input, in input order.
+//!
+//! Callback-based `pounce.Problem` objects cannot take this path —
+//! every `eval_*` would re-acquire the GIL, serializing the batch (see
+//! the phase-2 discussion on pounce#126). The pure-Python
+//! `pounce.solve_nlp_batch` wrapper routes those to a documented
+//! sequential fallback instead.
+
+use numpy::{IntoPyArray, PyArray1};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyDict;
+
+use pounce_algorithm::application::{default_backend_factory, feral_config_from_options};
+use pounce_algorithm::batch::{
+    install_serial_feral_backend, solve_nlp_batch as solve_batch_seq,
+    solve_nlp_batch_parallel as solve_batch_par, NlpBatchResult,
+};
+use pounce_algorithm::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_restoration::resto_alg_builder::RestoAlgorithmBuilder;
+use pounce_restoration::resto_inner_solver::{
+    make_default_restoration_factory_provider, InnerBackendFactoryFactory,
+};
+
+use crate::nl_problem::PyNlProblem;
+use crate::problem::status_message;
+
+/// Options decoded from the user dict, in the three value classes the
+/// `OptionsList` distinguishes. Plain data — `Sync`, shared by the
+/// per-worker configure closure.
+#[derive(Default)]
+struct BatchOptions {
+    str_opts: Vec<(String, String)>,
+    int_opts: Vec<(String, Index)>,
+    num_opts: Vec<(String, Number)>,
+}
+
+/// Decode an options dict with the same value coercion as
+/// `Problem.add_option`: `bool` → `"yes"`/`"no"` (checked before
+/// `int`, since Python's `bool` subclasses `int`), then `int`, then
+/// `float`, then `str`.
+fn decode_options(options: Option<&Bound<'_, PyDict>>) -> PyResult<BatchOptions> {
+    let mut out = BatchOptions::default();
+    let Some(dict) = options else {
+        return Ok(out);
+    };
+    for (key, value) in dict.iter() {
+        let name: String = key.extract().map_err(|_| {
+            PyValueError::new_err("solve_nlp_batch: option names must be strings")
+        })?;
+        if value.is_instance_of::<pyo3::types::PyBool>() {
+            if let Ok(b) = value.extract::<bool>() {
+                out.str_opts
+                    .push((name, if b { "yes".into() } else { "no".into() }));
+                continue;
+            }
+        }
+        if let Ok(i) = value.extract::<i64>() {
+            out.int_opts.push((name, i as Index));
+            continue;
+        }
+        if let Ok(f) = value.extract::<f64>() {
+            out.num_opts.push((name, f));
+            continue;
+        }
+        if let Ok(s) = value.extract::<String>() {
+            out.str_opts.push((name, s));
+            continue;
+        }
+        return Err(PyValueError::new_err(format!(
+            "solve_nlp_batch: option {name}: expected str / int / float / bool, got {}",
+            value.get_type().name()?
+        )));
+    }
+    Ok(out)
+}
+
+/// Apply decoded options to a fresh application, surfacing the first
+/// rejected option as an error.
+fn apply_options(app: &mut IpoptApplication, opts: &BatchOptions) -> Result<(), String> {
+    for (k, v) in &opts.str_opts {
+        app.options_mut()
+            .set_string_value(k, v, true, false)
+            .map_err(|e| format!("option {k}={v}: {e}"))?;
+    }
+    for (k, v) in &opts.num_opts {
+        app.options_mut()
+            .set_numeric_value(k, *v, true, false)
+            .map_err(|e| format!("option {k}={v}: {e}"))?;
+    }
+    for (k, v) in &opts.int_opts {
+        app.options_mut()
+            .set_integer_value(k, *v, true, false)
+            .map_err(|e| format!("option {k}={v}: {e}"))?;
+    }
+    Ok(())
+}
+
+/// The per-worker application recipe — the batch analog of
+/// `Problem::prepare`: user options, a FERAL linear-solver backend
+/// (inner-serial when the batch is parallel), and the default
+/// restoration-phase provider. Options were validated on a probe app
+/// before the batch started, so rejections here are unreachable and
+/// ignored.
+fn configure_worker(app: &mut IpoptApplication, opts: &BatchOptions, parallel: bool) {
+    let _ = apply_options(app, opts);
+    let mut feral_cfg = feral_config_from_options(app.options());
+    if parallel {
+        install_serial_feral_backend(app);
+        feral_cfg.parallel = Some(false);
+    } else {
+        let cfg = feral_cfg.clone();
+        app.set_linear_backend_factory(default_backend_factory(cfg));
+    }
+    // Restoration phase, including for the inner solves it runs.
+    let bff_mint = move || -> InnerBackendFactoryFactory {
+        let feral_cfg = feral_cfg.clone();
+        Box::new(move || default_backend_factory(feral_cfg.clone()))
+    };
+    let resto_provider = make_default_restoration_factory_provider(
+        RestoAlgorithmBuilder::new(),
+        app.algorithm_builder_from_options(),
+        bff_mint,
+    );
+    app.set_restoration_factory_provider(resto_provider);
+}
+
+/// Per-instance `(x, info)` pairs, one per input, in input order.
+type BatchResults<'py> = Vec<(Bound<'py, PyArray1<Number>>, Bound<'py, PyDict>)>;
+
+/// Build the per-instance `(x, info)` pair. Mirrors the key layout of
+/// `Problem.solve`'s info dict (status / status_msg / obj_val / g /
+/// mult_g / mult_x_L / mult_x_U / iter_count / mu / final_* metrics)
+/// so downstream code can treat both uniformly.
+fn build_result<'py>(
+    py: Python<'py>,
+    r: &NlpBatchResult,
+    n: usize,
+    m: usize,
+) -> PyResult<(Bound<'py, PyArray1<Number>>, Bound<'py, PyDict>)> {
+    let info = PyDict::new_bound(py);
+    info.set_item("status", r.status as i32)?;
+    info.set_item("status_msg", status_message(r.status))?;
+    info.set_item("iter_count", r.stats.iteration_count)?;
+    info.set_item("mu", r.stats.final_mu)?;
+    info.set_item("final_kkt_error", r.stats.final_kkt_error)?;
+    info.set_item("final_dual_inf", r.stats.final_dual_inf)?;
+    info.set_item("final_constr_viol", r.stats.final_constr_viol)?;
+    info.set_item("final_compl", r.stats.final_compl)?;
+    let x = match &r.solution {
+        Some(sol) => {
+            info.set_item("obj_val", sol.obj)?;
+            info.set_item("g", sol.g.clone().into_pyarray_bound(py))?;
+            info.set_item("mult_g", sol.lambda.clone().into_pyarray_bound(py))?;
+            info.set_item("mult_x_L", sol.z_l.clone().into_pyarray_bound(py))?;
+            info.set_item("mult_x_U", sol.z_u.clone().into_pyarray_bound(py))?;
+            sol.x.clone()
+        }
+        // The solve aborted before `finalize_solution` ran (e.g. an
+        // invalid problem definition): no iterate to report.
+        None => {
+            info.set_item("obj_val", f64::NAN)?;
+            info.set_item("g", vec![f64::NAN; m].into_pyarray_bound(py))?;
+            info.set_item("mult_g", vec![f64::NAN; m].into_pyarray_bound(py))?;
+            info.set_item("mult_x_L", vec![f64::NAN; n].into_pyarray_bound(py))?;
+            info.set_item("mult_x_U", vec![f64::NAN; n].into_pyarray_bound(py))?;
+            vec![f64::NAN; n]
+        }
+    };
+    Ok((x.into_pyarray_bound(py), info))
+}
+
+/// Solve a batch of independent native (`.nl`-loaded) NLPs, one result
+/// per input in input order.
+///
+/// `problems` is a sequence of `pounce.NlProblem` (from `read_nl` /
+/// `NlProblem.variant`). Each instance is solved end-to-end with its
+/// own application; with `parallel=True` (default) instances run
+/// concurrently on rayon with the GIL released and each worker using
+/// an inner-serial FERAL factor; `parallel=False` solves sequentially
+/// (each factor may then parallelize internally).
+///
+/// `options` accepts the same IPOPT-style names and value coercion as
+/// `Problem.add_option`, applied identically to every instance.
+/// `print_level` defaults to 0 for the batch (explicit values win).
+#[pyfunction]
+#[pyo3(signature = (problems, options=None, parallel=true))]
+pub fn solve_nlp_batch<'py>(
+    py: Python<'py>,
+    problems: Vec<Bound<'py, PyNlProblem>>,
+    options: Option<&Bound<'py, PyDict>>,
+    parallel: bool,
+) -> PyResult<BatchResults<'py>> {
+    let mut opts = decode_options(options)?;
+    // Quiet by default: N workers interleaving per-iteration tables on
+    // one stdout is noise, not output. An explicit user `print_level`
+    // (or `sb`) still wins.
+    if !opts.int_opts.iter().any(|(k, _)| k == "print_level")
+        && !opts.str_opts.iter().any(|(k, _)| k == "print_level")
+    {
+        opts.int_opts.push(("print_level".into(), 0));
+    }
+    // Validate the option set once, up front, so a typo is a Python
+    // error here rather than something each worker silently drops.
+    {
+        let mut probe = IpoptApplication::new();
+        apply_options(&mut probe, &opts).map_err(PyRuntimeError::new_err)?;
+    }
+
+    let dims: Vec<(usize, usize)> = problems.iter().map(|p| p.borrow().dims()).collect();
+    let tnlps: Vec<_> = problems.iter().map(|p| p.borrow().clone_tnlp()).collect();
+
+    // The evaluators are native Rust (`NlTnlp: Send`) — no Python
+    // callbacks — so the whole batch runs with the GIL released and
+    // only plain-data results come back.
+    let results: Vec<NlpBatchResult> = py.allow_threads(move || {
+        if parallel {
+            solve_batch_par(tnlps, |app| configure_worker(app, &opts, true))
+        } else {
+            solve_batch_seq(tnlps, |app| configure_worker(app, &opts, false))
+        }
+    });
+
+    results
+        .iter()
+        .zip(dims)
+        .map(|(r, (n, m))| build_result(py, r, n, m))
+        .collect()
+}

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -586,38 +586,7 @@ impl PyProblem {
             .transpose()?;
         let z_l0 = zl.map(|v| extract_f64_vec(&v, n, "zl")).transpose()?;
         let z_u0 = zu.map(|v| extract_f64_vec(&v, n, "zu")).transpose()?;
-
-        let (jac_rows, jac_cols, nele_jac) = if m > 0 {
-            let s = call0(&self.problem_obj, "jacobianstructure")?;
-            let (rows, cols) = decode_structure_inferred(&s)?;
-            (rows.clone(), cols.clone(), rows.len() as Index)
-        } else {
-            (Vec::new(), Vec::new(), 0)
-        };
-
-        // Hessian sparsity. When the user provides one, use it
-        // verbatim. Without one we still need a non-empty pattern: the
-        // L-BFGS updater pins its work-space sparsity from
-        // `curr_exact_hessian()`, so an empty space means nowhere for
-        // the quasi-Newton approximation to land. Declare the dense
-        // lower triangle — `eval_h(Values)` returns zeros and the
-        // updater overwrites them with its rank-update approximation.
-        let (hess_rows, hess_cols, nele_hess) = if self.has_hessian {
-            let s = call0(&self.problem_obj, "hessianstructure")?;
-            let (rows, cols) = decode_structure_inferred(&s)?;
-            (rows.clone(), cols.clone(), rows.len() as Index)
-        } else {
-            let mut rows = Vec::with_capacity(n * (n + 1) / 2);
-            let mut cols = Vec::with_capacity(n * (n + 1) / 2);
-            for i in 0..n {
-                for j in 0..=i {
-                    rows.push(i as Index);
-                    cols.push(j as Index);
-                }
-            }
-            let nele = rows.len() as Index;
-            (rows, cols, nele)
-        };
+        let init = self.build_tnlp_init(py, x0_vec, lam0, z_l0, z_u0)?;
 
         let mut app = IpoptApplication::new();
         if !self.has_hessian {
@@ -658,7 +627,62 @@ impl PyProblem {
         );
         app.set_restoration_factory_provider(resto_provider);
 
-        let init = PyTnlpInit {
+        let bridge = Rc::new(RefCell::new(PyTnlp::new(init)));
+        Ok((app, bridge))
+    }
+
+    /// Assemble the [`PyTnlpInit`] payload for one solve: resolve the
+    /// Jacobian / Hessian sparsity through the Python object (once, so
+    /// the solver's `Structure` calls are GIL-free copies) and capture
+    /// bounds, starting point, optional warm duals, and the callback
+    /// handle. Factored out of [`Self::prepare`] so the batch path
+    /// (pounce#126 phase 2) can mint per-instance bridges without
+    /// building the application on this thread — the resulting
+    /// `PyTnlpInit` is plain data + `Py<PyAny>` handles, hence `Send`,
+    /// and moves to the rayon worker that owns the solve.
+    pub(crate) fn build_tnlp_init(
+        &self,
+        py: Python<'_>,
+        x0_vec: Vec<Number>,
+        lam0: Option<Vec<Number>>,
+        z_l0: Option<Vec<Number>>,
+        z_u0: Option<Vec<Number>>,
+    ) -> PyResult<PyTnlpInit> {
+        let n = self.n as usize;
+        let m = self.m as usize;
+        let (jac_rows, jac_cols, nele_jac) = if m > 0 {
+            let s = call0(&self.problem_obj, "jacobianstructure")?;
+            let (rows, cols) = decode_structure_inferred(&s)?;
+            (rows.clone(), cols.clone(), rows.len() as Index)
+        } else {
+            (Vec::new(), Vec::new(), 0)
+        };
+
+        // Hessian sparsity. When the user provides one, use it
+        // verbatim. Without one we still need a non-empty pattern: the
+        // L-BFGS updater pins its work-space sparsity from
+        // `curr_exact_hessian()`, so an empty space means nowhere for
+        // the quasi-Newton approximation to land. Declare the dense
+        // lower triangle — `eval_h(Values)` returns zeros and the
+        // updater overwrites them with its rank-update approximation.
+        let (hess_rows, hess_cols, nele_hess) = if self.has_hessian {
+            let s = call0(&self.problem_obj, "hessianstructure")?;
+            let (rows, cols) = decode_structure_inferred(&s)?;
+            (rows.clone(), cols.clone(), rows.len() as Index)
+        } else {
+            let mut rows = Vec::with_capacity(n * (n + 1) / 2);
+            let mut cols = Vec::with_capacity(n * (n + 1) / 2);
+            for i in 0..n {
+                for j in 0..=i {
+                    rows.push(i as Index);
+                    cols.push(j as Index);
+                }
+            }
+            let nele = rows.len() as Index;
+            (rows, cols, nele)
+        };
+
+        Ok(PyTnlpInit {
             n: self.n,
             m: self.m,
             nele_jac,
@@ -685,9 +709,28 @@ impl PyProblem {
             final_lambda: vec![0.0; m],
             final_obj: 0.0,
             final_status_code: 0,
-        };
-        let bridge = Rc::new(RefCell::new(PyTnlp::new(init)));
-        Ok((app, bridge))
+        })
+    }
+
+    /// The pending option sets, in `OptionsList`'s three value classes
+    /// — for the batch path, which applies them to a fresh per-worker
+    /// application instead of going through [`Self::prepare`].
+    pub(crate) fn option_sets(
+        &self,
+    ) -> (
+        &[(String, String)],
+        &[(String, Number)],
+        &[(String, Index)],
+    ) {
+        (&self.str_opts, &self.num_opts, &self.int_opts)
+    }
+
+    pub(crate) fn uses_exact_hessian(&self) -> bool {
+        self.has_hessian
+    }
+
+    pub(crate) fn dims(&self) -> (usize, usize) {
+        (self.n as usize, self.m as usize)
     }
 }
 
@@ -839,7 +882,7 @@ fn extract_index_vec_inferred(val: &Py<PyAny>, what: &str) -> PyResult<Vec<Index
     })
 }
 
-fn extract_f64_vec(val: &Py<PyAny>, expected: usize, what: &str) -> PyResult<Vec<Number>> {
+pub(crate) fn extract_f64_vec(val: &Py<PyAny>, expected: usize, what: &str) -> PyResult<Vec<Number>> {
     Python::with_gil(|py| {
         let bound = val.bind(py);
         if let Ok(arr) = bound.downcast::<PyArray1<Number>>() {

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -1016,7 +1016,7 @@ fn extract_i8_vec(val: &Py<PyAny>, expected: usize, what: &str) -> PyResult<Vec<
     })
 }
 
-fn status_message(status: ApplicationReturnStatus) -> &'static str {
+pub(crate) fn status_message(status: ApplicationReturnStatus) -> &'static str {
     use ApplicationReturnStatus::*;
     match status {
         SolveSucceeded => "Solve_Succeeded",

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -717,11 +717,7 @@ impl PyProblem {
     /// application instead of going through [`Self::prepare`].
     pub(crate) fn option_sets(
         &self,
-    ) -> (
-        &[(String, String)],
-        &[(String, Number)],
-        &[(String, Index)],
-    ) {
+    ) -> (&[(String, String)], &[(String, Number)], &[(String, Index)]) {
         (&self.str_opts, &self.num_opts, &self.int_opts)
     }
 
@@ -882,7 +878,11 @@ fn extract_index_vec_inferred(val: &Py<PyAny>, what: &str) -> PyResult<Vec<Index
     })
 }
 
-pub(crate) fn extract_f64_vec(val: &Py<PyAny>, expected: usize, what: &str) -> PyResult<Vec<Number>> {
+pub(crate) fn extract_f64_vec(
+    val: &Py<PyAny>,
+    expected: usize,
+    what: &str,
+) -> PyResult<Vec<Number>> {
     Python::with_gil(|py| {
         let bound = val.bind(py);
         if let Ok(arr) = bound.downcast::<PyArray1<Number>>() {

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -728,6 +728,17 @@ impl PyProblem {
     pub(crate) fn dims(&self) -> (usize, usize) {
         (self.n as usize, self.m as usize)
     }
+
+    /// Per-constraint equality mask (`g_l[i] == g_u[i]`), used by the batch
+    /// info-dict builder to reproduce the single-solve `active_constraints`
+    /// classification (equalities are always active).
+    pub(crate) fn equality_mask(&self) -> Vec<bool> {
+        self.g_l
+            .iter()
+            .zip(&self.g_u)
+            .map(|(l, u)| l == u)
+            .collect()
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -85,25 +85,56 @@ instance with per-instance starting point / bounds; everything
 structural (expression DAG, AD tapes, sparsity, coloring) is shared
 work that is not redone.
 
-**Native vs. callback inputs — the GIL caveat.** Batch parallelism
-needs evaluators that don't touch Python during the solve:
+**Native vs. callback inputs — the GIL caveat.** Both kinds solve in
+parallel, with different ceilings:
 
 * `NlProblem` inputs (from `read_nl` / `variant`) are native-Rust
-  reverse-mode-AD evaluators. The batch runs **in parallel** on a
-  Rayon thread pool with the GIL released; each worker solves its
-  instance end-to-end with an inner-serial factorization
-  (outer-parallel / inner-serial, the same model as `solve_qp_batch`).
-* Callback-based `Problem` inputs evaluate through Python, and every
-  callback needs the GIL — parallelizing them buys nothing. They are
-  solved **sequentially** (pass `x0s=`, one starting point per
-  instance). True parallel callback batching is tracked as pounce#126
-  phase 2.
+  reverse-mode-AD evaluators. The batch runs on a Rayon thread pool
+  with the GIL fully released; each worker solves its instance
+  end-to-end with an inner-serial factorization (outer-parallel /
+  inner-serial, the same model as `solve_qp_batch`).
+* Callback-based `Problem` inputs (pass `x0s=`, one starting point per
+  instance) also run one instance per worker, but every `objective` /
+  `gradient` / `constraints` / `jacobian` / `hessian` call re-acquires
+  the GIL. The Python share of the work is therefore serialized: the
+  speedup scales with the Rust/Python work ratio — medium and large
+  problems whose factorizations dominate parallelize well (~4x on 4
+  cores for an n=800 banded NLP with vectorized NumPy callbacks);
+  tiny problems whose callbacks dominate won't. Each `Problem`'s own
+  `add_option` settings are honored per instance, with `options=` as
+  a batch-level overlay.
 
-With `parallel=False` the native path also solves one instance at a
-time, letting each factorization parallelize internally — better for a
-few large instances. For the batch, `print_level` defaults to 0
-(N workers interleaving iteration tables is noise); pass an explicit
+With `parallel=False` either path solves one instance at a time,
+letting each factorization parallelize internally — better for a few
+large instances. For the batch, `print_level` defaults to 0 (N workers
+interleaving iteration tables is noise); pass an explicit
 `print_level` to override.
+
+**Warm-start chaining (MPC / B&B).** Feed one batch's results into the
+next solve of a nearby batch:
+
+```python
+results = pounce.solve_nlp_batch(batch_t)              # cold
+results = pounce.solve_nlp_batch(batch_t1, warms=results)  # warm
+```
+
+Each instance is seeded with the previous `x` and duals, the converged
+barrier parameter (`info["mu"]`) is threaded into `mu_init`, and
+`warm_start_init_point=yes` is forced. A warm start changes iteration
+counts, never solutions (re-solving the 24-instance gaslib sweep warm
+drops 482 total iterations to 120). A dimension-mismatched warm entry
+falls back to that instance's cold start.
+
+**Identical-sparsity batches (`share_structure=True`).** When every
+instance shares its KKT sparsity (parametric sweeps, multi-start, B&B
+siblings), this opt-in keeps each worker's factorization backend alive
+across instances so the symbolic analysis (fill-reducing ordering,
+supernode structure) runs once per worker rather than once per
+instance. Always correct — a pattern change just triggers a fresh
+analysis — but pooled solver state means results are within solver
+tolerance of, not bit-identical to, the default fresh-backend solves.
+The win scales with how expensive ordering is for your model (small
+models: negligible; large sparse models: worth measuring).
 
 ## scipy.optimize-style
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -57,6 +57,54 @@ x, info = prob.solve(x0=np.array([1.0, 5.0, 5.0, 1.0]))
 print(info['status_msg'], info['obj_val'], x)
 ```
 
+## Batched NLP solving (`solve_nlp_batch`)
+
+`pounce.solve_nlp_batch` solves N **independent** NLPs and returns one
+`(x, info)` pair per input, in input order — for parametric sweeps,
+multi-start, MPC chains, or branch-and-bound node relaxations where
+each sibling differs only in tightened bounds.
+
+```python
+import numpy as np
+import pounce
+
+base = pounce.read_nl("model.nl")          # native-Rust evaluators
+
+# One parsed structure, many variations (cheap clones of the AD tapes):
+rng = np.random.default_rng(0)
+batch = [base.variant(x0=np.asarray(base.x0) + rng.normal(0, 0.01, base.n))
+         for _ in range(24)]
+
+results = pounce.solve_nlp_batch(batch, options={"tol": 1e-8})
+for x, info in results:
+    print(info["status_msg"], info["obj_val"])
+```
+
+`NlProblem.variant(x0=, x_l=, x_u=, g_l=, g_u=)` builds a sibling
+instance with per-instance starting point / bounds; everything
+structural (expression DAG, AD tapes, sparsity, coloring) is shared
+work that is not redone.
+
+**Native vs. callback inputs — the GIL caveat.** Batch parallelism
+needs evaluators that don't touch Python during the solve:
+
+* `NlProblem` inputs (from `read_nl` / `variant`) are native-Rust
+  reverse-mode-AD evaluators. The batch runs **in parallel** on a
+  Rayon thread pool with the GIL released; each worker solves its
+  instance end-to-end with an inner-serial factorization
+  (outer-parallel / inner-serial, the same model as `solve_qp_batch`).
+* Callback-based `Problem` inputs evaluate through Python, and every
+  callback needs the GIL — parallelizing them buys nothing. They are
+  solved **sequentially** (pass `x0s=`, one starting point per
+  instance). True parallel callback batching is tracked as pounce#126
+  phase 2.
+
+With `parallel=False` the native path also solves one instance at a
+time, letting each factorization parallelize internally — better for a
+few large instances. For the batch, `print_level` defaults to 0
+(N workers interleaving iteration tables is noise); pass an explicit
+`print_level` to override.
+
 ## scipy.optimize-style
 
 ```python

--- a/python/benchmarks/bench_nlp_batch_126.py
+++ b/python/benchmarks/bench_nlp_batch_126.py
@@ -1,0 +1,95 @@
+"""Benchmark parallel vs sequential batched NLP solving (issue #126).
+
+`pounce.solve_nlp_batch(..., parallel=True)` runs N independent native
+(`.nl`-loaded) instances on a Rayon pool, each worker with its own
+IpoptApplication and an inner-serial FERAL factor (outer-parallel /
+inner-serial — the same model as the QP batch). This script measures
+the end-to-end wall time of the parallel path against the sequential
+one (`parallel=False`, where each instance's factor may parallelize
+internally) on a multi-start sweep of one model: K clones of the same
+structure, each from a randomly perturbed starting point — the cheap
+per-instance `NlProblem.variant(...)` path.
+
+A correctness gate runs first: every instance must report
+Solve_Succeeded under both modes, and the per-instance solutions must
+agree across modes, so a timing win can't come from solving the wrong
+thing (or nothing).
+
+Expected shape of the result: speedup ~ min(K, cores), modulo
+per-instance iteration-count imbalance (NLP instances converge in
+ragged iteration counts; a finished instance frees its worker). On a
+4-core container with K=24 gaslib11 instances this measured ~4.7x —
+slightly super-linear because the sequential baseline pays the parallel
+factor's coordination overhead on factors this small.
+
+Run (from the repo root, with pounce installed):
+
+    python python/benchmarks/bench_nlp_batch_126.py [path/to/model.nl]
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+import pounce
+
+DEFAULT_NL = (
+    Path(__file__).resolve().parents[2]
+    / "crates" / "pounce-cli" / "tests" / "fixtures"
+    / "aux_presolve" / "gaslib11_steady.nl"
+)
+K = 24
+SEED = 0
+X0_NOISE = 0.01
+
+
+def main() -> int:
+    nl = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_NL
+    base = pounce.read_nl(str(nl))
+    print(f"model: {nl.name}  n={base.n} m={base.m} "
+          f"nnz_jac={base.nnz_jac} nnz_hess={base.nnz_hess}")
+
+    rng = np.random.default_rng(SEED)
+    x0 = np.asarray(base.x0)
+    batch = [
+        base.variant(x0=x0 + rng.normal(0.0, X0_NOISE, base.n))
+        for _ in range(K)
+    ]
+
+    t0 = time.perf_counter()
+    seq = pounce.solve_nlp_batch(batch, parallel=False)
+    t_seq = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    par = pounce.solve_nlp_batch(batch, parallel=True)
+    t_par = time.perf_counter() - t0
+
+    # Correctness gate before any timing claim.
+    bad = [
+        i for i, ((_, si), (_, pi)) in enumerate(zip(seq, par))
+        if si["status_msg"] != "Solve_Succeeded"
+        or pi["status_msg"] != "Solve_Succeeded"
+    ]
+    if bad:
+        print(f"FAIL: instances {bad} did not converge")
+        return 1
+    worst = max(
+        float(np.max(np.abs(xs - xp)))
+        for (xs, _), (xp, _) in zip(seq, par)
+    )
+    iters = [info["iter_count"] for _, info in par]
+
+    print(f"instances: {K}   cores: {os.cpu_count()}")
+    print(f"iters/instance: min={min(iters)} max={max(iters)} "
+          f"(ragged is expected)")
+    print(f"max |x_seq - x_par| over batch: {worst:.3e}")
+    print(f"sequential: {t_seq:.3f} s   parallel: {t_par:.3f} s   "
+          f"speedup: {t_seq / t_par:.2f}x")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/benchmarks/bench_nlp_batch_126.py
+++ b/python/benchmarks/bench_nlp_batch_126.py
@@ -67,6 +67,17 @@ def main() -> int:
     par = pounce.solve_nlp_batch(batch, parallel=True)
     t_par = time.perf_counter() - t0
 
+    # Optional extras (issue #126): identical-sparsity backend pooling
+    # and warm-start chaining (re-solve the same batch seeded from the
+    # previous results — the MPC / B&B shape).
+    t0 = time.perf_counter()
+    pooled = pounce.solve_nlp_batch(batch, share_structure=True)
+    t_pool = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    warm = pounce.solve_nlp_batch(batch, warms=par)
+    t_warm = time.perf_counter() - t0
+
     # Correctness gate before any timing claim.
     bad = [
         i for i, ((_, si), (_, pi)) in enumerate(zip(seq, par))
@@ -82,12 +93,24 @@ def main() -> int:
     )
     iters = [info["iter_count"] for _, info in par]
 
+    iters_warm = [info["iter_count"] for _, info in warm]
+    ok_extra = all(
+        i["status_msg"] == "Solve_Succeeded" for _, i in pooled
+    ) and all(i["status_msg"] == "Solve_Succeeded" for _, i in warm)
+    if not ok_extra:
+        print("FAIL: pooled / warm batch did not converge")
+        return 1
+
     print(f"instances: {K}   cores: {os.cpu_count()}")
     print(f"iters/instance: min={min(iters)} max={max(iters)} "
           f"(ragged is expected)")
     print(f"max |x_seq - x_par| over batch: {worst:.3e}")
-    print(f"sequential: {t_seq:.3f} s   parallel: {t_par:.3f} s   "
-          f"speedup: {t_seq / t_par:.2f}x")
+    print(f"sequential:        {t_seq:.3f} s")
+    print(f"parallel:          {t_par:.3f} s   speedup: {t_seq / t_par:.2f}x")
+    print(f"+ share_structure: {t_pool:.3f} s   (symbolic shared per worker; "
+          f"win grows with model size)")
+    print(f"+ warms re-solve:  {t_warm:.3f} s   "
+          f"({sum(iters)} -> {sum(iters_warm)} total iters)")
     return 0
 
 

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -17,6 +17,7 @@ from ._pounce import (
     Problem, Solver, NlProblem, read_nl, classify_working_set, __version__,
 )
 from ._minimize import minimize, OptimizeResult
+from ._nlp_batch import solve_nlp_batch
 from ._curve_fit import (
     curve_fit,
     curve_fit_minima,
@@ -46,6 +47,7 @@ __all__ = [
     "Solver",
     "NlProblem",
     "read_nl",
+    "solve_nlp_batch",
     "minimize",
     "OptimizeResult",
     "curve_fit",

--- a/python/pounce/_nlp_batch.py
+++ b/python/pounce/_nlp_batch.py
@@ -1,0 +1,108 @@
+"""Batched NLP solving (pounce#126): solve N independent NLPs, one
+result per input, in input order.
+
+Two kinds of input, two execution paths:
+
+* ``NlProblem`` instances (from :func:`pounce.read_nl` /
+  :meth:`NlProblem.variant`) are **native-Rust** evaluators — reverse-
+  mode AD tapes with no Python callbacks. These solve in parallel on a
+  Rayon thread pool with the GIL released (outer-parallel across
+  instances, inner-serial linear-solver factor per worker).
+* Callback-based :class:`pounce.Problem` objects evaluate through
+  Python, so every objective/gradient/constraint call needs the GIL —
+  parallelizing them buys nothing and risks deadlock. They are solved
+  **sequentially**, documented here rather than discovered the hard
+  way. (True parallel callback batching is pounce#126 phase 2.)
+"""
+
+from __future__ import annotations
+
+from . import _pounce
+
+
+def solve_nlp_batch(problems, x0s=None, options=None, parallel=True):
+    """Solve a batch of independent NLPs; one ``(x, info)`` per input.
+
+    Parameters
+    ----------
+    problems : sequence of NlProblem, or sequence of Problem
+        The instances to solve. All entries must be of the same kind.
+        ``NlProblem`` entries (native, from :func:`read_nl` /
+        :meth:`NlProblem.variant`) run in parallel; ``Problem``
+        entries (Python callbacks) run sequentially — see the module
+        docstring.
+    x0s : sequence of array-like, optional
+        Per-instance starting points. Required for ``Problem`` inputs
+        (their ``solve`` takes ``x0`` explicitly). For ``NlProblem``
+        inputs this overrides each model's ``.nl`` starting point
+        (entries may be ``None`` to keep a model's own ``x0``).
+    options : dict, optional
+        IPOPT-style options applied identically to every instance,
+        with the same value coercion as ``Problem.add_option``
+        (``True``/``False`` become ``"yes"``/``"no"``). The native
+        path defaults ``print_level`` to 0 — interleaved per-iteration
+        tables from concurrent workers are noise — but an explicit
+        ``print_level`` wins.
+    parallel : bool, default True
+        Native path only: solve instances concurrently on the Rayon
+        pool (each worker using an inner-serial factorization). With
+        ``False``, instances solve one at a time and each
+        factorization may parallelize internally — better for a few
+        large instances. Ignored for ``Problem`` inputs (always
+        sequential).
+
+    Returns
+    -------
+    list of (numpy.ndarray, dict)
+        Per instance, in input order: the final iterate ``x`` and an
+        info dict matching ``Problem.solve``'s layout (``status``,
+        ``status_msg``, ``obj_val``, ``g``, ``mult_g``, ``mult_x_L``,
+        ``mult_x_U``, ``iter_count``, ...).
+    """
+    problems = list(problems)
+    if not problems:
+        return []
+    if x0s is not None:
+        x0s = list(x0s)
+        if len(x0s) != len(problems):
+            raise ValueError(
+                f"solve_nlp_batch: got {len(problems)} problems but "
+                f"{len(x0s)} starting points"
+            )
+
+    native = [isinstance(p, _pounce.NlProblem) for p in problems]
+    if all(native):
+        if x0s is not None:
+            problems = [
+                p if x0 is None else p.variant(x0=x0)
+                for p, x0 in zip(problems, x0s)
+            ]
+        return _pounce.solve_nlp_batch(
+            problems, options=options, parallel=parallel
+        )
+    if any(native):
+        raise TypeError(
+            "solve_nlp_batch: mixed NlProblem and Problem inputs are not "
+            "supported; split the batch by kind"
+        )
+
+    # Callback-based Problem objects: sequential fallback (the GIL
+    # serializes every callback, so there is no parallel win to offer;
+    # see pounce#126 phase 2).
+    if not all(isinstance(p, _pounce.Problem) for p in problems):
+        raise TypeError(
+            "solve_nlp_batch: expected a sequence of pounce.NlProblem or "
+            "pounce.Problem instances"
+        )
+    if x0s is None:
+        raise ValueError(
+            "solve_nlp_batch: x0s is required for Problem inputs (their "
+            "solve() takes an explicit starting point)"
+        )
+    results = []
+    for p, x0 in zip(problems, x0s):
+        if options:
+            for name, value in options.items():
+                p.add_option(name, value)
+        results.append(p.solve(x0))
+    return results

--- a/python/pounce/_nlp_batch.py
+++ b/python/pounce/_nlp_batch.py
@@ -56,6 +56,12 @@ def solve_nlp_batch(problems, x0s=None, options=None, parallel=True,
         using an inner-serial factorization). With ``False``,
         instances solve one at a time and each factorization may
         parallelize internally — better for a few large instances.
+        On the default path (``share_structure=False``) each instance
+        gets its own fresh backend, so a result depends only on that
+        instance, not on which worker ran it or on ``parallel`` — the
+        batch is bit-identical to solving the same instances one by one
+        (this is what ``test_problem_batch_parallel_equals_sequential``
+        pins). ``share_structure=True`` relaxes this to within-tolerance.
     warms : sequence of (x, info), optional
         Previous results (as returned by this function), one per
         instance, to warm-start from: the warm ``x`` and the

--- a/python/pounce/_nlp_batch.py
+++ b/python/pounce/_nlp_batch.py
@@ -1,18 +1,26 @@
 """Batched NLP solving (pounce#126): solve N independent NLPs, one
 result per input, in input order.
 
-Two kinds of input, two execution paths:
+Two kinds of input, one entry point:
 
 * ``NlProblem`` instances (from :func:`pounce.read_nl` /
   :meth:`NlProblem.variant`) are **native-Rust** evaluators — reverse-
   mode AD tapes with no Python callbacks. These solve in parallel on a
-  Rayon thread pool with the GIL released (outer-parallel across
+  Rayon thread pool with the GIL fully released (outer-parallel across
   instances, inner-serial linear-solver factor per worker).
-* Callback-based :class:`pounce.Problem` objects evaluate through
-  Python, so every objective/gradient/constraint call needs the GIL —
-  parallelizing them buys nothing and risks deadlock. They are solved
-  **sequentially**, documented here rather than discovered the hard
-  way. (True parallel callback batching is pounce#126 phase 2.)
+* Callback-based :class:`pounce.Problem` objects also solve in
+  parallel (phase 2): each worker owns its solve and re-acquires the
+  GIL transiently for every ``objective`` / ``gradient`` /
+  ``constraints`` / ``jacobian`` / ``hessian`` call. The GIL
+  serializes the *Python* share of the work, so the speedup scales
+  with the Rust/Python work ratio — large instances whose KKT
+  factorizations dominate parallelize well; tiny problems whose
+  callbacks dominate won't. Native ``NlProblem`` batches don't have
+  this ceiling.
+
+Both paths support warm-start chaining: pass a previous batch's
+results as ``warms=`` to seed each instance (receding-horizon MPC,
+parameter continuation, B&B dives).
 """
 
 from __future__ import annotations
@@ -20,36 +28,52 @@ from __future__ import annotations
 from . import _pounce
 
 
-def solve_nlp_batch(problems, x0s=None, options=None, parallel=True):
+def solve_nlp_batch(problems, x0s=None, options=None, parallel=True,
+                    warms=None, share_structure=False):
     """Solve a batch of independent NLPs; one ``(x, info)`` per input.
 
     Parameters
     ----------
     problems : sequence of NlProblem, or sequence of Problem
-        The instances to solve. All entries must be of the same kind.
-        ``NlProblem`` entries (native, from :func:`read_nl` /
-        :meth:`NlProblem.variant`) run in parallel; ``Problem``
-        entries (Python callbacks) run sequentially — see the module
-        docstring.
+        The instances to solve. All entries must be of the same kind
+        (mixed batches raise ``TypeError``). See the module docstring
+        for the two execution models.
     x0s : sequence of array-like, optional
         Per-instance starting points. Required for ``Problem`` inputs
         (their ``solve`` takes ``x0`` explicitly). For ``NlProblem``
         inputs this overrides each model's ``.nl`` starting point
         (entries may be ``None`` to keep a model's own ``x0``).
     options : dict, optional
-        IPOPT-style options applied identically to every instance,
-        with the same value coercion as ``Problem.add_option``
-        (``True``/``False`` become ``"yes"``/``"no"``). The native
-        path defaults ``print_level`` to 0 — interleaved per-iteration
-        tables from concurrent workers are noise — but an explicit
-        ``print_level`` wins.
+        IPOPT-style options applied to every instance, with the same
+        value coercion as ``Problem.add_option`` (``True``/``False``
+        become ``"yes"``/``"no"``). For ``Problem`` inputs each
+        instance's own ``add_option`` settings are applied first, then
+        this overlay. ``print_level`` defaults to 0 for the batch —
+        interleaved per-iteration tables from concurrent workers are
+        noise — but an explicit ``print_level`` wins.
     parallel : bool, default True
-        Native path only: solve instances concurrently on the Rayon
-        pool (each worker using an inner-serial factorization). With
-        ``False``, instances solve one at a time and each
-        factorization may parallelize internally — better for a few
-        large instances. Ignored for ``Problem`` inputs (always
-        sequential).
+        Solve instances concurrently on the Rayon pool (each worker
+        using an inner-serial factorization). With ``False``,
+        instances solve one at a time and each factorization may
+        parallelize internally — better for a few large instances.
+    warms : sequence of (x, info), optional
+        Previous results (as returned by this function), one per
+        instance, to warm-start from: the warm ``x`` and the
+        ``mult_g`` / ``mult_x_L`` / ``mult_x_U`` duals seed each
+        solve, the previous barrier parameter (``info["mu"]``) is
+        threaded into ``mu_init``, and ``warm_start_init_point=yes``
+        is forced. A warm start only affects iteration counts, never
+        the solution.
+    share_structure : bool, default False
+        Opt-in for batches whose instances share their KKT sparsity
+        (parametric sweeps, multi-start, B&B siblings): each worker
+        keeps its factorization backend across instances, so the
+        symbolic analysis (fill-reducing ordering, supernode
+        structure) runs once per worker instead of once per instance.
+        Always correct — a sparsity change just triggers a fresh
+        analysis — but solver state carried across instances means
+        results are within tolerance of, not bit-identical to, the
+        default fresh-backend solves.
 
     Returns
     -------
@@ -78,7 +102,8 @@ def solve_nlp_batch(problems, x0s=None, options=None, parallel=True):
                 for p, x0 in zip(problems, x0s)
             ]
         return _pounce.solve_nlp_batch(
-            problems, options=options, parallel=parallel
+            problems, options=options, parallel=parallel, warms=warms,
+            share_structure=share_structure,
         )
     if any(native):
         raise TypeError(
@@ -86,9 +111,6 @@ def solve_nlp_batch(problems, x0s=None, options=None, parallel=True):
             "supported; split the batch by kind"
         )
 
-    # Callback-based Problem objects: sequential fallback (the GIL
-    # serializes every callback, so there is no parallel win to offer;
-    # see pounce#126 phase 2).
     if not all(isinstance(p, _pounce.Problem) for p in problems):
         raise TypeError(
             "solve_nlp_batch: expected a sequence of pounce.NlProblem or "
@@ -99,10 +121,7 @@ def solve_nlp_batch(problems, x0s=None, options=None, parallel=True):
             "solve_nlp_batch: x0s is required for Problem inputs (their "
             "solve() takes an explicit starting point)"
         )
-    results = []
-    for p, x0 in zip(problems, x0s):
-        if options:
-            for name, value in options.items():
-                p.add_option(name, value)
-        results.append(p.solve(x0))
-    return results
+    return _pounce.solve_problem_batch(
+        problems, x0s, options=options, parallel=parallel, warms=warms,
+        share_structure=share_structure,
+    )

--- a/python/tests/test_nlp_batch.py
+++ b/python/tests/test_nlp_batch.py
@@ -139,8 +139,56 @@ def test_variant_validates_lengths():
         p.variant(x0=[1.0])
 
 
+def test_native_warm_start_chain():
+    """MPC-style chain: solve cold, re-solve a perturbed batch seeded
+    from the previous results. Warm solves converge to the perturbed
+    optimum without iterating more than the cold solves."""
+    p = _load()
+    batch = [p, p.variant(x0=np.asarray(p.x0) + 0.05)]
+    cold = pounce.solve_nlp_batch(batch)
+
+    xu = np.asarray(p.x_u).copy()
+    xu[0] = cold[0][0][0] + 0.5  # loose bound: same optimum, new instance
+    perturbed = [q.variant(x_u=xu) for q in batch]
+    warm = pounce.solve_nlp_batch(perturbed, warms=cold)
+    cold2 = pounce.solve_nlp_batch(perturbed)
+    for i, ((xw, iw), (xc, ic)) in enumerate(zip(warm, cold2)):
+        assert iw["status_msg"] == "Solve_Succeeded", f"instance {i}"
+        np.testing.assert_allclose(xw, xc, atol=1e-6)
+        assert iw["iter_count"] <= ic["iter_count"], (
+            f"instance {i}: warm {iw['iter_count']} > cold {ic['iter_count']}"
+        )
+
+
+def test_share_structure_matches_default_within_tolerance():
+    """The identical-sparsity backend pool returns the same solutions
+    (within solver tolerance) as fresh-per-instance backends."""
+    p = _load()
+    rng = np.random.default_rng(1)
+    batch = [p.variant(x0=np.asarray(p.x0) + rng.normal(0, 0.01, p.n))
+             for _ in range(6)]
+    fresh = pounce.solve_nlp_batch(batch)
+    pooled = pounce.solve_nlp_batch(batch, share_structure=True)
+    for i, ((xf, inf_f), (xp, inf_p)) in enumerate(zip(fresh, pooled)):
+        assert inf_f["status_msg"] == "Solve_Succeeded", f"instance {i}"
+        assert inf_p["status_msg"] == "Solve_Succeeded", f"instance {i}"
+        np.testing.assert_allclose(xp, xf, atol=1e-6)
+
+
+def test_warms_validation():
+    p = _load()
+    results = pounce.solve_nlp_batch([p])
+    # Wrong length.
+    with pytest.raises(ValueError, match="warms"):
+        pounce.solve_nlp_batch([p, p], warms=results)
+    # Missing dual keys.
+    x, info = results[0]
+    with pytest.raises(ValueError, match="mult_g"):
+        pounce.solve_nlp_batch([p], warms=[(x, {"obj_val": 0.0})])
+
+
 # ---------------------------------------------------------------------
-# Callback (Problem) path — sequential fallback
+# Callback (Problem) path — parallel with per-callback GIL (phase 2)
 # ---------------------------------------------------------------------
 
 
@@ -183,18 +231,84 @@ def _hs071_problem():
     )
 
 
-def test_problem_inputs_solve_sequentially():
+def test_problem_batch_parallel_matches_individual_solves():
     x0 = np.array([1.0, 5.0, 5.0, 1.0])
-    results = pounce.solve_nlp_batch(
-        [_hs071_problem(), _hs071_problem()],
-        x0s=[x0, x0],
-        options={"print_level": 0, "tol": 1e-8},
+    k = 6
+    batch = pounce.solve_nlp_batch(
+        [_hs071_problem() for _ in range(k)],
+        x0s=[x0] * k,
+        options={"tol": 1e-8},
     )
-    assert len(results) == 2
-    for x, info in results:
-        assert info["status_msg"] == "Solve_Succeeded"
+    assert len(batch) == k
+
+    ref = _hs071_problem()
+    ref.add_option("tol", 1e-8)
+    ref.add_option("print_level", 0)
+    x_ref, info_ref = ref.solve(x0=x0)
+
+    for i, (x, info) in enumerate(batch):
+        assert info["status_msg"] == "Solve_Succeeded", f"instance {i}"
         np.testing.assert_allclose(info["obj_val"], 17.0140172, rtol=1e-5)
-    np.testing.assert_array_equal(results[0][0], results[1][0])
+        np.testing.assert_array_equal(x, x_ref)
+        assert info["iter_count"] == info_ref["iter_count"]
+    # All instances identical → identical iterates regardless of which
+    # worker ran them.
+    np.testing.assert_array_equal(batch[0][0], batch[k - 1][0])
+
+
+def test_problem_batch_parallel_equals_sequential():
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    probs = lambda: [_hs071_problem(), _hs071_problem()]  # noqa: E731
+    par = pounce.solve_nlp_batch(probs(), x0s=[x0, x0], parallel=True)
+    seq = pounce.solve_nlp_batch(probs(), x0s=[x0, x0], parallel=False)
+    for (xp, ip), (xs, _) in zip(par, seq):
+        assert ip["status_msg"] == "Solve_Succeeded"
+        np.testing.assert_array_equal(xp, xs)
+
+
+def test_problem_batch_honors_per_instance_options():
+    """Each Problem's own add_option settings apply to its instance."""
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    capped = _hs071_problem()
+    capped.add_option("max_iter", 1)
+    results = pounce.solve_nlp_batch(
+        [_hs071_problem(), capped], x0s=[x0, x0]
+    )
+    assert results[0][1]["status_msg"] == "Solve_Succeeded"
+    assert results[1][1]["status_msg"] == "Maximum_Iterations_Exceeded"
+
+
+def test_problem_batch_raising_callback_does_not_poison_batch():
+    """A Python exception inside one instance's callback degrades to an
+    eval failure for that instance only."""
+
+    class Exploding(_HS071):
+        def objective(self, x):
+            raise RuntimeError("boom")
+
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    bad = pounce.Problem(
+        n=4, m=2, problem_obj=Exploding(),
+        lb=[1.0] * 4, ub=[5.0] * 4,
+        cl=[25.0, 40.0], cu=[2e19, 40.0],
+    )
+    results = pounce.solve_nlp_batch(
+        [_hs071_problem(), bad, _hs071_problem()], x0s=[x0] * 3
+    )
+    assert results[0][1]["status_msg"] == "Solve_Succeeded"
+    assert results[2][1]["status_msg"] == "Solve_Succeeded"
+    assert results[1][1]["status_msg"] != "Solve_Succeeded"
+
+
+def test_problem_batch_warm_start_chain():
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    probs = lambda: [_hs071_problem(), _hs071_problem()]  # noqa: E731
+    cold = pounce.solve_nlp_batch(probs(), x0s=[x0, x0])
+    warm = pounce.solve_nlp_batch(probs(), x0s=[x0, x0], warms=cold)
+    for i, ((xw, iw), (xc, ic)) in enumerate(zip(warm, cold)):
+        assert iw["status_msg"] == "Solve_Succeeded", f"instance {i}"
+        np.testing.assert_allclose(xw, xc, atol=1e-6)
+        assert iw["iter_count"] <= ic["iter_count"]
 
 
 def test_problem_inputs_require_x0s():

--- a/python/tests/test_nlp_batch.py
+++ b/python/tests/test_nlp_batch.py
@@ -125,12 +125,43 @@ def test_info_dict_layout_matches_problem_solve():
         "mult_x_L", "mult_x_U", "iter_count", "mu",
         "final_kkt_error", "final_dual_inf", "final_constr_viol",
         "final_compl",
+        # DiffHandoff active-set masks — must match Problem.solve's keys
+        # so the JAX / torch backward passes read a batch result the same
+        # way they read a single solve (PR #129 info-dict parity).
+        "pinned_vars", "active_constraints", "active_tol",
     ):
         assert key in info, key
     assert info["g"].shape == (p.m,)
     assert info["mult_g"].shape == (p.m,)
     assert info["mult_x_L"].shape == (p.n,)
     assert info["mult_x_U"].shape == (p.n,)
+    assert info["pinned_vars"].shape == (p.n,)
+    assert info["pinned_vars"].dtype == bool
+    assert info["active_constraints"].shape == (p.m,)
+    assert info["active_constraints"].dtype == bool
+    assert info["active_tol"] > 0.0
+
+
+def test_native_active_constraints_follow_variant_bounds():
+    """The native batch's active-set mask is built from each instance's
+    own g_l/g_u, including a ``variant`` override (PR #129). parametric.nl
+    is all equalities (active); relaxing one row to a loose inequality
+    makes it slack (multiplier ~0) and drops it from the active set —
+    which only happens if the variant's bounds reach equality_mask."""
+    p = _load()
+    (_, base), = pounce.solve_nlp_batch([p])
+    assert base["status_msg"] == "Solve_Succeeded"
+    # every parametric.nl row is an equality, hence always active
+    assert np.all(base["active_constraints"])
+
+    gl = np.asarray(p.g_l).copy()
+    gu = np.asarray(p.g_u).copy()
+    gl[0], gu[0] = -1e3, 1e3  # row 0 → loose, non-binding inequality
+    (_, var), = pounce.solve_nlp_batch([p.variant(g_l=gl, g_u=gu)])
+    assert var["status_msg"] == "Solve_Succeeded"
+    assert abs(var["mult_g"][0]) < var["active_tol"]  # now slack
+    assert not var["active_constraints"][0]            # so: inactive
+    assert np.all(var["active_constraints"][1:])       # others still equalities
 
 
 def test_variant_validates_lengths():
@@ -251,6 +282,16 @@ def test_problem_batch_parallel_matches_individual_solves():
         np.testing.assert_allclose(info["obj_val"], 17.0140172, rtol=1e-5)
         np.testing.assert_array_equal(x, x_ref)
         assert info["iter_count"] == info_ref["iter_count"]
+        # Active-set masks must match the single solve byte-for-byte:
+        # HS071 has one equality row (cl==cu==40, always active) and one
+        # inequality, so this exercises the equality_mask the batch path
+        # now threads through from the input problem (PR #129 parity).
+        np.testing.assert_array_equal(
+            info["active_constraints"], info_ref["active_constraints"],
+        )
+        np.testing.assert_array_equal(info["pinned_vars"], info_ref["pinned_vars"])
+        assert info["active_tol"] == info_ref["active_tol"]
+        assert info_ref["active_constraints"][1]  # the equality is active
     # All instances identical → identical iterates regardless of which
     # worker ran them.
     np.testing.assert_array_equal(batch[0][0], batch[k - 1][0])
@@ -264,6 +305,59 @@ def test_problem_batch_parallel_equals_sequential():
     for (xp, ip), (xs, _) in zip(par, seq):
         assert ip["status_msg"] == "Solve_Succeeded"
         np.testing.assert_array_equal(xp, xs)
+
+
+class _DegenerateEq:
+    """min x0^2 s.t. x0 + x1 = 1. The optimum is x0=0, x1=1 with a
+    constraint multiplier of exactly 0 (the equality is satisfied but
+    does not bind the objective). So `|mult_g| > tol` alone classifies
+    the row as *inactive* — only the equality_mask marks it active.
+    This is the one configuration that exercises the mask the batch
+    path threads through from the input problem (PR #129)."""
+
+    def objective(self, x):
+        return x[0] ** 2
+
+    def gradient(self, x):
+        return np.array([2.0 * x[0], 0.0])
+
+    def constraints(self, x):
+        return np.array([x[0] + x[1]])
+
+    def jacobianstructure(self):
+        return (np.array([0, 0]), np.array([0, 1]))
+
+    def jacobian(self, x):
+        return np.array([1.0, 1.0])
+
+
+def _degenerate_eq_problem():
+    return pounce.Problem(
+        n=2, m=1, problem_obj=_DegenerateEq(),
+        lb=[-10.0, -10.0], ub=[10.0, 10.0],
+        cl=[1.0], cu=[1.0],  # equality row
+    )
+
+
+def test_problem_batch_active_constraints_use_equality_mask():
+    """A degenerate equality (zero multiplier) is marked active only via
+    the equality_mask the batch builder now threads from the input
+    problem. Without it the batch result would disagree with the single
+    solve — this is the fail-first guard for PR #129's info-dict parity."""
+    x0 = np.array([0.5, 0.5])
+    (x, info), = pounce.solve_nlp_batch([_degenerate_eq_problem()], x0s=[x0])
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, [0.0, 1.0], atol=1e-6)
+    # The multiplier is ~0, so a |mult|>tol-only classifier would miss it.
+    assert abs(info["mult_g"][0]) < info["active_tol"]
+    assert info["active_constraints"][0]  # equality is always active
+
+    ref = _degenerate_eq_problem()
+    ref.add_option("print_level", 0)
+    _, info_ref = ref.solve(x0=x0)
+    np.testing.assert_array_equal(
+        info["active_constraints"], info_ref["active_constraints"],
+    )
 
 
 def test_problem_batch_honors_per_instance_options():

--- a/python/tests/test_nlp_batch.py
+++ b/python/tests/test_nlp_batch.py
@@ -1,0 +1,210 @@
+"""Tests for ``pounce.solve_nlp_batch`` (pounce#126) — batched NLP
+solving: parallel native path for ``NlProblem`` inputs, sequential
+fallback for callback-based ``Problem`` inputs."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import pounce
+
+# Hand-crafted 5-var / 4-con NLP fixture committed for the CLI tests
+# (a transliteration of upstream sIPOPT's parametric_cpp example).
+_PARAMETRIC = (
+    Path(__file__).resolve().parents[2]
+    / "crates" / "pounce-cli" / "tests" / "fixtures" / "parametric.nl"
+)
+
+pytestmark = pytest.mark.skipif(
+    not _PARAMETRIC.exists(), reason="parametric.nl fixture missing"
+)
+
+
+def _load():
+    return pounce.read_nl(str(_PARAMETRIC))
+
+
+# ---------------------------------------------------------------------
+# Native (NlProblem) path
+# ---------------------------------------------------------------------
+
+
+def test_empty_batch_returns_empty_list():
+    assert pounce.solve_nlp_batch([]) == []
+
+
+def test_single_element_batch():
+    p = _load()
+    results = pounce.solve_nlp_batch([p])
+    assert len(results) == 1
+    x, info = results[0]
+    assert info["status_msg"] == "Solve_Succeeded"
+    assert x.shape == (p.n,)
+    assert np.all(np.isfinite(x))
+    assert info["iter_count"] > 0
+
+
+def test_batch_results_in_input_order_and_match_sequential():
+    p = _load()
+    # base, multi-start (shifted x0), and a bound-tightened sibling —
+    # the branch-and-bound node shape.
+    shifted = p.variant(x0=np.asarray(p.x0) + 0.1)
+    base_x, _ = pounce.solve_nlp_batch([p])[0]
+    xu = np.asarray(p.x_u).copy()
+    xu[0] = base_x[0] - 0.05
+    tightened = p.variant(x_u=xu)
+
+    batch = [p, shifted, tightened]
+    par = pounce.solve_nlp_batch(batch)
+    seq = pounce.solve_nlp_batch(batch, parallel=False)
+    assert len(par) == len(seq) == 3
+
+    for i, ((xp, ip), (xs, _)) in enumerate(zip(par, seq)):
+        assert ip["status_msg"] == "Solve_Succeeded", f"instance {i}"
+        # Parallel and sequential agree on the same instance.
+        np.testing.assert_allclose(xp, xs, rtol=0, atol=1e-12)
+
+    # Instance 0 reproduces the standalone solve.
+    np.testing.assert_array_equal(par[0][0], base_x)
+    # Instance 1 (multi-start) reaches the same optimum.
+    np.testing.assert_allclose(par[1][0], base_x, atol=1e-5)
+    # Instance 2 honors its tightened bound (modulo the IPM's
+    # bound_relax_factor slack) and differs from instance 0.
+    assert par[2][0][0] <= xu[0] + 1e-7
+    assert abs(par[2][0][0] - base_x[0]) > 1e-6
+
+
+def test_x0s_override_per_instance():
+    p = _load()
+    x0 = np.asarray(p.x0)
+    results = pounce.solve_nlp_batch([p, p], x0s=[None, x0 + 0.1])
+    assert all(info["status_msg"] == "Solve_Succeeded" for _, info in results)
+    np.testing.assert_allclose(results[0][0], results[1][0], atol=1e-5)
+
+
+def test_x0s_length_mismatch_raises():
+    p = _load()
+    with pytest.raises(ValueError, match="starting points"):
+        pounce.solve_nlp_batch([p, p], x0s=[np.asarray(p.x0)])
+
+
+def test_infeasible_instance_does_not_poison_batch():
+    p = _load()
+    # Contradictory variable bounds: x_l > x_u on the first variable.
+    xl = np.asarray(p.x_l).copy()
+    xu = np.asarray(p.x_u).copy()
+    xl[0], xu[0] = 2.0, 1.0
+    bad = p.variant(x_l=xl, x_u=xu)
+    results = pounce.solve_nlp_batch([p, bad, p])
+    assert results[0][1]["status_msg"] == "Solve_Succeeded"
+    assert results[2][1]["status_msg"] == "Solve_Succeeded"
+    assert results[1][1]["status_msg"] != "Solve_Succeeded"
+    np.testing.assert_array_equal(results[0][0], results[2][0])
+
+
+def test_unknown_option_raises():
+    p = _load()
+    with pytest.raises(RuntimeError, match="no_such_option"):
+        pounce.solve_nlp_batch([p], options={"no_such_option": 1})
+
+
+def test_options_are_applied():
+    p = _load()
+    # An absurdly tight iteration cap must change the outcome.
+    (x, info), = pounce.solve_nlp_batch([p], options={"max_iter": 1})
+    assert info["status_msg"] == "Maximum_Iterations_Exceeded"
+    assert info["iter_count"] <= 1
+
+
+def test_info_dict_layout_matches_problem_solve():
+    p = _load()
+    (x, info), = pounce.solve_nlp_batch([p])
+    for key in (
+        "status", "status_msg", "obj_val", "g", "mult_g",
+        "mult_x_L", "mult_x_U", "iter_count", "mu",
+        "final_kkt_error", "final_dual_inf", "final_constr_viol",
+        "final_compl",
+    ):
+        assert key in info, key
+    assert info["g"].shape == (p.m,)
+    assert info["mult_g"].shape == (p.m,)
+    assert info["mult_x_L"].shape == (p.n,)
+    assert info["mult_x_U"].shape == (p.n,)
+
+
+def test_variant_validates_lengths():
+    p = _load()
+    with pytest.raises(ValueError, match="x0"):
+        p.variant(x0=[1.0])
+
+
+# ---------------------------------------------------------------------
+# Callback (Problem) path — sequential fallback
+# ---------------------------------------------------------------------
+
+
+class _HS071:
+    def objective(self, x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def gradient(self, x):
+        return np.array([
+            x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]),
+            x[0] * x[3],
+            x[0] * x[3] + 1.0,
+            x[0] * (x[0] + x[1] + x[2]),
+        ])
+
+    def constraints(self, x):
+        return np.array([np.prod(x), np.dot(x, x)])
+
+    def jacobianstructure(self):
+        return (np.repeat([0, 1], 4), np.tile([0, 1, 2, 3], 2))
+
+    def jacobian(self, x):
+        return np.array([
+            x[1] * x[2] * x[3],
+            x[0] * x[2] * x[3],
+            x[0] * x[1] * x[3],
+            x[0] * x[1] * x[2],
+            2 * x[0],
+            2 * x[1],
+            2 * x[2],
+            2 * x[3],
+        ])
+
+
+def _hs071_problem():
+    return pounce.Problem(
+        n=4, m=2, problem_obj=_HS071(),
+        lb=[1.0] * 4, ub=[5.0] * 4,
+        cl=[25.0, 40.0], cu=[2e19, 40.0],
+    )
+
+
+def test_problem_inputs_solve_sequentially():
+    x0 = np.array([1.0, 5.0, 5.0, 1.0])
+    results = pounce.solve_nlp_batch(
+        [_hs071_problem(), _hs071_problem()],
+        x0s=[x0, x0],
+        options={"print_level": 0, "tol": 1e-8},
+    )
+    assert len(results) == 2
+    for x, info in results:
+        assert info["status_msg"] == "Solve_Succeeded"
+        np.testing.assert_allclose(info["obj_val"], 17.0140172, rtol=1e-5)
+    np.testing.assert_array_equal(results[0][0], results[1][0])
+
+
+def test_problem_inputs_require_x0s():
+    with pytest.raises(ValueError, match="x0s is required"):
+        pounce.solve_nlp_batch([_hs071_problem()])
+
+
+def test_mixed_inputs_raise():
+    with pytest.raises(TypeError, match="mixed"):
+        pounce.solve_nlp_batch(
+            [_load(), _hs071_problem()],
+            x0s=[None, np.ones(4)],
+        )


### PR DESCRIPTION
## Summary

Implements batched NLP solving for N independent problems in parallel on a Rayon thread pool — the general-NLP analog of `solve_qp_batch_parallel`. Covers parametric sweeps, multi-start, MPC chains, and branch-and-bound node relaxations where each instance differs only in starting point or tightened bounds.

Closes #126: phase 1 (native-Rust evaluators), phase 2 (parallel callback batching), and both optional extensions (warm-started batches, identical-sparsity structure sharing).

## Key Changes

**Core batching infrastructure (`pounce-algorithm`):**
- New `batch.rs` module: `solve_nlp_batch` (sequential), `solve_nlp_batch_parallel` (Rayon), and warm variants `solve_nlp_batch_warm` / `solve_nlp_batch_parallel_warm`
- Outer-parallel / inner-serial execution model: each worker owns a fully-equipped `IpoptApplication` built inside the worker via a `Sync` configure hook (which receives the instance index, enabling per-instance options); per-worker FERAL backends are forced serial to avoid oversubscription
- `CaptureTnlp` wrapper captures the final iterate, multipliers, and constraint values into owned `NlpBatchSolution` structs; results return in input order with per-instance `SolveStatistics`
- **Warm starts:** `NlpWarmStart` (built from a previous `NlpBatchResult`) seeds x + duals via a delegating `WarmStartTnlp` and threads the converged barrier μ into `mu_init` (floored at 1e-9, only when the caller didn't set `mu_init` explicitly); `warm_start_init_point=yes` is forced; dimension mismatches fall back to a cold start
- **Structure sharing (opt-in):** `FeralBackendPool` / `install_pooled_serial_feral_backend` park each worker's backend between instances so FERAL's pattern-fingerprint symbolic cache (ordering + supernode structure) carries across identical-sparsity instances; pattern changes re-analyze, so always correct

**Expression DAG thread-safety (`pounce-nl`):**
- Switched CSE (common subexpression) sharing from `Rc` to `Arc` in `Expr::Cse`, making `NlProblem` / `NlTnlp` `Send` for safe movement to rayon workers (compile-time `Send` assertions added)
- `NlTnlp` is now `Clone`; `NlTnlp::variant` / `NlVariation` build per-instance x0/bound overrides on one parsed model (cheap clones of AD tapes; only the named vectors replaced)

**Python bindings (`pounce-py` + `python/pounce`):**
- `pounce.solve_nlp_batch(problems, x0s=, options=, parallel=, warms=, share_structure=)` routes by input kind:
  - **Native `NlProblem`** (from `read_nl` / new `NlProblem.variant()`): full parallelism, GIL released for the whole batch
  - **Callback `Problem`** (phase 2): each instance's bridge (`PyTnlp` = `Py<PyAny>` handles + plain data, hence `Send`) is assembled under the GIL and moved to a rayon worker; every `eval_*` re-acquires the GIL transiently, so only the Python share serializes. No `Rc→Arc` refactor of the solver stack was needed — nothing solver-side crosses threads. Per-instance `add_option` settings honored with `options=` as a batch overlay; a raising callback fails only its own instance
- Options dict uses the same coercion as `Problem.add_option` (bool → "yes"/"no") and is validated up front; `print_level` defaults to 0 for batches (explicit values win)
- `warms=` accepts a previous batch's `(x, info)` results directly (the info dict's `mu` is threaded into `mu_init`)
- Info dicts mirror `Problem.solve`'s layout (`status`, `status_msg`, `obj_val`, `g`, `mult_g`, `mult_x_L`, `mult_x_U`, `iter_count`, `mu`, final convergence metrics)

**Tests, benchmarks, docs:**
- 9 Rust unit tests (`pounce-algorithm`), end-to-end `.nl` test (`pounce-cli`), 20 Python tests covering ordering, parallel≡sequential, infeasible-mixed, empty/single batches, per-instance options, raising callbacks, warm chains, structure sharing, and validation errors
- `python/benchmarks/bench_nlp_batch_126.py`; `docs/src/python.md` + `CHANGELOG.md` updated

## Measured results (4-core container)

| Workload | Result |
|---|---|
| 24× gaslib11 multi-start (`.nl`, native), parallel vs sequential | **4.99×**, bit-identical solutions |
| n=800 banded NLP × 8, Python callbacks (phase 2) | **3.85×**, identical solutions |
| Warm re-solve of the 24× gaslib sweep (`warms=`) | 482 → 120 total iterations (**2.2×** wall) |
| `share_structure=True` on the same sweep | ~1% here (symbolic share is tiny on this model; win grows with model size) |

## Determinism notes

- Default batch entry points build a fresh backend per instance: results are bit-identical to single solves (asserted in tests)
- `share_structure=True` carries solver state (MC64 scaling cache within its validity bound, pivot-quality escalation) across instances — results stay within solver tolerances but aren't guaranteed bit-identical, which is why it's opt-in
- Cross-*thread* symbolic sharing is deferred: it needs the `BackendPool` ownership refactor (`dev-notes/backend-pool-resolve.md`) or a feral-side symbolic export API

https://claude.ai/code/session_01A29C5YuUimCFmkYwuLGFQC