### PR TITLE
Fix #327: reach the true optimum on extreme-objective-scale problems instead of a masked interior false success

### DIFF
--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -515,6 +515,24 @@ impl ConvCheck for OptErrorConvCheck {
         ConvergenceStatus::Continue
     }
 
+    fn current_passes_strict(
+        &self,
+        nlp_err: Number,
+        _data: &IpoptDataHandle,
+        cq: &IpoptCqHandle,
+    ) -> bool {
+        // The strict per-component gate of `check_convergence_with_state`, minus
+        // the masking veto — see the trait doc. Unscaled per-component residuals,
+        // matching that method (the `*_tol` triplet is defined on the
+        // user-original residuals).
+        let cq_ref = cq.borrow();
+        let dual_inf = cq_ref.curr_unscaled_dual_infeasibility_max();
+        let constr_viol = cq_ref.curr_unscaled_primal_infeasibility_max();
+        let compl_inf = cq_ref.curr_unscaled_complementarity_max();
+        drop(cq_ref);
+        self.passes_component_tols(nlp_err, dual_inf, constr_viol, compl_inf)
+    }
+
     fn tol_or_default(&self) -> Number {
         self.tol
     }

--- a/crates/pounce-algorithm/src/conv_check/trait.rs
+++ b/crates/pounce-algorithm/src/conv_check/trait.rs
@@ -79,6 +79,28 @@ pub trait ConvCheck {
         self.check_convergence(nlp_err, iter_count)
     }
 
+    /// Whether the current iterate passes the *strict* per-component convergence
+    /// tolerances — the [`Self::check_convergence_with_state`] strict test with
+    /// the masked-certificate veto (gh #200) removed. In other words: would this
+    /// iterate have certified `Success` were it not for the objective-scale
+    /// masking?
+    ///
+    /// gh #327 reads it on the veto's fallback path to distinguish a point the
+    /// veto refused *only because of masking* — a would-be strict certificate,
+    /// e.g. the true optimum a continued run reached but could never certify
+    /// there — from one that never converged at all (an unbounded / diverging
+    /// iterate whose gradient never vanishes). Only the former may displace the
+    /// point the baseline stopped at. Default `false` for policies that expose no
+    /// strict test.
+    fn current_passes_strict(
+        &self,
+        _nlp_err: Number,
+        _data: &IpoptDataHandle,
+        _cq: &IpoptCqHandle,
+    ) -> bool {
+        false
+    }
+
     /// Whether the supplied `nlp_err` is at or below the acceptable
     /// tolerance — port of upstream
     /// `OptimalityErrorConvergenceCheck::CurrentIsAcceptable`. Used by

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -863,12 +863,54 @@ impl IpoptAlgorithm {
             // acceptable level would over-report.
             return refused_status;
         }
-        // The continued run failed outright, so any restored certificate
-        // dominates it on status and the tie-break never applies.
+        // The continued run did not certify — but its final point can still be a
+        // *better* would-be certificate than the one the baseline stopped at, and
+        // restoring the chronologically-first refusal unconditionally throws it
+        // away (gh #327). The masking veto keeps refusing at the true optimum too
+        // (its unscaled error stays above `acceptable_tol` under an extreme
+        // objective scale), so a run that actually reaches the optimum never gets
+        // to certify there and instead exits non-`Success` — typically on a tiny
+        // step once it settles. Rolling straight back to the first refusal then
+        // hands back the point the baseline stopped at, which can be far worse:
+        // on `min 1/x` over `[1e-12, 10]` the solve reaches x≈10 (f≈0.1) but was
+        // rolled back to the first refusal at x≈2.84 (f≈0.35) and reported
+        // success there.
+        //
+        // The extra candidate is admitted *narrowly*, and the gate is
+        // load-bearing: the continued point may displace the refused snapshot
+        // only if it itself passes the strict per-component tolerances — i.e. it
+        // is a would-be strict certificate the veto refused solely because of
+        // masking. That is precisely what tells the settled true optimum apart
+        // from a merely lower objective reached on an unbounded ray (e.g.
+        // `A(x−a)⁴ − K·√(1+y²)`, unbounded below in y): the diverging iterate
+        // never passes the strict test, so it can never win here, and those runs
+        // stay bit-for-bit as before. When the gate does open, keep whichever
+        // point ranks better under the same feasibility-aware key the dual-guard
+        // fallback uses, and report the baseline's restored status either way —
+        // never worse than baseline on status, never worse (often better) on the
+        // point.
         let Some((refused, restored_status)) = self.baseline_outcome() else {
             return result;
         };
