### PR TITLE
Never report infeasibility while holding a feasible point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,64 @@ changes.
   - Docs: [Solution output](docs/src/solution-output.md) gains a
     `solve_result_num` band table and the proved-vs-local distinction.
 
+### Fixed — the NLP path reported `Infeasible_Problem_Detected` on models whose own starting point is feasible (#379)
+
+- **No numerical path may now claim infeasibility while holding a point that
+  satisfies every constraint.** The feasible-by-construction property sweep in
+  `pyomo-pounce/tests/test_infeasibility_no_false_positives.py` found a model
+  (seed 294) that POUNCE was *handed a feasible starting point for* — `(5e5, 5e5)`,
+  satisfying both rows exactly — and reported as infeasible: AMPL
+  `solve_result_num` 200, Pyomo `TerminationCondition.infeasible`. POUNCE's own
+  convex QP route solves the same model to optimality, and `pounce verify`
+  reports `0.000e0` constraint and bound violation on that solution.
+  - Root cause is not a threshold. The gates that produce this verdict — the
+    restoration gates, the outer cycle detector, the SQP infeasible-subproblem
+    exit, the ℓ₁ wrapper's uncollapsed-slack certificate — all argue from a
+    *stalled feasibility sub-problem*: the violation is bounded away from zero
+    and no local move reduces it. That is evidence, not proof. On this model the
+    first row carries `±1e30` coefficients; in the scaled space its slack
+    initializes far from anything `x` can follow, the outer line search walks the
+    violation *up* from an exactly feasible start, restoration burns its
+    3000-iteration budget, and the cycle gate concluded infeasibility from the
+    exhaustion.
+  - Fix: a refutation. `pounce_algorithm::infeasibility_refutation` evaluates the
+    model's own starting point, clamped into the variable box, and withdraws the
+    verdict if it satisfies every row. One concrete feasible point settles the
+    question outright, whatever a local argument concluded.
+  - Applied as **one gate over all four claim sites**, not per-site. The two
+    preceding safeguards in this area were each added to one path and not its
+    twin, and a hole survived both times.
+  - One-directional by construction: it can only ever *withdraw* a verdict, never
+    create one. A model with no feasible point cannot produce a witness, so every
+    correct verdict is untouched — and a failure to evaluate simply declines to
+    refute.
+  - The withdrawn verdict becomes `Error_In_Step_Computation` (AMPL 500), the
+    status this codebase already uses for "the solve broke down and we are *not*
+    claiming infeasibility". The solve still fails on the `±1e30` model — that row
+    is genuinely hostile — but it fails visibly instead of returning a confident
+    wrong answer.
+  - The witness test is **pure relative** (`tol · scale`), not the clamped
+    accepting form. Measured: the clamped form withdrew *correct* infeasibility
+    verdicts on three models at row scalings `1e-12 … 1e-8`, because the clamp
+    reinstates an absolute floor exactly in the down-scaled direction. Caught by
+    `pyomo-pounce/tests/test_scale_invariance.py` before it could ship.
+  - Presolve *certificates* are exempt: a proof is not a numerical inference, and
+    it carries its own, tighter refutation.
+  - Measured: false positives on the numerical path (`solver_selection=nlp
+    presolve=no`) over 400 feasible-by-construction instances go **1 → 0**; over
+    the property test's full option set, **3 → 1** (the remaining one is seed 223
+    on the presolve path, unrelated to this fix). `MAX_FALSE_POSITIVES` ratchets
+    from 4 to 1.
+  - Not a bug: the CLI's MC64 second-opinion re-solve did not overturn these. That
+    guard exists for *hypersensitivity* — two backward-stable scalings falling
+    into different basins — and this failure reproduces under both scalings, so
+    the second opinion correctly agreed. The refutation runs before it, so the
+    wasted re-solve is now skipped too.
+  - Regression: `crates/pounce-cli/tests/false_local_infeasibility.rs` gains both
+    reported shapes and pins that the convex route still solves them, so the two
+    routes cannot drift back into disagreeing about whether the feasible set is
+    empty.
+
 ### Fixed — an infeasible model's verdict depended on the user's `tol` (follow-up to #372)
 
 - **A genuinely infeasible model now reports `Infeasible_Problem_Detected` (AMPL

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1010,6 +1010,23 @@ impl IpoptApplication {
             ),
         };
 
+        // Same gate as the IPM path: an infeasible-subproblem exit is a
+        // numerical inference, and a feasible starting point disproves it
+        // (gh #379). Only the infeasibility verdict is rewritten — every other
+        // status passes through untouched, so the pair stays in lockstep.
+        let refuted = withdraw_infeasibility_if_refuted(
+            &tnlp,
+            solver_status,
+            self.nlp_lower_bound_inf(),
+            self.nlp_upper_bound_inf(),
+            self.user_tol(),
+        );
+        let (app_status, solver_status) = if refuted == solver_status {
+            (app_status, solver_status)
+        } else {
+            (solver_return_to_app_status(refuted), refuted)
+        };
+
         // Forward to the user TNLP's finalize_solution. We pass
         // the SQP iterate and recovered multipliers via the
         // OrigIpoptNlp's lifting hooks. Failure here is silent
@@ -1057,6 +1074,35 @@ impl IpoptApplication {
             }
         }
         app_status
