### PR TITLE
Detect null(A_eq) free-variable recession rays as unbounded (#285)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,40 @@ changes.
     the ones the diagnostic flags. Well-conditioned solves are unaffected (their
     first residual is already at round-off, so refinement is a no-op).
 
+### Fixed — NLP-path divergence detector missed an unbounded LP whose recession ray lies in `null(A_eq)` over free variables (#285)
+
+- **On the forced-NLP path, an unbounded LP whose recession ray lives in the
+  equality null space over *free* variables (e.g. `min −x0 s.t. x0 − x1 = 0`,
+  ray `d = (1, 1)`) reported `Maximum_Iterations_Exceeded` instead of the
+  unbounded verdict `Diverging_Iterates`** that Ipopt, scipy/HiGHS and Clarabel
+  all return on the identical model. The existing `diverging_iterates_tol`
+  (`1e20`) magnitude guard only fires once `|x|_∞` crosses `1e20` and only
+  accumulates its streak on geometric growth; a recession ray in an equality
+  null space is walked out by regularized zero-Hessian Newton steps whose
+  growth decelerates so hard that `|x|` never reaches `1e20` within `max_iter`
+  (it stalls around `5e17` even at `max_iter = 3000`), so the guard never
+  fired. No wrong answer was ever certified — both statuses are non-success —
+  but the conservative fallback hid a definite certificate. The fix adds a
+  second, independent **checked recession-ray proof** to the running divergence
+  guard (`crates/pounce-algorithm/src/ipopt_alg.rs`), active from a far lower
+  magnitude floor (`1e10`): a genuinely *feasible* iterate of large norm
+  already witnesses that the feasible region is unbounded, and the proof
+  additionally certifies the escape direction lies in `null(A_eq)`
+  (`‖J_c x‖∞ ≪ |x|∞`), is not blocked by any finitely-bounded inequality
+  (`Pd_L`/`Pd_U` expansion), heads toward a variable side with no finite bound
+  (the existing free-to-escape check), and strictly lowers the objective
+  (`∇f·x ≤ −ε‖∇f‖‖x‖`) — for several consecutive *growing* iterations. Because
+  a bounded feasible region cannot supply a growing sequence of feasible
+  over-floor iterates, this remains a proof rather than a heuristic and cannot
+  manufacture a false `Diverging_Iterates` on a bounded problem. The existing
+  `1e20` magnitude guard is unchanged (new path is a pure `OR` branch), so the
+  unbounded shapes that already worked — unconstrained rays,
+  bounded-inequality rays — still report unbounded, and the #248 / #252
+  bounded / finite-optimum controls stay green. Regression tests in
+  `crates/pounce-algorithm/tests/repro_issue285.rs` pin the fixed shape as
+  `DivergingIterates` alongside four bounded controls (variable-bounded,
+  fully-pinned by equalities, and inequality-capped free variable) as optimal.
+
 ### Fixed — non-symmetric HSDE driver returned bare `numerical_failure` on infeasible/unbounded exp/power programs (#283)
 
 - **The exponential/power-cone (non-symmetric HSDE) driver degraded genuinely

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -138,6 +138,20 @@ pub struct IpoptAlgorithm {
     /// toward zero. `NaN` (non-finite) until the run has a first finite
     /// decrease to compare against, which bootstraps the check.
     divergence_prev_decrease: Number,
+    /// #285 recession-ray persistence — consecutive iterations for which the
+    /// *checked recession-ray proof* ([`Self::curr_is_recession_ray`]) held
+    /// while the primal iterate kept growing. This is a second, independent
+    /// unboundedness path that catches a genuine recession ray in
+    /// `null(A_eq)` over free variables whose `|x|` grows only *linearly*
+    /// (the regularized zero-Hessian step in an equality null space marches
+    /// out at a bounded rate), so it never crosses `diverging_iterates_tol`
+    /// (`1e20`) within `max_iter` and the geometric-growth
+    /// [`Self::divergence_streak`] never accumulates. Reset to zero whenever
+    /// the proof fails or the iterate stops growing.
+    recession_streak: u32,
+    /// Largest `|x|` seen in the current recession-ray run (companion to
+    /// [`Self::recession_streak`]). Zero when no run is active.
+    recession_prev_amax: Number,
     /// Companion threshold on the dual step — when both primal and dual
     /// steps are tiny in two consecutive iterations the algorithm
     /// declares convergence at the best attainable accuracy. Default
@@ -331,6 +345,8 @@ impl IpoptAlgorithm {
             divergence_prev_amax: 0.0,
             divergence_prev_f: Number::INFINITY,
             divergence_prev_decrease: Number::NAN,
+            recession_streak: 0,
+            recession_prev_amax: 0.0,
             tiny_step_y_tol: 1e-2,
             dual_diverging_streak: 15,
             dual_inf_prev: 0.0,
@@ -435,6 +451,40 @@ impl IpoptAlgorithm {
     /// user threshold no longer fires on the way to a finite optimum.
     const DIVERGENCE_ABS_RUNAWAY: Number = 1e18;
 
+    /// #285: magnitude floor for the checked recession-ray unboundedness path.
+    /// Below this the (slightly more expensive) recession proof is not even
+    /// attempted, so it is inert on every normal, well-scaled solve. Above it,
+    /// unboundedness is only ever concluded through the full checked proof in
+    /// [`Self::curr_is_recession_ray`] — a genuinely *feasible* iterate of this
+    /// magnitude already witnesses an unbounded feasible region, and the proof
+    /// additionally certifies the escape direction. Sits far below the
+    /// `diverging_iterates_tol` (`1e20`) magnitude guard so a linearly-growing
+    /// ray (which never reaches `1e20` within `max_iter`) is still caught.
+    const RECESSION_MIN_NORM: Number = 1e10;
+    /// #285: consecutive growing, proof-passing iterations required before the
+    /// recession-ray path reports `DivergingIterates`. A bounded feasible
+    /// region cannot supply a *growing* sequence of feasible over-floor
+    /// iterates, so persistence is defense-in-depth against a lone numerical
+    /// fluke rather than a soundness requirement.
+    const RECESSION_PERSIST_ITERS: u32 = 4;
+    /// #285: relative feasibility bar for the recession proof. The current
+    /// iterate counts as feasible (hence a witness that the feasible region
+    /// reaches its magnitude) when its unscaled max-norm primal infeasibility
+    /// is at most this fraction of `|x|_∞`. The check is *relative* on purpose:
+    /// evaluating `A_eq x − b` at `|x| ~ 1e17` carries floating-point roundoff
+    /// that scales with `|x|`, while a genuinely infeasible excursion (e.g.
+    /// mid-restoration) has a residual comparable to `|x|` itself.
+    const RECESSION_FEAS_REL: Number = 1e-6;
+    /// #285: relative bar for "the escape direction lies in `null(A_eq)`".
+    /// `‖J_c x‖_∞ ≤ this · |x|_∞` certifies that moving along `d ≈ x` preserves
+    /// the (linearized) equality constraints — `A_eq d ≈ 0`.
+    const RECESSION_DIR_TOL: Number = 1e-6;
+    /// #285: relative descent bar. The objective must strictly decrease along
+    /// the escape direction with a real margin — `∇f·x ≤ −this · ‖∇f‖ ‖x‖` —
+    /// so a variable drifting orthogonally to the objective (`∇f·x ≈ 0`) can
+    /// never be mistaken for a recession ray driving `f → −∞`.
+    const RECESSION_DESC_REL: Number = 1e-6;
+
     /// Update the divergence-persistence state for the current iterate and
     /// return whether `DivergingIterates` should be reported now (issues
     /// #248 / #252). `amax` is `max_i |x_i|`; `structural_free` is the result
@@ -521,9 +571,19 @@ impl IpoptAlgorithm {
     }
 
     fn divergence_is_true_unboundedness(&self, x: &dyn Vector) -> bool {
+        self.free_to_escape_over(x, self.diverging_iterates_tol)
+    }
+
+    /// Shared core of the free-variable structural check: returns `true` when
+    /// some component of `x` with magnitude exceeding `thresh` is heading
+    /// toward a side (positive → upper, negative → lower) that carries *no*
+    /// finite bound, so it is free to escape to infinity. Parameterized on the
+    /// magnitude threshold so both the `diverging_iterates_tol` (`1e20`)
+    /// divergence guard and the lower `RECESSION_MIN_NORM` recession-ray path
+    /// (#285) share one implementation.
+    fn free_to_escape_over(&self, x: &dyn Vector, thresh: Number) -> bool {
         use pounce_linalg::DenseVector;
 
-        let tol = self.diverging_iterates_tol;
         let cq = self.cq.borrow();
         let nlp = cq.nlp().borrow();
 
@@ -554,7 +614,7 @@ impl IpoptAlgorithm {
         };
 
         for i in 0..xv.len() {
-            if xv[i].abs() > tol {
+            if xv[i].abs() > thresh {
                 let free_to_diverge = if xv[i] > 0.0 {
                     ub[i] == 0.0
                 } else {
@@ -566,6 +626,145 @@ impl IpoptAlgorithm {
             }
         }
         false
+    }
+
+    /// #285: checked recession-ray unboundedness proof at the current iterate.
+    ///
+    /// Returns `true` only when the current iterate `x` (with `|x|_∞ = amax`,
+    /// already known `> RECESSION_MIN_NORM` by the caller) *proves* the
+    /// problem is unbounded below via a genuine recession ray — the same
+    /// standard the LP/symmetric path holds itself to, not a magnitude
+    /// heuristic. All of the following must hold:
+    ///
+    /// 1. **Feasible witness.** The iterate's unscaled primal infeasibility is
+    ///    at most `RECESSION_FEAS_REL · amax`. A genuinely feasible iterate of
+    ///    norm `≥ 1e10` witnesses that the feasible region reaches that far —
+    ///    a *bounded* region cannot contain it. (Relative bar: the residual of
+    ///    `A_eq x − b` carries roundoff that scales with `|x|`.)
+    /// 2. **Free to escape.** Some over-floor component heads toward a side
+    ///    with no finite variable bound ([`Self::free_to_escape_over`] at
+    ///    `RECESSION_MIN_NORM`).
+    /// 3. **Direction in `null(A_eq)`.** `‖J_c x‖_∞ ≤ RECESSION_DIR_TOL · amax`
+    ///    — moving along `d ≈ x` preserves the equality constraints.
+    /// 4. **Inequalities not blocking.** No finitely-bounded inequality row is
+    ///    driven toward its bound along `d ≈ x`
+    ///    ([`Self::recession_blocked_by_inequality`]).
+    /// 5. **Objective descending.** `∇f·x ≤ −RECESSION_DESC_REL · ‖∇f‖ ‖x‖` —
+    ///    the objective strictly decreases along the escape direction with a
+    ///    real (non-orthogonal) margin, so `f → −∞` along the ray.
+    ///
+    /// On a *bounded* problem at least one of (1)/(2)/(3)/(4)/(5) fails, so
+    /// this can never manufacture a spurious `DivergingIterates`.
+    fn curr_is_recession_ray(&self, x: &dyn Vector, amax: Number) -> bool {
+        // (1) Feasible witness (relative bar).
+        let primal_inf = self.cq.borrow().curr_unscaled_primal_infeasibility_max();
+        if !(primal_inf.is_finite() && primal_inf <= Self::RECESSION_FEAS_REL * amax) {
+            return false;
+        }
+        // (2) Some over-floor component free to escape to infinity.
+        if !self.free_to_escape_over(x, Self::RECESSION_MIN_NORM) {
+            return false;
+        }
+        // (3) Escape direction lies in the equality null space. A non-finite
+        // (NaN) residual is treated as failing, so the direction is only
+        // accepted on a genuinely small, finite `‖J_c x‖∞`.
+        let jc_x_amax = self.cq.borrow().curr_jac_c_times_vec(x).amax();
+        if !jc_x_amax.is_finite() || jc_x_amax > Self::RECESSION_DIR_TOL * amax {
+            return false;
+        }
+        // (4) No finitely-bounded inequality blocks the direction.
+        if self.recession_blocked_by_inequality(x, amax) {
+            return false;
+        }
+        // (5) Objective strictly descending along the escape direction.
+        let (dot, gnorm, xnorm) = {
+            let cq = self.cq.borrow();
+            let g = cq.curr_grad_f();
+            (g.dot(x), g.nrm2(), x.nrm2())
+        };
+        if !(dot < 0.0 && dot <= -Self::RECESSION_DESC_REL * gnorm * xnorm) {
+            return false;
+        }
+        true
+    }
+
+    /// #285: does any *finitely-bounded* inequality constraint block motion
+    /// along the escape direction `d ≈ x`? For each inequality row the
+    /// constraint value `d(x)` changes at rate `(J_d x)_j` per unit of the
+    /// direction; if that row has a finite upper bound and the rate is
+    /// positive (or a finite lower bound and the rate is negative) beyond a
+    /// relative tolerance, moving out along `d` would eventually violate it,
+    /// so it is not a feasible recession direction. Bounds are detected via
+    /// the `Pd_L / Pd_U` expansion matrices exactly as the variable-bound
+    /// check uses `Px_L / Px_U`.
+    fn recession_blocked_by_inequality(&self, x: &dyn Vector, amax: Number) -> bool {
+        use pounce_linalg::DenseVector;
+
+        let cq = self.cq.borrow();
+        // Rate of change of each inequality value along d ≈ x (length m_ineq).
+        // Compute first so the internal `nlp.borrow_mut()` is released before
+        // the immutable borrow below.
+        let jd_x = cq.curr_jac_d_times_vec(x);
+        let (has_dlb, has_dub) = {
+            let nlp = cq.nlp().borrow();
+            let mut ones_dl = nlp.d_l().make_new();
+            ones_dl.set(1.0);
+            let mut has_dlb = jd_x.make_new();
+            nlp.pd_l().mult_vector(1.0, &*ones_dl, 0.0, &mut *has_dlb);
+
+            let mut ones_du = nlp.d_u().make_new();
+            ones_du.set(1.0);
+            let mut has_dub = jd_x.make_new();
+            nlp.pd_u().mult_vector(1.0, &*ones_du, 0.0, &mut *has_dub);
+            (has_dub, has_dlb)
+        };
+
+        let downcast = |v: &dyn Vector| -> Option<Vec<Number>> {
+            v.as_any()
+                .downcast_ref::<DenseVector>()
+                .map(|d| d.expanded_values())
+        };
+        // Dense-only fallback: if we cannot inspect the rows, conservatively
+        // treat the direction as blocked (no spurious unbounded verdict).
+        let (Some(jd), Some(dlb), Some(dub)) =
+            (downcast(&*jd_x), downcast(&*has_dlb), downcast(&*has_dub))
+        else {
+            return true;
+        };
+        let tol = Self::RECESSION_DIR_TOL * amax;
+        for j in 0..jd.len() {
+            // Increasing a row that has a finite upper bound, or decreasing a
+            // row that has a finite lower bound, would leave the feasible set.
+            if (jd[j] > tol && dub[j] != 0.0) || (jd[j] < -tol && dlb[j] != 0.0) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// #285: update the recession-ray persistence state and return whether
+    /// `DivergingIterates` should be reported now. `amax` is `|x|_∞`;
+    /// `is_ray` is the result of [`Self::curr_is_recession_ray`]. The verdict
+    /// fires once the checked proof has held for
+    /// [`Self::RECESSION_PERSIST_ITERS`] consecutive *growing* iterations — a
+    /// bounded region cannot supply a growing sequence of feasible over-floor
+    /// iterates, so this is impossible to satisfy on a bounded problem.
+    fn update_recession_verdict(&mut self, amax: Number, is_ray: bool) -> bool {
+        if !is_ray {
+            self.recession_streak = 0;
+            self.recession_prev_amax = 0.0;
+            return false;
+        }
+        if amax > self.recession_prev_amax {
+            self.recession_streak += 1;
+        } else {
+            // Proof holds but the iterate is not growing (a stalled or rejected
+            // step). Restart the run at the current witness rather than firing
+            // on a plateau; a genuine ray resumes growing next step.
+            self.recession_streak = 1;
+        }
+        self.recession_prev_amax = amax;
+        self.recession_streak >= Self::RECESSION_PERSIST_ITERS
     }
 
     /// Honour a certificate the masked-scale veto refused, when the run that
@@ -1339,23 +1538,45 @@ impl IpoptAlgorithm {
         // Evaluate the structural check under an immutable borrow, then
         // update the persistence state and take the verdict separately so
         // the mutable field updates don't clash with the `data` borrow.
-        let (amax, structural_free) = {
+        // Two independent unboundedness paths share this block:
+        //   * the `diverging_iterates_tol` (`1e20`) magnitude guard, gated on
+        //     the free-variable structural check + geometric-growth streak
+        //     (issues #248 / #252); and
+        //   * the #285 recession-ray path — a *checked proof*, active from a
+        //     far lower magnitude floor, that catches a genuine recession ray
+        //     in `null(A_eq)` over free variables whose `|x|` grows only
+        //     linearly and so never reaches `1e20` within `max_iter`.
+        let (amax, structural_free, is_ray) = {
             let data = self.data.borrow();
             match data.curr.as_ref() {
                 Some(curr) => {
                     let amax = curr.x.amax();
                     let structural = amax > self.diverging_iterates_tol
                         && self.divergence_is_true_unboundedness(&*curr.x);
-                    (Some(amax), structural)
+                    let is_ray = amax > Self::RECESSION_MIN_NORM
+                        && self.curr_is_recession_ray(&*curr.x, amax);
+                    (Some(amax), structural, is_ray)
                 }
-                None => (None, false),
+                None => (None, false, false),
             }
         };
         // Evaluate the (scaled) objective only while a structural divergence
         // is live — the streak's descent gate needs it, and it costs an
         // objective evaluation, so skip it on the common non-diverging path.
         let curr_f = structural_free.then(|| self.cq.borrow().curr_f());
-        if self.update_divergence_verdict(amax, structural_free, curr_f) {
+        // Evaluate both streak updates (no short-circuit) so each keeps its
+        // state current, then fire if either concludes divergence.
+        let fire_magnitude = self.update_divergence_verdict(amax, structural_free, curr_f);
+        let fire_recession = self.update_recession_verdict(amax.unwrap_or(0.0), is_ray);
+        if fire_magnitude || fire_recession {
+            if fire_recession && !fire_magnitude {
+                tracing::debug!(target: "pounce::algorithm",
+                    "[POUNCE] recession-ray guard fired at iter {} (|x|_inf={:.2e}); \
+                     reporting DivergingIterates (pounce#285).",
+                    self.data.borrow().iter_count,
+                    amax.unwrap_or(f64::NAN),
+                );
+            }
             timing.check_convergence.end();
             return IterateOutcome::Terminate(SolverReturn::DivergingIterates);
         }

--- a/crates/pounce-algorithm/tests/repro_issue285.rs
+++ b/crates/pounce-algorithm/tests/repro_issue285.rs
@@ -1,0 +1,273 @@
+//! Regression tests for issue #285: the NLP-path divergence detector missed
+//! an unbounded LP whose recession ray lies in `null(A_eq)` over **free**
+//! variables.
+//!
+//! The `1e20` `diverging_iterates_tol` magnitude guard (issues #248 / #252)
+//! only fires once `|x|_∞` crosses `1e20`, and only accumulates its streak on
+//! *geometric* growth. A recession ray in an equality null space over free
+//! variables (`min −x0  s.t.  x0 − x1 = 0`, ray `d = (1, 1)`) is walked out by
+//! regularized zero-Hessian Newton steps at a bounded, roughly *linear* rate,
+//! so `|x|` never reaches `1e20` within `max_iter` and the geometric streak
+//! never accumulates — POUNCE reported `Maximum_Iterations_Exceeded` while
+//! Ipopt reported `Diverging_Iterates` on the identical model.
+//!
+//! The fix adds a second, independent unboundedness path: a *checked
+//! recession-ray proof* active from a far lower magnitude floor. A genuinely
+//! feasible iterate of large norm already witnesses that the feasible region
+//! is unbounded; the proof additionally certifies the escape direction lies in
+//! `null(A_eq)`, is not blocked by any finitely-bounded inequality, heads
+//! toward an unbounded variable side, and strictly lowers the objective. That
+//! makes it a proof, not a magnitude heuristic — so it must fire on the
+//! unbounded shape yet stay silent on every bounded control below.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// A dense linear program `min cᵀx  s.t.  gₗ ≤ A x ≤ gᵤ,  xₗ ≤ x ≤ xᵤ`.
+/// General enough to express both the `null(A_eq)` unbounded ray and its
+/// bounded controls (add a variable bound, or a second pinning equality).
+struct DenseLp {
+    n: usize,
+    m: usize,
+    c: Vec<Number>,
+    a: Vec<Number>, // row-major m×n
+    g_l: Vec<Number>,
+    g_u: Vec<Number>,
+    x_l: Vec<Number>,
+    x_u: Vec<Number>,
+    x0: Vec<Number>,
+    final_obj: Option<Number>,
+}
+
+impl DenseLp {
+    fn a(&self, i: usize, j: usize) -> Number {
+        self.a[i * self.n + j]
+    }
+}
+
+impl TNLP for DenseLp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: self.n as i32,
+            m: self.m as i32,
+            nnz_jac_g: (self.m * self.n) as i32,
+            nnz_h_lag: 0, // linear objective + constraints ⇒ zero Hessian
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&self.x_l);
+        b.x_u.copy_from_slice(&self.x_u);
+        b.g_l.copy_from_slice(&self.g_l);
+        b.g_u.copy_from_slice(&self.g_u);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&self.x0);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((0..self.n).map(|j| self.c[j] * x[j]).sum())
+    }
+
+    fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&self.c);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..self.m {
+            g[i] = (0..self.n).map(|j| self.a(i, j) * x[j]).sum();
+        }
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let mut k = 0;
+                for i in 0..self.m {
+                    for j in 0..self.n {
+                        irow[k] = i as i32;
+                        jcol[k] = j as i32;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&self.a);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        _obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        _mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Zero Hessian (LP): no structure entries, nothing to fill.
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_obj = Some(sol.obj_value);
+    }
+}
+
+fn solve(inst: Rc<RefCell<DenseLp>>, max_iter: i32) -> (ApplicationReturnStatus, Number) {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("max_iter", max_iter, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = inst;
+    let status = app.optimize_tnlp(tnlp);
+    let obj = app.statistics().final_objective;
+    (status, obj)
+}
+
+const INF: Number = 2e19; // > 1e19 infinity sentinel
+
+/// The headline case: `min −x0  s.t.  x0 − x1 = 0`, both variables free. The
+/// recession ray `d = (1, 1)` lies in `null(A_eq)`, `cᵀd = −1 < 0`. Before the
+/// fix this ran to `Maximum_Iterations_Exceeded`; it must now report
+/// `DivergingIterates` — POUNCE's (Ipopt `ApplicationReturnStatus`) unbounded
+/// verdict — matching Ipopt, scipy/HiGHS and Clarabel on the same model.
+#[test]
+fn null_aeq_free_var_unbounded_reports_diverging() {
+    // Reproducible across the iteration budgets the adversary exercised.
+    for &max_iter in &[300, 3000] {
+        let inst = Rc::new(RefCell::new(DenseLp {
+            n: 2,
+            m: 1,
+            c: vec![-1.0, 0.0],
+            a: vec![1.0, -1.0],
+            g_l: vec![0.0],
+            g_u: vec![0.0],
+            x_l: vec![-INF, -INF],
+            x_u: vec![INF, INF],
+            x0: vec![0.0, 0.0],
+            final_obj: None,
+        }));
+        let (status, obj) = solve(Rc::clone(&inst), max_iter);
+        assert!(
+            matches!(status, ApplicationReturnStatus::DivergingIterates),
+            "max_iter={max_iter}: a recession ray in null(A_eq) over free \
+             variables must report DivergingIterates (issue #285); got \
+             {status:?} obj={obj}",
+        );
+    }
+}
+
+/// Bounded control A — identical structure, but `x0` carries a finite upper
+/// bound. The ray is now capped; the optimum is `x0 = x1 = 10`, `obj = −10`.
+/// Must solve, never falsely report unbounded. Pins that the new recession
+/// path's free-to-escape gate keys on the *variable bound*.
+#[test]
+fn null_aeq_bounded_by_var_upper_is_optimal() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 2,
+        m: 1,
+        c: vec![-1.0, 0.0],
+        a: vec![1.0, -1.0],
+        g_l: vec![0.0],
+        g_u: vec![0.0],
+        x_l: vec![-INF, -INF],
+        x_u: vec![10.0, INF],
+        x0: vec![0.0, 0.0],
+        final_obj: None,
+    }));
+    let (status, obj) = solve(Rc::clone(&inst), 3000);
+    assert!(
+        !matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "a bounded variant (x0 ≤ 10) must not report DivergingIterates \
+         (issue #285); got {status:?} obj={obj}",
+    );
+    assert!(
+        (obj - (-10.0)).abs() < 1e-5,
+        "bounded variant objective {obj} is not the finite optimum -10",
+    );
+}
+
+/// Bounded control B — the same free variables and one equality, plus a second
+/// equality `x0 + x1 = 4` that fully determines `x0 = x1 = 2` (`obj = −2`). The
+/// feasible set is a single point: bounded despite free variable bounds. Must
+/// solve to the optimum, never falsely report unbounded. Pins that the
+/// recession path's `null(A_eq)` direction / feasibility gate is not fooled by
+/// free variables when the equalities themselves pin the region.
+#[test]
+fn free_vars_with_pinning_equalities_is_optimal() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 2,
+        m: 2,
+        c: vec![-1.0, 0.0],
+        a: vec![1.0, -1.0, 1.0, 1.0],
+        g_l: vec![0.0, 4.0],
+        g_u: vec![0.0, 4.0],
+        x_l: vec![-INF, -INF],
+        x_u: vec![INF, INF],
+        x0: vec![0.0, 0.0],
+        final_obj: None,
+    }));
+    let (status, obj) = solve(Rc::clone(&inst), 3000);
+    assert!(
+        !matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "a bounded, fully-pinned variant must not report DivergingIterates \
+         (issue #285); got {status:?} obj={obj}",
+    );
+    assert!(
+        (obj - (-2.0)).abs() < 1e-5,
+        "pinned variant objective {obj} is not the finite optimum -2",
+    );
+}
+
+/// Bounded control C — the escape direction is blocked by a *finitely-bounded
+/// inequality*, not a variable bound: `min −x0  s.t.  x0 ≤ 1e8`, `x` free. The
+/// variable is free (so the free-to-escape gate alone would admit it), but the
+/// inequality caps the ray, so the problem is bounded with optimum `−1e8`. Pins
+/// that [`recession_blocked_by_inequality`] prevents a false positive here.
+#[test]
+fn free_var_capped_by_inequality_is_optimal() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 1,
+        m: 1,
+        c: vec![-1.0],
+        a: vec![1.0],
+        g_l: vec![-INF],
+        g_u: vec![1e8],
+        x_l: vec![-INF],
+        x_u: vec![INF],
+        x0: vec![0.0],
+        final_obj: None,
+    }));
+    let (status, obj) = solve(Rc::clone(&inst), 3000);
+    assert!(
+        !matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "a free variable capped by an inequality must not report \
+         DivergingIterates (issue #285); got {status:?} obj={obj}",
+    );
+    assert!(
+        (obj - (-1e8)).abs() / 1e8 < 1e-4,
+        "inequality-capped variant objective {obj} is not the finite optimum -1e8",
+    );
+}


