### PR TITLE
fix(ode): dense-LU + complex-split RADAU5 stage solve, exact JAX/central-diff Jacobian (#175)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1046,6 +1046,7 @@ dependencies = [
 name = "pounce-py"
 version = "0.6.0"
 dependencies = [
+ "faer",
  "feral",
  "numpy",
  "pounce-algorithm",

--- a/crates/pounce-py/Cargo.toml
+++ b/crates/pounce-py/Cargo.toml
@@ -35,6 +35,7 @@ pounce-convex.workspace = true
 pounce-restoration.workspace = true
 pounce-feral.workspace = true
 feral.workspace = true
+faer.workspace = true
 pounce-linsol.workspace = true
 pounce-sensitivity.workspace = true
 pounce-observability.workspace = true

--- a/crates/pounce-py/src/dense_lu.rs
+++ b/crates/pounce-py/src/dense_lu.rs
@@ -1,0 +1,88 @@
+//! PyO3 binding for faer's dense partial-pivoting LU (general `A x = b` on a
+//! small **dense** matrix).
+//!
+//! `pounce.ode`'s Radau IIA(5) integrator factorizes the `(3n×3n)` stage
+//! operator `I⊗M − h(A⊗J)` and the `(n×n)` error operator every step. These
+//! are dense and tiny, but the engine previously ran them through FERAL's
+//! *sparse* LU (over a full dense pattern), which (a) pays sparse symbolic /
+//! supernodal overhead on a 6×6/9×9 block and (b) is stricter than LAPACK —
+//! it hard-fails as `SingularBasis` on the ill-conditioned (large-`h`) stage
+//! matrices a stiff/DAE problem reaches on its slow manifold, crashing the
+//! integration (pounce#175).
+//!
+//! A dense partial-pivoting LU is the right tool: faster on these blocks, no
+//! symbolic phase, and — like LAPACK / SciPy's `Radau` — it always completes
+//! (a genuinely singular matrix shows up as `inf`/`nan` in the *solve*, which
+//! the Newton/error control already handles by shrinking the step) rather than
+//! refusing to factor.
+//!
+//! Interface mirrors [`crate::sparse_lu::PySparseLu`] (`factor(values)` /
+//! `solve(b)`) so the Python side swaps backends with no call-site changes.
+//! Values are row-major (C-order) `n*n`, matching `numpy`'s default flatten.
+
+use faer::linalg::solvers::{PartialPivLu, Solve};
+use faer::Mat;
+use numpy::{IntoPyArray, PyReadonlyArray1};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+
+#[pyclass(name = "DenseLU", module = "pounce._pounce", unsendable)]
+pub struct PyDenseLu {
+    n: usize,
+    lu: Option<PartialPivLu<f64>>,
+}
+
+#[pymethods]
+impl PyDenseLu {
+    /// Build a reusable dense LU for an `n × n` matrix. Numerical values are
+    /// supplied later by [`Self::factor`].
+    #[new]
+    fn new(n: usize) -> Self {
+        Self { n, lu: None }
+    }
+
+    /// Factor `A` from its **row-major** `n*n` `values`. Dense
+    /// partial-pivoting LU has no symbolic phase and never rejects a matrix as
+    /// "singular": a rank-deficient `A` only surfaces as `inf`/`nan` in a
+    /// later :meth:`solve`.
+    fn factor(&mut self, values: PyReadonlyArray1<f64>) -> PyResult<()> {
+        let v = values.as_slice()?;
+        let n = self.n;
+        if v.len() != n * n {
+            return Err(PyValueError::new_err(format!(
+                "DenseLU.factor: values has length {} but expected n*n = {}",
+                v.len(),
+                n * n
+            )));
+        }
+        // Row-major (C-order) input → faer's column-major `Mat`:
+        // logical `A[(i, j)] = v[i*n + j]`.
+        let a = Mat::from_fn(n, n, |i, j| v[i * n + j]);
+        self.lu = Some(PartialPivLu::new(a.as_ref()));
+        Ok(())
+    }
+
+    /// Solve `A x = b`, returning `x`. Requires a prior :meth:`factor`.
+    fn solve<'py>(
+        &mut self,
+        py: Python<'py>,
+        b: PyReadonlyArray1<f64>,
+    ) -> PyResult<Bound<'py, numpy::PyArray1<f64>>> {
+        let lu = self
+            .lu
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("DenseLU.solve: call factor() first"))?;
+        let bs = b.as_slice()?;
+        if bs.len() != self.n {
+            return Err(PyValueError::new_err(format!(
+                "DenseLU.solve: rhs length {} != n {}",
+                bs.len(),
+                self.n
+            )));
+        }
+        let mut rhs = Mat::from_fn(self.n, 1, |i, _| bs[i]);
+        lu.solve_in_place(rhs.as_mut());
+        let out: Vec<f64> = (0..self.n).map(|i| rhs[(i, 0)]).collect();
+        Ok(out.into_pyarray_bound(py))
+    }
+}

--- a/crates/pounce-py/src/lib.rs
+++ b/crates/pounce-py/src/lib.rs
@@ -19,6 +19,7 @@
 
 use pyo3::prelude::*;
 
+mod dense_lu;
 mod nl_problem;
 mod nlp_batch;
 mod problem;
@@ -48,6 +49,7 @@ fn _pounce(_py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PySolver>()?;
     m.add_class::<PyNlProblem>()?;
     m.add_class::<sparse_lu::PySparseLu>()?;
+    m.add_class::<dense_lu::PyDenseLu>()?;
     m.add_function(wrap_pyfunction!(read_nl, m)?)?;
     // Batched NLP solving (pounce#126): native `.nl` path (phase 1)
     // and callback-Problem path (phase 2).

--- a/python/pounce/ode/__init__.py
+++ b/python/pounce/ode/__init__.py
@@ -3,12 +3,43 @@
 ``pounce.ode.solve_ivp`` is a drop-in for :func:`scipy.integrate.solve_ivp`
 with the implicit ``Radau`` method (3-stage Radau IIA, order 5, L-stable):
 it integrates **stiff** systems, and — given a mass matrix ``M`` (``M y' =
-f``) — index-1 **DAEs**, which SciPy's ``solve_ivp`` cannot. Each step's
-collocation stage system is solved by Newton with FERAL's sparse LU.
+f``) — index-1 **DAEs**.
 
