### PR TITLE
Raise on the remaining ambiguous n=2 curve_fit bounds spellings (#260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `curve_fit` two-parameter bounds: the last silently-transposing spellings now raise (#260)
+
+- **`pounce.curve_fit` no longer silently transposes a 2-parameter box when the
+  bounds are written as a *list of two lists* (`[[l0, l1], [u0, u1]]`) or a
+  `2 x 2` ndarray.** #263/#265 fixed the outer-*tuple* spellings — the scipy
+  `(lower, upper)` tuple is read scipy's way and the ambiguous tuple-of-pairs
+  raises — but the same `n == 2` collision reached through a non-tuple container
+  slipped past the guard: it fell through to the per-parameter pair-list reading,
+  applied the transposed box, and returned `Solve_Succeeded` with a badly wrong
+  fit (e.g. the reported optimum sitting on the *misread* box while the requested
+  upper bound was violated, with no warning). This was the remaining half of
+  issue #260 (its first comment enumerated all four spellings).
+  - **All three fit surfaces are covered** — `curve_fit`, `curve_fit_minima`, and
+    `curve_fit_streaming` share `_normalize_bound_arg`, so the guard applies
+    uniformly.
+  - **The unambiguous spellings are unchanged.** scipy's tuple of lists/arrays
+    `([l0, l1], [u0, u1])` still follows scipy; pounce's per-parameter pair list
+    spelled with `(lo, hi)` **tuples**, `[(l0, u0), (l1, u1)]`, still fits its
+    box. Only the genuinely ambiguous 2×2 shapes (matching-container list-of-lists
+    or ndarray, and mixed tuple/list pairs) now raise with a message naming both
+    unambiguous spellings — consistent with the #265 decision that the ambiguous
+    `n == 2` shape must be an error rather than a silent guess.
+
 ### Added — bound-multiplier `.sol` suffixes for Ipopt-parity reduced costs (#296)
 
 - **The `.sol` writer now emits `ipopt_zL_out` / `ipopt_zU_out` variable-suffix

--- a/python/pounce/_curve_fit.py
+++ b/python/pounce/_curve_fit.py
@@ -972,15 +972,17 @@ def curve_fit(
     ``bounds=([l0, l1], [u0, u1])`` bounds param ``i`` to ``[l_i, u_i]``; a
     length-2 **tuple** is read this scipy way, and a bare ``None`` on either
     side means unbounded there. pounce also accepts a per-parameter pair
-    **list**, ``bounds=[(l0, u0), (l1, u1)]`` (as :func:`pounce.minimize` does),
-    which is never reinterpreted as the scipy 2-tuple; entries may be ``None``
-    for a one-sided bound. For a 2-parameter model the two spellings collide
-    when written as a tuple of ``(lo, hi)`` pairs — ``bounds=((0, 10), (0, 10))``
-    is both scipy's ``(lower, upper)`` and a pair list. That shape is genuinely
-    ambiguous (silently guessing it misfit issues #260 and #265, in opposite
-    directions), so it now **raises**; pass a list ``[(l0, u0), (l1, u1)]`` for
-    the pair-list reading or lists/arrays ``([l0, l1], [u0, u1])`` for the scipy
-    reading. NaN bounds are rejected.
+    **list** of ``(lo, hi)`` *tuples*, ``bounds=[(l0, u0), (l1, u1)]`` (as
+    :func:`pounce.minimize` does), which is never reinterpreted as the scipy
+    2-tuple; entries may be ``None`` for a one-sided bound. For a 2-parameter
+    model the two spellings collide whenever the box is written as *two
+    length-2 sequences* — ``bounds=((0, 10), (0, 10))``, ``[[0, 10], [0, 10]]``,
+    or a ``2 x 2`` ndarray are each both scipy's ``(lower, upper)`` and a pair
+    list. That shape is genuinely ambiguous (silently guessing it misfit issues
+    #260 and #265, in opposite directions), so it now **raises**; pass a list of
+    ``(lo, hi)`` tuples ``[(l0, u0), (l1, u1)]`` for the pair-list reading or a
+    tuple of lists/arrays ``([l0, l1], [u0, u1])`` for the scipy reading. NaN
+    bounds are rejected.
 
     A **zero-width** bound (``lo == hi``) is honored and fixes that parameter to
     the value: pounce supports it as the "hold a parameter constant" idiom
@@ -1519,6 +1521,41 @@ f_scale, jac, alpha, sensitivity, options
 # helpers
 # --------------------------------------------------------------------------
 
+def _is_ambiguous_two_by_two(bounds) -> bool:
+    """True if ``bounds`` is a non-tuple length-2 container whose two elements
+    are both length-2 sequences and *not* both ``(lo, hi)`` tuples.
+
+    At ``n == 2`` such a value — a list of two lists, or a ``2 x 2`` ndarray —
+    reads either as scipy's ``(lower, upper)`` (two length-2 rows) or as
+    pounce's per-parameter pair list (two ``(lo, hi)`` pairs); the two readings
+    transpose the box relative to each other. Only the pair list spelled with
+    ``(lo, hi)`` **tuples** is unambiguous (tuples spell pairs; plain
+    lists/arrays spell scipy's lower/upper rows), so a value that is not
+    all-tuples is the ambiguous one. Silently resolving it applied the wrong box
+    (issue #260's list-of-lists and ndarray spellings), so it now raises like
+    the length-2 *tuple* form does (that spelling is handled earlier, in the
+    scipy branch of :func:`_normalize_bound_arg`).
+    """
+    def _pair_like(el):
+        if isinstance(el, np.ndarray):
+            return el.ndim == 1 and el.size == 2
+        return isinstance(el, (list, tuple)) and len(el) == 2
+
+    if isinstance(bounds, tuple):
+        return False  # length-2 tuple form is resolved in the scipy branch
+    if isinstance(bounds, np.ndarray):
+        if bounds.ndim != 2 or bounds.shape[0] != 2:
+            return False
+        elems = list(bounds)
+    elif isinstance(bounds, list):
+        elems = bounds
+    else:
+        return False
+    if len(elems) != 2 or not all(_pair_like(e) for e in elems):
+        return False
+    return not all(isinstance(e, tuple) for e in elems)
+
+
 def _normalize_bound_arg(bounds, n):
     """Accept scipy's ``(lower, upper)`` 2-tuple form OR pounce's per-parameter
     list of ``(lo, hi)`` pairs, and normalise to the per-parameter pair list
@@ -1545,6 +1582,13 @@ def _normalize_bound_arg(bounds, n):
     A bare ``None`` on either side (``(None, 10.0)``, ``(None, None)``) is *not*
     pair-shaped and takes the scipy reading with ``None`` → ∓inf (unbounded on
     that side); both readings coincide there anyway.
+
+    The same ``n == 2`` ambiguity is reachable *without* an outer tuple — a
+    list of two length-2 lists ``[[l0, l1], [u0, u1]]`` or a ``2 x 2`` ndarray
+    is likewise readable both ways and transposed the box silently (issue #260's
+    remaining spellings). Those now raise too (see
+    :func:`_is_ambiguous_two_by_two`); the unambiguous pair-list spelling uses
+    ``(lo, hi)`` **tuples**, ``[(l0, u0), (l1, u1)]``.
     """
     if bounds is None:
         return None
@@ -1600,6 +1644,24 @@ def _normalize_bound_arg(bounds, n):
         lo = np.broadcast_to(lo_a, (n,))
         hi = np.broadcast_to(hi_a, (n,))
         return list(zip(lo.tolist(), hi.tolist()))
+
+    # Non-tuple container: normally pounce's per-parameter list of (lo, hi)
+    # pairs, validated downstream. But at n == 2 a length-2 sequence whose two
+    # elements are themselves length-2 sequences is *also* readable as scipy's
+    # (lower, upper) — the same collision the tuple branch guards above, reached
+    # here through a list-of-lists or a 2x2 ndarray. Only the pair list spelled
+    # with (lo, hi) tuples is unambiguous, so every other 2x2 spelling (which
+    # silently transposed the box, issue #260) now raises like the tuple form.
+    if n == 2 and _is_ambiguous_two_by_two(bounds):
+        raise ValueError(
+            f"bounds={bounds!r} is ambiguous for a 2-parameter model: written "
+            f"as two length-2 sequences it reads either as scipy's "
+            f"(lower, upper) — param 0 in (lo[0], hi[0]), param 1 in "
+            f"(lo[1], hi[1]) — or as a per-parameter pair list — param 0 in the "
+            f"first pair, param 1 in the second. Pass a list of (lo, hi) tuples "
+            f"[(l0, u0), (l1, u1)] for the pair-list reading, or a tuple of "
+            f"lists/arrays ([l0, l1], [u0, u1]) for the scipy reading."
+        )
     return bounds  # already a per-parameter list of pairs (validated downstream)
 
 

--- a/python/tests/test_curve_fit.py
+++ b/python/tests/test_curve_fit.py
@@ -616,13 +616,31 @@ def test_normalize_bound_arg_unit_matrix():
     with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
         _normalize_bound_arg(((0.0, 10.0), None), 2)           # element 0 pair-shaped
 
+    # #260 (remaining spellings): the same n=2 collision reached WITHOUT an outer
+    # tuple -- a list of two lists, a 2x2 ndarray, or a mixed tuple/list of two
+    # pairs -- silently transposed the box before; each now raises too.
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg([[0.0, 2.0], [1.0, 4.0]], 2)      # list of two lists
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg(np.array([[0.0, 2.0], [1.0, 4.0]]), 2)  # 2x2 ndarray
+    with pytest.raises(ValueError, match="ambiguous for a 2-parameter model"):
+        _normalize_bound_arg([(0.0, 2.0), [1.0, 4.0]], 2)      # mixed tuple/list
+
     # literal NaN in the scipy branch -> raise
     with pytest.raises(ValueError, match="NaN"):
         _normalize_bound_arg((float("nan"), 10.0), 2)
 
-    # pair *lists* pass through untouched (the unambiguous pair-list spelling)
+    # pair *lists* pass through untouched (the unambiguous pair-list spelling
+    # uses (lo, hi) *tuples*, so it is never confused with scipy's array rows)
     assert _normalize_bound_arg([(0.0, 10.0), (0.0, 10.0)], 2) == [(0.0, 10.0), (0.0, 10.0)]
     assert _normalize_bound_arg([(None, 10.0), (0.0, None)], 2) == [(None, 10.0), (0.0, None)]
+
+    # the n=2 raise is specific to the ambiguous 2x2 shape: n!=2 list-of-lists /
+    # ndarrays stay a pair list (there the (2, n) scipy shape cannot collide),
+    # and a bare-None pair-list entry is not pair-shaped, so it passes through.
+    assert _normalize_bound_arg([[0.0, 1.0], [2.0, 4.0], [0.0, 1.0]], 3) == [
+        [0.0, 1.0], [2.0, 4.0], [0.0, 1.0]]
+    assert _normalize_bound_arg([None, (0.0, 10.0)], 2) == [None, (0.0, 10.0)]
 
     # scipy tuple of lists/arrays -> per-parameter pairs (param i in [l_i, u_i])
     assert _normalize_bound_arg(([0.0, 1.6], [10.0, 10.0]), 2) == [(0.0, 10.0), (1.6, 10.0)]
@@ -676,6 +694,39 @@ def test_curve_fit_list_spelling_fits_and_matches_scipy():
         expdecay_2p, x, y, p0=[1.0, 2.0],
         bounds=([-np.inf, 0.0], [10.0, np.inf]))
     np.testing.assert_allclose(r.popt, rs, rtol=1e-4)
+
+
+def test_curve_fit_two_param_nontuple_bounds_never_silently_transpose():
+    """#260 (remaining spellings): for a 2-parameter model every way of writing
+    the box as *two length-2 sequences* is handled without a silent out-of-box
+    fit -- the scipy tuple follows scipy, the pair-list-of-tuples fits its box,
+    and the genuinely ambiguous list-of-lists / 2x2 ndarray spellings raise
+    rather than transpose the box and report ``Solve_Succeeded``.
+    """
+    x = np.linspace(0, 3, 60)
+    y = 2.0 * np.exp(-1.0 * x)  # noiseless: A=2, k=1
+
+    # scipy contract: A in [0, 10], k in [1.6, 10] -> k rides its lower bound.
+    lower, upper = [0.0, 1.6], [10.0, 10.0]
+    expected, _ = scipy_optimize.curve_fit(
+        expdecay_2p, x, y, p0=[1.0, 2.0], bounds=(lower, upper))
+
+    # (a) scipy tuple-of-lists follows scipy exactly.
+    rp = pounce.curve_fit(expdecay_2p, x, y, p0=[1.0, 2.0],
+                          bounds=(lower, upper), jac="fd")
+    np.testing.assert_allclose(rp.popt, expected, rtol=1e-4)
+
+    # (b) the equivalent pair list *of tuples* fits inside its (transposed-
+    #     looking but explicitly requested) box and stays there.
+    rl = pounce.curve_fit(expdecay_2p, x, y, p0=[1.0, 2.0],
+                          bounds=[(0.0, 10.0), (1.6, 10.0)], jac="fd")
+    np.testing.assert_allclose(rl.popt, expected, rtol=1e-4)
+
+    # (c)/(d) the ambiguous non-tuple spellings raise instead of guessing.
+    for amb in ([lower, upper], np.array([lower, upper])):
+        with pytest.raises(ValueError, match="ambiguous"):
+            pounce.curve_fit(expdecay_2p, x, y, p0=[1.0, 2.0],
+                             bounds=amb, jac="fd")
 
 
 def test_curve_fit_minima_ambiguous_tuple_raises_and_list_fits():


### PR DESCRIPTION
## Problem

For a **2-parameter** model, `pounce.curve_fit` silently transposed the box when
the scipy-style `bounds=(lower, upper)` were written as a *non-tuple* container.
This is the remaining half of #260 (its first comment enumerated all four
spellings). With `bounds=[[0,2],[1,4]]` or `np.array([[0,2],[1,4]])` — meaning,
under scipy's contract, `a in [0,1]`, `b in [2,4]` — pounce instead applied
`a in [0,2]`, `b in [1,4]` and returned `Solve_Succeeded` with a fit that
**violates the requested upper bound**, with no warning or error.

| `bounds` spelling (a∈[0,1], b∈[2,4]) | before | after |
|---|---|---|
| `([0,2],[1,4])` tuple-of-lists (scipy) | correct | correct (unchanged) |
| `((0,2),(1,4))` tuple-of-tuples | raises (#265) | raises (unchanged) |
| `[[0,2],[1,4]]` list-of-lists | **silent transposed fit** | **raises** |
| `np.array([[0,2],[1,4]])` 2×2 ndarray | **silent transposed fit** | **raises** |
| `[(0,2),(1,4)]` pair-list of tuples | pair-list | pair-list (unchanged) |

## Cause

`_normalize_bound_arg` only inspected the `tuple` form. The `n==2` ambiguity
guard added in #263/#265 lived inside that tuple branch, so any other container
(a list-of-lists, or a 2×2 ndarray) fell straight through to the
per-parameter pair-list reading downstream — the transposed box.

## Fix

Extend `_normalize_bound_arg` with a new `_is_ambiguous_two_by_two` helper that
detects the genuinely-ambiguous `n==2` 2×2 shapes reached through a non-tuple
container and **raises** — consistent with the #265 decision that the ambiguous
`n==2` shape must be an error rather than a silent guess. The error message
names both unambiguous spellings.

The unambiguous spellings are deliberately kept working: scipy's tuple of
lists/arrays `([l0,l1],[u0,u1])` still follows scipy, and pounce's per-parameter
pair list spelled with `(lo, hi)` **tuples** `[(l0,u0),(l1,u1)]` (the docstring's
own example) still fits its box. Only matching-container spellings
(list-of-lists, ndarray) and mixed tuple/list pairs raise.

## Blast radius

Confined to `curve_fit` bounds parsing. All three fit surfaces — `curve_fit`,
`curve_fit_minima`, `curve_fit_streaming` — share `_normalize_bound_arg`, so the
guard applies uniformly. No existing test, example, or doc uses a 2×2
list-of-lists or ndarray as `curve_fit` bounds (verified by grep); every current
call uses the tuple form or a list-of-tuples pair list, both unchanged.

## Tests

- Extended `test_normalize_bound_arg_unit_matrix` to pin the new raising cases
  (list-of-lists, 2×2 ndarray, mixed tuple/list) and the still-passing cases
  (n≠2 list-of-lists, bare-`None` pair entry).
- Added `test_curve_fit_two_param_nontuple_bounds_never_silently_transpose`,
  which checks on the live `curve_fit` surface that the scipy tuple matches
  scipy, the pair-list-of-tuples fits its box, and the ambiguous non-tuple
  spellings raise. These fail on the parent commit for the right reason (the
  ambiguous spellings there return a silent out-of-box fit instead of raising).
- Full suite: `test_curve_fit.py` 60/60 pass; minimize bounds tests pass.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — not applicable (bounds-parsing
      contract, no user-facing book page covers it)
- [x] Existing Python + curve_fit tests clean (no Rust code changed)
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015dR6urxZzZG4frANnKsa42)_