### PR TITLE
Fix #366: skip pyomo-pounce tests on an environment mismatch instead of failing

### DIFF
--- a/pyomo-pounce/tests/conftest.py
+++ b/pyomo-pounce/tests/conftest.py
@@ -1,0 +1,91 @@
+"""Environment guards for the pyomo-pounce suite (gh #366).
+
+These tests shell out to a real `pounce` executable. Which one they get depends
+on the environment, and the difference is invisible from inside the tests:
+
+* **CI / an installed wheel** stage a binary at ``python/pounce/bin/pounce``
+  (see ``ci.yml``: "Stage CLI binary into pounce-solver wheel"). The plugin
+  resolves that *bundled* binary, which is by construction the build under test.
+* **A bare source checkout** has no bundled binary, so the plugin falls back to
+  whatever ``pounce`` is first on ``PATH`` — quite possibly an unrelated or
+  older install from another project or venv.
+
+`SolverFactory("pounce").available()` cannot tell these apart: it answers "is
+there an executable?", not "does *this* executable work for what I am about to
+ask". So a foreign binary sails past `available()` and then fails mid-test with
+``ApplicationError: Solver (pounce) did not exit normally`` — which reads like a
+solver defect but is an environment mismatch.
+
+That produced the #366 confusion: a suite that is green in CI and red locally,
+with the failing set varying by machine (it depends on what is on PATH), and one
+of the casualties being a *correctness* test in ``sens.py``. Five expected
+failures is exactly the number at which people stop reading the suite.
+
+The fixtures below probe the resolved executable **once per session** by
+actually exercising each capability, and skip with a precise reason when it is
+missing. A genuine defect still fails; only an unusable environment skips.
+
+To run the full suite locally, give the plugin the binary you just built::
+
+    cargo build --release -p pounce-cli
+    mkdir -p python/pounce/bin
+    ln -sf "$PWD/target/release/pounce" python/pounce/bin/pounce
+"""
+
+import pytest
+
+
+def _using_bundled():
+    """Is the plugin resolving the binary this checkout built?
+
+    ``check_binary`` reports both the resolved and bundled executables; the
+    tests are only trustworthy when those agree.
+    """
+    try:
+        import pyomo_pounce
+
+        info = pyomo_pounce.check_binary(verbose=False)
+    except Exception:  # noqa: BLE001 - a broken probe must not break the suite
+        return False, None
+    return bool(info.get("using_bundled")), info.get("resolved_executable")
+
+
+# The environment signature: pyomo raises this when the CLI it invoked did not
+# produce a usable result — i.e. the solver never really ran.
+_DID_NOT_RUN = "did not exit normally"
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_call(item):
+    """Turn "the solver never ran" into a skip — but only in an environment
+    that cannot be trusted to have the right binary.
+
+    Deliberately narrow, because the opposite failure mode is worse than a red
+    suite: a guard broad enough to swallow real defects makes the suite
+    meaningless. Two conditions must both hold before anything is skipped.
+
+    1. The error is pyomo's ``ApplicationError: Solver (pounce) did not exit
+       normally`` — the solver produced no result at all. A wrong *answer*, a
+       failed assertion, or any other exception still fails the test.
+    2. The plugin is **not** using this checkout's bundled binary, so the thing
+       that just failed is some other build we make no claims about.
+
+    Condition 2 is the safety property: CI stages the bundled binary, so
+    ``using_bundled`` is true there and this hook can never fire — CI cannot be
+    silently masked by it. It only ever fires in a source checkout that has
+    fallen back to a foreign `pounce` on PATH.
+    """
+    try:
+        return (yield)
+    except Exception as exc:  # noqa: BLE001 - re-raised unless it is the env
+        if _DID_NOT_RUN not in str(exc):
+            raise
+        bundled, resolved = _using_bundled()
+        if bundled:
+            raise
+        pytest.skip(
+            f"solver never ran, and the plugin is not using this checkout's "
+            f"bundled binary (resolved: {resolved}). This is an environment "
+            f"mismatch, not a solver defect -- see conftest.py for the "
+            f"expected local setup. Original error: {exc}"
+        )

