### PR TITLE
pyomo-pounce: add block_analyze, the analysis-only DM partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ changes.
 
 ## [Unreleased]
 
+### Added — `pyomo_pounce.block_analyze`, the analysis half of `block_initialize` on its own (Pyomo, #224)
+
+- **The Dulmage-Mendelsohn partition is now available without solving
+  anything.** `block_initialize` already computes the full partition of the
+  equality system, but a caller could only see it through the initialization
+  report, where the underconstrained/overconstrained lists are capped,
+  name-only, and bundled behind the fill and block solves. `block_analyze(model,
+  decisions=[...])` runs the same decision handling and the same decomposition
+  and returns a `BlockAnalysisReport` carrying the **full** partition as the
+  component objects themselves: the underconstrained and overconstrained
+  subsystems (variables and constraints on both sides), the square part, and
+  its block-triangular calculation order, with nothing capped. Convenience
+  counts (`n_extra_degrees_of_freedom`, `n_extra_specifications`) say how far
+  from square the system is.
+- Analysis is purely structural, so decisions do not need values here (they do
+  in `block_initialize`, whose solve must hold them at a concrete point), no
+  values are read or written, and fixed flags are restored on the way out.
+  This makes it a safe first pass on a badly specified model: diagnose, decide
+  what to specify, then call `initialize`/`block_initialize` to do the work.
+- `block_initialize` now delegates its partition step to `block_analyze`; its
+  behavior and report are unchanged.
+
 ### Fixed — a diverged conic solve could report `Optimal` with a `NaN` solution (#222)
 
 - **`solve_socp_ipm` could return `QpStatus::Optimal` alongside `x = [NaN, NaN]`.**

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -98,3 +98,25 @@ variables and constraints are reported **by name** —
 specify or flag as decisions, `overconstrained_constraints` the
 redundant or conflicting specifications. Permanently-known inputs can
 simply be `fix()`ed instead of listed as decisions.
