### PR TITLE
Enable MathJax in the docs; build the Python extension in release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ python-cli-bin:
 	install -m 0755 "$(CLI_BIN)" python/pounce/bin/pounce
 
 python-ext: python-cli-bin
-	cd python && maturin develop
+	cd python && maturin develop --release
 
 python-test: python-ext
 	cd python && python -m pytest tests -q

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,6 +6,11 @@ language = "en"
 src = "src"
 
 [output.html]
+# trf.md and dae.md write math with mdBook's escaped delimiters (`\\(...\\)`,
+# `\\[...\\]`). mdBook emits those as MathJax delimiters but only injects the
+# MathJax script when this is set, so without it the equations render as raw
+# `\(f, h, g\)` text.
+mathjax-support = true
 default-theme = "navy"
 preferred-dark-theme = "navy"
 additional-css = ["assets/pounce.css"]


### PR DESCRIPTION
## Enable MathJax (`docs/book.toml`)

Equations on [trf.html](https://kitchingroup.cheme.cmu.edu/pounce/dev/trf.html) render as raw TeX. The published page contains a literal `\(f, h, g\)` where the inline math should be.

The markdown was never the problem. `trf.md` and `dae.md` use mdBook's escaped delimiters (`\\(...\\)`, `\\[...\\]`) correctly, and mdBook collapses them to real MathJax delimiters in the HTML. But mdBook only injects the MathJax script when `mathjax-support = true`, and `book.toml` never set it, so nothing consumed the delimiters.

One line, plus a comment noting which pages depend on it.

Verified with a local mdbook 0.5.2 build: `trf.html` and `dae.html` now both carry the MathJax script tag and the 34 delimiters in `trf.html` survive intact. `scripts/check-docs-consistency.sh` passes (39 pages, no dead links).

Note this pulls MathJax **2.7.1 from cdnjs**. That version is hardcoded by mdBook 0.5.2 and is not configurable without overriding the theme. Fine for the TeX on these pages, but it is an unmaintained major version served from a CDN. Worth a follow-up if we would rather vendor it or move to `mdbook-katex`.

## Build the extension in release (`Makefile`)

Unrelated, but noticed while pulling. `PROFILE ?= release`, so `python-cli-bin` builds the CLI with `$(CARGO_PROFILE_FLAG)` = `--release`, while the `maturin develop` on the next line built the extension in debug. A default `make python-ext` produced a release CLI next to a debug extension, the slow half being the one doing the numerics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
