### PR TITLE
Reject non-finite inputs that silently reported success (#275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — non-finite inputs silently reported success (#275)
+
+- **`lb = +inf` / `ub = -inf` were dropped as if the bound were absent.** The
+  solver's presence test (`lb > -BOUND_INF`, `ub < BOUND_INF`) is
+  sign-agnostic, so a bound no finite value can satisfy was discarded and
+  `solve_qp` returned `status="optimal"` at a point violating it by an
+  infinite margin. `solve_qp` / `solve_qp_batch` / `solve_qp_multi_rhs` and
+  `minimize` now reject these spellings with a message naming the index.
+  `±inf` on the *absent* side (lower `-inf`, upper `+inf`) remains the
+  documented one-sided encoding, and a finite reversed box (`lb=1 > ub=0`) is
+  still reported as `primal_infeasible` rather than raising.
+- **A NaN or infinite `x0` reported `Solve_Succeeded` with `fun=nan` at
+  iteration 0.** Every convergence test is a comparison against a tolerance
+  and comparisons against NaN are False — including the ones that would have
+  rejected the iterate — so the loop fell through to "converged". `minimize`
+  now rejects a non-finite `x0`.
+
 ### Fixed — `check_psd` validated a different matrix than the solver used (#279)
 
 - With a `scipy.sparse` COO `P` containing **duplicate `(row, col)` entries**,

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -383,6 +383,25 @@ def _normalize_bounds(bounds, n: int):
             f"bounds[{i}] is reversed: lower {lb[i]} > upper {ub[i]}; "
             f"each bound must be (low, high) with low <= high"
         )
+    # ±inf is legal as the *absent* side of a bound (lower = -inf, upper =
+    # +inf), but not as the *present* side: no finite x satisfies `x >= +inf`
+    # or `x <= -inf`. The `lb > ub` test above catches the mixed spellings
+    # (e.g. lower=+inf with a finite upper) but not `lb == ub == ±inf`, where
+    # the comparison is False and the box silently admitted "any x". See
+    # gh #275.
+    for side, arr, bad_val, cmp_txt in (
+        ("lower", lb, np.inf, ">= +inf"),
+        ("upper", ub, -np.inf, "<= -inf"),
+    ):
+        bad = np.where(arr == bad_val)[0]
+        if bad.size:
+            i = int(bad[0])
+            raise ValueError(
+                f"bounds[{i}] has {side} bound {arr[i]}, which no finite value "
+                f"can satisfy (it requires x[{i}] {cmp_txt}). Use "
+                f"{'-inf' if side == 'lower' else '+inf'} (or None in the "
+                f"pair-list form) to leave the {side} side unbounded"
+            )
     return lb, ub
 
 