### PR DESCRIPTION
Fixes #285.

## The miss

On the forced-NLP path (`solver_selection="nlp"`), an unbounded LP whose
recession ray lies in the equality null space over **free** variables reported
`Maximum_Iterations_Exceeded` instead of the unbounded verdict
`Diverging_Iterates`. Minimal witness:

```
min -x0   s.t.   x0 - x1 = 0,   x free      (ray d = (1,1) in null(A_eq), c·d = -1 < 0)
```

Ipopt 3.14.19, scipy/HiGHS and cvxpy/Clarabel all report unbounded on the
identical model; auto-routing (LP-IPM) also reports unbounded. Only the forced
NLP path missed it. Reproducible at `max_iter` 300 / 3000 / 10000.

This is a conservative failure (both statuses are non-success, no wrong answer),
but the fallback hid a definite certificate.

## Root cause

The running divergence guard has one unboundedness path: the
`diverging_iterates_tol` (`1e20`) magnitude guard, gated on the free-variable
structural check plus a **geometric-growth** streak (#248/#252). A recession ray
in an equality null space over free variables is walked out by regularized
zero-Hessian Newton steps whose growth **decelerates hard** — `|x|_∞` stalls
around `5e17` even at `max_iter = 3000` and never crosses `1e20`, so `over =
amax > diverging_iterates_tol` is never true and the guard never fires. The
free-to-escape check itself was fine; the magnitude threshold was unreachable in
budget.

## The fix — a second, checked recession-ray proof

`crates/pounce-algorithm/src/ipopt_alg.rs` adds an independent unboundedness
path to the same guard, active from a far lower magnitude floor (`1e10`), fired
only through a full **checked proof** (`curr_is_recession_ray`) — not a
magnitude heuristic. All must hold, for several consecutive *growing*
iterations:

1. **Feasible witness** — unscaled primal infeasibility ≤ `1e-6·|x|∞`. A
   genuinely feasible iterate of norm ≥ `1e10` witnesses that the feasible
   region reaches that far; a *bounded* region cannot contain it. (Relative bar
   because the residual of `A_eq x − b` carries roundoff scaling with `|x|`.)
2. **Free to escape** — some over-floor component heads toward a variable side
   with no finite bound (the existing `Px_L`/`Px_U` lift, now shared).
3. **Direction in `null(A_eq)`** — `‖J_c x‖∞ ≤ 1e-6·|x|∞`.
4. **Inequalities not blocking** — no finitely-bounded inequality row is driven
   toward its bound along `d ≈ x` (`Pd_L`/`Pd_U` expansion).
5. **Objective descending** — `∇f·x ≤ −1e-6·‖∇f‖‖x‖` (real, non-orthogonal
   margin).

## Why it cannot false-fire on a bounded problem

A bounded feasible region has finite diameter, so it **cannot** supply a growing
sequence of feasible iterates of unbounded norm — condition (1) + persistence is
unsatisfiable there. Independently, every escape route a bounded problem could
take is closed: a finite variable bound fails (2), a pinning equality fails (1)
or (3), a capping inequality fails (4), and an orthogonal free-variable drift
fails (5). The existing `1e20` magnitude guard is untouched — the new path is a
pure `OR` branch, evaluated with no short-circuit so both streaks keep state — so
the unbounded shapes that already worked (unconstrained rays, bounded-inequality
rays) and the #248 / #252 bounded / finite-optimum controls are unaffected.

## Validation

- **Reproduced on main**: the target shape → `Maximum_Iterations_Exceeded`
  (`x ≈ 5e17`). **After**: → `Diverging_Iterates`, firing at `|x| ≈ 3.2e11`
  (iter ~17), matching Ipopt/HiGHS/Clarabel and the auto-routed path.
- **Adversary 11-case status audit** (`adversary/runs/2026-07-22_autoroute_status_certificates.py`):
  case 11 (the target) now PASS across auto / nlp / scipy / cvxpy. (Case 6, a
  QCQP/SOCP nonlinear unbounded shape, is a separate pre-existing gap the
  additive `OR` branch cannot have regressed.)
- **Regression battery** (bounded, must stay non-unbounded): variable-bounded
  variant → optimal `-10`; two pinning equalities → optimal `-2`;
  inequality-capped free variable → optimal `-1e8`; free-variable-not-in-objective
  → optimal; HS071 → optimal.
- **`repro_issue248` + `repro_issue252` + `optimize_hs71`**: 28/28 green.
- **New tests** `crates/pounce-algorithm/tests/repro_issue285.rs`: 4/4 green
  (fixed shape `DivergingIterates` at max_iter 300 & 3000; three bounded
  controls optimal).
- **Full workspace suite** `cargo test --workspace --release`: green.
- `cargo fmt --all` clean; the one clippy note the new code raised was resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
