### PR TITLE
Add pathsim-chem (MIT) attribution and Milan Rother acknowledgment for the GLC example

### DIFF
--- a/docs/src/acknowledgments.md
+++ b/docs/src/acknowledgments.md
@@ -45,6 +45,14 @@ wrapper — from two reference projects, gratefully acknowledged:
   solver, reduction frame with multiplier recovery — and ships
   with the `tutorial_flow_density{,_perturbed}.nl` and
   `gaslib11_steady.nl` test fixtures David vendored.
+- **Milan Rother** ([@milanofthe](https://github.com/milanofthe))
+  suggested the boundary value problem solver and the tritium
+  gas-liquid-contactor (GLC) test problem behind
+  [`docs/src/bvp.md`](bvp.md) and
+  `python/examples/glc_feral_vs_scipy.py`. The GLC model is adapted from
+  [pathsim-chem](https://github.com/pathsim/pathsim-chem)
+  (`src/pathsim_chem/tritium/glc.py`, MIT License, Copyright (c) 2025
+  PathSim).
 
 ## Key references
 

--- a/docs/src/bvp.md
+++ b/docs/src/bvp.md
@@ -25,7 +25,9 @@ autodiff frontends, `pounce.jax.solve_bvp` and `pounce.torch.solve_bvp`.
 > [`python/notebooks/24_boundary_value_problems.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/24_boundary_value_problems.ipynb),
 > and a SciPy speed/accuracy comparison in
 > `python/examples/bvp_scipy_compare.py` (plus the GLC tritium-column case in
-> `python/examples/glc_feral_vs_scipy.py`).
+> `python/examples/glc_feral_vs_scipy.py`). The GLC problem was suggested by
+> [Milan Rother](https://github.com/milanofthe) and is adapted from
+> [pathsim-chem](https://github.com/pathsim/pathsim-chem) (MIT License).
 
 ## Drop-in NumPy solve
 

--- a/python/examples/glc_feral_vs_scipy.py
+++ b/python/examples/glc_feral_vs_scipy.py
@@ -16,6 +16,20 @@ same BVP two ways and compare speed and accuracy:
   node count.
 
 Standalone — only needs numpy, scipy, pounce (no pathsim).
+
+Attribution
+-----------
+The model code reproduced below — the property correlations
+(``_calculate_properties``), the dimensionless groups
+(``_calculate_dimensionless_groups``), and the ODE / boundary-condition
+equations (``make_bvp``) — is adapted from pathsim-chem,
+``src/pathsim_chem/tritium/glc.py``, which is MIT-licensed:
+
+    Copyright (c) 2025 PathSim
+    https://github.com/pathsim/pathsim-chem   (MIT License)
+
+Reproduced here under the terms of the MIT License for a solver comparison;
+the pounce-specific parts (the solve/compare harness) are pounce's own.
 """
 
 import time

--- a/python/examples/glc_feral_vs_scipy.py
+++ b/python/examples/glc_feral_vs_scipy.py
@@ -30,6 +30,9 @@ equations (``make_bvp``) — is adapted from pathsim-chem,
 
 Reproduced here under the terms of the MIT License for a solver comparison;
 the pounce-specific parts (the solve/compare harness) are pounce's own.
+
+Thanks to Milan Rother (https://github.com/milanofthe) for suggesting this
+BVP and problem.
 """
 
 import time


### PR DESCRIPTION
## Summary

Follow-up to #150, which merged before these two attribution commits landed. `main` currently ships `python/examples/glc_feral_vs_scipy.py`, which reproduces model code (property correlations, dimensionless groups, ODE/boundary conditions) verbatim from [pathsim-chem](https://github.com/pathsim/pathsim-chem) `src/pathsim_chem/tritium/glc.py` — but **without the MIT attribution that reuse requires**, and without acknowledging who suggested the problem.

This PR adds:

1. **pathsim-chem MIT attribution** in the GLC example header — source URL, file path, MIT License, and `Copyright (c) 2025 PathSim`. (pathsim-chem is MIT-licensed, so reuse is permitted with the copyright + permission notice accompanying the copied portions.)
2. **Acknowledgment of Milan Rother** ([@milanofthe](https://github.com/milanofthe)) for suggesting the BVP solver and the tritium GLC test problem — in the example header, `docs/src/bvp.md`, and the Contributors section of `docs/src/acknowledgments.md`.

No code/behaviour changes — docs and comments only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkewNiehrg7D1sf5SPRfC3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkewNiehrg7D1sf5SPRfC3)_