### PR TITLE
fix(convex): converge tiny-curvature QPs, refute spurious unbounded, warn otherwise (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — convex QP convergence and honesty on tiny-curvature objectives (#293)
+
+- **A convex QP whose Hessian curvature is tiny relative to its linear/constraint
+  data now converges to the true optimum instead of silently truncating or
+  returning a wrong unboundedness verdict.** These are the shapes a
+  portfolio/least-squares user hits when a regularizer or a near-linear
+  objective makes the curvature small; the answer was previously silently wrong
+  or silently short of the optimum, with nothing in the status to flag it.
+  - **Uniformly tiny Hessian converges.** `min ½·1e-12·(x0²+x1²) − x1 s.t. x ≥ 0`
+    (optimum `x1*=1e12`, `f*=−5e11`) returned `iteration_limit` at `≈−4.95e11`;
+    it now returns `optimal` at `−5e11`. The default HSDE driver's per-cone NT
+    scaling never sees a Hessian 12+ orders below O(1), so on any non-clean
+    status the solver now retries once with Ruiz equilibration (which lifts the
+    scaled Hessian to O(1)) and accepts the retry only when it reaches a clean
+    `optimal` — a genuinely hard problem keeps its truthful status. Covers both
+    the unconstrained (`iteration_limit`) and constrained (`optimal_inaccurate`)
+    manifestations.
+  - **Spurious unboundedness refuted (machine-epsilon tail).** At `P ≈ 1e-20`
+    a bounded problem could be wrongly certified `dual_infeasible`; a
+    direct-driver reverify on the equilibrated problem now refutes the bogus
+    certificate and returns the verified finite optimum (gated to `P ≠ 0`, so
+    genuinely unbounded problems are unaffected).
+  - **Scaling warning for the unconvergeable residue.** When no driver can
+    converge a tiny-curvature problem at the default budget (e.g. a uniformly
+    tiny Hessian coupled through an equality), the honest non-`optimal` status
+    now carries an actionable scaling diagnostic naming tiny curvature as the
+    cause. Surfaced on the CLI (stderr) and in the Python `solve_qp` result as a
+    `scaling_warning` key. A clean `optimal` or a well-scaled hard problem emits
+    nothing.
+
 ### Added — bound-multiplier `.sol` suffixes for Ipopt-parity reduced costs (#296)
 
 - **The `.sol` writer now emits `ipopt_zL_out` / `ipopt_zU_out` variable-suffix

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1777,6 +1777,13 @@ fn run_convex_qp(
         class.name(),
         sol.iters,
     );
+    // gh #293 naive-caller guardrail: if the solve did not cleanly converge and
+    // the objective curvature is tiny relative to the data, say so — the status
+    // is honest but a naive caller might otherwise treat a truncated objective
+    // as the optimum.
+    if let Some(warn) = sol.scaling_diagnostic(&qp) {
+        eprintln!("pounce: {warn}");
+    }
 
     // Final KKT residuals from pounce-convex; reused for both the Ipopt-style
     // summary block and the JSON report below.

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -317,13 +317,7 @@ where
         QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::OptimalInaccurate
     );
     if opts.use_hsde && opts.equilibrate && retry_on {
-        let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
-        let inner = QpOptions {
-            equilibrate: false,
-            ..*opts
-        };
-        let mut retry = solve_qp_ipm_unscaled(&scaled, &inner, &mut make_backend);
-        scaling.unscale_solution(prob, &mut retry);
+        let retry = equilibrated_solve(prob, opts, /* use_hsde */ true, &mut make_backend);
         let accept = match sol.status {
             QpStatus::NumericalFailure => retry.status != QpStatus::NumericalFailure,
             QpStatus::IterationLimit | QpStatus::OptimalInaccurate => {
@@ -335,6 +329,58 @@ where
             return retry;
         }
     }
+    // gh #293 (extreme tail): refute a *spurious* unboundedness certificate on a
+    // QP with genuine curvature. A `DualInfeasible` verdict rests on finding a
+    // recession ray whose normalized curvature `dᵀPd/‖d‖²` is below
+    // [`RECESSION_CURV_TOL`]. When the Hessian is so tiny that a bounded descent
+    // direction's curvature sinks to that floor (`P ≈ 1e-20`, at the edge of
+    // double precision), the raw HSDE solve can read a bounded ray as a
+    // recession and wrongly certify the problem unbounded — the exact failure
+    // #290/#309 fixed for `1e-12`, resurfacing only in the machine-epsilon tail.
+    // A *genuine* recession lies in `null(P)` and survives equilibration, so
+    // re-solving the Ruiz-scaled problem with the direct driver (which lifts
+    // `P̂` to O(1), making the true curvature visible) is a decisive cross-check:
+    // if it returns a clean, finite `Optimal`, the problem was bounded and the
+    // certificate was a scaling artifact, so return the verified optimum;
+    // otherwise keep the original verdict. Gated to `P ≠ 0` — a pure LP's
+    // unboundedness is exact, never a curvature artifact — so genuine unbounded
+    // LPs never pay for the reverify.
+    if opts.use_hsde
+        && opts.equilibrate
+        && sol.status == QpStatus::DualInfeasible
+        && prob.p_lower.iter().any(|t| t.val != 0.0)
+    {
+        let verify = equilibrated_solve(prob, opts, /* use_hsde */ false, &mut make_backend);
+        if verify.status == QpStatus::Optimal {
+            return verify;
+        }
+    }
+    sol
+}
+
+/// Run an equilibrated solve: Ruiz-scale `prob`, solve the scaled problem with
+/// the driver selected by `use_hsde`, and unscale the result back to the
+/// original problem's coordinates. Shared by the HSDE convergence fallback
+/// (`use_hsde = true`) and the dual-infeasibility reverify guard
+/// (`use_hsde = false`, the direct driver, which exposes the true curvature of
+/// a tiny Hessian to the recession test).
+fn equilibrated_solve<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    use_hsde: bool,
+    make_backend: &mut F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
+    let inner = QpOptions {
+        equilibrate: false,
+        use_hsde,
+        ..*opts
+    };
+    let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend);
+    scaling.unscale_solution(prob, &mut sol);
     sol
 }
 

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -287,7 +287,27 @@ where
     // here because the un-equilibrated solve already failed, so there is nothing
     // left to regress — equilibration can only recover a usable solve or fail
     // the same way (in which case we keep the original result).
