### PR TITLE
fix(convex): normalize huge-magnitude objectives so the QP IPM reaches Optimal (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — convex QP IPM stalled on huge-magnitude objectives, never labeling the optimum `Optimal` (#286)
+
+- **A badly-scaled convex QP (`cond(P) = 1e10` with objective coefficients of
+  magnitude `O(1e22)`) exhausted the default iteration budget and returned
+  `IterationLimit` at a point violating the box by ~0.88 — a problem
+  CLARABEL/OSQP/ECOS/SCS all solve at their defaults.** Even at `max_iter = 5000`
+  the status stayed `IterationLimit` at a tightened tolerance despite the iterate
+  being accurate to ~5e-9. Root cause (`crates/pounce-convex/src/ipm.rs`,
+  `solve_qp_core`): the default HSDE driver deliberately skips Ruiz
+  equilibration — its per-cone NT scaling conditions the *constraint* system —
+  but nothing normalized the sheer *magnitude* of the objective data `(P, c)`.
+  With `‖P‖ ~ 1e22` the homogeneous embedding's `τ` collapsed toward the `τ → 0`
+  certificate boundary: the dual residual scale swamped the `τ`-row, primal
+  feasibility then crawled, and the solve ground to its cap even though the dual
+  and gap had converged in a few dozen steps.
+  - **Fix.** The HSDE QP/LP path now normalizes the objective by a scalar
+    `σ = max(‖P‖∞, ‖c‖∞)` — argmin-invariant, so the minimizer is unchanged —
+    before the solve, and maps the recovered dual multipliers and objective back
+    (`y, z ← σ·y, σ·z`, `obj ← σ·obj`; the primal `x` needs no correction). With
+    an `O(1)` objective the embedding's `τ` stays healthy and the badly-scaled QP
+    now converges to `Optimal` **in 9 iterations** at the correct optimum
+    (objective matched to CLARABEL / exact active-set enumeration to ~1e-7
+    relative), the cost scaling Clarabel/OSQP apply as a matter of course.
+  - **Normal problems are untouched.** The normalization is a no-op (`σ = 1`,
+    rounded to a power of two so the round-trip is exact) unless the coefficient
+    magnitude is large enough to genuinely destabilize the embedding
+    (`σ·ε > tol`, the same crossover the scale-relative stop already uses). It
+    keys on the objective *coefficient* magnitude, not the objective *value*, so
+    the large-data QP cluster (POWELL20/BOYD, whose large objective comes from a
+    large `‖x*‖` with modest coefficients) is left bit-for-bit unchanged. The
+    full `.nl` benchmark corpus (44 problems) is identical before/after in both
+    `solve_result_num` and objective, and the convex QP/LP suites are unchanged.
+
 ### Added — near-LICQ conditioning diagnostic for `QpSensitivity` (#284)
 
 - **`QpSensitivity.parametric_step` no longer silently over-damps `dx/db` on a

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -1204,6 +1204,46 @@ fn split_bound_duals(
     sol
 }
 
+/// Objective-normalization factor `σ ≥ 1` for the HSDE driver (see the call
+/// site in [`solve_qp_core`]). Returns the magnitude of the objective data
+/// `max(‖P‖∞, ‖c‖∞)`, rounded **up to a power of two** so that dividing the
+/// data by `σ` and multiplying the recovered duals/objective back by `σ` is
+/// exact in floating point — but only once that magnitude is large enough to
+/// genuinely destabilize the embedding's `τ`. The threshold is the same
+/// crossover the scale-relative stop uses (`σ·ε > tol`): below it, `tol`-level
+/// *absolute* KKT accuracy is still reachable and the embedding is healthy, so
+/// the wrapper returns `1.0` and the solve is byte-for-byte the historical one.
+///
+/// Crucially this keys on the objective **coefficient** magnitude, not the
+/// objective *value* at the solution: the large-data QP cluster
+/// (POWELL20/BOYD/QSHELL) owes its large objective to a large `‖x*‖` with
+/// modest `(P, c)` coefficients, so `σ = 1` there and its finely-tuned
+/// `τ`/`κ` iterates are untouched. Only data whose coefficients themselves are
+/// astronomically large (gh #286: `‖P‖ ~ 1e21`) is rescaled.
+fn hsde_cost_scale(prob: &QpProblem, tol: f64) -> f64 {
+    let mag = prob
+        .p_lower
+        .iter()
+        .map(|t| t.val.abs())
+        .chain(prob.c.iter().map(|v| v.abs()))
+        .fold(0.0_f64, f64::max);
+    // Only normalize once the coefficient magnitude is large enough that a
+    // `tol`-level absolute residual is below the finite-precision floor
+    // (`mag·ε > tol`) — the regime where the embedding's `τ` collapses. Below
+    // it the historical (un-normalized) solve is preserved exactly.
+    if !(mag.is_finite() && mag * f64::EPSILON > tol) {
+        return 1.0;
+    }
+    // Round up to a power of two: the scale/unscale round-trip is then exact.
+    let e = mag.log2().ceil();
+    let sigma = 2.0_f64.powf(e);
+    if sigma.is_finite() && sigma >= 1.0 {
+        sigma
+    } else {
+        1.0
+    }
+}
+
 /// Bounds-agnostic Mehrotra predictor-corrector core. `prob.lb`/`ub` are
 /// ignored here; the public [`solve_qp_ipm`] handles bound expansion.
 fn solve_qp_core<F>(
@@ -1221,6 +1261,39 @@ where
     // factor-reuse plumbing below (warm is ignored — it cannot change the
     // solution, only the iteration count, which HSDE does not exploit yet).
     if opts.use_hsde {
+        // Objective (cost) normalization for the embedding. HSDE deliberately
+        // skips Ruiz row/column equilibration (its per-cone NT scaling
+        // conditions the *constraint* system internally), but the NT scaling
+        // does nothing about the sheer *magnitude* of the objective data
+        // `(P, c)`. When those coefficients are enormous — e.g. a badly-scaled
+        // QP with `‖P‖ ~ 1e21` (gh #286) — the homogeneous embedding's `τ`
+        // collapses toward the `τ → 0` certificate boundary: the dual residual
+        // scale swamps the `τ`-row, primal feasibility then crawls, and the
+        // solve grinds to its iteration cap at a box-violating iterate even
+        // though the dual/gap converged in a few dozen steps. Dividing the
+        // objective by a scalar `σ ≥ 1` (argmin-invariant: the minimizer of
+        // `½xᵀPx+cᵀx` and of `½xᵀ(P/σ)x+(c/σ)ᵀx` coincide) restores an O(1)
+        // objective so `τ` stays healthy and the embedding converges in a
+        // handful of iterations — the cost scaling Clarabel/OSQP apply as a
+        // matter of course. The recovered dual multipliers and objective are
+        // in the scaled metric and are mapped back below (`y,z ← σ·y,σ·z`,
+        // `obj ← σ·obj`); the primal `x` needs no correction.
+        //
+        // Gated on `σ` being large enough to actually threaten the embedding
+        // (see [`hsde_cost_scale`]) and rounded to a power of two, so ordinary
+        // and moderately-scaled data — including the large-data QP cluster
+        // whose magnitude lives in `‖x*‖`, not the coefficients — are left
+        // **bit-for-bit unchanged** (`σ = 1`, the wrapper is a no-op).
+        let sigma = hsde_cost_scale(prob, opts.tol);
+        if sigma != 1.0 {
+            let scaled = prob.scaled_objective(1.0 / sigma);
+            let mut sol = crate::hsde::solve_conic_hsde(&scaled, cone, opts, make_backend, None);
+            for v in sol.y.iter_mut().chain(sol.z.iter_mut()) {
+                *v *= sigma;
+            }
+            sol.obj *= sigma;
+            return sol;
+        }
         return crate::hsde::solve_conic_hsde(prob, cone, opts, make_backend, None);
     }
 

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -89,6 +89,32 @@ impl QpProblem {
         self.lb.iter().any(|&v| v > -BOUND_INF) || self.ub.iter().any(|&v| v < BOUND_INF)
     }
 
+    /// A copy of this problem with the **objective** data scaled by `factor`
+    /// (`P ← factor·P`, `c ← factor·c`); constraints, bounds, and the feasible
+    /// set are untouched. Scaling the objective by a positive constant leaves
+    /// the minimizer `x*` unchanged, so this is used to renormalize a
+    /// badly-scaled objective before an interior-point solve and map the result
+    /// back afterward (the dual multipliers and objective value scale by the
+    /// same `factor`). See the HSDE cost-normalization in
+    /// [`crate::ipm`] (gh #286).
+    pub(crate) fn scaled_objective(&self, factor: f64) -> QpProblem {
+        QpProblem {
+            n: self.n,
+            p_lower: self
+                .p_lower
+                .iter()
+                .map(|t| Triplet::new(t.row, t.col, t.val * factor))
+                .collect(),
+            c: self.c.iter().map(|v| v * factor).collect(),
+            a: self.a.clone(),
+            b: self.b.clone(),
+            g: self.g.clone(),
+            h: self.h.clone(),
+            lb: self.lb.clone(),
+            ub: self.ub.clone(),
+        }
+    }
+
     /// Public `y += P x` (full symmetric product from the stored lower
     /// triangle). Exposed so external callers — e.g. a TNLP adapter
     /// reusing the same problem data — can evaluate the objective

--- a/crates/pounce-convex/tests/illconditioned_huge_scale.rs
+++ b/crates/pounce-convex/tests/illconditioned_huge_scale.rs
@@ -1,0 +1,185 @@
+//! Regression for gh #286: a convex QP with an enormous objective magnitude
+//! must terminate `Optimal` at the true optimum within the *default* iteration
+//! budget, not grind to the cap at a box-violating interior iterate.
+//!
+//! Root cause: the default HSDE driver skips Ruiz equilibration and relies on
+//! its per-cone NT scaling, which conditions the constraint system but does
+//! nothing about the sheer *magnitude* of the objective data. With
+//! `‖P‖, ‖c‖ ~ 1e18‥1e22` the homogeneous embedding's `τ` collapsed toward the
+//! `τ → 0` certificate boundary and primal feasibility crawled: the solve
+//! exhausted its budget at a point violating the box by ~0.88 even though the
+//! dual and gap had converged in a few dozen steps (and even at
+//! `max_iter = 5000` it only reached the optimum by brute force). Normalizing
+//! the objective by a scalar `σ = max(‖P‖∞, ‖c‖∞)` — which leaves the minimizer
+//! unchanged — restores an `O(1)` objective and the embedding converges in a
+//! handful of iterations, the cost scaling Clarabel/OSQP apply as a matter of
+//! course.
+//!
+//! The constructions are diagonal, so each box QP separates per coordinate and
+//! the exact optimum is the unconstrained target clamped to the box — an oracle
+//! independent of any solver.
+
+use pounce_convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// Diagonal box QP `min ½ xᵀP x + cᵀx s.t. -1 ≤ x ≤ 1` with
+/// `P = diag(eig)`, `eig_i = scale · cond^(i/(n-1))` and `c_i = -eig_i·tgt_i`.
+/// Because `P` is diagonal the objective separates and the exact minimizer is
+/// `x*_i = clamp(tgt_i, -1, 1)`.
+fn diagonal_box_qp(scale: f64, cond: f64, tgt: &[f64]) -> (QpProblem, Vec<f64>) {
+    let n = tgt.len();
+    let mut p_lower = Vec::with_capacity(n);
+    let mut c = Vec::with_capacity(n);
+    let mut xopt = Vec::with_capacity(n);
+    for (i, &t) in tgt.iter().enumerate() {
+        let eig = scale * cond.powf(i as f64 / (n - 1) as f64);
+        p_lower.push(Triplet::new(i, i, eig));
+        c.push(-eig * t);
+        xopt.push(t.clamp(-1.0, 1.0));
+    }
+    let prob = QpProblem {
+        n,
+        p_lower,
+        c,
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![-1.0; n],
+        ub: vec![1.0; n],
+    };
+    (prob, xopt)
+}
+
+fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
+    let mut px = vec![0.0; prob.n];
+    prob.p_mul_add_pub(x, &mut px);
+    (0..prob.n)
+        .map(|i| 0.5 * x[i] * px[i] + prob.c[i] * x[i])
+        .sum()
+}
+
+/// A well-conditioned but astronomically-scaled QP (`‖P‖ ~ 1e18`): the pure
+/// magnitude drives the `τ` collapse. With the objective normalization it
+/// recovers the *exact* clamped optimum in a handful of iterations.
+#[test]
+fn huge_magnitude_qp_recovers_exact_optimum_at_default_budget() {
+    let tgt = [1.5, -1.5, 0.3, -0.7, 2.0, -0.4];
+    let (prob, xopt) = diagonal_box_qp(1e18, 1.0, &tgt);
+
+    let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "huge-magnitude QP must converge to Optimal within the default budget \
+         (got {:?} after {} iters)",
+        sol.status,
+        sol.iters
+    );
+    let x_err = sol
+        .x
+        .iter()
+        .zip(&xopt)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        x_err < 1e-6,
+        "x off the exact optimum by {x_err}: {:?}",
+        sol.x
+    );
+    let obj_exact = objective(&prob, &xopt);
+    let rel = (sol.obj - obj_exact).abs() / obj_exact.abs().max(1.0);
+    assert!(
+        rel < 1e-6,
+        "objective rel error {rel} (got {}, exact {obj_exact})",
+        sol.obj
+    );
+    // Dual multipliers must return in the *original* objective metric (not the
+    // internal scaled one): `Px + c - z_lb + z_ub = 0` relative to ‖grad‖.
+    let mut grad = prob.c.clone();
+    prob.p_mul_add_pub(&sol.x, &mut grad);
+    let gnorm = grad.iter().map(|v| v.abs()).fold(0.0_f64, f64::max);
+    let stat = (0..prob.n)
+        .map(|i| (grad[i] - sol.z_lb[i] + sol.z_ub[i]).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(
+        stat / gnorm.max(1.0) < 1e-6,
+        "dual multipliers not in the original metric: rel stationarity {}",
+        stat / gnorm.max(1.0)
+    );
+    assert!(
+        sol.iters < 60,
+        "expected quick convergence, took {} iters",
+        sol.iters
+    );
+}
+
+/// The issue's exact regime: `cond(P) = 1e10` *and* objective magnitude
+/// `O(1e22)`. Under such conditioning the lowest-weight coordinates are
+/// numerically under-determined at `tol = 1e-8` (their scaled weight falls
+/// below the tolerance), so the objective — dominated by the well-determined
+/// high-weight terms — is the robust oracle. The status and box feasibility are
+/// what regressed in #286.
+#[test]
+fn issue_286_illconditioned_huge_scale_is_optimal_and_feasible() {
+    let tgt = [1.5, -1.5, 0.3, -0.7, 2.0, -0.4];
+    let (prob, xopt) = diagonal_box_qp(1e12, 1e10, &tgt);
+
+    let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "badly-scaled QP must report Optimal, not exhaust the budget (got {:?})",
+        sol.status
+    );
+    let box_viol = sol
+        .x
+        .iter()
+        .map(|&xi| (xi.abs() - 1.0).max(0.0))
+        .fold(0.0_f64, f64::max);
+    assert!(box_viol < 1e-6, "box violated by {box_viol}");
+    let obj_exact = objective(&prob, &xopt);
+    let rel = (sol.obj - obj_exact).abs() / obj_exact.abs().max(1.0);
+    assert!(
+        rel < 1e-6,
+        "objective rel error {rel} (got {}, exact {obj_exact})",
+        sol.obj
+    );
+    assert!(
+        sol.iters < 60,
+        "expected quick convergence, took {} iters",
+        sol.iters
+    );
+}
+
+/// A well-scaled box QP: `σ = max(‖P‖, ‖c‖)` is small, so the objective
+/// normalization is a no-op (`σ = 1`) and the solve is exactly the historical
+/// one — same status, same low iteration count, same answer.
+#[test]
+fn well_scaled_qp_is_untouched_by_the_normalization() {
+    let tgt = [0.9, -0.9, 0.3, -0.7, 0.5, -0.4];
+    let (prob, xopt) = diagonal_box_qp(2.0, 1.0, &tgt);
+
+    let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    let x_err = sol
+        .x
+        .iter()
+        .zip(&xopt)
+        .map(|(a, b)| (a - b).abs())
+        .fold(0.0_f64, f64::max);
+    assert!(x_err < 1e-6, "x off optimum by {x_err}");
+    assert!(
+        sol.iters < 30,
+        "well-scaled QP iteration count drifted: {}",
+        sol.iters
+    );
+}


