### PR TITLE
pyomo-pounce: dict row lookups in sens.py (#365); fix and document the local-vs-CI binary split (#366)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ changes.
 - Fixed by standing the real binary in as the bundled one when none is
   installed, so the scenario is still exercised locally rather than skipped.
   CI, which stages the built CLI into the wheel, is unaffected either way.
+- `pyomo-pounce/README.md` gains a **Running the tests locally** section. The
+  staging step that makes a local run match CI (`cp target/release/pounce
+  python/pounce/bin/pounce` *before* building the wheel) was discoverable only
+  by reading `ci.yml`, so a source checkout silently exercised the PATH
+  fallback rather than the bundled path — the root of the confusion behind
+  this issue. It also points at `check_binary()` as the first thing to check
+  when a dual/multiplier test fails, since a stale binary reports a plausible
+  version string.
 - Context for the wider report behind #366: the `pyomo-pounce` suite is green
   on `main` (82 passed, 2 skipped) when run against a binary built from the
   same commit. The other four failures reported there did not reproduce, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ changes.
 
 ## [Unreleased]
 
+### Performance — pyomo-pounce: `sens.py` resolved every row by linear scan, making `gradient(target=None).to_dataframe()` quadratic (#365)
+
+- **Name-to-row lookups are now dict lookups instead of `list.index` scans.**
+  Every query in `pyomo_pounce.sens` resolved a component name to its row by
+  scanning `var_names` or `con_names`, which is O(n) per lookup. The full
+  Jacobian was the worst case: `gradient(wrt=p)` with no target fans out over
+  *every* variable, and `to_dataframe()` then re-scanned the name list once per
+  cell — **O(n²·p)** string comparisons. At n = 2,000 that is unnoticeable; at
+  n = 50,000, a size an ordinary DAE discretization reaches, it is ~2.5e9
+  comparisons and the call effectively hangs.
+- The per-solve paths are fixed too: the fitted-variable and residual loops in
+  `sens_solve` were O(k·n) for k residuals, paid on *every* solve — which the
+  repeated-solve NMPC workflow the module is built around pays each cycle.
+- `_Session` now builds `{name: row}` maps once (`_row_index`), and
+  `sens_solve` hands over the maps it already built rather than having them
+  rebuilt. No API or behavior change: `var_entry`/`mult_entry` still raise
+  `ValueError` for an unknown name rather than leaking the dict's `KeyError`,
+  and the `con_alias` translation and inequality-multiplier errors are
+  untouched.
+
 ### Fixed — pyomo-pounce: a declared Param in a `Var` bound reported exactly zero sensitivity (#356)
 
 - **A limit written as a variable bound now moves with the Param that sets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ changes.
 
 ## [Unreleased]
 
+### Tests — pyomo-pounce: the shadowing-binary test failed on any source checkout (#366)
+
+- `test_check_binary_flags_a_shadowing_build` asserted that a different-build
+  `pounce` prepended to `PATH` is reported as shadowing. That only holds when
+  the resolved binary is PATH-independent, i.e. when a wheel-bundled binary
+  exists. Without one, `_default_executable` falls back to `shutil.which`, so
+  the fake *became* the resolved binary and shadowed nothing — the assertion
+  inverted and the test failed on every source checkout with no
+  `pounce-solver` wheel installed. Its sibling tests guard with
+  `if _bundled_path() is None: skip`; this one only guarded on
+  `resolved is None`.
+- Fixed by standing the real binary in as the bundled one when none is
+  installed, so the scenario is still exercised locally rather than skipped.
+  CI, which stages the built CLI into the wheel, is unaffected either way.
+- Context for the wider report behind #366: the `pyomo-pounce` suite is green
+  on `main` (82 passed, 2 skipped) when run against a binary built from the
+  same commit. The other four failures reported there did not reproduce, and
+  the two multiplier tests among them (`test_bound_multipliers_populate_ipopt_zL_zU`,
+  `test_multiplier_gradient_matches_finite_difference`) guard #296 and
+  #271/#272 — both of which landed *in* 0.9.0. Since builds from before and
+  after the dual-sign fix both report `0.9.0`, a locally built binary from a
+  slightly stale checkout fails exactly those two while looking current, which
+  is the scenario `check_binary()` exists to detect.
+
 ### Performance — pyomo-pounce: `sens.py` resolved every row by linear scan, making `gradient(target=None).to_dataframe()` quadratic (#365)
 
 - **Name-to-row lookups are now dict lookups instead of `list.index` scans.**

--- a/pyomo-pounce/README.md
+++ b/pyomo-pounce/README.md
@@ -89,6 +89,45 @@ install fails on the dependency. Two workarounds:
    pip install pyomo-pounce
    ```
 
+## Running the tests locally
+
+Which binary the tests exercise depends on whether a *bundled* one is
+present: the plugin prefers `pounce/bin/pounce` inside the installed
+`pounce-solver` package and falls back to `PATH` only when that is absent.
+Neither setup above bundles anything, so a plain source checkout takes the
+fallback path while CI takes the bundled one. Tests that describe the
+bundled arrangement then skip, and the suite you run locally is not the
+suite CI runs.
+
+To match CI, stage the freshly built CLI into the package *before* building
+the wheel — this is what `.github/workflows/ci.yml` does:
+
+```bash
+cargo build --release --bin pounce
+mkdir -p python/pounce/bin
+cp target/release/pounce python/pounce/bin/pounce   # the step that bundles it
+(cd python && maturin build --release --out dist)
+pip install python/dist/*.whl                       # pounce module + bundled CLI
+pip install --no-deps -e pyomo-pounce
+pytest pyomo-pounce/tests -q
+```
+
+`networkx` and `scipy` are needed for `test_block_init.py` and
+`test_repair.py`; without them those two files skip.
+
+If a test involving duals, multipliers, or bound reduced costs fails, check
+the binary before the code:
+
+```python
+import pyomo_pounce; pyomo_pounce.check_binary()
+```
+
+It reports which executable will actually run, its build *commit*, and
+whether anything on `PATH` shadows it. Two builds can share a version
+string while differing in commit, so a stale binary reports a plausible
+`X.Y.Z` while returning pre-fix results — that is the failure mode gh #315
+added `check_binary()` for, and the one gh #366 turned out to be about.
+
 ## License
 
 EPL-2.0, same as POUNCE.

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -230,14 +230,32 @@ class _NlBridge:
 
 # ── session ───────────────────────────────────────────────────────────────────
 
+def _row_index(names):
+    """{name: position} for a .col/.row name list.
+
+    The NL writer emits unique symbolic labels, so first-wins and last-wins
+    agree; enumerate order matches `list.index` either way.
+    """
+    return {nm: i for i, nm in enumerate(names)}
+
+
 class _Session:
     def __init__(self, model, nl, solver, var_names, con_names, pins,
-                 con_alias):
+                 con_alias, var_row=None, con_row=None):
         self.model = model            # original model
         self.nl = nl
         self.solver = solver
         self.var_names = var_names    # .col order = x-vector order
         self.con_names = con_names    # .row order = g-vector order
+        # Reverse maps for the two orders above. Every query resolves a
+        # component name to its row, and a list scan makes that O(n) per
+        # lookup -- quadratic for gradient(target=None).to_dataframe(),
+        # which asks for every variable (gh #365). Built once here, or
+        # reused from the caller when it has already built them.
+        # `is None`, not truthiness: an unconstrained model's con_row is a
+        # legitimately empty dict, which `or` would discard and rebuild.
+        self._var_row = _row_index(var_names) if var_row is None else var_row
+        self._con_row = _row_index(con_names) if con_row is None else con_row
         self.pins = pins              # ComponentMap: param data -> pin row
         self.con_alias = con_alias    # original con name -> clone row name
         self.base_x = None
@@ -255,13 +273,23 @@ class _Session:
         return self._columns[pin_idx]
 
     def var_entry(self, name):
-        return self.var_names.index(name)
+        # ValueError, not the dict's KeyError: this used to be a list scan
+        # and callers (and the message a user sees) expect ValueError.
+        try:
+            return self._var_row[name]
+        except KeyError:
+            raise ValueError(
+                f"{name}: not a variable of the solved model") from None
 
     def mult_entry(self, con_name):
         # the sensitivity surgery replaces user constraints with copies on
         # its data block; translate the original name to the clone's row
         con_name = self.con_alias.get(con_name, con_name)
-        g = self.con_names.index(con_name)
+        try:
+            g = self._con_row[con_name]
+        except KeyError:
+            raise ValueError(
+                f"{con_name}: not a constraint of the solved model") from None
         row = self.solver.multiplier_rows([g])[0]
         if row is None:
             raise ValueError(
@@ -523,6 +551,13 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
                 ov.set_value(float(val), skip_validation=True)
         return build_results()
 
+    # name -> row maps, built once here and handed to the session below.
+    # Every pin / fitted / residual lookup that follows, and every later
+    # query, would otherwise scan the whole name list (gh #365). Built
+    # after the non-converged early return, which has no use for them.
+    var_row = _row_index(var_names)
+    con_row = _row_index(con_names)
+
     pins = ComponentMap()
     con_alias = {}
     if si is not None:
@@ -533,7 +568,7 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
             orig_comp = eff_params[list_idx]
             orig_data = (orig_comp if not orig_comp.is_indexed()
                          else orig_comp[comp_idx])
-            pins[orig_data] = con_names.index(con.name)
+            pins[orig_data] = con_row[con.name]
         # original-name -> clone-row-name aliases for replaced constraints
         if getattr(block, "_has_replaced_expressions", False):
             for new_comp, old_comp in block._replaced_map.items():
@@ -542,7 +577,7 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
                     con_alias[od.name] = nd.name
 
     session = _Session(model, nl, solver, var_names, con_names, pins,
-                       con_alias)
+                       con_alias, var_row=var_row, con_row=con_row)
     session.base_x = np.asarray(x)
     session.moved_bounds = moved_bounds
 
@@ -550,12 +585,12 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     session.fit_rows = ComponentMap()
     for comp in eff_fitted:
         for vd in _iter_data(comp):
-            session.fit_rows[vd] = var_names.index(vd.name)
+            session.fit_rows[vd] = var_row[vd.name]
 
     # residual groups: member rows per group key (None = the common pool)
     session.res_rows = {}
     for container, group in eff_residuals:
-        rows = [var_names.index(rd.name) for rd in _iter_data(container)]
+        rows = [var_row[rd.name] for rd in _iter_data(container)]
         session.res_rows.setdefault(group, []).extend(rows)
 
     reg.session = session
@@ -928,7 +963,7 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     # silently skip the projection for that parameter; put the value the
     # bound had at the solve point back for the test only
     for name, (mlo, mhi) in session.moved_bounds.items():
-        r = session.var_names.index(name)
+        r = session.var_entry(name)
         if mlo is not None:
             lo[r] = mlo
         if mhi is not None:

--- a/pyomo-pounce/tests/test_binary_check.py
+++ b/pyomo-pounce/tests/test_binary_check.py
@@ -131,10 +131,21 @@ def test_check_binary_reports_resolved_and_bundled():
 
 def test_check_binary_flags_a_shadowing_build(tmp_path, monkeypatch):
     """A *different-build* `pounce` earlier on PATH is reported as shadowing;
-    an identical-build copy is not."""
+    an identical-build copy is not.
+
+    Shadowing only means anything when the resolved binary is PATH-independent,
+    i.e. when a bundled binary exists. Without one, `_default_executable` falls
+    back to `shutil.which`, so the fake prepended below simply *becomes* the
+    resolved binary and shadows nothing — the assertion then inverts and the
+    test fails on any source checkout with no wheel installed (gh #366). Stand
+    the real binary in as the bundled one in that case, so the scenario is
+    still exercised rather than skipped.
+    """
     resolved = pyomo_pounce.check_binary(verbose=False)["resolved_executable"]
     if resolved is None:
         pytest.skip("no pounce executable resolvable")
+    if ps._bundled_path() is None:
+        monkeypatch.setattr(ps, "_bundled_path", lambda: resolved)
 
     # A fake `pounce` on PATH whose `--about` reports a DIFFERENT commit.
     fake_dir = tmp_path / "stale"

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -496,3 +496,58 @@ def test_both_bounds_rewritten_are_both_recorded():
     assert lo_rec == pytest.approx(-1.0)
     assert hi_rec == pytest.approx(2.0)
     assert gradient(m.x, wrt=m.hi) == pytest.approx(1.0, abs=1e-6)
+
+
+# ── name -> row maps (jkitchin/pounce#365) ───────────────────────────────────
+#
+# Every name-to-row lookup used to be a `list.index` scan, which made
+# gradient(target=None).to_dataframe() O(n^2) in the variable count. These
+# are pure unit tests on _Session: no solve, so they pin the lookup contract
+# without needing the solver. The value-correctness of the fan-out path is
+# already covered by test_gradient_object_for_containers.
+
+def _fake_session(names, cons, row_offset=1000, **kw):
+    from pyomo_pounce.sens import _Session
+
+    class _Solver:
+        def multiplier_rows(self, gs):
+            return [None if row_offset is None else gs[0] + row_offset]
+
+    return _Session(None, None, _Solver(), names, cons, {},
+                    {"orig.c": cons[-1]}, **kw)
+
+
+def test_row_maps_agree_with_the_list_scan_they_replaced():
+    names = [f"x[{i}]" for i in range(200)] + ["y", "z"]
+    cons = ["c1", "c2", "blk.c[3]"]
+    s = _fake_session(names, cons)
+
+    assert isinstance(s._var_row, dict)          # a map, not a scan
+    assert all(s.var_entry(n) == names.index(n) for n in names)
+    assert s.mult_entry("c2") == cons.index("c2") + 1000
+    # the con_alias translation still happens before the lookup
+    assert s.mult_entry("orig.c") == cons.index("blk.c[3]") + 1000
+
+
+def test_row_maps_are_reused_when_the_caller_supplies_them():
+    """sens_solve builds them once and hands them over; no rebuild."""
+    from pyomo_pounce.sens import _row_index
+    names, cons = ["a", "b"], ["c"]
+    vr, cr = _row_index(names), _row_index(cons)
+    s = _fake_session(names, cons, var_row=vr, con_row=cr)
+    assert s._var_row is vr and s._con_row is cr
+
+
+def test_unknown_name_raises_value_error_not_key_error():
+    """The scans raised ValueError; the dicts must not leak KeyError."""
+    s = _fake_session(["a"], ["c"])
+    with pytest.raises(ValueError):
+        s.var_entry("nope")
+    with pytest.raises(ValueError):
+        s.mult_entry("nope")
+
+
+def test_inequality_multiplier_error_is_unchanged():
+    s = _fake_session(["a"], ["c"], row_offset=None)
+    with pytest.raises(ValueError, match="equality constraints"):
+        s.mult_entry("c")


### PR DESCRIPTION
Everything from the #357 review follow-up. Three commits, each independent:

| commit | what |
|---|---|
| `288c530` | #365 — dict row lookups in `sens.py` |
| `ff21a07` | #366 — fix the shadowing-binary test on source checkouts |
| `e91d453` | #366 — document running the tests locally |

## Problem

**#365** — every name-to-row lookup in `pyomo_pounce/sens.py` was a `list.index` scan. The full-Jacobian path was quadratic: `gradient(wrt=p)` with no target fans out over *every* variable, and `to_dataframe()` re-scanned the name list once per cell, giving O(n²·p) string comparisons.

| n | comparisons (p = 1) |
|---|---|
| 2,000 | 4e6 — unnoticeable |
| 10,000 | 1e8 — seconds |
| 50,000 | 2.5e9 — effectively hangs |

`gradient(target=None)` is the documented way to ask for everything, and a DAE discretized at a few thousand finite elements reaches n = 50k without being unusual. The fitted-variable and residual loops in `sens_solve` were separately O(k·n), paid on *every* solve — which the repeated-solve NMPC workflow pays each cycle.

**#366** — `test_check_binary_flags_a_shadowing_build` failed on any source checkout with no `pounce-solver` wheel installed:

```
assert 'deadbeef' in {'288c530d'}
```

Underneath that, a documentation gap: which binary the suite exercises depends on whether a wheel-bundled one exists, and the staging step that makes a local run match CI was discoverable only by reading `ci.yml`.

## Cause

**#365** — `_Session.var_entry` / `mult_entry` and three solve-time loops all resolved names by scanning `var_names` / `con_names`.

**#366** — shadowing only means something when the resolved binary is PATH-independent, i.e. when a bundled binary exists. Without one, `_default_executable` falls back to `shutil.which`, so the fake the test prepends to `PATH` *becomes* the resolved binary and shadows nothing; `shadowing_path_binaries` then lists the real binary and the assertion inverts. The sibling tests in that file guard with `if _bundled_path() is None: pytest.skip(...)` (lines 36, 192) — this one only guarded on `resolved is None`.

## Fix

**#365** — `_Session` builds `{name: row}` maps once via a new `_row_index()`, and `sens_solve` hands over the maps it already built rather than having them rebuilt. Behavior is unchanged by construction:

- `var_entry` / `mult_entry` still raise `ValueError`, not the dict's `KeyError`, since that is what callers and the user-facing message expect;
- the `con_alias` translation still happens before the constraint lookup;
- the inequality-multiplier `ValueError` is untouched;
- supplied maps are tested with `is None` rather than truthiness, so an unconstrained model's legitimately empty `con_row` is not discarded and rebuilt.

**#366** — stand the real binary in as the bundled one when none is installed, so the scenario is still exercised on a source checkout rather than skipped. CI stages the built CLI into the wheel, so it takes the unchanged path.

Plus a **Running the tests locally** section in `pyomo-pounce/README.md`: the CI-matching sequence, the `networkx`/`scipy` requirement for the two files that skip without them, and a pointer to `check_binary()` as the first thing to check when a dual or multiplier test fails — two builds can share a version string while differing in commit, which is what #315 added it for.

## Blast radius

**#365** is an internal refactor of a private class: no API change, no behavior change, no change to any returned value. The risk is a mis-built map, which the tests below pin directly.

**#366** is test-only plus docs. No shipped code changes.

## Tests

Built the CLI and the pyo3 extension from this branch and ran the suite for real, in both binary configurations:

```
82 passed, 2 skipped, 0 failed
```

(the 2 skips are `test_block_init.py` / `test_repair.py`, networkx absent). This is the #365 refactor against the real solver, not just reasoned about.

`test_binary_check.py` on a source checkout goes from **1 failed / 8 passed / 2 skipped** to **8 passed / 2 skipped**. In the bundled configuration all 10 run with **no skips** and pass.

Four new unit tests on `_Session` for #365. They need no solver, so they run in any environment:

- `test_row_maps_agree_with_the_list_scan_they_replaced` — `var_entry` matches `var_names.index` for every name; `mult_entry` works on both the direct and `con_alias` paths
- `test_row_maps_are_reused_when_the_caller_supplies_them`
- `test_unknown_name_raises_value_error_not_key_error`
- `test_inequality_multiplier_error_is_unchanged`

The first two pin the new structure and fail on `main`; the last two pin the preserved `ValueError` contract and pass both before and after, guarding the refactor rather than testing it. Value-correctness of the fan-out path is already covered by the existing `test_gradient_object_for_containers`.

**No timing test.** A wall-clock assertion large enough to catch the quadratic term would be dominated by the solve itself, so it would be slow and flaky without guarding much; the structural assertion is what actually catches a revert.

## What this does not resolve

Closes #365.

#366 should stay **open**. This fixes the one failure that reproduces and removes the setup trap behind it, but the reporter described *three* failures in `test_binary_check.py` and I cannot construct that state: only 4 of the file's 10 tests are environment-dependent, and their guards make the two configurations nearly disjoint — with no bundled binary at most one can fail, and with one the shadowing test passes while the rest can only fail on an unqueryable build id, which takes down two, not three. So the ceiling is two in any configuration I can build.

The two multiplier tests they reported pass here against a same-commit binary. Both guard fixes that shipped *in* 0.9.0 (#296, #271/#272), and per the 0.9.0 CHANGELOG builds from before and after the dual-sign fix **both report `0.9.0`** — so a slightly stale local build looks current while failing exactly those two. That is inference, not proof, and settling it needs the reporter's `check_binary()` output, which is [asked for in the issue](https://github.com/jkitchin/pounce/issues/366#issuecomment-5080672863).