-    if opts.use_hsde && opts.equilibrate && sol.status == QpStatus::NumericalFailure {
+    //
+    // gh #293: the same retry also rescues an HSDE solve that merely *ran out
+    // of iterations* (`IterationLimit`) on a badly-scaled QP whose Hessian is
+    // uniformly tiny — e.g. `P = diag(1e-12, 1e-12)`, where the optimum sits at
+    // `‖x*‖ ≈ 1e12`. There HSDE's per-cone NT scaling never sees the objective
+    // curvature (the `P` block is 12 orders below O(1)), so the iterates crawl
+    // and the budget is exhausted short of the optimum; Ruiz pre-scaling lifts
+    // `P̂` to O(1) and the same driver then converges. This does not contradict
+    // the "Ruiz composes badly with HSDE" note either: we only reach here
+    // because the un-equilibrated solve failed to converge, so there is nothing
+    // left to regress. Unlike the `NumericalFailure` case (where any non-failing
+    // status is an improvement), an `IterationLimit` is an *honest* status, so
+    // the equilibrated retry is accepted **only when it converges to `Optimal`**
+    // — never when it merely returns a different non-converged/certificate
+    // status, so a genuinely hard problem keeps its truthful `IterationLimit`
+    // and no infeasibility/unboundedness verdict can be introduced by the retry.
+    let retry_on = matches!(
+        sol.status,
+        QpStatus::NumericalFailure | QpStatus::IterationLimit
+    );
+    if opts.use_hsde && opts.equilibrate && retry_on {
         let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
         let inner = QpOptions {
             equilibrate: false,
@@ -295,7 +315,12 @@ where
         };
         let mut retry = solve_qp_ipm_unscaled(&scaled, &inner, &mut make_backend);
         scaling.unscale_solution(prob, &mut retry);
-        if retry.status != QpStatus::NumericalFailure {
+        let accept = match sol.status {
+            QpStatus::NumericalFailure => retry.status != QpStatus::NumericalFailure,
+            QpStatus::IterationLimit => retry.status == QpStatus::Optimal,
+            _ => false,
+        };
+        if accept {
             return retry;
         }
     }

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -288,24 +288,33 @@ where
     // left to regress — equilibration can only recover a usable solve or fail
     // the same way (in which case we keep the original result).
     //
-    // gh #293: the same retry also rescues an HSDE solve that merely *ran out
-    // of iterations* (`IterationLimit`) on a badly-scaled QP whose Hessian is
-    // uniformly tiny — e.g. `P = diag(1e-12, 1e-12)`, where the optimum sits at
-    // `‖x*‖ ≈ 1e12`. There HSDE's per-cone NT scaling never sees the objective
-    // curvature (the `P` block is 12 orders below O(1)), so the iterates crawl
-    // and the budget is exhausted short of the optimum; Ruiz pre-scaling lifts
-    // `P̂` to O(1) and the same driver then converges. This does not contradict
-    // the "Ruiz composes badly with HSDE" note either: we only reach here
-    // because the un-equilibrated solve failed to converge, so there is nothing
-    // left to regress. Unlike the `NumericalFailure` case (where any non-failing
-    // status is an improvement), an `IterationLimit` is an *honest* status, so
-    // the equilibrated retry is accepted **only when it converges to `Optimal`**
-    // — never when it merely returns a different non-converged/certificate
-    // status, so a genuinely hard problem keeps its truthful `IterationLimit`
-    // and no infeasibility/unboundedness verdict can be introduced by the retry.
+    // gh #293: the same retry also rescues an HSDE solve that failed to reach a
+    // clean `Optimal` on a badly-scaled QP whose Hessian curvature is tiny. The
+    // canonical case is a uniformly tiny Hessian — `P = diag(1e-12, 1e-12)`,
+    // optimum at `‖x*‖ ≈ 1e12` — where HSDE's per-cone NT scaling never sees the
+    // objective curvature (the `P` block is 12 orders below O(1)), so the
+    // iterates crawl and the budget is exhausted short of the optimum. Ruiz
+    // pre-scaling lifts `P̂` to O(1) and the same driver then converges. The same
+    // pathology surfaces through either non-converged status depending on the
+    // geometry: as `IterationLimit` when the optimum is unconstrained (the
+    // iterates never arrive), and as `OptimalInaccurate` when a constraint binds
+    // near it (a usable-but-loose iterate is returned at the cap). Both are keyed
+    // on the same retry, so the fix covers the *regime*, not one status symbol.
+    // This does not contradict the "Ruiz composes badly with HSDE" note either:
+    // we only reach here because the un-equilibrated solve did not cleanly
+    // converge, so there is nothing left to regress. Unlike the
+    // `NumericalFailure` case (where any non-failing status is an improvement),
+    // `IterationLimit` and `OptimalInaccurate` are *honest* statuses, so the
+    // equilibrated retry is accepted **only when it converges to a clean
+    // `Optimal`** — never when it merely returns a different non-converged or
+    // certificate status. A genuinely hard problem thus keeps its truthful
+    // status, and no infeasibility/unboundedness verdict can be introduced by
+    // the retry. (Cone-carrying problems never reach this branch: exp/power/SOC
+    // solve through `solve_socp_ipm`, and Ruiz — an orthant-only row scaling —
+    // is confined to this LP/QP entry point.)
     let retry_on = matches!(
         sol.status,
-        QpStatus::NumericalFailure | QpStatus::IterationLimit
+        QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::OptimalInaccurate
     );
     if opts.use_hsde && opts.equilibrate && retry_on {
         let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
@@ -317,7 +326,9 @@ where
         scaling.unscale_solution(prob, &mut retry);
         let accept = match sol.status {
             QpStatus::NumericalFailure => retry.status != QpStatus::NumericalFailure,
-            QpStatus::IterationLimit => retry.status == QpStatus::Optimal,
+            QpStatus::IterationLimit | QpStatus::OptimalInaccurate => {
+                retry.status == QpStatus::Optimal
+            }
             _ => false,
         };
         if accept {

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -382,7 +382,66 @@ impl QpResiduals {
     }
 }
 
+/// A tiny-curvature warning fires when `‖P‖∞` is more than this many orders of
+/// magnitude below the rest of the problem data. Six orders is comfortably past
+/// where a well-scaled convex QP sits (curvature commensurate with the linear
+/// and constraint coefficients) yet well above the gh #293 regime (`‖P‖`
+/// 8–20 orders below `‖c‖`), so a healthy hard problem is never blamed on
+/// curvature and an ill-scaled one always is.
+const CURV_DATA_RATIO: f64 = 1e-6;
+
 impl QpSolution {
+    /// Diagnose whether an *unconverged or possibly-spurious* status is likely
+    /// caused by tiny objective curvature relative to the rest of the problem
+    /// data — the ill-scaling regime of gh #293. There an interior-point solve
+    /// can exhaust its budget (`IterationLimit` / `OptimalInaccurate`) short of
+    /// a far-off optimum, or, in the machine-epsilon tail, return a
+    /// scaling-artifact certificate. Returns a human-readable warning when the
+    /// status is one of those *and* the curvature is tiny relative to the data;
+    /// otherwise `None` — so a caller can surface it without ever second-guessing
+    /// a clean `Optimal` (including one the solver recovered via its own
+    /// equilibrated retry) or an exact infeasibility certificate.
+    ///
+    /// This is the naive-caller guardrail for the residual cases no driver can
+    /// converge at the default budget (e.g. a uniformly tiny Hessian coupled
+    /// through an equality constraint): the status is already honest, and this
+    /// says *why*, with an actionable remedy, instead of leaving a truncated
+    /// objective to be mistaken for the optimum.
+    pub fn scaling_diagnostic(&self, prob: &QpProblem) -> Option<String> {
+        let suspect = matches!(
+            self.status,
+            QpStatus::IterationLimit
+                | QpStatus::OptimalInaccurate
+                | QpStatus::NumericalFailure
+                | QpStatus::DualInfeasible
+        );
+        if !suspect {
+            return None;
+        }
+        let maxabs_t = |it: &[Triplet]| it.iter().fold(0.0f64, |m, t| m.max(t.val.abs()));
+        let maxabs_v = |v: &[f64]| v.iter().fold(0.0f64, |m, &x| m.max(x.abs()));
+        let p_norm = maxabs_t(&prob.p_lower);
+        if p_norm == 0.0 {
+            // A pure LP has no curvature; its unboundedness/limits are not a
+            // tiny-Hessian artifact, so this diagnostic does not apply.
+            return None;
+        }
+        let data = maxabs_v(&prob.c)
+            .max(maxabs_t(&prob.a))
+            .max(maxabs_t(&prob.g))
+            .max(1.0);
+        if p_norm >= data * CURV_DATA_RATIO {
+            return None;
+        }
+        Some(format!(
+            "scaling warning: objective curvature ‖P‖∞ = {p_norm:.1e} is tiny \
+             relative to the problem data (‖c,A,G‖∞ ≈ {data:.1e}); the {:?} \
+             result may be inaccurate. Rescale the objective (e.g. divide P and \
+             c by ‖P‖∞) or cross-check with a reference solver.",
+            self.status
+        ))
+    }
+
     /// Recompute the final KKT residuals of this solution against `prob`.
     ///
     /// Uses the convex solver's standard-form conventions —

--- a/crates/pounce-convex/tests/bench293.rs
+++ b/crates/pounce-convex/tests/bench293.rs
@@ -29,14 +29,19 @@ fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
 fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
     let mut px = vec![0.0; prob.n];
     prob.p_mul_add_pub(x, &mut px);
-    (0..prob.n).map(|i| 0.5 * x[i] * px[i] + prob.c[i] * x[i]).sum()
+    (0..prob.n)
+        .map(|i| 0.5 * x[i] * px[i] + prob.c[i] * x[i])
+        .sum()
 }
 
 /// Deterministic LCG so the corpus is reproducible without an external rng.
 struct Lcg(u64);
 impl Lcg {
     fn next_f64(&mut self) -> f64 {
-        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
         ((self.0 >> 11) as f64) / ((1u64 << 53) as f64)
     }
     fn sym(&mut self) -> f64 {
@@ -76,7 +81,11 @@ fn diag_box(name: &str, scale: f64, cond: f64, tgt: &[f64], lb: f64, ub: f64) ->
         ub: vec![ub; n],
     };
     let oracle = objective(&prob, &xopt);
-    Case { name: name.to_string(), prob, oracle_obj: Some(oracle) }
+    Case {
+        name: name.to_string(),
+        prob,
+        oracle_obj: Some(oracle),
+    }
 }
 
 /// Dense random SPD QP (P = MᵀM + εI) with a box; no oracle.
@@ -108,7 +117,11 @@ fn rand_spd_box(name: &str, n: usize, seed: u64, pscale: f64, cscale: f64) -> Ca
         lb: vec![-1.0; n],
         ub: vec![1.0; n],
     };
-    Case { name: name.to_string(), prob, oracle_obj: None }
+    Case {
+        name: name.to_string(),
+        prob,
+        oracle_obj: None,
+    }
 }
 
 /// Random SPD QP with an equality constraint sum(x)=s and x>=0.
@@ -136,7 +149,11 @@ fn lp_box(name: &str, n: usize, seed: u64, cscale: f64) -> Case {
         lb: vec![-1.0; n],
         ub: vec![1.0; n],
     };
-    Case { name: name.to_string(), prob, oracle_obj: None }
+    Case {
+        name: name.to_string(),
+        prob,
+        oracle_obj: None,
+    }
 }
 
 fn corpus() -> Vec<Case> {
@@ -145,28 +162,74 @@ fn corpus() -> Vec<Case> {
     let tgt3 = [1e11, -0.5, 2.0];
 
     for &cond in &[1.0, 1e2, 1e4, 1e6] {
-        v.push(diag_box(&format!("diag_well_cond{cond:e}"), 1.0, cond, &tgt6, -1.0, 1.0));
+        v.push(diag_box(
+            &format!("diag_well_cond{cond:e}"),
+            1.0,
+            cond,
+            &tgt6,
+            -1.0,
+            1.0,
+        ));
     }
     for &sc in &[1e6, 1e12, 1e18] {
-        v.push(diag_box(&format!("diag_huge_{sc:e}"), sc, 1.0, &tgt6, -1.0, 1.0));
+        v.push(diag_box(
+            &format!("diag_huge_{sc:e}"),
+            sc,
+            1.0,
+            &tgt6,
+            -1.0,
+            1.0,
+        ));
     }
     for &sc in &[1e-6, 1e-9, 1e-12, 1e-14, 1e-16] {
-        v.push(diag_box(&format!("diag_tiny_{sc:e}"), sc, 1.0, &tgt3, 0.0, f64::INFINITY));
+        v.push(diag_box(
+            &format!("diag_tiny_{sc:e}"),
+            sc,
+            1.0,
+            &tgt3,
+            0.0,
+            f64::INFINITY,
+        ));
     }
     for &cond in &[1e12, 1e18] {
-        v.push(diag_box(&format!("diag_mixed_cond{cond:e}"), 1e-6, cond, &tgt3, 0.0, f64::INFINITY));
+        v.push(diag_box(
+            &format!("diag_mixed_cond{cond:e}"),
+            1e-6,
+            cond,
+            &tgt3,
+            0.0,
+            f64::INFINITY,
+        ));
     }
-    v.push(diag_box("diag_tiny_boundbox", 1e-12, 1.0, &[1e11, 1e11], 0.0, 1e6));
+    v.push(diag_box(
+        "diag_tiny_boundbox",
+        1e-12,
+        1.0,
+        &[1e11, 1e11],
+        0.0,
+        1e6,
+    ));
 
     for (i, &n) in [5usize, 10, 25, 50].iter().enumerate() {
-        v.push(rand_spd_box(&format!("rand_box_n{n}"), n, 1000 + i as u64, 1.0, 1.0));
+        v.push(rand_spd_box(
+            &format!("rand_box_n{n}"),
+            n,
+            1000 + i as u64,
+            1.0,
+            1.0,
+        ));
     }
     v.push(rand_spd_box("rand_box_pbig", 20, 7, 1e6, 1.0));
     v.push(rand_spd_box("rand_box_cbig", 20, 8, 1.0, 1e6));
     v.push(rand_spd_box("rand_box_ptiny", 20, 9, 1e-8, 1.0));
 
     for (i, &n) in [10usize, 30].iter().enumerate() {
-        v.push(rand_spd_eq(&format!("rand_eq_n{n}"), n, 2000 + i as u64, 3.0));
+        v.push(rand_spd_eq(
+            &format!("rand_eq_n{n}"),
+            n,
+            2000 + i as u64,
+            3.0,
+        ));
     }
 
     v.push(lp_box("lp_small", 10, 11, 1.0));
@@ -194,7 +257,10 @@ fn scaling_corpus_reaches_every_oracle_optimum() {
     let mut iters_tot = 0usize;
     let mut failures: Vec<String> = Vec::new();
 
-    println!("\n{:<26} {:>3} {:>6} {:>10} {:>6}", "case", "n", "status", "obj", "iters");
+    println!(
+        "\n{:<26} {:>3} {:>6} {:>10} {:>6}",
+        "case", "n", "status", "obj", "iters"
+    );
     for c in &cases {
         let sol = solve_qp_ipm(&c.prob, &QpOptions::default(), backend);
         iters_tot += sol.iters;
@@ -203,7 +269,11 @@ fn scaling_corpus_reaches_every_oracle_optimum() {
         }
         println!(
             "{:<26} {:>3} {:>6} {:>10.3e} {:>6}",
-            c.name, c.prob.n, short(sol.status), sol.obj, sol.iters
+            c.name,
+            c.prob.n,
+            short(sol.status),
+            sol.obj,
+            sol.iters
         );
         if let Some(o) = c.oracle_obj {
             oracle_n += 1;
@@ -231,5 +301,8 @@ fn scaling_corpus_reaches_every_oracle_optimum() {
         "{} oracle instance(s) missed their known optimum",
         failures.len()
     );
-    assert_eq!(oracle_ok, oracle_n, "every oracle instance must be solved exactly");
+    assert_eq!(
+        oracle_ok, oracle_n,
+        "every oracle instance must be solved exactly"
+    );
 }

--- a/crates/pounce-convex/tests/bench293.rs
+++ b/crates/pounce-convex/tests/bench293.rs
@@ -1,0 +1,235 @@
+//! gh #293 — convex-QP scaling regression corpus (ignored by default).
+//!
+//!   cargo test -p pounce-convex --test bench293 -- --ignored --nocapture
+//!
+//! Solves a spread of convex QP/LP instances spanning the scaling regimes that
+//! stress the HSDE driver — well-scaled, huge-magnitude (#286), mixed-scale
+//! (#293 symptom 1), and uniformly/nearly-tiny curvature (#293 symptom 2) —
+//! plus random SPD box/equality QPs and pure LPs. The diagonal box QPs carry a
+//! solver-independent oracle (`x*_i = clamp(target_i, lb, ub)`), so their
+//! optima are checked absolutely.
+//!
+//! This is the corpus proxy that backed the #293 prototype investigation
+//! (proactive P-Ruiz and c-keyed objective scaling vs. the shipped reactive
+//! fallback). The proactive variants reached the same 15/15 oracle correctness
+//! but perturbed ~75% of already-converged problems (bit-identical objective on
+//! only 3–7 of 26 vs. the fallback's 23/26) and inflated the huge-magnitude
+//! regime from ~8 to ~18 iterations — so the surgical reactive fallback was
+//! kept. This harness remains as a regression guard: the shipped solver must
+//! reach every oracle optimum here, and its iteration counts should stay flat.
+
+use pounce_convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
+    let mut px = vec![0.0; prob.n];
+    prob.p_mul_add_pub(x, &mut px);
+    (0..prob.n).map(|i| 0.5 * x[i] * px[i] + prob.c[i] * x[i]).sum()
+}
+
+/// Deterministic LCG so the corpus is reproducible without an external rng.
+struct Lcg(u64);
+impl Lcg {
+    fn next_f64(&mut self) -> f64 {
+        self.0 = self.0.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        ((self.0 >> 11) as f64) / ((1u64 << 53) as f64)
+    }
+    fn sym(&mut self) -> f64 {
+        2.0 * self.next_f64() - 1.0
+    }
+}
+
+struct Case {
+    name: String,
+    prob: QpProblem,
+    /// Exact optimal objective if a closed-form oracle exists.
+    oracle_obj: Option<f64>,
+}
+
+/// Diagonal box QP: eig_i = scale·cond^(i/(n-1)), c_i = -eig_i·tgt_i, box
+/// [lb,ub]. Separable ⇒ x*_i = clamp(tgt_i, lb, ub) is an exact oracle.
+fn diag_box(name: &str, scale: f64, cond: f64, tgt: &[f64], lb: f64, ub: f64) -> Case {
+    let n = tgt.len();
+    let mut p_lower = Vec::with_capacity(n);
+    let mut c = Vec::with_capacity(n);
+    let mut xopt = vec![0.0; n];
+    for (i, &t) in tgt.iter().enumerate() {
+        let eig = scale * cond.powf(i as f64 / (n.max(2) - 1) as f64);
+        p_lower.push(Triplet::new(i, i, eig));
+        c.push(-eig * t);
+        xopt[i] = t.clamp(lb, ub);
+    }
+    let prob = QpProblem {
+        n,
+        p_lower,
+        c,
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![lb; n],
+        ub: vec![ub; n],
+    };
+    let oracle = objective(&prob, &xopt);
+    Case { name: name.to_string(), prob, oracle_obj: Some(oracle) }
+}
+
+/// Dense random SPD QP (P = MᵀM + εI) with a box; no oracle.
+fn rand_spd_box(name: &str, n: usize, seed: u64, pscale: f64, cscale: f64) -> Case {
+    let mut r = Lcg(seed);
+    let m: Vec<Vec<f64>> = (0..n).map(|_| (0..n).map(|_| r.sym()).collect()).collect();
+    let mut p_lower = Vec::new();
+    for i in 0..n {
+        for j in 0..=i {
+            let mut v: f64 = (0..n).map(|k| m[k][i] * m[k][j]).sum();
+            v *= pscale;
+            if i == j {
+                v += pscale;
+            }
+            if v != 0.0 {
+                p_lower.push(Triplet::new(i, j, v));
+            }
+        }
+    }
+    let c: Vec<f64> = (0..n).map(|_| cscale * r.sym()).collect();
+    let prob = QpProblem {
+        n,
+        p_lower,
+        c,
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![-1.0; n],
+        ub: vec![1.0; n],
+    };
+    Case { name: name.to_string(), prob, oracle_obj: None }
+}
+
+/// Random SPD QP with an equality constraint sum(x)=s and x>=0.
+fn rand_spd_eq(name: &str, n: usize, seed: u64, s: f64) -> Case {
+    let mut base = rand_spd_box(name, n, seed, 1.0, 1.0);
+    base.prob.lb = vec![0.0; n];
+    base.prob.ub = vec![f64::INFINITY; n];
+    base.prob.a = (0..n).map(|j| Triplet::new(0, j, 1.0)).collect();
+    base.prob.b = vec![s];
+    base
+}
+
+/// Pure LP: min cᵀx s.t. box.
+fn lp_box(name: &str, n: usize, seed: u64, cscale: f64) -> Case {
+    let mut r = Lcg(seed);
+    let c: Vec<f64> = (0..n).map(|_| cscale * r.sym()).collect();
+    let prob = QpProblem {
+        n,
+        p_lower: vec![],
+        c,
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![-1.0; n],
+        ub: vec![1.0; n],
+    };
+    Case { name: name.to_string(), prob, oracle_obj: None }
+}
+
+fn corpus() -> Vec<Case> {
+    let mut v = Vec::new();
+    let tgt6 = [1.5, -1.5, 0.3, -0.7, 2.0, -0.4];
+    let tgt3 = [1e11, -0.5, 2.0];
+
+    for &cond in &[1.0, 1e2, 1e4, 1e6] {
+        v.push(diag_box(&format!("diag_well_cond{cond:e}"), 1.0, cond, &tgt6, -1.0, 1.0));
+    }
+    for &sc in &[1e6, 1e12, 1e18] {
+        v.push(diag_box(&format!("diag_huge_{sc:e}"), sc, 1.0, &tgt6, -1.0, 1.0));
+    }
+    for &sc in &[1e-6, 1e-9, 1e-12, 1e-14, 1e-16] {
+        v.push(diag_box(&format!("diag_tiny_{sc:e}"), sc, 1.0, &tgt3, 0.0, f64::INFINITY));
+    }
+    for &cond in &[1e12, 1e18] {
+        v.push(diag_box(&format!("diag_mixed_cond{cond:e}"), 1e-6, cond, &tgt3, 0.0, f64::INFINITY));
+    }
+    v.push(diag_box("diag_tiny_boundbox", 1e-12, 1.0, &[1e11, 1e11], 0.0, 1e6));
+
+    for (i, &n) in [5usize, 10, 25, 50].iter().enumerate() {
+        v.push(rand_spd_box(&format!("rand_box_n{n}"), n, 1000 + i as u64, 1.0, 1.0));
+    }
+    v.push(rand_spd_box("rand_box_pbig", 20, 7, 1e6, 1.0));
+    v.push(rand_spd_box("rand_box_cbig", 20, 8, 1.0, 1e6));
+    v.push(rand_spd_box("rand_box_ptiny", 20, 9, 1e-8, 1.0));
+
+    for (i, &n) in [10usize, 30].iter().enumerate() {
+        v.push(rand_spd_eq(&format!("rand_eq_n{n}"), n, 2000 + i as u64, 3.0));
+    }
+
+    v.push(lp_box("lp_small", 10, 11, 1.0));
+    v.push(lp_box("lp_cbig", 15, 12, 1e6));
+
+    v
+}
+
+#[test]
+#[ignore]
+fn scaling_corpus_reaches_every_oracle_optimum() {
+    let short = |s: QpStatus| match s {
+        QpStatus::Optimal => "OPT",
+        QpStatus::OptimalInaccurate => "OPT~",
+        QpStatus::IterationLimit => "ITER",
+        QpStatus::NumericalFailure => "NUMF",
+        QpStatus::PrimalInfeasible => "PINF",
+        QpStatus::DualInfeasible => "DINF",
+    };
+
+    let cases = corpus();
+    let mut oracle_n = 0usize;
+    let mut oracle_ok = 0usize;
+    let mut clean = 0usize;
+    let mut iters_tot = 0usize;
+    let mut failures: Vec<String> = Vec::new();
+
+    println!("\n{:<26} {:>3} {:>6} {:>10} {:>6}", "case", "n", "status", "obj", "iters");
+    for c in &cases {
+        let sol = solve_qp_ipm(&c.prob, &QpOptions::default(), backend);
+        iters_tot += sol.iters;
+        if sol.status == QpStatus::Optimal {
+            clean += 1;
+        }
+        println!(
+            "{:<26} {:>3} {:>6} {:>10.3e} {:>6}",
+            c.name, c.prob.n, short(sol.status), sol.obj, sol.iters
+        );
+        if let Some(o) = c.oracle_obj {
+            oracle_n += 1;
+            let denom = o.abs().max(1.0);
+            if (sol.obj - o).abs() / denom < 1e-4 {
+                oracle_ok += 1;
+            } else {
+                failures.push(format!(
+                    "{}: obj {:.6e} != oracle {:.6e} (status {:?})",
+                    c.name, sol.obj, o, sol.status
+                ));
+            }
+        }
+    }
+
+    println!(
+        "\nsummary: oracle-correct {oracle_ok}/{oracle_n}, clean-Optimal {clean}/{}, total-iters {iters_tot}",
+        cases.len()
+    );
+    for f in &failures {
+        println!("  FAIL {f}");
+    }
+    assert!(
+        failures.is_empty(),
+        "{} oracle instance(s) missed their known optimum",
+        failures.len()
+    );
+    assert_eq!(oracle_ok, oracle_n, "every oracle instance must be solved exactly");
+}

--- a/crates/pounce-convex/tests/infeasibility.rs
+++ b/crates/pounce-convex/tests/infeasibility.rs
@@ -226,6 +226,41 @@ fn uniform_tiny_hessian_converges_not_iteration_limit() {
     );
 }
 
+/// gh #293 (symptom 2, constrained) — the tiny-curvature pathology also
+/// surfaces as `OptimalInaccurate` (not `IterationLimit`) when a constraint
+/// binds near the far-off optimum: HSDE returns a usable-but-loose iterate at
+/// the cap instead of running fully dry. The equilibrated retry must rescue
+/// this manifestation too, so the fix is keyed on the *regime* rather than a
+/// single status symbol. `min ½·1e-12·(x0²+x1²) − x1  s.t.  x1 ≤ 1e6, x ≥ 0`
+/// has optimum `x1* = 1e6`, `f* ≈ −1e6`.
+#[test]
+fn tiny_hessian_with_binding_inequality_converges_cleanly() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1e-12), Triplet::new(1, 1, 1e-12)],
+        c: vec![0.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 1, 1.0)],
+        h: vec![1e6],
+        lb: vec![0.0, 0.0],
+        ub: vec![f64::INFINITY, f64::INFINITY],
+    };
+    let sol = solve(&prob);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "expected clean Optimal (x1* = 1e6), got {:?} after {} iters",
+        sol.status,
+        sol.iters
+    );
+    assert!(
+        (sol.obj - (-1e6)).abs() <= 1e-3 * 1e6,
+        "obj = {} should be ≈ -1e6",
+        sol.obj
+    );
+}
+
 // --- Status / edge-case honesty (PR70 item C) -----------------------------
 //
 // A solver that stops early for *any* reason must say so. The danger these

