### PR TITLE
Bind objective args into convex router probes in pounce.minimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ changes.
 
 ### Fixed
 
+- **`pounce.minimize(..., args=...)` now works with convex routing.** The extra
+  objective `args` were applied on the NLP path but not bound into the copies of
+  `fun`/`jac`/`hess` handed to the LP/QP/SOCP routers, which probe them as bare
+  `f(x)`. A parameterized convex objective therefore either silently never
+  routed (`solver_selection=auto` fell back to NLP) or was wrongly rejected as
+  "not convex" under a forced `solver_selection`. `args` are now bound into the
+  router probes, so a parameterized convex QP/LP/QCQP routes to the specialized
+  solver as expected.
 - **Post-optimal requests are no longer silently dropped on the specialized
   solve paths (#196).** When an `.nl` declared the sIPOPT sensitivity suffixes
   (`sens_state_1` / `sens_state_value_1` / `sens_init_constr`) or the solve

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -1006,15 +1006,27 @@ def minimize(
     else:
         router_jac_combined = jac_combined  # value-vec; never read when nlp
 
+    # Bind the objective's extra `args` into `fun`/`jac`/`hess` before handing
+    # them to the routers, which probe them as bare `f(x)`. The NLP path below
+    # applies `args` itself (`fun(x, *args)`), but the router copies would
+    # otherwise call the raw callables without `args` — so a parameterized
+    # convex objective either never routes (auto falls back to NLP) or is
+    # wrongly rejected as "not convex" under a forced solver_selection. (#196
+    # sibling: a user input silently not honored on the convex route.)
+    def _bind_args(f):
+        if f is None or not args:
+            return f
+        return lambda x, _f=f, _a=args: _f(x, *_a)
+
     # Wrap router callables in one shared point-cache (M34): the LP/QP and SOCP
     # routers probe an identical point set (same seed), so caching makes the
     # second router's probes cache hits instead of re-evaluating the objective.
     # Only these router copies are cached; the NLP fallback below still calls
     # the original `fun`/`jac`/… so the actual solve is unaffected.
     route_kw = dict(
-        fun=_point_cache(fun),
-        jac=_point_cache(jac),
-        hess=_point_cache(hess),
+        fun=_point_cache(_bind_args(fun)),
+        jac=_point_cache(_bind_args(jac)),
+        hess=_point_cache(_bind_args(hess)),
         lb=lb,
         ub=ub,
         m=m,

--- a/python/tests/test_minimize_autoroute.py
+++ b/python/tests/test_minimize_autoroute.py
@@ -152,6 +152,26 @@ def test_convex_route_warns_dropped_callback():
     assert seen == []  # callback did not fire — exactly what the warning says
 
 
+def test_args_are_bound_into_convex_router_probes():
+    # A parameterized convex QP min (x0 − c)² + x1² with args=(c,). The router
+    # probes fun/jac/hess as bare f(x), so before the fix `args` was dropped:
+    # `auto` silently fell back to NLP (never routed) and a forced `qp-ipm` was
+    # wrongly rejected as "not convex". Both must now route and land x0 = c.
+    fun = lambda x, c: (x[0] - c) ** 2 + x[1] ** 2
+    jac = lambda x, c: np.array([2 * (x[0] - c), 2 * x[1]])
+    hess = lambda x, c: np.array([[2.0, 0.0], [0.0, 2.0]])
+    kw = dict(args=(3.0,), jac=jac, hess=hess, bounds=[(-10, 10), (-10, 10)])
+
+    auto = minimize(fun, [0.0, 0.0], options={"solver_selection": "auto"}, **kw)
+    assert _routed_to(auto) == "qp-ipm"  # args-bound probe now detects the QP
+    np.testing.assert_allclose(auto.x, [3.0, 0.0], atol=1e-6)
+
+    # Forced convex must no longer spuriously reject a genuinely convex QP.
+    forced = minimize(fun, [0.0, 0.0], options={"solver_selection": "qp-ipm"}, **kw)
+    assert _routed_to(forced) == "qp-ipm"
+    np.testing.assert_allclose(forced.x, [3.0, 0.0], atol=1e-6)
+
+
 def test_forced_lp_on_nonlinear_raises():
     fun = lambda x: (1 - x[0]) ** 2 + 100 * (x[1] - x[0] ** 2) ** 2
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Problem

`pounce.minimize(fun, x0, args=..., solver_selection=<convex>)` silently dropped the objective's extra `args` on the routing path. The NLP path applies them (`fun(x, *args)`), but the copies of `fun`/`jac`/`hess` handed to the LP/QP/SOCP routers (`route_kw`) wrapped the **raw** callables, and the routers probe them as bare `f(x)`. For a parameterized convex objective:

- **`solver_selection=auto`** silently never routed — the probe raised (missing `args`), the router returned `None`, and the solve fell back to NLP. Correct answer, but the convex fast path the user opted into never engaged.
- **A forced `solver_selection=qp-ipm`/`lp-ipm`/`socp`** raised `ValueError: ... not detected as a convex ...` — a false negative on a genuinely convex problem.

Found while auditing for bugs of the same class as #196 (a user input silently not honored on the convex route).

## Fix

Bind `args` into `fun`/`jac`/`hess` before wrapping them in the router point-cache, so the routers probe the actual parameterized objective. The NLP path is unchanged (it already applied `args`).

## Verification

Before → after on `min (x0−c)² + x1²`, `args=(3.0,)`:

| `solver_selection` | before | after |
|---|---|---|
| `auto` | route=NLP (fast path missed) | route=`qp-ipm`, x0=3 ✓ |
| `qp-ipm` | `ValueError: not detected as convex` | route=`qp-ipm`, x0=3 ✓ |
| `nlp` | x0=3 ✓ | x0=3 ✓ (unchanged) |

Adds `test_args_are_bound_into_convex_router_probes`; the `minimize` autoroute + socp-autoroute + minimize suites pass (76 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
