### PR TITLE
Certify the DOF-gate infeasibility proof at sub-tolerance row scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the last 3 `inf_eq` cells: the DOF-gate proof survives sub-tolerance row scales (#391)
+
+- **A contradictory over-determined equality system is now reported infeasible
+  at every row scale, including the sub-`1e-8` ones.** #387 took
+  `test_scale_invariance.py`'s `inf_eq` from 13 wrong cells to 3; the residual
+  three (`k ∈ {-12, -10, -8}`) still reported the 504 structural error. The
+  `inf_eq` baseline goes **3 → 0** and the model is now scale-invariant across
+  the harness's full 25 decades.
+- **Root cause: an absolute floor in the witness gate, not in the proof.** The
+  bound-propagation proof is already scale-free — `s*x == 0.2*s` with
+  `s*x == 0.8*s` crosses by `0.6` at every `s`. What moved was the refutation:
+  the witness test accepts a row when the residual is negligible through the
+  *clamped* form `tol * max(scale, 1)`, and that clamp reinstates an absolute
+  floor once a row's magnitude drops below 1. At `s <= ~3e-8` every point of
+  `[0, 1]` therefore "satisfied" both rows, refuted the verdict, and the proof
+  was withdrawn.
+- **The fix is scoped to the one path where the solve cannot run.** The clamp
+  exists to honor #380 — never certify what the solver itself would accept as
+  feasible, or the same model reports "proved infeasible" with presolve on and
+  `Solve_Succeeded` with it off. On the DOF-gate path that counterfactual never
+  materializes: the gate fired *because* the solve cannot run (1 variable, 2
+  equality rows), so the alternative to the proof is the structural error, not a
+  solution. Only there does the witness switch to
+  `pounce_presolve::WitnessRule::DeclaredRowRelative`, which measures the
+  residual against the row's **declared** magnitude — `max(|g_l|, |g_u|)` over
+  its finite bounds, the same "declared, not live" pattern
+  `fbbt_infeasibility_survives_margin` already uses — with no clamp. Every
+  wrapper that is actually solved through keeps the clamped form; the rule is a
+  property of the call site (`PresolveTnlp::probing_without_a_solve`), not a
+  user-settable option.
+- **The `b = 0` hazard is handled explicitly and fails closed.** A homogeneous
+  row (`g_l = g_u = 0`, or one with no finite bound at all) has no declared
+  magnitude, which would make a pure relative test unsatisfiable by construction
+  — the violation *is* the scale, so float noise on a genuinely feasible point
+  would read as a full-magnitude violation and fail to refute. Such rows keep
+  the absolute floor.
+- Unchanged, and covered by tests: a *consistent* over-determined system still
+  reports the DOF error at every scale, and at extreme row magnitude
+  (declared `~1e30`) the witness still refutes on a residual of `1e5` — fifteen
+  relative digits — which is the over-approximation class the gate exists for.
+- The algorithm-level `sub_tolerance_scales_keep_the_dof_error` test is
+  deliberately flipped to `sub_tolerance_scales_are_certified_too`.
+
 ### Fixed — provably infeasible over-determined systems reported a DOF failure (#387)
 
 - **A contradictory over-determined equality system now reports
@@ -30,9 +73,9 @@ changes.
   - Consequences of fail-closed: a *consistent* over-determined system still
     reports the DOF error, and at row scales at or below ~`1e-8` — where every
     point in the box satisfies both rows within the solver's own acceptance
-    tolerance — the proof is withheld and the DOF error stands. Those are the
+    tolerance — the proof is withheld and the DOF error stands. Those were the
     3 remaining wrong cells in `test_scale_invariance.py`'s `inf_eq` baseline
-    (13 → 3).
+    (13 → 3); #391 above takes them to 0.
   - Also fixed on the way: the CLI's `CountingTnlp` / `SeededTnlp` wrappers did
     not forward `get_variables_linearity` / `get_objective_variables_linearity`
     / `get_constraints_linearity` (trait default `false`), so anything stacked

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1434,6 +1434,10 @@ impl IpoptApplication {
     /// and a concrete witness point satisfying every constraint withdraws the
     /// verdict. A `false` here costs nothing but keeping the DOF error.
     ///
+    /// The witness gate runs under [`pounce_presolve::WitnessRule`]'s
+    /// `DeclaredRowRelative` form, which is admissible only because the solve
+    /// cannot run on this path (gh#391) — see the comment on the probe below.
+    ///
     /// Deliberately independent of the `presolve` master switch: this is not a
     /// model transformation (the wrapper is dropped without solving through
     /// it), it is a last check before reporting a structural error for a
@@ -1451,7 +1455,15 @@ impl IpoptApplication {
         opts.redundant_constraint_removal = false;
         opts.licq_check = false;
         opts.warm_z_bounds = false;
-        let mut probe = pounce_presolve::PresolveTnlp::new(Rc::clone(tnlp), opts);
+        // The one place the witness rule is raised off the solver's own
+        // acceptance test (gh#391). It is sound *here specifically* because the
+        // gate has already established the solve cannot run: the alternative to
+        // the proof is the structural 5xx error, never `Solve_Succeeded`, so
+        // the #380 "two routes, two answers" contradiction the clamp exists to
+        // prevent has no second route to contradict. See `WitnessRule` for the
+        // full argument and the homogeneous-row fallback.
+        let mut probe =
+            pounce_presolve::PresolveTnlp::new(Rc::clone(tnlp), opts).probing_without_a_solve();
         if probe.get_nlp_info().is_none() {
             return false;
         }

--- a/crates/pounce-algorithm/tests/issue_387_overdetermined_infeasible.rs
+++ b/crates/pounce-algorithm/tests/issue_387_overdetermined_infeasible.rs
@@ -14,11 +14,18 @@
 //! fail-closed safety net is inherited wholesale:
 //!
 //! * a *consistent* over-determined system still reports the DOF error, and
-//! * at row scales so small that the solver's own acceptance test would wave
-//!   any point through (`|s*x - 0.2*s| <= tol` for every `x` in the box), the
-//!   witness-refutation rule withholds the proof and the DOF error stands —
-//!   "proved infeasible" is never claimed for a model the solver would accept
-//!   as feasible.
+//! * the witness-refutation rule still withdraws the proof whenever a point in
+//!   the declared box genuinely satisfies every row.
+//!
+//! gh #391 closed the residual: the three smallest row scalings still reported
+//! the DOF error, because the witness test's *clamped* accepting form
+//! (`tol * max(scale, 1)`) reinstates an absolute floor once a row's magnitude
+//! drops below 1, so at `s <= ~3e-8` every point of `[0, 1]` "satisfied" both
+//! rows and withdrew a proof whose crossing is `0.6` at every `s`. On this path
+//! the solve cannot run, so there is no `Solve_Succeeded` counterfactual for
+//! the clamp to protect; the witness now measures against the row's *declared*
+//! magnitude with no clamp (`pounce_presolve::WitnessRule`), and the verdict is
+//! scale-invariant across the full range.
 
 use pounce_algorithm::application::IpoptApplication;
 use pounce_common::types::Number;
@@ -172,11 +179,11 @@ fn contradictory_equalities_are_infeasible_not_dof_error() {
 }
 
 /// Multiplying every row by `s > 0` leaves the feasible set unchanged, so the
-/// verdict must not depend on `s` wherever the certification is willing to
-/// speak at all.
+/// verdict must not depend on `s` — over the *whole* range the scale-invariance
+/// harness sweeps, not just the part above the old absolute floor (gh#391).
 #[test]
 fn verdict_is_scale_invariant_where_certifiable() {
-    for k in [-6, -4, -2, 0, 2, 4, 6, 8, 10, 12] {
+    for k in [-12, -10, -8, -6, -4, -2, 0, 2, 4, 6, 8, 10, 12] {
         let status = solve(TwoEqualities::contradictory(10.0_f64.powi(k)));
         assert_eq!(
             status,
@@ -186,14 +193,32 @@ fn verdict_is_scale_invariant_where_certifiable() {
     }
 }
 
-/// Below the certification floor the proof is *withheld*, not manufactured:
-/// at `s = 1e-12` every point in `[0, 1]` satisfies both rows within the
-/// solver's own acceptance tolerance, so claiming "proved infeasible" would
-/// contradict what the solver itself would report if it could run. The
-/// fail-closed answer is the structural DOF error, unchanged from before.
+/// gh#391: the deliberate flip of what this test used to pin.
+///
+/// It formerly asserted the DOF error at `s = 1e-12`, on the reading that
+/// claiming "proved infeasible" would contradict what the solver would report
+/// if it could run. The premise does not hold on this path — *the solver
+/// cannot run*, that is why the gate fired — so there was never a
+/// `Solve_Succeeded` to contradict, only the structural error the proof
+/// replaces. The witness now measures against the row's declared magnitude, and
+/// the sub-tolerance scales are certified like every other.
 #[test]
-fn sub_tolerance_scales_keep_the_dof_error() {
+fn sub_tolerance_scales_are_certified_too() {
     let status = solve(TwoEqualities::contradictory(1e-12));
+    assert_eq!(
+        status,
+        ApplicationReturnStatus::InfeasibleProblemDetected,
+        "the crossing is 0.6 at every row scale; only the witness's absolute \
+         floor made 1e-12 different"
+    );
+}
+
+/// The safety net the flip above must not have cut: a genuinely feasible model
+/// at the same sub-tolerance row scale is still refuted by the witness, so the
+/// DOF error stands. `x == 0.2` with `2x == 0.4` is consistent at `x = 0.2`.
+#[test]
+fn sub_tolerance_consistent_system_still_reports_dof_error() {
+    let status = solve(TwoEqualities::consistent(1e-12));
     assert_eq!(status, ApplicationReturnStatus::NotEnoughDegreesOfFreedom);
 }
 

--- a/crates/pounce-cli/tests/issue_387_overdetermined_infeasible.rs
+++ b/crates/pounce-cli/tests/issue_387_overdetermined_infeasible.rs
@@ -107,14 +107,13 @@ fn contradictory_equalities_report_infeasible_band() {
 }
 
 /// Multiplying every row by `s > 0` leaves the feasible set unchanged, so the
-/// verdict must agree at every scale the certification can speak to. Scales
-/// at or below ~1e-8 are excluded deliberately: there the solver's own
-/// acceptance test would wave any point in the box through, so the
-/// fail-closed witness rule withholds the proof (see the algorithm-level
-/// test's `sub_tolerance_scales_keep_the_dof_error`).
+/// verdict must agree at every scale — including the sub-`1e-8` scalings this
+/// sweep used to skip. Those were excluded because the witness gate's absolute
+/// floor withdrew the proof there; gh#391 removed the floor on this path, where
+/// the solve provably cannot run and so cannot disagree.
 #[test]
 fn verdict_is_scale_invariant_where_certifiable() {
-    for k in [-6, -3, 0, 3, 6, 9, 12] {
+    for k in [-12, -9, -6, -3, 0, 3, 6, 9, 12] {
         let text = solve(&format!("k{k}"), &inf_eq_nl(10.0_f64.powi(k)));
         let srn = solve_result_num(&text);
         assert!(

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -149,6 +149,60 @@ pub fn wrap_from_options(
     wrap_with_presolve(inner, opts)
 }
 
+/// Which accepting test the witness-refutation gate uses to decide that a
+/// sampled point satisfies a row.
+///
+/// The two forms exist because the question the witness answers is not always
+/// the same question. Both are *accepting* tests, so both must fail closed —
+/// when in doubt, accept the point, withdraw the verdict, keep the proof
+/// unclaimed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum WitnessRule {
+    /// **Default, and the only rule for any path where the solve can run.**
+    ///
+    /// Accepts a row when the residual is negligible at the row's *live*
+    /// magnitude through the clamped form `tol * max(scale, 1)` — i.e. exactly
+    /// what the solver's own acceptance test would wave through. This is the
+    /// #380 rule: never certify what the solver itself would accept as
+    /// feasible, or the same model reports "proved infeasible" with presolve on
+    /// and `Solve_Succeeded` with it off.
+    #[default]
+    SolverAcceptance,
+    /// **Only for paths where the solve provably cannot run**, so no
+    /// `Solve_Succeeded` counterfactual exists to contradict (today: the
+    /// too-few-degrees-of-freedom gate, gh#391).
+    ///
+    /// Accepts a row when the residual is negligible relative to the row's
+    /// **declared** magnitude, `max(|g_l|, |g_u|)` over its *finite* bounds,
+    /// with no absolute clamp. Declared, not live: the live value moves with
+    /// the sampled point, while the bounds are the magnitude the modeller wrote
+    /// the row in — the same "declared, not live" pattern
+    /// `fbbt_infeasibility_survives_margin` uses for its per-row margin.
+    ///
+    /// Why the clamp has to go here: `tol * max(scale, 1)` reinstates an
+    /// absolute floor once the row's magnitude drops below 1, so multiplying
+    /// every row of an infeasible model by `1e-12` — which changes the feasible
+    /// set not at all — makes every point of the box "satisfy" every row and
+    /// withdraws a scale-free bound-propagation proof. That is the whole of
+    /// gh#391: `s*x == 0.2*s` with `s*x == 0.8*s` crosses by `0.6` at every `s`,
+    /// yet the verdict flipped at `s <= ~3e-8`.
+    ///
+    /// Why it is still safe: the clamp's job is to not demand more precision
+    /// than the solver promised, because a solver converges to *absolute*
+    /// residuals. On this path the solver never produces a point at all, so
+    /// there is no converged residual to be compatible with — the alternative
+    /// to the proof is a structural error, not a solution.
+    ///
+    /// The `b = 0` hazard is handled explicitly and fails closed: a homogeneous
+    /// row (`g_l = g_u = 0`, or a row with no finite bound at all) has no
+    /// declared magnitude, which would make the relative test unsatisfiable by
+    /// construction — `viol == scale` for any nonzero float noise — and a
+    /// genuinely feasible point would fail to refute. Such a row keeps
+    /// [`WitnessRule::SolverAcceptance`]'s clamped form, i.e. the absolute
+    /// floor.
+    DeclaredRowRelative,
+}
+
 /// Cached, reduced view of the problem after presolve passes have
 /// run. Exposed for inspection from integration tests.
 /// How far a model must be from satisfiable before an emptiness detection is
@@ -200,6 +254,7 @@ fn witness_refutes_infeasibility(
     g_l: &[Number],
     g_u: &[Number],
     tol: Number,
+    rule: WitnessRule,
 ) -> bool {
     if m_in == 0 || n == 0 {
         return false;
@@ -265,9 +320,22 @@ fn witness_refutes_infeasibility(
                     0.0
                 }
             };
-            let scale = v.abs().max(fin(g_l[i])).max(fin(g_u[i]));
+            let declared = fin(g_l[i]).max(fin(g_u[i]));
+            let scale = v.abs().max(declared);
             let viol = (g_l[i] - v).max(v - g_u[i]).max(0.0);
-            is_negligible(viol, scale, tol)
+            match rule {
+                WitnessRule::SolverAcceptance => is_negligible(viol, scale, tol),
+                // Pure relative against the *declared* magnitude — no clamp, so
+                // the test moves with the row under scaling. A row with no
+                // declared magnitude (homogeneous, or unbounded on both sides)
+                // has nothing to be relative to and keeps the absolute floor,
+                // which is the fail-closed direction here: it accepts the
+                // point, and accepting withdraws the verdict.
+                WitnessRule::DeclaredRowRelative if declared > 0.0 => {
+                    viol.is_finite() && viol <= tol * declared
+                }
+                WitnessRule::DeclaredRowRelative => is_negligible(viol, scale, tol),
+            }
         });
         if feasible {
             return true;
@@ -453,6 +521,15 @@ pub struct PresolveTnlp {
     expr_provider: Option<Rc<RefCell<dyn ExpressionProvider>>>,
     opts: PresolveOptions,
 
+    /// Which accepting test the final witness-refutation gate uses. Left at
+    /// [`WitnessRule::SolverAcceptance`] for every wrapper that is actually
+    /// solved through; raised to [`WitnessRule::DeclaredRowRelative`] only by
+    /// callers that have already established the solve cannot run (gh#391).
+    /// Deliberately *not* a `PresolveOptions` field: it is a property of the
+    /// call site, not a user-tunable knob, and no user should be able to switch
+    /// a live solve onto the stricter rule.
+    witness_rule: WitnessRule,
+
     /// `None` until init has run; afterwards `Some(state)`.
     state: Option<PresolveState>,
 
@@ -529,9 +606,25 @@ impl PresolveTnlp {
             inner,
             expr_provider: None,
             opts,
+            witness_rule: WitnessRule::default(),
             state: None,
             finalized_full_solution: None,
         }
+    }
+
+    /// Switch the final witness-refutation gate to
+    /// [`WitnessRule::DeclaredRowRelative`].
+    ///
+    /// **Only legitimate when the caller has already established that the solve
+    /// cannot run**, so the "never certify what the solver would accept"
+    /// counterfactual has nothing to compare against. Today that is the
+    /// too-few-degrees-of-freedom gate alone (gh#391). Calling this on a
+    /// wrapper that will be solved through reintroduces the #380 defect: a
+    /// small-magnitude model would report "proved infeasible" with presolve on
+    /// and `Solve_Succeeded` with it off.
+    pub fn probing_without_a_solve(mut self) -> Self {
+        self.witness_rule = WitnessRule::DeclaredRowRelative;
+        self
     }
 
     /// Build a presolve wrapper with an `ExpressionProvider` handle on
@@ -549,6 +642,7 @@ impl PresolveTnlp {
             inner,
             expr_provider: Some(expr_provider),
             opts,
+            witness_rule: WitnessRule::default(),
             state: None,
             finalized_full_solution: None,
         }
@@ -1262,6 +1356,12 @@ impl PresolveTnlp {
         // Placed here, once, rather than beside each detection: the two
         // previous safeguards were each added to one path and not its twin,
         // and a hole survived both times.
+        //
+        // Which accepting test decides "satisfies" is the call site's choice,
+        // not an option — see `WitnessRule`. Every wrapper that is solved
+        // through uses the solver's own acceptance; only a caller that has
+        // established the solve cannot run may raise it to the declared,
+        // scale-relative form.
         if certified_infeasible.is_some()
             && witness_refutes_infeasibility(
                 &self.inner,
@@ -1272,6 +1372,7 @@ impl PresolveTnlp {
                 &g_l_inner,
                 &g_u_inner,
                 self.opts.certify_tol,
+                self.witness_rule,
             )
         {
             tracing::warn!(
@@ -3649,5 +3750,229 @@ mod tests {
             .insert("two_globals".to_string(), vec![1.5, 2.5]);
         let reduced2 = project_con_metadata(&inner2, &rows_kept, m_in);
         assert_eq!(reduced2.numerics["two_globals"], vec![1.5, 2.5]);
+    }
+
+    /// gh#391 scratch. One variable in `[0, 1]`, `m` rows evaluated as
+    /// `coeff[i] * x + offset[i]` against per-row declared bounds — enough to
+    /// drive `witness_refutes_infeasibility` directly and compare the two
+    /// [`WitnessRule`] forms on the same numbers.
+    struct WitnessProbeRows {
+        coeff: Vec<Number>,
+        offset: Vec<Number>,
+        g_l: Vec<Number>,
+        g_u: Vec<Number>,
+        x0: Number,
+    }
+
+    impl TNLP for WitnessProbeRows {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 1,
+                m: self.coeff.len() as Index,
+                nnz_jac_g: self.coeff.len() as Index,
+                nnz_h_lag: 0,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l[0] = 0.0;
+            b.x_u[0] = 1.0;
+            b.g_l.copy_from_slice(&self.g_l);
+            b.g_u.copy_from_slice(&self.g_u);
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            if sp.init_x {
+                sp.x[0] = self.x0;
+            }
+            true
+        }
+        fn eval_f(&mut self, _x: &[Number], _new_x: bool) -> Option<Number> {
+            Some(0.0)
+        }
+        fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g[0] = 0.0;
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            for ((out, &c), &o) in g.iter_mut().zip(&self.coeff).zip(&self.offset) {
+                *out = c * x[0] + o;
+            }
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    for (i, r) in irow.iter_mut().enumerate() {
+                        *r = i as Index;
+                    }
+                    jcol.fill(0);
+                }
+                SparsityRequest::Values { values } => values.copy_from_slice(&self.coeff),
+            }
+            true
+        }
+        fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+            types.fill(Linearity::Linear);
+            true
+        }
+        fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+    }
+
+    fn refutes(model: WitnessProbeRows, rule: WitnessRule) -> bool {
+        let (g_l, g_u) = (model.g_l.clone(), model.g_u.clone());
+        let m = g_l.len();
+        let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(model));
+        witness_refutes_infeasibility(&inner, 1, m, &[0.0], &[1.0], &g_l, &g_u, 1e-8, rule)
+    }
+
+    /// The gh#391 mechanism in one assertion pair, on identical numbers.
+    ///
+    /// `s*x == 0.2*s` with `s*x == 0.8*s` over `x ∈ [0, 1]` is empty at every
+    /// `s > 0` — the crossing is `0.6` regardless. At `s = 1e-12` the clamped
+    /// accepting form reinstates the absolute floor (`tol * max(scale, 1)` =
+    /// `1e-8`), every point of the box "satisfies" both rows, and the witness
+    /// withdraws a scale-free proof. Measured against the row's declared
+    /// magnitude with no clamp, the same point violates by `0.6` relative and
+    /// refutes nothing.
+    #[test]
+    fn down_scaled_rows_only_defeat_the_clamped_witness_form() {
+        let model = |_s: Number| WitnessProbeRows {
+            coeff: vec![1e-12, 1e-12],
+            offset: vec![0.0, 0.0],
+            g_l: vec![0.2e-12, 0.8e-12],
+            g_u: vec![0.2e-12, 0.8e-12],
+            x0: 0.5,
+        };
+        assert!(
+            refutes(model(1e-12), WitnessRule::SolverAcceptance),
+            "the clamped form accepts every point of the box at this row scale \
+             — this is the behavior gh#391 is about, pinned so the contrast \
+             below stays meaningful"
+        );
+        assert!(
+            !refutes(model(1e-12), WitnessRule::DeclaredRowRelative),
+            "0.6 of the row's own declared magnitude is a violation at every \
+             scale; the strict rule must not withdraw the proof"
+        );
+    }
+
+    /// The same rows at unit scale: both forms agree, which is the point —
+    /// the strict rule changes nothing where the clamp was never active.
+    #[test]
+    fn unit_scale_rows_refute_under_neither_form() {
+        let model = || WitnessProbeRows {
+            coeff: vec![1.0, 1.0],
+            offset: vec![0.0, 0.0],
+            g_l: vec![0.2, 0.8],
+            g_u: vec![0.2, 0.8],
+            x0: 0.5,
+        };
+        assert!(!refutes(model(), WitnessRule::SolverAcceptance));
+        assert!(!refutes(model(), WitnessRule::DeclaredRowRelative));
+    }
+
+    /// The hazard the strict rule has to handle explicitly: a *homogeneous* row
+    /// (`g_l = g_u = 0`) has no declared magnitude, so a pure relative test
+    /// would be unsatisfiable by construction — the violation *is* the scale,
+    /// and any float-noise residual reads as a full-magnitude violation. Such a
+    /// row keeps the absolute floor, so a genuinely feasible point still
+    /// refutes and the proof is still withheld. Fail closed.
+    #[test]
+    fn homogeneous_row_keeps_the_absolute_floor_under_the_strict_rule() {
+        // `x - 0.5 == 0` evaluated at the modeller's `x0 = 0.5`, off by an ulp
+        // of noise. Feasible; the witness must say so under both rules.
+        let noisy = || WitnessProbeRows {
+            coeff: vec![1.0],
+            offset: vec![-0.5 + 1e-16],
+            g_l: vec![0.0],
+            g_u: vec![0.0],
+            x0: 0.5,
+        };
+        assert!(refutes(noisy(), WitnessRule::SolverAcceptance));
+        assert!(
+            refutes(noisy(), WitnessRule::DeclaredRowRelative),
+            "a homogeneous row has nothing to be relative to; float noise on it \
+             must not be promoted to a violation"
+        );
+
+        // A real violation on a homogeneous row still refutes nothing: the
+        // fallback is the absolute floor, not blanket acceptance.
+        let violated = || WitnessProbeRows {
+            coeff: vec![1.0],
+            offset: vec![0.6],
+            g_l: vec![0.0],
+            g_u: vec![0.0],
+            x0: 0.5,
+        };
+        assert!(!refutes(violated(), WitnessRule::SolverAcceptance));
+        assert!(!refutes(violated(), WitnessRule::DeclaredRowRelative));
+    }
+
+    /// The strict rule is relative, not absolute: on a row declared near `1e30`
+    /// a residual of `1e5` is fifteen relative digits of agreement and still
+    /// refutes. This is the extreme-coefficient class the witness gate exists
+    /// for, and it must survive the rule change.
+    #[test]
+    fn strict_rule_still_refutes_at_extreme_row_magnitude() {
+        let model = || WitnessProbeRows {
+            coeff: vec![2e30],
+            offset: vec![1e5],
+            g_l: vec![1e30],
+            g_u: vec![1e30],
+            x0: 0.5,
+        };
+        assert!(refutes(model(), WitnessRule::SolverAcceptance));
+        assert!(refutes(model(), WitnessRule::DeclaredRowRelative));
+    }
+
+    /// End-to-end through the wrapper: the rule is a property of the call site,
+    /// so a default wrapper (one that would be solved through) keeps the #380
+    /// behavior at sub-tolerance row scale, and only a caller that has
+    /// established the solve cannot run gets the proof.
+    #[test]
+    fn probing_without_a_solve_certifies_where_the_default_wrapper_withholds() {
+        let opts = PresolveOptions {
+            enabled: true,
+            bound_tightening: true,
+            auxiliary: false,
+            ..PresolveOptions::defaults()
+        };
+        let model = || WitnessProbeRows {
+            coeff: vec![1e-12, 1e-12],
+            offset: vec![0.0, 0.0],
+            g_l: vec![0.2e-12, 0.8e-12],
+            g_u: vec![0.2e-12, 0.8e-12],
+            x0: 0.5,
+        };
+
+        let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(model()));
+        let mut solved_through = PresolveTnlp::new(inner, opts);
+        solved_through.get_nlp_info().expect("init ok");
+        assert!(
+            solved_through.tighten_report().infeasible,
+            "bound propagation sees the contradiction at every scale"
+        );
+        assert_eq!(
+            solved_through.certified_infeasible(),
+            None,
+            "#380: a wrapper that will be solved through must not claim a proof \
+             the solver's own acceptance test would contradict"
+        );
+
+        let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(model()));
+        let mut probe = PresolveTnlp::new(inner, opts).probing_without_a_solve();
+        probe.get_nlp_info().expect("init ok");
+        assert_eq!(
+            probe.certified_infeasible(),
+            Some(InfeasibilityProof::BoundPropagation),
+            "gh#391: with no solve to contradict, the scale-free crossing is a \
+             proof at every row scale"
+        );
     }
 }

--- a/docs/src/solution-output.md
+++ b/docs/src/solution-output.md
@@ -66,6 +66,27 @@ it is off by default. A presolve-derived infeasibility is only reported when the
 contradiction holds on the *original* box — one produced by presolve's own
 auxiliary elimination is re-checked after rollback and never certified.
 
+### One more route to `200`: over-determined systems
+
+An **over-determined** model — more equality rows than free variables, such as
+`x == 0.2` with `x == 0.8` — cannot be solved at all: it fails a structural gate
+before the first iteration. That used to be reported as
+`Not_Enough_Degrees_Of_Freedom` (`504`, the failure band), which says "cannot
+attempt this" for a model whose answer is already decided.
+
+POUNCE now checks such a model for a bound-propagation contradiction on that
+failure path and reports `200` when it finds one. This does not need
+`presolve=yes` — nothing is transformed and no solve runs through the check — so
+it is the one way to reach the infeasible band with the default options and no
+iterations. A *consistent* over-determined system is unaffected and still
+reports `504`.
+
+Because the solve provably cannot run here, this route measures constraint
+residuals against each row's declared magnitude rather than an absolute
+tolerance, so the verdict does not change when every row is multiplied by a
+constant. Elsewhere — wherever a solve *can* run — an infeasibility smaller than
+the feasibility tolerance is still withheld, as described above.
+
 ## Choosing an output format
 
 | You want… | Use |

--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -126,12 +126,14 @@ BASELINE_WRONG = {
     "inf_372": 0,
     "inf_clear": 0,
     "inf_two": 0,
-    # gh#387: the DOF gate now consults bound-propagation certification, so
-    # the contradiction is proved at every scale the certification is willing
-    # to speak to. The 3 remaining cells are k in {-12, -10, -8}, where every
-    # point in the box satisfies both rows within the solver's own acceptance
-    # tolerance and the fail-closed witness rule withholds the proof.
-    "inf_eq": 3,
+    # gh#387 took this 13 -> 3 by having the DOF gate consult bound-propagation
+    # certification; gh#391 took the last 3 (k in {-12, -10, -8}) to 0. Those
+    # cells were the witness gate's absolute floor: below a row magnitude of 1,
+    # `tol * max(scale, 1)` stops moving with the row, every point of the box
+    # "satisfies" both rows, and a crossing that is 0.6 at every scale lost its
+    # proof. On the DOF path the solve cannot run, so the witness measures
+    # against the row's declared magnitude instead.
+    "inf_eq": 0,
 }
 
 


### PR DESCRIPTION
Fixes #391

## Problem

`inf_eq` in `pyomo-pounce/tests/test_scale_invariance.py` — `x == 0.2` with
`x == 0.8` over `x ∈ [0, 1]`, every row multiplied by `s = 10^k` — reported two
different verdicts for the same empty feasible set:

| `k` | verdict | band |
|---|---|---|
| `-12, -10, -8` | `Not_Enough_Degrees_Of_Freedom` | `504` (FAIL) |
| `-6 … 12` | `Infeasible_Problem_Detected` | `200` (INFEAS) |

Multiplying a row by a positive constant leaves the feasible set exactly
unchanged, so the `504` cells are the same problem answered a second way. The
`504` band surfaces through Pyomo as an internal solver error, indistinguishable
from a solver bug.

After this PR, all 13 scalings report `200`. Swept through the CLI on the exact
harness model (`solver_selection=nlp`, `print_level=0`), `k ∈ [-12, 12]` step 2:

```
k=-12 … k=12   objno 200   INFEAS      wrong: 0 / 13
```

## Cause

**Not the proof — the refutation.** Bound propagation is already scale-free
here: `s*x == 0.2*s` and `s*x == 0.8*s` propagate to `x ∈ [0.2, 0.2]` and
`x ∈ [0.8, 0.8]`, a crossing of `0.6` at every `s`. `crossing_is_certifiable`
accepts it at every `s`.

What moved was `witness_refutes_infeasibility`, the gate that can *withdraw* the
verdict. It accepts a row when the residual is negligible through the **clamped**
accepting form `tol * max(scale, 1)` — and that clamp reinstates an absolute
floor as soon as the row's magnitude drops below 1. At `s <= ~3e-8` the best
violation over the whole box (`0.3*s`) falls under `certify_tol * 1 = 1e-8`, so
every point of `[0, 1]` "satisfies" both rows, a witness is found, and the
scale-free proof is thrown away.

## Fix

The clamp exists to honor #380: never certify what the solver itself would
accept as feasible, or the same model reports "proved infeasible" with presolve
on and `Solve_Succeeded` with it off. **On the DOF-gate path that counterfactual
never materializes** — the gate fired *because* the solve cannot run (1 variable,
2 equality rows), so the alternative to the proof is the structural `504`, not a
solution. There is no second route to contradict, which is what makes dropping
the clamp sound there and only there.

New `pounce_presolve::WitnessRule`:

* `SolverAcceptance` (default) — today's clamped form, live row magnitude. Every
  wrapper that is actually solved through keeps this. Unchanged behavior.
* `DeclaredRowRelative` — residual against the row's **declared** magnitude,
  `max(|g_l|, |g_u|)` over its *finite* bounds, no clamp.

The rule is a property of the call site (`PresolveTnlp::probing_without_a_solve`),
deliberately **not** a `PresolveOptions` field — no user should be able to switch
a live solve onto it. `Application::overdetermined_model_certified_infeasible`
is the sole caller.

### On the `b = 0` hazard #391 said had to be resolved first

A homogeneous row has no declared magnitude, which makes a pure relative test
unsatisfiable by construction — the violation *is* the scale, so `viol/scale = 1`
for any float noise, and a genuinely feasible point would fail to refute. Those
rows keep the absolute floor. Fail-closed: accepting the point withdraws the
verdict, so the fallback direction costs a missed certification, never a wrong
one.

### On the #390 dependency #391 anticipated

#391 said option 2 "should not be attempted piecemeal; it interacts with the
declared row-magnitude plumbing tracked in #390." That plumbing turns out not to
be needed here. #390 is about the *runtime* measure, where the fold into
`c(x) = 0` erases the RHS magnitude. Presolve sits above that fold — `g_l`/`g_u`
in the wrapper still *are* the declared row bounds — so the witness gets a
principled per-row declared magnitude directly, the same "declared, not live"
pattern `fbbt_infeasibility_survives_margin` already uses for its row margin.
**#390 is unaffected and still open** for the runtime measure it is actually
about.

### Rejected: option 1 (keep the 3 cells)

#391's status-quo option rested on the clamp being "the single guard that keeps
interval over-approximation at extreme coefficient scale from certifying a
feasible model as proved-infeasible." Working through that class, the clamp is
not what does the work: at the `1e30` magnitudes where over-approximation bites,
`max(scale, 1) == scale` and the two forms are **identical**. The clamp only
differs below magnitude 1, where cancellation error is proportionally tiny and
`crossing_is_certifiable` catches the artifact first. That is pinned by
`strict_rule_still_refutes_at_extreme_row_magnitude`.

## Blast radius

**Bit-identical except the targeted case.** The new rule is reachable only from
the DOF gate, which fires only when `n_x_var < n_c`. Every other presolve
consumer constructs `PresolveTnlp` without `probing_without_a_solve()` and gets
`WitnessRule::default() == SolverAcceptance`.

The other six models in the scale-invariance harness are untouched by
construction — none is over-determined (`feas_eq` is 2 vars / 1 equality; the
`inf_*` models are inequality-only), so the DOF gate never fires for them.

`BASELINE_WRONG["inf_eq"]` ratchets **3 → 0**; no other baseline moves.

Full workspace suite: 158 test binaries, 0 failures. (`pounce-hsl`'s MA57 test
cannot link without `COINHSL_DIR`, pre-existing and unrelated to this diff.)

## Tests

**Verified failing on the parent commit** (`eb5ff09`) by copying the new test
file into a worktree at that commit:

```
failures:
    sub_tolerance_scales_are_certified_too
    verdict_is_scale_invariant_where_certifiable

  left: NotEnoughDegreesOfFreedom
```

Both fail for the stated reason — the `504` verdict, not a compile or harness
error.

* `sub_tolerance_scales_keep_the_dof_error` → **deliberately flipped** to
  `sub_tolerance_scales_are_certified_too`, as #391 instructed. Its old premise
  ("claiming proved-infeasible would contradict what the solver would report")
  does not hold on a path where the solver cannot report anything.
* `verdict_is_scale_invariant_where_certifiable` extends from
  `k ∈ [-6, 12]` to the full `k ∈ [-12, 12]`; the CLI-level twin likewise.
* `sub_tolerance_consistent_system_still_reports_dof_error` — **new**, guards the
  flip from cutting too deep: a *consistent* over-determined system at the same
  `s = 1e-12` must still get `504`. This one passes on the parent too, by design
  — it pins what must *not* change.
* `down_scaled_rows_only_defeat_the_clamped_witness_form` — the mechanism on
  identical numbers under both rules, so the contrast cannot rot.
* `homogeneous_row_keeps_the_absolute_floor_under_the_strict_rule` — the `b = 0`
  fallback in **both** directions: float noise still refutes, a real violation
  still does not (the fallback is the absolute floor, not blanket acceptance).
* `strict_rule_still_refutes_at_extreme_row_magnitude` — the `1e30` class the
  gate exists for.
* `probing_without_a_solve_certifies_where_the_default_wrapper_withholds` —
  end-to-end: a default wrapper withholds at `s = 1e-12` (#380 preserved), a
  probe certifies (#391 fixed).

Not pinned, deliberately: the pyomo harness itself did not run here — `pyomo` is
not installed in this environment — so the `3 → 0` ratchet was verified by
reproducing the harness's `_solve` path through the CLI on the same model and
options rather than by running the pytest. CI runs the real harness.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`solution-output.md`; already in `SUMMARY.md`)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01F5ES1AxQWXkGSaJ6RUEuGz)_