### PR TITLE
Fix HSDE exp/power driver reporting numerical_failure on correct answers under extreme scaling (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — HSDE exp/power driver reported `numerical_failure` on correct answers under extreme scaling (#336)
+
+- **The non-symmetric (exp/power) HSDE conic driver no longer discards a
+  correct solution as `numerical_failure` when the data are extremely (but
+  legitimately) scaled.** Its post-loop status test keyed the reduced-accuracy
+  salvage off the *absolute* KKT residual, which carries the raw, unnormalized
+  complementarity gap `s·z`. When the optimal cone variables are large (e.g. a
+  geometric program with `K = 1e12`, whose optimal cone values are `~1e6`), that
+  absolute floor scales with them and can never reach the absolute tolerance —
+  so a point that is primal-feasible, dual-feasible, and objective-correct was
+  labelled a failure and `success=False`, and the answer was thrown away.
+  - Fix: the adjudication now scores the recovered point on the *scale-relative*
+    conic KKT residual (each residual normalized by its own term magnitudes, as
+    ECOS/Clarabel do) at whichever of the final and best-snapshot iterates
+    certifies tighter. A genuinely tight certificate at a dual-feasible point is
+    still promoted to `Optimal`; a primal/dual-feasible point whose *normalized*
+    gap is only moderately above `tol` (the accuracy plateau of a
+    boundary-riding non-symmetric cone) is reported `OptimalInaccurate` —
+    matching the symmetric SOC driver and ECOS/Clarabel's `*_inacc` — instead of
+    a spurious `NumericalFailure`. The prior absolute reduced-accuracy fallback
+    is retained, so a well-scaled near-`tol` stall salvages exactly as before.
+  - Extends the scale-relative adjudication of #329 to the reduced-accuracy
+    salvage; the conic analogue of the scale-normalization work in #286/#293.
+    Infeasible / unbounded conic solves are unchanged (they terminate with a
+    certificate status before the adjudication and are never falsely promoted).
+  - Regression: `crates/pounce-convex/tests/issue336_scale_status.rs` reproduces
+    both cases — the `K`-swept exponential GP (`Optimal` while the certificate
+    is tight, then `OptimalInaccurate` on the plateau, never `NumericalFailure`)
+    and the large-budget power cone — and pins the well-scaled end at `Optimal`.
+
 ### Fixed — active-set path printed a `nan` scaled objective (#313)
 
 - On the active-set (`qp-active-set` / SQP) path, `final_scaled_objective` was

--- a/crates/pounce-convex/src/hsde_nonsym.rs
+++ b/crates/pounce-convex/src/hsde_nonsym.rs
@@ -1643,17 +1643,40 @@ where
         status,
         QpStatus::OptimalInaccurate | QpStatus::NumericalFailure | QpStatus::IterationLimit
     ) {
-        // Restore the lowest-residual iterate we saw (τ > 0) — the point we
-        // actually adjudicate. For a `near_opt` breakdown this is at least as
-        // good as the breakdown iterate; it also carries the prior NF/IL →
-        // reduced-accuracy salvage.
         let reduced_acc = opts.tol.sqrt();
-        let restore = best_res < reduced_acc;
+
+        // Score both candidate iterates — the loop's final one and the best
+        // (lowest in-loop-residual) snapshot — on the *scale-relative* conic KKT
+        // residual, the scale-invariant optimality certificate. gh #336: the
+        // in-loop residual carries the raw, *unnormalized* complementarity gap
+        // `s·z`, whose absolute floor grows with the optimal cone magnitudes, so
+        // on extreme-but-legitimate data scaling it stalls well above `tol` even
+        // at a point that is primal-feasible, dual-feasible, and objective-
+        // correct. The absolute residual therefore must not gate the salvage;
+        // `true_kkt_scale_rel` (each residual normalized by its own term
+        // magnitudes) can. Adjudicate on whichever iterate certifies tighter.
+        let final_rel = true_kkt_scale_rel(prob, &cone, &x, &y, &z, tau);
+        let best_rel = best
+            .as_ref()
+            .and_then(|(bx, by, bz, _bs, bt, _)| true_kkt_scale_rel(prob, &cone, bx, by, bz, *bt));
+        let use_best = match (best_rel, final_rel) {
+            (Some(b), Some(f)) => b < f,
+            (Some(_), None) => true,
+            _ => false,
+        };
+        // Absolute reduced-accuracy fallback (the prior salvage path): a
+        // well-scaled solve that stalled a hair short of `tol` still salvages,
+        // even when its scale-relative certificate is unavailable (e.g. the
+        // recovered dual sits just outside `K*`).
+        let abs_salvage = best_res < reduced_acc;
+        // Restore the best snapshot when it is the point we adjudicate — either it
+        // certifies tighter than the final iterate, or the absolute fallback fires
+        // on it. κ is not read downstream (the recovery un-homogenizes by 1/τ);
+        // restoring x/y/z/s/τ is what the solution recovery and post-mortem hook
+        // consume.
+        let restore = use_best || abs_salvage;
         if restore {
             if let Some((bx, by, bz, bs, btau, _bkappa)) = best.take() {
-                // κ is not read downstream (the recovery un-homogenizes by
-                // 1/τ); restoring x/y/z/s/τ is what the solution recovery and
-                // the post-mortem hook consume.
                 x = bx;
                 y = by;
                 z = bz;
@@ -1661,14 +1684,23 @@ where
                 tau = btau;
             }
         }
-        let promoted = true_kkt_scale_rel(prob, &cone, &x, &y, &z, tau)
-            .is_some_and(|e| e < PROMOTE_REL_TOL_FACTOR * opts.tol);
-        status = if promoted {
-            QpStatus::Optimal
-        } else if restore {
-            QpStatus::OptimalInaccurate
-        } else {
-            status
+        // Certificate of the point we actually return.
+        let rel = if restore { best_rel } else { final_rel };
+        status = match rel {
+            // Genuinely tight scale-relative certificate at a dual-feasible point
+            // (the `ẑ ∈ K*` gate lives in `true_kkt_scale_rel`): a clean
+            // `Optimal`.
+            Some(e) if e < PROMOTE_REL_TOL_FACTOR * opts.tol => QpStatus::Optimal,
+            // Primal- and dual-feasible with a *normalized* gap only moderately
+            // above `tol` — the accuracy plateau of a boundary-riding
+            // non-symmetric cone under extreme scaling. Usable at reduced
+            // accuracy: report `OptimalInaccurate` (matching the symmetric SOC
+            // driver) rather than discarding a correct answer as a spurious
+            // `NumericalFailure` (gh #336).
+            Some(e) if e < reduced_acc => QpStatus::OptimalInaccurate,
+            // Absolute-residual salvage for the well-scaled near-`tol` stall.
+            _ if abs_salvage => QpStatus::OptimalInaccurate,
+            _ => status,
         };
     }
 

--- a/crates/pounce-convex/tests/issue336_scale_status.rs
+++ b/crates/pounce-convex/tests/issue336_scale_status.rs
@@ -1,0 +1,166 @@
+//! gh #336 regression: the non-symmetric (exp/power) HSDE driver reported
+//! `NumericalFailure` on *correct* answers under extreme-but-legitimate data
+//! scaling. Its status test keyed off the raw (unnormalized) complementarity
+//! gap `s·z`, whose absolute floor grows with the optimal cone magnitudes, so a
+//! point that is primal-feasible, dual-feasible, and objective-correct could
+//! never reach the absolute tolerance and was discarded as a failure. The
+//! post-loop adjudication now scores the recovered point on the scale-relative
+//! conic KKT residual, certifying `Optimal` when it is tight and
+//! `OptimalInaccurate` (never a spurious `NumericalFailure`) on the accuracy
+//! plateau — matching the symmetric SOC driver and ECOS/Clarabel's `*_inacc`.
+
+use pounce_convex::{ConeSpec, QpOptions, QpProblem, QpStatus, Triplet, solve_socp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn solve(prob: &QpProblem, cones: &[ConeSpec]) -> pounce_convex::QpSolution {
+    let opts = QpOptions::default();
+    solve_socp_ipm(prob, cones, &opts, backend)
+}
+
+/// Append a 3-row exp block enforcing `t_col ≥ exp(off + sign · x[lin_col])`
+/// (the constant `off` folded into the `s0` row's `h`). In the `solve_socp`
+/// convention `s = (s0, s1, s2)` with `s1·exp(s0/s1) ≤ s2`, `s1 = 1`, `s2 =
+/// x[t_col]`.
+fn exp_block(
+    lin_col: usize,
+    sign: f64,
+    off: f64,
+    t_col: usize,
+    g: &mut Vec<Triplet>,
+    h: &mut Vec<f64>,
+) {
+    let r0 = h.len();
+    g.push(Triplet::new(r0, lin_col, -sign));
+    h.push(off); // s0 = off + sign·x[lin_col]
+    h.push(1.0); // s1 = 1
+    let r2 = h.len();
+    g.push(Triplet::new(r2, t_col, -1.0));
+    h.push(0.0);
+}
+
+/// Balanced GP for `min x + K/x`: `min t1 + t2` with `t1 ≥ e^u (=x)` and
+/// `t2 ≥ e^{lnK − u} (=K/x)`, so both cone variables sit at `~sqrt(K)` at the
+/// optimum. AM-GM optimum `x* = sqrt(K)`, `f* = 2 sqrt(K)`.
+fn exp_gp(k: f64) -> QpProblem {
+    let ln_k = k.ln();
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    exp_block(0, 1.0, 0.0, 1, &mut g, &mut h); // t1 ≥ e^u
+    exp_block(0, -1.0, ln_k, 2, &mut g, &mut h); // t2 ≥ e^{lnK − u}
+    QpProblem {
+        n: 3,
+        p_lower: vec![],
+        c: vec![0.0, 1.0, 1.0],
+        a: vec![],
+        b: vec![],
+        g,
+        h,
+        lb: vec![],
+        ub: vec![],
+    }
+}
+
+/// Case A, K=1e12: was `NumericalFailure` on the correct answer (obj ≈ 2e6,
+/// rel err ~4.9e-6). Must now be a usable solve (`OptimalInaccurate`, since the
+/// normalized gap is a little above the default `tol`), never `NumericalFailure`.
+#[test]
+fn exp_extreme_gp_not_numerical_failure() {
+    let k = 1e12_f64;
+    let sol = solve(&exp_gp(k), &[ConeSpec::Exponential; 2]);
+    let f_star = 2.0 * k.sqrt();
+    assert!(
+        (sol.obj - f_star).abs() / f_star < 1e-4,
+        "objective {:.6e} must match f* = {:.6e}",
+        sol.obj,
+        f_star
+    );
+    assert_ne!(
+        sol.status,
+        QpStatus::NumericalFailure,
+        "a correct answer must not be labelled NumericalFailure"
+    );
+    assert!(
+        matches!(sol.status, QpStatus::Optimal | QpStatus::OptimalInaccurate),
+        "expected Optimal/OptimalInaccurate, got {:?}",
+        sol.status
+    );
+}
+
+/// K-sweep: the objective stays correct throughout, and the status degrades
+/// gracefully with scale — `Optimal` while the scale-relative certificate is
+/// tight, then `OptimalInaccurate` on the plateau — but is *never*
+/// `NumericalFailure` on a correct answer. Pins the well-scaled end at `Optimal`
+/// (guarding against over-relaxing the promotion gate).
+#[test]
+fn exp_gp_scale_sweep_never_numerical_failure() {
+    for kexp in [8, 10, 11, 12, 13, 14] {
+        let k = 10f64.powi(kexp);
+        let sol = solve(&exp_gp(k), &[ConeSpec::Exponential; 2]);
+        let f_star = 2.0 * k.sqrt();
+        let rel = (sol.obj - f_star).abs() / f_star;
+        assert!(rel < 1e-4, "K=1e{kexp}: obj rel err {rel:.2e} too large");
+        assert!(
+            matches!(sol.status, QpStatus::Optimal | QpStatus::OptimalInaccurate),
+            "K=1e{kexp}: expected Optimal/OptimalInaccurate, got {:?}",
+            sol.status
+        );
+        if kexp <= 10 {
+            assert_eq!(
+                sol.status,
+                QpStatus::Optimal,
+                "K=1e{kexp}: a well-scaled GP must still certify Optimal"
+            );
+        }
+    }
+}
+
+/// Case B: power cone `max x s.t. |x| ≤ (y·w)^{1/2}, y + w ≤ S`, S=2e8.
+/// Optimum `x* = S/2 = 1e8`; optimal cone variables ~1e8. Was `NumericalFailure`
+/// on the correct answer; must now be a usable solve.
+#[test]
+fn power_extreme_budget_not_numerical_failure() {
+    let s_budget = 2e8_f64;
+    // vars [x, y, w]: min −x s.t. (x, y, w) ∈ K_{1/2}, y + w ≤ S.
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    g.push(Triplet::new(0, 0, -1.0)); // s0 = x
+    h.push(0.0);
+    g.push(Triplet::new(1, 1, -1.0)); // s1 = y
+    h.push(0.0);
+    g.push(Triplet::new(2, 2, -1.0)); // s2 = w
+    h.push(0.0);
+    let r = h.len(); // budget slack = S − y − w ≥ 0
+    g.push(Triplet::new(r, 1, 1.0));
+    g.push(Triplet::new(r, 2, 1.0));
+    h.push(s_budget);
+    let prob = QpProblem {
+        n: 3,
+        p_lower: vec![],
+        c: vec![-1.0, 0.0, 0.0],
+        a: vec![],
+        b: vec![],
+        g,
+        h,
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob, &[ConeSpec::Power(0.5), ConeSpec::Nonneg(1)]);
+    let x_star = s_budget / 2.0;
+    assert!(
+        (sol.x[0] - x_star).abs() / x_star < 1e-3,
+        "x {:.6e} must match x* = {:.6e}",
+        sol.x[0],
+        x_star
+    );
+    assert_ne!(sol.status, QpStatus::NumericalFailure);
+    assert!(
+        matches!(sol.status, QpStatus::Optimal | QpStatus::OptimalInaccurate),
+        "expected Optimal/OptimalInaccurate, got {:?}",
+        sol.status
+    );
+}


### PR DESCRIPTION
## Problem

The non-symmetric (exp/power) HSDE conic driver was discarding correct solutions as `NumericalFailure` when data were extremely (but legitimately) scaled. For example:

- **Exponential GP** (`min x + K/x` with `K = 1e12`): optimal cone variables ~1e6, objective ~2e6 with relative error ~4.9e-6 (correct), but reported `NumericalFailure` instead of a usable status.
- **Power cone** with large budget (`S = 2e8`): optimal solution with relative error <1e-3, but reported `NumericalFailure`.

| Case | Status (before) | Status (after) | Objective error |
|---|---|---|---|
| Exp GP, K=1e12 | `NumericalFailure` | `OptimalInaccurate` | ~4.9e-6 |
| Power cone, S=2e8 | `NumericalFailure` | `OptimalInaccurate` | <1e-3 |

## Cause

The post-loop status adjudication keyed the reduced-accuracy salvage off the *absolute* KKT residual, which carries the raw, unnormalized complementarity gap `s·z`. When optimal cone variables are large (e.g., `~1e6`), this absolute floor scales with them and can never reach the absolute tolerance `tol`. A point that is primal-feasible, dual-feasible, and objective-correct was therefore labelled a failure and discarded.

## Fix

The adjudication now scores the recovered point on the *scale-relative* conic KKT residual (each residual normalized by its own term magnitudes, as ECOS/Clarabel do) at whichever of the final and best-snapshot iterates certifies tighter:

1. **Genuinely tight certificate** (`rel < PROMOTE_REL_TOL_FACTOR * tol`) at a dual-feasible point → `Optimal` (unchanged).
2. **Primal/dual-feasible with moderately above-tolerance normalized gap** (`rel < sqrt(tol)`) → `OptimalInaccurate` (new; matches symmetric SOC driver and ECOS/Clarabel's `*_inacc`).
3. **Absolute reduced-accuracy fallback** (well-scaled near-`tol` stall) → `OptimalInaccurate` (retained for backward compatibility).
4. Otherwise → original status (infeasible/unbounded unchanged).

This extends the scale-relative adjudication of #329 to the reduced-accuracy salvage, analogous to the scale-normalization work in #286/#293.

## Blast radius

**Bit-identical except the targeted case.** The change only affects the post-loop adjudication when the loop exits with `OptimalInaccurate`, `NumericalFailure`, or `IterationLimit` status — i.e., when reduced-accuracy salvage is attempted. Well-scaled solves that reach `Optimal` in-loop are unaffected. Infeasible/unbounded solves terminate before adjudication and are unchanged.

## Tests

Added `crates/pounce-convex/tests/issue336_scale_status.rs` with three regression tests:

1. **`exp_extreme_gp_not_numerical_failure`**: K=1e12 exponential GP; verifies correct objective and that status is `Optimal` or `OptimalInaccurate`, never `NumericalFailure`.
2. **`exp_gp_scale_sweep_never_numerical_failure`**: K-sweep (1e8 to 1e14); verifies objective stays correct and status degrades gracefully (`Optimal` while certificate is tight, then `OptimalInaccurate` on plateau), never `NumericalFailure`. Pins well-scaled end (K ≤ 1e10) at `Optimal`.
3. **`power_extreme_budget_not_numerical_failure`**: Large-budget power cone (S=2e8); verifies correct solution and usable status.

All three tests fail on the parent

https://claude.ai/code/session_01Xf5H3aEhowDF1QQP8fLnZd