### PR TITLE
chore(deps): bump feral to 0.11.3 + fix iter-dump test flake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "feral"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7695a95dae6fdef1d1923752d70bd992d42b7ce4f8f7b23fe48e01bd463301d"
+checksum = "737271f4c9f92a85444ea8142c6d10fc35a7521fc80a0b228614861f5316a438"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.6.0"
 # feral: pinned to the published crates.io release so the pounce crates stay
 # publishable — a git rev would block the crates.io publish and is rejected by
 # scripts/check-release-consistency.sh ("git dependency … needs a crates.io
-# version"). 0.11.0 ships the formerly-unreleased MC64/scaling perf work (#80),
+# version"). 0.11.x ships the formerly-unreleased MC64/scaling perf work (#80),
 # LU basis engine (#81), and correctness campaign (#82/#83) that we previously
 # carried locally via a git patch. 0.11.1 adds a Forrest–Tomlin bump
 # re-triangularization fast path (a bump-local sub-diagonal pivot index that
@@ -95,13 +95,13 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.6.0"
 # (~15.8× on the casctanks root LP solve). 0.11.2 pools the Forrest–Tomlin
 # `SparseLu::update` scratch buffers (≈1804→82 heap allocs/update, ~31% faster
 # on a 144-update replay chain) — again bit-identical numerics, no API change.
-# If you ever need to develop against an
+# 0.11.3 is the current pin. If you ever need to develop against an
 # unreleased feral again, add an UNCOMMITTED `[patch.crates-io]` redirecting
 # feral to the git rev — e.g.
 #   [patch.crates-io]
 #   feral = { git = "https://github.com/jkitchin/feral.git", rev = "<sha>" }
 # Do NOT commit that patch (it re-introduces the publish blocker).
-feral = { version = "0.11.2" }
+feral = { version = "0.11.3" }
 # Dense linear algebra for the debugger's numerical rank diagnosis
 # (SVD of the active-constraint Jacobian). Pure-Rust, MIT; we pull only
 # the dense `std` core — no rayon/sparse/rand/npy.

--- a/crates/pounce-algorithm/src/iter_dump.rs
+++ b/crates/pounce-algorithm/src/iter_dump.rs
@@ -83,6 +83,23 @@ impl IterDumper {
         })
     }
 
+    /// Test-only constructor that opens `path` directly, bypassing the
+    /// process environment. Unit tests must NOT round-trip through
+    /// `from_env()`/`set_var`: the solver hot paths read `POUNCE_DBG_*`
+    /// via `std::env::var` on concurrently-running test threads, and on
+    /// glibc a `setenv` racing those `getenv` calls can hand back a
+    /// corrupted value — which made `from_env` open the wrong path and the
+    /// test read an empty file (the CI flake this replaces).
+    #[cfg(test)]
+    fn for_test(path: &std::path::Path, name: &str) -> std::io::Result<Self> {
+        let file = File::create(path)?;
+        Ok(Self {
+            writer: BufWriter::new(file),
+            header_written: false,
+            name: name.to_string(),
+        })
+    }
+
     fn write_u32(&mut self, v: u32) -> std::io::Result<()> {
         self.writer.write_all(&v.to_le_bytes())
     }
@@ -131,6 +148,14 @@ impl IterDumper {
             self.writer.write_all(&0.0_f64.to_le_bytes())?;
         }
         Ok(())
+    }
+
+    /// Flush buffered bytes to the underlying file. `Drop` also flushes,
+    /// but that path can only warn on failure; call this when you need to
+    /// observe (and surface) a flush error — e.g. before reading the file
+    /// back in a test.
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.writer.flush()
     }
 
     /// Emit the fixed POUNCEIT header. Called once before the first