-        self.restore_snapshot(&refused);
+        self.assert_comparable_scale(&refused);
+        let curr_nlp_err = self.cq.borrow().curr_nlp_error();
+        let curr_passes_strict =
+            self.bundle
+                .conv_check
+                .current_passes_strict(curr_nlp_err, &self.data, &self.cq);
+        let curr_f = self.cq.borrow().curr_f();
+        let curr_viol = self.cq.borrow().curr_unscaled_primal_infeasibility_max();
+        // Keep the continued point in place only when it is a would-be strict
+        // certificate that also ranks strictly better; otherwise restore the
+        // refused snapshot exactly as before. `ranks_better` treats a non-finite
+        // continued objective as worst, so a NaN-objective continuation never
+        // displaces a finite refused point (the NaN-loses convention the
+        // `Success` branch relies on).
+        let keep_continued = curr_passes_strict
+            && self.ranks_better(curr_f, curr_viol, refused.obj, refused.constr_viol);
+        if !keep_continued {
+            self.restore_snapshot(&refused);
+        }
         if self.cq.borrow().curr_f().is_finite() {
             restored_status
         } else {

--- a/crates/pounce-algorithm/tests/masked_certificate_fuzz.rs
+++ b/crates/pounce-algorithm/tests/masked_certificate_fuzz.rs
@@ -1933,3 +1933,131 @@ fn the_earliest_refusal_is_the_one_restored_not_the_strictest() {
         veto_obj - base_obj
     );
 }
