### PR TITLE
Fix test_binary_check.py on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,22 @@ integer-only seeds the solver is bit-for-bit reproducible, and the #358 work in
 fact improved that family substantially (92 → 38 failures/144) before #361 took
 it to 0.
 
+
+### ### Tests — pyomo-pounce: `test_binary_check.py` failed on any Windows checkout (#366)
+
+- Three tests were POSIX-only: the shadowing test joined `PATH` with a
+  hardcoded `":"` instead of `os.pathsep`, and the fake `pounce` binaries were
+  extensionless shell scripts, which Windows can neither execute (so
+  `_build_id` probed them to `None`) nor resolve (the scan looks for
+  `pounce.exe`). They failed on every Windows machine and passed on Linux,
+  which is why CI never saw them and why they were misread as pre-existing
+  failures on `main`.
+- Fakes are `.bat` files on Windows where the path is probed directly; where
+  PATH resolution is exercised, the stand-in is a copy of the real binary,
+  with the shadowing fake's build id injected at the seam `check_binary`
+  reads through, since a fabricated `.exe` cannot print a chosen `--about`.
+
+
 ## [0.9.0] - 2026-07-24
 
 ### Fixed — active-set-SQP stalled on curved-constraint NLPs via the Maratos effect (#349)

--- a/pyomo-pounce/tests/test_binary_check.py
+++ b/pyomo-pounce/tests/test_binary_check.py
@@ -20,7 +20,18 @@ from pyomo_pounce import pounce_solver as ps
 
 
 def _write_fake_pounce(path, about_first_line):
-    """A minimal `pounce` whose `--about` prints the given first line."""
+    """A minimal `pounce` whose `--about` prints the given first line.
+
+    On Windows a shell script cannot be executed, so the fake is a `.bat`
+    file instead; `subprocess` runs those directly when the extension is in
+    the filename. Callers that pass the path straight to `_build_id` are
+    indifferent to the name; callers that need PATH resolution handle the
+    platform's executable name themselves.
+    """
+    if os.name == "nt":
+        path = path.with_suffix(".bat")
+        path.write_text(f"@echo {about_first_line}\n")
+        return path
     path.write_text("#!/bin/sh\n" f'echo "{about_first_line}"\n')
     path.chmod(0o755)
     return path
@@ -78,9 +89,21 @@ def test_build_id_treats_unknown_commit_as_unqueryable(tmp_path):
 
 
 def test_all_path_pounce_finds_binary(tmp_path, monkeypatch):
-    exe = _write_fake_pounce(
-        tmp_path / "pounce", "pounce 0.9.0 (commit abc123, built x)"
-    )
+    if os.name == "nt":
+        # The scan resolves `pounce.exe` on Windows, and a fabricated fake
+        # cannot be an .exe, so the discoverable binary is a copy of the
+        # real one; the assertion is about discovery, not about its output.
+        import shutil
+
+        real = ps._bundled_path() or shutil.which("pounce.exe")
+        if real is None:
+            pytest.skip("no real pounce.exe to stand in as the PATH binary")
+        exe = tmp_path / "pounce.exe"
+        shutil.copyfile(real, exe)
+    else:
+        exe = _write_fake_pounce(
+            tmp_path / "pounce", "pounce 0.9.0 (commit abc123, built x)"
+        )
     monkeypatch.setenv("PATH", str(tmp_path))
     found = ps._all_path_pounce()
     assert any(os.path.realpath(f) == os.path.realpath(str(exe)) for f in found)
@@ -150,13 +173,32 @@ def test_check_binary_flags_a_shadowing_build(tmp_path, monkeypatch):
     # A fake `pounce` on PATH whose `--about` reports a DIFFERENT commit.
     fake_dir = tmp_path / "stale"
     fake_dir.mkdir()
