### PR TITLE
Report an unbounded model as unbounded on the qp-active-set path (#388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,43 @@ changes.
   - Docs: [Solution output](docs/src/solution-output.md) gains a
     `solve_result_num` band table and the proved-vs-local distinction.
 
+### Fixed — `qp-active-set` reported an unbounded model as a solver internal error (#388)
+
+- **An unbounded model solved with `solver_selection=qp-active-set` now reports
+  `Diverging_Iterates` (AMPL `solve_result_num` **300**, "your model is
+  unbounded"), matching every other selector on the identical `.nl` file.** It
+  previously reported `Internal_Error` (**500**, "the solver broke") — so a
+  modeler with a genuinely unbounded model was told POUNCE had a bug, and
+  drivers that branch on `solve_result_num` routed the result to the wrong
+  handler. Minimal reproduction: `min −x s.t. x ≥ 0`, one variable, one
+  constraint.
+  - The unboundedness was already *detected* — the inner QP said so in as many
+    words — but the SQP driver folded that correct diagnosis into
+    `QpFailure(LinearSolverFailure("QP subproblem returned status unbounded"))`,
+    which the application layer maps to `Internal_Error`. It was also mislabeled
+    a linear-solver failure with no linear solver having failed. A
+    status-mapping defect, not a numerical one.
+  - The verdict is **not** blanket-mapped, because an unbounded *step* QP is on
+    its own only a statement about the linearization: on a nonconvex NLP the
+    constraints can curve back and the objective turn around (`min −x s.t.
+    x² ≤ 1` has an unbounded step QP at `x = 0` and a bounded feasible set).
+    `pounce-qp` now returns the certified recession ray alongside the verdict
+    (`QpSolution::unbounded_ray`), and the SQP driver re-tests that ray against
+    the **true** `f` and `c` — feasible probe points spanning twelve decades of
+    step length, each required to sustain at least half the initial linear
+    descent rate, the same non-decelerating-descent bar the IPM's divergence
+    guard applies (#248/#252/#285). Only a ray that survives is reported
+    unbounded.
+  - A ray that does not survive now yields the honest non-committal
+    `Search_Direction_Becomes_Too_Small` (`QpStepFailed`) instead of the old
+    hard error — the QP could not produce a usable step, and no claim is made
+    either way.
+  - The unbounded verdict also travels the normal result path, so it reaches
+    `finalize_solution`: the JSON report carries an objective and an `x` block
+    where it previously emitted `"objective": null` and no `x`.
+  - Unaffected: the infeasible and feasible cases on the same selector, which
+    already answered `200` and `0` correctly.
+
 ### Fixed — an infeasible model's verdict depended on the user's `tol` (follow-up to #372)
 
 - **A genuinely infeasible model now reports `Infeasible_Problem_Detected` (AMPL

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1008,6 +1008,16 @@ impl IpoptApplication {
                 ApplicationReturnStatus::SearchDirectionBecomesTooSmall,
                 pounce_nlp::SolverReturn::ErrorInStepComputation,
             ),
+            // Unbounded below, with a recession ray verified against the
+            // true NLP (gh #388). `Diverging_Iterates` is POUNCE's (Ipopt's)
+            // unboundedness verdict and maps to AMPL `solve_result_num=300`
+            // — the same answer the IPM selectors give on the same model,
+            // instead of the `Internal_Error` / 500 ("the solver broke")
+            // this path used to report.
+            crate::sqp::SqpStatus::Unbounded => (
+                ApplicationReturnStatus::DivergingIterates,
+                pounce_nlp::SolverReturn::DivergingIterates,
+            ),
         };
 
         // Forward to the user TNLP's finalize_solution. We pass

--- a/crates/pounce-algorithm/src/sqp/result.rs
+++ b/crates/pounce-algorithm/src/sqp/result.rs
@@ -25,6 +25,17 @@ pub enum SqpStatus {
     /// — it makes no infeasibility claim it cannot back with a
     /// certificate. Maps to `Search_Direction_Becomes_Too_Small`.
     QpStepFailed,
+    /// The problem is unbounded below: the step QP returned a certified
+    /// recession ray (zero curvature, feasible for every step length,
+    /// strict descent) *and* that ray was re-verified against the true
+    /// NLP — feasible points along it drive `f` toward `−∞` at (at
+    /// least) half the linear rate out to `1e12·‖d‖`. Maps to
+    /// `Diverging_Iterates`, POUNCE's (Ipopt's) unboundedness verdict,
+    /// the same status the IPM paths report on an unbounded model
+    /// (gh #388). An *unverified* unbounded step QP is a statement about
+    /// the local model only and falls back to
+    /// [`QpStepFailed`](Self::QpStepFailed).
+    Unbounded,
 }
 
 impl fmt::Display for SqpStatus {
@@ -35,6 +46,7 @@ impl fmt::Display for SqpStatus {
             SqpStatus::InfeasibleSubproblem => write!(f, "infeasible-subproblem"),
             SqpStatus::LineSearchFailed => write!(f, "line-search-failed"),
             SqpStatus::QpStepFailed => write!(f, "qp-step-failed"),
+            SqpStatus::Unbounded => write!(f, "unbounded"),
         }
     }
 }

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -522,15 +522,64 @@ impl SqpAlgorithm {
                         working_set: iter.working,
                     });
                 }