### PR DESCRIPTION
Fixes #286.

## Root cause

A badly-scaled box-constrained convex QP — `cond(P) = 1e10` with objective
coefficients of magnitude `O(1e22)` — exhausted the default iteration budget and
returned `IterationLimit` at a point violating the box by ~0.88, on a problem
CLARABEL / OSQP / ECOS / SCS all solve at their defaults. Even at
`max_iter = 5000` the status stayed `IterationLimit` (at a tightened tolerance)
despite the iterate being accurate to ~5e-9.

The default QP path is the HSDE embedding (`solve_qp_core` →
`solve_conic_hsde`, `crates/pounce-convex/src/ipm.rs:1223`). HSDE deliberately
skips Ruiz equilibration — its per-cone NT scaling conditions the *constraint*
system — but **nothing normalized the sheer magnitude of the objective data
`(P, c)`**. Instrumenting the loop showed the mechanism precisely: with
`‖P‖ ~ 1e22` the homogeneous embedding's `τ` collapsed to ~3e-17 (drifting
toward the `τ → 0` certificate boundary). The dual and gap residuals were
relatively converged by iteration ~300, but the dual scale `~8e20` swamped the
`τ`-row and primal feasibility crawled — reaching the box only after ~4735
iterations, far past the default budget of 200.

