### PR TITLE
Fix `make python-ext` when the staged CLI is a symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,20 @@ help:
 # A stale binary that still works is far worse than one that fails.
 #
 # `python/pounce/bin/` is already gitignored for exactly this artifact.
+#
+# The `rm -f` before `install` is load-bearing. If the staged path is a symlink
+# back to $(CLI_BIN) — an easy thing to set up by hand, since it makes the stage
+# track rebuilds automatically — then `install` sees one file, refuses with
+# "are the same file", and exits 64. That takes down `python-ext` and
+# `python-test` with it, including the restore step `make coverage` tells you to
+# run. Removing the destination first makes the target idempotent whatever is
+# there (real file, symlink, or nothing) and keeps the stage a real copy, which
+# is what the wheel ships. `rm -f` on a symlink unlinks the symlink, not
+# $(CLI_BIN).
 python-cli-bin:
 	$(CARGO) build -p pounce-cli $(CARGO_PROFILE_FLAG) $(CARGO_FLAGS)
 	install -d python/pounce/bin
+	rm -f python/pounce/bin/pounce
 	install -m 0755 "$(CLI_BIN)" python/pounce/bin/pounce
 
 python-ext: python-cli-bin


### PR DESCRIPTION
Follow-up to #374, where this surfaced.

## The failure

`python-cli-bin` stages the CLI into `python/pounce/bin/` with `install`. If
that path is already a **symlink back to `$(CLI_BIN)`** — an easy thing to set
up by hand, since it makes the stage track rebuilds automatically — `install`
sees source and destination as one file and bails:

```
install: target/release/pounce and python/pounce/bin/pounce are the same file
make: *** [python-cli-bin] Error 64
```

`python-ext` and `python-test` both depend on it, so both go down with it.

That matters more than a broken convenience target: `make python-ext` is the
restore step `make coverage` (and the CONTRIBUTING section added in #374) tells
you to run after a coverage run leaves `_pounce*.so` instrumented. The
documented way back to a clean build was itself broken, and only in the trees
where someone had set up the symlink — so it would look like it worked for
everyone who tested it.

## The fix

Remove the destination before installing:

```make
install -d python/pounce/bin
rm -f python/pounce/bin/pounce
install -m 0755 "$(CLI_BIN)" python/pounce/bin/pounce
```

That makes the target idempotent whatever is there — real file, symlink, or
nothing — and keeps the stage a **real copy**, which is what the wheel ships and
what the surrounding comment block already describes as the intent.

`rm -f` on a symlink unlinks the symlink, not its target. I verified `$(CLI_BIN)`
survives, since deleting the build output would have been a much worse bug than
the one being fixed.

## Verification

All four starting states now succeed:

| starting state of `python/pounce/bin/pounce` | before | after |
|---|---|---|
| symlink to `$(CLI_BIN)` | **exit 64** | ok |
| existing real file | ok | ok |
| missing file | ok | ok |
| missing directory | ok | ok |

Plus:

- `target/release/pounce` still present after the symlink case — `rm -f` did not
  follow the link.
- Staged binary runs (`pounce 0.9.0`) and is byte-identical to `$(CLI_BIN)`
  (`cmp` clean).
- `make python-ext` completes (exit 0).
- `make python-test` completes: **800 passed**.

Dev-tooling fix with no user-visible behavior change, so no CHANGELOG entry or
book section per the definition of done in CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
