### PR TITLE
Fix qp-active-set InternalError on 3+ exact-duplicate / integer-combination rank-deficient equality rows (#326)

### DIFF
--- a/crates/pounce-cli/tests/fixtures/inconsistent_eq_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/inconsistent_eq_qp.nl
@@ -1,0 +1,46 @@
+g3 1 1 0	# problem unknown
+ 2 2 1 0 2 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+n0
+O0 0
+o0
+o5
+o0
+v0
+n-1
+n2
+o5
+o0
+v1
+n-2
+n2
+x2
+0 0
+1 0
+r
+4 2
+4 3
+b
+3
+3
+k1
+2
+J0 2
+0 1
+1 1
+J1 2
+0 1
+1 1
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/fixtures/rankdef_intcomb_eq_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/rankdef_intcomb_eq_qp.nl
@@ -1,0 +1,52 @@
+g3 1 1 0	# problem unknown
+ 2 3 1 0 3 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 6 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+n0
+C2
+n0
+O0 0
+o0
+o5
+o0
+v0
+n-1
+n2
+o5
+o0
+v1
+n-2
+n2
+x2
+0 0
+1 0
+r
+4 2
+4 6
+4 8
+b
+3
+3
+k1
+3
+J0 2
+0 1
+1 1
+J1 2
+0 3
+1 3
+J2 2
+0 4
+1 4
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/fixtures/rankdef_triple_eq_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/rankdef_triple_eq_qp.nl
@@ -1,0 +1,52 @@
+g3 1 1 0	# problem unknown
+ 2 3 1 0 3 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 6 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+n0
+C2
+n0
+O0 0
+o0
+o5
+o0
+v0
+n-1
+n2
+o5
+o0
+v1
+n-2
+n2
+x2
+0 0
+1 0
+r
+4 2
+4 2
+4 2
+b
+3
+3
+k1
+3
+J0 2
+0 1
+1 1
+J1 2
+0 1
+1 1
+J2 2
+0 1
+1 1
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/issue_326_active_set_rankdef_triple.rs
+++ b/crates/pounce-cli/tests/issue_326_active_set_rankdef_triple.rs
@@ -1,0 +1,133 @@
+//! gh #326 — `qp-active-set` on 3+ exact-duplicate / integer-combination
+//! rank-deficient equality rows (a residual of #313/#321/#323).
+//!
+//! The model is the projection of `(1, 2)` onto the line `x + y = 2`:
+//!   min (x − 1)² + (y − 2)²   s.t.  <redundant encodings of x + y = 2>
+//! whose unique optimum is `x* = (0.5, 1.5)`, `f* = 0.5`.
+//!
+//! The #313 fix taught the equality+bounds active-set path to prune a
+//! rank-deficient equality block, but the pure-equality / no-bounds fast path
+//! `solve_equality_only` was left without that guard. Under
+//! `solver_selection=qp-active-set` (unbounded variables → that fast path),
+//! three identical rows or an integer-combination triple made the pinned KKT
+//! singular; no H-block inertia shift can rescue a rank-deficient *constraint*
+//! block, so the solve aborted with `LinearSolverFailure` → `InternalError` /
+//! exit 1. `solve_equality_only` now delegates such a block to the
+//! rank-deficiency-aware `solve_general`.
+//!
+//! Pinned here:
+//!   * the 3-exact-duplicate and integer-combination encodings SOLVE to f = 0.5;
+//!   * an *inconsistent* rank-deficient block (`x+y=2` and `x+y=3`) is still
+//!     reported infeasible, not silently "solved" — the redundancy prune must
+//!     not mask genuine infeasibility.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn run_active_set(fixture_name: &str) -> (Option<i32>, String, Option<f64>) {
+    let json = std::env::temp_dir().join(format!("pounce_issue326_{fixture_name}.json"));
+    let _ = std::fs::remove_file(&json);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture(fixture_name))
+        .arg("--no-sol")
+        .arg("--json-output")
+        .arg(&json)
+        .arg("solver_selection=qp-active-set")
+        .output()
+        .expect("spawn pounce");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let obj = std::fs::read_to_string(&json)
+        .ok()
+        .and_then(|r| extract_objective(&r));
+    (out.status.code(), combined, obj)
+}
+
+/// Three exactly-identical equality rows `x+y=2` must SOLVE (f = 0.5), not
+/// crash with `InternalError` / exit 1.
+#[test]
+fn active_set_solves_three_exact_duplicate_equality_rows() {
+    let (code, combined, obj) = run_active_set("rankdef_triple_eq_qp.nl");
+    assert_eq!(code, Some(0), "should solve, exit 0:\n{combined}");
+    assert!(
+        !combined.contains("INTERNAL ERROR")
+            && !combined.contains("Unknown SolverReturn")
+            && !combined.contains("SQP solve failed"),
+        "must not hit the internal-error path:\n{combined}"
+    );
+    let obj = obj.expect("json report with objective");
+    assert!(
+        (obj - 0.5).abs() < 1e-6,
+        "objective {obj} != 0.5:\n{combined}"
+    );
+}
+
+/// Integer-combination redundant rows `[x+y=2 ; 3x+3y=6 ; 4x+4y=8]`
+/// (row3 = row1 + row2) must SOLVE (f = 0.5).
+#[test]
+fn active_set_solves_integer_combination_equality_rows() {
+    let (code, combined, obj) = run_active_set("rankdef_intcomb_eq_qp.nl");
+    assert_eq!(code, Some(0), "should solve, exit 0:\n{combined}");
+    assert!(
+        !combined.contains("INTERNAL ERROR")
+            && !combined.contains("Unknown SolverReturn")
+            && !combined.contains("SQP solve failed"),
+        "must not hit the internal-error path:\n{combined}"
+    );
+    let obj = obj.expect("json report with objective");
+    assert!(
+        (obj - 0.5).abs() < 1e-6,
+        "objective {obj} != 0.5:\n{combined}"
+    );
+}
+
+/// An *inconsistent* rank-deficient equality block (`x+y=2` and `x+y=3`) must
+/// still be reported infeasible — the redundancy prune must not mask genuine
+/// infeasibility by dropping a contradictory row.
+#[test]
+fn active_set_rejects_inconsistent_rank_deficient_rows() {
+    let (_code, combined, _) = run_active_set("inconsistent_eq_qp.nl");
+    // Must NOT crash with an internal error, and must NOT declare an optimal
+    // solution — the redundancy prune must not mask genuine infeasibility.
+    // (An infeasible verdict legitimately exits nonzero.)
+    assert!(
+        !combined.contains("INTERNAL ERROR") && !combined.contains("Unknown SolverReturn"),
+        "must not hit the internal-error path:\n{combined}"
+    );
+    assert!(
+        combined.to_ascii_lowercase().contains("infeasib"),
+        "inconsistent block must be reported infeasible:\n{combined}"
+    );
+    assert!(
+        !combined.contains("Optimal Solution Found"),
+        "inconsistent block must NOT be reported optimal:\n{combined}"
+    );
+}
+
+/// Minimal JSON scrape of the `"objective"` number from the solve report.
+fn extract_objective(report: &str) -> Option<f64> {
+    let key = "\"objective\":";
+    let i = report.find(key)?;
+    let tail = report[i + key.len()..].trim_start();
+    let end = tail
+        .find(|c: char| c == ',' || c == '}' || c == '\n')
+        .unwrap_or(tail.len());
+    tail[..end].trim().parse().ok()
+}

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -643,7 +643,49 @@ impl ParametricActiveSetSolver {
         // eigenvalues (Gould-Hribar-Nocedal 2001 §3.2). The
         // inertia-control retry handles indefinite reduced H via
         // §4.5.
-        let delta = self.factorize_with_inertia_control(kkt, &mut rhs, qp.m as i32, qp.n, opts)?;
+        //
+        // A rank-deficient equality block — redundant / linearly
+        // dependent rows, e.g. three identical rows or one row an
+        // integer combination of the others (#326) — makes the saddle
+        // KKT singular, and no §4.5 H-block shift can rescue a
+        // rank-deficient *constraint* block: the inertia loop exhausts
+        // and reports a recoverable failure. This fast path pins ALL `m`
+        // equality rows in one shot and has no per-row selection, so it
+        // cannot prune the dependent rows itself. On that signal,
+        // delegate to the rank-deficiency-aware `solve_general`, whose
+        // `cold_general_initial` prunes the equalities to a maximal
+        // independent subset (a dropped row is a linear combination of
+        // the kept ones, hence satisfied at any constraint-consistent
+        // point) and reaches the exact vertex. Without this the solve
+        // surfaced to the user as `InternalError` / exit 1 (#326).
+        let delta =
+            match self.factorize_with_inertia_control(kkt, &mut rhs, qp.m as i32, qp.n, opts) {
+                Ok(d) => d,
+                Err(ref e) if e.is_recoverable_factorization_failure() => {
+                    return self.solve_general(qp, None, opts);
+                }
+                Err(e) => return Err(e),
+            };
+
+        // Masked-rank-deficiency guard (companion to the one in
+        // `factor_pinned_primal`). A large enough δ can grow the H
+        // diagonal until the backend stops flagging the singular
+        // constraint block and returns a solution instead of a failure
+        // (feral masks the null direction around δ≈1e8), which would slip
+        // a redundant — or worse, *inconsistent* — equality block past the
+        // check above. A nonzero δ on this pinned equality KKT is the tell:
+        // only then rank-reveal the rows, and if any is redundant delegate
+        // to `solve_general` (same recovery as the exact-failure branch).
+        // A δ > 0 with a full-rank block is a legitimate indefinite /
+        // unbounded reduced-Hessian shift and falls through to the
+        // recession-ray test below unchanged (#326).
+        if delta > 0.0 {
+            let eq_rows: Vec<usize> = (0..qp.m).collect();
+            let (kept, _) = independent_active_subset(&mut self.linsol, qp, &eq_rows, &[]);
+            if kept.len() < qp.m {
+                return self.solve_general(qp, None, opts);
+            }
+        }
 
         // RHS now holds [x*; λ*].
         let mut x = vec![0.0; qp.n];

--- a/crates/pounce-qp/tests/rank_deficient_active_set.rs
+++ b/crates/pounce-qp/tests/rank_deficient_active_set.rs
@@ -163,6 +163,111 @@ fn equality_plus_bounds_prunes_exact_rank_deficient_rows() {
     );
 }
 
