### PR TITLE
Fix set_kkt_schur_block being a silent no-op on the default build

### DIFF
--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2123,11 +2123,28 @@ impl IpoptApplication {
         // has `linear_solver: Feral`, so gating on `found` would
         // silently route default runs through Feral while the banner
         // (and ipopt-compatible behavior) advertises MA57.
+        //
+        // Record the **effective** backend, not the requested one. MA57 lives
+        // behind the optional `ma57` cargo feature (HSL is licensed and needs a
+        // Fortran toolchain); without it `default_backend_factory` silently
+        // substitutes FERAL. Storing `Ma57` here therefore made
+        // `builder.linear_solver` disagree with the backend actually built, and
+        // consumers acted on the lie: the Schur KKT gate in
+        // `alg_builder::build_with_backend` tests `== Feral`, so on the
+        // pure-Rust default build — where the registry default "ma57" resolves
+        // to FERAL anyway — `set_kkt_schur_block()` silently never engaged for
+        // ANY user. Resolving here keeps the field truthful for every consumer.
         if let Ok((v, _found)) = self.options.get_string_value("linear_solver", "") {
-            builder.linear_solver = match v.as_str() {
+            let requested = match v.as_str() {
                 "ma57" => LinearSolverChoice::Ma57,
                 _ => LinearSolverChoice::Feral,
             };
+            builder.linear_solver =
+                if matches!(requested, LinearSolverChoice::Ma57) && !cfg!(feature = "ma57") {
+                    LinearSolverChoice::Feral
+                } else {
+                    requested
+                };
         }
 
         // `linear_system_scaling` — symmetric scaling of the augmented
@@ -3549,6 +3566,57 @@ mod tests {
         assert_eq!(
             app.algorithm_builder_snapshot().sqp.hessian,
             crate::sqp::SqpHessianSource::Lbfgs
+        );
+    }
+
+    /// `builder.linear_solver` must name the backend that will actually be
+    /// built, not the one the option string asked for.
+    ///
+    /// The option registry defaults `linear_solver` to "ma57", but MA57 is
+    /// behind the optional `ma57` cargo feature; without it
+    /// `default_backend_factory` silently substitutes FERAL. Recording `Ma57`
+    /// anyway made the field disagree with reality, and the Schur KKT gate in
+    /// `alg_builder::build_with_backend` (which tests `== Feral`) consumed that
+    /// disagreement — so `set_kkt_schur_block()` never engaged on the default
+    /// pure-Rust build for any user, while the transparent fallback kept every
+    /// answer correct and every test green.
+    #[test]
+    fn application_linear_solver_records_the_effective_backend() {
+        // Default options: registry says "ma57"; a build without the feature
+        // must still report FERAL, because FERAL is what gets constructed.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        let got = app.algorithm_builder_from_options().linear_solver;
+        if cfg!(feature = "ma57") {
+            assert_eq!(got, LinearSolverChoice::Ma57);
+        } else {
+            assert_eq!(
+                got,
+                LinearSolverChoice::Feral,
+                "default build has no MA57; the effective backend is FERAL"
+            );
+        }
+
+        // An explicit ma57 request resolves the same way.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str("linear_solver ma57\n")
+            .unwrap();
+        let got = app.algorithm_builder_from_options().linear_solver;
+        if cfg!(feature = "ma57") {
+            assert_eq!(got, LinearSolverChoice::Ma57);
+        } else {
+            assert_eq!(got, LinearSolverChoice::Feral);
+        }
+
+        // An explicit feral request is honored in every build.
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str("linear_solver feral\n")
+            .unwrap();
+        assert_eq!(
+            app.algorithm_builder_from_options().linear_solver,
+            LinearSolverChoice::Feral
         );
     }
 

--- a/python/tests/test_problem.py
+++ b/python/tests/test_problem.py
@@ -257,7 +257,18 @@ def _convex_eq_qp(target, A, b):
 
 def test_kkt_schur_block_matches_full_space_solve():
     """A Schur partition (the constraint-dual block) reaches the same optimum
-    as the standard full-space solve, and round-trips through the API."""
+    as the standard full-space solve, and round-trips through the API.
+
+    NOTE: this test cannot detect whether the Schur solver actually *engaged* —
+    the path falls back to the standard full-space solver transparently, so a
+    silently-disabled Schur path produces exactly the assertions below. It once
+    did: the gate compared the *requested* linear solver against FERAL while the
+    registry default "ma57" was recorded even on builds that substitute FERAL,
+    so `set_kkt_schur_block()` was a no-op for every default user and this test
+    still passed. The guard for that is
+    `application_linear_solver_records_the_effective_backend` on the Rust side;
+    coverage of `kkt/schur_aug_system_solver.rs` is the end-to-end signal.
+    """
     target = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
     A = np.array([[1.0, 1.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 1.0, 1.0]])
     b = np.array([3.0, 12.0])


### PR DESCRIPTION
## Summary

`Problem.set_kkt_schur_block()` (pounce#180 item 2) **never engaged the Schur KKT
solver** on the default pure-Rust build. Every call was a silent no-op.

## Root cause

`builder.linear_solver` recorded the **requested** backend, not the effective one.

The option registry defaults `linear_solver` to `"ma57"`, but MA57 sits behind the
optional `ma57` cargo feature (HSL is licensed and needs a Fortran toolchain).
Without that feature, `default_backend_factory` silently substitutes FERAL
*inside the factory* — so the field said `Ma57` while FERAL actually ran.

The Schur gate tests `== Feral` — correctly, since the Schur backend is
feral-specific — and therefore never fired.

## How it was found

Combined Rust+Python coverage. `kkt/schur_aug_system_solver.rs` sat at **0.0%**
(0 of 240 regions, 0 of 17 functions) despite a passing test written specifically
to exercise it. Line counts localized the branch exactly:

```
825|  4|  } else if let Some((indices, cfg)) = self.kkt_schur.clone() {   <- partition arrives
833|  2|      if matches!(self.linear_solver, LinearSolverChoice::Feral) {
834|  0|          Box::new(SchurAugSystemSolver::new(...))                <- NEVER
838|  2|      } else { Box::new(inner_aug) }                              <- ALWAYS
```

## Fix

Resolve to the effective backend at option-parse time: a `ma57` request on a
build without the feature becomes `Feral`, matching what the factory will
actually construct.

`builder.linear_solver` has only three readers — two factory calls (which already
resolved to FERAL anyway) and this gate — so the blast radius is the gate alone.
**Real `--features ma57` builds are unaffected**: a ma57 request still resolves to
`Ma57`, and the Schur path stays correctly disabled there.

## Verification

Coverage of the same QP, identical answers both ways:

| | default options | `linear_solver="feral"` |
|---|---|---|
| before | **0.00%** | 64.58% |
| after | **64.58%** | 64.58% |

2149 Rust + 793 Python + 115 pyomo-pounce green.

## Why the existing test didn't catch it

It couldn't. The Schur path falls back **transparently**, and the test only
compares against the full-space answer — which is exactly what the fallback
produces. A test passing for the wrong reason.

- Added `application_linear_solver_records_the_effective_backend`, which guards
  the resolution directly in both feature states.
- Documented the Python test's blind spot in its docstring so it isn't
  over-trusted, and pointed at coverage of `schur_aug_system_solver.rs` as the
  end-to-end signal.

Independent of #359 (branched from `main`; different region of `application.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
