### PR TITLE
pip GAMS link: honor json_output/json_detail via canonical report writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ changes.
 
 ### Fixed
 
+- **pip GAMS link honors `json_output` / `json_detail` (#187).** The pure-Python
+  GAMS link parsed those option-file keys and then discarded them, so a
+  `pounce.opt` requesting a `pounce.solve-report/v1` JSON was a silent no-op on
+  the pip route even though `docs/src/gams.md` advertises it (only the native C
+  link implemented it). `Problem.solve` now takes optional `report_path` /
+  `report_detail` (`"summary"` | `"full"`) kwargs that emit the report through
+  the **canonical Rust writer** (`pounce-solve-report`, the same schema/serializer
+  as the CLI's `--json-output`) — no report format is reimplemented in Python.
+  The GAMS link threads the two link options into that surface (Full detail
+  enables the per-iteration trace the `pounce-studio`/MCP post-mortem tools
+  consume), and the writer is now available to any Python caller.
 - **Convex QP/LP path now honors `max_iter=0` (#186).** A Pyomo/AMPL solve
   auto-routed to the `pounce-convex` interior-point path reported *Optimal
   Solution Found* even with `max_iter=0`, because the routed problem was solved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1060,6 +1060,7 @@ dependencies = [
  "pounce-qp",
  "pounce-restoration",
  "pounce-sensitivity",
+ "pounce-solve-report",
  "pyo3",
  "tracing",
 ]

--- a/crates/pounce-py/Cargo.toml
+++ b/crates/pounce-py/Cargo.toml
@@ -39,6 +39,7 @@ faer.workspace = true
 pounce-linsol.workspace = true
 pounce-sensitivity.workspace = true
 pounce-observability.workspace = true
+pounce-solve-report.workspace = true
 tracing.workspace = true
 pyo3 = { version = "0.22", features = ["abi3-py39"] }
 numpy = "0.22"

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -18,7 +18,10 @@ use pounce_restoration::resto_inner_solver::{
     make_default_restoration_factory_provider, InnerBackendFactoryFactory,
 };
 use pounce_sensitivity::SensSolve;
-use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pounce_solve_report::{
+    status_to_solve_result_num, write_report_file, InputDescriptor, ReportBuilder, ReportDetail,
+};
+use pyo3::exceptions::{PyIOError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
 use std::cell::RefCell;
@@ -203,7 +206,7 @@ impl PyProblem {
     /// previously stashed via `set_working_set`. After every SQP
     /// solve `info_dict["working_set"]` holds the final working
     /// set, and `get_working_set()` returns the same tuple.
-    #[pyo3(signature = (x0, lagrange=None, zl=None, zu=None, working_set=None))]
+    #[pyo3(signature = (x0, lagrange=None, zl=None, zu=None, working_set=None, report_path=None, report_detail=None))]
     fn solve<'py>(
         &mut self,
         py: Python<'py>,
@@ -212,8 +215,17 @@ impl PyProblem {
         zl: Option<Py<PyAny>>,
         zu: Option<Py<PyAny>>,
         working_set: Option<Py<PyAny>>,
+        report_path: Option<String>,
+        report_detail: Option<String>,
     ) -> PyResult<(Bound<'py, PyArray1<Number>>, Bound<'py, PyDict>)> {
         let (mut app, bridge) = self.prepare(py, x0, lagrange, zl, zu)?;
+        // A Full-detail solve report needs the per-iteration trace, which is
+        // only captured when explicitly enabled before the solve — mirrors the
+        // CLI's `--json-detail full` path (pounce#187).
+        let want_iter_history = report_path.is_some() && report_detail.as_deref() == Some("full");
+        if want_iter_history {
+            app.enable_iter_history();
+        }
         // Per-call working_set overrides any pending one set via
         // `set_working_set`. Either path lands as
         // `IpoptApplication::set_sqp_warm_start`.
@@ -365,6 +377,21 @@ impl PyProblem {
         }
         info.set_item("wall_time", timing.overall_alg.total_wallclock_time())?;
         info.set_item("timing", timing_dict)?;
+        // Optional `pounce.solve-report/v1` JSON, written by the canonical
+        // Rust writer (same schema as the CLI's `--json-output`), so callers
+        // like the pip GAMS link can emit a FAIR solve report without the
+        // report writer being reimplemented in Python (pounce#187).
+        if let Some(path) = report_path {
+            write_solve_report(
+                &path,
+                report_detail.as_deref(),
+                self.n,
+                self.m,
+                &stats,
+                status,
+                &bridge.borrow().state,
+            )?;
+        }
         let x_out = bridge.borrow().state.final_x.clone().into_pyarray_bound(py);
         Ok((x_out, info))
     }
@@ -925,6 +952,44 @@ impl PyProblem {
             .map(|(l, u)| l == u)
             .collect()
     }
+}
+
+/// Build and write a `pounce.solve-report/v1` JSON file from a finished
+/// solve, using the canonical Rust writer (`pounce-solve-report`) — the same
+/// schema and serializer the CLI's `--json-output` uses, so the Python path
+/// (pounce#187) never reimplements the report format. `detail` is
+/// `"summary"` (default) or `"full"`; the input is recorded as a direct TNLP
+/// solve.
+#[allow(clippy::too_many_arguments)]
+fn write_solve_report(
+    path: &str,
+    detail: Option<&str>,
+    n: Index,
+    m: Index,
+    stats: &pounce_nlp::solve_statistics::SolveStatistics,
+    status: ApplicationReturnStatus,
+    state: &PyTnlpInit,
+) -> PyResult<()> {
+    let detail = match detail {
+        Some(s) => ReportDetail::parse(s).map_err(PyValueError::new_err)?,
+        None => ReportDetail::Summary,
+    };
+    let mut builder = ReportBuilder::new(detail, InputDescriptor::TnlpDirect);
+    builder.problem.n_variables = n;
+    builder.problem.n_constraints = m;
+    builder.problem.n_objectives = 1;
+    // pounce's `Problem` always minimizes the objective callback.
+    builder.problem.minimize = true;
+    builder.ingest_stats(stats);
+    builder.solution.status = status;
+    builder.solution.solve_result_num = status_to_solve_result_num(status);
+    builder.solution.objective = state.final_obj;
+    builder.solution.x = state.final_x.clone();
+    builder.solution.lambda = state.final_lambda.clone();
+    let report = builder.finish();
+    write_report_file(std::path::Path::new(path), &report)
+        .map_err(|e| PyIOError::new_err(format!("failed to write solve report to {path}: {e}")))?;
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/python/pounce/gams/link.py
+++ b/python/pounce/gams/link.py
@@ -165,12 +165,31 @@ def _coerce(val: str):
         return val
 
 
+def _resolve_json_detail(val, gev=None, gev_h=None) -> str:
+    """Validate the ``json_detail`` link option, matching the native C link.
+
+    Accepts ``"summary"`` / ``"full"``; anything else (including ``None`` when
+    ``json_output`` was given without ``json_detail``) falls back to ``"full"``,
+    logging a warning through GEV for an explicit but invalid value.
+    """
+    if val in ("summary", "full"):
+        return val
+    if val is not None and gev is not None and gev_h is not None:
+        gev.gevLogStat(
+            gev_h,
+            f"*** Warning: json_detail '{val}' not in {{summary,full}}; using 'full'",
+        )
+    return "full"
+
+
 def solve_view(
     view: "GmoView",
     *,
     options: dict | None = None,
     max_iter: int | None = None,
     max_wall_time: float | None = None,
+    report_path: str | None = None,
+    report_detail: str | None = None,
 ):
     """Translate a GMO view, build a POUNCE problem, solve, return ``(prob, x, info)``.
 
@@ -182,6 +201,10 @@ def solve_view(
     file); ``max_iter`` / ``max_wall_time`` come from the GAMS environment
     (``gevIterLim`` / ``gevResLim``) and are applied as defaults the option file
     can still override.
+
+    ``report_path`` / ``report_detail`` (the ``json_output`` / ``json_detail``
+    link options) route a ``pounce.solve-report/v1`` JSON to disk via the
+    canonical Rust writer, matching the native C link (pounce#187).
     """
     import pounce
 
@@ -214,7 +237,9 @@ def solve_view(
         except Exception as exc:  # unknown / invalid option: warn, keep going
             sys.stderr.write(f"pounce-gams: ignoring option '{key}': {exc}\n")
 
-    x, info = prob.solve(x0=gp.x0)
+    x, info = prob.solve(
+        x0=gp.x0, report_path=report_path, report_detail=report_detail
+    )
     return gp, x, info
 
 
@@ -276,16 +301,33 @@ def solve_from_control_file(
 
     # Option file (pounce.opt / .op2 ...).
     options: dict = {}
+    link_opts: dict = {}
     if gmo.gmoOptFile(gmo_h) > 0:
         optname = gmo.gmoNameOptFile(gmo_h)
         if isinstance(optname, (list, tuple)):  # some bindings return [rc, name]
             optname = optname[-1]
         gev.gevLogStat(gev_h, f"  Reading option file {optname}")
-        options, _link_opts = parse_option_file(str(optname))
+        options, link_opts = parse_option_file(str(optname))
+
+    # Link-specific keys (json_output / json_detail): route a
+    # pounce.solve-report/v1 JSON to disk through the canonical Rust writer,
+    # honoring what docs/src/gams.md advertises for the pip route (pounce#187).
+    report_path = link_opts.get("json_output") or None
+    report_detail = None
+    if report_path is not None:
+        report_detail = _resolve_json_detail(link_opts.get("json_detail"), gev, gev_h)
+        gev.gevLogStat(
+            gev_h, f"  Writing pounce.solve-report/v1 ({report_detail}) to {report_path}"
+        )
 
     view = _GmoAdapter(gmo_h, gmo)
     _gp, x, info = solve_view(
-        view, options=options, max_iter=max_iter, max_wall_time=max_wall
+        view,
+        options=options,
+        max_iter=max_iter,
+        max_wall_time=max_wall,
+        report_path=report_path,
+        report_detail=report_detail,
     )
 
     gev.gevLogStat(gev_h, f"POUNCE status: {info.get('status_msg')}")

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -188,6 +188,45 @@ def test_solve_view_with_analytical_hessian_reaches_optimum():
     assert info["obj_val"] == pytest.approx(HS071_OPT, abs=1e-4)
 
 
+def test_solve_view_writes_solve_report(tmp_path):
+    """pounce#187: the pip link honors json_output/json_detail by writing a
+    canonical pounce.solve-report/v1 JSON via the Rust writer, so the report is
+    not a silent no-op on the pip route."""
+    import json
+
+    report = tmp_path / "hs071.report.json"
+    _gp, x, info = link.solve_view(
+        HS071View(with_hessian=True),
+        options={"tol": 1e-8},
+        report_path=str(report),
+        report_detail="full",
+    )
+    assert info["status_msg"] in _CONVERGED
+    assert report.exists(), "json_output must produce a report file on the pip route"
+
+    doc = json.loads(report.read_text())
+    assert doc["schema"] == "pounce.solve-report/v1"
+    assert doc["solution"]["status"] == "SolveSucceeded"
+    assert doc["problem"]["n_variables"] == 4
+    assert doc["problem"]["n_constraints"] == 2
+    # `full` detail carries the per-iteration trace the studio/MCP post-mortem
+    # tools consume; `summary` omits it.
+    assert doc["iterations"], "full detail should include the iteration history"
+    assert doc["solution"]["objective"] == pytest.approx(HS071_OPT, abs=1e-4)
+
+    # `summary` detail writes a valid report but drops the iteration history.
+    summary = tmp_path / "hs071.summary.json"
+    link.solve_view(
+        HS071View(with_hessian=True),
+        options={"tol": 1e-8},
+        report_path=str(summary),
+        report_detail="summary",
+    )
+    sdoc = json.loads(summary.read_text())
+    assert sdoc["schema"] == "pounce.solve-report/v1"
+    assert not sdoc.get("iterations")
+
+
 def test_maximize_sign_flips_objective_and_gradient():
     gp_min = problem_from_gmo(HS071View(maximize=False))
     gp_max = problem_from_gmo(HS071View(maximize=True))


### PR DESCRIPTION
## Summary

The pip GAMS link now honors `json_output` and `json_detail` option-file keys by writing a `pounce.solve-report/v1` JSON through the canonical Rust writer (`pounce-solve-report`), matching the native C link's behavior. Previously these options were parsed but silently discarded, making the feature a no-op on the pip route despite being advertised in documentation.

## Key Changes

- **`Problem.solve()` surface expansion**: Added optional `report_path` and `report_detail` kwargs to emit solve reports. `report_detail` accepts `"summary"` (default) or `"full"`; full detail enables per-iteration trace capture for post-mortem analysis tools.

- **Canonical report writer integration**: New `write_solve_report()` function in `pounce-py` uses `pounce-solve-report` crate (same schema/serializer as CLI's `--json-output`) to write reports, avoiding Python reimplementation of the report format.

- **GAMS link threading**: `solve_view()` and `solve_from_control_file()` now accept and pass through `report_path`/`report_detail`. The link parses `json_output`/`json_detail` from option files and validates `json_detail` with fallback to `"full"` (matching native C link behavior).

- **Per-iteration history on demand**: When full-detail reporting is requested, `app.enable_iter_history()` is called before solve to capture the trace needed by studio/MCP post-mortem tools.

- **Test coverage**: New test `test_solve_view_writes_solve_report()` validates that both `"summary"` and `"full"` detail levels produce valid reports with correct schema and expected content (iteration history present only in full detail).

## Implementation Details

- The report writer is now available to any Python caller via the `Problem.solve()` API, not just the GAMS link.
- Full-detail reporting requires explicit opt-in (via `report_detail="full"`) to avoid overhead of iteration history capture on every solve.
- The `_resolve_json_detail()` helper mirrors the native C link's validation logic, logging warnings through GEV for invalid values.
- Dependency: added `pounce-solve-report` to `pounce-py`'s workspace dependencies.

Fixes #187.

https://claude.ai/code/session_01HMadjjkDn1qhBxPcEmLifC