### PR TITLE
Reject zero-dimension cone blocks instead of panicking across FFI (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `solve_socp` panicked across the FFI boundary on a zero-dimension cone block (#278)
+
+- **A zero-dimension cone block made `solve_socp` raise
+  `pyo3_runtime.PanicException`** (a Rust panic crossing the FFI boundary,
+  which Python cannot catch as a normal error) instead of a clean, catchable
+  `ValueError`. The validator only checked that the cone dimensions *sum* to
+  `rows(G)`, so a 0-dim block — contributing 0 rows — passed every documented
+  check and then aborted inside a cone constructor: `SecondOrderCone::new(0)`
+  hit an `assert!`, and `PsdCone` indexed `vals[0]` on an empty eigenvalue
+  vector. It was reachable three ways, all ordinary user input: an explicit
+  `("soc", 0)` / `("psd", 0)`; a **negative** dimension (silently saturated to
+  `0` by `v.round() as usize`); and a **fractional** dimension below `0.5`
+  (rounded to `0`). `parse_cones` now validates each cone's dimension at the
+  Python boundary — rejecting non-finite, non-integer, negative, and
+  below-minimum values (`soc`/`psd` need `≥ 1`; the empty-safe nonnegative
+  orthant still permits `0`) — with a clear `ValueError` naming the offending
+  cone's index, kind, and value. As defense in depth, the constructors no
+  longer panic on a `0` reaching them from any path: `SecondOrderCone::new`
+  drops its `assert!`, and `PsdCone::min_eig` / `max_step` short-circuit the
+  degenerate `n = 0` block. A valid `("nonneg", 0)` block still solves
+  unchanged, and every well-posed SOCP/SDP/exp/pow solve is unaffected.
+
 ### Fixed — convex `tol` / `max_iter` options were unvalidated (#277)
 
 - **`solve_qp` / `solve_socp` (and the batch, multi-RHS, factorization, and

--- a/crates/pounce-convex/src/cones/psd.rs
+++ b/crates/pounce-convex/src/cones/psd.rs
@@ -138,6 +138,12 @@ impl PsdCone {
     /// Smallest eigenvalue of `smat(point)` — `> 0` iff strictly interior.
     pub fn min_eig(&self, point: &[f64]) -> f64 {
         let n = self.n;
+        if n == 0 {
+            // A degenerate 0×0 block has an empty spectrum: vacuously PD, so
+            // report +∞ rather than indexing an empty eigenvalue vector
+            // (gh #278). Callers must validate `n ≥ 1` (`parse_cones` does).
+            return f64::INFINITY;
+        }
         let mut m = vec![0.0; n * n];
         smat(point, n, &mut m);
         let mut vals = vec![0.0; n];
@@ -222,6 +228,12 @@ impl PsdCone {
     /// interiority check applies only to the drivers' `tau < 1`.
     pub fn max_step(&self, v: &[f64], dv: &[f64], tau: f64) -> f64 {
         let n = self.n;
+        if n == 0 {
+            // No constraint from an empty 0×0 block — take the full (capped)
+            // step instead of indexing `vals[0]` on an empty spectrum
+            // (gh #278). Callers must validate `n ≥ 1` (`parse_cones` does).
+            return tau.min(1.0);
+        }
         let mut vmat = vec![0.0; n * n];
         smat(v, n, &mut vmat);
         let mut vals = vec![0.0; n];
@@ -557,6 +569,20 @@ mod tests {
         let mut c = vec![0.0; n * n];
         matmul(a, b, n, &mut c);
         c
+    }
+
+    /// gh #278: a degenerate `n = 0` PSD cone must not panic. `PsdCone::new`
+    /// never asserted, but `min_eig`/`max_step` used to index `vals[0]` on an
+    /// empty eigenvalue vector, aborting across the FFI boundary. The Python
+    /// binding rejects such a size in `parse_cones`; this is defense in depth.
+    #[test]
+    fn zero_size_cone_does_not_panic() {
+        let c = PsdCone::new(0);
+        assert_eq!(c.dim(), 0); // n(n+1)/2 = 0
+        let empty: Vec<f64> = Vec::new();
+        assert_eq!(c.min_eig(&empty), f64::INFINITY);
+        assert_eq!(c.max_step(&empty, &empty, 0.95), 0.95);
+        assert!(c.in_cone(&empty, 1e-9));
     }
 
     #[test]

--- a/crates/pounce-convex/src/cones/soc.rs
+++ b/crates/pounce-convex/src/cones/soc.rs
@@ -35,7 +35,13 @@ pub struct SecondOrderCone {
 
 impl SecondOrderCone {
     pub fn new(m: usize) -> Self {
-        assert!(m >= 1, "second-order cone needs dimension ≥ 1");
+        // A meaningful second-order cone has `m ≥ 1` (`m = 1` degenerates to a
+        // single nonnegative coordinate); callers must validate the dimension
+        // first (the Python binding does, in `parse_cones` — gh #278). We no
+        // longer `assert!` here: a stray `m = 0` yields a trivial, panic-free
+        // block instead of aborting across the FFI boundary. Its Jordan/step
+        // methods assume `m ≥ 1` and must not be *stepped* at `m = 0`, but
+        // constructing and querying such a block never panics.
         SecondOrderCone { m }
     }
 
@@ -112,7 +118,9 @@ impl Cone for SecondOrderCone {
 
     fn identity(&self, out: &mut [f64]) {
         out.iter_mut().for_each(|v| *v = 0.0);
-        out[0] = 1.0; // e = (1, 0, …, 0)
+        if let Some(first) = out.first_mut() {
+            *first = 1.0; // e = (1, 0, …, 0); no-op on a degenerate m = 0 block
+        }
     }
 
     fn dim(&self) -> usize {
@@ -284,6 +292,22 @@ mod tests {
         w.iter()
             .map(|row| row.iter().zip(x).map(|(a, b)| a * b).sum())
             .collect()
+    }
+
+    /// gh #278: a degenerate `m = 0` cone (which a Python caller could reach
+    /// via `("soc", 0)`, a negative dim, or a fractional dim rounding to 0)
+    /// must *construct and query* without panicking — the raw `assert!` that
+    /// used to live in `new` aborted across the FFI boundary. The Python
+    /// binding rejects such a dim in `parse_cones`; this is defense in depth.
+    #[test]
+    fn zero_dimension_cone_does_not_panic() {
+        let c = SecondOrderCone::new(0);
+        assert_eq!(c.dim(), 0);
+        assert_eq!(c.degree(), 2);
+        // `identity` on an empty slice is a no-op, not an out-of-bounds write.
+        let mut e: Vec<f64> = Vec::new();
+        c.identity(&mut e);
+        assert!(e.is_empty());
     }
 
     #[test]

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -277,20 +277,60 @@ fn warm_from_dict(warm: &Bound<'_, PyDict>) -> PyResult<QpWarmStart> {
 fn parse_cones(specs: Vec<(String, f64)>) -> PyResult<Vec<ConeSpec>> {
     specs
         .into_iter()
-        .map(|(kind, v)| match kind.to_ascii_lowercase().as_str() {
-            "nonneg" | "nn" | "+" => Ok(ConeSpec::Nonneg(v.round() as usize)),
-            "soc" | "q" | "secondorder" => Ok(ConeSpec::SecondOrder(v.round() as usize)),
+        .enumerate()
+        .map(|(i, (kind, v))| match kind.to_ascii_lowercase().as_str() {
+            // The nonnegative orthant is empty-safe (all its ops iterate), so a
+            // 0-row block is harmless and permitted (`min = 0`).
+            "nonneg" | "nn" | "+" => Ok(ConeSpec::Nonneg(cone_dim(&kind, i, v, 0)?)),
+            // A second-order cone needs `≥ 1` row (`m = 1` is a nonneg); `m = 0`
+            // would panic in `SecondOrderCone::new`, so reject it here (gh #278).
+            "soc" | "q" | "secondorder" => Ok(ConeSpec::SecondOrder(cone_dim(&kind, i, v, 1)?)),
             "exp" | "exponential" | "e" => Ok(ConeSpec::Exponential),
             "pow" | "power" | "p" if v > 0.0 && v < 1.0 => Ok(ConeSpec::Power(v)),
             "pow" | "power" | "p" => Err(PyValueError::new_err(format!(
-                "power-cone exponent α must be in (0, 1), got {v}"
+                "cones[{i}] ('{kind}'): power-cone exponent α must be in (0, 1), got {v}"
             ))),
-            "psd" | "sdp" | "s" => Ok(ConeSpec::Psd(v.round() as usize)),
+            // A PSD cone of size `n ≥ 1` spans `n(n+1)/2` svec rows; `n = 0`
+            // would index an empty eigenvalue vector (gh #278).
+            "psd" | "sdp" | "s" => Ok(ConeSpec::Psd(cone_dim(&kind, i, v, 1)?)),
             other => Err(PyValueError::new_err(format!(
-                "unknown cone kind '{other}' (use 'nonneg', 'soc', 'exp', 'pow', or 'psd')"
+                "cones[{i}]: unknown cone kind '{other}' \
+                 (use 'nonneg', 'soc', 'exp', 'pow', or 'psd')"
             ))),
         })
         .collect()
+}
+
+/// Validate a cone `value` that denotes an integer dimension (`nonneg`/`soc`)
+/// or matrix size (`psd`) and convert it to `usize`. Rejects non-finite,
+/// non-integer, and below-`min` values with a clear, catchable `ValueError`
+/// naming the offending cone's index, kind, and value.
+///
+/// This is the front-line guard for gh #278: a degenerate dimension (an
+/// explicit `0`, a **negative** value — which would otherwise saturate to `0`
+/// in `v.round() as usize` — or a **fractional** value below `0.5` that rounds
+/// to `0`) must never reach a cone constructor, where it panics across the FFI
+/// boundary (`SecondOrderCone::new`'s assert, `PsdCone`'s empty-vector index).
+/// `min` is `0` for the empty-safe nonnegative orthant and `1` for the
+/// second-order and PSD cones.
+fn cone_dim(kind: &str, index: usize, v: f64, min: usize) -> PyResult<usize> {
+    if !v.is_finite() {
+        return Err(PyValueError::new_err(format!(
+            "cones[{index}] ('{kind}'): dimension must be a finite integer, got {v}"
+        )));
+    }
+    let rounded = v.round();
+    if (v - rounded).abs() > 1e-9 {
+        return Err(PyValueError::new_err(format!(
+            "cones[{index}] ('{kind}'): dimension must be a whole number, got {v}"
+        )));
+    }
+    if rounded < min as f64 {
+        return Err(PyValueError::new_err(format!(
+            "cones[{index}] ('{kind}'): dimension must be ≥ {min}, got {rounded}"
+        )));
+    }
+    Ok(rounded as usize)
 }
 
 fn opts(tol: Option<f64>, max_iter: Option<usize>, collect_iterates: bool) -> QpOptions {

--- a/python/tests/test_socp.py
+++ b/python/tests/test_socp.py
@@ -166,3 +166,58 @@ def test_psd_cannot_mix_with_exp():
     with pytest.raises(ValueError):
         solve_socp(c=[1.0, 0.0, 0.0, 0.0], G=-np.eye(4), h=[0.0] * 4,
                    cones=[("psd", 2), ("exp", 3)])
+
+
+# --- gh #278: zero-dimension cone blocks must raise a clean ValueError, not
+# panic across the FFI boundary (pyo3_runtime.PanicException). ---
+
+
+def test_zero_dim_soc_raises_value_error():
+    # An explicit ("soc", 0) block used to hit SecondOrderCone::new's assert.
+    import pytest
+
+    with pytest.raises(ValueError) as exc:
+        solve_socp(c=[1.0, 1.0], G=-np.eye(2), h=[0.0, 0.0],
+                   cones=[("soc", 0), ("soc", 2)])
+    msg = str(exc.value)
+    assert "cones[0]" in msg and "soc" in msg  # names the offending cone
+
+
+def test_negative_dim_soc_raises_value_error():
+    # A negative dim must be rejected, not silently saturated to 0 by
+    # `v.round() as usize`.
+    import pytest
+
+    with pytest.raises(ValueError) as exc:
+        solve_socp(c=[1.0, 1.0], G=-np.eye(2), h=[0.0, 0.0],
+                   cones=[("soc", -1), ("soc", 2)])
+    assert "cones[0]" in str(exc.value)
+
+
+def test_fractional_dim_soc_raises_value_error():
+    # A fractional dim below 0.5 rounds to 0; reject non-integer dims outright.
+    import pytest
+
+    with pytest.raises(ValueError) as exc:
+        solve_socp(c=[1.0, 1.0], G=-np.eye(2), h=[0.0, 0.0],
+                   cones=[("soc", 0.3), ("soc", 2)])
+    assert "whole number" in str(exc.value)
+
+
+def test_zero_size_psd_raises_value_error():
+    import pytest
+
+    with pytest.raises(ValueError) as exc:
+        solve_socp(c=[1.0], G=[[1.0]], h=[0.0], cones=[("psd", 0)])
+    assert "cones[0]" in str(exc.value) and "psd" in str(exc.value)
+
+
+def test_zero_dim_nonneg_still_solves():
+    # gh #278: nonneg is empty-safe, so a leading 0-row block is permitted and
+    # the problem still solves to the same optimum as without it.
+    #   max x0 + x1  s.t.  x0 <= 1 (nonneg), |x1| <= 1 (soc)  -> (1, 1).
+    G = np.array([[1.0, 0.0], [0.0, 0.0], [0.0, -1.0]])
+    r = solve_socp(c=[-1.0, -1.0], G=G, h=[1.0, 1.0, 0.0],
+                   cones=[("nonneg", 0), ("nonneg", 1), ("soc", 2)])
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, [1.0, 1.0], atol=1e-5)


### PR DESCRIPTION
Fixes #278.

## Root cause

`solve_socp(cones=[...])` raised `pyo3_runtime.PanicException` (a Rust panic
crossing the FFI boundary, uncatchable as a normal Python error) on a
zero-dimension cone block. The validator at `crates/pounce-py/src/qp.rs:377-385`
checked only that the cone dimensions **sum** to `rows(G)`. A 0-dim block
contributes 0 rows, so it passed every documented check and then reached a cone
constructor that aborts on an empty block:

- `SecondOrderCone::new(0)` → `assert!(m >= 1, …)` at `crates/pounce-convex/src/cones/soc.rs:38`
- `PsdCone` → unguarded `vals[0]` on an empty eigenvalue vector at `crates/pounce-convex/src/cones/psd.rs:235` (via `min_eig`/`max_step`)

## The three routes (all ordinary user input)

1. **Explicit** `("soc", 0)` / `("psd", 0)`.
2. **Negative** dim — `v.round() as usize` saturates a negative float to `0`.
3. **Fractional** dim below `0.5` — rounds to `0`.

`("nonneg", 0)` was already graceful (its ops iterate over empty slices), so the
fix is a per-cone-kind guard matching what `nonneg` already tolerated.

## Fix — guard at the Python/validator boundary (primary)

`parse_cones` now routes every integer-dimension cone through a new `cone_dim`
helper that rejects, **before** any constructor runs, with a clear catchable
`ValueError` naming the offending cone's index, kind, and value:

- non-finite (`NaN`/`inf`),
- non-integer (`0.3`, `2.5` → "must be a whole number"),
- negative (no longer silently saturated to `0`),
- below the per-kind minimum: `soc`/`psd` require `≥ 1`; the empty-safe
  nonnegative orthant still permits `0`.

Example: `cones[0] ('soc'): dimension must be ≥ 1, got 0`.

The exponential/power kinds are unchanged — `exp` dimension is still enforced by
the existing row-sum check (it is always 3 rows), and `pow`'s α∈(0,1) guard is
kept.

## Defense in depth (constructors)

So a future caller/bindings path cannot reintroduce the panic:

- `SecondOrderCone::new` drops its `assert!` — an `m = 0` block constructs and
  queries without panicking; `identity` now guards the empty slice with
  `first_mut()`.
- `PsdCone::min_eig` returns `+∞` (vacuously PD) and `max_step` returns the
  capped step for the degenerate `n = 0` block, instead of indexing `vals[0]`.

## Edge cases / no regressions

- `("nonneg", 0)` still solves to the same optimum (regression test added).
- Valid `("soc", 1)`, `("soc", 2)`, `("soc", 3)`, `("psd", 2)`, `("exp", 3)`,
  `("pow", α)`, and the int shorthand `cones=[3]` are unaffected.
- A well-posed SOCP solves to its known optimum unchanged.

## Validation

- All three repro lines now raise a clean `ValueError` (not `PanicException`)
  naming the bad cone.
- `cargo test -p pounce-convex --release -q` and `cargo test -p pounce-py --release -q` pass, including new constructor-guard unit tests (`soc.rs` / `psd.rs`, `n == 0` no longer panics).
- `python/tests/test_socp.py`: 19 passed (5 new — the three zero-dim routes, a zero-size PSD, and a still-solving `("nonneg", 0)`); `test_qp_host.py` + JAX/torch SOCP suites: 75 passed.
- `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
