### PR TITLE
perf(ode): reuse the Radau LU pattern across refactors (4–7× at large n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ changes.
   stiff systems where the dense factor dominates, this drops factorisations
   per step well below SciPy's and cuts wall-clock ~25–30% (e.g. a 100-state
   Brusselator), with no accuracy cost.
+- **Reuse the LU pattern across refactors.** The stepper was rebuilding the
+  `SparseLU` object — re-bucketing the `(3n)²` COO pattern and re-running
+  FERAL's symbolic analysis — on *every* refactor, even though the sparsity
+  pattern is fixed for the whole solve. The pattern object is now built once
+  per solve and refactored in place (the binding already caches the symbolic),
+  so each step pays only the numeric factorisation. This is a large-`n` win
+  that grows with system size: **~4× faster on a 100-state Brusselator
+  (318 → 79 ms) and ~7× on 300 states (2.83 s → 0.41 s)**, cutting the gap to
+  `scipy.integrate.solve_ivp` from ~14–30× down to ~3–4×. Identical accuracy
+  and step counts; no API change.
 
 ### Added — boundary value problems (`pounce.bvp`)
 

--- a/python/pounce/ode/_radau.py
+++ b/python/pounce/ode/_radau.py
@@ -67,13 +67,24 @@ _ODE_MESSAGES = {
 }
 
 
-def _dense_lu(Mat):
-    """Factor a dense ``(N × N)`` matrix with FERAL's sparse LU."""
-    N = Mat.shape[0]
+def _dense_lu_pattern(N):
+    """Build a reusable FERAL ``SparseLU`` over the full dense ``N × N`` pattern.
+
+    The sparsity pattern is fixed across a whole solve — only the matrix values
+    change as ``h`` and ``J`` vary — so the pattern object (and FERAL's symbolic
+    analysis, which it caches internally) is built **once** and the matrix is
+    refactored in place with :func:`_refactor` each step. Re-creating it per
+    refactor (re-bucketing the ``N²`` COO entries and re-analysing) dominated
+    the per-step cost on large systems.
+    """
     idx = np.arange(N, dtype=np.int64)
-    lu = SparseLU(N, np.repeat(idx, N), np.tile(idx, N))
+    return SparseLU(N, np.repeat(idx, N), np.tile(idx, N))
+
+
+def _refactor(lu, Mat):
+    """Numerically refactor ``lu`` (a fixed-pattern dense ``SparseLU``) from the
+    row-major values of ``Mat`` — reusing the cached symbolic analysis."""
     lu.factor(np.ascontiguousarray(Mat, dtype=np.float64).reshape(-1))
-    return lu
 
 
 def _fd_jac(f, t, y, f0):
@@ -244,7 +255,12 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
     # RADAU5 efficiency trick is to refactor only when J is refreshed or h
     # changes — so we hold the factor across steps (see the step-size band
     # below, which freezes h on mild growth to keep reusing it).
-    lu3 = lu_real = None
+    # Reusable LU factors over the FIXED dense patterns: the (3n×3n) stage
+    # operator and the (n×n) real error operator. Only the values change across
+    # steps, so the pattern objects (and FERAL's symbolic analysis) are built
+    # once here and refactored in place inside the loop.
+    lu3 = _dense_lu_pattern(3 * prob.n)
+    lu_real = _dense_lu_pattern(prob.n)
     h_lu = None
     need_factor = True
 
@@ -260,8 +276,8 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
         hs = s * h
         if need_factor or h != h_lu:
             big = np.kron(np.eye(3), prob.M) - hs * np.kron(RADAU_A, J)
-            lu3 = _dense_lu(big)
-            lu_real = _dense_lu(MU_REAL / hs * prob.M - J)
+            _refactor(lu3, big)
+            _refactor(lu_real, MU_REAL / hs * prob.M - J)
             prob.nlu += 2
             h_lu = h
             need_factor = False

--- a/python/tests/test_ode.py
+++ b/python/tests/test_ode.py
@@ -113,6 +113,32 @@ def test_stage_predictor_warm_start_reduces_nfev():
     assert r.nfev < 20000, f"stage predictor regressed: nfev={r.nfev}"
 
 
