### PR TITLE
release: 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ changes.
 
 ## [Unreleased]
 
+
+## [0.6.0] - 2026-06-20
+
 ### Performance — stiff ODE stepper (`pounce.ode`)
 
 - **Stage predictor.** The adaptive Radau stepper now warm-starts each step's
@@ -142,6 +145,42 @@ JAX/PyTorch frontends:
   drop-in.
 - Docs: `docs/src/ode.md`; worked stiff/DAE/differentiability comparison in
   `python/examples/ode_scipy_compare.py`.
+
+### Added — GAMS solver link, now pip-installable (`pounce-solver[gams]`)
+
+- **`pip install pounce-solver[gams]` + `pounce-gams register`** registers
+  POUNCE as a GAMS NLP solver (`option nlp = pounce;`) with no compiler, no
+  `sudo`, and nothing GAMS-owned redistributed — built on GAMS's own
+  `gamsapi[core]` GMO/GEV bindings. The link wires GMO's numerical evaluators
+  straight into the solver's cyipopt-style `Problem` callbacks (POUNCE is a
+  local NLP solver, so no opcode translator is needed). Registration merges a
+  per-user `gamsconfig.yaml` `solverConfig` entry, preserving other solvers and
+  surviving GAMS upgrades. The native C link in `gams/` remains as the
+  alternative route. Adds the `pounce-gams` / `pounce-gams-link` console scripts
+  and the `[gams]` extra. Docs: `docs/src/gams.md`.
+
+### Added — solver & `.nl` parser
+
+- **`mu_strategy_fallback`** (opt-in, default off): on a
+  `Solved_To_Acceptable_Level` or `Maximum_Iterations_Exceeded` exit, flip
+  `mu_strategy` (adaptive↔monotone) once and re-solve, promoting the retry only
+  if it reaches `Solve_Succeeded` (otherwise the original outcome is kept).
+  Recovers genuine adaptive-μ stalls.
+- **AMPL power opcodes** `o81` / `o82` / `o83` (`OP1POW` / `OP2POW` / `OPCPOW`)
+  in the `.nl` reader. AMPL emits these as a hint that one operand is constant;
+  they previously hit the unsupported-opcode fallthrough, so any `.nl` emitting
+  them failed to parse. They lower to the existing negative-base-safe
+  constant-power path.
+
+### Fixed
+
+- **`acceptable_iter=0` now disables acceptable-level termination** (restoring
+  upstream Ipopt's `acceptable_iter_ > 0` guard) instead of firing on the very
+  first acceptable iterate. The GAMS link also now defaults `acceptable_iter=0`,
+  mirroring the GAMS–Ipopt link, which removes premature
+  `Solved_To_Acceptable_Level` exits on several princetonlib models.
+- **CLI:** honor `presolve` on the convex LP/QP path (#139); report reduced
+  (post-fixed-variable-removal) dimensions in the solver banner (#140).
 
 
 ## [0.5.0] - 2026-06-14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-diff"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde_json",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-algorithm"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cinterface"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cli"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-common"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-convex"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-feral"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-hsl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-l1penalty"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -986,14 +986,14 @@ dependencies = [
 
 [[package]]
 name = "pounce-linalg"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
 ]
 
 [[package]]
 name = "pounce-linsol"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nl"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "libloading",
  "pounce-common",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nlp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-observability"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-presolve"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-py"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "feral",
  "numpy",
@@ -1065,7 +1065,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-qp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-feral",
@@ -1075,7 +1075,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-restoration"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1088,7 +1088,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-sensitivity"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-solve-report"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-common",
  "pounce-linsol",
@@ -1109,7 +1109,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1117,7 +1117,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-pyo3"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "pounce-studio-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "EPL-2.0"
 authors = ["John Kitchin <jkitchin@andrew.cmu.edu>"]
@@ -64,23 +64,23 @@ repository = "https://github.com/jkitchin/pounce"
 # deps lack a registry version). Crates pick these up via
 # `pounce-foo.workspace = true`.
 [workspace.dependencies]
-pounce-common = { path = "crates/pounce-common", version = "0.5.0" }
-pounce-linalg = { path = "crates/pounce-linalg", version = "0.5.0" }
-pounce-linsol = { path = "crates/pounce-linsol", version = "0.5.0" }
-pounce-nlp = { path = "crates/pounce-nlp", version = "0.5.0" }
-pounce-nl = { path = "crates/pounce-nl", version = "0.5.0" }
-pounce-hsl = { path = "crates/pounce-hsl", version = "0.5.0" }
-pounce-feral = { path = "crates/pounce-feral", version = "0.5.0" }
-pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.5.0" }
-pounce-restoration = { path = "crates/pounce-restoration", version = "0.5.0" }
-pounce-presolve = { path = "crates/pounce-presolve", version = "0.5.0" }
-pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.5.0" }
-pounce-qp = { path = "crates/pounce-qp", version = "0.5.0" }
-pounce-convex = { path = "crates/pounce-convex", version = "0.5.0" }
-pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.5.0" }
-pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.5.0" }
-pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.5.0" }
-pounce-observability = { path = "crates/pounce-observability", version = "0.5.0" }
+pounce-common = { path = "crates/pounce-common", version = "0.6.0" }
+pounce-linalg = { path = "crates/pounce-linalg", version = "0.6.0" }
+pounce-linsol = { path = "crates/pounce-linsol", version = "0.6.0" }
+pounce-nlp = { path = "crates/pounce-nlp", version = "0.6.0" }
+pounce-nl = { path = "crates/pounce-nl", version = "0.6.0" }
+pounce-hsl = { path = "crates/pounce-hsl", version = "0.6.0" }
+pounce-feral = { path = "crates/pounce-feral", version = "0.6.0" }
+pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.6.0" }
+pounce-restoration = { path = "crates/pounce-restoration", version = "0.6.0" }
+pounce-presolve = { path = "crates/pounce-presolve", version = "0.6.0" }
+pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.6.0" }
+pounce-qp = { path = "crates/pounce-qp", version = "0.6.0" }
+pounce-convex = { path = "crates/pounce-convex", version = "0.6.0" }
+pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.6.0" }
+pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.6.0" }
+pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.6.0" }
+pounce-observability = { path = "crates/pounce-observability", version = "0.6.0" }
 # feral: pinned to the published crates.io release so the pounce crates stay
 # publishable — a git rev would block the crates.io publish and is rejected by
 # scripts/check-release-consistency.sh ("git dependency … needs a crates.io

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomo-pounce"
-version = "0.5.0"
+version = "0.6.0"
 description = "Pyomo solver plugin for the POUNCE interior-point NLP solver"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 # because maturin's `module-name = "pounce._pounce"` and
 # `python-source = "."` keep the package folder named `pounce`.
 name = "pounce-solver"
-version = "0.5.0"
+version = "0.6.0"
 description = "Python interface to POUNCE — a pure-Rust interior-point optimization solver for nonlinear, conic (LP/QP/SOCP/SDP/exp/power), and global problems (NLP core ported from Ipopt). cyipopt-style Problem class, scipy-style minimize() facade, solve_qp/solve_socp/sos_minimize, and JAX-friendly autodiff / implicit differentiation."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

Release-prep for **0.6.0** — a minor, **fully additive** release (no breaking
changes), so it stays pre-1.0 minor versioning rather than going to `1.0.0`.

### Version surfaces (all → 0.6.0)
- `Cargo.toml` `[workspace.package]` + the intra-workspace dependency pins
  (crates.io; also drives the Python `__version__`, which is read from the Rust
  crate). `Cargo.lock` regenerated for the workspace crates.
- `python/pyproject.toml` — `pounce-solver`, **including the `[gams]` extra /
  `pounce-gams` link** (the GAMS link ships inside `pounce-solver`; no separate
  version).
- `pyomo-pounce/pyproject.toml` — `pyomo-pounce`.

`scripts/check-release-consistency.sh` passes (all three at 0.6.0; publish list
and dependency requirements OK).

> Note: `studio/mcp` (0.1.0) is a separate tool, not part of the X.Y.Z release
> train, and is intentionally left unchanged.

### Changelog
Rolled `[Unreleased]` into `## [0.6.0] - 2026-06-20`. The big-ticket items
(`pounce.bvp`, `pounce.ode`, the ODE perf work) were already documented; this
PR **adds the post-0.5.0 entries that were missing** so the release notes are
complete:
- pip-installable **GAMS solver link** (`pounce-solver[gams]` + `pounce-gams register`)
- **`mu_strategy_fallback`** option
- **AMPL power opcodes** `o81`/`o82`/`o83` in the `.nl` reader
- Fixes: `acceptable_iter=0` semantics; CLI `presolve` on convex LP/QP (#139); banner dims (#140)

## What this PR does NOT do
Tagging and publishing are **not** part of this PR. Once merged, the release is
cut by pushing the three tags (`vX.Y.Z`, `python-vX.Y.Z`, `pyomo-pounce-vX.Y.Z`)
that trigger the automated crates.io / PyPI workflows, plus a hand-created
GitHub Release. Holding those for explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
