### PR TITLE
Thread-scoped iteration capture + richer Nlp::solve() result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,11 @@ changes.
   the per-iteration trajectory (`stats.iterations`, one `IterRecord` per
   Newton iteration) by installing the thread-scoped collector around the
   solve — note the collector shadows a global subscriber's console output on
-  that thread for the solve's duration. The field additions are breaking
-  only for code that exhaustively destructures `Solution` (pre-1.0).
+  that thread for the solve's duration, and that only the interior-point
+  engine emits the per-iteration event (an active-set SQP solve leaves
+  `stats.iterations` empty while `iteration_count` still counts). The field
+  additions are breaking only for code that exhaustively destructures
+  `Solution` (pre-1.0).
 
 ### Changed — pyomo-pounce streams the engine's log under `tee=True`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes.
 
 ## [Unreleased]
 
+### Added — thread-scoped iteration capture from Rust (pounce-rs)
+
+- **A Rust consumer embedding POUNCE can now record a solve's iteration
+  trajectory with no direct `tracing`/`tracing-subscriber` dependencies and
+  without touching the global subscriber.** `pounce-observability` gains
+  thread-scoped helpers that bundle the collector-layer install:
+  `with_iter_capture(|| nlp.solve())` runs a closure with capture active and
+  returns its result alongside the recorded `IterRecord`s;
+  `ScopedIterCapture::start()`/`.finish()` is the guard-shaped equivalent for
+  solves that don't fit in a closure; and `collector_scope()` installs just
+  the collector for the `IpoptApplication` path
+  (`enable_iter_history()` + `statistics().iterations`), where the driver
+  manages its own capture guard. All three install the collector as the
+  *thread-default* subscriber (never global) and uninstall on drop; while a
+  scope is active it shadows any global subscriber on that thread, so scope
+  it tightly around the solve. Restoration sub-solve exclusion and nested /
+  sequential capture semantics are unchanged. `pounce-rs` re-exports the
+  helpers plus `IterRecord`, `SolveStatistics`, `IterCaptureGuard`, and
+  `init_subscriber` (and the whole `pounce_observability` crate), so the
+  facade alone covers both iteration capture and console logging;
+  `with_iter_capture`, `collector_scope`, `IterRecord`, and
+  `SolveStatistics` join the prelude.
+
+### Changed — richer `Nlp::solve()` result (pounce-rs)
+
+- **`builder::Solution` now carries the full per-solve picture.** New fields:
+  `g` (constraint values at the solution), `z_l`/`z_u` (bound multipliers),
+  and `stats: SolveStatistics` — wall time
+  (`stats.total_wallclock_time_secs`), `iteration_count`, evaluation counts,
+  final scaled and unscaled infeasibilities, final barrier `mu`, and
+  restoration counters, all filled on every solve with no new bookkeeping
+  (the driver already computed them; the builder now reads
+  `app.statistics()`). A new `.capture_iterations()` builder flag opts into
+  the per-iteration trajectory (`stats.iterations`, one `IterRecord` per
+  Newton iteration) by installing the thread-scoped collector around the
+  solve — note the collector shadows a global subscriber's console output on
+  that thread for the solve's duration. The field additions are breaking
+  only for code that exhaustively destructures `Solution` (pre-1.0).
+
 ### Changed — pyomo-pounce streams the engine's log under `tee=True`
 
 - **`SolverFactory('pounce').solve(m, tee=True)` now streams the engine's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,18 @@ changes.
   solves that don't fit in a closure; and `collector_scope()` installs just
   the collector for the `IpoptApplication` path
   (`enable_iter_history()` + `statistics().iterations`), where the driver
-  manages its own capture guard. All three install the collector as the
-  *thread-default* subscriber (never global) and uninstall on drop; while a
-  scope is active it shadows any global subscriber on that thread, so scope
-  it tightly around the solve. Restoration sub-solve exclusion and nested /
-  sequential capture semantics are unchanged. `pounce-rs` re-exports the
+  manages its own capture guard. All three activate the collector for the
+  scope's lifetime and never touch the global subscriber: when
+  `init_subscriber` already owns the global (which carries the collector)
+  the scope is a no-op and capture composes with console/JSON logging;
+  otherwise a collector-only thread-default is installed, which shadows the
+  host's own subscriber on that thread for the duration — scope it tightly
+  around the solve. Restoration sub-solve exclusion and nested /
+  sequential capture semantics are unchanged, and the driver now propagates
+  its iteration-history records to any enclosing capture on finish (new
+  `extend_active_capture`), so wrapping a solve that has iteration history
+  enabled in `with_iter_capture` yields the trajectory in both places
+  instead of an empty outer buffer. `pounce-rs` re-exports the
   helpers plus `IterRecord`, `SolveStatistics`, `IterCaptureGuard`, and
   `init_subscriber` (and the whole `pounce_observability` crate), so the
   facade alone covers both iteration capture and console logging;