+    }
+
+    /// `nlp_lower_bound_inf` — the magnitude at or below which a bound is
+    /// treated as absent.
+    fn nlp_lower_bound_inf(&self) -> Number {
+        self.options
+            .get_numeric_value("nlp_lower_bound_inf", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(DEFAULT_NLP_LOWER_BOUND_INF)
+    }
+
+    /// `nlp_upper_bound_inf` — the magnitude at or above which a bound is
+    /// treated as absent.
+    fn nlp_upper_bound_inf(&self) -> Number {
+        self.options
+            .get_numeric_value("nlp_upper_bound_inf", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(DEFAULT_NLP_UPPER_BOUND_INF)
+    }
+
+    /// The user's convergence tolerance `tol`.
+    fn user_tol(&self) -> Number {
+        self.options
+            .get_numeric_value("tol", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(1e-8)
     }
 
     /// Emit the Ipopt-style problem-statistics block (#206) from the
@@ -1375,15 +1421,30 @@ impl IpoptApplication {
                     | ApplicationReturnStatus::SolvedToAcceptableLevel
             ) && slack_sum.is_finite()
                 && slack_sum > slack_tol;
-            let final_app_status = if infeasible_certificate {
-                ApplicationReturnStatus::InfeasibleProblemDetected
-            } else {
-                last_status
+            // …unless the model's own starting point satisfies every
+            // constraint, which disproves the certificate outright (gh #379).
+            // Same gate as the IPM and SQP paths; see
+            // `withdraw_infeasibility_if_refuted`.
+            let refuted = infeasible_certificate
+                && withdraw_infeasibility_if_refuted(
+                    &tnlp,
+                    SolverReturn::LocalInfeasibility,
+                    self.nlp_lower_bound_inf(),
+                    self.nlp_upper_bound_inf(),
+                    self.user_tol(),
+                ) != SolverReturn::LocalInfeasibility;
+            let final_solver_status = match (infeasible_certificate, refuted) {
+                (true, false) => SolverReturn::LocalInfeasibility,
+                // The slacks did not collapse, so the returned point is not
+                // feasible and `Solve_Succeeded` would be just as wrong as
+                // `Infeasible_Problem_Detected`. Report the breakdown.
+                (true, true) => SolverReturn::ErrorInStepComputation,
+                (false, _) => solver_status,
             };
-            let final_solver_status = if infeasible_certificate {
-                SolverReturn::LocalInfeasibility
-            } else {
-                solver_status
+            let final_app_status = match (infeasible_certificate, refuted) {
+                (true, false) => ApplicationReturnStatus::InfeasibleProblemDetected,
+                (true, true) => ApplicationReturnStatus::ErrorInStepComputation,
+                (false, _) => last_status,
             };
 
             // Recompute f(x*) and c(x*) on the inner.
@@ -1971,6 +2032,15 @@ impl IpoptApplication {
                 stats.final_unscaled_kkt_error = cq.curr_unscaled_nlp_error();
             }
         }
+
+        // Never report `Infeasible_Problem_Detected` while holding a point that
+        // satisfies every constraint. The gates that produce this verdict argue
+        // from a stalled feasibility sub-problem, and gh #379 is what that looks
+        // like when the argument is wrong — a model whose own starting point is
+        // exactly feasible, reported infeasible. See
+        // `withdraw_infeasibility_if_refuted`.
+        let solver_status =
+            withdraw_infeasibility_if_refuted(&tnlp, solver_status, lo_inf, up_inf, tol);
 
         // Map SolverReturn → ApplicationReturnStatus per
         // MAIN_LOOP.md's exception table, then apply the opt-in
@@ -2909,6 +2979,60 @@ pub fn feral_config_from_options(
         }
     }
     cfg
+}
+
+/// Withdraw a numerical infeasibility verdict the model's own starting point
+/// disproves.
+///
+/// Applied at every site in this file that can return
+/// `Infeasible_Problem_Detected` from a *numerical* argument — the IPM path's
+/// restoration / cycle gates, the SQP path's infeasible-subproblem exit, and the
+/// ℓ₁ wrapper's uncollapsed-slack certificate. Deliberately one gate rather than
+/// three: the two preceding safeguards in this area (gh #376, gh #380) were each
+/// added to one path and not its twin, and a hole survived both times.
+///
+/// Not applied to a presolve *certificate*
+/// (`TNLP::presolve_infeasibility_proof`), which carries its own, tighter
+/// refutation
+/// (`pounce_presolve::witness_refutes_infeasibility`) and is a proof rather than
+/// a numerical inference.
+///
+/// The replacement is `Error_In_Step_Computation`, the status this codebase
+/// already uses for "the solve broke down and we are **not** claiming
+/// infeasibility" — see the `cycle_exit` fallback in
+/// [`crate::ipopt_alg::IpoptAlgorithm::invoke_restoration`], which picks between
+/// exactly these two on exactly this question. It maps to AMPL 500, an honest
+/// failure the caller can see, instead of AMPL 200, a wrong answer they cannot.
+///
+/// gh #379.
+fn withdraw_infeasibility_if_refuted(
+    tnlp: &Rc<RefCell<dyn TNLP>>,
+    solver_status: SolverReturn,
+    lo_inf: Number,
+    up_inf: Number,
+    tol: Number,
+) -> SolverReturn {
+    if solver_status != SolverReturn::LocalInfeasibility {
+        return solver_status;
+    }
+    // A presolve proof is not a numerical inference; it does its own refutation.
+    if tnlp.borrow().presolve_infeasibility_proof().is_some() {
+        return solver_status;
+    }
+    match crate::infeasibility_refutation::starting_point_refutes_infeasibility(
+        tnlp, lo_inf, up_inf, tol,
+    ) {
+        Some(w) => {
+            tracing::debug!(
+                target: "pounce::application",
+                "[PN_INFEAS_REFUTED] the model's starting point satisfies every constraint \
+                 (max violation {:.3e}) — withdrawing Infeasible_Problem_Detected",
+                w.max_violation
+            );
+            SolverReturn::ErrorInStepComputation
+        }
+        None => solver_status,
+    }
 }
 
 /// Map upstream `SolverReturn` codes to `ApplicationReturnStatus`.

--- a/crates/pounce-algorithm/src/infeasibility_refutation.rs
+++ b/crates/pounce-algorithm/src/infeasibility_refutation.rs
@@ -1,0 +1,477 @@
+//! Refuting an infeasibility verdict with a point that is actually feasible.
+//!
+//! # Why this exists
+//!
+//! `Infeasible_Problem_Detected` (AMPL `solve_result_num` 200, Pyomo
+//! `TerminationCondition.infeasible`) is the most consequential thing POUNCE
+//! can say: a caller told a feasible model is infeasible has no signal that
+//! anything went wrong. It fails silently and confidently, which is worse than
+//! an error.
+//!
+//! The numerical paths that produce that verdict — the restoration gates, the
+//! outer cycle detector, the SQP infeasible-subproblem exit, the ℓ₁ wrapper's
+//! uncollapsed-slack certificate — all reason from a *local* argument: the
+//! feasibility sub-problem stopped making progress at a point whose violation
+//! is bounded away from zero. That is evidence, not proof, and gh #379 is what
+//! it looks like when the evidence is wrong. On seed 294 of the
+//! feasible-by-construction property sweep
+//! (`pyomo-pounce/tests/test_infeasibility_no_false_positives.py`) the solver
+//! *starts* at a point that satisfies every row exactly, walks away from it
+//! (the model carries `±1e30` row coefficients, so the barrier's slack
+//! initialization moves the scaled slack far from what `x` can follow), burns
+//! the restoration budget, and reports the model infeasible.
+//!
+//! A concrete feasible point settles the question outright. If some `x` inside
+//! the variable box satisfies every constraint, the feasible set is not empty,
+//! whatever a local argument concluded. So: before any numerical path is
+//! allowed to say "infeasible", try to refute it.
+//!
+//! # Which point
+//!
+//! The model's own starting point, clamped into the variable box. Deliberately
+//! *only* that one, unlike the presolve-side refutation
+//! (`pounce_presolve::witness_refutes_infeasibility`), which also samples the
+//! box midpoint and corners.
+//!
+//! The two are answering different questions. Presolve claims a *proof* over
+//! the whole box from interval arithmetic, so probing the box is exactly the
+//! right counter-evidence. Here the claim is numerical and the refutation runs
+//! on every solve that ends in the infeasible band; widening it to sampled
+//! points would change verdicts on models this change cannot be validated
+//! against (the benchmark corpus is not in the tree). The starting point needs
+//! no such justification: a modeller who hands the solver a feasible point and
+//! is told the model is infeasible has been given a wrong answer under any
+//! reading.
+//!
+//! # Direction
+//!
+//! One-directional, like its presolve twin: this can only ever *withdraw* a
+//! verdict, never create one. A model with no feasible point cannot produce a
+//! witness, so a genuinely infeasible model is untouched — and any failure to
+//! evaluate (`eval_g` returning false, a non-finite value, a missing starting
+//! point) simply declines to refute.
+
+use pounce_common::tolerance::is_significant;
+use pounce_common::types::Number;
+use pounce_nlp::tnlp::{BoundsInfo, StartingPoint, TNLP};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// A point that satisfies every constraint and bound, disproving a candidate
+/// infeasibility verdict.
+#[derive(Debug, Clone)]
+pub struct FeasibleWitness {
+    /// The witnessing point, in the user's variable order.
+    pub x: Vec<Number>,
+    /// Largest constraint violation at `x`, for the diagnostic message. Below
+    /// `tol` times the row's own magnitude by construction.
+    pub max_violation: Number,
+}
+
+/// Try to refute a candidate infeasibility verdict using the model's starting
+/// point.
+///
+/// Returns the witness when the starting point (clamped into the variable box)
+/// satisfies every constraint; `None` when it does not, or when the model
+/// cannot be evaluated. `None` means "no refutation", never "infeasible".
+///
+/// `lower_bound_inf` / `upper_bound_inf` are the solver's
+/// `nlp_lower_bound_inf` / `nlp_upper_bound_inf` sentinels: a bound at or
+/// beyond them is treated as absent, both for clamping and for sizing a row's
+/// magnitude. Letting the sentinel (~1e19) inform the scale would put the
+/// slack around 1e11 and make every row look satisfied — the same trap the
+/// presolve refutation documents.
+pub fn starting_point_refutes_infeasibility(
+    tnlp: &Rc<RefCell<dyn TNLP>>,
+    lower_bound_inf: Number,
+    upper_bound_inf: Number,
+    tol: Number,
+) -> Option<FeasibleWitness> {
+    let info = tnlp.borrow_mut().get_nlp_info()?;
+    let n = info.n.max(0) as usize;
+    let m = info.m.max(0) as usize;
+    if n == 0 {
+        return None;
+    }
+
+    let mut x_l = vec![0.0; n];
+    let mut x_u = vec![0.0; n];
+    let mut g_l = vec![0.0; m];
+    let mut g_u = vec![0.0; m];
+    if !tnlp.borrow_mut().get_bounds_info(BoundsInfo {
+        x_l: &mut x_l,
+        x_u: &mut x_u,
+        g_l: &mut g_l,
+        g_u: &mut g_u,
+    }) {
+        return None;
+    }
+
+    let mut x = vec![0.0; n];
+    let mut z_l = vec![0.0; n];
+    let mut z_u = vec![0.0; n];
+    let mut lambda = vec![0.0; m];
+    let have_x0 = tnlp.borrow_mut().get_starting_point(StartingPoint {
+        init_x: true,
+        x: &mut x,
+        init_z: false,
+        z_l: &mut z_l,
+        z_u: &mut z_u,
+        init_lambda: false,
+        lambda: &mut lambda,
+    });
+    if !have_x0 || x.iter().any(|v| !v.is_finite()) {
+        return None;
+    }
+
+    // Clamp into the box. The solver does this to `x0` itself before iterating,
+    // so a point outside the declared bounds is not a witness as given — but the
+    // clamped point still is one if it satisfies the rows, since it is inside
+    // the box by construction.
+    for j in 0..n {
+        // A crossed box (`x_l > x_u`) cannot be clamped into; that is presolve's
+        // territory and not something to refute from.
+        if x_l[j].is_finite() && x_u[j].is_finite() && x_l[j] > x_u[j] {
+            return None;
+        }
+        if x_l[j].is_finite() && x_l[j] > lower_bound_inf && x[j] < x_l[j] {
+            x[j] = x_l[j];
+        }
+        if x_u[j].is_finite() && x_u[j] < upper_bound_inf && x[j] > x_u[j] {
+            x[j] = x_u[j];
+        }
+    }
+
+    // No constraints: the box alone defines the feasible set, and a point
+    // inside a non-crossed box is a witness.
+    let mut g = vec![0.0; m];
+    if m > 0 && !tnlp.borrow_mut().eval_g(&x, true, &mut g) {
+        return None;
+    }
+
+    let mut max_violation: Number = 0.0;
+    for i in 0..m {
+        let v = g[i];
+        if !v.is_finite() {
+            return None;
+        }
+        // Only *finite* bounds inform a row's magnitude — see the doc comment.
+        let finite_mag = |b: Number, is_lower: bool| -> Number {
+            let absent = if is_lower {
+                b <= lower_bound_inf
+            } else {
+                b >= upper_bound_inf
+            };
+            if b.is_finite() && !absent {
+                b.abs()
+            } else {
+                0.0
+            }
+        };
+        let scale = v
+            .abs()
+            .max(finite_mag(g_l[i], true))
+            .max(finite_mag(g_u[i], false));
+        let lo_viol = if g_l[i].is_finite() && g_l[i] > lower_bound_inf {
+            g_l[i] - v
+        } else {
+            0.0
+        };
+        let hi_viol = if g_u[i].is_finite() && g_u[i] < upper_bound_inf {
+            v - g_u[i]
+        } else {
+            0.0
+        };
+        let viol = lo_viol.max(hi_viol).max(0.0);
+        // Pure relative — `tol * scale`, via `is_significant` — and *not* the
+        // clamped accepting form `is_negligible`.
+        //
+        // The clamped form is right when the question is "did the solver
+        // converge well enough to call this feasible", because a solver
+        // converges to absolute residuals. It is wrong here, where the question
+        // is "is this residual real, or evaluation noise on a row of this
+        // magnitude". The clamp reinstates an absolute floor for `scale < 1`,
+        // and that is precisely the down-scaled direction this gate must not be
+        // fooled in.
+        //
+        // Measured, not assumed. With `is_negligible` the scale-invariance
+        // harness (`pyomo-pounce/tests/test_scale_invariance.py`) regressed on
+        // three genuinely infeasible models at row scalings `1e-12 … 1e-8`:
+        // `x >= 2` over `x ∈ [0, 1]`, multiplied through by `1e-12`, has a
+        // violation of `2e-12` against a row magnitude of `2e-12` — a full unit
+        // violation — but `tol * max(scale, 1)` is `1e-8`, so the starting point
+        // read as a witness and a correct infeasibility verdict was withdrawn.
+        // `tol * scale` is `2e-20` and the verdict stands.
+        if is_significant(viol, scale, tol) {
+            return None;
+        }
+        max_violation = max_violation.max(viol);
+    }
+
+    Some(FeasibleWitness { x, max_violation })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pounce_nlp::tnlp::{IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest};
+
+    const LO_INF: Number = -1e19;
+    const UP_INF: Number = 1e19;
+
+    /// `min (x-x0)^2` over `x ∈ [lo, hi]` subject to one row `a·x ∈ [g_l, g_u]`.
+    struct OneRow {
+        x0: Vec<Number>,
+        lo: Vec<Number>,
+        hi: Vec<Number>,
+        a: Vec<Number>,
+        g_l: Number,
+        g_u: Number,
+        eval_g_ok: bool,
+        have_x0: bool,
+    }
+
+    impl OneRow {
+        fn new(
+            x0: Vec<Number>,
+            lo: Vec<Number>,
+            hi: Vec<Number>,
+            a: Vec<Number>,
+            g_l: Number,
+            g_u: Number,
+        ) -> Self {
+            Self {
+                x0,
+                lo,
+                hi,
+                a,
+                g_l,
+                g_u,
+                eval_g_ok: true,
+                have_x0: true,
+            }
+        }
+    }
+
+    impl TNLP for OneRow {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: self.x0.len() as i32,
+                m: 1,
+                nnz_jac_g: self.a.len() as i32,
+                nnz_h_lag: 0,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l.copy_from_slice(&self.lo);
+            b.x_u.copy_from_slice(&self.hi);
+            b.g_l[0] = self.g_l;
+            b.g_u[0] = self.g_u;
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            if !self.have_x0 {
+                return false;
+            }
+            sp.x.copy_from_slice(&self.x0);
+            true
+        }
+        fn eval_f(&mut self, _x: &[Number], _new_x: bool) -> Option<Number> {
+            Some(0.0)
+        }
+        fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, grad_f: &mut [Number]) -> bool {
+            grad_f.fill(0.0);
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            if !self.eval_g_ok {
+                return false;
+            }
+            g[0] = self.a.iter().zip(x).map(|(a, v)| a * v).sum();
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            _mode: SparsityRequest<'_>,
+        ) -> bool {
+            true
+        }
+        fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _c: &IpoptCq) {}
+    }
+
+    fn refute(t: OneRow) -> Option<FeasibleWitness> {
+        let rc: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(t));
+        starting_point_refutes_infeasibility(&rc, LO_INF, UP_INF, 1e-8)
+    }
+
+    /// gh #379 seed 294 in miniature: the modeller's own starting point sits
+    /// exactly on a row whose coefficients are `±1e30`.
+    #[test]
+    fn extreme_scale_starting_point_refutes() {
+        let w = refute(OneRow::new(
+            vec![5e5, 5e5],
+            vec![0.0, 0.0],
+            vec![1e6, 1e6],
+            vec![-1e30, 1e30],
+            -1e-6,
+            UP_INF,
+        ))
+        .expect("x0 satisfies the row exactly — the verdict must be withdrawn");
+        assert_eq!(w.x, vec![5e5, 5e5]);
+        assert_eq!(w.max_violation, 0.0);
+    }
+
+    /// The whole point of the gate: a model with no feasible point cannot
+    /// produce a witness, so a correct verdict survives.
+    #[test]
+    fn genuinely_infeasible_model_is_not_refuted() {
+        // x ∈ [0, 0.6] with the row x >= 0.7 — gh #372's reproducer.
+        assert!(
+            refute(OneRow::new(
+                vec![0.3],
+                vec![0.0],
+                vec![0.6],
+                vec![1.0],
+                0.7,
+                UP_INF
+            ))
+            .is_none()
+        );
+    }
+
+    /// The verdict must not depend on how the model is written. `x >= 2` over
+    /// `x ∈ [0, 1]` is empty at every row scaling, so no scaling may produce a
+    /// witness.
+    ///
+    /// This is the case that rules out the clamped `is_negligible` form: at
+    /// `s = 1e-12` the violation and the row magnitude are both `2e-12`, which
+    /// `tol * max(scale, 1)` calls negligible and `tol * scale` does not. The
+    /// scale-invariance harness caught it on three models at once.
+    #[test]
+    fn a_down_scaled_infeasible_row_is_never_refuted() {
+        for k in -12..=12 {
+            let s = 10f64.powi(k);
+            assert!(
+                refute(OneRow::new(
+                    vec![0.5],
+                    vec![0.0],
+                    vec![1.0],
+                    vec![s],
+                    2.0 * s,
+                    UP_INF
+                ))
+                .is_none(),
+                "`x >= 2` over `x ∈ [0, 1]` is empty at row scaling 10^{k} too"
+            );
+        }
+    }
+
+    /// The feasible twin of the sweep above: a witness stays a witness at every
+    /// row scaling.
+    #[test]
+    fn a_scaled_feasible_row_is_refuted_at_every_scale() {
+        for k in -12..=12 {
+            let s = 10f64.powi(k);
+            assert!(
+                refute(OneRow::new(
+                    vec![0.5],
+                    vec![0.0],
+                    vec![1.0],
+                    vec![s],
+                    0.25 * s,
+                    UP_INF
+                ))
+                .is_some(),
+                "`x >= 0.25` at `x = 0.5` holds at row scaling 10^{k} too"
+            );
+        }
+    }
+
+    /// A starting point outside the box is clamped, and the clamped point is a
+    /// witness on its own terms.
+    #[test]
+    fn starting_point_is_clamped_into_the_box() {
+        let w = refute(OneRow::new(
+            vec![5.0],
+            vec![0.0],
+            vec![1.0],
+            vec![1.0],
+            0.0,
+            2.0,
+        ))
+        .expect("clamped to x = 1, which satisfies 0 <= x <= 2");
+        assert_eq!(w.x, vec![1.0]);
+    }
+
+    /// Clamping must not manufacture a witness for a row the clamped point
+    /// violates.
+    #[test]
+    fn clamping_does_not_manufacture_a_witness() {
+        assert!(
+            refute(OneRow::new(
+                vec![5.0],
+                vec![0.0],
+                vec![1.0],
+                vec![1.0],
+                3.0,
+                UP_INF
+            ))
+            .is_none(),
+            "clamped to x = 1, which violates x >= 3"
+        );
+    }
+
+    /// Failing to evaluate declines to refute — it never asserts infeasibility.
+    #[test]
+    fn unevaluable_model_declines_to_refute() {
+        let mut t = OneRow::new(vec![0.5], vec![0.0], vec![1.0], vec![1.0], 0.0, 2.0);
+        t.eval_g_ok = false;
+        assert!(refute(t).is_none());
+
+        let mut t = OneRow::new(vec![0.5], vec![0.0], vec![1.0], vec![1.0], 0.0, 2.0);
+        t.have_x0 = false;
+        assert!(refute(t).is_none());
+
+        let t = OneRow::new(vec![Number::NAN], vec![0.0], vec![1.0], vec![1.0], 0.0, 2.0);
+        assert!(refute(t).is_none());
+    }
+
+    /// An absent bound must not set the row's magnitude from the ~1e19
+    /// sentinel — that would make every row look satisfied.
+    #[test]
+    fn infinite_bound_sentinel_does_not_inflate_the_scale() {
+        // Row value 1.0 against `g <= 0.5`: a real violation of 0.5, on a row
+        // whose only finite bound is 0.5. The absent lower bound is the
+        // sentinel and must contribute nothing.
+        assert!(
+            refute(OneRow::new(
+                vec![1.0],
+                vec![0.0],
+                vec![2.0],
+                vec![1.0],
+                LO_INF,
+                0.5
+            ))
+            .is_none()
+        );
+    }
+
+    /// A crossed box is presolve's business, not something to refute from.
+    #[test]
+    fn crossed_box_declines_to_refute() {
+        assert!(
+            refute(OneRow::new(
+                vec![0.5],
+                vec![1.0],
+                vec![0.0],
+                vec![1.0],
+                LO_INF,
+                UP_INF
+            ))
+            .is_none()
+        );
+    }
+}

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -28,6 +28,7 @@ pub mod debug;
 pub mod debug_rank;
 pub mod eq_mult;
 pub mod hess;
