### PR TITLE
Report inequality-slack recession rays as unbounded (#314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — unbounded NLP with an inequality-slack recession ray reported as unbounded (#314)
+
+- **An unbounded-below NLP whose recession ray increases an inequality
+  constraint's slack is now correctly reported as `DivergingIterates`
+  (unbounded) instead of a generic `ErrorInStepComputation`.** Completes the
+  #274 family for the inequality-slack recession shape:
+  `min -(x1³ + x2³)  s.t.  x1 + x2 ≥ 1`, `x1, x2` free is unbounded below along
+  the feasible ray `x1 = t, x2 = 0`. The core "reported as solved"
+  defect (`solve_result_num = 100`, exit 0) the adversary bot filed against
+  was already fixed on `main` (the bot ran a stale pre-fix binary); this makes
+  the CLI's verdict *correct* and consistent with the library, which already
+  reported `Diverging_Iterates`.
+  - Root cause: the #285 checked recession-ray proof already handled a ray in
+    `null(A_eq)`, but a variable-swap bug in its
+    `recession_blocked_by_inequality` gate returned the lower/upper finite-bound
+    indicator vectors transposed, inverting the bound semantics. A ray that
+    *increases* an inequality's slack (moves deeper into the feasible region)
+    was spuriously treated as blocked, so the proof never fired and the KKT step
+    broke down first. The proof is otherwise unchanged: it still requires a
+    feasible large-norm witness, an unbounded free-variable escape side, a
+    `null(A_eq)` direction, strict objective descent, and no finitely-bounded
+    inequality actually driven toward its bound — so a bounded feasible region
+    can never manufacture a false unbounded verdict.
+
 ### Fixed — convex QP convergence and honesty on tiny-curvature objectives (#293)
 
 - **A convex QP whose Hessian curvature is tiny relative to its linear/constraint

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -716,7 +716,14 @@ impl IpoptAlgorithm {
             ones_du.set(1.0);
             let mut has_dub = jd_x.make_new();
             nlp.pd_u().mult_vector(1.0, &*ones_du, 0.0, &mut *has_dub);
-            (has_dub, has_dlb)
+            // Order matters: bind `(has_dlb, has_dub)` in that exact order so
+            // the finite-lower / finite-upper indicators are not transposed.
+            // #314: this pair was returned swapped, inverting the bound
+            // semantics below — a ray *increasing* a lower-bounded row (moving
+            // deeper into the feasible set, slack growing) was wrongly treated
+            // as blocked, so a genuine inequality-slack recession ray was never
+            // proven unbounded.
+            (has_dlb, has_dub)
         };
 
         let downcast = |v: &dyn Vector| -> Option<Vec<Number>> {

--- a/crates/pounce-cli/tests/fixtures/unbounded_cubic.nl
+++ b/crates/pounce-cli/tests/fixtures/unbounded_cubic.nl
@@ -1,0 +1,37 @@
+g3 1 1 0	# problem unknown
+ 2 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 2 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+O0 0
+o16
+o0
+o5
+v0
+n3
+o5
+v1
+n3
+x2
+0 1.0
+1 1.0
+r
+2 1.0
+b
+3
+3
+k1
+1
+J0 2
+0 1
+1 1
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/issue_314_unbounded_cubic_not_solved.rs
+++ b/crates/pounce-cli/tests/issue_314_unbounded_cubic_not_solved.rs
@@ -1,0 +1,137 @@
+//! gh #314 — an unbounded-below NLP whose recession ray increases an
+//! *inequality's slack* must not be reported in the AMPL *solved* family.
+//!
+//! Fixture `unbounded_cubic.nl` is
+//!
+//! ```text
+//! min  -(x1^3 + x2^3)   s.t.  x1 + x2 >= 1,   x1, x2 free
+//! ```
+//!
+//! It is unbounded below: the feasible ray `x1 = t, x2 = 0` (`t >= 1`) drives
+//! the objective `-t^3 -> -inf`. This is the same *family* as #274 (an
+//! unbounded solve must never be advertised as solved), but a distinct trigger:
+//! the recession direction `d = (1, 1)` is feasible, strictly lowers the
+//! objective, and *increases the slack* of the inequality `x1 + x2 >= 1`
+//! (moves deeper into the feasible region).
+//!
+//! The core defect this pins: the adversary bot (running a stale pre-fix
+//! binary) observed this land in the AMPL solved family
+//! (`solve_result_num = 100`, `SolvedToAcceptableLevel`, exit 0), so a
+//! Pyomo/AMPL caller silently loaded a diverging iterate
+//! (`x ~ 5.8e18`, `obj ~ -3.9e56`) as `optimal`.
+//!
+//! On current main the "reported as solved" defect is already gone. #314
+//! additionally makes the CLI's verdict the *correct* one: `DivergingIterates`
+//! (the AMPL 300 "unbounded" range), matching what the library reports for the
+//! same model. The #285 checked recession-ray proof already handled a
+//! recession ray in `null(A_eq)`; a variable-swap bug in its
+//! `recession_blocked_by_inequality` gate inverted the bound semantics and
+//! spuriously rejected a ray that *increases* an inequality's slack. Fixing
+//! that swap completes the #274 family for the inequality-slack recession
+//! shape.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("unbounded_cubic.nl");
+    p
+}
+
+fn solve_result_num(text: &str) -> i32 {
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("objno ") {
+            if let Some(code) = rest.split_whitespace().nth(1) {
+                return code.parse().expect("objno code parses");
+            }
+        }
+    }
+    panic!("no `objno` line in .sol:\n{text}");
+}
+
+/// The core assertion (Deliverable A): the `.sol` must not claim the solve
+/// succeeded. A `solve_result_num` in `0..=199` (0..99 solved, 100..199
+/// solved-with-warning) makes Pyomo report `TerminationCondition.optimal` and
+/// load the diverging iterate.
+#[test]
+fn unbounded_cubic_is_not_reported_as_solved() {
+    let dir = std::env::temp_dir();
+    let sol = dir.join("pounce_issue314_unbounded_cubic.sol");
+    let _ = std::fs::remove_file(&sol);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .output()
+        .expect("spawn pounce");
+
+    // Under `-AMPL` the termination travels in the file, so exit stays 0.
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+
+    let text = std::fs::read_to_string(&sol).expect("read .sol");
+    let srn = solve_result_num(&text);
+
+    // Deliverable A — never in the solved family.
+    assert!(
+        !(0..200).contains(&srn),
+        "unbounded NLP reported in the AMPL solved family (solve_result_num={srn}); \
+         0..99 = solved and 100..199 = solved-with-warning both make Pyomo report \
+         TerminationCondition.optimal and load the diverging iterate:\n{text}"
+    );
+
+    // Deliverable B — the correct verdict is unbounded (DivergingIterates),
+    // which maps to the AMPL 300..399 "unbounded" range.
+    assert!(
+        (300..400).contains(&srn),
+        "expected the unbounded-family solve_result_num (300..399, \
+         DivergingIterates), got {srn}:\n{text}"
+    );
+
+    assert!(
+        !text.contains("SolvedToAcceptableLevel") && !text.contains("Optimal"),
+        "an unbounded solve must not be labelled solved/optimal:\n{text}"
+    );
+}
+
+/// The CLI's verdict must match what the library reports for the same model,
+/// and must exit non-zero outside `-AMPL` mode. Before #314 the CLI wrote
+/// `ErrorInStepComputation` (srn 500) while the library reported
+/// `Diverging_Iterates` — the two surfaces disagreed about *why* the solve
+/// failed.
+#[test]
+fn cli_reports_diverging_and_exits_nonzero() {
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .output()
+        .expect("spawn pounce");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        combined.contains("diverging") || combined.contains("Diverging"),
+        "expected the DivergingIterates verdict the library reports:\n{combined}"
+    );
+    assert!(
+        !combined.contains("Solved To Acceptable Level"),
+        "must not claim acceptable-level convergence:\n{combined}"
+    );
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "a failed solve must exit non-zero outside -AMPL mode"
+    );
+}


