### PR TITLE
Fix false InternalError on solved convex QCQPs (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,38 @@ changes.
 
 ### Fixed
 
+- **A solved convex QCQP no longer reports `InternalError` / exit 1 (#209).**
+  On the `.nl` → SOCP conic path (`solver_selection=socp`, and `auto` when it
+  routes a QCQP there) POUNCE converged to the correct, feasible optimum and
+  then reported failure, with an end-of-run summary showing a large
+  `Constraint violation` for a point that is feasible to machine precision. Any
+  driver that trusts the exit code or the status — a Pyomo/AMPL wrapper, a CI
+  gate — read the solve as failed. Two independent defects:
+  - The summary measured the second-order cone rows with the nonnegative
+    orthant's per-row `Gx ≤ h` test. A converged SOC block legitimately has
+    individual rows with `Gx > h` (only the cone membership `s₀ ≥ ‖s₁‖` must
+    hold) and non-complementary rows (only the block product `⟨s, z⟩`
+    vanishes), so the reported violation measured nothing to do with the
+    quadratic constraint. Conic solves are now measured against their own
+    cones (`QpSolution::kkt_residuals_conic`).
+  - The conic driver's convergence test reads the *homogeneous* residuals,
+    which carry the consistency of the internal slack `s` (`Gx + s − hτ`)
+    alongside the real KKT quantities. That term is bookkeeping — `s` is never
+    returned — and it floors out once μ reaches ~1e-16 and the Nesterov–Todd
+    scaling's condition number explodes. On the reported QCQP it bottomed at
+    1e-8, drifted back up to 1e-4, and the solve ground on to a factorization
+    breakdown, all while the iterate itself was accurate to 1e-14. A solve
+    that ends without a verdict of its own (breakdown or iteration limit) now
+    takes one from the **true KKT error of the point it returns** — cone
+    feasibility, stationarity, complementarity and `z ∈ K*`, measured on the
+    un-homogenized iterate. Below `tol` that is `Optimal`; within `~1e3·tol`,
+    `SolvedToAcceptableLevel`; beyond it the original verdict stands. The
+    check runs only after the loop, so iterates and iteration counts are
+    unchanged — only the verdict and the exit code differ.
+- **`pounce.solve_socp` now reports final KKT `residuals`.** Conic solves
+  previously returned `residuals=None` / `kkt_error=None` because only the
+  orthant measure existed; they now carry the cone-aware residuals, so a conic
+  solve's convergence is checkable from Python.
 - **`pounce.minimize(..., args=...)` now works with convex routing.** The extra
   objective `args` were applied on the NLP path but not bound into the copies of
   `fun`/`jac`/`hess` handed to the LP/QP/SOCP routers, which probe them as bare

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1895,7 +1895,11 @@ fn run_convex_socp(
 
     // Final KKT residuals from pounce-convex; reused for both the Ipopt-style
     // summary block and the JSON report below.
-    let res = sol.kkt_residuals(&qp);
+    // Cone-aware: the quadratic rows became SOC blocks, whose individual rows
+    // legitimately violate `Gx ≤ h` at a perfectly feasible point, so the
+    // orthant-only `kkt_residuals` reported a large bogus constraint violation
+    // and NLP error for a solved problem (pounce#209).
+    let res = sol.kkt_residuals_conic(&qp, &cones);
     // Ipopt-style summary so the objective/iteration count are scrapable by
     // consumers that parse Ipopt's end-of-run block (see print_convex_summary).
     print::print_convex_summary(

--- a/crates/pounce-cli/tests/fixtures/qcqp_ball.nl
+++ b/crates/pounce-cli/tests/fixtures/qcqp_ball.nl
@@ -1,0 +1,36 @@
+g3 1 1 0	# problem unknown
+ 2 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 1 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 2 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o0
+o5
+v0
+n2
+o5
+v1
+n2
+O0 0
+n0
+x2
+0 0.0
+1 0.0
+r
+1 4.0
+b
+0 -10 10
+0 -10 10
+k1
+1
+J0 2
+0 0
+1 0
+G0 2
+0 3.0
+1 4.0

--- a/crates/pounce-cli/tests/issue_209_qcqp_socp_status.rs
+++ b/crates/pounce-cli/tests/issue_209_qcqp_socp_status.rs
@@ -1,0 +1,161 @@
+//! Regression for pounce#209: a feasible convex QCQP solved correctly by the
+//! `.nl` → SOCP conic path was reported as a failure.
+//!
+//! Fixture `qcqp_ball.nl` is `min 3x₀ + 4x₁ s.t. x₀² + x₁² ≤ 4`, box
+//! `[-10, 10]` — the linear objective over a ball, whose closed-form optimum
+//! needs no oracle: `x* = −r·c/‖c‖ = (−1.2, −1.6)`, `f* = −r‖c‖ = −10`.
+//!
+//! Two independent defects made that solve look like an internal error:
+//!
+//!   1. The end-of-run KKT summary measured the SOC rows with the orthant's
+//!      per-row `Gx ≤ h` test. A converged second-order cone block routinely
+//!      has individual rows with `Gx > h` (only `s₀ ≥ ‖s₁‖` must hold), so a
+//!      feasible point reported a large `Constraint violation` — in fact
+//!      `≈ √2·max(0, −min xᵢ)`, a quantity with nothing to do with the
+//!      quadratic constraint at all.
+//!   2. The conic driver's convergence test reads the *homogeneous* residuals,
+//!      which carry the internal slack's consistency `Gx + s − hτ` alongside
+//!      the real KKT quantities. That term is bookkeeping (`s` is never
+//!      returned) and it floors out once μ ~1e-16 makes the NT scaling
+//!      ill-conditioned: here it bottomed at 1e-8, wandered back up to 1e-4,
+//!      and the solve ground on to a factorization breakdown — all while the
+//!      iterate itself was accurate to 1e-14. The verdict is now taken from the
+//!      true KKT error of the point actually returned, so this reports
+//!      `Optimal`.
+//!
+//! The checks below pin the user-visible contract: right answer, success-family
+//! status, exit 0, and a summary whose residuals actually describe the point.
+
+use pounce_solve_report::SolveReport;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("qcqp_ball.nl");
+    p
+}
+
+fn run(selection: &str) -> (String, Option<i32>) {
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg(format!("solver_selection={selection}"))
+        .output()
+        .expect("spawn pounce");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        out.status.code(),
+    )
+}
+
+/// Pull a labelled value out of the Ipopt-style end-of-run block, e.g.
+/// `Constraint violation....:   0.0000e+00    0.0000e+00` → the first number.
+fn summary_value(stdout: &str, label: &str) -> f64 {
+    let line = stdout
+        .lines()
+        .find(|l| l.starts_with(label))
+        .unwrap_or_else(|| panic!("no `{label}` line in summary; stdout=\n{stdout}"));
+    let rhs = line.split(':').nth(1).expect("label line has a colon");
+    rhs.split_whitespace()
+        .next()
+        .expect("value after colon")
+        .parse()
+        .expect("summary value parses as f64")
+}
+
+/// The conic path must solve the ball QCQP and *say* it solved it: a
+/// success-family status and exit 0. Previously: "Numerical failure in KKT
+/// factorization", exit 1.
+#[test]
+fn feasible_qcqp_on_conic_path_reports_success_and_exits_zero() {
+    for selection in ["socp", "auto"] {
+        let (stdout, code) = run(selection);
+        assert_eq!(
+            code,
+            Some(0),
+            "solver_selection={selection} must exit 0; stdout=\n{stdout}"
+        );
+        let lower = stdout.to_lowercase();
+        assert!(
+            !lower.contains("numerical failure"),
+            "solver_selection={selection} must not report a numerical failure; stdout=\n{stdout}"
+        );
+        assert!(
+            lower.contains("optimal solution found"),
+            "solver_selection={selection} should report a clean optimum, not reduced \
+             accuracy; stdout=\n{stdout}"
+        );
+        // Sanity: it really did take the conic path (not a silent NLP fallback).
+        assert!(
+            lower.contains("pounce-convex"),
+            "solver_selection={selection} should route to the conic IPM; stdout=\n{stdout}"
+        );
+    }
+}
+
+/// The summary block must describe the point that was returned. A feasible
+/// iterate has ~zero cone violation; the orthant-only metric reported ≈3.2 here
+/// (`√2·max(0, −min xᵢ)` at `x = (−1.2, −1.6)`), which then dominated the
+/// "Overall NLP error" and made a solved problem look badly infeasible.
+#[test]
+fn conic_summary_reports_cone_violation_not_per_row_orthant_violation() {
+    let (stdout, _) = run("socp");
+    let viol = summary_value(&stdout, "Constraint violation");
+    let nlp_err = summary_value(&stdout, "Overall NLP error");
+    assert!(
+        viol < 1e-6,
+        "feasible QCQP must report ~zero constraint violation, got {viol}; stdout=\n{stdout}"
+    );
+    assert!(
+        nlp_err < 1e-6,
+        "overall NLP error must be small for a solved QCQP, got {nlp_err}; stdout=\n{stdout}"
+    );
+}
+
+/// The JSON report's status and objective must agree with the console, and the
+/// primal must be the closed-form optimum. `InternalError` here is what a
+/// Pyomo/AMPL wrapper or a CI gate would trip on.
+#[test]
+fn conic_json_report_status_is_success_family_with_correct_optimum() {
+    let json = std::env::temp_dir().join("pounce_issue_209_qcqp_ball.json");
+    let _ = std::fs::remove_file(&json);
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg("--json-output")
+        .arg(&json)
+        .arg("solver_selection=socp")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "must exit 0");
+
+    let text = std::fs::read_to_string(&json).expect("read JSON report");
+    let report: SolveReport = serde_json::from_str(&text).expect("parse JSON report");
+    let status = format!("{:?}", report.solution.status);
+    // Not merely a success-family status: this point satisfies the KKT
+    // conditions to ~1e-14, six orders inside `tol`, so anything short of a
+    // clean `SolveSucceeded` would be understating a converged solve.
+    assert_eq!(
+        status, "SolveSucceeded",
+        "a solve accurate to ~1e-14 must report a clean success, got {status}"
+    );
+    assert!(
+        (report.solution.objective - -10.0).abs() < 1e-6,
+        "objective should be −10, got {}",
+        report.solution.objective
+    );
+    let x = &report.solution.x;
+    assert!(
+        (x[0] - -1.2).abs() < 1e-5 && (x[1] - -1.6).abs() < 1e-5,
+        "primal should be (−1.2, −1.6), got {x:?}"
+    );
+
+    let _ = std::fs::remove_file(&json);
+}

--- a/crates/pounce-convex/src/cones/composite.rs
+++ b/crates/pounce-convex/src/cones/composite.rs
@@ -183,6 +183,21 @@ impl CompositeCone {
         &self.blocks
     }
 
+    /// The declarative [`ConeSpec`] partition this cone represents — the
+    /// inverse of [`Self::from_specs`]. Lets a driver that only holds the
+    /// assembled cone hand its partition to a spec-taking API such as
+    /// [`crate::QpSolution::kkt_residuals_conic`].
+    pub fn specs(&self) -> Vec<ConeSpec> {
+        self.blocks
+            .iter()
+            .map(|(_, k)| match k {
+                ConeKind::Nonneg(c) => ConeSpec::Nonneg(c.dim()),
+                ConeKind::SecondOrder(c) => ConeSpec::SecondOrder(c.dim()),
+                ConeKind::Psd(c) => ConeSpec::Psd(c.n),
+            })
+            .collect()
+    }
+
     /// True iff every block is a nonnegative orthant (the LP/QP case). The
     /// complementarity product `s ∘ z` is then elementwise, so a corrector can
     /// box-project the products directly on `(s, z)` without the Jordan-algebra

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -39,7 +39,7 @@ use crate::debug::{ConvexDebugState, fire};
 use crate::ipm::{
     QpOptions, build_factorization, build_rhs, detect_infeasibility_cone, dot, inf_norm, split_step,
 };
-use crate::qp::{QpIterate, QpProblem, QpSolution, QpStatus, breakdown_status};
+use crate::qp::{QpIterate, QpProblem, QpSolution, QpStatus};
 use pounce_common::debug::{Checkpoint, DebugAction, DebugHook};
 use pounce_common::types::Index;
 use pounce_linsol::{Factorization, FactorizationError, SparseSymLinearSolverInterface};
@@ -154,6 +154,58 @@ fn on_infeasibility_ray(tau: f64, kappa: f64) -> bool {
 /// under a caller-tightened/loosened tolerance.
 fn relative_stop_permitted(max_scale: f64, tol: f64) -> bool {
     max_scale * f64::EPSILON > tol
+}
+
+/// The KKT error of the **un-homogenized** iterate `(x, y, z)/τ`, measured
+/// directly against the original problem and this solve's own cones.
+///
+/// This is the definition of optimality applied to the point a caller would
+/// actually receive: cone feasibility of `h − Gx̂`, stationarity
+/// `‖Px̂ + c + Aᵀŷ + Gᵀẑ‖∞`, and per-cone-block complementarity. It is a
+/// *stronger* certificate than the driver's homogeneous residual, which also
+/// carries the consistency of the internal slack `s` (`Gx + s − hτ`) — a
+/// quantity that is pure bookkeeping (`s` is never returned) and that goes
+/// numerically noisy once `μ` reaches ~1e-16 and the NT scaling's condition
+/// number blows up. On a feasible convex QCQP the surrogate stalled at ~1e-7
+/// and drifted as high as 1e-4 while this error sat at 1e-14 (pounce#209).
+///
+/// Returns `None` when `τ ≤ 0` (an infeasibility ray, where un-homogenizing is
+/// meaningless) or when `ẑ` has left the dual cone — without `ẑ ∈ K*` the
+/// residuals below are not a KKT certificate, however small they are.
+fn true_kkt_error(
+    prob: &QpProblem,
+    cone: &CompositeCone,
+    x: &[f64],
+    y: &[f64],
+    z: &[f64],
+    tau: f64,
+) -> Option<f64> {
+    if !(tau > 0.0) {
+        return None;
+    }
+    let inv = 1.0 / tau;
+    let z_hat: Vec<f64> = z.iter().map(|v| v * inv).collect();
+    // `in_dual_cone` is scale-free in the sense that matters here: the cones
+    // are self-dual, so this asks whether `ẑ` is (nearly) in `K` itself.
+    if !cone.in_dual_cone(&z_hat, 1e-9) {
+        return None;
+    }
+    let candidate = QpSolution {
+        status: QpStatus::Optimal,
+        x: x.iter().map(|v| v * inv).collect(),
+        y: y.iter().map(|v| v * inv).collect(),
+        z: z_hat,
+        z_lb: vec![0.0; prob.n],
+        z_ub: vec![0.0; prob.n],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    };
+    Some(
+        candidate
+            .kkt_residuals_conic(prob, &cone.specs())
+            .kkt_error(),
+    )
 }
 
 /// Fraction-to-boundary step for a positive scalar ray `v + α dv > 0`,
@@ -449,18 +501,9 @@ where
         } else {
             pres.max(dres).max(gap)
         };
-        // "Acceptable level": near the cone boundary the scaling/factorization
-        // can break down a hair short of `tol`. If the (relative) KKT residuals
-        // are already tiny (within `~1e3·tol`) when that happens, the iterate
-        // is usable — report it as `OptimalInaccurate` (reduced accuracy)
-        // rather than discarding it as a spurious `NumericalFailure`. It is
-        // deliberately *not* reported as a bare `Optimal`: the residual sits
-        // above `tol`, so callers can tell it apart from a genuinely converged
-        // solve (code review 2026-06 item M20). This mirrors the non-symmetric
-        // HSDE driver (`hsde_nonsym.rs`), which already does this; the two
-        // drivers were inconsistent (the symmetric one discarded usable
-        // SOC/orthant iterates that the non-symmetric one would have accepted).
-        let near_opt = res < 1e3 * opts.tol;
+        // (`res` also feeds the debugger checkpoints below. The
+        // reduced-accuracy salvage that used to read it here now runs *after*
+        // the loop, against the true KKT residual — see `SALVAGE`.)
 
         // Debugger checkpoint: top of iteration. Blocks expose the
         // homogeneous iterate `(x, s, y, z, τ, κ)`; the objective is the
@@ -619,7 +662,7 @@ where
             break;
         }
         if !factored {
-            status = breakdown_status(near_opt);
+            status = QpStatus::NumericalFailure;
             break;
         }
         split_step(&rhs, n, m_eq, m_ineq, &mut p_x, &mut p_y, &mut p_z);