--- a/pyomo-pounce/tests/test_binary_check.py
+++ b/pyomo-pounce/tests/test_binary_check.py
@@ -163,6 +163,23 @@ def test_check_binary_flags_a_shadowing_build(tmp_path, monkeypatch):
     assert "deadbeef" in shadow_ids, info["path_pounce_binaries"]
 
 
+def test_env_skip_guard_is_inert_when_bundled():
+    """The conftest "solver never ran → skip" guard keys on ``using_bundled``.
+
+    That flag is the safety property: it makes the guard incapable of firing
+    wherever the bundled binary is in use — notably CI, which stages one — so a
+    real defect can never be silently skipped there. This pins the contract the
+    hook depends on (gh #366).
+    """
+    if ps._bundled_path() is None:
+        pytest.skip("no bundled binary in this environment")
+    info = pyomo_pounce.check_binary(verbose=False)
+    assert info["using_bundled"] is True, (
+        "a bundled binary exists but is not the resolved one; the conftest "
+        "environment guard would be live in a build it should not be"
+    )
+
+
 # ── the fallback warning ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #366. Complements #367, which landed the shadowing-test half of #366 while
this was in review.

On current `main`, a bare source checkout is **still red**:

| unbundled | failed | passed | skipped |
|---|---|---|---|
| `main` today (after #367) | **4** | 109 | 18 |
| with this PR | **0** | 109 | 22 |

All four are in `test_sens.py`, all one cause.

## Root cause

The trigger is **two** conditions, not one: no bundled binary at
`python/pounce/bin/pounce` **and** an unrelated `pounce` earlier on `PATH`.

pyomo then resolves a foreign build, which `SolverFactory("pounce").available()`
happily accepts — it answers *"is there an executable?"*, not *"does **this**
executable work for what I am about to ask"*. The solve dies with
`ApplicationError: Solver (pounce) did not exit normally`, which reads as a
solver defect but is an environment mismatch.

That second condition also explains why the failing set varies by machine, and
very likely the reported `120 passed` vs `121 passed` discrepancy.

## None of them is a real defect

This is what the issue most wanted settled, since one casualty is a correctness
test. They fail only because the solver never ran — `sens.py` math is not
implicated, and they pass the moment the right binary resolves.
**Issue item 3 resolves to: no.**

## Fix — deliberately narrow

The opposite failure mode is worse than a red suite: a guard broad enough to
swallow real defects makes the suite meaningless. A `pytest_runtest_call`
wrapper converts a failure to a skip only when **both**:

- the error is pyomo's `did not exit normally`, i.e. the solver produced no
  result at all — a wrong *answer*, or any failed assertion, still **fails**; and
- `check_binary()["using_bundled"]` is false, so the binary that just failed is
  one we make no claims about.

The second is the safety property: CI stages the bundled binary, so the hook is
**structurally incapable of firing there** and cannot mask a CI regression. A
regression test pins that contract.

An earlier draft guarded at module level and skipped **25** `test_sens.py` tests
that were passing — rejected, because over-skipping is the same disease as a
permanently red suite. The passing count above is identical with and without
this change: exactly the four failures became skips, nothing else moved.

Bundled stays green (131 passed), so **CI is unaffected**.

The README/local-setup docs this originally carried are dropped — #367 landed a
more thorough version.

Reproduction (restores the binary on every exit path):

```bash
BIN=python/pounce/bin/pounce
trap '[ -f "${BIN}.hidden" ] && mv "${BIN}.hidden" "$BIN"' EXIT INT TERM
mv "$BIN" "${BIN}.hidden"
python -m pytest pyomo-pounce/tests -q
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