### PR DESCRIPTION
Fixes #314.

## The core "reported as solved" defect was already fixed on main

The adversary bot ran a **stale pre-fix binary** (commit `2c49fad0`), which is
why the issue looked open. On current `main` (fresh binary) the unbounded cubic
already does **not** land in the AMPL solved family: the `.sol` carries
`objno 0 500` (`ErrorInStepComputation` — the failure family), Pyomo reports
`internalSolverError`, and the library `pounce.minimize(...)` reports
`Diverging_Iterates` (success=False). The "reported as `SolvedToAcceptableLevel`,
`solve_result_num=100`, exit 0" behavior is gone.

## Deliverable A — regression test guarding the core defect

Adds `crates/pounce-cli/tests/issue_314_unbounded_cubic_not_solved.rs` with a
committed `.nl` fixture (`tests/fixtures/unbounded_cubic.nl`) for
`min -(x1³ + x2³) s.t. x1 + x2 ≥ 1`, `x1, x2` free. It asserts under `-AMPL`
that the `.sol` `solve_result_num` is **not** in the solved family (`0..=199`),
that it is in the unbounded family (`300..=399`), that the message is not
`SolvedToAcceptableLevel`/`Optimal`, and that the CLI exits non-zero outside
`-AMPL`. This pins the adversary finding so it can never regress.

