### PR TITLE
Rewrite declared-Param variable bounds as constraints

### DIFF
--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -50,6 +50,8 @@ import pyomo.environ as pyo
 from pyomo.common.collections import ComponentMap
 from pyomo.contrib.sensitivity_toolbox.sens import SensitivityInterface
 from pyomo.core.base.constraint import Constraint
+from pyomo.core.expr import identify_mutable_parameters
+from pyomo.core.expr.visitor import replace_expressions
 from pyomo.opt import SolverResults, SolverStatus, TerminationCondition
 
 _REG = "_pounce_sens"
@@ -115,6 +117,51 @@ def declare_residual(*containers, group=None):
     to the heteroscedastic sandwich form."""
     for container in containers:
         _registry(container.model()).residuals.append((container, group))
+
+
+def _reformulate_param_bounds(clone):
+    """Move Var bounds that reference a declared Param into constraints.
+
+    `SensitivityInterface` substitutes declared Params in constraint
+    expressions only. A Param left in a bound is therefore written to the
+    NL file as a constant at its pre-perturbation value, so the bound never
+    moves and the reported sensitivity to that Param reads as exactly zero
+    (jkitchin/pounce#356). Rewriting the bound as a constraint over the
+    substituted Var puts it where the perturbation already reaches, which
+    makes the answer exact in the bound rather than approximating it.
+
+    Runs after `setup_sensitivity`, so the Param-to-Var map it needs is the
+    one the surgery has already built.
+    """
+    block = clone.component(SensitivityInterface.get_default_block_name())
+    if block is None:
+        return
+    sub = {id(param): var for var, param, _, _ in block._sens_data_list}
+    if not sub:
+        return
+
+    moved = []
+    for v in clone.component_data_objects(pyo.Var, descend_into=True):
+        for attr in ("_lb", "_ub"):
+            expr = getattr(v, attr, None)
+            if expr is None or isinstance(expr, (int, float)):
+                continue
+            if not any(id(p) in sub
+                       for p in identify_mutable_parameters(expr)):
+                continue
+            moved.append((v, attr, replace_expressions(expr, sub)))
+
+    if not moved:
+        return
+
+    block.boundConst = pyo.ConstraintList()
+    for v, attr, expr in moved:
+        if attr == "_lb":
+            v.setlb(None)
+            block.boundConst.add(expr <= v)
+        else:
+            v.setub(None)
+            block.boundConst.add(v <= expr)
 
 
 def has_declarations(model):
@@ -352,6 +399,7 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         si = SensitivityInterface(model, clone_model=True)
         si.setup_sensitivity(eff_params)
         clone = si.model_instance
+        _reformulate_param_bounds(clone)
     else:
         # estimation-only: nothing to pin, solve the model as written
         si = None

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -34,6 +34,14 @@ is written to .nl and evaluated in-process via pounce.read_nl, and the
 pounce.Solver session's parametric_step answers gradient()/estimate()
 queries from the stored factorization -- the sIPOPT computation, with no
 suffixes and no upfront perturbation values.
+
+One deliberate divergence from pyomo.contrib.sensitivity_toolbox: a
+declared Param appearing in a Var's BOUND is rewritten as a constraint
+before the solve, so its sensitivity is real rather than zero. The
+toolbox substitutes declared Params in constraint expressions only, and
+leaves such a bound frozen at its pre-perturbation value. On the clone
+that is solved the bound is dropped, so m.x.ub reads None there and the
+NL carries the no-bound sentinel for that row.
 """
 import codecs
 import os
@@ -131,17 +139,29 @@ def _reformulate_param_bounds(clone):
     makes the answer exact in the bound rather than approximating it.
 
     Runs after `setup_sensitivity`, so the Param-to-Var map it needs is the
-    one the surgery has already built.
+    one the surgery has already built. Returns {var name: (lb, ub)} of the
+    numeric values the moved bounds had at the solve point, with None on the
+    side that was not moved; covariance()'s active-bound projection reads
+    NL bounds, which now say +/-inf for these rows.
     """
     block = clone.component(SensitivityInterface.get_default_block_name())
     if block is None:
-        return
+        return {}
     sub = {id(param): var for var, param, _, _ in block._sens_data_list}
     if not sub:
-        return
+        return {}
 
     moved = []
-    for v in clone.component_data_objects(pyo.Var, descend_into=True):
+    # active=True so deactivated Blocks are skipped: stripping a bound there
+    # and adding an active constraint would pull the Var into the NL as a
+    # free column. Fixed Vars are skipped because their bounds are not
+    # enforced -- Pyomo substitutes them out as constants -- so turning one
+    # into a constraint would impose a restriction on the pinned Param that
+    # the original model never had.
+    for v in clone.component_data_objects(pyo.Var, active=True,
+                                          descend_into=True):
+        if v.fixed:
+            continue
         for attr in ("_lb", "_ub"):
             expr = getattr(v, attr, None)
             if expr is None or isinstance(expr, (int, float)):
@@ -149,19 +169,27 @@ def _reformulate_param_bounds(clone):
             if not any(id(p) in sub
                        for p in identify_mutable_parameters(expr)):
                 continue
-            moved.append((v, attr, replace_expressions(expr, sub)))
+            # the numeric value the NL would have carried, kept so
+            # covariance() can still see where the bound was
+            moved.append((v, attr, float(pyo.value(expr)),
+                          replace_expressions(expr, sub)))
 
     if not moved:
-        return
+        return {}
 
+    recorded = {}
     block.boundConst = pyo.ConstraintList()
-    for v, attr, expr in moved:
+    for v, attr, val, expr in moved:
+        lo, hi = recorded.get(v.name, (None, None))
         if attr == "_lb":
             v.setlb(None)
             block.boundConst.add(expr <= v)
+            recorded[v.name] = (val, hi)
         else:
             v.setub(None)
             block.boundConst.add(v <= expr)
+            recorded[v.name] = (lo, val)
+    return recorded
 
 
 def has_declarations(model):
@@ -212,6 +240,7 @@ class _Session:
         self.pins = pins              # ComponentMap: param data -> pin row
         self.con_alias = con_alias    # original con name -> clone row name
         self.base_x = None
+        self.moved_bounds = {}        # var name -> (lb, ub) moved to rows
         self._columns = {}            # pin row -> full KKT-space column
 
     def orig_var(self, name):
@@ -399,11 +428,12 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         si = SensitivityInterface(model, clone_model=True)
         si.setup_sensitivity(eff_params)
         clone = si.model_instance
-        _reformulate_param_bounds(clone)
+        moved_bounds = _reformulate_param_bounds(clone)
     else:
         # estimation-only: nothing to pin, solve the model as written
         si = None
         clone = model
+        moved_bounds = {}
 
     # The .nl/.col/.row files exist only to hand the model to read_nl;
     # everything needed later (evaluators, bounds, names) lives in memory,
@@ -513,6 +543,7 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     session = _Session(model, nl, solver, var_names, con_names, pins,
                        con_alias)
     session.base_x = np.asarray(x)
+    session.moved_bounds = moved_bounds
 
     # fitted parameters: their rows in the primal vector
     session.fit_rows = ComponentMap()
@@ -668,6 +699,12 @@ def estimate(model, perturb, clamp=True):
     ComponentMap (plain dicts don't work: Pyomo components are unhashable).
     Returns a ComponentMap {original var data: estimated value}. Values are
     clamped to variable bounds (with a warning) unless clamp=False.
+
+    A bound written in terms of a declared Param is a constraint by the
+    time the model is solved, so it is not clamped against here and no
+    clamp warning is raised for it. That is deliberate: the bound moves
+    with the perturbation, so the linear step already respects it to
+    first order.
     """
     reg = model.__dict__.get(_REG)
     session = reg.session if reg else None
@@ -885,6 +922,15 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             "regularized rather than exact. Linearly dependent (structurally"
             " unidentifiable) parameters are the usual cause.")
     lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
