### PR TITLE
Certify Optimal on scale-relative true-KKT for exp/power HSDE (#329)

### DIFF
--- a/crates/pounce-convex/src/hsde_nonsym.rs
+++ b/crates/pounce-convex/src/hsde_nonsym.rs
@@ -28,7 +28,9 @@
 //! The barrier oracles, conjugate-gradient shadow iterate, and the scaling
 //! itself live in [`crate::cones::exp`]; this module is the outer iteration.
 
-use crate::cones::{BarrierCone, Cone, ConeBlock, ExponentialCone, PowerCone, SecondOrderCone};
+use crate::cones::{
+    BarrierCone, Cone, ConeBlock, ConeSpec, ExponentialCone, PowerCone, SecondOrderCone,
+};
 use crate::debug::{ConvexDebugState, fire};
 use crate::ipm::{QpOptions, build_rhs, detect_infeasibility_with, dot, inf_norm, split_step};
 use crate::qp::{QpProblem, QpSolution, QpStatus, breakdown_status};
@@ -446,6 +448,21 @@ impl NsCone {
         true
     }
 
+    /// This cone product as the [`ConeSpec`] list consumed by
+    /// [`QpSolution::kkt_residuals_conic`], so the recovered point can be scored
+    /// against the same conic optimality measure the direct/symmetric paths use.
+    fn cone_specs(&self) -> Vec<ConeSpec> {
+        self.blocks
+            .iter()
+            .map(|&(_, b)| match b {
+                NsBlock::Orthant(n) => ConeSpec::Nonneg(n),
+                NsBlock::SecondOrder(m) => ConeSpec::SecondOrder(m),
+                NsBlock::Nonsym(NonsymCone::Exp(_)) => ConeSpec::Exponential,
+                NsBlock::Nonsym(NonsymCone::Power(pc)) => ConeSpec::Power(pc.alpha),
+            })
+            .collect()
+    }
+
     /// Self-dual starting iterate `e` (orthant: ones; non-symmetric cone: the
     /// cone's `interior_reference`, which lies in both `K` and `K*`). The
     /// corrector recenters from here, so an exact central point is not needed.
@@ -507,6 +524,116 @@ enum BlockScaling {
 /// representation. Above this, the aux form avoids the dense `O(m²)` fill that
 /// the review (L41) flagged for large SOCs mixed with exp cones.
 const SOC_DENSE_MAX_DIM: usize = 3;
+
+/// Multiple of `tol` at which a *scale-relative* true conic KKT residual is
+/// tight enough to promote a `near_opt` breakdown / iteration-limit iterate from
+/// `OptimalInaccurate` to `Optimal` (see the post-loop adjudication in
+/// [`run_nonsym`]). At the default `tol = 1e-8` this is `1e-6`: two orders below
+/// the reduced-accuracy salvage band (`√tol = 1e-4`) and one order below the
+/// in-loop `near_opt` band (`1e3·tol = 1e-5`), so a genuinely reduced-accuracy
+/// point stays `OptimalInaccurate` while a point solved to the exp/power cone's
+/// achievable floor (empirically ~1e-7 scale-relative) is certified `Optimal`.
+/// Because it multiplies `tol`, a caller-tightened tolerance tightens the
+/// promotion gate in lock-step.
+const PROMOTE_REL_TOL_FACTOR: f64 = 1e2;
+
+/// Relative slack by which the promotion's dual-feasibility check tolerates the
+/// recovered dual `ẑ` lying *outside* `K*`. At a true conic optimum complementary
+/// slackness puts `ẑ` on the boundary of `K*` (dual-slack margin → 0), so the
+/// membership test must accept the closure `cl(K*)` up to numerical noise rather
+/// than demand a strict interior. Kept far below `PROMOTE_REL_TOL_FACTOR·tol` so
+/// dual feasibility is verified far more tightly than the overall KKT budget.
+const DUAL_CLOSURE_SLACK: f64 = 1e-9;
+
+/// Scale-relative true conic KKT residual of the **un-homogenized** iterate
+/// `(x, y, z)/τ`, or `None` when it is not a valid optimality certificate.
+///
+/// Returns `None` when `τ ≤ 0` (an infeasibility ray, where un-homogenizing is
+/// meaningless) or when `ẑ = z/τ` has left the dual cone `K*` — without
+/// `ẑ ∈ K*` the residuals below are not a KKT certificate however small they
+/// are (this is the safety gate that keeps the promotion off infeasible /
+/// unbounded solves). Otherwise it scores the recovered point with
+/// [`QpSolution::kkt_residuals_conic`] (each block measured against *its own*
+/// cone) and normalizes each residual by the magnitude of its own constituent
+/// terms (Clarabel-style), so the certificate is invariant to problem scaling.
+fn true_kkt_scale_rel(
+    prob: &QpProblem,
+    cone: &NsCone,
+    x: &[f64],
+    y: &[f64],
+    z: &[f64],
+    tau: f64,
+) -> Option<f64> {
+    if !(tau > 0.0) {
+        return None;
+    }
+    let inv = 1.0 / tau;
+    let z_hat: Vec<f64> = z.iter().map(|v| v * inv).collect();
+    // Dual feasibility `ẑ ∈ K*` is required for the residuals below to be a KKT
+    // certificate. But at a true optimum complementary slackness places `ẑ` on
+    // the *boundary* of `K*` (its dual-slack margin → 0), so the strict-interior
+    // `in_dual_cone(·, +tol)` test is the wrong one here — it rejects exactly the
+    // duals optimality produces (the p=4 power ball's dual sits ~1e-11 inside the
+    // boundary, well under a 1e-9 interior margin). Test membership in the
+    // *closure* instead, tolerating a small numerical slack outside: a negative
+    // tolerance turns `in_dual_cone`'s interior margin (`margin > tol·(1+‖·‖)`)
+    // into the relaxed-closure test `margin > −slack·(1+‖·‖)`, so `ẑ` may lie up
+    // to `DUAL_CLOSURE_SLACK` (relative) outside `K*`. That slack is far tighter
+    // than the scale-relative promotion budget, so it never admits a dual that
+    // is not, to numerical precision, feasible.
+    if !cone.in_dual_cone(&z_hat, -DUAL_CLOSURE_SLACK) {
+        return None;
+    }
+    let x_hat: Vec<f64> = x.iter().map(|v| v * inv).collect();
+    let y_hat: Vec<f64> = y.iter().map(|v| v * inv).collect();
+    let n = prob.n;
+    let m_eq = prob.m_eq();
+    let m_ineq = prob.m_ineq();
+
+    // True conic KKT residuals (primal cone-membership, stationarity,
+    // per-block complementarity) at the recovered point.
+    let candidate = QpSolution {
+        status: QpStatus::Optimal,
+        x: x_hat.clone(),
+        y: y_hat.clone(),
+        z: z_hat.clone(),
+        z_lb: vec![0.0; n],
+        z_ub: vec![0.0; n],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    };
+    let res = candidate.kkt_residuals_conic(prob, &cone.cone_specs());
+
+    // Scale normalizers: each residual by the magnitude of the terms that
+    // compose it, so a large-data problem is not held to an unreachable
+    // absolute floor and a well-scaled one is not judged loosely.
+    let inf = |v: &[f64]| v.iter().fold(0.0f64, |m, &a| m.max(a.abs()));
+    let mut px = vec![0.0; n];
+    prob.p_mul(&x_hat, &mut px);
+    let mut aty = vec![0.0; n];
+    prob.at_mul(&y_hat, &mut aty);
+    let mut gtz = vec![0.0; n];
+    prob.gt_mul(&z_hat, &mut gtz);
+    let scale_d = inf(&px).max(inf(&aty)).max(inf(&gtz)).max(inf(&prob.c));
+    let mut ax = vec![0.0; m_eq];
+    prob.a_mul(&x_hat, &mut ax);
+    let mut gx = vec![0.0; m_ineq];
+    prob.g_mul(&x_hat, &mut gx);
+    let s_hat: Vec<f64> = (0..m_ineq).map(|i| prob.h[i] - gx[i]).collect();
+    let scale_p = inf(&ax)
+        .max(inf(&gx))
+        .max(inf(&s_hat))
+        .max(inf(&prob.b))
+        .max(inf(&prob.h));
+    let obj = 0.5 * dot(&x_hat, &px) + dot(&prob.c, &x_hat);
+    let scale_g = obj.abs();
+
+    let pres_rel = res.primal_infeasibility / (1.0 + scale_p);
+    let dres_rel = res.dual_infeasibility / (1.0 + scale_d);
+    let gap_rel = res.complementarity / (1.0 + scale_g);
+    Some(pres_rel.max(dres_rel).max(gap_rel))
+}
 
 /// KKT value-array positions for one cone block.
 enum ZPos {
@@ -1488,12 +1615,41 @@ where
     // fires for infeasible/unbounded problems (their residuals never get this
     // small — the embedding drives τ → 0 and the certificate path triggers
     // first) and never relaxes the clean convergence test above (still `tol`).
+    // Post-loop optimality adjudication. The in-loop test certifies `Optimal`
+    // only on an *absolute* KKT residual below `tol`. On a non-symmetric cone
+    // (exp/power) the barrier Hessian's conditioning worsens near the boundary
+    // (ψ → 0), so that absolute residual can floor a little above `tol` at a
+    // genuinely optimal point; the driver then breaks down `near_opt` (labelling
+    // the iterate `OptimalInaccurate`) or exhausts its budget. Re-adjudicate the
+    // recovered point against the *true, scale-relative* conic KKT residual —
+    // the scale-invariant optimality measure for a convex conic program — and
+    // promote to `Optimal` only when that certificate is genuinely tight *and*
+    // the recovered dual is in `K*`:
+    //   * `ẑ ∈ K*` and scale-relative KKT error < `PROMOTE_REL_TOL_FACTOR·tol`
+    //       → `Optimal`
+    //   * best iterate within the reduced-accuracy band (`√tol`)
+    //       → `OptimalInaccurate`
+    //   * otherwise the loop's own verdict stands.
+    //
+    // This never *relaxes* the in-loop `tol` test (that already returned) and is
+    // strictly safe: the promotion is gated on `ẑ ∈ K*` (dual feasibility) plus
+    // a scale-relative residency two orders below the reduced-accuracy band, so
+    // for a convex program — where KKT is sufficient for global optimality — it
+    // can only fire at a genuine optimum. Infeasible / unbounded solves
+    // terminate with a certificate status (`PrimalInfeasible` / `DualInfeasible`)
+    // and never reach here; a τ → 0 ray or an out-of-`K*` dual returns `None`
+    // from the certificate and is never promoted.
     if matches!(
         status,
-        QpStatus::NumericalFailure | QpStatus::IterationLimit
+        QpStatus::OptimalInaccurate | QpStatus::NumericalFailure | QpStatus::IterationLimit
     ) {
+        // Restore the lowest-residual iterate we saw (τ > 0) — the point we
+        // actually adjudicate. For a `near_opt` breakdown this is at least as
+        // good as the breakdown iterate; it also carries the prior NF/IL →
+        // reduced-accuracy salvage.
         let reduced_acc = opts.tol.sqrt();
-        if best_res < reduced_acc {
+        let restore = best_res < reduced_acc;
+        if restore {
             if let Some((bx, by, bz, bs, btau, _bkappa)) = best.take() {
                 // κ is not read downstream (the recovery un-homogenizes by
                 // 1/τ); restoring x/y/z/s/τ is what the solution recovery and
@@ -1503,9 +1659,17 @@ where
                 z = bz;
                 s = bs;
                 tau = btau;
-                status = QpStatus::OptimalInaccurate;
             }
         }
+        let promoted = true_kkt_scale_rel(prob, &cone, &x, &y, &z, tau)
+            .is_some_and(|e| e < PROMOTE_REL_TOL_FACTOR * opts.tol);
+        status = if promoted {
+            QpStatus::Optimal
+        } else if restore {
+            QpStatus::OptimalInaccurate
+        } else {
+            status
+        };
     }
 
     let inv = if tau.abs() > 0.0 { 1.0 / tau } else { 1.0 };
@@ -2407,5 +2571,93 @@ mod tests {
             ub: vec![],
         };
         assert!(!detect_cone_domain_infeasible(&pw, &[NsBlock::power(0.5)]));
+    }
+
+    // ---- gh #329: the scale-relative optimality certificate that gates the
+    // OptimalInaccurate → Optimal promotion. Its safety rests on two hard gates
+    // (`τ > 0` and `ẑ ∈ cl(K*)`); these pin them directly. ----
+
+    /// An infeasibility ray (`τ ≤ 0`) has no meaningful un-homogenized point, so
+    /// the certificate returns `None` and can never promote a ray to `Optimal`.
+    #[test]
+    fn scale_rel_cert_rejects_tau_nonpositive() {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, -1.0)],
+            h: vec![0.0, 1.0, 0.0],
+            lb: vec![],
+            ub: vec![],
+        };
+        let cone = NsCone::new(&[NsBlock::exp()]);
+        let z = [0.0, 0.0, 0.0];
+        assert_eq!(
+            true_kkt_scale_rel(&prob, &cone, &[0.0], &[], &z, 0.0),
+            None,
+            "τ = 0 must yield no certificate"
+        );
+        assert_eq!(
+            true_kkt_scale_rel(&prob, &cone, &[0.0], &[], &z, -1.0),
+            None,
+            "τ < 0 must yield no certificate"
+        );
+    }
+
+    /// A dual `ẑ` well outside `K*` is not a KKT certificate however small the
+    /// other residuals; the `ẑ ∈ cl(K*)` gate returns `None` (never promoted).
+    /// The exp dual `K_exp*` requires `u < 0`, so `(1, 1, 1)` is firmly outside.
+    #[test]
+    fn scale_rel_cert_rejects_dual_outside_cone() {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![0.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, -1.0)],
+            h: vec![0.0, 1.0, 0.0],
+            lb: vec![],
+            ub: vec![],
+        };
+        let cone = NsCone::new(&[NsBlock::exp()]);
+        let z_bad = [1.0, 1.0, 1.0]; // u = 1 > 0 ⇒ not in K_exp*
+        assert!(
+            !cone.in_dual_cone(&z_bad, -DUAL_CLOSURE_SLACK),
+            "sanity: (1,1,1) is outside cl(K_exp*)"
+        );
+        assert_eq!(
+            true_kkt_scale_rel(&prob, &cone, &[0.0], &[], &z_bad, 1.0),
+            None,
+            "a dual outside K* must yield no certificate"
+        );
+    }
+
+    /// The closure gate accepts a dual *on* the boundary of `K*` (where a true
+    /// conic optimum's dual sits by complementary slackness) that the old
+    /// strict-interior `+1e-9` test rejected — this is exactly what unblocks the
+    /// gh #329 promotion — while a dual a finite distance outside stays rejected.
+    #[test]
+    fn dual_closure_gate_accepts_boundary_rejects_exterior() {
+        let cone = NsCone::new(&[NsBlock::power(0.5)]);
+        // Boundary of K_{0.5}*: |u| = (v/α)^α (w/(1−α))^(1−α) = sqrt(v·w)·2.
+        // Take v = w = 0.5 ⇒ bound = sqrt(0.25)·2 = 1.0; u = 1.0 is on ∂K*.
+        let on_boundary = [1.0, 0.5, 0.5];
+        assert!(
+            !cone.in_dual_cone(&on_boundary, 1e-9),
+            "strict-interior test rejects the boundary dual (the gh #329 defect)"
+        );
+        assert!(
+            cone.in_dual_cone(&on_boundary, -DUAL_CLOSURE_SLACK),
+            "closure gate must accept the boundary dual"
+        );
+        // A dual well outside (u = 1.5 > bound = 1.0) is still rejected.
+        let exterior = [1.5, 0.5, 0.5];
+        assert!(
+            !cone.in_dual_cone(&exterior, -DUAL_CLOSURE_SLACK),
+            "closure gate must still reject an exterior dual"
+        );
     }
 }

