### PR TITLE
minimize: validate solver_selection instead of silently dropping it (#213)

### DIFF
--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -365,6 +365,20 @@ choice — mirroring the CLI option of the same name:
 | `"lp-ipm"` | Force the convex solver; raise `ValueError` if the problem is not detected as an LP. |
 | `"qp-ipm"` | Force the convex solver; raise `ValueError` if it is not detected as a convex LP/QP. |
 | `"socp"` | Force the conic solver; raise `ValueError` if it is not detected as a convex QCQP. |
+| `"qp-active-set"` | Run the active-set SQP engine instead of the filter-IPM. Equivalent to `algorithm="active-set-sqp"`. |
+
+Any other value raises `ValueError`. These are the same six selectors the CLI
+accepts, and matching is case-insensitive, as on the CLI.
+
+Two differences from the CLI are worth knowing, both because `minimize` is a
+*library* consumer with no `.nl` file to classify:
+
+* `"qp-active-set"` is **not** class-validated here. The CLI restricts it to
+  LP/convex QP; the library path simply runs the SQP engine on whatever problem
+  it is given, since it has no extracted problem class to check against.
+* The convex selectors (`"lp-ipm"`, `"qp-ipm"`, `"socp"`) work because
+  `minimize` does its own Python-side structure detection. The equivalent Rust
+  library API rejects them with `Invalid_Option`.
 
 ```python
 # Default: the general NLP solver, no probing.

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -128,6 +128,21 @@ _QP_STATUS_MESSAGE = {
 # (``jax/_path.py`` / ``torch/_path.py`` ``_OK_STATUS``). Excluding it (gh #119)
 # made HS071 and similar problems report ``success=False`` at a verified
 # optimum. Codes 2..6 (infeasible, tiny step, diverging, …) stay failures.
+# The `solver_selection` values the Rust option registry accepts
+# (`upstream_options.rs`, `add_string_option("solver_selection", ...)`). Kept in
+# sync by `test_solver_selection_values_match_rust`, which parses that file --
+# a hardcoded list here would drift the moment a selector is added.
+#
+# Behaviour differs by surface, and `pounce.minimize` is a *library* consumer
+# (no `.nl` problem-structure extraction), so the split is:
+#   auto / lp-ipm / qp-ipm / socp  -- handled here by Python-side extraction
+#   nlp                            -- the default; straight to the NLP backend
+#   qp-active-set                  -- forwarded to the backend, which selects the
+#                                     active-set SQP engine
+_SOLVER_SELECTION_VALUES = frozenset(
+    {"auto", "nlp", "lp-ipm", "qp-ipm", "qp-active-set", "socp"}
+)
+
 _NLP_SUCCESS_STATUS = frozenset({0, 1})
 
 # Statuses for which the KKT-error fallback below must NOT upgrade the solve to
@@ -974,6 +989,18 @@ def minimize(
     # so the remainder of `options` flows to the NLP backend. The default is
     # `"nlp"` (no probe) — opt in to `"auto"` to enable structure detection.
     selection = str(options.pop("solver_selection", "nlp")).lower()
+    # Validate against the registry rather than letting an unrecognized value
+    # fall through to the NLP path. Silently substituting a different engine
+    # than the caller named is the worst failure mode here: it still returns a
+    # correct answer on easy problems, so a typo (`qp_ipm`) or a selector this
+    # facade does not implement is invisible until someone benchmarks or ships
+    # the wrong solver. The CLI rejects these with OPTION_INVALID; match it.
+    # (gh #213)
+    if selection not in _SOLVER_SELECTION_VALUES:
+        raise ValueError(
+            f"solver_selection={selection!r} is not a valid selector; "
+            f"expected one of {sorted(_SOLVER_SELECTION_VALUES)}"
+        )
     route_tol = float(options.pop("route_tol", 1e-5))
     if warm_start is not None and selection != "nlp":
         warnings.warn(
@@ -982,6 +1009,13 @@ def minimize(
             stacklevel=2,
         )
         selection = "nlp"
+    if selection == "qp-active-set":
+        # Not a Python-side route: hand it back to the backend, whose
+        # `is_sqp_algorithm_selected` treats it as equivalent to
+        # `algorithm=active-set-sqp`. Note the library path does *not*
+        # class-validate this selector (the CLI restricts it to LP/convex QP);
+        # it simply runs the SQP engine on whatever problem it is given.
+        options["solver_selection"] = "qp-active-set"
     # scipy.optimize.minimize is silent unless `disp=True`; match that. pounce's
     # NLP backend otherwise prints a full IPM iteration table by default (and
     # the log is written from Rust to fd 1, so Python stdout redirection can't

--- a/python/tests/test_minimize_autoroute.py
+++ b/python/tests/test_minimize_autoroute.py
@@ -271,3 +271,93 @@ def test_unbounded_lp_reports_unbounded_not_iteration_limit():
     assert "unbounded" in res.message.lower()    # distinct, not "max iterations"
     # Raw HSDE certificate still available for programmatic callers.
     assert res.info["status"] == "dual_infeasible"
+
+
+# --- gh #213: solver_selection must be validated, not silently dropped -------
+
+def _qp_problem():
+    """min ½xᵀPx + cᵀx  s.t.  x0 + x1 >= 1  — a convex QP with an active
+    constraint at the optimum, so the SQP and IPM engines take visibly
+    different iteration counts."""
+    P = np.array([[2.0, 0.0], [0.0, 2.0]])
+    c = np.array([-2.0, -2.0])
+    con = [{"type": "ineq",
+            "fun": lambda x: 1.0 - (x[0] + x[1]),
+            "jac": lambda x: np.array([-1.0, -1.0])}]
+    return (lambda x: 0.5 * x @ P @ x + c @ x,
+            lambda x: P @ x + c,
+            con)
+
+
+@pytest.mark.parametrize("bad", ["qp_ipm", "totally-bogus-solver", "", "QP_IPM"])
+def test_invalid_solver_selection_raises(bad):
+    """An unrecognized selector must raise, not fall through to the NLP path.
+
+    This is the gh #213 defect. Silent fallback is the dangerous failure mode
+    precisely because it still returns a *correct* answer on easy problems: a
+    typo (`qp_ipm` for `qp-ipm`) benchmarks or ships an engine the caller never
+    asked for, with nothing in the result to reveal it.
+    """
+    fun, jac, con = _qp_problem()
+    with pytest.raises(ValueError, match="not a valid selector"):
+        minimize(fun, np.zeros(2), jac=jac, constraints=con,
+                 options={"solver_selection": bad})
+
+
+def test_qp_active_set_reaches_the_sqp_engine():
+    """`qp-active-set` is a valid CLI/library selector and must actually
+    dispatch, not be swallowed.
+
+    Before the fix it was indistinguishable from a bogus value: both fell
+    through to the filter-IPM. The backend treats it as equivalent to
+    `algorithm=active-set-sqp`, so pinning it against that spelling proves the
+    option reached the Rust side rather than merely being accepted by Python.
+    """
+    fun, jac, con = _qp_problem()
+    kw = dict(jac=jac, constraints=con)
+
+    sel = minimize(fun, np.zeros(2), options={"solver_selection": "qp-active-set"}, **kw)
+    algo = minimize(fun, np.zeros(2), options={"algorithm": "active-set-sqp"}, **kw)
+    nlp = minimize(fun, np.zeros(2), options={"solver_selection": "nlp"}, **kw)
+
+    assert sel.nit == algo.nit, "qp-active-set must select the same engine as algorithm=active-set-sqp"
+    assert np.allclose(sel.x, algo.x)
+    assert sel.nit != nlp.nit, "qp-active-set must be distinguishable from the NLP path"
+    assert np.allclose(sel.x, nlp.x, atol=1e-6), "both engines must still solve it"
+
+
+def test_solver_selection_is_case_insensitive():
+    """The Rust side compares with `eq_ignore_ascii_case`; match it, so a
+    selector that works on the CLI is not rejected here on casing alone."""
+    fun, jac, con = _qp_problem()
+    res = minimize(fun, np.zeros(2), jac=jac, constraints=con,
+                   options={"solver_selection": "QP-Active-Set"})
+    assert res.success
+
+
+def test_solver_selection_values_match_rust():
+    """Drift guard: the Python whitelist must equal the Rust registry.
+
+    A hardcoded list would silently diverge the moment a selector is added on
+    the Rust side — and the failure would be exactly the bug this test suite
+    exists to prevent, a valid selector rejected (or a dropped one accepted) by
+    the facade alone. Parse the registration instead.
+    """
+    import re
+    from pathlib import Path
+
+    from pounce._minimize import _SOLVER_SELECTION_VALUES
+
+    src = (Path(__file__).resolve().parents[2]
+           / "crates/pounce-algorithm/src/upstream_options.rs").read_text()
+    block = re.search(
+        r'add_string_option\(\s*"solver_selection".*?\n        \],', src, re.S
+    )
+    assert block, "could not locate the solver_selection registration in Rust"
+    rust_values = set(re.findall(r'^\s*\(\s*\n?\s*"([a-z-]+)",', block.group(0), re.M))
+
+    assert rust_values, "parsed no values; the registration format changed"
+    assert rust_values == set(_SOLVER_SELECTION_VALUES), (
+        f"Python whitelist {sorted(_SOLVER_SELECTION_VALUES)} != "
+        f"Rust registry {sorted(rust_values)}"
+    )


### PR DESCRIPTION
Fixes #213.

## The defect

`pounce.minimize` accepted **any** string for `solver_selection` and silently ignored unrecognized values, falling through to the NLP path with no error and no warning — while the CLI rejects the identical value with `OPTION_INVALID`.

Reproduced at HEAD exactly as reported: `nlp`, `qp-active-set`, `qp_ipm`, and `totally-bogus-solver` all gave byte-identical solves (`nit=5`, `f=-1.500000007`, zero warnings).

Silent fallback is the dangerous failure mode precisely because it still returns a *correct* answer on easy problems, so the mistake is invisible.

## Two things were wrong, not one

**1. No validation.** The selector is now checked against the six values the Rust registry accepts (`upstream_options.rs`) and an unrecognized one raises `ValueError`, consistent with the existing `lp-ipm`/`qp-ipm`/`socp` class-mismatch errors. Matching is case-insensitive, mirroring `eq_ignore_ascii_case` on the Rust side.

**2. `qp-active-set` was being dropped.** The issue notes this is a valid CLI selector that Python should "either support or reject". It turns out it can be genuinely **supported**: `minimize` is a library consumer, and the backend's `is_sqp_algorithm_selected` already treats `solver_selection=qp-active-set` as equivalent to `algorithm=active-set-sqp`. The facade was popping the key so it never reached Rust. It is now forwarded.

Verified it actually dispatches rather than merely being accepted:

| selector | `nit` | `f` |
|---|---|---|
| `nlp` | 5 | -1.500000007 |
| `qp-active-set` | **2** | **-1.5** |
| `algorithm=active-set-sqp` | 2 | -1.5 |

Before the fix, `qp-active-set` was indistinguishable from `totally-bogus-solver` — which is exactly the case the issue calls out, a user requiring the active-set engine for a working set and silently getting the filter-IPM.

## Drift guard

The whitelist is checked against the Rust registration by parsing `upstream_options.rs`, rather than hardcoding a list. A hardcoded copy would diverge the moment a selector is added — reproducing this same class of bug, where a valid selector is rejected (or a dropped one accepted) by the facade alone.

## Docs

`docs/src/python.md`'s selector table omitted `qp-active-set` entirely, consistent with it having been dropped. Added, along with two library-vs-CLI differences worth stating explicitly:

- `qp-active-set` is **not** class-validated here (the CLI restricts it to LP/convex QP; the library path has no extracted problem class to check against);
- the convex selectors work only because `minimize` does its own Python-side structure detection — the equivalent Rust library API rejects them with `Invalid_Option`.

## Tests

Seven new tests in `test_minimize_autoroute.py`: invalid selectors rejected (parametrized over typo / bogus / empty / wrong-case-with-underscore), `qp-active-set` reaching the SQP engine (pinned against the `algorithm=` spelling, so it proves the option crossed into Rust), case-insensitivity, and the drift guard.

600 Python tests pass, no regressions.

> Note: the pre-existing stale-extension guard fired locally (`_pounce.abi3.so` older than `crates/`). This change is pure Python and touches no Rust source, so tests were run with `POUNCE_SKIP_EXT_STALE_CHECK=1`. CI builds fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCWHfX7icowy2rj7jECnT8