+/// Pure-equality, no-bounds path (#326): a strictly convex QP whose ONLY
+/// general constraints are equalities and whose variables are unbounded
+/// (`xl = -inf`, `xu = +inf`) routes to the `solve_equality_only` fast path,
+/// which pins ALL `m` equality rows in one shot and — before this fix — had no
+/// rank-deficiency guard at all (unlike the #313 equality+bounds path). With
+/// THREE exactly identical rows the pinned KKT is singular; no H-block inertia
+/// shift can rescue a rank-deficient constraint block, so the loop exhausted
+/// and surfaced to the user as `InternalError` / exit 1. The path now delegates
+/// to the rank-deficiency-aware `solve_general` and reaches the exact optimum.
+///
+/// Fixture (the issue's reproduction, n = 3, unbounded):
+///   min  ½(x₀² + x₁² + x₂²) − x₀ − 2x₁ − 3x₂
+///   s.t.  x₀ + x₁ = 2   (×3, three identical rows — rank 1)
+/// Closed form: x* = (0.5, 1.5, 3.0), f* = −6.75.
+#[test]
+fn equality_only_prunes_three_exact_duplicate_rows() {
+    let h_space = SymTMatrixSpace::new(3, vec![1, 2, 3], vec![1, 2, 3]);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&[1.0, 1.0, 1.0]);
+
+    // Three identical rows x₀+x₁ (= 2) over 3 variables (rank 1).
+    let a_space = GenTMatrixSpace::new(3, 3, vec![1, 1, 2, 2, 3, 3], vec![1, 2, 1, 2, 1, 2]);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&[1.0, 1.0, 1.0, 1.0, 1.0, 1.0]);
+
+    let g = [-1.0, -2.0, -3.0];
+    let bl = [2.0, 2.0, 2.0];
+    let bu = [2.0, 2.0, 2.0];
+    let xl = [NEG_INF, NEG_INF, NEG_INF];
+    let xu = [POS_INF, POS_INF, POS_INF];
+
+    let qp = QpProblem {
+        n: 3,
+        m: 3,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let mut solver =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let sol = solver
+        .solve(&qp, None, &opts())
+        .expect("3 exact-duplicate equality rows must solve, not error (#326)");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "status = {:?}", sol.status);
+    assert!((sol.x[0] - 0.5).abs() < 1e-8, "x[0] = {}", sol.x[0]);
+    assert!((sol.x[1] - 1.5).abs() < 1e-8, "x[1] = {}", sol.x[1]);
+    assert!((sol.x[2] - 3.0).abs() < 1e-8, "x[2] = {}", sol.x[2]);
+    assert!((sol.obj - (-6.75)).abs() < 1e-8, "obj = {}", sol.obj);
+}
+
+/// Pure-equality, no-bounds path (#326): same fixture, but the redundant rows
+/// are an INTEGER COMBINATION rather than exact duplicates — row 3 = row 1 +
+/// row 2 as coefficient vectors: `[x+y=2 ; 3x+3y=6 ; 4x+4y=8]`. Still rank 1,
+/// still consistent; must reach the same optimum. (The #313 fix handled 2 exact
+/// duplicates and the scaled triple but not this integer-combination triple.)
+#[test]
+fn equality_only_prunes_integer_combination_rows() {
+    let h_space = SymTMatrixSpace::new(3, vec![1, 2, 3], vec![1, 2, 3]);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&[1.0, 1.0, 1.0]);
+
+    // Rows: x₀+x₁ (=2), 3x₀+3x₁ (=6), 4x₀+4x₁ (=8). Row3 = row1+row2 (rank 1).
+    let a_space = GenTMatrixSpace::new(3, 3, vec![1, 1, 2, 2, 3, 3], vec![1, 2, 1, 2, 1, 2]);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&[1.0, 1.0, 3.0, 3.0, 4.0, 4.0]);
+
+    let g = [-1.0, -2.0, -3.0];
+    let bl = [2.0, 6.0, 8.0];
+    let bu = [2.0, 6.0, 8.0];
+    let xl = [NEG_INF, NEG_INF, NEG_INF];
+    let xu = [POS_INF, POS_INF, POS_INF];
+
+    let qp = QpProblem {
+        n: 3,
+        m: 3,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let mut solver =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let sol = solver
+        .solve(&qp, None, &opts())
+        .expect("integer-combination redundant equality rows must solve, not error (#326)");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "status = {:?}", sol.status);
+    assert!((sol.x[0] - 0.5).abs() < 1e-8, "x[0] = {}", sol.x[0]);
+    assert!((sol.x[1] - 1.5).abs() < 1e-8, "x[1] = {}", sol.x[1]);
+    assert!((sol.x[2] - 3.0).abs() < 1e-8, "x[2] = {}", sol.x[2]);
+    assert!((sol.obj - (-6.75)).abs() < 1e-8, "obj = {}", sol.obj);
+}
+
 /// Cold path: `solve(qp, None, ..)` routes through `cold_general_initial`,
 /// which pins ALL equality rows up front. With redundant equalities that
 /// factor is singular; the guard prunes the redundant row so the cold start


