### PR TITLE
pounce#180: block-triangular KKT solver, timing breakdown, external ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+### Added — structure-aware KKT hooks (#180)
+
+- **Caller-supplied KKT ordering** (item 1). A structure-aware presolve can
+  now hand pounce a precomputed fill-reducing permutation for the KKT linear
+  solver — a block-triangular / Schur ordering (Parker, Garcia & Bent,
+  arXiv:2602.17968) or a tearing ordering from equation-oriented
+  decomposition — that the built-in AMD/METIS pass cannot derive.
+  Python: `Problem.set_ordering(perm)` / `get_ordering()` / `clear_ordering()`;
+  Rust: `IpoptApplication::set_external_ordering(perm)`. `perm` is a 0-based
+  new-to-old permutation whose length equals the augmented KKT dimension;
+  FERAL validates it as a bijection and fails the factorization (never a wrong
+  answer) on a bad permutation. Maps to FERAL's new `OrderingMethod::External`
+  (feral#107); honored by the default FERAL backend only.
+- **Per-solve linear-algebra / callback timing** (item 3). `Problem.solve`'s
+  `info` dict now carries `info["wall_time"]` and an `info["timing"]`
+  breakdown (overall total, the linear-algebra factorization-vs-back-solve
+  split, and the per-callback objective / gradient / constraint / Jacobian /
+  Lagrangian-Hessian eval time); `pounce.minimize` mirrors these as
+  `res.wall_time` / `res.timing`. Lets a caller attribute a reduced-space
+  solve's runtime (e.g. densified-Hessian eval cost) directly.
+
+### Changed
+
+- **feral 0.12.0 → 0.13.0**, which adds `OrderingMethod::External(Vec<usize>)`
+  (feral#107). The enum is no longer `Copy` (the `External` arm carries a heap
+  permutation); pounce clones it where a copy was previously implicit.
+
 ## [0.7.0] - 2026-07-01
 
 ### Added — `pounce-rs` Rust facade crate (#168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ changes.
   Lagrangian-Hessian eval time); `pounce.minimize` mirrors these as
   `res.wall_time` / `res.timing`. Lets a caller attribute a reduced-space
   solve's runtime (e.g. densified-Hessian eval cost) directly.
+- **Block-triangular / Schur KKT solve** (item 2). A structure-aware presolve
+  can hand pounce the reducible block of the KKT system; that block is
+  Schur-complemented out and only the two diagonal blocks are factorized, with
+  full-system inertia recovered a priori via Sylvester's law (Parker, Garcia &
+  Bent, arXiv:2602.17968). Python: `Problem.set_kkt_schur_block(indices)` /
+  `get_kkt_schur_block()` / `clear_kkt_schur_block()`; Rust:
+  `IpoptApplication::set_kkt_schur_block(indices)`. `indices` are KKT-space
+  (`x, slack, eq-dual, ineq-dual` block order). The Schur solver
+  (`FeralSchurSolver` + `SchurAugSystemSolver`) uses only feral's stable
+  factor/solve, and falls back to the standard full-space solver transparently
+  when the partition is unsuitable (too large a fraction, malformed, or a
+  singular diagonal block), so a stray hook never breaks a solve. Beneficial
+  only when the Schur block is much smaller than the eliminated block; honored
+  on the default feral + exact-Hessian path.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "feral"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef91918cdb92a5ea18d2a40563014b84102ec41ebf621fe4a5c0d9d337d59326"
+checksum = "9aa6f58ec773d907048e287e8b06c453459598c199075d756ec2d0ddbe629c67"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,7 +111,7 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.8.0"
 #   [patch.crates-io]
 #   feral = { git = "https://github.com/jkitchin/feral.git", rev = "<sha>" }
 # Do NOT commit that patch (it re-introduces the publish blocker).
-feral = { version = "0.12.0" }
+feral = { version = "0.13.0" }
 # Dense linear algebra for the debugger's numerical rank diagnosis
 # (SVD of the active-constraint Jacobian). Pure-Rust, MIT; we pull only
 # the dense `std` core — no rayon/sparse/rand/npy.

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -228,6 +228,14 @@ pub struct AlgorithmBuilder {
     /// `application::apply_qp_subproblem_options`.
     pub sqp_qp: pounce_qp::QpOptions,
     pub init: InitOptions,
+    /// Optional block-triangular / Schur KKT partition (pounce#180 item 2):
+    /// `(schur_indices, feral_cfg)`. When `Some` and the IPM path is selected
+    /// with the feral linear solver and an exact Hessian, `build_with_backend`
+    /// wraps the standard aug-system solver in a
+    /// [`crate::kkt::SchurAugSystemSolver`] over the given KKT-space indices.
+    /// The Schur solver falls back to the standard solver transparently when
+    /// the partition is unsuitable. Set via [`Self::set_kkt_schur`].
+    pub kkt_schur: Option<(Vec<usize>, pounce_feral::FeralConfig)>,
 }
 
 /// Knobs read off `OptionsList` and baked into
@@ -520,6 +528,7 @@ impl Default for AlgorithmBuilder {
             sqp: crate::sqp::SqpOptions::default(),
             sqp_qp: pounce_qp::QpOptions::default(),
             init: InitOptions::default(),
+            kkt_schur: None,
         }
     }
 }
