### PR TITLE
Never report Optimal with a non-finite solution (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a diverged conic solve could report `Optimal` with a `NaN` solution (#222)
+
+- **`solve_socp_ipm` could return `QpStatus::Optimal` alongside `x = [NaN, NaN]`.**
+  A caller checking the status — the documented way to know an answer is usable
+  — was handed a garbage solution with no indication anything had gone wrong.
+  Observed on the direct symmetric driver (`use_hsde: false`) on PSD programs;
+  the underlying flaw was shared by both drivers.
+
+- **Cause: `inf_norm` swallowed `NaN`.** `f64::max` is specified to *ignore*
+  `NaN`, so the natural `fold(0.0, |m, x| m.max(x.abs()))` reports the ∞-norm of
+  an all-`NaN` vector as a perfect `0.0`. Every convergence test in both drivers
+  compares such a norm against `tol`, so a fully diverged iterate read as
+  converged: on the reported instance the iterate went non-finite at iteration
+  31 and the residuals computed from it came back `pinf = dinf = res = 0`, so
+  `res < tol` passed and the solve declared success. `inf_norm` now
+  short-circuits on `NaN`, making every such comparison correctly false.
+
+- Two further guards, so the guarantee does not rest on one primitive: each
+  driver now breaks with `NumericalFailure` as soon as its iterate goes
+  non-finite, and a final pass demotes any `Optimal` / `OptimalInaccurate`
+  verdict that is not backed by a finite solution and objective. Across a
+  31,920-solve randomized sweep over both drivers, **no solve now reports
+  success with a non-finite solution** (previously 32).
+
+- The divergence itself is left as-is: the direct driver stalling or diverging
+  on a degenerate face is known behaviour and precisely why the homogeneous
+  self-dual embedding is the default (`use_hsde: true`, see `sos_opts`). HSDE
+  solves the reported instance correctly. What was wrong was reporting that
+  divergence as success, not the divergence.
+
+- The randomized differential suite added in #221 asserted this property of the
+  HSDE driver only, and had to skip the direct driver's cases as
+  `reference-unusable`; the skip is gone and both drivers are now asserted.
+
 ### Added — weak-activity detection for QP sensitivity (#219)
 
 - **`QpSensitivity` can now report whether its own precondition holds.** The

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -567,6 +567,13 @@ where
             }
         }
 
+        // Breakdown: a non-finite iterate carries no information, and every
+        // test below is a comparison against it. Stop and say so (gh #222).
+        if !crate::ipm::all_finite(&[&x, &s, &y, &z]) || !tau.is_finite() || !kappa.is_finite() {
+            status = QpStatus::NumericalFailure;
+            break;
+        }
+
         // Absolute test always governs; the scale-relative test only relaxes
         // it for genuinely large-data problems (`large_scale`, gated above).
         let converged = (pres < opts.tol && dres < opts.tol && gap < opts.tol)
@@ -1105,6 +1112,8 @@ where
         let _ = fire(&mut hook, &mut st);
     }
 
+    // Never hand back a success verdict without a usable solution (gh #222).
+    let status = crate::ipm::demote_unusable(status, &x, obj);
     QpSolution {
         status,
         x,

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -1427,6 +1427,13 @@ fn run_ipm(
             }
         }
 
