### PR TITLE
Report NaN gradient/Jacobian as an honest failure, not Solve_Succeeded (#292)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — NaN gradient / constraint Jacobian silently reported `Solve_Succeeded` (#292)
+
+- **An objective gradient or constraint Jacobian that returns `NaN` was laundered
+  into a successful solve.** `pounce.minimize(lambda x: float(x[0]**2),
+  np.array([0.5]), jac=lambda x: np.array([np.nan]))` returned `success=True`,
+  `message='Solve_Succeeded'`, `fun=0.25`, `nit=0` — the most dangerous shape,
+  because `fun` is finite (the value at `x0`) so the caller got no signal at all.
+  Root cause: the max-norm behind the dual-infeasibility measure
+  (`crates/pounce-linalg` `amax` / BLAS `iamax`) silently *drops* `NaN` — `NaN >
+  m` is `false`, so a `NaN` component leaves the running max untouched and the
+  KKT error read `0.0`. The existing finiteness guard
+  (`ipopt_alg.rs`, `!nlp_err.is_finite()` → `Invalid_Number_Detected`) never
+  fired because the value it checks had already been laundered to zero.
+  - **Fix.** `curr_nlp_error` (`crates/pounce-algorithm/src/ipopt_cq.rs`) now
+    detects any non-finite component of the Lagrangian gradients, constraint
+    residuals, and complementarity blocks — via the `NaN`-propagating `asum`
+    behind `has_valid_numbers`, *not* `amax` — and surfaces a non-finite KKT
+    error, so the guard fires `Invalid_Number_Detected` honestly. This covers a
+    `NaN` gradient, a `NaN` constraint Jacobian (through `∇_x L`'s `Jᵀy` term),
+    and `NaN`/`Inf` residuals. The check is confined to the convergence/error
+    measure; the general `amax` semantics that step-size selection, the line
+    search, and the divergence detectors depend on are deliberately left
+    unchanged. A `fun` that returns `NaN` already failed honestly and still
+    does; normal all-finite solves are bit-for-bit unchanged (the finiteness
+    check is a no-op when every component is finite).
+
 ### Fixed — convex QP IPM stalled on huge-magnitude objectives, never labeling the optimum `Optimal` (#286)
 
 - **A badly-scaled convex QP (`cond(P) = 1e10` with objective coefficients of

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -1383,21 +1383,40 @@ impl IpoptCalculatedQuantities {
         // dual infeasibility (max-norm of grad_lag_x and grad_lag_s)
         let glx = self.curr_grad_lag_x();
         let gls = self.curr_grad_lag_s();
-        let dual = glx.amax().max(gls.amax()) / s_d;
 
         // primal: max(||c||, ||d-s||)
         let c = self.curr_c();
         let dms = self.curr_d_minus_s();
-        let primal = c.amax().max(dms.amax());
 
         // unbarriered complementarity (mu_target = 0 → just ||compl||)
-        let compl = self
-            .curr_compl_x_l()
-            .amax()
-            .max(self.curr_compl_x_u().amax())
-            .max(self.curr_compl_s_l().amax())
-            .max(self.curr_compl_s_u().amax())
-            / s_c;
+        let cxl = self.curr_compl_x_l();
+        let cxu = self.curr_compl_x_u();
+        let csl = self.curr_compl_s_l();
+        let csu = self.curr_compl_s_u();
+
+        // #292: the max-norm (`amax`/BLAS `iamax`) behind every term below
+        // silently *drops* NaN — `NaN > m` is `false`, so a NaN component
+        // leaves the running max untouched and is laundered into a finite
+        // (typically `0.0`) KKT error. A NaN gradient, NaN constraint Jacobian
+        // (via `∇_x L`'s `Jᵀy` term), or NaN residual would then read as an
+        // *optimal* solve and return `Solve_Succeeded`. Detect any non-finite
+        // component here — through the NaN-propagating `asum` behind
+        // `has_valid_numbers`, not `amax` — and surface it as a non-finite KKT
+        // error so the caller's existing `!nlp_err.is_finite()` guard fires
+        // `Invalid_Number_Detected`. This is confined to the convergence/error
+        // measure; the general `amax` semantics that step-size selection, the
+        // line search, and the divergence detectors rely on are untouched.
+        // (Inf is *not* laundered — `Inf > m` is true — so it already
+        // propagated; this closes only the NaN hole, and Inf for free.)
+        for v in [&glx, &gls, &c, &dms, &cxl, &cxu, &csl, &csu] {
+            if !v.has_valid_numbers() {
+                return Number::NAN;
+            }
+        }
+
+        let dual = glx.amax().max(gls.amax()) / s_d;
+        let primal = c.amax().max(dms.amax());
+        let compl = cxl.amax().max(cxu.amax()).max(csl.amax()).max(csu.amax()) / s_c;
 
         dual.max(primal).max(compl)
     }
@@ -1887,9 +1906,23 @@ mod tests {
         obj_scale: Number,
         c_scale: Option<Vec<Number>>,
         d_scale: Option<Vec<Number>>,
+        // #292: inject a non-finite component into the gradient / constraint
+        // Jacobian to exercise the finiteness guard in `curr_nlp_error`.
+        nan_grad: bool,
+        nan_jac_c: bool,
     }
 
     impl MockNlp {
+        fn with_nan_grad(mut self) -> Self {
+            self.nan_grad = true;
+            self
+        }
+
+        fn with_nan_jac_c(mut self) -> Self {
+            self.nan_jac_c = true;
+            self
+        }
+
         fn with_scaling(
             mut self,
             obj_scale: Number,
@@ -1928,6 +1961,8 @@ mod tests {
                 obj_scale: 1.0,
                 c_scale: None,
                 d_scale: None,
+                nan_grad: false,
+                nan_jac_c: false,
             }
         }
     }
@@ -1953,6 +1988,9 @@ mod tests {
             let gg = g.as_any_mut().downcast_mut::<DenseVector>().unwrap();
             gg.values_mut()[0] = 2.0 * xx.values()[0];
             gg.values_mut()[1] = 2.0 * xx.values()[1];
+            if self.nan_grad {
+                gg.values_mut()[0] = Number::NAN;
+            }
         }
         fn eval_c(&mut self, x: &dyn Vector, c: &mut dyn Vector) {
             let xx = x.as_any().downcast_ref::<DenseVector>().unwrap();
@@ -1968,7 +2006,11 @@ mod tests {
             // c(x) = x0 + x1 - 1 → Jc = [1, 1] (1×2), nonzeros (1,1),(1,2).
             let space = GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]);
             let mut jac = GenTMatrix::new(space);
-            jac.set_values(&[1.0, 1.0]);
+            if self.nan_jac_c {
+                jac.set_values(&[Number::NAN, 1.0]);
+            } else {
+                jac.set_values(&[1.0, 1.0]);
+            }
             StdRc::new(jac)
         }
         fn eval_jac_d(&mut self, _x: &dyn Vector) -> Rc<dyn Matrix> {
@@ -2301,6 +2343,46 @@ mod tests {
         let ds = dvec(&[3.0]);
         let r = cq.curr_dwd(&dx, &ds);
         assert!((r - 7.00).abs() < 1e-13, "r = {r}");
+    }
+
+    // ---- #292: NaN gradient / Jacobian must not launder to a finite KKT error
+
+    #[test]
+    fn nlp_error_is_finite_for_a_finite_iterate() {
+        // Baseline: the well-formed fixture produces a finite, positive KKT
+        // error (this iterate is not a KKT point). The finiteness guard added
+        // for #292 must not perturb this normal path.
+        let cq = fixture();
+        let err = cq.curr_nlp_error();
+        assert!(err.is_finite() && err > 0.0, "err = {err}");
+    }
+
+    #[test]
+    fn nlp_error_is_non_finite_when_gradient_has_nan() {
+        // A NaN gradient component reaches ∇_x L, whose max-norm (`amax`)
+        // silently drops NaN and would launder the dual infeasibility to a
+        // finite value → bogus `Solve_Succeeded` (#292). `curr_nlp_error` must
+        // instead surface a non-finite error so the caller's
+        // `!nlp_err.is_finite()` guard fires `Invalid_Number_Detected`.
+        let cq = fixture_with(MockNlp::new().with_nan_grad());
+        assert!(
+            !cq.curr_nlp_error().is_finite(),
+            "NaN gradient laundered to finite KKT error: {}",
+            cq.curr_nlp_error()
+        );
+    }
+
+    #[test]
+    fn nlp_error_is_non_finite_when_constraint_jacobian_has_nan() {
+        // A NaN in the constraint Jacobian enters ∇_x L through the Jᵀy term
+        // and is likewise laundered by `amax` on the fixture's nonzero
+        // multipliers. Must read as a non-finite KKT error, not `Optimal`.
+        let cq = fixture_with(MockNlp::new().with_nan_jac_c());
+        assert!(
+            !cq.curr_nlp_error().is_finite(),
+            "NaN constraint Jacobian laundered to finite KKT error: {}",
+            cq.curr_nlp_error()
+        );
     }
 
     // ---- Unscaled (user-space) KKT residuals — pounce#173 -------------

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -690,6 +690,93 @@ def test_minimize_rejects_nan_bounds_end_to_end():
         )
 
 
+def test_minimize_nan_gradient_reports_honest_failure():
+    """#292: a ``jac`` that returns NaN used to be laundered into a
+    ``Solve_Succeeded`` at ``x0`` with a *finite* ``fun`` — the most dangerous
+    silent-success shape, since the caller gets no signal. The max-norm behind
+    the dual-infeasibility measure silently drops NaN (``NaN > m`` is False), so
+    the KKT error read 0.0 and the solve declared itself optimal. It must now
+    surface an honest non-success status."""
+    res = pounce.minimize(
+        lambda x: float(x[0] ** 2),
+        np.array([0.5]),
+        jac=lambda x: np.array([np.nan]),
+        options={"print_level": 0},
+    )
+    assert not res.success
+    assert res.message != "Solve_Succeeded"
+    assert res.status != 0
+
+
+def test_minimize_inf_gradient_reports_honest_failure():
+    """#292 sibling: an Inf gradient (Inf is *not* laundered by the max-norm,
+    but verify it still fails honestly and did not regress)."""
+    for bad in (np.inf, -np.inf):
+        res = pounce.minimize(
+            lambda x: float(x[0] ** 2),
+            np.array([0.5]),
+            jac=lambda x, bad=bad: np.array([bad]),
+            options={"print_level": 0},
+        )
+        assert not res.success, f"Inf gradient ({bad}) reported success"
+        assert res.status != 0
+
+
+def test_minimize_nan_constraint_jacobian_reports_honest_failure():
+    """#292: a NaN in the *constraint* Jacobian enters the Lagrangian gradient
+    through the Jᵀy term and was laundered by the same max-norm, again yielding
+    a bogus ``Solve_Succeeded``. It must now fail honestly."""
+
+    def f(x):
+        return float(x @ x)
+
+    res = pounce.minimize(
+        f,
+        x0=np.array([0.5, 0.5]),
+        jac=lambda x: 2.0 * x,
+        constraints=[
+            {
+                "type": "eq",
+                "fun": lambda x: np.array([x[0] + x[1] - 1.0]),
+                "jac": lambda x: np.array([[np.nan, 1.0]]),
+            }
+        ],
+        options={"print_level": 0},
+    )
+    assert not res.success
+    assert res.status != 0
+
+
+def test_minimize_nan_objective_stays_honest():
+    """#292 contrast (guard against over-correction): a ``fun`` that returns NaN
+    already failed honestly (the objective value reaches a finiteness check the
+    gradient norm bypassed). The fix must not change that — it must still report
+    a non-success status, not ``Solve_Succeeded``."""
+    res = pounce.minimize(
+        lambda x: float(np.nan),
+        np.array([0.5]),
+        jac=lambda x: np.array([2.0 * x[0]]),
+        options={"print_level": 0},
+    )
+    assert not res.success
+    assert res.status != 0
+
+
+def test_minimize_finite_solve_still_succeeds_to_optimum():
+    """#292 no-regression: with everything finite, a normal unconstrained solve
+    still converges to the known optimum with ``Solve_Succeeded``."""
+    res = pounce.minimize(
+        lambda x: float((x[0] - 3.0) ** 2),
+        np.array([0.5]),
+        jac=lambda x: np.array([2.0 * (x[0] - 3.0)]),
+        tol=1e-10,
+        options={"print_level": 0},
+    )
+    assert res.success
+    assert res.message == "Solve_Succeeded"
+    np.testing.assert_allclose(res.x, [3.0], atol=1e-6)
+
+
 def test_nlp_success_status_includes_acceptable_level():
     """gh #119 regression (mapping). ``success`` for the NLP path must count
     ``Solved_To_Acceptable_Level`` (status 1) as a success, not only


### PR DESCRIPTION
Fixes #292.

## The bug

A user objective gradient (or constraint Jacobian) that returns `NaN` was reported as a *successful* solve:

```python
pounce.minimize(lambda x: float(x[0]**2), np.array([0.5]), jac=lambda x: np.array([np.nan]))
# was: success=True, message='Solve_Succeeded', fun=0.25, nit=0   (WRONG)
```

This is the most dangerous shape of the family: `fun` is **finite** (the value at `x0`), so the caller gets no signal at all.

## Root cause — the max-norm launders NaN

The max-norm behind the dual-infeasibility measure silently *drops* `NaN`:

- `crates/pounce-linalg/src/compound_vector.rs` uses `if v > m { m = v }` — `NaN > m` is `false`, so a `NaN` component leaves the running max untouched.
- the dense path (`dense_vector.rs`) delegates to BLAS `iamax`, which is likewise NaN-indifferent.

So a `NaN` gradient is laundered into `0.0` before any guard sees it. There **is** a correct guard in `crates/pounce-algorithm/src/ipopt_alg.rs`:

```rust
let nlp_err = self.cq.borrow().curr_nlp_error();
if !nlp_err.is_finite() { return IterateOutcome::Terminate(SolverReturn::InvalidNumberDetected); }
```

It never fired because the value it checks (`curr_nlp_error`) had already been laundered to `0.0` upstream. Confirmed on `main` with `print_level=5`: `Dual infeasibility......: 0.0` and `EXIT: Optimal Solution Found.`

## The fix — a targeted finiteness check on the error measure only

`curr_nlp_error` (`crates/pounce-algorithm/src/ipopt_cq.rs`) now checks each constituent vector — the Lagrangian gradients `∇_x L`/`∇_s L`, the constraint residuals `c`/`d−s`, and the four complementarity blocks — for a non-finite component **before** reducing, and returns a non-finite KKT error if any is found. So the existing `!nlp_err.is_finite()` guard fires `Invalid_Number_Detected` honestly.

The finiteness test reuses the existing `has_valid_numbers()` primitive, which is built on `asum` (BLAS `dasum` sums `|x_i|`, so `NaN` **propagates** — unlike `amax`). No new scan semantics, no new trait method.

### Why this does *not* touch general `amax`

Making `amax` NaN-propagating everywhere was explicitly rejected: `amax` feeds step-size selection, the line search, the convergence test, and the divergence detectors, so changing its NaN semantics is a corpus-wide behavioral risk not appropriate for a release. This change is confined to the single convergence/error measure the guard reads; every other `amax` caller is byte-for-byte unchanged.

### Shapes now caught

| input | before | after |
|---|---|---|
| `jac` returns `NaN` | `Solve_Succeeded`, `fun=0.25`, `nit=0` | `Invalid_Number_Detected` |
| constraint `jac` returns `NaN` (via `∇_x L`'s `Jᵀy` term) | `Solve_Succeeded` | `Invalid_Number_Detected` |
| `jac` returns `Inf` / `-Inf` | `Invalid_Number_Detected` (already honest; `Inf > m` is true so it was never laundered) | `Invalid_Number_Detected` (unchanged) |
| `fun` returns `NaN` | `Error_In_Step_Computation` (already honest) | `Error_In_Step_Computation` (**unchanged** — not over-corrected) |

## No-regression evidence

- **`cargo test --workspace --release`: 2101 passed, 0 failed.** This is core NLP termination, so the whole workspace was run.
- **Python `test_minimize.py` + `test_qp_host.py`: 133 passed.**
- Normal all-finite solves are unchanged: when every component is finite the new check is a pure no-op and `curr_nlp_error` falls through to the identical arithmetic — no value change, no status change, and no measurable per-iteration cost (`asum` is cheap next to the per-iteration linear solves, and the KKT error is computed once per convergence check).

## Tests added

- Rust (near the guard, `ipopt_cq.rs`): a finite iterate yields a finite positive KKT error; a `NaN` gradient and a `NaN` constraint Jacobian each yield a non-finite KKT error.
- Python (`test_minimize.py`): `NaN` gradient, `Inf`/`-Inf` gradient, and `NaN` constraint Jacobian each report a non-success status (not `Solve_Succeeded`); a `NaN` objective stays honest; a finite solve still reaches the optimum with `Solve_Succeeded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
