### PR TITLE
Check the time deadline between KKT factorizations (bound overshoot to a sub-step)

### DIFF
--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -1043,6 +1043,21 @@ impl IpoptAlgorithm {
             tracing::debug!(target: "pounce::linsol", "kkt solve complete");
             drop(ls_enter);
             timing.compute_search_direction.end();
+            // Fine-grained time-budget gate (pounce#244). The KKT solve now
+            // checks the shared deadline *between* its major factorization
+            // steps (inertia correction / iterative refinement) and aborts
+            // cooperatively when the budget is crossed — bounding the
+            // overshoot to roughly one factorization instead of the whole
+            // multi-factorization sweep that #242's post-solve check let run
+            // to completion. Whether the solve returned a completed step or
+            // bailed mid-escalation, if the deadline tripped, stop here with
+            // the time-limit status *before* the `!ok` branch below would
+            // otherwise route a deadline-aborted solve into restoration.
+            // `data.curr` is untouched by the step computation, so it still
+            // holds the last accepted iterate.
+            if let Some(ret) = self.deadline_status() {
+                return IterateOutcome::Terminate(ret);
+            }
             if !ok {
                 // Mirror upstream `IpIpoptAlg.cpp:417-430`: a failed
                 // step computation puts the algorithm in emergency
@@ -1702,6 +1717,18 @@ impl IpoptAlgorithm {
         self.resto_inner_iters = self
             .resto_inner_iters
             .saturating_add(resto.last_inner_iter_count());
+        // pounce#244: the restoration inner IPM shares the outer solve's
+        // `Deadline` (both its convergence check and — post-#244 — its KKT
+        // solves consult it), so a budget crossing inside restoration
+        // terminates the inner solve with a time-limit status. Surface that
+        // as the time limit directly instead of letting the `Failed` arm map
+        // it onto `RestorationFailure` / `StopAtAcceptablePoint`. `data.curr`
+        // is the last accepted outer iterate — restoration stages its
+        // recovered point onto `trial`, not `curr`, and we return before
+        // promoting it — so this hands back a valid iterate.
+        if let Some(ret) = self.deadline_status() {
+            return IterateOutcome::Terminate(ret);
+        }
         match outcome {
             RestorationOutcome::Recovered => {
                 // The driver has staged the recovered point on

--- a/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
@@ -254,6 +254,14 @@ impl PdFullSpaceSolver {
         let mut improve = improve_solution;
 
         while !done {
+            // pounce#244: bail between major KKT steps when the shared time
+            // budget is crossed (see `deadline_exceeded`). Returning `false`
+            // routes through the caller's post-KKT deadline check, which
+            // terminates the solve with the time-limit status rather than
+            // treating the abort as a step-computation failure.
+            if deadline_exceeded(data) {
+                return false;
+            }
             let solve_ok = if improve {
                 true
             } else {
@@ -294,6 +302,12 @@ impl PdFullSpaceSolver {
                 && (num_iter_ref < self.min_refinement_steps
                     || residual_ratio > self.residual_ratio_max)
             {
+                // pounce#244: each refinement step drives another back-solve
+                // (and may refactor via the escalation path in `solve_once`);
+                // check the budget before spending one.
+                if deadline_exceeded(data) {
+                    return false;
+                }
                 let frozen_resid = resid.freeze();
                 let solve_ok = self.solve_once(
                     data,
@@ -969,6 +983,20 @@ impl PdFullSpaceSolver {
         let mut count = 0_i32;
         let mut retval;
         loop {
+            // pounce#244: the body of this loop is a full KKT factorization
+            // — the escalation path retries with a larger perturbation until
+            // the augmented system has the right inertia, and on a hard,
+            // ill-conditioned system that can be many refactorizations under
+            // one outer iteration. Abort between factorizations when the
+            // shared deadline is crossed so the solve cannot overshoot the
+            // budget by that whole sweep. `data`'s deadline is the caller's
+            // global budget; `false` unwinds to the outer loop's post-KKT
+            // time-limit check. A deadline already crossed on entry returns
+            // before the first factorization; otherwise overshoot is bounded
+            // to one.
+            if deadline_exceeded(data) {
+                return false;
+            }
             if pretend_singular {
                 retval = ESymSolverStatus::Singular;
                 pretend_singular = false;
@@ -1196,6 +1224,40 @@ impl PdSystemSolver for PdFullSpaceSolver {
     fn solve_status(&self) -> ESymSolverStatus {
         self.last_status.unwrap_or(ESymSolverStatus::FatalError)
     }
+}
+
+/// Cooperative time-budget check for the KKT solve (pounce#244).
+///
+/// Reads the shared per-solve [`Deadline`](pounce_common::timing::Deadline)
+/// off [`IpoptData`](crate::ipopt_data::IpoptData) — the same instance the
+/// outer loop, the line search, and the restoration inner IPM consult —
+/// and reports whether either the wall or CPU budget has been crossed.
+/// [`PdFullSpaceSolver::solve`] / [`PdFullSpaceSolver::solve_once`] call it
+/// between their major factorization steps so an over-budget solve aborts
+/// promptly instead of running a whole inertia-correction /
+/// iterative-refinement sweep to completion.
+///
+/// A single outer iteration of a large, ill-conditioned NLP is dominated
+/// by the KKT factorization, and the inertia-correction loop can refactor
+/// several times before the augmented system has the right inertia. #242
+/// only checked the deadline *after* the search direction was fully
+/// computed, so that whole multi-factorization sweep overshot the requested
+/// budget (the reported 2 s → 12.7 s single-NLP probe, "unchanged by #242").
+/// Checking here bounds the overshoot to roughly one factorization.
+///
+/// Returns `false` when no deadline is installed (the direct-driver /
+/// unit-test paths), leaving those on the coarse `overall_alg`-timer gate
+/// in [`crate::conv_check`]. Aborting with `false` is safe: `solve` only
+/// promotes the computed `delta` onto `IpoptData` on a `true` return, so a
+/// deadline abort leaves `data.curr` / `data.delta` untouched, and the
+/// caller's post-KKT deadline check then terminates with the time-limit
+/// status (returning the last accepted iterate) rather than treating the
+/// abort as a step-computation failure that would enter restoration.
+fn deadline_exceeded(data: &IpoptDataHandle) -> bool {
+    data.borrow()
+        .deadline
+        .as_ref()
+        .is_some_and(|d| d.exceeded().is_some())
 }
 
 /// Bag of borrowed blocks used by both `solve_once` and
@@ -1463,5 +1525,49 @@ impl AugSystemSolver for NoopAugSolver {
         _num_neg_evals: Index,
     ) -> ESymSolverStatus {
         unreachable!("NoopAugSolver is a transient placeholder")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::deadline_exceeded;
+    use crate::ipopt_data::IpoptData;
+    use pounce_common::timing::Deadline;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    #[test]
+    fn deadline_exceeded_is_false_without_a_deadline() {
+        // Direct-driver / unit-test path: no deadline installed, so the KKT
+        // solve never short-circuits and stays on the coarse timer gate.
+        let data = Rc::new(RefCell::new(IpoptData::new()));
+        assert!(!deadline_exceeded(&data));
+    }
+
+    #[test]
+    fn deadline_exceeded_is_false_when_budget_is_unbounded() {
+        // The pounce "no budget" defaults (1e6 s each) must never trip inside
+        // any realistic solve, so the fine-grained KKT check is a no-op.
+        let data = Rc::new(RefCell::new(IpoptData::new()));
+        data.borrow_mut().deadline = Some(Deadline::new(1e6, 1e6));
+        assert!(!deadline_exceeded(&data));
+    }
+
+    #[test]
+    fn deadline_exceeded_true_once_the_budget_is_crossed() {
+        // Zero wall budget: once any wall time elapses the KKT loops must see
+        // the deadline and abort between factorizations (pounce#244). Busy-spin
+        // until the monotonic clock advances past the start instant so the
+        // assertion is not racing a coarse-clock zero-duration read — matching
+        // the `Deadline` unit tests' pattern.
+        let data = Rc::new(RefCell::new(IpoptData::new()));
+        data.borrow_mut().deadline = Some(Deadline::new(0.0, 1e6));
+        for _ in 0..10_000 {
+            if deadline_exceeded(&data) {
+                break;
+            }
+            std::hint::black_box(0u64);
+        }
+        assert!(deadline_exceeded(&data));
     }
 }


### PR DESCRIPTION
Fixes #244. Follow-up to #242.

## Problem

#242 bounded `max_wall_time`/`max_cpu_time` overshoot to **one outer iteration** by checking the shared `Deadline` in the between-iteration convergence check, and fixed the unbounded restoration grind. But it checked the deadline only *after* `compute_search_direction` returned. On a large, ill-conditioned NLP a single outer iteration is dominated by the KKT solve, whose inertia-correction / iterative-refinement sweep can run many refactorizations under one search-direction computation — so that whole sweep overshot the budget. This is the "unchanged by #242" case in the issue (2 s budget → 12.7 s actual, 6.4x).

## Change

Thread the same `Deadline` into `PdFullSpaceSolver` and check it **between the major KKT steps**, giving the cooperative cancellation the issue asked for:

- top of the escalation loop in `solve_once` (before each factorization);
- top of the outer solve loop and the iterative-refinement loop in `solve`.

On a crossing the solve aborts by returning `false`, leaving `data.curr` / `data.delta` untouched (they are only promoted on a `true` return), so the algorithm keeps its last accepted iterate. This bounds the overshoot to roughly **one factorization** instead of the whole sweep.

The abort is routed to a clean time-limit termination rather than a step failure:

- the main loop checks `deadline_status()` right after `compute_search_direction` returns — before the `!ok` branch that would otherwise send a deadline-aborted solve into restoration — and terminates with the matching `Wall/CpuTimeExceeded` status;
- `invoke_restoration` checks the deadline right after the inner IPM returns, so a budget crossing inside restoration (its KKT solves now share the deadline too) surfaces as the time limit instead of being mapped onto `RestorationFailure` / `StopAtAcceptablePoint`.

## Scope / what's not done

This implements the issue's **pragmatic middle ground** (check at each major KKT step + at the nested-IPM inner boundaries), which bounds worst-case overshoot to a single factorization. It does **not** implement cancellation *inside* a single factorization/back-solve — if one individual factorization of a huge system runs longer than the budget, that one factorization still completes. Aborting mid-factorization would require cancellation hooks in the FERAL/MUMPS backend and is out of scope here.

## Tests

- New unit tests for the `deadline_exceeded` helper (no deadline / unbounded budget / zero-budget-crossed).
- Existing HS71 wall/CPU integration tests now flow through the KKT-level abort path and pass unchanged; full `pounce-algorithm` (276) and `pounce-restoration` (110) lib suites pass. No new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sbp5ftAv68sr4QdnXBWMDw

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sbp5ftAv68sr4QdnXBWMDw)_