-The differentiable counterpart (gradients of the trajectory w.r.t.
-parameters / initial conditions over a *fixed* step sequence, via the
-implicit-function theorem on each step's stage solve) lives in
+Why this reimplements SciPy's ``Radau`` rather than calling it
+--------------------------------------------------------------
+The core integrator (:mod:`._radau`) is deliberately the *same* method as
+SciPy's ``Radau``, and much of the tableau/error-control logic is
+transcribed from it. We do not simply dispatch to
+``scipy.integrate.solve_ivp`` because it cannot express — or is closed to —
+the three things this module exists to provide:
+
+1. **Mass matrices / index-1 DAEs.** SciPy's ``solve_ivp`` has *no*
+   mass-matrix argument: it only integrates the explicit form
+   ``y' = f(t, y)``. The Robertson problem and other index-1 DAEs need the
+   *singular*-``M`` form ``M y' = f`` (e.g. ``M = diag(1, 1, 0)``), which
+   SciPy has no way to represent. ``solve_dae`` / the ``mass=`` argument are
+   the reason this module is here at all.
+
+2. **Differentiability.** The trajectory must be differentiable w.r.t.
+   parameters and initial conditions (via the implicit-function theorem on
+   each step's stage solve, in ``pounce.jax.odeint``). That requires access
+   to the internal stage system, which a black-box SciPy call does not
+   expose.
+
+3. **A pounce-native numerical stack.** Stage/error operators are factored
+   with pounce's own dense LU (:class:`pounce._pounce.DenseLU`, faer-backed)
+   rather than SciPy/LAPACK, and — crucially — the stage Jacobian defaults to
+   **exact JAX autodiff** when the RHS is traceable (falling back to a
+   central finite difference otherwise; see :mod:`._jacobian`). SciPy's
+   ``Radau`` uses a finite-difference Jacobian only.
+
+So the duplication is intentional: it is the price of a differentiable,
+mass-matrix-capable, JAX-native stiff solver. For a *plain* explicit ODE
+with no mass matrix and no gradient requirement, SciPy's ``Radau`` is
+equivalent (and this implementation is validated to match its step counts).
+
+The differentiable counterpart (gradients over a *fixed* step sequence via
+the implicit-function theorem on each step's stage solve) lives in
 ``pounce.jax.odeint`` and is imported on demand.
 """
 

--- a/python/pounce/ode/_dae.py
+++ b/python/pounce/ode/_dae.py
@@ -33,24 +33,8 @@ from __future__ import annotations
 import numpy as np
 
 from . import _radau as R
-
-_FD = np.sqrt(np.finfo(float).eps)
+from ._jacobian import make_dae_jac
 _ALG_TOL = 1e-9            # column of F_y' below this (relative) => algebraic
-
-
-def _fd_dae_jacs(Ffun, t, y, yp, F0):
-    """Forward-difference ``(F_y, F_y')`` at ``(t, y, yp)``; ``2n`` evals."""
-    n = y.size
-    Fy = np.empty((n, n))
-    Fyp = np.empty((n, n))
-    for j in range(n):
-        dy = _FD * max(1.0, abs(y[j]))
-        yj = y.copy(); yj[j] += dy
-        Fy[:, j] = (Ffun(t, yj, yp) - F0) / dy
-        dp = _FD * max(1.0, abs(yp[j]))
-        pj = yp.copy(); pj[j] += dp
-        Fyp[:, j] = (Ffun(t, y, pj) - F0) / dp
-    return Fy, Fyp
 
 
 class _DaeProblem:
@@ -60,6 +44,7 @@ class _DaeProblem:
         self.Ffun = Ffun
         self.n = n
         self._user_jac = jac          # optional (t,y,yp) -> (F_y, F_y')
+        self._auto_jac = None         # lazily built JAX-or-central-diff strategy
         self.nfev = 0
         self.njev = 0
         self.nlu = 0
@@ -73,7 +58,11 @@ class _DaeProblem:
         if self._user_jac is not None:
             Fy, Fyp = self._user_jac(t, y, yp)
             return np.asarray(Fy, float), np.asarray(Fyp, float)
-        return _fd_dae_jacs(self.F, t, y, yp, F0)
+        # No analytic Jacobians: exact JAX autodiff when the residual is
+        # traceable, else accurate central differences (see _jacobian.py).
+        if self._auto_jac is None:
+            self._auto_jac = make_dae_jac(self.Ffun, self.F)
+        return self._auto_jac(t, y, yp, F0)
 
 
 def _algebraic_mask(Fyp):

--- a/python/pounce/ode/_dae_collocation.py
+++ b/python/pounce/ode/_dae_collocation.py
@@ -23,8 +23,7 @@ from __future__ import annotations
 import numpy as np
 
 from .._pounce import SparseLU
-
-_FD = np.sqrt(np.finfo(float).eps)
+from ._jacobian import make_dae_jac
 
 
 def _stencil(t, k, order):
@@ -44,21 +43,21 @@ def _stencil(t, k, order):
     return c_w, [(-1, c_k), (-2, c_km1)]
 
 
-def _node_jacs(Ffun, t1, w, wp, jac):
-    """``(dF/dy, dF/dy', F0)`` at a node, analytic if ``jac`` else forward-diff."""
+def _node_jacs(Ffun, t1, w, wp, jac, auto=None):
+    """``(dF/dy, dF/dy', F0)`` at a node.
+
+    Uses the analytic ``jac`` if given; otherwise the ``auto`` strategy
+    (exact JAX autodiff when traceable, else a central difference — see
+    :mod:`._jacobian`). ``auto`` is built once per solve by the caller so the
+    JAX-vs-FD probe is not repeated at every node.
+    """
     F0 = np.asarray(Ffun(t1, w, wp), float)
     if jac is not None:
         Fy, Fyp = jac(t1, w, wp)
         return np.asarray(Fy, float), np.asarray(Fyp, float), F0
-    n = w.size
-    Fy = np.empty((n, n)); Fyp = np.empty((n, n))
-    for j in range(n):
-        dy = _FD * max(1.0, abs(w[j]))
-        wj = w.copy(); wj[j] += dy
-        Fy[:, j] = (np.asarray(Ffun(t1, wj, wp), float) - F0) / dy
-        dp = _FD * max(1.0, abs(wp[j]))
-        pj = wp.copy(); pj[j] += dp
-        Fyp[:, j] = (np.asarray(Ffun(t1, w, pj), float) - F0) / dp
+    if auto is None:
+        auto = make_dae_jac(Ffun)
+    Fy, Fyp = auto(t1, w, wp, F0)
     return Fy, Fyp, F0
 
 
@@ -80,12 +79,13 @@ def collocation_forward(Ffun, t, y0, *, order=2, jac=None, tol=1e-10,
     n, m = y0.size, t.size
     Y = np.empty((n, m))
     Y[:, 0] = y0
+    auto = make_dae_jac(Ffun) if jac is None else None
     for k in range(m - 1):
         c_w, yp_k = _yp_known(t, Y, k, order)
         w = Y[:, k].copy()                        # warm start from prev node
         for _ in range(maxiter):
             wp = c_w * w + yp_k
-            Fy, Fyp, F0 = _node_jacs(Ffun, t[k + 1], w, wp, jac)
+            Fy, Fyp, F0 = _node_jacs(Ffun, t[k + 1], w, wp, jac, auto)
             if np.linalg.norm(F0) <= tol * (1.0 + np.linalg.norm(w)):
                 break
             w = w + np.linalg.solve(Fy + c_w * Fyp, -F0)
@@ -109,7 +109,7 @@ def _coo_pattern(n, M, order):
     return np.asarray(rows, np.int64), np.asarray(cols, np.int64)
 
 
-def _jac_values(Ffun, t, Y, n, M, order, jac):
+def _jac_values(Ffun, t, Y, n, M, order, jac, auto=None):
     """Values aligned to :func:`_coo_pattern`, evaluated at ``Y`` (full)."""
     t = np.asarray(t, float)
     vals = []
@@ -117,7 +117,7 @@ def _jac_values(Ffun, t, Y, n, M, order, jac):
         c_w, yp_k = _yp_known(t, Y, k, order)
         w = Y[:, k + 1]
         wp = c_w * w + yp_k
-        Fy, Fyp, _ = _node_jacs(Ffun, t[k + 1], w, wp, jac)
+        Fy, Fyp, _ = _node_jacs(Ffun, t[k + 1], w, wp, jac, auto)
         _, terms = _stencil(t, k, order)
         sub_coeff = {-off: c for off, c in terms}   # subdiagonal -> coeff
         for sub in range(0, order + 1):
@@ -140,5 +140,6 @@ def collocation_transpose_solve(Ffun, t, Y, v, *, order=2, jac=None):
     M = Y.shape[1] - 1
     rows, cols = _coo_pattern(n, M, order)
     lu = SparseLU(n * M, rows, cols)
-    lu.factor(_jac_values(Ffun, t, Y, n, M, order, jac))
+    auto = make_dae_jac(Ffun) if jac is None else None
+    lu.factor(_jac_values(Ffun, t, Y, n, M, order, jac, auto))
     return np.asarray(lu.solve_transpose(np.asarray(v, float).reshape(-1)))

--- a/python/pounce/ode/_jacobian.py
+++ b/python/pounce/ode/_jacobian.py
@@ -1,0 +1,149 @@
+"""Jacobian strategy for the ``pounce.ode`` integrators.
+
+For each problem the Jacobian is obtained, in order of preference:
+
+1. from a **user-supplied analytic Jacobian** (fastest, exact);
+2. by **JAX forward-mode autodiff** (:func:`jax.jacfwd`) when the RHS /
+   residual is JAX-traceable — exact, with *no* truncation error;
+3. by a **central finite difference** for opaque callables (raw NumPy, C
+   extensions, spline lookups, …) that JAX cannot trace.
+
+Why this matters — and why *central*, not forward, differences: near a
+singular-Jacobian steady state (e.g. the Robertson DAE on its slow manifold,
+pounce#175) a forward difference's O(d) truncation error is large enough to
+corrupt the simplified-Newton contraction, which drives the step-size
+controller to ~45x more steps than SciPy on the same problem. A central
+difference has O(d^2) error — and is *exact* for the quadratic stiff terms
+that dominate there — which restores step-count parity. Exact JAX autodiff
+sidesteps the issue entirely, which is why it is preferred whenever the RHS
+can be traced. (The rest of POUNCE is JAX-native; the ODE module defaulting
+to a hand-rolled finite difference was an oversight this module corrects.)
+
+The JAX-vs-FD decision is *probed once* per problem — on the first Jacobian
+evaluation — and cached: a single trial trace either succeeds (a jitted
+``jacfwd`` is reused for every subsequent step) or raises (fall back to
+central differences for the remainder of the solve). This keeps opaque
+callables working with zero JAX overhead while giving traceable ones exact
+derivatives.
+"""
+import numpy as np
+
+_SQRT_EPS = float(np.sqrt(np.finfo(float).eps))
+
+
+def _central(evalfn, x):
+    """Central-difference Jacobian of ``evalfn: R^n -> R^m`` at ``x``.
+
+    Returns ``(m, n)``. Costs ``2n`` evaluations. The perturbation
+    ``sqrt(eps)*max(1, |x_j|)`` matches the forward-difference scaling this
+    replaces, but the symmetric stencil gives O(d^2) truncation error.
+    """
+    n = x.size
+    cols = []
+    for j in range(n):
+        d = _SQRT_EPS * max(1.0, abs(x[j]))
+        xp = x.copy(); xp[j] += d
+        xm = x.copy(); xm[j] -= d
+        cols.append((np.asarray(evalfn(xp), float)
+                     - np.asarray(evalfn(xm), float)) / (2.0 * d))
+    return np.stack(cols, axis=1)
+
+
+def _try_jax_jacfwd(argnums):
+    """Return ``jax.jit(jax.jacfwd(g, argnums))`` builder, or ``None`` if JAX
+    is unavailable. ``g`` wraps the callable so list/tuple RHS outputs are
+    stacked into an array before differentiation."""
+    try:
+        import jax
+        import jax.numpy as jnp
+    except Exception:
+        return None
+
+    # pounce is a double-precision solver; a float32 autodiff Jacobian is too
+    # coarse to drive the stiff simplified-Newton iteration reliably. Enable
+    # x64 globally (a no-op if already on), matching ``pounce.jax``.
+    jax.config.update("jax_enable_x64", True)
+
+    def build(fn):
+        g = lambda *a: jnp.asarray(fn(*a))
+        return jax.jit(jax.jacfwd(g, argnums=argnums))
+
+    return build
+
+
+def make_ode_jac(fun_raw, f_counting=None):
+    """Return ``jac(t, y, f0) -> (n, n)`` for an explicit ODE ``y' = f(t, y)``.
+
+    ``fun_raw`` is the untouched user RHS (traced by JAX). ``f_counting``, if
+    given, is a wrapper that tallies evaluations (used only on the
+    finite-difference path, so ``nfev`` still reflects FD work; the JAX path
+    performs no host-side evaluations).
+    """
+    f_cd = f_counting if f_counting is not None else fun_raw
+    state = {"mode": None, "jf": None}
+
+    def jac(t, y, f0):
+        if state["mode"] is None:
+            _probe_ode(fun_raw, t, y, state)
+        if state["mode"] == "jax":
+            return np.asarray(state["jf"](t, y), dtype=float)
+        return _central(lambda yy: f_cd(t, yy), y)
+
+    return jac
+
+
+def _probe_ode(fun_raw, t, y, state):
+    build = _try_jax_jacfwd(argnums=1)
+    if build is not None:
+        try:
+            jf = build(fun_raw)
+            J = np.asarray(jf(t, y), dtype=float)
+            if J.shape == (y.size, y.size) and np.all(np.isfinite(J)):
+                state["jf"] = jf
+                state["mode"] = "jax"
+                return
+        except Exception:
+            pass
+    state["mode"] = "cd"
+
+
+def make_dae_jac(F_raw, F_counting=None):
+    """Return ``jacs(t, y, yp, F0) -> (F_y, F_y')`` for an implicit DAE
+    ``F(t, y, y') = 0``. JAX differentiates w.r.t. ``y`` (argnums 1) and ``y'``
+    (argnums 2); the fallback central-differences each separately."""
+    F_cd = F_counting if F_counting is not None else F_raw
+    state = {"mode": None, "jfy": None, "jfp": None}
+
+    def jacs(t, y, yp, F0):
+        if state["mode"] is None:
+            _probe_dae(F_raw, t, y, yp, state)
+        if state["mode"] == "jax":
+            Fy = np.asarray(state["jfy"](t, y, yp), dtype=float)
+            Fyp = np.asarray(state["jfp"](t, y, yp), dtype=float)
+            return Fy, Fyp
+        Fy = _central(lambda yy: F_cd(t, yy, yp), y)
+        Fyp = _central(lambda pp: F_cd(t, y, pp), yp)
+        return Fy, Fyp
+
+    return jacs
+
+
+def _probe_dae(F_raw, t, y, yp, state):
+    by = _try_jax_jacfwd(argnums=1)
+    bp = _try_jax_jacfwd(argnums=2)
+    if by is not None and bp is not None:
+        try:
+            jfy = by(F_raw)
+            jfp = bp(F_raw)
+            Fy = np.asarray(jfy(t, y, yp), dtype=float)
+            Fyp = np.asarray(jfp(t, y, yp), dtype=float)
+            n = y.size
+            if (Fy.shape == (n, n) and Fyp.shape == (n, n)
+                    and np.all(np.isfinite(Fy)) and np.all(np.isfinite(Fyp))):
+                state["jfy"] = jfy
+                state["jfp"] = jfp
+                state["mode"] = "jax"
+                return
+        except Exception:
+            pass
+    state["mode"] = "cd"

--- a/python/pounce/ode/_radau.py
+++ b/python/pounce/ode/_radau.py
@@ -9,10 +9,11 @@ differential-algebraic equations** when ``M`` is singular.
 
 Each step solves the coupled 3-stage system by a simplified Newton
 iteration; the ``(3n × 3n)`` stage Jacobian (and the ``n × n`` error-
-estimate operator) are factored with FERAL's sparse LU
-(:class:`pounce._pounce.SparseLU`). The Jacobian and its factorisation are
-reused across steps and only refreshed when Newton convergence degrades —
-the standard Hairer-Wanner efficiency trick.
+estimate operator) are dense and tiny, so they are factored with a dense
+partial-pivoting LU (:class:`pounce._pounce.DenseLU`, faer-backed) — the
+same dense factorisation SciPy's ``Radau`` uses. The Jacobian and its
+factorisation are reused across steps and only refreshed when Newton
+convergence degrades — the standard Hairer-Wanner efficiency trick.
 
 Adaptivity uses the embedded order-3 error estimate (the ``E`` weights with
 the ``(γ/h)M − J`` smoothing) and an elementary step-size controller.
@@ -22,7 +23,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from .._pounce import SparseLU
+from .._pounce import DenseLU
 
 # --- Radau IIA (5) tableau (Hairer-Wanner) --------------------------------
 _S6 = 6 ** 0.5
@@ -41,6 +42,27 @@ MU_REAL = 3 + 3 ** (2 / 3) - 3 ** (1 / 3)
 # step's collocation polynomial (its derivative interpolates K at the nodes) to
 # the new stage points, instead of cold-starting from K = 0 every step.
 _PRED_VINV = np.linalg.inv(np.vander(RADAU_C, 3, increasing=True))
+# RADAU5 eigendecomposition of the Butcher matrix (A = T Λ T⁻¹). The simplified
+# Newton stage solve runs in the eigenbasis W = T⁻¹ Z, where it decouples into
+# one real and one complex n×n system against the *shifted* operators
+# (μ/h·M − J) — which stay nonsingular even when J is singular (e.g. Robertson
+# at equilibrium), unlike the full I₃⊗M − h(A⊗J) operator (pounce#175).
+# MU_REAL / MU_COMPLEX are the eigenvalues of A⁻¹; T / TI = T⁻¹ are the standard
+# Radau IIA(5) transform matrices (Hairer-Wanner, matching SciPy's Radau).
+MU_COMPLEX = (3 + 0.5 * (3 ** (1 / 3) - 3 ** (2 / 3))
+              - 0.5j * (3 ** (5 / 6) + 3 ** (7 / 6)))
+_T = np.array([
+    [0.09443876248897524, -0.14125529502095421, 0.03002919410514742],
+    [0.25021312296533332, 0.20412935229379994, -0.38294211275726192],
+    [1.0, 1.0, 0.0]])
+_TI = np.array([
+    [4.17871859155190428, 0.32768282076106237, 0.52337644549944951],
+    [-4.17871859155190428, -0.32768282076106237, 0.47662355450055044],
+    [0.50287263494578682, -2.57192694985560522, 0.59603920482822492]])
+_TI_REAL = _TI[0]
+_TI_COMPLEX = _TI[1] + 1j * _TI[2]
+# Stage values ↔ derivatives: Z_i = h Σ_j A_ij K_j, so K = (1/h) A⁻¹ Z.
+RADAU_AINV = np.linalg.inv(RADAU_A)
 # Hold h (and so reuse the cached LU) when the controller's growth factor is
 # below this. 1.2 matches RADAU5's reference QUOT2; 2.0 reuses the factor more
 # aggressively, a net win for pounce because its (3n×3n) dense factor is
@@ -121,22 +143,22 @@ def _detect_events(events, dirs, t0, g0, t1, g1, step_data, n):
 
 
 def _dense_lu_pattern(N):
-    """Build a reusable FERAL ``SparseLU`` over the full dense ``N × N`` pattern.
+    """Build a reusable dense ``N × N`` LU (faer partial-pivoting, via
+    :class:`pounce._pounce.DenseLU`).
 
-    The sparsity pattern is fixed across a whole solve — only the matrix values
-    change as ``h`` and ``J`` vary — so the pattern object (and FERAL's symbolic
-    analysis, which it caches internally) is built **once** and the matrix is
-    refactored in place with :func:`_refactor` each step. Re-creating it per
-    refactor (re-bucketing the ``N²`` COO entries and re-analysing) dominated
-    the per-step cost on large systems.
+    The stage / error operators are dense and tiny; a dense LU is both faster
+    than a sparse factorisation on these blocks and, like LAPACK, stays
+    permissive on the ill-conditioned (large-``h``) operators a stiff/DAE
+    problem reaches on its slow manifold — where the old sparse-LU path
+    hard-failed as ``SingularBasis`` (pounce#175). Only the values change
+    across steps, so the object is built once and re-:func:`_refactor`-ed in
+    place each step.
     """
-    idx = np.arange(N, dtype=np.int64)
-    return SparseLU(N, np.repeat(idx, N), np.tile(idx, N))
+    return DenseLU(N)
 
 
 def _refactor(lu, Mat):
-    """Numerically refactor ``lu`` (a fixed-pattern dense ``SparseLU``) from the
-    row-major values of ``Mat`` — reusing the cached symbolic analysis."""
+    """Numerically refactor ``lu`` from the row-major values of ``Mat``."""
     lu.factor(np.ascontiguousarray(Mat, dtype=np.float64).reshape(-1))
 
 
@@ -192,59 +214,80 @@ def _predict_stages(K_prev, ratio):
     return (Vpred @ _PRED_VINV) @ K_prev            # (3,n)
 
 
-def _solve_stages(prob, t, y, h, lu3, scale, newton_tol, K0=None):
-    """Simplified-Newton solve of the 3-stage system for stage derivatives K.
+def _solve_stages(prob, t, y, h, lu_real, lu_cplx, scale, newton_tol, K0=None):
+    """Simplified-Newton solve of the 3-stage system via the RADAU5
+    eigendecomposition.
 
-    ``M K_i = f(t + c_i h, y + h Σ_j A_ij K_j)``. Returns ``(K, converged,
-    rate)``; ``lu3`` factors ``I_3 ⊗ M − h (A ⊗ J)`` (the Jacobian is already
-    baked into this factor, reused across the Newton iterations of this step).
+    Solves ``M K_i = f(t + c_i h, y + h Σ_j A_ij K_j)``. Rather than factoring
+    the full ``I₃⊗M − h(A⊗J)`` operator (which inherits any singularity of
+    ``J`` — Robertson at equilibrium, pounce#175), the iteration runs in the
+    eigenbasis ``W = T⁻¹ Z`` of the Butcher matrix, where it decouples into one
+    real and one complex ``n×n`` solve against the shifted operators
+    ``μ_real/h·M − J`` (``lu_real``) and ``μ_cplx/h·M − J`` (``lu_cplx``, held as
+    its real ``2n×2n`` embedding ``[[Re,−Im],[Im,Re]]``). Those stay
+    well-conditioned even at a singular-``J`` equilibrium, so the warm start is
+    corrected properly instead of leaving an uncorrectable near-null component.
 
-    Convergence uses the Hairer-Wanner criterion: the increments must shrink
-    (rate ``Θ = ‖ΔK‖/‖ΔK_prev‖ < 1``) and the predicted remaining error
-    ``Θ/(1−Θ)·‖ΔK‖`` must drop below ``newton_tol`` in the scaled RMS norm.
-    Norms are taken in the same ``scale = atol + rtol·|y|`` used for the step
-    error, so the stage solve is only as accurate as the tolerance needs.
+    Iterates on stage *values* ``Z`` (``Z_i = Y_i − y``) internally and returns
+    the stage *derivatives* ``K = (1/h) A⁻¹ Z`` for the caller, so the rest of
+    the integrator (step update, error estimate, dense output) is unchanged.
+    Convergence is the Hairer-Wanner criterion (SciPy's Radau): increments must
+    contract (rate ``Θ < 1``) with predicted remaining error
+    ``Θ/(1−Θ)·‖ΔW‖`` below ``newton_tol`` in the scaled RMS norm.
     """
     n = prob.n
-    K = np.zeros((3, n)) if K0 is None else K0.copy()
+    m_real = MU_REAL / h
+    m_cplx = MU_COMPLEX / h
+    Z = np.zeros((3, n)) if K0 is None else h * (RADAU_A @ K0)
+    W = _TI @ Z
+    sc = scale * np.sqrt(3 * n)              # RMS denominator for (3n,) stack
     dnorm_prev = None
     rate = None
     converged = False
-    sc = scale * np.sqrt(3 * n)              # RMS denominator for (3n,) stack
     for it in range(_NEWTON_MAXITER):
-        G = np.empty((3, n))
+        F = np.empty((3, n))
         for i in range(3):
-            stage_y = y + h * (RADAU_A[i] @ K)
-            G[i] = prob.M @ K[i] - prob.f(t + RADAU_C[i] * h, stage_y)
-        dK = lu3.solve(-G.reshape(-1)).reshape(3, n)
-        K = K + dK
-        dnorm = np.linalg.norm(dK / sc)
+            F[i] = prob.f(t + RADAU_C[i] * h, y + Z[i])
+        if not np.all(np.isfinite(F)):
+            break              # blew up — bail, caller shrinks h / refreshes J
+        f_real = F.T @ _TI_REAL - m_real * (prob.M @ W[0])
+        f_cplx = F.T @ _TI_COMPLEX - m_cplx * (prob.M @ (W[1] + 1j * W[2]))
+        dW_real = lu_real.solve(f_real)
+        sol = lu_cplx.solve(np.concatenate([f_cplx.real, f_cplx.imag]))
+        dW = np.array([dW_real, sol[:n], sol[n:]])
+        dnorm = np.linalg.norm(dW / sc)
         if dnorm_prev is not None and dnorm_prev > 0:
             rate = dnorm / dnorm_prev
-            if rate >= 1:
-                break          # diverging — bail, caller shrinks h / refreshes J
-            # Predicted error of the converged iterate; stop once it's tiny.
-            if rate / (1 - rate) * dnorm < newton_tol:
-                converged = True
+            # Bail if not contracting (Θ ≥ 1) or the predicted remaining error
+            # won't reach tol in the iterations left — caller shrinks h.
+            if rate >= 1 or rate ** (_NEWTON_MAXITER - it) / (1 - rate) * dnorm > newton_tol:
                 break
-        elif dnorm < newton_tol:
-            converged = True   # already at tolerance on the first increment
+        W = W + dW
+        Z = _T @ W
+        if dnorm == 0.0 or (rate is not None and rate / (1 - rate) * dnorm < newton_tol):
+            converged = True
             break
         dnorm_prev = dnorm
+    K = (RADAU_AINV @ Z) / h
     return K, converged, rate
 
 
-def _error_estimate(prob, t, y, h, K, lu_real):
+def _error_estimate(prob, t, y, h, K, lu_real, refine_from=None):
     """Embedded order-3 error estimate, smoothed by ``(MU_REAL/h)M − J``.
 
     The ``M @`` factor multiplies the stage-increment combination for *any*
     mass matrix (it reduces to the plain ``y' = f`` form when ``M = I``), so
     it is applied unconditionally — keying it on singularity would mis-scale
     the estimate for a full-rank non-identity ``M``.
+
+    ``refine_from`` performs the Hairer-Wanner / SciPy nonlinear refinement:
+    re-evaluate ``f`` at ``y + refine_from`` (a previous error estimate) instead
+    of at ``y``, so a linear estimate that is over-pessimistic at large ``h`` on
+    a stiff problem doesn't force a needless step rejection.
     """
     Z = h * (RADAU_A @ K)                       # stage increments Y_i − y
-    f0 = prob.f(t, y)
-    rhs = prob.M @ (Z.T @ (RADAU_E / h)) + f0
+    fpt = prob.f(t, y if refine_from is None else y + refine_from)
+    rhs = prob.M @ (Z.T @ (RADAU_E / h)) + fpt
     return lu_real.solve(rhs)
 
 
@@ -304,16 +347,16 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
     jac_current = True
     rejected = False
 
-    # Cached LU factors of the (h, J)-dependent stage / error operators. The
-    # RADAU5 efficiency trick is to refactor only when J is refreshed or h
-    # changes — so we hold the factor across steps (see the step-size band
-    # below, which freezes h on mild growth to keep reusing it).
-    # Reusable LU factors over the FIXED dense patterns: the (3n×3n) stage
-    # operator and the (n×n) real error operator. Only the values change across
-    # steps, so the pattern objects (and FERAL's symbolic analysis) are built
-    # once here and refactored in place inside the loop.
-    lu3 = _dense_lu_pattern(3 * prob.n)
+    # Cached LU factors of the (h, J)-dependent operators. The RADAU5 efficiency
+    # trick is to refactor only when J is refreshed or h changes — so we hold
+    # the factors across steps (see the step-size band below, which freezes h on
+    # mild growth to keep reusing them). The eigendecomposed stage solve uses two
+    # shifted operators: the real (n×n) ``μ_real/h·M − J`` (which doubles as the
+    # error-estimate operator) and the complex ``μ_cplx/h·M − J``, held as its
+    # real (2n×2n) embedding — both far better conditioned than the full
+    # (3n×3n) ``I₃⊗M − h(A⊗J)`` and cheaper to factor.
     lu_real = _dense_lu_pattern(prob.n)
+    lu_cplx = _dense_lu_pattern(2 * prob.n)
     h_lu = None
     need_factor = True
 
@@ -337,9 +380,33 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
         h = min(h, abs(t1 - t))
         hs = s * h
         if need_factor or h != h_lu:
-            big = np.kron(np.eye(3), prob.M) - hs * np.kron(RADAU_A, J)
-            _refactor(lu3, big)
-            _refactor(lu_real, MU_REAL / hs * prob.M - J)
+            # Shifted RADAU5 operators (eigenbasis of the Butcher matrix): the
+            # real ``μ_real/h·M − J`` and the complex ``μ_cplx/h·M − J``, the
+            # latter held as its real 2n×2n embedding ``[[Re,−Im],[Im,Re]]``.
+            mc = MU_COMPLEX / hs
+            c_re = mc.real * prob.M - J
+            c_im = mc.imag * prob.M
+            try:
+                _refactor(lu_real, MU_REAL / hs * prob.M - J)
+                _refactor(lu_cplx, np.block([[c_re, -c_im], [c_im, c_re]]))
+            except RuntimeError:
+                # A stage-operator factorization failure is treated like a
+                # rejected step (shrink h, refresh a stale J, retry) rather than
+                # killing the integration — the Hairer-Wanner RADAU5 response to
+                # a singular decomposition, mirroring the Newton-non-convergence
+                # branch below. The dense-LU backend factors near-singular
+                # operators like LAPACK, so this is a safety net for a genuinely
+                # unrecoverable (inf/nan) operator rather than the common path.
+                if not jac_current:
+                    J = prob.jac(t, y, prob.f(t, y)); jac_current = True
+                else:
+                    h *= 0.5
+                    rejected = True
+                need_factor = True
+                if h < 1e-13 * max(1.0, abs(t)):
+                    status, message = -1, _ODE_MESSAGES[-1].format(t=t)
+                    break
+                continue
             prob.nlu += 2
             h_lu = h
             need_factor = False
@@ -350,8 +417,8 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
         # rejection/refactor, so a shrunk step gets a matching guess.
         K0 = (_predict_stages(K_prev, h / h_prev)
               if K_prev is not None and h_prev else None)
-        K, converged, rate = _solve_stages(prob, t, y, hs, lu3, scale,
-                                           newton_tol, K0=K0)
+        K, converged, rate = _solve_stages(prob, t, y, hs, lu_real, lu_cplx,
+                                           scale, newton_tol, K0=K0)
         if not converged:
             # A stale Jacobian is the usual reason simplified Newton stalls at
             # a larger step; refresh it at the current point and retry the
@@ -371,6 +438,12 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
         err = _error_estimate(prob, t, y, hs, K, lu_real)
         scale = atol + rtol * np.maximum(np.abs(y), np.abs(y_new))
         enorm = np.sqrt(np.mean((err / scale) ** 2))
+        if rejected and enorm > 1:
+            # Nonlinear refinement of the stiff error estimate (so an
+            # over-pessimistic linear estimate at large h doesn't needlessly
+            # reject step growth on the slow manifold — Hairer-Wanner / SciPy).
+            err = _error_estimate(prob, t, y, hs, K, lu_real, refine_from=err)
+            enorm = np.sqrt(np.mean((err / scale) ** 2))
 
         if enorm > 1:
             h *= max(_MIN_FACTOR, _SAFETY * enorm ** _ERR_EXP)

--- a/python/pounce/ode/_radau.py
+++ b/python/pounce/ode/_radau.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import numpy as np
 
 from .._pounce import DenseLU
+from ._jacobian import make_ode_jac
 
 # --- Radau IIA (5) tableau (Hairer-Wanner) --------------------------------
 _S6 = 6 ** 0.5
@@ -162,18 +163,6 @@ def _refactor(lu, Mat):
     lu.factor(np.ascontiguousarray(Mat, dtype=np.float64).reshape(-1))
 
 
-def _fd_jac(f, t, y, f0):
-    """Forward-difference Jacobian ``df/dy``."""
-    n = y.size
-    J = np.empty((n, n))
-    for j in range(n):
-        d = (np.sqrt(np.finfo(float).eps)) * max(1.0, abs(y[j]))
-        yj = y.copy()
-        yj[j] += d
-        J[:, j] = (f(t, yj) - f0) / d
-    return J
-
-
 class _RadauProblem:
     """Holds the RHS, mass matrix, Jacobian, and counters for one solve."""
 
@@ -182,6 +171,7 @@ class _RadauProblem:
         self.n = n
         self.M = np.eye(n) if mass is None else np.asarray(mass, dtype=float)
         self._user_jac = jac
+        self._auto_jac = None      # lazily built JAX-or-central-diff strategy
         self.nfev = 0
         self.njev = 0
         self.nlu = 0
@@ -194,9 +184,11 @@ class _RadauProblem:
         self.njev += 1
         if self._user_jac is not None:
             return np.asarray(self._user_jac(t, y), dtype=float)
-        # FD costs n extra fun evals (counted).
-        J = _fd_jac(self.f, t, y, f0)
-        return J
+        # No analytic Jacobian: use exact JAX autodiff when the RHS is
+        # traceable, else an accurate central difference (see _jacobian.py).
+        if self._auto_jac is None:
+            self._auto_jac = make_ode_jac(self.fun, self.f)
+        return self._auto_jac(t, y, f0)
 
 
 def _predict_stages(K_prev, ratio):
@@ -269,7 +261,7 @@ def _solve_stages(prob, t, y, h, lu_real, lu_cplx, scale, newton_tol, K0=None):
             break
         dnorm_prev = dnorm
     K = (RADAU_AINV @ Z) / h
-    return K, converged, rate
+    return K, converged, rate, it + 1
 
 
 def _error_estimate(prob, t, y, h, K, lu_real, refine_from=None):
@@ -417,8 +409,9 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
         # rejection/refactor, so a shrunk step gets a matching guess.
         K0 = (_predict_stages(K_prev, h / h_prev)
               if K_prev is not None and h_prev else None)
-        K, converged, rate = _solve_stages(prob, t, y, hs, lu_real, lu_cplx,
-                                           scale, newton_tol, K0=K0)
+        K, converged, rate, n_iter = _solve_stages(prob, t, y, hs, lu_real,
+                                                   lu_cplx, scale, newton_tol,
+                                                   K0=K0)
         if not converged:
             # A stale Jacobian is the usual reason simplified Newton stalls at
             # a larger step; refresh it at the current point and retry the
@@ -502,13 +495,17 @@ def integrate(fun, t0, t1, y0, *, rtol=1e-3, atol=1e-6, first_step=None,
         if h_new != h:
             need_factor = True
         h = h_new
-        # Jacobian for the next step: if Newton convergence was anything but
-        # excellent, refresh J now at the new point; otherwise mark it stale
-        # so a later convergence failure triggers an on-demand refresh. This
-        # keeps a frozen Jacobian only while it is genuinely working.
-        if rate is not None and rate > 1e-3:
-            f_new = prob.f(t, y)
-            J = prob.jac(t, y, f_new); jac_current = True
+        # Jacobian for the next step (SciPy Radau policy): recompute J only when
+        # the just-completed Newton was *both* slow (took more than 2 iterations)
+        # and contracting poorly (rate > 1e-3). Otherwise keep J frozen and skip
+        # the refactor. Near a singular-Jacobian steady state (e.g. the Robertson
+        # DAE on its slow manifold) the dynamics change slowly, so a frozen J
+        # stays valid for many steps and the simplified Newton converges in ≤ 2
+        # iterations — refreshing it every step instead just burns evaluations
+        # and factorisations. A stale J that later stalls Newton is refreshed
+        # on-demand by the non-convergence branch above.
+        if rate is not None and n_iter > 2 and rate > 1e-3:
+            J = prob.jac(t, y, prob.f(t, y)); jac_current = True
             need_factor = True
         else:
             jac_current = False

--- a/python/tests/test_ode.py
+++ b/python/tests/test_ode.py
@@ -139,6 +139,78 @@ def test_lu_pattern_built_once_per_solve(monkeypatch):
     assert n_built[0] == 2, f"LU pattern rebuilt per refactor ({n_built[0]} builds)"
 
 
+# --- Jacobian strategy: JAX autodiff / central-difference fallback -----------
+
+def test_jacobian_jax_autodiff_is_exact():
+    """A JAX-traceable RHS gets an *exact* Jacobian from jax.jacfwd — matching
+    the analytic Jacobian to ~machine precision, far tighter than any FD."""
+    jnp = pytest.importorskip("jax.numpy")
+    from pounce.ode._jacobian import make_ode_jac
+
+    k1, k2, k3 = 0.04, 3e7, 1e4
+
+    def f(t, y):
+        y3 = 1.0 - y[0] - y[1]
+        return jnp.array([-k1 * y[0] + k3 * y[1] * y3,
+                          k1 * y[0] - k3 * y[1] * y3 - k2 * y[1] ** 2])
+
+    def jac_analytic(y):
+        y0, y1 = y
+        y3 = 1 - y0 - y1
+        return np.array([[-k1 - k3 * y1, k3 * (y3 - y1)],
+                         [k1 + k3 * y1, -k3 * (y3 - y1) - 2 * k2 * y1]])
+
+    jac = make_ode_jac(f)
+    y = np.array([1.9e-6, 7.6e-12])
+    J = jac(0.0, y, np.asarray(f(0.0, y), float))
+    assert np.allclose(J, jac_analytic(y), rtol=1e-10, atol=1e-12)
+
+
+def test_jacobian_central_diff_fallback_is_accurate():
+    """A plain-NumPy RHS (untraceable by JAX) falls back to a *central*
+    difference — accurate to O(d^2), not the noisy forward difference that
+    previously ballooned the Robertson step count ~45x (pounce#175)."""
+    from pounce.ode._jacobian import make_ode_jac
+
+    k1, k2, k3 = 0.04, 3e7, 1e4
+
+    def f(t, y):                       # np.array -> not JAX-traceable
+        y3 = 1.0 - y[0] - y[1]
+        return np.array([-k1 * y[0] + k3 * y[1] * y3,
+                         k1 * y[0] - k3 * y[1] * y3 - k2 * y[1] ** 2])
+
+    def jac_analytic(y):
+        y0, y1 = y
+        y3 = 1 - y0 - y1
+        return np.array([[-k1 - k3 * y1, k3 * (y3 - y1)],
+                         [k1 + k3 * y1, -k3 * (y3 - y1) - 2 * k2 * y1]])
+
+    jac = make_ode_jac(f)
+    y = np.array([1.9e-6, 7.6e-12])
+    J = jac(0.0, y, f(0.0, y))
+    # central difference reaches ~1e-4 relative here; a forward difference
+    # over the same perturbation is ~40x worse and wrecks Newton contraction.
+    assert np.allclose(J, jac_analytic(y), rtol=2e-4, atol=1e-10)
+
+
+def test_robertson_longtime_step_count_bounded():
+    """Robertson (reduced ODE, plain-NumPy RHS) integrated far onto its slow
+    manifold. The central-difference Jacobian keeps the step count near SciPy's;
+    the old forward difference took ~45x more steps (pounce#175). Guard the fix
+    with an absolute bound well below the regressed count."""
+    k1, k2, k3 = 0.04, 3e7, 1e4
+
+    def f(t, y):
+        y3 = 1.0 - y[0] - y[1]
+        return np.array([-k1 * y[0] + k3 * y[1] * y3,
+                         k1 * y[0] - k3 * y[1] * y3 - k2 * y[1] ** 2])
+
+    r = po.solve_ivp(f, (0.0, 1e11), [1.0, 0.0], rtol=1e-8, atol=1e-10)
+    assert r.success
+    assert r.nstep < 2000, f"Jacobian-quality regression: nstep={r.nstep}"
+    assert abs(r.y[0, -1] - 2.08e-8) < 5e-9
+
+
 # --- index-1 DAE (mass matrix) -----------------------------------------------
 
 def test_robertson_dae():


### PR DESCRIPTION
## Summary

Fixes #175 — `pounce.ode.solve_ivp` / `solve_dae` crashing on the Robertson DAE, and closes the large efficiency gap the fix exposed. Two commits:

### 1. Crash fix — faer dense LU + RADAU5 complex-split stage solve
The Radau IIA(5) integrator factored its tiny dense `(3n×3n)` stage operator and `(n×n)` error operator through FERAL's **sparse** LU over a full dense pattern. That path is stricter than LAPACK: on the ill-conditioned (large-`h`) stage matrices a stiff/DAE problem reaches on its slow manifold it hard-fails as `SingularBasis`, crashing the integration.

- New `pounce._pounce.DenseLU` (faer `PartialPivLu`) — no symbolic phase, and like LAPACK/SciPy it always completes (a genuinely singular matrix surfaces as `inf`/`nan` in the *solve*, which the Newton/error control already handles by shrinking the step).
- Stage solve rewritten as the standard RADAU5 **complex split** (one real + one complex shifted operator via the Butcher eigendecomposition) so the operators stay well-conditioned at a singular-Jacobian equilibrium.

### 2. Efficiency — exact JAX / central-difference Jacobian
With the crash gone, the DAE integrated but took **~45× more steps than SciPy** (33860 vs 757 to `t=1e11`). Root cause: the stage Jacobian came from a hand-rolled **forward** difference; near the singular-Jacobian steady state its `O(d)` truncation error corrupts the simplified-Newton contraction.

New shared strategy (`python/pounce/ode/_jacobian.py`), preferred in order:
1. user analytic Jacobian;
2. **exact JAX forward-mode autodiff** (`jax.jacfwd`) when the RHS/residual is traceable — the rest of POUNCE is JAX-native, so defaulting to a hand-rolled FD was an oversight (x64 enabled to match `pounce.jax`);
3. a **central** finite difference (`O(d²)`, exact for the quadratic stiff terms) for opaque NumPy/C callables JAX cannot trace.

The JAX-vs-FD choice is probed once per problem and cached. Wired into all three FD sites: `_radau.py` (ODE), `_dae.py` (implicit DAE), `_dae_collocation.py` (differentiable collocation). The Radau outer loop also adopts SciPy's lazy Jacobian-refresh policy (recompute only when Newton was both slow and poorly contracting) so a valid frozen `J` is reused instead of refactored every step.

## Results (`rtol=1e-8`)

| problem | before | after | SciPy |
|---|---|---|---|
| Robertson reduced ODE → 1e11 | 33860 steps | **903** | 757 |
| Robertson DAE → 1e11 | 33487 | **487** | *(no DAE support)* |
| Robertson reduced, JAX-autodiff RHS | — | **861** | — |
| Van der Pol μ=1000 | ~151k | 151191 | 158324 |

DAE answer is physical (`y = [2e-8, 0, 1.0]`), algebraic constraint held exactly.

## Why not just call `scipy.integrate.solve_ivp`?
Documented in `pounce.ode`'s package docstring: SciPy's `solve_ivp` has **no mass-matrix argument**, so index-1 DAEs (`M y' = f`, singular `M`) cannot be expressed; the trajectory must be **differentiable** (implicit-function theorem on each stage solve, for `pounce.jax.odeint`); and the numerical stack is pounce-native (faer LU + JAX autodiff). For a plain explicit ODE the two are equivalent, and this implementation is validated to match SciPy's step counts.

## Tests
80 ODE/DAE/BVP/collocation tests pass, including new guards: JAX autodiff is exact (matches analytic to ~machine precision), the central-difference fallback is `O(d²)`-accurate, and Robertson-to-1e11 step count is bounded well below the regressed value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
