### PR TITLE
Wire remaining registered-but-unread options: perturbation, refinement, tiny-step, filter-resets (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,9 +70,26 @@ changes.
     `s_phi`, `s_theta`, `alpha_min_frac`, `obj_max_inc`.
   - Second-order-correction constants: `max_soc` (incl. `0` to disable SOC),
     `kappa_soc`, `soc_method`.
+  - Filter-reset heuristic: `max_filter_resets` (incl. `0` to disable),
+    `filter_reset_trigger`.
+  - Tiny-step and divergence guards on the algorithm: `tiny_step_tol`,
+    `tiny_step_y_tol`, `diverging_iterates_tol`.
+  - Inertia-correction / Jacobian-regularization constants on the
+    perturbation handler: `max_hessian_perturbation`,
+    `min_hessian_perturbation`, `first_hessian_perturbation`,
+    `perturb_inc_fact_first`, `perturb_inc_fact`, `perturb_dec_fact`,
+    `jacobian_regularization_value`, `jacobian_regularization_exponent`,
+    `perturb_always_cd`.
+  - Iterative-refinement constants on the KKT full-space solver:
+    `min_refinement_steps`, `max_refinement_steps`, `residual_ratio_max`,
+    `residual_ratio_singular`, `residual_improvement_factor`.
 
   Every default equals the previously-hard-coded value, so runs that don't set
-  these options are unchanged. Remaining unread constants stay tracked in #191.
+  these options are unchanged. The remaining unread constants — restoration
+  reset/penalty thresholds (`bound_mult_reset_threshold`,
+  `constr_mult_reset_threshold`, `resto_penalty_parameter`,
+  `resto_proximity_weight`), which need per-frontend restoration-builder
+  plumbing — stay tracked in #191.
 - **`timing_statistics=no` no longer runs the detailed timers every iteration
   (#190).** Every `TimedTask::start`/`end` pair calls `getrusage(RUSAGE_SELF)`
   (twice — once each), and the per-subsystem / per-callback timers wrap hot

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -242,6 +242,8 @@ pub struct AlgorithmBuilder {
     pub conv_check: ConvCheckOptions,
     pub mu: MuOptions,
     pub line_search: LineSearchOptions,
+    pub refinement: RefinementOptions,
+    pub perturbation: PerturbationOptions,
     pub output: OutputOptions,
     pub warm: WarmStartOptions,
     /// SQP-specific options (consulted only when
@@ -518,6 +520,12 @@ pub struct LineSearchOptions {
     /// `obj_max_inc` — max acceptable increase (orders of magnitude) of
     /// the barrier objective for a trial point.
     pub obj_max_inc: Number,
+    /// `max_filter_resets` — maximum number of filter resets allowed
+    /// (`0` disables the reset heuristic).
+    pub max_filter_resets: Index,
+    /// `filter_reset_trigger` — successive filter-rejected iterations that
+    /// trigger a filter reset.
+    pub filter_reset_trigger: Index,
 
     // Second-order-correction constants baked onto the assembled
     // [`BacktrackingLineSearch`]. Registered but never read (#191);
@@ -550,9 +558,89 @@ impl Default for LineSearchOptions {
             s_theta: 1.1,
             alpha_min_frac: 0.05,
             obj_max_inc: 5.0,
+            max_filter_resets: 5,
+            filter_reset_trigger: 5,
             max_soc: 4,
             kappa_soc: 0.99,
             soc_method: 0,
+        }
+    }
+}
+
+/// Inertia-correction / regularization knobs baked onto the assembled
+/// [`crate::kkt::perturbation_handler::PdPerturbationHandler`]. Field
+/// names use the option names; they map to the handler's `delta_xs_*` /
+/// `delta_cd_*` fields. Defaults mirror
+/// `IpPDPerturbationHandler.cpp:RegisterOptions`. All were registered but
+/// never read (#191).
+#[derive(Debug, Clone)]
+pub struct PerturbationOptions {
+    /// `max_hessian_perturbation` → `delta_xs_max`.
+    pub max_hessian_perturbation: Number,
+    /// `min_hessian_perturbation` → `delta_xs_min`.
+    pub min_hessian_perturbation: Number,
+    /// `perturb_inc_fact_first` → `delta_xs_first_inc_fact`.
+    pub perturb_inc_fact_first: Number,
+    /// `perturb_inc_fact` → `delta_xs_inc_fact`.
+    pub perturb_inc_fact: Number,
+    /// `perturb_dec_fact` → `delta_xs_dec_fact`.
+    pub perturb_dec_fact: Number,
+    /// `first_hessian_perturbation` → `delta_xs_init`.
+    pub first_hessian_perturbation: Number,
+    /// `jacobian_regularization_value` → `delta_cd_val`.
+    pub jacobian_regularization_value: Number,
+    /// `jacobian_regularization_exponent` → `delta_cd_exp`.
+    pub jacobian_regularization_exponent: Number,
+    /// `perturb_always_cd` — always regularize the c/d (Jacobian) block.
+    pub perturb_always_cd: bool,
+}
+
+impl Default for PerturbationOptions {
+    fn default() -> Self {
+        Self {
+            max_hessian_perturbation: 1e20,
+            min_hessian_perturbation: 1e-20,
+            perturb_inc_fact_first: 100.0,
+            perturb_inc_fact: 8.0,
+            perturb_dec_fact: 1.0 / 3.0,
+            first_hessian_perturbation: 1e-4,
+            jacobian_regularization_value: 1e-8,
+            jacobian_regularization_exponent: 0.25,
+            perturb_always_cd: false,
+        }
+    }
+}
+
+/// Iterative-refinement knobs baked onto the assembled
+/// [`crate::kkt::pd_full_space_solver::PdFullSpaceSolver`]. Defaults
+/// mirror `IpPDFullSpaceSolver.cpp:RegisterOptions`. All were registered
+/// but never read (#191).
+#[derive(Debug, Clone)]
+pub struct RefinementOptions {
+    /// `min_refinement_steps` — minimum iterative-refinement steps per
+    /// linear solve.
+    pub min_refinement_steps: Index,
+    /// `max_refinement_steps` — maximum iterative-refinement steps.
+    pub max_refinement_steps: Index,
+    /// `residual_ratio_max` — refine until the residual test ratio drops
+    /// below this (or `max_refinement_steps` is reached).
+    pub residual_ratio_max: Number,
+    /// `residual_ratio_singular` — above this ratio after failed
+    /// refinement, the system is declared singular.
+    pub residual_ratio_singular: Number,
+    /// `residual_improvement_factor` — minimum per-step reduction of the
+    /// residual test ratio before refinement is aborted.
+    pub residual_improvement_factor: Number,
+}
+
+impl Default for RefinementOptions {
+    fn default() -> Self {
+        Self {
+            min_refinement_steps: 1,
+            max_refinement_steps: 10,
+            residual_ratio_max: 1e-10,
+            residual_ratio_singular: 1e-5,
+            residual_improvement_factor: 0.999_999_999,
         }
     }
 }
@@ -609,6 +697,8 @@ impl Default for AlgorithmBuilder {
             conv_check: ConvCheckOptions::default(),
             mu: MuOptions::default(),
             line_search: LineSearchOptions::default(),
+            refinement: RefinementOptions::default(),
+            perturbation: PerturbationOptions::default(),
             output: OutputOptions::default(),
             warm: WarmStartOptions::default(),
             sqp: crate::sqp::SqpOptions::default(),
@@ -689,8 +779,30 @@ impl AlgorithmBuilder {
         } else {
             Box::new(inner_aug)
         };
-        let perturb = Rc::new(RefCell::new(PdPerturbationHandler::new()));
-        let pd_solver = PdFullSpaceSolver::new(aug_solver, perturb);
+        // Inertia-correction / Jacobian-regularization constants (#191):
+        // registered but previously never read. Defaults equal the
+        // registered defaults. `perturb_always_cd` goes through the setter
+        // because it also rebuilds the initial jac-degeneracy state.
+        let mut ph = PdPerturbationHandler::new();
+        ph.delta_xs_max = self.perturbation.max_hessian_perturbation;
+        ph.delta_xs_min = self.perturbation.min_hessian_perturbation;
+        ph.delta_xs_first_inc_fact = self.perturbation.perturb_inc_fact_first;
+        ph.delta_xs_inc_fact = self.perturbation.perturb_inc_fact;
+        ph.delta_xs_dec_fact = self.perturbation.perturb_dec_fact;
+        ph.delta_xs_init = self.perturbation.first_hessian_perturbation;
+        ph.delta_cd_val = self.perturbation.jacobian_regularization_value;
+        ph.delta_cd_exp = self.perturbation.jacobian_regularization_exponent;
+        ph.set_perturb_always_cd(self.perturbation.perturb_always_cd);
+        let perturb = Rc::new(RefCell::new(ph));
+        let mut pd_solver = PdFullSpaceSolver::new(aug_solver, perturb);
+        // Iterative-refinement constants (#191): registered but previously
+        // never read, so overrides were silently dropped. Defaults equal
+        // the registered defaults.
+        pd_solver.min_refinement_steps = self.refinement.min_refinement_steps;
+        pd_solver.max_refinement_steps = self.refinement.max_refinement_steps;
+        pd_solver.residual_ratio_max = self.refinement.residual_ratio_max;
+        pd_solver.residual_ratio_singular = self.refinement.residual_ratio_singular;
+        pd_solver.residual_improvement_factor = self.refinement.residual_improvement_factor;
         let mut search_dir = PdSearchDirCalc::new(pd_solver);
         search_dir.mehrotra_algorithm = self.mehrotra_algorithm;
         self.build_inner(Some(search_dir))
@@ -790,6 +902,8 @@ impl AlgorithmBuilder {
                 f.s_theta = self.line_search.s_theta;
                 f.alpha_min_frac = self.line_search.alpha_min_frac;
                 f.obj_max_inc = self.line_search.obj_max_inc;
+                f.max_filter_resets = self.line_search.max_filter_resets;
+                f.filter_reset_trigger = self.line_search.filter_reset_trigger;
                 Box::new(f)
             }
             LineSearchChoice::Penalty => Box::new(PenaltyLsAcceptor::default()),
@@ -971,6 +1085,8 @@ mod tests {
                             conv_check: ConvCheckOptions::default(),
                             mu: MuOptions::default(),
                             line_search: LineSearchOptions::default(),
+                            refinement: RefinementOptions::default(),
+                            perturbation: PerturbationOptions::default(),
                             output: OutputOptions::default(),
                             warm: WarmStartOptions::default(),
                             sqp: crate::sqp::SqpOptions::default(),

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -226,6 +226,19 @@ pub struct AlgorithmBuilder {
     /// Baked onto [`crate::ipopt_cq::IpoptCalculatedQuantities`] by the
     /// solve path.
     pub kappa_d: Number,
+    /// `tiny_step_tol` — relative primal step size below which the full
+    /// step is accepted without line search; repeated tiny steps
+    /// terminate the solve. Mirrors `IpBacktrackingLineSearch.cpp`,
+    /// default `10·EPSILON`. Baked onto
+    /// [`crate::ipopt_alg::IpoptAlgorithm`] by the solve path.
+    pub tiny_step_tol: Number,
+    /// `tiny_step_y_tol` — dual-step threshold; when both primal and dual
+    /// steps are tiny in consecutive iterations the algorithm stops at the
+    /// best attainable accuracy. Default `1e-2`.
+    pub tiny_step_y_tol: Number,
+    /// `diverging_iterates_tol` — if `max_i |x_i|` exceeds this the solve
+    /// aborts as diverging. Default `1e20`.
+    pub diverging_iterates_tol: Number,
     pub conv_check: ConvCheckOptions,
     pub mu: MuOptions,
     pub line_search: LineSearchOptions,
@@ -590,6 +603,9 @@ impl Default for AlgorithmBuilder {
             mehrotra_algorithm: false,
             kappa_sigma: 1e10,
             kappa_d: 1e-5,
+            tiny_step_tol: 10.0 * Number::EPSILON,
+            tiny_step_y_tol: 1e-2,
+            diverging_iterates_tol: 1e20,
             conv_check: ConvCheckOptions::default(),
             mu: MuOptions::default(),
             line_search: LineSearchOptions::default(),
@@ -949,6 +965,9 @@ mod tests {
                             mehrotra_algorithm: false,
                             kappa_sigma: 1e10,
                             kappa_d: 1e-5,
+                            tiny_step_tol: 10.0 * Number::EPSILON,
+                            tiny_step_y_tol: 1e-2,
+                            diverging_iterates_tol: 1e20,
                             conv_check: ConvCheckOptions::default(),
                             mu: MuOptions::default(),
                             line_search: LineSearchOptions::default(),

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2229,6 +2229,12 @@ impl IpoptApplication {
         if let Some(v) = read_num("obj_max_inc") {
             builder.line_search.obj_max_inc = v;
         }
+        if let Some(v) = read_int("max_filter_resets") {
+            builder.line_search.max_filter_resets = v;
+        }
+        if let Some(v) = read_int("filter_reset_trigger") {
+            builder.line_search.filter_reset_trigger = v;
+        }
         // Second-order-correction constants (#191), consumed by
         // `BacktrackingLineSearch`. `max_soc = 0` disables SOC.
         if let Some(v) = read_int("max_soc") {
@@ -2239,6 +2245,54 @@ impl IpoptApplication {
         }
         if let Some(v) = read_int("soc_method") {
             builder.line_search.soc_method = v;
+        }
+
+        // Inertia-correction / Jacobian-regularization constants (#191),
+        // consumed by `PdPerturbationHandler`. Registered but never read.
+        if let Some(v) = read_num("max_hessian_perturbation") {
+            builder.perturbation.max_hessian_perturbation = v;
+        }
+        if let Some(v) = read_num("min_hessian_perturbation") {
+            builder.perturbation.min_hessian_perturbation = v;
+        }
+        if let Some(v) = read_num("perturb_inc_fact_first") {
+            builder.perturbation.perturb_inc_fact_first = v;
+        }
+        if let Some(v) = read_num("perturb_inc_fact") {
+            builder.perturbation.perturb_inc_fact = v;
+        }
+        if let Some(v) = read_num("perturb_dec_fact") {
+            builder.perturbation.perturb_dec_fact = v;
+        }
+        if let Some(v) = read_num("first_hessian_perturbation") {
+            builder.perturbation.first_hessian_perturbation = v;
+        }
+        if let Some(v) = read_num("jacobian_regularization_value") {
+            builder.perturbation.jacobian_regularization_value = v;
+        }
+        if let Some(v) = read_num("jacobian_regularization_exponent") {
+            builder.perturbation.jacobian_regularization_exponent = v;
+        }
+        if let Ok((v, true)) = self.options.get_bool_value("perturb_always_cd", "") {
+            builder.perturbation.perturb_always_cd = v;
+        }
+
+        // Iterative-refinement constants (#191), consumed by
+        // `PdFullSpaceSolver`. Registered but never read.
+        if let Some(v) = read_int("min_refinement_steps") {
+            builder.refinement.min_refinement_steps = v;
+        }
+        if let Some(v) = read_int("max_refinement_steps") {
+            builder.refinement.max_refinement_steps = v;
+        }
+        if let Some(v) = read_num("residual_ratio_max") {
+            builder.refinement.residual_ratio_max = v;
+        }
+        if let Some(v) = read_num("residual_ratio_singular") {
+            builder.refinement.residual_ratio_singular = v;
+        }
+        if let Some(v) = read_num("residual_improvement_factor") {
+            builder.refinement.residual_improvement_factor = v;
         }
 
         // Iteration-output options — consumed by `OrigIterationOutput`.

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1568,6 +1568,12 @@ impl IpoptApplication {
         // default matches the registered default, so default runs are
         // unchanged.
         alg.kappa_sigma = builder.kappa_sigma;
+        // Tiny-step and divergence guards (#191): registered but
+        // previously never read. Struct defaults match the registered
+        // defaults, so default runs are unchanged.
+        alg.tiny_step_tol = builder.tiny_step_tol;
+        alg.tiny_step_y_tol = builder.tiny_step_y_tol;
+        alg.diverging_iterates_tol = builder.diverging_iterates_tol;
         // Honor `print_level == 0`: suppress the per-iteration table
         // that the algorithm writes straight to stdout. (The Phase-7
         // journalist surface respects `print_level` already; this is
@@ -2018,6 +2024,15 @@ impl IpoptApplication {
         }
         if let Some(v) = read_num("kappa_d") {
             builder.kappa_d = v;
+        }
+        if let Some(v) = read_num("tiny_step_tol") {
+            builder.tiny_step_tol = v;
+        }
+        if let Some(v) = read_num("tiny_step_y_tol") {
+            builder.tiny_step_y_tol = v;
+        }
+        if let Some(v) = read_num("diverging_iterates_tol") {
+            builder.diverging_iterates_tol = v;
         }
 
         // Barrier-parameter (μ) options — consumers in

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -52,6 +52,32 @@ fn kappa_d_override_flows_through() {
 }
 
 #[test]
+fn tiny_step_and_divergence_defaults_match_registered() {
+    let b = builder_from(|_| {});
+    assert_eq!(b.tiny_step_tol, 10.0 * f64::EPSILON);
+    assert_eq!(b.tiny_step_y_tol, 1e-2);
+    assert_eq!(b.diverging_iterates_tol, 1e20);
+}
+
+#[test]
+fn tiny_step_and_divergence_overrides_flow_through() {
+    let b = builder_from(|app| {
+        app.options_mut()
+            .set_numeric_value("tiny_step_tol", 1e-12, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("tiny_step_y_tol", 1e-3, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("diverging_iterates_tol", 1e8, true, false)
+            .unwrap();
+    });
+    assert_eq!(b.tiny_step_tol, 1e-12);
+    assert_eq!(b.tiny_step_y_tol, 1e-3);
+    assert_eq!(b.diverging_iterates_tol, 1e8);
+}
+
+#[test]
 fn filter_constants_default_match_registered() {
     let b = builder_from(|_| {}).line_search;
     assert_eq!(b.eta_phi, 1e-8);

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -163,3 +163,103 @@ fn soc_constants_reach_assembled_line_search() {
     assert_eq!(bundle.line_search.kappa_soc, 0.5);
     assert_eq!(bundle.line_search.soc_method, 1);
 }
+
+#[test]
+fn filter_reset_constants_flow_through() {
+    let d = builder_from(|_| {}).line_search;
+    assert_eq!(d.max_filter_resets, 5);
+    assert_eq!(d.filter_reset_trigger, 5);
+    let b = builder_from(|app| {
+        app.options_mut()
+            .set_integer_value("max_filter_resets", 0, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_integer_value("filter_reset_trigger", 9, true, false)
+            .unwrap();
+    })
+    .line_search;
+    assert_eq!(b.max_filter_resets, 0);
+    assert_eq!(b.filter_reset_trigger, 9);
+}
+
+#[test]
+fn refinement_constants_default_match_registered() {
+    let r = builder_from(|_| {}).refinement;
+    assert_eq!(r.min_refinement_steps, 1);
+    assert_eq!(r.max_refinement_steps, 10);
+    assert_eq!(r.residual_ratio_max, 1e-10);
+    assert_eq!(r.residual_ratio_singular, 1e-5);
+    assert_eq!(r.residual_improvement_factor, 0.999_999_999);
+}
+
+#[test]
+fn refinement_constants_override_flows_through() {
+    let r = builder_from(|app| {
+        app.options_mut()
+            .set_integer_value("min_refinement_steps", 2, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_integer_value("max_refinement_steps", 20, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("residual_ratio_max", 1e-9, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("residual_ratio_singular", 1e-4, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("residual_improvement_factor", 0.5, true, false)
+            .unwrap();
+    })
+    .refinement;
+    assert_eq!(r.min_refinement_steps, 2);
+    assert_eq!(r.max_refinement_steps, 20);
+    assert_eq!(r.residual_ratio_max, 1e-9);
+    assert_eq!(r.residual_ratio_singular, 1e-4);
+    assert_eq!(r.residual_improvement_factor, 0.5);
+}
+
+#[test]
+fn perturbation_constants_default_match_registered() {
+    let p = builder_from(|_| {}).perturbation;
+    assert_eq!(p.max_hessian_perturbation, 1e20);
+    assert_eq!(p.min_hessian_perturbation, 1e-20);
+    assert_eq!(p.perturb_inc_fact_first, 100.0);
+    assert_eq!(p.perturb_inc_fact, 8.0);
+    assert_eq!(p.perturb_dec_fact, 1.0 / 3.0);
+    assert_eq!(p.first_hessian_perturbation, 1e-4);
+    assert_eq!(p.jacobian_regularization_value, 1e-8);
+    assert_eq!(p.jacobian_regularization_exponent, 0.25);
+    assert!(!p.perturb_always_cd);
+}
+
+#[test]
+fn perturbation_constants_override_flows_through() {
+    let p = builder_from(|app| {
+        let o = app.options_mut();
+        for (k, v) in [
+            ("max_hessian_perturbation", 1e18),
+            ("min_hessian_perturbation", 1e-18),
+            ("perturb_inc_fact_first", 50.0),
+            ("perturb_inc_fact", 4.0),
+            ("perturb_dec_fact", 0.5),
+            ("first_hessian_perturbation", 1e-3),
+            ("jacobian_regularization_value", 1e-7),
+            ("jacobian_regularization_exponent", 0.5),
+        ] {
+            o.set_numeric_value(k, v, true, false).unwrap();
+        }
+        o.set_string_value("perturb_always_cd", "yes", true, false)
+            .unwrap();
+    })
+    .perturbation;
+    assert_eq!(p.max_hessian_perturbation, 1e18);
+    assert_eq!(p.min_hessian_perturbation, 1e-18);
+    assert_eq!(p.perturb_inc_fact_first, 50.0);
+    assert_eq!(p.perturb_inc_fact, 4.0);
+    assert_eq!(p.perturb_dec_fact, 0.5);
+    assert_eq!(p.first_hessian_perturbation, 1e-3);
+    assert_eq!(p.jacobian_regularization_value, 1e-7);
+    assert_eq!(p.jacobian_regularization_exponent, 0.5);
+    assert!(p.perturb_always_cd);
+}

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -1060,3 +1060,30 @@ fn hs071_honors_user_kappa_d() {
         "kappa_d was ignored: both runs took {iters_default} iters",
     );
 }
+
+/// #191: `diverging_iterates_tol` was registered but never read. HS071
+/// starts at `x = (1, 5, 5, 1)` (max-norm 5), so a threshold below that
+/// must abort the solve as diverging — proving the option now reaches the
+/// running divergence guard. The default (1e20) never triggers.
+#[test]
+fn hs071_honors_diverging_iterates_tol() {
+    let solve = |tol: Option<Number>| {
+        let mut app = IpoptApplication::new();
+        if let Some(t) = tol {
+            app.options_mut()
+                .set_numeric_value("diverging_iterates_tol", t, true, false)
+                .unwrap();
+        }
+        app.initialize().unwrap();
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071::default()));
+        app.optimize_tnlp(tnlp)
+    };
+    assert!(matches!(
+        solve(None),
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    ));
+    assert!(
+        matches!(solve(Some(1.0)), ApplicationReturnStatus::DivergingIterates),
+        "diverging_iterates_tol=1.0 should abort HS071 (max|x0|=5) as diverging",
+    );
+}


### PR DESCRIPTION
Continues #191 (follow-up to the merged #193), wiring the remaining implemented-but-unread algorithmic options. Same root cause: each option is registered and its field is consumed every iteration/solve, but the option string was never read, so user overrides were silently dropped. Every struct default equals its registered default, so **default runs are byte-for-byte unchanged** — only explicit overrides are affected.

Verified with an independent audit sweep across the workspace (each option string confirmed to appear only at its `upstream_options.rs` registration line; each field confirmed to have a live consumer; each default confirmed to match).

## Included

**Algorithm-level guards** (`IpoptAlgorithm`, baked at solve setup):
- `tiny_step_tol`, `tiny_step_y_tol` — tiny-step acceptance/termination.
- `diverging_iterates_tol` — `max|x|` divergence abort.

**Inertia-correction / Jacobian regularization** (`PdPerturbationHandler`; struct fields are named `delta_xs_*`/`delta_cd_*`, mapped via a new `PerturbationOptions`):
- `max_hessian_perturbation`, `min_hessian_perturbation`, `first_hessian_perturbation`, `perturb_inc_fact_first`, `perturb_inc_fact`, `perturb_dec_fact`, `jacobian_regularization_value`, `jacobian_regularization_exponent`, `perturb_always_cd` (via its `set_` method, which rebuilds jac state).

**KKT iterative refinement** (`PdFullSpaceSolver`, new `RefinementOptions`):
- `min_refinement_steps`, `max_refinement_steps`, `residual_ratio_max`, `residual_ratio_singular`, `residual_improvement_factor`.

**Filter-reset heuristic** (`FilterLsAcceptor`):
- `max_filter_resets` (incl. `0` to disable), `filter_reset_trigger`.

All read in `algorithm_builder_from_options` into `AlgorithmBuilder` and applied at build time, matching the existing numeric-knob convention.

## Deliberately excluded

- **`neg_curv_test_tol`** — its non-zero branch is documented as "not exercised in v1.0", so exposing it would itself be a misleading no-op (the exact class of bug we're fixing).
- **Restoration reset/penalty thresholds** (`bound_mult_reset_threshold`, `constr_mult_reset_threshold`, `resto_penalty_parameter`, `resto_proximity_weight`) — implemented and consumed, but `RestoAlgorithmBuilder` is constructed per-frontend (`::new()`, defaults) and never options-configured, so wiring needs cross-frontend plumbing. Left tracked in #191.
- Confirmed-unimplemented options (`alpha_for_y_tol`, `neg_curv_test_reg`, `expect_infeasible_problem*`, `start_with_resto`, CG-penalty `kappa_x/y_dis`, etc.) — no live consumer.

## Tests

- Pure `option → AlgorithmBuilder` wiring tests for every constant (`tests/algorithm_options_wiring.rs`), mirroring `mu_options_wiring.rs`.
- End-to-end `hs071_honors_diverging_iterates_tol` — `diverging_iterates_tol = 1.0` aborts HS071 (which starts at `max|x| = 5`) as `DivergingIterates` while the default converges.
- Full `pounce-algorithm` suite passes; workspace builds; `cargo fmt` clean; CI clippy gate (`-D clippy::correctness -D clippy::suspicious`) passes.

## Scope note

This still does not fully close #191 — the restoration thresholds remain, needing frontend plumbing. Everything else flagged by the audit as implemented-and-unread is now wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfJG4XRe4JKKQdqEc1kbxP)_