### PR TITLE
Fix best-acceptable fallback to rank by feasibility first, not objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,48 @@ changes.
   acceptable iterate, off already-computed quantities, and clones only on an
   improvement.
 
+### Fixed — the best-acceptable fallback no longer trades feasibility for objective (#267)
+
+- **The fallback now ranks by `(feasibility, objective)`, not objective alone.**
+  The #250 fallback above chose among recorded acceptable points by scaled
+  objective. Every candidate is *bounded* by `acceptable_constr_viol_tol`, but
+  being bounded by the band is not the same as not trading feasibility *within*
+  it, and the band is a user option. Widen it and a pure-objective argmax has no
+  lower bound on the feasibility it will spend: it discards a nearly-feasible
+  point for a lower-objective one that is grossly infeasible, then hands it back
+  under a `Solved_To_Acceptable_Level` status.
+- **Symptom it fixes.** On `autocorr_bern55-06` at
+  `dual_diverging_streak=15 acceptable_constr_viol_tol=1e1 acceptable_tol=1e10
+  acceptable_dual_inf_tol=1e30 acceptable_compl_inf_tol=1e10`, the guard-on solve
+  returned objective `-2307.32` at a constraint violation of **9.94** — below the
+  true optimum `-2304.0` precisely because the point is infeasible, and rejected
+  by `pounce verify`. At the same tolerances the guard-*off* control returns a
+  feasible point (`-2298.57`, violation `1.06e-4`), so the loose band alone is not
+  the cause — it only widens what the fallback can exploit. The fix returns a
+  feasible point in the guard-on case too.
+- **How the ranking works.** Each recorded/returned point carries its unscaled
+  max-norm constraint violation — the same quantity the `acceptable_constr_viol_tol`
+  gate is defined against. The key is `(feasible_enough, objective)`: a point
+  inside the feasibility band beats one outside it outright, and objective decides
+  *only among points already inside the band*. `feasible_enough` uses the
+  acceptable feasibility band **capped at its upstream default** (`1e-2`), so it
+  never gets looser than a normal solve's — a grossly-infeasible low-objective
+  iterate is simply not a candidate. At default or tighter tolerances this is
+  behaviour-neutral: every recorded point already passed the
+  `acceptable_constr_viol_tol` gate, so with that band at or below the cap every
+  candidate is feasible-enough and objective alone decides, exactly as before. The
+  cap only bites once the user loosens `acceptable_constr_viol_tol` past its
+  default.
+- **Symptom, resolved.** With the fix the guard-on solve above returns the
+  diverted run's own near-optimal endpoint — objective `-2303.9999` at violation
+  `1.13e-4`, which `pounce verify` accepts — instead of the infeasible `9.94`
+  point a pure-objective ranking restored.
+- **Scope.** Latent and config-gated, not a live default-path bug: the guard is
+  off by default, and the trade needs `acceptable_constr_viol_tol` widened past
+  its default. Every solve the guard never fires on is still bit-identical — the
+  read stays gated on `dual_guard_fired`; only the recording cost grows by one
+  already-computed norm per acceptable iterate.
+
 ### Fixed — false `Infeasible_Problem_Detected` on a feasible, aggressively scaled NLP
 
 - **Rapid infeasibility detection now confirms its own claim before issuing it.**

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -519,6 +519,10 @@ impl ConvCheck for OptErrorConvCheck {
         self.tol
     }
 