@@ -642,7 +685,7 @@ where
         )
         .is_err()
         {
-            status = breakdown_status(near_opt);
+            status = QpStatus::NumericalFailure;
             break;
         }
         split_step(&rhs, n, m_eq, m_ineq, &mut dx, &mut dy, &mut dz);
@@ -686,7 +729,7 @@ where
         )
         .is_err()
         {
-            status = breakdown_status(near_opt);
+            status = QpStatus::NumericalFailure;
             break;
         }
         split_step(&rhs, n, m_eq, m_ineq, &mut dx, &mut dy, &mut dz);
@@ -917,6 +960,48 @@ where
     let mut px = vec![0.0; n];
     prob.p_mul(&x, &mut px);
     let obj = 0.5 * dot(&x, &px) + dot(&prob.c, &x);
+
+    // VERDICT. The loop's convergence test reads the *homogeneous* residuals,
+    // which carry the internal slack's consistency `Gx + s − hτ` alongside the
+    // real KKT quantities. That term is bookkeeping — `s` is never returned —
+    // and it floors out once `μ` reaches ~1e-16 and the NT scaling's condition
+    // number explodes. So a solve can be optimal in every sense the caller can
+    // observe while the surrogate refuses to certify it: on a feasible convex
+    // QCQP `pres` bottomed at 1e-8, wandered back up to 1e-4, and the solve
+    // ground on to a factorization breakdown while the iterate itself was
+    // accurate to 1e-14 — reported as `InternalError` / exit 1 (pounce#209).
+    //
+    // So when the loop ends *without* a verdict of its own, ask the question
+    // where it is actually defined: the true KKT error of the un-homogenized
+    // point being returned, against this solve's own cones (see
+    // [`true_kkt_error`], which is strictly stronger than the surrogate — it
+    // also requires `ẑ ∈ K*`). Below `tol` that point satisfies the optimality
+    // conditions and `Optimal` is the honest verdict; within `~1e3·tol` it is
+    // usable at reduced accuracy (`OptimalInaccurate`, deliberately kept
+    // distinguishable from a clean convergence — code review 2026-06 item M20);
+    // beyond that the breakdown stands.
+    //
+    // This deliberately runs *after* the loop rather than as an extra
+    // convergence test inside it. Breaking early on the certificate would stop
+    // some solves sooner and hand back a less-polished iterate: on a degenerate
+    // tangency (`min −x₁ s.t. ‖x‖ ≤ 1, x₀ ≥ 0`) the map from KKT residual to
+    // `x`-error is a square root, so a residual of `tol` still leaves `x₀` off
+    // by ~1e-4. Judging only at the end changes the verdict and never the
+    // iterates. Costs a handful of matvecs, once, and only on a solve that
+    // would otherwise have no answer.
+    if matches!(
+        status,
+        QpStatus::NumericalFailure | QpStatus::IterationLimit
+    ) {
+        // `x`/`y`/`z` are already un-homogenized above, hence `τ = 1`. Strictly
+        // an upgrade: a point that fails both bands leaves the loop's own
+        // verdict (breakdown *or* iteration limit) untouched.
+        status = match true_kkt_error(prob, cone, &x, &y, &z, 1.0) {
+            Some(e) if e < opts.tol => QpStatus::Optimal,
+            Some(e) if e < 1e3 * opts.tol => QpStatus::OptimalInaccurate,
+            _ => status,
+        };
+    }
 
     // Debugger post-mortem at the recovered (un-homogenized) solution. `s`
     // stays in its homogeneous scaling; `dx`/… are the last step.

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -1610,6 +1610,36 @@ fn run_ipm(
         }
     }
 
