### PR TITLE
Wire registered-but-unread algorithmic options (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,18 +55,24 @@ changes.
 
 ### Fixed
 
-- **`kappa_sigma` and `kappa_d` overrides are now honored (#191).** Both options
-  were registered but never read, so the solver always ran with the hard-coded
-  defaults and a user-set value was silently dropped. `kappa_sigma` (default
-  `1e10`) bounds how far the bound multipliers may deviate from their primal
-  estimates via a clamp applied after every accepted step — including the
-  documented `< 1` value that disables the correction; `kappa_d` (default
-  `1e-5`) weights the linear damping term for one-sided bounds in the barrier
-  objective/gradient. Both are now read into `AlgorithmBuilder` and baked onto
-  the algorithm / calculated-quantities at solve setup. Defaults are unchanged,
-  so only runs that explicitly set these options are affected. First tranche of
-  the broader "registered but unread algorithmic constants" audit tracked in
-  #191.
+- **Registered-but-unread algorithmic tuning options are now honored (#191).**
+  A range of options were registered but never read, so the solver always ran
+  with the hard-coded defaults and any user-set value was silently dropped.
+  Now wired through `AlgorithmBuilder`:
+  - `kappa_sigma` (default `1e10`) — bounds how far the bound multipliers may
+    deviate from their primal estimates via a clamp applied after every
+    accepted step, including the documented `< 1` value that disables the
+    correction.
+  - `kappa_d` (default `1e-5`) — weight of the linear damping term for
+    one-sided bounds in the barrier objective/gradient.
+  - Filter switching / Armijo / margin constants for the filter line search:
+    `eta_phi`, `theta_min_fact`, `theta_max_fact`, `gamma_phi`, `gamma_theta`,
+    `s_phi`, `s_theta`, `alpha_min_frac`, `obj_max_inc`.
+  - Second-order-correction constants: `max_soc` (incl. `0` to disable SOC),
+    `kappa_soc`, `soc_method`.
+
+  Every default equals the previously-hard-coded value, so runs that don't set
+  these options are unchanged. Remaining unread constants stay tracked in #191.
 - **`timing_statistics=no` no longer runs the detailed timers every iteration
   (#190).** Every `TimedTask::start`/`end` pair calls `getrusage(RUSAGE_SELF)`
   (twice — once each), and the per-subsystem / per-callback timers wrap hot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ changes.
 
 ### Fixed
 
+- **`kappa_sigma` and `kappa_d` overrides are now honored (#191).** Both options
+  were registered but never read, so the solver always ran with the hard-coded
+  defaults and a user-set value was silently dropped. `kappa_sigma` (default
+  `1e10`) bounds how far the bound multipliers may deviate from their primal
+  estimates via a clamp applied after every accepted step — including the
+  documented `< 1` value that disables the correction; `kappa_d` (default
+  `1e-5`) weights the linear damping term for one-sided bounds in the barrier
+  objective/gradient. Both are now read into `AlgorithmBuilder` and baked onto
+  the algorithm / calculated-quantities at solve setup. Defaults are unchanged,
+  so only runs that explicitly set these options are affected. First tranche of
+  the broader "registered but unread algorithmic constants" audit tracked in
+  #191.
 - **`timing_statistics=no` no longer runs the detailed timers every iteration
   (#190).** Every `TimedTask::start`/`end` pair calls `getrusage(RUSAGE_SELF)`
   (twice — once each), and the per-subsystem / per-callback timers wrap hot

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -213,6 +213,19 @@ pub struct AlgorithmBuilder {
     /// option-parser in `application.rs` is responsible for the
     /// cascading defaults (`mu_oracle = probing` etc.).
     pub mehrotra_algorithm: bool,
+    /// `kappa_sigma` — factor bounding how far the bound multipliers may
+    /// deviate from their primal estimates. The clamp
+    /// (`kappa_sigma_clamp`) runs after every accepted step; `< 1`
+    /// disables the correction. Mirrors `IpIpoptAlg.cpp` (Eqn. (16)),
+    /// default `1e10`. Baked onto [`crate::ipopt_alg::IpoptAlgorithm`] by
+    /// the solve path.
+    pub kappa_sigma: Number,
+    /// `kappa_d` — weight of the linear damping term added to the barrier
+    /// objective/gradient (and dual-infeasibility) to handle one-sided
+    /// bounds. Mirrors `IpIpoptCalculatedQuantities.cpp`, default `1e-5`.
+    /// Baked onto [`crate::ipopt_cq::IpoptCalculatedQuantities`] by the
+    /// solve path.
+    pub kappa_d: Number,
     pub conv_check: ConvCheckOptions,
     pub mu: MuOptions,
     pub line_search: LineSearchOptions,
@@ -520,6 +533,8 @@ impl Default for AlgorithmBuilder {
             line_search_method: LineSearchChoice::Filter,
             warm_start_init_point: false,
             mehrotra_algorithm: false,
+            kappa_sigma: 1e10,
+            kappa_d: 1e-5,
             conv_check: ConvCheckOptions::default(),
             mu: MuOptions::default(),
             line_search: LineSearchOptions::default(),
@@ -854,6 +869,8 @@ mod tests {
                             line_search_method,
                             warm_start_init_point: false,
                             mehrotra_algorithm: false,
+                            kappa_sigma: 1e10,
+                            kappa_d: 1e-5,
                             conv_check: ConvCheckOptions::default(),
                             mu: MuOptions::default(),
                             line_search: LineSearchOptions::default(),

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -474,6 +474,49 @@ pub struct LineSearchOptions {
     /// step length. Upstream default is `Primal`; the Mehrotra cascade
     /// switches to `BoundMult`.
     pub alpha_for_y: crate::line_search::backtracking::AlphaForY,
+
+    // Filter switching / Armijo / margin constants baked onto the
+    // assembled [`crate::line_search::filter_acceptor::FilterLsAcceptor`]
+    // (only when `line_search_method = Filter`). All were registered but
+    // never read (#191); defaults mirror `IpFilterLSAcceptor.cpp`.
+    /// `eta_phi` — relaxation factor in the Armijo condition (Eqn. (20)).
+    pub eta_phi: Number,
+    /// `theta_min_fact` — constraint-violation threshold factor in the
+    /// switching rule.
+    pub theta_min_fact: Number,
+    /// `theta_max_fact` — upper-bound factor for constraint violation in
+    /// the filter (Eqn. (21)).
+    pub theta_max_fact: Number,
+    /// `gamma_phi` — filter margin factor for the barrier function
+    /// (Eqn. (18a)).
+    pub gamma_phi: Number,
+    /// `gamma_theta` — filter margin factor for the constraint violation
+    /// (Eqn. (18b)).
+    pub gamma_theta: Number,
+    /// `s_phi` — exponent for the linear barrier model in the switching
+    /// rule (Eqn. (19)).
+    pub s_phi: Number,
+    /// `s_theta` — exponent for the current constraint violation in the
+    /// switching rule (Eqn. (19)).
+    pub s_theta: Number,
+    /// `alpha_min_frac` — safety factor for the minimal step size before
+    /// switching to restoration (gamma_alpha, Eqn. (23)).
+    pub alpha_min_frac: Number,
+    /// `obj_max_inc` — max acceptable increase (orders of magnitude) of
+    /// the barrier objective for a trial point.
+    pub obj_max_inc: Number,
+
+    // Second-order-correction constants baked onto the assembled
+    // [`BacktrackingLineSearch`]. Registered but never read (#191);
+    // defaults mirror `IpBacktrackingLineSearch.cpp`.
+    /// `max_soc` — max second-order-correction trial steps per iteration;
+    /// `0` disables SOC.
+    pub max_soc: Index,
+    /// `kappa_soc` — sufficient-reduction factor for a SOC step to be
+    /// continued.
+    pub kappa_soc: Number,
+    /// `soc_method` — `0` (paper method) or `1` (alpha-on-rhs variant).
+    pub soc_method: Index,
 }
 
 impl Default for LineSearchOptions {
@@ -485,6 +528,18 @@ impl Default for LineSearchOptions {
             max_soft_resto_iters: 10,
             accept_every_trial_step: false,
             alpha_for_y: crate::line_search::backtracking::AlphaForY::Primal,
+            eta_phi: 1e-8,
+            theta_min_fact: 1e-4,
+            theta_max_fact: 1e4,
+            gamma_phi: 1e-8,
+            gamma_theta: 1e-5,
+            s_phi: 2.3,
+            s_theta: 1.1,
+            alpha_min_frac: 0.05,
+            obj_max_inc: 5.0,
+            max_soc: 4,
+            kappa_soc: 0.99,
+            soc_method: 0,
         }
     }
 }
@@ -703,7 +758,24 @@ impl AlgorithmBuilder {
         };
 
         let acceptor: Box<dyn BacktrackingLsAcceptor> = match self.line_search_method {
-            LineSearchChoice::Filter => Box::new(FilterLsAcceptor::default()),
+            LineSearchChoice::Filter => {
+                // Filter switching / Armijo / margin constants (#191):
+                // registered but previously never read. Set them on the
+                // concrete acceptor before boxing; defaults equal the
+                // registered defaults, so a run that doesn't set them is
+                // unchanged.
+                let mut f = FilterLsAcceptor::default();
+                f.eta_phi = self.line_search.eta_phi;
+                f.theta_min_fact = self.line_search.theta_min_fact;
+                f.theta_max_fact = self.line_search.theta_max_fact;
+                f.gamma_phi = self.line_search.gamma_phi;
+                f.gamma_theta = self.line_search.gamma_theta;
+                f.s_phi = self.line_search.s_phi;
+                f.s_theta = self.line_search.s_theta;
+                f.alpha_min_frac = self.line_search.alpha_min_frac;
+                f.obj_max_inc = self.line_search.obj_max_inc;
+                Box::new(f)
+            }
             LineSearchChoice::Penalty => Box::new(PenaltyLsAcceptor::default()),
             // CG-penalty acceptor lands with the rest of the
             // CG-penalty path; fall back to the penalty acceptor's
@@ -719,6 +791,12 @@ impl AlgorithmBuilder {
         line_search.max_soft_resto_iters = self.line_search.max_soft_resto_iters;
         line_search.accept_every_trial_step = self.line_search.accept_every_trial_step;
         line_search.alpha_for_y = self.line_search.alpha_for_y;
+        // Second-order-correction constants (#191): registered but
+        // previously never read. Same direct-field pattern as the
+        // watchdog knobs above.
+        line_search.max_soc = self.line_search.max_soc;
+        line_search.kappa_soc = self.line_search.kappa_soc;
+        line_search.soc_method = self.line_search.soc_method;
 
         let conv_check: Box<dyn crate::conv_check::r#trait::ConvCheck> =
             Box::new(OptErrorConvCheck {

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1457,6 +1457,14 @@ impl IpoptApplication {
         if let Ok((v, true)) = self.options.get_numeric_value("slack_move", "") {
             cq.borrow_mut().slack_move = v;
         }
+        // `kappa_d` — weight of the linear damping term added to the
+        // barrier objective/gradient to handle one-sided bounds
+        // (`IpIpoptCalculatedQuantities.cpp`). Registered (default 1e-5)
+        // but previously never read, so a user override was silently
+        // ignored (#191). Routed through the builder for parity with the
+        // other numeric knobs; the default matches the registered
+        // default, so only explicit overrides change behavior.
+        cq.borrow_mut().kappa_d = builder.kappa_d;
 
         // Seed `data.curr` with a zero-valued iterate of the correct
         // dimensions. The `IterateInitializer` consumes these as its
@@ -1551,6 +1559,15 @@ impl IpoptApplication {
             alg = alg.with_debug_hook(hook);
         }
         alg.max_iter = max_iter;
+        // `kappa_sigma` — factor bounding how far the bound multipliers
+        // may deviate from their primal estimates; the clamp runs after
+        // every accepted step (`IpIpoptAlg.cpp`, Eqn. (16)). Registered
+        // (default 1e10) but previously never read, so a user override —
+        // including the documented `< 1` "disable the correction" — was
+        // silently ignored (#191). Routed through the builder; the struct
+        // default matches the registered default, so default runs are
+        // unchanged.
+        alg.kappa_sigma = builder.kappa_sigma;
         // Honor `print_level == 0`: suppress the per-iteration table
         // that the algorithm writes straight to stdout. (The Phase-7
         // journalist surface respects `print_level` already; this is
@@ -1989,6 +2006,18 @@ impl IpoptApplication {
         }
         if let Some(v) = read_int("infeas_max_streak") {
             builder.conv_check.infeas_max_streak = v;
+        }
+
+        // Bound-multiplier / barrier damping constants (#191). Both were
+        // registered but never read, so user overrides were silently
+        // dropped; the algorithm ran with the hard-coded struct defaults.
+        // Defaults equal the registered defaults, so this changes nothing
+        // for a run that doesn't set them.
+        if let Some(v) = read_num("kappa_sigma") {
+            builder.kappa_sigma = v;
+        }
+        if let Some(v) = read_num("kappa_d") {
+            builder.kappa_d = v;
         }
 
         // Barrier-parameter (μ) options — consumers in

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2183,6 +2183,49 @@ impl IpoptApplication {
             builder.line_search.max_soft_resto_iters = v;
         }
 
+        // Filter switching / Armijo / margin constants (#191). Consumed
+        // by `FilterLsAcceptor` (only on the `Filter` line-search path);
+        // registered but never read, so overrides were silently dropped.
+        // Defaults equal the registered defaults.
+        if let Some(v) = read_num("eta_phi") {
+            builder.line_search.eta_phi = v;
+        }
+        if let Some(v) = read_num("theta_min_fact") {
+            builder.line_search.theta_min_fact = v;
+        }
+        if let Some(v) = read_num("theta_max_fact") {
+            builder.line_search.theta_max_fact = v;
+        }
+        if let Some(v) = read_num("gamma_phi") {
+            builder.line_search.gamma_phi = v;
+        }
+        if let Some(v) = read_num("gamma_theta") {
+            builder.line_search.gamma_theta = v;
+        }
+        if let Some(v) = read_num("s_phi") {
+            builder.line_search.s_phi = v;
+        }
+        if let Some(v) = read_num("s_theta") {
+            builder.line_search.s_theta = v;
+        }
+        if let Some(v) = read_num("alpha_min_frac") {
+            builder.line_search.alpha_min_frac = v;
+        }
+        if let Some(v) = read_num("obj_max_inc") {
+            builder.line_search.obj_max_inc = v;
+        }
+        // Second-order-correction constants (#191), consumed by
+        // `BacktrackingLineSearch`. `max_soc = 0` disables SOC.
+        if let Some(v) = read_int("max_soc") {
+            builder.line_search.max_soc = v;
+        }
+        if let Some(v) = read_num("kappa_soc") {
+            builder.line_search.kappa_soc = v;
+        }
+        if let Some(v) = read_int("soc_method") {
+            builder.line_search.soc_method = v;
+        }
+
         // Iteration-output options — consumed by `OrigIterationOutput`.
         if let Some(v) = read_int("print_frequency_iter") {
             builder.output.print_frequency_iter = v;

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -1,0 +1,52 @@
+//! Wiring tests for algorithmic tuning constants that were registered
+//! but never read (#191), so a user override was silently dropped and the
+//! solver ran with the hard-coded struct default.
+//!
+//! Like `mu_options_wiring.rs`, these are pure wiring tests: they assert a
+//! `OptionsList` set turns into the corresponding field on
+//! `AlgorithmBuilder`. The numerics themselves are exercised by the
+//! upstream-mirroring unit tests in `crate::ipopt_alg` /
+//! `crate::ipopt_cq`.
+
+use pounce_algorithm::alg_builder::AlgorithmBuilder;
+use pounce_algorithm::application::IpoptApplication;
+
+fn builder_from(setup: impl FnOnce(&mut IpoptApplication)) -> AlgorithmBuilder {
+    let mut app = IpoptApplication::new();
+    setup(&mut app);
+    app.algorithm_builder_from_options()
+}
+
+#[test]
+fn kappa_sigma_default_matches_registered() {
+    // Untouched option ⇒ builder carries the upstream default 1e10.
+    let b = builder_from(|_| {});
+    assert!((b.kappa_sigma - 1e10).abs() <= 1e10 * 1e-12);
+}
+
+#[test]
+fn kappa_sigma_override_flows_through() {
+    let b = builder_from(|app| {
+        app.options_mut()
+            .set_numeric_value("kappa_sigma", 0.5, true, false)
+            .unwrap();
+    });
+    // The documented `< 1` "disable the correction" value must survive.
+    assert!((b.kappa_sigma - 0.5).abs() < 1e-12);
+}
+
+#[test]
+fn kappa_d_default_matches_registered() {
+    let b = builder_from(|_| {});
+    assert!((b.kappa_d - 1e-5).abs() < 1e-17);
+}
+
+#[test]
+fn kappa_d_override_flows_through() {
+    let b = builder_from(|app| {
+        app.options_mut()
+            .set_numeric_value("kappa_d", 0.0, true, false)
+            .unwrap();
+    });
+    assert_eq!(b.kappa_d, 0.0);
+}

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -50,3 +50,90 @@ fn kappa_d_override_flows_through() {
     });
     assert_eq!(b.kappa_d, 0.0);
 }
+
+#[test]
+fn filter_constants_default_match_registered() {
+    let b = builder_from(|_| {}).line_search;
+    assert_eq!(b.eta_phi, 1e-8);
+    assert_eq!(b.theta_min_fact, 1e-4);
+    assert_eq!(b.theta_max_fact, 1e4);
+    assert_eq!(b.gamma_phi, 1e-8);
+    assert_eq!(b.gamma_theta, 1e-5);
+    assert_eq!(b.s_phi, 2.3);
+    assert_eq!(b.s_theta, 1.1);
+    assert_eq!(b.alpha_min_frac, 0.05);
+    assert_eq!(b.obj_max_inc, 5.0);
+}
+
+#[test]
+fn filter_constants_override_flows_through() {
+    let b = builder_from(|app| {
+        let o = app.options_mut();
+        for (k, v) in [
+            ("eta_phi", 2e-8),
+            ("theta_min_fact", 2e-4),
+            ("theta_max_fact", 2e4),
+            ("gamma_phi", 2e-8),
+            ("gamma_theta", 2e-5),
+            ("s_phi", 2.5),
+            ("s_theta", 1.2),
+            ("alpha_min_frac", 0.1),
+            ("obj_max_inc", 6.0),
+        ] {
+            o.set_numeric_value(k, v, true, false).unwrap();
+        }
+    })
+    .line_search;
+    assert_eq!(b.eta_phi, 2e-8);
+    assert_eq!(b.theta_min_fact, 2e-4);
+    assert_eq!(b.theta_max_fact, 2e4);
+    assert_eq!(b.gamma_phi, 2e-8);
+    assert_eq!(b.gamma_theta, 2e-5);
+    assert_eq!(b.s_phi, 2.5);
+    assert_eq!(b.s_theta, 1.2);
+    assert_eq!(b.alpha_min_frac, 0.1);
+    assert_eq!(b.obj_max_inc, 6.0);
+}
+
+#[test]
+fn soc_constants_default_match_registered() {
+    let b = builder_from(|_| {}).line_search;
+    assert_eq!(b.max_soc, 4);
+    assert_eq!(b.kappa_soc, 0.99);
+    assert_eq!(b.soc_method, 0);
+}
+
+#[test]
+fn soc_constants_override_flows_through() {
+    let b = builder_from(|app| {
+        app.options_mut()
+            .set_integer_value("max_soc", 0, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("kappa_soc", 0.5, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_integer_value("soc_method", 1, true, false)
+            .unwrap();
+    })
+    .line_search;
+    assert_eq!(b.max_soc, 0);
+    assert_eq!(b.kappa_soc, 0.5);
+    assert_eq!(b.soc_method, 1);
+}
+
+/// The SOC constants must survive `build()` onto the concrete
+/// `BacktrackingLineSearch` in the assembled bundle — this covers the
+/// builder → line-search assignment (`build_inner`), not just the
+/// option → builder step above.
+#[test]
+fn soc_constants_reach_assembled_line_search() {
+    let mut builder = AlgorithmBuilder::new();
+    builder.line_search.max_soc = 0;
+    builder.line_search.kappa_soc = 0.5;
+    builder.line_search.soc_method = 1;
+    let bundle = builder.build();
+    assert_eq!(bundle.line_search.max_soc, 0);
+    assert_eq!(bundle.line_search.kappa_soc, 0.5);
+    assert_eq!(bundle.line_search.soc_method, 1);
+}

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -971,3 +971,92 @@ fn warm_start_options_flow_through_builder() {
         assert!(found, "{key} did not parse through the registry");
     }
 }
+
+/// #191: `kappa_sigma` (bound-multiplier deviation clamp) was registered
+/// but never read, so a user override was silently ignored. Honoring it
+/// must change the multiplier trajectory. `kappa_sigma = 1.0` tightens
+/// the clamp band to a point every accepted step, reshaping the solve
+/// while still converging to the same optimum; the default (1e10) leaves
+/// the clamp effectively slack.
+#[test]
+fn hs071_honors_user_kappa_sigma() {
+    let solve = |kappa_sigma: Option<Number>| {
+        let mut app = IpoptApplication::new();
+        if let Some(k) = kappa_sigma {
+            app.options_mut()
+                .set_numeric_value("kappa_sigma", k, true, false)
+                .unwrap();
+        }
+        app.initialize().unwrap();
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071::default()));
+        let status = app.optimize_tnlp(tnlp);
+        (
+            status,
+            app.statistics().iteration_count,
+            app.statistics().final_objective,
+        )
+    };
+
+    let (st_default, iters_default, obj_default) = solve(None);
+    let (st_tight, iters_tight, obj_tight) = solve(Some(1.0));
+
+    eprintln!(
+        "HS71 kappa_sigma: default(iters={iters_default}, {st_default:?}) \
+         vs 1.0(iters={iters_tight}, {st_tight:?})",
+    );
+
+    // Both still reach the true optimum...
+    assert!((obj_default - 17.014017).abs() < 1e-4);
+    assert!((obj_tight - 17.014017).abs() < 1e-4);
+    assert!(matches!(
+        st_default,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    ));
+    // ...but the tightened clamp reshapes the trajectory. Before the fix
+    // the option was ignored and both runs took the same iteration count.
+    assert_ne!(
+        iters_default, iters_tight,
+        "kappa_sigma was ignored: both runs took {iters_default} iters",
+    );
+}
+
+/// #191: `kappa_d` (linear damping weight for one-sided bounds) was
+/// registered but never read. A large weight measurably perturbs the
+/// barrier problem on a bounded NLP, so honoring the option changes the
+/// solve path (the true optimum is unchanged since the damping term
+/// vanishes as mu -> 0).
+#[test]
+fn hs071_honors_user_kappa_d() {
+    let solve = |kappa_d: Option<Number>| {
+        let mut app = IpoptApplication::new();
+        if let Some(k) = kappa_d {
+            app.options_mut()
+                .set_numeric_value("kappa_d", k, true, false)
+                .unwrap();
+        }
+        app.initialize().unwrap();
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071::default()));
+        let status = app.optimize_tnlp(tnlp);
+        (
+            status,
+            app.statistics().iteration_count,
+            app.statistics().final_objective,
+        )
+    };
+
+    let (_, iters_default, obj_default) = solve(None);
+    let (_, iters_damped, obj_damped) = solve(Some(100.0));
+
+    eprintln!("HS71 kappa_d: default(iters={iters_default}) vs 100(iters={iters_damped})");
+
+    // The damping term vanishes at the solution, so the objective is the
+    // same either way...
+    assert!((obj_default - 17.014017).abs() < 1e-4);
+    assert!((obj_damped - 17.014017).abs() < 1e-4);
+    // ...but a large weight reshapes the path. Before the fix the option
+    // was ignored and both runs were identical.
+    assert_ne!(
+        iters_default, iters_damped,
+        "kappa_d was ignored: both runs took {iters_default} iters",
+    );
+}


### PR DESCRIPTION
Addresses #191.

## Problem

The audit that motivated #190 surfaced a broader instance of the same root cause: registered algorithmic options that are implemented and run every iteration/evaluation, but are **never read**, so a user's explicit override is silently discarded and the solver runs with the hard-coded struct default. (Because each struct default currently equals its registered default, *default* runs are correct — only overrides were dropped.)

This PR wires up the highest-impact findings. The remaining long-tail constants stay itemized in #191 and can follow the same pattern.

## Included in this PR

**Bound-multiplier / barrier damping** (baked onto the algorithm / calculated-quantities at solve setup):
- **`kappa_sigma`** (default `1e10`) — bounds how far the bound multipliers may deviate from their primal estimates; the clamp runs after every accepted step, and the documented `< 1` value disables the correction. Consumed in `ipopt_alg.rs`.
- **`kappa_d`** (default `1e-5`) — weight of the linear damping term for one-sided bounds, added to the barrier objective/gradient on every evaluation. Consumed in `ipopt_cq.rs`.

**Filter switching / Armijo / margin constants** (baked onto `FilterLsAcceptor`, Filter line-search path):
- `eta_phi`, `theta_min_fact`, `theta_max_fact`, `gamma_phi`, `gamma_theta`, `s_phi`, `s_theta`, `alpha_min_frac`, `obj_max_inc`.

**Second-order-correction constants** (baked onto `BacktrackingLineSearch`):
- `max_soc` (incl. `0` to disable SOC), `kappa_soc`, `soc_method`.

All are read in `algorithm_builder_from_options` into `AlgorithmBuilder`, matching the existing numeric-knob convention, and applied in the shared `build_inner` path. Every default equals the registered default, so a run that doesn't set these options is byte-for-byte unchanged. (The dead `FilterLsAcceptor.max_soc` field — 0 uses; the live one is on `BacktrackingLineSearch` — is left alone.)

## Tests

- **Pure wiring tests** (`tests/algorithm_options_wiring.rs`) — assert `option → AlgorithmBuilder` field for every constant, mirroring `mu_options_wiring.rs` (no solve).
- **Build-assembly test** — the SOC constants survive `build()` onto the concrete `BacktrackingLineSearch` in the assembled bundle (covers the builder → component step in `build_inner`).
- **End-to-end behavior** (`tests/optimize_hs71.rs`) — a non-default value reshapes the actual solve while still reaching the true optimum: `kappa_sigma = 1.0` moves HS071 from 8 to 25 iterations, `kappa_d = 100` from 8 to 39; both still converge to `17.014017`. Same "was ignored, now honored" assertion style as the existing `hs071_probing_oracle_honors_user_sigma_max`.
- Full `pounce-algorithm` suite passes; workspace builds; `cargo fmt` clean; CI's clippy gate (`-D clippy::correctness -D clippy::suspicious`) passes.

## Scope note

This does **not** close #191 — it covers the highest-value tranches (kappa constants, filter switching, SOC). The remaining long-tail constants stay tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)