### PR TITLE
feat(pounce-rs): single-crate Rust facade + ergonomic Nlp builder (#168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ changes.
 - **Ergonomic builder API** in `pounce-rs` (argmin-style, per the #168
   discussion): implement the small `Problem` trait (only `objective` is
   required) and configure + solve with the `Nlp` builder
-  (`Nlp::new(problem, n).var_bounds(..).constraint_bounds(..).solve()`).
+  (`Nlp::new(problem).var_bounds(..).constraint_bounds(..).solve()`).
   Unimplemented `gradient` / `jacobian` are finite-differenced and the Hessian
   defaults to limited-memory L-BFGS, so a simple problem stays small; the full
   `TNLP` trait remains for advanced use. Runnable HS071 + constrained-QP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ changes.
 
 ## [Unreleased]
 
+### Added — `pounce-rs` Rust facade crate (#168)
+
+- **`pounce-rs`** is a single-crate facade for solving nonlinear programs from
+  Rust. It re-exports the `TNLP` problem trait (`pounce-nlp`), the
+  `IpoptApplication` driver (`pounce-algorithm`), and the supporting scalar
+  types (`pounce-common`) in one place, plus a `prelude` — the Rust counterpart
+  to the one-import `import pounce` Python API. Re-exports only (no logic), so
+  it also pins a single curated public surface. The 20th published crate. Docs
+  carry a complete, runnable HS071 example.
+
 ### Added — event detection (`pounce.ode.solve_ivp` / `solve_dae`)
 
 - **SciPy-compatible `events=`** on both `solve_ivp` and `solve_dae`. Zero

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,16 @@ changes.
   Rust. It re-exports the `TNLP` problem trait (`pounce-nlp`), the
   `IpoptApplication` driver (`pounce-algorithm`), and the supporting scalar
   types (`pounce-common`) in one place, plus a `prelude` — the Rust counterpart
-  to the one-import `import pounce` Python API. Re-exports only (no logic), so
-  it also pins a single curated public surface. The 20th published crate. Docs
-  carry a complete, runnable HS071 example.
+  to the one-import `import pounce` Python API. Pins a single curated public
+  surface. The 20th published crate.
+- **Ergonomic builder API** in `pounce-rs` (argmin-style, per the #168
+  discussion): implement the small `Problem` trait (only `objective` is
+  required) and configure + solve with the `Nlp` builder
+  (`Nlp::new(problem, n).var_bounds(..).constraint_bounds(..).solve()`).
+  Unimplemented `gradient` / `jacobian` are finite-differenced and the Hessian
+  defaults to limited-memory L-BFGS, so a simple problem stays small; the full
+  `TNLP` trait remains for advanced use. Runnable HS071 + constrained-QP
+  examples in the crate docs.
 
 ### Added — event detection (`pounce.ode.solve_ivp` / `solve_dae`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pounce-rs"
+version = "0.6.0"
+dependencies = [
+ "pounce-algorithm",
+ "pounce-common",
+ "pounce-nlp",
+]
+
+[[package]]
 name = "pounce-sensitivity"
 version = "0.6.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/pounce-cinterface",
     "crates/pounce-py",
     "crates/pounce-cli",
+    "crates/pounce-rs",
     "crates/pounce-studio-core",
     "crates/pounce-studio-pyo3",
     "tools/iter-diff",
@@ -48,6 +49,7 @@ default-members = [
     "crates/pounce-observability",
     "crates/pounce-cinterface",
     "crates/pounce-cli",
+    "crates/pounce-rs",
     "crates/pounce-studio-core",
     "tools/iter-diff",
 ]

--- a/crates/pounce-rs/Cargo.toml
+++ b/crates/pounce-rs/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pounce-rs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Single-crate facade for solving nonlinear programs with POUNCE from Rust: re-exports the TNLP trait, the IpoptApplication driver, and the supporting types in one place (plus a prelude)."
+keywords = ["ipopt", "nlp", "optimization", "solver", "nonlinear"]
+categories = ["mathematics", "science"]
+
+[dependencies]
+pounce-common.workspace = true
+pounce-nlp.workspace = true
+pounce-algorithm.workspace = true
+
+[lints]
+workspace = true

--- a/crates/pounce-rs/README.md
+++ b/crates/pounce-rs/README.md
@@ -1,0 +1,13 @@
+# pounce-rs
+
+Single-crate facade for solving nonlinear programs with [POUNCE](https://github.com/jkitchin/pounce)
+from Rust. Re-exports the `TNLP` problem trait (`pounce-nlp`), the
+`IpoptApplication` driver (`pounce-algorithm`), and the supporting scalar
+types (`pounce-common`) in one place, plus a `prelude`:
+
+```rust
+use pounce_rs::prelude::*;
+```
+
+This is the Rust counterpart to the one-import `import pounce` Python API. It
+contains re-exports only; see the crate docs for a complete HS071 example.

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -24,7 +24,7 @@
 //!     fn constraints(&self, x: &[f64], g: &mut [f64]) { g[0] = x[0] + x[1]; }
 //! }
 //!
-//! let sol = Nlp::new(P, 2)
+//! let sol = Nlp::new(P)                       // variable count inferred below
 //!     .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
 //!     .constraint_bounds(&[3.0], &[3.0])      // equality: lower == upper
 //!     .x0(&[0.0, 0.0])
@@ -91,44 +91,62 @@ pub struct Solution {
     pub multipliers: Vec<f64>,
 }
 
-/// Builder: `Nlp::new(problem, n)` then `.var_bounds(..).solve()`.
+/// Builder: `Nlp::new(problem)` then `.var_bounds(..)` / `.x0(..)` (which fix
+/// the number of variables) and `.solve()`.
 pub struct Nlp<P: Problem> {
     problem: P,
-    n: usize,
-    x_l: Vec<f64>,
-    x_u: Vec<f64>,
+    n: Option<usize>, // inferred from var_bounds / x0 (must agree)
+    x_l: Option<Vec<f64>>,
+    x_u: Option<Vec<f64>>,
     g_l: Vec<f64>,
     g_u: Vec<f64>,
-    x0: Vec<f64>,
+    x0: Option<Vec<f64>>,
     num: Vec<(String, f64)>,
     int: Vec<(String, i32)>,
     string: Vec<(String, String)>,
 }
 
 impl<P: Problem + 'static> Nlp<P> {
-    /// A problem in `n` variables. Variable bounds default to `±∞`, constraint
-    /// bounds to `0` (set them with [`constraint_bounds`](Self::constraint_bounds)),
-    /// and `x0` to the origin.
-    pub fn new(problem: P, n: usize) -> Self {
+    /// A new builder for `problem`. The number of variables is inferred from
+    /// the first of [`var_bounds`](Self::var_bounds) / [`x0`](Self::x0) you set
+    /// (they must agree); the number of constraints comes from
+    /// `Problem::n_constraints`. Variable bounds default to `±∞`, constraint
+    /// bounds to `0`, and `x0` to the origin.
+    pub fn new(problem: P) -> Self {
         let m = problem.n_constraints();
         Nlp {
             problem,
-            n,
-            x_l: vec![-INF; n],
-            x_u: vec![INF; n],
+            n: None,
+            x_l: None,
+            x_u: None,
             g_l: vec![0.0; m],
             g_u: vec![0.0; m],
-            x0: vec![0.0; n],
+            x0: None,
             num: Vec::new(),
             int: Vec::new(),
             string: Vec::new(),
         }
     }
 
-    /// Variable bounds `x_l ≤ x ≤ x_u` (use `±2e19` for ∞).
+    // Record (and cross-check) the variable count implied by a length-`len`
+    // argument.
+    fn set_n(&mut self, len: usize, what: &str) {
+        match self.n {
+            Some(n) if n != len => panic!(
+                "pounce_rs::Nlp: {what} has length {len}, but the problem was \
+                 already sized to {n} variables",
+            ),
+            _ => self.n = Some(len),
+        }
+    }
+
+    /// Variable bounds `x_l ≤ x ≤ x_u` (use `±2e19` for ∞). Fixes the number of
+    /// variables.
     pub fn var_bounds(mut self, lo: &[f64], hi: &[f64]) -> Self {
-        self.x_l = lo.to_vec();
-        self.x_u = hi.to_vec();
+        assert_eq!(lo.len(), hi.len(), "var_bounds: lo and hi differ in length");
+        self.set_n(lo.len(), "var_bounds");
+        self.x_l = Some(lo.to_vec());
+        self.x_u = Some(hi.to_vec());
         self
     }
 
@@ -139,9 +157,10 @@ impl<P: Problem + 'static> Nlp<P> {
         self
     }
 
-    /// Initial guess.
+    /// Initial guess. Fixes the number of variables.
     pub fn x0(mut self, x0: &[f64]) -> Self {
-        self.x0 = x0.to_vec();
+        self.set_n(x0.len(), "x0");
+        self.x0 = Some(x0.to_vec());
         self
     }
 
@@ -164,17 +183,24 @@ impl<P: Problem + 'static> Nlp<P> {
     }
 
     /// Build the `TNLP` adapter and run the interior-point solver.
+    ///
+    /// # Panics
+    /// If the number of variables was never fixed (no `var_bounds` or `x0`).
     pub fn solve(self) -> Solution {
+        let n = self.n.expect(
+            "pounce_rs::Nlp: number of variables unknown — call .var_bounds(..) \
+             or .x0(..) to set it",
+        );
         let m = self.problem.n_constraints();
         let adapter = Rc::new(RefCell::new(Adapter {
             problem: self.problem,
-            n: self.n,
+            n,
             m,
-            x_l: self.x_l,
-            x_u: self.x_u,
+            x_l: self.x_l.unwrap_or_else(|| vec![-INF; n]),
+            x_u: self.x_u.unwrap_or_else(|| vec![INF; n]),
             g_l: self.g_l,
             g_u: self.g_u,
-            x0: self.x0,
+            x0: self.x0.unwrap_or_else(|| vec![0.0; n]),
             sol_x: Vec::new(),
             sol_obj: 0.0,
             sol_lambda: Vec::new(),
@@ -333,5 +359,58 @@ impl<P: Problem> TNLP for Adapter<P> {
         self.sol_x = sol.x.to_vec();
         self.sol_obj = sol.obj_value;
         self.sol_lambda = sol.lambda.to_vec();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Quad; // min (x0-1)^2 + (x1-2)^2  s.t. x0 + x1 == 3
+    impl Problem for Quad {
+        fn objective(&self, x: &[f64]) -> f64 {
+            (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+        }
+        fn n_constraints(&self) -> usize {
+            1
+        }
+        fn constraints(&self, x: &[f64], g: &mut [f64]) {
+            g[0] = x[0] + x[1];
+        }
+    }
+
+    #[test]
+    fn infers_n_from_bounds_and_solves() {
+        let sol = Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0]) // n inferred = 2
+            .constraint_bounds(&[3.0], &[3.0])
+            .option_num("tol", 1e-10)
+            .solve();
+        assert!(sol.success);
+        assert!((sol.x[0] - 1.0).abs() < 1e-5 && (sol.x[1] - 2.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn infers_n_from_x0() {
+        let sol = Nlp::new(Quad)
+            .constraint_bounds(&[3.0], &[3.0])
+            .x0(&[0.0, 0.0]) // n inferred = 2
+            .solve();
+        assert!(sol.success);
+    }
+
+    #[test]
+    #[should_panic(expected = "already sized to 2")]
+    fn mismatched_sizes_panic() {
+        let _ = Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+            .x0(&[0.0, 0.0, 0.0]) // length 3 != 2
+            .solve();
+    }
+
+    #[test]
+    #[should_panic(expected = "number of variables unknown")]
+    fn missing_size_panics() {
+        let _ = Nlp::new(Quad).constraint_bounds(&[3.0], &[3.0]).solve();
     }
 }

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -1,0 +1,337 @@
+//! Ergonomic builder API over the [`TNLP`](crate::TNLP) trait.
+//!
+//! The raw `TNLP` interface is a faithful port of Ipopt's C++ `TNLP` (nine
+//! methods, sparsity bookkeeping, an `Rc<RefCell<dyn TNLP>>` driver) — full
+//! control, but heavy for a simple problem. This module offers the
+//! argmin-style alternative requested in
+//! [#168](https://github.com/jkitchin/pounce/issues/168): implement the small
+//! [`Problem`] trait (only `objective` is required), then configure and solve
+//! with the [`Nlp`] builder. Anything you don't implement is finite-
+//! differenced (gradient / constraint Jacobian) or approximated (the Hessian
+//! defaults to limited-memory L-BFGS), so a basic problem stays small while the
+//! full `TNLP` trait remains available for everything this doesn't expose.
+//!
+//! ```
+//! use pounce_rs::builder::{Problem, Nlp};
+//!
+//! // min (x0-1)^2 + (x1-2)^2  s.t.  x0 + x1 == 3,  0 <= xi <= 5
+//! struct P;
+//! impl Problem for P {
+//!     fn objective(&self, x: &[f64]) -> f64 {
+//!         (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+//!     }
+//!     fn n_constraints(&self) -> usize { 1 }
+//!     fn constraints(&self, x: &[f64], g: &mut [f64]) { g[0] = x[0] + x[1]; }
+//! }
+//!
+//! let sol = Nlp::new(P, 2)
+//!     .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+//!     .constraint_bounds(&[3.0], &[3.0])      // equality: lower == upper
+//!     .x0(&[0.0, 0.0])
+//!     .option_num("tol", 1e-10)
+//!     .solve();
+//!
+//! assert!(sol.success);
+//! assert!((sol.x[0] - 1.0).abs() < 1e-5 && (sol.x[1] - 2.0).abs() < 1e-5);
+//! ```
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::{
+    ApplicationReturnStatus, BoundsInfo, IndexStyle, IpoptApplication, IpoptCq, IpoptData, NlpInfo,
+    Solution as TnlpSolution, SparsityRequest, StartingPoint, TNLP,
+};
+
+const FD: f64 = 1.4901161193847656e-8; // sqrt(f64::EPSILON)
+const INF: f64 = 2.0e19; // Ipopt's "infinity" bound sentinel
+
+/// A nonlinear program. Implement `objective`; override the rest as needed.
+///
+/// `gradient` / `jacobian` return `false` (their default) to request a
+/// finite-difference approximation. The Hessian is never required — the
+/// builder uses a limited-memory (L-BFGS) approximation by default.
+pub trait Problem {
+    /// Objective `f(x)` to minimize.
+    fn objective(&self, x: &[f64]) -> f64;
+
+    /// Number of constraints `m` (default `0`, i.e. bound-constrained only).
+    fn n_constraints(&self) -> usize {
+        0
+    }
+
+    /// Constraint values `g(x)` into `out` (length `n_constraints`).
+    fn constraints(&self, _x: &[f64], _out: &mut [f64]) {}
+
+    /// Objective gradient `∇f(x)` into `grad`; return `false` for finite
+    /// differences.
+    fn gradient(&self, _x: &[f64], _grad: &mut [f64]) -> bool {
+        false
+    }
+
+    /// Dense constraint Jacobian (row-major, `n_constraints × n`) into `jac`;
+    /// return `false` for finite differences.
+    fn jacobian(&self, _x: &[f64], _jac: &mut [f64]) -> bool {
+        false
+    }
+}
+
+/// The outcome of [`Nlp::solve`].
+#[derive(Debug, Clone)]
+pub struct Solution {
+    /// Solver status; `success` is the convenient boolean.
+    pub status: ApplicationReturnStatus,
+    /// `true` for `SolveSucceeded` / `SolvedToAcceptableLevel`.
+    pub success: bool,
+    /// Optimal variables.
+    pub x: Vec<f64>,
+    /// Objective at the solution.
+    pub objective: f64,
+    /// Constraint multipliers `λ` (length `n_constraints`).
+    pub multipliers: Vec<f64>,
+}
+
+/// Builder: `Nlp::new(problem, n)` then `.var_bounds(..).solve()`.
+pub struct Nlp<P: Problem> {
+    problem: P,
+    n: usize,
+    x_l: Vec<f64>,
+    x_u: Vec<f64>,
+    g_l: Vec<f64>,
+    g_u: Vec<f64>,
+    x0: Vec<f64>,
+    num: Vec<(String, f64)>,
+    int: Vec<(String, i32)>,
+    string: Vec<(String, String)>,
+}
+
+impl<P: Problem + 'static> Nlp<P> {
+    /// A problem in `n` variables. Variable bounds default to `±∞`, constraint
+    /// bounds to `0` (set them with [`constraint_bounds`](Self::constraint_bounds)),
+    /// and `x0` to the origin.
+    pub fn new(problem: P, n: usize) -> Self {
+        let m = problem.n_constraints();
+        Nlp {
+            problem,
+            n,
+            x_l: vec![-INF; n],
+            x_u: vec![INF; n],
+            g_l: vec![0.0; m],
+            g_u: vec![0.0; m],
+            x0: vec![0.0; n],
+            num: Vec::new(),
+            int: Vec::new(),
+            string: Vec::new(),
+        }
+    }
+
+    /// Variable bounds `x_l ≤ x ≤ x_u` (use `±2e19` for ∞).
+    pub fn var_bounds(mut self, lo: &[f64], hi: &[f64]) -> Self {
+        self.x_l = lo.to_vec();
+        self.x_u = hi.to_vec();
+        self
+    }
+
+    /// Constraint bounds `g_l ≤ g(x) ≤ g_u` (`g_l == g_u` is an equality).
+    pub fn constraint_bounds(mut self, lo: &[f64], hi: &[f64]) -> Self {
+        self.g_l = lo.to_vec();
+        self.g_u = hi.to_vec();
+        self
+    }
+
+    /// Initial guess.
+    pub fn x0(mut self, x0: &[f64]) -> Self {
+        self.x0 = x0.to_vec();
+        self
+    }
+
+    /// A numeric solver option (e.g. `("tol", 1e-8)`).
+    pub fn option_num(mut self, tag: &str, value: f64) -> Self {
+        self.num.push((tag.to_string(), value));
+        self
+    }
+
+    /// An integer solver option (e.g. `("max_iter", 500)`).
+    pub fn option_int(mut self, tag: &str, value: i32) -> Self {
+        self.int.push((tag.to_string(), value));
+        self
+    }
+
+    /// A string solver option (e.g. `("mu_strategy", "adaptive")`).
+    pub fn option_str(mut self, tag: &str, value: &str) -> Self {
+        self.string.push((tag.to_string(), value.to_string()));
+        self
+    }
+
+    /// Build the `TNLP` adapter and run the interior-point solver.
+    pub fn solve(self) -> Solution {
+        let m = self.problem.n_constraints();
+        let adapter = Rc::new(RefCell::new(Adapter {
+            problem: self.problem,
+            n: self.n,
+            m,
+            x_l: self.x_l,
+            x_u: self.x_u,
+            g_l: self.g_l,
+            g_u: self.g_u,
+            x0: self.x0,
+            sol_x: Vec::new(),
+            sol_obj: 0.0,
+            sol_lambda: Vec::new(),
+        }));
+
+        let mut app = IpoptApplication::new();
+        app.initialize().expect("IpoptApplication::initialize");
+        // No analytic Hessian is required from `Problem`, so default to L-BFGS.
+        let _ = app.options_mut().set_string_value(
+            "hessian_approximation",
+            "limited-memory",
+            true,
+            true,
+        );
+        for (k, v) in &self.string {
+            let _ = app.options_mut().set_string_value(k, v, true, true);
+        }
+        for (k, v) in &self.num {
+            let _ = app.options_mut().set_numeric_value(k, *v, true, true);
+        }
+        for (k, v) in &self.int {
+            let _ = app.options_mut().set_integer_value(k, *v, true, true);
+        }
+
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&adapter) as _;
+        let status = app.optimize_tnlp(tnlp);
+        let a = adapter.borrow();
+        Solution {
+            status,
+            success: matches!(
+                status,
+                ApplicationReturnStatus::SolveSucceeded
+                    | ApplicationReturnStatus::SolvedToAcceptableLevel
+            ),
+            x: a.sol_x.clone(),
+            objective: a.sol_obj,
+            multipliers: a.sol_lambda.clone(),
+        }
+    }
+}
+
+/// Internal `TNLP` adapter: owns the user [`Problem`] and config, fills in
+/// finite-difference gradient / Jacobian and a dense Jacobian sparsity.
+struct Adapter<P: Problem> {
+    problem: P,
+    n: usize,
+    m: usize,
+    x_l: Vec<f64>,
+    x_u: Vec<f64>,
+    g_l: Vec<f64>,
+    g_u: Vec<f64>,
+    x0: Vec<f64>,
+    sol_x: Vec<f64>,
+    sol_obj: f64,
+    sol_lambda: Vec<f64>,
+}
+
+impl<P: Problem> TNLP for Adapter<P> {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: self.n as i32,
+            m: self.m as i32,
+            nnz_jac_g: (self.m * self.n) as i32, // dense Jacobian
+            nnz_h_lag: 0,                        // L-BFGS: no analytic Hessian
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&self.x_l);
+        b.x_u.copy_from_slice(&self.x_u);
+        b.g_l.copy_from_slice(&self.g_l);
+        b.g_u.copy_from_slice(&self.g_u);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&self.x0);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[f64], _new_x: bool) -> Option<f64> {
+        Some(self.problem.objective(x))
+    }
+
+    fn eval_grad_f(&mut self, x: &[f64], _new_x: bool, grad: &mut [f64]) -> bool {
+        if self.problem.gradient(x, grad) {
+            return true;
+        }
+        // forward-difference fallback
+        let f0 = self.problem.objective(x);
+        let mut xp = x.to_vec();
+        for j in 0..self.n {
+            let h = FD * x[j].abs().max(1.0);
+            xp[j] = x[j] + h;
+            grad[j] = (self.problem.objective(&xp) - f0) / h;
+            xp[j] = x[j];
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+        self.problem.constraints(x, g);
+        true
+    }
+
+    fn eval_jac_g(&mut self, x: Option<&[f64]>, _new_x: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let mut k = 0;
+                for i in 0..self.m {
+                    for j in 0..self.n {
+                        irow[k] = i as i32;
+                        jcol[k] = j as i32;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_jac_g(Values) without x");
+                if self.problem.jacobian(x, values) {
+                    return true;
+                }
+                // forward-difference fallback (dense)
+                let mut g0 = vec![0.0; self.m];
+                self.problem.constraints(x, &mut g0);
+                let mut xp = x.to_vec();
+                let mut gp = vec![0.0; self.m];
+                for j in 0..self.n {
+                    let h = FD * x[j].abs().max(1.0);
+                    xp[j] = x[j] + h;
+                    self.problem.constraints(&xp, &mut gp);
+                    for i in 0..self.m {
+                        values[i * self.n + j] = (gp[i] - g0[i]) / h;
+                    }
+                    xp[j] = x[j];
+                }
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[f64]>,
+        _new_x: bool,
+        _obj_factor: f64,
+        _lambda: Option<&[f64]>,
+        _new_lambda: bool,
+        _mode: SparsityRequest<'_>,
+    ) -> bool {
+        false // never called: the builder uses limited-memory (L-BFGS)
+    }
+
+    fn finalize_solution(&mut self, sol: TnlpSolution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.sol_x = sol.x.to_vec();
+        self.sol_obj = sol.obj_value;
+        self.sol_lambda = sol.lambda.to_vec();
+    }
+}

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -1,0 +1,162 @@
+//! # pounce-rs — solve nonlinear programs with POUNCE from Rust
+//!
+//! POUNCE's solver lives across several crates (`pounce-nlp` for the
+//! [`TNLP`] problem trait, `pounce-algorithm` for the [`IpoptApplication`]
+//! driver, `pounce-common` for the scalar types). This crate is a thin
+//! **facade**: it re-exports everything needed to define and solve a problem,
+//! so a Rust user depends on one crate and writes `use pounce_rs::prelude::*;`
+//! — the Rust counterpart to the one-import `import pounce` Python API.
+//!
+//! It is re-exports only (no logic of its own), and it pins a single curated
+//! public surface, so downstream code is insulated from churn in the internal
+//! crate layout.
+//!
+//! ## Example: HS071 (Hock–Schittkowski problem 71)
+//!
+//! ```text
+//! min  x1*x4*(x1 + x2 + x3) + x3
+//! s.t. x1*x2*x3*x4 >= 25
+//!      x1^2 + x2^2 + x3^2 + x4^2 == 40
+//!      1 <= xi <= 5
+//! ```
+//!
+//! ```
+//! use pounce_rs::prelude::*;
+//! use std::cell::RefCell;
+//! use std::rc::Rc;
+//!
+//! #[derive(Default)]
+//! struct Hs071 {
+//!     obj: Option<f64>,
+//!     x: Option<[f64; 4]>,
+//! }
+//!
+//! impl TNLP for Hs071 {
+//!     fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+//!         Some(NlpInfo { n: 4, m: 2, nnz_jac_g: 8, nnz_h_lag: 10, index_style: IndexStyle::C })
+//!     }
+//!
+//!     fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+//!         b.x_l.copy_from_slice(&[1.0; 4]);
+//!         b.x_u.copy_from_slice(&[5.0; 4]);
+//!         b.g_l.copy_from_slice(&[25.0, 40.0]);          // g0 >= 25, g1 == 40
+//!         b.g_u.copy_from_slice(&[2.0e19, 40.0]);
+//!         true
+//!     }
+//!
+//!     fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+//!         sp.x.copy_from_slice(&[1.0, 5.0, 5.0, 1.0]);
+//!         true
+//!     }
+//!
+//!     fn eval_f(&mut self, x: &[f64], _new_x: bool) -> Option<f64> {
+//!         Some(x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2])
+//!     }
+//!
+//!     fn eval_grad_f(&mut self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+//!         g[0] = x[3] * (2.0 * x[0] + x[1] + x[2]);
+//!         g[1] = x[0] * x[3];
+//!         g[2] = x[0] * x[3] + 1.0;
+//!         g[3] = x[0] * (x[0] + x[1] + x[2]);
+//!         true
+//!     }
+//!
+//!     fn eval_g(&mut self, x: &[f64], _new_x: bool, g: &mut [f64]) -> bool {
+//!         g[0] = x[0] * x[1] * x[2] * x[3];
+//!         g[1] = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] + x[3] * x[3];
+//!         true
+//!     }
+//!
+//!     fn eval_jac_g(&mut self, x: Option<&[f64]>, _new_x: bool, mode: SparsityRequest<'_>) -> bool {
+//!         match mode {
+//!             SparsityRequest::Structure { irow, jcol } => {
+//!                 irow.copy_from_slice(&[0, 0, 0, 0, 1, 1, 1, 1]);
+//!                 jcol.copy_from_slice(&[0, 1, 2, 3, 0, 1, 2, 3]);
+//!             }
+//!             SparsityRequest::Values { values } => {
+//!                 let x = x.unwrap();
+//!                 values.copy_from_slice(&[
+//!                     x[1] * x[2] * x[3], x[0] * x[2] * x[3], x[0] * x[1] * x[3], x[0] * x[1] * x[2],
+//!                     2.0 * x[0], 2.0 * x[1], 2.0 * x[2], 2.0 * x[3],
+//!                 ]);
+//!             }
+//!         }
+//!         true
+//!     }
+//!
+//!     fn eval_h(&mut self, x: Option<&[f64]>, _new_x: bool, of: f64,
+//!               lambda: Option<&[f64]>, _new_lambda: bool, mode: SparsityRequest<'_>) -> bool {
+//!         match mode {
+//!             SparsityRequest::Structure { irow, jcol } => {
+//!                 irow.copy_from_slice(&[0, 1, 1, 2, 2, 2, 3, 3, 3, 3]);
+//!                 jcol.copy_from_slice(&[0, 0, 1, 0, 1, 2, 0, 1, 2, 3]);
+//!             }
+//!             SparsityRequest::Values { values } => {
+//!                 let x = x.unwrap();
+//!                 let l = lambda.unwrap();
+//!                 values.copy_from_slice(&[
+//!                     of * (2.0 * x[3]) + l[1] * 2.0,
+//!                     of * x[3] + l[0] * (x[2] * x[3]),
+//!                     l[1] * 2.0,
+//!                     of * x[3] + l[0] * (x[1] * x[3]),
+//!                     l[0] * (x[0] * x[3]),
+//!                     l[1] * 2.0,
+//!                     of * (2.0 * x[0] + x[1] + x[2]) + l[0] * (x[1] * x[2]),
+//!                     of * x[0] + l[0] * (x[0] * x[2]),
+//!                     of * x[0] + l[0] * (x[0] * x[1]),
+//!                     l[1] * 2.0,
+//!                 ]);
+//!             }
+//!         }
+//!         true
+//!     }
+//!
+//!     fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+//!         self.obj = Some(sol.obj_value);
+//!         self.x = Some([sol.x[0], sol.x[1], sol.x[2], sol.x[3]]);
+//!     }
+//! }
+//!
+//! let mut app = IpoptApplication::new();
+//! app.initialize().unwrap();
+//! let prob = Rc::new(RefCell::new(Hs071::default()));
+//! let status = app.optimize_tnlp(Rc::clone(&prob) as Rc<RefCell<dyn TNLP>>);
+//!
+//! assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+//! let obj = prob.borrow().obj.unwrap();
+//! assert!((obj - 17.014_017).abs() < 1e-4);            // known optimum
+//! ```
+
+// --- scalar types -----------------------------------------------------------
+pub use pounce_common::types::{Index, Number};
+
+// --- the problem trait and its supporting types -----------------------------
+pub use pounce_nlp::return_codes::{AlgorithmMode, ApplicationReturnStatus};
+pub use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, IterStats, Linearity, MetaData, NlpInfo,
+    ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
+};
+
+// --- the solver driver ------------------------------------------------------
+pub use pounce_algorithm::application::IpoptApplication;
+
+// --- the underlying crates, for anything not surfaced above -----------------
+pub use pounce_algorithm;
+pub use pounce_common;
+pub use pounce_nlp;
+
+/// The common case in one glob import: the [`TNLP`] trait, the
+/// [`IpoptApplication`] driver, and the types a problem definition touches.
+///
+/// ```
+/// use pounce_rs::prelude::*;
+/// ```
+pub mod prelude {
+    pub use pounce_algorithm::application::IpoptApplication;
+    pub use pounce_common::types::{Index, Number};
+    pub use pounce_nlp::return_codes::ApplicationReturnStatus;
+    pub use pounce_nlp::tnlp::{
+        BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution,
+        SparsityRequest, StartingPoint, TNLP,
+    };
+}

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -145,13 +145,19 @@ pub use pounce_algorithm;
 pub use pounce_common;
 pub use pounce_nlp;
 
-/// The common case in one glob import: the [`TNLP`] trait, the
-/// [`IpoptApplication`] driver, and the types a problem definition touches.
+// --- ergonomic builder API (argmin-style small trait + builder; #168) -------
+pub mod builder;
+pub use builder::{Nlp, Problem, Solution as NlpSolution};
+
+/// The common case in one glob import. Brings in the ergonomic [`Problem`]
+/// trait + [`Nlp`] builder, plus the low-level [`TNLP`] surface and the
+/// [`IpoptApplication`] driver for full control.
 ///
 /// ```
 /// use pounce_rs::prelude::*;
 /// ```
 pub mod prelude {
+    pub use crate::builder::{Nlp, Problem};
     pub use pounce_algorithm::application::IpoptApplication;
     pub use pounce_common::types::{Index, Number};
     pub use pounce_nlp::return_codes::ApplicationReturnStatus;

--- a/dev-notes/cargo-release.md
+++ b/dev-notes/cargo-release.md
@@ -1,6 +1,6 @@
 # crates.io release
 
-POUNCE ships **19** Rust crates to crates.io. This file is the procedure.
+POUNCE ships **20** Rust crates to crates.io. This file is the procedure.
 For the PyPI side (`pounce-solver` + `pyomo-pounce`), see `pypi-release.md`.
 
 The publish list and its dependency order live in
@@ -13,7 +13,7 @@ are documentation, not a second source of truth to keep hand-synced.
 ## What publishes, what does not
 
 The publishable set is exactly "every workspace member without
-`publish = false`". As of this writing that is these 19:
+`publish = false`". As of this writing that is these 20:
 
 | Crate                  | Publishes? | Role                                         |
 | ---------------------- | ---------- | -------------------------------------------- |
@@ -36,6 +36,7 @@ The publishable set is exactly "every workspace member without
 | `pounce-nl`            | yes        | `.nl` reader + AD tape; pounce-cli depends   |
 | `pounce-studio-core`   | yes        | solve-report parsers; pounce-cli dep (0.4.0+)|
 | `pounce-cli`           | yes        | `pounce` and `pounce_sens` binaries          |
+| `pounce-rs`            | yes        | single-crate Rust facade (re-exports TNLP + driver) |
 | `pounce-py`            | **no**     | ships on PyPI as `pounce-solver` via maturin |
 | `pounce-studio-pyo3`   | **no**     | PyO3 wrapper; ships on PyPI                   |
 | `iter-diff`            | **no**     | internal Track-A validation tool             |
@@ -153,7 +154,7 @@ crates and drives `release-crates.yml`.)
 
 | Surface                 | Workflow                              | Trigger                  |
 | ----------------------- | ------------------------------------- | ------------------------ |
-| crates.io (19 crates)   | `release-crates.yml`                  | `v*` tag / manual        |
+| crates.io (20 crates)   | `release-crates.yml`                  | `v*` tag / manual        |
 | PyPI `pounce-solver`    | `release-pounce.yml`                  | `python-v*` tag          |
 | PyPI `pyomo-pounce`     | `release-pyomo-pounce.yml`            | `pyomo-pounce-v*` tag    |
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -54,6 +54,7 @@ CRATES=(
   pounce-nl
   pounce-studio-core
   pounce-cli
+  pounce-rs
 )
 
 DRY_RUN=""


### PR DESCRIPTION
Closes #168.

## Problem
A Rust "define + solve" currently pulls from three crates with deep paths:
```rust
use pounce_algorithm::application::IpoptApplication;
use pounce_common::types::Number;
use pounce_nlp::return_codes::ApplicationReturnStatus;
use pounce_nlp::tnlp::{TNLP, IndexStyle, NlpInfo, /* … */};
```
— versus the one-import `import pounce` Python API. There's no single crate that
*is* "depend on POUNCE from Rust."

## This PR
Adds **`pounce-rs`**, a thin facade crate (re-exports only, no logic) that
surfaces the whole NLP-solve API in one place plus a `prelude`:
```rust
use pounce_rs::prelude::*;
```
It re-exports `TNLP` + its supporting types (`pounce-nlp`), `IpoptApplication`
(`pounce-algorithm`), and `Index`/`Number` (`pounce-common`); the underlying
crates are also re-exported (`pounce_rs::pounce_algorithm`, …) for anything not
in the curated surface. Because it pins one public surface, downstream code is
insulated from internal-crate churn — the maintainability point @GermanHeim
raised.

Naming: `pounce` is taken on crates.io (a chess engine); `pounce-rs` is free and
clearest. `pounce-core` would be misleading (it's a facade, not the core).

## Docs / example
The crate docs include a complete **HS071** example (mirroring the Python one in
the issue) that runs as a **doctest** and asserts the known optimum
(`f* = 17.014017`).

## Release plumbing
- Added to workspace `members` / `default-members`.
- Added to `scripts/publish-crates.sh` (last, topological — depends on
  algorithm/nlp/common).
- `dev-notes/cargo-release.md`: 19 → **20** crates (+ table row).
- `scripts/check-release-consistency.sh` passes (20 crates, set matches `cargo
  metadata`, topo order). New crate name ⇒ a first-publish at the next release
  (new-crate rate limit applies once).

## Tests
Doctests green: the HS071 solve and the prelude import both compile and run.

Scope: NLP surface only for now; convex/QP (`pounce-convex`) and sensitivity
(`pounce-sensitivity`) re-exports can be added (feature-gated) as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
---

## Update: ergonomic builder added (per #168 discussion)

Following @GermanHeim's preference for an **argmin-style small trait + a builder**
(not closures; not `Executor::new(problem, solver)` since pounce has one solver),
`pounce-rs` now also ships an ergonomic layer **on top of** the re-exported
`TNLP` surface:

```rust
use pounce_rs::builder::{Problem, Nlp};

struct P;                                   // min (x0-1)² + (x1-2)²  s.t. x0+x1==3
impl Problem for P {
    fn objective(&self, x: &[f64]) -> f64 { (x[0]-1.0).powi(2) + (x[1]-2.0).powi(2) }
    fn n_constraints(&self) -> usize { 1 }
    fn constraints(&self, x: &[f64], g: &mut [f64]) { g[0] = x[0] + x[1]; }
}

let sol = Nlp::new(P, 2)
    .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
    .constraint_bounds(&[3.0], &[3.0])
    .x0(&[0.0, 0.0])
    .option_num("tol", 1e-10)
    .solve();                               // Solution { x, objective, multipliers, status, success }
```

- Small `Problem` trait — only `objective` is required; `n_constraints` /
  `constraints` / `gradient` / `jacobian` are optional. Unimplemented gradient
  and Jacobian are **finite-differenced**; the Hessian defaults to
  **limited-memory L-BFGS**, so `eval_h` is never needed.
- The `Nlp` builder configures bounds / `x0` / options and `.solve()`s; it
  builds an internal `TNLP` adapter (a Rust analog of the Python `PyTnlp`
  bridge) and runs `IpoptApplication`.
- The full `TNLP` trait remains exposed for advanced control (custom sparsity,
  metadata, scaling, intermediate callbacks).

Doctests green: HS071 via raw `TNLP`, the constrained QP via the builder, and
the prelude import.