+    // Final verdict from the true KKT error of the point being returned — the
+    // same rule the HSDE driver applies (see `VERDICT` in `hsde.rs`), so the two
+    // drivers cannot drift apart on whether a solve that ended without its own
+    // verdict actually produced an answer. Strictly an upgrade.
+    if matches!(
+        status,
+        QpStatus::NumericalFailure | QpStatus::IterationLimit
+    ) {
+        let candidate = QpSolution {
+            status,
+            x: x.clone(),
+            y: y.clone(),
+            z: z.clone(),
+            z_lb: vec![0.0; n],
+            z_ub: vec![0.0; n],
+            obj: 0.0,
+            iters,
+            iterates: Vec::new(),
+        };
+        let in_dual_cone = cone.in_dual_cone(&z, 1e-9);
+        let true_res = candidate
+            .kkt_residuals_conic(prob, &cone.specs())
+            .kkt_error();
+        status = match true_res {
+            e if in_dual_cone && e < opts.tol => QpStatus::Optimal,
+            e if in_dual_cone && e < 1e3 * opts.tol => QpStatus::OptimalInaccurate,
+            _ => status,
+        };
+    }
+
     // Objective ½ xᵀP x + cᵀx.
     let mut px = vec![0.0; n];
     prob.p_mul_add(&x, &mut px);

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -12,6 +12,8 @@
 //! triplets. This is the form the IPM in [`crate::ipm`] consumes, and
 //! the form the `.nl` → QP extraction (Phase 2 dispatch) will target.
 
