### PR TITLE
Move the impossible-bound guard into the pounce-convex core (#295, completes #275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the impossible-bound guard now lives in the convex core (#295, completes #275)
+
+- **A `QpProblem` with a box that admits no finite point — a *present* `+∞`
+  lower bound (`lb ≥ BOUND_INF`) or a *present* `−∞` upper bound
+  (`ub ≤ −BOUND_INF`) — was silently mishandled by the `pounce-convex` core and
+  could be reported `Optimal` at a point violating the bound by an infinite
+  margin.** #275 (fixed in #291) rejected these sign-inconsistent infinite
+  bounds, but the fix lived *entirely* in the Python layer
+  (`python/pounce/qp.py::_validate`, `python/pounce/_minimize.py`). The core's
+  bound-presence test (`expand_bounds` in `crates/pounce-convex/src/ipm.rs`) is
+  sign-agnostic — it keys only on magnitude (`ub < BOUND_INF`,
+  `lb > -BOUND_INF`) — so any surface reaching the core without
+  `_validate` (the raw `_pounce` PyO3 bindings, `pounce-convex` used directly as
+  a Rust crate) got the pre-#275 wrong `optimal`.
+  - **Fix (defense in depth).** The invariant now lives in the core, so every
+    surface inherits it. A new `QpProblem::bounds_admit_no_point` screen maps an
+    impossible box to `QpStatus::PrimalInfeasible` — the same class the finite
+    reversed box (`lb > ub`) already produces — at the earliest point of every
+    bound-accepting solve entry (`solve_qp_ipm`, `_warm`, `_debug`;
+    `solve_socp_ipm`, `_debug`) *before* the sign-agnostic bound expansion, and
+    at the top of `presolve` (`presolve.rs`, beside the existing reversed-bound
+    detection) so a presolve-then-solve caller is covered even when the solver
+    is otherwise reached directly.
+  - **Absent vs. impossible preserved.** An *absent* one-sided bound
+    (`lb ≤ −BOUND_INF` / `ub ≥ +BOUND_INF`, the normal `±∞` encoding for
+    "unbounded on that side") is untouched and still solves; a fixed variable
+    (`lb == ub`) still solves; a finite reversed box (`lb > ub`) still reports
+    `PrimalInfeasible`.
+  - The Python-layer `_validate` guard is retained as the first line of defense
+    (it raises a `ValueError` with an index-named message earlier, before the
+    solve). This change makes the core a certified second line.
+  - Verified by reproducing the wrong `optimal` on the raw `_pounce` binding on
+    `main` and confirming it now returns `primal_infeasible`
+    (`python/tests/test_qp_host.py::test_raw_binding_rejects_impossible_bounds`,
+    plus Rust unit tests in `crates/pounce-convex/tests/bounded_form.rs`).
+
 ### Tests — external/analytic dual-SIGN regression guard (#294, hardening after #271/#272/#287)
 
 - **A durable guard so a constraint-dual sign inversion cannot ship silently

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -225,6 +225,13 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     let mut make_backend = make_backend;
+    // gh #295: reject a box that admits no finite point (a *present* `+∞`
+    // lower / `−∞` upper bound) before bound expansion — `expand_bounds` is
+    // sign-agnostic and would otherwise mishandle it and report a violating
+    // point `Optimal`.
+    if prob.bounds_admit_no_point() {
+        return trivial_primal_infeasible_solution(prob);
+    }
     // Interior-point solve in the original problem's coordinates (the core
     // already unscales any internal Ruiz equilibration before returning).
     let sol = solve_qp_ipm_core(prob, opts, &mut make_backend);
@@ -331,6 +338,11 @@ pub fn solve_qp_ipm_debug<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    // gh #295: reject an impossible box (present `+∞` lower / `−∞` upper
+    // bound) before bound expansion, as the non-debug path does.
+    if prob.bounds_admit_no_point() {
+        return trivial_primal_infeasible_solution(prob);
+    }
     // Build the factorization and run the core loop directly with the hook
     // (mirrors `solve_qp_core`'s non-HSDE path; `solve_qp_core` itself can't
     // carry the borrowed hook through its generic plumbing). When the HSDE
@@ -384,6 +396,11 @@ where
     // otherwise the warm start would silently do nothing. A caller that
     // warm-starts is doing nearby reoptimization (a known-solvable
     // neighborhood), where the direct path's fragility is not a concern.
+    // gh #295: reject an impossible box (present `+∞` lower / `−∞` upper
+    // bound) before equilibration and bound expansion.
+    if prob.bounds_admit_no_point() {
+        return trivial_primal_infeasible_solution(prob);
+    }
     let direct = QpOptions {
         use_hsde: false,
         equilibrate: false,
@@ -434,6 +451,11 @@ pub fn solve_socp_ipm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    // gh #295: reject an impossible box (present `+∞` lower / `−∞` upper
+    // bound) before bound expansion; `expand_bounds` is sign-agnostic.
+    if prob.bounds_admit_no_point() {
+        return trivial_primal_infeasible_solution(prob);
+    }
     // The cones must partition the inequality rows exactly; otherwise the
     // cone vectors and the `m_ineq` slack disagree and the driver would read
     // out of bounds (an exp/power cone is always 3 rows). Fail cleanly here.
@@ -1063,7 +1085,7 @@ where
         // coordinate pinned strictly outside its `≥ 0` domain proves primal
         // infeasibility, which the HSDE's residual-gated Farkas detector misses.
         if crate::hsde_nonsym::detect_cone_domain_infeasible(prob, &blocks) {
-            return cone_domain_infeasible_solution(prob);
+            return trivial_primal_infeasible_solution(prob);
         }
         return match hook {
             Some(h) => solve_conic_hsde_nonsym_debug(prob, &blocks, opts, h, make_backend),
@@ -1073,7 +1095,7 @@ where
     let (expanded, bound_rows) = expand_bounds(prob);
     let blocks = blocks_of(cones, bound_rows.len());
     if crate::hsde_nonsym::detect_cone_domain_infeasible(&expanded, &blocks) {
-        return cone_domain_infeasible_solution(prob);
+        return trivial_primal_infeasible_solution(prob);
     }
     let sol = match hook {
         Some(h) => solve_conic_hsde_nonsym_debug(&expanded, &blocks, opts, h, make_backend),
@@ -2045,10 +2067,12 @@ fn failed_solution(
     }
 }
 
-/// Build a `PrimalInfeasible` solution reported by the setup-time cone-domain
-/// screen (gh #283). Carries the trivial iterate; the status is the certified
-/// result. `z = 0` (the cone apex) is dual-cone-feasible in every cone.
-fn cone_domain_infeasible_solution(prob: &QpProblem) -> QpSolution {
+/// Build a `PrimalInfeasible` solution reported by a **setup-time** screen —
+/// the cone-domain screen (gh #283) and the impossible-bound screen (gh #295,
+/// a *present* `+∞` lower / `−∞` upper bound). Carries the trivial iterate; the
+/// status is the certified result. `z = 0` (the cone apex) is dual-cone-feasible
+/// in every cone.
+fn trivial_primal_infeasible_solution(prob: &QpProblem) -> QpSolution {
     QpSolution {
         status: QpStatus::PrimalInfeasible,
         x: vec![0.0; prob.n],

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -427,6 +427,15 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
     let n = prob.n;
     let m_eq = prob.m_eq();
     let m_ineq = prob.m_ineq();
+    // gh #295: a *present* lower bound at `+∞` or upper bound at `−∞` admits no
+    // finite point — the same primal-infeasible class as a finite reversed box
+    // (`tlb[k] > tub[k]`, detected during bound tightening below). Catch it up
+    // front so an impossible bound is never mistaken for an *absent* one (the
+    // normal one-sided `±∞` encoding, which stays feasible). See
+    // [`QpProblem::bounds_admit_no_point`].
+    if prob.bounds_admit_no_point() {
+        return PresolveOutcome::Infeasible;
+    }
     let is_soc_row = |i: usize| soc_row.get(i).copied().unwrap_or(false);
     // A column is conic-coupled if it appears in any SOC inequality row.
     let mut soc_col = vec![false; n];

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -89,6 +89,25 @@ impl QpProblem {
         self.lb.iter().any(|&v| v > -BOUND_INF) || self.ub.iter().any(|&v| v < BOUND_INF)
     }
 
+    /// True when the variable box admits **no finite point**: a *present*
+    /// lower bound at `+∞` (`lb ≥ BOUND_INF`) or a *present* upper bound at
+    /// `−∞` (`ub ≤ −BOUND_INF`). Such a bound is genuinely primal-infeasible
+    /// (gh #295) — the same class as a finite reversed box (`lb > ub`).
+    ///
+    /// Deliberately distinct from an *absent* bound (`lb ≤ −BOUND_INF` /
+    /// `ub ≥ +BOUND_INF`, the normal one-sided `±∞` encoding), which is
+    /// feasible and left to the solver. The interior-point setup
+    /// ([`crate::ipm`]'s `expand_bounds`) is sign-agnostic — it tests only a
+    /// bound's *presence* by magnitude (`ub < BOUND_INF`, `lb > -BOUND_INF`)
+    /// — so without this screen a `+∞` lower / `−∞` upper bound is silently
+    /// mishandled and a point violating it can be reported `Optimal`. Every
+    /// solve entry point (and presolve) consults this so the rejection holds
+    /// on every surface — the raw `_pounce` bindings and direct Rust callers
+    /// included — mirroring the Python-layer `_validate` guard (#275 / #291).
+    pub(crate) fn bounds_admit_no_point(&self) -> bool {
+        (0..self.n).any(|i| self.lb_of(i) >= BOUND_INF || self.ub_of(i) <= -BOUND_INF)
+    }
+
     /// A copy of this problem with the **objective** data scaled by `factor`
     /// (`P ← factor·P`, `c ← factor·c`); constraints, bounds, and the feasible
     /// set are untouched. Scaling the objective by a positive constant leaves

--- a/crates/pounce-convex/tests/bounded_form.rs
+++ b/crates/pounce-convex/tests/bounded_form.rs
@@ -81,6 +81,130 @@ fn lower_bound_binds() {
     assert_stationarity(&prob, &sol, 1e-5);
 }
 
+/// gh #295 (defense-in-depth for #275): a box that admits **no finite point**
+/// — a *present* `+∞` lower bound or a *present* `−∞` upper bound — must be
+/// certified `PrimalInfeasible` by the core itself, on the raw solve path
+/// (bypassing the Python-layer `_validate` guard). Before this fix
+/// `expand_bounds` was sign-agnostic and silently dropped such a bound as
+/// "absent", returning `Optimal` at a violating point.
+#[test]
+fn present_infinite_lower_bound_is_primal_infeasible() {
+    // min ½x²  s.t.  x ≥ +∞ : impossible.
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 1.0)],
+        c: vec![0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![POS_INF],
+        ub: vec![POS_INF],
+    };
+    let sol = solve(&prob);
+    assert_eq!(sol.status, QpStatus::PrimalInfeasible);
+}
+
+#[test]
+fn present_infinite_upper_bound_is_primal_infeasible() {
+    // min ½x²  s.t.  x ≤ −∞ : impossible.
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 1.0)],
+        c: vec![0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![NEG_INF],
+        ub: vec![NEG_INF],
+    };
+    let sol = solve(&prob);
+    assert_eq!(sol.status, QpStatus::PrimalInfeasible);
+}
+
+/// The impossible-bound screen must NOT regress the *absent* one-sided `±∞`
+/// encoding: `lb = −∞` / `ub = +∞` is the normal way to say "unbounded on
+/// that side" and must still solve. `min ½(x+3)²` with `x ∈ (−∞, +∞)` → −3.
+#[test]
+fn absent_infinite_bounds_still_solve() {
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 1.0)],
+        c: vec![3.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![NEG_INF],
+        ub: vec![POS_INF],
+    };
+    let sol = solve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!((sol.x[0] - (-3.0)).abs() < 1e-6, "x0={}", sol.x[0]);
+}
+
+/// A finite reversed box (`lb > ub`) is the same infeasible class and must
+/// still map to `PrimalInfeasible` (regression guard for the pre-existing
+/// behavior the #295 screen sits beside).
+#[test]
+fn finite_reversed_box_is_primal_infeasible() {
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 1.0)],
+        c: vec![0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![5.0],
+        ub: vec![3.0],
+    };
+    let sol = solve(&prob);
+    assert_eq!(sol.status, QpStatus::PrimalInfeasible);
+}
+
+/// A fixed variable (`lb == ub`) is feasible and must still solve to that
+/// value — the screen must not over-reject the degenerate-but-valid box.
+#[test]
+fn fixed_variable_still_solves() {
+    // min ½(x−10)²  s.t.  x = 2  → x* = 2.
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 1.0)],
+        c: vec![-10.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![2.0],
+        ub: vec![2.0],
+    };
+    let sol = solve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!((sol.x[0] - 2.0).abs() < 1e-6, "x0={}", sol.x[0]);
+}
+
+/// Presolve is the other core entry that must certify an impossible bound
+/// infeasible (the fixpoint's first pass), so a presolve-then-solve caller
+/// inherits the same rejection.
+#[test]
+fn presolve_rejects_present_infinite_bound() {
+    use pounce_convex::presolve::{PresolveOutcome, presolve};
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 1.0)],
+        c: vec![0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![POS_INF],
+        ub: vec![POS_INF],
+    };
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+}
+
 /// Box-constrained LP: min −x0 − x1 with 0 ≤ x ≤ 1. Optimum (1, 1).
 #[test]
 fn box_constrained_lp() {

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -338,6 +338,42 @@ def test_solve_qp_batch_inherits_the_bound_guard():
         )
 
 
