### PR TITLE
Reject cost-normalization false Optimal on huge-Hessian/modest-gradient QPs (#324)

### DIFF
--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -1372,6 +1372,32 @@ fn hsde_cost_scale(prob: &QpProblem, tol: f64) -> f64 {
     }
 }
 
+/// Whether a solution the cost-normalized HSDE path certified `Optimal` is a
+/// *genuine* optimum of `prob` (the original, un-normalized problem), rather
+/// than a false certificate manufactured by the objective scaling (gh #324).
+///
+/// The test is the solution's **relative** KKT residual: each residual divided
+/// by the natural magnitude of its own terms (the stationarity residual by the
+/// objective-gradient scale `‖Px‖∞ ∨ ‖c‖∞`, the primal by the rhs scale). That
+/// ratio is invariant to the objective scaling σ, so a true optimum sits at
+/// `tol`-level relative accuracy regardless of σ, while the spurious cold-start
+/// certificate — accepted only because `‖c/σ‖ < tol` in the scaled metric —
+/// shows an `O(1)` relative residual. The `1e-3` cut sits three orders below
+/// that `O(1)` failure and three orders above a genuine solve's relative
+/// accuracy (the #286 huge-magnitude regression converges to ≲ 1e-6), so it
+/// separates the two cleanly without second-guessing a real large-scale solve.
+fn normalized_optimum_is_genuine(prob: &QpProblem, sol: &QpSolution) -> bool {
+    let res = sol.kkt_residuals(prob);
+    let mut px = vec![0.0; prob.n];
+    prob.p_mul(&sol.x, &mut px);
+    let gscale = inf_norm(&px).max(inf_norm(&prob.c)).max(1.0);
+    let pscale = inf_norm(&prob.b).max(inf_norm(&prob.h)).max(1.0);
+    let rel = (res.dual_infeasibility / gscale)
+        .max(res.primal_infeasibility / pscale)
+        .max(res.complementarity / gscale.max(pscale));
+    rel <= 1e-3
+}
+
 /// Bounds-agnostic Mehrotra predictor-corrector core. `prob.lb`/`ub` are
 /// ignored here; the public [`solve_qp_ipm`] handles bound expansion.
 fn solve_qp_core<F>(
@@ -1415,11 +1441,27 @@ where
         let sigma = hsde_cost_scale(prob, opts.tol);
         if sigma != 1.0 {
             let scaled = prob.scaled_objective(1.0 / sigma);
-            let mut sol = crate::hsde::solve_conic_hsde(&scaled, cone, opts, make_backend, None);
+            let mut sol =
+                crate::hsde::solve_conic_hsde(&scaled, cone, opts, &mut make_backend, None);
             for v in sol.y.iter_mut().chain(sol.z.iter_mut()) {
                 *v *= sigma;
             }
             sol.obj *= sigma;
+            // gh #324: the cost normalization divides the objective by σ (sized
+            // to ‖P‖∞). When ‖c‖ ≪ σ — a huge Hessian coefficient paired with a
+            // modest gradient, e.g. `P = diag(1e-10, 1e10)`, `c = [-1, -1]` — the
+            // *scaled* cold-start dual residual ‖c/σ‖ underflows below `tol`, so
+            // the embedding certifies `Optimal` at the untouched start (x = 0),
+            // nowhere near stationary in the original metric (kkt_error ≈ ‖c‖).
+            // A normalized `Optimal` must therefore be re-checked against the
+            // true, un-normalized *relative* KKT residual. When it is spurious
+            // the un-normalized solve — well-conditioned whenever σ has not
+            // actually collapsed τ, which is exactly the ‖c‖ ≪ σ regime — reaches
+            // the real optimum; if that solve cannot converge either, its honest
+            // non-`Optimal` status stands (never a false `Optimal`).
+            if sol.status == QpStatus::Optimal && !normalized_optimum_is_genuine(prob, &sol) {
+                return crate::hsde::solve_conic_hsde(prob, cone, opts, &mut make_backend, None);
+            }
             return sol;
         }
         return crate::hsde::solve_conic_hsde(prob, cone, opts, make_backend, None);

--- a/crates/pounce-convex/tests/illconditioned_huge_scale.rs
+++ b/crates/pounce-convex/tests/illconditioned_huge_scale.rs
@@ -64,6 +64,65 @@ fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
         .sum()
 }
 
