### PR TITLE
Declared-parameter sensitivity for Pyomo (declare_sens_param / gradient / estimate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,29 +198,47 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: python -m pip install --upgrade pip build
-      - name: Build wheel + sdist
+      - name: Build pyomo-pounce wheel + sdist
         working-directory: pyomo-pounce
         run: |
           python -m build
           ls -l dist/
-      - name: Build pounce CLI (stand-in for pounce-solver dep)
+      # Build the pounce-solver wheel from THIS branch and install it, so the
+      # in-process sensitivity session (`pyomo_pounce.sens` does `import pounce`
+      # and calls the new solver methods) has a real Python solver — not just
+      # the CLI. The wheel bundles the CLI, so its console script also satisfies
+      # the SolverFactory plugin's `.solve()` path. The pyomo-pounce sensitivity
+      # tests exercise both.
+      - name: Build pounce CLI binary
         run: cargo build --release --bin pounce
+      - name: Stage CLI binary into pounce-solver wheel
+        run: |
+          mkdir -p python/pounce/bin
+          cp target/release/pounce python/pounce/bin/pounce
+      - name: Build pounce-solver wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          working-directory: python
+          target: x86_64
+          manylinux: manylinux2014
+          args: --release --out dist
+          sccache: "true"
       - name: Install + smoke
         run: |
-          python -m pip install pyomo
-          # Install without deps because `pounce-solver` may not yet be
-          # published; the locally-built CLI on PATH satisfies the
-          # runtime requirement.
+          # pyomo + numpy (sensitivity needs numpy); the locally-built
+          # pounce-solver wheel provides the `pounce` Python package + CLI.
+          python -m pip install pyomo numpy
+          python -m pip install python/dist/*.whl
+          # pyomo-pounce itself installed without deps: its declared
+          # pounce-solver dep is satisfied by the wheel installed just above.
           python -m pip install --no-deps pyomo-pounce/dist/*.whl
-          export PATH="$PWD/target/release:$PATH"
           which pounce
           python -c "import pyomo_pounce; from pyomo.opt import SolverFactory; s = SolverFactory('pounce'); print('exe:', s.executable())"
       - name: Run pyomo-pounce tests
         run: |
           python -m pip install pytest
-          # The plugin resolves `pounce` from PATH, so re-export it here
-          # (each `run:` is a fresh shell). These tests drive real solves
-          # through the AMPL/`.nl` layer — option forwarding, solver routing —
-          # which is what catches regressions the import smoke test misses.
-          export PATH="$PWD/target/release:$PATH"
+          # Sensitivity tests (test_sens.py) drive real in-process solves +
+          # parametric backsolves through the installed pounce-solver; the
+          # AMPL/`.nl` tests exercise the CLI plugin path. Both catch
+          # regressions the import smoke test misses.
           python -m pytest pyomo-pounce/tests -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
         run: |
           # pyomo + numpy (sensitivity needs numpy); the locally-built
           # pounce-solver wheel provides the `pounce` Python package + CLI.
-          python -m pip install pyomo numpy
+          python -m pip install pyomo numpy pandas
           python -m pip install python/dist/*.whl
           # pyomo-pounce itself installed without deps: its declared
           # pounce-solver dep is satisfied by the wheel installed just above.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ changes.
 
 ## [Unreleased]
 
+### Added — declared-parameter sensitivity for Pyomo (Python / Pyomo)
+
+- **`pyomo_pounce` sensitivity interface.** Declare parameters while
+  building the model (`declare_sens_param(m.p)` — a flag, no perturbed
+  values), solve normally with `SolverFactory('pounce')`, then query:
+  `gradient(m.x, wrt=m.p)` (exact dx*/dp; equality constraints give
+  their multiplier's derivative), container/Jacobian access via the
+  `Gradient` object, and `estimate(m, [(m.p, value)])` for
+  first-order perturbed-solution estimates with bound clamping and an
+  active-set warning. When declarations are present the solve runs
+  in-process through the `pounce.Solver` session (`read_nl` + callback
+  bridge) and keeps the converged KKT factorization; models without
+  declarations use the CLI path unchanged.
+- **Python `Solver` session additions**: `parametric_step_full`
+  (full KKT-space step, exposing multiplier sensitivities) and
+  `multiplier_rows` (map constraint indices to their `y_c` rows), with
+  matching Rust methods `Solver::parametric_step_full` /
+  `Solver::g_multiplier_rows` in `pounce-sensitivity`.
+
 ### Added — structure-aware KKT hooks (#180)
 
 - **Caller-supplied KKT ordering** (item 1). A structure-aware presolve can

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ finished solve is also available through the **pounce-studio MCP server**
 The `pounce-sensitivity` crate is a Rust port of upstream Ipopt's
 `contrib/sIPOPT/` (Pirnay, López-Negrete & Biegler 2012, [DOI
 10.1007/s12532-012-0043-2](https://doi.org/10.1007/s12532-012-0043-2)).
-Three entry points cover the common workflows:
+Four entry points cover the common workflows:
 
 * **AMPL CLI** — the main `pounce` driver auto-detects the sIPOPT
   suffixes (`sens_state_1`, `sens_state_value_1`, `sens_init_constr`)
@@ -325,6 +325,23 @@ Three entry points cover the common workflows:
   capability from the cyipopt-compatible Python wrapper. See
   [`python/notebooks/04_sensitivity.ipynb`](python/notebooks/04_sensitivity.ipynb)
   for a walkthrough.
+
+* **Pyomo (`pyomo_pounce`)** — declare the parameters that matter when
+  building the model, solve normally, then query derivatives; no
+  suffixes and no upfront perturbation values:
+
+  ```python
+  from pyomo_pounce import declare_sens_param, gradient, estimate
+  declare_sens_param(m.p)
+  SolverFactory("pounce").solve(m)     # keeps the KKT factorization
+  gradient(m.x, wrt=m.p)               # dx*/dp; constraints give dlambda/dp
+  estimate(m, [(m.p, 2.5)])            # perturbed-solution estimate
+  ```
+
+  See [`docs/src/sensitivity.md`](docs/src/sensitivity.md) and
+  [`python/notebooks/25_pyomo_sensitivity.ipynb`](python/notebooks/25_pyomo_sensitivity.ipynb)
+  (an optimal-control example where the first-move gradients are the
+  NMPC feedback gains).
 
 All three are verified against upstream sIPOPT 3.14.19's
 `parametric_cpp` golden output to 1e-8. Reduced-Hessian eigendecomposition

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -239,6 +239,49 @@ impl PySolver {
         Ok(dx.into_pyarray_bound(py))
     }
 
+    /// Full KKT-space parametric step: like `parametric_step` but
+    /// returns the whole compound vector `(x, s, y_c, y_d, z_l, z_u,
+    /// v_l, v_u)` so multiplier sensitivities are available. Use
+    /// `block_dims()` for the layout and `multiplier_rows()` to find a
+    /// constraint's row.
+    fn parametric_step_full<'py>(
+        &self,
+        py: Python<'py>,
+        pin_constraint_indices: Vec<i64>,
+        deltas: Vec<Number>,
+    ) -> PyResult<Bound<'py, PyArray1<Number>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "parametric_step_full: no converged factor (call solve() first)",
+            )
+        })?;
+        let pins = validate_pins(&pin_constraint_indices, s.m)?;
+        if deltas.len() != pins.len() {
+            return Err(PyValueError::new_err(format!(
+                "deltas length {} must equal pin_constraint_indices length {}",
+                deltas.len(),
+                pins.len(),
+            )));
+        }
+        let dx_full = s
+            .inner
+            .parametric_step_full(&pins, &deltas)
+            .map_err(solver_error_to_py)?;
+        Ok(dx_full.into_pyarray_bound(py))
+    }
+
+    /// Rows of the compound KKT vector holding the equality
+    /// multipliers for the given 0-based constraint (`g`) indices;
+    /// `None` for inequality constraints.
+    fn multiplier_rows(&self, g_indices: Vec<i64>) -> PyResult<Vec<Option<i64>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("multiplier_rows: no converged factor (call solve() first)")
+        })?;
+        let gs = validate_pins(&g_indices, s.m)?;
+        let rows = s.inner.g_multiplier_rows(&gs).map_err(solver_error_to_py)?;
+        Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
+    }
+
     /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned
     /// rows, in **natural (unscaled) units**: any NLP scaling baked
     /// into the converged factor is undone, so `-inv(H_R)` is directly

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -400,6 +400,76 @@ impl Solver {
         Ok(dx_full)
     }
 
