### PR TITLE
Scale the recession residual by ||P|| in the unboundedness certificate (#273)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — strictly convex QP falsely reported unbounded (#273)
+
+- The convex IPM's dual-infeasibility (unboundedness) certificate tested
+  `‖Pd‖ ≤ rtol·‖d‖` for the candidate recession direction `d`. Because `‖Pd‖`
+  is itself proportional to `‖P‖·‖d‖`, the `‖d‖` cancelled and the test
+  collapsed to `‖P‖ ≤ rtol` — a bare comparison of the Hessian's magnitude
+  against the absolute constant `1e-10`, with no reference to `d` at all.
+- Consequence: **any** strictly convex QP with a small enough Hessian was
+  certified unbounded despite having a finite minimizer. `min -x + x²/(2M)
+  s.t. x >= 0` (unique minimum `x* = M`) was reported unbounded for every
+  `M >= 1e10`, terminating after 2 iterations twelve orders of magnitude short
+  of the optimum, on a problem Ipopt and pounce's own NLP path both solve
+  exactly.
+- The residual bound is now scaled by `‖P‖`, restoring the intended meaning:
+  a relative test for `d ∈ null(P)`. LPs (`P` empty, `Pd` exactly zero) and
+  genuinely singular Hessians with `d` in the nullspace are unaffected, so
+  real unboundedness is still detected.
+
 ### Fixed — constraint dual sign convention (#271, #272)
 
 - **`.sol` / Pyomo `model.dual`** carried pounce's internal Lagrange

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -2537,8 +2537,32 @@ pub(crate) fn detect_infeasibility_with(
         // SOC/PSD ⇒ true cone membership). Checked, not componentwise, so a
         // direction that merely has `Gd ≤ 0` but `−Gd ∉ K` is rejected.
         let gd_ok = primal_recession_ok(&gd, ctol * x_norm);
+        // `d` is a recession direction of the *quadratic* only if `Pd = 0`,
+        // i.e. `d ∈ null(P)`. Testing `‖Pd‖ ≤ rtol·‖d‖` cannot express that:
+        // `‖Pd‖` is itself proportional to `‖P‖·‖d‖`, so `‖d‖` cancels and the
+        // test collapses to `‖P‖ ≤ rtol` — a bare comparison of the Hessian's
+        // magnitude against an absolute constant, with no reference to `d` at
+        // all. Every strictly convex QP whose Hessian happens to be smaller
+        // than `rtol` then reads as unbounded regardless of having a finite
+        // minimizer: `min -x + x²/(2M)  s.t.  x ≥ 0` (unique minimum at
+        // `x* = M`) was reported unbounded for `M ≥ 1e10`, i.e. exactly when
+        // `P = 1/M` crossed `FARKAS_RESID_TOL`. See gh #273.
+        //
+        // Scaling the bound by `‖P‖` restores the intended meaning — a
+        // *relative* residual, "is `d` in the nullspace of `P` to `rtol`
+        // relative to `P`'s own scale". Both sides then carry the same
+        // `‖P‖·‖d‖` units and nothing cancels.
+        //
+        // For an LP (`P` empty) `p_scale` is 0 and `pd` is exactly 0, so the
+        // test reads `0 ≤ 0` and genuine LP unboundedness is unaffected. For a
+        // genuinely singular `P` with `d ∈ null(P)`, `pd` is 0 to round-off —
+        // on the order of `ε·‖P‖·‖d‖`, comfortably inside `rtol·‖P‖·‖d‖`.
+        let p_scale = prob
+            .p_lower
+            .iter()
+            .fold(0.0_f64, |acc, t| acc.max(t.val.abs()));
         if cd < -ctol * x_norm
-            && inf_norm(&pd) <= rtol * x_norm
+            && inf_norm(&pd) <= rtol * x_norm * p_scale
             && inf_norm(&ad) <= rtol * x_norm
             && gd_ok
         {
@@ -2581,6 +2605,103 @@ mod detect_infeasibility_tests {
             lb: vec![],
             ub: vec![],
         }
+    }
+
+    /// gh #273 — a strictly convex QP must never be certified unbounded just
+    /// because its Hessian is numerically small.
+    ///
+    /// `min -x + x²/(2M)  s.t.  x ≥ 0` has the unique minimum `x* = M`,
+    /// `f* = -M/2`, for every finite `M > 0`. The old recession test compared
+    /// `‖Pd‖ ≤ rtol·‖d‖`; since `‖Pd‖ = ‖P‖·‖d‖` for a scalar `P`, `‖d‖`
+    /// cancelled and the test reduced to `‖P‖ ≤ rtol`. So every `M ≥ 1/rtol`
+    /// (i.e. `P ≤ 1e-10`) read as unbounded. The bound is now scaled by `‖P‖`,
+    /// making it a genuine relative nullspace test.
+    #[test]
+    fn tiny_hessian_is_not_a_recession_direction() {
+        let opts = QpOptions::default();
+        let y: [f64; 0] = [];
+        let z: [f64; 0] = [];
+        // P far below FARKAS_RESID_TOL (1e-10) in every case.
+        for p_val in [1e-10, 1e-12, 1e-16] {
+            let prob = QpProblem {
+                n: 1,
+                p_lower: vec![Triplet::new(0, 0, p_val)],
+                c: vec![-1.0],
+                a: vec![],
+                b: vec![],
+                g: vec![],
+                h: vec![],
+                lb: vec![0.0],
+                ub: vec![f64::INFINITY],
+            };
+            let x = [1.0]; // candidate recession direction
+            assert_eq!(
+                detect_infeasibility(&prob, &x, &y, &z, &opts),
+                None,
+                "P = {p_val:e} is strictly positive, so d = 1 is NOT a recession \
+                 direction and the QP is bounded below; certifying unboundedness \
+                 here returns a wrong answer for a problem with a finite optimum"
+            );
+        }
+    }
+
+    /// The complement of the test above: a genuinely singular `P` with the
+    /// direction lying in its nullspace must still certify unboundedness, so
+    /// the #273 fix introduces no false negative.
+    ///
+    /// `min ½x₀² - x₁  s.t.  x ≥ 0` with `P = diag(1, 0)`: `d = (0, 1)` has
+    /// `Pd = 0` exactly and `cᵀd = -1 < 0`.
+    #[test]
+    fn singular_hessian_nullspace_direction_is_still_dual_infeasible() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 1.0)], // P = diag(1, 0)
+            c: vec![0.0, -1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![0.0, 0.0],
+            ub: vec![f64::INFINITY, f64::INFINITY],
+        };
+        let opts = QpOptions::default();
+        let x = [0.0, 1.0]; // in null(P)
+        let y: [f64; 0] = [];
+        let z: [f64; 0] = [];
+        assert_eq!(
+            detect_infeasibility(&prob, &x, &y, &z, &opts),
+            Some(QpStatus::DualInfeasible),
+            "d = (0,1) is exactly in null(P) with c'd < 0 — a genuine recession \
+             ray that must still be detected"
+        );
+    }
+
+    /// An LP (`P` empty, so `p_scale = 0`) must be unaffected: `Pd` is exactly
+    /// zero, so the scaled bound reads `0 ≤ 0` and genuine LP unboundedness is
+    /// still certified.
+    #[test]
+    fn empty_hessian_lp_unboundedness_unaffected() {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![-1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![0.0],
+            ub: vec![f64::INFINITY],
+        };
+        let opts = QpOptions::default();
+        let x = [1.0];
+        let y: [f64; 0] = [];
+        let z: [f64; 0] = [];
+        assert_eq!(
+            detect_infeasibility(&prob, &x, &y, &z, &opts),
+            Some(QpStatus::DualInfeasible),
+            "an LP with no Hessian is unbounded along d = 1; p_scale = 0 must \
+             not break this"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #273.

## The defect

The convex IPM's dual-infeasibility (unboundedness) certificate tested whether the candidate recession direction `d` satisfies

```rust
inf_norm(&pd) <= rtol * x_norm     // ‖Pd‖ ≤ rtol·‖d‖
```

Because `‖Pd‖` is itself proportional to `‖P‖·‖d‖`, the `‖d‖` **cancels** and the test collapses to `‖P‖ ≤ rtol` — a bare comparison of the Hessian's magnitude against the absolute constant `FARKAS_RESID_TOL = 1e-10`, with no reference to `d` at all.

So **any** strictly convex QP whose Hessian is smaller than that constant read as unbounded, regardless of having a finite minimizer:

`min -x + x²/(2M) s.t. x ≥ 0` has the unique minimum `x* = M`, `f* = -M/2` for every finite `M`.

| M | P = 1/M | before | after |
|---|---|---|---|
| 1e8 | 1e-8 | `-5.0e7` ✓ | `-5.0e7` ✓ |
| 1e10 | 1e-10 | **unbounded** (obj `-399`, 2 iters) | `-5.0e9` ✓ |
| 1e12 | 1e-12 | **unbounded** (obj `-399`, 2 iters) | `-5.0e11` ✓ |
| 1e14 | 1e-14 | **unbounded** | `-5.0e13` ✓ |

The threshold sits exactly where `P` crosses `1e-10`, as the cancellation predicts. Ipopt, pounce's own NLP path, and Clarabel/SCS/OSQP all solve these exactly.

Note this is **not** a routing bug — the problem is correctly classified as a convex QP. The false certificate comes from the IPM itself.

## The fix

`d` is a recession direction of the quadratic only if `Pd = 0`, i.e. `d ∈ null(P)`. Expressing that requires a *relative* residual, so the bound is scaled by `‖P‖`:

```rust
inf_norm(&pd) <= rtol * x_norm * p_scale
```

Both sides now carry the same `‖P‖·‖d‖` units and nothing cancels.

Unaffected in both limiting directions (each pinned by a new test):

- **LP** (`P` empty): `p_scale = 0` and `Pd` is exactly `0`, so the test reads `0 ≤ 0` — genuine LP unboundedness still certified.
- **Genuinely singular `P`** with `d ∈ null(P)`: `Pd` is zero to round-off, `~ε·‖P‖·‖d‖`, comfortably inside `rtol·‖P‖·‖d‖`.

## Known remaining limitation (not introduced here)

`p_scale` is a single global magnitude, so a **mixed-scale** Hessian can still misreport. `P = diag(1e6, 1e-12)` with descent along the tiny block returns `dual_infeasible` even though the problem is bounded (`x₁* = 1e12`).

I verified this case explicitly rather than assuming: it fails identically **before and after** this change, so the fix is a strict improvement and not a regression. Distinguishing "bounded with an optimum at 1e12" from "unbounded" when the curvature in the descent direction is 18 orders below the largest is genuinely ambiguous under any relative criterion — it's a tolerance question, not a bug with a clean answer. Happy to file it as a separate issue if you'd like it tracked.

## Regression evidence

This changes a termination certificate in the convex IPM, so I built before/after binaries and ran **every `.nl` in `benchmarks/` (44 problems)** through both: **all 44 return a byte-identical `solve_result_num`.**

Also: 142 Rust suites pass, including the full `pounce-convex` suite.

## Tests

Three in `ipm::detect_infeasibility_tests`:

- `tiny_hessian_is_not_a_recession_direction` — `P ∈ {1e-10, 1e-12, 1e-16}` must all return `None` (bounded)
- `singular_hessian_nullspace_direction_is_still_dual_infeasible` — no false negative
- `empty_hessian_lp_unboundedness_unaffected` — the `p_scale = 0` edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
