### PR TITLE
Add the scale-invariance harness (Phase 0, no production changes)

### DIFF
--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -1,0 +1,213 @@
+"""Scale invariance: multiplying a constraint by s > 0 must not change the verdict.
+
+Multiplying a row by a positive constant leaves the feasible set *exactly*
+unchanged — it is the same mathematical problem written differently. So the
+solver's verdict at every scale must agree. Where it does not, a modelling
+choice that carries no mathematical content is silently changing the answer.
+
+This is the regression detector for the scale-invariance work. Several defects
+found in this area shared one root cause: a scale-*dependent* quantity compared
+against an *absolute* threshold. A corpus sweep cannot detect that class,
+because real models cluster near O(1) — this harness manufactures the stress
+directly by sweeping the row scaling across 25 decades.
+
+The sharpest cell it finds: ``x >= 2`` over ``x in [0, 1]`` reports
+``Infeasible_Problem_Detected`` unscaled and ``Solve_Succeeded`` when every row
+is multiplied by ``1e-12``. Same empty feasible set, opposite verdicts —
+because at that scale the violation falls under an absolute feasibility
+tolerance and the solver accepts it.
+
+**Both directions are covered on purpose.** Feasible models guard against
+tightening a tolerance into false infeasibility; infeasible models guard
+against loosening one into a missed verdict. A relative tolerance is *more*
+permissive at large scale, so a fix aimed only at false positives could quietly
+lose true infeasibility verdicts. Any step that improves one column while
+worsening the other is a regression, not progress.
+
+The assertion is a **ratchet against the recorded baseline**, not zero: the
+current implementation is not scale-invariant, and pretending otherwise would
+make the test fail on arrival. Lower the baselines as the migration lands —
+that is the point.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+pyo = pytest.importorskip("pyomo.environ")
+
+#: Row-scaling exponents. s = 10**k multiplies every constraint row.
+KS = list(range(-12, 13, 2))
+
+_OPTS = ["solver_selection=nlp", "print_level=0"]
+
+
+def _pounce() -> str:
+    exe = shutil.which("pounce")
+    if exe is None:
+        pytest.skip("pounce not on PATH")
+    return exe
+
+
+# --- models -----------------------------------------------------------------
+# Each builder takes the scale factor and applies it to every row, so the
+# feasible set is identical for all k.
+
+def _feas_simple(m, s):
+    m.x = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.o = pyo.Objective(expr=(m.x - 0.5) ** 2)
+    m.c = pyo.Constraint(expr=s * m.x >= s * 0.2)
+
+
+def _feas_two(m, s):
+    m.x = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.y = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.o = pyo.Objective(expr=(m.x - 0.3) ** 2 + (m.y - 0.7) ** 2)
+    m.c1 = pyo.Constraint(expr=s * (m.x + m.y) >= s * 0.5)
+    m.c2 = pyo.Constraint(expr=s * (m.x - m.y) <= s * 0.9)
+
+
+def _feas_eq(m, s):
+    m.x = pyo.Var(bounds=(0, 10), initialize=1.0)
+    m.y = pyo.Var(bounds=(0, 10), initialize=1.0)
+    m.o = pyo.Objective(expr=m.x**2 + m.y**2)
+    m.e = pyo.Constraint(expr=s * (m.x + m.y) == s * 4.0)
+
+
+def _inf_372(m, s):
+    """The gh #372 model: 0 <= x <= 0.6 with x >= 0.7."""
+    m.x = pyo.Var(bounds=(0.0, 0.6), initialize=0.5)
+    m.o = pyo.Objective(expr=m.x**3 + m.x**2)
+    m.c = pyo.Constraint(expr=s * m.x >= s * 0.7)
+
+
+def _inf_clear(m, s):
+    m.x = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.o = pyo.Objective(expr=m.x**2)
+    m.c = pyo.Constraint(expr=s * m.x >= s * 2.0)
+
+
+def _inf_two(m, s):
+    m.x = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.y = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.o = pyo.Objective(expr=m.x**2 + m.y**2)
+    m.c = pyo.Constraint(expr=s * (m.x + m.y) >= s * 3.0)
+
+
+def _inf_eq(m, s):
+    m.x = pyo.Var(bounds=(0, 1), initialize=0.5)
+    m.o = pyo.Objective(expr=m.x**2)
+    m.e1 = pyo.Constraint(expr=s * m.x == s * 0.2)
+    m.e2 = pyo.Constraint(expr=s * m.x == s * 0.8)
+
+
+MODELS = [
+    ("feas_simple", _feas_simple, "SOLVED"),
+    ("feas_two", _feas_two, "SOLVED"),
+    ("feas_eq", _feas_eq, "SOLVED"),
+    ("inf_372", _inf_372, "INFEAS"),
+    ("inf_clear", _inf_clear, "INFEAS"),
+    ("inf_two", _inf_two, "INFEAS"),
+    ("inf_eq", _inf_eq, "INFEAS"),
+]
+
+#: Wrong-verdict cells per model, out of len(KS), measured on the
+#: implementation this harness landed with. **Lower these as the migration
+#: lands.** A model whose count rises is a regression even if every other test
+#: passes.
+BASELINE_WRONG = {
+    "feas_simple": 0,
+    "feas_two": 0,
+    "feas_eq": 0,
+    "inf_372": 5,
+    "inf_clear": 5,
+    "inf_two": 5,
+    "inf_eq": 13,
+}
+
+
+def _band(code: int | None) -> str:
+    if code is None:
+        return "?"
+    if code < 200:
+        return "SOLVED"  # 0..99 solved, 100..199 solved-with-warning
+    if code < 300:
+        return "INFEAS"
+    if code < 400:
+        return "UNBND"
+    if code < 500:
+        return "LIMIT"
+    return "FAIL"
+
+
+def _solve(exe, tmp_path, name, builder, k) -> int | None:
+    m = pyo.ConcreteModel()
+    builder(m, 10.0**k)
+    nl = tmp_path / f"{name}_{k}.nl"
+    sol = tmp_path / f"{name}_{k}.sol"
+    m.write(str(nl), io_options={"symbolic_solver_labels": True})
+    subprocess.run(
+        [exe, str(nl), "-AMPL", "--sol-output", str(sol), *_OPTS],
+        capture_output=True,
+        timeout=120,
+    )
+    if not sol.exists():
+        return None
+    for line in sol.read_text().splitlines():
+        if line.startswith("objno"):
+            return int(line.split()[2])
+    return None
+
+
+def test_scale_invariance_does_not_regress(tmp_path):
+    exe = _pounce()
+    executed = 0
+    report = []
+    regressions = []
+    improvements = []
+
+    for name, builder, want in MODELS:
+        curve = []
+        for k in KS:
+            code = _solve(exe, tmp_path, name, builder, k)
+            if code is not None:
+                executed += 1
+            curve.append(_band(code))
+        wrong = sum(1 for b in curve if b != want)
+        base = BASELINE_WRONG[name]
+        report.append(f"  {name:<12} want={want:<7} wrong={wrong:>2}/{len(KS)} "
+                      f"(baseline {base})  {' '.join(curve)}")
+        if wrong > base:
+            regressions.append((name, base, wrong, curve))
+        elif wrong < base:
+            improvements.append((name, base, wrong))
+
+    detail = "\n".join(report)
+
+    # A probe that silently exercised nothing is worse than a failing one.
+    assert executed >= len(MODELS) * len(KS) // 2, (
+        f"only {executed} solves completed; the harness or the CLI is failing, "
+        f"so this run proves nothing\n{detail}"
+    )
+
+    assert not regressions, (
+        "scale invariance regressed — a model's verdict is wrong at more row "
+        "scalings than before. Multiplying a row by a positive constant cannot "
+        "change the feasible set, so every one of these is the same problem "
+        "answered two different ways:\n"
+        + "\n".join(
+            f"  {n}: {b} -> {w} wrong cells\n    {' '.join(c)}"
+            for n, b, w, c in regressions
+        )
+        + f"\n\nfull report:\n{detail}"
+    )
+
+    if improvements:
+        print("\nscale invariance improved (lower BASELINE_WRONG accordingly):")
+        for n, b, w in improvements:
+            print(f"  {n}: {b} -> {w}")
+    print(f"\nscale-invariance report ({executed} solves):\n{detail}")


