### PR TITLE
Fix an infeasible model's verdict depending on the user's `tol` (follow-up to #372)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — an infeasible model's verdict depended on the user's `tol` (follow-up to #372)
+
+- **A genuinely infeasible model now reports `Infeasible_Problem_Detected` (AMPL
+  200, Pyomo `TerminationCondition.infeasible`) at every tolerance.** Sweeping
+  `tol` across the other infeasible fixtures after #372 found a second,
+  independent instance of the same user-visible defect — pre-existing, and
+  triggered from the opposite end. `infeasible_equalities.nl` reported
+  `Error_In_Step_Computation` (AMPL 500, Pyomo `internalSolverError`) for
+  `tol >= 3e-7` and `Infeasible_Problem_Detected` for `tol <= 1e-7`, a
+  non-monotonic split on a model whose true constraint violation is `2.0`.
+  - Root cause: a **units mismatch**. The constraint violation was measured
+    *scaled* (`eval_c` returns `dc ⊙ c_user`; `curr_constraint_violation`
+    likewise) but compared against *absolute* floors —
+    `max(100·outer_tol, 1e-4)`. Those floors are user-facing magnitudes meaning
+    "the violation is meaningfully nonzero", so the comparison mixed two unit
+    systems. NLP scaling shrinks this fixture's rows by ~3e6, so a violation of
+    `2.0` read as `6.67e-7` and could never clear a `1e-4` floor.
+  - Two sites had to change, because the fixture is a *square* 2×2 system:
+    `resto_inner_solver::eval_orig_inf_pr_at_inner_curr`, which feeds every
+    restoration locally-infeasible gate; and `ipopt_alg`'s outer `cycle_exit`.
+    Square problems are deliberately carved out of the `strict` restoration
+    gate so the outer loop gets another attempt, which makes that cycle exit
+    their *only* locally-infeasible safety net — and the unit mismatch had
+    silently disabled it.
+  - `ipopt_cq::unscaled_block_amax` is now public and shared by both call sites
+    rather than duplicated, so the two cannot drift.
+  - The `cycle_exit` test also moves from a 1-norm to a max-norm. Max-norm ≤
+    1-norm, so it is marginally *stricter* about declaring infeasibility on an
+    unscaled problem — the safe direction for a verdict this consequential.
+  - Regression: `crates/pounce-cli/tests/infeasible_status_tol_invariance.rs`
+    sweeps four infeasible fixtures over `tol` from `1e-3` to `1e-12`
+    (including the `3e-7` value that failed while its neighbour `1e-7` passed)
+    and pins the tolerance-invariance property rather than specific tolerances.
+  - Verified no false-positive risk: across 477 real `.nl` problems the count of
+    `Infeasible_Problem_Detected` verdicts is unchanged (1 before, 1 after) and
+    no problem changed verdict.
+
 ### Fixed — a trivially infeasible NLP was reported as `Restoration_Failed` at tight `tol` (#372)
 
 - **A visibly contradictory model now reports `Infeasible_Problem_Detected`

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -2429,8 +2429,27 @@ impl IpoptAlgorithm {
         // honest exit is `LocalInfeasibility`. Below that threshold
         // the failure is numerical, not algorithmic, so retain
         // `ErrorInStepComputation`.
+        //
+        // The violation is measured **unscaled**. `reference_theta` is the
+        // row-scaled residual, but the floor below is an absolute, user-facing
+        // magnitude, so comparing the two mixes unit systems — and on a problem
+        // whose rows are scaled down the scaled residual can never clear it.
+        // `infeasible_equalities.nl` is the worked example: a square 2x2 system
+        // with a true violation of 2.0 that NLP scaling reports as 6.67e-7, so
+        // this test read `6.67e-7 > 1e-4` = false and a blatantly infeasible
+        // model exited `Error_In_Step_Computation` (AMPL 500, Pyomo
+        // `internalSolverError`). Square problems have no restoration-side
+        // locally-infeasible gate — `strict` carves them out so the outer gets
+        // another shot — so this cycle exit *is* their safety net, and it was
+        // disabled by the unit mismatch. Same user-visible family as gh #372.
+        //
+        // Note this also moves from a 1-norm (`curr_constraint_violation`) to a
+        // max-norm. Max-norm <= 1-norm, so the test is marginally stricter
+        // about declaring infeasibility on an unscaled problem — the safe
+        // direction for a verdict this consequential.
         let outer_tol_for_cycle = self.bundle.conv_check.tol_or_default();
-        let cycle_exit = if reference_theta > (100.0 * outer_tol_for_cycle).max(1e-4) {
+        let reference_theta_unscaled = self.cq.borrow().curr_unscaled_primal_infeasibility_max();
+        let cycle_exit = if reference_theta_unscaled > (100.0 * outer_tol_for_cycle).max(1e-4) {
             SolverReturn::LocalInfeasibility
         } else {
             SolverReturn::ErrorInStepComputation

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -74,7 +74,13 @@ fn rc_from(v: Box<dyn Vector>) -> Rc<dyn Vector> {
 /// the identity (no divide) so a degenerate scale never yields infinities.
 /// Falls back to `v.amax()` for a non-dense backing — POUNCE is dense-only,
 /// so that branch is defensive.
-fn unscaled_block_amax(v: &dyn Vector, scale: Option<&[Number]>) -> Number {
+///
+/// Public because `pounce-restoration`'s locally-infeasible gates compare a
+/// constraint violation against absolute floors (`1e-4` / `1e-3`) and so must
+/// measure it in the same user-facing units this produces — see
+/// `resto_inner_solver::eval_orig_inf_pr_at_inner_curr`. One definition, so
+/// the two call sites cannot drift.
+pub fn unscaled_block_amax(v: &dyn Vector, scale: Option<&[Number]>) -> Number {
     let Some(s) = scale else {
         return v.amax();
     };

--- a/crates/pounce-cli/tests/infeasible_status_tol_invariance.rs
+++ b/crates/pounce-cli/tests/infeasible_status_tol_invariance.rs
@@ -1,0 +1,154 @@
+//! An infeasible model's *verdict* must not depend on the user's `tol`.
+//!
+//! Follow-up to gh #372, which fixed one instance of this: a one-variable
+//! contradiction reported `Restoration_Failed` at `tol=1e-10` but
+//! `Infeasible_Problem_Detected` at the default `tol=1e-8`. Sweeping `tol`
+//! across the other infeasible fixtures found a second, independent instance
+//! in `infeasible_equalities.nl` — pre-existing, and triggered from the
+//! opposite end:
+//!
+//! ```text
+//!   tol >= 3e-7   ->  Error_In_Step_Computation   (AMPL 500)
+//!   tol <= 1e-7   ->  Infeasible_Problem_Detected (AMPL 200)
+//! ```
+//!
+//! Non-monotonic (`1e-7` passed, `3e-7` failed), and the 500 range surfaces
+//! through Pyomo as `internalSolverError` — indistinguishable from a solver
+//! bug on a model whose true constraint violation is `2.0`.
+//!
+//! Root cause was a units mismatch in two places. The constraint violation was
+//! measured **scaled** (`eval_c` returns `dc ⊙ c_user`; `curr_constraint_violation`
+//! likewise) but compared against *absolute* floors — `max(100·outer_tol, 1e-4)`.
+//! Those floors are user-facing magnitudes meaning "the violation is
+//! meaningfully nonzero", so the comparison mixed unit systems. NLP scaling
+//! shrinks this fixture's rows by ~3e6, so a violation of `2.0` read as
+//! `6.67e-7` and could never clear a `1e-4` floor.
+//!
+//! Two sites had to change, because the fixture is a *square* 2x2 system:
+//!   1. `resto_inner_solver::eval_orig_inf_pr_at_inner_curr` — feeds all the
+//!      restoration locally-infeasible gates.
+//!   2. `ipopt_alg`'s outer `cycle_exit` — square problems are carved out of
+//!      the `strict` restoration gate, so this cycle exit is their only
+//!      locally-infeasible safety net, and the unit mismatch had disabled it.
+//!
+//! The tests below pin the invariant rather than the specific tolerances, so
+//! they keep their value if the detection path is reworked again.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn solve_result_num(text: &str) -> i32 {
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("objno ") {
+            if let Some(code) = rest.split_whitespace().nth(1) {
+                return code.parse().expect("objno code parses");
+            }
+        }
+    }
+    panic!("no `objno` line in .sol:\n{text}");
+}
+
+fn solve_at_tol(model: &str, tag: &str, tol: &str) -> String {
+    let sol = std::env::temp_dir().join(format!("pounce_inf_tol_{tag}.sol"));
+    let _ = std::fs::remove_file(&sol);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture(model))
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("print_level=0")
+        .arg(format!("tol={tol}"))
+        .output()
+        .expect("spawn pounce");
+
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+    std::fs::read_to_string(&sol).expect("read .sol")
+}
+
+/// `tol` values spanning four orders of magnitude either side of the default,
+/// including `3e-7` — the value that failed while its neighbour `1e-7` passed.
+const TOLS: &[(&str, &str)] = &[
+    ("t3", "1e-3"),
+    ("t4", "1e-4"),
+    ("t5", "1e-5"),
+    ("t6", "1e-6"),
+    ("t3e7", "3e-7"),
+    ("t7", "1e-7"),
+    ("t8", "1e-8"),
+    ("t10", "1e-10"),
+    ("t12", "1e-12"),
+];
+
+/// The regression this fixes: a square, badly-scaled, genuinely infeasible
+/// system must land in the AMPL infeasible range at every `tol`.
+#[test]
+fn infeasible_equalities_verdict_is_tol_invariant() {
+    for (tag, tol) in TOLS {
+        let text = solve_at_tol("infeasible_equalities.nl", &format!("eq_{tag}"), tol);
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "tol={tol}: expected the AMPL infeasible range (200..299), got \
+             solve_result_num={srn}. This model's true constraint violation is \
+             2.0; NLP scaling reports it as ~6.67e-7. A verdict that depends on \
+             the user's tolerance makes an infeasible model look like an \
+             internal solver error to Pyomo:\n{text}"
+        );
+    }
+}
+
+/// The gh #372 shape, swept over the same range — guards the first instance
+/// from the opposite direction than `issue_372_infeasible_bounds_status.rs`
+/// covers.
+#[test]
+fn issue_372_bounds_verdict_is_tol_invariant() {
+    for (tag, tol) in TOLS {
+        let text = solve_at_tol("issue_372_infeasible_bounds.nl", &format!("b_{tag}"), tol);
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "tol={tol}: expected the AMPL infeasible range (200..299), got \
+             solve_result_num={srn}:\n{text}"
+        );
+    }
+}
+
+/// Whatever the tolerance, an infeasible model must never be advertised in the
+/// AMPL *solved* family — that is what makes Pyomo load the returned point as
+/// `optimal`. Separate from the range assertion above so a future change that
+/// trades one wrong verdict for a worse one is caught explicitly.
+#[test]
+fn infeasible_models_are_never_reported_solved() {
+    for model in [
+        "infeasible_equalities.nl",
+        "issue_372_infeasible_bounds.nl",
+        "infeasible_qp.nl",
+        "inconsistent_eq_qp.nl",
+    ] {
+        for (tag, tol) in TOLS {
+            let stem = model.trim_end_matches(".nl");
+            let text = solve_at_tol(model, &format!("ns_{stem}_{tag}"), tol);
+            let srn = solve_result_num(&text);
+            assert!(
+                !(0..200).contains(&srn),
+                "{model} at tol={tol} reported in the AMPL solved family \
+                 (solve_result_num={srn}); 0..99 = solved and 100..199 = \
+                 solved-with-warning both make Pyomo report \
+                 TerminationCondition.optimal:\n{text}"
+            );
+        }
+    }
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -43,7 +43,7 @@ use crate::resto_alg_builder::RestoAlgorithmBuilder;
 use crate::resto_nlp::BLOCK_X;
 use pounce_algorithm::alg_builder::{AlgorithmBuilder, LinearBackendFactory};
 use pounce_algorithm::ipopt_alg::IpoptAlgorithm;
-use pounce_algorithm::ipopt_cq::{IpoptCalculatedQuantities, IpoptCqHandle};
+use pounce_algorithm::ipopt_cq::{IpoptCalculatedQuantities, IpoptCqHandle, unscaled_block_amax};
 use pounce_algorithm::ipopt_data::{IpoptData, IpoptDataHandle};
 use pounce_algorithm::ipopt_nlp::IpoptNlp;
 use pounce_algorithm::iterates_vector::IteratesVector;
@@ -692,10 +692,27 @@ pub fn run_inner_resto(
 }
 
 /// Evaluate `max(||c(x_orig)||∞, ||d(x_orig) − s||∞)` at the inner
-/// IPM's converged iterate. Returns `None` on any downcast / dim
-/// mismatch (caller treats as `0.0` and the locally-infeasible gate
-/// fails closed — i.e. we don't spuriously declare infeasibility on
-/// a fixture we can't evaluate).
+/// IPM's converged iterate, in **unscaled** (user) units. Returns `None` on
+/// any downcast / dim mismatch (caller treats as `0.0` and the
+/// locally-infeasible gate fails closed — i.e. we don't spuriously declare
+/// infeasibility on a fixture we can't evaluate).
+///
+/// The unscaling is load-bearing, not cosmetic. `eval_c` / `eval_d` return the
+/// row-scaled residual (`c_scaled = dc ⊙ c_user`), while every gate above
+/// compares this value against an *absolute* floor — `max(100·outer_tol, 1e-4)`
+/// or `1e-3`. Those floors are user-facing magnitudes meaning "the constraint
+/// violation is meaningfully nonzero", so mixing them with a scaled residual
+/// compares two different unit systems.
+///
+/// On a problem whose constraint scaling is small the mismatch silently
+/// disables the gates. `infeasible_equalities.nl` is the worked example: NLP
+/// scaling shrinks the rows by ~3e6, so a true violation of `2.0` reads as
+/// `6.67e-7` scaled and can never clear a `1e-4` floor. The `strict` gate then
+/// fails on that one term alone (its KKT condition passes), the diagnosis is
+/// discarded, and a blatantly infeasible model exits `Error_In_Step_Computation`
+/// — the AMPL 500 failure range, Pyomo `internalSolverError`. Same user-visible
+/// family as gh #372, opposite trigger: this one bites at *loose* `tol`, where
+/// the surviving detector that masked it at `tol <= 1e-7` no longer fires.
 fn eval_orig_inf_pr_at_inner_curr(
     inner_x: &dyn Vector,
     inner_s: &dyn Vector,
@@ -706,10 +723,11 @@ fn eval_orig_inf_pr_at_inner_curr(
     let mut orig = orig_rc.borrow_mut();
     let m_eq = orig.m_eq();
     let m_ineq = orig.m_ineq();
+    let (dc, dd) = (orig.c_scale_vec(), orig.d_scale_vec());
     let c_amax = if m_eq > 0 {
         let mut buf = DenseVectorSpace::new(m_eq).make_new_dense();
         orig.eval_c(x_orig, &mut buf);
-        buf.amax()
+        unscaled_block_amax(&buf, dc.as_deref())
     } else {
         0.0
     };
@@ -717,7 +735,7 @@ fn eval_orig_inf_pr_at_inner_curr(
         let mut buf = DenseVectorSpace::new(m_ineq).make_new_dense();
         orig.eval_d(x_orig, &mut buf);
         buf.axpy(-1.0, inner_s);
-        buf.amax()
+        unscaled_block_amax(&buf, dd.as_deref())
     } else {
         0.0
     };


### PR DESCRIPTION
Follow-up to #372. Found by sweeping `tol` across the *other* infeasible
fixtures after that fix landed — a second, independent instance of the same
user-visible defect, pre-existing and triggered from the opposite end.

## The bug

`infeasible_equalities.nl` — a model whose true constraint violation is `2.0`:

| `tol` | verdict | AMPL |
|---|---|---|
| 1e-3 … 3e-7 | `Error_In_Step_Computation` | **500** |
| 1e-7 and tighter | `Infeasible_Problem_Detected` | 200 |

Non-monotonic — `1e-7` passed while its neighbour `3e-7` failed. The 500 range
surfaces through Pyomo as `internalSolverError`, indistinguishable from a solver
bug. Same family as #372, but that one bit at *tight* `tol` and this one bites at
*loose* `tol`.

This is pre-existing: I re-ran the pre-#372 binary and got identical behavior, so
the #372 fix neither caused nor masked it.

## Root cause: a units mismatch

The constraint violation was measured **scaled** — `eval_c` returns
`dc ⊙ c_user`, and `curr_constraint_violation` likewise — but compared against
**absolute** floors, `max(100·outer_tol, 1e-4)`.

Those floors are user-facing magnitudes meaning *"the violation is meaningfully
nonzero"*, so the comparison mixes two unit systems. NLP scaling shrinks this
fixture's rows by ~3e6, so a violation of `2.0` reads as `6.67e-7` and can never
clear a `1e-4` floor. The solver's own output shows the split directly:

```
Constraint violation....:   6.6666666666666671e-07    2.0000000000000000e+00
                                     (scaled)                (unscaled)
```

## Two sites, because the fixture is square

My first fix — unscaling in the restoration gate — was **not enough**, and the
gate trace showed why: `orig_inf_pr` corrected to `2.0`, but the verdict stayed
500. `infeasible_equalities.nl` is a *square* 2×2 system, and square problems are
deliberately carved out of the `strict` restoration gate so the outer loop gets
another attempt. So they have no restoration-side infeasibility gate at all —
their only safety net is `ipopt_alg`'s outer `cycle_exit`, which had the
identical units bug and was therefore silently disabled.

Both sites now measure the violation unscaled:

1. `resto_inner_solver::eval_orig_inf_pr_at_inner_curr` — feeds every
   restoration locally-infeasible gate.
2. `ipopt_alg`'s `cycle_exit` — the square-problem safety net.

`ipopt_cq::unscaled_block_amax` is made public and shared rather than
duplicated, so the two call sites cannot drift.

**One deliberate side effect**, called out in the code comment: `cycle_exit` also
moves from a 1-norm (`curr_constraint_violation`) to a max-norm. Max-norm ≤
1-norm, so the test becomes marginally *stricter* about declaring infeasibility
on an unscaled problem — the safe direction for a verdict this consequential.

## Verification

All four infeasible fixtures now report 200 uniformly across `tol` from `1e-3` to
`1e-14` (previously `infeasible_equalities` split at the `3e-7`/`1e-7` boundary).

- Workspace suite: **2171 passed, 0 failed**.
- New test `infeasible_status_tol_invariance.rs` (3 cases) fails on the parent
  commit, passes here. It pins the *invariance property* over a `tol` sweep
  rather than specific tolerances, so it keeps its value if the detection path is
  reworked again.
- **False-positive check** — the one that matters, since this makes an
  infeasibility gate fire more readily. Across 477 real `.nl` problems from the
  benchmark corpus the count of `Infeasible_Problem_Detected` verdicts is
  **unchanged (1 before, 1 after)**, and no problem changed verdict. The sweep
  initially flagged `ex1_320.nl` as changed; re-running it uncapped gives
  `SolveSucceeded` on *both* binaries in ~6s, so that was 8-way contention
  against the 20s cap, not a behavior difference.
- `cargo fmt` clean, no new clippy warnings, both consistency guards pass.

## Related observation (not addressed here)

While confirming the mathematics, I found that `pounce-presolve` *already proves*
this class of contradiction exactly, via bound propagation, and then discards the
proof:

```
WARN pounce::presolve: Phase 1 bound tightening proved the feasible region empty;
its crossed bounds are being discarded — the solve proceeds on the original box
so the IPM can certify infeasibility itself.
```

`lib.rs:654` explains why: *"Presolve has no channel to certify infeasibility."*
That is defensible — it stops a buggy reduction from fabricating a false verdict —
but it means POUNCE cannot distinguish **"proved infeasible"** (an exact FBBT /
Farkas certificate) from **"converged to a locally infeasible point"** (a
stationary point of the violation, which for a nonconvex problem proves nothing
globally). That distinction is precisely what the #372 reporter wanted
downstream. Left as a follow-up; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
