### PR TITLE
Mirror the benchmark corpus locally and route harnesses through one resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@
 !/benchmarks/README.md
 !/benchmarks/Makefile
 !/benchmarks/benchmark_report.py
+# The corpus-root resolver is source, not generated data — every harness
+# imports it, so it must be tracked despite the /benchmarks/* blanket ignore.
+!/benchmarks/bench_data.py
 !/benchmarks/BENCHMARK_REPORT.md
 !/benchmarks/BENCHMARK_REPORT.json
 !/benchmarks/qp_three_way.md

--- a/benchmarks/bench_data.py
+++ b/benchmarks/bench_data.py
@@ -1,0 +1,133 @@
+"""Resolve the benchmark corpus root, preferring a local mirror over Dropbox.
+
+Why this exists
+---------------
+The corpus historically lives in a Dropbox folder. A benchmark run reads ~4.5 GB
+from it *and* writes a ``.sol`` beside every input (the documented layout — see
+``benchmarks/README.md``). Both halves put a shared, externally-scheduled daemon
+inside the measurement path, so a timing panel measures Dropbox's indexer as
+well as the solver.
+
+``scripts/sync-bench-data.sh`` builds an unsynced mirror; this module is the one
+place that decides which root to use.
+
+Resolution order
+----------------
+1. ``$POUNCE_BENCH_DATA``     — explicit override, always wins if valid
+2. ``~/projects/pounce-bench-data``  — the local mirror
+3. ``~/Dropbox/projects/pounce-bench-data`` — original, so a fresh checkout works
+
+**A root only counts if it actually holds the corpus.** An empty or half-synced
+tree that shadows a good one makes every benchmark silently vacuous — the worst
+outcome available here, because it looks like success. ``_looks_like_corpus``
+is what prevents it.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+
+#: Written by ``scripts/sync-bench-data.sh`` only after its file counts match
+#: the source, so its presence means "this mirror was verified complete".
+SENTINEL = ".pounce-bench-data"
+
+#: Suites used as a fallback liveness probe for roots without a sentinel (the
+#: Dropbox original never had one). Any single hit is enough.
+_PROBE_DIRS = ("vanderbei/nl", "mittelmann/nl", "qp/nl", "lp/nl")
+
+#: Path prefixes treated as "inside a sync folder".
+_SYNCED_MARKERS = ("Dropbox", "Google Drive", "OneDrive", "iCloud")
+
+
+def _looks_like_corpus(root: Path) -> bool:
+    """True if `root` actually contains problem inputs.
+
+    Checked cheaply: the verified-mirror sentinel, else at least one known
+    suite directory holding at least one ``.nl``. A recursive count would be
+    correct too but walks 4.5 GB on every call.
+    """
+    if not root.is_dir():
+        return False
+    if (root / SENTINEL).is_file():
+        return True
+    for probe in _PROBE_DIRS:
+        d = root / probe
+        if d.is_dir() and any(d.glob("*.nl")):
+            return True
+    return False
+
+
+def candidate_roots() -> list[Path]:
+    """The resolution order, before validity filtering."""
+    roots: list[Path] = []
+    env = os.environ.get("POUNCE_BENCH_DATA")
+    if env:
+        roots.append(Path(env).expanduser())
+    roots.append(Path.home() / "projects" / "pounce-bench-data")
+    roots.append(Path.home() / "Dropbox" / "projects" / "pounce-bench-data")
+    return roots
+
+
+def bench_data_root(required: bool = True) -> Path | None:
+    """Return the first candidate root that actually holds the corpus.
+
+    Raises ``FileNotFoundError`` when nothing valid is found and `required`,
+    rather than returning a path that would make every downstream glob empty.
+    """
+    tried = candidate_roots()
+    for root in tried:
+        if _looks_like_corpus(root):
+            return root
+    if not required:
+        return None
+    listed = "\n  ".join(str(p) for p in tried)
+    raise FileNotFoundError(
+        "no benchmark corpus found. Tried:\n  "
+        + listed
+        + "\n\nBuild the local mirror with:\n"
+        "    scripts/sync-bench-data.sh\n"
+        "or point POUNCE_BENCH_DATA at an existing corpus."
+    )
+
+
+def corpus_is_synced(root: Path | None = None) -> bool:
+    """True if the resolved corpus sits inside a file-sync folder.
+
+    A timing harness should refuse or warn on this: the sync daemon wakes on
+    its own schedule and its I/O lands in the measurement.
+    """
+    if root is None:
+        root = bench_data_root(required=False)
+    if root is None:
+        return False
+    return any(marker in str(root) for marker in _SYNCED_MARKERS)
+
+
+def warn_if_synced(root: Path | None = None) -> bool:
+    """Warn when timing off a synced corpus. Returns True if a warning fired."""
+    if root is None:
+        root = bench_data_root(required=False)
+    if root is not None and corpus_is_synced(root):
+        warnings.warn(
+            f"benchmark corpus is inside a sync folder ({root}); timings will "
+            "include the sync daemon's I/O and are not comparable across runs. "
+            "Build a local mirror with scripts/sync-bench-data.sh and export "
+            "POUNCE_BENCH_DATA to it.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return True
+    return False
+
+
+if __name__ == "__main__":  # pragma: no cover - manual probe
+    root = bench_data_root(required=False)
+    print(f"resolved root : {root}")
+    print(f"synced folder : {corpus_is_synced(root)}")
+    if root is not None:
+        n = sum(1 for _ in root.rglob("*.nl"))
+        print(f"problem inputs: {n} .nl")
+        if n == 0:
+            raise SystemExit("FAIL: resolved a root with zero inputs")

--- a/benchmarks/globallib/compare_obbt_engines.py
+++ b/benchmarks/globallib/compare_obbt_engines.py
@@ -44,6 +44,16 @@ import subprocess
 import sys
 from pathlib import Path
 
+def _bench_root():
+    """Corpus root via the shared resolver (local mirror preferred)."""
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from bench_data import bench_data_root
+
+    return bench_data_root()
+
+
 HERE = Path(__file__).parent
 RUNNER = HERE / "run_globallib.py"
 
@@ -86,7 +96,7 @@ def main():
     ap.add_argument("--nl-dir",
                     default=str(__import__("os").environ.get(
                         "POUNCE_BENCH_DATA",
-                        str(Path.home() / "Dropbox/projects/pounce-bench-data"))
+                        str(_bench_root()))
                         ) + "/globallib/nl")
     ap.add_argument("--timeout", type=float, default=30.0)
     ap.add_argument("--max-vars", type=int, default=None)

--- a/benchmarks/globallib/run_globallib.py
+++ b/benchmarks/globallib/run_globallib.py
@@ -18,7 +18,7 @@ Usage:
                    [--max-vars N] [--out report.json] [stems...]
 
 Default nl-dir: $POUNCE_BENCH_DATA/globallib/nl or
-                ~/Dropbox/projects/pounce-bench-data/globallib/nl
+                <corpus>/globallib/nl  (see benchmarks/bench_data.py)
 """
 import argparse
 import json
