### PR TITLE
Cut the 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ changes.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-24
+
 ### Fixed — active-set-SQP stalled on curved-constraint NLPs via the Maratos effect (#349)
 
 - **The active-set-SQP driver now defeats the Maratos effect** with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ topological order. Run it before tagging.
    publishes to PyPI. Version: `python/pyproject.toml`.
 2. **PyPI `pyomo-pounce`** — `.github/workflows/release-pyomo-pounce.yml`,
    triggered by a `pyomo-pounce-vX.Y.Z` tag. Version: `pyomo-pounce/pyproject.toml`.
-3. **crates.io — 19 workspace crates** — automated by
+3. **crates.io — 20 workspace crates** — automated by
    `.github/workflows/release-crates.yml`, triggered by a `vX.Y.Z` tag push
    (or run manually via `workflow_dispatch`, which defaults to a dry run). It
    runs `scripts/publish-crates.sh`, which publishes in topological order and


### PR DESCRIPTION
## Cut the 0.9.0 release

Prepares the `0.9.0` release. The three version surfaces were already bumped
to `0.9.0` on `main` (root `Cargo.toml`, `python/pyproject.toml`,
`pyomo-pounce/pyproject.toml`); this PR does the remaining pre-tag prep:

- **CHANGELOG** — stamps the accumulated `[Unreleased]` section as
  `## [0.9.0] - 2026-07-24` and opens a fresh empty `[Unreleased]`. The
  section already captures everything landed since `0.8.0`, through the most
  recent fix (#349, active-set-SQP Maratos second-order correction).
- **CLAUDE.md** — fixes the stale "19 workspace crates" line to **20**, matching
  `scripts/check-release-consistency.sh` (authoritative) and
  `dev-notes/cargo-release.md`. Doc drift flagged in the release tracking
  issue #239.

### Verification
- `scripts/check-release-consistency.sh` passes: all three surfaces at `0.9.0`,
  publish list is 20 crates matching `cargo metadata` in topological order,
  every publishable crate's deps carry a crates.io version requirement.
- `cargo test --workspace` passes locally.

### After merge (not in this PR — fires automated publishing)
Tagging is intentionally left out of this PR because pushing the tags publishes
to crates.io / PyPI. Per issue #239, in order:
`v0.9.0` → crates.io, then `python-v0.9.0` → PyPI `pounce-solver`, then
`pyomo-pounce-v0.9.0` → PyPI `pyomo-pounce`, then a hand-created GitHub Release.

Part of #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
