### PR TITLE
Report an unevaluated objective as NaN rather than zero

### DIFF
--- a/crates/pounce-nlp/src/solve_statistics.rs
+++ b/crates/pounce-nlp/src/solve_statistics.rs
@@ -137,6 +137,16 @@ pub struct SolveStatistics {
 ///   as `null` rather than `0.0` in a solve report for an aborted solve. See
 ///   `docs/src/schema/solve-report-v1.md`.
 ///
+/// The two objective fields are in the set for the same reason, though the
+/// stakes are lower: nothing *decides* anything from them, they are only
+/// reported (console summary, studio markdown, the JSON report). But `0.0` is
+/// a perfectly ordinary objective value, so a reader cannot tell a solve that
+/// legitimately reached zero from one that never evaluated anything. One rule
+/// -- uncomputed is NaN -- is easier to reason about than "residuals are NaN,
+/// objectives are zero, and you have to remember which is which". Note they
+/// are seeded best-effort from the current iterate whenever one exists, so
+/// they are only NaN when the solve died before producing any point at all.
+///
 /// `final_mu` is deliberately *not* in this set: `0.0` is its documented value
 /// on the barrier-free SQP path, where mu has no meaning.
 impl Default for SolveStatistics {
@@ -151,8 +161,8 @@ impl Default for SolveStatistics {
             num_obj_grad_evals: 0,
             num_constr_jac_evals: 0,
             num_hess_evals: 0,
-            final_objective: 0.0,
-            final_scaled_objective: 0.0,
+            final_objective: Number::NAN,
+            final_scaled_objective: Number::NAN,
             final_dual_inf: Number::NAN,
             final_constr_viol: Number::NAN,
             final_compl: Number::NAN,

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -929,7 +929,14 @@ impl PyProblem {
             final_z_u: vec![0.0; n],
             final_g: vec![0.0; m],
             final_lambda: vec![0.0; m],
-            final_obj: 0.0,
+            // NaN, not 0.0. This is only overwritten in `finalize_solution`,
+            // which a refused solve never reaches -- so a zero here surfaces
+            // in `info["obj_val"]` as a fabricated objective for a solve that
+            // evaluated nothing. `0.0` is an ordinary objective value and
+            // cannot signal "never computed". Matches the NaN the batch path
+            // already reports for its failure case (`nlp_batch.rs`) and the
+            // `SolveStatistics` residual/objective defaults.
+            final_obj: Number::NAN,
             final_status_code: 0,
         })
     }

--- a/crates/pounce-solve-report/src/lib.rs
+++ b/crates/pounce-solve-report/src/lib.rs
@@ -292,7 +292,9 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatisticsInfo {
     pub iteration_count: Index,
+    #[serde(default = "uncomputed", deserialize_with = "null_as_nan")]
     pub final_objective: Number,
+    #[serde(default = "uncomputed", deserialize_with = "null_as_nan")]
     pub final_scaled_objective: Number,
     #[serde(default = "uncomputed", deserialize_with = "null_as_nan")]
     pub final_dual_inf: Number,

--- a/crates/pounce-studio-core/src/report.rs
+++ b/crates/pounce-studio-core/src/report.rs
@@ -224,7 +224,9 @@ where
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StatisticsInfo {
     pub iteration_count: i32,
+    #[serde(default = "uncomputed", deserialize_with = "null_as_nan")]
     pub final_objective: f64,
+    #[serde(default = "uncomputed", deserialize_with = "null_as_nan")]
     pub final_scaled_objective: f64,
     #[serde(default = "uncomputed", deserialize_with = "null_as_nan")]
     pub final_dual_inf: f64,

--- a/docs/src/schema/solve-report-v1.md
+++ b/docs/src/schema/solve-report-v1.md
@@ -168,14 +168,14 @@ the per-iteration history (which lives at the top level when present).
 | Field | Type | Notes |
 |---|---|---|
 | `iteration_count` | integer | Number of accepted outer iterations. |
-| `final_objective` | float | Unscaled. Matches `solution.objective`. |
-| `final_scaled_objective` | float | Scaled by the IPM's internal NLP scaling. Equal to `final_objective` when no scaling is in effect. |
+| `final_objective` | float \| null | Unscaled. Matches `solution.objective`. `null` if never computed — see below. |
+| `final_scaled_objective` | float \| null | Scaled by the IPM's internal NLP scaling. Equal to `final_objective` when no scaling is in effect. `null` if never computed. |
 | `final_dual_inf` | float \| null | `||∇L||∞` at termination. `null` if never computed — see below. |
 | `final_constr_viol` | float \| null | `||c(x)||∞` (primal infeasibility). `null` if never computed. |
 | `final_compl` | float \| null | Max complementarity over the four bound blocks. `null` if never computed. |
 | `final_kkt_error` | float \| null | Overall KKT error reported by the convergence check. `null` if never computed. |
 
-> **`null` residuals.** These four are produced by the convergence check at the
+> **`null` values.** The four residuals are produced by the convergence check at the
 > end of a solve. A solve the solver *refused* — rejected during setup
 > (`NotEnoughDegreesOfFreedom`, `InvalidProblemDefinition`), aborted, or caught
 > by the batch panic handler — never reaches it, and these slots are emitted as
@@ -183,8 +183,13 @@ the per-iteration history (which lives at the top level when present).
 > solve, and consumers acted on it: it was enough to make `pounce.minimize`
 > report `success=True` for a problem the solver had declined to attempt.
 >
+> The two objective fields follow the same rule for the same reason: `0.0` is
+> an ordinary objective value, so it cannot signal "never evaluated". They are
+> seeded from the current iterate whenever one exists, so they are `null` only
+> when the solve produced no point at all.
+>
 > Consumers should treat `null` as "not computed", not as zero. pounce's own
-> readers map it to NaN, which fails closed against any `residual <= tol` test.
+> readers map it to NaN, which fails closed against any `value <= tol` test.
 | `num_obj_evals` | integer | `eval_f` call count. |
 | `num_constr_evals` | integer | `eval_g` call count. |
 | `num_obj_grad_evals` | integer | `eval_grad_f` count. |

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1398,3 +1398,51 @@ def test_active_set_sqp_honors_hessian_approximation():
         )
         assert r.success
         np.testing.assert_allclose(r.x, expected, atol=1e-6)
+
+
+def test_uncomputed_objective_is_nan_not_zero():
+    """An objective that was never evaluated must not be reported as ``0.0``.
+
+    Same sentinel problem the residuals had: ``0.0`` is a perfectly ordinary
+    objective value, so it cannot signal "never computed". A refused solve
+    never reaches ``finalize_solution``, so ``obj_val`` used to come back as a
+    fabricated zero.
+
+    Lower stakes than the residual case -- nothing *decides* anything from the
+    objective, it is only reported -- but one rule ("uncomputed is NaN") beats
+    remembering which fields lie.
+    """
+    # 2 variables, 3 equality constraints -> refused.
+    res = pounce.minimize(
+        lambda v: (v[1] - 1.0) ** 2 + v[0] ** 2,
+        [0.5, 0.0],
+        jac=lambda v: np.array([2 * v[0], 2 * (v[1] - 1.0)]),
+        bounds=[(0.3, 0.7), (-1e20, 1e20)],
+        constraints=[
+            {
+                "type": "eq",
+                "fun": lambda v: np.array([v[0] - 5.0, v[0] + 5.0]),
+                "jac": lambda v: np.array([[1.0, 0.0], [1.0, 0.0]]),
+            },
+            {
+                "type": "eq",
+                "fun": lambda v: np.array([v[1] - v[0] + 0.5]),
+                "jac": lambda v: np.array([[-1.0, 1.0]]),
+            },
+        ],
+    )
+    assert not res.success
+    assert np.isnan(res.info["obj_val"]), (
+        "a solve that evaluated nothing must not report an objective of 0.0"
+    )
+
+    # ...and a solve whose objective genuinely *is* zero still reports zero.
+    ok = pounce.minimize(
+        lambda v: float(v @ v),
+        [1.0, 1.0],
+        jac=lambda v: 2.0 * v,
+        bounds=[(-5, 5), (-5, 5)],
+    )
+    assert ok.success
+    assert not np.isnan(ok.info["obj_val"])
+    assert ok.info["obj_val"] == pytest.approx(0.0, abs=1e-12)


### PR DESCRIPTION
Completes the change started in #233, which made `SolveStatistics` residuals
default to NaN so "never computed" is distinguishable from "converged exactly".
The two objective fields were left at `0.0`, which has the same defect: `0.0` is
an ordinary objective value and cannot signal that nothing was evaluated.

## How much this actually matters

Less than the residual case, and it is worth being explicit about why.

The residual bug was harmful because `success` was **computed from**
`final_kkt_error` — a refused solve came back `success=True` with an `x`
outside its own bounds. Nothing decides anything from the objective. Grepping
every non-assignment use of `final_objective` turns up only reporting sites:
the console summary, studio markdown, the JSON report, and test assertions.

So the worst this does is print a misleading number in a summary for a solve
that has already reported failure. The argument for fixing it is consistency:
one rule — *uncomputed is NaN* — is easier to reason about than remembering
which fields lie.

## Three fields, not two

`info["obj_val"]`, the objective a Python caller actually reads, does **not**
come from `SolveStatistics`. It comes from the Python bridge's `final_obj`,
which is written only in `finalize_solution` — a path a refused solve never
reaches. Fixing just the Rust statistics would have left the user-facing field
returning a fabricated zero, which is the thing this PR is about.

The batch path already got this right (`nlp_batch.rs` reports `f64::NAN` for
its failure case); this brings the single-solve path in line.

## Behaviour

```
REFUSED  obj_val = nan
SUCCESS  obj_val = 0.0        <- a genuine zero objective still reports zero
```

Verified with a solve whose objective legitimately reaches zero
(`min xᵀx` from `[1,1]`): it reports a real value, not `null`. That is the whole
point of the distinction.

| surface | before | after |
|---|---|---|
| successful solve | — | identical |
| `info["obj_val"]`, refused | `0.0` | `nan` |
| report `final_objective`, refused | `0.0` | `null` |
| report `final_scaled_objective`, refused | `0.0` | `null` |
| `pounce --cite` on that report | worked | still works |

Both objective fields get the same `null`-tolerant deserializer the residuals
already have, so reports round-trip through `--cite` / studio / verify.

## Schema

`solve-report-v1.md`: the two objective fields become `float | null`, with a
note that they are seeded from the current iterate whenever one exists — so
they are `null` only when the solve produced no point at all, a narrower window
than the residuals have.

## Verification

- `cargo test --workspace --exclude pounce-hsl` — **1997 passed, 0 failed**
  (including the integration tests that assert on `final_objective`;
  they run successful solves, which populate it)
- `cargo clippy` under CI's exact flags — clean
- `pytest python/tests` — **663 passed, 3 skipped, 0 failed**
- New regression test `test_uncomputed_objective_is_nan_not_zero`, which pins
  both directions: NaN when refused, a real zero when the objective genuinely
  is zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEL8uhc9B1BeEbVo6tX4y3
