### PR TITLE
Finish the scale-invariance migration: Steps 4 and 6, and the baseline ratchet (#385)

### DIFF
--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -1015,6 +1015,8 @@ impl AlgorithmBuilder {
                 veto_fired: false,
                 acceptable_veto_fired: false,
                 veto_extra_iters: 0,
+                rel_infeas_extra_iters: 0,
+                prev_rel_viol: f64::NAN,
             });
 
         let init: Box<dyn crate::init::r#trait::IterateInitializer> = if self.warm_start_init_point

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -77,6 +77,18 @@ pub struct OptErrorConvCheck {
     /// terminate normally; correctness does not depend on the cap, because the
     /// refused certificate is restored either way.
     pub veto_extra_iters: Index,
+    /// Iterations on which the scale-relative feasibility veto blocked a
+    /// certificate (strict or acceptable) that the absolute tolerances had
+    /// passed. Bounded by [`VETO_MAX_EXTRA_ITERS`]; past the budget the veto
+    /// disengages and the run terminates as it would have without it, so the
+    /// worst case is a bounded number of extra iterations, never a lost
+    /// verdict. See [`Self::relative_viol_threshold`].
+    pub rel_infeas_extra_iters: Index,
+    /// Relative primal infeasibility at the previous
+    /// [`Self::note_infeasible_stationary`] call — the progress signal for the
+    /// relative arm's streak (see that method). `NAN` until first set, which
+    /// compares as "not improving" and lets the first iterate count.
+    pub prev_rel_viol: Number,
 }
 
 /// How many iterations the veto may spend before its bet is called off.
@@ -164,6 +176,8 @@ impl Default for OptErrorConvCheck {
             veto_fired: false,
             acceptable_veto_fired: false,
             veto_extra_iters: 0,
+            rel_infeas_extra_iters: 0,
+            prev_rel_viol: Number::NAN,
         }
     }
 }
@@ -280,17 +294,54 @@ impl OptErrorConvCheck {
         }
     }
 
+    /// Fraction of a row's own magnitude a violation must exceed before the
+    /// scale-relative machinery treats the row as genuinely violated —
+    /// used both to veto a success certificate and as an alternative
+    /// violation floor for rapid infeasibility detection.
+    ///
+    /// `max(100·constr_viol_tol, 1e-2)`: at the default `constr_viol_tol =
+    /// 1e-4` this is 1% — a row eaten to 1% of everything it is made of is not
+    /// a satisfied row at any scale. The `1e-2` floor is deliberate slack for
+    /// the accepting direction: an interior-point run converges inequality
+    /// residuals to *absolute* levels, so on a row of magnitude `1e-6` a
+    /// converged residual near `1e-9` is a solved row at 0.1% relative — a
+    /// tighter relative bar would veto genuine solutions on small-magnitude
+    /// rows, the exact failure the clamped form in
+    /// `pounce_common::tolerance::is_negligible` exists to avoid. The scale
+    /// non-invariance this leaves (`x >= 0.7` at row scale `1e-12` is violated
+    /// by 14%, well above any plausible bar; a knife-edge 0.9% violation is
+    /// not) is the conservative direction: too-loose withholds a verdict,
+    /// too-tight fabricates one.
+    fn relative_viol_threshold(&self) -> Number {
+        (100.0 * self.constr_viol_tol).max(1e-2)
+    }
+
     /// Pure predicate for a single infeasible-stationary iterate: the
-    /// constraint violation is bounded away from zero
-    /// (`constr_viol > infeas_viol_kappa · constr_viol_tol`) and the
-    /// scaled infeasibility gradient `‖Jᵀc‖/max(1,‖c‖)` is at or below
-    /// `infeas_stationarity_tol`. Returns `false` when rapid
+    /// constraint violation is bounded away from zero — absolutely
+    /// (`constr_viol > infeas_viol_kappa · constr_viol_tol`) **or relative to
+    /// the violated row's own magnitude** (`rel_viol` above
+    /// [`Self::relative_viol_threshold`]; a row violated by 10% of everything
+    /// it is made of is bounded away from feasible no matter how small its
+    /// numbers are) — and the scaled infeasibility gradient `‖Jᵀc‖/max(1,‖c‖)`
+    /// is at or below `infeas_stationarity_tol`. Returns `false` when rapid
     /// infeasibility detection is disabled (either knob non-positive).
