### PR TITLE
Wire restoration-phase options; close out the registered-but-unread audit (#191)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,13 +83,19 @@ changes.
   - Iterative-refinement constants on the KKT full-space solver:
     `min_refinement_steps`, `max_refinement_steps`, `residual_ratio_max`,
     `residual_ratio_singular`, `residual_improvement_factor`.
+  - Restoration-phase constants: `bound_mult_reset_threshold`,
+    `constr_mult_reset_threshold`, `resto_penalty_parameter`,
+    `resto_proximity_weight`. The outer builder carries these (read from the
+    options list) and propagates them into the restoration builder when the
+    restoration factory is minted, so all frontends honor them without
+    per-frontend plumbing.
 
   Every default equals the previously-hard-coded value, so runs that don't set
-  these options are unchanged. The remaining unread constants — restoration
-  reset/penalty thresholds (`bound_mult_reset_threshold`,
-  `constr_mult_reset_threshold`, `resto_penalty_parameter`,
-  `resto_proximity_weight`), which need per-frontend restoration-builder
-  plumbing — stay tracked in #191.
+  these options are unchanged. The only options still not wired are ones whose
+  underlying behavior is not yet implemented (e.g. `neg_curv_test_tol`'s
+  non-zero branch, `expect_infeasible_problem`, `start_with_resto`,
+  `alpha_for_y_tol`); wiring those would be misleading until the feature
+  lands.
 - **`timing_statistics=no` no longer runs the detailed timers every iteration
   (#190).** Every `TimedTask::start`/`end` pair calls `getrusage(RUSAGE_SELF)`
   (twice — once each), and the per-subsystem / per-callback timers wrap hot

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -244,6 +244,7 @@ pub struct AlgorithmBuilder {
     pub line_search: LineSearchOptions,
     pub refinement: RefinementOptions,
     pub perturbation: PerturbationOptions,
+    pub resto: RestoOptions,
     pub output: OutputOptions,
     pub warm: WarmStartOptions,
     /// SQP-specific options (consulted only when
@@ -611,6 +612,40 @@ impl Default for PerturbationOptions {
     }
 }
 
+/// Restoration-phase knobs carried on the outer builder and copied into
+/// the `RestoAlgorithmBuilder` when the restoration factory is minted
+/// (`pounce-restoration`). The restoration builder is constructed with
+/// defaults by each frontend and never options-configured, so these were
+/// registered but never read (#191). Defaults mirror upstream's
+/// restoration `RegisterOptions`.
+#[derive(Debug, Clone)]
+pub struct RestoOptions {
+    /// `bound_mult_reset_threshold` — reset bound multipliers to 1 after
+    /// restoration if the largest exceeds this.
+    pub bound_mult_reset_threshold: Number,
+    /// `constr_mult_reset_threshold` — ignore the least-square constraint
+    /// multiplier estimate after restoration if its norm exceeds this
+    /// (`0` keeps the estimate).
+    pub constr_mult_reset_threshold: Number,
+    /// `resto_penalty_parameter` — penalty on the slack 1-norm in the
+    /// restoration objective (`rho`).
+    pub resto_penalty_parameter: Number,
+    /// `resto_proximity_weight` — proximity-term weight (`eta_factor`;
+    /// `η = eta_factor · sqrt(μ)`).
+    pub resto_proximity_weight: Number,
+}
+
+impl Default for RestoOptions {
+    fn default() -> Self {
+        Self {
+            bound_mult_reset_threshold: 1e3,
+            constr_mult_reset_threshold: 0.0,
+            resto_penalty_parameter: 1e3,
+            resto_proximity_weight: 1.0,
+        }
+    }
+}
+
 /// Iterative-refinement knobs baked onto the assembled
 /// [`crate::kkt::pd_full_space_solver::PdFullSpaceSolver`]. Defaults
 /// mirror `IpPDFullSpaceSolver.cpp:RegisterOptions`. All were registered
@@ -699,6 +734,7 @@ impl Default for AlgorithmBuilder {
             line_search: LineSearchOptions::default(),
             refinement: RefinementOptions::default(),
             perturbation: PerturbationOptions::default(),
+            resto: RestoOptions::default(),
             output: OutputOptions::default(),
             warm: WarmStartOptions::default(),
             sqp: crate::sqp::SqpOptions::default(),
@@ -1087,6 +1123,7 @@ mod tests {
                             line_search: LineSearchOptions::default(),
                             refinement: RefinementOptions::default(),
                             perturbation: PerturbationOptions::default(),
+                            resto: RestoOptions::default(),
                             output: OutputOptions::default(),
                             warm: WarmStartOptions::default(),
                             sqp: crate::sqp::SqpOptions::default(),

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2295,6 +2295,25 @@ impl IpoptApplication {
             builder.refinement.residual_improvement_factor = v;
         }
 
+        // Restoration-phase constants (#191). Carried on the outer builder
+        // and copied into the `RestoAlgorithmBuilder` when the restoration
+        // factory is minted (the frontends pass this builder in). The
+        // restoration builder was never options-configured, so these were
+        // registered but never read. Defaults equal the registered
+        // defaults.
+        if let Some(v) = read_num("bound_mult_reset_threshold") {
+            builder.resto.bound_mult_reset_threshold = v;
+        }
+        if let Some(v) = read_num("constr_mult_reset_threshold") {
+            builder.resto.constr_mult_reset_threshold = v;
+        }
+        if let Some(v) = read_num("resto_penalty_parameter") {
+            builder.resto.resto_penalty_parameter = v;
+        }
+        if let Some(v) = read_num("resto_proximity_weight") {
+            builder.resto.resto_proximity_weight = v;
+        }
+
         // Iteration-output options — consumed by `OrigIterationOutput`.
         if let Some(v) = read_int("print_frequency_iter") {
             builder.output.print_frequency_iter = v;

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -263,3 +263,32 @@ fn perturbation_constants_override_flows_through() {
     assert_eq!(p.jacobian_regularization_exponent, 0.5);
     assert!(p.perturb_always_cd);
 }
+
+#[test]
+fn resto_constants_default_match_registered() {
+    let r = builder_from(|_| {}).resto;
+    assert_eq!(r.bound_mult_reset_threshold, 1e3);
+    assert_eq!(r.constr_mult_reset_threshold, 0.0);
+    assert_eq!(r.resto_penalty_parameter, 1e3);
+    assert_eq!(r.resto_proximity_weight, 1.0);
+}
+
+#[test]
+fn resto_constants_override_flows_through() {
+    let r = builder_from(|app| {
+        let o = app.options_mut();
+        for (k, v) in [
+            ("bound_mult_reset_threshold", 5e2),
+            ("constr_mult_reset_threshold", 3.0),
+            ("resto_penalty_parameter", 2e3),
+            ("resto_proximity_weight", 2.0),
+        ] {
+            o.set_numeric_value(k, v, true, false).unwrap();
+        }
+    })
+    .resto;
+    assert_eq!(r.bound_mult_reset_threshold, 5e2);
+    assert_eq!(r.constr_mult_reset_threshold, 3.0);
+    assert_eq!(r.resto_penalty_parameter, 2e3);
+    assert_eq!(r.resto_proximity_weight, 2.0);
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -143,6 +143,18 @@ pub fn make_resto_inner_solver(
 /// the ℓ₁-on-restoration-failure auto-fallback — must instead use
 /// [`make_default_restoration_factory_provider`] together with
 /// [`pounce_algorithm::application::IpoptApplication::set_restoration_factory_provider`].
+/// Copy the restoration options the outer [`AlgorithmBuilder`] carries
+/// (read from the `OptionsList` in `algorithm_builder_from_options`) into
+/// the [`RestoAlgorithmBuilder`], which every frontend constructs with
+/// bare defaults and never options-configures (#191). Defaults match, so a
+/// run that doesn't set these options is unchanged.
+fn apply_outer_resto_options(rb: &mut RestoAlgorithmBuilder, ab: &AlgorithmBuilder) {
+    rb.rho = ab.resto.resto_penalty_parameter;
+    rb.eta_factor = ab.resto.resto_proximity_weight;
+    rb.bound_mult_reset_threshold = ab.resto.bound_mult_reset_threshold;
+    rb.constr_mult_reset_threshold = ab.resto.constr_mult_reset_threshold;
+}
+
 pub fn make_default_restoration_factory(
     resto_builder: RestoAlgorithmBuilder,
     inner_alg_builder: AlgorithmBuilder,
@@ -150,9 +162,10 @@ pub fn make_default_restoration_factory(
 ) -> Box<dyn FnMut() -> Box<dyn pounce_algorithm::restoration::RestorationPhase>> {
     let mut state = Some((resto_builder, inner_alg_builder, backend_factory_factory));
     Box::new(move || {
-        let (rb, ab, bff) = state
+        let (mut rb, ab, bff) = state
             .take()
             .expect("restoration factory invoked more than once");
+        apply_outer_resto_options(&mut rb, &ab);
         let inner = make_resto_inner_solver(rb, ab, bff);
         let driver = crate::min_c_1nrm::MinC1NormRestoration::new().with_inner_solver(inner);
         Box::new(driver) as Box<dyn pounce_algorithm::restoration::RestorationPhase>
@@ -860,6 +873,46 @@ fn downcast_dense_mut(v: &mut dyn Vector) -> &mut DenseVector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn apply_outer_resto_options_propagates_overrides() {
+        // #191: restoration options set on the outer builder must reach
+        // the restoration builder (which frontends construct with bare
+        // defaults).
+        let mut ab = AlgorithmBuilder::new();
+        ab.resto.resto_penalty_parameter = 2.5e3;
+        ab.resto.resto_proximity_weight = 4.0;
+        ab.resto.bound_mult_reset_threshold = 7.0e2;
+        ab.resto.constr_mult_reset_threshold = 9.0;
+
+        let mut rb = RestoAlgorithmBuilder::new();
+        apply_outer_resto_options(&mut rb, &ab);
+
+        assert_eq!(rb.rho, 2.5e3);
+        assert_eq!(rb.eta_factor, 4.0);
+        assert_eq!(rb.bound_mult_reset_threshold, 7.0e2);
+        assert_eq!(rb.constr_mult_reset_threshold, 9.0);
+    }
+
+    #[test]
+    fn apply_outer_resto_options_defaults_are_unchanged() {
+        // Default outer options must reproduce the restoration builder's
+        // own defaults exactly, so a run that sets nothing is untouched.
+        let ab = AlgorithmBuilder::new();
+        let mut rb = RestoAlgorithmBuilder::new();
+        let baseline = RestoAlgorithmBuilder::new();
+        apply_outer_resto_options(&mut rb, &ab);
+        assert_eq!(rb.rho, baseline.rho);
+        assert_eq!(rb.eta_factor, baseline.eta_factor);
+        assert_eq!(
+            rb.bound_mult_reset_threshold,
+            baseline.bound_mult_reset_threshold
+        );
+        assert_eq!(
+            rb.constr_mult_reset_threshold,
+            baseline.constr_mult_reset_threshold
+        );
+    }
 
     #[test]
     fn placeholder_resto_iv_has_correct_shapes() {


### PR DESCRIPTION
Fixes #191.

Final tranche of the registered-but-unread audit (follow-up to #193 and #194). Wires the four restoration-phase options that were implemented and consumed (`MinC1NormRestoration` / the restoration NLP) but never read.

## The wiring problem, and a zero-frontend-churn fix

`RestoAlgorithmBuilder` is constructed with bare defaults (`::new()`) by every frontend — `pounce-cinterface`, `pounce-py` (`problem.rs`, `nlp_batch.rs`), `pounce-cli` — and never options-configured. Rather than duplicate option-reading across all of them, this uses the hook they already share: each frontend passes `app.algorithm_builder_from_options()` into `make_default_restoration_factory_provider`. So:

- the outer `AlgorithmBuilder` gains a `RestoOptions`, read once in `algorithm_builder_from_options` (the single option-reading site), and
- `make_default_restoration_factory` copies those values into the `RestoAlgorithmBuilder` when the factory is minted (extracted into `apply_outer_resto_options` for testability).

Every frontend honors the options with **no per-frontend changes**.

## Options wired

- `bound_mult_reset_threshold` (default `1e3`) — reset bound multipliers to 1 after restoration if the largest exceeds this.
- `constr_mult_reset_threshold` (default `0.0`) — ignore the least-square constraint-multiplier estimate after restoration if its norm exceeds this.
- `resto_penalty_parameter` (default `1e3`) → `rho`, the slack-1-norm penalty in the restoration objective.
- `resto_proximity_weight` (default `1.0`) → `eta_factor`, the proximity-term weight (`η = eta_factor·√μ`).

Defaults equal the registered defaults, so default runs are unchanged.

## Tests

- Pure `option → builder.resto` wiring tests (`tests/algorithm_options_wiring.rs`).
- Unit tests for `apply_outer_resto_options` in `pounce-restoration` — override propagation and defaults-unchanged.
- Full `pounce-algorithm` + `pounce-restoration` suites pass; workspace builds; `cargo fmt` clean; CI clippy gate passes.

## Closes #191

With this, every option the audit found to be **implemented and consumed but unread** is wired. The only registered options still not honored are ones whose underlying behavior is not yet implemented — `neg_curv_test_tol` (non-zero branch documented "not exercised in v1.0"), `expect_infeasible_problem`, `start_with_resto`, `alpha_for_y_tol`, and the unimplemented linear-solver / sensitivity / derivative-test families — where wiring the option would be a misleading no-op until the feature lands. Those aren't override-dropping bugs, so #191 is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfJG4XRe4JKKQdqEc1kbxP)_