### PR TITLE
Fix #348: exact-Hessian request without a Hessian now downgrades to L-BFGS instead of Internal_Error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `sqp_hessian=exact` with no Hessian gave `Internal_Error` (#348)
+
+- Explicitly requesting an exact Lagrangian Hessian (`sqp_hessian="exact"` or
+  `hessian_approximation="exact"`) on a problem that supplies no second
+  derivatives died with `Internal_Error` (the QP subproblem reported
+  "unbounded"). The automatic `hessian_approximation=limited-memory` downgrade
+  runs first, but an explicit exact request was applied *after* it, re-enabling
+  the `Exact` source with no Hessian behind it — the driver then evaluated a
+  zero Lagrangian Hessian, so the QP lost its curvature term and went unbounded.
+  This hit the Python `minimize`/`Problem` path whenever a `hess` was absent, or
+  present but not usable as the Lagrangian Hessian (dict constraints, which are
+  nonlinear-by-policy, or any genuinely nonlinear constraint). It affected only
+  those callers: it worked unconstrained and bounds-only, and the exact Hessian
+  is still honored when it *is* available (all-linear `LinearConstraint` blocks,
+  or unconstrained, with a `hess`). Now, when the problem exposes no
+  `hessian`/`hessianstructure`, an explicit exact request is downgraded to the
+  limited-memory (L-BFGS) approximation with a warning instead of failing. The
+  CLI `.nl` path (which always carries an exact Hessian) is unaffected. A
+  regression test pins the downgrade-and-solve behavior and the still-honored
+  exact path.
+
 ### Fixed — `solve_bvp` could not reach tolerances tighter than ~1.5e-8, exhausting the node budget instead (#345)
 
 - **`pounce.solve_bvp` with a tolerance below ~1.5e-8 now converges** (in the

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -817,10 +817,50 @@ impl PyProblem {
                 false,
             );
         }
