### PR TITLE
Add near-LICQ conditioning diagnostic + refinement to QpSensitivity (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+### Added — near-LICQ conditioning diagnostic for `QpSensitivity` (#284)
+
+- **`QpSensitivity.parametric_step` no longer silently over-damps `dx/db` on a
+  near-rank-deficient (near-LICQ) KKT.** When the active-constraint gradients are
+  *nearly* — not exactly — rank-deficient (e.g. two almost-parallel equality
+  rows), the static regularization `δ` floored the smallest KKT singular value
+  and a single back-solve returned a smooth but badly wrong sensitivity (up to
+  ~100% relative error), with `weakly_active_indices` empty, `kkt_dim` full, no
+  status change, and no exception — so a caller had no way to know. Two changes
+  close the gap (`crates/pounce-convex/src/sensitivity.rs`, the PyO3 getters in
+  `crates/pounce-py/src/qp.rs`, and the `pounce.qp.QpSensitivity` wrapper):
+  - **Diagnostic.** New `QpSensitivity.kkt_cond_estimate` (a cheap Hager 1-norm
+    estimate of the KKT condition number `κ₁`), the boolean
+    `QpSensitivity.ill_conditioned` (fires when `κ₁ > 1e14`), and
+    `QpSensitivity.last_step_residual` (the relative KKT residual the most
+    recent step achieved, measured against the *unregularized* system). On the
+    near-LICQ sweep the flag fires and the residual is large; on the
+    well-conditioned equality-only and active-set cases (κ₁ ≈ 3–8e9) it stays
+    quiet — no false alarm. All three are new, backward-compatible attributes.
+  - **Accuracy.** Each parametric step is now refined against the unregularized
+    KKT, stripping the `O(δ)` regularization bias wherever the information
+    survives in double precision. `dx/db` now tracks a plain float64 LU solve
+    (e.g. the badly-scaled equality-only case improved from ~1.6e-7 to ~7e-14
+    relative error); genuinely singular cases that refinement cannot recover are
+    the ones the diagnostic flags. Well-conditioned solves are unaffected (their
+    first residual is already at round-off, so refinement is a no-op).
+
 ### Fixed — non-symmetric HSDE driver returned bare `numerical_failure` on infeasible/unbounded exp/power programs (#283)
 
 - **The exponential/power-cone (non-symmetric HSDE) driver degraded genuinely

--- a/crates/pounce-convex/src/sensitivity.rs
+++ b/crates/pounce-convex/src/sensitivity.rs
@@ -28,7 +28,32 @@
 //! solve per query (the build-once / solve-many idiom of the NLP
 //! `Solver`). A tiny static regularization `δ` (the QP solver's own `reg`,
 //! default `1e-10`) is placed on the diagonal so the indefinite factor is
-//! stable; the induced error in the step is `O(δ)`.
+//! stable.
+//!
+//! # Near-singular (near-LICQ) KKT: refinement + a conditioning diagnostic
+//!
+//! When the active-constraint gradients are *nearly* rank-deficient (LICQ
+//! almost fails — e.g. two nearly-parallel equality rows) the KKT matrix is
+//! near-singular. A single regularized back-solve then **over-damps**
+//! `dx/db` toward a smooth but badly wrong value, silently, because the
+//! static `δ` floors the smallest KKT singular value (gh #284). Two
+//! defenses close that gap:
+//!
+//! 1. **Iterative refinement against the *unregularized* KKT.** Each solve
+//!    refines its back-substitution against the true (`δ`-free) KKT matrix,
+//!    so the `O(δ)` regularization bias is removed wherever the information
+//!    is still present in double precision — recovering LU-quality `dx/db`.
+//!    On a well-conditioned KKT the first residual is already at round-off
+//!    and refinement is a no-op, so this never perturbs the good cases.
+//! 2. **A condition-number diagnostic.** [`QpSensitivity::kkt_cond_estimate`]
+//!    is a cheap Hager 1-norm estimate of `κ₁` of the factored KKT, and
+//!    [`QpSensitivity::ill_conditioned`] thresholds it. When the system is
+//!    so near-singular that even refinement cannot recover the step (the
+//!    information is below the double-precision floor), the estimate is
+//!    huge and the flag fires — so a caller can *detect* that `dx/db` is
+//!    untrustworthy instead of consuming a silently-damped value. The
+//!    per-step [`QpSensitivity::last_step_residual`] is the companion
+//!    signal: the relative KKT residual the refinement actually achieved.
 
 use crate::ipm::QpOptions;
 use crate::qp::{BOUND_INF, QpProblem, QpSolution, QpStatus, Triplet};
@@ -89,6 +114,18 @@ pub struct QpSensitivity {
     weakly_active_ineq: Vec<usize>,
     /// Variables whose bound is weakly active.
     weakly_active_bound_vars: Vec<usize>,
+    /// Lower-triangle KKT pattern (1-based), shared by the factored
+    /// (regularized) matrix and the unregularized values below.
+    kkt_airn: Vec<Index>,
+    kkt_ajcn: Vec<Index>,
+    /// Unregularized KKT values (the `δ`-free matrix) for the refinement
+    /// residual — see [`solve_refined`] (gh #284).
+    kkt_vals_true: Vec<f64>,
+    /// Hager 1-norm estimate of `κ₁` of the factored KKT (gh #284).
+    kkt_cond_estimate: f64,
+    /// Relative KKT residual of the most recent parametric step, or `None`
+    /// before any step has been taken (gh #284).
+    last_residual: Option<f64>,
 }
 
 /// Relative threshold below which a slack or a multiplier counts as zero for
@@ -108,6 +145,161 @@ pub struct QpSensitivity {
 /// enough to look precise would simply miss the default-tolerance case, which
 /// is the one users hit.
 const WEAK_ACTIVE_REL: f64 = 1e-3;
+
+/// Above this 1-norm condition estimate of the factored KKT the parametric
+/// step is reported [`ill_conditioned`](QpSensitivity::ill_conditioned).
+///
+/// Calibrated against gh #284's near-LICQ sweep. With the static `δ = 1e-10`
+/// flooring the smallest KKT singular value, `κ₁` saturates near `1e16` on a
+/// numerically singular KKT while the genuinely well-conditioned sensitivity
+/// cases sit at `κ₁ ≈ 3–8e9`. Iterative refinement (see the module doc)
+/// recovers a correct `dx/db` up to `κ₁ ≈ 6e13`; past that the information is
+/// below the double-precision floor and refinement cannot help. The threshold
+/// sits in the wide gap between those regimes, so it fires exactly on the
+/// unrecoverable cases and stays quiet on every case refinement rescues — no
+/// false alarm on the well-conditioned equality-only or active-set paths.
+const KKT_ILL_CONDITIONED_THRESHOLD: f64 = 1e14;
+
+/// Iterative-refinement passes for a parametric step (mirrors the HSDE
+/// solve's `IR_MAX_PASSES`). A handful suffices: refinement against the
+/// unregularized KKT converges geometrically until it hits the near-singular
+/// floor, where it stagnates and stops.
+const IR_MAX_PASSES: usize = 5;
+
+/// Relative-residual target below which refinement stops early (the KKT step
+/// is solved to working precision).
+const IR_RELTOL: f64 = 1e-12;
+
+/// Hager/Higham 1-norm power iterations for the `‖K⁻¹‖₁` estimate. Five is
+/// LAPACK's `dlacon` default and is more than enough here (the estimate
+/// matched the exact 1-norm condition on gh #284's sweep).
+const HAGER_ITERS: usize = 5;
+
+fn inf_norm(v: &[f64]) -> f64 {
+    v.iter().fold(0.0_f64, |m, x| m.max(x.abs()))
+}
+
+/// Symmetric matvec `y ← K x` for lower-triangle KKT triplets (`airn`/`ajcn`
+/// 1-based, `row ≥ col`). Each strictly-lower entry hits both `y[i]` and
+/// `y[j]`; the diagonal once. Mirrors the HSDE solver's `kkt_matvec` — used
+/// to form the residual `rhs − K u` that drives refinement.
+fn kkt_matvec(airn: &[Index], ajcn: &[Index], vals: &[f64], x: &[f64], y: &mut [f64]) {
+    for v in y.iter_mut() {
+        *v = 0.0;
+    }
+    for k in 0..vals.len() {
+        let i = (airn[k] - 1) as usize;
+        let j = (ajcn[k] - 1) as usize;
+        let v = vals[k];
+        y[i] += v * x[j];
+        if i != j {
+            y[j] += v * x[i];
+        }
+    }
+}
+
+/// 1-norm `‖K‖₁ = maxⱼ Σᵢ |Kᵢⱼ|` of a symmetric matrix from its lower-triangle
+/// triplets (equal to `‖K‖∞`). Each off-diagonal entry contributes to both its
+/// row and column absolute sums.
+fn one_norm_sym(dim: usize, airn: &[Index], ajcn: &[Index], vals: &[f64]) -> f64 {
+    let mut colsum = vec![0.0_f64; dim];
+    for k in 0..vals.len() {
+        let i = (airn[k] - 1) as usize;
+        let j = (ajcn[k] - 1) as usize;
+        let a = vals[k].abs();
+        colsum[i] += a;
+        if i != j {
+            colsum[j] += a;
+        }
+    }
+    colsum.into_iter().fold(0.0_f64, f64::max)
+}
+
+/// Hager/Higham lower-bound estimate of `‖K⁻¹‖₁` using only back-solves
+/// against the cached factor. `K` is symmetric, so `K⁻ᵀ = K⁻¹` and a single
+/// factor drives both half-steps. Returns `∞` if a back-solve fails (the
+/// caller then reports an infinite condition estimate — the safe direction).
+fn estimate_inv_norm1(fact: &mut Factorization, dim: usize) -> f64 {
+    if dim == 0 {
+        return 0.0;
+    }
+    let mut x = vec![1.0 / dim as f64; dim];
+    let mut est = 0.0_f64;
+    let mut prev_j = usize::MAX;
+    for _ in 0..HAGER_ITERS {
+        // y = K⁻¹ x; the 1-norm of y is the running estimate of ‖K⁻¹‖₁.
+        let mut y = x.clone();
+        if fact.solve_one(&mut y).is_err() {
+            return f64::INFINITY;
+        }
+        est = y.iter().map(|v| v.abs()).sum();
+        // z = K⁻¹ sign(y)  (K symmetric ⇒ K⁻ᵀ = K⁻¹).
+        let mut z: Vec<f64> = y
+            .iter()
+            .map(|v| if *v >= 0.0 { 1.0 } else { -1.0 })
+            .collect();
+        if fact.solve_one(&mut z).is_err() {
+            return f64::INFINITY;
+        }
+        let (j, zmax) = z
+            .iter()
+            .enumerate()
+            .fold((0usize, 0.0_f64), |(bi, bm), (i, v)| {
+                if v.abs() > bm { (i, v.abs()) } else { (bi, bm) }
+            });
+        let ztx: f64 = z.iter().zip(&x).map(|(a, b)| a * b).sum();
+        // Higham's stopping test: no coordinate of z beats the current
+        // direction, or we would revisit a unit vector (a cycle).
+        if zmax <= ztx || j == prev_j {
+            break;
+        }
+        prev_j = j;
+        x = vec![0.0; dim];
+        x[j] = 1.0;
+    }
+    est
+}
+
+/// Solve `K u = rhs` against the cached (regularized) factor, then refine `u`
+/// against the **unregularized** KKT triplets `(airn, ajcn, vals_true)` to
+/// strip the `O(δ)` regularization bias. Overwrites `rhs` with `u` and returns
+/// the final relative residual `‖rhs₀ − K u‖∞ / (1 + ‖rhs₀‖∞)` — the
+/// reliability signal a caller reads back as
+/// [`last_step_residual`](QpSensitivity::last_step_residual).
+fn solve_refined(
+    fact: &mut Factorization,
+    airn: &[Index],
+    ajcn: &[Index],
+    vals_true: &[f64],
+    rhs: &mut [f64],
+) -> Result<f64, ()> {
+    let dim = rhs.len();
+    let b: Vec<f64> = rhs.to_vec();
+    fact.solve_one(rhs).map_err(|_| ())?;
+    let bnorm = 1.0 + inf_norm(&b);
+    let mut r = vec![0.0; dim];
+    let mut res = f64::INFINITY;
+    for _ in 0..IR_MAX_PASSES {
+        kkt_matvec(airn, ajcn, vals_true, rhs, &mut r);
+        for k in 0..dim {
+            r[k] = b[k] - r[k];
+        }
+        let new_res = inf_norm(&r) / bnorm;
+        // Stop when solved to working precision, or when refinement stops
+        // making progress — the latter is the near-singular floor and its
+        // residual is exactly the "step is unreliable" signal.
+        if new_res <= IR_RELTOL || new_res >= res {
+            res = new_res;
+            break;
+        }
+        res = new_res;
+        fact.solve_one(&mut r).map_err(|_| ())?;
+        for k in 0..dim {
+            rhs[k] += r[k];
+        }
+    }
+    Ok(res)
+}
 
 impl QpSensitivity {
     /// Build the active-set sensitivity for `sol` (a solution of `prob`).
@@ -190,57 +382,83 @@ impl QpSensitivity {
             })
             .collect();
 
-        // Assemble the lower triangle of the symmetric KKT matrix.
-        let mut entries: BTreeMap<(usize, usize), f64> = BTreeMap::new();
-        let mut add = |r: usize, c: usize, v: f64| {
+        // Assemble the lower triangle of the symmetric KKT matrix. We keep the
+        // *unregularized* value and the regularization offset per entry
+        // separately: the factor sees `value + reg_offset` (the stabilized,
+        // indefinite matrix) while iterative refinement in `step_from_db`
+        // measures the residual against the `δ`-free `value` (gh #284). Every
+        // diagonal slot `(i, i)` is materialized (even where `P` is zero) so
+        // the two value arrays share one sparsity pattern.
+        let mut entries: BTreeMap<(usize, usize), (f64, f64)> = BTreeMap::new();
+        let mut add = |r: usize, c: usize, v: f64, reg_off: f64| {
             let (r, c) = if r >= c { (r, c) } else { (c, r) };
-            *entries.entry((r, c)).or_insert(0.0) += v;
+            let e = entries.entry((r, c)).or_insert((0.0, 0.0));
+            e.0 += v;
+            e.1 += reg_off;
         };
 
-        // (x,x): P + δI.
+        // (x,x): P, with +δ on the diagonal for the factor only.
         for t in &prob.p_lower {
-            add(t.row, t.col, t.val);
+            add(t.row, t.col, t.val, 0.0);
         }
         for i in 0..n {
-            add(i, i, reg);
+            add(i, i, 0.0, reg);
         }
-        // (y,x): A; (y,y): −δI.
+        // (y,x): A; (y,y): −δI (factor only).
         for t in &prob.a {
-            add(n + t.row, t.col, t.val);
+            add(n + t.row, t.col, t.val, 0.0);
         }
         for i in 0..m_eq {
-            add(n + i, n + i, -reg);
+            add(n + i, n + i, 0.0, -reg);
         }
         // Active-row block `B_a` after the equality rows, in order:
-        // active inequality rows, then active bound rows. (·,·): −δI diagonal.
+        // active inequality rows, then active bound rows. (·,·): −δI diagonal
+        // (factor only).
         let abase = n + m_eq;
         let g_rows = group_rows_by_index(&prob.g, prob.m_ineq());
         for (k, &i) in active_ineq.iter().enumerate() {
             // The k-th active row holds G's row i.
             for &(col, val) in &g_rows[i] {
-                add(abase + k, col, val);
+                add(abase + k, col, val, 0.0);
             }
         }
         for (k, &j) in active_bound_vars.iter().enumerate() {
-            add(abase + active_ineq.len() + k, j, 1.0);
+            add(abase + active_ineq.len() + k, j, 1.0, 0.0);
         }
         for k in 0..n_active {
-            add(abase + k, abase + k, -reg);
+            add(abase + k, abase + k, 0.0, -reg);
         }
 
-        // Triplets → 1-based lower-triangle arrays for the factorization.
+        // Triplets → 1-based lower-triangle arrays. `values_reg` (true + reg
+        // offset) is factored; `kkt_vals_true` (δ-free) drives refinement.
         let nnz = entries.len();
-        let mut airn = Vec::with_capacity(nnz);
-        let mut ajcn = Vec::with_capacity(nnz);
-        let mut values = Vec::with_capacity(nnz);
-        for ((r, c), v) in entries {
-            airn.push((r + 1) as Index);
-            ajcn.push((c + 1) as Index);
-            values.push(v);
+        let mut kkt_airn = Vec::with_capacity(nnz);
+        let mut kkt_ajcn = Vec::with_capacity(nnz);
+        let mut kkt_vals_true = Vec::with_capacity(nnz);
+        let mut values_reg = Vec::with_capacity(nnz);
+        for ((r, c), (v_true, v_reg_off)) in entries {
+            kkt_airn.push((r + 1) as Index);
+            kkt_ajcn.push((c + 1) as Index);
+            kkt_vals_true.push(v_true);
+            values_reg.push(v_true + v_reg_off);
         }
 
-        let fact = Factorization::new(dim as Index, airn, ajcn, values, make_backend())
-            .map_err(|_| SensError::FactorizationFailed)?;
+        // 1-norm of the factored (regularized) KKT, for the condition estimate.
+        let kkt_norm1 = one_norm_sym(dim, &kkt_airn, &kkt_ajcn, &values_reg);
+
+        let mut fact = Factorization::new(
+            dim as Index,
+            kkt_airn.clone(),
+            kkt_ajcn.clone(),
+            values_reg,
+            make_backend(),
+        )
+        .map_err(|_| SensError::FactorizationFailed)?;
+
+        // Hager estimate of κ₁ = ‖K‖₁·‖K⁻¹‖₁ (gh #284). Reuses the factor, so
+        // it costs only a handful of back-solves.
+        let inv_norm1 = estimate_inv_norm1(&mut fact, dim);
+        let kkt_cond_estimate = kkt_norm1 * inv_norm1;
 
         Ok(QpSensitivity {
             n,
@@ -252,6 +470,11 @@ impl QpSensitivity {
             active_bound_vars,
             weakly_active_ineq,
             weakly_active_bound_vars,
+            kkt_airn,
+            kkt_ajcn,
+            kkt_vals_true,
+            kkt_cond_estimate,
+            last_residual: None,
         })
     }
 
@@ -308,17 +531,70 @@ impl QpSensitivity {
     /// Primal sensitivity for a full equality-RHS perturbation `db` (length
     /// `m_eq`): solves the active-set KKT with right-hand side `[0; db; 0]`
     /// and returns `dx = step[0..n]`.
+    ///
+    /// The back-solve is refined against the **unregularized** KKT
+    /// ([`solve_refined`]) so the `O(δ)` regularization bias is stripped
+    /// wherever the information survives in double precision; the achieved
+    /// relative residual is recorded for
+    /// [`last_step_residual`](Self::last_step_residual) (gh #284).
     pub fn step_from_db(&mut self, db: &[f64]) -> Vec<f64> {
         assert_eq!(db.len(), self.m_eq, "db must have length m_eq");
         let mut rhs = vec![0.0 as Number; self.dim];
         rhs[self.n..self.n + self.m_eq].copy_from_slice(db);
         // A singular factor would have been caught at build; a back-solve
         // failure here is not recoverable, so surface a zero step.
-        if self.fact.solve_one(&mut rhs).is_err() {
-            return vec![0.0; self.n];
+        match solve_refined(
+            &mut self.fact,
+            &self.kkt_airn,
+            &self.kkt_ajcn,
+            &self.kkt_vals_true,
+            &mut rhs,
+        ) {
+            Ok(res) => self.last_residual = Some(res),
+            Err(()) => return vec![0.0; self.n],
         }
         rhs.truncate(self.n);
         rhs
+    }
+
+    /// Hager 1-norm estimate of the condition number `κ₁` of the (factored,
+    /// regularized) active-set KKT.
+    ///
+    /// A large value warns that the sensitivity system is near-singular — the
+    /// active-constraint gradients are nearly rank-deficient (near-LICQ) — so
+    /// the parametric step may be untrustworthy even though the solve reports
+    /// success (gh #284). This is the quantitative companion to the boolean
+    /// [`ill_conditioned`](Self::ill_conditioned); see also the per-step
+    /// [`last_step_residual`](Self::last_step_residual). Well-conditioned
+    /// sensitivities report a modest `κ₁` (a few `×10⁹` on the badly-scaled
+    /// gh #284 QPs); a numerically singular one saturates near `1e16`.
+    pub fn kkt_cond_estimate(&self) -> f64 {
+        self.kkt_cond_estimate
+    }
+
+    /// Whether the KKT/sensitivity system is ill-conditioned enough that
+    /// [`parametric_step`](Self::parametric_step) may be unreliable even after
+    /// refinement — `true` when [`kkt_cond_estimate`](Self::kkt_cond_estimate)
+    /// exceeds [`KKT_ILL_CONDITIONED_THRESHOLD`] (gh #284).
+    ///
+    /// On a near-LICQ sweep this fires precisely where refinement can no
+    /// longer recover `dx/db` from double precision; on the well-conditioned
+    /// equality-only and active-set cases it stays quiet.
+    pub fn ill_conditioned(&self) -> bool {
+        self.kkt_cond_estimate > KKT_ILL_CONDITIONED_THRESHOLD
+    }
+
+    /// Relative KKT residual `‖rhs − K·step‖∞ / (1 + ‖rhs‖∞)` achieved by the
+    /// most recent [`parametric_step`](Self::parametric_step) /
+    /// [`step_from_db`](Self::step_from_db), or `None` before any step.
+    ///
+    /// Measured against the **unregularized** KKT, so it reflects how well the
+    /// returned step actually satisfies the true sensitivity system. A tiny
+    /// value (round-off level) means the step is trustworthy; a large one
+    /// means refinement could not solve the near-singular system and the step
+    /// is unreliable (gh #284).
+    pub fn last_step_residual(&self) -> Option<f64> {
+        self.last_residual
     }
 
     /// The active-set KKT dimension `n + m_eq + n_active`.
@@ -676,6 +952,261 @@ mod tests {
         let dx = sens.parametric_step(&[0], &[0.5]);
         assert!(dx[0].abs() < 1e-6, "dx0 = {} (should stay on x₀=1)", dx[0]);
         assert!((dx[1] - 0.5).abs() < 1e-6, "dx1 = {}", dx[1]);
+    }
+
+    // ---- gh #284: near-LICQ conditioning diagnostic + refinement ----------
+
+    /// The gh #284 Hessian `P = D·H₆·D` (Hilbert matrix `H₆`, `D =
+    /// diag(1e3,…,1e-2)`; `cond(P) ≈ 7e15`) and its linear term. Shared by the
+    /// conditioning tests below.
+    fn hilbert_p_and_c() -> (Vec<Triplet>, Vec<f64>) {
+        let d = [1e3, 1e2, 1e1, 1.0, 1e-1, 1e-2];
+        let mut p_lower = Vec::new();
+        for i in 0..6 {
+            for j in 0..=i {
+                let hij = 1.0 / ((i + j + 1) as f64);
+                p_lower.push(Triplet::new(i, j, d[i] * hij * d[j]));
+            }
+        }
+        (p_lower, vec![1.0, -2.0, 3.0, -1.0, 0.5, -0.25])
+    }
+
+    /// Two equality rows that are all-ones except the last entry of row 1,
+    /// which differs by `eps` — nearly parallel, so LICQ nearly fails.
+    fn near_parallel_rows(eps: f64) -> Vec<Triplet> {
+        let mut a = Vec::new();
+        for j in 0..6 {
+            a.push(Triplet::new(0, j, 1.0));
+            a.push(Triplet::new(1, j, if j == 5 { 1.0 + eps } else { 1.0 }));
+        }
+        a
+    }
+
+    /// Dense LU with partial pivoting — the float64 reference the gh #284 issue
+    /// uses (`numpy.linalg.solve`) to show `dx/db` survives in double precision.
+    /// `a` is row-major `n×n`; solves `a x = b`.
+    fn dense_lu_solve(mut a: Vec<Vec<f64>>, mut b: Vec<f64>) -> Vec<f64> {
+        let n = b.len();
+        for k in 0..n {
+            let mut piv = k;
+            for i in (k + 1)..n {
+                if a[i][k].abs() > a[piv][k].abs() {
+                    piv = i;
+                }
+            }
+            a.swap(k, piv);
+            b.swap(k, piv);
+            for i in (k + 1)..n {
+                let f = a[i][k] / a[k][k];
+                for j in k..n {
+                    a[i][j] -= f * a[k][j];
+                }
+                b[i] -= f * b[k];
+            }
+        }
+        let mut x = vec![0.0; n];
+        for k in (0..n).rev() {
+            let mut s = b[k];
+            for j in (k + 1)..n {
+                s -= a[k][j] * x[j];
+            }
+            x[k] = s / a[k][k];
+        }
+        x
+    }
+
+    /// Dense true (δ-free) equality KKT `[[P, Aᵀ], [A, 0]]`, row-major.
+    fn dense_eq_kkt(p_lower: &[Triplet], a: &[Triplet], n: usize, m: usize) -> Vec<Vec<f64>> {
+        let dim = n + m;
+        let mut k = vec![vec![0.0; dim]; dim];
+        for t in p_lower {
+            k[t.row][t.col] += t.val;
+            if t.row != t.col {
+                k[t.col][t.row] += t.val;
+            }
+        }
+        for t in a {
+            k[n + t.row][t.col] += t.val;
+            k[t.col][n + t.row] += t.val;
+        }
+        k
+    }
+
+    /// dx/db reference for the equality-only KKT: the x-block of the true-KKT
+    /// solve with rhs `[0; e_{pin}]`, by dense float64 LU (independent of the
+    /// factored/regularized path).
+    fn dxdb_reference(prob: &QpProblem, pin: usize) -> Vec<f64> {
+        let (n, m) = (prob.n, prob.m_eq());
+        let kkt = dense_eq_kkt(&prob.p_lower, &prob.a, n, m);
+        let mut rhs = vec![0.0; n + m];
+        rhs[n + pin] = 1.0;
+        dense_lu_solve(kkt, rhs)[..n].to_vec()
+    }
+
+    fn rel_err(a: &[f64], b: &[f64]) -> f64 {
+        let scale = b.iter().fold(1.0_f64, |m, v| m.max(v.abs()));
+        a.iter()
+            .zip(b)
+            .fold(0.0_f64, |m, (x, y)| m.max((x - y).abs()))
+            / scale
+    }
+
+    /// A near-LICQ sensitivity (two equality rows differing by `1e-9`) is
+    /// **detectably** untrustworthy (gh #284). Before the fix, `dx/db`
+    /// collapsed to a smoothly over-damped, ~98%-wrong value while every
+    /// existing signal (`weakly_active`, `kkt_dim`, status) looked ordinary and
+    /// no exception was raised — the caller had no way to know. The
+    /// conditioning diagnostic must fire, and the refinement residual must
+    /// expose that the near-singular step was not solved.
+    #[test]
+    fn near_licq_sensitivity_is_flagged_ill_conditioned() {
+        let (p_lower, c) = hilbert_p_and_c();
+        let prob = QpProblem {
+            n: 6,
+            p_lower,
+            c,
+            a: near_parallel_rows(1e-10),
+            b: vec![1.0, 1.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert_eq!(sol.status, QpStatus::Optimal);
+        let mut sens = QpSensitivity::build_default(&prob, &sol, backend).unwrap();
+
+        // The old signals stay silent: nothing weakly active, full KKT dim.
+        assert!(sens.weakly_active_ineq().is_empty());
+        assert!(sens.weakly_active_bound_vars().is_empty());
+        // The new diagnostic fires.
+        assert!(
+            sens.ill_conditioned(),
+            "near-LICQ KKT must be flagged (κ₁ = {:.3e})",
+            sens.kkt_cond_estimate()
+        );
+        assert!(
+            sens.kkt_cond_estimate() > KKT_ILL_CONDITIONED_THRESHOLD,
+            "κ₁ = {:.3e}",
+            sens.kkt_cond_estimate()
+        );
+
+        // The step's residual against the true KKT is large: refinement could
+        // not solve the near-singular system, so the step is unreliable.
+        let _ = sens.parametric_step(&[0], &[1.0]);
+        let res = sens.last_step_residual().expect("a step was taken");
+        assert!(
+            res > 1e-6,
+            "expected a large refinement residual, got {res:.3e}"
+        );
+    }
+
+    /// The false-alarm guard: the gh #284 *well-conditioned* case — the same
+    /// badly-scaled `P = D·H₆·D` with a full-rank (if badly scaled) `A` whose
+    /// rows differ by orders of magnitude, `cond(KKT) ≈ 5e9`. The diagnostic
+    /// must stay quiet, and `dx/db` must match a dense float64 LU reference to
+    /// ~1e-7 (the regularization introduces no detectable bias here).
+    #[test]
+    fn well_conditioned_sensitivity_not_flagged_and_accurate() {
+        let (p_lower, c) = hilbert_p_and_c();
+        // Rows: [1,1,1,1,1,1] and [1e4,1,1,1,1,1e-4] — badly scaled, full rank.
+        let a = vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(0, 2, 1.0),
+            Triplet::new(0, 3, 1.0),
+            Triplet::new(0, 4, 1.0),
+            Triplet::new(0, 5, 1.0),
+            Triplet::new(1, 0, 1e4),
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(1, 2, 1.0),
+            Triplet::new(1, 3, 1.0),
+            Triplet::new(1, 4, 1.0),
+            Triplet::new(1, 5, 1e-4),
+        ];
+        let prob = QpProblem {
+            n: 6,
+            p_lower,
+            c,
+            a,
+            b: vec![1.0, 2.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert_eq!(sol.status, QpStatus::Optimal);
+        let mut sens = QpSensitivity::build_default(&prob, &sol, backend).unwrap();
+
+        assert!(
+            !sens.ill_conditioned(),
+            "well-conditioned KKT must NOT be flagged (κ₁ = {:.3e})",
+            sens.kkt_cond_estimate()
+        );
+        assert!(
+            sens.kkt_cond_estimate() < 1e12,
+            "κ₁ = {:.3e}",
+            sens.kkt_cond_estimate()
+        );
+
+        let dx = sens.parametric_step(&[0], &[1.0]);
+        let reference = dxdb_reference(&prob, 0);
+        let err = rel_err(&dx, &reference);
+        assert!(err < 1e-7, "dx/db rel err vs float64 LU = {err:.3e}");
+        assert!(
+            sens.last_step_residual().unwrap() < 1e-8,
+            "residual = {:?}",
+            sens.last_step_residual()
+        );
+    }
+
+    /// Refinement recovers accuracy where the information survives in double
+    /// precision (gh #284). At `eps = 1e-6` the KKT is near-LICQ enough that a
+    /// single regularized back-solve over-damps `dx/db` to ~4e-5 relative
+    /// error, yet a plain float64 LU recovers it. Refinement against the
+    /// unregularized KKT must close that gap — matching the LU reference far
+    /// better than the un-refined solve could — while the conditioning flag
+    /// stays quiet (the step *is* reliable here).
+    #[test]
+    fn refinement_recovers_dxdb_where_information_survives() {
+        let (p_lower, c) = hilbert_p_and_c();
+        let prob = QpProblem {
+            n: 6,
+            p_lower,
+            c,
+            a: near_parallel_rows(1e-6),
+            b: vec![1.0, 1.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert_eq!(sol.status, QpStatus::Optimal);
+        let mut sens = QpSensitivity::build_default(&prob, &sol, backend).unwrap();
+
+        // Recoverable, so not flagged.
+        assert!(
+            !sens.ill_conditioned(),
+            "κ₁ = {:.3e}",
+            sens.kkt_cond_estimate()
+        );
+
+        let dx = sens.parametric_step(&[0], &[1.0]);
+        let reference = dxdb_reference(&prob, 0);
+        let err = rel_err(&dx, &reference);
+        // Comfortably better than the ~4e-5 an un-refined regularized solve
+        // yields here: refinement did its job.
+        assert!(
+            err < 1e-6,
+            "refined dx/db rel err vs float64 LU = {err:.3e}"
+        );
+        assert!(
+            sens.last_step_residual().unwrap() < 1e-6,
+            "residual = {:?}",
+            sens.last_step_residual()
+        );
     }
 
     /// A non-optimal solution has no well-defined active set.

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -725,6 +725,26 @@ impl PyQpSensitivity {
         self.inner.kkt_dim()
     }
 
+    /// Hager 1-norm estimate of the KKT condition number `κ₁` (gh #284).
+    #[getter]
+    fn kkt_cond_estimate(&self) -> f64 {
+        self.inner.kkt_cond_estimate()
+    }
+
+    /// Whether the sensitivity system is near-singular enough that the
+    /// parametric step may be unreliable even after refinement (gh #284).
+    #[getter]
+    fn ill_conditioned(&self) -> bool {
+        self.inner.ill_conditioned()
+    }
+
+    /// Relative KKT residual of the most recent parametric step, or `None`
+    /// before any step has been taken (gh #284).
+    #[getter]
+    fn last_step_residual(&self) -> Option<f64> {
+        self.inner.last_step_residual()
+    }
+
     /// Inequality rows (indices into `G`) in the active set.
     #[getter]
     fn active_inequalities(&self) -> Vec<usize> {

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -848,6 +848,15 @@ class QpSensitivity:
     first-order predictor of the perturbed solution — exact while the
     active set is unchanged.
 
+    On a *near*-LICQ problem (active-constraint gradients nearly, but not
+    exactly, rank-deficient) the sensitivity KKT is near-singular and
+    ``parametric_step`` can silently over-damp ``dx/db`` (issue #284). Two
+    guards address this: the solve is internally refined against the
+    unregularized KKT to recover ``dx/db`` wherever the information survives in
+    double precision, and :attr:`ill_conditioned` / :attr:`kkt_cond_estimate`
+    (build-time) and :attr:`last_step_residual` (per-step) let a caller
+    *detect* when a step is untrustworthy.
+
     Example
     -------
     >>> import numpy as np
@@ -907,6 +916,58 @@ class QpSensitivity:
         harder case where the count does not move at all.
         """
         return int(self._inner.kkt_dim)
+
+    @property
+    def kkt_cond_estimate(self) -> float:
+        """Estimated condition number ``κ₁`` of the active-set KKT system.
+
+        A cheap Hager 1-norm estimate of the conditioning of the (factored)
+        sensitivity system. It is the quantitative early-warning that
+        :attr:`kkt_dim` and :attr:`weakly_active_indices` cannot give: on a
+        *near*-LICQ problem — where the active-constraint gradients are nearly
+        (not exactly) rank-deficient — the KKT is near-singular and
+        :meth:`parametric_step` can silently over-damp ``dx/db`` toward a
+        smooth but badly wrong value (issue #284). A large estimate flags that
+        risk.
+
+        Well-conditioned sensitivities report a modest value (a few ``×10⁹``
+        even on badly-scaled data); a numerically singular one saturates near
+        ``1e16``. See :attr:`ill_conditioned` for the thresholded boolean and
+        :attr:`last_step_residual` for the achieved per-step residual.
+        """
+        return float(self._inner.kkt_cond_estimate)
+
+    @property
+    def ill_conditioned(self) -> bool:
+        """Whether ``dx/db`` may be unreliable because the KKT is near-singular.
+
+        ``True`` when :attr:`kkt_cond_estimate` exceeds an internal threshold
+        (``1e14``) — the regime where the sensitivity system is so near-LICQ
+        that even the internal iterative refinement cannot recover ``dx/db``
+        from double precision (issue #284). It stays ``False`` on
+        well-conditioned problems, including the badly-scaled equality-only and
+        active-set cases, so it does not false-alarm.
+
+        Use it as a guard: if ``ill_conditioned`` is ``True``, treat the
+        :meth:`parametric_step` result as untrustworthy (or cross-check it),
+        rather than consuming the silently-damped value.
+        """
+        return bool(self._inner.ill_conditioned)
+
+    @property
+    def last_step_residual(self) -> Optional[float]:
+        """Relative KKT residual of the most recent :meth:`parametric_step`.
+
+        ``‖rhs − K·step‖∞ / (1 + ‖rhs‖∞)`` measured against the *unregularized*
+        KKT, or ``None`` before any step has been taken. It reports how well the
+        returned step actually satisfies the true sensitivity system (issue
+        #284): a round-off-level value means the step is trustworthy; a large
+        one means the refinement could not solve the near-singular system and
+        the step is unreliable. This is the per-query companion to the
+        build-time :attr:`ill_conditioned` / :attr:`kkt_cond_estimate`.
+        """
+        r = self._inner.last_step_residual
+        return None if r is None else float(r)
 
     @property
     def active_indices(self) -> ActiveSet:

--- a/python/tests/test_qp_sensitivity.py
+++ b/python/tests/test_qp_sensitivity.py
@@ -342,3 +342,93 @@ def test_weakly_active_matches_the_one_sided_branches():
     matches_fwd = np.allclose(dx, fwd, atol=5e-3)
     matches_bwd = np.allclose(dx, bwd, atol=5e-3)
     assert matches_fwd != matches_bwd, f"dx={dx} fwd={fwd} bwd={bwd}"
+
+
+# ---- gh #284: near-LICQ conditioning diagnostic + refinement --------------
+
+
+def _hilbert_qp_data():
+    """The gh #284 family: P = D·H6·D (Hilbert, cond ≈ 7e15), badly scaled."""
+    d = np.array([1e3, 1e2, 1e1, 1.0, 1e-1, 1e-2])
+    H = np.array([[1.0 / (i + j + 1) for j in range(6)] for i in range(6)])
+    P = np.outer(d, d) * H
+    c = np.array([1.0, -2.0, 3.0, -1.0, 0.5, -0.25])
+    return P, c
+
+
+def _near_parallel_A(eps):
+    """Two nearly-parallel equality rows differing by ``eps`` (near-LICQ)."""
+    return np.array([[1.0] * 6, [1.0] * 5 + [1.0 + eps]])
+
+
+def _dxdb_lu_reference(P, A, pin):
+    """dx/db = x-block of the true (unregularized) KKT solve with rhs [0; e_pin],
+    by plain float64 LU — the reference the issue shows recovers the info."""
+    n, m = P.shape[0], A.shape[0]
+    K = np.zeros((n + m, n + m))
+    K[:n, :n] = P
+    K[:n, n:] = A.T
+    K[n:, :n] = A
+    rhs = np.zeros(n + m)
+    rhs[n + pin] = 1.0
+    return np.linalg.solve(K, rhs)[:n]
+
+
+def test_near_licq_sensitivity_is_flagged_ill_conditioned():
+    # The heart of gh #284: on a near-LICQ QP, dx/db silently over-damps to a
+    # ~100%-wrong value while every existing signal looks ordinary. The new
+    # diagnostic must let a caller DETECT that.
+    P, c = _hilbert_qp_data()
+    s = QpSensitivity(P=P, c=c, A=_near_parallel_A(1e-10), b=[1.0, 1.0])
+    # The old signals stay silent.
+    assert not s.weakly_active_indices
+    # The new diagnostic fires.
+    assert s.ill_conditioned
+    assert s.kkt_cond_estimate > 1e14
+    # And the per-step residual confirms the near-singular step was not solved.
+    s.parametric_step([0], [1.0])
+    assert s.last_step_residual > 1e-6
+
+
+def test_well_conditioned_sensitivity_not_flagged_and_accurate():
+    # The false-alarm guard: the badly-scaled but full-rank equality case
+    # (cond(KKT) ≈ 5e9). The diagnostic must stay quiet and dx/db must match a
+    # plain float64 LU reference to ~1e-7.
+    P, c = _hilbert_qp_data()
+    A = np.array([[1.0] * 6, [1e4, 1.0, 1.0, 1.0, 1.0, 1e-4]])
+    s = QpSensitivity(P=P, c=c, A=A, b=[1.0, 2.0])
+    assert not s.ill_conditioned
+    assert s.kkt_cond_estimate < 1e12
+    dx = s.parametric_step([0], [1.0])
+    ref = _dxdb_lu_reference(P, A, 0)
+    scale = max(1.0, np.abs(ref).max())
+    assert np.abs(dx - ref).max() / scale < 1e-7
+    assert s.last_step_residual < 1e-8
+
+
+def test_refinement_recovers_dxdb_where_information_survives():
+    # At eps = 1e-6 a single regularized back-solve over-damps dx/db to ~4e-5
+    # rel err, but float64 LU recovers it. Internal refinement must close that
+    # gap, and the flag must stay quiet (the step IS reliable here).
+    P, c = _hilbert_qp_data()
+    A = _near_parallel_A(1e-6)
+    s = QpSensitivity(P=P, c=c, A=A, b=[1.0, 1.0])
+    assert not s.ill_conditioned
+    dx = s.parametric_step([0], [1.0])
+    ref = _dxdb_lu_reference(P, A, 0)
+    scale = np.abs(ref).max()
+    # Comfortably better than the ~4e-5 an un-refined solve yields here.
+    assert np.abs(dx - ref).max() / scale < 1e-6
+    assert s.last_step_residual < 1e-6
+
+
+def test_diagnostic_attributes_before_any_step():
+    # kkt_cond_estimate / ill_conditioned are build-time (no step needed);
+    # last_step_residual is None until a step is taken.
+    P, c = _hilbert_qp_data()
+    s = QpSensitivity(P=P, c=c, A=_near_parallel_A(1e-6), b=[1.0, 1.0])
+    assert s.last_step_residual is None
+    assert isinstance(s.kkt_cond_estimate, float)
+    assert isinstance(s.ill_conditioned, bool)
+    s.parametric_step([0], [1.0])
+    assert s.last_step_residual is not None


### PR DESCRIPTION
Fixes #284.

## The defect

On a QP with near-rank-deficient (near-LICQ) equality rows, `QpSensitivity.parametric_step` returned a `dx/db` that collapsed to a smoothly over-damped, badly wrong value — **silently**. The static KKT regularization `δ` floors the smallest singular value of the near-singular system, so a single back-solve returns a tame, smooth, ~100%-wrong sensitivity while `weakly_active_indices` is empty, `kkt_dim` is full, no status changes, and no exception is raised. A plain float64 `numpy.linalg.solve` on the identical KKT matrix and rhs stays accurate to ~1e-6, so the information was present in double precision — the loss was **algorithmic (over-regularization), not a precision wall**. A caller had no way to detect the sensitivity was meaningless.

## What this PR adds

The invisibility was the actual defect, so the headline is a diagnostic; refinement additionally recovers accuracy where the information survives.

### 1. Conditioning diagnostic (build-time, RHS-independent)

Three new backward-compatible attributes on `QpSensitivity` (Rust, PyO3, and the `pounce.qp` wrapper):

- **`kkt_cond_estimate`** — a cheap Hager/Higham 1-norm estimate of the KKT condition number `κ₁`, computed once at build from a handful of back-solves against the existing factor (matched the exact 1-norm condition on #284's sweep).
- **`ill_conditioned`** — boolean, `True` when `κ₁ > 1e14`.
- **`last_step_residual`** — the relative KKT residual `‖rhs − K·step‖∞ / (1 + ‖rhs‖∞)` the most recent step achieved, measured against the *unregularized* system (`None` before any step). The per-query companion to the build-time flag.

A caller now guards with `if s.ill_conditioned:` (or inspects `kkt_cond_estimate` / `last_step_residual`) instead of consuming a silently-damped value.

### 2. Accuracy — iterative refinement against the unregularized KKT

Each parametric step is now refined against the true (`δ`-free) KKT, stripping the `O(δ)` regularization bias wherever the information survives in double precision. This directly attacks the over-regularization. On a well-conditioned KKT the first residual is already at round-off, so refinement is a no-op — the good cases are untouched.

## Evidence (the #284 sweep, eps = row-parallelism gap)

| eps | cond estimate | `ill_conditioned` | `dx/db` rel err (before -> after) |
|-----|--------------|-------------------|-------------------------------|
| well-cond. case 1 | 7.4e9 | **False** | 1.6e-7 -> **7.1e-14** |
| well-cond. case 2 (active ineq) | 3.9e9 | **False** | 2.1e-7 -> **6.6e-14** |
| 1e-6 | 3.0e12 | False | 4.1e-5 -> **1.3e-10** |
| 1e-7 | 6.8e13 | False | 4.1e-3 -> **6.9e-11** |
| 1e-8 | 3.2e15 | **True** | 2.9e-1 -> 5.9e-4 |
| 1e-9 | 1.0e16 | **True** | 9.8e-1 -> 8.6e-1 |
| 1e-10 | 1.1e16 | **True** | 1.0e0 -> 1.0e0 |

- **Fires on the near-LICQ sweep** exactly where the result is untrustworthy (eps <= 1e-8, where even refinement cannot recover the step from double precision — `last_step_residual` there is 5e-4 to 0.25).
- **Stays quiet with margin** on the well-conditioned cases (case 1/2, and every case refinement rescues). The threshold `1e14` sits in the wide gap between the well-conditioned regime (κ₁ ~ 3-8e9) and the numerically-singular one (κ₁ saturates ~ 1e16), so there is no false alarm.
- **Refinement recovers accuracy** where the information is present: eps 1e-6/1e-7 improve from 4e-5/4e-3 to ~1e-10, and the badly-scaled well-conditioned cases improve from ~1.6e-7 to ~7e-14, matching float64 LU. No regression to the well-conditioned equality-only or active-set paths; the strictly-complementary inequality case (exact multiplier 2.28e-5) is unchanged.

## Tests

- Rust (`cargo test -p pounce-convex`): near-LICQ instance triggers `ill_conditioned` while old signals stay silent; well-conditioned instance is not flagged and `dx/db` matches an inline float64-LU reference to ~1e-7; refinement recovers `dx/db` at eps = 1e-6 to < 1e-6 (vs the un-refined ~4e-5). All 157 lib tests pass.
- Python (`test_qp_sensitivity.py`): mirrors the above plus the attribute contract (`last_step_residual is None` before a step). All pass; existing sensitivity/session/host tests unaffected.
- `cargo clippy` (CI's `-D correctness -D suspicious`) and `cargo fmt --all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
