### PR TITLE
Validate tol/max_iter on the minimize NLP route (closes #325)

### DIFF
--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -1270,10 +1270,28 @@ def minimize(
     # always sends ``hessp=None``, ``bounds=None``, etc.; absorbed here when
     # undeclared on the signature). Real Ipopt option misses still surface as
     # ``RuntimeError`` from ``problem.solve()`` — by design.
+    translated = {}
     for k, v in options.items():
         if v is None:
             continue
         ipopt_k, ipopt_v = _translate_option(k, v)
+        translated[ipopt_k] = ipopt_v
+    # Validate ``tol`` / ``max_iter`` with the SAME shared guard the convex
+    # entry points use (``solve_qp`` / ``solve_socp`` via
+    # ``qp._validate_solver_opts``), so every route into the solver rejects an
+    # unsatisfiable tolerance identically. The Ipopt backend already rejects
+    # ``tol <= 0`` / NaN and a negative ``max_iter`` (OPTION_INVALID), but it
+    # silently *accepts* a non-finite ``tol=inf`` and any ``tol >= 1`` and then
+    # returns ``success=True`` at the non-stationary starting-band iterate
+    # (gh #325) — the exact ``tol >= 1`` failure mode #277 closed on the convex
+    # surfaces. Validating the translated values also covers the scipy aliases
+    # (``gtol`` / ``ftol`` / ``xtol`` → ``tol``, ``maxiter`` → ``max_iter``).
+    from .qp import _validate_solver_opts
+
+    _validate_solver_opts(
+        translated.get("tol"), translated.get("max_iter"), "pounce.minimize"
+    )
+    for ipopt_k, ipopt_v in translated.items():
         problem.add_option(ipopt_k, ipopt_v)
 
     # Pass warm_start only when set: test doubles (and any cyipopt-style

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -498,3 +498,66 @@ def test_minimize_qp_route_rejects_bad_tol():
                 solver_selection="qp-ipm",
                 tol=bad,
             )
+
+
+# --- gh #325: the guard must also reach the NLP route -----------------------
+
+# The default `minimize` route (`solver_selection="nlp"`) bypassed the shared
+# convex guard: the Ipopt backend rejects `tol <= 0` / NaN and a negative
+# `max_iter`, but silently ACCEPTS `tol = inf` and any `tol >= 1`, returning
+# `success=True, status=0` at the non-stationary starting-band iterate (Rosenbrock
+# stalls at f=0.199 instead of reaching x*=(1,1), f=0). Same `tol >= 1` failure
+# mode as #277, now on the NLP surface. Reuse the Rosenbrock repro from the issue.
+def _rosenbrock():
+    def f(x):
+        return (1 - x[0]) ** 2 + 100 * (x[1] - x[0] ** 2) ** 2
+
+    def j(x):
+        return np.array(
+            [
+                -2 * (1 - x[0]) - 400 * x[0] * (x[1] - x[0] ** 2),
+                200 * (x[1] - x[0] ** 2),
+            ]
+        )
+
+    return f, j, np.array([-1.2, 1.0])
+
+
+@pytest.mark.parametrize("bad", _BAD_TOLS)
+def test_minimize_nlp_route_rejects_bad_tol(bad):
+    """The NLP route must reject the same unsatisfiable `tol` values the convex
+    entry points do (gh #325); `tol=inf` / `tol>=1` used to return
+    `success=True` at a non-stationary point."""
+    f, j, x0 = _rosenbrock()
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        pounce.minimize(f, x0, jac=j, solver_selection="nlp", tol=bad)
+
+
+@pytest.mark.parametrize("bad", [-5, -1, 0])
+def test_minimize_nlp_route_rejects_bad_max_iter(bad):
+    """Non-positive `max_iter` must raise on the NLP route, matching the convex
+    surfaces (gh #325)."""
+    f, j, x0 = _rosenbrock()
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        pounce.minimize(f, x0, jac=j, solver_selection="nlp", max_iter=bad)
+
+
+def test_minimize_nlp_route_rejects_bad_tol_alias():
+    """scipy tolerance aliases (`gtol`/`ftol`/`xtol` -> Ipopt `tol`) and the
+    `maxiter` alias reach the NLP backend too, so the guard must see the
+    translated value, not only the canonical key (gh #325)."""
+    f, j, x0 = _rosenbrock()
+    with pytest.raises(ValueError, match=r"`tol` must be a finite positive number"):
+        pounce.minimize(f, x0, jac=j, solver_selection="nlp", gtol=float("inf"))
+    with pytest.raises(ValueError, match=r"`max_iter` must be a positive integer"):
+        pounce.minimize(f, x0, jac=j, solver_selection="nlp", maxiter=0)
+
+
+def test_minimize_nlp_route_valid_tol_still_solves():
+    """A legitimate tight `tol` on the NLP route is untouched: Rosenbrock still
+    converges to x*=(1, 1), f=0 (gh #325)."""
+    f, j, x0 = _rosenbrock()
+    r = pounce.minimize(f, x0, jac=j, solver_selection="nlp", tol=1e-8, max_iter=200)
+    assert r.success
+    np.testing.assert_allclose(r.x, [1.0, 1.0], atol=1e-5)
+    assert r.fun < 1e-8


### PR DESCRIPTION
Closes #325

## Root cause

The default `minimize` route (`solver_selection="nlp"`) never validated `tol` /
`max_iter`. Those options were forwarded straight to the Rust/Ipopt backend via
`problem.add_option`. The backend rejects `tol <= 0` / NaN and a negative
`max_iter` (OPTION_INVALID -> `RuntimeError`), but it **silently accepts** a
non-finite `tol = inf` and any `tol >= 1` and then returns `success=True,
status=0` at the non-stationary starting-band iterate.

This is the exact `tol >= 1` failure mode #277 closed on the convex surfaces:
the convergence test passes trivially at the O(1)-residual starting point, so
the solve short-circuits and labels a wrong point "optimal". The `solve_qp` /
`solve_socp` guard (`qp._validate_solver_opts`, `_TOL_MAX = 1.0`) was never
reached on the NLP path.

## Fix

`python/pounce/_minimize.py` — on the NLP path, reuse the **same** shared guard
the convex entry points use. The translated option dict is validated with
`qp._validate_solver_opts(tol, max_iter, "pounce.minimize")` before any option
reaches `problem.add_option`, so every route into the solver rejects an
unsatisfiable tolerance identically (same `ValueError` type and message as
`solve_qp` / `solve_socp`). Validating the *translated* values also covers the
scipy aliases (`gtol`/`ftol`/`xtol` -> `tol`, `maxiter` -> `max_iter`), which
the NLP backend honors but the canonical-key-only convex guard would miss.

No Rust changes; no new second guard — the one shared function now covers the
NLP path too.

### Consistency note

This also makes `max_iter=0` on the NLP route raise `ValueError` (it previously
returned `success=False`), and makes `tol<=0` / NaN raise `ValueError` instead
of the backend's `RuntimeError`. This is the deliberate, consistent choice: the
task and #277 require the NLP route to reject the same bad values, the same way,
as `solve_qp` / `solve_socp`.

## Before / after (exact issue repro, `tol=inf`)

Before:
```
True 0 [0.55653273 0.30526004] 0.1986600937919324
```

After:
```
ValueError: pounce.minimize: `tol` must be a finite positive number below 1.0
(it bounds the KKT-residual convergence measure); got inf. A value <= 0, NaN,
or Inf is unsatisfiable, and tol >= 1.0 would accept the non-stationary starting
iterate and return a wrong point labeled 'optimal'.
```

Full matrix on the NLP route after the fix:

| call | result |
|---|---|
| `tol=inf` | raises `ValueError` |
| `tol=1.0` | raises `ValueError` |
| `tol=1e6` | raises `ValueError` |
| `tol=nan` / `tol=0` / `tol=-1` | raises `ValueError` |
| `max_iter=-5` / `max_iter=0` | raises `ValueError` |
| `gtol=inf` / `maxiter=0` (aliases) | raises `ValueError` |
| `tol=1e-8` (valid) | `success=True`, `x=[1,1]`, `f=7.1e-22` |
| default | `success=True`, `x=[1,1]`, `f=7.1e-22` |

## Tests

Added to `python/tests/test_qp_host.py`, mirroring the existing convex
tol/max_iter tests:
- `test_minimize_nlp_route_rejects_bad_tol` (parametrized over `_BAD_TOLS`:
  `0, -1, nan, inf, 1e300, 1.0`)
- `test_minimize_nlp_route_rejects_bad_max_iter` (`-5, -1, 0`)
- `test_minimize_nlp_route_rejects_bad_tol_alias` (`gtol=inf`, `maxiter=0`)
- `test_minimize_nlp_route_valid_tol_still_solves` (Rosenbrock -> x*=(1,1), f<1e-8)

Ran:
- `pytest python/tests/test_minimize.py python/tests/test_qp.py python/tests/test_qp_host.py` -> 155 passed
- `cargo fmt --all -- --check` -> clean (no Rust changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
