### PR TITLE
Add `make coverage`: combined Rust + Python coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,10 @@ pyomo-pounce/pyomo_pounce.egg-info/
 # release and not part of the published book — docs/src/ holds that. Pattern
 # rather than the exact file so the next version doesn't reappear untracked.
 docs/linkedin-v*.org
+
+# LLVM coverage profiles. `make coverage` points LLVM_PROFILE_FILE at
+# target/coverage-combined/profraw, but the instrumented extension module keeps
+# emitting profiles for any process that imports it — so running pytest (or a
+# bare `python -c 'import pounce'`) outside that scope drops a
+# default_*.profraw wherever you happened to be. Ignore them everywhere.
+*.profraw

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,21 @@ CLI, and the installed `.so` — as an explicit `-object`. It needs
   corrupt a solve, and it would otherwise crowd out the gaps that can.
 - `lcov.info` — for editor/CI consumption.
 
-Two things to know before running it:
+As a sanity check that the attribution actually worked: `crates/pounce-py/*`
+is reachable *only* through the extension module, so those rows read 0% in a
+Rust-only report and 60–90% here. If you see `pounce-py` at zero, the `.so`
+did not get attributed and the whole report is suspect.
+
+Three things to know before running it:
 
 - **The run leaves `python/pounce/_pounce*.so` built with instrumentation**,
   which is slower and can upset timing-sensitive tests. Restore it with
-  `make python-ext`.
+  `make python-ext` (or `cd python && maturin develop --release`).
+- **`test_qp_solve_releases_the_gil` fails during the run.** That is expected,
+  not a regression: it asserts that a QP solve actually releases the GIL by
+  timing concurrent threads, and the instrumentation overhead breaks the
+  timing margin. It passes normally once the extension is restored. Any *other*
+  failure is worth investigating.
 - **Build everything under instrumentation first, then run, then report.**
   Rebuilding any artifact between profiling and reporting changes its
   coverage-mapping hash and silently yields a 0% report. The script already

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,3 +72,39 @@ These run on every PR; run them locally before pushing to get fast feedback:
   from `SUMMARY.md` and every TOC link resolves.
 - `cargo fmt --all -- --check`, `cargo clippy`, `cargo test`, and the Python
   test suite (see `.github/workflows/ci.yml`).
+
+## Measuring coverage (`make coverage`)
+
+Use `make coverage` (or `make coverage-quick` to skip the slow pytest suite),
+**not** `cargo llvm-cov --workspace`.
+
+`cargo llvm-cov` instruments and runs only the Rust test suite. Large parts of
+POUNCE are exercised solely through the Python extension (`pounce._pounce`) or
+through the CLI driven by pytest/pyomo, and those paths read as 0% in a
+Rust-only report. That makes the report actively misleading as a "what is
+under-tested?" signal: it invents gaps that are in fact well covered. Nor can
+`cargo llvm-cov report` fix this after the fact — it has no `--object` flag, so
+it can never attribute the extension module's profile data.
+
+`scripts/coverage-combined.sh` therefore drives `llvm-profdata` / `llvm-cov`
+directly and passes every instrumented artifact — the Rust test binaries, the
+CLI, and the installed `.so` — as an explicit `-object`. It needs
+`rustup component add llvm-tools-preview`. Outputs land under
+`target/coverage-combined/`:
+
+- `summary.txt` — per-file table across all sources.
+- `core.txt` — the numerical core only (`pounce-algorithm`, `pounce-qp`,
+  `pounce-linsol`, …), ranked by uncovered regions. Diagnostics, dump, and
+  binary paths are excluded deliberately: low coverage there is real but cannot
+  corrupt a solve, and it would otherwise crowd out the gaps that can.
+- `lcov.info` — for editor/CI consumption.
+
+Two things to know before running it:
+
+- **The run leaves `python/pounce/_pounce*.so` built with instrumentation**,
+  which is slower and can upset timing-sensitive tests. Restore it with
+  `make python-ext`.
+- **Build everything under instrumentation first, then run, then report.**
+  Rebuilding any artifact between profiling and reporting changes its
+  coverage-mapping hash and silently yields a 0% report. The script already
+  orders itself this way; keep that invariant if you edit it.

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 #   make build            # release build (alias)
 #   make debug            # debug build
 #   make test             # run all tests