+/// Regression for gh #324: a huge Hessian coefficient paired with a *modest*
+/// gradient (`‖c‖ ≪ ‖P‖`) must not falsely certify `Optimal` at the cold start.
+///
+/// `min ½ xᵀP x + cᵀx` with `P = diag(a, b)`, `c = [-1, -1]`, no constraints —
+/// unique optimum `x* = [1/a, 1/b]`, `f* = -½(1/a + 1/b)`. The cost
+/// normalization (gh #286) divides the objective by `σ ~ max(‖P‖, ‖c‖) ~ ‖P‖`;
+/// once `‖P‖ ≳ 1/ε` the scaled cold-start dual residual `‖c/σ‖` underflows below
+/// `tol` and the embedding used to report `Optimal` at the untouched start
+/// `x = 0` (objective 0 vs the true `-½(1/a+1/b)`), its own `kkt_error` sitting
+/// at `‖c‖ = 1`. The relative-KKT re-check now rejects that certificate and the
+/// un-normalized solve recovers the true optimum.
+#[test]
+fn issue_324_huge_hessian_modest_gradient_is_not_false_optimal_at_cold_start() {
+    for (a, b) in [(1e-8, 1e8), (1e-10, 1e10), (1e8, 1e8), (1e10, 1e10)] {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, a), Triplet::new(1, 1, b)],
+            c: vec![-1.0, -1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert_eq!(
+            sol.status,
+            QpStatus::Optimal,
+            "P=diag({a:.0e},{b:.0e}) must solve, got {:?}",
+            sol.status
+        );
+        // The bug terminated at iteration 0 (the untouched cold start); a
+        // genuine solve always steps.
+        assert!(
+            sol.iters > 0,
+            "P=diag({a:.0e},{b:.0e}) certified Optimal at iteration 0 (cold-start \
+             false optimum), x={:?}",
+            sol.x
+        );
+        // True optimum x* = [1/a, 1/b]; check the recovered point's own KKT
+        // residual is genuinely small (solver-independent oracle).
+        let res = sol.kkt_residuals(&prob);
+        assert!(
+            res.kkt_error() < 1e-6,
+            "P=diag({a:.0e},{b:.0e}) kkt_error {:.2e} — not a true optimum (x={:?})",
+            res.kkt_error(),
+            sol.x
+        );
+        let obj_exact = -0.5 * (1.0 / a + 1.0 / b);
+        let rel = (sol.obj - obj_exact).abs() / obj_exact.abs().max(1.0);
+        assert!(
+            rel < 1e-6,
+            "P=diag({a:.0e},{b:.0e}) objective rel error {rel} (got {}, exact {obj_exact})",
+            sol.obj
+        );
+    }
+}
+
 /// A well-conditioned but astronomically-scaled QP (`‖P‖ ~ 1e18`): the pure
 /// magnitude drives the `τ` collapse. With the objective normalization it
 /// recovers the *exact* clamped optimum in a handful of iterations.


### PR DESCRIPTION
## Summary

Fixes the false `Optimal` that `solve_qp` returned at **iteration 0** on a QP with a huge Hessian coefficient and a modest gradient (`‖c‖ ≪ ‖P‖`), e.g. `P = diag(1e-10, 1e10)`, `c = [-1, -1]`.

Closes #324.

## Root cause

The HSDE driver skips Ruiz equilibration and instead applies a scalar **cost normalization** (`hsde_cost_scale`, added for #286): when `max(‖P‖∞, ‖c‖∞)·ε > tol` it divides the whole objective by `σ = 2^⌈log₂ max(‖P‖∞,‖c‖∞)⌉` to keep the embedding's `τ` healthy.

That is safe when `‖c‖ ~ ‖P‖` (the #286 box-QP regime, `‖c‖,‖P‖ ~ 1e18`). But when `‖c‖ ≪ σ`, the *scaled* cold-start dual residual `‖c/σ‖` underflows **below `tol`**, so the convergence test fires on the untouched start `x = 0` at iteration 0. The point is reported `Optimal`/`success=True` even though its own `kkt_error` is `‖c‖ ≈ 1` and the objective is `0` vs the true `-5e9`. No `max_iter` (to 1e5) or `tol` (to 1e-10) rescued it.

## Fix

A normalized `Optimal` is now re-checked against the true, **un-normalized relative KKT residual** — each residual divided by the natural scale of its own terms (`‖Px‖∨‖c‖` for stationarity, the rhs scale for primal). That ratio is invariant to `σ`, so a genuine optimum sits at `tol`-level relative accuracy while the spurious cold-start certificate shows an `O(1)` relative residual. When the check fails, the solve falls back to the **un-normalized** path, which is well-conditioned precisely in the `‖c‖ ≪ σ` regime and reaches the true optimum. If that path cannot converge either, its honest non-`Optimal` status stands — the change can never manufacture a false `Optimal`.

The `1e-3` cut sits three orders below the `O(1)` failure and three orders above a genuine large-scale solve's relative accuracy (the #286 regression converges to ≲ 1e-6), so it separates the two cleanly.

## Evidence

Before (from #324) → after, via the Python API the bug was reported on:

```
$ python -c "import numpy as np, pounce; P=np.diag([1e-10,1e10]); \
    r=pounce.solve_qp(P=P,c=np.array([-1.,-1.])); \
    print(r.status, r.success, r.x, r.obj, r.residuals['kkt_error'])"

# before: optimal True [0. 0.]            0.0    1.0
# after:  optimal True [1.e+10 1.e-10]  -5.0e9   1.99e-09
```

All magnitudes now solve to the true optimum:

| P | status | x | kkt_error |
|---|--------|---|-----------|
| diag(1e-8, 1e8)   | optimal | [1e8, 1e-8]     | 6.9e-10 |
| diag(1e-10, 1e10) | optimal | [1e10, 1e-10]   | 2.0e-09 |
| diag(1e8, 1e8)    | optimal | [1e-8, 1e-8]    | 7.8e-10 |
| diag(1e10, 1e10)  | optimal | [1e-10, 1e-10]  | 7.8e-10 |

## Tests

- New regression `issue_324_huge_hessian_modest_gradient_is_not_false_optimal_at_cold_start` in `illconditioned_huge_scale.rs` (covers diag(1e±8), diag(1e±10), and the uniform-huge cases; asserts `iters > 0`, `kkt_error < 1e-6`, and objective rel-error against the closed form).
- The three existing **#286** huge-magnitude regressions still pass (the `‖c‖ ~ ‖P‖` regime is untouched).
- Full `pounce-convex` suite green (159 unit + all integration tests); `python/tests/test_qp.py` + `test_qp_host.py` = 77 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