--- a/crates/pounce-convex/tests/conic_nonsym_status.rs
+++ b/crates/pounce-convex/tests/conic_nonsym_status.rs
@@ -1,0 +1,232 @@
+//! Status-labelling regression tests for the non-symmetric (exp / power) HSDE
+//! driver (gh #329).
+//!
+//! Correctly-solved geometric-program / power-cone problems whose barrier
+//! Hessian conditions poorly near the cone boundary used to floor their
+//! *absolute* KKT residual a hair above `tol` and be reported
+//! `OptimalInaccurate` / `success=False`, even though the objective and
+//! minimiser matched the reference solvers (ECOS/SCS/Clarabel) to ~1e-7. The
+//! driver now re-adjudicates such a stalled iterate against the *scale-relative*
+//! true conic KKT residual (with `ẑ ∈ K*` required) and certifies `Optimal`
+//! when it is genuinely tight. These tests pin both the promoted `Optimal`
+//! labels **and** — critically — that infeasible / unbounded conic solves are
+//! unchanged (never falsely promoted).
+
+use pounce_convex::{ConeSpec, QpOptions, QpProblem, QpStatus, Triplet, solve_socp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn solve(prob: &QpProblem, cones: &[ConeSpec]) -> pounce_convex::QpSolution {
+    let opts = QpOptions::default();
+    solve_socp_ipm(prob, cones, &opts, backend)
+}
+
+/// Append a 3-row exp block enforcing `t_col ≥ exp(sign · x[lin_col])`, in the
+/// `solve_socp` convention `s = (s0, s1, s2)` with `s1·exp(s0/s1) ≤ s2`,
+/// `s0 = sign·x[lin_col]`, `s1 = 1`, `s2 = x[t_col]`.
+fn exp_block(lin_col: usize, sign: f64, t_col: usize, g: &mut Vec<Triplet>, h: &mut Vec<f64>) {
+    let r0 = h.len();
+    g.push(Triplet::new(r0, lin_col, -sign));
+    h.push(0.0);
+    h.push(1.0); // row r0+1 all-zero ⇒ s1 = 1
+    let r2 = h.len();
+    g.push(Triplet::new(r2, t_col, -1.0));
+    h.push(0.0);
+}
+
+/// gh #329 case 1: separable GP `min x + 4/x + y + 9/y`, four exp cones with
+/// non-unit coefficients. Known optimum `10` at `(x, y) = (2, 3)`. Was
+/// `OptimalInaccurate`; must now be `Optimal` with the same correct objective.
+#[test]
+fn exp_gp_four_cones_reports_optimal() {
+    // vars z = [u, v, t1, t2, t3, t4], with x = e^u, y = e^v.
+    let (iu, iv, it1, it2, it3, it4) = (0, 1, 2, 3, 4, 5);
+    let mut c = vec![0.0; 6];
+    c[it1] = 1.0;
+    c[it2] = 4.0;
+    c[it3] = 1.0;
+    c[it4] = 9.0;
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    exp_block(iu, 1.0, it1, &mut g, &mut h); // t1 ≥ e^{u}
+    exp_block(iu, -1.0, it2, &mut g, &mut h); // t2 ≥ e^{-u}
+    exp_block(iv, 1.0, it3, &mut g, &mut h); // t3 ≥ e^{v}
+    exp_block(iv, -1.0, it4, &mut g, &mut h); // t4 ≥ e^{-v}
+    let prob = QpProblem {
+        n: 6,
+        p_lower: vec![],
+        c,
+        a: vec![],
+        b: vec![],
+        g,
+        h,
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob, &[ConeSpec::Exponential; 4]);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "correctly-solved GP must report Optimal, got {:?}",
+        sol.status
+    );
+    // Objective and minimiser correct to the cone's achievable floor (~1e-7).
+    assert!(
+        (sol.obj - 10.0).abs() < 1e-5,
+        "objective {} must match known optimum 10",
+        sol.obj
+    );
+    let (x_star, y_star) = (sol.x[0].exp(), sol.x[1].exp());
+    assert!((x_star - 2.0).abs() < 1e-3, "x* = {x_star} vs 2");
+    assert!((y_star - 3.0).abs() < 1e-3, "y* = {y_star} vs 3");
+}
+
+/// The simpler two-cone GP `min x + 1/x` (optimum `2`) already reported a clean
+/// `Optimal`; guard that the change leaves it — and its objective — untouched.
+#[test]
+fn exp_gp_two_cones_stays_optimal() {
+    // vars [u, t1, t2], x = e^u.
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    exp_block(0, 1.0, 1, &mut g, &mut h); // t1 ≥ e^{u}
+    exp_block(0, -1.0, 2, &mut g, &mut h); // t2 ≥ e^{-u}
+    let prob = QpProblem {
+        n: 3,
+        p_lower: vec![],
+        c: vec![0.0, 1.0, 1.0],
+        a: vec![],
+        b: vec![],
+        g,
+        h,
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob, &[ConeSpec::Exponential; 2]);
+    assert_eq!(sol.status, QpStatus::Optimal, "got {:?}", sol.status);
+    assert!((sol.obj - 2.0).abs() < 1e-6, "objective {} vs 2", sol.obj);
+}
+
+/// gh #329 case 2: `max cᵀx s.t. ‖x‖₄ ≤ 1`, four power cones `K_{1/4}`. Known
+/// optimum `‖c‖_{4/3}` (Hölder). Was `OptimalInaccurate`; must now be `Optimal`.
+#[test]
+fn power_dualnorm_p4_reports_optimal() {
+    let p = 4.0;
+    let alpha = 1.0 / p;
+    let c_obj: [f64; 4] = [1.0, -2.0, 3.0, 0.5];
+    let q = p / (p - 1.0);
+    let known: f64 = c_obj
+        .iter()
+        .map(|v| v.abs().powf(q))
+        .sum::<f64>()
+        .powf(1.0 / q); // ‖c‖_{4/3}
+    let n = 4;
+    let nv = 2 * n; // [x0..3, z0..3]
+    let mut c = vec![0.0; nv];
+    for i in 0..n {
+        c[i] = -c_obj[i]; // min −cᵀx
+    }
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    for i in 0..n {
+        let r0 = h.len();
+        g.push(Triplet::new(r0, i, -1.0)); // s0 = x_i
+        h.push(0.0);
+        let r1 = h.len();
+        g.push(Triplet::new(r1, n + i, -1.0)); // s1 = z_i
+        h.push(0.0);
+        h.push(1.0); // s2 = 1 (const)
+    }
+    // Equality Σ z_i = 1.
+    let a: Vec<Triplet> = (0..n).map(|i| Triplet::new(0, n + i, 1.0)).collect();
+    let prob = QpProblem {
+        n: nv,
+        p_lower: vec![],
+        c,
+        a,
+        b: vec![1.0],
+        g,
+        h,
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob, &[ConeSpec::Power(alpha); 4]);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "correctly-solved power-ball must report Optimal, got {:?}",
+        sol.status
+    );
+    // Recovered max value = cᵀx = −obj.
+    let max_val = -sol.obj;
+    assert!(
+        (max_val - known).abs() < 1e-5,
+        "max value {max_val} must match ‖c‖_(4/3) = {known}"
+    );
+    // And the recovered point is feasible: ‖x‖₄ ≤ 1.
+    let norm4: f64 = (0..n)
+        .map(|i| sol.x[i].abs().powf(p))
+        .sum::<f64>()
+        .powf(1.0 / p);
+    assert!(norm4 <= 1.0 + 1e-6, "‖x‖₄ = {norm4} must be ≤ 1");
+}
+
+// ---- NEGATIVE tests: infeasible / unbounded conic solves are UNCHANGED and
+// are never falsely promoted to Optimal by the new adjudication. ----
+
+/// An unbounded exp program (`min u` with `t ≥ e^u`, so `u → −∞`) must still
+/// certify `DualInfeasible` — never `Optimal`.
+#[test]
+fn unbounded_exp_still_dual_infeasible() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 0.0], // min u
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, -1.0), Triplet::new(2, 1, -1.0)],
+        h: vec![0.0, 1.0, 0.0], // slack = (u, 1, t)
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob, &[ConeSpec::Exponential]);
+    assert_eq!(
+        sol.status,
+        QpStatus::DualInfeasible,
+        "unbounded exp program must stay DualInfeasible, got {:?}",
+        sol.status
+    );
+    assert_ne!(sol.status, QpStatus::Optimal);
+}
+
+/// A power program whose cone `y`-slack is forced strictly negative (domain
+/// violation `t − 2 ≤ T − 2 < 0`) must still certify `PrimalInfeasible`.
+#[test]
+fn infeasible_power_domain_still_primal_infeasible() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 0.0], // min w
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, -1.0), // s0 = w
+            Triplet::new(1, 1, -1.0), // s1 = t − 2
+            Triplet::new(3, 1, 1.0),  // s3 = T − t ≥ 0
+        ],
+        h: vec![0.0, -2.0, 1.0, 1.0], // s2 = 1 (const), T = 1
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob, &[ConeSpec::Power(0.5), ConeSpec::Nonneg(1)]);
+    assert_eq!(
+        sol.status,
+        QpStatus::PrimalInfeasible,
+        "power domain violation must stay PrimalInfeasible, got {:?}",
+        sol.status
+    );
+    assert_ne!(sol.status, QpStatus::Optimal);
+}