-                // `Unbounded` on a step QP is a genuine pathology (an
-                // indefinite/negative-curvature ray); keep the historical
-                // hard-error behavior.
-                other => {
-                    return Err(SqpError::QpFailure(
-                        pounce_qp::QpError::LinearSolverFailure(format!(
-                            "QP subproblem returned status {other}"
-                        )),
-                    ));
+                // The step QP is unbounded below along a certified
+                // recession ray of the LOCAL model (zero curvature,
+                // feasible for every step length, strict descent). That
+                // is a statement about the linearization, not yet about
+                // the NLP — so re-test the ray against the true
+                // objective and constraints. If it survives, the NLP
+                // itself is unbounded and we say so with the same
+                // `Diverging_Iterates` verdict every other POUNCE path
+                // returns; if it does not, the QP simply failed to
+                // produce a usable step, which is `QpStepFailed`.
+                //
+                // Neither outcome is a hard error. This used to return
+                // `QpFailure(LinearSolverFailure("QP subproblem returned
+                // status unbounded"))`, which surfaced to AMPL / Pyomo /
+                // GAMS consumers as `Internal_Error` /
+                // `solve_result_num=500` — "the solver broke" — on a
+                // model that is merely unbounded (`300`), and named a
+                // linear-solver failure when no linear solver had failed
+                // (gh #388).
+                QpStatus::Unbounded => {
+                    let certified = sol.unbounded_ray.as_ref().is_some_and(|d| {
+                        ray_certifies_unbounded(
+                            nlp,
+                            &iter.x,
+                            d,
+                            f_curr,
+                            &grad_f,
+                            &bl_c,
+                            &bu_c,
+                            &xl,
+                            &xu,
+                            self.opts.constr_viol_tol,
+                        )
+                    });
+                    if !certified {
+                        tracing::debug!(target: "pounce::sqp",
+                            "unbounded step QP whose recession ray does not survive \
+                             re-testing against the NLP — reporting qp-step-failed \
+                             rather than claiming unboundedness (gh #388)");
+                    }
+                    let obj = nlp.eval_f(&iter.x);
+                    self.iterates = Some(iter.clone());
+                    return Ok(SqpResult {
+                        x: iter.x,
+                        lambda_g: iter.lambda_g,
+                        lambda_x: iter.lambda_x,
+                        obj,
+                        status: if certified {
+                            SqpStatus::Unbounded
+                        } else {
+                            SqpStatus::QpStepFailed
+                        },
+                        n_iter: outer,
+                        n_qp_solves,
+                        final_stationarity,
+                        final_constr_viol,
+                        working_set: iter.working,
+                    });
                 }
             }
 
@@ -741,6 +790,141 @@ impl SqpAlgorithm {
             crate::sqp::SqpHessianSource::Lbfgs => HessianInertia::Psd,
         }
     }