@@ -43,11 +50,12 @@ changes.
   (the driver already computed them; the builder now reads
   `app.statistics()`). A new `.capture_iterations()` builder flag opts into
   the per-iteration trajectory (`stats.iterations`, one `IterRecord` per
-  Newton iteration) by installing the thread-scoped collector around the
-  solve — note the collector shadows a global subscriber's console output on
-  that thread for the solve's duration, and that only the interior-point
-  engine emits the per-iteration event (an active-set SQP solve leaves
-  `stats.iterations` empty while `iteration_count` still counts). The field
+  Newton iteration) by activating the thread-scoped collector around the
+  solve — a no-op composing with the logs when `init_subscriber` owns the
+  global subscriber, a host-subscriber-shadowing thread-default install
+  otherwise. Only the interior-point engine emits the per-iteration event
+  (an active-set SQP solve leaves `stats.iterations` empty while
+  `iteration_count` still counts). The field
   additions are breaking only for code that exhaustively destructures
   `Solution` (pre-1.0).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,7 @@ dependencies = [
  "pounce-algorithm",
  "pounce-common",
  "pounce-nlp",
+ "pounce-observability",
 ]
 
 [[package]]

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1751,6 +1751,10 @@ impl IpoptApplication {
         let solver_status = alg.optimize();
 
         let captured_iters = iter_capture.map(|g| g.finish()).unwrap_or_default();
+        // Propagate to any enclosing capture (e.g. `with_iter_capture`
+        // wrapped around a solve with iteration history enabled), whose
+        // buffer this inner guard would otherwise leave empty.
+        pounce_observability::extend_active_capture(&captured_iters);
         // Close the overall-algorithm timer on the success path. The
         // early-return arms above end it themselves before bailing out;
         // this one matches upstream `IpoptApplication::call_optimize`

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -69,6 +69,12 @@ thread_local! {
 /// in-process capture is active.
 static JSON_LOGGING: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
+/// Set when [`install`] successfully claimed the global subscriber, whose
+/// layers include the collector. [`collector_scope`] then skips its
+/// shadowing thread-default install, so capture composes with the
+/// global console/JSON output instead of silencing it.
+static GLOBAL_COLLECTOR: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
 /// Whether the per-iteration `pounce::iteration` event has a consumer
 /// right now, so the algorithm can skip emitting it (and the field
 /// evaluation it entails) when nothing would observe it.
@@ -256,15 +262,15 @@ fn collector_admits(m: &tracing::Metadata<'_>) -> bool {
 
 // ---- Scoped capture helpers ----
 
-/// Opaque RAII scope holding [`IterCollectorLayer`] installed as this
-/// thread's default subscriber.
+/// Opaque RAII scope guaranteeing [`IterCollectorLayer`] is active on
+/// this thread until drop.
 #[must_use = "the collector uninstalls as soon as this guard drops"]
 pub struct CollectorScope {
-    _default: tracing::subscriber::DefaultGuard,
+    _default: Option<tracing::subscriber::DefaultGuard>,
 }
 
-/// Install [`IterCollectorLayer`] as this thread's default subscriber
-/// until the returned guard drops.
+/// Ensure [`IterCollectorLayer`] is active on this thread until the
+/// returned guard drops.
 ///
 /// For the [`IterCaptureGuard`]-managed application path: with iteration
 /// history enabled the solver driver runs its own capture guard around
@@ -278,19 +284,22 @@ pub struct CollectorScope {
 /// let iters = app.statistics().iterations;
 /// ```
 ///
-/// While the scope is active, the thread-default subscriber shadows any
-/// global subscriber (e.g. one installed by [`init_subscriber`]) on
-/// this thread. Scope it tightly around the solve. Hosts that want
-/// both console logs and capture should instead install the global
-/// subscriber via [`init_subscriber`].
+/// When [`init_subscriber`] has claimed the global subscriber, its
+/// collector already covers this thread and the scope is a no-op.
+/// Otherwise a collector-only registry is installed as the thread-default
+/// subscriber, which shadows the host's own subscriber (its log output
+/// from this thread is dropped) for the scope's lifetime.
 pub fn collector_scope() -> CollectorScope {
     use tracing_subscriber::filter::filter_fn;
     use tracing_subscriber::prelude::*;
 
+    if GLOBAL_COLLECTOR.load(std::sync::atomic::Ordering::Relaxed) {
+        return CollectorScope { _default: None };
+    }
     let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
     let subscriber = tracing_subscriber::registry().with(collector);
     CollectorScope {
-        _default: tracing::subscriber::set_default(subscriber),
+        _default: Some(tracing::subscriber::set_default(subscriber)),
     }
 }
 
@@ -447,16 +456,17 @@ fn install() {
     // subject to the console's `pounce::iteration=off` suppression, so
     // it carries its own target filter. It is constructed inside each
     // branch so its subscriber type parameter is inferred per-branch.
-    if want_json {
+    let claimed = if want_json {
         let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
         let json_layer = tracing_subscriber::fmt::layer()
             .json()
             .with_writer(std::io::stderr)
             .with_filter(env_filter());
-        let _ = tracing_subscriber::registry()
+        tracing_subscriber::registry()
             .with(json_layer)
             .with(collector)
-            .try_init();
+            .try_init()
+            .is_ok()
     } else {
         let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
         let ansi = ansi_enabled();
@@ -465,10 +475,14 @@ fn install() {
             .with_ansi(ansi)
             .with_writer(std::io::stderr)
             .with_filter(console_filter());
-        let _ = tracing_subscriber::registry()
+        tracing_subscriber::registry()
             .with(text_layer)
             .with(collector)
-            .try_init();
+            .try_init()
+            .is_ok()
+    };
+    if claimed {
+        GLOBAL_COLLECTOR.store(true, std::sync::atomic::Ordering::Relaxed);
     }
 
     /// `RUST_LOG` filter, defaulting to `info`.

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -138,6 +138,23 @@ fn push_record(rec: IterRecord) {
     });
 }
 
+/// Append copies of `records` to the active capture slot, if any.
+///
+/// Called by the solver driver after it drains its own iteration-history
+/// capture, so an enclosing [`IterCaptureGuard`] still receives the
+/// trajectory instead of finding its buffer emptied by the driver's
+/// inner guard. No-op when no capture is active on this thread.
+pub fn extend_active_capture(records: &[IterRecord]) {
+    if records.is_empty() {
+        return;
+    }
+    CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.extend_from_slice(records);
+        }
+    });
+}
+
 // ---- Event → IterRecord visitor ----
 
 #[derive(Default)]
@@ -282,8 +299,8 @@ pub fn collector_scope() -> CollectorScope {
 /// on this thread, with no `tracing` wiring on the caller's side.
 ///
 /// For solves that don't fit inside a closure; otherwise prefer
-/// [`with_iter_capture`]. Do not combine with the driver's own
-/// iteration-history capture (`enable_iter_history`) on the same solve.
+/// [`with_iter_capture`]. Combining with the driver's own
+/// iteration-history capture (`enable_iter_history`) is safe.
 #[must_use = "call finish() to retrieve the captured iteration history"]
 pub struct ScopedIterCapture {
     capture: IterCaptureGuard,
@@ -656,6 +673,23 @@ mod tests {
             alpha_primal = 1.0,
             alpha_char = s.as_str(),
         );
+    }
+
+    #[test]
+    fn extend_active_capture_appends_to_enclosing_buffer() {
+        let outer = IterCaptureGuard::start();
+        push_record(sample_record(0, 1.0, ' '));
+        let inner = IterCaptureGuard::start();
+        push_record(sample_record(1, 0.5, ' '));
+        let inner_got = inner.finish();
+        extend_active_capture(&inner_got);
+        let outer_got = outer.finish();
+        let iters: Vec<i32> = outer_got.iter().map(|r| r.iter).collect();
+        assert_eq!(iters, vec![0, 1]);
+
+        extend_active_capture(&inner_got);
+        let fresh = IterCaptureGuard::start();
+        assert!(fresh.finish().is_empty());
     }
 
     #[test]

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -25,6 +25,16 @@
 //! the report captures only the outer solve's iterations (including
 //! `'R'`-marked outer iters) and not the restoration sub-solve's inner
 //! IPM iterations — matching the pre-tracing behavior exactly.
+//!
+//! ## Thread-scoped capture for embedders
+//!
+//! Hosts that must not claim the global subscriber (libraries embedding
+//! POUNCE as a solver backend) use the scoped helpers instead of
+//! [`init_subscriber`]: [`with_iter_capture`] wraps one solve in a
+//! closure and returns its trajectory, [`ScopedIterCapture`] is the
+//! guard-shaped equivalent, and [`collector_scope`] installs just the
+//! collector for drivers that manage their own [`IterCaptureGuard`]
+//! (the iteration-history application path).
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
@@ -225,6 +235,99 @@ where
 /// per-branch subscriber type parameter.
 fn collector_admits(m: &tracing::Metadata<'_>) -> bool {
     m.is_span() || m.target() == ITER_TARGET
+}
+
+// ---- Scoped capture helpers ----
+
+/// Opaque RAII scope holding [`IterCollectorLayer`] installed as this
+/// thread's default subscriber.
+#[must_use = "the collector uninstalls as soon as this guard drops"]
+pub struct CollectorScope {
+    _default: tracing::subscriber::DefaultGuard,
+}
+
+/// Install [`IterCollectorLayer`] as this thread's default subscriber
+/// until the returned guard drops.
+///
+/// For the [`IterCaptureGuard`]-managed application path: with iteration
+/// history enabled the solver driver runs its own capture guard around
+/// the solve and drains the records into its solve statistics, so the
+/// caller only needs the collector active for the solve's duration:
+///
+/// ```ignore
+/// let _scope = pounce_observability::collector_scope();
+/// app.enable_iter_history();
+/// app.optimize_tnlp(problem)?;
+/// let iters = app.statistics().iterations;
+/// ```
+///
+/// While the scope is active, the thread-default subscriber shadows any
+/// global subscriber (e.g. one installed by [`init_subscriber`]) on
+/// this thread. Scope it tightly around the solve. Hosts that want
+/// both console logs and capture should instead install the global
+/// subscriber via [`init_subscriber`].
+pub fn collector_scope() -> CollectorScope {
+    use tracing_subscriber::filter::filter_fn;
+    use tracing_subscriber::prelude::*;
+
+    let collector = IterCollectorLayer.with_filter(filter_fn(collector_admits));
+    let subscriber = tracing_subscriber::registry().with(collector);
+    CollectorScope {
+        _default: tracing::subscriber::set_default(subscriber),
+    }
+}
+
+/// [`IterCaptureGuard`] bundled with a [`collector_scope`] subscriber
+/// install: everything needed to capture one solve's iteration history
+/// on this thread, with no `tracing` wiring on the caller's side.
+///
+/// For solves that don't fit inside a closure; otherwise prefer
+/// [`with_iter_capture`]. Do not combine with the driver's own
+/// iteration-history capture (`enable_iter_history`) on the same solve.
+#[must_use = "call finish() to retrieve the captured iteration history"]
+pub struct ScopedIterCapture {
+    capture: IterCaptureGuard,
+    _scope: CollectorScope,
+}
+
+impl ScopedIterCapture {
+    /// Install the collector on this thread and begin capturing.
+    pub fn start() -> Self {
+        let scope = collector_scope();
+        let capture = IterCaptureGuard::start();
+        Self {
+            capture,
+            _scope: scope,
+        }
+    }
+
+    /// End capture, uninstall the collector, and return the records
+    /// collected since [`start`].
+    ///
+    /// [`start`]: ScopedIterCapture::start
+    pub fn finish(self) -> Vec<IterRecord> {
+        let Self { capture, _scope } = self;
+        let records = capture.finish();
+        drop(_scope);
+        records
+    }
+}
+
+/// Run `f` with iteration capture active on this thread, returning its
+/// result alongside the recorded trajectory.
+///
+/// Equivalent to wrapping `f` in a [`ScopedIterCapture`]: installs
+/// [`IterCollectorLayer`] as the thread-default subscriber,
+/// activates an [`IterCaptureGuard`], runs `f`, and tears both
+/// down before returning.
+///
+/// ```ignore
+/// let (solution, iters) = pounce_observability::with_iter_capture(|| nlp.solve());
+/// ```
+pub fn with_iter_capture<R>(f: impl FnOnce() -> R) -> (R, Vec<IterRecord>) {
+    let scope = ScopedIterCapture::start();
+    let result = f();
+    (result, scope.finish())
 }
 
 // ---- Tiger/rust themed text formatter ----
@@ -537,6 +640,104 @@ mod tests {
         assert!(
             got.iter().any(|m| m.contains("bridged log record")),
             "log record did not reach the tracing layer; captured: {got:?}"
+        );
+    }
+
+    /// Emit a synthetic `pounce::iteration` event as the algorithm does.
+    fn emit_iter(iter: i64, ch: char) {
+        let s = ch.to_string();
+        tracing::info!(
+            target: ITER_TARGET,
+            iter = iter,
+            objective = 0.5,
+            alpha_primal = 1.0,
+            alpha_char = s.as_str(),
+        );
+    }
+
+    #[test]
+    fn with_iter_capture_captures_events_and_threads_result() {
+        let (result, records) = with_iter_capture(|| {
+            emit_iter(0, ' ');
+            emit_iter(1, 'R');
+            "sentinel"
+        });
+        assert_eq!(result, "sentinel");
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].iter, 0);
+        assert_eq!(records[1].iter, 1);
+        assert_eq!(records[1].alpha_primal_char, 'R');
+        assert!((records[1].objective - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn with_iter_capture_ignores_events_outside_scope() {
+        emit_iter(7, ' '); // before the scope: no consumer
+        let ((), records) = with_iter_capture(|| ());
+        emit_iter(8, ' '); // after the scope: no consumer
+        assert!(records.is_empty());
+        assert!(
+            !iteration_event_wanted(),
+            "capture slot must be torn down after with_iter_capture returns"
+        );
+    }
+
+    #[test]
+    fn with_iter_capture_excludes_restoration_subsolve() {
+        let ((), records) = with_iter_capture(|| {
+            emit_iter(0, ' ');
+            {
+                let _resto = tracing::info_span!("restoration").entered();
+                let _inner_iter = tracing::info_span!("iteration").entered();
+                emit_iter(99, 'R');
+            }
+            emit_iter(1, ' ');
+        });
+        let iters: Vec<i32> = records.iter().map(|r| r.iter).collect();
+        assert_eq!(
+            iters,
+            vec![0, 1],
+            "inner restoration iteration leaked: {iters:?}"
+        );
+    }
+
+    #[test]
+    fn scoped_iter_capture_nesting_restores_outer_buffer() {
+        let outer = ScopedIterCapture::start();
+        emit_iter(0, ' ');
+        let ((), inner) = with_iter_capture(|| emit_iter(99, 'R'));
+        emit_iter(1, ' ');
+        let outer_got = outer.finish();
+        assert_eq!(inner.len(), 1);
+        assert_eq!(inner[0].iter, 99);
+        let iters: Vec<i32> = outer_got.iter().map(|r| r.iter).collect();
+        assert_eq!(iters, vec![0, 1]);
+    }
+
+    #[test]
+    fn collector_scope_feeds_manual_guard() {
+        let scope = collector_scope();
+        let guard = IterCaptureGuard::start();
+        emit_iter(0, ' ');
+        let records = guard.finish();
+        drop(scope);
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].iter, 0);
+
+        let guard = IterCaptureGuard::start();
+        emit_iter(1, ' ');
+        assert!(guard.finish().is_empty());
+    }
+
+    #[test]
+    fn with_iter_capture_is_panic_safe() {
+        let unwound = std::panic::catch_unwind(|| {
+            let _ = with_iter_capture(|| panic!("solve blew up"));
+        });
+        assert!(unwound.is_err());
+        assert!(
+            !iteration_event_wanted(),
+            "capture slot must be restored when the closure unwinds"
         );
     }
 

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -321,6 +321,9 @@ impl ScopedIterCapture {
 /// activates an [`IterCaptureGuard`], runs `f`, and tears both
 /// down before returning.
 ///
+/// Records exist only for solver paths that emit the [`ITER_TARGET`]
+/// event. An active-set SQP solve inside `f` captures nothing.
+///
 /// ```ignore
 /// let (solution, iters) = pounce_observability::with_iter_capture(|| nlp.solve());
 /// ```

--- a/crates/pounce-observability/tests/global_compose.rs
+++ b/crates/pounce-observability/tests/global_compose.rs
@@ -1,5 +1,5 @@
 use pounce_observability::{
-    IterCaptureGuard, ITER_TARGET, collector_scope, init_for_tests, with_iter_capture,
+    ITER_TARGET, IterCaptureGuard, collector_scope, init_for_tests, with_iter_capture,
 };
 
 fn emit(iter: i64) {

--- a/crates/pounce-observability/tests/global_compose.rs
+++ b/crates/pounce-observability/tests/global_compose.rs
@@ -1,0 +1,23 @@
+use pounce_observability::{
+    IterCaptureGuard, ITER_TARGET, collector_scope, init_for_tests, with_iter_capture,
+};
+
+fn emit(iter: i64) {
+    tracing::info!(target: ITER_TARGET, iter = iter, objective = 1.0);
+}
+
+#[test]
+fn scoped_capture_composes_with_global_install() {
+    init_for_tests();
+
+    let ((), records) = with_iter_capture(|| emit(3));
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].iter, 3);
+
+    let _scope = collector_scope();
+    let guard = IterCaptureGuard::start();
+    emit(4);
+    let records = guard.finish();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].iter, 4);
+}

