### PR TITLE
Sum duplicate COO entries in the PSD guard (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `check_psd` validated a different matrix than the solver used (#279)
+
+- With a `scipy.sparse` COO `P` containing **duplicate `(row, col)` entries**,
+  the PSD guard reconstructed the Hessian by *assignment* (last duplicate
+  wins) while the solver *sums* them, per the COO convention. The guard
+  therefore validated a matrix that was never solved: an indefinite `P` passed
+  `check_psd=True` and `solve_qp` returned `status="optimal"` at a saddle
+  point. `coo_matrix(([2, 2, 1.5, 1.5], ([0, 1, 1, 1], [0, 1, 0, 0])))` is
+  indefinite when summed (eigenvalues `[-1, 5]`) but positive definite under
+  overwrite (`[0.5, 3.5]`); the identical **dense** matrix was always rejected
+  correctly.
+- Duplicate entries now accumulate, so sparse and dense inputs reach the same
+  verdict. The mirror write is skipped on the diagonal so a duplicated
+  diagonal entry is not counted twice.
+
 ### Fixed — constraint dual sign convention (#271, #272)
 
 - **`.sol` / Pyomo `model.dual`** carried pounce's internal Lagrange

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -254,11 +254,25 @@ _PSD_CHECK_AUTO_MAX_N = 1500
 
 def _min_eig_lower_coo(pr, pc, pv, n: int) -> float:
     """Smallest eigenvalue of the symmetric Hessian reconstructed from its
-    lower-triangle COO — i.e. exactly the matrix the solver sees."""
+    lower-triangle COO — i.e. exactly the matrix the solver sees.
+
+    Duplicate ``(row, col)`` entries **accumulate**, matching both the COO
+    convention and what the solver does with them. Assigning instead of
+    accumulating (last-duplicate-wins) made this guard validate a different
+    matrix than the one being solved: ``coo_matrix(([2, 2, 1.5, 1.5],
+    ([0, 1, 1, 1], [0, 1, 0, 0])))`` is indefinite once summed
+    (eigenvalues ``[-1, 5]``) but positive definite under overwrite
+    (``[0.5, 3.5]``), so an indefinite ``P`` sailed past ``check_psd`` and
+    ``solve_qp`` returned ``status="optimal"`` at a saddle point. See gh #279.
+
+    The diagonal is written once per entry — accumulating into both
+    ``(ri, ci)`` and ``(ci, ri)`` would double it when ``ri == ci``.
+    """
     M = np.zeros((n, n), dtype=np.float64)
     for ri, ci, vi in zip(pr, pc, pv):
-        M[ri, ci] = vi
-        M[ci, ri] = vi
+        M[ri, ci] += vi
+        if ri != ci:
+            M[ci, ri] += vi
     return float(np.linalg.eigvalsh(M)[0]) if n else 0.0
 
 

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -201,3 +201,85 @@ def test_psd_p_still_solves_on_all_entry_points():
     QpFactorization(P=P, c=_C2, lb=_LB, ub=_UB)  # constructs, no raise
     s = QpSensitivity(P=P, c=_C2, A=[[1.0, 1.0]], b=[2.0])
     np.testing.assert_allclose(s.x, [1.0, 1.0], atol=1e-6)
+
+
+# --- gh #279: duplicate COO entries must be summed by the PSD guard ------
+
+
+def _dup_indefinite_coo():
+    """P whose PSD-ness depends on the duplicate convention.
+
+    Entries (1,0) appear twice at 1.5 each. Under the COO **sum** convention
+    — which is what scipy documents and what the solver applies — the
+    symmetric matrix is [[2, 3], [3, 2]], eigenvalues [-1, 5]: indefinite.
+    Under last-duplicate-wins it would be [[2, 1.5], [1.5, 2]], eigenvalues
+    [0.5, 3.5]: positive definite.
+    """
+    from scipy.sparse import coo_matrix
+
+    return coo_matrix(
+        ([2.0, 2.0, 1.5, 1.5], ([0, 1, 1, 1], [0, 1, 0, 0])), shape=(2, 2)
+    )
+
+
+def test_check_psd_sums_duplicate_coo_entries():
+    """The guard must validate the matrix the solver actually solves.
+
+    Before #279 ``_min_eig_lower_coo`` assigned rather than accumulated, so
+    it validated a *different* matrix: this indefinite P passed the guard and
+    ``solve_qp`` returned ``status="optimal"`` at a saddle point with
+    objective ~0, while the true minimum over the box is -100.
+    """
+    P = _dup_indefinite_coo()
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        solve_qp(
+            P=P,
+            c=np.zeros(2),
+            lb=np.full(2, -10.0),
+            ub=np.full(2, 10.0),
+            check_psd=True,
+        )
+
+
+def test_check_psd_duplicate_coo_matches_dense_verdict():
+    """Sparse-with-duplicates and its dense equivalent must agree.
+
+    The dense form of the same matrix was always rejected correctly; the
+    sparse form was not. Same mathematical input, same verdict.
+    """
+    P = _dup_indefinite_coo()
+    dense = P.toarray()
+    dense = np.tril(dense) + np.tril(dense, -1).T  # solver's lower-triangle read
+
+    for form in (P, dense):
+        with pytest.raises(ValueError, match="positive semidefinite"):
+            solve_qp(
+                P=form,
+                c=np.zeros(2),
+                lb=np.full(2, -10.0),
+                ub=np.full(2, 10.0),
+                check_psd=True,
+            )
+
+
+def test_check_psd_does_not_double_count_duplicate_diagonal():
+    """Accumulating must not double the diagonal.
+
+    The mirror write ``M[ci, ri]`` has to be skipped when ``ri == ci``, or a
+    diagonal entry is counted twice — which would inflate the spectrum and
+    could mask a genuine indefiniteness. Here two 1.0 entries on (0,0) sum to
+    2.0, so the solve is ``min x0^2 - 2 x0 + 0.25 x1^2 - x1`` with optimum
+    (1, 2); a doubled diagonal would move it to (0.5, 2).
+    """
+    from scipy.sparse import coo_matrix
+
+    P = coo_matrix(([1.0, 1.0, 0.5], ([0, 0, 1], [0, 0, 1])), shape=(2, 2))
+    r = solve_qp(
+        P=P,
+        c=np.array([-2.0, -1.0]),
+        lb=np.full(2, -10.0),
+        ub=np.full(2, 10.0),
+        check_psd=True,
+    )
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, [1.0, 2.0], atol=1e-6)


### PR DESCRIPTION
Fixes #279.

## The defect

`_min_eig_lower_coo` rebuilt the Hessian with `M[ri, ci] = vi` — last-duplicate-wins — while the solver **accumulates** duplicate `(row, col)` entries, which is the COO convention and what scipy documents. The PSD guard therefore validated a matrix that was never solved.

```python
P = coo_matrix(([2, 2, 1.5, 1.5], ([0, 1, 1, 1], [0, 1, 0, 0])))
```

| convention | symmetric matrix | eigenvalues | verdict |
|---|---|---|---|
| **sum** (what the solver does) | `[[2, 3], [3, 2]]` | `[-1, 5]` | indefinite |
| overwrite (what the guard did) | `[[2, 1.5], [1.5, 2]]` | `[0.5, 3.5]` | positive definite |

So this `P` passed `check_psd=True` and `solve_qp` returned `status="optimal"` at a saddle point with objective `~0` — while the true minimum over `[-10, 10]²` is `-100`.

The identical **dense** matrix was always rejected correctly, so the two input forms disagreed about the same mathematical problem.

The function's own docstring claimed it built "exactly the matrix the solver sees". That was the false premise.

## The fix

Entries accumulate. The mirror write into `(ci, ri)` is skipped when `ri == ci` — accumulating into both halves would double a diagonal entry, inflating the spectrum and potentially masking a genuine indefiniteness.

```python
for ri, ci, vi in zip(pr, pc, pv):
    M[ri, ci] += vi
    if ri != ci:
        M[ci, ri] += vi
```

## Tests

Three regression tests in `test_qp_host.py`:

- the indefinite-when-summed matrix is now rejected
- sparse and dense forms of it reach the **same** verdict (the asymmetry was the tell)
- a `P` whose diagonal is built from duplicate entries still solves to the correct optimum `(1, 2)` — pinning the double-counting guard, since a doubled diagonal would move it to `(0.5, 2)`

688 Python tests pass.

## Scope

This is guard-only: it does not change what the solver computes for any input, only which inputs it refuses. The blast radius is matrices with duplicate COO entries whose PSD-ness depends on the convention — previously silently mis-solved, now correctly rejected. A caller who genuinely wants nonconvex behavior still has `check_psd=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
