### PR TITLE
chore(deps): bump feral to 0.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "feral"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94827f41e265cb9c87199f0753f95d8ca6a29834a6dccba90843b37a73b5843f"
+checksum = "bbd64d9c03fe36ca9898f2f5f4616fac3c2fcfecc76af6864a6d0661e5e8b9ad"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,13 +86,17 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.5.0"
 # scripts/check-release-consistency.sh ("git dependency … needs a crates.io
 # version"). 0.11.0 ships the formerly-unreleased MC64/scaling perf work (#80),
 # LU basis engine (#81), and correctness campaign (#82/#83) that we previously
-# carried locally via a git patch. If you ever need to develop against an
+# carried locally via a git patch. 0.11.1 adds a Forrest–Tomlin bump
+# re-triangularization fast path (a bump-local sub-diagonal pivot index that
+# drops the O(bump²) pivot-selection scan) — bit-identical numerics, no API
+# change, big speedup on wide sparse LPs like lifted-McCormick relaxations
+# (~15.8× on the casctanks root LP solve). If you ever need to develop against an
 # unreleased feral again, add an UNCOMMITTED `[patch.crates-io]` redirecting
 # feral to the git rev — e.g.
 #   [patch.crates-io]
 #   feral = { git = "https://github.com/jkitchin/feral.git", rev = "<sha>" }
 # Do NOT commit that patch (it re-introduces the publish blocker).
-feral = { version = "0.11.0" }
+feral = { version = "0.11.1" }
 # Dense linear algebra for the debugger's numerical rank diagnosis
 # (SVD of the active-constraint Jacobian). Pure-Rust, MIT; we pull only
 # the dense `std` core — no rayon/sparse/rand/npy.


### PR DESCRIPTION
## Summary

Bumps the external `feral` dependency from `0.11.0` to `0.11.1`.

`0.11.1` adds a Forrest–Tomlin bump re-triangularization fast path — a
bump-local sub-diagonal pivot index that removes the `O(bump²)`
pivot-selection scan. It is **bit-identical** numerically (same optimum,
same factorization, same `FtOp` eta sequence) with **no API change**, and
delivers a large speedup on wide sparse LPs such as lifted-McCormick
relaxations (~15.8× on the casctanks root LP solve).

## Changes

- `Cargo.toml`: `feral = { version = "0.11.1" }` + updated pin comment
- `Cargo.lock`: feral version + checksum

The crates.io pin is preserved (no git dependency), so the publish path is
unaffected. `scripts/check-release-consistency.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
