### PR TITLE
Set final_scaled_objective on the active-set path; no more nan (#313)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — active-set path printed a `nan` scaled objective (#313)
+
+- On the active-set (`qp-active-set` / SQP) path, `final_scaled_objective` was
+  left at its `NaN` default — the result block populated the unscaled objective
+  and mirrored the residuals but never the scaled objective — so even a clean
+  optimal solve printed `Objective ...: nan  <unscaled>`. It now mirrors the
+  unscaled value (the SQP path does not thread `nlp_scaling`, so the two are
+  equal). The rank-deficient-but-consistent equality QP from #313 (`x0+x1==2`
+  with a redundant `2x0+2x1==4`) solves correctly on the active-set path
+  (objective −6.75, the same value `qp-ipm`/`nlp` find); the "INTERNAL ERROR:
+  Unknown SolverReturn value" the issue reported was from a stale pre-fix
+  binary and does not occur on a current build. A regression test pins both the
+  correct solve and the finite objective.
+
 ### Fixed — unbounded NLP with an inequality-slack recession ray reported as unbounded (#314)
 
 - **An unbounded-below NLP whose recession ray increases an inequality

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -858,6 +858,13 @@ impl IpoptApplication {
             let mut stats = self.statistics.borrow_mut();
             stats.iteration_count = res.n_iter as Index;
             stats.final_objective = res.obj;
+            // `final_scaled_objective` defaults to NaN; the SQP path does not
+            // thread nlp_scaling through the objective (same as the residuals
+            // mirrored below), so the scaled objective equals the unscaled
+            // one. Without this it stayed NaN and the console printed
+            // "Objective ...: nan  <unscaled>" on every active-set solve
+            // (gh #313), even on a clean optimal solve.
+            stats.final_scaled_objective = res.obj;
             stats.final_dual_inf = res.final_stationarity;
             stats.final_constr_viol = res.final_constr_viol;
             stats.final_compl = 0.0; // SQP has no barrier — no compl term.

--- a/crates/pounce-cli/tests/fixtures/rankdef_eq_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/rankdef_eq_qp.nl
@@ -1,0 +1,52 @@
+g3 1 1 0	# problem unknown
+ 3 2 1 0 2 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 3 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 3 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+n0
+O0 0
+o2
+n0.5
+o54
+3
+o5
+v0
+n2
+o5
+v1
+n2
+o5
+v2
+n2
+x3
+0 0.0
+1 0.0
+2 0.0
+r
+4 2.0
+4 4.0
+b
+0 -10 10
+0 -10 10
+0 -10 10
+k2
+2
+4
+J0 2
+0 1
+1 1
+J1 2
+0 2
+1 2
+G0 3
+0 -1
+1 -2
+2 -3

--- a/crates/pounce-cli/tests/issue_313_active_set_rankdef.rs
+++ b/crates/pounce-cli/tests/issue_313_active_set_rankdef.rs
@@ -1,0 +1,121 @@
+//! gh #313 — `qp-active-set` on a rank-deficient-but-consistent equality QP.
+//!
+//! Fixture `rankdef_eq_qp.nl` is the strictly convex QP
+//!   min 0.5 (x0²+x1²+x2²) − x0 − 2 x1 − 3 x2
+//!   s.t.  x0 + x1 == 2
+//!         2 x0 + 2 x1 == 4        (exactly 2× the first row — redundant)
+//!         −10 ≤ xi ≤ 10
+//! whose equality block is exactly rank-deficient but consistent. Unique
+//! optimum x* = (0.5, 1.5, 3), objective −6.75.
+//!
+//! Redundant/scaled-duplicate equality rows are routine in modelling, so this
+//! must be handled without adversarial intent. Two things are pinned:
+//!
+//! 1. The active-set path SOLVES it — status optimal, objective −6.75 — the
+//!    same answer `qp-ipm` and `nlp` find. (The issue was originally filed
+//!    against a stale binary that aborted with "INTERNAL ERROR: Unknown
+//!    SolverReturn value" / exit 1; a current binary solves it.)
+//! 2. The console summary reports a FINITE scaled objective, not `nan`. The
+//!    SQP result path left `final_scaled_objective` at its NaN default, so
+//!    even a clean optimal active-set solve printed
+//!    "Objective ...: nan  <unscaled>".
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("rankdef_eq_qp.nl");
+    p
+}
+
+/// The rank-deficient equality QP must SOLVE on the active-set path to the
+/// correct optimum — not crash, not fail, not return a wrong objective.
+#[test]
+fn active_set_solves_rank_deficient_equality_qp() {
+    let json = std::env::temp_dir().join("pounce_issue313.json");
+    let _ = std::fs::remove_file(&json);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg("--json-output")
+        .arg(&json)
+        .arg("solver_selection=qp-active-set")
+        .output()
+        .expect("spawn pounce");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "should solve, exit 0:\n{combined}"
+    );
+    assert!(
+        !combined.contains("INTERNAL ERROR") && !combined.contains("Unknown SolverReturn"),
+        "must not hit the internal-error path:\n{combined}"
+    );
+
+    let report = std::fs::read_to_string(&json).expect("json report written");
+    // Correct optimum objective is −6.75.
+    let obj = extract_objective(&report);
+    assert!(
+        (obj + 6.75).abs() < 1e-6,
+        "active-set objective {obj} != −6.75 (correct optimum):\n{report}"
+    );
+    assert!(
+        report.contains("\"status\": \"SolveSucceeded\"") || report.contains("SolveSucceeded"),
+        "expected SolveSucceeded status:\n{report}"
+    );
+}
+
+/// The console must not print a `nan` scaled objective (gh #313): the SQP
+/// result path now mirrors the unscaled objective into
+/// `final_scaled_objective` instead of leaving it at the NaN default.
+#[test]
+fn active_set_solve_reports_finite_scaled_objective() {
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg("solver_selection=qp-active-set")
+        .output()
+        .expect("spawn pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+
+    // Find the "Objective ...:" summary line and confirm neither column is nan.
+    let obj_line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("Objective"))
+        .unwrap_or_else(|| panic!("no Objective summary line:\n{stdout}"));
+    assert!(
+        !obj_line.to_ascii_lowercase().contains("nan"),
+        "scaled/unscaled objective must be finite, got:\n{obj_line}"
+    );
+    assert!(
+        obj_line.contains("-6.75"),
+        "objective summary should show the −6.75 optimum:\n{obj_line}"
+    );
+}
+
+/// Minimal JSON scrape of the `"objective"` number from the solve report.
+fn extract_objective(report: &str) -> f64 {
+    let key = "\"objective\":";
+    let i = report.find(key).expect("objective key in report");
+    let tail = &report[i + key.len()..];
+    let tail = tail.trim_start();
+    let end = tail
+        .find(|c: char| c == ',' || c == '}' || c == '\n')
+        .unwrap_or(tail.len());
+    tail[..end].trim().parse().expect("parse objective number")
+}


