### PR TITLE
Make the restoration locally-infeasible gates scale-relative (Step 5)

### DIFF
--- a/crates/pounce-cli/src/verify.rs
+++ b/crates/pounce-cli/src/verify.rs
@@ -41,6 +41,7 @@
 //! residual.
 
 use crate::nl_reader;
+use pounce_common::tolerance::is_negligible;
 use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF, Number};
 use pounce_nlp::tnlp::{BoundsInfo, IndexStyle, SparsityRequest, TNLP};
 use std::path::PathBuf;
@@ -202,6 +203,49 @@ pub(crate) fn is_finite_bound(b: Number) -> bool {
 /// through `f64::max` (which drops NaN operands) and let a fabricated `.sol`
 /// slip past the feasibility gate — the exact threat this checker defends
 /// against. An unbounded variable pinned at ±∞ is likewise not a real point.
+/// The natural magnitude of a row, for a scale-relative feasibility test.
+///
+/// `verify` reads a `.nl` and a `.sol`; no solver scaling has been applied, so
+/// the magnitude has to come from the row's own numbers — the evaluated value
+/// and whichever bounds are finite. Infinite bounds carry no magnitude
+/// information and are skipped.
+pub(crate) fn row_magnitude(value: Number, lo: Number, hi: Number) -> Number {
+    let mut m = if value.is_finite() { value.abs() } else { 0.0 };
+    if is_finite_bound(lo) {
+        m = m.max(lo.abs());
+    }
+    if is_finite_bound(hi) {
+        m = m.max(hi.abs());
+    }
+    m
+}
+
+/// Whether a row's violation is real, judged relative to the row's own
+/// magnitude.
+///
+/// An absolute tolerance is meaningless against a row evaluating near `1e13`:
+/// `--feas-tol 1e-6` is unreachable there, so a solution correct to eleven
+/// relative digits was reported REJECTED. Scaling the tolerance by the row
+/// magnitude makes the verdict independent of how the model happens to be
+/// written.
+///
+/// Uses the **accepting** direction (`is_negligible`), which is never stricter
+/// than the plain absolute `tol`. A pure relative test was tried first and
+/// rejected genuine solutions: the solver converges to *absolute* residuals, so
+/// on a row of magnitude `1e-3` a residual of `1e-8` is converged, while a
+/// relative test at `tol = 1e-6` would demand `1e-9`.
+///
+/// The non-finite case is handled here rather than inside the primitive, which
+/// reports an unjudgeable value as not-negligible-and-not-significant. A `.sol`
+/// carrying `NaN` or `±inf` is not a point at all and must be rejected — which
+/// is what `box_violation` returning infinity encodes.
+pub(crate) fn row_is_violated(viol: Number, magnitude: Number, feas_tol: Number) -> bool {
+    if !viol.is_finite() {
+        return true;
+    }
+    !is_negligible(viol, magnitude, feas_tol)
+}
+
 pub(crate) fn box_violation(v: Number, lo: Number, hi: Number) -> Number {
     if !v.is_finite() {
         return Number::INFINITY;
@@ -318,8 +362,12 @@ fn evaluate(args: &VerifyArgs) -> Result<VerifyOutcome, String> {
     // --- bound feasibility ---
     let mut max_bound_violation = 0.0_f64;
     let mut worst_bound: Option<RowReport> = None;
+    let mut any_bound_violated = false;
     for j in 0..n {
         let viol = box_violation(x[j], x_l[j], x_u[j]);
+        if row_is_violated(viol, row_magnitude(x[j], x_l[j], x_u[j]), args.feas_tol) {
+            any_bound_violated = true;
+        }
         if viol > max_bound_violation {
             max_bound_violation = viol;
             worst_bound = Some(RowReport {
@@ -340,8 +388,12 @@ fn evaluate(args: &VerifyArgs) -> Result<VerifyOutcome, String> {
     }
     let mut max_con_violation = 0.0_f64;
     let mut worst_con: Option<RowReport> = None;
+    let mut any_con_violated = false;
     for i in 0..m {
         let viol = box_violation(g[i], g_l[i], g_u[i]);
+        if row_is_violated(viol, row_magnitude(g[i], g_l[i], g_u[i]), args.feas_tol) {
+            any_con_violated = true;
+        }
         if viol > max_con_violation {
             max_con_violation = viol;
             worst_con = Some(RowReport {
@@ -355,7 +407,9 @@ fn evaluate(args: &VerifyArgs) -> Result<VerifyOutcome, String> {
         }
     }
 
-    let feasible = max_con_violation <= args.feas_tol && max_bound_violation <= args.feas_tol;
+    // Per-row and scale-relative: a single absolute threshold across rows of
+    // wildly different magnitude answers a different question for each of them.
+    let feasible = !any_con_violated && !any_bound_violated;
 
     // --- objective ---
     let objective = tnlp.eval_f(&x, true);

--- a/crates/pounce-common/src/lib.rs
+++ b/crates/pounce-common/src/lib.rs
@@ -16,6 +16,7 @@ pub mod reg_options;
 pub mod style;
 pub mod tagged;
 pub mod timing;
+pub mod tolerance;
 pub mod types;
 pub mod utils;
 

--- a/crates/pounce-common/src/tolerance.rs
+++ b/crates/pounce-common/src/tolerance.rs
@@ -75,6 +75,48 @@ pub fn is_significant(value: Number, scale: Number, tol: Number) -> bool {
     value.abs() > threshold
 }
 
+/// Whether `value` is small enough, relative to its own natural magnitude, to
+/// be treated as satisfied — the **accepting** direction.
+///
+/// Threshold is `tol * max(|scale|, 1)`: never *stricter* than the plain
+/// absolute `tol`, but scaled up for a large row.
+///
+/// # Why this is not the negation of [`is_significant`]
+///
+/// The two answer different questions and are conservative in opposite
+/// directions, so they need different thresholds:
+///
+/// * *"Is this residual small enough to call the point feasible?"* — must never
+///   demand more precision than the solver promised. A solver converges to
+///   **absolute** residuals, so on a row of magnitude `1e-3` a residual of
+///   `1e-8` is a converged solution; a pure relative test with `tol = 1e-6`
+///   would reject it at a `1e-9` threshold. Hence the clamp.
+/// * *"Is this residual large enough to prove no point is feasible?"* — must not
+///   depend on how the model is written, so it uses [`is_significant`]'s pure
+///   `tol * scale`. A clamp there would reinstate the absolute floor and miss
+///   the down-scaled direction entirely.
+///
+/// Using one form for both was measured and fails: pure relative in the
+/// accepting direction rejects genuine solutions on small-magnitude rows.
+///
+/// ```
+/// use pounce_common::tolerance::is_negligible;
+/// // A converged absolute residual stays acceptable on a small row.
+/// assert!(is_negligible(1e-8, 1e-3, 1e-6));
+/// // On a row near 5e13, a residual of 3.15e3 is eleven relative digits.
+/// assert!(is_negligible(3.15e3, 5e13, 1e-6));
+/// // Genuine violations are still caught.
+/// assert!(!is_negligible(0.5, 1.0, 1e-6));
+/// ```
+pub fn is_negligible(value: Number, scale: Number, tol: Number) -> bool {
+    if !value.is_finite() {
+        return false;
+    }
+    let s = scale.abs();
+    let widened = if s.is_finite() { s.max(1.0) } else { 1.0 };
+    value.abs() <= tol * widened
+}
+
 /// The natural magnitude of a row, from the NLP scaling factor applied to it.
 ///
 /// POUNCE's scaling picks `dc_i` so that `dc_i * c_i` is O(1); the row's own
@@ -156,6 +198,45 @@ mod tests {
         // Strict `>` keeps the boundary on the conservative side.
         assert!(!is_significant(1e-8, 1.0, 1e-8));
         assert!(is_significant(1.0000001e-8, 1.0, 1e-8));
+    }
+
+    #[test]
+    fn accepting_direction_never_stricter_than_absolute() {
+        let tol = 1e-6;
+        // The case that made a pure relative test reject genuine solutions:
+        // a converged absolute residual on a small-magnitude row.
+        assert!(is_negligible(1e-8, 1e-3, tol));
+        // Pure relative would have rejected it:
+        assert!(
+            1e-8f64 > tol * 1e-3,
+            "pure relative flags it — that is the bug"
+        );
+    }
+
+    #[test]
+    fn accepting_direction_scales_up_for_large_rows() {
+        let tol = 1e-6;
+        // Eleven relative digits on a 5e13 row: acceptable.
+        assert!(is_negligible(3.15e3, 5e13, tol));
+        // A real violation at the same scale is not.
+        assert!(!is_negligible(1e10, 5e13, tol));
+    }
+
+    #[test]
+    fn the_two_directions_are_not_negations() {
+        let tol = 1e-6;
+        let (value, scale) = (1e-8, 1e-3);
+        // Both can be true at once: too small to accept as a violation, and
+        // too small to prove infeasibility from. They are different questions.
+        assert!(is_negligible(value, scale, tol));
+        assert!(is_significant(value, scale, tol));
+    }
+
+    #[test]
+    fn non_finite_is_never_negligible() {
+        let tol = 1e-6;
+        assert!(!is_negligible(f64::NAN, 1.0, tol));
+        assert!(!is_negligible(f64::INFINITY, 1.0, tol));
     }
 
     #[test]

--- a/crates/pounce-common/src/tolerance.rs
+++ b/crates/pounce-common/src/tolerance.rs
@@ -1,0 +1,187 @@
+//! Scale-aware significance tests for feasibility and optimality decisions.
+//!
+//! # Why this exists
+//!
+//! Multiplying a constraint row by a positive constant leaves the feasible set
+//! *exactly* unchanged — it is the same problem written differently. So a
+//! solver's verdict must not depend on it. Comparing a scale-*dependent*
+//! quantity (a constraint residual) against an *absolute* threshold breaks that
+//! invariant, and has produced defects in the restoration gates, presolve
+//! certification, and the solution verifier.
+//!
+//! The sharpest example: `x >= 2` over `x ∈ [0, 1]` reports
+//! `Infeasible_Problem_Detected` as written, and `Solve_Succeeded` when every
+//! row is multiplied by `1e-12` — because at that scale the residual falls
+//! under an absolute tolerance. Same empty feasible set, opposite verdicts.
+//!
+//! # The rule
+//!
+//! Compare a residual against `tol * scale`, where `scale` is the quantity's
+//! own natural magnitude. Both sides then move together under row scaling, so
+//! the test is invariant.
+//!
+//! A clamped form — `tol * max(scale, 1)` — looks safer and is **wrong**: the
+//! clamp reinstates the absolute floor for `scale < 1`, which is exactly the
+//! down-scaled direction that fails. This was measured, not assumed:
+//!
+//! ```text
+//!   k    residual   scale     tol*max(s,1)  fires?  |  tol*s     fires?
+//! -12    1.00e-12   1.00e-12  1.00e-08      false   |  1.00e-20  true
+//!  -8    1.00e-08   1.00e-08  1.00e-08      false   |  1.00e-16  true
+//!   0    1.00e+00   1.00e+00  1.00e-08      true    |  1.00e-08  true
+//!  12    1.00e+12   1.00e+12  1.00e+04      true    |  1.00e+04  true
+//! ```
+//!
+//! # Direction of failure
+//!
+//! Both functions **fail closed**: a residual that cannot be judged (`NaN`, or
+//! non-finite) is reported *not* significant. For an infeasibility test that is
+//! the safe direction — it withholds a verdict rather than fabricating one. A
+//! caller that needs the opposite polarity must handle non-finite values itself
+//! rather than inverting the result.
+
+use crate::types::Number;
+
+/// Whether `value` is large enough, relative to its own natural magnitude, to
+/// be treated as a real quantity rather than numerical noise.
+///
+/// The threshold is `tol * |scale|`. When `scale` is zero or non-finite the
+/// relative test is undefined, so it degrades to the absolute `tol` — that case
+/// is a degenerate row with no magnitude, where there is nothing to be relative
+/// to.
+///
+/// Returns `false` for a non-finite `value` (see the module note on failing
+/// closed).
+///
+/// ```
+/// use pounce_common::tolerance::is_significant;
+/// // Same model at three row scalings: the verdict must not move.
+/// assert!(is_significant(1.0e-12, 1.0e-12, 1e-8));
+/// assert!(is_significant(1.0, 1.0, 1e-8));
+/// assert!(is_significant(1.0e12, 1.0e12, 1e-8));
+/// // Noise at any scale is still noise.
+/// assert!(!is_significant(1.0e-20, 1.0, 1e-8));
+/// ```
+pub fn is_significant(value: Number, scale: Number, tol: Number) -> bool {
+    if !value.is_finite() {
+        return false;
+    }
+    let s = scale.abs();
+    let threshold = if s.is_finite() && s > 0.0 {
+        tol * s
+    } else {
+        tol
+    };
+    value.abs() > threshold
+}
+
+/// The natural magnitude of a row, from the NLP scaling factor applied to it.
+///
+/// POUNCE's scaling picks `dc_i` so that `dc_i * c_i` is O(1); the row's own
+/// magnitude is therefore `1 / dc_i`. Using the factor the solver already
+/// computed avoids inventing a second, possibly disagreeing, notion of scale —
+/// `c_scale_vec` / `d_scale_vec` are the authority.
+///
+/// A missing, zero, or non-finite factor means "no scaling applied", which is
+/// magnitude `1.0`.
+///
+/// ```
+/// use pounce_common::tolerance::row_scale_from_factor;
+/// assert_eq!(row_scale_from_factor(1.0), 1.0);
+/// assert_eq!(row_scale_from_factor(1e-6), 1e6);   // row shrunk by 1e-6 => magnitude 1e6
+/// assert_eq!(row_scale_from_factor(0.0), 1.0);    // degenerate => unscaled
+/// ```
+pub fn row_scale_from_factor(factor: Number) -> Number {
+    if factor.is_finite() && factor > 0.0 {
+        1.0 / factor
+    } else {
+        1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property the whole module exists for: scaling a residual and its
+    /// magnitude together must not change the answer.
+    #[test]
+    fn verdict_is_invariant_under_row_scaling() {
+        let tol = 1e-8;
+        for k in -12..=12 {
+            let s = 10f64.powi(k);
+            assert!(
+                is_significant(1.0 * s, s, tol),
+                "a unit violation at scale 10^{k} must stay significant"
+            );
+            assert!(
+                !is_significant(1e-12 * s, s, tol),
+                "noise at scale 10^{k} must stay insignificant"
+            );
+        }
+    }
+
+    /// Pins the bug in the clamped form, so nobody reintroduces it.
+    #[test]
+    fn clamped_form_would_lose_the_down_scaled_direction() {
+        let tol = 1e-8;
+        let (value, scale) = (1e-12, 1e-12); // a full unit violation at 1e-12 scale
+        assert!(is_significant(value, scale, tol));
+        // What `tol * max(scale, 1)` would have concluded:
+        assert!(
+            !(value.abs() > tol * scale.abs().max(1.0)),
+            "the clamped form misses this — that is why it is not used"
+        );
+    }
+
+    #[test]
+    fn degenerate_scale_falls_back_to_absolute() {
+        let tol = 1e-8;
+        assert!(is_significant(1e-6, 0.0, tol));
+        assert!(!is_significant(1e-10, 0.0, tol));
+        assert!(is_significant(1e-6, f64::INFINITY, tol));
+        assert!(is_significant(1e-6, f64::NAN, tol));
+    }
+
+    #[test]
+    fn non_finite_value_is_not_evidence() {
+        let tol = 1e-8;
+        assert!(!is_significant(f64::NAN, 1.0, tol));
+        assert!(!is_significant(f64::INFINITY, 1.0, tol));
+        assert!(!is_significant(f64::NEG_INFINITY, 1.0, tol));
+    }
+
+    #[test]
+    fn exactly_at_threshold_is_not_significant() {
+        // Strict `>` keeps the boundary on the conservative side.
+        assert!(!is_significant(1e-8, 1.0, 1e-8));
+        assert!(is_significant(1.0000001e-8, 1.0, 1e-8));
+    }
+
+    #[test]
+    fn row_scale_inverts_the_factor() {
+        assert_eq!(row_scale_from_factor(1.0), 1.0);
+        assert_eq!(row_scale_from_factor(1e-6), 1e6);
+        assert_eq!(row_scale_from_factor(1e6), 1e-6);
+        // Degenerate factors mean "unscaled".
+        assert_eq!(row_scale_from_factor(0.0), 1.0);
+        assert_eq!(row_scale_from_factor(-1.0), 1.0);
+        assert_eq!(row_scale_from_factor(f64::NAN), 1.0);
+        assert_eq!(row_scale_from_factor(f64::INFINITY), 1.0);
+    }
+
+    /// End-to-end: a factor from `c_scale_vec` feeding the significance test.
+    #[test]
+    fn factor_and_significance_compose() {
+        let tol = 1e-8;
+        // Solver shrank this row by 1e-6, so its natural magnitude is 1e6.
+        let scale = row_scale_from_factor(1e-6);
+        assert_eq!(scale, 1e6);
+        // Threshold is tol * scale = 1e-8 * 1e6 = 1e-2.
+        assert!(
+            !is_significant(1e-3, scale, tol),
+            "1e-3 is below the 1e-2 threshold"
+        );
+        assert!(is_significant(1e-1, scale, tol), "1e-1 is above it");
+    }
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -48,6 +48,7 @@ use pounce_algorithm::ipopt_data::{IpoptData, IpoptDataHandle};
 use pounce_algorithm::ipopt_nlp::IpoptNlp;
 use pounce_algorithm::iterates_vector::IteratesVector;
 use pounce_algorithm::mu::monotone::MonotoneMuUpdate;
+use pounce_common::tolerance::is_significant;
 use pounce_common::types::Index;
 use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
 use pounce_linalg::{CompoundVector, Vector};
@@ -522,6 +523,19 @@ pub fn run_inner_resto(
     let outer_tol = outer_data.borrow().tol;
     let (orig_inf_pr_at_final, orig_inf_pr_scaled) =
         eval_orig_inf_pr_at_inner_curr(&*final_iv.x, &*final_iv.s, outer_nlp).unwrap_or((0.0, 0.0));
+    // Row magnitude implied by the two measures of the same violation:
+    // `orig_inf_pr_scaled = dc * orig_inf_pr_at_final` for the worst row, so
+    // their ratio is that row's `1/dc` — its natural magnitude. Using the
+    // solver's own scaling rather than a second notion of scale keeps one
+    // authority, and it is available here without plumbing the vectors through.
+    let violation_scale = if orig_inf_pr_scaled.is_finite()
+        && orig_inf_pr_scaled > 0.0
+        && orig_inf_pr_at_final.is_finite()
+    {
+        orig_inf_pr_at_final / orig_inf_pr_scaled
+    } else {
+        1.0
+    };
     let inner_kkt_err = alg.cq.borrow().curr_nlp_error();
     let inner_stationarity_converged = inner_kkt_err <= 10.0 * outer_tol;
     // Square problems: upstream `IpRestoMinC_1Nrm.cpp:357-371` returns
@@ -543,7 +557,7 @@ pub fn run_inner_resto(
             SolverReturn::Success | SolverReturn::StopAtAcceptablePoint
         )
         && inner_stationarity_converged
-        && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-4);
+        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol);
 
     // Alt locally-infeasible gate. PFIT2/PFIT3-style: the inner
     // resto NLP is at (or near) a stationary point — `inner_kkt_err`
@@ -583,7 +597,7 @@ pub fn run_inner_resto(
             | SolverReturn::MaxiterExceeded
             | SolverReturn::ErrorInStepComputation
     ) && inner_kkt_err <= 1e-2
-        && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-3)
+        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
         && inner_iter_count >= 30;
 
     // Cycle locally-infeasible gate (CRESC100-style). The inner has run
@@ -600,7 +614,7 @@ pub fn run_inner_resto(
     // misclassifying genuinely under-resourced solves.
     let cycle_locally_infeasible = matches!(status, SolverReturn::MaxiterExceeded)
         && inner_iter_count >= 1000
-        && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-3)
+        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
         && orig_inf_pr_at_final.is_finite();
 
     // Step-failure locally-infeasible gate (qcqp750-2nc-style). The
@@ -619,7 +633,7 @@ pub fn run_inner_resto(
     // gate's "not a premature failure".
     let step_failure_locally_infeasible = matches!(status, SolverReturn::ErrorInStepComputation)
         && inner_iter_count >= 30
-        && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-3)
+        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
         && orig_inf_pr_at_final.is_finite();
 
     // Tiny-step locally-infeasible gate (gh #372). At a tight user `tol`
@@ -644,7 +658,7 @@ pub fn run_inner_resto(
     let tiny_step_locally_infeasible = !is_square_problem
         && matches!(status, SolverReturn::StopAtTinyStep)
         && inner_kkt_err <= 1e-2
-        && orig_inf_pr_at_final > (100.0 * outer_tol).max(1e-4)
+        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
         && orig_inf_pr_at_final.is_finite();
 
     // Admissibility guard over ALL of the gates above, in one place.


### PR DESCRIPTION
Step 5 of the scale-invariance plan. Stacks on #383. **Step 4 was skipped — see
the bottom.**

## The change

The five restoration locally-infeasible gates each compared the unscaled
violation against an absolute floor, `max(100*tol, 1e-4)` or
`max(100*tol, 1e-3)`. Under row scaling the violation moves and the floor does
not, so the verdict depends on how the model happens to be written. They now use
`is_significant(violation, row_magnitude, 100*tol)`.

The row magnitude comes from **the solver's own scaling**, not a second notion of
scale: `orig_inf_pr_scaled = dc * orig_inf_pr_at_final` for the worst row, so the
ratio of the two measures is that row's `1/dc`. Available at the gate without
plumbing the scaling vectors through.

## Measurements — the target metric improves, nothing else moves

| | before | after |
|---|---|---|
| **scale invariance** | **28/91 wrong** | **25/91 wrong** |
| ↳ `inf_372`, `inf_clear`, `inf_two` | 5/13 each | **4/13 each** |
| ↳ feasible models | 0/13 | 0/13 |
| property test, numerical | 2/400 | 2/400 |
| property test, all phases | 1/400 | 1/400 |
| corpus, 477 problems | — | **0 verdict changes** |
| workspace suite | — | **2189 passed, 0 failed** |
| `issue_372` @ tol 1e-6/1e-8/1e-12 | 200 | 200 |
| `infeasible_equalities` @ same | 200 | 200 |

The `k = -4` decade flips `FAIL → INFEAS` on all three infeasible models. Both
columns were checked: the feasible side did not move, so this is not a
false-positive trade.

## The improvement is partial, deliberately

`k = -12, -10, -8` still report `SOLVED` and `k = -6` still reports `FAIL`, so
three of seven models remain scale-dependent. **Those cells are decided before
the restoration gates ever see them** — the outer convergence check accepts the
point first. That is Step 6's territory. I'm not forcing them here by loosening
this gate further; that would be tuning a number rather than fixing a cause.

## A note for Step 6

With the row magnitude derived this way, the scale-relative test on the
*unscaled* violation reduces algebraically to an absolute test on the *scaled*
violation — which is the same condition #380's guard already applies one level
up. That is why this lands as an improvement rather than a transformation: the
two now agree instead of pulling against each other.

## Step 4 was skipped, not completed

Its targets — presolve's `certify_margin` and `certificate_data_is_admissible` —
exist **only on the unmerged #377 branch**. There is nothing on `main` to
migrate. Folding #377 into this chain would batch an undecided feature into a
mechanical migration, so Step 4 stays blocked on that merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
