### PR TITLE
Fix sensitivity outputs to return natural (unscaled) units (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,26 @@ silently; the CLI sIPOPT path already mapped correctly and now shares the
 same helper). `pounce.curve_fit` no longer requires scaling to be off to
 trust the converged factor for its covariance / data-sensitivity reads.
 
+### Changed — C ABI: sensitivity entry points now return natural units (breaking)
+
+Behavior change for C callers of the sensitivity ABI (`pounce-cinterface`).
+`IpoptSolverReducedHessian`, `IpoptSolverParametricStep`, and
+`IpoptSolverKktSolve` now return values in **natural (unscaled) units** as part
+of the #128 fix above — previously, on a badly-scaled NLP (where the default
+`gradient-based` method fires), they returned the IPM's internally scaled
+values. A C caller that was compensating for the old behavior — e.g. passing a
+non-`1.0` `obj_scal` to `IpoptSolverReducedHessian` to undo the `df / dc²`
+factor by hand — will now get a doubly-corrected (wrong) result and must drop
+that workaround; `obj_scal` is once again only the plain extra multiplier its
+docs describe. Callers that want the old scaled values back have an escape
+hatch **only** for the raw KKT solve: `IpoptSolverKktSolveScaled(..., scaled =
+true)`. There is intentionally no scaled variant of `IpoptSolverReducedHessian`
+or `IpoptSolverParametricStep` — the natural-units reduced Hessian and
+parametric step are the only correct answers for a covariance / predictor read,
+so the scaled forms are not re-exposed across the ABI (the Rust
+`Solver::compute_reduced_hessian_scaled` remains for in-process calibrated
+callers).
+
 ### Added — PyTorch frontend for the differentiable solver (`pounce.torch`)
 
 A PyTorch frontend mirroring `pounce.jax`: a solve is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,27 +19,35 @@ whenever NLP scaling was active (the default
 constraint row exceeds 100 at the starting point). For a parameter-estimation
 NLP this made `-inv(reduced_hessian)` differ from the true covariance by
 `df / (dc_i·dc_j)` — the discretization-tracking "≈ nfe" fudge factor reported
-in #128. The same scaled factor silently corrupted the `pounce.jax`
-factor-reuse VJP (`JaxProblem(factor_reuse=True)`) on badly-scaled problems.
+in #128. The same scaled factor silently corrupted the factor-reuse VJP/JVP of
+**both** differentiable frontends (`pounce.jax` `JaxProblem(factor_reuse=True)`
+and `pounce.torch` `TorchProblem`) on badly-scaled problems.
 
-All held-factor back-solves now conjugate by the scaling diagonal
-(`K_natural⁻¹ = D K_scaled⁻¹ D`, `D = diag(√df·I_x, √df·dd⁻¹, dc/√df, dd/√df)`),
-so every sensitivity output is in the user's own units regardless of scaling
-method. The pre-fix solver-space values and the factors stay accessible:
+The scaled primal-dual system is the two-sided diagonal scaling
+`K_scaled = E·K_natural·F` (per-block: `E = (df, df/dd, dc, dd, df, df)` and
+`F = (1, 1/dd, dc/df, dd/df, 1/df, dd/df)` over `x, s, y_c, y_d, z, v`), so
+every held-factor back-solve now computes `K_natural⁻¹ = F·K_scaled⁻¹·E`: all
+eight KKT blocks — including the bound-multiplier z/v rows in `dx_full` —
+come back in the user's own units regardless of scaling method, and a
+negative `obj_scaling_factor` is handled (no square root involved). The CLI
+sIPOPT mode inherits the same correction: the `red_hessian` var-suffix output
+is now natural-units where upstream sIPOPT prints a scaled value it warns
+about. The pre-fix solver-space values and the factors stay accessible:
 `info["reduced_hessian_scaled"]` / `info["obj_scaling_factor"]` /
 `info["pin_g_scaling"]`, `Solver.reduced_hessian(..., scaled=True)`,
-`Solver.kkt_solve(..., scaled=True)`, the `Solver.nlp_scaling` dict, and the
-matching Rust surfaces (`SensResult` fields,
-`Solver::{compute_reduced_hessian_scaled, kkt_solve_scaled, nlp_scaling}`,
-`PdSensBacksolver::solve_scaled_space`).
+`Solver.kkt_solve(..., scaled=True)` / `kkt_solve_many(..., scaled=True)`,
+the `Solver.nlp_scaling` dict, the C ABI's `IpoptSolverKktSolveScaled`, and
+the matching Rust surfaces (`SensResult` fields,
+`Solver::{compute_reduced_hessian_scaled, kkt_solve_scaled,
+kkt_solve_many_scaled, nlp_scaling}`, `PdSensBacksolver::solve_scaled_space`).
 
 Also fixed in the same change: `SensSolve` / `Solver` pin-constraint indices
 are now mapped to KKT rows through the equality/inequality split
 (`full_g_to_c_block`), so pins are selected correctly when inequality
 constraints precede them in `g(x)` (previously the wrong row was used
-silently; the CLI sIPOPT path already mapped correctly). `pounce.curve_fit`
-no longer requires scaling to be off to trust the converged factor for its
-covariance / data-sensitivity reads.
+silently; the CLI sIPOPT path already mapped correctly and now shares the
+same helper). `pounce.curve_fit` no longer requires scaling to be off to
+trust the converged factor for its covariance / data-sensitivity reads.
 
 ### Added — PyTorch frontend for the differentiable solver (`pounce.torch`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `obj_scaling_factor` was silently ignored (maximization diverged)
