### PR TITLE
Fix qp-active-set internal error on rank-deficient equality blocks (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `qp-active-set` internal error / churn on rank-deficient equality blocks (#313)
+
+- **`solver_selection=qp-active-set` now solves a QP whose equality block is
+  exactly rank-deficient but consistent** (one row an exact scalar multiple of
+  another — routine when a constraint is written twice or a generator emits a
+  scaled duplicate). Such a model with finite variable bounds and no inequality
+  row previously aborted with `INTERNAL ERROR: Unknown SolverReturn value.` and
+  exit 1 (zero iterations, `objective = 0.0`), while `qp-ipm` and `nlp` solved
+  it correctly. The issue's reproduction now returns the exact optimum
+  `x* = (0.5, 1.5, 3.0)`, `objective = -6.75`.
+  - **Cause.** The equality+bounds path pins every equality row in each KKT and
+    cannot prune a redundant one itself. The shared rank-repair guard is keyed
+    off a *reported* recoverable factorization failure, but the inertia-control
+    δ·I shift grows until the backend stops flagging the singular constraint
+    block (masking the null direction) and returns a garbage solution instead of
+    failing — so the guard never fired.
+  - **Fix.** `factor_pinned_primal` now treats a nonzero inertia shift on a
+    pinned KKT as a red flag: it rank-reveals the pinned rows and, if any is
+    redundant, reports the recoverable failure the existing callers already
+    prune on. The equality+bounds path factors its initial point through that
+    helper and, on such a failure, delegates to the rank-deficiency-aware
+    general path. Full-rank problems (the `δ == 0` common case) are unaffected.
+
 ### Fixed — `curve_fit` two-parameter bounds: the last silently-transposing spellings now raise (#260)
 
 - **`pounce.curve_fit` no longer silently transposes a 2-parameter box when the

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -181,7 +181,36 @@ impl ParametricActiveSetSolver {
         }
         rhs[n..n + k_c].copy_from_slice(cons_targets);
         rhs[n + k_c..n + k_c + k_b].copy_from_slice(bound_targets);
-        self.factorize_with_inertia_control(kkt, &mut rhs, (k_c + k_b) as i32, n, opts)?;
+        let delta =
+            self.factorize_with_inertia_control(kkt, &mut rhs, (k_c + k_b) as i32, n, opts)?;
+
+        // Masked-rank-deficiency guard. No H-block δ·I shift can repair a
+        // rank-deficient *constraint* block — but a large enough δ can grow
+        // the H diagonal until the backend stops flagging the singular block
+        // and returns a garbage solution instead of a failure (feral masks
+        // the null direction around δ≈1e8). The pinned callers
+        // (`cold_general_initial`, `solve_with_working_set`, and the #313
+        // equality+bounds path) rely on a *reported* recoverable failure to
+        // trigger their linear-independence prune; a masked deficiency slips
+        // past silently and the solve churns to `MaxIter` (or worse, reports a
+        // wrong `Optimal`). A nonzero δ on a pinned KKT is the tell: only then
+        // do we rank-reveal the pinned rows, and if any is redundant we
+        // convert the spurious success into the recoverable failure the
+        // callers already know how to prune. A δ > 0 with a full-rank
+        // constraint block is a legitimate indefinite-reduced-Hessian shift
+        // and passes through untouched (the common case is δ == 0, which skips
+        // the probe entirely).
+        if delta > 0.0 {
+            let (kc, kb) =
+                independent_active_subset(&mut self.linsol, qp, active_cons, active_bounds);
+            if kc.len() < k_c || kb.len() < k_b {
+                return Err(QpError::LinearSolverFailure(
+                    "pinned KKT constraint block is rank-deficient (inertia shift masked a \
+                     singular constraint block); prune to a linearly-independent subset"
+                        .into(),
+                ));
+            }
+        }
         Ok(rhs[..n].to_vec())
     }
 
@@ -409,13 +438,34 @@ impl ParametricActiveSetSolver {
         let m = qp.m;
 
         // ---- 1. Equality-relaxed initial point ----
-        let kkt0 = KktTriplet::assemble_equality_only(qp);
-        let mut rhs0 = rhs_equality_only(qp);
-        self.factorize_with_inertia_control(kkt0, &mut rhs0, m as i32, qp.n, opts)?;
+        // A rank-deficient equality block — redundant / linearly dependent
+        // rows, e.g. one row an exact scalar multiple of another — makes the
+        // saddle KKT singular, and no §4.5 H-block shift can rescue a
+        // rank-deficient *constraint* block. This path pins ALL `m` equality
+        // rows in every inner-loop KKT (`assemble_equality_plus_bounds` has no
+        // per-row selection), so it cannot prune the dependent rows itself.
+        // Factor through `factor_pinned_primal`, which reports a recoverable
+        // failure on such a block (whether the backend exhausted the inertia
+        // loop or a large shift masked the singular block — see its
+        // masked-rank-deficiency guard); on that signal, delegate to
+        // `solve_general`, whose `cold_general_initial` + inner-loop
+        // linear-independence guard prune the equalities to a maximal
+        // independent subset (a dropped row is a linear combination of the
+        // kept ones, hence satisfied at any constraint-consistent point) and
+        // reach the exact vertex. Without this the solve surfaced to the user
+        // as `InternalError` / exit 1, or churned to `MaxIter` (#313).
+        let eq_rows: Vec<usize> = (0..m).collect();
+        let eq_targets: Vec<Number> = eq_rows.iter().map(|&r| qp.bl[r]).collect();
+        let mut x: Vec<Number> =
+            match self.factor_pinned_primal(qp, &eq_rows, &eq_targets, &[], &[], opts) {
+                Ok(x) => x,
+                Err(ref e) if e.is_recoverable_factorization_failure() => {
+                    return self.solve_general(qp, None, opts);
+                }
+                Err(e) => return Err(e),
+            };
         let mut n_refactor: u32 = 1;
         let mut n_changes: u32 = 0;
-
-        let mut x: Vec<Number> = rhs0[..n].to_vec();
 
         // ---- 2. Bound-feasibility check ----
         // The cheap equality-relaxed cold start may land outside

--- a/crates/pounce-qp/tests/rank_deficient_active_set.rs
+++ b/crates/pounce-qp/tests/rank_deficient_active_set.rs
@@ -100,6 +100,69 @@ fn warm_start_prunes_redundant_equality_rows() {
     );
 }
 
+/// Equality+bounds path (#313): a strictly convex QP whose ONLY general
+/// constraints are equalities, one row an exact scalar multiple of another,
+/// with finite variable bounds and no inequality row. This routes through
+/// `solve_equality_plus_bounds`, which pins every equality row in each KKT and
+/// (before the fix) propagated the rank-deficient factor's failure straight to
+/// the user as `InternalError` / exit 1. The path now delegates to the
+/// rank-deficiency-aware `solve_general` and reaches the exact optimum.
+///
+/// Fixture (the issue's reproduction, n = 3):
+///   min  ½(x₀² + x₁² + x₂²) − x₀ − 2x₁ − 3x₂
+///   s.t.   x₀ +  x₁       = 2          (row 1)
+///         2x₀ + 2x₁       = 4          (row 2 — exactly 2× row 1, redundant)
+///         −10 ≤ x ≤ 10
+/// Closed form: x* = (0.5, 1.5, 3.0), f* = −6.75 (all bounds inactive).
+#[test]
+fn equality_plus_bounds_prunes_exact_rank_deficient_rows() {
+    // H = I₃ (strictly convex): three unit diagonal entries.
+    let h_space = SymTMatrixSpace::new(3, vec![1, 2, 3], vec![1, 2, 3]);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&[1.0, 1.0, 1.0]);
+
+    // Rows 1,2: x₀+x₁ (=2) and 2x₀+2x₁ (=4) — exactly 2× row 1 (rank 1).
+    let a_space = GenTMatrixSpace::new(2, 3, vec![1, 1, 2, 2], vec![1, 2, 1, 2]);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&[1.0, 1.0, 2.0, 2.0]);
+
+    let g = [-1.0, -2.0, -3.0];
+    let bl = [2.0, 4.0];
+    let bu = [2.0, 4.0];
+    let xl = [-10.0, -10.0, -10.0];
+    let xu = [10.0, 10.0, 10.0];
+
+    let qp = QpProblem {
+        n: 3,
+        m: 2,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let mut solver =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let sol = solver
+        .solve(&qp, None, &opts())
+        .expect("exact rank-deficient equality+bounds QP must solve, not error (#313)");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "status = {:?}", sol.status);
+    assert!((sol.x[0] - 0.5).abs() < 1e-8, "x[0] = {}", sol.x[0]);
+    assert!((sol.x[1] - 1.5).abs() < 1e-8, "x[1] = {}", sol.x[1]);
+    assert!((sol.x[2] - 3.0).abs() < 1e-8, "x[2] = {}", sol.x[2]);
+    assert!((sol.obj - (-6.75)).abs() < 1e-8, "obj = {}", sol.obj);
+    // The dropped redundant equality is still satisfied: 2·(x₀+x₁) = 4.
+    assert!(
+        (2.0 * (sol.x[0] + sol.x[1]) - 4.0).abs() < 1e-7,
+        "redundant row violated"
+    );
+}
+
 /// Cold path: `solve(qp, None, ..)` routes through `cold_general_initial`,
 /// which pins ALL equality rows up front. With redundant equalities that
 /// factor is singular; the guard prunes the redundant row so the cold start


