### PR TITLE
fix(minimize): report routed LP/QP unbounded & infeasible clearly (#160)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ changes.
   emits a `UserWarning` instead of vanishing. The fully-implicit `solve_dae`
   above also supersedes the "constant mass only" limitation for callers needing
   a general implicit form.
+- **`pounce.minimize` routed LP/QP/SOCP results now report unbounded and
+  infeasible outcomes in plain language** (gh #160). When the convex solver
+  returns a dual- or primal-infeasibility certificate, the result `message` now
+  reads "The problem appears unbounded …" / "… infeasible …" (status `3` /
+  `2`, matching SciPy `linprog`) instead of the raw `dual_infeasible` /
+  `primal_infeasible` string — so a downstream adapter can distinguish
+  unboundedness from a generic iteration limit. The raw certificate is still
+  available in `res.info["status"]`. (Note: the general NLP path —
+  `solver_selection="nlp"`, the default — cannot certify LP unboundedness, the
+  same as stock Ipopt; route linear/convex problems with
+  `solver_selection="lp-ipm"` / `"auto"` to get the certificate.)
 
 
 ## [0.6.0] - 2026-06-20

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -89,6 +89,26 @@ _QP_STATUS_CODE = {
     "numerical_failure": 4,
 }
 
+# Human-readable message for each convex-solver status. `pounce.minimize`
+# always *minimizes*, so for the routed LP/QP the HSDE certificates map to the
+# usual primal verdicts: a dual-infeasibility certificate means the objective
+# is unbounded below over the feasible region (primal unbounded), and a
+# primal-infeasibility certificate means the feasible set is empty. The raw
+# certificate string stays available in ``info["status"]`` for callers that
+# key on it; this clearer text is surfaced as the result ``message`` so an
+# unbounded / infeasible solve is not mistaken for a generic iteration limit
+# (gh #160).
+_QP_STATUS_MESSAGE = {
+    "optimal": "Optimization terminated successfully.",
+    "primal_infeasible": "The problem appears infeasible (the convex solver "
+    "returned a primal-infeasibility certificate).",
+    "dual_infeasible": "The problem appears unbounded — the objective is "
+    "unbounded below over the feasible region (the convex solver returned a "
+    "dual-infeasibility certificate).",
+    "iteration_limit": "Maximum number of iterations reached.",
+    "numerical_failure": "Numerical difficulties encountered.",
+}
+
 # NLP ``ApplicationReturnStatus`` codes that count as a successful solve for the
 # scipy-style ``success`` flag. ``SolveSucceeded`` (0) is the obvious one;
 # ``SolvedToAcceptableLevel`` (1) means the iterate met the *acceptable*
@@ -711,12 +731,13 @@ def _solve_via_convex(ex, opts: dict) -> OptimizeResult:
     fun_val = float(res.obj) + ex.obj_const
     success = res.status == "optimal"
     selector = "lp-ipm" if ex.kind == "lp" else "qp-ipm"
+    message = _QP_STATUS_MESSAGE.get(res.status, res.status)
     return OptimizeResult(
         x=np.asarray(res.x),
         fun=fun_val,
         success=success,
         status=_QP_STATUS_CODE.get(res.status, 1),
-        message=res.status,
+        message=message,
         nit=int(res.iters),
         # The convex solver consumes the extracted quadratic form, not the
         # python callables, so no objective/gradient/Hessian callbacks fire
@@ -764,12 +785,13 @@ def _solve_via_socp(ex, opts: dict) -> OptimizeResult:
     )
     fun_val = float(res.obj) + ex.obj_const
     success = res.status == "optimal"
+    message = _QP_STATUS_MESSAGE.get(res.status, res.status)
     return OptimizeResult(
         x=np.asarray(res.x),
         fun=fun_val,
         success=success,
         status=_QP_STATUS_CODE.get(res.status, 1),
-        message=res.status,
+        message=message,
         nit=int(res.iters),
         # See ``_solve_via_convex``: the conic solver works on the extracted
         # cone program, so the python objective callbacks never fire — report
@@ -783,7 +805,7 @@ def _solve_via_socp(ex, opts: dict) -> OptimizeResult:
             "obj_val": fun_val,
             "obj_constant": ex.obj_const,
             "status": res.status,
-            "status_msg": res.status,
+            "status_msg": message,
             "iter_count": int(res.iters),
             "residuals": res.residuals,
         },

--- a/python/tests/test_minimize_autoroute.py
+++ b/python/tests/test_minimize_autoroute.py
@@ -204,3 +204,30 @@ def test_auto_route_probes_objective_once_not_twice():
     # Post-fix the overhead equals a single router's probe count; pre-fix (no
     # shared cache) it was 2× because each router re-probed from scratch.
     assert routing_overhead == c_one["n"]
+
+
+def test_unbounded_lp_reports_unbounded_not_iteration_limit():
+    """gh #160: an unbounded LP routed to the convex solver must report a
+    distinct unbounded status, not a generic iteration limit.
+
+        min -x0 - x1  s.t. x0 - x1 <= 1,  x0, x1 >= 0
+    is unbounded along x0 = x1 + 1, x1 -> inf. The NLP path can only hit
+    max_iter here (its iterates grow ~linearly, never reaching
+    diverging_iterates_tol), so LP callers route to the LP solver, whose HSDE
+    returns a dual-infeasibility certificate => primal unbounded.
+    """
+    fun = lambda x: -x[0] - x[1]
+    jac = lambda x: np.array([-1.0, -1.0])
+    con = {"type": "ineq",
+           "fun": lambda x: 1.0 - (x[0] - x[1]),   # con(x) >= 0
+           "jac": lambda x: np.array([-1.0, 1.0])}
+    res = minimize(fun, [0.5, 0.5], jac=jac, bounds=[(0.0, None), (0.0, None)],
+                   constraints=con,
+                   options={"solver_selection": "lp-ipm", "max_iter": 3000})
+
+    assert _routed_to(res) == "lp-ipm"          # took the LP path, not NLP
+    assert not res.success
+    assert res.status == 3                       # scipy-linprog: 3 == unbounded
+    assert "unbounded" in res.message.lower()    # distinct, not "max iterations"
+    # Raw HSDE certificate still available for programmatic callers.
+    assert res.info["status"] == "dual_infeasible"


### PR DESCRIPTION
Fixes #160.

## Diagnosis
The reported model is an unbounded LP:

```
min -x0 - x1   s.t.  x0 - x1 <= 1,   x0, x1 >= 0     (unbounded along x0 = x1+1)
```

Reproduced on **0.6.0** (the report was on 0.2.0). What happens depends entirely
on routing:

| `solver_selection` | result |
|---|---|
| `"nlp"` (**default**) | `status=-1 Maximum_Iterations_Exceeded`, nit=3000 |
| `"auto"` / `"lp-ipm"` | unbounded certificate in **2 iterations** |

The convex LP solver (HSDE) already diagnoses unboundedness correctly — it
returns a **dual-infeasibility certificate**, which for a minimization primal
*is* "unbounded." The general **NLP/IPM path cannot** certify this: an unbounded
LP's interior-point iterates grow only ~linearly, so they never reach
`diverging_iterates_tol` (1e20) and the solve hits `max_iter` first. (Stock
Ipopt behaves the same; the right tool for an LP is the LP solver.)

So the gap is twofold: (1) discopt's adapter was on the default NLP path, and
(2) even when routed, the unbounded result was reported as the raw string
`dual_infeasible`, which a downstream adapter couldn't tell apart from an
iteration limit.

## Change
`pounce.minimize` always minimizes, so on the routed convex path:
- a **dual-infeasibility** certificate → `message` "The problem appears
  unbounded — the objective is unbounded below over the feasible region …",
  `status=3` (matches `scipy.linprog`'s unbounded code);
- a **primal-infeasibility** certificate → "… appears infeasible …", `status=2`.

The raw certificate stays in `res.info["status"]` for programmatic callers.
Applied on both `_solve_via_convex` (LP/QP) and `_solve_via_socp` (SOCP).

This does **not** change the default NLP path — see the note below.

## For the discopt LP adapter
Route linear problems with `solver_selection="lp-ipm"` (or `"auto"`):

```python
pounce.minimize(..., options={"solver_selection": "lp-ipm"})
```

and map `res.status == 3` (or `res.info["status"] == "dual_infeasible"`) to
`UNBOUNDED`. That uses the LP solver, which certifies unboundedness/infeasibility
directly. (The convex fast paths are deliberately opt-in — the default `"nlp"`
path probes nothing.)

## Test
Adds `test_unbounded_lp_reports_unbounded_not_iteration_limit` mirroring the
issue's exact model; full `test_minimize_autoroute.py` green (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
