### PR TITLE
Report proved infeasibility, not a DOF failure, for contradictory over-determined equalities (#387)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — provably infeasible over-determined systems reported a DOF failure (#387)
+
+- **A contradictory over-determined equality system now reports
+  `Infeasible_Problem_Detected` (AMPL 200 band) instead of
+  `NotEnoughDegreesOfFreedom` (504).** `x == 0.2` with `x == 0.8` over
+  `x in [0, 1]` has an empty feasible set — about as provable as infeasibility
+  gets — yet it exited through the too-few-degrees-of-freedom gate (1 variable,
+  2 equality rows) before any iteration ran, so nothing downstream ever got the
+  chance to look at the constraints. On the scale-invariance harness the model
+  was wrong at all 13 row scalings; it is now wrong at 3 (see below).
+  - The DOF gate now consults presolve's bound-propagation certification on its
+    failure path before reporting the structural error. The probe runs only when
+    the gate fires, is independent of the `presolve` master switch (nothing is
+    transformed — the wrapper is dropped without solving through it), and
+    inherits the certification's fail-closed safety net wholesale: the crossing
+    must exceed the solver's own acceptance margin at the crossed pair's scale,
+    and a concrete witness point satisfying every constraint withdraws the
+    verdict.
+  - Consequences of fail-closed: a *consistent* over-determined system still
+    reports the DOF error, and at row scales at or below ~`1e-8` — where every
+    point in the box satisfies both rows within the solver's own acceptance
+    tolerance — the proof is withheld and the DOF error stands. Those are the
+    3 remaining wrong cells in `test_scale_invariance.py`'s `inf_eq` baseline
+    (13 → 3).
+  - Also fixed on the way: the CLI's `CountingTnlp` / `SeededTnlp` wrappers did
+    not forward `get_variables_linearity` / `get_objective_variables_linearity`
+    / `get_constraints_linearity` (trait default `false`), so anything stacked
+    above them — including this probe — saw every row as nonlinear and silently
+    lost linear-row bound propagation.
+  - What remains of #387: equality rows still have no scale-relative *runtime*
+    feasibility measure (`curr_relative_primal_infeasibility_max` skips the `c`
+    block because the fold into `c(x) = 0` erases the RHS magnitude), so a
+    genuinely *nonlinear* equality contradiction — out of bound propagation's
+    reach — still depends on absolute tolerances.
+
 ### Added — presolve can now certify infeasibility instead of discarding the proof
 
 - **When presolve proves the feasible region empty, that proof is now the

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1422,6 +1422,42 @@ impl IpoptApplication {
     /// Constrained-NLP path: build adapter → OrigIpoptNlp → algorithm
     /// bundle, run `optimize`, populate statistics, and call
     /// `finalize_solution` on the user's TNLP.
+    /// Whether an over-determined model (more equality rows than free
+    /// variables) is *provably* infeasible by linear bound propagation.
+    ///
+    /// Consulted only on the `NotEnoughDegreesOfFreedom` failure path, where
+    /// the solve never runs and therefore can never itself discover the
+    /// infeasibility (gh#387). Builds a throwaway presolve wrapper with only
+    /// Phase 1 (bound tightening) enabled and asks it for a certified proof —
+    /// this inherits the certification safety net wholesale: the crossing must
+    /// exceed the solver's own acceptance margin at the crossed pair's scale,
+    /// and a concrete witness point satisfying every constraint withdraws the
+    /// verdict. A `false` here costs nothing but keeping the DOF error.
+    ///
+    /// Deliberately independent of the `presolve` master switch: this is not a
+    /// model transformation (the wrapper is dropped without solving through
+    /// it), it is a last check before reporting a structural error for a
+    /// problem whose verdict is already decided.
+    fn overdetermined_model_certified_infeasible(&self, tnlp: &Rc<RefCell<dyn TNLP>>) -> bool {
+        let mut opts = pounce_presolve::PresolveOptions::from_options_list(&self.options)
+            .unwrap_or_else(|_| pounce_presolve::PresolveOptions::defaults());
+        opts.enabled = true;
+        opts.bound_tightening = true;
+        // Certification needs Phase 1 only; every transformative or
+        // diagnostic phase is dead weight on a wrapper that is never
+        // solved through.
+        opts.auxiliary = false;
+        opts.fbbt = false;
+        opts.redundant_constraint_removal = false;
+        opts.licq_check = false;
+        opts.warm_z_bounds = false;
+        let mut probe = pounce_presolve::PresolveTnlp::new(Rc::clone(tnlp), opts);
+        if probe.get_nlp_info().is_none() {
+            return false;
+        }
+        probe.certified_infeasible().is_some()
+    }
+
     fn optimize_constrained(&mut self, tnlp: Rc<RefCell<dyn TNLP>>) -> ApplicationReturnStatus {
         let t_start = Instant::now();
 
@@ -1591,6 +1627,29 @@ impl IpoptApplication {
         let n_c = orig_nlp.c_space().dim();
         if n_x_var > 0 && n_x_var < n_c {
             timing.overall_alg.end();
+            // An over-determined system can still be *provably* infeasible —
+            // `x == 0.2` with `x == 0.8` is about as provable as infeasibility
+            // gets — and for such a model the structural DOF error is the
+            // strictly weaker answer: it reports "cannot attempt this" for a
+            // problem whose verdict is already decided (gh#387). The DOF gate
+            // fires before any iteration runs, so nothing downstream will ever
+            // get the chance to detect the infeasibility; check for a
+            // bound-propagation proof here, on the rare failure path only.
+            // The probe reuses presolve's full certification pipeline
+            // (crossing margin + witness refutation), so a model the solver
+            // would accept as feasible at its own tolerance is never upgraded
+            // to "proved infeasible" — those still report the DOF error.
+            if self.overdetermined_model_certified_infeasible(&tnlp) {
+                use pounce_common::journalist::JournalCategory;
+                self.journalist.print(
+                    JournalLevel::J_SUMMARY,
+                    JournalCategory::J_MAIN,
+                    "\nEXIT: Problem has too few degrees of freedom, and bound \
+                     propagation proves its constraints inconsistent.\n\
+                     No feasible point exists; the solve was not run.\n",
+                );
+                return ApplicationReturnStatus::InfeasibleProblemDetected;
+            }
             return ApplicationReturnStatus::NotEnoughDegreesOfFreedom;
         }
 

--- a/crates/pounce-algorithm/tests/issue_387_overdetermined_infeasible.rs
+++ b/crates/pounce-algorithm/tests/issue_387_overdetermined_infeasible.rs
@@ -1,0 +1,206 @@
+//! gh #387 — an over-determined system that is *provably* infeasible must
+//! report `InfeasibleProblemDetected`, not `NotEnoughDegreesOfFreedom`.
+//!
+//! `x == 0.2` with `x == 0.8` over `x in [0, 1]` has an empty feasible set —
+//! about as provable as infeasibility gets — yet it exited through the DOF
+//! gate (1 variable < 2 equality rows) with the structural 5xx error before
+//! anything could look at the constraints. The gate fires before a single
+//! iteration runs, so no downstream mechanism ever had the chance to detect
+//! the contradiction.
+//!
+//! The fix consults presolve's bound-propagation certification on the DOF
+//! failure path (independent of the `presolve` master switch — nothing is
+//! transformed, no solve runs through the probe). The certification's
+//! fail-closed safety net is inherited wholesale:
+//!
+//! * a *consistent* over-determined system still reports the DOF error, and
+//! * at row scales so small that the solver's own acceptance test would wave
+//!   any point through (`|s*x - 0.2*s| <= tol` for every `x` in the box), the
+//!   witness-refutation rule withholds the proof and the DOF error stands —
+//!   "proved infeasible" is never claimed for a model the solver would accept
+//!   as feasible.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `min x^2  s.t.  s*a1*x == s*r1,  s*a2*x == s*r2,  x in [0, 1]`.
+///
+/// Every row is scaled by the same `s > 0`, which leaves the feasible set
+/// exactly unchanged; the contradiction (or consistency) lives in
+/// `(a1, r1, a2, r2)`.
+struct TwoEqualities {
+    scale: Number,
+    a: [Number; 2],
+    r: [Number; 2],
+}
+
+impl TwoEqualities {
+    fn contradictory(scale: Number) -> Self {
+        Self {
+            scale,
+            a: [1.0, 1.0],
+            r: [0.2, 0.8],
+        }
+    }
+
+    fn consistent(scale: Number) -> Self {
+        Self {
+            scale,
+            a: [1.0, 2.0],
+            r: [0.2, 0.4],
+        }
+    }
+}
+
+impl TNLP for TwoEqualities {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 1,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = 0.0;
+        b.x_u[0] = 1.0;
+        for i in 0..2 {
+            b.g_l[i] = self.scale * self.r[i];
+            b.g_u[i] = self.scale * self.r[i];
+        }
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.5;
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.fill(Linearity::Linear);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[0])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, grad: &mut [Number]) -> bool {
+        grad[0] = 2.0 * x[0];
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = self.scale * self.a[0] * x[0];
+        g[1] = self.scale * self.a[1] * x[0];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 0]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = self.scale * self.a[0];
+                values[1] = self.scale * self.a[1];
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 2.0 * obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+/// Solve with all-default options — in particular `presolve` stays at its
+/// default "no", which is the configuration the issue was filed against.
+fn solve(problem: TwoEqualities) -> ApplicationReturnStatus {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(problem));
+    app.optimize_tnlp(tnlp)
+}
+
+#[test]
+fn contradictory_equalities_are_infeasible_not_dof_error() {
+    let status = solve(TwoEqualities::contradictory(1.0));
+    assert_eq!(
+        status,
+        ApplicationReturnStatus::InfeasibleProblemDetected,
+        "x == 0.2 with x == 0.8 is provably infeasible; the structural DOF \
+         error is the strictly weaker answer"
+    );
+}
+
+/// Multiplying every row by `s > 0` leaves the feasible set unchanged, so the
+/// verdict must not depend on `s` wherever the certification is willing to
+/// speak at all.
+#[test]
+fn verdict_is_scale_invariant_where_certifiable() {
+    for k in [-6, -4, -2, 0, 2, 4, 6, 8, 10, 12] {
+        let status = solve(TwoEqualities::contradictory(10.0_f64.powi(k)));
+        assert_eq!(
+            status,
+            ApplicationReturnStatus::InfeasibleProblemDetected,
+            "row scale 1e{k}: same empty feasible set, different verdict"
+        );
+    }
+}
+
+/// Below the certification floor the proof is *withheld*, not manufactured:
+/// at `s = 1e-12` every point in `[0, 1]` satisfies both rows within the
+/// solver's own acceptance tolerance, so claiming "proved infeasible" would
+/// contradict what the solver itself would report if it could run. The
+/// fail-closed answer is the structural DOF error, unchanged from before.
+#[test]
+fn sub_tolerance_scales_keep_the_dof_error() {
+    let status = solve(TwoEqualities::contradictory(1e-12));
+    assert_eq!(status, ApplicationReturnStatus::NotEnoughDegreesOfFreedom);
+}
+
+/// A consistent over-determined system (`x == 0.2`, `2x == 0.4`) is not
+/// infeasible; the structural DOF error must survive the fix.
+#[test]
+fn consistent_equalities_still_report_dof_error() {
+    let status = solve(TwoEqualities::consistent(1.0));
+    assert_eq!(status, ApplicationReturnStatus::NotEnoughDegreesOfFreedom);
+}

--- a/crates/pounce-cli/src/counting_tnlp.rs
+++ b/crates/pounce-cli/src/counting_tnlp.rs
@@ -14,7 +14,7 @@
 
 use pounce_common::types::{Index, Number};
 use pounce_nlp::tnlp::{
-    BoundsInfo, InfeasibilityProof, IpoptCq, IpoptData, IterStats, MetaData, NlpInfo,
+    BoundsInfo, InfeasibilityProof, IpoptCq, IpoptData, IterStats, Linearity, MetaData, NlpInfo,
     ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
 };
 use std::cell::{Cell, RefCell};
@@ -121,6 +121,24 @@ impl TNLP for CountingTnlp {
 
     fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
         self.inner.borrow_mut().get_scaling_parameters(req)
+    }
+
+    fn get_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.borrow_mut().get_variables_linearity(types)
+    }
+
+    fn get_objective_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner
+            .borrow_mut()
+            .get_objective_variables_linearity(types)
+    }
+
+    // Without this forward, anything stacked above the counter (the
+    // application's DOF-gate infeasibility probe, a presolve wrapper) sees
+    // the trait default `false` and treats every row as nonlinear, silently
+    // disabling linear-row bound propagation (gh#387).
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.borrow_mut().get_constraints_linearity(types)
     }
 
     fn get_number_of_nonlinear_variables(&mut self) -> Index {

--- a/crates/pounce-cli/src/seeded_tnlp.rs
+++ b/crates/pounce-cli/src/seeded_tnlp.rs
@@ -11,7 +11,7 @@
 
 use pounce_common::types::{Index, Number};
 use pounce_nlp::tnlp::{
-    BoundsInfo, InfeasibilityProof, IpoptCq, IpoptData, IterStats, MetaData, NlpInfo,
+    BoundsInfo, InfeasibilityProof, IpoptCq, IpoptData, IterStats, Linearity, MetaData, NlpInfo,
     ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
 };
 use std::cell::RefCell;
@@ -84,6 +84,17 @@ impl TNLP for SeededTnlp {
     }
     fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
         self.inner.borrow_mut().get_scaling_parameters(req)
+    }
+    fn get_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.borrow_mut().get_variables_linearity(types)
+    }
+    fn get_objective_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner
+            .borrow_mut()
+            .get_objective_variables_linearity(types)
+    }
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.inner.borrow_mut().get_constraints_linearity(types)
     }
     fn get_number_of_nonlinear_variables(&mut self) -> Index {
         self.inner.borrow_mut().get_number_of_nonlinear_variables()

--- a/crates/pounce-cli/tests/issue_387_overdetermined_infeasible.rs
+++ b/crates/pounce-cli/tests/issue_387_overdetermined_infeasible.rs
@@ -1,0 +1,126 @@
+//! gh #387 — the CLI must report the AMPL infeasible band (200..299) for a
+//! provably contradictory over-determined system, not the 5xx failure band.
+//!
+//! `x == 0.2` with `x == 0.8` over `x in [0, 1]` trips the too-few-degrees-
+//! of-freedom gate (1 variable, 2 equality rows) before any iteration runs,
+//! so the solve itself can never discover the contradiction; the DOF path now
+//! consults presolve's bound-propagation certification first.
+//!
+//! This test goes through the full CLI stack on purpose: the CLI wraps the
+//! `.nl` TNLP in `CountingTnlp`, which used to swallow
+//! `get_constraints_linearity` (trait default `false`), silently disabling
+//! linear-row propagation for anything stacked above it. An algorithm-level
+//! test cannot see that hole — this one does.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// The Pyomo `inf_eq` model from `test_scale_invariance.py`, row-scaled by
+/// `s`: `min x^2  s.t.  s*x == 0.2*s,  s*x == 0.8*s,  x in [0, 1]`.
+fn inf_eq_nl(s: f64) -> String {
+    format!(
+        "g3 1 1 0\n \
+         1 2 1 0 2\n \
+         0 1 0 0 0 0\n \
+         0 0\n \
+         0 1 0\n \
+         0 0 0 1\n \
+         0 0 0 0 0\n \
+         2 1\n \
+         2 1\n \
+         0 0 0 0 0\n\
+         C0\nn0\n\
+         C1\nn0\n\
+         O0 0\no5\nv0\nn2\n\
+         x1\n0 0.5\n\
+         r\n4 {r1:e}\n4 {r2:e}\n\
+         b\n0 0 1\n\
+         k0\n\
+         J0 1\n0 {s:e}\n\
+         J1 1\n0 {s:e}\n\
+         G0 1\n0 0\n",
+        r1 = 0.2 * s,
+        r2 = 0.8 * s,
+        s = s,
+    )
+}
+
+fn solve_result_num(text: &str) -> i32 {
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("objno ") {
+            if let Some(code) = rest.split_whitespace().nth(1) {
+                return code.parse().expect("objno code parses");
+            }
+        }
+    }
+    panic!("no `objno` line in .sol:\n{text}");
+}
+
+/// Write `nl_text` to a temp file, solve it under `-AMPL` with default
+/// options, and return the `.sol` text.
+fn solve(tag: &str, nl_text: &str) -> String {
+    let dir = std::env::temp_dir();
+    let nl = dir.join(format!("pounce_issue387_{tag}.nl"));
+    let sol = dir.join(format!("pounce_issue387_{tag}.sol"));
+    std::fs::write(&nl, nl_text).expect("write .nl");
+    let _ = std::fs::remove_file(&sol);
+
+    // `solver_selection=nlp` pins the IPM route the issue was filed against
+    // (and the scale-invariance harness runs); the default auto-route sends
+    // this convex-QP-class model to `pounce-convex`, which detects the
+    // infeasibility on its own.
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("solver_selection=nlp")
+        .arg("print_level=0")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+
+    std::fs::read_to_string(&sol).expect("read .sol")
+}
+
+/// The headline regression: with all-default options (presolve off), the
+/// contradiction must land in the AMPL infeasible band.
+#[test]
+fn contradictory_equalities_report_infeasible_band() {
+    let text = solve("unit", &inf_eq_nl(1.0));
+    let srn = solve_result_num(&text);
+    assert!(
+        (200..300).contains(&srn),
+        "expected the AMPL infeasible band (200..299) for `x == 0.2, \
+         x == 0.8`, got solve_result_num={srn}. The 5xx failure band \
+         surfaces through Pyomo as an internal solver error, \
+         indistinguishable from a solver bug:\n{text}"
+    );
+    assert!(
+        text.contains("InfeasibleProblemDetected"),
+        "expected the InfeasibleProblemDetected verdict:\n{text}"
+    );
+}
+
+/// Multiplying every row by `s > 0` leaves the feasible set unchanged, so the
+/// verdict must agree at every scale the certification can speak to. Scales
+/// at or below ~1e-8 are excluded deliberately: there the solver's own
+/// acceptance test would wave any point in the box through, so the
+/// fail-closed witness rule withholds the proof (see the algorithm-level
+/// test's `sub_tolerance_scales_keep_the_dof_error`).
+#[test]
+fn verdict_is_scale_invariant_where_certifiable() {
+    for k in [-6, -3, 0, 3, 6, 9, 12] {
+        let text = solve(&format!("k{k}"), &inf_eq_nl(10.0_f64.powi(k)));
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "row scale 1e{k}: same empty feasible set, but \
+             solve_result_num={srn} left the infeasible band:\n{text}"
+        );
+    }
+}