+}
+
+/// gh #388: does the step QP's certified recession ray certify the **NLP**
+/// unbounded below?
+///
+/// The inner QP hands back a direction `d` that is a recession ray *of the
+/// linearization at `x`*: `∇²L d ≈ 0`, `d` feasible for the linearized
+/// constraints at every step length, `∇q(x)ᵀd < 0`. On an LP or a QP that
+/// linearization is exact and `d` is a recession ray of the original
+/// problem; on a general NLP it need not be — the constraints curve back
+/// and the objective can turn around. The two cases must not share a
+/// status, so we settle it by evaluation rather than by faith: walk the
+/// ray and check, at the **true** `f` and `c`, that
+///
+///  1. every probe point is *feasible* (variable bounds and constraint
+///     bounds, the latter with a roundoff allowance that grows with the
+///     row scale so a linear row evaluated at `‖x‖ ~ 1e12` is not failed
+///     on cancellation noise), and
+///  2. the objective keeps falling at **at least half** the initial linear
+///     rate `∇f(x)ᵀd` — not merely falling. A ray that decelerates is
+///     settling onto a finite optimum, the same distinction the IPM's
+///     divergence guard draws (#248/#252/#285).
+///
+/// Probes span twelve decades of step length, so a "pass" is a family of
+/// genuinely feasible points whose objective marches to `−∞` at a linear
+/// rate over `1e12`. Anything short of that — one infeasible probe, one
+/// decelerating decade, a NaN — returns `false` and the caller reports the
+/// non-committal `QpStepFailed` instead. False negatives cost an honest
+/// "no step" status; a false positive would tell a modeler their bounded
+/// model is unbounded, so the asymmetry is deliberate.
+///
+/// `dir` need not be normalized (it is rescaled to unit max-norm here, so
+/// the probe lengths are in the iterate's own units).
+#[allow(clippy::too_many_arguments)]
+fn ray_certifies_unbounded<N: SqpProblemSpec>(
+    nlp: &mut N,
+    x: &[Number],
+    dir: &[Number],
+    f_x: Number,
+    grad_f: &[Number],
+    bl_c: &[Number],
+    bu_c: &[Number],
+    xl: &[Number],
+    xu: &[Number],
+    constr_viol_tol: Number,
+) -> bool {
+    /// Step lengths along the unit-max-norm ray, spanning twelve decades.
+    const PROBES: [Number; 7] = [1e0, 1e2, 1e4, 1e6, 1e8, 1e10, 1e12];
+    /// Roundoff allowance per unit of `row_scale · ‖x‖∞` when checking a
+    /// constraint at a far-out probe: comfortably above f64 epsilon
+    /// (`2.2e-16`) to absorb accumulation over a row, far below anything
+    /// a real violation would produce.
+    const ROUNDOFF_REL: Number = 1e-12;
+
+    let n = x.len();
+    if dir.len() != n || grad_f.len() != n || !f_x.is_finite() {
+        return false;
+    }
+    let scale = dir.iter().map(|v| v.abs()).fold(0.0, f64::max);
+    if !scale.is_finite() || scale <= 0.0 {
+        return false;
+    }
+    let d: Vec<Number> = dir.iter().map(|v| v / scale).collect();
+
+    // Descent of the TRUE objective along the ray. The QP certified this
+    // for its own (possibly quasi-Newton) model gradient; re-derive it
+    // from `∇f(x)` so the rate we hold the probes to is the real one.
+    let slope: Number = grad_f.iter().zip(d.iter()).map(|(g, di)| g * di).sum();
+    let g_norm = grad_f.iter().map(|v| v * v).sum::<Number>().sqrt();
+    // Numerically meaningful (not roundoff-scale) descent; a NaN slope
+    // fails the `is_finite` guard rather than sneaking past the comparison.
+    let descent_bar = -1e-9 * g_norm.max(1.0);
+    if !slope.is_finite() || slope >= descent_bar {
+        return false;
+    }
+
+    // Per-row `max_j |∂c_i/∂x_j|`, the scale a linear row's value grows
+    // with along the ray — the basis for the roundoff allowance in (1).
+    let m = bl_c.len();
+    let mut row_scale: Vec<Number> = vec![0.0; m];
+    {
+        let jac = nlp.eval_jac_c(x);
+        for k in 0..jac.vals.len() {
+            let i = (jac.irow[k] - 1) as usize;
+            row_scale[i] = row_scale[i].max(jac.vals[k].abs());
+        }
+    }
+
+    for &t in PROBES.iter() {
+        let xt: Vec<Number> = x.iter().zip(d.iter()).map(|(xi, di)| xi + t * di).collect();
+        if xt.iter().any(|v| !v.is_finite()) {
+            return false;
+        }
+
+        // (1a) Variable bounds. These are exact linear rows in the probe's
+        // own arithmetic, so the tolerance stays tight.
+        for i in 0..n {
+            let tol = 1e-9 * (1.0 + xt[i].abs());
+            if xl[i] > NLP_LOWER_BOUND_INF && xt[i] < xl[i] - tol {
+                return false;
+            }
+            if xu[i] < NLP_UPPER_BOUND_INF && xt[i] > xu[i] + tol {
+                return false;
+            }
+        }
+
+        // (1b) Constraint bounds, at the true (possibly nonlinear) `c`.
+        let x_inf = xt.iter().map(|v| v.abs()).fold(0.0, f64::max);
+        let c = nlp.eval_c(&xt);
+        if c.len() != m {
+            return false;
+        }
+        for i in 0..m {
+            if c[i].is_nan() {
+                return false;
+            }
+            let tol =
+                constr_viol_tol.max(0.0) * (1.0 + c[i].abs()) + ROUNDOFF_REL * row_scale[i] * x_inf;
+            if bl_c[i] > NLP_LOWER_BOUND_INF && c[i] < bl_c[i] - tol {
+                return false;
+            }
+            if bu_c[i] < NLP_UPPER_BOUND_INF && c[i] > bu_c[i] + tol {
+                return false;
+            }
+        }
+
+        // (2) Sustained (non-decelerating) descent. `-inf` passes: an
+        // objective that has already overflowed downward is not evidence
+        // against unboundedness.
+        let f_t = nlp.eval_f(&xt);
+        if f_t.is_nan() || f_t > f_x + 0.5 * slope * t {
+            return false;
+        }
+    }
+    true
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/pounce-algorithm/tests/repro_issue388.rs
+++ b/crates/pounce-algorithm/tests/repro_issue388.rs
@@ -1,0 +1,437 @@
+//! Regression tests for issue #388: on an unbounded LP the active-set SQP
+//! selector (`solver_selection = qp-active-set`) reported `Internal_Error`
+//! (AMPL `solve_result_num=500`, "the solver broke") where every IPM
+//! selector reported `Diverging_Iterates` (`300`, "your model is
+//! unbounded") on the byte-identical model.
+//!
+//! The unboundedness was in fact detected — the inner QP said so in as many
+//! words — but the SQP driver folded that correct diagnosis into
+//! `QpFailure(LinearSolverFailure("QP subproblem returned status
+//! unbounded"))`, which the application layer mapped to `Internal_Error`.
+//! It was also mislabeled a linear-solver failure with no linear solver
+//! having failed.
+//!
+//! An unbounded *step* QP is, on its own, only a statement about the
+//! linearization: on a nonconvex NLP the constraints can curve back and the
+//! objective turn around, so the fix does not blanket-map it to
+//! unboundedness. `pounce-qp` now returns the certified recession ray
+//! alongside the verdict and the SQP driver re-tests that ray against the
+//! true `f` and `c` before claiming anything. Hence the two halves of this
+//! file: the unbounded shapes must reach `DivergingIterates`, and the
+//! bounded controls must never do so.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+const INF: Number = 2e19; // > the 1e19 infinity sentinel
+
+/// A dense linear program `min cᵀx  s.t.  gₗ ≤ A x ≤ gᵤ,  xₗ ≤ x ≤ xᵤ`.
+struct DenseLp {
+    n: usize,
+    m: usize,
+    c: Vec<Number>,
+    a: Vec<Number>, // row-major m×n
+    g_l: Vec<Number>,
+    g_u: Vec<Number>,
+    x_l: Vec<Number>,
+    x_u: Vec<Number>,
+    x0: Vec<Number>,
+    final_obj: Option<Number>,
+    final_x: Option<Vec<Number>>,
+}
+
+impl DenseLp {
+    fn a(&self, i: usize, j: usize) -> Number {
+        self.a[i * self.n + j]
+    }
+}
+
+impl TNLP for DenseLp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: self.n as i32,
+            m: self.m as i32,
+            nnz_jac_g: (self.m * self.n) as i32,
+            nnz_h_lag: 0, // linear objective + constraints ⇒ zero Hessian
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&self.x_l);
+        b.x_u.copy_from_slice(&self.x_u);
+        b.g_l.copy_from_slice(&self.g_l);
+        b.g_u.copy_from_slice(&self.g_u);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&self.x0);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((0..self.n).map(|j| self.c[j] * x[j]).sum())
+    }
+
+    fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&self.c);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..self.m {
+            g[i] = (0..self.n).map(|j| self.a(i, j) * x[j]).sum();
+        }
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let mut k = 0;
+                for i in 0..self.m {
+                    for j in 0..self.n {
+                        irow[k] = i as i32;
+                        jcol[k] = j as i32;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&self.a);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        _obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        _mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Zero Hessian (LP): no structure entries, nothing to fill.
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_obj = Some(sol.obj_value);
+        self.final_x = Some(sol.x.to_vec());
+    }
+}
+
+/// A nonconvex NLP with a *linearization* that is unbounded below at the
+/// starting point but a *true* objective that is bounded: `min −x  s.t.
+/// x² ≤ 1`. At `x = 0` the linearized constraint `0 + 0·p ≤ 1` does not
+/// block the descent ray `p = +1` at all, so the step QP is unbounded —
+/// yet the feasible set is `[−1, 1]` and the optimum is `f = −1` at
+/// `x = 1`. This is the shape that must NOT be reported unbounded.
+struct CurvedBounded {
+    final_obj: Option<Number>,
+}
+
+impl TNLP for CurvedBounded {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 1,
+            m: 1,
+            nnz_jac_g: 1,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -INF;
+        b.x_u[0] = INF;
+        b.g_l[0] = -INF;
+        b.g_u[0] = 1.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.0;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(-x[0])
+    }
+
+    fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = -1.0;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] * x[0];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 2.0 * x.expect("values mode supplies x")[0];
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0;
+                jcol[0] = 0;
+            }
+            SparsityRequest::Values { values } => {
+                // ∇²L = obj_factor·∇²f + λ·∇²g = 0 + 2λ.
+                values[0] = 2.0 * lambda.map_or(0.0, |l| l[0]) + 0.0 * obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_obj = Some(sol.obj_value);
+    }
+}
+
+/// Solve through the active-set SQP engine, selected exactly the way the
+/// issue's reproduction does (`solver_selection=qp-active-set`).
+fn solve_active_set(tnlp: Rc<RefCell<dyn TNLP>>) -> (ApplicationReturnStatus, Number) {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("solver_selection", "qp-active-set", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let status = app.optimize_tnlp(tnlp);
+    let obj = app.statistics().final_objective;
+    (status, obj)
+}
+
+/// Solve through the default (IPM) path — the cross-selector oracle the
+/// issue leans on: every other selector answers `DivergingIterates` on
+/// these models.
+fn solve_default(tnlp: Rc<RefCell<dyn TNLP>>) -> ApplicationReturnStatus {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    app.optimize_tnlp(tnlp)
+}
+
+/// The issue's minimal reproduction: `min −x  s.t.  x ≥ 0`, one variable,
+/// one constraint, `x` unbounded above. Must report `DivergingIterates`
+/// (`solve_result_num=300`), never `InternalError` (`500`).
+#[test]
+fn unbounded_lp_reports_diverging_not_internal_error() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 1,
+        m: 1,
+        c: vec![-1.0],
+        a: vec![1.0],
+        g_l: vec![0.0],
+        g_u: vec![INF],
+        x_l: vec![-INF],
+        x_u: vec![INF],
+        x0: vec![0.0],
+        final_obj: None,
+        final_x: None,
+    }));
+    let (status, _obj) = solve_active_set(Rc::clone(&inst) as Rc<RefCell<dyn TNLP>>);
+    assert!(
+        !matches!(status, ApplicationReturnStatus::InternalError),
+        "an unbounded LP must not be reported as a solver internal error \
+         (issue #388); got {status:?}",
+    );
+    assert!(
+        matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "qp-active-set must report DivergingIterates (solve_result_num=300) \
+         on min −x s.t. x ≥ 0, matching every other selector (issue #388); \
+         got {status:?}",
+    );
+    // The issue also notes the failing path emitted a null objective and no
+    // `x` block, because it bailed out before `finalize_solution`. Returning
+    // a status through the normal result path restores both.
+    assert!(
+        inst.borrow().final_obj.is_some() && inst.borrow().final_x.is_some(),
+        "the unbounded verdict must still reach finalize_solution so the \
+         report carries an objective and an x block (issue #388)",
+    );
+}
+
+/// The same model on the default IPM path — the cross-selector oracle. The
+/// two selectors must agree.
+#[test]
+fn unbounded_lp_agrees_across_selectors() {
+    let make = || {
+        Rc::new(RefCell::new(DenseLp {
+            n: 1,
+            m: 1,
+            c: vec![-1.0],
+            a: vec![1.0],
+            g_l: vec![0.0],
+            g_u: vec![INF],
+            x_l: vec![-INF],
+            x_u: vec![INF],
+            x0: vec![0.0],
+            final_obj: None,
+            final_x: None,
+        })) as Rc<RefCell<dyn TNLP>>
+    };
+    let (sqp, _) = solve_active_set(make());
+    let ipm = solve_default(make());
+    assert_eq!(
+        format!("{sqp:?}"),
+        format!("{ipm:?}"),
+        "qp-active-set and the IPM path must return the same status on the \
+         same unbounded LP (issue #388)",
+    );
+}
+
+/// A recession ray in an equality null space over free variables
+/// (`min −x₀  s.t.  x₀ − x₁ = 0`, ray `d = (1, 1)`) — the #285 shape, now
+/// through the active-set selector.
+#[test]
+fn unbounded_null_aeq_ray_reports_diverging() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 2,
+        m: 1,
+        c: vec![-1.0, 0.0],
+        a: vec![1.0, -1.0],
+        g_l: vec![0.0],
+        g_u: vec![0.0],
+        x_l: vec![-INF, -INF],
+        x_u: vec![INF, INF],
+        x0: vec![0.0, 0.0],
+        final_obj: None,
+        final_x: None,
+    }));
+    let (status, _obj) = solve_active_set(inst as Rc<RefCell<dyn TNLP>>);
+    assert!(
+        matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "a recession ray in null(A_eq) over free variables must report \
+         DivergingIterates on the active-set path too (issue #388); got \
+         {status:?}",
+    );
+}
+
+/// Bounded control: the identical LP with the ray blocked by a finite
+/// variable bound. Must solve, and must never claim unboundedness.
+#[test]
+fn bounded_lp_still_solves() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 1,
+        m: 1,
+        c: vec![-1.0],
+        a: vec![1.0],
+        g_l: vec![0.0],
+        g_u: vec![INF],
+        x_l: vec![-INF],
+        x_u: vec![3.0],
+        x0: vec![0.0],
+        final_obj: None,
+        final_x: None,
+    }));
+    let (status, obj) = solve_active_set(Rc::clone(&inst) as Rc<RefCell<dyn TNLP>>);
+    assert!(
+        !matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "a bounded LP must never report DivergingIterates (issue #388); got \
+         {status:?}",
+    );
+    assert!(
+        matches!(status, ApplicationReturnStatus::SolveSucceeded),
+        "min −x s.t. x ≥ 0, x ≤ 3 must solve; got {status:?}",
+    );
+    assert!(
+        (obj - (-3.0)).abs() < 1e-6,
+        "expected objective −3 at x = 3; got {obj}",
+    );
+}
+
+/// Infeasible control: `x ≥ 1` and `x ≤ 0` via a two-row LP. The issue
+/// records `qp-active-set` already answering `200` here; the unbounded
+/// branch must not have disturbed it.
+#[test]
+fn infeasible_lp_unchanged() {
+    let inst = Rc::new(RefCell::new(DenseLp {
+        n: 1,
+        m: 2,
+        c: vec![-1.0],
+        a: vec![1.0, 1.0],
+        g_l: vec![1.0, -INF],
+        g_u: vec![INF, 0.0],
+        x_l: vec![-INF],
+        x_u: vec![INF],
+        x0: vec![0.0],
+        final_obj: None,
+        final_x: None,
+    }));
+    let (status, _obj) = solve_active_set(inst as Rc<RefCell<dyn TNLP>>);
+    assert!(
+        !matches!(
+            status,
+            ApplicationReturnStatus::DivergingIterates | ApplicationReturnStatus::SolveSucceeded
+        ),
+        "an infeasible LP must be reported neither unbounded nor solved \
+         (issue #388); got {status:?}",
+    );
+}
+
+/// The false-positive guard, and the reason the fix verifies the ray rather
+/// than trusting the QP's verdict: `min −x  s.t.  x² ≤ 1` has an unbounded
+/// step QP at `x = 0` (the linearized constraint does not block `p = +1`)
+/// but a bounded feasible set `[−1, 1]`. Reporting this unbounded would
+/// tell a modeler their bounded model diverges.
+#[test]
+fn curved_constraint_never_falsely_unbounded() {
+    let inst = Rc::new(RefCell::new(CurvedBounded { final_obj: None }));
+    let (status, _obj) = solve_active_set(inst as Rc<RefCell<dyn TNLP>>);
+    assert!(
+        !matches!(status, ApplicationReturnStatus::DivergingIterates),
+        "min −x s.t. x² ≤ 1 is bounded (optimum −1 at x = 1) and must never \
+         be reported unbounded, however its step QP behaves (issue #388); \
+         got {status:?}",
+    );
+    assert!(
+        !matches!(status, ApplicationReturnStatus::InternalError),
+        "and it must not be an internal error either; got {status:?}",
+    );
+}

