### PR TITLE
Correct CHO IPOPT reference (live MA57) and explain the P4 QP tolerance gap

### DIFF
--- a/validation/SOLVER_EQUIVALENCE.md
+++ b/validation/SOLVER_EQUIVALENCE.md
@@ -19,12 +19,13 @@ resolve to.)
 
 ## Environment
 
-| item | value |
-|------|-------|
-| POUNCE version | `0.9.0` |
+| item                               | value                                                |
+|------------------------------------|------------------------------------------------------|
+| POUNCE version                     | `0.9.0`                                              |
 | POUNCE binary (via `pyomo_pounce`) | `python/pounce/bin/pounce` → `target/release/pounce` |
-| IPOPT | `Ipopt 3.14.19 (Darwin arm64), ASL(20241202)` |
-| date | 2026-07-22 |
+| IPOPT (P2–P5, default MUMPS)       | `Ipopt 3.14.19 (Darwin arm64), ASL(20241202)`        |
+| IPOPT-MA57 (P1 live reference)     | `Ipopt 3.14.20`, HSL MA57 (`ipopt-ma57`)             |
+| date                               | 2026-07-22                                           |
 
 Reproduce with `python validation/run_all.py` (see *How to reproduce*).
 
@@ -39,7 +40,7 @@ Reproduce with `python validation/run_all.py` (see *How to reproduce*).
 
 | # | Problem | What it uniquely proves | Tightest independent agreement achieved |
 |---|---------|--------------------------|------------------------------------------|
-| **P1** | CHO parameter estimation (21,732 vars) | Sensitivity/covariance is right, not just the optimum | Covariance **method** exact vs closed form (linear regression) to **1.0e-15**, and vs PyNumero reduced-Hessian to **5e-16**; nonlinear fit vs independent PyNumero to **7e-8**. Point estimate matches the IPOPT/MA57 benchmark to **1.5e-14** (rel). |
+| **P1** | CHO parameter estimation (21,732 vars) | Sensitivity/covariance is right, not just the optimum | Covariance **method** exact vs closed form (linear regression) to **1.0e-15**, and vs PyNumero reduced-Hessian to **5e-16**; nonlinear fit vs independent PyNumero to **7e-8**. Point estimate matches a **live HSL-MA57 IPOPT** solve to **1.5e-14** (rel) — where default MUMPS IPOPT fails on CHO but POUNCE's built-in FERAL solver succeeds. |
 | **P2** | Hock–Schittkowski 71 | Duals vs a *published*, solver-independent source (sign fix) | Both constraint multipliers agree pounce/IPOPT/analytic-KKT **in sign**; pounce vs IPOPT dual `c1` to **6.0e-10**, pounce vs exact KKT to **1.2e-9** |
 | **P3** | corkscrw, clnlbeam (hard control) | Restoration phase lands on IPOPT's optimum | Objective rel err **2.4e-13** (corkscrw) / **7.7e-12** (clnlbeam); both "Optimal Solution Found" |
 | **P4** | Strictly convex QP | Convex-path duals vs closed form + 2 solvers, sign incl. | 4-way multiplier **sign** agreement; pounce multipliers vs closed-form KKT to **2.6e-11**, KKT stationarity **3e-15** |
@@ -49,7 +50,7 @@ Reproduce with `python validation/run_all.py` (see *How to reproduce*).
 
 ## P1 — CHO bioprocess parameter estimation (the headline: sensitivity/covariance)
 