+
+The `obj_scaling_factor` option was registered but never read: every solve
+constructed the NLP with no-op scaling, so the documented behavior — a
+constant multiplier on the objective, negative to **maximize** — was a silent
+no-op and maximization problems diverged (the IPM minimized the unscaled
+objective). The option value is now carried into `OrigIpoptNlp` on both the
+IPM and SQP paths (`ConstObjScaling`), combining with gradient-based /
+user scaling exactly as documented. Sensitivity analysis works under a
+negative factor too: the natural-units correction from #128 below uses a
+two-sided scaling with no square root, so `solve_with_sens` /
+`Solver.reduced_hessian` return the declared problem's reduced Hessian for
+maximization problems as well.
+
+### Added — KKT regularization reported alongside sensitivity outputs
+
+The IPM's inertia-correction perturbations are baked into the converged
+factor in scaled space, so a regularized final factorization makes the
+natural-units sensitivity outputs (covariance in particular) inexact and not
+perfectly scaling-invariant. The final `(δ_x, δ_s, δ_c, δ_d)` are now
+reported so workflows can check for the all-zero (exact) case:
+`info["kkt_perturbations"]` and `Solver.kkt_perturbations` (Python),
+`SensResult::kkt_perturbations` and `Solver::kkt_perturbations` (Rust).
+
 ### Fixed — sensitivity back-solves now return natural (unscaled) units (#128)
 
 The reduced Hessian from `solve_with_sens(compute_reduced_hessian=True)` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — sensitivity back-solves now return natural (unscaled) units (#128)
+
+The reduced Hessian from `solve_with_sens(compute_reduced_hessian=True)` /
+`Solver.reduced_hessian`, the parametric step `dx`, and the raw
+`Solver.kkt_solve` were returned in the IPM's internally **scaled** space
+whenever NLP scaling was active (the default
+`nlp_scaling_method = "gradient-based"` fires when an objective gradient or a
+constraint row exceeds 100 at the starting point). For a parameter-estimation
+NLP this made `-inv(reduced_hessian)` differ from the true covariance by
+`df / (dc_i·dc_j)` — the discretization-tracking "≈ nfe" fudge factor reported
+in #128. The same scaled factor silently corrupted the `pounce.jax`
+factor-reuse VJP (`JaxProblem(factor_reuse=True)`) on badly-scaled problems.
+
+All held-factor back-solves now conjugate by the scaling diagonal
+(`K_natural⁻¹ = D K_scaled⁻¹ D`, `D = diag(√df·I_x, √df·dd⁻¹, dc/√df, dd/√df)`),
+so every sensitivity output is in the user's own units regardless of scaling
+method. The pre-fix solver-space values and the factors stay accessible:
+`info["reduced_hessian_scaled"]` / `info["obj_scaling_factor"]` /
+`info["pin_g_scaling"]`, `Solver.reduced_hessian(..., scaled=True)`,
+`Solver.kkt_solve(..., scaled=True)`, the `Solver.nlp_scaling` dict, and the
+matching Rust surfaces (`SensResult` fields,
+`Solver::{compute_reduced_hessian_scaled, kkt_solve_scaled, nlp_scaling}`,
+`PdSensBacksolver::solve_scaled_space`).
+
+Also fixed in the same change: `SensSolve` / `Solver` pin-constraint indices
+are now mapped to KKT rows through the equality/inequality split
+(`full_g_to_c_block`), so pins are selected correctly when inequality
+constraints precede them in `g(x)` (previously the wrong row was used
+silently; the CLI sIPOPT path already mapped correctly). `pounce.curve_fit`
+no longer requires scaling to be off to trust the converged factor for its
+covariance / data-sensitivity reads.
+
 ### Added — PyTorch frontend for the differentiable solver (`pounce.torch`)
 
 A PyTorch frontend mirroring `pounce.jax`: a solve is a

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -82,7 +82,7 @@ use pounce_linalg::dense_vector::DenseVectorSpace;
 use pounce_linsol::summary::LinearSolverSummary;
 use pounce_linsol::SparseSymLinearSolverInterface;
 use pounce_nlp::alg_types::SolverReturn;
-use pounce_nlp::orig_ipopt_nlp::{NoScaling, OrigIpoptNlp, ScalingMethod};
+use pounce_nlp::orig_ipopt_nlp::{ConstObjScaling, OrigIpoptNlp, ScalingMethod};
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::solve_statistics::SolveStatistics;
 use pounce_nlp::tnlp::{
@@ -630,13 +630,25 @@ impl IpoptApplication {
     fn optimize_sqp_tnlp(&mut self, tnlp: Rc<RefCell<dyn TNLP>>) -> ApplicationReturnStatus {
         use pounce_nlp::orig_ipopt_nlp::OrigIpoptNlp;
         use pounce_nlp::tnlp_adapter::TNLPAdapter;
-        use pounce_nlp::NoScaling;
+        use pounce_nlp::ConstObjScaling;
 
         let adapter = match TNLPAdapter::new(Rc::clone(&tnlp)) {
             Ok(a) => Rc::new(RefCell::new(a)),
             Err(_) => return ApplicationReturnStatus::InvalidProblemDefinition,
         };
-        let orig_nlp = match OrigIpoptNlp::new(Rc::clone(&adapter), Rc::new(NoScaling)) {
+        // The SQP path never runs gradient-based scaling, but the
+        // constant `obj_scaling_factor` (negative ⇒ maximize) still
+        // applies via the OrigIpoptNlp constructor.
+        let obj_scaling_factor = self
+            .options
+            .get_numeric_value("obj_scaling_factor", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(1.0);
+        let orig_nlp = match OrigIpoptNlp::new(
+            Rc::clone(&adapter),
+            Rc::new(ConstObjScaling(obj_scaling_factor)),
+        ) {
             Ok(n) => n,
             Err(_) => return ApplicationReturnStatus::InternalError,
         };
@@ -1046,7 +1058,21 @@ impl IpoptApplication {
                 return ApplicationReturnStatus::InvalidProblemDefinition;
             }
         };
-        let mut orig_nlp = match OrigIpoptNlp::new(Rc::clone(&adapter), Rc::new(NoScaling)) {
+        // Carry the user's constant `obj_scaling_factor` (default 1.0;
+        // negative ⇒ maximize) into the NLP. Until pounce#128's
+        // follow-up this option was registered but never read, so it
+        // was silently a no-op — maximization diverged because the
+        // algorithm minimized the unscaled objective.
+        let obj_scaling_factor = self
+            .options
+            .get_numeric_value("obj_scaling_factor", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(1.0);
+        let mut orig_nlp = match OrigIpoptNlp::new(
+            Rc::clone(&adapter),
+            Rc::new(ConstObjScaling(obj_scaling_factor)),
+        ) {
             Ok(n) => n,
             Err(_) => {
                 timing.overall_alg.end();

--- a/crates/pounce-cinterface/include/pounce.h
+++ b/crates/pounce-cinterface/include/pounce.h
@@ -484,8 +484,26 @@ Index IpoptSolverGetKktDim(IpoptSolver solver);
  * Apply the converged KKT factor to `rhs` (length = KKT dim).
  * Writes the result into `lhs`. Returns 1 (TRUE) on success,
  * 0 (FALSE) on NULL inputs or absent factor.
+ *
+ * The solve is in natural (unscaled) units: any NLP scaling the IPM
+ * applied internally (`nlp_scaling_method`) is undone, so RHS and
+ * result are in the user's own units (pounce#128). The same applies
+ * to IpoptSolverParametricStep and IpoptSolverReducedHessian. Use
+ * IpoptSolverKktSolveScaled for the raw solver-space back-solve
+ * (the pre-#128 behavior).
  */
 Bool IpoptSolverKktSolve(
+    IpoptSolver    solver,
+    const Number  *rhs,
+    Number        *lhs
+);
+
+/**
+ * IpoptSolverKktSolve without the natural-units correction: the
+ * back-solve runs in the solver's internal scaled space. Identical
+ * to IpoptSolverKktSolve when no NLP scaling is active.
+ */
+Bool IpoptSolverKktSolveScaled(
     IpoptSolver    solver,
     const Number  *rhs,
     Number        *lhs

--- a/crates/pounce-cinterface/include/pounce.h
+++ b/crates/pounce-cinterface/include/pounce.h
@@ -505,10 +505,16 @@ Bool IpoptSolverParametricStep(
 );
 
 /**
- * Reduced Hessian over the free directions left when the
- * constraints in `pin_indices` are pinned. Writes a dense
- * `(n - n_pins) x (n - n_pins)` matrix in row-major order to
- * `hr_out`. `obj_scal` scales the objective contribution.
+ * Reduced Hessian `H_R = obj_scal * B K^-1 B^T` over the pinned
+ * equality-constraint rows in `pin_indices` (0-based indices into
+ * g(x)). Writes a dense `n_pins x n_pins` matrix in column-major
+ * order to `hr_out`.
+ *
+ * `H_R` is in natural (unscaled) units: any NLP scaling the IPM
+ * applied (`nlp_scaling_method`) is undone before the value is
+ * reported, so `-inv(H_R)` is directly the parameter covariance of
+ * an estimation problem (pounce#128). `obj_scal` is a plain extra
+ * multiplier (pass 1.0).
  */
 Bool IpoptSolverReducedHessian(
     IpoptSolver    solver,

--- a/crates/pounce-cinterface/src/solver.rs
+++ b/crates/pounce-cinterface/src/solver.rs
@@ -261,6 +261,13 @@ pub unsafe extern "C" fn IpoptSolverGetKktDim(solver: IpoptSolver) -> Index {
 /// `rhs` and `lhs` are flat buffers of length [`IpoptSolverGetKktDim`]
 /// in the `x || s || y_c || y_d || z_l || z_u || v_l || v_u` packing.
 ///
+/// `K` is the **natural-units** (unscaled) KKT matrix: any NLP
+/// scaling the IPM applied (`nlp_scaling_method`) is undone in the
+/// back-solve, so RHS and solution are in the user's own units
+/// (pounce#128). Use [`IpoptSolverKktSolveScaled`] for the raw
+/// back-solve against the factor exactly as the IPM holds it (the
+/// pre-#128 behavior).
+///
 /// Returns `TRUE` on success, `FALSE` if no factor is held or the
 /// back-solve fails.
 ///
@@ -274,6 +281,31 @@ pub unsafe extern "C" fn IpoptSolverKktSolve(
     rhs: *const Number,
     lhs: *mut Number,
 ) -> Bool {
+    kkt_solve_impl(solver, rhs, lhs, false)
+}
+
+/// [`IpoptSolverKktSolve`] without the natural-units correction: the
+/// back-solve runs in the solver's internal scaled space. Identical
+/// to `IpoptSolverKktSolve` when no NLP scaling is active.
+///
+/// # Safety
+///
+/// Same contract as [`IpoptSolverKktSolve`].
+#[no_mangle]
+pub unsafe extern "C" fn IpoptSolverKktSolveScaled(
+    solver: IpoptSolver,
+    rhs: *const Number,
+    lhs: *mut Number,
+) -> Bool {
+    kkt_solve_impl(solver, rhs, lhs, true)
+}
+
+unsafe fn kkt_solve_impl(
+    solver: IpoptSolver,
+    rhs: *const Number,
+    lhs: *mut Number,
+    scaled: bool,
+) -> Bool {
     if solver.is_null() || rhs.is_null() || lhs.is_null() {
         return FALSE;
     }
@@ -286,7 +318,12 @@ pub unsafe extern "C" fn IpoptSolverKktSolve(
     };
     let rhs_slice = std::slice::from_raw_parts(rhs, dim);
     let mut lhs_vec = vec![0.0; dim];
-    if s.kkt_solve(rhs_slice, &mut lhs_vec).is_err() {
+    let res = if scaled {
+        s.kkt_solve_scaled(rhs_slice, &mut lhs_vec)
+    } else {
+        s.kkt_solve(rhs_slice, &mut lhs_vec)
+    };
+    if res.is_err() {
         return FALSE;
     }
     std::ptr::copy_nonoverlapping(lhs_vec.as_ptr(), lhs, dim);

--- a/crates/pounce-cinterface/src/solver.rs
+++ b/crates/pounce-cinterface/src/solver.rs
@@ -347,6 +347,13 @@ pub unsafe extern "C" fn IpoptSolverParametricStep(
 /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned rows.
 /// `hr_out` receives an `n_pins²`-long column-major dense matrix.
 ///
+/// `H_R` is in **natural (unscaled) units**: any NLP scaling the IPM
+/// applied (`nlp_scaling_method`) is undone before the value is
+/// reported, so `-inv(H_R)` is directly the parameter covariance of
+/// an estimation problem (pounce#128). `obj_scal` is a plain extra
+/// multiplier (pass 1.0); it is no longer needed to undo pounce's own
+/// scaling.
+///
 /// Returns `TRUE` on success, `FALSE` otherwise.
 ///
 /// # Safety

--- a/crates/pounce-cli/src/sens.rs
+++ b/crates/pounce-cli/src/sens.rs
@@ -347,31 +347,23 @@ fn try_compute_sens_step(
     // Pounce's compound layout matches upstream's
     // `MetadataMeasurement::GetInitialEqConstraints`
     // (`ref/Ipopt/contrib/sIPOPT/src/SensMetadataMeasurement.cpp:69-83`).
-    //
-    // Two coordinate transforms are needed when `n_x != n_full` (fixed
-    // variables present) or when the c/d split reorders constraints:
-    //   * full-x index → var-x index via `IpoptNlp::full_x_to_var_x`
-    //   * full-g index → c-block index via `IpoptNlp::full_g_to_c_block`
-    let curr = data.borrow().curr.clone()?;
-    let n_x = curr.x.dim() as usize;
-    let n_s = curr.s.dim() as usize;
-    let nlp_ref = nlp.borrow();
-    let y_c_offset = n_x + n_s;
-    let mut rows: Vec<Index> = Vec::with_capacity(n_params);
-    for k in 0..n_params {
-        let full_ci = param_con_idx[k].unwrap();
-        match nlp_ref.full_g_to_c_block(full_ci as Index) {
-            Some(c_idx) => rows.push(y_c_offset as Index + c_idx),
-            None => {
-                eprintln!(
-                    "pounce: parameter {} pinning constraint #{} is an inequality (not in the c block)",
-                    k + 1,
-                    full_ci
-                );
-                return None;
-            }
+    // The full-g → c-block transform (needed when the c/d split
+    // reorders constraints) is the backsolver's canonical
+    // `map_pin_g_to_kkt_rows` (pounce#128 single source of truth).
+    let backsolver = PdSensBacksolver::new(data, cq, nlp, pd)
+        .map_err(|e| eprintln!("pounce: could not capture the KKT factor: {e}"))
+        .ok()?;
+    let pin_g: Vec<Index> = param_con_idx
+        .iter()
+        .map(|ci| ci.unwrap() as Index)
+        .collect();
+    let rows = match backsolver.map_pin_g_to_kkt_rows(&pin_g) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("pounce: {e}");
+            return None;
         }
-    }
+    };
     let signs: Vec<Index> = vec![1; n_params];
     let a_data = IndexSchurData::from_parts(rows, signs).ok()?;
 
@@ -385,9 +377,6 @@ fn try_compute_sens_step(
         let vi = param_var_idx[k].unwrap();
         delta_p.push(sens_state_value[vi] - x_nominal[vi]);
     }
-    drop(nlp_ref);
-
-    let backsolver = PdSensBacksolver::new(data, cq, nlp, pd).ok()?;
     let n_full_pd = backsolver.dim();
     let mut rhs_full = vec![0.0; n_full_pd];
     a_data

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -264,6 +264,26 @@ pub trait IpoptNlp: Nlp {
         1.0
     }
 
+    /// Per-row scaling vector for the equality block (`dc_` upstream):
+    /// the factor each `c` row is multiplied by inside [`Self::eval_c`]
+    /// / [`Self::eval_jac_c`]. `None` ⇔ no row scaling (all 1.0);
+    /// length `m_eq()` when present. Together with
+    /// [`Self::obj_scaling_factor`] and [`Self::d_scale_vec`] this is
+    /// what lets `pounce-sensitivity` undo the NLP scaling baked into
+    /// the converged KKT factor (pounce#128). Default `None`;
+    /// `OrigIpoptNlp` overrides.
+    fn c_scale_vec(&self) -> Option<Vec<Number>> {
+        None
+    }
+
+    /// Per-row scaling vector for the inequality block (`dd_`
+    /// upstream), same convention as [`Self::c_scale_vec`]. Length
+    /// `m_ineq()` when present. Default `None`; `OrigIpoptNlp`
+    /// overrides.
+    fn d_scale_vec(&self) -> Option<Vec<Number>> {
+        None
+    }
+
     /// Human-readable variable / constraint names projected into the
     /// algorithm's split space (free variables, equalities, inequalities),
     /// or `None` when the model carries no names. The debugger uses this to

--- a/crates/pounce-nlp/src/lib.rs
+++ b/crates/pounce-nlp/src/lib.rs
@@ -33,7 +33,7 @@ pub mod tnlp_adapter;
 pub use alg_types::SolverReturn;
 pub use expression_provider::{ExpressionProvider, FbbtOp, FbbtTape};
 pub use ipopt_nlp::{IpoptNlp, Nlp};
-pub use orig_ipopt_nlp::{NlpScaling, NoScaling, OrigIpoptNlp};
+pub use orig_ipopt_nlp::{ConstObjScaling, NlpScaling, NoScaling, OrigIpoptNlp};
 pub use return_codes::{AlgorithmMode, ApplicationReturnStatus};
 pub use solve_statistics::SolveStatistics;
 pub use tnlp::{

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -1773,6 +1773,14 @@ impl IpoptNlp for OrigIpoptNlp {
         self.obj_scale_factor.get()
     }
 
+    fn c_scale_vec(&self) -> Option<Vec<Number>> {
+        self.c_scale.borrow().clone()
+    }
+
+    fn d_scale_vec(&self) -> Option<Vec<Number>> {
+        self.d_scale.borrow().clone()
+    }
+
     /// Project the underlying TNLP's `idx_names` metadata into the
     /// algorithm's split space. Variable names are gathered through the
     /// fixed-variable map (`x_not_fixed_map`), equality names through the

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -97,6 +97,18 @@ pub trait NlpScaling {
 pub struct NoScaling;
 impl NlpScaling for NoScaling {}
 
+/// Constant objective scaling: carries the user's `obj_scaling_factor`
+/// option value into [`OrigIpoptNlp`]. A negative factor flips the
+/// optimization direction (the IPM minimizes `factor·f`, i.e.
+/// maximizes `f`), matching upstream Ipopt's documented semantics.
+#[derive(Debug, Clone, Copy)]
+pub struct ConstObjScaling(pub Number);
+impl NlpScaling for ConstObjScaling {
+    fn obj_scaling(&self) -> Number {
+        self.0
+    }
+}
+
 /// Selector for [`OrigIpoptNlp::determine_scaling_from_starting_point`].
 /// Mirrors upstream's `nlp_scaling_method` option.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -467,10 +479,16 @@ impl OrigIpoptNlp {
             Some(SymTMatrixSpace::new(n_x_var, Vec::new(), Vec::new()))
         };
 
+        // Honor the scaling object's constant factor from construction
+        // (a negative `obj_scaling_factor` means maximize). Callers
+        // that run `determine_scaling_from_starting_point` overwrite
+        // this with the combined automatic·user factor; callers that
+        // don't (e.g. the SQP path) still get the user's constant.
+        let initial_obj_scal = scaling.obj_scaling();
         Ok(Self {
             adapter,
             scaling,
-            obj_scale_factor: Cell::new(1.0),
+            obj_scale_factor: Cell::new(initial_obj_scal),
             c_scale: RefCell::new(None),
             d_scale: RefCell::new(None),
             x_space,

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -409,6 +409,9 @@ impl PyProblem {
     /// iterate. Returns `(x, info_dict)`; `info_dict` includes the
     /// extra keys `dx`, `dx_full`, `reduced_hessian`,
     /// `reduced_hessian_scaled`, `obj_scaling_factor`, `pin_g_scaling`,
+    /// `kkt_perturbations` (the inertia-correction `(δ_x, δ_s, δ_c,
+    /// δ_d)` baked into the converged factor — all zero means the
+    /// factor is unregularized and the covariance reading is exact),
     /// `reduced_hessian_eigenvalues`, and `reduced_hessian_eigenvectors`
     /// (each may be `None` when the corresponding output was not
     /// requested or the solve did not converge).
@@ -540,6 +543,10 @@ impl PyProblem {
         };
         info.set_item("obj_scaling_factor", obj_scaling_obj)?;
         info.set_item("pin_g_scaling", opt_vec_to_py(py, result.pin_g_scaling))?;
+        info.set_item(
+            "kkt_perturbations",
+            opt_vec_to_py(py, result.kkt_perturbations.map(|p| p.to_vec())),
+        )?;
         info.set_item(
             "reduced_hessian_eigenvalues",
             opt_vec_to_py(py, result.reduced_hessian_eigenvalues),

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -527,46 +527,27 @@ impl PyProblem {
             stats.final_constr_viol,
             stats.final_compl,
         )?;
-        let dx_obj: PyObject = match result.dx {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("dx", dx_obj)?;
-        let dx_full_obj: PyObject = match result.dx_full {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("dx_full", dx_full_obj)?;
-        let rh_obj: PyObject = match result.reduced_hessian {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("reduced_hessian", rh_obj)?;
-        let rh_scaled_obj: PyObject = match result.reduced_hessian_scaled {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("reduced_hessian_scaled", rh_scaled_obj)?;
+        info.set_item("dx", opt_vec_to_py(py, result.dx))?;
+        info.set_item("dx_full", opt_vec_to_py(py, result.dx_full))?;
+        info.set_item("reduced_hessian", opt_vec_to_py(py, result.reduced_hessian))?;
+        info.set_item(
+            "reduced_hessian_scaled",
+            opt_vec_to_py(py, result.reduced_hessian_scaled),
+        )?;
         let obj_scaling_obj: PyObject = match result.obj_scaling_factor {
             Some(v) => v.into_py(py),
             None => py.None(),
         };
         info.set_item("obj_scaling_factor", obj_scaling_obj)?;
-        let pin_scaling_obj: PyObject = match result.pin_g_scaling {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("pin_g_scaling", pin_scaling_obj)?;
-        let eigvals_obj: PyObject = match result.reduced_hessian_eigenvalues {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("reduced_hessian_eigenvalues", eigvals_obj)?;
-        let eigvecs_obj: PyObject = match result.reduced_hessian_eigenvectors {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        info.set_item("reduced_hessian_eigenvectors", eigvecs_obj)?;
+        info.set_item("pin_g_scaling", opt_vec_to_py(py, result.pin_g_scaling))?;
+        info.set_item(
+            "reduced_hessian_eigenvalues",
+            opt_vec_to_py(py, result.reduced_hessian_eigenvalues),
+        )?;
+        info.set_item(
+            "reduced_hessian_eigenvectors",
+            opt_vec_to_py(py, result.reduced_hessian_eigenvectors),
+        )?;
 
         let x_out = bridge.borrow().state.final_x.clone().into_pyarray_bound(py);
         Ok((x_out, info))
@@ -583,6 +564,16 @@ impl PyProblem {
     #[getter]
     fn has_hessian(&self) -> bool {
         self.has_hessian
+    }
+}
+
+/// `Some(vec)` → 1-D float ndarray, `None` → Python `None`. Shared by
+/// the optional-output info-dict keys here and in the sibling
+/// `Solver` pyclass.
+pub(crate) fn opt_vec_to_py(py: Python<'_>, v: Option<Vec<Number>>) -> PyObject {
+    match v {
+        Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
+        None => py.None(),
     }
 }
 

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -408,9 +408,22 @@ impl PyProblem {
     /// Solve, then run a parametric sensitivity step at the converged
     /// iterate. Returns `(x, info_dict)`; `info_dict` includes the
     /// extra keys `dx`, `dx_full`, `reduced_hessian`,
+    /// `reduced_hessian_scaled`, `obj_scaling_factor`, `pin_g_scaling`,
     /// `reduced_hessian_eigenvalues`, and `reduced_hessian_eigenvectors`
     /// (each may be `None` when the corresponding output was not
     /// requested or the solve did not converge).
+    ///
+    /// `reduced_hessian` is in **natural (unscaled) units**: any NLP
+    /// scaling the IPM applied (`nlp_scaling_method`, default
+    /// `"gradient-based"`) is undone, so `-inv(reduced_hessian)` is
+    /// directly the parameter covariance of an estimation problem,
+    /// independent of problem scaling and discretization (pounce#128).
+    /// `reduced_hessian_scaled` is the value as the solver's internal
+    /// scaled space sees it (what pounce returned before #128), and
+    /// `obj_scaling_factor` / `pin_g_scaling` are the factors relating
+    /// the two: `H_scaled[i,j] = obj_scaling_factor /
+    /// (pin_g_scaling[i]*pin_g_scaling[j]) * H[i,j]`. `obj_scal`
+    /// survives as a plain extra multiplier on both (default 1.0).
     ///
     /// `pin_constraint_indices` are 0-based indices into `g(x)`
     /// identifying the parameter-pin equalities `g_i(x) = p_i`. The
@@ -529,6 +542,21 @@ impl PyProblem {
             None => py.None(),
         };
         info.set_item("reduced_hessian", rh_obj)?;
+        let rh_scaled_obj: PyObject = match result.reduced_hessian_scaled {
+            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
+            None => py.None(),
+        };
+        info.set_item("reduced_hessian_scaled", rh_scaled_obj)?;
+        let obj_scaling_obj: PyObject = match result.obj_scaling_factor {
+            Some(v) => v.into_py(py),
+            None => py.None(),
+        };
+        info.set_item("obj_scaling_factor", obj_scaling_obj)?;
+        let pin_scaling_obj: PyObject = match result.pin_g_scaling {
+            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
+            None => py.None(),
+        };
+        info.set_item("pin_g_scaling", pin_scaling_obj)?;
         let eigvals_obj: PyObject = match result.reduced_hessian_eigenvalues {
             Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
             None => py.None(),

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -135,11 +135,17 @@ impl PySolver {
     /// real back-solve cost (pounce#77 follow-up). Same converged
     /// factor and same per-RHS work — only the per-call FFI / executor
     /// pin overhead is amortised.
+    ///
+    /// Like [`Self::kkt_solve`], results are in natural (unscaled)
+    /// units; pass `scaled=True` for the raw solver-space back-solve
+    /// (pounce#128).
+    #[pyo3(signature = (rhs_flat, n_rhs, scaled = false))]
     fn kkt_solve_many<'py>(
         &self,
         py: Python<'py>,
         rhs_flat: Vec<Number>,
         n_rhs: usize,
+        scaled: bool,
     ) -> PyResult<Bound<'py, PyArray1<Number>>> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err("kkt_solve_many: no converged factor (call solve() first)")
@@ -160,9 +166,13 @@ impl PySolver {
             )));
         }
         let mut lhs_flat = vec![0.0; n_rhs * dim];
-        s.inner
-            .kkt_solve_many(&rhs_flat, &mut lhs_flat, n_rhs)
-            .map_err(solver_error_to_py)?;
+        let res = if scaled {
+            s.inner
+                .kkt_solve_many_scaled(&rhs_flat, &mut lhs_flat, n_rhs)
+        } else {
+            s.inner.kkt_solve_many(&rhs_flat, &mut lhs_flat, n_rhs)
+        };
+        res.map_err(solver_error_to_py)?;
         Ok(lhs_flat.into_pyarray_bound(py))
     }
 
@@ -239,16 +249,8 @@ impl PySolver {
         let (df, dc, dd) = s.inner.nlp_scaling().map_err(solver_error_to_py)?;
         let out = PyDict::new_bound(py);
         out.set_item("obj", df)?;
-        let dc_obj: PyObject = match dc {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        out.set_item("c_scale", dc_obj)?;
-        let dd_obj: PyObject = match dd {
-            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
-            None => py.None(),
-        };
-        out.set_item("d_scale", dd_obj)?;
+        out.set_item("c_scale", crate::problem::opt_vec_to_py(py, dc))?;
+        out.set_item("d_scale", crate::problem::opt_vec_to_py(py, dd))?;
         Ok(out)
     }
 

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -254,6 +254,22 @@ impl PySolver {
         Ok(out)
     }
 
+    /// Inertia-correction perturbations `(delta_x, delta_s, delta_c,
+    /// delta_d)` baked into the held KKT factor, as a length-4
+    /// ndarray. All zero means the final factorization was
+    /// unregularized and the natural-units back-solves (covariance in
+    /// particular) invert the exact KKT matrix; nonzero means the
+    /// factor carries a regularization and `-inv(reduced_hessian)` is
+    /// perturbed (pounce#128 follow-up).
+    #[getter]
+    fn kkt_perturbations<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<Number>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("kkt_perturbations: no converged factor (call solve() first)")
+        })?;
+        let p = s.inner.kkt_perturbations().map_err(solver_error_to_py)?;
+        Ok(p.to_vec().into_pyarray_bound(py))
+    }
+
     /// Dimension of the full compound KKT vector. `None` if no
     /// converged factor is held yet.
     #[getter]

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -98,18 +98,30 @@ impl PySolver {
 
     /// Solve `K · lhs = rhs` against the converged KKT factor. Returns
     /// the solution vector. `rhs` must have length [`Self::kkt_dim`].
+    ///
+    /// `K` is the **natural-units** (unscaled) KKT matrix: when the
+    /// IPM solved with active NLP scaling (`nlp_scaling_method`,
+    /// `obj_scaling_factor`, user scaling) the back-solve is
+    /// conjugated so RHS and solution are in the user's own units
+    /// (pounce#128). Pass `scaled=True` for the raw back-solve against
+    /// the factor exactly as the IPM holds it.
+    #[pyo3(signature = (rhs, scaled = false))]
     fn kkt_solve<'py>(
         &self,
         py: Python<'py>,
         rhs: Vec<Number>,
+        scaled: bool,
     ) -> PyResult<Bound<'py, PyArray1<Number>>> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err("kkt_solve: no converged factor (call solve() first)")
         })?;
         let mut lhs = vec![0.0; rhs.len()];
-        s.inner
-            .kkt_solve(&rhs, &mut lhs)
-            .map_err(solver_error_to_py)?;
+        let res = if scaled {
+            s.inner.kkt_solve_scaled(&rhs, &mut lhs)
+        } else {
+            s.inner.kkt_solve(&rhs, &mut lhs)
+        };
+        res.map_err(solver_error_to_py)?;
         Ok(lhs.into_pyarray_bound(py))
     }
 
@@ -182,24 +194,62 @@ impl PySolver {
     }
 
     /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned
-    /// rows. Returned as a `n²`-long column-major flat array
+    /// rows, in **natural (unscaled) units**: any NLP scaling baked
+    /// into the converged factor is undone, so `-inv(H_R)` is directly
+    /// the parameter covariance of an estimation problem regardless of
+    /// `nlp_scaling_method` (pounce#128). Pass `scaled=True` for the
+    /// solver-space value pounce returned before #128. `obj_scal`
+    /// survives as a plain extra multiplier (default 1.0); it is no
+    /// longer needed to undo pounce's own scaling. Returned as a
+    /// `n²`-long column-major flat array
     /// (`n = pin_constraint_indices.len()`).
-    #[pyo3(signature = (pin_constraint_indices, obj_scal = 1.0))]
+    #[pyo3(signature = (pin_constraint_indices, obj_scal = 1.0, scaled = false))]
     fn reduced_hessian<'py>(
         &self,
         py: Python<'py>,
         pin_constraint_indices: Vec<i64>,
         obj_scal: Number,
+        scaled: bool,
     ) -> PyResult<Bound<'py, PyArray1<Number>>> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err("reduced_hessian: no converged factor (call solve() first)")
         })?;
         let pins = validate_pins(&pin_constraint_indices, s.m)?;
-        let hr = s
-            .inner
-            .compute_reduced_hessian(&pins, obj_scal)
-            .map_err(solver_error_to_py)?;
+        let hr = if scaled {
+            s.inner.compute_reduced_hessian_scaled(&pins, obj_scal)
+        } else {
+            s.inner.compute_reduced_hessian(&pins, obj_scal)
+        }
+        .map_err(solver_error_to_py)?;
         Ok(hr.into_pyarray_bound(py))
+    }
+
+    /// Effective NLP scaling the IPM applied on the held solve, as a
+    /// dict with keys `obj` (float, the objective factor `df`),
+    /// `c_scale` and `d_scale` (each an ndarray of per-row factors
+    /// over the algorithm's equality / inequality blocks, or `None`
+    /// when that block carries no row scaling).
+    /// `{"obj": 1.0, "c_scale": None, "d_scale": None}` ⇔ no scaling
+    /// was active.
+    #[getter]
+    fn nlp_scaling<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("nlp_scaling: no converged factor (call solve() first)")
+        })?;
+        let (df, dc, dd) = s.inner.nlp_scaling().map_err(solver_error_to_py)?;
+        let out = PyDict::new_bound(py);
+        out.set_item("obj", df)?;
+        let dc_obj: PyObject = match dc {
+            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
+            None => py.None(),
+        };
+        out.set_item("c_scale", dc_obj)?;
+        let dd_obj: PyObject = match dd {
+            Some(v) => v.into_pyarray_bound(py).into_any().unbind(),
+            None => py.None(),
+        };
+        out.set_item("d_scale", dd_obj)?;
+        Ok(out)
     }
 
     /// Dimension of the full compound KKT vector. `None` if no

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -47,7 +47,7 @@ use pounce_algorithm::ipopt_cq::IpoptCqHandle;
 use pounce_algorithm::ipopt_data::IpoptDataHandle;
 use pounce_algorithm::iterates_vector::{IteratesVector, IteratesVectorMut};
 use pounce_algorithm::kkt::pd_full_space_solver::PdFullSpaceSolver;
-use pounce_common::types::Number;
+use pounce_common::types::{Index, Number};
 use pounce_linalg::dense_vector::DenseVector;
 use pounce_nlp::ipopt_nlp::IpoptNlp;
 
@@ -87,6 +87,24 @@ pub struct PdSensBacksolver {
     /// `VectorSpace`s as the converged iterate; cloned from
     /// `data.borrow().curr`.
     template: IteratesVector,
+    /// Natural-units conjugation vector `D` (pounce#128). The IPM's
+    /// KKT factor is held in the NLP's internally **scaled** space
+    /// (objective factor `df`, per-row constraint factors `dc` / `dd`
+    /// from `nlp_scaling_method`). The scaled augmented system is the
+    /// congruence `K̃ = D K D` of the natural-units system, with
+    ///
+    /// ```text
+    /// D = diag( √df·I_x,  √df·dd⁻¹ (s block),  dc/√df (y_c),  dd/√df (y_d) )
+    /// ```
+    ///
+    /// so `K⁻¹ = D K̃⁻¹ D`: scale the RHS by `D`, back-solve against
+    /// the held factor, scale the result by `D`. The z/v bound-
+    /// multiplier blocks carry `1.0` (their rows are not a clean part
+    /// of the congruence; they are condensed into Σ before the factor
+    /// and consumers neither feed RHS into nor read results from
+    /// them — see [`Self::solve`]). `None` ⇔ scaling inactive,
+    /// conjugation is the identity.
+    conj: Option<Rc<Vec<Number>>>,
 }
 
 impl PdSensBacksolver {
@@ -111,6 +129,7 @@ impl PdSensBacksolver {
             curr.v_l.dim() as usize,
             curr.v_u.dim() as usize,
         ];
+        let conj = Self::natural_units_conj(nlp, &dims)?;
         Ok(Self {
             pd,
             data: Rc::clone(data),
@@ -118,7 +137,123 @@ impl PdSensBacksolver {
             nlp: Rc::clone(nlp),
             dims,
             template: curr,
+            conj,
         })
+    }
+
+    /// Build the natural-units conjugation vector `D` from the NLP's
+    /// effective scaling (see the field doc on [`Self::conj`]).
+    /// Returns `Ok(None)` when no scaling is active. `Err(())` when
+    /// the NLP reports scaling vectors whose lengths disagree with the
+    /// converged iterate's block dimensions (would silently corrupt
+    /// every back-solve).
+    fn natural_units_conj(
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        dims: &[usize; 8],
+    ) -> Result<Option<Rc<Vec<Number>>>, ()> {
+        let (df, dc, dd) = {
+            let n = nlp.borrow();
+            (n.obj_scaling_factor(), n.c_scale_vec(), n.d_scale_vec())
+        };
+        if df == 1.0 && dc.is_none() && dd.is_none() {
+            return Ok(None);
+        }
+        if !(df.is_finite() && df > 0.0) {
+            return Err(());
+        }
+        if let Some(v) = &dc {
+            if v.len() != dims[2] {
+                return Err(());
+            }
+        }
+        if let Some(v) = &dd {
+            if v.len() != dims[3] || dims[1] != dims[3] {
+                return Err(());
+            }
+        }
+        let sqrt_df = df.sqrt();
+        let total: usize = dims.iter().sum();
+        let mut d = Vec::with_capacity(total);
+        // x block: √df.
+        d.extend(std::iter::repeat_n(sqrt_df, dims[0]));
+        // s block: √df / dd_i (slacks live in scaled d-space).
+        match &dd {
+            Some(v) => d.extend(v.iter().map(|&ddi| sqrt_df / ddi)),
+            None => d.extend(std::iter::repeat_n(sqrt_df, dims[1])),
+        }
+        // y_c block: dc_i / √df.
+        match &dc {
+            Some(v) => d.extend(v.iter().map(|&dci| dci / sqrt_df)),
+            None => d.extend(std::iter::repeat_n(1.0 / sqrt_df, dims[2])),
+        }
+        // y_d block: dd_i / √df.
+        match &dd {
+            Some(v) => d.extend(v.iter().map(|&ddi| ddi / sqrt_df)),
+            None => d.extend(std::iter::repeat_n(1.0 / sqrt_df, dims[3])),
+        }
+        // z_l / z_u / v_l / v_u blocks: identity (not part of the
+        // congruence; see field doc).
+        d.extend(std::iter::repeat_n(
+            1.0,
+            dims[4] + dims[5] + dims[6] + dims[7],
+        ));
+        Ok(Some(Rc::new(d)))
+    }
+
+    /// Effective objective scaling factor `df` of the converged NLP
+    /// (1.0 when no scaling is active).
+    pub fn obj_scaling_factor(&self) -> Number {
+        self.nlp.borrow().obj_scaling_factor()
+    }
+
+    /// Effective NLP scaling at convergence:
+    /// `(obj_scaling_factor, c_scale, d_scale)`. The vectors are
+    /// `None` when the corresponding block carries no row scaling.
+    pub fn nlp_scaling(&self) -> (Number, Option<Vec<Number>>, Option<Vec<Number>>) {
+        let n = self.nlp.borrow();
+        (n.obj_scaling_factor(), n.c_scale_vec(), n.d_scale_vec())
+    }
+
+    /// Map user-facing 0-based `g(x)` indices of parameter-pin
+    /// equality constraints to flat KKT rows (`n_x + n_s +
+    /// c_block_idx`, i.e. the matching `y_c` slots). Goes through
+    /// `IpoptNlp::full_g_to_c_block` so the c/d split's row
+    /// permutation is honored (pounce#128 follow-up: the previous
+    /// direct `n_x + n_s + g_idx` mapping silently picked wrong rows
+    /// when inequalities preceded the pins). Errors when a pin index
+    /// refers to an inequality row.
+    pub fn map_pin_g_to_kkt_rows(&self, pin_g_indices: &[Index]) -> Result<Vec<Index>, String> {
+        let y_c_offset = (self.dims[0] + self.dims[1]) as Index;
+        let nlp = self.nlp.borrow();
+        pin_g_indices
+            .iter()
+            .map(|&gi| match nlp.full_g_to_c_block(gi) {
+                Some(ci) => Ok(y_c_offset + ci),
+                None => Err(format!(
+                    "pin constraint index {gi} is an inequality (not an equality row); \
+                     parameter pins must be exact equalities"
+                )),
+            })
+            .collect()
+    }
+
+    /// Per-pin equality-row scaling factors `dc_i` (1.0 when no
+    /// constraint scaling is active). Same `pin_g_indices` convention
+    /// as [`Self::map_pin_g_to_kkt_rows`]. Reported alongside the
+    /// reduced Hessian so callers can reconstruct the solver-space
+    /// (scaled) value `H̃_ij = (df / (dc_i·dc_j)) · H_ij`.
+    pub fn pin_c_scales(&self, pin_g_indices: &[Index]) -> Result<Vec<Number>, String> {
+        let nlp = self.nlp.borrow();
+        let dc = nlp.c_scale_vec();
+        pin_g_indices
+            .iter()
+            .map(|&gi| match nlp.full_g_to_c_block(gi) {
+                Some(ci) => Ok(dc.as_ref().map(|v| v[ci as usize]).unwrap_or(1.0)),
+                None => Err(format!(
+                    "pin constraint index {gi} is an inequality (not an equality row)"
+                )),
+            })
+            .collect()
     }
 
     /// Block dimensions of the compound KKT vector at convergence, in
@@ -204,7 +339,46 @@ impl PdSensBacksolver {
     /// The matrix and perturbation state inside `PdFullSpaceSolver`
     /// are unchanged across calls, so each iteration hits the cached
     /// fast path in `solve_once` (`uptodate && !pretend_singular`).
+    ///
+    /// Like [`SensBacksolver::solve`], results are in **natural
+    /// (unscaled) units** — see [`Self::solve_many_scaled_space`] for
+    /// the raw solver-space back-solve.
     pub fn solve_many(&self, rhs_flat: &[Number], lhs_flat: &mut [Number], n_rhs: usize) -> bool {
+        match &self.conj {
+            None => self.solve_many_scaled_space(rhs_flat, lhs_flat, n_rhs),
+            Some(d) => {
+                let total = self.dim();
+                if rhs_flat.len() != n_rhs * total || lhs_flat.len() != n_rhs * total {
+                    return false;
+                }
+                let mut rhs_scaled = rhs_flat.to_vec();
+                for row in rhs_scaled.chunks_mut(total) {
+                    for (r, &di) in row.iter_mut().zip(d.iter()) {
+                        *r *= di;
+                    }
+                }
+                if !self.solve_many_scaled_space(&rhs_scaled, lhs_flat, n_rhs) {
+                    return false;
+                }
+                for row in lhs_flat.chunks_mut(total) {
+                    for (l, &di) in row.iter_mut().zip(d.iter()) {
+                        *l *= di;
+                    }
+                }
+                true
+            }
+        }
+    }
+
+    /// Batched-RHS back-solve against the held factor in the solver's
+    /// internal **scaled** space (no natural-units conjugation). Same
+    /// buffer contract as [`Self::solve_many`].
+    pub fn solve_many_scaled_space(
+        &self,
+        rhs_flat: &[Number],
+        lhs_flat: &mut [Number],
+        n_rhs: usize,
+    ) -> bool {
         let total = self.dim();
         if rhs_flat.len() != n_rhs * total || lhs_flat.len() != n_rhs * total {
             return false;
@@ -387,12 +561,12 @@ fn read_res_block(blk: &dyn pounce_linalg::vector::Vector, dst: &mut [Number]) -
     true
 }
 
-impl SensBacksolver for PdSensBacksolver {
-    fn dim(&self) -> usize {
-        self.dims.iter().sum()
-    }
-
-    fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+impl PdSensBacksolver {
+    /// Single-RHS back-solve against the held factor in the solver's
+    /// internal **scaled** space (no natural-units conjugation). This
+    /// is the value [`SensBacksolver::solve`] returned before
+    /// pounce#128; kept for callers that want the raw factor.
+    pub fn solve_scaled_space(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
         let total = self.dim();
         if rhs.len() != total || lhs.len() != total {
             return false;
@@ -437,5 +611,42 @@ impl SensBacksolver for PdSensBacksolver {
             return false;
         }
         self.unpack(&res_iv, lhs).is_ok()
+    }
+}
+
+impl SensBacksolver for PdSensBacksolver {
+    fn dim(&self) -> usize {
+        self.dims.iter().sum()
+    }
+
+    /// Solve `K · lhs = rhs` against the converged factor, in
+    /// **natural (unscaled) units** (pounce#128): when the NLP carries
+    /// active scaling (`nlp_scaling_method`, `obj_scaling_factor`,
+    /// user scaling) the RHS and result are conjugated by the diagonal
+    /// `D` documented on the `conj` field, so `lhs = K_natural⁻¹ rhs`
+    /// for the `x / s / y_c / y_d` blocks. The z/v bound-multiplier
+    /// blocks are passed through unconjugated: RHS entries there are
+    /// fed to the factor as-is and the corresponding result entries
+    /// remain in solver space. Use [`Self::solve_scaled_space`] for
+    /// the raw factor.
+    fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+        match &self.conj {
+            None => self.solve_scaled_space(rhs, lhs),
+            Some(d) => {
+                let total = self.dim();
+                if rhs.len() != total || lhs.len() != total {
+                    return false;
+                }
+                let rhs_scaled: Vec<Number> =
+                    rhs.iter().zip(d.iter()).map(|(&r, &di)| r * di).collect();
+                if !self.solve_scaled_space(&rhs_scaled, lhs) {
+                    return false;
+                }
+                for (l, &di) in lhs.iter_mut().zip(d.iter()) {
+                    *l *= di;
+                }
+                true
+            }
+        }
     }
 }

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -309,6 +309,21 @@ impl PdSensBacksolver {
         (n.obj_scaling_factor(), n.c_scale_vec(), n.d_scale_vec())
     }
 
+    /// Inertia-correction perturbations `(δ_x, δ_s, δ_c, δ_d)` baked
+    /// into the held KKT factor (the IPM's `current_perturbation`
+    /// state at convergence). All zero ⇔ the final factorization was
+    /// unregularized and the natural-units back-solves invert the
+    /// exact KKT matrix. Nonzero ⇔ the factor carries a (scaled-space)
+    /// regularization, so sensitivity outputs — covariance in
+    /// particular — are perturbed and no longer exactly
+    /// scaling-invariant; consumers should check this before trusting
+    /// `-inv(reduced_hessian)` on ill-conditioned problems
+    /// (pounce#128 follow-up).
+    pub fn kkt_perturbations(&self) -> [Number; 4] {
+        let p = self.data.borrow().perturbations;
+        [p.delta_x, p.delta_s, p.delta_c, p.delta_d]
+    }
+
     /// Map user-facing 0-based `g(x)` indices of parameter-pin
     /// equality constraints to flat KKT rows **and** the pin rows'
     /// `dc_i` scaling factors, in one pass. The KKT row of pin `i` is

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -87,38 +87,60 @@ pub struct PdSensBacksolver {
     /// `VectorSpace`s as the converged iterate; cloned from
     /// `data.borrow().curr`.
     template: IteratesVector,
-    /// Natural-units conjugation vector `D` (pounce#128). The IPM's
+    /// Natural-units row/column scaling pair (pounce#128). The IPM's
     /// KKT factor is held in the NLP's internally **scaled** space
     /// (objective factor `df`, per-row constraint factors `dc` / `dd`
-    /// from `nlp_scaling_method`). The scaled augmented system is the
-    /// congruence `K̃ = D K D` of the natural-units system, with
+    /// from `nlp_scaling_method`; scaled multipliers `ỹ = (df/dc)·y`,
+    /// `z̃ = df·z`, `ṽ = (df/dd)·v`, scaled slack `s̃ = dd·s`). The
+    /// scaled 8-block primal-dual system is the two-sided diagonal
+    /// scaling `K̃ = E K F` of the natural-units system, with
+    /// per-block entries
     ///
     /// ```text
-    /// D = diag( √df·I_x,  √df·dd⁻¹ (s block),  dc/√df (y_c),  dd/√df (y_d) )
+    ///        x      s        y_c      y_d     z_l/z_u   v_l/v_u
+    /// E  =   df     df/dd_i  dc_i     dd_i    df        df
+    /// F  =   1      1/dd_i   dc_i/df  dd_i/df 1/df      dd_r(j)/df
     /// ```
     ///
-    /// so `K⁻¹ = D K̃⁻¹ D`: scale the RHS by `D`, back-solve against
-    /// the held factor, scale the result by `D`. The z/v bound-
-    /// multiplier blocks carry `1.0` (their rows are not a clean part
-    /// of the congruence; they are condensed into Σ before the factor
-    /// and consumers neither feed RHS into nor read results from
-    /// them — see [`Self::solve`]). `None` ⇔ scaling inactive,
-    /// conjugation is the identity.
-    conj: Option<Rc<Vec<Number>>>,
+    /// (`dd_r(j)` = the d-row scaling of the j-th finite d-bound,
+    /// through the `pd_l` / `pd_u` expansion). Hence
+    /// `K⁻¹ = F K̃⁻¹ E`: scale the RHS by `E`, back-solve against the
+    /// held factor, scale the result by `F`. Unlike a symmetric
+    /// congruence this needs no square root, so it covers a negative
+    /// `obj_scaling_factor` (maximization) and covers the z/v
+    /// bound-multiplier rows exactly (those rows admit no symmetric
+    /// diagonal: `K̃_{z,x} = df·Z·Pᵀ` but `K̃_{z,z} = X − x_L` is
+    /// unscaled). `None` ⇔ scaling inactive, identity.
+    conj: Option<Rc<ConjPair>>,
+}
+
+/// Left/right diagonal pair for the natural-units back-solve; see the
+/// `conj` field doc on [`PdSensBacksolver`]. Both vectors are
+/// flat-KKT-length, in the `x‖s‖y_c‖y_d‖z_l‖z_u‖v_l‖v_u` packing.
+struct ConjPair {
+    /// `E`: multiplied into the RHS before the scaled-space solve.
+    e: Vec<Number>,
+    /// `F`: multiplied into the solution after the scaled-space solve.
+    f: Vec<Number>,
 }
 
 impl PdSensBacksolver {
     /// Construct from the four handles handed in by the `on_converged`
-    /// callback. Returns `Err(())` if `data` has no `curr` (i.e. the
-    /// algorithm never reached an iterate — should not happen on
-    /// `SolveSucceeded`).
+    /// callback. Errors if `data` has no `curr` (i.e. the algorithm
+    /// never reached an iterate — should not happen on
+    /// `SolveSucceeded`) or the NLP reports scaling data inconsistent
+    /// with the converged iterate (see [`Self::natural_units_conj`]).
     pub fn new(
         data: &IpoptDataHandle,
         cq: &IpoptCqHandle,
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
         pd: Rc<RefCell<PdFullSpaceSolver>>,
-    ) -> Result<Self, ()> {
-        let curr = data.borrow().curr.clone().ok_or(())?;
+    ) -> Result<Self, String> {
+        let curr = data
+            .borrow()
+            .curr
+            .clone()
+            .ok_or_else(|| "no current iterate at convergence".to_string())?;
         let dims = [
             curr.x.dim() as usize,
             curr.s.dim() as usize,
@@ -141,63 +163,136 @@ impl PdSensBacksolver {
         })
     }
 
-    /// Build the natural-units conjugation vector `D` from the NLP's
+    /// Build the natural-units scaling pair `(E, F)` from the NLP's
     /// effective scaling (see the field doc on [`Self::conj`]).
-    /// Returns `Ok(None)` when no scaling is active. `Err(())` when
-    /// the NLP reports scaling vectors whose lengths disagree with the
-    /// converged iterate's block dimensions (would silently corrupt
-    /// every back-solve).
+    /// Returns `Ok(None)` when no scaling is active. Errors when the
+    /// NLP reports scaling data inconsistent with the converged
+    /// iterate's block dimensions (would silently corrupt every
+    /// back-solve) or a zero/non-finite `df`.
     fn natural_units_conj(
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
         dims: &[usize; 8],
-    ) -> Result<Option<Rc<Vec<Number>>>, ()> {
-        let (df, dc, dd) = {
-            let n = nlp.borrow();
-            (n.obj_scaling_factor(), n.c_scale_vec(), n.d_scale_vec())
-        };
+    ) -> Result<Option<Rc<ConjPair>>, String> {
+        let nlp_ref = nlp.borrow();
+        let df = nlp_ref.obj_scaling_factor();
+        let dc = nlp_ref.c_scale_vec();
+        let dd = nlp_ref.d_scale_vec();
         if df == 1.0 && dc.is_none() && dd.is_none() {
             return Ok(None);
         }
-        if !(df.is_finite() && df > 0.0) {
-            return Err(());
+        // df may be negative (obj_scaling_factor < 0 means maximize);
+        // the two-sided scaling needs no square root, only df ≠ 0.
+        if !df.is_finite() || df == 0.0 {
+            return Err(format!("invalid obj_scaling_factor {df}"));
         }
         if let Some(v) = &dc {
             if v.len() != dims[2] {
-                return Err(());
+                return Err(format!("c_scale length {} != y_c dim {}", v.len(), dims[2]));
             }
         }
         if let Some(v) = &dd {
             if v.len() != dims[3] || dims[1] != dims[3] {
-                return Err(());
+                return Err(format!(
+                    "d_scale length {} != y_d dim {} (s dim {})",
+                    v.len(),
+                    dims[3],
+                    dims[1]
+                ));
             }
         }
-        let sqrt_df = df.sqrt();
+        // Per-entry d-row scale for the compressed v_l / v_u blocks:
+        // entry j of v_l covers the d row pd_l.expanded_pos[j].
+        let v_row_scale = |pm: Rc<dyn pounce_linalg::matrix::Matrix>,
+                           n_v: usize,
+                           which: &str|
+         -> Result<Vec<Number>, String> {
+            let Some(dd) = &dd else {
+                return Ok(vec![1.0; n_v]);
+            };
+            if n_v == 0 {
+                return Ok(Vec::new());
+            }
+            let Some(em) = pm
+                .as_any()
+                .downcast_ref::<pounce_linalg::expansion_matrix::ExpansionMatrix>()
+            else {
+                return Err(format!("{which} is not an ExpansionMatrix"));
+            };
+            let pos = em.expanded_pos_indices();
+            if pos.len() != n_v {
+                return Err(format!(
+                    "{which} expansion length {} != {} block dim {}",
+                    pos.len(),
+                    which,
+                    n_v
+                ));
+            }
+            pos.iter()
+                .map(|&r| {
+                    dd.get(r as usize).copied().ok_or_else(|| {
+                        format!(
+                            "{which} expansion row {r} out of d_scale range {}",
+                            dd.len()
+                        )
+                    })
+                })
+                .collect()
+        };
+        let vl_dd = v_row_scale(nlp_ref.pd_l(), dims[6], "pd_l")?;
+        let vu_dd = v_row_scale(nlp_ref.pd_u(), dims[7], "pd_u")?;
+        drop(nlp_ref);
+
         let total: usize = dims.iter().sum();
-        let mut d = Vec::with_capacity(total);
-        // x block: √df.
-        d.extend(std::iter::repeat_n(sqrt_df, dims[0]));
-        // s block: √df / dd_i (slacks live in scaled d-space).
+        let mut e = Vec::with_capacity(total);
+        let mut f = Vec::with_capacity(total);
+        // x block: E = df, F = 1.
+        e.extend(std::iter::repeat_n(df, dims[0]));
+        f.extend(std::iter::repeat_n(1.0, dims[0]));
+        // s block: E = df/dd_i, F = 1/dd_i (slacks live in scaled d-space).
         match &dd {
-            Some(v) => d.extend(v.iter().map(|&ddi| sqrt_df / ddi)),
-            None => d.extend(std::iter::repeat_n(sqrt_df, dims[1])),
+            Some(v) => {
+                e.extend(v.iter().map(|&ddi| df / ddi));
+                f.extend(v.iter().map(|&ddi| 1.0 / ddi));
+            }
+            None => {
+                e.extend(std::iter::repeat_n(df, dims[1]));
+                f.extend(std::iter::repeat_n(1.0, dims[1]));
+            }
         }
-        // y_c block: dc_i / √df.
+        // y_c block: E = dc_i, F = dc_i/df.
         match &dc {
-            Some(v) => d.extend(v.iter().map(|&dci| dci / sqrt_df)),
-            None => d.extend(std::iter::repeat_n(1.0 / sqrt_df, dims[2])),
+            Some(v) => {
+                e.extend(v.iter().copied());
+                f.extend(v.iter().map(|&dci| dci / df));
+            }
+            None => {
+                e.extend(std::iter::repeat_n(1.0, dims[2]));
+                f.extend(std::iter::repeat_n(1.0 / df, dims[2]));
+            }
         }
-        // y_d block: dd_i / √df.
+        // y_d block: E = dd_i, F = dd_i/df.
         match &dd {
-            Some(v) => d.extend(v.iter().map(|&ddi| ddi / sqrt_df)),
-            None => d.extend(std::iter::repeat_n(1.0 / sqrt_df, dims[3])),
+            Some(v) => {
+                e.extend(v.iter().copied());
+                f.extend(v.iter().map(|&ddi| ddi / df));
+            }
+            None => {
+                e.extend(std::iter::repeat_n(1.0, dims[3]));
+                f.extend(std::iter::repeat_n(1.0 / df, dims[3]));
+            }
         }
-        // z_l / z_u / v_l / v_u blocks: identity (not part of the
-        // congruence; see field doc).
-        d.extend(std::iter::repeat_n(
-            1.0,
-            dims[4] + dims[5] + dims[6] + dims[7],
-        ));
-        Ok(Some(Rc::new(d)))
+        // z_l / z_u blocks: E = df, F = 1/df (z̃ = df·z; bounds on x
+        // are unscaled so the slack diagonal X − x_L is shared by both
+        // systems).
+        e.extend(std::iter::repeat_n(df, dims[4] + dims[5]));
+        f.extend(std::iter::repeat_n(1.0 / df, dims[4] + dims[5]));
+        // v_l / v_u blocks: E = df, F = dd_r/df (ṽ = (df/dd)·v and the
+        // slack diagonal s̃ − d̃_l = dd·(s − d_l) carries the d-row
+        // scale).
+        e.extend(std::iter::repeat_n(df, dims[6] + dims[7]));
+        f.extend(vl_dd.iter().map(|&ddr| ddr / df));
+        f.extend(vu_dd.iter().map(|&ddr| ddr / df));
+        Ok(Some(Rc::new(ConjPair { e, f })))
     }
 
     /// Effective objective scaling factor `df` of the converged NLP
@@ -215,45 +310,55 @@ impl PdSensBacksolver {
     }
 
     /// Map user-facing 0-based `g(x)` indices of parameter-pin
-    /// equality constraints to flat KKT rows (`n_x + n_s +
-    /// c_block_idx`, i.e. the matching `y_c` slots). Goes through
-    /// `IpoptNlp::full_g_to_c_block` so the c/d split's row
+    /// equality constraints to flat KKT rows **and** the pin rows'
+    /// `dc_i` scaling factors, in one pass. The KKT row of pin `i` is
+    /// `n_x + n_s + c_block_idx`, i.e. the matching `y_c` slot, found
+    /// through `IpoptNlp::full_g_to_c_block` so the c/d split's row
     /// permutation is honored (pounce#128 follow-up: the previous
     /// direct `n_x + n_s + g_idx` mapping silently picked wrong rows
-    /// when inequalities preceded the pins). Errors when a pin index
-    /// refers to an inequality row.
-    pub fn map_pin_g_to_kkt_rows(&self, pin_g_indices: &[Index]) -> Result<Vec<Index>, String> {
+    /// when inequalities preceded the pins). The scales are 1.0 when
+    /// no constraint scaling is active; they relate the natural and
+    /// solver-space reduced Hessians via
+    /// `H̃_ij = (df / (dc_i·dc_j)) · H_ij`. Errors when a pin index
+    /// is out of range or refers to an inequality row.
+    pub fn pin_rows_and_c_scales(
+        &self,
+        pin_g_indices: &[Index],
+    ) -> Result<(Vec<Index>, Vec<Number>), String> {
         let y_c_offset = (self.dims[0] + self.dims[1]) as Index;
         let nlp = self.nlp.borrow();
-        pin_g_indices
-            .iter()
-            .map(|&gi| match nlp.full_g_to_c_block(gi) {
-                Some(ci) => Ok(y_c_offset + ci),
-                None => Err(format!(
+        let dc = nlp.c_scale_vec();
+        let n_full_g = nlp.n_full_g();
+        let mut rows = Vec::with_capacity(pin_g_indices.len());
+        let mut scales = Vec::with_capacity(pin_g_indices.len());
+        for &gi in pin_g_indices {
+            // n_full_g() defaults to 0 for IpoptNlp impls that don't
+            // report it; only range-check when it's meaningful.
+            if gi < 0 || (n_full_g > 0 && gi >= n_full_g) {
+                return Err(format!(
+                    "pin constraint index {gi} out of range [0, m={n_full_g})"
+                ));
+            }
+            let Some(ci) = nlp.full_g_to_c_block(gi) else {
+                return Err(format!(
                     "pin constraint index {gi} is an inequality (not an equality row); \
                      parameter pins must be exact equalities"
-                )),
-            })
-            .collect()
+                ));
+            };
+            rows.push(y_c_offset + ci);
+            scales.push(dc.as_ref().map(|v| v[ci as usize]).unwrap_or(1.0));
+        }
+        Ok((rows, scales))
     }
 
-    /// Per-pin equality-row scaling factors `dc_i` (1.0 when no
-    /// constraint scaling is active). Same `pin_g_indices` convention
-    /// as [`Self::map_pin_g_to_kkt_rows`]. Reported alongside the
-    /// reduced Hessian so callers can reconstruct the solver-space
-    /// (scaled) value `H̃_ij = (df / (dc_i·dc_j)) · H_ij`.
+    /// KKT-row half of [`Self::pin_rows_and_c_scales`].
+    pub fn map_pin_g_to_kkt_rows(&self, pin_g_indices: &[Index]) -> Result<Vec<Index>, String> {
+        Ok(self.pin_rows_and_c_scales(pin_g_indices)?.0)
+    }
+
+    /// Scaling half of [`Self::pin_rows_and_c_scales`].
     pub fn pin_c_scales(&self, pin_g_indices: &[Index]) -> Result<Vec<Number>, String> {
-        let nlp = self.nlp.borrow();
-        let dc = nlp.c_scale_vec();
-        pin_g_indices
-            .iter()
-            .map(|&gi| match nlp.full_g_to_c_block(gi) {
-                Some(ci) => Ok(dc.as_ref().map(|v| v[ci as usize]).unwrap_or(1.0)),
-                None => Err(format!(
-                    "pin constraint index {gi} is an inequality (not an equality row)"
-                )),
-            })
-            .collect()
+        Ok(self.pin_rows_and_c_scales(pin_g_indices)?.1)
     }
 
     /// Block dimensions of the compound KKT vector at convergence, in
@@ -346,23 +451,23 @@ impl PdSensBacksolver {
     pub fn solve_many(&self, rhs_flat: &[Number], lhs_flat: &mut [Number], n_rhs: usize) -> bool {
         match &self.conj {
             None => self.solve_many_scaled_space(rhs_flat, lhs_flat, n_rhs),
-            Some(d) => {
+            Some(c) => {
                 let total = self.dim();
                 if rhs_flat.len() != n_rhs * total || lhs_flat.len() != n_rhs * total {
                     return false;
                 }
                 let mut rhs_scaled = rhs_flat.to_vec();
                 for row in rhs_scaled.chunks_mut(total) {
-                    for (r, &di) in row.iter_mut().zip(d.iter()) {
-                        *r *= di;
+                    for (r, &ei) in row.iter_mut().zip(c.e.iter()) {
+                        *r *= ei;
                     }
                 }
                 if !self.solve_many_scaled_space(&rhs_scaled, lhs_flat, n_rhs) {
                     return false;
                 }
                 for row in lhs_flat.chunks_mut(total) {
-                    for (l, &di) in row.iter_mut().zip(d.iter()) {
-                        *l *= di;
+                    for (l, &fi) in row.iter_mut().zip(c.f.iter()) {
+                        *l *= fi;
                     }
                 }
                 true
@@ -622,28 +727,26 @@ impl SensBacksolver for PdSensBacksolver {
     /// Solve `K · lhs = rhs` against the converged factor, in
     /// **natural (unscaled) units** (pounce#128): when the NLP carries
     /// active scaling (`nlp_scaling_method`, `obj_scaling_factor`,
-    /// user scaling) the RHS and result are conjugated by the diagonal
-    /// `D` documented on the `conj` field, so `lhs = K_natural⁻¹ rhs`
-    /// for the `x / s / y_c / y_d` blocks. The z/v bound-multiplier
-    /// blocks are passed through unconjugated: RHS entries there are
-    /// fed to the factor as-is and the corresponding result entries
-    /// remain in solver space. Use [`Self::solve_scaled_space`] for
-    /// the raw factor.
+    /// user scaling) the RHS is pre-multiplied by `E` and the result
+    /// post-multiplied by `F` (see the `conj` field doc), so
+    /// `lhs = K_natural⁻¹ rhs` for **all eight blocks** — including
+    /// the z/v bound-multiplier rows. Use
+    /// [`Self::solve_scaled_space`] for the raw factor.
     fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
         match &self.conj {
             None => self.solve_scaled_space(rhs, lhs),
-            Some(d) => {
+            Some(c) => {
                 let total = self.dim();
                 if rhs.len() != total || lhs.len() != total {
                     return false;
                 }
                 let rhs_scaled: Vec<Number> =
-                    rhs.iter().zip(d.iter()).map(|(&r, &di)| r * di).collect();
+                    rhs.iter().zip(c.e.iter()).map(|(&r, &ei)| r * ei).collect();
                 if !self.solve_scaled_space(&rhs_scaled, lhs) {
                     return false;
                 }
-                for (l, &di) in lhs.iter_mut().zip(d.iter()) {
-                    *l *= di;
+                for (l, &fi) in lhs.iter_mut().zip(c.f.iter()) {
+                    *l *= fi;
                 }
                 true
             }

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -104,7 +104,10 @@ pub struct SensResult {
     pub dx: Option<Vec<Number>>,
     /// Full KKT-space step (primals + slacks + duals stacked in the
     /// pounce compound-vector layout). Lower-level than `dx`; useful
-    /// for cross-checking against upstream sIPOPT outputs.
+    /// for cross-checking against upstream sIPOPT outputs. All blocks
+    /// — including the bound-multiplier z/v rows — are in natural
+    /// (unscaled) units (pounce#128); note upstream sIPOPT reports the
+    /// scaled-space step when NLP scaling is active.
     pub dx_full: Option<Vec<Number>>,
     /// Reduced Hessian `H_R`, length `n_params²`, column-major, in
     /// **natural (unscaled) units** — any NLP scaling baked into the
@@ -308,7 +311,7 @@ impl SensSolve {
                 Ok(b) => b,
                 Err(e) => {
                     outbox_cb.borrow_mut().error =
-                        Some(format!("PdSensBacksolver::new failed: {e:?}"));
+                        Some(format!("PdSensBacksolver::new failed: {e}"));
                     return;
                 }
             };
@@ -319,15 +322,8 @@ impl SensSolve {
             // NLP's c/d-split row map (pounce#128: a direct
             // `n_x + n_s + i` is wrong once inequalities precede the
             // pins in g).
-            let param_rows = match backsolver.map_pin_g_to_kkt_rows(&pin_indices) {
-                Ok(r) => r,
-                Err(e) => {
-                    outbox_cb.borrow_mut().error = Some(e);
-                    return;
-                }
-            };
-            let pin_scales = match backsolver.pin_c_scales(&pin_indices) {
-                Ok(s) => s,
+            let (param_rows, pin_scales) = match backsolver.pin_rows_and_c_scales(&pin_indices) {
+                Ok(rs) => rs,
                 Err(e) => {
                     outbox_cb.borrow_mut().error = Some(e);
                     return;
@@ -396,14 +392,9 @@ impl SensSolve {
                     return;
                 }
                 // Solver-space (pre-#128) value, reconstructed from
-                // the natural-units H rather than re-solved:
-                // H̃_ij = (df / (dc_i·dc_j)) · H_ij.
+                // the natural-units H rather than re-solved.
                 let mut hr_scaled = hr.clone();
-                for j in 0..n_params {
-                    for i in 0..n_params {
-                        hr_scaled[j * n_params + i] *= df / (pin_scales[i] * pin_scales[j]);
-                    }
-                }
+                crate::reduced_hessian::scale_to_solver_space(&mut hr_scaled, df, &pin_scales);
                 outbox_cb.borrow_mut().reduced_hessian = Some(hr);
                 outbox_cb.borrow_mut().reduced_hessian_scaled = Some(hr_scaled);
             }

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -106,10 +106,28 @@ pub struct SensResult {
     /// pounce compound-vector layout). Lower-level than `dx`; useful
     /// for cross-checking against upstream sIPOPT outputs.
     pub dx_full: Option<Vec<Number>>,
-    /// Reduced Hessian `H_R`, length `n_params²`, column-major. Only
-    /// present when [`SensSolve::with_reduced_hessian`] was called and
-    /// the solve converged.
+    /// Reduced Hessian `H_R`, length `n_params²`, column-major, in
+    /// **natural (unscaled) units** — any NLP scaling baked into the
+    /// converged KKT factor is undone, so `−inv(H_R)` is directly the
+    /// parameter covariance of an estimation problem regardless of
+    /// `nlp_scaling_method` (pounce#128). Only present when
+    /// [`SensSolve::with_reduced_hessian`] was called and the solve
+    /// converged.
     pub reduced_hessian: Option<Vec<Number>>,
+    /// The reduced Hessian as the solver's internal scaled space sees
+    /// it — `H̃_ij = (df / (dc_i·dc_j)) · H_ij` with `df =`
+    /// [`Self::obj_scaling_factor`] and `dc =` [`Self::pin_g_scaling`].
+    /// This is the value pounce returned before #128; kept for callers
+    /// that calibrated against it. Present iff `reduced_hessian` is.
+    pub reduced_hessian_scaled: Option<Vec<Number>>,
+    /// Effective objective scaling factor `df` the IPM applied
+    /// (`nlp_scaling_method` / `obj_scaling_factor`; 1.0 ⇔ none).
+    /// Present whenever the solve converged.
+    pub obj_scaling_factor: Option<Number>,
+    /// Per-pin equality-row scaling factors `dc_i` (all 1.0 when no
+    /// constraint scaling is active), ordered like
+    /// `pin_constraint_indices`. Present whenever the solve converged.
+    pub pin_g_scaling: Option<Vec<Number>>,
     /// Eigenvalues of `H_R` in ascending order, length `n_params`.
     /// Present only when [`SensSolve::with_reduced_hessian_eigen`] was
     /// called and the solve converged.
@@ -160,8 +178,14 @@ impl SensSolve {
         self
     }
 
-    /// Request the reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` at the
-    /// converged solution, where `B` selects the parameter-pin rows.
+    /// Request the reduced Hessian `H_R = B K⁻¹ Bᵀ` at the converged
+    /// solution, where `B` selects the parameter-pin rows and `K` is
+    /// the **natural-units** (unscaled) KKT matrix — any active NLP
+    /// scaling is undone by the backsolver (pounce#128). The
+    /// solver-space value and the scaling factors are reported
+    /// alongside in [`SensResult::reduced_hessian_scaled`] /
+    /// [`SensResult::obj_scaling_factor`] /
+    /// [`SensResult::pin_g_scaling`].
     pub fn with_reduced_hessian(mut self) -> Self {
         self.compute_reduced_hessian = true;
         self
@@ -177,9 +201,12 @@ impl SensSolve {
         self
     }
 
-    /// Objective scaling factor applied to the reduced Hessian.
-    /// Default 1.0; set to the IPM's `obj_scaling_factor` if the
-    /// caller scaled their objective.
+    /// Extra constant multiplier applied to the reduced Hessian.
+    /// Default 1.0. **Deprecated in spirit since pounce#128**: the
+    /// backsolver now undoes the IPM's NLP scaling itself, so this is
+    /// no longer needed to recover natural units — it survives as a
+    /// plain user-side multiplier for callers that scaled their
+    /// objective *outside* pounce.
     pub fn with_obj_scal(mut self, obj_scal: Number) -> Self {
         self.obj_scal = obj_scal;
         self
@@ -276,14 +303,6 @@ impl SensSolve {
             }
 
             let n_x = curr.x.dim() as usize;
-            let n_s = curr.s.dim() as usize;
-            // y_c rows live right after the (x, s) primal block in
-            // the compound-vector layout. Pin constraint indices are
-            // user-facing 0-based indices into g(x); the same
-            // constraint lives at flat KKT row `n_x + n_s + i`.
-            let y_c_offset = (n_x + n_s) as Index;
-            let param_rows: Vec<Index> = pin_indices.iter().map(|&i| y_c_offset + i).collect();
-            let signs = vec![1; n_params];
 
             let backsolver = match PdSensBacksolver::new(data, cq, nlp, Rc::clone(&pd)) {
                 Ok(b) => b,
@@ -294,6 +313,30 @@ impl SensSolve {
                 }
             };
             let n_full = backsolver.dim();
+
+            // Pin constraint indices are user-facing 0-based indices
+            // into g(x); the matching y_c slot is found through the
+            // NLP's c/d-split row map (pounce#128: a direct
+            // `n_x + n_s + i` is wrong once inequalities precede the
+            // pins in g).
+            let param_rows = match backsolver.map_pin_g_to_kkt_rows(&pin_indices) {
+                Ok(r) => r,
+                Err(e) => {
+                    outbox_cb.borrow_mut().error = Some(e);
+                    return;
+                }
+            };
+            let pin_scales = match backsolver.pin_c_scales(&pin_indices) {
+                Ok(s) => s,
+                Err(e) => {
+                    outbox_cb.borrow_mut().error = Some(e);
+                    return;
+                }
+            };
+            let df = backsolver.obj_scaling_factor();
+            outbox_cb.borrow_mut().obj_scaling_factor = Some(df);
+            outbox_cb.borrow_mut().pin_g_scaling = Some(pin_scales.clone());
+            let signs = vec![1; n_params];
 
             let a_data = match IndexSchurData::from_parts(param_rows, signs) {
                 Ok(a) => a,
@@ -345,16 +388,24 @@ impl SensSolve {
                             Some("SensApplication::compute_reduced_hessian_eigen failed".into());
                         return;
                     }
-                    outbox_cb.borrow_mut().reduced_hessian = Some(hr);
                     outbox_cb.borrow_mut().reduced_hessian_eigenvalues = Some(w);
                     outbox_cb.borrow_mut().reduced_hessian_eigenvectors = Some(v);
                 } else if !sens_app.compute_reduced_hessian(&mut hr) {
                     outbox_cb.borrow_mut().error =
                         Some("SensApplication::compute_reduced_hessian failed".into());
                     return;
-                } else {
-                    outbox_cb.borrow_mut().reduced_hessian = Some(hr);
                 }
+                // Solver-space (pre-#128) value, reconstructed from
+                // the natural-units H rather than re-solved:
+                // H̃_ij = (df / (dc_i·dc_j)) · H_ij.
+                let mut hr_scaled = hr.clone();
+                for j in 0..n_params {
+                    for i in 0..n_params {
+                        hr_scaled[j * n_params + i] *= df / (pin_scales[i] * pin_scales[j]);
+                    }
+                }
+                outbox_cb.borrow_mut().reduced_hessian = Some(hr);
+                outbox_cb.borrow_mut().reduced_hessian_scaled = Some(hr_scaled);
             }
         }));
 
@@ -367,6 +418,9 @@ impl SensSolve {
             dx: out.dx.clone(),
             dx_full: out.dx_full.clone(),
             reduced_hessian: out.reduced_hessian.clone(),
+            reduced_hessian_scaled: out.reduced_hessian_scaled.clone(),
+            obj_scaling_factor: out.obj_scaling_factor,
+            pin_g_scaling: out.pin_g_scaling.clone(),
             reduced_hessian_eigenvalues: out.reduced_hessian_eigenvalues.clone(),
             reduced_hessian_eigenvectors: out.reduced_hessian_eigenvectors.clone(),
             mult_g: out.mult_g.clone(),
@@ -384,6 +438,9 @@ struct CallbackOut {
     dx: Option<Vec<Number>>,
     dx_full: Option<Vec<Number>>,
     reduced_hessian: Option<Vec<Number>>,
+    reduced_hessian_scaled: Option<Vec<Number>>,
+    obj_scaling_factor: Option<Number>,
+    pin_g_scaling: Option<Vec<Number>>,
     reduced_hessian_eigenvalues: Option<Vec<Number>>,
     reduced_hessian_eigenvectors: Option<Vec<Number>>,
     mult_g: Option<Vec<Number>>,

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -131,6 +131,14 @@ pub struct SensResult {
     /// constraint scaling is active), ordered like
     /// `pin_constraint_indices`. Present whenever the solve converged.
     pub pin_g_scaling: Option<Vec<Number>>,
+    /// Inertia-correction perturbations `(δ_x, δ_s, δ_c, δ_d)` baked
+    /// into the converged KKT factor. All zero ⇔ the factor is
+    /// unregularized and the natural-units sensitivity outputs invert
+    /// the exact KKT matrix; nonzero ⇔ they are perturbed (and not
+    /// exactly scaling-invariant) — check before trusting
+    /// `-inv(reduced_hessian)` as a covariance on ill-conditioned
+    /// problems. Present whenever the solve converged.
+    pub kkt_perturbations: Option<[Number; 4]>,
     /// Eigenvalues of `H_R` in ascending order, length `n_params`.
     /// Present only when [`SensSolve::with_reduced_hessian_eigen`] was
     /// called and the solve converged.
@@ -332,6 +340,7 @@ impl SensSolve {
             let df = backsolver.obj_scaling_factor();
             outbox_cb.borrow_mut().obj_scaling_factor = Some(df);
             outbox_cb.borrow_mut().pin_g_scaling = Some(pin_scales.clone());
+            outbox_cb.borrow_mut().kkt_perturbations = Some(backsolver.kkt_perturbations());
             let signs = vec![1; n_params];
 
             let a_data = match IndexSchurData::from_parts(param_rows, signs) {
@@ -412,6 +421,7 @@ impl SensSolve {
             reduced_hessian_scaled: out.reduced_hessian_scaled.clone(),
             obj_scaling_factor: out.obj_scaling_factor,
             pin_g_scaling: out.pin_g_scaling.clone(),
+            kkt_perturbations: out.kkt_perturbations,
             reduced_hessian_eigenvalues: out.reduced_hessian_eigenvalues.clone(),
             reduced_hessian_eigenvectors: out.reduced_hessian_eigenvectors.clone(),
             mult_g: out.mult_g.clone(),
@@ -432,6 +442,7 @@ struct CallbackOut {
     reduced_hessian_scaled: Option<Vec<Number>>,
     obj_scaling_factor: Option<Number>,
     pin_g_scaling: Option<Vec<Number>>,
+    kkt_perturbations: Option<[Number; 4]>,
     reduced_hessian_eigenvalues: Option<Vec<Number>>,
     reduced_hessian_eigenvectors: Option<Vec<Number>>,
     mult_g: Option<Vec<Number>>,

--- a/crates/pounce-sensitivity/src/diff_handoff.rs
+++ b/crates/pounce-sensitivity/src/diff_handoff.rs
@@ -257,6 +257,7 @@ mod tests {
             reduced_hessian_scaled: None,
             obj_scaling_factor: None,
             pin_g_scaling: None,
+            kkt_perturbations: None,
             reduced_hessian_eigenvalues: None,
             reduced_hessian_eigenvectors: None,
             mult_g: Some(vec![0.0]), // degenerate: |λ| ≈ 0
@@ -286,6 +287,7 @@ mod tests {
             reduced_hessian_scaled: None,
             obj_scaling_factor: None,
             pin_g_scaling: None,
+            kkt_perturbations: None,
             reduced_hessian_eigenvalues: None,
             reduced_hessian_eigenvectors: None,
             mult_g: None, // duals not populated → no handoff

--- a/crates/pounce-sensitivity/src/diff_handoff.rs
+++ b/crates/pounce-sensitivity/src/diff_handoff.rs
@@ -254,6 +254,9 @@ mod tests {
             dx: None,
             dx_full: None,
             reduced_hessian: None,
+            reduced_hessian_scaled: None,
+            obj_scaling_factor: None,
+            pin_g_scaling: None,
             reduced_hessian_eigenvalues: None,
             reduced_hessian_eigenvectors: None,
             mult_g: Some(vec![0.0]), // degenerate: |λ| ≈ 0
@@ -280,6 +283,9 @@ mod tests {
             dx: None,
             dx_full: None,
             reduced_hessian: None,
+            reduced_hessian_scaled: None,
+            obj_scaling_factor: None,
+            pin_g_scaling: None,
             reduced_hessian_eigenvalues: None,
             reduced_hessian_eigenvectors: None,
             mult_g: None, // duals not populated → no handoff

--- a/crates/pounce-sensitivity/src/reduced_hessian.rs
+++ b/crates/pounce-sensitivity/src/reduced_hessian.rs
@@ -70,6 +70,29 @@ use pounce_common::types::Number;
 /// constructing a reduced Hessian outside a configured pounce IPM
 /// own the responsibility to pass an `obj_scal` consistent with
 /// whatever scaling their `K` factor encodes.
+/// Convert a natural-units reduced Hessian (column-major `n×n`,
+/// `n = dc.len()`) into the solver's internal scaled space in place:
+/// `H̃_ij = (df / (dc_i·dc_j)) · H_ij`, with `df` the effective
+/// objective scaling factor and `dc` the pin rows' constraint scaling
+/// factors. This is the inverse of the natural-units correction the
+/// live-factor backsolver applies (pounce#128) — i.e. the value
+/// pounce returned before #128. Single home for the formula so the
+/// `SensSolve` and `Solver` surfaces cannot drift.
+///
+/// Returns `false` when `hr` is mis-sized.
+pub fn scale_to_solver_space(hr: &mut [Number], df: Number, dc: &[Number]) -> bool {
+    let n = dc.len();
+    if hr.len() != n * n {
+        return false;
+    }
+    for j in 0..n {
+        for i in 0..n {
+            hr[j * n + i] *= df / (dc[i] * dc[j]);
+        }
+    }
+    true
+}
+
 pub fn compute_reduced_hessian<P: PCalculator>(
     pcalc: &mut P,
     hess_data: &dyn SchurData,

--- a/crates/pounce-sensitivity/src/reduced_hessian.rs
+++ b/crates/pounce-sensitivity/src/reduced_hessian.rs
@@ -17,10 +17,13 @@
 //! from the augmented-system reduction), which is then multiplied
 //! by `-obj_scal` to produce the unscaled reduced Hessian.
 //!
-//! In pounce we default `obj_scal = 1.0` (no NLP-side scaling
-//! folded in here) so the operation reduces to `H_R = -S = B K⁻¹ Bᵀ`.
-//! Phase D's `SensApplication` will plumb the real obj scaling once
-//! the algorithm-side wiring lands.
+//! In pounce we default `obj_scal = 1.0` so the operation reduces to
+//! `H_R = -S = B K⁻¹ Bᵀ`. Unlike upstream, no NLP-side scaling needs
+//! folding in here: since pounce#128 the live-factor backsolver
+//! ([`crate::PdSensBacksolver`]) conjugates every back-solve by the
+//! NLP scaling diagonal, so `K⁻¹` is already the natural-units KKT
+//! inverse and `obj_scal` survives purely as a user-side extra
+//! multiplier.
 //!
 //! Reference: Pirnay, López-Negrete & Biegler 2012, §5
 //! (reduced-Hessian use case), DOI:

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -480,6 +480,17 @@ impl Solver {
         Ok(state.backsolver.nlp_scaling())
     }
 
+    /// Inertia-correction perturbations `(δ_x, δ_s, δ_c, δ_d)` baked
+    /// into the held KKT factor. All zero ⇔ the final factorization
+    /// was unregularized and the natural-units back-solves invert the
+    /// exact KKT matrix — see
+    /// [`crate::PdSensBacksolver::kkt_perturbations`].
+    pub fn kkt_perturbations(&self) -> Result<[Number; 4], SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        Ok(state.backsolver.kkt_perturbations())
+    }
+
     /// Per-pin equality-row scaling factors `dc_i` (1.0 entries when
     /// no constraint scaling is active), ordered like
     /// `pin_constraint_indices`.

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -223,6 +223,14 @@ impl Solver {
     /// Solve `K · lhs = rhs` against the converged KKT factor. Both
     /// slices must have length `kkt_dim()`; the layout is the flat
     /// `x || s || y_c || y_d || z_l || z_u || v_l || v_u` packing.
+    ///
+    /// `K` here is the **natural-units** (unscaled) KKT matrix: when
+    /// the IPM solved with active NLP scaling, the backsolver
+    /// conjugates the RHS/solution so callers can pass RHS data in the
+    /// user's own units (pounce#128). The z/v bound-multiplier blocks
+    /// are passed through in solver space — see
+    /// [`crate::PdSensBacksolver::solve`]. For the raw scaled-space
+    /// back-solve use [`Self::kkt_solve_scaled`].
     pub fn kkt_solve(&self, rhs: &[Number], lhs: &mut [Number]) -> Result<(), SolverError> {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
@@ -242,6 +250,35 @@ impl Solver {
             });
         }
         if state.backsolver.solve(rhs, lhs) {
+            Ok(())
+        } else {
+            Err(SolverError::BacksolveFailed)
+        }
+    }
+
+    /// [`Self::kkt_solve`] without the natural-units conjugation: the
+    /// back-solve runs against the factor exactly as the IPM holds it
+    /// (the solver's internal scaled space). Identical to `kkt_solve`
+    /// when no NLP scaling is active.
+    pub fn kkt_solve_scaled(&self, rhs: &[Number], lhs: &mut [Number]) -> Result<(), SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let total = state.backsolver.dim();
+        if rhs.len() != total {
+            return Err(SolverError::BadShape {
+                what: "rhs",
+                got: rhs.len(),
+                expected: total,
+            });
+        }
+        if lhs.len() != total {
+            return Err(SolverError::BadShape {
+                what: "lhs",
+                got: lhs.len(),
+                expected: total,
+            });
+        }
+        if state.backsolver.solve_scaled_space(rhs, lhs) {
             Ok(())
         } else {
             Err(SolverError::BacksolveFailed)
@@ -307,16 +344,14 @@ impl Solver {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
 
-        // y_c rows live right after the (x, s) primal block in the
-        // compound-vector layout (matches `convenience.rs`).
+        // Map user g-indices to y_c rows through the NLP's c/d-split
+        // permutation (pounce#128; matches `convenience.rs`).
         let dims = state.backsolver.block_dims();
         let n_x = dims[0];
-        let n_s = dims[1];
-        let y_c_offset = (n_x + n_s) as Index;
-        let param_rows: Vec<Index> = pin_constraint_indices
-            .iter()
-            .map(|&i| y_c_offset + i)
-            .collect();
+        let param_rows = state
+            .backsolver
+            .map_pin_g_to_kkt_rows(pin_constraint_indices)
+            .map_err(SolverError::SensComputationFailed)?;
         let signs = vec![1; pin_constraint_indices.len()];
         let a_data = IndexSchurData::from_parts(param_rows, signs)
             .map_err(|e| SolverError::SensComputationFailed(format!("{e:?}")))?;
@@ -339,11 +374,20 @@ impl Solver {
 
     /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned
     /// equality-constraint rows, where `B` selects the
-    /// `pin_constraint_indices` rows of the y_c block. Returns the
-    /// `n²`-long column-major dense matrix (`n = pin_constraint_indices.len()`).
+    /// `pin_constraint_indices` rows of the y_c block and `K` is the
+    /// **natural-units** (unscaled) KKT matrix — active NLP scaling
+    /// is undone by the backsolver, so `−inv(H_R)` is directly the
+    /// parameter covariance regardless of `nlp_scaling_method`
+    /// (pounce#128). `obj_scal` survives as a plain extra multiplier
+    /// (default 1.0); it is no longer needed to recover natural units.
+    /// Returns the `n²`-long column-major dense matrix
+    /// (`n = pin_constraint_indices.len()`).
     ///
     /// Equivalent to [`crate::SensSolve::with_reduced_hessian`] but
-    /// usable post-hoc on a held `Solver`.
+    /// usable post-hoc on a held `Solver`. For the solver-space
+    /// (pre-#128) value use [`Self::compute_reduced_hessian_scaled`];
+    /// the factors themselves are exposed via [`Self::nlp_scaling`] /
+    /// [`Self::pin_g_scaling`].
     pub fn compute_reduced_hessian(
         &self,
         pin_constraint_indices: &[Index],
@@ -352,12 +396,10 @@ impl Solver {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
         let n = pin_constraint_indices.len();
-        let dims = state.backsolver.block_dims();
-        let y_c_offset = (dims[0] + dims[1]) as Index;
-        let param_rows: Vec<Index> = pin_constraint_indices
-            .iter()
-            .map(|&i| y_c_offset + i)
-            .collect();
+        let param_rows = state
+            .backsolver
+            .map_pin_g_to_kkt_rows(pin_constraint_indices)
+            .map_err(SolverError::SensComputationFailed)?;
         let signs = vec![1; n];
         let a_data = IndexSchurData::from_parts(param_rows, signs)
             .map_err(|e| SolverError::SensComputationFailed(format!("{e:?}")))?;
@@ -374,6 +416,61 @@ impl Solver {
             ));
         }
         Ok(hr)
+    }
+
+    /// The reduced Hessian as the solver's internal **scaled** space
+    /// sees it — the value [`Self::compute_reduced_hessian`] returned
+    /// before pounce#128: `H̃_ij = (df / (dc_i·dc_j)) · H_ij`.
+    /// Identical to `compute_reduced_hessian` when no NLP scaling is
+    /// active.
+    pub fn compute_reduced_hessian_scaled(
+        &self,
+        pin_constraint_indices: &[Index],
+        obj_scal: Number,
+    ) -> Result<Vec<Number>, SolverError> {
+        let mut hr = self.compute_reduced_hessian(pin_constraint_indices, obj_scal)?;
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let df = state.backsolver.obj_scaling_factor();
+        let dc = state
+            .backsolver
+            .pin_c_scales(pin_constraint_indices)
+            .map_err(SolverError::SensComputationFailed)?;
+        let n = pin_constraint_indices.len();
+        for j in 0..n {
+            for i in 0..n {
+                hr[j * n + i] *= df / (dc[i] * dc[j]);
+            }
+        }
+        Ok(hr)
+    }
+
+    /// Effective NLP scaling the IPM applied on the most recent
+    /// converged solve: `(obj_scaling_factor, c_scale, d_scale)`.
+    /// `(1.0, None, None)` ⇔ no scaling was active. The vectors are
+    /// per-row factors over the algorithm's equality (`c`) and
+    /// inequality (`d`) blocks.
+    pub fn nlp_scaling(
+        &self,
+    ) -> Result<(Number, Option<Vec<Number>>, Option<Vec<Number>>), SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        Ok(state.backsolver.nlp_scaling())
+    }
+
+    /// Per-pin equality-row scaling factors `dc_i` (1.0 entries when
+    /// no constraint scaling is active), ordered like
+    /// `pin_constraint_indices`.
+    pub fn pin_g_scaling(
+        &self,
+        pin_constraint_indices: &[Index],
+    ) -> Result<Vec<Number>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        state
+            .backsolver
+            .pin_c_scales(pin_constraint_indices)
+            .map_err(SolverError::SensComputationFailed)
     }
 }
 

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -174,7 +174,13 @@ impl Solver {
                 };
                 let backsolver = match PdSensBacksolver::new(data, cq, nlp, Rc::clone(&pd)) {
                     Ok(b) => b,
-                    Err(_) => return,
+                    Err(e) => {
+                        // No session state is stored, so post-solve
+                        // calls will report NotConverged; at least say
+                        // why on stderr rather than failing silently.
+                        eprintln!("pounce: Solver could not capture the KKT factor: {e}");
+                        return;
+                    }
                 };
                 let x = dense_to_vec(&*curr.x);
                 let obj_val = cq.borrow_mut().curr_f();
@@ -225,35 +231,14 @@ impl Solver {
     /// `x || s || y_c || y_d || z_l || z_u || v_l || v_u` packing.
     ///
     /// `K` here is the **natural-units** (unscaled) KKT matrix: when
-    /// the IPM solved with active NLP scaling, the backsolver
-    /// conjugates the RHS/solution so callers can pass RHS data in the
-    /// user's own units (pounce#128). The z/v bound-multiplier blocks
-    /// are passed through in solver space — see
+    /// the IPM solved with active NLP scaling, the backsolver scales
+    /// the RHS/solution (all eight blocks, including the z/v
+    /// bound-multiplier rows) so callers pass and receive data in the
+    /// user's own units (pounce#128) — see
     /// [`crate::PdSensBacksolver::solve`]. For the raw scaled-space
     /// back-solve use [`Self::kkt_solve_scaled`].
     pub fn kkt_solve(&self, rhs: &[Number], lhs: &mut [Number]) -> Result<(), SolverError> {
-        let state = self.state.borrow();
-        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
-        let total = state.backsolver.dim();
-        if rhs.len() != total {
-            return Err(SolverError::BadShape {
-                what: "rhs",
-                got: rhs.len(),
-                expected: total,
-            });
-        }
-        if lhs.len() != total {
-            return Err(SolverError::BadShape {
-                what: "lhs",
-                got: lhs.len(),
-                expected: total,
-            });
-        }
-        if state.backsolver.solve(rhs, lhs) {
-            Ok(())
-        } else {
-            Err(SolverError::BacksolveFailed)
-        }
+        self.kkt_solve_impl(rhs, lhs, false)
     }
 
     /// [`Self::kkt_solve`] without the natural-units conjugation: the
@@ -261,6 +246,15 @@ impl Solver {
     /// (the solver's internal scaled space). Identical to `kkt_solve`
     /// when no NLP scaling is active.
     pub fn kkt_solve_scaled(&self, rhs: &[Number], lhs: &mut [Number]) -> Result<(), SolverError> {
+        self.kkt_solve_impl(rhs, lhs, true)
+    }
+
+    fn kkt_solve_impl(
+        &self,
+        rhs: &[Number],
+        lhs: &mut [Number],
+        scaled: bool,
+    ) -> Result<(), SolverError> {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
         let total = state.backsolver.dim();
@@ -278,7 +272,12 @@ impl Solver {
                 expected: total,
             });
         }
-        if state.backsolver.solve_scaled_space(rhs, lhs) {
+        let ok = if scaled {
+            state.backsolver.solve_scaled_space(rhs, lhs)
+        } else {
+            state.backsolver.solve(rhs, lhs)
+        };
+        if ok {
             Ok(())
         } else {
             Err(SolverError::BacksolveFailed)
@@ -296,6 +295,27 @@ impl Solver {
         rhs_flat: &[Number],
         lhs_flat: &mut [Number],
         n_rhs: usize,
+    ) -> Result<(), SolverError> {
+        self.kkt_solve_many_impl(rhs_flat, lhs_flat, n_rhs, false)
+    }
+
+    /// [`Self::kkt_solve_many`] without the natural-units
+    /// conjugation (the batched sibling of [`Self::kkt_solve_scaled`]).
+    pub fn kkt_solve_many_scaled(
+        &self,
+        rhs_flat: &[Number],
+        lhs_flat: &mut [Number],
+        n_rhs: usize,
+    ) -> Result<(), SolverError> {
+        self.kkt_solve_many_impl(rhs_flat, lhs_flat, n_rhs, true)
+    }
+
+    fn kkt_solve_many_impl(
+        &self,
+        rhs_flat: &[Number],
+        lhs_flat: &mut [Number],
+        n_rhs: usize,
+        scaled: bool,
     ) -> Result<(), SolverError> {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
@@ -315,7 +335,14 @@ impl Solver {
                 expected,
             });
         }
-        if state.backsolver.solve_many(rhs_flat, lhs_flat, n_rhs) {
+        let ok = if scaled {
+            state
+                .backsolver
+                .solve_many_scaled_space(rhs_flat, lhs_flat, n_rhs)
+        } else {
+            state.backsolver.solve_many(rhs_flat, lhs_flat, n_rhs)
+        };
+        if ok {
             Ok(())
         } else {
             Err(SolverError::BacksolveFailed)
@@ -436,12 +463,7 @@ impl Solver {
             .backsolver
             .pin_c_scales(pin_constraint_indices)
             .map_err(SolverError::SensComputationFailed)?;
-        let n = pin_constraint_indices.len();
-        for j in 0..n {
-            for i in 0..n {
-                hr[j * n + i] *= df / (dc[i] * dc[j]);
-            }
-        }
+        crate::reduced_hessian::scale_to_solver_space(&mut hr, df, &dc);
         Ok(hr)
     }
 

--- a/crates/pounce-sensitivity/tests/scaling_invariance.rs
+++ b/crates/pounce-sensitivity/tests/scaling_invariance.rs
@@ -440,6 +440,380 @@ impl TNLP for NegatedScaledPinTnlp {
     fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
 }
 
+/// `min c0(x−p)² + c1(x−1)²` with an **active** inequality
+/// `SCALE·x ≥ SCALE·0.95` (g[0]) and the pin `SCALE·p = SCALE·p̂`
+/// (g[1]). Variables `(x, p)`. With `p` pinned at `p̂ = 0.7` the
+/// unconstrained-in-`x` minimizer is `x* = (c0·p̂ + c1)/(c0+c1) =
+/// 0.88 < 0.95`, so the lower bound binds and `x` is clamped at
+/// `0.95`. The active inequality makes its slack bound multiplier
+/// (`v_l`) nonzero, so — unlike the *inactive* inequality in
+/// [`ScaledPinTnlp`] — the v-block of the natural-units (E, F) pair
+/// now actually moves the numbers: this is the coverage that proves
+/// the `dd`-dependent v-row scaling is applied correctly, not merely
+/// present.
+struct ActiveIneqTnlp;
+
+impl TNLP for ActiveIneqTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -1.0e19;
+        b.x_u[0] = 1.0e19;
+        b.x_l[1] = -1.0e19;
+        b.x_u[1] = 1.0e19;
+        // g[0] = SCALE·x ≥ SCALE·0.95 (active lower bound)
+        b.g_l[0] = SCALE * 0.95;
+        b.g_u[0] = 1.0e19;
+        // g[1] = SCALE·p = SCALE·p̂ (pin)
+        b.g_l[1] = SCALE * P_HAT;
+        b.g_u[1] = SCALE * P_HAT;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.0;
+        sp.x[1] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (xx, p) = (x[0], x[1]);
+        Some(C0 * (xx - p) * (xx - p) + C1 * (xx - 1.0) * (xx - 1.0))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (xx, p) = (x[0], x[1]);
+        g[0] = 2.0 * C0 * (xx - p) + 2.0 * C1 * (xx - 1.0);
+        g[1] = -2.0 * C0 * (xx - p);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = SCALE * x[0];
+        g[1] = SCALE * x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = SCALE;
+                values[1] = SCALE;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1]);
+                jcol.copy_from_slice(&[0, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor * 2.0 * (C0 + C1);
+                values[1] = obj_factor * (-2.0) * C0;
+                values[2] = obj_factor * 2.0 * C0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+#[test]
+fn reduced_hessian_with_active_inequality_is_scaling_invariant() {
+    // With x clamped at 0.95 by the active inequality, f*(p) =
+    // c0·(0.95 − p)² + c1·(0.95 − 1)², so ∂²f*/∂p² = 2·c0 and, with
+    // the pin RHS r = SCALE·p, ∂²f*/∂r² = 2·c0 / SCALE². The reported
+    // reduced Hessian carries the pin-row sign flip (= −∂²f*/∂r²):
+    const H_ACTIVE: Number = -2.0 * C0 / (SCALE * SCALE);
+
+    let run = |method: &str| -> (Number, Number) {
+        let mut app = make_app(method);
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ActiveIneqTnlp));
+        let result = SensSolve::new(vec![1])
+            .with_reduced_hessian()
+            .run(&mut app, tnlp);
+        assert!(
+            matches!(
+                result.status,
+                ApplicationReturnStatus::SolveSucceeded
+                    | ApplicationReturnStatus::SolvedToAcceptableLevel
+            ),
+            "solve failed under nlp_scaling_method={method}: {:?}",
+            result.status,
+        );
+        let hr = result.reduced_hessian.expect("reduced Hessian populated");
+        let hr_scaled = result
+            .reduced_hessian_scaled
+            .expect("scaled reduced Hessian populated");
+        (hr[0], hr_scaled[0])
+    };
+
+    let (h_none, h_none_scaled) = run("none");
+    let (h_grad, h_grad_scaled) = run("gradient-based");
+    let rel = |a: Number, b: Number| (a - b).abs() / b.abs();
+
+    // The headline guard: the natural-units reduced Hessian over an
+    // ACTIVE inequality is the same regardless of NLP scaling. The
+    // v-block scaling factors (`dd`-dependent F rows) are now nonzero
+    // contributors to the back-solve; if they were dropped or wrong,
+    // the gradient-based value would diverge from the unscaled one.
+    assert!(
+        rel(h_none, h_grad) < 1e-6,
+        "active-inequality reduced Hessian not scaling-invariant: \
+         none {h_none}, gradient-based {h_grad}",
+    );
+    // ...and it matches the clamped-x analytic value, which differs
+    // from the inactive-inequality H_ANALYTIC (= −4.8e-4): the active
+    // constraint removes x as a free variable, so the curvature comes
+    // from c0 alone.
+    assert!(
+        rel(h_none, H_ACTIVE) < 1e-6,
+        "active-inequality reduced Hessian: H = {h_none}, analytic = {H_ACTIVE}",
+    );
+    assert!(
+        rel(H_ACTIVE, H_ANALYTIC) > 0.1,
+        "fixture sanity: the active-inequality H must differ from the inactive one",
+    );
+    // With scaling off the two accessors agree; with gradient-based
+    // scaling on they must differ (the scaled value is the pre-#128
+    // leak preserved for calibrated callers).
+    assert!(rel(h_none_scaled, h_none) < 1e-12);
+    assert!(
+        rel(h_grad_scaled, h_grad) > 1.0,
+        "expected the scaled accessor to differ when scaling is active: \
+         natural {h_grad}, scaled {h_grad_scaled}",
+    );
+}
+
+/// Two pins at **different** scales so the off-diagonal of the
+/// reported reduced Hessian carries a `dc_i·dc_j` cross term:
+///
+/// ```text
+/// min c0(x − p0)² + c1(x − p1)²
+/// s.t. SCALE0·p0 = SCALE0·p̂0   (g[0], pin)
+///      SCALE1·p1 = SCALE1·p̂1   (g[1], pin)
+/// ```
+///
+/// Variables `(x, p0, p1)`. Eliminating x gives `f*(p0,p1) =
+/// K·(p1 − p0)²` with `K = c0·c1/(c0+c1)`, so the natural-units
+/// reduced Hessian over `(r0, r1) = (SCALE0·p0, SCALE1·p1)` is, in
+/// the pin-row sign convention (`= −∂²f*/∂r²`):
+///
+/// ```text
+/// H = [ −2K/SCALE0²        +2K/(SCALE0·SCALE1) ]
+///     [ +2K/(SCALE0·SCALE1)   −2K/SCALE1²      ]
+/// ```
+///
+/// The two distinct scales (`dc_0 ≠ dc_1`) make every entry carry a
+/// different scaling correction; the off-diagonal in particular
+/// exercises the `dc_i·dc_j` cross product that a per-pin (diagonal-
+/// only) correction would get wrong.
+struct MultiPinTnlp;
+
+const SCALE0: Number = 1.0e4;
+const SCALE1: Number = 2.0e4;
+const P0_HAT: Number = 0.3;
+const P1_HAT: Number = 0.8;
+
+impl TNLP for MultiPinTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 5,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        for k in 0..3 {
+            b.x_l[k] = -1.0e19;
+            b.x_u[k] = 1.0e19;
+        }
+        b.g_l[0] = SCALE0 * P0_HAT;
+        b.g_u[0] = SCALE0 * P0_HAT;
+        b.g_l[1] = SCALE1 * P1_HAT;
+        b.g_u[1] = SCALE1 * P1_HAT;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        // Nonzero so the objective gradient at the start exceeds
+        // nlp_scaling_max_gradient and gradient-based `df` fires.
+        sp.x[0] = 1.0;
+        sp.x[1] = 0.0;
+        sp.x[2] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (xx, p0, p1) = (x[0], x[1], x[2]);
+        Some(C0 * (xx - p0) * (xx - p0) + C1 * (xx - p1) * (xx - p1))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (xx, p0, p1) = (x[0], x[1], x[2]);
+        g[0] = 2.0 * C0 * (xx - p0) + 2.0 * C1 * (xx - p1);
+        g[1] = -2.0 * C0 * (xx - p0);
+        g[2] = -2.0 * C1 * (xx - p1);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = SCALE0 * x[1];
+        g[1] = SCALE1 * x[2];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[1, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = SCALE0;
+                values[1] = SCALE1;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Lower triangle: (0,0)=2c0+2c1, (1,0)=−2c0, (1,1)=2c0,
+        // (2,0)=−2c1, (2,2)=2c1. The p0/p1 cross term is zero.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1, 2, 2]);
+                jcol.copy_from_slice(&[0, 0, 1, 0, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor * 2.0 * (C0 + C1);
+                values[1] = obj_factor * (-2.0) * C0;
+                values[2] = obj_factor * 2.0 * C0;
+                values[3] = obj_factor * (-2.0) * C1;
+                values[4] = obj_factor * 2.0 * C1;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+#[test]
+fn multi_pin_reduced_hessian_off_diagonal_is_scaling_invariant() {
+    const K: Number = C0 * C1 / (C0 + C1);
+    // Column-major 2×2; symmetric so only three distinct values.
+    let h00 = -2.0 * K / (SCALE0 * SCALE0);
+    let h11 = -2.0 * K / (SCALE1 * SCALE1);
+    let h01 = 2.0 * K / (SCALE0 * SCALE1);
+
+    let run = |method: &str| -> Vec<Number> {
+        let mut app = make_app(method);
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(MultiPinTnlp));
+        let result = SensSolve::new(vec![0, 1])
+            .with_reduced_hessian()
+            .run(&mut app, tnlp);
+        assert!(
+            matches!(
+                result.status,
+                ApplicationReturnStatus::SolveSucceeded
+                    | ApplicationReturnStatus::SolvedToAcceptableLevel
+            ),
+            "solve failed under nlp_scaling_method={method}: {:?}",
+            result.status,
+        );
+        let hr = result.reduced_hessian.expect("reduced Hessian populated");
+        assert_eq!(hr.len(), 4, "expected a 2×2 reduced Hessian");
+        hr
+    };
+
+    let h_none = run("none");
+    let h_grad = run("gradient-based");
+    let rel = |a: Number, b: Number| (a - b).abs() / b.abs().max(1e-30);
+
+    // Off-diagonal symmetry within each solve.
+    assert!(rel(h_none[1], h_none[2]) < 1e-9, "asymmetric: {h_none:?}");
+
+    // Headline guard: the full 2×2 natural-units reduced Hessian —
+    // diagonal AND off-diagonal — is invariant to NLP scaling. The
+    // off-diagonal mixes the two distinct pin scales (dc_0 ≠ dc_1);
+    // a diagonal-only scaling correction would leave it wrong under
+    // gradient-based scaling.
+    for k in 0..4 {
+        assert!(
+            rel(h_none[k], h_grad[k]) < 1e-6,
+            "entry {k} not scaling-invariant: none {}, gradient-based {}",
+            h_none[k],
+            h_grad[k],
+        );
+    }
+
+    // ...and matches the hand-derived analytic block.
+    assert!(
+        rel(h_none[0], h00) < 1e-6,
+        "H[0,0] = {}, analytic {h00}",
+        h_none[0]
+    );
+    assert!(
+        rel(h_none[3], h11) < 1e-6,
+        "H[1,1] = {}, analytic {h11}",
+        h_none[3]
+    );
+    assert!(
+        rel(h_none[1], h01) < 1e-6,
+        "H[1,0] = {}, analytic {h01} (the cross-scale off-diagonal)",
+        h_none[1],
+    );
+    // The off-diagonal must be genuinely nonzero — otherwise this
+    // would silently pass as a pair of decoupled single-pin tests.
+    assert!(h01.abs() > 1e-6, "fixture sanity: off-diagonal is nonzero");
+}
+
 #[test]
 fn parametric_step_is_invariant_to_nlp_scaling() {
     // dx*/dr for the pin RHS r: x*(p) = (c0·p + c1)/(c0+c1) and

--- a/crates/pounce-sensitivity/tests/scaling_invariance.rs
+++ b/crates/pounce-sensitivity/tests/scaling_invariance.rs
@@ -49,9 +49,12 @@ const P_HAT: Number = 0.7;
 
 /// `min c0(x−p)² + c1(x−1)²  s.t.  SCALE·p = SCALE·p̂`. Variables
 /// `(x, p)`; one equality (the pin). Optionally prepends an inactive
-/// inequality `x + p ≤ 10` as g[0] so the pin sits *after* an
-/// inequality in the user's g ordering (exercises the full-g → c-block
-/// row mapping).
+/// inequality `SCALE·(x + p) ≤ SCALE·10` as g[0] so the pin sits
+/// *after* an inequality in the user's g ordering (exercises the
+/// full-g → c-block row mapping) — and, being badly scaled itself,
+/// fires the per-row `dd` inequality scaling, which exercises the
+/// s/y_d/v-block entries of the natural-units (E, F) pair, including
+/// the `pd_u` expansion lookup for the v rows.
 struct ScaledPinTnlp {
     with_leading_inequality: bool,
 }
@@ -93,7 +96,7 @@ impl TNLP for ScaledPinTnlp {
         let pin = self.pin_row() as usize;
         if self.with_leading_inequality {
             b.g_l[0] = -1.0e19;
-            b.g_u[0] = 10.0;
+            b.g_u[0] = SCALE * 10.0;
         }
         b.g_l[pin] = SCALE * P_HAT;
         b.g_u[pin] = SCALE * P_HAT;
@@ -121,7 +124,7 @@ impl TNLP for ScaledPinTnlp {
     fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
         let pin = self.pin_row() as usize;
         if self.with_leading_inequality {
-            g[0] = x[0] + x[1];
+            g[0] = SCALE * (x[0] + x[1]);
         }
         g[pin] = SCALE * x[1];
         true
@@ -146,8 +149,8 @@ impl TNLP for ScaledPinTnlp {
             }
             SparsityRequest::Values { values } => {
                 if self.with_leading_inequality {
-                    values[0] = 1.0;
-                    values[1] = 1.0;
+                    values[0] = SCALE;
+                    values[1] = SCALE;
                     values[2] = SCALE;
                 } else {
                     values[0] = SCALE;
@@ -281,19 +284,27 @@ fn pin_rows_map_through_the_c_d_split() {
     // Hessian matches the same analytic value as the
     // no-inequality fixture.
     let (h, _) = run_reduced_hessian("none", true);
-    let rel = (h - H_ANALYTIC).abs() / H_ANALYTIC;
+    let rel = (h - H_ANALYTIC).abs() / H_ANALYTIC.abs();
     assert!(
         rel < 1e-6,
         "with a leading inequality: H = {h}, analytic = {H_ANALYTIC}",
     );
     // And stays right when scaling fires too.
     let (h2, _) = run_reduced_hessian("gradient-based", true);
-    let rel2 = (h2 - H_ANALYTIC).abs() / H_ANALYTIC;
+    let rel2 = (h2 - H_ANALYTIC).abs() / H_ANALYTIC.abs();
     assert!(
         rel2 < 1e-6,
         "leading inequality + gradient-based scaling: H = {h2}, analytic = {H_ANALYTIC}",
     );
 }
+
+// Note on `obj_scaling_factor < 0` (maximization): the two-sided
+// (E, F) natural-units scaling handles a negative effective `df`
+// (no square root involved), so `PdSensBacksolver::new` accepts it.
+// An end-to-end regression test is not possible yet because pounce's
+// IPM currently diverges on maximization problems posed via a
+// negative `obj_scaling_factor` (pre-existing, independent of the
+// #128 fix), so no converged factor is ever produced.
 
 #[test]
 fn parametric_step_is_invariant_to_nlp_scaling() {

--- a/crates/pounce-sensitivity/tests/scaling_invariance.rs
+++ b/crates/pounce-sensitivity/tests/scaling_invariance.rs
@@ -225,6 +225,13 @@ fn run_reduced_hessian(scaling_method: &str, with_leading_inequality: bool) -> (
         "solve failed under nlp_scaling_method={scaling_method}: {:?}",
         result.status,
     );
+    // Clean quadratic fixture: the final factorization needs no
+    // inertia correction, and the all-zero perturbations are the
+    // signal that the natural-units covariance reading is exact.
+    let pert = result
+        .kkt_perturbations
+        .expect("KKT perturbations reported at convergence");
+    assert_eq!(pert, [0.0; 4], "unexpected KKT regularization: {pert:?}");
     let hr = result.reduced_hessian.expect("reduced Hessian populated");
     let hr_scaled = result
         .reduced_hessian_scaled
@@ -298,13 +305,140 @@ fn pin_rows_map_through_the_c_d_split() {
     );
 }
 
-// Note on `obj_scaling_factor < 0` (maximization): the two-sided
-// (E, F) natural-units scaling handles a negative effective `df`
-// (no square root involved), so `PdSensBacksolver::new` accepts it.
-// An end-to-end regression test is not possible yet because pounce's
-// IPM currently diverges on maximization problems posed via a
-// negative `obj_scaling_factor` (pre-existing, independent of the
-// #128 fix), so no converged factor is ever produced.
+/// `obj_scaling_factor < 0` is the documented way to maximize. The
+/// two-sided (E, F) natural-units scaling needs no square root, so a
+/// negative effective `df` is handled and the sensitivity surfaces
+/// keep working. The fixture maximizes `−[c0(x−p)² + c1(x−1)²]`
+/// (same minimizer as [`ScaledPinTnlp`] under `obj_scaling_factor =
+/// −1`). The user-space multipliers satisfy the *declared* problem's
+/// Lagrangian `−f + yᵀg`, so the natural-units reduced Hessian is
+/// the sign-flip of [`H_ANALYTIC`].
+#[test]
+fn reduced_hessian_works_under_negative_obj_scaling() {
+    let mut app = make_app("gradient-based");
+    app.options_mut()
+        .set_numeric_value("obj_scaling_factor", -1.0, true, false)
+        .unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(NegatedScaledPinTnlp));
+    let result = SensSolve::new(vec![0])
+        .with_reduced_hessian()
+        .run(&mut app, tnlp);
+    assert!(
+        matches!(
+            result.status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "maximization solve failed: {:?}",
+        result.status,
+    );
+    let hr = result
+        .reduced_hessian
+        .expect("reduced Hessian populated under negative obj scaling");
+    let expected = -H_ANALYTIC;
+    let rel = (hr[0] - expected).abs() / expected.abs();
+    assert!(
+        rel < 1e-6,
+        "negative obj_scaling_factor: H = {}, expected = {expected}",
+        hr[0],
+    );
+    let df = result.obj_scaling_factor.expect("df reported");
+    assert!(df < 0.0, "effective df must carry the user's sign: {df}");
+}
+
+/// `max −[c0(x−p)² + c1(x−1)²]` posed as a TNLP whose `f` is the
+/// negated objective; with `obj_scaling_factor = −1` the IPM
+/// re-negates it internally and converges to the same minimizer as
+/// [`ScaledPinTnlp`].
+struct NegatedScaledPinTnlp;
+
+impl TNLP for NegatedScaledPinTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 1,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -1.0e19;
+        b.x_u[0] = 1.0e19;
+        b.x_l[1] = -1.0e19;
+        b.x_u[1] = 1.0e19;
+        b.g_l[0] = SCALE * P_HAT;
+        b.g_u[0] = SCALE * P_HAT;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.0;
+        sp.x[1] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (xx, p) = (x[0], x[1]);
+        Some(-(C0 * (xx - p) * (xx - p) + C1 * (xx - 1.0) * (xx - 1.0)))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (xx, p) = (x[0], x[1]);
+        g[0] = -(2.0 * C0 * (xx - p) + 2.0 * C1 * (xx - 1.0));
+        g[1] = 2.0 * C0 * (xx - p);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = SCALE * x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0]);
+                jcol.copy_from_slice(&[1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = SCALE;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1]);
+                jcol.copy_from_slice(&[0, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = -obj_factor * 2.0 * (C0 + C1);
+                values[1] = obj_factor * 2.0 * C0;
+                values[2] = -obj_factor * 2.0 * C0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
 
 #[test]
 fn parametric_step_is_invariant_to_nlp_scaling() {

--- a/crates/pounce-sensitivity/tests/scaling_invariance.rs
+++ b/crates/pounce-sensitivity/tests/scaling_invariance.rs
@@ -1,0 +1,329 @@
+//! Regression tests for pounce#128: the reduced Hessian and the
+//! parametric step must come back in **natural (unscaled) units**,
+//! independent of the NLP scaling the IPM applied internally.
+//!
+//! Fixture: a 2-variable least-squares-style NLP
+//!
+//! ```text
+//! min  c0·(x − p)² + c1·(x − 1)²
+//! s.t. SCALE·p = SCALE·p̂          (parameter pin, row scaled by SCALE)
+//! ```
+//!
+//! Eliminating x analytically gives `f*(p) = c0·c1·(p − 1)² / (c0 + c1)`,
+//! so with the pin's right-hand side `r = SCALE·p̂` as the parameter,
+//!
+//! ```text
+//! ∂²f*/∂r² = 2·c0·c1 / ((c0 + c1)·SCALE²)
+//! ```
+//!
+//! Sign convention: over pin *constraint* rows, `B K⁻¹ Bᵀ` is the
+//! multiplier sensitivity `∂y/∂r = −∂²f*/∂r²` (IPOPT's `L = f + yᵀg`
+//! gives `y = −∂f*/∂r` at the optimum), so the reported reduced
+//! Hessian is the **negative** of `∂²f*/∂r²` — which is why the
+//! covariance recipe is `Cov = −inv(H)`.
+//!
+//! The coefficients are chosen so the objective gradient at the
+//! starting point (≈ 2·c1 = 1.2e5) exceeds `nlp_scaling_max_gradient`
+//! (100) — the gradient-based objective scaling `df` fires — and the
+//! pin row's Jacobian entry SCALE = 1e4 exceeds it too, so the
+//! per-row constraint scaling `dc` fires on the pin itself. Before
+//! pounce#128 the returned reduced Hessian was off by exactly
+//! `df / dc²`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use pounce_sensitivity::SensSolve;
+
+const C0: Number = 4.0e4;
+const C1: Number = 6.0e4;
+const SCALE: Number = 1.0e4;
+const P_HAT: Number = 0.7;
+
+/// `min c0(x−p)² + c1(x−1)²  s.t.  SCALE·p = SCALE·p̂`. Variables
+/// `(x, p)`; one equality (the pin). Optionally prepends an inactive
+/// inequality `x + p ≤ 10` as g[0] so the pin sits *after* an
+/// inequality in the user's g ordering (exercises the full-g → c-block
+/// row mapping).
+struct ScaledPinTnlp {
+    with_leading_inequality: bool,
+}
+
+impl ScaledPinTnlp {
+    fn m(&self) -> Index {
+        if self.with_leading_inequality {
+            2
+        } else {
+            1
+        }
+    }
+    /// Row index of the pin constraint in the user's g ordering.
+    fn pin_row(&self) -> Index {
+        if self.with_leading_inequality {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+impl TNLP for ScaledPinTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: self.m(),
+            nnz_jac_g: if self.with_leading_inequality { 3 } else { 1 },
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -1.0e19;
+        b.x_u[0] = 1.0e19;
+        b.x_l[1] = -1.0e19;
+        b.x_u[1] = 1.0e19;
+        let pin = self.pin_row() as usize;
+        if self.with_leading_inequality {
+            b.g_l[0] = -1.0e19;
+            b.g_u[0] = 10.0;
+        }
+        b.g_l[pin] = SCALE * P_HAT;
+        b.g_u[pin] = SCALE * P_HAT;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.0;
+        sp.x[1] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let (xx, p) = (x[0], x[1]);
+        Some(C0 * (xx - p) * (xx - p) + C1 * (xx - 1.0) * (xx - 1.0))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (xx, p) = (x[0], x[1]);
+        g[0] = 2.0 * C0 * (xx - p) + 2.0 * C1 * (xx - 1.0);
+        g[1] = -2.0 * C0 * (xx - p);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let pin = self.pin_row() as usize;
+        if self.with_leading_inequality {
+            g[0] = x[0] + x[1];
+        }
+        g[pin] = SCALE * x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        let pin = self.pin_row();
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                if self.with_leading_inequality {
+                    irow.copy_from_slice(&[0, 0, pin]);
+                    jcol.copy_from_slice(&[0, 1, 1]);
+                } else {
+                    irow.copy_from_slice(&[pin]);
+                    jcol.copy_from_slice(&[1]);
+                }
+            }
+            SparsityRequest::Values { values } => {
+                if self.with_leading_inequality {
+                    values[0] = 1.0;
+                    values[1] = 1.0;
+                    values[2] = SCALE;
+                } else {
+                    values[0] = SCALE;
+                }
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Lower triangle of ∇²f: (0,0)=2c0+2c1, (1,0)=−2c0, (1,1)=2c0.
+        // Constraints are linear — no Lagrangian contribution.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1]);
+                jcol.copy_from_slice(&[0, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor * 2.0 * (C0 + C1);
+                values[1] = obj_factor * (-2.0) * C0;
+                values[2] = obj_factor * 2.0 * C0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn make_app(scaling_method: &str) -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", scaling_method, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    app
+}
+
+/// Analytic reduced Hessian w.r.t. the pin's right-hand side, in
+/// pounce's pin-row sign convention (`= −∂²f*/∂r²`, see module doc).
+const H_ANALYTIC: Number = -2.0 * C0 * C1 / ((C0 + C1) * SCALE * SCALE);
+
+fn run_reduced_hessian(scaling_method: &str, with_leading_inequality: bool) -> (Number, Number) {
+    let mut app = make_app(scaling_method);
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ScaledPinTnlp {
+        with_leading_inequality,
+    }));
+    let pin_row = if with_leading_inequality { 1 } else { 0 };
+    let result = SensSolve::new(vec![pin_row])
+        .with_reduced_hessian()
+        .run(&mut app, tnlp);
+    assert!(
+        matches!(
+            result.status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve failed under nlp_scaling_method={scaling_method}: {:?}",
+        result.status,
+    );
+    let hr = result.reduced_hessian.expect("reduced Hessian populated");
+    let hr_scaled = result
+        .reduced_hessian_scaled
+        .expect("scaled reduced Hessian populated");
+    assert_eq!(hr.len(), 1);
+
+    // Cross-check the reported scaling factors reconstruct the scaled
+    // value exactly: H̃ = (df / dc²) · H.
+    let df = result.obj_scaling_factor.expect("df reported");
+    let dc = result.pin_g_scaling.expect("pin scaling reported");
+    assert_eq!(dc.len(), 1);
+    let reconstructed = hr[0] * df / (dc[0] * dc[0]);
+    assert!(
+        (reconstructed - hr_scaled[0]).abs() <= 1e-10 * hr_scaled[0].abs().max(1.0),
+        "scaled reconstruction mismatch: {} vs {}",
+        reconstructed,
+        hr_scaled[0],
+    );
+    (hr[0], hr_scaled[0])
+}
+
+#[test]
+fn reduced_hessian_is_invariant_to_nlp_scaling() {
+    let (h_none, h_none_scaled) = run_reduced_hessian("none", false);
+    let (h_grad, h_grad_scaled) = run_reduced_hessian("gradient-based", false);
+
+    let rel = |a: Number, b: Number| (a - b).abs() / b.abs();
+    assert!(
+        rel(h_none, H_ANALYTIC) < 1e-6,
+        "unscaled solve: H = {h_none}, analytic = {H_ANALYTIC}",
+    );
+    assert!(
+        rel(h_grad, H_ANALYTIC) < 1e-6,
+        "gradient-based solve: H = {h_grad}, analytic = {H_ANALYTIC} \
+         (ratio {} — a ratio ≫ 1 means the pre-#128 scaled value leaked out)",
+        H_ANALYTIC / h_grad,
+    );
+
+    // With scaling off, the scaled accessor must equal the natural one.
+    assert!(rel(h_none_scaled, h_none) < 1e-12);
+    // With gradient-based scaling active on this fixture, the two must
+    // differ wildly (df ≈ 8.3e-4 fires AND dc ≈ 1e-2 fires on the pin):
+    // that's the pre-#128 value preserved for calibrated callers.
+    assert!(
+        rel(h_grad_scaled, h_grad) > 1.0,
+        "expected the scaled accessor to differ when scaling is active: \
+         natural {h_grad}, scaled {h_grad_scaled}",
+    );
+}
+
+#[test]
+fn pin_rows_map_through_the_c_d_split() {
+    // The pin is g[1], *after* an inactive inequality g[0] — the y_c
+    // block holds only the pin (c-block row 0). Before pounce#128 the
+    // pin row was mapped as `n_x + n_s + 1`, silently selecting a
+    // wrong KKT row; with the `full_g_to_c_block` mapping the reduced
+    // Hessian matches the same analytic value as the
+    // no-inequality fixture.
+    let (h, _) = run_reduced_hessian("none", true);
+    let rel = (h - H_ANALYTIC).abs() / H_ANALYTIC;
+    assert!(
+        rel < 1e-6,
+        "with a leading inequality: H = {h}, analytic = {H_ANALYTIC}",
+    );
+    // And stays right when scaling fires too.
+    let (h2, _) = run_reduced_hessian("gradient-based", true);
+    let rel2 = (h2 - H_ANALYTIC).abs() / H_ANALYTIC;
+    assert!(
+        rel2 < 1e-6,
+        "leading inequality + gradient-based scaling: H = {h2}, analytic = {H_ANALYTIC}",
+    );
+}
+
+#[test]
+fn parametric_step_is_invariant_to_nlp_scaling() {
+    // dx*/dr for the pin RHS r: x*(p) = (c0·p + c1)/(c0+c1) and
+    // p = r/SCALE, so dx/dr = c0/((c0+c1)·SCALE), dp/dr = 1/SCALE.
+    let delta = 0.5 * SCALE; // Δr (RHS units) ⇒ Δp = 0.5
+    let dx_expected = [delta * C0 / ((C0 + C1) * SCALE), delta / SCALE];
+
+    for method in ["none", "gradient-based"] {
+        let mut app = make_app(method);
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ScaledPinTnlp {
+            with_leading_inequality: false,
+        }));
+        let result = SensSolve::new(vec![0])
+            .with_deltas(vec![delta])
+            .run(&mut app, tnlp);
+        assert!(matches!(
+            result.status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ));
+        let dx = result.dx.expect("dx populated");
+        for k in 0..2 {
+            let err = (dx[k] - dx_expected[k]).abs() / dx_expected[k].abs();
+            assert!(
+                err < 1e-6,
+                "nlp_scaling_method={method}: dx[{k}] = {}, expected {} (rel err {err})",
+                dx[k],
+                dx_expected[k],
+            );
+        }
+    }
+}

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -106,12 +106,16 @@ The relation is `H_scaled[i,j] = df / (dc_i·dc_j) · H[i,j]`, where
 `df` is the objective scaling factor and `dc_i` the pin rows'
 constraint scaling factors.
 
-One caveat: the IPM's inertia-correction perturbations (`delta_w`,
-`delta_c`) are added to the factor in *scaled* space, so on a problem
-whose final factorization needed regularization (e.g. linearly
-dependent pin rows) the unscaling maps a slightly different perturbed
-system per scaling method. On well-posed estimation problems the
-final factor is unregularized and the invariance is exact.
+One caveat: the IPM's inertia-correction perturbations (`δ_x`, `δ_s`,
+`δ_c`, `δ_d`) are added to the factor in *scaled* space, so on a
+problem whose final factorization needed regularization (e.g.
+linearly dependent pin rows) the unscaling maps a slightly different
+perturbed system per scaling method. The perturbations are reported —
+`info["kkt_perturbations"]` / `Solver.kkt_perturbations` (Python),
+`SensResult::kkt_perturbations` / `Solver::kkt_perturbations` (Rust)
+— so a covariance workflow can assert they are all zero before
+trusting `-inv(reduced_hessian)`; on well-posed estimation problems
+the final factor is unregularized and the invariance is exact.
 
 ## Verification
 

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -70,6 +70,42 @@ eigendecomposition; `sens_bound_eps=…` tunes the bound projection. See
 [`python/notebooks/04_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/04_sensitivity.ipynb)
 for a walkthrough.
 
+## Units and NLP scaling
+
+All sensitivity outputs are in **natural (unscaled) units**. The IPM
+holds its converged KKT factor in an internally scaled space whenever
+NLP scaling is active (the default `nlp_scaling_method =
+"gradient-based"` fires when an objective gradient or constraint row
+exceeds `nlp_scaling_max_gradient = 100` at the starting point);
+pounce undoes that scaling in every held-factor back-solve, so `dx`,
+`kkt_solve`, and the reduced Hessian are independent of how the
+problem was scaled internally
+([#128](https://github.com/jkitchin/pounce/issues/128)).
+
+In particular, for a parameter-estimation NLP with the parameters
+pinned by equality constraints, `-inv(info["reduced_hessian"])` is
+directly the parameter covariance — no per-problem scale factor, no
+need to set `nlp_scaling_method = "none"`. (Sign convention: over pin
+*constraint* rows, `B K⁻¹ Bᵀ` equals the multiplier sensitivity
+`∂λ/∂p = −∂²f*/∂p²`, hence the minus in the covariance recipe.)
+
+For callers that calibrated against the pre-#128 behavior, the
+solver-space value and the factors that relate the two are exposed:
+
+- Python: `info["reduced_hessian_scaled"]`,
+  `info["obj_scaling_factor"]`, `info["pin_g_scaling"]`;
+  `Solver.reduced_hessian(pins, scaled=True)`,
+  `Solver.kkt_solve(rhs, scaled=True)`, and the `Solver.nlp_scaling`
+  dict (`{"obj": df, "c_scale": …, "d_scale": …}`).
+- Rust: `SensResult::{reduced_hessian_scaled, obj_scaling_factor,
+  pin_g_scaling}`, `Solver::{compute_reduced_hessian_scaled,
+  kkt_solve_scaled, nlp_scaling, pin_g_scaling}`, and
+  `PdSensBacksolver::solve_scaled_space`.
+
+The relation is `H_scaled[i,j] = df / (dc_i·dc_j) · H[i,j]`, where
+`df` is the objective scaling factor and `dc_i` the pin rows'
+constraint scaling factors.
+
 ## Verification
 
 All three entry points are verified against upstream sIPOPT 3.14.19's

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -106,6 +106,13 @@ The relation is `H_scaled[i,j] = df / (dc_i·dc_j) · H[i,j]`, where
 `df` is the objective scaling factor and `dc_i` the pin rows'
 constraint scaling factors.
 
+One caveat: the IPM's inertia-correction perturbations (`delta_w`,
+`delta_c`) are added to the factor in *scaled* space, so on a problem
+whose final factorization needed regularization (e.g. linearly
+dependent pin rows) the unscaling maps a slightly different perturbed
+system per scaling method. On well-posed estimation problems the
+final factor is unregularized and the invariance is exact.
+
 ## Verification
 
 All three entry points are verified against upstream sIPOPT 3.14.19's

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -57,7 +57,17 @@ lhs = solver.kkt_solve(rhs)
 The KKT compound vector is laid out as
 `x || s || y_c || y_d || z_l || z_u || v_l || v_u`. `pin` indices in
 `parametric_step` / `reduced_hessian` are 0-based row indices into
-`g(x)`; they are shifted internally to the y_c block.
+`g(x)`; they are mapped internally to the matching y_c rows (through
+the equality/inequality split, so inequalities may precede the pins).
+
+All back-solves are in **natural (unscaled) units** — any NLP scaling
+the IPM applied internally is undone, so results are independent of
+`nlp_scaling_method`
+([#128](https://github.com/jkitchin/pounce/issues/128)). The
+solver-space values remain available via
+`reduced_hessian(pins, scaled=True)` / `kkt_solve(rhs, scaled=True)`,
+and the factors via the `Solver.nlp_scaling` dict — see
+[Sensitivity Analysis](sensitivity.md#units-and-nlp-scaling).
 
 `pounce.Problem.solve()` and `Problem.solve_with_sens()` still work
 unchanged — each internally builds a fresh session — but new code that

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -695,24 +695,25 @@ def _solve_fit(
     problem.add_option("print_level", 0)
     problem.add_option("sb", "yes")
     # With exact derivatives (analytic/JAX) the IPM converges cleanly with no
-    # NLP scaling, which keeps the converged factor's Hessian *unscaled* so the
-    # pounce-native covariance/sensitivity back-solves are exact. With a
-    # finite-difference fallback we leave scaling on for convergence robustness
-    # (and read covariance from the scaling-independent Jacobian instead).
+    # NLP scaling; keep it off so the converged factor matches the natural
+    # problem exactly. Since pounce#128 this is a preference, not a
+    # correctness requirement: held-factor back-solves (``Solver.kkt_solve``)
+    # undo any active NLP scaling, so a user who explicitly turns scaling on
+    # still gets natural-units covariance from the factor path.
     user_opts = dict(options or {})
     if pr.jac_exact and "nlp_scaling_method" not in user_opts:
         problem.add_option("nlp_scaling_method", "none")
     for k, v in user_opts.items():
         problem.add_option(k, v)
-    scaling_off = pr.jac_exact and user_opts.get("nlp_scaling_method", "none") == "none"
 
     solver = Solver(problem)
     popt, info = solver.solve(x0=np.asarray(p0, dtype=float))
     popt = np.asarray(popt)
     success = int(info["status"]) == 0
-    # The converged factor is only trustworthy as an *unscaled* Hessian when
-    # scaling was off and the solve actually held a factor.
-    factor_ok = bool(scaling_off and solver.converged)
+    # The converged factor is trustworthy when the derivatives that built it
+    # were exact and the solve actually held a factor. (Scaling state no
+    # longer enters: factor back-solves are scaling-corrected, pounce#128.)
+    factor_ok = bool(pr.jac_exact and solver.converged)
 
     # --- residual diagnostics (unweighted, for reporting) --------------
     # Both paths produce the same scalar sums; streaming accumulates them over a
@@ -1500,10 +1501,11 @@ def _covariance(
 
     For least squares ``pcov = s^2 (J_w^T J_w)^-1`` (the inverse reduced
     Hessian of the sum-of-squares objective). When the converged factor is
-    trustworthy (exact derivatives, scaling off) this is read pounce-natively
-    from the inverse-Hessian block of ``K`` (``pcov = 2 s^2 inv(H_S)``, no
-    explicit matrix inverse); otherwise it is formed from the model Jacobian,
-    which is scaling-independent and gives the identical value. Robust losses
+    trustworthy (exact derivatives) this is read pounce-natively from the
+    inverse-Hessian block of ``K`` (``pcov = 2 s^2 inv(H_S)``, no explicit
+    matrix inverse; the back-solve is scaling-corrected, pounce#128);
+    otherwise it is formed from the model Jacobian, which is
+    scaling-independent and gives the identical value. Robust losses
     use the sandwich estimator; active bounds/constraints project onto the
     free parameter set.
     """

--- a/python/pounce/jax/_problem.py
+++ b/python/pounce/jax/_problem.py
@@ -368,6 +368,15 @@ def _bwd_single_factor_reuse(
     Lagrangian needs the multipliers as a constant inside the trace,
     so we close ``lam`` (already returned from the fwd in user g-order)
     into ``lagrangian(x, p_)``.
+
+    Units. ``dgradL_dp`` / ``dg_dp`` are autodiffed from the user's own
+    ``f`` / ``g`` — natural units — so the back-solve must be against
+    the *natural-units* KKT matrix. ``Solver.kkt_solve`` guarantees
+    exactly that since pounce#128: when the IPM solved with active NLP
+    scaling (``nlp_scaling_method``, default ``gradient-based``), the
+    Rust side conjugates the RHS/solution by the scaling factors, so
+    this VJP is correct whether or not scaling fired on the forward
+    solve.
     """
     def lagrangian(x, p_):
         base = f(x, p_)

--- a/python/tests/test_jax.py
+++ b/python/tests/test_jax.py
@@ -792,6 +792,62 @@ def test_factor_reuse_matches_dense_pounce_76():
     np.testing.assert_allclose(np.asarray(g_new), np.asarray(g_old), atol=1e-7)
 
 
+def test_factor_reuse_correct_under_nlp_scaling_pounce_128():
+    """pounce#128: the factor-reuse VJP back-solves against the IPM's
+    converged compound KKT factor. That factor is held in the NLP's
+    internally *scaled* space whenever the default gradient-based
+    scaling fires (objective gradient or a constraint row exceeding
+    ``nlp_scaling_max_gradient = 100`` at the start). The cotangents
+    contracted with the back-solve (``dgradL_dp`` / ``dg_dp``) are
+    autodiffed from the user's natural-units ``f`` / ``g``, so the
+    back-solve must be in natural units too — ``Solver.kkt_solve``
+    now conjugates by the scaling factors.
+
+    This fixture makes both factors fire (objective and constraint
+    coefficients of 1e4) and checks the factor-reuse gradient against
+    the dense path (which assembles its own natural-units KKT block in
+    JAX, so it was never affected) and the analytic gradient.
+    """
+    from pounce.jax import JaxProblem
+
+    BIG = 1.0e4
+
+    def f(x, p):
+        return BIG * jnp.sum((x - p) ** 2)
+
+    def g(x, p):  # noqa: ARG001
+        return jnp.stack([BIG * (x[0] + x[1] - 1.0)])
+
+    kwargs = dict(
+        f=f, g=g, n=2, m=1, p_example=jnp.zeros(2),
+        lb=jnp.full(2, -10.0), ub=jnp.full(2, 10.0),
+        cl=jnp.zeros(1), cu=jnp.zeros(1),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    jp_reuse = JaxProblem(**kwargs, factor_reuse=True)
+    jp_dense = JaxProblem(**kwargs, factor_reuse=False)
+
+    p = jnp.array([0.3, -0.1])
+
+    def loss(jp, p):
+        return jnp.sum(jp.solve(p, jnp.zeros(2)) ** 2)
+
+    g_reuse = jax.grad(lambda p: loss(jp_reuse, p))(p)
+    g_dense = jax.grad(lambda p: loss(jp_dense, p))(p)
+
+    # Analytic: x*(p) projects p onto {x0 + x1 = 1} (the 1e4 on the
+    # constraint doesn't move the feasible set):
+    # x* = p + (1 - p0 - p1)/2 * [1, 1], so with loss = |x*|^2,
+    # dloss/dp = 2 x*^T (I - 0.5 * ones(2,2)).
+    p_np = np.asarray(p)
+    x_star = p_np + 0.5 * (1.0 - p_np.sum()) * np.ones(2)
+    g_analytic = 2.0 * x_star @ (np.eye(2) - 0.5 * np.ones((2, 2)))
+
+    np.testing.assert_allclose(np.asarray(g_dense), g_analytic, atol=1e-6)
+    # Pre-#128 this was off by ~the objective scaling factor (~100x here).
+    np.testing.assert_allclose(np.asarray(g_reuse), g_analytic, atol=1e-6)
+
+
 def test_factor_reuse_jacobian_pounce_76():
     """The bwd is called once per output direction under
     ``jax.jacobian``; verify the LRU lookup holds the factor across

--- a/python/tests/test_problem.py
+++ b/python/tests/test_problem.py
@@ -119,3 +119,31 @@ def test_unconstrained_quadratic():
     x, info = prob.solve(x0=np.zeros(4))
     assert info["status_msg"] == "Solve_Succeeded"
     np.testing.assert_allclose(x, target, atol=1e-6)
+
+
+def test_negative_obj_scaling_factor_maximizes():
+    """obj_scaling_factor < 0 means maximize (upstream Ipopt semantics).
+
+    Regression for the pounce#128 follow-up: the option was registered
+    but never read, so the IPM minimized the unscaled objective and a
+    concave maximization diverged (Diverging_Iterates) instead of
+    converging to the maximizer.
+    """
+
+    class ConcaveBump:
+        def objective(self, x):
+            return -((x[0] - 1.0) ** 2)
+
+        def gradient(self, x):
+            return np.array([-2.0 * (x[0] - 1.0)])
+
+    prob = pounce.Problem(n=1, m=0, problem_obj=ConcaveBump(),
+                          lb=[-1e19], ub=[1e19])
+    prob.add_option("print_level", 0)
+    prob.add_option("sb", "yes")
+    prob.add_option("obj_scaling_factor", -1.0)
+    x, info = prob.solve(x0=np.array([0.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, [1.0], atol=1e-6)
+    # The reported objective is the user's (unscaled) value at the max.
+    np.testing.assert_allclose(info["obj_val"], 0.0, atol=1e-8)

--- a/python/tests/test_sensitivity.py
+++ b/python/tests/test_sensitivity.py
@@ -328,6 +328,11 @@ def test_reduced_hessian_is_unscaled_regardless_of_nlp_scaling_pounce_128():
         info_off["reduced_hessian_scaled"], info_off["reduced_hessian"]
     )
 
+    # The clean quadratic fixture needs no inertia correction: the
+    # all-zero perturbations certify the covariance reading is exact.
+    for info in results.values():
+        np.testing.assert_allclose(info["kkt_perturbations"], np.zeros(4))
+
     # ...and with gradient-based scaling both df and the pin dc fire,
     # and the scaled accessor reconstructs from the reported factors.
     info_on = results[None]
@@ -366,6 +371,9 @@ def test_solver_session_reduced_hessian_scaled_accessor_and_nlp_scaling():
     h_scaled = solver.reduced_hessian([0], scaled=True)
     dc = scaling["c_scale"][0]
     np.testing.assert_allclose(h_scaled[0], h[0] * df / dc ** 2, rtol=1e-12)
+
+    # Factor-regularization diagnostic mirrors the info-dict key.
+    np.testing.assert_allclose(solver.kkt_perturbations, np.zeros(4))
 
 
 def test_solve_with_sens_finite_difference_cross_check():

--- a/python/tests/test_sensitivity.py
+++ b/python/tests/test_sensitivity.py
@@ -218,6 +218,156 @@ def test_solve_with_sens_boundcheck_clamps_violating_step():
     np.testing.assert_allclose(dx[4], UPSTREAM_DX[4], atol=5e-8)
 
 
+class ScaledPinNLP:
+    """pounce#128 regression fixture: a badly-scaled 2-variable
+    least-squares NLP with a badly-scaled parameter pin.
+
+        min  c0*(x - p)**2 + c1*(x - 1)**2
+        s.t. SCALE*p = SCALE*p_hat
+
+    The objective gradient at the start (~2*c1 = 1.2e5) and the pin
+    row's Jacobian entry (SCALE = 1e4) both exceed
+    nlp_scaling_max_gradient (100), so the default gradient-based NLP
+    scaling fires on both the objective and the pin row. Analytically,
+    f*(p) = c0*c1*(p-1)**2/(c0+c1), and w.r.t. the pin RHS r = SCALE*p,
+    the reduced Hessian in pounce's pin-row sign convention is
+
+        H = -d2f*/dr2 = -2*c0*c1 / ((c0+c1)*SCALE**2)
+
+    Before #128 the returned value was off by exactly df/dc**2 (the
+    objective / pin-row scaling factors).
+    """
+
+    C0 = 4.0e4
+    C1 = 6.0e4
+    SCALE = 1.0e4
+    P_HAT = 0.7
+
+    def objective(self, x):
+        xx, p = x
+        return self.C0 * (xx - p) ** 2 + self.C1 * (xx - 1.0) ** 2
+
+    def gradient(self, x):
+        xx, p = x
+        return np.array([
+            2 * self.C0 * (xx - p) + 2 * self.C1 * (xx - 1.0),
+            -2 * self.C0 * (xx - p),
+        ])
+
+    def constraints(self, x):
+        return np.array([self.SCALE * x[1]])
+
+    def jacobianstructure(self):
+        return np.array([0], dtype=np.int64), np.array([1], dtype=np.int64)
+
+    def jacobian(self, x):
+        return np.array([self.SCALE])
+
+    def hessianstructure(self):
+        rows = np.array([0, 1, 1], dtype=np.int64)
+        cols = np.array([0, 0, 1], dtype=np.int64)
+        return rows, cols
+
+    def hessian(self, x, lagrange, obj_factor):
+        return obj_factor * np.array([
+            2 * (self.C0 + self.C1),
+            -2 * self.C0,
+            2 * self.C0,
+        ])
+
+
+H_ANALYTIC_128 = (
+    -2.0 * ScaledPinNLP.C0 * ScaledPinNLP.C1
+    / ((ScaledPinNLP.C0 + ScaledPinNLP.C1) * ScaledPinNLP.SCALE ** 2)
+)
+
+
+def _make_scaled_pin(nlp_scaling_method=None):
+    nlp = ScaledPinNLP()
+    rhs = nlp.SCALE * nlp.P_HAT
+    p = pounce.Problem(
+        n=2, m=1, problem_obj=nlp,
+        lb=[-1e19, -1e19], ub=[1e19, 1e19],
+        cl=[rhs], cu=[rhs],
+    )
+    p.add_option("tol", 1e-9)
+    p.add_option("print_level", 0)
+    p.add_option("sb", "yes")
+    if nlp_scaling_method is not None:
+        p.add_option("nlp_scaling_method", nlp_scaling_method)
+    return p
+
+
+def test_reduced_hessian_is_unscaled_regardless_of_nlp_scaling_pounce_128():
+    """The headline #128 fix: -inv(reduced_hessian) (the covariance
+    recipe) must be the same with scaling off and with the default
+    gradient-based scaling actively firing."""
+    x0 = np.array([0.0, 0.0])
+    results = {}
+    for method in ("none", None):  # None = pounce default (gradient-based)
+        _, info = _make_scaled_pin(method).solve_with_sens(
+            x0=x0,
+            pin_constraint_indices=[0],
+            compute_reduced_hessian=True,
+        )
+        assert info["status_msg"] == "Solve_Succeeded"
+        results[method] = info
+
+    for method, info in results.items():
+        h = info["reduced_hessian"][0]
+        np.testing.assert_allclose(
+            h, H_ANALYTIC_128, rtol=1e-6,
+            err_msg=f"nlp_scaling_method={method}: natural-units H wrong",
+        )
+
+    # Scaling factors are reported. With scaling off they are trivial...
+    info_off = results["none"]
+    assert info_off["obj_scaling_factor"] == pytest.approx(1.0)
+    np.testing.assert_allclose(info_off["pin_g_scaling"], [1.0])
+    np.testing.assert_allclose(
+        info_off["reduced_hessian_scaled"], info_off["reduced_hessian"]
+    )
+
+    # ...and with gradient-based scaling both df and the pin dc fire,
+    # and the scaled accessor reconstructs from the reported factors.
+    info_on = results[None]
+    df = info_on["obj_scaling_factor"]
+    dc = info_on["pin_g_scaling"][0]
+    assert df < 1.0  # max grad ~1.2e5 >> 100
+    assert dc < 1.0  # pin row max = SCALE = 1e4 >> 100
+    np.testing.assert_allclose(
+        info_on["reduced_hessian_scaled"],
+        info_on["reduced_hessian"] * df / dc ** 2,
+        rtol=1e-12,
+    )
+    # The pre-#128 value really was wildly off for this fixture.
+    ratio = info_on["reduced_hessian_scaled"][0] / info_on["reduced_hessian"][0]
+    assert not ratio == pytest.approx(1.0, rel=0.5)
+
+
+def test_solver_session_reduced_hessian_scaled_accessor_and_nlp_scaling():
+    """Session API mirror: Solver.reduced_hessian is natural-units by
+    default, scaled=True returns the solver-space value, and
+    Solver.nlp_scaling exposes the factors."""
+    problem = _make_scaled_pin()  # default gradient-based scaling
+    solver = pounce.Solver(problem)
+    _, info = solver.solve(x0=np.array([0.0, 0.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+
+    h = solver.reduced_hessian([0])
+    np.testing.assert_allclose(h[0], H_ANALYTIC_128, rtol=1e-6)
+
+    scaling = solver.nlp_scaling
+    df = scaling["obj"]
+    assert df < 1.0
+    assert scaling["c_scale"] is not None and scaling["c_scale"][0] < 1.0
+    assert scaling["d_scale"] is None  # no inequalities in this fixture
+
+    h_scaled = solver.reduced_hessian([0], scaled=True)
+    dc = scaling["c_scale"][0]
+    np.testing.assert_allclose(h_scaled[0], h[0] * df / dc ** 2, rtol=1e-12)
+
+
 def test_solve_with_sens_finite_difference_cross_check():
     """First-order sensitivity Δx_sens vs Δx from a fresh resolve."""
     x0 = np.array([0.15, 0.15, 0.0, 0.0, 0.0])

--- a/python/tests/test_torch.py
+++ b/python/tests/test_torch.py
@@ -358,6 +358,42 @@ def test_torch_problem_grad_pounce_75():
     np.testing.assert_allclose(J.numpy(), np.eye(n), atol=5e-6)
 
 
+def test_torch_problem_grad_correct_under_nlp_scaling_pounce_128():
+    """pounce#128 (torch mirror of the test_jax.py regression): the
+    TorchProblem factor-reuse backward back-solves against the IPM's
+    converged KKT factor, which lives in the NLP's internally *scaled*
+    space whenever the default gradient-based scaling fires. The
+    cotangents are autodiffed from the user's natural-units f/g, so
+    the back-solve must be in natural units too (``Solver.kkt_solve``
+    now applies the scaling correction). The 1e4 coefficients make
+    both the objective factor df and the constraint row factor dc
+    fire; the analytic Jacobian of the projection onto x0+x1=1 is
+    I - 0.5*ones (the constraint's 1e4 doesn't move the feasible set).
+    """
+    from pounce.torch import TorchProblem
+
+    n, m = 2, 1
+    BIG = 1.0e4
+
+    def f(x, p):
+        d = x - p
+        return BIG * torch.dot(d, d)
+
+    def g(x, p):  # noqa: ARG001
+        return torch.stack([BIG * (x[0] + x[1] - 1.0)])
+
+    tp = TorchProblem(
+        f=f, g=g, n=n, m=m, p_example=torch.zeros(n),
+        lb=torch.full((n,), -10.0), ub=torch.full((n,), 10.0),
+        cl=torch.tensor([0.0]), cu=torch.tensor([0.0]),
+        options={"tol": 1e-10, "print_level": 0, "sb": "yes"},
+    )
+    p0 = torch.tensor([0.3, -0.1])
+    J = torch.autograd.functional.jacobian(lambda p: tp.solve(p, torch.zeros(n)), p0)
+    # Pre-#128 this came back off by ~the objective scaling factor.
+    np.testing.assert_allclose(J.numpy(), np.eye(n) - 0.5 * np.ones((n, n)), atol=1e-6)
+
+
 def _warm_problem():
     """min ½‖x−p‖² s.t. Σx = 1, −10 ≤ x ≤ 10 — x*(p) projects p onto the
     simplex hyperplane, so ∂x*/∂p = I − 11ᵀ/n and the equality multiplier


### PR DESCRIPTION
## Summary

This PR fixes a critical bug where sensitivity analysis outputs (reduced Hessian, parametric step, KKT back-solves) were returned in the IPM's internally scaled space rather than the user's natural units. When NLP scaling was active (the default `nlp_scaling_method = "gradient-based"`), the returned values were silently corrupted by the scaling factors. The fix applies a two-sided diagonal conjugation to every back-solve, undoing the NLP scaling so all outputs are scaling-invariant.

Additionally, this PR fixes `obj_scaling_factor` being silently ignored (the option was registered but never read), which caused maximization problems to diverge.

## Key Changes

- **Natural-units KKT back-solve** (`PdSensBacksolver`): Added `ConjPair` struct holding the left/right diagonal scaling pair `(E, F)` computed from the NLP's effective scaling (`df`, `dc`, `dd`). Every back-solve now applies `K⁻¹ = F K̃⁻¹ E` where `K̃` is the scaled-space factor the IPM holds. The two-sided scaling requires no square root, so it correctly handles negative `obj_scaling_factor` (maximization) and the z/v bound-multiplier rows.

- **Scaling factor reporting**: `SensResult` now includes `obj_scaling_factor`, `pin_g_scaling`, `reduced_hessian_scaled`, and `kkt_perturbations` so callers can verify the natural-units conversion and check whether the final KKT factor was regularized (all-zero perturbations = exact).

- **Dual API for scaled-space access**: Added `kkt_solve_scaled` / `kkt_solve_many_scaled` (Rust) and `kkt_solve(..., scaled=True)` (Python) for callers that need the raw solver-space back-solve (pre-#128 behavior).

- **`obj_scaling_factor` option now functional**: The option value is carried into `OrigIpoptNlp` via the new `ConstObjScaling` wrapper on both IPM and SQP paths, combining with gradient-based/user scaling as documented. Negative values correctly maximize.

- **Full-g to c-block row mapping**: Fixed pin-row indexing when the c/d split reorders constraints; the reduced Hessian now correctly maps through the `full_g_to_c_block` transformation.

## Implementation Details

- The `(E, F)` pair is built in `PdSensBacksolver::natural_units_conj` by reading the NLP's scaling vectors (`c_scale_vec`, `d_scale_vec`, `obj_scaling_factor`) and validating consistency with the converged iterate's block dimensions.

- Per-entry d-row scaling for the compressed v_l/v_u blocks is extracted via `ExpansionMatrix::expanded_pos_indices()` to map each bound-multiplier row to its corresponding d-row scaling factor.

- The `Solver` API now routes through `kkt_solve_impl` / `kkt_solve_many_impl` with a `scaled` flag to select between natural-units (default) and raw scaled-space back-solves.

- Comprehensive regression tests in `crates/pounce-sensitivity/tests/scaling_invariance.rs` verify the reduced Hessian matches the analytic value under both no scaling and gradient-based scaling, with and without a leading inactive inequality (exercises the full-g mapping).

- Python tests confirm the factor-reuse VJP and TorchProblem backward paths produce correct gradients under NLP scaling.

## Fixes

- Reduced Hessian is now independent of `nlp_scaling_method` and problem discretization (pounce#128).
- `-inv(reduced_hessian)` is directly the parameter covariance for estimation problems.
- Maximization problems (`obj_scaling_factor < 0`) now converge correctly.
- KKT regularization status is visible so workflows can check for the exact (all-zero perturbations) case.

https://claude.ai/code/session_01P78voQHEUnUHKWMudcTFtB