### PR TITLE
Reject out-of-range integer options instead of silently truncating (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — integer options above `i32::MAX` silently truncated (#276)
+
+- **`Problem.add_option` / `minimize(...)` wrapped out-of-range integer
+  options instead of rejecting them.** The PyO3 binding converted an
+  extracted `i64` with a bare `i as Index` (`Index = i32`) cast, which
+  *wraps* rather than checks. So `max_iter = 2**32 + 3` silently truncated to
+  `3` and ran exactly three iterations with no error or warning, while the CLI
+  and Pyomo plugin rejected the same input — the surfaces disagreed. The cast
+  is now a checked `i32::try_from`, so any integer option (`max_iter`,
+  `acceptable_iter`, `print_level`, `max_soc`, … all share this one path)
+  outside the signed-32-bit range raises a clear `ValueError` naming the
+  option and quoting the value the user actually passed (not the truncated
+  one). In-range values — including the `i32::MIN`/`i32::MAX` boundaries and
+  legitimate negatives — still work unchanged.
+
 ### Fixed — non-finite inputs silently reported success (#275)
 
 - **`lb = +inf` / `ub = -inf` were dropped as if the bound were absent.** The

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -176,7 +176,21 @@ impl PyProblem {
             }
         }
         if let Ok(i) = value.extract::<i64>() {
-            self.int_opts.push((name.to_string(), i as Index));
+            // Convert with a checked cast: a bare `i as Index` silently
+            // *wraps* values outside the signed-32-bit range, so e.g.
+            // `max_iter = 2**32 + 3` would truncate to `3` and run without
+            // complaint (pounce#276). Reject out-of-range integers instead,
+            // quoting the value the *user* passed (not the truncated one),
+            // matching how the CLI / Pyomo surfaces reject the same input.
+            let converted = Index::try_from(i).map_err(|_| {
+                PyValueError::new_err(format!(
+                    "add_option({name}): integer value {i} is out of range for \
+                     this option (must be between {} and {})",
+                    Index::MIN,
+                    Index::MAX
+                ))
+            })?;
+            self.int_opts.push((name.to_string(), converted));
             return Ok(());
         }
         if let Ok(f) = value.extract::<f64>() {

--- a/python/tests/test_problem.py
+++ b/python/tests/test_problem.py
@@ -479,3 +479,64 @@ def test_negative_obj_scaling_factor_maximizes():
     np.testing.assert_allclose(x, [1.0], atol=1e-6)
     # The reported objective is the user's (unscaled) value at the max.
     np.testing.assert_allclose(info["obj_val"], 0.0, atol=1e-8)
+
+
+# --------------------------------------------------------------------------
+# issue #276 — integer options outside the signed-32-bit Index range were
+# silently *wrapped* by an `i as i32` cast, so e.g. `max_iter = 2**32 + 3`
+# quietly ran 3 iterations instead of erroring. They must now raise, quoting
+# the value the user passed and naming the option, matching the CLI / Pyomo.
+# --------------------------------------------------------------------------
+def _quad2():
+    class Quad:
+        def objective(self, x):
+            return float(x @ x)
+
+        def gradient(self, x):
+            return 2.0 * x
+
+    return pounce.Problem(n=2, m=0, problem_obj=Quad())
+
+
+@pytest.mark.parametrize("bad", [2**31, 2**32 + 3, 2**32 + 1, 10**12, -(2**31) - 1])
+def test_add_option_integer_out_of_range_rejected(bad):
+    """Over-range integer options raise instead of silently truncating."""
+    prob = _quad2()
+    with pytest.raises(ValueError) as exc:
+        prob.add_option("max_iter", bad)
+    msg = str(exc.value)
+    # Error names the option and quotes the *user's* value, not a wrapped one.
+    assert "max_iter" in msg
+    assert str(bad) in msg
+
+
+def test_add_option_integer_out_of_range_via_minimize():
+    """The high-level minimize() surface rejects the same value the CLI does."""
+    with pytest.raises(ValueError) as exc:
+        pounce.minimize(
+            lambda x: float(x @ x),
+            np.array([1.0, 1.0]),
+            jac=lambda x: 2.0 * x,
+            max_iter=2**32 + 3,
+        )
+    msg = str(exc.value)
+    assert "max_iter" in msg
+    assert str(2**32 + 3) in msg
+
+
+@pytest.mark.parametrize("good", [2**31 - 1, -(2**31), 0, 5, 500])
+def test_add_option_integer_in_range_accepted(good):
+    """Legitimate in-range integers (incl. i32::MIN/MAX boundaries) still work."""
+    prob = _quad2()
+    # Must not raise; boundary values i32::MAX and i32::MIN are valid.
+    prob.add_option("max_iter", good)
+
+
+def test_add_option_large_but_in_range_solves():
+    """A large-but-in-range max_iter still drives a real solve."""
+    prob = _quad2()
+    prob.add_option("max_iter", 2**31 - 1)
+    prob.add_option("print_level", 0)
+    x, info = prob.solve(x0=np.array([1.0, 1.0]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(x, [0.0, 0.0], atol=1e-6)


### PR DESCRIPTION
Fixes #276.

## Root cause

`crates/pounce-py/src/problem.rs:179` converted an extracted `i64` option
value with a bare `i as Index` cast (`Index = i32`, defined in
`crates/pounce-common/src/types.rs`). A `as` cast between integer types
**wraps**, it does not check — so any integer option above `i32::MAX` was
silently truncated modulo 2^32 and applied without any error or warning.

All integer options funnel through this single `add_option` path
(`max_iter`, `acceptable_iter`, `print_level`, `max_soc`, etc.), so every one
of them shared the bug — fixing the one cast fixes them all consistently.

## Before / after

Before:
```python
r = pounce.minimize(lambda x: float(x@x), np.array([1.0,1.0]),
                    jac=lambda x: 2*x, max_iter=2**32+3)
print(r.nit)  # -> 3, silently (truncated)
```
`2**32+1` ran 1 iter, `2**33+7` ran 7, `10**12` was rejected but the message
quoted the truncated value `-727379968` the caller never typed.

After — a clear `ValueError` naming the option and quoting the user's value:
```
ValueError: add_option(max_iter): integer value 4294967299 is out of range
for this option (must be between -2147483648 and 2147483647)
```
This now matches the CLI/Pyomo surfaces, which already reject the same input
(the CLI parses option strings directly as `i32` in
`crates/pounce-common/src/options_list.rs:461`).

## The fix

Replace `i as Index` with a checked `Index::try_from(i)`, returning a
`PyValueError` that names the option and quotes `i` (the user's original
value, not the wrapped one) plus the valid `i32::MIN..=i32::MAX` range.

## Edge cases covered

- Exactly `i32::MAX` (`2**31 - 1`) and `i32::MIN` (`-(2**31)`): accepted.
- `i32::MAX + 1` (`2**31`), `2**32+1`, `2**32+3`, `10**12`: rejected.
- `-(2**31) - 1` (just below `i32::MIN`): rejected.
- Legitimate negatives within range (e.g. `-1`), `0`, small ints: accepted.
- Non-integer floats where an int is expected still route to the numeric
  path and are rejected downstream — not regressed (bool-before-int ordering
  is also preserved).

Out of scope (per the issue): `solve_qp` `tol`/negative-int handling is #277.

## Other integer options audited

Confirmed every integer option reaches `int_opts` through the same
`add_option` extraction (`crates/pounce-py/src/problem.rs`), so `max_iter`,
`acceptable_iter`, `print_level`, `max_soc`, and any other `OT_Integer`
option are all covered by the single checked conversion.

## Validation

- Rebuilt the extension: `cd python && maturin develop --release`, confirmed
  the repro now raises the clear error above.
- New Python tests in `python/tests/test_problem.py`:
  `test_add_option_integer_out_of_range_rejected` (parametrized over-range
  values, asserts option name + user's value in message),
  `test_add_option_integer_out_of_range_via_minimize` (high-level surface),
  `test_add_option_integer_in_range_accepted` (i32 boundaries + negatives),
  `test_add_option_large_but_in_range_solves` (large in-range value still
  drives a real solve).
- Suites run green: `pytest python/tests/test_problem.py` (34 passed),
  `pytest python/tests/test_minimize.py` (62 passed),
  `cargo test -p pounce-py --release`, `cargo test -p pounce-cli --release`
  (all passed). `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
