### PR TITLE
Read curve_fit's 2-tuple bounds as scipy (lower, upper), not pairs

### DIFF
--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -917,6 +917,16 @@ def curve_fit(
     bound-aware, data-scale sweep scored by the objective; see
     :func:`_initial_guess`) rather than defaulting to ones.
 
+    ``bounds`` follows scipy's convention: the ``(lower, upper)`` 2-tuple, where
+    each side is a scalar or a length-``n_params`` array. So
+    ``bounds=([l0, l1], [u0, u1])`` bounds param ``i`` to ``[l_i, u_i]`` — a
+    length-2 tuple is *always* read this scipy way, including the 2-parameter
+    case where it could otherwise be mistaken for a list of ``(lo, hi)`` pairs
+    (issue #260). pounce also accepts a per-parameter pair **list**,
+    ``bounds=[(l0, u0), (l1, u1)]`` (as :func:`pounce.minimize` does), which is
+    never reinterpreted as the scipy 2-tuple; entries may be ``None`` for a
+    one-sided bound.
+
     See also ``pyomo_pounce.covariance`` (in the ``pyomo-pounce`` package),
     the counterpart surface for an estimation model written directly in
     Pyomo rather than a ``f(x, *params)`` callable. It uses the same
@@ -1448,17 +1458,34 @@ f_scale, jac, alpha, sensitivity, options
 # --------------------------------------------------------------------------
 
 def _normalize_bound_arg(bounds, n):
-    """Accept scipy's ``(lo, hi)`` scalar/array form OR a per-parameter list
-    of ``(lo, hi)`` pairs, and normalise to the per-parameter pair list that
-    :func:`pounce._minimize._normalize_bounds` expects."""
+    """Accept scipy's ``(lower, upper)`` 2-tuple form OR pounce's per-parameter
+    list of ``(lo, hi)`` pairs, and normalise to the per-parameter pair list
+    that :func:`pounce._minimize._normalize_bounds` expects.
+
+    scipy's ``curve_fit`` has exactly one ``bounds`` form — the ``(lower,
+    upper)`` 2-tuple, each side a scalar or length-``n`` array — and
+    :func:`curve_fit` documents that it mirrors scipy, so a length-2 **tuple**
+    is always read as that scipy form. This is load-bearing only for a
+    2-parameter model, where ``([l0, l1], [u0, u1])`` is *also* structurally a
+    list of two ``(lo, hi)`` pairs. That collision is genuinely ambiguous, and
+    resolving it the pair-list way silently applied the wrong box (param 0 in
+    ``[l0, l1]``, param 1 in ``[u0, u1]``) while still reporting
+    ``Solve_Succeeded`` — see issue #260. scipy's convention wins: param ``i``
+    is bounded to ``[l_i, u_i]``.
+
+    To pass pounce's per-parameter pair list — its extension over scipy — use a
+    **list**, ``[(l0, u0), (l1, u1)]`` (as :func:`pounce.minimize` does). A list
+    is never reinterpreted as the scipy 2-tuple form, so the two APIs stay
+    distinct even for ``n == 2``.
+    """
     if bounds is None:
         return None
-    # scipy form: a 2-tuple of (lower, upper), each scalar or length-n array
-    if (
-        isinstance(bounds, tuple)
-        and len(bounds) == 2
-        and not _is_pair_list(bounds, n)
-    ):
+    # scipy form: a 2-tuple of (lower, upper), each scalar or length-n array. A
+    # length-2 tuple can only double as a pair list when n == 2 (a pair list
+    # needs one pair per parameter); we deliberately resolve that lone ambiguous
+    # case to the scipy convention curve_fit mirrors, rather than the pair-list
+    # reading, so the returned box matches scipy's (issue #260).
+    if isinstance(bounds, tuple) and len(bounds) == 2:
         lo, hi = bounds
         lo_a, hi_a = _to_array(lo), _to_array(hi)
         for side, arr in (("lower", lo_a), ("upper", hi_a)):
@@ -1471,14 +1498,6 @@ def _normalize_bound_arg(bounds, n):
         hi = np.broadcast_to(hi_a, (n,))
         return list(zip(lo.tolist(), hi.tolist()))
     return bounds  # already a per-parameter list of pairs (validated downstream)
-
-
-def _is_pair_list(bounds, n):
-    if len(bounds) != n:
-        return False
-    return all(
-        (isinstance(b, (tuple, list)) and len(b) == 2) or b is None for b in bounds
-    )
 
 
 def _make_problem_obj(objective, gradient, hess, n, m, g, jac_g):

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -36,6 +36,10 @@ def expdecay_np(x, a, b, c):
     return a * np.exp(-b * x) + c
 
 
+def expdecay_2p(x, a, b):
+    return a * np.exp(-b * x)
+
+
 # --------------------------------------------------------------------------
 # 1. OLS calibration: pins the reduced-Hessian -> covariance constant.
 # --------------------------------------------------------------------------
@@ -510,6 +514,81 @@ def test_curve_fit_rejects_wrong_length_bounds():
     r2 = pounce.curve_fit(expdecay, x, y, p0=[1, 1, 0],
                           bounds=[(-10, 10), (-10, 10), (-10, 10)])
     np.testing.assert_allclose(r1.popt, r2.popt, rtol=1e-6)
+
+
+def test_scipy_tuple_bounds_two_params_not_misread_as_pair_list():
+    """A length-2 ``(lower, upper)`` tuple follows scipy's convention even for a
+    2-parameter model, where it is *also* structurally a list of two ``(lo, hi)``
+    pairs (issue #260).
+
+    Previously pounce resolved that ambiguity the pair-list way, silently
+    applying the transposed box (param 0 in ``[l0, l1]``, param 1 in
+    ``[u0, u1]``) and returning ``Solve_Succeeded`` with a badly wrong fit. The
+    scipy oracle is the ground truth for the API pounce documents it mirrors.
+    """
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x)  # noiseless: A=2, k=1; deterministic
+    model = expdecay_2p
+
+    # scipy convention: bounds = (lower_array, upper_array) -> A in [0,10],
+    # k in [1.6,10]. k rides its lower bound, A re-fits to compensate.
+    lower, upper = [0.0, 1.6], [10.0, 10.0]
+    rp = pounce.curve_fit(model, x, y, p0=[1.0, 2.0], bounds=(lower, upper),
+                          jac="fd")
+    rs, _ = scipy_optimize.curve_fit(model, x, y, p0=[1.0, 2.0],
+                                     bounds=(lower, upper))
+    np.testing.assert_allclose(rp.popt, rs, rtol=1e-4)
+    # the true constrained optimum, not the misread box [1.6, 10.0]
+    np.testing.assert_allclose(rp.popt, [2.42445211, 1.6], rtol=1e-4)
+
+    # The equivalent per-parameter pair *list* is pounce's own API and gives the
+    # identical box (A in [0,10], k in [1.6,10]) -- the two forms agree here.
+    rl = pounce.curve_fit(model, x, y, p0=[1.0, 2.0],
+                          bounds=[(0.0, 10.0), (1.6, 10.0)], jac="fd")
+    np.testing.assert_allclose(rl.popt, rs, rtol=1e-4)
+
+
+def test_scipy_tuple_bounds_match_scipy_across_param_counts():
+    """The scipy ``(lower, upper)`` 2-tuple maps to the same box as scipy for
+    n=2 (the formerly-broken ambiguous case) and n=3, and the scalar form keeps
+    working."""
+    x = np.linspace(0.0, 3.0, 80)
+
+    # n=2
+    y2 = 2.0 * np.exp(-1.0 * x)
+    b2 = ([0.0, 1.6], [10.0, 10.0])
+    p2 = pounce.curve_fit(expdecay_2p, x, y2, p0=[1.0, 2.0], bounds=b2,
+                          jac="fd").popt
+    s2, _ = scipy_optimize.curve_fit(expdecay_2p, x, y2, p0=[1.0, 2.0], bounds=b2)
+    np.testing.assert_allclose(p2, s2, rtol=1e-4)
+
+    # n=3 (already matched scipy; guard against regression)
+    y3 = expdecay_np(x, 3.0, 0.9, 0.5)
+    b3 = ([0.0, 0.0, -5.0], [10.0, 5.0, 5.0])
+    p3 = pounce.curve_fit(expdecay_np, x, y3, p0=[1.0, 1.0, 0.0], bounds=b3,
+                          jac="fd").popt
+    s3, _ = scipy_optimize.curve_fit(expdecay_np, x, y3, p0=[1.0, 1.0, 0.0],
+                                     bounds=b3)
+    np.testing.assert_allclose(p3, s3, rtol=1e-3)
+
+    # scalar scipy form
+    ps = pounce.curve_fit(expdecay_2p, x, y2, p0=[1.0, 2.0], bounds=(0, 10),
+                          jac="fd").popt
+    ss, _ = scipy_optimize.curve_fit(expdecay_2p, x, y2, p0=[1.0, 2.0],
+                                     bounds=(0, 10))
+    np.testing.assert_allclose(ps, ss, rtol=1e-4)
+
+
+def test_scipy_tuple_bounds_reversed_looking_box_is_valid():
+    """``bounds=([0.5, 0.1], [0.6, 0.2])`` is valid scipy semantics (param 0 in
+    ``[0.5, 0.6]``, param 1 in ``[0.1, 0.2]``) and must not raise the
+    reversed-bound error it produced when misread as pairs (issue #260)."""
+    x = np.linspace(0, 3, 60)
+    y = 0.55 * np.exp(-0.15 * x)
+    r = pounce.curve_fit(expdecay_2p, x, y, p0=[0.55, 0.15],
+                         bounds=([0.5, 0.1], [0.6, 0.2]), jac="fd")
+    assert 0.5 <= r.popt[0] <= 0.6 + 1e-9
+    assert 0.1 <= r.popt[1] <= 0.2 + 1e-9
 
 
 def test_curve_fit_validates_data_sigma_fscale_p0():