+pub mod infeasibility_refutation;
 pub mod init;
 pub mod intermediate;
 pub mod ipopt_alg;

--- a/crates/pounce-cli/tests/false_local_infeasibility.rs
+++ b/crates/pounce-cli/tests/false_local_infeasibility.rs
@@ -194,6 +194,72 @@ fn hs13_neither_scaling_path_reports_infeasible() {
     }
 }
 
+/// gh #379: the two shapes where the *numerical* path called a feasible model
+/// infeasible, found by the feasible-by-construction property sweep in
+/// `pyomo-pounce/tests/test_infeasibility_no_false_positives.py`.
+///
+/// Both are linear-constrained sum-of-squares models — convex, so the auto-route
+/// sends them to the QP IPM and a user on defaults never sees this. They reach
+/// the numerical path only under `solver_selection=nlp`, which is also what every
+/// genuinely nonlinear model uses, where there is no second solver to disagree
+/// and no way to notice.
+///
+/// `feasible_x0_extreme_row` (property seed 294) is the sharper of the two: the
+/// model's own starting point `(5e5, 5e5)` satisfies both rows *exactly*, and
+/// `pounce verify` reports `0.000e0` constraint and bound violation on the convex
+/// route's solution. Its first row carries `±1e30` coefficients; in the scaled
+/// space that row's slack initializes far from anything `x` can follow, the outer
+/// line search walks the violation up rather than down, restoration burns its
+/// 3000-iteration budget, and the cycle gate reported
+/// `Infeasible_Problem_Detected` — AMPL 200 — about a model the solver was
+/// *handed a feasible point for*.
+///
+/// The fix is a refutation rather than a retune: no numerical path may claim
+/// infeasibility while the starting point satisfies every constraint. See
+/// `pounce_algorithm::infeasibility_refutation`. The solve still fails here — the
+/// `±1e30` row is genuinely hostile — but it fails as AMPL 500, which a caller
+/// can see, instead of AMPL 200, which is a wrong answer they cannot.
+///
+/// `feasible_x0_wide_scale` (property seed 102) is the same family at milder
+/// scale (`1e8` row coefficients, right-hand sides near `5e13`). It was a false
+/// positive before the scale-relative tolerance work (#382–#386) and solves
+/// cleanly now; it is pinned here so that stays true.
+#[test]
+fn feasible_models_with_a_feasible_start_are_not_reported_infeasible() {
+    for model in ["feasible_x0_extreme_row.nl", "feasible_x0_wide_scale.nl"] {
+        let report = solve(
+            model,
+            &["solver_selection=nlp", "presolve=no", "print_level=0"],
+        );
+        let code = report.solution.solve_result_num;
+        assert!(
+            !(200..300).contains(&code),
+            "{model} is feasible — its own starting point satisfies every \
+             constraint, and POUNCE's convex QP route solves it to optimality — \
+             but the NLP path reported the AMPL infeasible band \
+             (solve_result_num={code}, status={:?})",
+            report.solution.status,
+        );
+    }
+}
+
+/// The contradiction that made gh #379 unambiguous: POUNCE's own convex solver
+/// returns `Optimal Solution Found` on the same models. Pinned so the two routes
+/// cannot drift back into disagreeing about whether the feasible set is empty.
+#[test]
+fn the_convex_route_still_solves_both_shapes() {
+    for model in ["feasible_x0_extreme_row.nl", "feasible_x0_wide_scale.nl"] {
+        let report = solve(model, &["print_level=0"]);
+        let code = report.solution.solve_result_num;
+        assert_eq!(
+            code, 0,
+            "{model} is a convex QP the auto-route solves; got \
+             solve_result_num={code}, status={:?}",
+            report.solution.status,
+        );
+    }
+}
+
 /// The other direction, and the test whose absence caused two wrong fixes.
 ///
 /// The probe withholds the verdict when a materially less-violating point sits

