### PR TITLE
Mode-aware dedup for flat Hessian eigenmodes in reaction_network

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,21 @@ changes.
   (feral#107). The enum is no longer `Copy` (the `External` arm carries a heap
   permutation); pounce clones it where a copy was previously implicit.
 
+### Fixed
+
+- **`reaction_network` mode-aware dedup on flat eigenmodes (#183).** When the
+  PES has a genuine zero (flat) Hessian eigenmode — rigid translation/rotation
+  of any molecule, or an intrinsically flat coordinate — the minima dedup
+  compared full-coordinate distance, so copies of the *same* basin displaced
+  along the flat direction counted as distinct minima and exhausted the
+  `n_states` budget before flooding reached other basins (a whole basin, and
+  its connections, silently missed). `reaction_network` now deduplicates
+  minima, saddles, and saddle→basin descent matches in the **non-null subspace**
+  of the Hessian, quotienting out any eigenmode below `eig_tol`. Reduces
+  exactly to the previous scaled-Euclidean metric when no null modes are
+  present, so well-conditioned surfaces are unaffected. `find_saddles` gains an
+  optional `distance` override for the same purpose.
+
 ## [0.7.0] - 2026-07-01
 
 ### Added — `pounce-rs` Rust facade crate (#168)

--- a/python/pounce/_critical.py
+++ b/python/pounce/_critical.py
@@ -228,13 +228,17 @@ def find_saddles(
     eig_tol: float = 1e-8,
     max_step: float = 0.2,
     local_max_iter: int = 200,
+    distance: Callable | None = None,
     seed: int | None = None,
 ) -> CriticalPointResult:
     """Find index-``index`` saddle points by multistart eigenvector following.
 
     Each start is driven to a saddle by :func:`_eigvec_follow`; results with
     the requested Morse index, a converged gradient, and within bounds are
-    de-duplicated and collected.
+    de-duplicated and collected. ``distance`` overrides the dedup metric
+    (default: per-dimension scaled Euclidean, matching :func:`find_minima`);
+    :func:`reaction_network` passes a mode-aware metric so a flat Hessian
+    direction cannot spawn duplicate saddles (pounce#183).
     """
     x0 = np.atleast_1d(np.asarray(x0, float))
     _validate_bounds_length(bounds, x0.size)
@@ -256,7 +260,7 @@ def find_saddles(
     # Dedup in the same per-dimension scaled metric find_minima uses, so a
     # single `dedup` tolerance means the same thing across routes.
     L, _ = _scale_from_bounds(bounds, n)
-    sdist = lambda a, b: float(np.linalg.norm((a - b) / L))
+    sdist = distance or (lambda a, b: float(np.linalg.norm((a - b) / L)))
 
     def in_bounds(x):
         if bounds is None:
@@ -391,8 +395,16 @@ class ReactionNetwork:
         return len(self.minima)
 
 
-def _descend(grad, x_start, minima_x, ds, max_steps, reach):
-    """Normalized steepest-descent path; stop on reaching a known minimum."""
+def _descend(grad, x_start, minima_x, ds, max_steps, reach, distance=None):
+    """Normalized steepest-descent path; stop on reaching a known minimum.
+
+    ``distance`` overrides the reach metric (default: Euclidean). The
+    reaction-network caller passes a mode-aware metric so a descent that
+    parks at a different point along a flat Hessian direction still matches
+    the minimum in that basin instead of recording an unmapped endpoint
+    (pounce#183).
+    """
+    dist = distance or (lambda a, b: float(np.linalg.norm(a - b)))
     x = np.asarray(x_start, float).copy()
     path = [x.copy()]
     for _ in range(max_steps):
@@ -403,17 +415,71 @@ def _descend(grad, x_start, minima_x, ds, max_steps, reach):
         x = x - ds * g / ng
         path.append(x.copy())
         if minima_x:
-            d = [np.linalg.norm(x - m) for m in minima_x]
+            d = [dist(x, m) for m in minima_x]
             j = int(np.argmin(d))
             if d[j] < reach:
                 path.append(np.asarray(minima_x[j], float))
                 return np.array(path), j
     if minima_x:
-        d = [np.linalg.norm(x - m) for m in minima_x]
+        d = [dist(x, m) for m in minima_x]
         j = int(np.argmin(d))
         if d[j] < reach:
             return np.array(path), j
     return np.array(path), -1
+
+
+def _mode_aware_distance(hess, eig_tol, L):
+    """Dedup metric that ignores displacement along flat (near-null) modes.
+
+    The default minima-dedup metric is full-coordinate Euclidean distance.
+    When the PES has a genuine zero eigenmode — rigid translation/rotation
+    of any molecule, or an intrinsically flat coordinate — a minimizer can
+    halt anywhere along that direction, so two coordinates that are the
+    *same* basin land arbitrarily far apart and dedup keeps them as
+    distinct minima. On a fixed ``n_states`` budget those copies crowd out
+    genuinely different basins (pounce#183).
+
+    Measuring the displacement only in the **non-null subspace** of the
+    Hessian at the already-accepted minimum ``b`` collapses zero-mode
+    copies onto one representative while leaving stiff directions
+    untouched. When every mode is stiff the projector is the identity and
+    this reduces exactly to the ordinary per-dimension scaled metric, so
+    it is a safe always-on refinement rather than a behavior change for
+    well-conditioned surfaces.
+
+    ``dedup`` (the caller's tolerance) is still interpreted in the same
+    per-dimension scaled space ``(a - b) / L``; projection only removes
+    components, so a retained-mode separation still reads the same
+    magnitude.
+    """
+    L = np.asarray(L, float)
+    # The archive only ever compares a candidate against a *stored*
+    # minimum (the second argument), and there are at most ``n_states`` of
+    # them, so caching the projector per accepted minimum keeps this to one
+    # Hessian evaluation + eigendecomposition per basin.
+    cache: dict[bytes, np.ndarray] = {}
+
+    def projector(b):
+        key = b.tobytes()
+        P = cache.get(key)
+        if P is None:
+            H = np.asarray(hess(b), float)
+            H = 0.5 * (H + H.T)
+            w, U = np.linalg.eigh(H)
+            keep = np.abs(w) > eig_tol
+            Uk = U[:, keep]
+            # Uk @ Ukᵀ projects onto the span of the stiff modes; identity
+            # when `keep` is all-True (no null modes to quotient out).
+            P = Uk @ Uk.T
+            cache[key] = P
+        return P
+
+    def distance(a, b):
+        a = np.asarray(a, float)
+        b = np.asarray(b, float)
+        return float(np.linalg.norm(projector(b) @ ((a - b) / L)))
+
+    return distance
 
 
 def reaction_network(
@@ -469,10 +535,20 @@ def reaction_network(
     ms_min = max_solves if max_solves is not None else 40 * n_states
     ms_ts = max_solves if max_solves is not None else 40 * n_transition_states
 
+    # Mode-aware dedup: quotient out flat (near-null) Hessian directions so
+    # a zero eigenmode cannot manufacture arbitrarily many "distinct" minima
+    # that exhaust the `n_states` budget before flooding reaches other basins
+    # (pounce#183). Reduces to the ordinary scaled metric when no null modes
+    # are present.
+    n_vars = np.atleast_1d(np.asarray(x0, float)).size
+    L, _ = _scale_from_bounds(bounds, n_vars)
+    mode_distance = _mode_aware_distance(hess, eig_tol, L)
+
     mres = find_minima(
         fun, x0, method=minima_method, jac=grad, hess=hess, bounds=bounds,
         n_minima=n_states, max_solves=ms_min, patience=patience,
         dedup=dedup, options=options, strategy_kw=minima_kw, seed=seed,
+        distance=mode_distance,
     )
     minima = [_critical_point(fun, grad, hess, x, eig_tol) for x in mres.minima]
     minima_x = [m.x for m in minima]
@@ -482,7 +558,8 @@ def reaction_network(
     sres = find_saddles(
         fun, x0, grad=grad, hess=hess, bounds=bounds, index=1,
         n_saddles=n_transition_states, max_solves=ms_ts,
-        patience=patience, dedup=dedup, eig_tol=eig_tol, seed=seed, **skw,
+        patience=patience, dedup=dedup, eig_tol=eig_tol,
+        distance=mode_distance, seed=seed, **skw,
     )
 
     connections: list[Connection] = []
@@ -493,7 +570,8 @@ def reaction_network(
         segs, ends = [], []
         for sgn in (+1.0, -1.0):
             seg, j = _descend(grad, p.x + connect_offset * sgn * v, minima_x,
-                              descent_step, 3000, descent_reach)
+                              descent_step, 3000, descent_reach,
+                              distance=mode_distance)
             segs.append(seg)
             ends.append(j)
         i, j = ends

--- a/python/tests/test_critical.py
+++ b/python/tests/test_critical.py
@@ -171,6 +171,48 @@ def test_reaction_network_muller_brown():
     assert net.path_between(0, hub) is not None
 
 
+def test_reaction_network_zero_eigenmode_basin():
+    """A flat (zero-eigenvalue) direction must not manufacture duplicate
+    minima that crowd out a genuine basin (pounce#183).
+
+    ``V = (x^2 - 1)^2 + 2 y^2`` is a double well in ``x``, harmonic in
+    ``y``, and *flat* in ``z`` — a genuine zero Hessian eigenmode. With
+    full-coordinate dedup, minimizers stopping at different ``z`` count as
+    distinct minima and exhaust ``n_states`` before flooding reaches the
+    ``x = -1`` well. Mode-aware dedup quotients the flat direction out, so
+    both wells are found and the ``x = 0`` saddle connects to both.
+    """
+    def V(v):
+        x, y, _z = v
+        return (x * x - 1.0) ** 2 + 2.0 * y * y
+
+    def gradV(v):
+        x, y, _z = v
+        return np.array([4.0 * x * (x * x - 1.0), 4.0 * y, 0.0])
+
+    def hessV(v):
+        x, y, _z = v
+        return np.array([[4.0 * (3.0 * x * x - 1.0), 0.0, 0.0],
+                         [0.0, 4.0, 0.0],
+                         [0.0, 0.0, 0.0]])
+
+    x0 = np.array([0.1, 0.2, 0.0])
+    net = pounce.reaction_network(
+        V, x0, grad=gradV, hess=hessV,
+        n_states=4, n_transition_states=4, seed=0,
+        options={"print_level": 0, "tol": 1e-10},
+    )
+
+    # Both wells (x = +1 and x = -1) are discovered rather than four
+    # z-shifted copies of a single well.
+    distinct_x = sorted({round(float(m.x[0])) for m in net.minima})
+    assert distinct_x == [-1, 1]
+
+    # The saddle at x = 0 descends to both wells: at least one connection is
+    # fully resolved (no unmapped -1 endpoint).
+    assert any(c.minima[0] >= 0 and c.minima[1] >= 0 for c in net.connections)
+
+
 def test_kind_labels():
     r = pounce.find_critical_points(
         fun, [0.3, 0.4], grad=grad, hess=hess, bounds=BOUNDS,


### PR DESCRIPTION
## Summary

Fixes issue #183 where flat (zero-eigenvalue) Hessian directions caused `reaction_network` to generate duplicate minima that exhausted the `n_states` budget before discovering all genuine basins. The fix introduces mode-aware deduplication that quotients out near-null eigenmodes when comparing distances between critical points.

## Changes

- **New `_mode_aware_distance()` function**: Creates a distance metric that projects displacement vectors onto the non-null subspace of the Hessian at a reference point. This allows minima displaced only along flat directions to be recognized as duplicates while preserving sensitivity to stiff directions.

- **Updated `find_saddles()`**: Added optional `distance` parameter to allow callers to override the default per-dimension scaled Euclidean metric used for deduplication.

- **Updated `_descend()`**: Added optional `distance` parameter to allow mode-aware distance comparison when matching descent endpoints to known minima, preventing unmapped endpoints when a descent parks at a different point along a flat direction.

- **Updated `reaction_network()`**: 
  - Computes mode-aware distance metric once at startup using the Hessian
  - Passes this metric to `find_minima()`, `find_saddles()`, and `_descend()` calls
  - Ensures consistent deduplication across all critical point operations

- **Added test `test_reaction_network_zero_eigenmode_basin()`**: Validates the fix with a double-well potential in x, harmonic in y, and flat in z. Confirms both wells are discovered and properly connected despite the zero eigenmode.

## Implementation Details

The mode-aware distance metric:
- Computes the Hessian eigendecomposition at the reference point (cached per minimum)
- Projects the displacement vector onto the span of stiff modes (those with eigenvalue > `eig_tol`)
- Reduces exactly to the standard scaled-Euclidean metric when no null modes exist, so well-conditioned surfaces are unaffected
- Maintains the same per-dimension scaling interpretation as the original metric

This is a safe refinement that only removes components from distance calculations, never adds them, so retained-mode separations still read the same magnitude in the scaled space.

https://claude.ai/code/session_01HMadjjkDn1qhBxPcEmLifC