### PR TITLE
Gate detailed timing on timing_statistics (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,10 @@ changes.
   split, and the per-callback objective / gradient / constraint / Jacobian /
   Lagrangian-Hessian eval time); `pounce.minimize` mirrors these as
   `res.wall_time` / `res.timing`. Lets a caller attribute a reduced-space
-  solve's runtime (e.g. densified-Hessian eval cost) directly.
+  solve's runtime (e.g. densified-Hessian eval cost) directly. The detailed
+  breakdown is opt-in via `timing_statistics="yes"` (see #190 under Fixed);
+  without it, `wall_time` / `overall_alg` are populated and the per-subsystem
+  entries read `0.0`.
 - **Block-triangular / Schur KKT solve** (item 2). A structure-aware presolve
   can hand pounce the reducible block of the KKT system; that block is
   Schur-complemented out and only the two diagonal blocks are factorized, with
@@ -52,6 +55,17 @@ changes.
 
 ### Fixed
 
+- **`timing_statistics=no` no longer runs the detailed timers every iteration
+  (#190).** Every `TimedTask::start`/`end` pair calls `getrusage(RUSAGE_SELF)`
+  (twice — once each), and the per-subsystem / per-callback timers wrap hot
+  paths (each objective/gradient/constraint/Jacobian/Hessian evaluation, plus
+  every solve phase). Upstream Ipopt gates these detailed timers on
+  `timing_statistics` (default `no`), but pounce mirrored the timers without
+  the gating — so the syscalls were paid unconditionally, measuring at 16–20%
+  of busy CPU on fast-objective, high-iteration NLPs. The detailed timers are
+  now disabled unless `timing_statistics yes` (or `print_timing_statistics
+  yes`, which implies it) is set. `OverallAlgorithm` stays live regardless: it
+  feeds the `max_cpu_time` convergence check and its total is always reported.
 - **pip GAMS link honors `json_output` / `json_detail` (#187).** The pure-Python
   GAMS link parsed those option-file keys and then discarded them, so a
   `pounce.opt` requesting a `pounce.solve-report/v1` JSON was a silent no-op on

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1225,6 +1225,25 @@ impl IpoptApplication {
         // via [`Self::timing_stats`].
         let timing = Rc::new(TimingStatistics::new());
         *self.timing.borrow_mut() = Rc::clone(&timing);
+        // Gate the *detailed* per-subsystem timers on `timing_statistics`
+        // (default "no"), matching upstream Ipopt. Without this, every
+        // timed `eval_*` / phase section pays two `getrusage` syscalls per
+        // start/end even when statistics are off — 16-20% of busy CPU on
+        // fast-objective NLPs (issue #190). `print_timing_statistics=yes`
+        // implies `timing_statistics=yes` (per its option help), so either
+        // one enables the detailed timers. `overall_alg` is started
+        // unconditionally below: it feeds the `max_cpu_time` check and is
+        // reported regardless of the option.
+        let timing_enabled = ["timing_statistics", "print_timing_statistics"]
+            .iter()
+            .any(|opt| {
+                self.options
+                    .get_bool_value(opt, "")
+                    .ok()
+                    .and_then(|(v, f)| f.then_some(v))
+                    .unwrap_or(false)
+            });
+        timing.set_detailed_enabled(timing_enabled);
         timing.overall_alg.start();
 
         // Reset the linear-solver summary sink so back-to-back solves

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -771,6 +771,59 @@ fn hs071_output_file_captures_timing_report() {
     let _ = std::fs::remove_file(&path);
 }
 
+/// Regression test for issue #190: with `timing_statistics` at its
+/// default (`no`), the detailed per-subsystem timers must be disabled so
+/// a fast-objective solve doesn't pay two `getrusage` syscalls per timed
+/// section. `overall_alg` stays live regardless (it feeds `max_cpu_time`
+/// and is always reported). Setting the option back on re-enables the
+/// detailed breakdown.
+#[test]
+fn hs071_timing_statistics_gates_detailed_timers() {
+    // Default configuration — `timing_statistics` unset (⇒ "no").
+    let mut app = IpoptApplication::new();
+    app.initialize_with_options_str("").unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071::default()));
+    let status = app.optimize_tnlp(tnlp);
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status: {status:?}",
+    );
+    let t = app.timing_stats();
+    // Overall timer runs unconditionally.
+    assert!(t.overall_alg.is_enabled(), "overall_alg must stay enabled");
+    assert!(t.overall_alg.total_wallclock_time() >= 0.0);
+    // Every detailed timer is disabled ⇒ accumulated nothing.
+    assert!(!t.eval_obj.is_enabled(), "eval_obj should be gated off");
+    assert_eq!(
+        t.eval_obj.total_wallclock_time(),
+        0.0,
+        "detailed eval timer accumulated despite timing_statistics=no",
+    );
+    assert_eq!(
+        t.total_function_evaluation_time.total_wallclock_time(),
+        0.0,
+    );
+    assert_eq!(t.check_convergence.total_wallclock_time(), 0.0);
+
+    // Opting in re-enables the detailed timers, so the breakdown is
+    // populated again.
+    let mut app = IpoptApplication::new();
+    app.initialize_with_options_str("timing_statistics yes\n")
+        .unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071::default()));
+    let _ = app.optimize_tnlp(tnlp);
+    let t = app.timing_stats();
+    assert!(t.eval_obj.is_enabled(), "eval_obj should be enabled");
+    assert!(
+        t.check_convergence.is_enabled(),
+        "check_convergence should be enabled when timing_statistics=yes",
+    );
+}
+
 /// Wave-4 smoke: the eight `warm_start_*` knobs and the
 /// `warm_start_init_point` toggle parse through
 /// `algorithm_builder_from_options` without erroring. End-to-end

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -803,10 +803,7 @@ fn hs071_timing_statistics_gates_detailed_timers() {
         0.0,
         "detailed eval timer accumulated despite timing_statistics=no",
     );