## Deliverable B — achieved: report UNBOUNDED (500 → 300), consistent with the library

Before: CLI reported `ErrorInStepComputation` (srn 500) while the library
reported `Diverging_Iterates`. Now both report `DivergingIterates` (srn 300),
the correct verdict for a genuinely unbounded-below problem.

**Root cause.** The #285 checked recession-ray proof already handled a recession
ray in `null(A_eq)`, and already had a `recession_blocked_by_inequality` gate
intended to *allow* directions that increase an inequality's slack (move deeper
into the feasible region). But a variable-swap bug returned the finite
lower/upper-bound indicator vectors **transposed** — `(has_dub, has_dlb)` where
the destructuring expected `(has_dlb, has_dub)` — inverting the bound semantics.
For the cubic's recession direction `d = (1, 1)`, the inequality `x1 + x2 ≥ 1` is
lower-bounded and `d` *increases* its value (slack grows), which should never
block; the swap made it read as blocked, so condition (4) failed every iteration
and the proof never fired. The one-line fix restores the documented tuple order.

**No false positives on bounded problems (P0).** Every other proof condition is
unchanged: a feasible large-norm (`≥ 1e10`) witness, an over-floor component free
to escape toward a side with no finite variable bound, a `null(A_eq)` direction,
strict objective descent, and — now correctly — no finitely-bounded inequality
actually driven toward its bound. A bounded feasible region cannot supply a
growing sequence of feasible over-floor iterates, so the feasible-witness
condition alone forecloses a false unbounded verdict; the inequality gate is
defense-in-depth. Verified directly: a battery of bounded free-variable +
inequality problems (upper-bounded inequality with `min -Σx`, boxed cubic,
`min x s.t. x ≥ -1e6`) all report `solve_result_num=0` (solved), none newly
unbounded. HS071 and the #285 bounded controls (`x0 ≤ 10`; pinning equalities;
free var capped by inequality) stay solved.

## Benchmark regression

Built before/after CLI binaries and ran all 44 `benchmarks/**/*.nl` through both
with `-AMPL --sol-output` and a 90 s per-file timeout:
**0 `solve_result_num` differences.**

## Tests

`cargo test --workspace --release` is fully green, including the #248 / #252 /
#274 / #285 unboundedness/recession suites and `optimize_hs71`. `cargo fmt --all`
applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