### PR DESCRIPTION
Closes #329

## Problem
The non-symmetric (exp/power) HSDE conic driver returned
`status="optimal_inaccurate"` / `success=False` on correctly-solved
geometric-program / power-cone problems, even though the objective and
minimiser matched cvxpy's ECOS/SCS/Clarabel to ~1e-7. A user gating on
`res.success` (the documented pattern) wrongly saw a solved GP as a failure.

## Diagnosis (true residual at termination)
Instrumented the two adversary repros through the public path and measured
the **true conic KKT residual** (`kkt_residuals_conic().kkt_error()`) at the
returned point:

| problem | terminal status | true abs KKT | scale-relative KKT |
|---|---|---|---|
| exp GP `min x+4/x+y+9/y` (opt 10, 4 exp cones) | OptimalInaccurate | 5.07e-7 | 5.2e-8 |
| power p=4 dual-norm ball (opt 4.865, 4 pow cones) | OptimalInaccurate | 1.86e-6 | 3.2e-7 |
| simple `min x+1/x` (opt 2, 2 exp cones) | **Optimal** | 6.1e-9 | 2.3e-9 |

So this is **not** a fully-solved point that was mislabeled (residual is not
~1e-15) — the exp/power barrier Hessian conditions poorly near the cone
boundary (psi -> 0), the driver **breaks down `near_opt` at iter 8/17** and
the *absolute* residual genuinely floors ~5e-7, a hair above `tol=1e-8`.
But the **scale-relative** residual (5e-8 / 3e-7) is genuinely tight — the
point is optimal to ~7 significant figures, matching the reference solvers.