+    # a bound moved to a constraint row reads as +/-inf here, which would
+    # silently skip the projection for that parameter; put the value the
+    # bound had at the solve point back for the test only
+    for name, (mlo, mhi) in session.moved_bounds.items():
+        r = session.var_names.index(name)
+        if mlo is not None:
+            lo[r] = mlo
+        if mhi is not None:
+            hi[r] = mhi
     active = []
     for i, p in enumerate(params):
         r = session.fit_rows[p]

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -142,7 +142,8 @@ def _reformulate_param_bounds(clone):
     one the surgery has already built. Returns {var name: (lb, ub)} of the
     numeric values the moved bounds had at the solve point, with None on the
     side that was not moved; covariance()'s active-bound projection reads
-    NL bounds, which now say +/-inf for these rows.
+    NL bounds, which for these rows now hold the reader's no-bound sentinel
+    of +/-1e19. That value is finite, so an isinf() test would never fire.
     """
     block = clone.component(SensitivityInterface.get_default_block_name())
     if block is None:
@@ -922,7 +923,8 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             "regularized rather than exact. Linearly dependent (structurally"
             " unidentifiable) parameters are the usual cause.")
     lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
-    # a bound moved to a constraint row reads as +/-inf here, which would
+    # a bound moved to a constraint row reads as the no-bound sentinel
+    # +/-1e19 here (finite, so isinf() would never catch it), which would
     # silently skip the projection for that parameter; put the value the
     # bound had at the solve point back for the test only
     for name, (mlo, mhi) in session.moved_bounds.items():

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -381,9 +381,10 @@ def test_undeclared_param_in_bound_is_left_alone():
     declare_sens_param(m.p)
     pyo.SolverFactory("pounce").solve(m)
 
+    assert m.x.ub == 5.0                              # original untouched
     session = m.__dict__["_pounce_sens"].session
-    r = session.var_names.index("x")
-    assert session.nl.x_u[r] == pytest.approx(5.0)    # still an NL bound
+    r = session.var_entry(m.x.name)
+    assert session.nl.x_u[r] == pytest.approx(5.0)    # survived into the solve
     assert session.moved_bounds == {}                 # nothing was rewritten
     assert pyo.value(m.x) == pytest.approx(5.0, abs=1e-6)
 
@@ -399,7 +400,7 @@ def test_moved_bound_is_recorded_for_covariance():
     pyo.SolverFactory("pounce").solve(m)
 
     session = m.__dict__["_pounce_sens"].session
-    r = session.var_names.index("x")
+    r = session.var_entry(m.x.name)
     assert session.nl.x_u[r] >= 1e19                  # NL no-bound sentinel
     assert session.moved_bounds["x"] == (None, pytest.approx(2.0))
 
@@ -469,7 +470,7 @@ def test_rewritten_bound_still_projects_in_covariance():
     pyo.SolverFactory("pounce").solve(m)
 
     session = m.__dict__["_pounce_sens"].session
-    assert session.nl.x_u[session.var_names.index("A")] >= 1e19
+    assert session.nl.x_u[session.var_entry(m.A.name)] >= 1e19
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         covariance(m)

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -367,16 +367,76 @@ def test_bound_as_constraint_is_unchanged():
 
 
 def test_undeclared_param_in_bound_is_left_alone():
-    """Only declared Params are rewritten; an undeclared one stays a bound."""
+    """Only declared Params are rewritten; an undeclared one stays a bound.
+
+    Asserted on the clone that was actually solved, via the NL bounds the
+    session carries. Asserting on the original model would pass no matter
+    what, since the rewrite runs on a clone and never touches it.
+    """
     m = pyo.ConcreteModel()
     m.p = pyo.Param(initialize=2.0, mutable=True)
     m.cap = pyo.Param(initialize=5.0, mutable=True)   # never declared
     m.x = pyo.Var(bounds=(0, m.cap), initialize=1.0)
-    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
+    m.obj = pyo.Objective(expr=-m.x)                  # drive x onto the cap
     declare_sens_param(m.p)
     pyo.SolverFactory("pounce").solve(m)
-    assert m.x.ub == 5.0                              # bound survived
+
+    session = m.__dict__["_pounce_sens"].session
+    r = session.var_names.index("x")
+    assert session.nl.x_u[r] == pytest.approx(5.0)    # still an NL bound
+    assert session.moved_bounds == {}                 # nothing was rewritten
+    assert pyo.value(m.x) == pytest.approx(5.0, abs=1e-6)
+
+
+def test_moved_bound_is_recorded_for_covariance():
+    """A rewritten bound reads as the NL no-bound sentinel, so the value it
+    had is recorded; covariance()'s projection reads that instead."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(bounds=(0, m.p), initialize=1.0)
+    m.obj = pyo.Objective(expr=-m.x)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+
+    session = m.__dict__["_pounce_sens"].session
+    r = session.var_names.index("x")
+    assert session.nl.x_u[r] >= 1e19                  # NL no-bound sentinel
+    assert session.moved_bounds["x"] == (None, pytest.approx(2.0))
+
+
+def test_fixed_var_bound_is_not_rewritten():
+    """A fixed Var's bounds are not enforced, so turning one into a
+    constraint would impose a restriction the original model never had."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.f = pyo.Var(bounds=(0, m.p), initialize=5.0)
+    m.f.fix(5.0)                                  # legally outside its bound
+    m.x = pyo.Var(bounds=(0, None), initialize=1.0)
+    m.c = pyo.Constraint(expr=m.x <= m.p)
+    m.obj = pyo.Objective(expr=-m.x)
+    declare_sens_param(m.p)
+    res = pyo.SolverFactory("pounce").solve(m)
+    assert res.solver.termination_condition == pyo.TerminationCondition.optimal
     assert gradient(m.x, wrt=m.p) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_deactivated_block_var_is_not_rewritten():
+    """Stripping a bound on a dead Block and adding an active constraint
+    would pull the Var into the NL as a free column."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(bounds=(0, None), initialize=1.0)
+    m.c = pyo.Constraint(expr=m.x <= m.p)
+    m.obj = pyo.Objective(expr=-m.x)
+    m.dead = pyo.Block()
+    m.dead.y = pyo.Var(bounds=(0, m.p), initialize=1.0)
+    m.dead.c = pyo.Constraint(expr=m.dead.y <= 1)
+    m.dead.deactivate()
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+
+    names = m.__dict__["_pounce_sens"].session.var_names
+    assert not any("dead.y" in n for n in names)
 
 
 def test_indexed_var_bound_on_declared_param():