--- a/crates/pounce-rs/Cargo.toml
+++ b/crates/pounce-rs/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["mathematics", "science"]
 pounce-common.workspace = true
 pounce-nlp.workspace = true
 pounce-algorithm.workspace = true
+pounce-observability.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -77,13 +77,19 @@ pub trait Problem {
 }
 
 /// The outcome of [`Nlp::solve`].
+///
+/// The vector fields (`x`, `multipliers`, `g`, `z_l`, `z_u`) are filled
+/// by the solver's `finalize_solution` callback. They stay empty
+/// when the solve aborts before finalization, so check
+/// `success`/`status` before indexing.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct Solution {
     /// Solver status; `success` is the convenient boolean.
     pub status: ApplicationReturnStatus,
     /// `true` for `SolveSucceeded` / `SolvedToAcceptableLevel`.
     pub success: bool,
-    /// Optimal variables.
+    /// Optimal variables (length `n`).
     pub x: Vec<f64>,
     /// Objective at the solution.
     pub objective: f64,
@@ -264,10 +270,10 @@ impl<P: Problem + 'static> Nlp<P> {
             let _ = app.options_mut().set_integer_value(k, *v, true, true);
         }
 
-        let scope = self.capture_iterations.then(crate::collector_scope);
-        if self.capture_iterations {
+        let scope = self.capture_iterations.then(|| {
             app.enable_iter_history();
-        }
+            crate::collector_scope()
+        });
         let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&adapter) as _;
         let status = app.optimize_tnlp(tnlp);
         drop(scope);

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -199,6 +199,12 @@ impl<P: Problem + 'static> Nlp<P> {
     /// Record the per-iteration trajectory: one
     /// [`IterRecord`](crate::IterRecord) per Newton iteration into
     /// [`Solution::stats`]`.iterations` (empty without this call).
