### PR TITLE
Initialization tooling: docs, check-x0 preflight, WarmStart, point generation, Pyomo helpers, skill/MCP

### DIFF
--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -18,10 +18,14 @@
 //!   apply the same multiplier clamps.
 //!
 //! Wired options today: `bound_push`, `bound_frac`,
-//! `slack_bound_push`, `slack_bound_frac`, `mult_init_max`,
-//! `target_mu`. The remaining knobs (`mult_bound_push`,
-//! `entire_iterate`, `same_structure`) are stored but not yet
-//! consumed.
+//! `slack_bound_push`, `slack_bound_frac`, `mult_bound_push`,
+//! `mult_init_max`, `target_mu`. `mult_bound_push` floors the four
+//! bound-multiplier blocks (mirroring upstream's `ElementWiseMax`
+//! with `warm_start_mult_bound_push`): a user-seeded `z = 0` would
+//! otherwise start the barrier on its boundary. The remaining knobs
+//! (`entire_iterate`, `same_structure`) are parsed for Ipopt option
+//! compatibility but not yet consumed — they require the
+//! `GetWarmStartIterate` TNLP surface, which pounce does not expose.
 
 use crate::alg_builder::WarmStartOptions;
 use crate::init::default::push_x_into_interior;
@@ -84,23 +88,32 @@ impl IterateInitializer for WarmStartIterateInitializer {
             seed_from_nlp(data, nlp, &self.opts);
         }
 
