### PR TITLE
Make the direct symmetric driver survive PSD-boundary optima (#226)

### DIFF
--- a/crates/pounce-convex/src/cones/psd.rs
+++ b/crates/pounce-convex/src/cones/psd.rs
@@ -209,34 +209,88 @@ impl PsdCone {
 
     /// Largest `α ∈ (0, tau]` with `smat(v) + α·smat(dv) ⪰ 0`, scaled by the
     /// fraction-to-boundary parameter `tau`. Computes the most-negative
-    /// eigenvalue of `L⁻¹ smat(dv) L⁻ᵀ` where `smat(v) = L Lᵀ` (here via the
-    /// symmetric form `V^{-1/2} smat(dv) V^{-1/2}`, `V = smat(v) ≻ 0`).
+    /// eigenvalue of `V^{-1/2} smat(dv) V^{-1/2}` (`V = smat(v) ≻ 0`), then —
+    /// because that computation loses accuracy exactly where it matters, at a
+    /// near-singular `V` (an optimum on the PSD boundary) — **verifies** the
+    /// candidate in the original coordinates and backtracks until the stepped
+    /// point is genuinely inside the cone. An unverified, optimistic α at a
+    /// rank-deficient slack ejects the iterate from the cone (`μ < 0`) and
+    /// the direct IPM never recovers (gh #226).
+    ///
+    /// `tau ≥ 1` deliberately requests the exact boundary point (`α = 1`
+    /// with `V + dV` singular is a legitimate answer there), so the strict
+    /// interiority check applies only to the drivers' `tau < 1`.
     pub fn max_step(&self, v: &[f64], dv: &[f64], tau: f64) -> f64 {
         let n = self.n;
         let mut vmat = vec![0.0; n * n];
         smat(v, n, &mut vmat);
-        let vinv_half = match sym_apply(&vmat, n, |l| 1.0 / l.max(1e-300).sqrt()) {
-            Some(m) => m,
-            None => return tau, // can't scale; let the caller's safeguard handle it
-        };
-        let mut dmat = vec![0.0; n * n];
-        smat(dv, n, &mut dmat);
-        // M = V^{-1/2} dV V^{-1/2}  (symmetric).
-        let mut tmp = vec![0.0; n * n];
-        let mut mmat = vec![0.0; n * n];
-        matmul(&vinv_half, &dmat, n, &mut tmp);
-        matmul(&tmp, &vinv_half, n, &mut mmat);
         let mut vals = vec![0.0; n];
         let mut vecs = vec![0.0; n * n];
-        if !symmetric_eigen(&mmat, n, &mut vals, &mut vecs) {
-            return tau;
-        }
-        let min_eig = vals[0]; // ascending
-        if min_eig >= 0.0 {
-            1.0 // direction keeps PSD for all α ⇒ full step
+        // Candidate from the scaled eigenvalue problem, using the true
+        // spectrum of V. This used to clamp non-positive eigenvalues to
+        // 1e-300, so a boundary slack whose λ_min rounded below zero
+        // produced a ~1e150-entry V^{-1/2} and a garbage α; a failed
+        // eigensolve returned the near-full step `tau` outright. Both now
+        // start from the τ cap and rely on the verification below.
+        let candidate = if symmetric_eigen(&vmat, n, &mut vals, &mut vecs) && vals[0] > 0.0 {
+            // V^{-1/2} = Q Λ^{-1/2} Qᵀ (vecs is column-major, vals ascending).
+            let mut vinv_half = vec![0.0; n * n];
+            for i in 0..n {
+                for k in 0..n {
+                    let mut acc = 0.0;
+                    for j in 0..n {
+                        acc += (1.0 / vals[j].sqrt()) * vecs[j * n + i] * vecs[j * n + k];
+                    }
+                    vinv_half[i * n + k] = acc;
+                }
+            }
+            let mut dmat = vec![0.0; n * n];
+            smat(dv, n, &mut dmat);
+            // M = V^{-1/2} dV V^{-1/2}  (symmetric).
+            let mut tmp = vec![0.0; n * n];
+            let mut mmat = vec![0.0; n * n];
+            matmul(&vinv_half, &dmat, n, &mut tmp);
+            matmul(&tmp, &vinv_half, n, &mut mmat);
+            let mut mvals = vec![0.0; n];
+            let mut mvecs = vec![0.0; n * n];
+            if symmetric_eigen(&mmat, n, &mut mvals, &mut mvecs) {
+                let min_eig = mvals[0]; // ascending
+                if min_eig >= 0.0 {
+                    1.0 // direction keeps PSD for all α ⇒ full step
+                } else {
+                    (tau * (-1.0 / min_eig)).min(1.0)
+                }
+            } else {
+                tau.min(1.0)
+            }
         } else {
-            (tau * (-1.0 / min_eig)).min(1.0)
+            tau.min(1.0)
+        };
+        if tau >= 1.0 {
+            return candidate;
         }
+        // Fraction-to-boundary contract (τ < 1): the returned step keeps the
+        // block *strictly* inside the cone. In exact arithmetic the candidate
+        // carries a (1 − τ) margin; near a rank-deficient slack rounding can
+        // eat it, so verify and halve until interiority holds. If no positive
+        // step is strictly interior — `v` itself has already numerically left
+        // the cone — return 0, which the driver treats as a breakdown rather
+        // than stepping onto meaningless data.
+        let mut alpha = candidate;
+        let mut trial = vec![0.0; v.len()];
+        for _ in 0..60 {
+            if alpha <= 0.0 {
+                return 0.0;
+            }
+            for (t, (a, b)) in trial.iter_mut().zip(v.iter().zip(dv)) {
+                *t = a + alpha * b;
+            }
+            if self.min_eig(&trial) > 0.0 {
+                return alpha;
+            }
+            alpha *= 0.5;
+        }
+        0.0
     }
 
     /// The Nesterov–Todd scaling matrix `W` (symmetric PD) for the
@@ -632,6 +686,97 @@ mod tests {
         // At α just below 1 the point is still PD; with τ = 0.99, step ≈ 0.99.
         let a2 = c.max_step(&v, &dv, 0.99);
         assert!((a2 - 0.99).abs() < 1e-9, "step {a2}");
+    }
+
+    /// gh #226: the fraction-to-boundary step (τ < 1) must keep the block
+    /// *strictly* inside the cone even when `v` is nearly singular — the
+    /// regime (an optimum on the PSD boundary) where the scaled eigenvalue
+    /// computation loses exactly the accuracy that matters. Sweep
+    /// boundary-hugging points against outward directions and require strict
+    /// interiority at the returned step.
+    #[test]
+    fn max_step_keeps_near_singular_blocks_inside_the_cone() {
+        let c = PsdCone::new(3);
+        // A rotation Q (Givens on axes 0-1 then 1-2) to make the test
+        // matrices dense rather than diagonal.
+        let (co, si) = (0.8, 0.6);
+        let q1 = vec![co, -si, 0.0, si, co, 0.0, 0.0, 0.0, 1.0];
+        let q2 = vec![1.0, 0.0, 0.0, 0.0, co, -si, 0.0, si, co];
+        let mut q = vec![0.0; 9];
+        matmul(&q1, &q2, 3, &mut q);
+        let rotate = |diag: [f64; 3]| {
+            let mut d = vec![0.0; 9];
+            for i in 0..3 {
+                d[i * 3 + i] = diag[i];
+            }
+            let mut tmp = vec![0.0; 9];
+            let mut out = vec![0.0; 9];
+            matmul(&q, &d, 3, &mut tmp);
+            // Q D Qᵀ: Qᵀ as the transpose of the row-major q.
+            let mut qt = vec![0.0; 9];
+            for i in 0..3 {
+                for j in 0..3 {
+                    qt[i * 3 + j] = q[j * 3 + i];
+                }
+            }
+            matmul(&tmp, &qt, 3, &mut out);
+            let mut sv = vec![0.0; 6];
+            svec(&out, 3, &mut sv);
+            sv
+        };
+        for &eps in &[1e-6, 1e-10, 1e-13] {
+            let v = rotate([1.0, 0.3, eps]);
+            for (case, dv) in [
+                rotate([-1.0, -0.3, -eps]),       // straight at the origin
+                rotate([-2.0, 0.1, -10.0 * eps]), // out through the small mode
+                rotate([0.5, -0.7, -1.0]),        // hard out of the cone
+            ]
+            .iter()
+            .enumerate()
+            {
+                let alpha = c.max_step(&v, dv, 0.95);
+                assert!(
+                    (0.0..=1.0).contains(&alpha),
+                    "eps={eps} case {case}: alpha {alpha} out of range"
+                );
+                let trial: Vec<f64> = v.iter().zip(dv).map(|(a, b)| a + alpha * b).collect();
+                assert!(
+                    c.min_eig(&trial) > 0.0,
+                    "eps={eps} case {case}: step alpha={alpha} left the cone \
+                     (min eig {})",
+                    c.min_eig(&trial)
+                );
+            }
+            // An inward direction still takes the full step.
+            let mut inward = vec![0.0; 6];
+            c.identity(&mut inward);
+            assert!(
+                (c.max_step(&v, &inward, 0.95) - 1.0).abs() < 1e-12,
+                "eps={eps}"
+            );
+        }
+    }
+
+    /// gh #226: a `v` that has already (numerically) left the cone admits no
+    /// strictly interior step along an outward direction — the answer is 0
+    /// (the driver treats it as a breakdown), never a garbage near-full step
+    /// from a clamped or failed scaling.
+    #[test]
+    fn max_step_is_zero_when_v_is_outside_and_direction_points_out() {
+        let c = PsdCone::new(2);
+        // diag(1, −1e-12): min eig negative, i.e. round-off past the boundary.
+        let v = {
+            let m = vec![1.0, 0.0, 0.0, -1e-12];
+            let mut sv = vec![0.0; 3];
+            svec(&m, 2, &mut sv);
+            sv
+        };
+        let mut dv = vec![0.0; 3];
+        c.identity(&mut dv);
+        for x in dv.iter_mut() {
+            *x = -*x;
+        }
+        assert_eq!(c.max_step(&v, &dv, 0.95), 0.0);
     }
 
     #[test]

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -115,6 +115,11 @@ pub struct QpOptions {
     /// into the direct solver, which they require. Their callers are doing
     /// *nearby reoptimization* (a known-solvable neighborhood), where the
     /// direct path's fragility is not a concern.
+    ///
+    /// With `false` on a PSD-carrying problem, [`solve_socp_ipm`] retries a
+    /// direct solve that ends without a full answer through HSDE once (gh
+    /// #226) — the direct driver is known-weak on boundary-degenerate PSD
+    /// optima, where the embedding stays well-conditioned.
     pub use_hsde: bool,
     /// Collect a per-iteration convergence trace into
     /// [`crate::QpSolution::iterates`]. Off by default so a normal solve has
@@ -445,11 +450,58 @@ where
         // variables); then chordal range-space decomposition of any still
         // connected-but-sparse PSD cone (introduces clique blocks + overlap
         // consistency equalities). Reconstruct the dual through both layers.
+        let mut make_backend = make_backend;
         let (prob1, cones1, row_map) = decompose_psd(prob, cones);
         let (prob2, cones2, recon) = chordal_decompose(&prob1, &cones1);
-        let sol2 = solve_socp_symmetric(&prob2, &cones2, opts, make_backend);
-        let sol1 = chordal_reconstruct(sol2, &recon, &prob1);
-        return remap_decomposed_z(sol1, &row_map, prob.m_ineq());
+        let run = |o: &QpOptions, mk: &mut F| {
+            let sol2 = solve_socp_symmetric(&prob2, &cones2, o, mk);
+            let sol1 = chordal_reconstruct(sol2, &recon, &prob1);
+            remap_decomposed_z(sol1, &row_map, prob.m_ineq())
+        };
+        let sol = run(opts, &mut make_backend);
+        // gh #226: the direct symmetric driver is known-weak on PSD programs
+        // whose optimum sits on the cone boundary (a rank-deficient slack,
+        // where the NT scaling's condition number blows up) — a small
+        // fraction of well-posed instances stall or break down there while
+        // the HSDE embedding solves them cleanly. When a caller opted out of
+        // HSDE and the direct solve ended without a full answer, retry once
+        // with the embedding, mirroring the reverse-direction fallback in
+        // `solve_qp_ipm_core`. Sound for the same reason: the direct solve
+        // already failed, so there is nothing left to regress — the retry is
+        // kept only when it is a strict upgrade. Verified infeasibility /
+        // unboundedness certificates are proofs, not failures, and are never
+        // second-guessed.
+        if !opts.use_hsde
+            && matches!(
+                sol.status,
+                QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::OptimalInaccurate
+            )
+        {
+            let hsde_opts = QpOptions {
+                use_hsde: true,
+                ..*opts
+            };
+            let retry = run(&hsde_opts, &mut make_backend);
+            let upgraded = match (sol.status, retry.status) {
+                // A clean optimum always wins.
+                (_, QpStatus::Optimal) => true,
+                // A failed solve carries no usable answer, so any verdict
+                // with information beats it. An `OptimalInaccurate` original
+                // is a usable answer, so only the clean arm above replaces it
+                // (in particular a contradictory infeasibility claim does not).
+                (
+                    QpStatus::NumericalFailure | QpStatus::IterationLimit,
+                    QpStatus::OptimalInaccurate
+                    | QpStatus::PrimalInfeasible
+                    | QpStatus::DualInfeasible,
+                ) => true,
+                _ => false,
+            };
+            if upgraded {
+                return retry;
+            }
+        }
+        return sol;
     }
     solve_socp_symmetric(prob, cones, opts, make_backend)
 }
@@ -1434,6 +1486,18 @@ fn run_ipm(
             break;
         }
 
+        // Breakdown: the cones are self-dual, so `⟨s,z⟩ ≥ 0` for any iterate
+        // genuinely inside them — a clearly negative μ means the iterate has
+        // left the cone (a fraction-to-boundary failure) and every Newton
+        // step from here is computed on meaningless data. Fail fast instead
+        // of diverging to a non-finite iterate (gh #226). The threshold sits
+        // orders of magnitude above the tiny negative values ordinary
+        // round-off can produce as μ → 0 near convergence (|μ| ≲ ε·‖s‖‖z‖).
+        if mu < -1e-10 * (1.0 + inf_norm(&s) * inf_norm(&z)) {
+            status = QpStatus::NumericalFailure;
+            break;
+        }
+
         if res < opts.tol {
             status = QpStatus::Optimal;
             // Record the converged iterate so the trace *ends* at the
@@ -1533,6 +1597,22 @@ fn run_ipm(
             let (alpha_p, alpha_d) = step_lengths(cone, &s, &ds, &z, &dz, opts.tau, m_ineq);
             step_p = alpha_p;
             step_d = alpha_d;
+
+            // Breakdown: an exactly zero step (both lengths — the PSD
+            // fraction-to-boundary returns 0 when the block has numerically
+            // left the cone, gh #226) leaves the iterate bit-for-bit
+            // unchanged, so every later pass recomputes the same direction
+            // and the same zero step until the iteration cap. Stop now
+            // instead; the final verdict below still salvages a near-optimal
+            // iterate, and the PSD entry point falls back to HSDE on this
+            // status. A *tiny but nonzero* step is deliberately not treated
+            // as a stall: near a breakdown the direction can be huge, so
+            // even a ~1e-15 step moves the iterate materially and some such
+            // solves do recover.
+            if step_p.max(step_d) <= 0.0 {
+                status = QpStatus::NumericalFailure;
+                break;
+            }
         }
 
         // Debugger checkpoint: the Newton step and its fraction-to-boundary

--- a/crates/pounce-convex/tests/conic_hsde_vs_direct.rs
+++ b/crates/pounce-convex/tests/conic_hsde_vs_direct.rs
@@ -192,6 +192,7 @@ fn solve(prob: &QpProblem, cones: &[ConeSpec], use_hsde: bool) -> pounce_convex:
 fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng) -> Vec<ConeSpec>) {
     let mut rng = Rng(seed);
     let (mut compared, mut hsde_only, mut direct_only) = (0usize, 0usize, 0usize);
+    let mut hsde_only_psd = 0usize;
     for case in 0..count {
         let blocks = shape(&mut rng);
         let n = rng.range(3, 8);
@@ -230,7 +231,12 @@ fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng)
             // A driver that solves one the other cannot is an improvement, not
             // a regression — but count them so a shape that silently stopped
             // solving anything cannot masquerade as agreement.
-            (QpStatus::Optimal, _) => hsde_only += 1,
+            (QpStatus::Optimal, _) => {
+                hsde_only += 1;
+                if cones.iter().any(|c| matches!(c, ConeSpec::Psd(_))) {
+                    hsde_only_psd += 1;
+                }
+            }
             (_, QpStatus::Optimal) => direct_only += 1,
             _ => {}
         }
@@ -241,6 +247,18 @@ fn agree_on(name: &str, seed: u64, count: usize, mut shape: impl FnMut(&mut Rng)
         compared * 4 >= count * 3,
         "{name}: only {compared}/{count} instances were solved by both drivers \
          (hsde-only {hsde_only}, direct-only {direct_only}) — too few to be evidence"
+    );
+    // gh #226: on PSD-carrying instances, the hsde-only column was the
+    // population the direct driver diverged on (~0.2% of a 15,960-instance
+    // sweep — every divergence involved a PSD block). With the hardened PSD
+    // fraction-to-boundary step and the direct→HSDE breakdown fallback it
+    // must be empty: any PSD instance HSDE solves, the direct entry point
+    // now solves. SOC-only instances are outside the fallback's scope (they
+    // never diverged; the residual hsde-only there is plain stalling), so
+    // they keep the informational count above.
+    assert_eq!(
+        hsde_only_psd, 0,
+        "{name}: {hsde_only_psd} PSD instances solved by HSDE but not the direct entry point"
     );
     println!(
         "{name}: {compared}/{count} compared, hsde-only {hsde_only}, direct-only {direct_only}"
@@ -331,16 +349,21 @@ fn boundary_hugging_instances_agree_across_drivers() {
 
 /// The gh #222 instance, verbatim.
 ///
-/// The direct driver diverges here — which is expected of it on a degenerate
-/// face, and precisely why the HSDE embedding is the default (see `sos_opts`).
-/// The defect was that it reported the divergence as `Optimal`, handing back
-/// `x = [NaN, NaN]` under a status that says the answer is usable.
+/// History: the direct driver used to diverge here (the optimum sits on the
+/// PSD boundary, where its NT scaling breaks down) and report the divergence
+/// as `Optimal` with `x = [NaN, NaN]`. gh #222 made the failure honest
+/// (`NumericalFailure`, via a NaN-proof `inf_norm` and an explicit exit
+/// guard). gh #226 then made the solve *succeed*: the PSD fraction-to-
+/// boundary step is verified (so the iterate can no longer be ejected from
+/// the cone), breakdowns fail fast, and the direct entry point falls back to
+/// HSDE — which solves this instance — when the direct iteration ends
+/// without a full answer.
 ///
-/// The mechanism was `inf_norm`: `f64::max` ignores `NaN`, so the ∞-norm of an
-/// all-`NaN` iterate came out `0.0` and `res < tol` passed. Both the norm and
-/// an explicit exit guard now prevent that.
+/// So the pinned behavior is now: the direct entry point returns the same
+/// finite, correct optimum HSDE does. The gh #222 invariant is subsumed — a
+/// success verdict with a non-finite answer would fail the value assertions.
 #[test]
-fn a_diverged_solve_is_never_reported_as_optimal() {
+fn the_gh222_instance_solves_through_the_direct_entry_point() {
     let prob = QpProblem {
         n: 2,
         p_lower: vec![],
@@ -380,19 +403,22 @@ fn a_diverged_solve_is_never_reported_as_optimal() {
     let cones = [ConeSpec::Nonneg(4), ConeSpec::Psd(3)];
 
     let direct = solve(&prob, &cones, false);
-    assert!(
-        !matches!(
-            direct.status,
-            QpStatus::Optimal | QpStatus::OptimalInaccurate
-        ),
-        "direct driver claimed {:?} with x = {:?}",
+    assert_eq!(
+        direct.status,
+        QpStatus::Optimal,
+        "direct entry point returned {:?} with x = {:?}",
         direct.status,
         direct.x
     );
+    assert!(direct.x.iter().all(|v| v.is_finite()), "{:?}", direct.x);
+    assert!(
+        (direct.obj - -3.0311688992249475).abs() < 1e-6,
+        "{}",
+        direct.obj
+    );
 
-    // The instance itself is solvable, and HSDE solves it — so the honest
-    // failure above is a property of that driver, not of the problem. Pin the
-    // answer so a future change cannot quietly break the case that works.
+    // Pin the HSDE answer too, so a future change cannot quietly break the
+    // driver the fallback (and the default path) relies on.
     let hsde = solve(&prob, &cones, true);
     assert_eq!(hsde.status, QpStatus::Optimal, "{:?}", hsde.status);
     assert!(


### PR DESCRIPTION
Closes #226.

The direct (non-HSDE) symmetric IPM diverged on ~0.2% of well-posed PSD programs: at an optimum with a rank-deficient slack, the PSD fraction-to-boundary step could return an optimistic length, the iterate left the cone (the negative-`mu` signature in the issue's trace), and the solve blew up into the `NumericalFailure` that #222/#225 made honest. HSDE solves every one of these instances, so the answer existed and this driver was failing to find it.

## Root cause

`PsdCone::max_step` computed the step through `V^{-1/2}` with eigenvalues clamped at `1e-300`. At a rank-deficient slack, a boundary eigenvalue rounding below zero turned that clamp into a ~1e150-entry scaling matrix and a garbage step length — and a failed eigensolve returned a near-full `tau` step with no safeguard. Either way the iterate was ejected from the cone and never recovered.

## Fix — the issue's directions 1–3, layered

1. **Real fix (`cones/psd.rs`)** — `max_step` computes the candidate from the true spectrum of `V` and, for the drivers' `tau < 1`, **verifies** the stepped point is strictly inside the cone, halving until it is. If `v` itself has numerically left the cone it returns 0 rather than garbage. `tau ≥ 1` keeps the exact boundary-landing semantics the existing unit tests pin.
2. **Fail fast on breakdown (`run_ipm`)** — a clearly negative `mu` (the cones are self-dual, so `⟨s,z⟩ ≥ 0` for any genuine interior iterate; the threshold is scaled so ordinary round-off as `mu → 0` never trips it) and an exactly zero step (a bit-for-bit fixed point) both stop the iteration immediately instead of diverging or spinning to the cap. The existing final-verdict salvage still runs. A tiny-but-nonzero step is deliberately *not* treated as a stall — near a breakdown the direction can be huge, and some such solves do recover.
3. **HSDE fallback (`solve_socp_ipm`)** — a direct solve of a PSD-carrying problem that ends without a full answer is retried once through the embedding, mirroring the reverse-direction fallback in `solve_qp_ipm_core`, and kept only when it is a strict upgrade. Verified infeasibility/unboundedness certificates are proofs and are never second-guessed.

## Results

- Differential sweep (`conic_hsde_vs_direct.rs`): hsde-only drops to **zero on every PSD tier** — `mixed` 7 → 0, `psd` 5 → 0, `degenerate` compared 75 → 80 — and is now locked by an assertion (`hsde_only_psd == 0`).
- SOC-only stays at its baseline (25 hsde-only): those are pre-existing plain stalls, never divergences per the issue's table, and are outside this issue's scope.
- The #222 minimal instance now solves to the pinned optimum (−3.03116889…) through the direct entry point; the test was updated to pin the new behavior (the #222 "never Optimal-with-NaN" invariant is subsumed by the value assertions).
- New unit tests: `max_step` strict interiority across boundary-hugging slacks and outward directions, and the zero-step contract for a slack already outside the cone.
- Full `pounce-convex`, `pounce-algorithm`, and `pounce-cli` suites pass; fmt clean; no new warnings in the CI-enforced clippy categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJNjNnUWsqNdkCpZB6kPXC

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJNjNnUWsqNdkCpZB6kPXC)_