## Root cause
`hsde_nonsym.rs` certified `Optimal` only on the in-loop *absolute* test
`pres<tol && dres<tol && gap<tol`, unreachable on these cones. Unlike the
symmetric driver (`hsde.rs`), it had **no post-loop optimality
adjudication** — a `near_opt` breakdown was labelled `OptimalInaccurate` and
never reconsidered.

## Fix (verification-gated promotion only)
`crates/pounce-convex/src/hsde_nonsym.rs`: after the loop, re-adjudicate the
recovered iterate against the **true, scale-relative conic KKT residual**
(new `true_kkt_scale_rel`), mirroring the symmetric driver's post-loop
`true_kkt_error` promotion. Promote `OptimalInaccurate`/`NumericalFailure`/
`IterationLimit` to `Optimal` **only when**:
1. `tau > 0` (a real un-homogenized point, not an infeasibility ray), and
2. `z_hat` in `cl(K*)` — dual feasibility. The old strict-interior `+1e-9`
   test is the *wrong* test at an optimum: complementary slackness puts the
   dual **on** the boundary of `K*` (margin -> 0), so it rejected exactly the
   duals optimality produces (the p=4 ball's dual sits ~1e-11 inside). Now a
   closure test tolerating a tight numerical slack (`DUAL_CLOSURE_SLACK=1e-9`
   outside), and
3. scale-relative true conic KKT error (primal cone membership + stationarity
   + per-block complementarity, each normalised by its own term magnitudes)
   `< PROMOTE_REL_TOL_FACTOR * tol` (1e-6 at the default) — two orders below
   the reduced-accuracy salvage band (`sqrt(tol)=1e-4`), one below the in-loop
   `near_opt` band (`1e3*tol`).

Both thresholds multiply `tol`, so a caller-tightened tolerance tightens the
gate in lock-step. The in-loop `tol` test is untouched.

## Safety argument (no false Optimal is possible)
For a convex conic program, KKT conditions are **sufficient** for global
optimality. Promotion fires only when the recovered point satisfies primal
cone membership, dual cone membership (`z_hat` in cl(K*)), stationarity and
per-block complementarity **all** to 1e-6 relative — the definition of a
1e-6-optimal point; no non-optimal point can meet it. The dual-cone gate is
the key safety lock; it is verified far more tightly (1e-9) than the overall
budget. Infeasible/unbounded solves terminate with `PrimalInfeasible` /
`DualInfeasible` and never reach this code; a `tau -> 0` ray or an out-of-K*
dual yields no certificate (`None`) and is never promoted. A NaN iterate
fails `NaN < 1e-6` and is never promoted. This is the mirror image of #324/#327
done conservatively: when the certificate is not tight the label stays
`OptimalInaccurate`.

## Before / after (objectives unchanged)
```
exp GP    : optimal_inaccurate success=False  ->  optimal success=True   obj 9.9999988204 (ECOS/SCS 10.0)
power p=4 : optimal_inaccurate               ->  optimal                 max 4.8649820771 (Clarabel/SCS 4.8649838)
```

## Tests
- New `crates/pounce-convex/tests/conic_nonsym_status.rs`: exp GP (opt 10)
  and power p=4 ball now report `Optimal` with the correct objective; the
  simple 2-cone GP stays `Optimal`; **negative** — unbounded exp stays
  `DualInfeasible`, infeasible power-domain stays `PrimalInfeasible`.
- New unit tests pinning the safety gates: `true_kkt_scale_rel` returns
  `None` for `tau <= 0` and for a dual outside `K*`; the closure gate accepts
  an on-boundary dual (the #329 unblock) but still rejects an exterior one.
- Full `cargo test -p pounce-convex` green (164 tests); all
  infeasibility/unboundedness conic tests **unchanged**.
- `python -m pytest test_qp.py test_socp.py test_minimize_socp_autoroute.py
  test_qp_host.py` green; both adversary scripts now `VERDICT: PASS` with
  `status=optimal` and identical objectives.
- `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
