### PR TITLE
Add post-solve activity classification to Solver (roadmap item 0, #362)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,11 @@ changes.
   of the held converged solve as `inactive`, `weakly_active`,
   `strongly_active`, `ambiguous`, or `unidentified`, from the ratio `r = Σ/q`
   of barrier curvature (`Σ = z/s`, summed over the sides that exist) to the
-  model's own curvature (`q = |H_ii|` for a variable, curvature along the
-  constraint normal for a row) at the converged iterate. `r` is O(μ)
+  model's own curvature (`q = |H_ii|` for a variable; for a row,
+  `|∇dᵀH∇d|/‖∇d‖⁴`, whose fourth power makes the ratio invariant to
+  rescaling the row and to the solver's per-row scaling, so both
+  spellings of one limit classify identically at any row coefficient)
+  at the converged iterate. `r` is O(μ)
   inactive, O(1) weakly active, O(1/μ) strongly active, so one ratio
   separates the regimes where no fixed threshold on a slack or multiplier
   alone can: both are O(√μ) at weak activity. Edges sit at √μ and 1/√μ with
@@ -35,7 +38,8 @@ changes.
   reports `equality`, so user indices never shift.
 - Per-entry honesty flags on variables and rows alike: `off_central_path`
   (`s·z` differs from `μ` by more than 10× on some side) and `contaminated`
-  (classified inactive yet carrying non-negligible barrier curvature).
+  (classified inactive yet `r > 100μ`: `inactive` means `r = O(μ)`, so
+  the threshold is μ-relative and reachable).
   `classify_activity` refuses to run with `bound_relax_factor != 0` (the
   Ipopt default is `1e-8`): relaxed bounds shift the slacks the classifier
   reads.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ changes.
 
 ## [Unreleased]
 
+### Added — post-solve activity classification on `Solver` (#362, covariance roadmap item 0)
+
+- `Solver.classify_activity()` (Rust: `pounce_sensitivity::activity`)
+  classifies every bounded variable and every finite-bounded inequality row
+  of the held converged solve as `inactive`, `weakly_active`,
+  `strongly_active`, `ambiguous`, or `unidentified`, from the ratio `r = Σ/q`
+  of barrier curvature (`Σ = z/s`, summed over the sides that exist) to the
+  model's own curvature (`q = |H_ii|` for a variable, curvature along the
+  constraint normal for a row) at the converged iterate. `r` is O(μ)
+  inactive, O(1) weakly active, O(1/μ) strongly active, so one ratio
+  separates the regimes where no fixed threshold on a slack or multiplier
+  alone can: both are O(√μ) at weak activity. Edges sit at √μ and 1/√μ with
+  a fixed inner band [1e-1, 1e1]; gaps report `ambiguous`; at μ > 1e-4 only
+  the two clear calls are made. Curvature below `√ε·max(1, max_j|H_jj|)`
+  reports `unidentified`, with the sign of the raw value.
+- Inequality rows classify through the same rule as variable bounds, which
+  is the gap behind #362: a bound moved onto a row disappears from the
+  bound-multiplier view but not from this one. The tests walk the same
+  scalar geometry through both formulations and require identical statuses.
+- Per-entry honesty flags: `off_central_path` (`s·z` differs from `μ` by
+  more than 10× on some side) and `contaminated` (classified inactive yet
+  carrying non-negligible barrier curvature). `classify_activity` refuses
+  to run with `bound_relax_factor != 0` (the Ipopt default is `1e-8`):
+  relaxed bounds shift the slacks the classifier reads.
+- Item 0 of `dev-notes/covariance-information-roadmap.md` (#262).
+  Everything the classifier reads was already retained at convergence
+  (`Σ`, the solver's slacks, the bound multipliers, `μ`, and the exact
+  Lagrangian Hessian), so the change is exposure plus the rule, not new
+  computation. Items 1-4 build on these statuses.
+
 ### Fixed — active-set SQP: a warm start was discarded whenever the active set moved (#428)
 
 - `solve_with_working_set` pins the hinted active rows to their new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,11 +28,17 @@ changes.
   is the gap behind #362: a bound moved onto a row disappears from the
   bound-multiplier view but not from this one. The tests walk the same
   scalar geometry through both formulations and require identical statuses.
-- Per-entry honesty flags: `off_central_path` (`s·z` differs from `μ` by
-  more than 10× on some side) and `contaminated` (classified inactive yet
-  carrying non-negligible barrier curvature). `classify_activity` refuses
-  to run with `bound_relax_factor != 0` (the Ipopt default is `1e-8`):
-  relaxed bounds shift the slacks the classifier reads.
+- The report is indexed in user space: `var_*` follow the user's `n`
+  variables and `row_*` the user's `m` constraints, in their order. A
+  variable removed internally by `fixed_variable_treatment = make_parameter`
+  (`lb == ub`) reports `fixed` at its own index and an equality constraint
+  reports `equality`, so user indices never shift.
+- Per-entry honesty flags on variables and rows alike: `off_central_path`
+  (`s·z` differs from `μ` by more than 10× on some side) and `contaminated`
+  (classified inactive yet carrying non-negligible barrier curvature).
+  `classify_activity` refuses to run with `bound_relax_factor != 0` (the
+  Ipopt default is `1e-8`): relaxed bounds shift the slacks the classifier
+  reads.
 - Item 0 of `dev-notes/covariance-information-roadmap.md` (#262).
   Everything the classifier reads was already retained at convergence
   (`Σ`, the solver's slacks, the bound multipliers, `μ`, and the exact

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -2271,10 +2271,12 @@ impl IpoptNlp for OrigIpoptNlp {
     fn full_g_to_c_block(&self, full_idx: Index) -> Option<Index> {
         let cls = self.adapter.borrow();
         let cls = cls.classification();
-        cls.c_map
-            .iter()
-            .position(|&g_idx| g_idx == full_idx)
-            .map(|p| p as Index)
+        let f = full_idx as usize;
+        if f >= cls.full_to_c.len() {
+            return None;
+        }
+        let c = cls.full_to_c[f];
+        if c < 0 { None } else { Some(c) }
     }
 
     fn var_x_to_full_x(&self, var_idx: Index) -> Index {

--- a/crates/pounce-nlp/src/tnlp_adapter.rs
+++ b/crates/pounce-nlp/src/tnlp_adapter.rs
@@ -88,6 +88,9 @@ pub struct BoundClassification {
     pub d_l_map: Vec<Index>,
     /// Subset of `[0, n_d)` with a finite upper bound.
     pub d_u_map: Vec<Index>,
+    /// Maps full-g index → c-block position, with `-1` for inequality
+    /// rows: the O(1) inverse of `c_map`, mirroring `full_to_var`.
+    pub full_to_c: Vec<Index>,
 }
 
 impl BoundClassification {
@@ -412,6 +415,7 @@ fn classify_bounds(
     let mut d_map: Vec<Index> = Vec::new();
     let mut d_l_map: Vec<Index> = Vec::new();
     let mut d_u_map: Vec<Index> = Vec::new();
+    let mut full_to_c: Vec<Index> = vec![-1; ng];
 
     for i in 0..ng {
         let lo = g_l[i];
@@ -435,6 +439,7 @@ fn classify_bounds(
                 ));
             }
             if lo == hi {
+                full_to_c[i] = c_map.len() as Index;
                 c_map.push(i as Index);
                 continue;
             }
@@ -468,6 +473,7 @@ fn classify_bounds(
         d_map,
         d_l_map,
         d_u_map,
+        full_to_c,
     })
 }
 

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -382,26 +382,36 @@ impl PySolver {
 
     /// Classify every bounded variable and every finite-bounded
     /// inequality row of the held solve by activity, from the ratio of
-    /// barrier curvature to the objective's own curvature at the
+    /// barrier curvature to the model's own curvature (the exact
+    /// Lagrangian Hessian, so constraint curvature contributes) at the
     /// converged iterate (covariance-information-roadmap item 0,
     /// pounce#362).
+    ///
+    /// Indexing is **user space**: `var_*` entries follow your `n`
+    /// variables and `row_*` entries your `m` constraints, in your
+    /// order. A variable fixed by its bounds (`lb == ub`) reports
+    /// `"fixed"` (the solve removes it and classifies no barrier
+    /// geometry for it), and an equality constraint reports
+    /// `"equality"`, so indices never shift.
     ///
     /// Returns a dict:
     ///
     /// - `"mu"`: the converged barrier parameter.
     /// - `"var_status"`, `"row_status"`: list of str per variable /
-    ///   inequality row: `"inactive"`, `"weakly_active"`,
-    ///   `"strongly_active"`, `"ambiguous"`, `"unidentified"`, or
-    ///   `"unbounded"` where there is no finite bound.
+    ///   constraint: `"inactive"`, `"weakly_active"`,
+    ///   `"strongly_active"`, `"ambiguous"`, `"unidentified"`,
+    ///   `"unbounded"` where there is no finite bound, plus the
+    ///   `"fixed"` / `"equality"` placeholders above.
     /// - `"var_ratio"`, `"row_ratio"`: ndarray of the ratio `Σ/q`
-    ///   (NaN where unbounded).
+    ///   (NaN where nothing was classified).
     /// - `"var_q_sign"`, `"row_q_sign"`: ndarray of the sign of the
     ///   signed curvature, so an indefinite direction is visible.
     /// - `"var_off_central_path"`, `"row_off_central_path"`: list of
     ///   bool, true where `s·z` differs from `μ` by more than 10× on
     ///   some side.
-    /// - `"var_contaminated"`: list of bool, true where classified
-    ///   inactive yet carrying non-negligible barrier curvature.
+    /// - `"var_contaminated"`, `"row_contaminated"`: list of bool,
+    ///   true where classified inactive yet carrying non-negligible
+    ///   barrier curvature.
     ///
     /// Requires `bound_relax_factor=0` (raises `ValueError` otherwise;
     /// the Ipopt default is `1e-8`): relaxed bounds shift the slacks
@@ -415,12 +425,15 @@ impl PySolver {
             codes
                 .iter()
                 .map(|&c| match c {
+                    activity::UNBOUNDED => "unbounded",
                     activity::INACTIVE => "inactive",
                     activity::WEAKLY_ACTIVE => "weakly_active",
                     activity::STRONGLY_ACTIVE => "strongly_active",
                     activity::AMBIGUOUS => "ambiguous",
                     activity::UNIDENTIFIED => "unidentified",
-                    _ => "unbounded",
+                    activity::FIXED => "fixed",
+                    activity::EQUALITY => "equality",
+                    _ => unreachable!("unknown activity status code {c}"),
                 })
                 .collect()
         };
@@ -449,6 +462,7 @@ impl PySolver {
                 .into_pyarray_bound(py),
         )?;
         out.set_item("row_off_central_path", rep.row_off_central_path)?;
+        out.set_item("row_contaminated", rep.row_contaminated)?;
         Ok(out)
     }
 }

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -22,6 +22,7 @@ use numpy::{IntoPyArray, PyArray1};
 use pounce_common::types::{Index, Number};
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::tnlp::TNLP;
+use pounce_sensitivity::activity;
 use pounce_sensitivity::{Solver as RustSolver, SolverError};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
@@ -378,6 +379,78 @@ impl PySolver {
             .map(|s| s.inner.converged().is_some())
             .unwrap_or(false)
     }
+
+    /// Classify every bounded variable and every finite-bounded
+    /// inequality row of the held solve by activity, from the ratio of
+    /// barrier curvature to the objective's own curvature at the
+    /// converged iterate (covariance-information-roadmap item 0,
+    /// pounce#362).
+    ///
+    /// Returns a dict:
+    ///
+    /// - `"mu"`: the converged barrier parameter.
+    /// - `"var_status"`, `"row_status"`: list of str per variable /
+    ///   inequality row: `"inactive"`, `"weakly_active"`,
+    ///   `"strongly_active"`, `"ambiguous"`, `"unidentified"`, or
+    ///   `"unbounded"` where there is no finite bound.
+    /// - `"var_ratio"`, `"row_ratio"`: ndarray of the ratio `Σ/q`
+    ///   (NaN where unbounded).
+    /// - `"var_q_sign"`, `"row_q_sign"`: ndarray of the sign of the
+    ///   signed curvature, so an indefinite direction is visible.
+    /// - `"var_off_central_path"`, `"row_off_central_path"`: list of
+    ///   bool, true where `s·z` differs from `μ` by more than 10× on
+    ///   some side.
+    /// - `"var_contaminated"`: list of bool, true where classified
+    ///   inactive yet carrying non-negligible barrier curvature.
+    ///
+    /// Requires `bound_relax_factor=0` (raises `ValueError` otherwise;
+    /// the Ipopt default is `1e-8`): relaxed bounds shift the slacks
+    /// the classifier reads.
+    fn classify_activity<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("classify_activity: no converged factor (call solve() first)")
+        })?;
+        let rep = s.inner.classify_activity().map_err(solver_error_to_py)?;
+        let status_str = |codes: &[i8]| -> Vec<&'static str> {
+            codes
+                .iter()
+                .map(|&c| match c {
+                    activity::INACTIVE => "inactive",
+                    activity::WEAKLY_ACTIVE => "weakly_active",
+                    activity::STRONGLY_ACTIVE => "strongly_active",
+                    activity::AMBIGUOUS => "ambiguous",
+                    activity::UNIDENTIFIED => "unidentified",
+                    _ => "unbounded",
+                })
+                .collect()
+        };
+        let out = PyDict::new_bound(py);
+        out.set_item("mu", rep.mu)?;
+        out.set_item("var_status", status_str(&rep.var_status))?;
+        out.set_item("var_ratio", rep.var_ratio.into_pyarray_bound(py))?;
+        out.set_item(
+            "var_q_sign",
+            rep.var_q_sign
+                .iter()
+                .map(|&s| s as i64)
+                .collect::<Vec<_>>()
+                .into_pyarray_bound(py),
+        )?;
+        out.set_item("var_off_central_path", rep.var_off_central_path)?;
+        out.set_item("var_contaminated", rep.var_contaminated)?;
+        out.set_item("row_status", status_str(&rep.row_status))?;
+        out.set_item("row_ratio", rep.row_ratio.into_pyarray_bound(py))?;
+        out.set_item(
+            "row_q_sign",
+            rep.row_q_sign
+                .iter()
+                .map(|&s| s as i64)
+                .collect::<Vec<_>>()
+                .into_pyarray_bound(py),
+        )?;
+        out.set_item("row_off_central_path", rep.row_off_central_path)?;
+        Ok(out)
+    }
 }
 
 fn validate_pins(pin_constraint_indices: &[i64], m: usize) -> PyResult<Vec<Index>> {
@@ -409,5 +482,6 @@ fn solver_error_to_py(e: SolverError) -> PyErr {
         SolverError::SensComputationFailed(msg) => {
             PyRuntimeError::new_err(format!("Solver: sensitivity computation failed: {msg}"))
         }
+        SolverError::BadOptions(msg) => PyValueError::new_err(format!("Solver: {msg}")),
     }
 }

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -403,7 +403,11 @@ impl PySolver {
     ///   `"unbounded"` where there is no finite bound, plus the
     ///   `"fixed"` / `"equality"` placeholders above.
     /// - `"var_ratio"`, `"row_ratio"`: ndarray of the ratio `Σ/q`
-    ///   (NaN where nothing was classified).
+    ///   (NaN where nothing was classified). An `"unidentified"` entry
+    ///   holds `Σ/floor`, a lower bound on any honest ratio rather
+    ///   than the ratio itself. Rows classify on the scale-invariant
+    ///   form `Σ‖∇d‖⁴/|∇dᵀH∇d|`, so rescaling a constraint row
+    ///   does not change its status.
     /// - `"var_q_sign"`, `"row_q_sign"`: ndarray of the sign of the
     ///   signed curvature, so an indefinite direction is visible.
     /// - `"var_off_central_path"`, `"row_off_central_path"`: list of
@@ -497,5 +501,7 @@ fn solver_error_to_py(e: SolverError) -> PyErr {
             PyRuntimeError::new_err(format!("Solver: sensitivity computation failed: {msg}"))
         }
         SolverError::BadOptions(msg) => PyValueError::new_err(format!("Solver: {msg}")),
+        // SolverError is #[non_exhaustive]
+        other => PyRuntimeError::new_err(format!("Solver: {other:?}")),
     }
 }

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -3,13 +3,16 @@
 //!
 //! Classifies every bounded variable and every finite-bounded inequality
 //! row of a converged barrier solve into one of five statuses, keyed on
