### PR TITLE
pyomo-pounce: failed initialization solves no longer poison variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — failed initialization solves no longer poison variable values (Pyomo)
+
+- **A failed solve anywhere in the initialization pipeline now leaves
+  variable values exactly as they were.** Previously `block_initialize`
+  delegated its block loop to Pyomo's `solve_strongly_connected_components`,
+  which loads whatever the subsystem solver returns: a diverged block with a
+  warning-status result (infeasible, iteration limit) was written into
+  `Var.value` and the loop continued, reporting success. On a 1525-equation
+  air-separation model this turned a solvable steady state into a
+  3000-iteration stall — the model's own build point solved fine, but the
+  "initialized" point, containing a diverged 1500-variable block iterate,
+  did not. The block loop is now in this module: each block's verdict is
+  checked before its values are kept, a failed block restores its seed
+  values, the loop stops there (downstream blocks feed on the failed one by
+  construction), and the failure names the block. `project_to_feasible` had
+  the same defect — a diverged projection loaded its iterate, making the
+  pipeline's "continuing with the unrepaired point" warning untrue — and now
+  restores the pre-projection point on any non-optimal termination.
+
+
 ### Added — automatic specification repair: `block_repair_plan`, and repair inside `initialize`/`block_initialize` (Pyomo, #228)
 
 - **A structurally broken specification now initializes anyway, and the report

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ changes.
 
 ## [Unreleased]
 
-### Fixed — failed initialization solves no longer poison variable values (Pyomo)
+### Fixed — failed initialization solves no longer poison variable values (Pyomo, #230)
 
 - **A failed solve anywhere in the initialization pipeline now leaves
   variable values exactly as they were.** Previously `block_initialize`

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -84,6 +84,12 @@ one); `project_to_feasible` repairs that by minimizing
 bounds — the full nonlinear projection, solved with POUNCE, with the
 original objective restored afterwards.
 