+        // Breakdown: a non-finite iterate carries no information, and every
+        // test below is a comparison against it. Stop and say so (gh #222).
+        if !all_finite(&[&x, &s, &y, &z]) {
+            status = QpStatus::NumericalFailure;
+            break;
+        }
+
         if res < opts.tol {
             status = QpStatus::Optimal;
             // Record the converged iterate so the trace *ends* at the
@@ -1677,6 +1684,8 @@ fn run_ipm(
     }
 
     let nn = n;
+    // Never hand back a success verdict without a usable solution (gh #222).
+    let status = demote_unusable(status, &x, obj);
     QpSolution {
         status,
         x,
@@ -2241,8 +2250,59 @@ fn block_shapes(cone: &CompositeCone) -> Vec<BlockShape> {
         .collect()
 }
 
+/// Whether every entry of every block of an iterate is finite.
+///
+/// A single non-finite entry means the iteration has broken down: there is no
+/// point continuing, and — more importantly — no verdict but a failure is
+/// honest, since the "solution" carries no information.
+pub(crate) fn all_finite(blocks: &[&[f64]]) -> bool {
+    blocks.iter().all(|b| b.iter().all(|v: &f64| v.is_finite()))
+}
+
+/// Demote a success verdict that is not backed by a usable solution (gh #222).
+///
+/// The last line of defence before a solution leaves either driver: reporting
+/// `Optimal` is a *claim*, and a caller that checks the status — the documented
+/// way to know an answer is usable — must never be handed `NaN` alongside it.
+/// Whatever went wrong upstream, `NumericalFailure` is the honest verdict.
+///
+/// Deliberately a separate final pass rather than a fix at one breakdown site:
+/// the guarantee wanted is about what comes *out*, so it belongs where the
+/// result is assembled, and it then holds no matter which internal path
+/// produced the iterate.
+pub(crate) fn demote_unusable(status: QpStatus, x: &[f64], obj: f64) -> QpStatus {
+    let claims_success = matches!(status, QpStatus::Optimal | QpStatus::OptimalInaccurate);
+    if claims_success && !(all_finite(&[x]) && obj.is_finite()) {
+        return QpStatus::NumericalFailure;
+    }
+    status
+}
+
+/// `‖v‖∞`, propagating `NaN` rather than swallowing it (gh #222).
+///
+/// The obvious `fold(0.0, |m, x| m.max(x.abs()))` is **wrong on a `NaN`
+/// input**, and silently so: `f64::max` is defined to *ignore* `NaN`, so
+/// `0.0f64.max(NaN) == 0.0` and the ∞-norm of an all-`NaN` vector comes back as
+/// a perfect `0.0`.
+///
+/// Every convergence test in both drivers is a comparison of `inf_norm`-derived
+/// residuals against `tol`, so that turned a fully diverged iterate into a
+/// declaration of optimality. On the gh #222 instance the direct driver's
+/// iterate went entirely non-finite at iteration 31 and the residuals it
+/// computed from that iterate read `pinf = dinf = res = 0`, so `res < tol`
+/// passed and the solve returned `Optimal` with `x = [NaN, NaN]`.
+///
+/// `NaN` short-circuits here so the norm is genuinely `NaN`; every `< tol`
+/// test against it is then false, which is the correct answer.
 pub(crate) fn inf_norm(v: &[f64]) -> f64 {
-    v.iter().fold(0.0_f64, |m, &x| m.max(x.abs()))
+    let mut m = 0.0_f64;
+    for &x in v {
+        if x.is_nan() {
+            return f64::NAN;
+        }
+        m = m.max(x.abs());
+    }
+    m
 }
 
 pub(crate) fn dot(a: &[f64], b: &[f64]) -> f64 {
@@ -2576,5 +2636,83 @@ mod detect_infeasibility_tests {
             Some(QpStatus::PrimalInfeasible),
             "residual 1e-12 ≪ FARKAS_RESID_TOL is a genuine Farkas certificate"
         );
+    }
+}
+
+#[cfg(test)]
+mod non_finite_guard_tests {
+    //! gh #222: a success verdict must never accompany an unusable solution.
+    use super::{all_finite, demote_unusable, inf_norm};
+    use crate::qp::QpStatus;
+
+    #[test]
+    fn inf_norm_propagates_nan_instead_of_swallowing_it() {
+        // The bug. `f64::max` is specified to IGNORE NaN, so the natural
+        // `fold(0.0, |m, x| m.max(x.abs()))` reports the ∞-norm of an all-NaN
+        // vector as a perfect 0.0. Every convergence test compares such a norm
+        // against `tol`, so that made a fully diverged iterate read as
+        // converged — the direct driver returned `Optimal` with `x = [NaN,NaN]`.
+        assert!(
+            0.0_f64.max(f64::NAN) == 0.0,
+            "premise: f64::max ignores NaN"
+        );
+
+        assert!(inf_norm(&[f64::NAN, f64::NAN]).is_nan());
+        assert!(inf_norm(&[1.0, f64::NAN, 2.0]).is_nan());
+        // NaN anywhere wins, including after a larger finite entry (a fold that
+        // let `max` swallow it would return 5.0 here).
+        assert!(inf_norm(&[5.0, f64::NAN]).is_nan());
+        // And the convergence test then rejects it, which is the point: the
+        // drivers all decide by comparing such a norm against `tol`.
+        let converged = |residual: f64| residual < 1e-8;
+        assert!(!converged(inf_norm(&[f64::NAN])));
+
+        // Ordinary inputs are unchanged, infinities included.
+        assert_eq!(inf_norm(&[]), 0.0);
+        assert_eq!(inf_norm(&[-3.0, 2.0]), 3.0);
+        assert_eq!(inf_norm(&[f64::INFINITY]), f64::INFINITY);
+        assert!(!converged(inf_norm(&[f64::INFINITY])));
+    }
+
+    #[test]
+    fn all_finite_spots_a_single_bad_entry_in_any_block() {
+        let good = [1.0, 2.0];
+        let nan = [1.0, f64::NAN];
+        let inf = [f64::INFINITY];
+        assert!(all_finite(&[&good, &good]));
+        assert!(!all_finite(&[&good, &nan]));
+        assert!(!all_finite(&[&inf, &good]));
+        assert!(all_finite(&[]));
+    }
+
+    #[test]
+    fn success_verdicts_are_demoted_when_the_solution_is_unusable() {
+        let bad = [f64::NAN, 1.0];
+        let good = [1.0, 2.0];
+        for claim in [QpStatus::Optimal, QpStatus::OptimalInaccurate] {
+            assert_eq!(
+                demote_unusable(claim, &bad, 1.0),
+                QpStatus::NumericalFailure,
+                "{claim:?} with a NaN x must not survive"
+            );
+            assert_eq!(
+                demote_unusable(claim, &good, f64::NAN),
+                QpStatus::NumericalFailure,
+                "{claim:?} with a NaN objective must not survive"
+            );
+            // A usable solution is left alone.
+            assert_eq!(demote_unusable(claim, &good, 1.0), claim);
+        }
+        // Failure verdicts are reported as-is; the guard only demotes, never
+        // promotes, so it cannot manufacture a success.
+        for keep in [
+            QpStatus::NumericalFailure,
+            QpStatus::IterationLimit,
+            QpStatus::PrimalInfeasible,
+            QpStatus::DualInfeasible,
+        ] {
+            assert_eq!(demote_unusable(keep, &bad, f64::NAN), keep);
+            assert_eq!(demote_unusable(keep, &good, 1.0), keep);
+        }
     }
 }

--- a/crates/pounce-convex/tests/conic_hsde_vs_direct.rs
+++ b/crates/pounce-convex/tests/conic_hsde_vs_direct.rs
@@ -192,7 +192,6 @@ fn solve(prob: &QpProblem, cones: &[ConeSpec], use_hsde: bool) -> pounce_convex:
 fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng) -> Vec<ConeSpec>) {
     let mut rng = Rng(seed);
     let (mut compared, mut hsde_only, mut direct_only) = (0usize, 0usize, 0usize);
-    let mut reference_unusable = 0usize;
     for case in 0..count {
         let blocks = shape(&mut rng);
         let n = rng.range(3, 8);
@@ -206,22 +205,19 @@ fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng)
 
         match (a.status, b.status) {
             (QpStatus::Optimal, QpStatus::Optimal) => {
-                // The HSDE driver — the one this change touches — must never
-                // claim optimality with a garbage value.
+                // Neither driver may claim optimality without a usable answer.
+                // This used to hold for HSDE only — the direct driver returned
+                // `Optimal` with `obj = NaN` on some PSD instances (gh #222),
+                // and the comparison had to skip those. Since that fix the
+                // guarantee is symmetric, so assert it on both.
                 assert!(
                     a.obj.is_finite(),
-                    "{name} case {case}: HSDE reported Optimal with a non-finite objective {}",
-                    a.obj
+                    "{name} case {case}: HSDE reported Optimal with a non-finite objective"
                 );
-                // The *direct* driver can (pre-existing defect, reproduced on an
-                // unmodified tree: it returns `Optimal` with `obj = NaN` on some
-                // mixed SOC+PSD instances). Where the reference is unusable there
-                // is nothing to compare against, so count it and move on rather
-                // than blame this change for it.
-                if !b.obj.is_finite() {
-                    reference_unusable += 1;
-                    continue;
-                }
+                assert!(
+                    b.obj.is_finite(),
+                    "{name} case {case}: direct driver reported Optimal with a non-finite objective"
+                );
                 compared += 1;
                 let scale = 1.0_f64.max(a.obj.abs()).max(b.obj.abs());
                 assert!(
@@ -244,12 +240,10 @@ fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng)
     assert!(
         compared * 4 >= count * 3,
         "{name}: only {compared}/{count} instances were solved by both drivers \
-         (hsde-only {hsde_only}, direct-only {direct_only}, reference unusable \
-         {reference_unusable}) — too few to be evidence"
+         (hsde-only {hsde_only}, direct-only {direct_only}) — too few to be evidence"
     );
     println!(
-        "{name}: {compared}/{count} compared, hsde-only {hsde_only}, \
-         direct-only {direct_only}, reference-unusable {reference_unusable}"
+        "{name}: {compared}/{count} compared, hsde-only {hsde_only}, direct-only {direct_only}"
     );
 }
 
@@ -315,12 +309,9 @@ fn boundary_hugging_instances_agree_across_drivers() {
         let b = solve(&prob, &cones, false);
         if a.status == QpStatus::Optimal && b.status == QpStatus::Optimal {
             assert!(
-                a.obj.is_finite(),
-                "degenerate case {case}: HSDE reported Optimal with a non-finite objective"
+                a.obj.is_finite() && b.obj.is_finite(),
+                "degenerate case {case}: a driver reported Optimal with a non-finite objective"
             );
-            if !b.obj.is_finite() {
-                continue;
-            }
             compared += 1;
             let scale = 1.0_f64.max(a.obj.abs()).max(b.obj.abs());
             assert!(
@@ -336,4 +327,78 @@ fn boundary_hugging_instances_agree_across_drivers() {
         "only {compared}/80 degenerate instances solved by both — too few to be evidence"
     );
     println!("degenerate: {compared}/80 compared");
+}
+
+/// The gh #222 instance, verbatim.
+///
+/// The direct driver diverges here — which is expected of it on a degenerate
+/// face, and precisely why the HSDE embedding is the default (see `sos_opts`).
+/// The defect was that it reported the divergence as `Optimal`, handing back
+/// `x = [NaN, NaN]` under a status that says the answer is usable.
+///
+/// The mechanism was `inf_norm`: `f64::max` ignores `NaN`, so the ∞-norm of an
+/// all-`NaN` iterate came out `0.0` and `res < tol` passed. Both the norm and
+/// an explicit exit guard now prevent that.
+#[test]
+fn a_diverged_solve_is_never_reported_as_optimal() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![-0.4587520836280501, -0.28511097640465644],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 0, -1.0),
+            Triplet::new(2, 1, 1.0),
+            Triplet::new(3, 1, -1.0),
+            Triplet::new(4, 1, 0.9144362258975529),
+            Triplet::new(5, 0, 0.5271709449981303),
+            Triplet::new(5, 1, -0.6408278339462257),
+            Triplet::new(6, 0, -0.9444454430308236),
+            Triplet::new(6, 1, -0.9246001786463665),
+            Triplet::new(8, 0, -0.7591854473470727),
+            Triplet::new(8, 1, -0.533518750473565),
+            Triplet::new(9, 0, -0.7290269156600226),
+            Triplet::new(9, 1, 0.6420378359547312),
+        ],
+        h: vec![
+            10.0,
+            10.0,
+            10.0,
+            10.0,
+            2.3063630770492667,
+            2.5412241108987312,
+            -2.3996656180605522,
+            2.6724192569915712,
+            -2.0785098897371794,
+            -0.09460366494727701,
+        ],
+        lb: vec![],
+        ub: vec![],
+    };
+    let cones = [ConeSpec::Nonneg(4), ConeSpec::Psd(3)];
+
+    let direct = solve(&prob, &cones, false);
+    assert!(
+        !matches!(
+            direct.status,
+            QpStatus::Optimal | QpStatus::OptimalInaccurate
+        ),
+        "direct driver claimed {:?} with x = {:?}",
+        direct.status,
+        direct.x
+    );
+
+    // The instance itself is solvable, and HSDE solves it — so the honest
+    // failure above is a property of that driver, not of the problem. Pin the
+    // answer so a future change cannot quietly break the case that works.
+    let hsde = solve(&prob, &cones, true);
+    assert_eq!(hsde.status, QpStatus::Optimal, "{:?}", hsde.status);
+    assert!(
+        (hsde.obj - -3.0311688992249475).abs() < 1e-9,
+        "{}",
+        hsde.obj
+    );
+    assert!(hsde.x.iter().all(|v| v.is_finite()));
 }


