### PR TITLE
Fix #376 regression: don't certify infeasibility at a point the solver calls feasible

### DIFF
--- a/crates/pounce-cli/tests/fixtures/scaled_feasible_a.nl
+++ b/crates/pounce-cli/tests/fixtures/scaled_feasible_a.nl
@@ -1,0 +1,74 @@
+g3 1 1 0	# problem unknown
+ 4 3 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 4 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 9 4 	# nonzeros in Jacobian, obj. gradient
+ 4 4	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#c[1]
+n0
+C1	#c[2]
+n0
+C2	#c[3]
+n0
+O0 0	#o
+o54	# sumlist
+4	# (n)
+o5	#^
+o0	#+
+v0	#x[0]
+n3.8075263197246603
+n2
+o5	#^
+o0	#+
+v1	#x[1]
+n-500000.0
+n2
+o5	#^
+o0	#+
+v2	#x[2]
+n-0.5
+n2
+o5	#^
+o0	#+
+v3	#x[3]
+n-499999.0
+n2
+x4	# initial guess
+0 -3.8075263197246603	#x[0]
+1 500000.0	#x[1]
+2 0.5	#x[2]
+3 499999.0	#x[3]
+r	#3 ranges (rhs's)
+1 530752631.97246605	#c[1]
+2 -26547947618426.85	#c[2]
+1 8.737549066070076e-07	#c[3]
+b	#4 bounds (on variables)
+0 -3.8075263202246603 -3.8075263192246602	#x[0]
+0 0.0 1000000.0	#x[1]
+0 0.0 1.0	#x[2]
+0 -1.0 999999.0	#x[3]
+k3	#intermediate Jacobian column lengths
+1
+4
+6
+J0 4	#c[1]
+0 -100000000.0
+1 100000000.0
+2 100000000.0
+3 -100000000.0
+J1 2	#c[2]
+1 46903904.763146296
+3 -100000000.0
+J2 3	#c[3]
+1 1e-12
+2 1e-12
+3 7.475083082306318e-13
+G0 4	#o
+0 0
+1 0
+2 0
+3 0

--- a/crates/pounce-cli/tests/fixtures/scaled_feasible_b.nl
+++ b/crates/pounce-cli/tests/fixtures/scaled_feasible_b.nl
@@ -1,0 +1,74 @@
+g3 1 1 0	# problem unknown
+ 4 3 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 4 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 9 4 	# nonzeros in Jacobian, obj. gradient
+ 4 4	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#c[1]
+n0
+C1	#c[2]
+n0
+C2	#c[3]
+n0
+O0 0	#o
+o54	# sumlist
+4	# (n)
+o5	#^
+o0	#+
+v0	#x[0]
+n-500000.0
+n2
+o5	#^
+o0	#+
+v1	#x[1]
+n9.216393895220474
+n2
+o5	#^
+o0	#+
+v2	#x[2]
+n-0.5
+n2
+o5	#^
+o0	#+
+v3	#x[3]
+n-500000.0
+n2
+x4	# initial guess
+0 500000.0	#x[0]
+1 -9.216393895220474	#x[1]
+2 0.5	#x[2]
+3 500000.0	#x[3]
+r	#3 ranges (rhs's)
+1 -871639389.5220464	#c[1]
+1 -999989.7836061048	#c[2]
+1 1e-12	#c[3]
+b	#4 bounds (on variables)
+0 0.0 1000000.0	#x[0]
+0 -9.716393895220474 -8.716393895220474	#x[1]
+0 0.0 1.0	#x[2]
+0 0.0 1000000.0	#x[3]
+k3	#intermediate Jacobian column lengths
+3
+5
+6
+J0 4	#c[1]
+0 -100000000.0
+1 100000000.0
+2 100000000.0
+3 100000000.0
+J1 3	#c[2]
+0 -1.0
+1 -1.0
+3 -1.0
+J2 2	#c[3]
+0 100000000.0
+3 -100000000.0
+G0 4	#o
+0 0
+1 0
+2 0
+3 0

