### PR TITLE
Honor max_wall_time/max_cpu_time with bounded overshoot

### DIFF
--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1599,6 +1599,19 @@ impl IpoptApplication {
         // the application exposes via `timing_stats()`.
         let data: crate::ipopt_data::IpoptDataHandle = Rc::new(RefCell::new(AlgIpoptData::new()));
         data.borrow_mut().timing = Rc::clone(&timing);
+        // Install a shared wall/CPU-time deadline (pounce#242) so the time
+        // budget is honored at the granularity of the expensive inner
+        // steps — the main loop's KKT factorization / line search and the
+        // restoration inner IPM — instead of only between outer iterations.
+        // The `Deadline` starts its clock now (right after `overall_alg`),
+        // and the restoration sub-solve reuses this same instance, so the
+        // caller's budget bounds the whole solve rather than each nested
+        // level independently. The convergence check treats it as
+        // authoritative when present (see `conv_check::opt_error`).
+        data.borrow_mut().deadline = Some(pounce_common::timing::Deadline::new(
+            builder.conv_check.max_wall_time,
+            builder.conv_check.max_cpu_time,
+        ));
         let cq: crate::ipopt_cq::IpoptCqHandle = Rc::new(RefCell::new(
             IpoptCalculatedQuantities::new(Rc::clone(&data), Rc::clone(&nlp_handle)),
         ));

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -458,18 +458,36 @@ impl ConvCheck for OptErrorConvCheck {
                 return ConvergenceStatus::LocallyInfeasible;
             }
         }
-        // Time-budget gates. Upstream
+        // Time-budget gates. When the application installed a shared
+        // [`Deadline`] (pounce#242) it is authoritative: it measures
+        // global elapsed time from a fixed start instant, so it fires
+        // correctly even inside the restoration inner IPM, whose fresh
+        // `timing.overall_alg` is never started. Absent a deadline (the
+        // direct-driver / unit-test path), fall back to the `overall_alg`
+        // timer, which `IpoptApplication` starts at the top of
+        // `optimize_constrained`; `live_*` returns the running elapsed
+        // without forcing a `start/end` cycle. Upstream
         // `IpOptErrorConvCheck.cpp::CheckConvergence` reads the
-        // application-level start time; pounce piggybacks on
-        // `data.timing.overall_alg`, which `IpoptApplication` starts
-        // at the top of `optimize_constrained`. `live_*` returns the
-        // running elapsed without forcing a `start/end` cycle.
-        let timing = &data.borrow().timing;
-        if timing.overall_alg.live_cpu_time() >= self.max_cpu_time {
-            return ConvergenceStatus::CpuTimeExceeded;
-        }
-        if timing.overall_alg.live_wallclock_time() >= self.max_wall_time {
-            return ConvergenceStatus::WallTimeExceeded;
+        // application-level start time similarly.
+        let d = data.borrow();
+        if let Some(deadline) = d.deadline.as_ref() {
+            match deadline.exceeded() {
+                Some(pounce_common::timing::DeadlineKind::Cpu) => {
+                    return ConvergenceStatus::CpuTimeExceeded;
+                }
+                Some(pounce_common::timing::DeadlineKind::Wall) => {
+                    return ConvergenceStatus::WallTimeExceeded;
+                }
+                None => {}
+            }
+        } else {
+            let timing = &d.timing;
+            if timing.overall_alg.live_cpu_time() >= self.max_cpu_time {
+                return ConvergenceStatus::CpuTimeExceeded;
+            }
+            if timing.overall_alg.live_wallclock_time() >= self.max_wall_time {
+                return ConvergenceStatus::WallTimeExceeded;
+            }
         }
         ConvergenceStatus::Continue
     }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -722,6 +722,23 @@ impl IpoptAlgorithm {
         let _ = hook.borrow_mut().at_checkpoint(&mut ctx);
     }
 