@@ -36,10 +36,18 @@ STATUS_RE = re.compile(r"pounce-global\):\s*(?P<msg>[^.]+\.)")
 
 
 def default_nl_dir():
-    env = os.environ.get("POUNCE_BENCH_DATA")
-    if env:
-        return Path(env) / "globallib" / "nl"
-    return Path.home() / "Dropbox/projects/pounce-bench-data/globallib/nl"
+    """Corpus subdir via the shared resolver.
+
+    The previous inline lookup honoured $POUNCE_BENCH_DATA but fell back
+    straight to Dropbox, so it never found the local mirror and accepted a
+    root that did not actually hold the corpus.
+    """
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from bench_data import bench_data_root
+
+    return bench_data_root() / "globallib" / "nl"
 
 
 def load_optima(path):

--- a/benchmarks/globallib/translate.sh
+++ b/benchmarks/globallib/translate.sh
@@ -14,7 +14,10 @@ set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 AMPL="${AMPL:-ampl}"
-OUT="${1:-${POUNCE_BENCH_DATA:-$HOME/Dropbox/projects/pounce-bench-data}/globallib/nl}"
+# Corpus root via the shared resolver: the old inline fallback went straight to
+# Dropbox and never found the local mirror.
+. "$HERE/../../scripts/bench_data_root.sh"
+OUT="${1:-$BENCH_DATA_ROOT/globallib/nl}"
 WORK="$(mktemp -d)"
 trap 'rm -rf "$WORK"' EXIT
 

