### PR TITLE
feat(gams): pip-installable pure-Python GAMS solver link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,29 @@ crates.io API needs a User-Agent or it silently looks unpublished:
 
 Sanity-check against `serde` first; if serde reads NOT PUBLISHED your request is
 being rejected, not the crate missing.
+
+## GAMS solver link — two routes
+
+POUNCE registers with GAMS (`option nlp = pounce;`) two independent ways:
+
+1. **pip (pure-Python, recommended for users)** — `pip install
+   pounce-solver[gams]` + `pounce-gams register`. Lives in
+   `python/pounce/gams/` (`gmo_translate.py`, `link.py`, `register.py`) with the
+   `pounce-gams` CLI in `python/pounce/_gams_cli.py`. Built on GAMS's own
+   `gamsapi[core]` PyPI bindings (which `dlopen` the user's GAMS libs) — **we
+   redistribute nothing GAMS-owned**. POUNCE is a local NLP solver, so the link
+   wires GMO's numerical evaluators straight into the cyipopt-style `Problem`
+   callbacks (no opcode translator, unlike discopt's global solver). Registers a
+   script solver via a `gamsconfig.yaml` `solverConfig` entry — no `sudo`, no
+   system-dir writes, survives GAMS upgrades. The per-user config dir is
+   OS-specific and **NOT XDG on macOS**: macOS `~/Library/Preferences/GAMS`,
+   Linux `~/.config/GAMS`, Windows `%LOCALAPPDATA%\GAMS` (verify with `gamsinst
+   -listdirs`). License-free unit tests in `python/tests/test_gams_link.py`
+   drive a fake `GmoView`; the live `gamsapi` adapter is the only
+   CI-untestable surface.
+2. **native C link** — `gams/gams_pounce.c` + `make -C gams && sudo make -C gams
+   install`. The authoritative reference for GMO call sequence, sign
+   conventions, option keywords, and status mapping. Adds active-set-SQP
+   working-set / state-file warm starts the pip link does not yet reproduce.
+
+Docs: `docs/src/gams.md` (user-facing), `gams/README.md` (C link).

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -27,6 +27,7 @@
 # Integrations
 
 - [Pyomo](pyomo.md)
+- [GAMS](gams.md)
 - [Python API](python.md)
 - [Curve Fitting](curve-fitting.md)
 

--- a/docs/src/gams.md
+++ b/docs/src/gams.md
@@ -1,0 +1,129 @@
+# GAMS
+
+POUNCE plugs into [GAMS](https://www.gams.com/) as an NLP solver, so a model
+can hand its problem to POUNCE with:
+
+```
+option nlp = pounce;
+solve mymodel using nlp minimizing obj;
+```
+
+There are two ways to make POUNCE available to GAMS. Pick one:
+
+| Route | Install | What it is |
+| --- | --- | --- |
+| **pip (recommended)** | `pip install pounce-solver[gams]` then `pounce-gams register` | A pure-Python solver link built on GAMS's own `gamsapi` package. No compiler, no `sudo`, survives GAMS upgrades. |
+| **native C link** | build + `sudo make -C gams install` | A C shared library installed into the GAMS system directory. Adds active-set-SQP working-set / state-file warm starts. See [`gams/README.md`](https://github.com/jkitchin/pounce/blob/main/gams/README.md). |
+
+Both register POUNCE under the same name (`pounce`) for `NLP`, `DNLP`, and
+`RMINLP` models — POUNCE is a continuous local NLP solver, so mixed-integer and
+conic model types are not offered here.
+
+## The pip route
+
+### 1. Install
+
+```
+pip install pounce-solver[gams]
+```
+
+The `[gams]` extra pulls in
+[`gamsapi[core]`](https://pypi.org/project/gamsapi/) — GAMS's own expert-level
+GMO/GEV Python bindings — and PyYAML. The bindings `dlopen` the GAMS C
+libraries from your local install, so **`gamsapi` must match your GAMS
+version**. POUNCE itself redistributes nothing GAMS-owned. If your GAMS and
+`gamsapi` versions disagree, install the matching one from your GAMS system
+(GAMS ships a `gamsapi` wheel under `apifiles/Python/`), or:
+
+```
+pip install 'gamsapi[core]==<your GAMS X.Y.Z>'
+```
+
+### 2. Check the install
+
+```
+pounce-gams status
+```
+
+reports whether `gamsapi` imports, the config directory POUNCE will register
+into, and whether POUNCE is already registered:
+
+```
+gamsapi:       available
+               gamsapi 53.2.0 importable
+config dir:    /Users/you/Library/Preferences/GAMS
+gamsconfig:    /Users/you/Library/Preferences/GAMS/gamsconfig.yaml (missing)
+POUNCE solver: not registered
+```
+
+### 3. Register
+
+```
+pounce-gams register
+```
+
+This writes a tiny launcher script and a `solverConfig` entry into your GAMS
+per-user `gamsconfig.yaml`. It **merges** — any other solvers already in that
+file (CONOPT overrides, discopt, …) are preserved — and is idempotent (re-running
+just updates POUNCE in place). The per-user config directory GAMS searches is
+OS-specific:
+
+| OS | Directory |
+| --- | --- |
+| macOS | `~/Library/Preferences/GAMS` |
+| Linux | `$XDG_CONFIG_HOME/GAMS` (else `~/.config/GAMS`) |
+| Windows | `%LOCALAPPDATA%\GAMS` (else `…\Documents\GAMS`) |
+
+Override the target with `--config-dir <path>` (e.g. to register into the GAMS
+system directory instead). To undo, `pounce-gams unregister`.
+
+No `sudo` is needed and nothing is written into the GAMS system directory, so a
+GAMS upgrade does not wipe the registration.
+
+### 4. Solve
+
+```
+option nlp = pounce;
+solve mymodel using nlp minimizing obj;
+```
+
+GAMS invokes the launcher with a control file; the launcher runs the Python
+link, which reads the model through GMO/GEV, solves it with POUNCE, and writes
+the primal/dual solution and GAMS model/solve status back.
+
+## Option files
+
+If a model sets `mymodel.optfile = 1`, POUNCE reads `pounce.opt` (`.op2`,
+`.op3`, … for higher `optfile` values). Each line is a `keyword value` pair
+using POUNCE's [option names](options.md); lines starting with `*` or `#` are
+comments. The GAMS `iterlim` and `reslim` are honored as `max_iter` and
+`max_wall_time`.
+
+```
+* pounce.opt
+tol        1e-10
+max_iter   500
+```
+
+### Machine-readable solve report
+
+Set `json_output` in `pounce.opt` to also emit a structured
+`pounce.solve-report/v1` JSON report (identical to the CLI's `--json-output`,
+consumable by `pounce-studio`):
+
+```
+json_output  my_solve.json
+json_detail  full        * "summary" or "full"; default is "full"
+```
+
+See the [JSON Solve Report](json-output.md) schema for the format.
+
+## Notes & limitations
+
+- **Version match.** The single most common failure is a `gamsapi` ↔ GAMS
+  version mismatch; `pounce-gams status` diagnoses it.
+- **Warm starts.** The active-set-SQP working-set / state-file warm-start
+  features (`algorithm active-set-sqp`, `sqp_state_file`) are currently only in
+  the native C link, where each `solve` reuses an in-process state. The pip
+  link runs each solve as a fresh process; full warm-start parity is a planned
+  follow-up.

--- a/gams/README.md
+++ b/gams/README.md
@@ -1,4 +1,4 @@
-# GAMS solver link for POUNCE
+# GAMS solver link for POUNCE (native C link)
 
 This directory builds `libGamsPounce`, a shared library that registers POUNCE
 as a GAMS NLP solver. Once installed, a GAMS model can invoke POUNCE with
@@ -7,6 +7,14 @@ as a GAMS NLP solver. Once installed, a GAMS model can invoke POUNCE with
 option nlp = pounce;
 solve mymodel using nlp minimizing obj;
 ```
+
+> **Most users want the pip route instead.** `pip install pounce-solver[gams]`
+> followed by `pounce-gams register` makes POUNCE a GAMS solver with **no
+> compiler and no `sudo`** — a pure-Python link built on GAMS's own `gamsapi`
+> package. See the [GAMS integration docs](../docs/src/gams.md). This C link is
+> the *native* route: it requires building from source and `sudo make install`,
+> but adds the active-set-SQP working-set / on-disk state-file warm starts that
+> the pip link does not yet reproduce.
 
 ## Files
 

--- a/python/pounce/_gams_cli.py
+++ b/python/pounce/_gams_cli.py
@@ -1,0 +1,109 @@
+"""``pounce-gams`` -- register POUNCE as a GAMS solver.
+
+The main ``pounce`` executable is the Rust CLI binary, so GAMS registration is
+its own pure-Python console script.  Subcommands:
+
+* ``register``   -- write/merge ``gamsconfig.yaml`` + the launcher script
+* ``unregister`` -- remove POUNCE from ``gamsconfig.yaml`` + delete the launcher
+* ``status``     -- report gamsapi importability and whether POUNCE is registered
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+def _cmd_register(args) -> int:
+    from pounce.gams import register
+
+    written = register.write_registration(args.config_dir)
+    action = written["action"]
+    verb = {
+        "created": "Created",
+        "merged": "Merged POUNCE into",
+        "replaced": "Updated POUNCE entry in",
+    }.get(action, "Wrote")
+    print(f"{verb} {written['config']}")
+    print(f"Launcher: {written['script']}")
+    print(f"\nPOUNCE is now registered for GAMS in {written['config_dir']}.")
+    print("Solve a model with:  option nlp = pounce;")
+
+    check = register.check_gamsapi()
+    if not check["available"]:
+        print(f"\nNote: {check['detail']}", file=sys.stderr)
+    return 0
+
+
+def _cmd_unregister(args) -> int:
+    from pounce.gams import register
+
+    result = register.unregister(args.config_dir)
+    if result["removed"]:
+        print(f"Removed POUNCE from {result['config']}")
+    else:
+        print(f"No POUNCE entry found in {result['config']} (launcher removed if present)")
+    return 0
+
+
+def _cmd_status(args) -> int:
+    from pounce.gams import register
+
+    cfg_dir = Path(args.config_dir) if args.config_dir else register.gams_user_config_dir()
+    config = cfg_dir / "gamsconfig.yaml"
+
+    check = register.check_gamsapi()
+    print(f"gamsapi:       {'available' if check['available'] else 'NOT available'}")
+    print(f"               {check['detail']}")
+    print(f"config dir:    {cfg_dir}")
+
+    registered = False
+    if config.exists():
+        text = config.read_text()
+        registered = f"{register.SOLVER_NAME}:" in text and "scriptName" in text
+    print(f"gamsconfig:    {config} ({'exists' if config.exists() else 'missing'})")
+    print(f"POUNCE solver: {'registered' if registered else 'not registered'}")
+    if not registered:
+        print("\nRun `pounce-gams register` to register POUNCE with GAMS.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="pounce-gams",
+        description="Register POUNCE as a GAMS solver (pure-Python, gamsapi-based).",
+    )
+    sub = parser.add_subparsers(dest="command")
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument(
+        "--config-dir",
+        default=None,
+        help="GAMS user config directory (default: auto-detected).",
+    )
+
+    p_reg = sub.add_parser(
+        "register", parents=[common], help="Register POUNCE with GAMS."
+    )
+    p_reg.set_defaults(func=_cmd_register)
+
+    p_unreg = sub.add_parser(
+        "unregister", parents=[common], help="Remove POUNCE from GAMS."
+    )
+    p_unreg.set_defaults(func=_cmd_unregister)
+
+    p_stat = sub.add_parser(
+        "status", parents=[common], help="Show gamsapi + registration status."
+    )
+    p_stat.set_defaults(func=_cmd_status)
+
+    args = parser.parse_args(argv)
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 1
+    return args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/python/pounce/gams/__init__.py
+++ b/python/pounce/gams/__init__.py
@@ -1,0 +1,56 @@
+"""POUNCE as a GAMS solver (pure-Python, pip-installable).
+
+This package lets a GAMS user solve a model with POUNCE::
+
+    option nlp = pounce;
+    solve m using nlp minimizing z;
+
+After ``pip install pounce-solver[gams]`` and a one-shot ``pounce-gams
+register``, GAMS launches the POUNCE *solver link* with a control file; the link
+reads the model through the GAMS Modeling Object (GMO), feeds GMO's numerical
+function / gradient / Hessian evaluators straight into POUNCE's
+cyipopt-compatible :class:`pounce.Problem`, solves it, and writes the solution
+back.
+
+It is the pip-installable counterpart to the native C link in ``gams/`` and
+relies on GAMS's own ``gamsapi`` package (the ``[gams]`` extra); nothing
+GAMS-owned is redistributed.
+"""
+
+from __future__ import annotations
+
+from .gmo_translate import GmoProblem, GmoView, problem_from_gmo
+from .link import (
+    is_available,
+    parse_option_file,
+    solve_from_control_file,
+    solve_view,
+    status_to_gams,
+)
+from .register import (
+    check_gamsapi,
+    gams_user_config_dir,
+    gamsconfig_snippet,
+    render_gamsconfig,
+    run_script,
+    unregister,
+    write_registration,
+)
+
+__all__ = [
+    "GmoProblem",
+    "GmoView",
+    "problem_from_gmo",
+    "is_available",
+    "parse_option_file",
+    "solve_from_control_file",
+    "solve_view",
+    "status_to_gams",
+    "check_gamsapi",
+    "gams_user_config_dir",
+    "gamsconfig_snippet",
+    "render_gamsconfig",
+    "run_script",
+    "unregister",
+    "write_registration",
+]

--- a/python/pounce/gams/gmo_translate.py
+++ b/python/pounce/gams/gmo_translate.py
@@ -1,0 +1,211 @@
+"""Build a POUNCE problem object from a GAMS Modeling Object (GMO) view.
+
+POUNCE is a *local* NLP solver (an Ipopt-style interior-point method), so it
+only ever needs function / gradient / Hessian **values** at a point — never the
+symbolic expression DAG.  GMO evaluates those values directly
+(``gmoEvalFuncObj`` / ``gmoEvalGradObj`` / ``gmoEvalFunc`` / ``gmoEvalGrad`` /
+``gmoHessLagValue``), so the translation here is far simpler than a global
+solver's: it wires GMO's numerical evaluators straight into POUNCE's
+cyipopt-compatible :class:`pounce.Problem` callbacks.
+
+Everything is read through the small :class:`GmoView` protocol below.  Keeping
+the interface this thin lets the whole translate -> build -> solve path be
+unit-tested with an in-memory fake (no GAMS license required); the only
+GAMS-library-specific code lives in the adapter in :mod:`pounce.gams.link`.
+
+The sign / objective conventions mirror the C link ``gams/gams_pounce.c``
+exactly:
+
+* ``obj_sign = -1`` for a GAMS *maximize* model, ``+1`` otherwise.  POUNCE
+  always minimizes, so the objective and its gradient are scaled by ``obj_sign``
+  (maximize -> minimize ``-f``).
+* The Hessian of the Lagrangian is obtained from a single ``gmoHessLagValue``
+  call with ``objweight = obj_sign * obj_factor`` and ``conweight = -1.0``.  The
+  ``conweight = -1`` is equivalent to negating the multipliers (GAMS's ``pi`` is
+  ``-lambda``), so POUNCE's standard cyipopt ``lagrange`` vector is passed
+  through unchanged.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, Sequence
+
+import numpy as np
+
+# POUNCE / GAMS "infinity": bounds at or beyond GAMS's +/- inf are mapped to
+# +/- this value, matching gams_pounce.c.
+POUNCE_INF = 1e19
+
+
+class GmoView(Protocol):
+    """Minimal numerical read interface over a GAMS Modeling Object.
+
+    All indexing is 0-based (the adapter sets ``gmoIndexBaseSet(0)``).  The
+    evaluators work in the model's *native* objective sense; the sign flip for
+    maximization is applied by :func:`problem_from_gmo`, not by the view.
+    """
+
+    # --- dimensions -------------------------------------------------------
+    def name(self) -> str: ...
+    def num_vars(self) -> int: ...
+    def num_cons(self) -> int: ...
+
+    # True for a GAMS ``maximizing`` model, False for ``minimizing``.
+    def maximize(self) -> bool: ...
+
+    # True if GMO can supply an analytical Hessian of the Lagrangian.
+    def has_hessian(self) -> bool: ...
+
+    # --- bounds / initial point ------------------------------------------
+    # Each returns a length-``num_vars`` (or ``num_cons``) sequence with GAMS
+    # infinities already mapped to +/- POUNCE_INF.
+    def var_lower(self) -> Sequence[float]: ...
+    def var_upper(self) -> Sequence[float]: ...
+    def var_init(self) -> Sequence[float]: ...
+    def con_lower(self) -> Sequence[float]: ...
+    def con_upper(self) -> Sequence[float]: ...
+
+    # --- sparsity structure (0-based COO) --------------------------------
+    # Constraint Jacobian nonzeros, in the order ``eval_jac`` returns values.
+    def jac_structure(self) -> tuple[Sequence[int], Sequence[int]]: ...
+    # Lower-triangle Hessian-of-Lagrangian nonzeros (only when has_hessian()).
+    def hess_structure(self) -> tuple[Sequence[int], Sequence[int]]: ...
+
+    # --- numerical evaluators (native sense) -----------------------------
+    def eval_obj(self, x: np.ndarray) -> float: ...
+    def eval_grad_obj(self, x: np.ndarray) -> Sequence[float]: ...
+    def eval_cons(self, x: np.ndarray) -> Sequence[float]: ...
+    def eval_jac(self, x: np.ndarray) -> Sequence[float]: ...
+
+    def hess_lag_value(
+        self,
+        x: np.ndarray,
+        lam: np.ndarray,
+        obj_weight: float,
+        con_weight: float,
+    ) -> Sequence[float]: ...
+
+
+@dataclass
+class GmoProblem:
+    """Everything needed to construct and solve a :class:`pounce.Problem`.
+
+    ``problem_obj`` carries the cyipopt callbacks; the remaining fields are the
+    constructor arguments and a couple of conveniences for the link.
+    """
+
+    problem_obj: "_GmoProblemObj"
+    n: int
+    m: int
+    lb: list[float]
+    ub: list[float]
+    cl: list[float]
+    cu: list[float]
+    x0: np.ndarray
+    has_hessian: bool
+    obj_sign: float  # +1 minimize, -1 maximize
+
+
+class _GmoProblemObj:
+    """cyipopt-style problem object delegating to a :class:`GmoView`.
+
+    Mirrors the callback set POUNCE expects (see ``pounce.Problem``):
+    ``objective``, ``gradient``, ``constraints``, ``jacobianstructure`` and
+    ``jacobian``.  When an analytical Hessian is available the
+    :class:`_GmoProblemObjHess` subclass adds ``hessianstructure`` /
+    ``hessian``; POUNCE detects the Hessian callbacks by their presence
+    (``hasattr``), so the no-Hessian object must simply not define them, which
+    selects limited-memory (L-BFGS) mode exactly as the C link does.  The
+    objective-sense and Hessian-weight conventions match ``gams_pounce.c``.
+    """
+
+    def __init__(self, view: GmoView, obj_sign: float):
+        self._v = view
+        self._sign = obj_sign
+        jr, jc = view.jac_structure()
+        self._jac_rows = np.asarray(jr, dtype=np.int64)
+        self._jac_cols = np.asarray(jc, dtype=np.int64)
+
+    # --- objective --------------------------------------------------------
+    def objective(self, x):
+        return self._sign * float(self._v.eval_obj(np.asarray(x, dtype=float)))
+
+    def gradient(self, x):
+        g = np.asarray(self._v.eval_grad_obj(np.asarray(x, dtype=float)), dtype=float)
+        return self._sign * g
+
+    # --- constraints ------------------------------------------------------
+    def constraints(self, x):
+        return np.asarray(self._v.eval_cons(np.asarray(x, dtype=float)), dtype=float)
+
+    def jacobianstructure(self):
+        return self._jac_rows, self._jac_cols
+
+    def jacobian(self, x):
+        return np.asarray(self._v.eval_jac(np.asarray(x, dtype=float)), dtype=float)
+
+
+class _GmoProblemObjHess(_GmoProblemObj):
+    """:class:`_GmoProblemObj` plus the analytical Hessian of the Lagrangian."""
+
+    def __init__(self, view: GmoView, obj_sign: float):
+        super().__init__(view, obj_sign)
+        hr, hc = view.hess_structure()
+        self._hess_rows = np.asarray(hr, dtype=np.int64)
+        self._hess_cols = np.asarray(hc, dtype=np.int64)
+
+    def hessianstructure(self):
+        return self._hess_rows, self._hess_cols
+
+    def hessian(self, x, lagrange, obj_factor):
+        # gmoHessLagValue computes  objweight * d2f + conweight * sum_i pi_i d2c_i.
+        # objweight = obj_sign*obj_factor (negate objective Hessian for max);
+        # conweight = -1.0 absorbs the GAMS pi = -lambda sign flip, so the
+        # standard cyipopt `lagrange` is passed straight through.
+        vals = self._v.hess_lag_value(
+            np.asarray(x, dtype=float),
+            np.asarray(lagrange, dtype=float),
+            self._sign * float(obj_factor),
+            -1.0,
+        )
+        return np.asarray(vals, dtype=float)
+
+
+def problem_from_gmo(view: GmoView) -> GmoProblem:
+    """Translate a :class:`GmoView` into a :class:`GmoProblem`.
+
+    The returned ``problem_obj`` exposes ``hessianstructure`` / ``hessian`` only
+    when ``view.has_hessian()`` is true; otherwise those callbacks are absent so
+    POUNCE falls back to a limited-memory (L-BFGS) Hessian approximation,
+    exactly as the C link does.
+    """
+    n = int(view.num_vars())
+    m = int(view.num_cons())
+    obj_sign = -1.0 if view.maximize() else 1.0
+
+    lb = [float(v) for v in view.var_lower()]
+    ub = [float(v) for v in view.var_upper()]
+    cl = [float(v) for v in view.con_lower()] if m else []
+    cu = [float(v) for v in view.con_upper()] if m else []
+    x0 = np.asarray(view.var_init(), dtype=float)
+
+    has_hess = bool(view.has_hessian())
+    obj = (
+        _GmoProblemObjHess(view, obj_sign)
+        if has_hess
+        else _GmoProblemObj(view, obj_sign)
+    )
+
+    return GmoProblem(
+        problem_obj=obj,
+        n=n,
+        m=m,
+        lb=lb,
+        ub=ub,
+        cl=cl,
+        cu=cu,
+        x0=x0,
+        has_hessian=has_hess,
+        obj_sign=obj_sign,
+    )

--- a/python/pounce/gams/link.py
+++ b/python/pounce/gams/link.py
@@ -1,0 +1,621 @@
+"""POUNCE as a GAMS solver: the control-file solver link.
+
+When GAMS solves a model with ``option nlp = pounce;`` it launches this link
+with the path to a *control file*, and expects the solution written back
+through the GAMS Modeling Object (GMO).  This module:
+
+1. boots the GAMS environment (GEV) and model (GMO) objects from that control
+   file (:func:`solve_from_control_file`),
+2. translates the GMO instance into a POUNCE problem object
+   (:mod:`pounce.gams.gmo_translate`),
+3. solves it with :class:`pounce.Problem`, and
+4. writes the primal/dual solution and the GAMS model/solve status back.
+
+The GAMS-library calls live entirely in :class:`_GmoAdapter` /
+:func:`solve_from_control_file`; the rest (status mapping, option parsing, the
+solve wrapper :func:`solve_view`) is plain Python and unit-tested without a GAMS
+installation.
+
+This is the pure-Python, pip-installable counterpart to the native C link in
+``gams/gams_pounce.c``.  It uses GAMS's own ``gamsapi`` package (the ``[gams]``
+extra) and redistributes nothing GAMS-owned; the bindings ``dlopen`` the user's
+GAMS libraries, so their versions must match.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from .gmo_translate import POUNCE_INF, problem_from_gmo
+
+if TYPE_CHECKING:
+    from .gmo_translate import GmoProblem, GmoView
+
+# ── GAMS status constants (gmomcc) ───────────────────────────────────────────
+MODELSTAT_OPTIMAL = 1
+MODELSTAT_LOCALLY_OPTIMAL = 2
+MODELSTAT_UNBOUNDED = 3
+MODELSTAT_INFEASIBLE_LOCAL = 5
+MODELSTAT_INFEASIBLE_INTERMED = 6
+MODELSTAT_FEASIBLE = 7  # intermediate non-optimal, feasible point available
+MODELSTAT_ERROR_NO_SOLUTION = 13
+MODELSTAT_NO_SOLUTION_RETURNED = 14
+
+SOLVESTAT_NORMAL = 1
+SOLVESTAT_ITERATION = 2
+SOLVESTAT_RESOURCE = 3  # time / resource interrupt
+SOLVESTAT_USER = 8
+SOLVESTAT_SETUP_ERR = 9
+SOLVESTAT_SOLVER_ERR = 10
+SOLVESTAT_EVAL_ERR = 11
+SOLVESTAT_INTERNAL_ERR = 12
+
+# POUNCE (== Ipopt 3.14) ApplicationReturnStatus names -> (modelStat, solveStat).
+# Ported verbatim from map_status_to_gams() in gams/gams_pounce.c so the two
+# links report identically.  `status_msg` from POUNCE is the enum *name*.
+_STATUS_MAP: dict[str, tuple[int, int]] = {
+    "Solve_Succeeded": (MODELSTAT_LOCALLY_OPTIMAL, SOLVESTAT_NORMAL),
+    "Solved_To_Acceptable_Level": (MODELSTAT_FEASIBLE, SOLVESTAT_NORMAL),
+    "Feasible_Point_Found": (MODELSTAT_FEASIBLE, SOLVESTAT_NORMAL),
+    "Infeasible_Problem_Detected": (MODELSTAT_INFEASIBLE_LOCAL, SOLVESTAT_SOLVER_ERR),
+    "Search_Direction_Becomes_Too_Small": (MODELSTAT_FEASIBLE, SOLVESTAT_SOLVER_ERR),
+    "Diverging_Iterates": (MODELSTAT_UNBOUNDED, SOLVESTAT_SOLVER_ERR),
+    "User_Requested_Stop": (MODELSTAT_FEASIBLE, SOLVESTAT_USER),
+    "Maximum_Iterations_Exceeded": (MODELSTAT_FEASIBLE, SOLVESTAT_ITERATION),
+    "Restoration_Failed": (MODELSTAT_INFEASIBLE_INTERMED, SOLVESTAT_SOLVER_ERR),
+    "Error_In_Step_Computation": (MODELSTAT_FEASIBLE, SOLVESTAT_SOLVER_ERR),
+    "Maximum_CpuTime_Exceeded": (MODELSTAT_FEASIBLE, SOLVESTAT_RESOURCE),
+    "Maximum_WallTime_Exceeded": (MODELSTAT_FEASIBLE, SOLVESTAT_RESOURCE),
+    "Not_Enough_Degrees_Of_Freedom": (MODELSTAT_ERROR_NO_SOLUTION, SOLVESTAT_SETUP_ERR),
+    "Invalid_Problem_Definition": (MODELSTAT_ERROR_NO_SOLUTION, SOLVESTAT_SETUP_ERR),
+    "Invalid_Option": (MODELSTAT_ERROR_NO_SOLUTION, SOLVESTAT_SETUP_ERR),
+    "Invalid_Number_Detected": (MODELSTAT_INFEASIBLE_INTERMED, SOLVESTAT_EVAL_ERR),
+    "Internal_Error": (MODELSTAT_ERROR_NO_SOLUTION, SOLVESTAT_INTERNAL_ERR),
+}
+
+# Statuses that still leave a usable primal iterate in `x` (mirrors
+# pounce_status_has_solution() in the C link).
+_STATUS_HAS_SOLUTION = frozenset(
+    {
+        "Solve_Succeeded",
+        "Solved_To_Acceptable_Level",
+        "Feasible_Point_Found",
+        "Infeasible_Problem_Detected",
+        "Search_Direction_Becomes_Too_Small",
+        "User_Requested_Stop",
+        "Maximum_Iterations_Exceeded",
+        "Error_In_Step_Computation",
+        "Maximum_CpuTime_Exceeded",
+        "Maximum_WallTime_Exceeded",
+    }
+)
+
+# Option-file keys handled by the link itself rather than forwarded to POUNCE,
+# matching the GAMS-link-specific keys in gams_pounce.c.
+_LINK_OPTION_KEYS = frozenset({"sqp_state_file", "json_output", "json_detail"})
+
+
+def is_available() -> bool:
+    """Return ``True`` if the GAMS expert-level Python API (gamsapi) is present."""
+    try:  # pragma: no cover - depends on optional gamsapi
+        import gams.core.gev  # noqa: F401
+        import gams.core.gmo  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+def status_to_gams(status_msg: str) -> tuple[int, int]:
+    """Map a POUNCE ``status_msg`` (ApplicationReturnStatus name) to GAMS.
+
+    Returns ``(modelStat, solveStat)``.  Unknown statuses map to the generic
+    error pair, matching the ``default`` arm of the C link's switch.
+    """
+    return _STATUS_MAP.get(
+        status_msg, (MODELSTAT_ERROR_NO_SOLUTION, SOLVESTAT_INTERNAL_ERR)
+    )
+
+
+def parse_option_file(path: str) -> tuple[dict, dict]:
+    """Parse a GAMS option file (``pounce.opt``) into POUNCE options.
+
+    Returns ``(pounce_options, link_options)``.  ``pounce_options`` maps option
+    names to int / float / str values (coerced the same way the C link does:
+    int first, then float, then string); ``link_options`` holds the
+    link-specific keys (``json_output`` etc.).  Lines beginning with ``*`` or
+    ``#`` are comments; blank lines are skipped.
+    """
+    pounce_opts: dict = {}
+    link_opts: dict = {}
+    try:
+        with open(path) as fh:
+            lines = fh.readlines()
+    except OSError:
+        return pounce_opts, link_opts
+
+    for raw in lines:
+        line = raw.strip()
+        if not line or line[0] in ("*", "#"):
+            continue
+        parts = line.split(None, 1)
+        if len(parts) < 2:
+            continue
+        key, val = parts[0], parts[1].strip()
+        if key in _LINK_OPTION_KEYS:
+            link_opts[key] = val
+            continue
+        pounce_opts[key] = _coerce(val)
+    return pounce_opts, link_opts
+
+
+def _coerce(val: str):
+    """Coerce an option string to int, else float, else leave as a string."""
+    try:
+        return int(val)
+    except ValueError:
+        pass
+    try:
+        return float(val)
+    except ValueError:
+        return val
+
+
+def solve_view(
+    view: "GmoView",
+    *,
+    options: dict | None = None,
+    max_iter: int | None = None,
+    max_wall_time: float | None = None,
+):
+    """Translate a GMO view, build a POUNCE problem, solve, return ``(prob, x, info)``.
+
+    This is the GAMS-library-free core of the link: given anything implementing
+    :class:`~pounce.gams.gmo_translate.GmoView` it produces a solved POUNCE
+    problem, so it can be exercised in tests with an in-memory fake.
+
+    ``options`` are POUNCE option name/value pairs (e.g. from a ``pounce.opt``
+    file); ``max_iter`` / ``max_wall_time`` come from the GAMS environment
+    (``gevIterLim`` / ``gevResLim``) and are applied as defaults the option file
+    can still override.
+    """
+    import pounce
+
+    gp: "GmoProblem" = problem_from_gmo(view)
+    prob = pounce.Problem(
+        n=gp.n,
+        m=gp.m,
+        problem_obj=gp.problem_obj,
+        lb=gp.lb,
+        ub=gp.ub,
+        cl=gp.cl,
+        cu=gp.cu,
+    )
+
+    # Defaults mirroring the C link, set before the option file so a user
+    # pounce.opt can override them.
+    if max_iter is not None:
+        prob.add_option("max_iter", int(max_iter))
+    if max_wall_time is not None:
+        prob.add_option("max_wall_time", float(max_wall_time))
+    # acceptable_iter=0 disables acceptable-level early termination, matching
+    # the GAMS Ipopt link default (pounce#138).
+    prob.add_option("acceptable_iter", 0)
+    if not gp.has_hessian:
+        prob.add_option("hessian_approximation", "limited-memory")
+
+    for key, value in (options or {}).items():
+        try:
+            prob.add_option(key, value)
+        except Exception as exc:  # unknown / invalid option: warn, keep going
+            sys.stderr.write(f"pounce-gams: ignoring option '{key}': {exc}\n")
+
+    x, info = prob.solve(x0=gp.x0)
+    return gp, x, info
+
+
+def solve_from_control_file(
+    control_file: str, sysdir: str | None = None
+) -> int:  # pragma: no cover - needs GAMS
+    """Entry point GAMS invokes: solve the model described by ``control_file``.
+
+    ``sysdir`` is the GAMS system directory (passed by GAMS); when omitted it is
+    discovered from the control file so the GAMS shared libraries load from the
+    right place via ``gmoCreateD`` / ``gevCreateD``.
+
+    Returns a process exit code (0 on success).
+    """
+    try:
+        import gams.core.gev as gev
+        import gams.core.gmo as gmo
+    except Exception as exc:  # gamsapi[core] not installed
+        sys.stderr.write(
+            "POUNCE GAMS link requires the GAMS expert-level Python API.\n"
+            "Install it from your GAMS system: pip install gamsapi[core]\n"
+            f"({exc})\n"
+        )
+        return 1
+
+    if not (sysdir and os.path.isdir(sysdir)):
+        sysdir = _gams_sysdir(control_file)
+
+    gev_h = gev.new_gevHandle_tp()
+    rc, msg = gev.gevCreateD(gev_h, sysdir, 256) if sysdir else gev.gevCreate(gev_h, 256)
+    if not rc:
+        sys.stderr.write(f"gevCreate failed: {msg}\n")
+        return 1
+    gev.gevInitEnvironmentLegacy(gev_h, control_file)
+
+    gmo_h = gmo.new_gmoHandle_tp()
+    rc, msg = gmo.gmoCreateD(gmo_h, sysdir, 256) if sysdir else gmo.gmoCreate(gmo_h, 256)
+    if not rc:
+        sys.stderr.write(f"gmoCreate failed: {msg}\n")
+        return 1
+    gmo.gmoRegisterEnvironment(gmo_h, gev.gevHandleToPtr(gev_h))
+    gmo.gmoLoadDataLegacy(gmo_h)
+
+    # Objective handled as a function (objective variable substituted out), with
+    # 0-based column/row indexing -- matches gams_pounce.c.
+    gmo.gmoObjStyleSet(gmo_h, gmo.gmoObjType_Fun)
+    gmo.gmoObjReformSet(gmo_h, 1)
+    gmo.gmoIndexBaseSet(gmo_h, 0)
+
+    gev.gevLogStat(gev_h, "")
+    gev.gevLogStat(gev_h, "--- POUNCE: A Rust Interior-Point Optimizer (Python link)")
+    gev.gevLogStat(gev_h, "")
+
+    # Resource/iteration limits from the GAMS environment.
+    iterlim = int(gev.gevGetIntOpt(gev_h, gev.gevIterLim))
+    reslim = float(gev.gevGetDblOpt(gev_h, gev.gevResLim))
+    max_iter = iterlim if 0 <= iterlim < 2_000_000_000 else None
+    max_wall = reslim if 0 < reslim < 1e10 else None
+
+    # Option file (pounce.opt / .op2 ...).
+    options: dict = {}
+    if gmo.gmoOptFile(gmo_h) > 0:
+        optname = gmo.gmoNameOptFile(gmo_h)
+        if isinstance(optname, (list, tuple)):  # some bindings return [rc, name]
+            optname = optname[-1]
+        gev.gevLogStat(gev_h, f"  Reading option file {optname}")
+        options, _link_opts = parse_option_file(str(optname))
+
+    view = _GmoAdapter(gmo_h, gmo)
+    _gp, x, info = solve_view(
+        view, options=options, max_iter=max_iter, max_wall_time=max_wall
+    )
+
+    gev.gevLogStat(gev_h, f"POUNCE status: {info.get('status_msg')}")
+
+    # GAMS requires the solver to open/finalize a status file via GEV; otherwise
+    # it reports solveStat=13 regardless of the GMO solution we unload.
+    gev.gevStatCon(gev_h)
+    _write_solution(gmo_h, gmo, view, x, info)
+    gev.gevStatEOF(gev_h)
+    return 0
+
+
+def _write_solution(gmo_h, gmo, view, x, info) -> None:  # pragma: no cover - needs GAMS
+    """Write primal/dual solution and GAMS model/solve status back into GMO."""
+    status_msg = str(info.get("status_msg", ""))
+    obj_sign = -1.0 if view.maximize() else 1.0
+    model_stat, solve_stat = status_to_gams(status_msg)
+    gmo.gmoModelStatSet(gmo_h, model_stat)
+    gmo.gmoSolveStatSet(gmo_h, solve_stat)
+
+    if status_msg in _STATUS_HAS_SOLUTION and x is not None:
+        # Objective in GAMS convention (undo our sign flip for max).
+        obj_val = float(info.get("obj_val", 0.0))
+        gmo.gmoSetHeadnTail(gmo_h, gmo.gmoHobjval, obj_sign * obj_val)
+
+    iters = info.get("iter_count")
+    if iters is not None:
+        gmo.gmoSetHeadnTail(gmo_h, gmo.gmoHiterused, float(iters))
+
+    m = int(view.num_cons())
+    # Constraint multipliers: POUNCE lambda -> GAMS pi (negate).
+    mult_g = info.get("mult_g")
+    pi = None
+    if m and mult_g is not None:
+        pi = _to_double_array(gmo, -np.asarray(mult_g, dtype=float))
+
+    if x is not None:
+        gmo.gmoSetSolution2(gmo_h, _to_double_array(gmo, x), pi)
+
+    # Variable marginals: z_L - z_U, negated for max (matches gams_pounce.c).
+    mult_xl = info.get("mult_x_L")
+    mult_xu = info.get("mult_x_U")
+    if mult_xl is not None and mult_xu is not None:
+        var_marg = np.asarray(mult_xl, dtype=float) - np.asarray(mult_xu, dtype=float)
+        if obj_sign < 0.0:
+            var_marg = -var_marg
+        gmo.gmoSetVarM(gmo_h, _to_double_array(gmo, var_marg))
+
+    gmo.gmoUnloadSolutionLegacy(gmo_h)
+
+
+class _GmoAdapter:  # pragma: no cover - thin wrapper over gamsapi calls
+    """Adapt a gamsapi GMO handle to the :class:`GmoView` protocol.
+
+    Isolates the version-specific GMO calling convention.  Index base is set to
+    0 by the caller, so column/row indices are 0-based.  GMO's vector getters
+    fill preallocated SWIG ``intArray`` / ``doubleArray`` buffers; the dense
+    evaluators (``gmoEvalGradObj`` / ``gmoEvalGrad``) likewise write into a
+    preallocated dense buffer, from which we pull the structural nonzeros.
+
+    The GMO call sequence and sign conventions are cross-checked against the
+    working C link in ``gams/gams_pounce.c``.
+    """
+
+    def __init__(self, gmo_h, gmo):
+        self._h = gmo_h
+        self._gmo = gmo
+        self._n = int(gmo.gmoN(gmo_h))
+        self._m = int(gmo.gmoM(gmo_h))
+        self._nz = int(gmo.gmoNZ(gmo_h))
+
+        # Hessian-of-Lagrangian availability. gmoHessLoad(h, maxJacRatio,
+        # do2dir_req, doHess_req) requests the structures; we ask for the
+        # Lagrangian Hessian only (do2dir=0, doHess=1) and call it exactly ONCE
+        # -- re-loading clears the structure that gmoHessLagStruct / -Value
+        # then read.  Availability is gmoHessLagNz() > 0.
+        gmo.gmoHessLoad(gmo_h, 0.0, 0, 1)
+        self._nnz_hess = int(gmo.gmoHessLagNz(gmo_h))
+        self._has_hess = self._nnz_hess > 0
+
+        # Jacobian structure (CSR from GMO) -> 0-based COO, cached.
+        self._jac_rows, self._jac_cols, self._row_has_nl, self._jac_lin = (
+            self._load_jacobian_structure()
+        )
+        # Scratch dense gradient buffer reused across evaluations.
+        self._grad_buf = gmo.doubleArray(self._n)
+
+    # --- dimensions / sense ----------------------------------------------
+    def name(self) -> str:
+        try:
+            return str(self._gmo.gmoNameModel(self._h))
+        except Exception:
+            return "gams_model"
+
+    def num_vars(self) -> int:
+        return self._n
+
+    def num_cons(self) -> int:
+        return self._m
+
+    def maximize(self) -> bool:
+        return bool(self._gmo.gmoSense(self._h) == self._gmo.gmoObj_Max)
+
+    def has_hessian(self) -> bool:
+        return self._has_hess
+
+    # --- bounds / initial point ------------------------------------------
+    def var_lower(self):
+        return self._mapped_bounds(self._gmo.gmoGetVarLower, lower=True)
+
+    def var_upper(self):
+        return self._mapped_bounds(self._gmo.gmoGetVarUpper, lower=False)
+
+    def var_init(self):
+        buf = self._gmo.doubleArray(self._n)
+        self._gmo.gmoGetVarL(self._h, buf)
+        return [float(buf[j]) for j in range(self._n)]
+
+    def con_lower(self):
+        return [b[0] for b in self._con_bounds()]
+
+    def con_upper(self):
+        return [b[1] for b in self._con_bounds()]
+
+    def _con_bounds(self):
+        gmo = self._gmo
+        out = []
+        for i in range(self._m):
+            etyp = gmo.gmoGetEquTypeOne(self._h, i)
+            rhs = float(gmo.gmoGetRhsOne(self._h, i))
+            if etyp == gmo.gmoequ_E:
+                out.append((rhs, rhs))
+            elif etyp == gmo.gmoequ_G:
+                out.append((rhs, POUNCE_INF))
+            elif etyp == gmo.gmoequ_L:
+                out.append((-POUNCE_INF, rhs))
+            else:  # gmoequ_N (free) or unsupported -> free row
+                out.append((-POUNCE_INF, POUNCE_INF))
+        return out
+
+    def _mapped_bounds(self, getter, lower: bool):
+        gmo = self._gmo
+        buf = gmo.doubleArray(self._n)
+        getter(self._h, buf)
+        pinf = float(gmo.gmoPinf(self._h))
+        minf = float(gmo.gmoMinf(self._h))
+        out = []
+        for j in range(self._n):
+            v = float(buf[j])
+            if lower and v <= minf:
+                v = -POUNCE_INF
+            elif (not lower) and v >= pinf:
+                v = POUNCE_INF
+            out.append(v)
+        return out
+
+    # --- structure -------------------------------------------------------
+    def jac_structure(self):
+        return self._jac_rows, self._jac_cols
+
+    def hess_structure(self):
+        gmo = self._gmo
+        irow = gmo.intArray(self._nnz_hess)
+        jcol = gmo.intArray(self._nnz_hess)
+        gmo.gmoHessLagStruct(self._h, irow, jcol)
+        rows = [int(irow[k]) for k in range(self._nnz_hess)]
+        cols = [int(jcol[k]) for k in range(self._nnz_hess)]
+        return rows, cols
+
+    def _load_jacobian_structure(self):
+        """Read the CSR Jacobian structure into 0-based COO arrays.
+
+        Also caches, per nonzero, whether it is linear (constant coefficient)
+        and the coefficient value, so :meth:`eval_jac` can copy linear-row
+        values without an evaluator call -- matching the C link.
+        """
+        gmo, m, nz = self._gmo, self._m, self._nz
+        if m == 0 or nz == 0:
+            return [], [], [], []
+        rowstart = gmo.intArray(m + 1)
+        colidx = gmo.intArray(nz)
+        values = gmo.doubleArray(nz)
+        nlflag = gmo.intArray(nz)
+        gmo.gmoGetMatrixRow(self._h, rowstart, colidx, values, nlflag)
+
+        rows, cols, lin = [], [], []
+        row_has_nl = [False] * m
+        for i in range(m):
+            for k in range(int(rowstart[i]), int(rowstart[i + 1])):
+                rows.append(i)
+                cols.append(int(colidx[k]))
+                if int(nlflag[k]) != 0:
+                    row_has_nl[i] = True
+                    lin.append(None)  # filled by evaluator
+                else:
+                    lin.append(float(values[k]))
+        return rows, cols, row_has_nl, lin
+
+    # --- numerical evaluators (native sense) -----------------------------
+    def eval_obj(self, x):
+        ret = self._gmo.gmoEvalFuncObj(self._h, _to_double_array(self._gmo, x))
+        # bindings return either fval or [rc, fval, numerr]; take the value.
+        if isinstance(ret, (list, tuple)):
+            return float(ret[1])
+        return float(ret)
+
+    def eval_grad_obj(self, x):
+        gmo = self._gmo
+        grad = gmo.doubleArray(self._n)
+        gmo.gmoEvalGradObj(self._h, _to_double_array(gmo, x), grad)
+        return [float(grad[j]) for j in range(self._n)]
+
+    def eval_cons(self, x):
+        gmo = self._gmo
+        xa = _to_double_array(gmo, x)
+        out = []
+        for i in range(self._m):
+            ret = gmo.gmoEvalFunc(self._h, i, xa)
+            out.append(float(ret[1] if isinstance(ret, (list, tuple)) else ret))
+        return out
+
+    def eval_jac(self, x):
+        gmo = self._gmo
+        xa = _to_double_array(gmo, x)
+        vals = [0.0] * len(self._jac_rows)
+        # Walk per row, reusing the dense grad buffer for nonlinear rows.
+        k = 0
+        nrows = len(self._jac_rows)
+        while k < nrows:
+            i = self._jac_rows[k]
+            # span of row i in the COO arrays (rows are contiguous & sorted)
+            start = k
+            while k < nrows and self._jac_rows[k] == i:
+                k += 1
+            end = k
+            if not self._row_has_nl[i]:
+                for t in range(start, end):
+                    vals[t] = self._jac_lin[t]
+                continue
+            gmo.gmoEvalGrad(self._h, i, xa, self._grad_buf)
+            for t in range(start, end):
+                vals[t] = float(self._grad_buf[self._jac_cols[t]])
+        return vals
+
+    def hess_lag_value(self, x, lam, obj_weight, con_weight):
+        gmo = self._gmo
+        vals = gmo.doubleArray(self._nnz_hess)
+        gmo.gmoHessLagValue(
+            self._h,
+            _to_double_array(gmo, x),
+            _to_double_array(gmo, lam),
+            vals,
+            float(obj_weight),
+            float(con_weight),
+        )
+        return [float(vals[k]) for k in range(self._nnz_hess)]
+
+
+def _to_double_array(gmo, x):  # pragma: no cover - needs gamsapi
+    """Copy a numpy/list vector into a fresh SWIG ``doubleArray``."""
+    xa = np.asarray(x, dtype=float)
+    buf = gmo.doubleArray(len(xa))
+    for j in range(len(xa)):
+        buf[j] = float(xa[j])
+    return buf
+
+
+def _gams_sysdir(control_file: str) -> str | None:
+    """Best-effort discovery of the GAMS system directory from a control file."""
+    try:
+        with open(control_file) as fh:
+            lines = [ln.strip() for ln in fh]
+    except OSError:
+        return None
+    for ln in lines:
+        for tok in ln.split():
+            if os.path.basename(tok) in ("gmscmpun.txt", "gmscmpdef.txt") and os.path.isfile(tok):
+                return os.path.dirname(tok)
+    for ln in lines:
+        if os.path.isdir(ln) and os.path.isfile(os.path.join(ln, "gmscmpun.txt")):
+            return ln
+    return None
+
+
+def _parse_gams_args(args: list[str]) -> tuple[str | None, str | None]:
+    """Resolve ``(control_file, sysdir)`` from a solver script's arguments.
+
+    GAMS's classic script-solver interface passes six arguments -- ``<scrdir>
+    <workdir> <prmfile> <cntrfile> <sysdir> <solvername>`` -- so we resolve the
+    control file and system directory by *content* (the ``gamscntr*`` file vs.
+    the directory containing ``gmscmpun.txt``).  This is robust to convention
+    drift and also works when invoked directly with a single control-file path.
+    """
+    files = [tok for tok in args if os.path.isfile(tok)]
+    control_file = next(
+        (tok for tok in files if os.path.basename(tok).startswith("gamscntr")), None
+    )
+    if control_file is None:
+        control_file = next((tok for tok in files if tok.endswith(".dat")), None)
+    if control_file is None:
+        control_file = files[0] if files else None
+
+    sysdir = next(
+        (
+            tok
+            for tok in args
+            if os.path.isdir(tok) and os.path.isfile(os.path.join(tok, "gmscmpun.txt"))
+        ),
+        None,
+    )
+    return control_file, sysdir
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Console entry point: the GAMS solver link.
+
+    Accepts either a single control-file path (direct invocation) or the full
+    GAMS script-solver argument list.
+    """
+    args = sys.argv[1:] if argv is None else argv
+    if not args or args[0] in ("-h", "--help"):
+        sys.stderr.write("usage: pounce-gams-link <gams-control-file>\n")
+        return 0 if args else 1
+
+    control_file, sysdir = _parse_gams_args(args)
+    if control_file is None:
+        sys.stderr.write(f"pounce-gams-link: no control file found in arguments: {args}\n")
+        return 1
+    return solve_from_control_file(control_file, sysdir)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/python/pounce/gams/register.py
+++ b/python/pounce/gams/register.py
@@ -1,0 +1,243 @@
+"""Register POUNCE as a solver with a GAMS system.
+
+A third-party solver is made known to GAMS through the ``solverConfig`` section
+of ``gamsconfig.yaml`` (the modern mechanism; the legacy equivalent is an entry
+in ``gmscmpun.txt``).  GAMS invokes the configured ``scriptName`` with the path
+to a control file; that launcher just runs the POUNCE link
+(:mod:`pounce.gams.link`).  No sudo, no system-directory writes, and the
+registration survives GAMS upgrades.
+
+* :func:`gamsconfig_snippet` returns the YAML block for POUNCE alone.
+* :func:`render_gamsconfig` merges that block into an existing
+  ``gamsconfig.yaml``, preserving any other solvers and top-level keys.
+* :func:`run_script` returns the launcher (POSIX ``sh`` or Windows ``.cmd``).
+* :func:`write_registration` writes the launcher + merged config into the GAMS
+  user config directory.
+* :func:`gams_user_config_dir` locates that directory.
+* :func:`check_gamsapi` diagnoses gamsapi importability.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import sys
+from pathlib import Path
+
+SOLVER_NAME = "pounce"
+# GAMS model types POUNCE can solve. POUNCE is a continuous local NLP solver,
+# so this matches the C link's gmscmpun.txt registration -- NOT MINLP/MIP.
+MODEL_TYPES = ("NLP", "DNLP", "RMINLP")
+
+
+def gamsconfig_snippet(script_path: str | Path = "pounce-gams-link") -> str:
+    """Return the ``gamsconfig.yaml`` ``solverConfig`` block for POUNCE.
+
+    Follows the GAMS ``gamsconfig_schema.json`` solver schema: each entry maps
+    the *solver name* to its config object with ``scriptName`` + ``modelTypes``.
+    POUNCE is a control-file *script* solver, so no ``library`` block is emitted
+    (GAMS invokes ``scriptName`` with the control file).
+    """
+    model_types = "\n".join(f"        - {t}" for t in MODEL_TYPES)
+    return f"""\
+solverConfig:
+  - {SOLVER_NAME}:
+      scriptName: {script_path}
+      modelTypes:
+{model_types}
+"""
+
+
+def _pounce_solver_entry(script_path: str) -> dict:
+    """The POUNCE ``solverConfig`` entry as a Python object (for YAML merge)."""
+    return {
+        SOLVER_NAME: {
+            "scriptName": script_path,
+            "modelTypes": list(MODEL_TYPES),
+        }
+    }
+
+
+def render_gamsconfig(existing: str | None, script_path: str | Path) -> tuple[str, str]:
+    """Merge a POUNCE ``solverConfig`` entry into an existing config.
+
+    ``existing`` is the current ``gamsconfig.yaml`` text (or ``None`` / empty for
+    a fresh file).  Returns ``(text, action)`` where ``action`` is one of
+    ``"created"`` (no prior file), ``"merged"`` (POUNCE added alongside other
+    solvers), or ``"replaced"`` (a prior POUNCE entry was updated in place).
+
+    Other solvers and unrelated top-level keys are preserved.  Falls back to a
+    plain appended snippet when PyYAML is unavailable.
+    """
+    script_path = str(script_path)
+    entry = _pounce_solver_entry(script_path)
+
+    if not existing or not existing.strip():
+        return gamsconfig_snippet(script_path), "created"
+
+    try:
+        import yaml
+    except Exception:
+        # No PyYAML: append the snippet and report it as a merge. The user may
+        # need to hand-resolve a duplicate solverConfig key.
+        return existing.rstrip() + "\n\n" + gamsconfig_snippet(script_path), "merged"
+
+    data = yaml.safe_load(existing)
+    if not isinstance(data, dict):
+        data = {}
+
+    solver_cfg = data.get("solverConfig")
+    if not isinstance(solver_cfg, list):
+        solver_cfg = []
+
+    action = "merged"
+    replaced = False
+    for i, item in enumerate(solver_cfg):
+        if isinstance(item, dict) and SOLVER_NAME in item:
+            solver_cfg[i] = entry
+            replaced = True
+            action = "replaced"
+            break
+    if not replaced:
+        solver_cfg.append(entry)
+    data["solverConfig"] = solver_cfg
+
+    text = yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+    return text, action
+
+
+def run_script(python_executable: str | None = None, *, windows: bool | None = None) -> str:
+    """Return the launcher that runs the POUNCE GAMS link.
+
+    GAMS calls it with the control-file path as ``$1`` (POSIX) or ``%*``
+    (Windows).  ``windows`` defaults to the current platform.
+    """
+    py = python_executable or sys.executable
+    if windows is None:
+        windows = os.name == "nt"
+    # Invoke via `-c` import rather than `-m pounce.gams.link`: running the
+    # module as __main__ after the package has already imported it triggers a
+    # benign-but-noisy runpy RuntimeWarning, which would otherwise show up in
+    # the GAMS log on every solve.
+    run = "from pounce.gams.link import main; import sys; sys.exit(main())"
+    if windows:
+        return f'@echo off\r\n"{py}" -c "{run}" %*\r\n'
+    return f"""\
+#!/bin/sh
+# POUNCE GAMS solver link -- invoked by GAMS as: <script> <control-file>
+exec "{py}" -c "{run}" "$@"
+"""
+
+
+def gams_user_config_dir() -> Path:
+    """Return the GAMS per-user config directory (created on demand by callers).
+
+    These are the per-user locations GAMS searches for ``gamsconfig.yaml``
+    (verified with ``gamsinst -listdirs``; see the GAMS "Standard Locations"
+    docs).  The path is OS-specific and NOT the XDG default on macOS:
+
+    * Windows: ``%LOCALAPPDATA%/GAMS`` (else ``%USERPROFILE%/Documents/GAMS``)
+    * macOS:   ``$HOME/Library/Preferences/GAMS``
+    * Linux:   ``$XDG_CONFIG_HOME/GAMS`` (else ``~/.config/GAMS``)
+    """
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / "GAMS"
+        home = os.environ.get("USERPROFILE") or str(Path.home())
+        return Path(home) / "Documents" / "GAMS"
+    if sys.platform == "darwin":
+        # macOS does NOT use XDG; GAMS searches ~/Library/Preferences/GAMS.
+        return Path.home() / "Library" / "Preferences" / "GAMS"
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".config"
+    return base / "GAMS"
+
+
+def write_registration(directory: str | Path | None = None) -> dict[str, object]:
+    """Write the launcher and a merged ``gamsconfig.yaml``.
+
+    Writes into ``directory`` (defaults to :func:`gams_user_config_dir`).  An
+    existing ``gamsconfig.yaml`` is merged in place (other solvers preserved).
+    Returns ``{"config": Path, "script": Path, "action": str, "config_dir": Path}``.
+    """
+    out = Path(directory) if directory is not None else gams_user_config_dir()
+    out.mkdir(parents=True, exist_ok=True)
+
+    windows = os.name == "nt"
+    script = out / ("pounce-gams-link.cmd" if windows else "pounce-gams-link")
+    script.write_text(run_script(windows=windows))
+    if not windows:
+        script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    config = out / "gamsconfig.yaml"
+    existing = config.read_text() if config.exists() else None
+    text, action = render_gamsconfig(existing, script_path=str(script))
+    config.write_text(text)
+
+    return {"config": config, "script": script, "action": action, "config_dir": out}
+
+
+def unregister(directory: str | Path | None = None) -> dict[str, object]:
+    """Remove POUNCE from ``gamsconfig.yaml`` and delete the launcher.
+
+    Returns ``{"config": Path, "removed": bool, "config_dir": Path}``.  Other
+    solvers in the config are preserved.  Requires PyYAML for a clean removal;
+    without it, only the launcher is deleted and ``removed`` is ``False``.
+    """
+    out = Path(directory) if directory is not None else gams_user_config_dir()
+    config = out / "gamsconfig.yaml"
+    removed = False
+
+    if config.exists():
+        try:
+            import yaml
+
+            data = yaml.safe_load(config.read_text())
+            if isinstance(data, dict) and isinstance(data.get("solverConfig"), list):
+                kept = [
+                    item
+                    for item in data["solverConfig"]
+                    if not (isinstance(item, dict) and SOLVER_NAME in item)
+                ]
+                removed = len(kept) != len(data["solverConfig"])
+                if kept:
+                    data["solverConfig"] = kept
+                else:
+                    data.pop("solverConfig", None)
+                config.write_text(
+                    yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+                )
+        except Exception:
+            removed = False
+
+    for name in ("pounce-gams-link", "pounce-gams-link.cmd"):
+        launcher = out / name
+        if launcher.exists():
+            launcher.unlink()
+
+    return {"config": config, "removed": removed, "config_dir": out}
+
+
+def check_gamsapi() -> dict[str, object]:
+    """Diagnose whether the GAMS expert-level Python API (gamsapi) is usable.
+
+    Returns ``{"available": bool, "detail": str}``.  ``available`` is true only
+    when both ``gams.core.gmo`` and ``gams.core.gev`` import (the bindings
+    ``dlopen`` the user's GAMS libraries, so an import failure usually means a
+    missing or version-mismatched ``gamsapi``/GAMS install).
+    """
+    try:
+        import gams  # noqa: F401
+        import gams.core.gev  # noqa: F401
+        import gams.core.gmo  # noqa: F401
+    except Exception as exc:
+        return {
+            "available": False,
+            "detail": (
+                f"gamsapi not importable ({exc}). Install it from your GAMS "
+                "system, matched to your GAMS version: pip install gamsapi[core]"
+            ),
+        }
+    version = getattr(__import__("gams"), "__version__", "unknown")
+    return {"available": True, "detail": f"gamsapi {version} importable"}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -37,6 +37,11 @@ pounce = "pounce._cli:main"
 # Interactive viewer for the debugger's `viz`/`save` artifacts. Point the
 # debugger at it with: export POUNCE_DBG_VIEWER='pounce-dbg-viz {}'
 pounce-dbg-viz = "pounce._debug_viz:main"
+# GAMS solver-link registration (the `[gams]` extra). `pounce-gams register`
+# writes/merges a gamsconfig.yaml entry so GAMS can `option nlp = pounce;`.
+# `pounce-gams-link` is the launcher GAMS invokes with a control file.
+pounce-gams = "pounce._gams_cli:main"
+pounce-gams-link = "pounce.gams.link:main"
 
 [project.optional-dependencies]
 jax = ["jax>=0.4.30", "jaxlib>=0.4.30"]
@@ -52,7 +57,13 @@ scipy = ["scipy>=1.11"]
 # (pounce#91); the inverse_map_rhs helper itself depends only on jax.
 diffrax = ["diffrax>=0.5"]
 viz = ["plotly>=5"]
-dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30", "torch>=2.2", "plotly>=5"]
+# GAMS solver link. `gamsapi[core]` is GAMS's own expert-level GMO/GEV Python
+# API (on PyPI); its bindings dlopen the user's GAMS C libraries, so pin it to
+# match the installed GAMS (`pounce-gams status` diagnoses a mismatch). PyYAML
+# is used to merge POUNCE into an existing gamsconfig.yaml without clobbering
+# other solvers.
+gams = ["gamsapi[core]>=45", "pyyaml>=6"]
+dev = ["pytest>=7", "scipy>=1.11", "jax>=0.4.30", "jaxlib>=0.4.30", "torch>=2.2", "plotly>=5", "pyyaml>=6"]
 
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -1,0 +1,391 @@
+"""License-free tests for the pure-Python GAMS solver link.
+
+These exercise the whole translate -> build -> solve path through an in-memory
+fake :class:`~pounce.gams.gmo_translate.GmoView` (no GAMS / gamsapi needed), the
+POUNCE-status -> GAMS-status mapping, the sign conventions, and the
+``gamsconfig.yaml`` create/merge/replace logic.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pounce.gams import (
+    link,
+    register,
+)
+from pounce.gams.gmo_translate import POUNCE_INF, problem_from_gmo
+
+
+class HS071View:
+    """In-memory fake of a GMO view for the classic HS071 NLP.
+
+    minimize  x0*x3*(x0+x1+x2) + x2
+    s.t.      x0*x1*x2*x3 >= 25
+              x0^2+x1^2+x2^2+x3^2 == 40
+              1 <= xi <= 5
+    Known optimum: f* ~= 17.0140173 at (1, 4.743, 3.821, 1.379).
+
+    ``maximize`` and ``with_hessian`` are constructor knobs so the same fake
+    drives the minimize/L-BFGS path and the analytical-Hessian / sign-flip
+    tests.
+    """
+
+    def __init__(self, maximize: bool = False, with_hessian: bool = False):
+        self._max = maximize
+        self._hess = with_hessian
+
+    def name(self):
+        return "hs071"
+
+    def num_vars(self):
+        return 4
+
+    def num_cons(self):
+        return 2
+
+    def maximize(self):
+        return self._max
+
+    def has_hessian(self):
+        return self._hess
+
+    def var_lower(self):
+        return [1.0, 1.0, 1.0, 1.0]
+
+    def var_upper(self):
+        return [5.0, 5.0, 5.0, 5.0]
+
+    def var_init(self):
+        return [1.0, 5.0, 5.0, 1.0]
+
+    def con_lower(self):
+        return [25.0, 40.0]
+
+    def con_upper(self):
+        return [POUNCE_INF, 40.0]
+
+    def jac_structure(self):
+        rows = [0, 0, 0, 0, 1, 1, 1, 1]
+        cols = [0, 1, 2, 3, 0, 1, 2, 3]
+        return rows, cols
+
+    def hess_structure(self):
+        # Dense lower triangle of the 4x4 Hessian (cyipopt HS071 layout).
+        rows = [0, 1, 1, 2, 2, 2, 3, 3, 3, 3]
+        cols = [0, 0, 1, 0, 1, 2, 0, 1, 2, 3]
+        return rows, cols
+
+    # --- evaluators (native minimize sense) ------------------------------
+    def eval_obj(self, x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def eval_grad_obj(self, x):
+        return [
+            x[3] * (2 * x[0] + x[1] + x[2]),
+            x[0] * x[3],
+            x[0] * x[3] + 1.0,
+            x[0] * (x[0] + x[1] + x[2]),
+        ]
+
+    def eval_cons(self, x):
+        return [
+            x[0] * x[1] * x[2] * x[3],
+            x[0] ** 2 + x[1] ** 2 + x[2] ** 2 + x[3] ** 2,
+        ]
+
+    def eval_jac(self, x):
+        return [
+            x[1] * x[2] * x[3], x[0] * x[2] * x[3], x[0] * x[1] * x[3], x[0] * x[1] * x[2],
+            2 * x[0], 2 * x[1], 2 * x[2], 2 * x[3],
+        ]
+
+    def hess_lag_value(self, x, lam, obj_weight, con_weight):
+        # True Lagrangian Hessian (lower triangle), emulating GMO:
+        #   obj_weight * d2f + con_weight * sum_i lam_i * d2c_i
+        hf = [
+            2 * x[3],                       # (0,0)
+            x[3],                           # (1,0)
+            0.0,                            # (1,1)
+            x[3],                           # (2,0)
+            0.0,                            # (2,1)
+            0.0,                            # (2,2)
+            2 * x[0] + x[1] + x[2],         # (3,0)
+            x[0],                           # (3,1)
+            x[0],                           # (3,2)
+            0.0,                            # (3,3)
+        ]
+        hc0 = [
+            0.0,
+            x[2] * x[3],
+            0.0,
+            x[1] * x[3],
+            x[0] * x[3],
+            0.0,
+            x[1] * x[2],
+            x[0] * x[2],
+            x[0] * x[1],
+            0.0,
+        ]
+        hc1 = [2.0, 0, 0, 0, 0, 2.0, 0, 0, 0, 2.0]
+        return [
+            obj_weight * hf[k] + con_weight * (lam[0] * hc0[k] + lam[1] * hc1[k])
+            for k in range(10)
+        ]
+
+
+HS071_OPT = 17.0140173
+
+# Statuses that mean POUNCE converged to a usable local solution. Whether the
+# IPM parks at "acceptable" vs full "optimal" is a solver-tuning detail (and is
+# version-sensitive); the link's job is only to translate / solve / report.
+_CONVERGED = {"Solve_Succeeded", "Solved_To_Acceptable_Level"}
+
+
+# ── translate / solve ────────────────────────────────────────────────────────
+
+
+def test_problem_from_gmo_dimensions_and_bounds():
+    gp = problem_from_gmo(HS071View())
+    assert gp.n == 4
+    assert gp.m == 2
+    assert gp.lb == [1.0] * 4
+    assert gp.ub == [5.0] * 4
+    assert gp.cl == [25.0, 40.0]
+    assert gp.cu == [POUNCE_INF, 40.0]
+    assert gp.obj_sign == 1.0
+    np.testing.assert_allclose(gp.x0, [1.0, 5.0, 5.0, 1.0])
+
+
+def test_no_hessian_object_omits_hessian_callbacks():
+    gp = problem_from_gmo(HS071View(with_hessian=False))
+    assert not hasattr(gp.problem_obj, "hessian")
+    assert not hasattr(gp.problem_obj, "hessianstructure")
+    assert hasattr(gp.problem_obj, "jacobian")
+
+
+def test_hessian_object_exposes_hessian_callbacks():
+    gp = problem_from_gmo(HS071View(with_hessian=True))
+    assert hasattr(gp.problem_obj, "hessian")
+    assert hasattr(gp.problem_obj, "hessianstructure")
+    rows, cols = gp.problem_obj.hessianstructure()
+    assert rows.dtype == np.int64 and cols.dtype == np.int64
+    assert len(rows) == 10
+
+
+def test_solve_view_lbfgs_reaches_hs071_optimum():
+    """End-to-end translate -> build -> solve with L-BFGS (no analytical Hessian)."""
+    _gp, x, info = link.solve_view(HS071View(with_hessian=False), options={"tol": 1e-8})
+    assert info["status_msg"] in _CONVERGED
+    assert info["obj_val"] == pytest.approx(HS071_OPT, abs=1e-4)
+    np.testing.assert_allclose(x, [1.0, 4.743, 3.821, 1.379], atol=1e-2)
+
+
+def test_solve_view_with_analytical_hessian_reaches_optimum():
+    _gp, x, info = link.solve_view(HS071View(with_hessian=True), options={"tol": 1e-8})
+    assert info["status_msg"] in _CONVERGED
+    assert info["obj_val"] == pytest.approx(HS071_OPT, abs=1e-4)
+
+
+def test_maximize_sign_flips_objective_and_gradient():
+    gp_min = problem_from_gmo(HS071View(maximize=False))
+    gp_max = problem_from_gmo(HS071View(maximize=True))
+    x = np.array([1.0, 5.0, 5.0, 1.0])
+    assert gp_max.obj_sign == -1.0
+    assert gp_max.problem_obj.objective(x) == pytest.approx(-gp_min.problem_obj.objective(x))
+    np.testing.assert_allclose(
+        gp_max.problem_obj.gradient(x), -gp_min.problem_obj.gradient(x)
+    )
+
+
+def test_hessian_callback_applies_sign_and_conweight():
+    """hessian() must call hess_lag_value with obj_sign*obj_factor and conweight=-1."""
+
+    captured = {}
+
+    class RecordingView(HS071View):
+        def hess_lag_value(self, x, lam, obj_weight, con_weight):
+            captured["obj_weight"] = obj_weight
+            captured["con_weight"] = con_weight
+            captured["lam"] = list(lam)
+            return [0.0] * 10
+
+    # minimize: obj_weight == obj_factor, conweight == -1, lambda passed through.
+    gp = problem_from_gmo(RecordingView(maximize=False, with_hessian=True))
+    gp.problem_obj.hessian(np.ones(4), np.array([2.0, 3.0]), 0.5)
+    assert captured["obj_weight"] == pytest.approx(0.5)
+    assert captured["con_weight"] == pytest.approx(-1.0)
+    assert captured["lam"] == [2.0, 3.0]
+
+    # maximize: obj_weight negated.
+    gp = problem_from_gmo(RecordingView(maximize=True, with_hessian=True))
+    gp.problem_obj.hessian(np.ones(4), np.array([1.0, 1.0]), 0.5)
+    assert captured["obj_weight"] == pytest.approx(-0.5)
+    assert captured["con_weight"] == pytest.approx(-1.0)
+
+
+# ── status mapping ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status_msg, model_stat, solve_stat",
+    [
+        ("Solve_Succeeded", link.MODELSTAT_LOCALLY_OPTIMAL, link.SOLVESTAT_NORMAL),
+        ("Solved_To_Acceptable_Level", link.MODELSTAT_FEASIBLE, link.SOLVESTAT_NORMAL),
+        ("Feasible_Point_Found", link.MODELSTAT_FEASIBLE, link.SOLVESTAT_NORMAL),
+        ("Infeasible_Problem_Detected", link.MODELSTAT_INFEASIBLE_LOCAL, link.SOLVESTAT_SOLVER_ERR),
+        ("Diverging_Iterates", link.MODELSTAT_UNBOUNDED, link.SOLVESTAT_SOLVER_ERR),
+        ("Maximum_Iterations_Exceeded", link.MODELSTAT_FEASIBLE, link.SOLVESTAT_ITERATION),
+        ("Maximum_WallTime_Exceeded", link.MODELSTAT_FEASIBLE, link.SOLVESTAT_RESOURCE),
+        ("Invalid_Option", link.MODELSTAT_ERROR_NO_SOLUTION, link.SOLVESTAT_SETUP_ERR),
+        ("Internal_Error", link.MODELSTAT_ERROR_NO_SOLUTION, link.SOLVESTAT_INTERNAL_ERR),
+    ],
+)
+def test_status_to_gams(status_msg, model_stat, solve_stat):
+    assert link.status_to_gams(status_msg) == (model_stat, solve_stat)
+
+
+def test_status_to_gams_unknown_is_error():
+    assert link.status_to_gams("Something_New") == (
+        link.MODELSTAT_ERROR_NO_SOLUTION,
+        link.SOLVESTAT_INTERNAL_ERR,
+    )
+
+
+# ── option file parsing ───────────────────────────────────────────────────────
+
+
+def test_parse_option_file(tmp_path):
+    opt = tmp_path / "pounce.opt"
+    opt.write_text(
+        "* a comment\n"
+        "# another comment\n"
+        "\n"
+        "max_iter 200\n"
+        "tol 1e-9\n"
+        "hessian_approximation limited-memory\n"
+        "json_output /tmp/report.json\n"
+        "json_detail summary\n"
+    )
+    pounce_opts, link_opts = link.parse_option_file(str(opt))
+    assert pounce_opts["max_iter"] == 200
+    assert isinstance(pounce_opts["max_iter"], int)
+    assert pounce_opts["tol"] == pytest.approx(1e-9)
+    assert pounce_opts["hessian_approximation"] == "limited-memory"
+    assert link_opts["json_output"] == "/tmp/report.json"
+    assert link_opts["json_detail"] == "summary"
+    assert "json_output" not in pounce_opts
+
+
+# ── argument resolution ───────────────────────────────────────────────────────
+
+
+def test_parse_gams_args_finds_control_file(tmp_path):
+    sysdir = tmp_path / "sys"
+    sysdir.mkdir()
+    (sysdir / "gmscmpun.txt").write_text("")
+    cntr = tmp_path / "gamscntr.dat"
+    cntr.write_text("")
+    args = ["scrdir", "workdir", "prm.dat", str(cntr), str(sysdir), "pounce"]
+    control_file, found_sysdir = link._parse_gams_args(args)
+    assert control_file == str(cntr)
+    assert found_sysdir == str(sysdir)
+
+
+def test_parse_gams_args_single_arg(tmp_path):
+    cntr = tmp_path / "gamscntr.dat"
+    cntr.write_text("")
+    control_file, found_sysdir = link._parse_gams_args([str(cntr)])
+    assert control_file == str(cntr)
+    assert found_sysdir is None
+
+
+# ── gamsconfig.yaml render / merge ────────────────────────────────────────────
+
+
+def test_render_gamsconfig_created():
+    text, action = register.render_gamsconfig(None, "/opt/pounce-gams-link")
+    assert action == "created"
+    assert "solverConfig" in text
+    assert "pounce" in text
+    assert "/opt/pounce-gams-link" in text
+    assert "NLP" in text
+
+
+def test_gamsconfig_snippet_lists_only_continuous_types():
+    snippet = register.gamsconfig_snippet()
+    assert "NLP" in snippet and "DNLP" in snippet and "RMINLP" in snippet
+    # POUNCE is continuous-only; no discrete/global types in the registered set.
+    assert "MINLP" not in register.MODEL_TYPES
+    assert "MIP" not in register.MODEL_TYPES
+    assert set(register.MODEL_TYPES) == {"NLP", "DNLP", "RMINLP"}
+
+
+def test_render_gamsconfig_merge_preserves_other_solver():
+    yaml = pytest.importorskip("yaml")
+    existing = yaml.safe_dump(
+        {
+            "solverConfig": [{"othersolver": {"scriptName": "/x/other", "modelTypes": ["LP"]}}],
+            "someOtherKey": {"keep": True},
+        }
+    )
+    text, action = register.render_gamsconfig(existing, "/opt/pounce-gams-link")
+    assert action == "merged"
+    data = yaml.safe_load(text)
+    names = [list(item.keys())[0] for item in data["solverConfig"]]
+    assert "othersolver" in names
+    assert "pounce" in names
+    assert data["someOtherKey"] == {"keep": True}
+
+
+def test_render_gamsconfig_replace_existing_pounce():
+    yaml = pytest.importorskip("yaml")
+    existing = yaml.safe_dump(
+        {"solverConfig": [{"pounce": {"scriptName": "/old/path", "modelTypes": ["NLP"]}}]}
+    )
+    text, action = register.render_gamsconfig(existing, "/new/pounce-gams-link")
+    assert action == "replaced"
+    data = yaml.safe_load(text)
+    assert len(data["solverConfig"]) == 1
+    assert data["solverConfig"][0]["pounce"]["scriptName"] == "/new/pounce-gams-link"
+
+
+# ── write / unregister round trip ─────────────────────────────────────────────
+
+
+def test_write_and_unregister_round_trip(tmp_path):
+    pytest.importorskip("yaml")
+    written = register.write_registration(tmp_path)
+    assert written["action"] == "created"
+    assert written["config"].exists()
+    assert written["script"].exists()
+    assert "pounce" in written["config"].read_text()
+
+    result = register.unregister(tmp_path)
+    assert result["removed"] is True
+    assert not written["script"].exists()
+
+
+def test_write_registration_merges_into_existing(tmp_path):
+    yaml = pytest.importorskip("yaml")
+    config = tmp_path / "gamsconfig.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {"solverConfig": [{"othersolver": {"scriptName": "/x", "modelTypes": ["LP"]}}]}
+        )
+    )
+    written = register.write_registration(tmp_path)
+    assert written["action"] == "merged"
+    data = yaml.safe_load(config.read_text())
+    names = [list(item.keys())[0] for item in data["solverConfig"]]
+    assert "othersolver" in names and "pounce" in names
+
+
+def test_run_script_variants():
+    posix = register.run_script(python_executable="/usr/bin/python3", windows=False)
+    assert posix.startswith("#!/bin/sh")
+    assert "pounce.gams.link" in posix
+    win = register.run_script(python_executable="C:/py/python.exe", windows=True)
+    assert "%*" in win
+    assert "pounce.gams.link" in win


### PR DESCRIPTION
## Summary

Adds a pip-installable GAMS solver link so a GAMS user can do:

```
pip install pounce-solver[gams]
pounce-gams register
```

```gams
option nlp = pounce;
solve mymodel using nlp minimizing obj;
```

with **no compiler, no `sudo`, and nothing GAMS-owned redistributed**. The link
is pure Python on GAMS's own `gamsapi[core]` GMO/GEV bindings (which `dlopen`
the user's GAMS C libs). Because POUNCE is a local NLP solver, it wires GMO's
numerical evaluators straight into the cyipopt-style `Problem` callbacks — no
symbolic opcode translator needed. Registration is a per-user `gamsconfig.yaml`
`solverConfig` script-solver entry that merges (preserving other solvers) and
survives GAMS upgrades.

The existing native C link in `gams/` is kept untouched as the alternative
route (it still carries the active-set-SQP working-set / state-file warm starts
the pip link does not yet reproduce).

## What's here

- `python/pounce/gams/{gmo_translate,link,register}.py` — GMO→`Problem`
  translator, control-file driver/entry point, and `gamsconfig.yaml`
  registration.
- `python/pounce/_gams_cli.py` — `pounce-gams` CLI (`register` / `unregister` /
  `status`).
- `python/pyproject.toml` — `gams = ["gamsapi[core]>=45", "pyyaml>=6"]` extra +
  `pounce-gams` / `pounce-gams-link` console scripts.
- `python/tests/test_gams_link.py` — 27 license-free tests driving a fake
  `GmoView` through translate→build→solve, status mapping, option-file parsing,
  and gamsconfig create/merge/replace.
- `docs/src/gams.md` (new user page) + `gams/README.md` / `CLAUDE.md`
  two-routes notes.

## Per-user config directory (NOT XDG on macOS)

`pounce-gams register` writes into the per-user dir GAMS actually searches
(verified with `gamsinst -listdirs`):

| OS | Directory |
| --- | --- |
| macOS | `~/Library/Preferences/GAMS` |
| Linux | `$XDG_CONFIG_HOME/GAMS` (else `~/.config/GAMS`) |
| Windows | `%LOCALAPPDATA%\GAMS` (else `…\Documents\GAMS`) |

## Testing

- `pytest python/tests/test_gams_link.py` — 27 passed, license-free.
- `ruff` clean; `mdbook build` clean; `scripts/check-release-consistency.sh`
  passes (no crate/version change).
- **End-to-end against real GAMS 53 / gamsapi 53.2.0**: `gams test_hs071
  NLP=pounce` solved in 8 iterations to 17.014017, `Solve_Succeeded` / Normal
  completion, model abort checks passed.

## Notes / follow-ups

- The single most common failure mode is a `gamsapi` ↔ GAMS version mismatch
  (the bindings `dlopen` GAMS's libs); `pounce-gams status` diagnoses it.
- Warm-start parity (active-set-SQP working set / state file) is C-link only
  for now; the pip link runs each solve as a fresh process. Tracked as a
  follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