-//! the ratio of barrier curvature to the objective's own curvature:
+//! the ratio of barrier curvature to the model's own curvature:
 //!
 //! ```text
 //! r = Σ / q,   Σ = z/s summed over the sides that exist,
 //!              q = |H_ii|                        (variable)
 //!                  |∇dⱼᵀ H ∇dⱼ| / ‖∇dⱼ‖²         (inequality row)
 //! ```
+//!
+//! `H` is the exact Lagrangian Hessian, so constraint curvature
+//! contributes to `q` alongside the objective's.
 //!
 //! `r` is `O(μ)` when the bound is inactive, `O(1)` when weakly active
 //! (slack and multiplier vanish together), and `O(1/μ)` when strongly
@@ -23,13 +26,21 @@
 //! solver's own slacks, `Σ` as `curr_sigma_x` / `curr_sigma_s`, the
 //! barrier parameter, and the exact Lagrangian Hessian, so `H` is
 //! never recovered from the barrier-augmented factor.
+//!
+//! The report is indexed in **user space**: `var_*` arrays have the
+//! user TNLP's full variable count and `row_*` arrays its full
+//! constraint count. A variable removed internally by
+//! `fixed_variable_treatment = make_parameter` (`lb == ub`, the
+//! default) reports [`FIXED`] at its own user index, and an equality
+//! constraint reports [`EQUALITY`], so user indices never shift.
 
 use std::rc::Rc;
 
-use pounce_common::types::Number;
+use pounce_common::types::{Index, Number};
 use pounce_linalg::Matrix;
 use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
 use pounce_linalg::expansion_matrix::ExpansionMatrix;
+use pounce_linalg::triplet::SymTMatrix;
 
 use crate::PdSensBacksolver;
 use crate::vec_util::dense_to_vec;
@@ -48,17 +59,28 @@ pub const AMBIGUOUS: i8 = 3;
 /// The curvature `q` is below noise scale: the bound question does not
 /// arise, and the direction is poorly identified.
 pub const UNIDENTIFIED: i8 = 4;
+/// `lb == ub`: the variable was removed from the solve as a parameter
+/// (`fixed_variable_treatment = make_parameter`), so there is no
+/// barrier geometry to classify.
+pub const FIXED: i8 = 5;
+/// An equality constraint: always active by construction, with no
+/// slack or multiplier pair on the barrier, so outside this
+/// classification.
+pub const EQUALITY: i8 = 6;
 
 /// Per-variable and per-row classification of a converged solve.
 ///