+use crate::cones::ConeSpec;
+
 /// A sparse matrix entry `(row, col, val)`, 0-based.
 #[derive(Debug, Clone, Copy)]
 pub struct Triplet {
@@ -273,6 +275,45 @@ pub struct QpIterate {
     pub alpha_dual: f64,
 }
 
+/// How far `s` is outside the cone `spec`, in the cone's own defining
+/// inequality (`0` when `s ∈ K`). Not a Euclidean distance — a violation
+/// magnitude, which is what a convergence report wants and what vanishes
+/// exactly at a feasible point.
+///
+/// * orthant — `max(0, −sᵢ)`
+/// * second-order — `max(0, ‖s₁‖ − s₀)`
+/// * PSD — `max(0, −λ_min(smat s))`
+/// * exponential — `max(0, −ψ)` for `ψ = y·log(z/y) − x`, plus `y, z ≥ 0`
+/// * power — `max(0, |x| − y^α z^{1−α})`, plus `y, z ≥ 0`
+fn cone_violation(spec: &ConeSpec, s: &[f64]) -> f64 {
+    let neg = |v: f64| (-v).max(0.0);
+    match spec {
+        ConeSpec::Nonneg(_) => s.iter().fold(0.0_f64, |m, &si| m.max(neg(si))),
+        ConeSpec::SecondOrder(_) => {
+            let tail = s[1..].iter().map(|v| v * v).sum::<f64>().sqrt();
+            (tail - s[0]).max(0.0)
+        }
+        ConeSpec::Psd(k) => neg(crate::cones::PsdCone::new(*k).min_eig(s)),
+        ConeSpec::Exponential => {
+            let (x, y, z) = (s[0], s[1], s[2]);
+            let bounds = neg(y).max(neg(z));
+            if y <= 0.0 || z <= 0.0 {
+                // ψ is undefined here; the sign violation is the whole story.
+                return bounds.max(0.0_f64.max(x));
+            }
+            bounds.max(neg(y * (z / y).ln() - x))
+        }
+        ConeSpec::Power(alpha) => {
+            let (x, y, z) = (s[0], s[1], s[2]);
+            let bounds = neg(y).max(neg(z));
+            if y < 0.0 || z < 0.0 {
+                return bounds.max(x.abs());
+            }
+            bounds.max((x.abs() - y.powf(*alpha) * z.powf(1.0 - *alpha)).max(0.0))
+        }
+    }
+}
+
 /// Final KKT residuals of a [`QpSolution`] with respect to its [`QpProblem`]
 /// — the convergence quantities a caller (e.g. a solve report or benchmark
 /// harness) needs but that aren't otherwise carried on the solution.
@@ -306,6 +347,31 @@ impl QpSolution {
     /// `−z_lb + z_ub` matching how variable bounds expand into `G`-rows and
     /// split back into the bound multipliers.
     pub fn kkt_residuals(&self, prob: &QpProblem) -> QpResiduals {
+        self.kkt_residuals_inner(prob, None)
+    }
+
+    /// Recompute the final KKT residuals of a **conic** solve, where the
+    /// inequality block is not `Gx ≤ h` row-by-row but `h − Gx ∈ K` for the
+    /// product cone `cones` (the form [`crate::solve_socp_ipm`] consumes).
+    ///
+    /// [`Self::kkt_residuals`] assumes the nonnegative orthant, so on a solve
+    /// with second-order / PSD / exponential / power blocks it reports garbage:
+    /// individual rows of a converged SOC block legitimately have `Gx > h`
+    /// (only the *cone* membership `s₀ ≥ ‖s₁‖` must hold) and `zᵢsᵢ ≠ 0` (only
+    /// the *block* product `⟨s, z⟩` vanishes). Feeding those per-row numbers to
+    /// a convergence report made a feasible, optimal QCQP look badly infeasible
+    /// (pounce#209). This variant measures each block with its own cone:
+    /// membership violation for the primal residual, the block inner product
+    /// for complementarity. Equalities, variable bounds and stationarity are
+    /// unchanged.
+    ///
+    /// `cones` must cover `prob.m_ineq()` rows in order; any trailing rows it
+    /// does not cover are treated as orthant rows.
+    pub fn kkt_residuals_conic(&self, prob: &QpProblem, cones: &[ConeSpec]) -> QpResiduals {
+        self.kkt_residuals_inner(prob, Some(cones))
+    }
+
+    fn kkt_residuals_inner(&self, prob: &QpProblem, cones: Option<&[ConeSpec]>) -> QpResiduals {
         let n = prob.n;
 
         // Dual infeasibility (stationarity).
@@ -327,19 +393,46 @@ impl QpSolution {
         }
         let mut gx = vec![0.0; prob.m_ineq()];
         prob.g_mul(&self.x, &mut gx);
-        for (&gxi, &hi) in gx.iter().zip(&prob.h) {
-            primal_infeasibility = primal_infeasibility.max((gxi - hi).max(0.0));
+        // Inequality slack `s = h − Gx`, the vector that must lie in the cone
+        // (in the orthant `s ≥ 0`, i.e. the familiar `Gx ≤ h`).
+        let s: Vec<f64> = prob.h.iter().zip(&gx).map(|(&hi, &gxi)| hi - gxi).collect();
+        let mut complementarity = 0.0_f64;
+        let mut off = 0usize;
+        for spec in cones.unwrap_or(&[]) {
+            let dim = spec.dim().min(s.len() - off);
+            if dim == 0 {
+                break;
+            }
+            let (sb, zb) = (&s[off..off + dim], &self.z[off..off + dim]);
+            primal_infeasibility = primal_infeasibility.max(cone_violation(spec, sb));
+            complementarity = match spec {
+                // Orthant rows complement one-for-one; keep the sharper
+                // per-row measure rather than the block sum.
+                ConeSpec::Nonneg(_) => sb
+                    .iter()
+                    .zip(zb)
+                    .fold(complementarity, |m, (&si, &zi)| m.max((si * zi).abs())),
+                _ => complementarity.max(
+                    sb.iter()
+                        .zip(zb)
+                        .map(|(&si, &zi)| si * zi)
+                        .sum::<f64>()
+                        .abs(),
+                ),
+            };
+            off += dim;
+        }
+        // Rows past the cone list (all of them when `cones` is `None`) are the
+        // nonnegative orthant.
+        for i in off..s.len() {
+            primal_infeasibility = primal_infeasibility.max((-s[i]).max(0.0));
+            complementarity = complementarity.max((self.z[i] * s[i]).abs());
         }
         for i in 0..n {
             primal_infeasibility = primal_infeasibility.max((prob.lb_of(i) - self.x[i]).max(0.0));
             primal_infeasibility = primal_infeasibility.max((self.x[i] - prob.ub_of(i)).max(0.0));
         }
 
-        // Complementarity.
-        let mut complementarity = 0.0_f64;
-        for ((&zi, &hi), &gxi) in self.z.iter().zip(&prob.h).zip(&gx) {
-            complementarity = complementarity.max((zi * (hi - gxi)).abs());
-        }
         for i in 0..n {
             let (lb, ub) = (prob.lb_of(i), prob.ub_of(i));
             if lb > -1e19 {
@@ -553,5 +646,91 @@ mod residual_tests {
         );
         // Genuine breakdown with a large residual: still a hard failure.
         assert_eq!(breakdown_status(false), QpStatus::NumericalFailure);
+    }
+}
+
+#[cfg(test)]
+mod conic_residual_tests {
+    use super::*;
+    use crate::ipm::{QpOptions, solve_socp_ipm};
+    use pounce_feral::FeralSolverInterface;
+    use pounce_linsol::SparseSymLinearSolverInterface;
+
+    fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+        Box::new(FeralSolverInterface::new())
+    }
+
+    /// pounce#209: the residuals of a *conic* solve must be measured with the
+    /// solve's own cones. `min x₀ s.t. ‖x‖ ≤ 1` in SOC form
+    /// (`s = (1, x₀, x₁) ∈ K_soc`) has the optimum `x = (−1, 0)`, at which the
+    /// cone is satisfied exactly — but its second SOC row reads `Gx = 1 > h = 0`
+    /// and its rows are individually non-complementary. The orthant-only
+    /// [`QpSolution::kkt_residuals`] therefore reports a large violation for a
+    /// perfectly feasible point, which is what leaked into the CLI's
+    /// end-of-run summary and made a solved QCQP look infeasible.
+    #[test]
+    fn conic_residuals_vanish_where_orthant_residuals_do_not() {
+        // Rows of `s = h − Gx`: s₀ = 1 (the radius), s₁ = x₀, s₂ = x₁.
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![],
+            c: vec![1.0, 0.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(1, 0, -1.0), Triplet::new(2, 1, -1.0)],
+            h: vec![1.0, 0.0, 0.0],
+            lb: vec![-5.0, -5.0],
+            ub: vec![5.0, 5.0],
+        };
+        let cones = [ConeSpec::SecondOrder(3)];
+        let sol = solve_socp_ipm(&prob, &cones, &QpOptions::default(), backend);
+        assert!(
+            (sol.x[0] - -1.0).abs() < 1e-6 && sol.x[1].abs() < 1e-6,
+            "expected the optimum (−1, 0), got {:?}",
+            sol.x
+        );
+
+        let conic = sol.kkt_residuals_conic(&prob, &cones);
+        assert!(
+            conic.kkt_error() < 1e-6,
+            "cone-aware residuals must vanish at the optimum: {conic:?}"
+        );
+
+        // The orthant reading of the same point is badly wrong — `s₁ = x₀ = −1`
+        // looks like a violation of ~1 even though `s` is squarely in the cone.
+        // (Pinned so the two measures cannot silently converge and make the
+        // test above vacuous.)
+        let orthant = sol.kkt_residuals(&prob);
+        assert!(
+            orthant.primal_infeasibility > 0.5,
+            "the orthant metric should misread this feasible point (that is the \
+             bug); got {orthant:?}"
+        );
+    }
+
+    /// The trailing rows a cone list does not cover fall back to the orthant, so
+    /// a plain QP's residuals are identical whether or not a (nonneg) cone list
+    /// is supplied. Guards the shared implementation against drift.
+    #[test]
+    fn conic_residuals_match_orthant_on_a_cone_free_qp() {
+        // min ½(x₀² + x₁²) − x₀ s.t. x₀ + x₁ ≤ 1, 0 ≤ x ≤ 2.
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+            c: vec![-1.0, 0.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            h: vec![1.0],
+            lb: vec![0.0, 0.0],
+            ub: vec![2.0, 2.0],
+        };
+        let cones = [ConeSpec::Nonneg(1)];
+        let sol = solve_socp_ipm(&prob, &cones, &QpOptions::default(), backend);
+        let orthant = sol.kkt_residuals(&prob);
+        let conic = sol.kkt_residuals_conic(&prob, &cones);
+        assert_eq!(orthant, conic, "orthant rows must measure identically");
+        // And with no cone list at all: every row is orthant by default.
+        assert_eq!(orthant, sol.kkt_residuals_conic(&prob, &[]));
     }
 }

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -194,26 +194,28 @@ fn status_str(s: QpStatus) -> &'static str {
 /// Build the Python result dict `{x, y, z, z_lb, z_ub, obj, iters, status,
 /// iterates, residuals}` from a `QpSolution`.
 ///
-/// When `prob` is `Some`, the final KKT `residuals` block is attached — but
-/// only for the plain-QP path, where `Gx ≤ h` is an orthant constraint and
-/// [`QpSolution::kkt_residuals`] applies. Conic (SOCP/exp/power) solves pass
-/// `None`: there the slack lives in a non-orthant cone, so those orthant
-/// residuals would be meaningless. The `iterates` trace is always attached
+/// When `prob` is `Some`, the final KKT `residuals` block is attached, measured
+/// against `cones` when the solve had any: `Gx ≤ h` is an orthant constraint
+/// only on the plain-QP path, so a conic solve needs
+/// [`QpSolution::kkt_residuals_conic`] (an orthant reading of a second-order
+/// block is meaningless — pounce#209). Conic solves used to pass `None` here
+/// and report no residuals at all. The `iterates` trace is always attached
 /// (empty unless `collect_iterates` was set, so there is no overhead off the
 /// opt-in path).
 fn solution_dict<'py>(
     py: Python<'py>,
     sol: QpSolution,
     prob: Option<&QpProblem>,
+    cones: &[ConeSpec],
 ) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new_bound(py);
     d.set_item("status", status_str(sol.status))?;
     d.set_item("obj", sol.obj)?;
     d.set_item("iters", sol.iters)?;
 
-    // Final KKT residuals (plain QP only — see the doc comment).
+    // Final KKT residuals (see the doc comment).
     if let Some(p) = prob {
-        let r = sol.kkt_residuals(p);
+        let r = sol.kkt_residuals_conic(p, cones);
         let rd = PyDict::new_bound(py);
         rd.set_item("primal_infeasibility", r.primal_infeasibility)?;
         rd.set_item("dual_infeasibility", r.dual_infeasibility)?;
@@ -330,7 +332,7 @@ pub fn solve_qp<'py>(
         Some(w) => solve_qp_ipm_warm(&prob.inner, &o, w, backend),
         None => solve_qp_ipm(&prob.inner, &o, backend),
     });
