### PR TITLE
chore: add a PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,76 @@
+<!--
+Delete any section that does not apply. A one-line typo fix does not need a
+verification table; a solver behaviour change does.
+
+The prose sections matter more than the checklist. POUNCE PRs are read later as
+the record of *why* a numerical decision was made — the CHANGELOG says what
+changed, this says what was tried and rejected.
+-->
+
+## Problem
+
+<!--
+What breaks, in the user's terms, with numbers. If there is an oracle (Ipopt,
+a published optimum, a closed-form answer), compare against it here.
+
+| | status | objective | NLP error | iters |
+|---|---|---|---|---|
+| before | | | | |
+| after | | | | |
+| oracle | | | | |
+-->
+
+## Cause
+
+<!-- The actual mechanism, not the symptom. -->
+
+## Fix
+
+<!--
+What changed and why this approach. If you tried something else first and
+rejected it, say so and say what ruled it out — a future maintainer retuning
+this will otherwise repeat the experiment. Prefer "measured over N models,
+every threshold that fires also introduces X" over "this seemed better".
+-->
+
+## Blast radius
+
+<!--
+Who else is affected. For solver changes: what does the corpus sweep say, and
+against which baseline commit? If the answer is "bit-identical except the
+targeted case", say that — it is the most useful sentence in the PR.
+-->
+
+## Tests
+
+<!--
+What pins this, and how you know the tests bite: state that they fail on the
+parent commit, and for the right reason. A regression test that passes pre-fix
+is not a regression test.
+
+If a behaviour is deliberately NOT pinned (platform-dependent, needs a fixture
+too large to vendor), say so and why, so the gap is a known one.
+-->
+
+---
+
+- [ ] Tests fail on the parent commit for the stated reason
+- [ ] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
+- [ ] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
+- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
+- [ ] Every claim in this PR body and in the code comments is true of the code
+      as it stands now — no test named that does not exist, no doc describing a
+      design that was revised mid-review, no measurement whose baseline has
+      since moved
+
+<!--
+That last box is not boilerplate. The recurring failure here is a PR body or
+doc comment that was accurate three commits ago: a claim that a test pins some
+behaviour when that test was later dropped, a comment describing the first
+attempt rather than what shipped, or a corpus sweep measured before a sibling
+PR landed. Re-read the body against the final diff before requesting review.
+
+See CONTRIBUTING.md for the full definition of done and the cross-solver doc
+ownership rules (solver routing / problem-class coverage changes need
+@jkitchin as reviewer).
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,10 @@ a multi-solver, multi-registry project from drifting. The release mechanics
 live in `dev-notes/cargo-release.md` and `dev-notes/pypi-release.md`; this file
 is about getting a change *merge-ready*.
 
+Opening a PR fills in `.github/pull_request_template.md`, which scaffolds the
+narrative these PRs are expected to carry — problem with numbers, cause, fix,
+blast radius, tests — and checklists the definition of done below.
+
 ## Enable the git hooks (one-time)
 
 ```sh


### PR DESCRIPTION
Adds `.github/pull_request_template.md`, plus a pointer to it from `CONTRIBUTING.md`.

## Problem

There is no template, so each PR reinvents its structure. In practice the recent ones have converged on the same shape anyway — #249, #253, #258, #259 and #261 all run problem-with-numbers → cause → fix → validation → tests — so the template is mostly writing down what already happens, and making it the path of least resistance for the next contributor.

## Fix

A scaffold in that shape, with guidance in HTML comments so a filled-in body renders clean. Sections are explicitly droppable; a typo fix should not need a verification table.

The checklist covers CONTRIBUTING's three-part definition of done (code + test, CHANGELOG, book page) and adds two items this repo has paid for:

- **"Tests fail on the parent commit for the stated reason."** A regression test that passes pre-fix pins nothing. Worth an explicit box because it is invisible in review — the diff looks identical either way.
- **A claim-hygiene box.** #259 shipped a PR body and a doc comment both asserting that a test pinned the `deb7` rescue. That test had been dropped mid-review, once the guard's effect on `deb7` turned out to differ by host in sign. The same PR described its bookkeeping as "gated on the guard having actually fired", which is precisely what its own code comment spent a paragraph explaining had been a bug. Neither was careless: both were accurate three commits earlier and went stale as the design moved. Re-reading the body against the final diff is the cheap catch, so the template asks for it directly.

## Blast radius

Documentation only, no code. Affects the pre-filled body on new PRs; existing PRs are untouched. `scripts/check-docs-consistency.sh` passes (the template lives under `.github/`, not `docs/src/`, so it is outside the book's link graph).

## Tests

None — there is nothing executable here. The rendering was checked by reading the file; the mechanism (GitHub reads `.github/pull_request_template.md`) is standard and will be visibly exercised by the next PR opened against this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
