### PR TITLE
Give equality rows a scale-relative runtime feasibility measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,54 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — equality rows had no scale-relative runtime feasibility measure (#390)
+
+- **A nonlinear equality contradiction is no longer accepted as solved once its
+  rows are written small enough.** `x*y == 1` with `x + y == 0.5` has no real
+  solution (the roots would need discriminant `0.25 - 4 < 0`), and refuting it
+  needs the discriminant, not intervals — so neither the DOF gate's linear
+  bound propagation (#389) nor FBBT can reach it, and the verdict comes from
+  the runtime feasibility test. Multiplying both rows by `1e-6` used to flip
+  that verdict from `Infeasible_Problem_Detected` to `Solve_Succeeded`. Same
+  empty solution set, opposite answers.
+- **Cause:** POUNCE folds an equality's right-hand side into `c(x) = 0`, so
+  `|c_i|` *is* the violation and carries no independent magnitude. The
+  scale-relative measure added for inequality rows in #386
+  (`curr_relative_primal_infeasibility_max`) therefore skipped the `c` block
+  entirely, and every runtime feasibility decision on an equality row was
+  against an absolute tolerance — which down-scaling walks straight under.
+- **Fix:** the pre-fold RHS is plumbed back out as
+  `IpoptNlp::declared_c_rhs`, the same "declared, not live" pattern
+  `declared_d_bounds` established for inequality rows, and reported in the
+  same internally-scaled space as `eval_c` so the solver's own row scaling
+  cancels. The measure now covers the `c` block with `|c_i| / |b_i|`, which is
+  identical at every writing of the row. Both consumers pick it up unchanged:
+  the certificate/acceptable-point veto and the rapid-infeasibility
+  pre-filter.
+- **A homogeneous row (`b_i = 0`) keeps the absolute test and contributes
+  nothing** — it has no declared magnitude, and needs none, since `s·g(x) == 0`
+  is the same row at every `s`. Dividing by a fabricated floor there would turn
+  float-noise residuals into 100% "violations" on the most common equality row
+  there is. An NLP that does not track the RHS (the trait default — e.g. the
+  restoration NLP, whose `c` block is not the user's rows) abstains wholesale
+  rather than invent a magnitude.
+- Covered by a new `inf_eq_nl` model in
+  `pyomo-pounce/tests/test_scale_invariance.py`: 5 wrong cells out of 13 row
+  scalings before (`SOLVED` at `k in {-10, -8, -6}`, no verdict at
+  `k in {-12, -4}`), 0 after. No other model in the harness moved, and a
+  differential sweep over the repository's `.nl` fixtures shows no verdict
+  changes. `crates/pounce-algorithm/tests/issue_390_nonlinear_equality_scale.rs`
+  pins the same property on the direct driver, in both directions.
+- Trade-off worth knowing: refusing a certificate keeps the run going, so on a
+  *nonconvex* model the continued trajectory can land in a different basin than
+  the premature stop did. The measured instance — the same product/sum pair
+  started at `(1, 1)`, where the feasible twin already converges to a
+  locally-infeasible point at unit scale — traded a `Solve_Succeeded` at row
+  scale `1e-8` for a local-infeasibility verdict. What was given up there was
+  not, in general, a solution: at `1e-12` the same "success" returned
+  `x = y = 2.3e-14`, which satisfies neither `x*y == 1` nor `x + y == 2.5`.
+- This closes out #387; #389 handled the linear half at the DOF gate.
+
 ### Fixed — provably infeasible over-determined systems reported a DOF failure (#387)
 
 - **A contradictory over-determined equality system now reports
@@ -38,11 +86,10 @@ changes.
     / `get_constraints_linearity` (trait default `false`), so anything stacked
     above them — including this probe — saw every row as nonlinear and silently
     lost linear-row bound propagation.
-  - What remains of #387: equality rows still have no scale-relative *runtime*
-    feasibility measure (`curr_relative_primal_infeasibility_max` skips the `c`
-    block because the fold into `c(x) = 0` erases the RHS magnitude), so a
-    genuinely *nonlinear* equality contradiction — out of bound propagation's
-    reach — still depends on absolute tolerances.
+  - What remained of #387 — equality rows having no scale-relative *runtime*
+    feasibility measure, so a genuinely *nonlinear* equality contradiction (out
+    of bound propagation's reach) still depended on absolute tolerances — was
+    split out as #390 and is fixed above.
 
 ### Added — presolve can now certify infeasibility instead of discarding the proof
 

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -452,13 +452,15 @@ impl ConvCheck for OptErrorConvCheck {
         let obj_scale = cq_ref.computed_obj_scaling_factor();
         drop(cq_ref);
 
-        // Scale-relative feasibility veto (#385, Step 6). The absolute
+        // Scale-relative feasibility veto (#385 Step 6; extended to equality
+        // rows by #390, which plumbs the pre-fold RHS back so `|c_i|` has a
+        // declared magnitude to be relative to). The absolute
         // `constr_viol_tol` gate cannot tell "satisfied" from "violated by 14%
         // of everything the row is" once the row's numbers are small: `x >= 0.7`
         // written as `1e-12·x >= 0.7e-12` has an absolute violation of `1e-13`
         // at `x = 0.6` — under every absolute tolerance, while the same empty
         // feasible set written at unit scale is reported infeasible. Refuse a
-        // certificate whose point still has an inequality row violated by more
+        // certificate whose point still has a constraint row violated by more
         // than `relative_viol_threshold` of its own magnitude, and let the run
         // continue: for a genuinely infeasible model the rapid-infeasibility
         // detection below then reaches the honest verdict (its violation floor
@@ -530,7 +532,7 @@ impl ConvCheck for OptErrorConvCheck {
                         rel_viol,
                         constr_viol,
                         threshold = self.relative_viol_threshold(),
-                        "refusing a success certificate: an inequality row is still \
+                        "refusing a success certificate: a constraint row is still \
                          violated by more than the scale-relative threshold of its own \
                          magnitude; continuing (bounded by the veto budget)"
                     );
@@ -705,7 +707,7 @@ impl ConvCheck for OptErrorConvCheck {
         // unlike the masked-scale (#200) veto above it. That veto refuses a
         // possibly-premature stop at a point that is still genuinely feasible,
         // so the stash stays a legitimate rollback target. Here the point has
-        // an inequality row violated by more than the relative threshold of
+        // a constraint row violated by more than the relative threshold of
         // its own magnitude — it is not acceptable in any honest sense, and a
         // stall later in the run must not roll back to it and surface
         // `Solved_To_Acceptable_Level` on an infeasible model (measured: an

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -844,8 +844,79 @@ impl IpoptCalculatedQuantities {
         c_max.max(dms_max)
     }
 
-    /// Largest primal infeasibility of an inequality row **relative to that
-    /// row's own magnitude**: `max_i |d_i − s_i| / max(|d_i|, |d_l_i|, |d_u_i|)`.
+    /// Largest primal infeasibility of a constraint row **relative to that
+    /// row's own magnitude** — `|c_i| / |b_i|` over the equality block and
+    /// `dist(d_i, [d_l_i, d_u_i]) / max(|d_l_i|, |d_u_i|)` over the
+    /// inequality block, whichever is worse.
+    ///
+    /// See [`Self::relative_d_infeasibility_max`] and
+    /// [`Self::relative_c_infeasibility_max`] for the two blocks; both use
+    /// the row's **declared** magnitude, never a live or relaxed stand-in,
+    /// and both abstain (contribute nothing) on a row that has no declared
+    /// magnitude to be relative to.
+    pub fn curr_relative_primal_infeasibility_max(&self) -> Number {
+        self.relative_d_infeasibility_max()
+            .max(self.relative_c_infeasibility_max())
+    }
+
+    /// The equality-block half of
+    /// [`Self::curr_relative_primal_infeasibility_max`]: `max_i |c_i| / |b_i|`,
+    /// where `b_i` is the row's declared right-hand side
+    /// ([`IpoptNlp::declared_c_rhs`]).
+    ///
+    /// POUNCE folds `g_i(x) == b_i` into `c_i(x) = 0`, so `|c_i|` *is* the
+    /// violation and by itself carries no magnitude to be judged against —
+    /// which is why every runtime feasibility decision on an equality row was
+    /// an absolute one, and why down-scaling such a row shrank `|c_i|` under
+    /// the absolute tolerance and flipped a true infeasibility verdict to
+    /// `Solve_Succeeded` (gh #390, residual of #387). Dividing by the pre-fold
+    /// RHS restores it: `s·g(x) == s·b` has residual `s·(g(x) − b)` and RHS
+    /// `s·b`, so the ratio is the same at every `s` — the point.
+    ///
+    /// Both numerator and denominator are taken in the internally-scaled
+    /// space, so the solver's own row scaling `dc_i` cancels too.
+    ///
+    /// A **homogeneous** row (`b_i = 0`) contributes nothing. It has no
+    /// declared magnitude to be relative to, and needs none: `s·g(x) == 0` is
+    /// the same row at every `s`, so the absolute test is already invariant
+    /// there. Dividing by zero — or by a fabricated floor — would turn
+    /// float-noise residuals into 100% "violations" on the single most common
+    /// equality row there is. Non-finite entries likewise contribute nothing:
+    /// an unjudgeable row must not fabricate a relative verdict. When the NLP
+    /// does not track the RHS at all (`declared_c_rhs` is `None` — e.g. the
+    /// restoration NLP, whose `c` block is not the user's rows), the whole
+    /// block abstains.
+    pub fn relative_c_infeasibility_max(&self) -> Number {
+        let c = self.curr_c();
+        if c.dim() == 0 {
+            return 0.0;
+        }
+        let Some(rhs) = self.nlp.borrow().declared_c_rhs() else {
+            return 0.0;
+        };
+        let Some(c) = c.as_any().downcast_ref::<DenseVector>() else {
+            return 0.0;
+        };
+        if !c.is_initialized() {
+            return 0.0;
+        }
+        let cv = c.expanded_values();
+        if cv.len() != rhs.len() {
+            return 0.0;
+        }
+        let mut worst = 0.0_f64;
+        for (&ci, &bi) in cv.iter().zip(rhs.iter()) {
+            let mag = bi.abs();
+            if mag > 0.0 && mag.is_finite() && ci.is_finite() {
+                worst = worst.max(ci.abs() / mag);
+            }
+        }
+        worst
+    }
+
+    /// The inequality-block half of
+    /// [`Self::curr_relative_primal_infeasibility_max`]:
+    /// `max_i |d_i − s_i| / max(|d_i|, |d_l_i|, |d_u_i|)`.
     ///
     /// This is the scale-free companion to
     /// [`Self::curr_unscaled_primal_infeasibility_max`]. An absolute violation
@@ -870,10 +941,10 @@ impl IpoptCalculatedQuantities {
     /// first place: `s·g >= 0` is the same row at every `s`, so the absolute
     /// test is already invariant there. Rows whose bounds are all zero or
     /// non-finite therefore contribute nothing (the relative measure
-    /// abstains), as do equality rows — their right-hand side is folded into
-    /// `c(x) = 0`, so `|c_i|` *is* the violation and carries no independent
-    /// magnitude. Non-finite entries contribute nothing — an unjudgeable row
-    /// must not fabricate a relative verdict.
+    /// abstains). Equality rows are judged by
+    /// [`Self::relative_c_infeasibility_max`], which plumbs the pre-fold RHS
+    /// back to supply the magnitude the fold into `c(x) = 0` erased.
+    ///
     /// The violation judged is the **distance of `d(x)` outside the declared
     /// box** — NOT the lifted residual `|d − s|` the absolute measure uses.
     /// `|d − s|` only bounds the true violation from above: mid-solve the
@@ -884,7 +955,7 @@ impl IpoptCalculatedQuantities {
     /// confirmation is vacuous (the violation is already ~0, so no materially
     /// less-violating point exists) — and 18 feasible CUTEr QPs were reported
     /// locally infeasible. Measured, not hypothetical.
-    pub fn curr_relative_primal_infeasibility_max(&self) -> Number {
+    pub fn relative_d_infeasibility_max(&self) -> Number {
         let dms = self.curr_d_minus_s();
         if dms.dim() == 0 {
             return 0.0;
@@ -2049,9 +2120,17 @@ mod tests {
         // Jacobian to exercise the finiteness guard in `curr_nlp_error`.
         nan_grad: bool,
         nan_jac_c: bool,
+        // gh#390: the declared equality RHS the c-block relative measure
+        // divides by. `None` (the default) is the "not tracked" contract.
+        c_rhs: Option<Vec<Number>>,
     }
 
     impl MockNlp {
+        fn with_c_rhs(mut self, rhs: Option<Vec<Number>>) -> Self {
+            self.c_rhs = rhs;
+            self
+        }
+
         fn with_nan_grad(mut self) -> Self {
             self.nan_grad = true;
             self
@@ -2102,6 +2181,7 @@ mod tests {
                 d_scale: None,
                 nan_grad: false,
                 nan_jac_c: false,
+                c_rhs: None,
             }
         }
     }
@@ -2203,6 +2283,9 @@ mod tests {
         }
         fn d_scale_vec(&self) -> Option<Vec<Number>> {
             self.d_scale.clone()
+        }
+        fn declared_c_rhs(&self) -> Option<Vec<Number>> {
+            self.c_rhs.clone()
         }
     }
 
@@ -2353,6 +2436,54 @@ mod tests {
         // theta = 4 + 2 = 6.
         let cq = fixture();
         assert!((cq.curr_constraint_violation() - 6.0).abs() < 1e-13);
+    }
+
+    /// gh#390. The fixture's equality row is `x0 + x1 == 1` at `x = (2, 3)`,
+    /// so `c = 4`. Judged against a declared RHS of 2 that is a 200% violation
+    /// — and it is 200% however the row is written, which is the point.
+    #[test]
+    fn relative_c_infeasibility_is_residual_over_declared_rhs() {
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![2.0])));
+        assert_eq!(cq.relative_c_infeasibility_max(), 2.0);
+        // The fixture's inequality row (`d = 2` against `d >= 1`) is satisfied,
+        // so the combined measure is the equality block's verdict.
+        assert_eq!(cq.relative_d_infeasibility_max(), 0.0);
+        assert_eq!(cq.curr_relative_primal_infeasibility_max(), 2.0);
+    }
+
+    /// An NLP that does not track the pre-fold RHS (the trait default, e.g.
+    /// the restoration NLP) must abstain rather than invent a magnitude.
+    #[test]
+    fn relative_c_infeasibility_abstains_without_declared_rhs() {
+        let cq = fixture();
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+        assert_eq!(cq.curr_relative_primal_infeasibility_max(), 0.0);
+    }
+
+    /// A homogeneous row (`g(x) == 0`) has no declared magnitude and needs
+    /// none — `s·g(x) == 0` is the same row at every `s`. Dividing by its zero
+    /// RHS would report every float-noise residual as an infinite violation.
+    #[test]
+    fn relative_c_infeasibility_abstains_on_homogeneous_row() {
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![0.0])));
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+    }
+
+    /// An unjudgeable row must not fabricate a relative verdict.
+    #[test]
+    fn relative_c_infeasibility_abstains_on_non_finite_rhs() {
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![Number::INFINITY])));
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![Number::NAN])));
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+    }
+
+    /// A row-count mismatch means the RHS does not describe this `c` block;
+    /// pairing them up anyway would judge rows against other rows' magnitudes.
+    #[test]
+    fn relative_c_infeasibility_abstains_on_length_mismatch() {
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![2.0, 2.0])));
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
     }
 
     #[test]