+    /// Cheap mid-iteration time-budget check (pounce#242). Returns the
+    /// terminal [`SolverReturn`] when the shared [`Deadline`] has been
+    /// crossed, so the caller can bail *within* an iteration — after the
+    /// KKT factorization, before the line search — rather than only at the
+    /// next outer-iteration convergence check. Returns `None` (never
+    /// terminating) when no deadline is installed, keeping the
+    /// direct-driver / unit-test paths on their `overall_alg`-based gate.
+    /// A `None` here is not "no budget" but "check it at the coarse site".
+    fn deadline_status(&self) -> Option<SolverReturn> {
+        let d = self.data.borrow();
+        let kind = d.deadline.as_ref()?.exceeded()?;
+        Some(match kind {
+            pounce_common::timing::DeadlineKind::Cpu => SolverReturn::CpuTimeExceeded,
+            pounce_common::timing::DeadlineKind::Wall => SolverReturn::WallTimeExceeded,
+        })
+    }
+
     /// One iteration body — port of `Optimize()`'s inner loop.
     /// Returns either `Continue` to keep iterating or a terminal
     /// [`SolverReturn`] mirroring upstream's exception → return-code
@@ -1261,6 +1278,20 @@ impl IpoptAlgorithm {
             return o;
         }
 
+        // Fine-grained time-budget gate (pounce#242). The KKT
+        // factorization (and any inertia-correction / quality-escalation
+        // refactorizations) is the single most expensive step of a large
+        // solve, and it has just finished. Check the deadline here so an
+        // over-budget solve returns its current best iterate *before*
+        // spending a line search and another whole iteration — bounding
+        // the overshoot to roughly one search-direction computation
+        // instead of a full outer iteration. `data.curr` is untouched by
+        // the step computation (the trial lives in `data.trial`), so it
+        // still holds the last accepted iterate.
+        if let Some(ret) = self.deadline_status() {
+            return IterateOutcome::Terminate(ret);
+        }
+
         // 6. Acceptable trial point — run the line search if we have a
         //    primal/dual step on `data.delta`. Wrap in a guard so all
         //    early-return paths (ErrorInStepComputation, InternalError,
@@ -1368,6 +1399,18 @@ impl IpoptAlgorithm {
                         // turn triggers `ActivateLineSearch` →
                         // restoration.
                         return self.invoke_restoration_debugged();
+                    }
+                    Outcome::Deadline => {
+                        // The time budget was crossed inside the line
+                        // search (pounce#242). No trial was promoted, so
+                        // `data.curr` still holds the best iterate; stop
+                        // with the matching time-limit status. Re-derive
+                        // wall vs CPU from the deadline (it can only still
+                        // be exceeded — time is monotonic).
+                        return IterateOutcome::Terminate(
+                            self.deadline_status()
+                                .unwrap_or(SolverReturn::WallTimeExceeded),
+                        );
                     }
                 }
             }

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -11,7 +11,7 @@
 //! and outputs.
 
 use crate::iterates_vector::IteratesVector;
-use pounce_common::timing::TimingStatistics;
+use pounce_common::timing::{Deadline, TimingStatistics};
 use pounce_common::types::{Index, Number};
 use pounce_linalg::SymMatrix;
 use std::cell::RefCell;
@@ -145,6 +145,19 @@ pub struct IpoptData {
     /// Defaults to a fresh empty instance for the structural unit tests
     /// that don't go through `IpoptApplication`.
     pub timing: Rc<TimingStatistics>,
+
+    /// Shared wall/CPU-time deadline for the whole solve (pounce#242).
+    /// `IpoptApplication` installs one at solve start from the
+    /// `max_wall_time` / `max_cpu_time` options, and the restoration inner
+    /// IPM copies the *same* deadline onto its own `IpoptData` so the
+    /// nested solve is bounded by the caller's global budget rather than
+    /// running unbounded (its fresh `timing.overall_alg` is never
+    /// started). When present it is the authoritative time gate — checked
+    /// at the granularity of the expensive inner steps (KKT factorization,
+    /// each line-search trial), not only between outer iterations. `None`
+    /// for direct-driver / unit-test paths, which fall back to the
+    /// `overall_alg` timer in [`crate::conv_check`].
+    pub deadline: Option<Deadline>,
 }
 
 impl Default for IpoptData {
@@ -180,6 +193,7 @@ impl IpoptData {
             info_last_output: -1.0,
             info_iters_since_header: 0,
             timing: Rc::new(TimingStatistics::new()),
+            deadline: None,
         }
     }
 