### PR DESCRIPTION
## Problem

`solver_selection=qp-active-set` aborts on a small, feasible, strictly convex QP whose equality block is **exactly rank-deficient but consistent** (one row a scalar multiple of another), with finite variable bounds and no inequality row. It does zero iterations and returns `objective = 0.0`; the same model solves under `qp-ipm` and `nlp`. Redundant-but-consistent equality rows are routine in modelling (a constraint written twice, a scaled duplicate from a generator), so this is reachable without adversarial intent.

Reproduction (issue #313):

```
min  0.5 (x0^2 + x1^2 + x2^2) - x0 - 2 x1 - 3 x2
s.t.   x0 +   x1  = 2
      2 x0 + 2 x1 = 4          (exactly 2 x row 1 — redundant, consistent)
      -10 <= x <= 10
```

| | status | objective | iters |
|---|---|---|---|
| before (shipping backend) | `InternalError` (exit 1) | 0.0 | 0 |
| before (feral, in-tree) | `MaxIter` | -2.0 | 1000 |
| after | `Optimal` | **-6.75** | few |
| oracle (closed form + `qp-ipm`) | Optimal | **-6.75** at `x* = (0.5, 1.5, 3.0)` | — |

## Cause

The model routes to `solve_equality_plus_bounds`, which pins **every** equality row in each KKT (`assemble_equality_plus_bounds` has no per-row selection) and so cannot prune a redundant row itself. The codebase's shared rank-repair machinery (`independent_active_subset`) is triggered only by a *reported* recoverable factorization failure.

But `factorize_with_inertia_control` grows the H-block δ·I shift until the backend stops flagging the singular constraint block — feral **masks** the null direction around δ≈1e8 and returns a garbage solution (`Ok(δ=1e8)`) instead of failing. No H-block shift can legitimately repair a rank-deficient *constraint* block, so this "success" is spurious. It bypassed every existing prune guard: the equality+bounds path then either propagated a hard error (backends that do keep flagging it) or churned to `MaxIter` (feral).

## Fix

- **`factor_pinned_primal`** — add a masked-rank-deficiency guard. A nonzero δ on a pinned KKT is the tell, so rank-reveal the pinned rows and, if any is redundant, convert the spurious success into the recoverable failure the existing callers (`cold_general_initial`, `solve_with_working_set`) already know how to prune. A δ > 0 with a full-rank constraint block is a legitimate indefinite-reduced-Hessian shift and passes through unchanged; the common δ == 0 case skips the probe entirely (zero overhead).
- **`solve_equality_plus_bounds`** — factor the equality-relaxed initial point through `factor_pinned_primal` and, on a recoverable failure, delegate to the rank-deficiency-aware `solve_general`, which prunes the equalities to a maximal independent subset (a dropped row is a combination of the kept ones, hence satisfied at any consistent point) and reaches the exact vertex.

Rejected alternative: catching the failure only at the direct `factorize_with_inertia_control` call in `solve_equality_plus_bounds`. That does not fire under backends that mask the deficiency (feral returns `Ok`), and `solve_general` on its own has the same blind spot — so the masking had to be neutralized at the shared `factor_pinned_primal` helper, which is where the reliable signal now originates for all three pinned callers.

Scope note: the issue's "likely-adjacent" *near*-rank-deficient false-infeasibility (n=8, smallest singular value ~4.3e-7) is a distinct failure mode — those rows sit above the rank-reveal tolerance, so it is an ill-conditioning problem, not a pruning one — and the issue gives only a description, no exact model. It is intentionally **not** addressed here.

## Blast radius

Confined to the rank-deficient / masked-shift case. The added probe runs only when the inertia shift fired (`δ > 0`); the overwhelmingly common `δ == 0` factor path is bit-identical. Full-rank δ>0 shifts (indefinite reduced Hessian) are unchanged. No routing changes for full-rank equality+bounds problems.

- `pounce-qp`: 96 tests pass
- `pounce-algorithm` + `pounce-cinterface`: 492 tests pass
- `pounce-convex` + `pounce-cli`: pass

## Tests

`equality_plus_bounds_prunes_exact_rank_deficient_rows` in `crates/pounce-qp/tests/rank_deficient_active_set.rs` reproduces the issue's exact model and asserts `x* = (0.5, 1.5, 3.0)`, `f* = -6.75`, status `Optimal`, plus that the dropped redundant row stays satisfied. Verified to **fail on the parent commit** (`status = MaxIter` under the in-tree feral backend — the same root cause as the reported `InternalError` under a backend that reports the singular factor) and pass with the fix.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a (internal solver-numerics fix, no user-facing routing/problem-class change)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean (for touched crates)
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Us9k2zHbqDBsLvKqBBRBht)_