### PR TITLE
pyomo-pounce: harden the #315 binary check on Windows and dirty builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,14 @@ changes.
   `SolverFactory('pounce')` raises a clear `UnknownSolver` error — it never
   silently runs an unrelated binary. Docs updated to state the import
   requirement and point at `check_binary()`.
+- Follow-up hardening of the above: the PATH scan now resolves each entry
+  through `shutil.which`, so it looks for `pounce.exe` on Windows — previously
+  the bare-`pounce` filename test found nothing there, and `check_binary()`
+  reported no shadowing on Windows even when a stale `pounce.exe` was earlier on
+  `PATH`. The build id also keeps a `+dirty` marker (`96fc5890+dirty`), so a
+  build with uncommitted changes is distinguished from the clean build at the
+  same commit; a `commit unknown` build (made outside a git checkout) still
+  reads as unqueryable so two independent such builds never compare equal.
 
 ### Fixed — `curve_fit` two-parameter bounds: the last silently-transposing spellings now raise (#260)
 

--- a/pyomo-pounce/pyomo_pounce/pounce_solver.py
+++ b/pyomo-pounce/pyomo_pounce/pounce_solver.py
@@ -61,6 +61,12 @@ def _build_id(exe):
     straddling a bug fix can share the same ``X.Y.Z`` while differing in
     commit — see the pounce dual-sign fix (gh #271/#272), where a stale
     0.9.0 binary returned flipped duals that a version check would miss.
+
+    A dirty working tree is kept in the identifier (``96fc5890+dirty``), so a
+    build with uncommitted changes is distinguished from the clean build at
+    the same commit — that is exactly a "same commit, different bits" case.
+    ``unknown`` (a build made outside a git checkout) is still treated as
+    unqueryable so two independent such builds never compare equal.
     """
     if not exe:
         return None
@@ -70,7 +76,7 @@ def _build_id(exe):
         ).stdout
     except Exception:
         return None
-    m = re.search(r"commit\s+([0-9a-f]+)", out)
+    m = re.search(r"commit\s+([0-9a-f]+(?:\+dirty)?)", out)
     return m.group(1) if m else None
 
 
@@ -154,16 +160,24 @@ class POUNCE(ASL):
 def _all_path_pounce():
     """Every `pounce` executable resolvable via PATH, in PATH order — the
     candidates Pyomo's ASL fallback *would* pick from if the bundled binary
-    were absent. Used to flag a binary that shadows the intended one."""
+    were absent. Used to flag a binary that shadows the intended one.
+
+    The executable is named ``pounce.exe`` on Windows; resolving it through
+    ``shutil.which`` (rather than a bare ``pounce`` filename test) applies the
+    platform's own name/extension and executable-bit rules, so the shadowing
+    scan works on Windows too."""
     import os
 
+    name = "pounce.exe" if os.name == "nt" else "pounce"
     seen, found = set(), []
     for d in os.environ.get("PATH", "").split(os.pathsep):
         if not d:
             continue
-        cand = os.path.join(d, "pounce")
+        cand = shutil.which(name, path=d)
+        if cand is None:
+            continue
         real = os.path.realpath(cand)
-        if os.path.isfile(cand) and os.access(cand, os.X_OK) and real not in seen:
+        if real not in seen:
             seen.add(real)
             found.append(cand)
     return found

--- a/pyomo-pounce/tests/test_binary_check.py
+++ b/pyomo-pounce/tests/test_binary_check.py
@@ -10,12 +10,20 @@ duals). The plugin therefore discriminates on the git *commit* embedded in
 different one shadows it on PATH.
 """
 
+import os
 import warnings
 
 import pytest
 
 import pyomo_pounce
 from pyomo_pounce import pounce_solver as ps
+
+
+def _write_fake_pounce(path, about_first_line):
+    """A minimal `pounce` whose `--about` prints the given first line."""
+    path.write_text("#!/bin/sh\n" f'echo "{about_first_line}"\n')
+    path.chmod(0o755)
+    return path
 
 
 # ── build-id discrimination (the mechanism version strings can't provide) ──
@@ -28,13 +36,73 @@ def test_build_id_parses_commit_from_about():
         pytest.skip("no bundled pounce binary in this environment")
     bid = ps._build_id(bundled)
     assert bid is not None and len(bid) >= 6
-    # It is a hex commit, not a version string.
-    int(bid, 16)
+    # It is a hex commit (optionally carrying a `+dirty` marker for a build
+    # with uncommitted changes), not a version string.
+    int(bid.split("+")[0], 16)
 
 
 def test_build_id_none_on_missing_or_bad_executable():
     assert ps._build_id(None) is None
     assert ps._build_id("/definitely/no/such/pounce/binary") is None
+
+
+def test_build_id_keeps_dirty_suffix(tmp_path):
+    """A build with uncommitted changes reports ``<commit>+dirty``; that
+    marker is kept, so it is distinguished from the clean build at the same
+    commit — a genuine "same commit, different bits" case."""
+    clean = _write_fake_pounce(
+        tmp_path / "clean",
+        "pounce 0.9.0 (commit 96fc5890, built 2026-01-01T00:00:00Z)",
+    )
+    dirty = _write_fake_pounce(
+        tmp_path / "dirty",
+        "pounce 0.9.0 (commit 96fc5890+dirty, built 2026-01-01T00:00:00Z)",
+    )
+    assert ps._build_id(str(clean)) == "96fc5890"
+    assert ps._build_id(str(dirty)) == "96fc5890+dirty"
+    assert ps._build_id(str(clean)) != ps._build_id(str(dirty))
+
+
+def test_build_id_treats_unknown_commit_as_unqueryable(tmp_path):
+    """A binary built outside a git checkout reports ``commit unknown``. That
+    must read as None, so two independent such builds never compare equal
+    (and never look like a match to the bundled binary)."""
+    exe = _write_fake_pounce(
+        tmp_path / "pounce",
+        "pounce 0.9.0 (commit unknown, built 2026-01-01T00:00:00Z)",
+    )
+    assert ps._build_id(str(exe)) is None
+
+
+# ── PATH scan (the candidates ASL fallback would pick from) ─────────────────
+
+
+def test_all_path_pounce_finds_binary(tmp_path, monkeypatch):
+    exe = _write_fake_pounce(
+        tmp_path / "pounce", "pounce 0.9.0 (commit abc123, built x)"
+    )
+    monkeypatch.setenv("PATH", str(tmp_path))
+    found = ps._all_path_pounce()
+    assert any(os.path.realpath(f) == os.path.realpath(str(exe)) for f in found)
+
+
+def test_all_path_pounce_resolves_via_which(monkeypatch):
+    """The scan resolves each PATH entry through ``shutil.which`` with the
+    platform's executable name, rather than a bare-``pounce`` filename test.
+    The pre-fix code used ``os.path.join(d, "pounce")`` directly, so it never
+    called ``which`` — and on Windows (name ``pounce.exe``) found nothing,
+    silently reporting no shadowing."""
+    calls = []
+    monkeypatch.setattr(
+        ps.shutil, "which", lambda name, path=None: calls.append(name) or None
+    )
+    monkeypatch.setenv("PATH", "/nonexistent-dir-xyz")
+    ps._all_path_pounce()
+    assert calls, "the scan must resolve PATH entries through shutil.which"
+    # The name carries the platform's executable extension (`pounce.exe` on
+    # Windows), so the shadowing scan is not silently empty there.
+    expected = "pounce.exe" if os.name == "nt" else "pounce"
+    assert all(c == expected for c in calls)
 
 
 # ── check_binary() ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Follow-up to the merged #315 stale-binary detection (PR #318). This branch was originally a duplicate implementation of #315; #318 landed the feature first, so this is now rebased onto `main` and scoped down to two real gaps I found in the shipped `check_binary()` / `_build_id` while comparing the two.

## Problem

Two edge cases where the merged binary check is weaker than intended:

1. **The shadowing scan is silently empty on Windows.** `_all_path_pounce` tested a bare `pounce` filename (`os.path.join(d, "pounce")` + `os.path.isfile`). On Windows the executable is `pounce.exe`, so the scan finds nothing — and `check_binary()` reports **no shadowing** even when a stale `pounce.exe` is earlier on `PATH`. Since pounce ships Windows wheels, that defeats the diagnostic exactly where a user would run it.
2. **A dirty build collapses onto the clean commit.** `_build_id`'s regex `commit\s+([0-9a-f]+)` drops the `+dirty` suffix that `pounce --about` emits for a build with uncommitted changes, so `96fc5890+dirty` reads as `96fc5890` — indistinguishable from the clean build at that commit, which is precisely a "same commit, different bits" case. (The CI wheel itself builds `+dirty`, so this path is exercised in the wheel-smoke job.)

## Cause

Both live in the resolver helpers added by #318: `_all_path_pounce` (a filename test that doesn't know the platform extension) and `_build_id` (a hex-only capture group).

## Fix

- **PATH scan** resolves each entry through `shutil.which(name, path=d)` with `name = "pounce.exe" if os.name == "nt" else "pounce"`, so it applies the platform's own name/extension and executable-bit rules and works on Windows.
- **Build id** widens the capture to `([0-9a-f]+(?:\+dirty)?)`, keeping the `+dirty` marker. `commit unknown` (a build made outside a git checkout) is deliberately still *not* matched, so it stays unqueryable (`None`) and two independent unknown builds never compare equal — preserving #318's conservative behaviour there.

No change to the public API (`check_binary()` still returns the same dict), the shipped binary, or any solver numerics.

## Blast radius

Confined to `pyomo-pounce`'s two resolver helpers. On Linux/macOS the PATH scan resolves the same binaries as before (`shutil.which` with the literal name applies the same file+exec test); the only behavioural change on those platforms is the preserved `+dirty` marker. Windows gains a working shadowing scan.

## Tests

Added to `pyomo-pounce/tests/test_binary_check.py`:

- `test_build_id_keeps_dirty_suffix` — `96fc5890+dirty` is preserved and distinct from `96fc5890`.
- `test_build_id_treats_unknown_commit_as_unqueryable` — `commit unknown` → `None`.
- `test_all_path_pounce_finds_binary` — real fake binary on PATH is found.
- `test_all_path_pounce_resolves_via_which` — asserts the scan goes through `shutil.which` with the platform executable name.

Also updated the existing `test_build_id_parses_commit_from_about`: its `int(bid, 16)` hex assertion now strips an optional `+dirty` marker first, since a dirty wheel build (the CI case) legitimately yields `<commit>+dirty`. That collision is what the first CI run surfaced.

Both new fix-tests fail on the parent commit for the stated reason: the dirty test sees `96fc5890` (suffix dropped), and the scan test sees `shutil.which` never called (pre-fix used `os.path.join`). Verified locally — pass on this branch, fail on `main`'s `pounce_solver.py`.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry (appended under the existing #315 entry)
- [x] Book page under `docs/src/` already documents `check_binary()` (#318); no doc change needed for these internal-helper fixes
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — N/A, Python-only change; `pytest pyomo-pounce/tests` is the relevant gate (wheel-smoke job)
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ku7FaPstDZ5NLqy2sa71nj