### PR TITLE
Fix silent drop of sensitivity/reduced-Hessian on specialized solve paths (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,30 @@ changes.
 
 ### Fixed
 
+- **Post-optimal requests are no longer silently dropped on the specialized
+  solve paths (#196).** When an `.nl` declared the sIPOPT sensitivity suffixes
+  (`sens_state_1` / `sens_state_value_1` / `sens_init_constr`) or the solve
+  asked for a reduced Hessian (`--compute-red-hessian`), the request was
+  honored only on the general NLP filter-IPM path. Three fast paths bypassed it
+  without a word:
+  - **Convex LP/QP/QCQP routing.** Under `solver_selection=auto`, a problem
+    that classifies as LP / convex-QP was sent to the pounce-convex solver,
+    which has no sensitivity / reduced-Hessian machinery, so no
+    `sens_sol_state_1` was written. `auto` now declines the fast path and
+    routes such a solve to the NLP path (which honors the request); an
+    *explicit* convex `solver_selection` still runs convex but now warns that
+    the request is skipped.
+  - **`--minima` multistart.** The `--minima` early-return skipped the
+    post-optimal step entirely; it now warns that sensitivity / reduced-Hessian
+    is not available in a multistart search.
+  - **`--minima` `.sol` duals.** The multistart `.sol` wrote a zero placeholder
+    for the constraint multipliers; it now recovers the real base-problem duals
+    at each reported minimum (via a clean re-solve, so a point accepted from an
+    augmented penalty/tunnel solve still gets the base problem's multipliers).
+  - **Python `pounce.minimize` convex route.** A user `callback` cannot fire on
+    the convex/SOCP route (the solver consumes the extracted quadratic form and
+    never calls back into Python); it is now surfaced in the dropped-options
+    warning rather than silently ignored.
 - **Registered-but-unread algorithmic tuning options are now honored (#191).**
   A range of options were registered but never read, so the solver always ran
   with the hard-coded defaults and any user-set value was silently dropped.

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -614,11 +614,44 @@ pub fn main() -> ExitCode {
         }
     };
 
+    // issue #196 (and related): does the .nl / CLI request post-optimal work
+    // that only the general NLP filter-IPM path provides — the sIPOPT
+    // parametric sensitivity step (sens_* suffixes) or a reduced-Hessian
+    // computation (--compute-red-hessian)? Neither the --minima multistart
+    // driver nor the specialized convex solvers run it, so detect it up front
+    // and make sure no path silently drops the request.
+    let wants_sens = nl_suffixes
+        .as_ref()
+        .map(sens::is_sensitivity_input)
+        .unwrap_or(false);
+    let wants_nlp_postopt = wants_sens || args.compute_red_hessian;
+    // Human-readable description of the requested post-optimal work, reused in
+    // the "not available on this path" messages below.
+    let postopt_what = match (wants_sens, args.compute_red_hessian) {
+        (true, true) => {
+            "a parametric sensitivity step (sIPOPT sens_* suffixes) and a \
+             reduced-Hessian computation"
+        }
+        (true, false) => "a parametric sensitivity step (sIPOPT sens_* suffixes)",
+        _ => "a reduced-Hessian computation",
+    };
+
     // Multistart / find-minima: when a `--minima` method is set, drive the
     // local solver in a loop over the *raw* problem TNLP (presolve / counting
     // wrappers are intentionally bypassed so coordinates match the original
     // problem and the clean objective is evaluated directly) and return.
     if let Some(mcfg) = &args.minima {
+        // Related to #196: --minima is a multistart search, not a single
+        // post-optimal solve, so it does not run the sIPOPT sensitivity /
+        // reduced-Hessian step. Warn rather than silently drop the request
+        // (sensitivity at a multistart optimum is ill-defined).
+        if wants_nlp_postopt {
+            eprintln!(
+                "pounce: warning: the .nl requests {postopt_what}, but --minima \
+                 runs a multistart search that does not compute it; the request \
+                 will be skipped. Run without --minima to obtain it."
+            );
+        }
         return pounce_cli::minima::run(&mut app, &inner_tnlp, mcfg, &args, sol_path.as_deref());
     }
 
@@ -666,15 +699,31 @@ pub fn main() -> ExitCode {
             }
         };
 
+        // issue #196: `wants_sens` / `wants_nlp_postopt` / `postopt_what` were
+        // computed above (they also gate the --minima warning). Under `auto`,
+        // decline the convex fast-path and fall through to the NLP filter-IPM
+        // (which honors the request — correctness over the specialized path's
+        // speed); under an explicit convex solver_selection, respect the forced
+        // choice but warn (below) instead of silently skipping.
+        let decline_convex_for_postopt =
+            wants_nlp_postopt && matches!(selection, SolverSelection::Auto);
+
         // Banner-level routing line: report the detected problem class and
         // which of pounce's solvers was selected for it. Gated like the
         // banner (suppressed by `sb yes` and in JSON-debug protocol mode) so
-        // stdout stays clean for machine consumers.
+        // stdout stays clean for machine consumers. When we decline the convex
+        // fast-path for a post-optimal request (#196), report the NLP path that
+        // actually runs, not the convex one `resolve_solver` picked.
         if !suppress_banner && !json_dbg {
+            let described = if decline_convex_for_postopt {
+                SolverChoice::Nlp.describe()
+            } else {
+                choice.describe()
+            };
             println!(
                 "Problem class: {}. Selected solver: {} [solver_selection={}].",
                 class.name(),
-                choice.describe(),
+                described,
                 sel_str
             );
             println!();
@@ -688,13 +737,39 @@ pub fn main() -> ExitCode {
             choice,
             SolverChoice::LpIpm | SolverChoice::QpIpm | SolverChoice::SocpIpm
         ) {
+            // issue #196: if the .nl requested a sensitivity / reduced-Hessian
+            // step, either reroute (auto) or warn (explicit convex force) so
+            // the fast path never silently drops it.
+            if wants_nlp_postopt {
+                if decline_convex_for_postopt {
+                    eprintln!(
+                        "pounce: note: this problem classifies as {} but the .nl \
+                         requests {postopt_what}, which the convex solver \
+                         (pounce-convex) does not provide; routing to the general \
+                         NLP interior-point path so the request is honored.",
+                        class.name()
+                    );
+                } else {
+                    eprintln!(
+                        "pounce: warning: the .nl requests {postopt_what}, but \
+                         solver_selection={sel_str} forces the convex solver \
+                         (pounce-convex), which does not compute it; the request \
+                         will be skipped. Use solver_selection=nlp or auto to \
+                         obtain it."
+                    );
+                }
+            }
             // The convex solvers need the parsed `NlProblem`, but the initial
             // parse moved it into `NlTnlp`. Re-parse the file here — only on
             // the convex dispatch path (LP / convex-QP / SOCP), never for a
             // general NLP solve. Only `.nl` inputs ever classify as convex, so
             // the builtin arm falls through to NLP. A parse failure surfaces
             // and exits rather than silently mis-routing to NLP (L24).
-            if let ProblemSource::NlFile(path) = &args.problem {
+            if decline_convex_for_postopt {
+                // Declined for #196: fall through to the NLP solve below, which
+                // runs the sensitivity / reduced-Hessian step in `on_converged`
+                // and writes `sens_sol_state_1` to the `.sol`.
+            } else if let ProblemSource::NlFile(path) = &args.problem {
                 let prob = match nl_reader::read_nl_file(path) {
                     Ok(p) => p,
                     Err(e) => {

--- a/crates/pounce-cli/src/minima/archive.rs
+++ b/crates/pounce-cli/src/minima/archive.rs
@@ -25,6 +25,10 @@ pub struct Archive {
     l: Vec<Number>,
     pub xs: Vec<Vec<Number>>,
     pub fs: Vec<Number>,
+    /// Per-minimum base-problem constraint duals (length `m`), recovered by a
+    /// clean re-solve at the accepted point (issue #196, related). Parallel to
+    /// `xs` / `fs`.
+    pub ls: Vec<Vec<Number>>,
 }
 
 impl Archive {
@@ -34,6 +38,7 @@ impl Archive {
             l,
             xs: Vec::new(),
             fs: Vec::new(),
+            ls: Vec::new(),
         }
     }
 
@@ -59,8 +64,9 @@ impl Archive {
             .any(|m| scaled_distance(x, m, &self.l) <= radius)
     }
 
-    pub fn add(&mut self, x: Vec<Number>, f: Number) {
+    pub fn add(&mut self, x: Vec<Number>, lambda: Vec<Number>, f: Number) {
         self.xs.push(x);
+        self.ls.push(lambda);
         self.fs.push(f);
     }
 

--- a/crates/pounce-cli/src/minima/mod.rs
+++ b/crates/pounce-cli/src/minima/mod.rs
@@ -68,14 +68,19 @@ struct SolveOut {
     x: Vec<Number>,
 }
 
+/// On-converged capture slot: the lifted full-length primal `x` plus the
+/// base-problem constraint duals `lambda` of the most recent solve.
+type SolveCapture = Rc<RefCell<Option<(Vec<Number>, Vec<Number>)>>>;
+
 /// The find-minima driver. Holds the single application and base problem and
 /// runs the chosen strategy until a [`Stop`].
 struct Driver<'a> {
     app: &'a mut IpoptApplication,
     base: Rc<RefCell<dyn TNLP>>,
     /// Filled by the `on_converged` hook with the converged primal (full
-    /// length); cleared before each solve, taken after.
-    capture: Rc<RefCell<Option<Vec<Number>>>>,
+    /// length) plus the base-problem constraint duals; cleared before each
+    /// solve, taken after.
+    capture: SolveCapture,
     cfg: &'a MinimaArgs,
     n: usize,
     m: usize,
@@ -133,13 +138,47 @@ impl<'a> Driver<'a> {
                 | ApplicationReturnStatus::SolvedToAcceptableLevel
         );
         match self.capture.borrow_mut().take() {
-            Some(x) if success => Ok(SolveOut { success: true, x }),
+            // Only the primal is needed for acceptance; the duals are recovered
+            // later by `recover_duals` (a clean base re-solve) so a point
+            // accepted from an augmented penalty/tunnel solve still gets the
+            // base problem's multipliers.
+            Some((x, _lambda)) if success => Ok(SolveOut { success: true, x }),
             // A failed solve has no usable captured point; acceptance needs
             // success anyway, so the empty x is never read.
             _ => Ok(SolveOut {
                 success: false,
                 x: Vec::new(),
             }),
+        }
+    }
+
+    /// Recover the base-problem constraint duals at an accepted minimum `x`.
+    /// The accepting solve may have run on an augmented (penalty / tunnel)
+    /// objective, whose multipliers are not the base problem's, so re-solve the
+    /// clean base objective once from `x` — it is already optimal, so this
+    /// converges immediately — and take the captured `lambda`. Budget-exempt:
+    /// the point is already kept, so this does not consume a `--max-solves`
+    /// slot. Falls back to zeros if the recovery solve does not converge or the
+    /// nlp exposes no user-facing duals (length ≠ `m`).
+    fn recover_duals(&mut self, x: &[Number]) -> Vec<Number> {
+        let t: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(SeededTnlp::new(
+            Rc::clone(&self.base),
+            x.to_vec(),
+        )));
+        let _ = self
+            .app
+            .options_mut()
+            .read_from_str("hessian_approximation exact\n", true);
+        *self.capture.borrow_mut() = None;
+        let status = self.app.optimize_tnlp(t);
+        let ok = matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        );
+        match self.capture.borrow_mut().take() {
+            Some((_x, lambda)) if ok && lambda.len() == self.m => lambda,
+            _ => vec![0.0; self.m],
         }
     }
 
@@ -358,7 +397,12 @@ impl<'a> Driver<'a> {
         let accepted =
             finite && self.in_bounds(&x) && self.is_minimum(&x) && !self.archive.is_known(&x);
         if accepted {
-            self.archive.add(x, fval);
+            // Recover the base-problem duals at the accepted point before
+            // archiving (issue #196, related): the search may have accepted a
+            // point from an augmented penalty/tunnel solve whose multipliers
+            // are not the base problem's.
+            let lambda = self.recover_duals(&x);
+            self.archive.add(x, lambda, fval);
             self.stagnant = 0;
             if self.archive.len() >= self.cfg.n_minima {
                 return Err(Stop::TargetReached);
@@ -646,6 +690,9 @@ impl<'a> Driver<'a> {
 struct Minimum {
     x: Vec<Number>,
     objective: Number,
+    /// Base-problem constraint duals at this minimum (length `m`), recovered by
+    /// a clean re-solve (issue #196, related). Zeros if unavailable.
+    lambda: Vec<Number>,
 }
 
 /// Entry point: run the `--minima` search on `base` (the raw problem TNLP —
@@ -715,14 +762,21 @@ pub fn run(
         })
         .collect();
 
-    // Capture the converged primal of each solve via the on-converged hook.
-    let capture: Rc<RefCell<Option<Vec<Number>>>> = Rc::new(RefCell::new(None));
+    // Capture the converged primal AND the base-problem constraint duals of
+    // each solve via the on-converged hook. `lambda` uses the same
+    // `finalize_solution_lambda` convention as the main NLP `.sol` path (c/d
+    // split inversion + unscaling), so the `.sol` duals match a plain solve.
+    // An nlp that does not expose user-facing duals returns an empty vec; that
+    // (or any length mismatch) falls back to zeros where the duals are stored.
+    let capture: SolveCapture = Rc::new(RefCell::new(None));
     {
         let cap = Rc::clone(&capture);
         app.set_on_converged(Box::new(move |data, _cq, nlp, _pd| {
             if let Some(curr) = data.borrow().curr.clone() {
-                let x = nlp.borrow().lift_x_to_full(&*curr.x);
-                *cap.borrow_mut() = Some(x);
+                let nlp_ref = nlp.borrow();
+                let x = nlp_ref.lift_x_to_full(&*curr.x);
+                let lambda = nlp_ref.finalize_solution_lambda(&*curr.y_c, &*curr.y_d);
+                *cap.borrow_mut() = Some((x, lambda));
             }
         }));
     }
@@ -777,6 +831,7 @@ pub fn run(
         .map(|&i| Minimum {
             x: driver.archive.xs[i].clone(),
             objective: driver.archive.fs[i],
+            lambda: driver.archive.ls[i].clone(),
         })
         .collect();
     let best_obj = order.first().map(|&i| driver.archive.fs[i]);
@@ -837,10 +892,17 @@ fn write_sol_files(sol_path: &Path, minima: &[Minimum], m: usize) {
             "POUNCE {} find-minima rank {rank}: Solve_Succeeded",
             env!("CARGO_PKG_VERSION")
         );
+        // Real base-problem duals recovered per minimum (issue #196, related);
+        // `recover_duals` guarantees length `m`, but guard defensively.
+        let lambda = if mn.lambda.len() == m {
+            &mn.lambda
+        } else {
+            &zeros
+        };
         let payload = crate::nl_writer::SolutionFile {
             message: &message,
             x: &mn.x,
-            lambda: &zeros,
+            lambda,
             solve_result_num: status_to_solve_result_num(ApplicationReturnStatus::SolveSucceeded),
             suffixes: &[],
         };
@@ -892,7 +954,13 @@ fn write_json_report(
             status_to_solve_result_num(ApplicationReturnStatus::SolveSucceeded);
         builder.solution.objective = best.objective;
         builder.solution.x = best.x.clone();
-        builder.solution.lambda = vec![0.0; m];
+        // Real base-problem duals for the best minimum (issue #196, related);
+        // `recover_duals` guarantees length `m`, guard defensively.
+        builder.solution.lambda = if best.lambda.len() == m {
+            best.lambda.clone()
+        } else {
+            vec![0.0; m]
+        };
     }
     let report = builder.finish();
 

--- a/crates/pounce-cli/tests/fixtures/convex_qp_sens.nl
+++ b/crates/pounce-cli/tests/fixtures/convex_qp_sens.nl
@@ -1,0 +1,49 @@
+g3 1 1 0	# problem unknown
+ 3 1 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 3 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 3 	# nonzeros in Jacobian, obj. gradient
+ 3 1	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+S0 1 sens_state_1
+1 1
+S4 1 sens_state_value_1
+1 1.5
+S1 1 sens_init_constr
+0 1
+C0	#pin
+n0
+O0 0	#obj
+o0	#+
+o5	#^
+o0	#+
+v0	#x
+o2	#*
+n-1
+v1	#p
+n2
+o5	#^
+v2	#y
+n2
+x3	# initial guess
+0 0.0	#x
+1 1.0	#p
+2 0.0	#y
+r	#1 ranges (rhs's)
+4 1.0	#pin
+b	#3 bounds (on variables)
+3	#x
+3	#p
+3	#y
+k2	#intermediate Jacobian column lengths
+0
+1
+J0 1	#pin
+1 1
+G0 3	#obj
+0 0
+1 0
+2 0

--- a/crates/pounce-cli/tests/minima_sol_duals.rs
+++ b/crates/pounce-cli/tests/minima_sol_duals.rs
@@ -1,0 +1,85 @@
+//! Regression test for issue #196 (related, Finding 2): the `--minima`
+//! multistart writer must emit the *real* base-problem constraint duals at each
+//! reported minimum, not a zero placeholder.
+//!
+//! `convex_qp.nl` is `min x0² + x1²  s.t.  x0 + x1 = 2`, optimum (1, 1) with the
+//! equality multiplier λ = −2. A plain solve writes that dual; before the fix,
+//! `--minima` wrote 0.0. The multistart archive can also accept points from
+//! penalty/tunnel solves on an augmented objective, so the fix recovers duals
+//! via a clean re-solve at each minimum — this test pins that the recovered
+//! dual matches the true value (and is not the old zero placeholder).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("convex_qp.nl");
+    p
+}
+
+fn best_lambda(args: &[&str]) -> Vec<f64> {
+    // Sanitize the tag: an `=` (or other punctuation) in the path would make
+    // the CLI misparse the .nl path token as a `key=value` option.
+    let tag: String = args
+        .join("_")
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect();
+    let dir = std::env::temp_dir().join(format!("pounce_minima_duals_{tag}"));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let nl = dir.join("m.nl");
+    std::fs::copy(fixture(), &nl).expect("copy fixture");
+    let json = dir.join("out.json");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(args)
+        .arg("--json-output")
+        .arg(&json)
+        .arg("--no-sol")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "solve should succeed");
+    let report: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&json).expect("read json")).expect("parse");
+    report["solution"]["lambda"]
+        .as_array()
+        .expect("lambda array")
+        .iter()
+        .map(|v| v.as_f64().expect("f64"))
+        .collect()
+}
+
+#[test]
+fn minima_sol_writes_real_duals_not_zeros() {
+    // The general NLP path's dual is the reference value (λ = −2 for the
+    // single equality).
+    let reference = best_lambda(&["solver_selection=nlp"]);
+    assert_eq!(reference.len(), 1);
+    assert!(
+        (reference[0] - (-2.0)).abs() < 1e-6,
+        "reference equality dual should be ≈ −2; got {}",
+        reference[0]
+    );
+
+    // --minima must now recover that same dual (was 0.0 before the fix).
+    let minima = best_lambda(&["--minima", "multistart"]);
+    assert_eq!(minima.len(), 1);
+    assert!(
+        minima[0].abs() > 1e-3,
+        "the dual must not be the old zero placeholder; got {}",
+        minima[0]
+    );
+    assert!(
+        (minima[0] - reference[0]).abs() < 1e-5,
+        "--minima dual {} should match the NLP-path dual {}",
+        minima[0],
+        reference[0]
+    );
+}

--- a/crates/pounce-cli/tests/qp_sens_dispatch.rs
+++ b/crates/pounce-cli/tests/qp_sens_dispatch.rs
@@ -1,0 +1,155 @@
+//! Regression test for issue #196: sIPOPT sensitivity suffixes must not be
+//! silently dropped when a problem classifies as a convex QP.
+//!
+//! Fixture `convex_qp_sens.nl` is the issue's reproduction — a *pure convex QP*
+//!   min (x - p)^2 + y^2   s.t.   p == 1.0
+//! carrying the three sIPOPT suffixes (`sens_state_1`, `sens_state_value_1`,
+//! `sens_init_constr`) that request a post-optimal parametric sensitivity step,
+//! with the perturbed parameter value p -> 1.5. Because it is a convex QP,
+//! `solver_selection=auto` classifies it as such; the specialized pounce-convex
+//! fast path has no sensitivity machinery, so pre-fix it returned no
+//! `sens_sol_state_1` suffix at all (the silent drop the issue reports).
+//!
+//! The analytical sensitivity is dx*/dp = 1, so the perturbed primal has
+//! x -> 1.5 (and p -> 1.5). Generated with pyomo 6.10 (quadratic objective +
+//! linear equality + INT/FLOAT sIPOPT export suffixes); see the issue thread.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("convex_qp_sens.nl");
+    p
+}
+
+/// Copy the fixture next to a fresh temp path so each test writes its own
+/// sibling `.sol` (the AMPL convention) without racing the others.
+fn staged_nl(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("pounce_issue196_{tag}"));
+    std::fs::create_dir_all(&dir).expect("mkdir temp");
+    let dst = dir.join("convex_qp_sens.nl");
+    std::fs::copy(fixture(), &dst).expect("copy fixture");
+    // Remove any stale .sol from a previous run.
+    let _ = std::fs::remove_file(dir.join("convex_qp_sens.sol"));
+    dst
+}
+
+/// Parse the `sens_sol_state_1` real-var suffix block out of a `.sol` file.
+/// Returns index -> value for the listed entries, or None if the suffix is
+/// absent.
+fn parse_sens_sol_state_1(sol: &str) -> Option<HashMap<usize, f64>> {
+    let mut lines = sol.lines();
+    while let Some(line) = lines.next() {
+        if let Some(rest) = line.strip_prefix("suffix ") {
+            // AMPL `.sol` suffix header:
+            //   "<kind> <nvalues> <namelen> <tablen> <tabline>"
+            // then the suffix name, any table lines, then nvalues "<idx> <val>".
+            let parts: Vec<&str> = rest.split_whitespace().collect();
+            if parts.len() < 5 {
+                continue;
+            }
+            let count: usize = parts[1].parse().ok()?;
+            let tabline: usize = parts[4].parse().ok()?;
+            let name = lines.next()?.trim().to_string();
+            if name != "sens_sol_state_1" {
+                // Skip this suffix's table + value lines and keep scanning.
+                for _ in 0..(tabline + count) {
+                    lines.next();
+                }
+                continue;
+            }
+            for _ in 0..tabline {
+                lines.next();
+            }
+            let mut out = HashMap::new();
+            for _ in 0..count {
+                let l = lines.next()?;
+                let mut it = l.split_whitespace();
+                let idx: usize = it.next()?.parse().ok()?;
+                let val: f64 = it.next()?.parse().ok()?;
+                out.insert(idx, val);
+            }
+            return Some(out);
+        }
+    }
+    None
+}
+
+/// `auto` must honor the sensitivity request by routing to the NLP path and
+/// writing `sens_sol_state_1` with the correct perturbed primal (x -> 1.5).
+#[test]
+fn auto_routes_sens_qp_to_nlp_and_writes_sens_suffix() {
+    let nl = staged_nl("auto");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "solve should succeed");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("routing to the general NLP"),
+        "auto should announce the reroute to NLP; stderr=\n{stderr}"
+    );
+
+    let sol_path = nl.with_extension("sol");
+    let sol = std::fs::read_to_string(&sol_path).expect("read .sol");
+    let sens = parse_sens_sol_state_1(&sol)
+        .expect("sens_sol_state_1 must be present after auto reroute (issue #196)");
+    let x = *sens.get(&0).expect("perturbed x (index 0)");
+    assert!(
+        (x - 1.5).abs() < 1e-6,
+        "dx*/dp = 1 so p 1.0 -> 1.5 gives x* -> 1.5; got {x}"
+    );
+}
+
+/// An *explicit* convex force must be respected, but the dropped sensitivity
+/// request must be surfaced as a warning (not silent), and no
+/// `sens_sol_state_1` is written.
+#[test]
+fn explicit_qp_ipm_warns_and_skips_sens() {
+    let nl = staged_nl("qp_ipm");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg("solver_selection=qp-ipm")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "solve should succeed");
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("warning:") && stderr.contains("will be skipped"),
+        "explicit convex force must warn that sensitivity is skipped; stderr=\n{stderr}"
+    );
+
+    let sol = std::fs::read_to_string(nl.with_extension("sol")).expect("read .sol");
+    assert!(
+        parse_sens_sol_state_1(&sol).is_none(),
+        "forced convex path does not compute sensitivity, so no sens_sol_state_1"
+    );
+}
+
+/// Control / no-regression: the general NLP path still writes the suffix.
+#[test]
+fn nlp_path_writes_sens_suffix() {
+    let nl = staged_nl("nlp");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg("solver_selection=nlp")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "solve should succeed");
+
+    let sol = std::fs::read_to_string(nl.with_extension("sol")).expect("read .sol");
+    let sens = parse_sens_sol_state_1(&sol).expect("sens_sol_state_1 present on NLP path");
+    let x = *sens.get(&0).expect("perturbed x (index 0)");
+    assert!((x - 1.5).abs() < 1e-6, "expected x* -> 1.5; got {x}");
+}

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -1038,6 +1038,14 @@ def minimize(
         ignored = sorted(requested_opt_keys - _CONVEX_HONORED)
         if hess is not None:
             ignored.append("hess (argument)")
+        # The convex/SOCP routers consume the extracted quadratic form directly
+        # and never call back into Python, so a user `callback` would never fire
+        # on this route. It is a named argument (not in `options`), so the set
+        # diff above cannot catch it — surface it explicitly rather than let it
+        # be silently dropped (issue #196, related). Pass solver_selection='nlp'
+        # to keep the callback firing.
+        if callback is not None:
+            ignored.append("callback (argument)")
         if ignored:
             warnings.warn(
                 f"pounce.minimize routed this problem to the dedicated {route_name} "

--- a/python/tests/test_minimize_autoroute.py
+++ b/python/tests/test_minimize_autoroute.py
@@ -132,6 +132,26 @@ def test_nonconvex_qp_stays_on_nlp():
     assert _routed_to(res) is None
 
 
+def test_convex_route_warns_dropped_callback():
+    # issue #196 (related): the convex/SOCP routers consume the extracted
+    # quadratic form and never call back into Python, so a user `callback`
+    # cannot fire on that route. `callback` is a named argument (not in
+    # `options`), so it must be surfaced explicitly in the dropped-options
+    # warning rather than silently ignored.
+    fun = lambda x: x[0] ** 2 + x[1] ** 2 - 3 * x[0] - 4 * x[1] + 5.0
+    jac = lambda x: np.array([2 * x[0] - 3, 2 * x[1] - 4])
+    hess = lambda x: np.array([[2.0, 0.0], [0.0, 2.0]])
+    seen = []
+    with pytest.warns(UserWarning, match=r"callback \(argument\)"):
+        res = minimize(
+            fun, [0.5, 0.5], jac=jac, hess=hess, bounds=[(0, 1), (0, 1)],
+            callback=lambda xk: seen.append(1),
+            options={"solver_selection": "auto"},
+        )
+    assert _routed_to(res) == "qp-ipm"  # still took the convex fast path
+    assert seen == []  # callback did not fire — exactly what the warning says
+
+
 def test_forced_lp_on_nonlinear_raises():
     fun = lambda x: (1 - x[0]) ** 2 + 100 * (x[1] - x[0] ** 2) ** 2
     with pytest.raises(ValueError):


### PR DESCRIPTION
Fixes #196.

## Problem

The sIPOPT parametric-sensitivity step (`sens_state_1` / `sens_state_value_1` / `sens_init_constr` suffixes) and the reduced-Hessian computation (`--compute-red-hessian`) were honored **only** on the general NLP filter-IPM path. Several fast paths early-return before that post-optimal wiring and dropped the request **silently**. The reported case: a pure convex QP declaring the sens suffixes routes to the pounce-convex solver under `solver_selection=auto`, and no `sens_sol_state_1` is written to the `.sol`.

An audit for the same bug-class (early-return dispatch skipping a general-path feature) turned up three more instances, all fixed here.

## Fixes

| Path | Before | After |
|---|---|---|
| **Convex LP/QP/QCQP routing** (`main.rs`) | `auto` sent sens/red-Hessian solves to pounce-convex, silently dropping them | `auto` declines the fast path → NLP path honors the request; explicit convex `solver_selection` warns instead of silently skipping; banner names the path that actually runs |
| **`--minima` multistart** (`main.rs`) | early-return skipped sens/red-Hessian silently | warns it is not computed in a multistart search |
| **`--minima` `.sol` duals** (`minima/`) | wrote a zero placeholder for constraint multipliers | recovers the real base-problem duals per minimum via a clean, budget-exempt re-solve (avoids the augmented penalty/tunnel-objective multiplier trap); verified to match the NLP-path dual |
| **Python `pounce.minimize` convex route** (`_minimize.py`) | a user `callback` was silently dropped (it is a named arg, not in `options`, so the drop-warning missed it) | `callback` now listed in the convex-route dropped-options warning |

## Design notes

- **Convex reroute vs. warn.** Under `auto` we prefer correctness (route to the path that honors the request); under an *explicit* convex force we respect the user's choice but stop being silent. Mirrors how the CLI and Python already surface dropped options.
- **`--minima` duals correctness.** The multistart archive can accept a point found by a penalty/tunnel solve on an *augmented* objective, whose multipliers are **not** the base problem's duals. Naively capturing them would write wrong duals — worse than the honest zeros. So the fix recovers duals via a clean re-solve seeded at each reported minimum (already optimal → converges immediately), replicating the NLP path's `finalize_solution_lambda` convention.

## Tests

- `qp_sens_dispatch.rs` — `auto` reroutes and writes `sens_sol_state_1 = 1.5` (matches the analytical `dx*/dp = 1`); explicit `qp-ipm` warns and skips; `nlp` control.
- `minima_sol_duals.rs` — `--minima` best-minimum dual (−2) matches the NLP-path dual, not the old zero.
- Python autoroute callback-warning test.
- Fixture `convex_qp_sens.nl` is the issue's exact model (`min (x−p)² + y²`, p pinned, perturbed to 1.5), generated with pyomo.

Full `pounce-cli` suite: 278 passed. Python autoroute suite: green. rustfmt + clippy clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