--- a/crates/pounce-qp/src/problem.rs
+++ b/crates/pounce-qp/src/problem.rs
@@ -139,6 +139,16 @@ pub struct QpSolution {
     pub obj: Number,
     pub status: QpStatus,
     pub stats: QpStats,
+    /// The certified recession direction `d` behind a
+    /// [`QpStatus::Unbounded`] verdict: `Hd ≈ 0`, `d` feasible for every
+    /// step length, `∇q(x)ᵀd < 0`. `None` for every other status.
+    ///
+    /// Callers that embed this QP as a *subproblem* need the witness, not
+    /// just the verdict: an unbounded step QP is only evidence about the
+    /// local model, so an SQP driver has to re-test the ray against the
+    /// true NLP before it can report the NLP unbounded (gh #388). The
+    /// direction is not normalized.
+    pub unbounded_ray: Option<Vec<Number>>,
 }
 
 /// Per-solve counters and timers reported alongside the solution.

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -344,6 +344,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: None,
                 });
             }
 
@@ -411,6 +412,7 @@ impl ParametricActiveSetSolver {
                 used_phase1: false,
                 time: started.elapsed(),
             },
+            unbounded_ray: None,
         })
     }
 
@@ -566,6 +568,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: None,
                 });
             }
 
@@ -623,6 +626,7 @@ impl ParametricActiveSetSolver {
                 used_phase1: false,
                 time: started.elapsed(),
             },
