### PR TITLE
Fix the SOS hierarchy on constrained programs; surface QP weak activity (#218, #219)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,8 @@ pyomo-pounce/pyomo_pounce.egg-info/
 
 # Jupyter notebook autosave checkpoints
 .ipynb_checkpoints/
+
+# Personal release-announcement drafts (docs/linkedin-v*.org). Written per
+# release and not part of the published book — docs/src/ holds that. Pattern
+# rather than the exact file so the next version doesn't reappear untracked.
+docs/linkedin-v*.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,138 @@ changes.
 
 ## [Unreleased]
 
+### Added — weak-activity detection for QP sensitivity (#219)
+
+- **`QpSensitivity` can now report whether its own precondition holds.** The
+  first-order predictor `parametric_step` is exact only while the active set is
+  unchanged, but nothing on the object let a caller check that. Two new
+  properties expose what the object already knew: `active_indices` — which
+  inequality rows and variable bounds are in the active set, by identity rather
+  than the count implied by `kkt_dim` — and `weakly_active_indices`, the
+  constraints at which **strict complementarity fails**. Both return an
+  `ActiveSet` (`.inequalities` indexes rows of `G`, `.bounds` indexes
+  variables), also exported at the package root.
+- A weakly active constraint is binding in the primal while carrying a
+  negligible multiplier. Classical post-optimal sensitivity (Fiacco) assumes
+  this away; where it happens the perturbation changes the active set, so
+  `dx/db` is a genuine *one-sided* derivative and the other direction has a
+  different, equally valid value. Nothing previously returned was wrong — both
+  branches are real derivatives — but a caller could not tell the situation
+  apart from an ordinary one.
+- The screen is deliberately tolerance-invariant, which `kkt_dim` is not. On the
+  reported QP the two branches of `dx/db` are 33% apart and which one is
+  reported turns on the solver's `tol`, an unrelated setting; `kkt_dim` flips
+  4 → 3 across that sweep while the geometry never changes. The new flag stays
+  on throughout, because it tests the multiplier and the slack *together* —
+  at a degenerate optimum both collapse at ~`√tol`, while strict
+  complementarity keeps one of them bounded away from zero.
+
+### Fixed — the Lasserre/SOS hierarchy now converges on constrained programs (#218)
+
+- **`sos_minimize` returns a real bound where it used to return `nan`.** On the
+  reported benchmark (Lasserre, *SIAM J. Optim.* 11(3):796–817, Example 5) the
+  hierarchy now tightens to the global optimum instead of stalling:
+
+  | order | before | after |
+  |---|---|---|
+  | 2 | `optimal` `−7.000` (trivial box bound) | `optimal` `−7.000` |
+  | 3 | `iteration_limit` `nan` | `optimal` `−6.667` |
+  | 4 | `iteration_limit` `nan` | `optimal` `−5.5080139` (certified), **exact**, minimizer `(2.3295, 3.1785)` |
+
+  True global minimum `−5.5080132716` at `(2.3295, 3.1783)`, verified
+  independently here by a 400-start SLSQP sweep. Order 4 is certified exact by
+  flat truncation, so the minimizer comes back with the bound, and the reported
+  value is a *rigorous* lower bound (see below) rather than merely an accurate
+  one.
+
+- **Root cause: Mehrotra's centering parameter inverts on a degenerate face.**
+  `σ = (μ_aff/μ)³` infers centering from how far the affine direction could
+  travel. On a degenerate face that direction looks excellent while pointing
+  almost straight out of the cone, so `σ` collapses toward zero — nearly no
+  centering — exactly where centering is the only thing that helps. Order 4 of
+  the reported problem pinned `σ` at 0.0218 while the step fell
+  `4.0e-1 → 2.1e-2 → 9.7e-4 → … → 1e-281`, throttled by the PSD slack block
+  alone, with `μ` frozen at 2.6e-3 and residuals at 4.2e-4 — nowhere near
+  converged, simply stuck on the boundary. The corrector is now recomputed under
+  an escalating `σ` when its step collapses, each retry one extra back-solve
+  through the factorization already in hand. This is the PSD-cone counterpart of
+  what the Gondzio correctors do on the orthant, where they are confined because
+  a PSD block's complementarity product needs Jordan-algebra machinery.
+
+  The same fix carries the **NETLIB GEN family** (`gen`, `gen1`, `gen4`) and
+  `pilot87` from `Maximum_Iterations_Exceeded` to `Solved_To_Acceptable_Level`.
+
+- **Regularization no longer ratchets on a conditioning symptom.** When
+  iterative refinement could not reach its tolerance, the driver escalated both
+  the `(z,z)` dynamic regularization *and* `δ_c`, the equality-block
+  regularization — treating a cone-conditioning symptom as an
+  equality-Jacobian rank defect. The KKT is inherently ill-conditioned in the
+  `μ→0` endgame (the NT scaling's condition number blows up by design), so this
+  fired there on healthy solves and drove `δ_c` to its `1e-1` ceiling, biasing
+  the equality residual by `~δ_c·‖dy‖` and flooring `pres` permanently. Order 3
+  of the reported problem stood at `pres` 8.6e-9 ✓, `dres` 1.2e-10 ✓, `gap`
+  1.7e-8 — one step from converging — when the escalation pushed `pres` to
+  2.7e-8, where it stayed. Inertia was correct at every try throughout, so no
+  rank defect was ever present. Only the `(z,z)` regularization escalates on
+  this signal now.
+
+- **The bound is now certified, not merely converged.** A converged SDP reports
+  a `γ` that is *accurate* but need not be a lower **bound**: on the reported
+  problem at order 4 the raw value came back `2.2e-7` **above** the true
+  minimum, which is the one genuinely unsound failure mode for this API and one
+  no solver tolerance removes. `sos_minimize` now measures the miss instead of
+  trusting the solve — it projects each Gram block onto the PSD cone, evaluates
+  the residual `e` of the coefficient-matching system there, and reports
+  `γ − Σ_α|e_α|`. Since every other term of the Putinar identity is nonnegative
+  on the feasible set and `|u^α| ≤ 1` on the normalized box, that value is a
+  true lower bound however the solve went. Order 4 moves from `−5.508013056`
+  (invalid) to `−5.508013930` (valid, and within 1e-6 of the optimum). Costs one
+  eigendecomposition per block — no extra solve.
+
+  A new `certified` flag (Rust `SosSolution::certified`, Python
+  `SosResult.certified`) reports whether this held. It requires the feasible set
+  to lie in a box readable off the constraints — either `x ≥ l` / `x ≤ u` pairs
+  or the `c − a·x² ≥ 0` idiom — and is `false` on an unbounded domain, where no
+  finite correction exists (a residual with a negative leading coefficient is
+  unbounded below). Adding explicit box constraints upgrades such a problem.
+
+- **`tol` and `max_iter` are exposed** on `sos_minimize` (Python) and via
+  `sos_minimize_opts` / the now-public `sos_opts` (Rust) — the escape hatch the
+  report asked for, for a relaxation that will not converge. Loosening `tol`
+  buys a weaker bound, never an invalid one: certification measures the actual
+  residual rather than assuming convergence, so validity is preserved across
+  the whole range.
+
+- **A coarser bound is no longer discarded.** If the requested order does not
+  converge, `sos_minimize` falls back through successively coarser orders and
+  reports the first that does, via a new `order` field on the result (Rust
+  `SosSolution::order`, Python `SosResult.order`) identifying which relaxation
+  produced the bound. A lower-order bound is a valid bound on the same problem,
+  so returning nothing in its place threw away a certificate already computed.
+
+- **`PolyProblem::equilibrated` now normalizes the domain, not just the
+  coefficients.** When box constraints pin a variable's range it is mapped onto
+  `[−1, 1]` before the SDP is assembled. Coefficient equilibration (#124) left
+  the domain alone, so a wide box made the moment matrix span decades by itself
+  — over `x₁ ∈ [0,3]` the degree-8 moments span `3⁸ ≈ 6561` against 1, which no
+  coefficient scaling touches. The change of variables is value- and
+  minimizer-preserving, and recovered minimizers are mapped back to the caller's
+  coordinates.
+
+- Verified against the committed benchmark baselines: **371 NETLIB LPs** (4
+  improvements above, no regressions — the three objective deltas are all on
+  runs whose status is unchanged and non-converged or infeasible, where the
+  objective is not a meaningful output) and **138 Maros–Mészáros QPs**
+  (byte-identical statuses and objectives). The changed driver serves the
+  symmetric cones only — exponential/power route to the separate non-symmetric
+  driver, and the CBLIB tier is bit-identical to an unmodified tree — so SOC and
+  PSD are covered by a new randomized differential suite
+  (`tests/conic_hsde_vs_direct.rs`) that checks the HSDE driver against the
+  untouched direct driver over **318 generated instances** with planted Slater
+  points and compact feasible sets: no disagreement on any optimal value, no
+  instance solved by the direct driver that HSDE failed, and 36 that only HSDE
+  solved.
+
 ### Added — thread-scoped iteration capture from Rust (pounce-rs)
 
 - **A Rust consumer embedding POUNCE can now record a solve's iteration

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -121,6 +121,38 @@ const GONDZIO_GAMMA: f64 = 0.1;
 const GONDZIO_BETA_LO: f64 = 0.1;
 const GONDZIO_BETA_HI: f64 = 10.0;
 
+/// Centering fallback for a collapsing step (gh #218).
+///
+/// Mehrotra's centering parameter `σ = (μ_aff/μ)³` is inferred from how far the
+/// *affine* (σ = 0) direction could travel. On a degenerate face that inference
+/// inverts: the affine direction looks excellent while actually pointing almost
+/// straight out of the cone, so σ comes back near zero — almost no centering —
+/// exactly when centering is the only thing that helps. The step length then
+/// collapses geometrically and the solve freezes with `μ` still far from zero.
+///
+/// Observed on gh #218's order-4 moment SDP: `σ` pinned at 0.0218 while the
+/// step fell 4.0e-1 → 2.1e-2 → 9.7e-4 → 4.8e-5 → … → 1e-281, throttled by the
+/// PSD slack block alone (`z`, `τ`, `κ` all stayed healthy), with `μ` stuck at
+/// 2.6e-3 and the residuals frozen at 4.2e-4. Nothing was near convergence; the
+/// iterate had simply run into the boundary and could not get off it.
+///
+/// So when the corrector's step comes back below `CENTERING_MIN_STEP`, redo it
+/// with a larger σ — a more centered target pulls the direction back inside the
+/// cone, where a usable step exists. Each retry costs one back-solve through
+/// the factorization already computed. The ladder is bounded by
+/// `CENTERING_MAX_TRIES`, and the last (most centered) attempt is kept if none
+/// clears the bar, since a near-pure centering direction is the one most likely
+/// to admit a step.
+///
+/// This is the PSD-cone counterpart of what the Gondzio correctors below do on
+/// the orthant — they lengthen the step by re-centering — and it is deliberately
+/// step-length-triggered so that a healthy iteration never pays for it.
+const CENTERING_MIN_STEP: f64 = 1e-2;
+const CENTERING_MAX_TRIES: usize = 3;
+const CENTERING_FACTOR: f64 = 10.0;
+const CENTERING_SIGMA_FLOOR: f64 = 0.1;
+const CENTERING_SIGMA_MAX: f64 = 0.9;
+
 /// HSDE infeasibility-ray discriminant: is the homogenizing pair `(τ, κ)` on
 /// the Farkas/recession ray (`κ ≫ τ`), as opposed to converging to a solution
 /// (`τ → τ* > 0`) or merely degenerating on a feasible-but-ill-scaled problem
@@ -652,8 +684,24 @@ where
                 Ok(res) => res,
                 Err(_) => break, // factored stays false → breakdown below
             };
-            if res_p > DYN_REG_RES_TOL && budget {
-                delta_c = (delta_c.max(DELTA_C_INIT) * DELTA_C_FACTOR).min(DELTA_C_MAX);
+            // An un-refinable solve means the *scaling* has gone ill-conditioned,
+            // so bump the `(z,z)` dynamic regularization — and deliberately NOT
+            // `δ_c`. `δ_c` regularizes the equality block; escalating it here
+            // treats a cone-conditioning symptom as an equality-Jacobian rank
+            // defect, and it is actively harmful. The KKT is inherently
+            // ill-conditioned in the μ→0 endgame (the NT scaling's condition
+            // number blows up by design), so this branch fires there on healthy
+            // solves and used to ratchet `δ_c` all the way to `DELTA_C_MAX`
+            // = 1e-1. That biases the equality residual by ~`δ_c·‖dy‖`, which
+            // floors `pres` permanently.
+            //
+            // gh #218 order 3: at the iteration before the escalation the solve
+            // stood at `pres` 8.6e-9 ✓, `dres` 1.2e-10 ✓, `gap` 1.7e-8 — one
+            // step from converging. The escalation pushed `pres` to 2.7e-8 and
+            // it never recovered, ending `OptimalInaccurate` instead of
+            // `Optimal`. Inertia was correct at every single try throughout, so
+            // nothing here was a rank defect.
+            if res_p > DYN_REG_RES_TOL && tries < INERTIA_MAX_TRIES && reg_eff < DYN_REG_MAX {
                 reg_eff = (reg_eff * DYN_REG_FACTOR).min(DYN_REG_MAX);
                 tries += 1;
                 continue;
@@ -717,55 +765,81 @@ where
             dot_aff += (s[i] + alpha_aff * ds_aff[i]) * (z[i] + alpha_aff * dz_aff[i]);
         }
         let mu_aff = dot_aff / (degree as f64 + 1.0);
-        let sigma = if mu > 0.0 { (mu_aff / mu).powi(3) } else { 0.0 };
-        let sigma_mu = sigma * mu;
+        let mut sigma = if mu > 0.0 { (mu_aff / mu).powi(3) } else { 0.0 };
 
         // === Corrector (centered target + second-order term) ===
-        cone.comp_residual_corrector(&s, &z, &ds_aff, &dz_aff, sigma_mu, &mut r_c);
-        cone.rhs_comp_term(&s, &z, &r_c, &mut comp);
-        build_rhs(&rho_x, &rho_y, &rho_z, &comp, n, m_eq, m_ineq, &mut rhs);
-        if solve_refined(
-            &mut fact, &kkt.airn, &kkt.ajcn, &kkt_vals, &mut rhs, &mut ir_b, &mut ir_r, &mut ir_d,
-        )
-        .is_err()
-        {
+        // Recomputed under an escalating σ when the resulting step collapses —
+        // see `CENTERING_MIN_STEP`. Each retry is one extra back-solve through
+        // the factorization already in hand, and a healthy iteration (the
+        // overwhelming majority) clears the threshold on the first pass and
+        // never enters the ladder.
+        let mut dtau = 0.0;
+        let mut dkappa = 0.0;
+        let mut alpha = 0.0;
+        let mut centering_tries = 0usize;
+        let mut solve_failed = false;
+        loop {
+            let sigma_mu = sigma * mu;
+            cone.comp_residual_corrector(&s, &z, &ds_aff, &dz_aff, sigma_mu, &mut r_c);
+            cone.rhs_comp_term(&s, &z, &r_c, &mut comp);
+            build_rhs(&rho_x, &rho_y, &rho_z, &comp, n, m_eq, m_ineq, &mut rhs);
+            if solve_refined(
+                &mut fact, &kkt.airn, &kkt.ajcn, &kkt_vals, &mut rhs, &mut ir_b, &mut ir_r,
+                &mut ir_d,
+            )
+            .is_err()
+            {
+                solve_failed = true;
+                break;
+            }
+            split_step(&rhs, n, m_eq, m_ineq, &mut dx, &mut dy, &mut dz);
+            let gtq = dot(&prob.c, &dx)
+                + two_over_tau * dot(&px_vec, &dx)
+                + dot(&prob.b, &dy)
+                + dot(&prob.h, &dz);
+            // τκ corrector residual: τκ + Δτ_aff·Δκ_aff (target σμ).
+            let r_tk = tau * kappa + dtau_aff * dkappa_aff;
+            dtau = (-rho_tau - gtq - (sigma_mu - r_tk) / tau) / denom;
+            // Combine: dw = q + Δτ·p.
+            for i in 0..n {
+                dx[i] += dtau * p_x[i];
+            }
+            for i in 0..m_eq {
+                dy[i] += dtau * p_y[i];
+            }
+            for i in 0..m_ineq {
+                dz[i] += dtau * p_z[i];
+            }
+            dkappa = (sigma_mu - r_tk - kappa * dtau) / tau;
+            cone.recover_ds(&s, &z, &r_c, &dz, &mut ds);
+
+            // Single fraction-to-boundary step (HSDE is primal/dual-symmetric).
+            // A *separate* primal/dual step is unsound here: τ couples both
+            // residuals (ρ_x carries `cτ` + `Px`, ρ_y carries `bτ`), so stepping
+            // the primal block (x, s, τ) and dual block (y, z, κ) by different
+            // amounts leaves a dual-infeasibility residual ∝ (α_p − α_d) — on the
+            // degenerate NETLIB GEN family (α_p ≫ α_d) that blows ρ_x up from
+            // ~1e-8 to ~5e-2. The symmetric step keeps the embedding's clean
+            // (1−α) residual decrease.
+            alpha = ray_step(tau, dtau, opts.tau).min(ray_step(kappa, dkappa, opts.tau));
+            if m_ineq > 0 {
+                alpha = alpha
+                    .min(cone.max_step(&s, &ds, opts.tau))
+                    .min(cone.max_step(&z, &dz, opts.tau));
+            }
+
+            if alpha >= CENTERING_MIN_STEP
+                || centering_tries >= CENTERING_MAX_TRIES
+                || sigma >= CENTERING_SIGMA_MAX
+            {
+                break;
+            }
+            centering_tries += 1;
+            sigma = (sigma * CENTERING_FACTOR).clamp(CENTERING_SIGMA_FLOOR, CENTERING_SIGMA_MAX);
+        }
+        if solve_failed {
             status = QpStatus::NumericalFailure;
             break;
-        }
-        split_step(&rhs, n, m_eq, m_ineq, &mut dx, &mut dy, &mut dz);
-        let gtq = dot(&prob.c, &dx)
-            + two_over_tau * dot(&px_vec, &dx)
-            + dot(&prob.b, &dy)
-            + dot(&prob.h, &dz);
-        // τκ corrector residual: τκ + Δτ_aff·Δκ_aff (target σμ).
-        let r_tk = tau * kappa + dtau_aff * dkappa_aff;
-        let mut dtau = (-rho_tau - gtq - (sigma_mu - r_tk) / tau) / denom;
-        // Combine: dw = q + Δτ·p.
-        for i in 0..n {
-            dx[i] += dtau * p_x[i];
-        }
-        for i in 0..m_eq {
-            dy[i] += dtau * p_y[i];
-        }
-        for i in 0..m_ineq {
-            dz[i] += dtau * p_z[i];
-        }
-        let mut dkappa = (sigma_mu - r_tk - kappa * dtau) / tau;
-        cone.recover_ds(&s, &z, &r_c, &dz, &mut ds);
-
-        // Single fraction-to-boundary step (HSDE is primal/dual-symmetric).
-        // A *separate* primal/dual step is unsound here: τ couples both
-        // residuals (ρ_x carries `cτ` + `Px`, ρ_y carries `bτ`), so stepping
-        // the primal block (x, s, τ) and dual block (y, z, κ) by different
-        // amounts leaves a dual-infeasibility residual ∝ (α_p − α_d) — on the
-        // degenerate NETLIB GEN family (α_p ≫ α_d) that blows ρ_x up from
-        // ~1e-8 to ~5e-2. The symmetric step keeps the embedding's clean
-        // (1−α) residual decrease.
-        let mut alpha = ray_step(tau, dtau, opts.tau).min(ray_step(kappa, dkappa, opts.tau));
-        if m_ineq > 0 {
-            alpha = alpha
-                .min(cone.max_step(&s, &ds, opts.tau))
-                .min(cone.max_step(&z, &dz, opts.tau));
         }
 
         // === Gondzio multiple centrality correctors ===

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -49,6 +49,7 @@ pub use ipm::{
 pub use qp::{NEG_INF, POS_INF, QpIterate, QpProblem, QpResiduals, QpSolution, QpStatus, Triplet};
 pub use sensitivity::{QpSensitivity, ReducedHessian, SensError};
 pub use sos::{
-    PolyProblem, Polynomial, SosBound, SosSolution, sos_constrained_lower_bound, sos_lower_bound,
-    sos_minimize,
+    PolyProblem, Polynomial, SosBound, SosSolution, sos_constrained_lower_bound,
+    sos_constrained_lower_bound_opts, sos_lower_bound, sos_lower_bound_opts, sos_minimize,
+    sos_minimize_opts, sos_opts,
 };

--- a/crates/pounce-convex/src/sensitivity.rs
+++ b/crates/pounce-convex/src/sensitivity.rs
@@ -31,7 +31,7 @@
 //! stable; the induced error in the step is `O(δ)`.
 
 use crate::ipm::QpOptions;
-use crate::qp::{QpProblem, QpSolution, QpStatus, Triplet};
+use crate::qp::{BOUND_INF, QpProblem, QpSolution, QpStatus, Triplet};
 use pounce_common::types::{Index, Number};
 use pounce_linalg::symmetric_eigen;
 use pounce_linsol::{Factorization, SparseSymLinearSolverInterface};
@@ -85,7 +85,29 @@ pub struct QpSensitivity {
     active_ineq: Vec<usize>,
     /// Variables whose bound is active (one `eⱼᵀ` row each).
     active_bound_vars: Vec<usize>,
+    /// Inequality rows at which strict complementarity fails (gh #219).
+    weakly_active_ineq: Vec<usize>,
+    /// Variables whose bound is weakly active.
+    weakly_active_bound_vars: Vec<usize>,
 }
+
+/// Relative threshold below which a slack or a multiplier counts as zero for
+/// the weak-activity screen (see [`QpSensitivity::weakly_active_ineq`]).
+///
+/// Deliberately loose, because it is the *conjunction* that carries the signal:
+/// a constraint must be binding in the primal **and** carry a negligible dual
+/// at the same time. Either alone is ordinary — every active constraint has
+/// zero slack, every inactive one has zero multiplier — while both at once is
+/// exactly the non-strict complementarity that makes `dx/db` one-sided.
+///
+/// The magnitude is set by how these quantities actually behave. At a
+/// degenerate optimum both collapse together at roughly `√tol`: on gh #219's
+/// QP the multiplier and slack measure `(3.8e-5, 1.7e-4)` at `tol = 1e-8`,
+/// `(2.0e-7, 9.0e-7)` at `1e-12`, and `(2.9e-8, 1.3e-7)` at `1e-14` — their
+/// ratio pinned near 0.22 across six orders of magnitude. A threshold tight
+/// enough to look precise would simply miss the default-tolerance case, which
+/// is the one users hit.
+const WEAK_ACTIVE_REL: f64 = 1e-3;
 
 impl QpSensitivity {
     /// Build the active-set sensitivity for `sol` (a solution of `prob`).
@@ -126,6 +148,47 @@ impl QpSensitivity {
             .collect();
         let n_active = active_ineq.len() + active_bound_vars.len();
         let dim = n + m_eq + n_active;
+
+        // Weak activity (gh #219): binding in the primal *and* negligible in
+        // the dual, i.e. non-strict complementarity. Classical post-optimal
+        // sensitivity (Fiacco) assumes this never happens; where it does, the
+        // perturbation changes the active set and `dx/db` is a one-sided
+        // derivative with another, equally valid, value on the other side.
+        //
+        // Both tests are relative to the natural scale of their own quantity,
+        // so the screen is invariant to a rescaling of the problem data.
+        let inf_norm = |v: &[f64]| v.iter().fold(0.0_f64, |m, x| m.max(x.abs()));
+        let dual_scale = inf_norm(&sol.y)
+            .max(inf_norm(&sol.z))
+            .max(inf_norm(&sol.z_lb))
+            .max(inf_norm(&sol.z_ub))
+            .max(1.0);
+        let mut gx = vec![0.0; prob.m_ineq()];
+        prob.g_mul(&sol.x, &mut gx);
+        let primal_scale = inf_norm(&prob.h).max(inf_norm(&gx)).max(1.0);
+        let dual_zero = WEAK_ACTIVE_REL * dual_scale;
+        let primal_zero = WEAK_ACTIVE_REL * primal_scale;
+
+        let weakly_active_ineq: Vec<usize> = (0..prob.m_ineq())
+            .filter(|&i| (prob.h[i] - gx[i]).abs() <= primal_zero && sol.z[i] <= dual_zero)
+            .collect();
+        let x_scale = inf_norm(&sol.x).max(1.0);
+        let bound_zero = WEAK_ACTIVE_REL * x_scale;
+        let weakly_active_bound_vars: Vec<usize> = (0..n)
+            .filter(|&j| {
+                // `lb`/`ub` may be empty (= unbounded), and a "present" bound
+                // is one inside the `BOUND_INF` sentinel band, matching
+                // `QpProblem::has_bounds`.
+                let (lb, ub) = (prob.lb_of(j), prob.ub_of(j));
+                let lb_weak = lb > -BOUND_INF
+                    && (sol.x[j] - lb).abs() <= bound_zero
+                    && sol.z_lb[j] <= dual_zero;
+                let ub_weak = ub < BOUND_INF
+                    && (ub - sol.x[j]).abs() <= bound_zero
+                    && sol.z_ub[j] <= dual_zero;
+                lb_weak || ub_weak
+            })
+            .collect();
 
         // Assemble the lower triangle of the symmetric KKT matrix.
         let mut entries: BTreeMap<(usize, usize), f64> = BTreeMap::new();
@@ -187,6 +250,8 @@ impl QpSensitivity {
             prob: prob.clone(),
             active_ineq,
             active_bound_vars,
+            weakly_active_ineq,
+            weakly_active_bound_vars,
         })
     }
 
@@ -259,6 +324,43 @@ impl QpSensitivity {
     /// The active-set KKT dimension `n + m_eq + n_active`.
     pub fn kkt_dim(&self) -> usize {
         self.dim
+    }
+
+    /// Inequality rows (indices into `G`) in the active set.
+    pub fn active_ineq(&self) -> &[usize] {
+        &self.active_ineq
+    }
+
+    /// Variables whose bound is in the active set.
+    pub fn active_bound_vars(&self) -> &[usize] {
+        &self.active_bound_vars
+    }
+
+    /// Inequality rows at which **strict complementarity fails**: binding in
+    /// the primal while carrying a negligible multiplier (gh #219).
+    ///
+    /// This is the precondition check for
+    /// [`parametric_step`](Self::parametric_step). That predictor is exact only
+    /// while the active set is unchanged; at a weakly active constraint the
+    /// perturbation changes it, so `dx/db` is a genuine one-sided derivative
+    /// and the opposite direction has a different — equally correct — value.
+    /// On gh #219's QP the two branches differ by 33%, and which one is
+    /// reported turns on the solver's `tol`.
+    ///
+    /// A non-empty result does not invalidate anything already returned: both
+    /// branches are real derivatives. It means the caller should not assume the
+    /// predictor extrapolates in both directions, and should probe the
+    /// direction it actually cares about. The screen is deliberately
+    /// conservative (see `WEAK_ACTIVE_REL`) — a near-degenerate constraint is
+    /// flagged too, which is the useful behaviour for a diagnostic.
+    pub fn weakly_active_ineq(&self) -> &[usize] {
+        &self.weakly_active_ineq
+    }
+
+    /// Variables whose bound is weakly active — the bound analog of
+    /// [`weakly_active_ineq`](Self::weakly_active_ineq).
+    pub fn weakly_active_bound_vars(&self) -> &[usize] {
+        &self.weakly_active_bound_vars
     }
 
     /// Reduced Hessian of the QP at the optimum: the objective Hessian `P`
@@ -422,6 +524,96 @@ mod tests {
 
     fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
         Box::new(FeralSolverInterface::new())
+    }
+
+    /// gh #219's degenerate QP: `min ½‖x‖² s.t. x₀ + x₁ = 1, x₀ − 2x₁ ≤ h`.
+    /// At `h = −½` the equality-only optimum `(½, ½)` hits the inequality
+    /// *exactly*, so strict complementarity fails; other `h` give a strictly
+    /// active (`h = −0.9`) or strictly inactive (`h = 0.5`) constraint.
+    fn weakly_active_qp(h: f64) -> QpProblem {
+        QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+            c: vec![0.0, 0.0],
+            a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            b: vec![1.0],
+            g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -2.0)],
+            h: vec![h],
+            lb: vec![f64::NEG_INFINITY; 2],
+            ub: vec![f64::INFINITY; 2],
+        }
+    }
+
+    #[test]
+    fn weak_activity_is_detected_independently_of_solver_tol() {
+        // The point of the flag (gh #219). At this optimum `dx/db` is
+        // two-valued — (2/3, 1/3) on the minus side, (1/2, 1/2) on the plus
+        // side, 33% apart — and *which* one `parametric_step` reports turns on
+        // `tol`, an otherwise unrelated setting: the multiplier and the slack
+        // both collapse at ~√tol, so `active_tol` slices the pair differently
+        // at different `tol`.
+        //
+        // `kkt_dim` therefore flips 4 → 3 across this sweep while the geometry
+        // does not change at all. The weak-activity flag is the stable signal:
+        // it must fire at every tolerance, including the ones where the
+        // constraint *is* in the active set.
+        let prob = weakly_active_qp(-0.5);
+        let mut saw_in_active_set = false;
+        let mut saw_out_of_active_set = false;
+        for tol in [1e-8, 1e-12, 1e-14] {
+            let opts = QpOptions {
+                tol,
+                ..QpOptions::default()
+            };
+            let sol = solve_qp_ipm(&prob, &opts, backend);
+            assert_eq!(sol.status, QpStatus::Optimal);
+            let sens = QpSensitivity::build(&prob, &sol, &opts, 1e-7, backend).unwrap();
+            assert_eq!(
+                sens.weakly_active_ineq(),
+                &[0],
+                "tol {tol:e}: weak activity missed (kkt_dim {})",
+                sens.kkt_dim()
+            );
+            match sens.active_ineq() {
+                [] => saw_out_of_active_set = true,
+                [0] => saw_in_active_set = true,
+                other => panic!("tol {tol:e}: unexpected active set {other:?}"),
+            }
+        }
+        // Guards the premise: if the sweep stopped straddling the active-set
+        // boundary the test would still pass while no longer testing anything.
+        assert!(
+            saw_in_active_set && saw_out_of_active_set,
+            "sweep no longer straddles the active-set boundary, so this test \
+             no longer demonstrates tol-independence"
+        );
+    }
+
+    #[test]
+    fn strictly_complementary_constraints_are_not_flagged_weak() {
+        // The false-positive guard. A screen that fired on every active
+        // constraint, or on every constraint with a small multiplier, would
+        // pass the test above while being useless.
+        //
+        // `h = −0.9`: the constraint binds with multiplier ~8.9e-2 — strictly
+        // active, `dx/db` two-sided. `h = 0.5`: the constraint is slack at the
+        // optimum — strictly inactive. Neither is degenerate.
+        for (h, expect_active) in [(-0.9, true), (0.5, false)] {
+            let prob = weakly_active_qp(h);
+            let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+            assert_eq!(sol.status, QpStatus::Optimal);
+            let sens = QpSensitivity::build_default(&prob, &sol, backend).unwrap();
+            assert!(
+                sens.weakly_active_ineq().is_empty(),
+                "h = {h}: strictly complementary constraint flagged as weakly active"
+            );
+            assert_eq!(
+                !sens.active_ineq().is_empty(),
+                expect_active,
+                "h = {h}: active set {:?}",
+                sens.active_ineq()
+            );
+        }
     }
 
     /// `min ½‖x‖²  s.t.  x₀ + x₁ = b` (b = 2). The optimum is the projection

--- a/crates/pounce-convex/src/sos.rs
+++ b/crates/pounce-convex/src/sos.rs
@@ -95,6 +95,116 @@ impl Polynomial {
             .product()
     }
 
+    /// If this polynomial is a single variable bound `a·xⱼ + c ≥ 0`, the bound
+    /// it imposes: `(j, value, is_upper)`.
+    ///
+    /// `a > 0` reads as the lower bound `xⱼ ≥ −c/a`, `a < 0` as the upper bound
+    /// `xⱼ ≤ −c/a`. Anything else — two variables, a higher-degree term, an
+    /// extra monomial — is not a box side and returns `None`. Used to find a
+    /// variable's range for domain normalization (see
+    /// [`PolyProblem::equilibrated`]).
+    fn as_variable_bound(&self) -> Option<(usize, f64, bool)> {
+        let mut linear: Option<(usize, f64)> = None;
+        let mut constant = 0.0;
+        for (e, c) in &self.coeff_map() {
+            if *c == 0.0 {
+                continue;
+            }
+            match e.iter().sum::<usize>() {
+                0 => constant += c,
+                1 => {
+                    let j = e.iter().position(|&p| p == 1)?;
+                    // A second linear term means two variables are coupled.
+                    if linear.is_some() {
+                        return None;
+                    }
+                    linear = Some((j, *c));
+                }
+                _ => return None,
+            }
+        }
+        let (j, a) = linear?;
+        Some((j, -constant / a, a < 0.0))
+    }
+
+    /// If this polynomial is `c − a·xⱼ² ≥ 0` with `a, c > 0`, the symmetric
+    /// range it imposes: `(j, √(c/a))`, i.e. `|xⱼ| ≤ √(c/a)`.
+    ///
+    /// The idiomatic way to write a ball/box side in an SOS model, and common
+    /// enough that missing it would leave obviously-bounded problems
+    /// uncertifiable (`min −x s.t. 1 − x² ≥ 0` is the textbook example).
+    fn as_variable_square_bound(&self) -> Option<(usize, f64)> {
+        let mut square: Option<(usize, f64)> = None;
+        let mut constant = 0.0;
+        for (e, c) in &self.coeff_map() {
+            if *c == 0.0 {
+                continue;
+            }
+            match e.iter().sum::<usize>() {
+                0 => constant += c,
+                2 => {
+                    // Must be `xⱼ²`, not a cross term `xⱼxₖ`.
+                    let j = e.iter().position(|&p| p == 2)?;
+                    if square.is_some() {
+                        return None;
+                    }
+                    square = Some((j, *c));
+                }
+                _ => return None,
+            }
+        }
+        let (j, a) = square?;
+        // `c − a·xⱼ² ≥ 0` bounds xⱼ only when the square enters negatively and
+        // the constant is nonnegative.
+        if a >= 0.0 || constant < 0.0 {
+            return None;
+        }
+        Some((j, (constant / -a).sqrt()))
+    }
+
+    /// Substitute `xⱼ = shiftⱼ + scaleⱼ·uⱼ` into this polynomial, returning it
+    /// as a polynomial in `u`.
+    ///
+    /// Each monomial `∏ⱼ xⱼ^{eⱼ}` expands binomially, one variable at a time:
+    /// `(shiftⱼ + scaleⱼuⱼ)^{eⱼ} = Σₖ C(eⱼ,k)·shiftⱼ^{eⱼ−k}·scaleⱼ^k·uⱼ^k`.
+    /// Terms are accumulated through a `BTreeMap` so the result is ordered
+    /// deterministically regardless of the input term order.
+    fn affine_substitute(&self, shift: &[f64], scale: &[f64]) -> Polynomial {
+        let n = self.n_vars;
+        let mut acc: BTreeMap<Vec<usize>, f64> = BTreeMap::new();
+        for (e, c) in &self.terms {
+            let mut cur: Vec<(Vec<usize>, f64)> = vec![(vec![0usize; n], *c)];
+            for j in 0..n {
+                let ej = e[j];
+                if ej == 0 {
+                    continue;
+                }
+                let mut next = Vec::with_capacity(cur.len() * (ej + 1));
+                let mut binom = 1.0_f64;
+                for k in 0..=ej {
+                    let w = binom * shift[j].powi((ej - k) as i32) * scale[j].powi(k as i32);
+                    if w != 0.0 {
+                        for (m, cc) in &cur {
+                            let mut m2 = m.clone();
+                            m2[j] += k;
+                            next.push((m2, cc * w));
+                        }
+                    }
+                    // C(e, k+1) = C(e, k)·(e−k)/(k+1).
+                    binom = binom * (ej - k) as f64 / (k + 1) as f64;
+                }
+                cur = next;
+            }
+            for (m, cc) in cur {
+                *acc.entry(m).or_insert(0.0) += cc;
+            }
+        }
+        Polynomial {
+            n_vars: n,
+            terms: acc.into_iter().filter(|(_, c)| *c != 0.0).collect(),
+        }
+    }
+
     /// This polynomial with every coefficient divided by `s`.
     fn scaled(&self, s: f64) -> Polynomial {
         Polynomial {
@@ -173,27 +283,124 @@ impl PolyProblem {
     /// (`numerical_failure` / `iteration_limit`) while the equilibrated one
     /// certifies the exact bound in ~2 s. A zero/empty polynomial scales by
     /// `1.0` (nothing to do).
-    fn equilibrated(&self) -> (PolyProblem, f64) {
+    fn equilibrated(&self) -> (PolyProblem, Rescaling) {
         fn nonzero_norm(p: &Polynomial) -> f64 {
             let s = p.coeff_inf_norm();
             if s > 0.0 { s } else { 1.0 }
         }
-        let s_obj = nonzero_norm(&self.objective);
+        let (shift, scale, boxed) = self.domain_normalization();
+        // Domain first, coefficients second: the substitution rewrites every
+        // coefficient, so equilibrating before it would be undone.
+        let sub = |p: &Polynomial| p.affine_substitute(&shift, &scale);
+        let objective = sub(&self.objective);
+        let s_obj = nonzero_norm(&objective);
         let scaled = PolyProblem {
             n_vars: self.n_vars,
-            objective: self.objective.scaled(s_obj),
+            objective: objective.scaled(s_obj),
             inequalities: self
                 .inequalities
                 .iter()
-                .map(|g| g.scaled(nonzero_norm(g)))
+                .map(|g| {
+                    let g = sub(g);
+                    g.scaled(nonzero_norm(&g))
+                })
                 .collect(),
             equalities: self
                 .equalities
                 .iter()
-                .map(|h| h.scaled(nonzero_norm(h)))
+                .map(|h| {
+                    let h = sub(h);
+                    h.scaled(nonzero_norm(&h))
+                })
                 .collect(),
         };
-        (scaled, s_obj)
+        (
+            scaled,
+            Rescaling {
+                s_obj,
+                shift,
+                scale,
+                boxed,
+            },
+        )
+    }
+
+    /// Per-variable affine map `xⱼ = shiftⱼ + scaleⱼ·uⱼ` normalizing every
+    /// boxed variable's range onto `[−1, 1]`.
+    ///
+    /// A variable is boxed when the inequality list carries both a lower and an
+    /// upper bound for it as standalone constraints (`xⱼ − l ≥ 0`, `u − xⱼ ≥ 0`
+    /// and their scalar multiples); the tightest of each is used. Variables
+    /// without a finite box, or with a degenerate one (`u ≤ l`), map by the
+    /// identity `(0, 1)`.
+    ///
+    /// This complements coefficient equilibration, which normalizes each
+    /// polynomial's coefficients but leaves the *domain* alone. The moment
+    /// matrix entries are monomials in `x`, so a wide box makes them span
+    /// decades on their own: on gh #218's quartic over `x₁ ∈ [0,3]` the
+    /// degree-8 moments span `3⁸ ≈ 6561` against `1`, and no amount of
+    /// coefficient scaling touches that. Normalizing the domain moves the
+    /// order-3 relaxation there from a frozen `IterationLimit` (no bound at
+    /// all) to `OptimalInaccurate` at `−6.667`, a valid bound tighter than the
+    /// trivial `−7`.
+    ///
+    /// The map is value- and minimizer-preserving: it is a bijection of the
+    /// feasible set, so the minimum is unchanged and a recovered minimizer maps
+    /// back through [`Rescaling::unmap`].
+    fn domain_normalization(&self) -> (Vec<f64>, Vec<f64>, bool) {
+        let mut lower = vec![f64::NEG_INFINITY; self.n_vars];
+        let mut upper = vec![f64::INFINITY; self.n_vars];
+        for g in &self.inequalities {
+            if let Some((j, v, is_upper)) = g.as_variable_bound() {
+                if is_upper {
+                    upper[j] = upper[j].min(v);
+                } else {
+                    lower[j] = lower[j].max(v);
+                }
+            } else if let Some((j, r)) = g.as_variable_square_bound() {
+                lower[j] = lower[j].max(-r);
+                upper[j] = upper[j].min(r);
+            }
+        }
+        let mut shift = vec![0.0; self.n_vars];
+        let mut scale = vec![1.0; self.n_vars];
+        let mut boxed = true;
+        for j in 0..self.n_vars {
+            let (l, u) = (lower[j], upper[j]);
+            if l.is_finite() && u.is_finite() && u > l {
+                shift[j] = 0.5 * (l + u);
+                scale[j] = 0.5 * (u - l);
+            } else {
+                boxed = false;
+            }
+        }
+        (shift, scale, boxed)
+    }
+}
+
+/// The change of variables [`PolyProblem::equilibrated`] applied, and how to
+/// undo it on a recovered bound and minimizer.
+struct Rescaling {
+    /// The objective's coefficient scale: a bound computed on the equilibrated
+    /// problem is multiplied by this to recover the original one.
+    s_obj: f64,
+    /// Per-variable `xⱼ = shiftⱼ + scaleⱼ·uⱼ` (identity `(0, 1)` when unboxed).
+    shift: Vec<f64>,
+    scale: Vec<f64>,
+    /// Whether *every* variable was boxed, so the normalized feasible set is
+    /// contained in `[−1, 1]ⁿ`. This is the precondition for a rigorous bound
+    /// (see [`certified_slack`]); with even one variable unbounded, the
+    /// residual polynomial cannot be bounded over the feasible set at all.
+    boxed: bool,
+}
+
+impl Rescaling {
+    /// Map a point from the normalized `u` coordinates back to the caller's `x`.
+    fn unmap(&self, u: &[f64]) -> Vec<f64> {
+        u.iter()
+            .enumerate()
+            .map(|(j, v)| self.shift[j] + self.scale[j] * v)
+            .collect()
     }
 }
 
@@ -266,7 +473,9 @@ where
     sos_constrained_lower_bound_opts(prob, order, &sos_opts(), make_backend)
 }
 
-/// Default solver options for an SOS/moment SDP.
+/// Default solver options for an SOS/moment SDP — the base a caller should
+/// build on (`QpOptions { tol: 1e-6, ..sos_opts() }`) rather than starting from
+/// [`QpOptions::default`], so the HSDE choice below is preserved.
 ///
 /// SOS relaxations are *degenerate by design*: an exact relaxation has a
 /// rank-deficient optimal moment matrix sitting on the PSD-cone boundary, where
@@ -275,7 +484,7 @@ where
 /// refinement ran to the iteration limit and drifted to a `-6e7` "bound");
 /// the homogeneous self-dual embedding stays well-conditioned on the same
 /// problems (≈10 iterations), so SOS solves default to it.
-fn sos_opts() -> QpOptions {
+pub fn sos_opts() -> QpOptions {
     QpOptions {
         use_hsde: true,
         ..QpOptions::default()
@@ -291,6 +500,91 @@ struct MomentInfo {
     d: usize,
     basis0: Vec<Vec<usize>>,
     row_of: HashMap<Vec<usize>, usize>,
+    /// Each SOS block's `(column base in x, basis dimension)`, in build order:
+    /// σ₀ first, then one localizing block per inequality. Used to read the
+    /// Gram matrices back out of the primal for [`certified_slack`].
+    psd_blocks: Vec<(usize, usize)>,
+}
+
+/// A rigorous bound on how far the computed SOS certificate misses the exact
+/// polynomial identity, given that the feasible set lies inside the unit box.
+///
+/// The SDP asks for `p − γ = σ₀ + Σᵢ σᵢ gᵢ + Σⱼ λⱼ hⱼ`, one linear equation per
+/// monomial. A converged interior-point solve satisfies those equations only to
+/// its tolerance, and its Gram matrices are only *approximately* PSD — so the
+/// `γ` it reports can, and on gh #218's order-4 relaxation does, sit slightly
+/// **above** the true minimum. That is the one genuinely unsound failure mode
+/// for a lower bound, and no tightening of the solve removes it: it is a
+/// property of finite precision, not of convergence.
+///
+/// The fix is to stop trusting the identity and measure it. Project every Gram
+/// block onto the PSD cone (clamp negative eigenvalues to zero) so the `σ` are
+/// *exactly* SOS, then evaluate the residual of the coefficient-matching system
+/// at the projected point: `e = b − A·x'`. As polynomials that says
+///
+/// ```text
+///   p(u) − γ = σ₀(u) + Σᵢ σᵢ(u) gᵢ(u) + Σⱼ λⱼ(u) hⱼ(u) + e(u),
+/// ```
+///
+/// where every term but `e` is nonnegative on the feasible set — the `σ` are
+/// SOS by construction now, the `gᵢ` are nonnegative there by definition, and
+/// the `hⱼ` vanish there. Hence `p ≥ γ + e` on the feasible set, and with
+/// `|u^α| ≤ 1` on `[−1,1]ⁿ` the crudest possible bound on `e` is already enough:
+///
+/// ```text
+///   p(u) ≥ γ − Σ_α |e_α|   for all u in the feasible set.
+/// ```
+///
+/// This function returns that `Σ_α |e_α|`. Subtracting it turns a bound that is
+/// merely accurate into one that is *valid*, and it costs one eigendecomposition
+/// per block plus a sparse matvec — no extra solve.
+///
+/// The `|u^α| ≤ 1` step is what requires the unit box, which is why
+/// certification is available only when every variable is boxed (see
+/// [`Rescaling::boxed`]). On an unbounded domain a nonzero residual cannot be
+/// bounded at all: a residual with a negative leading coefficient is unbounded
+/// below, so no finite correction exists. Certifying there needs the residual
+/// driven to *exactly* zero in exact arithmetic (rational Gram recovery), which
+/// is a different technique entirely.
+fn certified_slack(qp: &QpProblem, mi: &MomentInfo, x: &[f64]) -> Option<f64> {
+    let mut xp = x.to_vec();
+    for &(col_base, bn) in &mi.psd_blocks {
+        let sd = bn * (bn + 1) / 2;
+        // svec -> dense symmetric (off-diagonals carry a √2 in svec).
+        let mut m = vec![0.0; bn * bn];
+        crate::cones::psd::smat(&xp[col_base..col_base + sd], bn, &mut m);
+        let mut vals = vec![0.0; bn];
+        let mut vecs = vec![0.0; bn * bn];
+        if !symmetric_eigen(&m, bn, &mut vals, &mut vecs) {
+            return None;
+        }
+        // Already PSD to working precision: leave the block untouched so a
+        // clean solve pays nothing for the projection's round-off.
+        if vals[0] >= 0.0 {
+            continue;
+        }
+        // Q₊ = Σ max(λ_k, 0) v_k v_kᵀ, rebuilt straight back into svec.
+        let r2 = std::f64::consts::SQRT_2;
+        for i in 0..bn {
+            for j in 0..=i {
+                let mut acc = 0.0;
+                for k in 0..bn {
+                    if vals[k] > 0.0 {
+                        acc += vals[k] * vecs[k * bn + i] * vecs[k * bn + j];
+                    }
+                }
+                let scale = if i == j { 1.0 } else { r2 };
+                xp[col_base + svec_index(bn, i, j)] = scale * acc;
+            }
+        }
+    }
+
+    // e = b − A·x' over the coefficient-matching rows, summed in absolute value.
+    let mut ax = vec![0.0; qp.b.len()];
+    for t in &qp.a {
+        ax[t.row] += t.val * xp[t.col];
+    }
+    Some(qp.b.iter().zip(&ax).map(|(bi, axi)| (bi - axi).abs()).sum())
 }
 
 /// Build the SOS / Putinar SDP for `prob` at the given (clamped) order,
@@ -307,6 +601,19 @@ struct MomentInfo {
 /// solve (unlike pinning `L(p)=γ*`, which is degenerate when `γ*≈0`), and the
 /// recovered moment matrix is flat even when the optimum is non-unique. The
 /// reported bound still comes from the unperturbed solve.
+/// The smallest relaxation order that can represent `prob`: every polynomial
+/// must fit inside the degree-`2d` window, so `d ≥ ⌈deg/2⌉` for each of them.
+fn min_relaxation_order(prob: &PolyProblem) -> usize {
+    let mut d = prob.objective.degree().div_ceil(2);
+    for g in &prob.inequalities {
+        d = d.max(g.degree().div_ceil(2));
+    }
+    for h in &prob.equalities {
+        d = d.max(h.degree().div_ceil(2));
+    }
+    d
+}
+
 fn build_sos_sdp(
     prob: &PolyProblem,
     order: Option<usize>,
@@ -316,13 +623,7 @@ fn build_sos_sdp(
     let r2 = std::f64::consts::SQRT_2;
 
     // Minimum relaxation order, then honor a user-requested (larger) order.
-    let mut d_min = prob.objective.degree().div_ceil(2);
-    for g in &prob.inequalities {
-        d_min = d_min.max(g.degree().div_ceil(2));
-    }
-    for h in &prob.equalities {
-        d_min = d_min.max(h.degree().div_ceil(2));
-    }
+    let d_min = min_relaxation_order(prob);
     let d = order.map_or(d_min, |o| o.max(d_min));
     let basis0 = monomials(n, d); // σ₀ basis = moment-matrix index set
 
@@ -336,6 +637,7 @@ fn build_sos_sdp(
     // ordering — and hence the solver's floating-point path and results — varied
     // run-to-run (M22).
     let mut by_mono: BTreeMap<Vec<usize>, Vec<(usize, f64)>> = BTreeMap::new();
+    let mut psd_blocks: Vec<(usize, usize)> = Vec::new();
     let unit = [(vec![0usize; n], 1.0)]; // weight ≡ 1 for σ₀
 
     // PSD (SOS) blocks: σ₀ (weight 1, basis degree d), then one localizing
@@ -367,6 +669,7 @@ fn build_sos_sdp(
             g_h.push(0.0);
         }
         cones.push(ConeSpec::Psd(bn));
+        psd_blocks.push((col_base, bn));
         col += sd;
     }
 
@@ -439,6 +742,7 @@ fn build_sos_sdp(
             d,
             basis0,
             row_of,
+            psd_blocks,
         },
     )
 }
@@ -453,13 +757,15 @@ pub fn sos_constrained_lower_bound_opts<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    // Equilibrate coefficients before assembling the SDP (gh #124); undo the
-    // objective scale on the recovered bound.
-    let (prob, s_obj) = prob.equilibrated();
+    // Equilibrate coefficients and normalize the domain before assembling the
+    // SDP (gh #124, gh #218); undo the objective scale on the recovered bound.
+    // The change of variables is value-preserving, so no other correction is
+    // needed for a bound-only solve.
+    let (prob, resc) = prob.equilibrated();
     let (qp, cones, _moments) = build_sos_sdp(&prob, order, None);
     let sol = solve_socp_ipm(&qp, &cones, opts, make_backend);
     SosBound {
-        lower_bound: sol.x.first().copied().unwrap_or(f64::NEG_INFINITY) * s_obj,
+        lower_bound: sol.x.first().copied().unwrap_or(f64::NEG_INFINITY) * resc.s_obj,
         status: sol.status,
     }
 }
@@ -507,26 +813,117 @@ pub struct SosSolution {
     /// moment matrix is flat; recovered via the self-adjoint multiplication
     /// operators in the moment inner product (symmetric eigensolver only).
     pub minimizers: Vec<Vec<f64>>,
+    /// Whether `lower_bound` is **rigorous**: proved to be a true lower bound,
+    /// not merely accurate to the solver's tolerance.
+    ///
+    /// An uncertified bound is the raw `γ` the SDP reported. It is normally
+    /// correct to several digits, but it can — and on hard relaxations does —
+    /// land slightly *above* the true minimum, which makes it not a lower bound
+    /// at all. A certified bound has the identity's measured residual
+    /// subtracted, so it is valid no matter how the solve went.
+    ///
+    /// Certification requires the feasible set to lie in a box readable from
+    /// the constraints; it is `false` for an unbounded feasible set (an
+    /// unconstrained problem, say) where no finite correction can exist.
+    pub certified: bool,
+    /// The relaxation order that actually produced `lower_bound`.
+    ///
+    /// Normally the requested order. It is *lower* when that order failed to
+    /// converge and a coarser one did — see [`sos_minimize`], which falls back
+    /// rather than discard a bound it already proved. Always check this before
+    /// reading a converged result as a statement about the order you asked for.
+    pub order: usize,
 }
 
 /// Solve `prob` by the SOS/Lasserre relaxation **and** recover the solution
 /// from the moment matrix: certify exactness via flat truncation and extract
 /// the global minimizer when it is unique. See [`SosSolution`].
-pub fn sos_minimize<F>(prob: &PolyProblem, order: Option<usize>, mut make_backend: F) -> SosSolution
+///
+/// If the requested order does not converge, successively coarser orders are
+/// tried down to the minimum admissible one, and the first that converges is
+/// returned with its own [`order`](SosSolution::order). A bound from a lower
+/// order is a *valid* bound on the same problem — just a weaker one — so
+/// discarding it would throw away a certificate already computed (gh #218). The
+/// fallback costs extra solves only on a failure, and when nothing converges
+/// the requested order's own (non-converged) result is what comes back.
+pub fn sos_minimize<F>(prob: &PolyProblem, order: Option<usize>, make_backend: F) -> SosSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    let opts = sos_opts();
-    // Equilibrate coefficients before assembling the SDP (gh #124). The scaling
-    // is value- and minimizer-preserving (see `PolyProblem::equilibrated`): the
-    // recovered moments — and so `is_exact` and the extracted minimizers — are
-    // unchanged, and the bound is recovered by multiplying back by `s_obj`. The
-    // facial-reduction re-solve below also runs on the equilibrated problem.
-    let (prob, s_obj) = prob.equilibrated();
+    sos_minimize_opts(prob, order, &sos_opts(), make_backend)
+}
+
+/// [`sos_minimize`] with explicit solver options.
+///
+/// Only `tol` and `max_iter` are worth touching; the rest of [`QpOptions`] is
+/// fixed by [`sos_opts`] because a moment SDP needs the homogeneous self-dual
+/// embedding to stay conditioned. Loosening `tol` can rescue a relaxation that
+/// would otherwise not converge, at the cost of a weaker certificate — the
+/// bound stays *valid* either way when it is certified, since the certification
+/// slack measures the actual miss rather than assuming the solve converged.
+pub fn sos_minimize_opts<F>(
+    prob: &PolyProblem,
+    order: Option<usize>,
+    opts: &QpOptions,
+    mut make_backend: F,
+) -> SosSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    // Equilibrate coefficients and normalize the domain before assembling the
+    // SDP (gh #124, gh #218). The scaling is value- and minimizer-preserving
+    // (see `PolyProblem::equilibrated`), so `is_exact` and the extracted
+    // minimizers are unchanged; the bound is recovered by multiplying back by
+    // `s_obj` and the minimizers by `Rescaling::unmap`.
+    let (prob, resc) = prob.equilibrated();
     let prob = &prob;
+    let d_min = min_relaxation_order(prob);
+    let requested = order.map_or(d_min, |o| o.max(d_min));
+
+    let requested_result = sos_minimize_at(prob, &resc, requested, opts, &mut make_backend);
+    if requested_result.status == QpStatus::Optimal {
+        return requested_result;
+    }
+    for d in (d_min..requested).rev() {
+        let sol = sos_minimize_at(prob, &resc, d, opts, &mut make_backend);
+        if sol.status == QpStatus::Optimal {
+            return sol;
+        }
+    }
+    // Nothing converged: report the order the caller actually asked for, with
+    // its own verdict, exactly as it would have been without the fallback.
+    requested_result
+}
+
+/// One [`sos_minimize`] attempt at a fixed relaxation order `d`, on an
+/// already-equilibrated problem.
+fn sos_minimize_at<F>(
+    prob: &PolyProblem,
+    resc: &Rescaling,
+    d: usize,
+    opts: &QpOptions,
+    mut make_backend: F,
+) -> SosSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    let order = Some(d);
     let (qp, cones, mi) = build_sos_sdp(prob, order, None);
-    let sol = solve_socp_ipm(&qp, &cones, &opts, &mut make_backend);
-    let lower_bound = sol.x.first().copied().unwrap_or(f64::NEG_INFINITY) * s_obj;
+    let sol = solve_socp_ipm(&qp, &cones, opts, &mut make_backend);
+    let gamma = sol.x.first().copied().unwrap_or(f64::NEG_INFINITY);
+
+    // Make the bound rigorous where that is possible: subtract the measured
+    // miss in the SOS identity, so `lower_bound` is a true lower bound rather
+    // than one that merely converged (see `certified_slack`). Only the reported
+    // value moves — the moments, and hence exactness and the minimizers, are
+    // read from the unmodified solve.
+    let slack = if resc.boxed && sol.status == QpStatus::Optimal {
+        certified_slack(&qp, &mi, &sol.x)
+    } else {
+        None
+    };
+    let certified = slack.is_some();
+    let lower_bound = (gamma - slack.unwrap_or(0.0)) * resc.s_obj;
     if sol.status != QpStatus::Optimal {
         return SosSolution {
             lower_bound,
@@ -534,10 +931,12 @@ where
             is_exact: false,
             num_minimizers: 0,
             minimizers: Vec::new(),
+            certified: false,
+            order: d,
         };
     }
 
-    let mut rec = recover_from_moments(prob, &mi, &sol.y, lower_bound / s_obj);
+    let mut rec = recover_from_moments(prob, &mi, &sol.y, gamma);
 
     // Facial reduction. The interior-point solver lands on the analytic-center
     // (maximum-rank) optimal moment matrix, which is flat only when the optimum
@@ -550,11 +949,13 @@ where
     if !rec.is_exact {
         const TRACE_EPS: f64 = 1e-4;
         let (qp2, cones2, mi2) = build_sos_sdp(prob, order, Some(TRACE_EPS));
-        let sol2 = solve_socp_ipm(&qp2, &cones2, &opts, &mut make_backend);
+        let sol2 = solve_socp_ipm(&qp2, &cones2, opts, &mut make_backend);
         if sol2.status == QpStatus::Optimal {
-            // Validate the re-solve's atoms against the UNPERTURBED bound: the
-            // trace penalty changes the moment matrix, not the value being certified.
-            let rec2 = recover_from_moments(prob, &mi2, &sol2.y, lower_bound / s_obj);
+            // Validate the re-solve's atoms against the UNPERTURBED, uncertified
+            // `γ`: the trace penalty changes the moment matrix, not the value
+            // being certified, and the certification slack is a reporting
+            // correction that must not move the exactness test.
+            let rec2 = recover_from_moments(prob, &mi2, &sol2.y, gamma);
             if rec2.is_exact {
                 rec = rec2;
             }
@@ -564,9 +965,14 @@ where
     SosSolution {
         lower_bound,
         status: sol.status,
+        certified,
         is_exact: rec.is_exact,
         num_minimizers: rec.num_minimizers,
-        minimizers: rec.minimizers,
+        // Atoms are extracted in the normalized `u` coordinates the SDP was
+        // built in; report them in the caller's `x`. A no-op when no variable
+        // was boxed, since the map is then the identity.
+        minimizers: rec.minimizers.iter().map(|u| resc.unmap(u)).collect(),
+        order: d,
     }
 }
 
@@ -1127,6 +1533,357 @@ mod tests {
             (r.lower_bound - 1.0).abs() < 1e-5,
             "bound = {}",
             r.lower_bound
+        );
+    }
+
+    /// Lasserre, *SIAM J. Optim.* 11(3):796–817 (2001), Example 5 — the gh #218
+    /// constrained quartic. `min −x₁−x₂` over two quartics and the box
+    /// `[0,3]×[0,4]`; true global minimum −5.50801.
+    fn lasserre_ex5() -> PolyProblem {
+        let obj = Polynomial::new(2, vec![(vec![1, 0], -1.0), (vec![0, 1], -1.0)]);
+        let g1 = Polynomial::new(
+            2,
+            vec![
+                (vec![4, 0], 2.0),
+                (vec![3, 0], -8.0),
+                (vec![2, 0], 8.0),
+                (vec![0, 0], 2.0),
+                (vec![0, 1], -1.0),
+            ],
+        );
+        let g2 = Polynomial::new(
+            2,
+            vec![
+                (vec![4, 0], 4.0),
+                (vec![3, 0], -32.0),
+                (vec![2, 0], 88.0),
+                (vec![1, 0], -96.0),
+                (vec![0, 0], 36.0),
+                (vec![0, 1], -1.0),
+            ],
+        );
+        PolyProblem::new(obj)
+            .ge(g1)
+            .ge(g2)
+            .ge(Polynomial::new(2, vec![(vec![1, 0], 1.0)]))
+            .ge(Polynomial::new(
+                2,
+                vec![(vec![0, 0], 3.0), (vec![1, 0], -1.0)],
+            ))
+            .ge(Polynomial::new(2, vec![(vec![0, 1], 1.0)]))
+            .ge(Polynomial::new(
+                2,
+                vec![(vec![0, 0], 4.0), (vec![0, 1], -1.0)],
+            ))
+    }
+
+    #[test]
+    fn affine_substitute_preserves_values() {
+        // Substitution is only sound if the rewritten polynomial is the *same
+        // function* under the change of variables: q(u) = p(shift + scale·u).
+        // Check that pointwise on a polynomial with cross terms and a variable
+        // appearing at several degrees.
+        let p = Polynomial::new(
+            2,
+            vec![
+                (vec![3, 0], 2.0),
+                (vec![2, 1], -1.5),
+                (vec![1, 1], 4.0),
+                (vec![0, 2], 0.5),
+                (vec![1, 0], -3.0),
+                (vec![0, 0], 7.0),
+            ],
+        );
+        let shift = [1.5, -2.0];
+        let scale = [0.5, 3.0];
+        let q = p.affine_substitute(&shift, &scale);
+        for &(u0, u1) in &[
+            (0.0, 0.0),
+            (1.0, -1.0),
+            (-1.0, 1.0),
+            (0.37, 0.62),
+            (-0.8, -0.25),
+        ] {
+            let x = [shift[0] + scale[0] * u0, shift[1] + scale[1] * u1];
+            assert!(
+                (q.eval(&[u0, u1]) - p.eval(&x)).abs() < 1e-9,
+                "q({u0},{u1}) = {} but p({},{}) = {}",
+                q.eval(&[u0, u1]),
+                x[0],
+                x[1],
+                p.eval(&x)
+            );
+        }
+    }
+
+    #[test]
+    fn domain_normalization_reports_minimizers_in_original_coordinates() {
+        // gh #218. Domain normalization solves the SDP in `u ∈ [−1,1]²`, so a
+        // recovered atom must be mapped back or the caller silently receives a
+        // point in the wrong coordinate system.
+        //
+        // The boxes here are deliberately wide, off-center, and *different per
+        // variable* (x: [0,10] ⇒ shift 5 scale 5; y: [−5,1] ⇒ shift −2 scale 3),
+        // so a transposed or shared map lands visibly wrong rather than
+        // coincidentally right.
+        //
+        // min (x−8)² + (y+3)² s.t. x ∈ [0,10], y ∈ [−5,1] ⇒ min 0 at (8, −3),
+        // interior to the box so the box does not distort the optimum.
+        let obj = Polynomial::new(
+            2,
+            vec![
+                (vec![2, 0], 1.0),
+                (vec![1, 0], -16.0),
+                (vec![0, 2], 1.0),
+                (vec![0, 1], 6.0),
+                (vec![0, 0], 73.0),
+            ],
+        );
+        let prob = PolyProblem::new(obj)
+            .ge(Polynomial::new(2, vec![(vec![1, 0], 1.0)]))
+            .ge(Polynomial::new(
+                2,
+                vec![(vec![0, 0], 10.0), (vec![1, 0], -1.0)],
+            ))
+            .ge(Polynomial::new(
+                2,
+                vec![(vec![0, 1], 1.0), (vec![0, 0], 5.0)],
+            ))
+            .ge(Polynomial::new(
+                2,
+                vec![(vec![0, 0], 1.0), (vec![0, 1], -1.0)],
+            ));
+
+        let r = sos_minimize(&prob, None, backend);
+        assert_eq!(r.status, QpStatus::Optimal, "{:?}", r.status);
+        assert!(r.lower_bound.abs() < 1e-4, "bound = {}", r.lower_bound);
+        assert!(r.is_exact, "relaxation should be exact here");
+        assert_eq!(r.num_minimizers, 1);
+        let m = &r.minimizers[0];
+        assert!(
+            (m[0] - 8.0).abs() < 1e-3 && (m[1] + 3.0).abs() < 1e-3,
+            "minimizer {m:?} is not (8, -3) — coordinates left un-mapped?"
+        );
+    }
+
+    #[test]
+    fn lasserre_ex5_hierarchy_converges_to_the_global_minimum() {
+        // gh #218's acceptance criterion, verbatim: "a finite bound ≤ −5.50801,
+        // tightening toward it as the order rises."
+        //
+        // Every order must converge (no `nan`, no iteration limit), every bound
+        // must be a valid lower bound, the sequence must be monotone, and the
+        // hierarchy must actually reach the optimum rather than plateau.
+        const TRUE_MIN: f64 = -5.508013;
+        let prob = lasserre_ex5();
+        let mut prev = f64::NEG_INFINITY;
+        let mut bounds = Vec::new();
+        for order in [2usize, 3, 4] {
+            let r = sos_constrained_lower_bound(&prob, Some(order), backend);
+            assert_eq!(r.status, QpStatus::Optimal, "order {order}: {:?}", r.status);
+            // Soundness first: a lower bound may never exceed the true minimum.
+            assert!(
+                r.lower_bound <= TRUE_MIN + 1e-5,
+                "order {order}: bound {} exceeds the true minimum {TRUE_MIN}",
+                r.lower_bound
+            );
+            assert!(
+                r.lower_bound >= prev - 1e-6,
+                "order {order}: bound {} is looser than order {}'s {prev}",
+                r.lower_bound,
+                order - 1
+            );
+            prev = r.lower_bound;
+            bounds.push(r.lower_bound);
+        }
+        // Order 4 is where the hierarchy becomes exact for this problem; before
+        // the degenerate-face fix it stalled with no usable bound at all.
+        assert!(
+            (bounds[2] - TRUE_MIN).abs() < 1e-4,
+            "order 4 bound {} should reach the global minimum {TRUE_MIN}; got the sequence {bounds:?}",
+            bounds[2]
+        );
+        // And the hierarchy must genuinely tighten, not sit at the trivial box
+        // bound: order 2 is −7 (the quartics barely participate there).
+        assert!(
+            bounds[0] < bounds[1] - 1e-3 && bounds[1] < bounds[2] - 1e-3,
+            "hierarchy did not tighten: {bounds:?}"
+        );
+    }
+
+    #[test]
+    fn certified_bound_is_a_true_lower_bound_not_merely_an_accurate_one() {
+        // The soundness fix. A converged SDP reports a `γ` that is accurate but
+        // not necessarily *below* the minimum: on this problem at order 4 the
+        // raw value came back 2.2e-7 ABOVE the true minimum, which makes it not
+        // a lower bound at all — the one genuinely unsound failure mode for
+        // this API, and one no amount of solver tolerance removes.
+        //
+        // The certified value subtracts the SOS identity's measured miss, so it
+        // is valid however the solve went. `TRUE_MIN` here is not the issue's
+        // quoted figure but an independently computed one (400-start SLSQP),
+        // and the assertion is strict — no tolerance slack — because the whole
+        // point is that the bound must genuinely be below it.
+        const TRUE_MIN: f64 = -5.508013271595;
+        let prob = lasserre_ex5();
+        for order in [2usize, 3, 4, 5] {
+            let r = sos_minimize(&prob, Some(order), backend);
+            assert_eq!(r.status, QpStatus::Optimal, "order {order}");
+            assert!(
+                r.certified,
+                "order {order}: a fully boxed problem must certify"
+            );
+            assert!(
+                r.lower_bound <= TRUE_MIN,
+                "order {order}: certified bound {} is ABOVE the true minimum {TRUE_MIN} \
+                 — not a lower bound",
+                r.lower_bound
+            );
+            // Validity must not come from being uselessly loose: order 4 still
+            // has to land within 1e-4 of the optimum.
+            if order >= 4 {
+                assert!(
+                    r.lower_bound >= TRUE_MIN - 1e-4,
+                    "order {order}: bound {} is valid but far too loose",
+                    r.lower_bound
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn certification_is_withheld_when_the_domain_is_unbounded() {
+        // Certification rests on `|u^α| ≤ 1` over the feasible set, so it needs
+        // a box. Without one the residual polynomial cannot be bounded below at
+        // all, and claiming a certificate would be a lie — the flag must say so
+        // rather than the bound silently pretending.
+        let p = Polynomial::new(1, vec![(vec![2], 1.0), (vec![1], -4.0), (vec![0], 5.0)]);
+        let r = sos_minimize(&PolyProblem::new(p), None, backend);
+        assert_eq!(r.status, QpStatus::Optimal);
+        assert!(!r.certified, "an unconstrained problem cannot be certified");
+    }
+
+    #[test]
+    fn square_box_idiom_is_recognized_for_certification() {
+        // `1 − x² ≥ 0` is the idiomatic way to write a box in an SOS model, and
+        // bounds x just as surely as the linear pair does. Missing it would
+        // leave obviously-bounded textbook problems uncertifiable.
+        // min −x s.t. 1 − x² ≥ 0  ⇒  min = −1 at x = 1.
+        let prob = PolyProblem::new(Polynomial::new(1, vec![(vec![1], -1.0)]))
+            .ge(Polynomial::new(1, vec![(vec![0], 1.0), (vec![2], -1.0)]));
+        let r = sos_minimize(&prob, None, backend);
+        assert_eq!(r.status, QpStatus::Optimal);
+        assert!(r.certified, "the `c − a·x² ≥ 0` idiom should be recognized");
+        assert!(
+            r.lower_bound <= -1.0,
+            "certified bound {} is above the true minimum -1",
+            r.lower_bound
+        );
+        assert!(
+            r.lower_bound >= -1.0 - 1e-6,
+            "bound {} too loose",
+            r.lower_bound
+        );
+    }
+
+    #[test]
+    fn loosening_tol_costs_tightness_but_never_validity() {
+        // The knob gh #218 asked for. Loosening `tol` is the escape hatch for a
+        // relaxation that will not converge — and because certification measures
+        // the actual miss rather than trusting the solve, a sloppier solve buys
+        // a weaker bound, never an invalid one.
+        const TRUE_MIN: f64 = -5.508013271595;
+        let prob = lasserre_ex5();
+        let mut prev_gap = 0.0;
+        for tol in [1e-10, 1e-8, 1e-6] {
+            let opts = QpOptions { tol, ..sos_opts() };
+            let r = sos_minimize_opts(&prob, Some(4), &opts, backend);
+            assert_eq!(r.status, QpStatus::Optimal, "tol {tol:e}");
+            assert!(r.certified, "tol {tol:e}");
+            assert!(
+                r.lower_bound <= TRUE_MIN,
+                "tol {tol:e}: bound {} is above the true minimum",
+                r.lower_bound
+            );
+            // Looser tolerance ⇒ larger measured residual ⇒ looser bound.
+            let gap = TRUE_MIN - r.lower_bound;
+            assert!(
+                gap >= prev_gap,
+                "tol {tol:e}: gap {gap:e} should not be tighter than the stricter tolerance's {prev_gap:e}"
+            );
+            prev_gap = gap;
+        }
+    }
+
+    #[test]
+    fn a_failed_order_falls_back_to_a_coarser_proved_bound() {
+        // gh #218 suggestion 2. `sos_minimize` must not answer "no bound" at a
+        // high order when it already proved one at a lower order — a coarser
+        // bound is still valid, just weaker.
+        //
+        // Driven through the public entry point on a problem that converges at
+        // every order, so what is asserted is the contract that survives: the
+        // reported `order` identifies which relaxation produced the bound, and
+        // that bound is always valid.
+        let prob = lasserre_ex5();
+        for requested in [2usize, 3, 4] {
+            let r = sos_minimize(&prob, Some(requested), backend);
+            assert_eq!(r.status, QpStatus::Optimal, "order {requested}");
+            assert!(
+                r.order <= requested,
+                "reported order {} exceeds the requested {requested}",
+                r.order
+            );
+            assert!(
+                r.lower_bound <= -5.508013 + 1e-5,
+                "order {requested} (solved at {}): bound {} exceeds the true minimum",
+                r.order,
+                r.lower_bound
+            );
+        }
+    }
+
+    #[test]
+    fn requested_order_below_the_minimum_admissible_is_raised_not_rejected() {
+        // The fallback walks down to the minimum admissible order, so that
+        // floor has to be right: the quartic constraints force d >= 2, and
+        // asking for 1 must be silently raised rather than looping or building
+        // a degree-deficient SDP.
+        let prob = lasserre_ex5();
+        assert_eq!(min_relaxation_order(&prob), 2);
+        let r = sos_minimize(&prob, Some(1), backend);
+        assert_eq!(r.status, QpStatus::Optimal);
+        assert_eq!(
+            r.order, 2,
+            "order should be raised to the admissible minimum"
+        );
+    }
+
+    #[test]
+    fn degenerate_moment_sdp_converges_in_a_sane_iteration_count() {
+        // gh #218. This relaxation's moment SDP sits on a degenerate face. The
+        // affine direction points almost straight out of the PSD cone there, so
+        // Mehrotra's σ came back near zero — no centering, exactly where
+        // centering was needed — and the step collapsed geometrically until the
+        // iterate froze, burning the entire `max_iter` budget to change no digit
+        // of the objective.
+        //
+        // With the centering fallback it converges outright, so assert the
+        // strong property rather than the weak one: a real solve in a sane
+        // iteration count, nowhere near the budget it used to exhaust.
+        let (prob, _resc) = lasserre_ex5().equilibrated();
+        let (qp, cones, _mi) = build_sos_sdp(&prob, Some(3), None);
+        let opts = QpOptions {
+            max_iter: 5000,
+            ..sos_opts()
+        };
+        let sol = solve_socp_ipm(&qp, &cones, &opts, backend);
+        assert_eq!(sol.status, QpStatus::Optimal, "{:?}", sol.status);
+        assert!(
+            sol.iters < 100,
+            "took {} of {} iterations",
+            sol.iters,
+            opts.max_iter
         );
     }
 

--- a/crates/pounce-convex/tests/conic_hsde_vs_direct.rs
+++ b/crates/pounce-convex/tests/conic_hsde_vs_direct.rs
@@ -1,0 +1,339 @@
+//! Randomized differential test: the HSDE driver against the direct one, over
+//! second-order and semidefinite cones.
+//!
+//! The gh #218 centering fallback lives in the **HSDE** driver (`hsde.rs`),
+//! which serves the symmetric cones — orthant, second-order, PSD. Orthant
+//! coverage is strong already (the NETLIB LP and Maros–Mészáros QP benchmark
+//! suites run through it), and the exponential/power cones are untouched
+//! because they route to the separate non-symmetric driver. That leaves SOC and
+//! PSD, whose only coverage was a handful of closed-form instances.
+//!
+//! The direct symmetric driver (`use_hsde: false`, in `ipm.rs`) solves the same
+//! cones by an independent path that the change does not touch, which makes it
+//! a genuine reference rather than a self-comparison: the two drivers agree on
+//! the optimal value of any problem with a bounded optimum and a Slater point,
+//! so a disagreement is a real defect in one of them.
+//!
+//! Instances are generated so that both properties hold by construction — a
+//! strictly feasible point is planted, and every variable is boxed, so the
+//! feasible set is compact and nonempty. The RNG is a fixed-seed xorshift, so
+//! failures are reproducible and the suite is deterministic.
+
+use pounce_convex::{ConeSpec, QpOptions, QpProblem, QpStatus, Triplet, solve_socp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// xorshift64*, so the suite is deterministic and a failure is reproducible
+/// from its seed alone.
+struct Rng(u64);
+
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+    /// Uniform in `[-1, 1)`.
+    fn signed(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64 * 2.0 - 1.0
+    }
+    fn range(&mut self, lo: usize, hi: usize) -> usize {
+        lo + (self.next_u64() % (hi - lo + 1) as u64) as usize
+    }
+}
+
+const BOX: f64 = 10.0;
+
+/// A random conic program with a planted strictly feasible point and a compact
+/// feasible set.
+///
+/// Every variable carries `|xⱼ| ≤ BOX` as a pair of orthant rows, so the
+/// feasible set is bounded and the optimum is attained. The remaining cone
+/// blocks get their `h` set to `G·x₀ + s₀` for a random interior `s₀`, which
+/// makes `x₀` a Slater point. Both properties together are exactly the
+/// hypotheses under which the two drivers must agree.
+fn random_instance(rng: &mut Rng, n: usize, blocks: &[ConeSpec], m_eq: usize) -> QpProblem {
+    let x0: Vec<f64> = (0..n).map(|_| rng.signed() * 0.5 * BOX).collect();
+
+    // Equalities through the planted point: A x = A x₀.
+    let mut a = Vec::new();
+    let mut b = vec![0.0; m_eq];
+    for r in 0..m_eq {
+        for (j, x0j) in x0.iter().enumerate() {
+            let v = rng.signed();
+            if v.abs() > 0.3 {
+                a.push(Triplet::new(r, j, v));
+                b[r] += v * x0j;
+            }
+        }
+    }
+
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    let mut cones = Vec::new();
+
+    // Variable box as two orthant rows per variable: BOX ∓ xⱼ ≥ 0.
+    for j in 0..n {
+        let r = h.len();
+        g.push(Triplet::new(r, j, 1.0));
+        h.push(BOX);
+        let r = h.len();
+        g.push(Triplet::new(r, j, -1.0));
+        h.push(BOX);
+    }
+    cones.push(ConeSpec::Nonneg(2 * n));
+
+    for spec in blocks {
+        let dim = match spec {
+            ConeSpec::Nonneg(k) | ConeSpec::SecondOrder(k) => *k,
+            ConeSpec::Psd(k) => k * (k + 1) / 2,
+            // Exponential/power cones route to the non-symmetric driver, which
+            // this change does not touch, so they are out of scope here.
+            other => panic!("unsupported cone in this generator: {other:?}"),
+        };
+        let row0 = h.len();
+        // Random sparse G rows, then h = G·x₀ + s₀ with s₀ interior.
+        let mut gx0 = vec![0.0; dim];
+        for (i, gx) in gx0.iter_mut().enumerate() {
+            for (j, x0j) in x0.iter().enumerate() {
+                let v = rng.signed();
+                if v.abs() > 0.5 {
+                    g.push(Triplet::new(row0 + i, j, v));
+                    *gx += v * x0j;
+                }
+            }
+        }
+        let s0 = interior_point(rng, spec, dim);
+        for i in 0..dim {
+            h.push(gx0[i] + s0[i]);
+        }
+        cones.push(spec.clone());
+    }
+
+    QpProblem {
+        n,
+        p_lower: Vec::new(),
+        c: (0..n).map(|_| rng.signed()).collect(),
+        a,
+        b,
+        g,
+        h,
+        lb: Vec::new(),
+        ub: Vec::new(),
+    }
+}
+
+/// A point strictly inside `spec` — the planted slack `s₀`, which is what makes
+/// the generated instance Slater-feasible.
+fn interior_point(rng: &mut Rng, spec: &ConeSpec, dim: usize) -> Vec<f64> {
+    match spec {
+        ConeSpec::Nonneg(_) => (0..dim).map(|_| 1.0 + rng.signed().abs()).collect(),
+        ConeSpec::SecondOrder(_) => {
+            // (t, v) with t > ‖v‖: build v, then set t above its norm.
+            let mut s = vec![0.0; dim];
+            let mut nrm = 0.0;
+            for si in s.iter_mut().skip(1) {
+                *si = rng.signed();
+                nrm += *si * *si;
+            }
+            s[0] = nrm.sqrt() + 1.0 + rng.signed().abs();
+            s
+        }
+        ConeSpec::Psd(k) => {
+            // svec of `L Lᵀ + 2I`, which is positive definite by construction.
+            let k = &(*k);
+            let l: Vec<f64> = (0..k * k).map(|_| rng.signed()).collect();
+            let mut m = vec![0.0; k * k];
+            for i in 0..*k {
+                for j in 0..*k {
+                    let mut acc = 0.0;
+                    for p in 0..*k {
+                        acc += l[i * k + p] * l[j * k + p];
+                    }
+                    m[i * k + j] = acc + if i == j { 2.0 } else { 0.0 };
+                }
+            }
+            // svec: lower triangle column by column, off-diagonals × √2.
+            let r2 = std::f64::consts::SQRT_2;
+            let mut s = Vec::with_capacity(dim);
+            for j in 0..*k {
+                for i in j..*k {
+                    s.push(if i == j {
+                        m[i * k + j]
+                    } else {
+                        r2 * m[i * k + j]
+                    });
+                }
+            }
+            s
+        }
+        other => panic!("unsupported cone in this generator: {other:?}"),
+    }
+}
+
+fn solve(prob: &QpProblem, cones: &[ConeSpec], use_hsde: bool) -> pounce_convex::QpSolution {
+    let opts = QpOptions {
+        use_hsde,
+        max_iter: 500,
+        ..QpOptions::default()
+    };
+    solve_socp_ipm(prob, cones, &opts, backend)
+}
+
+/// Run `count` random instances of the given shape through both drivers and
+/// require they agree on the optimal value.
+fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng) -> Vec<ConeSpec>) {
+    let mut rng = Rng(seed);
+    let (mut compared, mut hsde_only, mut direct_only) = (0usize, 0usize, 0usize);
+    let mut reference_unusable = 0usize;
+    for case in 0..count {
+        let blocks = shape(&mut rng);
+        let n = rng.range(3, 8);
+        let m_eq = rng.range(0, 2);
+        let prob = random_instance(&mut rng, n, &blocks, m_eq);
+        let mut cones = vec![ConeSpec::Nonneg(2 * n)];
+        cones.extend(blocks.iter().cloned());
+
+        let a = solve(&prob, &cones, true);
+        let b = solve(&prob, &cones, false);
+
+        match (a.status, b.status) {
+            (QpStatus::Optimal, QpStatus::Optimal) => {
+                // The HSDE driver — the one this change touches — must never
+                // claim optimality with a garbage value.
+                assert!(
+                    a.obj.is_finite(),
+                    "{name} case {case}: HSDE reported Optimal with a non-finite objective {}",
+                    a.obj
+                );
+                // The *direct* driver can (pre-existing defect, reproduced on an
+                // unmodified tree: it returns `Optimal` with `obj = NaN` on some
+                // mixed SOC+PSD instances). Where the reference is unusable there
+                // is nothing to compare against, so count it and move on rather
+                // than blame this change for it.
+                if !b.obj.is_finite() {
+                    reference_unusable += 1;
+                    continue;
+                }
+                compared += 1;
+                let scale = 1.0_f64.max(a.obj.abs()).max(b.obj.abs());
+                assert!(
+                    (a.obj - b.obj).abs() <= 1e-6 * scale,
+                    "{name} case {case}: HSDE obj {} vs direct obj {} (n={n}, m_eq={m_eq}, cones={cones:?})",
+                    a.obj,
+                    b.obj
+                );
+            }
+            // A driver that solves one the other cannot is an improvement, not
+            // a regression — but count them so a shape that silently stopped
+            // solving anything cannot masquerade as agreement.
+            (QpStatus::Optimal, _) => hsde_only += 1,
+            (_, QpStatus::Optimal) => direct_only += 1,
+            _ => {}
+        }
+    }
+    // Guard the premise: if the generator drifted into producing problems
+    // neither driver solves, every assertion above would vacuously pass.
+    assert!(
+        compared * 4 >= count * 3,
+        "{name}: only {compared}/{count} instances were solved by both drivers \
+         (hsde-only {hsde_only}, direct-only {direct_only}, reference unusable \
+         {reference_unusable}) — too few to be evidence"
+    );
+    println!(
+        "{name}: {compared}/{count} compared, hsde-only {hsde_only}, \
+         direct-only {direct_only}, reference-unusable {reference_unusable}"
+    );
+}
+
+#[test]
+fn second_order_cones_agree_across_drivers() {
+    agree_on("soc", 0x5EED_1234, 120, |rng| {
+        let k = rng.range(1, 3);
+        (0..k)
+            .map(|_| ConeSpec::SecondOrder(rng.range(2, 6)))
+            .collect()
+    });
+}
+
+#[test]
+fn psd_cones_agree_across_drivers() {
+    agree_on("psd", 0xBEEF_0001, 80, |rng| {
+        vec![ConeSpec::Psd(rng.range(2, 5))]
+    });
+}
+
+#[test]
+fn mixed_soc_and_psd_cones_agree_across_drivers() {
+    agree_on("mixed", 0xC0FFEE_02, 80, |rng| {
+        vec![
+            ConeSpec::SecondOrder(rng.range(2, 5)),
+            ConeSpec::Psd(rng.range(2, 4)),
+        ]
+    });
+}
+
+/// The degenerate tier: a planted slack sitting *on* the cone boundary rather
+/// than strictly inside it, which is the regime the gh #218 centering fallback
+/// exists for. Slater no longer holds, so the two drivers may legitimately
+/// disagree on which optimal point they return — but when both converge they
+/// must still agree on the optimal *value*.
+#[test]
+fn boundary_hugging_instances_agree_across_drivers() {
+    let mut rng = Rng(0xDEAD_BEEF);
+    let mut compared = 0usize;
+    for case in 0..80 {
+        let n = rng.range(3, 6);
+        let blocks = vec![ConeSpec::Psd(rng.range(2, 4))];
+        let m_eq = rng.range(0, 1);
+        let mut prob = random_instance(&mut rng, n, &blocks, m_eq);
+        // Pull the planted PSD slack onto the boundary: drop `h` by the 2I that
+        // `interior_point` added, leaving a singular (rank-deficient) slack.
+        let base = 2 * n;
+        if let ConeSpec::Psd(k) = blocks[0] {
+            let mut idx = base;
+            for j in 0..k {
+                for i in j..k {
+                    if i == j {
+                        prob.h[idx] -= 2.0;
+                    }
+                    idx += 1;
+                }
+            }
+        }
+        let mut cones = vec![ConeSpec::Nonneg(2 * n)];
+        cones.extend(blocks.iter().cloned());
+
+        let a = solve(&prob, &cones, true);
+        let b = solve(&prob, &cones, false);
+        if a.status == QpStatus::Optimal && b.status == QpStatus::Optimal {
+            assert!(
+                a.obj.is_finite(),
+                "degenerate case {case}: HSDE reported Optimal with a non-finite objective"
+            );
+            if !b.obj.is_finite() {
+                continue;
+            }
+            compared += 1;
+            let scale = 1.0_f64.max(a.obj.abs()).max(b.obj.abs());
+            assert!(
+                (a.obj - b.obj).abs() <= 1e-5 * scale,
+                "degenerate case {case}: HSDE obj {} vs direct obj {}",
+                a.obj,
+                b.obj
+            );
+        }
+    }
+    assert!(
+        compared >= 20,
+        "only {compared}/80 degenerate instances solved by both — too few to be evidence"
+    );
+    println!("degenerate: {compared}/80 compared");
+}

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -684,4 +684,28 @@ impl PyQpSensitivity {
     fn kkt_dim(&self) -> usize {
         self.inner.kkt_dim()
     }
+
+    /// Inequality rows (indices into `G`) in the active set.
+    #[getter]
+    fn active_inequalities(&self) -> Vec<usize> {
+        self.inner.active_ineq().to_vec()
+    }
+
+    /// Variables whose bound is in the active set.
+    #[getter]
+    fn active_bounds(&self) -> Vec<usize> {
+        self.inner.active_bound_vars().to_vec()
+    }
+
+    /// Inequality rows at which strict complementarity fails.
+    #[getter]
+    fn weakly_active_inequalities(&self) -> Vec<usize> {
+        self.inner.weakly_active_ineq().to_vec()
+    }
+
+    /// Variables whose bound is weakly active.
+    #[getter]
+    fn weakly_active_bounds(&self) -> Vec<usize> {
+        self.inner.weakly_active_bound_vars().to_vec()
+    }
 }

--- a/crates/pounce-py/src/sos.rs
+++ b/crates/pounce-py/src/sos.rs
@@ -8,7 +8,9 @@
 //! handled in `python/pounce/sos.py`.
 
 use numpy::IntoPyArray;
-use pounce_convex::{PolyProblem, Polynomial, QpStatus, sos_minimize as core_sos_minimize};
+use pounce_convex::{
+    PolyProblem, Polynomial, QpStatus, sos_minimize_opts as core_sos_minimize, sos_opts,
+};
 use pounce_feral::FeralSolverInterface;
 use pounce_linsol::SparseSymLinearSolverInterface;
 use pyo3::exceptions::PyValueError;
@@ -45,11 +47,12 @@ fn poly(n_vars: usize, terms: Vec<(Vec<usize>, f64)>, what: &str) -> PyResult<Po
 }
 
 /// Globally minimize a polynomial via the SOS/Lasserre relaxation. Returns a
-/// dict with `lower_bound`, `status`, `is_exact`, `num_minimizers`, and
+/// dict with `lower_bound`, `status`, `is_exact`, `num_minimizers`,
 /// `minimizers` (a list of length-`n_vars` arrays — the global optimizers,
-/// populated when the moment matrix is flat).
+/// populated when the moment matrix is flat), `certified`, and `order`.
 #[pyfunction]
-#[pyo3(signature = (n_vars, objective, inequalities=vec![], equalities=vec![], order=None))]
+#[pyo3(signature = (n_vars, objective, inequalities=vec![], equalities=vec![], order=None, tol=None, max_iter=None))]
+#[allow(clippy::too_many_arguments)]
 pub fn sos_minimize<'py>(
     py: Python<'py>,
     n_vars: usize,
@@ -57,6 +60,8 @@ pub fn sos_minimize<'py>(
     inequalities: Vec<Vec<(Vec<usize>, f64)>>,
     equalities: Vec<Vec<(Vec<usize>, f64)>>,
     order: Option<usize>,
+    tol: Option<f64>,
+    max_iter: Option<usize>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let mut prob = PolyProblem::new(poly(n_vars, objective, "objective")?);
     prob.inequalities = inequalities
@@ -68,13 +73,32 @@ pub fn sos_minimize<'py>(
         .map(|t| poly(n_vars, t, "equality"))
         .collect::<PyResult<_>>()?;
 
-    let sol = py.allow_threads(|| core_sos_minimize(&prob, order, backend));
+    let mut opts = sos_opts();
+    if let Some(t) = tol {
+        if !t.is_finite() || t <= 0.0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "sos_minimize: `tol` must be positive",
+            ));
+        }
+        opts.tol = t;
+    }
+    if let Some(m) = max_iter {
+        if m == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "sos_minimize: `max_iter` must be at least 1",
+            ));
+        }
+        opts.max_iter = m;
+    }
+    let sol = py.allow_threads(|| core_sos_minimize(&prob, order, &opts, backend));
 
     let d = PyDict::new_bound(py);
     d.set_item("lower_bound", sol.lower_bound)?;
     d.set_item("status", status_str(sol.status))?;
     d.set_item("is_exact", sol.is_exact)?;
     d.set_item("num_minimizers", sol.num_minimizers)?;
+    d.set_item("order", sol.order)?;
+    d.set_item("certified", sol.certified)?;
     let mins = PyList::empty_bound(py);
     for m in sol.minimizers {
         mins.append(m.into_pyarray_bound(py))?;

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -36,6 +36,7 @@ from ._critical import (
     CriticalPoint, CriticalPointResult, Connection, ReactionNetwork,
 )
 from .qp import (
+    ActiveSet,
     QpResult,
     QpFactorization,
     QpSensitivity,
@@ -82,6 +83,7 @@ __all__ = [
     "project_to_feasible",
     "race_starts",
     # Convex QP / SOCP (the same solvers also live under ``pounce.qp``)
+    "ActiveSet",
     "QpResult",
     "QpFactorization",
     "QpSensitivity",

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -39,13 +39,14 @@ from __future__ import annotations
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Tuple
 
 import numpy as np
 
 from . import _pounce
 
 __all__ = [
+    "ActiveSet",
     "QpResult",
     "QpFactorization",
     "QpSensitivity",
@@ -176,6 +177,31 @@ class ReducedHessian:
     def is_positive_definite(self) -> bool:
         """Whether every eigenvalue is positive (strict second-order min)."""
         return self.n_dof == 0 or bool(self.eigenvalues[0] > 0.0)
+
+
+@dataclass(frozen=True)
+class ActiveSet:
+    """Which constraints of a QP are active at the optimum.
+
+    The two index spaces are distinct and are kept separate deliberately:
+    ``inequalities`` indexes rows of ``G``, ``bounds`` indexes *variables*.
+
+    Attributes
+    ----------
+    inequalities:
+        Row indices of ``G`` whose constraint is active.
+    bounds:
+        Indices of variables whose lower or upper bound is active.
+    """
+
+    inequalities: Tuple[int, ...]
+    bounds: Tuple[int, ...]
+
+    def __len__(self) -> int:
+        return len(self.inequalities) + len(self.bounds)
+
+    def __bool__(self) -> bool:
+        return len(self) > 0
 
 
 def _coo(mat, n_cols: int, what: str):
@@ -775,8 +801,65 @@ class QpSensitivity:
 
     @property
     def kkt_dim(self) -> int:
-        """Active-set KKT dimension ``n + m_eq + n_active``."""
+        """Active-set KKT dimension ``n + m_eq + n_active``.
+
+        Since ``n_active = kkt_dim − n − m_eq``, a change in this value across
+        a parameter sweep signals that the active set changed — and so that the
+        :meth:`parametric_step` predictor's precondition was crossed somewhere
+        in the sweep. :attr:`active_indices` reports the same thing by identity
+        rather than by count, and :attr:`weakly_active_indices` catches the
+        harder case where the count does not move at all.
+        """
         return int(self._inner.kkt_dim)
+
+    @property
+    def active_indices(self) -> ActiveSet:
+        """Which constraints are in the active set at the optimum.
+
+        The active set is read from the dual certificate, using the
+        ``active_tol`` passed to the constructor.
+        """
+        return ActiveSet(
+            inequalities=tuple(self._inner.active_inequalities),
+            bounds=tuple(self._inner.active_bounds),
+        )
+
+    @property
+    def weakly_active_indices(self) -> ActiveSet:
+        """Constraints at which **strict complementarity fails**.
+
+        A weakly active constraint is binding in the primal while carrying a
+        negligible multiplier. Classical post-optimal sensitivity (Fiacco)
+        assumes this does not happen; where it does, the perturbation changes
+        the active set and :meth:`parametric_step` returns a genuine *one-sided*
+        derivative — the other direction has a different, equally correct value.
+
+        Nothing returned by :meth:`parametric_step` is wrong when this is
+        non-empty; both branches are real derivatives. What it means is that the
+        predictor should not be assumed to extrapolate in both directions. Probe
+        the direction you actually care about.
+
+        This is the check :attr:`kkt_dim` cannot provide. On the QP below the
+        two branches of ``dx/db`` differ by 33%, and which one is reported turns
+        on the solver's ``tol`` — an unrelated setting. ``kkt_dim`` flips 4 → 3
+        across that change while this flag stays on throughout.
+
+        Example
+        -------
+        >>> import numpy as np
+        >>> from pounce.qp import QpSensitivity
+        >>> # min ½‖x‖² s.t. x0 + x1 = 1, x0 − 2x1 ≤ −½.
+        >>> # The equality-only optimum (½, ½) hits the inequality exactly.
+        >>> s = QpSensitivity(P=np.eye(2), c=[0.0, 0.0],
+        ...                   A=[[1.0, 1.0]], b=[1.0],
+        ...                   G=[[1.0, -2.0]], h=[-0.5])
+        >>> s.weakly_active_indices.inequalities
+        (0,)
+        """
+        return ActiveSet(
+            inequalities=tuple(self._inner.weakly_active_inequalities),
+            bounds=tuple(self._inner.weakly_active_bounds),
+        )
 
     def parametric_step(self, pin_constraint_indices, deltas) -> np.ndarray:
         """First-order primal step ``dx ≈ x*(b + Δb) − x*(b)``.
@@ -787,6 +870,11 @@ class QpSensitivity:
         the perturbed solution (exact to first order while the active set is
         unchanged). The factorization is reused, so a continuation sweep
         costs one back-substitution per query.
+
+        The "while the active set is unchanged" precondition is checkable:
+        :attr:`weakly_active_indices` reports where it fails at this optimum,
+        which is where ``dx`` is a one-sided derivative rather than the
+        derivative. See that property for what to do about it.
         """
         pins = [int(i) for i in pin_constraint_indices]
         ds = [float(d) for d in deltas]

--- a/python/pounce/sos.py
+++ b/python/pounce/sos.py
@@ -91,6 +91,27 @@ class SosResult:
     minimizers:
         The extracted global minimizers, each a length-``n_vars`` array.
         Populated when ``is_exact``.
+    certified:
+        Whether ``lower_bound`` is **rigorous** — proved to be a true lower
+        bound, not merely accurate to the solver's tolerance. An uncertified
+        bound is the raw value the SDP reported; it is normally correct to
+        several digits but can land slightly *above* the true minimum, which
+        would make it not a lower bound at all. A certified bound has the
+        measured miss in the SOS identity subtracted, so it is valid however
+        the solve went.
+
+        Certification needs the feasible set to lie in a box readable off the
+        constraints (``x >= l`` / ``x <= u`` pairs, or the ``c - a*x**2 >= 0``
+        idiom). It is ``False`` on an unbounded feasible set — an
+        unconstrained problem, say — where no finite correction exists. Adding
+        explicit box constraints you know contain the minimizer upgrades such
+        a problem to a certified bound.
+    order:
+        The relaxation order that produced ``lower_bound``. Normally the order
+        requested, but *lower* when that order failed to converge and a coarser
+        one did — a coarser bound is still a valid bound, so it is reported
+        rather than discarded. Check this before reading a converged result as
+        a statement about the order you asked for.
     """
 
     lower_bound: float
@@ -98,6 +119,8 @@ class SosResult:
     is_exact: bool
     num_minimizers: int
     minimizers: list
+    certified: bool
+    order: int
 
     @property
     def success(self) -> bool:
@@ -135,6 +158,8 @@ def sos_minimize(
     equalities: Sequence = (),
     n_vars: Optional[int] = None,
     order: Optional[int] = None,
+    tol: Optional[float] = None,
+    max_iter: Optional[int] = None,
 ) -> SosResult:
     """Globally minimize ``objective`` subject to ``gᵢ ≥ 0`` (``inequalities``)
     and ``hⱼ = 0`` (``equalities``) via the SOS/Lasserre relaxation.
@@ -143,6 +168,13 @@ def sos_minimize(
     docstring). ``n_vars`` is inferred from the exponent tuples if omitted.
     ``order`` raises the relaxation order above the minimum to tighten the
     bound (the Lasserre hierarchy). Returns an :class:`SosResult`.
+
+    ``tol`` and ``max_iter`` override the underlying SDP solver's convergence
+    tolerance (default ``1e-8``) and iteration cap (default ``200``). They are
+    an escape hatch for a relaxation that will not converge: loosening ``tol``
+    trades certificate strength for convergence. Loosening it cannot make the
+    answer *unsound* when ``certified`` is set, because the certification
+    subtracts the identity's measured miss rather than trusting the solve.
     """
     _check_poly(objective, "objective")
     for g in inequalities:
@@ -156,7 +188,9 @@ def sos_minimize(
     obj = _terms(objective, n_vars, "objective")
     ineq = [_terms(g, n_vars, "inequality") for g in inequalities]
     eq = [_terms(h, n_vars, "equality") for h in equalities]
-    d = _pounce.sos_minimize(n_vars, obj, ineq, eq, order=order)
+    d = _pounce.sos_minimize(
+        n_vars, obj, ineq, eq, order=order, tol=tol, max_iter=max_iter
+    )
     status = d["status"]
     # On a failed/non-optimal relaxation the raw bound is meaningless (it can be
     # ~5e9 for a problem whose minimum is 1.0); report NaN so a garbage bound
@@ -168,4 +202,6 @@ def sos_minimize(
         is_exact=bool(d["is_exact"]),
         num_minimizers=int(d["num_minimizers"]),
         minimizers=[np.asarray(m) for m in d["minimizers"]],
+        certified=bool(d["certified"]),
+        order=int(d["order"]),
     )

--- a/python/tests/test_qp_sensitivity.py
+++ b/python/tests/test_qp_sensitivity.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 
 import pounce
-from pounce.qp import QpSensitivity, ReducedHessian, solve_qp
+from pounce.qp import ActiveSet, QpSensitivity, ReducedHessian, solve_qp
 
 
 def test_top_level_export():
@@ -247,3 +247,98 @@ def _timed(fn):
     t0 = time.perf_counter()
     fn()
     return time.perf_counter() - t0
+
+
+# --- weak activity / non-strict complementarity (gh #219) -------------------
+
+
+def _degenerate_qp(h, **kw):
+    """min ½‖x‖² s.t. x0 + x1 = 1, x0 − 2x1 ≤ h.
+
+    At h = −½ the equality-only optimum (½, ½) hits the inequality exactly,
+    so strict complementarity fails and dx/db is one-sided.
+    """
+    return QpSensitivity(
+        P=np.eye(2),
+        c=[0.0, 0.0],
+        A=[[1.0, 1.0]],
+        b=[1.0],
+        G=[[1.0, -2.0]],
+        h=[h],
+        **kw,
+    )
+
+
+def test_active_set_exports():
+    assert pounce.ActiveSet is ActiveSet
+
+
+def test_active_indices_reports_membership_by_identity():
+    # h = −0.9: the inequality binds strictly (multiplier ~8.9e-2).
+    s = _degenerate_qp(-0.9)
+    assert s.active_indices.inequalities == (0,)
+    assert s.active_indices.bounds == ()
+    # And the count still agrees with what kkt_dim encodes: n + m_eq + n_active.
+    assert s.kkt_dim == 2 + 1 + len(s.active_indices)
+
+
+def test_inactive_constraint_is_not_in_the_active_set():
+    # h = 0.5: slack at the optimum.
+    s = _degenerate_qp(0.5)
+    assert s.active_indices.inequalities == ()
+    assert not s.active_indices
+
+
+def test_weakly_active_detected_regardless_of_tol():
+    # The gh #219 gap. dx/db is two-valued here — (2/3, 1/3) vs (1/2, 1/2),
+    # 33% apart — and which branch parametric_step reports depends on `tol`,
+    # an unrelated setting. kkt_dim flips 4 -> 3 across the sweep; the weak
+    # flag must stay on throughout, since the geometry never changed.
+    seen_dims = set()
+    for tol in (None, 1e-12, 1e-14):
+        s = _degenerate_qp(-0.5, tol=tol)
+        assert s.weakly_active_indices.inequalities == (0,), f"missed at tol={tol}"
+        seen_dims.add(s.kkt_dim)
+    # Guards the premise: if the sweep stopped straddling the active-set
+    # boundary this test would pass while demonstrating nothing.
+    assert seen_dims == {3, 4}, f"sweep no longer straddles the boundary: {seen_dims}"
+
+
+@pytest.mark.parametrize("h", [-0.9, 0.5])
+def test_strictly_complementary_is_not_flagged_weak(h):
+    # False-positive guard: a screen that fired on every active constraint,
+    # or on every small multiplier, would pass the test above and be useless.
+    s = _degenerate_qp(h)
+    assert s.weakly_active_indices.inequalities == ()
+    assert not s.weakly_active_indices
+
+
+def test_weakly_active_matches_the_one_sided_branches():
+    # Ground the flag in the behaviour it warns about: the predictor really
+    # does disagree with the two sides of a finite difference here.
+    s = _degenerate_qp(-0.5, tol=1e-12)
+    assert s.weakly_active_indices.inequalities == (0,)
+    dx = s.parametric_step([0], [1.0])
+
+    # A finite difference at a degenerate optimum needs care: too small a step
+    # and the solve error swamps the perturbation, returning the *average* of
+    # the two branches (~(0.583, 0.417)) — an artifact, not a third branch. Use
+    # a tight solve tol and a step no smaller than 1e-3.
+    delta = 1e-3
+
+    def at(b):
+        return solve_qp(
+            P=np.eye(2), c=[0.0, 0.0], A=[[1.0, 1.0]], b=[b],
+            G=[[1.0, -2.0]], h=[-0.5], tol=1e-12,
+        ).x
+
+    fwd = (at(1.0 + delta) - s.x) / delta
+    bwd = (s.x - at(1.0 - delta)) / delta
+    # The two one-sided derivatives are genuinely different: (½,½) vs (⅔,⅓).
+    np.testing.assert_allclose(fwd, [0.5, 0.5], atol=5e-3)
+    np.testing.assert_allclose(bwd, [2 / 3, 1 / 3], atol=5e-3)
+    # The predictor matches exactly one of them — it is one-sided, and it is
+    # not the average of the two.
+    matches_fwd = np.allclose(dx, fwd, atol=5e-3)
+    matches_bwd = np.allclose(dx, bwd, atol=5e-3)
+    assert matches_fwd != matches_bwd, f"dx={dx} fwd={fwd} bwd={bwd}"

--- a/python/tests/test_sos.py
+++ b/python/tests/test_sos.py
@@ -101,3 +101,133 @@ def test_explicit_n_vars_and_order():
 def test_mismatched_exponent_length_raises():
     with pytest.raises(ValueError):
         sos_minimize({(2, 0): 1.0, (1,): -2.0})  # inconsistent tuple lengths
+
+
+# --- constrained quartic hierarchy (gh #218) --------------------------------
+
+
+def _lasserre_ex5():
+    """Lasserre, SIAM J. Optim. 11(3):796-817 (2001), Example 5.
+
+    min -x1 - x2 over two quartic constraints and the box [0,3]x[0,4].
+    Known global minimum -5.50801 at (2.3295, 3.1783).
+    """
+    obj = {(1, 0): -1.0, (0, 1): -1.0}
+    g = [
+        {(4, 0): 2.0, (3, 0): -8.0, (2, 0): 8.0, (0, 0): 2.0, (0, 1): -1.0},
+        {(4, 0): 4.0, (3, 0): -32.0, (2, 0): 88.0, (1, 0): -96.0, (0, 0): 36.0,
+         (0, 1): -1.0},
+        {(1, 0): 1.0},
+        {(0, 0): 3.0, (1, 0): -1.0},
+        {(0, 1): 1.0},
+        {(0, 0): 4.0, (0, 1): -1.0},
+    ]
+    return obj, g
+
+
+TRUE_MIN = -5.508013271595  # independently verified, 400-start SLSQP
+
+
+def test_constrained_quartic_hierarchy_tightens_to_the_global_minimum():
+    # The acceptance criterion from gh #218, verbatim: "a finite bound
+    # <= -5.50801, tightening toward it as the order rises." Previously
+    # order 2 returned the trivial box bound -7 and orders 3/4 returned nan.
+    obj, g = _lasserre_ex5()
+    bounds = []
+    for order in (2, 3, 4):
+        r = sos_minimize(obj, inequalities=g, order=order)
+        assert r.success, f"order {order}: status {r.status}"
+        assert np.isfinite(r.lower_bound), f"order {order}: bound is not finite"
+        # Soundness, asserted strictly: the bound is certified, so it must
+        # genuinely lie below the true minimum -- no tolerance slack.
+        assert r.certified, f"order {order}: a boxed problem must certify"
+        assert r.lower_bound <= TRUE_MIN, f"order {order}: {r.lower_bound}"
+        bounds.append(r.lower_bound)
+    # Monotone and genuinely tightening, not stuck at the trivial box bound.
+    assert bounds[0] < bounds[1] < bounds[2], bounds
+    assert abs(bounds[0] + 7.0) < 1e-4, "order 2 is the trivial box bound"
+    assert abs(bounds[2] - TRUE_MIN) < 1e-4, f"order 4 should be exact: {bounds[2]}"
+    assert bounds[0] <= TRUE_MIN and bounds[1] <= TRUE_MIN
+
+
+def test_constrained_quartic_order_four_extracts_the_minimizer():
+    # At order 4 the relaxation is exact, so the global minimizer comes back too.
+    obj, g = _lasserre_ex5()
+    r = sos_minimize(obj, inequalities=g, order=4)
+    assert r.success and r.is_exact
+    assert r.num_minimizers >= 1
+    x = r.minimizers[0]
+    np.testing.assert_allclose(x, [2.3295, 3.1783], atol=1e-3)
+
+
+def test_reported_order_identifies_the_relaxation_that_produced_the_bound():
+    # A bound from a coarser order is still valid, so sos_minimize falls back
+    # rather than discarding one it already proved -- and `order` says which
+    # relaxation the reported bound actually came from.
+    obj, g = _lasserre_ex5()
+    for requested in (2, 3, 4):
+        r = sos_minimize(obj, inequalities=g, order=requested)
+        assert r.order <= requested
+        assert r.lower_bound <= TRUE_MIN
+    # Below the minimum admissible order (the quartics force d >= 2), the
+    # request is raised rather than rejected.
+    r = sos_minimize(obj, inequalities=g, order=1)
+    assert r.success and r.order == 2
+
+
+# --- certification and solver controls (gh #218 caveats) --------------------
+
+
+def test_certified_bound_is_below_the_true_minimum():
+    # A converged SDP reports a value that is accurate but not necessarily a
+    # lower *bound*: the raw order-4 value landed 2.2e-7 ABOVE the true
+    # minimum. The certified value subtracts the SOS identity's measured miss,
+    # so it is valid regardless of how the solve went.
+    obj, g = _lasserre_ex5()
+    r = sos_minimize(obj, inequalities=g, order=4)
+    assert r.certified
+    assert r.lower_bound <= TRUE_MIN, r.lower_bound
+    # Valid, and not uselessly loose.
+    assert r.lower_bound >= TRUE_MIN - 1e-4, r.lower_bound
+
+
+def test_certification_withheld_on_an_unbounded_domain():
+    # Certification needs the feasible set inside a box; without one the
+    # residual cannot be bounded, so the flag must report the truth rather
+    # than the bound silently pretending.
+    r = sos_minimize({(4,): 1.0, (2,): -2.0, (0,): 3.0})
+    assert r.success
+    assert not r.certified
+
+
+def test_square_box_idiom_is_certified():
+    # min -x s.t. 1 - x**2 >= 0  =>  min = -1. The quadratic form is the
+    # idiomatic way to write a box in an SOS model.
+    r = sos_minimize({(1,): -1.0}, inequalities=[{(0,): 1.0, (2,): -1.0}])
+    assert r.success and r.certified
+    assert r.lower_bound <= -1.0 <= r.lower_bound + 1e-6
+
+
+def test_tol_and_max_iter_are_accepted_and_never_cost_validity():
+    # The escape hatch gh #218 asked for. A looser tol buys a weaker bound,
+    # never an invalid one, because certification measures the actual miss.
+    obj, g = _lasserre_ex5()
+    gaps = []
+    for tol in (1e-10, 1e-8, 1e-6):
+        r = sos_minimize(obj, inequalities=g, order=4, tol=tol)
+        assert r.success and r.certified, tol
+        assert r.lower_bound <= TRUE_MIN, (tol, r.lower_bound)
+        gaps.append(TRUE_MIN - r.lower_bound)
+    assert gaps == sorted(gaps), f"looser tol should not tighten the bound: {gaps}"
+    # max_iter is plumbed through and accepted.
+    assert sos_minimize(obj, inequalities=g, order=2, max_iter=500).success
+
+
+@pytest.mark.parametrize(
+    "kwargs, msg",
+    [({"tol": 0.0}, "tol"), ({"tol": -1e-8}, "tol"), ({"max_iter": 0}, "max_iter")],
+)
+def test_invalid_solver_controls_raise(kwargs, msg):
+    obj, g = _lasserre_ex5()
+    with pytest.raises(ValueError, match=msg):
+        sos_minimize(obj, inequalities=g, order=2, **kwargs)


### PR DESCRIPTION
Closes #218. Closes #219.

## #218 — the Lasserre hierarchy now converges, and the bound is rigorous

The reported benchmark (Lasserre, *SIAM J. Optim.* **11**(3):796–817, Example 5):

| order | before | after |
|---|---|---|
| 2 | `optimal` −7.000 (trivial box bound) | `optimal` −7.000 |
| 3 | `iteration_limit` `nan` | `optimal` −6.667 |
| 4 | `iteration_limit` `nan` | `optimal` **−5.5080139**, exact, minimizer (2.3295, 3.1785) |

True global minimum −5.5080132716 at (2.3295, 3.1783), verified here independently by a 400-start SLSQP sweep. This meets the issue's stated criterion — "a finite bound ≤ −5.50801, tightening toward it as the order rises" — and at order 4 the relaxation certifies exact by flat truncation, so the minimizer comes back with the bound.

### Root cause — not what the report proposed

The issue's top-ranked fix was exposing `tol`/`max_iter`. That would not have worked: `max_iter` was provably inert, because the iterate froze bit-for-bit and 392 of 400 iterations were literal no-ops. Tracing the solve found **two distinct bugs**.

**1. Mehrotra's centering parameter inverts on a degenerate face.** `σ = (μ_aff/μ)³` infers centering from how far the affine direction travels. On a degenerate face that direction *looks* excellent while pointing almost straight out of the cone, so σ collapsed toward zero — nearly no centering, exactly where centering was the only remedy. Order 4 pinned σ at 0.0218 while the step fell `4.0e-1 → 2.1e-2 → 9.7e-4 → … → 1e-281`, throttled by the PSD slack block alone, with μ frozen at 2.6e-3 and residuals at 4.2e-4 — nowhere near converged, simply stuck on the boundary.

The corrector is now recomputed under an escalating σ when its step collapses; each retry is one extra back-solve through the factorization already in hand, and the ladder is step-length-gated so a healthy iteration never enters it. This is the PSD-cone counterpart of the Gondzio correctors, which are confined to the orthant because a PSD block's complementarity product needs Jordan-algebra machinery.

The same fix carries the **NETLIB GEN family** (`gen`, `gen1`, `gen4`) and `pilot87` from `Maximum_Iterations_Exceeded` to `Solved_To_Acceptable_Level`.

**2. Regularization ratcheted on a conditioning symptom.** When iterative refinement missed its tolerance, the driver escalated both the `(z,z)` dynamic regularization *and* `δ_c`, the equality-block regularization — treating cone ill-conditioning as an equality-Jacobian rank defect. The KKT is inherently ill-conditioned in the μ→0 endgame, so this fired there on healthy solves and drove `δ_c` to its `1e-1` ceiling, biasing the equality residual by `~δ_c·‖dy‖` and flooring `pres` permanently. Order 3 stood at `pres` 8.6e-9 ✓, `dres` 1.2e-10 ✓, `gap` 1.7e-8 — one step from converging — when the escalation pushed `pres` to 2.7e-8, where it stayed. Inertia was correct at *every* try throughout, so no rank defect was ever present. Only the `(z,z)` regularization escalates on this signal now.

### The bound is now certified, not merely converged

A converged SDP reports a `γ` that is *accurate* but need not be a lower **bound** — at order 4 the raw value came back **2.2e-7 above** the true minimum, which the issue rightly calls the one genuinely unsound failure mode. No solver tolerance removes it; it is a property of finite precision.

`sos_minimize` now measures the miss rather than trusting the solve: it projects each Gram block onto the PSD cone, evaluates the residual `e` of the coefficient-matching system there, and reports `γ − Σ_α|e_α|`. Every other term of the Putinar identity is nonnegative on the feasible set and `|u^α| ≤ 1` on the normalized box, so that value is a true lower bound however the solve went. Costs one eigendecomposition per block — no extra solve.

A new **`certified`** flag reports whether this held. It needs the feasible set inside a box readable off the constraints (`x ≥ l`/`x ≤ u` pairs, or the `c − a·x² ≥ 0` idiom) and is `false` on an unbounded domain, where no finite correction exists — a residual with a negative leading coefficient is unbounded below. Adding explicit box constraints upgrades such a problem.

### Also addressed

- **`tol`/`max_iter` exposed** (Python `sos_minimize`; Rust `sos_minimize_opts` + the now-public `sos_opts`). Loosening `tol` costs tightness, never validity — certification measures the actual residual rather than assuming convergence.
- **Domain normalization** in `equilibrated()`: a boxed variable's range maps to `[−1,1]` before the SDP is assembled, since coefficient equilibration (#124) left the domain alone and a wide box made the moment matrix span decades by itself (`x₁ ∈ [0,3]` → degree-8 moments spanning `3⁸ ≈ 6561`). Value- and minimizer-preserving; minimizers map back to the caller's coordinates.
- **A coarser bound is no longer discarded** — if the requested order fails, coarser orders are tried and the first that converges is returned, via a new `order` field.

## #219 — weak activity is now detectable

`QpSensitivity` could not report whether its own documented precondition held. Adds **`active_indices`** and **`weakly_active_indices`** (both returning `ActiveSet`), retaining the multipliers `build()` was discarding.

The screen tests the multiplier and the slack *together*, which is what makes it tolerance-invariant where `kkt_dim` is not. On the reported QP the two branches of `dx/db` are 33% apart and which one is reported turns on the solver's `tol`; `kkt_dim` flips 4 → 3 across that sweep while the geometry never changes. Measured behaviour: multiplier and slack collapse together at ~`√tol` with their ratio pinned near 0.22 across six orders of magnitude, whereas strict complementarity keeps one bounded away from zero. Both false-positive controls (strictly active, strictly inactive) are tested — without them a screen that fired on every active constraint would pass.

## Verification

The centering fix touches the shared IPM corrector, so it was checked broadly against the committed benchmark baselines:

- **371 NETLIB LPs** — the 4 improvements above, **0 regressions**. (Three objective deltas are all on runs whose status is unchanged and non-converged or infeasible, where the objective is not a meaningful output.)
- **138 Maros–Mészáros QPs** — byte-identical statuses and objectives.
- **CBLIB** exp/power cones — bit-identical to an unmodified tree, as expected: they route to the separate non-symmetric driver.
- **New randomized differential suite** (`tests/conic_hsde_vs_direct.rs`) closing the SOC/PSD gap, since those had only closed-form coverage. It checks the changed HSDE driver against the **untouched direct driver** over **318 generated instances** with planted Slater points and compact feasible sets: no disagreement on any optimal value, no instance the direct driver solved that HSDE failed, and 36 that only HSDE solved.

Full Rust workspace and **618 Python tests** pass. Clippy output is byte-identical to `main`; no new broken doc links; `check-release-consistency.sh` OK.

## Separate defect found, not fixed here

The randomized suite surfaced a pre-existing bug **unrelated to this change**, reproduced on an unmodified tree: the **direct** driver (`use_hsde: false`) can return `QpStatus::Optimal` with a `NaN` objective on some mixed SOC+PSD instances. The new test asserts the HSDE driver never does this, and counts/skips the cases where the reference is unusable rather than attributing them here. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCWHfX7icowy2rj7jECnT8
