### PR TITLE
Validate tol/max_iter on all convex entry points (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — convex `tol` / `max_iter` options were unvalidated (#277)
+
+- **`solve_qp` / `solve_socp` (and the batch, multi-RHS, factorization, and
+  sensitivity entry points) applied no validation to `tol`,** while every
+  other pounce surface (`minimize`, the CLI, `sos_minimize`) rejects a
+  non-positive or non-finite tolerance with `OPTION_INVALID`. Consequences: an
+  unsatisfiable `tol` (`0`, `-1`, `NaN`, `Inf`) silently burned every
+  iteration, and a huge finite `tol` (`1e300`) short-circuited at the
+  interior-point *starting* iterate — the convex IPM tests `max KKT residual
+  <= tol` at every iterate, so an O(1) tolerance "passes" immediately —
+  returning `status="optimal"` after **0 iterations at a wrong point**
+  (`x=(0,0)`, `kkt_error=1.0` on the issue's repro). That mislabel propagated
+  through the facade: `minimize(solver_selection="qp-ipm", tol=1e300)` reported
+  `success=True, nit=0`. Every convex entry point now rejects `tol <= 0`,
+  non-finite `tol`, and `tol >= 1` with a clear `ValueError` naming the option
+  and value. Capping at `1.0` (rather than accepting any positive `tol`)
+  guarantees an accepted tolerance with an `"optimal"` result carries
+  `kkt_error <= tol < 1`, i.e. a genuinely near-stationary point — a wrong
+  point can never again be labeled `optimal`. A legitimate tight `tol` (e.g.
+  `1e-8`) is untouched.
+- **`solve_qp(max_iter=-5)` leaked a raw PyO3
+  `OverflowError: can't convert negative int to unsigned`** from the `usize`
+  binding. `max_iter` is now validated in Python — before it reaches the
+  binding — on every convex entry point, so a negative, zero, or non-integer
+  value raises a named `ValueError` instead.
+
 ### Fixed — integer options above `i32::MAX` silently truncated (#276)
 
 - **`Problem.add_option` / `minimize(...)` wrapped out-of-range integer

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -452,6 +452,56 @@ def _to_result(d: dict) -> QpResult:
     )
 
 
+# A convergence tolerance here bounds the max KKT residual / duality measure,
+# and the convex IPM tests it at *every* iterate — including the interior-point
+# self-dual starting point. Unlike the NLP line search (which makes progress and
+# still returns the right answer for a loose tol), the convex solver therefore
+# *short-circuits* at a non-stationary point whenever `tol` is loose enough to
+# admit the starting iterate: with `tol >= 1` the O(1) KKT residual at the start
+# already "passes", so the solve returns after 0 iterations at a wildly wrong
+# point still labeled ``status="optimal"`` (gh #277). A meaningful KKT tolerance
+# is well below 1, so reject `tol >= 1`; this guarantees that an accepted `tol`
+# with an ``"optimal"`` result carries `kkt_error <= tol < 1` — a genuinely
+# near-stationary point, never the 0-iteration wrong point. The unsatisfiable
+# `tol <= 0` / non-finite values are rejected the same way every other pounce
+# surface already does (NLP ``minimize``, the CLI, and ``sos_minimize`` all
+# raise ``OPTION_INVALID``).
+_TOL_MAX = 1.0
+
+
+def _validate_solver_opts(tol, max_iter, func: str) -> None:
+    """Validate the shared ``tol`` / ``max_iter`` options for every convex
+    entry point, matching the NLP / CLI / ``sos_minimize`` surfaces (which all
+    reject ``tol <= 0`` and non-finite ``tol`` and a non-positive iteration
+    count with ``OPTION_INVALID``).
+
+    Both are optional (``None`` keeps the solver default). ``max_iter`` is
+    checked here — *before* it reaches the PyO3 ``usize`` binding — so a
+    negative value raises a clear named error instead of leaking a raw
+    ``OverflowError: can't convert negative int to unsigned`` (gh #277)."""
+    if tol is not None:
+        t = float(tol)
+        if not np.isfinite(t) or t <= 0.0 or t >= _TOL_MAX:
+            raise ValueError(
+                f"{func}: `tol` must be a finite positive number below "
+                f"{_TOL_MAX} (it bounds the KKT-residual convergence measure); "
+                f"got {tol!r}. A value <= 0, NaN, or Inf is unsatisfiable, and "
+                f"tol >= {_TOL_MAX} would accept the non-stationary starting "
+                f"iterate and return a wrong point labeled 'optimal'."
+            )
+    if max_iter is not None:
+        # bool is an int subclass; treat True/False as a type error, not 1/0.
+        if isinstance(max_iter, bool) or not isinstance(max_iter, (int, np.integer)):
+            raise ValueError(
+                f"{func}: `max_iter` must be a positive integer, got {max_iter!r}"
+            )
+        if max_iter < 1:
+            raise ValueError(
+                f"{func}: `max_iter` must be a positive integer (at least 1), "
+                f"got {max_iter}"
+            )
+
+
 def _warm_dict(warm):
     """Coerce a warm start (a :class:`QpResult` or a mapping) into the
     ``{x, y, z, z_lb, z_ub}`` dict the binding expects, or ``None``."""
@@ -515,6 +565,7 @@ def solve_qp(
     """
     if c is None:
         raise ValueError("solve_qp: `c` is required")
+    _validate_solver_opts(tol, max_iter, "solve_qp")
     _maybe_check_psd(P, c, check_psd)
     prob = _build(P, c, A, b, G, h, lb, ub)
     return _to_result(
@@ -617,6 +668,7 @@ def solve_socp(
     """
     if c is None:
         raise ValueError("solve_socp: `c` is required")
+    _validate_solver_opts(tol, max_iter, "solve_socp")
     _maybe_check_psd(P, c, check_psd)
     prob = _build(P, c, A, b, G, h, None, None)
     specs = _normalize_cones(cones)
@@ -650,6 +702,7 @@ def solve_qp_batch(
     :func:`solve_qp`; an offending problem raises ``ValueError`` before any
     solve runs.
     """
+    _validate_solver_opts(tol, max_iter, "solve_qp_batch")
     for pr in problems:
         _maybe_check_psd(pr.get("P"), pr["c"], check_psd)
     built = [
@@ -706,6 +759,7 @@ def solve_qp_multi_rhs(
     """
     if cs is None or len(cs) == 0:
         raise ValueError("solve_qp_multi_rhs: `cs` must be a non-empty sequence")
+    _validate_solver_opts(tol, max_iter, "solve_qp_multi_rhs")
     n = len(np.asarray(cs[0], dtype=np.float64).ravel())
     # `c` only fixes `n` for the base structure; the real objectives are `cs`.
     base_c = c if c is not None else np.zeros(n)
@@ -745,6 +799,7 @@ class QpFactorization:
             raise ValueError(
                 "QpFactorization: `c` is required (representative problem)"
             )
+        _validate_solver_opts(tol, max_iter, "QpFactorization")
         # `P` is fixed for the lifetime of the handle, so one check at build
         # time covers every same-structure `solve` (issue #112).
         _maybe_check_psd(P, c, check_psd)
@@ -823,6 +878,7 @@ class QpSensitivity:
     ):
         if c is None:
             raise ValueError("QpSensitivity: `c` is required")
+        _validate_solver_opts(tol, max_iter, "QpSensitivity")
         _maybe_check_psd(P, c, check_psd)
         prob = _build(P, c, A, b, G, h, lb, ub)
         self._inner = _pounce.QpSensitivity(

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -336,3 +336,129 @@ def test_solve_qp_batch_inherits_the_bound_guard():
             [{"P": np.eye(1), "c": np.zeros(1), "lb": np.array([np.inf]),
               "ub": np.array([np.inf])}]
         )
+
+
+# --- tol / max_iter option validation (gh #277) -----------------------------
+
+# The convex entry points used to apply *no* validation to `tol` while every
+# other pounce surface (NLP `minimize`, the CLI, `sos_minimize`) rejects a
+# non-positive / non-finite tolerance with OPTION_INVALID. An unsatisfiable
+# `tol` (<= 0, NaN, Inf) silently burned every iteration; a huge finite `tol`
+# (1e300) short-circuited at the non-stationary starting iterate and returned a
+# wrong point labeled "optimal". `max_iter=-5` leaked a raw PyO3 OverflowError.
+
+# A small bound-constrained QP: min 1/2 x'x - 1'x, optimum x* = (1, 1).
+_QP277 = dict(
+    P=np.eye(2),
+    c=np.array([-1.0, -1.0]),
+    lb=np.array([-10.0, -10.0]),
+    ub=np.array([10.0, 10.0]),
+)
+_BAD_TOLS = [0.0, -1.0, float("nan"), float("inf"), 1e300, 1.0]
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_solve_qp_rejects_bad_tol(bad):
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        solve_qp(**_QP277, tol=bad)
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_solve_socp_rejects_bad_tol(bad):
+    # min t s.t. (t, x - x*) in SOC — a well-formed conic problem.
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        solve_socp(
+            c=[1.0, 0.0, 0.0],
+            G=-np.eye(3),
+            h=[0.0, -2.0, 1.0],
+            cones=[("soc", 3)],
+            tol=bad,
+        )
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_solve_qp_batch_rejects_bad_tol(bad):
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        solve_qp_batch([_QP277], tol=bad)
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_solve_qp_multi_rhs_rejects_bad_tol(bad):
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        solve_qp_multi_rhs(**_QP277, cs=[_QP277["c"]], tol=bad)
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_qp_factorization_rejects_bad_tol(bad):
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        QpFactorization(**_QP277, tol=bad)
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_qp_sensitivity_rejects_bad_tol(bad):
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        QpSensitivity(P=np.eye(2), c=[0.0, 0.0], A=[[1.0, 1.0]], b=[2.0], tol=bad)
+
+
+def test_huge_tol_never_returns_a_wrong_optimal():
+    """The exact repro from gh #277: `tol=1e300` used to return
+    `status="optimal"` at x=(0,0) (a non-stationary point, kkt_error=1.0)
+    after 0 iterations. It must now be rejected outright, so no wrong
+    "optimal" can escape."""
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        solve_qp(**_QP277, tol=1e300)
+
+
+@pytest.mark.parametrize("bad", [-5, -1, 0, 2.5])
+def test_solve_qp_rejects_bad_max_iter(bad):
+    # A negative int previously leaked a raw PyO3 OverflowError from the usize
+    # binding; every invalid value must now be a clear, named ValueError.
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        solve_qp(**_QP277, max_iter=bad)
+
+
+def test_all_convex_entry_points_reject_negative_max_iter():
+    """The raw-OverflowError leak must be closed on *every* convex surface that
+    accepts `max_iter`, not only `solve_qp`."""
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        solve_socp(
+            c=[1.0, 0.0, 0.0], G=-np.eye(3), h=[0.0, -2.0, 1.0],
+            cones=[("soc", 3)], max_iter=-5,
+        )
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        solve_qp_batch([_QP277], max_iter=-5)
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        solve_qp_multi_rhs(**_QP277, cs=[_QP277["c"]], max_iter=-5)
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        QpFactorization(**_QP277, max_iter=-5)
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        QpSensitivity(P=np.eye(2), c=[0.0, 0.0], A=[[1.0, 1.0]], b=[2.0], max_iter=-5)
+
+
+def test_valid_tol_and_max_iter_still_solve_to_optimum():
+    """A legitimate tight `tol` and finite `max_iter` are untouched: the QP
+    still solves to the known optimum x* = (1, 1)."""
+    r = solve_qp(**_QP277, tol=1e-8, max_iter=100)
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, [1.0, 1.0], atol=1e-6)
+    assert r.kkt_error is not None and r.kkt_error <= 1e-6
+
+
+def test_minimize_qp_route_rejects_bad_tol():
+    """The convex facade (`minimize(solver_selection="qp-ipm")`) inherits the
+    guard, so the `tol=1e300` mislabel no longer propagates to a
+    `success=True, nit=0` OptimizeResult (gh #277)."""
+    import pounce
+
+    def f(x):
+        return 0.5 * (x @ x) - x.sum()
+
+    for bad in (0.0, 1e300, float("nan")):
+        with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+            pounce.minimize(
+                f,
+                x0=np.array([5.0, 5.0]),
+                jac=lambda x: x - 1.0,
+                solver_selection="qp-ipm",
+                tol=bad,
+            )


### PR DESCRIPTION
Fixes #277.

## Root cause

`python/pounce/qp.py` passed `tol` / `max_iter` straight through to the
`_pounce` binding with **no validation**, unlike the NLP `minimize` path, the
CLI, and `sos_minimize` (which all reject `tol <= 0` / non-finite `tol` with
`OPTION_INVALID`). Two failure modes resulted:

- **Unsatisfiable `tol`** (`0`, `-1`, `NaN`, `Inf`) was accepted and silently
  consumed every iteration (e.g. 199 on a QP that converges in 1).
- **Huge finite `tol`** (`1e300`) short-circuited at the interior-point
  *starting* iterate. The convex IPM's stopping test is `max KKT residual
  <= tol` evaluated at every iterate including the self-dual start, so an O(1)
  tolerance "passes" immediately: `solve_qp(..., tol=1e300)` returned
  `status="optimal"` after **0 iterations** at `x=(0,0)` with `kkt_error=1.0`
  (the exact repro in the issue). This mislabel propagated through
  `_solve_via_convex` (`python/pounce/_minimize.py:841`) so
  `minimize(solver_selection="qp-ipm", tol=1e300)` reported
  `success=True, nit=0, f=0`.
- Separately, `solve_qp(max_iter=-5)` leaked a raw PyO3
  `OverflowError: can't convert negative int to unsigned` from the `usize`
  binding (`crates/pounce-py/src/qp.rs`), instead of a named option error.

## Fix

A single Python-side helper `_validate_solver_opts(tol, max_iter, func)` in
`python/pounce/qp.py`, called by **every** convex entry point:
`solve_qp`, `solve_socp`, `solve_qp_batch`, `solve_qp_multi_rhs`, and the
`QpFactorization` / `QpSensitivity` constructors (the only other public
surfaces that take `tol`/`max_iter`; `QpFactorization.solve` takes neither).

Python is the cleanest single location: it covers all public surfaces (the
convex `minimize` facade routes through `solve_qp`/`solve_socp`), and it
catches the `max_iter` overflow **before** the value reaches the PyO3 `usize`
binding.

## Huge-tol policy and justification

I chose to **reject** `tol >= 1` (option a: cap `tol`), rather than accept any
positive `tol` and gate the status. Rationale:

- A tolerance bounds the max KKT residual; the IPM tests it at the starting
  iterate, whose KKT error is O(1). Capping `tol < 1` gives a hard guarantee:
  an accepted `tol` producing an `"optimal"` result carries
  `kkt_error <= tol < 1`, i.e. a genuinely near-stationary point — **a wrong
  point can never again be labeled `optimal`.** Gating on `kkt_error` cannot
  give this guarantee, because with a huge `tol` the wrong point *does* satisfy
  `kkt_error <= tol` (1.0 <= 1e300), so there is no relative test that catches
  it — an absolute cap is required.
- This is the "simplest defensible rule" the issue suggests. The lower-bound
  rejection (`tol <= 0`, `NaN`, `Inf`) matches the NLP/CLI/`sos_minimize`
  surfaces exactly.
- Minor cross-surface asymmetry (noted deliberately): the NLP path accepts
  `tol=1e300` and still returns the correct answer, because its line search
  makes progress from `x0` — the convex IPM does not, so the convex surface
  needs the upper bound the NLP surface does not. Legitimate loose tolerances
  (`1e-1`, `1e-4`, …) are all well below the cap and unaffected.

`max_iter` must be a positive integer; a negative, zero, or non-integer value
now raises a named `ValueError` on every convex entry point.

## Edge cases

- `tol` = `0`, `-1`, `NaN`, `Inf`, `1e300`, `1.0` → `ValueError`.
- `tol` = `1e-8` (and any `0 < tol < 1`) → solves normally.
- `max_iter` = `-5`, `-1`, `0`, `2.5`, `True` → `ValueError` (bool treated as a
  type error, not `1`/`0`).
- `max_iter` = `100` → solves normally.

## Entry points covered

`solve_qp`, `solve_socp`, `solve_qp_batch`, `solve_qp_multi_rhs`,
`QpFactorization`, `QpSensitivity`, and — transitively — the
`minimize(solver_selection="qp-ipm"/"lp-ipm"/SOCP)` facade.

## Validation

New regression tests in `python/tests/test_qp_host.py`:
`test_solve_qp_rejects_bad_tol`, `test_solve_socp_rejects_bad_tol`,
`test_solve_qp_batch_rejects_bad_tol`, `test_solve_qp_multi_rhs_rejects_bad_tol`,
`test_qp_factorization_rejects_bad_tol`, `test_qp_sensitivity_rejects_bad_tol`
(each parametrized over `0/-1/NaN/Inf/1e300/1.0`),
`test_huge_tol_never_returns_a_wrong_optimal` (the issue repro),
`test_solve_qp_rejects_bad_max_iter`,
`test_all_convex_entry_points_reject_negative_max_iter`,
`test_valid_tol_and_max_iter_still_solve_to_optimum`, and
`test_minimize_qp_route_rejects_bad_tol` (cross-surface facade check).

Suites run (all pass):
- `python -m pytest python/tests/test_qp_host.py python/tests/test_minimize.py -q`
  → **128 passed**.
- `cargo test -p pounce-py --release -q` → pass.
- `cargo test -p pounce-convex --release -q` → pass.

No Rust sources were changed (pure-Python fix), so no `cargo fmt` was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