@@ -527,6 +536,15 @@ impl Default for AlgorithmBuilder {
 impl AlgorithmBuilder {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Install a Schur KKT partition (pounce#180 item 2). `schur_indices` are
+    /// KKT-space indices (`0..dim`, the `x,s,c,d` block order the aug-system
+    /// solver assembles); `cfg` configures the per-block feral solvers. Only
+    /// honored on the IPM + feral + exact-Hessian path by
+    /// [`Self::build_with_backend`]; ignored otherwise.
+    pub fn set_kkt_schur(&mut self, schur_indices: Vec<usize>, cfg: pounce_feral::FeralConfig) {
+        self.kkt_schur = Some((schur_indices, cfg));
     }
 
     /// Assemble the strategy bundle without a search-direction
@@ -561,11 +579,27 @@ impl AlgorithmBuilder {
         // Sherman-Morrison-Woodbury low-rank solver so the augmented
         // system factorizes only the diagonal `B0` and the quasi-Newton
         // update is applied as a rank-`m` correction (`O(n·m)` memory).
-        let aug_solver: Box<dyn AugSystemSolver> = if matches!(
+        let is_lbfgs = matches!(
             self.hessian_approximation,
             HessianApproxChoice::LimitedMemory
-        ) {
+        );
+        let aug_solver: Box<dyn AugSystemSolver> = if is_lbfgs {
             Box::new(LowRankAugSystemSolver::new(Box::new(inner_aug)))
+        } else if let Some((indices, cfg)) = self.kkt_schur.clone() {
+            // Block-triangular / Schur KKT path (pounce#180 item 2). Only on the
+            // exact-Hessian feral path — the Schur backend is feral-specific,
+            // and the L-BFGS low-rank Woodbury wrapper owns the (2,2) block.
+            // The Schur solver falls back to `StdAugSystemSolver` transparently
+            // when the partition is unsuitable, so a stray hook never breaks a
+            // solve; we gate on `linear_solver == Feral` here to avoid silently
+            // ignoring a user's explicit MA57 selection.
+            if matches!(self.linear_solver, LinearSolverChoice::Feral) {
+                Box::new(crate::kkt::SchurAugSystemSolver::new(
+                    inner_aug, indices, cfg,
+                ))
+            } else {
+                Box::new(inner_aug)
+            }
         } else {
             Box::new(inner_aug)
         };
@@ -828,6 +862,7 @@ mod tests {
                             sqp: crate::sqp::SqpOptions::default(),
                             sqp_qp: pounce_qp::QpOptions::default(),
                             init: InitOptions::default(),
+                            kkt_schur: None,
                         }
                         .build();
                     }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -196,6 +196,19 @@ pub struct IpoptApplication {
     /// backends and by any custom factory plugged via
     /// [`Self::set_linear_backend_factory`].
     external_ordering: Option<Vec<usize>>,
+    /// Caller-supplied block-triangular / Schur KKT partition (pounce#180
+    /// item 2). When `Some`, the next IPM solve on the feral + exact-Hessian
+    /// path routes the KKT linear solve through a
+    /// [`crate::kkt::SchurAugSystemSolver`] over these **KKT-space indices**
+    /// (`0..dim` in the `x, s, c, d` block order the aug-system solver
+    /// assembles): the `S` block is Schur-complemented out and only the two
+    /// diagonal blocks are factorized, with inertia recovered via Sylvester's
+    /// law. Beneficial only when `|S| ≪` the eliminated block; the Schur solver
+    /// falls back to the standard full-space solver transparently when the
+    /// partition is unsuitable (too large, malformed, or the backend errors),
+    /// so a stray hook never breaks a solve. Persistent config (not
+    /// auto-cleared). Wire-set via [`Self::set_kkt_schur_block`].
+    kkt_schur_block: Option<Vec<usize>>,
 }
 
 impl fmt::Debug for IpoptApplication {
@@ -243,6 +256,7 @@ impl IpoptApplication {
             sqp_last_working_set: None,
             warm_start_iterate: None,
             external_ordering: None,
+            kkt_schur_block: None,
         }
     }
 
@@ -675,6 +689,31 @@ impl IpoptApplication {
     /// The currently-installed external KKT ordering, if any.
     pub fn external_ordering(&self) -> Option<&[usize]> {
         self.external_ordering.as_deref()
+    }
+
+    /// Install a block-triangular / Schur KKT partition (pounce#180 item 2).
+    /// `indices` are KKT-space indices (`0..dim` in the `x, s, c, d` block
+    /// order the aug-system solver assembles) naming the Schur block `S`; that
+    /// block is Schur-complemented out and only the two diagonal blocks are
+    /// factorized (inertia via Sylvester's law). Honored on the IPM + feral +
+    /// exact-Hessian path; the Schur solver falls back to the standard
+    /// full-space solver transparently when the partition is unsuitable (too
+    /// large a fraction of the system, malformed, or a backend error), so a
+    /// stray hook never breaks a solve. Persistent config (not auto-cleared);
+    /// drop it via [`Self::clear_kkt_schur_block`].
+    pub fn set_kkt_schur_block(&mut self, indices: Vec<usize>) {
+        self.kkt_schur_block = Some(indices);
+    }
+
+    /// Drop any installed Schur KKT partition, restoring the standard
+    /// full-space solver for subsequent solves.
+    pub fn clear_kkt_schur_block(&mut self) {
+        self.kkt_schur_block = None;
+    }
+
+    /// The currently-installed Schur KKT partition, if any.
+    pub fn kkt_schur_block(&self) -> Option<&[usize]> {
+        self.kkt_schur_block.as_deref()
     }
 
     /// Return the final QP working set from the most recent SQP
@@ -1353,7 +1392,7 @@ impl IpoptApplication {
         // `AlgBuilder::RegisterOptions` in upstream — that registry
         // hookup lands as a follow-up; default builder is correct for
         // HS71-class problems.
-        let builder = self.algorithm_builder_from_options();
+        let mut builder = self.algorithm_builder_from_options();
 
         // Linear-solver backend. The default factory is option-aware
         // — it reads the `feral_*` extension options off the same
@@ -1361,6 +1400,15 @@ impl IpoptApplication {
         // per-problem `.opt` files can flip backend knobs without
         // rebuilding pounce.
         let mut feral_cfg = feral_config_from_options(&self.options);
+        // Block-triangular / Schur KKT partition (pounce#180 item 2). Configure
+        // the Schur block solvers from the *base* feral cfg: a full-KKT external
+        // ordering (item 1) is sized for the whole system and cannot apply to
+        // the A_FF sub-block, so the Schur path keeps the default sub-block
+        // ordering. `build_with_backend` honors this only on the IPM + feral +
+        // exact-Hessian path and falls back to the standard solver otherwise.
+        if let Some(indices) = &self.kkt_schur_block {
+            builder.set_kkt_schur(indices.clone(), feral_cfg.clone());
+        }
         // A caller-supplied KKT permutation (pounce#180 item 1) overrides
         // the string-option / env ordering: `OrderingMethod::External`
         // can't be expressed through the OptionsList (it carries a

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -182,6 +182,20 @@ pub struct IpoptApplication {
     /// re-optimize branch of `WarmStartIterateInitializer` keeps the
     /// installed iterate. Wire-set via [`Self::set_warm_start_iterate`].
     warm_start_iterate: Option<crate::debug::IterateSnapshot>,
+    /// Caller-supplied fill-reducing permutation for the KKT linear
+    /// solver (pounce#180 item 1 / FERAL#107). When `Some`, it overrides
+    /// whatever `feral_ordering` / `POUNCE_FERAL_ORDERING` resolves to,
+    /// installing [`pounce_feral::OrderingMethod::External`] on the FERAL
+    /// backend for the next solve. The vector is a **0-based, new-to-old
+    /// permutation** whose length must equal the augmented KKT system
+    /// dimension; FERAL validates it as a bijection and returns
+    /// `InvalidInput` (never panics) on a wrong length / index. Unlike the
+    /// warm-start hooks this is treated as persistent config — it is *not*
+    /// auto-cleared after a solve, so a caller sets it once for a run.
+    /// Wire-set via [`Self::set_external_ordering`]. Ignored by non-FERAL
+    /// backends and by any custom factory plugged via
+    /// [`Self::set_linear_backend_factory`].
+    external_ordering: Option<Vec<usize>>,
 }
 
 impl fmt::Debug for IpoptApplication {
@@ -228,6 +242,7 @@ impl IpoptApplication {
             sqp_warm_start: None,
             sqp_last_working_set: None,
             warm_start_iterate: None,
+            external_ordering: None,
         }
     }
 
@@ -624,6 +639,42 @@ impl IpoptApplication {
     /// Consumed once per solve, then auto-cleared.
     pub fn set_warm_start_iterate(&mut self, snap: crate::debug::IterateSnapshot) {
         self.warm_start_iterate = Some(snap);
+    }
+
+    /// Install a caller-supplied fill-reducing permutation for the KKT
+    /// linear solver (pounce#180 item 1). The next `optimize_*` builds
+    /// the FERAL backend with [`pounce_feral::OrderingMethod::External`],
+    /// overriding the `feral_ordering` string option / env var. Use this
+    /// to inject a block-triangular / Schur ordering a generic algorithm
+    /// cannot see (Parker, Garcia & Bent, arXiv:2602.17968) or a tearing
+    /// ordering from equation-oriented decomposition.
+    ///
+    /// `perm` is a **0-based, new-to-old permutation** (`perm[k]` is the
+    /// original index that becomes index `k`), and its length must equal
+    /// the augmented KKT system dimension (variables + slacks +
+    /// constraint duals), *not* the problem's `n`. A wrong length or a
+    /// non-bijection is rejected by FERAL at the first factorization with
+    /// an `InvalidInput` error (never a panic), surfacing as a solver
+    /// failure rather than a silently-wrong solve — the ordering only
+    /// affects fill/time, never the computed solution.
+    ///
+    /// Persistent config: unlike the warm-start hooks it is *not*
+    /// auto-cleared after a solve. Call [`Self::clear_external_ordering`]
+    /// to drop it. Ignored by non-FERAL backends and by any custom
+    /// factory plugged via [`Self::set_linear_backend_factory`].
+    pub fn set_external_ordering(&mut self, perm: Vec<usize>) {
+        self.external_ordering = Some(perm);
+    }
+
+    /// Drop any installed external KKT ordering, restoring the
+    /// `feral_ordering`-driven default for subsequent solves.
+    pub fn clear_external_ordering(&mut self) {
+        self.external_ordering = None;
+    }
+
+    /// The currently-installed external KKT ordering, if any.
+    pub fn external_ordering(&self) -> Option<&[usize]> {
+        self.external_ordering.as_deref()
     }
 
     /// Return the final QP working set from the most recent SQP
@@ -1309,7 +1360,16 @@ impl IpoptApplication {
         // `OptionsList` that drove the IPM-level builder above so
         // per-problem `.opt` files can flip backend knobs without
         // rebuilding pounce.
-        let feral_cfg = feral_config_from_options(&self.options);
+        let mut feral_cfg = feral_config_from_options(&self.options);
+        // A caller-supplied KKT permutation (pounce#180 item 1) overrides
+        // the string-option / env ordering: `OrderingMethod::External`
+        // can't be expressed through the OptionsList (it carries a
+        // vector), so it is injected here from the side-channel field.
+        // Only applies to the workspace-default FERAL backend below; a
+        // custom `linear_backend_factory` owns its own config.
+        if let Some(perm) = &self.external_ordering {
+            feral_cfg.ordering = pounce_feral::OrderingMethod::External(perm.clone());
+        }
         let factory = self.linear_backend_factory.take().unwrap_or_else(|| {
             default_backend_factory_with_sink(feral_cfg, Arc::clone(&self.linsol_summary_sink))
         });

--- a/crates/pounce-algorithm/src/kkt/mod.rs
+++ b/crates/pounce-algorithm/src/kkt/mod.rs
@@ -14,11 +14,13 @@ pub mod pd_full_space_solver;
 pub mod pd_search_dir_calc;
 pub mod pd_system_solver;
 pub mod perturbation_handler;
+pub mod schur_aug_system_solver;
 pub mod search_dir_calc;
 pub mod slack_scaling;
 pub mod std_aug_system_solver;
 
 pub use aug_system_solver::AugSystemSolver;
 pub use low_rank_aug_system_solver::LowRankAugSystemSolver;
+pub use schur_aug_system_solver::SchurAugSystemSolver;
 pub use slack_scaling::SlackBasedTSymScalingMethod;
 pub use std_aug_system_solver::StdAugSystemSolver;

--- a/crates/pounce-algorithm/src/kkt/schur_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/schur_aug_system_solver.rs
@@ -1,0 +1,316 @@
+//! Block-triangular / Schur augmented-system solver (pounce#180 item 2, Phase 2).
+//!
+//! Wraps the standard [`StdAugSystemSolver`] — reusing its exact KKT assembly
+//! and RHS packing — but routes the assembled system through a
+//! [`FeralSchurSolver`] over a caller-supplied F/S partition (see
+//! `crates/pounce-feral/src/schur.rs`). The partition is given as KKT-space
+//! indices (`0..dim` in the `x, s, c, d` block order `StdAugSystemSolver`
+//! assembles); the `S` block is Schur-complemented out and only the two
+//! diagonal blocks are factorized, with inertia recovered a priori via
+//! Sylvester's law.
+//!
+//! **Gate + fallback (first-class, per the scope doc).** The Schur path helps
+//! only when `n_schur ≪ n_f`; and it is feral-specific. This wrapper falls back
+//! to the plain `StdAugSystemSolver` — transparently, preserving every solve —
+//! whenever: the Schur fraction exceeds `max_schur_frac`, the partition is
+//! malformed for the current KKT dimension, or the Schur backend reports a
+//! `FatalError`. A fallback is permanent for the rest of the solve (the KKT
+//! pattern is fixed across IPM iterations, so re-deciding every iterate is
+//! pointless).
+
+use std::rc::Rc;
+
+use crate::kkt::aug_system_solver::{AugSysCoeffs, AugSysRhs, AugSysSol, AugSystemSolver};
+use crate::kkt::std_aug_system_solver::StdAugSystemSolver;
+use pounce_common::diagnostics::DiagnosticsState;
+use pounce_common::timing::TimingStatistics;
+use pounce_common::types::{Index, Number};
+use pounce_feral::{FeralConfig, FeralSchurSolver};
+use pounce_linsol::{ESymSolverStatus, FactorPattern};
+
+/// Default upper bound on `n_schur / dim`. Beyond this the dense `S`
+/// (`O(n_s²)` store, `O(n_s³)` factor) makes the Schur path lose to a
+/// monolithic factorization, so we fall back. Lenient by default — the caller
+/// opts in by supplying the block, and knows its structure — but guards against
+/// a pathological "Schur block is most of the matrix" request.
+const DEFAULT_MAX_SCHUR_FRAC: f64 = 0.5;
+
+pub struct SchurAugSystemSolver {
+    /// KKT assembly + the fallback solver.
+    inner: StdAugSystemSolver,
+    schur: FeralSchurSolver,
+    /// Caller-supplied Schur block, KKT-space indices.
+    schur_indices: Vec<usize>,
+    max_schur_frac: f64,
+
+    /// `None` until the partition has been validated against a concrete KKT
+    /// dimension; `Some(dim)` records what it was pinned for (re-decide only if
+    /// the dimension changes, which it does not within one solve).
+    decided_for_dim: Option<Index>,
+    /// After [`Self::decided_for_dim`] is set: whether the Schur path is active.
+    /// `false` means permanent fallback to `inner`.
+    use_schur: bool,
+    have_factor: bool,
+    negevals: Index,
+    last_status: ESymSolverStatus,
+    timing: Option<Rc<TimingStatistics>>,
+}
+
+impl SchurAugSystemSolver {
+    /// Wrap `inner` with a Schur backend over `schur_indices` (KKT-space).
+    /// The Schur block's per-block feral solvers are configured from `cfg`
+    /// (same knobs as the monolithic feral backend).
+    pub fn new(inner: StdAugSystemSolver, schur_indices: Vec<usize>, cfg: FeralConfig) -> Self {
+        Self {
+            inner,
+            schur: FeralSchurSolver::new(cfg),
+            schur_indices,
+            max_schur_frac: DEFAULT_MAX_SCHUR_FRAC,
+            decided_for_dim: None,
+            use_schur: false,
+            have_factor: false,
+            negevals: 0,
+            last_status: ESymSolverStatus::Success,
+            timing: None,
+        }
+    }
+
+    /// Decide (once per KKT dimension) whether the Schur path is usable and, if
+    /// so, pin its structure. `irn/jcn` are the assembled lower-triangle
+    /// triplet from `inner`.
+    fn decide(&mut self, dim: Index) {
+        if self.decided_for_dim == Some(dim) {
+            return;
+        }
+        self.decided_for_dim = Some(dim);
+        self.use_schur = false;
+        let n_s = self.schur_indices.len();
+        let d = dim as usize;
+        if n_s == 0 || n_s >= d {
+            return;
+        }
+        if (n_s as f64) / (d as f64) > self.max_schur_frac {
+            tracing::warn!(
+                target: "pounce::kkt",
+                n_schur = n_s, dim = d, max_frac = self.max_schur_frac,
+                "Schur block too large relative to the KKT; using the standard solver"
+            );
+            return;
+        }
+        // Copy the triplet out of `inner` before touching `self.schur`
+        // (disjoint fields, but the borrow checker only sees whole-`self`).
+        let (irn, jcn) = {
+            let (a, b, _v) = self.inner.assembled_triplet();
+            (a.to_vec(), b.to_vec())
+        };
+        let st = self
+            .schur
+            .initialize_structure(dim, &irn, &jcn, &self.schur_indices);
+        if st == ESymSolverStatus::Success {
+            self.use_schur = true;
+        } else {
+            tracing::warn!(
+                target: "pounce::kkt",
+                "Schur partition rejected by the backend; using the standard solver"
+            );
+        }
+    }
+
+    /// Run the Schur factor + block backsolve for one RHS. Assumes `inner` has
+    /// already assembled and `use_schur` is set. Returns the factor status;
+    /// on `Success` the solution is written to `sol`.
+    fn schur_solve_one(
+        &mut self,
+        rhs: &AugSysRhs<'_>,
+        sol: &mut AugSysSol<'_>,
+        check_neg_evals: bool,
+        num_neg_evals: Index,
+    ) -> ESymSolverStatus {
+        let dim = self.inner.assembled_dim() as usize;
+        // Refill the Schur backend's values from the freshly assembled KKT.
+        let vals = self.inner.assembled_triplet().2.to_vec();
+        self.schur.values_array_mut().copy_from_slice(&vals);
+
+        let status = {
+            let _g = self
+                .timing
+                .as_deref()
+                .map(|t| t.linear_system_factorization.guard());
+            self.schur.factor(check_neg_evals, num_neg_evals)
+        };
+        self.last_status = status;
+        match status {
+            ESymSolverStatus::Success => {
+                self.negevals = self.schur.number_of_neg_evals();
+                let mut packed = vec![0.0; dim];
+                self.inner.pack_rhs(rhs, &mut packed);
+                let bstat = {
+                    let _g = self
+                        .timing
+                        .as_deref()
+                        .map(|t| t.linear_system_back_solve.guard());
+                    self.schur.backsolve(1, &mut packed)
+                };
+                if bstat != ESymSolverStatus::Success {
+                    self.have_factor = false;
+                    self.last_status = bstat;
+                    return bstat;
+                }
+                self.inner.unpack_sol(&packed, sol);
+                self.have_factor = true;
+                ESymSolverStatus::Success
+            }
+            ESymSolverStatus::WrongInertia => {
+                // Both diagonal blocks factored, but the combined (Sylvester)
+                // inertia is wrong: surface the count so the IPM's δ-perturbation
+                // loop reacts, exactly as the monolithic path. The perturbation
+                // reaches both blocks (δ_x/δ_s → A_FF, δ_c/δ_d → A_SS), so the
+                // next re-factor can correct it.
+                self.negevals = self.schur.number_of_neg_evals();
+                self.have_factor = false;
+                status
+            }
+            // Singular (a diagonal block itself is rank-deficient — the Schur
+            // precondition is violated for this iterate) or FatalError/CallAgain:
+            // return the sentinel and let `solve` fall back to the monolithic
+            // solver, which regularizes the *full* system correctly. Bumping
+            // δ_c (where `perturb_for_singular` routes a `Singular`) would not
+            // fix a singular A_FF, so we do not surface `Singular` upward.
+            other => {
+                self.have_factor = false;
+                other
+            }
+        }
+    }
+}
+
+impl AugSystemSolver for SchurAugSystemSolver {
+    fn provides_inertia(&self) -> bool {
+        // Both the Schur (feral) path and the fallback backend report inertia.
+        self.inner.provides_inertia()
+    }
+
+    fn number_of_neg_evals(&self) -> Index {
+        if self.use_schur {
+            self.negevals
+        } else {
+            self.inner.number_of_neg_evals()
+        }
+    }
+
+    fn system_dim(&self) -> Index {
+        self.inner.system_dim()
+    }
+
+    fn kkt_triplets(&self) -> Option<(Index, Vec<Index>, Vec<Index>, Vec<Number>)> {
+        self.inner.kkt_triplets()
+    }
+
+    fn l_factor(&self, want_values: bool) -> Option<FactorPattern> {
+        // The Schur path has no single monolithic L factor; only the fallback
+        // (monolithic) path can expose one.
+        if self.use_schur {
+            None
+        } else {
+            self.inner.l_factor(want_values)
+        }
+    }
+
+    fn increase_quality(&mut self) -> bool {
+        self.have_factor = false;
+        if self.use_schur {
+            self.schur.increase_quality()
+        } else {
+            self.inner.increase_quality()
+        }
+    }
+
+    fn last_solve_status(&self) -> ESymSolverStatus {
+        if self.use_schur {
+            self.last_status
+        } else {
+            self.inner.last_solve_status()
+        }
+    }
+
+    fn set_timing_stats(&mut self, timing: Rc<TimingStatistics>) {
+        self.timing = Some(Rc::clone(&timing));
+        self.inner.set_timing_stats(timing);
+    }
+
+    fn set_diagnostics(&mut self, diag: Rc<DiagnosticsState>) {
+        self.inner.set_diagnostics(diag);
+    }
+
+    fn solve(
+        &mut self,
+        coeffs: &AugSysCoeffs<'_>,
+        rhs: &AugSysRhs<'_>,
+        sol: &mut AugSysSol<'_>,
+        check_neg_evals: bool,
+        num_neg_evals: Index,
+    ) -> ESymSolverStatus {
+        // Assemble the KKT once (reused by whichever path runs).
+        let s = self.inner.assemble(coeffs);
+        if s != ESymSolverStatus::Success {
+            self.last_status = s;
+            return s;
+        }
+        let dim = self.inner.assembled_dim();
+        self.decide(dim);
+
+        if self.use_schur {
+            let st = self.schur_solve_one(rhs, sol, check_neg_evals, num_neg_evals);
+            match st {
+                ESymSolverStatus::Success | ESymSolverStatus::WrongInertia => return st,
+                // Singular block / FatalError / CallAgain → permanent fallback.
+                // Re-run this solve through the monolithic path so the IPM never
+                // sees a spurious failure and gets correct full-system
+                // regularization for the rest of the run.
+                _ => {
+                    tracing::warn!(
+                        target: "pounce::kkt",
+                        status = ?st,
+                        "Schur backend could not factor this KKT; falling back to the standard solver"
+                    );
+                    self.use_schur = false;
+                    return self
+                        .inner
+                        .solve(coeffs, rhs, sol, check_neg_evals, num_neg_evals);
+                }
+            }
+        }
+        self.inner
+            .solve(coeffs, rhs, sol, check_neg_evals, num_neg_evals)
+    }
+
+    fn resolve(
+        &mut self,
+        coeffs: &AugSysCoeffs<'_>,
+        rhs: &AugSysRhs<'_>,
+        sol: &mut AugSysSol<'_>,
+    ) -> ESymSolverStatus {
+        if self.use_schur {
+            if self.have_factor {
+                // Back-substitution only, against the cached Schur factor.
+                let dim = self.inner.assembled_dim() as usize;
+                let mut packed = vec![0.0; dim];
+                self.inner.pack_rhs(rhs, &mut packed);
+                let bstat = {
+                    let _g = self
+                        .timing
+                        .as_deref()
+                        .map(|t| t.linear_system_back_solve.guard());
+                    self.schur.backsolve(1, &mut packed)
+                };
+                if bstat == ESymSolverStatus::Success {
+                    self.inner.unpack_sol(&packed, sol);
+                }
+                return bstat;
+            }
+            // No cached factor — do a full solve.
+            return self.solve(coeffs, rhs, sol, false, 0);
+        }
+        self.inner.resolve(coeffs, rhs, sol)
+    }
+}

--- a/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/std_aug_system_solver.rs
@@ -336,7 +336,51 @@ impl StdAugSystemSolver {
         );
     }
 
-    fn pack_rhs(&self, rhs: &AugSysRhs<'_>, packed: &mut [Number]) {
+    /// Rebuild the triplet structure when the structural fingerprint changes,
+    /// then refill the value array — i.e. everything `solve` does *before*
+    /// handing the matrix to the linear solver. Factored out so
+    /// [`crate::kkt::schur_aug_system_solver::SchurAugSystemSolver`] can reuse
+    /// the exact KKT assembly (the same lower-triangle triplet layout) without
+    /// duplicating it, then route the assembled `(dim, irn, jcn, vals)` through
+    /// the Schur backend instead of `self.linsol`. Returns the build status;
+    /// on `Success` the `dim`/`irn`/`jcn`/`vals` accessors are current.
+    pub(crate) fn assemble(&mut self, coeffs: &AugSysCoeffs<'_>) -> ESymSolverStatus {
+        let sig = {
+            let w_nnz = coeffs.w.map(w_nonzeros).unwrap_or(0);
+            let jc_nnz = gen_t_downcast(coeffs.j_c).nonzeros() as usize;
+            let jd_nnz = gen_t_downcast(coeffs.j_d).nonzeros() as usize;
+            (
+                w_nnz,
+                jc_nnz,
+                jd_nnz,
+                coeffs.j_c.n_cols(),
+                coeffs.j_c.n_rows(),
+                coeffs.j_d.n_rows(),
+            )
+        };
+        if !self.initialized || self.struct_sig != Some(sig) {
+            let s = self.build_structure(coeffs);
+            if s != ESymSolverStatus::Success {
+                self.last_status = Some(s);
+                return s;
+            }
+            self.struct_sig = Some(sig);
+        }
+        self.refill_values(coeffs);
+        ESymSolverStatus::Success
+    }
+
+    /// Assembled KKT dimension (valid after [`Self::assemble`]).
+    pub(crate) fn assembled_dim(&self) -> Index {
+        self.dim
+    }
+    /// Assembled 1-based lower-triangle triplet + value array (after
+    /// [`Self::assemble`]). Same layout the linear solver receives.
+    pub(crate) fn assembled_triplet(&self) -> (&[Index], &[Index], &[Number]) {
+        (&self.irn, &self.jcn, &self.vals)
+    }
+
+    pub(crate) fn pack_rhs(&self, rhs: &AugSysRhs<'_>, packed: &mut [Number]) {
         let n_x = self.n_x as usize;
         let n_s = self.n_s as usize;
         let n_c = self.n_c as usize;
@@ -350,7 +394,7 @@ impl StdAugSystemSolver {
         );
     }
 
-    fn unpack_sol(&self, packed: &[Number], sol: &mut AugSysSol<'_>) {
+    pub(crate) fn unpack_sol(&self, packed: &[Number], sol: &mut AugSysSol<'_>) {
         let n_x = self.n_x as usize;
         let n_s = self.n_s as usize;
         let n_c = self.n_c as usize;
@@ -418,28 +462,10 @@ impl AugSystemSolver for StdAugSystemSolver {
         // (`zero_w` for Hessian-free init/multiplier solves vs an
         // `n`-diagonal `B0` for the main solves); reusing a stale pinned
         // structure would drop the W block entirely.
-        let sig = {
-            let w_nnz = coeffs.w.map(w_nonzeros).unwrap_or(0);
-            let jc_nnz = gen_t_downcast(coeffs.j_c).nonzeros() as usize;
-            let jd_nnz = gen_t_downcast(coeffs.j_d).nonzeros() as usize;
-            (
-                w_nnz,
-                jc_nnz,
-                jd_nnz,
-                coeffs.j_c.n_cols(),
-                coeffs.j_c.n_rows(),
-                coeffs.j_d.n_rows(),
-            )
-        };
-        if !self.initialized || self.struct_sig != Some(sig) {
-            let s = self.build_structure(coeffs);
-            if s != ESymSolverStatus::Success {
-                self.last_status = Some(s);
-                return s;
-            }
-            self.struct_sig = Some(sig);
+        let s = self.assemble(coeffs);
+        if s != ESymSolverStatus::Success {
+            return s;
         }
-        self.refill_values(coeffs);
 
         let mut packed = vec![0.0; self.dim as usize];
         self.pack_rhs(rhs, &mut packed);

--- a/crates/pounce-algorithm/tests/optimize_hs14.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs14.rs
@@ -182,3 +182,63 @@ fn hs014_solves_with_adaptive_mu_quality_function() {
         stats.final_objective,
     );
 }
+
+/// pounce#180 item 2: solving with a Schur KKT partition installed reaches the
+/// same optimum as the standard full-space solve. HS14's augmented KKT has
+/// dimension `n_x + n_s + n_c + n_d = 2 + 1 + 1 + 1 = 5` in `x, s, c, d` block
+/// order; the constraint-dual block is indices `[3, 4]`. Choosing that as the
+/// Schur block leaves the primal `(x, s)` block — positive definite in the
+/// interior — as the eliminated `A_FF`, the classic range/null-space split.
+#[test]
+fn hs014_solves_with_schur_kkt_block() {
+    let mut app = IpoptApplication::new();
+    app.set_kkt_schur_block(vec![3, 4]);
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs014));
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    eprintln!(
+        "HS14 schur[3,4]: status={:?} iter={} obj={}",
+        status, stats.iteration_count, stats.final_objective,
+    );
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+    assert!(
+        (stats.final_objective - F_STAR).abs() < 1e-4,
+        "schur final_objective = {} (expected ~{F_STAR})",
+        stats.final_objective,
+    );
+}
+
+/// An oversized / unsuitable Schur block must not break the solve: the wrapper
+/// falls back to the standard full-space solver transparently. Here the block
+/// covers all-but-one index (well past the gate), so the Schur path is never
+/// activated, yet the solve still converges to the optimum.
+#[test]
+fn hs014_schur_oversized_block_falls_back() {
+    let mut app = IpoptApplication::new();
+    app.set_kkt_schur_block(vec![0, 1, 2, 3]); // 4/5 of the KKT → gate rejects
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs014));
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+    assert!(
+        (stats.final_objective - F_STAR).abs() < 1e-4,
+        "fallback final_objective = {} (expected ~{F_STAR})",
+        stats.final_objective,
+    );
+}

--- a/crates/pounce-algorithm/tests/schur_corpus.rs
+++ b/crates/pounce-algorithm/tests/schur_corpus.rs
@@ -1,0 +1,247 @@
+//! pounce#180 item 2, Phase 3 — corpus correctness parity in CI.
+//!
+//! Solves a scalable, strictly-convex, box-and-equality-constrained NLP both
+//! through the standard full-space solver and through the Schur KKT solver
+//! (constraint-dual block as the Schur set, the range/null-space split), and
+//! asserts the two reach the *same* optimum. This guards, at moderate scale and
+//! for a nontrivial (~15-iteration) barrier trajectory, that the Schur path —
+//! block factorization + Sylvester inertia + the per-iteration inertia check +
+//! resolve — stays in lock-step with the monolithic path. The larger sweep and
+//! the linear-algebra timing comparison live in
+//! `python/benchmarks/schur_kkt_180.py`.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+
+/// min Σ 0.5 d_i (x_i − t_i)²  s.t.  A x = b,  −0.5 ≤ x ≤ 0.5.
+/// Diagonal (PD) Hessian ⇒ the primal block stays positive definite, so the
+/// dual block is a clean Schur set. Each equality couples a contiguous window
+/// of variables (banded Jacobian).
+struct ConvexQp {
+    n: usize,
+    m: usize,
+    width: usize,
+    t: Vec<Number>,
+    d: Vec<Number>,
+    // Jacobian triplet (constant): row i couples cols [starts[i], starts[i]+width).
+    starts: Vec<usize>,
+    coef: Vec<Number>, // length m*width
+    b: Vec<Number>,
+    captured_x: Rc<RefCell<Vec<Number>>>,
+}
+
+impl ConvexQp {
+    fn new(n: usize, m: usize) -> Self {
+        let width = (n / (2 * m)).max(4);
+        // Deterministic pseudo-random data (no rng dependency).
+        let h = |k: usize| ((k.wrapping_mul(2_654_435_761) >> 8) % 1000) as f64 / 1000.0;
+        let t: Vec<Number> = (0..n).map(|i| 2.0 * h(i + 1) - 1.0).collect();
+        let d: Vec<Number> = (0..n).map(|i| 0.5 + 1.5 * h(i + 7)).collect();
+        let starts: Vec<usize> = (0..m)
+            .map(|i| {
+                if m > 1 {
+                    (i * (n - width)) / (m - 1)
+                } else {
+                    0
+                }
+            })
+            .collect();
+        let coef: Vec<Number> = (0..m * width).map(|k| 2.0 * h(k + 101) - 1.0).collect();
+        // Feasible RHS from a point strictly inside the box.
+        let x_feas: Vec<Number> = (0..n).map(|i| 0.8 * (h(i + 31) - 0.5)).collect();
+        let mut b = vec![0.0; m];
+        for i in 0..m {
+            let mut s = 0.0;
+            for w in 0..width {
+                s += coef[i * width + w] * x_feas[starts[i] + w];
+            }
+            b[i] = s;
+        }
+        Self {
+            n,
+            m,
+            width,
+            t,
+            d,
+            starts,
+            coef,
+            b,
+            captured_x: Rc::new(RefCell::new(Vec::new())),
+        }
+    }
+}
+
+impl TNLP for ConvexQp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: self.n as i32,
+            m: self.m as i32,
+            nnz_jac_g: (self.m * self.width) as i32,
+            nnz_h_lag: self.n as i32, // diagonal
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.iter_mut().for_each(|v| *v = -0.5);
+        b.x_u.iter_mut().for_each(|v| *v = 0.5);
+        // Equalities.
+        for i in 0..self.m {
+            b.g_l[i] = self.b[i];
+            b.g_u[i] = self.b[i];
+        }
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.iter_mut().for_each(|v| *v = 0.0);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let mut f = 0.0;
+        for i in 0..self.n {
+            let dx = x[i] - self.t[i];
+            f += 0.5 * self.d[i] * dx * dx;
+        }
+        Some(f)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..self.n {
+            g[i] = self.d[i] * (x[i] - self.t[i]);
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..self.m {
+            let mut s = 0.0;
+            for w in 0..self.width {
+                s += self.coef[i * self.width + w] * x[self.starts[i] + w];
+            }
+            g[i] = s;
+        }
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let mut k = 0;
+                for i in 0..self.m {
+                    for w in 0..self.width {
+                        irow[k] = i as i32;
+                        jcol[k] = (self.starts[i] + w) as i32;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&self.coef);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Linear constraints ⇒ Hessian of Lagrangian = obj_factor · diag(d).
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for i in 0..self.n {
+                    irow[i] = i as i32;
+                    jcol[i] = i as i32;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                for i in 0..self.n {
+                    values[i] = obj_factor * self.d[i];
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        *self.captured_x.borrow_mut() = sol.x.to_vec();
+    }
+}
+
+fn solve(n: usize, m: usize, schur: bool) -> (ApplicationReturnStatus, i32, Number, Vec<Number>) {
+    let mut app = IpoptApplication::new();
+    if schur {
+        // Constraint-dual block: KKT dim = n + n_slack + n_eq + n_ineq. All
+        // constraints are equalities ⇒ n_slack = n_ineq = 0, so dim = n + m and
+        // the dual block is [n, n + m).
+        app.set_kkt_schur_block((n..n + m).collect());
+    }
+    app.options_mut()
+        .set_numeric_value("tol", 1e-8, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let prob = ConvexQp::new(n, m);
+    let cap = Rc::clone(&prob.captured_x);
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(prob));
+    let status = app.optimize_tnlp(tnlp);
+    let stats = app.statistics();
+    let x = cap.borrow().clone();
+    (status, stats.iteration_count, stats.final_objective, x)
+}
+
+fn ok(status: ApplicationReturnStatus) -> bool {
+    matches!(
+        status,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    )
+}
+
+fn parity_case(n: usize, m: usize) {
+    let (s_std, it_std, f_std, x_std) = solve(n, m, false);
+    let (s_sch, it_sch, f_sch, x_sch) = solve(n, m, true);
+    assert!(ok(s_std), "std status {s_std:?} (n={n}, m={m})");
+    assert!(ok(s_sch), "schur status {s_sch:?} (n={n}, m={m})");
+    let dx = x_std
+        .iter()
+        .zip(&x_sch)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    eprintln!(
+        "schur corpus n={n} m={m}: iters std/schur={it_std}/{it_sch} f={f_std:.6} max|dx|={dx:e}"
+    );
+    assert!(
+        (f_std - f_sch).abs() < 1e-6,
+        "objective mismatch: std={f_std} schur={f_sch}"
+    );
+    assert!(dx < 1e-6, "solution mismatch: max|dx|={dx:e}");
+}
+
+#[test]
+fn schur_matches_full_space_small() {
+    parity_case(120, 6);
+}
+
+#[test]
+fn schur_matches_full_space_medium() {
+    parity_case(600, 10);
+}

--- a/crates/pounce-common/src/timing.rs
+++ b/crates/pounce-common/src/timing.rs
@@ -316,6 +316,56 @@ impl TimingStatistics {
         s
     }
 
+    /// Structured wall-clock breakdown (seconds) of the major solve
+    /// subsystems, as ordered `(label, seconds)` pairs. Same numbers
+    /// [`Self::report`] prints, but as data rather than formatted text,
+    /// so a programmatic consumer (e.g. the Python `Problem.solve` `info`
+    /// dict) can attribute a solve's runtime without scraping the report
+    /// or patching the solver.
+    ///
+    /// Ordered coarse→fine: the overall algorithm total; the
+    /// linear-algebra split (`linear_system_total` = factorization +
+    /// back-solve, with factorization broken out); and the per-callback
+    /// function-evaluation split (objective / gradient / constraints /
+    /// Jacobian / Lagrangian Hessian). This is exactly the func /
+    /// Jacobian / Hessian time split issue #180 needs to reproduce a
+    /// Table-6-style "where did the time go" analysis for a
+    /// reduced-space / variable-aggregation solve.
+    pub fn wall_time_breakdown(&self) -> Vec<(&'static str, Number)> {
+        let factorization = self.linear_system_factorization.total_wallclock_time();
+        let back_solve = self.linear_system_back_solve.total_wallclock_time();
+        vec![
+            ("overall_alg", self.overall_alg.total_wallclock_time()),
+            ("update_hessian", self.update_hessian.total_wallclock_time()),
+            (
+                "compute_search_direction",
+                self.compute_search_direction.total_wallclock_time(),
+            ),
+            ("linear_system_total", factorization + back_solve),
+            ("linear_system_factorization", factorization),
+            ("linear_system_back_solve", back_solve),
+            (
+                "function_evaluations_total",
+                self.total_function_evaluation_time.total_wallclock_time(),
+            ),
+            ("eval_objective", self.eval_obj.total_wallclock_time()),
+            ("eval_gradient", self.eval_grad_obj.total_wallclock_time()),
+            ("eval_constraints", self.eval_constr.total_wallclock_time()),
+            (
+                "eval_constraint_jacobian",
+                self.eval_constr_jac.total_wallclock_time(),
+            ),
+            (
+                "eval_lagrangian_hessian",
+                self.eval_lag_hess.total_wallclock_time(),
+            ),
+            (
+                "total_callback",
+                self.total_callback_time.total_wallclock_time(),
+            ),
+        ]
+    }
+
     /// Reset all counters. Mirrors upstream `ResetTimes()`.
     pub fn reset(&self) {
         self.overall_alg.reset();
@@ -372,5 +422,43 @@ mod tests {
         let t = TimedTask::new();
         t.end_if_started();
         assert_eq!(t.total_wallclock_time(), 0.0);
+    }
+
+    #[test]
+    fn wall_time_breakdown_reports_subsystems() {
+        let stats = TimingStatistics::new();
+        // Accumulate into two distinct subsystems so the breakdown is
+        // not trivially all-zero and the linear-algebra total is the
+        // sum of its two parts.
+        stats.linear_system_factorization.start();
+        stats.linear_system_factorization.end();
+        stats.eval_lag_hess.start();
+        stats.eval_lag_hess.end();
+
+        let bd = stats.wall_time_breakdown();
+        let get = |k: &str| bd.iter().find(|(label, _)| *label == k).map(|(_, v)| *v);
+
+        // Every advertised key is present and non-negative.
+        for key in [
+            "overall_alg",
+            "linear_system_total",
+            "linear_system_factorization",
+            "linear_system_back_solve",
+            "function_evaluations_total",
+            "eval_objective",
+            "eval_gradient",
+            "eval_constraints",
+            "eval_constraint_jacobian",
+            "eval_lagrangian_hessian",
+        ] {
+            assert!(get(key).is_some(), "missing breakdown key {key}");
+            assert!(get(key).unwrap() >= 0.0, "negative time for {key}");
+        }
+
+        // linear_system_total == factorization + back_solve, exactly.
+        let total = get("linear_system_total").unwrap();
+        let fact = get("linear_system_factorization").unwrap();
+        let back = get("linear_system_back_solve").unwrap();
+        assert_eq!(total, fact + back);
     }
 }

--- a/crates/pounce-feral/src/lib.rs
+++ b/crates/pounce-feral/src/lib.rs
@@ -387,7 +387,11 @@ impl FeralSolverInterface {
         // default — it picks a concrete method per-matrix from cheap
         // pattern features. Override via the `feral_ordering`
         // OptionsList option or `POUNCE_FERAL_ORDERING` env var.
-        solver = solver.with_ordering(cfg.ordering);
+        // `.clone()` since FERAL 0.13's `OrderingMethod` is no longer
+        // `Copy` (the `External(Vec<usize>)` variant carries a heap
+        // permutation); the owned copy is moved into `self.ordering`
+        // below. Mirrors the `cfg.scaling.clone()` handling.
+        solver = solver.with_ordering(cfg.ordering.clone());
         // Diagonal scaling. `ScalingStrategy::Auto` is pounce's default
         // — FERAL's adaptive shape-based router. Override via the
         // `feral_scaling` OptionsList option or `POUNCE_FERAL_SCALING`
@@ -480,7 +484,11 @@ impl FeralSolverInterface {
         span.record("factor_nnz", stats.nnz_l);
         span.record("inertia_neg", stats.inertia.negative);
         span.record("fill_ratio", stats.fill_ratio);
-        span.record("ordering", tracing::field::debug(self.ordering));
+        // Borrow rather than move: `OrderingMethod` is no longer `Copy`
+        // (FERAL 0.13). FERAL's hand-written `Debug` prints the `External`
+        // arm compactly as `External { len: N }`, so this stays a
+        // one-liner even for a caller-supplied permutation.
+        span.record("ordering", tracing::field::debug(&self.ordering));
     }
 
     /// Build the lower-triangle CSC view, factor it, and stash the
@@ -1254,7 +1262,7 @@ mod tests {
         for (tag, expected) in cases {
             assert_eq!(
                 parse_ordering_method(tag),
-                Some(*expected),
+                Some(expected.clone()),
                 "tag {tag:?} should parse"
             );
         }
@@ -1269,7 +1277,9 @@ mod tests {
         use OrderingMethod::*;
         for method in [Auto, AutoRace, Amd, Amf, MetisND, ScotchND, KahipND] {
             let cfg = FeralConfig {
-                ordering: method,
+                // `.clone()` — `OrderingMethod` is no longer `Copy` (FERAL
+                // 0.13); `method` is reused in the assert messages below.
+                ordering: method.clone(),
                 ..FeralConfig::default()
             };
             let mut s = FeralSolverInterface::with_config(cfg);
@@ -1289,6 +1299,66 @@ mod tests {
             );
             assert!((rhs[0] - 1.0).abs() < 1e-10, "x0 for {method:?}");
             assert!((rhs[1] - 1.0).abs() < 1e-10, "x1 for {method:?}");
+        }
+    }
+
+    /// A caller-supplied `OrderingMethod::External` permutation (pounce#180
+    /// item 1 / FERAL#107) factors and solves correctly. Both the identity
+    /// and a swapped permutation are valid bijections, so each must recover
+    /// the same solution as every built-in ordering does above.
+    #[test]
+    fn external_ordering_solves_correctly() {
+        for perm in [vec![0usize, 1], vec![1usize, 0]] {
+            let cfg = FeralConfig {
+                ordering: OrderingMethod::External(perm.clone()),
+                ..FeralConfig::default()
+            };
+            let mut s = FeralSolverInterface::with_config(cfg);
+            // [[2,1],[1,3]] x = [3,4]  →  x = [1,1].
+            let irn: [Index; 3] = [1, 2, 2];
+            let jcn: [Index; 3] = [1, 1, 2];
+            assert_eq!(
+                s.initialize_structure(2, 3, &irn, &jcn),
+                ESymSolverStatus::Success,
+                "structure init for perm {perm:?}"
+            );
+            s.values_array_mut().copy_from_slice(&[2.0, 1.0, 3.0]);
+            let mut rhs = [3.0, 4.0];
+            assert_eq!(
+                s.multi_solve(true, &irn, &jcn, 1, &mut rhs, false, 0),
+                ESymSolverStatus::Success,
+                "solve for perm {perm:?}"
+            );
+            assert!((rhs[0] - 1.0).abs() < 1e-10, "x0 for perm {perm:?}");
+            assert!((rhs[1] - 1.0).abs() < 1e-10, "x1 for perm {perm:?}");
+        }
+    }
+
+    /// A wrong-length / non-bijection `External` permutation is rejected
+    /// by FERAL as `InvalidInput` and surfaces as a non-`Success` status —
+    /// never a panic and never a silently-wrong solve. Here a length-3
+    /// permutation is supplied for a 2×2 matrix.
+    #[test]
+    fn external_ordering_wrong_length_fails_without_panic() {
+        let cfg = FeralConfig {
+            ordering: OrderingMethod::External(vec![0, 1, 2]),
+            ..FeralConfig::default()
+        };
+        let mut s = FeralSolverInterface::with_config(cfg);
+        let irn: [Index; 3] = [1, 2, 2];
+        let jcn: [Index; 3] = [1, 1, 2];
+        // The validation can fire at symbolic (structure init) or at the
+        // first factor (solve); either way the status must not be Success.
+        let init_st = s.initialize_structure(2, 3, &irn, &jcn);
+        if init_st == ESymSolverStatus::Success {
+            s.values_array_mut().copy_from_slice(&[2.0, 1.0, 3.0]);
+            let mut rhs = [3.0, 4.0];
+            let solve_st = s.multi_solve(true, &irn, &jcn, 1, &mut rhs, false, 0);
+            assert_ne!(
+                solve_st,
+                ESymSolverStatus::Success,
+                "wrong-length external ordering must fail the solve"
+            );
         }
     }
 

--- a/crates/pounce-feral/src/lib.rs
+++ b/crates/pounce-feral/src/lib.rs
@@ -20,6 +20,9 @@
 
 use std::sync::{Arc, Mutex};
 
+pub mod schur;
+pub use schur::FeralSchurSolver;
+
 use feral::symbolic::SupernodeParams;
 use feral::{CscMatrix, FactorStats, FactorStatus, NumericParams, Solver};
 
@@ -268,6 +271,68 @@ pub fn parse_ordering_method(s: &str) -> Option<OrderingMethod> {
     }
 }
 
+/// Build a configured `feral::Solver` from a [`FeralConfig`]. Extracted from
+/// [`FeralSolverInterface::with_config`] so the Schur backend
+/// ([`crate::schur::FeralSchurSolver`]) configures its per-block solvers
+/// identically (same pivot threshold, cascade-break, parallelism, ordering,
+/// scaling) as the monolithic path.
+pub(crate) fn configure_solver(cfg: &FeralConfig) -> Solver {
+    // `POUNCE_FERAL_MIN_PAR_FLOPS=<u64>` overrides feral's parallel-dispatch
+    // flop gate (feral#19, default 10^8). `0` fires the gate on every
+    // multi-child tree ≥ N_PAR_MIN supernodes; `u64::MAX` rejects all
+    // parallel dispatch at the tree level.
+    let mut np = NumericParams::default();
+    if let Ok(s) = std::env::var("POUNCE_FERAL_MIN_PAR_FLOPS") {
+        if let Ok(v) = s.parse::<u64>() {
+            np.min_parallel_flops = Some(v);
+        }
+    }
+    // Relative Bunch-Kaufman partial-pivoting threshold — the analog of
+    // Ipopt's `ma27_pivtol` / `ma57_pivtol` (`feral_pivtol` option /
+    // `POUNCE_FERAL_PIVTOL` env, read in `FeralConfig::from_env`).
+    np.bk.pivot_threshold = cfg.pivtol;
+    // Cascade-break (FERAL issue #55 Phase B). `NumericParams::default()`
+    // arms CB; the tri-state `cfg.cascade_break` only intervenes on an
+    // explicit set: None inherits the FERAL default (on), Some(true)
+    // re-arms explicitly, Some(false) disarms (reproduces pre-Phase-B).
+    match cfg.cascade_break {
+        None => {}
+        Some(true) => {
+            np.cascade_break_ratio = Some(0.5);
+            np.cascade_break_eps = Some(1e-10);
+        }
+        Some(false) => {
+            np.cascade_break_ratio = None;
+            np.cascade_break_eps = None;
+        }
+    }
+    let mut solver = Solver::with_params(np, SupernodeParams::default());
+    // Internal-parallelism toggle. Explicit `cfg.parallel` is the primary
+    // per-backend lever; when unset, fall back to the legacy process-wide
+    // `FERAL_PARALLEL` env var.
+    match cfg.parallel {
+        Some(p) => solver = solver.with_parallel(p),
+        None => {
+            if matches!(
+                std::env::var("FERAL_PARALLEL").as_deref(),
+                Ok("0") | Ok("false") | Ok("off")
+            ) {
+                solver = solver.with_parallel(false);
+            }
+        }
+    }
+    if cfg.fma {
+        solver = solver.with_fma(true);
+    }
+    // Fill-reducing ordering (`feral_ordering` / `POUNCE_FERAL_ORDERING`),
+    // and diagonal scaling (`feral_scaling` / `POUNCE_FERAL_SCALING`).
+    // `.clone()` since FERAL 0.13's `OrderingMethod` / `ScalingStrategy`
+    // carry heap `External` variants and are no longer `Copy`.
+    solver = solver.with_ordering(cfg.ordering.clone());
+    solver = solver.with_scaling(cfg.scaling.clone());
+    solver
+}
+
 /// Parse a case-insensitive scaling tag (the values accepted by the
 /// `feral_scaling` OptionsList option and the `POUNCE_FERAL_SCALING`
 /// env var) into the corresponding [`ScalingStrategy`]. Returns `None`
@@ -320,84 +385,7 @@ impl FeralSolverInterface {
     /// `feral_cascade_break` option is left unset. See
     /// [`FeralConfig::cascade_break`] for the tri-state semantics.
     pub fn with_config(cfg: FeralConfig) -> Self {
-        // `POUNCE_FERAL_MIN_PAR_FLOPS=<u64>` overrides feral's parallel-
-        // dispatch flop gate (feral#19, default 10^8). `0` fires the
-        // gate on every multi-child tree ≥ N_PAR_MIN supernodes (pre-
-        // feral#19 behavior). `u64::MAX` rejects all parallel dispatch
-        // at the tree level. Useful when the per-hardware break-even
-        // is far from feral's default.
-        let mut np = NumericParams::default();
-        if let Ok(s) = std::env::var("POUNCE_FERAL_MIN_PAR_FLOPS") {
-            if let Ok(v) = s.parse::<u64>() {
-                np.min_parallel_flops = Some(v);
-            }
-        }
-        // Relative Bunch-Kaufman partial-pivoting threshold — the
-        // analog of Ipopt's `ma27_pivtol` / `ma57_pivtol`. Surfaced as
-        // the `feral_pivtol` OptionsList option (registered in
-        // pounce-algorithm's `upstream_options::register_all_options`),
-        // with the `POUNCE_FERAL_PIVTOL` env var (or its deprecated legacy
-        // alias `FERAL_PIVTOL`) as a fallback read in
-        // `FeralConfig::from_env`.
-        np.bk.pivot_threshold = cfg.pivtol;
-        // Cascade-break (FERAL issue #55 Phase B, commit 7554a78):
-        // `NumericParams::default()` now arms CB with `ratio = 0.5,
-        // eps = 1e-10` and bounds delayed-pivot catchment via a
-        // symbolic-time delay budget. Pounce no longer disables CB by
-        // default — the tri-state `cfg.cascade_break` only intervenes
-        // when the caller explicitly set the option:
-        //   None        — leave `np` alone (inherit FERAL default = on)
-        //   Some(true)  — explicit re-arm (matches the default; no-op
-        //                 in behaviour, but records caller intent)
-        //   Some(false) — explicit disarm (re-enables FERAL's
-        //                 `DelayBudgetExceeded` path on non-root
-        //                 cascade victims; only meaningful for
-        //                 reproducing pre-Phase-B behaviour)
-        match cfg.cascade_break {
-            None => {}
-            Some(true) => {
-                np.cascade_break_ratio = Some(0.5);
-                np.cascade_break_eps = Some(1e-10);
-            }
-            Some(false) => {
-                np.cascade_break_ratio = None;
-                np.cascade_break_eps = None;
-            }
-        }
-        let mut solver = Solver::with_params(np, SupernodeParams::default());
-        // Internal-parallelism toggle. An explicit `cfg.parallel` is the
-        // primary, per-backend lever (no global state); when unset, fall
-        // back to the legacy process-wide `FERAL_PARALLEL` env var for
-        // backward compatibility.
-        match cfg.parallel {
-            Some(p) => solver = solver.with_parallel(p),
-            None => {
-                if matches!(
-                    std::env::var("FERAL_PARALLEL").as_deref(),
-                    Ok("0") | Ok("false") | Ok("off")
-                ) {
-                    solver = solver.with_parallel(false);
-                }
-            }
-        }
-        if cfg.fma {
-            solver = solver.with_fma(true);
-        }
-        // Fill-reducing ordering. `OrderingMethod::Auto` is pounce's
-        // default — it picks a concrete method per-matrix from cheap
-        // pattern features. Override via the `feral_ordering`
-        // OptionsList option or `POUNCE_FERAL_ORDERING` env var.
-        // `.clone()` since FERAL 0.13's `OrderingMethod` is no longer
-        // `Copy` (the `External(Vec<usize>)` variant carries a heap
-        // permutation); the owned copy is moved into `self.ordering`
-        // below. Mirrors the `cfg.scaling.clone()` handling.
-        solver = solver.with_ordering(cfg.ordering.clone());
-        // Diagonal scaling. `ScalingStrategy::Auto` is pounce's default
-        // — FERAL's adaptive shape-based router. Override via the
-        // `feral_scaling` OptionsList option or `POUNCE_FERAL_SCALING`
-        // env var (e.g. `mc64` recovers exact inertia on some
-        // ill-conditioned KKTs where `Auto` mis-pivots — feral#65).
-        solver = solver.with_scaling(cfg.scaling.clone());
+        let solver = configure_solver(&cfg);
         Self {
             solver,
             initialized: false,

--- a/crates/pounce-feral/src/schur.rs
+++ b/crates/pounce-feral/src/schur.rs
@@ -1,0 +1,725 @@
+//! Block-triangular / Schur KKT linear solver (pounce#180 item 2, Phase 1).
+//!
+//! Given a symmetric-indefinite KKT matrix and a caller-supplied partition of
+//! its indices into an eliminated "F" block and a small Schur "S" block, this
+//! solves the system by the Schur-complement method:
+//!
+//! ```text
+//!   M = [ A_FF  A_FS ]   (symmetric; A_SF = A_FSᵀ)
+//!       [ A_SF  A_SS ]
+//!
+//!   S = A_SS − A_SF · A_FF⁻¹ · A_FS          (dense, n_s × n_s)
+//! ```
+//!
+//! and recovers the full-system inertia **a priori via Sylvester's law of
+//! inertia** (Haynsworth additivity): `inertia(M) = inertia(A_FF) + inertia(S)`.
+//! Only the two diagonal blocks are factorized — `A_FF` sparsely (feral
+//! multifrontal) and the small `S` densely. This is the reduced-space /
+//! variable-aggregation path of Parker, Garcia & Bent (arXiv:2602.17968).
+//!
+//! **Design (validated by the Phase-0 spike, `dev-notes/research/`):** we form
+//! `S` ourselves via `n_s` back-solves against a *standalone* `A_FF`
+//! factorization, using only feral's proven `Solver::factor` / `solve`. This
+//! needs no un-exported partial back-solve, so it carries no FERAL dependency
+//! beyond the stable factor/solve API. Correctness and Sylvester inertia were
+//! confirmed to machine precision (incl. an indefinite `A_FF`).
+//!
+//! **Cost / the dense trap:** every `n_s`-dependent cost is confined to the
+//! (intended-small) Schur block — dense `S` is `O(n_s²)` storage / `O(n_s³)`
+//! factor, forming it costs `n_s` back-solves plus an `O(n_f · n_s)` transient
+//! `W = A_FF⁻¹A_FS`. The method beats a monolithic factorization only when
+//! `n_s ≪ n_f`; the caller (Phase 2 `SchurAugSystemSolver`) is responsible for
+//! gating on that and falling back to the standard solver otherwise.
+
+use feral::{CscMatrix, FactorStatus, Solver};
+use pounce_common::types::{Index, Number};
+use pounce_linsol::ESymSolverStatus;
+
+use crate::{configure_solver, FeralConfig};
+
+/// Schur-complement KKT solver over a caller-supplied F/S partition.
+///
+/// Lifecycle mirrors [`crate::FeralSolverInterface`]:
+/// [`Self::initialize_structure`] pins the pattern + partition,
+/// [`Self::values_array_mut`] receives the KKT nonzeros (same order as the
+/// triplet passed to `initialize_structure`), [`Self::factor`] factorizes both
+/// blocks and combines inertia, and [`Self::backsolve`] applies the block
+/// back-substitution in place.
+pub struct FeralSchurSolver {
+    cfg: FeralConfig,
+
+    dim: usize,
+    n_f: usize,
+    n_s: usize,
+
+    /// F-local index → KKT index.
+    f_kkt: Vec<usize>,
+    /// S-local index → KKT index.
+    s_kkt: Vec<usize>,
+
+    // --- A_FF block: f-local lower-triangle triplet; values refilled per factor.
+    ff_rows: Vec<usize>,
+    ff_cols: Vec<usize>,
+    ff_src: Vec<usize>, // input-nnz position feeding each A_FF value
+    ff_vals: Vec<Number>,
+
+    // --- coupling A_FS[f_local, s_local]; values refilled per factor.
+    coup_f: Vec<usize>,
+    coup_s: Vec<usize>,
+    coup_src: Vec<usize>,
+
+    // --- A_SS: s-local lower-triangle triplet.
+    ss_rows: Vec<usize>,
+    ss_cols: Vec<usize>,
+    ss_src: Vec<usize>,
+
+    /// Caller-written KKT nonzeros, indexed as the `initialize_structure` triplet.
+    values: Vec<Number>,
+
+    ff_solver: Solver,
+    s_solver: Solver,
+    /// Cached block matrices for iterative-refinement solves (feral needs the
+    /// original matrix to compute residuals). Kept when `cfg.refine`.
+    ff_matrix: Option<CscMatrix>,
+    s_matrix: Option<CscMatrix>,
+
+    // Scratch reused across factors.
+    afs: Vec<Number>,  // n_f × n_s column-major (also holds W = A_FF⁻¹A_FS)
+    astw: Vec<Number>, // n_s × n_s column-major (A_SFᵀ W), then S base
+    ass: Vec<Number>,  // n_s × n_s column-major (dense A_SS, lower filled)
+
+    negevals: Index,
+    have_factor: bool,
+    initialized: bool,
+    last_status: ESymSolverStatus,
+}
+
+impl FeralSchurSolver {
+    pub fn new(cfg: FeralConfig) -> Self {
+        let ff_solver = configure_solver(&cfg);
+        let s_solver = configure_solver(&cfg);
+        Self {
+            cfg,
+            dim: 0,
+            n_f: 0,
+            n_s: 0,
+            f_kkt: Vec::new(),
+            s_kkt: Vec::new(),
+            ff_rows: Vec::new(),
+            ff_cols: Vec::new(),
+            ff_src: Vec::new(),
+            ff_vals: Vec::new(),
+            coup_f: Vec::new(),
+            coup_s: Vec::new(),
+            coup_src: Vec::new(),
+            ss_rows: Vec::new(),
+            ss_cols: Vec::new(),
+            ss_src: Vec::new(),
+            values: Vec::new(),
+            ff_solver,
+            s_solver,
+            ff_matrix: None,
+            s_matrix: None,
+            afs: Vec::new(),
+            astw: Vec::new(),
+            ass: Vec::new(),
+            negevals: 0,
+            have_factor: false,
+            initialized: false,
+            last_status: ESymSolverStatus::Success,
+        }
+    }
+
+    /// Pin the KKT sparsity pattern and the F/S partition.
+    ///
+    /// `ia` / `ja` are the **1-based lower-triangle** triplet of the full KKT
+    /// (the exact layout `StdAugSystemSolver` assembles). `schur_indices` are
+    /// the **0-based KKT indices** (`0..dim`) forming the Schur block `S`; they
+    /// need not be contiguous. Returns [`ESymSolverStatus::FatalError`] on a
+    /// malformed partition (out-of-range / duplicate index, empty `S`, or
+    /// `S == everything` — in which case the caller should use the standard
+    /// full-space solver instead).
+    pub fn initialize_structure(
+        &mut self,
+        dim: Index,
+        ia: &[Index],
+        ja: &[Index],
+        schur_indices: &[usize],
+    ) -> ESymSolverStatus {
+        let dim = dim as usize;
+        if ia.len() != ja.len() {
+            return self.fail();
+        }
+        // Validate the Schur set is a strict, non-empty subset of 0..dim.
+        let mut is_schur = vec![false; dim];
+        for &s in schur_indices {
+            if s >= dim || is_schur[s] {
+                return self.fail(); // out of range or duplicate
+            }
+            is_schur[s] = true;
+        }
+        let n_s = schur_indices.len();
+        if n_s == 0 || n_s == dim {
+            return self.fail();
+        }
+        let n_f = dim - n_s;
+
+        // Build F/S local↔KKT maps. F-local and S-local both follow increasing
+        // KKT order, which keeps a lower-triangle input entry lower-triangle in
+        // each block's local coordinates.
+        let mut f_local = vec![usize::MAX; dim];
+        let mut s_local = vec![usize::MAX; dim];
+        let mut f_kkt = Vec::with_capacity(n_f);
+        let mut s_kkt = Vec::with_capacity(n_s);
+        for (i, &sch) in is_schur.iter().enumerate() {
+            if sch {
+                s_local[i] = s_kkt.len();
+                s_kkt.push(i);
+            } else {
+                f_local[i] = f_kkt.len();
+                f_kkt.push(i);
+            }
+        }
+
+        // Split the triplet into A_FF / coupling / A_SS, recording for each the
+        // input-nnz position so `factor` can scatter the value buffer.
+        let (mut ff_rows, mut ff_cols, mut ff_src) = (Vec::new(), Vec::new(), Vec::new());
+        let (mut coup_f, mut coup_s, mut coup_src) = (Vec::new(), Vec::new(), Vec::new());
+        let (mut ss_rows, mut ss_cols, mut ss_src) = (Vec::new(), Vec::new(), Vec::new());
+        for k in 0..ia.len() {
+            let i = (ia[k] - 1) as usize;
+            let j = (ja[k] - 1) as usize;
+            if i >= dim || j >= dim {
+                return self.fail();
+            }
+            match (is_schur[i], is_schur[j]) {
+                (false, false) => {
+                    ff_rows.push(f_local[i]);
+                    ff_cols.push(f_local[j]);
+                    ff_src.push(k);
+                }
+                (true, true) => {
+                    ss_rows.push(s_local[i]);
+                    ss_cols.push(s_local[j]);
+                    ss_src.push(k);
+                }
+                // Mixed: one endpoint in F, the other in S. Store as
+                // A_FS[f_local, s_local] regardless of which was row/col
+                // (M is symmetric, input is lower-triangle so only one of
+                // (i,j)/(j,i) is present).
+                (false, true) => {
+                    coup_f.push(f_local[i]);
+                    coup_s.push(s_local[j]);
+                    coup_src.push(k);
+                }
+                (true, false) => {
+                    coup_f.push(f_local[j]);
+                    coup_s.push(s_local[i]);
+                    coup_src.push(k);
+                }
+            }
+        }
+
+        self.dim = dim;
+        self.n_f = n_f;
+        self.n_s = n_s;
+        self.f_kkt = f_kkt;
+        self.s_kkt = s_kkt;
+        self.ff_vals = vec![0.0; ff_src.len()];
+        self.ff_rows = ff_rows;
+        self.ff_cols = ff_cols;
+        self.ff_src = ff_src;
+        self.coup_f = coup_f;
+        self.coup_s = coup_s;
+        self.coup_src = coup_src;
+        self.ss_rows = ss_rows;
+        self.ss_cols = ss_cols;
+        self.ss_src = ss_src;
+        self.values = vec![0.0; ia.len()];
+        self.afs = vec![0.0; n_f * n_s];
+        self.astw = vec![0.0; n_s * n_s];
+        self.ass = vec![0.0; n_s * n_s];
+        self.ff_matrix = None;
+        self.s_matrix = None;
+        self.have_factor = false;
+        self.initialized = true;
+        self.last_status = ESymSolverStatus::Success;
+        ESymSolverStatus::Success
+    }
+
+    /// Mutable view of the KKT value array (same order as the
+    /// `initialize_structure` triplet). The caller writes nonzeros here before
+    /// each [`Self::factor`].
+    pub fn values_array_mut(&mut self) -> &mut [Number] {
+        &mut self.values
+    }
+
+    /// Factor both blocks and combine inertia. `check_neg_evals` verifies the
+    /// combined negative-eigenvalue count equals `num_neg_evals` (the IPM's
+    /// expected `m`); on mismatch the status is [`ESymSolverStatus::WrongInertia`].
+    /// A singular `A_FF` or `S` (zero pivot) yields [`ESymSolverStatus::Singular`]
+    /// so the IPM's `perturb_for_singular` path fires, exactly as the monolithic
+    /// backend does.
+    pub fn factor(&mut self, check_neg_evals: bool, num_neg_evals: Index) -> ESymSolverStatus {
+        if !self.initialized {
+            return self.set_status(ESymSolverStatus::FatalError);
+        }
+        // 1. Scatter values into A_FF and factor it (sparse).
+        for p in 0..self.ff_src.len() {
+            self.ff_vals[p] = self.values[self.ff_src[p]];
+        }
+        let ff_mat =
+            match CscMatrix::from_triplets(self.n_f, &self.ff_rows, &self.ff_cols, &self.ff_vals) {
+                Ok(m) => m,
+                Err(_) => return self.set_status(ESymSolverStatus::FatalError),
+            };
+        let (neg_ff, singular_ff) = match self.ff_solver.factor(&ff_mat, None) {
+            FactorStatus::Success => match self.ff_solver.inertia() {
+                Some(i) => (i.negative, i.zero > 0),
+                None => (self.ff_solver.num_negative_eigenvalues(), false),
+            },
+            FactorStatus::Singular => return self.set_status(ESymSolverStatus::Singular),
+            FactorStatus::WrongInertia { .. } | FactorStatus::FatalError(_) => {
+                return self.set_status(ESymSolverStatus::FatalError)
+            }
+        };
+        self.ff_matrix = Some(ff_mat);
+        if singular_ff || self.pivot_below_floor(&self.ff_solver) {
+            return self.set_status(ESymSolverStatus::Singular);
+        }
+
+        // 2. Form S = A_SS − A_SFᵀ·(A_FF⁻¹·A_FS). One dense back-solve batch.
+        for v in self.afs.iter_mut() {
+            *v = 0.0;
+        }
+        for p in 0..self.coup_src.len() {
+            self.afs[self.coup_f[p] + self.coup_s[p] * self.n_f] += self.values[self.coup_src[p]];
+        }
+        // W = A_FF⁻¹ A_FS (n_f × n_s — the transient, gated on small n_s).
+        // Refine against the original A_FF when `cfg.refine`, matching the
+        // monolithic backend — S's accuracy hinges on W's.
+        let w = {
+            let r = match (self.cfg.refine, self.ff_matrix.as_ref()) {
+                (true, Some(m)) => self.ff_solver.solve_many_refined(m, &self.afs, self.n_s),
+                _ => self.ff_solver.solve_many(&self.afs, self.n_s),
+            };
+            match r {
+                Ok(w) => w,
+                Err(_) => return self.set_status(ESymSolverStatus::FatalError),
+            }
+        };
+        // astw[i,j] = Σ_f A_FS[f,i] · W[f,j]  (= (A_SFᵀ W)[i,j], symmetric).
+        for v in self.astw.iter_mut() {
+            *v = 0.0;
+        }
+        for p in 0..self.coup_src.len() {
+            let s = self.coup_s[p];
+            let f = self.coup_f[p];
+            let val = self.values[self.coup_src[p]];
+            for j in 0..self.n_s {
+                self.astw[s + j * self.n_s] += val * w[f + j * self.n_f];
+            }
+        }
+        // Dense A_SS (lower-triangle input).
+        for v in self.ass.iter_mut() {
+            *v = 0.0;
+        }
+        for p in 0..self.ss_src.len() {
+            self.ass[self.ss_rows[p] + self.ss_cols[p] * self.n_s] += self.values[self.ss_src[p]];
+        }
+        // S lower-triangle = A_SS − astw.
+        let n_s = self.n_s;
+        let (mut sr, mut sc, mut sv) = (Vec::new(), Vec::new(), Vec::new());
+        for j in 0..n_s {
+            for i in j..n_s {
+                let val = self.ass[i + j * n_s] - self.astw[i + j * n_s];
+                sr.push(i);
+                sc.push(j);
+                sv.push(val);
+            }
+        }
+        let s_mat = match CscMatrix::from_triplets(n_s, &sr, &sc, &sv) {
+            Ok(m) => m,
+            Err(_) => return self.set_status(ESymSolverStatus::FatalError),
+        };
+        let (neg_s, singular_s) = match self.s_solver.factor(&s_mat, None) {
+            FactorStatus::Success => match self.s_solver.inertia() {
+                Some(i) => (i.negative, i.zero > 0),
+                None => (self.s_solver.num_negative_eigenvalues(), false),
+            },
+            FactorStatus::Singular => return self.set_status(ESymSolverStatus::Singular),
+            FactorStatus::WrongInertia { .. } | FactorStatus::FatalError(_) => {
+                return self.set_status(ESymSolverStatus::FatalError)
+            }
+        };
+        self.s_matrix = Some(s_mat);
+        if singular_s || self.pivot_below_floor(&self.s_solver) {
+            return self.set_status(ESymSolverStatus::Singular);
+        }
+
+        // 3. Combine inertia via Sylvester's law.
+        self.negevals = (neg_ff + neg_s) as Index;
+        self.have_factor = true;
+        if check_neg_evals && self.negevals != num_neg_evals {
+            // Factor is valid and usable; the caller's perturbation loop will
+            // bump δ and re-factor. Mirror the monolithic backend's contract.
+            return self.set_status(ESymSolverStatus::WrongInertia);
+        }
+        self.set_status(ESymSolverStatus::Success)
+    }
+
+    /// Block back-substitution, in place, for `nrhs` right-hand sides packed
+    /// column-major (`dim` per column, in KKT/original index order). Requires a
+    /// prior successful [`Self::factor`].
+    pub fn backsolve(&self, nrhs: Index, rhs: &mut [Number]) -> ESymSolverStatus {
+        let nrhs = nrhs as usize;
+        if !self.have_factor || rhs.len() != self.dim * nrhs {
+            return ESymSolverStatus::FatalError;
+        }
+        let (n_f, n_s) = (self.n_f, self.n_s);
+        let mut b_f = vec![0.0; n_f];
+        let mut b_s = vec![0.0; n_s];
+        for c in 0..nrhs {
+            let col = &mut rhs[c * self.dim..(c + 1) * self.dim];
+            for (fl, &k) in self.f_kkt.iter().enumerate() {
+                b_f[fl] = col[k];
+            }
+            for (sl, &k) in self.s_kkt.iter().enumerate() {
+                b_s[sl] = col[k];
+            }
+            // u = A_FF⁻¹ b_F
+            let Some(u) = self.ff_solve(&b_f) else {
+                return ESymSolverStatus::FatalError;
+            };
+            // r_S = b_S − A_SF u
+            let mut r_s = b_s.clone();
+            for p in 0..self.coup_src.len() {
+                r_s[self.coup_s[p]] -= self.values[self.coup_src[p]] * u[self.coup_f[p]];
+            }
+            // x_S = S⁻¹ r_S
+            let Some(x_s) = self.s_solve(&r_s) else {
+                return ESymSolverStatus::FatalError;
+            };
+            // x_F = A_FF⁻¹ (b_F − A_FS x_S)
+            let mut rhs_f = b_f.clone();
+            for p in 0..self.coup_src.len() {
+                rhs_f[self.coup_f[p]] -= self.values[self.coup_src[p]] * x_s[self.coup_s[p]];
+            }
+            let Some(x_f) = self.ff_solve(&rhs_f) else {
+                return ESymSolverStatus::FatalError;
+            };
+            // Scatter the solution back into the column in KKT order.
+            for (fl, &k) in self.f_kkt.iter().enumerate() {
+                col[k] = x_f[fl];
+            }
+            for (sl, &k) in self.s_kkt.iter().enumerate() {
+                col[k] = x_s[sl];
+            }
+        }
+        ESymSolverStatus::Success
+    }
+
+    pub fn number_of_neg_evals(&self) -> Index {
+        self.negevals
+    }
+    pub fn provides_inertia(&self) -> bool {
+        true
+    }
+    pub fn system_dim(&self) -> Index {
+        self.dim as Index
+    }
+    pub fn schur_dim(&self) -> Index {
+        self.n_s as Index
+    }
+    pub fn last_solve_status(&self) -> ESymSolverStatus {
+        self.last_status
+    }
+    /// Feral delegates all recovery to the IPM's δ-perturbation loop (there is
+    /// no higher pivot-quality mode), matching [`crate::FeralSolverInterface`].
+    pub fn increase_quality(&mut self) -> bool {
+        false
+    }
+
+    /// Single-RHS `A_FF⁻¹` solve, iteratively refined against the original
+    /// `A_FF` when `cfg.refine` (matching the monolithic backend's default).
+    fn ff_solve(&self, rhs: &[Number]) -> Option<Vec<Number>> {
+        match (self.cfg.refine, self.ff_matrix.as_ref()) {
+            (true, Some(m)) => self.ff_solver.solve_refined(m, rhs),
+            _ => self.ff_solver.solve(rhs),
+        }
+        .ok()
+    }
+    /// Single-RHS `S⁻¹` solve, refined against the dense `S` when `cfg.refine`.
+    fn s_solve(&self, rhs: &[Number]) -> Option<Vec<Number>> {
+        match (self.cfg.refine, self.s_matrix.as_ref()) {
+            (true, Some(m)) => self.s_solver.solve_refined(m, rhs),
+            _ => self.s_solver.solve(rhs),
+        }
+        .ok()
+    }
+
+    fn pivot_below_floor(&self, solver: &Solver) -> bool {
+        // MA57 CNTL(2) analog — see `FeralSolverInterface::factor`.
+        if self.cfg.singular_pivot_floor > 0.0 {
+            if let Some(min_piv) = solver.min_pivot_magnitude() {
+                return min_piv < self.cfg.singular_pivot_floor;
+            }
+        }
+        false
+    }
+
+    fn fail(&mut self) -> ESymSolverStatus {
+        self.initialized = false;
+        self.last_status = ESymSolverStatus::FatalError;
+        ESymSolverStatus::FatalError
+    }
+    fn set_status(&mut self, s: ESymSolverStatus) -> ESymSolverStatus {
+        self.last_status = s;
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FeralSolverInterface;
+    use pounce_linsol::SparseSymLinearSolverInterface;
+
+    /// Build a symmetric-indefinite KKT test matrix as a 1-based lower-triangle
+    /// triplet. F = `0..n_f` (tridiagonal, `f_indef` flips the sign of the
+    /// second half → indefinite eliminated block); S = `n_f..n_f+n_s` coupled
+    /// sparsely to F; A_SS negative diagonal. Returns `(dim, ia, ja, vals)`.
+    fn kkt(
+        n_f: usize,
+        n_s: usize,
+        deg: usize,
+        f_indef: bool,
+    ) -> (Index, Vec<Index>, Vec<Index>, Vec<Number>) {
+        let (mut ia, mut ja, mut v) = (Vec::new(), Vec::new(), Vec::new());
+        let push = |i: usize,
+                    j: usize,
+                    x: Number,
+                    ia: &mut Vec<Index>,
+                    ja: &mut Vec<Index>,
+                    v: &mut Vec<Number>| {
+            ia.push((i + 1) as Index);
+            ja.push((j + 1) as Index);
+            v.push(x);
+        };
+        for i in 0..n_f {
+            let d = if f_indef && i >= n_f / 2 { -4.0 } else { 4.0 };
+            push(i, i, d, &mut ia, &mut ja, &mut v);
+            if i > 0 {
+                push(i, i - 1, -1.0, &mut ia, &mut ja, &mut v);
+            }
+        }
+        for s in 0..n_s {
+            for k in 0..deg {
+                let f = ((s * 7 + k * 101 + 3) * 2_654_435_761usize) % n_f.max(1);
+                // lower-triangle: row = n_f+s (larger index) , col = f
+                push(n_f + s, f, 0.5 + 0.1 * (k as f64), &mut ia, &mut ja, &mut v);
+            }
+            push(n_f + s, n_f + s, -1.0, &mut ia, &mut ja, &mut v);
+        }
+        ((n_f + n_s) as Index, ia, ja, v)
+    }
+
+    /// Oracle: solve the same KKT monolithically through `FeralSolverInterface`.
+    fn oracle_solve(
+        dim: Index,
+        ia: &[Index],
+        ja: &[Index],
+        vals: &[Number],
+        rhs: &[Number],
+    ) -> (Vec<Number>, Index) {
+        let mut s = FeralSolverInterface::with_config(FeralConfig::default());
+        assert_eq!(
+            s.initialize_structure(dim, ia.len() as Index, ia, ja),
+            ESymSolverStatus::Success
+        );
+        s.values_array_mut().copy_from_slice(vals);
+        let mut b = rhs.to_vec();
+        let st = s.multi_solve(true, ia, ja, 1, &mut b, false, 0);
+        assert_eq!(st, ESymSolverStatus::Success);
+        (b, s.number_of_neg_evals())
+    }
+
+    fn schur_indices_tail(n_f: usize, n_s: usize) -> Vec<usize> {
+        (n_f..n_f + n_s).collect()
+    }
+
+    fn run_and_check(n_f: usize, n_s: usize, deg: usize, f_indef: bool, schur: &[usize]) {
+        let (dim, ia, ja, vals) = kkt(n_f, n_s, deg, f_indef);
+        let rhs: Vec<Number> = (0..dim as usize)
+            .map(|i| 1.0 + (i % 5) as f64 * 0.25)
+            .collect();
+        let (x_oracle, neg_oracle) = oracle_solve(dim, &ia, &ja, &vals, &rhs);
+
+        let mut solver = FeralSchurSolver::new(FeralConfig::default());
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, schur),
+            ESymSolverStatus::Success
+        );
+        solver.values_array_mut().copy_from_slice(&vals);
+        // Check inertia against the oracle's count.
+        let st = solver.factor(true, neg_oracle);
+        assert_eq!(st, ESymSolverStatus::Success, "factor status");
+        assert_eq!(
+            solver.number_of_neg_evals(),
+            neg_oracle,
+            "Sylvester inertia mismatch"
+        );
+
+        let mut b = rhs.clone();
+        assert_eq!(solver.backsolve(1, &mut b), ESymSolverStatus::Success);
+        let err = b
+            .iter()
+            .zip(&x_oracle)
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0, f64::max);
+        assert!(err < 1e-8, "solution mismatch: {err:e}");
+    }
+
+    #[test]
+    fn spd_ff_tail_partition_matches_oracle() {
+        run_and_check(6, 2, 2, false, &schur_indices_tail(6, 2));
+        run_and_check(200, 8, 4, false, &schur_indices_tail(200, 8));
+    }
+
+    #[test]
+    fn indefinite_ff_matches_oracle_and_sylvester() {
+        // Both A_FF and S carry negative eigenvalues here.
+        run_and_check(50, 4, 3, true, &schur_indices_tail(50, 4));
+        run_and_check(400, 12, 4, true, &schur_indices_tail(400, 12));
+    }
+
+    #[test]
+    fn scattered_non_contiguous_schur_set() {
+        // Interleaved Schur indices (not a tail) must work: the F/S maps are
+        // by KKT order, so a lower-triangle entry stays lower-triangle locally.
+        let (n_f_plus_s, n_s) = (60usize, 6usize);
+        let n_f = n_f_plus_s - n_s;
+        let schur: Vec<usize> = (0..n_s)
+            .map(|k| k * 9 + 4)
+            .filter(|&x| x < n_f_plus_s)
+            .collect();
+        run_and_check(n_f, n_s, 3, true, &schur);
+    }
+
+    #[test]
+    fn multi_rhs_backsolve() {
+        let (dim, ia, ja, vals) = kkt(120, 6, 4, true);
+        let schur = schur_indices_tail(120, 6);
+        let mut solver = FeralSchurSolver::new(FeralConfig::default());
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &schur),
+            ESymSolverStatus::Success
+        );
+        solver.values_array_mut().copy_from_slice(&vals);
+        assert_eq!(solver.factor(false, 0), ESymSolverStatus::Success);
+        // Two independent RHS packed column-major.
+        let n = dim as usize;
+        let mut packed = vec![0.0; 2 * n];
+        for i in 0..n {
+            packed[i] = 1.0 + (i % 3) as f64;
+            packed[n + i] = -0.5 + (i % 7) as f64 * 0.1;
+        }
+        assert_eq!(solver.backsolve(2, &mut packed), ESymSolverStatus::Success);
+        for c in 0..2 {
+            let rhs_c: Vec<Number> = (0..n)
+                .map(|i| {
+                    if c == 0 {
+                        1.0 + (i % 3) as f64
+                    } else {
+                        -0.5 + (i % 7) as f64 * 0.1
+                    }
+                })
+                .collect();
+            let (x_oracle, _) = oracle_solve(dim, &ia, &ja, &vals, &rhs_c);
+            let err = packed[c * n..(c + 1) * n]
+                .iter()
+                .zip(&x_oracle)
+                .map(|(x, y)| (x - y).abs())
+                .fold(0.0, f64::max);
+            assert!(err < 1e-8, "col {c} mismatch: {err:e}");
+        }
+    }
+
+    #[test]
+    fn refactor_with_new_values_reuses_pattern() {
+        let (dim, ia, ja, mut vals) = kkt(80, 5, 3, true);
+        let schur = schur_indices_tail(80, 5);
+        let mut solver = FeralSchurSolver::new(FeralConfig::default());
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &schur),
+            ESymSolverStatus::Success
+        );
+        solver.values_array_mut().copy_from_slice(&vals);
+        assert_eq!(solver.factor(false, 0), ESymSolverStatus::Success);
+        // Perturb the diagonal (same pattern) and re-factor + re-solve.
+        for (k, x) in vals.iter_mut().enumerate() {
+            if ia[k] == ja[k] {
+                *x += 0.3;
+            }
+        }
+        solver.values_array_mut().copy_from_slice(&vals);
+        assert_eq!(solver.factor(false, 0), ESymSolverStatus::Success);
+        let rhs: Vec<Number> = (0..dim as usize).map(|i| 1.0 + (i % 4) as f64).collect();
+        let (x_oracle, _) = oracle_solve(dim, &ia, &ja, &vals, &rhs);
+        let mut b = rhs.clone();
+        assert_eq!(solver.backsolve(1, &mut b), ESymSolverStatus::Success);
+        let err = b
+            .iter()
+            .zip(&x_oracle)
+            .map(|(x, y)| (x - y).abs())
+            .fold(0.0, f64::max);
+        assert!(err < 1e-8, "post-refactor mismatch: {err:e}");
+    }
+
+    #[test]
+    fn wrong_inertia_is_flagged() {
+        let (dim, ia, ja, vals) = kkt(40, 4, 3, true);
+        let schur = schur_indices_tail(40, 4);
+        let mut solver = FeralSchurSolver::new(FeralConfig::default());
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &schur),
+            ESymSolverStatus::Success
+        );
+        solver.values_array_mut().copy_from_slice(&vals);
+        // Demand the wrong number of negatives → WrongInertia (factor still usable).
+        let true_neg = {
+            let (_, n) = oracle_solve(dim, &ia, &ja, &vals, &vec![0.0; dim as usize]);
+            n
+        };
+        let st = solver.factor(true, true_neg + 1);
+        assert_eq!(st, ESymSolverStatus::WrongInertia);
+        assert_eq!(solver.number_of_neg_evals(), true_neg);
+    }
+
+    #[test]
+    fn malformed_partition_is_rejected() {
+        let (dim, ia, ja, _vals) = kkt(10, 2, 2, false);
+        let mut solver = FeralSchurSolver::new(FeralConfig::default());
+        // Empty Schur set.
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &[]),
+            ESymSolverStatus::FatalError
+        );
+        // Out-of-range index.
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &[dim as usize]),
+            ESymSolverStatus::FatalError
+        );
+        // Duplicate index.
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &[1, 1]),
+            ESymSolverStatus::FatalError
+        );
+        // Whole system as Schur (F empty) → use Std instead.
+        let all: Vec<usize> = (0..dim as usize).collect();
+        assert_eq!(
+            solver.initialize_structure(dim, &ia, &ja, &all),
+            ESymSolverStatus::FatalError
+        );
+    }
+}

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -70,6 +70,11 @@ pub struct PyProblem {
     /// installs `OrderingMethod::External` on the FERAL backend. `None`
     /// leaves the `feral_ordering` option / env default in charge.
     external_ordering: Option<Vec<usize>>,
+    /// Caller-supplied Schur KKT partition installed via
+    /// `set_kkt_schur_block` (pounce#180 item 2). Forwarded to
+    /// `IpoptApplication::set_kkt_schur_block` in `prepare`. `None` uses the
+    /// standard full-space solver.
+    kkt_schur_block: Option<Vec<usize>>,
 }
 
 /// Per-problem user scaling vector, mirroring `SetIpoptProblemScaling`
@@ -144,6 +149,7 @@ impl PyProblem {
             last_working_set: None,
             user_scaling: None,
             external_ordering: None,
+            kkt_schur_block: None,
         })
     }
 
@@ -481,6 +487,57 @@ impl PyProblem {
         })
     }
 
+    /// Install a block-triangular / Schur KKT partition (pounce#180 item 2).
+    /// Lets a structure-aware presolve hand pounce the reducible block of the
+    /// KKT system (e.g. from a reduced-space / variable-aggregation analysis,
+    /// Parker, Garcia & Bent, arXiv:2602.17968): that block is
+    /// Schur-complemented out and only the two diagonal blocks are factorized,
+    /// with inertia recovered a priori via Sylvester's law.
+    ///
+    /// `indices` are **KKT-space indices** (`0..dim`, where
+    /// `dim = n + n_slack + n_eq + n_ineq` in the solver's internal
+    /// `x, slack, eq-dual, ineq-dual` block order) given as a sequence or numpy
+    /// integer array. The Schur block should be a **small** fraction of the
+    /// system (the method wins only when it is much smaller than the eliminated
+    /// block); when the partition is unsuitable (too large, malformed, or the
+    /// backend errors) the solver falls back to the standard full-space path
+    /// transparently, so a stray hook never breaks a solve. Honored only on the
+    /// default feral + exact-Hessian path. Negative indices are rejected.
+    ///
+    /// Persistent config: call once before `solve()`; drop with
+    /// `clear_kkt_schur_block()`.
+    fn set_kkt_schur_block(&mut self, indices: Py<PyAny>) -> PyResult<()> {
+        let idx = extract_index_vec_inferred(&indices, "kkt_schur_block")?;
+        let mut out = Vec::with_capacity(idx.len());
+        for v in idx {
+            if v < 0 {
+                return Err(PyValueError::new_err(
+                    "kkt_schur_block: indices must be non-negative (0-based KKT indices)",
+                ));
+            }
+            out.push(v as usize);
+        }
+        self.kkt_schur_block = Some(out);
+        Ok(())
+    }
+
+    /// Drop any installed Schur KKT partition, restoring the standard
+    /// full-space solver.
+    fn clear_kkt_schur_block(&mut self) {
+        self.kkt_schur_block = None;
+    }
+
+    /// The currently-installed Schur KKT partition as a numpy int64 array, or
+    /// `None` if none is set.
+    fn get_kkt_schur_block<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray1<i64>>> {
+        self.kkt_schur_block.as_ref().map(|p| {
+            p.iter()
+                .map(|&v| v as i64)
+                .collect::<Vec<_>>()
+                .into_pyarray_bound(py)
+        })
+    }
+
     /// Solve, then run a parametric sensitivity step at the converged
     /// iterate. Returns `(x, info_dict)`; `info_dict` includes the
     /// extra keys `dx`, `dx_full`, `reduced_hessian`,
