### PR TITLE
chore: open 0.8.0 development cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-diff"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde_json",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-algorithm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cinterface"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-convex"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-feral"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -969,7 +969,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-hsl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-l1penalty"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -986,14 +986,14 @@ dependencies = [
 
 [[package]]
 name = "pounce-linalg"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
 ]
 
 [[package]]
 name = "pounce-linsol"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1002,7 +1002,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "libloading",
  "pounce-common",
@@ -1012,7 +1012,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nlp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-observability"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -1035,7 +1035,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-presolve"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -1044,7 +1044,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-py"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "faer",
  "feral",
@@ -1066,7 +1066,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-qp"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-feral",
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-restoration"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1089,7 +1089,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-rs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1098,7 +1098,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-sensitivity"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1108,7 +1108,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-solve-report"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-common",
  "pounce-linsol",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1127,7 +1127,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-pyo3"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "pounce-studio-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "EPL-2.0"
 authors = ["John Kitchin <jkitchin@andrew.cmu.edu>"]
@@ -66,23 +66,23 @@ repository = "https://github.com/jkitchin/pounce"
 # deps lack a registry version). Crates pick these up via
 # `pounce-foo.workspace = true`.
 [workspace.dependencies]
-pounce-common = { path = "crates/pounce-common", version = "0.7.0" }
-pounce-linalg = { path = "crates/pounce-linalg", version = "0.7.0" }
-pounce-linsol = { path = "crates/pounce-linsol", version = "0.7.0" }
-pounce-nlp = { path = "crates/pounce-nlp", version = "0.7.0" }
-pounce-nl = { path = "crates/pounce-nl", version = "0.7.0" }
-pounce-hsl = { path = "crates/pounce-hsl", version = "0.7.0" }
-pounce-feral = { path = "crates/pounce-feral", version = "0.7.0" }
-pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.7.0" }
-pounce-restoration = { path = "crates/pounce-restoration", version = "0.7.0" }
-pounce-presolve = { path = "crates/pounce-presolve", version = "0.7.0" }
-pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.7.0" }
-pounce-qp = { path = "crates/pounce-qp", version = "0.7.0" }
-pounce-convex = { path = "crates/pounce-convex", version = "0.7.0" }
-pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.7.0" }
-pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.7.0" }
-pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.7.0" }
-pounce-observability = { path = "crates/pounce-observability", version = "0.7.0" }
+pounce-common = { path = "crates/pounce-common", version = "0.8.0" }
+pounce-linalg = { path = "crates/pounce-linalg", version = "0.8.0" }
+pounce-linsol = { path = "crates/pounce-linsol", version = "0.8.0" }
+pounce-nlp = { path = "crates/pounce-nlp", version = "0.8.0" }
+pounce-nl = { path = "crates/pounce-nl", version = "0.8.0" }
+pounce-hsl = { path = "crates/pounce-hsl", version = "0.8.0" }
+pounce-feral = { path = "crates/pounce-feral", version = "0.8.0" }
+pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.8.0" }
+pounce-restoration = { path = "crates/pounce-restoration", version = "0.8.0" }
+pounce-presolve = { path = "crates/pounce-presolve", version = "0.8.0" }
+pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.8.0" }
+pounce-qp = { path = "crates/pounce-qp", version = "0.8.0" }
+pounce-convex = { path = "crates/pounce-convex", version = "0.8.0" }
+pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.8.0" }
+pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.8.0" }
+pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.8.0" }
+pounce-observability = { path = "crates/pounce-observability", version = "0.8.0" }
 # feral: pinned to the published crates.io release so the pounce crates stay
 # publishable — a git rev would block the crates.io publish and is rejected by
 # scripts/check-release-consistency.sh ("git dependency … needs a crates.io

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomo-pounce"
-version = "0.7.0"
+version = "0.8.0"
 description = "Pyomo solver plugin for the POUNCE interior-point NLP solver"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 # because maturin's `module-name = "pounce._pounce"` and
 # `python-source = "."` keep the package folder named `pounce`.
 name = "pounce-solver"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python interface to POUNCE — a pure-Rust interior-point optimization solver for nonlinear, conic (LP/QP/SOCP/SDP/exp/power), and global problems (NLP core ported from Ipopt). cyipopt-style Problem class, scipy-style minimize() facade, solve_qp/solve_socp/sos_minimize, and JAX-friendly autodiff / implicit differentiation."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Post-release version tick after the 0.7.0 release: bumps the Rust workspace + both PyPI projects from 0.7.0 to 0.8.0 so main's in-development builds aren't labelled with the shipped 0.7.0. CITATION.cff stays at 0.7.0 (cites the release); CHANGELOG already has an empty `[Unreleased]`.

No `-dev`/`.dev0` suffix — the consistency guard requires byte-identical version strings across the three surfaces, and Rust (`-dev`) vs PEP 440 (`.dev0`) spellings differ. Plain 0.8.0 keeps the guard green. **Do not tag `v0.8.0` until 0.8.0 is ready.**

Guard: check-release-consistency.sh OK (all three at 0.8.0); workspace compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)