+    ///
+    /// Interior-point solves only, since the per-iteration event
+    /// is emitted by the IPM engine, so on the active-set SQP engine
+    /// (`solver_selection=qp-active-set`/`algorithm=active-set-sqp`)
+    /// `stats.iterations` stays empty even though
+    /// `stats.iteration_count` still reports the iterations run.
     pub fn capture_iterations(mut self) -> Self {
         self.capture_iterations = true;
         self
@@ -481,6 +487,19 @@ mod tests {
             iters.windows(2).all(|w| w[0].iter < w[1].iter),
             "iteration counter must be strictly increasing"
         );
+    }
+
+    #[test]
+    fn capture_iterations_is_empty_on_sqp_engine() {
+        let sol = Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+            .constraint_bounds(&[3.0], &[3.0])
+            .option_str("solver_selection", "qp-active-set")
+            .capture_iterations()
+            .solve();
+        assert!(sol.success, "status = {:?}", sol.status);
+        assert!(sol.stats.iteration_count > 0);
+        assert!(sol.stats.iterations.is_empty());
     }
 
     #[test]

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -40,7 +40,7 @@ use std::rc::Rc;
 
 use crate::{
     ApplicationReturnStatus, BoundsInfo, IndexStyle, IpoptApplication, IpoptCq, IpoptData, NlpInfo,
-    Solution as TnlpSolution, SparsityRequest, StartingPoint, TNLP,
+    Solution as TnlpSolution, SolveStatistics, SparsityRequest, StartingPoint, TNLP,
 };
 
 const FD: f64 = 1.4901161193847656e-8; // sqrt(f64::EPSILON)
@@ -89,6 +89,18 @@ pub struct Solution {
     pub objective: f64,
     /// Constraint multipliers `λ` (length `n_constraints`).
     pub multipliers: Vec<f64>,
+    /// Constraint values `g(x)` at the solution (length `n_constraints`).
+    pub g: Vec<f64>,
+    /// Lower-bound multipliers `z_L` (length `n`).
+    pub z_l: Vec<f64>,
+    /// Upper-bound multipliers `z_U` (length `n`).
+    pub z_u: Vec<f64>,
+    /// Per-solve statistics: wall time (`total_wallclock_time_secs`),
+    /// `iteration_count`, evaluation counts, final scaled and unscaled
+    /// infeasibilities, final barrier `final_mu`, restoration counters.
+    /// `stats.iterations` holds the per-iteration trajectory and is
+    ///  non-empty only when [`Nlp::capture_iterations`] was requested.
+    pub stats: SolveStatistics,
 }
 
 /// Builder: `Nlp::new(problem)` then `.var_bounds(..)` / `.x0(..)` (which fix
@@ -104,6 +116,7 @@ pub struct Nlp<P: Problem> {
     num: Vec<(String, f64)>,
     int: Vec<(String, i32)>,
     string: Vec<(String, String)>,
+    capture_iterations: bool,
 }
 
 impl<P: Problem + 'static> Nlp<P> {