@@ -735,6 +792,13 @@ impl PyProblem {
         // dimension than the permutation is sized for.
         if let Some(perm) = &self.external_ordering {
             app.set_external_ordering(perm.clone());
+        }
+        // Block-triangular / Schur KKT partition (pounce#180 item 2). The
+        // application routes the KKT solve through a SchurAugSystemSolver over
+        // these KKT-space indices, falling back to the standard solver when the
+        // partition is unsuitable.
+        if let Some(indices) = &self.kkt_schur_block {
+            app.set_kkt_schur_block(indices.clone());
         }
 
         let feral_cfg = pounce_algorithm::application::feral_config_from_options(app.options());

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -64,6 +64,12 @@ pub struct PyProblem {
     /// `TNLP::get_scaling_parameters`. Only consulted by the IPM when
     /// `nlp_scaling_method=user-scaling`.
     user_scaling: Option<UserScaling>,
+    /// Caller-supplied fill-reducing KKT permutation installed via
+    /// `set_ordering` (pounce#180 item 1). Forwarded to
+    /// `IpoptApplication::set_external_ordering` in `prepare`, which
+    /// installs `OrderingMethod::External` on the FERAL backend. `None`
+    /// leaves the `feral_ordering` option / env default in charge.
+    external_ordering: Option<Vec<usize>>,
 }
 
 /// Per-problem user scaling vector, mirroring `SetIpoptProblemScaling`
@@ -137,6 +143,7 @@ impl PyProblem {
             pending_working_set: None,
             last_working_set: None,
             user_scaling: None,
+            external_ordering: None,
         })
     }
 
