### PR TITLE
Pre-release 0.8.0 metadata fixes (pyomo-pounce dep pin + crate descriptions)

### DIFF
--- a/crates/pounce-convex/Cargo.toml
+++ b/crates/pounce-convex/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 readme = "README.md"
-description = "Interior-point solvers for the convex problem classes in POUNCE: LP and convex QP today, with cone-generic scaffolding (Mehrotra + HSDE, SOCP/exp/pow/SDP) planned. Shares the pounce-linsol sparse symmetric factorization backbone with the NLP path."
+description = "Interior-point solvers for the convex problem classes in POUNCE: LP, convex QP, and conic programs (SOCP, exponential and power cones, SDP, and SOS) via a Mehrotra predictor-corrector with an HSDE embedding. Shares the pounce-linsol sparse symmetric factorization backbone with the NLP path."
 keywords = ["lp", "qp", "interior-point", "convex-optimization", "solver"]
 categories = ["mathematics", "science"]
 

--- a/crates/pounce-linsol/Cargo.toml
+++ b/crates/pounce-linsol/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 readme = "README.md"
-description = "Symmetric linear-solver trait layer for POUNCE (port of Ipopt's Algorithm/LinearSolvers/Ip{SymLinearSolver,SparseSymLinearSolverInterface,TSymLinearSolver,TSymScalingMethod,TripletToCSRConverter}). No FFI; concrete backends live in pounce-hsl, pounce-mumps (future), pounce-feral (future)."
+description = "Symmetric linear-solver trait layer for POUNCE (port of Ipopt's Algorithm/LinearSolvers/Ip{SymLinearSolver,SparseSymLinearSolverInterface,TSymLinearSolver,TSymScalingMethod,TripletToCSRConverter}). No FFI; concrete backends are pounce-feral (the pure-Rust sparse LDLᵀ default) and the optional pounce-hsl (MA57)."
 keywords = ["linear-solver", "sparse", "symmetric", "ldl", "ipopt"]
 categories = ["mathematics", "algorithms"]
 

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -17,7 +17,7 @@ authors = [{name = "John Kitchin", email = "jkitchin@andrew.cmu.edu"}]
 # API changes.
 dependencies = [
     "pyomo>=6.0",
-    "pounce-solver>=0.1",
+    "pounce-solver>=0.8.0",
     "numpy",
     "pandas",
 ]


### PR DESCRIPTION
Pre-release metadata fixes for 0.8.0, from a release-readiness audit.

## Blocker
- **`pyomo-pounce`: `pounce-solver>=0.1` → `>=0.8.0`.** #199's `sens.py` calls `parametric_step_full` / `multiplier_rows` / `read_nl`, all new in the 0.8.0 `pounce-py` binding. With the old pin a user on an older `pounce-solver` installs cleanly and then `AttributeError`s the moment they call `gradient()` / `estimate()`.

## crates.io description refresh (permanent once published)
- **`pounce-convex`:** described SOCP / exp / power / SDP as "planned" — they're shipped and validated now.
- **`pounce-linsol`:** listed `pounce-feral` as "future" and a nonexistent `pounce-mumps` — feral is the shipped default backend.

Deferred (tracked, not in this PR): move `pandas` to an optional pyomo-pounce extra, refresh `pyomo-pounce/README.md` for the sensitivity API, fix "19 crates"→20 comments, add `pounce-nl`/`pounce-rs` to the README crate table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