@@ -993,6 +1012,26 @@ def minimize(
     # Promote a scalar / 0-d x0 to 1-D, matching scipy.optimize.minimize, so a
     # single-variable problem can be written ``minimize(f, 1.5)``.
     x0 = np.atleast_1d(_to_array(x0))
+    # A non-finite starting point must never reach the solver. Every
+    # convergence test is a comparison against a tolerance, and comparisons
+    # against NaN are False -- including the ones that would have rejected the
+    # iterate. The loop therefore fell straight through to "converged" at
+    # iteration zero and returned `success=True, status=0,
+    # message="Solve_Succeeded", fun=nan, nit=0`, which is the most dangerous
+    # possible response: a caller checking `success` is told the solve worked.
+    # Reproduced with analytic `jac`, with finite-difference gradients, with
+    # equality constraints, and on forced `solver_selection="nlp"`; it was
+    # masked only when `bounds` were supplied, because clipping repaired x0.
+    # See gh #275.
+    bad = np.where(~np.isfinite(x0))[0]
+    if bad.size:
+        i = int(bad[0])
+        raise ValueError(
+            f"x0[{i}] is {x0[i]}; the starting point must be finite. "
+            f"(A non-finite x0 silently defeats the convergence test -- every "
+            f"comparison against NaN is False -- so the solve would report "
+            f"success at iteration 0 with a NaN objective.)"
+        )
     n = x0.size
     lb, ub = _normalize_bounds(bounds, n)
     m, g_combined, jac_combined, cl, cu, jac_rows, jac_cols = _wrap_constraints(

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -375,6 +375,32 @@ def _validate(P, c, A, b, G, h, lb, ub, n: int) -> None:
                     f"solve_qp: `{name}` has length {vlen} but n={n} (from `c`)"
                 )
 
+    # ±inf marks an *absent* bound (lower = -inf, upper = +inf). The opposite
+    # signs are not "absent" — they are constraints no finite value can meet.
+    # The solver's presence test (`lb > -BOUND_INF`, `ub < BOUND_INF`) is
+    # sign-agnostic, so `lb = +inf` / `ub = -inf` were dropped as if unbounded
+    # and the solve returned `status="optimal"` at a point violating the stated
+    # bound by an infinite margin. Note the *finite* analogue (`lb=1 > ub=0`)
+    # is correctly reported `primal_infeasible` by the solver, so this rejects
+    # only the degenerate spellings that silently produced a wrong answer.
+    # See gh #275.
+    for name, vec, bad_val, cmp_txt in (
+        ("lb", lb, np.inf, ">= +inf"),
+        ("ub", ub, -np.inf, "<= -inf"),
+    ):
+        if vec is None:
+            continue
+        arr = np.asarray(vec, dtype=np.float64).ravel()
+        bad = np.where(arr == bad_val)[0]
+        if bad.size:
+            i = int(bad[0])
+            raise ValueError(
+                f"solve_qp: `{name}[{i}]` is {arr[i]}, which no finite value can "
+                f"satisfy (it requires x[{i}] {cmp_txt}). Use "
+                f"{'-inf' if name == 'lb' else '+inf'} to leave that side "
+                f"unbounded, or a finite value for a real bound"
+            )
+
 
 def _build(
     P,

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1482,3 +1482,58 @@ def test_uncomputed_objective_is_nan_not_zero():
     assert ok.success
     assert not np.isnan(ok.info["obj_val"])
     assert ok.info["obj_val"] == pytest.approx(0.0, abs=1e-12)
+
+
+# --- gh #275: non-finite inputs must not report success ------------------
+
+
+def test_minimize_rejects_nonfinite_x0():
+    """A NaN/inf x0 must raise, not report a successful solve.
+
+    Every convergence test is a comparison against a tolerance, and
+    comparisons against NaN are False — including the ones that would have
+    rejected the iterate. Before #275 the loop fell straight through to
+    "converged" at iteration zero and returned ``success=True, status=0,
+    message="Solve_Succeeded", fun=nan, nit=0``.
+    """
+    f = lambda x: float(x @ x)
+    g = lambda x: 2.0 * x
+
+    for bad in (np.nan, np.inf, -np.inf):
+        with pytest.raises(ValueError, match=r"x0\[0\] is .*must be finite"):
+            pounce.minimize(f, np.array([bad, 1.0]), jac=g)
+
+    # A non-first bad entry is reported at its own index.
+    with pytest.raises(ValueError, match=r"x0\[1\] is nan"):
+        pounce.minimize(f, np.array([1.0, np.nan]), jac=g)
+
+
+def test_minimize_rejects_bounds_no_finite_value_can_satisfy():
+    """``lb = +inf`` / ``ub = -inf`` admit no finite point.
+
+    ``lb > ub`` catches the mixed spellings (``lower=+inf`` with a finite
+    upper) but not ``lb == ub == ±inf``, where the comparison is False — so
+    that box silently admitted any x.
+    """
+    f = lambda x: float(x @ x)
+    g = lambda x: 2.0 * x
+
+    with pytest.raises(ValueError, match=r"bounds\[0\] has lower bound inf"):
+        pounce.minimize(f, np.array([0.5]), jac=g, bounds=[(np.inf, np.inf)])
+
+    with pytest.raises(ValueError, match=r"bounds\[0\] has upper bound -inf"):
+        pounce.minimize(f, np.array([0.5]), jac=g, bounds=[(-np.inf, -np.inf)])
+
+
+def test_minimize_still_accepts_legitimate_infinite_bounds():
+    """±inf on the *absent* side stays legal — that is the one-sided encoding."""
+    f = lambda x: float((x[0] - 3.0) ** 2)
+    g = lambda x: np.array([2.0 * (x[0] - 3.0)])
+
+    r = pounce.minimize(f, np.array([0.5]), jac=g, bounds=[(-np.inf, np.inf)])
+    assert r.success
+    assert r.x[0] == pytest.approx(3.0, abs=1e-6)
+
+    r2 = pounce.minimize(f, np.array([0.5]), jac=g, bounds=[(0.0, np.inf)])
+    assert r2.success
+    assert r2.x[0] == pytest.approx(3.0, abs=1e-6)

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -283,3 +283,56 @@ def test_check_psd_does_not_double_count_duplicate_diagonal():
     )
     assert r.status == "optimal"
     np.testing.assert_allclose(r.x, [1.0, 2.0], atol=1e-6)
+
+
+# --- gh #275: sign-aware infinite bounds ---------------------------------
+
+
+def test_solve_qp_rejects_bounds_no_finite_value_can_satisfy():
+    """``lb = +inf`` / ``ub = -inf`` are constraints, not "absent" bounds.
+
+    The solver's presence test (``lb > -BOUND_INF``, ``ub < BOUND_INF``) is
+    sign-agnostic, so these were dropped as if unbounded and the solve
+    returned ``status="optimal"`` at a point violating the stated bound by an
+    infinite margin.
+    """
+    for lb, ub, pat in (
+        ([np.inf], [np.inf], r"`lb\[0\]` is inf"),
+        ([np.inf], [5.0], r"`lb\[0\]` is inf"),
+        ([-np.inf], [-np.inf], r"`ub\[0\]` is -inf"),
+        ([-5.0], [-np.inf], r"`ub\[0\]` is -inf"),
+    ):
+        with pytest.raises(ValueError, match=pat):
+            solve_qp(
+                P=np.eye(1), c=np.zeros(1), lb=np.array(lb), ub=np.array(ub)
+            )
+
+
+def test_solve_qp_still_accepts_legitimate_infinite_bounds():
+    """±inf on the absent side is the documented one-sided encoding."""
+    r = solve_qp(
+        P=np.eye(1),
+        c=np.array([-3.0]),
+        lb=np.array([-np.inf]),
+        ub=np.array([np.inf]),
+    )
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, [3.0], atol=1e-6)
+
+
+def test_solve_qp_finite_reversed_bounds_still_report_infeasible():
+    """Unchanged: a finite reversed box is a *status*, not an exception.
+
+    Only the degenerate infinite spellings — which previously produced a
+    silently wrong "optimal" — are rejected up front.
+    """
+    r = solve_qp(P=np.eye(1), c=np.zeros(1), lb=np.array([1.0]), ub=np.array([0.0]))
+    assert r.status == "primal_infeasible"
+
+
+def test_solve_qp_batch_inherits_the_bound_guard():
+    with pytest.raises(ValueError, match=r"`lb\[0\]` is inf"):
+        solve_qp_batch(
+            [{"P": np.eye(1), "c": np.zeros(1), "lb": np.array([np.inf]),
+              "ub": np.array([np.inf])}]
+        )


