### PR TITLE
Emit AMPL-convention duals in .sol; fix GAMS max-model marginals (#271, #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — constraint dual sign convention (#271, #272)
+
+- **`.sol` / Pyomo `model.dual`** carried pounce's internal Lagrange
+  multiplier instead of the AMPL *marginal* `d obj / d b`, so every dual came
+  back negated relative to Ipopt, glpk, CBC and CONOPT (#271). Objectives and
+  primal solutions were never affected. The `.sol` writer now performs the
+  conversion. **This flips the sign of duals read through Pyomo and AMPL** —
+  if you compensated for the old behavior in downstream code, remove that
+  workaround.
+- The Python API's `mult_g` and the JSON report's `solution.lambda` are
+  unchanged: they keep the Lagrange-multiplier convention, which matches
+  cyipopt. `marginal = −λ`; both conventions are now documented side by side
+  in [Running Solves](docs/src/cli.md).
+- **GAMS equation marginals on `maximizing` models** were inverted in both the
+  pip link and the native C link (#272): the `obj_sign` factor already applied
+  to the objective value and the variable marginals was missing from the
+  multiplier conversion, which is now `pi = −obj_sign · λ`. `minimizing`
+  models, objective values, variable marginals and status mapping were never
+  affected, and the two links behaved identically, so install method made no
+  difference.
+- `pyomo_pounce.gradient()` on a `Constraint` target returned
+  `d(λ)/d(param)`, which no longer matched `model.dual` once duals were
+  converted; it now reports `d(dual)/d(param)`.
+
 ### Fixed — ambiguous 2-parameter tuple bounds and NaN bounds (#265)
 
 - `curve_fit` / `curve_fit_minima` / `curve_fit_streaming`: at `n == 2`, a

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1376,7 +1376,7 @@ pub fn main() -> ExitCode {
         let payload = nl_writer::SolutionFile {
             message: &message,
             x: &x,
-            lambda: &lambda,
+            mult_g: &lambda,
             solve_result_num: status_to_solve_result_num(status),
             suffixes: &sol_suffixes,
         };
@@ -1747,7 +1747,7 @@ fn run_convex_qp(
         let payload = nl_writer::SolutionFile {
             message: &format!("POUNCE {} IPM (pounce-convex): {msg}", class.name()),
             x: &sol.x,
-            lambda: &lambda,
+            mult_g: &lambda,
             solve_result_num: srn,
             suffixes: &[],
         };
@@ -1920,7 +1920,7 @@ fn run_convex_socp(
         let payload = nl_writer::SolutionFile {
             message: &format!("POUNCE {} conic IPM (pounce-convex): {msg}", class.name()),
             x: &sol.x,
-            lambda: &lambda,
+            mult_g: &lambda,
             solve_result_num: srn,
             suffixes: &[],
         };

--- a/crates/pounce-cli/src/minima/mod.rs
+++ b/crates/pounce-cli/src/minima/mod.rs
@@ -898,7 +898,7 @@ fn write_sol_files(sol_path: &Path, minima: &[Minimum], m: usize) {
         let payload = crate::nl_writer::SolutionFile {
             message: &message,
             x: &mn.x,
-            lambda,
+            mult_g: lambda,
             solve_result_num: status_to_solve_result_num(ApplicationReturnStatus::SolveSucceeded),
             suffixes: &[],
         };

--- a/crates/pounce-cli/src/nl_writer.rs
+++ b/crates/pounce-cli/src/nl_writer.rs
@@ -101,8 +101,19 @@ pub struct SolutionFile<'a> {
     pub message: &'a str,
     /// Primal variable values, length `n`.
     pub x: &'a [Number],
-    /// Constraint dual values, length `m`.
-    pub lambda: &'a [Number],
+    /// Constraint multipliers in **pounce's internal (cyipopt)
+    /// convention**, length `m`: the `lambda` of
+    /// `L = f + lambda' g - z_L (x - x_L) + z_U (x - x_U)`, so
+    /// `d obj / d b = -lambda`.
+    ///
+    /// [`format_sol`] negates these on the way out, because the AMPL
+    /// `.sol` dual block carries *marginal values* (`d obj / d b`),
+    /// not Lagrange multipliers. Pass the internal multipliers here
+    /// and let the writer do the translation — do not pre-negate at
+    /// the call site.
+    ///
+    /// See [Gay, "Hooking Your Solver to AMPL" §5](https://ampl.com/REFS/hooking2.pdf).
+    pub mult_g: &'a [Number],
     /// AMPL solver return code. Convention: 0 = solved, 100..199 =
     /// "solved with warning", 200..299 = "infeasible", 300..399 =
     /// "unbounded", 400..499 = "limit reached", 500..599 = "failure".
@@ -132,7 +143,7 @@ pub fn format_sol(payload: &SolutionFile<'_>) -> String {
     // `.nl`. We write every dual and primal, so the pairs collapse to
     // (m, m) and (n, n). Emitting only `m` and `n` (the two-integer
     // short form) makes AMPL's and Pyomo's `.sol` readers fail.
-    let m = payload.lambda.len();
+    let m = payload.mult_g.len();
     let n = payload.x.len();
     let _ = writeln!(out, "{m}");
     let _ = writeln!(out, "{m}");
@@ -142,8 +153,14 @@ pub fn format_sol(payload: &SolutionFile<'_>) -> String {
     // Dual block, then primal block. AMPL writes doubles with at least
     // 16 significant digits to round-trip through IEEE-754; we use
     // Rust's `{:.17e}` to match.
-    for &v in payload.lambda {
-        let _ = writeln!(out, "{v:.17e}");
+    // AMPL's dual block is the *marginal value* `d obj / d b`, while
+    // pounce carries the Lagrange multiplier of
+    // `L = f + lambda' g`, for which `d obj / d b = -lambda`. Negate
+    // on the way out so `.sol` consumers (AMPL, Pyomo `model.dual`,
+    // and anything reading the file directly) see shadow prices with
+    // the sign the rest of the ecosystem uses. See gh #271.
+    for &v in payload.mult_g {
+        let _ = writeln!(out, "{:.17e}", -v);
     }
     for &v in payload.x {
         let _ = writeln!(out, "{v:.17e}");
@@ -233,7 +250,7 @@ mod tests {
         let payload = SolutionFile {
             message: "POUNCE: SolveSucceeded",
             x: &[1.0, 2.5, -0.5],
-            lambda: &[0.1, -0.2],
+            mult_g: &[0.1, -0.2],
             solve_result_num: 0,
             suffixes: &[],
         };
@@ -257,7 +274,7 @@ mod tests {
         let payload = SolutionFile {
             message: "POUNCE-SENS",
             x: &[0.0, 0.0],
-            lambda: &[],
+            mult_g: &[],
             solve_result_num: 0,
             suffixes: &[SolSuffix {
                 name: "sens_sol_state_1".into(),
@@ -288,7 +305,7 @@ mod tests {
         let payload = SolutionFile {
             message: "msg",
             x: &[],
-            lambda: &[],
+            mult_g: &[],
             solve_result_num: 0,
             suffixes: &[SolSuffix {
                 name: "sens_init_constr".into(),
@@ -308,7 +325,7 @@ mod tests {
         let payload = SolutionFile {
             message: "msg",
             x: &[],
-            lambda: &[],
+            mult_g: &[],
             solve_result_num: 0,
             suffixes: &[SolSuffix {
                 name: "wall_time".into(),
@@ -334,7 +351,7 @@ mod tests {
         let payload = SolutionFile {
             message: "m",
             x: &[],
-            lambda: &[],
+            mult_g: &[],
             solve_result_num: 0,
             suffixes: &[SolSuffix {
                 name: "foo".into(),

--- a/crates/pounce-cli/src/verify.rs
+++ b/crates/pounce-cli/src/verify.rs
@@ -1009,7 +1009,7 @@ mod tests {
         let payload = SolutionFile {
             message: &message,
             x: &[1.0, 2.5, -0.5, 100.0],
-            lambda: &[0.1, -0.2],
+            mult_g: &[0.1, -0.2],
             solve_result_num: 0,
             suffixes: &[],
         };
@@ -1019,7 +1019,14 @@ mod tests {
         assert_eq!(parsed.lambda.len(), 2);
         assert!((parsed.x[1] - 2.5).abs() < 1e-15);
         assert!((parsed.x[3] - 100.0).abs() < 1e-12);
-        assert!((parsed.lambda[0] - 0.1).abs() < 1e-15);
+        // The primal round-trips as an identity, but the dual block does
+        // NOT: `format_sol` negates pounce's internal multipliers into the
+        // AMPL marginal convention (gh #271), and `parse_sol` reads the
+        // file back verbatim. So a `mult_g` of +0.1 must come back as a
+        // parsed dual of -0.1. Asserting identity here is what previously
+        // let the sign defect pass unnoticed.
+        assert!((parsed.lambda[0] + 0.1).abs() < 1e-15);
+        assert!((parsed.lambda[1] - 0.2).abs() < 1e-15);
         assert_eq!(parsed.solve_result_num, Some(0));
     }
 
@@ -1028,7 +1035,7 @@ mod tests {
         let payload = SolutionFile {
             message: "msg",
             x: &[3.0, 4.0],
-            lambda: &[],
+            mult_g: &[],
             solve_result_num: 200,
             suffixes: &[],
         };

--- a/crates/pounce-cli/tests/qp_dispatch_end_to_end.rs
+++ b/crates/pounce-cli/tests/qp_dispatch_end_to_end.rs
@@ -325,8 +325,14 @@ fn forced_qp_active_set_solves_convex_qp() {
 /// The active-set route's `.sol` must carry the *real* primal and dual — not
 /// the zero fallback. Its solve bypasses the IPM-only `on_converged` capture,
 /// so the CLI backfills the solution from `finalize_solution`; this test pins
-/// that the captured `x ≈ (1,1)` and the equality dual `≈ −2` match the IPM /
+/// that the captured `x ≈ (1,1)` and the equality dual `≈ +2` match the IPM /
 /// NLP convention on the same `min x0²+x1² s.t. x0+x1=2` fixture.
+///
+/// The dual is `+2`, not `−2`: for `min x0²+x1² s.t. x0+x1=b` the optimum is
+/// `b²/2`, so the AMPL marginal `d obj / d b = b = 2`. Ipopt, glpk and cbc all
+/// report `+2` on this model. Until gh #271 this assertion read `−2`, pinning
+/// pounce's internal multiplier sign into the `.sol` contract and masking the
+/// defect.
 #[test]
 fn qp_active_set_sol_matches_known_optimum_and_dual() {
     let dir = std::env::temp_dir();
@@ -351,15 +357,15 @@ fn qp_active_set_sol_matches_known_optimum_and_dual() {
         near_one >= 2,
         "active-set .sol must carry the real primal x ≈ (1,1), not zeros:\n{text}"
     );
-    // The equality multiplier is −2 in the same convention as the IPM/NLP path.
+    // The equality marginal is +2 in the same convention as the IPM/NLP path.
     let dual_near = floats
         .iter()
         .copied()
-        .min_by(|a, b| (a + 2.0).abs().partial_cmp(&(b + 2.0).abs()).unwrap())
+        .min_by(|a, b| (a - 2.0).abs().partial_cmp(&(b - 2.0).abs()).unwrap())
         .expect("a float in .sol");
     assert!(
-        (dual_near + 2.0).abs() < 1e-5,
-        "active-set equality dual {dual_near} != −2:\n{text}"
+        (dual_near - 2.0).abs() < 1e-5,
+        "active-set equality dual {dual_near} != +2:\n{text}"
     );
 }
 
@@ -408,8 +414,15 @@ fn sol_primal_matches_known_optimum() {
 }
 
 /// The convex QP path's recovered constraint dual must match the NLP
-/// path's dual on the same `.nl` file (the reference convention). For
-/// `min x0²+x1² s.t. x0+x1=2` the equality multiplier is −2.
+/// path's dual on the same `.nl` file, **and** both must match the
+/// externally-correct AMPL marginal. For `min x0²+x1² s.t. x0+x1=b` the
+/// optimum is `b²/2`, so `d obj / d b = b = +2` — the value Ipopt, glpk
+/// and cbc report.
+///
+/// Pinning the absolute value matters: before gh #271 this test asserted
+/// only that the two pounce paths agreed with each other (at `−2`), which
+/// a uniform sign error satisfies trivially. Cross-path agreement alone
+/// cannot detect a convention defect shared by both paths.
 #[test]
 fn qp_and_nlp_duals_agree() {
     let dir = std::env::temp_dir();
@@ -427,12 +440,12 @@ fn qp_and_nlp_duals_agree() {
         std::fs::read_to_string(out).expect("read .sol")
     };
 
-    // The single constraint dual is the value closest to −2 in each
+    // The single constraint dual is the value closest to +2 in each
     // `.sol`'s float block.
     let dual_near = |text: &str| -> f64 {
         text.lines()
             .filter_map(|l| l.trim().parse::<f64>().ok())
-            .min_by(|a, b| (a - (-2.0)).abs().partial_cmp(&(b - (-2.0)).abs()).unwrap())
+            .min_by(|a, b| (a - 2.0).abs().partial_cmp(&(b - 2.0).abs()).unwrap())
             .expect("a float in .sol")
     };
 
@@ -441,7 +454,7 @@ fn qp_and_nlp_duals_agree() {
 
     let qp_dual = dual_near(&qp_sol);
     let nlp_dual = dual_near(&nlp_sol);
-    assert!((qp_dual - (-2.0)).abs() < 1e-5, "QP dual {qp_dual} != −2");
+    assert!((qp_dual - 2.0).abs() < 1e-5, "QP dual {qp_dual} != +2");
     assert!(
         (qp_dual - nlp_dual).abs() < 1e-5,
         "QP dual {qp_dual} disagrees with NLP dual {nlp_dual}"

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -91,6 +91,32 @@ the AMPL exit-code contract (see below), so the driver reads the
 termination from the `.sol` file rather than the exit status. The
 [`pyomo-pounce`](pyomo.md) package builds on top of this mode.
 
+### Dual sign conventions
+
+Two different quantities are in play, and they differ by a sign. Getting
+them confused is easy, so pounce names them differently:
+
+| Surface | Quantity | Meaning |
+|---|---|---|
+| `.sol` dual block, Pyomo `model.dual` | **marginal** | `d obj / d b` — the shadow price |
+| `mult_g` (Python API, JSON `solution.lambda`) | **Lagrange multiplier** | the `λ` of `L = f + λ'g − z_L(x−x_L) + z_U(x−x_U)` |
+
+They are related by `marginal = −λ`. The `.sol` writer performs this
+negation, so a `.sol` (and therefore Pyomo's `model.dual`) carries shadow
+prices with the same sign Ipopt, glpk, CBC and CONOPT report. For
+`min x₀²+x₁² s.t. x₀+x₁ = b` the optimum is `b²/2`, so a `.sol` written at
+`b = 2` reports `+2`.
+
+The Python API's `mult_g` keeps the Lagrange-multiplier convention, which
+matches cyipopt and satisfies the stationarity identity above directly.
+If you are comparing a `mult_g` against a `model.dual` for the same solve,
+expect them to differ by a sign — that is by design, not a bug.
+
+> Before v0.9.1 the `.sol` writer emitted the Lagrange multiplier without
+> converting it, so every AMPL/Pyomo dual came back negated relative to
+> every other solver ([#271](https://github.com/jkitchin/pounce/issues/271)).
+> Objectives and primal solutions were never affected.
+
 ## Exit codes
 
 - `0` — `Solve_Succeeded` (or `Solved_To_Acceptable_Level`).

--- a/docs/src/gams.md
+++ b/docs/src/gams.md
@@ -91,6 +91,25 @@ GAMS invokes the launcher with a control file; the launcher runs the Python
 link, which reads the model through GMO/GEV, solves it with POUNCE, and writes
 the primal/dual solution and GAMS model/solve status back.
 
+### Marginals
+
+Equation marginals (`.M`) follow the usual GAMS convention: they are stated
+against the objective **as you wrote it**, for both `minimizing` and
+`maximizing` models. POUNCE always minimizes internally, so for a
+`maximizing` model it solves `min(−f)` and converts its multipliers back
+via `pi = −obj_sign · λ` (see `gams_pi` in `python/pounce/gams/link.py` and
+the matching block in `gams/gams_pounce.c`).
+
+Variable marginals (`.M` on variables, i.e. reduced costs) are
+`z_L − z_U`, carrying the same `obj_sign` factor.
+
+> Before v0.9.1 the conversion omitted the `obj_sign` factor, so equation
+> marginals on `maximizing` models came back with the wrong sign
+> ([#272](https://github.com/jkitchin/pounce/issues/272)). `minimizing`
+> models, objective values, variable marginals and status mapping were
+> never affected. Both the pip link and the native C link were affected
+> identically, so the install method made no difference.
+
 ## Option files
 
 If a model sets `mymodel.optfile = 1`, POUNCE reads `pounce.opt` (`.op2`,

--- a/gams/gams_pounce.c
+++ b/gams/gams_pounce.c
@@ -1093,10 +1093,24 @@ DllExport int STDCALL pouCallSolver(void *Cptr)
             gmoSetHeadnTail(gmo, gmoHiterused, (double)iters_now);
         }
 
-        /* Negate constraint multipliers: POUNCE lambda -> GAMS pi */
+        /* Constraint multipliers: POUNCE lambda -> GAMS pi.
+         *
+         * POUNCE always minimizes, so for a `maximizing` model it solves
+         * min(-f) and its lambda refers to that negated objective. GAMS
+         * marginals are stated against the ORIGINAL objective, so the
+         * conversion carries the same obj_sign factor already applied to
+         * the objective value (line ~1081) and to the variable marginals
+         * (below):
+         *
+         *     pi = -obj_sign * lambda
+         *
+         * which reduces to the historical `-lambda` for minimizing models
+         * and flips it for maximizing ones. Omitting obj_sign here — while
+         * applying it everywhere else — inverted every equation marginal on
+         * max models. See gh #272. */
         if (mult_g) {
             for (int i = 0; i < m; i++)
-                mult_g[i] = -mult_g[i];
+                mult_g[i] = -data->obj_sign * mult_g[i];
         }
 
         /* Set primal + dual solution */

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -545,9 +545,27 @@ class Gradient:
             return self._session.mult_entry(td.name)
         return self._session.var_entry(td.name)
 
+    @staticmethod
+    def _convention_sign(td):
+        """Sign taking a raw sensitivity row into the convention of the
+        quantity the user reads off the model.
+
+        Variable targets need no conversion: `var_entry` rows are
+        derivatives of primal values, which is what `m.x.value` holds.
+
+        Constraint targets do. `mult_entry` rows come from
+        `parametric_step_full`'s y_c block, i.e. derivatives of POUNCE's
+        internal Lagrange multiplier, whereas `m.dual[con]` holds the AMPL
+        *marginal* `d obj / d b = -lambda` (gh #271). So d(dual)/d(param)
+        is the negation of the raw row -- without this, `gradient(m.con,
+        wrt=m.p)` disagrees in sign with a finite difference of
+        `m.dual[m.con]` taken across a re-solve.
+        """
+        return -1.0 if td.ctype is Constraint else 1.0
+
     def _value(self, td, pd):
         col = self._session.column(_param_pin(self._session, pd))
-        return float(col[self._entry(td)])
+        return self._convention_sign(td) * float(col[self._entry(td)])
 
     def __getitem__(self, key):
         if isinstance(key, tuple):

--- a/python/pounce/gams/link.py
+++ b/python/pounce/gams/link.py
@@ -340,6 +340,29 @@ def solve_from_control_file(
     return 0
 
 
+def gams_pi(mult_g, obj_sign: float):
+    """Convert POUNCE constraint multipliers to GAMS equation marginals.
+
+    POUNCE always minimizes, so for a ``maximizing`` model it solves
+    ``min(-f)`` and its ``lambda`` refers to that negated objective. GAMS
+    marginals are stated against the ORIGINAL objective, so the conversion
+    carries the same ``obj_sign`` factor already applied to the objective
+    value and to the variable marginals::
+
+        pi = -obj_sign * lambda
+
+    This reduces to ``-lambda`` for minimizing models (``obj_sign = +1``),
+    which is what the link has always done, and flips it for maximizing
+    models (``obj_sign = -1``).
+
+    Omitting the ``obj_sign`` factor here -- while applying it to the
+    objective and to the variable marginals -- inverted every equation
+    marginal on ``maximizing`` models. See gh #272. Mirrors the same
+    conversion in ``gams/gams_pounce.c``.
+    """
+    return -obj_sign * np.asarray(mult_g, dtype=float)
+
+
 def _write_solution(gmo_h, gmo, view, x, info) -> None:  # pragma: no cover - needs GAMS
     """Write primal/dual solution and GAMS model/solve status back into GMO."""
     status_msg = str(info.get("status_msg", ""))
@@ -358,11 +381,11 @@ def _write_solution(gmo_h, gmo, view, x, info) -> None:  # pragma: no cover - ne
         gmo.gmoSetHeadnTail(gmo_h, gmo.gmoHiterused, float(iters))
 
     m = int(view.num_cons())
-    # Constraint multipliers: POUNCE lambda -> GAMS pi (negate).
+    # Constraint multipliers: POUNCE lambda -> GAMS pi. See `gams_pi`.
     mult_g = info.get("mult_g")
     pi = None
     if m and mult_g is not None:
-        pi = _to_double_array(gmo, -np.asarray(mult_g, dtype=float))
+        pi = _to_double_array(gmo, gams_pi(mult_g, obj_sign))
 
     if x is not None:
         gmo.gmoSetSolution2(gmo_h, _to_double_array(gmo, x), pi)

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -428,3 +428,48 @@ def test_run_script_variants():
     win = register.run_script(python_executable="C:/py/python.exe", windows=True)
     assert "%*" in win
     assert "pounce.gams.link" in win
+
+
+# --- gh #272: equation marginal sign convention -------------------------
+
+
+def test_gams_pi_minimizing_negates_lambda():
+    """For a minimizing model, pi = -lambda (the historical behavior)."""
+    pi = link.gams_pi([1.5, -0.25, 0.0], obj_sign=1.0)
+    assert pi == pytest.approx([-1.5, 0.25, 0.0])
+
+
+def test_gams_pi_maximizing_preserves_lambda_sign():
+    """For a maximizing model, pi = +lambda.
+
+    Regression guard for gh #272: the link applied ``-lambda``
+    unconditionally, so every equation marginal on a ``maximizing`` model
+    came back inverted. Verified live against GAMS 53.2.0/CPLEX, which
+    reports +2.25 / +0.25 on the test LP; POUNCE's internal multipliers
+    there are +2.25 / +0.25, and the old ``pi = -lambda`` turned them into
+    the -2.25 / -0.25 that GAMS displayed.
+    """
+    pi = link.gams_pi([2.25, 0.25], obj_sign=-1.0)
+    assert pi == pytest.approx([2.25, 0.25])
+
+
+def test_gams_pi_sign_flips_between_senses():
+    """The two senses must be exact negations of one another."""
+    lam = [3.0, -1.0, 0.5]
+    assert link.gams_pi(lam, obj_sign=1.0) == pytest.approx(
+        -link.gams_pi(lam, obj_sign=-1.0)
+    )
+
+
+def test_gams_pi_matches_analytic_shadow_price_maximizing():
+    """End-to-end sign check against an analytic marginal.
+
+    ``max 2x s.t. x <= 3`` has ``obj* = 6`` and ``d obj / d b = +2``.
+
+    POUNCE minimizes ``-2x`` subject to ``x - 3 <= 0``, whose Lagrangian
+    ``L = -2x + lambda (x - 3)`` gives stationarity ``-2 + lambda = 0``,
+    i.e. ``lambda = +2``. With ``obj_sign = -1`` the GAMS marginal is
+    ``-(-1) * 2 = +2`` -- the sign GAMS's own solvers report. The old
+    unconditional negation returned ``-2``.
+    """
+    assert link.gams_pi([2.0], obj_sign=-1.0) == pytest.approx([2.0])


### PR DESCRIPTION
Fixes #271. Fixes #272.

## The defect

Constraint duals reached every AMPL-facing surface negated relative to the sign Ipopt, glpk, CBC and CONOPT report. Objectives and primal solutions were never affected — which is exactly why it went unnoticed.

Two different quantities were being conflated:

| | quantity | meaning |
|---|---|---|
| `.sol` dual block, Pyomo `model.dual` | **marginal** | `d obj / d b` — the shadow price |
| `mult_g`, JSON `solution.lambda` | **Lagrange multiplier** | the `λ` of `L = f + λ'g − z_L(x−x_L) + z_U(x−x_U)` |

They differ by a sign: `marginal = −λ`. The `.sol` writer emitted `λ` without converting it.

## #271 — `.sol` writer

`format_sol` now performs the conversion. `SolutionFile.lambda` is renamed to `mult_g` and documented as taking pounce's *internal* multipliers.

The rename is deliberate. It makes the compiler enumerate every construction site rather than trusting a grep, and it stops the field name from implying the file carries a Lagrange multiplier when it carries a shadow price.

**The Python API and JSON report are unchanged.** `mult_g` keeps the Lagrange-multiplier convention — it matches cyipopt, satisfies the stationarity identity directly, and `lambda` is the accurate name for it. Both conventions are now documented side by side in `docs/src/cli.md`, since users comparing a `mult_g` against a `model.dual` will legitimately see opposite signs.

*(If you'd rather the JSON report also flip for cross-surface consistency, say so — I kept it as-is because the field name is semantically correct and the benchmark harness reads that file. It's a one-line change.)*

## #272 — GAMS marginals on `maximizing` models

Both links negated `λ` unconditionally to form `pi`. That is correct only for `minimizing` models: pounce always minimizes, so a `maximizing` model is solved as `min(−f)` and its multipliers refer to the negated objective. The `obj_sign` factor already applied to the objective value (`gams_pounce.c:1081`) and to the variable marginals was simply missing from the multiplier conversion.

Both links now use `pi = −obj_sign · λ`, extracted into `gams_pi()` in `link.py` so it is unit-testable without a GAMS install, and mirrored in `gams_pounce.c`.

## pyomo-pounce coupling

`Gradient` returned `d(λ)/d(param)` from `parametric_step_full`'s y_c block, while the user compares against `model.dual`. Once duals are converted, that block needs the same conversion — added as `_convention_sign`, applied to `Constraint` targets only.

I did not anticipate this; `test_sens.py`'s two sign-convention tests caught it. They're good tests.

## Why this survived to a release candidate

Worth recording, because the fix alone doesn't address it:

- **The benchmark suite compares objectives, statuses, iteration counts and wall times — never duals.** A defect that leaves primals exact is invisible to it by construction.

- **`qp_dispatch_end_to_end.rs` asserted the wrong sign as expected behavior.** It pinned the equality dual of `min x₀²+x₁² s.t. x₀+x₁=2` at `−2`, when the analytic `d obj / d b = b = +2`. Its sibling test checked only that the QP and NLP paths *agreed with each other* — which a uniform sign error satisfies trivially. Both now assert `+2`, and the comments explain why cross-path agreement can't detect a shared convention defect.

- **`pounce verify` evaluates stationarity for both `+λ` and `−λ` and keeps the better residual**, so it certifies either sign. It could not have caught this and still cannot. The `.sol` tests are the guard; `verify`'s leniency is left alone here since tightening it is a separate change with its own blast radius.

## Validation

- Pyomo duals now match Ipopt/glpk and an analytic finite-difference on all 7 cases of the reproducer (LP/QP/NLP × `<=`,`>=`,`==` × min/max)
- Raw `.sol` duals match Ipopt to 1e-9 (`[-0, -1.5, -1.0]` both)
- 142 Rust suites, 685 Python tests, 101 pyomo-pounce tests pass
- The native C link compiles against GAMS 53.2.0 headers

New regression tests: 4 in `test_gams_link.py` covering both senses and an analytic shadow price; the two corrected `.sol` assertions; a corrected writer↔parser round-trip that documents why the dual block is *not* an identity round-trip.

## Compatibility

**This flips the sign of duals read through Pyomo and AMPL.** Anyone who compensated for the old behavior downstream should remove that workaround. Flagged in the changelog.

The GAMS `minimizing` path is unchanged — it was already correct, via the compensating negation. Only `maximizing` models change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
