### PR TITLE
fix(algorithm): honor limited_memory_update_type/max_history on IPM path (#131)

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -199,6 +199,9 @@ pub struct AlgorithmBuilder {
     pub mu_oracle: MuOracleKind,
     pub hessian_approximation: HessianApproxChoice,
     pub limited_memory_update_type: UpdateType,
+    /// History length for the limited-memory quasi-Newton approximation
+    /// (`limited_memory_max_history`). Defaults to upstream's 6.
+    pub limited_memory_max_history: i32,
     pub line_search_method: LineSearchChoice,
     pub warm_start_init_point: bool,
     /// `mehrotra_algorithm` — when true, [`PdSearchDirCalc`] folds
@@ -499,6 +502,7 @@ impl Default for AlgorithmBuilder {
             mu_oracle: MuOracleKind::QualityFunction,
             hessian_approximation: HessianApproxChoice::Exact,
             limited_memory_update_type: UpdateType::Bfgs,
+            limited_memory_max_history: 6,
             line_search_method: LineSearchChoice::Filter,
             warm_start_init_point: false,
             mehrotra_algorithm: false,
@@ -705,6 +709,7 @@ impl AlgorithmBuilder {
             HessianApproxChoice::Exact => Box::new(ExactHessianUpdater::new()),
             HessianApproxChoice::LimitedMemory => Box::new(LimMemQuasiNewtonUpdater {
                 update_type: self.limited_memory_update_type,
+                max_history: self.limited_memory_max_history,
                 ..LimMemQuasiNewtonUpdater::default()
             }),
         };
@@ -801,6 +806,7 @@ mod tests {
                             mu_oracle: MuOracleKind::QualityFunction,
                             hessian_approximation,
                             limited_memory_update_type: UpdateType::Bfgs,
+                            limited_memory_max_history: 6,
                             line_search_method,
                             warm_start_init_point: false,
                             mehrotra_algorithm: false,

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -21,6 +21,7 @@ use crate::alg_builder::{
     AlgorithmBuilder, HessianApproxChoice, LineSearchChoice, LinearBackendFactory,
     LinearSolverChoice, MuStrategyChoice,
 };
+use crate::hess::lim_mem_quasi_newton::UpdateType;
 use crate::ipopt_alg::IpoptAlgorithm;
 use crate::ipopt_cq::IpoptCalculatedQuantities;
 use crate::ipopt_data::IpoptData as AlgIpoptData;
@@ -1561,6 +1562,31 @@ impl IpoptApplication {
                 };
             }
         }
+        // Limited-memory quasi-Newton update formula. Registered upstream
+        // (`limited_memory_update_type`, IpLimMemQuasiNewtonUpdater.cpp) but
+        // until now read nowhere on the IPM path — the updater was hard-wired
+        // to Powell-damped BFGS. SR1 is honored too (the updater and the
+        // low-rank/inertia path already handle its indefinite models).
+        if let Ok((v, found)) = self
+            .options
+            .get_string_value("limited_memory_update_type", "")
+        {
+            if found {
+                builder.limited_memory_update_type = match v.as_str() {
+                    "sr1" => UpdateType::Sr1,
+                    _ => UpdateType::Bfgs,
+                };
+            }
+        }
+        // Limited-memory history length (`limited_memory_max_history`).
+        if let Ok((v, found)) = self
+            .options
+            .get_integer_value("limited_memory_max_history", "")
+        {
+            if found && v >= 0 {
+                builder.limited_memory_max_history = v as Index;
+            }
+        }
         if let Ok((v, found)) = self.options.get_string_value("line_search_method", "") {
             if found {
                 builder.line_search_method = match v.as_str() {
@@ -2651,6 +2677,36 @@ mod tests {
         assert!((snap.sqp.bt_min_alpha - 1e-10).abs() < 1e-18);
         assert_eq!(snap.sqp.print_level, 2);
         assert_eq!(snap.sqp.lbfgs_max_history, 12);
+    }
+
+    #[test]
+    fn application_limited_memory_options_propagate_to_builder() {
+        use crate::hess::lim_mem_quasi_newton::UpdateType;
+
+        // Default: no options set -> bit-exact with Ipopt's default
+        // (bfgs, history 6). This is what the IPM path runs unless the
+        // user opts in, so it must not drift.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        let def = app.algorithm_builder_from_options();
+        assert_eq!(def.limited_memory_update_type, UpdateType::Bfgs);
+        assert_eq!(def.limited_memory_max_history, 6);
+
+        // `limited_memory_update_type=sr1` and a custom history length
+        // must reach the builder (these were registered upstream but
+        // read nowhere on the IPM path before — see #131). Honoring
+        // them is what lets SR1 break the monotone L-BFGS stall.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str(
+            "hessian_approximation limited-memory\n\
+             limited_memory_update_type sr1\n\
+             limited_memory_max_history 9\n",
+        )
+        .unwrap();
+        let snap = app.algorithm_builder_from_options();
+        assert_eq!(snap.limited_memory_update_type, UpdateType::Sr1);
+        assert_eq!(snap.limited_memory_max_history, 9);
     }
 
     #[test]

--- a/dev-notes/issue-131-monotone-lbfgs-stall.md
+++ b/dev-notes/issue-131-monotone-lbfgs-stall.md
@@ -1,0 +1,132 @@
+# issue #131 — monotone L-BFGS stall: the two follow-ups
+
+[#131](https://github.com/jkitchin/pounce/issues/131): a D-optimal design
+problem on the **limited-memory (L-BFGS) + monotone** path runs to `max_iter`
+(status `-1`) where the reporter expected convergence.
+
+**Root cause (documented in the issue reply):** it is the *curvature model*,
+not the barrier strategy. Under monotone, μ only decreases once the barrier
+subproblem error drops below `barrier_tol_factor · μ` (κ_ε = 10). On this
+problem μ freezes at `lg(mu) = −2.5` while `inf_du ≈ 0.24 ≫ κ_ε·μ ≈ 0.032`, so
+the subproblem never clears its tolerance and μ is wedged. The true Hessian has
+min eigenvalue ≈ −1.8e7 (genuinely nonconvex), but **Powell-damped BFGS forces
+a PSD model**, so the IPM's inertia check never sees the indefiniteness, never
+fires regularization, and never escapes. cyipopt with the same L-BFGS monotone
+settings also fails in our environment (status `-3`); the exact Lagrangian
+Hessian (= `obj_factor · ∇²f`, since all constraints are linear) fixes both
+solvers (pounce: 108 iters, status 0).
+
+The reply committed to two internal follow-ups. This note records both
+outcomes.
+
+---
+
+## Follow-up A — auto stall-detector: **prototyped and discarded**
+
+An opt-in, default-off `monotone_stall_iter` option that watched for μ frozen
+for N consecutive iterations and terminated early with a diagnostic instead of
+grinding to `max_iter`. Wired end-to-end (option → `application.rs` →
+`ipopt_alg.rs` detection block → early return), default-off kept the
+bit-exact-Ipopt path inert, all `mu::` tests passed. On #131 it bailed ~300–400
+iters early at the same objective the baseline reaches.
+
+**Why discarded.** Building it falsified the premise. The "μ freeze" looks like
+a hard stall in a `print_level=5` trace, but it is actually a *uniformly
+decelerating crawl*: μ keeps inching forward, E_μ and the objective keep
+falling, just too slowly to clear `κ_ε·μ` within budget. There is **no clean
+bimodality** — no fixed-window gate separates "slow but will clear" from
+"doomed." An objective-progress gate (`Δf < 1e-6`) never fired (the objective
+genuinely creeps ~`2e-5`/window the whole time); a barrier-error stagnation
+gate (`E_μ` fell <50% over the window) worked but false-positived on the μ=0.1
+initial plateau, so the only usable thresholds were problem-specific (~150–200).
+
+So `monotone_stall_iter` is fundamentally a **patience limit** dressed up as a
+stall detector — an unprincipled tuning knob whose only good value is
+problem-specific, competing with the actual fix. Reverted; nothing landed.
+If a "don't silently grind to max_iter" message is ever wanted, prefer a
+*post-hoc* diagnostic keyed on the existing `max_iter`+frozen-μ exit state, not
+a mid-solve heuristic that perturbs the trajectory.
+
+---
+
+## Follow-up B — honor `limited_memory_update_type`: **wired and kept**
+
+While surveying the limited-memory machinery for "strengthen the inner solve,"
+we found the strengthening lever already exists and is unit-tested — it was
+just never reachable:
+
+- `crates/pounce-algorithm/src/hess/lim_mem_quasi_newton.rs` implements **both**
+  `UpdateType::Bfgs` *and* `UpdateType::Sr1`. SR1 is sign-indefinite: when the
+  curvature denominator is negative it stores the pair as a `−UUᵀ`
+  (negative-curvature) column instead of damping it away.
+- That indefinite model is already wired into inertia correction: in
+  `kkt/low_rank_aug_system_solver.rs` an SR1 negative-curvature column makes the
+  SMW middle-matrix Cholesky fail → returns `WrongInertia` → triggers
+  `PdPerturbationHandler` regularization (unit test
+  `smw_reports_wrong_inertia_on_indefinite_negative_update`).
+- But `limited_memory_update_type` (and `limited_memory_max_history`,
+  `limited_memory_initialization`, `limited_memory_init_val*`,
+  `limited_memory_special_for_resto`) were **registered but read nowhere on the
+  IPM path** — the updater was hard-wired to BFGS via the struct `Default`. A
+  user setting `limited_memory_update_type=sr1` was silently ignored. That's a
+  genuine Ipopt-parity defect independent of #131.
+
+**What was wired** (the clean-mapping subset):
+
+- `application.rs` now reads `limited_memory_update_type` (`bfgs`/`sr1`) →
+  `AlgorithmBuilder.limited_memory_update_type` (field already existed and was
+  already consumed at `alg_builder.rs`), and `limited_memory_max_history` →
+  new `AlgorithmBuilder.limited_memory_max_history` field → the updater's
+  `max_history`.
+- **Default unchanged: `bfgs`, history 6** — bit-exact with Ipopt's default, so
+  no behavior change unless the option is explicitly set. All 259
+  `pounce-algorithm` lib tests pass.
+
+**Empirical result on #131** (`/tmp/dopt_sr1_test.py`, `max_iter=1000`,
+`OMP_NUM_THREADS=1`):
+
+```
+limited-memory (no Hessian supplied):
+L-BFGS bfgs / monotone (baseline)    iters=1000 status= -1 obj=123.6373   <- the #131 stall
+L-BFGS sr1  / monotone               iters= 597 status=  1 obj=122.3683   <- converges
+L-BFGS bfgs / adaptive               iters= 786 status=  1 obj=122.8050
+L-BFGS sr1  / adaptive               iters= 402 status=  1 obj=123.9170
+EXACT-H     / monotone (reference)   iters= 108 status=  0 obj=122.9828
+```
+
+`limited_memory_update_type=sr1` **breaks the monotone stall** (status `-1` →
+`1`, feasible, `viol≈1e-8`) and lands on a better objective (122.37) than the
+stalled BFGS reached, near the exact-Hessian reference (122.98). The mechanism
+held: SR1's negative-curvature columns make the inertia check fire,
+regularization engages, μ unfreezes.
+
+### Honest caveat — do NOT make SR1 the default
+
+Ipopt's own option registration labels SR1 **"(not working well)"** (see
+`upstream_options.rs:602`), and that judgment is upstream's for good reason —
+SR1 limited-memory is unreliable in general. The right framing:
+
+- We now **honor** the option (parity fix) — that part is unconditionally
+  correct.
+- For **#131's problem class** specifically, `limited_memory_update_type=sr1`
+  is an *effective opt-in workaround* when an exact Hessian isn't available.
+- The **default stays `bfgs`**. The substantive recommendation for #131 remains
+  the exact Hessian (status 0, fewest iters, matches Ipopt); SR1 and `adaptive`
+  are the limited-memory fallbacks.
+
+### Not wired (deliberate, documented)
+
+`limited_memory_initialization` (only `scalar1`/`scalar2` map to the
+`InitialApprox` enum; `scalar3`/`scalar4`/`constant` have no variant),
+`limited_memory_init_val*`, `limited_memory_max_skipping`, and
+`limited_memory_special_for_resto` remain registered-but-unread. Wiring them
+partially would itself be a parity mismatch; left for a focused follow-up if
+needed.
+
+### Files touched (kept)
+
+- `crates/pounce-algorithm/src/application.rs` — read `limited_memory_update_type`
+  + `limited_memory_max_history`; `use ...::UpdateType`.
+- `crates/pounce-algorithm/src/alg_builder.rs` — new
+  `limited_memory_max_history` builder field (+ default, + consumed in the
+  `LimMemQuasiNewtonUpdater` construction, + the test struct literal).


### PR DESCRIPTION
## Summary

`limited_memory_update_type` and `limited_memory_max_history` were registered as Ipopt options but **read nowhere on the interior-point path** — the limited-memory updater was hard-wired to Powell-damped BFGS via its struct `Default`. A user setting `limited_memory_update_type=sr1` was silently ignored. This wires both options through `algorithm_builder_from_options` into the builder and on to `LimMemQuasiNewtonUpdater`.

**The default is unchanged (`bfgs`, history 6)** — bit-exact with Ipopt's default, so no behavior change unless the option is explicitly set.

## Motivation (#131)

On an ill-conditioned, nonconvex D-optimal objective, the L-BFGS + monotone path stalls to `max_iter`. Powell-damped BFGS always yields a PSD curvature model, hiding the indefiniteness (min eigenvalue ≈ −1.8e7) from the inertia check, so regularization never fires and the barrier parameter μ never unfreezes. SR1 can represent negative curvature; the updater and the low-rank/inertia path already handle its indefinite models (they were just unreachable).

With `limited_memory_update_type=sr1` honored, the same problem converges:

| limited-memory config         | iters | status | objective |
|-------------------------------|------:|:------:|----------:|
| `bfgs` / monotone (the stall) |  1000 | **−1** | 123.6373  |
| **`sr1` / monotone**          |   597 | **1**  | 122.3683  |
| `bfgs` / adaptive             |   786 |   1    | 122.8050  |
| exact Hessian / monotone (ref)|   108 |   0    | 122.9828  |

SR1 is documented upstream as "not working well" *in general*, so it stays **opt-in, not a default**; the exact Hessian remains the primary recommendation for that problem class.

## Changes

- `application.rs` — read `limited_memory_update_type` (`bfgs`/`sr1`) and `limited_memory_max_history` into the builder.
- `alg_builder.rs` — new `limited_memory_max_history` builder field (default 6), consumed when constructing the limited-memory updater.
- Test `application_limited_memory_options_propagate_to_builder` — pins both the bit-exact default and the sr1/history wiring.
- `dev-notes/issue-131-monotone-lbfgs-stall.md` — full analysis, including the discarded auto-stall-detector approach.

## Testing

- `cargo test -p pounce-algorithm --lib` — 259 passed, 0 failed.
- Empirical #131 repro reproduced the table above (`OMP_NUM_THREADS=1`, `max_iter=1000`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