+            unbounded_ray: None,
         })
     }
 
@@ -747,6 +751,9 @@ impl ParametricActiveSetSolver {
             };
 
             if feasible_ray && ray_is_unbounded_descent(qp.h, qp.g, &x, &x) {
+                // The witness direction on this path IS the blown-up
+                // iterate `x` (see the `d = x/‖x‖` argument above).
+                let ray = x.clone();
                 return Ok(QpSolution {
                     x,
                     lambda_g,
@@ -761,6 +768,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: Some(ray),
                 });
             }
         }
@@ -790,6 +798,7 @@ impl ParametricActiveSetSolver {
                 used_phase1: false,
                 time: started.elapsed(),
             },
+            unbounded_ray: None,
         })
     }
 
@@ -1071,6 +1080,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: None,
                 });
             }
 
@@ -1162,6 +1172,7 @@ impl ParametricActiveSetSolver {
             // takes unbounded full steps until `MaxIter` (δ discarded).
             if candidates.is_empty() && delta > 0.0 && ray_is_unbounded_descent(qp.h, qp.g, &x, &p)
             {
+                let ray = p.clone();
                 return Ok(QpSolution {
                     obj: Number::NEG_INFINITY,
                     x,
@@ -1176,6 +1187,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: Some(ray),
                 });
             }
 
@@ -1277,6 +1289,7 @@ impl ParametricActiveSetSolver {
                 used_phase1: false,
                 time: started.elapsed(),
             },
+            unbounded_ray: None,
         })
     }
 
@@ -1476,6 +1489,7 @@ impl ParametricActiveSetSolver {
                     used_phase1: true,
                     time: started.elapsed(),
                 },
+                unbounded_ray: None,
             });
         }
 
@@ -1564,6 +1578,12 @@ impl ParametricActiveSetSolver {
                 used_phase1: true,
                 time: started.elapsed(),
             },
+            // Deliberately `None` even when `status` carries an `Unbounded`
+            // forwarded from phase-1: that ray lives in the *augmented*
+            // (elastic) space, so it is neither dimensioned nor meaningful
+            // for the original QP. A caller that needs a witness gets no
+            // witness and must not claim unboundedness.
+            unbounded_ray: None,
         })
     }
 
@@ -1772,6 +1792,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: None,
                 });
             }
 
@@ -1823,6 +1844,7 @@ impl ParametricActiveSetSolver {
             // Newton step never certifies and the unconditional check is
             // still safe.
             if candidates.is_empty() && ray_is_unbounded_descent(qp.h, qp.g, &x, &p) {
+                let ray = p.clone();
                 return Ok(QpSolution {
                     obj: Number::NEG_INFINITY,
                     x,
@@ -1837,6 +1859,7 @@ impl ParametricActiveSetSolver {
                         used_phase1: false,
                         time: started.elapsed(),
                     },
+                    unbounded_ray: Some(ray),
                 });
             }
 
@@ -1903,6 +1926,7 @@ impl ParametricActiveSetSolver {
                 used_phase1: false,
                 time: started.elapsed(),
             },
+            unbounded_ray: None,
         })
     }
 }

--- a/docs/src/choosing-a-solver.md
+++ b/docs/src/choosing-a-solver.md
@@ -17,16 +17,16 @@ pluggable backend (FERAL by default, HSL MA57 optionally).
 
 | Solver | Problem class | Optimum | Crate | Entry points |
 |---|---|---|---|---|