--- a/crates/pounce-cli/tests/scaled_feasible_not_infeasible.rs
+++ b/crates/pounce-cli/tests/scaled_feasible_not_infeasible.rs
@@ -1,0 +1,85 @@
+//! A feasible model whose rows carry heavy scaling must not be reported
+//! infeasible.
+//!
+//! Regression for a defect introduced by the #376 fix. That change made the
+//! restoration locally-infeasible gates measure the constraint violation
+//! **unscaled**, which was correct — the floors they compare against
+//! (`max(100*tol, 1e-4)`) are absolute, user-facing magnitudes. But
+//! `inner_kkt_err` and the inner convergence test remain in the *scaled* space,
+//! so the fix moved the units mismatch rather than removing it.
+//!
+//! On a model whose rows are scaled down, the inner restoration can stop at a
+//! point it considers feasible — scaled violation below `tol` — while the
+//! unscaled violation still clears the `1e-4` floor. A gate then fires and a
+//! feasible model is reported `Infeasible_Problem_Detected`. `scaled_feasible_a`
+//! made the mechanism plain: `inner_kkt_err = 3.249625e-9` against
+//! `orig_inf_pr = 3.249625e-3` — the same mantissa, scaled by `1e6`, the row
+//! scaling factor.
+//!
+//! Both fixtures are verified feasible by `pounce verify` with exactly `0.000e0`
+//! constraint and bound violation, and POUNCE's own convex QP route solves both
+//! to optimality. Before #376 they returned `Solve_Succeeded` (a) and
+//! `Solved_To_Acceptable_Level` (b); after #376 both returned 200.
+//!
+//! The fix guards all five gates in one place: never claim infeasibility at a
+//! point the solver's own convergence test would accept as feasible.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn solve_result_num(text: &str) -> i32 {
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("objno ") {
+            if let Some(code) = rest.split_whitespace().nth(1) {
+                return code.parse().expect("objno code parses");
+            }
+        }
+    }
+    panic!("no `objno` line in .sol:\n{text}");
+}
+
+fn solve(model: &str, tag: &str) -> String {
+    let sol = std::env::temp_dir().join(format!("pounce_scaled_feas_{tag}.sol"));
+    let _ = std::fs::remove_file(&sol);
+    let out = Command::new(pounce_exe())
+        .arg(fixture(model))
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("print_level=0")
+        .arg("solver_selection=nlp")
+        .arg("presolve=no")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+    std::fs::read_to_string(&sol).expect("read .sol")
+}
+
+#[test]
+fn heavily_scaled_feasible_models_are_not_reported_infeasible() {
+    for (model, tag) in [("scaled_feasible_a.nl", "a"), ("scaled_feasible_b.nl", "b")] {
+        let text = solve(model, tag);
+        let srn = solve_result_num(&text);
+        assert!(
+            !(200..300).contains(&srn),
+            "{model} is feasible — `pounce verify` reports 0.000e0 constraint \
+             and bound violation on the convex route's solution — but the NLP \
+             path reported the AMPL infeasible band (solve_result_num={srn}). \
+             This is the scaled/unscaled units mismatch: the inner stops at a \
+             point it considers feasible in scaled terms while the unscaled \
+             violation clears the 1e-4 floor.\n{text}"
+        );
+    }
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -520,8 +520,8 @@ pub fn run_inner_resto(
     // exit at exactly the entry `inf_pr` as locally-infeasible
     // (HATFLDF, POLAK6, ROSENMMX, ... regress).
     let outer_tol = outer_data.borrow().tol;
-    let orig_inf_pr_at_final =
-        eval_orig_inf_pr_at_inner_curr(&*final_iv.x, &*final_iv.s, outer_nlp).unwrap_or(0.0);
+    let (orig_inf_pr_at_final, orig_inf_pr_scaled) =
+        eval_orig_inf_pr_at_inner_curr(&*final_iv.x, &*final_iv.s, outer_nlp).unwrap_or((0.0, 0.0));
     let inner_kkt_err = alg.cq.borrow().curr_nlp_error();
     let inner_stationarity_converged = inner_kkt_err <= 10.0 * outer_tol;
     // Square problems: upstream `IpRestoMinC_1Nrm.cpp:357-371` returns
@@ -647,19 +647,49 @@ pub fn run_inner_resto(
         && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-4)
         && orig_inf_pr_at_final.is_finite();
 
-    let locally_infeasible = strict_locally_infeasible
-        || alt_locally_infeasible
-        || cycle_locally_infeasible
-        || step_failure_locally_infeasible
-        || tiny_step_locally_infeasible;
+    // Admissibility guard over ALL of the gates above, in one place.
+    //
+    // Never claim infeasibility at a point the solver's own convergence test
+    // would accept as feasible. `orig_inf_pr_at_final` is measured *unscaled*
+    // (correctly — the floors it is compared against are absolute, user-facing
+    // magnitudes), but `inner_kkt_err` and the convergence check are in the
+    // *scaled* space. Comparing across the two is the same units mismatch the
+    // unscaling was introduced to fix, just moved: on a model whose rows are
+    // scaled down, the inner can stop at a point it considers feasible
+    // (scaled violation below `tol`) while the unscaled violation still clears
+    // a `1e-4` floor, and a gate then reports a feasible model infeasible.
+    //
+    // Measured: two feasible instances (property-test seeds 99 and 193) turned
+    // from `Solve_Succeeded` into `Infeasible_Problem_Detected` exactly this
+    // way. Seed 99's numbers make the mechanism plain — `inner_kkt_err`
+    // 3.249625e-9 against `orig_inf_pr` 3.249625e-3, the same mantissa scaled
+    // by 1e6, the row scaling factor.
+    //
+    // The guard costs nothing on models that carry no row scaling (the two
+    // measures coincide) and nothing on genuinely infeasible ones, whose scaled
+    // violation is comfortably above `tol` — `infeasible_equalities.nl`, the
+    // model the unscaling was introduced for, sits at 6.7e-7 against a `1e-8`
+    // tolerance and still certifies.
+    //
+    // Applied once to the combination rather than to each disjunct: the two
+    // preceding safeguards in this area were each added to one path and not its
+    // twin, and a hole survived both times.
+    let solver_would_call_it_feasible = orig_inf_pr_scaled <= outer_tol;
+    let locally_infeasible = !solver_would_call_it_feasible
+        && (strict_locally_infeasible
+            || alt_locally_infeasible
+            || cycle_locally_infeasible
+            || step_failure_locally_infeasible
+            || tiny_step_locally_infeasible);
 
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
         tracing::debug!(target: "pounce::restoration",
-            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} tiny_step={} → loc_inf={}",
+            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} tiny_step={} → loc_inf={}",
             status,
             inner_iter_count,
             inner_kkt_err,
             orig_inf_pr_at_final,
+            orig_inf_pr_scaled,
             outer_tol,
             strict_locally_infeasible,
             alt_locally_infeasible,
@@ -717,7 +747,7 @@ fn eval_orig_inf_pr_at_inner_curr(
     inner_x: &dyn Vector,
     inner_s: &dyn Vector,
     orig_rc: &Rc<RefCell<dyn IpoptNlp>>,
-) -> Option<f64> {
+) -> Option<(f64, f64)> {
     let xc = inner_x.as_any().downcast_ref::<CompoundVector>()?;
     let x_orig = xc.comp(BLOCK_X);
     let mut orig = orig_rc.borrow_mut();
@@ -727,19 +757,22 @@ fn eval_orig_inf_pr_at_inner_curr(
     let c_amax = if m_eq > 0 {
         let mut buf = DenseVectorSpace::new(m_eq).make_new_dense();
         orig.eval_c(x_orig, &mut buf);
-        unscaled_block_amax(&buf, dc.as_deref())
+        (unscaled_block_amax(&buf, dc.as_deref()), buf.amax())
     } else {
-        0.0
+        (0.0, 0.0)
     };
     let d_minus_s_amax = if m_ineq > 0 {
         let mut buf = DenseVectorSpace::new(m_ineq).make_new_dense();
         orig.eval_d(x_orig, &mut buf);
         buf.axpy(-1.0, inner_s);
-        unscaled_block_amax(&buf, dd.as_deref())
+        (unscaled_block_amax(&buf, dd.as_deref()), buf.amax())
     } else {
-        0.0
+        (0.0, 0.0)
     };
-    Some(c_amax.max(d_minus_s_amax))
+    Some((
+        c_amax.0.max(d_minus_s_amax.0),
+        c_amax.1.max(d_minus_s_amax.1),
+    ))
 }
 
 /// Capture the pieces of the outer iterate the resto initializer needs.


### PR DESCRIPTION
Fixes a regression I introduced in #376, found by adversarially testing my own
merged work.

## The regression

#376 made the restoration locally-infeasible gates measure the constraint
violation **unscaled**. That correction was right — the floors they compare
against, `max(100*tol, 1e-4)`, are absolute user-facing magnitudes. But it
*moved* the units mismatch rather than removing it: `inner_kkt_err` and the inner
convergence test are still in the **scaled** space.

On a model whose rows are scaled down, the inner restoration can stop at a point
it considers feasible — scaled violation below `tol` — while the unscaled
violation still clears the `1e-4` floor. A gate fires, and a feasible model is
reported `Infeasible_Problem_Detected`.

Seed 99's numbers make the mechanism plain:

```
inner_kkt_err = 3.249625e-9      (scaled)
orig_inf_pr   = 3.249625e-3      (unscaled)
```

Same mantissa, differing by exactly `1e6` — the row scaling factor.

| | before #376 | on `main` |
|---|---|---|
| seed 99 | `[0]` Solve_Succeeded | **`[200]`** Infeasible_Problem_Detected |
| seed 193 | `[100]` Solved_To_Acceptable_Level | **`[200]`** Infeasible_Problem_Detected |

Both are verified feasible by `pounce verify` with exactly `0.000e0` constraint
and bound violation, and POUNCE's own convex QP route solves both to optimality.

## The fix

**Never claim infeasibility at a point the solver's own convergence test would
accept as feasible.** `eval_orig_inf_pr_at_inner_curr` now returns the scaled
violation alongside the unscaled one, and the gate combination requires the
scaled violation to exceed `outer_tol`.

Applied **once to the combination**, not to each of the five disjuncts. The two
preceding safeguards in this area were each added to one path and not its twin,
and a hole survived both times.

It costs nothing where it should not fire: with no row scaling the two measures
coincide, and on genuinely infeasible models the scaled violation is comfortably
above `tol`.

## Measurements

400 feasible-by-construction instances, main-based binaries:

| | numerical path | all presolve phases |
|---|---|---|
| before #373 | 2/400 | 1/400 |
| current `main` | **4/400** | **2/400** |
| **with this fix** | **2/400** | **1/400** |

Restores the pre-#373 baseline exactly. It does **not** go below it — the
remaining instances (seeds 102, 294) predate all of this work and are tracked in
#379.

Both original targets intact:

- gh #372 reports 200 at `tol` from `1e-6` to `1e-12`
- `infeasible_equalities.nl` — the model #376 was written for — reports 200 at
  `tol` from `1e-4` to `1e-14` (scaled violation `6.7e-7` vs `1e-8`)

Also: **477 real `.nl` problems from the benchmark corpus, zero verdict changes**;
workspace suite **2175 passed / 0 failed**; the new regression test fails without
this change.

## How it was missed

#376 claimed "no false-positive risk" on the strength of that same 477-problem
corpus sweep showing zero changes. The sweep was real; the conclusion drawn from
it was too strong. The corpus contains no extreme-scale shapes, so it could not
have detected this — and the property test that found it in one run did not exist
when #376 landed.

That test is in #377. Worth noting it earns its place independently of the
feature it was written for: it found this, and it found #379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