--- a/crates/pounce-cli/tests/fixtures/feasible_x0_extreme_row.nl
+++ b/crates/pounce-cli/tests/fixtures/feasible_x0_extreme_row.nl
@@ -1,0 +1,46 @@
+g3 1 1 0	# problem unknown
+ 2 2 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 4 4	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#c[1]
+n0
+C1	#c[2]
+n0
+O0 0	#o
+o0	#+
+o5	#^
+o0	#+
+v0	#x[0]
+n-500000.0
+n2
+o5	#^
+o0	#+
+v1	#x[1]
+n-500000.0
+n2
+x2	# initial guess
+0 500000.0	#x[0]
+1 500000.0	#x[1]
+r	#2 ranges (rhs's)
+2 -1e-06	#c[1]
+2 -1.01	#c[2]
+b	#2 bounds (on variables)
+0 0.0 1000000.0	#x[0]
+0 0.0 1000000.0	#x[1]
+k1	#intermediate Jacobian column lengths
+2
+J0 2	#c[1]
+0 -1e+30
+1 1e+30
+J1 2	#c[2]
+0 -1e-08
+1 -1e-08
+G0 2	#o
+0 0
+1 0

--- a/crates/pounce-cli/tests/fixtures/feasible_x0_wide_scale.nl
+++ b/crates/pounce-cli/tests/fixtures/feasible_x0_wide_scale.nl
@@ -1,0 +1,44 @@
+g3 1 1 0	# problem unknown
+ 2 2 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 2 2 	# nonzeros in Jacobian, obj. gradient
+ 4 4	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#c[1]
+n0
+C1	#c[2]
+n0
+O0 0	#o
+o0	#+
+o5	#^
+o0	#+
+v0	#x[0]
+n0.5
+n2
+o5	#^
+o0	#+
+v1	#x[1]
+n-499998.3031417761
+n2
+x2	# initial guess
+0 -0.5	#x[0]
+1 499998.3031417761	#x[1]
+r	#2 ranges (rhs's)
+2 49999830314176.61	#c[1]
+1 34489200259824.066	#c[2]
+b	#2 bounds (on variables)
+0 -1.0 0.0	#x[0]
+0 -1.696858223856672 999998.3031417761	#x[1]
+k1	#intermediate Jacobian column lengths
+0
+J0 1	#c[1]
+1 100000000.0
+J1 1	#c[2]
+1 68978634.61357497
+G0 2	#o
+0 0
+1 0