@@ -424,6 +431,56 @@ impl PyProblem {
         self.user_scaling = None;
     }
 
+    /// Install a caller-supplied fill-reducing permutation for the KKT
+    /// linear solver (pounce#180 item 1 / FERAL#107). Lets a structure-
+    /// aware presolve hand pounce a block-triangular / Schur ordering the
+    /// generic AMD/METIS pass cannot see (Parker, Garcia & Bent,
+    /// arXiv:2602.17968).
+    ///
+    /// `perm` is a **0-based, new-to-old permutation** (`perm[k]` is the
+    /// original index that becomes index `k`) given as a sequence or
+    /// numpy integer array. Its length must equal the **augmented KKT
+    /// system dimension** (variables + slacks + constraint duals), *not*
+    /// the problem's `n`; supplying the wrong length or a non-bijection
+    /// makes the first factorization fail with a solver error rather than
+    /// return a wrong answer — the ordering only changes fill/time, never
+    /// the solution. Only the default FERAL backend honors it.
+    ///
+    /// Persistent config: call once before `solve()`; it applies to every
+    /// subsequent solve until `clear_ordering()`. Negative indices are
+    /// rejected here; the bijection check happens in FERAL.
+    fn set_ordering(&mut self, perm: Py<PyAny>) -> PyResult<()> {
+        let idx = extract_index_vec_inferred(&perm, "ordering")?;
+        let mut out = Vec::with_capacity(idx.len());
+        for v in idx {
+            if v < 0 {
+                return Err(PyValueError::new_err(
+                    "ordering: permutation indices must be non-negative (0-based)",
+                ));
+            }
+            out.push(v as usize);
+        }
+        self.external_ordering = Some(out);
+        Ok(())
+    }
+
+    /// Drop any installed external KKT ordering, restoring the
+    /// `feral_ordering` option / `POUNCE_FERAL_ORDERING` default.
+    fn clear_ordering(&mut self) {
+        self.external_ordering = None;
+    }
+
+    /// The currently-installed external KKT permutation as a numpy int64
+    /// array, or `None` if none is set.
+    fn get_ordering<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray1<i64>>> {
+        self.external_ordering.as_ref().map(|p| {
+            p.iter()
+                .map(|&v| v as i64)
+                .collect::<Vec<_>>()
+                .into_pyarray_bound(py)
+        })
+    }
+
     /// Solve, then run a parametric sensitivity step at the converged
     /// iterate. Returns `(x, info_dict)`; `info_dict` includes the
     /// extra keys `dx`, `dx_full`, `reduced_hessian`,
@@ -670,6 +727,15 @@ impl PyProblem {
         }
         app.initialize()
             .map_err(|e| PyRuntimeError::new_err(format!("initialize: {e}")))?;
+
+        // Caller-supplied KKT ordering (pounce#180 item 1). Installed on
+        // the main-solve FERAL backend; the restoration factory built
+        // below intentionally keeps its default ordering, since the
+        // restoration KKT has extra p/n variables and a different
+        // dimension than the permutation is sized for.
+        if let Some(perm) = &self.external_ordering {
+            app.set_external_ordering(perm.clone());
+        }
 
         let feral_cfg = pounce_algorithm::application::feral_config_from_options(app.options());
         let bff_mint = move || -> InnerBackendFactoryFactory {

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -337,6 +337,21 @@ impl PyProblem {
             None => py.None(),
         };
         info.set_item("working_set", ws_obj)?;
+        // Per-subsystem wall-clock breakdown (seconds) of this solve
+        // (pounce#180 item 3). `info["timing"]` is a dict keyed by
+        // subsystem (`overall_alg`, the linear-algebra split, and the
+        // per-callback objective/gradient/constraint/Jacobian/Hessian
+        // eval split); `info["wall_time"]` mirrors the overall total for
+        // convenience. Lets a reduced-space / variable-aggregation caller
+        // attribute runtime (e.g. densified-Hessian eval cost) directly
+        // instead of inferring it.
+        let timing = app.timing_stats();
+        let timing_dict = PyDict::new_bound(py);
+        for (label, secs) in timing.wall_time_breakdown() {
+            timing_dict.set_item(label, secs)?;
+        }
+        info.set_item("wall_time", timing.overall_alg.total_wallclock_time())?;
+        info.set_item("timing", timing_dict)?;
         let x_out = bridge.borrow().state.final_x.clone().into_pyarray_bound(py);
         Ok((x_out, info))
     }

--- a/dev-notes/research/issue-180-item2-schur-kkt-scope.md
+++ b/dev-notes/research/issue-180-item2-schur-kkt-scope.md
@@ -211,8 +211,7 @@ Implications:
   HS14 uses the dual-block Schur split end-to-end (verified *not* falling back,
   7 iters → optimum) + oversized-block fallback; Python convex-QP parity vs the
   full-space solve, round-trip, oversized fallback, negative-index reject.
-- **Phase 3 — validation + perf (2–4 days):** corpus correctness/inertia parity,
-  perf study, docs.
+- **Phase 3 — validation + perf: DONE.** See § Phase-3 below.
 - **Total ≈ 2–3 weeks** *if* Phase 0 hits outcome (1). Outcome (2) adds a FERAL
   request + release round-trip (as with item 1). A FERAL F3.3 (multi-supernode
   Schur tail) follow-up may be needed for larger aggregation problems.
@@ -275,6 +274,55 @@ self-formed design as the baseline, revisit native as an optimization.**
 FERAL round-trip** (the previously-largest risk), so the estimate tightens to the
 ~2–3 week Phases 1–3 with the biggest unknown removed. Sylvester inertia — the
 remaining correctness risk — is empirically confirmed (incl. indefinite `A_FF`).
+
+## Phase-3 results (corpus / perf validation)
+
+Harnesses: `crates/pounce-algorithm/tests/schur_corpus.rs` (Rust, in CI) and
+`python/benchmarks/schur_kkt_180.py` (larger sweep, not CI). Corpus: a scalable,
+strictly-convex, box- **and** equality-constrained NLP (diagonal PD Hessian ⇒
+positive-definite primal block; the constraint-dual block is the Schur set — the
+range/null-space split), swept over size `n`, constraint count `m`, and two
+Jacobian shapes (`banded` local coupling, `spread` strided coupling). Active
+bounds force a full ~13–15-iteration barrier trajectory, so the Schur factor +
+resolve + per-iteration inertia check are exercised repeatedly, not once.
+
+**Correctness / inertia parity — PASS, at scale.** The Schur solve reaches the
+*same* optimum as the standard full-space solve in every case:
+
+- Rust CI: `n = 120, 600` — identical objective, identical iteration count
+  (13/13), `max|Δx| = 0`.
+- Python: `banded` + `spread`, `n = 1 000 … 32 000`, `m = 16` — every solve
+  `Solve_Succeeded` both ways, identical iteration counts (15/15), `max|Δx| = 0`,
+  `Δobj = 0`. (Exact agreement, not just within tol — the block backsolve is a
+  reordering of the same system, and both converge to the unique convex optimum.)
+
+**The Schur path is genuinely exercised (not silently falling back).** The
+per-solve factorization time (item-3 `info["timing"]`) has a distinct signature:
+an intentionally-oversized block (gate → fallback) times **equal to** the
+monolithic `Std` path, while the real Schur block times **differently** — e.g.
+`n=800, m=10 spread`: `Std 0.0174 s`, forced-fallback `0.0173 s`, Schur `0.0162 s`.
+A silent fallback would match `Std` exactly; it does not.
+
+**Perf — competitive and linear-scaling, no dramatic win on these synthetics.**
+Schur-vs-`Std` factorization-time ratio ranged **0.74×–1.55×** across shapes and
+sizes; both scale ~linearly in `n` (4× size → ~4–5× factor time — no `n²`
+through the full solve). No large speedup here, and that is *expected*: feral's
+multifrontal factor with AMD already forms the equivalent dense Schur complement
+*internally* when it eliminates a well-orderable bordered/banded KKT, so an
+*explicit* Schur split has little to beat. The paper's up-to-15×-over-MA57/MA86
+requires the specific **block-triangular / NN-surrogate** structures where a
+generic symmetric degree/ND ordering underperforms — reproducing that needs the
+actual aggregation models the `discopt` plugin generates, which are not
+available here.
+
+**Conclusion / value.** Phase 3 establishes the mechanism is **correct, safe, and
+linear-scaling at scale**, and that the gate + transparent fallback behave as
+designed. The feature's value is: (1) letting a structure-aware caller exploit a
+block structure feral's AMD cannot discover (the paper's regime), (2) exact
+a-priori inertia via Sylvester, and (3) the item-1/item-2 hooks that let the
+downstream tool drive it — with pounce providing the validated mechanism. A
+quantified end-to-end speedup on real block-triangular models is the natural
+follow-up once such a model is available through the hooks.
 
 ## Recommendation
 

--- a/dev-notes/research/issue-180-item2-schur-kkt-scope.md
+++ b/dev-notes/research/issue-180-item2-schur-kkt-scope.md
@@ -197,9 +197,20 @@ Implications:
   `FeralSolverInterface` oracle: SPD + indefinite `A_FF`, scattered (non-tail)
   Schur sets, multi-RHS, refactor-same-pattern, `WrongInertia` flagging,
   malformed-partition rejection — all machine-precision solution + exact inertia.