+        // Issue #348: when the problem object exposes no exact Lagrangian
+        // Hessian (`has_hessian == false`), an explicit request for the exact
+        // Hessian cannot be honored — the driver would evaluate a *zero*
+        // Hessian, so the SQP QP subproblem gets a null curvature term and
+        // reports "unbounded" (surfacing as `Internal_Error`), and the IPM
+        // loses its curvature. The `hessian_approximation = limited-memory`
+        // default set above already fixes the implicit case, but an explicit
+        // `sqp_hessian = "exact"` / `hessian_approximation = "exact"` in the
+        // user options is applied below and would re-enable the broken path.
+        // Downgrade any such request to the limited-memory fallback and warn
+        // once so the override is visible.
+        let mut downgraded_exact = false;
         for (k, v) in &self.str_opts {
+            let effective = if !self.has_hessian && v.eq_ignore_ascii_case("exact") {
+                match k.as_str() {
+                    "sqp_hessian" => {
+                        downgraded_exact = true;
+                        Some("lbfgs")
+                    }
+                    "hessian_approximation" => {
+                        downgraded_exact = true;
+                        Some("limited-memory")
+                    }
+                    _ => None,
+                }
+            } else {
+                None
+            };
+            let v_eff = effective.unwrap_or(v.as_str());
             app.options_mut()
-                .set_string_value(k, v, true, false)
-                .map_err(|e| PyRuntimeError::new_err(format!("option {k}={v}: {e}")))?;
+                .set_string_value(k, v_eff, true, false)
+                .map_err(|e| PyRuntimeError::new_err(format!("option {k}={v_eff}: {e}")))?;
+        }
+        if downgraded_exact {
+            let warnings = py.import_bound("warnings")?;
+            let _ = warnings.call_method1(
+                "warn",
+                ("an exact Hessian was requested (sqp_hessian / \
+                  hessian_approximation = \"exact\") but the problem provides no \
+                  Lagrangian Hessian (no `hessian` / `hessianstructure` methods); \
+                  falling back to a limited-memory (L-BFGS) approximation. Supply \
+                  a `hess` for an unconstrained or all-linear-constraint problem \
+                  to use the exact Hessian.",),
+            );
         }
         for (k, v) in &self.num_opts {
             app.options_mut()

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1523,6 +1523,89 @@ def test_active_set_sqp_honors_hessian_approximation():
         np.testing.assert_allclose(r.x, expected, atol=1e-6)
 
 
+def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
+    """Explicit ``sqp_hessian=exact`` with no available Hessian must fall back
+    to L-BFGS, not die with ``Internal_Error`` (issue #348).
+
+    The automatic ``hessian_approximation=limited-memory`` downgrade is applied
+    first, but an explicit ``sqp_hessian=exact`` in the user options is applied
+    *after* it and re-enabled the ``Exact`` source with no Hessian behind it:
+    the driver evaluated a zero Lagrangian Hessian, so the QP subproblem went
+    unbounded and the solve died with ``Internal_Error``. The fix downgrades an
+    exact request to L-BFGS (with a warning) whenever the problem exposes no
+    ``hessian`` / ``hessianstructure``.
+    """
+    fun = lambda v: (v[0] - 3.0) ** 2 + (v[1] - 2.0) ** 2
+    jac = lambda v: np.array([2 * (v[0] - 3.0), 2 * (v[1] - 2.0)])
+    hess = lambda v: 2.0 * np.eye(2)
+    expected = np.array([2.5, 1.5])  # project (3, 2) onto x0 + x1 = 4
+
+    # (a) dict constraint (nonlinear-by-policy) — previously Internal_Error,
+    #     whether or not a hess is supplied (the facade attaches no Hessian).
+    dict_con = [
+        {
+            "type": "ineq",
+            "fun": lambda v: np.array([4.0 - v[0] - v[1]]),
+            "jac": lambda v: np.array([[-1.0, -1.0]]),
+        }
+    ]
+    for hh in (hess, None):
+        with pytest.warns(UserWarning, match="exact Hessian was requested"):
+            r = pounce.minimize(
+                fun,
+                [0.0, 0.0],
+                jac=jac,
+                hess=hh,
+                constraints=dict_con,
+                solver_selection="qp-active-set",
+                sqp_hessian="exact",
+            )
+        assert r.success, f"exact-without-hessian must not fail: {r.message}"
+        np.testing.assert_allclose(r.x, expected, atol=1e-6)
+        assert r.nhev == 0, "downgrade to L-BFGS means the exact Hessian is unused"
+
+    # (b) genuinely nonlinear constraint + hess: same downgrade, still solves.
+    nl_con = [
+        {
+            "type": "eq",
+            "fun": lambda v: v[0] ** 2 + v[1] ** 2 - 2.0,
+            "jac": lambda v: np.array([[2 * v[0], 2 * v[1]]]),
+        }
+    ]
+    with pytest.warns(UserWarning, match="exact Hessian was requested"):
+        r = pounce.minimize(
+            fun,
+            [1.0, 1.0],
+            jac=jac,
+            hess=hess,
+            constraints=nl_con,
+            solver_selection="qp-active-set",
+            sqp_hessian="exact",
+        )
+    assert r.success, f"exact-without-hessian (nonlinear) must not fail: {r.message}"
+
+    # (c) control: an explicit LinearConstraint keeps the exact Hessian — no
+    #     downgrade, no #348 warning, and the Hessian is actually used.
+    lc = opt.LinearConstraint(np.array([[1.0, 1.0]]), lb=-np.inf, ub=4.0)
+    with warnings.catch_warnings(record=True) as rec:
+        warnings.simplefilter("always")
+        r = pounce.minimize(
+            fun,
+            [0.0, 0.0],
+            jac=jac,
+            hess=hess,
+            constraints=lc,
+            solver_selection="qp-active-set",
+            sqp_hessian="exact",
+        )
+    assert r.success
+    np.testing.assert_allclose(r.x, expected, atol=1e-6)
+    assert not any(
+        "exact Hessian was requested" in str(w.message) for w in rec
+    ), "exact must be honored (not downgraded) when a Hessian is available"
+    assert r.nhev > 0, "the exact Hessian should actually be used here"
+
+
 def test_uncomputed_objective_is_nan_not_zero():
     """An objective that was never evaluated must not be reported as ``0.0``.
 


### PR DESCRIPTION
Fixes #348.

## Problem
Explicitly requesting an exact Lagrangian Hessian on a problem that supplies no
second derivatives died with `Internal_Error`:

```python
import numpy as np, pounce
f    = lambda x: (x[0]-2)**2 + (x[1]-1)**2
jac  = lambda x: np.array([2*(x[0]-2), 2*(x[1]-1)])
hess = lambda x: np.array([[2.0, 0.0], [0.0, 2.0]])          # PD
cons = [{"type": "ineq", "fun": lambda x: 5 - x[0] - x[1],
         "jac": lambda x: np.array([-1.0, -1.0])}]
pounce.minimize(f, [0.,0.], jac=jac, hess=hess, constraints=cons,
                options={"algorithm": "active-set-sqp", "sqp_hessian": "exact"})
# -> status Internal_Error (QP subproblem "unbounded")
```

It worked unconstrained / bounds-only but failed with **any** general constraint
(linear-eq, linear-ineq, or nonlinear), including the linear-constraint case the
option docs say is supported.

## Root cause
`PyProblem::prepare` sets `hessian_approximation=limited-memory` when the problem
object exposes no `hessian`/`hessianstructure`, but then applies the caller's
option strings **afterward**. An explicit `sqp_hessian="exact"` (or
`hessian_approximation="exact"`) therefore re-enabled the `Exact` source with no
Hessian behind it. The SQP driver evaluated a **zero** Lagrangian Hessian, so the
QP subproblem lost its curvature term and became an unbounded LP along the active
constraints' null space → `Internal_Error`. (There is already a maintainer note
on `application.rs` documenting this exact failure class for the *implicit*
default; this closes the remaining explicit-request hole.)

## Fix
In `crates/pounce-py/src/problem.rs`, when `has_hessian` is false, downgrade an
exact-Hessian selection in the user options before handing them to the driver:
`sqp_hessian=exact → lbfgs`, `hessian_approximation=exact → limited-memory`, and
emit a one-time warning so the override is visible. This is the authoritative
choke point for every Python `Problem`-based solve.

Untouched:
- the exact path when a Hessian **is** available (all-linear `LinearConstraint`
  blocks, or unconstrained, with a `hess`) — still uses the exact Hessian, no
  warning;
- the CLI `.nl` path (a different problem type that always carries an exact
  Hessian).

## Verification
- All four previously-`Internal_Error` configurations now `Solve_Succeeded` at
  the correct optimum (cross-checked vs Ipopt), each with the downgrade warning.
- The legitimate exact path (`LinearConstraint` + `hess`) still uses the exact
  Hessian (`nhev > 0`, no warning).
- New regression test `test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error`.
- `python/tests/test_minimize.py` (69), `test_problem.py` (34), and the
  `sqp`/`warm`/`nlp` suites (88) all pass.

Found by the adversary agent (the same run that filed #349 for the separate
filter-globalization / Maratos limitation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
