### PR TITLE
Fix #265: reject ambiguous n=2 tuple bounds and NaN bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ changes.
   (previously they slipped past the reversed-bound check — `lb > ub` is `False`
   against `NaN` — and behaved as a silent "no bound"). `None` / ±inf remain the
   supported unbounded spellings.
+- A degenerate covariance is no longer silent. A zero-width bound (`lo == hi`,
+  pounce's "hold a parameter constant" idiom) fixes a parameter and reports its
+  `perr` as `0`; a corner solution with every parameter on an active bound
+  reports `pcov = 0` throughout. Both are intended, but previously came back
+  with no signal — "infinite confidence in a wrong answer" in #265's words.
+  `curve_fit` / `curve_fit_minima` / `curve_fit_streaming` now emit a
+  `UserWarning` in each case (naming the pinned parameters for the zero-width
+  case), so the perr of 0 reads as the constraint it is, not an estimated
+  uncertainty. No numbers change.
 
 ### Changed — `dual_diverging_streak` is now **off by default** (#250 follow-up)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — ambiguous 2-parameter tuple bounds and NaN bounds (#265)
+
+- `curve_fit` / `curve_fit_minima` / `curve_fit_streaming`: at `n == 2`, a
+  length-2 **tuple** of `(lo, hi)` pairs (e.g. `((0, 10), (0, 10))`) was
+  silently read as scipy's `(lower, upper)` — the transposed box pinned both
+  parameters and still reported `Solve_Succeeded` (#265, the mirror of #260).
+  That shape is genuinely ambiguous and now **raises**, naming both unambiguous
+  spellings; the list-of-pairs form `[(l0, u0), (l1, u1)]` and the
+  tuple-of-arrays form `([l0, l1], [u0, u1])` are unchanged. A bare `None` side
+  (`(None, 10.0)`) still means unbounded on that side.
+- NaN bounds are now rejected in `minimize` and every `curve_fit` surface
+  (previously they slipped past the reversed-bound check — `lb > ub` is `False`
+  against `NaN` — and behaved as a silent "no bound"). `None` / ±inf remain the
+  supported unbounded spellings.
+
 ### Changed — `dual_diverging_streak` is now **off by default** (#250 follow-up)
 
 - **The dual-divergence guard is opt-in.** It shipped default-on at `15` to bound

--- a/dev-notes/issue-265-plan.md
+++ b/dev-notes/issue-265-plan.md
@@ -344,11 +344,19 @@ else under the other reading, and did we silently pick?" The invariant to
 hold: **every accepted input has exactly one valid reading; every input with
 two valid readings at n=2 raises.**
 
-## 9. Explicitly out of scope (file separately, don't fix here)
+## 9. Scope notes
 
 - `curve_fit_minima` reporting `pcov = 0`, `perr = [0, 0]` for a degenerate
-  (zero-width) box — "infinite confidence in a wrong answer". Real, but
-  independent of how the box got degenerate; the issue's comment flags it as
-  possibly its own issue. Recommend opening one and linking #265.
+  (zero-width) box — "infinite confidence in a wrong answer". Originally
+  deferred here as possibly its own issue, but **pulled into this PR** (owner
+  decision, PR #269). Fixed by warning — not by changing any number — at the
+  single shared result-assembly site in `_solve_fit` (`_curve_fit.py`), which
+  all three surfaces route through. The covariance projection is correct,
+  intentional, documented behavior (`_projected_covariance` zeros variance
+  along active directions; `_active_constraint_jac` supports `lo == hi` as the
+  fix-a-parameter idiom); the only defect was that a resulting `perr = 0` was
+  silent. Two warnings: a zero-width-bound case (naming the pinned params) and
+  an all-params-on-active-bounds fully-degenerate case. Docstring, changelog,
+  and tests updated alongside.
 - Any change to `pounce.minimize`'s pair-list API itself — it was never
-  ambiguous (no scipy tuple form there).
+  ambiguous (no scipy tuple form there). Still out of scope.

--- a/dev-notes/issue-265-plan.md
+++ b/dev-notes/issue-265-plan.md
@@ -1,0 +1,354 @@
+# Issue #265 — implementation plan
+
+Fix for [#265](https://github.com/jkitchin/pounce/issues/265): PR #263
+silently transposes a 2-parameter tuple pair-list box (the mirror image of
+the #260 failure it fixed), and NaN bounds pass validation everywhere.
+
+This plan was prepared against `5acbb10` (current `main`). Every behavior
+claim below was re-verified empirically at that commit (§2), not taken from
+the issue text.
+
+## 1. History — why this is round three
+
+| Round | What happened |
+|---|---|
+| #260 | `bounds=([0,1.6],[10,10])` (scipy's `(lower, upper)`) at n=2 was misread as a per-parameter pair list. Box silently transposed, `Solve_Succeeded`, wrong fit. |
+| PR #263 | Dropped the `_is_pair_list` guard: a length-2 **tuple** is now *always* scipy's `(lower, upper)`. A pair list must be a **list**. Fixed #260's direction. |
+| #265 | The same collision now fails in the mirror direction: at n=2, a pair list written as a **tuple** — `((0,10),(0,10))` or `((None,10.0),(0.0,None))` — is silently transposed. Bonus: the `None` form produces NaN bounds that pass the NaN-blind `lb > ub` check. |
+
+The lesson from two adversary rounds: at n=2 the tuple-of-two-pairs shape is
+**genuinely ambiguous**, and any silent resolution loses one direction. The
+only fix that cannot be silently wrong is to make the ambiguous shape an
+error, while keeping an unambiguous spelling for each reading.
+
+## 2. Confirmed behavior at `5acbb10`
+
+Reproduced without the compiled extension (stub-import recipe in §8.1):
+
+```
+_normalize_bound_arg(((0.0,10.0),(0.0,10.0)), 2)   -> [(0.0, 0.0), (10.0, 10.0)]   # transposed: both params pinned
+_normalize_bound_arg(((None,10.0),(0.0,None)), 2)  -> [(nan, 0.0), (10.0, nan)]    # transposed + NaN
+_normalize_bound_arg([(0.0,10.0),(0.0,10.0)], 2)   -> unchanged                    # list form correct
+_normalize_bound_arg(([0.0,1.6],[10.0,10.0]), 2)   -> [(0.0,10.0), (1.6,10.0)]     # scipy form correct
+_normalize_bound_arg(((0,10),(0,10),(0,10)), 3)    -> unchanged                    # n!=2 tuple pair list correct
+_normalize_bound_arg((None,10.0), 1)               -> [(nan, 10.0)]                # NaN lower at n=1 (!)
+_normalize_bounds([(float('nan'),10.0)], 1)        -> (array([nan]), array([10.])) # NaN passes validation
+_minima_bounds(((None,10.0),(0.0,None)), 2)        -> [(None, 0.0), (10.0, None)]  # transposed for find_minima
+```
+
+Two defects, independently fixable, and **both are required** (either alone
+leaves a hole — see the issue's first comment):
+
+- **(A)** `_normalize_bound_arg` (`python/pounce/_curve_fit.py:1460`) silently
+  resolves the ambiguous n=2 tuple shape.
+- **(B)** `_normalize_bounds` (`python/pounce/_minimize.py:339`) accepts NaN
+  bounds: `lb > ub` is False against NaN, so a malformed box sails through.
+  Reachable directly: `pounce.minimize(..., bounds=[(float('nan'), 10.0)])`
+  succeeds today.
+
+Plus one **interaction discovered while preparing this plan**: at n=1,
+`bounds=(None, 10.0)` goes down the scipy branch and `_to_array(None)` → NaN,
+which today *silently behaves as unbounded-below* (accidentally the right
+semantics). A naive fix (B) would turn that working call into a NaN error.
+Fix (A) must therefore handle side-level `None` explicitly (§3.2) **before**
+(B) lands, or in the same change.
+
+## 3. Design — the disambiguation rule
+
+Keep #263's convention (length-2 tuple = scipy `(lower, upper)`; pair list =
+list). Layer three changes on top, all inside the scipy-tuple branch of
+`_normalize_bound_arg` except (B):
+
+### 3.1 (A) Raise on the genuinely ambiguous shape
+
+At `n == 2`, inside the `isinstance(bounds, tuple) and len(bounds) == 2`
+branch, **before** array conversion, raise `ValueError` if either element is
+"pair-shaped":
+
+```python
+def _pair_shaped(el):
+    # An element that reads as a pair-list entry rather than a scipy
+    # lower/upper array: a length-2 tuple, or a sequence containing None
+    # (scipy arrays cannot contain None; pair entries can).
+    if isinstance(el, tuple) and len(el) == 2:
+        return True
+    if isinstance(el, (list, tuple)) and any(e is None for e in el):
+        return True
+    return False
+
+if n == 2 and (_pair_shaped(lo) or _pair_shaped(hi)):
+    raise ValueError(...)
+```
+
+The error message must name both readings and both disambiguating
+spellings (adapt the issue's suggested wording):
+
+```
+bounds=((0.0, 10.0), (0.0, 10.0)) is ambiguous for a 2-parameter model: it
+reads either as scipy's (lower, upper) — param 0 in [0.0, 0.0], param 1 in
+[10.0, 10.0] — or as a per-parameter pair list — param 0 in [0.0, 10.0],
+param 1 in [0.0, 10.0]. Pass a list [(l0, u0), (l1, u1)] for the pair-list
+reading, or lists/arrays ([l0, l1], [u0, u1]) for the scipy reading.
+```
+
+(If an element contains `None`, computing the per-reading boxes for the
+message may not be possible — fall back to the static two-spellings sentence.
+Tests should match on a stable substring, e.g. `"ambiguous for a
+2-parameter model"`.)
+
+**Why inner *tuples* raise but inner *lists/arrays* stay scipy.** This is the
+crux, so it is worth being explicit:
+
+- `([0.0, 1.6], [10.0, 10.0])` — tuple of lists/arrays — is scipy's canonical
+  spelling, exactly what #260's reporter passed and what #263's regression
+  tests pin (`test_curve_fit.py:519/:551/:582` all use list elements; the
+  issue's follow-up comment confirms they are expected to stay green). Raising
+  on it would re-break scipy drop-in compatibility at n=2, i.e. undo #263.
+- `((0.0, 10.0), (0.0, 10.0))` — tuple of tuples — is the pair-list spelling
+  pounce itself used pre-#263 and the shape both adversary rounds abused.
+  Nobody writes scipy bounds as a tuple of tuples of scalars *at exactly
+  n=2* with colliding intent that we could safely guess.
+- Elements containing `None` can never be a valid scipy array (scipy uses
+  ±inf), so `((None, 10.0), (0.0, None))` and `([None, 10.0], [0.0, None])`
+  both raise — the former via the tuple rule, the latter via the None rule.
+  This kills the NaN-injection path at its source, with a message far better
+  than a downstream NaN error.
+
+The residual asymmetry — a user who writes a pair list as a tuple of *lists*
+`([0, 10], [0, 10])` at n=2 still gets the scipy reading silently — is
+irreducible: that spelling is byte-for-byte scipy's documented form, and the
+docstring (since #263) says pair lists are lists. Document it; don't guess.
+
+**Scope guard:** the raise applies only at `n == 2`. At n=1 and n≥3 a
+length-2 tuple of length-2 sequences already fails the existing
+length-vs-n check ("bounds lower has length 2 but the problem has N
+parameter(s)"), and a length-n tuple pair list (`((0,10),(0,10),(0,10))` at
+n=3) never enters the scipy branch (len ≠ 2) — verified correct today; pin
+with tests.
+
+### 3.2 Side-level `None` maps to ∓inf in the scipy branch
+
+Still inside the scipy branch, before `_to_array`:
+
+```python
+if lo is None: lo = -np.inf
+if hi is None: hi = np.inf
+```
+
+Rationale: preserves today's (accidental) n=1 `(None, 10.0)` = unbounded-below
+behavior once NaN rejection (B) lands; `None` = "no bound" is pounce's
+convention everywhere else; and at any n the pair-list reading of a bare
+`(None, x)` tuple is invalid, so this is unambiguous. Note `_pair_shaped`
+deliberately does *not* treat bare `None` as pair-shaped — `(None, None)`
+and `(None, 10.0)` take the scipy reading, where both readings' semantics
+coincide anyway.
+
+After conversion, reject NaN inside scipy arrays with a targeted message
+(catches `([None, 0], [10, 10])` at n≠2, and literal NaN at any n):
+
+```python
+for side, arr in (("lower", lo_a), ("upper", hi_a)):
+    if np.isnan(arr).any():
+        raise ValueError(
+            f"bounds {side} contains NaN (or None inside an array); "
+            f"use -inf/inf for an unbounded side, or pass a per-parameter "
+            f"list of (lo, hi) pairs"
+        )
+```
+
+### 3.3 (B) `_normalize_bounds` rejects NaN
+
+In `python/pounce/_minimize.py:339`, immediately before the reversed-bound
+check (both the `Bounds` path and the legacy pair path flow through there):
+
+```python
+for side, arr in (("lower", lb), ("upper", ub)):
+    bad = np.where(np.isnan(arr))[0]
+    if bad.size:
+        i = int(bad[0])
+        raise ValueError(
+            f"bounds[{i}] has a NaN {side} bound; use -inf/inf "
+            f"(or None in the pair-list form) for an unbounded side"
+        )
+```
+
+Must be `np.isnan`, **not** `~np.isfinite`: ±inf is the one-sided encoding
+this very function produces (`:356-357`) and must stay legal.
+
+This is a deliberate behavior change: NaN was previously a silent
+"no bound" sentinel on this path. In-repo grep shows nobody relies on it;
+changelog entry required (§6).
+
+### 3.4 (B′) `_minima_bounds` must not launder NaN into `None`
+
+`_curve_fit.py:872` maps non-finite → `None` via `np.isfinite`, so a NaN pair
+entry (`curve_fit_minima(..., bounds=[(float('nan'), 10)])`) silently becomes
+"unbounded" — inconsistent with the minimize path after (B). Add an explicit
+NaN check in the loop (raise, same message shape as 3.3) while keeping
+±inf → `None`. Note `lo`/`hi` may be `None` here — guard before `np.isnan`.
+
+## 4. Files to change
+
+| File | Change |
+|---|---|
+| `python/pounce/_curve_fit.py:1460` `_normalize_bound_arg` | §3.1 raise, §3.2 None→∓inf + NaN check; rewrite docstring (it currently asserts "a length-2 tuple is always read the scipy way" — no longer unconditionally true). |
+| `python/pounce/_curve_fit.py:872` `_minima_bounds` | §3.4 NaN rejection. |
+| `python/pounce/_minimize.py:339` `_normalize_bounds` | §3.3 NaN rejection before the reversed check. |
+| `python/pounce/_curve_fit.py:920-928` `curve_fit` docstring | Document: tuple = scipy form; list = pair list; ambiguous n=2 tuple-of-pairs raises; None sides OK. Mention #265. `curve_fit_minima` / `curve_fit_streaming` docstrings inherit by reference — check they don't restate the old rule. |
+| `docs/src/python.md:297` (`minimize` bounds row) | Note NaN bounds now raise. |
+| `docs/src/curve-fitting.md` | If it shows tuple-form bounds anywhere, align wording; its examples at `:110/:263` already use the list form — likely no change, but check. |
+| `CHANGELOG.md` `## [Unreleased]` | New `### Fixed` entry (§6). |
+| `python/tests/test_curve_fit.py`, `python/tests/test_minimize.py` (or wherever `_normalize_bounds` tests live — check) | §5. |
+
+All three public surfaces (`curve_fit`, `curve_fit_minima`,
+`curve_fit_streaming`) route through `_normalize_bound_arg`
+(`_curve_fit.py:629`, `:876`, `:1212`), so no per-surface parsing changes —
+only tests to prove each inherits the fix.
+
+## 5. Test plan
+
+Existing tests that MUST stay green unchanged (they encode #263's fix and
+all use list elements inside the tuple, which stays the scipy reading):
+
+- `test_curve_fit.py:519` `test_scipy_tuple_bounds_two_params_not_misread_as_pair_list`
+- `test_curve_fit.py:551` `test_scipy_tuple_bounds_match_scipy_across_param_counts`
+- `test_curve_fit.py:582` `test_scipy_tuple_bounds_reversed_looking_box_is_valid`
+
+New tests — unit level, directly on `_normalize_bound_arg` (fast, no solver):
+
+| Input (n) | Expected |
+|---|---|
+| `((0.0,10.0),(0.0,10.0))` (2) | raises, message contains "ambiguous for a 2-parameter model" |
+| `((None,10.0),(0.0,None))` (2) | raises (ambiguous) |
+| `([None,10.0],[0.0,None])` (2) | raises (None inside array → the §3.2 message or ambiguity message; pick one and assert it) |
+| `((0.0,10.0), None)` (2) | raises (element 0 pair-shaped) |
+| `[(0.0,10.0),(0.0,10.0)]` (2) | pair list, unchanged |
+| `[(None,10.0),(0.0,None)]` (2) | pair list, unchanged |
+| `([0.0,1.6],[10.0,10.0])` (2) | scipy: `[(0.0,10.0),(1.6,10.0)]` |
+| `(np.array([0.0,1.6]), np.array([10.0,10.0]))` (2) | scipy, same as above |
+| `(0, 10)` (1, 2, 3) | scipy scalar broadcast |
+| `(None, 10.0)` (1) | `[(-inf, 10.0)]` — the §3.2 regression guard |
+| `(None, 10.0)` (2) | scipy: both params `(-inf, 10.0)` |
+| `((0,10),(0,10),(0,10))` (3) | pair list, unchanged (n≠2 pin) |
+| `((0,10),)` (1) | pair list, unchanged (len≠2 tuple) |
+| `([0,0,0],[10,10,10])` (3) | scipy, unchanged |
+| `(nan, 10.0)` (2) | raises (NaN in scipy branch) |
+
+New tests — end-to-end, one per public surface, on the issue's model
+(`f(x; A, k) = A·exp(-k·x)`, noiseless data at A=2, k=1, deterministic):
+
+- `curve_fit` with `bounds=((0.0,10.0),(0.0,10.0))` → `pytest.raises(ValueError, match="ambiguous")`.
+- `curve_fit` with `bounds=[(None,10.0),(0.0,None)]` (list spelling) →
+  `popt ≈ (2.0, 1.0)`; cross-check against
+  `scipy.optimize.curve_fit(..., bounds=([-np.inf,0.0],[10.0,np.inf]))`.
+- `curve_fit_minima` with the ambiguous tuple → raises (covers `_minima_bounds`);
+  with the list spelling → best minimum ≈ (2, 1) and `perr` not identically 0.
+- `curve_fit_streaming` with the ambiguous tuple → raises; with
+  `bounds=([0.0,0.0],[10.0,10.0])` → ≈ (2, 1).
+
+New tests — `_normalize_bounds` (B):
+
+- `[(float('nan'), 10.0)]` → raises "NaN".
+- `scipy.optimize.Bounds(np.nan, 10.0)` → raises.
+- `[(-np.inf, np.inf)]` and `[(None, None)]` → still pass, lb/ub = ∓inf.
+- End-to-end: `pounce.minimize(lambda v: (v[0]-3.0)**2, x0=[0.0],
+  bounds=[(float('nan'), 10.0)])` → raises (today it returns success).
+- `curve_fit_minima(..., bounds=[(float('nan'), 10.0), (0.0, 10.0)])` → raises (§3.4).
+
+## 6. Changelog entry (sketch)
+
+Under `## [Unreleased]`, `### Fixed`:
+
+- `curve_fit`/`curve_fit_minima`/`curve_fit_streaming`: at n=2, a length-2
+  **tuple** of `(lo, hi)` pairs (e.g. `((0,10),(0,10))`) was silently read as
+  scipy's `(lower, upper)` — the transposed box pinned both parameters and
+  still reported `Solve_Succeeded` (#265, the mirror of #260). The ambiguous
+  shape now raises with both unambiguous spellings; list-of-pairs and
+  tuple-of-arrays forms are unchanged.
+- NaN bounds are now rejected in `minimize` and all `curve_fit` surfaces
+  (previously they silently passed the reversed-bound check and behaved as
+  "no bound"). `None`/±inf remain the supported unbounded spellings.
+
+## 7. Implementation order
+
+1. §3.2 (None→∓inf + scipy-branch NaN check) and §3.1 (ambiguity raise) in
+   `_normalize_bound_arg`, together — one commit.
+2. §3.3 + §3.4 NaN rejection — second commit (independent; keep separable
+   for review).
+3. Tests + docs + changelog alongside each.
+
+## 8. Verification protocol
+
+### 8.1 Fast loop, no Rust build
+
+The normalization layer is pure Python. Verify the full §5 unit matrix
+without building `pounce._pounce` (numpy + scipy required):
+
+```python
+# run from python/
+import sys, types, importlib.util
+pkg = types.ModuleType('pounce'); pkg.__path__ = ['pounce']; sys.modules['pounce'] = pkg
+stub = types.ModuleType('pounce._pounce')
+for name in ('Solver', 'Problem'):
+    setattr(stub, name, type(name, (), {}))
+sys.modules['pounce._pounce'] = stub
+def load(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    mod = importlib.util.module_from_spec(spec); sys.modules[name] = mod
+    spec.loader.exec_module(mod); return mod
+m  = load('pounce._minimize',  'pounce/_minimize.py')
+cf = load('pounce._curve_fit', 'pounce/_curve_fit.py')
+# ... assert the §5 unit matrix against cf._normalize_bound_arg / m._normalize_bounds
+```
+
+(This recipe was used to produce §2; it works at `5acbb10`. If the stub
+list drifts, add whatever names the import error asks for.)
+
+### 8.2 Full suite
+
+```bash
+cd python && maturin develop --release   # or: pip install -e . in a venv
+python -m pytest tests/test_curve_fit.py tests/test_minimize.py -q
+python -m pytest tests -q                # full suite, mirrors CI's python-test job
+```
+
+Expected: currently 41 tests in `test_curve_fit.py` (49 asserted in the
+issue includes parametrized expansion) — all green plus the new ones. CI
+(`ci.yml` `python-test`) runs `pytest python/tests -q` on the built wheel.
+
+### 8.3 Issue reproduction
+
+The issue's `adversary/runs/...` scripts are NOT in this repo — don't look
+for them. Re-derive the check from the issue table:
+
+```python
+import numpy as np, pounce, scipy.optimize as sopt
+x = np.linspace(0, 3, 60); y = 2.0 * np.exp(-1.0 * x)
+model = lambda t, A, k: A * np.exp(-k * t)
+# rows 1 & 3 of the issue table must now raise ValueError("...ambiguous..."):
+#   bounds=((0.0,10.0),(0.0,10.0))   and   bounds=((None,10.0),(0.0,None))
+# rows 2 & 4 (list spelling) must return popt ≈ (2.0, 1.0), matching
+#   sopt.curve_fit(model, x, y, p0=[1.0,2.0], bounds=([-np.inf,0.0],[10.0,np.inf]))
+# and the #260 repro must STILL match scipy:
+#   bounds=([0.0,1.6],[10.0,10.0]) -> popt ≈ [2.42445211, 1.6]
+```
+
+Acceptance: all five checks pass, plus
+`pounce.minimize(lambda v: (v[0]-3.0)**2, x0=[0.0], bounds=[(float('nan'),10.0)])`
+raises.
+
+### 8.4 Adversarial self-review before pushing
+
+Re-run the §5 matrix and ask, for each row: "could this input mean something
+else under the other reading, and did we silently pick?" The invariant to
+hold: **every accepted input has exactly one valid reading; every input with
+two valid readings at n=2 raises.**
+
+## 9. Explicitly out of scope (file separately, don't fix here)
+
+- `curve_fit_minima` reporting `pcov = 0`, `perr = [0, 0]` for a degenerate
+  (zero-width) box — "infinite confidence in a wrong answer". Real, but
+  independent of how the box got degenerate; the issue's comment flags it as
+  possibly its own issue. Recommend opening one and linking #265.
+- Any change to `pounce.minimize`'s pair-list API itself — it was never
+  ambiguous (no scipy tuple form there).

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -294,7 +294,7 @@ minimize(fun, x0, args=(), jac=None, hess=None, bounds=None,
 | `args` | ✅ | tuple of extra positional arguments forwarded to `fun` / `jac` |
 | `jac` | ✅ | callable, **or `jac=True`** (then `fun` returns `(value, gradient)`, cached so the gradient is not recomputed); **omitted → central finite differences** (`eps^(1/3)` step) and a one-time `UserWarning`. Provide one (or use `pounce.jax` / `pounce.torch`) for production. |
 | `hess` | ⚠️ | used when there are no constraints **or all constraints are linear** (the constraint curvature is then zero, so the objective Hessian is the Lagrangian Hessian); with nonlinear constraints the solver falls back to L-BFGS (`hessian_approximation=limited-memory`) |
-| `bounds` | ✅ | a sequence of `(lo, hi)` pairs **or a scipy `Bounds` object**; a `None` element or endpoint means ±∞ |
+| `bounds` | ✅ | a sequence of `(lo, hi)` pairs **or a scipy `Bounds` object**; a `None` element or endpoint means ±∞. A `NaN` bound is rejected (previously it slipped past the reversed-bound check and behaved as "no bound"); use ±∞ / `None` for an unbounded side |
 | `constraints` | ✅ | scipy **dict(s)** `{"type": "eq"\|"ineq", "fun": …, "jac": …}` **or scipy `LinearConstraint` object(s)** (dense or sparse `A`); multiple are concatenated; dict `"jac"` optional (finite-diff fallback) |
 | `callback` | ✅ | called each iteration; both scipy signatures supported — `callback(xk)` and `callback(intermediate_result)` |
 | `tol` | ✅ | accepted directly (scipy `gtol` / `ftol` / `xtol` are synonyms) |

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -825,6 +825,46 @@ def _solve_fit(
     tval = _t_ppf(1.0 - alpha / 2.0, max(dof, 1))
     ci = np.column_stack([popt - tval * perr, popt + tval * perr])
 
+    # --- degenerate-covariance warnings --------------------------------
+    # A zero variance in `perr` is a legitimate, intended output here: a
+    # zero-width bound (lo == hi) fixes a parameter, and `_projected_covariance`
+    # zeros variance along every actively-constrained direction. Both are
+    # correct, but a reported perr of 0 reads as "infinite confidence" and was
+    # previously handed back with no signal (see #265). Warn — at the single
+    # shared assembly site so every public surface inherits it — without
+    # changing any number: the pcov / perr / ci above stand.
+    pinned = None
+    if pr.lb is not None and pr.ub is not None:
+        lb_arr = np.asarray(pr.lb, dtype=float)
+        ub_arr = np.asarray(pr.ub, dtype=float)
+        pinned = np.isfinite(lb_arr) & (lb_arr == ub_arr)
+    if pinned is not None and pinned.any():
+        import warnings
+
+        idx = np.nonzero(pinned)[0]
+        if pr.param_names is not None:
+            names = ", ".join(str(pr.param_names[i]) for i in idx)
+        else:
+            names = ", ".join(str(int(i)) for i in idx)
+        warnings.warn(
+            f"pounce.curve_fit: zero-width bound(s) on parameter(s) {names} "
+            f"(lower == upper) pin each of those parameters to a fixed value; "
+            f"the reported perr of 0 for them is the constraint itself, not an "
+            f"estimated uncertainty. Give a parameter a non-degenerate bound "
+            f"(lo < hi) to obtain an uncertainty for it.",
+            stacklevel=2,
+        )
+    elif active_mask is not None and pr.n > 0 and active_mask.all():
+        import warnings
+
+        warnings.warn(
+            f"pounce.curve_fit: all {pr.n} parameter(s) sit on active bounds "
+            f"at the solution, so the covariance is fully degenerate "
+            f"(pcov = 0) and the reported standard errors and confidence "
+            f"intervals are not meaningful.",
+            stacklevel=2,
+        )
+
     # --- sensitivity dpopt/ddata --------------------------------------
     # dpopt/ddata is (n_params x n_data) -- the size of the data -- so it is not
     # offered in streaming mode (see ``curve_fit_streaming``).
@@ -941,6 +981,13 @@ def curve_fit(
     directions), so it now **raises**; pass a list ``[(l0, u0), (l1, u1)]`` for
     the pair-list reading or lists/arrays ``([l0, l1], [u0, u1])`` for the scipy
     reading. NaN bounds are rejected.
+
+    A **zero-width** bound (``lo == hi``) is honored and fixes that parameter to
+    the value: pounce supports it as the "hold a parameter constant" idiom
+    (unlike scipy, which forbids ``lb == ub``). The parameter's reported
+    ``perr`` of ``0`` is then the constraint, not an estimated uncertainty, so a
+    :class:`UserWarning` is emitted naming the pinned parameters; give a
+    parameter a non-degenerate bound to obtain an uncertainty for it.
 
     See also ``pyomo_pounce.covariance`` (in the ``pyomo-pounce`` package),
     the counterpart surface for an estimation model written directly in

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -882,6 +882,16 @@ def _minima_bounds(bounds, n):
             out.append(None)
             continue
         lo, hi = bd
+        # Reject NaN explicitly rather than laundering it into ``None``
+        # (unbounded) via the ``not np.isfinite`` map below — that would be
+        # inconsistent with the minimize path (see ``_normalize_bounds``). ±inf
+        # still maps to ``None``. ``lo``/``hi`` may be ``None``; guard first.
+        for side, v in (("lower", lo), ("upper", hi)):
+            if v is not None and np.isnan(v):
+                raise ValueError(
+                    f"bounds {side} is NaN; use -inf/inf or None for an "
+                    f"unbounded side, not NaN"
+                )
         lo = None if (lo is None or not np.isfinite(lo)) else float(lo)
         hi = None if (hi is None or not np.isfinite(hi)) else float(hi)
         out.append((lo, hi))

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -919,13 +919,18 @@ def curve_fit(
 
     ``bounds`` follows scipy's convention: the ``(lower, upper)`` 2-tuple, where
     each side is a scalar or a length-``n_params`` array. So
-    ``bounds=([l0, l1], [u0, u1])`` bounds param ``i`` to ``[l_i, u_i]`` — a
-    length-2 tuple is *always* read this scipy way, including the 2-parameter
-    case where it could otherwise be mistaken for a list of ``(lo, hi)`` pairs
-    (issue #260). pounce also accepts a per-parameter pair **list**,
-    ``bounds=[(l0, u0), (l1, u1)]`` (as :func:`pounce.minimize` does), which is
-    never reinterpreted as the scipy 2-tuple; entries may be ``None`` for a
-    one-sided bound.
+    ``bounds=([l0, l1], [u0, u1])`` bounds param ``i`` to ``[l_i, u_i]``; a
+    length-2 **tuple** is read this scipy way, and a bare ``None`` on either
+    side means unbounded there. pounce also accepts a per-parameter pair
+    **list**, ``bounds=[(l0, u0), (l1, u1)]`` (as :func:`pounce.minimize` does),
+    which is never reinterpreted as the scipy 2-tuple; entries may be ``None``
+    for a one-sided bound. For a 2-parameter model the two spellings collide
+    when written as a tuple of ``(lo, hi)`` pairs — ``bounds=((0, 10), (0, 10))``
+    is both scipy's ``(lower, upper)`` and a pair list. That shape is genuinely
+    ambiguous (silently guessing it misfit issues #260 and #265, in opposite
+    directions), so it now **raises**; pass a list ``[(l0, u0), (l1, u1)]`` for
+    the pair-list reading or lists/arrays ``([l0, l1], [u0, u1])`` for the scipy
+    reading. NaN bounds are rejected.
 
     See also ``pyomo_pounce.covariance`` (in the ``pyomo-pounce`` package),
     the counterpart surface for an estimation model written directly in
@@ -1465,34 +1470,75 @@ def _normalize_bound_arg(bounds, n):
     scipy's ``curve_fit`` has exactly one ``bounds`` form — the ``(lower,
     upper)`` 2-tuple, each side a scalar or length-``n`` array — and
     :func:`curve_fit` documents that it mirrors scipy, so a length-2 **tuple**
-    is always read as that scipy form. This is load-bearing only for a
-    2-parameter model, where ``([l0, l1], [u0, u1])`` is *also* structurally a
-    list of two ``(lo, hi)`` pairs. That collision is genuinely ambiguous, and
-    resolving it the pair-list way silently applied the wrong box (param 0 in
-    ``[l0, l1]``, param 1 in ``[u0, u1]``) while still reporting
-    ``Solve_Succeeded`` — see issue #260. scipy's convention wins: param ``i``
-    is bounded to ``[l_i, u_i]``.
+    is normally read as that scipy form; a **list** ``[(l0, u0), (l1, u1)]`` is
+    pounce's per-parameter pair list (never reinterpreted as the scipy tuple).
 
-    To pass pounce's per-parameter pair list — its extension over scipy — use a
-    **list**, ``[(l0, u0), (l1, u1)]`` (as :func:`pounce.minimize` does). A list
-    is never reinterpreted as the scipy 2-tuple form, so the two APIs stay
-    distinct even for ``n == 2``.
+    At ``n == 2`` a length-2 tuple whose elements are themselves ``(lo, hi)``
+    *pairs* is genuinely ambiguous — ``([l0, l1], [u0, u1])`` (scipy) and
+    ``[(l0, u0), (l1, u1)]`` written as a tuple are the same shape. Resolving it
+    silently applied the wrong box in one direction each time (the pair-list
+    reading broke issue #260; the scipy reading broke its mirror, issue #265),
+    so that shape now **raises** and the caller must pick an unambiguous
+    spelling. Only *pair-shaped* elements trigger the raise: a length-2 tuple,
+    or a list/tuple containing ``None`` (a scipy array uses ±inf for an
+    unbounded side, never ``None``). Inner **lists/arrays** of scalars stay the
+    scipy reading — ``([l0, l1], [u0, u1])`` is scipy's canonical spelling and
+    must remain a drop-in (issue #260's regression tests pin it).
+
+    A bare ``None`` on either side (``(None, 10.0)``, ``(None, None)``) is *not*
+    pair-shaped and takes the scipy reading with ``None`` → ∓inf (unbounded on
+    that side); both readings coincide there anyway.
     """
     if bounds is None:
         return None
-    # scipy form: a 2-tuple of (lower, upper), each scalar or length-n array. A
-    # length-2 tuple can only double as a pair list when n == 2 (a pair list
-    # needs one pair per parameter); we deliberately resolve that lone ambiguous
-    # case to the scipy convention curve_fit mirrors, rather than the pair-list
-    # reading, so the returned box matches scipy's (issue #260).
+    # scipy form: a 2-tuple of (lower, upper), each scalar or length-n array.
     if isinstance(bounds, tuple) and len(bounds) == 2:
         lo, hi = bounds
+
+        def _pair_shaped(el):
+            # An element that reads as a pair-list entry rather than a scipy
+            # lower/upper array: a length-2 tuple, or a sequence containing
+            # None (scipy arrays cannot contain None; pair entries can).
+            if isinstance(el, tuple) and len(el) == 2:
+                return True
+            if isinstance(el, (list, tuple)) and any(e is None for e in el):
+                return True
+            return False
+
+        # The one shape no silent resolution can get right (issue #265).
+        if n == 2 and (_pair_shaped(lo) or _pair_shaped(hi)):
+            raise ValueError(
+                f"bounds={bounds!r} is ambiguous for a 2-parameter model: it "
+                f"reads either as scipy's (lower, upper) — param 0 in "
+                f"(lo[0], hi[0]), param 1 in (lo[1], hi[1]) — or as a "
+                f"per-parameter pair list — param 0 in the first pair, param 1 "
+                f"in the second. Pass a list [(l0, u0), (l1, u1)] for the "
+                f"pair-list reading, or lists/arrays ([l0, l1], [u0, u1]) for "
+                f"the scipy reading."
+            )
+
+        # A bare None side means "no bound" -> scipy's ±inf. Do this before array
+        # conversion so it never becomes NaN (preserves the n==1 (None, 10.0) =
+        # unbounded-below call, and matches pounce's None convention elsewhere).
+        if lo is None:
+            lo = -np.inf
+        if hi is None:
+            hi = np.inf
+
         lo_a, hi_a = _to_array(lo), _to_array(hi)
         for side, arr in (("lower", lo_a), ("upper", hi_a)):
             if arr.ndim > 1 or (arr.ndim == 1 and arr.size not in (1, n)):
                 raise ValueError(
                     f"bounds {side} has length {arr.size} but the problem has "
                     f"{n} parameter(s); pass a scalar or a length-{n} array"
+                )
+            # None inside an array becomes NaN under float conversion; a literal
+            # NaN is equally malformed. Reject both with a targeted message.
+            if np.isnan(arr).any():
+                raise ValueError(
+                    f"bounds {side} contains NaN (or None inside an array); "
+                    f"use -inf/inf for an unbounded side, or pass a "
+                    f"per-parameter list of (lo, hi) pairs"
                 )
         lo = np.broadcast_to(lo_a, (n,))
         hi = np.broadcast_to(hi_a, (n,))

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -363,8 +363,19 @@ def _normalize_bounds(bounds, n: int):
                 lb[i] = lo
             if hi is not None:
                 ub[i] = hi
-    # Both paths share the reversed-bound check (the ``Bounds`` path silently
-    # produced an infeasible box before).
+    # Both paths share NaN rejection and the reversed-bound check (the
+    # ``Bounds`` path silently produced an infeasible box before). NaN must be
+    # rejected first: ``lb > ub`` is False against NaN, so a malformed box would
+    # sail through. Use ``np.isnan`` (not ``~np.isfinite``) so ±inf — the
+    # one-sided encoding produced above — stays legal.
+    for side, arr in (("lower", lb), ("upper", ub)):
+        bad = np.where(np.isnan(arr))[0]
+        if bad.size:
+            i = int(bad[0])
+            raise ValueError(
+                f"bounds[{i}] has a NaN {side} bound; use -inf/inf "
+                f"(or None in the pair-list form) for an unbounded side"
+            )
     bad = np.where(lb > ub)[0]
     if bad.size:
         i = int(bad[0])

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 import pounce
+from pounce._curve_fit import _normalize_bound_arg
 
 scipy_optimize = pytest.importorskip("scipy.optimize")
 jnp = pytest.importorskip("jax.numpy")
@@ -589,6 +590,127 @@ def test_scipy_tuple_bounds_reversed_looking_box_is_valid():
                          bounds=([0.5, 0.1], [0.6, 0.2]), jac="fd")
     assert 0.5 <= r.popt[0] <= 0.6 + 1e-9
     assert 0.1 <= r.popt[1] <= 0.2 + 1e-9
+
+
+# --------------------------------------------------------------------------
+# issue #265: the mirror of #260 -- an n=2 tuple *of pairs* is ambiguous and
+# must raise rather than silently transpose; NaN bounds are rejected.
+# --------------------------------------------------------------------------
+
+def test_normalize_bound_arg_unit_matrix():
+    """Pin the disambiguation table directly on the bounds normaliser (#265):
+    the ambiguous n=2 tuple-of-pairs raises, every unambiguous spelling maps to
+    exactly one reading, and the n!=2 / scalar / None-side cases are unchanged.
+    """
+    inf = np.inf
+
+    # ambiguous n=2 shapes -> raise (tuple-of-pairs, and None inside either side)
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg(((0.0, 10.0), (0.0, 10.0)), 2)
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg(((None, 10.0), (0.0, None)), 2)
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg(([None, 10.0], [0.0, None]), 2)   # None inside a list
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg(((0.0, 10.0), None), 2)           # element 0 pair-shaped
+
+    # literal NaN in the scipy branch -> raise
+    with pytest.raises(ValueError, match="NaN"):
+        _normalize_bound_arg((float("nan"), 10.0), 2)
+
+    # pair *lists* pass through untouched (the unambiguous pair-list spelling)
+    assert _normalize_bound_arg([(0.0, 10.0), (0.0, 10.0)], 2) == [(0.0, 10.0), (0.0, 10.0)]
+    assert _normalize_bound_arg([(None, 10.0), (0.0, None)], 2) == [(None, 10.0), (0.0, None)]
+
+    # scipy tuple of lists/arrays -> per-parameter pairs (param i in [l_i, u_i])
+    assert _normalize_bound_arg(([0.0, 1.6], [10.0, 10.0]), 2) == [(0.0, 10.0), (1.6, 10.0)]
+    assert _normalize_bound_arg(
+        (np.array([0.0, 1.6]), np.array([10.0, 10.0])), 2
+    ) == [(0.0, 10.0), (1.6, 10.0)]
+    assert _normalize_bound_arg(([0, 0, 0], [10, 10, 10]), 3) == [
+        (0.0, 10.0), (0.0, 10.0), (0.0, 10.0)]
+
+    # scalar scipy form broadcasts at every n
+    assert _normalize_bound_arg((0, 10), 1) == [(0.0, 10.0)]
+    assert _normalize_bound_arg((0, 10), 2) == [(0.0, 10.0), (0.0, 10.0)]
+    assert _normalize_bound_arg((0, 10), 3) == [(0.0, 10.0)] * 3
+
+    # a bare None side takes the scipy reading, None -> ∓inf (no raise). The n=1
+    # case is the regression guard for §3.2 (was NaN-as-unbounded-below before).
+    assert _normalize_bound_arg((None, 10.0), 1) == [(-inf, 10.0)]
+    assert _normalize_bound_arg((None, 10.0), 2) == [(-inf, 10.0), (-inf, 10.0)]
+    assert _normalize_bound_arg((None, None), 2) == [(-inf, inf), (-inf, inf)]
+
+    # n != 2 tuple pair list never enters the scipy branch (len != 2) -> unchanged
+    assert _normalize_bound_arg(((0, 10), (0, 10), (0, 10)), 3) == ((0, 10), (0, 10), (0, 10))
+    assert _normalize_bound_arg(((0, 10),), 1) == ((0, 10),)
+
+    # None passes through as None
+    assert _normalize_bound_arg(None, 2) is None
+
+
+def test_curve_fit_ambiguous_tuple_bounds_raise():
+    """#265: the n=2 tuple-of-pairs box now raises on the single-fit surface
+    instead of silently transposing to a pinned box that still 'succeeds'."""
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x)  # noiseless: A=2, k=1
+    with pytest.raises(ValueError, match="ambiguous"):
+        pounce.curve_fit(expdecay_2p, x, y, p0=[1.0, 2.0],
+                         bounds=((0.0, 10.0), (0.0, 10.0)), jac="fd")
+    with pytest.raises(ValueError, match="ambiguous"):
+        pounce.curve_fit(expdecay_2p, x, y, p0=[1.0, 2.0],
+                         bounds=((None, 10.0), (0.0, None)), jac="fd")
+
+
+def test_curve_fit_list_spelling_fits_and_matches_scipy():
+    """The unambiguous pair-*list* spelling of the same box fits correctly and
+    agrees with scipy's equivalent (lower, upper) call."""
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x)
+    r = pounce.curve_fit(expdecay_2p, x, y, p0=[1.0, 2.0],
+                         bounds=[(None, 10.0), (0.0, None)], jac="fd")
+    np.testing.assert_allclose(r.popt, [2.0, 1.0], rtol=1e-4)
+    rs, _ = scipy_optimize.curve_fit(
+        expdecay_2p, x, y, p0=[1.0, 2.0],
+        bounds=([-np.inf, 0.0], [10.0, np.inf]))
+    np.testing.assert_allclose(r.popt, rs, rtol=1e-4)
+
+
+def test_curve_fit_minima_ambiguous_tuple_raises_and_list_fits():
+    """``curve_fit_minima`` inherits the raise (covers ``_minima_bounds``); the
+    finite pair-*list* box enumerates the correct minimum near (2, 1)."""
+    rng = np.random.default_rng(0)
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x) + 0.01 * rng.standard_normal(x.size)
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        pounce.curve_fit_minima(expdecay_2p, x, y, p0=[1.0, 2.0],
+                                bounds=((0.0, 10.0), (0.0, 10.0)),
+                                jac="fd", seed=0)
+
+    fits = pounce.curve_fit_minima(expdecay_2p, x, y, p0=[1.0, 2.0],
+                                   bounds=[(0.0, 10.0), (0.0, 10.0)],
+                                   jac="fd", seed=0)
+    assert fits, "expected at least one minimum"
+    np.testing.assert_allclose(fits[0].popt, [2.0, 1.0], rtol=5e-2)
+    # not the degenerate zero-width-box state: a real box gives a real perr
+    assert np.all(np.isfinite(fits[0].perr))
+    assert np.any(fits[0].perr > 0)
+
+
+def test_curve_fit_streaming_ambiguous_tuple_raises_and_scipy_box_fits():
+    """``curve_fit_streaming`` inherits the raise; the scipy tuple-of-arrays box
+    still fits to (2, 1)."""
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x)
+    with pytest.raises(ValueError, match="ambiguous"):
+        pounce.curve_fit_streaming(expdecay_2p, _batched_source(x, y),
+                                   p0=[1.0, 2.0],
+                                   bounds=((0.0, 10.0), (0.0, 10.0)), jac="fd")
+    r = pounce.curve_fit_streaming(expdecay_2p, _batched_source(x, y),
+                                   p0=[1.0, 2.0],
+                                   bounds=([0.0, 0.0], [10.0, 10.0]), jac="fd")
+    np.testing.assert_allclose(r.popt, [2.0, 1.0], rtol=1e-4)
 
 
 def test_curve_fit_validates_data_sigma_fscale_p0():

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -698,6 +698,17 @@ def test_curve_fit_minima_ambiguous_tuple_raises_and_list_fits():
     assert np.any(fits[0].perr > 0)
 
 
+def test_curve_fit_minima_rejects_nan_pair_bound():
+    """A NaN inside a pair-list entry is rejected (not laundered to 'unbounded'),
+    consistent with the minimize path (§3.4)."""
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x)
+    with pytest.raises(ValueError, match="NaN"):
+        pounce.curve_fit_minima(expdecay_2p, x, y, p0=[1.0, 2.0],
+                                bounds=[(float("nan"), 10.0), (0.0, 10.0)],
+                                jac="fd", seed=0)
+
+
 def test_curve_fit_streaming_ambiguous_tuple_raises_and_scipy_box_fits():
     """``curve_fit_streaming`` inherits the raise; the scipy tuple-of-arrays box
     still fits to (2, 1)."""

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -7,6 +7,8 @@ object's UX. Models are written with ``jax.numpy`` where the exact-derivative
 (reduced-Hessian) path is being exercised.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -1068,3 +1070,72 @@ def test_curve_fit_constraint_probed_at_p0_not_origin():
         [{"type": "ineq", "fun": s_con}], "sse", 1.0, "fd", None,
     )
     np.testing.assert_allclose(s_probes[0], p0)  # streaming builder too
+
+
+# --------------------------------------------------------------------------
+# Degenerate-covariance warnings (#265): a zero-width bound or an all-active
+# corner reports perr = 0 legitimately, but that must no longer be silent.
+# --------------------------------------------------------------------------
+
+def test_zero_width_bounds_warn_and_are_not_an_estimate():
+    """A zero-width bound (lo == hi) pins a parameter; its perr of 0 is the
+    constraint, and pounce warns while the free parameter keeps a real perr."""
+    rng = np.random.default_rng(0)
+    x = np.linspace(0.0, 3.0, 60)
+    y = expdecay_2p(x, 2.0, 1.0) + 0.01 * rng.standard_normal(x.size)
+
+    with pytest.warns(UserWarning, match="zero-width"):
+        r = pounce.curve_fit(expdecay_2p, x, y, p0=[2.0, 1.0],
+                             bounds=[(2.0, 2.0), (0.0, 10.0)], jac="fd")
+
+    np.testing.assert_allclose(r.popt[0], 2.0, atol=1e-9)  # pinned exactly
+    assert r.perr[0] == 0.0                                 # constraint, not estimate
+    assert r.perr[1] > 0.0                                  # free param has real uncertainty
+
+
+def test_all_params_on_active_bounds_warn_fully_degenerate():
+    """A box that excludes the optimum pins every parameter on a bound; the
+    covariance is then fully degenerate (pcov = 0) and pounce warns."""
+    x = np.linspace(-1.0, 1.0, 41)  # sum(x) == 0 => SSE separable in a and b
+    y = x.copy()                    # unconstrained optimum a=1, b=0
+    # Box excludes the optimum; separability pins the corner (a=2, b=1).
+    with pytest.warns(UserWarning, match="fully degenerate"):
+        r = pounce.curve_fit(line, x, y, p0=[2.5, 1.5],
+                             bounds=[(2.0, 3.0), (1.0, 2.0)], jac="fd")
+
+    assert r.active_mask is not None and r.active_mask.all()
+    np.testing.assert_array_equal(r.pcov, np.zeros_like(r.pcov))
+    np.testing.assert_array_equal(r.perr, np.zeros_like(r.perr))
+
+
+def test_ordinary_bounded_fit_does_not_warn_degenerate():
+    """A normal fit with wide bounds and an interior optimum emits neither of
+    the degenerate-covariance warnings."""
+    rng = np.random.default_rng(0)
+    x = np.linspace(0.0, 3.0, 60)
+    y = expdecay_2p(x, 2.0, 1.0) + 0.02 * rng.standard_normal(x.size)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        pounce.curve_fit(expdecay_2p, x, y, p0=[2.0, 1.0],
+                         bounds=[(0.0, 10.0), (0.0, 10.0)], jac="fd")
+
+    msgs = [str(w.message) for w in caught]
+    assert not any("zero-width" in m for m in msgs), msgs
+    assert not any("fully degenerate" in m for m in msgs), msgs
+
+
+def test_curve_fit_minima_zero_width_box_warns():
+    """The #265 scenario (minus the transposition): a fully zero-width box via
+    curve_fit_minima still yields perr = 0 everywhere, but no longer silently."""
+    x = np.linspace(0.0, 3.0, 60)
+    y = 2.0 * np.exp(-1.0 * x)
+
+    with pytest.warns(UserWarning, match="zero-width"):
+        fits = pounce.curve_fit_minima(expdecay_2p, x, y, p0=[1.0, 2.0],
+                                       bounds=[(0.0, 0.0), (10.0, 10.0)],
+                                       jac="fd", seed=0)
+
+    assert fits, "expected at least one result"
+    for r in fits:
+        np.testing.assert_array_equal(r.perr, np.zeros_like(r.perr))

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -654,6 +654,42 @@ def test_minimize_rejects_reversed_bounds():
     np.testing.assert_allclose(res.x[0], 0.5, atol=1e-6)
 
 
+def test_normalize_bounds_rejects_nan():
+    """#265: a NaN bound used to sail through the reversed-bound check (``lb >
+    ub`` is False against NaN) and behave as a silent 'no bound'. It now raises,
+    on both the pair-list and ``scipy.optimize.Bounds`` paths. ±inf/None — the
+    real unbounded spellings — must still pass."""
+    from pounce._minimize import _normalize_bounds
+
+    # pair-list path
+    with pytest.raises(ValueError, match="NaN"):
+        _normalize_bounds([(float("nan"), 10.0)], 1)
+    # scipy Bounds path
+    with pytest.raises(ValueError, match="NaN"):
+        _normalize_bounds(opt.Bounds(np.nan, 10.0), 1)
+
+    # ±inf and None stay legal (they are the one-sided encoding this function
+    # itself produces); use np.isnan, never ~np.isfinite.
+    lb, ub = _normalize_bounds([(-np.inf, np.inf)], 1)
+    np.testing.assert_array_equal(lb, [-np.inf])
+    np.testing.assert_array_equal(ub, [np.inf])
+    lb, ub = _normalize_bounds([(None, None)], 1)
+    np.testing.assert_array_equal(lb, [-np.inf])
+    np.testing.assert_array_equal(ub, [np.inf])
+
+
+def test_minimize_rejects_nan_bounds_end_to_end():
+    """A NaN bound reaches the public ``minimize`` API and now raises instead of
+    silently returning a 'successful' solve (#265)."""
+    with pytest.raises(ValueError, match="NaN"):
+        pounce.minimize(
+            lambda v: (v[0] - 3.0) ** 2,
+            x0=[0.0],
+            bounds=[(float("nan"), 10.0)],
+            options={"print_level": 0},
+        )
+
+
 def test_nlp_success_status_includes_acceptable_level():
     """gh #119 regression (mapping). ``success`` for the NLP path must count
     ``Solved_To_Acceptable_Level`` (status 1) as a success, not only


### PR DESCRIPTION
## Problem

Issue #265 reports that at `n=2`, a tuple of `(lo, hi)` pairs like `((0,10),(0,10))` is silently transposed and read as scipy's `(lower, upper)` form, pinning both parameters to single values while still reporting `Solve_Succeeded`. This is the mirror of #260, which was fixed by PR #263 but introduced this regression.

Additionally, NaN bounds pass validation everywhere: `lb > ub` is `False` against NaN, so malformed boxes silently behave as "no bound".

| Case | Before | After |
|---|---|---|
| `bounds=((0,10),(0,10))` at n=2 | silently transposes, wrong fit | raises `ValueError` |
| `bounds=[(0,10),(0,10)]` at n=2 | correct pair-list reading | unchanged |
| `bounds=([0,1.6],[10,10])` at n=2 | correct scipy reading | unchanged |
| `bounds=[(float('nan'),10)]` | silent "no bound" | raises `ValueError` |

## Cause

The root cause is a genuinely ambiguous shape at `n=2`: `([l0, l1], [u0, u1])` is both scipy's canonical `(lower, upper)` form *and* structurally a list of two `(lo, hi)` pairs. PR #263 resolved this by saying "a length-2 tuple is always scipy," but that breaks the tuple-of-tuples pair-list spelling `((0,10),(0,10))` in the opposite direction.

The only fix that cannot be silently wrong is to make the ambiguous shape an error while keeping unambiguous spellings for each reading:
- Pair list: `[(l0, u0), (l1, u1)]` (list, not tuple)
- Scipy form: `([l0, l1], [u0, u1])` (tuple of lists/arrays, not tuples)

NaN bounds slip through because the reversed-bound check `lb > ub` evaluates to `False` when either side is NaN.

## Fix

Three independent changes, all required (either alone leaves a hole):

**(A) Reject the ambiguous n=2 tuple-of-pairs shape** in `_normalize_bound_arg` (§3.1):
- At `n == 2`, inside the scipy tuple branch, raise `ValueError` if either element is "pair-shaped" (a length-2 tuple, or a sequence containing `None`).
- Inner **lists/arrays** of scalars stay the scipy reading — `([l0, l1], [u0, u1])` is scipy's canonical spelling and must remain a drop-in (pins #260's regression tests).
- Error message names both readings and both disambiguating spellings.

**(B) Map bare `None` sides to ∓inf in the scipy branch** (§3.2):
- Before array conversion, `None` → `-np.inf` or `np.inf`.
- Preserves today's accidental `(None, 10.0)` = unbounded-below behavior at n=1 once NaN rejection lands.
- After conversion, reject NaN inside scipy arrays with a targeted message.

**(C) Reject NaN in `_normalize_bounds`** (§3.3):
- Before the reversed-bound check, detect NaN and raise.
- Use `np.isnan`, not `~np.isfinite`, so ±inf (the one-sided encoding this function produces) stays legal.

**(D) Reject NaN in `_minima_bounds`** (§3.4):
- Add explicit NaN check in the loop while keeping ±inf → `None`.

## Blast radius

**Bit-identical except the targeted cases:**
- All existing tests pass unchanged (including #260's regression tests, which use list elements inside the tuple).
- The list-of-pairs spelling `[(l0, u0), (l1, u1)]` is unchanged.
- The scipy tuple-of-arrays spelling `([l0, l1], [u0, u1])`

https://claude.ai/code/session_01HmNgxvsP9JW3hjaHFKT7Ht