### PR TITLE
Improve `pounce-rs` README (incorporates #241 + review polish)

### DIFF
--- a/crates/pounce-rs/README.md
+++ b/crates/pounce-rs/README.md
@@ -1,13 +1,87 @@
 # pounce-rs
 
-Single-crate facade for solving nonlinear programs with [POUNCE](https://github.com/jkitchin/pounce)
-from Rust. Re-exports the `TNLP` problem trait (`pounce-nlp`), the
-`IpoptApplication` driver (`pounce-algorithm`), and the supporting scalar
-types (`pounce-common`) in one place, plus a `prelude`:
+[![crates.io](https://img.shields.io/crates/v/pounce-rs.svg)](https://crates.io/crates/pounce-rs) [![CI](https://github.com/jkitchin/pounce/actions/workflows/ci.yml/badge.svg)](https://github.com/jkitchin/pounce/actions/workflows/ci.yml) [![docs.rs](https://img.shields.io/docsrs/pounce-rs)](https://docs.rs/pounce-rs)
 
-```rust
-use pounce_rs::prelude::*;
+A single-crate entry point for solving nonlinear programs with
+[POUNCE](https://github.com/jkitchin/pounce) in Rust. It provides two APIs:
+
+- a high-level builder API (`Problem` + `Nlp`) for the common case, where only the objective is required and everything else is optional; and
+- the low-level `TNLP` trait, re-exported for full control over Hessians, sparsity patterns, scaling, and other advanced features.
+
+Both APIs are backed by the same pure-Rust interior-point solver.
+
+## Install
+
+```sh
+cargo add pounce-rs
 ```
 
-This is the Rust counterpart to the one-import `import pounce` Python API. It
-contains re-exports only; see the crate docs for a complete HS071 example.
+or add it to `Cargo.toml`:
+
+```toml
+[dependencies]
+pounce-rs = "0.8"
+```
+
+## Quick start
+
+Implement `Problem` (only `objective` is required), then configure and solve
+with the `Nlp` builder:
+
+```rust
+use pounce_rs::builder::{Problem, Nlp};
+
+// min (x0-1)^2 + (x1-2)^2  s.t.  x0 + x1 == 3,  0 <= xi <= 5
+struct P;
+impl Problem for P {
+    fn objective(&self, x: &[f64]) -> f64 {
+        (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+    }
+    fn n_constraints(&self) -> usize { 1 }
+    fn constraints(&self, x: &[f64], g: &mut [f64]) { g[0] = x[0] + x[1]; }
+}
+
+let sol = Nlp::new(P)                     // variable count inferred below
+    .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+    .constraint_bounds(&[3.0], &[3.0])    // equality: lower == upper
+    .x0(&[0.0, 0.0])
+    .option_num("tol", 1e-10)
+    .solve();
+
+assert!(sol.success);
+assert!((sol.x[0] - 1.0).abs() < 1e-5 && (sol.x[1] - 2.0).abs() < 1e-5);
+```
+
+Anything you don't implement is provided automatically. Missing gradients and
+Jacobians are approximated with finite differences, while the Hessian defaults
+to a limited-memory (L-BFGS) approximation. This keeps simple problems concise
+without sacrificing access to exact derivatives when needed.
+
+Solver options use the same names as upstream Ipopt
+(`option_num`, `option_int`, `option_str`).
+
+## Result
+
+`Nlp::solve` returns a `Solution` containing
+
+- `success` and the full `status`
+- the optimal point `x`
+- the objective value
+- constraint multipliers (`multipliers`)
+- constraint values (`g`)
+- bound multipliers (`z_l` and `z_u`)
+
+The vector fields remain empty if the solve aborts before finalization.
+
+## Full control: the `TNLP` trait
+
+For problems that need an exact Hessian, custom Jacobian/Hessian sparsity, or
+NLP scaling, implement the re-exported `TNLP` trait directly and drive it with
+`IpoptApplication`. The whole surface is reachable through the prelude.
+
+See the [crate docs on docs.rs](https://docs.rs/pounce-rs) for a complete HS071
+`TNLP` walkthrough.
+
+## License
+
+EPL-2.0.

--- a/crates/pounce-rs/README.md
+++ b/crates/pounce-rs/README.md
@@ -29,7 +29,7 @@ Implement `Problem` (only `objective` is required), then configure and solve
 with the `Nlp` builder:
 
 ```rust
-use pounce_rs::builder::{Problem, Nlp};
+use pounce_rs::prelude::*;
 
 // min (x0-1)^2 + (x1-2)^2  s.t.  x0 + x1 == 3,  0 <= xi <= 5
 struct P;
@@ -70,8 +70,12 @@ Solver options use the same names as upstream Ipopt
 - constraint multipliers (`multipliers`)
 - constraint values (`g`)
 - bound multipliers (`z_l` and `z_u`)
+- solve statistics (`stats`): wall time, iteration count, evaluation counts,
+  and final infeasibilities
 
-The vector fields remain empty if the solve aborts before finalization.
+The vector fields remain empty if the solve aborts before finalization. Opt in
+to the full per-iteration trajectory (`stats.iterations`) with
+`.capture_iterations()` on the builder.
 
 ## Full control: the `TNLP` trait
 


### PR DESCRIPTION
Incorporates @GermanHeim's README rewrite from #241 and applies the polish suggestions from that review.

## Commits
- `dc14c08` Improve `pounce-rs` README — original work from #241 (badges, Install, Quick start, Result, Full-control sections)
- `60d6fed` docs(pounce-rs): polish README from review

## Polish applied on top
- **Quick start import** now uses the documented `use pounce_rs::prelude::*;` — the common-case entry point the crate docs point to — instead of the explicit `builder::{...}` path.
- **Result section** now documents the `stats` (`SolveStatistics`) field (wall time, iteration count, evaluation counts, final infeasibilities) and mentions `.capture_iterations()` for the per-iteration trajectory.

## Notes
- Version pin `pounce-rs = "0.8"` is correct for now (crates.io max_version is 0.8.0); the bump is tracked separately under #239.
- Docs-only change; no code paths touched.

Supersedes #241 (that branch's commit is included here, preserving authorship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DeJVBifKhtQ1E2RqGZxNEW)_