+#   make coverage         # combined Rust + Python coverage report
+#   make coverage-quick   # same, skipping the slow pytest suite
 #   make check            # cargo check
 #   make clippy           # lint with clippy (treats warnings as errors)
 #   make fmt              # rustfmt the workspace
@@ -70,7 +72,7 @@ endif
 
 .PHONY: all build debug test check clippy fmt fmt-check doc book screencast install uninstall clean help \
         install-mcp uninstall-mcp install-skill uninstall-skill pounce-ma57 \
-        python-ext python-cli-bin python-test \
+        python-ext python-cli-bin python-test coverage coverage-quick \
         benchmark benchmark-rerun benchmark-report benchmark-gams
 
 all: build
@@ -83,6 +85,24 @@ debug:
 
 test:
 	$(CARGO) test --workspace $(CARGO_PROFILE_FLAG) $(CARGO_FLAGS)
+
+# ---- Coverage ------------------------------------------------------------
+# `cargo llvm-cov --workspace` instruments only the Rust test suite, so every
+# path reached solely through the Python extension or the pytest/pyomo-driven
+# CLI reads as 0% — which turns the report into a source of invented gaps
+# rather than a usable "what is under-tested?" signal. `coverage` drives
+# llvm-profdata / llvm-cov directly and attributes every instrumented artifact
+# (Rust test binaries, the CLI, and the installed extension module), so the
+# number reflects what the whole project actually exercises.
+#
+# Note: the run leaves `python/pounce/_pounce*.so` built WITH instrumentation,
+# which is slower and can upset timing-sensitive tests. Restore it with
+# `make python-ext` (or `cd python && maturin develop --release`).
+coverage:
+	scripts/coverage-combined.sh
+
+coverage-quick:
+	scripts/coverage-combined.sh --quick
 
 check:
 	$(CARGO) check --workspace $(CARGO_FLAGS)

