### PR TITLE
Write ipopt_zL_out/ipopt_zU_out bound-multiplier .sol suffixes (#296)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ changes.
 
 ## [Unreleased]
 
+### Added — bound-multiplier `.sol` suffixes for Ipopt-parity reduced costs (#296)
+
+- **The `.sol` writer now emits `ipopt_zL_out` / `ipopt_zU_out` variable-suffix
+  blocks — the reduced costs / bound sensitivities Ipopt writes and Pyomo
+  surfaces as `model.ipopt_zL_out[var]` / `model.ipopt_zU_out[var]` (AMPL's
+  variable `.rc`).** pounce emitted the constraint duals (correctly signed
+  since #287) but *no* bound multipliers, so a user migrating from Ipopt read
+  `None` back with no error — a silent parity gap surfaced in the #271/#272
+  dual audit. The underlying multipliers already existed internally
+  (`mult_x_L`/`mult_x_U`, confirmed correct against Ipopt in the #271 audit);
+  they are now written out.
+  - **Sign convention, verified numerically against Ipopt 3.14** on
+    bound-active models: Ipopt writes `ipopt_zL_out = +z_l` (≥ 0 at an active
+    lower bound) and `ipopt_zU_out = −z_u` (≤ 0 at an active upper bound) —
+    both equal to the objective-gradient component at the bound. pounce now
+    matches to solver tolerance (e.g. `min (x−3)² s.t. 0 ≤ x ≤ 1`: `x*=1`,
+    `ipopt_zU_out[x] = −4`, matching Ipopt's `−3.99999998…`).
+  - **All three `.sol`-producing paths covered.** The NLP interior-point path
+    lifts the converged bound multipliers through
+    `OrigIpoptNlp::finalize_solution_z_l`/`_z_u` (fixed-var + scaling maps
+    unwound, `obj_scale_factor` divided out); the convex QP and SOCP paths fold
+    variable bounds into `G` rows, so a new
+    `qp_extract::recover_bound_mults` reads the multipliers back out of the
+    inequality-multiplier vector and applies the maximize `sign`.
+  - **Pyomo populated automatically.** Pyomo's ASL `.sol` reader maps the suffix
+    blocks straight onto the model suffixes, so `model.ipopt_zL_out` /
+    `model.ipopt_zU_out` now come back populated after
+    `SolverFactory('pounce').solve(model)` — matching Ipopt exactly (both
+    leave the derived `rc` suffix `None`; AMPL, not the reader, derives `.rc`).
+    No `pyomo-pounce` changes were needed.
+
 ### Fixed — the impossible-bound guard now lives in the convex core (#295, completes #275)
 
 - **A `QpProblem` with a box that admits no finite point — a *present* `+∞`

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -822,11 +822,25 @@ pub fn main() -> ExitCode {
     > = Rc::new(RefCell::new(None));
     let sens_capture: Rc<RefCell<Option<Vec<pounce_common::types::Number>>>> =
         Rc::new(RefCell::new(None));
+    // Converged bound multipliers, lifted to full-x order and the user's
+    // unscaled-Lagrangian convention (Ipopt `ipopt_zL_out`/`ipopt_zU_out`).
+    // Both are `≥ 0` at an active bound; zero elsewhere. Written as `.sol`
+    // suffix blocks so Pyomo's `model.ipopt_zL_out` / AMPL `.rc` are
+    // populated for reduced-cost / sensitivity work (gh #296).
+    let bound_mult_capture: Rc<
+        RefCell<
+            Option<(
+                Vec<pounce_common::types::Number>,
+                Vec<pounce_common::types::Number>,
+            )>,
+        >,
+    > = Rc::new(RefCell::new(None));
     let red_hessian_capture: Rc<RefCell<Option<sens::RedHessianResult>>> =
         Rc::new(RefCell::new(None));
     if args.json_output.is_some() || sol_path.is_some() || sens_active || args.compute_red_hessian {
         let cap = Rc::clone(&nominal_capture);
         let sens_cap = Rc::clone(&sens_capture);
+        let bmult_cap = Rc::clone(&bound_mult_capture);
         let rh_cap = Rc::clone(&red_hessian_capture);
         let suffixes_cb = nl_suffixes.clone();
         let dims_cb = nl_dims;
@@ -883,6 +897,20 @@ pub fn main() -> ExitCode {
                 }
             }
             *cap.borrow_mut() = Some((x.clone(), lambda));
+
+            // Lift the algorithm-side compressed bound multipliers to
+            // full-x order in the user's convention. `finalize_solution_z_l`
+            // /`_z_u` unwind the fixed-var/scaling maps and divide out
+            // `obj_scale_factor`, yielding Ipopt-convention duals
+            // (`z_l ≥ 0` at an active lower bound, `z_u ≥ 0` at an active
+            // upper bound) — exactly Ipopt's `ipopt_zL_out`/`ipopt_zU_out`
+            // (gh #296). A non-`OrigIpoptNlp` returns empty here and no
+            // bound-multiplier suffixes are written.
+            let z_l_full = nlp.borrow().finalize_solution_z_l(&*curr.z_l);
+            let z_u_full = nlp.borrow().finalize_solution_z_u(&*curr.z_u);
+            if !z_l_full.is_empty() || !z_u_full.is_empty() {
+                *bmult_cap.borrow_mut() = Some((z_l_full, z_u_full));
+            }
 
             // Suffix-driven post-processing on the converged KKT
             // system: the parametric sensitivity step and (on request)
@@ -1248,6 +1276,34 @@ pub fn main() -> ExitCode {
             name: "sens_sol_state_1".to_string(),
             target: nl_writer::SolSuffixTarget::Var,
             values: nl_writer::SolSuffixValues::Real(xp),
+        });
+    }
+    // Bound-multiplier suffixes (`ipopt_zL_out` / `ipopt_zU_out`): the
+    // reduced costs / bound sensitivities. Pyomo maps these `.sol` suffix
+    // blocks straight onto `model.ipopt_zL_out` / `model.ipopt_zU_out` and
+    // AMPL onto variable `.rc` (gh #296).
+    //
+    // Sign convention — verified numerically against Ipopt 3.14 on
+    // bound-active models (gh #296): Ipopt's AMPL `.sol` writes
+    //   `ipopt_zL_out = +z_l`  (≥ 0 at an active lower bound), and
+    //   `ipopt_zU_out = −z_u`  (≤ 0 at an active upper bound),
+    // i.e. both equal the objective-gradient component at the bound
+    // (`∂f/∂x_i`). `finalize_solution_z_l`/`_z_u` return the internal
+    // multipliers with `z_l, z_u ≥ 0` (Ipopt's internal convention), so
+    // the lower block is emitted as-is and the upper block is negated to
+    // match Ipopt's output. (`min (x−3)² s.t. x≤1`: x*=1, ∂f/∂x=−4, so
+    // Ipopt writes `ipopt_zU_out = −4`; pounce now matches.)
+    if let Some((z_l_full, z_u_full)) = bound_mult_capture.borrow().clone() {
+        let z_u_neg: Vec<pounce_common::types::Number> = z_u_full.iter().map(|&z| -z).collect();
+        sol_suffixes.push(nl_writer::SolSuffix {
+            name: "ipopt_zL_out".to_string(),
+            target: nl_writer::SolSuffixTarget::Var,
+            values: nl_writer::SolSuffixValues::Real(z_l_full),
+        });
+        sol_suffixes.push(nl_writer::SolSuffix {
+            name: "ipopt_zU_out".to_string(),
+            target: nl_writer::SolSuffixTarget::Var,
+            values: nl_writer::SolSuffixValues::Real(z_u_neg),
         });
     }
 
@@ -1741,6 +1797,35 @@ fn run_convex_qp(
     // report.
     let lambda = pounce_cli::qp_extract::recover_duals(prob, &con_map, &sol.y, &sol.z);
 
+    // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`). The QP extractor
+    // folds each finite variable bound into a nonnegative `G` row (so
+    // `sol.z_lb`/`z_ub` stay empty); `recover_bound_mults` reads the raw
+    // non-negative multipliers back out of `sol.z`. They are for the
+    // *internal* minimize form (`½xᵀPx + cᵀx`, a maximize objective
+    // negated), so `sign` restores the user's objective sense — the same
+    // conversion `recover_duals` applies to the constraint duals. The
+    // Ipopt output convention (verified numerically, gh #296) is
+    // `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u`, both equal to the
+    // objective-gradient component at the bound. QP variables are 1:1 with
+    // the `.nl` variables, so no remap is needed.
+    let n_con_ineq = pounce_cli::qp_extract::count_constraint_ineq_rows(&con_map);
+    let (z_lb_raw, z_ub_raw) =
+        pounce_cli::qp_extract::recover_bound_mults(prob, n_con_ineq, &sol.z);
+    let z_l_suffix: Vec<f64> = z_lb_raw.iter().map(|&z| sign * z).collect();
+    let z_u_suffix: Vec<f64> = z_ub_raw.iter().map(|&z| -sign * z).collect();
+    let qp_bound_suffixes = [
+        nl_writer::SolSuffix {
+            name: "ipopt_zL_out".to_string(),
+            target: nl_writer::SolSuffixTarget::Var,
+            values: nl_writer::SolSuffixValues::Real(z_l_suffix),
+        },
+        nl_writer::SolSuffix {
+            name: "ipopt_zU_out".to_string(),
+            target: nl_writer::SolSuffixTarget::Var,
+            values: nl_writer::SolSuffixValues::Real(z_u_suffix),
+        },
+    ];
+
     // Write a `.sol` if requested: primal x and recovered constraint duals in
     // the AMPL `.sol` convention.
     if let Some(path) = sol_path {
@@ -1749,7 +1834,7 @@ fn run_convex_qp(
             x: &sol.x,
             mult_g: &lambda,
             solve_result_num: srn,
-            suffixes: &[],
+            suffixes: &qp_bound_suffixes,
         };
         // Log a `.sol` write failure but do not early-return a distinct exit
         // code: the NLP path (main.rs:1091-1093) only logs, and under `-AMPL`
@@ -1916,13 +2001,37 @@ fn run_convex_socp(
     // `recover_socp_duals`).
     let lambda = pounce_cli::qp_extract::recover_socp_duals(prob, &con_map, &sol.y, &sol.z);
 
+    // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`), recovered from the
+    // nonnegative-block multipliers `sol.z` (variable bounds are `G` rows
+    // appended right after the linear-inequality rows and before the SOC
+    // cones). `sign` restores the user objective sense and the Ipopt output
+    // convention is `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u` — same
+    // treatment as the QP path (gh #296).
+    let n_con_ineq = pounce_cli::qp_extract::count_socp_constraint_ineq_rows(&con_map);
+    let (z_lb_raw, z_ub_raw) =
+        pounce_cli::qp_extract::recover_bound_mults(prob, n_con_ineq, &sol.z);
+    let z_l_suffix: Vec<f64> = z_lb_raw.iter().map(|&z| sign * z).collect();
+    let z_u_suffix: Vec<f64> = z_ub_raw.iter().map(|&z| -sign * z).collect();
+    let socp_bound_suffixes = [
+        nl_writer::SolSuffix {
+            name: "ipopt_zL_out".to_string(),
+            target: nl_writer::SolSuffixTarget::Var,
+            values: nl_writer::SolSuffixValues::Real(z_l_suffix),
+        },
+        nl_writer::SolSuffix {
+            name: "ipopt_zU_out".to_string(),
+            target: nl_writer::SolSuffixTarget::Var,
+            values: nl_writer::SolSuffixValues::Real(z_u_suffix),
+        },
+    ];
+
     if let Some(path) = sol_path {
         let payload = nl_writer::SolutionFile {
             message: &format!("POUNCE {} conic IPM (pounce-convex): {msg}", class.name()),
             x: &sol.x,
             mult_g: &lambda,
             solve_result_num: srn,
-            suffixes: &[],
+            suffixes: &socp_bound_suffixes,
         };
         // Log a `.sol` write failure but do not early-return a distinct exit
         // code: the NLP path (main.rs:1091-1093) only logs, and under `-AMPL`

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -239,6 +239,76 @@ fn next_row(rhs: &[f64]) -> usize {
     rhs.len()
 }
 
+/// Count the nonnegative (`G`) rows the *constraints* contributed, so the
+/// appended variable-bound rows can be located. Both extractors emit each
+/// linear inequality / range constraint as up to two `G` rows (an upper
+/// `row ≤ g_u` and/or a lower `−row ≤ −g_l`) and place the per-variable
+/// bound rows immediately after them (equalities go to `A`, and the SOCP
+/// cones are appended *after* the bound rows). This count is that offset.
+pub fn count_constraint_ineq_rows(con_map: &[ConRowMap]) -> usize {
+    con_map
+        .iter()
+        .map(|m| match m {
+            ConRowMap::Eq { .. } => 0,
+            ConRowMap::Ineq { upper, lower } => upper.is_some() as usize + lower.is_some() as usize,
+        })
+        .sum()
+}
+
+/// SOCP analogue of [`count_constraint_ineq_rows`]: only the linear
+/// inequality rows land in the nonnegative block *before* the variable
+/// bounds (equalities → `A`; quadratics → cones appended afterwards).
+pub fn count_socp_constraint_ineq_rows(con_map: &[ConSocpMap]) -> usize {
+    con_map
+        .iter()
+        .map(|m| match m {
+            ConSocpMap::Ineq { upper, lower } => {
+                upper.is_some() as usize + lower.is_some() as usize
+            }
+            ConSocpMap::Eq { .. } | ConSocpMap::Quad { .. } => 0,
+        })
+        .sum()
+}
+
+/// Recover the per-variable **bound multipliers** from the inequality
+/// multiplier vector `z`. Both extractors fold each finite variable bound
+/// into a nonnegative `G` row (`x_i ≤ x_u` and/or `−x_i ≤ −x_l`), appended
+/// right after the `n_con_ineq_rows` constraint-derived rows, in variable
+/// order with the upper row before the lower row. The `G`-row multiplier of
+/// `x_i ≤ x_u` is the (non-negative) upper-bound multiplier `z_ub[i]`; that
+/// of `−x_i ≤ −x_l` is the lower-bound multiplier `z_lb[i]`. Slots without a
+/// finite bound stay `0.0`.
+///
+/// The returned `z_lb` / `z_ub` are the raw non-negative multipliers of the
+/// *internal minimize* problem (a maximize objective was negated during
+/// extraction); the caller applies the maximize `sign` and the Ipopt
+/// `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u` output convention.
+pub fn recover_bound_mults(
+    prob: &NlProblem,
+    n_con_ineq_rows: usize,
+    z: &[f64],
+) -> (Vec<f64>, Vec<f64>) {
+    let n = prob.n;
+    let mut z_lb = vec![0.0; n];
+    let mut z_ub = vec![0.0; n];
+    let mut row = n_con_ineq_rows;
+    for i in 0..n {
+        if is_finite_bound(prob.x_u[i]) {
+            if let Some(&zv) = z.get(row) {
+                z_ub[i] = zv;
+            }
+            row += 1;
+        }
+        if is_finite_bound(prob.x_l[i]) {
+            if let Some(&zv) = z.get(row) {
+                z_lb[i] = zv;
+            }
+            row += 1;
+        }
+    }
+    (z_lb, z_ub)
+}
+
 // ===========================================================================
 // QCQP → SOCP extraction
 // ===========================================================================

--- a/crates/pounce-cli/tests/fixtures/bound_active_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/bound_active_qp.nl
@@ -1,0 +1,34 @@
+g3 1 1 0	# problem unknown
+ 2 0 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 0 2 	# nonzeros in Jacobian, obj. gradient
+ 3 1	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+O0 0	#obj
+o0	#+
+o5	#^
+o0	#+
+v0	#x
+n-3
+n2
+o5	#^
+o0	#+
+v1	#y
+n2
+n2
+x2	# initial guess
+0 0.5	#x
+1 0.0	#y
+r	#0 ranges (rhs's)
+b	#2 bounds (on variables)
+0 0 1	#x
+0 -1 1	#y
+k1	#intermediate Jacobian column lengths
+0
+G0 2	#obj
+0 0
+1 0

--- a/crates/pounce-cli/tests/issue_296_bound_multiplier_suffixes.rs
+++ b/crates/pounce-cli/tests/issue_296_bound_multiplier_suffixes.rs
@@ -1,0 +1,180 @@
+//! Bound-multiplier (`ipopt_zL_out` / `ipopt_zU_out`) `.sol` suffix guard
+//! for issue #296.
+//!
+//! ## Why this test exists
+//!
+//! pounce advertises drop-in Ipopt compatibility, and Ipopt writes the
+//! reduced costs / bound sensitivities into the AMPL `.sol` as the
+//! `ipopt_zL_out` / `ipopt_zU_out` variable-suffix blocks (Pyomo surfaces
+//! them as `model.ipopt_zL_out[var]`). pounce used to write NO suffix blocks
+//! at all, so a user migrating from Ipopt read `None` back with no error
+//! (#296). This test pins the presence, the sparse layout, AND — most
+//! importantly — the SIGN of those blocks against an analytic reference, on
+//! BOTH `.sol`-producing solve paths (the NLP interior-point path and the
+//! convex QP path), so a future regression fails loudly.
+//!
+//! ## Analytic reference (hand-computable)
+//!
+//! `bound_active_qp.nl`: `min (x−3)² + (y+2)²  s.t.  0 ≤ x ≤ 1, −1 ≤ y ≤ 1`.
+//! The unconstrained minimum is `(3, −2)`, so both bounds bind:
+//!   * `x* = 1` (upper bound active). `∂f/∂x = 2(x−3) = −4` at `x=1`.
+//!   * `y* = −1` (lower bound active). `∂f/∂y = 2(y+2) = +2` at `y=−1`.
+//!
+//! Ipopt's `.sol` convention (verified numerically against Ipopt 3.14 while
+//! building #296): both suffix values equal the objective-gradient component
+//! at the bound, i.e.
+//!   * `ipopt_zL_out = +z_l` (≥ 0 at an active lower bound) → `zL_out[y] = +2`,
+//!   * `ipopt_zU_out = −z_u` (≤ 0 at an active upper bound) → `zU_out[x] = −4`.
+//! The inactive side of each variable is ≈ 0 and is sparse-trimmed away.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// One parsed `.sol` suffix block: its name and the sparse `(index, value)`
+/// entries (real-valued suffixes only).
+struct SolSuffixBlock {
+    name: String,
+    entries: Vec<(usize, f64)>,
+}
+
+/// Extract every real-valued variable-suffix block from an AMPL `.sol`.
+///
+/// A suffix block is the five-integer header line
+/// `suffix <kind> <nvalues> <namelen> 0 0`, the suffix name on the next
+/// line, then `<nvalues>` `<index> <value>` pairs. We only need the name +
+/// entries here; `kind`/`namelen` are not asserted.
+fn parse_sol_suffixes(text: &str) -> Vec<SolSuffixBlock> {
+    let mut blocks = Vec::new();
+    let mut lines = text.lines().peekable();
+    while let Some(line) = lines.next() {
+        let mut it = line.split_whitespace();
+        if it.next() != Some("suffix") {
+            continue;
+        }
+        // kind, nvalues, namelen, tablen, tabline
+        let _kind: u32 = it.next().unwrap().parse().unwrap();
+        let nvalues: usize = it.next().unwrap().parse().unwrap();
+        let name = lines.next().expect("suffix name line").trim().to_string();
+        let mut entries = Vec::with_capacity(nvalues);
+        for _ in 0..nvalues {
+            let e = lines.next().expect("suffix entry line");
+            let mut p = e.split_whitespace();
+            let idx: usize = p.next().unwrap().parse().unwrap();
+            let val: f64 = p.next().unwrap().parse().unwrap();
+            entries.push((idx, val));
+        }
+        blocks.push(SolSuffixBlock { name, entries });
+    }
+    blocks
+}
+
+/// Solve `bound_active_qp.nl` via the CLI with the given `solver_selection`,
+/// returning the parsed `.sol` suffix blocks.
+fn solve_bound_active(selection: &str, tag: &str) -> Vec<SolSuffixBlock> {
+    let dir = std::env::temp_dir().join(format!("pounce_i296_{}_{tag}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("mkdir");
+    let nl = dir.join("m.nl");
+    std::fs::copy(fixture("bound_active_qp.nl"), &nl).expect("copy fixture");
+    let sol = dir.join("m.sol");
+
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg(format!("solver_selection={selection}"))
+        .arg("--sol-output")
+        .arg(&sol)
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "solve should succeed ({selection}); stderr:\n{}",
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let sol_text = std::fs::read_to_string(&sol).expect("read .sol");
+    parse_sol_suffixes(&sol_text)
+}
+
+/// Assert the two bound-multiplier blocks are present with the analytic
+/// values: `ipopt_zU_out[x=0] = −4` and `ipopt_zL_out[y=1] = +2`.
+fn assert_bound_multipliers(blocks: &[SolSuffixBlock], path: &str) {
+    let zl = blocks
+        .iter()
+        .find(|b| b.name == "ipopt_zL_out")
+        .unwrap_or_else(|| panic!("{path}: .sol must contain an ipopt_zL_out block"));
+    let zu = blocks
+        .iter()
+        .find(|b| b.name == "ipopt_zU_out")
+        .unwrap_or_else(|| panic!("{path}: .sol must contain an ipopt_zU_out block"));
+
+    // Upper bound active on x (variable index 0): zU_out = −4 (NOT +4).
+    let (_, zu_x) = zu
+        .entries
+        .iter()
+        .find(|(i, _)| *i == 0)
+        .copied()
+        .unwrap_or_else(|| panic!("{path}: ipopt_zU_out must carry an entry for x (index 0)"));
+    assert!(
+        (zu_x - (-4.0)).abs() < 1e-4,
+        "{path}: ipopt_zU_out[x] must be −4 (Ipopt convention: −z_u at an \
+         active upper bound); got {zu_x}",
+    );
+
+    // Lower bound active on y (variable index 1): zL_out = +2.
+    let (_, zl_y) = zl
+        .entries
+        .iter()
+        .find(|(i, _)| *i == 1)
+        .copied()
+        .unwrap_or_else(|| panic!("{path}: ipopt_zL_out must carry an entry for y (index 1)"));
+    assert!(
+        (zl_y - 2.0).abs() < 1e-4,
+        "{path}: ipopt_zL_out[y] must be +2 (Ipopt convention: +z_l at an \
+         active lower bound); got {zl_y}",
+    );
+
+    // The inactive sides are ≈ 0 and sparse-trimmed: x has no active lower
+    // bound and y no active upper bound, so those slots must be absent (or
+    // negligible if present).
+    if let Some((_, v)) = zl.entries.iter().find(|(i, _)| *i == 0) {
+        assert!(
+            v.abs() < 1e-4,
+            "{path}: ipopt_zL_out[x] should be ≈0; got {v}"
+        );
+    }
+    if let Some((_, v)) = zu.entries.iter().find(|(i, _)| *i == 1) {
+        assert!(
+            v.abs() < 1e-4,
+            "{path}: ipopt_zU_out[y] should be ≈0; got {v}"
+        );
+    }
+}
+
+/// The NLP interior-point path (`solver_selection=nlp`) must write the
+/// bound-multiplier suffixes with the Ipopt sign convention.
+#[test]
+fn nlp_path_writes_bound_multiplier_suffixes() {
+    let blocks = solve_bound_active("nlp", "nlp");
+    assert_bound_multipliers(&blocks, "NLP path");
+}
+
+/// The convex QP path (`solver_selection=qp-ipm`) must write the same
+/// bound-multiplier suffixes — the multipliers are recovered from the folded
+/// variable-bound `G` rows — so parity is consistent across solve paths.
+#[test]
+fn qp_path_writes_bound_multiplier_suffixes() {
+    let blocks = solve_bound_active("qp-ipm", "qp");
+    assert_bound_multipliers(&blocks, "QP path");
+}

--- a/pyomo-pounce/tests/test_pounce.py
+++ b/pyomo-pounce/tests/test_pounce.py
@@ -15,6 +15,7 @@ from pyomo.environ import (
     NonNegativeReals,
     Objective,
     SolverFactory,
+    Suffix,
     Var,
     value,
 )
@@ -112,6 +113,40 @@ def test_constrained(solver):
 
     assert value(m.x) == pytest.approx(1.5, abs=1e-5)
     assert value(m.y) == pytest.approx(2.5, abs=1e-5)
+
+
+def test_bound_multipliers_populate_ipopt_zL_zU(solver):
+    """`model.ipopt_zL_out` / `ipopt_zU_out` are populated with the reduced
+    costs, matching Ipopt's convention (issue #296).
+
+    min (x-3)^2 + (y+2)^2  s.t.  0<=x<=1, -1<=y<=1  ->  x*=1, y*=-1.
+    The unconstrained minimum (3, -2) is outside the box, so both bounds bind:
+      * x=1 upper-active:  d f/d x = 2(x-3) = -4  =>  ipopt_zU_out[x] = -4
+      * y=-1 lower-active:  d f/d y = 2(y+2) = +2  =>  ipopt_zL_out[y] = +2
+    Ipopt writes zL_out = +z_l (>= 0) and zU_out = -z_u (<= 0); before #296
+    pounce wrote no suffix blocks at all and these came back as ``None``.
+    """
+    m = ConcreteModel()
+    m.x = Var(bounds=(0, 1), initialize=0.5)
+    m.y = Var(bounds=(-1, 1), initialize=0.0)
+    m.obj = Objective(expr=(m.x - 3) ** 2 + (m.y + 2) ** 2)
+    m.ipopt_zL_out = Suffix(direction=Suffix.IMPORT)
+    m.ipopt_zU_out = Suffix(direction=Suffix.IMPORT)
+
+    solver.solve(m)
+
+    assert value(m.x) == pytest.approx(1.0, abs=1e-5)
+    assert value(m.y) == pytest.approx(-1.0, abs=1e-5)
+
+    # The blocks must actually be populated (the #296 gap was silent Nones).
+    zU_x = m.ipopt_zU_out.get(m.x)
+    zL_y = m.ipopt_zL_out.get(m.y)
+    assert zU_x is not None, "ipopt_zU_out[x] must be populated"
+    assert zL_y is not None, "ipopt_zL_out[y] must be populated"
+
+    # Analytic reduced costs, with Ipopt's sign convention.
+    assert zU_x == pytest.approx(-4.0, abs=1e-4)
+    assert zL_y == pytest.approx(2.0, abs=1e-4)
 
 
 def test_options_forwarded(solver):


### PR DESCRIPTION
Fixes #296.

## What was missing

pounce's `.sol` writer emitted the constraint duals (correctly signed since #287) but **no bound multipliers**. Ipopt writes `ipopt_zL_out` / `ipopt_zU_out` variable-suffix blocks — the reduced costs / bound sensitivities — which Pyomo surfaces as `model.ipopt_zL_out[var]` / `model.ipopt_zU_out[var]` and AMPL as variable `.rc`. A user migrating from Ipopt (pounce advertises drop-in Ipopt compatibility) who read `model.ipopt_zL_out` got `None` back with no error — a silent parity gap surfaced in the #271/#272 dual audit. The underlying multipliers already existed internally (`mult_x_L`/`mult_x_U`, confirmed correct against Ipopt in the #271 audit); they were simply never written.

## What this adds

`ipopt_zL_out` / `ipopt_zU_out` variable-suffix blocks in the `.sol`, wired through from the solver's bound multipliers to **all three `.sol`-producing paths** — NLP, convex QP, convex SOCP.

- **NLP path** — lifts the converged compressed bound multipliers to full-x order via `OrigIpoptNlp::finalize_solution_z_l`/`_z_u` (fixed-var + scaling maps unwound, `obj_scale_factor` divided out), captured in the `on_converged` callback.
- **Convex QP / SOCP paths** — the extractors fold each finite variable bound into a nonnegative `G` row, so `sol.z_lb`/`z_ub` stay empty; a new `qp_extract::recover_bound_mults` reads the multipliers back out of the inequality-multiplier vector `sol.z` at the appended bound rows (`count_constraint_ineq_rows` / `count_socp_constraint_ineq_rows` locate the offset) and the maximize `sign` restores the user objective sense.

## How the sign/values were verified against Ipopt

Solved bound-active models with **both** pounce and Ipopt 3.14 via the CLI on the same `.nl`, then dumped the `.sol` suffix values. Ipopt's convention (both values equal the objective-gradient component at the bound): `ipopt_zL_out = +z_l` (≥ 0 at an active lower bound), `ipopt_zU_out = −z_u` (≤ 0 at an active upper bound) — i.e. the lower block is written as-is and the **upper block is negated**.

`min (x−3)² + (y+2)²  s.t.  0 ≤ x ≤ 1, −1 ≤ y ≤ 1` → `x*=1` (upper active), `y*=−1` (lower active). Analytic: `∂f/∂x = −4`, `∂f/∂y = +2`.

| suffix | var | analytic | Ipopt 3.14 | pounce NLP | pounce QP |
|--------|-----|---------:|-----------:|-----------:|----------:|
| `ipopt_zU_out` | x | −4 | −3.99999998 | −4.00000000 | −4.00000000 |
| `ipopt_zL_out` | y | +2 | +1.99999998 | +2.00000000 | +2.00000000 |

A quartic (NLP-routed) `min (x−3)⁴ + (y+2)⁴` over the same box gave `ipopt_zU_out[x] = −31.9999995` and `ipopt_zL_out[y] = +3.9999999`, matching Ipopt digit-for-digit.

## Pyomo is now populated

Pyomo's ASL `.sol` reader maps the suffix blocks straight onto the model suffixes, so after `SolverFactory('pounce').solve(model)` with `model.ipopt_zL_out = Suffix(direction=IMPORT)` (and `zU`), the reduced costs come back populated and match Ipopt / the analytic values. This matches Ipopt **exactly**, including that both leave the derived `rc` suffix `None` (AMPL, not the ASL reader, derives `.rc`) — verified by running the same model through Ipopt via Pyomo. No `pyomo-pounce` code changes were needed.

## Validation

- New Rust guard `crates/pounce-cli/tests/issue_296_bound_multiplier_suffixes.rs` pins the presence + sparse layout + **sign** of both blocks against the analytic reduced costs, on both the NLP and QP paths.
- New pyomo test in `pyomo-pounce/tests/test_pounce.py` asserts `model.ipopt_zL_out`/`ipopt_zU_out` populate and match the analytic values.
- Regression: `cargo test -p pounce-cli --release` (all 34 test binaries green, including the #294 dual-sign regression and `.sol` round-trip tests), `python -m pytest python/tests/test_gams_link.py -q` (33 passed), and the pyomo-pounce suite (`python -m pytest pyomo-pounce/tests/ -q`, 102 passed). `cargo fmt --all` clean, no new clippy warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