--- a/crates/pounce-algorithm/tests/issue_390_nonlinear_equality_scale.rs
+++ b/crates/pounce-algorithm/tests/issue_390_nonlinear_equality_scale.rs
@@ -1,0 +1,243 @@
+//! gh #390 — the verdict on a *nonlinear* equality contradiction must not
+//! depend on how large the rows are written.
+//!
+//! `x*y == 1` with `x + y == 0.5` asks for two reals whose sum is `0.5` and
+//! whose product is `1` — the roots of `t² - 0.5t + 1`, discriminant
+//! `0.25 - 4 < 0`. There are none. Refuting it needs the discriminant, not
+//! intervals: each row is individually satisfiable over the box and interval
+//! propagation narrows neither variable, so neither the DOF gate's linear
+//! bound-propagation probe (#389) nor FBBT can prove it. The verdict has to
+//! come from the runtime feasibility test.
+//!
+//! That test was absolute on equality rows. POUNCE folds the right-hand side
+//! into `c(x) = 0`, so `|c_i|` *is* the violation and carries no independent
+//! magnitude — the scale-relative measure added for inequality rows in #386
+//! skipped the `c` block entirely. Scaling both rows by `1e-8` shrank the
+//! residuals under `constr_viol_tol` and the solve stopped at
+//! `x = y ≈ 2e-14` — a point that satisfies neither row — and called it
+//! `Solve_Succeeded`.
+//!
+//! Both directions are covered on purpose. A relative measure is *stricter*
+//! than an absolute one on small rows, so a fix aimed only at the missed
+//! infeasibility could quietly start refusing genuine solutions;
+//! [`feasible_twin_solves_at_every_scale`] is that guard.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Row scalings swept by every test here. Multiplying both rows by `s > 0`
+/// leaves the solution set exactly unchanged, so the verdict must not move.
+const SCALES: [i32; 10] = [-12, -10, -8, -6, -4, -2, 0, 2, 4, 6];
+
+/// `min x² + y²  s.t.  s·x·y == s·1,  s·(x + y) == s·sum,  x, y in [-10, 10]`.
+///
+/// `sum = 0.5` is contradictory (discriminant `< 0`); `sum = 2.5` is solvable
+/// (`{x, y} = {2, 0.5}`).
+struct ProductAndSum {
+    scale: Number,
+    sum: Number,
+    start: [Number; 2],
+}
+
+impl ProductAndSum {
+    /// The contradictory model, started at `(1, 1)`. That start satisfies the
+    /// product row exactly and misses the sum row, which is what drove the
+    /// pre-fix run to stop at a sub-tolerance non-solution and report success
+    /// at the small-scale end.
+    fn contradictory(scale: Number) -> Self {
+        Self {
+            scale,
+            sum: 0.5,
+            start: [1.0, 1.0],
+        }
+    }
+
+    /// The feasible twin, started at `(0.5, -0.5)` — a start from which this
+    /// nonconvex model converges to its genuine solution at every scale in
+    /// [`SCALES`]. (From `(1, 1)` the *feasible* twin lands in a
+    /// locally-infeasible basin at several scales both before and after this
+    /// change, so it says nothing about the fix and is not used here.)
+    fn feasible(scale: Number) -> Self {
+        Self {
+            scale,
+            sum: 2.5,
+            start: [0.5, -0.5],
+        }
+    }
+}
+
+impl TNLP for ProductAndSum {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 2,
+            nnz_jac_g: 4,
+            nnz_h_lag: 3,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-10.0, -10.0]);
+        b.x_u.copy_from_slice(&[10.0, 10.0]);
+        // Equalities: g_l == g_u. Both right-hand sides are non-zero, so both
+        // rows have a declared magnitude the relative measure can divide by (a
+        // homogeneous row has none and keeps the absolute test).
+        b.g_l.copy_from_slice(&[self.scale, self.scale * self.sum]);
+        b.g_u.copy_from_slice(&[self.scale, self.scale * self.sum]);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&self.start);
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        // Honest classification: the product row is nonlinear, the sum row is
+        // linear. Bound propagation gets to see the linear row and still
+        // cannot prove anything — the contradiction is in the coupling.
+        types.copy_from_slice(&[Linearity::NonLinear, Linearity::Linear]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[0] + x[1] * x[1])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, grad: &mut [Number]) -> bool {
+        grad[0] = 2.0 * x[0];
+        grad[1] = 2.0 * x[1];
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = self.scale * x[0] * x[1];
+        g[1] = self.scale * (x[0] + x[1]);
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 1, 1]);
+                jcol.copy_from_slice(&[0, 1, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("jacobian values need x");
+                values[0] = self.scale * x[1];
+                values[1] = self.scale * x[0];
+                values[2] = self.scale;
+                values[3] = self.scale;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                // Lower triangle: (0,0), (1,0), (1,1).
+                irow.copy_from_slice(&[0, 1, 1]);
+                jcol.copy_from_slice(&[0, 0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                let l0 = lambda.map(|l| l[0]).unwrap_or(0.0);
+                values[0] = 2.0 * obj_factor;
+                // ∂²(s·x·y)/∂x∂y = s; the sum row contributes nothing.
+                values[1] = l0 * self.scale;
+                values[2] = 2.0 * obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+/// All-default options — in particular `presolve` stays at its default "no",
+/// the configuration the issue was filed against.
+fn solve(problem: ProductAndSum) -> ApplicationReturnStatus {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(problem));
+    app.optimize_tnlp(tnlp)
+}
+
+fn is_success(status: ApplicationReturnStatus) -> bool {
+    matches!(
+        status,
+        ApplicationReturnStatus::SolveSucceeded | ApplicationReturnStatus::SolvedToAcceptableLevel
+    )
+}
+
+/// The defect, stated as the property it violated: a model with no solution
+/// must never be reported as solved, at any row scale. Before the fix this
+/// failed at `1e-12`, `1e-10` and `1e-8` (`Solve_Succeeded`) and at `1e-6`
+/// (`Solved_To_Acceptable_Level`).
+#[test]
+fn contradictory_equalities_are_never_reported_solved() {
+    for k in SCALES {
+        let status = solve(ProductAndSum::contradictory(10.0_f64.powi(k)));
+        assert!(
+            !is_success(status),
+            "row scale 1e{k}: `x*y == 1, x + y == 0.5` has no real solution, \
+             yet the solve reported {status:?}"
+        );
+    }
+}
+
+/// And at the small-scale end it now reaches the *positive* verdict, not just
+/// a non-answer: the relative measure keeps the violation visible, so rapid
+/// infeasibility detection can do its job where the absolute tolerance had
+/// erased the evidence. (At `1e-4` and above this driver path exits
+/// `Restoration_Failed` — a pre-existing non-verdict, unchanged by this fix,
+/// which is why the sweep above asserts the invariant rather than a status.)
+#[test]
+fn contradictory_equalities_are_diagnosed_at_small_row_scales() {
+    for k in [-12, -10, -8, -6] {
+        assert_eq!(
+            solve(ProductAndSum::contradictory(10.0_f64.powi(k))),
+            ApplicationReturnStatus::InfeasibleProblemDetected,
+            "row scale 1e{k}"
+        );
+    }
+}
+
+/// The accepting direction. A relative measure is *stricter* than an absolute
+/// one on small rows, so it must not start refusing certificates on a model
+/// that genuinely has a solution.
+#[test]
+fn feasible_twin_solves_at_every_scale() {
+    for k in SCALES {
+        let status = solve(ProductAndSum::feasible(10.0_f64.powi(k)));
+        assert!(
+            is_success(status),
+            "row scale 1e{k}: `x*y == 1, x + y == 2.5` has the solution \
+             (2, 0.5); got {status:?}"
+        );
+    }
+}

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -109,6 +109,25 @@ pub trait IpoptNlp: Nlp {
         None
     }
 
+    /// The *declared* equality right-hand sides `b` — the pre-fold constants
+    /// subtracted to turn `g_i(x) == b_i` into the algorithm's residual
+    /// `c_i(x) = 0` — reported in the same (internally scaled) space as
+    /// [`Nlp::eval_c`]'s output, so `|c_i| / |b_i|` is a pure ratio.
+    ///
+    /// The fold is exactly what erases the row's magnitude: `|c_i|` *is* the
+    /// violation and carries no independent scale, so a scale-relative
+    /// feasibility measure has nothing to divide by unless the RHS is plumbed
+    /// back. Same "declared, not live" contract as [`Self::declared_d_bounds`]:
+    /// the value is the one the user wrote (times any row scaling the solver
+    /// itself applied), never a relaxed or otherwise adjusted stand-in.
+    ///
+    /// `None` (the default) means "not tracked" — callers must then abstain
+    /// from any relative verdict on the `c` block rather than substitute a
+    /// magnitude of their own.
+    fn declared_c_rhs(&self) -> Option<Vec<Number>> {
+        None
+    }
+
     /// Bound expansion matrices: `Px_L` extracts the
     /// `x` components that have a finite lower bound, etc.
     fn px_l(&self) -> Rc<dyn Matrix>;

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -1901,6 +1901,21 @@ impl IpoptNlp for OrigIpoptNlp {
         Some((dl, du))
     }
 
+    fn declared_c_rhs(&self) -> Option<Vec<Number>> {
+        // `c_rhs` is captured at construction from the user's `g_l` and never
+        // touched afterwards — no relaxation applies to an equality row, so it
+        // is already the declared value. Only the row scaling has to be
+        // reapplied: `eval_c` emits `c_scale_i · (g_i(x) − b_i)`, so the RHS
+        // must carry the same factor for the ratio to cancel it.
+        let mut b = self.c_rhs.clone();
+        if let Some(dc) = self.c_scale.borrow().as_ref() {
+            for (i, slot) in b.iter_mut().enumerate() {
+                *slot *= dc[i];
+            }
+        }
+        Some(b)
+    }
+
     fn px_l(&self) -> Rc<dyn Matrix> {
         Rc::clone(&self.px_l)
     }
@@ -3009,6 +3024,67 @@ mod tests {
         fn finalize_solution(&mut self, _: Solution<'_>, _: &IpoptData, _: &IpoptCq) {}
     }
 
+    /// Equality twin of [`OneIneqLargeOffset`]: `1000·x == 4e6`, whose
+    /// Jacobian magnitude likewise trips `nlp_scaling_max_gradient`, giving
+    /// `c_scale = 100/1000 = 0.1`. Used to check that the declared equality
+    /// RHS is reported in the same scaled space as `eval_c` (gh#390).
+    struct OneEqLargeOffset;
+    impl TNLP for OneEqLargeOffset {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 1,
+                m: 1,
+                nnz_jac_g: 1,
+                nnz_h_lag: 0,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l[0] = -1.0e19;
+            b.x_u[0] = 1.0e19;
+            b.g_l[0] = 4.0e6;
+            b.g_u[0] = 4.0e6;
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            sp.x[0] = 5000.0;
+            true
+        }
+        fn eval_f(&mut self, _: &[Number], _: bool) -> Option<Number> {
+            Some(0.0)
+        }
+        fn eval_grad_f(&mut self, _: &[Number], _: bool, g: &mut [Number]) -> bool {
+            g[0] = 0.0;
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _: bool, g: &mut [Number]) -> bool {
+            g[0] = 1000.0 * x[0];
+            true
+        }
+        fn eval_jac_g(&mut self, _: Option<&[Number]>, _: bool, m: SparsityRequest<'_>) -> bool {
+            match m {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow[0] = 0;
+                    jcol[0] = 0;
+                }
+                SparsityRequest::Values { values } => values[0] = 1000.0,
+            }
+            true
+        }
+        fn eval_h(
+            &mut self,
+            _: Option<&[Number]>,
+            _: bool,
+            _: Number,
+            _: Option<&[Number]>,
+            _: bool,
+            _: SparsityRequest<'_>,
+        ) -> bool {
+            true
+        }
+        fn finalize_solution(&mut self, _: Solution<'_>, _: &IpoptData, _: &IpoptCq) {}
+    }
+
     #[test]
     fn gradient_based_scaling_scales_d_l_and_d_u() {
         let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(OneIneqLargeOffset));
@@ -3512,6 +3588,58 @@ mod tests {
         let (dl, du) = nlp.declared_d_bounds().expect("snapshotted at relax");
         assert_eq!(dl, vec![25.0], "declared bound is the pre-relax value");
         assert!(du.is_empty() || du[0] >= 25.0); // HS071: no finite d upper
+    }
+
+    /// gh#390: the equality RHS folded into `c(x) = 0` is plumbed back out, so
+    /// the runtime feasibility measure has a magnitude to judge `|c_i|`
+    /// against. Unlike an inequality bound it is never relaxed — an equality
+    /// row has no bound to widen — so the captured value is already the
+    /// declared one, at every point in the solve.
+    #[test]
+    fn declared_c_rhs_is_the_pre_fold_right_hand_side() {
+        // HS071's equality row is `x1² + x2² + x3² + x4² == 40`.
+        let (_adapter, mut nlp) = build_orig_nlp();
+        assert_eq!(nlp.declared_c_rhs(), Some(vec![40.0]));
+        nlp.relax_bounds(1e-2, 1.0);
+        assert_eq!(
+            nlp.declared_c_rhs(),
+            Some(vec![40.0]),
+            "bound relaxation must not reach the equality RHS"
+        );
+    }
+
+    /// The RHS is reported in the same space as `eval_c`'s output, so the
+    /// ratio `|c_i| / |b_i|` cancels the solver's own row scaling — the
+    /// property that makes it a scale-*free* measure rather than one that
+    /// merely moved which scale it depends on.
+    #[test]
+    fn declared_c_rhs_carries_the_row_scaling() {
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(OneEqLargeOffset));
+        let adapter = Rc::new(RefCell::new(TNLPAdapter::new(tnlp).unwrap()));
+        let mut nlp = OrigIpoptNlp::new(Rc::clone(&adapter), Rc::new(NoScaling)).unwrap();
+        assert_eq!(nlp.declared_c_rhs(), Some(vec![4.0e6]));
+
+        nlp.determine_scaling_from_starting_point(
+            ScalingMethod::GradientBased,
+            100.0,
+            1e-8,
+            0.0,
+            0.0,
+        );
+        // c_scale = 100 / 1000 = 0.1.
+        let rhs = nlp.declared_c_rhs().unwrap();
+        assert!(
+            (rhs[0] - 4.0e5).abs() < 1e-9,
+            "declared RHS should carry c_scale=0.1; got {}",
+            rhs[0]
+        );
+
+        // At x = 5000: unscaled residual 5e6 - 4e6 = 1e6 over an unscaled RHS
+        // of 4e6 is 0.25 — and the scaled pair reads the same 0.25.
+        let x = dense_x(&[5000.0], nlp.x_space());
+        let mut c = nlp.c_space().make_new_dense();
+        nlp.eval_c(&x, &mut c);
+        assert!((c.values()[0] / rhs[0] - 0.25).abs() < 1e-12);
     }
 
     #[test]

--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -105,6 +105,30 @@ def _inf_eq(m, s):
     m.e2 = pyo.Constraint(expr=s * m.x == s * 0.8)
 
 
+def _inf_eq_nl(m, s):
+    """gh#390: a *nonlinear* equality contradiction, out of bound propagation's reach.
+
+    ``x*y == 1`` and ``x + y == 0.5`` ask for two reals whose sum is 0.5 and
+    whose product is 1 — i.e. roots of ``t**2 - 0.5*t + 1``, discriminant
+    ``0.25 - 4 < 0``. There are none. Refuting it needs the discriminant, not
+    intervals: each row is individually satisfiable over the box, and interval
+    propagation narrows neither variable, so neither the DOF gate's linear
+    bound propagation (both rows are nonlinear) nor FBBT can prove it. The
+    verdict has to come from the runtime feasibility test — which is exactly
+    the surface that had no scale-relative measure on equality rows.
+
+    Both right-hand sides are non-zero on purpose: a homogeneous row has no
+    declared magnitude, so the relative measure abstains on it, and a model
+    whose least-infeasible point parks all its residual on such a row would
+    not exercise the fix.
+    """
+    m.x = pyo.Var(bounds=(-10, 10), initialize=0.5)
+    m.y = pyo.Var(bounds=(-10, 10), initialize=-0.5)
+    m.o = pyo.Objective(expr=m.x**2 + m.y**2)
+    m.e1 = pyo.Constraint(expr=s * (m.x * m.y) == s * 1.0)
+    m.e2 = pyo.Constraint(expr=s * (m.x + m.y) == s * 0.5)
+
+
 MODELS = [
     ("feas_simple", _feas_simple, "SOLVED"),
     ("feas_two", _feas_two, "SOLVED"),
@@ -113,6 +137,7 @@ MODELS = [
     ("inf_clear", _inf_clear, "INFEAS"),
     ("inf_two", _inf_two, "INFEAS"),
     ("inf_eq", _inf_eq, "INFEAS"),
+    ("inf_eq_nl", _inf_eq_nl, "INFEAS"),
 ]
 
 #: Wrong-verdict cells per model, out of len(KS), measured on the
@@ -132,6 +157,11 @@ BASELINE_WRONG = {
     # point in the box satisfies both rows within the solver's own acceptance
     # tolerance and the fail-closed witness rule withholds the proof.
     "inf_eq": 3,
+    # gh#390: with the equality block covered by the scale-relative runtime
+    # feasibility measure this model is right at every scale (was 5 wrong:
+    # SOLVED at k in {-10, -8, -6} — the verdict flip the issue describes —
+    # and a non-verdict at k in {-12, -4}).
+    "inf_eq_nl": 0,
 }
 
 


### PR DESCRIPTION
Fixes #390. Residual of #387 (defect 2); #389 and #391 handled the linear half at the DOF gate.

> **Rebaselined after merging `main` (`1fd45a7`, which brought in #392/#394).** Every number below is measured against that commit, not the original parent. `inf_eq` is now 0 wrong cells on *both* sides — #391 took it there, not this PR.

## Problem

A *nonlinear* equality contradiction is accepted as solved once its rows are written small enough.

`x*y == 1` with `x + y == 0.5` asks for two reals whose sum is `0.5` and whose product is `1` — the roots of `t² − 0.5t + 1`, discriminant `0.25 − 4 < 0`. There are none. Refuting it needs the discriminant, not intervals: each row is individually satisfiable over the box and interval propagation narrows neither variable, so neither the DOF gate's linear bound-propagation probe (#389, #391) nor FBBT can reach it. The verdict has to come from the runtime feasibility test.

Multiplying both rows by `s > 0` leaves the solution set exactly unchanged. The verdict did not agree with itself:

| row scale `s` | status | returned point |
|---|---|---|
| `1e0` | `Infeasible_Problem_Detected` | — |
| `1e-8` | **`Solve_Succeeded`** | `x = y = 2.3e-14` |
| `1e-12` | **`Solve_Succeeded`** | `x = y = 2.3e-14` |

`x = y = 2.3e-14` satisfies neither row. It is not a solution that was found; it is a point at which the absolute tolerance stopped being able to see the residual.

Same on the scale-invariance harness (`inf_eq_nl`, 13 row scalings, `want=INFEAS`), measured against `1fd45a7`:

```
before  FAIL SOLVED SOLVED SOLVED FAIL INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS   (5 wrong)
after   INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS INFEAS   (0 wrong)
```

## Cause

POUNCE folds an equality's right-hand side into `c(x) = 0`, so `|c_i|` *is* the violation and carries no independent magnitude. `IpoptCq::curr_relative_primal_infeasibility_max` (#386) therefore skipped the `c` block entirely — there was nothing to divide by — and every runtime feasibility decision on an equality row was against an absolute threshold. Down-scaling the row walks straight under it.

The fix that made inequality rows scale-relative could not reach equality rows as built: it keys row magnitudes off `declared_d_bounds`, and an equality row has no bound vector, only a folded-away constant.

## Fix

Plumb the **pre-fold RHS** back out, then divide by it.

- **`IpoptNlp::declared_c_rhs`** (`crates/pounce-nlp/src/ipopt_nlp.rs`) — the constants subtracted to form `c(x)`, same "declared, not live" contract `declared_d_bounds` established in #386. `OrigIpoptNlp` returns its construction-time `c_rhs` multiplied by `c_scale`, i.e. in the same internally-scaled space `eval_c` emits, so the solver's own row scaling cancels out of the ratio rather than merely moving which scale the measure depends on.
- **`IpoptCq::relative_c_infeasibility_max`** (`crates/pounce-algorithm/src/ipopt_cq.rs`) — `max_i |c_i| / |b_i|`, which is identical at every writing of the row: `s·g(x) == s·b` has residual `s·(g(x) − b)` over RHS `s·b`. The previous function body became `relative_d_infeasibility_max`; `curr_relative_primal_infeasibility_max` is now the max of the two blocks, so both existing consumers — the certificate / acceptable-point veto and the rapid-infeasibility pre-filter — pick the equality block up unchanged.

Two abstentions, both deliberate:

- **A homogeneous row (`b_i = 0`) keeps the absolute test.** It has no declared magnitude, and needs none: `s·g(x) == 0` is the same row at every `s`, so the absolute test is already invariant there. This is the absolute-clamp question the issue flagged, and the answer is *abstain*, not *clamp* — `max(1, |b_i|)` or any other floor would turn float-noise residuals into 100% "violations" on the single most common equality row there is. Same shape as the zero-bound decision on the `d` block in #386 (where including `|d_i|` in the magnitude vetoed HS13's genuine solution), and the same hazard #391 hit and resolved the same way on the witness gate.
- **An NLP that does not track the RHS abstains wholesale** (trait default `None`) rather than substituting a magnitude of its own. That covers the restoration NLP, whose `c` block is `c(x) − p + n`, not the user's rows.

## Blast radius

Bit-identical except the targeted case, as far as every corpus available here can see. All against `1fd45a7`, release builds:

- **Differential verdict sweep over every `.nl` fixture in the repository**, baseline binary vs. this branch, comparing AMPL `solve_result_num`: **zero** differences. That fixture set now includes `feasible_x0_extreme_row.nl` and `feasible_x0_wide_scale.nl`, the false-infeasibility guards #379 added on `main`.
- **Scale-invariance harness**: `inf_eq_nl` 5 → 0 wrong cells; every other model's curve is byte-identical, including `inf_eq` (0 on both sides after #391) and all three feasible models (0 wrong at all 13 scalings).
- **Full workspace `cargo test --release`** on the merged tree: clean, including the `infeasibility_refutation` suite #379 brought in.

One honest caveat, stated in the CHANGELOG as well. Refusing a certificate keeps the run going, so on a *nonconvex* model the continued trajectory can land in a different basin than the premature stop did. The one instance measured: the same product/sum pair started at `(1, 1)` traded a `Solve_Succeeded` at row scale `1e-8` for a local-infeasibility verdict. What was given up there is not in general a solution — at `1e-12` that same "success" returned `x = y = 2.3e-14` — and from that start the *feasible* twin already converges to a locally-infeasible point at unit scale in both builds, so the basin is start-dependent, not fix-dependent. It is not swept under the rug, but it is also not a solution lost.

## Tests

- `pyomo-pounce/tests/test_scale_invariance.py` — new `inf_eq_nl` model, ratcheted at `BASELINE_WRONG = 0`. This is the acceptance criterion the issue asked for; the linear `inf_eq` goes through the presolve / DOF-gate route and cannot exercise this path.
- `crates/pounce-algorithm/tests/issue_390_nonlinear_equality_scale.rs` — new, pins the same property on the direct driver in both directions:
  - `contradictory_equalities_are_never_reported_solved` — the invariant, over 10 row scalings. **Fails on the parent commit** at `1e-12`, `1e-10`, `1e-8` (`Solve_Succeeded`) and `1e-6` (`Solved_To_Acceptable_Level`) — i.e. for exactly the stated reason.
  - `contradictory_equalities_are_diagnosed_at_small_row_scales` — the small-scale end reaches the *positive* verdict, not merely a non-answer. **Fails on the parent commit.**
  - `feasible_twin_solves_at_every_scale` — the accepting direction. A relative measure is *stricter* than an absolute one on small rows, so it must not start refusing genuine solutions. Passes on both commits; it is a guard, not a regression detector.
- `crates/pounce-nlp` — `declared_c_rhs_is_the_pre_fold_right_hand_side` (and that bound relaxation cannot reach it), `declared_c_rhs_carries_the_row_scaling`.
- `crates/pounce-algorithm` — five unit tests on `relative_c_infeasibility_max`: the ratio itself, and abstention on no-declared-RHS, homogeneous, non-finite, and length-mismatch.

**Deliberately not pinned:** the direct driver exits `Restoration_Failed` on the contradictory model at row scales `1e-4` and above. That is a pre-existing non-verdict on that path, unchanged by this commit (the CLI reaches `Infeasible_Problem_Detected` there), which is why the sweep asserts the invariant rather than a specific status. Pinning `Restoration_Failed` would lock in a defect.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a, no user-facing surface changed; `docs/src/` has no page on the feasibility measure
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean (re-run on the merged tree)
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now — re-measured against `1fd45a7` after the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiRNF2bP2XGcdnsXatcKVv