--- a/docs/src/solution-output.md
+++ b/docs/src/solution-output.md
@@ -53,6 +53,16 @@ different in kind — on a nonconvex problem a positive local minimum of the
 violation does **not** rule out a feasible point elsewhere, which is why the
 console message says "Problem may be infeasible."
 
+Because `200` is an inference rather than a proof, it is withdrawn when POUNCE
+holds a point that contradicts it. Before any numerical path reports `200`, the
+model's own starting point is evaluated against every constraint; if it
+satisfies them all, the feasible set is demonstrably non-empty and the verdict
+becomes `Error_In_Step_Computation` (`500`) — an honest "the solve broke down"
+rather than a wrong answer. This can only ever *withdraw* a verdict: a model
+with no feasible point cannot produce such a point, so a correct `200` is
+unaffected. Supplying a feasible starting point is therefore worth doing on a
+model you believe is feasible but POUNCE reports otherwise.
+
 When the region is found empty the solve is skipped entirely and the message
 names how it was found, so the claim is checkable:
 

--- a/pyomo-pounce/tests/test_infeasibility_no_false_positives.py
+++ b/pyomo-pounce/tests/test_infeasibility_no_false_positives.py
@@ -19,6 +19,11 @@ underneath is not exact, and a handful of extreme-scale knife-edge instances
 Pinning the measured rate stops it silently getting worse — a change that pushes
 it up is a regression even if every hand-written case still passes. Lowering
 ``MAX_FALSE_POSITIVES`` as the path improves is the point.