### PR DESCRIPTION
Phase 0 of the scale-invariance plan. **No production code is touched** — this
lands the measurement that makes every later step checkable.

## The invariant

Multiplying a constraint row by a positive constant leaves the feasible set
*exactly* unchanged. It is the same problem written differently, so the verdict
at every scale must agree. Where it doesn't, a modelling choice carrying no
mathematical content is silently changing the answer.

## Why a new harness rather than the corpus

The 477-problem corpus sweep **cannot detect this class of defect** — real models
cluster near O(1), so the stress has to be manufactured. That gap is precisely
how the #376 regression reached `main`: the corpus showed zero verdict changes,
and "no false-positive risk" was concluded from a measurement that could not have
detected the failure. This harness sweeps 25 decades and looks for the decade
where a verdict flips.

## Baseline on current `main` (91 solves)

```
feas_simple  want=SOLVED  wrong= 0/13
feas_two     want=SOLVED  wrong= 0/13
feas_eq      want=SOLVED  wrong= 0/13
inf_372      want=INFEAS  wrong= 5/13   SOLVED SOLVED SOLVED FAIL FAIL INFEAS ...
inf_clear    want=INFEAS  wrong= 5/13   SOLVED SOLVED SOLVED FAIL FAIL INFEAS ...
inf_two      want=INFEAS  wrong= 5/13   SOLVED SOLVED SOLVED FAIL FAIL INFEAS ...
inf_eq       want=INFEAS  wrong=13/13   FAIL at every scale
```

**Feasible models are already perfectly scale-invariant.** Infeasible ones are
not, and the sharpest cell is worse than anything found so far:

| model | verdict |
|---|---|
| `x >= 2` over `x ∈ [0,1]` | `Infeasible_Problem_Detected` (200) |
| `1e-12·x >= 2e-12` over `x ∈ [0,1]` | **`Solve_Succeeded` (0)** |

Same empty feasible set, opposite verdicts. Below roughly `1e-8` the violation
falls under an absolute feasibility tolerance and POUNCE accepts an infeasible
model as solved.

`inf_eq` is a separate finding the harness happened to surface: a contradictory
equality pair (`x == 0.2` and `x == 0.8`) reports `FAIL` at **every** scale, so it
is uniformly wrong rather than scale-dependent. Not addressed here.

## Both directions, deliberately

Feasible models guard against tightening a tolerance into false infeasibility;
infeasible models guard against loosening one into a missed verdict. A relative
tolerance is *more* permissive at large scale, so a fix aimed only at false
positives could quietly lose true infeasibility verdicts — the inverse of the
#376 mistake. **A later step that improves one column while worsening the other
is a regression, not progress**, and this harness is what makes that visible.

## Ratchet, not zero

The assertion compares against the recorded baseline. The implementation is not
scale-invariant today, and a zero assertion would fail on arrival. Lowering these
numbers is the objective of the migration steps that follow. The test also fails
loudly if it completes too few solves, so it cannot pass vacuously.

## Verification

- No crate changes: `git diff --stat HEAD -- crates/` is empty.
- Workspace suite: **2175 passed, 0 failed**.
- Both consistency guards clean.
- The harness itself: 91 solves, passes against its own baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