+Both stages guarantee that a failed solve leaves variable values
+exactly as they were: a diverged projection restores the
+pre-projection point, and a failed block solve restores that block's
+seeds and stops, so initialization can never make your starting point
+worse than it found it.
+
 `block_initialize` is IDAES-flavored initialization without
 hand-written routines. `decisions=` holds the listed variables at
 their current values for the solve and releases them afterwards (each

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -6,10 +6,11 @@ active **equality** constraints, extract the square (well-determined)
 part of the variable/constraint incidence graph (Dulmage-Mendelsohn,
 via ``pyomo.contrib.incidence_analysis``), and solve it block by block
 in topological order, writing the solution into ``Var.value``. The
-block-by-block solve itself is delegated to Pyomo's
-``solve_strongly_connected_components`` (1x1 blocks by Newton, larger
-blocks by POUNCE); this module contributes the decision handling, the
-square-part extraction, the seeding, and the diagnostics.
+blocks solve one at a time (1x1 blocks by Newton, larger blocks by
+POUNCE), and every solve's verdict is checked before its values are
+kept: a failed block restores its seed values instead of poisoning the
+model. This module contributes the decision handling, the square-part
+extraction, the seeding, the checked block loop, and the diagnostics.
 
 The distillation-column shape of the workflow::
 
@@ -669,10 +670,11 @@ def block_initialize(
     Returns a :class:`BlockInitReport`. ``report.square`` is False when
     the equality system (after the repair) is still not exactly square;
     the offending variable/constraint **names** are reported, and the
-    square part is still solved best-effort. ``report.failures``
-    is non-empty when the block solve itself failed (Pyomo's
-    ``solve_strongly_connected_components`` fails fast, so variables in
-    blocks downstream of a failure keep their seed values).
+    square part is still solved best-effort. ``report.failures`` is
+    non-empty when a block solve failed: the failed block's variables
+    are restored to their seed values, the loop stops there, and the
+    downstream blocks keep their seeds — a failed solve never writes
+    its values into the model.
     """
     import pyomo.environ as pyo
 
@@ -682,14 +684,13 @@ def block_initialize(
         # would only blow up (DeferredImportError) at first use.
         import networkx  # noqa: F401
 
-        from pyomo.contrib.incidence_analysis import (
-            solve_strongly_connected_components,
-        )
+        import pyomo.contrib.incidence_analysis  # noqa: F401
     except ImportError as e:  # pragma: no cover - environment-dependent
         raise ImportError(
             "block_initialize requires pyomo.contrib.incidence_analysis "
             "and its optional dependencies (pip install networkx scipy)"
         ) from e
+    from pyomo.util.calc_var_value import calculate_variable_from_constraint
     from pyomo.util.subsystems import TemporarySubsystemManager, create_subsystem_block
 
     if repair not in ("auto", "off"):
@@ -770,25 +771,48 @@ def block_initialize(
         if n_large > 0 and solver is None:
             solver = pyo.SolverFactory("pounce")
 
-        # Delegate the block-by-block solve to Pyomo's own machinery:
-        # 1x1 blocks via calculate_variable_from_constraint, larger
-        # blocks via `solver`. Variables that appear in the square
-        # constraints but belong to the non-square part are temporarily
-        # fixed at their current values.
-        blk = create_subsystem_block(square_cons, square_vars)
-        try:
-            with TemporarySubsystemManager(to_fix=list(blk.input_vars.values())):
-                solve_strongly_connected_components(
-                    blk,
-                    solver=solver,
-                    solve_kwds={"tee": tee},
-                )
-            report.n_subsystem_solves = n_large
-            report.n_vars_initialized = len(square_vars)
-        except Exception as e:  # noqa: BLE001 - report, don't raise
-            report.failures.append(
-                f"strongly-connected-component solve failed: {e}"
-            )
+        # The block loop is ours so every solve's verdict is checked
+        # before its values are kept: a failed block restores its seed
+        # values instead of poisoning the model, then the loop stops
+        # (downstream blocks feed on this block by construction). 1x1
+        # blocks solve by Pyomo's single-constraint Newton, larger ones
+        # by `solver`; variables outside the block are held at their
+        # current values while it solves.
+        ok_conditions = ("optimal", "locallyOptimal", "globallyOptimal", "feasible")
+        n_done = 0
+        n_sub = 0
+        outer = create_subsystem_block(square_cons, square_vars)
+        with TemporarySubsystemManager(to_fix=list(outer.input_vars.values())):
+            for vblk, cblk in zip(
+                analysis.variable_blocks, analysis.constraint_blocks
+            ):
+                snapshot = [(vd, vd.value) for vd in vblk]
+                try:
+                    if len(vblk) == 1:
+                        calculate_variable_from_constraint(vblk[0], cblk[0])
+                    else:
+                        sub = create_subsystem_block(cblk, vblk)
+                        with TemporarySubsystemManager(
+                            to_fix=list(sub.input_vars.values())
+                        ):
+                            results = solver.solve(sub, tee=tee)
+                        cond = str(results.solver.termination_condition)
+                        if cond not in ok_conditions:
+                            raise RuntimeError(f"termination condition {cond}")
+                        n_sub += 1
+                    n_done += len(vblk)
+                except Exception as e:  # noqa: BLE001 - report, don't raise
+                    for vd, val in snapshot:
+                        vd.set_value(val, skip_validation=True)
+                    report.failures.append(
+                        f"{len(vblk)}x{len(vblk)} block at {cblk[0].name!r} "
+                        f"failed ({e}); its seed values are restored and "
+                        f"the {len(square_vars) - n_done - len(vblk)} "
+                        f"downstream variables keep their seeds"
+                    )
+                    break
+        report.n_subsystem_solves = n_sub
+        report.n_vars_initialized = n_done
     finally:
         for vd in fixed_by_us:
             vd.unfix()

--- a/pyomo-pounce/pyomo_pounce/repair.py
+++ b/pyomo-pounce/pyomo_pounce/repair.py
@@ -61,7 +61,9 @@ def project_to_feasible(
         tee: Echo solver output.
 
     Returns the solver termination condition as a string (``"optimal"``
-    / ``"locallyOptimal"`` on success). Raises ``ValueError`` when no
+    / ``"locallyOptimal"`` on success). On any other termination the
+    pre-projection values are restored, so a diverged projection never
+    writes its iterate into the model. Raises ``ValueError`` when no
     unfixed variable has a value (nothing to anchor; run
     ``initialize_missing_values`` first).
     """
@@ -78,6 +80,7 @@ def project_to_feasible(
             "project_to_feasible: no unfixed variable has a value to anchor "
             "the projection; run initialize_missing_values(model) first"
         )
+    snapshot = [(v, v.value) for v in variables]
     for v in variables:
         if v.value is None:
             _seed_var(v)
@@ -94,10 +97,16 @@ def project_to_feasible(
     model._pounce_projection_objective = pyo.Objective(
         expr=sum((v - v0) ** 2 for v, v0 in anchored)
     )
+    restore = True
     try:
         results = solver.solve(model, tee=tee, options=dict(options or {}))
-        return str(results.solver.termination_condition)
+        cond = str(results.solver.termination_condition)
+        restore = cond not in ("optimal", "locallyOptimal", "globallyOptimal", "feasible")
+        return cond
     finally:
+        if restore:
+            for v, val in snapshot:
+                v.set_value(val, skip_validation=True)
         model.del_component(model._pounce_projection_objective)
         for obj in deactivated:
             obj.activate()

--- a/pyomo-pounce/tests/test_block_init.py
+++ b/pyomo-pounce/tests/test_block_init.py
@@ -341,6 +341,52 @@ def drum_model():
     return m
 
 
+def test_failed_block_solve_keeps_seed_values(solver):
+    # A coupled block with no solution inside the bounds: the solve
+    # fails, and the seeds must survive untouched.
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(-10.0, 0.0), initialize=-1.0)  # solution needs x=2
+    m.y = pyo.Var(initialize=1.0)
+    m.c1 = pyo.Constraint(expr=m.x + m.y == 3.0)
+    m.c2 = pyo.Constraint(expr=m.x - m.y == 1.0)
+    m.obj = pyo.Objective(expr=m.y)
+
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert not report.ok
+    assert report.failures and "restored" in report.failures[0]
+    assert report.n_vars_initialized == 0
+    assert m.x.value == -1.0 and m.y.value == 1.0  # seeds, not the wreck
+
+
+def test_failed_newton_block_restores_seed():
+    # x**2 == -1 has no real solution: the single-constraint Newton
+    # fails, and the seed must come back.
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(initialize=3.0)
+    m.c = pyo.Constraint(expr=m.x**2 == -1.0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    report = pyomo_pounce.block_initialize(m)
+    assert not report.ok
+    assert m.x.value == 3.0
+
+
+def test_failure_stops_before_downstream_blocks(solver):
+    # the block after a failed one must keep its seed, not consume wreckage
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(-10.0, 0.0), initialize=-1.0)
+    m.y = pyo.Var(initialize=1.0)
+    m.z = pyo.Var(initialize=42.0)  # downstream of the failing 2x2
+    m.c1 = pyo.Constraint(expr=m.x + m.y == 3.0)
+    m.c2 = pyo.Constraint(expr=m.x - m.y == 1.0)
+    m.c3 = pyo.Constraint(expr=m.z == m.x * m.y)
+    m.obj = pyo.Objective(expr=m.z)
+
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert not report.ok
+    assert m.z.value == 42.0
+
+
 def test_repair_plan_no_op_on_square_system():
     m = pyo.ConcreteModel()
     m.feed = pyo.Var(initialize=10.0)

--- a/pyomo-pounce/tests/test_repair.py
+++ b/pyomo-pounce/tests/test_repair.py
@@ -142,3 +142,18 @@ def test_initialize_repair_off_reports_instead(solver):
     assert report.n_pinned == 0
     assert not report.block.square
     assert not m.M.fixed
+
+
+def test_projection_failure_restores_values(solver):
+    # projecting onto contradictory constraints fails; the point the
+    # caller had must come back, so the pipeline's "continuing with the
+    # unrepaired point" is literally true
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(initialize=5.0)
+    m.c1 = pyo.Constraint(expr=m.x == 1.0)
+    m.c2 = pyo.Constraint(expr=m.x == 2.0)
+    m.obj = pyo.Objective(expr=m.x)
+
+    cond = pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert cond not in ("optimal", "locallyOptimal")
+    assert m.x.value == 5.0


### PR DESCRIPTION
A failed solve anywhere in the initialization pipeline now leaves variable values exactly as they were. Failures are reported, never written into the model.

**The bug.** `block_initialize` delegated its block loop to Pyomo's `solve_strongly_connected_components`, which loads whatever the subsystem solver returns: a diverged block with a warning-status result (infeasible, iteration limit) was written into `Var.value` and the loop continued, with the report claiming every variable initialized. `project_to_feasible` had the same defect, so a diverged projection also loaded its iterate, making the pipeline's "continuing with the unrepaired point" warning untrue.

**The evidence.** On a 1525-equation air-separation model, the model's own build point solves the repaired steady-state specification to optimal, while the "initialized" point, containing the diverged iterate of a failed 1518-variable block solve, stalls for 3000 iterations. The poisoning was the entire difference.

**The fix.** The block loop moves into this module so each solve's verdict is checked before its values are kept: 1x1 blocks by Pyomo's single-constraint Newton, larger blocks by the solver, each block snapshotted first. A failed block restores its seeds, the loop stops there (downstream blocks feed on the failed one by construction), and the failure names the block and its size. The projection restores the pre-projection point on any non-optimal termination. Same restore-don't-report-through philosophy as the refused-stop mechanism in #229, one layer up.

Arguably the underlying sharp edge belongs to the Pyomo utility, which offers no per-block status check for a tool whose stated purpose is initialization; owning the loop fixes it here regardless and buys the named-block reporting.

Four new tests (failed coupled block keeps seeds, failed Newton restores its seed, downstream blocks keep seeds after a failure, failed projection restores the point); 100 pass. CHANGELOG under Unreleased and the no-poisoning guarantee stated in the book's pyomo page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)