+
+The analysis half is also available on its own:
+
+```python
+rep = pyomo_pounce.block_analyze(               # the DM partition only:
+    model, decisions=[m.feed, m.reflux])        # nothing seeded or solved
+rep.underconstrained_variables                  # VarData objects, uncapped
+rep.n_extra_degrees_of_freedom                  # how many specs are missing
+rep.variable_blocks                             # the calculation order
+```
+
+`block_analyze` runs the same decision handling and the same
+Dulmage-Mendelsohn decomposition, but touches nothing: no values are
+read or written (so, unlike `block_initialize`, the decisions do not
+need values), and no solve happens. Where the initialization reports
+cap their name lists for display, `block_analyze` returns the **full**
+partition as the component objects themselves: the underconstrained
+and overconstrained subsystems, the square part, and its
+block-triangular calculation order. Use it to diagnose a large model's
+specification, or as the structural front end for tooling that decides
+*what* to specify before calling `initialize` /
+`block_initialize` to do the work.

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -12,6 +12,8 @@ Initialization helpers (see the POUNCE docs' initialization chapter):
     pyomo_pounce.initialize_missing_values(model)  # fill unset Var values
     pyomo_pounce.project_to_feasible(model)        # min-norm repair onto constraints
     pyomo_pounce.block_initialize(model, decisions=[...])  # DM-ordered equality solve
+    pyomo_pounce.block_analyze(model, decisions=[...])     # the DM partition only:
+    #     full component lists, nothing solved, no values needed or written
 
 Parametric sensitivity (see pyomo_pounce.sens):
     declare_sens_param(m.p)      # flag parameters when building the model
@@ -20,7 +22,12 @@ Parametric sensitivity (see pyomo_pounce.sens):
     estimate(m, [(m.p, 2.5)])
     covariance(m, n_data=len(y)) # parameter covariance for least squares
 """
-from pyomo_pounce.block_init import BlockInitReport, block_initialize
+from pyomo_pounce.block_init import (
+    BlockAnalysisReport,
+    BlockInitReport,
+    block_analyze,
+    block_initialize,
+)
 from pyomo_pounce.pounce_solver import POUNCE
 from pyomo_pounce.sens import (
     Covariance,
@@ -57,4 +64,6 @@ __all__ = [
     "InitializeReport",
     "block_initialize",
     "BlockInitReport",
+    "block_analyze",
+    "BlockAnalysisReport",
 ]

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -30,6 +30,13 @@ reported **by name** — pair with
 :func:`pyomo_pounce.project_to_feasible` to handle the remainder (or
 use the :func:`pyomo_pounce.initialize` pipeline).
 
+:func:`block_analyze` is the analysis-only sibling: the same decision
+handling and the same Dulmage-Mendelsohn partition, but nothing is
+seeded, projected, or solved, and the full partition is returned as
+**component objects with nothing capped** — for diagnosing a large
+model, and for tooling that builds on the partition (automated
+specification repair) rather than on a display-sized name list.
+
 Requires ``pyomo.contrib.incidence_analysis`` (needs ``networkx`` and
 ``scipy``); raises ``ImportError`` with instructions otherwise.
 """
@@ -39,7 +46,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-__all__ = ["block_initialize", "BlockInitReport"]
+__all__ = [
+    "block_analyze",
+    "block_initialize",
+    "BlockAnalysisReport",
+    "BlockInitReport",
+]
 
 
 @dataclass
@@ -95,6 +107,110 @@ class BlockInitReport:
         return "\n".join(lines)
 
 
+def _preview(components, cap: int = 10) -> str:
+    """Display-sized name list; the underlying data is never capped."""
+    names = [c.name for c in components[:cap]]
+    extra = len(components) - len(names)
+    return ", ".join(names) + (f", ... and {extra} more" if extra > 0 else "")
+
+
+@dataclass
+class BlockAnalysisReport:
+    """The full Dulmage-Mendelsohn partition from :func:`block_analyze`.
+
+    Every list holds the Pyomo **component data objects** themselves
+    (``VarData`` / ``ConstraintData``), in DM order, with nothing
+    capped; ``str(report)`` shows a display-sized preview.
+    """
+
+    #: True when the equality system (after fixing decisions) is exactly
+    #: square: no underconstrained part and no overconstrained part.
+    square: bool = True
+    n_decisions_fixed: int = 0
+    #: Size of the analyzed system: active equality constraints and the
+    #: unfixed variables appearing in them.
+    n_constraints: int = 0
+    n_variables: int = 0
+    #: The underconstrained subsystem: variables the equalities cannot
+    #: determine (the things to specify or flag as decisions), and the
+    #: constraints entangled with them.
+    underconstrained_variables: List = field(default_factory=list)
+    underconstrained_constraints: List = field(default_factory=list)
+    #: The overconstrained subsystem: redundant or conflicting
+    #: specifications, and the variables they fight over.
+    overconstrained_constraints: List = field(default_factory=list)
+    overconstrained_variables: List = field(default_factory=list)
+    #: The square (well-determined) part, and its block-triangular
+    #: calculation order: ``variable_blocks[k]`` is solved from
+    #: ``constraint_blocks[k]``, in sequence.
+    square_variables: List = field(default_factory=list)
+    square_constraints: List = field(default_factory=list)
+    variable_blocks: List = field(default_factory=list)
+    constraint_blocks: List = field(default_factory=list)
+
+    @property
+    def n_extra_degrees_of_freedom(self) -> int:
+        """How many more specifications would square the under part."""
+        return len(self.underconstrained_variables) - len(
+            self.underconstrained_constraints
+        )
+
+    @property
+    def n_extra_specifications(self) -> int:
+        """How many redundant/conflicting rows the over part carries."""
+        return len(self.overconstrained_constraints) - len(
+            self.overconstrained_variables
+        )
+
+    @property
+    def n_blocks(self) -> int:
+        return len(self.variable_blocks)
+
+    @property
+    def n_1x1(self) -> int:
+        return sum(1 for blk in self.variable_blocks if len(blk) == 1)
+
+    def __str__(self) -> str:
+        lines = [
+            "pyomo-pounce block_analyze",
+            f"  decisions fixed   : {self.n_decisions_fixed}",
+            f"  equality system   : {self.n_constraints} constraints, "
+            f"{self.n_variables} variables",
+            f"  system square     : {self.square}",
+            f"  square part       : {len(self.square_variables)} variables in "
+            f"{self.n_blocks} blocks ({self.n_1x1} 1x1)",
+        ]
+        if self.underconstrained_variables:
+            lines.append(
+                f"  underconstrained  : {len(self.underconstrained_variables)} "
+                f"variables, {len(self.underconstrained_constraints)} constraints "
+                f"({self.n_extra_degrees_of_freedom} more specifications needed)"
+            )
+            lines.append(
+                "    vars (specify or flag as decisions): "
+                + _preview(self.underconstrained_variables)
+            )
+            if self.underconstrained_constraints:
+                lines.append(
+                    "    cons: " + _preview(self.underconstrained_constraints)
+                )
+        if self.overconstrained_constraints:
+            lines.append(
+                f"  overconstrained   : {len(self.overconstrained_constraints)} "
+                f"constraints, {len(self.overconstrained_variables)} variables "
+                f"({self.n_extra_specifications} redundant/conflicting)"
+            )
+            lines.append(
+                "    cons (redundant/conflicting specs): "
+                + _preview(self.overconstrained_constraints)
+            )
+            if self.overconstrained_variables:
+                lines.append(
+                    "    vars: " + _preview(self.overconstrained_variables)
+                )
+        return "\n".join(lines)
+
+
 def _flatten_vars(vars_like):
     """Accept VarData, indexed Var containers, or iterables of either."""
     out = []
@@ -104,6 +220,88 @@ def _flatten_vars(vars_like):
         else:
             out.append(v)
     return out
+
+
+def block_analyze(model, decisions=None) -> BlockAnalysisReport:
+    """Partition the equality system; touch nothing, solve nothing.
+
+    The analysis half of :func:`block_initialize` on its own: hold the
+    decisions fixed, decompose the active equality constraints
+    (Dulmage-Mendelsohn), and return the **full** partition — the
+    underconstrained, overconstrained, and square parts as component
+    objects, plus the square part's block-triangular calculation order —
+    with nothing capped for display and no values read or written.
+
+    Args:
+        model: A Pyomo model (Block). Only active equality constraints
+            and unfixed variables participate.
+        decisions: Variables (VarData or indexed Var containers) to hold
+            fixed during the analysis, then release. Purely structural,
+            so unlike :func:`block_initialize` they do **not** need
+            values. Already-fixed variables may be listed and stay
+            fixed.
+
+    Returns a :class:`BlockAnalysisReport`.
+    """
+    try:
+        # Probe networkx explicitly: pyomo defers its optional imports, so
+        # `pyomo.contrib.incidence_analysis` imports fine without it and
+        # would only blow up (DeferredImportError) at first use.
+        import networkx  # noqa: F401
+
+        from pyomo.contrib.incidence_analysis import IncidenceGraphInterface
+    except ImportError as e:  # pragma: no cover - environment-dependent
+        raise ImportError(
+            "block_analyze requires pyomo.contrib.incidence_analysis "
+            "and its optional dependencies (pip install networkx scipy)"
+        ) from e
+
+    report = BlockAnalysisReport()
+
+    fixed_by_us = []
+    if decisions is not None:
+        for vd in _flatten_vars(decisions):
+            if vd.fixed:
+                continue  # already an input; leave as the user set it
+            vd.fix()
+            fixed_by_us.append(vd)
+    report.n_decisions_fixed = len(fixed_by_us)
+
+    try:
+        igraph = IncidenceGraphInterface(model, include_inequality=False)
+        if not igraph.constraints:
+            return report
+        report.n_constraints = len(igraph.constraints)
+        report.n_variables = len(igraph.variables)
+
+        var_dm, con_dm = igraph.dulmage_mendelsohn()
+        report.underconstrained_variables = list(var_dm.unmatched) + list(
+            var_dm.underconstrained
+        )
+        report.underconstrained_constraints = list(con_dm.underconstrained)
+        report.overconstrained_constraints = list(con_dm.unmatched) + list(
+            con_dm.overconstrained
+        )
+        report.overconstrained_variables = list(var_dm.overconstrained)
+        report.square_variables = list(var_dm.square)
+        report.square_constraints = list(con_dm.square)
+        report.square = (
+            not report.underconstrained_variables
+            and not report.overconstrained_constraints
+        )
+
+        if report.square_variables:
+            var_blocks, con_blocks = igraph.block_triangularize(
+                variables=report.square_variables,
+                constraints=report.square_constraints,
+            )
+            report.variable_blocks = [list(blk) for blk in var_blocks]
+            report.constraint_blocks = [list(blk) for blk in con_blocks]
+    finally:
+        for vd in fixed_by_us:
+            vd.unfix()
+
+    return report
 
 
 def block_initialize(
@@ -149,7 +347,6 @@ def block_initialize(
         import networkx  # noqa: F401
 
         from pyomo.contrib.incidence_analysis import (
-            IncidenceGraphInterface,
             solve_strongly_connected_components,
         )
     except ImportError as e:  # pragma: no cover - environment-dependent
@@ -177,34 +374,28 @@ def block_initialize(
     report.n_decisions_fixed = len(fixed_by_us)
 
     try:
-        igraph = IncidenceGraphInterface(model, include_inequality=False)
-        if not igraph.constraints:
-            return report
-
         # The square (well-determined) part of the equality system: the
         # DM decomposition separates it from remaining degrees of
-        # freedom and redundant specifications — and names them.
-        var_dm, con_dm = igraph.dulmage_mendelsohn()
-        under_vars = list(var_dm.unmatched) + list(var_dm.underconstrained)
-        over_cons = list(con_dm.unmatched) + list(con_dm.overconstrained)
+        # freedom and redundant specifications — and names them. The
+        # decisions are already fixed above, so none are passed on.
+        analysis = block_analyze(model)
+        under_vars = analysis.underconstrained_variables
+        over_cons = analysis.overconstrained_constraints
         report.skipped_underdetermined = len(under_vars)
         report.skipped_overdetermined = len(over_cons)
         report.underconstrained_variables = [v.name for v in under_vars[:max_list]]
         report.overconstrained_constraints = [c.name for c in over_cons[:max_list]]
-        report.square = not under_vars and not over_cons
+        report.square = analysis.square
 
-        square_vars = list(var_dm.square)
-        square_cons = list(con_dm.square)
+        square_vars = analysis.square_variables
+        square_cons = analysis.square_constraints
         if not square_vars:
             return report
 
         # Solve-plan statistics (the SCC solve below follows exactly
-        # this block structure).
-        var_blocks, _con_blocks = igraph.block_triangularize(
-            variables=square_vars, constraints=square_cons
-        )
-        report.n_blocks = len(var_blocks)
-        report.n_1x1 = sum(1 for blk in var_blocks if len(blk) == 1)
+        # the analysis' block structure).
+        report.n_blocks = analysis.n_blocks
+        report.n_1x1 = analysis.n_1x1
         n_large = report.n_blocks - report.n_1x1
 
         for v in square_vars:

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -44,7 +44,11 @@ Requires ``pyomo.contrib.incidence_analysis`` (needs ``networkx`` and
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pyomo.core.base.constraint import ConstraintData
+    from pyomo.core.base.var import VarData
 
 __all__ = [
     "block_analyze",
@@ -134,19 +138,19 @@ class BlockAnalysisReport:
     #: The underconstrained subsystem: variables the equalities cannot
     #: determine (the things to specify or flag as decisions), and the
     #: constraints entangled with them.
-    underconstrained_variables: List = field(default_factory=list)
-    underconstrained_constraints: List = field(default_factory=list)
+    underconstrained_variables: List[VarData] = field(default_factory=list)
+    underconstrained_constraints: List[ConstraintData] = field(default_factory=list)
     #: The overconstrained subsystem: redundant or conflicting
     #: specifications, and the variables they fight over.
-    overconstrained_constraints: List = field(default_factory=list)
-    overconstrained_variables: List = field(default_factory=list)
+    overconstrained_constraints: List[ConstraintData] = field(default_factory=list)
+    overconstrained_variables: List[VarData] = field(default_factory=list)
     #: The square (well-determined) part, and its block-triangular
     #: calculation order: ``variable_blocks[k]`` is solved from
     #: ``constraint_blocks[k]``, in sequence.
-    square_variables: List = field(default_factory=list)
-    square_constraints: List = field(default_factory=list)
-    variable_blocks: List = field(default_factory=list)
-    constraint_blocks: List = field(default_factory=list)
+    square_variables: List[VarData] = field(default_factory=list)
+    square_constraints: List[ConstraintData] = field(default_factory=list)
+    variable_blocks: List[List[VarData]] = field(default_factory=list)
+    constraint_blocks: List[List[ConstraintData]] = field(default_factory=list)
 
     @property
     def n_extra_degrees_of_freedom(self) -> int:

--- a/pyomo-pounce/tests/test_block_init.py
+++ b/pyomo-pounce/tests/test_block_init.py
@@ -194,6 +194,108 @@ def test_coupled_block_uses_subsystem_solve(solver):
     assert m.z.value == pytest.approx(2.0, abs=1e-6)
 
 
+def test_block_analyze_touches_nothing():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.x == 2.0)
+    m.c2 = pyo.Constraint(expr=m.y == m.x + 1.0)
+    m.obj = pyo.Objective(expr=m.y)
+
+    report = pyomo_pounce.block_analyze(m)
+    assert report.square
+    assert report.n_constraints == 2 and report.n_variables == 2
+    assert report.n_blocks == 2 and report.n_1x1 == 2
+    # analysis only: nothing seeded, nothing solved
+    assert m.x.value is None and m.y.value is None
+
+
+def test_block_analyze_returns_components_uncapped():
+    # 15 loose variables in one equation: more than block_initialize's
+    # display cap, and block_analyze must return every one, as objects.
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(range(15))
+    m.c = pyo.Constraint(expr=sum(m.x[i] for i in range(15)) == 1.0)
+    m.obj = pyo.Objective(expr=m.x[0])
+
+    report = pyomo_pounce.block_analyze(m)
+    assert not report.square
+    assert len(report.underconstrained_variables) == 15
+    assert report.underconstrained_constraints == [m.c]
+    assert report.n_extra_degrees_of_freedom == 14
+    assert any(v is m.x[3] for v in report.underconstrained_variables)
+    # the display preview is capped, the data is not
+    assert "and 5 more" in str(report)
+    # contrast: block_initialize's name list is display-sized
+    init_report = pyomo_pounce.block_initialize(m)
+    assert len(init_report.underconstrained_variables) == 10
+
+
+def test_block_analyze_overconstrained_part():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.x == 1.0)
+    m.c2 = pyo.Constraint(expr=2.0 * m.x == 2.0)  # redundant spec
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.block_analyze(m)
+    assert not report.square
+    assert set(report.overconstrained_constraints) == {m.c1, m.c2}
+    assert report.overconstrained_variables == [m.x]
+    assert report.n_extra_specifications == 1
+    assert "overconstrained" in str(report)
+
+
+def test_block_analyze_decisions_need_no_values():
+    # Purely structural: a valueless decision is fine here (it is a
+    # ValueError in block_initialize), and its fixed flag is restored.
+    m = pyo.ConcreteModel()
+    m.feed = pyo.Var()  # no value
+    m.split = pyo.Var(bounds=(0.0, 1.0))  # no value
+    m.out1 = pyo.Var()
+    m.out2 = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.out1 == m.split * m.feed)
+    m.c2 = pyo.Constraint(expr=m.out2 == (1.0 - m.split) * m.feed)
+    m.obj = pyo.Objective(expr=m.out1)
+
+    report = pyomo_pounce.block_analyze(m, decisions=[m.feed, m.split])
+    assert report.square
+    assert report.n_decisions_fixed == 2
+    assert not m.feed.fixed and not m.split.fixed
+    assert m.feed.value is None  # still untouched
+
+
+def test_block_analyze_calculation_order():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var()
+    m.z = pyo.Var()
+    # 2x2 coupled block feeding a downstream 1x1.
+    m.c1 = pyo.Constraint(expr=m.x + m.y == 3.0)
+    m.c2 = pyo.Constraint(expr=m.x - m.y == 1.0)
+    m.c3 = pyo.Constraint(expr=m.z == m.x * m.y)
+    m.obj = pyo.Objective(expr=m.z)
+
+    report = pyomo_pounce.block_analyze(m)
+    assert report.square
+    assert report.n_blocks == 2 and report.n_1x1 == 1
+    assert sorted(v.name for v in report.variable_blocks[0]) == ["x", "y"]
+    assert report.variable_blocks[1] == [m.z]
+    assert report.constraint_blocks[1] == [m.c3]
+
+
+def test_block_analyze_no_equalities():
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.c = pyo.Constraint(expr=m.x <= 1.0)  # inequalities do not participate
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.block_analyze(m)
+    assert report.square
+    assert report.n_constraints == 0 and report.n_variables == 0
+    assert report.variable_blocks == []
+
+
 def test_failure_is_reported_not_raised():
     m = pyo.ConcreteModel()
     m.x = pyo.Var(bounds=(0.0, 1.0))

--- a/pyomo-pounce/tests/test_block_init.py
+++ b/pyomo-pounce/tests/test_block_init.py
@@ -284,6 +284,26 @@ def test_block_analyze_calculation_order():
     assert report.constraint_blocks[1] == [m.c3]
 
 
+def test_block_analyze_unfixes_decisions_on_exception(monkeypatch):
+    # The finally must release our fixes even when the analysis dies
+    # before producing anything.
+    import pyomo.contrib.incidence_analysis as ia
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("igraph construction failed")
+
+    monkeypatch.setattr(ia, "IncidenceGraphInterface", boom)
+    m = pyo.ConcreteModel()
+    m.u = pyo.Var()
+    m.x = pyo.Var()
+    m.c = pyo.Constraint(expr=m.x == m.u)
+    m.obj = pyo.Objective(expr=m.x)
+
+    with pytest.raises(RuntimeError, match="igraph construction failed"):
+        pyomo_pounce.block_analyze(m, decisions=[m.u])
+    assert not m.u.fixed
+
+
 def test_block_analyze_no_equalities():
     m = pyo.ConcreteModel()
     m.x = pyo.Var()


### PR DESCRIPTION
## What

`pyomo_pounce.block_analyze(model, decisions=[...])`: the analysis half of `block_initialize` on its own. Same decision handling, same Dulmage-Mendelsohn decomposition of the active equality system, but nothing is seeded, projected, or solved, and no values are read or written (so, unlike `block_initialize`, decisions do not need values). It returns a `BlockAnalysisReport` carrying the **full** partition as the component objects themselves, with nothing capped:

- the underconstrained subsystem (variables and constraints), with `n_extra_degrees_of_freedom`
- the overconstrained subsystem (constraints and variables), with `n_extra_specifications`
- the square part and its block-triangular calculation order (`variable_blocks` / `constraint_blocks`)

`str(report)` previews long name lists at 10 entries; the data is never capped.

## Why

`block_initialize` already computes this partition, but a caller can only see it through the initialization report: capped, name-only, and only after the fill and block solves have run under a specification already known to be bad. Downstream tooling (the steady-state initialization in [drto](https://github.com/devin-griff/drto) is the immediate consumer) wants to *diagnose first, decide what to specify, then solve once*. A badly specified distillation column is the motivating shape: the levels land underconstrained and the holdup balances overconstrained, and repairing that specification needs the full partition, not a display list.

## How

The partition step is extracted from `block_initialize`, which now delegates to `block_analyze` (its behavior and report are unchanged; the existing suite passes as-is). Decisions are fixed for the analysis and restored in a `finally`, same as before.

Per CONTRIBUTING: code + tests (6 new, hermetic, no solver binary needed), CHANGELOG entry under Unreleased, and the book's `docs/src/pyomo.md` section extended. `pyomo-pounce/tests` passes locally (75 passed). No solver routing touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)