--- a/crates/pounce-algorithm/src/line_search/backtracking.rs
+++ b/crates/pounce-algorithm/src/line_search/backtracking.rs
@@ -43,6 +43,11 @@ pub enum Outcome {
     TinyStep,
     /// All α reductions rejected; the caller hands off to restoration.
     Failed,
+    /// The shared wall/CPU-time deadline was crossed mid-search
+    /// (pounce#242). The caller terminates the solve with the
+    /// corresponding time-limit status, returning the current best
+    /// iterate (`data.curr`, left untouched — no trial was promoted).
+    Deadline,
 }
 
 /// Policy for the step length applied to the equality multipliers
@@ -212,6 +217,9 @@ enum AlphaResult {
         last_alpha: Number,
         evaluation_error: bool,
     },
+    /// The shared wall/CPU-time deadline was crossed before a trial was
+    /// accepted (pounce#242). Propagated up as [`Outcome::Deadline`].
+    Deadline,
 }
 
 impl BacktrackingLineSearch {
@@ -358,6 +366,12 @@ impl BacktrackingLineSearch {
             self.run_filter_line_search(data, cq, delta, alpha_init, alpha_dual, nlp, search_dir);
         if outcome == Outcome::Accepted {
             return Outcome::Accepted;
+        }
+        // Time budget crossed (pounce#242): the caller is stopping the
+        // solve, so skip the soft-restoration attempt and hand the
+        // terminal outcome straight back.
+        if outcome == Outcome::Deadline {
+            return Outcome::Deadline;
         }
 
         // ---- Regular line search failed. Before the (expensive) full
@@ -625,6 +639,10 @@ impl BacktrackingLineSearch {
                     Outcome::Failed
                 }
             }
+            // Time budget crossed mid-loop (pounce#242) — terminal, and it
+            // pre-empts the watchdog: there is no point reverting to a
+            // snapshot when the caller is about to stop the solve.
+            AlphaResult::Deadline => Outcome::Deadline,
         }
     }
 
@@ -789,6 +807,9 @@ impl BacktrackingLineSearch {
                     d.info_ls_count = ns2 + 1;
                     Outcome::Failed
                 }