@@ -125,6 +138,7 @@ impl<P: Problem + 'static> Nlp<P> {
             num: Vec::new(),
             int: Vec::new(),
             string: Vec::new(),
+            capture_iterations: false,
         }
     }
 
@@ -182,6 +196,14 @@ impl<P: Problem + 'static> Nlp<P> {
         self
     }
 
+    /// Record the per-iteration trajectory: one
+    /// [`IterRecord`](crate::IterRecord) per Newton iteration into
+    /// [`Solution::stats`]`.iterations` (empty without this call).
+    pub fn capture_iterations(mut self) -> Self {
+        self.capture_iterations = true;
+        self
+    }
+
     /// Build the `TNLP` adapter and run the interior-point solver.
     ///
     /// # Panics
@@ -204,6 +226,9 @@ impl<P: Problem + 'static> Nlp<P> {
             sol_x: Vec::new(),
             sol_obj: 0.0,
             sol_lambda: Vec::new(),
+            sol_g: Vec::new(),
+            sol_z_l: Vec::new(),
+            sol_z_u: Vec::new(),
         }));
 
         let mut app = IpoptApplication::new();
@@ -233,8 +258,14 @@ impl<P: Problem + 'static> Nlp<P> {
             let _ = app.options_mut().set_integer_value(k, *v, true, true);
         }
 
+        let scope = self.capture_iterations.then(crate::collector_scope);
+        if self.capture_iterations {
+            app.enable_iter_history();
+        }
         let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&adapter) as _;
         let status = app.optimize_tnlp(tnlp);
+        drop(scope);
+        let stats = app.statistics();
         let a = adapter.borrow();
         Solution {
             status,
@@ -246,6 +277,10 @@ impl<P: Problem + 'static> Nlp<P> {
             x: a.sol_x.clone(),
             objective: a.sol_obj,
             multipliers: a.sol_lambda.clone(),
+            g: a.sol_g.clone(),
+            z_l: a.sol_z_l.clone(),
+            z_u: a.sol_z_u.clone(),
+            stats,
         }
     }
 }
@@ -264,6 +299,9 @@ struct Adapter<P: Problem> {
     sol_x: Vec<f64>,
     sol_obj: f64,
     sol_lambda: Vec<f64>,
+    sol_g: Vec<f64>,
+    sol_z_l: Vec<f64>,
+    sol_z_u: Vec<f64>,
 }
 
 impl<P: Problem> TNLP for Adapter<P> {
@@ -367,6 +405,9 @@ impl<P: Problem> TNLP for Adapter<P> {
         self.sol_x = sol.x.to_vec();
         self.sol_obj = sol.obj_value;
         self.sol_lambda = sol.lambda.to_vec();
+        self.sol_g = sol.g.to_vec();
+        self.sol_z_l = sol.z_l.to_vec();
+        self.sol_z_u = sol.z_u.to_vec();
     }
 }
 
@@ -405,6 +446,41 @@ mod tests {
             .x0(&[0.0, 0.0]) // n inferred = 2
             .solve();
         assert!(sol.success);
+    }
+
+    #[test]
+    fn solve_populates_stats_and_duals() {
+        let sol = Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+            .constraint_bounds(&[3.0], &[3.0])
+            .solve();
+        assert!(sol.success);
+        assert!(sol.stats.iteration_count > 0);
+        assert!(sol.stats.total_wallclock_time_secs > 0.0);
+        assert!(sol.stats.num_obj_evals > 0);
+        assert!(sol.stats.final_constr_viol < 1e-6);
+        assert_eq!(sol.g.len(), 1);
+        assert!((sol.g[0] - 3.0).abs() < 1e-6, "g at solution: {:?}", sol.g);
+        assert_eq!(sol.z_l.len(), 2);
+        assert_eq!(sol.z_u.len(), 2);
+        assert!(sol.stats.iterations.is_empty());
+    }
+
+    #[test]
+    fn capture_iterations_fills_trajectory() {
+        let sol = Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+            .constraint_bounds(&[3.0], &[3.0])
+            .capture_iterations()
+            .solve();
+        assert!(sol.success);
+        let iters = &sol.stats.iterations;
+        assert!(!iters.is_empty(), "no iteration records captured");
+        assert_eq!(iters[0].iter, 0, "trajectory must start at iteration 0");
+        assert!(
+            iters.windows(2).all(|w| w[0].iter < w[1].iter),
+            "iteration counter must be strictly increasing"
+        );
     }
 
     #[test]

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -126,6 +126,48 @@
 //! let obj = prob.borrow().obj.unwrap();
 //! assert!((obj - 17.014_017).abs() < 1e-4);            // known optimum
 //! ```