-| **NLP filter-IPM** | general smooth NLP (nonconvex OK) | local (KKT) | `pounce-algorithm` + `pounce-nlp` | CLI default; Python `Problem`/`minimize`; `--solver nlp` |
+| **NLP filter-IPM** | general smooth NLP (nonconvex OK) | local (KKT) | `pounce-algorithm` + `pounce-nlp` | CLI default; Python `Problem`/`minimize`; `solver_selection=nlp` |
 | **NLP active-set SQP** | general smooth NLP | local | `pounce-algorithm` (subproblems via `pounce-qp`) | `algorithm=active-set-sqp` |
-| **Convex IPM (LP/QP)** | LP, convex QP | **global** | `pounce-convex` | `solve_qp_ipm`; `pounce.qp.solve_qp`; `--solver lp-ipm`/`qp-ipm` |
-| **Convex IPM (conic)** | SOCP, exp/power/PSD cones, convex QCQP | **global** | `pounce-convex` | `solve_socp_ipm`; `pounce.qp.solve_socp`; `minimize` (convex QCQP); `--solver socp`; `pounce <file>.cbf` |
-| **Active-set QP** | QP, convex *or* indefinite | local | `pounce-qp` | `ParametricActiveSetSolver`; `--solver qp-active-set` |
+| **Convex IPM (LP/QP)** | LP, convex QP | **global** | `pounce-convex` | `solve_qp_ipm`; `pounce.qp.solve_qp`; `solver_selection=lp-ipm`/`qp-ipm` |
+| **Convex IPM (conic)** | SOCP, exp/power/PSD cones, convex QCQP | **global** | `pounce-convex` | `solve_socp_ipm`; `pounce.qp.solve_socp`; `minimize` (convex QCQP); `solver_selection=socp`; `pounce <file>.cbf` |
+| **Active-set QP** | QP, convex *or* indefinite | local | `pounce-qp` | `ParametricActiveSetSolver`; `solver_selection=qp-active-set` |
 | **SOS / Lasserre** | polynomial (nonconvex) | **global** | `pounce-convex` | `sos_minimize`; `pounce.sos_minimize` |
 
 > A general-purpose **spatial branch-and-bound** solver for factorable nonconvex
 > NLPs (`pounce-global`) is in development on the `feature/global` branch and is
-> **not part of this release** — there is no `--solver global` CLI route or
+> **not part of this release** — there is no `solver_selection=global` CLI route or
 > `minimize_global` Python entry point yet. Today the only certified-global path
 > for nonconvex problems is SOS / Lasserre, for *polynomials*.
 
@@ -126,16 +126,19 @@ The CLI classifies each `.nl` problem and picks a solver, but you can force
 the choice:
 
 ```sh
-pounce model.nl --solver auto          # default: classify, then route
-pounce model.nl --solver nlp           # filter-IPM (or active-set-sqp via algorithm=)
-pounce model.nl --solver lp-ipm        # convex LP interior-point
-pounce model.nl --solver qp-ipm        # convex QP interior-point
-pounce model.nl --solver socp          # conic interior-point (convex QCQP)
-pounce model.nl --solver qp-active-set # active-set QP
+pounce model.nl solver_selection=auto          # default: classify, then route
+pounce model.nl solver_selection=nlp           # filter-IPM (or active-set-sqp via algorithm=)
+pounce model.nl solver_selection=lp-ipm        # convex LP interior-point
+pounce model.nl solver_selection=qp-ipm        # convex QP interior-point
+pounce model.nl solver_selection=socp          # conic interior-point (convex QCQP)
+pounce model.nl solver_selection=qp-active-set # active-set QP
 ```
 
-(The CLI spelling of the option is `solver_selection=<value>`, e.g.
-`pounce model.nl solver_selection=qp-ipm`.)
+`solver_selection` is an ordinary POUNCE option, not a command-line flag:
+it is passed as a trailing `KEY=VALUE` pair (the ipopt CLI convention), and
+so also works from an options file, the `pounce_options` environment
+variable, or Pyomo's `solver.options`. Forcing a value the problem class
+does not support is rejected with a message rather than silently ignored.
 
 See [LP / QP Solver Routing](lp-qp-routing.md) for how classification works
 and when it falls back to the more general solver.

--- a/docs/src/global-optimization.md
+++ b/docs/src/global-optimization.md
@@ -18,7 +18,7 @@ minimizer(s).
 > the `feature/global` branch and is not part of this release**. It is described
 > at the end of this chapter for context, but there is no `pounce-global` crate
 > in the shipped workspace, no `pounce.minimize_global` Python entry point, and
-> no `--solver global` CLI route here.
+> no `solver_selection=global` CLI route here.
 
 ## The SOS / Lasserre path (polynomials)
 

--- a/docs/src/images/solver-landscape.svg
+++ b/docs/src/images/solver-landscape.svg
@@ -30,7 +30,7 @@
   <!-- ===================== Routing ===================== -->
   <rect x="130" y="128" width="740" height="46" rx="8" fill="#fee2e2" stroke="#dc2626" stroke-width="1.5"/>
   <text x="500" y="148" text-anchor="middle" font-size="13" font-weight="bold" fill="#111827">Dispatch &amp; routing</text>
-  <text x="500" y="165" text-anchor="middle" font-size="11.5" fill="#374151">auto-classify (LP · QP · conic · NLP) — or force with <tspan font-style="italic">--solver</tspan></text>
+  <text x="500" y="165" text-anchor="middle" font-size="11.5" fill="#374151">auto-classify (LP · QP · conic · NLP) — or force with <tspan font-style="italic">solver_selection=</tspan></text>
 
   <!-- routing -> solvers -->
   <line x1="160" y1="174" x2="160" y2="210" stroke="#475569" stroke-width="1.5" marker-end="url(#arrow)"/>

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -168,5 +168,12 @@ infeasibility proof or an unbounded recession direction that is checked,
 not merely inferred), so these statuses are never reported in error; a
 problem the solver cannot certify simply runs to the iteration limit.
 