@@ -260,7 +285,7 @@ impl Drop for IterDumper {
     fn drop(&mut self) {
         // BufWriter flushes on drop, but surface any error rather than
         // swallowing it silently.
-        if let Err(e) = self.writer.flush() {
+        if let Err(e) = self.flush() {
             tracing::warn!(target: "pounce::diagnostics", "iter_dump: failed to flush trace file on drop: {}", e);
         }
     }
@@ -285,6 +310,20 @@ mod tests {
         ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner())
     }
 
+    /// A process- and call-unique temp path. `std::process::id()` alone is
+    /// constant for the whole test binary, so a re-run or any future test
+    /// reusing the same prefix would share one file; the atomic counter
+    /// makes every path unique within the process, removing that footgun.
+    fn unique_temp_path(tag: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "pounce_iter_dump_{tag}_{}_{n}.bin",
+            std::process::id()
+        ))
+    }
+
     fn dense(n: i32, vals: Option<&[Number]>) -> Rc<dyn Vector> {
         let space = DenseVectorSpace::new(n);
         let mut dv = space.make_new_dense();
@@ -296,17 +335,15 @@ mod tests {
 
     #[test]
     fn write_vec_emits_len_then_values_little_endian() {
-        let _env = env_guard();
-        // Round-trip a small vector through write_vec → in-memory buffer.
-        // We don't have IpoptDataHandle here, so we test write_vec
-        // directly via a tempfile + manual byte-level check.
-        let path =
-            std::env::temp_dir().join(format!("pounce_iter_dump_test_{}.bin", std::process::id()));
-        std::env::set_var(ENV_DUMP_PATH, &path);
-        let mut dumper = IterDumper::from_env().expect("dumper");
-        std::env::remove_var(ENV_DUMP_PATH);
+        // Round-trip a small vector through write_vec → tempfile. Open the
+        // file directly (no env) — see `for_test`.
+        let path = unique_temp_path("vec");
+        let mut dumper = IterDumper::for_test(&path, "").expect("dumper");
         let v = dense(3, Some(&[1.0_f64, 2.0, 3.0]));
         dumper.write_vec(&*v).unwrap();
+        // Flush explicitly so a write/flush failure surfaces here as a
+        // clear error instead of a mystifying empty-file assert below.
+        dumper.flush().expect("flush");
         drop(dumper);
         let bytes = std::fs::read(&path).unwrap();
         // 4 bytes len (=3) + 3 * 8 bytes values
@@ -320,6 +357,9 @@ mod tests {
 
     #[test]
     fn from_env_returns_none_when_unset() {
+        // The only test that still touches the process environment, and it
+        // only reads/clears `ENV_DUMP_PATH` (no test sets it anymore), so
+        // there is no setenv/getenv data race with concurrent tests.
         let _env = env_guard();
         std::env::remove_var(ENV_DUMP_PATH);
         assert!(IterDumper::from_env().is_none());
@@ -327,15 +367,11 @@ mod tests {
 
     #[test]
     fn header_writes_magic_and_version() {
-        let _env = env_guard();
-        let path =
-            std::env::temp_dir().join(format!("pounce_iter_dump_hdr_{}.bin", std::process::id()));
-        std::env::set_var(ENV_DUMP_PATH, &path);
-        std::env::set_var(ENV_DUMP_NAME, "hs071");
-        let mut dumper = IterDumper::from_env().expect("dumper");
-        std::env::remove_var(ENV_DUMP_PATH);
-        std::env::remove_var(ENV_DUMP_NAME);
+        // Open the file directly (no env) — see `for_test`.
+        let path = unique_temp_path("hdr");
+        let mut dumper = IterDumper::for_test(&path, "hs071").expect("dumper");
         dumper.write_header(4, 2).unwrap();
+        dumper.flush().expect("flush");
         drop(dumper);
         let bytes = std::fs::read(&path).unwrap();
         assert_eq!(&bytes[0..8], MAGIC);


### PR DESCRIPTION
## Summary

Two small changes on top of `main`:

1. **`chore(deps): bump feral to 0.11.3`** — moves the workspace feral pin from
   `0.11.2` → `0.11.3` (latest crates.io release) and refreshes `Cargo.lock`.
   Pin stays a plain crates.io version, so the publish path and
   `check-release-consistency.sh` are unaffected.

2. **`fix(iter-dump): drop env round-trip in unit tests to kill CI flake`** —
   fixes a genuinely racy test that was failing CI intermittently.

## The flake (and why it was real)

`iter_dump`'s file-write tests set `IPOPT_ITER_DUMP_PATH` and rebuilt the dumper
via `from_env()`. `set_var` is a process-global write that races the many
`std::env::var`/`var_os` reads in the solver hot paths (`POUNCE_DBG_*`) running
on concurrent test threads. On glibc, a `setenv` racing those `getenv` calls can
hand back a corrupted value, so `from_env` opened the wrong path and the test
read back an **empty file** (`bytes.len() == 0`, expected 28/37). The `env_guard`
mutex only serialized the three `iter_dump` tests — not the other ~260 running
concurrently — so it never closed the race.

This reproduced locally at ~1-in-6 once the failure mode was made observable.

## Fix

- Add a `#[cfg(test)] for_test(path, name)` constructor that opens the file
  directly, so `write_vec_*` / `header_*` never touch the environment. Only
  `from_env_returns_none_when_unset` still reads env, and nothing sets
  `ENV_DUMP_PATH` anymore, so no setenv/getenv race remains.
- Give each test a process-unique temp path (atomic counter, not bare PID) so a
  re-run or a future same-prefix test can't share a file.
- Add `IterDumper::flush()` (delegated to from `Drop`) and call it explicitly
  before reading, so a real flush error surfaces as a clear failure instead of a
  mystifying empty-file assert.

## Test plan

- Full `pounce-algorithm` lib suite: **40/40 runs green** locally (was ~1-in-6
  failing before).
- `cargo clippy -p pounce-algorithm --lib --tests` clean.
- CI re-run on the pushed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
