### PR TITLE
Cap μ_min to prevent blocking termination certificate under strong scaling

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -922,6 +922,7 @@ impl AlgorithmBuilder {
                 adaptive.mu_max = self.mu.mu_max;
                 adaptive.mu_max_fact = self.mu.mu_max_fact;
                 adaptive.mu_min = self.mu.mu_min;
+                adaptive.compl_inf_tol = self.conv_check.compl_inf_tol;
                 adaptive.mu_linear_decrease_factor = self.mu.mu_linear_decrease_factor;
                 adaptive.mu_superlinear_decrease_power = self.mu.mu_superlinear_decrease_power;
                 adaptive.barrier_tol_factor = self.mu.barrier_tol_factor;

--- a/crates/pounce-algorithm/src/mu/adaptive.rs
+++ b/crates/pounce-algorithm/src/mu/adaptive.rs
@@ -67,6 +67,14 @@ pub struct AdaptiveMuUpdate {
     pub filter_max_margin: Number,
     pub filter_margin_fact: Number,
     pub mu_min: Number,
+    /// Complementarity tolerance — option `compl_inf_tol`, default 1e-4 per
+    /// `IpAlgorithmRegOp.cpp`. Not used directly by the adaptive update;
+    /// enters only through [`Self::certificate_safe_mu_min`], which caps
+    /// `mu_min` so a strongly scaled-down objective can still reach the
+    /// termination certificate (pounce#266) — the μ floor lives in scaled
+    /// space while `compl_inf_tol` is enforced on the *unscaled*
+    /// complementarity.
+    pub compl_inf_tol: Number,
     /// Upper bound on μ. Sentinel `-1.0` means "not yet computed; init
     /// lazily on the first `update_barrier_parameter` call to
     /// `mu_max_fact * curr_avrg_compl()`". Mirrors
@@ -189,6 +197,7 @@ impl Default for AdaptiveMuUpdate {
             filter_max_margin: 1.0,
             filter_margin_fact: 1e-5,
             mu_min: 1e-11,
+            compl_inf_tol: 1e-4,
             // Sentinel; lazy-initialised to `mu_max_fact * avrg_compl`
             // on the first `update_barrier_parameter` call. Upstream
             // `IpAdaptiveMuUpdate.cpp:164` sets `mu_max_ = -1.` when
@@ -388,15 +397,44 @@ impl AdaptiveMuUpdate {
         }
     }
 
+    /// `mu_min` capped so it can never block the termination certificate
+    /// (pounce#266) — the adaptive twin of
+    /// [`crate::mu::monotone::MonotoneMuUpdate::certificate_safe_mu_min`],
+    /// which carries the full story. The raw absolute `mu_min` (default
+    /// `1e-11`) lives in μ's scaled space while `compl_inf_tol` is enforced
+    /// on the *unscaled* complementarity; below
+    /// `|df| ≈ mu_min·(barrier_tol_factor+1)/compl_inf_tol` an uncapped
+    /// floor pins the unscaled complementarity above `compl_inf_tol` and
+    /// the strict certificate is unreachable — in adaptive mode the solve
+    /// then degrades to `Solved_To_Acceptable_Level` (code 100, outside
+    /// AMPL's 0..99 solved band) on an iterate sitting at the optimum.
+    ///
+    /// The restoration sub-builder's `mu_min = 100 · outer_mu_min`
+    /// safeguard is unaffected for the same reason as in monotone mode:
+    /// `RestoIpoptNlp` does not override `obj_scaling_factor`, so the resto
+    /// inner IPM sees `df = 1` and the cap sits far above the safeguard.
+    pub fn certificate_safe_mu_min(&self, obj_scaling_factor: Number) -> Number {
+        crate::mu::certificate_safe_mu_min(
+            self.mu_min,
+            self.compl_inf_tol,
+            self.barrier_tol_factor,
+            obj_scaling_factor,
+        )
+    }
+
     /// Port of `AdaptiveMuUpdate::NewFixedMu`
     /// (`IpAdaptiveMuUpdate.cpp:583-627`). Selects μ when the state
     /// machine drops out of free mode. v1.0 always uses the
     /// "average complementarity" branch (no `fix_mu_oracle_` is
     /// wired; matches `fixed_mu_oracle = average_compl`).
-    fn new_fixed_mu(&self, cq: &IpoptCqHandle) -> Number {
+    ///
+    /// The lower clamp is the certificate-safe `mu_min` (pounce#266);
+    /// capped ≤ raw `mu_min`, so the `[mu_min, mu_max]` band the lazy
+    /// `mu_max` init guarantees stays valid.
+    fn new_fixed_mu(&self, cq: &IpoptCqHandle, mu_min: Number) -> Number {
         let avrg = cq.borrow().curr_avrg_compl();
         let new_mu = self.adaptive_mu_monotone_init_factor * avrg;
-        new_mu.clamp(self.mu_min, self.mu_max)
+        new_mu.clamp(mu_min, self.mu_max)
     }
 }
 
@@ -536,6 +574,16 @@ impl MuUpdate for AdaptiveMuUpdate {
         let force_no_progress = tiny_step_flag
             && self.adaptive_mu_globalization != AdaptiveMuGlobalization::NeverMonotoneMode;
 
+        // Certificate-safe μ floor (pounce#266): every place below that
+        // stops μ from descending — the fixed-mode reduction, the
+        // fixed-mode re-seed, the oracles' internal clamps, and the final
+        // band clamp — must use `mu_min` capped into the space the
+        // certificate lives in, or a strongly scaled-down objective ends
+        // `Solved_To_Acceptable_Level` on an iterate at the optimum. The
+        // `no_bounds` short-circuit above keeps the raw `mu_min`: with no
+        // bound multipliers there is no complementarity to certify.
+        let mu_min = self.certificate_safe_mu_min(cq.borrow().obj_scaling_factor());
+
         if !self.free_mu_mode {
             // Fixed-mu branch — `cpp:299-342`.
             let sufficient_progress = !force_no_progress && self.check_sufficient_progress(cq);
@@ -562,7 +610,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                 if sub_problem_error <= self.barrier_tol_factor * curr_mu || tiny_step_flag {
                     let lin = self.mu_linear_decrease_factor * curr_mu;
                     let sup = curr_mu.powf(self.mu_superlinear_decrease_power);
-                    let new_mu = lin.min(sup).max(self.mu_min).min(self.mu_max);
+                    let new_mu = lin.min(sup).max(mu_min).min(self.mu_max);
                     let new_tau = self.tau_min.max(1.0 - new_mu);
                     data.borrow_mut().curr_tau = new_tau;
                     return new_mu;
@@ -617,7 +665,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                         d.accept_trial_point();
                     }
                 }
-                let new_mu = self.new_fixed_mu(cq);
+                let new_mu = self.new_fixed_mu(cq, mu_min);
                 let new_tau = self.tau_min.max(1.0 - new_mu);
                 data.borrow_mut().curr_tau = new_tau;
                 return new_mu;
@@ -639,7 +687,7 @@ impl MuUpdate for AdaptiveMuUpdate {
 
         let loqo_candidate = || {
             let mut oracle = LoqoMuOracle {
-                mu_min: self.mu_min,
+                mu_min,
                 mu_max: self.mu_max,
                 avrg_compl,
                 centrality_xi,
@@ -692,7 +740,7 @@ impl MuUpdate for AdaptiveMuUpdate {
                             // was hard-coded to 100.0, so a user-set `sigma_max`
                             // reached only the quality-function oracle (L3).
                             sigma_max: self.sigma_max,
-                            mu_min: self.mu_min,
+                            mu_min,
                             mu_max: self.mu_max,
                             mu_curr: curr_mu,
                             mu_aff: curr_mu,
@@ -707,7 +755,7 @@ impl MuUpdate for AdaptiveMuUpdate {
             MuOracleKind::QualityFunction => match (nlp, pd_search_dir) {
                 (Some(nlp), Some(sd)) => {
                     let mut oracle = QualityFunctionMuOracle::new();
-                    oracle.mu_min = self.mu_min;
+                    oracle.mu_min = mu_min;
                     oracle.mu_max = self.mu_max;
                     oracle.sigma_min = self.sigma_min;
                     oracle.sigma_max = self.sigma_max;
@@ -731,7 +779,7 @@ impl MuUpdate for AdaptiveMuUpdate {
 
         // Safeguard floor + global band clamp (cpp:410-426).
         let lower = self.lower_mu_safeguard(dual_inf, primal_inf, candidate);
-        let mu = candidate.max(self.mu_min).max(lower).min(self.mu_max);
+        let mu = candidate.max(mu_min).max(lower).min(self.mu_max);
 
         // NB: upstream `IpAdaptiveMuUpdate.cpp:410-426` does NOT require
         // `mu ≤ curr_mu` in free mode — the oracle is allowed to bump
@@ -749,6 +797,37 @@ impl MuUpdate for AdaptiveMuUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// pounce#266, adaptive twin of the monotone test: the raw `mu_min`
+    /// clamp must yield to `compl_inf_tol·|df|/(barrier_tol_factor+1)` once
+    /// |df| drops below `df* = mu_min·(barrier_tol_factor+1)/compl_inf_tol`,
+    /// or the strict certificate is unreachable and the solve degrades to
+    /// `Solved_To_Acceptable_Level` (code 100) at the optimum.
+    #[test]
+    fn adaptive_mu_min_is_capped_so_certificate_stays_reachable() {
+        let a = AdaptiveMuUpdate::new();
+        let df_star = a.mu_min * (a.barrier_tol_factor + 1.0) / a.compl_inf_tol;
+        assert!((df_star - 1.1e-6).abs() < 1e-21);
+        for df in [1.0, -1.0, 1e-3, 1e-5, df_star] {
+            assert_eq!(a.certificate_safe_mu_min(df), a.mu_min);
+        }
+        // HS71 × 1e8 computes df = 8.3e-8, under the cliff: the cap engages.
+        let df = 8.3e-8;
+        let capped = a.certificate_safe_mu_min(df);
+        assert!(capped < a.mu_min);
+        assert!((capped - 1e-4 * 8.3e-8 / 11.0).abs() < 1e-27);
+        assert_eq!(a.certificate_safe_mu_min(-df), capped);
+        // Degenerate factors fall back to the unconverted tolerance, whose
+        // cap (9.09e-6) leaves mu_min alone.
+        for df in [0.0, Number::NAN, Number::INFINITY] {
+            assert_eq!(a.certificate_safe_mu_min(df), a.mu_min);
+        }
+        // The restoration sub-builder's `mu_min = 100 · outer_mu_min`
+        // safeguard survives: the resto inner IPM sees df = 1.
+        let mut resto = AdaptiveMuUpdate::new();
+        resto.mu_min = 100.0 * a.mu_min;
+        assert_eq!(resto.certificate_safe_mu_min(1.0), resto.mu_min);
+    }
 
     #[test]
     fn lower_mu_safeguard_initializes_from_first_call() {

--- a/crates/pounce-algorithm/src/mu/mod.rs
+++ b/crates/pounce-algorithm/src/mu/mod.rs
@@ -13,3 +13,43 @@ pub mod oracle;
 pub mod r#trait;
 
 pub use r#trait::MuUpdate;
+
+use pounce_common::types::Number;
+
+/// `compl_inf_tol` expressed in the **internally scaled** space that μ lives
+/// in (pounce#257). Shared by both μ strategies; see
+/// [`monotone::MonotoneMuUpdate::scaled_compl_inf_tol`] for the full story.
+///
+/// `compl_inf_tol` is enforced on the **unscaled** complementarity, which is
+/// the scaled complementarity divided by the objective scaling factor — so in
+/// scaled units the tolerance is `compl_inf_tol · |df|`. The factor is signed
+/// (`obj_scaling_factor = -1` poses a maximization), so take its magnitude,
+/// and fall back to the unconverted tolerance when it is absent or degenerate.
+pub(crate) fn scaled_compl_inf_tol(compl_inf_tol: Number, obj_scaling_factor: Number) -> Number {
+    let df = obj_scaling_factor.abs();
+    if df.is_finite() && df > 0.0 {
+        compl_inf_tol * df
+    } else {
+        compl_inf_tol
+    }
+}
+
+/// `mu_min` capped so it can never block the termination certificate
+/// (pounce#266). Shared by both μ strategies; see
+/// [`monotone::MonotoneMuUpdate::certificate_safe_mu_min`] for the full story.
+///
+/// `mu_min` is an absolute constant in μ's scaled space. Left raw, once
+/// `compl_inf_tol·|df|/(barrier_tol_factor+1) < mu_min` the unscaled
+/// complementarity is pinned at `mu_min/|df| > compl_inf_tol` and the strict
+/// certificate becomes unreachable. The cap keeps `mu_min` inert exactly when
+/// it would cost the certificate, with the same headroom the monotone dynamic
+/// floor reserves. A floor that is too low only costs iterations; one that is
+/// too high costs the certificate.
+pub(crate) fn certificate_safe_mu_min(
+    mu_min: Number,
+    compl_inf_tol: Number,
+    barrier_tol_factor: Number,
+    obj_scaling_factor: Number,
+) -> Number {
+    mu_min.min(scaled_compl_inf_tol(compl_inf_tol, obj_scaling_factor) / (barrier_tol_factor + 1.0))
+}

--- a/crates/pounce-algorithm/src/mu/monotone.rs
+++ b/crates/pounce-algorithm/src/mu/monotone.rs
@@ -141,12 +141,7 @@ impl MonotoneMuUpdate {
     /// it is absent or degenerate — a floor that is too low only costs
     /// iterations, whereas one that is too high costs the certificate.
     pub fn scaled_compl_inf_tol(&self, obj_scaling_factor: Number) -> Number {
-        let df = obj_scaling_factor.abs();
-        if df.is_finite() && df > 0.0 {
-            self.compl_inf_tol * df
-        } else {
-            self.compl_inf_tol
-        }
+        crate::mu::scaled_compl_inf_tol(self.compl_inf_tol, obj_scaling_factor)
     }
 
     /// `mu_min` capped so it can never block the termination certificate
@@ -178,8 +173,12 @@ impl MonotoneMuUpdate {
     /// cap (`compl_inf_tol/(barrier_tol_factor+1) ≈ 9e-6` at defaults) sits
     /// far above `100 · mu_min`.
     pub fn certificate_safe_mu_min(&self, obj_scaling_factor: Number) -> Number {
-        self.mu_min
-            .min(self.scaled_compl_inf_tol(obj_scaling_factor) / (self.barrier_tol_factor + 1.0))
+        crate::mu::certificate_safe_mu_min(
+            self.mu_min,
+            self.compl_inf_tol,
+            self.barrier_tol_factor,
+            obj_scaling_factor,
+        )
     }
 
     /// Pure scalar reduction used by the trait impl. Exposed so unit

--- a/crates/pounce-algorithm/src/mu/monotone.rs
+++ b/crates/pounce-algorithm/src/mu/monotone.rs
@@ -149,6 +149,39 @@ impl MonotoneMuUpdate {
         }
     }
 
+    /// `mu_min` capped so it can never block the termination certificate
+    /// (pounce#266) — the companion of [`Self::scaled_compl_inf_tol`].
+    ///
+    /// #258 converted the *dynamic* term of the barrier floor into μ's scaled
+    /// space, but the floor has a second, independent term: `mu_min`, a raw
+    /// absolute constant (default `1e-11`) that also lives in scaled space.
+    /// Once `compl_inf_tol·|df|/(barrier_tol_factor+1) < mu_min` — i.e.
+    /// `|df|` below `≈ mu_min·(barrier_tol_factor+1)/compl_inf_tol` — the
+    /// converted term stops mattering, μ bottoms out at `mu_min`, and the
+    /// unscaled complementarity is pinned at `mu_min/|df| > compl_inf_tol`:
+    /// the certificate is unreachable no matter how long the solve runs, and
+    /// μ-at-floor plus the vanishing step exits `STOP_AT_TINY_STEP` on an
+    /// iterate that is *at* the optimum (HS71 × 1e8, `df = 8.3e-8`).
+    ///
+    /// Upstream's monotone floor (`IpMonotoneMuUpdate.cpp:CalcNewMuAndTau`)
+    /// has no `mu_min` term at all — pounce added it so the restoration
+    /// sub-builder's `with_mu_min(100 * outer_mu_min)` safeguard applies —
+    /// which is why Ipopt certifies these files even with `mu_min=1e-11`
+    /// forced. Capping at `scaled_compl_inf_tol / (barrier_tol_factor + 1)`
+    /// keeps `mu_min` inert exactly when it would cost the certificate, with
+    /// the same headroom the dynamic floor reserves (μ then bottoms out where
+    /// Ipopt's does: `7.58e-13` on HS71 × 1e8). A floor that is too low only
+    /// costs iterations; one that is too high costs the certificate.
+    ///
+    /// The restoration safeguard is unaffected: `RestoIpoptNlp` does not
+    /// override `obj_scaling_factor`, so the inner IPM sees `df = 1` and the
+    /// cap (`compl_inf_tol/(barrier_tol_factor+1) ≈ 9e-6` at defaults) sits
+    /// far above `100 · mu_min`.
+    pub fn certificate_safe_mu_min(&self, obj_scaling_factor: Number) -> Number {
+        self.mu_min
+            .min(self.scaled_compl_inf_tol(obj_scaling_factor) / (self.barrier_tol_factor + 1.0))
+    }
+
     /// Pure scalar reduction used by the trait impl. Exposed so unit
     /// tests can drive the formula without standing up an
     /// `IpoptData`/`IpoptCq` fixture.
@@ -214,12 +247,21 @@ impl MuUpdate for MonotoneMuUpdate {
         // where the next direction is dominated by ill-conditioned
         // barrier terms and the line search stalls.
         // We also `max` with `mu_min` so the restoration sub-builder's
-        // `with_mu_min(100 * outer_mu_min)` safeguard still applies.
+        // `with_mu_min(100 * outer_mu_min)` safeguard still applies —
+        // but capped by `certificate_safe_mu_min` (pounce#266): both
+        // floor terms live in μ's scaled space, and an uncapped
+        // absolute `mu_min` re-creates exactly the unreachable
+        // certificate that `scaled_compl_inf_tol` (pounce#257) removed
+        // from the dynamic term, once |df| drops below
+        // `mu_min·(barrier_tol_factor+1)/compl_inf_tol ≈ 1e-7`.
         let tol = data.borrow().tol;
         let df = cq.borrow().obj_scaling_factor();
         let dynamic_floor =
             tol.min(self.scaled_compl_inf_tol(df)) / (self.barrier_tol_factor + 1.0);
-        let floor = self.mu_target.max(self.mu_min).max(dynamic_floor);
+        let floor = self
+            .mu_target
+            .max(self.certificate_safe_mu_min(df))
+            .max(dynamic_floor);
 
         // The barrier error depends on μ via the relaxed
         // complementarity. Read it once per μ value.
@@ -353,5 +395,52 @@ mod tests {
         for df in [0.0, Number::NAN, Number::INFINITY] {
             assert_eq!(m.scaled_compl_inf_tol(df), m.compl_inf_tol);
         }
+    }
+
+    /// pounce#266: `mu_min` is the *other* floor term in scaled space, and
+    /// unconverted it blocks the certificate below `df ≈ 1e-7` exactly as the
+    /// raw `compl_inf_tol` did in #257.
+    #[test]
+    fn mu_min_is_capped_so_certificate_stays_reachable() {
+        let m = MonotoneMuUpdate::default();
+        // The cap engages once `compl_inf_tol·df/(barrier_tol_factor+1)`
+        // drops under `mu_min`, i.e. below
+        // `df* = mu_min·(barrier_tol_factor+1)/compl_inf_tol = 1.1e-6`.
+        // Unscaled and mildly scaled problems are untouched.
+        let df_star = m.mu_min * (m.barrier_tol_factor + 1.0) / m.compl_inf_tol;
+        assert!((df_star - 1.1e-6).abs() < 1e-21);
+        for df in [1.0, -1.0, 1e-3, 1e-5, df_star] {
+            assert_eq!(m.certificate_safe_mu_min(df), m.mu_min);
+        }
+        // HS71 × 1e8 computes df = 8.3e-8. The certificate needs
+        // μ ≤ compl_inf_tol·df ≈ 8.3e-12 < mu_min, so the cap must engage —
+        // with the dynamic floor's own headroom, landing at ≈ 7.55e-13
+        // (which is where Ipopt's μ bottoms out on the same file).
+        let df = 8.3e-8;
+        let capped = m.certificate_safe_mu_min(df);
+        assert!(capped < m.mu_min);
+        assert!(
+            capped <= m.scaled_compl_inf_tol(df),
+            "floor {capped} still exceeds the scaled certificate bound",
+        );
+        assert!((capped - 1e-4 * 8.3e-8 / 11.0).abs() < 1e-27);
+        // Signed factor, same as `scaled_compl_inf_tol`.
+        assert_eq!(m.certificate_safe_mu_min(-df), capped);
+        // Degenerate factors fall back to the unconverted tolerance inside
+        // `scaled_compl_inf_tol`, whose cap (9.09e-6) leaves mu_min alone.
+        for df in [0.0, Number::NAN, Number::INFINITY] {
+            assert_eq!(m.certificate_safe_mu_min(df), m.mu_min);
+        }
+    }
+
+    /// The restoration sub-builder raises the floor to `100 · outer_mu_min`
+    /// (DECONVBNE safeguard). `RestoIpoptNlp` does not override
+    /// `obj_scaling_factor`, so the resto inner IPM sees `df = 1` — the cap
+    /// must leave that safeguard fully intact.
+    #[test]
+    fn resto_mu_min_safeguard_survives_the_cap() {
+        let outer = MonotoneMuUpdate::default();
+        let resto = MonotoneMuUpdate::new().with_mu_min(100.0 * outer.mu_min);
+        assert_eq!(resto.certificate_safe_mu_min(1.0), 100.0 * outer.mu_min);
     }
 }

--- a/crates/pounce-cli/tests/fixtures/hs71_obj1e8.nl
+++ b/crates/pounce-cli/tests/fixtures/hs71_obj1e8.nl
@@ -1,0 +1,77 @@
+g3 1 1 0	# problem unknown
+ 4 2 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 2 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 4 4 4 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 8 4 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o2
+o2
+o2
+v0
+v2
+v3
+v1
+C1
+o54
+4
+o5
+v0
+n2
+o5
+v2
+n2
+o5
+v3
+n2
+o5
+v1
+n2
+O0 0
+o2
+n100000000.0
+o2
+o2
+v0
+v1
+o54
+3
+v0
+v2
+v3
+x4
+0 1.0
+1 1.0
+2 5.0
+3 5.0
+r
+2 25
+4 40
+b
+0 1 5
+0 1 5
+0 1 5
+0 1 5
+k3
+2
+4
+6
+J0 4
+0 0
+1 0
+2 0
+3 0
+J1 4
+0 0
+1 0
+2 0
+3 0
+G0 4
+0 0
+1 0
+2 0
+3 100000000.0

--- a/crates/pounce-cli/tests/issue_266_mu_min_scaled_floor.rs
+++ b/crates/pounce-cli/tests/issue_266_mu_min_scaled_floor.rs
@@ -170,3 +170,16 @@ fn hs71_obj1e8_certifies_with_loosened_compl_inf_tol() {
     let report = solve("hs71_obj1e8.nl", &["compl_inf_tol=1e-2"]);
     assert_solved_at_optimum(&report, "hs71×1e8 (compl_inf_tol=1e-2)");
 }
+
+/// The same unconverted `mu_min` lived in the adaptive strategy's clamps
+/// (`adaptive.rs`: the fixed-mode reduction, the fixed-mode re-seed, the
+/// oracles' internal `[mu_min, mu_max]` bands, and the final band clamp).
+/// The consequence there is milder — the acceptable-level fallback rescues
+/// the solve into `Solved_To_Acceptable_Level` — but code 100 is still
+/// outside AMPL's 0..99 solved band. Post-fix the strict certificate must be
+/// issued.
+#[test]
+fn hs71_obj1e8_certifies_under_adaptive_mu_strategy() {
+    let report = solve("hs71_obj1e8.nl", &["mu_strategy=adaptive"]);
+    assert_solved_at_optimum(&report, "hs71×1e8 (mu_strategy=adaptive)");
+}

--- a/crates/pounce-cli/tests/issue_266_mu_min_scaled_floor.rs
+++ b/crates/pounce-cli/tests/issue_266_mu_min_scaled_floor.rs
@@ -1,0 +1,172 @@
+//! Issue #266 regression: the μ floor's *absolute* term must not block the
+//! termination certificate under strong objective scaling.
+//!
+//! PR #258 (issue #257) converted `compl_inf_tol` — enforced on the
+//! **unscaled** complementarity — into μ's scaled space before it enters the
+//! dynamic barrier floor. But the floor has a second, independent term:
+//! `mu_min`, a raw absolute constant (default `1e-11`) living in scaled
+//! space. Once `compl_inf_tol · df / (barrier_tol_factor + 1) < mu_min`, the
+//! converted dynamic term stops mattering and μ bottoms out at `mu_min`,
+//! leaving an unscaled complementarity of `≈ mu_min / df`. The certificate
+//! needs `mu_min / df ≤ compl_inf_tol`, so it becomes unreachable below
+//!
+//! ```text
+//!     df* = mu_min / compl_inf_tol = 1e-11 / 1e-4 = 1e-7
+//! ```
+//!
+//! `hs71_obj1e8.nl` is HS71 with the objective multiplied by `1e8` (the
+//! issue's `c1e8.nl`): gradient-based scaling computes `df ≈ 8.3e-8`, just
+//! under the cliff. The iterate sits *at* the optimum — same x* as unscaled
+//! HS71 to ~1e-9 — yet pre-fix POUNCE exits
+//! `Search_Direction_Becomes_Too_Small` (code 400, outside AMPL's 0..99
+//! solved band, which discopt's status map reads as UNBOUNDED). Upstream
+//! Ipopt certifies the same file Optimal.
+//!
+//! Fixture provenance: written by Pyomo 6.10 from
+//!
+//! ```python
+//! m.x1..m.x4 = Var(bounds=(1, 5)); x0 = (1, 5, 5, 1)
+//! m.obj = Objective(expr=1e8 * (x1*x4*(x1+x2+x3) + x3))
+//! m.g1 = Constraint(expr=x1*x2*x3*x4 >= 25)
+//! m.g2 = Constraint(expr=x1**2 + x2**2 + x3**2 + x4**2 == 40)
+//! ```
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pounce_cli::solve_report::SolveReport;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn tmp_path(suffix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_issue266_{}_{}_{suffix}",
+        std::process::id(),
+        n
+    ));
+    p
+}
+
+fn solve(fixture_name: &str, extra_opts: &[&str]) -> SolveReport {
+    let json_path = tmp_path(&format!("{fixture_name}.json"));
+    let sol_path = tmp_path(&format!("{fixture_name}.sol"));
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(fixture(fixture_name))
+        .arg(&sol_path)
+        .arg("--json-output")
+        .arg(&json_path);
+    for opt in extra_opts {
+        cmd.arg(opt);
+    }
+    let _ = cmd.status().expect("spawn pounce");
+    let text = std::fs::read_to_string(&json_path).expect("read json report");
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&sol_path);
+    serde_json::from_str(&text).expect("deserialize SolveReport")
+}
+
+/// HS71's optimum. The fixture's objective is the model's × `OBJ_MULTIPLIER`,
+/// and x* does not depend on the multiplier.
+const HS71_OPTIMUM: f64 = 17.014_017_140_2;
+const OBJ_MULTIPLIER: f64 = 1e8;
+
+/// `solve_result_num` 0..100 is AMPL's "solved" band; anything else is what a
+/// B&B driver turns into a spurious UNBOUNDED. Assert on the band, not one
+/// code.
+fn assert_solved_at_optimum(report: &SolveReport, ctx: &str) {
+    let code = report.solution.solve_result_num;
+    assert!(
+        (0..100).contains(&code),
+        "{ctx}: did not converge (solve_result_num={code}, status={:?}); \
+         this problem has a finite optimum ~{HS71_OPTIMUM}·{OBJ_MULTIPLIER:e} \
+         that Ipopt certifies (issue #266)",
+        report.solution.status,
+    );
+    let obj = report.solution.objective / OBJ_MULTIPLIER;
+    assert!(
+        (obj - HS71_OPTIMUM).abs() / HS71_OPTIMUM < 1e-6,
+        "{ctx}: objective/{OBJ_MULTIPLIER:e} = {obj} is not the known optimum \
+         {HS71_OPTIMUM}",
+    );
+}
+
+/// Confirm the fixture still lands in the regime that triggers #266: the
+/// computed objective scaling factor must sit below the `1e-7` cliff.
+fn assert_df_below_cliff(report: &SolveReport, ctx: &str) -> f64 {
+    let stats = &report.statistics;
+    let obj_scale = stats.final_scaled_objective / stats.final_objective;
+    assert!(
+        obj_scale < 1e-7,
+        "{ctx}: expected df < 1e-7 (the #266 cliff; HS71×1e8 computes \
+         df≈8.3e-8), got {obj_scale} — the fixture no longer exercises the \
+         bug",
+    );
+    obj_scale
+}
+
+/// The issue's headline row: HS71 × 1e8 at stock options must certify. Pre-fix
+/// this exits `Search_Direction_Becomes_Too_Small` (400) with the iterate
+/// sitting on the optimum, because μ cannot descend below the unconverted
+/// `mu_min = 1e-11` while the certificate needs `μ ≤ compl_inf_tol·df ≈
+/// 8.3e-12`.
+#[test]
+fn hs71_obj1e8_certifies_at_default_options() {
+    let report = solve("hs71_obj1e8.nl", &[]);
+    assert_df_below_cliff(&report, "hs71×1e8 (defaults)");
+    assert_solved_at_optimum(&report, "hs71×1e8 (defaults)");
+}
+
+/// #266 is tolerance-independent (unlike #257, whose tell was a tol
+/// inversion): pre-fix, tol=1e-6 and tol=1e-10 both fail, because the floor is
+/// pinned by `mu_min`, not by the `min(tol, …)` dynamic term. The whole band
+/// must certify.
+#[test]
+fn hs71_obj1e8_certifies_across_tolerances() {
+    for tol in ["1e-6", "1e-8", "1e-10"] {
+        let report = solve("hs71_obj1e8.nl", &[&format!("tol={tol}")]);
+        assert_solved_at_optimum(&report, &format!("hs71×1e8 (tol={tol})"));
+    }
+}
+
+/// Pin the mechanism rather than the symptom: the unscaled complementarity —
+/// the quantity `compl_inf_tol` is actually enforced on — must land under
+/// `compl_inf_tol` (1e-4). Pre-fix it is held at `mu_min/df ≈ 1.2e-4`, a hard
+/// 20% over, and no amount of further iteration can clear it because μ is
+/// already at its floor.
+#[test]
+fn hs71_obj1e8_unscaled_complementarity_clears_compl_inf_tol() {
+    let report = solve("hs71_obj1e8.nl", &[]);
+    let obj_scale = assert_df_below_cliff(&report, "hs71×1e8 (defaults)");
+    let unscaled_compl = report.statistics.final_compl / obj_scale;
+    assert!(
+        unscaled_compl <= 1e-4,
+        "unscaled complementarity {unscaled_compl} exceeds compl_inf_tol=1e-4, \
+         so no strict certificate is reachable no matter how long the solve \
+         runs (issue #266)",
+    );
+}
+
+/// A user forcing the pre-fix behaviour (`mu_min` big enough to block the
+/// certificate) must still be able to *loosen* `compl_inf_tol` and get their
+/// certificate — i.e. the fix must key on the option values, not constants.
+/// With `compl_inf_tol=1e-2`, the cliff moves to `df* = 1e-9`, well below this
+/// fixture's `df ≈ 8.3e-8`.
+#[test]
+fn hs71_obj1e8_certifies_with_loosened_compl_inf_tol() {
+    let report = solve("hs71_obj1e8.nl", &["compl_inf_tol=1e-2"]);
+    assert_solved_at_optimum(&report, "hs71×1e8 (compl_inf_tol=1e-2)");
+}

--- a/crates/pounce-restoration/tests/restoration_deadline.rs
+++ b/crates/pounce-restoration/tests/restoration_deadline.rs
@@ -183,8 +183,14 @@ fn solve_with_budget(budget: f64, n: usize) -> (ApplicationReturnStatus, i32, i3
 fn restoration_grind_honors_wall_deadline() {
     let n = 40;
 
-    // Baseline: a generous budget lets restoration run to completion.
+    // Baseline: a generous budget lets restoration run to completion. Timed,
+    // because the tight budget below is derived from this measurement — a
+    // hard-coded budget cannot be right on every machine (the original
+    // 0.05 s covered ~40% of the grind on a runner that finishes the whole
+    // baseline in ~0.13 s, and the 3× margin assertion flaked).
+    let t0 = std::time::Instant::now();
     let (base_status, _base_outer, base_inner) = solve_with_budget(60.0, n);
+    let base_elapsed = t0.elapsed().as_secs_f64();
     // Sanity: the fixture is genuinely restoration-heavy (many inner iters)
     // and does not spuriously "succeed" on an infeasible problem.
     assert!(
@@ -202,12 +208,16 @@ fn restoration_grind_honors_wall_deadline() {
         "fixture claimed success on an infeasible NLP: {base_status:?}",
     );
 
-    // Tight budget: the solve must stop on the wall-time limit having done
-    // dramatically fewer restoration inner iterations. Comparing the inner
-    // iteration count (rather than raw wall time) keeps the assertion robust
-    // across machine speeds: the budget is short enough that no realistic
-    // machine reaches even a third of the unbounded inner-iteration count.
-    let (tight_status, _tight_outer, tight_inner) = solve_with_budget(0.05, n);
+    // Tight budget: 1/20 of the measured baseline duration. The solve must
+    // stop on the wall-time limit having done dramatically fewer restoration
+    // inner iterations. Deriving the budget from the baseline (instead of
+    // hard-coding one) makes the 3× margin below machine-independent — it
+    // only fails if machine load drifts by more than ~6× between the two
+    // runs, or if the deadline genuinely stops being honored. Landing at
+    // 1/20 may cut the solve anywhere, including before restoration entry
+    // (tight_inner = 0): that is still correct behaviour, exercising the
+    // pre-loop init check rather than the per-inner-iteration check.
+    let (tight_status, _tight_outer, tight_inner) = solve_with_budget(base_elapsed / 20.0, n);
     assert!(
         matches!(
             tight_status,

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -56,7 +56,7 @@ current iterate's complementarity). See
 | `mu_strategy`                           | `monotone`         | `monotone` (Fiacco–McCormick schedule) or `adaptive` (oracle-driven).                         |
 | `mu_oracle`                             | `quality-function` | Adaptive oracle: `quality-function` / `loqo` / `probing`.                                     |
 | `mu_init`                               | `0.1`              | Seed value for μ at the first iterate.                                                        |
-| `mu_min`                                | `1e-11`            | Floor on μ; the solver stops decreasing past this.                                            |
+| `mu_min`                                | `1e-11`            | Floor on μ; the solver stops decreasing past this. In monotone mode the effective floor is capped at `compl_inf_tol·|df|/(barrier_tol_factor+1)` (df = objective scaling factor) so a strongly scaled-down objective can still certify. |
 | `mu_max`                                | `1e5`              | Cap on μ (adaptive mode). When set explicitly it overrides the `mu_max_fact` initialization.  |
 | `mu_max_fact`                           | `1e3`              | Initializes `mu_max` as `mu_max_fact · curr_avrg_compl` at the first iterate (adaptive mode). |
 | `mu_target`                             | `0.0`              | Stop target for μ in monotone mode.                                                           |

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -56,7 +56,7 @@ current iterate's complementarity). See
 | `mu_strategy`                           | `monotone`         | `monotone` (Fiacco–McCormick schedule) or `adaptive` (oracle-driven).                         |
 | `mu_oracle`                             | `quality-function` | Adaptive oracle: `quality-function` / `loqo` / `probing`.                                     |
 | `mu_init`                               | `0.1`              | Seed value for μ at the first iterate.                                                        |
-| `mu_min`                                | `1e-11`            | Floor on μ; the solver stops decreasing past this. In monotone mode the effective floor is capped at `compl_inf_tol·|df|/(barrier_tol_factor+1)` (df = objective scaling factor) so a strongly scaled-down objective can still certify. |
+| `mu_min`                                | `1e-11`            | Floor on μ; the solver stops decreasing past this. In both μ strategies the effective floor is capped at `compl_inf_tol·|df|/(barrier_tol_factor+1)` (df = objective scaling factor) so a strongly scaled-down objective can still certify. |
 | `mu_max`                                | `1e5`              | Cap on μ (adaptive mode). When set explicitly it overrides the `mu_max_fact` initialization.  |
 | `mu_max_fact`                           | `1e3`              | Initializes `mu_max` as `mu_max_fact · curr_avrg_compl` at the first iterate (adaptive mode). |
 | `mu_target`                             | `0.0`              | Stop target for μ in monotone mode.                                                           |


### PR DESCRIPTION
## Problem

HS71 with objective scaled by 1e8 (gradient-based scaling computes `df ≈ 8.3e-8`) sits at the optimum but POUNCE exits `Search_Direction_Becomes_Too_Small` (code 400) instead of certifying. Upstream Ipopt certifies the same file as Optimal.

The iterate is numerically at the solution (x* matches unscaled HS71 to ~1e-9), yet the solver cannot reach the termination certificate.

| | status | objective | certificate |
|---|---|---|---|
| before | 400 (UNBOUNDED) | correct | unreachable |
| after | 0 (Optimal) | correct | satisfied |
| Ipopt | 0 (Optimal) | correct | satisfied |

## Cause

PR #258 (issue #257) converted the *dynamic* term of the barrier floor (`compl_inf_tol · df / (barrier_tol_factor + 1)`) into μ's scaled space. However, the floor has a second, independent term: `mu_min`, a raw absolute constant (default `1e-11`) that also lives in scaled space and was left unconverted.

Once the dynamic term drops below `mu_min` — which happens when `|df|` falls below `≈ mu_min · (barrier_tol_factor + 1) / compl_inf_tol ≈ 1e-7` — μ bottoms out at `mu_min`. This pins the unscaled complementarity at `mu_min / |df|`, which for HS71×1e8 is `≈ 1.2e-4`, exceeding `compl_inf_tol = 1e-4`. The certificate becomes unreachable no matter how long the solve runs, and μ-at-floor plus vanishing steps exit on an iterate that is already at the optimum.

## Fix

Cap `mu_min` by the same logic that converted the dynamic floor term: the effective floor uses `min(mu_min, scaled_compl_inf_tol(df) / (barrier_tol_factor + 1))`, keeping `mu_min` inert exactly when it would cost the certificate — with the same headroom the dynamic floor reserves, so μ bottoms out where Ipopt's does (`7.58e-13` on HS71×1e8; the issue observed Ipopt at `7.5788e-13`).

The cap logic lives in a shared helper (`mu/mod.rs::certificate_safe_mu_min`), applied in **both μ strategies** (second commit):

- **Monotone** (`MonotoneMuUpdate::certificate_safe_mu_min`) — the barrier floor in `update_barrier_parameter`. Pre-fix consequence: code 400 as above.
- **Adaptive** (`AdaptiveMuUpdate::certificate_safe_mu_min`) — the fixed-mode Fiacco–McCormick reduction, the fixed-mode re-seed (`new_fixed_mu`), the oracles' internal `[mu_min, mu_max]` bands, and the final band clamp. `AdaptiveMuUpdate` gains a `compl_inf_tol` field, wired from `conv_check` in the builder like monotone's. Pre-fix consequence was milder — the acceptable-level fallback rescued the solve into `Solved_To_Acceptable_Level` — but code 100 is still outside AMPL's 0..99 solved band, on an iterate at the optimum.

Left raw on purpose: adaptive's lazy `mu_max` init (band-validity floor only; the capped value is ≤ raw so the `[mu_min, mu_max]` band stays valid) and the no-bounds short-circuit (no bound multipliers ⇒ no complementarity to certify).

The restoration sub-builder's safeguard (`mu_min = 100 · outer_mu_min`) is unaffected in both strategies because `RestoIpoptNlp` does not override `obj_scaling_factor`, so the restoration inner IPM sees `df = 1`, where the cap (~9e-6 at defaults) sits far above the safeguard.

## Blast radius

Bit-identical on unscaled and mildly scaled problems (`|df| ≥ 1.1e-6`, where the cap equals raw `mu_min`). Only affects solves with strong objective scaling, where it enables the certificate that was previously unreachable. Verified on the issue's sweeps:

- HS71 × s for s ∈ {1, 1e5, 1e7, 1e8, 1e9, 1e12}: every row certifies 0/SolveSucceeded at obj/s = 17.0140171402, bit-identical to the issue's known-good `mu_min=1e-14` cure — under both μ strategies.
- The issue comment's HS13 family (×1e6/1e8/1e10 from x0=(1e4,1e4)): `SearchDirTooSmall` → `Optimal`, bit-identical to the cure.
- The issue's non-finding regimes (large `obj_scaling_factor`, small model-scaled objectives) unchanged.

## Tests

- `issue_266_mu_min_scaled_floor.rs` (new, with a Pyomo-generated `hs71_obj1e8.nl` fixture):
  - `hs71_obj1e8_certifies_at_default_options` — the headline case at stock options
  - `hs71_obj1e8_certifies_across_tolerances` — the failure was tolerance-independent (unlike #257); the whole band must certify
  - `hs71_obj1e8_unscaled_complementarity_clears_compl_inf_tol` — pins the mechanism: unscaled complementarity must land under `compl_inf_tol`
  - `hs71_obj1e8_certifies_with_loosened_compl_inf_tol` — the fix keys on option values, not constants
  - `hs71_obj1e8_certifies_under_adaptive_mu_strategy` — the adaptive twin (pre-fix: code 100)
- Unit tests: `monotone.rs::mu_min_is_capped_so_certificate_stays_reachable` and `adaptive.rs::adaptive_mu_min_is_capped_so_certificate_stays_reachable` pin the cap's engage threshold (`df* = 1.1e-6`), sign/degenerate-factor handling, and the restoration safeguard; `monotone.rs::resto_mu_min_safeguard_survives_the_cap` covers the `100·mu_min` builder path.

Full `pounce-algorithm`, `pounce-restoration`, and `pounce-cli` suites pass.

## Bonus: pre-existing flake fixed (third commit)

Running the full suites surfaced `restoration_grind_honors_wall_deadline` (pounce-restoration) failing on fast machines: it hard-coded a 0.05 s wall budget and assumed no machine completes a third of the baseline restoration grind in that time — a current runner grinds the whole 505-iteration baseline in ~0.13 s, so the 3× margin assertion failed whenever the machine wasn't loaded. Unrelated to the μ change (fails identically with it stashed; identical iteration counts in both trees since the fixture has `df = 1`). Fixed by timing the baseline solve and giving the tight run 1/20 of the measured duration, making the margin machine-independent. Verified 10/10 green idle and 10/10 green under full-core CPU load; the old constant failed consistently idle on the same machine.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Q3TZJV9N3TebCaCNuS4aA