### PR TITLE
Honor hessian_approximation on the active-set SQP path

### DIFF
--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -828,9 +828,18 @@ impl IpoptApplication {
         let res = match alg.optimize_with_warm_start(&mut sqp_adapter, warm) {
             Ok(r) => r,
             Err(e) => {
-                if std::env::var_os("POUNCE_DBG_SQP").is_some() {
-                    tracing::warn!(target: "pounce::sqp", "[SQP] optimize_with_warm_start error: {e:?}");
-                }
+                // Always surface this. It used to be gated on the
+                // undocumented `POUNCE_DBG_SQP`, so the only thing a user saw
+                // was a bare `Internal_Error` with no indication of what went
+                // wrong -- the underlying message here was
+                // `QpFailure(LinearSolverFailure("QP subproblem returned
+                // status unbounded"))`, which points straight at the cause.
+                // A solve that is about to fail is exactly when the reason
+                // should be cheapest to obtain.
+                tracing::warn!(
+                    target: "pounce::sqp",
+                    "SQP solve failed: {e:?}"
+                );
                 return ApplicationReturnStatus::InternalError;
             }
         };
@@ -2879,6 +2888,28 @@ fn apply_sqp_options(options: &OptionsList, opts: &mut crate::sqp::SqpOptions) {
             "l1-elastic" => SqpGlobalization::L1Elastic,
             _ => opts.globalization,
         };
+    }
+    // `hessian_approximation` is the upstream Ipopt option a frontend sets
+    // when the caller supplies no second derivatives -- `pounce.minimize` does
+    // it automatically, and warns that it is doing so. It was only ever read
+    // on the IPM path, so an SQP solve ignored it and fell back to the
+    // `Exact` default, asking the NLP for a Lagrangian Hessian that was never
+    // provided. A zero Hessian turns the QP subproblem into an LP, which is
+    // unbounded whenever the objective gradient has a component in the null
+    // space of the active constraints -- so the solve died with
+    // `Internal_Error` on problems the IPM handles without complaint:
+    //
+    //     min (x0-3)^2 + (x1-2)^2  s.t.  4 - x0 - x1 >= 0
+    //
+    // (IPM: x = [2.5, 1.5]. Active-set SQP before this: Internal_Error, or
+    // with variable bounds, a run to the box corner along the null-space
+    // direction.)
+    //
+    // Read it before `sqp_hessian` so an explicit setting still wins.
+    if let Ok((s, true)) = options.get_string_value("hessian_approximation", "") {
+        if s == "limited-memory" {
+            opts.hessian = SqpHessianSource::Lbfgs;
+        }
     }
     if let Ok((s, true)) = options.get_string_value("sqp_hessian", "") {
         opts.hessian = match s.as_str() {

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1311,3 +1311,51 @@ def test_non_mapping_options_is_rejected_not_silently_dropped():
     # The supported forms are untouched.
     assert M.minimize(fun, np.ones(2), jac=jac, options={"tol": 1e-9}).success
     assert M.minimize(fun, np.ones(2), jac=jac).success
+
+
+def test_active_set_sqp_honors_hessian_approximation():
+    """An SQP solve must not demand a Hessian the caller never supplied.
+
+    ``hessian_approximation=limited-memory`` is what a frontend sets when no
+    second derivatives are available -- ``minimize`` does it automatically and
+    warns that it has. That option was only read on the IPM path, so an
+    active-set SQP solve fell back to its ``Exact`` default and asked the NLP
+    for a Lagrangian Hessian nobody provided. The resulting zero Hessian turns
+    the QP subproblem into an LP, unbounded along any null-space direction of
+    the active constraints, and the solve died with ``Internal_Error`` on a
+    problem the IPM solves without complaint.
+    """
+    fun = lambda v: (v[0] - 3.0) ** 2 + (v[1] - 2.0) ** 2
+    jac = lambda v: np.array([2 * (v[0] - 3.0), 2 * (v[1] - 2.0)])
+    con = [
+        {
+            "type": "ineq",
+            "fun": lambda v: np.array([4.0 - v[0] - v[1]]),
+            "jac": lambda v: np.array([[-1.0, -1.0]]),
+        }
+    ]
+    # Constrained minimum: project (3, 2) onto x0 + x1 = 4.
+    expected = np.array([2.5, 1.5])
+
+    sqp = pounce.minimize(
+        fun, [0.0, 0.0], jac=jac, constraints=con, solver_selection="qp-active-set"
+    )
+    assert sqp.success, f"active-set SQP failed: {sqp.message}"
+    np.testing.assert_allclose(sqp.x, expected, atol=1e-6)
+
+    # Same answer as the interior-point path.
+    ipm = pounce.minimize(fun, [0.0, 0.0], jac=jac, constraints=con)
+    np.testing.assert_allclose(sqp.x, ipm.x, atol=1e-6)
+
+    # An explicit sqp_hessian still overrides the inferred default.
+    for source in ("lbfgs", "damped-bfgs"):
+        r = pounce.minimize(
+            fun,
+            [0.0, 0.0],
+            jac=jac,
+            constraints=con,
+            solver_selection="qp-active-set",
+            sqp_hessian=source,
+        )
+        assert r.success
+        np.testing.assert_allclose(r.x, expected, atol=1e-6)


### PR DESCRIPTION
## The bug

```python
pounce.minimize(
    lambda v: (v[0]-3)**2 + (v[1]-2)**2, [0., 0.],
    jac=lambda v: np.array([2*(v[0]-3), 2*(v[1]-2)]),
    constraints=[{"type": "ineq",
                  "fun": lambda v: np.array([4. - v[0] - v[1]]),
                  "jac": lambda v: np.array([[-1., -1.]])}],
    solver_selection="qp-active-set",
)
```

```
status  = -199 (Internal_Error)
x       = [0. 0.]
```

The default interior-point path solves the same problem to `x = [2.5, 1.5]` — which is simply the projection of the unconstrained minimum `(3, 2)` onto `x0 + x1 = 4`. Nothing exotic: a convex QP with one linear inequality.

Adding variable bounds is worse than the error. It converges, to the wrong place:

```
bounds=[(-10, 10), (-10, 10)]  ->  status = -1 (MaxIter), x = [-10, 10]
```

`[-10, 10]` is the box corner along `(-1, +1)` — the null space of the constraint normal.

## Root cause

`hessian_approximation=limited-memory` is the upstream Ipopt option a frontend sets when the caller supplies no second derivatives. `pounce.minimize` sets it automatically and even warns that it is doing so.

`apply_sqp_options` never read it. It consulted only `sqp_hessian`, so an SQP solve fell back to `SqpHessianSource::Exact` and asked the NLP for a Lagrangian Hessian that was never provided.

A zero Hessian makes the QP subproblem an LP, unbounded along any null-space direction of the active constraints — hence the corner-running with bounds and the outright failure without them.

Confirmed by bisecting the option:

| | result |
|---|---|
| default (`sqp_hessian` unset → `exact`) | `Internal_Error` |
| `sqp_hessian="lbfgs"` | `x = [2.5, 1.5]` |
| `sqp_hessian="damped-bfgs"` | `x = [2.5, 1.5]` |

## The fix

`apply_sqp_options` now reads `hessian_approximation` and maps `limited-memory` to `SqpHessianSource::Lbfgs`.

It is read **before** `sqp_hessian`, so an explicit setting still wins, and a caller who genuinely supplies second derivatives is unaffected.

## Also: stop swallowing the failure

The underlying error names the cause exactly:

```
QpFailure(LinearSolverFailure("QP subproblem returned status unbounded"))
```

It was gated behind the undocumented `POUNCE_DBG_SQP`, so a user saw only a bare `Internal_Error` with nothing to go on. Diagnosing this required reading `application.rs` to discover the variable existed.

It is now logged unconditionally. `POUNCE_DBG_SQP` had exactly one use and is removed.

## Verification

- `cargo test --workspace --exclude pounce-hsl` — **1997 passed, 0 failed**
- `cargo clippy` under CI's exact flags — clean
- `pytest python/tests` — **619 passed, 3 skipped, 0 failed**
- New regression test `test_active_set_sqp_honors_hessian_approximation`, which pins the SQP answer to the IPM answer and checks that explicit `sqp_hessian` still overrides

## Related

Found while building the trust-region filter optimizer (#233), which drives repeated subproblem solves and so exercises this path hard. Independent of that change — this branch is cut from `main` and can land on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEL8uhc9B1BeEbVo6tX4y3