+//!
+//! ## Solve statistics and the iteration trajectory
+//!
+//! Every [`builder::Nlp::solve`] fills [`Solution::stats`](builder::Solution)
+//! with the solve's [`SolveStatistics`] (wall time, iteration count,
+//! evaluation counts, final infeasibilities) and the solution carries the
+//! constraint values `g` and bound multipliers `z_l`/`z_u`. Opt in to the
+//! per-iteration trajectory with `.capture_iterations()`.
+//!
+//! ```
+//! use pounce_rs::prelude::*;
+//!
+//! struct Quad; // min (x0-1)^2 + (x1-2)^2  s.t. x0 + x1 == 3
+//! impl Problem for Quad {
+//!     fn objective(&self, x: &[f64]) -> f64 {
+//!         (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+//!     }
+//!     fn n_constraints(&self) -> usize {
+//!         1
+//!     }
+//!     fn constraints(&self, x: &[f64], g: &mut [f64]) {
+//!         g[0] = x[0] + x[1];
+//!     }
+//! }
+//!
+//! let sol = Nlp::new(Quad)
+//!     .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+//!     .constraint_bounds(&[3.0], &[3.0])
+//!     .capture_iterations()
+//!     .solve();
+//! assert!(sol.success);
+//! assert!(sol.stats.iteration_count > 0);
+//! assert!(sol.stats.total_wallclock_time_secs > 0.0);
+//! assert!(!sol.stats.iterations.is_empty());           // one record per iteration
+//! ```
+//!
+//! For solves outside the builder, [`with_iter_capture`] wraps any closure
+//! with capture active and returns the recorded [`IterRecord`]s alongside
+//! the closure's result. For the [`IpoptApplication`] path, install
+//! [`collector_scope`] for the duration of the solve and read the history
+//! back from `statistics()`:
+//! `let _scope = collector_scope(); app.enable_iter_history(); …`.
 
 // --- scalar types -----------------------------------------------------------
 pub use pounce_common::types::{Index, Number};