-/// Vectors are full-length (`n` variables, `m_d` inequality rows);
-/// entries with no finite bound hold [`UNBOUNDED`] and `NaN` ratios.
+/// All vectors are **user-space**: `var_*` have length `n_full_x` (the
+/// user TNLP's `n`) and `row_*` length `n_full_g` (the user's `m`).
+/// Entries with no finite bound hold [`UNBOUNDED`]; [`FIXED`]
+/// variables and [`EQUALITY`] rows are placeholders for entries the
+/// barrier never classified. All three carry `NaN` ratios.
 pub struct ActivityReport {
     /// Barrier parameter of the converged iterate.
     pub mu: Number,
-    /// Status per variable (codes above).
+    /// Status per user variable (codes above).
     pub var_status: Vec<i8>,
-    /// `Σ_i / q_i` per variable; `NaN` where unbounded.
+    /// `Σ_i / q_i` per user variable; `NaN` where not classified.
     pub var_ratio: Vec<Number>,
     /// Sign of the signed curvature `H_ii` (−1, 0, +1); the absolute
     /// value goes into `q`, so an indefinite direction is reported
@@ -70,21 +92,26 @@ pub struct ActivityReport {
     /// Classified inactive yet `r` non-negligible: barrier curvature
     /// where none should be.
     pub var_contaminated: Vec<bool>,
-    /// Status per inequality row.
+    /// Status per user constraint row.
     pub row_status: Vec<i8>,
-    /// `Σ_j / q_j` per row; `NaN` where the row has no finite bound.
+    /// `Σ_j / q_j` per user row; `NaN` where not classified.
     pub row_ratio: Vec<Number>,
     /// Sign of the signed row curvature `∇dⱼᵀ H ∇dⱼ`.
     pub row_q_sign: Vec<i8>,
     /// Central-path check per row, as for variables.
     pub row_off_central_path: Vec<bool>,
+    /// Contamination check per row, as for variables.
+    pub row_contaminated: Vec<bool>,
 }
 
 /// The classification rule of the roadmap's item 0.
 fn classify(r: Number, mu: Number) -> i8 {
     if mu > 1e-4 {
-        // the μ-edges have closed inside the fixed band: only the two
-        // clear calls are made, everything else is honest refusal
+        // The band is fixed at [1e-1, 1e1] while the μ-edges √μ and
+        // 1/√μ move with the solve: they meet the band at μ = 1e-2,
+        // and a full decade separates them from it at μ = 1e-4. Above
+        // 1e-4 that margin is what's thinning, so only the two calls
+        // that stay clear are made and the middle is honest refusal.
         if r < 1e-1 {
             INACTIVE
         } else if r > 1e1 {
@@ -116,46 +143,64 @@ fn sign_of(x: Number) -> i8 {
 /// Scatter a compressed (bounded-entries-only) vector to full length
 /// through its expansion matrix. Entries without that bound stay 0.
 fn expand(compressed: &[Number], px: &Rc<dyn Matrix>, n: usize) -> Vec<Number> {
+    let em = px
+        .as_any()
+        .downcast_ref::<ExpansionMatrix>()
+        .expect("bound projection is an ExpansionMatrix (orig_ipopt_nlp builds no other kind)");
+    let idx = em.expanded_pos_indices();
+    assert_eq!(
+        idx.len(),
+        compressed.len(),
+        "compressed bound vector length disagrees with its expansion",
+    );
     let mut full = vec![0.0; n];
-    if let Some(em) = px.as_any().downcast_ref::<ExpansionMatrix>() {
-        for (k, &pos) in em.expanded_pos_indices().iter().enumerate() {
-            if k < compressed.len() {
-                full[pos as usize] = compressed[k];
-            }
-        }
+    for (k, &pos) in idx.iter().enumerate() {
+        full[pos as usize] = compressed[k];
     }
     full
 }
 
 /// Presence mask for a bound side, from the same expansion.
 fn present(px: &Rc<dyn Matrix>, n: usize) -> Vec<bool> {
+    let em = px
+        .as_any()
+        .downcast_ref::<ExpansionMatrix>()
+        .expect("bound projection is an ExpansionMatrix (orig_ipopt_nlp builds no other kind)");
     let mut mask = vec![false; n];
-    if let Some(em) = px.as_any().downcast_ref::<ExpansionMatrix>() {
-        for &pos in em.expanded_pos_indices() {
-            mask[pos as usize] = true;
-        }
+    for &pos in em.expanded_pos_indices() {
+        mask[pos as usize] = true;
     }
     mask
 }
 
-/// `y = H · e_i` restricted to entry `i`: the exact Hessian diagonal,
-/// one sparse product per bounded variable.
-fn hessian_diag_entry(
-    hess: &Rc<dyn pounce_linalg::SymMatrix>,
-    i: usize,
-    n: usize,
-    work_in: &mut DenseVector,
-    work_out: &mut DenseVector,
-) -> Number {
-    work_in.values_mut().fill(0.0);
-    work_in.values_mut()[i] = 1.0;
-    work_out.values_mut().fill(0.0);
-    hess.mult_vector(1.0, work_in, 0.0, work_out);
-    // values_mut, not values: a zero product may have left the output
-    // homogeneous (empty backing slice); this materializes it
-    let out = work_out.values_mut();
-    debug_assert_eq!(out.len(), n);
-    out[i]
+/// The exact Hessian diagonal: one pass over the triplet structure for
+/// the type `eval_h` builds today. The mat-vec fallback keeps any
+/// future non-triplet `SymMatrix` correct, at O(n·nnz) cost.
+fn hessian_diagonal(hess: &Rc<dyn pounce_linalg::SymMatrix>, n: usize) -> Vec<Number> {
+    let mut diag = vec![0.0; n];
+    if let Some(t) = hess.as_any().downcast_ref::<SymTMatrix>() {
+        // triplet indices are 1-based (the GenTMatrix convention);
+        // duplicates accumulate, matching mult_vector
+        for ((&i, &j), &v) in t.irows().iter().zip(t.jcols()).zip(t.values()) {
+            if i == j {
+                diag[(i - 1) as usize] += v;
+            }
+        }
+        return diag;
+    }
+    let space = DenseVectorSpace::new(n as i32);
+    let mut e = DenseVector::new(space.clone());
+    let mut he = DenseVector::new(space);
+    for (i, d) in diag.iter_mut().enumerate() {
+        e.values_mut().fill(0.0);
+        e.values_mut()[i] = 1.0;
+        he.values_mut().fill(0.0);
+        hess.mult_vector(1.0, &e, 0.0, &mut he);
+        // values_mut, not values: a zero product may have left the
+        // output homogeneous (empty backing slice); this materializes
+        *d = he.values_mut()[i];
+    }
+    diag
 }
 
 /// Central-path check for one side: `s·z` within a factor of ten of `μ`.
@@ -166,6 +211,55 @@ fn off_path(s: Number, z: Number, mu: Number) -> bool {
 
 /// `r` above this while classified inactive flags contamination.
 const CONTAMINATION_FLOOR: Number = 1e-3;
+
+fn contaminated(status: i8, r: Number) -> bool {
+    status == INACTIVE && r > CONTAMINATION_FLOOR
+}
+
+/// One classified entry in internal space, before the user-space
+/// scatter.
+#[derive(Clone, Copy)]
+struct Entry {
+    status: i8,
+    ratio: Number,
+    q_sign: i8,
+    off_path: bool,
+    contaminated: bool,
+}
+
+const NOT_CLASSIFIED: Entry = Entry {
+    status: UNBOUNDED,
+    ratio: Number::NAN,
+    q_sign: 0,
+    off_path: false,
+    contaminated: false,
+};
+
+/// Classify one bounded variable or row from its `Σ` and signed `q`.
+/// `off_path` is the caller's to fill: it reads the per-side slack and
+/// multiplier, not the ratio.
+fn classify_entry(sigma: Number, q_signed: Number, floor: Number, mu: Number) -> Entry {
+    let q_sign = sign_of(q_signed);
+    let q = q_signed.abs();
+    if q < floor {
+        return Entry {
+            status: UNIDENTIFIED,
+            ratio: sigma / floor,
+            q_sign,
+            off_path: false,
+            contaminated: false,
+        };
+    }
+    let r = sigma / q;
+    let status = classify(r, mu);
+    Entry {
+        status,
+        ratio: r,
+        q_sign,
+        off_path: false,
+        contaminated: contaminated(status, r),
+    }
+}
 
 pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let (data, cq, nlp) = bs.activity_handles();
@@ -192,7 +286,7 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     };
     let cq = cq.borrow();
 
-    // --- variables -----------------------------------------------------
+    // --- variables, in internal space ------------------------------------
     let has_l = present(&px_l, n);
     let has_u = present(&px_u, n);
     let z_l = expand(&dense_to_vec(mult_z_l.as_ref()), &px_l, n);
@@ -202,46 +296,25 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let sigma_x = dense_to_vec(cq.curr_sigma_x().as_ref());
 
     let hess = cq.curr_exact_hessian();
-    let space = DenseVectorSpace::new(n as i32);
-    let mut w_in = DenseVector::new(space.clone());
-    let mut w_out = DenseVector::new(space);
-
     // the identification floor is relative to the largest curvature
     // anywhere on the diagonal, not just the bounded entries, so a
     // row-only model still measures q against the model's own scale
-    let mut diag = vec![0.0; n];
-    let mut max_abs_diag: Number = 0.0;
-    for i in 0..n {
-        diag[i] = hessian_diag_entry(&hess, i, n, &mut w_in, &mut w_out);
-        max_abs_diag = max_abs_diag.max(diag[i].abs());
-    }
+    let diag = hessian_diagonal(&hess, n);
+    let max_abs_diag = diag.iter().fold(0.0, |a: Number, d| a.max(d.abs()));
     let floor = Number::EPSILON.sqrt() * max_abs_diag.max(1.0);
 
-    let mut var_status = vec![UNBOUNDED; n];
-    let mut var_ratio = vec![Number::NAN; n];
-    let mut var_q_sign = vec![0i8; n];
-    let mut var_off = vec![false; n];
-    let mut var_cont = vec![false; n];
+    let mut vars = vec![NOT_CLASSIFIED; n];
     for i in 0..n {
         if !(has_l[i] || has_u[i]) {
             continue;
         }
-        var_q_sign[i] = sign_of(diag[i]);
-        let q = diag[i].abs();
-        if q < floor {
-            var_status[i] = UNIDENTIFIED;
-            var_ratio[i] = sigma_x[i] / floor;
-            continue;
-        }
-        let r = sigma_x[i] / q;
-        var_ratio[i] = r;
-        var_status[i] = classify(r, mu);
-        var_off[i] = (has_l[i] && off_path(s_l[i], z_l[i], mu))
+        let mut e = classify_entry(sigma_x[i], diag[i], floor, mu);
+        e.off_path = (has_l[i] && off_path(s_l[i], z_l[i], mu))
             || (has_u[i] && off_path(s_u[i], z_u[i], mu));
-        var_cont[i] = var_status[i] == INACTIVE && r > CONTAMINATION_FLOOR;
+        vars[i] = e;
     }
 
-    // --- inequality rows ----------------------------------------------
+    // --- inequality rows, in internal space -------------------------------
     let rhas_l = present(&pd_l, m_d);
     let rhas_u = present(&pd_u, m_d);
     let v_l = expand(&dense_to_vec(mult_v_l.as_ref()), &pd_l, m_d);
@@ -257,10 +330,7 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let mut grad = DenseVector::new(nspace.clone());
     let mut hgrad = DenseVector::new(nspace);
 
-    let mut row_status = vec![UNBOUNDED; m_d];
-    let mut row_ratio = vec![Number::NAN; m_d];
-    let mut row_q_sign = vec![0i8; m_d];
-    let mut row_off = vec![false; m_d];
+    let mut rows = vec![NOT_CLASSIFIED; m_d];
     for j in 0..m_d {
         if !(rhas_l[j] || rhas_u[j]) {
             continue;
@@ -273,44 +343,153 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
         grad.values_mut().fill(0.0);
         jac_d.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
         let norm2: Number = grad.values_mut().iter().map(|g| *g * *g).sum();
-        if norm2 <= 0.0 {
-            continue;
-        }
-        hgrad.values_mut().fill(0.0);
-        hess.mult_vector(1.0, &grad, 0.0, &mut hgrad);
-        let ghg: Number = {
-            let h = hgrad.values_mut();
-            grad.values_mut()
-                .iter()
-                .zip(h.iter())
-                .map(|(g, h)| g * h)
-                .sum()
+        let mut e = if norm2 <= 0.0 {
+            // a bounded row whose gradient vanishes at the iterate has
+            // no direction to measure curvature along: unidentified,
+            // exactly as a below-floor q, never `unbounded` (the
+            // bounds are real)
+            Entry {
+                status: UNIDENTIFIED,
+                ratio: sigma_s[j] / floor,
+                q_sign: 0,
+                off_path: false,
+                contaminated: false,
+            }
+        } else {
+            hgrad.values_mut().fill(0.0);
+            hess.mult_vector(1.0, &grad, 0.0, &mut hgrad);
+            let ghg: Number = {
+                let h = hgrad.values_mut();
+                grad.values_mut()
+                    .iter()
+                    .zip(h.iter())
+                    .map(|(g, h)| g * h)
+                    .sum()
+            };
+            classify_entry(sigma_s[j], ghg / norm2, floor, mu)
         };
-        let q_signed = ghg / norm2;
-        row_q_sign[j] = sign_of(q_signed);
-        let q = q_signed.abs();
-        if q < floor {
-            row_status[j] = UNIDENTIFIED;
-            row_ratio[j] = sigma_s[j] / floor;
-            continue;
-        }
-        let r = sigma_s[j] / q;
-        row_ratio[j] = r;
-        row_status[j] = classify(r, mu);
-        row_off[j] = (rhas_l[j] && off_path(rs_l[j], v_l[j], mu))
+        e.off_path = (rhas_l[j] && off_path(rs_l[j], v_l[j], mu))
             || (rhas_u[j] && off_path(rs_u[j], v_u[j], mu));
+        rows[j] = e;
     }
+
+    // --- scatter to user space --------------------------------------------
+    // all Cq evaluation is done, so borrowing the NLP again is safe
+    let nl = nlp.borrow();
+    let n_full_x = nl.n_full_x() as usize;
+    let n_full_g = nl.n_full_g() as usize;
+
+    let fixed_entry = Entry {
+        status: FIXED,
+        ..NOT_CLASSIFIED
+    };
+    let mut var_full = vec![fixed_entry; n_full_x];
+    for (i, e) in vars.iter().enumerate() {
+        var_full[nl.var_x_to_full_x(i as Index) as usize] = *e;
+    }
+
+    let equality_entry = Entry {
+        status: EQUALITY,
+        ..NOT_CLASSIFIED
+    };
+    let mut row_full = vec![equality_entry; n_full_g];
+    // BoundClassification's d_map is one ascending scan over the
+    // user's g, so the j-th full-g index outside the c-block is
+    // internal inequality row j
+    let mut d_pos = 0usize;
+    for (full_idx, slot) in row_full.iter_mut().enumerate() {
+        if nl.full_g_to_c_block(full_idx as Index).is_none() {
+            *slot = rows[d_pos];
+            d_pos += 1;
+        }
+    }
+    assert_eq!(d_pos, m_d, "inequality count disagrees with the c/d split");
 
     ActivityReport {
         mu,
-        var_status,
-        var_ratio,
-        var_q_sign,
-        var_off_central_path: var_off,
-        var_contaminated: var_cont,
-        row_status,
-        row_ratio,
-        row_q_sign,
-        row_off_central_path: row_off,
+        var_status: var_full.iter().map(|e| e.status).collect(),
+        var_ratio: var_full.iter().map(|e| e.ratio).collect(),
+        var_q_sign: var_full.iter().map(|e| e.q_sign).collect(),
+        var_off_central_path: var_full.iter().map(|e| e.off_path).collect(),
+        var_contaminated: var_full.iter().map(|e| e.contaminated).collect(),
+        row_status: row_full.iter().map(|e| e.status).collect(),
+        row_ratio: row_full.iter().map(|e| e.ratio).collect(),
+        row_q_sign: row_full.iter().map(|e| e.q_sign).collect(),
+        row_off_central_path: row_full.iter().map(|e| e.off_path).collect(),
+        row_contaminated: row_full.iter().map(|e| e.contaminated).collect(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tight_mu_walks_all_five_regions() {
+        let mu = 1e-10; // edges at 1e-5 and 1e5
+        assert_eq!(classify(0.9e-5, mu), INACTIVE);
+        assert_eq!(classify(1.1e-5, mu), AMBIGUOUS); // gap: edge..band
+        assert_eq!(classify(0.5, mu), WEAKLY_ACTIVE);
+        assert_eq!(classify(50.0, mu), AMBIGUOUS); // gap: band..edge
+        assert_eq!(classify(2e5, mu), STRONGLY_ACTIVE);
+    }
+
+    #[test]
+    fn band_edges_are_inclusive_and_mu_edges_separate() {
+        let mu = 1e-10;
+        assert_eq!(classify(1e-1, mu), WEAKLY_ACTIVE);
+        assert_eq!(classify(1e1, mu), WEAKLY_ACTIVE);
+        // either side of each μ-edge (exactly-on is float-fragile:
+        // √(1e-10) is not exactly 1e-5)
+        assert_eq!(classify(0.99e-5, mu), INACTIVE);
+        assert_eq!(classify(1.01e-5, mu), AMBIGUOUS);
+        assert_eq!(classify(0.99e5, mu), AMBIGUOUS);
+        assert_eq!(classify(1.01e5, mu), STRONGLY_ACTIVE);
+    }
+
+    #[test]
+    fn loose_mu_refuses_the_weak_call() {
+        // μ > 1e-4: three statuses only, the band reports ambiguous
+        for mu in [1e-3, 1e-2, 1e-1] {
+            assert_eq!(classify(0.05, mu), INACTIVE);
+            assert_eq!(classify(1.0, mu), AMBIGUOUS);
+            assert_eq!(classify(50.0, mu), STRONGLY_ACTIVE);
+        }
+        // at μ = 1e-4 exactly the μ-branch is not taken: the weak call
+        // is available, with a decade of margin edge-to-band
+        assert_eq!(classify(1.0, 1e-4), WEAKLY_ACTIVE);
+    }
+
+    #[test]
+    fn off_path_is_a_factor_of_ten_both_ways() {
+        let mu = 1e-2;
+        assert!(!off_path(1.0, 1e-2, mu)); // s·z = μ exactly
+        assert!(!off_path(0.5, 1e-2, mu)); // within 10×
+        assert!(off_path(1.0, 0.2, mu)); // 20× above
+        assert!(off_path(1.0, 5e-4, mu)); // 20× below
+    }
+
+    #[test]
+    fn contamination_flags_inactive_only() {
+        assert!(contaminated(INACTIVE, 1e-2));
+        assert!(!contaminated(INACTIVE, 1e-4));
+        assert!(!contaminated(WEAKLY_ACTIVE, 1.0));
+        assert!(!contaminated(STRONGLY_ACTIVE, 1e5));
+    }
+
+    #[test]
+    fn below_floor_reports_unidentified_with_the_sign() {
+        let e = classify_entry(0.5, 1e-12, 1e-8, 1e-10);
+        assert_eq!(e.status, UNIDENTIFIED);
+        assert_eq!(e.q_sign, 1);
+        let e = classify_entry(0.5, -1e-12, 1e-8, 1e-10);
+        assert_eq!(e.status, UNIDENTIFIED);
+        assert_eq!(e.q_sign, -1);
+        // negative curvature above the floor classifies on |q| but
+        // keeps its sign visible
+        let e = classify_entry(1.0, -2.0, 1e-8, 1e-10);
+        assert_eq!(e.status, WEAKLY_ACTIVE);
+        assert_eq!(e.q_sign, -1);
+        assert_eq!(e.ratio, 0.5);
     }
 }

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -8,11 +8,27 @@
 //! ```text
 //! r = Σ / q,   Σ = z/s summed over the sides that exist,
 //!              q = |H_ii|                        (variable)
-//!                  |∇dⱼᵀ H ∇dⱼ| / ‖∇dⱼ‖²         (inequality row)
+//!                  |∇dⱼᵀ H ∇dⱼ| / ‖∇dⱼ‖⁴         (inequality row)
 //! ```
 //!
+//! The row denominator carries the fourth power so that `r` is
+//! invariant to rescaling the row: `d → c·d` sends `Σ → Σ/c²` while
+//! the curvature along the unit normal is unchanged, and `‖∇d‖⁴`
+//! restores the balance. Equivalently, the geometric barrier weight
+//! `Σ‖∇d‖²` (distance to the surface is `d/‖∇d‖`, its conjugate
+//! multiplier `v‖∇d‖`) is measured against the curvature along the
+//! unit normal. Variable bounds are invariant as written. This also
+//! absorbs the solver's own per-row `d_scale`.
+//!
 //! `H` is the exact Lagrangian Hessian, so constraint curvature
-//! contributes to `q` alongside the objective's.
+//! contributes to `q` alongside the objective's. For variables, `q`
+//! reads the Hessian DIAGONAL only, so purely off-diagonal coupling is
+//! invisible to it: `f = x₁x₂` with bounds on both variables reports
+//! `unidentified` on every bound even though the bound directions have
+//! well-defined curvature. Items 1-4 of the covariance roadmap inherit
+//! these semantics where they consume the per-coordinate statuses;
+//! their reduced-block classification is where coupling becomes
+//! visible, folded into the reduced diagonal by elimination.
 //!
 //! `r` is `O(μ)` when the bound is inactive, `O(1)` when weakly active
 //! (slack and multiplier vanish together), and `O(1/μ)` when strongly
@@ -40,7 +56,7 @@ use pounce_common::types::{Index, Number};
 use pounce_linalg::Matrix;
 use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
 use pounce_linalg::expansion_matrix::ExpansionMatrix;
-use pounce_linalg::triplet::SymTMatrix;
+use pounce_linalg::triplet::{GenTMatrix, SymTMatrix};
 
 use crate::PdSensBacksolver;
 use crate::vec_util::dense_to_vec;
@@ -81,6 +97,9 @@ pub struct ActivityReport {
     /// Status per user variable (codes above).
     pub var_status: Vec<i8>,
     /// `Σ_i / q_i` per user variable; `NaN` where not classified.
+    /// For an [`UNIDENTIFIED`] entry the value is `Σ/floor`, a lower
+    /// bound on any honest ratio rather than the ratio itself, since
+    /// `q` is below the identification floor there.
     pub var_ratio: Vec<Number>,
     /// Sign of the signed curvature `H_ii` (−1, 0, +1); the absolute
     /// value goes into `q`, so an indefinite direction is reported
@@ -95,6 +114,7 @@ pub struct ActivityReport {
     /// Status per user constraint row.
     pub row_status: Vec<i8>,
     /// `Σ_j / q_j` per user row; `NaN` where not classified.
+    /// [`UNIDENTIFIED`] entries hold `Σ/floor` as for variables.
     pub row_ratio: Vec<Number>,
     /// Sign of the signed row curvature `∇dⱼᵀ H ∇dⱼ`.
     pub row_q_sign: Vec<i8>,
@@ -203,17 +223,34 @@ fn hessian_diagonal(hess: &Rc<dyn pounce_linalg::SymMatrix>, n: usize) -> Vec<Nu
     diag
 }
 
+/// A bounded row whose gradient vanishes at the iterate has no
+/// direction to measure curvature along: unidentified, exactly as a
+/// below-floor `q`, never `unbounded` (the bounds are real). The
+/// ratio is the raw `Σ/floor` lower bound; the geometric weight is
+/// degenerate at zero gradient.
+fn zero_gradient_row(sigma: Number, floor: Number) -> Entry {
+    Entry {
+        status: UNIDENTIFIED,
+        ratio: sigma / floor,
+        q_sign: 0,
+        off_path: false,
+        contaminated: false,
+    }
+}
+
 /// Central-path check for one side: `s·z` within a factor of ten of `μ`.
 fn off_path(s: Number, z: Number, mu: Number) -> bool {
     let comp = s * z;
     comp > 10.0 * mu || comp < 0.1 * mu
 }
 
-/// `r` above this while classified inactive flags contamination.
-const CONTAMINATION_FLOOR: Number = 1e-3;
-
-fn contaminated(status: i8, r: Number) -> bool {
-    status == INACTIVE && r > CONTAMINATION_FLOOR
+/// Classified inactive yet `r` well above the `O(μ)` an inactive
+/// bound should carry: barrier curvature where none should be. The
+/// threshold is μ-relative because `inactive` MEANS `r = O(μ)`; a
+/// fixed constant can never sit below the inactive edge `√μ` at any
+/// converged μ (second review).
+fn contaminated(status: i8, r: Number, mu: Number) -> bool {
+    status == INACTIVE && r > 100.0 * mu
 }
 
 /// One classified entry in internal space, before the user-space
@@ -257,7 +294,7 @@ fn classify_entry(sigma: Number, q_signed: Number, floor: Number, mu: Number) ->
         ratio: r,
         q_sign,
         off_path: false,
-        contaminated: contaminated(status, r),
+        contaminated: contaminated(status, r, mu),
     }
 }
 
@@ -324,53 +361,117 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let sigma_s = dense_to_vec(cq.curr_sigma_s().as_ref());
 
     let jac_d = cq.curr_jac_d();
-    let mspace = DenseVectorSpace::new(m_d as i32);
-    let mut e_row = DenseVector::new(mspace);
-    let nspace = DenseVectorSpace::new(n as i32);
-    let mut grad = DenseVector::new(nspace.clone());
-    let mut hgrad = DenseVector::new(nspace);
-
+    // One pass over the Jacobian triplets gathers every row's support
+    // and one pass over the Hessian triplets builds an adjacency view,
+    // so each row's curvature costs its own support times its
+    // neighbours instead of a full mat-vec pair per row (second
+    // review). The mat-vec loop below remains the fallback for any
+    // future non-triplet matrix types.
     let mut rows = vec![NOT_CLASSIFIED; m_d];
+    let fast = match (
+        jac_d.as_any().downcast_ref::<GenTMatrix>(),
+        hess.as_any().downcast_ref::<SymTMatrix>(),
+    ) {
+        (Some(jt), Some(ht)) => {
+            // gather and merge each row's entries (triplet duplicates
+            // sum, matching mult_vector; indices are 1-based)
+            let mut support: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m_d];
+            for ((&r, &c), &v) in jt.irows().iter().zip(jt.jcols()).zip(jt.values()) {
+                support[(r - 1) as usize].push(((c - 1) as usize, v));
+            }
+            for sup in &mut support {
+                sup.sort_unstable_by_key(|&(c, _)| c);
+                sup.dedup_by(|a, b| {
+                    if a.0 == b.0 {
+                        b.1 += a.1;
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+            let mut adj: Vec<Vec<(usize, Number)>> = vec![Vec::new(); n];
+            for ((&i, &l), &v) in ht.irows().iter().zip(ht.jcols()).zip(ht.values()) {
+                let (a, b) = ((i - 1) as usize, (l - 1) as usize);
+                adj[a].push((b, v));
+                if a != b {
+                    adj[b].push((a, v));
+                }
+            }
+            let mut scratch = vec![0.0; n];
+            for j in 0..m_d {
+                if !(rhas_l[j] || rhas_u[j]) {
+                    continue;
+                }
+                let sup = &support[j];
+                let norm2: Number = sup.iter().map(|&(_, g)| g * g).sum();
+                rows[j] = if norm2 <= 0.0 {
+                    zero_gradient_row(sigma_s[j], floor)
+                } else {
+                    for &(k, g) in sup {
+                        scratch[k] = g;
+                    }
+                    let mut ghg = 0.0;
+                    for &(k, gk) in sup {
+                        let mut acc = 0.0;
+                        for &(l, v) in &adj[k] {
+                            acc += v * scratch[l];
+                        }
+                        ghg += gk * acc;
+                    }
+                    for &(k, _) in sup {
+                        scratch[k] = 0.0;
+                    }
+                    // Σ·‖∇d‖² against curvature along the unit
+                    // normal: invariant to rescaling the row
+                    classify_entry(sigma_s[j] * norm2, ghg / norm2, floor, mu)
+                };
+            }
+            true
+        }
+        _ => false,
+    };
+    if !fast {
+        let mspace = DenseVectorSpace::new(m_d as i32);
+        let mut e_row = DenseVector::new(mspace);
+        let nspace = DenseVectorSpace::new(n as i32);
+        let mut grad = DenseVector::new(nspace.clone());
+        let mut hgrad = DenseVector::new(nspace);
+        for j in 0..m_d {
+            if !(rhas_l[j] || rhas_u[j]) {
+                continue;
+            }
+            // ∇dⱼ = Jdᵀ eⱼ, then the curvature along the normal;
+            // values_mut throughout because a zero product may leave
+            // the output homogeneous (empty backing slice)
+            e_row.values_mut().fill(0.0);
+            e_row.values_mut()[j] = 1.0;
+            grad.values_mut().fill(0.0);
+            jac_d.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
+            let norm2: Number = grad.values_mut().iter().map(|g| *g * *g).sum();
+            rows[j] = if norm2 <= 0.0 {
+                zero_gradient_row(sigma_s[j], floor)
+            } else {
+                hgrad.values_mut().fill(0.0);
+                hess.mult_vector(1.0, &grad, 0.0, &mut hgrad);
+                let ghg: Number = {
+                    let h = hgrad.values_mut();
+                    grad.values_mut()
+                        .iter()
+                        .zip(h.iter())
+                        .map(|(g, h)| g * h)
+                        .sum()
+                };
+                classify_entry(sigma_s[j] * norm2, ghg / norm2, floor, mu)
+            };
+        }
+    }
     for j in 0..m_d {
         if !(rhas_l[j] || rhas_u[j]) {
             continue;
         }
-        // ∇dⱼ = Jdᵀ eⱼ, then the curvature along the normal;
-        // values_mut throughout because a zero product may leave the
-        // output homogeneous (empty backing slice behind values())
-        e_row.values_mut().fill(0.0);
-        e_row.values_mut()[j] = 1.0;
-        grad.values_mut().fill(0.0);
-        jac_d.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
-        let norm2: Number = grad.values_mut().iter().map(|g| *g * *g).sum();
-        let mut e = if norm2 <= 0.0 {
-            // a bounded row whose gradient vanishes at the iterate has
-            // no direction to measure curvature along: unidentified,
-            // exactly as a below-floor q, never `unbounded` (the
-            // bounds are real)
-            Entry {
-                status: UNIDENTIFIED,
-                ratio: sigma_s[j] / floor,
-                q_sign: 0,
-                off_path: false,
-                contaminated: false,
-            }
-        } else {
-            hgrad.values_mut().fill(0.0);
-            hess.mult_vector(1.0, &grad, 0.0, &mut hgrad);
-            let ghg: Number = {
-                let h = hgrad.values_mut();
-                grad.values_mut()
-                    .iter()
-                    .zip(h.iter())
-                    .map(|(g, h)| g * h)
-                    .sum()
-            };
-            classify_entry(sigma_s[j], ghg / norm2, floor, mu)
-        };
-        e.off_path = (rhas_l[j] && off_path(rs_l[j], v_l[j], mu))
+        rows[j].off_path = (rhas_l[j] && off_path(rs_l[j], v_l[j], mu))
             || (rhas_u[j] && off_path(rs_u[j], v_u[j], mu));
-        rows[j] = e;
     }
 
     // --- scatter to user space --------------------------------------------
@@ -470,11 +571,15 @@ mod tests {
     }
 
     #[test]
-    fn contamination_flags_inactive_only() {
-        assert!(contaminated(INACTIVE, 1e-2));
-        assert!(!contaminated(INACTIVE, 1e-4));
-        assert!(!contaminated(WEAKLY_ACTIVE, 1.0));
-        assert!(!contaminated(STRONGLY_ACTIVE, 1e5));
+    fn contamination_is_mu_relative_and_inactive_only() {
+        let mu = 1e-10; // inactive edge at 1e-5, threshold at 1e-8
+        assert!(contaminated(INACTIVE, 1e-6, mu));
+        assert!(!contaminated(INACTIVE, 5e-9, mu));
+        assert!(!contaminated(WEAKLY_ACTIVE, 1.0, mu));
+        assert!(!contaminated(STRONGLY_ACTIVE, 1e5, mu));
+        // the flag is reachable: 100μ sits below the inactive edge √μ
+        // whenever μ < 1e-4, so an inactive r can exceed it
+        assert!(100.0 * mu < mu.sqrt());
     }
 
     #[test]

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -1,0 +1,316 @@
+//! Post-solve activity classification (the covariance/information
+//! roadmap's item 0, gh #362).
+//!
+//! Classifies every bounded variable and every finite-bounded inequality
+//! row of a converged barrier solve into one of five statuses, keyed on
+//! the ratio of barrier curvature to the objective's own curvature:
+//!
+//! ```text
+//! r = Σ / q,   Σ = z/s summed over the sides that exist,
+//!              q = |H_ii|                        (variable)
+//!                  |∇dⱼᵀ H ∇dⱼ| / ‖∇dⱼ‖²         (inequality row)
+//! ```
+//!
+//! `r` is `O(μ)` when the bound is inactive, `O(1)` when weakly active
+//! (slack and multiplier vanish together), and `O(1/μ)` when strongly
+//! active, so one ratio separates the regimes at any `μ` where a fixed
+//! threshold on the slack or the multiplier alone cannot: both are
+//! `O(√μ)` at weak activity, so any constant tracks the solve rather
+//! than the geometry.
+//!
+//! Everything read here is retained by the converged state the
+//! backsolver already holds: the bound multipliers on the iterate, the
+//! solver's own slacks, `Σ` as `curr_sigma_x` / `curr_sigma_s`, the
+//! barrier parameter, and the exact Lagrangian Hessian, so `H` is
+//! never recovered from the barrier-augmented factor.
+
+use std::rc::Rc;
+
+use pounce_common::types::Number;
+use pounce_linalg::Matrix;
+use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
+use pounce_linalg::expansion_matrix::ExpansionMatrix;
+
+use crate::PdSensBacksolver;
+use crate::vec_util::dense_to_vec;
+
+/// No finite bound on this variable or row: nothing to classify.
+pub const UNBOUNDED: i8 = -1;
+/// `r = O(μ)`: the bound is not doing anything.
+pub const INACTIVE: i8 = 0;
+/// `r = O(1)`: slack and multiplier vanish together; kept, flagged.
+pub const WEAKLY_ACTIVE: i8 = 1;
+/// `r = O(1/μ)`: the bound holds the variable; projected out.
+pub const STRONGLY_ACTIVE: i8 = 2;
+/// `r` in a gap between the band and a `μ`-edge: undetermined at this
+/// `μ`; re-solving tighter separates it.
+pub const AMBIGUOUS: i8 = 3;
+/// The curvature `q` is below noise scale: the bound question does not
+/// arise, and the direction is poorly identified.
+pub const UNIDENTIFIED: i8 = 4;
+
+/// Per-variable and per-row classification of a converged solve.
+///
+/// Vectors are full-length (`n` variables, `m_d` inequality rows);
+/// entries with no finite bound hold [`UNBOUNDED`] and `NaN` ratios.
+pub struct ActivityReport {
+    /// Barrier parameter of the converged iterate.
+    pub mu: Number,
+    /// Status per variable (codes above).
+    pub var_status: Vec<i8>,
+    /// `Σ_i / q_i` per variable; `NaN` where unbounded.
+    pub var_ratio: Vec<Number>,
+    /// Sign of the signed curvature `H_ii` (−1, 0, +1); the absolute
+    /// value goes into `q`, so an indefinite direction is reported
+    /// rather than hidden.
+    pub var_q_sign: Vec<i8>,
+    /// `s·z` differs from `μ` by more than a factor of ten on some
+    /// side: off the central path, or the bound was relaxed.
+    pub var_off_central_path: Vec<bool>,
+    /// Classified inactive yet `r` non-negligible: barrier curvature
+    /// where none should be.
+    pub var_contaminated: Vec<bool>,
+    /// Status per inequality row.
+    pub row_status: Vec<i8>,
+    /// `Σ_j / q_j` per row; `NaN` where the row has no finite bound.
+    pub row_ratio: Vec<Number>,
+    /// Sign of the signed row curvature `∇dⱼᵀ H ∇dⱼ`.
+    pub row_q_sign: Vec<i8>,
+    /// Central-path check per row, as for variables.
+    pub row_off_central_path: Vec<bool>,
+}
+
+/// The classification rule of the roadmap's item 0.
+fn classify(r: Number, mu: Number) -> i8 {
+    if mu > 1e-4 {
+        // the μ-edges have closed inside the fixed band: only the two
+        // clear calls are made, everything else is honest refusal
+        if r < 1e-1 {
+            INACTIVE
+        } else if r > 1e1 {
+            STRONGLY_ACTIVE
+        } else {
+            AMBIGUOUS
+        }
+    } else if r < mu.sqrt() {
+        INACTIVE
+    } else if r > 1.0 / mu.sqrt() {
+        STRONGLY_ACTIVE
+    } else if (1e-1..=1e1).contains(&r) {
+        WEAKLY_ACTIVE
+    } else {
+        AMBIGUOUS
+    }
+}
+
+fn sign_of(x: Number) -> i8 {
+    if x > 0.0 {
+        1
+    } else if x < 0.0 {
+        -1
+    } else {
+        0
+    }
+}
+
+/// Scatter a compressed (bounded-entries-only) vector to full length
+/// through its expansion matrix. Entries without that bound stay 0.
+fn expand(compressed: &[Number], px: &Rc<dyn Matrix>, n: usize) -> Vec<Number> {
+    let mut full = vec![0.0; n];
+    if let Some(em) = px.as_any().downcast_ref::<ExpansionMatrix>() {
+        for (k, &pos) in em.expanded_pos_indices().iter().enumerate() {
+            if k < compressed.len() {
+                full[pos as usize] = compressed[k];
+            }
+        }
+    }
+    full
+}
+
+/// Presence mask for a bound side, from the same expansion.
+fn present(px: &Rc<dyn Matrix>, n: usize) -> Vec<bool> {
+    let mut mask = vec![false; n];
+    if let Some(em) = px.as_any().downcast_ref::<ExpansionMatrix>() {
+        for &pos in em.expanded_pos_indices() {
+            mask[pos as usize] = true;
+        }
+    }
+    mask
+}
+
+/// `y = H · e_i` restricted to entry `i`: the exact Hessian diagonal,
+/// one sparse product per bounded variable.
+fn hessian_diag_entry(
+    hess: &Rc<dyn pounce_linalg::SymMatrix>,
+    i: usize,
+    n: usize,
+    work_in: &mut DenseVector,
+    work_out: &mut DenseVector,
+) -> Number {
+    work_in.values_mut().fill(0.0);
+    work_in.values_mut()[i] = 1.0;
+    work_out.values_mut().fill(0.0);
+    hess.mult_vector(1.0, work_in, 0.0, work_out);
+    // values_mut, not values: a zero product may have left the output
+    // homogeneous (empty backing slice); this materializes it
+    let out = work_out.values_mut();
+    debug_assert_eq!(out.len(), n);
+    out[i]
+}
+
+/// Central-path check for one side: `s·z` within a factor of ten of `μ`.
+fn off_path(s: Number, z: Number, mu: Number) -> bool {
+    let comp = s * z;
+    comp > 10.0 * mu || comp < 0.1 * mu
+}
+
+/// `r` above this while classified inactive flags contamination.
+const CONTAMINATION_FLOOR: Number = 1e-3;
+
+pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
+    let (data, cq, nlp) = bs.activity_handles();
+
+    // scoped borrows: the Cq getters below re-borrow the NLP (mutably,
+    // for lazy evaluation) and the data, so nothing here may hold
+    // either across a Cq call
+    let (mu, mult_z_l, mult_z_u, mult_v_l, mult_v_u, n, m_d) = {
+        let d = data.borrow();
+        let curr = d.curr.as_ref().expect("converged state has an iterate");
+        (
+            d.curr_mu,
+            Rc::clone(&curr.z_l),
+            Rc::clone(&curr.z_u),
+            Rc::clone(&curr.v_l),
+            Rc::clone(&curr.v_u),
+            curr.x.dim() as usize,
+            curr.s.dim() as usize,
+        )
+    };
+    let (px_l, px_u, pd_l, pd_u) = {
+        let nl = nlp.borrow();
+        (nl.px_l(), nl.px_u(), nl.pd_l(), nl.pd_u())
+    };
+    let cq = cq.borrow();
+
+    // --- variables -----------------------------------------------------
+    let has_l = present(&px_l, n);
+    let has_u = present(&px_u, n);
+    let z_l = expand(&dense_to_vec(mult_z_l.as_ref()), &px_l, n);
+    let z_u = expand(&dense_to_vec(mult_z_u.as_ref()), &px_u, n);
+    let s_l = expand(&dense_to_vec(cq.curr_slack_x_l().as_ref()), &px_l, n);
+    let s_u = expand(&dense_to_vec(cq.curr_slack_x_u().as_ref()), &px_u, n);
+    let sigma_x = dense_to_vec(cq.curr_sigma_x().as_ref());
+
+    let hess = cq.curr_exact_hessian();
+    let space = DenseVectorSpace::new(n as i32);
+    let mut w_in = DenseVector::new(space.clone());
+    let mut w_out = DenseVector::new(space);
+
+    // the identification floor is relative to the largest curvature
+    // anywhere on the diagonal, not just the bounded entries, so a
+    // row-only model still measures q against the model's own scale
+    let mut diag = vec![0.0; n];
+    let mut max_abs_diag: Number = 0.0;
+    for i in 0..n {
+        diag[i] = hessian_diag_entry(&hess, i, n, &mut w_in, &mut w_out);
+        max_abs_diag = max_abs_diag.max(diag[i].abs());
+    }
+    let floor = Number::EPSILON.sqrt() * max_abs_diag.max(1.0);
+
+    let mut var_status = vec![UNBOUNDED; n];
+    let mut var_ratio = vec![Number::NAN; n];
+    let mut var_q_sign = vec![0i8; n];
+    let mut var_off = vec![false; n];
+    let mut var_cont = vec![false; n];
+    for i in 0..n {
+        if !(has_l[i] || has_u[i]) {
+            continue;
+        }
+        var_q_sign[i] = sign_of(diag[i]);
+        let q = diag[i].abs();
+        if q < floor {
+            var_status[i] = UNIDENTIFIED;
+            var_ratio[i] = sigma_x[i] / floor;
+            continue;
+        }
+        let r = sigma_x[i] / q;
+        var_ratio[i] = r;
+        var_status[i] = classify(r, mu);
+        var_off[i] = (has_l[i] && off_path(s_l[i], z_l[i], mu))
+            || (has_u[i] && off_path(s_u[i], z_u[i], mu));
+        var_cont[i] = var_status[i] == INACTIVE && r > CONTAMINATION_FLOOR;
+    }
+
+    // --- inequality rows ----------------------------------------------
+    let rhas_l = present(&pd_l, m_d);
+    let rhas_u = present(&pd_u, m_d);
+    let v_l = expand(&dense_to_vec(mult_v_l.as_ref()), &pd_l, m_d);
+    let v_u = expand(&dense_to_vec(mult_v_u.as_ref()), &pd_u, m_d);
+    let rs_l = expand(&dense_to_vec(cq.curr_slack_s_l().as_ref()), &pd_l, m_d);
+    let rs_u = expand(&dense_to_vec(cq.curr_slack_s_u().as_ref()), &pd_u, m_d);
+    let sigma_s = dense_to_vec(cq.curr_sigma_s().as_ref());
+
+    let jac_d = cq.curr_jac_d();
+    let mspace = DenseVectorSpace::new(m_d as i32);
+    let mut e_row = DenseVector::new(mspace);
+    let nspace = DenseVectorSpace::new(n as i32);
+    let mut grad = DenseVector::new(nspace.clone());
+    let mut hgrad = DenseVector::new(nspace);
+
+    let mut row_status = vec![UNBOUNDED; m_d];
+    let mut row_ratio = vec![Number::NAN; m_d];
+    let mut row_q_sign = vec![0i8; m_d];
+    let mut row_off = vec![false; m_d];
+    for j in 0..m_d {
+        if !(rhas_l[j] || rhas_u[j]) {
+            continue;
+        }
+        // ∇dⱼ = Jdᵀ eⱼ, then the curvature along the normal;
+        // values_mut throughout because a zero product may leave the
+        // output homogeneous (empty backing slice behind values())
+        e_row.values_mut().fill(0.0);
+        e_row.values_mut()[j] = 1.0;
+        grad.values_mut().fill(0.0);
+        jac_d.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
+        let norm2: Number = grad.values_mut().iter().map(|g| *g * *g).sum();
+        if norm2 <= 0.0 {
+            continue;
+        }
+        hgrad.values_mut().fill(0.0);
+        hess.mult_vector(1.0, &grad, 0.0, &mut hgrad);
+        let ghg: Number = {
+            let h = hgrad.values_mut();
+            grad.values_mut()
+                .iter()
+                .zip(h.iter())
+                .map(|(g, h)| g * h)
+                .sum()
+        };
+        let q_signed = ghg / norm2;
+        row_q_sign[j] = sign_of(q_signed);
+        let q = q_signed.abs();
+        if q < floor {
+            row_status[j] = UNIDENTIFIED;
+            row_ratio[j] = sigma_s[j] / floor;
+            continue;
+        }
+        let r = sigma_s[j] / q;
+        row_ratio[j] = r;
+        row_status[j] = classify(r, mu);
+        row_off[j] = (rhas_l[j] && off_path(rs_l[j], v_l[j], mu))
+            || (rhas_u[j] && off_path(rs_u[j], v_u[j], mu));
+    }
+
+    ActivityReport {
+        mu,
+        var_status,
+        var_ratio,
+        var_q_sign,
+        var_off_central_path: var_off,
+        var_contaminated: var_cont,
+        row_status,
+        row_ratio,
+        row_q_sign,
+        row_off_central_path: row_off,
+    }
+}

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -125,6 +125,14 @@ struct ConjPair {
 }
 
 impl PdSensBacksolver {
+    /// The retained handles the activity classifier reads
+    /// (crate-internal; see [`crate::activity`]).
+    pub(crate) fn activity_handles(
+        &self,
+    ) -> (&IpoptDataHandle, &IpoptCqHandle, &Rc<RefCell<dyn IpoptNlp>>) {
+        (&self.data, &self.cq, &self.nlp)
+    }
+
     /// Construct from the four handles handed in by the `on_converged`
     /// callback. Errors if `data` has no `curr` (i.e. the algorithm
     /// never reached an iterate — should not happen on

--- a/crates/pounce-sensitivity/src/lib.rs
+++ b/crates/pounce-sensitivity/src/lib.rs
@@ -63,6 +63,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+pub mod activity;
 pub mod algorithm_backsolver;
 pub mod backsolver;
 pub mod boundcheck;

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -242,13 +242,14 @@ impl Solver {
     /// perturbed bounds, and the complementarity products the
     /// classifier reads no longer track `μ`.
     pub fn classify_activity(&self) -> Result<ActivityReport, SolverError> {
+        // the registry supplies its own default when the option is
+        // unset, so no second copy of the default lives here
         let brf = self
             .app
             .options()
             .get_numeric_value("bound_relax_factor", "")
-            .ok()
-            .and_then(|(v, f)| f.then_some(v))
-            .unwrap_or(1e-8);
+            .map(|(v, _)| v)
+            .expect("bound_relax_factor is a registered core option");
         if brf != 0.0 {
             return Err(SolverError::BadOptions(format!(
                 "classify_activity requires bound_relax_factor=0 \

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -64,6 +64,7 @@ use crate::vec_util::dense_to_vec;
 
 /// Errors returned by post-convergence operations on [`Solver`].
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum SolverError {
     /// The solver has not yet converged, or the last solve failed
     /// before producing a usable KKT factor.

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -56,6 +56,7 @@ use pounce_nlp::TNLP;
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 
 use crate::PdSensBacksolver;
+use crate::activity::ActivityReport;
 use crate::backsolver::SensBacksolver;
 use crate::schur_data::IndexSchurData;
 use crate::sens_app::{SensApplication, SensOptions};
@@ -83,6 +84,10 @@ pub enum SolverError {
     /// The underlying [`SensApplication`] step failed (e.g. row mapping
     /// invalid for the current problem).
     SensComputationFailed(String),
+    /// An option the requested computation depends on holds an
+    /// incompatible value; the message names the option and the value
+    /// required.
+    BadOptions(String),
 }
 
 /// State captured at convergence: the user-visible iterate plus the
@@ -225,6 +230,35 @@ impl Solver {
     /// no converged factor is held.
     pub fn block_dims(&self) -> Option<[usize; 8]> {
         self.converged().map(|c| c.block_dims())
+    }
+
+    /// Classify every bounded variable and every finite-bounded
+    /// inequality row of the converged solve by activity: see
+    /// [`crate::activity`] and
+    /// `dev-notes/covariance-information-roadmap.md` item 0 (gh #362).
+    ///
+    /// Requires `bound_relax_factor=0` (the Ipopt default is `1e-8`):
+    /// with relaxed bounds the solver's slacks are measured against
+    /// perturbed bounds, and the complementarity products the
+    /// classifier reads no longer track `μ`.
+    pub fn classify_activity(&self) -> Result<ActivityReport, SolverError> {
+        let brf = self
+            .app
+            .options()
+            .get_numeric_value("bound_relax_factor", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(1e-8);
+        if brf != 0.0 {
+            return Err(SolverError::BadOptions(format!(
+                "classify_activity requires bound_relax_factor=0 \
+                 (currently {brf:e}): relaxed bounds shift the slacks \
+                 the classifier reads"
+            )));
+        }
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        Ok(crate::activity::compute(&state.backsolver))
     }
 
     /// Solve `K · lhs = rhs` against the converged KKT factor. Both

--- a/python/tests/test_activity.py
+++ b/python/tests/test_activity.py
@@ -151,8 +151,9 @@ def test_variable_bound_regimes(p, status):
 def test_variable_bound_ratio_scales():
     # on the central path z·s = μ with unit curvature: r ≈ μ inactive,
     # r ≈ 1/μ strongly active, r ≈ 1 weakly active
-    mu = _solve_bound(1.0)["mu"]
-    assert _solve_bound(1.0)["var_ratio"][0] == pytest.approx(mu, rel=10.0)
+    rep_in = _solve_bound(1.0)
+    mu = rep_in["mu"]
+    assert rep_in["var_ratio"][0] == pytest.approx(mu, rel=10.0)
     assert _solve_bound(-1.0)["var_ratio"][0] > 1.0 / np.sqrt(mu)
     assert _solve_bound(0.0)["var_ratio"][0] == pytest.approx(1.0, rel=0.5)
 
@@ -196,7 +197,8 @@ def test_relaxed_bounds_are_refused():
     prob.add_option("print_level", 0)
     prob.add_option("sb", "yes")
     solver = pounce.Solver(prob)
-    solver.solve(x0=np.array([0.5]))
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
     with pytest.raises(ValueError, match="bound_relax_factor"):
         solver.classify_activity()
 
@@ -208,3 +210,93 @@ def test_classify_before_solve_raises():
     ))
     with pytest.raises(RuntimeError, match="no converged factor"):
         pounce.Solver(prob).classify_activity()
+
+
+def test_loose_mu_reports_ambiguous():
+    # the weakly active geometry solved only to μ = 1e-2: r ≈ 1 sits in
+    # the fixed band, but at this μ the edges give it no margin, so the
+    # classifier refuses rather than guesses
+    prob = pounce.Problem(
+        n=1, m=0, problem_obj=ScalarBound(0.0),
+        lb=[0.0], ub=[1e19], cl=[], cu=[],
+    )
+    prob.add_option("mu_target", 1e-2)
+    # the outer test measures unbarriered complementarity, which the
+    # μ-floored point holds at ~1e-2, so both gates must sit above it
+    prob.add_option("tol", 5e-2)
+    prob.add_option("compl_inf_tol", 5e-2)
+    prob.add_option("bound_relax_factor", 0.0)
+    prob.add_option("print_level", 0)
+    prob.add_option("sb", "yes")
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    rep = solver.classify_activity()
+    assert rep["mu"] == pytest.approx(1e-2, rel=1e-6)
+    assert rep["var_status"] == ["ambiguous"]
+    assert rep["var_ratio"][0] == pytest.approx(1.0, rel=0.5)
+
+
+class MixedModel:
+    """Four variables, two constraints, every status in one report:
+
+    min ½(x0-5)² + ½(x1+1)² + ½(x2-2)² + ½(x3+1)²
+    s.t. x0 + x2 = 7        (equality row)
+         x1 >= 0            (inequality row, pulled active by the objective)
+         0 <= x0 <= 10      (two-sided bound, inactive: x0* = 5)
+         x2 = 2             (fixed variable, removed internally)
+         x3 >= 0            (bound, pulled active)
+         x1 free
+    """
+
+    def objective(self, x):
+        return 0.5 * ((x[0] - 5) ** 2 + (x[1] + 1) ** 2
+                      + (x[2] - 2) ** 2 + (x[3] + 1) ** 2)
+
+    def gradient(self, x):
+        return np.array([x[0] - 5, x[1] + 1, x[2] - 2, x[3] + 1])
+
+    def constraints(self, x):
+        return np.array([x[0] + x[2], x[1]])
+
+    def jacobianstructure(self):
+        rows = np.array([0, 0, 1], dtype=np.int64)
+        cols = np.array([0, 2, 1], dtype=np.int64)
+        return rows, cols
+
+    def jacobian(self, x):
+        return np.array([1.0, 1.0, 1.0])
+
+    def hessianstructure(self):
+        idx = np.array([0, 1, 2, 3], dtype=np.int64)
+        return idx, idx
+
+    def hessian(self, x, lagrange, obj_factor):
+        return obj_factor * np.ones(4)
+
+
+def test_mixed_model_reports_in_user_space():
+    # a fixed variable is removed from the internal solve
+    # (make_parameter); the report must keep the user's indices, with
+    # the fixed slot marked rather than everything after it shifted,
+    # and rows indexed by the user's constraint order with the
+    # equality as a placeholder
+    prob = _options(pounce.Problem(
+        n=4, m=2, problem_obj=MixedModel(),
+        lb=[0.0, -1e19, 2.0, 0.0], ub=[10.0, 1e19, 2.0, 1e19],
+        cl=[7.0, 0.0], cu=[7.0, 1e19],
+    ))
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([4.0, 0.5, 2.0, 0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    rep = solver.classify_activity()
+    assert rep["var_status"] == [
+        "inactive", "unbounded", "fixed", "strongly_active",
+    ]
+    assert rep["row_status"] == ["equality", "strongly_active"]
+    assert len(rep["var_ratio"]) == 4 and len(rep["row_ratio"]) == 2
+    assert np.isnan(rep["var_ratio"][1]) and np.isnan(rep["var_ratio"][2])
+    assert np.isnan(rep["row_ratio"][0])
+    assert rep["var_q_sign"][0] == 1 and rep["var_q_sign"][3] == 1
+    assert rep["row_q_sign"][1] == 1
+    assert not any(rep["var_contaminated"]) and not any(rep["row_contaminated"])

--- a/python/tests/test_activity.py
+++ b/python/tests/test_activity.py
@@ -1,0 +1,210 @@
+"""`Solver.classify_activity`: post-solve activity classification
+(dev-notes/covariance-information-roadmap.md item 0, gh #362).
+
+The scalar study model min ½x² − p·x with x ≥ 0 walks the three
+regimes by moving the unconstrained minimizer: p > 0 puts it inside
+(bound inactive), p < 0 outside (strongly active), p = 0 exactly on
+the bound (weakly active: slack and multiplier both O(√μ), where no
+fixed threshold on either alone can classify). The same geometry
+written as an inequality row (x unbounded, row x ≥ 0) must classify
+identically: that is the gh #362 shape, where the activity lives on a
+row and never shows up in the bound multipliers.
+"""
+
+import numpy as np
+import pytest
+
+import pounce
+
+
+class ScalarBound:
+    """min ½x² − p·x with the bound on the variable: x ≥ 0."""
+
+    def __init__(self, p):
+        self.p = p
+
+    def objective(self, x):
+        return 0.5 * x[0] ** 2 - self.p * x[0]
+
+    def gradient(self, x):
+        return np.array([x[0] - self.p])
+
+    def constraints(self, x):
+        return np.array([])
+
+    def jacobianstructure(self):
+        empty = np.array([], dtype=np.int64)
+        return empty, empty
+
+    def jacobian(self, x):
+        return np.array([])
+
+    def hessianstructure(self):
+        return np.array([0], dtype=np.int64), np.array([0], dtype=np.int64)
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([obj_factor])
+
+
+class ScalarRow:
+    """min ½x² − p·x with the bound as an inequality row: g(x) = x ≥ 0,
+    the variable itself unbounded."""
+
+    def __init__(self, p):
+        self.p = p
+
+    def objective(self, x):
+        return 0.5 * x[0] ** 2 - self.p * x[0]
+
+    def gradient(self, x):
+        return np.array([x[0] - self.p])
+
+    def constraints(self, x):
+        return np.array([x[0]])
+
+    def jacobianstructure(self):
+        zero = np.array([0], dtype=np.int64)
+        return zero, zero
+
+    def jacobian(self, x):
+        return np.array([1.0])
+
+    def hessianstructure(self):
+        return np.array([0], dtype=np.int64), np.array([0], dtype=np.int64)
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([obj_factor])
+
+
+class LinearBox:
+    """min −x on 0 ≤ x ≤ 1: zero curvature everywhere, so activity is
+    below the identification floor no matter how hard the bound binds."""
+
+    def objective(self, x):
+        return -x[0]
+
+    def gradient(self, x):
+        return np.array([-1.0])
+
+    def constraints(self, x):
+        return np.array([])
+
+    def jacobianstructure(self):
+        empty = np.array([], dtype=np.int64)
+        return empty, empty
+
+    def jacobian(self, x):
+        return np.array([])
+
+    def hessianstructure(self):
+        empty = np.array([], dtype=np.int64)
+        return empty, empty
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([])
+
+
+def _options(p):
+    p.add_option("tol", 1e-10)
+    p.add_option("bound_relax_factor", 0.0)
+    p.add_option("print_level", 0)
+    p.add_option("sb", "yes")
+    return p
+
+
+def _solve_bound(p):
+    prob = _options(pounce.Problem(
+        n=1, m=0, problem_obj=ScalarBound(p),
+        lb=[0.0], ub=[1e19], cl=[], cu=[],
+    ))
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    return solver.classify_activity()
+
+
+def _solve_row(p):
+    prob = _options(pounce.Problem(
+        n=1, m=1, problem_obj=ScalarRow(p),
+        lb=[-1e19], ub=[1e19], cl=[0.0], cu=[1e19],
+    ))
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    return solver.classify_activity()
+
+
+@pytest.mark.parametrize("p, status", [
+    (1.0, "inactive"),
+    (-1.0, "strongly_active"),
+    (0.0, "weakly_active"),
+])
+def test_variable_bound_regimes(p, status):
+    rep = _solve_bound(p)
+    assert rep["var_status"] == [status]
+    assert rep["var_q_sign"][0] == 1
+    assert not rep["var_off_central_path"][0]
+    assert not rep["var_contaminated"][0]
+    assert rep["mu"] < 1e-4
+
+
+def test_variable_bound_ratio_scales():
+    # on the central path z·s = μ with unit curvature: r ≈ μ inactive,
+    # r ≈ 1/μ strongly active, r ≈ 1 weakly active
+    mu = _solve_bound(1.0)["mu"]
+    assert _solve_bound(1.0)["var_ratio"][0] == pytest.approx(mu, rel=10.0)
+    assert _solve_bound(-1.0)["var_ratio"][0] > 1.0 / np.sqrt(mu)
+    assert _solve_bound(0.0)["var_ratio"][0] == pytest.approx(1.0, rel=0.5)
+
+
+@pytest.mark.parametrize("p, status", [
+    (1.0, "inactive"),
+    (-1.0, "strongly_active"),
+    (0.0, "weakly_active"),
+])
+def test_row_agrees_with_bound(p, status):
+    # gh #362: the same geometry moved onto an inequality row classifies
+    # identically, and the now-unbounded variable reports as such
+    rep = _solve_row(p)
+    assert rep["row_status"] == [status]
+    assert rep["row_q_sign"][0] == 1
+    assert rep["var_status"] == ["unbounded"]
+    assert np.isnan(rep["var_ratio"][0])
+
+
+def test_zero_curvature_is_unidentified():
+    prob = _options(pounce.Problem(
+        n=1, m=0, problem_obj=LinearBox(),
+        lb=[0.0], ub=[1.0], cl=[], cu=[],
+    ))
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    rep = solver.classify_activity()
+    assert rep["var_status"] == ["unidentified"]
+    assert rep["var_q_sign"][0] == 0
+
+
+def test_relaxed_bounds_are_refused():
+    # bound_relax_factor defaults to 1e-8; the classifier's slacks and
+    # complementarity products assume unperturbed bounds
+    prob = pounce.Problem(
+        n=1, m=0, problem_obj=ScalarBound(1.0),
+        lb=[0.0], ub=[1e19], cl=[], cu=[],
+    )
+    prob.add_option("tol", 1e-10)
+    prob.add_option("print_level", 0)
+    prob.add_option("sb", "yes")
+    solver = pounce.Solver(prob)
+    solver.solve(x0=np.array([0.5]))
+    with pytest.raises(ValueError, match="bound_relax_factor"):
+        solver.classify_activity()
+
+
+def test_classify_before_solve_raises():
+    prob = _options(pounce.Problem(
+        n=1, m=0, problem_obj=ScalarBound(1.0),
+        lb=[0.0], ub=[1e19], cl=[], cu=[],
+    ))
+    with pytest.raises(RuntimeError, match="no converged factor"):
+        pounce.Solver(prob).classify_activity()

--- a/python/tests/test_activity.py
+++ b/python/tests/test_activity.py
@@ -47,11 +47,13 @@ class ScalarBound:
 
 
 class ScalarRow:
-    """min ½x² − p·x with the bound as an inequality row: g(x) = x ≥ 0,
-    the variable itself unbounded."""
+    """min ½x² − p·x with the bound as an inequality row: g(x) = c·x ≥ 0,
+    the variable itself unbounded. The coefficient c changes the row's
+    units, not its geometry, so classification must not move with it."""
 
-    def __init__(self, p):
+    def __init__(self, p, c=1.0):
         self.p = p
+        self.c = c
 
     def objective(self, x):
         return 0.5 * x[0] ** 2 - self.p * x[0]
@@ -60,14 +62,14 @@ class ScalarRow:
         return np.array([x[0] - self.p])
 
     def constraints(self, x):
-        return np.array([x[0]])
+        return np.array([self.c * x[0]])
 
     def jacobianstructure(self):
         zero = np.array([0], dtype=np.int64)
         return zero, zero
 
     def jacobian(self, x):
-        return np.array([1.0])
+        return np.array([self.c])
 
     def hessianstructure(self):
         return np.array([0], dtype=np.int64), np.array([0], dtype=np.int64)
@@ -123,9 +125,9 @@ def _solve_bound(p):
     return solver.classify_activity()
 
 
-def _solve_row(p):
+def _solve_row(p, c=1.0):
     prob = _options(pounce.Problem(
-        n=1, m=1, problem_obj=ScalarRow(p),
+        n=1, m=1, problem_obj=ScalarRow(p, c),
         lb=[-1e19], ub=[1e19], cl=[0.0], cu=[1e19],
     ))
     solver = pounce.Solver(prob)
@@ -171,6 +173,60 @@ def test_row_agrees_with_bound(p, status):
     assert rep["row_q_sign"][0] == 1
     assert rep["var_status"] == ["unbounded"]
     assert np.isnan(rep["var_ratio"][0])
+
+
+@pytest.mark.parametrize("c", [1.0, 100.0, 1000.0])
+@pytest.mark.parametrize("p, status", [
+    (1.0, "inactive"),
+    (-1.0, "strongly_active"),
+    (0.0, "weakly_active"),
+])
+def test_row_classification_is_scale_invariant(c, p, status):
+    # d -> c*d sends Sigma -> Sigma/c^2 while the curvature along the
+    # unit normal is unchanged; the ||grad||^4 normalization restores
+    # the balance, so the status cannot move with the row's units
+    # (second review's blocking finding)
+    rep = _solve_row(p, c=c)
+    assert rep["row_status"] == [status]
+
+
+def test_row_scale_invariance_without_nlp_scaling():
+    # gradient-based scaling (the default) caps the distortion the old
+    # ratio suffered; with scaling off nothing does, so this is the
+    # sharp version: the weakly active ratio must sit at 1 exactly
+    prob = pounce.Problem(
+        n=1, m=1, problem_obj=ScalarRow(0.0, 1000.0),
+        lb=[-1e19], ub=[1e19], cl=[0.0], cu=[1e19],
+    )
+    prob.add_option("tol", 1e-10)
+    prob.add_option("bound_relax_factor", 0.0)
+    prob.add_option("nlp_scaling_method", "none")
+    prob.add_option("print_level", 0)
+    prob.add_option("sb", "yes")
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    rep = solver.classify_activity()
+    assert rep["row_status"] == ["weakly_active"]
+    assert rep["row_ratio"][0] == pytest.approx(1.0, rel=0.5)
+
+
+def test_near_bound_inactive_flags_contamination():
+    # lb at distance 0.01 from the optimum: genuinely inactive, but the
+    # barrier contributes r = mu/s^2, about 1e4 times the O(mu) an
+    # inactive bound should carry; the mu-relative rule flags it while
+    # the far-bound cases above stay clean
+    prob = _options(pounce.Problem(
+        n=1, m=0, problem_obj=ScalarBound(1.0),
+        lb=[0.99], ub=[1e19], cl=[], cu=[],
+    ))
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.995]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    rep = solver.classify_activity()
+    assert rep["var_status"] == ["inactive"]
+    assert rep["var_contaminated"][0]
+    assert not rep["var_off_central_path"][0]
 
 
 def test_zero_curvature_is_unidentified():


### PR DESCRIPTION
_Description corrected after merge to match what actually landed: the row formula gained its fourth power, the `μ > 1e-4` wording was wrong about the geometry, and the contamination rule became μ-relative. The original text is preserved in the review thread below._

Implements item 0 of the covariance/information roadmap (#262): post-solve activity classification for bounded variables and inequality rows, closing the mechanism gap behind #362.

## What

`Solver.classify_activity()` (Rust core: new `pounce_sensitivity::activity` module) classifies every bounded variable and every finite-bounded inequality row of the held converged solve on the ratio of barrier curvature to the model's own curvature:

```
r = Σ / q,   Σ = z/s summed over the sides that exist
             q = |H_ii|                 (variable)
                 |∇dᵀH∇d| / ‖∇d‖⁴       (inequality row)
```

`r` is O(μ) when the bound is inactive, O(1) when weakly active, O(1/μ) when strongly active, so one ratio separates the regimes where no fixed threshold on a slack or multiplier alone can (both are O(√μ) at weak activity). Edges at √μ and 1/√μ, fixed inner band [1e-1, 1e1], `ambiguous` in the gaps; the μ-edges meet the band at μ = 1e-2 and a full decade separates them from it at μ = 1e-4, so above 1e-4 — where that margin is thinning — only the two calls that stay clear are made and the middle is honest refusal. Curvature below `√ε·max(1, max_j|H_jj|)` reports `unidentified` with the sign of the raw value.

The row denominator carries the **fourth** power so that `r` is invariant to rescaling the row: `d → c·d` sends `Σ → Σ/c²` while the curvature along the unit normal is unchanged. Equivalently, the geometric barrier weight `Σ‖∇d‖²` (the distance to the surface is `d/‖∇d‖`, its conjugate multiplier `v‖∇d‖`) is measured against the curvature along the unit normal. Variable bounds are invariant as written. This also absorbs the solver's own per-row `d_scale`, so `nlp_scaling_method` cannot move a status either.

Per-entry runtime flags: `off_central_path` (s·z differs from μ by more than 10x on some side) and `contaminated` (classified inactive yet `r > 100μ` — `inactive` MEANS `r = O(μ)`, so the threshold is μ-relative; a fixed constant could never sit below the inactive edge `√μ` at a converged μ). The call refuses to run with `bound_relax_factor != 0` (the Ipopt default is 1e-8): relaxed bounds shift the slacks the classifier reads.

## Why rows too

That is #362's shape: move a variable bound onto a linear inequality row and the activity disappears from the bound-multiplier view entirely, silently breaking any covariance/activity heuristic keyed on z alone. Rows classify through the same rule via the curvature along the constraint normal, and the tests require the two formulations of the same scalar geometry to classify identically — at any row coefficient.

## Implementation notes

- Everything the classifier reads was already retained at convergence: `Σ` (`curr_sigma_x`/`curr_sigma_s`), the solver's own slacks, the bound multipliers on the iterate, `μ`, and the exact Lagrangian Hessian (`curr_exact_hessian`, so `H` is never recovered from the barrier-augmented factor). Item 0 is exposure plus the rule, not new computation.
- `H_ii` comes from one pass over the Hessian triplet structure. Row curvature gathers each Jacobian row's support in one triplet pass and takes the product over that support against a Hessian adjacency view, so a row costs its own support times its neighbours rather than a full mat-vec pair; the mat-vec loop survives as the fallback for any future non-triplet matrix type. Compressed bound-side vectors scatter to full length through the existing `ExpansionMatrix` machinery.
- The report is indexed in **user space**: `var_*` follows the user's `n` variables and `row_*` the user's `m` constraints, in their order. A variable removed by `fixed_variable_treatment = make_parameter` (`lb == ub`) reports `fixed` at its own index and an equality row reports `equality`, so user indices never shift.
- `BoundClassification` gained a `full_to_c` inverse map, making `full_g_to_c_block` O(1) for every caller rather than a linear scan of `c_map`.
- One crate-internal accessor on `PdSensBacksolver` hands the classifier the retained handles; no public surface changes besides `Solver::classify_activity()` and a `SolverError::BadOptions` variant (the enum is now `#[non_exhaustive]`).
- Python: `Solver.classify_activity()` returns a dict (statuses as strings, ratios/signs as ndarrays); raises `ValueError` on nonzero `bound_relax_factor`, `RuntimeError` before a converged solve.

## Tests

`python/tests/test_activity.py`: the scalar study model min ½x² − px with x ≥ 0 walks all three regimes by moving the unconstrained minimizer (p>0 inactive, p<0 strongly active, p=0 weakly active, where slack and multiplier are both O(√μ)); the same geometry as an inequality row classifies identically (the #362 agreement case) and the now-unbounded variable reports `unbounded`; the row cases repeat at coefficients 1, 100 and 1000 plus a `nlp_scaling_method=none` case pinning r = 1.0 exactly, so scale invariance is enforced rather than assumed; a linear objective on a box reports `unidentified`; ratio magnitudes track μ, 1, and 1/μ on the central path; a near-bound inactive case drives `contaminated` true end to end; a mixed model pins the user-space indexing (two-sided bound, fixed variable, equality plus an active row in one report); the `bound_relax_factor` precondition and the not-converged path raise. Rust unit tests cover `classify()`, `off_path`, the contamination rule and the identification floor directly.

Refs #262 (roadmap, item 0), #362. Items 1-4 follow as separate PRs in roadmap order. No closing keyword by intent: item 0 classifies; the `covariance()` fix for #362 is item 1, so the issue stays open until item 1 lands.