### PR DESCRIPTION
Fixes #275.

Two input paths returned a confident wrong answer on malformed input.

## 1. Sign-agnostic infinite bounds

The solver's bound-presence test is `lb > -BOUND_INF` / `ub < BOUND_INF` — it doesn't look at the sign. So `lb = +inf` and `ub = -inf`, which are constraints *no finite value can meet*, were dropped as if the bound were absent, and `solve_qp` returned `status="optimal"` at a point violating the stated bound by an infinite margin.

pounce contradicted itself two ways:

| case | `solve_qp` before | `minimize` before |
|---|---|---|
| `lb=1 > ub=0` (finite) | `primal_infeasible` ✓ | `ValueError` ✓ |
| `lb=+inf, ub=5` | **`optimal`** ✗ | `ValueError` ✓ |
| `lb=ub=+inf` | **`optimal`** ✗ | **`success=True`** ✗ |
| `lb=ub=-inf` | **`optimal`** ✗ | **`success=True`** ✗ |
| `lb=-5, ub=-inf` | **`optimal`** ✗ | `ValueError` ✓ |

`minimize`'s `lb > ub` test catches the *mixed* spellings but not `lb == ub == ±inf`, where the comparison is False.

Both surfaces now reject any bound admitting no finite point, naming the index. **Deliberately unchanged:** `±inf` on the *absent* side stays legal (it's the one-sided encoding), and a finite reversed box keeps returning `primal_infeasible` rather than raising — only the degenerate spellings that previously produced a wrong `"optimal"` are rejected. `solve_qp_batch` and `solve_qp_multi_rhs` inherit the guard.

## 2. Non-finite `x0`

```
minimize(f, np.array([np.nan]), jac=g)
  -> success=True, status=0, message="Solve_Succeeded", fun=nan, nit=0
```

Every convergence test compares against a tolerance, and comparisons against NaN are False — including the ones that would have *rejected* the iterate. So the loop fell straight through to "converged" at iteration zero.

Reproduced with analytic `jac`, with finite-difference gradients, with equality constraints, and on forced `solver_selection="nlp"`; masked only when `bounds` were supplied, because clipping repaired `x0`. `minimize` now requires a finite `x0`.

## Not fixed here — filed separately

A NaN **gradient** still reports `Solve_Succeeded`, and with a *finite* `fun` (the value at `x0`), so the caller gets no signal at all.

I traced it, and the root cause is different from either fix above: the max-reduction behind the dual-infeasibility norm **drops NaN**. `compound_vector.rs:235` uses `if v > m`, which is False for NaN, and the dense path uses BLAS `iamax`. Confirmed end-to-end — with a NaN gradient the solver prints:

```
Dual infeasibility......:   0.0000000000000000e+00
Overall NLP error.......:   0.0000000000000000e+00
EXIT: Optimal Solution Found.
```

So the existing `!nlp_err.is_finite()` guard never fires, because the value it checks was laundered to `0.0` upstream. Correcting the reduction touches every consumer of `amax` — step sizes, convergence, line search — and is not a change I'd make during release prep without a dedicated regression pass. Filed as its own issue with the root cause recorded.

## Tests

Seven new tests. Beyond the rejections, they pin the things that must **not** change: legitimate one-sided `±inf` bounds still solve, finite reversed boxes still report `primal_infeasible` rather than raising, and the batch entry points inherit the guard.

695 Python tests and 101 pyomo-pounce tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