### PR DESCRIPTION
Closes #326

## Summary
`qp-active-set` returned `InternalError` / exit 1 on a well-posed QP whose
equality block is exactly rank-deficient but **consistent** — 3+ identical
rows, or an integer-combination triple like `[x+y=2 ; 3x+3y=6 ; 4x+4y=8]`
(row3 = row1+row2). This was a residual of #313/#321/#323.

## Root cause
A strictly convex QP whose only general constraints are equalities and whose
variables are unbounded routes to the `solve_equality_only` fast path. The
#313 fix added rank-deficiency handling to the equality+bounds path
(`solve_equality_plus_bounds` -> `factor_pinned_primal`), but
`solve_equality_only` was left with **no rank guard at all**.

With rank-deficient equality rows the pinned KKT `[H Aᵀ; A 0]` is singular in
the multiplier space. No §4.5 H-block δ·I shift can rescue a rank-deficient
*constraint* block, so `factorize_with_inertia_control` exhausted its 12
shifts and returned a recoverable `LinearSolverFailure`, which
`solve_equality_only` propagated to the user as `InternalError` / exit 1.

The scaled triple `[x+y=2 ; 2x+2y=4 ; 3x+3y=6]` and the 2-exact-duplicate case
only worked because feral happened to *mask* the near-singular block at a large
δ and return a correct (consistent) solution — so the exact-duplicate crash was
a genuine internal inconsistency, not a shared limitation.