+
+/// gh #327: `min 1/x` over `x ∈ [1e-12, 10]` from x0 = 1e-12, under the default
+/// quasi-Newton (limited-memory) Hessian — the common scipy-style `minimize`
+/// call.
+///
+/// The objective is monotone decreasing, so the true optimum is the upper bound
+/// x = 10, f = 0.1. The enormous initial gradient (−1/x² = −1e24 at x0) pins the
+/// gradient scaling at its 1e-8 floor, deflating the scaled KKT error below `tol`
+/// all along the trajectory — the masking pathology. With the veto disabled the
+/// solver certifies `Solve_Succeeded` at the first masked strict point, a
+/// non-stationary interior iterate x ≈ 2.84 (f ≈ 0.35). With the veto enabled the
+/// run continues and actually reaches the bound, x ≈ 10 (f ≈ 0.1) — but the veto
+/// refuses to certify there too (its unscaled error stays above `acceptable_tol`),
+/// so it exits non-`Success` on a tiny step. The bug was that the fallback then
+/// rolled all the way back to the first refusal at x ≈ 2.84 and reported success
+/// there; the fix keeps the settled would-be certificate at the bound.
+struct MonotoneToBound;
+
+impl TNLP for MonotoneToBound {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 1,
+            m: 0,
+            nnz_jac_g: 0,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[1e-12]);
+        b.x_u.copy_from_slice(&[10.0]);
+        true
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[1e-12]);
+        true
+    }
+    fn eval_f(&mut self, x: &[Number], _n: bool) -> Option<Number> {
+        Some(1.0 / x[0])
+    }
+    fn eval_grad_f(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+        g[0] = -1.0 / (x[0] * x[0]);
+        true
+    }
+    fn eval_g(&mut self, _x: &[Number], _n: bool, _g: &mut [Number]) -> bool {
+        true
+    }
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _n: bool, _m: SparsityRequest<'_>) -> bool {
+        true
+    }
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _n: bool,
+        obj_factor: Number,
+        _l: Option<&[Number]>,
+        _nl: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Unused under limited-memory, but a well-formed TNLP supplies it.
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0]);
+                jcol.copy_from_slice(&[0]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("no x");
+                values[0] = obj_factor * 2.0 / (x[0] * x[0] * x[0]);
+            }
+        }
+        true
+    }
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+#[test]
+fn a_masked_monotone_bound_optimum_is_reached_not_a_false_interior_success() {
+    let solve = |threshold: Number| {
+        let mut app = IpoptApplication::new();
+        // The default quasi-Newton path the issue is about.
+        app.options_mut()
+            .set_string_value("hessian_approximation", "limited-memory", true, false)
+            .unwrap();
+        app.options_mut()
+            .set_numeric_value("obj_scale_certificate_threshold", threshold, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_integer_value("max_iter", 300, true, false)
+            .unwrap();
+        app.options_mut()
+            .set_integer_value("print_level", 0, true, false)
+            .unwrap();
+        app.initialize().unwrap();
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(MonotoneToBound));
+        let status = app.optimize_tnlp(tnlp);
+        let s = app.statistics();
+        (status, s.final_objective, s.iteration_count)
+    };
+
+    // Veto disabled: the pre-fix baseline. It exhibits the reported pathology —
+    // a `Solve_Succeeded` certificate at the non-stationary interior point
+    // x ≈ 2.84 (f ≈ 0.35). This guards the premise: if the baseline ever stopped
+    // reproducing the masked false success, the assertion below would prove
+    // nothing.
+    let (base_status, base_obj, _base_iters) = solve(0.0);
+    assert!(
+        succeeded(base_status) && base_obj > 0.2,
+        "premise broken: the veto-off baseline is supposed to reproduce the gh #327 \
+         false interior success (f ≈ 0.35); got {base_status:?} f={base_obj:.6e}"
+    );
+
+    // Veto enabled (the default): the solve must reach the true bound optimum
+    // f = 0.1, not roll back to the interior point. Anything materially above 0.1
+    // means the fallback discarded the point the continuation actually reached.
+    let (veto_status, veto_obj, _veto_iters) = solve(1e-4);
+    assert!(
+        veto_obj <= 0.1 + 1e-3,
+        "gh #327: the masked monotone problem must converge to the bound optimum \
+         f = 0.1, but the veto returned {veto_status:?} f={veto_obj:.6e} — the fallback \
+         rolled back to the non-stationary interior point instead of keeping the \
+         would-be certificate at the bound"
+    );
+    // And that better point is a legitimate outcome, never a bare failure.
+    assert!(
+        succeeded(veto_status),
+        "gh #327: reached the bound optimum but reported {veto_status:?}"
+    );
+}

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1624,3 +1624,34 @@ def test_minimize_still_accepts_legitimate_infinite_bounds():
     r2 = pounce.minimize(f, np.array([0.5]), jac=g, bounds=[(0.0, np.inf)])
     assert r2.success
     assert r2.x[0] == pytest.approx(3.0, abs=1e-6)
+
+def test_minimize_extreme_objective_scale_monotone_reaches_bound_not_false_success():
+    """gh #327: ``min 1/x`` over ``x in [1e-12, 10]`` from x0 = 1e-12.
+
+    The objective is monotone decreasing, so the true optimum is the upper bound
+    x = 10, f = 0.1. The enormous initial gradient (``-1/x**2 = -1e24`` at x0)
+    pins pounce's gradient scaling at its 1e-8 floor, which deflates the scaled
+    KKT error below ``tol`` all along the trajectory. Previously the default
+    quasi-Newton path stopped at a non-stationary interior point x ≈ 2.84
+    (f ≈ 0.35, |grad| = 0.124, neither bound active) and reported
+    ``success=True, status=0`` — a false certificate. The masked-certificate veto
+    now keeps the point the continuation actually reaches (the bound optimum),
+    matching every independent oracle (ipopt MA57 / L-BFGS, scipy L-BFGS-B).
+    """
+    f = lambda z: 1.0 / z[0]
+    g = lambda z: np.array([-1.0 / z[0] ** 2])
+
+    r = pounce.minimize(
+        f,
+        np.array([1e-12]),
+        jac=g,
+        bounds=[(1e-12, 10.0)],
+        solver_selection="nlp",
+    )
+    # Must reach the true bound optimum, not the interior false success.
+    assert r.x[0] == pytest.approx(10.0, abs=1e-2)
+    assert r.fun == pytest.approx(0.1, abs=1e-3)
+    # And never report success at the non-stationary interior point x ≈ 2.84.
+    assert r.x[0] > 5.0, (
+        f"regressed to the gh #327 interior false optimum: x={r.x[0]}, f={r.fun}"
+    )


