### PR TITLE
Add external/analytic dual-sign regression guard (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+### Tests — external/analytic dual-SIGN regression guard (#294, hardening after #271/#272/#287)
+
+- **A durable guard so a constraint-dual sign inversion cannot ship silently
+  again.** The #271/#272 flip inverted every AMPL/Pyomo/GAMS marginal for an
+  unknown span of releases and no automated check caught it: the benchmark
+  suite compares objectives/status/iterations/wall-time but never duals, and
+  `pounce verify` keeps the better KKT residual of `+λ`/`−λ` so it certifies
+  either sign. Agreement *between pounce surfaces* is not a guard (a uniform
+  flip satisfies it); each new assertion pins a dual against an **external**
+  reference (IPOPT via pyomo) or an **analytic** value with an explicit
+  expected sign, on every dual-bearing surface:
+  - `crates/pounce-cli/tests/issue_294_dual_sign_regression.rs` — the `.sol`
+    marginal block (AMPL `d obj/d b`) and JSON `solution.lambda` (internal
+    Lagrange convention), pinned to the equality QP `min x0²+x1² s.t. x0+x1=2`
+    (marginal `+2`, lambda `−2`) and the Wyndor Glass LP (active-inequality
+    marginals `[0,−1.5,−1]`, lambda `[0,1.5,1]`). New fixture
+    `tests/fixtures/wyndor_min.nl`.
+  - `python/tests/test_dual_sign_regression.py` — `pyomo-pounce` `model.dual`
+    (cross-asserted equal to IPOPT's on the same model, both senses),
+    `minimize(...).info["mult_g"]`, and `solve_qp` `y`/`z`, pinned to the
+    Wyndor shadow prices `(0, 1.5, 1)` and the equality multiplier `y=−2`.
+  - `python/tests/test_gams_link.py` — extends the `gams_pi` cases with the
+    Wyndor shadow prices for both minimizing and maximizing senses.
+  The guard was confirmed to have teeth by momentarily flipping the sign in the
+  `.sol` writer and in `gams_pi` and observing the exact-value asserts fail
+  (reverted).
+
 ### Fixed — convex QP IPM falsely certified a mixed-scale Hessian unbounded (#293, completes #273/#290)
 
 - **A bounded QP with a mixed-scale Hessian was returned as `dual_infeasible`

--- a/crates/pounce-cli/tests/fixtures/wyndor_min.nl
+++ b/crates/pounce-cli/tests/fixtures/wyndor_min.nl
@@ -1,0 +1,40 @@
+g3 1 1 0	# problem unknown
+ 2 3 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+n0
+C2
+n0
+O0 0
+n0
+x2
+0 0
+1 0
+r
+1 4
+1 12
+1 18
+b
+2 0
+2 0
+k1
+2
+J0 1
+0 1
+J1 1
+1 2
+J2 2
+0 3
+1 2
+G0 2
+0 -3
+1 -5

--- a/crates/pounce-cli/tests/issue_294_dual_sign_regression.rs
+++ b/crates/pounce-cli/tests/issue_294_dual_sign_regression.rs
@@ -1,0 +1,208 @@
+//! Dual-SIGN regression guard for the `.sol` / JSON surfaces (issue #294).
+//!
+//! ## Why this test exists (the #271 post-mortem)
+//!
+//! A constraint-dual sign inversion (#271/#272, fixed in #287) flipped every
+//! AMPL/Pyomo/GAMS marginal for an unknown span of releases and NO automated
+//! check caught it, because the two guards that structurally *could* have —
+//! don't:
+//!
+//!   * the benchmark suite (`benchmarks/benchmark_report.py`) compares
+//!     objectives / status / iterations / wall-time and NEVER duals, so a
+//!     defect that leaves primals and objectives exact (which a uniform sign
+//!     flip does) is invisible to it by construction; and
+//!   * `pounce verify` (`crates/pounce-cli/src/verify.rs`) evaluates KKT
+//!     stationarity for BOTH `+λ` and `−λ` and keeps the better residual, so
+//!     it certifies either sign and cannot guard the convention.
+//!
+//! The key principle: **agreement between pounce's own surfaces is not a
+//! guard** — a uniform flip satisfies it. This test therefore pins each dual
+//! surface against an EXTERNAL/ANALYTIC reference with an explicit expected
+//! SIGN, so a future uniform flip fails loudly instead of shipping silently.
+//!
+//! Analytic references used here (both hand-computable in closed form):
+//!
+//!   * `convex_qp.nl`: `min x0² + x1²  s.t.  x0 + x1 = 2`, optimum (1, 1).
+//!     obj*(b) = b²/2 for the RHS `b`, so the AMPL marginal `d obj / d b = b = 2`.
+//!     The internal Lagrange multiplier of `L = f + λ(x0+x1−b)` is `λ = −2`
+//!     (2·x0 + λ = 0). So: `.sol` marginal = **+2**, JSON `lambda` = **−2**,
+//!     and the two must be exact negations.
+//!   * `wyndor_min.nl`: the Wyndor Glass Co. LP as a pure minimize,
+//!     `min −3x1 − 5x2  s.t.  x1≤4, 2x2≤12, 3x1+2x2≤18, x≥0`, optimum (2, 6).
+//!     Textbook shadow prices are (0, 1.5, 1); with the `L = f + Σλᵢ(gᵢ−hᵢ)`,
+//!     `λᵢ ≥ 0` convention the KKT multipliers are `λ = [0, 1.5, 1]`, so the
+//!     AMPL `.sol` marginals `−λ = [0, −1.5, −1]` and JSON `lambda = [0, 1.5, 1]`.
+//!     (The pyomo/GAMS max-vs-min conventions are pinned against IPOPT and
+//!     analytically in the Python tests: `python/tests/test_dual_sign_regression.py`
+//!     and `python/tests/test_gams_link.py`.)
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// Solve `fixture_name` via the CLI, returning the `.sol` marginals and the
+/// JSON `solution.lambda`. Duals are read straight from the emitted `.sol`
+/// (the AMPL `d obj / d b` marginal convention) and the JSON report (the
+/// internal Lagrange-multiplier convention), so both dual-bearing CLI
+/// surfaces are checked from one solve.
+fn solve_duals(fixture_name: &str, tag: &str) -> (Vec<f64>, Vec<f64>) {
+    let dir = std::env::temp_dir().join(format!("pounce_i294_{}_{tag}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let nl = dir.join("m.nl");
+    std::fs::copy(fixture(fixture_name), &nl).expect("copy fixture");
+    let sol = dir.join("m.sol");
+    let json = dir.join("m.json");
+
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg("solver_selection=nlp")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("--json-output")
+        .arg(&json)
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "solve should succeed for {fixture_name}; stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let sol_text = std::fs::read_to_string(&sol).expect("read .sol");
+    let sol_duals = parse_sol_marginals(&sol_text);
+
+    let report: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&json).expect("read json")).expect("parse");
+    let json_lambda = report["solution"]["lambda"]
+        .as_array()
+        .expect("lambda array")
+        .iter()
+        .map(|v| v.as_f64().expect("f64"))
+        .collect();
+
+    (sol_duals, json_lambda)
+}
+
+/// Parse the dual (marginal) block out of an AMPL `.sol` file.
+///
+/// Layout after the free-text banner: a blank line, `Options`, the option
+/// count `nopts` and its `nopts` value lines, then the four-integer count
+/// block `<n_dual> <m> <n_primal> <n>`, then `n_dual` dual value lines, then
+/// the primal block. We consume exactly `n_dual` duals so the parser does not
+/// mistake a primal value for a marginal.
+fn parse_sol_marginals(text: &str) -> Vec<f64> {
+    let mut lines = text.lines();
+    // Advance to the "Options" line.
+    for line in lines.by_ref() {
+        if line.trim() == "Options" {
+            break;
+        }
+    }
+    let next_int = |lines: &mut std::str::Lines| -> usize {
+        lines
+            .next()
+            .expect("truncated .sol")
+            .trim()
+            .parse::<usize>()
+            .expect("expected an integer count line in .sol")
+    };
+    let nopts = next_int(&mut lines);
+    for _ in 0..nopts {
+        lines.next().expect("truncated option block");
+    }
+    let n_dual = next_int(&mut lines);
+    let _m = next_int(&mut lines);
+    let _n_primal = next_int(&mut lines);
+    let _n = next_int(&mut lines);
+
+    (0..n_dual)
+        .map(|_| {
+            lines
+                .next()
+                .expect("truncated dual block")
+                .trim()
+                .parse::<f64>()
+                .expect("dual value should parse as f64")
+        })
+        .collect()
+}
+
+/// `convex_qp.nl`: single equality `x0 + x1 = 2`.
+///
+/// Analytic references: `.sol` marginal `d obj / d b = +2`; JSON internal
+/// Lagrange multiplier `lambda = −2`. The explicit signs are what make this a
+/// guard rather than a self-consistency check — a uniform flip of either
+/// surface flips these and fails the exact-value asserts below.
+#[test]
+fn equality_qp_sol_marginal_and_json_lambda_have_the_right_sign() {
+    let (sol_duals, json_lambda) = solve_duals("convex_qp.nl", "eq");
+
+    assert_eq!(sol_duals.len(), 1, ".sol should carry one marginal");
+    assert!(
+        (sol_duals[0] - 2.0).abs() < 1e-5,
+        "AMPL .sol marginal must be d obj/d b = +2 (NOT −2); got {}",
+        sol_duals[0],
+    );
+
+    assert_eq!(json_lambda.len(), 1, "JSON should carry one multiplier");
+    assert!(
+        (json_lambda[0] - (-2.0)).abs() < 1e-5,
+        "JSON solution.lambda must be the internal Lagrange multiplier −2 \
+         (NOT +2); got {}",
+        json_lambda[0],
+    );
+
+    // The two conventions differ by exactly a sign: marginal = −lambda. A
+    // uniform flip that negated BOTH would still satisfy this relation, so it
+    // is not the guard on its own — the exact-value asserts above are — but it
+    // pins the writer's negation step (nl_writer.rs, the `−v` at the heart of
+    // #271) against silent drift.
+    assert!(
+        (sol_duals[0] + json_lambda[0]).abs() < 1e-9,
+        ".sol marginal ({}) must equal −(JSON lambda) ({})",
+        sol_duals[0],
+        json_lambda[0],
+    );
+}
+
+/// `wyndor_min.nl`: the Wyndor Glass LP (pure minimize) with two active
+/// inequality constraints, textbook shadow prices (0, 1.5, 1).
+///
+/// Expected signs (analytic): JSON internal multipliers `lambda = [0, 1.5, 1]`
+/// (≥ 0, the `L = f + Σλᵢ(gᵢ−hᵢ)` convention), and AMPL `.sol` marginals
+/// `−lambda = [0, −1.5, −1]`.
+#[test]
+fn wyndor_lp_active_inequality_marginals_have_the_right_sign() {
+    let (sol_duals, json_lambda) = solve_duals("wyndor_min.nl", "wyndor");
+
+    assert_eq!(json_lambda.len(), 3);
+    let expect_lambda = [0.0, 1.5, 1.0];
+    for (i, (&got, &want)) in json_lambda.iter().zip(&expect_lambda).enumerate() {
+        assert!(
+            (got - want).abs() < 1e-4,
+            "JSON lambda[{i}] must be {want} (≥ 0 Lagrange convention); got {got}",
+        );
+    }
+
+    assert_eq!(sol_duals.len(), 3);
+    let expect_marginal = [0.0, -1.5, -1.0];
+    for (i, (&got, &want)) in sol_duals.iter().zip(&expect_marginal).enumerate() {
+        assert!(
+            (got - want).abs() < 1e-4,
+            "AMPL .sol marginal[{i}] must be {want} (= −lambda for a minimize \
+             model); got {got}",
+        );
+    }
+}

--- a/python/tests/test_dual_sign_regression.py
+++ b/python/tests/test_dual_sign_regression.py
@@ -1,0 +1,170 @@
+"""Dual-SIGN regression guard for the Python / pyomo dual surfaces (issue #294).
+
+Why this test exists (the #271 post-mortem)
+-------------------------------------------
+A constraint-dual sign inversion (#271/#272, fixed in #287) flipped every
+AMPL/Pyomo/GAMS marginal for an unknown span of releases and NO automated check
+caught it. The benchmark suite compares objectives/status/iterations/wall-time
+and never duals, so a flip that leaves primals and objectives exact is invisible
+to it; and ``pounce verify`` evaluates KKT stationarity for both ``+λ`` and
+``−λ`` and keeps the better residual, so it certifies either sign.
+
+The key principle: **agreement between pounce's own surfaces is not a guard** — a
+uniform flip satisfies it. Each assertion below therefore pins a dual against an
+EXTERNAL reference (IPOPT, via pyomo) or an ANALYTIC value with an explicit
+expected SIGN, so a future uniform flip fails loudly.
+
+Analytic references
+-------------------
+* Wyndor Glass Co. LP (textbook): ``max 3x1+5x2 s.t. x1≤4, 2x2≤12, 3x1+2x2≤18``,
+  optimum 36 at (2, 6), shadow prices (0, 1.5, 1). Written to pyomo both as a
+  maximize and as the equivalent ``min −3x1−5x2``.
+* Strictly convex equality QP: ``min x0²+x1² s.t. x0+x1=2``, optimum (1, 1);
+  KKT ``2x + Aᵀy = 0`` gives the equality multiplier ``y = −2`` exactly, and
+  the pyomo/AMPL marginal ``d obj / d b = +2``.
+
+The sibling Rust test ``issue_294_dual_sign_regression.rs`` pins the ``.sol``
+and JSON ``solution.lambda`` surfaces; ``test_gams_link.py`` pins the GAMS ``pi``
+conversion for both senses.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import pounce
+from pounce.qp import solve_qp
+
+# Textbook shadow prices for the Wyndor LP constraints (c1, c2, c3).
+WYNDOR_SHADOW = np.array([0.0, 1.5, 1.0])
+
+
+# ── pyomo model.dual — the surface #271 flipped, checked against IPOPT ────────
+
+
+def _build_wyndor_pyomo(pyo, maximize):
+    m = pyo.ConcreteModel()
+    m.x1 = pyo.Var(bounds=(0, None), initialize=0.0)
+    m.x2 = pyo.Var(bounds=(0, None), initialize=0.0)
+    if maximize:
+        m.obj = pyo.Objective(expr=3 * m.x1 + 5 * m.x2, sense=pyo.maximize)
+    else:
+        m.obj = pyo.Objective(expr=-3 * m.x1 - 5 * m.x2, sense=pyo.minimize)
+    m.c1 = pyo.Constraint(expr=m.x1 <= 4)
+    m.c2 = pyo.Constraint(expr=2 * m.x2 <= 12)
+    m.c3 = pyo.Constraint(expr=3 * m.x1 + 2 * m.x2 <= 18)
+    return m
+
+
+def _solve_pyomo_duals(pyo, solver_name, maximize):
+    m = _build_wyndor_pyomo(pyo, maximize)
+    m.dual = pyo.Suffix(direction=pyo.Suffix.IMPORT)
+    pyo.SolverFactory(solver_name).solve(m)
+    x = np.array([pyo.value(m.x1), pyo.value(m.x2)])
+    duals = np.array([m.dual[c] for c in (m.c1, m.c2, m.c3)])
+    return x, duals
+
+
+@pytest.mark.parametrize(
+    "maximize, expected",
+    [
+        # A maximize model's marginals are the natural shadow prices, +sign.
+        (True, WYNDOR_SHADOW),
+        # The equivalent minimize model's marginals are the exact negation.
+        (False, -WYNDOR_SHADOW),
+    ],
+)
+def test_pyomo_model_dual_sign(maximize, expected):
+    """``SolverFactory('pounce')`` model.dual must carry the shadow price with
+    the sign IPOPT/AMPL use: +1.5/+1 for the maximize model, −1.5/−1 for the
+    equivalent minimize. The explicit sign is the guard — a uniform flip
+    (the #271 defect) fails these exact-value asserts."""
+    pyo = pytest.importorskip("pyomo.environ")
+    pytest.importorskip("pyomo_pounce")  # registers 'pounce'
+    import pyomo_pounce  # noqa: F401
+
+    x, duals = _solve_pyomo_duals(pyo, "pounce", maximize)
+    np.testing.assert_allclose(x, [2.0, 6.0], atol=1e-4)
+    np.testing.assert_allclose(duals, expected, atol=1e-4)
+
+
+@pytest.mark.parametrize("maximize", [True, False])
+def test_pyomo_pounce_matches_ipopt_duals(maximize):
+    """External-reference guard: pounce's pyomo duals must agree with IPOPT's
+    on the SAME model, sign and value. This is the check the benchmark corpus
+    lacks — agreement with an independent solver, not with pounce itself."""
+    pyo = pytest.importorskip("pyomo.environ")
+    pytest.importorskip("pyomo_pounce")
+    import pyomo_pounce  # noqa: F401
+
+    if not pyo.SolverFactory("ipopt").available(exception_flag=False):
+        pytest.skip("ipopt not available for the external cross-check")
+
+    _, ref = _solve_pyomo_duals(pyo, "ipopt", maximize)
+    _, got = _solve_pyomo_duals(pyo, "pounce", maximize)
+    np.testing.assert_allclose(got, ref, atol=1e-4)
+    # And the sign matches the analytic shadow price, not just IPOPT.
+    np.testing.assert_allclose(
+        got, WYNDOR_SHADOW if maximize else -WYNDOR_SHADOW, atol=1e-4
+    )
+
+
+# ── pounce.minimize(...).info["mult_g"] — Lagrange convention = −marginal ─────
+
+
+def test_minimize_mult_g_sign():
+    """``info['mult_g']`` keeps the *Lagrange multiplier* convention (= −marginal).
+
+    For ``min −3x1−5x2`` with the three ``Gx ≤ h`` rows, the KKT multipliers of
+    ``L = f + Σ λᵢ (gᵢ − hᵢ)`` (λᵢ ≥ 0) are the analytic shadow prices
+    ``[0, 1.5, 1]``. That is the opposite sign to the minimize-model AMPL
+    marginal ``[0, −1.5, −1]``; assert against the Lagrange value, not the
+    marginal."""
+    from scipy.optimize import LinearConstraint
+
+    G = np.array([[1.0, 0.0], [0.0, 2.0], [3.0, 2.0]])
+    h = np.array([4.0, 12.0, 18.0])
+    res = pounce.minimize(
+        lambda x: -3.0 * x[0] - 5.0 * x[1],
+        x0=[0.0, 0.0],
+        jac=lambda x: np.array([-3.0, -5.0]),
+        constraints=[LinearConstraint(G, -np.inf, h)],
+        bounds=[(0, None), (0, None)],
+    )
+    np.testing.assert_allclose(res.x, [2.0, 6.0], atol=1e-4)
+    mult_g = np.asarray(res.info["mult_g"], dtype=float)
+    # Explicit signed analytic value: ≥ 0, NOT the negated marginal.
+    np.testing.assert_allclose(mult_g, WYNDOR_SHADOW, atol=1e-4)
+    assert mult_g[1] > 0 and mult_g[2] > 0, "mult_g must be the +λ Lagrange sign"
+
+
+# ── solve_qp y / z — convex path ─────────────────────────────────────────────
+
+
+def test_solve_qp_inequality_multipliers_sign():
+    """``QpResult.z`` are the ≥ 0 inequality multipliers. For the Wyndor LP as
+    ``min −3x1−5x2 s.t. Gx ≤ h`` they equal the analytic shadow prices
+    ``[0, 1.5, 1]`` — a uniform flip would make the active ones negative."""
+    G = np.array([[1.0, 0.0], [0.0, 2.0], [3.0, 2.0]])
+    h = np.array([4.0, 12.0, 18.0])
+    r = solve_qp(P=np.zeros((2, 2)), c=[-3.0, -5.0], G=G, h=h, lb=[0.0, 0.0])
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, [2.0, 6.0], atol=1e-4)
+    np.testing.assert_allclose(r.z, WYNDOR_SHADOW, atol=1e-4)
+    assert r.z[1] > 0 and r.z[2] > 0, "active inequality multipliers must be ≥ 0"
+
+
+def test_solve_qp_equality_multiplier_sign():
+    """``QpResult.y`` is the equality multiplier. For ``min x0²+x1² s.t.
+    x0+x1=2`` (P = 2I), KKT ``2x + Aᵀy = 0`` at x=(1,1) gives ``y = −2``
+    exactly — pin the sign so a flip to +2 fails."""
+    r = solve_qp(
+        P=2.0 * np.eye(2),
+        c=[0.0, 0.0],
+        A=np.array([[1.0, 1.0]]),
+        b=[2.0],
+    )
+    assert r.status == "optimal"
+    np.testing.assert_allclose(r.x, [1.0, 1.0], atol=1e-6)
+    np.testing.assert_allclose(r.y, [-2.0], atol=1e-5)

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -473,3 +473,28 @@ def test_gams_pi_matches_analytic_shadow_price_maximizing():
     unconditional negation returned ``-2``.
     """
     assert link.gams_pi([2.0], obj_sign=-1.0) == pytest.approx([2.0])
+
+
+# --- gh #294: analytic dual-sign regression guard, BOTH senses ---------------
+
+
+def test_gams_pi_wyndor_shadow_prices_both_senses():
+    """Pin the GAMS marginal against the textbook Wyndor Glass shadow prices
+    for BOTH a maximizing and a minimizing model (gh #294 hardening).
+
+    The Wyndor LP ``max 3x1+5x2 s.t. x1<=4, 2x2<=12, 3x1+2x2<=18`` has optimum
+    36 at (2, 6) with shadow prices ``(0, 1.5, 1)``. POUNCE's internal
+    constraint multipliers there are ``lambda = [0, 1.5, 1]`` (the ``+lambda``
+    Lagrange convention; verified live and against IPOPT).
+
+    * Maximizing (``obj_sign = -1``): ``pi = -(-1)*lambda = +lambda`` = the
+      shadow prices ``[0, 1.5, 1]`` GAMS's own solvers report.
+    * Minimizing the equivalent ``min -3x1-5x2`` (``obj_sign = +1``):
+      ``pi = -lambda`` = ``[0, -1.5, -1]``.
+
+    A uniform sign flip (the #271/#272 defect) would negate both; the explicit
+    signed expectations below fail loudly if that recurs.
+    """
+    lam = [0.0, 1.5, 1.0]  # POUNCE internal multipliers for the Wyndor optimum
+    assert link.gams_pi(lam, obj_sign=-1.0) == pytest.approx([0.0, 1.5, 1.0])
+    assert link.gams_pi(lam, obj_sign=1.0) == pytest.approx([0.0, -1.5, -1.0])


### PR DESCRIPTION
Fixes #294.

## Why the flip survived (the post-mortem)

The #271/#272 constraint-dual **sign inversion** flipped every AMPL/Pyomo/GAMS marginal for an unknown span of releases, and **no automated check caught it**, because the two guards that structurally *could* have — don't:

1. **The benchmark suite never compares duals.** `benchmarks/benchmark_report.py`'s pass criterion is matching objectives (plus status/iterations/wall-time). A defect that leaves primals and objectives exact — which a uniform dual sign flip does — is invisible to the entire corpus by construction.
2. **`pounce verify` accepts either dual sign.** `crates/pounce-cli/src/verify.rs` evaluates KKT stationarity for **both** `+lambda` and `-lambda` and keeps the better residual, so it certifies either sign and cannot guard the convention.

The key principle: **agreement between pounce's own surfaces is not a guard** — a uniform flip satisfies it. The guard must be agreement with an **external** reference (IPOPT) or an **analytic** value, with the expected **sign** encoded explicitly.

## The guard added

A dedicated regression test on **every dual-bearing surface**, each pinned to an external/analytic reference with an explicit expected sign:

**Analytic references**
- Equality QP `min x0^2+x1^2 s.t. x0+x1=2`, optimum (1,1): `obj*(b)=b^2/2` => AMPL marginal `d obj/d b = +2`; internal Lagrange multiplier of `L=f+lambda(x0+x1-b)` is `lambda=-2`.
- Wyndor Glass Co. LP `max 3x1+5x2 s.t. x1<=4, 2x2<=12, 3x1+2x2<=18`, optimum 36 at (2,6), textbook shadow prices **(0, 1.5, 1)**.

**Surfaces and expected signs**
| Surface | File | Expected (signed) |
|---|---|---|
| `.sol` dual block (AMPL `d obj/d b`) | `crates/pounce-cli/tests/issue_294_dual_sign_regression.rs` | eq QP `+2`; Wyndor min-form `[0, -1.5, -1]` |
| JSON `solution.lambda` (internal Lagrange) | same | eq QP `-2`; Wyndor `[0, 1.5, 1]` |
| `pyomo-pounce` `model.dual` | `python/tests/test_dual_sign_regression.py` | Wyndor max `[0, +1.5, +1]`, min `[0, -1.5, -1]`, **cross-asserted equal to IPOPT** on the same model |
| `minimize(...).info["mult_g"]` (= -marginal) | same | Wyndor `[0, 1.5, 1]` (asserted against the Lagrange value, not the marginal) |
| `solve_qp` `y` / `z` (convex path) | same | ineq `z = [0, 1.5, 1]` (>= 0); eq `y = -2` (KKT `2x+A'y=0`) |
| GAMS `pi` via fake-`GmoView` harness | `python/tests/test_gams_link.py` | Wyndor: maximizing `[0, 1.5, 1]`, minimizing `[0, -1.5, -1]` |

New fixture: `crates/pounce-cli/tests/fixtures/wyndor_min.nl` (Wyndor as a pure minimize, so its `.sol` marginals are unambiguous; the max-vs-min convention is pinned on the pyomo/GAMS surfaces). Each test file carries a module-level comment explaining the #271 post-mortem and why it references an external/analytic value rather than self-agreement.

## How I confirmed the guard has teeth

The assertions pin the **exact signed value**, so a negation is caught. I additionally verified this concretely by momentarily flipping the production sign and observing failures, then reverting:
- Flipped `-v` -> `v` in the `.sol` writer (`crates/pounce-cli/src/nl_writer.rs`, the #271 site), rebuilt, ran the Rust test => both cases **FAILED** (`marginal must be +2 ... got -2`; `marginal[1] must be -1.5 ... got 1.5`). Reverted; passes.
- Flipped `-obj_sign` -> `obj_sign` in `pounce.gams.link.gams_pi`, ran `test_gams_link.py` => the analytic-value cases **FAILED** while the flip-invariant self-agreement case (`...sign_flips_between_senses`) still passed — a live demonstration of exactly the weakness this issue is about. Reverted; passes.

## Validation (on current main, sign is correct)

- `cargo test -p pounce-cli --release -q` — all pass (incl. the 2 new tests).
- `python -m pytest python/tests/test_gams_link.py python/tests/test_dual_sign_regression.py -q` — **40 passed**.
- `python -m pytest pyomo-pounce/tests/ -q` — **101 passed**.
- `cargo fmt --all` clean; rustfmt pre-commit passed.

No solver behavior changed — this is tests + one `.nl` fixture only. `benchmarks/` and `adversary/` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