+# --- gh #295: the core defends even when the Python _validate guard is bypassed
+
+
+def test_raw_binding_rejects_impossible_bounds():
+    """Defense in depth (gh #295): the ``pounce-convex`` core itself must map a
+    box that admits no finite point to ``primal_infeasible``, even on the raw
+    ``_pounce`` binding that never runs ``qp.py::_validate``.
+
+    Before #295 the sign-agnostic ``expand_bounds`` dropped a ``+inf`` lower /
+    ``-inf`` upper bound as "absent" and returned ``optimal`` at a violating
+    point. This exercises the actual exposed surface (the raw binding), not the
+    guarded ``solve_qp`` wrapper.
+    """
+    import pounce._pounce as _pounce  # the raw, unvalidated PyO3 surface
+
+    def raw_status(lb, ub):
+        prob = _pounce.QpProblem(
+            1, [0.0],
+            [0], [0], [1.0],           # P = [[1]]
+            [], [], [], [],            # A, b
+            [], [], [], [],            # G, h
+            lb, ub,
+        )
+        return _pounce.solve_qp(prob)["status"]
+
+    # Present +inf lower / -inf upper bound → impossible → primal_infeasible.
+    assert raw_status([np.inf], [np.inf]) == "primal_infeasible"
+    assert raw_status([-np.inf], [-np.inf]) == "primal_infeasible"
+    # Absent one-sided ±inf is the normal encoding and must still solve.
+    assert raw_status([-np.inf], [np.inf]) == "optimal"
+    # A fixed variable (lb == ub) is feasible and must still solve.
+    assert raw_status([2.0], [2.0]) == "optimal"
+    # A finite reversed box remains primal_infeasible.
+    assert raw_status([5.0], [3.0]) == "primal_infeasible"
+
+
 # --- tol / max_iter option validation (gh #277) -----------------------------
 
 # The convex entry points used to apply *no* validation to `tol` while every


