### PR TITLE
fix(ci): deploy versioned docs from main via workflow_run, not v* tags

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,11 +1,19 @@
 name: Deploy docs
 
 on:
+  # main rebuilds the dev/ docs. A release additionally needs the versioned
+  # site rebuilt (new archive entry + stable pointer) — but GitHub Pages only
+  # *serves* deployments from the source branch (main), so a tag-triggered run
+  # reports success yet never publishes (docs-deploy postmortem, 0.6.0). So
+  # instead of `tags: ['v*']` we ride `workflow_run` after the crates release:
+  # that event runs in the default-branch (main) context, so it deploys from
+  # main (and therefore actually publishes), and by the time it fires the new
+  # vX.Y.Z tag already exists, so build-versioned-docs.sh picks it up as stable.
   push:
-    # main rebuilds the dev/ docs; a new vX.Y.Z release tag rebuilds the
-    # whole versioned site (stable at root + the new archive entry).
     branches: [main]
-    tags: ['v*']
+  workflow_run:
+    workflows: ["release-crates"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -26,6 +34,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # On the release (workflow_run) trigger, only rebuild if the release
+    # actually succeeded; push/dispatch runs are unconditional. `deploy` needs
+    # `build`, so skipping here skips the deploy too.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       # fetch-depth: 0 — the versioned build checks out each v* tag via
       # `git worktree`, so the full tag history must be present (the default


### PR DESCRIPTION
## Summary

Fixes the versioned-docs deploy so a release actually publishes its docs
without manual intervention.

### The bug (0.6.0 docs postmortem)
GitHub Pages only *serves* deployments that originate from the Pages source
branch (`main`). `docs.yml` triggered the versioned-site rebuild on `v*` tag
pushes, so at release the deploy job ran, reported **success**, but the content
was **never published** — 0.6.0 didn't show up in the version selector / at the
site root until a manual `workflow_dispatch` on `main`. (The `github-pages`
environment also only allowed `main`, which masked this as an outright deploy
failure first.)

### The fix
Replace `tags: ['v*']` with a `workflow_run` trigger on the **`release-crates`**
workflow:

- `workflow_run` events execute in the **default-branch (`main`) context**, so
  the deploy originates from `main` → it actually publishes.
- It fires **after** the release workflow, so the new `vX.Y.Z` tag already
  exists and `build-versioned-docs.sh` picks it up as **stable** (the build
  enumerates all tags regardless of the triggering ref).
- The build job is gated on the release having **succeeded**; ordinary
  `push: main` and `workflow_dispatch` runs are unconditional.

Net: pushing `vX.Y.Z` → `release-crates` runs → on completion, docs rebuild
+ deploy from `main` → the new version goes live automatically. No PAT, no
manual dispatch.

### Notes
- 0.6.0 docs are already live (deployed via the manual main dispatch); this just
  makes the next release automatic.
- I added a `v*` tag rule to the `github-pages` environment earlier while
  diagnosing — it's now unused (deploys come from `main`) but harmless; can be
  removed later if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