-    solution_dict(py, sol, Some(&prob.inner))
+    solution_dict(py, sol, Some(&prob.inner), &[])
 }
 
 /// Solve a standard-form conic program (LP/QP plus second-order, exponential,
@@ -383,7 +385,7 @@ pub fn solve_socp<'py>(
     }
     let sol = py.allow_threads(|| solve_socp_ipm(&prob.inner, &specs, &o, backend));
     // Conic slack lives in a non-orthant cone: skip the orthant residuals.
-    solution_dict(py, sol, None)
+    solution_dict(py, sol, Some(&prob.inner), &specs)
 }
 
 /// Solve a batch of convex QPs in parallel (across instances). Returns a
@@ -423,7 +425,7 @@ pub fn solve_qp_batch<'py>(
     });
     sols.into_iter()
         .zip(inners.iter())
-        .map(|(s, p)| solution_dict(py, s, Some(p)))
+        .map(|(s, p)| solution_dict(py, s, Some(p), &[]))
         .collect()
 }
 
@@ -460,7 +462,7 @@ pub fn solve_qp_multi_rhs<'py>(
         .map(|(s, c)| {
             let mut prob = base_inner.clone();
             prob.c = c.clone();
-            solution_dict(py, s, Some(&prob))
+            solution_dict(py, s, Some(&prob), &[])
         })
         .collect()
 }