-- **Phase 2 — `SchurAugSystemSolver` + app/Problem API (3–5 days):** trait impl,
-  block-partition hook, `InvalidInput`→`Std` fallback, wire through
-  `PdFullSpaceSolver`, inertia-loop integration.
+- **Phase 2 — `SchurAugSystemSolver` + app/Problem API: DONE.**
+  `crates/pounce-algorithm/src/kkt/schur_aug_system_solver.rs` implements
+  `AugSystemSolver` by wrapping `StdAugSystemSolver` (assembly + fallback) and a
+  `FeralSchurSolver`. Extracted `StdAugSystemSolver::assemble` +
+  triplet/packing accessors for reuse (no duplication). Transparent fallback to
+  the monolithic path on an over-`max_schur_frac` (default 0.5), malformed, or
+  singular-block partition — only `WrongInertia` reaches the δ-perturbation
+  loop (both blocks' diagonals are perturbed, so it converges). Wired through
+  `AlgorithmBuilder::set_kkt_schur` / `build_with_backend` (IPM + feral +
+  exact-Hessian only). API: `IpoptApplication::set_kkt_schur_block` (+ clear /
+  getter) and pyo3 `Problem.set_kkt_schur_block` (+ clear / getter). Tests:
+  HS14 uses the dual-block Schur split end-to-end (verified *not* falling back,
+  7 iters → optimum) + oversized-block fallback; Python convex-QP parity vs the
+  full-space solve, round-trip, oversized fallback, negative-index reject.
 - **Phase 3 — validation + perf (2–4 days):** corpus correctness/inertia parity,
   perf study, docs.
 - **Total ≈ 2–3 weeks** *if* Phase 0 hits outcome (1). Outcome (2) adds a FERAL

--- a/dev-notes/research/issue-180-item2-schur-kkt-scope.md
+++ b/dev-notes/research/issue-180-item2-schur-kkt-scope.md
@@ -1,0 +1,212 @@
+# Issue #180 item 2 — block-triangular / Schur KKT path: scope
+
+> Scoping note for the third and largest part of pounce#180. Items 1 (external
+> ordering passthrough) and 3 (per-solve timing) have shipped on
+> `claude/github-issue-180-4uijx2`. This note scopes item 2 — adopting the
+> Schur-complement / block-triangular KKT solve of Parker, Garcia & Bent
+> (arXiv:2602.17968), driven by a caller-supplied block partition from a
+> reduced-space / variable-aggregation presolve (Naik, Biegler, Bent & Parker,
+> arXiv:2502.13869).
+
+## TL;DR / recommendation
+
+- **FERAL 0.13 already ships the hard linear algebra.** The "F3" feature series
+  gives us `symbolic_factorize_with_schur`, `factorize_multifrontal_with_schur`
+  → `(SparseFactors, Inertia(A_FF), SchurBlock)`, a dense `SchurBlock`
+  factor/solve, and `compute_schur_aware_perm`. So item 2 is mostly
+  **orchestration + plumbing in pounce** wrapping an existing primitive — much
+  like item 1 — **not** a from-scratch dense/sparse Schur build.
+- **It is not pure plumbing, though.** Three real risks gate a production path:
+  (a) inertia must be recovered a priori via Sylvester's law (correctness core);
+  (b) one **open FERAL dependency** — the full-system block backsolve is not
+  demonstrated/exported; (c) a current FERAL **scope limit** (single-supernode
+  Schur tail, F3.2b) that not all aggregation problems will satisfy.
+- **Recommended path:** a ½–1 day **spike** to resolve the backsolve dependency,
+  then a ~2–3 week 3-phase build, contingent on the spike. Do the spike first.
+
+## The method (and how it maps onto FERAL)
+
+The paper: isolate a **nonsingular block-triangular submatrix** of the KKT,
+Schur-complement it out, factor **only the diagonal blocks**, block-backsolve,
+and recover the full-system inertia **a priori via Sylvester's law of inertia**
+(no factorization of the Schur complement's spectrum needed to know it). The
+aggregation presolve hands pounce the block structure (the "LM" nonsingular
+submatrix).
+
+Mapping to FERAL's `factorize_multifrontal_with_schur(matrix, symbolic, params)`
+which returns `(SparseFactors, Inertia, SchurBlock)` and forms
+`S = A_SS − A_SF · A_FF⁻¹ · A_FS`:
+
+- **A_FF (eliminated block)** = the large block-triangular nonsingular submatrix
+  — cheap to factor multifrontally.
+- **`schur_indices` (the Schur tail)** = the small coupling complement left over.
+- FERAL returns the **dense** `S`; pounce factors `S` densely (Bunch-Kaufman via
+  `SchurBlock::solve_with`, which yields *its* inertia) and adds the two inertias.
+
+The paper's reported win (up to 15× over MA57/MA86 on NN-surrogate-constrained
+KKTs) comes from factoring only the diagonal blocks of A_FF and keeping `S`
+small; it holds when the Schur block ≪ the eliminated block.
+
+## What already exists (so we don't rebuild it)
+
+**pounce (verified):**
+- The `AugSystemSolver` trait (`crates/pounce-algorithm/src/kkt/aug_system_solver.rs:73`)
+  is the clean insertion point; `StdAugSystemSolver`
+  (`std_aug_system_solver.rs`) assembles the 4×4 KKT into one lower-triangular
+  1-based triplet, `dim = n_x + n_s + n_c + n_d`.
+- The inertia-correction loop lives in
+  `pd_full_space_solver.rs:866–1085` (`num_neg_evals = rhs.y_c.dim() +
+  rhs.y_d.dim()`, i.e. `m`), driving `PdPerturbationHandler`
+  (`perturbation_handler.rs`) — bumps δ_x/δ_s on `WrongInertia`, δ_c/δ_d on
+  `Singular`, refactor-until-success (no fixed cap; bails to restoration when
+  δ_x > 1e20).
+- FERAL wrapper `FeralSolverInterface` (`crates/pounce-feral/src/lib.rs`) already
+  reads inertia via `solver.inertia()` / `num_negative_eigenvalues()`, splits
+  `zero > 0 → Singular` vs `neg ≠ expected → WrongInertia` (gh#52 / feral#54).
+
+**FERAL 0.13 (verified in the registry source):**
+- `symbolic_factorize_with_schur(matrix, snode_params, schur_indices)`
+  (`symbolic/mod.rs:1308`) → `SymbolicFactorization { is_schur_tail: Some(n_schur), … }`.
+  Forces `preprocess = None`, `amalgamation = Adjacency`; pins the Schur set to
+  perm tail `[n − n_schur, n)`.
+- `factorize_multifrontal_with_schur(...)` (`numeric/factorize.rs:1707`) →
+  `(SparseFactors, Inertia, SchurBlock)`. **Inertia is of A_FF only** (docs
+  `factorize.rs:761–763`).
+- `SchurBlock { dim, data }` (`factorize.rs:764`) with `get`, `symv`, `solve` /
+  `solve_with` (dense Bunch-Kaufman LDLᵀ — gives S's inertia).
+- `compute_schur_aware_perm` (`ordering/schur.rs:46`); `Solver::with_sqd_mode`
+  (symmetric-quasi-definite fast path) as a possible companion lever.
+- **Neither pounce nor any caller wires this yet** (tree grep: no
+  `factorize_multifrontal_with_schur` / `SchurBlock` references in pounce).
+
+**pounce's own Schur code is unrelated** (do not reuse for the NLP inner solve,
+but `pounce-sensitivity/src/schur_driver.rs` is a useful reference for block
+backsolve mechanics): `pounce-qp/src/schur.rs` (active-set QP SMW updates),
+`pounce-sensitivity` (post-optimal sIPOPT), `pounce-convex/src/hsde.rs`
+(cone-solver HSDE). None is a condensed/Schur reduction of the NLP IPM KKT.
+
+## Design — where it slots in
+
+1. **`SchurAugSystemSolver`** (new, `crates/pounce-algorithm/src/kkt/`) — a second
+   `AugSystemSolver` impl behind the existing trait. Assembles the *same* KKT
+   triplet as `Std` (reuse that code), then routes factor+solve through a new
+   pounce-feral Schur path. Selected only when a KKT block partition is
+   installed; otherwise the solver stack is unchanged.
+2. **pounce-feral Schur backend** (new path on/next to `FeralSolverInterface`) —
+   drives `symbolic_factorize_with_schur` + `factorize_multifrontal_with_schur`,
+   caches `(SparseFactors, SchurBlock)`, and implements factor / backsolve /
+   inertia against the same `SparseSymLinearSolverInterface` contract.
+3. **Application / Problem API** — `set_kkt_schur_block(indices)` on
+   `IpoptApplication` and `Problem`, threaded exactly like item 1's
+   `external_ordering` side-channel. `indices` are **KKT-space** (the augmented
+   system's `0..dim`), matching the issue's "hook to supply the (rows, cols) of
+   the reducible block."
+
+## Inertia via Sylvester's law (the correctness core)
+
+- Required: `(n_pos, n_neg) = (n_x + n_s, n_c + n_d)`.
+- Sylvester: `inertia(M) = inertia(A_FF) + inertia(S)`. FERAL gives
+  `inertia(A_FF)`; pounce factors `S` (dense BK) for `inertia(S)`; sum, compare
+  the negative count to `num_neg_evals`, and return `WrongInertia` / `Singular`
+  **exactly as `Std` does** so the existing perturbation loop is untouched.
+- **Refactor cadence:** diagonal perturbations δ change *values* not *pattern*, so
+  the symbolic Schur factor is computed **once** and numeric-refactored per
+  inertia-correction retry (matches FERAL's same-pattern cache); the dense `S`
+  is re-formed + re-factored each retry.
+- **Subtle risks to verify:**
+  - Sylvester requires A_FF factored **without pivots crossing the F/S
+    boundary.** FERAL's per-front `NPIV ≤ NASS − NVSCHUR` stopping rule keeps
+    delayed pivots inside F — good, but must be confirmed under μ→0.
+  - A near-singular A_FF pivot (μ→0) hitting FERAL static pivoting would corrupt
+    the inertia read; pounce must route A_FF zero/tiny pivots to `Singular` the
+    same way the current `zero > 0` path does. Confirm FERAL surfaces A_FF
+    zero-pivots on the Schur path.
+
+## Open dependency — the full-system block backsolve (biggest risk)
+
+FERAL returns the **partial** `SparseFactors` (A_FF eliminated) + dense `S`, but
+does **not** export a combined "solve the full permuted system" helper, and its
+own F3.4 test only solves the `S` subsystem (`factorize.rs:4767–4780`). The full
+solve of `M [x_F; x_S] = [b_F; b_S]` is:
+
+1. `y = A_FF⁻¹ b_F`
+2. `b_S' = b_S − A_SF y`
+3. `x_S = S⁻¹ b_S'`  (dense, `SchurBlock::solve`)
+4. `x_F = A_FF⁻¹ (b_F − A_FS x_S)`
+
+Steps 2 & 4 apply the coupling `A_SF` / `A_FS` — pounce **holds the KKT triplet**,
+so it can apply those directly. The unknown is steps 1 & 4: **does
+`solve_sparse(partial_factors, v)` compute `A_FF⁻¹ v`?** Unverified. Outcomes:
+
+- **(1) It does** → pounce assembles the backsolve from `solve_sparse` +
+  its own coupling apply + `SchurBlock::solve`. Medium effort, no FERAL change.
+- **(2) It doesn't** → companion FERAL request ("F3.5": a partial `A_FF⁻¹` solve
+  or a one-shot `solve_with_schur(factors, schur_block, rhs)`), then a
+  crates.io round-trip — same pattern as item 1.
+- **(3) Ask the FERAL author to add the one-shot solve regardless** (cleanest for
+  reuse across refinement).
+
+**Phase 0 spike resolves (1) vs (2) definitively before committing to the build.**
+
+## FERAL scope limit to design around (F3.2b)
+
+The Schur tail must be a **single root supernode ending at column `n−1`**;
+multi-supernode Schur tails → `InvalidInput` (deferred to FERAL F3.3).
+Forest-structured Schur sets rejected; `schur_indices.len() == n` → `InvalidInput`.
+Implications:
+
+- The coupling block must be small & connected enough to land in one supernode
+  (true for "Schur ≪ eliminated" aggregation, but not guaranteed).
+- pounce **must fall back to `StdAugSystemSolver`** when FERAL returns
+  `InvalidInput`, rather than failing the solve — the block structure is a
+  *hint*, not a contract. This graceful fallback is a first-class requirement.
+- Measure in Phase 3 whether real aggregation problems exceed the single-supernode
+  limit; if so, a FERAL F3.3 follow-up is needed.
+
+## Interactions that must keep working
+
+- **Iterative refinement** (`PdFullSpaceSolver`): support `resolve` (back-solve
+  only) by reusing cached A_FF + S factors; `multi_solve` ideally too. Feasible.
+- **Scaling:** FERAL's Schur path forces `preprocess = None`; MC64 symmetric
+  scaling permutes/reweights and may fight the fixed Schur tail. Start with
+  `Identity` / symmetric scaling on the Schur path, revisit.
+- **Debugger `kkt_triplets` / `l_factor`:** the factor representation changes;
+  `l_factor` may return `None` initially.
+- **Timing/diagnostics:** bump the same `linear_system_factorization` /
+  `linear_system_back_solve` counters (item 3) so the perf study is measurable.
+- Defer `try_resolve_many_flat` (sensitivity backward fast path).
+
+## Validation
+
+- **Acceptance gate:** identical solutions to `StdAugSystemSolver` (within tol)
+  per-solve, and inertia parity at *every* IPM iteration — item 2 changes only
+  factorization structure, solutions are identical.
+- **Corpus:** NN-surrogate-constrained / aggregation problems (the paper's
+  Table-6 set) + the standard HS/CUTEst regression subset.
+- **Perf:** factor+solve wall-time vs `Std`, attributed via the item-3 timing
+  breakdown; look for the paper's up-to-15× on the surrogate KKTs.
+
+## Effort estimate & phasing
+
+- **Phase 0 — Spike (½–1 day):** small KKT, `symbolic_factorize_with_schur` +
+  `factorize_multifrontal_with_schur`, attempt the full block backsolve, check
+  residual + inertia against `Std`. Resolves the backsolve dependency. **Gate.**
+- **Phase 1 — pounce-feral Schur backend (3–5 days):** factor/backsolve/inertia
+  wrapping the FERAL primitives; unit-tested at the pounce-feral layer
+  (identity-vs-`Std` residual + inertia on small KKTs).
+- **Phase 2 — `SchurAugSystemSolver` + app/Problem API (3–5 days):** trait impl,
+  block-partition hook, `InvalidInput`→`Std` fallback, wire through
+  `PdFullSpaceSolver`, inertia-loop integration.
+- **Phase 3 — validation + perf (2–4 days):** corpus correctness/inertia parity,
+  perf study, docs.
+- **Total ≈ 2–3 weeks** *if* Phase 0 hits outcome (1). Outcome (2) adds a FERAL
+  request + release round-trip (as with item 1). A FERAL F3.3 (multi-supernode
+  Schur tail) follow-up may be needed for larger aggregation problems.
+
+## Recommendation
+
+Worth doing, and **much cheaper than it first looked** because FERAL already
+built the primitive. But unlike item 1 it carries genuine correctness risk
+(inertia via Sylvester), one open FERAL dependency (block backsolve), and a
+scope limit (single-supernode Schur tail). **Do the Phase 0 spike first** — it is
+the cheapest way to de-risk the whole feature and decide go/no-go.

--- a/dev-notes/research/issue-180-item2-schur-kkt-scope.md
+++ b/dev-notes/research/issue-180-item2-schur-kkt-scope.md
@@ -203,10 +203,72 @@ Implications:
   request + release round-trip (as with item 1). A FERAL F3.3 (multi-supernode
   Schur tail) follow-up may be needed for larger aggregation problems.
 
+## Phase-0 spike results (RAN — green)
+
+Reproducer: `issue-180-item2-schur-spike.rs` (standalone `feral = "0.13.0"`
+crate). It builds KKT-shaped symmetric-indefinite matrices with an explicit
+F/S partition, runs the **self-formed Schur design** (factor `A_FF` standalone
+via `feral::Solver`, form `S = A_SS − A_FSᵀ A_FF⁻¹ A_FS` with `n_schur`
+backsolves, factor `S` densely, block-backsolve), and checks against a
+monolithic-factorization oracle. Sweeps `n` in both dimensions.
+
+**Q1 — correctness: PASS.** `max|x_schur − x_oracle|` is `4e-16 … 2e-15`
+(machine precision) across every case, including `n = 256 008`.
+
+**Q2 — inertia via Sylvester: PASS.** `inertia(A_FF) + inertia(S)` equals the
+oracle's full-system inertia in every case — including an **indefinite**
+eliminated block where both blocks carry negatives (`(25,29,0)`,
+`(1000,1016,0)`), not just the SPD-`A_FF` case. Haynsworth/Sylvester additivity
+holds exactly, which is the correctness core of the whole method.
+
+**Q3 — the dense trap: located precisely, and it is confined to `n_schur`.**
+- **Sweep A** (grow the sparse block `n_F` from 1k→256k, hold `n_S = 8`):
+  `nnz(L_AFF)` is exactly linear in `n_F` (≈9.5·`n_F`, tridiagonal → banded, no
+  fill blow-up); factor / form-S / backsolve times all scale ~linearly; the
+  dense-`S` cost is flat. **No n² anywhere in the sparse dimension.**
+- **Sweep B** (hold `n_F = 8000`, grow `n_S` from 2→1024): `nnz(L_AFF)` flat;
+  dense `S` storage `= n_S²`; the transient `W = A_FF⁻¹A_FS` buffer `= n_F·n_S`
+  (64 MB at `n_S=1024`); form-`S` superlinear; factor-`S` ~`n_S³` (0.055→0.262 s
+  as `n_S` 512→1024). This is the trap — **entirely a function of `n_schur`.**
+- **Crossover vs monolithic factor:** Schur is ~3.3× *faster* than the oracle
+  full factor at `n_S = 32` (`n_F=8000`) and ~15× *slower* at `n_S = 1024`. The
+  method wins iff `n_schur ≪ n_F`.
+
+**Open FERAL dependency — RESOLVED (unblocked).** The self-formed design uses
+only `feral::Solver::factor` / `solve` (proven, stable) and needs **no**
+un-exported partial-backsolve, so **item 2 is not blocked at the FERAL layer and
+needs no companion FERAL request** for a baseline. As an independent
+cross-check, feral's native `factorize_multifrontal_with_schur` produced a dense
+`S` that **matched the self-formed `S` to < 1e-9 in every case** — and it did
+**not** hit the F3.2b single-supernode limit even at `n_S = 1024` (feral's
+HALO-SCHUR amalgamation merges the tail). The native path remains attractive as
+a *memory* optimization (it forms `S` without materializing the `O(n_F·n_S)`
+`W` buffer) but would reintroduce the partial-backsolve question; **use the
+self-formed design as the baseline, revisit native as an optimization.**
+
+**Design guardrails this surfaces for Phase 1/2:**
+1. **Gate on `n_schur ≪ n_F`.** Refuse (fall back to `Std`) or warn when the
+   supplied Schur block is not small — otherwise the O(n_S³) factor + O(n_F·n_S)
+   memory make it lose to the monolithic solve. This threshold is the single
+   most important knob.
+2. **Stream the `S` formation** column-by-column (solve one `A_FS` column,
+   accumulate into `S`, discard) to keep transient memory at O(n_F) instead of
+   O(n_F·n_S).
+3. Per-IPM-iteration overhead adds `O(n_S · nnz(L_FF)) + O(n_S³)`; fine for
+   small `n_S`, and the item-3 timing breakdown already lets us measure it.
+
+**Effort revision:** Phase 0 (this spike) done. The baseline design carries **no
+FERAL round-trip** (the previously-largest risk), so the estimate tightens to the
+~2–3 week Phases 1–3 with the biggest unknown removed. Sylvester inertia — the
+remaining correctness risk — is empirically confirmed (incl. indefinite `A_FF`).
+
 ## Recommendation
 
-Worth doing, and **much cheaper than it first looked** because FERAL already
-built the primitive. But unlike item 1 it carries genuine correctness risk
-(inertia via Sylvester), one open FERAL dependency (block backsolve), and a
-scope limit (single-supernode Schur tail). **Do the Phase 0 spike first** — it is
-the cheapest way to de-risk the whole feature and decide go/no-go.
+**Green light.** Item 2 is **much cheaper and lower-risk than it first looked**:
+FERAL already ships the Schur primitive, the block backsolve + Sylvester inertia
+are proven correct to machine precision (incl. an indefinite eliminated block),
+and the design needs **no companion FERAL change** — the self-formed-`S` path
+uses only stable exported APIs. The one real hazard, the dense `n_schur²/n_schur³`
+cost, is fully understood and confined to the (intended-small) Schur block; guard
+it with an `n_schur ≪ n_F` gate + `Std` fallback. Proceed to Phase 1 (the
+pounce-feral Schur backend) when ready.

--- a/dev-notes/research/issue-180-item2-schur-kkt-scope.md
+++ b/dev-notes/research/issue-180-item2-schur-kkt-scope.md
@@ -188,12 +188,15 @@ Implications:
 
 ## Effort estimate & phasing
 
-- **Phase 0 — Spike (½–1 day):** small KKT, `symbolic_factorize_with_schur` +
-  `factorize_multifrontal_with_schur`, attempt the full block backsolve, check
-  residual + inertia against `Std`. Resolves the backsolve dependency. **Gate.**
-- **Phase 1 — pounce-feral Schur backend (3–5 days):** factor/backsolve/inertia
-  wrapping the FERAL primitives; unit-tested at the pounce-feral layer
-  (identity-vs-`Std` residual + inertia on small KKTs).
+- **Phase 0 — Spike (½–1 day): DONE (green).** See § Phase-0 above.
+- **Phase 1 — pounce-feral Schur backend: DONE.** `crates/pounce-feral/src/schur.rs`
+  — `FeralSchurSolver` (init/values/factor/backsolve), self-formed-`S` design,
+  Sylvester inertia, per-block iterative refinement (`cfg.refine`), graceful
+  `FatalError` on a malformed partition. Extracted `configure_solver` so both the
+  monolithic and Schur backends configure feral identically. 7 unit tests vs a
+  `FeralSolverInterface` oracle: SPD + indefinite `A_FF`, scattered (non-tail)
+  Schur sets, multi-RHS, refactor-same-pattern, `WrongInertia` flagging,
+  malformed-partition rejection — all machine-precision solution + exact inertia.
 - **Phase 2 — `SchurAugSystemSolver` + app/Problem API (3–5 days):** trait impl,
   block-partition hook, `InvalidInput`→`Std` fallback, wire through
   `PdFullSpaceSolver`, inertia-loop integration.

--- a/dev-notes/research/issue-180-item2-schur-spike.rs
+++ b/dev-notes/research/issue-180-item2-schur-spike.rs
@@ -1,0 +1,415 @@
+//! pounce#180 item-2 Phase-0 spike.  [REFERENCE ARTIFACT — not a workspace member]
+//!
+//! Standalone reproducer. To run: drop this into a fresh crate with
+//! `feral = "0.13.0"` as the only dependency and `cargo run --release`.
+//! Results are summarised in `issue-180-item2-schur-kkt-scope.md` § Phase-0.
+//!
+//! Question 1 (correctness): does a block Schur backsolve reconstruct the
+//!   exact KKT solution that a monolithic factorization gives?
+//! Question 2 (inertia): does inertia(A_FF) + inertia(S) — Sylvester / Haynsworth
+//!   additivity — equal the true inertia of the full system?
+//! Question 3 (the dense trap): where does cost live as n grows? We must confirm
+//!   the SPARSE dimension (n_F, the eliminated block) stays ~linear and the only
+//!   n_schur-dependent cost (dense S: O(n_s^2) store, O(n_s^3) factor, plus
+//!   n_s backsolves to form it) is CONFINED to the intended-small Schur block.
+//!
+//! Design under test = "self-formed Schur": factor A_FF standalone (feral
+//! `Solver::factor` — proven), form S = A_SS - A_FS^T A_FF^{-1} A_FS via n_schur
+//! backsolves, factor S densely. Uses ONLY feral's public factor/solve; does NOT
+//! rely on `factorize_multifrontal_with_schur`'s un-eliminated partial factors
+//! being solvable. We ALSO cross-check S against feral's native Schur extraction.
+
+use std::time::Instant;
+
+use feral::inertia::Inertia;
+use feral::scaling::ScalingStrategy;
+use feral::sparse::csc::CscMatrix;
+use feral::symbolic::{symbolic_factorize_with_schur, SupernodeParams};
+use feral::{factorize_multifrontal_with_schur, NumericParams, Solver};
+
+/// A KKT-shaped symmetric-indefinite test matrix, held as lower-triangle
+/// pieces so we can assemble the full system OR the F/S blocks on demand.
+///
+/// F = indices `0..n_f` (the "eliminated" / block-triangular submatrix):
+///   tridiagonal SPD (diag 2+something, off-diag -1) → sparse, banded,
+///   near-linear to factor; all-positive inertia.
+/// S = indices `n_f..n_f+n_s` (the Schur tail): `A_SS` negative-definite-ish,
+///   coupled to F by a sparse `A_FS` (a few entries per Schur column).
+/// The full matrix then has inertia `(n_f, n_s, 0)` — a clean Sylvester target.
+struct Kkt {
+    n_f: usize,
+    n_s: usize,
+    /// A_FF lower-triangle triplets, indices in `0..n_f`.
+    ff: Vec<(usize, usize, f64)>,
+    /// Coupling entries, stored as A_SF: `(schur s in 0..n_s, f in 0..n_f, val)`.
+    /// By symmetry these are also A_FS[f, s]. ~`coupling_deg` per Schur column.
+    coupling: Vec<(usize, usize, f64)>,
+    /// A_SS lower-triangle triplets, indices in `0..n_s`.
+    ss: Vec<(usize, usize, f64)>,
+}
+
+impl Kkt {
+    fn build(n_f: usize, n_s: usize, coupling_deg: usize) -> Self {
+        Self::build_ex(n_f, n_s, coupling_deg, false)
+    }
+
+    /// `f_indef=true` makes the eliminated block A_FF *indefinite* (first half
+    /// +diag, second half −diag) — a diagonally-dominant, nonsingular saddle,
+    /// mimicking a real KKT eliminated block that contains constraint rows. The
+    /// point is to confirm Sylvester additivity when BOTH A_FF and S contribute
+    /// negative eigenvalues, not just when A_FF is SPD.
+    fn build_ex(n_f: usize, n_s: usize, coupling_deg: usize, f_indef: bool) -> Self {
+        let mut ff = Vec::with_capacity(2 * n_f);
+        for i in 0..n_f {
+            let d = if f_indef && i >= n_f / 2 { -4.0 } else { 4.0 };
+            ff.push((i, i, d));
+            if i > 0 {
+                ff.push((i, i - 1, -1.0));
+            }
+        }
+        // Coupling: spread each Schur column across `coupling_deg` F-rows,
+        // deterministically (no RNG — vary the stride by index).
+        let mut coupling = Vec::with_capacity(n_s * coupling_deg.max(1));
+        if n_f > 0 {
+            for s in 0..n_s {
+                for k in 0..coupling_deg {
+                    let f = ((s * 7 + k * 101 + 3) * 2_654_435_761usize) % n_f;
+                    coupling.push((s, f, 0.5 + 0.1 * (k as f64)));
+                }
+            }
+        }
+        // A_SS: negative diagonal (drives the Schur complement negative-def).
+        let mut ss = Vec::with_capacity(n_s);
+        for i in 0..n_s {
+            ss.push((i, i, -1.0));
+        }
+        Kkt { n_f, n_s, ff, coupling, ss }
+    }
+
+    fn n(&self) -> usize {
+        self.n_f + self.n_s
+    }
+
+    /// Full lower-triangle triplets of M (F first, S as the tail).
+    fn full_lower(&self) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
+        let (mut r, mut c, mut v) = (Vec::new(), Vec::new(), Vec::new());
+        for &(i, j, x) in &self.ff {
+            r.push(i);
+            c.push(j);
+            v.push(x);
+        }
+        // Coupling lands as (row = n_f + s, col = f) — strictly lower since
+        // the Schur tail has the largest indices.
+        for &(s, f, x) in &self.coupling {
+            r.push(self.n_f + s);
+            c.push(f);
+            v.push(x);
+        }
+        for &(i, j, x) in &self.ss {
+            r.push(self.n_f + i);
+            c.push(self.n_f + j);
+            v.push(x);
+        }
+        (r, c, v)
+    }
+
+    fn ff_lower(&self) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
+        let mut r = Vec::new();
+        let mut c = Vec::new();
+        let mut v = Vec::new();
+        for &(i, j, x) in &self.ff {
+            r.push(i);
+            c.push(j);
+            v.push(x);
+        }
+        (r, c, v)
+    }
+}
+
+fn factor_identity_scaled(csc: &CscMatrix) -> (Solver, Inertia, usize, f64) {
+    let mut s = Solver::new().with_scaling(ScalingStrategy::Identity);
+    let t = Instant::now();
+    let status = s.factor(csc, None);
+    let dt = t.elapsed().as_secs_f64();
+    match status {
+        feral::numeric::solver::FactorStatus::Success => {}
+        other => panic!("factor failed: {other:?}"),
+    }
+    let inertia = s.inertia().cloned().unwrap_or(Inertia {
+        positive: 0,
+        negative: s.num_negative_eigenvalues(),
+        zero: 0,
+    });
+    let nnz_l = s.last_factor_stats().map(|st| st.nnz_l).unwrap_or(0);
+    (s, inertia, nnz_l, dt)
+}
+
+/// Dense apply pieces used by the block backsolve, all O(nnz(coupling)).
+fn apply_afs(k: &Kkt, x_s: &[f64], out_f: &mut [f64]) {
+    // out_f += A_FS x_s  (A_FS[f,s] = coupling(s,f))
+    for &(s, f, v) in &k.coupling {
+        out_f[f] += v * x_s[s];
+    }
+}
+fn apply_asf(k: &Kkt, x_f: &[f64], out_s: &mut [f64]) {
+    // out_s += A_SF x_f  (A_SF[s,f] = coupling(s,f))
+    for &(s, f, v) in &k.coupling {
+        out_s[s] += v * x_f[f];
+    }
+}
+
+struct SchurResult {
+    x: Vec<f64>,
+    inertia: Inertia,
+    // timing / size instrumentation
+    t_factor_ff: f64,
+    t_form_s: f64,
+    t_factor_s: f64,
+    t_backsolve: f64,
+    nnz_l_ff: usize,
+    w_store: usize, // n_f * n_s intermediate (dense columns of A_FF^{-1} A_FS)
+    native_s_matches: Option<bool>,
+}
+
+/// The design under test.
+fn schur_solve(k: &Kkt, b: &[f64]) -> SchurResult {
+    let n_f = k.n_f;
+    let n_s = k.n_s;
+
+    // 1. Factor A_FF (sparse, the big block).
+    let (rf, cf, vf) = k.ff_lower();
+    let ff_csc = CscMatrix::from_triplets(n_f, &rf, &cf, &vf).unwrap();
+    let (ff, inertia_ff, nnz_l_ff, t_factor_ff) = factor_identity_scaled(&ff_csc);
+
+    // 2. Form S = A_SS - A_FS^T A_FF^{-1} A_FS.
+    let t = Instant::now();
+    //   Build A_FS as a dense n_f x n_s column-major buffer (n_s solves).
+    let mut afs = vec![0.0f64; n_f * n_s];
+    for &(s, f, v) in &k.coupling {
+        afs[f + s * n_f] = v; // column s, row f
+    }
+    let w = ff.solve_many(&afs, n_s).unwrap(); // W = A_FF^{-1} A_FS, n_f x n_s
+    //   S = A_SS - A_FS^T W  (n_s x n_s, dense — CONFINED to n_s).
+    let mut s_dense = vec![0.0f64; n_s * n_s];
+    for &(i, j, x) in &k.ss {
+        s_dense[i + j * n_s] += x;
+    }
+    // A_FS^T W: for each coupling (s,f,v): row s of A_FS^T; subtract v*W[f,:].
+    for &(s, f, v) in &k.coupling {
+        for j in 0..n_s {
+            s_dense[s + j * n_s] -= v * w[f + j * n_f];
+        }
+    }
+    let t_form_s = t.elapsed().as_secs_f64();
+
+    // 3. Factor S densely (as a small sparse matrix via feral — symmetric
+    //    indefinite Bunch-Kaufman, gives its inertia). Lower triangle only.
+    let t = Instant::now();
+    let (mut sr, mut sc, mut sv) = (Vec::new(), Vec::new(), Vec::new());
+    for j in 0..n_s {
+        for i in j..n_s {
+            let val = s_dense[i + j * n_s];
+            if val != 0.0 || i == j {
+                sr.push(i);
+                sc.push(j);
+                sv.push(val);
+            }
+        }
+    }
+    let s_csc = CscMatrix::from_triplets(n_s, &sr, &sc, &sv).unwrap();
+    let (s_solver, inertia_s, _n, _feral_dt) = factor_identity_scaled(&s_csc);
+    let t_factor_s = t.elapsed().as_secs_f64();
+
+    // 4. Block backsolve for M x = b.
+    let t = Instant::now();
+    let b_f = &b[..n_f];
+    let b_s = &b[n_f..];
+    //   u = A_FF^{-1} b_F
+    let u = ff.solve(b_f).unwrap();
+    //   r_S = b_S - A_SF u
+    let mut r_s = b_s.to_vec();
+    let mut asf_u = vec![0.0; n_s];
+    apply_asf(k, &u, &mut asf_u);
+    for i in 0..n_s {
+        r_s[i] -= asf_u[i];
+    }
+    //   x_S = S^{-1} r_S
+    let x_s = s_solver.solve(&r_s).unwrap();
+    //   x_F = A_FF^{-1} (b_F - A_FS x_S)
+    let mut rhs_f = b_f.to_vec();
+    let mut afs_xs = vec![0.0; n_f];
+    apply_afs(k, &x_s, &mut afs_xs);
+    for f in 0..n_f {
+        rhs_f[f] -= afs_xs[f];
+    }
+    let x_f = ff.solve(&rhs_f).unwrap();
+    let t_backsolve = t.elapsed().as_secs_f64();
+
+    let mut x = Vec::with_capacity(n_f + n_s);
+    x.extend_from_slice(&x_f);
+    x.extend_from_slice(&x_s);
+
+    let inertia = Inertia {
+        positive: inertia_ff.positive + inertia_s.positive,
+        negative: inertia_ff.negative + inertia_s.negative,
+        zero: inertia_ff.zero + inertia_s.zero,
+    };
+
+    // Cross-check S against feral's NATIVE Schur extraction (Design A), where
+    // the F3.2b single-supernode constraint permits it.
+    let native_s_matches = native_schur_check(k, &s_dense);
+
+    SchurResult {
+        x,
+        inertia,
+        t_factor_ff,
+        t_form_s,
+        t_factor_s,
+        t_backsolve,
+        nnz_l_ff,
+        w_store: n_f * n_s,
+        native_s_matches,
+    }
+}
+
+/// Feed the full lower-triangle matrix to feral's own Schur factorization and
+/// compare its dense S to ours. Returns None if feral rejects the partition
+/// (e.g. the F3.2b single-supernode scope limit) — which is itself a finding.
+fn native_schur_check(k: &Kkt, our_s: &[f64]) -> Option<bool> {
+    let (r, c, v) = k.full_lower();
+    let m = CscMatrix::from_triplets(k.n(), &r, &c, &v).ok()?;
+    let schur_indices: Vec<usize> = (k.n_f..k.n()).collect();
+    let snode = SupernodeParams::default();
+    let sym = symbolic_factorize_with_schur(&m, &snode, &schur_indices).ok()?;
+    let params = NumericParams {
+        scaling: ScalingStrategy::Identity,
+        ..NumericParams::default()
+    };
+    let (_factors, _inertia_ff, schur_block) =
+        factorize_multifrontal_with_schur(&m, &sym, &params).ok()?;
+    // Compare diagonals (both symmetric); tolerate ordering by comparing the
+    // symmetric entrywise max-abs difference over the n_s x n_s block.
+    let n_s = k.n_s;
+    if schur_block.dim != n_s {
+        return Some(false);
+    }
+    let mut max_diff = 0.0f64;
+    for i in 0..n_s {
+        for j in 0..n_s {
+            let d = (schur_block.get(i, j) - our_s[i + j * n_s]).abs();
+            if d > max_diff {
+                max_diff = d;
+            }
+        }
+    }
+    Some(max_diff < 1e-9)
+}
+
+/// Oracle: monolithic factorization of the full system.
+fn oracle(k: &Kkt, b: &[f64]) -> (Vec<f64>, Inertia, usize, f64, f64) {
+    let (r, c, v) = k.full_lower();
+    let m = CscMatrix::from_triplets(k.n(), &r, &c, &v).unwrap();
+    let (solver, inertia, nnz_l, t_factor) = factor_identity_scaled(&m);
+    let t = Instant::now();
+    let x = solver.solve(b).unwrap();
+    let t_solve = t.elapsed().as_secs_f64();
+    (x, inertia, nnz_l, t_factor, t_solve)
+}
+
+fn max_abs_diff(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b).map(|(x, y)| (x - y).abs()).fold(0.0, f64::max)
+}
+
+fn rhs(n: usize) -> Vec<f64> {
+    (0..n).map(|i| 1.0 + ((i % 7) as f64) * 0.3 - ((i % 3) as f64) * 0.5).collect()
+}
+
+fn run_case(label: &str, n_f: usize, n_s: usize, coupling_deg: usize, verbose: bool) {
+    run_case_ex(label, n_f, n_s, coupling_deg, verbose, false)
+}
+
+fn run_case_ex(label: &str, n_f: usize, n_s: usize, coupling_deg: usize, verbose: bool, f_indef: bool) {
+    let k = Kkt::build_ex(n_f, n_s, coupling_deg, f_indef);
+    let b = rhs(k.n());
+
+    let (x_true, inertia_true, nnz_l_full, t_full_factor, t_full_solve) = oracle(&k, &b);
+    let res = schur_solve(&k, &b);
+
+    let sol_err = max_abs_diff(&res.x, &x_true);
+    let inertia_ok = res.inertia == inertia_true;
+    let schur_total = res.t_factor_ff + res.t_form_s + res.t_factor_s + res.t_backsolve;
+
+    println!("── {label}  (n_f={n_f}, n_s={n_s}, n={})", k.n());
+    println!(
+        "   correctness: max|x_schur - x_oracle| = {sol_err:.3e}   {}",
+        if sol_err < 1e-7 { "OK" } else { "*** FAIL ***" }
+    );
+    println!(
+        "   inertia:     schur={:?}  oracle={:?}   {}",
+        (res.inertia.positive, res.inertia.negative, res.inertia.zero),
+        (inertia_true.positive, inertia_true.negative, inertia_true.zero),
+        if inertia_ok { "OK (Sylvester)" } else { "*** FAIL ***" }
+    );
+    println!(
+        "   native S cross-check (feral factorize_multifrontal_with_schur): {}",
+        match res.native_s_matches {
+            Some(true) => "MATCHES our S".to_string(),
+            Some(false) => "*** DIFFERS ***".to_string(),
+            None => "rejected (F3.2b scope limit / not applicable)".to_string(),
+        }
+    );
+    if verbose {
+        println!(
+            "   sparsity:  nnz(L_AFF)={}  (full-M nnz(L)={})   dense S: {}x{}={} f64 ({} KiB)",
+            res.nnz_l_ff,
+            nnz_l_full,
+            n_s,
+            n_s,
+            n_s * n_s,
+            (n_s * n_s * 8) / 1024
+        );
+        println!(
+            "   W intermediate (A_FF^-1 A_FS, dense): {} f64 ({} KiB)",
+            res.w_store,
+            (res.w_store * 8) / 1024
+        );
+        println!(
+            "   time[s]: factorAFF={:.4} formS={:.4} factorS={:.4} backsolve={:.4} | schurTOTAL={:.4}  ||  oracle factor={:.4} solve={:.4}",
+            res.t_factor_ff,
+            res.t_form_s,
+            res.t_factor_s,
+            res.t_backsolve,
+            schur_total,
+            t_full_factor,
+            t_full_solve
+        );
+    }
+    assert!(sol_err < 1e-6, "solution mismatch");
+    assert!(inertia_ok, "inertia (Sylvester) mismatch");
+    println!();
+}
+
+fn main() {
+    println!("=== pounce#180 item-2 Phase-0 spike: Schur KKT backsolve + inertia + scaling ===\n");
+
+    println!("## Correctness & Sylvester inertia (small, thorough) ##\n");
+    run_case("tiny", 6, 2, 2, true);
+    run_case("small", 50, 4, 3, true);
+    run_case("medium", 500, 8, 4, true);
+
+    println!("## Indefinite eliminated block A_FF (both A_FF and S carry negatives) ##\n");
+    run_case_ex("indef small", 50, 4, 3, true, true);
+    run_case_ex("indef medium", 2000, 16, 4, true, true);
+
+    println!("## Sweep A: grow the SPARSE block n_F, hold n_S=8 (should stay ~linear) ##\n");
+    for &n_f in &[1_000usize, 4_000, 16_000, 64_000, 256_000] {
+        run_case(&format!("A n_f={n_f}"), n_f, 8, 4, true);
+    }
+
+    println!("## Sweep B: hold n_F=8000, grow the DENSE Schur block n_S (find the trap) ##\n");
+    for &n_s in &[2usize, 8, 32, 128, 512, 1024] {
+        run_case(&format!("B n_s={n_s}"), 8_000, n_s, 4, true);
+    }
+
+    println!("All correctness + inertia assertions passed.");
+}

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -201,6 +201,28 @@ problem looks linear-solver-bound, try `feral_ordering auto_race`
 before per-variant manual sweeping — it's the safe choice when the
 per-problem winner is uncertain.
 