## Fix (`crates/pounce-qp/src/solver.rs`, `solve_equality_only`)
Mirrors the #313 equality+bounds path:
- On a recoverable factorization failure, delegate to the
  rank-deficiency-aware `solve_general`, whose `cold_general_initial` prunes
  the equalities to a maximal linearly-independent subset (a dropped row is a
  linear combination of the kept ones, hence satisfied at any
  constraint-consistent point) and reaches the exact vertex.
- Companion masked-rank-deficiency guard (δ > 0 + rank-reveal via
  `independent_active_subset`) routes the masked case through the same
  recovery. A δ > 0 with a full-rank block is a legitimate indefinite/unbounded
  reduced-Hessian shift and falls through to the existing recession-ray test
  unchanged.

The inconsistent block (`x+y=2` and `x+y=3`) stays infeasible: the QP returns a
point satisfying the kept row and the SQP/CLI residual audit rejects it exactly
as before.

## Before / after (CLI, `solver_selection=qp-active-set`)

| encoding | before | after |
|---|---|---|
| `[x+y=2]` (single, control) | Optimal f=0.5 | Optimal f=0.5 |
| `[x+y=2 ; x+y=2]` (2 dup) | Optimal f=0.5 | Optimal f=0.5 |
| `[x+y=2 ; 2x+2y=4 ; 3x+3y=6]` (scaled) | Optimal f=0.5 | Optimal f=0.5 |
| `[x+y=2 ; x+y=2 ; x+y=2]` (3 dup) | **InternalError / exit 1** | **Optimal f=0.5** |
| `[x+y=2 ; 3x+3y=6 ; 4x+4y=8]` (r3=r1+r2) | **InternalError / exit 1** | **Optimal f=0.5** |
| `[x+y=2 ; x+y=3]` (inconsistent) | infeasible | infeasible (verify REJECTED) |

After the fix, `pounce verify` reports `VERIFIED` on the triple and
integer-combination `.sol` files and `REJECTED` on the inconsistent one.

## Tests
- `crates/pounce-qp/tests/rank_deficient_active_set.rs`: new
  `equality_only_prunes_three_exact_duplicate_rows` and
  `equality_only_prunes_integer_combination_rows` (unbounded pure-equality path
  -> x*=(0.5,1.5,3), f*=-6.75).
- `crates/pounce-cli/tests/issue_326_active_set_rankdef_triple.rs`: CLI
  integration test on the issue's exact reproduction, incl. the
  inconsistent-infeasible guard (+ 3 `.nl` fixtures).
- `cargo test -p pounce-qp` (85+ tests), `cargo test -p pounce-cli`,
  `cargo test -p pounce-algorithm` — all green.
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
