### PR TITLE
Use presolve in pounce-rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ changes.
 
 ## [Unreleased]
 
+### Changed
+
+- **`pounce-nlp` warm starts now fetch one coherent TNLP starting-point
+  snapshot.** With `warm_start_init_point=yes`, the adapter calls
+  `TNLP::get_starting_point` once with the primal, bound-multiplier, and
+  constraint-multiplier flags enabled, then projects that single payload into
+  the IPM's `x`, `y`, and `z` blocks. This replaces three independent callback
+  invocations, matching Ipopt's `GetStartingPoint` contract and avoiding
+  inconsistent or side-effect-dependent warm starts in existing library,
+  Python, and C-bridge users.
+
 ## [0.9.0] - 2026-07-24
 
 ### Fixed — active-set-SQP stalled on curved-constraint NLPs via the Maratos effect (#349)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ changes.
 
 ## [Unreleased]
 
+### Added
+
+- **Generic presolve for library TNLP solves.** `presolve=yes` now wraps every
+  `IpoptApplication::optimize_tnlp` call once, before algorithm dispatch, so
+  IPM, SQP, and retry paths all use the same reduced TNLP while
+  `finalize_solution` continues to receive original-space values and
+  multipliers. Library code no longer needs to call `wrap_with_presolve` for
+  the ordinary callback-TNLP case.
+  - `IpoptApplication::set_presolve_already_applied` declares an explicit
+    caller-owned presolve wrapper; `optimize_tnlp_without_presolve` is the
+    scoped bypass for consumers, such as sensitivity analysis, that require
+    the original KKT coordinate system; and `TNLP::is_presolve_wrapper` lets
+    generic TNLP decorators preserve the no-double-wrap marker.
+
 ### Changed
 
 - **`pounce-nlp` warm starts now fetch one coherent TNLP starting-point
@@ -18,7 +32,9 @@ changes.
   the IPM's `x`, `y`, and `z` blocks. This replaces three independent callback
   invocations, matching Ipopt's `GetStartingPoint` contract and avoiding
   inconsistent or side-effect-dependent warm starts in existing library,