@@ -140,10 +182,20 @@ pub use pounce_nlp::tnlp::{
 // --- the solver driver ------------------------------------------------------
 pub use pounce_algorithm::application::IpoptApplication;
 
+// --- iteration capture & observability --------------------------------------
+// Thread-scoped helpers so an embedding library can record a solve's
+// trajectory (and turn on console logs) with no direct `tracing` deps.
+pub use pounce_nlp::solve_statistics::{IterRecord, SolveStatistics};
+pub use pounce_observability::{
+    CollectorScope, IterCaptureGuard, ScopedIterCapture, collector_scope, init_subscriber,
+    with_iter_capture,
+};
+
 // --- the underlying crates, for anything not surfaced above -----------------
 pub use pounce_algorithm;
 pub use pounce_common;
 pub use pounce_nlp;
+pub use pounce_observability;
 
 // --- ergonomic builder API (argmin-style small trait + builder; #168) -------
 pub mod builder;
@@ -161,6 +213,8 @@ pub mod prelude {
     pub use pounce_algorithm::application::IpoptApplication;
     pub use pounce_common::types::{Index, Number};
     pub use pounce_nlp::return_codes::ApplicationReturnStatus;
+    pub use pounce_nlp::solve_statistics::{IterRecord, SolveStatistics};
+    pub use pounce_observability::{collector_scope, with_iter_capture};
     pub use pounce_nlp::tnlp::{
         BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution,
         SparsityRequest, StartingPoint, TNLP,

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -214,9 +214,9 @@ pub mod prelude {
     pub use pounce_common::types::{Index, Number};
     pub use pounce_nlp::return_codes::ApplicationReturnStatus;
     pub use pounce_nlp::solve_statistics::{IterRecord, SolveStatistics};
-    pub use pounce_observability::{collector_scope, with_iter_capture};
     pub use pounce_nlp::tnlp::{
         BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution,
         SparsityRequest, StartingPoint, TNLP,
     };
+    pub use pounce_observability::{collector_scope, with_iter_capture};
 }

--- a/crates/pounce-rs/tests/iteration_capture.rs
+++ b/crates/pounce-rs/tests/iteration_capture.rs
@@ -51,6 +51,25 @@ fn builder_capture_iterations_flag_fills_stats() {
     assert_eq!(sol.z_l.len(), 2);
 }
 
+#[test]
+fn with_iter_capture_around_capture_iterations_gets_records_too() {
+    let (sol, iters) = with_iter_capture(|| {
+        Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+            .constraint_bounds(&[3.0], &[3.0])
+            .capture_iterations()
+            .solve()
+    });
+    assert!(sol.success, "status = {:?}", sol.status);
+    assert!(!sol.stats.iterations.is_empty());
+    assert_eq!(
+        iters.len(),
+        sol.stats.iterations.len(),
+        "outer capture must see the same trajectory the driver recorded"
+    );
+    assert_eq!(iters[0].iter, sol.stats.iterations[0].iter);
+}
+
 /// min (x0-1)^2 + (x1+2)^2, bounds only (m = 0), L-BFGS Hessian.
 #[derive(Default)]
 struct Bounded2 {

--- a/crates/pounce-rs/tests/iteration_capture.rs
+++ b/crates/pounce-rs/tests/iteration_capture.rs
@@ -1,0 +1,119 @@
+//! End-to-end iteration capture through `pounce_rs`
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_rs::prelude::*;
+
+/// min (x0-1)^2 + (x1-2)^2  s.t. x0 + x1 == 3
+struct Quad;
+impl Problem for Quad {
+    fn objective(&self, x: &[f64]) -> f64 {
+        (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+    }
+    fn n_constraints(&self) -> usize {
+        1
+    }
+    fn constraints(&self, x: &[f64], g: &mut [f64]) {
+        g[0] = x[0] + x[1];
+    }
+}
+
+#[test]
+fn builder_solve_inside_with_iter_capture_records_trajectory() {
+    let (sol, iters) = with_iter_capture(|| {
+        Nlp::new(Quad)
+            .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+            .constraint_bounds(&[3.0], &[3.0])
+            .solve()
+    });
+    assert!(sol.success, "status = {:?}", sol.status);
+    assert!(!iters.is_empty(), "no iteration records captured");
+    assert_eq!(iters[0].iter, 0, "trajectory must start at iteration 0");
+    assert!(
+        iters.windows(2).all(|w| w[0].iter < w[1].iter),
+        "iteration counter must be strictly increasing"
+    );
+}
+
+#[test]
+fn builder_capture_iterations_flag_fills_stats() {
+    let sol = Nlp::new(Quad)
+        .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+        .constraint_bounds(&[3.0], &[3.0])
+        .capture_iterations()
+        .solve();
+    assert!(sol.success, "status = {:?}", sol.status);
+    assert!(!sol.stats.iterations.is_empty());
+    assert!(sol.stats.iteration_count > 0);
+    assert!(sol.stats.total_wallclock_time_secs > 0.0);
+    assert_eq!(sol.g.len(), 1);
+    assert_eq!(sol.z_l.len(), 2);
+}
+
+/// min (x0-1)^2 + (x1+2)^2, bounds only (m = 0), L-BFGS Hessian.
+#[derive(Default)]
+struct Bounded2 {
+    solved: bool,
+}
+impl TNLP for Bounded2 {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 0,
+            nnz_jac_g: 0,
+            nnz_h_lag: 0,
+            index_style: IndexStyle::C,
+        })
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-5.0, -5.0]);
+        b.x_u.copy_from_slice(&[5.0, 5.0]);
+        true
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.0, 0.0]);
+        true
+    }
+    fn eval_f(&mut self, x: &[f64], _new_x: bool) -> Option<f64> {
+        Some((x[0] - 1.0).powi(2) + (x[1] + 2.0).powi(2))
+    }
+    fn eval_grad_f(&mut self, x: &[f64], _new_x: bool, grad_f: &mut [f64]) -> bool {
+        grad_f[0] = 2.0 * (x[0] - 1.0);
+        grad_f[1] = 2.0 * (x[1] + 2.0);
+        true
+    }
+    fn eval_g(&mut self, _x: &[f64], _new_x: bool, _g: &mut [f64]) -> bool {
+        true
+    }
+    fn eval_jac_g(&mut self, _x: Option<&[f64]>, _new_x: bool, _mode: SparsityRequest<'_>) -> bool {
+        true
+    }
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.solved = true;
+    }
+}
+
+#[test]
+fn application_iter_history_fills_under_collector_scope() {
+    let _scope = collector_scope();
+    let mut app = IpoptApplication::new();
+    let init = app.initialize();
+    assert!(init.is_ok(), "IpoptApplication::initialize failed: {init:?}");
+    let _ = app
+        .options_mut()
+        .set_string_value("hessian_approximation", "limited-memory", true, true);
+    app.enable_iter_history();
+
+    let prob = Rc::new(RefCell::new(Bounded2::default()));
+    let status = app.optimize_tnlp(Rc::clone(&prob) as Rc<RefCell<dyn TNLP>>);
+    assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+    assert!(prob.borrow().solved);
+
+    let stats = app.statistics();
+    assert!(
+        !stats.iterations.is_empty(),
+        "enable_iter_history under collector_scope must fill statistics().iterations"
+    );
+    assert_eq!(stats.iterations[0].iter, 0);
+}

--- a/crates/pounce-rs/tests/iteration_capture.rs
+++ b/crates/pounce-rs/tests/iteration_capture.rs
@@ -99,10 +99,13 @@ fn application_iter_history_fills_under_collector_scope() {
     let _scope = collector_scope();
     let mut app = IpoptApplication::new();
     let init = app.initialize();
-    assert!(init.is_ok(), "IpoptApplication::initialize failed: {init:?}");
-    let _ = app
-        .options_mut()
-        .set_string_value("hessian_approximation", "limited-memory", true, true);
+    assert!(
+        init.is_ok(),
+        "IpoptApplication::initialize failed: {init:?}"
+    );
+    let _ =
+        app.options_mut()
+            .set_string_value("hessian_approximation", "limited-memory", true, true);
     app.enable_iter_history();
 
     let prob = Rc::new(RefCell::new(Bounded2::default()));


### PR DESCRIPTION
A library that uses `pounce-rs` as a solver backend cannot claim the global tracing subscriber, so capturing a solve's iteration trajectory requires direct `tracing` and `tracing-subscriber` dependencies and additional code.
IterCaptureGuard::start() without that installs silently and captures nothing. Also, `builder::Solution` exposes only status/success/x/objective/multipliers, discarding statistics the driver already computes (wall time, iteration count, evaluation counts, final infeasibilities) and the g/z_L/z_U values available at finalize_solution.

In this PR, I added scoped capture helpers to `pounce-observability` and improved results and exposure in `pounce-rs`.

Some of the code and the changelog were generated using GitHub Copilot. See commit trailer.