### PR TITLE
Stage the CLI binary into python/pounce/bin on a dev install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 
 .PHONY: all build debug test check clippy fmt fmt-check doc book screencast install uninstall clean help \
         install-mcp uninstall-mcp install-skill uninstall-skill pounce-ma57 \
-        python-ext python-test \
+        python-ext python-cli-bin python-test \
         benchmark benchmark-rerun benchmark-report benchmark-gams
 
 all: build
@@ -146,7 +146,25 @@ help:
 # `python/tests/conftest.py` additionally guards against running pytest
 # against a stale artifact. Requires `maturin` and the test extras in the
 # active environment (`pip install -e 'python[dev]'`).
-python-ext:
+#
+# `python-ext` also stages the CLI binary into `python/pounce/bin/`, because
+# `maturin develop` does not. The wheel ships the Rust `pounce` executable
+# there and installs a console-script shim that execs it (see
+# `python/pounce/_cli.py`); `maturin develop` installs that same shim but
+# builds only the extension module, so in a dev install the shim always points
+# at a file nothing ever created. The visible symptom is not an error: the
+# broken shim sits later on `PATH` than `~/.local/bin`, so `pounce` silently
+# resolves to whatever older binary was installed there — and anything driving
+# the CLI (Pyomo via NL/SOL, the benchmark harness) quietly runs that instead.
+# A stale binary that still works is far worse than one that fails.
+#
+# `python/pounce/bin/` is already gitignored for exactly this artifact.
+python-cli-bin:
+	$(CARGO) build -p pounce-cli $(CARGO_PROFILE_FLAG) $(CARGO_FLAGS)
+	install -d python/pounce/bin
+	install -m 0755 "$(CLI_BIN)" python/pounce/bin/pounce
+
+python-ext: python-cli-bin
 	cd python && maturin develop
 
 python-test: python-ext


### PR DESCRIPTION
## The problem

The wheel ships the Rust `pounce` executable inside `python/pounce/bin/` and
installs a console-script shim that execs it (`python/pounce/_cli.py`).
`maturin develop` installs that **same shim** but builds only the extension
module — so in a dev install the shim always points at a file nothing ever
created:

```
$ .venv/bin/pounce --version
pounce: bundled CLI binary not found at .../python/pounce/bin/pounce.
This usually means the package was installed with `maturin develop`,
which builds only the Python extension.
```

`python/pounce/bin/` is already in `.gitignore` for exactly this artifact. The
dev flow simply never populated it.

## Why it matters more than it looks

The failure is silent, not loud. That dead shim sits **later on PATH** than
`~/.local/bin`, so `pounce` resolves to whatever older binary happens to be
installed there. Anything driving the CLI — Pyomo over NL/SOL, the benchmark
harness — quietly runs that instead, with nothing indicating a version
mismatch.

On the machine where this was found, `~/.local/bin/pounce` was **0.2.0** from
three months earlier while the workspace was at **0.9.0**. It surfaced as a
literature benchmark appearing to need 113 iterations where the reference (and
ipopt) said 70 — which read as a real convergence difference and cost a
debugging cycle before the version gap turned up. Rebuilding closed the gap
exactly.

A stale binary that still works is considerably worse than one that fails.

## The change

`python-ext` now builds `pounce-cli` and installs it alongside the extension,
so a dev install has a working `pounce` on PATH. Split into its own
`python-cli-bin` target so the CLI can be staged without rebuilding the
extension.

```make
python-cli-bin:
	$(CARGO) build -p pounce-cli $(CARGO_PROFILE_FLAG) $(CARGO_FLAGS)
	install -d python/pounce/bin
	install -m 0755 "$(CLI_BIN)" python/pounce/bin/pounce

python-ext: python-cli-bin
	cd python && maturin develop
```

It follows the profile convention of the rest of the Makefile (`PROFILE ?=
release`), so `make python-ext PROFILE=debug` stages a debug CLI if you want
the faster build.

## Verification

```
$ make python-ext
$ .venv/bin/pounce --version
pounce 0.9.0                     # was: "bundled CLI binary not found"

$ git status --short
 M Makefile                      # the staged binary stays gitignored
```

`pytest python/tests/test_minimize.py python/tests/test_trf.py` — 99 passed.

## Note

This does not by itself fix a machine that already has an old binary earlier on
PATH — `~/.local/bin` still wins. `make install` (which targets
`$(PREFIX)/bin`, default `$(HOME)/.local/bin`) overwrites it. This change stops
new dev installs from landing in that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GEL8uhc9B1BeEbVo6tX4y3