-        if self.opts.mult_init_max > 0.0 {
+        if self.opts.mult_init_max > 0.0 || self.opts.mult_bound_push > 0.0 {
             // Rebuild `curr` with clamped multipliers. Components are
             // shared via `Rc` with previous solves, so we make fresh
             // copies before mutating to avoid clobbering downstream
-            // borrowers.
+            // borrowers. Bound multipliers are additionally floored at
+            // `mult_bound_push` (upstream `warm_start_mult_bound_push`):
+            // the barrier needs them strictly positive, and a carried-in
+            // 0 (e.g. an inactive bound in the previous solution) would
+            // otherwise start on the boundary.
             let mut borrow = data.borrow_mut();
             let curr = borrow.curr.as_ref().unwrap();
-            let cap = self.opts.mult_init_max;
+            let cap = if self.opts.mult_init_max > 0.0 {
+                self.opts.mult_init_max
+            } else {
+                f64::INFINITY
+            };
+            let z_floor = self.opts.mult_bound_push.max(0.0);
             let new_curr = IteratesVector::new(
                 Rc::clone(&curr.x),
                 Rc::clone(&curr.s),
                 clone_clamped(&curr.y_c, -cap, cap),
                 clone_clamped(&curr.y_d, -cap, cap),
-                clone_clamped(&curr.z_l, 0.0, cap),
-                clone_clamped(&curr.z_u, 0.0, cap),
-                clone_clamped(&curr.v_l, 0.0, cap),
-                clone_clamped(&curr.v_u, 0.0, cap),
+                clone_clamped(&curr.z_l, z_floor, cap),
+                clone_clamped(&curr.z_u, z_floor, cap),
+                clone_clamped(&curr.v_l, z_floor, cap),
+                clone_clamped(&curr.v_u, z_floor, cap),
             );
             borrow.set_curr(new_curr);
         }
@@ -280,6 +293,20 @@ mod tests {
         let out = clone_clamped(&v, 0.0, 1.0);
         assert!((out.max() - 0.5).abs() < 1e-15);
         assert!((out.min() - 0.5).abs() < 1e-15);
+    }
+
+    #[test]
+    fn mult_bound_push_floors_zero_bound_multipliers() {
+        // A carried-in z = 0 (inactive bound in the previous solution)
+        // must be floored at warm_start_mult_bound_push, matching
+        // upstream's ElementWiseMax — the barrier needs z > 0.
+        let v = dense(3, 0.0);
+        let out = clone_clamped(&v, 1e-3, 1e6);
+        assert!((out.min() - 1e-3).abs() < 1e-18);
+        // Values already above the floor pass through.
+        let v2 = dense(3, 0.7);
+        let out2 = clone_clamped(&v2, 1e-3, 1e6);
+        assert!((out2.max() - 0.7).abs() < 1e-15);
     }
 
     #[test]

--- a/crates/pounce-cli/src/check_x0.rs
+++ b/crates/pounce-cli/src/check_x0.rs
@@ -312,8 +312,7 @@ fn load_model(args: &CheckX0Args) -> Result<LoadedModel, String> {
         .nl
         .as_ref()
         .ok_or("expected a <problem.nl> argument or --builtin <name>")?;
-    let bytes =
-        std::fs::read(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let bytes = std::fs::read(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?;
     let sha = sha256::hex(&bytes);
     let prob = nl_reader::read_nl_file(path)?;
     let var_names = prob.var_names.clone();
@@ -379,8 +378,10 @@ pub fn check_tnlp(
     let x0_source = if let Some(path) = &args.x0_file {
         let text = std::fs::read_to_string(path)
             .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
-        let vals: Result<Vec<Number>, _> =
-            text.split_whitespace().map(|t| t.parse::<Number>()).collect();
+        let vals: Result<Vec<Number>, _> = text
+            .split_whitespace()
+            .map(|t| t.parse::<Number>())
+            .collect();
         let vals = vals.map_err(|e| format!("{}: bad value: {e}", path.display()))?;
         if vals.len() != n {
             return Err(format!(
@@ -418,8 +419,7 @@ pub fn check_tnlp(
 
     let mut g = vec![0.0; m];
     let g_ok = m == 0 || tnlp.eval_g(&x, false, &mut g);
-    let (g_nonfinite, g_nonfinite_count) =
-        scan_nonfinite(&g, con_names, 'c', args.max_list, g_ok);
+    let (g_nonfinite, g_nonfinite_count) = scan_nonfinite(&g, con_names, 'c', args.max_list, g_ok);
 
     // Jacobian: structure then values.
     let mut irow = vec![0i32; nnz];
@@ -434,7 +434,11 @@ pub fn check_tnlp(
                 irow: &mut irow,
                 jcol: &mut jcol,
             },
-        ) && tnlp.eval_jac_g(Some(&x), false, SparsityRequest::Values { values: &mut jval });
+        ) && tnlp.eval_jac_g(
+            Some(&x),
+            false,
+            SparsityRequest::Values { values: &mut jval },
+        );
     }
     let mut jac_nonfinite = Vec::new();
     let mut jac_nonfinite_count = 0usize;
@@ -800,7 +804,11 @@ fn print_report(o: &CheckX0Outcome) {
     if let Some(sha) = &o.nl_sha256 {
         println!("            sha256:{sha}");
     }
-    println!("  x0      : {}{}", o.x0_source, if o.x0_all_zero { "  (all zeros)" } else { "" });
+    println!(
+        "  x0      : {}{}",
+        o.x0_source,
+        if o.x0_all_zero { "  (all zeros)" } else { "" }
+    );
     println!();
 
     println!("  evaluation at x0:");
@@ -815,13 +823,14 @@ fn print_report(o: &CheckX0Outcome) {
         println!(
             "    Jacobian : {} non-finite entr{}",
             o.jac_nonfinite_count,
-            if o.jac_nonfinite_count == 1 { "y" } else { "ies" }
+            if o.jac_nonfinite_count == 1 {
+                "y"
+            } else {
+                "ies"
+            }
         );
         for e in &o.jac_nonfinite {
-            println!(
-                "        d{}/d{} = {}",
-                e.row_name, e.col_name, e.value
-            );
+            println!("        d{}/d{} = {}", e.row_name, e.col_name, e.value);
         }
     } else {
         println!("    Jacobian : finite");
@@ -912,7 +921,8 @@ fn report_json(o: &CheckX0Outcome) -> String {
             "lower": r.lo, "upper": r.hi, "violation": r.violation,
         })
     };
-    let nf = |e: &NonFinite| json!({"index": e.index, "name": e.name, "value": e.value.to_string()});
+    let nf =
+        |e: &NonFinite| json!({"index": e.index, "name": e.name, "value": e.value.to_string()});
     let report = json!({
         "pounce_check_x0_version": 1,
         "schema": "pounce.check-x0/v1",
@@ -1001,7 +1011,8 @@ mod tests {
         }
         fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
             b.x_l.copy_from_slice(&[0.0, NLP_LOWER_BOUND_INF]);
-            b.x_u.copy_from_slice(&[NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF]);
+            b.x_u
+                .copy_from_slice(&[NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF]);
             b.g_l[0] = 1.0;
             b.g_u[0] = 1.0;
             true
@@ -1086,7 +1097,10 @@ mod tests {
         assert!(o.n_on_bounds >= 1);
         assert!(o.n_clamp_moved >= 1);
         assert!((o.max_clamp_move - 1e-2).abs() < 1e-9);
-        assert!(o.warnings.iter().any(|w| w.contains("warm_start_bound_push")));
+        assert!(o
+            .warnings
+            .iter()
+            .any(|w| w.contains("warm_start_bound_push")));
     }
 
     #[test]
@@ -1120,8 +1134,7 @@ mod tests {
         );
         // Upper one-sided: hi=100 → push = 1e-2*100 = 1 → 100 → 99.
         assert!(
-            (clamp_to_interior(100.0, NLP_LOWER_BOUND_INF, 100.0, 1e-2, 1e-2) - 99.0).abs()
-                < 1e-12
+            (clamp_to_interior(100.0, NLP_LOWER_BOUND_INF, 100.0, 1e-2, 1e-2) - 99.0).abs() < 1e-12
         );
     }
 

--- a/crates/pounce-cli/src/check_x0.rs
+++ b/crates/pounce-cli/src/check_x0.rs
@@ -1,0 +1,1135 @@
+//! `pounce check-x0 <problem.nl>` — starting-point preflight.
+//!
+//! # Why this exists
+//!
+//! A local NLP solver's fate is largely decided at iteration 0, but the
+//! solver only reports starting-point trouble *after* it has tripped over
+//! it (`Invalid_Number_Detected` mid-solve, immediate restoration, a slow
+//! crawl caused by scaling). This subcommand evaluates the model once at
+//! its starting point, before any solve, and reports what the initializer
+//! and the first iteration will actually see:
+//!
+//! * **Non-finite evaluations** — NaN/inf in `f`, `∇f`, `g`, the Jacobian,
+//!   or the Hessian at x0. These are fatal: the solve would abort.
+//! * **Bound violations of x0** and components sitting exactly on a bound
+//!   (the interior clamp will move both; see below).
+//! * **Interior-clamp displacement** — the `bound_push` / `bound_frac`
+//!   clamp (`DefaultIterateInitializer`) applied to x0, so "the solver
+//!   silently moved my point" is visible up front.
+//! * **Initial constraint violation** per row (infeasibility is fine for
+//!   the IPM, but very large violations usually mean a wrong or missing
+//!   starting point).
+//! * **Derivative scale spread** — max/min nonzero magnitudes of `∇f` and
+//!   the Jacobian at x0, the early-warning signal for scaling trouble.
+//!
+//! The checks are read-only and cost one evaluation of each callback:
+//! `O(nnz)` work, no factorization, no solve.
+//!
+//! Verdict / exit code: `0` when the model evaluates cleanly at x0
+//! (warnings allowed); `21` when an evaluation produced NaN/inf (the
+//! solver would fail); `2` on a usage or I/O error.
+//!
+//! User-facing background: `docs/src/initialization.md`.
+
+use crate::nl_reader;
+use crate::verify::{box_violation, is_finite_bound, name_at, sha256, RowReport};
+use pounce_common::types::Number;
+use pounce_nlp::tnlp::{BoundsInfo, SparsityRequest, StartingPoint, TNLP};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+/// Parsed `check-x0` subcommand arguments.
+#[derive(Debug, Clone)]
+pub struct CheckX0Args {
+    /// `.nl` path, or `None` when `--builtin` is used.
+    pub nl: Option<PathBuf>,
+    /// Built-in problem name (`--builtin rosenbrock`).
+    pub builtin: Option<String>,
+    /// Optional whitespace-separated file of `n` values overriding the
+    /// model's starting point (`--x0-file`).
+    pub x0_file: Option<PathBuf>,
+    /// Violations above this are counted in `n_violated` (default 1e-6).
+    pub feas_tol: Number,
+    /// `bound_push` used for the clamp preview (default 1e-2).
+    pub bound_push: Number,
+    /// `bound_frac` used for the clamp preview (default 1e-2).
+    pub bound_frac: Number,
+    /// Max offenders listed per category (default 5).
+    pub max_list: usize,
+    /// Print the JSON report to stdout instead of the text report.
+    pub json: bool,
+    /// Also write the JSON report to this path.
+    pub json_output: Option<PathBuf>,
+}
+
+impl Default for CheckX0Args {
+    fn default() -> Self {
+        CheckX0Args {
+            nl: None,
+            builtin: None,
+            x0_file: None,
+            feas_tol: 1e-6,
+            bound_push: 1e-2,
+            bound_frac: 1e-2,
+            max_list: 5,
+            json: false,
+            json_output: None,
+        }
+    }
+}
+
+const USAGE: &str = "\
+Usage: pounce check-x0 <problem.nl> [OPTIONS]
+       pounce check-x0 --builtin <name> [OPTIONS]
+
+Evaluate the model once at its starting point, before any solve, and
+report what iteration 0 will see: NaN/inf evaluations (fatal), bound
+violations of x0, how far the bound_push interior clamp will move the
+point, initial constraint violation, and derivative scale spread.
+
+Arguments:
+  <problem.nl>           AMPL .nl problem (x0 from its initial-guess
+                         segment; zeros for variables without one)
+
+Options:
+  --builtin <name>       check a built-in problem instead of a .nl file
+  --x0-file <path>       override x0 with n whitespace-separated values
+  --feas-tol <t>         constraint-violation report threshold (default 1e-6)
+  --bound-push <v>       bound_push used for the clamp preview (default 1e-2)
+  --bound-frac <v>       bound_frac used for the clamp preview (default 1e-2)
+  --max-list <k>         max offenders listed per category (default 5)
+  --json                 print the JSON report to stdout
+  --json-output <path>   write the JSON report to <path>
+  -h, --help             print this message
+
+Exit code: 0 = model evaluates cleanly at x0 (warnings allowed),
+21 = NaN/inf at x0 (a solve would abort), 2 = usage/IO error.";
+
+/// Entry point dispatched from `main` when argv[1] == "check-x0".
+pub fn run_from_argv(rest: &[String]) -> ExitCode {
+    let args = match parse_argv(rest) {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            println!("{USAGE}");
+            return ExitCode::SUCCESS;
+        }
+        Err(msg) => {
+            eprintln!("pounce check-x0: {msg}");
+            eprintln!("{USAGE}");
+            return ExitCode::from(2);
+        }
+    };
+    run(&args)
+}
+
+fn parse_argv(rest: &[String]) -> Result<Option<CheckX0Args>, String> {
+    let mut a = CheckX0Args::default();
+    let mut positionals: Vec<PathBuf> = Vec::new();
+    let mut it = rest.iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "-h" | "--help" => return Ok(None),
+            "--builtin" => {
+                let v = it.next().ok_or("--builtin requires a value")?;
+                a.builtin = Some(v.clone());
+            }
+            "--x0-file" => {
+                let v = it.next().ok_or("--x0-file requires a value")?;
+                a.x0_file = Some(PathBuf::from(v));
+            }
+            "--feas-tol" => {
+                let v = it.next().ok_or("--feas-tol requires a value")?;
+                a.feas_tol = v.parse().map_err(|e| format!("--feas-tol: {e}"))?;
+            }
+            "--bound-push" => {
+                let v = it.next().ok_or("--bound-push requires a value")?;
+                a.bound_push = v.parse().map_err(|e| format!("--bound-push: {e}"))?;
+            }
+            "--bound-frac" => {
+                let v = it.next().ok_or("--bound-frac requires a value")?;
+                a.bound_frac = v.parse().map_err(|e| format!("--bound-frac: {e}"))?;
+            }
+            "--max-list" => {
+                let v = it.next().ok_or("--max-list requires a value")?;
+                a.max_list = v.parse().map_err(|e| format!("--max-list: {e}"))?;
+            }
+            "--json" => a.json = true,
+            "--json-output" => {
+                let v = it.next().ok_or("--json-output requires a value")?;
+                a.json_output = Some(PathBuf::from(v));
+            }
+            other if other.starts_with('-') => {
+                return Err(format!("unknown flag `{other}`"));
+            }
+            _ => positionals.push(PathBuf::from(arg)),
+        }
+    }
+    match (positionals.len(), &a.builtin) {
+        (0, Some(_)) => Ok(Some(a)),
+        (1, None) => {
+            a.nl = Some(positionals[0].clone());
+            Ok(Some(a))
+        }
+        (0, None) => Err("expected a <problem.nl> argument or --builtin <name>".to_string()),
+        _ => Err("expected exactly one of <problem.nl> or --builtin <name>".to_string()),
+    }
+}
+
+/// One non-finite evaluation entry.
+#[derive(Debug, Clone)]
+pub struct NonFinite {
+    pub index: usize,
+    pub name: String,
+    pub value: Number,
+}
+
+/// One Jacobian/Hessian non-finite entry (row/col in matrix coordinates).
+#[derive(Debug, Clone)]
+pub struct NonFiniteEntry {
+    pub row: usize,
+    pub col: usize,
+    pub row_name: String,
+    pub col_name: String,
+    pub value: Number,
+}
+
+/// One interior-clamp displacement entry.
+#[derive(Debug, Clone)]
+pub struct ClampMove {
+    pub index: usize,
+    pub name: String,
+    pub from: Number,
+    pub to: Number,
+    pub distance: Number,
+}
+
+/// Max/min-nonzero magnitude summary of a derivative array at x0.
+#[derive(Debug, Clone, Default)]
+pub struct ScaleSpread {
+    pub max_abs: Number,
+    pub min_abs_nonzero: Number,
+    /// `max_abs / min_abs_nonzero`, or 0 when there are no nonzeros.
+    pub ratio: Number,
+}
+
+/// The fully-evaluated preflight result.
+#[derive(Debug)]
+pub struct CheckX0Outcome {
+    pub n_vars: usize,
+    pub n_cons: usize,
+    pub nl_sha256: Option<String>,
+    pub source: String,
+    pub x0_source: String,
+    pub x0_all_zero: bool,
+    pub objective: Option<Number>,
+    // non-finite scans (counts are totals; lists are capped at max_list)
+    pub grad_nonfinite: Vec<NonFinite>,
+    pub grad_nonfinite_count: usize,
+    pub g_nonfinite: Vec<NonFinite>,
+    pub g_nonfinite_count: usize,
+    pub jac_nonfinite: Vec<NonFiniteEntry>,
+    pub jac_nonfinite_count: usize,
+    /// `None` when the TNLP declines exact Hessians (quasi-Newton).
+    pub hess_nonfinite_count: Option<usize>,
+    // x0 vs bounds
+    pub bound_violations: Vec<RowReport>,
+    pub n_bound_violations: usize,
+    pub max_bound_violation: Number,
+    pub n_on_bounds: usize,
+    // interior-clamp preview
+    pub clamp_moves: Vec<ClampMove>,
+    pub n_clamp_moved: usize,
+    pub max_clamp_move: Number,
+    // initial constraint violation
+    pub con_violations: Vec<RowReport>,
+    pub n_con_violations: usize,
+    pub max_con_violation: Number,
+    // derivative scale spread
+    pub grad_spread: ScaleSpread,
+    pub jac_spread: ScaleSpread,
+    // rollup
+    pub warnings: Vec<String>,
+    pub fatal: bool,
+    pub verdict: &'static str,
+}
+
+pub fn run(args: &CheckX0Args) -> ExitCode {
+    let outcome = match evaluate(args) {
+        Ok(o) => o,
+        Err(msg) => {
+            eprintln!("pounce check-x0: {msg}");
+            return ExitCode::from(2);
+        }
+    };
+
+    if args.json {
+        println!("{}", report_json(&outcome));
+    } else {
+        print_report(&outcome);
+    }
+    if let Some(path) = &args.json_output {
+        if let Err(e) = std::fs::write(path, report_json(&outcome).as_bytes()) {
+            eprintln!(
+                "pounce check-x0: failed to write report {}: {e}",
+                path.display()
+            );
+            return ExitCode::from(2);
+        }
+        if !args.json {
+            println!("  report: {}", path.display());
+        }
+    }
+
+    if outcome.fatal {
+        ExitCode::from(21)
+    } else {
+        ExitCode::SUCCESS
+    }
+}
+
+/// A model loaded for preflight: the evaluator plus its provenance.
+struct LoadedModel {
+    tnlp: std::rc::Rc<std::cell::RefCell<dyn TNLP>>,
+    var_names: Vec<String>,
+    con_names: Vec<String>,
+    nl_sha256: Option<String>,
+    source: String,
+}
+
+fn load_model(args: &CheckX0Args) -> Result<LoadedModel, String> {
+    if let Some(name) = &args.builtin {
+        let tnlp = crate::builtin::lookup(name)
+            .ok_or_else(|| format!("unknown builtin `{name}` (see `pounce --list-problems`)"))?;
+        return Ok(LoadedModel {
+            tnlp,
+            var_names: Vec::new(),
+            con_names: Vec::new(),
+            nl_sha256: None,
+            source: format!("builtin:{name}"),
+        });
+    }
+    let path = args
+        .nl
+        .as_ref()
+        .ok_or("expected a <problem.nl> argument or --builtin <name>")?;
+    let bytes =
+        std::fs::read(path).map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+    let sha = sha256::hex(&bytes);
+    let prob = nl_reader::read_nl_file(path)?;
+    let var_names = prob.var_names.clone();
+    let con_names = prob.con_names.clone();
+    let t = nl_reader::NlTnlp::try_new(prob)?;
+    Ok(LoadedModel {
+        tnlp: std::rc::Rc::new(std::cell::RefCell::new(t)),
+        var_names,
+        con_names,
+        nl_sha256: Some(sha),
+        source: path.display().to_string(),
+    })
+}
+
+fn evaluate(args: &CheckX0Args) -> Result<CheckX0Outcome, String> {
+    let model = load_model(args)?;
+    let mut tnlp = model.tnlp.borrow_mut();
+    check_tnlp(
+        &mut *tnlp,
+        &model.var_names,
+        &model.con_names,
+        model.nl_sha256.clone(),
+        model.source.clone(),
+        args,
+    )
+}
+
+/// The core preflight over any TNLP. Public so the debugger / tests can
+/// reuse it without going through a file.
+pub fn check_tnlp(
+    tnlp: &mut dyn TNLP,
+    var_names: &[String],
+    con_names: &[String],
+    nl_sha256: Option<String>,
+    source: String,
+    args: &CheckX0Args,
+) -> Result<CheckX0Outcome, String> {
+    let info = tnlp.get_nlp_info().ok_or("get_nlp_info failed")?;
+    let n = info.n.max(0) as usize;
+    let m = info.m.max(0) as usize;
+    let nnz = info.nnz_jac_g.max(0) as usize;
+    let nnz_h = info.nnz_h_lag.max(0) as usize;
+    let fortran = matches!(info.index_style, pounce_nlp::tnlp::IndexStyle::Fortran);
+    let off = if fortran { 1usize } else { 0usize };
+
+    // --- bounds ---
+    let mut x_l = vec![0.0; n];
+    let mut x_u = vec![0.0; n];
+    let mut g_l = vec![0.0; m];
+    let mut g_u = vec![0.0; m];
+    if !tnlp.get_bounds_info(BoundsInfo {
+        x_l: &mut x_l,
+        x_u: &mut x_u,
+        g_l: &mut g_l,
+        g_u: &mut g_u,
+    }) {
+        return Err("get_bounds_info failed".to_string());
+    }
+
+    // --- starting point ---
+    let mut x = vec![0.0; n];
+    let (mut zl_buf, mut zu_buf, mut lam_buf) = (vec![0.0; n], vec![0.0; n], vec![0.0; m]);
+    let x0_source = if let Some(path) = &args.x0_file {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("cannot read {}: {e}", path.display()))?;
+        let vals: Result<Vec<Number>, _> =
+            text.split_whitespace().map(|t| t.parse::<Number>()).collect();
+        let vals = vals.map_err(|e| format!("{}: bad value: {e}", path.display()))?;
+        if vals.len() != n {
+            return Err(format!(
+                "{} has {} values but the problem has {n} variables",
+                path.display(),
+                vals.len()
+            ));
+        }
+        x.copy_from_slice(&vals);
+        format!("--x0-file {}", path.display())
+    } else {
+        if !tnlp.get_starting_point(StartingPoint {
+            init_x: true,
+            x: &mut x,
+            init_z: false,
+            z_l: &mut zl_buf,
+            z_u: &mut zu_buf,
+            init_lambda: false,
+            lambda: &mut lam_buf,
+        }) {
+            return Err("get_starting_point failed".to_string());
+        }
+        "model".to_string()
+    };
+    let x0_all_zero = n > 0 && x.iter().all(|v| *v == 0.0);
+
+    // --- evaluations at x0 ---
+    let objective = tnlp.eval_f(&x, true);
+    let obj_finite = objective.map(|v| v.is_finite()).unwrap_or(false);
+
+    let mut grad_f = vec![0.0; n];
+    let grad_ok = tnlp.eval_grad_f(&x, false, &mut grad_f);
+    let (grad_nonfinite, grad_nonfinite_count) =
+        scan_nonfinite(&grad_f, var_names, 'x', args.max_list, grad_ok);
+
+    let mut g = vec![0.0; m];
+    let g_ok = m == 0 || tnlp.eval_g(&x, false, &mut g);
+    let (g_nonfinite, g_nonfinite_count) =
+        scan_nonfinite(&g, con_names, 'c', args.max_list, g_ok);
+
+    // Jacobian: structure then values.
+    let mut irow = vec![0i32; nnz];
+    let mut jcol = vec![0i32; nnz];
+    let mut jval = vec![0.0; nnz];
+    let mut jac_ok = nnz == 0;
+    if nnz > 0 {
+        jac_ok = tnlp.eval_jac_g(
+            Some(&x),
+            false,
+            SparsityRequest::Structure {
+                irow: &mut irow,
+                jcol: &mut jcol,
+            },
+        ) && tnlp.eval_jac_g(Some(&x), false, SparsityRequest::Values { values: &mut jval });
+    }
+    let mut jac_nonfinite = Vec::new();
+    let mut jac_nonfinite_count = 0usize;
+    if jac_ok {
+        for k in 0..nnz {
+            if !jval[k].is_finite() {
+                jac_nonfinite_count += 1;
+                if jac_nonfinite.len() < args.max_list {
+                    let row = (irow[k] as usize).wrapping_sub(off);
+                    let col = (jcol[k] as usize).wrapping_sub(off);
+                    jac_nonfinite.push(NonFiniteEntry {
+                        row,
+                        col,
+                        row_name: name_at(con_names, row, 'c'),
+                        col_name: name_at(var_names, col, 'x'),
+                        value: jval[k],
+                    });
+                }
+            }
+        }
+    } else if nnz > 0 {
+        jac_nonfinite_count = usize::MAX; // "evaluation itself failed"
+    }
+
+    // Hessian of the Lagrangian at (x0, lambda=0, obj_factor=1) — catches
+    // second-derivative domain errors. Optional: quasi-Newton TNLPs decline.
+    let hess_nonfinite_count = if nnz_h > 0 {
+        let mut hrow = vec![0i32; nnz_h];
+        let mut hcol = vec![0i32; nnz_h];
+        let mut hval = vec![0.0; nnz_h];
+        let lambda0 = vec![0.0; m];
+        let ok = tnlp.eval_h(
+            None,
+            false,
+            1.0,
+            None,
+            false,
+            SparsityRequest::Structure {
+                irow: &mut hrow,
+                jcol: &mut hcol,
+            },
+        ) && tnlp.eval_h(
+            Some(&x),
+            false,
+            1.0,
+            Some(&lambda0),
+            true,
+            SparsityRequest::Values { values: &mut hval },
+        );
+        if ok {
+            Some(hval.iter().filter(|v| !v.is_finite()).count())
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // --- x0 vs bounds ---
+    let mut bound_violations: Vec<RowReport> = Vec::new();
+    let mut n_bound_violations = 0usize;
+    let mut max_bound_violation = 0.0_f64;
+    let mut n_on_bounds = 0usize;
+    for j in 0..n {
+        let viol = box_violation(x[j], x_l[j], x_u[j]);
+        if viol > args.feas_tol {
+            n_bound_violations += 1;
+            max_bound_violation = max_bound_violation.max(viol);
+            push_worst(
+                &mut bound_violations,
+                RowReport {
+                    index: j,
+                    name: name_at(var_names, j, 'x'),
+                    value: x[j],
+                    lo: x_l[j],
+                    hi: x_u[j],
+                    violation: viol,
+                },
+                args.max_list,
+            );
+        }
+        if x[j].is_finite() {
+            let at_lo =
+                is_finite_bound(x_l[j]) && (x[j] - x_l[j]).abs() <= 1e-8 * (1.0 + x_l[j].abs());
+            let at_hi =
+                is_finite_bound(x_u[j]) && (x_u[j] - x[j]).abs() <= 1e-8 * (1.0 + x_u[j].abs());
+            if at_lo || at_hi {
+                n_on_bounds += 1;
+            }
+        }
+    }
+
+    // --- interior-clamp preview (DefaultIterateInitializer::push_to_interior) ---
+    let mut clamp_moves: Vec<ClampMove> = Vec::new();
+    let mut n_clamp_moved = 0usize;
+    let mut max_clamp_move = 0.0_f64;
+    for j in 0..n {
+        if !x[j].is_finite() {
+            continue;
+        }
+        let to = clamp_to_interior(x[j], x_l[j], x_u[j], args.bound_push, args.bound_frac);
+        let d = (to - x[j]).abs();
+        if d > 0.0 {
+            n_clamp_moved += 1;
+            max_clamp_move = max_clamp_move.max(d);
+            if clamp_moves.len() < args.max_list
+                || clamp_moves.last().map(|w| d > w.distance).unwrap_or(false)
+            {
+                clamp_moves.push(ClampMove {
+                    index: j,
+                    name: name_at(var_names, j, 'x'),
+                    from: x[j],
+                    to,
+                    distance: d,
+                });
+                clamp_moves.sort_by(|a, b| {
+                    b.distance
+                        .partial_cmp(&a.distance)
+                        .unwrap_or(std::cmp::Ordering::Equal)
+                });
+                clamp_moves.truncate(args.max_list);
+            }
+        }
+    }
+
+    // --- initial constraint violation ---
+    let mut con_violations: Vec<RowReport> = Vec::new();
+    let mut n_con_violations = 0usize;
+    let mut max_con_violation = 0.0_f64;
+    if g_ok {
+        for i in 0..m {
+            let viol = box_violation(g[i], g_l[i], g_u[i]);
+            if viol > args.feas_tol {
+                n_con_violations += 1;
+                if viol.is_finite() {
+                    max_con_violation = max_con_violation.max(viol);
+                }
+                push_worst(
+                    &mut con_violations,
+                    RowReport {
+                        index: i,
+                        name: name_at(con_names, i, 'c'),
+                        value: g[i],
+                        lo: g_l[i],
+                        hi: g_u[i],
+                        violation: viol,
+                    },
+                    args.max_list,
+                );
+            }
+        }
+    }
+
+    // --- derivative scale spread ---
+    let grad_spread = scale_spread(grad_f.iter().copied());
+    let jac_spread = scale_spread(jval.iter().copied());
+
+    // --- warnings + verdict ---
+    let mut warnings = Vec::new();
+    let eval_failed = !grad_ok || !g_ok || (!jac_ok && nnz > 0) || objective.is_none();
+    let nonfinite_total = grad_nonfinite_count.min(usize::MAX - 1)
+        + g_nonfinite_count.min(usize::MAX - 1)
+        + if jac_nonfinite_count == usize::MAX {
+            0
+        } else {
+            jac_nonfinite_count
+        }
+        + hess_nonfinite_count.unwrap_or(0)
+        + usize::from(!obj_finite && objective.is_some());
+    let fatal = eval_failed || nonfinite_total > 0;
+    if eval_failed {
+        warnings.push(
+            "an evaluation callback failed outright at the starting point; \
+             the solver cannot start from this x0"
+                .to_string(),
+        );
+    }
+    if nonfinite_total > 0 {
+        warnings.push(format!(
+            "{nonfinite_total} non-finite value(s) at the starting point; a solve \
+             would abort with Invalid_Number_Detected. The interior clamp only \
+             repairs bound violations, not domain errors — move x0 into the \
+             domain or add bounds that keep it there"
+        ));
+    }
+    if x0_all_zero {
+        warnings.push(
+            "the starting point is all zeros: the model supplies no initial \
+             guess (or an explicitly zero one)"
+                .to_string(),
+        );
+    }
+    if n_bound_violations > 0 {
+        warnings.push(format!(
+            "x0 violates {n_bound_violations} variable bound(s) (max {max_bound_violation:.3e}); \
+             the initializer will clamp them inside"
+        ));
+    }
+    if n_on_bounds > 0 {
+        warnings.push(format!(
+            "{n_on_bounds} component(s) of x0 sit exactly on a bound and will be \
+             pushed into the interior (bound_push={:.1e}); if x0 is a previous \
+             solution, use the warm-start recipe (warm_start_init_point=yes with \
+             tightened warm_start_bound_push/_frac)",
+            args.bound_push
+        ));
+    }
+    if max_con_violation > 1e4 {
+        warnings.push(format!(
+            "very large initial infeasibility (max constraint violation \
+             {max_con_violation:.3e}); consider a better starting point or \
+             least_square_init_primal=yes"
+        ));
+    }
+    for (label, s) in [("gradient", &grad_spread), ("Jacobian", &jac_spread)] {
+        if s.ratio > 1e8 || s.max_abs > 1e8 {
+            warnings.push(format!(
+                "{label} magnitudes at x0 span a large range (max {:.3e}, min \
+                 nonzero {:.3e}); see the scaling reference page",
+                s.max_abs, s.min_abs_nonzero
+            ));
+        }
+    }
+
+    let verdict = if fatal {
+        "FATAL"
+    } else if warnings.is_empty() {
+        "CLEAN"
+    } else {
+        "WARNINGS"
+    };
+
+    Ok(CheckX0Outcome {
+        n_vars: n,
+        n_cons: m,
+        nl_sha256,
+        source,
+        x0_source,
+        x0_all_zero,
+        objective,
+        grad_nonfinite,
+        grad_nonfinite_count,
+        g_nonfinite,
+        g_nonfinite_count,
+        jac_nonfinite,
+        jac_nonfinite_count: if jac_nonfinite_count == usize::MAX {
+            0
+        } else {
+            jac_nonfinite_count
+        },
+        hess_nonfinite_count,
+        bound_violations,
+        n_bound_violations,
+        max_bound_violation,
+        n_on_bounds,
+        clamp_moves,
+        n_clamp_moved,
+        max_clamp_move,
+        con_violations,
+        n_con_violations,
+        max_con_violation,
+        grad_spread,
+        jac_spread,
+        warnings,
+        fatal,
+        verdict,
+    })
+}
+
+/// The per-component interior clamp from
+/// `DefaultIterateInitializer::push_to_interior` (see
+/// `crates/pounce-algorithm/src/init/default.rs` and
+/// `docs/src/initialization.md`).
+pub fn clamp_to_interior(
+    x: Number,
+    lo: Number,
+    hi: Number,
+    bound_push: Number,
+    bound_frac: Number,
+) -> Number {
+    match (is_finite_bound(lo), is_finite_bound(hi)) {
+        (true, true) => {
+            let span = hi - lo;
+            let p_l = (bound_push * lo.abs().max(1.0)).min(bound_frac * span);
+            let p_u = (bound_push * hi.abs().max(1.0)).min(bound_frac * span);
+            x.max(lo + p_l).min(hi - p_u)
+        }
+        (true, false) => x.max(lo + bound_push * lo.abs().max(1.0)),
+        (false, true) => x.min(hi - bound_push * hi.abs().max(1.0)),
+        (false, false) => x,
+    }
+}
+
+fn scan_nonfinite(
+    values: &[Number],
+    names: &[String],
+    kind: char,
+    cap: usize,
+    eval_ok: bool,
+) -> (Vec<NonFinite>, usize) {
+    if !eval_ok {
+        return (Vec::new(), 0);
+    }
+    let mut out = Vec::new();
+    let mut count = 0usize;
+    for (i, v) in values.iter().enumerate() {
+        if !v.is_finite() {
+            count += 1;
+            if out.len() < cap {
+                out.push(NonFinite {
+                    index: i,
+                    name: name_at(names, i, kind),
+                    value: *v,
+                });
+            }
+        }
+    }
+    (out, count)
+}
+
+/// Keep the `cap` worst entries by violation, descending.
+fn push_worst(list: &mut Vec<RowReport>, r: RowReport, cap: usize) {
+    list.push(r);
+    list.sort_by(|a, b| {
+        b.violation
+            .partial_cmp(&a.violation)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    list.truncate(cap);
+}
+
+fn scale_spread(values: impl Iterator<Item = Number>) -> ScaleSpread {
+    let mut max_abs = 0.0_f64;
+    let mut min_abs = Number::INFINITY;
+    for v in values {
+        let a = v.abs();
+        if a.is_finite() && a > 0.0 {
+            max_abs = max_abs.max(a);
+            min_abs = min_abs.min(a);
+        }
+    }
+    if max_abs == 0.0 {
+        ScaleSpread::default()
+    } else {
+        ScaleSpread {
+            max_abs,
+            min_abs_nonzero: min_abs,
+            ratio: max_abs / min_abs,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Console + JSON rendering.
+// ---------------------------------------------------------------------------
+
+fn print_report(o: &CheckX0Outcome) {
+    println!("pounce check-x0 — starting-point preflight");
+    println!(
+        "  problem : {}  ({} vars, {} cons)",
+        o.source, o.n_vars, o.n_cons
+    );
+    if let Some(sha) = &o.nl_sha256 {
+        println!("            sha256:{sha}");
+    }
+    println!("  x0      : {}{}", o.x0_source, if o.x0_all_zero { "  (all zeros)" } else { "" });
+    println!();
+
+    println!("  evaluation at x0:");
+    match o.objective {
+        Some(v) if v.is_finite() => println!("    objective: {v:.10e}"),
+        Some(v) => println!("    objective: {v}  <- NON-FINITE"),
+        None => println!("    objective: EVALUATION FAILED"),
+    }
+    print_nonfinite("gradient", o.grad_nonfinite_count, &o.grad_nonfinite);
+    print_nonfinite("constraints", o.g_nonfinite_count, &o.g_nonfinite);
+    if o.jac_nonfinite_count > 0 {
+        println!(
+            "    Jacobian : {} non-finite entr{}",
+            o.jac_nonfinite_count,
+            if o.jac_nonfinite_count == 1 { "y" } else { "ies" }
+        );
+        for e in &o.jac_nonfinite {
+            println!(
+                "        d{}/d{} = {}",
+                e.row_name, e.col_name, e.value
+            );
+        }
+    } else {
+        println!("    Jacobian : finite");
+    }
+    match o.hess_nonfinite_count {
+        Some(0) => println!("    Hessian  : finite (lambda=0)"),
+        Some(k) => println!("    Hessian  : {k} non-finite entries (lambda=0)"),
+        None => println!("    Hessian  : not checked (quasi-Newton or declined)"),
+    }
+    println!();
+
+    println!("  x0 vs bounds:");
+    println!(
+        "    violations: {}  on-bound components: {}",
+        o.n_bound_violations, o.n_on_bounds
+    );
+    for r in &o.bound_violations {
+        println!(
+            "        {}: value {:.6e} outside [{:.6e}, {:.6e}] by {:.3e}",
+            r.name, r.value, r.lo, r.hi, r.violation
+        );
+    }
+    println!(
+        "    interior clamp moves {} component(s), max move {:.3e}",
+        o.n_clamp_moved, o.max_clamp_move
+    );
+    for c in &o.clamp_moves {
+        println!(
+            "        {}: {:.6e} -> {:.6e}  (moved {:.3e})",
+            c.name, c.from, c.to, c.distance
+        );
+    }
+    println!();
+
+    println!("  initial constraint violation:");
+    println!(
+        "    rows violated: {}  max violation: {:.3e}",
+        o.n_con_violations, o.max_con_violation
+    );
+    for r in &o.con_violations {
+        println!(
+            "        {}: g = {:.6e}, bounds [{:.6e}, {:.6e}], violation {:.3e}",
+            r.name, r.value, r.lo, r.hi, r.violation
+        );
+    }
+    println!();
+
+    println!("  derivative scale at x0:");
+    println!(
+        "    gradient: max |.| {:.3e}, min nonzero |.| {:.3e}",
+        o.grad_spread.max_abs, o.grad_spread.min_abs_nonzero
+    );
+    println!(
+        "    Jacobian: max |.| {:.3e}, min nonzero |.| {:.3e}",
+        o.jac_spread.max_abs, o.jac_spread.min_abs_nonzero
+    );
+    println!();
+
+    if !o.warnings.is_empty() {
+        println!("  warnings:");
+        for w in &o.warnings {
+            println!("    - {w}");
+        }
+        println!();
+    }
+    println!("  VERDICT: {}", o.verdict);
+}
+
+fn print_nonfinite(label: &str, count: usize, list: &[NonFinite]) {
+    if count > 0 {
+        println!(
+            "    {label:<9}: {count} non-finite entr{}",
+            if count == 1 { "y" } else { "ies" }
+        );
+        for e in list {
+            println!("        {} = {}", e.name, e.value);
+        }
+    } else {
+        println!("    {label:<9}: finite");
+    }
+}
+
+fn report_json(o: &CheckX0Outcome) -> String {
+    use serde_json::json;
+    let row = |r: &RowReport| {
+        json!({
+            "index": r.index, "name": r.name, "value": r.value,
+            "lower": r.lo, "upper": r.hi, "violation": r.violation,
+        })
+    };
+    let nf = |e: &NonFinite| json!({"index": e.index, "name": e.name, "value": e.value.to_string()});
+    let report = json!({
+        "pounce_check_x0_version": 1,
+        "schema": "pounce.check-x0/v1",
+        "solver": format!("pounce {}", env!("CARGO_PKG_VERSION")),
+        "problem": {
+            "source": o.source,
+            "sha256": o.nl_sha256,
+            "n_vars": o.n_vars,
+            "n_cons": o.n_cons,
+        },
+        "x0": { "source": o.x0_source, "all_zero": o.x0_all_zero },
+        "evaluation": {
+            "objective": o.objective.filter(|v| v.is_finite()),
+            "objective_finite": o.objective.map(|v| v.is_finite()).unwrap_or(false),
+            "grad_nonfinite_count": o.grad_nonfinite_count,
+            "grad_nonfinite": o.grad_nonfinite.iter().map(nf).collect::<Vec<_>>(),
+            "constraints_nonfinite_count": o.g_nonfinite_count,
+            "constraints_nonfinite": o.g_nonfinite.iter().map(nf).collect::<Vec<_>>(),
+            "jacobian_nonfinite_count": o.jac_nonfinite_count,
+            "jacobian_nonfinite": o.jac_nonfinite.iter().map(|e| json!({
+                "row": e.row, "col": e.col,
+                "row_name": e.row_name, "col_name": e.col_name,
+                "value": e.value.to_string(),
+            })).collect::<Vec<_>>(),
+            "hessian_nonfinite_count": o.hess_nonfinite_count,
+        },
+        "bounds": {
+            "n_violations": o.n_bound_violations,
+            "max_violation": o.max_bound_violation,
+            "n_on_bounds": o.n_on_bounds,
+            "worst": o.bound_violations.iter().map(row).collect::<Vec<_>>(),
+        },
+        "interior_clamp": {
+            "n_moved": o.n_clamp_moved,
+            "max_move": o.max_clamp_move,
+            "worst": o.clamp_moves.iter().map(|c| json!({
+                "index": c.index, "name": c.name,
+                "from": c.from, "to": c.to, "distance": c.distance,
+            })).collect::<Vec<_>>(),
+        },
+        "constraint_violation": {
+            "n_violated": o.n_con_violations,
+            "max_violation": o.max_con_violation,
+            "worst": o.con_violations.iter().map(row).collect::<Vec<_>>(),
+        },
+        "derivative_scale": {
+            "gradient": {
+                "max_abs": o.grad_spread.max_abs,
+                "min_abs_nonzero": o.grad_spread.min_abs_nonzero,
+                "ratio": o.grad_spread.ratio,
+            },
+            "jacobian": {
+                "max_abs": o.jac_spread.max_abs,
+                "min_abs_nonzero": o.jac_spread.min_abs_nonzero,
+                "ratio": o.jac_spread.ratio,
+            },
+        },
+        "warnings": o.warnings,
+        "fatal": o.fatal,
+        "verdict": o.verdict,
+    });
+    serde_json::to_string_pretty(&report).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
+    use pounce_nlp::tnlp::{IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution};
+
+    /// min 1/x0 + x1  s.t. x0 + x1 = 1, with x0 starting AT zero — the
+    /// canonical Invalid_Number_Detected trap.
+    struct DomainTrap {
+        x0: Vec<Number>,
+    }
+
+    impl TNLP for DomainTrap {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 2,
+                m: 1,
+                nnz_jac_g: 2,
+                nnz_h_lag: 0,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l.copy_from_slice(&[0.0, NLP_LOWER_BOUND_INF]);
+            b.x_u.copy_from_slice(&[NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF]);
+            b.g_l[0] = 1.0;
+            b.g_u[0] = 1.0;
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            if sp.init_x {
+                sp.x.copy_from_slice(&self.x0);
+            }
+            true
+        }
+        fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+            Some(1.0 / x[0] + x[1])
+        }
+        fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, grad_f: &mut [Number]) -> bool {
+            grad_f[0] = -1.0 / (x[0] * x[0]);
+            grad_f[1] = 1.0;
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g[0] = x[0] + x[1];
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow.copy_from_slice(&[0, 0]);
+                    jcol.copy_from_slice(&[0, 1]);
+                }
+                SparsityRequest::Values { values } => {
+                    values.copy_from_slice(&[1.0, 1.0]);
+                }
+            }
+            true
+        }
+        fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _c: &IpoptCq) {}
+    }
+
+    fn check(x0: Vec<Number>) -> CheckX0Outcome {
+        let mut t = DomainTrap { x0 };
+        check_tnlp(
+            &mut t,
+            &[],
+            &[],
+            None,
+            "test".into(),
+            &CheckX0Args::default(),
+        )
+        .expect("check")
+    }
+
+    #[test]
+    fn nan_at_x0_is_fatal() {
+        // x0[0] = 0 → f = 1/0 = inf, grad[0] = -inf.
+        let o = check(vec![0.0, 0.0]);
+        assert!(o.fatal);
+        assert_eq!(o.verdict, "FATAL");
+        assert!(o.grad_nonfinite_count >= 1);
+        assert!(o.x0_all_zero);
+    }
+
+    #[test]
+    fn clean_interior_point_passes() {
+        let o = check(vec![0.5, 0.5]);
+        assert!(!o.fatal);
+        assert_eq!(o.n_bound_violations, 0);
+        // x0 + x1 = 1 exactly: feasible.
+        assert_eq!(o.n_con_violations, 0);
+        assert_eq!(o.verdict, "CLEAN");
+        assert!((o.objective.unwrap() - 2.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn on_bound_component_is_flagged_and_clamped() {
+        // x0[0] = 1e-12 is (numerically) on its lower bound 0; the clamp
+        // moves it to ~bound_push = 1e-2 (span is infinite: one-sided).
+        let o = check(vec![1e-12, 1.0]);
+        assert!(o.n_on_bounds >= 1);
+        assert!(o.n_clamp_moved >= 1);
+        assert!((o.max_clamp_move - 1e-2).abs() < 1e-9);
+        assert!(o.warnings.iter().any(|w| w.contains("warm_start_bound_push")));
+    }
+
+    #[test]
+    fn bound_violation_reported() {
+        let o = check(vec![-3.0, 1.0]);
+        assert_eq!(o.n_bound_violations, 1);
+        assert!((o.max_bound_violation - 3.0).abs() < 1e-12);
+        // clamp brings it inside: from -3 to lo + push
+        assert!(o.n_clamp_moved >= 1);
+    }
+
+    #[test]
+    fn infeasible_start_is_not_fatal() {
+        let o = check(vec![5.0, 5.0]);
+        assert!(!o.fatal);
+        assert_eq!(o.n_con_violations, 1);
+        assert!((o.max_con_violation - 9.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn clamp_formula_matches_default_initializer() {
+        // Two-sided [1, 5], bound_push=bound_frac=1e-2:
+        // p_l = min(1e-2*1, 1e-2*4) = 0.01 → 1.0 clamps to 1.01.
+        assert!((clamp_to_interior(1.0, 1.0, 5.0, 1e-2, 1e-2) - 1.01).abs() < 1e-15);
+        // Interior stays put.
+        assert_eq!(clamp_to_interior(3.0, 1.0, 5.0, 1e-2, 1e-2), 3.0);
+        // Free variable untouched.
+        assert_eq!(
+            clamp_to_interior(-7.0, NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF, 1e-2, 1e-2),
+            -7.0
+        );
+        // Upper one-sided: hi=100 → push = 1e-2*100 = 1 → 100 → 99.
+        assert!(
+            (clamp_to_interior(100.0, NLP_LOWER_BOUND_INF, 100.0, 1e-2, 1e-2) - 99.0).abs()
+                < 1e-12
+        );
+    }
+
+    #[test]
+    fn scale_spread_ignores_zeros_and_nonfinite() {
+        let s = scale_spread(vec![0.0, 1e-6, 1e3, Number::NAN].into_iter());
+        assert!((s.max_abs - 1e3).abs() < 1e-9);
+        assert!((s.min_abs_nonzero - 1e-6).abs() < 1e-18);
+        assert!((s.ratio - 1e9).abs() / 1e9 < 1e-9);
+    }
+}

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -257,13 +257,21 @@ Options may also be supplied via the `pounce_options` environment
 variable (AMPL's `<solver>_options` convention): a whitespace-separated
 list of KEY=VALUE tokens. Command-line KEY=VALUE options override it.
 
-Subcommand:
+Subcommands:
   pounce verify <problem.nl> <claim.sol> [--feas-tol T] [--json-output P]
                             independently check that a .sol solution
                             satisfies the canonical .nl's constraints and
                             bounds, without trusting the solver/agent that
                             produced it. Exit 0 = feasible, 20 = violated.
                             Run `pounce verify --help` for details.
+  pounce check-x0 <problem.nl> [--json] [--json-output P]
+                            starting-point preflight: evaluate the model
+                            once at x0 and report NaN/inf, bound and
+                            constraint violations, interior-clamp
+                            displacement, and derivative scale spread
+                            before any solve. Exit 0 = evaluates cleanly,
+                            21 = NaN/inf at x0.
+                            Run `pounce check-x0 --help` for details.
 
 When the .nl declares the sIPOPT suffixes (sens_state_1,
 sens_state_value_1, sens_init_constr), pounce additionally runs the

--- a/crates/pounce-cli/src/lib.rs
+++ b/crates/pounce-cli/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod builtin;
 pub mod cbf;
+pub mod check_x0;
 pub mod citations;
 pub mod cli;
 pub mod counting_tnlp;

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -58,6 +58,14 @@ pub fn main() -> ExitCode {
         return pounce_cli::verify::run_from_argv(&raw_argv[2..]);
     }
 
+    // `pounce check-x0 <problem.nl>` — starting-point preflight: evaluate
+    // the model once at x0 and report NaN/inf, bound/constraint violations,
+    // interior-clamp displacement, and derivative scale spread before any
+    // solve. See `pounce_cli::check_x0` and docs/src/initialization.md.
+    if raw_argv.get(1).map(|s| s == "check-x0").unwrap_or(false) {
+        return pounce_cli::check_x0::run_from_argv(&raw_argv[2..]);
+    }
+
     let mut args = match Args::parse_argv(std::env::args().collect()) {
         Ok(a) => a,
         Err(msg) => {

--- a/crates/pounce-cli/src/verify.rs
+++ b/crates/pounce-cli/src/verify.rs
@@ -191,7 +191,7 @@ pub struct RowReport {
     pub violation: Number,
 }
 
-fn is_finite_bound(b: Number) -> bool {
+pub(crate) fn is_finite_bound(b: Number) -> bool {
     b > NLP_LOWER_BOUND_INF && b < NLP_UPPER_BOUND_INF
 }
 
@@ -202,7 +202,7 @@ fn is_finite_bound(b: Number) -> bool {
 /// through `f64::max` (which drops NaN operands) and let a fabricated `.sol`
 /// slip past the feasibility gate — the exact threat this checker defends
 /// against. An unbounded variable pinned at ±∞ is likewise not a real point.
-fn box_violation(v: Number, lo: Number, hi: Number) -> Number {
+pub(crate) fn box_violation(v: Number, lo: Number, hi: Number) -> Number {
     if !v.is_finite() {
         return Number::INFINITY;
     }
@@ -520,7 +520,7 @@ fn constraint_complementarity(
     comp
 }
 
-fn name_at(names: &[String], i: usize, kind: char) -> String {
+pub(crate) fn name_at(names: &[String], i: usize, kind: char) -> String {
     match names.get(i) {
         Some(s) if !s.is_empty() => s.clone(),
         _ => format!("{kind}[{i}]"),

--- a/crates/pounce-cli/tests/check_x0_subcommand.rs
+++ b/crates/pounce-cli/tests/check_x0_subcommand.rs
@@ -40,7 +40,12 @@ fn healthy_nl_is_clean_and_emits_schema_json() {
         .arg("--json")
         .output()
         .expect("spawn pounce check-x0");
-    assert_eq!(out.status.code(), Some(0), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let v: serde_json::Value =
         serde_json::from_slice(&out.stdout).expect("stdout is a JSON report");
     assert_eq!(v["schema"], "pounce.check-x0/v1");
@@ -60,7 +65,12 @@ fn builtin_is_supported() {
         .arg("--json")
         .output()
         .expect("spawn pounce check-x0 --builtin");
-    assert_eq!(out.status.code(), Some(0), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
     let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("JSON");
     assert_eq!(v["fatal"], false);
     assert_eq!(v["problem"]["source"], "builtin:rosenbrock");
@@ -97,7 +107,11 @@ fn x0_file_overrides_start_and_infeasibility_is_not_fatal() {
         .status()
         .expect("spawn")
         .code();
-    assert_eq!(code, Some(0), "an infeasible-but-evaluable start is not fatal");
+    assert_eq!(
+        code,
+        Some(0),
+        "an infeasible-but-evaluable start is not fatal"
+    );
     let v: serde_json::Value =
         serde_json::from_slice(&std::fs::read(&report).unwrap()).expect("JSON");
     assert_eq!(v["fatal"], false);

--- a/crates/pounce-cli/tests/check_x0_subcommand.rs
+++ b/crates/pounce-cli/tests/check_x0_subcommand.rs
@@ -1,0 +1,110 @@
+//! End-to-end integration test for the `pounce check-x0` subcommand.
+//!
+//! Drives the real binary against committed fixtures and checks the
+//! contract:
+//!
+//! * a healthy `.nl` (`parametric.nl`) evaluates cleanly → exit 0, JSON
+//!   report with `"fatal": false` and the documented schema fields;
+//! * a builtin (`rosenbrock`) works through `--builtin` → exit 0;
+//! * `--x0-file` with the wrong length → usage error, exit 2;
+//! * `--x0-file` overriding the start is honored (a wildly infeasible
+//!   point raises the reported constraint violation but stays exit 0 —
+//!   infeasibility is not fatal, only non-evaluability is).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture_nl() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("parametric.nl");
+    p
+}
+
+fn tmp(suffix: &str) -> PathBuf {
+    let mut p = std::env::temp_dir();
+    p.push(format!("pounce_check_x0_{}_{suffix}", std::process::id()));
+    p
+}
+
+#[test]
+fn healthy_nl_is_clean_and_emits_schema_json() {
+    let out = Command::new(pounce_exe())
+        .arg("check-x0")
+        .arg(fixture_nl())
+        .arg("--json")
+        .output()
+        .expect("spawn pounce check-x0");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("stdout is a JSON report");
+    assert_eq!(v["schema"], "pounce.check-x0/v1");
+    assert_eq!(v["fatal"], false);
+    assert_eq!(v["problem"]["n_vars"], 5);
+    assert_eq!(v["problem"]["n_cons"], 4);
+    assert!(v["evaluation"]["objective_finite"].as_bool().unwrap());
+    assert!(v["problem"]["sha256"].as_str().is_some());
+}
+
+#[test]
+fn builtin_is_supported() {
+    let out = Command::new(pounce_exe())
+        .arg("check-x0")
+        .arg("--builtin")
+        .arg("rosenbrock")
+        .arg("--json")
+        .output()
+        .expect("spawn pounce check-x0 --builtin");
+    assert_eq!(out.status.code(), Some(0), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let v: serde_json::Value = serde_json::from_slice(&out.stdout).expect("JSON");
+    assert_eq!(v["fatal"], false);
+    assert_eq!(v["problem"]["source"], "builtin:rosenbrock");
+}
+
+#[test]
+fn x0_file_wrong_length_is_usage_error() {
+    let bad = tmp("short_x0.txt");
+    std::fs::write(&bad, "1.0 2.0").unwrap(); // parametric.nl has 5 vars
+    let code = Command::new(pounce_exe())
+        .arg("check-x0")
+        .arg(fixture_nl())
+        .arg("--x0-file")
+        .arg(&bad)
+        .status()
+        .expect("spawn")
+        .code();
+    assert_eq!(code, Some(2));
+    let _ = std::fs::remove_file(&bad);
+}
+
+#[test]
+fn x0_file_overrides_start_and_infeasibility_is_not_fatal() {
+    let far = tmp("far_x0.txt");
+    std::fs::write(&far, "1e6 1e6 1e6 1e6 1e6").unwrap();
+    let report = tmp("far_report.json");
+    let code = Command::new(pounce_exe())
+        .arg("check-x0")
+        .arg(fixture_nl())
+        .arg("--x0-file")
+        .arg(&far)
+        .arg("--json-output")
+        .arg(&report)
+        .status()
+        .expect("spawn")
+        .code();
+    assert_eq!(code, Some(0), "an infeasible-but-evaluable start is not fatal");
+    let v: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).expect("JSON");
+    assert_eq!(v["fatal"], false);
+    assert!(v["x0"]["source"].as_str().unwrap().contains("far_x0.txt"));
+    // A point at 1e6 in every coordinate must violate something in a
+    // 5-var/4-con parametric model with finite constraint bounds.
+    assert!(v["constraint_violation"]["max_violation"].as_f64().unwrap() > 1.0);
+    let _ = std::fs::remove_file(&far);
+    let _ = std::fs::remove_file(&report);
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -43,6 +43,7 @@
 # Reference
 
 - [Algorithm & Workspace](algorithm.md)
+- [Initialization and Warm Starts](initialization.md)
 - [Active-Set SQP & Warm Starts](active-set-sqp.md)
   - [Design Note](active-set-sqp-warm-start.md)
 - [Scaling](scaling.md)

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -1,0 +1,221 @@
+# Initialization and Warm Starts
+
+POUNCE is a local NLP solver: every solve starts from a point, and that
+point often decides whether the solve takes 15 iterations or 150, or
+whether it converges at all. This page collects the initialization
+story in one place: where the starting point comes from on each
+frontend, what the solver does with it (the part that surprises
+people), how to warm-start each algorithm path, and how to diagnose a
+bad start. The per-algorithm details live in their own pages; this is
+the map.
+
+## Where the starting point comes from
+
+| Frontend | Primal starting point |
+|---|---|
+| Python `Problem.solve(x0=...)` | the `x0` argument |
+| Python `minimize(fun, x0, ...)` | the `x0` argument |
+| CLI / AMPL | the `.nl` file's initial-guess segment; zeros for variables without one |
+| Pyomo | each `Var`'s `.value`, serialized into the `.nl` by Pyomo's writer |
+| GAMS | variable levels (`x.L`) via GMO |
+| Rust | `Nlp::new(problem).x0(&[...])`, or `TNLP::get_starting_point` |
+
+Two silent-zero traps hide in that table:
+
+* **Pyomo:** a `Var` whose `.value` was never set is written as `0`
+  in the `.nl` file. A model initialized "nowhere" is actually
+  initialized at the origin, which for many process models is outside
+  every variable's meaningful range (and a domain error for `log`,
+  `/`, and friends).
+* **GAMS:** levels default to `0` unless assigned. Set `x.L` before
+  the `solve` statement.
+
+Dual estimates can be seeded too: `Problem.solve` accepts
+`lagrange=`, `zl=`, `zu=` keyword arguments, and the `.nl` format
+carries constraint-dual guesses when the modeling layer writes them.
+Dual seeds are ignored unless you opt into a warm start (below). The
+scipy-style `minimize` facade does not expose dual seeding; use
+`pounce.Problem` directly when you need it.
+
+## What the solver does with your point (cold start)
+
+The default interior-point path ports Ipopt's iterate initializer
+(`crates/pounce-algorithm/src/init/default.rs`). The sequence:
+
+1. **The primal point is pushed into the interior of the bounds.**
+   Per component, with bounds `lo <= x <= hi`:
+   `p_l = min(bound_push * max(|lo|, 1), bound_frac * (hi - lo))`,
+   likewise `p_u`, and `x` is clamped into `[lo + p_l, hi - p_u]`.
+   One-sided bounds use the `bound_push` term alone; free variables
+   are untouched. With the defaults (`bound_push = bound_frac =
+   1e-2`), a variable sitting exactly on its lower bound `1.0` starts
+   at `1.01` instead. Your point is honored *approximately*, and the
+   deliberately-at-a-bound part of it is not honored at all. This is
+   the single most common reason a "perfect" starting point does not
+   behave like one.
+2. **Slacks** are set to `s = d(x)` and pushed into the slack bounds
+   the same way.
+3. **Duals** get fixed defaults: constraint multipliers `y = 0` (or a
+   least-square estimate, see `bound_mult_init_method` below) and
+   bound multipliers `z = v = bound_mult_init_val = 1.0`.
+4. **The barrier parameter** starts at `mu_init = 0.1` (monotone
+   `mu_strategy`, the default) regardless of how good your point is.
+
+The knobs, all Ipopt-compatible:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `bound_push` | `1e-2` | Absolute push off each bound (relative to `max(|bound|, 1)`). |
+| `bound_frac` | `1e-2` | Cap on the push as a fraction of the bound interval. |
+| `slack_bound_push` / `slack_bound_frac` | `1e-2` | Same, for inequality slacks. |
+| `bound_mult_init_val` | `1.0` | Initial bound-multiplier value. |
+| `bound_mult_init_method` | `constant` | `constant` / `mu-based` / `least-square`. |
+| `constr_mult_init_max` | `1e3` | Cap on the least-square constraint-multiplier estimate; `0` keeps `y = 0`. |
+| `least_square_init_primal` | `no` | Replace the starting `x` with the min-norm solution of the linearized constraints before the interior push. |
+| `mu_init` | `0.1` | Initial barrier parameter (monotone strategy). |
+| `start_with_resto` | `no` | Jump straight into feasibility restoration at iteration 1 (aborts if the start is already feasible). |
+
+An *infeasible* starting point is fine: the IPM does not require
+feasibility, and `least_square_init_primal=yes` can cheaply reduce
+iteration-0 infeasibility on mostly-linear models (the
+`mehrotra_algorithm` LP/QP cascade turns it on for you, along with
+more aggressive `bound_push` / `bound_frac` / `bound_mult_init_val`).
+A point where a function *fails to evaluate* is not fine; see
+[Diagnosing a bad start](#diagnosing-a-bad-start).
+
+## Warm-starting the interior-point path
+
+Passing a previous solution as `x0` is **not** a warm start by
+itself. The IPM warm start is a package of three things, and skipping
+any one of them silently degrades to (roughly) a cold solve:
+
+1. **Opt in and seed the duals.** Set `warm_start_init_point=yes` and
+   pass the previous multipliers.
+2. **Lower `mu_init`.** The default `0.1` makes the solver walk the
+   barrier schedule down from scratch even when started at the
+   optimum. Seed it near the converged complementarity (e.g. `1e-7`
+   after a `tol=1e-8` solve).
+3. **Tighten the warm-start pushes.** The warm initializer applies
+   its own interior clamp with `warm_start_bound_push` / `_frac`
+   (default `1e-3`), which shoves an at-the-bound solution back off
+   its bounds. Tighten them to keep the point.
+
+```python
+x, info = make_problem().solve(x0=x0_cold)      # cold solve
+
+warm = make_problem()
+warm.add_option("warm_start_init_point", "yes")
+warm.add_option("mu_init", 1e-7)
+for k in ("warm_start_bound_push", "warm_start_bound_frac",
+          "warm_start_slack_bound_push", "warm_start_slack_bound_frac",
+          "warm_start_mult_bound_push"):
+    warm.add_option(k, 1e-9)
+
+x2, info2 = warm.solve(
+    x0=x,
+    lagrange=np.asarray(info["mult_g"]),
+    zl=np.asarray(info["mult_x_L"]),
+    zu=np.asarray(info["mult_x_U"]),
+)
+```
+
+On HS071 this takes the re-solve from 11 iterations to 5, while
+`warm_start_init_point=yes` alone saves nothing; the full runnable
+comparison is `python/examples/hs071_warm_start.py`. On the CLI the
+same options apply as `KEY=VALUE` pairs, with dual seeds coming from
+the `.nl` file's dual segment when present.
+
+| Option | Default | Meaning |
+|---|---|---|
+| `warm_start_init_point` | `no` | Master switch: honor supplied primal *and* dual seeds. |
+| `warm_start_bound_push` / `warm_start_bound_frac` | `1e-3` | Interior clamp used instead of `bound_push` / `bound_frac`. |
+| `warm_start_slack_bound_push` / `warm_start_slack_bound_frac` | `1e-3` | Same, for slacks. |
+| `warm_start_mult_bound_push` | `1e-3` | Same, for bound multipliers. |
+| `warm_start_mult_init_max` | `1e6` | Cap on seeded equality multipliers. |
+
+Even a well-executed IPM warm start has a structural limit: the
+barrier pushes iterates off the bounds, so the active-set information
+in a converged solution cannot be fully exploited. When you are
+solving a *sequence* of related NLPs (MPC steps, branch-and-bound
+nodes, homotopy paths), that limit is the reason the active-set SQP
+path exists.
+
+## Warm-starting the active-set SQP path
+
+With `algorithm=active-set-sqp`, the warm-start payload is different:
+alongside the primal/dual seeds it carries the **working set** (which
+bounds and constraints are active), and an unchanged working set means
+the next solve converges in a handful of QP iterations.
+
+```python
+prob.add_option("algorithm", "active-set-sqp")
+
+ws = None
+for k in range(horizon_steps):
+    x, info = prob.solve(x0=x_prev, working_set=ws)
+    ws = info["working_set"]
+    x_prev = x
+```
+
+The two paths' warm-start inputs are deliberately path-local: the
+IPM-side options above (`warm_start_init_point`, `mu_init`,
+`bound_push`, ...) are silently ignored on the SQP path, and
+`working_set=` is ignored on the IPM path. Details, the
+`classify_working_set` helper for reconstructing a working set from
+multipliers, and the GAMS `sqp_state_file` / marginal-based routes are
+in [Active-Set SQP & Warm Starts](active-set-sqp.md). Note the GAMS
+warm-start features currently live in the native C link only, not the
+pip link (see [GAMS](gams.md)).
+
+## Sequences of solves: batch chaining and sessions
+
+For MPC chains, parametric sweeps, and B&B node relaxations from
+Python, `solve_nlp_batch` packages the whole IPM warm-start recipe
+for you:
+
+```python
+results = pounce.solve_nlp_batch(batch_t)                   # cold
+results = pounce.solve_nlp_batch(batch_t1, warms=results)   # warm
+```
+
+Each instance is seeded with the previous primal and duals, the
+converged `mu` is threaded into `mu_init`, and
+`warm_start_init_point=yes` is forced; see
+[Batched NLP solving](python.md#batched-nlp-solving-solve_nlp_batch).
+For post-solve sensitivity queries against the converged KKT factor
+(a different kind of reuse, no re-solve at all), see
+[Sessions](sessions.md). JAX users get warm-start hand-off along a
+parameter trajectory via `JaxProblem`; see
+[the Python guide](python.md).
+
+## Diagnosing a bad start
+
+* **`Invalid_Number_Detected`** means an evaluator returned NaN/inf,
+  and the very first evaluation at the starting point is the usual
+  culprit (`log(0)` or a division at an all-zeros default start).
+  The interior clamp only repairs bound violations; it cannot fix
+  domain errors on free variables. Move the start into the domain,
+  or add bounds that keep the clamp inside it.
+* **`derivative_test=first-order`** runs the derivative checker at
+  the starting point; wrong derivatives look exactly like a bad
+  start (immediate restoration, tiny steps).
+* **The [interactive debugger](debugger.md)** (`--debug`) breaks at
+  iteration 0, so you can inspect the initial objective, `inf_pr`,
+  and `inf_du` before a single step is taken, and `resolve` from an
+  edited iterate.
+* **Presolve** (`presolve=yes`) reports structural trouble that no
+  starting point can fix, like rank-deficient equality blocks
+  (LICQ check), and its bound tightening shrinks the box the
+  interior clamp places you in. See
+  [Troubleshooting Recipes](troubleshooting.md) and [FBBT](fbbt.md).
+* **`pounce-studio analyze-nl`** gives a structural pre-flight of a
+  model file without solving.
+
+## No good starting point at all?
+
+When the model has many local minima, or every start you try lands in
+the wrong basin, stop hand-tuning single points: the
+[global search drivers](find-minima.md) (`multistart`, `mlsl`,
+`deflation`, `flooding`, `tunneling`, `basinhopping`) manage
+populations of starting points and warm-start bookkeeping for you,
+from Python (`pounce.find_minima`) or the CLI (`--minima`).

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -190,6 +190,25 @@ parameter trajectory via `JaxProblem`; see
 
 ## Diagnosing a bad start
 
+The first stop is the preflight check, which evaluates the model once
+at its starting point (no solve) and reports everything this page has
+warned about: NaN/inf evaluations, bound violations, how far the
+interior clamp will move the point, initial constraint violation, and
+derivative scale spread.
+
+```sh
+pounce check-x0 model.nl              # text report; --json for tools
+pounce check-x0 model.nl --x0-file candidate.txt
+```
+
+```python
+report = pounce.preflight(problem_obj, x0, lb=lb, ub=ub, cl=cl, cu=cu)
+print(report)          # report.fatal, report.warnings, report.to_dict()
+```
+
+Exit code 0 means the model evaluates cleanly at x0 (warnings allowed);
+21 means a solve from this point would abort. The other diagnostics:
+
 * **`Invalid_Number_Detected`** means an evaluator returned NaN/inf,
   and the very first evaluation at the starting point is the usual
   culprit (`log(0)` or a division at an all-zeros default start).

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -247,8 +247,27 @@ Exit code 0 means the model evaluates cleanly at x0 (warnings allowed);
 
 ## No good starting point at all?
 
-When the model has many local minima, or every start you try lands in
-the wrong basin, stop hand-tuning single points: the
+Three composable primitives cover the "generate or repair a point"
+workflows from Python:
+
+```python
+# N diverse starts (the sampler behind find_minima): sobol / uniform /
+# jitter / bounds midpoint. Feed them to solve_nlp_batch or race them.
+starts = pounce.generate_starts(16, bounds=bounds, seed=0)
+
+# Min-norm repair of a candidate onto the linearized constraints +
+# bounds (the standalone form of least_square_init_primal).
+x0 = pounce.project_to_feasible(problem_obj, x0, lb=lb, ub=ub, cl=cl, cu=cu)
+
+# Cheap tournament: a few iterations from each start, ranked; continue
+# the winner at full effort with a WarmStart.
+best = pounce.race_starts(fun, starts, bounds=bounds, iters=10)[0]
+res = pounce.minimize(fun, best.x,
+                      warm_start=pounce.WarmStart.from_info(best.x, best.info))
+```
+
+When the model has many local minima and you want *all* of them (or a
+managed search rather than a tournament), the
 [global search drivers](find-minima.md) (`multistart`, `mlsl`,
 `deflation`, `flooding`, `tunneling`, `basinhopping`) manage
 populations of starting points and warm-start bookkeeping for you,

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -85,6 +85,21 @@ A point where a function *fails to evaluate* is not fine; see
 
 ## Warm-starting the interior-point path
 
+From Python, the packaged form is one object:
+
+```python
+x, info = prob.solve(x0=x0)                  # cold solve
+ws = pounce.WarmStart.from_info(x, info)     # captures x, duals, mu
+x2, info2 = prob.solve(warm_start=ws)        # warm re-solve
+ws.save("state.npz")                         # reuse across processes
+```
+
+`warm_start=` is accepted by `Problem.solve` and `pounce.minimize`,
+seeds the primal and dual iterates, applies the enabling options
+below, and forwards the SQP working set when the state was captured
+from that path. The rest of this section is what it does under the
+hood (and the only route from the CLI or an options file).
+
 Passing a previous solution as `x0` is **not** a warm start by
 itself. The IPM warm start is a package of three things, and skipping
 any one of them silently degrades to (roughly) a cold solve:
@@ -130,7 +145,7 @@ the `.nl` file's dual segment when present.
 | `warm_start_init_point` | `no` | Master switch: honor supplied primal *and* dual seeds. |
 | `warm_start_bound_push` / `warm_start_bound_frac` | `1e-3` | Interior clamp used instead of `bound_push` / `bound_frac`. |
 | `warm_start_slack_bound_push` / `warm_start_slack_bound_frac` | `1e-3` | Same, for slacks. |
-| `warm_start_mult_bound_push` | `1e-3` | Same, for bound multipliers. |
+| `warm_start_mult_bound_push` | `1e-3` | Floor on seeded bound multipliers (a carried-in `z = 0` must not start on the barrier's boundary). |
 | `warm_start_mult_init_max` | `1e6` | Cap on seeded equality multipliers. |
 
 Even a well-executed IPM warm start has a structural limit: the

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -34,7 +34,8 @@ file. See [Running Solves](cli.md) for the `-AMPL` solver mode.
 A `Var` whose `.value` was never set is written as **0** into the
 `.nl` file, so an uninitialized model actually starts at the origin
 (see [Initialization and Warm Starts](initialization.md)). The package
-ships three helpers for exactly this:
+ships a preflight check plus an initialization pipeline for exactly
+this:
 
 ```python
 import pyomo_pounce
@@ -44,14 +45,10 @@ print(report)                            # unset vars, bound/constraint
 if report.fatal:                         # violations, NaN/inf evaluations
     ...
 
-pyomo_pounce.initialize_missing_values(model)   # bounds-aware fill
-                                                # (midpoint / one unit
-                                                # inside / zero)
-
-rep = pyomo_pounce.block_initialize(model)      # experimental: solve the
-                                                # equality system's square
-                                                # blocks in DM order and
-                                                # write the values back
+# fill -> repair -> block-solve, with the decisions held constant:
+rep = pyomo_pounce.initialize(model, decisions=[m.feed, m.reflux])
+if not rep.block.square:
+    print(rep)          # names of what you forgot to specify
 ```
 
 `preflight` evaluates every active constraint and the objective at the
@@ -60,12 +57,44 @@ writer sends), restores the model untouched, and reports what
 iteration 0 will see; `report.fatal` means the solve would abort with
 `Invalid_Number_Detected`.
 
-`block_initialize` is IDAES-flavored initialization without hand-written
-routines: it takes the active equality constraints, finds the square
-part of the incidence graph (Dulmage-Mendelsohn, via
-`pyomo.contrib.incidence_analysis`), and solves the diagonal blocks in
-topological order — 1x1 blocks by Newton, larger blocks as square
-subsystem solves with POUNCE — filling `Var.value` along the way.
-Variables in the under- or over-determined parts are left untouched;
-follow with `initialize_missing_values` to fill the remainder. Fix a
-variable to treat it as a known input.
+`initialize` follows the workflow you would run by hand on, say, a
+distillation column: set the decisions (feed, reflux, boilup), solve
+for a physical profile with them held constant, then let the optimizer
+move them. Its three stages are also available individually:
+
+```python
+pyomo_pounce.initialize_missing_values(model)   # bounds-aware fill
+                                                # (midpoint / one unit
+                                                # inside / zero)
+
+pyomo_pounce.project_to_feasible(model)         # min-norm repair: move the
+                                                # current point onto the
+                                                # model's own constraints
+                                                # (one POUNCE solve)
+
+rep = pyomo_pounce.block_initialize(            # solve the equality
+    model, decisions=[m.feed, m.reflux])        # system's square blocks
+                                                # in calculation order
+```
+
+`initialize_missing_values` fills each variable independently, so the
+fill can be internally inconsistent (mole fractions that do not sum to
+one); `project_to_feasible` repairs that by minimizing
+`sum((v - v0)**2)` subject to the model's active constraints and
+bounds — the full nonlinear projection, solved with POUNCE, with the
+original objective restored afterwards.
+
+`block_initialize` is IDAES-flavored initialization without
+hand-written routines. `decisions=` holds the listed variables at
+their current values for the solve and releases them afterwards (each
+must have a value). The active equality constraints are decomposed
+(Dulmage-Mendelsohn, via `pyomo.contrib.incidence_analysis`); the
+square part is solved block by block in topological order by Pyomo's
+`solve_strongly_connected_components` (1x1 blocks by Newton, larger
+blocks by POUNCE), filling `Var.value` along the way. When the system
+is **not** square, `report.square` is False and the offending
+variables and constraints are reported **by name** —
+`underconstrained_variables` is the list of things you forgot to
+specify or flag as decisions, `overconstrained_constraints` the
+redundant or conflicting specifications. Permanently-known inputs can
+simply be `fix()`ed instead of listed as decisions.

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -28,3 +28,44 @@ solver.solve(model, options={'tol': 1e-10, 'max_iter': 500})
 Under the hood, Pyomo writes the model to an AMPL `.nl` file, invokes
 `pounce problem.nl -AMPL`, and reads the result back from the `.sol`
 file. See [Running Solves](cli.md) for the `-AMPL` solver mode.
+
+## Preflight and initialization
+
+A `Var` whose `.value` was never set is written as **0** into the
+`.nl` file, so an uninitialized model actually starts at the origin
+(see [Initialization and Warm Starts](initialization.md)). The package
+ships three helpers for exactly this:
+
+```python
+import pyomo_pounce
+
+report = pyomo_pounce.preflight(model)   # what will POUNCE see at x0?
+print(report)                            # unset vars, bound/constraint
+if report.fatal:                         # violations, NaN/inf evaluations
+    ...
+
+pyomo_pounce.initialize_missing_values(model)   # bounds-aware fill
+                                                # (midpoint / one unit
+                                                # inside / zero)
+
+rep = pyomo_pounce.block_initialize(model)      # experimental: solve the
+                                                # equality system's square
+                                                # blocks in DM order and
+                                                # write the values back
+```
+
+`preflight` evaluates every active constraint and the objective at the
+current values with unset values treated as 0 (exactly what the NL
+writer sends), restores the model untouched, and reports what
+iteration 0 will see; `report.fatal` means the solve would abort with
+`Invalid_Number_Detected`.
+
+`block_initialize` is IDAES-flavored initialization without hand-written
+routines: it takes the active equality constraints, finds the square
+part of the incidence graph (Dulmage-Mendelsohn, via
+`pyomo.contrib.incidence_analysis`), and solves the diagonal blocks in
+topological order — 1x1 blocks by Newton, larger blocks as square
+subsystem solves with POUNCE — filling `Var.value` along the way.
+Variables in the under- or over-determined parts are left untouched;
+follow with `initialize_missing_values` to fill the remainder. Fix a
+variable to treat it as a known input.

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -4,7 +4,25 @@ Usage:
     import pyomo_pounce  # registers 'pounce' with SolverFactory
     from pyomo.environ import *
     solver = SolverFactory('pounce')
-"""
-from pyomo_pounce.pounce_solver import POUNCE
 
-__all__ = ["POUNCE"]
+Initialization helpers (see the POUNCE docs' initialization chapter):
+    report = pyomo_pounce.preflight(model)         # starting-point check
+    pyomo_pounce.initialize_missing_values(model)  # fill unset Var values
+    pyomo_pounce.block_initialize(model)           # experimental DM-ordered init
+"""
+from pyomo_pounce.block_init import BlockInitReport, block_initialize
+from pyomo_pounce.pounce_solver import POUNCE
+from pyomo_pounce.preflight import (
+    PyomoPreflightReport,
+    initialize_missing_values,
+    preflight,
+)
+
+__all__ = [
+    "POUNCE",
+    "preflight",
+    "PyomoPreflightReport",
+    "initialize_missing_values",
+    "block_initialize",
+    "BlockInitReport",
+]

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -7,8 +7,11 @@ Usage:
 
 Initialization helpers (see the POUNCE docs' initialization chapter):
     report = pyomo_pounce.preflight(model)         # starting-point check
+    pyomo_pounce.initialize(model, decisions=[...])  # fill -> repair -> block-solve
+    # ... or the individual stages:
     pyomo_pounce.initialize_missing_values(model)  # fill unset Var values
-    pyomo_pounce.block_initialize(model)           # experimental DM-ordered init
+    pyomo_pounce.project_to_feasible(model)        # min-norm repair onto constraints
+    pyomo_pounce.block_initialize(model, decisions=[...])  # DM-ordered equality solve
 """
 from pyomo_pounce.block_init import BlockInitReport, block_initialize
 from pyomo_pounce.pounce_solver import POUNCE
@@ -17,12 +20,16 @@ from pyomo_pounce.preflight import (
     initialize_missing_values,
     preflight,
 )
+from pyomo_pounce.repair import InitializeReport, initialize, project_to_feasible
 
 __all__ = [
     "POUNCE",
     "preflight",
     "PyomoPreflightReport",
     "initialize_missing_values",
+    "project_to_feasible",
+    "initialize",
+    "InitializeReport",
     "block_initialize",
     "BlockInitReport",
 ]

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -89,11 +89,16 @@ def block_initialize(
     import pyomo.environ as pyo
 
     try:
+        # Probe networkx explicitly: pyomo defers its optional imports, so
+        # `pyomo.contrib.incidence_analysis` imports fine without it and
+        # would only blow up (DeferredImportError) at first use.
+        import networkx  # noqa: F401
+
         from pyomo.contrib.incidence_analysis import IncidenceGraphInterface
     except ImportError as e:  # pragma: no cover - environment-dependent
         raise ImportError(
             "block_initialize requires pyomo.contrib.incidence_analysis "
-            "(pip install networkx scipy)"
+            "and its optional dependencies (pip install networkx scipy)"
         ) from e
     from pyomo.util.calc_var_value import calculate_variable_from_constraint
     from pyomo.util.subsystems import TemporarySubsystemManager, create_subsystem_block

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -1,0 +1,183 @@
+"""Block-sequential initialization for Pyomo models (experimental).
+
+IDAES-style initialization without hand-written initialization routines:
+take the model's active **equality** constraints, find the square
+(well-determined) part of the variable/constraint incidence graph, order
+it into diagonal blocks (Dulmage-Mendelsohn / block triangularization,
+via ``pyomo.contrib.incidence_analysis``), and solve the blocks in
+topological order, writing each block's solution into ``Var.value``.
+1x1 blocks are solved with Pyomo's Newton one-liner
+(``calculate_variable_from_constraint``); larger blocks become square
+subsystem solves with POUNCE.
+
+The result is a starting point that satisfies the model's sequential
+"calculation order" structure — usually a dramatically better start
+than zeros for flowsheet-shaped models.
+
+**Experimental.** The API and semantics may change; in particular:
+variables in the square subsystem are (re)computed in place, using any
+existing values as Newton starting guesses. Variables in the under- or
+over-determined parts (degrees of freedom, redundant specifications)
+are left untouched — pair with
+:func:`pyomo_pounce.initialize_missing_values` to fill the remainder.
+
+Requires ``pyomo.contrib.incidence_analysis`` (needs ``networkx`` and
+``scipy``); raises ``ImportError`` with instructions otherwise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+__all__ = ["block_initialize", "BlockInitReport"]
+
+
+@dataclass
+class BlockInitReport:
+    """What :func:`block_initialize` did."""
+
+    n_blocks: int = 0
+    n_1x1: int = 0
+    n_subsystem_solves: int = 0
+    n_vars_initialized: int = 0
+    skipped_underdetermined: int = 0
+    skipped_overdetermined: int = 0
+    failures: List[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.failures
+
+    def __str__(self) -> str:
+        lines = [
+            "pyomo-pounce block_initialize",
+            f"  blocks solved     : {self.n_blocks} "
+            f"({self.n_1x1} by Newton 1x1, {self.n_subsystem_solves} subsystem solves)",
+            f"  vars initialized  : {self.n_vars_initialized}",
+            f"  left untouched    : {self.skipped_underdetermined} underdetermined, "
+            f"{self.skipped_overdetermined} overdetermined",
+        ]
+        for f in self.failures:
+            lines.append(f"  FAILED: {f}")
+        return "\n".join(lines)
+
+
+def block_initialize(
+    model,
+    solver=None,
+    *,
+    max_block_solver_iter: int = 100,
+    tee: bool = False,
+) -> BlockInitReport:
+    """Fill ``Var.value`` by solving equality blocks in calculation order.
+
+    Args:
+        model: A Pyomo model (Block). Only active equality constraints
+            and unfixed variables participate; fix a variable to treat
+            it as a known input.
+        solver: A Pyomo solver (from ``SolverFactory``) for blocks
+            larger than 1x1. Default: ``SolverFactory("pounce")``.
+            Never invoked when every block is 1x1.
+        max_block_solver_iter: ``max_iter`` passed to the block solver.
+        tee: Echo block-solver output.
+
+    Returns a :class:`BlockInitReport`; ``report.failures`` lists blocks
+    whose solve did not converge (their variables keep whatever values
+    they had).
+    """
+    import pyomo.environ as pyo
+
+    try:
+        from pyomo.contrib.incidence_analysis import IncidenceGraphInterface
+    except ImportError as e:  # pragma: no cover - environment-dependent
+        raise ImportError(
+            "block_initialize requires pyomo.contrib.incidence_analysis "
+            "(pip install networkx scipy)"
+        ) from e
+    from pyomo.util.calc_var_value import calculate_variable_from_constraint
+    from pyomo.util.subsystems import TemporarySubsystemManager, create_subsystem_block
+
+    report = BlockInitReport()
+
+    igraph = IncidenceGraphInterface(model, include_inequality=False)
+    if not igraph.constraints:
+        return report
+
+    # The square (well-determined) part of the equality system: DM
+    # decomposition separates it from degrees of freedom and redundant
+    # specifications.
+    var_dm, con_dm = igraph.dulmage_mendelsohn()
+    report.skipped_underdetermined = len(var_dm.unmatched) + len(
+        var_dm.underconstrained
+    )
+    report.skipped_overdetermined = len(con_dm.unmatched) + len(con_dm.overconstrained)
+    square_vars = list(var_dm.square)
+    square_cons = list(con_dm.square)
+    if not square_vars:
+        return report
+
+    var_blocks, con_blocks = igraph.block_triangularize(
+        variables=square_vars, constraints=square_cons
+    )
+
+    for vars_blk, cons_blk in zip(var_blocks, con_blocks):
+        report.n_blocks += 1
+        if len(vars_blk) == 1 and len(cons_blk) == 1:
+            var, con = vars_blk[0], cons_blk[0]
+            if var.value is None:
+                _seed_var(var)
+            try:
+                calculate_variable_from_constraint(var, con)
+                report.n_1x1 += 1
+                report.n_vars_initialized += 1
+            except Exception as e:  # noqa: BLE001 - collect, keep going
+                report.failures.append(f"{con.name} -> {var.name}: {e}")
+            continue
+
+        # k x k block: square subsystem solve. Other variables appearing
+        # in these constraints are temporarily fixed at their current
+        # values (they were computed by earlier blocks).
+        if solver is None:
+            solver = pyo.SolverFactory("pounce")
+        blk = create_subsystem_block(cons_blk, vars_blk)
+        for v in vars_blk:
+            if v.value is None:
+                _seed_var(v)
+        blk._obj = pyo.Objective(expr=0.0)
+        try:
+            with TemporarySubsystemManager(to_fix=list(blk.input_vars.values())):
+                results = solver.solve(
+                    blk, tee=tee, options={"max_iter": max_block_solver_iter}
+                )
+            cond = str(results.solver.termination_condition)
+            if cond not in ("optimal", "locallyOptimal", "feasible"):
+                report.failures.append(
+                    f"block of {len(vars_blk)} vars "
+                    f"({vars_blk[0].name}, ...): termination {cond}"
+                )
+            else:
+                report.n_subsystem_solves += 1
+                report.n_vars_initialized += len(vars_blk)
+        except Exception as e:  # noqa: BLE001
+            report.failures.append(
+                f"block of {len(vars_blk)} vars ({vars_blk[0].name}, ...): {e}"
+            )
+        finally:
+            blk.del_component(blk._obj)
+
+    return report
+
+
+def _seed_var(v) -> None:
+    """Bounds-aware Newton seed for a valueless variable."""
+    lo, hi = v.lb, v.ub
+    finite = lambda b: b is not None and abs(b) < 1e19  # noqa: E731
+    if finite(lo) and finite(hi):
+        v.set_value(0.5 * (lo + hi), skip_validation=True)
+    elif finite(lo):
+        v.set_value(lo + 1.0, skip_validation=True)
+    elif finite(hi):
+        v.set_value(hi - 1.0, skip_validation=True)
+    else:
+        v.set_value(0.0, skip_validation=True)

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -1,25 +1,34 @@
 """Block-sequential initialization for Pyomo models (experimental).
 
 IDAES-style initialization without hand-written initialization routines:
-take the model's active **equality** constraints, find the square
-(well-determined) part of the variable/constraint incidence graph, order
-it into diagonal blocks (Dulmage-Mendelsohn / block triangularization,
-via ``pyomo.contrib.incidence_analysis``), and solve the blocks in
-topological order, writing each block's solution into ``Var.value``.
-1x1 blocks are solved with Pyomo's Newton one-liner
-(``calculate_variable_from_constraint``); larger blocks become square
-subsystem solves with POUNCE.
+hold the *decision* variables at their current values, take the model's
+active **equality** constraints, extract the square (well-determined)
+part of the variable/constraint incidence graph (Dulmage-Mendelsohn,
+via ``pyomo.contrib.incidence_analysis``), and solve it block by block
+in topological order, writing the solution into ``Var.value``. The
+block-by-block solve itself is delegated to Pyomo's
+``solve_strongly_connected_components`` (1x1 blocks by Newton, larger
+blocks by POUNCE); this module contributes the decision handling, the
+square-part extraction, the seeding, and the diagnostics.
 
-The result is a starting point that satisfies the model's sequential
-"calculation order" structure — usually a dramatically better start
-than zeros for flowsheet-shaped models.
+The distillation-column shape of the workflow::
 
-**Experimental.** The API and semantics may change; in particular:
-variables in the square subsystem are (re)computed in place, using any
-existing values as Newton starting guesses. Variables in the under- or
-over-determined parts (degrees of freedom, redundant specifications)
-are left untouched — pair with
-:func:`pyomo_pounce.initialize_missing_values` to fill the remainder.
+    report = pyomo_pounce.block_initialize(
+        model, decisions=[m.feed, m.reflux, m.boilup])
+    if not report.square:
+        print(report)   # names of what you forgot to specify
+
+set the decisions, solve for a physical profile with them held
+constant, then let the optimizer move them.
+
+**Experimental.** Variables in the square subsystem are (re)computed in
+place, using any existing values as Newton starting guesses. Variables
+in the under- or over-determined parts (degrees of freedom you did not
+flag as decisions, redundant specifications) are left untouched and
+reported **by name** — pair with
+:func:`pyomo_pounce.initialize_missing_values` /
+:func:`pyomo_pounce.project_to_feasible` to handle the remainder (or
+use the :func:`pyomo_pounce.initialize` pipeline).
 
 Requires ``pyomo.contrib.incidence_analysis`` (needs ``networkx`` and
 ``scipy``); raises ``ImportError`` with instructions otherwise.
@@ -35,14 +44,25 @@ __all__ = ["block_initialize", "BlockInitReport"]
 
 @dataclass
 class BlockInitReport:
-    """What :func:`block_initialize` did."""
+    """What :func:`block_initialize` did (and could not do)."""
 
+    #: True when the equality system (after fixing decisions) is exactly
+    #: square: no unmatched/underconstrained variables and no
+    #: unmatched/overconstrained constraints.
+    square: bool = True
+    n_decisions_fixed: int = 0
     n_blocks: int = 0
     n_1x1: int = 0
     n_subsystem_solves: int = 0
     n_vars_initialized: int = 0
     skipped_underdetermined: int = 0
     skipped_overdetermined: int = 0
+    #: Names of unmatched/underconstrained variables (capped): the
+    #: things you probably forgot to specify or flag as decisions.
+    underconstrained_variables: List[str] = field(default_factory=list)
+    #: Names of unmatched/overconstrained constraints (capped):
+    #: redundant or conflicting specifications.
+    overconstrained_constraints: List[str] = field(default_factory=list)
     failures: List[str] = field(default_factory=list)
 
     @property
@@ -52,39 +72,73 @@ class BlockInitReport:
     def __str__(self) -> str:
         lines = [
             "pyomo-pounce block_initialize",
+            f"  decisions fixed   : {self.n_decisions_fixed}",
+            f"  system square     : {self.square}",
             f"  blocks solved     : {self.n_blocks} "
             f"({self.n_1x1} by Newton 1x1, {self.n_subsystem_solves} subsystem solves)",
             f"  vars initialized  : {self.n_vars_initialized}",
             f"  left untouched    : {self.skipped_underdetermined} underdetermined, "
             f"{self.skipped_overdetermined} overdetermined",
         ]
+        if self.underconstrained_variables:
+            lines.append(
+                "  underconstrained vars (specify or flag as decisions): "
+                + ", ".join(self.underconstrained_variables)
+            )
+        if self.overconstrained_constraints:
+            lines.append(
+                "  overconstrained cons (redundant/conflicting specs): "
+                + ", ".join(self.overconstrained_constraints)
+            )
         for f in self.failures:
             lines.append(f"  FAILED: {f}")
         return "\n".join(lines)
 
 
+def _flatten_vars(vars_like):
+    """Accept VarData, indexed Var containers, or iterables of either."""
+    out = []
+    for v in vars_like:
+        if hasattr(v, "values") and callable(v.values):  # indexed container
+            out.extend(v.values())
+        else:
+            out.append(v)
+    return out
+
+
 def block_initialize(
     model,
+    decisions=None,
     solver=None,
     *,
-    max_block_solver_iter: int = 100,
+    max_list: int = 10,
     tee: bool = False,
 ) -> BlockInitReport:
     """Fill ``Var.value`` by solving equality blocks in calculation order.
 
     Args:
         model: A Pyomo model (Block). Only active equality constraints
-            and unfixed variables participate; fix a variable to treat
-            it as a known input.
+            and unfixed variables participate.
+        decisions: Variables (VarData or indexed Var containers) to hold
+            at their **current values** during the initialization solve,
+            then release — the degrees of freedom the optimizer will
+            move later. Each must have a value (``ValueError``
+            otherwise). Already-fixed variables may be listed and stay
+            fixed. Equivalent to fixing them yourself, but scoped and
+            self-documenting.
         solver: A Pyomo solver (from ``SolverFactory``) for blocks
-            larger than 1x1. Default: ``SolverFactory("pounce")``.
-            Never invoked when every block is 1x1.
-        max_block_solver_iter: ``max_iter`` passed to the block solver.
+            larger than 1x1. Default: ``SolverFactory("pounce")``,
+            constructed only when such a block exists.
+        max_list: Cap on the reported name lists.
         tee: Echo block-solver output.
 
-    Returns a :class:`BlockInitReport`; ``report.failures`` lists blocks
-    whose solve did not converge (their variables keep whatever values
-    they had).
+    Returns a :class:`BlockInitReport`. ``report.square`` is False when
+    the equality system (with decisions fixed) is not exactly square;
+    the offending variable/constraint **names** are reported, and the
+    square part is still solved best-effort. ``report.failures``
+    is non-empty when the block solve itself failed (Pyomo's
+    ``solve_strongly_connected_components`` fails fast, so variables in
+    blocks downstream of a failure keep their seed values).
     """
     import pyomo.environ as pyo
 
@@ -94,82 +148,94 @@ def block_initialize(
         # would only blow up (DeferredImportError) at first use.
         import networkx  # noqa: F401
 
-        from pyomo.contrib.incidence_analysis import IncidenceGraphInterface
+        from pyomo.contrib.incidence_analysis import (
+            IncidenceGraphInterface,
+            solve_strongly_connected_components,
+        )
     except ImportError as e:  # pragma: no cover - environment-dependent
         raise ImportError(
             "block_initialize requires pyomo.contrib.incidence_analysis "
             "and its optional dependencies (pip install networkx scipy)"
         ) from e
-    from pyomo.util.calc_var_value import calculate_variable_from_constraint
     from pyomo.util.subsystems import TemporarySubsystemManager, create_subsystem_block
 
     report = BlockInitReport()
 
-    igraph = IncidenceGraphInterface(model, include_inequality=False)
-    if not igraph.constraints:
-        return report
+    # --- hold the decisions -------------------------------------------
+    fixed_by_us = []
+    if decisions is not None:
+        for vd in _flatten_vars(decisions):
+            if vd.fixed:
+                continue  # already an input; leave as the user set it
+            if vd.value is None:
+                raise ValueError(
+                    f"decision variable {vd.name!r} has no value: a decision "
+                    "must be held at a concrete value during initialization"
+                )
+            vd.fix()
+            fixed_by_us.append(vd)
+    report.n_decisions_fixed = len(fixed_by_us)
 
-    # The square (well-determined) part of the equality system: DM
-    # decomposition separates it from degrees of freedom and redundant
-    # specifications.
-    var_dm, con_dm = igraph.dulmage_mendelsohn()
-    report.skipped_underdetermined = len(var_dm.unmatched) + len(
-        var_dm.underconstrained
-    )
-    report.skipped_overdetermined = len(con_dm.unmatched) + len(con_dm.overconstrained)
-    square_vars = list(var_dm.square)
-    square_cons = list(con_dm.square)
-    if not square_vars:
-        return report
+    try:
+        igraph = IncidenceGraphInterface(model, include_inequality=False)
+        if not igraph.constraints:
+            return report
 
-    var_blocks, con_blocks = igraph.block_triangularize(
-        variables=square_vars, constraints=square_cons
-    )
+        # The square (well-determined) part of the equality system: the
+        # DM decomposition separates it from remaining degrees of
+        # freedom and redundant specifications — and names them.
+        var_dm, con_dm = igraph.dulmage_mendelsohn()
+        under_vars = list(var_dm.unmatched) + list(var_dm.underconstrained)
+        over_cons = list(con_dm.unmatched) + list(con_dm.overconstrained)
+        report.skipped_underdetermined = len(under_vars)
+        report.skipped_overdetermined = len(over_cons)
+        report.underconstrained_variables = [v.name for v in under_vars[:max_list]]
+        report.overconstrained_constraints = [c.name for c in over_cons[:max_list]]
+        report.square = not under_vars and not over_cons
 
-    for vars_blk, cons_blk in zip(var_blocks, con_blocks):
-        report.n_blocks += 1
-        if len(vars_blk) == 1 and len(cons_blk) == 1:
-            var, con = vars_blk[0], cons_blk[0]
-            if var.value is None:
-                _seed_var(var)
-            try:
-                calculate_variable_from_constraint(var, con)
-                report.n_1x1 += 1
-                report.n_vars_initialized += 1
-            except Exception as e:  # noqa: BLE001 - collect, keep going
-                report.failures.append(f"{con.name} -> {var.name}: {e}")
-            continue
+        square_vars = list(var_dm.square)
+        square_cons = list(con_dm.square)
+        if not square_vars:
+            return report
 
-        # k x k block: square subsystem solve. Other variables appearing
-        # in these constraints are temporarily fixed at their current
-        # values (they were computed by earlier blocks).
-        if solver is None:
-            solver = pyo.SolverFactory("pounce")
-        blk = create_subsystem_block(cons_blk, vars_blk)
-        for v in vars_blk:
+        # Solve-plan statistics (the SCC solve below follows exactly
+        # this block structure).
+        var_blocks, _con_blocks = igraph.block_triangularize(
+            variables=square_vars, constraints=square_cons
+        )
+        report.n_blocks = len(var_blocks)
+        report.n_1x1 = sum(1 for blk in var_blocks if len(blk) == 1)
+        n_large = report.n_blocks - report.n_1x1
+
+        for v in square_vars:
             if v.value is None:
                 _seed_var(v)
-        blk._obj = pyo.Objective(expr=0.0)
+
+        if n_large > 0 and solver is None:
+            solver = pyo.SolverFactory("pounce")
+
+        # Delegate the block-by-block solve to Pyomo's own machinery:
+        # 1x1 blocks via calculate_variable_from_constraint, larger
+        # blocks via `solver`. Variables that appear in the square
+        # constraints but belong to the non-square part are temporarily
+        # fixed at their current values.
+        blk = create_subsystem_block(square_cons, square_vars)
         try:
             with TemporarySubsystemManager(to_fix=list(blk.input_vars.values())):
-                results = solver.solve(
-                    blk, tee=tee, options={"max_iter": max_block_solver_iter}
+                solve_strongly_connected_components(
+                    blk,
+                    solver=solver,
+                    solve_kwds={"tee": tee},
                 )
-            cond = str(results.solver.termination_condition)
-            if cond not in ("optimal", "locallyOptimal", "feasible"):
-                report.failures.append(
-                    f"block of {len(vars_blk)} vars "
-                    f"({vars_blk[0].name}, ...): termination {cond}"
-                )
-            else:
-                report.n_subsystem_solves += 1
-                report.n_vars_initialized += len(vars_blk)
-        except Exception as e:  # noqa: BLE001
+            report.n_subsystem_solves = n_large
+            report.n_vars_initialized = len(square_vars)
+        except Exception as e:  # noqa: BLE001 - report, don't raise
             report.failures.append(
-                f"block of {len(vars_blk)} vars ({vars_blk[0].name}, ...): {e}"
+                f"strongly-connected-component solve failed: {e}"
             )
-        finally:
-            blk.del_component(blk._obj)
+    finally:
+        for vd in fixed_by_us:
+            vd.unfix()
 
     return report
 

--- a/pyomo-pounce/pyomo_pounce/preflight.py
+++ b/pyomo-pounce/pyomo_pounce/preflight.py
@@ -1,0 +1,262 @@
+"""Starting-point preflight for Pyomo models solved with POUNCE.
+
+The Pyomo-shaped twin of ``pounce check-x0`` / ``pounce.preflight``
+(see the POUNCE docs' initialization chapter). The headline trap it
+catches: a ``Var`` whose ``.value`` was never set is written as **0**
+into the ``.nl`` file, so a model initialized "nowhere" is actually
+initialized at the origin — outside many models' meaningful range and
+a domain error for ``log``, division, and friends.
+
+Usage::
+
+    import pyomo_pounce
+
+    report = pyomo_pounce.preflight(model)
+    if report.fatal:
+        raise ValueError(str(report))
+    pyomo.environ.SolverFactory("pounce").solve(model)
+
+The report evaluates the model exactly as the NL writer will see it
+(unset values temporarily treated as 0, then restored).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+__all__ = ["preflight", "PyomoPreflightReport", "initialize_missing_values"]
+
+
+def _finite(b: Optional[float]) -> bool:
+    return b is not None and math.isfinite(b) and abs(b) < 1e19
+
+
+def _box_violation(v: float, lo: Optional[float], hi: Optional[float]) -> float:
+    if v is None or not math.isfinite(v):
+        return math.inf
+    below = (lo - v) if _finite(lo) else -math.inf
+    above = (v - hi) if _finite(hi) else -math.inf
+    return max(below, above, 0.0)
+
+
+@dataclass
+class PyomoPreflightReport:
+    """Result of :func:`preflight`. ``str(report)`` renders a text
+    report; ``report.fatal`` is True when a POUNCE solve of the model
+    as written would abort at the starting point."""
+
+    n_vars: int
+    n_cons: int
+    unset: List[str]  # capped list of names
+    n_unset: int
+    bound_violations: List[Tuple[str, float, Optional[float], Optional[float], float]]
+    n_bound_violations: int
+    n_on_bounds: int
+    con_violations: List[Tuple[str, float, Optional[float], Optional[float], float]]
+    n_con_violations: int
+    max_con_violation: float
+    non_evaluable: List[str]  # constraint/objective names, capped
+    n_non_evaluable: int
+    objective: Optional[float]
+    warnings: List[str] = field(default_factory=list)
+    fatal: bool = False
+    verdict: str = "CLEAN"
+
+    @property
+    def ok(self) -> bool:
+        return not self.fatal
+
+    def __str__(self) -> str:
+        lines = ["pyomo-pounce preflight — starting-point check"]
+        lines.append(f"  model      : {self.n_vars} vars, {self.n_cons} constraints")
+        lines.append(
+            f"  unset vars : {self.n_unset} (become 0 in the .nl file)"
+            + (f"  e.g. {', '.join(self.unset)}" if self.unset else "")
+        )
+        obj = (
+            f"{self.objective:.10e}"
+            if self.objective is not None and math.isfinite(self.objective)
+            else "NOT EVALUABLE"
+        )
+        lines.append(f"  objective  : {obj}")
+        lines.append(
+            f"  bounds     : {self.n_bound_violations} violated, "
+            f"{self.n_on_bounds} on-bound (the solver's interior clamp moves these)"
+        )
+        for name, v, lo, hi, viol in self.bound_violations:
+            lines.append(f"      {name}: value {v} outside [{lo}, {hi}] by {viol:.3e}")
+        lines.append(
+            f"  constraints: {self.n_con_violations} violated at the start "
+            f"(max {self.max_con_violation:.3e}), {self.n_non_evaluable} not evaluable"
+        )
+        for name, v, lo, hi, viol in self.con_violations:
+            lines.append(f"      {name}: body {v} vs [{lo}, {hi}], violation {viol:.3e}")
+        for name in self.non_evaluable:
+            lines.append(f"      {name}: NOT EVALUABLE at the starting point")
+        for w in self.warnings:
+            lines.append(f"  warning: {w}")
+        lines.append(f"  VERDICT: {self.verdict}")
+        return "\n".join(lines)
+
+
+def preflight(model, feas_tol: float = 1e-6, max_list: int = 5) -> PyomoPreflightReport:
+    """Check a Pyomo model's starting point as POUNCE will see it.
+
+    Evaluates every active constraint and the objective at the current
+    variable values, with unset values temporarily treated as 0 —
+    exactly what Pyomo's NL writer sends to the solver — and restores
+    the model untouched. Reports unset variables, values at/outside
+    their bounds, per-constraint violations, and expressions that fail
+    to evaluate (NaN/inf/exception: these are fatal, the solve would
+    abort with ``Invalid_Number_Detected``).
+    """
+    import pyomo.environ as pyo
+    from pyomo.environ import value
+
+    variables = [
+        v
+        for v in model.component_data_objects(pyo.Var, active=True, descend_into=True)
+        if not v.fixed
+    ]
+    constraints = list(
+        model.component_data_objects(pyo.Constraint, active=True, descend_into=True)
+    )
+
+    unset_vars = [v for v in variables if v.value is None]
+
+    # Evaluate as-written: unset -> 0, restore afterwards.
+    try:
+        for v in unset_vars:
+            v.set_value(0.0, skip_validation=True)
+
+        n_bound_violations = 0
+        n_on_bounds = 0
+        bound_violations = []
+        for v in variables:
+            val = v.value
+            lo, hi = v.lb, v.ub
+            viol = _box_violation(val, lo, hi)
+            if viol > feas_tol:
+                n_bound_violations += 1
+                bound_violations.append((v.name, val, lo, hi, viol))
+            if val is not None and math.isfinite(val):
+                at_lo = _finite(lo) and abs(val - lo) <= 1e-8 * (1.0 + abs(lo))
+                at_hi = _finite(hi) and abs(hi - val) <= 1e-8 * (1.0 + abs(hi))
+                if at_lo or at_hi:
+                    n_on_bounds += 1
+        bound_violations.sort(key=lambda t: -t[4])
+        del bound_violations[max_list:]
+
+        con_violations = []
+        non_evaluable = []
+        n_con_violations = 0
+        n_non_evaluable = 0
+        max_con_violation = 0.0
+        for c in constraints:
+            body = value(c.body, exception=False)
+            if body is None or not math.isfinite(body):
+                n_non_evaluable += 1
+                if len(non_evaluable) < max_list:
+                    non_evaluable.append(c.name)
+                continue
+            lo = value(c.lower, exception=False) if c.lower is not None else None
+            hi = value(c.upper, exception=False) if c.upper is not None else None
+            viol = _box_violation(body, lo, hi)
+            if viol > feas_tol:
+                n_con_violations += 1
+                if math.isfinite(viol):
+                    max_con_violation = max(max_con_violation, viol)
+                con_violations.append((c.name, body, lo, hi, viol))
+        con_violations.sort(key=lambda t: -t[4])
+        del con_violations[max_list:]
+
+        objective = None
+        obj = next(
+            model.component_data_objects(pyo.Objective, active=True, descend_into=True),
+            None,
+        )
+        obj_bad = False
+        if obj is not None:
+            objective = value(obj.expr, exception=False)
+            obj_bad = objective is None or not math.isfinite(objective)
+    finally:
+        for v in unset_vars:
+            v.set_value(None, skip_validation=True)
+
+    warnings: List[str] = []
+    fatal = n_non_evaluable > 0 or obj_bad
+    if unset_vars:
+        warnings.append(
+            f"{len(unset_vars)} variable(s) have no value and will be written "
+            "as 0 in the .nl file; set Var values (or run "
+            "initialize_missing_values / block_initialize) before solving"
+        )
+    if fatal:
+        warnings.append(
+            "the model does not evaluate at its starting point (as written, "
+            "unset values = 0); a POUNCE solve would abort with "
+            "Invalid_Number_Detected"
+        )
+    if n_bound_violations:
+        warnings.append(
+            f"{n_bound_violations} variable value(s) violate their bounds; "
+            "the solver clamps them inside before iterating"
+        )
+    if max_con_violation > 1e4:
+        warnings.append(
+            f"very large initial infeasibility (max constraint violation "
+            f"{max_con_violation:.3e}); consider better initial values"
+        )
+
+    verdict = "FATAL" if fatal else ("WARNINGS" if warnings else "CLEAN")
+    return PyomoPreflightReport(
+        n_vars=len(variables),
+        n_cons=len(constraints),
+        unset=[v.name for v in unset_vars[:max_list]],
+        n_unset=len(unset_vars),
+        bound_violations=bound_violations,
+        n_bound_violations=n_bound_violations,
+        n_on_bounds=n_on_bounds,
+        con_violations=con_violations,
+        n_con_violations=n_con_violations,
+        max_con_violation=max_con_violation,
+        non_evaluable=non_evaluable,
+        n_non_evaluable=n_non_evaluable,
+        objective=objective,
+        warnings=warnings,
+        fatal=fatal,
+        verdict=verdict,
+    )
+
+
+def initialize_missing_values(model, strategy: str = "midpoint") -> int:
+    """Give every valueless, unfixed ``Var`` a sane starting value.
+
+    ``strategy="midpoint"`` uses the midpoint of two finite bounds, one
+    unit inside a one-sided bound, and 0 for free variables — a
+    bounds-aware version of the NL writer's silent 0. ``strategy="zero"``
+    makes the silent default explicit. Returns the number of variables
+    initialized. Set values survive untouched either way.
+    """
+    import pyomo.environ as pyo
+
+    if strategy not in ("midpoint", "zero"):
+        raise ValueError(f"unknown strategy {strategy!r}")
+    count = 0
+    for v in model.component_data_objects(pyo.Var, active=True, descend_into=True):
+        if v.fixed or v.value is not None:
+            continue
+        val = 0.0
+        if strategy == "midpoint":
+            lo, hi = v.lb, v.ub
+            if _finite(lo) and _finite(hi):
+                val = 0.5 * (lo + hi)
+            elif _finite(lo):
+                val = lo + 1.0
+            elif _finite(hi):
+                val = hi - 1.0
+        v.set_value(val, skip_validation=True)
+        count += 1
+    return count

--- a/pyomo-pounce/pyomo_pounce/repair.py
+++ b/pyomo-pounce/pyomo_pounce/repair.py
@@ -1,0 +1,200 @@
+"""Starting-point repair for Pyomo models: projection and the
+fill -> repair -> block-solve pipeline.
+
+:func:`pyomo_pounce.initialize_missing_values` fills each valueless
+variable independently, so the fill can be internally inconsistent
+(mole fractions that do not sum to one, flows that violate a balance).
+:func:`project_to_feasible` repairs that: it moves the current point
+the minimum distance onto the model's own feasible set, writing the
+repaired values back into ``Var.value``. Unlike the NumPy-level
+``pounce.project_to_feasible`` (which projects onto *linearized*
+constraints), this solves the full nonlinear projection with POUNCE.
+
+:func:`initialize` chains the whole story::
+
+    report = pyomo_pounce.initialize(model, decisions=[m.feed, m.reflux])
+    # fill missing values -> project onto the constraints -> solve the
+    # equality blocks in calculation order (block_initialize)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from pyomo_pounce.block_init import BlockInitReport, _flatten_vars, block_initialize
+from pyomo_pounce.preflight import initialize_missing_values
+
+__all__ = ["project_to_feasible", "initialize", "InitializeReport"]
+
+
+def project_to_feasible(
+    model,
+    solver=None,
+    *,
+    options: Optional[dict] = None,
+    tee: bool = False,
+) -> str:
+    """Move the current point the minimum distance onto the feasible set.
+
+    Temporarily replaces the model's objective with
+    ``min sum((v - v0)**2)`` over every unfixed variable that has a
+    value ``v0``, solves against the model's own (active) constraints
+    and bounds with POUNCE, and restores the original objective(s). The
+    repaired point lands in ``Var.value``. Valueless variables get a
+    bounds-aware seed and are free to move (they carry no anchor term).
+
+    Args:
+        model: A Pyomo model. Modified in place: variable values only;
+            objectives/constraints are restored exactly.
+        solver: A Pyomo solver; default ``SolverFactory("pounce")``.
+        options: Solver options dict (e.g. ``{"tol": 1e-8}``).
+        tee: Echo solver output.
+
+    Returns the solver termination condition as a string (``"optimal"``
+    / ``"locallyOptimal"`` on success). Raises ``ValueError`` when no
+    unfixed variable has a value (nothing to anchor; run
+    ``initialize_missing_values`` first).
+    """
+    import pyomo.environ as pyo
+    from pyomo_pounce.block_init import _seed_var
+
+    variables = [
+        v
+        for v in model.component_data_objects(pyo.Var, active=True, descend_into=True)
+        if not v.fixed
+    ]
+    anchored = [(v, float(v.value)) for v in variables if v.value is not None]
+    if not anchored:
+        raise ValueError(
+            "project_to_feasible: no unfixed variable has a value to anchor "
+            "the projection; run initialize_missing_values(model) first"
+        )
+    for v in variables:
+        if v.value is None:
+            _seed_var(v)
+
+    if solver is None:
+        solver = pyo.SolverFactory("pounce")
+
+    deactivated = []
+    for obj in model.component_data_objects(
+        pyo.Objective, active=True, descend_into=True
+    ):
+        obj.deactivate()
+        deactivated.append(obj)
+    model._pounce_projection_objective = pyo.Objective(
+        expr=sum((v - v0) ** 2 for v, v0 in anchored)
+    )
+    try:
+        results = solver.solve(model, tee=tee, options=dict(options or {}))
+        return str(results.solver.termination_condition)
+    finally:
+        model.del_component(model._pounce_projection_objective)
+        for obj in deactivated:
+            obj.activate()
+
+
+@dataclass
+class InitializeReport:
+    """What :func:`initialize` did, stage by stage."""
+
+    n_decisions_fixed: int = 0
+    n_filled: int = 0
+    #: Termination condition of the projection solve, or None when the
+    #: projection stage was skipped.
+    projection: Optional[str] = None
+    block: Optional[BlockInitReport] = None
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        proj_ok = self.projection in (None, "optimal", "locallyOptimal", "feasible")
+        return proj_ok and (self.block is None or self.block.ok)
+
+    def __str__(self) -> str:
+        lines = [
+            "pyomo-pounce initialize (fill -> repair -> block-solve)",
+            f"  decisions held: {self.n_decisions_fixed}",
+            f"  values filled : {self.n_filled}",
+            f"  projection    : {self.projection or 'skipped'}",
+        ]
+        for w in self.warnings:
+            lines.append(f"  warning: {w}")
+        if self.block is not None:
+            lines.extend("  " + line for line in str(self.block).splitlines())
+        return "\n".join(lines)
+
+
+def initialize(
+    model,
+    decisions=None,
+    solver=None,
+    *,
+    fill: str = "midpoint",
+    project: bool = True,
+    options: Optional[dict] = None,
+    tee: bool = False,
+) -> InitializeReport:
+    """Fill, repair, and block-solve a model's starting point.
+
+    ``decisions`` are held (fixed) at their current values for the
+    **whole** pipeline — the projection must not drift the feed or the
+    reflux you just specified — and released at the end. The three
+    stages, each skippable:
+
+    1. **Fill** — :func:`initialize_missing_values` gives every
+       valueless unfixed variable a bounds-aware value
+       (``fill="midpoint"`` or ``"zero"``; ``fill=None`` skips).
+    2. **Repair** — :func:`project_to_feasible` moves the (possibly
+       internally inconsistent) filled point the minimum distance onto
+       the model's constraints (``project=False`` skips).
+    3. **Block-solve** — :func:`block_initialize` solves the square
+       equality system in calculation order, overwriting the repaired
+       values with the consistent profile.
+
+    Returns an :class:`InitializeReport`; ``report.block.square`` and
+    the name lists tell you what the model is still missing.
+    """
+    report = InitializeReport()
+
+    # Hold the decisions across ALL stages: filling must not paper over
+    # a valueless decision, and the projection must not drift them.
+    fixed_by_us = []
+    if decisions is not None:
+        for vd in _flatten_vars(decisions):
+            if vd.fixed:
+                continue
+            if vd.value is None:
+                raise ValueError(
+                    f"decision variable {vd.name!r} has no value: a decision "
+                    "must be held at a concrete value during initialization"
+                )
+            vd.fix()
+            fixed_by_us.append(vd)
+    report.n_decisions_fixed = len(fixed_by_us)
+
+    try:
+        if fill is not None:
+            report.n_filled = initialize_missing_values(model, strategy=fill)
+        if project:
+            try:
+                report.projection = project_to_feasible(
+                    model, solver=solver, options=options, tee=tee
+                )
+                if report.projection not in ("optimal", "locallyOptimal", "feasible"):
+                    report.warnings.append(
+                        f"projection ended {report.projection}; continuing with "
+                        "the unrepaired point"
+                    )
+            except ValueError as e:
+                report.warnings.append(str(e))
+        # Decisions are already fixed, so block_initialize sees them as
+        # plain inputs; passing them again is harmless.
+        report.block = block_initialize(
+            model, decisions=decisions, solver=solver, tee=tee
+        )
+    finally:
+        for vd in fixed_by_us:
+            vd.unfix()
+    return report

--- a/pyomo-pounce/tests/test_block_init.py
+++ b/pyomo-pounce/tests/test_block_init.py
@@ -40,6 +40,7 @@ def test_triangular_system_solved_by_newton_only():
 
     report = pyomo_pounce.block_initialize(m)
     assert report.ok, str(report)
+    assert report.square
     assert report.n_blocks == 3
     assert report.n_1x1 == 3
     assert report.n_subsystem_solves == 0  # no solver needed
@@ -48,7 +49,7 @@ def test_triangular_system_solved_by_newton_only():
     assert m.z.value == pytest.approx(2.0)
 
 
-def test_degrees_of_freedom_left_untouched():
+def test_degrees_of_freedom_left_untouched_and_named():
     m = pyo.ConcreteModel()
     m.x = pyo.Var()
     m.w = pyo.Var()  # free DOF: appears only in the objective
@@ -59,9 +60,106 @@ def test_degrees_of_freedom_left_untouched():
     assert report.ok, str(report)
     assert m.x.value == pytest.approx(4.0)
     assert m.w.value is None
+    # w participates in no equality, so the equality system is square
+    # over {x}; the DM partition never sees w. Nothing to name.
+    assert report.square
     # ... and initialize_missing_values fills the rest.
     pyomo_pounce.initialize_missing_values(m)
     assert m.w.value == 0.0
+
+
+def test_underconstrained_names_reported():
+    # Two variables coupled by one equation: without a decision the
+    # system is underdetermined, and the names say which variables.
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var()
+    m.split = pyo.Var(bounds=(0.0, 1.0))
+    m.out = pyo.Var()
+    m.c = pyo.Constraint(expr=m.out == m.split * m.feed)
+    m.obj = pyo.Objective(expr=m.out)
+
+    report = pyomo_pounce.block_initialize(m)
+    assert not report.square
+    assert report.skipped_underdetermined >= 2
+    named = set(report.underconstrained_variables)
+    assert {"feed", "split"} & named, str(report)
+    assert "underconstrained" in str(report)
+
+
+def test_decisions_square_the_system_and_are_released():
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var(initialize=10.0)
+    m.split = pyo.Var(bounds=(0.0, 1.0), initialize=0.3)
+    m.out1 = pyo.Var()
+    m.out2 = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.out1 == m.split * m.feed)
+    m.c2 = pyo.Constraint(expr=m.out2 == (1.0 - m.split) * m.feed)
+    m.obj = pyo.Objective(expr=m.out1)
+
+    report = pyomo_pounce.block_initialize(m, decisions=[m.feed, m.split])
+    assert report.ok, str(report)
+    assert report.square
+    assert report.n_decisions_fixed == 2
+    assert m.out1.value == pytest.approx(3.0)
+    assert m.out2.value == pytest.approx(7.0)
+    # Decisions are released afterwards (the optimizer moves them next).
+    assert not m.feed.fixed and not m.split.fixed
+    assert m.feed.value == pytest.approx(10.0)
+
+
+def test_decisions_accept_indexed_containers():
+    m = pyo.ConcreteModel()
+    m.d = pyo.Var([1, 2], initialize={1: 2.0, 2: 3.0})
+    m.y = pyo.Var()
+    m.c = pyo.Constraint(expr=m.y == m.d[1] + m.d[2])
+    m.obj = pyo.Objective(expr=m.y)
+
+    report = pyomo_pounce.block_initialize(m, decisions=[m.d])
+    assert report.ok and report.square, str(report)
+    assert report.n_decisions_fixed == 2
+    assert m.y.value == pytest.approx(5.0)
+    assert not m.d[1].fixed and not m.d[2].fixed
+
+
+def test_decision_without_value_raises():
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var()  # no value: cannot be held at anything
+    m.out = pyo.Var()
+    m.c = pyo.Constraint(expr=m.out == 2.0 * m.feed)
+    m.obj = pyo.Objective(expr=m.out)
+
+    with pytest.raises(ValueError, match="feed"):
+        pyomo_pounce.block_initialize(m, decisions=[m.feed])
+    assert not m.feed.fixed  # nothing leaked
+
+
+def test_already_fixed_decision_stays_fixed():
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var()
+    m.feed.fix(10.0)
+    m.out = pyo.Var()
+    m.c = pyo.Constraint(expr=m.out == 0.5 * m.feed)
+    m.obj = pyo.Objective(expr=m.out)
+
+    report = pyomo_pounce.block_initialize(m, decisions=[m.feed])
+    assert report.ok, str(report)
+    assert report.n_decisions_fixed == 0  # was already fixed, not by us
+    assert m.out.value == pytest.approx(5.0)
+    assert m.feed.fixed  # user's fix survives
+
+
+def test_overconstrained_names_reported():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.x == 1.0)
+    m.c2 = pyo.Constraint(expr=2.0 * m.x == 2.0)  # redundant spec
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.block_initialize(m)
+    assert not report.square
+    assert report.skipped_overdetermined >= 1
+    assert report.overconstrained_constraints, str(report)
+    assert "overconstrained" in str(report)
 
 
 def test_fixed_vars_act_as_inputs():
@@ -99,7 +197,7 @@ def test_coupled_block_uses_subsystem_solve(solver):
 def test_failure_is_reported_not_raised():
     m = pyo.ConcreteModel()
     m.x = pyo.Var(bounds=(0.0, 1.0))
-    # No solution in the bounds: Newton cannot satisfy x == 5.
+    # No solution in the bounds: Newton cannot satisfy x == 5 inside them.
     m.c = pyo.Constraint(expr=m.x**3 == 125.0)
     m.obj = pyo.Objective(expr=m.x)
 

--- a/pyomo-pounce/tests/test_block_init.py
+++ b/pyomo-pounce/tests/test_block_init.py
@@ -1,0 +1,104 @@
+"""Tests for pyomo_pounce.block_initialize (experimental).
+
+The 1x1 Newton path is hermetic; the multi-variable subsystem path
+needs the pounce binary and is skipped when it is absent.
+"""
+
+import pyomo.environ as pyo
+import pytest
+
+import pyomo_pounce
+
+pytest.importorskip(
+    "pyomo.contrib.incidence_analysis",
+    reason="block_initialize needs pyomo.contrib.incidence_analysis",
+)
+
+
+@pytest.fixture(scope="module")
+def solver():
+    s = pyo.SolverFactory("pounce")
+    if not s.available(exception_flag=False):
+        pytest.skip("pounce binary not found on PATH")
+    return s
+
+
+def test_triangular_system_solved_by_newton_only():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var()
+    m.z = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.x == 2.0)
+    m.c2 = pyo.Constraint(expr=m.y == m.x + 1.0)
+    m.c3 = pyo.Constraint(expr=m.z * m.y == 6.0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.block_initialize(m)
+    assert report.ok, str(report)
+    assert report.n_blocks == 3
+    assert report.n_1x1 == 3
+    assert report.n_subsystem_solves == 0  # no solver needed
+    assert m.x.value == pytest.approx(2.0)
+    assert m.y.value == pytest.approx(3.0)
+    assert m.z.value == pytest.approx(2.0)
+
+
+def test_degrees_of_freedom_left_untouched():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.w = pyo.Var()  # free DOF: appears only in the objective
+    m.c = pyo.Constraint(expr=m.x == 4.0)
+    m.obj = pyo.Objective(expr=(m.w - 1.0) ** 2 + m.x)
+
+    report = pyomo_pounce.block_initialize(m)
+    assert report.ok, str(report)
+    assert m.x.value == pytest.approx(4.0)
+    assert m.w.value is None
+    # ... and initialize_missing_values fills the rest.
+    pyomo_pounce.initialize_missing_values(m)
+    assert m.w.value == 0.0
+
+
+def test_fixed_vars_act_as_inputs():
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var()
+    m.feed.fix(10.0)
+    m.out = pyo.Var()
+    m.c = pyo.Constraint(expr=m.out == 0.5 * m.feed)
+    m.obj = pyo.Objective(expr=m.out)
+
+    report = pyomo_pounce.block_initialize(m)
+    assert report.ok, str(report)
+    assert m.out.value == pytest.approx(5.0)
+
+
+def test_coupled_block_uses_subsystem_solve(solver):
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var()
+    m.z = pyo.Var()
+    # 2x2 coupled block feeding a downstream 1x1.
+    m.c1 = pyo.Constraint(expr=m.x + m.y == 3.0)
+    m.c2 = pyo.Constraint(expr=m.x - m.y == 1.0)
+    m.c3 = pyo.Constraint(expr=m.z == m.x * m.y)
+    m.obj = pyo.Objective(expr=m.z)
+
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert report.ok, str(report)
+    assert report.n_subsystem_solves == 1
+    assert m.x.value == pytest.approx(2.0, abs=1e-6)
+    assert m.y.value == pytest.approx(1.0, abs=1e-6)
+    assert m.z.value == pytest.approx(2.0, abs=1e-6)
+
+
+def test_failure_is_reported_not_raised():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0.0, 1.0))
+    # No solution in the bounds: Newton cannot satisfy x == 5.
+    m.c = pyo.Constraint(expr=m.x**3 == 125.0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.block_initialize(m)
+    # calculate_variable_from_constraint ignores bounds and sets x = 5,
+    # or raises depending on version — either way no exception escapes.
+    assert report.n_blocks == 1

--- a/pyomo-pounce/tests/test_block_init.py
+++ b/pyomo-pounce/tests/test_block_init.py
@@ -9,6 +9,11 @@ import pytest
 
 import pyomo_pounce
 
+# pyomo defers optional imports, so pyomo.contrib.incidence_analysis
+# imports fine without networkx and only fails at first use — skip on
+# the real dependencies.
+pytest.importorskip("networkx", reason="block_initialize needs networkx")
+pytest.importorskip("scipy", reason="block_initialize needs scipy")
 pytest.importorskip(
     "pyomo.contrib.incidence_analysis",
     reason="block_initialize needs pyomo.contrib.incidence_analysis",

--- a/pyomo-pounce/tests/test_preflight.py
+++ b/pyomo-pounce/tests/test_preflight.py
@@ -1,0 +1,123 @@
+"""Tests for pyomo_pounce.preflight / initialize_missing_values.
+
+Hermetic: no solver binary required.
+"""
+
+import math
+
+import pyomo.environ as pyo
+import pytest
+
+import pyomo_pounce
+
+
+def test_unset_values_are_flagged_and_restored():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var(initialize=1.0)
+    m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+
+    report = pyomo_pounce.preflight(m)
+    assert report.n_unset == 1
+    assert report.unset == ["x"]
+    assert any(".nl" in w for w in report.warnings)
+    # The model is untouched afterwards.
+    assert m.x.value is None
+    assert m.y.value == 1.0
+    # As written (x = 0), the objective evaluates fine.
+    assert report.objective == pytest.approx(1.0)
+    assert not report.fatal
+
+
+def test_silent_zero_domain_error_is_fatal():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()  # unset -> written as 0 -> log(0) blows up
+    m.c = pyo.Constraint(expr=pyo.log(m.x) >= 0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.preflight(m)
+    assert report.fatal
+    assert report.verdict == "FATAL"
+    assert report.n_non_evaluable == 1
+    assert "c" in report.non_evaluable
+    assert m.x.value is None  # restored
+
+
+def test_bound_and_constraint_violations_reported():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(1.0, 5.0), initialize=-2.0)
+    m.y = pyo.Var(bounds=(0.0, 10.0), initialize=0.0)  # on its lower bound
+    m.c = pyo.Constraint(expr=m.x + m.y >= 10.0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.preflight(m)
+    assert not report.fatal
+    assert report.n_bound_violations == 1
+    name, val, lo, hi, viol = report.bound_violations[0]
+    assert name == "x" and viol == pytest.approx(3.0)
+    assert report.n_on_bounds == 1
+    assert report.n_con_violations == 1
+    assert report.max_con_violation == pytest.approx(12.0)
+    assert report.verdict == "WARNINGS"
+
+
+def test_clean_model():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(0.0, 4.0), initialize=2.0)
+    m.c = pyo.Constraint(expr=m.x <= 3.0)
+    m.obj = pyo.Objective(expr=(m.x - 1.0) ** 2)
+
+    report = pyomo_pounce.preflight(m)
+    assert report.verdict == "CLEAN"
+    assert report.ok
+    assert "VERDICT: CLEAN" in str(report)
+
+
+def test_fixed_vars_are_ignored():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.x.fix(3.0)
+    m.obj = pyo.Objective(expr=m.x**2)
+    report = pyomo_pounce.preflight(m)
+    assert report.n_vars == 0
+    assert report.n_unset == 0
+
+
+def test_initialize_missing_values_midpoint():
+    m = pyo.ConcreteModel()
+    m.a = pyo.Var(bounds=(1.0, 3.0))
+    m.b = pyo.Var(bounds=(0.0, None))
+    m.c = pyo.Var(bounds=(None, -5.0))
+    m.d = pyo.Var()
+    m.e = pyo.Var(initialize=7.0)
+
+    count = pyomo_pounce.initialize_missing_values(m)
+    assert count == 4
+    assert m.a.value == pytest.approx(2.0)
+    assert m.b.value == pytest.approx(1.0)
+    assert m.c.value == pytest.approx(-6.0)
+    assert m.d.value == 0.0
+    assert m.e.value == 7.0  # untouched
+
+
+def test_initialize_missing_values_zero():
+    m = pyo.ConcreteModel()
+    m.a = pyo.Var(bounds=(1.0, 3.0))
+    count = pyomo_pounce.initialize_missing_values(m, strategy="zero")
+    assert count == 1
+    assert m.a.value == 0.0
+    with pytest.raises(ValueError):
+        pyomo_pounce.initialize_missing_values(m, strategy="nope")
+
+
+def test_preflight_then_init_clears_warning():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(1.0, 5.0))
+    m.c = pyo.Constraint(expr=pyo.log(m.x) >= 0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    assert pyomo_pounce.preflight(m).fatal  # log(0) as written
+    pyomo_pounce.initialize_missing_values(m)  # midpoint: x = 3
+    report = pyomo_pounce.preflight(m)
+    assert not report.fatal
+    assert math.isfinite(report.objective)

--- a/pyomo-pounce/tests/test_repair.py
+++ b/pyomo-pounce/tests/test_repair.py
@@ -1,0 +1,103 @@
+"""Tests for pyomo_pounce.project_to_feasible and the initialize pipeline.
+
+The projection is a real POUNCE solve, so most of these need the
+binary and skip without it.
+"""
+
+import pyomo.environ as pyo
+import pytest
+
+import pyomo_pounce
+
+pytest.importorskip("networkx", reason="initialize pipeline needs networkx")
+pytest.importorskip("scipy", reason="initialize pipeline needs scipy")
+
+
+@pytest.fixture(scope="module")
+def solver():
+    s = pyo.SolverFactory("pounce")
+    if not s.available(exception_flag=False):
+        pytest.skip("pounce binary not found on PATH")
+    return s
+
+
+def _mole_fraction_model():
+    """The reviewer's example: midpoint fill gives x_i = 0.5 each, which
+    violates sum(x) == 1."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var([1, 2, 3], bounds=(0.0, 1.0))
+    m.sum_to_one = pyo.Constraint(expr=m.x[1] + m.x[2] + m.x[3] == 1.0)
+    m.obj = pyo.Objective(expr=m.x[1])
+    return m
+
+
+def test_project_repairs_inconsistent_fill(solver):
+    m = _mole_fraction_model()
+    n = pyomo_pounce.initialize_missing_values(m)  # x_i = 0.5, sum = 1.5
+    assert n == 3
+    cond = pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert cond in ("optimal", "locallyOptimal")
+    total = sum(pyo.value(m.x[i]) for i in [1, 2, 3])
+    assert total == pytest.approx(1.0, abs=1e-6)
+    # Min-norm from equal anchors: the components stay equal.
+    for i in [1, 2, 3]:
+        assert pyo.value(m.x[i]) == pytest.approx(1.0 / 3.0, abs=1e-5)
+
+
+def test_project_restores_objective(solver):
+    m = _mole_fraction_model()
+    pyomo_pounce.initialize_missing_values(m)
+    assert m.obj.active
+    pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert m.obj.active  # original objective restored
+    # ... and the temporary projection objective is gone.
+    objs = list(m.component_data_objects(pyo.Objective, descend_into=True))
+    assert len(objs) == 1
+
+
+def test_project_without_anchors_raises():
+    m = _mole_fraction_model()  # nothing has a value yet
+    with pytest.raises(ValueError, match="initialize_missing_values"):
+        pyomo_pounce.project_to_feasible(m)
+
+
+def test_initialize_pipeline_end_to_end(solver):
+    # fill -> repair -> block-solve on a split with a composition sum.
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var(initialize=10.0)
+    m.split = pyo.Var(bounds=(0.0, 1.0), initialize=0.3)
+    m.out1 = pyo.Var(bounds=(0.0, None))
+    m.out2 = pyo.Var(bounds=(0.0, None))
+    m.x = pyo.Var([1, 2], bounds=(0.0, 1.0))
+    m.bal1 = pyo.Constraint(expr=m.out1 == m.split * m.feed)
+    m.bal2 = pyo.Constraint(expr=m.out2 == (1.0 - m.split) * m.feed)
+    m.sum_x = pyo.Constraint(expr=m.x[1] + m.x[2] == 1.0)
+    m.obj = pyo.Objective(expr=m.out1 + m.x[1])
+
+    report = pyomo_pounce.initialize(
+        m, decisions=[m.feed, m.split], solver=solver
+    )
+    assert report.ok, str(report)
+    assert report.n_filled == 4  # out1, out2, x[1], x[2]
+    assert report.projection in ("optimal", "locallyOptimal")
+    assert report.block is not None and report.block.ok
+    # Block solve produced the physical profile with decisions held...
+    assert m.out1.value == pytest.approx(3.0, abs=1e-5)
+    assert m.out2.value == pytest.approx(7.0, abs=1e-5)
+    # ... and the projection made the composition consistent.
+    assert pyo.value(m.x[1]) + pyo.value(m.x[2]) == pytest.approx(1.0, abs=1e-5)
+    # Decisions are free again for the optimizer.
+    assert not m.feed.fixed and not m.split.fixed
+    assert "fill -> repair -> block-solve" in str(report)
+
+
+def test_initialize_skips_projection_when_asked():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(1.0, 3.0))
+    m.c = pyo.Constraint(expr=m.x <= 2.5)
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.initialize(m, project=False)
+    assert report.projection is None
+    assert report.n_filled == 1
+    assert m.x.value == pytest.approx(2.0)  # midpoint fill, no repair

--- a/python/examples/hs071_warm_start.py
+++ b/python/examples/hs071_warm_start.py
@@ -1,18 +1,25 @@
 """HS071 solved cold, then warm-started from the cold solution.
 
-`warm_start_init_point=yes` forwards the primal point and the dual
-seeds (`lagrange`, `zl`, `zu`) into the iterate initializer -- but on
-its own it does NOT cut iterations. Two defaults cancel the warm start:
+The one-liner is `pounce.WarmStart`: capture a solve's state with
+`WarmStart.from_info(x, info)` and pass it back as
+`solve(warm_start=ws)`. On HS071 that takes the re-solve from 11
+iterations down to 5.
+
+The rest of this example shows what that does under the hood, and why
+each piece is needed. `warm_start_init_point=yes` forwards the primal
+point and the dual seeds (`lagrange`, `zl`, `zu`) into the iterate
+initializer -- but on its own it does NOT cut iterations. Two defaults
+cancel the warm start:
 
 * `mu_init` (0.1) keeps the barrier parameter large, so the solver still
   walks mu down its full schedule even when started at x*.
-* `warm_start_bound_push` / `_frac` (1e-2) shove the initial point off
+* `warm_start_bound_push` / `_frac` (1e-3) shove the initial point off
   its bounds; HS071's x1 sits exactly on its lower bound, so the warm
   point is discarded.
 
 To actually save iterations, pair the dual seeds with a small `mu_init`
-and tight `warm_start_*_bound_push`/`_frac`. On HS071 that takes the
-re-solve from 11 iterations down to 5.
+and tight `warm_start_*_bound_push`/`_frac` -- which is exactly the
+option set `WarmStart` applies for you.
 """
 
 import numpy as np
@@ -74,6 +81,16 @@ def main():
     cold_x, cold_info = make_problem().solve(x0=np.array([1.0, 5.0, 5.0, 1.0]))
     print(f"cold:                   status={cold_info['status_msg']}, "
           f"iters={cold_info['iter_count']}")
+
+    # The one-liner: WarmStart captures x, the duals, and mu, and applies
+    # the whole tuned-option recipe below on the next solve.
+    ws = pounce.WarmStart.from_info(cold_x, cold_info)
+    ws_x, ws_info = make_problem().solve(warm_start=ws)
+    print(f"warm (WarmStart):       status={ws_info['status_msg']}, "
+          f"iters={ws_info['iter_count']}   <- {cold_info['iter_count']} "
+          f"-> {ws_info['iter_count']}")
+
+    # ----- what WarmStart does under the hood, step by step -----
 
     seeds = dict(
         lagrange=np.asarray(cold_info["mult_g"]),

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -29,6 +29,7 @@ from ._curve_fit import (
 )
 from ._minima import find_minima, MinimaResult
 from ._preflight import preflight, PreflightReport
+from ._starts import generate_starts, project_to_feasible, race_starts
 from ._critical import (
     find_critical_points, find_saddles, reaction_network,
     CriticalPoint, CriticalPointResult, Connection, ReactionNetwork,
@@ -70,10 +71,14 @@ __all__ = [
     "Connection",
     "ReactionNetwork",
     "classify_working_set",
-    # Starting-point preflight + warm starts (see docs: initialization.md)
+    # Starting-point preflight, warm starts, and generation/repair
+    # (see docs: initialization.md)
     "preflight",
     "PreflightReport",
     "WarmStart",
+    "generate_starts",
+    "project_to_feasible",
+    "race_starts",
     # Convex QP / SOCP (the same solvers also live under ``pounce.qp``)
     "QpResult",
     "QpFactorization",

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -25,6 +25,7 @@ from ._curve_fit import (
     CurveFitResult,
 )
 from ._minima import find_minima, MinimaResult
+from ._preflight import preflight, PreflightReport
 from ._critical import (
     find_critical_points, find_saddles, reaction_network,
     CriticalPoint, CriticalPointResult, Connection, ReactionNetwork,
@@ -66,6 +67,9 @@ __all__ = [
     "Connection",
     "ReactionNetwork",
     "classify_working_set",
+    # Starting-point preflight (see docs: initialization.md)
+    "preflight",
+    "PreflightReport",
     # Convex QP / SOCP (the same solvers also live under ``pounce.qp``)
     "QpResult",
     "QpFactorization",

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -16,6 +16,9 @@ in JAX when it is not installed.
 from ._pounce import (
     Problem, Solver, NlProblem, read_nl, classify_working_set, __version__,
 )
+# Installs the Problem.solve(warm_start=...) wrapper as an import side
+# effect — keep this import directly after ._pounce.
+from ._warm_start import WarmStart
 from ._minimize import minimize, OptimizeResult
 from ._nlp_batch import solve_nlp_batch
 from ._curve_fit import (
@@ -67,9 +70,10 @@ __all__ = [
     "Connection",
     "ReactionNetwork",
     "classify_working_set",
-    # Starting-point preflight (see docs: initialization.md)
+    # Starting-point preflight + warm starts (see docs: initialization.md)
     "preflight",
     "PreflightReport",
+    "WarmStart",
     # Convex QP / SOCP (the same solvers also live under ``pounce.qp``)
     "QpResult",
     "QpFactorization",

--- a/python/pounce/_minima.py
+++ b/python/pounce/_minima.py
@@ -355,48 +355,10 @@ def _mk_result(x, f):
 
 
 # --------------------------------------------------------------------------
-# Start-point helpers.
+# Start-point helpers — the implementations live in pounce._starts, where
+# they also power the public pounce.generate_starts.
 # --------------------------------------------------------------------------
-def _box(bounds):
-    lo = np.array([b[0] for b in bounds], dtype=float)
-    hi = np.array([b[1] for b in bounds], dtype=float)
-    return lo, hi
-
-
-def _has_box(bounds):
-    return bounds is not None and all(
-        b is not None and b[0] is not None and b[1] is not None
-        for b in bounds
-    )
-
-
-def _sample(bounds, x0, rng, jitter, sobol=None):
-    """Draw a fresh start: Sobol/uniform in the box, else jitter around x0."""
-    if _has_box(bounds):
-        lo, hi = _box(bounds)
-        if sobol is not None:
-            u = sobol.random(1)[0]
-        else:
-            u = rng.random(x0.shape)
-        return lo + (hi - lo) * u
-    return x0 + jitter * rng.standard_normal(x0.shape)
-
-
-def _make_sobol(n, seed, enabled):
-    if not enabled:
-        return None
-    try:
-        from scipy.stats import qmc
-        return qmc.Sobol(d=n, scramble=True, seed=seed)
-    except Exception:
-        return None
-
-
-def _clip(x, bounds):
-    if not _has_box(bounds):
-        return x
-    lo, hi = _box(bounds)
-    return np.clip(x, lo, hi)
+from ._starts import _box, _clip, _has_box, _make_sobol, _sample  # noqa: E402
 
 
 # --------------------------------------------------------------------------

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -899,6 +899,7 @@ def minimize(
     bounds: Sequence | None = None,
     constraints: Sequence | LinearConstraint | dict | None = None,
     callback: Callable | None = None,
+    warm_start=None,
     **options: Any,
 ) -> OptimizeResult:
     """scipy.optimize.minimize-style facade over pounce.
@@ -938,6 +939,13 @@ def minimize(
     Like :func:`scipy.optimize.minimize`, this facade is **silent by default**.
     Pass ``disp=True`` for a concise log or an explicit ``print_level=N``
     (0–12) to control the NLP backend's IPM iteration table directly.
+
+    Re-solves of a related problem can pass ``warm_start=`` a
+    :class:`pounce.WarmStart` captured from a previous result
+    (``WarmStart.from_info(res.x, res.info)``): it seeds the primal and
+    dual iterates and sets the enabling warm-start options (see
+    the initialization chapter of the docs). A warm start always runs on
+    the NLP path — convex routing is skipped.
     """
     # Accept both calling conventions: scipy-style ``options={...}`` (one dict
     # argument) and the splatted ``**options`` form (kwargs absorbed by the
@@ -967,6 +975,13 @@ def minimize(
     # `"nlp"` (no probe) — opt in to `"auto"` to enable structure detection.
     selection = str(options.pop("solver_selection", "nlp")).lower()
     route_tol = float(options.pop("route_tol", 1e-5))
+    if warm_start is not None and selection != "nlp":
+        warnings.warn(
+            "pounce.minimize: warm_start= runs on the NLP path; "
+            f"solver_selection={selection!r} is ignored for this solve.",
+            stacklevel=2,
+        )
+        selection = "nlp"
     # scipy.optimize.minimize is silent unless `disp=True`; match that. pounce's
     # NLP backend otherwise prints a full IPM iteration table by default (and
     # the log is written from Rust to fd 1, so Python stdout redirection can't
@@ -1148,7 +1163,12 @@ def minimize(
         ipopt_k, ipopt_v = _translate_option(k, v)
         problem.add_option(ipopt_k, ipopt_v)
 
-    x, info = problem.solve(x0=x0)
+    # Pass warm_start only when set: test doubles (and any cyipopt-style
+    # stand-in) may not accept the keyword.
+    if warm_start is not None:
+        x, info = problem.solve(x0=x0, warm_start=warm_start)
+    else:
+        x, info = problem.solve(x0=x0)
     # (E, gh #119 / #123) Judge success on the final KKT error, not the exit
     # status enum alone. Ipopt-family solvers report a non-success status (e.g.
     # ``Search_Direction_Becomes_Too_Small``, code 3) when progress stalls — but

--- a/python/pounce/_preflight.py
+++ b/python/pounce/_preflight.py
@@ -1,0 +1,467 @@
+"""Starting-point preflight: evaluate a problem once at x0, before any
+solve, and report what iteration 0 will see.
+
+This is the Python twin of the ``pounce check-x0`` CLI subcommand (see
+``docs/src/initialization.md``): NaN/inf evaluations are fatal (a solve
+would abort with ``Invalid_Number_Detected``), bound violations and
+on-bound components will be moved by the interior clamp, very large
+initial constraint violation usually means a wrong or missing starting
+point, and wide derivative magnitude spread is the early signal for
+scaling trouble.
+
+The native :class:`pounce.Problem` does not expose its callbacks or
+bounds, so ``preflight`` takes the same pieces the ``Problem``
+constructor does::
+
+    report = pounce.preflight(problem_obj, x0, lb=lb, ub=ub, cl=cl, cu=cu)
+    if report.fatal:
+        raise ValueError(str(report))
+    x, info = pounce.Problem(n, m, problem_obj=problem_obj,
+                             lb=lb, ub=ub, cl=cl, cu=cu).solve(x0=x0)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+import numpy as np
+
+__all__ = ["preflight", "PreflightReport"]
+
+# Bounds at or beyond this magnitude are treated as infinite, matching
+# the solver's NLP_LOWER_BOUND_INF / NLP_UPPER_BOUND_INF sentinels.
+_BOUND_INF = 1e19
+
+
+@dataclass
+class PreflightReport:
+    """Result of :func:`preflight`. ``str(report)`` renders a readable
+    text report; :meth:`to_dict` gives the JSON-ready form (the same
+    shape as ``pounce check-x0 --json``, minus file provenance)."""
+
+    n: int
+    m: int
+    objective: Optional[float]
+    x0_all_zero: bool
+    # non-finite scans: (index-or-(row,col), value) pairs, capped lists
+    grad_nonfinite: List[Tuple[int, float]]
+    grad_nonfinite_count: int
+    g_nonfinite: List[Tuple[int, float]]
+    g_nonfinite_count: int
+    jac_nonfinite: List[Tuple[int, int, float]]
+    jac_nonfinite_count: int
+    hess_nonfinite_count: Optional[int]
+    eval_errors: List[str]
+    # x0 vs bounds
+    bound_violations: List[Tuple[int, float, float, float, float]]  # (j, x, lo, hi, viol)
+    n_bound_violations: int
+    max_bound_violation: float
+    n_on_bounds: int
+    # interior-clamp preview
+    clamp_moves: List[Tuple[int, float, float, float]]  # (j, from, to, dist)
+    n_clamp_moved: int
+    max_clamp_move: float
+    # initial constraint violation
+    con_violations: List[Tuple[int, float, float, float, float]]  # (i, g, lo, hi, viol)
+    n_con_violations: int
+    max_con_violation: float
+    # derivative scale spread: (max_abs, min_abs_nonzero, ratio)
+    grad_spread: Tuple[float, float, float]
+    jac_spread: Tuple[float, float, float]
+    # rollup
+    warnings: List[str] = field(default_factory=list)
+    fatal: bool = False
+    verdict: str = "CLEAN"
+
+    @property
+    def ok(self) -> bool:
+        """True when the model evaluates cleanly at x0 (warnings allowed)."""
+        return not self.fatal
+
+    def to_dict(self) -> dict:
+        return {
+            "schema": "pounce.check-x0/v1",
+            "problem": {"n_vars": self.n, "n_cons": self.m},
+            "x0": {"all_zero": self.x0_all_zero},
+            "evaluation": {
+                "objective": self.objective
+                if self.objective is not None and np.isfinite(self.objective)
+                else None,
+                "objective_finite": self.objective is not None
+                and bool(np.isfinite(self.objective)),
+                "grad_nonfinite_count": self.grad_nonfinite_count,
+                "constraints_nonfinite_count": self.g_nonfinite_count,
+                "jacobian_nonfinite_count": self.jac_nonfinite_count,
+                "hessian_nonfinite_count": self.hess_nonfinite_count,
+                "errors": list(self.eval_errors),
+            },
+            "bounds": {
+                "n_violations": self.n_bound_violations,
+                "max_violation": self.max_bound_violation,
+                "n_on_bounds": self.n_on_bounds,
+                "worst": [
+                    {"index": j, "value": x, "lower": lo, "upper": hi, "violation": v}
+                    for (j, x, lo, hi, v) in self.bound_violations
+                ],
+            },
+            "interior_clamp": {
+                "n_moved": self.n_clamp_moved,
+                "max_move": self.max_clamp_move,
+                "worst": [
+                    {"index": j, "from": a, "to": b, "distance": d}
+                    for (j, a, b, d) in self.clamp_moves
+                ],
+            },
+            "constraint_violation": {
+                "n_violated": self.n_con_violations,
+                "max_violation": self.max_con_violation,
+                "worst": [
+                    {"index": i, "value": g, "lower": lo, "upper": hi, "violation": v}
+                    for (i, g, lo, hi, v) in self.con_violations
+                ],
+            },
+            "derivative_scale": {
+                "gradient": dict(
+                    zip(("max_abs", "min_abs_nonzero", "ratio"), self.grad_spread)
+                ),
+                "jacobian": dict(
+                    zip(("max_abs", "min_abs_nonzero", "ratio"), self.jac_spread)
+                ),
+            },
+            "warnings": list(self.warnings),
+            "fatal": self.fatal,
+            "verdict": self.verdict,
+        }
+
+    def __str__(self) -> str:  # noqa: C901 - straightforward rendering
+        lines = ["pounce preflight — starting-point check"]
+        lines.append(f"  problem : {self.n} vars, {self.m} cons")
+        lines.append(f"  x0      : {'all zeros' if self.x0_all_zero else 'supplied'}")
+        obj = (
+            f"{self.objective:.10e}"
+            if self.objective is not None and np.isfinite(self.objective)
+            else f"{self.objective}  <- NON-FINITE"
+            if self.objective is not None
+            else "EVALUATION FAILED"
+        )
+        lines.append(f"  objective at x0: {obj}")
+        for label, count in (
+            ("gradient", self.grad_nonfinite_count),
+            ("constraints", self.g_nonfinite_count),
+            ("Jacobian", self.jac_nonfinite_count),
+        ):
+            state = "finite" if count == 0 else f"{count} non-finite entries"
+            lines.append(f"  {label:<11}: {state}")
+        if self.hess_nonfinite_count is not None:
+            state = (
+                "finite (lambda=0)"
+                if self.hess_nonfinite_count == 0
+                else f"{self.hess_nonfinite_count} non-finite entries (lambda=0)"
+            )
+            lines.append(f"  Hessian    : {state}")
+        for err in self.eval_errors:
+            lines.append(f"  eval error : {err}")
+        lines.append(
+            f"  bounds     : {self.n_bound_violations} violated, "
+            f"{self.n_on_bounds} on-bound; clamp moves {self.n_clamp_moved} "
+            f"(max {self.max_clamp_move:.3e})"
+        )
+        lines.append(
+            f"  constraints: {self.n_con_violations} violated at x0 "
+            f"(max {self.max_con_violation:.3e})"
+        )
+        for w in self.warnings:
+            lines.append(f"  warning: {w}")
+        lines.append(f"  VERDICT: {self.verdict}")
+        return "\n".join(lines)
+
+
+def _as_bounds(bound, n: int, default: float) -> np.ndarray:
+    if bound is None:
+        return np.full(n, default)
+    b = np.asarray(bound, dtype=float).ravel()
+    if b.size != n:
+        raise ValueError(f"bound has length {b.size}, expected {n}")
+    return b
+
+
+def _finite_bound(b: float) -> bool:
+    return bool(np.isfinite(b)) and -_BOUND_INF < b < _BOUND_INF
+
+
+def _box_violation(v: float, lo: float, hi: float) -> float:
+    if not np.isfinite(v):
+        return float("inf")
+    below = lo - v if _finite_bound(lo) else -float("inf")
+    above = v - hi if _finite_bound(hi) else -float("inf")
+    return max(below, above, 0.0)
+
+
+def _clamp_to_interior(
+    x: float, lo: float, hi: float, bound_push: float, bound_frac: float
+) -> float:
+    """The per-component interior clamp from the solver's
+    ``DefaultIterateInitializer`` (see docs/src/initialization.md)."""
+    flo, fhi = _finite_bound(lo), _finite_bound(hi)
+    if flo and fhi:
+        span = hi - lo
+        p_l = min(bound_push * max(abs(lo), 1.0), bound_frac * span)
+        p_u = min(bound_push * max(abs(hi), 1.0), bound_frac * span)
+        return min(max(x, lo + p_l), hi - p_u)
+    if flo:
+        return max(x, lo + bound_push * max(abs(lo), 1.0))
+    if fhi:
+        return min(x, hi - bound_push * max(abs(hi), 1.0))
+    return x
+
+
+def _scale_spread(values: np.ndarray) -> Tuple[float, float, float]:
+    a = np.abs(np.asarray(values, dtype=float).ravel())
+    a = a[np.isfinite(a) & (a > 0.0)]
+    if a.size == 0:
+        return (0.0, 0.0, 0.0)
+    mx, mn = float(a.max()), float(a.min())
+    return (mx, mn, mx / mn)
+
+
+def _nonfinite_indexed(values: np.ndarray, cap: int) -> Tuple[List[Tuple[int, float]], int]:
+    v = np.asarray(values, dtype=float).ravel()
+    bad = np.flatnonzero(~np.isfinite(v))
+    return [(int(i), float(v[i])) for i in bad[:cap]], int(bad.size)
+
+
+def preflight(
+    problem_obj: Any,
+    x0,
+    *,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    feas_tol: float = 1e-6,
+    bound_push: float = 1e-2,
+    bound_frac: float = 1e-2,
+    max_list: int = 5,
+) -> PreflightReport:
+    """Evaluate ``problem_obj`` once at ``x0`` and report what the solver's
+    first iteration will see.
+
+    Parameters mirror the :class:`pounce.Problem` constructor:
+    ``problem_obj`` is a cyipopt-style object with ``objective(x)`` and
+    optionally ``gradient(x)``, ``constraints(x)``, ``jacobian(x)`` (+
+    ``jacobianstructure()``), ``hessian(x, lagrange, obj_factor)`` (+
+    ``hessianstructure()``); ``lb``/``ub`` are variable bounds and
+    ``cl``/``cu`` constraint bounds (``None`` = unbounded).
+
+    Returns a :class:`PreflightReport`. ``report.fatal`` is True exactly
+    when an evaluation produced NaN/inf or raised, i.e. when a solve from
+    this ``x0`` would abort with ``Invalid_Number_Detected``. Bound and
+    constraint violations are reported but are *not* fatal: the solver
+    clamps bound violations and the interior-point method accepts an
+    infeasible start.
+    """
+    x0 = np.asarray(x0, dtype=float).ravel()
+    n = x0.size
+    eval_errors: List[str] = []
+
+    def _try(label, fn, *args):
+        try:
+            return fn(*args)
+        except Exception as e:  # noqa: BLE001 - report, don't crash
+            eval_errors.append(f"{label} raised {type(e).__name__}: {e}")
+            return None
+
+    # --- constraint bounds first (they define m) ---
+    g = None
+    if hasattr(problem_obj, "constraints"):
+        g = _try("constraints(x0)", problem_obj.constraints, x0)
+    if g is not None:
+        g = np.asarray(g, dtype=float).ravel()
+        m = g.size
+    elif cl is not None:
+        m = np.asarray(cl, dtype=float).ravel().size
+    else:
+        m = 0
+    x_l = _as_bounds(lb, n, -np.inf)
+    x_u = _as_bounds(ub, n, np.inf)
+    g_l = _as_bounds(cl, m, -np.inf)
+    g_u = _as_bounds(cu, m, np.inf)
+
+    # --- evaluations at x0 ---
+    fval = _try("objective(x0)", problem_obj.objective, x0)
+    objective = float(fval) if fval is not None else None
+
+    grad = None
+    if hasattr(problem_obj, "gradient"):
+        grad = _try("gradient(x0)", problem_obj.gradient, x0)
+    grad = np.asarray(grad, dtype=float).ravel() if grad is not None else np.zeros(0)
+    grad_nonfinite, grad_nonfinite_count = _nonfinite_indexed(grad, max_list)
+
+    g_arr = g if g is not None else np.zeros(0)
+    g_nonfinite, g_nonfinite_count = _nonfinite_indexed(g_arr, max_list)
+
+    # Jacobian: honor jacobianstructure() when present, else dense (m, n).
+    jac_nonfinite: List[Tuple[int, int, float]] = []
+    jac_nonfinite_count = 0
+    jac_vals = np.zeros(0)
+    if m > 0 and hasattr(problem_obj, "jacobian"):
+        jv = _try("jacobian(x0)", problem_obj.jacobian, x0)
+        if jv is not None:
+            jac_vals = np.asarray(jv, dtype=float).ravel()
+            if hasattr(problem_obj, "jacobianstructure"):
+                rows, cols = problem_obj.jacobianstructure()
+                rows = np.asarray(rows, dtype=int).ravel()
+                cols = np.asarray(cols, dtype=int).ravel()
+            else:
+                rows, cols = np.divmod(np.arange(jac_vals.size), n)
+            bad = np.flatnonzero(~np.isfinite(jac_vals))
+            jac_nonfinite_count = int(bad.size)
+            jac_nonfinite = [
+                (int(rows[k]), int(cols[k]), float(jac_vals[k]))
+                for k in bad[:max_list]
+                if k < rows.size
+            ]
+
+    # Hessian of the Lagrangian at (x0, lambda=0, obj_factor=1).
+    hess_nonfinite_count: Optional[int] = None
+    if hasattr(problem_obj, "hessian"):
+        hv = _try(
+            "hessian(x0, 0, 1)", problem_obj.hessian, x0, np.zeros(m), 1.0
+        )
+        if hv is not None:
+            hvals = np.asarray(hv, dtype=float).ravel()
+            hess_nonfinite_count = int(np.count_nonzero(~np.isfinite(hvals)))
+
+    # --- x0 vs bounds + clamp preview ---
+    bound_violations: List[Tuple[int, float, float, float, float]] = []
+    n_bound_violations = 0
+    max_bound_violation = 0.0
+    n_on_bounds = 0
+    clamp_moves: List[Tuple[int, float, float, float]] = []
+    n_clamp_moved = 0
+    max_clamp_move = 0.0
+    for j in range(n):
+        viol = _box_violation(x0[j], x_l[j], x_u[j])
+        if viol > feas_tol:
+            n_bound_violations += 1
+            if np.isfinite(viol):
+                max_bound_violation = max(max_bound_violation, viol)
+            bound_violations.append((j, float(x0[j]), float(x_l[j]), float(x_u[j]), viol))
+        if np.isfinite(x0[j]):
+            at_lo = _finite_bound(x_l[j]) and abs(x0[j] - x_l[j]) <= 1e-8 * (
+                1.0 + abs(x_l[j])
+            )
+            at_hi = _finite_bound(x_u[j]) and abs(x_u[j] - x0[j]) <= 1e-8 * (
+                1.0 + abs(x_u[j])
+            )
+            if at_lo or at_hi:
+                n_on_bounds += 1
+            to = _clamp_to_interior(x0[j], x_l[j], x_u[j], bound_push, bound_frac)
+            d = abs(to - x0[j])
+            if d > 0.0:
+                n_clamp_moved += 1
+                max_clamp_move = max(max_clamp_move, d)
+                clamp_moves.append((j, float(x0[j]), float(to), float(d)))
+    bound_violations.sort(key=lambda t: -t[4])
+    del bound_violations[max_list:]
+    clamp_moves.sort(key=lambda t: -t[3])
+    del clamp_moves[max_list:]
+
+    # --- initial constraint violation ---
+    con_violations: List[Tuple[int, float, float, float, float]] = []
+    n_con_violations = 0
+    max_con_violation = 0.0
+    for i in range(g_arr.size):
+        viol = _box_violation(g_arr[i], g_l[i], g_u[i])
+        if viol > feas_tol:
+            n_con_violations += 1
+            if np.isfinite(viol):
+                max_con_violation = max(max_con_violation, viol)
+            con_violations.append((i, float(g_arr[i]), float(g_l[i]), float(g_u[i]), viol))
+    con_violations.sort(key=lambda t: -t[4])
+    del con_violations[max_list:]
+
+    grad_spread = _scale_spread(grad)
+    jac_spread = _scale_spread(jac_vals)
+
+    # --- warnings + verdict ---
+    warnings: List[str] = []
+    nonfinite_total = (
+        grad_nonfinite_count
+        + g_nonfinite_count
+        + jac_nonfinite_count
+        + (hess_nonfinite_count or 0)
+        + int(objective is not None and not np.isfinite(objective))
+    )
+    fatal = bool(eval_errors) or nonfinite_total > 0 or objective is None
+    if eval_errors:
+        warnings.append(
+            "an evaluation callback raised at the starting point; the solver "
+            "cannot start from this x0"
+        )
+    if nonfinite_total > 0:
+        warnings.append(
+            f"{nonfinite_total} non-finite value(s) at the starting point; a "
+            "solve would abort with Invalid_Number_Detected. Move x0 into the "
+            "domain or add bounds that keep it there"
+        )
+    x0_all_zero = n > 0 and bool(np.all(x0 == 0.0))
+    if x0_all_zero:
+        warnings.append("the starting point is all zeros")
+    if n_bound_violations > 0:
+        warnings.append(
+            f"x0 violates {n_bound_violations} variable bound(s) "
+            f"(max {max_bound_violation:.3e}); the initializer will clamp them inside"
+        )
+    if n_on_bounds > 0:
+        warnings.append(
+            f"{n_on_bounds} component(s) of x0 sit exactly on a bound and will "
+            f"be pushed into the interior (bound_push={bound_push:.1e}); if x0 "
+            "is a previous solution, use the warm-start recipe "
+            "(warm_start_init_point=yes with tightened warm_start_bound_push/_frac)"
+        )
+    if max_con_violation > 1e4:
+        warnings.append(
+            f"very large initial infeasibility (max constraint violation "
+            f"{max_con_violation:.3e}); consider a better starting point or "
+            "least_square_init_primal=yes"
+        )
+    for label, spread in (("gradient", grad_spread), ("Jacobian", jac_spread)):
+        if spread[2] > 1e8 or spread[0] > 1e8:
+            warnings.append(
+                f"{label} magnitudes at x0 span a large range (max {spread[0]:.3e}, "
+                f"min nonzero {spread[1]:.3e}); see the scaling reference page"
+            )
+
+    verdict = "FATAL" if fatal else ("WARNINGS" if warnings else "CLEAN")
+
+    return PreflightReport(
+        n=n,
+        m=m,
+        objective=objective,
+        x0_all_zero=x0_all_zero,
+        grad_nonfinite=grad_nonfinite,
+        grad_nonfinite_count=grad_nonfinite_count,
+        g_nonfinite=g_nonfinite,
+        g_nonfinite_count=g_nonfinite_count,
+        jac_nonfinite=jac_nonfinite,
+        jac_nonfinite_count=jac_nonfinite_count,
+        hess_nonfinite_count=hess_nonfinite_count,
+        eval_errors=eval_errors,
+        bound_violations=bound_violations,
+        n_bound_violations=n_bound_violations,
+        max_bound_violation=max_bound_violation,
+        n_on_bounds=n_on_bounds,
+        clamp_moves=clamp_moves,
+        n_clamp_moved=n_clamp_moved,
+        max_clamp_move=max_clamp_move,
+        con_violations=con_violations,
+        n_con_violations=n_con_violations,
+        max_con_violation=max_con_violation,
+        grad_spread=grad_spread,
+        jac_spread=jac_spread,
+        warnings=warnings,
+        fatal=fatal,
+        verdict=verdict,
+    )

--- a/python/pounce/_starts.py
+++ b/python/pounce/_starts.py
@@ -1,0 +1,308 @@
+"""Starting-point generation and repair.
+
+Three composable building blocks (see ``docs/src/initialization.md``):
+
+* :func:`generate_starts` — draw N diverse starting points (Sobol /
+  uniform / jitter / bounds midpoint). This is the sampler that powers
+  :func:`pounce.find_minima`, exposed as a standalone primitive.
+* :func:`project_to_feasible` — min-norm repair of a candidate point
+  onto the linearized constraints and bounds (one convex QP).
+* :func:`race_starts` — run a few solver iterations from each of N
+  starts and rank them, so the full-effort solve continues only from
+  the most promising one(s).
+
+The sampling internals here are also imported by ``pounce._minima``;
+keep the private helpers' signatures stable.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import numpy as np
+
+__all__ = ["generate_starts", "project_to_feasible", "race_starts"]
+
+# Bounds at or beyond this magnitude count as infinite (the solver's
+# NLP_*_BOUND_INF sentinels).
+_BOUND_INF = 1e19
+
+
+# --------------------------------------------------------------------------
+# Sampling primitives (shared with pounce._minima).
+# --------------------------------------------------------------------------
+def _box(bounds):
+    lo = np.array([b[0] for b in bounds], dtype=float)
+    hi = np.array([b[1] for b in bounds], dtype=float)
+    return lo, hi
+
+
+def _has_box(bounds):
+    return bounds is not None and all(
+        b is not None and b[0] is not None and b[1] is not None
+        for b in bounds
+    )
+
+
+def _sample(bounds, x0, rng, jitter, sobol=None):
+    """Draw a fresh start: Sobol/uniform in the box, else jitter around x0."""
+    if _has_box(bounds):
+        lo, hi = _box(bounds)
+        if sobol is not None:
+            u = sobol.random(1)[0]
+        else:
+            u = rng.random(x0.shape)
+        return lo + (hi - lo) * u
+    return x0 + jitter * rng.standard_normal(x0.shape)
+
+
+def _make_sobol(n, seed, enabled):
+    if not enabled:
+        return None
+    try:
+        from scipy.stats import qmc
+        return qmc.Sobol(d=n, scramble=True, seed=seed)
+    except Exception:
+        return None
+
+
+def _clip(x, bounds):
+    if not _has_box(bounds):
+        return x
+    lo, hi = _box(bounds)
+    return np.clip(x, lo, hi)
+
+
+def _finite(b) -> bool:
+    return b is not None and np.isfinite(b) and -_BOUND_INF < b < _BOUND_INF
+
+
+def _midpoint(bounds, x0, n):
+    """Bounds-aware deterministic start: midpoint of each finite box,
+    one unit inside a one-sided bound, else the x0 component (or 0)."""
+    base = np.zeros(n) if x0 is None else np.asarray(x0, dtype=float).ravel()
+    if bounds is None:
+        return base.copy()
+    out = base.copy()
+    for j, b in enumerate(bounds):
+        lo = b[0] if b is not None else None
+        hi = b[1] if b is not None else None
+        flo, fhi = _finite(lo), _finite(hi)
+        if flo and fhi:
+            out[j] = 0.5 * (lo + hi)
+        elif flo:
+            out[j] = max(out[j], lo + 1.0)
+        elif fhi:
+            out[j] = min(out[j], hi - 1.0)
+    return out
+
+
+# --------------------------------------------------------------------------
+# Public API.
+# --------------------------------------------------------------------------
+def generate_starts(
+    n_points: int,
+    *,
+    bounds=None,
+    x0=None,
+    strategy: str = "sobol",
+    jitter: float = 0.1,
+    seed: Optional[int] = None,
+) -> np.ndarray:
+    """Generate ``n_points`` starting points, shape ``(n_points, n)``.
+
+    This is the sampler behind :func:`pounce.find_minima`, exposed as a
+    composable primitive — feed the result to
+    :func:`pounce.solve_nlp_batch`, :func:`race_starts`, or a loop of
+    :func:`pounce.minimize` calls.
+
+    Args:
+        n_points: How many starts to generate.
+        bounds: ``[(lo, hi), ...]`` box, scipy-style. Entries (or either
+            side) may be ``None`` / ``±inf`` for unbounded.
+        x0: Anchor point. Required for the ``jitter`` strategy and for
+            any strategy when ``bounds`` has unbounded components.
+        strategy: One of
+            ``"sobol"`` — scrambled Sobol sequence in the box (falls
+            back to uniform when SciPy is unavailable);
+            ``"uniform"`` — i.i.d. uniform in the box;
+            ``"jitter"`` — Gaussian ``x0 + jitter * N(0, I)`` samples;
+            ``"midpoint"`` — the deterministic bounds midpoint first
+            (the cold start the solver *doesn't* give you: zeros +
+            clamp), then Sobol for the remainder.
+        jitter: Scale for the ``jitter`` strategy (also used as the
+            fallback when a box strategy meets unbounded components).
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        ``(n_points, n)`` array; every row is clipped into ``bounds``.
+    """
+    if n_points < 1:
+        raise ValueError("n_points must be >= 1")
+    if x0 is not None:
+        x0 = np.asarray(x0, dtype=float).ravel()
+        n = x0.size
+    elif bounds is not None:
+        n = len(bounds)
+    else:
+        raise ValueError("generate_starts needs bounds or x0 to fix the dimension")
+    if x0 is None:
+        if not _has_box(bounds):
+            raise ValueError(
+                "generate_starts: with unbounded components, pass x0 as the anchor"
+            )
+        x0 = _midpoint(bounds, None, n)
+
+    strategy = strategy.lower()
+    if strategy not in ("sobol", "uniform", "jitter", "midpoint"):
+        raise ValueError(f"unknown strategy {strategy!r}")
+
+    rng = np.random.default_rng(seed)
+    starts = np.empty((n_points, n), dtype=float)
+    k = 0
+    if strategy == "midpoint":
+        starts[0] = _midpoint(bounds, x0, n)
+        k = 1
+    if strategy == "jitter":
+        for i in range(k, n_points):
+            starts[i] = x0 + jitter * rng.standard_normal(n)
+    else:
+        sobol = _make_sobol(n, seed, strategy in ("sobol", "midpoint"))
+        for i in range(k, n_points):
+            starts[i] = _sample(bounds, x0, rng, jitter, sobol)
+    return np.array([_clip(s, bounds) for s in starts])
+
+
+def project_to_feasible(
+    problem_obj: Any,
+    x0,
+    *,
+    lb=None,
+    ub=None,
+    cl=None,
+    cu=None,
+    tol: Optional[float] = None,
+) -> np.ndarray:
+    """Min-norm repair of ``x0`` onto the linearized constraints + bounds.
+
+    Solves the convex QP ``min ½‖x − x0‖²`` subject to
+    ``cl ≤ g(x0) + J(x0)(x − x0) ≤ cu`` and ``lb ≤ x ≤ ub`` — the
+    standalone form of the solver's ``least_square_init_primal`` step
+    (see ``docs/src/initialization.md``). For mostly-linear models this
+    slashes iteration-0 infeasibility; for a strongly nonlinear ``g``
+    the linearization is only a local repair (it may be worth a second
+    call at the projected point).
+
+    Parameters mirror :class:`pounce.Problem` /
+    :func:`pounce.preflight`: a cyipopt-style ``problem_obj`` (only
+    ``constraints`` and ``jacobian`` are used) and bound arrays.
+
+    Returns the repaired point. With no constraints it is simply the
+    clip of ``x0`` into the box. Raises ``RuntimeError`` when the
+    projection QP fails (e.g. the linearized constraints are themselves
+    inconsistent).
+    """
+    from .qp import solve_qp
+
+    x0 = np.asarray(x0, dtype=float).ravel()
+    n = x0.size
+    x_l = np.full(n, -np.inf) if lb is None else np.asarray(lb, dtype=float).ravel()
+    x_u = np.full(n, np.inf) if ub is None else np.asarray(ub, dtype=float).ravel()
+
+    m = 0
+    if cl is not None:
+        m = np.asarray(cl, dtype=float).ravel().size
+    if m == 0:
+        return np.clip(x0, x_l, x_u)
+
+    g_l = np.asarray(cl, dtype=float).ravel()
+    g_u = np.full(m, np.inf) if cu is None else np.asarray(cu, dtype=float).ravel()
+
+    g0 = np.asarray(problem_obj.constraints(x0), dtype=float).ravel()
+    jv = np.asarray(problem_obj.jacobian(x0), dtype=float).ravel()
+    J = np.zeros((m, n))
+    if hasattr(problem_obj, "jacobianstructure"):
+        rows, cols = problem_obj.jacobianstructure()
+        J[np.asarray(rows, dtype=int), np.asarray(cols, dtype=int)] = jv
+    else:
+        J = jv.reshape(m, n)
+
+    # Linearized rows: J x ∈ [cl − g0 + J x0, cu − g0 + J x0].
+    shift = J @ x0 - g0
+    row_lo = g_l + shift
+    row_hi = g_u + shift
+
+    A_rows, b_rows, G_rows, h_rows = [], [], [], []
+    for i in range(m):
+        lo_f = _finite(g_l[i])
+        hi_f = _finite(g_u[i])
+        eq = abs(g_u[i] - g_l[i]) <= 1e-12 if (lo_f and hi_f) else False
+        if eq:
+            A_rows.append(J[i])
+            b_rows.append(row_lo[i])
+            continue
+        if hi_f:
+            G_rows.append(J[i])
+            h_rows.append(row_hi[i])
+        if lo_f:
+            G_rows.append(-J[i])
+            h_rows.append(-row_lo[i])
+
+    res = solve_qp(
+        P=np.eye(n),
+        c=-x0,
+        A=np.array(A_rows) if A_rows else None,
+        b=np.array(b_rows) if b_rows else None,
+        G=np.array(G_rows) if G_rows else None,
+        h=np.array(h_rows) if h_rows else None,
+        lb=x_l,
+        ub=x_u,
+        tol=tol,
+    )
+    if not res.success:
+        raise RuntimeError(
+            f"project_to_feasible: projection QP ended with status "
+            f"{res.status!r} — the linearized constraints may be inconsistent"
+        )
+    return np.asarray(res.x)
+
+
+def race_starts(
+    fun,
+    starts,
+    *,
+    jac=None,
+    bounds=None,
+    constraints=None,
+    iters: int = 10,
+    top: int = 1,
+    options: Optional[dict] = None,
+) -> List[Any]:
+    """Run ``iters`` solver iterations from each start and rank them.
+
+    A cheap tournament: each candidate gets a short, truncated
+    :func:`pounce.minimize` run (``max_iter=iters``), and the resulting
+    iterates are ranked by (constraint violation beyond tolerance,
+    objective value). Continue the real solve from the winner —
+    typically with ``warm_start=pounce.WarmStart.from_info(res.x,
+    res.info)``.
+
+    Returns the ``top`` best :class:`OptimizeResult` objects, best
+    first.
+    """
+    from ._minimize import minimize
+
+    opts = dict(options or {})
+    opts["max_iter"] = int(iters)
+    results = []
+    for s in np.atleast_2d(np.asarray(starts, dtype=float)):
+        res = minimize(
+            fun, s, jac=jac, bounds=bounds, constraints=constraints, **opts
+        )
+        viol = float(res.info.get("final_constr_viol", 0.0))
+        if not np.isfinite(viol):
+            viol = np.inf
+        obj = res.fun if np.isfinite(res.fun) else np.inf
+        results.append((max(viol - 1e-6, 0.0), obj, res))
+    results.sort(key=lambda t: (t[0], t[1]))
+    return [r for _, _, r in results[: max(1, int(top))]]

--- a/python/pounce/_warm_start.py
+++ b/python/pounce/_warm_start.py
@@ -1,0 +1,245 @@
+"""One warm-start object for every solve path.
+
+POUNCE's warm-start machinery is spread over several knobs whose
+interplay is easy to get wrong (see ``docs/src/initialization.md``):
+``warm_start_init_point=yes`` alone saves nothing, because the default
+``mu_init`` (0.1) re-walks the barrier schedule and the default
+``warm_start_bound_push``/``_frac`` (1e-3) shove an at-the-bound
+solution back off its bounds. :class:`WarmStart` packages the whole
+recipe into a single argument::
+
+    x, info = prob.solve(x0=x0)                     # cold solve
+    ws = pounce.WarmStart.from_info(x, info)        # capture everything
+    x2, info2 = prob.solve(warm_start=ws)           # warm re-solve
+
+    ws.save("state.npz")                            # ... and across processes
+    ws = pounce.WarmStart.load("state.npz")
+
+``warm_start=`` is accepted by :meth:`pounce.Problem.solve` and
+:func:`pounce.minimize`. On the interior-point path it seeds the primal
+and dual iterates and sets the five enabling options; on the active-set
+SQP path (``algorithm=active-set-sqp``) it forwards the captured
+working set, which is that path's warm-start payload.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Optional, Tuple
+
+import numpy as np
+
+from . import _pounce
+
+__all__ = ["WarmStart"]
+
+
+def _opt_array(v) -> Optional[np.ndarray]:
+    if v is None:
+        return None
+    a = np.asarray(v, dtype=float).ravel()
+    return a if a.size else None
+
+
+@dataclasses.dataclass
+class WarmStart:
+    """A captured solve state, usable as ``solve(warm_start=...)``.
+
+    Attributes:
+        x: Primal point (used as ``x0`` unless an explicit ``x0`` is
+            passed to ``solve``).
+        lagrange: Constraint multipliers (``info["mult_g"]``).
+        zl / zu: Lower / upper bound multipliers.
+        mu: Barrier parameter at capture (``info["mu"]``); seeds
+            ``mu_init``. ``None`` or ``<= 0`` (e.g. captured from the
+            SQP path) falls back to ``mu_init_fallback``.
+        working_set: The SQP ``(bounds, constraints)`` working-set pair,
+            forwarded on the ``algorithm=active-set-sqp`` path.
+        bound_push: Value applied to the five ``warm_start_*_push`` /
+            ``_frac`` options. The tight default (1e-9) keeps an
+            at-the-bound solution essentially where it is; raise it if
+            the next problem's solution may sit elsewhere.
+        mu_init: Explicit ``mu_init`` override; default derives it from
+            ``mu`` (clamped to ``[1e-9, 1e-1]``).
+        mu_init_fallback: ``mu_init`` used when ``mu`` is unknown.
+    """
+
+    x: np.ndarray
+    lagrange: Optional[np.ndarray] = None
+    zl: Optional[np.ndarray] = None
+    zu: Optional[np.ndarray] = None
+    mu: Optional[float] = None
+    working_set: Optional[Tuple[np.ndarray, np.ndarray]] = None
+    bound_push: float = 1e-9
+    mu_init: Optional[float] = None
+    mu_init_fallback: float = 1e-6
+
+    def __post_init__(self):
+        self.x = np.asarray(self.x, dtype=float).ravel()
+        self.lagrange = _opt_array(self.lagrange)
+        self.zl = _opt_array(self.zl)
+        self.zu = _opt_array(self.zu)
+        if self.working_set is not None:
+            b, c = self.working_set
+            self.working_set = (
+                np.asarray(b, dtype=np.int8).ravel(),
+                np.asarray(c, dtype=np.int8).ravel(),
+            )
+
+    # -- construction --------------------------------------------------
+
+    @classmethod
+    def from_info(cls, x, info, **overrides) -> "WarmStart":
+        """Capture a warm start from a solve's ``(x, info)`` result.
+
+        Works with :meth:`Problem.solve`'s ``info`` dict and with
+        :func:`pounce.minimize`'s ``result.info``. Keyword overrides
+        (e.g. ``bound_push=1e-6``) are forwarded to the constructor.
+        """
+        mu = info.get("mu")
+        mu = float(mu) if mu is not None and float(mu) > 0.0 else None
+        return cls(
+            x=np.asarray(x, dtype=float),
+            lagrange=info.get("mult_g"),
+            zl=info.get("mult_x_L"),
+            zu=info.get("mult_x_U"),
+            mu=mu,
+            working_set=info.get("working_set"),
+            **overrides,
+        )
+
+    # -- persistence ----------------------------------------------------
+
+    def save(self, path) -> None:
+        """Serialize to a NumPy ``.npz`` archive (portable across
+        processes; the file-based analog of the GAMS ``sqp_state_file``)."""
+        payload = {"x": self.x, "_meta": np.array(
+            [self.mu if self.mu is not None else np.nan,
+             self.bound_push,
+             self.mu_init if self.mu_init is not None else np.nan,
+             self.mu_init_fallback]
+        )}
+        for key in ("lagrange", "zl", "zu"):
+            v = getattr(self, key)
+            if v is not None:
+                payload[key] = v
+        if self.working_set is not None:
+            payload["ws_bounds"], payload["ws_constraints"] = self.working_set
+        np.savez(path, **payload)
+
+    @classmethod
+    def load(cls, path) -> "WarmStart":
+        """Inverse of :meth:`save`."""
+        with np.load(path, allow_pickle=False) as data:
+            meta = data["_meta"]
+            working_set = None
+            if "ws_bounds" in data.files:
+                working_set = (data["ws_bounds"], data["ws_constraints"])
+            return cls(
+                x=data["x"],
+                lagrange=data["lagrange"] if "lagrange" in data.files else None,
+                zl=data["zl"] if "zl" in data.files else None,
+                zu=data["zu"] if "zu" in data.files else None,
+                mu=None if np.isnan(meta[0]) else float(meta[0]),
+                working_set=working_set,
+                bound_push=float(meta[1]),
+                mu_init=None if np.isnan(meta[2]) else float(meta[2]),
+                mu_init_fallback=float(meta[3]),
+            )
+
+    # -- application ----------------------------------------------------
+
+    def options(self) -> dict:
+        """The enabling solver options this warm start implies.
+
+        ``warm_start_init_point=yes`` makes the solver honor the seeds;
+        ``mu_init`` skips the barrier walk-down; the tightened
+        ``warm_start_*`` pushes keep an at-the-bound point where it is.
+        All are ignored (harmlessly) on the SQP path.
+        """
+        if self.mu_init is not None:
+            mu_init = self.mu_init
+        elif self.mu is not None:
+            mu_init = float(np.clip(self.mu, 1e-9, 1e-1))
+        else:
+            mu_init = self.mu_init_fallback
+        p = self.bound_push
+        return {
+            "warm_start_init_point": "yes",
+            "mu_init": mu_init,
+            "warm_start_bound_push": p,
+            "warm_start_bound_frac": p,
+            "warm_start_slack_bound_push": p,
+            "warm_start_slack_bound_frac": p,
+            "warm_start_mult_bound_push": p,
+        }
+
+    def solve_kwargs(self) -> dict:
+        """The seed keyword arguments for :meth:`Problem.solve`."""
+        kw = {}
+        if self.lagrange is not None:
+            kw["lagrange"] = self.lagrange
+        if self.zl is not None:
+            kw["zl"] = self.zl
+        if self.zu is not None:
+            kw["zu"] = self.zu
+        if self.working_set is not None:
+            kw["working_set"] = self.working_set
+        return kw
+
+
+# ---------------------------------------------------------------------------
+# Problem.solve(warm_start=...) — wrap the native method once at import.
+# The pyo3 class cannot be subclassed, so the ergonomic entry point is a
+# thin wrapper that translates a WarmStart into the native seed kwargs +
+# enabling options and otherwise passes through unchanged.
+# ---------------------------------------------------------------------------
+
+_native_solve = _pounce.Problem.solve
+
+
+def _solve_with_warm_start(
+    self,
+    x0=None,
+    lagrange=None,
+    zl=None,
+    zu=None,
+    working_set=None,
+    warm_start: Optional[WarmStart] = None,
+):
+    if warm_start is None:
+        if x0 is None:
+            raise TypeError("Problem.solve() missing required argument: 'x0'")
+        return _native_solve(
+            self, x0=x0, lagrange=lagrange, zl=zl, zu=zu, working_set=working_set
+        )
+    ws = warm_start
+    for k, v in ws.options().items():
+        self.add_option(k, v)
+    kw = ws.solve_kwargs()
+    # Explicit per-call seeds win over the WarmStart's captured ones.
+    for key, val in (
+        ("lagrange", lagrange),
+        ("zl", zl),
+        ("zu", zu),
+        ("working_set", working_set),
+    ):
+        if val is not None:
+            kw[key] = val
+    return _native_solve(self, x0=ws.x if x0 is None else x0, **kw)
+
+
+_solve_with_warm_start.__name__ = "solve"
+_solve_with_warm_start.__qualname__ = "Problem.solve"
+_solve_with_warm_start.__doc__ = (_native_solve.__doc__ or "") + (
+    "\n\n"
+    "warm_start : pounce.WarmStart, optional\n"
+    "    A captured solve state (see ``WarmStart.from_info``). Applies the\n"
+    "    enabling options (``warm_start_init_point=yes``, ``mu_init``, the\n"
+    "    tightened ``warm_start_*`` pushes — note they persist on this\n"
+    "    Problem like any ``add_option``), seeds the duals, forwards the\n"
+    "    SQP working set when present, and defaults ``x0`` to the captured\n"
+    "    point. Explicit ``x0``/seed arguments override the captured ones.\n"
+)
+
+_pounce.Problem.solve = _solve_with_warm_start

--- a/python/pounce/_warm_start.py
+++ b/python/pounce/_warm_start.py
@@ -206,12 +206,22 @@ def _solve_with_warm_start(
     zu=None,
     working_set=None,
     warm_start: Optional[WarmStart] = None,
+    **kwargs,
 ):
+    # **kwargs forwards any other native solve keywords untouched
+    # (e.g. report_path / report_detail), so this wrapper never lags
+    # the native signature.
     if warm_start is None:
         if x0 is None:
             raise TypeError("Problem.solve() missing required argument: 'x0'")
         return _native_solve(
-            self, x0=x0, lagrange=lagrange, zl=zl, zu=zu, working_set=working_set
+            self,
+            x0=x0,
+            lagrange=lagrange,
+            zl=zl,
+            zu=zu,
+            working_set=working_set,
+            **kwargs,
         )
     ws = warm_start
     for k, v in ws.options().items():
@@ -226,7 +236,7 @@ def _solve_with_warm_start(
     ):
         if val is not None:
             kw[key] = val
-    return _native_solve(self, x0=ws.x if x0 is None else x0, **kw)
+    return _native_solve(self, x0=ws.x if x0 is None else x0, **kw, **kwargs)
 
 
 _solve_with_warm_start.__name__ = "solve"

--- a/python/tests/test_preflight.py
+++ b/python/tests/test_preflight.py
@@ -1,0 +1,124 @@
+"""Tests for pounce.preflight — the starting-point check.
+
+Pure-Python: no solve is performed, so these run without the native
+extension doing any work beyond import.
+"""
+
+import numpy as np
+import pytest
+
+import pounce
+
+
+class HS071:
+    def objective(self, x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def gradient(self, x):
+        return np.array([
+            x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]),
+            x[0] * x[3],
+            x[0] * x[3] + 1.0,
+            x[0] * (x[0] + x[1] + x[2]),
+        ])
+
+    def constraints(self, x):
+        return np.array([np.prod(x), np.dot(x, x)])
+
+    def jacobianstructure(self):
+        return (np.repeat([0, 1], 4), np.tile([0, 1, 2, 3], 2))
+
+    def jacobian(self, x):
+        return np.array([
+            x[1] * x[2] * x[3], x[0] * x[2] * x[3],
+            x[0] * x[1] * x[3], x[0] * x[1] * x[2],
+            2 * x[0], 2 * x[1], 2 * x[2], 2 * x[3],
+        ])
+
+
+HS071_BOUNDS = dict(lb=[1.0] * 4, ub=[5.0] * 4, cl=[25.0, 40.0], cu=[2e19, 40.0])
+
+
+class DomainTrap:
+    """min 1/x0 + x1: NaN/inf at any x with x0 == 0."""
+
+    def objective(self, x):
+        return 1.0 / x[0] + x[1]
+
+    def gradient(self, x):
+        return np.array([-1.0 / x[0] ** 2, 1.0])
+
+
+class Raiser:
+    def objective(self, x):
+        raise ValueError("domain error")
+
+
+def test_clean_interior_point():
+    r = pounce.preflight(HS071(), np.array([2.0, 3.0, 3.0, 2.0]), **HS071_BOUNDS)
+    assert r.ok and not r.fatal
+    assert r.n == 4 and r.m == 2
+    assert r.n_bound_violations == 0
+    assert np.isfinite(r.objective)
+    # g1 = prod = 36 >= 25 ok; g2 = 4+9+9+4 = 26 != 40 -> violated
+    assert r.n_con_violations == 1
+    assert r.max_con_violation == pytest.approx(14.0)
+
+
+def test_on_bound_start_warns_about_clamp():
+    # The canonical HS071 start has x0 and x3 exactly on the lower bound.
+    r = pounce.preflight(HS071(), np.array([1.0, 5.0, 5.0, 1.0]), **HS071_BOUNDS)
+    assert r.ok
+    assert r.n_on_bounds == 4  # x1, x2 are on the upper bound too
+    assert r.n_clamp_moved == 4
+    # two-sided [1, 5]: p_l = min(1e-2*1, 1e-2*4) = 0.01 at the lower bound,
+    # p_u = min(1e-2*5, 1e-2*4) = 0.04 at the upper bound.
+    assert r.max_clamp_move == pytest.approx(0.04, abs=1e-12)
+    assert any("warm_start_bound_push" in w for w in r.warnings)
+    assert r.verdict == "WARNINGS"
+
+
+def test_nan_at_x0_is_fatal():
+    r = pounce.preflight(DomainTrap(), np.array([0.0, 0.0]))
+    assert r.fatal and not r.ok
+    assert r.verdict == "FATAL"
+    assert r.grad_nonfinite_count >= 1
+    assert r.x0_all_zero
+    assert any("Invalid_Number_Detected" in w for w in r.warnings)
+
+
+def test_raising_callback_is_fatal_not_crashing():
+    r = pounce.preflight(Raiser(), np.array([1.0]))
+    assert r.fatal
+    assert r.eval_errors and "ValueError" in r.eval_errors[0]
+
+
+def test_bound_violation_reported_not_fatal():
+    r = pounce.preflight(HS071(), np.array([-2.0, 3.0, 3.0, 2.0]), **HS071_BOUNDS)
+    assert r.ok  # clampable, not fatal
+    assert r.n_bound_violations == 1
+    assert r.max_bound_violation == pytest.approx(3.0)
+    assert r.n_clamp_moved >= 1
+
+
+def test_unconstrained_problem():
+    class Quad:
+        def objective(self, x):
+            return float(x @ x)
+
+        def gradient(self, x):
+            return 2.0 * x
+
+    r = pounce.preflight(Quad(), np.array([1.0, -1.0]))
+    assert r.ok and r.m == 0
+    assert r.verdict == "CLEAN"
+
+
+def test_report_dict_and_str():
+    r = pounce.preflight(HS071(), np.array([2.0, 3.0, 3.0, 2.0]), **HS071_BOUNDS)
+    d = r.to_dict()
+    assert d["schema"] == "pounce.check-x0/v1"
+    assert d["problem"] == {"n_vars": 4, "n_cons": 2}
+    assert d["fatal"] is False
+    text = str(r)
+    assert "VERDICT" in text and "preflight" in text

--- a/python/tests/test_starts.py
+++ b/python/tests/test_starts.py
@@ -1,0 +1,126 @@
+"""Tests for pounce.generate_starts / project_to_feasible / race_starts."""
+
+import numpy as np
+import pytest
+
+import pounce
+
+
+BOUNDS = [(-2.0, 2.0), (0.0, 4.0)]
+
+
+def test_generate_starts_shape_and_box():
+    starts = pounce.generate_starts(16, bounds=BOUNDS, seed=0)
+    assert starts.shape == (16, 2)
+    lo = np.array([-2.0, 0.0])
+    hi = np.array([2.0, 4.0])
+    assert np.all(starts >= lo) and np.all(starts <= hi)
+
+
+def test_generate_starts_reproducible():
+    a = pounce.generate_starts(5, bounds=BOUNDS, seed=42)
+    b = pounce.generate_starts(5, bounds=BOUNDS, seed=42)
+    np.testing.assert_array_equal(a, b)
+    c = pounce.generate_starts(5, bounds=BOUNDS, seed=43)
+    assert not np.array_equal(a, c)
+
+
+def test_generate_starts_jitter_needs_x0():
+    with pytest.raises(ValueError):
+        pounce.generate_starts(3, strategy="jitter")
+    starts = pounce.generate_starts(3, x0=[1.0, 1.0], strategy="jitter", seed=0)
+    assert starts.shape == (3, 2)
+
+
+def test_generate_starts_midpoint_first_point_deterministic():
+    starts = pounce.generate_starts(4, bounds=BOUNDS, strategy="midpoint", seed=0)
+    np.testing.assert_allclose(starts[0], [0.0, 2.0])
+
+
+def test_generate_starts_unbounded_requires_anchor():
+    with pytest.raises(ValueError):
+        pounce.generate_starts(3, bounds=[(-2.0, 2.0), (None, None)])
+    starts = pounce.generate_starts(
+        3, bounds=[(-2.0, 2.0), (None, None)], x0=[0.0, 1.0], seed=0
+    )
+    assert starts.shape == (3, 2)
+    assert np.all(np.abs(starts[:, 0]) <= 2.0)
+
+
+def test_generate_starts_feeds_batch_and_find_minima_still_works():
+    # find_minima imports the same sampler internals; smoke both paths.
+    def hump(x):
+        return float(np.sin(3 * x[0]) + 0.1 * x[0] ** 2)
+
+    res = pounce.find_minima(hump, np.array([0.0]), method="multistart",
+                             bounds=[(-3, 3)], n_minima=2, seed=1)
+    assert len(res.minima) >= 1
+
+
+class LinCon:
+    """g(x) = [x0 + x1, x0 - x1], linear so projection is exact."""
+
+    def constraints(self, x):
+        return np.array([x[0] + x[1], x[0] - x[1]])
+
+    def jacobianstructure(self):
+        return (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))
+
+    def jacobian(self, x):
+        return np.array([1.0, 1.0, 1.0, -1.0])
+
+
+def test_project_to_feasible_equality_and_inequality():
+    # x0 violates the equality x0 + x1 = 1 and the inequality x0 - x1 <= 0.
+    x0 = np.array([2.0, 2.0])
+    x = pounce.project_to_feasible(
+        LinCon(), x0, cl=[1.0, -2e19], cu=[1.0, 0.0],
+        lb=[-5.0, -5.0], ub=[5.0, 5.0],
+    )
+    g = LinCon().constraints(x)
+    assert g[0] == pytest.approx(1.0, abs=1e-6)
+    assert g[1] <= 1e-6
+    # Min-norm: stays as close to x0 as the constraints allow.
+    assert np.linalg.norm(x - x0) <= np.linalg.norm(np.array([0.5, 0.5]) - x0) + 1e-6
+
+
+def test_project_to_feasible_box_only():
+    x = pounce.project_to_feasible(object(), [3.0, -7.0], lb=[0.0, 0.0], ub=[1.0, 1.0])
+    np.testing.assert_allclose(x, [1.0, 0.0])
+
+
+def test_project_to_feasible_inconsistent_raises():
+    with pytest.raises(RuntimeError):
+        # x0 + x1 == 1 AND x0 + x1 == 3 (same row twice via cl==cu rows).
+        class TwoRows:
+            def constraints(self, x):
+                return np.array([x[0] + x[1], x[0] + x[1]])
+
+            def jacobianstructure(self):
+                return (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))
+
+            def jacobian(self, x):
+                return np.array([1.0, 1.0, 1.0, 1.0])
+
+        pounce.project_to_feasible(
+            TwoRows(), [0.0, 0.0], cl=[1.0, 3.0], cu=[1.0, 3.0]
+        )
+
+
+def test_race_starts_picks_the_better_basin():
+    # Double well: minima near x = ±1 with f(-1) = 0 and f(+1) = 0.5.
+    def f(x):
+        return float((x[0] ** 2 - 1.0) ** 2 + 0.25 * (x[0] + 1.0))
+
+    starts = np.array([[1.1], [-1.1]])
+    best = pounce.race_starts(f, starts, iters=8, top=2)
+    assert len(best) == 2
+    # The winner must be the deeper (x = -1) basin.
+    assert best[0].x[0] == pytest.approx(-1.0, abs=0.2)
+    assert best[0].fun <= best[1].fun
+
+    # The composable follow-up: continue the winner warm.
+    ws = pounce.WarmStart.from_info(best[0].x, best[0].info)
+    res = pounce.minimize(f, best[0].x, warm_start=ws)
+    assert res.success
+    assert res.x[0] == pytest.approx(-1.0290, abs=1e-2)

--- a/python/tests/test_warm_start_object.py
+++ b/python/tests/test_warm_start_object.py
@@ -1,0 +1,184 @@
+"""Tests for pounce.WarmStart — the unified warm-start object.
+
+(Distinct from test_warm_start.py, which exercises the raw
+lagrange/zl/zu solve kwargs and options.)
+"""
+
+import numpy as np
+import pytest
+
+import pounce
+
+
+class HS071:
+    def objective(self, x):
+        return x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2]
+
+    def gradient(self, x):
+        return np.array([
+            x[0] * x[3] + x[3] * (x[0] + x[1] + x[2]),
+            x[0] * x[3],
+            x[0] * x[3] + 1.0,
+            x[0] * (x[0] + x[1] + x[2]),
+        ])
+
+    def constraints(self, x):
+        return np.array([np.prod(x), np.dot(x, x)])
+
+    def jacobianstructure(self):
+        return (np.repeat([0, 1], 4), np.tile([0, 1, 2, 3], 2))
+
+    def jacobian(self, x):
+        return np.array([
+            x[1] * x[2] * x[3], x[0] * x[2] * x[3],
+            x[0] * x[1] * x[3], x[0] * x[1] * x[2],
+            2 * x[0], 2 * x[1], 2 * x[2], 2 * x[3],
+        ])
+
+
+def _make():
+    p = pounce.Problem(
+        n=4, m=2, problem_obj=HS071(),
+        lb=[1.0] * 4, ub=[5.0] * 4,
+        cl=[25.0, 40.0], cu=[2e19, 40.0],
+    )
+    p.add_option("tol", 1e-8)
+    p.add_option("print_level", 0)
+    return p
+
+
+X0 = np.array([1.0, 5.0, 5.0, 1.0])
+
+
+def test_from_info_captures_fields():
+    x, info = _make().solve(x0=X0)
+    ws = pounce.WarmStart.from_info(x, info)
+    np.testing.assert_allclose(ws.x, x)
+    assert ws.lagrange is not None and ws.lagrange.shape == (2,)
+    assert ws.zl is not None and ws.zl.shape == (4,)
+    assert ws.zu is not None and ws.zu.shape == (4,)
+    assert ws.mu is not None and 0 < ws.mu < 1e-4
+    assert ws.working_set is None  # IPM path carries no working set
+    opts = ws.options()
+    assert opts["warm_start_init_point"] == "yes"
+    assert opts["mu_init"] == pytest.approx(max(ws.mu, 1e-9))
+    assert opts["warm_start_bound_push"] == 1e-9
+
+
+def test_warm_start_cuts_iterations_and_reaches_same_solution():
+    cold_x, cold_info = _make().solve(x0=X0)
+    ws = pounce.WarmStart.from_info(cold_x, cold_info)
+
+    warm_x, warm_info = _make().solve(warm_start=ws)  # x0 defaults to ws.x
+    assert warm_info["status"] == cold_info["status"]
+    assert warm_info["iter_count"] < cold_info["iter_count"]
+    np.testing.assert_allclose(warm_x, cold_x, atol=1e-6)
+    assert abs(warm_info["obj_val"] - cold_info["obj_val"]) < 1e-6
+
+
+def test_explicit_x0_overrides_captured_point():
+    cold_x, cold_info = _make().solve(x0=X0)
+    ws = pounce.WarmStart.from_info(cold_x, cold_info)
+    x0 = np.clip(cold_x + 1e-3, 1.0, 5.0)
+    warm_x, warm_info = _make().solve(x0=x0, warm_start=ws)
+    assert warm_info["iter_count"] < cold_info["iter_count"]
+    np.testing.assert_allclose(warm_x, cold_x, atol=1e-5)
+
+
+def test_save_load_round_trip(tmp_path):
+    cold_x, cold_info = _make().solve(x0=X0)
+    ws = pounce.WarmStart.from_info(cold_x, cold_info, bound_push=1e-8)
+    path = tmp_path / "state.npz"
+    ws.save(path)
+    back = pounce.WarmStart.load(path)
+    np.testing.assert_allclose(back.x, ws.x)
+    np.testing.assert_allclose(back.lagrange, ws.lagrange)
+    np.testing.assert_allclose(back.zl, ws.zl)
+    np.testing.assert_allclose(back.zu, ws.zu)
+    assert back.mu == pytest.approx(ws.mu)
+    assert back.bound_push == 1e-8
+    assert back.working_set is None
+
+    # ... and the reloaded state warm-starts identically.
+    warm_x, warm_info = _make().solve(warm_start=back)
+    assert warm_info["iter_count"] < cold_info["iter_count"]
+
+
+def test_solve_without_x0_or_warm_start_raises():
+    with pytest.raises(TypeError):
+        _make().solve()
+
+
+def test_plain_solve_is_unchanged():
+    # The wrapper must be a pure pass-through without warm_start.
+    x, info = _make().solve(x0=X0)
+    assert info["status_msg"] == "Solve_Succeeded"
+    x2, info2 = _make().solve(
+        x0=X0,
+        lagrange=np.asarray(info["mult_g"]),
+        zl=np.asarray(info["mult_x_L"]),
+        zu=np.asarray(info["mult_x_U"]),
+    )
+    assert info2["status_msg"] == "Solve_Succeeded"
+
+
+def test_minimize_warm_start():
+    def rosen(x):
+        return (1 - x[0]) ** 2 + 100 * (x[1] - x[0] ** 2) ** 2
+
+    res1 = pounce.minimize(rosen, np.array([-1.2, 1.0]), bounds=[(-2, 2), (-2, 2)])
+    assert res1.success
+    ws = pounce.WarmStart.from_info(res1.x, res1.info)
+    res2 = pounce.minimize(rosen, res1.x, bounds=[(-2, 2), (-2, 2)], warm_start=ws)
+    assert res2.success
+    assert res2.nit <= res1.nit
+    np.testing.assert_allclose(res2.x, res1.x, atol=1e-6)
+
+
+def test_minimize_warm_start_overrides_routing_with_warning():
+    def quad(x):
+        return float(x @ x)
+
+    res1 = pounce.minimize(quad, np.array([1.0, 1.0]))
+    ws = pounce.WarmStart.from_info(res1.x, res1.info)
+    with pytest.warns(UserWarning, match="NLP path"):
+        res2 = pounce.minimize(
+            quad, res1.x, warm_start=ws, solver_selection="auto"
+        )
+    assert res2.success
+
+
+def test_sqp_working_set_round_trip():
+    class Quad:
+        def objective(self, x):
+            return (x[0] - 2.0) ** 2
+
+        def gradient(self, x):
+            return np.array([2.0 * (x[0] - 2.0)])
+
+        def constraints(self, x):
+            return np.array([x[0]])
+
+        def jacobianstructure(self):
+            return (np.array([0]), np.array([0]))
+
+        def jacobian(self, x):
+            return np.array([1.0])
+
+    def make():
+        p = pounce.Problem(
+            n=1, m=1, problem_obj=Quad(),
+            lb=[0.0], ub=[10.0], cl=[0.0], cu=[1.0],
+        )
+        p.add_option("algorithm", "active-set-sqp")
+        p.add_option("print_level", 0)
+        return p
+
+    x, info = make().solve(x0=np.array([0.5]))
+    ws = pounce.WarmStart.from_info(x, info)
+    assert ws.working_set is not None  # SQP path returns the working set
+    assert ws.mu is None  # SQP reports mu = 0.0 -> None
+
+    x2, info2 = make().solve(warm_start=ws)
+    np.testing.assert_allclose(x2, x, atol=1e-8)
+    assert info2["working_set"] is not None

--- a/studio/mcp/pounce_studio_mcp/server.py
+++ b/studio/mcp/pounce_studio_mcp/server.py
@@ -538,6 +538,118 @@ def verify_solution(
     }
 
 
+# ---- check-x0 (starting-point preflight) -----------------------------
+
+
+@mcp.tool()
+def check_x0(
+    nl_file: str | None = None,
+    builtin: str | None = None,
+    x0_file: str | None = None,
+    feas_tol: float = 1e-6,
+    bound_push: float = 1e-2,
+    bound_frac: float = 1e-2,
+    max_list: int = 5,
+    timeout_seconds: float = 120.0,
+) -> dict[str, Any]:
+    """Preflight a model's starting point before any solve.
+
+    Evaluates the model once at its starting point (the `.nl` initial-guess
+    segment, or `x0_file`) and reports what iteration 0 will see: NaN/inf
+    evaluations (fatal — the solve would abort with
+    `Invalid_Number_Detected`), bound violations of x0, how far the
+    `bound_push` interior clamp will move the point, initial constraint
+    violation per row, and derivative magnitude spread (the early signal
+    for scaling trouble). Costs one evaluation of each callback: no
+    factorization, no solve.
+
+    Use this BEFORE `run_problem` when a model is new, when a previous
+    solve died with `Invalid_Number_Detected`, or when a warm start did
+    not help (on-bound components + the clamp preview explain that case).
+
+    Args:
+        nl_file: Path to the AMPL `.nl` problem. Exactly one of `nl_file`
+            or `builtin` must be given.
+        builtin: Name of a built-in problem (see `list_builtins`).
+        x0_file: Optional whitespace-separated file of n values overriding
+            the model's starting point (e.g. a candidate warm-start point).
+        feas_tol: Violations above this are counted (default 1e-6).
+        bound_push: `bound_push` used for the clamp preview (default 1e-2,
+            the solver default).
+        bound_frac: `bound_frac` used for the clamp preview (default 1e-2).
+        max_list: Max offenders listed per category.
+        timeout_seconds: Kill the check after this many seconds.
+
+    Returns:
+        Dict with `fatal` (the bottom line: True means a solve from this
+        point would abort), `verdict` (CLEAN / WARNINGS / FATAL),
+        `warnings` (human-readable findings), `exit_code` (0 clean or
+        warnings, 21 fatal), and `report` (the full parsed
+        `pounce.check-x0/v1` JSON: evaluation, bounds, interior_clamp,
+        constraint_violation, derivative_scale sections).
+    """
+    if (nl_file is None) == (builtin is None):
+        raise ValueError("pass exactly one of nl_file or builtin")
+    binary = _find_pounce_bin()
+
+    fd, tmp = tempfile.mkstemp(suffix=".json", prefix="pounce-check-x0-")
+    os.close(fd)
+    report_path = Path(tmp)
+
+    argv: list[str] = [binary, "check-x0"]
+    if nl_file is not None:
+        nl = Path(nl_file).expanduser()
+        if not nl.exists():
+            raise FileNotFoundError(f"no such .nl file: {nl}")
+        argv.append(str(nl))
+    else:
+        argv += ["--builtin", str(builtin)]
+    if x0_file is not None:
+        x0 = Path(x0_file).expanduser()
+        if not x0.exists():
+            raise FileNotFoundError(f"no such x0 file: {x0}")
+        argv += ["--x0-file", str(x0)]
+    argv += [
+        "--feas-tol", repr(feas_tol),
+        "--bound-push", repr(bound_push),
+        "--bound-frac", repr(bound_frac),
+        "--max-list", str(max_list),
+        "--json-output", str(report_path),
+    ]
+
+    try:
+        proc = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise TimeoutError(
+            f"pounce check-x0 did not finish within {timeout_seconds}s"
+        ) from e
+
+    report: dict[str, Any] = {}
+    if report_path.exists():
+        try:
+            report = json.loads(report_path.read_text())
+        except json.JSONDecodeError:
+            report = {}
+        finally:
+            report_path.unlink(missing_ok=True)
+
+    return {
+        "fatal": bool(report.get("fatal", proc.returncode == 21)),
+        "verdict": report.get("verdict"),
+        "warnings": report.get("warnings", []),
+        "exit_code": proc.returncode,
+        "max_constraint_violation": report.get("constraint_violation", {}).get(
+            "max_violation"
+        ),
+        "n_clamp_moved": report.get("interior_clamp", {}).get("n_moved"),
+        "stdout_tail": proc.stdout[-2000:],
+        "stderr_tail": proc.stderr[-2000:],
+        "report": report,
+    }
+
+
 # ---- explain / citations --------------------------------------------
 
 

--- a/studio/mcp/pounce_studio_mcp/server.py
+++ b/studio/mcp/pounce_studio_mcp/server.py
@@ -588,6 +588,28 @@ def check_x0(
         `pounce.check-x0/v1` JSON: evaluation, bounds, interior_clamp,
         constraint_violation, derivative_scale sections).
     """
+    return _check_x0_impl(
+        nl_file=nl_file,
+        builtin=builtin,
+        x0_file=x0_file,
+        feas_tol=feas_tol,
+        bound_push=bound_push,
+        bound_frac=bound_frac,
+        max_list=max_list,
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _check_x0_impl(
+    nl_file: str | None,
+    builtin: str | None,
+    x0_file: str | None,
+    feas_tol: float,
+    bound_push: float,
+    bound_frac: float,
+    max_list: int,
+    timeout_seconds: float,
+) -> dict[str, Any]:
     if (nl_file is None) == (builtin is None):
         raise ValueError("pass exactly one of nl_file or builtin")
     binary = _find_pounce_bin()
@@ -647,6 +669,187 @@ def check_x0(
         "stdout_tail": proc.stdout[-2000:],
         "stderr_tail": proc.stderr[-2000:],
         "report": report,
+    }
+
+
+# ---- suggest_initialization ------------------------------------------
+
+
+@mcp.tool()
+def suggest_initialization(
+    nl_file: str | None = None,
+    builtin: str | None = None,
+    x0_file: str | None = None,
+    prior_report: str | None = None,
+    timeout_seconds: float = 120.0,
+) -> dict[str, Any]:
+    """Preflight a model's starting point and propose concrete fixes.
+
+    Runs the `check_x0` preflight and translates its findings into an
+    ordered list of deterministic, advisory suggestions: solver options
+    to set, Python/Pyomo helper calls to make, and doc pointers. When a
+    `prior_report` (a `pounce.solve-report/v1` JSON from a previous
+    solve of this model) is supplied, its outcome sharpens the advice
+    (e.g. restoration-heavy solves point at the starting point; a clean
+    preflight with a failed solve points away from it).
+
+    Suggestions are **advisory** — never auto-applied. Present them to
+    the user in order and let them choose.
+
+    Args:
+        nl_file: Path to the AMPL `.nl` problem (or use `builtin`).
+        builtin: Name of a built-in problem.
+        x0_file: Optional candidate starting point to check instead of
+            the model's own.
+        prior_report: Optional path to a previous solve's JSON report.
+        timeout_seconds: Kill the preflight after this many seconds.
+
+    Returns:
+        Dict with `verdict`, `fatal`, `suggestions` (list of
+        `{kind, why, options?, python?, pyomo?, docs?}` in priority
+        order), and `preflight` (the underlying check-x0 result).
+    """
+    checked = _check_x0_impl(
+        nl_file=nl_file,
+        builtin=builtin,
+        x0_file=x0_file,
+        feas_tol=1e-6,
+        bound_push=1e-2,
+        bound_frac=1e-2,
+        max_list=5,
+        timeout_seconds=timeout_seconds,
+    )
+    rep = checked.get("report", {})
+    suggestions: list[dict[str, Any]] = []
+
+    ev = rep.get("evaluation", {})
+    nonfinite = (
+        ev.get("grad_nonfinite_count", 0)
+        + ev.get("constraints_nonfinite_count", 0)
+        + ev.get("jacobian_nonfinite_count", 0)
+        + (ev.get("hessian_nonfinite_count") or 0)
+        + (0 if ev.get("objective_finite", True) else 1)
+    )
+    if checked.get("fatal"):
+        suggestions.append({
+            "kind": "fix-evaluation",
+            "why": f"{nonfinite} non-finite evaluation(s) at the starting "
+                   "point; a solve would abort with Invalid_Number_Detected. "
+                   "The interior clamp only repairs bound violations, not "
+                   "domain errors on free variables.",
+            "python": "set an in-domain x0; pounce.preflight(problem_obj, x0, "
+                      "...) reproduces this check on callback problems",
+            "pyomo": "pyomo_pounce.initialize_missing_values(model) then "
+                     "pyomo_pounce.preflight(model)",
+            "docs": "initialization.md#diagnosing-a-bad-start",
+        })
+
+    if rep.get("x0", {}).get("all_zero"):
+        suggestions.append({
+            "kind": "provide-x0",
+            "why": "the starting point is all zeros: the model supplies no "
+                   "initial guess (or an explicitly zero one).",
+            "python": "pounce.generate_starts(n, bounds=..., "
+                      "strategy='midpoint') for a bounds-aware start",
+            "pyomo": "set Var .value before solve, or "
+                     "pyomo_pounce.block_initialize(model)",
+            "docs": "initialization.md#where-the-starting-point-comes-from",
+        })
+
+    clamp = rep.get("interior_clamp", {})
+    bounds_sec = rep.get("bounds", {})
+    if bounds_sec.get("n_on_bounds", 0) > 0 and clamp.get("n_moved", 0) > 0:
+        suggestions.append({
+            "kind": "warm-start-recipe",
+            "why": f"{bounds_sec['n_on_bounds']} component(s) sit exactly on a "
+                   "bound and the interior clamp will move them (max move "
+                   f"{clamp.get('max_move')}). If this x0 is a previous "
+                   "solution, a plain re-solve discards it.",
+            "options": {
+                "warm_start_init_point": "yes",
+                "mu_init": 1e-7,
+                "warm_start_bound_push": 1e-9,
+                "warm_start_bound_frac": 1e-9,
+                "warm_start_slack_bound_push": 1e-9,
+                "warm_start_slack_bound_frac": 1e-9,
+                "warm_start_mult_bound_push": 1e-9,
+            },
+            "python": "ws = pounce.WarmStart.from_info(x, info); "
+                      "prob.solve(warm_start=ws)",
+            "docs": "initialization.md#warm-starting-the-interior-point-path",
+        })
+
+    max_viol = rep.get("constraint_violation", {}).get("max_violation") or 0.0
+    if max_viol > 1e4:
+        suggestions.append({
+            "kind": "reduce-initial-infeasibility",
+            "why": f"very large initial constraint violation ({max_viol:.3e}).",
+            "options": {"least_square_init_primal": "yes"},
+            "python": "x0 = pounce.project_to_feasible(problem_obj, x0, ...)",
+            "docs": "initialization.md#what-the-solver-does-with-your-point-cold-start",
+        })
+
+    scale = rep.get("derivative_scale", {})
+    for label in ("gradient", "jacobian"):
+        s = scale.get(label, {})
+        if (s.get("ratio") or 0.0) > 1e8 or (s.get("max_abs") or 0.0) > 1e8:
+            suggestions.append({
+                "kind": "scaling",
+                "why": f"{label} magnitudes at x0 span a large range "
+                       f"(max {s.get('max_abs')}, min nonzero "
+                       f"{s.get('min_abs_nonzero')}); poor scaling mimics a "
+                       "bad starting point.",
+                "docs": "scaling.md",
+            })
+            break
+
+    # Prior-solve context, when supplied.
+    if prior_report is not None:
+        try:
+            r = R.load_report(Path(prior_report).expanduser())
+            summary = R.summarize(r)
+            findings = R.diagnose(r)
+        except Exception as e:  # noqa: BLE001 - advisory only
+            suggestions.append({
+                "kind": "prior-report-unreadable",
+                "why": f"could not read prior report: {e}",
+            })
+        else:
+            status = str(summary.get("status", ""))
+            codes = {f.get("code") for f in findings.get("findings", [])} if isinstance(
+                findings, dict
+            ) else set()
+            if {"restoration_used", "restoration_loop"} & codes:
+                suggestions.append({
+                    "kind": "restoration-points-at-x0",
+                    "why": f"the previous solve ({status}) spent time in "
+                           "feasibility restoration — a classic symptom of a "
+                           "poor starting point.",
+                    "docs": "initialization.md",
+                })
+            elif status not in ("SolveSucceeded", "SolvedToAcceptableLevel") \
+                    and not suggestions:
+                suggestions.append({
+                    "kind": "not-an-initialization-problem",
+                    "why": f"the preflight is clean but the previous solve "
+                           f"ended {status}: the starting point is probably "
+                           "not the bottleneck.",
+                    "docs": "troubleshooting.md",
+                })
+
+    if not suggestions:
+        suggestions.append({
+            "kind": "clean",
+            "why": "the starting point evaluates cleanly with no red flags; "
+                   "if the solve still struggles, look beyond initialization.",
+            "docs": "troubleshooting.md",
+        })
+
+    return {
+        "verdict": checked.get("verdict"),
+        "fatal": checked.get("fatal"),
+        "suggestions": suggestions,
+        "preflight": checked,
     }
 
 

--- a/studio/skill/SKILL.md
+++ b/studio/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pounce
-description: Inspect and diagnose pounce solve reports via the pounce-studio CLI. Use when the user asks to analyze a pounce.solve-report JSON, diagnose a stuck or non-converging solve, compare two runs, look up a per-iteration column or finding code, or pre-flight an AMPL .nl or GAMS .gms file before solving.
+description: Inspect and diagnose pounce solve reports via the pounce-studio CLI. Use when the user asks to analyze a pounce.solve-report JSON, diagnose a stuck or non-converging solve, compare two runs, look up a per-iteration column or finding code, pre-flight an AMPL .nl or GAMS .gms file before solving, check or fix a starting point (check-x0), or set up a warm start.
 ---
 
 # pounce — solver post-mortem and pre-flight
@@ -78,6 +78,22 @@ pounce-studio list-builtins                   # builtin --problem options
 The suggestion blocks are **advisory** — they are never auto-applied.
 Decide based on the user's intent whether to pass any of them to a
 fresh solve.
+
+### Starting-point pre-flight (`check-x0`, on the `pounce` binary)
+
+```sh
+pounce check-x0 <path.nl> [--json]            # evaluate the model at x0
+pounce check-x0 <path.nl> --x0-file cand.txt  # ... at a candidate point
+pounce check-x0 --builtin <name> --json
+```
+
+Evaluates the model once at its starting point (no solve) and reports
+NaN/inf evaluations (exit 21 — a solve WOULD abort with
+`Invalid_Number_Detected`), bound violations, how far the `bound_push`
+interior clamp will move the point, initial constraint violation per
+row, and derivative scale spread. Run it before the first solve of a
+new model, after any `Invalid_Number_Detected`, and whenever a warm
+start saved no iterations.
 
 ## Running a fresh solve
 
@@ -190,6 +206,41 @@ pounce-studio explain alpha_primal_char
 
 Returns a definition, typical numeric range, what abnormal values
 mean, and `see_also` citation keys.
+
+### "This model won't start / initialize" — the initialization playbook
+
+Reference: the *Initialization and Warm Starts* chapter of the docs
+(`docs/src/initialization.md`).
+
+1. **Preflight.** `pounce check-x0 model.nl --json`. `"fatal": true`
+   means the model does not evaluate at its start — fix that first
+   (in-domain values, or bounds that keep the clamp in the domain).
+   Not fatal: read the warnings in order.
+2. **Interpret.**
+   - *all-zeros x0* → the model supplies no start. Set values
+     (Pyomo `Var.value` / GAMS `x.L`), or generate them:
+     `pounce.generate_starts(...)` (Python),
+     `pyomo_pounce.initialize_missing_values(model)` /
+     `pyomo_pounce.block_initialize(model)` (Pyomo).
+   - *on-bound components + clamp moves* on a re-solve → the previous
+     solution is being discarded; use the warm-start recipe:
+     `ws = pounce.WarmStart.from_info(x, info); prob.solve(warm_start=ws)`
+     from Python, or the `warm_start_init_point=yes mu_init=1e-7
+     warm_start_*=1e-9` option set on the CLI.
+   - *very large initial infeasibility* →
+     `least_square_init_primal=yes`, or repair the point:
+     `pounce.project_to_feasible(...)`.
+   - *large derivative scale spread* → a scaling problem wearing an
+     initialization costume; go to the scaling recipes.
+3. **Re-solve with `--json-output ... --json-detail full` and
+   `pounce-studio diagnose`.** `restoration_used` findings that
+   disappear after re-initialization confirm the diagnosis; a clean
+   preflight plus a failing solve means the start is NOT the problem —
+   switch to the troubleshooting recipes.
+
+The MCP twin (`suggest_initialization` in `pounce-studio-mcp`) runs
+step 1 and emits these suggestions mechanically; treat its output as
+advisory, exactly like the `analyze-*` suggestion blocks.
 
 ### "Cite this for me"
 


### PR DESCRIPTION
Implements the full initialization-tooling roadmap (phases 0-5) on one branch, one commit per phase.

## What's here

**Phase 0 — docs.** `docs/src/initialization.md`: one reference page consolidating cold-start behavior (the bound_push interior clamp), the per-algorithm warm-start recipes and their traps, batch chaining, and bad-start diagnostics. Registered in SUMMARY.md.

**Phase 1 — x0 preflight.** One contract (`pounce.check-x0/v1`), three surfaces: `pounce check-x0 <model.nl> [--builtin N] [--x0-file F] [--json]` (exit 0 = evaluates cleanly, 21 = NaN/inf at x0), `pounce.preflight(problem_obj, x0, ...)` in Python, and a `check_x0` MCP tool. Reports non-finite evaluations, bound violations, interior-clamp displacement, initial constraint violation, and derivative scale spread. *Deviation from the original plan:* the core lives in `pounce-cli` (mirroring `pounce verify`), not `pounce-studio-core`, which is deliberately WASM-clean/serde-only and cannot evaluate NLPs.

**Phase 2 — `pounce.WarmStart`.** `WarmStart.from_info(x, info)` captures primal, duals, mu, and SQP working set; `solve(warm_start=ws)` / `minimize(..., warm_start=ws)` apply the whole enabling-option recipe; `save()/load()` (npz) carry it across processes. HS071: 11 cold iterations → 4 warm. Also wires the previously parsed-but-ignored `warm_start_mult_bound_push` in the Rust warm-start initializer (bound multipliers floored, matching upstream); `entire_iterate`/`same_structure` stay parse-for-compat, now documented as such.

**Phase 3 — generation/repair.** `pounce.generate_starts` (the find_minima sampler refactored public, plus a bounds-midpoint strategy), `pounce.project_to_feasible` (min-norm linearized repair via one convex QP), `pounce.race_starts` (truncated-run tournament returning OptimizeResults, composable with WarmStart). *Deviation:* the bounds-aware cold start is a Python sampling strategy, not a Rust `initializer=midpoint` solver option; FBBT integration stays future work.

**Phase 4 — Pyomo.** `pyomo_pounce.preflight(model)` (evaluates the model exactly as the NL writer sends it — unset values as 0 — and restores it), `initialize_missing_values`, and experimental `block_initialize` (Dulmage-Mendelsohn-ordered equality-block solves via `pyomo.contrib.incidence_analysis`; 1x1 blocks by Newton, larger blocks as square POUNCE subsystem solves).

**Phase 5 — skill/MCP.** The studio skill gains a check-x0 section and an initialization playbook recipe; the MCP server gains `suggest_initialization` (deterministic advisory suggestions from the preflight, sharpened by an optional prior solve report).

## Verification

- Rust: full workspace `cargo test` (excluding the HSL-linked `pounce-hsl`, no MA57 locally): **1888 passed, 0 failed**, including 7 new check-x0 unit tests + 4 binary integration tests.
- Python: **553 passed, 3 skipped** (full `python/tests`, native extension rebuilt), including new `test_preflight`, `test_warm_start_object`, `test_starts` suites; `hs071_warm_start.py` runs and shows 11 → 4.
- pyomo-pounce: 13 new tests pass (subsystem-solve case exercises the real binary).
- studio/mcp: 83 passed; both new tools smoke-tested end-to-end.
- `mdbook build docs` and `scripts/check-docs-consistency.sh` pass (38 pages, no dead links).

## Pre-existing failures surfaced (not caused by this branch)

- `pyomo-pounce/tests/test_pounce.py::test_options_forwarded`: the convex QP routing path ignores `max_iter=0` (`pounce quad.nl -AMPL max_iter=0` reports optimal via the convex IPM; `solver_selection=nlp` honors the limit). These tests don't run in CI, so this rotted silently. Deserves its own issue.
- `studio/mcp/tests/test_gams_tools.py::test_run_gams_problem_solves_hs071`: needs a registered GAMS link in the environment (gams exit 6 here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)