+    /// Full KKT-space parametric step for a set of pinned equality
+    /// constraints: the same computation as [`Self::parametric_step`],
+    /// returned WITHOUT truncating to the primal block. The layout is
+    /// the compound KKT vector `(x, s, y_c, y_d, z_l, z_u, v_l, v_u)`;
+    /// use [`Self::block_dims`] for the block sizes and
+    /// [`Self::g_multiplier_rows`] to locate a constraint's multiplier
+    /// row. This exposes the multiplier sensitivities `∂λ*/∂p`
+    /// alongside the primal step.
+    pub fn parametric_step_full(
+        &self,
+        pin_constraint_indices: &[Index],
+        deltas: &[Number],
+    ) -> Result<Vec<Number>, SolverError> {
+        if pin_constraint_indices.len() != deltas.len() {
+            return Err(SolverError::BadShape {
+                what: "deltas",
+                got: deltas.len(),
+                expected: pin_constraint_indices.len(),
+            });
+        }
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+
+        let param_rows = state
+            .backsolver
+            .map_pin_g_to_kkt_rows(pin_constraint_indices)
+            .map_err(SolverError::SensComputationFailed)?;
+        let signs = vec![1; pin_constraint_indices.len()];
+        let a_data = IndexSchurData::from_parts(param_rows, signs)
+            .map_err(|e| SolverError::SensComputationFailed(format!("{e:?}")))?;
+
+        let opts = SensOptions {
+            run_sens: true,
+            ..SensOptions::default()
+        };
+        let sens_app = SensApplication::new(a_data, state.backsolver.clone(), opts);
+        let n_full = state.backsolver.dim();
+        let mut dx_full = vec![0.0; n_full];
+        if !sens_app.parametric_step(deltas, &mut dx_full) {
+            return Err(SolverError::SensComputationFailed(
+                "SensApplication::parametric_step failed".into(),
+            ));
+        }
+        Ok(dx_full)
+    }
+
+    /// Flat rows of the compound KKT vector holding the equality
+    /// multipliers `y_c` for the given 0-based **full-g** constraint
+    /// indices. `None` for inequalities (their multipliers live in the
+    /// `y_d` block; mapping those is not exposed here). Row `r` of a
+    /// [`Self::parametric_step_full`] result is then `∂λ_g/∂p · Δp`.
+    pub fn g_multiplier_rows(
+        &self,
+        g_indices: &[Index],
+    ) -> Result<Vec<Option<Index>>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let dims = state.backsolver.block_dims();
+        let y_c_offset = (dims[0] + dims[1]) as Index;
+        Ok(g_indices
+            .iter()
+            .map(|&g| {
+                state
+                    .backsolver
+                    .full_g_to_c_block(g)
+                    .map(|pos| y_c_offset + pos)
+            })
+            .collect())
+    }
+
     /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned
     /// equality-constraint rows, where `B` selects the
     /// `pin_constraint_indices` rows of the y_c block and `K` is the

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -6,7 +6,7 @@ upstream Ipopt's `contrib/sIPOPT/` (Pirnay, López-Negrete & Biegler
 [10.1007/s12532-012-0043-2](https://doi.org/10.1007/s12532-012-0043-2)).
 It computes the first-order change in the optimal primal solution with
 respect to a problem parameter, reusing the KKT factorization from the
-converged solve. Three entry points cover the common workflows.
+converged solve. Four entry points cover the common workflows.
 
 ## AMPL CLI
 
@@ -69,6 +69,46 @@ x, info = prob.solve_with_sens(x0, pin_constraint_indices=[2, 3],
 eigendecomposition; `sens_bound_eps=…` tunes the bound projection. See
 [`python/notebooks/04_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/04_sensitivity.ipynb)
 for a walkthrough.
+
+## Pyomo
+
+`pyomo_pounce` wraps the same machinery in a declare-then-query
+interface: flag the parameters that matter while building the model
+(no perturbed values required), solve normally, then ask for
+derivatives. Parameters are declared with `declare_sens_param`
+(mutable `Param` or fixed `Var`, scalar or indexed); when declarations
+are present, `SolverFactory("pounce").solve(m)` runs in-process and
+keeps the converged KKT factorization, so every query afterwards is a
+single backsolve.
+
+```python
+import pyomo.environ as pyo
+import pyomo_pounce
+from pyomo_pounce import declare_sens_param, gradient, estimate
+
+m.p = pyo.Param(initialize=2.0, mutable=True)
+declare_sens_param(m.p)                 # a flag, not a perturbation
+
+pyo.SolverFactory("pounce").solve(m)    # ordinary solve
+
+gradient(m.x, wrt=m.p)                  # dx*/dp (float)
+gradient(m.con, wrt=m.p)                # d(multiplier of con)/dp
+G = gradient(m.z, wrt=m.r)              # containers -> Gradient object
+G[m.z[1], m.r[2]]; G.to_dataframe()     # element access / full Jacobian
+estimate(m, [(m.p, 2.5)])               # first-order solution estimate at
+                                        # new values, clamped to bounds
+```
+
+`gradient` returns exact first-order derivatives (unit-perturbation
+backsolves, no finite differencing); `estimate` combines the stored
+derivative columns for arbitrary perturbed values after the fact, and
+warns when the linear step leaves the variable bounds (the clamp is
+the same single-pass projection as `--sens-boundcheck`). Multiplier
+sensitivities are available for equality constraints. Models without
+declarations solve through the ordinary AMPL/CLI path, unchanged. See
+[`python/notebooks/25_pyomo_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/25_pyomo_sensitivity.ipynb)
+for a worked optimal-control example (initial conditions as
+parameters; the first-move gradient IS the NMPC feedback gain).
 
 ## Units and NLP scaling
 

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -102,8 +102,8 @@ estimate(m, [(m.p, 2.5)])               # first-order solution estimate at
 `gradient` returns exact first-order derivatives (unit-perturbation
 backsolves, no finite differencing); `estimate` combines the stored
 derivative columns for arbitrary perturbed values after the fact, and
-warns when the linear step leaves the variable bounds (the clamp is
-the same single-pass projection as `--sens-boundcheck`). Multiplier
+warns when the linear step leaves the variable bounds (a single-pass
+projection analogous to the CLI's `--sens-boundcheck`). Multiplier
 sensitivities are available for equality constraints. Models without
 declarations solve through the ordinary AMPL/CLI path, unchanged. See
 [`python/notebooks/25_pyomo_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/25_pyomo_sensitivity.ipynb)

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -12,9 +12,21 @@ Initialization helpers (see the POUNCE docs' initialization chapter):
     pyomo_pounce.initialize_missing_values(model)  # fill unset Var values
     pyomo_pounce.project_to_feasible(model)        # min-norm repair onto constraints
     pyomo_pounce.block_initialize(model, decisions=[...])  # DM-ordered equality solve
+
+Parametric sensitivity (see pyomo_pounce.sens):
+    declare_sens_param(m.p)      # flag parameters when building the model
+    SolverFactory('pounce').solve(m)   # normal solve keeps the KKT factor
+    gradient(m.x, wrt=m.p)       # then sensitivities are cheap backsolves
+    estimate(m, [(m.p, 2.5)])
 """
 from pyomo_pounce.block_init import BlockInitReport, block_initialize
 from pyomo_pounce.pounce_solver import POUNCE
+from pyomo_pounce.sens import (
+    Gradient,
+    declare_sens_param,
+    estimate,
+    gradient,
+)
 from pyomo_pounce.preflight import (
     PyomoPreflightReport,
     initialize_missing_values,
@@ -24,6 +36,10 @@ from pyomo_pounce.repair import InitializeReport, initialize, project_to_feasibl
 
 __all__ = [
     "POUNCE",
+    "declare_sens_param",
+    "gradient",
+    "estimate",
+    "Gradient",
     "preflight",
     "PyomoPreflightReport",
     "initialize_missing_values",

--- a/pyomo-pounce/pyomo_pounce/pounce_solver.py
+++ b/pyomo-pounce/pyomo_pounce/pounce_solver.py
@@ -38,11 +38,13 @@ class POUNCE(ASL):
         # (pyomo_pounce.declare_sens_param), solve in-process through the
         # pounce.Solver session so the converged KKT factorization stays
         # available for gradient()/estimate(). Otherwise the ordinary
-        # ASL/CLI path runs.
+        # ASL/CLI path runs. The model may arrive positionally or as the
+        # `model` keyword.
         from pyomo_pounce.sens import has_declarations, sens_solve
 
-        if args and has_declarations(args[0]):
-            return sens_solve(args[0], tee=kwds.get("tee", False))
+        model = args[0] if args else kwds.get("model")
+        if model is not None and has_declarations(model):
+            return sens_solve(model, tee=kwds.get("tee", False))
         return super().solve(*args, **kwds)
 
     def _default_executable(self):

--- a/pyomo-pounce/pyomo_pounce/pounce_solver.py
+++ b/pyomo-pounce/pyomo_pounce/pounce_solver.py
@@ -33,6 +33,18 @@ class POUNCE(ASL):
         self._metasolver = False
         self.options.solver = "pounce"
 
+    def solve(self, *args, **kwds):
+        # When the model declares sensitivity parameters
+        # (pyomo_pounce.declare_sens_param), solve in-process through the
+        # pounce.Solver session so the converged KKT factorization stays
+        # available for gradient()/estimate(). Otherwise the ordinary
+        # ASL/CLI path runs.
+        from pyomo_pounce.sens import has_declarations, sens_solve
+
+        if args and has_declarations(args[0]):
+            return sens_solve(args[0], tee=kwds.get("tee", False))
+        return super().solve(*args, **kwds)
+
     def _default_executable(self):
         # Prefer the binary bundled in the installed ``pounce-solver`` wheel,
         # whose location is deterministic (``pounce/bin/pounce`` inside the

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1,0 +1,344 @@
+"""Declared-parameter sensitivity for Pyomo models solved with POUNCE.
+
+Declare which parameters matter when you build the model -- no perturbed
+values required -- then solve normally. The converged KKT factorization is
+kept, and every sensitivity is a cheap backsolve afterwards:
+
+    import pyomo_pounce
+    from pyomo_pounce import declare_sens_param, gradient, estimate
+
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    declare_sens_param(m.p)
+
+    pyo.SolverFactory("pounce").solve(m)     # normal solve
+
+    gradient(m.x, wrt=m.p)                   # dx*/dp (float)
+    gradient(m.x, wrt=m.p2)                  # containers -> Gradient object
+    gradient(m.c, wrt=m.p)                   # d(multiplier of c)/dp
+    estimate(m, [(m.p, 2.5)])                # perturbed-solution estimate,
+                                             # clamped to bounds, warns on clamp
+
+Mechanics: declared Params become pinned variables on a clone
+(pyomo.contrib.sensitivity_toolbox does the expression surgery), the clone
+is written to .nl and evaluated in-process via pounce.read_nl, and the
+pounce.Solver session's parametric_step answers gradient()/estimate()
+queries from the stored factorization -- the sIPOPT computation, with no
+suffixes and no upfront perturbation values.
+"""
+import os
+import tempfile
+import warnings
+
+import numpy as np
+import pyomo.environ as pyo
+from pyomo.common.collections import ComponentMap
+from pyomo.contrib.sensitivity_toolbox.sens import SensitivityInterface
+from pyomo.core.base.constraint import Constraint
+
+_REG = "_pounce_sens"
+
+
+# ── declaration ───────────────────────────────────────────────────────────────
+
+class _Registry:
+    """Per-model sensitivity registry. Deepcopy-aware so model.clone() (and
+    the sensitivity surgery's own clone) works cleanly: declared parameters
+    follow the clone through the memo, while the session -- which holds
+    solver handles tied to one converged factorization -- is deliberately
+    not copied (a clone has no solve of its own yet)."""
+
+    def __init__(self):
+        self.params = []
+        self.session = None
+
+    def __deepcopy__(self, memo):
+        import copy
+        new = _Registry()
+        memo[id(self)] = new
+        new.params = [copy.deepcopy(p, memo) for p in self.params]
+        return new
+
+
+def declare_sens_param(param):
+    """Flag a mutable Param (or fixed Var), scalar or indexed, for
+    sensitivity. No perturbed value is required, or accepted."""
+    model = param.model()
+    reg = model.__dict__.setdefault(_REG, _Registry())
+    reg.params.append(param)
+
+
+def has_declarations(model):
+    reg = getattr(model, "__dict__", {}).get(_REG)
+    return bool(reg and reg.params)
+
+
+# ── the read_nl -> callback-Problem bridge ────────────────────────────────────
+
+class _NlBridge:
+    """cyipopt-style callback object backed by pounce.read_nl evaluators."""
+
+    def __init__(self, nl):
+        self._nl = nl
+
+    def objective(self, x):
+        return self._nl.objective(x)
+
+    def gradient(self, x):
+        return self._nl.gradient(x)
+
+    def constraints(self, x):
+        return self._nl.constraints(x)
+
+    def jacobianstructure(self):
+        return self._nl.jacobian_structure()
+
+    def jacobian(self, x):
+        return self._nl.jacobian(x)
+
+    def hessianstructure(self):
+        return self._nl.hessian_structure()
+
+    def hessian(self, x, lam, obj_factor):
+        return self._nl.hessian(x, lam, obj_factor)
+
+
+# ── session ───────────────────────────────────────────────────────────────────
+
+class _Session:
+    def __init__(self, model, nl, solver, var_names, con_names, pins,
+                 con_alias):
+        self.model = model            # original model
+        self.nl = nl
+        self.solver = solver
+        self.var_names = var_names    # .col order = x-vector order
+        self.con_names = con_names    # .row order = g-vector order
+        self.pins = pins              # ComponentMap: param data -> pin row
+        self.con_alias = con_alias    # original con name -> clone row name
+        self.base_x = None
+        self._columns = {}            # pin row -> full KKT-space column
+
+    def orig_var(self, name):
+        return self.model.find_component(name)
+
+    def column(self, pin_idx):
+        """Full KKT-space derivative column for a unit perturbation."""
+        if pin_idx not in self._columns:
+            self._columns[pin_idx] = np.asarray(
+                self.solver.parametric_step_full([pin_idx], [1.0]))
+        return self._columns[pin_idx]
+
+    def var_entry(self, name):
+        return self.var_names.index(name)
+
+    def mult_entry(self, con_name):
+        # the sensitivity surgery replaces user constraints with copies on
+        # its data block; translate the original name to the clone's row
+        con_name = self.con_alias.get(con_name, con_name)
+        g = self.con_names.index(con_name)
+        row = self.solver.multiplier_rows([g])[0]
+        if row is None:
+            raise ValueError(
+                f"{con_name}: multiplier sensitivities are only available "
+                "for equality constraints")
+        return row
+
+
+def _iter_data(comp):
+    if comp.is_indexed():
+        for idx in comp:
+            yield comp[idx]
+    else:
+        yield comp
+
+
+def sens_solve(model, tee=False):
+    """Solve `model` in-process with POUNCE and keep the KKT factorization
+    for gradient()/estimate(). Called automatically by
+    SolverFactory('pounce').solve() when declarations are present."""
+    import pounce
+
+    reg = model.__dict__[_REG]
+    si = SensitivityInterface(model, clone_model=True)
+    si.setup_sensitivity(reg.params)
+    clone = si.model_instance
+
+    tmp = tempfile.mkdtemp(prefix="pounce_sens_")
+    nl_path = os.path.join(tmp, "model.nl")
+    clone.write(nl_path, io_options={"symbolic_solver_labels": True})
+    var_names = open(nl_path[:-3] + ".col").read().splitlines()
+    con_names = open(nl_path[:-3] + ".row").read().splitlines()
+
+    nl = pounce.read_nl(nl_path)
+    prob = pounce.Problem(nl.n, nl.m, _NlBridge(nl),
+                          lb=nl.x_l, ub=nl.x_u, cl=nl.g_l, cu=nl.g_u)
+    solver = pounce.Solver(prob)
+    x, info = solver.solve(np.asarray(nl.x0))
+    if tee:
+        print(info.get("status_msg", info))
+    if not solver.converged:
+        raise RuntimeError(
+            f"pounce did not converge: {info.get('status_msg')}")
+
+    block = clone.component(SensitivityInterface.get_default_block_name())
+    pins = ComponentMap()
+    for i, (var, clone_param, list_idx, comp_idx) in enumerate(
+            block._sens_data_list):
+        con = block.paramConst[i + 1]
+        orig_comp = reg.params[list_idx]
+        orig_data = (orig_comp if not orig_comp.is_indexed()
+                     else orig_comp[comp_idx])
+        pins[orig_data] = con_names.index(con.name)
+
+    # original-name -> clone-row-name aliases for the replaced constraints
+    con_alias = {}
+    if getattr(block, "_has_replaced_expressions", False):
+        for new_comp, old_comp in block._replaced_map.items():
+            for nd, od in zip(_iter_data(new_comp), _iter_data(old_comp)):
+                con_alias[od.name] = nd.name
+
+    session = _Session(model, nl, solver, var_names, con_names, pins,
+                       con_alias)
+    session.base_x = np.asarray(x)
+    reg.session = session
+
+    # load the solution back onto the ORIGINAL model's variables
+    for name, val in zip(var_names, session.base_x):
+        ov = model.find_component(name)
+        if ov is not None:
+            ov.set_value(val, skip_validation=True)
+    return info
+
+
+# ── queries ───────────────────────────────────────────────────────────────────
+
+def _session_for(component):
+    reg = component.model().__dict__.get(_REG)
+    if reg is None or reg.session is None:
+        raise RuntimeError(
+            "no sensitivity session: declare_sens_param() then solve with "
+            "SolverFactory('pounce') first")
+    return reg.session
+
+
+def _param_pin(session, param_data):
+    if param_data not in session.pins:
+        raise ValueError(f"{param_data.name} was not declared with "
+                         "declare_sens_param before the solve")
+    return session.pins[param_data]
+
+
+class Gradient:
+    """Derivatives d(target*)/d(param) for one or more targets/parameters.
+    Targets are variables (primal sensitivities) or equality constraints
+    (multiplier sensitivities).
+
+    Access with g[target_data, param_data] (either order); when one side is
+    a single component, g[data] works. to_dataframe() gives the full
+    Jacobian (rows = targets, columns = parameters)."""
+
+    def __init__(self, session, targets, params):
+        self._session = session
+        self._targets = list(targets)
+        self._params = list(params)
+        self._tset = set(id(t) for t in self._targets)
+        self._pset = set(id(p) for p in self._params)
+
+    def _entry(self, td):
+        if td.ctype is Constraint:
+            return self._session.mult_entry(td.name)
+        return self._session.var_entry(td.name)
+
+    def _value(self, td, pd):
+        col = self._session.column(_param_pin(self._session, pd))
+        return float(col[self._entry(td)])
+
+    def __getitem__(self, key):
+        if isinstance(key, tuple):
+            td, pd = key
+            if id(td) in self._pset and id(pd) in self._tset:
+                td, pd = pd, td            # accept either order
+            return self._value(td, pd)
+        if id(key) in self._tset and len(self._params) == 1:
+            return self._value(key, self._params[0])
+        if id(key) in self._pset and len(self._targets) == 1:
+            return self._value(self._targets[0], key)
+        raise KeyError(
+            f"{getattr(key, 'name', key)}: give g[target, param], or a "
+            "single component when the other dimension has exactly one "
+            "member")
+
+    def to_dataframe(self):
+        import pandas as pd
+        return pd.DataFrame(
+            [[self._value(td, p) for p in self._params]
+             for td in self._targets],
+            index=[td.name for td in self._targets],
+            columns=[p.name for p in self._params])
+
+
+def gradient(target=None, *, wrt):
+    """d(target*)/d(wrt).
+
+    target: a Var (primal sensitivity) or an equality Constraint (its
+    multiplier's sensitivity); data object or container; omit for all
+    model variables. wrt: a declared Param (data or container).
+
+    Scalar target and scalar wrt -> float. Anything else -> a Gradient
+    object: g[target, param], or g.to_dataframe() for the full Jacobian."""
+    session = _session_for(wrt)
+    params = list(_iter_data(wrt))
+    if target is None:
+        targets = [v for v in (session.orig_var(nm)
+                               for nm in session.var_names) if v is not None]
+    else:
+        targets = list(_iter_data(target))
+    if target is not None and not target.is_indexed() and len(params) == 1:
+        return Gradient(session, targets, params)._value(
+            targets[0], params[0])
+    return Gradient(session, targets, params)
+
+
+def estimate(model, perturb, clamp=True):
+    """First-order estimate of the solution at perturbed parameter values.
+
+    perturb: pairs of (declared Param, new value) -- a list of tuples or a
+    ComponentMap (plain dicts don't work: Pyomo components are unhashable).
+    Returns a ComponentMap {original var data: estimated value}. Values are
+    clamped to variable bounds (with a warning) unless clamp=False.
+    """
+    reg = model.__dict__.get(_REG)
+    session = reg.session if reg else None
+    if session is None:
+        raise RuntimeError(
+            "no sensitivity session: declare_sens_param() then solve with "
+            "SolverFactory('pounce') first")
+
+    items = perturb.items() if hasattr(perturb, "items") else perturb
+    pin_idx, deltas = [], []
+    for comp, newval in items:
+        for pd in _iter_data(comp):
+            nv = newval[pd.index()] if comp.is_indexed() and hasattr(
+                newval, "__getitem__") else newval
+            pin_idx.append(_param_pin(session, pd))
+            deltas.append(float(nv) - pyo.value(pd))
+
+    dx = np.asarray(session.solver.parametric_step(pin_idx, deltas))
+    x_new = session.base_x + dx
+
+    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
+    if clamp:
+        clipped = (x_new < lo - 1e-9) | (x_new > hi + 1e-9)
+        if clipped.any():
+            names = [session.var_names[i] for i in np.where(clipped)[0]]
+            warnings.warn(
+                "estimate: linear step leaves the variable bounds for "
+                f"{names}; values were clamped and the active set likely "
+                "changed, so the estimate is unreliable there.")
+        x_new = np.clip(x_new, lo, hi)
+
+    out = ComponentMap()
+    for name, val in zip(session.var_names, x_new):
+        ov = model.find_component(name)
+        if ov is not None:
+            out[ov] = float(val)
+    return out

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -26,14 +26,17 @@ queries from the stored factorization -- the sIPOPT computation, with no
 suffixes and no upfront perturbation values.
 """
 import os
+import shutil
 import tempfile
 import warnings
+from pathlib import Path
 
 import numpy as np
 import pyomo.environ as pyo
 from pyomo.common.collections import ComponentMap
 from pyomo.contrib.sensitivity_toolbox.sens import SensitivityInterface
 from pyomo.core.base.constraint import Constraint
+from pyomo.opt import SolverResults, SolverStatus, TerminationCondition
 
 _REG = "_pounce_sens"
 
@@ -154,7 +157,8 @@ def _iter_data(comp):
 def sens_solve(model, tee=False):
     """Solve `model` in-process with POUNCE and keep the KKT factorization
     for gradient()/estimate(). Called automatically by
-    SolverFactory('pounce').solve() when declarations are present."""
+    SolverFactory('pounce').solve() when declarations are present.
+    Returns a Pyomo SolverResults, like an ordinary solve."""
     import pounce
 
     reg = model.__dict__[_REG]
@@ -162,13 +166,20 @@ def sens_solve(model, tee=False):
     si.setup_sensitivity(reg.params)
     clone = si.model_instance
 
+    # The .nl/.col/.row files exist only to hand the model to read_nl;
+    # everything needed later (evaluators, bounds, names) lives in memory,
+    # so the temp dir is removed as soon as they are parsed. Repeated
+    # solves (the NMPC use case) must not accumulate temp dirs.
     tmp = tempfile.mkdtemp(prefix="pounce_sens_")
-    nl_path = os.path.join(tmp, "model.nl")
-    clone.write(nl_path, io_options={"symbolic_solver_labels": True})
-    var_names = open(nl_path[:-3] + ".col").read().splitlines()
-    con_names = open(nl_path[:-3] + ".row").read().splitlines()
+    try:
+        nl_path = os.path.join(tmp, "model.nl")
+        clone.write(nl_path, io_options={"symbolic_solver_labels": True})
+        var_names = Path(nl_path[:-3] + ".col").read_text().splitlines()
+        con_names = Path(nl_path[:-3] + ".row").read_text().splitlines()
+        nl = pounce.read_nl(nl_path)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
 
-    nl = pounce.read_nl(nl_path)
     prob = pounce.Problem(nl.n, nl.m, _NlBridge(nl),
                           lb=nl.x_l, ub=nl.x_u, cl=nl.g_l, cu=nl.g_u)
     solver = pounce.Solver(prob)
@@ -206,7 +217,18 @@ def sens_solve(model, tee=False):
         ov = model.find_component(name)
         if ov is not None:
             ov.set_value(val, skip_validation=True)
-    return info
+
+    # Return a Pyomo SolverResults so callers see the same shape as an
+    # ordinary solve (res.solver.termination_condition etc).
+    results = SolverResults()
+    results.solver.name = "pounce (in-process sensitivity session)"
+    results.solver.status = SolverStatus.ok
+    results.solver.termination_condition = TerminationCondition.optimal
+    results.solver.message = str(info.get("status_msg", ""))
+    if info.get("obj_val") is not None:
+        results.problem.upper_bound = float(info["obj_val"])
+        results.problem.lower_bound = float(info["obj_val"])
+    return results
 
 
 # ── queries ───────────────────────────────────────────────────────────────────
@@ -327,7 +349,9 @@ def estimate(model, perturb, clamp=True):
 
     lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
     if clamp:
-        clipped = (x_new < lo - 1e-9) | (x_new > hi + 1e-9)
+        # scale-aware tolerance: 1e-9 relative to the variable's magnitude
+        tol = 1e-9 * np.maximum(1.0, np.abs(x_new))
+        clipped = (x_new < lo - tol) | (x_new > hi + tol)
         if clipped.any():
             names = [session.var_names[i] for i in np.where(clipped)[0]]
             warnings.warn(

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pyomo>=6.0",
     "pounce-solver>=0.1",
     "numpy",
+    "pandas",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -18,6 +18,7 @@ authors = [{name = "John Kitchin", email = "jkitchin@andrew.cmu.edu"}]
 dependencies = [
     "pyomo>=6.0",
     "pounce-solver>=0.1",
+    "numpy",
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -126,3 +126,40 @@ def test_resolve_and_clone_are_clean():
     assert g1 != g2                              # new factorization was used
     from pyomo_pounce.sens import has_declarations
     assert has_declarations(clone)               # declarations survive clone
+
+
+def test_declared_solve_returns_solver_results():
+    """The declared path must return the same result shape as a plain
+    Pyomo solve (review #199 item 2)."""
+    m = build()
+    declare_sens_param(m.p)
+    res = pyo.SolverFactory("pounce").solve(m)
+    assert (res.solver.termination_condition
+            == pyo.TerminationCondition.optimal)
+    assert str(res.solver.status) == "ok"
+
+
+def test_no_temp_dir_leak(tmp_path):
+    """Repeated declared solves must not accumulate pounce_sens_* temp
+    dirs (review #199 item 1)."""
+    import glob
+    import os
+    import tempfile
+
+    pattern = os.path.join(tempfile.gettempdir(), "pounce_sens_*")
+    before = set(glob.glob(pattern))
+    m = build()
+    declare_sens_param(m.p)
+    for _ in range(3):
+        pyo.SolverFactory("pounce").solve(m)
+    after = set(glob.glob(pattern))
+    assert after == before, f"leaked: {after - before}"
+
+
+def test_keyword_model_solve_uses_declared_path():
+    """solve(model=m) must hit the sensitivity path too (review #199
+    item 4)."""
+    m = build()
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(model=m)
+    assert gradient(m.x, wrt=m.p) is not None

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -1,0 +1,128 @@
+"""Tests for pyomo_pounce.sens: declared-parameter sensitivity."""
+import warnings
+
+import pytest
+import pyomo.environ as pyo
+
+import pyomo_pounce  # noqa: F401  (registers 'pounce')
+from pyomo_pounce import declare_sens_param, estimate, gradient
+
+FD_H = 1e-5
+
+
+def build(p=2.0, q=1.0):
+    """min (x-p)^2 + (y-q)^2 + 0.1 exp(x+y), x <= 3, one equality tying a
+    third variable (for multiplier sensitivities)."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(initialize=1.0, bounds=(None, 3.0))
+    m.y = pyo.Var(initialize=1.0)
+    m.w = pyo.Var(initialize=0.0)
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.q = pyo.Param(initialize=q, mutable=True)
+    m.tie = pyo.Constraint(expr=m.w == m.x + m.y)     # equality, has a dual
+    m.obj = pyo.Objective(
+        expr=(m.x - m.p) ** 2 + (m.y - m.q) ** 2 + 0.1 * pyo.exp(m.w)
+        + 0.01 * m.w**2)
+    return m
+
+
+def solve_plain(m):
+    m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+@pytest.fixture(scope="module")
+def solved():
+    m = build()
+    declare_sens_param(m.p)
+    declare_sens_param(m.q)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def test_gradient_matches_finite_difference(solved):
+    m = solved
+    for pname in ("p", "q"):
+        g = gradient(m.x, wrt=getattr(m, pname))
+        assert isinstance(g, float)
+        hi = build(**{pname: pyo.value(getattr(m, pname)) + FD_H})
+        lo = build(**{pname: pyo.value(getattr(m, pname)) - FD_H})
+        solve_plain(hi)
+        solve_plain(lo)
+        fd = (pyo.value(hi.x) - pyo.value(lo.x)) / (2 * FD_H)
+        assert g == pytest.approx(fd, abs=1e-4)
+
+
+def test_multiplier_gradient_matches_finite_difference(solved):
+    m = solved
+    g = gradient(m.tie, wrt=m.p)
+    hi = solve_plain(build(p=2.0 + FD_H))
+    lo = solve_plain(build(p=2.0 - FD_H))
+    fd = (hi.dual[hi.tie] - lo.dual[lo.tie]) / (2 * FD_H)
+    assert abs(g) == pytest.approx(abs(fd), abs=1e-4)
+    assert g == pytest.approx(fd, abs=1e-4), (
+        "sign convention mismatch between parametric_step_full's y_c block "
+        "and pyomo duals")
+
+
+def test_estimate_matches_resolve(solved):
+    m = solved
+    est = estimate(m, [(m.p, 2.2), (m.q, 0.9)])
+    mt = solve_plain(build(p=2.2, q=0.9))
+    assert est[m.x] == pytest.approx(pyo.value(mt.x), abs=5e-3)
+    assert est[m.y] == pytest.approx(pyo.value(mt.y), abs=5e-3)
+
+
+def test_estimate_clamps_and_warns(solved):
+    m = solved
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        est = estimate(m, [(m.p, 8.0)])       # drives x past its bound of 3
+    assert any("clamped" in str(wi.message) for wi in w)
+    assert est[m.x] <= 3.0 + 1e-9
+
+
+def test_gradient_object_for_containers(solved):
+    m = solved
+    G = gradient(m.x, wrt=m.p)          # scalar -> float
+    assert isinstance(G, float)
+    Gall = gradient(wrt=m.p)            # all variables
+    assert Gall[m.x] == pytest.approx(G)
+    df_cols = gradient(wrt=m.q).to_dataframe()
+    assert "x" in df_cols.index
+
+
+def test_plain_solve_unaffected():
+    m = build()                          # no declarations
+    res = pyo.SolverFactory("pounce").solve(m)
+    assert pyo.value(m.obj) == pytest.approx(1.2653, abs=1e-3)
+    with pytest.raises(RuntimeError, match="no sensitivity session"):
+        gradient(m.x, wrt=m.p)
+
+
+def test_resolve_and_clone_are_clean():
+    """Solving twice (or cloning) must not trip Pyomo's uncopyable-field
+    error: the registry deepcopies its declarations but not the session."""
+    import io
+    import logging
+
+    buf = io.StringIO()
+    h = logging.StreamHandler(buf)
+    logging.getLogger("pyomo").addHandler(h)
+    try:
+        m = build()
+        declare_sens_param(m.p)
+        pyo.SolverFactory("pounce").solve(m)
+        g1 = gradient(m.x, wrt=m.p)
+        m.p = 2.5
+        pyo.SolverFactory("pounce").solve(m)     # re-solve re-clones
+        g2 = gradient(m.x, wrt=m.p)
+        clone = m.clone()
+    finally:
+        logging.getLogger("pyomo").removeHandler(h)
+    log = buf.getvalue()
+    assert "Unable to clone" not in log and "uncopyable" not in log, log
+    assert g1 != g2                              # new factorization was used
+    from pyomo_pounce.sens import has_declarations
+    assert has_declarations(clone)               # declarations survive clone

--- a/python/notebooks/25_pyomo_sensitivity.ipynb
+++ b/python/notebooks/25_pyomo_sensitivity.ipynb
@@ -1,0 +1,499 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b281119",
+   "metadata": {},
+   "source": [
+    "# Pyomo parametric sensitivity: quad-tank optimal control\n",
+    "\n",
+    "Declared-parameter sensitivity through `pyomo_pounce`: flag the four\n",
+    "initial conditions as parameters, solve the OCP once, then read exact\n",
+    "derivatives and perturbed-solution estimates off the stored KKT\n",
+    "factorization. The first-move gradients are the NMPC feedback gains.\n",
+    "\n",
+    "Extra dependency beyond `pounce-solver` + `pyomo-pounce`: the control\n",
+    "parameterization uses [`pyomo-cvp`](https://pypi.org/project/pyomo-cvp/)\n",
+    "(`pip install pyomo-cvp`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a93de42f-efd2-4a7c-853c-e6ae9b764e2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:08.305810Z",
+     "iopub.status.busy": "2026-07-11T20:06:08.305810Z",
+     "iopub.status.idle": "2026-07-11T20:06:09.576200Z",
+     "shell.execute_reply": "2026-07-11T20:06:09.574804Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from pyomo.environ import (\n",
+    "    ConcreteModel, Set, RangeSet, Var, Param, Constraint, minimize,\n",
+    "    NonNegativeReals, sqrt, Objective, TransformationFactory,\n",
+    "    SolverFactory, value)\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pyomo.dae import ContinuousSet, DerivativeVar\n",
+    "from pyomo_cvp import declare_profile, control_value\n",
+    "import pyomo_pounce  # registers 'pounce' with SolverFactory\n",
+    "from pyomo_pounce import declare_sens_param, gradient, estimate\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ec6b729",
+   "metadata": {},
+   "source": [
+    "Sets\n",
+    "\n",
+    "$\\mathcal{I} = \\{1, 2, 3, 4\\}$ tanks \\\n",
+    "$\\mathcal{K} = \\{1, 2\\}$ pumps\n",
+    "\n",
+    "Parameters\n",
+    "\n",
+    "$A_i$ tank cross-section area (cm²) \\\n",
+    "$a_i$ tank outlet area (cm²) \\\n",
+    "$x_i^{ss}$ steady-state level (cm) \\\n",
+    "$u_k^{ss}$ steady-state pump flow (ml/s) \\\n",
+    "$\\gamma_k$ pump-$k$ flow-split ratio \\\n",
+    "$x_i^L, x_i^U$ per-tank level bounds (cm) \\\n",
+    "$T$ horizon (s), $g = 981$ cm/s²\n",
+    "\n",
+    "Variables\n",
+    "\n",
+    "$x_i(t)$ level in tank $i$ (cm) \\\n",
+    "$u_k(t)$ pump-$k$ flow rate (ml/s) \\\n",
+    "$z_i(t) = x_i(t) - x_i^{ss}$ level deviation \\\n",
+    "$v_k(t) = u_k(t) - u_k^{ss}$ flow deviation\n",
+    "\n",
+    "Objective\n",
+    "\n",
+    "\\begin{gather}\n",
+    " \\min_{x(\\cdot),\\, u(\\cdot)} \\sum_{j=0}^{N} \\sum_{i \\in \\mathcal{I}} z_i(t_j)^2\n",
+    "\\end{gather}\n",
+    "\n",
+    "where $t_j$ are the finite element boundaries.\n",
+    "\n",
+    "Subject to (mass balance with flow split through pump valves):\n",
+    "\n",
+    "\\begin{align}\n",
+    " \\dot{x}_1 &= -\\tfrac{a_1}{A_1}\\sqrt{2 g x_1} + \\tfrac{a_3}{A_1}\\sqrt{2 g x_3} + \\tfrac{\\gamma_1}{A_1} u_1 \\\\\n",
+    " \\dot{x}_2 &= -\\tfrac{a_2}{A_2}\\sqrt{2 g x_2} + \\tfrac{a_4}{A_2}\\sqrt{2 g x_4} + \\tfrac{\\gamma_2}{A_2} u_2 \\\\\n",
+    " \\dot{x}_3 &= -\\tfrac{a_3}{A_3}\\sqrt{2 g x_3} + \\tfrac{1 - \\gamma_2}{A_3} u_2 \\\\\n",
+    " \\dot{x}_4 &= -\\tfrac{a_4}{A_4}\\sqrt{2 g x_4} + \\tfrac{1 - \\gamma_1}{A_4} u_1\n",
+    "\\end{align}\n",
+    "\n",
+    "with initial condition $x_i(0) = x_i^0$, pump bounds $0 \\le u_k(t) \\le 60$ ml/s, and level bounds $x_i^L \\le x_i(t) \\le x_i^U$.\n",
+    "\n",
+    "Solved by simultaneous direct transcription with orthogonal collocation on finite elements (Radau-IIA, 3 collocation points per element) via pyomo.dae, with the piecewise-constant controls reduced to one free value per element by pyomo-cvp. The resulting NLP is handed to POUNCE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0d5180ff-dd96-4644-89ce-7527b8b34e12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:09.579204Z",
+     "iopub.status.busy": "2026-07-11T20:06:09.579204Z",
+     "iopub.status.idle": "2026-07-11T20:06:09.599271Z",
+     "shell.execute_reply": "2026-07-11T20:06:09.599271Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "#Define the model\n",
+    "m = ConcreteModel()\n",
+    "\n",
+    "\n",
+    "# ── Discretisation ─────────────────────────────────────────────────────────────\n",
+    "# The optimal control problem is solved via direct collocation (Radau IIA, 3-point).\n",
+    "# The time horizon [0, N*h] = [0, 150 s] is divided into N finite elements,\n",
+    "# each of length h = 10 s, with ncp = 3 Radau collocation points per element.\n",
+    "\n",
+    "#sets\n",
+    "h = 10 #step size\n",
+    "N = 15  # Number of finite elements\n",
+    "m.i = ContinuousSet(initialize=RangeSet(0,N*h,h))\n",
+    "m.t = Set(initialize=RangeSet(1,4)) # Set of tanks\n",
+    "\n",
+    "# ── Variables ──────────────────────────────────────────────────────────────────\n",
+    "# All state variables are expressed as DEVIATIONS from steady state (z = x - x_ss).\n",
+    "# This formulation simplifies the objective and boundary conditions.\n",
+    "\n",
+    "#variables\n",
+    "\n",
+    "# z_k[i]: state of tank k at time i\n",
+    "# Bounds enforce physical height limits (z = x - x_ss, so bounds = [x_min - x_ss, x_max - x_ss])\n",
+    "m.z1 = Var(m.i, bounds = (-6.5,14))\n",
+    "m.z2 = Var(m.i, bounds = (-6.5,14))\n",
+    "m.z3 = Var(m.i, bounds = (-10.7,13.8))\n",
+    "m.z4 = Var(m.i, bounds = (-16.8,6.7))\n",
+    "\n",
+    "#derivative dz/dt at time i\n",
+    "m.z1dot = DerivativeVar(m.z1, wrt=m.i)\n",
+    "m.z2dot = DerivativeVar(m.z2, wrt=m.i)\n",
+    "m.z3dot = DerivativeVar(m.z3, wrt=m.i)\n",
+    "m.z4dot = DerivativeVar(m.z4, wrt=m.i)\n",
+    "\n",
+    "\n",
+    "# v_k[i]: control input DEVIATION from steady state (u_k = v_k + u_ss_k);\n",
+    "# piecewise-constant, one free value per element, applied over the element\n",
+    "# STARTING at time i (the pyomo-cvp convention)\n",
+    "# Bounds correspond to allowable pump flow deviations (ml/s)\n",
+    "m.v1 = Var(m.i,bounds = (-43.4,16.6))\n",
+    "declare_profile(m.v1, wrt=m.i, profile=\"piecewise_constant\")\n",
+    "m.v2 = Var(m.i, bounds = (-35.4,24.6))\n",
+    "declare_profile(m.v2, wrt=m.i, profile=\"piecewise_constant\")\n",
+    "\n",
+    "# Scalar tracking variable: holds the summed squared deviations (the objective value)\n",
+    "m.track = Var(within=NonNegativeReals)\n",
+    "\n",
+    "# ── Parameters ─────────────────────────────────────────────────────────────────\n",
+    "\n",
+    "#parameters\n",
+    "m.smalla = Param(m.t, initialize = {1: .233, 2: .242, 3: .127, 4: .127})   # Drain nozzle areas a_k (cm²)\n",
+    "m.biga = Param(m.t, initialize = {1: 50.27, 2: 50.27, 3: 28.27, 4: 28.27}) # Tank cross-sections A_k (cm²)\n",
+    "m.xss = Param(m.t, initialize = {1: 14, 2: 14, 3: 14.2, 4: 21.3})          # Steady-state heights x_ss (cm)\n",
+    "m.uss = Param(RangeSet(1,2), initialize = {1: 43.4, 2: 35.4})           # Steady-state pump flows u_ss (ml/s)\n",
+    "m.g = Param(initialize = 981)     # Gravitational acceleration (cm/s²)\n",
+    "m.gamma = Param(initialize = .4)  # Flow split fraction: γ to lower tank, (1-γ) to upper tank\n",
+    "m.h = Param(initialize = 10)      # Finite element length (s); total horizon = N*h = 150 s\n",
+    "\n",
+    "\n",
+    "# Initial conditions: deviation from steady state at t=0 (cm)\n",
+    "m.z1init = Param(initialize = 5, mutable=True)\n",
+    "m.z2init = Param(initialize = -5, mutable=True)\n",
+    "m.z3init = Param(initialize = 5, mutable=True)\n",
+    "m.z4init = Param(initialize = -5, mutable=True)\n",
+    "\n",
+    "# Flag the four initial conditions for sensitivity: no perturbed values,\n",
+    "# just a declaration (pounce keeps the KKT factorization after the solve).\n",
+    "declare_sens_param(m.z1init)\n",
+    "declare_sens_param(m.z2init)\n",
+    "declare_sens_param(m.z3init)\n",
+    "declare_sens_param(m.z4init)\n",
+    "\n",
+    "# ── Differential equations (enforced at every discretized time point) ──────────\n",
+    "# Torricelli drain law + pump inflow, written in deviation form:\n",
+    "#   A_k * dz_k/dt = -a_k*sqrt(2g*(z_k + x_ss_k)) + inflows\n",
+    "#\n",
+    "# Tank 1 (lower-left): drains via nozzle a1, receives γ*u1 from pump 1 and outflow from Tank 3\n",
+    "# Tank 2 (lower-right): drains via nozzle a2, receives γ*u2 from pump 2 and outflow from Tank 4\n",
+    "# Tank 3 (upper-left): drains via nozzle a3 into Tank 1, receives (1-γ)*u2 from pump 2\n",
+    "# Tank 4 (upper-right): drains via nozzle a4 into Tank 2, receives (1-γ)*u1 from pump 1\n",
+    "\n",
+    "#differential equations\n",
+    "\n",
+    "@m.Constraint(m.i)\n",
+    "def z1dot_def(m,i): \n",
+    "    return m.z1dot[i] == -(m.smalla[1]/m.biga[1])*sqrt(2*m.g*(m.z1[i]+m.xss[1]))+(m.smalla[3]/m.biga[1])*sqrt(2*m.g*(m.z3[i]+m.xss[3]))+(m.gamma/m.biga[1])*(m.v1[i]+m.uss[1]) \n",
+    "\n",
+    "@m.Constraint(m.i)\n",
+    "def z2dot_def(m,i): \n",
+    "    return m.z2dot[i] == -(m.smalla[2]/m.biga[2])*sqrt(2*m.g*(m.z2[i]+m.xss[2]))+(m.smalla[4]/m.biga[2])*sqrt(2*m.g*(m.z4[i]+m.xss[4]))+(m.gamma/m.biga[2])*(m.v2[i]+m.uss[2]) \n",
+    "\n",
+    "@m.Constraint(m.i)\n",
+    "def z3dot_def(m,i): \n",
+    "    return m.z3dot[i] == -(m.smalla[3]/m.biga[3])*sqrt(2*m.g*(m.z3[i]+m.xss[3]))+((1-m.gamma)/m.biga[3])*(m.v2[i]+m.uss[2])\n",
+    "\n",
+    "@m.Constraint(m.i)\n",
+    "def z4dot_def(m,i):\n",
+    "    return m.z4dot[i] == -(m.smalla[4]/m.biga[4])*sqrt(2*m.g*(m.z4[i]+m.xss[4]))+((1-m.gamma)/m.biga[4])*(m.v1[i]+m.uss[1])\n",
+    "\n",
+    "# ── Initial conditions ─────────────────────────────────────────────────────────\n",
+    "# Fix the state at t=0 to the specified initial deviation.\n",
+    "@m.Constraint()\n",
+    "def z1init_def(m):\n",
+    "    return m.z1[0] == m.z1init\n",
+    "\n",
+    "@m.Constraint()\n",
+    "def z2init_def(m):\n",
+    "    return m.z2[0] == m.z2init\n",
+    "\n",
+    "@m.Constraint()\n",
+    "def z3init_def(m):\n",
+    "    return m.z3[0] == m.z3init\n",
+    "\n",
+    "\n",
+    "@m.Constraint()\n",
+    "def z4init_def(m):\n",
+    "    return m.z4[0] == m.z4init\n",
+    "\n",
+    "\n",
+    "# ── Objective ──────────────────────────────────────────────────────────────────\n",
+    "# Minimise the sum of squared state deviations over the element boundaries.\n",
+    "# track = Σ_j (z1[t_j]² + z2[t_j]² + z3[t_j]² + z4[t_j]²)\n",
+    "# Declared BEFORE dae.collocation, so m.i still holds only the seeded\n",
+    "# boundaries and the sum stays boundary-only (collocation points added\n",
+    "# later never enter this expression).\n",
+    "@m.Constraint()\n",
+    "def tracking_def(m):\n",
+    "    return m.track == sum(m.z1[i]**2 + m.z2[i]**2 + m.z3[i]**2 + m.z4[i]**2 for i in m.i)\n",
+    "\n",
+    "m.obj = Objective(expr = m.track, sense = minimize)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "08ff0ec5-0f77-45c7-b744-57b5746ba512",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:09.602278Z",
+     "iopub.status.busy": "2026-07-11T20:06:09.602278Z",
+     "iopub.status.idle": "2026-07-11T20:06:10.380170Z",
+     "shell.execute_reply": "2026-07-11T20:06:10.380170Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "track = 236.3517\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Transform and solve. With sensitivity parameters declared, the ordinary\n",
+    "# pounce solve keeps the converged KKT factorization for the queries below.\n",
+    "TransformationFactory(\"dae.collocation\").apply_to(\n",
+    "    m, nfe=N, ncp=3, scheme=\"LAGRANGE-RADAU\")\n",
+    "TransformationFactory(\"cvp.parameterize\").apply_to(m)\n",
+    "SolverFactory(\"pounce\").solve(m)\n",
+    "print(f\"track = {value(m.track):.4f}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4a420b38-3c3a-49c8-885a-4a1c2b8b5228",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:10.383177Z",
+     "iopub.status.busy": "2026-07-11T20:06:10.383177Z",
+     "iopub.status.idle": "2026-07-11T20:06:10.501842Z",
+     "shell.execute_reply": "2026-07-11T20:06:10.501842Z"
+    },
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjUAAAGwCAYAAABRgJRuAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAX5tJREFUeJzt3Qd4VFXeBvB3ZjJJJr2RBEjooYTQVUSQolh2VUQsWBFFXf2sq7uW1V2RdVfddV1XXVF07WJHxYaiiAWk10gNLQmEJKQnM0kmM/M959yZYdIgwEzu3Dvvz+d679ScO4Hk5Zz/PcfgcrlcICIiItI4o9oNICIiIvIHhhoiIiLSBYYaIiIi0gWGGiIiItIFhhoiIiLSBYYaIiIi0gWGGiIiItKFMIQQp9OJAwcOIDY2FgaDQe3mEBERUQeIKfVqamrQrVs3GI3t98eEVKgRgSYzM1PtZhAREdFxKCgoQEZGRruPh1SoET00ng8lLi5O7eYQERFRB1RXV8tOCc/v8faEVKjxDDmJQMNQQ0REpC1HKx1hoTARERHpAkMNERER6QJDDREREelCSNXUEBERBfO0I42NjQhFZrMZJpPphN+HoYaIiEhlIszs2bNHBptQlZCQgPT09BOaR46hhoiISOWJ5YqKimRPhbhs+UiTy+n1/K1WK0pKSuTtrl27Hvd7MdQQERGpqKmpSf5SF7PlRkVFheT3wmKxyL0INqmpqcc9FBVacZCIiCjIOBwOuQ8PD0coi3IHOrvdftzvwVBDREQUBEJ9TUKDH86foYaIiIh0gaGGiIiIdIGhhoiIiHSBoUbjl8HV1B9/QRUREVEg1NfXY+bMmRgyZAjCwsIwdepUdAZe0q3BILOhoBJfbCrCV7kHUVRlwz8uGYZLRmWo3TQiIiLvFV3iMu077rgDH330EToLQ41Ggsymwip8sblIhpn9lbZmj/9pwWb0S43B8MwE1dpIRET++5lvsyuXeXc2i9nU4auQ9u7di969e7e6f8KECVi6dCnmzp0rby9btgyVlZXoDAw1QfyHevP+KhliRJgprDgcZKLCTZg8KA2/HdIVH60rxOItxbj5zbX47PZx6BIboWq7iYjoxIhAk/2Xr1X5GLfMOQdR4R2LBmL2YzETssfBgwcxefJkjB8/HmphqAmyIPPrgWp8LoPMARSU25ql5zMHpeL8oV0xcUAqIs3KbItj+yVj6n+XYVdpHW59ex3eumE0wsNYKkVERIElZv0VazV5amhE3cyYMWMwe/Zs1T56hpogCTKiN+bLzUXYV2ZtFmTOEEFmiBJkLOGtp42OjTRj3oyTMPW5ZVi1txyPfrEFcy7M6eSzICIifxE/+0WPiVpf+3jMmjULNTU1WLx4saprVzHUqBRkthbVyN4YMby01yfIRJqNOGNgKs4b0g2TBnbpUDdg3y4x+Pf04bjhjTV445d9yOkej8tOygzwWRARUSCImpaODgEFg0cffRSLFi3CqlWrEBsbq2pbtPOp6SDIbDtYI0OM6JHZfajO+1hEmDvIDO2KSQNSER1x7N+WydlpuGtyFp7+dice+iQXA9JiMYyFw0REFEDiyqY5c+bgq6++Qt++faE2hpoAB5kdxbX4YtMBfC6CTOnhICPqXiYN6ILzhnbDmQOPL8i0dMcZWcjdX41vtxbjdywcJiKiAMrNzcWMGTNw3333YfDgwbJQ2LMwZ1JSErZs2YLGxkaUl5fLoakNGzbIx4cPHx6wNhlc4jdviKiurkZ8fDyqqqoQFxcXsK+zo7hGFvuKHpm8ktpmQWZC/y6y2PfMQWmI8UOQaUlMxnfhf5fJAHVKryS8feNomE0sHCYiClaiyHbPnj3y8ujIyEhoxWuvvYbrrruu3Uu6e/XqhX379rV6vL3YcaTPoaO/vxlq/GRV/h78uL0WX28ux07fIGMyYrw3yKTKwt5AE0FKXBFV29CEa8f0xCMsHCYiClpaDTX+5o9Qw+EnPxj96jRYjTthzb8OjroBMJsMGJ8lhpa6ylqXuE4IMr7ERHyicPjGN9bgdXfh8KUsHCYiIp1jqPGDBHMXWB07kZVZiRuHDJNBJt7SuUGmpbOy03DnmVn4z3c78eAnuejPwmEiItI5Flv4wfkDT5b77F61uHhUhuqBxkOEGjHzcGOTEze/tRalNQ1qN4mIiChgGGr8YHT3oXK/pWwLgonRaMBT04ehT5doFFXV49b562B3ONVuFhERUUAw1PjBwOSBcr+/dj+qGqoQTEQ9z7xrTpJXWq3aU46/fbFV7SYREREFBEONH8SFxyEjJkMebyvfhmAjCoefumyYPH5t+V58sKZA7SYRERH5HUONnwxKHiT3W8uCsyfk7MHpuOPMLHksCoc3FXbOMvBERESdhaHGT7KTs+V+S3lw1dX4uksWDqfKwmEx4/ChWhYOExGRfjDU+MmgpODuqTlcODwcfVKUwuH/e5uFw0REpB8MNX4yMEkpFt5XvQ919sNrPAUbWTg8YxQLh4mIKGDEMgkXXnghunbtiujoaLne09tvv41AY6jxk2RLMtKi0uCCC9vLtyOY9UuNbVY4/NHaQrWbREREOrJ8+XIMHTpUruK9adMmXH/99XLxy88++yygX5czCvu5WLjYWoyt5VsxMm0kgpmncPiZ73bigY83IystBkMzEtRuFhERacTevXvlOk3tLWjp64477sDXX3+Njz/+GBdccEHA2sRQ40fZSdlYWrA06CbhO1Lh8K/7q/DdthLc/OZaLLx9HFJiItRuFhFRaBOrWNut6nxtcxRgMHToqZmZmSgqKvLePnjwICZPnozx48e3+XyxGOWgQUr9aaAw1ATisu7y4C0Wblk4/O/Lh2Pqc8uw+1Adbn17Hd66YTTMJo5KEhGpRgSav3dT52v/6QAQHt2hp5pMJqSnp3tX2J46dSrGjBmD2bNnt3ruhx9+iNWrV+PFF19EIPG3VwCKhXdX7kZ9Uz20QBQOv3jNKESHm7ByTzn+/qU2AhkREQWPWbNmoaamBvPnz4fR2DxaiKGomTNn4qWXXsLgwYMD2g721PiRKBROikxCeX058irzkJOSAy3ISouVl3qLuWteXbYXQ7rHY9pIZYZkIiJSYQhI9Jio9bWP0aOPPopFixZh1apViI2NbfbYDz/8IGtonnrqKVkoHGjsqfEjg8Hgna9GK3U1HueIwuEz+snjBxZsxubC4FrDiogoZIiaFjEEpMZm6Fg9jYe4umnOnDl4//330bdv31Y9NOeddx4ef/xx3HTTTegMDDUhXlfj667J/XHGwFQ0yBmH16CMMw4TEVE7cnNzZe/LfffdJ4eVRKGw2MrLy72BRlz1dPHFFzd7LJAYakJwZuEjFg5PH47eKdE4UFWPW+dzxmEiImrbmjVrYLVa5fCTmGTPs02bNg2vvfaafOyxxx5r9VggMdQEqKdmR8UO2J12aE28xYx57sLhFbtZOExERG0Txb8ul6vVJnppRKhp77FAYqjxs4yYDMSaY2WgEVdBaZEoHP7XZcPlsSgcXrCOMw4TEVHwY6gJRLFwsjaLhX2dm5OO230Kh3P3s3CYiIiCG0NNIOtqNFgs3LJweNKALu7C4bUsHCYioqDGUBPIK6A0WCzsy2Q04OnLR8jC4f2VNtw2fz2aHE61m0VERNQmhpoAhprtFdvhcDqgZb6Fw7/sLsPfv9ymdpOIiIjaxFATAD1je8ISZoGtyYZ91fugdUrh8DB5/MqyPfh4PQuHiYgo+DDUBIDJaPKuA7WlXLvFwr7OzemK2yYphcP3f8TCYSIiCj4MNQGi5Un42vP7s/pjok/h8CHOOExEREGEoSZAPD01Wr8CqmXh8H8uH4FeyVGycPjql1fyiigiIgoamg01YuplMSfMXXfdhWCUnZwt99vKtslZFPVCFA7/b+bJSI2NwLaDNbjipRUorWlQu1lERETaDDWrV6/GvHnzMHToUASrPgl9YDaaUWOvQWGtvgpr+3aJwbs3nYq0uAjsKK6Vwaakpl7tZhERUZDYvn07Jk2ahLS0NERGRqJPnz546KGHYLcHdvkgzYWa2tpaXHXVVXjppZeQmJiIYCUCTf/E/rqrq/Ho0yUG7900Bl3jI5FXUovL561AcTWDDRERAWazWa7g/c0338iA8/TTT8vf2w8//HBAPx7NhZpbb71VLmc+efLkoz63oaEB1dXVzTZVJuHTUV2Nr14p0TLYdE+wYHdpnQw2RVU2tZtFRESdYO/evbIMpOU2ceJE2TNz3XXXYdiwYejZsyemTJkiOyR++umngLYpDBry7rvvYt26dXL4qaN1N4888gjUoscroFrqkRwlh6LEENSeQ0qweefGU9EtwaJ204iINEnUYYp5ztRgCbPIYNIRmZmZKCoq8t4+ePCg7HAYP358q+fm5eVh0aJFmDZtGgJJM6GmoKAAd955p+zKEuNzHfHAAw/g7rvv9t4WPTXim9DZxcKip0b8Ie3oHxStyUxSgs2VL63EvjIrps/7RQabjMQotZtGRKQ5ItCMnj9ala+98sqViDJ37Ge3yWRCenq6PK6vr8fUqVMxZswYzJ492/uc0047TXZGiJGTm266CXPmzEEgaWb4ae3atSgpKcGoUaMQFhYmtx9++AHPPPOMPHY4Wi9HEBERgbi4uGZbZ8pKzILJYEJ5fTmKrcXQMxFgRLDpmRyFgnIbpr+4AgXlVrWbRUREnWDWrFmoqanB/PnzYTQejhbvvfeeDDXi/i+++AJPPvlkQNuhmZ6aM888E5s3b252nxivGzhwIO677z6ZGINNhCkCfRP6YkfFDjkElR6tJFq9EkNOosbGMxQ1/cVf8I4MOtFqN42ISDPEEJDoMVHrax+rRx99VA4trVq1CrGxsc0e84yOZGdny84H0Vtzzz33BOx3tmZCjfigcnJymt0XHR2N5OTkVvcHE1FXI0NN+VZM6jEJepceH4n33DU2u0pFsFkhg41Y6ZuIiI5OlCp0dAhIbR999JEcUvrqq6/Qt2/fIz5XlGGIS7oDOXebZoaftMp7BZSOi4VbSo2LlEEmKzUGB6vrcfm8X7CrtFbtZhERkR/l5ubKy7bFaMngwYNlobDYysvL8fbbb+P999/H1q1bsXv3bnzwwQeyznX69OmyZCRQNB1qli5dKq99D2aeYmG9LGzZUamxSrAZkBaL4uoGeVVUXkmN2s0iIiI/WbNmDaxWqxx+6tq1q3cTVziJ4PLEE0/glFNOkRPliuJhMSXLyy+/jEAyuPQ0h/9RiKuf4uPjUVVV1WlFw1a7FafOPxUuuPD9Zd8jxZKCUFJW24CrXl4pl1RIiQnH/BtPRf+05mOuREShTFw5tGfPHvTu3bvDV/eG2udQ3cHf35ruqdECMS7aM66nPN5Wvg2hJjkmQl7end01DodqG2WPzbaDnTsJIhERhQaGmk6sqwnFUCMkRosemtHI6R6H8rpGXDFvBbYcYLAhIiL/YqjpBNlJ7rqastCqq/GVEBWOt2edimEZ8aiw2nHlyyuQu79K7WYREZGOMNR0glC8Aqot8VFmvHnDaAzPTEClCDYvrcCmwkq1m0VERDrBUNMJBiYNlPvC2kJUNYR270RcpBlvzjoFo3omorq+SRYRbyhgsCEiohPHUNMJ4iPi0T2muzzeXr4doS420ozXrz8FJ/dKRE19E655eSXW7qtQu1lERKRxDDUqLG5JQExEGF677hSc0jsJNQ1NmPG/lVi9t5wfDRERHTeGmk5cLiHUi4VbipbB5mSM6ZOMukYHrn1lFVbuLlO7WUREpFEMNZ1dLMyemmaiwsPwysyTMa5fCqyNDsx8dTV+2cVgQ0REx46hppOLhfdW7ZWzDNNhlnATXr72JJyelQKb3YHrXluFZXmH+BEREdExYajpJGJ5hNSoVLlcwvYKFgu3FGk24aUZJ2HigC6otztx/Wur8eOO0s769hARUYDk5eUhNjYWCQkJAf+MGWo6ESfhO3qwefGaUThzYCoampy44Y01WLq9pJO+O0RE5G92ux1XXHEFTj/9dHQGhppOxEn4ji4izIS5V4/CWdlpaGxy4qY31mLJtuJO+O4QEdGx2Lt3LwwGQ6tt4sSJ3uc89NBDGDhwIC677DJ0hrBO+SrU7AooFgsfWXiYEf+9ciTueGc9Fv16EL97cy2ev0oJOkREeudyueCy2VT52gaLRQaTjsjMzERRUZH39sGDBzF58mSMHz9e3l6yZAk++OADbNiwAQsWLEBnYKhRoadmd+VuNDgaEGGK6Mwvr7lg8+yVI3DXuxvwxeYi3PLWWjx35Uicm5OudtOIiAJKBJrtI0ep8ikPWLcWhqioDj3XZDIhPV35mVxfX4+pU6dizJgxmD17NsrKyjBz5ky89dZbiIuLQ2fh8FMnSotKQ2JEIppcTciryOvML61JZpMR/7l8OC4Y1g1NThdum78OX24+/K8CIiIKDrNmzUJNTQ3mz58Po9GIG2+8EVdeeaW316azsKemE4kuPdFbs/zAcmwp34LBKYM788trUpjJiH9fNgwmA/DJhgO4/Z31qLLZcfnJmR3uIiUi0hIxBCR6TNT62sfq0UcfxaJFi7Bq1Sp5lZNn6GnhwoV48sknvUNqTqcTYWFhmDdvHq6//noEAkONCnU1ItSE+ordxxps/nXZcJiMRny0rhAPLNiMdfsq8NepOfKKKSIiPZEFtx0cAlLbRx99hDlz5uCrr75C3759vff/8ssvcDgc3tuffvopnnjiCSxfvhzduytrIQYCQ00n4xVQx8dkNOCflwxFny7R+Nc32/HB2kLkHqjGC1ePRM/kaD9/l4iI6Ghyc3MxY8YM3HfffRg8eLAsFBbCw8MxaJBSQ+qxZs0aOSyVk5ODQGJNjUpz1eyo2AG7097ZX17TjEYDbp3UD2/OGo3k6HBsLarG+c/+jMVbeMk3EVFnE0HFarXK4aeuXbt6t2nTpkEtDDWdLCM2A7HmWDQ6G+VVUHTsxvZLwed3jMPIHgmoqW/CjW+swT8WbUOTw8mPk4iok4irm+Tl5y22pUuXtvncysrKgLeJoUaFsdKByco6UJyv5vh1jbfg3ZvGYOZpveTt55fuwoxXVuFQbYOfvlNERKQ1DDVqTsLHYuETnstm9pTBeOaKEYgKN2H5rjKc98xPWLuv3D/fKCIi0hSGGjWLhct5BZQ/TBnWDZ/eOhZ9u0SjuLoB019cgVeX7ZHdoEREFDoYalQsFt5Wvg0O5+FL3uj4ZaXF4tPbxuG8oV3lRH2PfLYFt72zHrUNTfxYiYhCBEONCnrG9YQlzAJbkw37avap0QRdiokIw3NXjMDDF2QjzGjAF5uKcOFzP2NncY3aTSMiOqpQ7112+eH8GWpUYDKaMCBxgDxmXY3/C7GvG9sb7/3uVKTFRWBXaR0u/O8yLNx4wM9fiYjIP8QaSkJjY2NIf6RWq1XuzWbzcb8HJ99Tsa5mQ+kGGWrO63OeWs3QrVE9k/DFHafj9vnr8cvuMrnit5iF+E+/HSQLjImIgoVYOiAqKgqlpaXyF7qYpC7UemisVitKSkqQkJDgDXnHg6FG5SugRF0NBUZKTATenHUKnlq8Q17y/dryvdhUWIn/XjVSXhJORBQsPcxi0ro9e/Zg377QLUlISEjwrvp9vBhqVL4CSixsKVIqF2cM3LpR9547ECN6JOLu9zdgXX4lzn/mZ3kZuJjEj4goGIilBbKyskJ2CMpsNp9QD40HQ41K+sb3hdloRk1jDfbX7pczDVPgnJWdhs9vH4eb31onl1e45n8rcc/ZA3DLhL5y+QUiIrWJYafIyEi1m6FpoTVwF0TMJjOyErPkMeer6Rxi4cuP/+80XDIqA04X8M+vt+OmN9egyso1uIiI9IChRkWcWbjzRZpNcrXvx6cNkQXD324twQXP/YxfD1Sp0BoiIvInhhoVZSdne+tqqPOI+qXLT+mBBbechoxEC/LLrZj2/HK8v6aA3wYiIg1jqAmSnppQn3RJDTnd42WdzRkDU9HQ5MS9H27CfR9uQr2dszwTEWkRQ42KRE2NyWBCeX05SqwlajYlZCVEhePlGSfhD2f3h8EAvLemABfPXY78MmUSKCIi0g6GGhVFhkWiT0IfecxiYfWIq59uOyMLb1x/CpKiw/HrgWqc/+xP+G5rsYqtIiKiY8VQozIWCweP07O6yOGo4ZkJqK5vwqzX1+DJr7fDIS6VIiKioMdQozIWCweXbgkWvP+7Mbh2TE95+7nv8zDjlZUoq21Qu2lERHQUDDUqY09N8BGXej9yYQ7+c/lwWMwmLMsrw/nP/ozleYfUbhoRER0BQ43KBiQNgAEGFFuLZcEwBY8Lh3fHp7eNRZ+UaBRV1ePKl1fi9nfWo7i6Xu2mERFRGxhqVBZtjkbPOGWoY1sZF7cMNv3TYmWwmTGmJ8RqCp9tPIAznlyKl3/aDbvDqXbziIjIB0NNEA1BcRK+4BQbacacC3Ow8DaliLiu0YFHv9gqF8ZcubtM7eYREZEbQ00QrdgtJuGj4J6sT8xC/MTFQ5AYZcb24hpMn7cCd7+3AaU1LCQmIlIbQ00whZpyhhotzGkz/eQeWHLPRFxxSg85Yd+C9fvlkNRry/agiUNSRESqYagJouGngpoCVDdWq90c6oDE6HA8Nm0IPv6/sRjSPR41DU2Y/dkWTHluGdbuq+BnSESkAoaaIBAfEY/uMd3l8fby7Wo3h46BqLH55NaxeHRqDuItZmwpqpbLLNz74UbObUNE1MkYaoKtWLiMK3ZrjclowNWn9sSSeybgspMy5H3vrynEpCeX4s0V+zgjMRFRJ2GoCRKsq9G+5JgI/OOSYfjoljEY1DVOLrXw509ycdHzy7CxoFLt5hER6R5DTZDgzML6MapnEj67bSxmX5CN2IgwbCqswtTnl+GBBZtRUdeodvOIiHSLoSbIemr2VO2B1W5Vuzl0gsJMRswc2xtL/jAR00Z0h8sFvLMqH2f8ayneXZUPJxfJJCIK3VDz2GOP4eSTT0ZsbCxSU1MxdepUbN+un6LaFEsKUi2pcMGFHRU71G4O+UmX2Ag8NX043rvpVAxIi0WF1Y77F2zGtLnLkbu/ip8zEVEohpoffvgBt956K1asWIHFixejqakJZ599Nurq6qC33hoWC+vP6D7J+PyOcXjovEGIDjdhQ0Elpjz3M/7yaS6qrHa1m0dEpAuaCTWLFi3CzJkzMXjwYAwbNgyvvvoq8vPzsXbtWugFi4X1zWwy4obT+8ghqSnDukGMQL3xyz45JPXh2kK4xBgVERHpP9S0VFWldN0nJSW1+5yGhgZUV1c327RQLLytnAtb6llaXCSeuWIE5t8wGn27RKOsrhF/+GAjLnvxF2wtCu4/o0REwUyToUb8i/buu+/GuHHjkJOTc8Q6nPj4eO+WmZmJYJadnC33eRV5aHTwKhm9O61fCr66czzu/81AWMwmrN5bgfOf/RlzPtuCmnoOSRERhUSoue2227Bp0ya88847R3zeAw88IHt0PFtBQQGCWVpUGhIiEtDkasLOyp1qN4c6QXiYETdP6Ivv7pmA3w5JlxP1vbJsD8741w/4dMN+DkkREek51Nx+++1YuHAhvv/+e2RkKLO3ticiIgJxcXHNtmBmMBg4X02I6pZgwfNXjcIb15+C3inRctXvO9/dgMvnrcDmQl4lRUSkq1AjhpxED82CBQuwZMkS9O7dG3rkLRYu44rdoWh8/y5YdNfp+OM5AxBpNmLlnnJc8NzPuOZ/K7E87xB7boiIjiAMGiEu554/fz4+/fRTOVfNwYMH5f2iVsZisUAveAUURYSZcOukfvIKqacW78DCjQfw085DchuWEY9bJvbF2dnpMBoN/LCIiHwYXBq5jlQMzbRFXNotLvXuCHH1kwhBor4mWIei8qvzcd7H5yHcGI4VV62A2WhWu0mksoJyK17+aTfeXV2AhianvK9Pl2jcPL4vpo7oLutyiIj0rKO/vzUTavxBC6HG6XJi7DtjUWuvxUdTPkL/xP5qN4mCxKHaBry+fK/cxGKZQnpcJG44vTeuOKUHoiM00/FKRBSQ39/8J16QMRqMGJg0UB6zroZ8pcRE4J6zB2D5A2fiwd8OQlpcBA5W1+PRL7bitMeXyKGqci6YSUQhjKEmCLGuho4kJiIMN47vgx/vnYTHpw2RV0tV2ex45rudOO3x7zB74a/YX2njh0hEIYehJohnFmZPDR2toPjyU3rg27sn4PmrRmJI93jU2514bfleTPjH97jn/Y3YWVzDD5GIQgYH4YN4ZuGt5VtljY0YkiJqj8lowG+HdMVvctKxLK8Mc3/Ik/uP1hXK7azsNHnF1MgeifwQiUjXGGqCUK+4Xog0RcLWZMO+6n3oHa/POXnI/1cIjstKkdvGgkrMXboLX285iMVbiuU2uneSDDcT+ndp92pCIiItYxdAEDIZTRiQNEAecwiKjsewzAS8cM0oLP79BFx2UgbMJoOcyG/mq6vx22d+lnPfNDmUy8OJiPSCoSZIccVu8od+qTH4xyXDZFHxDeN6IyrcJFcCv+Od9XJ9qbdX7kO93cEPm4h0gaEmyOtqtpRvUbsppANd4y146PxsLL//DNx9Vn8kRpmRX27Fgx/nYtwT38uhqmquDE5EGsdQE6R856oJofkRKcASosJxx5lZWHb/GXj4gmx0i4+Uk/o9sWgbxj62RO5Laur5fSAiTeKMwkHK7rDjlPmnoMnZhEUXL0L3mO5qN4l0yO5wYuGGA3jhh13YWVIr7xPLLlw6KgMzT+uFrLRYtZtIRATOKKxxZpMZWQlZ8pjFwhS4P2dGXDwqA1/fNR4vzTgJI3okoLHJibdX5uOsf/+I85/9Cf/7eQ9Kaxr4TSCioMfhJy3U1ZSxroYCS6z4LeazWXDLaXjvplPlcZjRgNz91fjr51tw6mPfYearq/Dphv2wNbKwmIiCE+ep0cLMwuVb1W4KhQgxf83oPslyE+tIfb7pABas248NBZVYur1UbmKZBjHR30Uju+PU3skyEBERBQOGGg2sASV6akSxMCdMo86UFB2OGWN6yW13aS0+Wb8fH2/Yj4JyGz5YWyg3UWh84YjumDaiO+tviEh1LBQOYvVN9Th1/qlwuBz47tLvkBqVqnaTKMSJcL1mX4XsvRG9ODX1Td7HcrrH4aIRGZgyrBu6xEao2k4iCs1CYYaaIHfRpxchrzIPz53xHCZkTlC7OUReYtK+JdtKZMBZur0ETU6Xdy2q07NScNGI7jg7Ox2WcBM/NSLqlFDD4ScNFAuLUCMm4WOooWASaTbJhTTFxvobIgoGDDUaKBZeuGshL+smzdXfLFi/H4UVrL8hos7D4acgt7Z4LWYumon06HQsvmSx2s0h6jCnU6m/+Xh9IT7fVMT6GyI6bqypOYEPJZjU2etksbDw4/QfkRiZqHaTiI4Z62+I6ESwpkYnos3R6BXXC3ur98r5ak7rdpraTSIKWP3NuTnpOG9IV5zaJ5kFxkR0zFhTo5G6GhlqyhhqSH/1Nx+L+W/c9Tcfri2Um1h/anTvJIzP6oIJA7ogKzWG8zQR0VGxpkYDXsl9Bf9e+2+c0+scPDnhSbWbQxSw+huxDIPotdlfaWv2eNf4SEzo30Vup/VLQbzFzO8CUQip5iXdOlwuoYzLJZA+iaUWTumdJDcxwd+u0jr8sKMUP+4oxYrdZSiqqse7qwvkJubBGdkjwR1yUjG4WxyXaiAiiT01GlBZX4nT3ztdHi+/Yjliw2PVbhJRpxYZr9xTjh+2l+KHHSUy8PhKjg7HeHcvjpj0LzmGsxkT6Q17anQkITIB3aK74UDdAWwr34aT009Wu0lEnVpk7Bl6ArJRUG7FjztLZchZlncIZXWN3rocgwHI6RavPH9AF4zITECYycjvFlGIYKGwhha3FKFGDEEx1FAoy0yKwlWje8qtscmJdfkVcqhKhJwtRdXYvL9Kbs99n4fYyDCM65ciQ47ozemWYFG7+UQUQAw1Gqqr+S7/O3lZNxEpxFVS4vJvsd137kCUVNfjx52HZC2O6M2ptNrxVe5BuQn902K8tTgn9UqUvUBEpB8MNRrqqRFYLEzUvtS4SFwyKkNuDqdL9th4anHEnDg7imvl9tJPe2AxmzCmb7J3aKtXSjQ/WiKNY6GwRhyyHcKk9yfBaDDilyt+QZQ5Su0mEWlKpbURP+cdcoecUpTUNDR7PD0uEsMzEzCiR4LcD8mIR1Q4/91HFAy4TMIJfCjB6oz3z0CprRRv/uZNDE8drnZziDRLXDa+7WCN97Lx1XvLYXe4mj1HXDo+IC3WG3JG9EhEn5RoXj5OpAJe/aTTIajSwlJZV8NQQ3T8DAYDBnWNk9vNE/rC2tiEzYVVWF9QiQ35lVhfUIHi6gZZeCy2t1fmy9eJwmMZcNwhRxwnRofzW0EUJNi3qrFi4R8Lf5SXdROR/4hhptF9kuXmUVRlw/r8SlmLsz6/Qtbn1NQ34aedh+Tm0Ss5ytuTI/YiKIkCZiLqfAw1GsJiYaLO0zXegq5DLHIRTsHucGL7wRrZmyNCjgg7u0vrsLfMKrdPNhyQzxOBJqdbHIZnJnqHrjISLVy7iqgTMNRoSHZSttzvrNyJRkcjwk3s9ibqLGaTETnd4+V2zak95X1VVjs2FB4OOWITl5Gvy6+UG5Ypr02JifAWIYuhq6GZCXJVciLyL/6t0pD06HTER8SjqqEKeZV5yE5WQg4RqSM+yuwz27FSgCx6bTYUVHiHrrYcqMah2gZ8u7VYboKY+bh/qlKEPLh7vFyFvH9arFzBnIiOH0ON1oobkwZhRdEKOV8NQw1R8P0d7Z0SLbeLRmR416769UCVDDmeQmSxCvn24hq5YXWB9/UpMeHISo1FVloMstJi0T9V2TPsEHUMQ40G62pkqOHMwkSaIGYtHtUzSW4eYuZjGXAKKmWdzo7iGhRW2HCothGHasvwy+6yZu/hCTtiRuR+7rAjenZ45RVRcww1Gq2r4czCRNqe+ficwely86hraMKuUmXG453FStDZWVLb4bAjenQ8w1gMOxSqGGo0egXU9ortaHI2IczIbyGRHkRHhGFoRoLcfImwk1dSKwOOJ+yI4COGsNoPOxHugOMexnIHHoYd0rvj/o2Yl5eHXbt2Yfz48bBYLLJATownU2BlxmYi2hyNOnsd9lTtQVZiFj9yIp2HnWGZCXJrK+x4enR2Ngs7DXJrK+zIoJMagz5dYpCZZEFmYhQyEqNgCefinhSCoaasrAzTp0/HkiVLZIjZuXMn+vTpgxtuuAEJCQn417/+FZiWkiTWfhqYNBBri9fKuhqGGqLQ1F7YqRXDWEcJO8t3NQ87nqEsEW4yk6KQmWhx78Vti5yzhxMKki5Dze9//3uEhYUhPz8fgwYpQyGCCDriMYaawBNXQMlQU7YVU/pO6YSvSERaEXOEsCOHsdxhZ++hOhRU2FBYbkVNQ5N7KKtRFi+3ZDQoC35m+AQdZa8cp8ZGyrWyiDQXar755ht8/fXXyMhQLlf0yMrKwr59+/zZNmqH51LuLWVb+BkRUYfDjpgAUGy+ROlAta0JBRVWFJRb3Xub3IsiZXFfQ5MTB6rq5bZqT3mr9zabDOieoPTuZLQMPYkWeUk6yxMoKENNXV0doqKiWt1/6NAhRERE+KtddJSeGkGsAeV0OeWQFBHR8RBhQ0wiGB+lzJbckgg9pbUNMugUeoKPT+g5UGmTK5x7lotoS1S4SS4VIYJOtwTRsxOBtLhIdImL8B4nRYVzBXTq/FAjCoPfeOMN/PWvf/X+hXA6nfjnP/+JSZMmnXiL6Kh6xfdCpCkS1iYr8qvz5W0iokAQP+PF8JLYRvVMbPV4k8OJg9X1h4OO7O3xBCAbimvqYW10yLoesbUnzGiQhcxpcRHoIr6eT+ARe/H1xWPJMREc6iL/hRoRXiZOnIg1a9agsbER9957L3799VeUl5dj2TL3QicUUOIy7v5J/bGpdJPsrWGoISK1hJmMcshJbGNweJVzj4YmB/aLYSz3UNbBqnqU1IitAcXVDSitqUdZXSOanC4ZjsQGVLX79UTpjgg2IuAoYStCzvujBB/lWDwmApJYr4tCyzGHmuzsbGzatAlz586FyWSSw1HTpk3Drbfeiq5dldVsqXOGoESo2VK+Bef2PpcfOREFpYgwk7x8XGztESugi6uySqobZNgRoccTeMR9xe69eI7TBZTWiMcaAFS3+55ihhExpOUJPCLkJEWbkRAVLmt8EqPMSIwKl3P3iH1ClJkhKFTnqUlPT8cjjzzi/9bQMRcLc2ZhItI60aMiLhsX25E4nC6U1XnCjzvweI5FGKpW9iLwiJ4f0QMktq1FHWtHbGSYEnRE4HGHnVa3o5UwJIKRCEIitJGGQ82PP/541JobCjwxV40g5qrhxIdEFArEZeOe+h6gdVGzh9PpQoW1sVngKattlPdV1Ln3Vrv3uNJmh8sF1NQ3yS2/9QVe7YoON3l7f0TIUXqBDgegeIsZcZFmGZhivfswRIeHsTA6GEKNqKdpyfdSPYfDceKtoqPql9BP1tZUNVShqK4I3WK68VMjIhJ1N0aDrLsRWzbijvqZiB6gapsd5SLgWBtRXmf3CUB2933iscPPEfeL19U1OlDXaJOTGx4L8WtTXGZ/OPA0Dz2Hj0Uoan2f2McwGJ14qKmoqGh22263Y/369fjzn/+Mv/3tb8f6dnScwk3hyErIkj0113x5DWLDYxERFiGvihKPib24HWE6vEWG+TzWxm25ud+jrdsmI7tZiUifPUByeCk6vMOvEb1BYtLCwz0/IgS5w5A7GInwI4JQTYPd2wtUU2+Xl8D79gwdLxmMwtsPRFHhJkSFhyE6wgSL2Ltvi/vFfZ5jz3Miw0ya7z065lATH9+6y++ss86Sc9SIGYXXrl3rr7bRUYztPlaGmhJbidwCLcwQ5g1KIgyZDErIEfPkGGDwzpfjuS168MRmhFE5Rovb7vuaPb+d2zDA+zpxW/5nOLyJ+0V7mt0H5T7Pa7zH4j9j6/dotbm/Xrvv0cZrvO1o47W+73uk13rOudlrfc+9xTn6vt7z3m29zvOZEtGJE7/8xdCS2HohusOvE+UCYjLD6vrmQcd3X93Gfc0f9wlGDU1yQ5W4auzEeUKOshfhx+c4PEyuEeZ7nzc0mZW9uN0vNUZ+LmowuMQn7Adbt27FySefjNra9uch8Ifnn39eXlZeVFSEwYMH4+mnn8bpp5/eoddWV1fLUFZVVYW4uKN3SQY78a3bVbkLtfZaNDgavFt9Uz0aHY2od9Qr9zX5POZwP9ZU3+Zt79akPGZ32tU+TfKjlkHPNxgdKQj53u8bpATfUNUylPqGrJZfp62Q6/3aUIJsWyHX93HvYy1Dsc9zfQP3kR4Xe8/XbPn1mu19ntcyLLZ8Xlvv0awdLYJmW69tdn9b97W43eY5tHO/53W+fz6anYv7de0+5vP6Vu1ocdzqsXZe7/v1jvi8tr72Mb5nu+/b4nVtvffR3s9Xe48f7XXtPUf87Lc3KT1FYvmL2gYHauvtci8WOq2tV+6vtzthtTfB1uCEtbEJVrsTtkaHctzogK3RCZtdHDvb/NqtPgQP15Gf878Zp+LMQf69Grqjv7+PuadGXM7tS3y4ImA8/vjjGDZsGALpvffew1133SWDzdixY/Hiiy/iN7/5DbZs2YIePXog1Ig/4P0S+wX0a4gZi9sLRuJ774RT7uV/4rbL6T0W/7V12/O+nteLvyCe9/Hedr+u2fM97+d+npj0Uf7nar2J5zqcDu/7OlwOb/s8m7zP/Z7tvofL0fw+3/eCs8339W4+bfS8rtl7uNvoaUOr93K/3vdz9G2H59yPhXiPJldTGz+UiEj3wtybz6IAor891s9fprD+SQBdtdFTI7rtxS/Tli879dRT8corr2DgQOWqnEAYPXo0Ro4cKefI8RCLak6dOhWPPfZYq+c3NDTIzTfpZWZm6qanhqhZePQJOt5w5AmLPkGtrWDU8vmegNUymLY8bnbbE7LcIdU3kHq+hvfre8Jwi2AsQp7QKhAfJSQfMWC3DNk+z2nvuZ42+D7m+Totn9eyTS2f5/lMWrbF+1rfr6c8sdVzPff7tqu95/s+50jP921ny9e0+R4+r/E+x/d9Wz7WTht8+T7ebN/i/mbn3t5zTuA9fdt8pPdu77H2vqb367hcSl+G2LsfMojXuACj56lO5THf54njZnv3c+VrWtzf1vM9vF/Tc4fn63TgeZ7bvs9r9dwWr/vDJU9jzIDJ0ERPzZ49e1qFnC5duiAyUlxiFzhi9mJRr3P//fc3u//ss8/G8uXL23yNCDqcT4f0rOXwClEguESPYVMT0NQk9y6HAy67Xbktj5sAh/uxJgdcTc0fczl8XtvkAEQPpcOpvEbsxW2f++XzxV6EXPF+Yt/stniteG777+V9je97iZn7xLmIoCmf6w6V4r3EfZ7Hj/TcFo8rtz2Pywpi9/sdfjzUdB8fDgxQ52sfc6jp2bMn1CAWzBSXi6elpTW7X9w+ePBgm6954IEHcPfdd7fqqSEiUpPstWhshKuhQdnb7c23I93XeAzPPcp9MgjI0CGCgG/wUO6DeJ4MDqH3iznoiHoao6glE3VO7vomzyZGUMRzjIcfl8/xvK7lvtmx+xDtPH4czwuztF70OqhCzTPPPNPhN7zjjjsQSC2LqY408Zy4IosrhxPREXsg6uvhtNmUfUMjXI0NzY6d9fVwieOGBjgb2j5WntegHMvHjn6seeIXaVgYEBYm93IzmQCz2B++z/u4yaTcFnvxPN+9+GUcJvbitlG+Xu6N4jUmQOzFOk7ifcVe3vY81/MeR3mtdy9+8Yu9QXmt+OUv7nNv8lgUcfs81yAuc5bPdR/7PtcdJOR7ucszlMdFmw6HjmZBxBM+REQwthFO2gowwcIhwq8NsPtsLW/36BXcoebf//53h95MfPCBCjUpKSlyramWvTIlJSWtem+ISD9ET4EIHU6rFS6xl8di385tedzWbRtcNmuL28c2YVqgGMxmGMLDlb3vFi72PveHmwGzGUaf58K999znuX34NW28r9zC5S99b9AIE/e5g4lvUGkrmIhj8UuXgocYEmusBRrrgIZawF7XInjUA3YrYHfv27zdTlDxfawjV8Re8wnQdxKCNtS0rKNRQ3h4OEaNGoXFixfjoosu8t4vbl944YWqto2IWveAiBDirKmBs7YWjppaOOtq5W1Hrdgrt+X94natz/3idSJwePaNjZ3y8RoiItxbOIwRkX46FvtIGCPC3ff5HEdGHg4cwfQvcQo8UW8jgoIIHzKI+IQRz7Hn/oYO3hYhpLOFWQCzz+a9HeTDT8FC1Mdcc801OOmkkzBmzBjMmzcP+fn5uPnmm9VuGpFuiFoLR3W13Jy1dc0DhwgotSKo1CmBpWUw8RzX1Sk/uP1JTJhoscAQZYHREiWP5RZlgSHS59ji87jvbfk6ZTO0um1hzwN18C+ISwkR9VVAfaWyt7n3vvd57m+obhFa3IHEFaAlhYxhQHgMEB7dRtho43ZYZPuPHem54jgIw/hxhZrCwkIsXLhQBgpxVZKvp556CoEyffp0lJWVYc6cOXJunJycHHz55ZeqFS8TBX0xqtUKR2Ulmior5b75VtX6vooKGUr8xmyGKSYGRrHFxsAUEyuPTbExMEaL+8TtaJjEXtyOiYYxOrpZCJGhJCpK6dUIwh+ipEFNja3Dh7zd8r42gorYnMe/tEEr5mggwh1CZBiJOfbb4jgiVtmHRSCUHfM8Nd999x2mTJmC3r17Y/v27TJY7N27V/4AFXPILFmyBMFKbzMKU2jVlcjek4q2wkn724kM3ShBJBYmETTaCyPi/hbBRD7H/VoGEeqUwlVbOVBXCtQdAqyHlL3cSg/ftlUcDir+GKoRPSKRCYAlAYiMV47lPt7nvnggIu5w4GgZSkSgYW2SuvPUiMuk77nnHtlbEhsbi48++gipqam46qqrcO655x7r2xGFLDmxW3U1mkpL0VRSoux9t5JSNImpDCoqZKA53uEcUbNhSkhoe0tMbOO+BJji4pSCUSI1Cl6t5e4w4g4q3rDiCS5lh49FWDneKbIjRACJbxFKfINKe2ElQRmCYc9h0Ak7njWe3nnnHeXFYWGw2WyIiYmRIUcU7N5yyy2BaCeRpopkRRBpFVRESGkRXI61J0UMzbQZRNoIJmHuY4MYuuEPX1JTUwNQUwRUHwBqi9sIKu6QIm6LQHPMIcUARCUBUSlAdBcgOtnnWOxTAEtS81Aiek/EZeAU2qEmOjrau/RAt27dsGvXLrmwpGeCPCK9EhOSNZWVHQ4rbYQUuZWVyUnMOsoYF4ewLl2ab6nufUoXhCW5Q0x8vBzOIQoq4jJfEVa82/4Wx/uVwHKsLIlKKJHhxLO1uO0JLiLQMKDQ8YQascbTsmXLkJ2djfPOO08ORW3evBkLFiyQjxFpleg1sRcVobGwEPbC/bCL/f5CNIrjAwfgEGHlGIaATElJCEtNbR1YfINLSgqMAV5ihOi4iat12gwqPseinqUjTBFAXDcgNh2ISvbpRenS+rboVRGT6BEdo2P+UyOubqp1Xx0xe/ZseSxWz+7Xr1+HJ+kjUqvYtqm4WAkt+w8ooaWwEI37lRAjHjtqaDGZZBBpN6R4jpOTlYnQiIKR+HMuLjVuGVKqCpv3ujRUdez9xLwkIrDIrbt769Z8L3pTOAxKwRZq/vrXv+Lqq6+WRY5RUVF4/vnnA9MyomMkV5cuK3MHlf2te1uKiuRaNkciJkQzZ3RHePcMmDMyYO7eXd6W+/R0Wc/CmVRJM8FFFNSW7wbKdgHlu3yOdyuhpiPE1TvewNIiqHjuEzUqDCykxVAj5okRw07Jycm4/PLL5WR4w4cPD0zriFpw1NTAXlDQdm/L/gNHn/bebIa5a1eEy6DiDi4yxIjwkgGT6GHhD2fSUnARV/94QosnsMjj3UfvaRFhxDectHUcyekvSMfz1AiVlZV4//33MX/+fPz0008YMGCA7L258sor0auXegtZHQ3nqdFWeGnYmYeGvJ1oyMtDY16evC0KcY/IYEBYejrM3bsd7m3JyFBCTEaGrHHhpcqkOeKKIN9eFm+A2aXMu3IkIpwk9QGS+yr7pL7KcUIPZa4UIg3o6O/v4wo1LWcXFpd4v/LKK9i5cyeajuGqj87GUBN8xPT7MrC4Q4vc5+Up9S3tEL0p3iEidw+LvC32XbvyCiHSJtnjsrt1aBG35VwsRxDbzSe0eAJMXyCxFxCu3jo8REE/+Z4vu92ONWvWYOXKlXJWYa6WTe0RawE17NrVLLjI8CLqXNr7w5mejoh+/ZQtS9mH9+0nZ7gl0iwRUA7mAgc3K1vZTiXAHO0qotiu7l6WPs17XBJ7M7gQnUio+f777+XQk5hN2OFwYNq0afjss89wxhlnHM/bkY6IFZYbdu12hxb30NHOPHlJdHvEkJAnuIR7Qky/fnLafSLNEp3gVQWHw4vcNgGV+e2/Jia97R6XJBFcGOaJ/B5qMjIyZLHwOeecgxdffBEXXHABIjnPRshx1tfLnpeWQ0f2/fvbvSza1CXFHViyDve+9O0rJ5Uj0jSHHSjd3jy8iK29ehdRz5I+VNm6DDjc4yLWBCKizgs1f/nLX3DppZciMTHx+L8qaW5SuvodO1G/eRNsm3PlXvTGwOlst+al9bBRX4TxzwzpgQgqxb8q4aXIHV5KtwGOxrYXPewyCOgqAswQZUvLUabrJyL1Q81NN93k/1ZQUK1b1Lh3L+o3b4Zt02bYcjejYeu2NtcoElP3y8DiDi6yByarH8KSklRpO5FfiR5HMQGd7HXx9L5sBir2tr84oie4eDbRCxMWwW8MUSfhPNQhTFz4Jq4ysm3ahPrNubBt3oz63Fw43TNG+zLGx8OSk4PIoUNgGTIEkTk5cuZczulCuuBoAg7taB5exNZe8W58ZusAk9CTE9ARqYyhJoQ4Kithy/3VO4xk27wJjtJDbc6qG5mdDcuQHEQOGQrL0CEwZ2YywJC+Vo3evxbYuwzY9zNQsAqwW1s/z2ACugxsHWDElP9EFHQYanTKabOhfuvWZsNI9n1tXHVhMiEiK0vpfRmSA8vQoXIoyRDGPxqkI/Z6oHA1sG8ZsPdn5bipvvlzwmOB9Byf8CKKeAcCZi44SqQV/M2lA66mJnnlke8wUsPOnYDD0eq55p49YMkZIntfIkWQGTQIRotFlXYTBUyjFShcpQQY0Ruzf03rQl6xGnTPsUCvccqWMgAwGvlNIdIwhhoNs65bj5J//Qv1v/4KV319606YlBTZA6MEmKGw5AyWxb1EutNQCxSscA8niRCzDnDaW88B08sdYnqKEJPFGhginWGo0bBDzz0H29q18tgYHS17XpQ6GKWYV8zIy0Je0qX6aiB/hVIPI4LMgfWAy9F6zSMZYNxBRkxmx8VKiXSNoUajXA4HbBs2yOPMl15C9NjTYGDXOemVrRLI/0UZThI9MUUbxfwDzZ8T38M9lDRWCTJi3SOGGKKQwlCjUQ07dsglCYwxMYg+bQwDDelvVep9y92FvT8payWhxUzVYgZeGWDcQUbM0ktEIY2hRqOs69bJvWXYMBhMJrWbQ3RinA4lxGz7AtjzI1Dya+vnJPc7PJQk9vHd+akTUTMMNRplW7de7i0jRqjdFKLjXy9JBJgtnyphxtpiziRxNZJnKEkEmdh0ftJEdEQMNRplW6+EmqiRDDWksflidn8PbFkIbP8SqK88/FhkAjDwfCBrsjKkFNNFzZYSkQYx1GiQvbgY9gMH5JwakUOHqd0coiNrrAPyvlWCzI6vgcaa5nPFiCCTPQXodTpgMvPTJKLjxlCjQTZ3PU3EwAEwxUSr3Ryiti+53vkNsOUTYOe3QJPt8GOx3YBBFyhBpscYwMiaMCLyD4YajU66J0QN59ATBdkVS9u/ArYuBHYtaT6Dr7gyadAUIHsq0H0UZ+4looBgqNFwPY1l5Ei1m0KhrrYU2Pa5EmRE0a+zqfnVStkXKmGm6zDOGUNEAcdQozFibhqxUKXAImFSRfUBYKs7yIh5ZHwnwUsdrAwriSCTOohBhog6FUONxogVt8VClWIJBHO3bmo3h0JFxT4lxIhiX7FQpK+uw91B5kIgpZ9aLSQiYqjRGtt696R7I4ar3RTSu0N5wNZPlSBTpCzJ4ZVxijvIXKAsR0BEFATYU6MxVs/8NCNYT0MBuvx647vAmleAYrE0gZvBCPQ4zV0jcz4Qx15CIgo+DDUa4nI6YduwUR6zSJj8qmIvsOolYP2bQH2Vcp8xDOg9XqmPEXPJcDI8IgpyDDUa0pCXB2d1NQwWCyIHDlC7OaR1LpdyxdLKF5XZfT0LRib1AU65CRg6HYhKUruVREQdxlCjxfWehg6FIYzfOjqBIaZN7ythplS5kk7qeyYw+mag32TOI0NEmsTfjJqcn4aT7tFxXsG0+mVg3RuH11wyRwPDr1R6Zrr058dKRJrGUKPFImFOukfHMsS096fDQ0yeOWXEFUun/A4YcRUQGc/Pk4h0gaFGI5oOHYI9P19OZmYZxkUs6SgarcBm9xBTyZbD9/eZpAwxZZ3FNZeISHcYajTC6lnEsl8/mOLi1G4OBavKfGWIae3rPkNMUcCwK5QhptSBareQiChgGGo0wrZemfyMl3JTm0NMYrmClS8A2744PMSU0FMJMiOuBiwJ/OCISPcYajTC5u6p4XpP5GW3AZs/UIaYfCfK6z1BGWLqfw6HmIgopDDUaICzvh62LUpdBHtqCFWF7iGm1wBbhfKBhFmAYZcDo3+nLCRJRBSCGGo0oD43F7DbYUpJgTkjQ+3mkFpDTPm/KENMYoVsl0O5P6GHzxBTIr83RBTSGGo0td7TCBgMBrWbQ53JXg/kfqiEmYObD98vli+QQ0zncoiJiMiNoUZLMwlzfprQ4bAri0r+8ARgLfMZYpqu9MykDVa7hUREQYehJsi5XC7vTMIsEg4ROxcDX/8JOLRDuR2fCZxyIzDiGq7FRER0BAw1Qa5xzx44KithiIhA5CAWgOpa6Xbg6weBvMXK7ahk4IyHgBEzABP/qhIRHQ1/UgY5Ty9N5JAcGMLD1W4OBYK1HFj6uHJFkygANpqBU28Gxv+RSxgQER0DhhqNzCQcNWKk2k2hQNTNrP4fsPSxw7P/DjwfOGsOkNyXnzcR0TFiqNFMkTBX5tZ13UxaDnDO34E+E9RuGRGRZjHUBLGmigpZUyNYhg9XuznkDyXbgG9E3cy3yu2oFKVuZuQMXppNRHSCjNCAvXv3YtasWejduzcsFgv69u2Lhx9+GI2NjQiF9Z7C+/RBWCInVtN83cyXfwTmnqYEGlE3c9odwB3rgJOuY6AhIgqVnppt27bB6XTixRdfRL9+/ZCbm4sbb7wRdXV1ePLJJ6FXtvVKPQ2HnrReN/Oyu26mSrmPdTNERKEbas4991y5efTp0wfbt2/H3LlzjxhqGhoa5OZRXV0NLbG662lYJKzRZQ08dTNlO5X70oYA5/5dmQ2YiIhCM9S0paqqCklJSUd8zmOPPYZHHnkEWuRsbET9ZmVafMsIFglrSslWZb6ZXd8drps588/K5HlGk9qtIyLSLU3U1LS0a9cuPPvss7j55puP+LwHHnhAhh/PVlBQAK1o2LIFrsZGmBITEd67l9rNoY6oKwO++AMwd6wSaEzhwNg7lbqZUTMZaIiI9BxqZs+eLRdoPNK2Zs2aZq85cOCAHIq69NJLccMNNxzx/SMiIhAXF9ds09rQk+il4SKWQa6pEfjleeDZEcDql5QJ9AZdANy6UplzJjJe7RYSEYUEVYefbrvtNlx++eVHfE6vXr2aBZpJkyZhzJgxmDdvHvTMUyTM9Z6CvW7mG3fdTJ5yH+tmiIhCM9SkpKTIrSP2798vA82oUaPw6quvwmjU5MhZhxex9O2poWCtm/kTsGuJcju6C3CGqJu5msNMREQq0UShsOihmThxInr06CGvdiotLfU+lp6eDr2xFxTAUVYGg9mMyJwctZtDLetmlv4dWPOqMswk6mZO/T/g9HuASO0MbxIR6ZEmQs0333yDvLw8uWVkZLTq1dDrek+RgwfDGBGhdnPIUzcj6mWWPgE0uOebEXUzomYmqQ8/IyKiIKCJMZyZM2fK8NLWpuv1njj0FBzyVwJzxyjDTSLQpA8Brv0cmP4WAw0RURDRRE9NqOFMwkFChOZf/gt8+zDgbFLqZs78CzD8KtbNEBEFIYaaIOOorkbDTuVKmij21KhHLGnwyf8B2z5Xbg+eBlzwNC/PJiIKYgw1Qca2QVnE0tyzB8I6eGUY+VnRJuD9GUDFHmXhyXMfA06+ATAY+FETEQUxhpogLRKOGs5LuVWx7k3gyz8ATfVAfCZw6etAxih12kJERMeEoSbI2NYrPTWWkSPVbkpoabQqYWbD28rtrLOBi14Eoo68vhgREQUPhpog4rLbYdu0SR5zJuFOdChPGW4q+RUwGIFJDwLj7gZ0PMEjEZEeMdQEkfpt2+Gy2WCMi0N4375qNyc0/Pox8OntQGONcnXTJa8Avcer3SoiIjoODDXBeCn38GEwsJcg8JPpLf4LsHKucrvHaUqgiesa4C9MRESBwlATRKzrlUn3olhPE1iVBcCH1wGFq5XbY+9S1m0y8a8DEZGW8ad4kBCzIx+eSZhFwgGz81tgwY2ArVyZc2bqC8DA3wbu6xERUadhqAkSTQcOoKm4GDCZYBk6RO3m6I/TASx9HPjxnyJCAl2HAZe9AST2UrtlRETkJww1QcLq7qWJHDQIRotF7eboS20p8NEsYM8Pyu2TrgfOeQwwR6rdMiIi8iOGmiBhc9fTWEZy0j2/yl8BfDATqCkCzFHABf8Bhl7m369BRERBgaEmSLBIOBCLUT4HLH4YcDmAlP7AZW8CqQP9/ZWIiChIMNQEAUdtHRq2b5fHLBL2A1sl8OmthxejzLlE6aGJiPHHuxMRUZBiqAkCto0bAKcT5m7dYE5LVbs5+lmM0hSuLEZ50iwuRklEFAIYaoIA13vy03DTujeAL/8IOBqA+B7AZa8D3Xl5PBFRqGCoCQI298rcLBI+gcUov7gH2Dhfud3/XGDqXC5GSUQUYhhqVOZyOGDbuFEecybh43Bop3sxyi3KYpRiZmAxQzCXmSAiCjkMNSpr2LEDzro6GKOjEZGVpXZztCV3AbBQLEZZC0SnuhejPF3tVhERkUoYaoLkUm7LsGEwmExqN0dDi1H+GVj5gnK75zjgkv8Bselqt4yIiFTEUKMy73pPXMSy44tRisn09q9Rbo+7G5j0IBejJCIihppgKRKO4kzCR7dvOfDulYCtAohMAC56ERhwbsC/R0REpA3sqVGRvbgY9gMHZFFr5NBhajYl+BWsAt6+VKmf6TYCuPR1ILGn2q0iIqIgwlATBOs9RQwYAFNMtJpNCW4H1gNvXawEmt4TgCvfA8xc9JOIiJoztrhNncjqGXoawUUs23UwF3jzIqChGuhxGnDFOww0RETUJoYaFbFI+ChKdwBvXKjU0HQ/SemhCWePFhERtY2hRiVOqxX1W7fK46gRw9VqRvAq3w28MQWwHgLShwBXfwhExqndKiIiCmIMNSqxbc4FHA6EpaUhrFs3tZoRnCrzgdenADVFQJdBwDWfApZEtVtFRERBjqFGJbb1h9d7MhgMajUj+FQfUAJNVQGQ3A+4diEQnax2q4iISAMYalQvEuYq0l61JUoNTcUeIKEnMGMhEJOq1reIiIg0hqFGBS6nE7YNyiKWFl75pLCWA29MBQ7tAOIygGs/A+K7q/HtISIijWKoUUHjrl1wVlfDYLEgcuAANZoQXGyVwJtTgZJfgZh0ZciJE+sREdExYqhRgdWz3tPQoTCYzQhpDTXA25cARRuBqGRgxqdAcl+1W0VERBrEUKPiek+iSDikNVqB+dOBwtXKWk4i0KQOVLtVRESkUQw1KrC6l0cI6ZmE7fXK4pT7lgERccA1C5T5aIiIiI4TQ00nazp0CPb8fMBggGV4iE6619QIfHAtsPt7wBwNXPUh0H2U2q0iIiKNY6hRqZcmol8/mOJCcIZcRxPw0SxgxyIgLFJZ+qDHaLVbRUREOsBQ08lCer0npwP45GZg60LAFA5c/jbQ+3S1W0VERDrBUKNWkXCorffkdAKf3QFs/gAwhgGXvg70m6x2q4iISEcYajqRs6EBti1b5HFUKPXUuFzAV38E1r8FGIzAxS8DA3+rdquIiEhnGGo6UX1uLmC3w5SSAnNmJkIm0HzzELD6ZQAGYOpcYPBFareKiIh0iKFGlfWeQmgRy+//BvzynHJ8wdPAsMvVbhEREekUQ40aRcKhMj/Nj08CP/5TOf7NP4FRM9VuERER6RhDTSdxuVyweSbdC4WZhH/5L7Dkr8rxWXOA0Tep3SIiItI5hppO0rhnLxyVlTBERCAyOxu6tuol4Os/KccT/wSMvVPtFhERUQhgqOkktvVKPU3kkBwYwsOhW+veBL78g3I87vfAhHvVbhEREYUIhhoVioR1a9MHwMLblePRtwBnPiyXgyAiIuoMDDWdxLZ+g9xbRuh0fpotnwIf/05UDwGjrgPOfYyBhoiIOhVDTSdoqqhA4+7d+p1JeMfXwIezAJcDGHYlcN5TDDRERNTpGGo6sZcmvE8fhCUmQld2fQ+8dw3gtAM5FwMXPgcY+ceKiIg6H3/7dALPpdy666XZuwx45wrA0QAMPB+46EXAaFK7VUREFKI0F2oaGhowfPhwOSPvhg1KD0iws7qvfNLVek8Fq4H5lwFNNqDfWcAlrwAms9qtIiKiEKa5UHPvvfeiW7du0ApXYyPqN+fqq0i4aBPw1sVAYy3Qezww/U0gLELtVhERUYjTVKj56quv8M033+DJJ5+EVtRv2QJXQwNMCQkI790LmtdQC3xwLdBQBfQYA1zxLmC2qN0qIiIihGnlMyguLsaNN96ITz75BFFRUR0eqhKbR3V1NTqb1Xspt04Wsfz6AaB8NxDXHbjiHSA8Wu0WERERaaenRqybNHPmTNx888046aSTOvy6xx57DPHx8d4tMzMTnc3mnnTPoof1nrZ+Bqx7A4BBKQq26OxKLiIi0jRVQ83s2bNl78WRtjVr1uDZZ5+VvSwPPPDAMb2/eH5VVZV3KygoQGeHMat3EUuN19NUFwEL71COx94B9D5d7RYRERE1Y3CJ37wqOXTokNyOpFevXrj88svx2WefNRu+cTgcMJlMuOqqq/D666936OuJYCR6bETAiYuLQ6A15udj19nnAGYzBqxZDWOERotpnU7g7YuBXUuA9KHADd8BYTpev4qIiIJKR39/q1pTk5KSIrejeeaZZ/Doo496bx84cADnnHMO3nvvPYwePRpBPz9NdrZ2A42w6kUl0IRFAhe/zEBDRERBSROFwj169Gh2OyYmRu779u2LjIwMBCvrOneo0fLQU/GvwOKHleOzHwW6DFC7RURERNotFNYqzRcJ2+uBj25UZgzOOgc4+Qa1W0RERKTtnpq26mxULAXqEEd1NRry8uRx1AiNhprv5gAlvwJRKcqaTnq4JJ2IiHSLPTUBYtu4UVz+BHOPHgjrQN1Q0BE1NCv+qxxf+F8gJlXtFhERER0RQ02AWN1DT5rspbGWA5/8n3J80ixgwLlqt4iIiOioGGoCxKbVImExrPfZHUBNEZDSXykOJiIi0gCGmgBw2e2wbdokj6O0ViS8/i1l5mCjGZj2EhDesSUpiIiI1MZQEwD123fAZbPBGBeH8L59oRllu4Cv7lOOz3gQ6DZc7RYRERF1GENNIC/lHj4MBqNGPmKHHVhwE2CvA3qOA05zL4lARESkERr5jast1vXuImEt1dP8+E9g/xogIh646AXAaFK7RURERMeEocbPxPw53iLhERoJNfkrlVAjnP8UkND5q5kTERGdKIYaP2sqKkJTcTFgMsEyJAdBr74aWHAj4HICQ6cDQy5Ru0VERETHhaEmQOs9RQ4aBGOUBq4cEoXBlfuA+B7Ab929NURERBrEUBPK6z3lLgA2zgcMRmDaPCAyXu0WERERHTeGGj+zrl+vjSLhqkLg87uU43F3Az3HqN0iIiKiE8JQ40eO2jo0bN8ujy3BvDyC0wl8fDNQXwV0GwlMvF/tFhEREZ0whho/qt+0UQYGc7duMKelIWj98iyw9yfAHKXMGmwyq90iIiKiE8ZQE4Ai4aBe76loI/DdX5Xjcx8DUvqp3SIiIiK/YKgJpSLhRivw0Y2A0w4MOA8Yea3aLSIiIvIbhho/cTkcsG3cKI+jgrWeZvFfgEPbgZg0YMqzgMGgdouIiIj8hqHGTxp27oSzrg7G6GhE9O+PoLPjG2D1S8rx1OeB6GS1W0RERORXDDV+YvUMPQ0bBoMpyNZNqi0FPv0/5Xj0LUC/yWq3iIiIyO8YavzEFqxFwi4XsPA2oK4USM0GJs9Wu0VEREQBwVDjJzb3pHuWEcMRVNa8AuxYBJjClcu3zZFqt4iIiCggGGr8wF5cAvv+/YDRCMuwIAo1pTuArx9UjkUPTboGFtgkIiI6Tgw1fmBbr9TTRAwYAFNMNIJCUyOw4AagyQb0majU0hAREekYQ40fWBcqVxVFZViUotxgsPTvykR7lkRg6guyF4mIiEjPwtRugB7Yct3rPdV8BzyZBfQYAwy6ABh0PpDQo/MbtPdn4OenleMLngHiunZ+G4iIiDqZweUSl8eEhurqasTHx6OqqgpxcXF+e1/bz1/B9u37iI3Lg7l6U/MHuw5Xws2gKUCXAX77mu03phKYOxaoLgRGXA1c+N/Af00iIqIg+P3NUONvlQXAti+ArZ8B+csBl/PwYyn9lR6cgecD3UYEZkbfD2cBuR8Cib2Bm38GImL8/zWIiIg6EUPNCXwofiPqa7Z/CWz7HNj1vbLmkkd8phJuRMjpcSpg9MOEfZveBxbcCBhMwKxvgIyTTvw9iYiIVMZQcwIfSkDUVwE7Fys9OGJvrzv8WFQKMPC3yhBV7/FAWMSxv3/FPuCFcUBDNTDxT8DE+/zafCIiIrUw1JzAhxJwdpvScyMCjujJqa88/FhEHJB1ttKDI5Yz6MjwkdMBvHa+MtyVORqY+SVgYg04ERHpA0PNCXwoncphB/YtUwLO1s+B2oOHHwuLBPqeqRQa9z8XiEpq+z1+fBJY8lcgPBa4+ScgqXenNZ+IiCjQGGpO4ENRjdMJ7F8LbF2ohJyKPYcfE3UyvU8/XGgcm67cv38d8L+zAGcTMHUuMPxK1ZpPREQUCAw1J/ChBAVxpX3xr0qRsQg4xbnNH884RenBWfcGUJYHZE8FLn0tMFdUERERqYih5gQ+lKBUvlsZnhIBp3BV88diuwG3LGt/eIqIiCgEfn+zmlQrkvoAY+9QtuoipQdHbIfygGnzGGiIiCjkMdRokVj24JQblY2IiIgkrnJIREREusBQQ0RERLrAUENERES6wFBDREREusBQQ0RERLrAUENERES6wFBDREREusBQQ0RERLrAUENERES6wFBDREREusBQQ0RERLrAUENERES6wFBDREREusBQQ0RERLoQhhDicrnkvrq6Wu2mEBERUQd5fm97fo+3J6RCTU1NjdxnZmaq3RQiIiI6jt/j8fHx7T5ucB0t9uiI0+nEgQMHEBsbC4PB4NcEKYJSQUEB4uLioHehdr6heM48X33j91ffqnX480pEFRFounXrBqOx/cqZkOqpER9ERkZGwN5f/OHRyx+gjgi18w3Fc+b56hu/v/oWp7OfV0fqofFgoTARERHpAkMNERER6QJDjR9ERETg4YcflvtQEGrnG4rnzPPVN35/9S0ixH5ehWyhMBEREekXe2qIiIhIFxhqiIiISBcYaoiIiEgXGGqIiIhIFxhq/OD5559H7969ERkZiVGjRuGnn36CHjz22GM4+eST5QzMqampmDp1KrZv397sOaLOfPbs2XKWR4vFgokTJ+LXX3+FHs5dzDp911136fpc9+/fj6uvvhrJycmIiorC8OHDsXbtWl2ec1NTEx566CH5d1WcS58+fTBnzhw507gezvfHH3/EBRdcINsu/ux+8sknzR7vyLk1NDTg9ttvR0pKCqKjozFlyhQUFhZCa+drt9tx3333YciQIfI8xHNmzJghZ5TX4/m29Lvf/U4+5+mnn9bs+R4vhpoT9N5778lffA8++CDWr1+P008/Hb/5zW+Qn58Prfvhhx9w6623YsWKFVi8eLH8pXD22Wejrq7O+5x//OMfeOqpp/Dcc89h9erVSE9Px1lnneVdZ0uLxHnMmzcPQ4cObXa/3s61oqICY8eOhdlsxldffYUtW7bgX//6FxISEnR5zk888QReeOEFeS5bt26V5/bPf/4Tzz77rC7OV/y9HDZsmGx7WzpybuJn2ccff4x3330XP//8M2pra3H++efD4XBAS+drtVqxbt06/PnPf5b7BQsWYMeOHfKXuC+9nK+vTz75BCtXrpThpyUtne9xE5d00/E75ZRTXDfffHOz+wYOHOi6//77dfexlpSUiMv/XT/88IO87XQ6Xenp6a7HH3/c+5z6+npXfHy864UXXnBpUU1NjSsrK8u1ePFi14QJE1x33nmnbs/1vvvuc40bN67dx/V2zuedd57r+uuvb3bftGnTXFdffbXuzlf8Pf3444+9tztybpWVlS6z2ex69913vc/Zv3+/y2g0uhYtWuTS0vm2ZdWqVfJ5+/bt0+35FhYWurp37+7Kzc119ezZ0/Xvf//b+5iWz/dYsKfmBDQ2NsquetF74UvcXr58OfSmqqpK7pOSkuR+z549OHjwYLPzF5M9TZgwQbPnL3qmzjvvPEyePLnZ/Xo814ULF+Kkk07CpZdeKocXR4wYgZdeekm35zxu3Dh899138l/swsaNG+W/Vn/729/q8nx9deTcxM8yMWzj+xzxr/2cnBzNn7/n55cYkvH0ROrtfMUw6jXXXIM//vGPGDx4cKvH9Xa+7QmpBS397dChQ7LbLi0trdn94rb4AaIn4h8Hd999t/zFIP4SCJ5zbOv89+3bB60RXbKiq1p0zbekt3MVdu/ejblz58rv65/+9CesWrUKd9xxh/xlJ+oP9HbOosZC/GIbOHAgTCaT/Lv7t7/9DVdccYV8XG/n66sj5yaeEx4ejsTERN39PKuvr8f999+PK6+80rvAo97OVwyvhoWFyb/DbdHb+baHocYPRPpvGQBa3qd1t912GzZt2iT/ZavH8y8oKMCdd96Jb775RhZ8t0cP5+r7LzvRU/P3v/9d3hY9NaJwVAQdEWr0ds6i/u2tt97C/Pnz5b9kN2zYIGsMxL9Wr732Wt2db1uO59y0fv6id+Lyyy+Xf97FRR1Ho8XzFb0w//nPf+Q/yo617Vo83yPh8NMJEBXk4l98LVNuSUlJq38RaZmolhdDFd9//z0yMjK894tCQ0EP5y9+KIh2i6vXxL92xCYKpZ955hl57DkfPZyrR9euXZGdnd3svkGDBnmL3PX0/RVEt7z417r4BSeuihFd9b///e/llW56PF9fHTk38RwxpC4KyNt7jhYDzWWXXSaH38TFDp5eGr2dr7jiVrS7R48e3p9fogfunnvuQa9evXR3vkfCUHMCRFee+CUo/rL4ErdPO+00aJ1I8KKHRlw5sGTJEnkprC9xW/xF8T1/8ZdGhAGtnf+ZZ56JzZs3y3+9ezbRi3HVVVfJY3H5r17O1UNc+dTyEn1Rb9KzZ0/dfX89V8QYjc1/5Il/lHgu6dbb+frqyLmJn2XiSjjf5xQVFSE3N1eT5+8JNDt37sS3334rpy3wpafzFQFd9KRv8Pn5JXogRZD/+uuvdXe+R6R2pbLWiUpyUVH+v//9z7VlyxbXXXfd5YqOjnbt3bvXpXW33HKLvDpi6dKlrqKiIu9mtVq9zxFXU4jnLFiwwLV582bXFVdc4erataururrapXW+Vz/p8VzF1SBhYWGuv/3tb66dO3e63n77bVdUVJTrrbfe0uU5X3vttfLKkM8//9y1Z88eeU4pKSmue++9VxfnK67cW79+vdzEj/annnpKHnuu9unIuYkrOTMyMlzffvuta926da4zzjjDNWzYMFdTU5NLS+drt9tdU6ZMkeeyYcOGZj+/GhoadHe+benZ4uonrZ3v8WKo8YP//ve/8g9QeHi4a+TIkd5LnrVO/MVpa3v11VebXSr68MMPy8tFIyIiXOPHj5c/MPWgZajR47l+9tlnrpycHHk+YiqCefPmNXtcT+csfnmL72ePHj1ckZGRrj59+rgefPDBZr/ktHy+33//fZt/X0WY6+i52Ww212233eZKSkpyWSwW1/nnn+/Kz893ae18RWht7+eXeJ3ezrejocamofM9XgbxP7V7i4iIiIhOFGtqiIiISBcYaoiIiEgXGGqIiIhIFxhqiIiISBcYaoiIiEgXGGqIiIhIFxhqiIiISBcYaoiIiEgXGGqISBVLly6VqwNXVlaq8vXFemYDBw70rv10JJ9//rlcxbwjzyUi9TDUEFHATZw4EXfddVez+8QiemJBvfj4eFW+A/feey8efPDBVotctuX888+XAWz+/Pmd0jYiOj4MNUSk2ir3YuVoERY62/Lly+XqzZdeemmHX3Pdddfh2WefDWi7iOjEMNQQUUDNnDkTP/zwA/7zn//IACO2vXv3thp+eu2115CQkCCHegYMGICoqChccsklqKurw+uvv45evXohMTERt99+OxwOh/f9GxsbZa9L9+7dER0djdGjR8v3PpJ3330XZ599NiIjI733bdy4EZMmTUJsbCzi4uIwatQorFmzxvv4lClTsGrVKuzevTsgnxMRnbgwP7wHEVG7RJjZsWMHcnJyMGfOHHlfly5dZLBpyWq14plnnpGho6amBtOmTZObCDtffvmlDBQXX3wxxo0bh+nTp3t7UMR7idd069YNH3/8Mc4991xs3rwZWVlZbbbpxx9/xBVXXNHsvquuukrWzcydOxcmkwkbNmyA2Wz2Pt6zZ0+kpqbip59+Qp8+ffgdJwpCDDVEFFCiZkYMNYmeFzHcdCR2u12Gir59+8rboqfmzTffRHFxMWJiYpCdnS17U77//nsZanbt2oV33nkHhYWFMtAIf/jDH7Bo0SK8+uqr+Pvf/97m1xEhyPN8j/z8fPzxj3+UxcNCW4FI9Aa1FcaIKDgw1BBR0BDBxxNohLS0NDnsJAKN730lJSXyeN26dXC5XOjfv3+z92loaEBycnK7X8dmszUbehLuvvtu3HDDDTJETZ48Wdbb+LZFsFgssjeJiIITQw0RBQ3f4R5B1Ny0dZ/n0mqxF0NFa9eulXtfvkGopZSUFFRUVDS7b/bs2bjyyivxxRdf4KuvvsLDDz8sh7Quuugi73PKy8vl0BkRBSeGGiIKODH85Fvc6y+iBka8r+i5Of3004/pdVu2bGl1v+jxEdvvf/97WXMjhrA8oaa+vl4Od4nXElFw4tVPRBRwYghp5cqVsh7l0KFDfpvETgQQUeA7Y8YMLFiwAHv27MHq1avxxBNPyMLi9pxzzjn4+eefmw1H3XbbbfKqqX379mHZsmXyfQYNGuR9zooVKxAREYExY8b4pe1E5H8MNUQUcKJ4VwwPiUJfMXwjinL9RfSmiFBzzz33yEvBxaXXIkBlZma2+5qrr75a9tRs375d3hZtKysrk+8jgtJll12G3/zmN3jkkUe8rxEFySJAibofIgpOBpeosiMiCjFibpuqqiq8+OKLR31uaWmpvCpKzFvTu3fvTmkfER079tQQUUgSSySIuWc6UusjhrWef/55BhqiIMeeGiIiItIF9tQQERGRLjDUEBERkS4w1BAREZEuMNQQERGRLjDUEBERkS4w1BAREZEuMNQQERGRLjDUEBERkS4w1BARERH04P8BxUI2vgp9vKwAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#Plot states\n",
+    "\n",
+    "t = m.i.get_finite_elements()      \n",
+    "\n",
+    "z1 = [value(m.z1[i]) for i in t]\n",
+    "z2 = [value(m.z2[i]) for i in t]\n",
+    "z3 = [value(m.z3[i]) for i in t]\n",
+    "z4 = [value(m.z4[i]) for i in t]\n",
+    "\n",
+    "# Plot optimal state trajectories (deviations from steady state, cm)\n",
+    "plt.plot(t, z1, label='z1')\n",
+    "plt.plot(t, z2, label='z2')\n",
+    "plt.plot(t, z3, label='z3')\n",
+    "plt.plot(t, z4, label='z4')\n",
+    "\n",
+    "plt.xlabel('time (s)')\n",
+    "plt.ylabel('value')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "34322b82-a04a-421f-8975-8c1192899913",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:10.504847Z",
+     "iopub.status.busy": "2026-07-11T20:06:10.504847Z",
+     "iopub.status.idle": "2026-07-11T20:06:10.586321Z",
+     "shell.execute_reply": "2026-07-11T20:06:10.586321Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj4AAAGwCAYAAACpYG+ZAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAKWlJREFUeJzt3QlcVPX+//EPsgkugKIsiVvaYnS10FJb1FLTa1pZlFtpi9Y1U9OyyG4iPZTKtMyupt1SWyz/PbJuZqVWuOWSmpRpP1NDwZQIJXALXM7/8f3eH/NjEJAUZuac7+v5eByHOXNm5vsdZOY93+34WZZlCQAAgAFqeLsAAAAAnkLwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwRoC3C+BrTp8+Lfv375c6deqIn5+ft4sDAAAqQS1LePjwYYmNjZUaNcpv1yH4lKJCT1xcXGVeYwAA4GOysrKkUaNG5d5O8ClFtfQUv3B169at3t8OAACoEgUFBbrhovhzvDwEn1KKu7dU6CH4AABgL2cbpsLgZgAAYAyCDwAAMAbBBwAAGIMxPgAA2GS5laKiIjFVYGCg+Pv7n/fjEHwAAPBxKvBkZGTo8GOy8PBwiY6OPq919gg+AAD4+MJ8Bw4c0K0darp2RYvzOfk1OHbsmOTk5OjrMTEx5/xYBB8AAHzYyZMn9Ye+WpE4NDRUTBUSEqIvVfhp2LDhOXd7mRcbAQCwkVOnTunLoKAgMV3o/wa/EydOnPNjEHwAALABzh8pVfIaEHwAAIAxCD4AAMAYBB8AAGAMgg8AAPAoNT1/wIABcvHFF+vp+aNHj/bYczOd3YNyCv6UnMOF4mkRtYLkgvD/TgMEAMDbCgsLpUGDBjJ+/Hh56aWXPPrcBB8PendDpkz/aqd4Wkigv3w5thPhBwDgEbNnz5aUlBTJyspyW3CxT58+EhERIfPnz5fp06frfW+++aZ4EsHHgwZe3Vi6tYry5FPKrpwjMnphuuQdLSL4AIBDHC86Jbt/P+Lx572wQW0JCTr7woGJiYkycuRISUtLkxtvvFHvy8vLk6VLl8rixYvFmwg+HtSwbk29AQBwPlTouXnGGo+/iJ8+cq3EXxB21uPq1asnPXr0kAULFriCzwcffKD3F1/3FoIPAAA2o1peVAjxxvNW1sCBA2XYsGEyc+ZMCQ4OlnfffVf69etXJWdYPx8EHwAAbEZ1N1Wm5cWbevfurc8mv2TJEmnXrp2sXr1apk2b5u1iEXwAAED1nFS0b9++uqVn165dctFFF0lCQoJ4Gy0+AACgWqjuLtXys23bNhk0aJDbbenp6fryyJEj8vvvv+vr6kSsrVq1kupE8AEAANXihhtu0AOad+zYoRcsLOmKK65w/bx582Y9ELpJkyayZ88eqU4EHwAAUC3UQOb9+/eXeZtlWeINtjplxapVq3STWWxsrD41/ccff+x2+5AhQ/T+klv79u29Vl4AAOBbbBV8jh49Kq1bt5ZXX3213GPUugHqHCDF22effebRMgIAAN9lq66unj176q0iaq2A6Ojov3S+ELUVKygoOK8yAgAA32WrFp/KWLFihTRs2FBPmxs6dKjk5ORUeHxqaqqEhYW5tri4OI+VFQAAeJajgo9qDVLrBXz99dcydepU2bhxox5RXrJFp7SkpCTJz893beqEagAAwJls1dV1NnfddZfr5/j4eGnbtq2eGqdWjVSLKJXXNaY2AADgfI5q8SktJiZGB5+dO3d6uygAAMAHODr4HDx4UHddqQAEAABgq64utay1Ot9HsYyMDL3EtVoVUm3Jycly++2366CjVn586qmnJDIyUm677TavlhsAAPgGW7X4bNq0SS9xXbzM9ZgxY/TPzzzzjF4dcuvWrXLLLbfoGV2DBw/Wl+vWrZM6dep4u+gAAOB/LVq0SLp16yYNGjSQunXrSocOHWTp0qXiCbZq8encuXOFS1x76kUDAADndyYGFXwmT54s4eHhMnfuXH1mhg0bNridw0tMDz4AAMD3zZ49W1JSUvQ42xo1/q9zqU+fPhIRESHz5893O14FoP/85z+yePHiag8+turqAgAAvi8xMVFyc3MlLS3NtS8vL0/3zAwcOPCM40+fPi2HDx/W43WrGy0+AADYTdExkdyfPf+8kReJBIWe9TAVYNS5MxcsWCA33nij3vfBBx/o/cXXS1KLDqvzcd55551S3Qg+AADYjQo9czp5/nmHrRSJbVOpQ1XLzrBhw2TmzJl6oWB1ZoV+/frpyUglvffee3pWturqUqecqm4EHwAA7Ea1vKgQ4o3nrSQ1WFl1YamzJ7Rr105Wr14t06ZNcztm4cKFcv/99+vWoK5du4onEHwAALAb1d1UyZYXbwkJCdGni1ItPWoNPrXETEJCgltLz3333acve/Xq5bFyEXwAAEC1UN1dquVn27ZtMmjQINd+FXbuuecemT59urRv316ys7NdYSksLEyqE7O6AABAtbjhhhv0gOYdO3bIgAED3Ka7nzx5Uh5++GF9toXibdSoUVLdaPEBAADVQg1k3r9//xn7V6xYId5Ciw8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAYAOWZYnprCp4DQg+AAD4sOJTPBQVFYnpjh07pi8DAwPP+TGYzg4AgA8LCAiQ0NBQ+f333/UHfo0aNYxs6Tl27Jjk5ORIeHj4Gef7+isIPgAA+DA/Pz+9uF9GRobs3btXTBYeHi7R0dHn9RgEHwAAfFxQUJC0bNnS6O6uwMDA82rpKUbwAQDABlQXV82aNb1dDNszr6MQAAAYi+ADAACMQfABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMIatgs+qVaukd+/eEhsbK35+fvLxxx+73W5ZliQnJ+vbQ0JCpHPnzrJt2zavlRcAAPgWWwWfo0ePSuvWreXVV18t8/YXXnhBpk2bpm/fuHGjREdHS7du3eTw4cMeLysAAPA9AWIjPXv21FtZVGvPyy+/LOPHj5e+ffvqffPnz5eoqChZsGCBPPjggx4uLQAA8DW2avGpSEZGhmRnZ0v37t1d+4KDg6VTp06ydu3acu9XWFgoBQUFbhsAAHAmxwQfFXoU1cJTkrpefFtZUlNTJSwszLXFxcVVe1kBAIB3OCb4FFODnkt3gZXeV1JSUpLk5+e7tqysLA+UEgAAeIOtxvhURA1kVlTrTkxMjGt/Tk7OGa1AJanuMLUBAADnc0yLT7NmzXT4Wb58uWtfUVGRrFy5Ujp27OjVsgEAAN9gqxafI0eOyK5du9wGNKenp0u9evWkcePGMnr0aJk8ebK0bNlSb+rn0NBQGTBggFfLDQAAfIOtgs+mTZukS5curutjxozRl4MHD5Z58+bJuHHj5Pjx4zJ8+HDJy8uTq6++WpYtWyZ16tTxYqkBAICvsFXwUSsxq8HK5VGDmNXKzWoDAABw7BgfAACAsyH4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwAAIAxHBV8kpOTxc/Pz22Ljo72drEAAICPCBCHueyyy+TLL790Xff39/dqeQAAgO9wXPAJCAiglQcAADi/q0vZuXOnxMbGSrNmzaRfv37yyy+/VHh8YWGhFBQUuG0AAMCZHBV8rr76annrrbdk6dKl8vrrr0t2drZ07NhRDh48WO59UlNTJSwszLXFxcV5tMwAAMBzHBV8evbsKbfffrtcfvnl0rVrV1myZIneP3/+/HLvk5SUJPn5+a4tKyvLgyUGAACe5LgxPiXVqlVLhyDV/VWe4OBgvQEAAOdzVItPWeN3fvrpJ4mJifF2UQAAgA9wVPB57LHHZOXKlZKRkSEbNmyQO+64Qw9WHjx4sLeLBgAAfICjurr27dsn/fv3l9zcXGnQoIG0b99e1q9fL02aNPF20QAAgA9wVPB5//33vV0EAADgwxzV1QUAAFARgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGMORwWfmzJnSrFkzqVmzpiQkJMjq1au9XSQAAOADHBd8Fi5cKKNHj5bx48fLli1b5LrrrpOePXtKZmamt4sGAAC8LEAcZtq0aXL//ffLAw88oK+//PLLsnTpUpk1a5akpqaKqXblHPH4cwYe+VX8/zzk8eetHREl0Y1bevx5AQC+z1HBp6ioSDZv3ixPPvmk2/7u3bvL2rVry7xPYWGh3ooVFBSIk0TUCpLmgXny+v/7yKPPW9+vQF4LfFlC/f7vtfWUY1aw/NBlloRGRHn8uYHqUDckUBrWDubFhTPUif7v5iWOCj65ubly6tQpiYpy/8BT17Ozs8u8j2oFmjhxojjVBZIrXwY/JjX8j3v8uU8HhMierm/LyZB6HnvOY3m/SYu0f8jfVtznsecEAFTe0faPSa0e/xTbBZ9du3bJ7t275frrr5eQkBCxLEv8/PzEF5QuR0VlS0pKkjFjxri1+MTFxYljHDsoNU4eF+n7ukjkRR596hqh9aVpuOdfy+zmf5P9eb95/HmB6pB//IRMXvKT/HnyNC8wHOGWU1fKMC8+/18OPgcPHpS77rpLvv76ax0mdu7cKc2bN9djasLDw2Xq1KniLZGRkeLv739G605OTs4ZrUDFgoOD9eZ4KvTEthET6PE9jPGBg7xySXvJO1rk7WIAVaJhHe9+5v7l4PPoo49KQECAniV16aWXuvarMKRu82bwCQoK0tPXly9fLrfddptrv7p+yy23eK1cAHA+LggP0RsALwSfZcuW6VlSjRo1ctvfsmVL2bt3r3ib6ra6++67pW3bttKhQweZM2eODmkPPfSQt4sGAADsFnyOHj0qoaGhZQ4s9oUuI9XypLrjUlJS5MCBAxIfHy+fffaZNGnSxNtFAwAAdlvAUA1mfuutt1zX1Tif06dPy5QpU6RLly7iC4YPHy579uzR09TV9HZVZgAAgL/c4qMCTufOnWXTpk163Zxx48bJtm3b5NChQ/LNN9/wigIAAOe0+LRq1Up++OEHueqqq6Rbt26666tv37769BAXXnhh9ZQSAADAW+v4REdHO3rRPwAA4Ex/OfisWrWqwtsZTwMAABwTfNT4ntJKroqsThkBAADgiDE+eXl5bptaFfmLL76Qdu3a6TV+AAAAHNPiExYWdsY+NchZreGjVm5W08cBAAAc0eJTngYNGsiOHTuq6uEAAAC83+KjprKXPvO5WiH5ueeek9atW1dl2QAAALwbfNq0aaMHM6vAU1L79u3lzTffrMqyAQAAeDf4ZGRkuF2vUaOG7uaqWbNmVZYLAADA+8GHk30CAABHB59XXnml0g84cuTI8ykPAACAd4PPSy+9VKkHU2N/CD4AAMDWwaf0uB4AAACj1/EBAABw5NnZ9+3bJ5988olkZmZKUVGR223Tpk2rqrIBAAB4N/h89dVX0qdPH2nWrJleqTk+Pl727Nmj1/W58sorq7Z0AAAA3uzqSkpKkrFjx8qPP/6o1+758MMPJSsrSzp16iSJiYlVWTYAAADvBp+ffvpJBg8erH8OCAiQ48ePS+3atSUlJUWef/75qi0dAACAN4NPrVq1pLCwUP8cGxsru3fvdt2Wm5tblWUDAADw7hgfdU6ub775Rlq1aiW9evXS3V5bt26VRYsW6dsAAAAcE3zUrK0jR47on5OTk/XPCxculBYtWlR6oUMAAABbBJ9nn31WBg0apGdxhYaGysyZM6unZAAAAN4e43Pw4EHdxdWoUSPdzZWenl7VZQIAAPCN4KMWLszOzpYJEybI5s2bJSEhQY/3mTx5sl7PBwAAwFGnrAgPD5dhw4bJihUrZO/evXLvvffK22+/rcf5AAAAOPJcXSdOnJBNmzbJhg0bdGtPVFRU1ZUMAADAF4JPWlqaDB06VAcdtZhhnTp1ZPHixXoFZwAAAMfM6lKDmtUA55tuuklmz54tvXv31qeuAAAAcFzweeaZZ/Q5uSIiIqqnRAAAAL4SfNSgZgAAAOMGNwMAANgJwQcAABiD4AMAAIzhqODTtGlT8fPzc9uefPJJbxcLAADYdXCzr0tJSdFrDBWrXbu2V8sDAAB8h+OCj1pMMTo62tvFAAAAPshRXV3K888/L/Xr15c2bdrIpEmTpKioqMLjCwsLpaCgwG0DAADO5KgWn1GjRsmVV16pF1f89ttvJSkpSTIyMuTf//53ufdJTU2ViRMnerScAADAO/wsy7LEhyUnJ581mGzcuFHatm17xv4PP/xQ7rjjDsnNzdWtQOW1+KitmGrxiYuLk/z8fKlbt67Y3v50kTmdRIatFIlt4+3SAABQLdTnd1hY2Fk/v32+xWfEiBHSr1+/s87mKkv79u315a5du8oNPsHBwXoDAADO5/PBJzIyUm/nYsuWLfoyJiamiksFAADsyOeDT2WtW7dO1q9fL126dNFNXar769FHH5U+ffpI48aNvV08AADgAxwTfFR31cKFC/V4IDVmp0mTJno9n3Hjxnm7aAAAwEc4Jvio2VyqxQcAAMCYdXwAAADKQ/ABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGPYJvhMmjRJOnbsKKGhoRIeHl7mMZmZmdK7d2+pVauWREZGysiRI6WoqMjjZQUAAL4pQGxCBZjExETp0KGDvPHGG2fcfurUKenVq5c0aNBA1qxZIwcPHpTBgweLZVkyY8YMr5QZAAD4FtsEn4kTJ+rLefPmlXn7smXLZPv27ZKVlSWxsbF639SpU2XIkCG6tahu3boeLS8AAPA9tunqOpt169ZJfHy8K/QoN910kxQWFsrmzZvLvZ+6vaCgwG0DAADO5Jjgk52dLVFRUW77IiIiJCgoSN9WntTUVAkLC3NtcXFxHigtAAAwLvgkJyeLn59fhdumTZsq/Xjq+NLUGJ+y9hdLSkqS/Px816a6ygAAgDN5dYzPiBEjpF+/fhUe07Rp00o9VnR0tGzYsMFtX15enpw4ceKMlqCSgoOD9QYAAJzPq8FHTTlXW1VQs73UIOYDBw5ITEyMa8CzCjUJCQlV8hwAAMDebDOrS63Rc+jQIX2ppq6np6fr/S1atJDatWtL9+7dpVWrVnL33XfLlClT9LGPPfaYDB06lBldAADAXsHnmWeekfnz57uuX3HFFfoyLS1NOnfuLP7+/rJkyRIZPny4XHPNNRISEiIDBgyQF1980YulBgAAvsTPUqN/4aKms6vZXWqgsyPW/tmfLjKnk8iwlSKxbbxdGgAAvPr57Zjp7AAAAGdD8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAxiD4AAAAY9gm+EyaNEk6duwooaGhEh4eXuYxfn5+Z2yvvfaax8sKAAB8U4DYRFFRkSQmJkqHDh3kjTfeKPe4uXPnSo8ePVzXw8LCPFRCAADg62wTfCZOnKgv582bV+FxqjUoOjraQ6UCAAB2YpuursoaMWKEREZGSrt27XQ31+nTpys8vrCwUAoKCtw2AADgTLZp8amMZ599Vm688UYJCQmRr776SsaOHSu5ubny9NNPl3uf1NRUV2sSAABwNq+2+CQnJ5c5ILnktmnTpko/ngo4agxQmzZtdOhJSUmRKVOmVHifpKQkyc/Pd21ZWVlVUDMAAOCLArzdLdWvX78Kj2natOk5P3779u1119Vvv/0mUVFRZR4THBysNwAA4HxeDT5qLI7aqsuWLVukZs2a5U5/BwAAZrHNGJ/MzEw5dOiQvjx16pSkp6fr/S1atJDatWvL4sWLJTs7W3d1qTE+aWlpMn78eBk2bBgtOgAAwF7B55lnnpH58+e7rl9xxRX6UgWczp07S2BgoMycOVPGjBmjZ3I1b95cj/F5+OGHvVhqAADgS/wsy7K8XQhfosYEqUUP1UDnunXriu3tTxeZ00lk2EqR2DbeLg0AAF79/HbcOj4AAADlIfgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwAAIAxCD4AAMAYBB8AAGAMgg8AADAGwQcAABiD4AMAAIxB8AEAAMYg+AAAAGMQfAAAgDFsEXz27Nkj999/vzRr1kxCQkLkwgsvlAkTJkhRUZHbcZmZmdK7d2+pVauWREZGysiRI884BgAAmCtAbOB//ud/5PTp0zJ79mxp0aKF/PjjjzJ06FA5evSovPjii/qYU6dOSa9evaRBgwayZs0aOXjwoAwePFgsy5IZM2Z4uwoAAMAH2CL49OjRQ2/FmjdvLjt27JBZs2a5gs+yZctk+/btkpWVJbGxsXrf1KlTZciQITJp0iSpW7eu18oPAAB8gy26usqSn58v9erVc11ft26dxMfHu0KPctNNN0lhYaFs3ry53MdRtxcUFLhtAADAmWzR4lPa7t27dfeVatEplp2dLVFRUW7HRURESFBQkL6tPKmpqTJx4kTxiMPZ/908Kfdnzz4fAAA+zKvBJzk5+ayhY+PGjdK2bVvX9f379+tur8TERHnggQfcjvXz8zvj/mqMT1n7iyUlJcmYMWNc11WLT1xcnFSLTXNFVj4nHhcYKhJa3/PPCwCAj/Fq8BkxYoT069evwmOaNm3qFnq6dOkiHTp0kDlz5rgdFx0dLRs2bHDbl5eXJydOnDijJaik4OBgvXlE23tFLu4pHqdCT3g1hTkAAGzEq8FHTTlXW2X8+uuvOvQkJCTI3LlzpUYN9+FJKgypQcwHDhyQmJgY14BnFWrUfXxCnej/bgAAwCv8LNUX5ONUS0+nTp2kcePG8tZbb4m/v79bS0/xdPY2bdro1p0pU6bIoUOH9IyuW2+99S9NZ1ddXWFhYXrwNDPBAACwh8p+ftticLNqudm1a5feGjVq5HZbcW5TYWjJkiUyfPhwueaaa/RChwMGDHBNdwcAALBFi48n0eIDAIBzP79tu44PAADAX0XwAQAAxiD4AAAAYxB8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGsMW5ujyp+AweaulrAABgD8Wf22c7ExfBp5TDhw/ry7i4uOr63QAAgGr8HFfn7CoPJykt5fTp07J//36pU6eO+Pn5VWkSVWEqKyurwpOnOQX1dT5+x87G79fZChz4maRaelToiY2NlRo1yh/JQ4tPKerFatSoUbX9YtR/MKf8J6sM6ut8/I6djd+vs9V12GdSRS09xRjcDAAAjEHwAQAAxiD4eEhwcLBMmDBBX5qA+jofv2Nn4/frbMGGfSaVxOBmAABgDFp8AACAMQg+AADAGAQfAABgDIIPAAAwBsHHQ2bOnCnNmjWTmjVrSkJCgqxevVrsLjU1Vdq1a6dXuW7YsKHceuutsmPHjjNW0kxOTtYraYaEhEjnzp1l27Zt4gSq/mp179GjRzu6vr/++qsMGjRI6tevL6GhodKmTRvZvHmzI+t88uRJefrpp/XfqqpL8+bNJSUlRa/o7oT6rlq1Snr37q3Lrv7vfvzxx263V6ZuhYWF8sgjj0hkZKTUqlVL+vTpI/v27RO71ffEiRPyxBNPyOWXX67roY6555579Mr9TqxvaQ8++KA+5uWXX7Ztfc8VwccDFi5cqD8cx48fL1u2bJHrrrtOevbsKZmZmWJnK1eulIcffljWr18vy5cv1x8a3bt3l6NHj7qOeeGFF2TatGny6quvysaNGyU6Olq6devmOieaXam6zJkzR/72t7+57XdaffPy8uSaa66RwMBA+fzzz2X79u0ydepUCQ8Pd2Sdn3/+eXnttdd0XX766SddtylTpsiMGTMcUV/1t9m6dWtd9rJUpm7qveyjjz6S999/X9asWSNHjhyRm2++WU6dOiV2qu+xY8fku+++k3/+85/6ctGiRfLzzz/rD/qSnFLfkj7++GPZsGGDDkil2am+58xCtbvqqqushx56yG3fJZdcYj355JOOevVzcnLUKXGtlStX6uunT5+2oqOjreeee851zJ9//mmFhYVZr732mmVXhw8ftlq2bGktX77c6tSpkzVq1CjH1veJJ56wrr322nJvd1qde/XqZd13331u+/r27WsNGjTIcfVVf6sfffSR63pl6vbHH39YgYGB1vvvv+865tdff7Vq1KhhffHFF5ad6luWb7/9Vh+3d+9ex9Z337591gUXXGD9+OOPVpMmTayXXnrJdZud6/tX0OJTzYqKinS3gGoJKUldX7t2rThJfn6+vqxXr56+zMjIkOzsbLe6q8WyOnXqZOu6q1auXr16SdeuXd32O7G+n3zyibRt21YSExN1d+YVV1whr7/+umPrfO2118pXX32lv/kr33//vf7W+/e//92R9S2pMnVT72Wqi6jkMarVID4+3vb1L34PU90/xS2aTquv6rK9++675fHHH5fLLrvsjNudVt/ycJLSapabm6ubCKOiotz2q+vqTcYp1BeMMWPG6A8O9UeiFNevrLrv3btX7Eg1/6pmcdUNUJoT6/vLL7/IrFmz9O/2qaeekm+//VZGjhypPxDVeAin1VmN+VAffpdccon4+/vrv91JkyZJ//799e1Oq29JlambOiYoKEgiIiIc9372559/ypNPPikDBgxwnbTTafVVXbkBAQH6b7gsTqtveQg+HqK+RZQOCqX32dmIESPkhx9+0N+OnVr3rKwsGTVqlCxbtkwPUi+PU+pb/A1RtfhMnjxZX1ctPmqwqwpDKvg4rc5qPN4777wjCxYs0N+I09PT9ZgH9a138ODBjqtvWc6lbnavv2rl6Nevn/7/riainI0d66tac6ZPn66/uP3VstuxvhWhq6uaqZHx6ptj6bSck5Nzxjcru1IzAFSXSFpamjRq1Mi1Xw2MVJxSd/XGocquZuWpb01qUwO8X3nlFf1zcZ2cUl8lJiZGWrVq5bbv0ksvdQ3Md9rvWHUBqG/96kNQzfZR3QKPPvqonsHnxPqWVJm6qWNU970a9F7eMXYMPXfeeafu6lOTNIpbe5xWXzWTWJW7cePGrvcv1ZI3duxYadq0qePqWxGCTzVTzYbqg1L9QZWkrnfs2FHsTH0LUC09ajbE119/racAl6Suqz+kknVXf1QqLNix7jfeeKNs3bpVtwIUb6o1ZODAgfpnNfXZSfVV1Iyu0ksUqPEvTZo0ceTvWM30qVHD/W1RfXEpns7utPqWVJm6qfcyNcOv5DEHDhyQH3/80Zb1Lw49O3fulC+//FIv2VCSk+qrQrxqlU8v8f6lWjJV2F+6dKnj6lshb4+uNoEaIa9Gyr/xxhvW9u3brdGjR1u1atWy9uzZY9nZP/7xDz3jY8WKFdaBAwdc27Fjx1zHqBki6phFixZZW7dutfr372/FxMRYBQUFlhOUnNXlxPqqWS4BAQHWpEmTrJ07d1rvvvuuFRoaar3zzjuOrPPgwYP1jJdPP/3UysjI0HWKjIy0xo0b54j6qhmJW7Zs0Zt6+582bZr+uXgWU2XqpmaoNmrUyPryyy+t7777zrrhhhus1q1bWydPnrTsVN8TJ05Yffr00XVJT093ew8rLCx0XH3L0qTUrC671fdcEXw85F//+pf+TxYUFGRdeeWVrinfdqb+sMra5s6d6zZFdsKECXqabHBwsHX99dfrN1SnKB18nFjfxYsXW/Hx8bo+ahmGOXPmuN3upDqrD3j1+2zcuLFVs2ZNq3nz5tb48ePdPgjtXN+0tLQy/2ZV4Kts3Y4fP26NGDHCqlevnhUSEmLdfPPNVmZmpmW3+qpgW957mLqf0+pb2eBz3Eb1PVd+6h9vtzoBAAB4AmN8AACAMQg+AADAGAQfAABgDIIPAAAwBsEHAAAYg+ADAACMQfABAADGIPgAAABjEHwA+KwVK1bos0L/8ccfXnl+dQ66Sy65xHWurop8+umn+uz1lTkWgPcQfAD4hM6dO8vo0aPd9qkTI6qTJIaFhXmlTOPGjZPx48efceLSstx88806pC1YsMAjZQNwbgg+AHxWUFCQPmO4ChSetnbtWn3W7sTExErf595775UZM2ZUa7kAnB+CDwCvGzJkiKxcuVKmT5+uQ47a9uzZc0ZX17x58yQ8PFx3K1188cUSGhoqd9xxhxw9elTmz58vTZs2lYiICHnkkUfk1KlTrscvKirSrTcXXHCB1KpVS66++mr92BV5//33pXv37lKzZk3Xvu+//166dOkiderUkbp160pCQoJs2rTJdXufPn3k22+/lV9++aVaXicA5y+gCh4DAM6LCjw///yzxMfHS0pKit7XoEEDHX5KO3bsmLzyyis6mBw+fFj69u2rNxWIPvvsMx06br/9drn22mvlrrvucrXEqMdS94mNjZWPPvpIevToIVu3bpWWLVuWWaZVq1ZJ//793fYNHDhQj+OZNWuW+Pv7S3p6ugQGBrpub9KkiTRs2FBWr14tzZs3538F4IMIPgC8To3hUd1aqgVHdW1V5MSJEzp4XHjhhfq6avF5++235bfffpPatWtLq1atdKtMWlqaDj67d++W9957T/bt26dDj/LYY4/JF198IXPnzpXJkyeX+TwqKBUfXywzM1Mef/xxPeBZKSs0qValsgIbAN9A8AFgKyocFYceJSoqSndxqdBTcl9OTo7++bvvvhPLsuSiiy5ye5zCwkKpX79+uc9z/Phxt24uZcyYMfLAAw/ooNW1a1c9/qdkWZSQkBDdKgXANxF8ANhKya4lRY0BKmtf8bRydam6pTZv3qwvSyoZlkqLjIyUvLw8t33JyckyYMAAWbJkiXz++ecyYcIE3X122223uY45dOiQ7qYD4JsIPgB8gurqKjkguaqoMTnqcVUL0HXXXfeX7rd9+/Yz9quWI7U9+uijegyQ6i4rDj5//vmn7lpT9wXgm5jVBcAnqO6qDRs26PExubm5VbYQoAopalDyPffcI4sWLZKMjAzZuHGjPP/883owdHluuukmWbNmjVvX14gRI/RssL1798o333yjH+fSSy91HbN+/XoJDg6WDh06VEnZAVQ9gg8An6AGHKuuKDU4WXUVqYHEVUW1yqjgM3bsWD0NXk07VyErLi6u3PsMGjRIt/js2LFDX1dlO3jwoH4cFabuvPNO6dmzp0ycONF1HzWIWoUsNQ4JgG/ys9SoPwDAGdTaP/n5+TJ79uyzvjq///67nu2l1vVp1qwZrybgo2jxAYByqNNVqLV5KjP2SHWhzZw5k9AD+DhafAAAgDFo8QEAAMYg+AAAAGMQfAAAgDEIPgAAwBgEHwAAYAyCDwAAMAbBBwAAGIPgAwAAjEHwAQAAYor/D9Zffdr9VBoWAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot controls\n",
+    "\n",
+    "t = m.i.get_finite_elements()\n",
+    "\n",
+    "v1 = [value(m.v1[i]) for i in t[:-1]]\n",
+    "v2 = [value(m.v2[i]) for i in t[:-1]]\n",
+    "\n",
+    "# Plot optimal control trajectories (deviations from steady-state pump flows\n",
+    "plt.figure()\n",
+    "plt.stairs(v1, t, baseline=None, label='v1')\n",
+    "plt.stairs(v2, t, baseline=None, label='v2')\n",
+    "plt.xlabel('time (s)')\n",
+    "plt.ylabel('value')\n",
+    "plt.legend()\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69a47a54",
+   "metadata": {},
+   "source": [
+    "## Sensitivities\n",
+    "\n",
+    "Everything below is a cheap backsolve on the stored KKT factorization: no re-solving.\n",
+    "\n",
+    "First, the objective's sensitivity to each initial condition."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "034567ab",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:10.590332Z",
+     "iopub.status.busy": "2026-07-11T20:06:10.589368Z",
+     "iopub.status.idle": "2026-07-11T20:06:10.595974Z",
+     "shell.execute_reply": "2026-07-11T20:06:10.595974Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "d(track)/d(z1init) =   31.2155\n",
+      "d(track)/d(z2init) =  -26.0767\n",
+      "d(track)/d(z3init) =   17.9000\n",
+      "d(track)/d(z4init) =  -19.1009\n"
+     ]
+    }
+   ],
+   "source": [
+    "for p in (m.z1init, m.z2init, m.z3init, m.z4init):\n",
+    "    print(f\"d(track)/d({p.name}) = {gradient(m.track, wrt=p):9.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ff8d9ba",
+   "metadata": {},
+   "source": [
+    "The first control move's gains with respect to the initial state: the 2x4 NMPC feedback law, straight from the factorization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3d78dfba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:10.598092Z",
+     "iopub.status.busy": "2026-07-11T20:06:10.598092Z",
+     "iopub.status.idle": "2026-07-11T20:06:10.602064Z",
+     "shell.execute_reply": "2026-07-11T20:06:10.602064Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "d(v1[0])/dz(0) =  -1.3023   -0.4766    0.1007   -3.7354\n",
+      "d(v2[0])/dz(0) =  -0.9938   -0.7669   -3.8952    0.3150\n"
+     ]
+    }
+   ],
+   "source": [
+    "for v in (m.v1, m.v2):\n",
+    "    row = [gradient(v[0], wrt=p)\n",
+    "           for p in (m.z1init, m.z2init, m.z3init, m.z4init)]\n",
+    "    print(f\"d({v.name}[0])/dz(0) = \" + \"  \".join(f\"{g:8.4f}\" for g in row))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0620d7ab",
+   "metadata": {},
+   "source": [
+    "A first-order estimate of the solution at a perturbed initial condition (z1(0): 5 -> 6), checked against a true re-solve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f4087924",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-11T20:06:10.605111Z",
+     "iopub.status.busy": "2026-07-11T20:06:10.604118Z",
+     "iopub.status.idle": "2026-07-11T20:06:10.743844Z",
+     "shell.execute_reply": "2026-07-11T20:06:10.743844Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "estimate:  track =  267.5672   v1[0] =  15.0612   v2[0] = -21.1139\n",
+      "re-solve:  track =  270.0264   v1[0] =  15.0485   v2[0] = -21.1274\n"
+     ]
+    }
+   ],
+   "source": [
+    "est = estimate(m, [(m.z1init, 6.0)])\n",
+    "print(f\"estimate:  track = {est[m.track]:9.4f}   v1[0] = {est[m.v1[0]]:8.4f}   v2[0] = {est[m.v2[0]]:8.4f}\")\n",
+    "\n",
+    "m.z1init = 6.0\n",
+    "SolverFactory(\"pounce\").solve(m)\n",
+    "print(f\"re-solve:  track = {value(m.track):9.4f}   v1[0] = {value(m.v1[0]):8.4f}   v2[0] = {value(m.v2[0]):8.4f}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -28,10 +28,10 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 |---|---|---|
 | 03 | [`03_implicit_differentiation.ipynb`](03_implicit_differentiation.ipynb) | Implicit differentiation of the optimum w.r.t. parameters. |
 | 04 | [`04_sensitivity.ipynb`](04_sensitivity.ipynb) | Parametric sensitivity (sIPOPT-style). |
-| 25 | [`25_pyomo_sensitivity.ipynb`](25_pyomo_sensitivity.ipynb) | Declared-parameter sensitivity from Pyomo: an optimal-control example whose first-move gradients are the NMPC feedback gains (needs `pyomo-cvp`). |
 | 09 | [`09_differentiable_layer.ipynb`](09_differentiable_layer.ipynb) | A differentiable constrained-projection layer. |
 | 13 | [`13_post_solve_jacobian.ipynb`](13_post_solve_jacobian.ipynb) | Post-solve Jacobian/sensitivities from the held KKT factor. |
 | 17 | [`17_differentiable_convex.ipynb`](17_differentiable_convex.ipynb) | Differentiable convex optimization with `pounce.jax`. |
+| 25 | [`25_pyomo_sensitivity.ipynb`](25_pyomo_sensitivity.ipynb) | Declared-parameter sensitivity from Pyomo: an optimal-control example whose first-move gradients are the NMPC feedback gains (needs `pyomo-cvp`). |
 
 ## Performance & sparsity
 

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -28,6 +28,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 |---|---|---|
 | 03 | [`03_implicit_differentiation.ipynb`](03_implicit_differentiation.ipynb) | Implicit differentiation of the optimum w.r.t. parameters. |
 | 04 | [`04_sensitivity.ipynb`](04_sensitivity.ipynb) | Parametric sensitivity (sIPOPT-style). |
+| 25 | [`25_pyomo_sensitivity.ipynb`](25_pyomo_sensitivity.ipynb) | Declared-parameter sensitivity from Pyomo: an optimal-control example whose first-move gradients are the NMPC feedback gains (needs `pyomo-cvp`). |
 | 09 | [`09_differentiable_layer.ipynb`](09_differentiable_layer.ipynb) | A differentiable constrained-projection layer. |
 | 13 | [`13_post_solve_jacobian.ipynb`](13_post_solve_jacobian.ipynb) | Post-solve Jacobian/sensitivities from the held KKT factor. |
 | 17 | [`17_differentiable_convex.ipynb`](17_differentiable_convex.ipynb) | Differentiable convex optimization with `pounce.jax`. |


### PR DESCRIPTION
This provides a fix for longstanding issues with sIPOPT and the pyomo sensitivity toolbox. The main themes are 1) a better pyomo user interface for sensitivity calculations and 2) a sensitivity solve step that is separate from the full NLP solve, thereby truly enabling things such as advanced step NMPC.

## What it adds

A declare-then-query sensitivity interface in `pyomo_pounce`:

```python
from pyomo_pounce import declare_sens_param, gradient, estimate

declare_sens_param(m.p)                # a flag while building the model:
                                       # no perturbed values required
SolverFactory("pounce").solve(m)       # ordinary solve, keeps the KKT factor

gradient(m.x, wrt=m.p)                 # exact dx*/dp (float)
gradient(m.con, wrt=m.p)               # d(multiplier of con)/dp
G = gradient(m.z, wrt=m.r)             # containers -> Gradient object
G[m.z[1], m.r[2]]; G.to_dataframe()    # element access / full Jacobian
estimate(m, [(m.p, 2.5)])              # first-order estimate at new values,
                                       # bound-clamped, warns on active-set risk
```

When declarations are present, the solve runs in-process (Pyomo writes the .nl, `read_nl` evaluates it through a cyipopt-style bridge into the `Solver` session) and the converged factorization answers every later query as a single backsolve. Perturbation values are never needed at solve time: gradients come from unit-delta backsolves, and `estimate` combines the stored columns for arbitrary values afterwards, matching the separation that advanced-step NMPC needs. Models without declarations use the AMPL/CLI path unchanged.

Parameters ride as pinned variables via `pyomo.contrib.sensitivity_toolbox`'s model surgery; the per-model registry is deepcopy-aware so re-solves and `model.clone()` stay clean.

## Rust/bindings additions

`Solver::parametric_step_full` (full compound-vector step, exposing multiplier sensitivities) and `Solver::g_multiplier_rows` in `pounce-sensitivity`, with Python bindings `parametric_step_full` and `multiplier_rows`.

## Definition of done

- 7 pytest tests in `pyomo-pounce/tests/test_sens.py`: primal and multiplier gradients validated against finite-differenced re-solves, estimate accuracy vs a true re-solve, bound-clamp warning, container/Jacobian forms, plain-solve passthrough, re-solve/clone cleanliness.
- CHANGELOG entry under Unreleased (Python / Pyomo surfaces).
- Book section: `docs/src/sensitivity.md` gains a Pyomo entry point (intro updated to four entry points).
- README: fourth entry-point bullet in the sensitivity section.
- Executed walkthrough notebook `python/notebooks/25_pyomo_sensitivity.ipynb` (quad-tank optimal control; the first-move gradients are the NMPC feedback gains; needs `pyomo-cvp`), indexed in the notebooks README.

## Notes for review

- Developed and tested on Windows. Pre-existing local failures are unchanged from main and unrelated: the two `test_bvp` failures, the hs71 timing-report test, and `pounce-hsl` not linking without HSL libraries.
- clippy adds nothing beyond the existing pymethods `useless_conversion` baseline; `cargo fmt` clean.
- Related: #196 (QP fast path skips the sIPOPT suffixes; independent of this PR since this path always uses the general IPM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