--- a/crates/pounce-convex/tests/infeasibility.rs
+++ b/crates/pounce-convex/tests/infeasibility.rs
@@ -289,7 +289,12 @@ fn extreme_tiny_hessian_not_falsely_unbounded() {
          DualInfeasible after {} iters",
         sol.iters
     );
-    assert_eq!(sol.status, QpStatus::Optimal, "expected Optimal, got {:?}", sol.status);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "expected Optimal, got {:?}",
+        sol.status
+    );
     assert!(
         (sol.obj - (-5e19)).abs() <= 1e-3 * 5e19,
         "obj = {} should be ≈ -5e19",
@@ -351,7 +356,10 @@ fn tiny_curvature_iteration_limit_emits_scaling_warning() {
     };
     let gsol = solve(&good);
     assert_eq!(gsol.status, QpStatus::Optimal);
-    assert!(gsol.scaling_diagnostic(&good).is_none(), "well-scaled Optimal needs no warning");
+    assert!(
+        gsol.scaling_diagnostic(&good).is_none(),
+        "well-scaled Optimal needs no warning"
+    );
 }
 
 // --- Status / edge-case honesty (PR70 item C) -----------------------------

--- a/crates/pounce-convex/tests/infeasibility.rs
+++ b/crates/pounce-convex/tests/infeasibility.rs
@@ -190,6 +190,42 @@ fn mixed_scale_hessian_is_bounded_not_dual_infeasible() {
     );
 }
 
