### PR TITLE
Return a status instead of panicking when Mehrotra's affine step is missing (#231)

### DIFF
--- a/crates/pounce-algorithm/src/kkt/pd_search_dir_calc.rs
+++ b/crates/pounce-algorithm/src/kkt/pd_search_dir_calc.rs
@@ -99,15 +99,35 @@ impl PdSearchDirCalc {
             n.x_l().dim() + n.x_u().dim() + n.d_l().dim() + n.d_u().dim()
         };
 
-        if nbounds > 0 && self.mehrotra_algorithm {
-            let delta_aff = {
-                let d = data.borrow();
-                d.delta_aff
-                    .clone()
-                    .unwrap_or_else(|| panic!("PdSearchDirCalc: delta_aff missing for Mehrotra"))
-            };
+        // The Mehrotra corrector needs the affine (predictor) step, which
+        // the adaptive-μ oracle stores in `data.delta_aff`. Several
+        // legitimate paths leave it unset at this point even though
+        // `mehrotra_algorithm` is on: the affine solve can fail and fall
+        // back to the LOQO oracle (which computes no predictor step), the
+        // probing iterate-quality guard can return early without one, or we
+        // may be on an iteration before any affine step has been taken. In
+        // those cases fall back to the plain primal-dual z-blocks rather
+        // than panicking — the corrector is a second-order refinement, and
+        // the plain direction is a valid (if less aggressive) step. If the
+        // KKT system is genuinely unsolvable, `pd_solver.solve` below will
+        // report it by returning `false`, which the caller surfaces as a
+        // failed solve (`ErrorInStepComputation`) — a status callers can
+        // catch, unlike a process-killing panic (gh #231).
+        let delta_aff = if nbounds > 0 && self.mehrotra_algorithm {
+            data.borrow().delta_aff.clone()
+        } else {
+            None
+        };
+
+        if let Some(delta_aff) = delta_aff {
             self.fill_mehrotra_z_blocks(&delta_aff, cq, nlp, &mut rhs);
         } else {
+            if nbounds > 0 && self.mehrotra_algorithm {
+                tracing::debug!(target: "pounce::algorithm",
+                    "PdSearchDirCalc: Mehrotra corrector requested but no \
+                     affine step available; using the plain primal-dual \
+                     direction this iteration.");
+            }
             let cq_ref = cq.borrow();
             rhs.z_l.copy(&*cq_ref.curr_relaxed_compl_x_l());
             rhs.z_u.copy(&*cq_ref.curr_relaxed_compl_x_u());

--- a/crates/pounce-algorithm/tests/mehrotra_missing_affine_step.rs
+++ b/crates/pounce-algorithm/tests/mehrotra_missing_affine_step.rs
@@ -1,0 +1,169 @@
+//! gh #231 — `PdSearchDirCalc` must not panic when the Mehrotra corrector's
+//! affine step is missing.
+//!
+//! Under `mehrotra_algorithm=yes` the predictor (affine) step is produced by the
+//! adaptive-μ oracle and stashed in `IpoptData::delta_aff`. Several legitimate
+//! paths leave it unset when the main search-direction solve runs: the affine
+//! solve can fail and fall back to the LOQO oracle (which computes no predictor),
+//! the probing iterate-quality guard can return early without one, or an early
+//! iteration may precede the first affine step. Previously the main-step RHS
+//! assembly did `unwrap_or_else(|| panic!(...))` on `delta_aff`, so those states
+//! took the whole process down — uncatchable from the C API, the Python
+//! bindings, or the GAMS link.
+//!
+//! The minimal reproducer from the issue: a separable quartic with a single
+//! upper-bounded inequality, started far from the optimum with a large target
+//! coefficient, which is exactly the regime where the zero/ill-conditioned
+//! affine solve leaves `delta_aff` empty. The only property under test is that
+//! the solve returns *a status* instead of panicking.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `min (x0 − a0)⁴ + (x1 − a1)⁴  s.t.  x0 ≤ a0`, started at the origin.
+///
+/// With `a = [100, 137]` this is the issue's `a0 ≥ 1e2` panicking family.
+struct QuarticWithCap {
+    a: [Number; 2],
+}
+
+impl TNLP for QuarticWithCap {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 1,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-2.0e19; 2]);
+        b.x_u.copy_from_slice(&[2.0e19; 2]);
+        // g(x) = x0 ≤ a0.
+        b.g_l[0] = -2.0e19;
+        b.g_u[0] = self.a[0];
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.0, 0.0]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - self.a[0]).powi(4) + (x[1] - self.a[1]).powi(4))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 4.0 * (x[0] - self.a[0]).powi(3);
+        g[1] = 4.0 * (x[1] - self.a[1]).powi(3);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for i in 0..2 {
+                    irow[i] = i as i32;
+                    jcol[i] = i as i32;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                // g is linear, so the Lagrangian Hessian is the objective's.
+                let x = x.expect("eval_h(Values) without x");
+                values[0] = obj_factor * 12.0 * (x[0] - self.a[0]).powi(2);
+                values[1] = obj_factor * 12.0 * (x[1] - self.a[1]).powi(2);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn solve_mehrotra(a: [Number; 2]) -> ApplicationReturnStatus {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("mehrotra_algorithm", "yes", true, false)
+        .unwrap();
+    // Keep the run short — we only care that assembling the search direction
+    // does not panic, not that this pathological problem converges.
+    app.options_mut()
+        .set_integer_value("max_iter", 50, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(QuarticWithCap { a }));
+    app.optimize_tnlp(tnlp)
+}
+
+/// The regression: before the fix this panicked with
+/// "PdSearchDirCalc: delta_aff missing for Mehrotra". Now it returns a status.
+#[test]
+fn missing_affine_step_returns_a_status_instead_of_panicking() {
+    let status = solve_mehrotra([100.0, 137.0]);
+    eprintln!("gh#231 reproducer finished with {status:?}");
+    // Any terminal status is acceptable; the point is that the library returned
+    // control to the caller rather than aborting the process. `Internal_Error`
+    // (which is what an unwinding panic would map to if it were caught) must not
+    // appear, since the fix is a graceful fallback, not a caught panic.
+    assert!(
+        !matches!(status, ApplicationReturnStatus::InternalError),
+        "solve should not report an internal error, got {status:?}"
+    );
+}
+
+/// The issue notes the panic is fine at small `a0` and fires for `a0 ≥ 1e2`.
+/// The small-coefficient case must keep working (and should actually solve).
+#[test]
+fn small_coefficient_case_still_solves() {
+    let status = solve_mehrotra([1.0, 1.0]);
+    eprintln!("small-coefficient control finished with {status:?}");
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "the well-behaved case should still converge, got {status:?}"
+    );
+}