-    fn is_infeasible_stationary(&self, constr_viol: Number, stationarity: Number) -> bool {
+    ///
+    /// The relative arm changes only this pre-filter; the verdict still
+    /// requires the direct no-descent confirmation in
+    /// `check_convergence_with_state`, which is what protects against the
+    /// false-infeasibility failures the surrogate alone was measured to
+    /// produce.
+    fn is_infeasible_stationary(
+        &self,
+        constr_viol: Number,
+        rel_viol: Number,
+        stationarity: Number,
+    ) -> bool {
         if self.infeas_stationarity_tol <= 0.0 || self.infeas_max_streak <= 0 {
             return false;
         }
-        constr_viol > self.infeas_viol_kappa * self.constr_viol_tol
+        (constr_viol > self.infeas_viol_kappa * self.constr_viol_tol
+            || rel_viol > self.relative_viol_threshold())
             && stationarity <= self.infeas_stationarity_tol
     }
 
@@ -301,8 +352,33 @@ impl OptErrorConvCheck {
     /// reaches `infeas_max_streak`, signalling the caller to terminate
     /// with `ConvergenceStatus::LocallyInfeasible`. The streak guards
     /// against firing on a transient flat spot.
-    fn note_infeasible_stationary(&mut self, constr_viol: Number, stationarity: Number) -> bool {
-        if self.is_infeasible_stationary(constr_viol, stationarity) {
+    ///
+    /// The **relative** arm additionally requires the relative violation to
+    /// have stopped improving — "bounded away from feasible" must mean *not
+    /// still converging*. The no-descent confirmation cannot provide that
+    /// guard here: it compares violations absolutely, so in the small-scale
+    /// regime the relative arm targets (violation ~1e-9 and falling), no
+    /// "materially less-violating" point registers and the confirmation is
+    /// vacuous. Measured on QSCORPIO: the detector fired at iteration 57 with
+    /// the endgame still cutting the violation 16× over its last five
+    /// iterations (4.6e-9 → 2.9e-10 relative 4.6e-2 → 2.9e-3); five more
+    /// iterations reached `Optimal Solution Found`. An iterate that improved
+    /// the relative violation by more than 10% since the previous check
+    /// therefore resets the streak; a genuinely infeasible row's violation is
+    /// pinned at its infeasibility gap and cannot improve at all.
+    fn note_infeasible_stationary(
+        &mut self,
+        constr_viol: Number,
+        rel_viol: Number,
+        stationarity: Number,
+    ) -> bool {
+        let still_improving = rel_viol < 0.9 * self.prev_rel_viol;
+        self.prev_rel_viol = rel_viol;
+        // Only the relative arm is progress-gated; the absolute arm keeps its
+        // own guard (the direct no-descent confirmation, which is meaningful
+        // at absolute violation scales).
+        let effective_rel = if still_improving { 0.0 } else { rel_viol };
+        if self.is_infeasible_stationary(constr_viol, effective_rel, stationarity) {
             self.infeas_streak += 1;
             self.infeas_streak >= self.infeas_max_streak
         } else {
@@ -368,12 +444,31 @@ impl ConvCheck for OptErrorConvCheck {
         let dual_inf = cq_ref.curr_unscaled_dual_infeasibility_max();
         let constr_viol = cq_ref.curr_unscaled_primal_infeasibility_max();
         let compl_inf = cq_ref.curr_unscaled_complementarity_max();
+        let rel_viol = cq_ref.curr_relative_primal_infeasibility_max();
         let curr_f = cq_ref.curr_f();
         let unscaled_err = cq_ref.curr_unscaled_nlp_error();
         // The gate asks whether *our* scaling clamped, not how the user chose
         // to scale their objective — see `certificate_masked`.
         let obj_scale = cq_ref.computed_obj_scaling_factor();
         drop(cq_ref);
+
+        // Scale-relative feasibility veto (#385, Step 6). The absolute
+        // `constr_viol_tol` gate cannot tell "satisfied" from "violated by 14%
+        // of everything the row is" once the row's numbers are small: `x >= 0.7`
+        // written as `1e-12·x >= 0.7e-12` has an absolute violation of `1e-13`
+        // at `x = 0.6` — under every absolute tolerance, while the same empty
+        // feasible set written at unit scale is reported infeasible. Refuse a
+        // certificate whose point still has an inequality row violated by more
+        // than `relative_viol_threshold` of its own magnitude, and let the run
+        // continue: for a genuinely infeasible model the rapid-infeasibility
+        // detection below then reaches the honest verdict (its violation floor
+        // understands the same relative measure), and for anything else the
+        // budget bounds the cost — after `VETO_MAX_EXTRA_ITERS` blocked
+        // iterations the veto disengages and the run terminates exactly as it
+        // would have, so no verdict is ever lost to it.
+        let rel_veto = rel_viol > self.relative_viol_threshold()
+            && self.rel_infeas_extra_iters < VETO_MAX_EXTRA_ITERS;
+        let mut rel_veto_blocked = false;
 
         // gh #200: refuse a certificate the objective scaling has masked, and
         // keep iterating. A constant objective scale cancels out of the Newton
@@ -428,7 +523,21 @@ impl ConvCheck for OptErrorConvCheck {
         }
 
         if !masked && self.passes_component_tols(nlp_err, dual_inf, constr_viol, compl_inf) {
-            return ConvergenceStatus::Converged;
+            if rel_veto {
+                rel_veto_blocked = true;
+                if self.rel_infeas_extra_iters == 0 {
+                    tracing::info!(
+                        rel_viol,
+                        constr_viol,
+                        threshold = self.relative_viol_threshold(),
+                        "refusing a success certificate: an inequality row is still \
+                         violated by more than the scale-relative threshold of its own \
+                         magnitude; continuing (bounded by the veto budget)"
+                    );
+                }
+            } else {
+                return ConvergenceStatus::Converged;
+            }
         }
         // `acceptable_iter == 0` disables acceptable-level termination
         // (upstream `IpOptErrorConvCheck.cpp:241`). See `check_convergence`.
@@ -436,8 +545,18 @@ impl ConvCheck for OptErrorConvCheck {
         // not merely swapped for an acceptable-level one at the same wrong
         // point. Acceptable-point *storage* is deliberately left un-vetoed —
         // that stashed point is the rollback target if the run later stalls.
-        let acceptable_now = self.acceptable_iter > 0
+        let mut acceptable_now = self.acceptable_iter > 0
             && self.passes_acceptable_tols(nlp_err, dual_inf, constr_viol, compl_inf, curr_f);
+        // The scale-relative veto covers the acceptable band for the same
+        // reason the masked-scale veto does: a refused strict certificate must
+        // not be swapped for an acceptable-level one at the same wrong point.
+        if acceptable_now && rel_veto {
+            acceptable_now = false;
+            rel_veto_blocked = true;
+        }
+        if rel_veto_blocked {
+            self.rel_infeas_extra_iters += 1;
+        }
         if self.note_acceptable(acceptable_now, masked) {
             return ConvergenceStatus::ConvergedToAcceptable;
         }
@@ -470,7 +589,7 @@ impl ConvCheck for OptErrorConvCheck {
             // that no local move reduces the violation -- is confirmed directly
             // before the verdict is issued.
             let stationarity = cq.borrow().curr_infeasibility_stationarity();
-            if self.note_infeasible_stationary(constr_viol, stationarity) {
+            if self.note_infeasible_stationary(constr_viol, rel_viol, stationarity) {
                 if cq.borrow().infeasibility_descent_available() {
                     // Descent exists: not a stationary point of the violation,
                     // so the surrogate was wrong here. Drop the streak and keep
@@ -579,8 +698,25 @@ impl ConvCheck for OptErrorConvCheck {
         let dual_inf = cq_ref.curr_unscaled_dual_infeasibility_max();
         let constr_viol = cq_ref.curr_unscaled_primal_infeasibility_max();
         let compl_inf = cq_ref.curr_unscaled_complementarity_max();
+        let rel_viol = cq_ref.curr_relative_primal_infeasibility_max();
         let curr_f = cq_ref.curr_f();
         drop(cq_ref);
+        // The scale-relative veto reaches acceptable-point *storage* too,
+        // unlike the masked-scale (#200) veto above it. That veto refuses a
+        // possibly-premature stop at a point that is still genuinely feasible,
+        // so the stash stays a legitimate rollback target. Here the point has
+        // an inequality row violated by more than the relative threshold of
+        // its own magnitude — it is not acceptable in any honest sense, and a
+        // stall later in the run must not roll back to it and surface
+        // `Solved_To_Acceptable_Level` on an infeasible model (measured: an
+        // infeasible row at scale `1e-10`, 100% violated, exited exactly that
+        // way through this stash). Budget-aware like the certificate veto, so
+        // a spent budget restores the old behaviour entirely.
+        if rel_viol > self.relative_viol_threshold()
+            && self.rel_infeas_extra_iters < VETO_MAX_EXTRA_ITERS
+        {
+            return false;
+        }
         self.passes_acceptable_tols(nlp_err, dual_inf, constr_viol, compl_inf, curr_f)
     }
 
@@ -597,6 +733,70 @@ mod tests {
     fn converges_at_tol() {
         let mut c = OptErrorConvCheck::new();
         assert_eq!(c.check_convergence(1e-9, 0), ConvergenceStatus::Converged);
+    }
+
+    /// The scale-relative arm of rapid infeasibility detection (#385 Step 6):
+    /// a row violated by a large fraction of its own magnitude is bounded away
+    /// from feasible no matter how small its numbers are, so the pre-filter
+    /// must fire even when the absolute violation is far below
+    /// `infeas_viol_kappa * constr_viol_tol`.
+    #[test]
+    fn relative_violation_arms_the_infeasibility_prefilter() {
+        let c = OptErrorConvCheck::new();
+        // `x >= 0.7` at row scale 1e-12: absolute violation 1e-13 (invisible
+        // to the absolute arm, floor is 1e-2), relative violation 0.14.
+        assert!(c.is_infeasible_stationary(1e-13, 0.14, 1e-9));
+        // The same iterate without the relative signal must NOT fire — this
+        // is exactly the old behaviour.
+        assert!(!c.is_infeasible_stationary(1e-13, 0.0, 1e-9));
+        // A converged small-magnitude row (residual 1e-9 on a 1e-6-bound row,
+        // 0.1% relative) stays under the 1% threshold.
+        assert!(!c.is_infeasible_stationary(1e-9, 1e-3, 1e-9));
+    }
+
+    /// The relative arm's streak resets while the relative violation is still
+    /// improving — "bounded away from feasible" must mean *not still
+    /// converging*. QSCORPIO's endgame was cutting its violation 16× over
+    /// five iterations when the un-guarded arm declared it locally
+    /// infeasible; five more iterations reached the optimum.
+    #[test]
+    fn improving_relative_violation_resets_the_streak() {
+        let mut c = OptErrorConvCheck::new();
+        c.infeas_max_streak = 3;
+        // A pinned relative violation (an infeasibility gap) accumulates.
+        assert!(!c.note_infeasible_stationary(1e-13, 0.14, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-13, 0.14, 1e-9));
+        assert!(c.note_infeasible_stationary(1e-13, 0.14, 1e-9));
+        // A geometrically shrinking one (a converging endgame) never fires.
+        let mut c = OptErrorConvCheck::new();
+        c.infeas_max_streak = 3;
+        let mut rel = 0.5;
+        for _ in 0..20 {
+            assert!(
+                !c.note_infeasible_stationary(1e-13, rel, 1e-9),
+                "a converging endgame must not be declared infeasible"
+            );
+            rel *= 0.5;
+        }
+    }
+
+    /// The relative-violation veto blocks a strict certificate the absolute
+    /// tolerances would grant, and its budget bounds the cost: once spent,
+    /// the certificate goes through exactly as before.
+    #[test]
+    fn relative_viol_threshold_is_floored() {
+        let mut c = OptErrorConvCheck::new();
+        // Default constr_viol_tol = 1e-4 -> threshold 1e-2.
+        assert_eq!(c.relative_viol_threshold(), 1e-2);
+        // A loosened constr_viol_tol loosens the relative bar with it.
+        c.constr_viol_tol = 1e-3;
+        assert_eq!(c.relative_viol_threshold(), 1e-1);
+        // A tightened one must not push the relative bar below 1% — an
+        // interior-point run converges inequality residuals to absolute
+        // levels, and a tighter relative bar vetoes genuine solutions on
+        // small-magnitude rows.
+        c.constr_viol_tol = 1e-8;
+        assert_eq!(c.relative_viol_threshold(), 1e-2);
     }
 
     #[test]
@@ -897,13 +1097,13 @@ mod tests {
         };
         // Violation well above 1e-2 and the infeasibility gradient
         // essentially zero → counts as infeasible-stationary.
-        assert!(c.is_infeasible_stationary(1e-1, 1e-9));
+        assert!(c.is_infeasible_stationary(1e-1, 0.0, 1e-9));
         // Violation above threshold but the gradient is not flat →
         // still making feasibility progress, does not count.
-        assert!(!c.is_infeasible_stationary(1e-1, 1e-3));
+        assert!(!c.is_infeasible_stationary(1e-1, 0.0, 1e-3));
         // Gradient flat but violation below threshold → nearly
         // feasible, does not count.
-        assert!(!c.is_infeasible_stationary(1e-3, 1e-9));
+        assert!(!c.is_infeasible_stationary(1e-3, 0.0, 1e-9));
     }
 
     #[test]
@@ -913,13 +1113,13 @@ mod tests {
             infeas_max_streak: 5,
             ..Default::default()
         };
-        assert!(!off_tol.is_infeasible_stationary(1e9, 0.0));
+        assert!(!off_tol.is_infeasible_stationary(1e9, 0.0, 0.0));
         let off_streak = OptErrorConvCheck {
             infeas_stationarity_tol: 1e-8,
             infeas_max_streak: 0,
             ..Default::default()
         };
-        assert!(!off_streak.is_infeasible_stationary(1e9, 0.0));
+        assert!(!off_streak.is_infeasible_stationary(1e9, 0.0, 0.0));
     }
 
     #[test]
@@ -933,9 +1133,9 @@ mod tests {
         };
         // Infeasible-stationary iterate: violation 1e-1 > 1e-2, flat
         // gradient. Streak accrues but does not fire until the third.
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-9));
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-9));
-        assert!(c.note_infeasible_stationary(1e-1, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
+        assert!(c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
     }
 
     #[test]
@@ -947,15 +1147,15 @@ mod tests {
             infeas_max_streak: 3,
             ..Default::default()
         };
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-9));
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
         // A non-stationary iterate (gradient not flat) resets the streak.
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-3));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-3));
         assert_eq!(c.infeas_streak, 0);
         // The streak must rebuild from scratch — no carry-over credit.
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-9));
-        assert!(!c.note_infeasible_stationary(1e-1, 1e-9));
-        assert!(c.note_infeasible_stationary(1e-1, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
+        assert!(!c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
+        assert!(c.note_infeasible_stationary(1e-1, 0.0, 1e-9));
     }
 
     #[test]
@@ -966,7 +1166,7 @@ mod tests {
             ..Default::default()
         };
         for _ in 0..20 {
-            assert!(!c.note_infeasible_stationary(1e9, 0.0));
+            assert!(!c.note_infeasible_stationary(1e9, 0.0, 0.0));
         }
         assert_eq!(c.infeas_streak, 0);
     }

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -844,6 +844,139 @@ impl IpoptCalculatedQuantities {
         c_max.max(dms_max)
     }
 
+    /// Largest primal infeasibility of an inequality row **relative to that
+    /// row's own magnitude**: `max_i |d_i − s_i| / max(|d_i|, |d_l_i|, |d_u_i|)`.
+    ///
+    /// This is the scale-free companion to
+    /// [`Self::curr_unscaled_primal_infeasibility_max`]. An absolute violation
+    /// measure cannot tell "satisfied" from "violated by 10% of everything the
+    /// row is" once the row's numbers are small — `x >= 0.7` written as
+    /// `1e-12·x >= 0.7e-12` has an absolute violation of `1e-13` at `x = 0.6`,
+    /// under every absolute tolerance, while the row is violated by a seventh
+    /// of its own right-hand side. The ratio is `0.14` at every writing of the
+    /// row.
+    ///
+    /// Computed entirely in the internally-scaled space: numerator and
+    /// denominator both carry the row scaling `dd_i`, so it cancels and the
+    /// ratio is invariant under it — which is the point.
+    ///
+    /// The magnitude comes from the row's **declared bounds only** — the
+    /// current value `d_i` is deliberately excluded. On an *active* row the
+    /// value converges to the bound, so for a zero-bound row (`g(x) >= 0`,
+    /// ubiquitous) both the violation and `|d_i|` go to zero together and
+    /// their ratio hovers near 1 at a perfectly converged point — including
+    /// `|d_i|` made HS13's genuine solution read as 100% violated and vetoed
+    /// its certificate. A zero bound also needs no relative treatment in the
+    /// first place: `s·g >= 0` is the same row at every `s`, so the absolute
+    /// test is already invariant there. Rows whose bounds are all zero or
+    /// non-finite therefore contribute nothing (the relative measure
+    /// abstains), as do equality rows — their right-hand side is folded into
+    /// `c(x) = 0`, so `|c_i|` *is* the violation and carries no independent
+    /// magnitude. Non-finite entries contribute nothing — an unjudgeable row
+    /// must not fabricate a relative verdict.
+    /// The violation judged is the **distance of `d(x)` outside the declared
+    /// box** — NOT the lifted residual `|d − s|` the absolute measure uses.
+    /// `|d − s|` only bounds the true violation from above: mid-solve the
+    /// slack lags `d` while `d` is comfortably inside its bounds, so a
+    /// slack-lag of 1% of a small row's magnitude read as "violated" at
+    /// points that are genuinely feasible. That armed the rapid-infeasibility
+    /// pre-filter at degenerate QP endgames, where the no-descent
+    /// confirmation is vacuous (the violation is already ~0, so no materially
+    /// less-violating point exists) — and 18 feasible CUTEr QPs were reported
+    /// locally infeasible. Measured, not hypothetical.
+    pub fn curr_relative_primal_infeasibility_max(&self) -> Number {
+        let dms = self.curr_d_minus_s();
+        if dms.dim() == 0 {
+            return 0.0;
+        }
+        let d = self.curr_d();
+        let (lo, hi, mask_l, mask_u) = {
+            let nlp = self.nlp.borrow();
+            // The *declared* bounds where the NLP tracks them: the live
+            // `d_l`/`d_u` carry the `bound_relax_factor` widening, under which
+            // a declared-zero bound reads as `~1e-8` — a fabricated magnitude
+            // for a row that has none (that misread both vetoed HS13's genuine
+            // solution and manufactured "relative" verdicts out of thin air).
+            let (mut cl, mut cu) = (nlp.d_l().make_new(), nlp.d_u().make_new());
+            match nlp.declared_d_bounds() {
+                Some((dl, du)) => {
+                    let (Some(cld), Some(cud)) = (
+                        cl.as_any_mut().downcast_mut::<DenseVector>(),
+                        cu.as_any_mut().downcast_mut::<DenseVector>(),
+                    ) else {
+                        return 0.0;
+                    };
+                    cld.set_values(&dl);
+                    cud.set_values(&du);
+                }
+                None => {
+                    cl.copy(nlp.d_l());
+                    cu.copy(nlp.d_u());
+                }
+            }
+            let mut lo = dms.make_new();
+            lo.set(0.0);
+            nlp.pd_l().mult_vector(1.0, &*cl, 0.0, &mut *lo);
+            let mut hi = dms.make_new();
+            hi.set(0.0);
+            nlp.pd_u().mult_vector(1.0, &*cu, 0.0, &mut *hi);
+            // A projected 0 is ambiguous — "no bound on this side" and "a
+            // declared zero bound" both read 0 — so project an all-ones
+            // vector through the same expansion to get presence masks.
+            let mut ones_l = nlp.d_l().make_new();
+            ones_l.set(1.0);
+            let mut mask_l = dms.make_new();
+            mask_l.set(0.0);
+            nlp.pd_l().mult_vector(1.0, &*ones_l, 0.0, &mut *mask_l);
+            let mut ones_u = nlp.d_u().make_new();
+            ones_u.set(1.0);
+            let mut mask_u = dms.make_new();
+            mask_u.set(0.0);
+            nlp.pd_u().mult_vector(1.0, &*ones_u, 0.0, &mut *mask_u);
+            (lo, hi, mask_l, mask_u)
+        };
+        let (Some(d), Some(lo), Some(hi), Some(mask_l), Some(mask_u)) = (
+            d.as_any().downcast_ref::<DenseVector>(),
+            lo.as_any().downcast_ref::<DenseVector>(),
+            hi.as_any().downcast_ref::<DenseVector>(),
+            mask_l.as_any().downcast_ref::<DenseVector>(),
+            mask_u.as_any().downcast_ref::<DenseVector>(),
+        ) else {
+            return 0.0;
+        };
+        if !(d.is_initialized()
+            && lo.is_initialized()
+            && hi.is_initialized()
+            && mask_l.is_initialized()
+            && mask_u.is_initialized())
+        {
+            return 0.0;
+        }
+        let dv = d.expanded_values();
+        let lov = lo.expanded_values();
+        let hiv = hi.expanded_values();
+        let mlv = mask_l.expanded_values();
+        let muv = mask_u.expanded_values();
+        let mut worst = 0.0_f64;
+        for i in 0..dv.len() {
+            let (has_l, has_u) = (mlv[i] > 0.5, muv[i] > 0.5);
+            let mut viol = 0.0_f64;
+            let mut mag = 0.0_f64;
+            if has_l {
+                viol = viol.max(lov[i] - dv[i]);
+                mag = mag.max(lov[i].abs());
+            }
+            if has_u {
+                viol = viol.max(dv[i] - hiv[i]);
+                mag = mag.max(hiv[i].abs());
+            }
+            if mag > 0.0 && mag.is_finite() && viol.is_finite() && viol > 0.0 {
+                worst = worst.max(viol / mag);
+            }
+        }
+        worst
+    }
+
     /// The objective scaling factor `df` currently in force (`1.0` when no
     /// objective scaling is active).
     ///

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -97,6 +97,18 @@ pub trait IpoptNlp: Nlp {
     fn d_l(&self) -> &dyn Vector;
     fn d_u(&self) -> &dyn Vector;
 
+    /// The *declared* compressed inequality bounds `(d_L, d_U)`, in the same
+    /// (internally scaled) space as [`Self::d_l`] / [`Self::d_u`] but without
+    /// the `bound_relax_factor` widening or safe-slack adjustments the live
+    /// vectors carry. The scale-relative feasibility measure keys row
+    /// magnitudes off these: on the live vector a relaxed zero bound reads as
+    /// `~1e-8`, fabricating a magnitude for a row that has none. `None` (the
+    /// default) means "not tracked" — callers should fall back to the live
+    /// bounds.
+    fn declared_d_bounds(&self) -> Option<(Vec<Number>, Vec<Number>)> {
+        None
+    }
+
     /// Bound expansion matrices: `Px_L` extracts the
     /// `x` components that have a finite lower bound, etc.
     fn px_l(&self) -> Rc<dyn Matrix>;

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -149,6 +149,16 @@ pub struct OrigIpoptNlp {
     c_scale: RefCell<Option<Vec<Number>>>,
     /// Same as [`Self::c_scale`] but for inequality rows.
     d_scale: RefCell<Option<Vec<Number>>>,
+    /// The *declared* compressed `d_L / d_U` — snapshotted (unscaled) at
+    /// [`Self::relax_bounds`] time, before `bound_relax_factor` widens the
+    /// live bounds and before any safe-slack adjustment moves them. The
+    /// scale-relative feasibility measure keys row magnitudes off these: a
+    /// relaxed zero bound reads as `~1e-8` on the live vector and would
+    /// fabricate a magnitude for a row that has none. `None` until
+    /// `relax_bounds` runs (direct drivers that skip it fall back to the
+    /// live bounds).
+    declared_d_l: RefCell<Option<Vec<Number>>>,
+    declared_d_u: RefCell<Option<Vec<Number>>>,
 
     // ----- vector / matrix spaces (shared via Rc) -----
     x_space: Rc<DenseVectorSpace>,
@@ -533,6 +543,8 @@ impl OrigIpoptNlp {
             computed_obj_scale: Cell::new(1.0),
             c_scale: RefCell::new(None),
             d_scale: RefCell::new(None),
+            declared_d_l: RefCell::new(None),
+            declared_d_u: RefCell::new(None),
             x_space,
             c_space,
             d_space,
@@ -687,6 +699,12 @@ impl OrigIpoptNlp {
     /// affect scaling — but the bounds themselves should be the
     /// post-relax values when they enter the algorithm).
     pub fn relax_bounds(&mut self, bound_relax_factor: Number, constr_viol_tol: Number) {
+        // Snapshot the declared inequality bounds before anything widens them
+        // — even when relaxation is disabled, so `declared_d_bounds` has one
+        // authoritative answer per solve. Safe-slack adjustments come later
+        // and only touch the live vectors.
+        *self.declared_d_l.borrow_mut() = Some(self.d_l.expanded_values());
+        *self.declared_d_u.borrow_mut() = Some(self.d_u.expanded_values());
         if bound_relax_factor <= 0.0 {
             return;
         }
@@ -697,6 +715,31 @@ impl OrigIpoptNlp {
             for x in xs.iter_mut() {
                 let delta = (relax * x.abs().max(1.0)).min(cap);
                 *x += sign * delta;
+            }
+        };
+        // Inequality-row bounds use a *scale-relative* delta (#385, Step 6):
+        // `min(relax, cap) · |b|`, with the absolute `min(relax, cap)` kept
+        // only for a declared-zero bound (`s·g >= 0` is the same row at every
+        // `s`, so zero has no scale and the absolute form is already
+        // invariant there). The upstream formula's `max(|b|, 1)` clamp is the
+        // same absolute floor this migration removes everywhere else: it
+        // relaxed a `2e-12`-bound row by `1e-8` — 5000× the bound — silently
+        // erasing every down-scaled constraint before the solver saw it,
+        // which is exactly how an infeasible model at row scale `1e-8` and
+        // below reported `Solve_Succeeded`. In the other direction the
+        // absolute `cap` pinned a `1e13`-bound row's relaxation at `1e-4` —
+        // relative `1e-17`, i.e. no relaxation at all. Both directions are
+        // now relative: `min(relax, cap)` is the *relative* width, identical
+        // to the upstream formula on `1 <= |b| <= cap/relax`, which is where
+        // the corpus lives. Variable bounds keep the upstream formula — row
+        // scaling never touches them, and their relaxation is not this
+        // change's business.
+        let apply_d = |v: &mut DenseVector, sign: Number| {
+            let rel_width = relax.min(cap);
+            let xs = v.values_mut();
+            for x in xs.iter_mut() {
+                let scale = if *x == 0.0 { 1.0 } else { x.abs() };
+                *x += sign * rel_width * scale;
             }
         };
         // The bound `Rc`s are uniquely owned (nothing clones them — the same
@@ -713,11 +756,11 @@ impl OrigIpoptNlp {
             Rc::get_mut(&mut self.x_u).expect("relax_bounds: x_u is uniquely owned"),
             1.0,
         );
-        apply(
+        apply_d(
             Rc::get_mut(&mut self.d_l).expect("relax_bounds: d_l is uniquely owned"),
             -1.0,
         );
-        apply(
+        apply_d(
             Rc::get_mut(&mut self.d_u).expect("relax_bounds: d_u is uniquely owned"),
             1.0,
         );
@@ -1839,6 +1882,25 @@ impl IpoptNlp for OrigIpoptNlp {
     fn d_u(&self) -> &dyn Vector {
         &*self.d_u
     }
+
+    fn declared_d_bounds(&self) -> Option<(Vec<Number>, Vec<Number>)> {
+        let mut dl = self.declared_d_l.borrow().clone()?;
+        let mut du = self.declared_d_u.borrow().clone()?;
+        // Return them in the live vectors' space: `apply_d_scale_to_bounds`
+        // scaled `d_l`/`d_u` in place after the snapshot was taken, so the
+        // same per-row factors apply here.
+        if let Some(dd) = self.d_scale.borrow().as_ref() {
+            let cls = self.adapter.borrow().classification().clone();
+            for (i, slot) in dl.iter_mut().enumerate() {
+                *slot *= dd[cls.d_l_map[i] as usize];
+            }
+            for (i, slot) in du.iter_mut().enumerate() {
+                *slot *= dd[cls.d_u_map[i] as usize];
+            }
+        }
+        Some((dl, du))
+    }
+
     fn px_l(&self) -> Rc<dyn Matrix> {
         Rc::clone(&self.px_l)
     }
@@ -3428,6 +3490,28 @@ mod tests {
         for (b, a) in x_u_before.iter().zip(nlp.x_u.values()) {
             assert!(a > b, "x_u should relax upward: {a} !> {b}");
         }
+    }
+
+    /// #385 Step 6: inequality-row bounds relax by a *scale-relative* delta
+    /// (`min(relax, cap) · |b|`), and the declared (pre-relax) bounds stay
+    /// available for the scale-relative feasibility measure — the live vector
+    /// alone cannot distinguish a declared `2e-12` bound from a relaxed zero.
+    #[test]
+    fn relax_bounds_is_scale_relative_on_d_and_snapshots_declared() {
+        // HS071's inequality row is `x1*x2*x3*x4 >= 25`.
+        let (_adapter, mut nlp) = build_orig_nlp();
+        assert_eq!(nlp.d_l.values(), &[25.0]);
+        assert_eq!(nlp.declared_d_bounds(), None, "no snapshot before relax");
+        nlp.relax_bounds(1e-2, 1.0);
+        // delta = min(1e-2, 1.0) * 25 = 0.25 — proportional to the bound, so
+        // the same row written at any scaling relaxes to the same feasible
+        // set. The upstream form `min(cap, relax*max(|b|,1))` coincides here;
+        // where they differ (|b| < 1) the old absolute floor erased
+        // down-scaled rows entirely (a 2e-12 bound relaxed by 1e-8).
+        assert_eq!(nlp.d_l.values(), &[25.0 - 0.25]);
+        let (dl, du) = nlp.declared_d_bounds().expect("snapshotted at relax");
+        assert_eq!(dl, vec![25.0], "declared bound is the pre-relax value");
+        assert!(du.is_empty() || du[0] >= 25.0); // HS071: no finite d upper
     }
 
     #[test]

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -43,6 +43,7 @@ use std::rc::Rc;
 use pounce_common::exception::SolverException;
 use pounce_common::options_list::OptionsList;
 use pounce_common::reg_options::RegisteredOptions;
+use pounce_common::tolerance::is_negligible;
 use pounce_common::types::{Index, Number};
 use pounce_nlp::expression_provider::ExpressionProvider;
 use pounce_nlp::tnlp::{
@@ -251,10 +252,12 @@ fn witness_refutes_infeasibility(
                 return false;
             }
             // Slack relative to the row's own magnitude: an absolute tolerance
-            // is meaningless against a row evaluating near 1e30.
+            // is meaningless against a row evaluating near 1e30. This is the
+            // accepting direction, so it goes through `is_negligible` — the
+            // shared clamped form, never stricter than the absolute `tol`.
             // Only *finite* bounds inform the scale. The unbounded sentinel
-            // (~1e19) would otherwise set eps around 1e11 and make every row
-            // look satisfied — which withdrew even correct verdicts.
+            // (~1e19) would otherwise set the slack around 1e11 and make every
+            // row look satisfied — which withdrew even correct verdicts.
             let fin = |b: Number| {
                 if b.is_finite() && b.abs() < crate::bound_tighten::INF_BOUND {
                     b.abs()
@@ -262,9 +265,9 @@ fn witness_refutes_infeasibility(
                     0.0
                 }
             };
-            let scale = v.abs().max(fin(g_l[i])).max(fin(g_u[i])).max(1.0);
-            let eps = tol * scale;
-            v >= g_l[i] - eps && v <= g_u[i] + eps
+            let scale = v.abs().max(fin(g_l[i])).max(fin(g_u[i]));
+            let viol = (g_l[i] - v).max(v - g_u[i]).max(0.0);
+            is_negligible(viol, scale, tol)
         });
         if feasible {
             return true;
@@ -315,9 +318,39 @@ fn certify_margin(tol: Number) -> Number {
     tol.max(1e-12)
 }
 
-/// Re-run FBBT with every constraint bound widened by [`certify_margin`].
-/// Returns `true` only if the problem is *still* infeasible with that slack —
-/// i.e. the infeasibility is robust, not a hair's-breadth modelling artifact.
+/// Whether some variable's crossed bounds are crossed by more than the solver
+/// itself would accept as feasible — the condition for promoting a Phase-1
+/// detection to a certified proof.
+///
+/// The scale is the crossed pair's own magnitude, through `is_negligible`'s
+/// clamped accepting form — deliberately NOT the pure-relative proving form
+/// (`is_significant`). The #380 rule binds here: a crossing so small that the
+/// solver's acceptance test would wave a point through must never be certified,
+/// or the same model reports "proved infeasible" with presolve on and
+/// `Solve_Succeeded` with it off. The clamp hazard that rules the proving form
+/// out for *row residuals* does not arise for bound crossings: row scaling
+/// divides out of a propagated bound (`s*x >= 2*s` implies `x >= 2` at every
+/// `s`), so crossings do not shrink in the down-scaled direction. What the
+/// relative part fixes is the *up-scaled* model — a crossing of `6e-5` on
+/// bounds near `3e11` is float noise (relative `2e-16`), and the absolute
+/// margin used to certify it.
+fn crossing_is_certifiable(x_l: &[Number], x_u: &[Number], tol: Number) -> bool {
+    x_l.iter()
+        .zip(x_u)
+        .any(|(&l, &u)| l > u && !is_negligible(l - u, l.abs().max(u.abs()), tol))
+}
+
+/// Re-run FBBT with every constraint's bounds widened by that row's own
+/// acceptance slack, `tol * max(|bound|, 1)` — the same clamped form
+/// `is_negligible` uses. Returns `true` only if the problem is *still*
+/// infeasible with that slack — i.e. the infeasibility is robust at the scale
+/// the row is written in, not a hair's-breadth modelling artifact.
+///
+/// Per-row rather than one absolute margin: an absolute `1e-8` widening is
+/// invisible on a row whose bounds sit near `5e13`, so an "infeasibility" of
+/// `3e3` there (eleven relative digits — a violation `pounce verify` accepts)
+/// would survive the probe and be certified, contradicting the verifier on the
+/// same model.
 ///
 /// Sound in the conservative direction: a false `false` merely withholds the
 /// proof and leaves the previous behavior (let the IPM decide), while a false
@@ -334,25 +367,35 @@ fn fbbt_infeasibility_survives_margin(
     g_u: &[Number],
     row_kept: &[bool],
     cfg: &crate::fbbt::FbbtConfig,
-    margin: Number,
+    tol: Number,
 ) -> bool {
+    let fin = |b: Number| {
+        if b.is_finite() && b.abs() < crate::bound_tighten::INF_BOUND {
+            b.abs()
+        } else {
+            0.0
+        }
+    };
+    let row_margin = |i: usize| -> Number { tol * fin(g_l[i]).max(fin(g_u[i])).max(1.0) };
     let g_l_relaxed: Vec<Number> = g_l
         .iter()
-        .map(|&v| {
+        .enumerate()
+        .map(|(i, &v)| {
             if v <= -crate::bound_tighten::INF_BOUND {
                 v
             } else {
-                v - margin
+                v - row_margin(i)
             }
         })
         .collect();
     let g_u_relaxed: Vec<Number> = g_u
         .iter()
-        .map(|&v| {
+        .enumerate()
+        .map(|(i, &v)| {
             if v >= crate::bound_tighten::INF_BOUND {
                 v
             } else {
-                v + margin
+                v + row_margin(i)
             }
         })
         .collect();
@@ -921,8 +964,6 @@ impl PresolveTnlp {
         if tighten_report.infeasible {
             // Measure the crossing *before* the restore below overwrites it.
             let crossing = (0..n).map(|j| x_l[j] - x_u[j]).fold(0.0_f64, f64::max);
-            x_l.copy_from_slice(&inner_x_l);
-            x_u.copy_from_slice(&inner_x_u);
             // Reaching here implies the tightening ran on an un-clamped box:
             // the aux rollback above either did not fire (empty reduction
             // stack ⇒ Phase 0 changed nothing) or fired and recomputed
@@ -932,12 +973,14 @@ impl PresolveTnlp {
             // discarded — a degenerate box must not reach the solver — but the
             // *verdict* now survives.
             // Phase 1 flags a crossing above its own `1e-12` test, which is
-            // far below what the solver treats as feasible. Measure the actual
-            // crossing (the crossed bounds are still in place here — they are
-            // restored on the next line) and certify only if it clears
-            // `certify_margin`, so a model POUNCE would solve to
-            // `Solve_Succeeded` can never be called proved infeasible.
-            let robust = crossing > certify_margin(self.opts.certify_tol);
+            // far below what the solver treats as feasible. Certify only a
+            // crossing the solver's own acceptance would call a real violation
+            // at that variable's scale (see `crossing_is_certifiable`), so a
+            // model POUNCE would solve to `Solve_Succeeded` can never be
+            // called proved infeasible.
+            let robust = crossing_is_certifiable(&x_l, &x_u, certify_margin(self.opts.certify_tol));
+            x_l.copy_from_slice(&inner_x_l);
+            x_u.copy_from_slice(&inner_x_u);
             if robust {
                 certified_infeasible = Some(InfeasibilityProof::BoundPropagation);
             }
@@ -974,17 +1017,26 @@ impl PresolveTnlp {
         // `honor_original_bounds`. Clamping to the original box keeps the
         // reported point admissible.
         //
-        // Only *sub-margin* crossings collapse. A crossing the solver itself
-        // would call a real violation — above `certify_margin` — is not float
-        // noise; it is a user-declared empty box (`x in [5, 3]`) on a variable
-        // no linear row ever propagated into, which Phase 1 therefore never
-        // flagged. Collapsing that would turn `Invalid_Problem_Definition`
-        // into `Solve_Succeeded` at a point the model excludes — a wrong
-        // answer replacing a correct error. Those stay crossed so the solver
-        // rejects them exactly as it does with presolve off.
-        let collapse_margin = certify_margin(self.opts.certify_tol);
+        // Only *negligible* crossings collapse — `is_negligible` at the
+        // crossed pair's own magnitude, the exact complement of
+        // `crossing_is_certifiable`, so every crossing is either collapsed
+        // here or certifiable there, never both. A crossing the solver itself
+        // would call a real violation is not float noise; it is a
+        // user-declared empty box (`x in [5, 3]`) on a variable no linear row
+        // ever propagated into, which Phase 1 therefore never flagged.
+        // Collapsing that would turn `Invalid_Problem_Definition` into
+        // `Solve_Succeeded` at a point the model excludes — a wrong answer
+        // replacing a correct error. Those stay crossed so the solver rejects
+        // them exactly as it does with presolve off.
+        let collapse_tol = certify_margin(self.opts.certify_tol);
         for j in 0..n {
-            if x_l[j] > x_u[j] && x_l[j] - x_u[j] <= collapse_margin {
+            if x_l[j] > x_u[j]
+                && is_negligible(
+                    x_l[j] - x_u[j],
+                    x_l[j].abs().max(x_u[j].abs()),
+                    collapse_tol,
+                )
+            {
                 let mid = (0.5 * (x_l[j] + x_u[j]))
                     .max(inner_x_l[j])
                     .min(inner_x_u[j]);
@@ -1086,11 +1138,16 @@ impl PresolveTnlp {
                     if tighten_report.infeasible {
                         // Measure the crossing before the restore wipes it.
                         let crossing = (0..n).map(|j| x_l[j] - x_u[j]).fold(0.0_f64, f64::max);
+                        // Derived on the rolled-back, un-clamped box, so the
+                        // aux elimination cannot be to blame — certifiable when
+                        // the crossing is real at the variable's own scale.
+                        let robust = crossing_is_certifiable(
+                            &x_l,
+                            &x_u,
+                            certify_margin(self.opts.certify_tol),
+                        );
                         x_l.copy_from_slice(&inner_x_l);
                         x_u.copy_from_slice(&inner_x_u);
-                        // Derived on the rolled-back, un-clamped box, so the
-                        // aux elimination cannot be to blame — certifiable.
-                        let robust = crossing > certify_margin(self.opts.certify_tol);
                         if robust {
                             certified_infeasible = Some(InfeasibilityProof::BoundPropagation);
                         }

--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -123,9 +123,9 @@ BASELINE_WRONG = {
     "feas_simple": 0,
     "feas_two": 0,
     "feas_eq": 0,
-    "inf_372": 4,
-    "inf_clear": 4,
-    "inf_two": 4,
+    "inf_372": 0,
+    "inf_clear": 0,
+    "inf_two": 0,
     "inf_eq": 13,
 }
 

--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -123,9 +123,9 @@ BASELINE_WRONG = {
     "feas_simple": 0,
     "feas_two": 0,
     "feas_eq": 0,
-    "inf_372": 5,
-    "inf_clear": 5,
-    "inf_two": 5,
+    "inf_372": 4,
+    "inf_clear": 4,
+    "inf_two": 4,
     "inf_eq": 13,
 }
 


### PR DESCRIPTION
Fixes #385.

Finishes the scale-invariance migration: the baseline ratchet, Step 4
(presolve certification thresholds), and Step 6 (the outer convergence
acceptance) — the layer every previous step stopped short of.

## Headline result

The three inequality models in the scale-invariance harness go from 4/13
wrong cells each to **0/13: `INFEAS` at every row scaling from 1e-12 to
1e+12**, with the feasible models untouched at 0/13. Harness total across
the whole migration: 28/91 wrong cells before #384 → **13/91**, and every
remaining wrong cell is `inf_eq` — equality rows fold their RHS into
`c(x) = 0` and have no independent magnitude to be relative to (filed as #387).

## Step 6 — three mechanisms, one root cause

An infeasible model at row scale 1e-12 reported `Solve_Succeeded` because
three absolute floors conspired:

1. **`bound_relax_factor` erased the constraint first.** Its
   `min(cap, relax·max(|b|,1))` formula relaxed a declared `2e-12` bound
   by `1e-8` — 5000× the bound. Inequality-row deltas are now
   scale-relative (`min(relax, cap)·|b|`; a declared-zero bound keeps the
   absolute width — zero has no scale, and `s·g ≥ 0` is the same row at
   every `s`). Identical to upstream on `1 ≤ |b| ≤ cap/relax`, where the
   corpus lives. Variable bounds keep the upstream formula.
2. **The acceptance gate couldn't see the violation.** New
   `IpoptCq::curr_relative_primal_infeasibility_max` (violation of each
   inequality row relative to its *declared* magnitude, computed in scaled
   space so row scaling cancels) plus a budget-bounded veto on strict and
   acceptable certificates — and on acceptable-point *storage*, which the
   stall-rollback path otherwise converts into `Solved_To_Acceptable_Level`
   at a 100%-violated point. Past the budget the veto disengages: worst
   case is bounded extra iterations, never a lost verdict.
3. **Rapid infeasibility detection couldn't fire either** — its violation
   floor is absolute. The relative measure is an alternative arm of its
   pre-filter; the direct no-descent confirmation still guards the verdict.

## What the corpus taught (all three found by measurement, then fixed)

- **HS13**: magnitude must come from *declared bounds only* — on an active
  zero-bound row, value and violation vanish together and their ratio
  hovers near 1 at a perfectly converged point. Zero-bound rows abstain.
- **18 feasible CUTEr QPs**: the violation judged must be the distance of
  `d(x)` outside the declared box, **not** the lifted `|d − s|` — slack
  lag reads as violation at feasible endgames, exactly where the
  no-descent confirmation is vacuous.
- **QSCORPIO**: the relative arm is progress-gated — an endgame still
  cutting its violation 16× per five iterations is *converging*, not
  "bounded away from feasible". A pinned infeasibility gap cannot improve.

## Step 4 — presolve certification thresholds

Crossing certification, the collapse guard, and the FBBT margin probe now
judge at each quantity's own scale through the shared `is_negligible`
(certification = its complement: never certify what the solver's own
acceptance would wave through, per #380). Witness refutation now literally
calls the primitive instead of an inline copy. Measured: no verdict moves
— the witness-refutation gate above both paths was already scale-aware and
catching what the inner thresholds missed; now they agree by construction.

## Validation

| check | result |
|---|---|
| scale-invariance harness | 25/91 → 13/91 wrong; three models perfect 0/13; baselines ratcheted 4/4/4 → 0/0/0 |
| corpus, 1437 `.nl` (base vs branch) | **0 verdict changes** (only 30s-cap timing flips; each solves to the identical code serially on both binaries) |
| workspace suite | 2200 passed / 0 failed (incl. HS13 hard start, #200 veto, #372/#376/#380 regressions) |
| 200-instance feasible-by-construction property test | ≤ 4/200 false positives, unchanged |
| fmt / clippy / release-consistency guard | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