+`solver_selection=qp-active-set` follows the same contract. Its inner QP
+certifies the recession ray of the *linearization*, which on a nonlinear
+model is not yet a statement about the problem, so the ray is re-tested
+against the true objective and constraints before the 300 is reported;
+a ray that does not survive yields
+`Search_Direction_Becomes_Too_Small`, never an unboundedness claim.
+
 The design and roadmap live in
 [`dev-notes/lp-qp-routing.md`](https://github.com/jkitchin/pounce/blob/main/dev-notes/lp-qp-routing.md).

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -48,14 +48,14 @@ The `solver_selection` option overrides the automatic choice. It is a
 normal POUNCE option, so it works on the command line, in an options
 file, or through Pyomo's `solver.options`.
 
-| Value           | Behavior                                                            |
-|-----------------|---------------------------------------------------------------------|
-| `auto`          | **Default.** Route by detected class (table above).                 |
-| `nlp`           | Always use the NLP filter-IPM, regardless of class.                 |
-| `lp-ipm`        | Force the convex IPM; **errors** if the problem is not an LP.        |
-| `qp-ipm`        | Force the convex IPM; **errors** if the problem is not LP/convex-QP. |
-| `socp`          | Force the conic IPM; **errors** if the problem is not a convex QCQP. |
-| `qp-active-set` | Reserved for the active-set QP track; currently falls back to NLP.  |
+| Value           | Behavior                                                                        |
+|-----------------|---------------------------------------------------------------------------------|
+| `auto`          | **Default.** Route by detected class (table above).                             |
+| `nlp`           | Always use the NLP filter-IPM, regardless of class.                             |
+| `lp-ipm`        | Force the convex IPM; **errors** if the problem is not an LP.                   |
+| `qp-ipm`        | Force the convex IPM; **errors** if the problem is not LP/convex-QP.            |
+| `socp`          | Force the conic IPM; **errors** if the problem is not a convex QCQP.            |
+| `qp-active-set` | Force the active-set SQP engine; **errors** if the problem is not LP/convex-QP. |
 
 ```sh
 # Let POUNCE decide (default):
@@ -66,6 +66,9 @@ pounce model.nl solver_selection=nlp
 
 # Insist the problem is a convex QP — fail loudly if it is not:
 pounce model.nl solver_selection=qp-ipm
+
+# Solve that same QP with the active-set engine instead of the IPM:
+pounce model.nl solver_selection=qp-active-set
 ```
 
 A forced value that does not match the detected class is rejected with
@@ -75,6 +78,16 @@ a clear message rather than silently ignored:
 pounce: problem class NLP does not match forced solver qp-ipm
         (expected an LP or convex QP)
 ```
+
+`qp-active-set` runs the active-set SQP engine, whose step QPs are solved
+by `pounce-qp`'s `ParametricActiveSetSolver`; on an LP or convex QP that
+converges in essentially one QP solve. It is the same engine the
+`algorithm=active-set-sqp` option selects — on the CLI, `solver_selection`
+additionally validates the problem class first, which is why the row above
+can promise the error. Duals are recovered and the `.sol` written exactly
+as on the IPM path. (The `minimize` library path has no `.nl` to classify,
+so there it runs on whatever problem it is given; see
+[Python](python.md#forcing-the-solver).)
 
 ### From Pyomo
 


### PR DESCRIPTION
## Problem

On an unbounded model, `solver_selection=qp-active-set` reported `Internal_Error` —
AMPL `solve_result_num=500`, "the solver broke" — where every other selector reported
`Diverging_Iterates` (`300`, "your model is unbounded") on the byte-identical `.nl`.
A modeler with a genuinely unbounded model was told POUNCE had a bug, and drivers that
branch on `solve_result_num` routed the result to the wrong handler.

Minimal reproduction, 1 variable and 1 constraint: `min -x  s.t.  x >= 0`.

| | status | `solve_result_num` | objective | x |
|---|---|---|---|---|
| before | `InternalError` | **500** | `null` | absent |
| after | `DivergingIterates` | **300** | `0.0` | `[0.0]` |
| oracle — the other four selectors | `DivergingIterates` | 300 | `-399.1` | `[399.1]` |
| oracle — closed form | unbounded | — | `-inf` along `x -> +inf` | — |

Measured on the parent commit (`91804a4`) and on this branch, same `.nl`, same build.

The strongest oracle here is POUNCE's own `auto` / `lp-ipm` / `qp-ipm` / `nlp` on the
same file: this was pure internal inconsistency, and it is a status-mapping defect
rather than a numerical one — the unboundedness was already detected correctly.

The `null` objective and missing `x` block are the same defect seen from the other
side: the failing path returned before `finalize_solution` ever ran.

Note the `objective` / `x` columns still differ from the IPM selectors after the fix.
Those report a large partial iterate from a diverging run; the SQP reports the iterate
it was actually standing on when it certified the ray. Advancing it to a far-out
witness point would look more like "diverging", but its multipliers and residuals
would not correspond to it, so I left the reported iterate honest. The status and
`solve_result_num` — the machine-readable contract — now agree across all five.

## Cause

`sqp_alg.rs` treated `QpStatus::Unbounded` from the step QP as a hard error:

```rust
other => return Err(SqpError::QpFailure(
    pounce_qp::QpError::LinearSolverFailure(
        format!("QP subproblem returned status {other}"))))
```

`application.rs` maps any `Err` out of `optimize` to `Internal_Error`, and bails
before `finalize_solution` — hence both halves of the symptom. It was also
mislabeled a `LinearSolverFailure` with no linear solver having failed.

## Fix

**Rejected first:** mapping `QpStatus::Unbounded` straight onto `Diverging_Iterates`,
which is what the issue suggests. An unbounded *step* QP is only a statement about
the linearization. On `min -x  s.t.  x^2 <= 1` the linearized constraint at `x = 0`
is `0 + 0*p <= 1`, which does not block the descent ray `p = +1` at all — so the step
QP is unbounded while the feasible set is `[-1, 1]` with optimum `-1`. The blanket map
manufactures exactly the false UNBOUNDED that #248 / #252 / #285 were spent
eliminating. That model is now a test (`curved_constraint_never_falsely_unbounded`);
it fails on the parent commit with `Internal_Error` and would fail the blanket map
with `Diverging_Iterates`.

So the verdict is earned rather than forwarded:

1. `pounce-qp` returns the witness alongside the verdict — `QpSolution::unbounded_ray`,
   the certified recession direction (zero curvature, feasible at every step length,
   strict descent). Populated at the three sites that certify one; `None` everywhere
   else, including the elastic path, where the ray lives in the augmented space and is
   neither dimensioned nor meaningful for the original QP.
2. The SQP driver re-tests that ray against the **true** `f` and `c`: probe points at
   `t = 1e0 .. 1e12` along the unit-max-norm direction, each required to be feasible
   (variable bounds tight; constraint bounds with a roundoff allowance that grows with
   the row scale, so a linear row evaluated at `|x| ~ 1e12` is not failed on
   cancellation noise) and to sustain **at least half** the initial linear descent rate
   `grad_f(x)'d` — not merely to be falling. The non-decelerating-descent bar is the
   same one the IPM's divergence guard already applies: a ray that decelerates is
   settling onto a finite optimum.
3. A ray that survives twelve decades is `SqpStatus::Unbounded` -> `Diverging_Iterates`.
   One that does not is the existing non-committal `QpStepFailed` ->
   `Search_Direction_Becomes_Too_Small` — the QP could not produce a usable step and no
   claim is made either way.

The asymmetry is deliberate: a false negative costs an honest "no step" status, while
a false positive tells a modeler their bounded model diverges. Both outcomes now
travel the normal result path, so both reach `finalize_solution`.

## Blast radius

Confined to solves that previously ended in `Internal_Error` out of the SQP path with
that specific message. The only behavioural edit is the `QpStatus::Unbounded` arm,
which previously always terminated the solve as a hard error; the `QpSolution` field is
additive, and the probe evaluations and the extra `eval_jac_c` run only on that arm.
No path that previously produced a solution can reach the new code, so everything else
is bit-identical by construction rather than by measurement.

A differential corpus sweep against `91804a4` is **in progress**; I will post the
result as a comment. Two things to set expectations honestly:

- It is **not the full benchmark corpus**. That tree is gitignored (~4.5 GB) and
  `scripts/sync-bench-data.sh` mirrors it from a Dropbox path unavailable in the
  environment this was developed in. The sweep covers the 138-problem Maros-Meszaros
  convex-QP suite, regenerated 138/138 from public sources by the repo's own
  `benchmarks/qp/generate_nl.py` — chosen because it is exactly the LP / convex-QP
  class `qp-active-set` accepts. The NLP suites (vanderbei, water, gas, grid, cho,
  large_scale) are not covered.
- It can only rule out **collateral damage**, not confirm the new verdict: none of
  those 138 problems is unbounded, so the new code should never fire on them. The
  evidence that the new verdict is *correct* remains the six regression tests and the
  reasoning above.

On that basis I would not treat the sweep as a merge blocker, but it is running and
the number will be posted either way.

## Tests

`crates/pounce-algorithm/tests/repro_issue388.rs`, six tests. Verified against the
parent commit `91804a4`: **four fail there, and for the stated reason** — three with
`Internal_Error` where a status is expected, one on cross-selector disagreement:

- `unbounded_lp_reports_diverging_not_internal_error` — the issue's reproduction,
  including that the objective and `x` block come back populated
- `unbounded_lp_agrees_across_selectors` — SQP vs. IPM on the same model
- `unbounded_null_aeq_ray_reports_diverging` — the #285 `null(A_eq)` ray over free
  variables, now through the active-set selector
- `curved_constraint_never_falsely_unbounded` — the false-positive guard above

The remaining two are controls that pass on both sides and must keep passing:
`bounded_lp_still_solves` (ray blocked by a finite bound; solves, objective `-3`) and
`infeasible_lp_unchanged` (the issue records `qp-active-set` already answering `200`).

Not pinned deliberately: the specific probe schedule (`1e0..1e12`, half-rate bar) is a
threshold, not a contract. The tests pin the *verdicts* on both sides of it, so
retuning the schedule is free as long as those hold.

Clean: `cargo fmt --all --check`, the CI clippy gate
(`-D clippy::correctness -D clippy::suspicious`, workspace, all targets), and
`cargo test --workspace --exclude pounce-hsl` — **159 test binaries, no failures**, run
on the merged tree (`main` merged in at `14d02e5`; the count was 157 before that merge,
the extra two coming from the tests `main` landed in the meantime).

## Merge of `main` (`14d02e5`)

`main` moved ahead while this was open (#387, #391, #379, #394) and left the PR
un-mergeable. Only `CHANGELOG.md` conflicted: `main` added a `### Fixed` section for
 #379 under `[Unreleased]` and this branch added one for #388, neither replacing the
other, so both are kept — #388 above #379, leaving `main`'s ordering relative to the
 #372 entry below it untouched.

`crates/pounce-algorithm/src/application.rs` auto-merged, and it is the file holding
this PR's `SqpStatus::Unbounded -> DivergingIterates` arm — so that was checked rather
than assumed: the arm is intact, and all six `repro_issue388` tests plus the full
workspace suite pass on the merged tree.

## Also in this PR

Two doc commits, separable if you would rather they landed on their own:

- **`docs/src/lp-qp-routing.md`** — the `solver_selection` table said `qp-active-set`
  was "Reserved for the active-set QP track; currently falls back to NLP." It has not
  fallen back to NLP for some time: `resolve_solver` validates the class is LP /
  convex QP and rejects anything else, then the CLI sets `algorithm=active-set-sqp`.
  The banner on this issue's own reproduction says so — *"Selected solver: active-set
  QP (pounce-qp)"*. Rewritten to match, plus the paragraph the terse row needs.
- **`docs/src/choosing-a-solver.md`, `global-optimization.md`, the landscape SVG** —
  these documented a `--solver <value>` command-line flag in the at-a-glance table and
  a six-line example. There is no such flag: `pounce model.nl --solver qp-active-set`
  exits with `unrecognized argument '--solver'`. The page then said the real spelling
  is `solver_selection=<value>` in a parenthetical directly under the example that used
  the flag. Now uses the real spelling throughout; I checked all six documented values
  against the binary, and that forcing `qp-ipm` on an NLP prints the rejection message
  the page describes. `dev-notes/` keeps `--solver` deliberately — it is the record of
  the original design discussion, and `qa-lp-qp-torch.md` is the note that documented
  the flag's absence in the first place.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now — no test named that does not exist, no doc describing a
      design that was revised mid-review, no measurement whose baseline has
      since moved

Fixes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtrCL7AoA4EmRjLh6dpPFn