### PR DESCRIPTION
Closes #222.

## The bug

`solve_socp_ipm` could return `QpStatus::Optimal` alongside `x = [NaN, NaN]`. A caller checking the status — the documented way to know an answer is usable — was handed a garbage solution with no signal anything had gone wrong.

## Root cause: `inf_norm` swallowed `NaN`

`f64::max` is specified to **ignore** `NaN`, so the natural

```rust
v.iter().fold(0.0_f64, |m, &x| m.max(x.abs()))
```

reports the ∞-norm of an all-`NaN` vector as a perfect `0.0` (`0.0f64.max(NAN) == 0.0`).

Every convergence test in both drivers is a comparison of `inf_norm`-derived residuals against `tol`, so a fully diverged iterate read as converged. Tracing the reported instance:

```
it=15  res=2.302e-6  pinf=2.478e-13  dinf=1.022e-8  mu=2.302e-6   xfin=true
it=16  res=3.642e8   pinf=6.224e-13  dinf=8.134e4   mu=3.642e8    xfin=true   <- diverges
it=19  res=3.134e15  pinf=3.134e15   dinf=1.016e1   mu=-2.344e12  xfin=true   <- mu goes negative
it=30  res=6.650e18  pinf=6.650e18   dinf=1.016e1   mu=-7.900e16  xfin=true
it=31  res=0.000e0   pinf=0.000e0    dinf=0.000e0   mu=NaN        xfin=false  <- "converged"
```