### PR DESCRIPTION
Fixes #260.

## Problem

`pounce.curve_fit` documents that its parameters mirror `scipy.optimize.curve_fit`, whose `bounds` is a 2-tuple `(lower_array, upper_array)`. For a **2-parameter** model, `_normalize_bound_arg` instead misread that tuple as a per-parameter list of `(lo, hi)` pairs:

- `bounds=([0.0, 1.6], [10.0, 10.0])` (scipy: `A ∈ [0, 10]`, `k ∈ [1.6, 10]`) was applied as `A ∈ [0, 1.6]`, `k ∈ [10, 10]` (k pinned).
- The box was silently transposed, and the solver still returned `Solve_Succeeded` with a fit ~14× worse than the true constrained optimum — no warning, no error.
- A reversed-looking-but-valid scipy box like `([0.5, 0.1], [0.6, 0.2])` raised a spurious "bounds reversed" error.

n=3 and n=4 already matched scipy (a 2-tuple can't be read as a pair list there); only the ambiguous n=2 case was wrong.

## Fix

The culprit was the `not _is_pair_list(bounds, n)` guard. A length-2 tuple can only double as a pair list when `n == 2` (a pair list needs one pair per parameter), so that guard only ever changed the lone ambiguous 2-parameter case — and it resolved it *against* the scipy convention `curve_fit` claims to mirror.

- Drop the guard (and the now-dead `_is_pair_list` helper): a length-2 tuple is **always** scipy's `(lower, upper)` form.
- pounce's per-parameter pair-list API stays available via a **list**, `bounds=[(l0, u0), (l1, u1)]` (as `pounce.minimize` uses), which is never reinterpreted — so the two forms stay distinct even for `n == 2`.
- Updated the public `curve_fit` docstring to state the convention.

## Verification

- The issue's reproduction now matches the scipy oracle exactly: `popt ≈ [2.4244521, 1.6]`, SSE ≈ 2.133 (was `[1.6, 10.0]`, SSE 30.3).
- The reversed-looking-but-valid box no longer raises.
- Added regression tests: n=2 tuple bounds pinned to the scipy oracle, an n=3 regression guard, the scalar and list pair-list forms, and the reversed-box case.
- `test_curve_fit.py`: 49 passed; bounds/minima/streaming subset across `curve_fit` + `minimize`: 28 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFVqH8SYbXD2qJroUXwtTA

---
_Generated by [Claude Code](https://claude.ai/code/session_01QFVqH8SYbXD2qJroUXwtTA)_