### PR DESCRIPTION
Fixes #295. Follow-up to #275 (fixed in #291).

## The core exposure

#275 rejected sign-inconsistent infinite bounds — a *present* `+INF` lower bound or `-INF` upper bound, which no finite point can satisfy — but the fix lived **entirely in the Python layer** (`python/pounce/qp.py::_validate`, `python/pounce/_minimize.py`). The `pounce-convex` core stayed sign-agnostic.

`expand_bounds` in `crates/pounce-convex/src/ipm.rs` decides a bound is *present* purely by magnitude:

```rust
if ub < crate::qp::BOUND_INF { ... }   // treats +inf AND a finite huge ub identically
if lb > -crate::qp::BOUND_INF { ... }  // treats -inf AND a finite huge lb identically
```

So a `QpProblem` with `lb[i] = +inf` had that bound mishandled as "absent" and returned `status = "optimal"` at a point violating it by an infinite margin. Every surface reaching the core **without** `_validate` was still exposed:

- the raw `_pounce` PyO3 bindings (`_pounce.solve_qp`, `_pounce.QpProblem`, ...),
- `pounce-convex` used directly as a Rust crate.

(The `.nl` / CLI path is not exposed in practice — AMPL `.nl` encodes an unbounded side as an *absent* bound, so `+/-inf` cannot be spelled there — but that is luck of the format, not a guarantee.)

