### PR TITLE
fix: resolve princetonlib MS=7 cases (acceptable-exit guard + mu-strategy fallback) (#138)

### DIFF
--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -505,6 +505,15 @@ impl IpoptApplication {
         if info.m > 0 && self.is_l1_fallback_enabled() && !self.is_l1_penalty_enabled() {
             return self.run_with_l1_fallback(tnlp);
         }
+        // μ-strategy auto-fallback (pounce#138): if the standard solve
+        // only reaches Solved_To_Acceptable_Level, retry once with the
+        // opposite mu_strategy and promote only on Solve_Succeeded.
+        // Applies to constrained and unconstrained alike (both run the
+        // same IPM). Independent of, and lower priority than, the ℓ₁
+        // fallback above.
+        if self.is_mu_strategy_fallback_enabled() {
+            return self.run_with_mu_strategy_fallback(tnlp);
+        }
         // Every problem — constrained or not — goes through the same
         // primal-dual IPM, exactly as upstream Ipopt does. There is no
         // separate "unconstrained Newton" path: the linear-solver
@@ -569,6 +578,16 @@ impl IpoptApplication {
     fn is_l1_fallback_enabled(&self) -> bool {
         self.options
             .get_bool_value("l1_fallback_on_restoration_failure", "")
+            .ok()
+            .and_then(|(v, found)| found.then_some(v))
+            .unwrap_or(false)
+    }
+
+    /// Read the μ-strategy auto-fallback switch (pounce#138).
+    /// Default `false` when the option is not set.
+    fn is_mu_strategy_fallback_enabled(&self) -> bool {
+        self.options
+            .get_bool_value("mu_strategy_fallback", "")
             .ok()
             .and_then(|(v, found)| found.then_some(v))
             .unwrap_or(false)
@@ -786,6 +805,72 @@ impl IpoptApplication {
         let _ = self.options.set_string_value(
             "l1_exact_penalty_barrier",
             prev.as_ref().map(|(v, _)| v.as_str()).unwrap_or("no"),
+            true,
+            false,
+        );
+        if matches!(retry_status, ApplicationReturnStatus::SolveSucceeded) {
+            retry_status
+        } else {
+            first_status
+        }
+    }
+
+    /// μ-strategy auto-fallback driver (pounce#138).
+    ///
+    /// Runs the standard solve first. If it stalls short of optimal in a
+    /// way a μ-strategy flip can plausibly fix — `Solved_To_Acceptable_Level`
+    /// or `Maximum_Iterations_Exceeded`, the two signatures seen on the
+    /// princetonlib instances where the dual infeasibility parks above
+    /// `tol` while constraint violation and complementarity are already
+    /// deeply converged — it flips `mu_strategy` (adaptive↔monotone) and
+    /// solves once more. The retry's status is promoted only if it returns
+    /// `Solve_Succeeded`; otherwise the original status is returned.
+    ///
+    /// (maxcut/price stall at acceptable-level under adaptive; fermat2_vareps
+    /// stalls at `max_iter` — hence both triggers. flosp2tm is μ-independent
+    /// and correctly does not promote.)
+    ///
+    /// The flip direction is taken from the option's current value:
+    /// `adaptive` → `monotone`, anything else (including absent, which
+    /// the builder treats as monotone) → `adaptive`. The option table is
+    /// restored to the user's original view afterward.
+    ///
+    /// Caveat (shared with the ℓ₁ fallback): the user TNLP's
+    /// `finalize_solution` runs once per attempt, so when the retry
+    /// doesn't promote the captured fields hold the retry's iterate.
+    fn run_with_mu_strategy_fallback(
+        &mut self,
+        tnlp: Rc<RefCell<dyn TNLP>>,
+    ) -> ApplicationReturnStatus {
+        let first_status = self.optimize_constrained(Rc::clone(&tnlp));
+        if !matches!(
+            first_status,
+            ApplicationReturnStatus::SolvedToAcceptableLevel
+                | ApplicationReturnStatus::MaximumIterationsExceeded
+        ) {
+            return first_status;
+        }
+        // Flip the strategy for one retry. The parser maps "adaptive" →
+        // Adaptive and every other value (incl. unset) → Monotone, so the
+        // opposite of an explicit "adaptive" is "monotone" and the
+        // opposite of anything else is "adaptive".
+        let prev = self.options.get_string_value("mu_strategy", "").ok();
+        let was_adaptive = prev
+            .as_ref()
+            .map(|(v, found)| *found && v == "adaptive")
+            .unwrap_or(false);
+        let flipped = if was_adaptive { "monotone" } else { "adaptive" };
+        let _ = self
+            .options
+            .set_string_value("mu_strategy", flipped, true, false);
+        let retry_status = self.optimize_constrained(Rc::clone(&tnlp));
+        // Restore the user's original option-table view.
+        let _ = self.options.set_string_value(
+            "mu_strategy",
+            prev.as_ref()
+                .filter(|(_, found)| *found)
+                .map(|(v, _)| v.as_str())
+                .unwrap_or("monotone"),
             true,
             false,
         );

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -186,7 +186,12 @@ impl ConvCheck for OptErrorConvCheck {
         if nlp_err <= self.tol {
             return ConvergenceStatus::Converged;
         }
-        if nlp_err <= self.acceptable_tol {
+        // `acceptable_iter == 0` disables acceptable-level termination,
+        // mirroring upstream `IpOptErrorConvCheck.cpp:241`
+        // (`if( acceptable_iter_ > 0 && CurrentIsAcceptable() )`). Without
+        // the `> 0` guard, a zero would make `acceptable_count >= 0` fire on
+        // the first acceptable iterate — the opposite of "disabled".
+        if self.acceptable_iter > 0 && nlp_err <= self.acceptable_tol {
             self.acceptable_count += 1;
             if self.acceptable_count >= self.acceptable_iter {
                 return ConvergenceStatus::ConvergedToAcceptable;
@@ -225,7 +230,11 @@ impl ConvCheck for OptErrorConvCheck {
         if self.passes_component_tols(nlp_err, dual_inf, constr_viol, compl_inf) {
             return ConvergenceStatus::Converged;
         }
-        if self.passes_acceptable_tols(nlp_err, dual_inf, constr_viol, compl_inf, curr_f) {
+        // `acceptable_iter == 0` disables acceptable-level termination
+        // (upstream `IpOptErrorConvCheck.cpp:241`). See `check_convergence`.
+        if self.acceptable_iter > 0
+            && self.passes_acceptable_tols(nlp_err, dual_inf, constr_viol, compl_inf, curr_f)
+        {
             self.acceptable_count += 1;
             if self.acceptable_count >= self.acceptable_iter {
                 return ConvergenceStatus::ConvergedToAcceptable;
@@ -338,6 +347,30 @@ mod tests {
             c.check_convergence(1e-7, 2),
             ConvergenceStatus::ConvergedToAcceptable
         );
+    }
+
+    #[test]
+    fn acceptable_iter_zero_disables_acceptable_termination() {
+        // Upstream `IpOptErrorConvCheck.cpp:241` gates the acceptable
+        // counter on `acceptable_iter_ > 0`, so a zero disables the
+        // acceptable-level exit entirely. Before the guard, `>= 0` made
+        // pounce fire on the FIRST acceptable iterate (the opposite).
+        let mut c = OptErrorConvCheck {
+            acceptable_iter: 0,
+            ..Default::default()
+        };
+        // Many iterates parked between tol (1e-8) and acceptable (1e-6)
+        // must never trigger ConvergedToAcceptable; the run continues
+        // until tol or max_iter.
+        for k in 0..50 {
+            assert_eq!(
+                c.check_convergence(1e-7, k),
+                ConvergenceStatus::Continue,
+                "acceptable_iter=0 must not stop at the acceptable level (iter {k})"
+            );
+        }
+        // tol is still honored regardless.
+        assert_eq!(c.check_convergence(1e-9, 51), ConvergenceStatus::Converged);
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -1816,6 +1816,12 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
         false,
         "When set, optimize_tnlp first runs the standard solve. If it terminates in Restoration_Failed / Infeasible_Problem_Detected / Solved_To_Acceptable_Level / Maximum_Iterations_Exceeded / Not_Enough_Degrees_Of_Freedom, the wrapper is enabled and the solve is repeated. The retry's status replaces the original ONLY if the retry returns Solve_Succeeded (promotion); otherwise the original status is returned. NOTE: the user TNLP's finalize_solution is called once per attempt, so when the retry doesn't promote the user's captured fields hold the retry's iterate (the ℓ₁-best least-infeasible point) even though the returned status is the original's — pounce#10 Phase-4 note.",
     )?;
+    r.add_bool_option(
+        "mu_strategy_fallback",
+        "Auto-retry with the opposite mu_strategy when the standard solve stalls short of optimal.",
+        false,
+        "When set, optimize_tnlp first runs the standard solve. If it terminates in Solved_To_Acceptable_Level or Maximum_Iterations_Exceeded — the stall signatures where the dual infeasibility parks above tol while constraint violation and complementarity are already converged — the mu_strategy is flipped (adaptive↔monotone) and the solve is repeated once. The retry's status replaces the original ONLY if the retry returns Solve_Succeeded (promotion); otherwise the original status is returned. Motivated by pounce#138: on several princetonlib instances adaptive under-converges the dual term while monotone drives it under tol (maxcut, price recover from acceptable-level; fermat2_vareps recovers from a 3000-iter stall) — and the converse holds on other models (globallib/ex8_3_1), so neither strategy is globally correct and a one-shot fallback recovers the stalled cases without a blanket flag flip. NOTE: like the ℓ₁ fallback, the user TNLP's finalize_solution runs once per attempt, so when the retry doesn't promote the captured fields hold the retry's iterate.",
+    )?;
 
     register_sipopt_options(r)?;
 

--- a/crates/pounce-algorithm/tests/mu_strategy_fallback_option.rs
+++ b/crates/pounce-algorithm/tests/mu_strategy_fallback_option.rs
@@ -1,0 +1,45 @@
+//! Wiring test for the μ-strategy auto-fallback switch (pounce#138).
+//!
+//! `optimize_tnlp` consults `mu_strategy_fallback` to decide
+//! whether to retry a `Solved_To_Acceptable_Level` solve with the opposite
+//! `mu_strategy`. This test pins the option's registration, default, and the
+//! `"yes"`/`"no"` string round-trip the GAMS link depends on (the link
+//! forwards unknown keys via `AddIpoptStrOption`, so the bool must accept the
+//! string form). It does not run a solve — the end-to-end promotion is
+//! exercised through the GAMS princetonlib instances in the issue.
+
+use pounce_algorithm::application::IpoptApplication;
+
+#[test]
+fn fallback_option_defaults_off() {
+    let mut app = IpoptApplication::new();
+    let (value, _found) = app
+        .options_mut()
+        .get_bool_value("mu_strategy_fallback", "")
+        .expect("option must be registered");
+    assert!(!value, "μ-strategy fallback must default to off");
+}
+
+#[test]
+fn fallback_option_accepts_string_yes() {
+    // The GAMS link sets bool options via their string form ("yes"/"no");
+    // mirror that exact path rather than set_bool_value.
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("mu_strategy_fallback", "yes", true, false)
+        .expect("string 'yes' must round-trip into the bool option");
+    let (value, found) = app
+        .options_mut()
+        .get_bool_value("mu_strategy_fallback", "")
+        .unwrap();
+    assert!(found && value, "after set 'yes', the switch reads true");
+
+    app.options_mut()
+        .set_string_value("mu_strategy_fallback", "no", true, false)
+        .unwrap();
+    let (value, _) = app
+        .options_mut()
+        .get_bool_value("mu_strategy_fallback", "")
+        .unwrap();
+    assert!(!value, "after set 'no', the switch reads false");
+}

--- a/gams/gams_pounce.c
+++ b/gams/gams_pounce.c
@@ -887,6 +887,17 @@ DllExport int STDCALL pouCallSolver(void *Cptr)
     /* Default print level */
     AddIpoptIntOption(nlp, "print_level", 5);
 
+    /* Disable acceptable-level termination by default, matching the GAMS
+     * Ipopt link (optipopt.def sets `acceptable_iter` default 0, overriding
+     * Ipopt's source default of 15). Without this, pounce stops early at the
+     * "acceptable" point on slow-tail problems where GAMS-Ipopt grinds on to
+     * true local optimality — e.g. princetonlib/flosp2tm, which pounce parked
+     * at MS=7 (dual inf 2e-8, iter 17) while GAMS-Ipopt reaches MS=2 (8.7e-9,
+     * iter 248). Set before the opt-file parse so a user pounce.opt can still
+     * re-enable it. See pounce#138. (pounce honors 0 == disabled per the
+     * IpOptErrorConvCheck.cpp:241 `acceptable_iter_ > 0` guard.) */
+    AddIpoptIntOption(nlp, "acceptable_iter", 0);
+
     /* Use L-BFGS if no analytical Hessian */
     if (!data->have_hessian)
         AddIpoptStrOption(nlp, "hessian_approximation", "limited-memory");


### PR DESCRIPTION
## Summary

Fixes the princetonlib `ModelStatus=7` (Feasible, not Locally Optimal) cases in #138. Two independent causes, two fixes:

**1. Acceptable-exit faithfulness fix — the primary cause (3/4 instances).**
pounce's acceptable-level convergence check omitted upstream's `acceptable_iter_ > 0` guard (`IpOptErrorConvCheck.cpp:241`), so `acceptable_iter=0` did *not* disable acceptable-level termination — it made the acceptable streak fire on the first acceptable iterate (`acceptable_count >= 0`), the opposite of "disabled". Restored the guard in both `check_convergence` and `check_convergence_with_state`.

The GAMS link now also defaults `acceptable_iter=0`, mirroring the GAMS-Ipopt link (`optipopt.def` overrides Ipopt's source default of 15 → 0). pounce's link had never replicated that override, so it bailed early at `Solved_To_Acceptable_Level` on maxcut/price/flosp2tm where adaptive otherwise drives the dual term under `tol` (maxcut iter 107, price 68, flosp2tm 164).

**2. μ-strategy auto-fallback — narrow, for the genuine stall (fermat2_vareps only).**
Opt-in bool `mu_strategy_fallback` (default off): on a `Solved_To_Acceptable_Level` or `Maximum_Iterations_Exceeded` exit, flip `mu_strategy` once, re-solve, and promote only on `Solve_Succeeded`. Wired into `optimize_tnlp` next to the existing ℓ₁ fallback. fermat2_vareps goes from a 3000-iteration adaptive stall (dual inf 1.24e-6) to a 20-iteration monotone solve (1.61e-9, MS=2).

## Corrected root-cause split

| instance | true cause | fixed by |
|---|---|---|
| flosp2tm | premature acceptable exit | acceptable_iter guard |
| maxcut | premature acceptable exit | acceptable_iter guard |
| price | premature acceptable exit | acceptable_iter guard |
| fermat2_vareps | genuine adaptive μ-stall | μ-strategy fallback |

(An earlier #138 comment mis-attributed maxcut/price to the μ-strategy; that toggle was confounded by acceptable-termination still being enabled. Corrected in a follow-up comment on the issue.)

With both fixes (`acceptable_iter=0` + `mu_strategy_fallback=yes`) all four princetonlib instances reach `ModelStatus=2`.

## Testing

- New unit test `acceptable_iter_zero_disables_acceptable_termination` (conv_check): 14/14 conv_check tests pass.
- New wiring tests `mu_strategy_fallback_option`: option default-off + `"yes"`/`"no"` string round-trip (the GAMS link's bool path).
- Full `pounce-algorithm` suite green.
- End-to-end verified through a rebuilt GAMS-pounce link on `princetonlib.gms/{maxcut,price,flosp2tm,fermat2_vareps}` (GAMS 53, `tol=1e-8 max_iter=3000`). Rebuilt dylibs were reversibly installed for verification and the released build has been restored.

Refs #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
