### PR TITLE
Honor max_iter=0 on convex QP/SOCP paths (#186)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,11 +179,14 @@ jobs:
           which pounce
           pounce --help | head -5
 
-  # Smoke-build the pyomo-pounce wheel. Pure-Python now: the `pounce`
-  # binary comes from the `pounce-solver` dep, not bundled here. We
-  # build the wheel, install it alongside a locally-built `pounce` on
-  # PATH (since `pounce-solver` may not yet be on PyPI at PR time), and
-  # confirm the plugin resolves the executable.
+  # Smoke-build the pyomo-pounce wheel and run its test suite. Pure-Python
+  # now: the `pounce` binary comes from the `pounce-solver` dep, not bundled
+  # here. We build the wheel, install it alongside a locally-built `pounce`
+  # on PATH (since `pounce-solver` may not yet be on PyPI at PR time), confirm
+  # the plugin resolves the executable, then run `pytest pyomo-pounce/tests`
+  # end-to-end against that binary. The pytest step exercises actual solves
+  # (option forwarding, routing) that a plain import smoke test cannot —
+  # without it, routing regressions like pounce#186 ship silently.
   pyomo-pounce-smoke:
     name: wheel smoke (pyomo-pounce)
     runs-on: ubuntu-latest
@@ -212,3 +215,12 @@ jobs:
           export PATH="$PWD/target/release:$PATH"
           which pounce
           python -c "import pyomo_pounce; from pyomo.opt import SolverFactory; s = SolverFactory('pounce'); print('exe:', s.executable())"
+      - name: Run pyomo-pounce tests
+        run: |
+          python -m pip install pytest
+          # The plugin resolves `pounce` from PATH, so re-export it here
+          # (each `run:` is a fresh shell). These tests drive real solves
+          # through the AMPL/`.nl` layer — option forwarding, solver routing —
+          # which is what catches regressions the import smoke test misses.
+          export PATH="$PWD/target/release:$PATH"
+          python -m pytest pyomo-pounce/tests -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ changes.
 
 ### Fixed
 
+- **Convex QP/LP path now honors `max_iter=0` (#186).** A Pyomo/AMPL solve
+  auto-routed to the `pounce-convex` interior-point path reported *Optimal
+  Solution Found* even with `max_iter=0`, because the routed problem was solved
+  by presolve or a direct step that ignored the iteration cap — violating the
+  AMPL/Ipopt contract that zero iterations cannot reach optimality (the NLP
+  path already reported `MaximumIterationsExceeded`). The convex QP and SOCP
+  dispatch now short-circuit to an iteration-limit result before any solve when
+  `max_iter=0`, and `max_iter` is forwarded to the convex driver for the `=0`
+  case (previously dropped). CI now runs `pytest pyomo-pounce/tests`
+  end-to-end (not just an import smoke test), which is how this regressed
+  silently.
 - **`reaction_network` mode-aware dedup on flat eigenmodes (#183).** When the
   PES has a genuine zero (flat) Hessian eigenmode — rigid translation/rotation
   of any molecule, or an intrinsically flat coordinate — the minima dedup

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1564,7 +1564,11 @@ fn convex_cli_opts(app: &IpoptApplication) -> pounce_convex::QpOptions {
     let mut o = pounce_convex::QpOptions::default();
     let opt = app.options();
     if let Ok((v, true)) = opt.get_integer_value("max_iter", "") {
-        if v > 0 {
+        // Forward `max_iter=0` too: AMPL/Ipopt semantics make it a
+        // "take no iterations" request that must not reach optimality
+        // (pounce#186). Only a negative value (invalid) is ignored so the
+        // usize cast can't wrap.
+        if v >= 0 {
             o.max_iter = v as usize;
         }
     }
@@ -1676,7 +1680,15 @@ fn run_convex_qp(
         collect_iterates: want_trace,
         ..convex_opts
     };
-    let sol = if let Some(hook) = debug_hook {
+    let sol = if qp_opts.max_iter == 0 {
+        // AMPL/Ipopt semantics: `max_iter=0` takes no iterations and so
+        // cannot reach optimality. Presolve can otherwise solve a trivial
+        // problem (e.g. an unconstrained quadratic) directly — or the IPM's
+        // reduced/empty solve can report Optimal — regardless of the cap, so
+        // enforce the zero-iteration stop here before any solve runs
+        // (pounce#186). Mirrors the NLP path's MaximumIterationsExceeded.
+        trivial(QpStatus::IterationLimit)
+    } else if let Some(hook) = debug_hook {
         // Interactive debug: step the IPM on the extracted QP directly.
         // Presolve is skipped so the debugger's `x`/`s`/`y`/`z` blocks
         // correspond to the user's problem rather than a reduced one.
@@ -1864,7 +1876,21 @@ fn run_convex_socp(
         ..convex_opts
     };
     let t0 = std::time::Instant::now();
-    let sol = if let Some(hook) = debug_hook {
+    let sol = if qp_opts.max_iter == 0 {
+        // `max_iter=0` cannot reach optimality — stop before any solve, the
+        // same zero-iteration contract the QP path enforces (pounce#186).
+        pounce_convex::QpSolution {
+            status: pounce_convex::QpStatus::IterationLimit,
+            x: vec![0.0; qp.n],
+            y: vec![0.0; qp.m_eq()],
+            z: vec![0.0; qp.m_ineq()],
+            z_lb: vec![0.0; qp.n],
+            z_ub: vec![0.0; qp.n],
+            obj: 0.0,
+            iters: 0,
+            iterates: Vec::new(),
+        }
+    } else if let Some(hook) = debug_hook {
         let mut h = hook.borrow_mut();
         solve_socp_ipm_debug(&qp, &cones, &qp_opts, &mut *h, backend)
     } else {

--- a/crates/pounce-cli/tests/qp_dispatch_end_to_end.rs
+++ b/crates/pounce-cli/tests/qp_dispatch_end_to_end.rs
@@ -226,6 +226,65 @@ fn auto_routes_convex_qp_to_pounce_convex() {
     );
 }
 
+/// pounce#186: `max_iter=0` on the convex-routed path must honor AMPL/Ipopt
+/// semantics — zero iterations cannot reach optimality. The convex path used
+/// to report "Optimal Solution Found" regardless (the routed QP was solved by
+/// presolve / a direct step that ignored the cap), so a Pyomo `max_iter=0`
+/// silently "succeeded". Both arms are checked on the same `auto`-routed convex
+/// QP: the plain-CLI status line reports the iteration limit (not optimal), and
+/// under `-AMPL` the `.sol` carries the non-optimal `solve_result_num` 400.
+#[test]
+fn max_iter_zero_on_convex_path_is_not_optimal() {
+    // Plain-CLI arm: the convex banner must report the iteration limit.
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg("solver_selection=auto")
+        .arg("max_iter=0")
+        .output()
+        .expect("spawn pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("pounce-convex"),
+        "the QP must still route to the convex path:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains("Optimal Solution Found"),
+        "max_iter=0 must not report optimal on the convex path:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Maximum iterations exceeded"),
+        "max_iter=0 must report the iteration limit:\n{stdout}"
+    );
+
+    // `-AMPL` arm: the non-optimal verdict travels in the `.sol` as
+    // solve_result_num 400, which is what Pyomo reads back.
+    let dir = std::env::temp_dir();
+    let sol = dir.join("pounce_186_max_iter_zero.sol");
+    let _ = std::fs::remove_file(&sol);
+    let ampl = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("solver_selection=auto")
+        .arg("max_iter=0")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(
+        ampl.status.code(),
+        Some(0),
+        "-AMPL must exit 0 (verdict travels in the .sol); stdout=\n{}",
+        String::from_utf8_lossy(&ampl.stdout)
+    );
+    let text = std::fs::read_to_string(&sol).expect("verdict .sol written under -AMPL");
+    assert!(
+        text.contains("400"),
+        "the iteration-limit solve_result_num (400) must be in the .sol:\n{text}"
+    );
+    let _ = std::fs::remove_file(&sol);
+}
+
 #[test]
 fn forced_qp_ipm_solves() {
     let out = Command::new(pounce_exe())

--- a/pyomo-pounce/tests/test_pounce.py
+++ b/pyomo-pounce/tests/test_pounce.py
@@ -50,7 +50,9 @@ def _make_executable(path):
 def test_default_executable_prefers_bundled(monkeypatch, tmp_path):
     # A bundled binary exists at the deterministic wheel path, but PATH does
     # NOT contain `pounce`. The plugin must still resolve the bundled binary.
-    import pounce._cli as cli
+    # Needs the `pounce-solver` package (for `pounce._cli`); skip where only
+    # the CLI binary is on PATH (e.g. CI's pyomo-pounce smoke job).
+    cli = pytest.importorskip("pounce._cli")
 
     bundled = tmp_path / "bin" / "pounce"
     bundled.parent.mkdir()
@@ -65,7 +67,7 @@ def test_default_executable_prefers_bundled(monkeypatch, tmp_path):
 def test_default_executable_falls_back_to_path(monkeypatch, tmp_path):
     # No bundled binary (system install / local cargo dev build): fall back to
     # whatever `pounce` is on PATH.
-    import pounce._cli as cli
+    cli = pytest.importorskip("pounce._cli")
 
     monkeypatch.setattr(cli, "_bundled_binary", lambda: tmp_path / "absent" / "pounce")
     shim_dir = tmp_path / "pathbin"
@@ -79,7 +81,7 @@ def test_default_executable_falls_back_to_path(monkeypatch, tmp_path):
 
 def test_default_executable_none_when_nowhere(monkeypatch, tmp_path):
     # Neither bundled nor on PATH → None (the honest "unavailable" signal).
-    import pounce._cli as cli
+    cli = pytest.importorskip("pounce._cli")
 
     monkeypatch.setattr(cli, "_bundled_binary", lambda: tmp_path / "absent" / "pounce")
     monkeypatch.setenv("PATH", str(tmp_path / "empty"))


### PR DESCRIPTION
## Summary

The convex QP and SOCP dispatch paths now correctly honor `max_iter=0` by short-circuiting to an iteration-limit result before any solve runs. Previously, these paths reported "Optimal Solution Found" even with `max_iter=0` because the routed problem was solved by presolve or a direct step that ignored the iteration cap, violating the AMPL/Ipopt contract that zero iterations cannot reach optimality.

## Changes

- **`main.rs` convex dispatch**: Modified `convex_cli_opts()` to forward `max_iter=0` (previously dropped negative/zero values). Added early-exit checks in both `run_convex_qp()` and `run_convex_socp()` that return an `IterationLimit` status when `max_iter=0`, before any solve runs. This mirrors the NLP path's `MaximumIterationsExceeded` behavior.

- **Test coverage**: Added `max_iter_zero_on_convex_path_is_not_optimal()` end-to-end test that verifies:
  - Plain-CLI arm reports "Maximum iterations exceeded" (not "Optimal Solution Found")
  - `-AMPL` arm writes `solve_result_num 400` (non-optimal) to the `.sol` file, which Pyomo reads back

- **CI enhancement**: Updated `.github/workflows/ci.yml` to run `pytest pyomo-pounce/tests` end-to-end (not just an import smoke test). This catches routing regressions like #186 that would otherwise ship silently.

- **Documentation**: Updated `CHANGELOG.md` with the fix and rationale.

## Implementation Details

- `max_iter=0` is now treated as a valid (non-negative) value and forwarded to the convex driver, allowing the early-exit logic to distinguish it from invalid negative values.
- The zero-iteration short-circuit happens before presolve or any IPM step, ensuring the iteration cap is always honored regardless of problem structure.
- For SOCP, the trivial solution is constructed with zero dual variables and zero objective, consistent with the zero-iteration contract.

https://claude.ai/code/session_01HMadjjkDn1qhBxPcEmLifC