@@ -389,3 +449,28 @@ def test_indexed_var_bound_on_declared_param():
     pyo.SolverFactory("pounce").solve(m)
     for i in m.I:
         assert gradient(m.x[i], wrt=m.p) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_rewritten_bound_still_projects_in_covariance():
+    """A fitted Var capped by a declared Param still triggers covariance()'s
+    active-bound projection, even though its NL bound is now the no-bound
+    sentinel (jkitchin/pounce#357 review)."""
+    from pyomo_pounce import covariance, declare_fitted, declare_residual
+    m = pyo.ConcreteModel()
+    m.I = pyo.RangeSet(5)
+    m.cap = pyo.Param(initialize=1.0, mutable=True)
+    m.A = pyo.Var(bounds=(0, m.cap), initialize=0.5)
+    m.r = pyo.Var(m.I, initialize=0.0)
+    m.res = pyo.Constraint(m.I, rule=lambda mm, i: mm.r[i] == 3.0 - mm.A)
+    m.obj = pyo.Objective(expr=sum(m.r[i] ** 2 for i in m.I))
+    declare_sens_param(m.cap)
+    declare_fitted(m.A)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+
+    session = m.__dict__["_pounce_sens"].session
+    assert session.nl.x_u[session.var_names.index("A")] >= 1e19
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        covariance(m)
+    assert any("sits on its bound" in str(x.message) for x in w)

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -315,3 +315,77 @@ def test_all_three_declarations_coexist():
     cov = covariance(m)                     # estimation family
     assert cov.std_err[m.A] > 0 and cov.std_err[m.k] > 0
     assert abs(cov.correlation[m.A, m.k]) < 1.0