+/// gh #293 (symptom 2) — a *uniformly* tiny Hessian must converge, not exhaust
+/// the iteration budget. `min ½·1e-12·(x0² + x1²) − x1  s.t.  x ≥ 0` is bounded
+/// with the same optimum as above (`x1* = 1e12`, `f* = −5e11`). #290 stopped
+/// this from being falsely certified unbounded, but the default HSDE driver
+/// then merely ran out of iterations (obj ≈ −4.95e11 at `IterationLimit`)
+/// because its per-cone NT scaling never sees the 12-orders-below-O(1)
+/// curvature. The fix Ruiz-equilibrates and retries when HSDE hits the cap, so
+/// the solve now reports `Optimal` at the true optimum.
+#[test]
+fn uniform_tiny_hessian_converges_not_iteration_limit() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1e-12), Triplet::new(1, 1, 1e-12)],
+        c: vec![0.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![f64::INFINITY, f64::INFINITY],
+    };
+    let sol = solve(&prob);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "expected Optimal (x1* = 1e12, f* = -5e11), got {:?} after {} iters",
+        sol.status,
+        sol.iters
+    );
+    assert!(
+        (sol.obj - (-5e11)).abs() <= 1e-3 * 5e11,
+        "obj = {} should be ≈ -5e11",
+        sol.obj
+    );
+}
+
 // --- Status / edge-case honesty (PR70 item C) -----------------------------
 //
 // A solver that stops early for *any* reason must say so. The danger these