This is a *scale* problem in the classic sense the issue anticipated: the
optimality measure that a `1e22`-scale problem can never satisfy in absolute
units. The scale-relative stop added in 8ae1e0d handles the *termination test*,
but the embedding itself never converges quickly here because the data magnitude
destabilizes `τ` — so the real fix is to normalize the objective, exactly the
cost scaling Clarabel/OSQP apply as a matter of course.

## Fix

`solve_qp_core`'s HSDE branch now normalizes the objective by a scalar
`σ = max(‖P‖∞, ‖c‖∞)` before the solve (`P ← P/σ`, `c ← c/σ`). Scaling the
objective by a positive constant leaves the minimizer unchanged, so `x` needs no
correction; the recovered dual multipliers and objective come back in the scaled
metric and are mapped back (`y, z ← σ·y, σ·z`, `obj ← σ·obj`). With an `O(1)`
objective the embedding's `τ` stays healthy and the badly-scaled QP now
converges to **`Optimal` in 9 iterations** at the correct optimum.

The normalization is a **gated no-op** so normal problems are untouched:

- It returns `σ = 1` (a literal no-op) unless the coefficient magnitude is large
  enough to genuinely destabilize the embedding — `σ·ε > tol`, the same
  crossover the scale-relative stop already uses. `σ` is rounded up to a power of
  two so the scale/unscale round-trip is exact in floating point.