## The core-level fix (defense in depth)

The invariant now lives in the core, so every surface inherits it:

- **New `QpProblem::bounds_admit_no_point`** (`crates/pounce-convex/src/qp.rs`): a *present* lower bound at `+INF` (`lb >= BOUND_INF`) or a *present* upper bound at `-INF` (`ub <= -BOUND_INF`) admits no finite point -> primal-infeasible. It is **deliberately distinct from an *absent* bound** (`lb <= -BOUND_INF` / `ub >= +BOUND_INF`, the normal one-sided `+/-inf` encoding for "unbounded on that side"), which stays feasible and is left to the solver.
- **Every bound-accepting solve entry** (`solve_qp_ipm`, `solve_qp_ipm_warm`, `solve_qp_ipm_debug`, `solve_socp_ipm`, `solve_socp_ipm_debug`) consults it **before** the sign-agnostic bound expansion and returns `QpStatus::PrimalInfeasible` — the same class the finite reversed box (`lb > ub`) already produces. (`solve_socp_ipm_warm` already asserts no bounds, so it is unaffected.)
- **Presolve screens it too** (`crates/pounce-convex/src/presolve.rs`, at the top of `presolve_once`, beside the pre-existing reversed-bound detection), so a presolve-then-solve caller is covered even when presolve is otherwise the entry.
- The trivial-solution builder `cone_domain_infeasible_solution` was generalized to `trivial_primal_infeasible_solution` (it already built exactly the certified `PrimalInfeasible` result for the gh #283 cone-domain screen).

The Python-layer `_validate` check is **retained as the first line of defense** — it raises a `ValueError` with an index-named message *before* the solve, which is a better error than a status. This change makes the core a certified **second** line; it does not replace the first.

## Validation

- **Reproduced the exposure on `main`** by bypassing `_validate` and calling the raw binding directly: `_pounce.solve_qp` on a QP with `lb = [+inf]` returned `status = "optimal"` at `x = [0]` (violating `x >= +inf`). With the fix the same raw path returns `primal_infeasible`.
- **Absent-vs-impossible preserved:** absent one-sided `+/-inf` (`lb=-inf`, `ub=+inf`) still solves; a fixed variable (`lb == ub`) still solves; a finite reversed box (`lb > ub`) still reports `primal_infeasible`.
- **Python path unchanged:** `solve_qp(lb=[+inf])` still raises the #275 `ValueError` (the Python check fires first).
- **Regression:** `cargo test -p pounce-convex --release` and `cargo test -p pounce-py --release` green; `pytest python/tests/test_qp_host.py python/tests/test_minimize.py` (134 passed). A few QP `.nl` benchmarks (HS35, HS21, GENHS28, ZECEVIC2) still solve to their known optima.
- **New tests:** `crates/pounce-convex/tests/bounded_form.rs` (impossible lower/upper -> `PrimalInfeasible`; absent one-sided `+/-inf` still solves; finite reversed infeasible; fixed variable solves; `presolve` rejects the impossible bound) and `python/tests/test_qp_host.py::test_raw_binding_rejects_impossible_bounds` (drives the raw `_pounce` binding — the actual exposed surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