--- a/scripts/coverage-combined.sh
+++ b/scripts/coverage-combined.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Combined Rust + Python coverage for pounce.
+#
+# WHY THIS EXISTS
+# ---------------
+# `cargo llvm-cov --workspace` instruments and runs only the *Rust* test suite.
+# Large parts of pounce are exercised solely through the Python extension
+# (`pounce._pounce`) or through the CLI driven by pytest/pyomo. Those paths show
+# up as 0% in a Rust-only report, which makes the report actively misleading as
+# a "what is under-tested?" signal: it invents gaps that are in fact covered.
+#
+# `cargo llvm-cov report` cannot fix this on its own — it has no `--object`
+# flag, so it can never attribute the extension module's profile data. This
+# script therefore drives `llvm-profdata` / `llvm-cov` directly and passes every
+# instrumented artifact (Rust test binaries + CLI + the installed .so) as an
+# explicit `-object`.
+#
+# THE ONE RULE: build everything under instrumentation FIRST, then run, then
+# report. Rebuilding any artifact between profiling and reporting changes its
+# coverage-mapping hash and silently yields a 0% report.
+#
+# Usage:
+#   scripts/coverage-combined.sh              # full run, summary to stdout
+#   scripts/coverage-combined.sh --quick      # skip the slow pytest suite
+#   COV_OUT=/tmp/cov scripts/coverage-combined.sh
+#
+# Outputs (under $COV_OUT, default target/coverage-combined):
+#   summary.txt   per-file table, all sources
+#   core.txt      numerical-core files ranked by uncovered regions
+#   lcov.info     for editor/CI consumption
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO" || exit 1
+COV_OUT="${COV_OUT:-$REPO/target/coverage-combined}"
+PROFDIR="$COV_OUT/profraw"
+QUICK=0
+[ "${1:-}" = "--quick" ] && QUICK=1
+
+LLVMBIN="$(dirname "$(rustc --print target-libdir)")/bin"
+for t in llvm-profdata llvm-cov; do
+  [ -x "$LLVMBIN/$t" ] || { echo "FATAL: $t not found in $LLVMBIN"; echo "  rustup component add llvm-tools-preview"; exit 1; }
+done
+
+rm -rf "$COV_OUT"; mkdir -p "$PROFDIR"
+export RUSTFLAGS="-C instrument-coverage ${RUSTFLAGS:-}"
+export LLVM_PROFILE_FILE="$PROFDIR/pounce-%p-%m.profraw"
+
+echo "==> [1/5] building instrumented Rust test binaries"
+# --no-run so nothing executes before every artifact exists.
+cargo test --workspace --no-run --message-format=json 2>/dev/null \
+  | python3 -c '
+import json,sys
+for line in sys.stdin:
+    try: m=json.loads(line)
+    except ValueError: continue
+    exe=m.get("executable")
+    if exe: print(exe)
+' | sort -u > "$COV_OUT/objects.txt"
+echo "    $(wc -l < "$COV_OUT/objects.txt") test binaries"
+
+echo "==> [2/5] building instrumented CLI + Python extension"
+cargo build --workspace >/dev/null 2>&1
+[ -x target/debug/pounce ] && echo target/debug/pounce >> "$COV_OUT/objects.txt"
+(cd python && maturin develop --release 2>&1 | tail -1)
+SO="$(python -c 'import pounce._pounce as m; print(m.__file__)')"
+echo "$SO" >> "$COV_OUT/objects.txt"
+echo "    extension: $SO"
+
+echo "==> [3/5] running Rust tests"
+cargo test --workspace >/dev/null 2>&1
+echo "==> [4/5] running Python + pyomo suites"
+if [ "$QUICK" = "1" ]; then
+  (cd python && python -m pytest tests/ -q -x -k "problem or minimize" 2>&1 | tail -1)
+else
+  (cd python && python -m pytest tests/ -q 2>&1 | tail -1)
+  python -m pytest pyomo-pounce/tests -q 2>&1 | tail -1
+fi
+
+echo "==> [5/5] merging $(find "$PROFDIR" -name '*.profraw' | wc -l | tr -d ' ') profraw files and reporting"
+"$LLVMBIN/llvm-profdata" merge -sparse "$PROFDIR"/*.profraw -o "$COV_OUT/merged.profdata" || exit 1
+
+OBJARGS=(); while read -r o; do [ -e "$o" ] && OBJARGS+=(-object "$o"); done < "$COV_OUT/objects.txt"
+IGNORE='(/\.cargo/registry|/rustc/|/library/std|/tests?/|_test\.rs$)'
+
+"$LLVMBIN/llvm-cov" report "${OBJARGS[@]}" \
+  -instr-profile="$COV_OUT/merged.profdata" \
+  -ignore-filename-regex="$IGNORE" > "$COV_OUT/summary.txt" 2>/dev/null
+
+"$LLVMBIN/llvm-cov" export "${OBJARGS[@]}" \
+  -instr-profile="$COV_OUT/merged.profdata" \
+  -ignore-filename-regex="$IGNORE" -format=lcov > "$COV_OUT/lcov.info" 2>/dev/null
+
+# Numerical core only: where a coverage gap can hide a silently-wrong answer.
+# Diagnostics/dump/binaries are deliberately excluded — low coverage there is
+# real but cannot corrupt a solve.
+python3 - "$COV_OUT" <<'PY'
+import sys, os
+out = sys.argv[1]
+CORE = ('pounce-algorithm','pounce-qp','pounce-convex','pounce-nlp','pounce-linsol',
+        'pounce-feral','pounce-restoration','pounce-presolve','pounce-l1penalty',
+        'pounce-sensitivity','pounce-linalg','pounce-common','pounce-nl')
+SKIP = ('debug.rs','iter_dump.rs','iterate_dump.rs','console.rs','output.rs')
+# Examples/benches/bins are not shipped solve paths: 0% there is expected and
+# would otherwise dominate the ranking and crowd out real gaps.
+SKIPDIR = ('/examples/','/benches/','/bin/')
+rows=[]
+for l in open(os.path.join(out,'summary.txt')):
+    p=l.split()
+    if len(p)<10 or 'crates/' not in p[0]: continue
+    try: rows.append((p[0], int(p[1]), int(p[2]), float(p[3].rstrip('%'))))
+    except ValueError: pass
+core=[r for r in rows
+      if any(f'/{c}/' in r[0] for c in CORE)
+      and not any(r[0].endswith(s) for s in SKIP)
+      and not any(d in r[0] for d in SKIPDIR)]
+with open(os.path.join(out,'core.txt'),'w') as f:
+    if core:
+        tot=sum(r[1] for r in core); mis=sum(r[2] for r in core)
+        f.write(f"numerical core: {100*(1-mis/tot):.1f}% region coverage "
+                f"({mis} uncovered of {tot}) across {len(core)} files\n\n")
+        f.write(f"{'file':64s} {'regions':>8s} {'uncov':>7s} {'cov%':>7s}\n")
+        for r in sorted(core, key=lambda r:-r[2])[:30]:
+            f.write(f"{r[0].replace('crates/',''):64s} {r[1]:8d} {r[2]:7d} {r[3]:6.1f}%\n")
+    else:
+        f.write("no core rows parsed - check summary.txt\n")
+print(open(os.path.join(out,'core.txt')).read())
+PY
+
+echo "wrote: $COV_OUT/{summary.txt,core.txt,lcov.info}"
+echo
+echo "NOTE: this leaves python/pounce/_pounce.abi3.so built WITH instrumentation"
+echo "      (slower, and timing-sensitive tests may fail). Restore with:"
+echo "      cd python && maturin develop --release"

--- a/scripts/coverage-combined.sh
+++ b/scripts/coverage-combined.sh
@@ -61,20 +61,33 @@ echo "    $(wc -l < "$COV_OUT/objects.txt") test binaries"
 
 echo "==> [2/5] building instrumented CLI + Python extension"
 cargo build --workspace >/dev/null 2>&1
-[ -x target/debug/pounce ] && echo target/debug/pounce >> "$COV_OUT/objects.txt"
+# Absolute path: cargo's JSON already reports absolute executables, so a
+# relative entry here would hand llvm-cov the same object twice.
+[ -x target/debug/pounce ] && echo "$REPO/target/debug/pounce" >> "$COV_OUT/objects.txt"
 (cd python && maturin develop --release 2>&1 | tail -1)
 SO="$(python -c 'import pounce._pounce as m; print(m.__file__)')"
 echo "$SO" >> "$COV_OUT/objects.txt"
 echo "    extension: $SO"
 
+# Run a pytest suite, surfacing which tests failed. Piping straight to
+# `tail -1` keeps the output short but hides the FAILED lines, which turns a
+# single failure into a full re-run to find out what broke.
+run_pytest() {
+  local label="$1"; shift
+  local log="$COV_OUT/pytest-$label.log"
+  "$@" > "$log" 2>&1
+  grep -E '^(FAILED|ERROR)' "$log" | sed 's/^/    /'
+  tail -1 "$log" | sed 's/^/    /'
+}
+
 echo "==> [3/5] running Rust tests"
 cargo test --workspace >/dev/null 2>&1
 echo "==> [4/5] running Python + pyomo suites"
 if [ "$QUICK" = "1" ]; then
-  (cd python && python -m pytest tests/ -q -x -k "problem or minimize" 2>&1 | tail -1)
+  (cd python && run_pytest python python -m pytest tests/ -q -x -k "problem or minimize")
 else
-  (cd python && python -m pytest tests/ -q 2>&1 | tail -1)
-  python -m pytest pyomo-pounce/tests -q 2>&1 | tail -1
+  (cd python && run_pytest python python -m pytest tests/ -q)
+  run_pytest pyomo python -m pytest pyomo-pounce/tests -q
 fi
 
 echo "==> [5/5] merging $(find "$PROFDIR" -name '*.profraw' | wc -l | tr -d ' ') profraw files and reporting"


### PR DESCRIPTION
## What this is

`scripts/coverage-combined.sh` has been sitting in the working tree untracked,
uncommitted, and referenced by nothing — so it was undiscoverable to anyone who
didn't already know it existed. This commits it and wires it in.

## Why it exists

`cargo llvm-cov --workspace` instruments and runs only the **Rust** test suite.
Large parts of POUNCE are exercised solely through the Python extension
(`pounce._pounce`) or through the CLI driven by pytest/pyomo, and those paths
read as 0% in a Rust-only report.

That makes the report actively misleading as a *"what is under-tested?"* signal:
it invents gaps that are in fact well covered, so the ranking you'd actually act
on is dominated by noise.

`cargo llvm-cov report` cannot fix it after the fact either — it has no
`--object` flag, so it can never attribute the extension module's profile data.
The script therefore drives `llvm-profdata` / `llvm-cov` directly and passes
every instrumented artifact (Rust test binaries + CLI + the installed `.so`) as
an explicit `-object`.

## What's added

- `scripts/coverage-combined.sh`.
- `make coverage` / `make coverage-quick`, listed in `make help`.
- A **CONTRIBUTING.md** section: why not to reach for `cargo llvm-cov
  --workspace`, what each output means, and the invariants that bite.

Outputs land under `target/coverage-combined/`: `summary.txt` (all sources),
`core.txt` (numerical core ranked by uncovered regions, excluding
diagnostics/dump/bin paths where a gap is real but cannot corrupt a solve), and
`lcov.info`.

## Verification

**Ran `make coverage` end to end.** It works, and produces real numbers rather
than the silent 0% report that the mis-ordered-build failure mode yields:

```
==> [1/5] building instrumented Rust test binaries   -> 155 test binaries
==> [2/5] building instrumented CLI + Python extension
==> [3/5] running Rust tests
==> [4/5] running Python + pyomo suites              -> 799 + 131 passed
==> [5/5] merging 1278 profraw files and reporting

numerical core: 86.7% region coverage (15139 uncovered of 114101) across 175 files
```

The attribution demonstrably works: `crates/pounce-py/*` is reachable **only**
through the extension module and reads 60–90% here (`problem.rs` 84%,
`nl_problem.rs` 89%, `tnlp_bridge.rs` 62%). A Rust-only `cargo llvm-cov` shows
those at 0% — which is the entire point of the script.

Also `shellcheck` clean, `bash -n` clean, `make help` renders correctly, and both
`make -n coverage` / `make -n coverage-quick` resolve. The extension was restored
to an uninstrumented build afterward.

## Fixed while verifying

Running it surfaced three things, each fixed in its own commit:

1. **`target/debug/pounce` was passed to llvm-cov twice.** cargo's
   `--message-format json` already reports absolute paths, and the CLI was
   appended again as a relative path — 157 entries for 156 distinct files.
2. **A pytest failure was invisible.** Both suites were piped to `tail -1`, so
   the run printed `1 failed, 799 passed` and nothing more; finding out *which*
   test broke meant re-running the whole 3-minute suite. I hit exactly this.
   Both suites now go through a `run_pytest` helper that echoes the
   FAILED/ERROR lines above the summary.
3. **Stray `*.profraw` files.** The instrumented `.so` emits a profile for any
   process that imports it, so running pytest outside the script's scope drops
   `default_*.profraw` into the cwd. Now gitignored.

## One expected failure, documented

`test_qp_solve_releases_the_gil` fails *during* a coverage run. It asserts a QP
solve releases the GIL by timing concurrent threads, and instrumentation
overhead breaks the timing margin. I confirmed it passes once the extension is
restored (`1 passed in 0.76s`). CONTRIBUTING.md now records this, and notes that
any *other* failure is worth investigating.

## Unrelated finding

`make python-ext` fails in a tree where `python/pounce/bin/pounce` is a
**symlink** to `target/release/pounce` (mine is, dated Jul 19): `install` refuses
because source and destination are the same file. Pre-existing and out of scope
here, but it does mean the documented restore path can fail — worth a follow-up
if you want the Makefile to tolerate a symlinked stage.

Not a user-facing change, so no CHANGELOG entry or book section (per the
definition of done in CONTRIBUTING.md, which scopes those to user-visible
behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