--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -126,7 +126,12 @@ BASELINE_WRONG = {
     "inf_372": 0,
     "inf_clear": 0,
     "inf_two": 0,
-    "inf_eq": 13,
+    # gh#387: the DOF gate now consults bound-propagation certification, so
+    # the contradiction is proved at every scale the certification is willing
+    # to speak to. The 3 remaining cells are k in {-12, -10, -8}, where every
+    # point in the box satisfies both rows within the solver's own acceptance
+    # tolerance and the fail-closed witness rule withholds the proof.
+    "inf_eq": 3,
 }
 
 


### PR DESCRIPTION
Fixes #387

## What was actually happening

The issue's cell 1 ("at unit scale it is already wrong") turned out not to be a
solve failure at all: with default options the solve never runs. One variable
with two equality rows trips the too-few-degrees-of-freedom gate in
`optimize_constrained` (mirroring upstream `IpOrigIpoptNLP.cpp:299`), which
returned `NotEnoughDegreesOfFreedom` (AMPL 504) before a single iteration —
so no downstream mechanism, scale-relative or otherwise, ever got the chance
to look at the constraints. That is why `inf_eq` was `FAIL` at **all** 13 row
scalings.

The issue's suggestion to "check first whether presolve should simply certify
this model" was on target: Phase-1 bound propagation already handles equality
pairs (an equality row is just `lo == hi`), and `presolve=yes` already proves
this model infeasible (201). The gap was that nothing consults that machinery
on the default path.