At iteration 31 the iterate is entirely non-finite, and the residuals computed *from it* come back exactly zero — so `res < tol` passes and the driver declares `Optimal`.

## Fix

- **`inf_norm` short-circuits on `NaN`**, so the norm is genuinely `NaN` and every `< tol` test against it is correctly false. This is the actual defect and it was shared by both drivers.
- **Each driver breaks with `NumericalFailure`** as soon as its iterate goes non-finite, rather than continuing to compute with it.
- **A final pass demotes** any `Optimal` / `OptimalInaccurate` verdict not backed by a finite solution and objective — the guarantee is about what comes *out*, so it is enforced where the result is assembled and holds regardless of which internal path produced the iterate.

Belt and braces deliberately: the first is the correct primitive, the other two mean the property does not depend on any single call site staying correct.

## What is *not* changed

The divergence itself. The direct symmetric driver stalling or diverging on a degenerate face is known behaviour, and is precisely why the homogeneous self-dual embedding is the default (`use_hsde: true` — see the `sos_opts` commentary). HSDE solves the reported instance correctly, to a verified optimum. What was wrong was reporting the divergence as success, not the divergence.

## Verification

- **31,920-solve randomized sweep** across both drivers: **0** solves now report success with a non-finite solution (previously 32, all on the direct driver, all involving a PSD block). The 32 are now honest `NumericalFailure`s.
- **138 Maros–Mészáros QPs** — 0 status changes, 0 objective changes.
- **371 NETLIB LPs** — no regressions. One caveat stated plainly: `gen4` came back `Maximum_CpuTime_Exceeded` rather than repeating #221's `Solved_To_Acceptable_Level`. That is a harness timeout, not a solver change — its baseline time was already **278.8s against a 300s limit**, and this run shared the machine with a concurrent test suite. `pilot87` (the largest of that family) is **95.9s → 95.3s**, unchanged, which rules out a systematic slowdown from the added `is_nan` branch.
- Full Rust workspace and 621 Python tests pass; clippy output identical to base.

The randomized differential suite from #221 asserted this property of the HSDE driver only and had to skip the direct driver's cases as `reference-unusable`; that skip is now gone and **both** drivers are asserted. New tests: unit coverage for `inf_norm` NaN propagation, `all_finite`, and the demotion rule (including that it only ever demotes, never promotes), plus the reported instance end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCWHfX7icowy2rj7jECnT8