+                // Deadline crossed during the StopWatchDog retry sweep
+                // (pounce#242) — propagate the terminal outcome.
+                AlphaResult::Deadline => Outcome::Deadline,
             }
         } else {
             // Accept the last attempted trial despite filter rejection
@@ -891,6 +912,20 @@ impl BacktrackingLineSearch {
         };
 
         for trial in 0..self.max_trials {
+            // Fine-grained time-budget gate (pounce#242): each trial
+            // evaluates the constraints / barrier objective, which on a
+            // large problem is not cheap, so honor the deadline at
+            // per-trial granularity rather than letting a full backtracking
+            // sweep run past it. Bail before staging another trial; no
+            // trial is promoted, so `data.curr` stays the best iterate.
+            if data
+                .borrow()
+                .deadline
+                .as_ref()
+                .is_some_and(|dl| dl.exceeded().is_some())
+            {
+                return AlphaResult::Deadline;
+            }
             if alpha < alpha_min_eff {
                 return AlphaResult::TinyStep {
                     n_steps,
@@ -1369,6 +1404,62 @@ mod tests {
             (a - 0.25).abs() < 1e-12,
             "retry first alpha = {a}, expected 0.25 (snapshot FTB cap 0.5 × red 0.5)"
         );
+    }
+
+    /// pounce#242: an already-crossed shared [`Deadline`] on `data` makes
+    /// the alpha loop bail on its very first trial with `Outcome::Deadline`
+    /// — before staging or evaluating any trial point — so the main loop
+    /// can stop the solve at per-trial granularity while `data.curr`
+    /// (untouched) remains the best iterate.
+    #[test]
+    fn deadline_short_circuits_the_alpha_loop() {
+        let nlp: Rc<RefCell<dyn IpoptNlp>> = Rc::new(RefCell::new(F4MockNlp::new()));
+        let data: IpoptDataHandle = Rc::new(RefCell::new(IpoptData::new()));
+        let curr = IteratesVector::new(
+            dense(1, &[2.0]),
+            empty(),
+            empty(),
+            empty(),
+            dense(1, &[0.5]),
+            empty(),
+            empty(),
+            empty(),
+        );
+        {
+            let mut d = data.borrow_mut();
+            d.curr_mu = 0.1;
+            d.curr_tau = 1.0;
+            d.set_curr(curr.clone());
+            // Zero wall budget — already crossed by the time the loop runs.
+            d.deadline = Some(pounce_common::timing::Deadline::new(0.0, 1e6));
+        }
+        let cq: IpoptCqHandle = Rc::new(RefCell::new(IpoptCalculatedQuantities::new(
+            data.clone(),
+            nlp.clone(),
+        )));
+        let delta = IteratesVector::new(
+            dense(1, &[-1.0]),
+            empty(),
+            empty(),
+            empty(),
+            dense(1, &[0.0]),
+            empty(),
+            empty(),
+            empty(),
+        );
+        let mut bls = BacktrackingLineSearch::new(Box::new(FilterLsAcceptor::new()));
+        let outcome = bls.find_acceptable_trial_point(
+            &data,
+            &cq,
+            &delta,
+            /*alpha_init*/ 1.0,
+            /*alpha_dual*/ 1.0,
+            Some(&nlp),
+            None,
+        );
+        assert_eq!(outcome, Outcome::Deadline);
+        // No trial was staged/promoted — curr is still the best iterate.
+        assert!(data.borrow().trial.is_none());
     }
 
     fn iv_from(x: &[Number], s: &[Number]) -> IteratesVector {

--- a/crates/pounce-common/src/lib.rs
+++ b/crates/pounce-common/src/lib.rs
@@ -28,5 +28,5 @@ pub use journalist::{
 pub use options_list::OptionsList;
 pub use reg_options::{DefaultValue, OptionType, RegisteredOption, RegisteredOptions, StringEntry};
 pub use tagged::{Tag, TaggedCell, TaggedObject};
-pub use timing::{TimedTask, TimingStatistics};
+pub use timing::{Deadline, DeadlineKind, TimedTask, TimingStatistics};
 pub use types::{Index, NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF, Number};

--- a/crates/pounce-common/src/timing.rs
+++ b/crates/pounce-common/src/timing.rs
@@ -6,6 +6,93 @@
 use crate::types::Number;
 use crate::utils::{cpu_time, sys_time, wallclock_time};
 use std::cell::Cell;
+use std::rc::Rc;
+
+/// Which time budget a [`Deadline`] check found crossed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeadlineKind {
+    /// Wall-clock budget (`max_wall_time`) exceeded.
+    Wall,
+    /// CPU-time budget (`max_cpu_time`) exceeded.
+    Cpu,
+}
+
+/// A monotonic wall/CPU-clock deadline for a single solve (pounce#242).
+///
+/// Cheaply clonable (`Rc`-backed) so the outer loop, the KKT solver, the
+/// line search, and the *restoration inner IPM* can all check the same
+/// global budget — not just the outer-iteration convergence check. The
+/// motivating bug: `max_wall_time` was only tested between outer
+/// iterations (in `OptErrorConvCheck`), so a solve whose per-iteration
+/// cost is dominated by a single expensive step — a slow KKT
+/// factorization, or a restoration sub-solve that runs an entire nested
+/// IPM under one outer "iteration" — overshot the requested budget by up
+/// to a full iteration (~7x on the reported 1611-variable NLP). Checking
+/// this deadline at the granularity of the expensive inner steps bounds
+/// the overshoot to roughly one such step.
+///
+/// The elapsed time is measured from the instant the `Deadline` is
+/// constructed, using the same process clocks the timing subsystem uses.
+/// Unlike [`TimedTask::live_wallclock_time`] it does **not** depend on a
+/// `start()`/`end()` cycle, so it works inside the nested restoration
+/// solve — whose fresh [`TimingStatistics`] has an `overall_alg` timer
+/// that is never started, which is exactly why the inner loop used to run
+/// unbounded by wall time.
+#[derive(Debug, Clone)]
+pub struct Deadline {
+    inner: Rc<DeadlineInner>,
+}
+
+#[derive(Debug)]
+struct DeadlineInner {
+    wall_start: Number,
+    cpu_start: Number,
+    max_wall: Number,
+    max_cpu: Number,
+}
+
+impl Deadline {
+    /// Create a deadline that fires once `max_wall` wall seconds or
+    /// `max_cpu` CPU seconds have elapsed from *now*. The pounce defaults
+    /// for both budgets are `1e6`, i.e. effectively unbounded; a caller
+    /// that passes those gets a deadline that never trips in practice.
+    pub fn new(max_wall: Number, max_cpu: Number) -> Self {
+        Self {
+            inner: Rc::new(DeadlineInner {
+                wall_start: wallclock_time(),
+                cpu_start: cpu_time(),
+                max_wall,
+                max_cpu,
+            }),
+        }
+    }
+
+    /// Return `Some(kind)` if either budget has been crossed, else
+    /// `None`. CPU is tested before wall to match the branch order of
+    /// upstream `OptimalityErrorConvergenceCheck::CheckConvergence` (and
+    /// pounce's `OptErrorConvCheck`), so a solve that trips both in the
+    /// same check reports `MaximumCpuTimeExceeded` identically to the
+    /// coarse path.
+    pub fn exceeded(&self) -> Option<DeadlineKind> {
+        if cpu_time() - self.inner.cpu_start >= self.inner.max_cpu {
+            return Some(DeadlineKind::Cpu);
+        }
+        if wallclock_time() - self.inner.wall_start >= self.inner.max_wall {
+            return Some(DeadlineKind::Wall);
+        }
+        None
+    }
+
+    /// The wall-clock budget this deadline was built with.
+    pub fn max_wall(&self) -> Number {
+        self.inner.max_wall
+    }
+
+    /// The CPU-time budget this deadline was built with.
+    pub fn max_cpu(&self) -> Number {
+        self.inner.max_cpu
+    }
+}
 
 /// Equivalent to `Ipopt::TimedTask`. Use [`TimedTask::start`] /
 /// [`TimedTask::end`] around a section to accumulate cpu/system/wall
@@ -444,6 +531,61 @@ impl TimingStatistics {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn deadline_unbounded_never_trips() {
+        // The pounce "no budget" defaults (1e6 seconds each) must never
+        // fire in any realistic test runtime.
+        let d = Deadline::new(1e6, 1e6);
+        assert!(d.exceeded().is_none());
+        assert_eq!(d.max_wall(), 1e6);
+        assert_eq!(d.max_cpu(), 1e6);
+    }
+
+    #[test]
+    fn deadline_zero_wall_trips_wall() {
+        // Zero wall budget, effectively-unbounded CPU budget: after any
+        // wall time elapses the check reports `Wall` (CPU is tested first
+        // but its budget is not crossed).
+        let d = Deadline::new(0.0, 1e6);
+        // Busy-spin until the monotonic wall clock has advanced past the
+        // start instant, so the assertion is not racing a zero-duration
+        // `elapsed()` on a coarse clock.
+        for _ in 0..10_000 {
+            if d.exceeded().is_some() {
+                break;
+            }
+            std::hint::black_box(0u64);
+        }
+        assert_eq!(d.exceeded(), Some(DeadlineKind::Wall));
+    }
+
+    #[test]
+    fn deadline_zero_cpu_takes_priority() {
+        // Both budgets at zero: CPU is checked first, so a solve that
+        // crosses both in the same check reports `Cpu` — matching the
+        // convergence check's branch order.
+        let d = Deadline::new(0.0, 0.0);
+        for _ in 0..10_000 {
+            if d.exceeded().is_some() {
+                break;
+            }
+            std::hint::black_box(0u64);
+        }
+        assert_eq!(d.exceeded(), Some(DeadlineKind::Cpu));
+    }
+
+    #[test]
+    fn deadline_is_cheaply_clonable_and_shares_start() {
+        // Cloning shares the same start instant / budgets (the restoration
+        // inner IPM relies on this to be bounded by the outer solve's
+        // elapsed time, not its own).
+        let d = Deadline::new(1e6, 1e6);
+        let d2 = d.clone();
+        assert_eq!(d2.max_wall(), d.max_wall());
+        assert_eq!(d2.max_cpu(), d.max_cpu());
+        assert!(d2.exceeded().is_none());
+    }
 
     #[test]
     fn start_end_accumulates_nonneg() {

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -251,6 +251,17 @@ pub fn run_inner_resto(
     // which `f(x)` reads via `ip_data_->curr_mu()`
     // (`IpRestoIpoptNLP.cpp:485`).
     let inner_data: IpoptDataHandle = Rc::new(RefCell::new(IpoptData::new()));
+    // Share the outer solve's wall/CPU-time deadline (pounce#242) so the
+    // nested IPM is bounded by the caller's *global* budget. Without this
+    // the inner solve ran effectively unbounded by wall time: it builds a
+    // fresh `IpoptData` whose `timing.overall_alg` is never started, so
+    // the coarse `overall_alg`-based check read 0 elapsed and never
+    // tripped — a single restoration entry could then grind for many
+    // iterations under one outer "iteration", the dominant source of the
+    // observed budget overshoot. The shared `Deadline` measures elapsed
+    // time from the outer solve's start, so the inner convergence check
+    // trips at the correct global wall time.
+    inner_data.borrow_mut().deadline = outer_data.borrow().deadline.clone();
     resto_bundle.nlp.set_inner_data(Rc::clone(&inner_data));
 
     // Wrap the resto NLP in an Rc<RefCell<dyn IpoptNlp>> for the inner


### PR DESCRIPTION
Fixes #242.

## Problem

`Problem.solve` checked the wall/CPU-time budget only in the outer-iteration convergence check (`OptErrorConvCheck`), so a solve whose per-iteration cost is dominated by a single expensive step overshot the requested budget by up to a full iteration (~7x on the reported 1611-variable NLP).

The worst offender was the **restoration phase**: its nested IPM builds a fresh `IpoptData` whose `timing.overall_alg` timer is *never started*, so the coarse `overall_alg`-based check read 0 elapsed and never tripped. A single restoration entry could then run an entire inner IPM (many factorizations) under one outer "iteration", entirely unbounded by wall time — the most likely source of the large overshoot in the reported warm-started case.

## Fix

Introduce a shared, `Rc`-backed `Deadline` (in `pounce-common`) that measures elapsed wall/CPU time from a fixed start instant, independent of the per-solve timing subsystem (so it fires correctly even where `overall_alg` is unstarted). `IpoptApplication` installs one from the `max_wall_time` / `max_cpu_time` options, and the restoration inner solver copies the **same** instance onto its `IpoptData`, so the caller's *global* budget bounds the whole solve rather than each nested level independently.

The deadline is checked at the granularity of the expensive inner steps, always returning the current best iterate (`data.curr`, never a half-applied step) with the matching time-limit status:

- **Convergence check** treats the shared deadline as authoritative when present (this is what makes the restoration inner solve honor the budget); falls back to the `overall_alg` timer for direct-driver / unit-test paths, so their behavior is unchanged.
- **Main loop** checks right after the KKT factorization, before the line search — bounding overshoot to one search-direction computation instead of a full outer iteration.
- **Backtracking line search** checks per trial (new `Outcome::Deadline` / `AlphaResult::Deadline`), before staging or evaluating a trial point.

A single atomic KKT factorization cannot be interrupted (the issue accepts this as the floor); every step around it is now gated.

## Tests

- `Deadline` unit tests: unbounded budget never trips, zero-wall trips `Wall`, both-zero prioritizes `Cpu` (matching the convergence check's branch order), clone shares the start instant.
- A line-search unit test asserting the alpha loop short-circuits to `Outcome::Deadline` on an already-crossed deadline, without staging a trial (`data.curr` stays the best iterate).
- The existing HS71 `max_wall_time` / `max_cpu_time` integration tests now flow through the new shared-deadline path end-to-end.

All 273 `pounce-algorithm` lib tests + 27 integration binaries pass; `pounce-common` and `pounce-restoration` suites pass; no new clippy lints; downstream `pounce-cli` / `pounce-py` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZCiJgPiDcffSRpkswZi9u)_