### PR TITLE
Fix #372: diagnose a trivially infeasible NLP at tight tol instead of Restoration_Failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a trivially infeasible NLP was reported as `Restoration_Failed` at tight `tol` (#372)
+
+- **A visibly contradictory model now reports `Infeasible_Problem_Detected`
+  (AMPL `solve_result_num` 200, Pyomo `TerminationCondition.infeasible`) at any
+  user `tol`, not just the default.** The reporter's model is a one-variable
+  contradiction — `min x³ + x²  s.t.  x ≥ 0.7`, `0 ≤ x ≤ 0.6` — which Ipopt
+  3.14.16 diagnoses as `Converged to a locally infeasible point`. POUNCE
+  returned `Restoration_Failed`, which lands in the AMPL 500 *failure* range
+  and surfaces through Pyomo as `SolverStatus.error` /
+  `TerminationCondition.internalSolverError`, leaving client code unable to
+  distinguish a mathematically infeasible model from a solver bug.
+  - Root cause: the trigger was the reporter's `tol=1e-10`, not the model — the
+    identical model at the default `tol=1e-8` was already diagnosed correctly.
+    The locally-infeasible gates in `resto_inner_solver.rs` all key off *how*
+    the restoration inner sub-IPM terminated. At a tight `tol` the inner
+    reaches the same stationary point of the feasibility problem
+    (`inner_kkt_err ≈ 1.2e-10`, `orig_inf_pr = 1.0e-1`) but can no longer
+    certify it against its own, equally tightened, convergence test — every
+    remaining step is below the tiny-step threshold, so it exits
+    `StopAtTinyStep` rather than `Success`. No gate admitted that status, so a
+    correct infeasibility diagnosis was discarded and the solve fell through to
+    `Restoration_Failed`.
+  - Fix: a `tiny_step_locally_infeasible` gate. A step shrunk to machine
+    precision *is* the numerical stationarity evidence, so unlike the `strict`
+    gate it does not additionally demand `inner_kkt_err ≤ 10·outer_tol` — the
+    threshold the inner cannot reach at tight `tol`, which is exactly how the
+    case arises. It keeps the `alt` gate's looser `1e-2` KKT ceiling to reject
+    inners that stalled without ever approaching stationarity, and mirrors
+    `strict`'s `!is_square_problem` guard and `max(100·outer_tol, 1e-4)`
+    violation floor, so a merely near-feasible kappa-guard exit still cannot
+    manufacture a false infeasibility verdict.
+  - The AMPL status mapping is unchanged: `Restoration_Failed` stays in the 500
+    range, matching Ipopt's own `AmplTNLP` mapping. The defect was the
+    classification, not the mapping.
+  - Regression: `crates/pounce-cli/tests/issue_372_infeasible_bounds_status.rs`
+    pins the reporter's exact option set, sweeps `tol` from `1e-6` to `1e-12`,
+    and asserts the result is never advertised in the AMPL *solved* family.
+
 ### Tests — pyomo-pounce: the shadowing-binary test failed on any source checkout (#366)
 
 - `test_check_binary_flags_a_shadowing_build` asserted that a different-build

--- a/crates/pounce-cli/tests/fixtures/issue_372_infeasible_bounds.nl
+++ b/crates/pounce-cli/tests/fixtures/issue_372_infeasible_bounds.nl
@@ -1,0 +1,31 @@
+g3 1 1 0	# problem unknown
+ 1 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 10 1	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#impossible
+n0
+O0 0	#objective
+o0	#+
+o5	#^
+v0	#x
+n3
+o5	#^
+v0	#x
+n2
+x1	# initial guess
+0 0.5	#x
+r	#1 ranges (rhs's)
+2 0.7	#impossible
+b	#1 bounds (on variables)
+0 0.0 0.6	#x
+k0	#intermediate Jacobian column lengths
+J0 1	#impossible
+0 1
+G0 1	#objective
+0 0

--- a/crates/pounce-cli/tests/issue_372_infeasible_bounds_status.rs
+++ b/crates/pounce-cli/tests/issue_372_infeasible_bounds_status.rs
@@ -1,0 +1,185 @@
+//! gh #372 — a trivially infeasible bounded NLP must be diagnosed as locally
+//! infeasible (AMPL 200 range) at *any* user `tol`, not just the default.
+//!
+//! Fixture `issue_372_infeasible_bounds.nl` is the reporter's Pyomo model:
+//!
+//! ```text
+//! min  x^3 + x^2   s.t.  x >= 0.7,   0 <= x <= 0.6
+//! ```
+//!
+//! The contradiction is visible directly in the model — the bound caps `x` at
+//! `0.6` while the constraint demands `x >= 0.7`. Ipopt 3.14.16 reports
+//! `Converged to a locally infeasible point`; POUNCE reported
+//! `Restoration_Failed`, which lands in the AMPL 500 *failure* range and
+//! surfaces through Pyomo as `SolverStatus.error` /
+//! `TerminationCondition.internalSolverError` — indistinguishable from a
+//! solver implementation bug.
+//!
+//! The trigger was the reporter's `tol=1e-10`, not the model. At the default
+//! `tol=1e-8` the restoration inner sub-IPM converges (`Success`) and the
+//! `strict` gate in `resto_inner_solver.rs` correctly declares local
+//! infeasibility. At `tol <= 1e-10` the inner reaches the same stationary
+//! point of the feasibility problem (`inner_kkt_err ~ 1.2e-10`,
+//! `orig_inf_pr = 1.0e-1`) but can no longer certify it against its own,
+//! equally tightened, convergence test — every remaining step is below the
+//! tiny-step threshold, so it exits `StopAtTinyStep`. No gate admitted that
+//! status, so the diagnosis was thrown away and the solve fell through to
+//! `Restoration_Failed`. The `tiny_step_locally_infeasible` gate closes it.
+//!
+//! Regression coverage requested in the issue:
+//!   1. this one-variable `.nl` shape in the restoration tests,
+//!   2. an infeasible (non-internal) status, and
+//!   3. no candidate solution advertised as optimal.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("issue_372_infeasible_bounds.nl");
+    p
+}
+
+fn solve_result_num(text: &str) -> i32 {
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("objno ") {
+            if let Some(code) = rest.split_whitespace().nth(1) {
+                return code.parse().expect("objno code parses");
+            }
+        }
+    }
+    panic!("no `objno` line in .sol:\n{text}");
+}
+
+/// Solve the fixture under `-AMPL` with `extra` options appended, returning
+/// the `.sol` text. `tag` keeps concurrent test cases off each other's files.
+fn solve(tag: &str, extra: &[&str]) -> String {
+    let sol = std::env::temp_dir().join(format!("pounce_issue372_{tag}.sol"));
+    let _ = std::fs::remove_file(&sol);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .args(extra)
+        .output()
+        .expect("spawn pounce");
+
+    // Under `-AMPL` the termination travels in the file, so exit stays 0.
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+
+    std::fs::read_to_string(&sol).expect("read .sol")
+}
+
+/// The core regression: the reporter's exact option set must produce the
+/// AMPL *infeasible* range, not the *failure* range.
+#[test]
+fn reporter_option_set_is_infeasible_not_failure() {
+    let text = solve(
+        "reporter",
+        &[
+            "print_level=0",
+            "tol=1.0e-10",
+            "bound_relax_factor=0.0",
+            "honor_original_bounds=yes",
+            "max_cpu_time=30.0",
+        ],
+    );
+    let srn = solve_result_num(&text);
+
+    assert!(
+        (200..300).contains(&srn),
+        "expected the AMPL infeasible range (200..299) for `0 <= x <= 0.6, \
+         x >= 0.7`, got solve_result_num={srn}. The 500 failure range makes \
+         Pyomo report TerminationCondition.internalSolverError, which client \
+         code cannot distinguish from a solver bug:\n{text}"
+    );
+    assert!(
+        !text.contains("RestorationFailed"),
+        "a one-inequality contradiction must not be reported as a restoration \
+         failure:\n{text}"
+    );
+    assert!(
+        text.contains("InfeasibleProblemDetected"),
+        "expected the InfeasibleProblemDetected verdict:\n{text}"
+    );
+}
+
+/// The diagnosis must not depend on `tol`. `1e-8` is the default (which
+/// already worked); `1e-10` and `1e-12` are past the point where the
+/// restoration inner sub-IPM can still exit `Success`.
+#[test]
+fn diagnosis_is_stable_across_tolerances() {
+    for (tag, tol) in [
+        ("t6", "1e-6"),
+        ("t8", "1e-8"),
+        ("t10", "1e-10"),
+        ("t12", "1e-12"),
+    ] {
+        let text = solve(tag, &["print_level=0", &format!("tol={tol}")]);
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "tol={tol}: expected the AMPL infeasible range (200..299), got \
+             solve_result_num={srn}. A tighter user tolerance must not turn a \
+             certified infeasibility into a restoration failure:\n{text}"
+        );
+    }
+}
+
+/// Deliverable 3 from the issue: the nonoptimal result must never be
+/// advertised in the AMPL *solved* family, which is what makes Pyomo load the
+/// returned point as `optimal`.
+#[test]
+fn never_reported_as_solved() {
+    let text = solve("solved_family", &["print_level=0", "tol=1.0e-10"]);
+    let srn = solve_result_num(&text);
+
+    assert!(
+        !(0..200).contains(&srn),
+        "an infeasible model reported in the AMPL solved family \
+         (solve_result_num={srn}); 0..99 = solved and 100..199 = \
+         solved-with-warning both make Pyomo report \
+         TerminationCondition.optimal:\n{text}"
+    );
+}
+
+/// Outside `-AMPL` the console verdict must say local infeasibility and the
+/// process must exit non-zero, matching what the library reports.
+#[test]
+fn cli_reports_local_infeasibility_and_exits_nonzero() {
+    let out = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg("tol=1.0e-10")
+        .output()
+        .expect("spawn pounce");
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    assert!(
+        combined.contains("point of local infeasibility"),
+        "expected the local-infeasibility verdict:\n{combined}"
+    );
+    assert!(
+        !combined.contains("Restoration Failed"),
+        "must not report a restoration failure for a visible \
+         contradiction:\n{combined}"
+    );
+    assert_ne!(
+        out.status.code(),
+        Some(0),
+        "an infeasible solve must exit non-zero outside -AMPL mode"
+    );
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -622,14 +622,40 @@ pub fn run_inner_resto(
         && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-3)
         && orig_inf_pr_at_final.is_finite();
 
+    // Tiny-step locally-infeasible gate (gh #372). At a tight user `tol`
+    // the inner sub-IPM can drive the resto NLP to its stationary point
+    // and then be unable to certify it against its own (equally tight)
+    // convergence test — every remaining step is below the tiny-step
+    // threshold, so it exits `StopAtTinyStep` instead of `Success`. The
+    // reproducer is `0 <= x <= 0.6, x >= 0.7` at `tol=1e-10`: the inner
+    // stops after 13 iters with `inner_kkt_err = 1.2e-10` and
+    // `orig_inf_pr = 1.0e-1`, and every gate above rejects the exit
+    // status, so a one-inequality contradiction landed in
+    // `Restoration_Failed` (AMPL 500, Pyomo `internalSolverError`) while
+    // the identical model at the default `tol=1e-8` exits `Success` and
+    // is correctly diagnosed. A step that has shrunk to machine
+    // precision IS the numerical stationarity evidence, so unlike
+    // `strict` this gate does not additionally demand `inner_kkt_err <=
+    // 10*outer_tol` (a threshold the inner cannot reach at tight `tol`,
+    // which is exactly how the case arises); it uses the `alt` gate's
+    // looser `1e-2` KKT ceiling to reject inners that stalled without
+    // ever approaching stationarity. `!is_square_problem` and the
+    // `max(100*outer_tol, 1e-4)` violation floor mirror `strict`.
+    let tiny_step_locally_infeasible = !is_square_problem
+        && matches!(status, SolverReturn::StopAtTinyStep)
+        && inner_kkt_err <= 1e-2
+        && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-4)
+        && orig_inf_pr_at_final.is_finite();
+
     let locally_infeasible = strict_locally_infeasible
         || alt_locally_infeasible
         || cycle_locally_infeasible
-        || step_failure_locally_infeasible;
+        || step_failure_locally_infeasible
+        || tiny_step_locally_infeasible;
 
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
         tracing::debug!(target: "pounce::restoration",
-            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} → loc_inf={}",
+            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} tiny_step={} → loc_inf={}",
             status,
             inner_iter_count,
             inner_kkt_err,
@@ -639,6 +665,7 @@ pub fn run_inner_resto(
             alt_locally_infeasible,
             cycle_locally_infeasible,
             step_failure_locally_infeasible,
+            tiny_step_locally_infeasible,
             locally_infeasible
         );
     }


### PR DESCRIPTION
Fixes #372

## What was wrong

The reporter's model is a one-variable contradiction:

```
min  x^3 + x^2   s.t.  x >= 0.7,   0 <= x <= 0.6
```

Ipopt 3.14.16 diagnoses it as `Converged to a locally infeasible point`.
POUNCE returned `Restoration_Failed`, which lands in the AMPL 500 *failure*
range and surfaces through Pyomo as `SolverStatus.error` /
`TerminationCondition.internalSolverError` — leaving client code unable to
distinguish a mathematically infeasible model from a solver bug.

## Root cause

**The trigger was the reporter's `tol=1e-10`, not the model.** The identical
model at the default `tol=1e-8` was already diagnosed correctly — that is why
the bug looked model-specific.

The locally-infeasible gates in `resto_inner_solver.rs` all key off *how* the
restoration inner sub-IPM terminated. Sweeping `tol` makes the mechanism
obvious (`POUNCE_DBG_RESTO_LOCINF=1`):

| `tol` | inner exit | `inner_kkt_err` | `orig_inf_pr` | gate fired | verdict |
|---|---|---|---|---|---|
| `1e-6`  | `Success`         | 2.3e-07 | 1.0e-01 | `strict` | 200 infeasible |
| `1e-8`  | `Success`         | 3.1e-10 | 1.0e-01 | `strict` | 200 infeasible |
| `1e-10` | `StopAtTinyStep`  | 1.2e-10 | 1.0e-01 | *none*   | **500 failure** |
| `1e-12` | `StopAtTinyStep`  | 1.2e-10 | 1.0e-01 | *none*   | **500 failure** |

At a tight `tol` the inner reaches the *same* stationary point of the
feasibility problem, but can no longer certify it against its own, equally
tightened, convergence test — every remaining step is below the tiny-step
threshold, so it exits `StopAtTinyStep` rather than `Success`. No gate admitted
that status, so a correct infeasibility diagnosis was discarded and the solve
fell through to `Restoration_Failed`.

## The fix

A `tiny_step_locally_infeasible` gate. A step shrunk to machine precision *is*
the numerical stationarity evidence, so unlike the `strict` gate it does not
additionally demand `inner_kkt_err <= 10*outer_tol` — the threshold the inner
cannot reach at tight `tol`, which is exactly how the case arises.

Guards against a false infeasibility verdict:

- `inner_kkt_err <= 1e-2` (the `alt` gate's ceiling) rejects inners that
  stalled without ever approaching stationarity.
- `orig_inf_pr > max(100*outer_tol, 1e-4)` — the `strict` gate's violation
  floor — so a merely near-feasible kappa-guard exit cannot trip it.
- `!is_square_problem`, mirroring `strict`.
- Downstream, the CLI's existing `feral_infeasibility_scaling_retry` still
  re-solves with MC64 scaling before believing any infeasibility verdict.

**The AMPL status mapping is deliberately unchanged.** The issue also suggested
surfacing restoration failure as a non-internal termination, but Ipopt's own
`AmplTNLP.cpp:919` maps `RESTORATION_FAILURE` to 501 — also in the 500 failure
range. POUNCE's 500 matches upstream; the defect was the classification, not the
mapping.

## Verification

End-to-end through the reporter's exact Pyomo path, POUNCE now matches the
IPOPT reference output exactly:

```
solver-status=warning
termination-condition=infeasible
message=POUNCE 0.9.0\x3a InfeasibleProblemDetected
solutions=1
```

- New regression test `crates/pounce-cli/tests/issue_372_infeasible_bounds_status.rs`
  (4 cases) pins the reporter's exact option set, sweeps `tol` from `1e-6` to
  `1e-12`, asserts the result is never advertised in the AMPL *solved* family,
  and checks the non-`-AMPL` console verdict and exit code. 3 of the 4 fail on
  the parent commit.
- Full workspace suite: **2161 passed, 0 failed**.
- `false_local_infeasibility.rs` — the dedicated guard against exactly this
  class of false-positive regression — passes (5/5).
- `pyomo-pounce` suite: 131 passed.
- Before/after status sweep over 477 real `.nl` problems from the benchmark
  corpus (every 3rd problem, 20s cap): **no problem changed verdict**, identical
  status distributions. Worth stating precisely — that sample had no
  `RestorationFailed` in the baseline, so it is evidence the new gate introduces
  no *false* infeasibility verdicts, not evidence that it fires anywhere beyond
  the reported case.
- `cargo fmt` clean; `cargo clippy` produces no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