+
+It has been lowered once, for gh #379: the numerical path (``solver_selection=nlp
+presolve=no``) now reports zero over 400 instances, because no path may claim
+infeasibility while the model's own starting point satisfies every constraint
+(``pounce_algorithm::infeasibility_refutation``).
 """
 
 from __future__ import annotations
@@ -35,9 +40,13 @@ pyo = pytest.importorskip("pyomo.environ")
 #: Instances per run. Large enough to be sensitive, small enough for CI.
 N_INSTANCES = 200
 
-#: Measured on the implementation this test landed with: 3 of 400 (~0.75%).
-#: Scaled to N_INSTANCES with headroom for generator jitter across seeds.
-MAX_FALSE_POSITIVES = 4
+#: Ratchet. Landed at 3 of 400 (~0.75%); gh #379's refutation gate took the
+#: numerical path to 0 of 400, leaving 1 of 400 — seed 223, on the presolve
+#: certification path. That seed is outside this run's first ``N_INSTANCES``, so
+#: the measured count here is 0; the 1 is headroom for a machine-dependent flip
+#: on a knife-edge instance, not a known failure. Lower it again as the presolve
+#: path improves.
+MAX_FALSE_POSITIVES = 1
 
 _SCALES = [1e-320, 1e-12, 1e-8, 1.0, 1e8, 1e18, 1e30]
 


### PR DESCRIPTION
Fixes #379.

## Problem

POUNCE reported `Infeasible_Problem_Detected` — AMPL `solve_result_num` 200, Pyomo `TerminationCondition.infeasible` — on a model it was **handed a feasible starting point for**.

Only one of the four seeds in the issue still reproduces on `main`. Seeds 99 and 193 (the #376 regressions) are fixed and pinned by `scaled_feasible_not_infeasible.rs`; seed 102 was fixed by the scale-relative tolerance work (#382–#386). Seed 294 remained, and its mechanism is different from all of those.

The model is two variables, both in `[0, 1e6]`, two linear rows, sum-of-squares objective. Its declared starting point is `(5e5, 5e5)`, which satisfies both rows **exactly**. `pounce verify` reports `0.000e0` constraint and bound violation on the convex route's solution.

| route | status | `solve_result_num` |
|---|---|---|
| `solver_selection=nlp presolve=no`, before | `InfeasibleProblemDetected` | **200** |
| `solver_selection=nlp presolve=no`, after | `ErrorInStepComputation` | 500 |
| default auto-route (convex QP IPM) | `Optimal Solution Found` | 0 |

Two of POUNCE's own solvers contradicting each other about whether the feasible set is empty, on a model whose feasibility is witnessed by its own `x0`.

## Cause

Not a threshold. The first row carries `±1e30` coefficients. In the scaled space that row's slack initializes far from anything `x` can follow, so the outer line search walks the violation **up** from an exactly feasible start:

```
iter  0  inf_pr 1.00e-02      <- x0, feasible in user units
iter  1  inf_pr 1.10e-01
iter  3  inf_pr 1.00e+03
iter  9  inf_pr 9.98e+03      alpha_pr 4.88e-04, 12 backtracks
```

Restoration then burns its full 3000-iteration budget and exits `MaxiterExceeded`, and `cycle_locally_infeasible` in `resto_inner_solver.rs` converts that exhaustion into an infeasibility verdict:

```
[PN_RESTO_LOCINF] status=MaxiterExceeded iter=3000 inner_kkt_err=1.000000e5
  orig_inf_pr=1.000000e13 orig_inf_pr_scaled=1.000000e5 outer_tol=1.000000e-8
  strict=false alt=false cycle=true step_fail=false tiny_step=false -> loc_inf=true
```

`inner_kkt_err = 1e5`. The inner never approached stationarity at all — the gate's own comment says as much ("the inner's line search is cycling between basins rather than approaching a stationary point"). Every gate here argues from a *stalled feasibility sub-problem*: violation bounded away from zero, no local move reduces it. That is evidence, not proof, and this is what it looks like when the evidence is wrong.

Note the existing scale-relative guards were all working correctly and did not fire falsely; the defect is upstream of them, in what the `cycle` gate treats as evidence.

## Fix

A refutation rather than a retune. One concrete feasible point settles the question outright, whatever a local argument concluded — and the model's own starting point is right there. New `pounce_algorithm::infeasibility_refutation` evaluates it (clamped into the variable box) against every row and withdraws the verdict if it satisfies them all.

**Applied as one gate over all four claim sites**, not per-site: the IPM path's restoration/cycle gates, the SQP infeasible-subproblem exit, and the ℓ₁ wrapper's uncollapsed-slack certificate. The two preceding safeguards in this area (#376, #380) were each added to one path and not its twin, and a hole survived both times.

One-directional by construction: a model with no feasible point cannot produce a witness, so every correct verdict is untouched, and any failure to evaluate simply declines to refute.

The withdrawn verdict becomes `Error_In_Step_Computation` (AMPL 500) — the status this codebase already uses for "the solve broke down and we are *not* claiming infeasibility"; the `cycle_exit` fallback in `ipopt_alg.rs` picks between exactly these two on exactly this question. The `±1e30` model still fails, because that row is genuinely hostile. It now fails visibly instead of returning a confident wrong answer.

### What was tried and rejected

**`is_negligible` for the witness test — rejected, measured.** The first version used the clamped accepting form, matching presolve's `witness_refutes_infeasibility`. `test_scale_invariance.py` caught it before it could ship: it withdrew *correct* infeasibility verdicts on three models (`inf_372`, `inf_clear`, `inf_two`) at row scalings `1e-12 … 1e-8`, turning 0 wrong cells into 2–3 each. Mechanism: `x >= 2` over `x ∈ [0, 1]` multiplied through by `1e-12` has a violation of `2e-12` against a row magnitude of `2e-12` — a full unit violation — but `tol * max(scale, 1)` is `1e-8`, so `x0` read as a witness. The clamp reinstates an absolute floor exactly in the down-scaled direction this gate must not be fooled in. Shipped form is pure relative `tol * scale` (`is_significant`), threshold `2e-20`, verdict stands. Pinned by a 25-decade sweep in both directions.

**Sampling the box (midpoint, corners) — deliberately not done.** Presolve's refutation does this, correctly: it is countering a *proof over the whole box* from interval arithmetic. Here the claim is numerical and the gate runs on every solve ending in the infeasible band, so widening it would change verdicts on models this PR cannot validate against — the benchmark corpus is not in the tree. The starting point needs no such justification. This is a known, documented gap, not an oversight.

**Cross-checking against the convex route (issue's step 3) — subsumed.** The refutation is strictly cheaper (no second solve), more general (works on genuinely nonlinear models, where there is no convex route to disagree), and catches the same case.

**The MC64 re-solve not overturning these (issue's step 2) — not a defect.** That guard exists for *hypersensitivity*: two backward-stable scalings falling into different basins. This failure reproduces under both scalings, so the second opinion correctly agreed. Confirmed by running with `nlp_scaling_method=none` and `feral_scaling=mc64` — same verdict. The refutation now runs first, so the wasted re-solve is skipped entirely.

## Blast radius

Any solve that would have returned `Infeasible_Problem_Detected` from a numerical argument, and only those. A correct verdict cannot be affected: the withdrawal requires a point that satisfies every constraint, which an infeasible model does not have.

Presolve *certificates* (`TNLP::presolve_infeasibility_proof`) are exempt — a proof is not a numerical inference, and it carries its own, tighter refutation.

Cost is one `eval_g` on a path that has already terminated.

Corpus sweep: **not run** — the benchmark `.nl` inputs are gitignored and not present in this checkout, so I cannot make the "bit-identical except the targeted case" claim that a solver change normally warrants. What I can state is measured below. Flagging this explicitly rather than implying coverage I do not have; the property sweeps and the full test suite are the evidence this rests on.

Measured, over 400 feasible-by-construction instances from `test_infeasibility_no_false_positives.py`'s generator:

| configuration | before | after |
|---|---|---|
| `solver_selection=nlp presolve=no` | 1 (seed 294) | **0** |
| property test's full option set | 3 (seeds 223, 294, + 1) | **1** (seed 223) |

Seed 223 is `solve_result_num` 201 on the presolve certification path — #377's territory, untouched here.

## Tests

**`crates/pounce-cli/tests/false_local_infeasibility.rs`** gains both reported shapes as fixtures (`feasible_x0_extreme_row.nl` = seed 294, `feasible_x0_wide_scale.nl` = seed 102), plus a pin that the convex route still solves them, so the two routes cannot drift back into disagreeing.

Verified biting on the parent commit (`91804a4`) by copying the test and fixtures into a worktree at that commit:

```
test feasible_models_with_a_feasible_start_are_not_reported_infeasible ... FAILED
  feasible_x0_extreme_row.nl is feasible — its own starting point satisfies every
  constraint, and POUNCE's convex QP route solves it to optimality — but the NLP
  path reported the AMPL infeasible band (solve_result_num=200,
  status=InfeasibleProblemDetected)
test result: FAILED. 6 passed; 1 failed
```

Two honest qualifications about which halves bite:

- The `feasible_x0_wide_scale.nl` (seed 102) half **passes on the parent**. It was a false positive before #382–#386 and is pinned here as a ratchet, not as a reproducer of this bug.
- `the_convex_route_still_solves_both_shapes` also **passes on the parent**. It pins the contradiction that made the issue unambiguous; it is not a regression test for this fix.

**`crates/pounce-algorithm/src/infeasibility_refutation.rs`** — 9 unit tests. The load-bearing ones: `a_down_scaled_infeasible_row_is_never_refuted` and `a_scaled_feasible_row_is_refuted_at_every_scale` sweep 25 decades in both directions and pin the `is_negligible` mistake so nobody reintroduces it; `genuinely_infeasible_model_is_not_refuted` uses #372's reproducer; `clamping_does_not_manufacture_a_witness` and `infinite_bound_sentinel_does_not_inflate_the_scale` cover the two ways this could fabricate a withdrawal.

**`pyomo-pounce/tests/test_infeasibility_no_false_positives.py`** — `MAX_FALSE_POSITIVES` ratchets 4 → 1. Measured count at `N_INSTANCES = 200` is 0; the 1 is headroom for a machine-dependent flip on a knife-edge instance, not a known failure.

Full workspace suite (`--exclude pounce-hsl`, which needs `COINHSL_DIR` and does not link in this environment): **156 test binaries, exit 0, zero failures**. `cargo fmt --all -- --check` clean; `cargo clippy --all-targets` introduces no new warnings.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`solution-output.md`, existing page — no `SUMMARY.md` change needed)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyT66Zbb3fZEPQgtEK9tPp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyT66Zbb3fZEPQgtEK9tPp)_