-    fake = fake_dir / "pounce"
-    fake.write_text(
-        "#!/bin/sh\n"
-        'echo "pounce 0.9.0 (commit deadbeef, built 2000-01-01T00:00:00Z)"\n'
-    )
-    fake.chmod(0o755)
-    monkeypatch.setenv("PATH", str(fake_dir) + ":" + __import__("os").environ["PATH"])
+    if os.name == "nt":
+        # A fabricated .exe cannot print a chosen --about, so the fake is a
+        # copy of the real binary with its build id injected at the seam
+        # `check_binary` already reads through. The comparison logic under
+        # test is untouched; the subprocess probe has its own coverage via
+        # the .bat fakes above.
+        import shutil
+
+        fake = fake_dir / "pounce.exe"
+        shutil.copyfile(resolved, fake)
+        real_build_id = ps._build_id
+
+        def _spoofed(exe):
+            if exe and os.path.realpath(str(exe)) == os.path.realpath(str(fake)):
+                return "deadbeef"
+            return real_build_id(exe)
+
+        monkeypatch.setattr(ps, "_build_id", _spoofed)
+    else:
+        fake = fake_dir / "pounce"
+        fake.write_text(
+            "#!/bin/sh\n"
+            'echo "pounce 0.9.0 (commit deadbeef, built 2000-01-01T00:00:00Z)"\n'
+        )
+        fake.chmod(0o755)
+    monkeypatch.setenv("PATH", str(fake_dir) + os.pathsep + os.environ["PATH"])
 
     info = pyomo_pounce.check_binary(verbose=False)
     shadow_ids = {b["build_id"] for b in info["shadowing_path_binaries"]}

--- a/pyomo-pounce/tests/test_binary_check.py
+++ b/pyomo-pounce/tests/test_binary_check.py
@@ -167,6 +167,11 @@ def test_check_binary_flags_a_shadowing_build(tmp_path, monkeypatch):
     resolved = pyomo_pounce.check_binary(verbose=False)["resolved_executable"]
     if resolved is None:
         pytest.skip("no pounce executable resolvable")
+    if ps._build_id(resolved) is None:
+        # the mechanism under test is build-id discrimination, so a resolved
+        # binary with no queryable build id (a foreign `pounce` on PATH, gh
+        # #366) can neither shadow nor be shadowed meaningfully
+        pytest.skip("resolved pounce has no queryable build id")
     if ps._bundled_path() is None:
         monkeypatch.setattr(ps, "_bundled_path", lambda: resolved)
 
@@ -254,6 +259,4 @@ def test_default_executable_no_warning_when_bundled_present():
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         SolverFactory("pounce")._default_executable()
-    assert not [
-        w for w in caught if "no wheel-bundled" in str(w.message)
-    ]
+    assert not [w for w in caught if "no wheel-bundled" in str(w.message)]


### PR DESCRIPTION
Closes the Windows half of #366, built on top of ff21a07 (cherry-picked, so the two land together without a merge).

Three tests in `test_binary_check.py` were POSIX-only and fail on every Windows checkout regardless of binary staleness, which is the missing piece of the #366 puzzle: they are green in CI (Linux) forever and red on Windows forever, so they read as "pre-existing failures on main" from the one machine that ran them.

- `test_check_binary_flags_a_shadowing_build` joined `PATH` with a hardcoded `":"`; Windows needs `os.pathsep`.
- `test_build_id_keeps_dirty_suffix` (and the fake-binary helper generally) wrote extensionless `#!/bin/sh` scripts, which Windows cannot execute, so `_build_id` probed them to `None`.
- `test_all_path_pounce_finds_binary` planted a fake named `pounce`, which the scan never resolves on Windows since it looks for `pounce.exe` — as `test_all_path_pounce_resolves_via_which` itself documents.

Fixes keep POSIX behavior byte-identical:

- The fake helper writes `.bat` files on Windows where the path is probed directly; `subprocess` runs those without a shell.
- Where PATH resolution is exercised, the stand-in is a copy of the real binary, since a fabricated `.exe` cannot print a chosen `--about`. For the shadowing test, the fake's build id is injected at the seam `check_binary` reads through; the comparison logic under test is untouched, and the subprocess probe keeps its own coverage through the `.bat` fakes.

Verified on Windows 11 with the CLI and extension built from this branch: `test_binary_check.py` 10 passed, full pyomo-pounce suite **115 passed, 0 failed** — the first fully green Windows run. The two multiplier failures reported in #357 were the stale binary exactly as diagnosed in #366; details going to that issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
