### PR TITLE
chore(deps): bump feral to 0.11.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "feral"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd64d9c03fe36ca9898f2f5f4616fac3c2fcfecc76af6864a6d0661e5e8b9ad"
+checksum = "a7695a95dae6fdef1d1923752d70bd992d42b7ce4f8f7b23fe48e01bd463301d"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,13 +90,16 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.5.0"
 # re-triangularization fast path (a bump-local sub-diagonal pivot index that
 # drops the O(bump²) pivot-selection scan) — bit-identical numerics, no API
 # change, big speedup on wide sparse LPs like lifted-McCormick relaxations
-# (~15.8× on the casctanks root LP solve). If you ever need to develop against an
+# (~15.8× on the casctanks root LP solve). 0.11.2 pools the Forrest–Tomlin
+# `SparseLu::update` scratch buffers (≈1804→82 heap allocs/update, ~31% faster
+# on a 144-update replay chain) — again bit-identical numerics, no API change.
+# If you ever need to develop against an
 # unreleased feral again, add an UNCOMMITTED `[patch.crates-io]` redirecting
 # feral to the git rev — e.g.
 #   [patch.crates-io]
 #   feral = { git = "https://github.com/jkitchin/feral.git", rev = "<sha>" }
 # Do NOT commit that patch (it re-introduces the publish blocker).
-feral = { version = "0.11.1" }
+feral = { version = "0.11.2" }
 # Dense linear algebra for the debugger's numerical rank diagnosis
 # (SVD of the active-constraint Jacobian). Pure-Rust, MIT; we pull only
 # the dense `std` core — no rayon/sparse/rand/npy.


### PR DESCRIPTION
## Summary

Bumps the external `feral` dependency from `0.11.1` to `0.11.2`.

`0.11.2` pools the Forrest–Tomlin `SparseLu::update` scratch buffers,
eliminating per-pivot heap allocations (~1804 → 82 per update, ~95% fewer;
~31% faster on a 144-update replay chain, 12.35 ms → 8.55 ms). Numerics are
**bit-identical** — pooling changes only where buffers come from, not pivot
choices — and there is **no API change**.

## Changes

- `Cargo.toml`: `feral = { version = "0.11.2" }` + updated pin comment
- `Cargo.lock`: feral version + checksum

The crates.io pin is preserved (no git dependency), so the publish path is
unaffected. `scripts/check-release-consistency.sh` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