### PR DESCRIPTION
Fixes #313.

## Two-part status

**The reported crash is already fixed on current `main`.** #313 reported `qp-active-set` aborting with `INTERNAL ERROR: Unknown SolverReturn value` / exit 1 on a rank-deficient-but-consistent equality QP. That was filed by the adversary bot against a **stale pre-fix binary** (commit `2c49fad0`) — the same stale-binary artifact behind #314 (and exactly what `pyomo_pounce.check_binary()` from #315 now detects). On a current build the active-set path **solves it correctly**: objective `−6.75` (the same value `qp-ipm` and `nlp` find), constraint violation and dual infeasibility both `0`, status `SolveSucceeded`.

**The genuine residual — fixed here — was a `nan` scaled objective.** `SolveStatistics::final_scaled_objective` defaults to `NaN`. The SQP/active-set result block in `application.rs` set `final_objective` and mirrored the SQP-side residuals but **never set the scaled objective**, so it stayed `NaN` and the console printed:

```
Objective ...............:   nan    -6.7500000000000000e+00
```

even on a clean optimal solve. (`qp-ipm` prints `−6.75 / −6.75` — the bug was active-set-only.) The one-line fix mirrors `res.obj` into `final_scaled_objective`, exactly as the residuals block already assumes (the SQP path does not thread `nlp_scaling`, so scaled == unscaled). After:

```
Objective ...............:   -6.7500000000000000e+00    -6.7500000000000000e+00
```

## The rank-deficient QP

```
min 0.5(x0²+x1²+x2²) − x0 − 2x1 − 3x2
s.t.  x0 + x1 == 2
      2x0 + 2x1 == 4     (exactly 2× the first row — redundant but consistent)
      −10 ≤ xi ≤ 10
```
Redundant/scaled-duplicate equality rows are routine in modelling (a constraint written twice, a generator-emitted scaled duplicate), so this must be handled without adversarial intent — and it is.

## Tests

`issue_313_active_set_rankdef.rs` (with a committed `rankdef_eq_qp.nl` fixture) pins both: the active-set path **solves** the rank-deficient QP to `−6.75` / `SolveSucceeded`, and the console objective summary is **finite** (no `nan`). `cargo test --workspace --release` is green (150 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