## The fix

1. **The DOF gate now consults bound-propagation certification on its failure
   path.** When `n_x_var < n_c`, before reporting the structural error, a
   throwaway `PresolveTnlp` probe (Phase 1 only) is asked for a certified
   infeasibility proof; if it certifies, the verdict is
   `Infeasible_Problem_Detected`. The probe runs only when the gate fires, is
   independent of the `presolve` master switch (nothing is transformed — the
   wrapper is dropped without solving through it), and inherits the
   certification's fail-closed safety net wholesale: the crossing must exceed
   the solver's own acceptance margin at the crossed pair's scale, and a
   concrete witness point satisfying every constraint withdraws the verdict.

2. **`CountingTnlp` / `SeededTnlp` now forward the three linearity queries.**
   The CLI's counting wrapper inherited the trait default (`false`), so
   anything stacked above it — including the new probe — saw every row as
   nonlinear and silently lost linear-row bound propagation. This was the
   reason the probe initially certified nothing through the CLI.

## What this deliberately does *not* do

- A **consistent** over-determined system (`x == 0.2`, `2x == 0.4`) still
  reports the DOF error — the probe only relabels a *proved* contradiction.
- At row scales at or below ~`1e-8`, every point in `[0, 1]` satisfies both
  rows within the solver's own acceptance tolerance, so the witness rule
  (#380: never certify what the solver itself would accept as feasible)
  withholds the proof and the DOF error stands. Those are the 3 remaining
  wrong cells.

## Baseline ratchet

`inf_eq` in `test_scale_invariance.py`: **13/13 → 3/13** wrong cells
(remaining: k = −12, −10, −8). Full harness run:

```
feas_simple  want=SOLVED  wrong= 0/13 (baseline 0)
feas_two     want=SOLVED  wrong= 0/13 (baseline 0)
feas_eq      want=SOLVED  wrong= 0/13 (baseline 0)
inf_372      want=INFEAS  wrong= 0/13 (baseline 0)
inf_clear    want=INFEAS  wrong= 0/13 (baseline 0)
inf_two      want=INFEAS  wrong= 0/13 (baseline 0)
inf_eq       want=INFEAS  wrong= 3/13 (baseline 3)  FAIL FAIL FAIL INFEAS ×10
```

## What remains of #387 (defect 2)

Equality rows still have no scale-relative *runtime* feasibility measure:
`curr_relative_primal_infeasibility_max` skips the `c` block because the fold
into `c(x) = 0` erases the RHS magnitude. That only matters for genuinely
**nonlinear** equality contradictions (out of bound propagation's reach) and
needs the pre-fold RHS plumbed through, per the `declared_d_bounds` pattern —
left for a follow-up as the issue anticipated.

## Tests

- `crates/pounce-algorithm/tests/issue_387_overdetermined_infeasible.rs` —
  gate-level: contradiction → `InfeasibleProblemDetected` at unit scale and
  across `1e-6..1e12`; consistent system and sub-tolerance scales keep the
  DOF error (pins fail-closed behavior).
- `crates/pounce-cli/tests/issue_387_overdetermined_infeasible.rs` — full CLI
  stack (would catch the `CountingTnlp` linearity hole): AMPL 200 band with
  default options, scale-invariant where certifiable.
- `cargo test -p pounce-algorithm -p pounce-cli -p pounce-presolve`: all pass.
- `pyomo-pounce/tests/test_scale_invariance.py`: passes at the new baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