- It keys on the objective **coefficient** magnitude, not the objective *value*
  at the solution, so the large-data QP cluster (POWELL20 / BOYD / QSHELL, whose
  large objective comes from a large `‖x*‖` with modest `(P, c)` coefficients) is
  left bit-for-bit unchanged.

## Validation

- **Issue repro (`solve_qp_batch`, cvxpy + exact 3^6 enumeration):** all six
  items now `optimal` (were `['optimal'×5, 'iteration_limit']`). Item k=5: box
  violation `0.884 → 0`, objective `-6.851052e19` matching CLARABEL / exact
  enumeration to `1.8e-7` relative. At `tol=1e-10` item 5 now reaches `optimal`
  at `max_iter=200` (was `iteration_limit` even at 5000) — the issue's secondary
  observation. Adversary script `VERDICT: PASS`.
- **Benchmark corpus regression (required):** every `.nl` under `benchmarks/`
  (44 files) run through before/after CLI binaries with `-AMPL --sol-output`.
  **`solve_result_num` and objective identical on all 44 — zero differences**,
  including all 21 LP/QP-family problems that route through pounce-convex.
- **Tests:** `cargo test -p pounce-convex` (157+ pass), the CLI QP-dispatch
  suites, and `python -m pytest python/tests/test_qp_host.py` (66 pass) all
  green. New regression test `illconditioned_huge_scale.rs`: the huge-magnitude
  QP reports `Optimal` at the exact optimum within the default budget, and a
  well-scaled QP is unchanged (σ = 1 no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