--- a/benchmarks/scripts/compare_qp_three_way.py
+++ b/benchmarks/scripts/compare_qp_three_way.py
@@ -31,6 +31,17 @@ import os
 import tempfile
 import time
 
+def _bench_root():
+    """Corpus root via the shared resolver (local mirror preferred)."""
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from bench_data import bench_data_root
+
+    return bench_data_root()
+
+
 HERE = os.path.dirname(os.path.abspath(__file__))
 BENCH = os.path.dirname(HERE)
 ROOT = os.path.dirname(BENCH)
@@ -43,7 +54,7 @@ cmp_pc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(cmp_pc)
 
 GROUND_TRUTH = os.path.expanduser(
-    "~/Dropbox/projects/pounce-bench-data/qp/Maros-Meszaros-answers.json")
+    str(_bench_root() / "qp" / "Maros-Meszaros-answers.json"))
 
 POUNCE_OK = cmp_pc.POUNCE_OK            # {"SolveSucceeded","SolvedToAcceptableLevel"}
 CLARABEL_OK = cmp_pc.CLARABEL_OK        # {"Solved","AlmostSolved"}

--- a/scripts/bench_data_root.sh
+++ b/scripts/bench_data_root.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Shell counterpart of benchmarks/bench_data.py — resolve the corpus root,
+# preferring a local mirror over Dropbox. Source it, then use $BENCH_DATA_ROOT:
+#
+#   . "$(git rev-parse --show-toplevel)/scripts/bench_data_root.sh"
+#   ls "$BENCH_DATA_ROOT/vanderbei/nl"
+#
+# Order: $POUNCE_BENCH_DATA -> ~/projects/pounce-bench-data -> ~/Dropbox/...
+# A root only counts if it actually holds the corpus; an empty or half-synced
+# tree that shadows a good one would make every benchmark silently vacuous.
+
+_bench_looks_like_corpus() {
+    [ -d "$1" ] || return 1
+    [ -f "$1/.pounce-bench-data" ] && return 0
+    for probe in vanderbei/nl mittelmann/nl qp/nl lp/nl; do
+        [ -d "$1/$probe" ] || continue
+        [ -n "$(find "$1/$probe" -maxdepth 1 -name '*.nl' -print -quit 2>/dev/null)" ] && return 0
+    done
+    return 1
+}
+
+bench_data_root() {
+    for cand in "${POUNCE_BENCH_DATA:-}" "$HOME/projects/pounce-bench-data" \
+                "$HOME/Dropbox/projects/pounce-bench-data"; do
+        [ -n "$cand" ] || continue
+        if _bench_looks_like_corpus "$cand"; then echo "$cand"; return 0; fi
+    done
+    return 1
+}
+
+# True when the resolved corpus sits in a sync folder — its daemon's I/O lands
+# in any timing measured against it.
+bench_corpus_is_synced() {
+    case "${1:-$BENCH_DATA_ROOT}" in
+        *Dropbox*|*"Google Drive"*|*OneDrive*|*iCloud*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+bench_warn_if_synced() {
+    if bench_corpus_is_synced "${1:-$BENCH_DATA_ROOT}"; then
+        echo "WARNING: benchmark corpus is inside a sync folder (${1:-$BENCH_DATA_ROOT});" >&2
+        echo "         timings include the sync daemon's I/O. Run scripts/sync-bench-data.sh" >&2
+        echo "         and export POUNCE_BENCH_DATA to the mirror." >&2
+        return 0
+    fi
+    return 1
+}
+
+BENCH_DATA_ROOT="$(bench_data_root)" || {
+    echo "FATAL: no benchmark corpus found (tried \$POUNCE_BENCH_DATA," >&2
+    echo "       ~/projects/pounce-bench-data, ~/Dropbox/projects/pounce-bench-data)." >&2
+    echo "       Build one with scripts/sync-bench-data.sh" >&2
+}
+export BENCH_DATA_ROOT

--- a/scripts/sync-bench-data.sh
+++ b/scripts/sync-bench-data.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Mirror the benchmark corpus out of Dropbox into a local, unsynced directory.
+#
+# WHY THIS EXISTS
+# ---------------
+# The corpus lives in a Dropbox folder. A benchmark run reads ~4.5 GB from it
+# *and writes a `.sol` beside every input* (1397 of them at last count — that is
+# the documented layout, see benchmarks/README.md). Both halves put a shared,
+# externally-scheduled daemon inside the measurement path: the indexer wakes on
+# its own schedule, for reasons unrelated to the run, and every timing panel
+# then measures Dropbox as well as the solver.
+#
+# Mirroring to a plain local directory removes that variable. Nothing about the
+# corpus is Dropbox-specific — it is read-only input data plus regenerable
+# scratch.
+#
+# Usage:
+#   scripts/sync-bench-data.sh            # sync, then verify counts
+#   scripts/sync-bench-data.sh --check    # dry run: report what would change
+#   BENCH_SRC=... BENCH_DST=... scripts/sync-bench-data.sh
+#
+# After a successful sync, point the harnesses at the mirror:
+#   export POUNCE_BENCH_DATA="$HOME/projects/pounce-bench-data"
+# (scripts/bench_data_root.sh prefers it automatically — see that file.)
+set -uo pipefail
+
+SRC="${BENCH_SRC:-$HOME/Dropbox/projects/pounce-bench-data}"
+DST="${BENCH_DST:-$HOME/projects/pounce-bench-data}"
+CHECK=0
+[ "${1:-}" = "--check" ] && CHECK=1
+
+[ -d "$SRC" ] || { echo "FATAL: source corpus not found: $SRC"; exit 1; }
+
+# Excluded from the mirror:
+#   *.sol      — per-run solver scratch the harness rewrites on every run
+#                (368 MB). Inputs, not outputs, are what must be mirrored.
+#   .DS_Store  — Finder droppings.
+# Deliberately NOT excluded: Maros-Meszaros-answers.{json,pdf}. Those are
+# *oracle* files the QP comparison checks against; dropping them would make
+# that harness silently unable to verify anything.
+EXCLUDES=(--exclude "*.sol" --exclude ".DS_Store")
+
+# macOS ships openrsync / rsync 2.6.9, which has no `--info=`. Passing one makes
+# rsync print usage and exit in a way that looks like success while leaving an
+# EMPTY mirror — so the flag is not used here, and the file counts below are the
+# real check. Never trust the exit code alone.
+echo "==> source: $SRC"
+echo "==> mirror: $DST"
+rsync --version 2>&1 | head -1 | sed 's/^/    rsync: /'
+
+count_inputs() { find "$1" \( -name '*.nl' -o -name '*.cbf' \) -type f 2>/dev/null | wc -l | tr -d ' '; }
+count_all()    { find "$1" -type f ! -name '*.sol' ! -name '.DS_Store' 2>/dev/null | wc -l | tr -d ' '; }
+
+SRC_INPUTS="$(count_inputs "$SRC")"
+SRC_ALL="$(count_all "$SRC")"
+echo "==> source holds $SRC_INPUTS problem inputs (.nl/.cbf), $SRC_ALL mirrored files total"
+if [ "$SRC_INPUTS" -eq 0 ]; then
+  echo "FATAL: source contains zero problem inputs — refusing to build a vacuous mirror."
+  exit 1
+fi
+
+if [ "$CHECK" = "1" ]; then
+  echo "==> --check: dry run, nothing will be written"
+  rsync -a --dry-run --delete "${EXCLUDES[@]}" "$SRC/" "$DST/" | tail -20
+  if [ -d "$DST" ]; then
+    echo "==> current mirror: $(count_inputs "$DST") inputs, $(count_all "$DST") files"
+  else
+    echo "==> mirror does not exist yet"
+  fi
+  exit 0
+fi
+
+mkdir -p "$DST"
+rsync -a --delete "${EXCLUDES[@]}" "$SRC/" "$DST/"
+RC=$?
+
+# Verification. A silent partial mirror combined with a resolver that prefers it
+# is the worst outcome available here — every benchmark would pass vacuously
+# while looking healthy. Counts, not the exit code, decide success.
+DST_INPUTS="$(count_inputs "$DST")"
+DST_ALL="$(count_all "$DST")"
+echo "==> mirror holds $DST_INPUTS problem inputs, $DST_ALL files total"
+
+if [ "$SRC_INPUTS" != "$DST_INPUTS" ] || [ "$SRC_ALL" != "$DST_ALL" ]; then
+  echo "FATAL: mirror is incomplete (rsync exit $RC)."
+  echo "       inputs: source=$SRC_INPUTS mirror=$DST_INPUTS"
+  echo "       files : source=$SRC_ALL mirror=$DST_ALL"
+  echo "       The mirror is left in place for inspection but MUST NOT be used;"
+  echo "       unset POUNCE_BENCH_DATA or re-run this script until counts match."
+  exit 1
+fi
+
+# Sentinel: the resolver refuses a root without it, so a half-synced tree can
+# never shadow a good one. Written last, only once the counts agree.
+date -u +"%Y-%m-%dT%H:%M:%SZ" > "$DST/.pounce-bench-data"
+echo "    wrote sentinel $DST/.pounce-bench-data"
+
+echo "==> OK — $DST_INPUTS inputs verified against source ($(du -sh "$DST" | cut -f1))"
+echo
+echo "Point the harnesses at it:"
+echo "    export POUNCE_BENCH_DATA=\"$DST\""


### PR DESCRIPTION
Benchmark timings currently include Dropbox's indexer. This mirrors the corpus
to a local directory and routes every harness through one resolver.

## The measured mechanism — and what I falsified

The prompt warned not to assume the sibling repo's (discopt) answer transfers.
It does not.

| Probe | Result |
|---|---|
| files modified in last 24 h | **0** |
| files modified in last 7 d | **0** |
| `.sol` files inside the corpus | **1397**, beside the `.nl`, across 8 suite dirs |
| newest `.sol` mtime | **2026-07-24 12:37** |
| newest `.nl` mtime | 2026-06-11 01:13 (inputs static) |

discopt falsified "we write files next to the inputs" by measuring **0 files
modified in 24 h**. Run here, that same probe returns 0 — **and is wrong.** The
24 h window is quiet only because the last benchmark ran three days ago. The
corpus holds 1397 solver outputs, and the `.sol`/`.nl` mtime split (July 24 vs
June 11) pins them to benchmark runs. A run *does* write ~1400 files into the
sync folder; the 7-day window is what reveals it.

**It is not the in-place-execution bug the prompt asked about.** The Ipopt
reference path already stages to `tempfile.mkdtemp` with `cwd=optdir`
(`run_nl_benchmark.py:122`), and writing `.sol` beside the input is the
*documented* POUNCE layout (`benchmarks/README.md`). Nothing to fix there —
once the corpus is local, those writes are harmless.

Also worth recording: the `.sol` files are not "stray untracked droppings". The
corpus is not a git repository at all, so `.gitignore` never applied to them.

## Mirror

**4.1 G** at `~/projects/pounce-bench-data` (source 4.5 G; 597 Gi free).

Excluded:
- `*.sol` — 368 MB of per-run scratch the harness rewrites every run.
- `.DS_Store`.

**Deliberately kept:** `Maros-Meszaros-answers.{json,pdf}`. The one PDF in the
corpus is an *oracle* the QP comparison checks against — a naive `*.pdf`
exclusion would have silently removed it.

Verification, both sides:

```
source holds 1569 problem inputs (.nl/.cbf), 3791 mirrored files total
mirror holds 1569 problem inputs, 3791 files total
OK — 1569 inputs verified against source (4.1G)
```

## Resolver

One resolver, extending the existing `POUNCE_BENCH_DATA` convention rather than
inventing a second: `$POUNCE_BENCH_DATA` → `~/projects/pounce-bench-data` →
`~/Dropbox/...`. Available to Python (`benchmarks/bench_data.py`) and shell
(`scripts/bench_data_root.sh`).

**A root only counts if it actually holds the corpus** — the verified-mirror
sentinel, else a known suite dir containing at least one `.nl`. Proven:

| Case | Resolved root | `synced` |
|---|---|---|
| no env var | `~/projects/pounce-bench-data` (**local mirror**) | False |
| `POUNCE_BENCH_DATA=~/Dropbox/...` | the Dropbox path (honoured) | **True** |
| `POUNCE_BENCH_DATA=/tmp/empty` | **falls through** to the local mirror | False |

Both valid roots report 1437 `.nl`, confirming the mirror is complete. The
empty-root case is the one that matters most: a half-synced tree shadowing a
good one would make every benchmark pass vacuously while looking like success.

`corpus_is_synced()` / `warn_if_synced()` (and the shell equivalents) let a
timing harness warn or refuse rather than publish a contaminated number.

## Refresh script

`scripts/sync-bench-data.sh`, with `--check` dry run. After syncing it
**verifies file counts against the source and fails rather than leaving a
partial mirror**, writing the sentinel only once counts agree.

The macOS rsync trap is real and is handled: this machine has `openrsync`
(rsync 2.6.9 compatible) with **no `--info=`**, confirmed by probing. The script
never passes one, and counts — not the exit code — decide success.

## Migrations

All **5** hardcoded sites migrated; **0** hardcoded `Dropbox/projects/pounce-bench-data`
references remain in harness code. The Dropbox fallback stays so a fresh
checkout still works.

- `benchmarks/experiments/run_linsolver_experiment.sh` (absolute `/Users/jkitchin/…`)
- `benchmarks/scripts/compare_qp_three_way.py`
- `benchmarks/globallib/compare_obbt_engines.py`
- `benchmarks/globallib/run_globallib.py`
- `benchmarks/globallib/translate.sh`

The last two already read `POUNCE_BENCH_DATA` but fell straight back to Dropbox
and accepted a root that did not hold the corpus, so they never found the mirror.

All five compile / `bash -n` clean, `shellcheck` clean. End-to-end probe through
a migrated module: `default_nl_dir()` → the mirror, **104 globallib inputs**
(the probe asserts non-zero and fails loudly at zero).

## Two things that were wrong about this repo

1. **`/benchmarks/*` is blanket-gitignored** with a whitelist. `benchmarks/bench_data.py`
   — the resolver every harness imports — was silently ignored and would not have
   been committed. Added a whitelist entry.
2. **`benchmarks/experiments/run_linsolver_experiment.sh` is itself gitignored**
   (pre-existing, not caused here). Its migration is therefore local-only and
   will not appear in this diff. Flagging rather than quietly whitelisting a file
   the repo chose not to track — say the word and I'll add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