-    assert_eq!(
-        t.total_function_evaluation_time.total_wallclock_time(),
-        0.0,
-    );
+    assert_eq!(t.total_function_evaluation_time.total_wallclock_time(), 0.0,);
     assert_eq!(t.check_convergence.total_wallclock_time(), 0.0);
 
     // Opting in re-enables the detailed timers, so the breakdown is

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2101,6 +2101,12 @@ fn write_diagnostics_manifest(
 
 /// Emit a sibling `timing.json` so dump consumers can correlate
 /// per-iter files with the solve's wall-clock budget.
+///
+/// `overall_alg_secs` is always populated. The
+/// `linear_system_*` splits are detailed timers gated on
+/// `timing_statistics` (default "no", issue #190), so they read `0.0`
+/// unless the run set `timing_statistics yes` (or
+/// `print_timing_statistics yes`, which implies it).
 fn write_diagnostics_timing(diag: &DiagnosticsState, app: &IpoptApplication) {
     let t = app.timing_stats();
     let body = format!(

--- a/crates/pounce-common/src/timing.rs
+++ b/crates/pounce-common/src/timing.rs
@@ -366,6 +366,54 @@ impl TimingStatistics {
         ]
     }
 
+    /// Enable or disable the *detailed* per-subsystem timers, mirroring
+    /// upstream Ipopt's `timing_statistics` gating (`IpoptApplication`
+    /// only measures the detailed function/phase timers when
+    /// `timing_statistics=yes`). When `on` is `false` every `start()` /
+    /// `end()` on these tasks becomes a no-op, so a fast-objective solve
+    /// stops paying two `getrusage` syscalls per timed section (issue
+    /// #190).
+    ///
+    /// [`Self::overall_alg`] is deliberately left untouched: its
+    /// `live_cpu_time()` feeds the `max_cpu_time` convergence check and
+    /// its total is reported regardless of the option — upstream's help
+    /// text is explicit that "the overall algorithm time is unaffected by
+    /// this option". Callers that need the detailed
+    /// [`Self::wall_time_breakdown`] populated (the Python `info["timing"]`
+    /// dict, the CLI `timing.json`) must therefore set `timing_statistics`
+    /// (or `print_timing_statistics`, which implies it) to `yes`.
+    pub fn set_detailed_enabled(&self, on: bool) {
+        let set = |t: &TimedTask| {
+            if on {
+                t.enable();
+            } else {
+                t.disable();
+            }
+        };
+        // Every field except `overall_alg`.
+        set(&self.print_problem_statistics);
+        set(&self.initialize_iterates);
+        set(&self.update_hessian);
+        set(&self.output_iteration);
+        set(&self.update_barrier_parameter);
+        set(&self.compute_search_direction);
+        set(&self.compute_acceptable_trial_point);
+        set(&self.accept_trial_point);
+        set(&self.check_convergence);
+        set(&self.linear_system_factorization);
+        set(&self.linear_system_back_solve);
+        set(&self.linear_system_structure_converter);
+        set(&self.linear_system_structure_converter_init);
+        set(&self.quality_function_search);
+        set(&self.total_callback_time);
+        set(&self.total_function_evaluation_time);
+        set(&self.eval_obj);
+        set(&self.eval_grad_obj);
+        set(&self.eval_constr);
+        set(&self.eval_constr_jac);
+        set(&self.eval_lag_hess);
+    }
+
     /// Reset all counters. Mirrors upstream `ResetTimes()`.
     pub fn reset(&self) {
         self.overall_alg.reset();
@@ -415,6 +463,36 @@ mod tests {
         t.start();
         t.end();
         assert_eq!(t.total_wallclock_time(), 0.0);
+    }
+
+    #[test]
+    fn set_detailed_enabled_gates_all_but_overall_alg() {
+        let stats = TimingStatistics::new();
+        // Default: every timer enabled.
+        assert!(stats.overall_alg.is_enabled());
+        assert!(stats.eval_obj.is_enabled());
+        assert!(stats.check_convergence.is_enabled());
+
+        // Disabling the detail timers (issue #190: `timing_statistics=no`)
+        // must leave `overall_alg` alive — it feeds the `max_cpu_time`
+        // check and is always reported — while every other timer becomes
+        // a no-op that skips the `getrusage` syscalls.
+        stats.set_detailed_enabled(false);
+        assert!(stats.overall_alg.is_enabled(), "overall_alg must stay live");
+        assert!(!stats.eval_obj.is_enabled());
+        assert!(!stats.check_convergence.is_enabled());
+        assert!(!stats.total_function_evaluation_time.is_enabled());
+        assert!(!stats.linear_system_factorization.is_enabled());
+
+        // A disabled detail timer accumulates nothing even across start/end.
+        stats.eval_obj.start();
+        stats.eval_obj.end();
+        assert_eq!(stats.eval_obj.total_wallclock_time(), 0.0);
+
+        // Re-enabling restores them.
+        stats.set_detailed_enabled(true);
+        assert!(stats.eval_obj.is_enabled());
+        assert!(stats.check_convergence.is_enabled());
     }
 
     #[test]

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -370,6 +370,15 @@ impl PyProblem {
         // convenience. Lets a reduced-space / variable-aggregation caller
         // attribute runtime (e.g. densified-Hessian eval cost) directly
         // instead of inferring it.
+        //
+        // NOTE (issue #190): the *detailed* per-subsystem timers are gated
+        // on the `timing_statistics` option (default "no"), matching
+        // upstream Ipopt — running them unconditionally costs two
+        // `getrusage` syscalls per timed section, which is 16-20% of busy
+        // CPU on fast-objective NLPs. So every key except `overall_alg`
+        // (and `wall_time`) is reported as `0.0` unless the caller passes
+        // `timing_statistics="yes"`. `overall_alg`/`wall_time` are always
+        // populated.
         let timing = app.timing_stats();
         let timing_dict = PyDict::new_bound(py);
         for (label, secs) in timing.wall_time_breakdown() {

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -51,7 +51,15 @@ def test_minimize_reports_timing_breakdown():
     breakdown (``res.timing`` / ``res.info["timing"]``) plus a top-level
     ``res.wall_time``, so a caller can attribute solve runtime (func /
     gradient / Jacobian / Hessian eval time, factorization vs back-solve)
-    without patching the solver."""
+    without patching the solver.
+
+    The *detailed* breakdown is opt-in via ``timing_statistics="yes"``
+    (issue #190): running the per-subsystem timers unconditionally costs
+    two ``getrusage`` syscalls per timed section, so by default only
+    ``overall_alg`` / ``wall_time`` are populated and the rest read
+    ``0.0``. The breakdown schema (keys present, non-negative, the
+    linear-algebra total equal to the sum of its parts) holds either way.
+    """
 
     def f(x):
         return float(x @ x)
@@ -59,7 +67,13 @@ def test_minimize_reports_timing_breakdown():
     def grad(x):
         return 2.0 * x
 
-    res = pounce.minimize(f, x0=np.array([1.0, 2.0, 3.0]), jac=grad, print_level=0)
+    res = pounce.minimize(
+        f,
+        x0=np.array([1.0, 2.0, 3.0]),
+        jac=grad,
+        print_level=0,
+        timing_statistics="yes",
+    )
     assert res.success
 
     # Top-level convenience fields.
@@ -91,6 +105,40 @@ def test_minimize_reports_timing_breakdown():
         res.timing["linear_system_factorization"]
         + res.timing["linear_system_back_solve"]
     )
+
+
+def test_minimize_timing_breakdown_gated_by_default():
+    """Issue #190: with ``timing_statistics`` at its default (``no``), the
+    detailed per-subsystem timers are disabled — the solve stops paying two
+    ``getrusage`` syscalls per timed section on fast objectives. The
+    breakdown schema is still present (keys exist), ``overall_alg`` /
+    ``wall_time`` are still populated, but every detailed key reads ``0.0``.
+    """
+
+    def f(x):
+        return float(x @ x)
+
+    def grad(x):
+        return 2.0 * x
+
+    res = pounce.minimize(f, x0=np.array([1.0, 2.0, 3.0]), jac=grad, print_level=0)
+    assert res.success
+
+    # Overall totals survive the gating.
+    assert res.wall_time >= 0.0
+    assert res.timing["overall_alg"] >= 0.0
+
+    # Detailed per-callback / linear-algebra timers are gated off ⇒ 0.0.
+    for key in (
+        "eval_objective",
+        "eval_gradient",
+        "function_evaluations_total",
+        "linear_system_factorization",
+        "linear_system_back_solve",
+    ):
+        assert res.timing[key] == 0.0, (
+            f"{key} accumulated despite timing_statistics=no (#190)"
+        )
 
 
 def test_minimize_eq_constraint():


### PR DESCRIPTION
Fixes #190.

## Problem

`TimedTask::start`/`end` each call `cpu_time()` → `getrusage(RUSAGE_SELF)`, and the per-subsystem / per-callback timers in `TimingStatistics` wrap hot paths: every objective, gradient, constraint, Jacobian, and Hessian evaluation (`orig_ipopt_nlp.rs` `timed_eval`, two timers per call = 4 syscalls), plus every solve phase. Upstream Ipopt gates these detailed timers on the `timing_statistics` option (default `no`), but pounce mirrored the timers **without** the gating — only the end-of-solve *printing* was gated (`print_timing_statistics`). So the syscalls were paid unconditionally, even in the default configuration.

The reporter measured `getrusage` at **16–20% of busy CPU** on fast-objective, high-iteration NLPs (a quantum-chemistry solver, objectives ~100 µs–1 ms, hundreds of macro iterations), and it sits in the serial fraction of an Amdahl fit, so it also caps parallel scaling of the caller.

## Fix

- `TimingStatistics::set_detailed_enabled(bool)` (`pounce-common`) enables/disables every timer **except** `overall_alg`.
- `IpoptApplication` calls it at solve setup, gated on `timing_statistics` (with `print_timing_statistics` implying it, per its option help). Detailed timers are off by default; a solve stops paying the syscalls unless the user opts in.
- `overall_alg` stays live regardless: its `live_cpu_time()` feeds the `max_cpu_time` convergence check and its total is always reported.

## Behavior change (documented)

The detailed per-solve breakdown — Python `res.info["timing"]` / `res.timing` (#180) and the CLI diagnostics `timing.json` linear-algebra split — is now **opt-in** via `timing_statistics=yes`. `overall_alg` / `wall_time` remain populated unconditionally; the detailed keys read `0.0` when the option is off. This matches upstream Ipopt, and crucially gives the default (fast) path to users who don't need the breakdown. Documented at both consumer sites and in the CHANGELOG (#190 Fixed + the #180 Added entry).

## Tests

- `set_detailed_enabled_gates_all_but_overall_alg` — unit test on the gating.
- `hs071_timing_statistics_gates_detailed_timers` — end-to-end: solves HS071 with the option off (asserts detailed timers disabled and zero, `overall_alg` live) and on (asserts detailed timers enabled).
- Python: `test_minimize_timing_breakdown_gated_by_default` (new) plus the existing breakdown test updated to opt in.
- Full `pounce-common` and `pounce-algorithm` suites pass; clippy clean on changed lines.

## Notes

The audit that motivated the fix also surfaced a broader, milder instance of the same root cause (~90 registered algorithmic constants that are implemented but never read, so user overrides are silently dropped). That is tracked separately in #191 and intentionally **not** part of this PR, which stays scoped to the #190 performance bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfJG4XRe4JKKQdqEc1kbxP)_