-  Python, and C-bridge users.
+  Python, and C-bridge users. A TNLP that refuses that requested warm-start
+  payload now fails explicitly with `Invalid_Problem_Definition` rather than
+  silently using default iterates.
 
 ## [0.9.0] - 2026-07-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1107,6 +1107,7 @@ dependencies = [
  "pounce-common",
  "pounce-linalg",
  "pounce-nlp",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -515,6 +515,24 @@ impl IpoptApplication {
         // `algorithm` option resolves to "active-set-sqp", route
         // to the Phase 5b SQP path; otherwise fall through to the
         // existing IPM flow unchanged.
+        // Materialize generic TNLP presolve once at the public entry point.
+        // The wrapper owns the submitted callback TNLP, so every algorithm
+        // path below (including retry paths) continues to postsolve into
+        // the original user-facing space. With `presolve=no`, this returns
+        // the exact same Rc unchanged.
+        let tnlp = match pounce_presolve::wrap_from_options(tnlp, &self.options) {
+            Ok(tnlp) => tnlp,
+            Err(err) => {
+                use pounce_common::journalist::JournalCategory;
+                self.journalist.print(
+                    JournalLevel::J_ERROR,
+                    JournalCategory::J_MAIN,
+                    &format!("pounce: could not materialize presolve options: {err}\n"),
+                );
+                return ApplicationReturnStatus::InvalidOption;
+            }
+        };
+
         if self.is_sqp_algorithm_selected() {
             return self.optimize_sqp_tnlp(tnlp);
         }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -284,6 +284,23 @@ impl IpoptApplication {
         self.presolve_already_applied = applied;
     }
 
+    /// Solve without materializing the generic presolve wrapper.
+    ///
+    /// This is for consumers that require the original TNLP coordinate system
+    /// for the solve's KKT matrix, such as sensitivity and reduced-Hessian
+    /// drivers. It is scoped to this invocation and does not change the
+    /// application's `presolve` option or persistent explicit-wrapper setting.
+    pub fn optimize_tnlp_without_presolve(
+        &mut self,
+        tnlp: Rc<RefCell<dyn TNLP>>,
+    ) -> ApplicationReturnStatus {
+        let explicit_wrapper = self.presolve_already_applied;
+        self.presolve_already_applied = true;
+        let status = self.optimize_tnlp(tnlp);
+        self.presolve_already_applied = explicit_wrapper;
+        status
+    }
+
     pub fn registered_options(&self) -> &Rc<RegisteredOptions> {
         &self.reg_options
     }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -101,6 +101,9 @@ use std::time::Instant;
 
 pub struct IpoptApplication {
     options: OptionsList,
+    /// Whether the submitted TNLP has already been explicitly wrapped by the
+    /// caller's presolve layer.
+    presolve_already_applied: bool,
     reg_options: Rc<RegisteredOptions>,
     journalist: Rc<Journalist>,
     statistics: RefCell<SolveStatistics>,
@@ -240,6 +243,7 @@ impl IpoptApplication {
         let reg = Rc::new(reg);
         Self {
             options: OptionsList::with_registered(Rc::clone(&reg)),
+            presolve_already_applied: false,
             reg_options: reg,
             journalist: Rc::new(Journalist::new()),
             statistics: RefCell::new(SolveStatistics::new()),
@@ -266,6 +270,18 @@ impl IpoptApplication {
 
     pub fn options_mut(&mut self) -> &mut OptionsList {
         &mut self.options
+    }
+
+    /// Declare whether callers have already applied an explicit presolve
+    /// wrapper to the TNLPs submitted to [`Self::optimize_tnlp`].
+    ///
+    /// When set, `optimize_tnlp` leaves its input TNLP unchanged even if the
+    /// `presolve` option is enabled. This preserves the option table for
+    /// reporting and debugger use while allowing specialized frontends to
+    /// supply a wrapper with capabilities unavailable to generic callback
+    /// TNLPs, such as an expression provider for FBBT.
+    pub fn set_presolve_already_applied(&mut self, applied: bool) {
+        self.presolve_already_applied = applied;
     }
 
     pub fn registered_options(&self) -> &Rc<RegisteredOptions> {
@@ -520,16 +536,20 @@ impl IpoptApplication {
         // path below (including retry paths) continues to postsolve into
         // the original user-facing space. With `presolve=no`, this returns
         // the exact same Rc unchanged.
-        let tnlp = match pounce_presolve::wrap_from_options(tnlp, &self.options) {
-            Ok(tnlp) => tnlp,
-            Err(err) => {
-                use pounce_common::journalist::JournalCategory;
-                self.journalist.print(
-                    JournalLevel::J_ERROR,
-                    JournalCategory::J_MAIN,
-                    &format!("pounce: could not materialize presolve options: {err}\n"),
-                );
-                return ApplicationReturnStatus::InvalidOption;
+        let tnlp = if self.presolve_already_applied {
+            tnlp
+        } else {
+            match pounce_presolve::wrap_from_options(tnlp, &self.options) {
+                Ok(tnlp) => tnlp,
+                Err(err) => {
+                    use pounce_common::journalist::JournalCategory;
+                    self.journalist.print(
+                        JournalLevel::J_ERROR,
+                        JournalCategory::J_MAIN,
+                        &format!("pounce: could not materialize presolve options: {err}\n"),
+                    );
+                    return ApplicationReturnStatus::InvalidOption;
+                }
             }
         };
 

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1885,6 +1885,8 @@ impl IpoptApplication {
             stats.restoration_outer_iters = alg.resto_outer_iters;
             stats.restoration_wall_secs = alg.resto_wall_secs;
             stats.iterations = captured_iters;
+            // A refused starting point does not produce a valid iterate.
+            // Leave final objective/residual fields at their NaN defaults.
             // Capture the final *scaled* objective at the algorithm's
             // (compressed `x_var`-space) iterate via the NLP: the
             // algorithm-side `eval_f` returns `f * obj_scale_factor`.
@@ -1892,40 +1894,42 @@ impl IpoptApplication {
             // fallback; the success path below overwrites it with the
             // true unscaled objective from `finalize_via_orig_nlp`
             // (which evaluates the user TNLP directly).
-            let curr_x = alg.data.borrow().curr.as_ref().map(|c| c.x.clone());
-            if let Some(x) = curr_x {
-                if let Ok(f) = try_eval_curr_f(&nlp_handle, &x) {
-                    stats.final_objective = f;
-                    stats.final_scaled_objective = f;
+            if solver_status != SolverReturn::InvalidProblemDefinition {
+                let curr_x = alg.data.borrow().curr.as_ref().map(|c| c.x.clone());
+                if let Some(x) = curr_x {
+                    if let Ok(f) = try_eval_curr_f(&nlp_handle, &x) {
+                        stats.final_objective = f;
+                        stats.final_scaled_objective = f;
+                    }
                 }
+				// Final residuals straight off the cq cache. These mirror
+				// the values upstream prints in its end-of-run summary
+				// ("Dual infeasibility / Constraint violation /
+				// Complementarity / Overall NLP error").
+                let cq = alg.cq.borrow();
+                stats.final_dual_inf = cq.curr_dual_infeasibility_max();
+                stats.final_constr_viol = cq.curr_primal_infeasibility_max();
+				// Infinity-norm complementarity, max over all four bound
+				// blocks (s_xl·z_l, s_xu·z_u, s_sl·v_l, s_su·v_u). The
+				// empty-bound blocks return `0` from amax(), so the max is
+				// safe even when only one side has bounds.
+                let compl = cq
+                    .curr_compl_x_l()
+                    .amax()
+                    .max(cq.curr_compl_x_u().amax())
+                    .max(cq.curr_compl_s_l().amax())
+                    .max(cq.curr_compl_s_u().amax());
+                stats.final_compl = compl;
+                stats.final_kkt_error = cq.curr_nlp_error();
+				// Unscaled (user-space) counterparts — divide the nlp_scaling
+				// back out so a consumer can verify the certificate in its own
+				// units (pounce#173). Identical to the scaled fields when no
+				// scaling is active.
+                stats.final_unscaled_dual_inf = cq.curr_unscaled_dual_infeasibility_max();
+                stats.final_unscaled_constr_viol = cq.curr_unscaled_primal_infeasibility_max();
+                stats.final_unscaled_compl = cq.curr_unscaled_complementarity_max();
+                stats.final_unscaled_kkt_error = cq.curr_unscaled_nlp_error();
             }
-            // Final residuals straight off the cq cache. These mirror
-            // the values upstream prints in its end-of-run summary
-            // ("Dual infeasibility / Constraint violation /
-            // Complementarity / Overall NLP error").
-            let cq = alg.cq.borrow();
-            stats.final_dual_inf = cq.curr_dual_infeasibility_max();
-            stats.final_constr_viol = cq.curr_primal_infeasibility_max();
-            // Infinity-norm complementarity, max over all four bound
-            // blocks (s_xl·z_l, s_xu·z_u, s_sl·v_l, s_su·v_u). The
-            // empty-bound blocks return `0` from amax(), so the max is
-            // safe even when only one side has bounds.
-            let compl = cq
-                .curr_compl_x_l()
-                .amax()
-                .max(cq.curr_compl_x_u().amax())
-                .max(cq.curr_compl_s_l().amax())
-                .max(cq.curr_compl_s_u().amax());
-            stats.final_compl = compl;
-            stats.final_kkt_error = cq.curr_nlp_error();
-            // Unscaled (user-space) counterparts — divide the nlp_scaling
-            // back out so a consumer can verify the certificate in its own
-            // units (pounce#173). Identical to the scaled fields when no
-            // scaling is active.
-            stats.final_unscaled_dual_inf = cq.curr_unscaled_dual_infeasibility_max();
-            stats.final_unscaled_constr_viol = cq.curr_unscaled_primal_infeasibility_max();
-            stats.final_unscaled_compl = cq.curr_unscaled_complementarity_max();
-            stats.final_unscaled_kkt_error = cq.curr_unscaled_nlp_error();
         }
 
         // Map SolverReturn → ApplicationReturnStatus per
@@ -1955,13 +1959,13 @@ impl IpoptApplication {
         // unscaled iterate, so it overrides the scaled best-effort
         // value stashed in `final_objective` above (the algorithm-side
         // `eval_f` returns `f * obj_scale_factor`).
-        match finalize_via_orig_nlp(&nlp_handle, &alg, solver_status, app_status, &tnlp) {
-            Ok(f_unscaled) => {
-                self.statistics.borrow_mut().final_objective = f_unscaled;
-            }
-            Err(()) => {
-                // Couldn't finalize; keep the scaled fallback and
-                // surface the original status.
+        if solver_status != SolverReturn::InvalidProblemDefinition {
+            match finalize_via_orig_nlp(&nlp_handle, &alg, solver_status, app_status, &tnlp) {
+                Ok(f_unscaled) => {
+                    self.statistics.borrow_mut().final_objective = f_unscaled;
+                }
+                Err(()) => {
+                }
             }
         }
 
@@ -2872,6 +2876,7 @@ fn solver_return_to_app_status(s: SolverReturn) -> ApplicationReturnStatus {
         SolverReturn::ErrorInStepComputation => ApplicationReturnStatus::ErrorInStepComputation,
         SolverReturn::InvalidNumberDetected => ApplicationReturnStatus::InvalidNumberDetected,
         SolverReturn::TooFewDegreesOfFreedom => ApplicationReturnStatus::NotEnoughDegreesOfFreedom,
+        SolverReturn::InvalidProblemDefinition => ApplicationReturnStatus::InvalidProblemDefinition,
         SolverReturn::InvalidOption => ApplicationReturnStatus::InvalidOption,
         SolverReturn::OutOfMemory => ApplicationReturnStatus::InsufficientMemory,
         SolverReturn::InternalError | SolverReturn::Unassigned => {

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1902,17 +1902,17 @@ impl IpoptApplication {
                         stats.final_scaled_objective = f;
                     }
                 }
-				// Final residuals straight off the cq cache. These mirror
-				// the values upstream prints in its end-of-run summary
-				// ("Dual infeasibility / Constraint violation /
-				// Complementarity / Overall NLP error").
+                // Final residuals straight off the cq cache. These mirror
+                // the values upstream prints in its end-of-run summary
+                // ("Dual infeasibility / Constraint violation /
+                // Complementarity / Overall NLP error").
                 let cq = alg.cq.borrow();
                 stats.final_dual_inf = cq.curr_dual_infeasibility_max();
                 stats.final_constr_viol = cq.curr_primal_infeasibility_max();
-				// Infinity-norm complementarity, max over all four bound
-				// blocks (s_xl·z_l, s_xu·z_u, s_sl·v_l, s_su·v_u). The
-				// empty-bound blocks return `0` from amax(), so the max is
-				// safe even when only one side has bounds.
+                // Infinity-norm complementarity, max over all four bound
+                // blocks (s_xl·z_l, s_xu·z_u, s_sl·v_l, s_su·v_u). The
+                // empty-bound blocks return `0` from amax(), so the max is
+                // safe even when only one side has bounds.
                 let compl = cq
                     .curr_compl_x_l()
                     .amax()
@@ -1921,10 +1921,10 @@ impl IpoptApplication {
                     .max(cq.curr_compl_s_u().amax());
                 stats.final_compl = compl;
                 stats.final_kkt_error = cq.curr_nlp_error();
-				// Unscaled (user-space) counterparts — divide the nlp_scaling
-				// back out so a consumer can verify the certificate in its own
-				// units (pounce#173). Identical to the scaled fields when no
-				// scaling is active.
+                // Unscaled (user-space) counterparts — divide the nlp_scaling
+                // back out so a consumer can verify the certificate in its own
+                // units (pounce#173). Identical to the scaled fields when no
+                // scaling is active.
                 stats.final_unscaled_dual_inf = cq.curr_unscaled_dual_infeasibility_max();
                 stats.final_unscaled_constr_viol = cq.curr_unscaled_primal_infeasibility_max();
                 stats.final_unscaled_compl = cq.curr_unscaled_complementarity_max();
@@ -1964,8 +1964,7 @@ impl IpoptApplication {
                 Ok(f_unscaled) => {
                     self.statistics.borrow_mut().final_objective = f_unscaled;
                 }
-                Err(()) => {
-                }
+                Err(()) => {}
             }
         }
 

--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -202,6 +202,7 @@ fn seed_from_nlp(
     v_u.set(0.0);
     nlp.borrow_mut()
         .get_starting_z(&mut z_l, &mut z_u, &mut v_l, &mut v_u);
+    nlp.borrow_mut().finish_warm_start();
 
     let iv = IteratesVector::new(
         Rc::new(x),

--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -84,8 +84,8 @@ impl IterateInitializer for WarmStartIterateInitializer {
             }
         };
 
-        if needs_seed_from_nlp {
-            seed_from_nlp(data, nlp, &self.opts);
+        if needs_seed_from_nlp && !seed_from_nlp(data, nlp, &self.opts) {
+            return false;
         }
 
         if self.opts.mult_init_max > 0.0 || self.opts.mult_bound_push > 0.0 {
@@ -133,7 +133,14 @@ impl IterateInitializer for WarmStartIterateInitializer {
 /// install the result on `data.curr`. Mirrors steps 1-4 of
 /// `DefaultIterateInitializer::set_initial_iterates`, but with
 /// upstream's warm-start option block governing the push.
-fn seed_from_nlp(data: &IpoptDataHandle, nlp: &Rc<RefCell<dyn IpoptNlp>>, opts: &WarmStartOptions) {
+fn seed_from_nlp(
+    data: &IpoptDataHandle,
+    nlp: &Rc<RefCell<dyn IpoptNlp>>,
+    opts: &WarmStartOptions,
+) -> bool {
+    if !nlp.borrow_mut().prepare_warm_start() {
+        return false;
+    }
     let (n_x, n_s, n_yc, n_yd, n_zl, n_zu, n_vl, n_vu) = {
         let borrow = data.borrow();
         let c = borrow.curr.as_ref().unwrap();
@@ -207,6 +214,7 @@ fn seed_from_nlp(data: &IpoptDataHandle, nlp: &Rc<RefCell<dyn IpoptNlp>>, opts: 
         Rc::new(v_u),
     );
     data.borrow_mut().set_curr(iv);
+    true
 }
 
 fn is_initialized(v: &Rc<dyn Vector>) -> bool {

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -2876,7 +2876,7 @@ impl IpoptAlgorithm {
                 drop(pd_guard);
                 timing.initialize_iterates.end();
                 if !ok {
-                    return SolverReturn::InternalError;
+                    return SolverReturn::InvalidProblemDefinition;
                 }
             }
         }

--- a/crates/pounce-algorithm/tests/presolve_application.rs
+++ b/crates/pounce-algorithm/tests/presolve_application.rs
@@ -27,8 +27,6 @@ struct FinalPayload {
 #[derive(Default)]
 struct TightenedRow {
     final_payload: Option<FinalPayload>,
-    warm_z_seen: Option<(Vec<Number>, Vec<Number>)>,
-    warm_lambda_seen: Option<Vec<Number>>,
 }
 
 impl TNLP for TightenedRow {
@@ -58,12 +56,6 @@ impl TNLP for TightenedRow {
         }
         if sp.init_lambda {
             sp.lambda.copy_from_slice(&[7.0, 11.0]);
-        }
-        if sp.init_z {
-            self.warm_z_seen = Some((sp.z_l.to_vec(), sp.z_u.to_vec()));
-        }
-        if sp.init_lambda {
-            self.warm_lambda_seen = Some(sp.lambda.to_vec());
         }
         true
     }
@@ -218,14 +210,12 @@ fn library_presolve_off_preserves_unwrapped_solution_and_callback_shape() {
 }
 
 #[test]
-fn library_presolve_projects_warm_start_and_restores_original_payload() {
+fn library_presolve_warm_started_solve_restores_original_payload() {
     let (status, problem) = solve(true, true, None, false);
     assert!(matches!(
         status,
         ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
     ));
-    assert_eq!(problem.warm_z_seen, Some((vec![3.0], vec![0.0])));
-    assert_eq!(problem.warm_lambda_seen, Some(vec![7.0, 11.0]));
     let final_payload = problem.final_payload.expect("finalize_solution");
     assert_eq!(final_payload.g.len(), 2);
     assert_eq!(final_payload.lambda.len(), 2);

--- a/crates/pounce-algorithm/tests/presolve_application.rs
+++ b/crates/pounce-algorithm/tests/presolve_application.rs
@@ -9,6 +9,7 @@ use pounce_nlp::tnlp::{
     BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
     StartingPoint, TNLP,
 };
+use pounce_presolve::{PresolveOptions, wrap_from_options, wrap_with_presolve};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -248,4 +249,25 @@ fn explicit_presolve_bypass_preserves_user_option_and_unwrapped_tnlp() {
         "without generic wrapping, the active original row retains its dual: {}",
         final_payload.lambda[0]
     );
+}
+
+#[test]
+fn manual_presolve_wrapper_is_not_wrapped_again_when_option_is_enabled() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("presolve", "yes", true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(TightenedRow::default()));
+    let manual = wrap_with_presolve(
+        inner,
+        PresolveOptions {
+            enabled: true,
+            ..PresolveOptions::defaults()
+        },
+    )
+    .unwrap();
+    let automatic = wrap_from_options(Rc::clone(&manual), app.options()).unwrap();
+    assert!(Rc::ptr_eq(&manual, &automatic));
 }

--- a/crates/pounce-algorithm/tests/presolve_application.rs
+++ b/crates/pounce-algorithm/tests/presolve_application.rs
@@ -144,6 +144,7 @@ fn solve(
     presolve: bool,
     warm_start: bool,
     max_iter: Option<i32>,
+    presolve_already_applied: bool,
 ) -> (ApplicationReturnStatus, TightenedRow) {
     let mut app = IpoptApplication::new();
     app.options_mut()
@@ -160,6 +161,7 @@ fn solve(
             .unwrap();
     }
     app.initialize().unwrap();
+    app.set_presolve_already_applied(presolve_already_applied);
 
     let problem = Rc::new(RefCell::new(TightenedRow::default()));
     let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&problem) as Rc<RefCell<dyn TNLP>>;
@@ -170,8 +172,8 @@ fn solve(
 
 #[test]
 fn library_presolve_off_preserves_unwrapped_solution_and_callback_shape() {
-    let (off_status, off) = solve(false, false, None);
-    let (on_status, on) = solve(true, false, None);
+    let (off_status, off) = solve(false, false, None, false);
+    let (on_status, on) = solve(true, false, None, false);
 
     assert!(
         matches!(
@@ -217,7 +219,7 @@ fn library_presolve_off_preserves_unwrapped_solution_and_callback_shape() {
 
 #[test]
 fn library_presolve_projects_warm_start_and_restores_original_payload() {
-    let (status, problem) = solve(true, true, None);
+    let (status, problem) = solve(true, true, None, false);
     assert!(matches!(
         status,
         ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
@@ -232,7 +234,7 @@ fn library_presolve_projects_warm_start_and_restores_original_payload() {
 
 #[test]
 fn library_presolve_preserves_max_iter_failure_and_callback_shape() {
-    let (status, problem) = solve(true, false, Some(0));
+    let (status, problem) = solve(true, false, Some(0), false);
     assert_eq!(status, ApplicationReturnStatus::MaximumIterationsExceeded);
     let final_payload = problem
         .final_payload
@@ -240,4 +242,20 @@ fn library_presolve_preserves_max_iter_failure_and_callback_shape() {
     assert_eq!(final_payload.status, SolverReturn::MaxiterExceeded);
     assert_eq!(final_payload.g.len(), 2);
     assert_eq!(final_payload.lambda.len(), 2);
+}
+
+#[test]
+fn explicit_presolve_bypass_preserves_user_option_and_unwrapped_tnlp() {
+    let (status, problem) = solve(true, false, None, true);
+    assert!(matches!(
+        status,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    ));
+    let final_payload = problem.final_payload.expect("finalize_solution");
+    assert_eq!(final_payload.lambda.len(), 2);
+    assert!(
+        final_payload.lambda[0].abs() > 1.0,
+        "without generic wrapping, the active original row retains its dual: {}",
+        final_payload.lambda[0]
+    );
 }

--- a/crates/pounce-algorithm/tests/presolve_application.rs
+++ b/crates/pounce-algorithm/tests/presolve_application.rs
@@ -28,6 +28,7 @@ struct FinalPayload {
 #[derive(Default)]
 struct TightenedRow {
     final_payload: Option<FinalPayload>,
+    reject_warm_start: bool,
 }
 
 impl TNLP for TightenedRow {
@@ -50,6 +51,9 @@ impl TNLP for TightenedRow {
     }
 
     fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        if self.reject_warm_start && sp.init_z && sp.init_lambda {
+            return false;
+        }
         sp.x[0] = 3.0;
         if sp.init_z {
             sp.z_l[0] = 3.0;
@@ -221,6 +225,28 @@ fn library_presolve_warm_started_solve_restores_original_payload() {
     assert_eq!(final_payload.g.len(), 2);
     assert_eq!(final_payload.lambda.len(), 2);
     assert!(final_payload.lambda[0].abs() < 1e-10);
+}
+
+#[test]
+fn refused_warm_start_is_an_invalid_problem_definition() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("warm_start_init_point", "yes", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("presolve", "yes", true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let problem = Rc::new(RefCell::new(TightenedRow {
+        reject_warm_start: true,
+        ..TightenedRow::default()
+    }));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&problem) as Rc<RefCell<dyn TNLP>>;
+    let status = app.optimize_tnlp(tnlp);
+
+    assert_eq!(status, ApplicationReturnStatus::InvalidProblemDefinition);
+    assert!(problem.borrow().final_payload.is_none());
 }
 
 #[test]

--- a/crates/pounce-algorithm/tests/presolve_application.rs
+++ b/crates/pounce-algorithm/tests/presolve_application.rs
@@ -1,0 +1,243 @@
+//! Public-library presolve integration coverage. These tests configure
+//! `IpoptApplication` only.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::SolverReturn;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, Clone)]
+struct FinalPayload {
+    status: SolverReturn,
+    x: Vec<Number>,
+    z_l: Vec<Number>,
+    g: Vec<Number>,
+    lambda: Vec<Number>,
+    obj: Number,
+}
+
+/// `x >= 2` tightens the original `x >= 0` lower bound, after which that
+/// linear row is redundant.
+#[derive(Default)]
+struct TightenedRow {
+    final_payload: Option<FinalPayload>,
+    warm_z_seen: Option<(Vec<Number>, Vec<Number>)>,
+    warm_lambda_seen: Option<Vec<Number>>,
+}
+
+impl TNLP for TightenedRow {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 1,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = 0.0;
+        b.x_u[0] = 10.0;
+        b.g_l.copy_from_slice(&[2.0, -1.0e19]);
+        b.g_u.copy_from_slice(&[1.0e19, 10.0]);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 3.0;
+        if sp.init_z {
+            sp.z_l[0] = 3.0;
+            sp.z_u[0] = 0.0;
+        }
+        if sp.init_lambda {
+            sp.lambda.copy_from_slice(&[7.0, 11.0]);
+        }
+        if sp.init_z {
+            self.warm_z_seen = Some((sp.z_l.to_vec(), sp.z_u.to_vec()));
+        }
+        if sp.init_lambda {
+            self.warm_lambda_seen = Some(sp.lambda.to_vec());
+        }
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types[0] = Linearity::Linear;
+        types[1] = Linearity::NonLinear;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 1.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, grad: &mut [Number]) -> bool {
+        grad[0] = 2.0 * (x[0] - 1.0);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&[x[0], (x[0] - 2.0).powi(2)]);
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 0]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("Jacobian values need x");
+                values.copy_from_slice(&[1.0, 2.0 * (x[0] - 2.0)]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 2.0 * obj_factor + 2.0 * lambda.map_or(0.0, |v| v[1]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_payload = Some(FinalPayload {
+            status: sol.status,
+            x: sol.x.to_vec(),
+            z_l: sol.z_l.to_vec(),
+            g: sol.g.to_vec(),
+            lambda: sol.lambda.to_vec(),
+            obj: sol.obj_value,
+        });
+    }
+}
+
+fn solve(
+    presolve: bool,
+    warm_start: bool,
+    max_iter: Option<i32>,
+) -> (ApplicationReturnStatus, TightenedRow) {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("presolve", if presolve { "yes" } else { "no" }, true, false)
+        .unwrap();
+    if warm_start {
+        app.options_mut()
+            .set_string_value("warm_start_init_point", "yes", true, false)
+            .unwrap();
+    }
+    if let Some(value) = max_iter {
+        app.options_mut()
+            .set_integer_value("max_iter", value, true, false)
+            .unwrap();
+    }
+    app.initialize().unwrap();
+
+    let problem = Rc::new(RefCell::new(TightenedRow::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&problem) as Rc<RefCell<dyn TNLP>>;
+    let status = app.optimize_tnlp(tnlp);
+    let result = std::mem::take(&mut *problem.borrow_mut());
+    (status, result)
+}
+
+#[test]
+fn library_presolve_off_preserves_unwrapped_solution_and_callback_shape() {
+    let (off_status, off) = solve(false, false, None);
+    let (on_status, on) = solve(true, false, None);
+
+    assert!(
+        matches!(
+            off_status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected presolve=no status: {off_status:?}"
+    );
+    assert!(
+        matches!(
+            on_status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected presolve=yes status: {on_status:?}"
+    );
+    let off_final = off.final_payload.expect("presolve=no finalize_solution");
+    let on_final = on.final_payload.expect("presolve=yes finalize_solution");
+    assert!((off_final.x[0] - 2.0).abs() < 1e-5);
+    assert!((on_final.x[0] - off_final.x[0]).abs() < 1e-5);
+    assert!((on_final.obj - off_final.obj).abs() < 1e-5);
+    assert_eq!(off_final.g.len(), 2);
+    assert_eq!(off_final.lambda.len(), 2);
+    assert_eq!(on_final.g.len(), 2, "postsolve restores the dropped row");
+    assert_eq!(
+        on_final.lambda.len(),
+        2,
+        "postsolve restores the dropped dual"
+    );
+    assert!((on_final.g[0] - 2.0).abs() < 1e-5);
+    assert!(
+        on_final.lambda[0].abs() < 1e-10,
+        "dropped row dual = {}",
+        on_final.lambda[0]
+    );
+    assert!(
+        on_final.z_l[0] > 1.0,
+        "tightened lower-bound dual = {}",
+        on_final.z_l[0]
+    );
+}
+
+#[test]
+fn library_presolve_projects_warm_start_and_restores_original_payload() {
+    let (status, problem) = solve(true, true, None);
+    assert!(matches!(
+        status,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    ));
+    assert_eq!(problem.warm_z_seen, Some((vec![3.0], vec![0.0])));
+    assert_eq!(problem.warm_lambda_seen, Some(vec![7.0, 11.0]));
+    let final_payload = problem.final_payload.expect("finalize_solution");
+    assert_eq!(final_payload.g.len(), 2);
+    assert_eq!(final_payload.lambda.len(), 2);
+    assert!(final_payload.lambda[0].abs() < 1e-10);
+}
+
+#[test]
+fn library_presolve_preserves_max_iter_failure_and_callback_shape() {
+    let (status, problem) = solve(true, false, Some(0));
+    assert_eq!(status, ApplicationReturnStatus::MaximumIterationsExceeded);
+    let final_payload = problem
+        .final_payload
+        .expect("finalize_solution on early termination");
+    assert_eq!(final_payload.status, SolverReturn::MaxiterExceeded);
+    assert_eq!(final_payload.g.len(), 2);
+    assert_eq!(final_payload.lambda.len(), 2);
+}

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1019,6 +1019,15 @@ pub fn main() -> ExitCode {
         None => Rc::clone(&inner_tnlp),
     };
 
+    // The CLI owns its explicit wrapper so `.nl` input can supply an
+    // ExpressionProvider for FBBT and so it can report presolve diagnostics
+    // before solving. Prevent the public application entry point from adding
+    // a second generic wrapper around it. This also keeps the sensitivity
+    // branch above genuinely un-presolved when it disabled the local wrapper.
+    let _ = app
+        .options_mut()
+        .set_bool_value("presolve", false, true, false);
+
     // Wrap so we can pull eval-call counts out for the final summary.
     let counting = Rc::new(RefCell::new(CountingTnlp::new(Rc::clone(&post_presolve))));
     let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&counting) as Rc<RefCell<dyn TNLP>>;
@@ -1072,6 +1081,12 @@ pub fn main() -> ExitCode {
     // and run again. Without `resolve`, this runs exactly once.
     let mut solve_tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp);
     let mut status = loop {
+        // `resolve` may have staged a `presolve` override, but this CLI solve
+        // continues to use the wrapper selected above. Keep the application
+        // entry point from double-wrapping that fixed instance.
+        let _ = app
+            .options_mut()
+            .set_bool_value("presolve", false, true, false);
         let st = app.optimize_tnlp(Rc::clone(&solve_tnlp));
         let req = restart_cell.borrow_mut().take();
         let Some(req) = req else { break st };

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -586,6 +586,7 @@ pub fn main() -> ExitCode {
                  will be skipped. Run without --minima to obtain it."
             );
         }
+        app.set_presolve_already_applied(true);
         return pounce_cli::minima::run(&mut app, &inner_tnlp, mcfg, &args, sol_path.as_deref());
     }
 
@@ -1021,12 +1022,10 @@ pub fn main() -> ExitCode {
 
     // The CLI owns its explicit wrapper so `.nl` input can supply an
     // ExpressionProvider for FBBT and so it can report presolve diagnostics
-    // before solving. Prevent the public application entry point from adding
-    // a second generic wrapper around it. This also keeps the sensitivity
-    // branch above genuinely un-presolved when it disabled the local wrapper.
-    let _ = app
-        .options_mut()
-        .set_bool_value("presolve", false, true, false);
+    // before solving. This also keeps the sensitivity branch above un-presolved
+    // when it disabled the local wrapper, without mutating the user's `presolve`
+    // option.
+    app.set_presolve_already_applied(true);
 
     // Wrap so we can pull eval-call counts out for the final summary.
     let counting = Rc::new(RefCell::new(CountingTnlp::new(Rc::clone(&post_presolve))));
@@ -1081,12 +1080,6 @@ pub fn main() -> ExitCode {
     // and run again. Without `resolve`, this runs exactly once.
     let mut solve_tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&tnlp);
     let mut status = loop {
-        // `resolve` may have staged a `presolve` override, but this CLI solve
-        // continues to use the wrapper selected above. Keep the application
-        // entry point from double-wrapping that fixed instance.
-        let _ = app
-            .options_mut()
-            .set_bool_value("presolve", false, true, false);
         let st = app.optimize_tnlp(Rc::clone(&solve_tnlp));
         let req = restart_cell.borrow_mut().take();
         let Some(req) = req else { break st };

--- a/crates/pounce-nlp/src/alg_types.rs
+++ b/crates/pounce-nlp/src/alg_types.rs
@@ -21,6 +21,7 @@ pub enum SolverReturn {
     ErrorInStepComputation,
     InvalidNumberDetected,
     TooFewDegreesOfFreedom,
+    InvalidProblemDefinition,
     InvalidOption,
     OutOfMemory,
     InternalError,

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -138,6 +138,13 @@ pub trait IpoptNlp: Nlp {
         true
     }
 
+    /// Release any temporary state prepared for the warm-start projections.
+    ///
+    /// Called once the initializer has obtained its `x`, `y`, and `z` blocks.
+    /// The default is a no-op; adapters that cache a TNLP callback payload use
+    /// this to keep that snapshot scoped to one initialization only.
+    fn finish_warm_start(&mut self) {}
+
     /// Fill `y_c` / `y_d` with initial multiplier guesses (mirrors
     /// `IpoptNLP::GetStartingPoint`'s `init_lambda` flag). Default
     /// impl leaves them at their current contents (zeros).

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -126,6 +126,18 @@ pub trait IpoptNlp: Nlp {
         true
     }
 
+    /// Prepare a complete primal-dual starting-point snapshot for a warm
+    /// start. The default is a no-op for NLP implementations that do not
+    /// route through a TNLP callback.
+    ///
+    /// The warm-start initializer calls this once before its separate
+    /// `get_starting_x` / `get_starting_y` / `get_starting_z` projections.
+    /// Implementations can therefore fetch all requested data in one callback,
+    /// matching Ipopt's single `GetStartingPoint` call.
+    fn prepare_warm_start(&mut self) -> bool {
+        true
+    }
+
     /// Fill `y_c` / `y_d` with initial multiplier guesses (mirrors
     /// `IpoptNLP::GetStartingPoint`'s `init_lambda` flag). Default
     /// impl leaves them at their current contents (zeros).

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -180,6 +180,9 @@ pub struct OrigIpoptNlp {
     /// full-size scratch allocations that requires) on every line-search
     /// trial. (Code review 2026-06 item M17.)
     c_rhs: Vec<Number>,
+    /// Full TNLP start point fetched once for a warm start, then projected
+    /// through the split x/y/z accessor calls without re-entering the TNLP.
+    warm_start_snapshot: RefCell<Option<StartingPointSnapshot>>,
 
     // ----- expansion matrices (instances; spaces above) -----
     px_l: Rc<dyn Matrix>,
@@ -242,6 +245,14 @@ pub struct OrigIpoptNlp {
     /// [`Self::set_timing_stats`]; when `None`, all `eval_*` entry
     /// points skip the timing overhead.
     timing: RefCell<Option<Rc<TimingStatistics>>>,
+}
+
+#[derive(Clone)]
+struct StartingPointSnapshot {
+    x: Vec<Number>,
+    z_l: Vec<Number>,
+    z_u: Vec<Number>,
+    lambda: Vec<Number>,
 }
 
 impl std::fmt::Debug for OrigIpoptNlp {
@@ -541,6 +552,7 @@ impl OrigIpoptNlp {
             d_l: Rc::new(d_l),
             d_u: Rc::new(d_u),
             c_rhs,
+            warm_start_snapshot: RefCell::new(None),
             px_l,
             px_u,
             pd_l,
@@ -1281,6 +1293,30 @@ impl OrigIpoptNlp {
 
     // -------------------- Initialization --------------------
 
+    fn fetch_warm_start_snapshot(&self) -> Option<StartingPointSnapshot> {
+        let cls = self.adapter.borrow().classification().clone();
+        let mut snapshot = StartingPointSnapshot {
+            x: vec![0.0; cls.n_full_x as usize],
+            z_l: vec![0.0; cls.n_full_x as usize],
+            z_u: vec![0.0; cls.n_full_x as usize],
+            lambda: vec![0.0; cls.n_full_g as usize],
+        };
+        let ok = {
+            let a = self.adapter.borrow();
+            let mut t = a.tnlp().borrow_mut();
+            t.get_starting_point(StartingPoint {
+                init_x: true,
+                x: &mut snapshot.x,
+                init_z: true,
+                z_l: &mut snapshot.z_l,
+                z_u: &mut snapshot.z_u,
+                init_lambda: true,
+                lambda: &mut snapshot.lambda,
+            })
+        };
+        ok.then_some(snapshot)
+    }
+
     /// Fill the algorithm's iterate slots with the TNLP's starting
     /// point. Mirrors the second half of upstream
     /// `InitializeStructures`. The caller passes already-allocated
@@ -1923,11 +1959,28 @@ impl IpoptNlp for OrigIpoptNlp {
         names.any_present().then_some(names)
     }
 
+    fn prepare_warm_start(&mut self) -> bool {
+        let Some(snapshot) = self.fetch_warm_start_snapshot() else {
+            return false;
+        };
+        *self.warm_start_snapshot.borrow_mut() = Some(snapshot);
+        true
+    }
+
     /// Populate `x` (length `n_x_var`) from the TNLP's starting point,
     /// compressed via `x_not_fixed_map`. Mirrors the `init_x` arm of
     /// upstream `IpOrigIpoptNLP::GetStartingPoint`.
     fn get_starting_x(&mut self, x: &mut dyn Vector) -> bool {
         let cls = self.adapter.borrow().classification().clone();
+        if let Some(snapshot) = self.warm_start_snapshot.borrow().as_ref() {
+            let Some(dx) = x.as_any_mut().downcast_mut::<DenseVector>() else {
+                return false;
+            };
+            for (var_idx, &full_idx) in cls.x_not_fixed_map.iter().enumerate() {
+                dx.values_mut()[var_idx] = snapshot.x[full_idx as usize];
+            }
+            return true;
+        }
         let n_full_x = cls.n_full_x as usize;
         let n_full_g = cls.n_full_g as usize;
         let mut full_x = vec![0.0; n_full_x];
@@ -1967,6 +2020,21 @@ impl IpoptNlp for OrigIpoptNlp {
         let Some(y_d) = y_d.as_any_mut().downcast_mut::<DenseVector>() else {
             return false;
         };
+        if let Some(snapshot) = self.warm_start_snapshot.borrow().as_ref() {
+            let cls = self.adapter.borrow().classification().clone();
+            let obj_scal = self.obj_scale_factor.get();
+            let c_scale = self.c_scale.borrow();
+            for (i, &g_idx) in cls.c_map.iter().enumerate() {
+                let cs = c_scale.as_ref().map(|v| v[i]).unwrap_or(1.0);
+                y_c.values_mut()[i] = snapshot.lambda[g_idx as usize] / cs * obj_scal;
+            }
+            let d_scale = self.d_scale.borrow();
+            for (i, &g_idx) in cls.d_map.iter().enumerate() {
+                let ds = d_scale.as_ref().map(|v| v[i]).unwrap_or(1.0);
+                y_d.values_mut()[i] = snapshot.lambda[g_idx as usize] / ds * obj_scal;
+            }
+            return true;
+        }
         let mut x = DenseVectorSpace::new(self.n()).make_new_dense();
         let mut z_l = DenseVectorSpace::new(self.x_l.dim()).make_new_dense();
         let mut z_u = DenseVectorSpace::new(self.x_u.dim()).make_new_dense();
@@ -1988,6 +2056,21 @@ impl IpoptNlp for OrigIpoptNlp {
         let Some(z_u) = z_u.as_any_mut().downcast_mut::<DenseVector>() else {
             return false;
         };
+        if let Some(snapshot) = self.warm_start_snapshot.borrow().as_ref() {
+            let cls = self.adapter.borrow().classification().clone();
+            let obj_scal = self.obj_scale_factor.get();
+            for (i, slot) in z_l.values_mut().iter_mut().enumerate() {
+                let var_idx = cls.x_l_map[i] as usize;
+                let full_idx = cls.x_not_fixed_map[var_idx] as usize;
+                *slot = snapshot.z_l[full_idx] * obj_scal;
+            }
+            for (i, slot) in z_u.values_mut().iter_mut().enumerate() {
+                let var_idx = cls.x_u_map[i] as usize;
+                let full_idx = cls.x_not_fixed_map[var_idx] as usize;
+                *slot = snapshot.z_u[full_idx] * obj_scal;
+            }
+            return true;
+        }
         let mut x = DenseVectorSpace::new(self.n()).make_new_dense();
         let mut y_c = DenseVectorSpace::new(self.m_eq()).make_new_dense();
         let mut y_d = DenseVectorSpace::new(self.m_ineq()).make_new_dense();
@@ -2140,6 +2223,7 @@ mod tests {
         eval_jac_g_value_calls: usize,
         eval_h_value_calls: usize,
         get_bounds_info_calls: usize,
+        get_starting_point_calls: usize,
     }
 
     impl TNLP for Hs071 {
@@ -2163,7 +2247,15 @@ mod tests {
             true
         }
         fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            self.get_starting_point_calls += 1;
             sp.x.copy_from_slice(&[1.0, 5.0, 5.0, 1.0]);
+            if sp.init_z {
+                sp.z_l.copy_from_slice(&[1.0, 2.0, 3.0, 4.0]);
+                sp.z_u.copy_from_slice(&[5.0, 6.0, 7.0, 8.0]);
+            }
+            if sp.init_lambda {
+                sp.lambda.copy_from_slice(&[11.0, 13.0]);
+            }
             true
         }
         fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
@@ -2502,6 +2594,48 @@ mod tests {
         );
         assert!(ok);
         assert_eq!(x.values(), &[1.0, 5.0, 5.0, 1.0]);
+    }
+
+    #[test]
+    fn warm_start_duals_are_forwarded_into_algorithm_vectors() {
+        let (_, mut nlp) = build_orig_nlp();
+        let mut y_c = nlp.c_space().make_new_dense();
+        let mut y_d = nlp.d_space().make_new_dense();
+        assert!(nlp.get_starting_y(&mut y_c, &mut y_d));
+        assert_eq!(y_c.values(), &[13.0], "equality multiplier g1");
+        assert_eq!(y_d.values(), &[11.0], "inequality multiplier g0");
+
+        let mut z_l = nlp.x_l_space().make_new_dense();
+        let mut z_u = nlp.x_u_space().make_new_dense();
+        let mut v_l = nlp.d_l_space().make_new_dense();
+        let mut v_u = nlp.d_u_space().make_new_dense();
+        assert!(nlp.get_starting_z(&mut z_l, &mut z_u, &mut v_l, &mut v_u));
+        assert_eq!(z_l.values(), &[1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(z_u.values(), &[5.0, 6.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn warm_start_prefetches_one_tnlp_snapshot_for_x_y_and_z() {
+        let (tnlp, mut nlp) = build_orig_nlp_counting();
+        assert!(nlp.prepare_warm_start());
+
+        let mut x = nlp.x_space().make_new_dense();
+        let mut y_c = nlp.c_space().make_new_dense();
+        let mut y_d = nlp.d_space().make_new_dense();
+        let mut z_l = nlp.x_l_space().make_new_dense();
+        let mut z_u = nlp.x_u_space().make_new_dense();
+        let mut v_l = nlp.d_l_space().make_new_dense();
+        let mut v_u = nlp.d_u_space().make_new_dense();
+        assert!(nlp.get_starting_x(&mut x));
+        assert!(nlp.get_starting_y(&mut y_c, &mut y_d));
+        assert!(nlp.get_starting_z(&mut z_l, &mut z_u, &mut v_l, &mut v_u));
+
+        assert_eq!(tnlp.borrow().get_starting_point_calls, 1);
+        assert_eq!(x.values(), &[1.0, 5.0, 5.0, 1.0]);
+        assert_eq!(y_c.values(), &[13.0]);
+        assert_eq!(y_d.values(), &[11.0]);
+        assert_eq!(z_l.values(), &[1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(z_u.values(), &[5.0, 6.0, 7.0, 8.0]);
     }
 
     /// Two-variable TNLP with `x[0]` fixed at 7.0 (`x_l == x_u`) and

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -2055,7 +2055,7 @@ impl IpoptNlp for OrigIpoptNlp {
         _v_u: &mut dyn Vector,
     ) -> bool {
         // TNLP exposes only variable-bound multipliers.
-		// Slack-bound v_l/v_u have no user-facing warm-start payload to forward.
+        // Slack-bound v_l/v_u have no user-facing warm-start payload to forward.
         let Some(z_l) = z_l.as_any_mut().downcast_mut::<DenseVector>() else {
             return false;
         };

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -2054,6 +2054,8 @@ impl IpoptNlp for OrigIpoptNlp {
         _v_l: &mut dyn Vector,
         _v_u: &mut dyn Vector,
     ) -> bool {
+        // TNLP exposes only variable-bound multipliers.
+		// Slack-bound v_l/v_u have no user-facing warm-start payload to forward.
         let Some(z_l) = z_l.as_any_mut().downcast_mut::<DenseVector>() else {
             return false;
         };

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -1960,6 +1960,42 @@ impl IpoptNlp for OrigIpoptNlp {
         true
     }
 
+    fn get_starting_y(&mut self, y_c: &mut dyn Vector, y_d: &mut dyn Vector) -> bool {
+        let Some(y_c) = y_c.as_any_mut().downcast_mut::<DenseVector>() else {
+            return false;
+        };
+        let Some(y_d) = y_d.as_any_mut().downcast_mut::<DenseVector>() else {
+            return false;
+        };
+        let mut x = DenseVectorSpace::new(self.n()).make_new_dense();
+        let mut z_l = DenseVectorSpace::new(self.x_l.dim()).make_new_dense();
+        let mut z_u = DenseVectorSpace::new(self.x_u.dim()).make_new_dense();
+        self.initialize_starting_point(
+            &mut x, false, y_c, true, y_d, true, &mut z_l, false, &mut z_u, false,
+        )
+    }
+
+    fn get_starting_z(
+        &mut self,
+        z_l: &mut dyn Vector,
+        z_u: &mut dyn Vector,
+        _v_l: &mut dyn Vector,
+        _v_u: &mut dyn Vector,
+    ) -> bool {
+        let Some(z_l) = z_l.as_any_mut().downcast_mut::<DenseVector>() else {
+            return false;
+        };
+        let Some(z_u) = z_u.as_any_mut().downcast_mut::<DenseVector>() else {
+            return false;
+        };
+        let mut x = DenseVectorSpace::new(self.n()).make_new_dense();
+        let mut y_c = DenseVectorSpace::new(self.m_eq()).make_new_dense();
+        let mut y_d = DenseVectorSpace::new(self.m_ineq()).make_new_dense();
+        self.initialize_starting_point(
+            &mut x, false, &mut y_c, false, &mut y_d, false, z_l, true, z_u, true,
+        )
+    }
+
     fn lift_x_to_full(&self, x: &dyn Vector) -> Vec<Number> {
         OrigIpoptNlp::lift_x_to_full(self, x)
     }

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -1967,6 +1967,10 @@ impl IpoptNlp for OrigIpoptNlp {
         true
     }
 
+    fn finish_warm_start(&mut self) {
+        self.warm_start_snapshot.borrow_mut().take();
+    }
+
     /// Populate `x` (length `n_x_var`) from the TNLP's starting point,
     /// compressed via `x_not_fixed_map`. Mirrors the `init_x` arm of
     /// upstream `IpOrigIpoptNLP::GetStartingPoint`.
@@ -2636,6 +2640,15 @@ mod tests {
         assert_eq!(y_d.values(), &[11.0]);
         assert_eq!(z_l.values(), &[1.0, 2.0, 3.0, 4.0]);
         assert_eq!(z_u.values(), &[5.0, 6.0, 7.0, 8.0]);
+
+        nlp.finish_warm_start();
+        let mut x_after_init = nlp.x_space().make_new_dense();
+        assert!(nlp.get_starting_x(&mut x_after_init));
+        assert_eq!(
+            tnlp.borrow().get_starting_point_calls,
+            2,
+            "the snapshot must not affect later starting-point requests"
+        );
     }
 
     /// Two-variable TNLP with `x[0]` fixed at 7.0 (`x_l == x_u`) and

--- a/crates/pounce-nlp/src/tnlp.rs
+++ b/crates/pounce-nlp/src/tnlp.rs
@@ -268,6 +268,15 @@ pub trait TNLP {
     /// Final metadata pass — called just before
     /// [`Self::finalize_solution`]. Default does nothing.
     fn finalize_metadata(&mut self, _var: &MetaData, _con: &MetaData) {}
+
+    /// Whether this TNLP is already an explicit generic-presolve wrapper.
+    ///
+    /// This lets the application preserve the public `wrap_with_presolve`
+    /// workflow when `presolve=yes` is also present in its options. Ordinary
+    /// TNLPs and unrelated decorators return `false`.
+    fn is_presolve_wrapper(&self) -> bool {
+        false
+    }
 }
 
 #[cfg(test)]

--- a/crates/pounce-nlp/src/tnlp.rs
+++ b/crates/pounce-nlp/src/tnlp.rs
@@ -274,6 +274,11 @@ pub trait TNLP {
     /// This lets the application preserve the public `wrap_with_presolve`
     /// workflow when `presolve=yes` is also present in its options. Ordinary
     /// TNLPs and unrelated decorators return `false`.
+    ///
+    /// A transparent decorator around another TNLP should override this and
+    /// forward `inner.borrow().is_presolve_wrapper()`. Otherwise the public
+    /// solve entry point cannot see a presolve wrapper below the decorator and
+    /// may add a second one.
     fn is_presolve_wrapper(&self) -> bool {
         false
     }

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -130,7 +130,7 @@ pub fn wrap_with_presolve_provider(
     expr_provider: Rc<RefCell<dyn ExpressionProvider>>,
     opts: PresolveOptions,
 ) -> Result<Rc<RefCell<dyn TNLP>>, PresolveError> {
-    if !opts.enabled {
+    if !opts.enabled || inner.borrow().is_presolve_wrapper() {
         return Ok(inner);
     }
     Ok(Rc::new(RefCell::new(
@@ -1599,6 +1599,9 @@ mod tests {
         fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
     }
 
+    struct NoopProvider;
+    impl ExpressionProvider for NoopProvider {}
+
     #[test]
     fn c1_redundancy_mask_realigned_after_phase0_drop() {
         // Regression for C1. `find_redundant_rows` returns a verdict
@@ -1670,6 +1673,20 @@ mod tests {
         let info = wrapped.borrow_mut().get_nlp_info().unwrap();
         assert_eq!(info.n, 1);
         assert_eq!(info.m, 0);
+    }
+
+    #[test]
+    fn provider_wrapper_does_not_nest_an_existing_presolve_wrapper() {
+        let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Probe));
+        let opts = PresolveOptions {
+            enabled: true,
+            ..PresolveOptions::defaults()
+        };
+        let manual = wrap_with_presolve(inner, opts.clone()).unwrap();
+        let provider: Rc<RefCell<dyn ExpressionProvider>> = Rc::new(RefCell::new(NoopProvider));
+        let wrapped = wrap_with_presolve_provider(manual.clone(), provider, opts).unwrap();
+
+        assert!(Rc::ptr_eq(&manual, &wrapped));
     }
 
     #[test]

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -113,7 +113,7 @@ pub fn wrap_with_presolve(
     inner: Rc<RefCell<dyn TNLP>>,
     opts: PresolveOptions,
 ) -> Result<Rc<RefCell<dyn TNLP>>, PresolveError> {
-    if !opts.enabled {
+    if !opts.enabled || inner.borrow().is_presolve_wrapper() {
         return Ok(inner);
     }
     Ok(Rc::new(RefCell::new(PresolveTnlp::new(inner, opts))))
@@ -1001,6 +1001,10 @@ fn apply_redundant_verdicts(
 // becomes `Some`).
 #[allow(clippy::expect_used)]
 impl TNLP for PresolveTnlp {
+    fn is_presolve_wrapper(&self) -> bool {
+        true
+    }
+
     fn get_nlp_info(&mut self) -> Option<NlpInfo> {
         let s = self.ensure_init()?;
         Some(s.info_outer)

--- a/crates/pounce-presolve/src/options.rs
+++ b/crates/pounce-presolve/src/options.rs
@@ -211,7 +211,10 @@ pub fn register_options(reg: &RegisteredOptions) -> Result<(), SolverException> 
         "If yes, wraps the user TNLP with a presolve layer that may \
          tighten variable bounds, drop redundant constraints, and \
          detect rank-deficient equality blocks before the IPM starts. \
-         Off by default; the per-pass options below are then dormant.",
+         Off by default; the per-pass options below are then dormant. \
+         A removed row that tightened a variable bound may be returned with \
+         a zero row multiplier, while its dual attribution is carried by the \
+         corresponding tightened variable-bound multiplier.",
     )?;
 
     reg.add_bool_option(

--- a/crates/pounce-sensitivity/Cargo.toml
+++ b/crates/pounce-sensitivity/Cargo.toml
@@ -15,6 +15,7 @@ pounce-common.workspace = true
 pounce-linalg.workspace = true
 pounce-algorithm.workspace = true
 pounce-nlp.workspace = true
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -451,7 +451,7 @@ impl SensSolve {
             }
         }));
 
-        let status = app.optimize_tnlp(tnlp);
+        let status = crate::optimize_tnlp_for_sensitivity(app, tnlp);
         let out = outbox.borrow();
         SensResult {
             status,

--- a/crates/pounce-sensitivity/src/lib.rs
+++ b/crates/pounce-sensitivity/src/lib.rs
@@ -91,3 +91,28 @@ pub use schur_driver::{DenseGenSchurDriver, SchurDriver};
 pub use sens_app::{SensApplication, SensOptions, register_options};
 pub use solver::{ConvergedState, Solver, SolverError};
 pub use step_calc::{SensStepCalc, StdStepCalc, WithBacksolver};
+
+/// Run a sensitivity-producing solve in the original TNLP coordinate system.
+///
+/// Presolve can reduce or reorder the KKT system, while sIPOPT pin indices and
+/// reduced-Hessian coordinates are defined against the submitted TNLP. Keep
+/// the public `presolve` option intact for callers, but bypass its generic
+/// wrapper for this solve.
+pub(crate) fn optimize_tnlp_for_sensitivity(
+    app: &mut pounce_algorithm::IpoptApplication,
+    tnlp: std::rc::Rc<std::cell::RefCell<dyn pounce_nlp::TNLP>>,
+) -> pounce_nlp::return_codes::ApplicationReturnStatus {
+    let presolve_enabled = app
+        .options()
+        .get_bool_value("presolve", "")
+        .ok()
+        .map(|(value, _)| value)
+        .unwrap_or(false);
+    if presolve_enabled {
+        eprintln!(
+            "pounce: disabling generic presolve for sensitivity / reduced-Hessian \
+             analysis; its KKT coordinates must match the original TNLP"
+        );
+    }
+    app.optimize_tnlp_without_presolve(tnlp)
+}

--- a/crates/pounce-sensitivity/src/lib.rs
+++ b/crates/pounce-sensitivity/src/lib.rs
@@ -109,9 +109,10 @@ pub(crate) fn optimize_tnlp_for_sensitivity(
         .map(|(value, _)| value)
         .unwrap_or(false);
     if presolve_enabled {
-        eprintln!(
-            "pounce: disabling generic presolve for sensitivity / reduced-Hessian \
-             analysis; its KKT coordinates must match the original TNLP"
+        tracing::warn!(
+            target: "pounce::sensitivity",
+            "disabling generic presolve for sensitivity / reduced-Hessian analysis; \
+             its KKT coordinates must match the original TNLP"
         );
     }
     app.optimize_tnlp_without_presolve(tnlp)

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -195,7 +195,7 @@ impl Solver {
                 });
             }));
 
-        let status = self.app.optimize_tnlp(Rc::clone(&self.tnlp));
+        let status = crate::optimize_tnlp_for_sensitivity(&mut self.app, Rc::clone(&self.tnlp));
         if let Some(s) = self.state.borrow_mut().as_mut() {
             s.status = status;
         }

--- a/crates/pounce-sensitivity/tests/solver_session.rs
+++ b/crates/pounce-sensitivity/tests/solver_session.rs
@@ -218,6 +218,33 @@ fn solver_parametric_step_matches_sens_solve_builder() {
 }
 
 #[test]
+fn solver_keeps_sensitivity_kkt_in_original_space_when_presolve_is_enabled() {
+    let mut app = make_app();
+    app.options_mut()
+        .set_string_value("presolve", "yes", true, false)
+        .unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ParametricTNLP::new(5.0, 1.0)));
+    let mut solver = Solver::new(app, tnlp);
+
+    let status = solver.solve();
+    assert!(matches!(
+        status,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    ));
+    assert!(solver.converged().is_some());
+    assert!(
+        solver
+            .app()
+            .options()
+            .get_bool_value("presolve", "")
+            .unwrap()
+            .0,
+        "the sensitivity guard must not overwrite the user's option"
+    );
+    assert!(solver.parametric_step(&[2, 3], &[-0.5, 0.0]).is_ok());
+}
+
+#[test]
 fn solver_kkt_solve_against_zero_rhs_returns_zero() {
     let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ParametricTNLP::new(5.0, 1.0)));
     let mut solver = Solver::new(make_app(), tnlp);

--- a/crates/pounce-sensitivity/tests/solver_session.rs
+++ b/crates/pounce-sensitivity/tests/solver_session.rs
@@ -14,8 +14,8 @@ use pounce_algorithm::application::IpoptApplication;
 use pounce_common::types::{Index, Number};
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::tnlp::{
-    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
-    TNLP,
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
 };
 use pounce_sensitivity::{SensSolve, Solver};
 
@@ -40,8 +40,8 @@ impl TNLP for ParametricTNLP {
     fn get_nlp_info(&mut self) -> Option<NlpInfo> {
         Some(NlpInfo {
             n: 5,
-            m: 4,
-            nnz_jac_g: 10,
+            m: 5,
+            nnz_jac_g: 11,
             nnz_h_lag: 5,
             index_style: IndexStyle::C,
         })
@@ -64,6 +64,11 @@ impl TNLP for ParametricTNLP {
         b.g_u[2] = self.nominal_eta1;
         b.g_l[3] = self.nominal_eta2;
         b.g_u[3] = self.nominal_eta2;
+        // This duplicates x[0]'s lower bound. Generic presolve tightens the
+        // bound and drops the redundant inequality, while sensitivity must
+        // keep the original-space KKT dimensions.
+        b.g_l[4] = 0.0;
+        b.g_u[4] = 1.0e19;
         true
     }
 
@@ -73,6 +78,12 @@ impl TNLP for ParametricTNLP {
         sp.x[2] = 0.0;
         sp.x[3] = 0.0;
         sp.x[4] = 0.0;
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.fill(Linearity::NonLinear);
+        types[4] = Linearity::Linear;
         true
     }
 
@@ -95,6 +106,7 @@ impl TNLP for ParametricTNLP {
         g[1] = eta2 * x1 + x2 - x3 - 1.0;
         g[2] = eta1;
         g[3] = eta2;
+        g[4] = x1;
         true
     }
 
@@ -106,8 +118,8 @@ impl TNLP for ParametricTNLP {
     ) -> bool {
         match mode {
             SparsityRequest::Structure { irow, jcol } => {
-                let rs: [Index; 10] = [0, 0, 0, 0, 1, 1, 1, 1, 2, 3];
-                let cs: [Index; 10] = [0, 1, 2, 3, 0, 1, 2, 4, 3, 4];
+                let rs: [Index; 11] = [0, 0, 0, 0, 1, 1, 1, 1, 2, 3, 4];
+                let cs: [Index; 11] = [0, 1, 2, 3, 0, 1, 2, 4, 3, 4, 0];
                 irow.copy_from_slice(&rs);
                 jcol.copy_from_slice(&cs);
             }
@@ -123,6 +135,7 @@ impl TNLP for ParametricTNLP {
                 values[7] = x[0];
                 values[8] = 1.0;
                 values[9] = 1.0;
+                values[10] = 1.0;
             }
         }
         true
@@ -231,7 +244,13 @@ fn solver_keeps_sensitivity_kkt_in_original_space_when_presolve_is_enabled() {
         status,
         ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
     ));
-    assert!(solver.converged().is_some());
+    let converged = solver.converged().expect("converged state captured");
+    assert_eq!(
+        converged.block_dims(),
+        [5, 1, 4, 1, 3, 0, 1, 0],
+        "sensitivity must retain the original five-row TNLP KKT layout"
+    );
+    drop(converged);
     assert!(
         solver
             .app()

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -121,6 +121,14 @@ starts. It tightens variable bounds, drops redundant rows, and
 (optionally) eliminates square auxiliary-equality sub-systems
 structurally. All are off by default — set the master switch first:
 
+`presolve=yes` applies equally to CLI solves and to every
+`IpoptApplication::optimize_tnlp` library solve; callers no longer need to
+wrap a callback TNLP manually.
+The wrapper postsolves before `finalize_solution`, so callback payloads remain
+in the submitted TNLP's original variable and constraint space. Bare callback
+TNLPs do not expose an expression provider, so `presolve_fbbt=yes` remains a
+no-op for this library entry point.
+
 | Option                                  | Default | Meaning                                                                        |
 |-----------------------------------------|---------|--------------------------------------------------------------------------------|
 | `presolve`                              | `no`    | Master switch for the whole presolve layer. Off → wrapper is a no-op.          |


### PR DESCRIPTION
Hello!

Currently, `presolve=yes` only takes effect when callers manually wrap their TNLP. Library solves through `IpoptApplication::optimize_tnlp` (including `pounce-rs`) bypass generic NLP presolve. I found this while updating the oximo-pounce API.

This change wires presolve into `optimize_tnlp` so every library solve actually honors `presolve=yes`. The wrapper is created once per public solve, before algorithm dispatch, and is reused across IPM, SQP, and retry paths. Its existing postsolve mapping continues to return original-space primal values, constraint values, and multipliers to user callbacks.

I keep FBBT separate from this PR, since it needs an `ExpressionProvider`, which a generic callback TNLP does not provide. A follow-up PR could provide an `optimize_tnlp_with_expression_provider(...)` to enable it.

Also, for the algorithms lp-ipm, qp-ipm, and socp, deliberately return `InvalidOption` in `IpoptApplication` since they require Pounce’s CLI .nl parser to extract a convex LP/QP/QCQP and route it to `pounce-convex`. Maybe there are other options that aren't being correctly parsed from `pounce-rs`? I allow edits by maintainers in this PR in case you want to take a look at the parameter parsing/use, but we could probably open another PR.