-**Why this problem.** This is the case a skeptic actually cares about: a large
+**Why this problem.** This is a large
 (~21.7k-variable) nonlinear parameter-estimation DAE where a solver can hit the
 optimum yet report a *subtly wrong* covariance. It is a monolithic Pyomo model
 — 10 CHO cell-culture batches, orthogonal collocation (60 finite elements × 3
@@ -63,23 +64,26 @@ data points, 12 fitted parameters
 
 ### Point estimate
 
-| quantity | POUNCE | IPOPT (MA57 benchmark) |
-|----------|--------|-------------------------|
-| status | optimal | Solve_Succeeded |
-| objective (SSE) | `67672.86755753502` | `67672.86755753602` |
-| iterations | 31 | 33 |
+| quantity        | POUNCE              | IPOPT-MA57 (live)   |
+|-----------------|---------------------|---------------------|
+| status          | optimal             | optimal             |
+| objective (SSE) | `67672.86755753502` | `67672.86755753601` |
+| linear solver   | FERAL (built-in)    | HSL MA57            |
 
-Objective agreement POUNCE vs the committed MA57 benchmark:
-**abs 1.0e-9, rel 1.5e-14.**
+Objective agreement POUNCE vs a **live** MA57-linked IPOPT solve of the same
+model: **rel 1.5e-14**. The committed `benchmarks/cho/ipopt_ma57.json`
+(`67672.86755753602`, 33 iters) is a third, independent corroboration.
 
-> **Caveat (IPOPT linear solver).** The IPOPT on this machine has **no MA57/HSL
-> library** (`linear_solver=ma57` → *"Library loading failure"*), and with its
-> only available linear solver, MUMPS, IPOPT **fails** on CHO (*"Error in step
-> computation"* / restoration failure) at full size *and* at reduced sizes
-> (NFE=8 still exceeds max-iter). The IPOPT column above therefore uses the
-> **committed** `benchmarks/cho/ipopt_ma57.json`, which ran IPOPT+MA57 on this
-> exact model and reached the same optimum POUNCE finds. POUNCE solves the full
-> model here with no special linear-solver dependency.
+> **On the IPOPT linear solver — and a point in POUNCE's favor.** CHO is a
+> large, badly-conditioned collocation NLP. IPOPT's **default MUMPS** linear
+> solver *fails* on it — `internalSolverError: Error in step computation` /
+> restoration failure — so the live reference above uses an **HSL-MA57-linked
+> IPOPT** (`ipopt-ma57`, Ipopt 3.14.20), which solves it and agrees with POUNCE
+> to 1.5e-14. Notably, **POUNCE solves the full CHO model with its built-in
+> FERAL linear solver — no HSL / MA57 dependency — where default IPOPT fails
+> outright.** (The script discovers `ipopt-ma57` on `PATH`; where it is absent
+> it falls back to the committed MA57 benchmark, and records the MUMPS failure
+> explicitly.)
 
 Parameter recovery (fitted vs the true values used to generate the data) is
 limited by **identifiability**, not by the solver: three parameters
@@ -101,10 +105,10 @@ POUNCE's held-factorization sensitivity path.
 either route on CHO, both are pinned to problems whose covariance is known in
 closed form:
 
-| control | POUNCE vs known | PyNumero ref vs known | POUNCE vs PyNumero |
-|---------|------------------|------------------------|---------------------|
-| linear regression, `cov = σ²(XᵀX)⁻¹` | **1.0e-15** | **1.3e-15** | **5.0e-16** |
-| nonlinear `A·exp(−k·t)` fit | vs scipy (Gauss–Newton) 0.9%¹ | — | **7.0e-8** |
+| control                              | POUNCE vs known               | PyNumero ref vs known | POUNCE vs PyNumero |
+|--------------------------------------|-------------------------------|-----------------------|--------------------|
+| linear regression, `cov = σ²(XᵀX)⁻¹` | **1.0e-15**                   | **1.3e-15**           | **5.0e-16**        |
+| nonlinear `A·exp(−k·t)` fit          | vs scipy (Gauss–Newton) 0.9%¹ | —                     | **7.0e-8**         |
 
 ¹ The 0.9% is the *expected* difference between POUNCE's observed-information
 (full Lagrangian Hessian) covariance and scipy's expected-information
@@ -119,20 +123,20 @@ independent reduced-Hessian oracle on a nonlinear fit (7e-8).
 **Step 2 — CHO standard errors and correlation.** POUNCE's covariance at the CHO
 optimum (σ² = 37.85):
 
-| parameter | std error (POUNCE) | note |
-|-----------|--------------------|------|
-| K_glc  | 6.58e-02 | |
-| K_gln  | 1.05e-03 | |
-| KI_amm | 8.15e-02 | |
-| KI_lac | 1.78e+00 | |
-| KD_amm | 0 | on bound — unidentifiable, projected out |
-| KD_lac | 0 | on bound — unidentifiable, projected out |
-| m_glc  | 8.48e-06 | |
-| a1     | 8.20e-07 | |
-| a2     | 4.78e-01 | |
-| d_gln  | 1.07e-04 | |
-| r_amm  | 0 | on bound — unidentifiable, projected out |
-| Q_B1   | 1.94e-05 | |
+| parameter | std error (POUNCE) | note                                     |
+|-----------|--------------------|------------------------------------------|
+| K_glc     | 6.58e-02           |                                          |
+| K_gln     | 1.05e-03           |                                          |
+| KI_amm    | 8.15e-02           |                                          |
+| KI_lac    | 1.78e+00           |                                          |
+| KD_amm    | 0                  | on bound — unidentifiable, projected out |
+| KD_lac    | 0                  | on bound — unidentifiable, projected out |
+| m_glc     | 8.48e-06           |                                          |
+| a1        | 8.20e-07           |                                          |
+| a2        | 4.78e-01           |                                          |
+| d_gln     | 1.07e-04           |                                          |
+| r_amm     | 0                  | on bound — unidentifiable, projected out |
+| Q_B1      | 1.94e-05           |                                          |
 
 POUNCE correctly detects the three bound-active parameters and projects them
 out (zero variance, conditional on the active bound), the same behaviour a
@@ -182,11 +186,11 @@ s.t. x1·x2·x3·x4 >= 25          (c1)
      1 <= xi <= 5,  x0=(1,5,5,1)
 ```
 
-| quantity | POUNCE | IPOPT (tol 1e-9) | exact KKT oracle |
-|----------|--------|-------------------|-------------------|
-| objective | 17.014017145 | 17.014017140 | 17.0140172891563 |
-| dual `c1` (ineq) | **+0.5522936588816062** | **+0.5522936594811181** | **+0.5522936601207269** |
-| dual `c2` (eq) | **−0.16146856313488797** | **−0.1614685641449677** | **−0.1614685667705059** |
+| quantity         | POUNCE                   | IPOPT (tol 1e-9)        | exact KKT oracle        |
+|------------------|--------------------------|-------------------------|-------------------------|
+| objective        | 17.014017145             | 17.014017140            | 17.0140172891563        |
+| dual `c1` (ineq) | **+0.5522936588816062**  | **+0.5522936594811181** | **+0.5522936601207269** |
+| dual `c2` (eq)   | **−0.16146856313488797** | **−0.1614685641449677** | **−0.1614685667705059** |
 
 - **Sign agreement is exact** across POUNCE, IPOPT, *and* the analytic KKT
   oracle for both multipliers — the live evidence the dual-sign fix is correct.
@@ -211,17 +215,17 @@ point is that POUNCE's restoration and endgame land on the *same* optimum IPOPT
 does on genuinely hard problems — not just easy static NLPs. Both binaries run
 on the **identical** `.nl` fixture.
 
-| | corkscrw | clnlbeam |
-|---|----------|----------|
-| n / m | 44,997 / 35,000 | 59,999 / 40,000 |
-| POUNCE iters (restoration) | 224 (**30**) | 483 (0) |
-| IPOPT iters | 382 | 492 |
-| both "Optimal Solution Found" | ✅ | ✅ |
-| objective (POUNCE) | 98.09596925639791 | 344.8761314083454 |
-| objective (IPOPT) | 98.09596925642172 | 344.87613141098416 |
-| **objective rel err** | **2.4e-13** | **7.7e-12** |
-| primal max\|Δ\| (L2 rel) | 1.6e-4 (1.1e-4) | 1.8e-5 (4.7e-6) |
-| dual max\|Δ\| | 4.6e-8 | 0.77 |
+|                               | corkscrw          | clnlbeam           |
+|-------------------------------|-------------------|--------------------|
+| n / m                         | 44,997 / 35,000   | 59,999 / 40,000    |
+| POUNCE iters (restoration)    | 224 (**30**)      | 483 (0)            |
+| IPOPT iters                   | 382               | 492                |
+| both "Optimal Solution Found" | ✅                | ✅                 |
+| objective (POUNCE)            | 98.09596925639791 | 344.8761314083454  |
+| objective (IPOPT)             | 98.09596925642172 | 344.87613141098416 |
+| **objective rel err**         | **2.4e-13**       | **7.7e-12**        |
+| primal max|Δ| (L2 rel)        | 1.6e-4 (1.1e-4)   | 1.8e-5 (4.7e-6)    |
+| dual max|Δ|                   | 4.6e-8            | 0.77               |
 
 POUNCE takes 30 restoration iterations on corkscrw and still converges to
 IPOPT's objective to **2.4e-13**.
@@ -254,18 +258,38 @@ min 0.5·xᵀP x   s.t.  1ᵀx = 1,  μᵀx = 0.12
 
 Closed-form KKT solution: `[[P, Aᵀ],[A, 0]][x; y] = [−c; b]`.
 
-| route | max\|Δx\| vs closed form | max\|Δy\| vs closed form (multipliers) | KKT stationarity `‖Px+c+Aᵀy‖∞` |
-|-------|--------------------------|-----------------------------------------|-------------------------------|
-| closed form | — | — | 1.2e-17 |
-| **POUNCE** `solve_qp` | **1.4e-10** | **2.6e-11** | **3.0e-15** |
-| cvxpy (CLARABEL) | 7.9e-14 | 3.3e-15 | 2.7e-15 |
-| IPOPT (Pyomo) | 3.1e-16 | 6.2e-17 | 3.5e-18 |
+| route                 | max|Δx| vs closed form | max|Δy| vs closed form (multipliers) | KKT stationarity `‖Px+c+Aᵀy‖∞` |
+|-----------------------|------------------------|--------------------------------------|--------------------------------|
+| closed form           | —                      | —                                    | 1.2e-17                        |
+| **POUNCE** `solve_qp` | **1.4e-10**            | **2.6e-11**                          | **3.0e-15**                    |
+| cvxpy (CLARABEL)      | 7.9e-14                | 3.3e-15                              | 2.7e-15                        |
+| IPOPT (Pyomo)         | 3.1e-16                | 6.2e-17                              | 3.5e-18                        |
 
 Multiplier **signs agree 4-way** (closed form, POUNCE, cvxpy, IPOPT): budget
 multiplier negative, return multiplier positive. POUNCE's returned duals satisfy
 the KKT stationarity residual to **3e-15**, and match the closed-form multiplier
 values to **2.6e-11** — on the convex path the duals are pinned to an analytic
 number, sign included, by three independent routes.
+
+> **Why POUNCE's `|Δx|`/`|Δy|` look looser than CLARABEL's and IPOPT's — it is
+> the default stopping tolerance, not an accuracy ceiling.** `solve_qp` defaults
+> to `tol=1e-8`. The distance to the exact vertex, `|Δx|`, is set by the
+> **primal** residual `‖Ax−b‖`, which an interior-point method drives down to
+> about `tol` — so at the default it sits near `5.7e-10`, giving `|Δx| ≈ 1.4e-10`.
+> The **dual** stationarity is already machine-precision (`3e-15`) at that same
+> default, which is the residual that actually certifies the duals are correct.
+> Ask POUNCE for more and it delivers: tightening `tol` walks `|Δx|` down
+> monotonically to **9.7e-16 at `tol=1e-14`** — matching IPOPT (`3.1e-16`) and
+> beating CLARABEL (`7.9e-14`). IPOPT/CLARABEL look tighter "at default" only
+> because this QP is trivial for them (`cond(KKT) = 73`) and their defaults
+> polish further.
+>
+> | `tol` | primal `‖Ax−b‖` | dual `‖Px+c+Aᵀy‖` | `max|Δx|` vs exact |
+> |-------|------------------|--------------------|---------------------|
+> | `1e-8` (default) | 5.7e-10 | 3.0e-15 | 1.4e-10 |
+> | `1e-10` | 2.8e-11 | 2.9e-15 | 6.8e-12 |
+> | `1e-12` | 7.1e-14 | 3.5e-16 | 1.7e-14 |
+> | `1e-14` | 3.4e-15 | 3.3e-17 | **9.7e-16** |
 
 ---
 
@@ -287,13 +311,13 @@ at `p=2`: `x*=(1,1)`, multiplier `λ=1/2`, `dObj/dp=−1/2`.
 **(a) `dx/dp` matches central FD to O(δ²).** The finite-difference error in
 `dx1/dp` shrinks quadratically as δ halves:
 
-| δ | FD `dx1/dp` | error vs analytic (0.25) |
-|---|-------------|---------------------------|
-| 1.0e-1 | 0.2500782 | 7.82e-5 |
-| 5.0e-2 | 0.2500195 | 1.95e-5 |
-| 2.5e-2 | 0.2500049 | 4.88e-6 |
-| 1.25e-2 | 0.2500012 | 1.22e-6 |
-| 6.25e-3 | 0.2500003 | 3.05e-7 |
+| δ       | FD `dx1/dp` | error vs analytic (0.25) |
+|---------|-------------|--------------------------|
+| 1.0e-1  | 0.2500782   | 7.82e-5                  |
+| 5.0e-2  | 0.2500195   | 1.95e-5                  |
+| 2.5e-2  | 0.2500049   | 4.88e-6                  |
+| 1.25e-2 | 0.2500012   | 1.22e-6                  |
+| 6.25e-3 | 0.2500003   | 3.05e-7                  |
 
 Error ratios per halving: **4.003, 4.001, 4.0002, 4.00005** — clean O(δ²)
 convergence toward POUNCE's sensitivity value, which itself equals the analytic

--- a/validation/p1_cho.py
+++ b/validation/p1_cho.py
@@ -6,9 +6,11 @@ orthogonal collocation, 12 shared kinetic parameters, deterministic seed).
 Two things are validated:
 
   1. POINT ESTIMATE. pounce solves the full model; its objective and 12
-     fitted parameters are checked against the committed IPOPT (MA57)
-     benchmark and against the true parameters used to generate the data.
-     (Live IPOPT is attempted too; see the caveat about MA57 below.)
+     fitted parameters are checked against a LIVE HSL-MA57-linked IPOPT on
+     the same model, and against the true parameters used to generate the
+     data. (Default MUMPS IPOPT fails on CHO, so the live reference uses an
+     `ipopt-ma57` executable; the committed MA57 benchmark is kept as a
+     secondary cross-check.)
 
   2. SENSITIVITY / COVARIANCE -- the part that matters most. A solver can
      nail the optimum and still compute a subtly-wrong covariance. We check
@@ -163,19 +165,63 @@ def main():
     theta_p = {nm: float(pyo.value(getattr(m, nm))) for nm in cho.THETA_NAMES}
     theta_true = {nm: float(getattr(p_true, nm)) for nm in cho.THETA_NAMES}
 
-    # committed IPOPT (MA57) benchmark for the same model
+    # committed IPOPT (MA57) benchmark for the same model, kept as a
+    # secondary cross-check alongside the live solve below.
     bench = json.loads((MAIN / "benchmarks/cho/ipopt_ma57.json").read_text())[0]
 
-    # live IPOPT attempt (this box's IPOPT lacks MA57; MUMPS fails on CHO)
+    # LIVE IPOPT reference. CHO is a large, badly-conditioned collocation NLP:
+    # IPOPT's *default* (MUMPS) linear solver fails on it (restoration /
+    # "Error in step computation"), so the honest live reference uses an
+    # HSL-MA57-linked IPOPT. We discover an `ipopt-ma57` executable on PATH;
+    # if absent, we fall back to the committed MA57 benchmark. We ALSO record
+    # that default MUMPS IPOPT fails, as an explicit contrast (pounce's own
+    # FERAL linear solver handles CHO with no HSL dependency).
+    def _find_ma57_ipopt():
+        import shutil
+        for name in ("ipopt-ma57", "ipopt_ma57"):
+            p = shutil.which(name)
+            if p:
+                return p
+        return None
+
     live_ipopt = {}
+    ma57_exe = _find_ma57_ipopt()
+    if ma57_exe is not None:
+        try:
+            mi = cho.build_full_model(batches, nfe=cho.NFE, ncp=cho.NCP)
+            ri = SolverFactory("ipopt", executable=ma57_exe).solve(
+                mi, load_solutions=True,
+                options={"linear_solver": "ma57", "tol": 1e-8})
+            obj_i = float(pyo.value(mi.obj))
+            iters_i = None
+            try:  # best-effort iteration count from the results object
+                iters_i = int(ri.solver.statistics.iterations)
+            except Exception:  # noqa: BLE001
+                pass
+            live_ipopt = {
+                "executable": ma57_exe,
+                "linear_solver": "ma57",
+                "termination": str(ri.solver.termination_condition),
+                "objective": obj_i,
+                "iterations": iters_i,
+                "obj_relerr_pounce_vs_live": rel_err(obj_p, obj_i),
+            }
+        except Exception as e:  # noqa: BLE001
+            live_ipopt = {"executable": ma57_exe, "error": str(e)[:200]}
+    else:
+        live_ipopt = {"note": "no ipopt-ma57 on PATH; see committed MA57 "
+                              "benchmark (benchmarks/cho/ipopt_ma57.json)"}
+
+    # Explicit contrast: default (MUMPS) IPOPT genuinely fails on CHO.
+    mumps_ipopt = {}
     try:
-        mi = cho.build_full_model(batches, nfe=cho.NFE, ncp=cho.NCP)
-        ri = SolverFactory("ipopt").solve(mi, load_solutions=False,
+        mm = cho.build_full_model(batches, nfe=cho.NFE, ncp=cho.NCP)
+        rm = SolverFactory("ipopt").solve(mm, load_solutions=False,
                                           options={"tol": 1e-8})
-        live_ipopt = {"termination": str(ri.solver.termination_condition),
-                      "message": str(ri.solver.message)}
+        mumps_ipopt = {"termination": str(rm.solver.termination_condition),
+                       "message": str(rm.solver.message)}
     except Exception as e:  # noqa: BLE001
-        live_ipopt = {"error": str(e)[:200]}
+        mumps_ipopt = {"error": str(e)[:200]}
 
     # (2) covariance via pounce
     ndata = count_ndata(cho, m, batches)
@@ -220,7 +266,8 @@ def main():
                 abs_err(obj_p, bench["objective"]),
             "obj_relerr_pounce_vs_benchmark":
                 rel_err(obj_p, bench["objective"]),
-            "live_ipopt": live_ipopt,
+            "live_ipopt_ma57": live_ipopt,
+            "default_mumps_ipopt": mumps_ipopt,
             "theta_pounce": theta_p,
             "theta_true": theta_true,
             "theta_max_relerr_vs_true": max(

--- a/validation/p4_qp.py
+++ b/validation/p4_qp.py
@@ -102,6 +102,25 @@ def solve_ipopt():
     return x, y, float(pyo.value(m.obj)), "ipopt"
 
 
+def _pounce_tol_sweep(xc):
+    """Solve the P4 QP at a range of tolerances, reporting primal residual,
+    dual stationarity, and distance-to-vertex — to show pounce reaches machine
+    precision when asked (the default tol is a stopping choice)."""
+    from pounce.qp import solve_qp
+    rows = []
+    for tol in (1e-8, 1e-10, 1e-12, 1e-14):
+        r = solve_qp(P=P, c=c, A=A, b=b, tol=tol)
+        x = np.asarray(r.x)
+        y = np.asarray(r.y)
+        rows.append({
+            "tol": tol,
+            "primal_Ax_minus_b_inf": float(np.max(np.abs(A @ x - b))),
+            "dual_stationarity_inf": float(np.max(np.abs(P @ x + c + A.T @ y))),
+            "x_maxabs_vs_closed_form": float(np.max(np.abs(x - xc))),
+        })
+    return rows
+
+
 def main():
     xc, yc = closed_form()
     xp, yp, op, sp = solve_pounce()
@@ -147,6 +166,12 @@ def main():
                 np.allclose(np.sign(yc), np.sign(yv)) and
                 np.allclose(np.sign(yc), np.sign(yi))),
         },
+        # pounce's distance-to-vertex is set by the primal residual, which the
+        # IPM drives to ~tol; the dual stationarity is already machine-precision
+        # at the default tol. Tightening tol walks |dx| to machine precision,
+        # showing the default (1e-8) is a stopping choice, not an accuracy
+        # ceiling. Substantiates the tolerance note in the P4 doc section.
+        "pounce_tolerance_sweep": _pounce_tol_sweep(xc),
     }
     import json
     print(json.dumps(payload, indent=2))

--- a/validation/results.json
+++ b/validation/results.json
@@ -3,7 +3,7 @@
     "pounce_version": "0.9.0",
     "pounce_executable": "/Users/jkitchin/projects/pounce/python/pounce/bin/pounce",
     "ipopt_version": "Ipopt 3.14.19 (Darwin arm64), ASL(20241202)",
-    "date": "2026-07-22"
+    "date": "2026-07-23"
   },
   "problems": {
     "p1_cho": {
@@ -23,7 +23,15 @@
         "benchmark_ipopt_ma57_iters": 33,
         "obj_absdiff_pounce_vs_benchmark": 1.0040821507573128e-09,
         "obj_relerr_pounce_vs_benchmark": 1.4837292802815455e-14,
-        "live_ipopt": {
+        "live_ipopt_ma57": {
+          "executable": "/Users/jkitchin/.local/bin/ipopt-ma57",
+          "linear_solver": "ma57",
+          "termination": "optimal",
+          "objective": 67672.86755753601,
+          "iterations": null,
+          "obj_relerr_pounce_vs_live": 1.462225957378915e-14
+        },
+        "default_mumps_ipopt": {
           "termination": "internalSolverError",
           "message": "Ipopt 3.14.19\\x3a Error in step computation."
         },
@@ -509,7 +517,33 @@
           1.0
         ],
         "all_agree": true
-      }
+      },
+      "pounce_tolerance_sweep": [
+        {
+          "tol": 1e-08,
+          "primal_Ax_minus_b_inf": 5.65884450409726e-10,
+          "dual_stationarity_inf": 3.0097452308197603e-15,
+          "x_maxabs_vs_closed_form": 1.3640649720869646e-10
+        },
+        {
+          "tol": 1e-10,
+          "primal_Ax_minus_b_inf": 2.8289592890473614e-11,
+          "dual_stationarity_inf": 2.942091015256665e-15,
+          "x_maxabs_vs_closed_form": 6.815881192778761e-12
+        },
+        {
+          "tol": 1e-12,
+          "primal_Ax_minus_b_inf": 7.049916206369744e-14,
+          "dual_stationarity_inf": 3.5388358909926865e-16,
+          "x_maxabs_vs_closed_form": 1.6930901125533637e-14
+        },
+        {
+          "tol": 1e-14,
+          "primal_Ax_minus_b_inf": 3.4416913763379853e-15,
+          "dual_stationarity_inf": 3.2959746043559335e-17,
+          "x_maxabs_vs_closed_form": 9.71445146547012e-16
+        }
+      ]
     },
     "p5_parametric": {
       "problem": "parametric_NLP",


### PR DESCRIPTION
Two accuracy corrections to `validation/SOLVER_EQUIVALENCE.md`, both raised on review of the merged validation suite.

## 1. CHO IPOPT reference was wrong — there IS a live MA57 IPOPT

The doc claimed *"IPOPT on this machine has no MA57/HSL library"* and used the committed benchmark json as the reference. That's false: an `ipopt-ma57` executable (Ipopt 3.14.20 + HSL MA57) is on this machine.

The corrected — and stronger — story:

| | POUNCE | IPOPT-MA57 (live) | default MUMPS IPOPT |
|---|---|---|---|
| status | optimal | optimal | **internalSolverError** |
| objective | `67672.86755753502` | `67672.86755753601` | (fails) |
| linear solver | FERAL (built-in) | HSL MA57 | MUMPS |

- POUNCE agrees with a **live MA57-linked IPOPT** to **1.46e-14** relative.
- IPOPT's **default MUMPS** linear solver genuinely **fails** on CHO (`Error in step computation` / restoration) — confirming it's a hard, badly-conditioned NLP.
- **POUNCE solves the full CHO model with its built-in FERAL solver, no HSL dependency, where default IPOPT fails outright** — a genuine point in its favor.

`p1_cho.py` now discovers `ipopt-ma57` on PATH, runs the live solve as the primary reference, records the MUMPS failure explicitly, and keeps the committed MA57 benchmark as a third corroboration.

## 2. P4 QP: why POUNCE's `|Δx|` looks looser than CLARABEL/IPOPT

On the convex QP, POUNCE's distance-to-vertex (`1.4e-10`) looked worse than CLARABEL (`7.9e-14`) and IPOPT (`3.1e-16`) — which reads as lower accuracy. It isn't; it's `solve_qp`'s **default `tol=1e-8`**:

| `tol` | primal `‖Ax−b‖` | dual `‖Px+c+Aᵀy‖` | `max|Δx|` |
|---|---|---|---|
| `1e-8` (default) | 5.7e-10 | 3.0e-15 | 1.4e-10 |
| `1e-14` | 3.4e-15 | 3.3e-17 | **9.7e-16** |

The distance to the vertex is set by the **primal** residual (driven to ~`tol`), while the **dual** stationarity — the residual that certifies the duals — is already machine-precision at the default. Ask for more and POUNCE delivers `9.7e-16`, matching IPOPT and beating CLARABEL. `p4_qp.py` now emits the sweep and the doc explains it inline, so a skeptic's obvious question is preempted.

`results.json` regenerated via `run_all.py`; P2/P3/P5 unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