### PR DESCRIPTION
Closes #327.

## Problem

`pounce.minimize` on the default quasi-Newton NLP path reported
`Solve_Succeeded` (`success=True, status=0`) at a **non-KKT** point on
`min 1/x` over `x in [1e-12, 10]` from `x0=1e-12`. That objective is monotone
decreasing, so the optimum is the upper bound **x=10, f=0.1**; the solve instead
stopped at the interior point **x≈2.84, f≈0.35** (|grad|=0.124, neither bound
active).

## Root cause

The enormous initial gradient (`-1/x^2 = -1e24` at `x0`) pins pounce's gradient
scaling at its `1e-8` floor, so the **scaled** KKT error stays below `tol`
everywhere while the true user-space error is O(0.1) — the gh #200 masking
pathology.

The key finding: with `print_level=5`, the quasi-Newton solve **actually reaches
the bound optimum** (x≈10, f≈0.1) by iteration ~17 and settles there. But the
masked-certificate veto keeps refusing to certify — its unscaled error stays
above `acceptable_tol` at the true optimum too — so the run exits non-`Success`
on a tiny step. `honour_refused_certificate`'s failure branch then restored the
**chronologically first** refusal (x≈2.84) *unconditionally*, throwing away the
much better point the continuation had reached and reporting success there.

So the veto's own logged refusal was working; the fallback that consumes it was
discarding the reached optimum.

## Fix

In that failure branch, let the continued point displace the first refusal when
it is itself a **would-be strict certificate** — it passes the strict
per-component tolerances, i.e. it was refused *only* because of masking — and
ranks better under the existing feasibility-aware key (`ranks_better`).

The strict-certificate gate is load-bearing: it separates a settled true optimum
from a merely lower objective reached on an **unbounded ray** (e.g.
`A(x-a)^4 - K*sqrt(1+y^2)`, unbounded below in y), whose diverging iterate never
passes the strict test. Those runs, and every well-scaled / huge-objective
(#286/#307) solve, are bit-for-bit unchanged. Adds
`ConvCheck::current_passes_strict` (the strict gate minus the masking veto).

The outcome is the *preferred* one from the issue: the solver now **converges to
the true optimum**, not merely an honest non-success.

## Before / after (Python repro)

Before:
```
x=[2.837] fun=0.3525 success=True status=0   # false interior success
```
After:
```
x=[9.99909] fun=0.10001 success=True status=0   # true bound optimum
```
Matches every independent oracle (ipopt MA57 exact-Hessian, ipopt L-BFGS → 9.9953,
scipy L-BFGS-B, and pounce `hess=exact` → 10).

No regression on the cross-checks:

| case | x | success | status |
|---|---|---|---|
| #327 default quasi-Newton | 9.999 | True | 0 |
| #327 exact-Hessian | 10.000 | True | 0 |
| well-scaled `(x-3)^2` | 3.000 | True | 0 |

## Tests

- New Rust regression `a_masked_monotone_bound_optimum_is_reached_not_a_false_interior_success`
  in `masked_certificate_fuzz` (with a premise-guard confirming the veto-off
  baseline still reproduces the false interior success).
- New Python regression
  `test_minimize_extreme_objective_scale_monotone_reaches_bound_not_false_success`.
- `cargo test -p pounce-algorithm` — all 31 test binaries green, including the
  full adversarial `masked_certificate_fuzz` suite (gh #200 "never worse off"
  guarantee preserved).
- `pytest test_minimize.py test_problem.py test_sqp_warm_start.py` — 110 passed.
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