+#### Caller-supplied ordering (`External`)
+
+Beyond the string variants above, a structure-aware caller can inject a
+**precomputed permutation** the generic AMD/METIS pass cannot see — a
+block-triangular / Schur ordering (Parker, Garcia & Bent,
+arXiv:2602.17968) or a tearing ordering from equation-oriented
+decomposition. Because a permutation is a vector it cannot travel through
+the string `feral_ordering` option; supply it programmatically instead:
+
+- **Python:** `Problem.set_ordering(perm)` (and `get_ordering()` /
+  `clear_ordering()`) — see [the Python guide](./python.md#caller-supplied-kkt-ordering-set_ordering).
+- **Rust:** `IpoptApplication::set_external_ordering(perm)`.
+
+`perm` is a 0-based, new-to-old permutation (`perm[k]` is the original
+index that becomes index `k`) whose length must equal the **augmented KKT
+system dimension** (variables + slacks + constraint duals), not the
+problem's `n`. FERAL validates it as a bijection and fails the
+factorization with an error on a wrong length or duplicate — a valid but
+poor ordering only costs fill/time, never correctness. This maps to
+FERAL's `OrderingMethod::External` (feral#107) and honors only the default
+FERAL backend.
+
 ## Logging and colored output
 
 POUNCE emits structured logs and a colored iteration table through the

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -154,6 +154,36 @@ persistent config (it applies to every subsequent `solve()` until
 `clear_ordering()`) and is honored only by the default FERAL backend. This
 maps to FERAL's `OrderingMethod::External` (feral#107).
 
+### Block-triangular / Schur KKT solve (`set_kkt_schur_block`)
+
+If a presolve can identify a **reducible block** of the KKT system — e.g. the
+nonsingular block-triangular submatrix a reduced-space / variable-aggregation
+analysis exposes (Parker, Garcia & Bent, arXiv:2602.17968) — it can hand that
+block to pounce, which Schur-complements it out and factorizes only the two
+diagonal blocks, recovering the full-system inertia a priori via Sylvester's
+law:
+
+```python
+prob = pounce.Problem(n, m, problem_obj=...)   # needs an exact Hessian
+prob.set_kkt_schur_block(indices)              # KKT-space indices of the Schur block
+x, info = prob.solve(x0=...)
+# prob.get_kkt_schur_block()  -> installed indices, or None
+# prob.clear_kkt_schur_block()
+```
+
+`indices` are **KKT-space** indices into `0..dim` where
+`dim = n + n_slack + n_eq + n_ineq`, in the solver's internal
+`x, slack, eq-dual, ineq-dual` block order (e.g. for an all-equality problem
+the constraint-dual block is `range(n, n + n_eq)`, and the primal block is the
+positive-definite eliminated block — the classic range/null-space split). The
+method wins **only when the Schur block is much smaller than the eliminated
+block** (the dense Schur complement is `O(n_schur²)` to store and `O(n_schur³)`
+to factor). When the partition is unsuitable — too large a fraction of the
+system, malformed, or a diagonal block turns out singular — the solver **falls
+back to the standard full-space path transparently**, so the hook can never
+break a solve; it only changes *how* the identical system is factored, never
+the solution. Honored on the default feral + exact-Hessian path.
+
 ## Batched NLP solving (`solve_nlp_batch`)
 
 `pounce.solve_nlp_batch` solves N **independent** NLPs and returns one

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -126,6 +126,34 @@ Lagrangian-Hessian evaluation — the func/Jacobian/Hessian story becomes a
 direct measurement rather than an inference. All values are wall-clock
 seconds; unused subsystems read `0.0`.
 
+### Caller-supplied KKT ordering (`set_ordering`)
+
+A structure-aware presolve can hand pounce a fill-reducing permutation for
+the KKT linear solver that the built-in AMD/METIS pass cannot derive — a
+block-triangular / Schur ordering (Parker, Garcia & Bent, arXiv:2602.17968)
+or a tearing ordering from equation-oriented decomposition. Install it on
+the low-level `Problem` before solving:
+
+```python
+prob = pounce.Problem(n, m, problem_obj=...)
+prob.set_ordering(perm)        # 0-based new-to-old permutation (list / int array)
+x, info = prob.solve(x0=...)
+# prob.get_ordering()  -> the installed permutation, or None
+# prob.clear_ordering() -> restore the feral_ordering default
+```
+
+`perm[k]` is the original index that becomes index `k`. Its **length must
+equal the augmented KKT system dimension** (variables + slacks + constraint
+duals), *not* the problem's `n`; for an unconstrained problem that is `n`,
+but with constraints it is larger. The ordering is validated inside FERAL as
+a bijection — a wrong length or a duplicate fails the factorization and the
+solve returns a non-success status (e.g. `Error_In_Step_Computation`) rather
+than crashing or returning a wrong answer, since a permutation only affects
+fill and pivot order, never the computed solution. `set_ordering` is
+persistent config (it applies to every subsequent `solve()` until
+`clear_ordering()`) and is honored only by the default FERAL backend. This
+maps to FERAL's `OrderingMethod::External` (feral#107).
+
 ## Batched NLP solving (`solve_nlp_batch`)
 
 `pounce.solve_nlp_batch` solves N **independent** NLPs and returns one

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -99,6 +99,33 @@ Two convenience knobs back this up:
   distinguishes those two statuses; if yours doesn't, gate on the residual
   directly as above.
 
+### Where the time went (`info["timing"]`)
+
+Every `Problem.solve` attaches a per-subsystem wall-clock breakdown so you
+can attribute a solve's runtime without patching or rebuilding the solver.
+`info["wall_time"]` is the overall-algorithm total (seconds); `info["timing"]`
+is a dict of the same total plus its components:
+
+```python
+x, info = prob.solve(x0=...)
+t = info["timing"]
+print(t["overall_alg"])                    # total solve wall time
+print(t["linear_system_factorization"],    # KKT factorization vs …
+      t["linear_system_back_solve"],        # … back-solve, and their
+      t["linear_system_total"])             # sum (total linear algebra)
+print(t["eval_objective"], t["eval_gradient"],
+      t["eval_constraints"], t["eval_constraint_jacobian"],
+      t["eval_lagrangian_hessian"])         # per-callback eval time
+```
+
+The `scipy`-style `pounce.minimize` facade mirrors these onto the result as
+`res.wall_time` and `res.timing` (also in `res.info`). The callback split is
+what lets you see, for example, that a reduced-space / variable-aggregation
+solve converges in few iterations but spends most of its time in a densified
+Lagrangian-Hessian evaluation — the func/Jacobian/Hessian story becomes a
+direct measurement rather than an inference. All values are wall-clock
+seconds; unused subsystems read `0.0`.
+
 ## Batched NLP solving (`solve_nlp_batch`)
 
 `pounce.solve_nlp_batch` solves N **independent** NLPs and returns one

--- a/python/benchmarks/schur_kkt_180.py
+++ b/python/benchmarks/schur_kkt_180.py
@@ -1,0 +1,191 @@
+"""Corpus + perf validation for the block-triangular / Schur KKT solve (pounce#180 item 2).
+
+Companion to `dev-notes/research/issue-180-item2-schur-kkt-scope.md` § Phase 3.
+**Not a CI benchmark** — a hands-on harness to (a) confirm the Schur path solves
+a scalable corpus to the *same* optimum as the standard full-space solver
+(correctness / inertia parity, at scale, across shapes), and (b) characterise
+where its linear-algebra cost stands versus the monolithic factorization, using
+the per-solve timing breakdown shipped in item 3 (`info["timing"]`).
+
+Corpus: a convex, equality-constrained NLP family
+
+    min  Σ_i 0.5 d_i (x_i − t_i)²       (separable, strictly convex ⇒ PD primal)
+    s.t. A x = b                         (m linear equalities)
+
+parameterised by the primal size `n` and the constraint count `m` (m ≪ n). With
+no inequalities the augmented KKT is `[[D+δ, Aᵀ],[A, −δ_c]]` of dimension
+`n + m`; choosing the constraint-dual block `[n, n+m)` as the Schur set leaves
+the positive-definite primal block as the eliminated `A_FF` — the classic
+range-space split, and exactly the regime where `n_schur = m ≪ n`.
+
+Two Jacobian shapes are swept because they stress the monolithic factorization
+differently:
+  * `banded`  — each constraint couples a contiguous window (sparse, local).
+  * `spread`  — each constraint couples entries strided across all of `x`
+                (a diffuse coupling AMD cannot localise as well).
+
+Run:  python python/benchmarks/schur_kkt_180.py [--sizes 500,2000,8000] [--m 16]
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+
+import pounce
+
+
+def make_problem(n, m, shape, seed=0):
+    """Build (target, A, b) for the convex equality-constrained QP."""
+    rng = np.random.default_rng(seed)
+    target = rng.uniform(-1.0, 1.0, size=n)
+    d = rng.uniform(0.5, 2.0, size=n)  # diagonal Hessian (PD)
+
+    rows, cols, vals = [], [], []
+    width = max(4, n // (2 * m))
+    for i in range(m):
+        if shape == "banded":
+            start = (i * (n - width)) // max(1, m - 1) if m > 1 else 0
+            idx = np.arange(start, start + width)
+        else:  # spread: strided across the whole vector
+            idx = (i + np.arange(width) * m) % n
+            idx = np.unique(idx)
+        coef = rng.uniform(-1.0, 1.0, size=idx.size)
+        rows.extend([i] * idx.size)
+        cols.extend(idx.tolist())
+        vals.extend(coef.tolist())
+    rows = np.asarray(rows)
+    cols = np.asarray(cols)
+    vals = np.asarray(vals, dtype=float)
+
+    # Feasible RHS from a random point *inside* the [-0.5, 0.5] box, so the
+    # equality system is feasible together with the bounds.
+    x_feas = rng.uniform(-0.4, 0.4, size=n)
+    A_dense_row = np.zeros(m)
+    b = np.zeros(m)
+    for i in range(m):
+        sel = rows == i
+        b[i] = np.dot(vals[sel], x_feas[cols[sel]])
+    _ = A_dense_row
+
+    return target, d, (rows, cols, vals), b
+
+
+def build(n, m, target, d, jac, b):
+    rows, cols, vals = jac
+
+    class QP:
+        def objective(self, x):
+            dd = x - target
+            return 0.5 * float(np.dot(d * dd, dd))
+
+        def gradient(self, x):
+            return d * (x - target)
+
+        def constraints(self, x):
+            out = np.zeros(m)
+            np.add.at(out, rows, vals * x[cols])
+            return out - b
+
+        def jacobianstructure(self):
+            return (rows, cols)
+
+        def jacobian(self, x):
+            return vals
+
+        def hessianstructure(self):
+            ar = np.arange(n, dtype=np.int64)
+            return (ar, ar)
+
+        def hessian(self, x, lagrange, obj_factor):
+            # Linear constraints ⇒ no Lagrangian contribution.
+            return obj_factor * d
+
+    # Box bounds tighter than the unconstrained optimum (`target`) so a good
+    # fraction are active at the solution — this forces the IPM to reduce the
+    # barrier over many iterations, exercising the Schur factor + resolve + the
+    # per-iteration inertia check repeatedly (not a trivial one-Newton-step QP).
+    lb = [-0.5] * n
+    ub = [0.5] * n
+    prob = pounce.Problem(
+        n=n, m=m, problem_obj=QP(), lb=lb, ub=ub, cl=[0.0] * m, cu=[0.0] * m
+    )
+    prob.add_option("tol", 1e-8)
+    prob.add_option("print_level", 0)
+    prob.add_option("max_iter", 300)
+    return prob
+
+
+def solve_once(prob, x0, schur_indices=None):
+    if schur_indices is not None:
+        prob.set_kkt_schur_block(schur_indices)
+    t0 = time.perf_counter()
+    x, info = prob.solve(x0=x0)
+    wall = time.perf_counter() - t0
+    t = info.get("timing", {})
+    return {
+        "x": x,
+        "status": info["status_msg"],
+        "iters": int(info["iter_count"]),
+        "obj": float(info["obj_val"]),
+        "wall": wall,
+        "factor": float(t.get("linear_system_factorization", float("nan"))),
+        "backsolve": float(t.get("linear_system_back_solve", float("nan"))),
+        "la_total": float(t.get("linear_system_total", float("nan"))),
+        "overall": float(t.get("overall_alg", float("nan"))),
+    }
+
+
+def run(sizes, m, shapes):
+    print(f"\npounce#180 item 2 — Schur KKT corpus/perf validation (m={m} equality constraints)\n")
+    hdr = (
+        f"{'shape':7} {'n':>7} {'dim':>7} | {'status(std/schur)':>22} "
+        f"{'iters':>11} {'max|Δx|':>10} {'Δobj':>10} | "
+        f"{'factor_std':>11} {'factor_schur':>13} {'speedup':>8}"
+    )
+    print(hdr)
+    print("-" * len(hdr))
+    all_ok = True
+    for shape in shapes:
+        for n in sizes:
+            target, d, jac, b = make_problem(n, m, shape)
+            dim = n + m
+            schur = list(range(n, n + m))  # constraint-dual block
+            x0 = np.zeros(n)
+
+            std = solve_once(build(n, m, target, d, jac, b), x0, schur_indices=None)
+            sch = solve_once(build(n, m, target, d, jac, b), x0, schur_indices=schur)
+
+            dx = float(np.max(np.abs(std["x"] - sch["x"]))) if std["x"].shape == sch["x"].shape else float("inf")
+            dobj = abs(std["obj"] - sch["obj"])
+            ok = (
+                std["status"] == "Solve_Succeeded"
+                and sch["status"] == "Solve_Succeeded"
+                and dx < 1e-6
+            )
+            all_ok = all_ok and ok
+            speed = (std["factor"] / sch["factor"]) if sch["factor"] > 0 else float("nan")
+            flag = "" if ok else "  <-- MISMATCH"
+            print(
+                f"{shape:7} {n:>7} {dim:>7} | "
+                f"{std['status'][:10]:>10}/{sch['status'][:10]:<10} "
+                f"{std['iters']:>4}/{sch['iters']:<5} {dx:>10.2e} {dobj:>10.2e} | "
+                f"{std['factor']:>11.4f} {sch['factor']:>13.4f} {speed:>7.2f}x{flag}"
+            )
+    print()
+    print("ALL SOLVES MATCHED" if all_ok else "*** SOME SOLVES MISMATCHED ***")
+    return all_ok
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--sizes", default="500,2000,8000")
+    ap.add_argument("--m", type=int, default=16)
+    ap.add_argument("--shapes", default="banded,spread")
+    args = ap.parse_args()
+    sizes = [int(s) for s in args.sizes.split(",")]
+    shapes = args.shapes.split(",")
+    ok = run(sizes, args.m, shapes)
+    raise SystemExit(0 if ok else 1)

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -1175,5 +1175,12 @@ def minimize(
         nfev=int(eval_counters["nfev"]),
         njev=int(eval_counters["njev"]),
         nhev=int(eval_counters["nhev"]),
+        # Solve wall-clock total and its per-subsystem breakdown (seconds),
+        # surfaced top-level for discoverability (pounce#180 item 3). The
+        # full breakdown dict — objective / gradient / constraint /
+        # Jacobian / Lagrangian-Hessian eval time and the linear-algebra
+        # factorization-vs-back-solve split — is also in ``info["timing"]``.
+        wall_time=float(info.get("wall_time", float("nan"))),
+        timing=dict(info.get("timing", {})),
         info=dict(info),
     )

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -46,6 +46,53 @@ def test_minimize_rosenbrock():
     np.testing.assert_allclose(res.x, np.ones(4), atol=1e-4)
 
 
+def test_minimize_reports_timing_breakdown():
+    """pounce#180 item 3: the result exposes a per-subsystem wall-clock
+    breakdown (``res.timing`` / ``res.info["timing"]``) plus a top-level
+    ``res.wall_time``, so a caller can attribute solve runtime (func /
+    gradient / Jacobian / Hessian eval time, factorization vs back-solve)
+    without patching the solver."""
+
+    def f(x):
+        return float(x @ x)
+
+    def grad(x):
+        return 2.0 * x
+
+    res = pounce.minimize(f, x0=np.array([1.0, 2.0, 3.0]), jac=grad, print_level=0)
+    assert res.success
+
+    # Top-level convenience fields.
+    assert np.isfinite(res.wall_time)
+    assert res.wall_time >= 0.0
+    assert isinstance(res.timing, dict)
+    # Same breakdown is mirrored into the info dict.
+    assert res.info["timing"] == res.timing
+    assert res.info["wall_time"] == res.wall_time
+
+    # Advertised keys are present, non-negative, and the linear-algebra
+    # total is the exact sum of its factorization / back-solve parts.
+    expected_keys = {
+        "overall_alg",
+        "linear_system_total",
+        "linear_system_factorization",
+        "linear_system_back_solve",
+        "function_evaluations_total",
+        "eval_objective",
+        "eval_gradient",
+        "eval_constraints",
+        "eval_constraint_jacobian",
+        "eval_lagrangian_hessian",
+    }
+    assert expected_keys <= set(res.timing)
+    for key in expected_keys:
+        assert res.timing[key] >= 0.0, key
+    assert res.timing["linear_system_total"] == pytest.approx(
+        res.timing["linear_system_factorization"]
+        + res.timing["linear_system_back_solve"]
+    )
+
+
 def test_minimize_eq_constraint():
     """min  x[0]^2 + x[1]^2   s.t.   x[0] + x[1] = 1   →   x* = (.5, .5), f* = .5."""
 

--- a/python/tests/test_problem.py
+++ b/python/tests/test_problem.py
@@ -142,6 +142,69 @@ def test_unconstrained_quadratic():
 
 
 # --------------------------------------------------------------------------
+# issue #180 item 1 — caller-supplied KKT ordering (FERAL External).
+# --------------------------------------------------------------------------
+def _quad_problem(n, target):
+    class Quad:
+        def objective(self, x):
+            d = x - target
+            return float(d @ d)
+
+        def gradient(self, x):
+            return 2.0 * (x - target)
+
+    prob = pounce.Problem(n=n, m=0, problem_obj=Quad())
+    prob.add_option("tol", 1e-10)
+    prob.add_option("print_level", 0)
+    return prob
+
+
+def test_external_ordering_matches_default_and_round_trips():
+    """A caller-supplied permutation reaches the FERAL backend, solves to the
+    same optimum as the default ordering, and round-trips through
+    get_ordering / clear_ordering. For an unconstrained problem the augmented
+    KKT system is n×n, so a length-n permutation is a valid bijection — and a
+    valid ordering only changes fill/pivot order, never the solution."""
+    target = np.array([1.0, 2.0, -3.0, 4.5])
+
+    x_ref, _ = _quad_problem(4, target).solve(x0=np.zeros(4))
+
+    prob = _quad_problem(4, target)
+    assert prob.get_ordering() is None
+    prob.set_ordering([3, 2, 1, 0])  # reversed — a valid 4×4 permutation
+    np.testing.assert_array_equal(prob.get_ordering(), [3, 2, 1, 0])
+
+    x, info = prob.solve(x0=np.zeros(4))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, x_ref, atol=1e-9)
+
+    # Persistent config: a second solve still uses it; then it clears.
+    x2, info2 = prob.solve(x0=np.ones(4))
+    assert info2["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x2, x_ref, atol=1e-9)
+    prob.clear_ordering()
+    assert prob.get_ordering() is None
+
+
+def test_external_ordering_negative_index_rejected():
+    """Negative permutation entries are rejected at set time (0-based indices);
+    the FERAL bijection check catches the rest at factorization."""
+    prob = _quad_problem(3, np.zeros(3))
+    with pytest.raises(ValueError):
+        prob.set_ordering([0, -1, 2])
+
+
+def test_external_ordering_wrong_length_fails_cleanly():
+    """A permutation whose length ≠ the KKT dimension is rejected by FERAL as
+    invalid input: the solve returns a non-success status rather than crashing
+    or silently returning a wrong answer."""
+    prob = _quad_problem(3, np.zeros(3))
+    prob.set_ordering([0, 1, 2, 3, 4, 5])  # length 6 for a 3×3 KKT system
+    _x, info = prob.solve(x0=np.ones(3))
+    assert info["status_msg"] != "Solve_Succeeded"
+
+
+# --------------------------------------------------------------------------
 # issue M32 — the `intermediate` callback return value must follow cyipopt
 # truthiness. A falsy return (False, 0, 0.0, []) requests a stop; truthy
 # continues. Pre-fix, the bridge used a strict `extract::<bool>().unwrap_or

--- a/python/tests/test_problem.py
+++ b/python/tests/test_problem.py
@@ -205,6 +205,108 @@ def test_external_ordering_wrong_length_fails_cleanly():
 
 
 # --------------------------------------------------------------------------
+# issue #180 item 2 — Schur KKT partition (SchurAugSystemSolver).
+# --------------------------------------------------------------------------
+def _convex_eq_qp(target, A, b):
+    """Convex equality-constrained QP: min ½‖x−target‖² s.t. A x = b. Exact
+    Hessian (identity) so the solver takes the exact-Hessian path the Schur
+    solver requires. All-equality ⇒ the KKT is `[[I+Σ, Aᵀ],[A, 0]]` of
+    dimension `n + m`; the primal block is positive-definite, so the
+    constraint-dual block `[n, n+m)` is a clean Schur set."""
+    n = len(target)
+    m = len(b)
+    rows = np.repeat(np.arange(m), n)
+    cols = np.tile(np.arange(n), m)
+    Aflat = A.reshape(-1).astype(float)
+
+    class QP:
+        def objective(self, x):
+            d = x - target
+            return 0.5 * float(d @ d)
+
+        def gradient(self, x):
+            return x - target
+
+        def constraints(self, x):
+            return A @ x - b
+
+        def jacobianstructure(self):
+            return (rows, cols)
+
+        def jacobian(self, x):
+            return Aflat
+
+        def hessianstructure(self):
+            return (np.arange(n, dtype=np.int64), np.arange(n, dtype=np.int64))
+
+        def hessian(self, x, lagrange, obj_factor):
+            # Objective Hessian is I; constraints are linear ⇒ no contribution.
+            return obj_factor * np.ones(n)
+
+    prob = pounce.Problem(
+        n=n,
+        m=m,
+        problem_obj=QP(),
+        cl=list(b),
+        cu=list(b),
+    )
+    prob.add_option("tol", 1e-9)
+    prob.add_option("print_level", 0)
+    return prob, n, m
+
+
+def test_kkt_schur_block_matches_full_space_solve():
+    """A Schur partition (the constraint-dual block) reaches the same optimum
+    as the standard full-space solve, and round-trips through the API."""
+    target = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    A = np.array([[1.0, 1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0, 1.0]])
+    b = np.array([3.0, 12.0])
+
+    prob_ref, n, m = _convex_eq_qp(target, A, b)
+    x_ref, info_ref = prob_ref.solve(x0=np.zeros(n))
+    assert info_ref["status_msg"] == "Solve_Succeeded"
+
+    prob, n, m = _convex_eq_qp(target, A, b)
+    # KKT dim = n + m (no inequalities); the dual block is [n, n+m).
+    schur = list(range(n, n + m))
+    assert prob.get_kkt_schur_block() is None
+    prob.set_kkt_schur_block(schur)
+    np.testing.assert_array_equal(prob.get_kkt_schur_block(), schur)
+
+    x, info = prob.solve(x0=np.zeros(n))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, x_ref, atol=1e-7)
+
+    prob.clear_kkt_schur_block()
+    assert prob.get_kkt_schur_block() is None
+
+
+def test_kkt_schur_block_oversized_falls_back():
+    """An oversized Schur block is rejected by the gate and the solve falls back
+    to the full-space solver — still converging to the optimum."""
+    target = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    A = np.array([[1.0, 1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0, 1.0]])
+    b = np.array([3.0, 12.0])
+    prob, n, m = _convex_eq_qp(target, A, b)
+    # Almost the whole KKT (well past the 0.5 gate) → transparent fallback.
+    prob.set_kkt_schur_block(list(range(n + m - 1)))
+    x, info = prob.solve(x0=np.zeros(n))
+    assert info["status_msg"] == "Solve_Succeeded"
+
+    prob_ref, _, _ = _convex_eq_qp(target, A, b)
+    x_ref, _ = prob_ref.solve(x0=np.zeros(n))
+    np.testing.assert_allclose(x, x_ref, atol=1e-7)
+
+
+def test_kkt_schur_block_negative_index_rejected():
+    prob, n, _m = _convex_eq_qp(
+        np.zeros(3), np.array([[1.0, 1.0, 1.0]]), np.array([1.0])
+    )
+    with pytest.raises(ValueError):
+        prob.set_kkt_schur_block([3, -1])
+
+
+# --------------------------------------------------------------------------
 # issue M32 — the `intermediate` callback return value must follow cyipopt
 # truthiness. A falsy return (False, 0, 0.0, []) requests a stop; truthy
 # continues. Pre-fix, the bridge used a strict `extract::<bool>().unwrap_or


### PR DESCRIPTION
Implements the three items of pounce#180: a block-triangular / Schur KKT linear solver (item 2), per-subsystem wall-clock timing breakdown (item 3), and caller-supplied fill-reducing KKT ordering (item 1).

## Summary

This PR adds structure-aware KKT solving capabilities to pounce, enabling reduced-space / variable-aggregation presolves to hand the IPM a precomputed block partition or fill-reducing permutation. The Schur-complement method (Parker, Garcia & Bent, arXiv:2602.17968) factors only the two diagonal blocks of a partitioned KKT and recovers full-system inertia a priori via Sylvester's law, beating monolithic factorization when the Schur block ≪ the eliminated block. Timing instrumentation lets callers attribute solve runtime to linear algebra (factorization vs back-solve) and per-callback function evaluations.

## Key Changes

**Item 2: Block-triangular / Schur KKT solver**
- New `FeralSchurSolver` (`crates/pounce-feral/src/schur.rs`, 725 lines) wrapping feral's proven `Solver::factor` / `solve` API to form and factor the Schur complement `S = A_SS − A_SF·A_FF⁻¹·A_FS` via `n_s` back-solves, then block-backsolve the full system. Inertia is combined a priori: `inertia(M) = inertia(A_FF) + inertia(S)`.
- New `SchurAugSystemSolver` (`crates/pounce-algorithm/src/kkt/schur_aug_system_solver.rs`) wrapping `StdAugSystemSolver` to reuse its exact KKT assembly, with transparent fallback to the standard solver when the Schur fraction exceeds `max_schur_frac` (default 0.5) or the partition is malformed.
- Extracted `configure_solver` helper (`crates/pounce-feral/src/lib.rs`) so both monolithic and per-block Schur solvers use identical configuration (pivot threshold, cascade-break, parallelism, ordering, scaling).
- Phase-0 spike artifact (`dev-notes/research/issue-180-item2-schur-spike.rs`, 415 lines) validates correctness and Sylvester inertia to machine precision; scope document (`dev-notes/research/issue-180-item2-schur-kkt-scope.md`) details the method, FERAL dependencies, and cost analysis.

**Item 3: Per-subsystem timing breakdown**
- `TimingStatistics::wall_time_breakdown()` (`crates/pounce-common/src/timing.rs`) returns ordered `(label, seconds)` pairs: overall algorithm, linear-system factorization / back-solve / total, and per-callback objective / gradient / constraints / Jacobian / Hessian eval time.
- Python `Problem.solve()` and `pounce.minimize()` expose `info["timing"]` (dict) and `info["wall_time"]` (float) so callers can attribute runtime without patching the solver — critical for reduced-space solves to measure densified-Hessian eval cost.

**Item 1: Caller-supplied KKT ordering**
- Python `Problem.set_ordering(perm)` / `get_ordering()` / `clear_ordering()` (`crates/pounce-py/src/problem.rs`) and Rust `IpoptApplication::set_external_ordering(perm)` (`crates/pounce-algorithm/src/application.rs`) install a 0-based new-to-old permutation that overrides `feral_ordering` / `POUNCE_FERAL_ORDERING`, routing it to FERAL as `OrderingMethod::External`. Persistent config (not auto-cleared after solve); FERAL validates bijection and returns `InvalidInput` on wrong length / index.

## Implementation Details

- **

https://claude.ai/code/session_01XLA2ZWpcv3paL1cVxwqpuw