+    fn acceptable_constr_viol_tol_or_default(&self) -> Number {
+        self.acceptable_constr_viol_tol
+    }
+
     fn set_tolerance(&mut self, name: &str, value: Number) -> bool {
         match name {
             "tol" => self.tol = value,

--- a/crates/pounce-algorithm/src/conv_check/trait.rs
+++ b/crates/pounce-algorithm/src/conv_check/trait.rs
@@ -121,6 +121,17 @@ pub trait ConvCheck {
         1e-8
     }
 
+    /// Acceptable-level primal-feasibility band `acceptable_constr_viol_tol`, in
+    /// the unscaled max-norm space `curr_unscaled_primal_infeasibility_max`
+    /// reports. Read by the best-acceptable fallback's feasibility-aware ranking
+    /// (gh #267), which caps it at the upstream default so a user-widened band
+    /// cannot let the fallback spend feasibility to buy objective. Default
+    /// `1e-2` matches upstream's default `acceptable_constr_viol_tol`; policies
+    /// that track no such tolerance keep it.
+    fn acceptable_constr_viol_tol_or_default(&self) -> Number {
+        1e-2
+    }
+
     /// Live-update a named convergence tolerance mid-solve, for the
     /// debugger's in-place option hot-swap. Returns `true` if `name`
     /// matched a tolerance this policy owns (so the caller can report

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -879,27 +879,19 @@ impl IpoptAlgorithm {
     /// gh #200 comparisons already rely on, and it keeps a `NaN`-objective
     /// returned point losing to a finite recorded one in
     /// [`Self::honour_best_acceptable_after_dual_guard`].
+    ///
+    /// The ranking itself lives in the pure [`ranks_better_within_band`] so its
+    /// never-worse-off guarantee can be proven by deterministic unit tests rather
+    /// than inferred from a host-dependent end-to-end objective comparison (see
+    /// gh #267, which flagged an earlier CLI test for measuring the wrong,
+    /// host-varying property). This method only resolves the admitted band.
     fn ranks_better(&self, a_obj: Number, a_viol: Number, b_obj: Number, b_viol: Number) -> bool {
-        if !a_obj.is_finite() {
-            return false;
-        }
-        if !b_obj.is_finite() {
-            return true;
-        }
         let band = self
             .bundle
             .conv_check
             .acceptable_constr_viol_tol_or_default()
             .min(Self::FEASIBLE_ENOUGH_CAP);
-        // A non-finite violation is never feasible_enough.
-        let feasible = |v: Number| v.is_finite() && v <= band;
-        let (a_ok, b_ok) = (feasible(a_viol), feasible(b_viol));
-        if a_ok != b_ok {
-            // The feasible_enough point wins outright.
-            return a_ok;
-        }
-        // Same feasibility class: lower objective wins (original behaviour).
-        a_obj < b_obj
+        ranks_better_within_band(a_obj, a_viol, b_obj, b_viol, band)
     }
 
     /// Make the dual-divergence guard's diversion non-destructive (pounce#250
@@ -2789,6 +2781,45 @@ enum IterateOutcome {
     Terminate(SolverReturn),
 }
 
+/// Feasibility-aware ranking core for the best-acceptable fallback (gh #267).
+///
+/// `true` iff candidate `(a_obj, a_viol)` ranks **strictly** better than
+/// `(b_obj, b_viol)` under the `(feasible_enough, objective)` key, where a point
+/// is `feasible_enough` when its unscaled max-norm constraint violation is
+/// within `band`. Lexicographic: a `feasible_enough` point beats one that is not
+/// outright; among points in the same feasibility class, the lower objective
+/// wins. A non-finite objective ranks worst (never wins, always loses to a
+/// finite one); a non-finite violation is never `feasible_enough`.
+///
+/// Pure and total, so the fallback's "never worse off" guarantee is a theorem
+/// this function's unit tests prove by cases — host-independent by construction,
+/// unlike an end-to-end objective comparison across two live nonconvex solves
+/// (the trap gh #267 caught). [`IpoptAlgorithm::ranks_better`] supplies `band`
+/// as `min(acceptable_constr_viol_tol, FEASIBLE_ENOUGH_CAP)`; both the record
+/// and the read side route through here, so they cannot disagree.
+fn ranks_better_within_band(
+    a_obj: Number,
+    a_viol: Number,
+    b_obj: Number,
+    b_viol: Number,
+    band: Number,
+) -> bool {
+    if !a_obj.is_finite() {
+        return false;
+    }
+    if !b_obj.is_finite() {
+        return true;
+    }
+    let feasible = |v: Number| v.is_finite() && v <= band;
+    let (a_ok, b_ok) = (feasible(a_viol), feasible(b_viol));
+    if a_ok != b_ok {
+        // The feasible_enough point wins outright, whatever the objectives.
+        return a_ok;
+    }
+    // Same feasibility class: lower objective wins (the original behaviour).
+    a_obj < b_obj
+}
+
 /// `||a - b||_2 / (1 + ||b||_2)`. Used by the restoration cycle
 /// detector in [`IpoptAlgorithm::invoke_restoration`] to test whether
 /// the outer iterate has moved between two consecutive restoration
@@ -3026,4 +3057,86 @@ mod tests {
     /// IPM driver.
     struct _DummyResto;
     impl RestorationPhase for _DummyResto {}
+
+    // --------------------------------------------------------------
+    // Best-acceptable fallback ranking (gh #267).
+    //
+    // These prove the "never worse off" guarantee host-independently, by
+    // cases, on the pure ranking core — the property the earlier end-to-end
+    // `hair_trigger_*` objective comparison could only *approximate* on one
+    // host's basin luck (gh #267's secondary finding). `band` here stands in
+    // for the resolved `min(acceptable_constr_viol_tol, FEASIBLE_ENOUGH_CAP)`.
+    // --------------------------------------------------------------
+
+    #[test]
+    fn ranks_better_is_a_strict_order_within_a_feasibility_class() {
+        let band = 1e-2;
+        // Both feasible: lower objective wins, strictly.
+        assert!(ranks_better_within_band(-2.0, 1e-4, -1.0, 1e-4, band));
+        assert!(!ranks_better_within_band(-1.0, 1e-4, -2.0, 1e-4, band));
+        // Ties are not "strictly better" in either direction — so an equal
+        // returned point is never displaced, matching the read side's
+        // keep-current-on-tie contract.
+        assert!(!ranks_better_within_band(-1.0, 1e-4, -1.0, 5e-3, band));
+        assert!(!ranks_better_within_band(-1.0, 5e-3, -1.0, 1e-4, band));
+        // Both infeasible: still ranked by objective (no feasible point to
+        // protect), so the fallback never *gains* infeasibility for free here.
+        assert!(ranks_better_within_band(-2.0, 5.0, -1.0, 9.0, band));
+    }
+
+    #[test]
+    fn ranks_better_puts_feasibility_first_regardless_of_objective() {
+        let band = 1e-2;
+        // The gh #267 case in miniature: a feasible point outranks an
+        // arbitrarily-lower-objective infeasible one, and vice-versa.
+        assert!(ranks_better_within_band(0.0, 1e-4, -1e9, 9.94, band));
+        assert!(!ranks_better_within_band(-1e9, 9.94, 0.0, 1e-4, band));
+        // Exactly at the band is still feasible_enough; just past it is not.
+        assert!(ranks_better_within_band(
+            1.0,
+            band,
+            -1.0,
+            band * 1.000_001,
+            band
+        ));
+    }
+
+    #[test]
+    fn ranks_better_never_lets_a_widened_band_matter_past_the_cap() {
+        // The band the method feeds is capped at FEASIBLE_ENOUGH_CAP, so a
+        // point beyond the cap is never feasible_enough however loose the
+        // user's `acceptable_constr_viol_tol`. Model that by passing the capped
+        // band: the near-optimal-but-mildly-infeasible endpoint (viol 1.13e-4,
+        // within the cap) must beat the grossly-infeasible lower-objective
+        // point (viol 9.94, past it) — the exact swap the fix forbids.
+        let band = IpoptAlgorithm::FEASIBLE_ENOUGH_CAP;
+        assert!(ranks_better_within_band(
+            -2303.99, 1.13e-4, -2307.32, 9.94, band
+        ));
+        assert!(!ranks_better_within_band(
+            -2307.32, 9.94, -2303.99, 1.13e-4, band
+        ));
+    }
+
+    #[test]
+    fn ranks_better_ranks_a_nonfinite_objective_worst() {
+        let band = 1e-2;
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            // A non-finite objective never ranks better than a finite one...
+            assert!(!ranks_better_within_band(bad, 0.0, 0.0, 9.9, band));
+            // ...and always loses to one, even on worse feasibility — so a
+            // finite recorded point is restored over a NaN-objective return,
+            // preserving the pre-fix `!(curr <= best)` NaN behaviour.
+            assert!(ranks_better_within_band(0.0, 9.9, bad, 0.0, band));
+        }
+    }
+
+    #[test]
+    fn ranks_better_treats_a_nonfinite_violation_as_infeasible() {
+        let band = 1e-2;
+        // A NaN violation is never feasible_enough, so a genuinely feasible
+        // point outranks it regardless of objective.
+        assert!(ranks_better_within_band(0.0, 0.0, -100.0, f64::NAN, band));
+        assert!(!ranks_better_within_band(-100.0, f64::NAN, 0.0, 0.0, band));
+    }
 }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -737,6 +737,7 @@ impl IpoptAlgorithm {
             obj: cq.curr_f(),
             mu: self.data.borrow().curr_mu,
             unscaled_kkt: cq.curr_unscaled_nlp_error(),
+            constr_viol: cq.curr_unscaled_primal_infeasibility_max(),
             obj_scale: cq.obj_scaling_factor(),
         })
     }
