### PR TITLE
pyomo-pounce: detect a stale/shadowing pounce binary via build-id (#315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ changes.
 
 ## [Unreleased]
 
+### Added — pyomo-pounce: detect a stale/shadowing `pounce` binary (#315)
+
+- `pyomo_pounce.check_binary()` reports which `pounce` executable
+  `SolverFactory('pounce')` will run, its build, whether it matches the
+  wheel-bundled binary, and — critically — whether a *different* `pounce`
+  earlier on `PATH` would shadow it. The comparison is on the git **commit**
+  embedded in `pounce --about`, not the version string, because two builds can
+  share the same `X.Y.Z` while behaving differently (a binary from before and
+  after the #271/#272 dual-sign fix both report `0.9.0`).
+- The plugin now **warns** when it falls back to a `PATH` binary (only reachable
+  on a source/dev install without the `pounce-solver` wheel; a normal install
+  runs the bundled binary). Note: with `pyomo_pounce` un-imported,
+  `SolverFactory('pounce')` raises a clear `UnknownSolver` error — it never
+  silently runs an unrelated binary. Docs updated to state the import
+  requirement and point at `check_binary()`.
+
 ### Added — bound-multiplier `.sol` suffixes for Ipopt-parity reduced costs (#296)
 
 - **The `.sol` writer now emits `ipopt_zL_out` / `ipopt_zU_out` variable-suffix

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -29,6 +29,27 @@ Under the hood, Pyomo writes the model to an AMPL `.nl` file, invokes
 `pounce problem.nl -AMPL`, and reads the result back from the `.sol`
 file. See [Running Solves](cli.md) for the `-AMPL` solver mode.
 
+### Which `pounce` binary runs
+
+`import pyomo_pounce` is **required** before `SolverFactory('pounce')`.
+Without it Pyomo does not know the solver and raises a clear
+`UnknownSolver` / "plugin not registered" error — it does not silently run
+some other `pounce`. With it imported, the plugin runs the binary **bundled
+in the `pounce-solver` wheel**, independent of `PATH`; only a source/dev
+install lacking that wheel falls back to a `pounce` on `PATH` (and the plugin
+warns when it does).
+
+Because two builds can report the same version string (`X.Y.Z`) while
+behaving differently — a binary from before and after a fix does — a stale
+`pounce` on `PATH` is otherwise hard to notice. To see exactly which
+executable will run, its build (the git commit from `pounce --about`), and
+whether a different `pounce` earlier on `PATH` would shadow it:
+
+```python
+import pyomo_pounce
+pyomo_pounce.check_binary()   # prints a report; returns a dict
+```
+
 ## Preflight and initialization
 
 A `Var` whose `.value` was never set is written as **0** into the

--- a/pyomo-pounce/README.md
+++ b/pyomo-pounce/README.md
@@ -19,7 +19,7 @@ install, `pounce` is on your `PATH` and Pyomo finds it automatically.
 ## Usage
 
 ```python
-import pyomo_pounce  # registers the solver
+import pyomo_pounce  # registers the solver — REQUIRED before SolverFactory('pounce')
 from pyomo.environ import *
 
 model = ConcreteModel()
@@ -30,6 +30,25 @@ solver = SolverFactory('pounce')
 result = solver.solve(model, tee=True)
 print(f"x* = {value(model.x)}")  # 2.0
 ```
+
+> **`import pyomo_pounce` is required.** Without it, `SolverFactory('pounce')`
+> raises a clear `UnknownSolver` / "plugin not registered" error — it does not
+> silently run some other `pounce`. With it imported, the plugin runs the
+> `pounce` binary **bundled in the `pounce-solver` wheel**, independent of
+> `PATH`. Only a source/dev install without that wheel falls back to a `pounce`
+> on `PATH`, in which case the plugin warns.
+>
+> To see exactly which binary will run (and whether a stale or unrelated
+> `pounce` earlier on `PATH` would shadow it), call:
+>
+> ```python
+> import pyomo_pounce
+> pyomo_pounce.check_binary()
+> ```
+>
+> The check compares the git **commit** embedded in `pounce --about`, not the
+> version string — two builds can share the same `X.Y.Z` while differing in
+> behavior (as a binary from before/after a fix does).
 
 ## Solver Options
 

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -33,7 +33,7 @@ from pyomo_pounce.block_init import (
     block_initialize,
     block_repair_plan,
 )
-from pyomo_pounce.pounce_solver import POUNCE
+from pyomo_pounce.pounce_solver import POUNCE, check_binary
 from pyomo_pounce.sens import (
     Covariance,
     Gradient,
@@ -53,6 +53,7 @@ from pyomo_pounce.repair import InitializeReport, initialize, project_to_feasibl
 
 __all__ = [
     "POUNCE",
+    "check_binary",
     "declare_sens_param",
     "declare_fitted",
     "declare_residual",

--- a/pyomo-pounce/pyomo_pounce/pounce_solver.py
+++ b/pyomo-pounce/pyomo_pounce/pounce_solver.py
@@ -6,21 +6,94 @@ interface exactly as it drives IPOPT.
 
 The `pounce` binary is provided by the `pounce-solver` dependency,
 which ships a per-platform wheel that drops the executable into the
-active environment under `<venv>/bin/pounce`. Falls back to any
-`pounce` already on PATH for system installs or local dev builds
-(`cargo install --path crates/pounce-cli`).
+active environment under `<venv>/bin/pounce`. The plugin resolves that
+**bundled** binary deterministically (independent of PATH). Only when no
+bundled binary is present (a source/dev checkout without the wheel) does
+it fall back to whatever `pounce` is first on `PATH`.
+
+**You must** ``import pyomo_pounce`` before ``SolverFactory('pounce')``:
+without it Pyomo does not know the solver and raises a clear
+``UnknownSolver`` / "plugin not registered" error (it does **not** silently
+run some other `pounce`). If the plugin has to fall back to a PATH binary,
+it warns — and :func:`check_binary` reports exactly which executable will
+run, its build, and whether a different `pounce` earlier on PATH would
+shadow it (version strings alone cannot tell two builds apart — e.g. a
+binary from before and after a fix can both report the same ``X.Y.Z`` — so
+the check compares the git *commit* embedded in ``pounce --about``).
 
 Usage:
     import pyomo_pounce
     from pyomo.environ import *
     solver = SolverFactory('pounce')
     result = solver.solve(model)
+
+Diagnose which binary will run:
+    import pyomo_pounce
+    pyomo_pounce.check_binary()          # prints a report; returns a dict
 """
 
+import re
 import shutil
+import subprocess
+import warnings
 
 from pyomo.opt import SolverFactory
 from pyomo.solvers.plugins.solvers.ASL import ASL
+
+
+def _bundled_path():
+    """Path to the wheel-bundled `pounce` binary, or None if not present."""
+    try:
+        from pounce._cli import _bundled_binary
+
+        b = _bundled_binary()
+        return str(b) if b.is_file() else None
+    except Exception:
+        return None
+
+
+def _build_id(exe):
+    """Best-effort build identifier of a `pounce` executable: the short git
+    commit embedded in ``pounce --about``. Returns None if the executable is
+    missing, too old to support ``--about``, or otherwise unqueryable.
+
+    This is the discriminator a version string cannot provide: two builds
+    straddling a bug fix can share the same ``X.Y.Z`` while differing in
+    commit — see the pounce dual-sign fix (gh #271/#272), where a stale
+    0.9.0 binary returned flipped duals that a version check would miss.
+    """
+    if not exe:
+        return None
+    try:
+        out = subprocess.run(
+            [exe, "--about"], capture_output=True, text=True, timeout=15
+        ).stdout
+    except Exception:
+        return None
+    m = re.search(r"commit\s+([0-9a-f]+)", out)
+    return m.group(1) if m else None
+
+
+_fallback_warned = False
+
+
+def _warn_path_fallback(resolved):
+    """One-time warning that the plugin fell back to a PATH binary rather than
+    the wheel-bundled one, naming the resolved executable and its build."""
+    global _fallback_warned
+    if _fallback_warned:
+        return
+    _fallback_warned = True
+    bid = _build_id(resolved)
+    warnings.warn(
+        f"pyomo-pounce: no wheel-bundled `pounce` binary found; using the "
+        f"PATH executable {resolved!r} (build {bid or 'unknown'}). This may "
+        f"be a stale or unrelated `pounce` — version strings do not "
+        f"distinguish builds. Run `pyomo_pounce.check_binary()` to verify, "
+        f"or `pip install -U pounce-solver` to get the bundled binary.",
+        UserWarning,
+        stacklevel=3,
+    )
 
 
 @SolverFactory.register("pounce", doc="The POUNCE interior-point NLP solver")
@@ -66,13 +139,99 @@ class POUNCE(ASL):
         # invisible to non-activated-environment runs (cron, IDE runners,
         # Jupyter kernels) and can be shadowed by a stale system binary. Fall
         # back to PATH for system installs and local cargo dev builds where
-        # ``pounce-solver`` is not installed.
-        try:
-            from pounce._cli import _bundled_binary
+        # ``pounce-solver`` is not installed — and WARN when we do, since a
+        # PATH binary may be stale/unrelated and version strings cannot tell
+        # builds apart (gh #315).
+        bundled = _bundled_path()
+        if bundled is not None:
+            return bundled
+        resolved = shutil.which("pounce")
+        if resolved is not None:
+            _warn_path_fallback(resolved)
+        return resolved
 
-            bundled = _bundled_binary()
-            if bundled.is_file():
-                return str(bundled)
-        except Exception:
-            pass
-        return shutil.which("pounce")
+
+def _all_path_pounce():
+    """Every `pounce` executable resolvable via PATH, in PATH order — the
+    candidates Pyomo's ASL fallback *would* pick from if the bundled binary
+    were absent. Used to flag a binary that shadows the intended one."""
+    import os
+
+    seen, found = set(), []
+    for d in os.environ.get("PATH", "").split(os.pathsep):
+        if not d:
+            continue
+        cand = os.path.join(d, "pounce")
+        real = os.path.realpath(cand)
+        if os.path.isfile(cand) and os.access(cand, os.X_OK) and real not in seen:
+            seen.add(real)
+            found.append(cand)
+    return found
+
+
+def check_binary(verbose=True):
+    """Report which `pounce` executable ``SolverFactory('pounce')`` will run,
+    its build, and whether it matches the wheel-bundled binary — and flag any
+    *different* `pounce` earlier on PATH that would shadow it under Pyomo's
+    ASL fallback (the case that silently ran a stale, dual-sign-flipped binary
+    before gh #315).
+
+    Returns a dict; when ``verbose`` also prints a human-readable report.
+    Because two builds can share a version string, the comparison is on the
+    git *commit* embedded in ``pounce --about``, not the version.
+    """
+    resolved = SolverFactory("pounce")._default_executable()
+    bundled = _bundled_path()
+    resolved_id = _build_id(resolved)
+    bundled_id = _build_id(bundled)
+
+    path_bins = []
+    for p in _all_path_pounce():
+        path_bins.append({"path": p, "build_id": _build_id(p)})
+
+    # A PATH binary shadows the intended one if it is NOT the resolved binary
+    # and its build differs — i.e. a bare SolverFactory ASL fallback (or a
+    # forgotten `import pyomo_pounce`) could run a different build.
+    import os
+
+    resolved_real = os.path.realpath(resolved) if resolved else None
+    shadowing = [
+        b
+        for b in path_bins
+        if os.path.realpath(b["path"]) != resolved_real
+        and b["build_id"] != resolved_id
+    ]
+
+    info = {
+        "resolved_executable": resolved,
+        "resolved_build_id": resolved_id,
+        "bundled_executable": bundled,
+        "bundled_build_id": bundled_id,
+        "using_bundled": bool(bundled) and resolved == bundled,
+        "matches_bundled": (
+            bundled_id is not None and resolved_id == bundled_id
+        ),
+        "path_pounce_binaries": path_bins,
+        "shadowing_path_binaries": shadowing,
+    }
+
+    if verbose:
+        print("pyomo-pounce binary check")
+        print(f"  will run : {resolved}  (build {resolved_id or 'unknown'})")
+        if bundled:
+            match = "MATCHES" if info["matches_bundled"] else "DIFFERS from"
+            print(f"  bundled  : {bundled}  (build {bundled_id or 'unknown'})"
+                  f"  [{match} the binary that will run]")
+        else:
+            print("  bundled  : none found (source/dev install without the "
+                  "pounce-solver wheel)")
+        if shadowing:
+            print("  WARNING  : a different `pounce` is earlier on PATH; "
+                  "without `import pyomo_pounce` (or on the ASL fallback "
+                  "path) it could be run instead:")
+            for b in shadowing:
+                bid = b["build_id"] or "unknown"
+                print(f"             {b['path']}  (build {bid})")
+        else:
+            print("  PATH     : no shadowing `pounce` detected")
+    return info

--- a/pyomo-pounce/tests/test_binary_check.py
+++ b/pyomo-pounce/tests/test_binary_check.py
@@ -1,0 +1,121 @@
+"""Tests for the binary-resolution hardening (gh #315).
+
+The concern: ``SolverFactory('pounce')`` can be driven by a stale or unrelated
+`pounce` binary, and a *version string* cannot tell two builds apart (a binary
+from before and after a fix can both report the same ``X.Y.Z`` — precisely the
+dual-sign fix, gh #271/#272, where a stale 0.9.0 binary returned flipped
+duals). The plugin therefore discriminates on the git *commit* embedded in
+``pounce --about``, warns when it falls back to a PATH binary, and exposes
+``check_binary()`` to report exactly which executable will run and whether a
+different one shadows it on PATH.
+"""
+
+import warnings
+
+import pytest
+
+import pyomo_pounce
+from pyomo_pounce import pounce_solver as ps
+
+
+# ── build-id discrimination (the mechanism version strings can't provide) ──
+
+
+def test_build_id_parses_commit_from_about():
+    """``_build_id`` extracts the git commit from ``pounce --about``."""
+    bundled = ps._bundled_path()
+    if bundled is None:
+        pytest.skip("no bundled pounce binary in this environment")
+    bid = ps._build_id(bundled)
+    assert bid is not None and len(bid) >= 6
+    # It is a hex commit, not a version string.
+    int(bid, 16)
+
+
+def test_build_id_none_on_missing_or_bad_executable():
+    assert ps._build_id(None) is None
+    assert ps._build_id("/definitely/no/such/pounce/binary") is None
+
+
+# ── check_binary() ─────────────────────────────────────────────────────────
+
+
+def test_check_binary_reports_resolved_and_bundled():
+    info = pyomo_pounce.check_binary(verbose=False)
+    assert set(
+        [
+            "resolved_executable",
+            "resolved_build_id",
+            "bundled_executable",
+            "bundled_build_id",
+            "using_bundled",
+            "matches_bundled",
+            "path_pounce_binaries",
+            "shadowing_path_binaries",
+        ]
+    ).issubset(info)
+    # When a bundled binary exists it must be the one that runs, and match.
+    if info["bundled_executable"] is not None:
+        assert info["using_bundled"] is True
+        assert info["matches_bundled"] is True
+        assert info["resolved_build_id"] == info["bundled_build_id"]
+
+
+def test_check_binary_flags_a_shadowing_build(tmp_path, monkeypatch):
+    """A *different-build* `pounce` earlier on PATH is reported as shadowing;
+    an identical-build copy is not."""
+    resolved = pyomo_pounce.check_binary(verbose=False)["resolved_executable"]
+    if resolved is None:
+        pytest.skip("no pounce executable resolvable")
+
+    # A fake `pounce` on PATH whose `--about` reports a DIFFERENT commit.
+    fake_dir = tmp_path / "stale"
+    fake_dir.mkdir()
+    fake = fake_dir / "pounce"
+    fake.write_text(
+        "#!/bin/sh\n"
+        'echo "pounce 0.9.0 (commit deadbeef, built 2000-01-01T00:00:00Z)"\n'
+    )
+    fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_dir) + ":" + __import__("os").environ["PATH"])
+
+    info = pyomo_pounce.check_binary(verbose=False)
+    shadow_ids = {b["build_id"] for b in info["shadowing_path_binaries"]}
+    assert "deadbeef" in shadow_ids, info["path_pounce_binaries"]
+
+
+# ── the fallback warning ────────────────────────────────────────────────────
+
+
+def test_default_executable_warns_on_path_fallback(monkeypatch):
+    """When no bundled binary exists and the plugin falls back to a PATH
+    binary, it emits a one-time UserWarning naming the resolved executable."""
+    # Force the "no bundled binary" branch.
+    monkeypatch.setattr(ps, "_bundled_path", lambda: None)
+    monkeypatch.setattr(ps.shutil, "which", lambda name: "/some/path/pounce")
+    # Reset the one-time latch so the warning can fire in this test.
+    monkeypatch.setattr(ps, "_fallback_warned", False)
+    monkeypatch.setattr(ps, "_build_id", lambda exe: "abc123")
+
+    from pyomo.opt import SolverFactory
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        exe = SolverFactory("pounce")._default_executable()
+    assert exe == "/some/path/pounce"
+    msgs = [str(w.message) for w in caught if issubclass(w.category, UserWarning)]
+    assert any("no wheel-bundled" in m and "/some/path/pounce" in m for m in msgs)
+
+
+def test_default_executable_no_warning_when_bundled_present():
+    """The common case (bundled binary present) must be silent."""
+    if ps._bundled_path() is None:
+        pytest.skip("no bundled binary to exercise the quiet path")
+    from pyomo.opt import SolverFactory
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        SolverFactory("pounce")._default_executable()
+    assert not [
+        w for w in caught if "no wheel-bundled" in str(w.message)
+    ]


### PR DESCRIPTION
Fixes #315.

A `pounce` binary from **before and after a fix reports the same version string** — both `0.9.0` across the #271/#272 dual-sign fix — so a stale binary returning flipped duals is invisible to a version check. This adds build-identity detection to the pyomo-pounce plugin.

## The mechanism, refined during implementation

The issue as filed described a "silent ASL fallback to a stale PATH binary when `pyomo_pounce` isn't imported." Verifying on Pyomo 6.10.1, the reality is **safer and narrower**:

- **Un-imported → loud error.** `SolverFactory('pounce')` without `import pyomo_pounce` raises `UnknownSolver` / "plugin not registered". Pyomo does not lazily load the `pyomo.solvers` entry point, so it never silently runs another `pounce`.
- **Imported plugin already resolves the bundled binary** (independent of PATH), so a normal `pip install` is safe.
- **Genuine residual risk:** the `shutil.which("pounce")` *fallback* — reachable only on a source/dev install lacking the wheel — can pick a stale/shadowing PATH binary, undetectable by version (both `0.9.0`; commits `96fc5890` vs `2c49fad0`).

## Changes

- **`_build_id(exe)`** — parses the git commit from `pounce --about`, the discriminator a version string can't provide. Returns `None` on any failure.
- **`_default_executable`** now warns (once) when it falls back to a PATH binary, naming the executable and its build.
- **`check_binary()`** (exported from `pyomo_pounce`) — reports the executable that will run, its build, whether it matches the bundled binary, and any *different-build* `pounce` earlier on PATH that would shadow it. Verified live: it flags the stale `~/.local/bin/pounce` (commit `2c49fad0`) shadowing the current build (`96fc5890`).
- **Docs** (pyomo-pounce README, `docs/src/pyomo.md`): state that `import pyomo_pounce` is required (else `UnknownSolver`), that the bundled binary is used, and point at `check_binary()`.

## Tests / validation

6 new tests (`test_binary_check.py`): build-id parse and `None` fallback; `check_binary()` structure; shadowing detection via a fake different-commit PATH binary; the fallback warning; and the quiet path when the bundled binary is present. Full pyomo-pounce suite: **108 passed**.

No Rust change was needed — the git commit is already embedded in `pounce --about`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