### PR DESCRIPTION
Fixes #231.

## Problem

`PdSearchDirCalc::compute_search_direction` assembled the Mehrotra corrector's RHS by unwrapping `data.delta_aff` with `unwrap_or_else(|| panic!("PdSearchDirCalc: delta_aff missing for Mehrotra"))` (`pd_search_dir_calc.rs:107`). A library panic unwinds/aborts the caller's process — uncatchable from the C API, the Python bindings, or the GAMS link — so this was the wrong failure mode for a recoverable condition.

## Root cause

`delta_aff` (the affine predictor step) is produced by the adaptive-μ oracle and stashed in `IpoptData`. Tracing the flow, three legitimate paths reach `compute_search_direction` with it unset while `mehrotra_algorithm` is on:

- The affine solve fails → the oracle returns `None` → falls back to the LOQO oracle (`adaptive.rs:702`), which computes no predictor step.
- The probing iterate-quality guard fires (`adaptive.rs:682`) and returns early; if no restoration phase is configured, `ipopt_alg.rs:970` only warns and continues into the search-direction step.
- Early iterations that precede the first affine step.

So `delta_aff` being absent is a legitimate state, exactly as the issue anticipated — not a bug upstream of this point.

## Fix

When the affine step is absent, fall back to the plain primal-dual z-blocks (the same blocks the non-Mehrotra branch already uses) rather than panicking. This is the handling the issue names as preferable: the Mehrotra corrector is a second-order refinement, and the plain direction is a valid — if less aggressive — step. If the KKT system is genuinely unsolvable, the downstream `pd_solver.solve` still returns `false`, which the caller surfaces as `ErrorInStepComputation` — a catchable status rather than a process-killing panic. A `debug`-level log records when the fallback is taken.

## Testing

- New regression test `mehrotra_missing_affine_step.rs` reproduces the issue's minimal case (separable quartic with an upper-bounded inequality, `a = [100, 137]`, `mehrotra_algorithm=yes`). Verified it panics at `pd_search_dir_calc.rs:107` without the fix and returns a status with it. A well-behaved control case (`a = [1, 1]`) still converges.
- Full `pounce-algorithm` test suite passes with no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W5ydumCyZsWdWx3CV8Foax

---
_Generated by [Claude Code](https://claude.ai/code/session_01W5ydumCyZsWdWx3CV8Foax)_