@@ -804,20 +805,30 @@ impl IpoptAlgorithm {
     /// cloned only on an actual improvement, so this does not double the
     /// per-iteration clone `store_acceptable_point` already pays.
     ///
-    /// "Best" is the lower scaled objective among points that already passed
-    /// `current_is_acceptable_with_state`, so feasibility is not being traded
-    /// away for objective: every candidate is bounded by the same
-    /// `acceptable_constr_viol_tol` that gates `store_acceptable_point`. (This
-    /// matters — early `autocorr_bern55-06` iterates sit at objective -1.2e4,
-    /// far below the -2304 optimum, but at a constraint violation of 3.65e3;
-    /// they are not acceptable, so they can never be recorded.)
+    /// "Best" is a feasibility-aware ranking, **not** the lowest objective:
+    /// candidates are ordered by [`Self::ranks_better`]'s `(feasible_enough,
+    /// objective)` key, so objective only decides among points already inside a
+    /// capped feasibility band. Being *bounded* by `acceptable_constr_viol_tol`
+    /// is not the same as *not trading* feasibility within it — that band is a
+    /// user option and can be widened to `1e1` or beyond. A pure-objective argmax
+    /// over it has no lower bound on the feasibility it will spend, and one
+    /// option-value away it returns a point `pounce verify` rejects under a
+    /// `Solved_To_Acceptable_Level` status (gh #267). Whether an early
+    /// low-objective iterate is even a candidate is the user's
+    /// `acceptable_constr_viol_tol`; the capped feasibility key is what keeps a
+    /// grossly-infeasible one from winning even when the band admits it.
     fn record_best_acceptable(&mut self, curr_f: Number) {
         if !curr_f.is_finite() {
             return;
         }
-        // Reject before cloning: only an improvement is worth a snapshot.
+        // Same quantity the acceptable-point gate keys on, so the recorded
+        // feasibility matches the band the candidate just passed.
+        let curr_viol = self.cq.borrow().curr_unscaled_primal_infeasibility_max();
+        // Reject before cloning: only a strictly better candidate — by the
+        // feasibility-aware key, not objective alone — is worth a snapshot.
         if let Some(best) = self.best_acceptable.as_ref() {
-            if !(curr_f < best.obj) {
+            let (b_obj, b_viol) = (best.obj, best.constr_viol);
+            if !self.ranks_better(curr_f, curr_viol, b_obj, b_viol) {
                 return;
             }
         }
@@ -833,6 +844,62 @@ impl IpoptAlgorithm {
             }
         }
         self.best_acceptable = Some(snap);
+    }
+
+    /// Cap on the feasibility band [`Self::ranks_better`] admits, matching the
+    /// upstream default `acceptable_constr_viol_tol`. The fallback treats a point
+    /// as "feasible enough to win on objective" only within this band, *however
+    /// loose the user made `acceptable_constr_viol_tol`*, so widening that option
+    /// cannot let the fallback trade feasibility for objective (gh #267).
+    const FEASIBLE_ENOUGH_CAP: Number = 1e-2;
+
+    /// Whether candidate `(a_obj, a_viol)` ranks strictly better than
+    /// `(b_obj, b_viol)` for the best-acceptable fallback (gh #267).
+    ///
+    /// The key is `(feasible_enough, objective)` compared lexicographically: a
+    /// point within the feasibility band beats one outside it outright, and
+    /// objective decides *only among points already inside the band*. A point is
+    /// `feasible_enough` when its unscaled max-norm constraint violation is
+    /// within `min(acceptable_constr_viol_tol, FEASIBLE_ENOUGH_CAP)` — the
+    /// acceptable feasibility band the solve is using, but never looser than its
+    /// upstream default. The cap is the whole fix: `acceptable_constr_viol_tol`
+    /// is user-widenable, and ranking by objective across a widened band spends
+    /// feasibility to buy objective, handing back a `pounce verify`-rejected
+    /// point under a success status. Capping the admission band bounds that — a
+    /// grossly-infeasible low-objective iterate is simply not a candidate.
+    ///
+    /// At default (or tighter) tolerances this is behaviour-neutral: every
+    /// recorded point already passed the `acceptable_constr_viol_tol` gate, so
+    /// with that band at or below the cap every candidate is `feasible_enough`
+    /// and objective alone decides, exactly as before. The band only bites once
+    /// the user loosens `acceptable_constr_viol_tol` past its default.
+    ///
+    /// A non-finite objective ranks worst and can never win — feasibility never
+    /// rescues a `NaN`/`Inf` `f`. This mirrors the `NaN`-loses convention the
+    /// gh #200 comparisons already rely on, and it keeps a `NaN`-objective
+    /// returned point losing to a finite recorded one in
+    /// [`Self::honour_best_acceptable_after_dual_guard`].
+    fn ranks_better(&self, a_obj: Number, a_viol: Number, b_obj: Number, b_viol: Number) -> bool {
+        if !a_obj.is_finite() {
+            return false;
+        }
+        if !b_obj.is_finite() {
+            return true;
+        }
+        let band = self
+            .bundle
+            .conv_check
+            .acceptable_constr_viol_tol_or_default()
+            .min(Self::FEASIBLE_ENOUGH_CAP);
+        // A non-finite violation is never feasible_enough.
+        let feasible = |v: Number| v.is_finite() && v <= band;
+        let (a_ok, b_ok) = (feasible(a_viol), feasible(b_viol));
+        if a_ok != b_ok {
+            // The feasible_enough point wins outright.
+            return a_ok;
+        }
+        // Same feasibility class: lower objective wins (original behaviour).
+        a_obj < b_obj
     }
 
     /// Make the dual-divergence guard's diversion non-destructive (pounce#250
@@ -871,6 +938,16 @@ impl IpoptAlgorithm {
     /// instead. This is the same "never worse off" bargain the gh #200 veto
     /// makes, applied to the other bet in the algorithm.
     ///
+    /// "Beats" is the feasibility-aware ranking in [`Self::ranks_better`], not a
+    /// bare objective comparison: the recorded point wins only if it is
+    /// feasible-enough while the returned point is not, or both are in the same
+    /// feasibility class and it has a lower objective. Ranking by objective alone
+    /// let a widened `acceptable_constr_viol_tol` band trade feasibility for
+    /// objective here — restoring a lower-objective point that `pounce verify`
+    /// rejects, under a success-mapped status (gh #267). The key prevents that:
+    /// objective can only win among points already inside the capped acceptable
+    /// feasibility band.
+    ///
     /// Note "anywhere in the solve", not "since the guard fired":
     /// [`Self::record_best_acceptable`] runs unconditionally and explains why —
     /// points at or before the diversion have to be on offer, or a diversion that
@@ -893,19 +970,23 @@ impl IpoptAlgorithm {
             return result;
         };
         let (curr_f, _) = self.curr_obj_and_unscaled_kkt();
+        let curr_viol = self.cq.borrow().curr_unscaled_primal_infeasibility_max();
         let curr_scale = self.cq.borrow().obj_scaling_factor();
         // Only comparable under the same factor, sign included.
         if curr_scale != best.obj_scale {
             return result;
         }
-        // Negated `<=`, not `>`: they differ at NaN, and a non-finite objective
-        // at the returned point must lose to a finite recorded one rather than
-        // silently winning the comparison.
-        if !(curr_f <= best.obj) {
+        // Restore only when the recorded point ranks strictly better under the
+        // feasibility-aware key — more feasible, or equally feasible at a lower
+        // objective. `ranks_better` also handles the `NaN` case the previous
+        // bare `!(curr_f <= best.obj)` did: a non-finite returned objective
+        // ranks worst, so a finite recorded point wins and is restored.
+        if self.ranks_better(best.obj, best.constr_viol, curr_f, curr_viol) {
             tracing::debug!(target: "pounce::algorithm",
                 "[POUNCE] dual-divergence diversion ended worse than a point already \
-                 in hand (obj {:.10e} -> {:.10e}, iter {}); restoring it (pounce#250).",
-                curr_f, best.obj, best.iter,
+                 in hand (obj {:.10e} viol {:.3e} -> obj {:.10e} viol {:.3e}, iter {}); \
+                 restoring it (pounce#250, gh#267).",
+                curr_f, curr_viol, best.obj, best.constr_viol, best.iter,
             );
             self.restore_snapshot(&best);
             // Swap the *point*, but never let the swap erase why the solve
@@ -2676,6 +2757,18 @@ struct VetoSnapshot {
     /// `apply_kkt_fidelity_gate` will see. Recorded at refusal time because the
     /// gate runs post-solve, long after this iterate is gone.
     unscaled_kkt: Number,
+    /// Unscaled max-norm constraint violation there — the same quantity the
+    /// `acceptable_constr_viol_tol` gate is defined against
+    /// (`curr_unscaled_primal_infeasibility_max`, cf. gh #261). The
+    /// best-acceptable fallback ranks candidates by `(feasible_enough,
+    /// objective)` rather than objective alone, so a point outside a capped
+    /// feasibility band can never displace one inside it on objective grounds;
+    /// without this field the ranking has no feasibility term and, under a
+    /// user-widened `acceptable_constr_viol_tol`, will trade feasibility for
+    /// objective and hand back a verifiably infeasible point under a success
+    /// status (gh #267). Unused by the gh #200 masked-scale paths, which key on
+    /// objective only.
+    constr_viol: Number,
     /// Objective scaling factor in force when `obj` was recorded.
     ///
     /// `obj` is a *scaled* objective, so comparing it against the continued

--- a/crates/pounce-cli/tests/issue_250_dual_guard_never_worse.rs
+++ b/crates/pounce-cli/tests/issue_250_dual_guard_never_worse.rs
@@ -154,8 +154,11 @@ fn dual_guard_diversion_returns_a_stationary_point() {
 // acceptable point the diverted run ever reached — see
 // `honour_best_acceptable_after_dual_guard`.
 //
-// deb7 is still exercised below, by the relative hair-trigger comparison, which
-// is host-independent by construction.
+// deb7 is still exercised below, under maximum firing pressure — but only for
+// invariants that hold on every host (a valid, honestly-labelled point), not the
+// cross-host objective comparison an earlier version tried and gh #267 retired.
+// The fallback's actual guarantee is a property of the ranking, proven
+// host-independently by the `ranks_better_*` unit tests in `ipopt_alg.rs`.
 
 /// The guard must stay off unless asked for. This is the model that decided it:
 /// `pooling_rt2stp` solves cleanly with the guard disabled and at streaks 5, 25
@@ -190,57 +193,66 @@ fn pooling_rt2stp_solves_at_default_settings() {
     );
 }
 
-/// The "never worse off" property under **maximum firing pressure**.
+/// Under **maximum firing pressure** the guard must still return a valid,
+/// honestly-labelled point — but this test does *not* assert it beats the
+/// counterfactual of never diverting, which the mechanism cannot promise
+/// (gh #267).
 ///
 /// `dual_diverging_streak=1` is a hair trigger: the guard diverts on the first
 /// growing dual-infeasibility step in the elevated regime, so it fires early and
-/// often on models that would otherwise converge untouched. If the fallback were
-/// incomplete, this is where it would show — a diversion landing somewhere the
-/// solve cannot recover from.
+/// often on models that would otherwise converge untouched. That makes it the
+/// sharpest probe of the record/read machinery — it moves the diversion as early
+/// as it can go, exercising the recorder on points at and before the diversion.
 ///
-/// This is also the test that covers the gap the first version of the fix had.
-/// Recording was originally gated on `dual_guard_fired`, but the guard returns
-/// to the driver *before* the recording site on the iteration it fires, so
-/// nothing at or before the diversion was captured. `autocorr_bern55-06` did not
-/// expose it — its better point arrives at iteration 86, long after the guard
-/// fires at 23 — so a hair trigger, which moves the diversion as early as it can
-/// go, is the sharper probe.
+/// WHAT THIS ASSERTS, AND WHAT IT DELIBERATELY DOES NOT. An earlier version
+/// asserted `guard_on_obj <= guard_off_obj + slack` — that a diverted run is no
+/// worse than *not diverting*. gh #267 caught that as unsound: the fallback
+/// guarantees only that a diverted run is no worse than the best acceptable
+/// point *that same run visited*, never that diverting beats the counterfactual
+/// solve that never happened. That comparison passed only by a slack ~28,000x
+/// the real gap, and on a host whose streak=1 basin flips — as `deb7`'s does at
+/// streak 15, 97.56 off vs 127.87 on — it would fail on basin luck, not on any
+/// defect. It was host-independent in form, not in outcome.
 ///
-/// DELIBERATELY RELATIVE, no absolute reference. An earlier version asserted that
-/// the guard-off arm reproduced a hard-coded objective, to stop fixture drift
-/// making the test vacuous. That assertion was itself wrong: which local optimum
-/// these nonconvex models land in is **platform-dependent**. `deb7` with the
-/// guard off returns 104.95 on macOS/FERAL and 97.56 on the Linux CI runner, so
-/// the hard-coded value failed in CI. Both are legitimate local optima; POUNCE
-/// claims neither globally.
-///
-/// That platform dependence is not noise around the property being tested — it
-/// *is* the property. A heuristic whose benefit varies by host is basin luck, and
-/// it is the reason `dual_diverging_streak` is off by default.
-///
-/// Vacuity is covered by the two tests above, which pin that the guard fires on
-/// `autocorr_bern55-06` at streak 15 and that the fallback recovers the optimum.
-/// Here the comparison is between two live solves on the same machine and build,
-/// so it cannot go stale.
+/// The mechanism's real guarantee is a property of the ranking, and it is proven
+/// host-independently, by cases, in the `ranks_better_*` unit tests in
+/// `ipopt_alg.rs`. Here we assert only what is sound under heavy firing on every
+/// host: each arm terminates with a finite objective, and — the gh #267
+/// invariant — never reports a success/acceptable status while carrying a
+/// grossly-infeasible point. Feasibility is not silently traded for a
+/// better-looking objective.
 #[test]
-fn hair_trigger_guard_never_degrades_the_answer() {
+fn hair_trigger_guard_returns_a_valid_honestly_labelled_point() {
     for name in ["autocorr_bern55-06.nl", "deb7.nl"] {
-        let off = solve(name, &["max_wall_time=20", "dual_diverging_streak=0"]);
-        let hair = solve(name, &["max_wall_time=20", "dual_diverging_streak=1"]);
-        // Minimization: the hair-trigger arm must not return a higher objective
-        // than the same build reaches with the guard disabled. A small relative
-        // slack absorbs last-digit differences between two legitimately
-        // different trajectories.
-        let off_obj = off.solution.objective;
-        let hair_obj = hair.solution.objective;
-        let slack = 1e-6 * off_obj.abs().max(1.0);
-        assert!(
-            hair_obj <= off_obj + slack,
-            "{name}: hair-trigger guard (dual_diverging_streak=1) returned \
-             {hair_obj} — worse than the {off_obj} the same build reaches with \
-             the guard disabled. The diversion left the solve worse off, which \
-             the best-acceptable fallback exists to prevent (pounce#250 follow-up)",
-        );
+        for streak in ["dual_diverging_streak=0", "dual_diverging_streak=1"] {
+            let report = solve(name, &["max_wall_time=20", streak]);
+            let obj = report.solution.objective;
+            assert!(
+                obj.is_finite(),
+                "{name} ({streak}): non-finite objective {obj} under hair-trigger \
+                 firing — the diversion produced garbage (gh #267 / pounce#250)",
+            );
+            // The gh #267 invariant: a success/acceptable status (AMPL
+            // solve_result_num 0..199) must describe a feasible point. At default
+            // tolerances the acceptable gate already bounds this; asserting it
+            // here guards the fallback + status mapping against a regression that
+            // restores an infeasible point under a success status, and it holds
+            // on every host (unlike the objective comparison it replaced). The
+            // pre-fix gh #267 failure sat at violation 9.94 under this very
+            // status; the bound is far below that and far above what a genuine
+            // acceptable point reaches.
+            let code = report.solution.solve_result_num;
+            if (0..200).contains(&code) {
+                let viol = report.statistics.final_constr_viol;
+                assert!(
+                    viol < 1e-2,
+                    "{name} ({streak}): reported a success/acceptable status \
+                     (solve_result_num={code}) at constraint violation {viol} — \
+                     the fallback handed back an infeasible point under a success \
+                     status (gh #267)",
+                );
+            }
+        }
     }
 }
 

--- a/crates/pounce-cli/tests/issue_250_dual_guard_never_worse.rs
+++ b/crates/pounce-cli/tests/issue_250_dual_guard_never_worse.rs
@@ -99,8 +99,9 @@ const AUTOCORR_OPTIMUM: f64 = -2_304.000_027_802_734_2;
 /// former default of 15 — or it would exercise nothing and pass vacuously.
 const GUARD_ON: [&str; 2] = ["max_wall_time=10", "dual_diverging_streak=15"];
 
-/// With the guard at its default the diversion must not cost the objective.
-/// Pre-fix this returned -2263.4612448099933.
+/// With the guard enabled (streak 15 — its former default; it is now off by
+/// default) the diversion must not cost the objective. Pre-fix this returned
+/// -2263.4612448099933.
 #[test]
 fn dual_guard_diversion_does_not_return_a_worse_point() {
     let report = solve("autocorr_bern55-06.nl", &GUARD_ON);
@@ -241,4 +242,90 @@ fn hair_trigger_guard_never_degrades_the_answer() {
              the best-acceptable fallback exists to prevent (pounce#250 follow-up)",
         );
     }
+}
+
+/// The best-acceptable fallback must not spend feasibility to buy objective
+/// (gh #267 — a pounce#259 / PR #259 follow-up).
+///
+/// The fallback originally ranked recorded acceptable points by scaled
+/// objective alone. Being *bounded* by `acceptable_constr_viol_tol` is not the
+/// same as *not trading* feasibility within that band, and the band is a user
+/// option: widen it and a pure-objective argmax will discard a nearly-feasible
+/// point for a lower-objective one that is grossly infeasible, then hand it back
+/// under a `Solved_To_Acceptable_Level` status.
+///
+/// The control is the point of this test. At the same widened tolerances the
+/// guard-*off* solve returns a feasible point, so the loose band alone does not
+/// cause the infeasible return — it only widens what the fallback can exploit.
+/// The fix ranks by `(feasibility, objective)`, so the guard-on solve must also
+/// return a feasible point.
+///
+/// Pre-fix numbers (dev host): guard on returned objective -2307.32 at a
+/// constraint violation of **9.94** — below the true optimum -2304.0 precisely
+/// because the point is infeasible — while guard off returned -2298.57 at
+/// violation 1.06e-4. Both reported `solve_result_num` 100.
+#[test]
+fn best_acceptable_fallback_does_not_trade_feasibility_for_objective() {
+    // A widened acceptable band. `acceptable_constr_viol_tol` alone is not
+    // enough — the other acceptable criteria gate first — so the whole triplet
+    // is loosened, which is unusual but entirely legal on hard or badly-scaled
+    // models. `constr_viol_tol` (the strict feasibility band the fix keys on) is
+    // left at its 1e-4 default.
+    const BAND: [&str; 5] = [
+        "acceptable_constr_viol_tol=1e1",
+        "acceptable_tol=1e10",
+        "acceptable_dual_inf_tol=1e30",
+        "acceptable_compl_inf_tol=1e10",
+        "max_wall_time=20",
+    ];
+
+    let off = solve(
+        "autocorr_bern55-06.nl",
+        &[BAND.as_slice(), &["dual_diverging_streak=0"]].concat(),
+    );
+    let on = solve(
+        "autocorr_bern55-06.nl",
+        &[BAND.as_slice(), &["dual_diverging_streak=15"]].concat(),
+    );
+
+    // The control: the loose band on its own must not produce an infeasible
+    // return, or this fixture no longer isolates the fallback's behaviour.
+    assert!(
+        off.statistics.final_constr_viol < 1e-2,
+        "control invalid: guard-off solve is itself infeasible at these \
+         tolerances (constr_viol {}) — the fixture no longer isolates the \
+         fallback (gh #267)",
+        off.statistics.final_constr_viol,
+    );
+
+    // The fix: the guard-on solve must hand back a feasible point, not the
+    // grossly-infeasible lower-objective one a pure-objective ranking chose.
+    // Pre-fix this was 9.94; the threshold sits far below that and far above the
+    // ~1e-4 the recovered point actually reaches.
+    assert!(
+        on.statistics.final_constr_viol < 1e-2,
+        "best-acceptable fallback traded feasibility for objective: guard-on \
+         solve returned objective {} at constraint violation {} (pre-fix 9.94), \
+         while the guard-off control at the same tolerances is feasible at {}. \
+         The fallback ranked by objective alone and handed back an infeasible \
+         point under a success status (gh #267).",
+        on.solution.objective,
+        on.statistics.final_constr_viol,
+        off.statistics.final_constr_viol,
+    );
+
+    // The fix must not over-correct into feasibility-first ranking, which would
+    // hand back a trivially-feasible but useless point — the starting iterate
+    // sits at objective 0 and violation 0 and would win a feasibility-primary
+    // key. Among feasible-enough points objective still decides, so the returned
+    // point is the diverted run's own near-optimal endpoint (~-2304), the point
+    // gh #267 says should have been kept, not the starting point.
+    assert!(
+        on.solution.objective < -2000.0,
+        "best-acceptable fallback over-corrected: guard-on solve returned \
+         objective {} — a feasibility-first ranking handed back a trivially \
+         feasible but far-from-optimal point instead of the near-optimal \
+         endpoint the diverted run reached (gh #267).",
+        on.solution.objective,
+    );
 }


### PR DESCRIPTION
## Problem

The best-acceptable fallback (introduced in #250) ranks recorded acceptable points by scaled objective alone. Being *bounded* by `acceptable_constr_viol_tol` is not the same as *not trading* feasibility *within* that band, and the band is a user option. Widen it and a pure-objective argmax has no lower bound on the feasibility it will spend: it discards a nearly-feasible point for a lower-objective one that is grossly infeasible, then hands it back under a `Solved_To_Acceptable_Level` status.

**Symptom:** On `autocorr_bern55-06` at `dual_diverging_streak=15 acceptable_constr_viol_tol=1e1 acceptable_tol=1e10 acceptable_dual_inf_tol=1e30 acceptable_compl_inf_tol=1e10`, the guard-on solve returned objective `-2307.32` at a constraint violation of **9.94** — below the true optimum `-2304.0` precisely because the point is infeasible, and rejected by `pounce verify`. At the same tolerances the guard-*off* control returns a feasible point (`-2298.57`, violation `1.06e-4`), so the loose band alone is not the cause — it only widens what the fallback can exploit.

| | objective | constraint violation | status |
|---|---|---|---|
| guard off (control) | -2298.57 | 1.06e-4 | feasible |
| guard on (pre-fix) | -2307.32 | **9.94** | infeasible, rejected by pounce verify |
| guard on (post-fix) | -2303.9999 | 1.13e-4 | feasible |

## Cause

The fallback's `record_best_acceptable` and `honour_best_acceptable_after_dual_guard` methods compared points by objective alone. The `VetoSnapshot` struct tracked only `obj`, `mu`, `unscaled_kkt`, and `obj_scale` — no feasibility information. When the user widened `acceptable_constr_viol_tol` past its default, the fallback could exploit the wider band to trade feasibility for objective.

## Fix

**The fallback now ranks by `(feasibility, objective)` lexicographically, not objective alone.**

1. **Added constraint violation tracking:** `VetoSnapshot` now carries `constr_viol` — the unscaled max-norm constraint violation at the recorded point, the same quantity the `acceptable_constr_viol_tol` gate is defined against.

2. **Introduced feasibility-aware ranking:** New pure function `ranks_better_within_band(a_obj, a_viol, b_obj, b_viol, band)` implements the key: a point inside the feasibility band beats one outside it outright; objective decides *only among points already inside the band*. Non-finite objectives rank worst (never win); non-finite violations are never feasible-enough.

3. **Capped the feasibility band:** `IpoptAlgorithm::ranks_better` resolves the band as `min(acceptable_constr_viol_tol, FEASIBLE_ENOUGH_CAP)` where `FEASIBLE_ENOUGH_CAP = 1e-2` (the upstream default). This ensures a user-widened `acceptable_constr_viol_tol` cannot let the fallback spend feasibility to buy objective — a grossly-infeasible low-objective iterate is simply not a candidate.

4. **Updated both record and read sides:** Both `record_best_acceptable` and `honour_best_acceptable_after_dual_guard` now use `ranks_better` to decide whether a candidate improves on the recorded point.

**Why this approach:** At default or tighter tolerances this is behaviour-neutral: every recorded point already passed the `acceptable_constr_viol_tol` gate, so with that band at or below the cap every candidate is feasible-enough and objective alone decides, exactly as before. The cap only bites once the user loosens `acceptable_constr_

https://claude.ai/code/session_017H5fVWVhN6eFaNWyKgouue