### PR TITLE
Fix #358: qp-active-set facade stalled with L-BFGS on convex QPs with an active inequality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@ changes.
     and every other pounce path already solved these; only the facade's L-BFGS
     SQP default was affected.
 
+### Fixed — active-set-SQP quasi-Newton overshoot on ill-conditioned QPs (#358 tail)
+
+- **The damped-BFGS active-set-SQP now sizes its initial Hessian**, fixing the
+  ill-conditioned tail of #358 (`cond(P) ≳ 1e3`). The identity seed `B₀ = I` is
+  a catastrophic scale when `‖∇²L‖ ≫ 1`: the first QP step overshoots the Newton
+  step by `~cond(∇²L)`, and the filter line search — with an empty filter at a
+  near-feasible start (`θ_curr` tiny) — accepts the objective-blowing step
+  because it drives the negligible constraint violation to zero. The working set
+  is corrupted and the solve diverges to `‖x‖ ~ 1e4` before dying with
+  `Search_Direction_Becomes_Too_Small`.
+  - Fix (`crates/pounce-algorithm/src/sqp/bfgs.rs`): before the first rank-2
+    update, rescale `B` from `I` to `γI` with the Rayleigh-quotient curvature
+    estimate `γ = sᵀy / sᵀs ∈ [λ_min(∇²L), λ_max(∇²L)]` — applied once, so the
+    persistent damped updates still accumulate on top. Halves the failure rate
+    on a broad ill-conditioned-QP sweep (~21% → ~10%) and clears the #358
+    36-instance tail sweep entirely.
+  - Not a complete cure for *extreme* conditioning: `cond(P) ≳ 1e4` (especially
+    small `n`) remains harder for the quasi-Newton path than for the
+    exact-Hessian / IPM / `solver_selection="auto"` routes, which solve these to
+    machine precision. Prefer those for very ill-conditioned QPs.
+
 ## [0.9.0] - 2026-07-24
 
 ### Fixed — active-set-SQP stalled on curved-constraint NLPs via the Maratos effect (#349)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,16 +81,58 @@ unchanged (median `6e-11`, max true constraint violation `4e-11`).
   (retaining the matrix's scale), rebuilds the subproblem, and re-solves once
   from cold.
 
-Remaining known gap, **pre-existing and out of scope here**: equality-constrained
-ill-conditioned QPs (`cond ≳ 1e2`) still converge slowly and can exit
-`Maximum_Iterations_Exceeded` / `Internal_Error` — a different signature from
-the inequality-active stall #358 reported. Measured unchanged by this work
-(mean 36.3/144 before vs 35.7/144 after, over 6 runs each). Note those runs also
-exposed genuine **run-to-run nondeterminism** on that path (same binary, same
-inputs, ±4 instances), which the inequality path does not show; that is tracked
-separately. The exact-Hessian, IPM, and `solver_selection="auto"` routes solve
-all of these to machine precision and remain the recommendation for very
-ill-conditioned QPs.
+### Fixed — quasi-Newton curvature pair used inconsistent multipliers (#361)
+
+- **The active-set-SQP quasi-Newton update now differences `∇L` at a single
+  fixed multiplier**, per Nocedal-Wright §18.3:
+  `y = ∇L(x_k, λ_k) − ∇L(x_{k−1}, λ_k)`. It previously held
+  `∇L(x_{k−1}, λ_{k−1})` inside the Hessian object and differenced against
+  `∇L(x_k, λ_k)` — two *different* multipliers — which for linear constraints
+  contributes a spurious `Aᵀ(λ_k − λ_{k−1})` term: pure multiplier difference,
+  carrying no curvature at all (the true `∇²L` equals `∇²f` there).
+  - That fed a divergent loop — a perturbed `B` yields a worse QP multiplier,
+    which injects a larger error into the next `y`, which corrupts `B` further.
+    On equality-constrained QPs (where `λ` is sign-free) the multiplier was
+    observed oscillating and growing exponentially
+    (`−13, 19, −69, 104, −145, 581, −1320, 3176, …`) while **`x` sat on the
+    exact optimum**. The solve burned its whole iteration budget and exited
+    `Maximum_Iterations_Exceeded` *at the right answer*, because the reported
+    stationarity residual is formed from that multiplier.
+  - Equality-constrained sweep (144 instances): **92 failures on 0.9.0 → 0**.
+    Inequality sweep (500 instances): **4 → 0**. All constraint families
+    (linear equality, linear inequality, nonlinear inequality) now solve clean.
+  - Fixed for both `damped-bfgs` and `lbfgs`. The consistent-multiplier form
+    telescopes to `Σλᵢ(∇cᵢ(x_k) − ∇cᵢ(x_{k−1}))`, which correctly vanishes for
+    linear constraints and is retained for nonlinear ones.
+
+- **`sqp_tol` is now honored.** It was registered and documented as the max-norm
+  KKT stationarity tolerance (default `1e-8`) but never read, so the looser
+  `sqp_dual_inf_tol` (`1e-4`) governed alone and silently capped attainable
+  accuracy. The convergence test now requires the tighter of the two — the only
+  reading under which neither option is inert. Worst-case error on the #358
+  sweep improves from `7e-5` to `5e-9` for ~10% more iterations. Same
+  registered-but-inert defect family as #360.
+
+### Fixed — `sqp_qp_*` inner-QP options were unusable (#360)
+
+- **The five `sqp_qp_*` options are now registered** and reach
+  `pounce_qp::QpOptions`: `sqp_qp_max_iter`, `sqp_qp_feas_tol`,
+  `sqp_qp_opt_tol`, `sqp_qp_elastic_gamma`, `sqp_qp_anti_cycling`.
+  `apply_qp_subproblem_options` read all five, but none was registered, so the
+  options registry rejected every one with `OPTION_INVALID` ("Unknown option")
+  and the reader was unreachable — the whole documented family was dead code.
+  Added a guard test asserting each key is settable *and* propagates, and that
+  unset keys keep the `pounce-qp` defaults.
+
+**Correction to an earlier note in this section:** a previous revision of this
+entry stated that equality-constrained ill-conditioned QPs were "measured
+unchanged" by the #358 work and that the path showed run-to-run
+nondeterminism. Both claims were wrong — artifacts of a benchmark harness that
+seeded `numpy` from `hash()` of a tuple **containing a string**, which Python
+randomizes per process, so every run silently generated different problems. With
+integer-only seeds the solver is bit-for-bit reproducible, and the #358 work in
+fact improved that family substantially (92 → 38 failures/144) before #361 took
+it to 0.
 
 ## [0.9.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `qp-active-set` facade returned `success=False` and a wrong `x` on convex QPs with an active inequality (#358)
+
+- **The default `pounce.minimize(..., solver_selection="qp-active-set")` path
+  now converges** on easy, well-conditioned convex QPs whose general inequality
+  is active at the optimum. When the caller supplies no analytic Hessian the
+  facade sets `hessian_approximation=limited-memory`, which on the
+  active-set-SQP path selected the L-BFGS Lagrangian Hessian — it stalled with
+  `Search_Direction_Becomes_Too_Small` (or reported the QP subproblem
+  `unbounded`) and returned `success=False` together with a silently wrong `x`,
+  even at `cond(P)=10`, `n=3`. On a 36-instance sweep 29/36 failed.
+  - Fix: on the SQP path the automatic quasi-Newton approximation now maps to
+    the dense Powell-damped BFGS (`crates/pounce-algorithm/src/application.rs`),
+    which is far more robust and — because L-BFGS materializes the same dense
+    `n×n` Hessian for the QP subproblem today — costs nothing extra. An explicit
+    `sqp_hessian="lbfgs"` opt-in is still honored unchanged. The `#348`
+    exact-without-Hessian downgrade now targets damped-BFGS for the same reason.
+  - Independent oracles (closed-form KKT, `pounce.solve_qp` IPM, scipy SLSQP)
+    and every other pounce path already solved these; only the facade's L-BFGS
+    SQP default was affected.
+
 ## [0.9.0] - 2026-07-24
 
 ### Fixed — active-set-SQP stalled on curved-constraint NLPs via the Maratos effect (#349)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,52 @@ changes.
     persistent damped updates still accumulate on top. Halves the failure rate
     on a broad ill-conditioned-QP sweep (~21% → ~10%) and clears the #358
     36-instance tail sweep entirely.
-  - Not a complete cure for *extreme* conditioning: `cond(P) ≳ 1e4` (especially
-    small `n`) remains harder for the quasi-Newton path than for the
-    exact-Hessian / IPM / `solver_selection="auto"` routes, which solve these to
-    machine precision. Prefer those for very ill-conditioned QPs.
+  - Three further fixes below close the rest of this gap.
+
+### Fixed — three more active-set-SQP robustness holes on ill-conditioned QPs (#358)
+
+Continuing the above: on a 500-instance convex-QP sweep (`n ∈ {2,3,5,8,12}`,
+`cond ∈ {1…1e4}`, 20 seeds) failures fell from **~10% to 0.8%**, and the
+`Search_Direction_Becomes_Too_Small` failure mode was eliminated entirely
+(46 → 0). The error distribution of the solves that already succeeded is
+unchanged (median `6e-11`, max true constraint violation `4e-11`).
+
+- **Iteration-0 curvature probe.** The one-time BFGS sizing above cannot fire
+  until iteration 1 — but iteration **0** already solves a QP, against the raw
+  identity seed. Before that first QP, the driver now differences the gradient
+  across a short steepest-descent probe step and seeds `B = γI` with the
+  resulting Rayleigh quotient (one extra gradient evaluation). This is applied
+  **only when the constraint Jacobian is detected constant** (linear
+  constraints, or none), because the probe measures `∇²f`, which equals the
+  Lagrangian Hessian `∇²L = ∇²f + Σλᵢ∇²cᵢ` only when the constraint-curvature
+  term vanishes. On the Maratos problem `∇²f = 4I` while `∇²L ≈ I`, so probing
+  there would over-scale fourfold — the linearity gate keeps that path
+  untouched.
+- **Scale-relative inner-QP tolerances.** `QpOptions::{feas_tol, opt_tol}` are
+  absolute `1e-9`. As an *inner* subproblem the QP inherits the NLP's scale, so
+  with `‖∇f‖ ~ ‖B‖ ~ 1e3` that is `~1e-12` relative — the f64 noise floor. The
+  active-set solver could not certify its own optimality, burned its iteration
+  budget, returned `MaxIter`, and the driver aborted with `QpStepFailed`. Both
+  tolerances are now scaled by the QP data magnitude (clamped at `1e6`).
+  Correctness is unaffected: the outer loop still gates optimality on the true,
+  unscaled NLP KKT residuals, so a sloppier inner step can cost an extra outer
+  iteration but never a false `Optimal`.
+- **Quasi-Newton reset-and-retry.** A QP subproblem that still fails is usually
+  reporting a drifted quasi-Newton Hessian, not a bad linearization. Rather than
+  abort the whole solve, the driver now discards the accumulated curvature
+  (retaining the matrix's scale), rebuilds the subproblem, and re-solves once
+  from cold.
+
+Remaining known gap, **pre-existing and out of scope here**: equality-constrained
+ill-conditioned QPs (`cond ≳ 1e2`) still converge slowly and can exit
+`Maximum_Iterations_Exceeded` / `Internal_Error` — a different signature from
+the inequality-active stall #358 reported. Measured unchanged by this work
+(mean 36.3/144 before vs 35.7/144 after, over 6 runs each). Note those runs also
+exposed genuine **run-to-run nondeterminism** on that path (same binary, same
+inputs, ±4 instances), which the inequality path does not show; that is tracked
+separately. The exact-Hessian, IPM, and `solver_selection="auto"` routes solve
+all of these to machine precision and remain the recommendation for very
+ill-conditioned QPs.
 
 ## [0.9.0] - 2026-07-24
 

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3467,6 +3467,53 @@ mod tests {
         assert_eq!(snap.sqp.lbfgs_max_history, 12);
     }
 
+    /// Every `sqp_qp_*` key that [`apply_qp_subproblem_options`] reads must
+    /// actually be *registered*, and must reach `pounce_qp::QpOptions`.
+    ///
+    /// The whole family was readable-but-unregistered (gh #360): the options
+    /// registry rejected each one with OPTION_INVALID, so the reader was
+    /// unreachable and the documented knobs were unusable. This is the guard
+    /// that class of omission needs — it fails both if a key stops being
+    /// registered and if a newly-read key is never registered at all.
+    #[test]
+    fn application_sqp_qp_subproblem_options_are_registered_and_propagate() {
+        use pounce_qp::AntiCyclingChoice;
+
+        // Source of truth: the keys `apply_qp_subproblem_options` reads.
+        // Kept in step with that function by the round-trip assertions below.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str(
+            "algorithm active-set-sqp\n\
+             sqp_qp_max_iter 37\n\
+             sqp_qp_feas_tol 1e-7\n\
+             sqp_qp_opt_tol 2e-7\n\
+             sqp_qp_elastic_gamma 1e4\n\
+             sqp_qp_anti_cycling bland\n",
+        )
+        .expect("every sqp_qp_* option must be registered (gh #360)");
+
+        let qp = &app.algorithm_builder_snapshot().sqp_qp;
+        assert_eq!(qp.max_iter, 37);
+        assert!((qp.feas_tol - 1e-7).abs() < 1e-20);
+        assert!((qp.opt_tol - 2e-7).abs() < 1e-20);
+        assert!((qp.elastic_gamma - 1e4).abs() < 1e-9);
+        assert_eq!(qp.anti_cycling, AntiCyclingChoice::Bland);
+
+        // Untouched options must keep the pounce-qp defaults, not be
+        // overwritten with zeros by the "explicitly set" gate.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str("algorithm active-set-sqp\n")
+            .unwrap();
+        let defaults = pounce_qp::QpOptions::default();
+        let qp = &app.algorithm_builder_snapshot().sqp_qp;
+        assert_eq!(qp.max_iter, defaults.max_iter);
+        assert!((qp.feas_tol - defaults.feas_tol).abs() < 1e-20);
+        assert!((qp.opt_tol - defaults.opt_tol).abs() < 1e-20);
+        assert_eq!(qp.anti_cycling, defaults.anti_cycling);
+    }
+
     #[test]
     fn application_sqp_hessian_approximation_maps_to_damped_bfgs() {
         // The frontend sets `hessian_approximation = limited-memory` when no

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2960,10 +2960,26 @@ fn apply_sqp_options(options: &OptionsList, opts: &mut crate::sqp::SqpOptions) {
     // with variable bounds, a run to the box corner along the null-space
     // direction.)
     //
-    // Read it before `sqp_hessian` so an explicit setting still wins.
+    // The quasi-Newton source picked here is the *dense Powell-damped BFGS*,
+    // not the limited-memory one, even though the requesting option is spelled
+    // `limited-memory`. On this active-set-SQP path L-BFGS buys nothing: its
+    // `as_triplet` materializes a full dense `n×n` Hessian for the QP
+    // subproblem exactly as `DampedBfgs` does (the matrix-free product
+    // interface that would make L-BFGS cheaper is not implemented yet), and it
+    // is markedly less robust -- it stalls with
+    // `Search_Direction_Becomes_Too_Small` (or reports the QP subproblem
+    // `unbounded`) on easy, well-conditioned convex QPs whenever a general
+    // inequality is active at the optimum, returning `success=False` with a
+    // wrong `x` (issue #358). `DampedBfgs` solves those. So the automatic
+    // approximation the facade injects when no analytic Hessian is available
+    // maps to the robust dense update; a caller who genuinely wants
+    // limited-memory storage can still request it explicitly with
+    // `sqp_hessian = "lbfgs"` below (read after this, so it wins).
+    //
+    // Read this before `sqp_hessian` so an explicit setting still wins.
     if let Ok((s, true)) = options.get_string_value("hessian_approximation", "") {
         if s == "limited-memory" {
-            opts.hessian = SqpHessianSource::Lbfgs;
+            opts.hessian = SqpHessianSource::DampedBfgs;
         }
     }
     if let Ok((s, true)) = options.get_string_value("sqp_hessian", "") {
@@ -3449,6 +3465,44 @@ mod tests {
         assert!((snap.sqp.bt_min_alpha - 1e-10).abs() < 1e-18);
         assert_eq!(snap.sqp.print_level, 2);
         assert_eq!(snap.sqp.lbfgs_max_history, 12);
+    }
+
+    #[test]
+    fn application_sqp_hessian_approximation_maps_to_damped_bfgs() {
+        // The frontend sets `hessian_approximation = limited-memory` when no
+        // exact Lagrangian Hessian is available (e.g. `pounce.minimize` with
+        // no `hess`). On the active-set-SQP path that must resolve to the
+        // dense Powell-damped BFGS, NOT the limited-memory update: L-BFGS
+        // materializes the same dense Hessian for the QP subproblem yet stalls
+        // (`Search_Direction_Becomes_Too_Small` / wrong `x`) on convex QPs with
+        // an active inequality (issue #358); damped-BFGS solves them.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str(
+            "algorithm active-set-sqp\n\
+             hessian_approximation limited-memory\n",
+        )
+        .unwrap();
+        assert_eq!(
+            app.algorithm_builder_snapshot().sqp.hessian,
+            crate::sqp::SqpHessianSource::DampedBfgs
+        );
+
+        // An explicit `sqp_hessian = lbfgs` is still honored (it is read after
+        // `hessian_approximation`, so it wins): callers who genuinely want the
+        // limited-memory update can still ask for it.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str(
+            "algorithm active-set-sqp\n\
+             hessian_approximation limited-memory\n\
+             sqp_hessian lbfgs\n",
+        )
+        .unwrap();
+        assert_eq!(
+            app.algorithm_builder_snapshot().sqp.hessian,
+            crate::sqp::SqpHessianSource::Lbfgs
+        );
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/sqp/bfgs.rs
+++ b/crates/pounce-algorithm/src/sqp/bfgs.rs
@@ -180,7 +180,25 @@ impl DampedBfgs {
                 .zip(prev_grad_lag.iter())
                 .map(|(a, b)| a - b)
                 .collect();
+            self.update_sy(&s, &y);
+        }
 
+        self.prev_x = Some(x_new.to_vec());
+        self.prev_grad_lag = Some(grad_lag_new.to_vec());
+    }
+
+    /// Apply the Powell-damped rank-2 update from an explicit curvature
+    /// pair `(s, y)`.
+    ///
+    /// Prefer this over [`Self::update`] when the caller can form `y`
+    /// itself: the SQP driver must difference `∇L` at a **single, fixed**
+    /// multiplier (see the note in `sqp_alg.rs`), which the `(x, ∇L)` form
+    /// of [`Self::update`] cannot express because it stores the previous
+    /// `∇L` as evaluated at the previous multiplier.
+    pub fn update_sy(&mut self, s: &[Number], y: &[Number]) {
+        assert_eq!(s.len(), self.n, "BFGS::update_sy: s.len() != n");
+        assert_eq!(y.len(), self.n, "BFGS::update_sy: y.len() != n");
+        {
             // One-time initial Hessian sizing (Nocedal-Wright §6.1). The
             // identity seed `B_0 = I` is a catastrophic scale on
             // ill-conditioned problems: when `‖∇²L‖ ≫ 1` the first QP
@@ -256,9 +274,6 @@ impl DampedBfgs {
                 }
             }
         }
-
-        self.prev_x = Some(x_new.to_vec());
-        self.prev_grad_lag = Some(grad_lag_new.to_vec());
     }
 
     /// Produce the current B as a `Triplet` over the upper
@@ -359,6 +374,32 @@ mod tests {
             mean_diag > 10.0,
             "sanity: the retained scale should reflect the problem, not 1"
         );
+    }
+
+    #[test]
+    fn update_sy_matches_the_x_grad_lag_form() {
+        // `update_sy` is the primitive; `update` is the (s, y)-from-stored-
+        // prev convenience wrapper. Feeding the same curvature pair through
+        // either path must land on the identical matrix, so the driver's
+        // switch to `update_sy` (gh #361) changes only *which* y is formed,
+        // never how it is applied.
+        let mut via_update = DampedBfgs::new(2);
+        via_update.update(&[0.0, 0.0], &[1.0, 2.0]);
+        via_update.update(&[1.0, 3.0], &[4.0, 9.0]);
+
+        let mut via_sy = DampedBfgs::new(2);
+        via_sy.update_sy(&[1.0, 3.0], &[3.0, 7.0]); // s = x1-x0, y = g1-g0
+
+        for i in 0..2 {
+            for j in 0..=i {
+                assert!(
+                    (via_update.get(i, j) - via_sy.get(i, j)).abs() < 1e-12,
+                    "B[{i},{j}]: update={} update_sy={}",
+                    via_update.get(i, j),
+                    via_sy.get(i, j)
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/sqp/bfgs.rs
+++ b/crates/pounce-algorithm/src/sqp/bfgs.rs
@@ -33,6 +33,11 @@ pub struct DampedBfgs {
     /// Previous `x` and ∇L; updated at the end of each `update` call.
     prev_x: Option<Vec<Number>>,
     prev_grad_lag: Option<Vec<Number>>,
+    /// Whether the one-time initial sizing has been applied yet (see
+    /// [`Self::update`]). `false` until the first `(s, y)` pair with
+    /// `sᵀy > 0` arrives, at which point `B` is rescaled from the
+    /// identity to `γI` and this flips to `true`.
+    sized: bool,
     /// Pre-computed sparsity pattern for `as_triplet`. Fixed:
     /// every (i, j) with `i ≥ j`. 1-based.
     h_irow: Vec<Index>,
@@ -59,6 +64,7 @@ impl DampedBfgs {
             b,
             prev_x: None,
             prev_grad_lag: None,
+            sized: false,
             h_irow,
             h_jcol,
         }
@@ -112,6 +118,46 @@ impl DampedBfgs {
                 .zip(prev_grad_lag.iter())
                 .map(|(a, b)| a - b)
                 .collect();
+
+            // One-time initial Hessian sizing (Nocedal-Wright §6.1). The
+            // identity seed `B_0 = I` is a catastrophic scale on
+            // ill-conditioned problems: when `‖∇²L‖ ≫ 1` the first QP
+            // step, computed against `B = I`, overshoots the true Newton
+            // step by a factor `~cond(∇²L)`, and the filter line search —
+            // with an empty filter at the first iterate, where the
+            // starting point is near-feasible so `θ_curr` is tiny — accepts
+            // the objective-blowing step because it happens to drive the
+            // (negligible) constraint violation to zero. The overshoot
+            // corrupts the working set and the solve then diverges to
+            // `‖x‖ ~ 1e4` before dying with
+            // `Search_Direction_Becomes_Too_Small`, on easy convex QPs
+            // (issue #358 tail: `cond(P) ≳ 1e3`). Before applying the very
+            // first rank-2 update, rescale `B` from `I` to `γI` with the
+            // Rayleigh-quotient curvature estimate `γ = sᵀy / sᵀs`, which
+            // for a quadratic lies in `[λ_min(∇²L), λ_max(∇²L)]` — a
+            // representative scale that keeps the first post-sizing step
+            // in range. Applied *once* on the first curvature pair, not
+            // every iteration: re-seeding each step would discard the
+            // curvature the persistent damped update accumulates (that
+            // re-seeding is exactly what makes the L-BFGS path oscillate).
+            // Halves the ill-conditioned-QP failure rate on a broad sweep
+            // and clears the #358 tail; a fully robust cure for extreme
+            // conditioning (`cond ≳ 1e4`) still needs the exact-Hessian or
+            // IPM path.
+            if !self.sized {
+                let s_y: Number = s.iter().zip(y.iter()).map(|(a, b)| a * b).sum();
+                let s_s: Number = s.iter().map(|v| v * v).sum();
+                if s_y > 1e-30 && s_s > 1e-30 {
+                    let gamma = s_y / s_s;
+                    for i in 0..self.n {
+                        self.set(i, i, gamma);
+                    }
+                }
+                // Mark sized once a genuine pair is seen, even if the
+                // ratio was degenerate (leave B = I in that rare case) —
+                // we only ever size on the first curvature pair.
+                self.sized = true;
+            }
 
             // bs = B · s
             let bs: Vec<Number> = (0..self.n)
@@ -169,5 +215,60 @@ impl DampedBfgs {
             jcol: self.h_jcol.clone(),
             vals,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn diag(b: &DampedBfgs, i: usize) -> Number {
+        b.get(i, i)
+    }
+
+    #[test]
+    fn first_update_sizes_the_identity_seed() {
+        // Curvature pair along axis 0 from the quadratic f = ½·9‖x‖²
+        // (∇²f = 9I): s = (1, 0), y = 9 s = (9, 0), so the sizing
+        // factor is γ = sᵀy / sᵀs = 9. After the first update the
+        // *untouched* direction (axis 1) must carry the sized scale
+        // γ = 9, not the identity seed 1 — that is the whole point of
+        // sizing on an ill-conditioned problem (issue #358). Along the
+        // updated axis the Powell-damped rank-2 term keeps it at 9 too.
+        let mut b = DampedBfgs::new(2);
+        b.update(&[0.0, 0.0], &[0.0, 0.0]); // record start (no pair yet)
+        assert!((diag(&b, 0) - 1.0).abs() < 1e-12, "seed must be I");
+        assert!((diag(&b, 1) - 1.0).abs() < 1e-12, "seed must be I");
+        b.update(&[1.0, 0.0], &[9.0, 0.0]); // first genuine (s, y): sizes then updates
+        assert!(
+            (diag(&b, 1) - 9.0).abs() < 1e-9,
+            "off-axis diagonal should be sized to γ = 9, got {}",
+            diag(&b, 1)
+        );
+        assert!(
+            (diag(&b, 0) - 9.0).abs() < 1e-9,
+            "on-axis diagonal should be 9 after sizing + rank-2 update, got {}",
+            diag(&b, 0)
+        );
+    }
+
+    #[test]
+    fn sizing_happens_only_once() {
+        // A second pair must NOT re-seed the diagonal; the persistent
+        // rank-2 updates accumulate on top of the one-time sized base.
+        let mut b = DampedBfgs::new(2);
+        b.update(&[0.0, 0.0], &[0.0, 0.0]);
+        b.update(&[1.0, 0.0], &[9.0, 0.0]); // sizes to γ = 9
+        assert!(b.sized);
+        // A second pair along axis 1 with a *different* curvature (4):
+        // γ would have been 4 had we re-sized, but we must not.
+        b.update(&[1.0, 1.0], &[9.0, 4.0]); // s = (0,1), y = (0,4)
+        // Axis-0 diagonal is untouched by this axis-1 pair and must
+        // still reflect the first sizing (9), never re-seeded to 4.
+        assert!(
+            (diag(&b, 0) - 9.0).abs() < 1e-9,
+            "second pair must not re-seed; axis-0 diagonal = {}",
+            diag(&b, 0)
+        );
     }
 }

--- a/crates/pounce-algorithm/src/sqp/bfgs.rs
+++ b/crates/pounce-algorithm/src/sqp/bfgs.rs
@@ -76,6 +76,68 @@ impl DampedBfgs {
         self.prev_x.is_some()
     }
 
+    /// Seed `B = γI` directly and mark the one-time sizing done, so the
+    /// first [`Self::update`] applies its rank-2 correction on top of
+    /// this scale instead of re-seeding from its own `(s, y)`.
+    ///
+    /// Used by the driver's iteration-0 curvature probe: the internal
+    /// sizing in [`Self::update`] cannot fire until a first `(s, y)` pair
+    /// exists, i.e. not until iteration 1 — but iteration **0** already
+    /// solves a QP against `B`, and with the identity seed that step
+    /// overshoots by `~cond(∇²L)` on an ill-conditioned problem. See the
+    /// sizing comment in [`Self::update`] for why that is fatal.
+    ///
+    /// `gamma` must be finite and strictly positive; anything else is
+    /// ignored (leaving `B = I`) rather than corrupting the matrix.
+    pub fn seed_scale(&mut self, gamma: Number) {
+        if !gamma.is_finite() || gamma <= 0.0 {
+            return;
+        }
+        for i in 0..self.n {
+            self.set(i, i, gamma);
+        }
+        self.sized = true;
+    }
+
+    /// Discard the accumulated rank-2 curvature and fall back to a
+    /// scaled identity `γI`, where `γ` is the current mean diagonal
+    /// (a scale the accumulated matrix has already vouched for).
+    /// `prev_x` / `prev_grad_lag` are retained, so the next
+    /// [`Self::update`] resumes accumulating from the reset base.
+    ///
+    /// Used as a recovery step when the QP subproblem fails: a
+    /// quasi-Newton matrix that has drifted ill-conditioned makes the
+    /// step subproblem numerically unsolvable, and that is recoverable
+    /// — far better than aborting an otherwise healthy solve.
+    /// Off-diagonals are zeroed; the diagonal keeps the problem's scale.
+    pub fn reset_to_scale(&mut self) {
+        let mut sum = 0.0;
+        let mut count = 0usize;
+        for i in 0..self.n {
+            let d = self.get(i, i);
+            if d.is_finite() && d > 0.0 {
+                sum += d;
+                count += 1;
+            }
+        }
+        let gamma = if count > 0 {
+            sum / count as Number
+        } else {
+            1.0
+        };
+        let gamma = if gamma.is_finite() && gamma > 0.0 {
+            gamma
+        } else {
+            1.0
+        };
+        for v in self.b.iter_mut() {
+            *v = 0.0;
+        }
+        for i in 0..self.n {
+            self.set(i, i, gamma);
+        }
+    }
+
     fn idx(&self, i: usize, j: usize) -> usize {
         debug_assert!(i < self.n && j < self.n);
         let (lo, hi) = if i >= j { (j, i) } else { (i, j) };
@@ -249,6 +311,53 @@ mod tests {
             (diag(&b, 0) - 9.0).abs() < 1e-9,
             "on-axis diagonal should be 9 after sizing + rank-2 update, got {}",
             diag(&b, 0)
+        );
+    }
+
+    #[test]
+    fn seed_scale_sets_the_diagonal_and_marks_sized() {
+        let mut b = DampedBfgs::new(3);
+        b.seed_scale(25.0);
+        assert!(b.sized, "seeding must suppress the later one-time sizing");
+        for i in 0..3 {
+            assert!((diag(&b, i) - 25.0).abs() < 1e-12);
+        }
+        // A degenerate scale must be ignored, not written into B.
+        let mut c = DampedBfgs::new(2);
+        for bad in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+            c.seed_scale(bad);
+            assert!(!c.sized, "seed_scale({bad}) must be refused");
+            assert!((diag(&c, 0) - 1.0).abs() < 1e-12, "B must stay I");
+        }
+    }
+
+    #[test]
+    fn reset_to_scale_drops_curvature_but_keeps_magnitude() {
+        // Build up genuine off-diagonal curvature, then reset: the
+        // off-diagonals must vanish and the diagonal must retain the
+        // matrix's own scale (its mean diagonal), not collapse to 1.
+        let mut b = DampedBfgs::new(2);
+        b.seed_scale(100.0);
+        b.update(&[0.0, 0.0], &[0.0, 0.0]);
+        b.update(&[1.0, 1.0], &[150.0, 40.0]); // rank-2 update -> off-diagonals
+        assert!(
+            b.get(1, 0).abs() > 1e-9,
+            "test precondition: expected off-diagonal curvature, got {}",
+            b.get(1, 0)
+        );
+        let mean_diag = (diag(&b, 0) + diag(&b, 1)) / 2.0;
+        b.reset_to_scale();
+        assert!(b.get(1, 0).abs() < 1e-12, "off-diagonals must be zeroed");
+        for i in 0..2 {
+            assert!(
+                (diag(&b, i) - mean_diag).abs() < 1e-9,
+                "diagonal must keep the mean scale {mean_diag}, got {}",
+                diag(&b, i)
+            );
+        }
+        assert!(
+            mean_diag > 10.0,
+            "sanity: the retained scale should reflect the problem, not 1"
         );
     }
 

--- a/crates/pounce-algorithm/src/sqp/lbfgs.rs
+++ b/crates/pounce-algorithm/src/sqp/lbfgs.rs
@@ -104,18 +104,31 @@ impl LBfgs {
                 .zip(prev_grad_lag.iter())
                 .map(|(a, b)| a - b)
                 .collect();
-            // Skip degenerate pairs (s ≈ 0).
-            let s_norm2: Number = s.iter().map(|v| v * v).sum();
-            if s_norm2 > 1e-30 {
-                if self.pairs.len() == self.m_history {
-                    self.pairs.pop_front();
-                }
-                self.pairs.push_back((s, y));
-            }
+            self.update_sy(&s, &y);
         }
 
         self.prev_x = Some(x_new.to_vec());
         self.prev_grad_lag = Some(grad_lag_new.to_vec());
+    }
+
+    /// Record an explicit curvature pair `(s, y)`.
+    ///
+    /// Prefer this over [`Self::update`] when the caller can form `y`
+    /// itself: the SQP driver must difference `∇L` at a **single, fixed**
+    /// multiplier (see `sqp_alg::curvature_pair`), which the `(x, ∇L)`
+    /// form cannot express because it stores the previous `∇L` as
+    /// evaluated at the previous multiplier.
+    pub fn update_sy(&mut self, s: &[Number], y: &[Number]) {
+        assert_eq!(s.len(), self.n, "LBFGS::update_sy: s.len() != n");
+        assert_eq!(y.len(), self.n, "LBFGS::update_sy: y.len() != n");
+        // Skip degenerate pairs (s ≈ 0).
+        let s_norm2: Number = s.iter().map(|v| v * v).sum();
+        if s_norm2 > 1e-30 {
+            if self.pairs.len() == self.m_history {
+                self.pairs.pop_front();
+            }
+            self.pairs.push_back((s.to_vec(), y.to_vec()));
+        }
     }
 
     /// Materialize the current B_k as a dense `Triplet` over the

--- a/crates/pounce-algorithm/src/sqp/qp_assembly.rs
+++ b/crates/pounce-algorithm/src/sqp/qp_assembly.rs
@@ -40,6 +40,7 @@ pub struct SqpQpData {
 
 /// Sparse-triplet view of a derivative matrix. Indices are
 /// 1-based per the pounce-linalg convention; values are owned.
+#[derive(Clone)]
 pub struct Triplet {
     pub n_rows: usize,
     pub n_cols: usize,

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -163,6 +163,12 @@ impl SqpAlgorithm {
         // LS already computed them at the new iterate).
         let mut f_cached: Option<Number> = None;
         let mut c_cached: Option<Vec<Number>> = None;
+        // Previous iterate's `(x, ∇f, ∇c)`, kept so the quasi-Newton
+        // curvature pair can difference `∇L` at a single fixed multiplier
+        // (see [`curvature_pair`]). Storing `∇L` directly — as the older
+        // `DampedBfgs::update(x, ∇L)` form did — bakes in the multiplier
+        // that was current at the time, which is precisely the bug.
+        let mut prev_point: Option<(Vec<Number>, Vec<Number>, Triplet)> = None;
 
         // Damped-BFGS state, allocated only if needed. The
         // matrix is updated at the END of each iteration (after
@@ -270,20 +276,28 @@ impl SqpAlgorithm {
                 SqpHessianSource::Exact => nlp.eval_hess_lag(&iter.x, &iter.lambda_g),
                 SqpHessianSource::DampedBfgs => {
                     let bfgs = bfgs.as_mut().expect("DampedBfgs state initialized above");
-                    // Update on the *current* (x, ∇L). The
-                    // very first iteration's update is a no-op
-                    // (no previous pair); the matrix stays I.
-                    let grad_lag = compute_grad_lag(&grad_f, &jac_c, &iter.lambda_g, n);
-                    bfgs.update(&iter.x, &grad_lag);
+                    if let Some((s, y)) =
+                        curvature_pair(prev_point.as_ref(), &iter, &grad_f, &jac_c, n)
+                    {
+                        bfgs.update_sy(&s, &y);
+                    }
                     bfgs.as_triplet()
                 }
                 SqpHessianSource::Lbfgs => {
                     let lb = lbfgs.as_mut().expect("LBfgs state initialized above");
-                    let grad_lag = compute_grad_lag(&grad_f, &jac_c, &iter.lambda_g, n);
-                    lb.update(&iter.x, &grad_lag);
+                    if let Some((s, y)) =
+                        curvature_pair(prev_point.as_ref(), &iter, &grad_f, &jac_c, n)
+                    {
+                        lb.update_sy(&s, &y);
+                    }
                     lb.as_triplet()
                 }
             };
+
+            // Remember this iterate's `(x, ∇f, ∇c)` so the next
+            // iteration can build its curvature pair at a fixed
+            // multiplier. See `curvature_pair`.
+            prev_point = Some((iter.x.clone(), grad_f.clone(), jac_c.clone()));
 
             // KKT check uses the current iterate's evaluations.
             let kkt = check_kkt(
@@ -304,8 +318,17 @@ impl SqpAlgorithm {
                 );
             }
 
-            if kkt.stationarity <= self.opts.dual_inf_tol
-                && kkt.constr_viol <= self.opts.constr_viol_tol
+            // `sqp_tol` and `sqp_dual_inf_tol` are both registered and both
+            // documented as a max-norm tolerance on the stationarity
+            // residual, but only `dual_inf_tol` was ever read — `opts.tol`
+            // (default 1e-8) was dead, so the loose 1e-4 governed alone and
+            // silently capped attainable accuracy (max x-error `7e-5` on the
+            // #358 sweep). Honor both by requiring the tighter, which is the
+            // only reading under which neither option is a no-op. Restores
+            // `~5e-9` worst-case accuracy for ~10% more iterations. Same
+            // registered-but-inert defect family as gh #360.
+            let stationarity_tol = self.opts.tol.min(self.opts.dual_inf_tol);
+            if kkt.stationarity <= stationarity_tol && kkt.constr_viol <= self.opts.constr_viol_tol
             {
                 self.iterates = Some(iter.clone());
                 return Ok(SqpResult {
@@ -740,6 +763,67 @@ fn mat_vec_gen(a: &GenTMatrix, p: &[Number], m: usize) -> Vec<Number> {
         out[i] += vals[k] * p[j];
     }
     out
+}
+
+/// Build the quasi-Newton curvature pair `(s, y)` for the step from the
+/// previous iterate to the current one, differencing `∇L` at a **single,
+/// fixed multiplier** (Nocedal-Wright §18.3):
+///
+/// ```text
+///     s = x_k − x_{k−1}
+///     y = ∇L(x_k, λ_k) − ∇L(x_{k−1}, λ_k)        ← the SAME λ_k twice
+/// ```
+///
+/// Returns `None` on the first iteration (no previous point yet).
+///
+/// **Why the fixed multiplier matters (gh #361).** The previous code held
+/// `∇L(x_{k−1}, λ_{k−1})` inside the Hessian object and differenced against
+/// `∇L(x_k, λ_k)`, giving
+///
+/// ```text
+///     y = (∇f_k − ∇f_{k−1}) + (J_kᵀλ_k − J_{k−1}ᵀλ_{k−1})
+/// ```
+///
+/// For **linear** constraints `J` is constant, so that second group collapses
+/// to `Aᵀ(λ_k − λ_{k−1})` — pure *multiplier* difference, carrying no
+/// curvature information at all. Since the true `∇²L` equals `∇²f` there, the
+/// whole term is spurious, and it feeds a divergent loop: a perturbed `B`
+/// yields a worse QP multiplier, which injects a larger error into the next
+/// `y`, which corrupts `B` further. On equality-constrained QPs (where `λ` is
+/// sign-free and can swing hard) the multiplier was observed oscillating and
+/// growing exponentially — `−13, 19, −69, 104, −145, 581, −1320, 3176, …` —
+/// while `x` itself sat on the exact optimum. The solve then burned its whole
+/// iteration budget and exited `Maximum_Iterations_Exceeded` *at the right
+/// answer*, because the stationarity residual is computed from that garbage
+/// multiplier.
+///
+/// Using one multiplier at both points makes the term telescope to
+/// `Σλᵏᵢ(∇cᵢ(x_k) − ∇cᵢ(x_{k−1}))`, which is the genuine constraint-curvature
+/// contribution: it vanishes identically for linear constraints (as it must)
+/// and is retained for nonlinear ones.
+fn curvature_pair(
+    prev: Option<&(Vec<Number>, Vec<Number>, Triplet)>,
+    iter: &SqpIterates,
+    grad_f: &[Number],
+    jac_c: &Triplet,
+    n: usize,
+) -> Option<(Vec<Number>, Vec<Number>)> {
+    let (prev_x, prev_grad_f, prev_jac) = prev?;
+    let s: Vec<Number> = iter
+        .x
+        .iter()
+        .zip(prev_x.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+    // Both evaluated at the *current* multiplier `iter.lambda_g`.
+    let lag_curr = compute_grad_lag(grad_f, jac_c, &iter.lambda_g, n);
+    let lag_prev = compute_grad_lag(prev_grad_f, prev_jac, &iter.lambda_g, n);
+    let y: Vec<Number> = lag_curr
+        .iter()
+        .zip(lag_prev.iter())
+        .map(|(a, b)| a - b)
+        .collect();
+    Some((s, y))
 }
 
 /// Lagrangian gradient `∇L(x, λ_g) = ∇f(x) + J_c(x)ᵀ λ_g` at the

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -180,6 +180,87 @@ impl SqpAlgorithm {
             None
         };
 
+        // Iteration-0 curvature probe (issue #358 tail).
+        //
+        // `DampedBfgs::update` sizes the identity seed from the first
+        // `(s, y)` pair — but that pair only exists at iteration 1, and
+        // iteration **0** already solves a QP against `B`. With `B = I`
+        // on a problem where `‖∇²L‖ ≫ 1`, that first step overshoots the
+        // Newton step by `~cond(∇²L)`; the filter (empty, and `θ` tiny at
+        // a near-feasible start) accepts the objective-blowing step, the
+        // iterate is flung to `‖x‖ ~ 1e3`, and the huge `(s, y)` pairs
+        // that follow drive `B` so ill-conditioned that the QP subproblem
+        // itself fails a few iterations later (`QpStepFailed`, surfacing
+        // as `Search_Direction_Becomes_Too_Small`).
+        //
+        // Fix the scale *before* that first QP with one extra gradient
+        // evaluation: step a short distance along the steepest-descent
+        // direction, difference the gradients, and seed `B = γI` with the
+        // resulting Rayleigh quotient `γ = sᵀy / sᵀs`. For a quadratic
+        // this is exactly the curvature along the probe direction, and it
+        // lies in `[λ_min(∇²L), λ_max(∇²L)]`.
+        //
+        // The probe differences the *objective* gradient, so it estimates
+        // `∇²f` — which equals the Lagrangian Hessian `∇²L = ∇²f + Σλᵢ∇²cᵢ`
+        // only when the constraint-curvature term vanishes, i.e. when every
+        // constraint is linear (or there are none). That condition is
+        // exactly the #358 family, and it is *not* cosmetic: on the Maratos
+        // problem (`min 2(x₁²+x₂²−1) − x₁ s.t. x₁²+x₂²=1`) `∇²f = 4I` while
+        // `∇²L ≈ I` at the solution, so seeding the objective curvature
+        // would over-scale `B` fourfold and cost that solve its convergence.
+        //
+        // Detect linearity directly rather than trusting a declaration:
+        // compare the constraint Jacobian at the probe point with the one
+        // at `x`. Identical ⇒ `∇c` is constant ⇒ constraints are linear ⇒
+        // the objective Hessian *is* the Lagrangian Hessian and the probe
+        // is exact. Otherwise leave the identity seed alone and let the
+        // rank-2 updates (which see the true `∇L`) do the work.
+        if let Some(b) = bfgs.as_mut() {
+            let g0 = nlp.eval_grad_f(&iter.x);
+            let g_norm = g0.iter().map(|v| v * v).sum::<Number>().sqrt();
+            if g_norm.is_finite() && g_norm > 0.0 {
+                // Absolute probe length, scaled by the iterate so the step
+                // is meaningful in the problem's own units but always tiny
+                // relative to it. `1e-7` keeps the gradient difference well
+                // above f64 roundoff without leaving the local model.
+                let x_scale = iter.x.iter().map(|v| v.abs()).fold(1.0, f64::max);
+                let eps = 1e-7 * x_scale;
+                let step: Vec<Number> = g0.iter().map(|gi| -eps * gi / g_norm).collect();
+                let x_probe: Vec<Number> =
+                    iter.x.iter().zip(step.iter()).map(|(a, d)| a + d).collect();
+                // Constant-Jacobian (linear-constraint) check, per above.
+                let linear_constraints = m == 0 || {
+                    let j0 = nlp.eval_jac_c(&iter.x);
+                    let j1 = nlp.eval_jac_c(&x_probe);
+                    j0.vals.len() == j1.vals.len()
+                        && j0.vals.iter().zip(j1.vals.iter()).all(|(a, c)| {
+                            // Relative comparison: a linear constraint
+                            // reproduces its Jacobian bit-for-bit, so this
+                            // only tolerates evaluation noise.
+                            let scale = a.abs().max(c.abs()).max(1.0);
+                            (a - c).abs() <= 1e-12 * scale
+                        })
+                };
+                if linear_constraints {
+                    let g1 = nlp.eval_grad_f(&x_probe);
+                    let s_y: Number = step
+                        .iter()
+                        .zip(g1.iter().zip(g0.iter()))
+                        .map(|(si, (a, bg))| si * (a - bg))
+                        .sum();
+                    let s_s: Number = step.iter().map(|v| v * v).sum();
+                    if s_s > 0.0 && s_y.is_finite() {
+                        // A non-positive quotient means the probe direction
+                        // has non-positive curvature (nonconvex or
+                        // numerically flat); `seed_scale` ignores it, leaving
+                        // the identity seed rather than a meaningless or
+                        // negative scale.
+                        b.seed_scale(s_y / s_s);
+                    }
+                }
+            }
+        }
+
         for outer in 0..self.opts.max_iter {
             let grad_f = nlp.eval_grad_f(&iter.x);
             let c_vals = c_cached.take().unwrap_or_else(|| nlp.eval_c(&iter.x));
@@ -255,6 +336,50 @@ impl SqpAlgorithm {
             );
             let qp = qp_data.as_qp();
 
+            // Scale-relative inner-QP tolerances (issue #358 tail).
+            //
+            // `QpOptions::{feas_tol, opt_tol}` are **absolute** (1e-9 each).
+            // That is a sane default for a standalone `solve_qp` on
+            // well-scaled data, but this QP is an *inner* subproblem whose
+            // data inherits the NLP's scale: with `‖∇f‖ ~ 1e3` and
+            // `‖B‖ ~ 1e3`, an absolute 1e-9 is ~1e-12 *relative* — at the
+            // f64 noise floor. The active-set solver then cannot certify
+            // its own optimality, burns its whole iteration budget, and
+            // returns `MaxIter`; the driver reports `QpStepFailed`, which
+            // surfaces to the user as `Search_Direction_Becomes_Too_Small`
+            // on a QP that is trivially solvable. This is what stalled the
+            // ill-conditioned tail of #358 even once the Hessian scale was
+            // fixed by the probe above.
+            //
+            // Scale both tolerances by the QP data magnitude, so the inner
+            // solve is asked for a *relative* accuracy it can actually
+            // reach. Nothing is lost in the answer: the SQP outer loop
+            // still gates optimality on the true, unscaled NLP KKT
+            // residuals (`dual_inf_tol` / `constr_viol_tol`) at the top of
+            // each iteration, so a sloppier inner step can only cost an
+            // extra outer iteration — never a false `Optimal`. Measured on
+            // a 500-instance convex-QP sweep this converts 34 failures into
+            // successes with a *bit-for-bit identical* error distribution
+            // (median 6e-11, max true constraint violation 4e-11).
+            //
+            // The `SCALE_MAX` clamp bounds the relaxation on pathological
+            // data (a quasi-Newton `B` that has blown up); it does not bind
+            // on any problem in the sweep.
+            const SCALE_MAX: Number = 1e6;
+            let g_inf = grad_f.iter().map(|v| v.abs()).fold(0.0, f64::max);
+            let b_inf = qp_data
+                .h
+                .values()
+                .iter()
+                .map(|v| v.abs())
+                .fold(0.0, f64::max);
+            let base = self.qp_opts.clone();
+            let scale = g_inf.max(b_inf).clamp(1.0, SCALE_MAX);
+            if scale > 1.0 {
+                self.qp_opts.opt_tol = base.opt_tol * scale;
+                self.qp_opts.feas_tol = base.feas_tol * scale;
+            }
+
             // Warm-start from the previous QP's working set when
             // available. Pounce-qp's `solve_with_working_set`
             // internally computes a feasible primal compatible
@@ -290,6 +415,47 @@ impl SqpAlgorithm {
                     sol = cold;
                 }
             }
+
+            // Quasi-Newton reset fallback (issue #358 tail). If the QP
+            // still cannot be solved, the usual culprit is not the
+            // linearization but the *approximated* Hessian: a damped-BFGS
+            // matrix that has accumulated enough drift (typically after a
+            // large early step on an ill-conditioned problem) to make the
+            // step subproblem numerically unsolvable. That is recoverable
+            // — throwing away the accumulated curvature and retrying from
+            // a scaled identity almost always yields a usable step —
+            // whereas the alternative is aborting an otherwise healthy
+            // solve with `QpStepFailed`, which the user sees as
+            // `Search_Direction_Becomes_Too_Small` on a trivially solvable
+            // problem. Rebuild the subproblem around the reset Hessian and
+            // re-solve once, from cold (the carried working set belongs to
+            // the discarded model).
+            let mut qp_data = qp_data;
+            if matches!(sol.status, QpStatus::MaxIter | QpStatus::NumericalError)
+                && let Some(b) = bfgs.as_mut()
+            {
+                b.reset_to_scale();
+                qp_data = SqpQpData::build(
+                    &iter.x,
+                    &grad_f,
+                    &c_vals,
+                    &bl_c,
+                    &bu_c,
+                    &xl,
+                    &xu,
+                    nlp.eval_jac_c(&iter.x),
+                    b.as_triplet(),
+                    self.hessian_inertia(),
+                );
+                let retry = self
+                    .qp_solver
+                    .solve(&qp_data.as_qp(), None, &self.qp_opts)?;
+                n_qp_solves += 1;
+                if retry.status == QpStatus::Optimal {
+                    sol = retry;
+                }
+            }
+            self.qp_opts = base;
 
             match sol.status {
                 QpStatus::Optimal => {}

--- a/crates/pounce-algorithm/src/sqp/tests.rs
+++ b/crates/pounce-algorithm/src/sqp/tests.rs
@@ -256,6 +256,111 @@ fn sqp_optimize_convex_eq_nlp_one_iter() {
 }
 
 // ─────────────────────────────────────────────────────────────────
+// Ill-conditioned equality-constrained QP (gh #361):
+//
+//     min ½ xᵀPx + cᵀx   s.t.  x₁ + x₂ + x₃ = 3
+//     P = diag(1, 100, 1000),  c = (−2, −101, −1001)
+//
+// Closed form: x* = (1, 1, 1), λ* = 1, f* = −553.5.
+//
+// Under a quasi-Newton Hessian this used to expose the
+// inconsistent-multiplier curvature pair: `y` was differenced across
+// *two different* multipliers, so for these (linear) constraints it
+// carried a spurious `Aᵀ(λ_k − λ_{k−1})` term. The multiplier then
+// oscillated and diverged (−13, 19, −69, 104, −145, 581, −1320, 3176, …)
+// while `x` sat on the exact optimum, and the solve exited
+// `MaxIter` *at the right answer* because the stationarity residual is
+// formed from that multiplier. Hence the assertions below check the
+// multiplier and the status, not just `x`.
+// ─────────────────────────────────────────────────────────────────
+struct IllConditionedEqQp;
+
+impl SqpProblemSpec for IllConditionedEqQp {
+    fn n(&self) -> usize {
+        3
+    }
+    fn m(&self) -> usize {
+        1
+    }
+    fn x_init(&self) -> Vec<f64> {
+        vec![0.0, 0.0, 0.0]
+    }
+    fn variable_bounds(&self) -> (Vec<f64>, Vec<f64>) {
+        (vec![NLP_LOWER_BOUND_INF; 3], vec![NLP_UPPER_BOUND_INF; 3])
+    }
+    fn constraint_bounds(&self) -> (Vec<f64>, Vec<f64>) {
+        (vec![0.0], vec![0.0])
+    }
+    fn eval_f(&mut self, x: &[f64]) -> f64 {
+        0.5 * (x[0] * x[0] + 100.0 * x[1] * x[1] + 1000.0 * x[2] * x[2])
+            - 2.0 * x[0]
+            - 101.0 * x[1]
+            - 1001.0 * x[2]
+    }
+    fn eval_grad_f(&mut self, x: &[f64]) -> Vec<f64> {
+        vec![x[0] - 2.0, 100.0 * x[1] - 101.0, 1000.0 * x[2] - 1001.0]
+    }
+    fn eval_c(&mut self, x: &[f64]) -> Vec<f64> {
+        vec![x[0] + x[1] + x[2] - 3.0]
+    }
+    fn eval_jac_c(&mut self, _x: &[f64]) -> Triplet {
+        Triplet {
+            n_rows: 1,
+            n_cols: 3,
+            irow: vec![1, 1, 1],
+            jcol: vec![1, 2, 3],
+            vals: vec![1.0, 1.0, 1.0],
+        }
+    }
+    fn eval_hess_lag(&mut self, _x: &[f64], _lambda_g: &[f64]) -> Triplet {
+        Triplet {
+            n_rows: 3,
+            n_cols: 3,
+            irow: vec![1, 2, 3],
+            jcol: vec![1, 2, 3],
+            vals: vec![1.0, 100.0, 1000.0],
+        }
+    }
+}
+
+#[test]
+fn issue_361_ill_conditioned_eq_qp_converges_under_quasi_newton() {
+    for hess in [
+        SqpHessianSource::DampedBfgs,
+        SqpHessianSource::Lbfgs,
+        SqpHessianSource::Exact,
+    ] {
+        let qp_solver =
+            ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+        let mut opts = SqpOptions::default();
+        opts.hessian = hess;
+        let mut alg = SqpAlgorithm::new(qp_solver, opts);
+        let mut nlp = IllConditionedEqQp;
+        let res = alg.optimize(&mut nlp).unwrap();
+
+        assert_eq!(res.status, SqpStatus::Optimal, "hess={hess:?}: {res:?}");
+        for (i, xi) in res.x.iter().enumerate() {
+            assert!(
+                (xi - 1.0).abs() < 1e-6,
+                "hess={hess:?}: x[{i}] = {xi}, expected 1"
+            );
+        }
+        // The multiplier is the quantity the old inconsistent-`y` update
+        // destroyed, so assert it directly.
+        assert!(
+            (res.lambda_g[0] - 1.0).abs() < 1e-4,
+            "hess={hess:?}: λ_g = {}, expected 1",
+            res.lambda_g[0]
+        );
+        assert!(
+            (res.obj - (-553.5)).abs() < 1e-5,
+            "hess={hess:?}: obj = {}",
+            res.obj
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
 // Nonlinear NLP:
 //
 //     min ½(x − 3)² + ½(y − 2)²   s.t.  x² + y² = 4

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -430,6 +430,67 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
         6,
         "Limited-memory BFGS keeps a circular buffer of the most-recent (s, y) curvature pairs; this option caps that buffer length. Mirrors upstream's \"limited_memory_max_history\". Only consulted when \"algorithm\" is \"active-set-sqp\" and \"sqp_hessian\" is \"lbfgs\".",
     )?;
+    // ----- Inner QP-subproblem knobs (`sqp_qp_*`) -----
+    //
+    // Read by `application::apply_qp_subproblem_options` into
+    // `pounce_qp::QpOptions`. These were previously read but never
+    // registered here, so the options registry rejected every one of them
+    // with OPTION_INVALID ("Unknown option") and the reader was
+    // unreachable — the whole family was undocumented dead code (gh #360).
+    // Defaults below mirror `pounce_qp::QpOptions::default()`; each is
+    // forwarded only when the user explicitly sets it, so the pounce-qp
+    // defaults still stand otherwise.
+    //
+    // NOTE: the SQP driver additionally scales `sqp_qp_feas_tol` /
+    // `sqp_qp_opt_tol` by the QP-subproblem data magnitude at each
+    // iteration (gh #358) — these values are the *base* tolerances that
+    // scaling multiplies, not a hard floor on the inner solve.
+    r.add_lower_bounded_integer_option(
+        "sqp_qp_max_iter",
+        "Iteration cap for the SQP inner QP subproblem solver.",
+        0,
+        200,
+        "Maximum active-set iterations allowed for each QP subproblem. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+    )?;
+    r.add_lower_bounded_number_option(
+        "sqp_qp_feas_tol",
+        "Primal-feasibility tolerance for the SQP inner QP subproblem.",
+        0.0,
+        true,
+        1e-9,
+        "Base primal-feasibility tolerance of the inner QP solve; the driver scales it by the subproblem's data magnitude. Loosen it if QP subproblems report \"maximum iterations\" on badly scaled problems. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+    )?;
+    r.add_lower_bounded_number_option(
+        "sqp_qp_opt_tol",
+        "Optimality (dual) tolerance for the SQP inner QP subproblem.",
+        0.0,
+        true,
+        1e-9,
+        "Base dual/optimality tolerance of the inner QP solve; the driver scales it by the subproblem's data magnitude. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+    )?;
+    r.add_lower_bounded_number_option(
+        "sqp_qp_elastic_gamma",
+        "Elastic-mode penalty weight for the SQP inner QP subproblem.",
+        0.0,
+        true,
+        1e6,
+        "Weight on the elastic slacks used when a QP subproblem is infeasible. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+    )?;
+    r.add_string_option(
+        "sqp_qp_anti_cycling",
+        "Anti-cycling rule for the SQP inner QP subproblem.",
+        "expand",
+        &[
+            (
+                "expand",
+                "EXPAND: slowly growing feasibility tolerance (Gill et al. 1989)",
+            ),
+            ("bland", "Bland's rule: lowest-index entering constraint"),
+            ("none", "no anti-cycling safeguard"),
+        ],
+        "Selects the degeneracy safeguard used by the inner active-set QP solver. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+    )?;
+
     r.add_string_option("linear_system_scaling", "Method for scaling the linear system.", "none", &[("none", "no scaling will be performed"), ("mc19", "use the Harwell routine MC19 (Curtis-Reid; minimizes sum of log^2 |a_ij|)"), ("ruiz", "use iterative symmetric infinity-norm equilibration (Ruiz, 2001)"), ("slack-based", "use the slack values")], "Determines the method used to compute symmetric scaling factors for the augmented system (see also the \"linear_scaling_on_demand\" option). This scaling is independent of the NLP problem scaling.")?;
     r.add_string_option("nlp_scaling_method", "Select the technique used for scaling the NLP.", "gradient-based", &[("none", "no problem scaling will be performed"), ("user-scaling", "scaling parameters will come from the user"), ("gradient-based", "scale the problem so the maximum gradient at the starting point is nlp_scaling_max_gradient"), ("equilibration-based", "scale the problem so that first derivatives are of order 1 at random points (uses Harwell routine MC19)")], "Selects the technique used for scaling the problem internally before it is solved. For user-scaling, the parameters come from the NLP.")?;
 

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -432,63 +432,74 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
     )?;
     // ----- Inner QP-subproblem knobs (`sqp_qp_*`) -----
     //
-    // Read by `application::apply_qp_subproblem_options` into
-    // `pounce_qp::QpOptions`. These were previously read but never
-    // registered here, so the options registry rejected every one of them
-    // with OPTION_INVALID ("Unknown option") and the reader was
-    // unreachable — the whole family was undocumented dead code (gh #360).
-    // Defaults below mirror `pounce_qp::QpOptions::default()`; each is
-    // forwarded only when the user explicitly sets it, so the pounce-qp
-    // defaults still stand otherwise.
+    // Consulted only on `solver_selection=qp-active-set` (the active-set SQP
+    // engine, whose step QPs are solved by pounce-qp). Read into the algorithm
+    // builder by `application::apply_qp_subproblem_options`; each forwards only
+    // when explicitly set, otherwise the pounce-qp default stands. The outer
+    // SQP loop has its own `sqp_*` family, registered above; these `sqp_qp_*`
+    // knobs tune the inner QP solver specifically.
+    //
+    // These used to be registered by the CLI binary alone (`pounce-cli`'s
+    // `main`), so they worked on the command line but were rejected with
+    // OPTION_INVALID ("Unknown option") on the library / Python path, where
+    // `apply_qp_subproblem_options` could therefore never see them (gh #360).
+    // Registering here — in the core registry every entry point initializes —
+    // serves both. Do NOT re-add a CLI-side copy: duplicate registration
+    // raises OPTION_ALREADY_REGISTERED and aborts the binary at startup.
     //
     // NOTE: the SQP driver additionally scales `sqp_qp_feas_tol` /
-    // `sqp_qp_opt_tol` by the QP-subproblem data magnitude at each
-    // iteration (gh #358) — these values are the *base* tolerances that
-    // scaling multiplies, not a hard floor on the inner solve.
-    r.add_lower_bounded_integer_option(
-        "sqp_qp_max_iter",
-        "Iteration cap for the SQP inner QP subproblem solver.",
-        0,
-        200,
-        "Maximum active-set iterations allowed for each QP subproblem. Only consulted when \"algorithm\" is \"active-set-sqp\".",
-    )?;
+    // `sqp_qp_opt_tol` by the QP-subproblem data magnitude at each iteration
+    // (gh #358) — these are the *base* tolerances that scaling multiplies, not
+    // a hard floor on the inner solve.
     r.add_lower_bounded_number_option(
         "sqp_qp_feas_tol",
-        "Primal-feasibility tolerance for the SQP inner QP subproblem.",
+        "Active-set QP-subproblem feasibility tolerance > 0.",
         0.0,
         true,
         1e-9,
-        "Base primal-feasibility tolerance of the inner QP solve; the driver scales it by the subproblem's data magnitude. Loosen it if QP subproblems report \"maximum iterations\" on badly scaled problems. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+        "Active-set SQP only (solver_selection=qp-active-set). Constraint \
+         feasibility tolerance for the pounce-qp subproblem solve. \
+         Default 1e-9.",
     )?;
     r.add_lower_bounded_number_option(
         "sqp_qp_opt_tol",
-        "Optimality (dual) tolerance for the SQP inner QP subproblem.",
+        "Active-set QP-subproblem optimality (KKT) tolerance > 0.",
         0.0,
         true,
         1e-9,
-        "Base dual/optimality tolerance of the inner QP solve; the driver scales it by the subproblem's data magnitude. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+        "Active-set SQP only. Optimality / KKT tolerance for the pounce-qp \
+         subproblem solve. Default 1e-9.",
+    )?;
+    r.add_lower_bounded_integer_option(
+        "sqp_qp_max_iter",
+        "Active-set QP-subproblem iteration cap.",
+        1,
+        200,
+        "Active-set SQP only. Maximum active-set pivots per QP subproblem \
+         solve. Default 200.",
     )?;
     r.add_lower_bounded_number_option(
         "sqp_qp_elastic_gamma",
-        "Elastic-mode penalty weight for the SQP inner QP subproblem.",
+        "Active-set QP-subproblem elastic-mode penalty γ > 0.",
         0.0,
         true,
         1e6,
-        "Weight on the elastic slacks used when a QP subproblem is infeasible. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+        "Active-set SQP only. Penalty on the elastic (phase-1) slacks used \
+         to recover from an infeasible QP subproblem. Large enough that the \
+         slacks vanish at the solution of a feasible QP, small enough not to \
+         dominate the Hessian conditioning. Default 1e6.",
     )?;
     r.add_string_option(
         "sqp_qp_anti_cycling",
-        "Anti-cycling rule for the SQP inner QP subproblem.",
+        "Active-set QP-subproblem anti-cycling rule.",
         "expand",
         &[
-            (
-                "expand",
-                "EXPAND: slowly growing feasibility tolerance (Gill et al. 1989)",
-            ),
-            ("bland", "Bland's rule: lowest-index entering constraint"),
-            ("none", "no anti-cycling safeguard"),
+            ("expand", "EXPAND tolerance-growth + Harris two-pass (Gill-Murray-Saunders-Wright 1989). Default."),
+            ("bland", "Bland's rule: slower but guaranteed finite; mainly for tests."),
+            ("none", "No anti-cycling — benchmarking only; may cycle on degenerate QPs."),
         ],
-        "Selects the degeneracy safeguard used by the inner active-set QP solver. Only consulted when \"algorithm\" is \"active-set-sqp\".",
+        "Active-set SQP only. Anti-cycling strategy for the pounce-qp \
+         subproblem ratio test. Default expand.",
     )?;
 
     r.add_string_option("linear_system_scaling", "Method for scaling the linear system.", "none", &[("none", "no scaling will be performed"), ("mc19", "use the Harwell routine MC19 (Curtis-Reid; minimizes sum of log^2 |a_ij|)"), ("ruiz", "use iterative symmetric infinity-norm equilibration (Ruiz, 2001)"), ("slack-based", "use the slack values")], "Determines the method used to compute symmetric scaling factors for the augmented system (see also the \"linear_scaling_on_demand\" option). This scaling is independent of the NLP problem scaling.")?;

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -203,71 +203,12 @@ pub fn main() -> ExitCode {
         return ExitCode::from(2);
     }
 
-    // ---- Active-set SQP QP-subproblem knobs (pounce-qp `QpOptions`) ----
-    // Consulted only on `solver_selection=qp-active-set` (the active-set SQP
-    // engine, whose step QPs are solved by pounce-qp). Read into the algorithm
-    // builder by `application::apply_qp_subproblem_options`; each forwards only
-    // when explicitly set, otherwise the pounce-qp default stands. The outer
-    // SQP loop has its own `sqp_*` family (registered with the SQP options);
-    // these `sqp_qp_*` knobs tune the inner QP solver specifically.
-    let sqp_qp_knobs: Result<(), pounce_common::SolverException> = (|| {
-        let r = app.registered_options();
-        r.add_lower_bounded_number_option(
-            "sqp_qp_feas_tol",
-            "Active-set QP-subproblem feasibility tolerance > 0.",
-            0.0,
-            true,
-            1e-9,
-            "Active-set SQP only (solver_selection=qp-active-set). Constraint \
-             feasibility tolerance for the pounce-qp subproblem solve. \
-             Default 1e-9.",
-        )?;
-        r.add_lower_bounded_number_option(
-            "sqp_qp_opt_tol",
-            "Active-set QP-subproblem optimality (KKT) tolerance > 0.",
-            0.0,
-            true,
-            1e-9,
-            "Active-set SQP only. Optimality / KKT tolerance for the pounce-qp \
-             subproblem solve. Default 1e-9.",
-        )?;
-        r.add_lower_bounded_integer_option(
-            "sqp_qp_max_iter",
-            "Active-set QP-subproblem iteration cap.",
-            1,
-            200,
-            "Active-set SQP only. Maximum active-set pivots per QP subproblem \
-             solve. Default 200.",
-        )?;
-        r.add_lower_bounded_number_option(
-            "sqp_qp_elastic_gamma",
-            "Active-set QP-subproblem elastic-mode penalty γ > 0.",
-            0.0,
-            true,
-            1e6,
-            "Active-set SQP only. Penalty on the elastic (phase-1) slacks used \
-             to recover from an infeasible QP subproblem. Large enough that the \
-             slacks vanish at the solution of a feasible QP, small enough not to \
-             dominate the Hessian conditioning. Default 1e6.",
-        )?;
-        r.add_string_option(
-            "sqp_qp_anti_cycling",
-            "Active-set QP-subproblem anti-cycling rule.",
-            "expand",
-            &[
-                ("expand", "EXPAND tolerance-growth + Harris two-pass (Gill-Murray-Saunders-Wright 1989). Default."),
-                ("bland", "Bland's rule: slower but guaranteed finite; mainly for tests."),
-                ("none", "No anti-cycling — benchmarking only; may cycle on degenerate QPs."),
-            ],
-            "Active-set SQP only. Anti-cycling strategy for the pounce-qp \
-             subproblem ratio test. Default expand.",
-        )?;
-        Ok(())
-    })();
-    if let Err(e) = sqp_qp_knobs {
-        eprintln!("pounce: failed to register active-set QP options: {e}");
-        return ExitCode::from(2);
-    }
+    // NOTE: the active-set SQP QP-subproblem knobs (`sqp_qp_feas_tol`,
+    // `sqp_qp_opt_tol`, `sqp_qp_max_iter`, `sqp_qp_elastic_gamma`,
+    // `sqp_qp_anti_cycling`) used to be registered here. They now live in the
+    // core registry (`pounce_algorithm::upstream_options`) so the library and
+    // Python paths see them too — registering them here as well would raise
+    // OPTION_ALREADY_REGISTERED and abort the binary at startup (gh #360).
 
     // Opt into iter-history capture when the user asked for a JSON
     // report at Full detail — saves the per-iter alloc when they

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -832,10 +832,18 @@ impl PyProblem {
         for (k, v) in &self.str_opts {
             let effective = if !self.has_hessian && v.eq_ignore_ascii_case("exact") {
                 match k.as_str() {
+                    // Downgrade to the dense Powell-damped BFGS, not L-BFGS:
+                    // on the active-set-SQP path L-BFGS materializes the same
+                    // dense Hessian yet stalls on convex QPs with an active
+                    // inequality (issue #358), whereas damped-BFGS solves them.
                     "sqp_hessian" => {
                         downgraded_exact = true;
-                        Some("lbfgs")
+                        Some("damped-bfgs")
                     }
+                    // `hessian_approximation = limited-memory` is itself mapped
+                    // to the dense damped-BFGS on the SQP path (see
+                    // `apply_sqp_options`), so this fallback is robust too and
+                    // stays the correct spelling for the IPM path.
                     "hessian_approximation" => {
                         downgraded_exact = true;
                         Some("limited-memory")

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1525,15 +1525,17 @@ def test_active_set_sqp_honors_hessian_approximation():
 
 def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
     """Explicit ``sqp_hessian=exact`` with no available Hessian must fall back
-    to L-BFGS, not die with ``Internal_Error`` (issue #348).
+    to a quasi-Newton approximation, not die with ``Internal_Error`` (issue #348).
 
     The automatic ``hessian_approximation=limited-memory`` downgrade is applied
     first, but an explicit ``sqp_hessian=exact`` in the user options is applied
     *after* it and re-enabled the ``Exact`` source with no Hessian behind it:
     the driver evaluated a zero Lagrangian Hessian, so the QP subproblem went
     unbounded and the solve died with ``Internal_Error``. The fix downgrades an
-    exact request to L-BFGS (with a warning) whenever the problem exposes no
-    ``hessian`` / ``hessianstructure``.
+    exact request to the dense Powell-damped BFGS (with a warning) whenever the
+    problem exposes no ``hessian`` / ``hessianstructure`` (damped-BFGS rather
+    than L-BFGS: the latter stalls on convex QPs with an active inequality,
+    issue #358).
     """
     fun = lambda v: (v[0] - 3.0) ** 2 + (v[1] - 2.0) ** 2
     jac = lambda v: np.array([2 * (v[0] - 3.0), 2 * (v[1] - 2.0)])
@@ -1562,7 +1564,7 @@ def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
             )
         assert r.success, f"exact-without-hessian must not fail: {r.message}"
         np.testing.assert_allclose(r.x, expected, atol=1e-6)
-        assert r.nhev == 0, "downgrade to L-BFGS means the exact Hessian is unused"
+        assert r.nhev == 0, "the quasi-Newton downgrade means the exact Hessian is unused"
 
     # (b) genuinely nonlinear constraint + hess: same downgrade, still solves.
     nl_con = [
@@ -1604,6 +1606,44 @@ def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
         "exact Hessian was requested" in str(w.message) for w in rec
     ), "exact must be honored (not downgraded) when a Hessian is available"
     assert r.nhev > 0, "the exact Hessian should actually be used here"
+
+
+def test_qp_active_set_facade_solves_convex_qp_with_active_inequality():
+    """The default ``qp-active-set`` facade path must converge on an easy convex
+    QP whose general inequality is active at the optimum (issue #358).
+
+    With no ``hess`` supplied, ``pounce.minimize`` sets
+    ``hessian_approximation=limited-memory`` automatically. That used to select
+    the L-BFGS Lagrangian Hessian on the active-set-SQP path, which stalled with
+    ``Search_Direction_Becomes_Too_Small`` and returned ``success=False`` with a
+    wrong ``x`` — even on a well-conditioned 3-D QP. The fix maps the automatic
+    approximation to the dense Powell-damped BFGS (which materializes the same
+    dense QP-subproblem Hessian but is far more robust); the explicit
+    ``sqp_hessian=lbfgs`` opt-in is unchanged.
+    """
+    rng = np.random.default_rng(113)
+    Q, _ = np.linalg.qr(rng.standard_normal((3, 3)))
+    P = (Q * np.geomspace(1, 10, 3)) @ Q.T  # SPD, cond(P) = 10
+    xu = rng.standard_normal(3)  # unconstrained minimiser
+    c = -P @ xu
+    a = rng.standard_normal(3)
+    G = a.reshape(1, 3)
+    h = np.array([a @ xu - 1.0])  # one inequality a·x <= a·xu - 1 (ACTIVE)
+
+    fun = lambda x: 0.5 * x @ P @ x + c @ x
+    jac = lambda x: P @ x + c
+    con = [{"type": "ineq", "fun": lambda x: (h - G @ x), "jac": lambda x: -G}]
+
+    # Closed-form KKT optimum (single active inequality).
+    kkt = np.block([[P, G.T], [G, np.zeros((1, 1))]])
+    x_star = np.linalg.solve(kkt, np.concatenate([-c, h]))[:3]
+
+    r = pounce.minimize(
+        fun, np.zeros(3), jac=jac, constraints=con,
+        options={"solver_selection": "qp-active-set"},
+    )
+    assert r.success, f"qp-active-set must converge here: {r.message}"
+    np.testing.assert_allclose(r.x, x_star, atol=1e-5)
 
 
 def test_uncomputed_objective_is_nan_not_zero():

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1720,6 +1720,71 @@ def test_qp_active_set_facade_sweep_matches_issue_358_scope():
     assert not failures, f"{len(failures)}/36 instances failed: {failures}"
 
 
+def test_qp_active_set_equality_constrained_ill_conditioned():
+    """Ill-conditioned *equality*-constrained QPs must converge (gh #361).
+
+    These used to exit ``Maximum_Iterations_Exceeded`` **at the right answer**:
+    the quasi-Newton curvature pair differenced ``∇L`` across two different
+    multipliers, injecting a spurious ``Aᵀ(λ_k − λ_{k−1})`` term (pure
+    multiplier noise for linear constraints). The multiplier then diverged while
+    ``x`` sat on the optimum, and the reported stationarity residual — computed
+    from that multiplier — never met the tolerance.
+    """
+    failures = []
+    for n in (3, 5, 8):
+        for cond in (100, 1000):
+            for seed in range(4):
+                rng = np.random.default_rng(50000 + n * 1000 + cond + seed * 7)
+                Q, _ = np.linalg.qr(rng.standard_normal((n, n)))
+                P = (Q * np.geomspace(1, cond, n)) @ Q.T
+                xu = rng.standard_normal(n)
+                c = -P @ xu
+                a = rng.standard_normal(n)
+                b = a @ xu - 0.5
+
+                fun = lambda x, P=P, c=c: 0.5 * x @ P @ x + c @ x
+                jac = lambda x, P=P, c=c: P @ x + c
+                con = [{
+                    "type": "eq",
+                    "fun": lambda x, a=a, b=b: np.array([a @ x - b]),
+                    "jac": lambda x, a=a, n=n: a.reshape(1, n),
+                }]
+                kkt = np.block([[P, a.reshape(-1, 1)],
+                                [a.reshape(1, -1), np.zeros((1, 1))]])
+                x_star = np.linalg.solve(kkt, np.concatenate([-c, [b]]))[:n]
+
+                r = pounce.minimize(
+                    fun, np.zeros(n), jac=jac, constraints=con,
+                    options={"solver_selection": "qp-active-set"},
+                )
+                if not r.success or np.linalg.norm(r.x - x_star, np.inf) > 1e-4:
+                    failures.append((n, cond, seed, r.message))
+    assert not failures, f"{len(failures)}/24 equality instances failed: {failures}"
+
+
+def test_sqp_qp_subproblem_options_are_settable():
+    """The ``sqp_qp_*`` inner-QP options must be accepted (gh #360).
+
+    They were read by the backend but never registered, so every one of them
+    raised ``Unknown option`` and the documented knobs were unusable.
+    """
+    fun = lambda x: x @ x
+    jac = lambda x: 2 * x
+    for key, val in [
+        ("sqp_qp_max_iter", 500),
+        ("sqp_qp_feas_tol", 1e-7),
+        ("sqp_qp_opt_tol", 1e-7),
+        ("sqp_qp_elastic_gamma", 1e5),
+        ("sqp_qp_anti_cycling", "bland"),
+    ]:
+        r = pounce.minimize(
+            fun, np.ones(2), jac=jac,
+            options={"solver_selection": "qp-active-set", key: val},
+        )
+        assert r.success, f"{key}={val!r}: {r.message}"
+        np.testing.assert_allclose(r.x, np.zeros(2), atol=1e-6)
+
+
 def test_uncomputed_objective_is_nan_not_zero():
     """An objective that was never evaluated must not be reported as ``0.0``.
 

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1646,6 +1646,41 @@ def test_qp_active_set_facade_solves_convex_qp_with_active_inequality():
     np.testing.assert_allclose(r.x, x_star, atol=1e-5)
 
 
+@pytest.mark.parametrize("n,cond,seed", [(8, 1000, 0), (8, 1000, 1), (3, 100, 0)])
+def test_qp_active_set_facade_solves_ill_conditioned_tail(n, cond, seed):
+    """The ``cond(P) ≳ 1e3`` tail of issue #358.
+
+    These convex QPs (active inequality) previously failed even with the
+    damped-BFGS Hessian: the identity-seeded quasi-Newton first step overshoots
+    the Newton step by ``~cond(P)``, and the empty filter accepts the
+    objective-blowing step at the near-feasible start, corrupting the working
+    set and diverging to ``‖x‖ ~ 1e4`` before dying with
+    ``Search_Direction_Becomes_Too_Small``. One-time initial Hessian sizing
+    (``B₀ ← (sᵀy/sᵀs)·I`` before the first update) fixes them.
+    """
+    rng = np.random.default_rng(1000 + seed * 7 + n * 100 + cond)
+    Q, _ = np.linalg.qr(rng.standard_normal((n, n)))
+    P = (Q * np.geomspace(1, cond, n)) @ Q.T
+    xu = rng.standard_normal(n)
+    c = -P @ xu
+    a = rng.standard_normal(n)
+    G = a.reshape(1, n)
+    h = np.array([a @ xu - 1.0])
+
+    fun = lambda x: 0.5 * x @ P @ x + c @ x
+    jac = lambda x: P @ x + c
+    con = [{"type": "ineq", "fun": lambda x: (h - G @ x), "jac": lambda x: -G}]
+    kkt = np.block([[P, G.T], [G, np.zeros((1, 1))]])
+    x_star = np.linalg.solve(kkt, np.concatenate([-c, h]))[:n]
+
+    r = pounce.minimize(
+        fun, np.zeros(n), jac=jac, constraints=con,
+        options={"solver_selection": "qp-active-set"},
+    )
+    assert r.success, f"n={n} cond={cond}: {r.message}"
+    np.testing.assert_allclose(r.x, x_star, atol=1e-4)
+
+
 def test_uncomputed_objective_is_nan_not_zero():
     """An objective that was never evaluated must not be reported as ``0.0``.
 

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1681,6 +1681,45 @@ def test_qp_active_set_facade_solves_ill_conditioned_tail(n, cond, seed):
     np.testing.assert_allclose(r.x, x_star, atol=1e-4)
 
 
+def test_qp_active_set_facade_sweep_matches_issue_358_scope():
+    """Guard the #358 scope measurement itself: the whole 36-instance grid.
+
+    The issue reported 29/36 of these failing on 0.9.0. This asserts the grid
+    solves clean, so a future regression in the active-set-SQP quasi-Newton
+    path cannot silently reintroduce it. Deterministic (fixed seeds).
+    """
+    failures = []
+    for n in (3, 5, 8):
+        for cond in (10, 100, 1000):
+            for seed in range(4):
+                rng = np.random.default_rng(1000 + seed * 7 + n * 100 + cond)
+                Q, _ = np.linalg.qr(rng.standard_normal((n, n)))
+                P = (Q * np.geomspace(1, cond, n)) @ Q.T
+                xu = rng.standard_normal(n)
+                c = -P @ xu
+                a = rng.standard_normal(n)
+                G = a.reshape(1, n)
+                h = np.array([a @ xu - 1.0])
+
+                fun = lambda x, P=P, c=c: 0.5 * x @ P @ x + c @ x
+                jac = lambda x, P=P, c=c: P @ x + c
+                con = [{
+                    "type": "ineq",
+                    "fun": lambda x, h=h, G=G: (h - G @ x),
+                    "jac": lambda x, G=G: -G,
+                }]
+                kkt = np.block([[P, G.T], [G, np.zeros((1, 1))]])
+                x_star = np.linalg.solve(kkt, np.concatenate([-c, h]))[:n]
+
+                r = pounce.minimize(
+                    fun, np.zeros(n), jac=jac, constraints=con,
+                    options={"solver_selection": "qp-active-set"},
+                )
+                if not r.success or np.linalg.norm(r.x - x_star, np.inf) > 1e-4:
+                    failures.append((n, cond, seed, r.message))
+    assert not failures, f"{len(failures)}/36 instances failed: {failures}"
+
+
 def test_uncomputed_objective_is_nan_not_zero():
     """An objective that was never evaluated must not be reported as ``0.0``.
 


### PR DESCRIPTION
## Summary

Fixes #358. Two commits, addressing the two layers of the failure.

### 1. Facade default: L-BFGS → damped-BFGS

`pounce.minimize(..., solver_selection="qp-active-set")` returned `success=False`
with a **silently wrong `x`** on convex QPs whose inequality is active — even at
`cond(P)=10, n=3`. With no analytic Hessian the facade sets
`hessian_approximation=limited-memory`, which on the active-set-SQP path selected
the **L-BFGS** Lagrangian Hessian, which stalls. L-BFGS buys nothing here today —
`LBfgs::as_triplet` materializes the same dense `n×n` Hessian for the QP
subproblem as damped-BFGS — so it was strictly worse.

- `crates/pounce-algorithm/src/application.rs`: map
  `hessian_approximation=limited-memory` → **dense Powell-damped BFGS** on the
  SQP path. Explicit `sqp_hessian="lbfgs"` still wins (read afterward).
- `crates/pounce-py/src/problem.rs`: the #348 exact-without-Hessian downgrade
  now targets damped-BFGS too.
- Result: 29/36 → 4/36 on the issue's sweep (matching its stated damped-BFGS
  baseline).

### 2. Ill-conditioned tail: initial Hessian sizing

The remaining `cond(P) ≳ 1e3` failures were **not** a Hessian-*source* problem —
with the exact Hessian these QPs solve in one iteration. The defect is the
quasi-Newton **initial scale**: `B₀ = I` makes the first QP step overshoot the
Newton step by `~cond(∇²L)`, and the filter (empty, near-feasible start,
`θ_curr` tiny) accepts the objective-blowing full step just to zero out a
negligible constraint violation → working set corrupted → diverge to `‖x‖~1e4` →
`Search_Direction_Becomes_Too_Small`.

- `crates/pounce-algorithm/src/sqp/bfgs.rs`: one-time initial sizing
  (Nocedal-Wright §6.1) — before the first rank-2 update, rescale `B` from `I` to
  `γI` with `γ = sᵀy/sᵀs`, the Rayleigh-quotient curvature estimate. Applied
  once, so the persistent damped updates still accumulate.

## Verification

- Issue reproduction: `qp-active-set` now `success=True`, `x_err=2.3e-11`.
- **Broad convex-QP sweep** (n∈{2,3,5,8,12}, cond∈{1…1e4}, 20 seeds = 500
  instances): failures **~21% → ~10%**.
- **Issue's 36-instance tail sweep: 0/36.**
- New tests: `DampedBfgs` sizing unit tests; Rust mapping test; parametrized
  Python regression over the cond=1e3 tail + the original n=3 case.
- Green: `pounce-algorithm` suite incl. #349 Maratos/HS6 (298+), `test_minimize.py`
  (73), sqp/qp Python selection (210).

## Known limitation (documented in CHANGELOG)

This is not a complete cure for **extreme** conditioning: `cond(P) ≳ 1e4`
(especially small `n`) remains harder for the quasi-Newton path than for the
exact-Hessian / IPM / `solver_selection="auto"` routes, which solve these to
machine precision. That is a deeper quasi-Newton-robustness gap worth a
follow-up; this PR resolves the reported failures and more than halves the broad
failure rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: ill-conditioned tail closed (commit 3)

The "known limitation" above is now fixed. Tracing actual failures (rather than
guessing) found **three** further independent holes:

1. **Iteration-0 curvature probe.** The sizing in commit 2 cannot fire until
   iteration 1 — but iteration **0** already solves a QP against the raw
   identity seed, and that is where the overshoot happens (traced: `|p| = 906`
   on a problem whose optimum has `‖x‖ = 2.7`). Now seeded from a
   gradient-difference probe. **Gated on a detected-constant constraint
   Jacobian**: the probe measures `∇²f`, which equals `∇²L` only when the
   constraint-curvature term vanishes. Ungated it regressed the #349 Maratos
   test (`∇²f = 4I` but `∇²L ≈ I`) — caught by the existing suite.
2. **Scale-relative inner-QP tolerances.** `feas_tol`/`opt_tol` are absolute
   `1e-9`; the inner QP inherits the NLP's scale, so at `‖g‖ ~ ‖B‖ ~ 1e3` that
   is `~1e-12` relative — the f64 noise floor. The solver couldn't certify
   optimality on a *3-variable* QP and hit its iteration cap. The outer loop
   still gates on true unscaled KKT residuals, so this cannot cause a false
   `Optimal`.
3. **Quasi-Newton reset-and-retry.** A failing QP usually means a drifted
   quasi-Newton Hessian, not a bad linearization — recover instead of aborting.

### Results

| | failures / 500 |
|---|---|
| original (0.9.0) | 105 |
| + commits 1–2 | 50 |
| **+ commit 3** | **4 (0.8%)** |

- `Search_Direction_Becomes_Too_Small` — the mode #358 reported — **eliminated** (46 → 0).
- Issue's own 36-instance scope grid: **0/36** (now a regression test).
- Accuracy of already-succeeding solves **unchanged**: median err `6e-11`, max
  true constraint violation `4e-11`, well-conditioned max `4.9e-9`.
- **451 Rust + 798 Python tests green.**

### Rejected after measuring
Wächter-Biegler f/h-type filter switching + Armijo (50 → 56), l1-elastic
globalization (150), capping the tolerance relaxation (10 → 20–33). Recorded so
they aren't re-attempted.

### Also fixed here (commit 4)

Both follow-ups are now fixed in this PR.

Fixes #360.
Fixes #361.

#### #361 — quasi-Newton curvature pair used inconsistent multipliers

Not slow convergence, as the issue guessed. The solver was reaching the **exact
optimum** and failing to recognize it:

```
status: Maximum_Iterations_Exceeded  nit=200
x error             : 2.96e-12   <- exact
constraint violation: 0.0        <- exact
stationarity        : 2.46e-03   <- fails dual_inf_tol=1e-4
```

`x` was right, the **multiplier** was wrong — oscillating and diverging
exponentially: `−13, 19, −69, 104, −145, 581, −1320, 3176, …`

**Root cause:** the curvature pair differenced `∇L` across *two different
multipliers* (`∇L(x_{k−1}, λ_{k−1})` vs `∇L(x_k, λ_k)`). For linear constraints
that leaves `Aᵀ(λ_k − λ_{k−1})` — pure multiplier noise, no curvature (the true
`∇²L` equals `∇²f` there). Nocedal-Wright §18.3 requires one fixed multiplier at
both points. The spurious term drove a feedback loop: perturbed `B` → worse QP
multiplier → larger `y` error → more corrupt `B`. Equality constraints hit it
hardest because `λ` is sign-free.

**Fix:** `y = ∇L(x_k, λ_k) − ∇L(x_{k−1}, λ_k)`. Telescopes to
`Σλᵢ(∇cᵢ(x_k) − ∇cᵢ(x_{k−1}))` — vanishes for linear constraints, retained for
nonlinear. Applied to both `damped-bfgs` and `lbfgs`.

Also honors **`sqp_tol`**, registered and documented as the KKT stationarity
tolerance (default `1e-8`) but never read, so the looser `sqp_dual_inf_tol`
(`1e-4`) governed alone and capped accuracy.

#### #360 — `sqp_qp_*` options registered

All five (`max_iter`, `feas_tol`, `opt_tol`, `elastic_gamma`, `anti_cycling`)
were read by `apply_qp_subproblem_options` but never registered, so every one
raised `Unknown option`. Guard test asserts each is settable *and* propagates,
and that unset keys keep the `pounce-qp` defaults.

### Final results

| sweep | `main` | this PR |
|---|---|---|
| inequality-constrained (500) | 105 | **0** |
| equality-constrained (144) | 92 | **0** |
| issue #358 scope grid (36) | 29 | **0** |
| constraint families (linear-eq / linear-ineq / nonlinear-ineq) | — | **0 / 0 / 0** |

Worst-case error also *improved* over the original: `1.49e-5` → **`5.07e-9`**;
max true constraint violation `3.6e-11`.

**454 Rust + 800 Python tests green.**

### Correction to an earlier claim in this PR

An earlier commit and CHANGELOG entry here said the equality-constrained family
was "measured unchanged" by the #358 work, and that the path showed run-to-run
nondeterminism. **Both were wrong** — artifacts of a benchmark harness that
seeded numpy from `hash()` of a tuple *containing a string*, which Python
randomizes per process, so each run silently generated different problems. With
integer-only seeds the solver is bit-for-bit reproducible, and the #358 work had
in fact improved that family 92 → 38 before commit 4 took it to 0. The correction
is recorded in the CHANGELOG and on #361.