--- a/crates/pounce-convex/tests/infeasibility.rs
+++ b/crates/pounce-convex/tests/infeasibility.rs
@@ -261,6 +261,99 @@ fn tiny_hessian_with_binding_inequality_converges_cleanly() {
     );
 }
 
+/// gh #293 (machine-epsilon tail) — a spurious unboundedness certificate on a
+/// QP with genuine (if tiny) curvature must be refuted. `min ½·1e-20·(x0²+x1²)
+/// − x1  s.t.  x ≥ 0` is bounded (`x1* = 1e20`, `f* = −5e19`), but the raw HSDE
+/// solve reads the descent ray as a recession at `P ≈ 1e-20` (the recession
+/// curvature floor) and certifies `DualInfeasible`. The direct-driver reverify
+/// on the equilibrated problem exposes the true curvature and returns a clean
+/// finite optimum, which overrides the bogus certificate.
+#[test]
+fn extreme_tiny_hessian_not_falsely_unbounded() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1e-20), Triplet::new(1, 1, 1e-20)],
+        c: vec![0.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![f64::INFINITY, f64::INFINITY],
+    };
+    let sol = solve(&prob);
+    assert_ne!(
+        sol.status,
+        QpStatus::DualInfeasible,
+        "bounded problem (f* = -5e19) must not be certified unbounded; got \
+         DualInfeasible after {} iters",
+        sol.iters
+    );
+    assert_eq!(sol.status, QpStatus::Optimal, "expected Optimal, got {:?}", sol.status);
+    assert!(
+        (sol.obj - (-5e19)).abs() <= 1e-3 * 5e19,
+        "obj = {} should be ≈ -5e19",
+        sol.obj
+    );
+}
+
+/// gh #293 naive-caller guardrail — when no driver can converge a tiny-curvature
+/// problem at the default budget (here a uniformly tiny Hessian coupled through
+/// an equality constraint, which stays `IterationLimit`), the honest status must
+/// carry a scaling diagnostic that names tiny curvature as the cause. A
+/// well-scaled `Optimal` must carry none.
+#[test]
+fn tiny_curvature_iteration_limit_emits_scaling_warning() {
+    let n = 10;
+    let mut p_lower = Vec::new();
+    let mut c = Vec::new();
+    for i in 0..n {
+        p_lower.push(Triplet::new(i, i, 1e-13));
+        c.push(-1.0 - (i % 7) as f64);
+    }
+    let prob = QpProblem {
+        n,
+        p_lower,
+        c,
+        a: (0..n).map(|j| Triplet::new(0, j, 1.0)).collect(),
+        b: vec![1e13],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0; n],
+        ub: vec![f64::INFINITY; n],
+    };
+    let sol = solve(&prob);
+    // This case is genuinely unconvergeable at the default budget; the point is
+    // the diagnostic, not the status. Guard the premise, then the diagnostic.
+    if sol.status == QpStatus::Optimal {
+        // If a future improvement converges it, the guardrail is moot here.
+        return;
+    }
+    let warn = sol.scaling_diagnostic(&prob);
+    assert!(
+        warn.is_some(),
+        "tiny-curvature {:?} must carry a scaling diagnostic",
+        sol.status
+    );
+    assert!(warn.unwrap().contains("scaling warning"));
+
+    // A well-scaled optimal solve carries no diagnostic.
+    let good = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+        c: vec![-2.0, -2.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![10.0, 10.0],
+    };
+    let gsol = solve(&good);
+    assert_eq!(gsol.status, QpStatus::Optimal);
+    assert!(gsol.scaling_diagnostic(&good).is_none(), "well-scaled Optimal needs no warning");
+}
+
 // --- Status / edge-case honesty (PR70 item C) -----------------------------
 //
 // A solver that stops early for *any* reason must say so. The danger these

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -222,6 +222,18 @@ fn solution_dict<'py>(
         rd.set_item("complementarity", r.complementarity)?;
         rd.set_item("kkt_error", r.kkt_error())?;
         d.set_item("residuals", rd)?;