@@ -521,7 +523,7 @@ impl PyQpFactorization {
                 None => inner.solve(qp),
             }
         });
-        solution_dict(py, sol, Some(&prob.inner))
+        solution_dict(py, sol, Some(&prob.inner), &[])
     }
 }
 

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -114,9 +114,10 @@ class QpResult:
         Final KKT residuals as a dict with keys
         ``primal_infeasibility``, ``dual_infeasibility``,
         ``complementarity``, and ``kkt_error`` (the max of the three).
-        ``None`` for conic (:func:`solve_socp`) solves, where the slack
-        lives in a non-orthant cone and these orthant residuals do not
-        apply.
+        For a conic (:func:`solve_socp`) solve these are measured against
+        the solve's own cones — cone-membership violation for the primal
+        residual and the per-block inner product for complementarity —
+        not the orthant's per-row test, which is meaningless there.
     iterates:
         Per-iteration convergence trace — a list of dicts with keys
         ``iter``, ``objective``, ``primal_infeasibility``,
@@ -141,7 +142,7 @@ class QpResult:
 
     @property
     def kkt_error(self) -> Optional[float]:
-        """Overall KKT error (max residual), or ``None`` for conic solves."""
+        """Overall KKT error (the max residual), or ``None`` if unavailable."""
         return None if self.residuals is None else self.residuals["kkt_error"]
 
 

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -82,14 +82,27 @@ def test_iterate_trace_is_opt_in():
     assert traced.iterates[-1]["mu"] < traced.iterates[0]["mu"]
 
 
