### PR TITLE
Fix four silent-acceptance defects found by the adversary sweep

### DIFF
--- a/crates/pounce-cli/src/verify.rs
+++ b/crates/pounce-cli/src/verify.rs
@@ -730,16 +730,27 @@ fn receipt_json(args: &VerifyArgs, o: &VerifyOutcome) -> String {
     let worst_con = o.worst_con.as_ref().map(row_json);
     let worst_bound = o.worst_bound.as_ref().map(row_json);
     let optimality = if o.duals_present {
+        // Optimality is a property of a FEASIBLE point, so this must not report
+        // `true` for one that violates the constraints. The stationarity
+        // residual of an infeasible point can be legitimately zero, which
+        // previously surfaced as `optimality.optimal: true` inside a receipt
+        // whose verdict was REJECTED — the top-level fields were correct, but a
+        // consumer reading this nested field alone was told the opposite.
+        // The raw residuals are still reported unconditioned: they are useful
+        // for diagnosing *why* a point failed.
+        let optimal = o.optimal.map(|opt| opt && o.feasible);
         json!({
             "available": true,
             "objective": o.objective,
             "stationarity_residual": o.stationarity,
             "dual_sign": o.dual_sign,
             "complementarity_residual": o.complementarity,
-            "optimal": o.optimal,
+            "optimal": optimal,
             "note": "bound-projected stationarity (dual infeasibility) using the .sol's \
                      constraint duals; bound multipliers inferred from activity. Sign chosen \
-                     to match the supplied dual convention. Feasibility is the rigorous gate."
+                     to match the supplied dual convention. Feasibility is the rigorous gate, \
+                     and `optimal` is reported false for an infeasible point regardless of \
+                     its stationarity residual."
         })
     } else {
         json!({ "available": false })

--- a/crates/pounce-convex/src/sos.rs
+++ b/crates/pounce-convex/src/sos.rs
@@ -495,6 +495,13 @@ pub struct SosSolution {
     /// relaxation is then exact, so `lower_bound` is the global minimum.
     pub is_exact: bool,
     /// Number of global minimizers (the flat moment-matrix rank) when exact.
+    ///
+    /// **May under-report.** When the relaxation is not flat at the analytic
+    /// center, the low-rank re-solve can collapse a multi-atom optimal measure
+    /// onto fewer atoms; the survivors are validated against the certified
+    /// bound (so they are genuine minimizers) but siblings can be missed.
+    /// Himmelblau's function at order 2 reports 1 of its 4. Treat this as a
+    /// lower bound on the number of global minimizers, not a count.
     pub num_minimizers: usize,
     /// The extracted global minimizers (all `num_minimizers` atoms) when the
     /// moment matrix is flat; recovered via the self-adjoint multiplication
@@ -530,7 +537,7 @@ where
         };
     }
 
-    let mut rec = recover_from_moments(prob, &mi, &sol.y);
+    let mut rec = recover_from_moments(prob, &mi, &sol.y, lower_bound / s_obj);
 
     // Facial reduction. The interior-point solver lands on the analytic-center
     // (maximum-rank) optimal moment matrix, which is flat only when the optimum
@@ -545,7 +552,9 @@ where
         let (qp2, cones2, mi2) = build_sos_sdp(prob, order, Some(TRACE_EPS));
         let sol2 = solve_socp_ipm(&qp2, &cones2, &opts, &mut make_backend);
         if sol2.status == QpStatus::Optimal {
-            let rec2 = recover_from_moments(prob, &mi2, &sol2.y);
+            // Validate the re-solve's atoms against the UNPERTURBED bound: the
+            // trace penalty changes the moment matrix, not the value being certified.
+            let rec2 = recover_from_moments(prob, &mi2, &sol2.y, lower_bound / s_obj);
             if rec2.is_exact {
                 rec = rec2;
             }
@@ -581,7 +590,15 @@ struct Recovery {
 /// `M_d` can yield atoms outside `K` (M21). We therefore validate the extracted
 /// atoms against `prob`'s constraints and withdraw the exactness certificate if
 /// any atom is infeasible — `lower_bound` remains a valid lower bound.
-fn recover_from_moments(prob: &PolyProblem, mi: &MomentInfo, y: &[f64]) -> Recovery {
+fn recover_from_moments(
+    prob: &PolyProblem,
+    mi: &MomentInfo,
+    y: &[f64],
+    // `bound_scaled` is the certified bound in the EQUILIBRATED space: `prob`
+    // here is the scaled problem, so the user-units bound must be divided by
+    // `s_obj` before it can be compared against `prob.objective.eval`.
+    bound_scaled: f64,
+) -> Recovery {
     let moment = |alpha: &[usize]| -> f64 { y[mi.row_of[alpha]] };
     let zero = vec![0usize; mi.n_vars];
     let sign = if moment(&zero) < 0.0 { -1.0 } else { 1.0 };
@@ -635,7 +652,36 @@ fn recover_from_moments(prob: &PolyProblem, mi: &MomentInfo, y: &[f64]) -> Recov
     let atoms_feasible = (mi.d >= 1)
         && !minimizers.is_empty()
         && minimizers.iter().all(|x| prob.is_feasible(x, FEAS_TOL));
-    let is_exact = is_exact && (minimizers.is_empty() || atoms_feasible);
+    let mut is_exact = is_exact && (minimizers.is_empty() || atoms_feasible);
+
+    // Atom-objective guard. Feasibility is not enough: an extracted atom must
+    // also *attain* the certified bound, i.e. `p(atom) ≈ γ*`. When it does not,
+    // the moment matrix we read is not the optimal measure and the exactness
+    // certificate is unsound.
+    //
+    // This is not hypothetical. The low-rank (min-trace) re-solve above exists
+    // to collapse rank inflated by spurious pseudo-moments, but it selects the
+    // *lowest-rank* near-optimal moment matrix — and when the true optimal
+    // measure has several atoms, a rank-1 matrix concentrated on a single
+    // non-minimizing point can be near-optimal too. The relaxation then reports
+    // `is_exact = true` with `num_minimizers = 1` and hands back the measure's
+    // mean rather than a minimizer. Himmelblau's function (four global
+    // minimizers) is the reference case: it returned one "minimizer" whose
+    // objective drifted from 4e-2 to 3e+1 as the order rose, while the bound
+    // stayed correct at ~0.
+    //
+    // The bound is a valid lower bound regardless, so withdrawing exactness
+    // costs nothing that was sound to begin with.
+    if is_exact && !minimizers.is_empty() {
+        let attains = minimizers.iter().all(|x| {
+            let mag = prob.objective.eval_magnitude(x).max(1.0);
+            (prob.objective.eval(x) - bound_scaled).abs() <= ATOM_OBJ_TOL * mag
+        });
+        if !attains {
+            is_exact = false;
+        }
+    }
+
     if !is_exact {
         minimizers.clear();
     }
@@ -783,6 +829,18 @@ fn extract_atoms(mi: &MomentInfo, r: usize, moment: impl Fn(&[usize]) -> f64) ->
 /// only within the plausible band `(1e-9, 1e-2)·λ_max` — above the band an
 /// eigenvalue is certainly real, below it is certainly numerical zero. With no
 /// gap in the band the matrix is effectively full rank over that band.
+/// Tolerance for the atom-objective guard, relative to the objective's
+/// magnitude at the atom (`eval_magnitude`, the cancellation scale — a bare
+/// absolute test is meaningless for a polynomial whose terms cancel to ~0).
+///
+/// Chosen from measurement, not taste. Across every extraction-exercising test
+/// the relative residual of a genuine minimizer is `4e-10 … 2e-8`, with one
+/// outlier at `2.5e-5` (`goldstein_price_wide_coefficient_range`, whose
+/// coefficients span 144..23616 — gh #124 conditioning, still a correct
+/// recovery). Non-minimizing atoms measured `7.6e-3` and `7.3e-2`. `1e-3` sits
+/// ~40x above the worst legitimate case and ~7x below the worst bogus one.
+const ATOM_OBJ_TOL: f64 = 1e-3;
+
 fn psd_rank(mat: &[f64], n: usize) -> usize {
     if n == 0 {
         return 0;
@@ -831,6 +889,87 @@ mod tests {
 
     fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
         Box::new(FeralSolverInterface::new())
+    }
+
+    #[test]
+    fn himmelblau_never_returns_a_non_minimizing_atom() {
+        // Himmelblau's function: f = (x²+y−11)² + (x+y²−7)², four global
+        // minimizers with f* = 0. The moment relaxation is not flat at the
+        // analytic center here, so the low-rank re-solve collapses it to rank 1
+        // — and the resulting single "minimizer" drifted further from a true one
+        // as the order ROSE: f(atom) = 4e-2, 4.2, then 30. `is_exact` was true
+        // throughout, so a caller reading `minimizers[0]` got a non-minimizer
+        // with no signal. The bound stayed correct (~0) the whole time.
+        //
+        // The guarantee asserted here is the one that matters: whatever comes
+        // back is validated against the certified bound, so a reported
+        // minimizer really is one. Under-reporting the COUNT is a known
+        // remaining limitation (see `SosSolution::num_minimizers`).
+        let p = Polynomial::new(
+            2,
+            vec![
+                (vec![4, 0], 1.0),
+                (vec![0, 4], 1.0),
+                (vec![2, 1], 2.0),
+                (vec![1, 2], 2.0),
+                (vec![2, 0], -21.0),
+                (vec![0, 2], -13.0),
+                (vec![1, 0], -14.0),
+                (vec![0, 1], -22.0),
+                (vec![0, 0], 170.0),
+            ],
+        );
+        let prob = PolyProblem::new(p);
+        let himmelblau = |x: f64, y: f64| (x * x + y - 11.0).powi(2) + (x + y * y - 7.0).powi(2);
+
+        for order in [2usize, 3, 4] {
+            let r = sos_minimize(&prob, Some(order), backend);
+            assert_eq!(r.status, QpStatus::Optimal, "order {order}: {:?}", r.status);
+
+            // The bound stays a valid lower bound at every order — this never
+            // regressed, and the fix must not cost it.
+            assert!(
+                r.lower_bound <= 1e-4,
+                "order {order}: bound {} exceeds the true global minimum of 0",
+                r.lower_bound
+            );
+
+            // Every returned minimizer must be near a TRUE one. Distance is the
+            // meaningful test rather than f alone: Himmelblau is steep near its
+            // minima, so a legitimately approximate atom at a low relaxation
+            // order still carries a visible objective value (order 2 lands
+            // 0.033 away, f = 4e-2). The failure being guarded against is not
+            // imprecision but a point that is nowhere near any minimizer —
+            // orders 3 and 4 previously returned atoms 1.0 and 2.0 away.
+            const TRUE_MINIMIZERS: [(f64, f64); 4] = [
+                (3.0, 2.0),
+                (-2.805118, 3.131312),
+                (-3.779310, -3.283186),
+                (3.584428, -1.848126),
+            ];
+            for m in &r.minimizers {
+                let nearest = TRUE_MINIMIZERS
+                    .iter()
+                    .map(|(a, b)| ((m[0] - a).powi(2) + (m[1] - b).powi(2)).sqrt())
+                    .fold(f64::INFINITY, f64::min);
+                assert!(
+                    nearest < 0.1,
+                    "order {order}: reported minimizer ({}, {}) is {nearest:.3} from the \
+                     nearest true minimizer (f = {:.3e})",
+                    m[0],
+                    m[1],
+                    himmelblau(m[0], m[1])
+                );
+            }
+            // And exactness must not be claimed with an unvalidated set.
+            if r.is_exact {
+                assert_eq!(
+                    r.num_minimizers,
+                    r.minimizers.len(),
+                    "order {order}: num_minimizers disagrees with the returned atoms"
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/pounce-studio-core/src/analysis.rs
+++ b/crates/pounce-studio-core/src/analysis.rs
@@ -123,11 +123,26 @@ pub fn find_stalls(report: &SolveReport) -> Vec<Stall> {
     find_stalls_with(report, 5, 0.3)
 }
 
+/// Smallest meaningful stall window.
+///
+/// A stall is lack of progress *between* iterations, so it takes at least two
+/// of them to observe one. With `min_window <= 1` the window test
+/// `j - i + 1 >= min_window` is trivially true and every single iterate is
+/// reported as a stall — on a healthy monotone solve that means every
+/// iteration, each as a degenerate `start_iter == end_iter` window with
+/// `delta_log10 == 0`. Callers must reject smaller values at their boundary;
+/// see `MIN_STALL_WINDOW` uses in the pyo3 and CLI front ends.
+pub const MIN_STALL_WINDOW: usize = 2;
+
+/// `min_window` below [`MIN_STALL_WINDOW`] is meaningless; it is raised to it
+/// rather than producing degenerate single-iterate windows. Front ends reject
+/// such values outright, so this is a backstop for other Rust callers.
 pub fn find_stalls_with(
     report: &SolveReport,
     min_window: usize,
     max_log10_progress: f64,
 ) -> Vec<Stall> {
+    let min_window = min_window.max(MIN_STALL_WINDOW);
     let mut out = Vec::new();
     for (metric, series) in [
         ("inf_pr", series_log10(&report.iterations, |r| r.inf_pr)),
@@ -597,5 +612,38 @@ mod tests {
             !codes.contains(&"convergence_stall"),
             "stall shouldn't trip on healthy convergence: {codes:?}",
         );
+    }
+
+    #[test]
+    fn degenerate_min_window_cannot_report_single_iterate_stalls() {
+        // gh: an adversary probe passed `min_window = 0` to a monotonically
+        // converging solve with no stalls and got back one "stall" per
+        // iteration, 18 of 20 with `start_iter == end_iter` and
+        // `delta_log10 == 0`. A stall is an absence of progress BETWEEN
+        // iterations, so a single iterate cannot be one; the window test
+        // `j - i + 1 >= min_window` is just trivially true below 2.
+        //
+        // Front ends now reject `min_window < 2` outright. This asserts the
+        // core's backstop for other Rust callers: it must never manufacture a
+        // degenerate window, whatever it is handed.
+        let iters: Vec<IterRecord> = (0..8)
+            .map(|i| iter(i, 10f64.powi(-(i + 1)), 10f64.powi(-i)))
+            .collect();
+        let report = report_with(iters);
+
+        for bad in [0usize, 1] {
+            let windows = find_stalls_with(&report, bad, 0.3);
+            assert!(
+                windows.iter().all(|w| w.end_iter > w.start_iter),
+                "min_window={bad} produced a degenerate single-iterate window: {windows:?}"
+            );
+            assert_eq!(
+                windows,
+                find_stalls_with(&report, MIN_STALL_WINDOW, 0.3),
+                "min_window={bad} must behave as MIN_STALL_WINDOW, not as its literal value"
+            );
+        }
+        // A healthy monotone solve still reports nothing at the default.
+        assert!(find_stalls(&report).is_empty());
     }
 }

--- a/crates/pounce-studio-core/src/bin/pounce_studio.rs
+++ b/crates/pounce-studio-core/src/bin/pounce_studio.rs
@@ -249,6 +249,13 @@ fn cmd_find_stalls(args: &[String]) -> Result<(), CliError> {
         .transpose()
         .map_err(|e| CliError::Usage(format!("--min-window: {e}")))?
         .unwrap_or(5);
+    if min_window < analysis::MIN_STALL_WINDOW {
+        return Err(CliError::Usage(format!(
+            "--min-window must be >= {} (a stall spans at least two consecutive \
+             iterations); got {min_window}",
+            analysis::MIN_STALL_WINDOW
+        )));
+    }
     let max_progress = take_flag(&mut args, "--max-progress")?
         .map(|s| s.parse::<f64>())
         .transpose()

--- a/crates/pounce-studio-pyo3/src/lib.rs
+++ b/crates/pounce-studio-pyo3/src/lib.rs
@@ -130,6 +130,17 @@ impl PyReport {
         // mirror `core::find_stalls`. Not memoised because results are
         // parameter-dependent.
         let min_window = min_window.unwrap_or(5);
+        // Reject rather than clamp: a stall spans consecutive iterations, so
+        // `min_window < 2` is not a smaller request but an ill-posed one, and
+        // silently honouring it reports every iteration of a healthy solve as
+        // a stall.
+        if min_window < core::analysis::MIN_STALL_WINDOW {
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "min_window must be >= {} (a stall spans at least two \
+                 consecutive iterations); got {min_window}",
+                core::analysis::MIN_STALL_WINDOW
+            )));
+        }
         let max_log10_progress = max_log10_progress.unwrap_or(0.3);
         json_or_err(core::analysis::find_stalls_with(
             &self.inner,

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -967,6 +967,15 @@ def minimize(
     # signature, as scipy's ``_custom`` dispatch sends them). Explicit kwargs
     # win over the legacy dict if both are supplied.
     legacy_options = options.pop("options", None)
+    if legacy_options is not None and not isinstance(legacy_options, Mapping):
+        # Silently discarding it would drop EVERY option the caller passed --
+        # tolerances, iteration limits, solver_selection -- and still return a
+        # plausible answer from the defaults. That is the gh #213 failure mode
+        # one level up: the mistake is invisible because the solve succeeds.
+        raise TypeError(
+            f"options= must be a mapping, got {type(legacy_options).__name__}; "
+            "all options would otherwise be silently ignored"
+        )
     if isinstance(legacy_options, Mapping):
         options = {**dict(legacy_options), **options}
 

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1288,3 +1288,26 @@ def test_user_requested_stop_is_not_success_despite_small_kkt(monkeypatch):
     )
     assert res2.status == 3
     assert res2.success is True, "an acceptable-KKT numerical stall stays a success"
+
+
+def test_non_mapping_options_is_rejected_not_silently_dropped():
+    """A non-Mapping ``options=`` must raise, not be discarded.
+
+    Found by an adversary probe following gh #213. ``options=`` was popped and
+    merged only when it was a ``Mapping``; anything else fell through and the
+    solve ran on defaults. That drops *every* option the caller passed --
+    tolerances, iteration limits, ``solver_selection`` -- and still returns a
+    plausible answer, so the mistake is invisible. Same failure mode as #213,
+    one level up.
+    """
+    import pounce._minimize as M
+
+    fun = lambda x: float(x @ x)
+    jac = lambda x: 2.0 * x
+    for bad in ([("tol", 1e-9)], ("tol", 1e-9), "tol=1e-9", 42):
+        with pytest.raises(TypeError, match="must be a mapping"):
+            M.minimize(fun, np.ones(2), jac=jac, options=bad)
+
+    # The supported forms are untouched.
+    assert M.minimize(fun, np.ones(2), jac=jac, options={"tol": 1e-9}).success
+    assert M.minimize(fun, np.ones(2), jac=jac).success


### PR DESCRIPTION
Fixes four defects found by a comprehensive adversary sweep (10 agents, 19 problems across every solver family plus the debugger and certificate pipeline). All four share one shape — **an invalid input or unsound result is accepted silently and a plausible answer comes back**, so the mistake is invisible. Same class as #213.

---

## 1. SOS returned a non-minimizing atom

The serious one.

`sos_minimize` reported `is_exact=true` with `num_minimizers=1` on **Himmelblau's function**, which has four global minimizers — and the single "minimizer" drifted *further* from a true one as the relaxation order rose:

| order | `is_exact` | `num_minimizers` | f(atom) | true min |
|---|---|---|---|---|
| 2 | true | 1 | 4.2e-02 | 0 |
| 3 | true | 1 | 4.2e+00 | 0 |
| 4 | true | 1 | **3.0e+01** | 0 |

The bound stayed correct (~0) throughout, so a caller reading `minimizers[0]` got a wrong point with nothing to signal it. This violates the documented contract in `sos.py` ("all global minimizers are recovered").

### Root cause — not rank detection

The analytic-center solve **correctly** finds rank 4. Instrumenting the spectrum:

```
first solve      1.0  3.4e-1  7.7e-2  2.5e-2  5.6e-9  6.3e-11   -> rank 4  (correct)
facial reduction 1.0  1.1e-6  2.0e-7  7.8e-8  3.8e-9  2.9e-11   -> rank 1  (collapsed)
```

The low-rank (min-trace) re-solve exists to collapse rank inflated by *spurious pseudo-moments*. But it selects the lowest-rank near-optimal moment matrix, and when the true optimal measure has several atoms, a rank-1 matrix concentrated on a single **non-minimizing** point is near-optimal too — and flat, hence "exact".

Note `facial_reduction_four_minimizers_2d_order_three` recovers four minimizers correctly, so multiplicity handling is fine in general; Himmelblau is specific.

### Fix

An **atom-objective guard**, mirroring the existing M21 atom-feasibility guard: an extracted atom must attain the certified bound or exactness is withdrawn. The bound is a valid lower bound regardless, so withdrawing costs nothing that was sound.

Two subtleties that took measurement to get right:

- **The comparison must happen in the equilibrated space.** `prob.objective` is scaled by `s_obj`; `lower_bound` is in user units. Comparing them directly is meaningless — before this was caught, correct instances measured relative residuals of 0.24 and 0.67.
- **The tolerance is relative to `eval_magnitude`**, the cancellation scale. An absolute test says nothing for a polynomial whose terms cancel to ~0.

The `1e-3` threshold is **measured, not guessed**:

| case | relative residual |
|---|---|
| genuine minimizers (7 tests) | 4e-10 … 2e-8 |
| `goldstein_price_wide_coefficient_range` (#124 conditioning, correct) | 2.5e-5 |
| **threshold** | **1e-3** |
| Himmelblau order 3 (bogus) | 7.6e-3 |
| Himmelblau order 4 (bogus) | 7.3e-2 |

~40× headroom above the worst legitimate case, ~7× below the worst bogus one.

### What is NOT fixed

**Undercounting.** At order 2 Himmelblau still reports 1 of 4 — but that atom is a *genuine approximate minimizer* (0.033 from `(3,2)`), so it is incomplete rather than wrong. Rather than imply otherwise, `num_minimizers` is now documented as a **lower bound on the count, not a count**.

---

## 2. `find_stalls` accepted `min_window <= 1`

A stall is absence of progress *between* iterations, so a single iterate cannot be one — but `j - i + 1 >= min_window` is trivially true below 2. On a stall-free monotone solve, `min_window=0` reported **every iteration as a stall**, 18 of 20 windows degenerate with `start_iter == end_iter` and `delta_log10 == 0`. `0` and `1` also behaved identically, i.e. `0` was silently coerced.

Both front ends (pyo3, CLI) now reject `< 2` with a clear message; the core clamps as a backstop for other Rust callers.

## 3. `receipt.optimality.optimal` was `true` on an infeasible point

The stationarity residual of an infeasible point can legitimately be zero, which surfaced as `optimality.optimal: true` inside a receipt whose verdict was `REJECTED` (constraint violation 196). The top-level fields were correct, but a consumer reading the nested field alone was told the opposite. Now conditioned on feasibility; raw residuals still reported unconditioned, since they are useful for diagnosing *why* a point failed.

## 4. Non-Mapping `options=` was silently discarded whole

`options=` was merged only when it was a `Mapping`; anything else fell through and the solve ran on defaults — dropping *every* option the caller passed, not just one. Now a `TypeError`.

---

## Verification

- 125 `pounce-convex`, 35 `pounce-studio-core`, 601 Python tests pass
- Workspace builds clean; clippy clean on touched crates; docs guard OK
- Each fix has a regression test asserting the *specific* failure mode

The Himmelblau test asserts distance to a true minimizer rather than objective value alone — Himmelblau is steep near its minima, so a legitimately approximate atom at low order still carries a visible `f`. The failure being guarded against is a point nowhere near any minimizer, not imprecision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCWHfX7icowy2rj7jECnT8