+
+        // gh #293 naive-caller guardrail: attach a tiny-curvature scaling
+        // warning when the solve did not cleanly converge (or returned a
+        // machine-epsilon-tail certificate) on an ill-scaled objective, so a
+        // caller inspecting `result["obj"]` is told *why* it may be off. Only
+        // for the orthant QP/LP path — the ratio test reads `G` as inequality
+        // rows, which is meaningless for second-order/exp/power cone blocks.
+        if cones.is_empty() {
+            if let Some(warn) = sol.scaling_diagnostic(p) {
+                d.set_item("scaling_warning", warn)?;
+            }
+        }
     }
 
     // Per-iteration convergence trace (empty unless `collect_iterates` set).

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -124,6 +124,13 @@ class QpResult:
         ``iter``, ``objective``, ``primal_infeasibility``,
         ``dual_infeasibility``, ``mu``, ``alpha_primal``, ``alpha_dual``.
         Empty unless the solve was called with ``collect_iterates=True``.
+    scaling_warning:
+        ``None`` on a cleanly-solved, well-scaled problem. Otherwise a
+        human-readable warning that the objective curvature ``‖P‖`` is tiny
+        relative to the problem data and the (non-``optimal``) result may be
+        inaccurate — set only when the solve did not converge cleanly *and* the
+        problem is in that ill-scaled regime, with an actionable remedy
+        (rescale the objective, or cross-check with a reference solver).
     """
 
     status: str
@@ -136,6 +143,7 @@ class QpResult:
     iters: int
     residuals: Optional[dict] = None
     iterates: list = field(default_factory=list)
+    scaling_warning: Optional[str] = None
 
     @property
     def success(self) -> bool:
@@ -449,6 +457,7 @@ def _to_result(d: dict) -> QpResult:
         iters=int(d["iters"]),
         residuals=d.get("residuals"),
         iterates=list(d.get("iterates", [])),
+        scaling_warning=d.get("scaling_warning"),
     )
 
 


### PR DESCRIPTION
Closes #293 (symptom 2 and the residual tail; symptom 1 was #309).

## Problem

Convex QPs whose Hessian curvature is tiny relative to the linear/constraint data — the shape a portfolio/least-squares user hits when a regularizer or near-linear objective makes curvature small — were silently wrong or silently truncated, with nothing in the status to flag it.

`min ½·1e-12·(x0²+x1²) − x1 s.t. x ≥ 0` (bounded; `x1*=1e12`, `f*=−5e11`):

| | status | objective | iters |
|---|---|---|---|
| before | `iteration_limit` | −4.95e11 | 199 |
| after | `optimal` | −5e11 | 22 |
| oracle | optimal | −5e11 | — |

And in the machine-epsilon tail, `min ½·1e-20·(x0²+x1²) − x1 s.t. x ≥ 0` (bounded; `f*=−5e19`):

| | status | objective |
|---|---|---|
| before | `dual_infeasible` (wrong) | −1.6e5 |
| after | `optimal` | −5e19 |
| oracle | optimal | −5e19 |

## Cause

The default HSDE driver conditions the *constraint* system through per-cone NT scaling but does nothing about a Hessian 12+ orders below O(1): the embedding's iterates crawl toward the far-off optimum and exhaust the budget (`iteration_limit` unconstrained, `optimal_inaccurate` when a constraint binds). In the `P≈1e-20` tail, a bounded descent ray's normalized curvature `dᵀPd/‖d‖²` sinks to the recession floor and the ray is misread as a genuine recession → spurious `dual_infeasible` (the #290/#309 failure resurfacing below the curvature floor).

## Fix

Layered, each layer earning its place with a case it alone fixes:

- **Convergence fallback.** On any non-clean HSDE status (`numerical_failure` / `iteration_limit` / `optimal_inaccurate`) retry once with Ruiz equilibration (lifts `P̂` to O(1) so NT scaling sees the curvature). For the two honest statuses the retry is accepted **only when it reaches a clean `optimal`**, so a genuinely hard problem keeps its truthful status and no infeasible/unbounded verdict can be introduced.
- **Spurious-unbounded reverify.** On `dual_infeasible` for a QP with `P ≠ 0`, re-solve the equilibrated problem with the direct driver; a clean finite `optimal` refutes the certificate and is returned. A genuine recession lies in `null(P)` and survives, so real unbounded QPs/LPs are unaffected (gated to `P ≠ 0`).
- **Scaling warning (the guardrail).** For the residue no driver converges at the default budget (e.g. a uniformly tiny Hessian coupled through an equality, which stays `iteration_limit`), `QpSolution::scaling_diagnostic(&prob)` returns an actionable warning when the status is non-clean **and** `‖P‖∞` is >6 orders below the data. Surfaced on the CLI (stderr) and as a `scaling_warning` key in the Python `solve_qp` result. Clean `optimal` / well-scaled problems emit nothing.

**Rejected: the proactive root-cause fix** (equilibrate every HSDE-QP up front, incl. the issue's c-keyed objective scaling). Prototyped and benchmarked (`tests/bench293.rs`): it reaches the same 15/15 oracle correctness but perturbs ~75% of already-converged problems (bit-identical objective on 3–7/26 vs the fallback's 23/26) and inflates the huge-magnitude #286 regime from ~8 to ~18 iterations. The surgical reactive fallback touches only the broken cases, so it was kept.

## Blast radius

Corpus proxy (26 convex QP/LP instances, 15 with a closed-form oracle) is unchanged by these additions: 15/15 oracle-correct, 26/26 clean-optimal, 373 total iters — identical to the parent. The fallback and reverify fire only after a non-clean solve, so already-converging problems are byte-for-byte unchanged. Cone problems never reach this path (exp/power/SOC go through `solve_socp_ipm`; Ruiz is orthant-only). Caveat: the full 138-problem Maros-Mészáros corpus (~2 GB gitignored `.nl`) is not in the container, so the sweep is the in-repo proxy plus existing suites, not the upstream set.

## Tests

New regression tests in `tests/infeasibility.rs`, each failing on the parent for the stated reason:
- `uniform_tiny_hessian_converges_not_iteration_limit` — was `iteration_limit`.
- `tiny_hessian_with_binding_inequality_converges_cleanly` — was `optimal_inaccurate`.
- `extreme_tiny_hessian_not_falsely_unbounded` — was a wrong `dual_infeasible`.
- `tiny_curvature_iteration_limit_emits_scaling_warning` — asserts the diagnostic fires on the unconvergeable case and is absent on a well-scaled `optimal`.

`tests/bench293.rs` (`#[ignore]`) is retained as a scaling-regression corpus. Full `pounce-convex` + `pounce-cli` suites green; `pounce-py`/`pounce-cli` build clean; `cargo fmt --all -- --check` and `cargo clippy` clean (no new warnings).

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a (no user-facing doc surface changed; behavior is an internal convergence/robustness fix plus a diagnostic string)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GBBYNSJr9inCcFNVBUcvdw)_