+def test_lu_pattern_built_once_per_solve(monkeypatch):
+    """The (3n×3n) stage and (n×n) error LU patterns — and FERAL's cached
+    symbolic analysis — must be built once per solve and refactored in place,
+    not re-created on every step. Re-analysing the pattern per refactor was the
+    large-n bottleneck. Guard the invariant: exactly two patterns are built,
+    regardless of how many times the step refactors."""
+    from pounce.ode import _radau
+
+    n_built = [0]
+    orig = _radau._dense_lu_pattern
+
+    def counting(N):
+        n_built[0] += 1
+        return orig(N)
+
+    monkeypatch.setattr(_radau, "_dense_lu_pattern", counting)
+
+    def f(t, y):
+        return [y[1], 100.0 * (1 - y[0] ** 2) * y[1] - y[0]]
+
+    r = po.solve_ivp(f, (0.0, 200.0), [2.0, 0.0], rtol=1e-6, atol=1e-9)
+    assert r.success
+    assert r.nlu >= 4, "test needs several refactors to be meaningful"
+    assert n_built[0] == 2, f"LU pattern rebuilt per refactor ({n_built[0]} builds)"
+
+
 # --- index-1 DAE (mass matrix) -----------------------------------------------
 
 def test_robertson_dae():


### PR DESCRIPTION
## Summary

Profiling the stiff Radau stepper at large `n` to chase the "sparse `_dense_lu`"
lever turned up something more fundamental: the dominant cost wasn't the LU
algorithm at all — it was **re-creating the `SparseLU` object on every
refactor**.

cProfile, Brusselator n=100 (3 solves):

```
_dense_lu        0.703s  (72%)   <- Python rebuild + re-analysis, every refactor
factor (FERAL)   0.084s  (8.6%)  <- the actual numeric factorization
f (RHS)          0.098s  (10%)
```

The stepper built a fresh `SparseLU(N, rows, cols)` each refactor — re-bucketing
the `(3n)²` COO pattern and re-running FERAL's symbolic analysis — even though
the sparsity pattern is **fixed for the whole solve**. The binding is explicitly
designed for reuse ("build once over a fixed sparsity pattern, then
`factor(values)` repeatedly"; it caches the symbolic). So this PR builds the two
pattern objects (the `3n×3n` stage operator and the `n×n` real error operator)
**once per solve** and refactors them in place each step.

## Measured (best-of-7, accuracy vs a tight reference)

| problem | before | after | speedup | vs SciPy (before → after) |
|---|---|---|---|---|
| VdP n=2 | 102.6 ms | 99.6 ms | ~par | 1.1× → 0.9× |
| Brusselator n=100 | 317.5 ms | **78.7 ms** | **4.0×** | 14.1× → **3.4×** |
| Brusselator n=300 | 2827 ms | **409 ms** | **6.9×** | 30× → **4.4×** |

The win **grows with system size** (the per-refactor re-analysis scaled with
`N²`). **Identical step counts and accuracy** — same algorithm, just stop
re-analysing a fixed pattern. No API change.

## What's left (now-smaller levers)
The remaining ~3–4× gap to SciPy at large `n` is three separate, bigger changes:
1. **Actual sparse pattern** — `_dense_lu_pattern` still uses the full dense
   `(3n)²` pattern; a banded `J` (e.g. MOL PDEs) would shrink the values vector
   and the numeric factor. Needs a `jac_sparsity` (SciPy-compatible) hint.
2. **Sparse FD Jacobian with graph coloring** — the FD Jacobian now dominates
   `nfev` at large `n`.
3. **RADAU5 real+complex decoupling** — factoring one real `n×n` + one complex
   `n×n` instead of the full `3n×3n`, the way SciPy/Hairer do.

This PR is the clean, universal, profile-driven win that those build on.

## Test
Adds `test_lu_pattern_built_once_per_solve` — monkeypatches the pattern factory
and asserts exactly two patterns are built per solve regardless of refactor
count, guarding the invariant against a regression to per-step construction.
Full `pounce.ode` suite green (20 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