-def test_conic_solve_has_no_orthant_residuals():
-    # SOCP slack lives in a non-orthant cone: orthant residuals don't apply.
+def test_conic_solve_reports_cone_aware_residuals():
+    # A SOCP slack lives in a non-orthant cone, so its residuals must be
+    # measured against that cone. They used to be omitted entirely (the
+    # orthant reading being meaningless); reporting them is what makes a
+    # conic solve's convergence checkable at all (pounce#209).
     r = solve_socp(
         c=[1.0, 0.0, 0.0], G=-np.eye(3), h=[0.0, -2.0, 1.0], cones=[("soc", 3)]
     )
     assert r.status == "optimal"
-    assert r.residuals is None
-    assert r.kkt_error is None
+    assert r.residuals is not None
+    assert set(r.residuals) == {
+        "primal_infeasibility",
+        "dual_infeasibility",
+        "complementarity",
+        "kkt_error",
+    }
+    # Converged ⇒ every component is at tolerance. In particular the primal
+    # residual measures cone *membership*: an orthant reading of this same
+    # point is nonzero, since the SOC rows individually have `Gx > h`.
+    assert r.kkt_error < 1e-6
+    assert r.residuals["primal_infeasibility"] < 1e-6
 
 
 def test_solve_qp_multi_rhs_host_matches_individual():