+
+
+# ── declared Params in variable bounds (jkitchin/pounce#356) ─────────────────
+#
+# SensitivityInterface substitutes declared Params in constraint expressions
+# only, so a Param left in a bound used to be written to the NL file as a
+# constant and its sensitivity read as exactly zero. sens_solve now rewrites
+# such a bound as a constraint over the substituted Var. Each case below is
+# a limit the objective drives the variable straight into, so dx/dp is known
+# in closed form.
+
+def _bounded(ub=None, lb=None, sense=-1.0, x0=1.0):
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(bounds=(lb(m) if lb else None, ub(m) if ub else None),
+                  initialize=x0)
+    m.obj = pyo.Objective(expr=sense * m.x)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+@pytest.mark.parametrize("ub, dxdp, pnew, xnew", [
+    (lambda m: m.p, 1.0, 3.0, 3.0),            # bare Param
+    (lambda m: 2 * m.p + 1, 2.0, 3.0, 7.0),    # expression around it
+])
+def test_upper_bound_on_declared_param_is_differentiable(ub, dxdp, pnew, xnew):
+    m = _bounded(ub=ub)
+    assert gradient(m.x, wrt=m.p) == pytest.approx(dxdp, abs=1e-6)
+    assert estimate(m, [(m.p, pnew)])[m.x] == pytest.approx(xnew, abs=1e-6)
+
+
+def test_lower_bound_on_declared_param_is_differentiable():
+    m = _bounded(lb=lambda m: m.p, sense=1.0, x0=3.0)
+    assert gradient(m.x, wrt=m.p) == pytest.approx(1.0, abs=1e-6)
+    assert estimate(m, [(m.p, 3.0)])[m.x] == pytest.approx(3.0, abs=1e-6)
+
+
+def test_bound_as_constraint_is_unchanged():
+    """The already-working spelling keeps working and agrees with the bound."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(bounds=(0, None), initialize=1.0)
+    m.cap = pyo.Constraint(expr=m.x <= m.p)
+    m.obj = pyo.Objective(expr=-m.x)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert gradient(m.x, wrt=m.p) == pytest.approx(1.0, abs=1e-6)
+    assert estimate(m, [(m.p, 3.0)])[m.x] == pytest.approx(3.0, abs=1e-6)
+
+
+def test_undeclared_param_in_bound_is_left_alone():
+    """Only declared Params are rewritten; an undeclared one stays a bound."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.cap = pyo.Param(initialize=5.0, mutable=True)   # never declared
+    m.x = pyo.Var(bounds=(0, m.cap), initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert m.x.ub == 5.0                              # bound survived
+    assert gradient(m.x, wrt=m.p) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_indexed_var_bound_on_declared_param():
+    m = pyo.ConcreteModel()
+    m.I = pyo.RangeSet(3)
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(m.I, bounds=(0, m.p), initialize=1.0)
+    m.obj = pyo.Objective(expr=-sum(m.x[i] for i in m.I))
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    for i in m.I:
+        assert gradient(m.x[i], wrt=m.p) == pytest.approx(1.0, abs=1e-6)

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -475,3 +475,24 @@ def test_rewritten_bound_still_projects_in_covariance():
         warnings.simplefilter("always")
         covariance(m)
     assert any("sits on its bound" in str(x.message) for x in w)
+    # and the projected answer, not just the warning: identical to what the
+    # same model gives with the bound left alone
+    assert covariance(m).std_err[m.A] == 0.0
+
+
+def test_both_bounds_rewritten_are_both_recorded():
+    """A Var with both bounds on declared Params records both sides; the
+    single-sided tests pass even if the merge dropped one."""
+    m = pyo.ConcreteModel()
+    m.lo = pyo.Param(initialize=-1.0, mutable=True)
+    m.hi = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(bounds=(m.lo, m.hi), initialize=0.0)
+    m.obj = pyo.Objective(expr=-m.x)
+    declare_sens_param(m.lo, m.hi)
+    pyo.SolverFactory("pounce").solve(m)
+
+    session = m.__dict__["_pounce_sens"].session
+    lo_rec, hi_rec = session.moved_bounds[m.x.name]
+    assert lo_rec == pytest.approx(-1.0)
+    assert hi_rec == pytest.approx(2.0)
+    assert gradient(m.x, wrt=m.hi) == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
Closes #356.

`SensitivityInterface` substitutes declared Params in constraint expressions only, so a Param left in a `Var` bound was written to the NL file as a constant at its pre-perturbation value. The bound never moved and the reported sensitivity to that Param was exactly zero.

`sens_solve` now rewrites such a bound as a constraint over the substituted Var. It runs after `setup_sensitivity`, so the Param-to-Var map it needs (`block._sens_data_list`) already exists and the substitution never has to run twice. Going through `replace_expressions` rather than swapping a bare Param means an expression bound such as `bounds=(0, 2*p + 1)` works too.

The rewrite drops the bound. On the clone that is solved, `m.x.ub` reads `None` and the NL row carries the no-bound sentinel `1e19`, so anything downstream reading NL bounds sees no bound there. Two consequences are handled explicitly: `covariance()`'s active-bound projection reads the recorded pre-rewrite value rather than the sentinel, and `estimate()` no longer clamps or warns for those variables, which is correct because the bound now moves with the perturbation and the linear step respects it to first order.

Fixed Vars and Vars on deactivated Blocks are skipped. A fixed Var's bounds are not enforced, so rewriting one imposes a restriction on the pinned Param that the original model never had; a deactivated Block's Var would be pulled into the NL as a free column restricted only by the new row.

## Effect

Minimum-time racing problem with an acceleration cap `u_up`, discretized at `nfe=100`. The cap binds over the acceleration phase, so more allowed acceleration should mean a faster lap.

```
exact re-solve at u_up=1.1:  tf = 15.890520 s

limit written as        tf(1.0)   d tf/d u_up   estimate(1.1)      error
------------------------------------------------------------------------
bound  (before)       16.471138      0.000000       16.471138   5.81e-01
bound  (after)        16.471138     -6.323665       15.838771   5.17e-02
constraint            16.471138     -6.323665       15.838771   5.17e-02
```

The two spellings of the same limit now agree. The residual is linearization error on a 10% perturbation, and the constraint form carries it identically.

## Cost

A simple bound is handled directly in the barrier; a general inequality costs a slack and a Jacobian row. The racing example above trades roughly 100 bounds for roughly 100 rows. That is the price of the limit being differentiable with respect to the Param that sets it, and it is paid only by models that write a bound in terms of a declared Param.

## Tests

Eight cases in `tests/test_sens.py`: bare Param in an upper bound, an expression bound, a lower bound, an indexed Var, a fixed Var, a Var on a deactivated Block, the recorded pre-rewrite bound, and a `declare_fitted` Var whose rewritten bound must still trigger `covariance()`'s projection. Two controls: the constraint spelling still works and agrees, and an undeclared mutable Param in a bound is left as a bound, asserted against the NL bounds of the clone that was solved rather than against the original model.

Full suite: 120 passed, 5 failed. The same 5 fail on `main` without this change (three in `test_binary_check.py`, plus `test_bound_multipliers_populate_ipopt_zL_zU` and `test_multiplier_gradient_matches_finite_difference`).

## Note on divergence

This makes pyomo-pounce answer differently from `sensitivity_calculation` on the same model. Writing a limit as a bound is the natural way to write it, and requiring a rewrite to a constraint is the kind of usability problem `declare_sens_param` exists to avoid. Kept ungated per review, and recorded in the module docstring so it is discoverable without being opt-in-able.