### PR DESCRIPTION
Fixes #209.

A feasible convex QCQP routed to the conic path (`solver_selection=socp`, and
`auto` when it sends a QCQP there) converged to the **correct optimum** and then
reported `status=InternalError`, exit **1**, and a KKT summary showing a large
`Constraint violation` for a point that is feasible to machine precision. Any
driver that trusts the exit code or the status — a Pyomo/AMPL wrapper, a CI gate
— read the solve as failed.

| | before | after |
|---|---|---|
| status | `InternalError` | `SolveSucceeded` |
| exit code | 1 | 0 |
| objective error vs oracle | — | 1.2e-12 |
| reported "Overall NLP error" | 8.80 | 2.7e-15 |

## Two independent defects

**1. The summary measured the wrong thing.** It applied the nonnegative
orthant's per-row `Gx <= h` test to second-order cone rows. A *converged* SOC
block routinely has individual rows with `Gx > h` (only the cone membership
`s0 >= ||s1||` must hold) and non-complementary rows (only the block product
`<s, z>` vanishes). This is exactly the closed form the reporter derived — the
number tracked the most-negative decision variable and never touched the
quadratic constraint.

Adds `QpSolution::kkt_residuals_conic`, which measures each block with its own
cone (orthant / SOC / PSD / exp / power), and uses it on the SOCP path.

**2. The convergence test was blocked by bookkeeping.** The conic driver's test
reads the *homogeneous* residuals, which carry the internal slack's consistency
`Gx + s - h*tau` alongside the real KKT quantities. That term is bookkeeping —
`s` is never returned — and it floors out once `mu` reaches ~1e-16 and the
Nesterov–Todd scaling's condition number explodes. Per-iteration trace on the
reported QCQP:

```
it=13 pres=1.016e-8  dres=2.545e-9   gap=9.088e-8
it=16 pres=1.205e-6  dres=8.315e-12  gap=2.707e-10
it=19 pres=1.650e-4  dres=4.860e-13  gap=8.887e-13   <-- pres drifting UP
it=22 pres=2.137e-5  dres=1.268e-15  gap=1.105e-15   <-- breakdown
```

`dres` and `gap` converge to 1e-15; `pres` bottoms at 1e-8 and wanders back up.
The solve ground on to a factorization breakdown while the iterate itself was
accurate to **1e-14**.

A solve that ends without a verdict of its own (breakdown or iteration limit)
now takes one from the **true KKT error of the point it returns** — cone
feasibility, stationarity, complementarity, and `z` in `K*`, on the
un-homogenized iterate. Below `tol` that is `Optimal`; within `~1e3*tol`,
`OptimalInaccurate`; beyond it the original verdict stands. Strictly an upgrade,
never a downgrade.

## One design decision worth review

I first put the certificate check *inside* the loop as an early exit. It worked
and cut iterations 22 to 14 — but it broke
`test_qcqp_with_linear_and_quadratic_constraints`, landing `x0` at 9.7e-5
instead of 1.6e-8. That failure was real, not a stale test: at that tangency
(`min -x1 s.t. ||x|| <= 1, x0 >= 0`) the map from KKT residual to x-error is a
square root, so a residual at `tol` genuinely leaves `x0` off by ~1e-4.

Rather than relax the assertion I moved the check after the loop. **Iterates and
iteration counts are now unchanged** — only the verdict and exit code differ.
The cost is that the repro still burns 8 iterations grinding to a breakdown it
then recovers from; that is a performance nit, not correctness, and preserving
every existing trajectory seemed worth more. Happy to revisit if you'd rather
have the early exit and adjust that test.

## Ruled out

The issue suggests the QCQP-to-SOC *reformulation* is at fault, since
`solve_socp` with explicit cones reportedly returns `optimal`. It isn't: I built
both the natural `||x-c|| <= R` encoding and the CLI's lifted
`(s+1, s-1, sqrt2*Fx)` encoding of the same problem and drove them through
`solve_socp` directly. Both stall identically. The `optimal` results in the
issue were on easier SOCPs.

## Also fixed

`pounce.solve_socp` previously returned `residuals=None` / `kkt_error=None`
because only the orthant measure existed (the "weaker signal" in the follow-up
comment). It now reports the cone-aware residuals, so a conic solve's
convergence is checkable from Python.

## Verification

- Issue's 4-var repro: `Optimal`, exit 0, objective matches the SLSQP/clarabel
  oracle to 1.2e-12.
- Follow-up's 2-var repro: `Optimal`, exit 0, obj -10.000000000000028 (3e-14).
- Corroboration case that printed `Constraint violation = 2.0` for a feasible
  point: now 0.
- `socp`, `auto`, and `nlp` agree on all three.
- **1946 Rust + 593 Python tests pass, with no test relaxations.** The only test
  changed is the one that pinned the old `residuals is None` behavior, which
  this makes obsolete.
- New regression tests (3 CLI end-to-end + 2 unit) confirmed failing on the
  pre-fix tree.
- CI clippy gate, `cargo fmt --check`, and `check-release-consistency.sh` clean.

I did not test the 3-var repro from the follow-up comment — its data was
truncated in what I could fetch — but it is the same class and code path as the
two that are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
