### PR TITLE
Never certify infeasibility from an absent-bound sentinel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,47 @@ changes.
   - Docs: [Solution output](docs/src/solution-output.md) gains a
     `solve_result_num` band table and the proved-vs-local distinction.
 
+### Fixed — presolve *certified* a feasible model infeasible, from an absent-bound sentinel (#396)
+
+- **A model with a feasible point is no longer reported `solve_result_num` 201.**
+  `201` claims a *proof*, which is the strongest thing POUNCE says; this one was
+  false. The model (property-test seed 223) is feasible by construction, and
+  `pounce check-x0` measures its own declared starting point at **exactly** zero
+  violation — `rows violated: 0, max violation: 0.000e0` — while the convex QP
+  route solves it to optimality.
+  - Root cause is the absent-bound sentinel, mishandled in **both directions on
+    the same row**. POUNCE stores an absent constraint bound as `±1e19`
+    (`INF_BOUND`), not as an infinity, so every use has to ask whether a bound is
+    real. `witness_refutes_infeasibility` asked twice, differently, and got both
+    wrong for row `-1e30·x[0] <= -5.0000000000000007e20`:
+    - The violation term was `(g_l - v).max(v - g_u)` with **no** presence test,
+      so it scored `4.9e20` against a lower bound the row does not have — at a
+      point whose true violation is zero.
+    - The magnitude term used a **symmetric** test, `|b| < INF_BOUND`, which
+      called the row's genuine upper bound `-5e20` absent and discarded a real
+      constraint.
+  - Either error alone sinks the witness, so no candidate point could ever
+    refute the verdict, and the certification escaped.
+  - Fix: one **directional** predicate, matching the convention
+    `pounce_presolve::bound_tighten` already uses (`x_l <= -INF_BOUND`,
+    `x_u >= INF_BOUND`) — a lower bound is absent below `-INF_BOUND`, an upper
+    bound above `+INF_BOUND` — derived once and used for both the magnitude and
+    the violation, so the two cannot drift apart again.
+  - Strictly one-directional, like the gate it sits in: it can only ever
+    *withdraw* a verdict. Every certified-infeasibility test still passes,
+    including the must-still-detect cases.
+  - **The property sweep is now at zero.** Over 400 feasible-by-construction
+    instances, false positives in the AMPL infeasible band go `1 → 0` on the full
+    presolve option set (and stay at 0 on the numerical path from #379).
+    `MAX_FALSE_POSITIVES` ratchets `1 → 0` — a floor, not a target.
+  - **Still open on this model:** it does not solve. It now returns
+    `Invalid_Problem_Definition` (504), because `TNLPAdapter` reads the same
+    out-of-range bound as a crossed constraint pair — `g_l = -1e19` against
+    `g_u = -5e20` trips the `lo > hi` check. That is a separate defect in the
+    sentinel convention for constraint bounds, affecting any model with a
+    one-sided bound beyond `±1e19`; it is tracked on its own. The regression test
+    here asserts the *band*, not a specific code, for that reason.
+
 ### Fixed — the NLP path reported `Infeasible_Problem_Detected` on models whose own starting point is feasible (#379)
 
 - **No numerical path may now claim infeasibility while holding a point that

--- a/crates/pounce-cli/tests/fixtures/feasible_x0_sentinel_bound.nl
+++ b/crates/pounce-cli/tests/fixtures/feasible_x0_sentinel_bound.nl
@@ -1,0 +1,61 @@
+g3 1 1 0	# problem unknown
+ 3 3 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 3 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 5 3 	# nonzeros in Jacobian, obj. gradient
+ 4 4	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#c[1]
+n0
+C1	#c[2]
+n0
+C2	#c[3]
+n0
+O0 0	#o
+o54	# sumlist
+3	# (n)
+o5	#^
+o0	#+
+v0	#x[0]
+n-5e-10
+n2
+o5	#^
+o0	#+
+v1	#x[1]
+n3.9190147700811693
+n2
+o5	#^
+o0	#+
+v2	#x[2]
+n1.2913940476175876
+n2
+x3	# initial guess
+0 5e-10	#x[0]
+1 -3.9190147700811693	#x[1]
+2 -1.2913940476175876	#x[2]
+r	#3 ranges (rhs's)
+1 5.2104e-320	#c[1]
+2 1.29139404770787e+18	#c[2]
+1 -5.0000000000000007e+20	#c[3]
+b	#3 bounds (on variables)
+0 0.0 1e-09	#x[0]
+0 -3.9190147705811693 -3.9190147695811692	#x[1]
+0 -6.291394047617588 3.7086059523824124	#x[2]
+k2	#intermediate Jacobian column lengths
+2
+3
+J0 2	#c[1]
+1 -1e-320
+2 -1e-320
+J1 2	#c[2]
+0 1.8056493234311766e+17
+2 -1e+18
+J2 1	#c[3]
+0 -1e+30
+G0 3	#o
+0 0
+1 0
+2 0

--- a/crates/pounce-cli/tests/presolve_certified_infeasibility.rs
+++ b/crates/pounce-cli/tests/presolve_certified_infeasibility.rs
@@ -65,6 +65,64 @@ fn solve(tag: &str, extra: &[&str]) -> String {
     std::fs::read_to_string(&sol).expect("read .sol")
 }
 
+fn solve_fixture(model: &str, tag: &str, extra: &[&str]) -> String {
+    let sol = std::env::temp_dir().join(format!("pounce_presolve_cert_{tag}.sol"));
+    let _ = std::fs::remove_file(&sol);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture(model))
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("print_level=0")
+        .args(extra)
+        .output()
+        .expect("spawn pounce");
+
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+    std::fs::read_to_string(&sol).expect("read .sol")
+}
+
+/// **gh #396.** A *proof* of infeasibility is the strongest claim POUNCE makes;
+/// it must never be issued for a model that has a feasible point.
+///
+/// `feasible_x0_sentinel_bound.nl` is property-test seed 223, feasible by
+/// construction. `pounce check-x0` measures its declared starting point at
+/// **exactly** zero violation — `rows violated: 0, max violation: 0.000e0` — and
+/// the convex QP route solves it to optimality. Presolve reported
+/// `solve_result_num` 201, "detected by presolve: bound propagation".
+///
+/// The witness gate that exists to stop precisely this was mishandling the
+/// absent-bound sentinel on row `c[3]` (`-1e30·x[0] <= -5.0000000000000007e20`),
+/// in both directions at once: it scored a violation against the `-1e19`
+/// sentinel standing in for the row's absent *lower* bound, and it discarded
+/// the row's real *upper* bound because `|−5e20|` exceeds that same sentinel's
+/// magnitude. See `pounce_presolve::witness_refutes_infeasibility`.
+///
+/// The assertion is on the band, not on a specific code. This model still does
+/// not solve — it returns `Invalid_Problem_Definition` (504) because the
+/// adapter reads the same out-of-range bound as a crossed constraint pair,
+/// which is tracked separately. What must never come back is a claim that a
+/// model with a feasible point has none.
+#[test]
+fn a_feasible_model_is_never_certified_infeasible() {
+    for (tag, opts) in [
+        ("s223_presolve", vec!["presolve=yes", "presolve_fbbt=yes"]),
+        ("s223_plain", vec!["presolve=no"]),
+    ] {
+        let text = solve_fixture("feasible_x0_sentinel_bound.nl", tag, &opts);
+        let srn = solve_result_num(&text);
+        assert!(
+            !(200..300).contains(&srn),
+            "{opts:?}: this model is feasible — `pounce check-x0` reports \
+             `rows violated: 0  max violation: 0.000e0` at its own starting \
+             point, and the convex route solves it — so no code in the AMPL \
+             infeasible band is defensible, least of all the certified 201 \
+             (got {srn}):\n{text}"
+        );
+    }
+}
+
 /// `0 <= x <= 0.6` with `x >= 0.7` is a one-row contradiction over a box, which
 /// bound propagation decides exactly. With presolve on it must be reported as
 /// *proved*, not merely locally infeasible.

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -251,22 +251,53 @@ fn witness_refutes_infeasibility(
             if !v.is_finite() {
                 return false;
             }
-            // Slack relative to the row's own magnitude: an absolute tolerance
-            // is meaningless against a row evaluating near 1e30. This is the
-            // accepting direction, so it goes through `is_negligible` — the
-            // shared clamped form, never stricter than the absolute `tol`.
-            // Only *finite* bounds inform the scale. The unbounded sentinel
-            // (~1e19) would otherwise set the slack around 1e11 and make every
-            // row look satisfied — which withdrew even correct verdicts.
-            let fin = |b: Number| {
-                if b.is_finite() && b.abs() < crate::bound_tighten::INF_BOUND {
-                    b.abs()
+            // An absent bound is stored as the sentinel (`±INF_BOUND`), not as
+            // an infinity, so every use of a bound has to ask whether it is
+            // real — and the question is **directional**. A lower bound is
+            // absent when it is at or below `-INF_BOUND`; an upper bound when
+            // it is at or above `+INF_BOUND`. This is the convention
+            // [`crate::bound_tighten`] already uses (`x_l[j] <= -INF_BOUND`,
+            // `x_u[j] >= INF_BOUND`).
+            //
+            // gh #396 is what the symmetric magnitude test (`|b| < INF_BOUND`)
+            // cost, and it went wrong in both directions at once on the same
+            // row. Property-test seed 223 carries
+            // `-1e30·x[0] <= -5.0000000000000007e20` over `x[0] ∈ [0, 1e-9]`,
+            // with a starting point landing *exactly* on that upper bound:
+            //
+            //   * `g_l = -1e19` is the sentinel for an absent lower bound, but
+            //     `viol` had no presence test at all, so it scored
+            //     `g_l - v = 4.9e20` — a violation of a bound the row does not
+            //     have, against a point whose true violation is zero.
+            //   * `g_u = -5e20` is a genuine, finite upper bound, but
+            //     `|−5e20| < 1e19` is false, so the magnitude test called it
+            //     absent — discarding a real constraint.
+            //
+            // Either error alone sinks the witness. With no candidate able to
+            // pass, presolve certified a *feasible* model infeasible and
+            // reported `solve_result_num` 201, which asserts a proof.
+            let lo_present = |b: Number| b.is_finite() && b > -crate::bound_tighten::INF_BOUND;
+            let up_present = |b: Number| b.is_finite() && b < crate::bound_tighten::INF_BOUND;
+            // Only *real* bounds inform the scale. The sentinel would otherwise
+            // set the slack around 1e11 and make every row look satisfied —
+            // which withdrew even correct verdicts.
+            let scale = v
+                .abs()
+                .max(if lo_present(g_l[i]) {
+                    g_l[i].abs()
                 } else {
                     0.0
-                }
-            };
-            let scale = v.abs().max(fin(g_l[i])).max(fin(g_u[i]));
-            let viol = (g_l[i] - v).max(v - g_u[i]).max(0.0);
+                })
+                .max(if up_present(g_u[i]) {
+                    g_u[i].abs()
+                } else {
+                    0.0
+                });
+            let lo_viol = if lo_present(g_l[i]) { g_l[i] - v } else { 0.0 };
+            let hi_viol = if up_present(g_u[i]) { v - g_u[i] } else { 0.0 };
+            let viol = lo_viol.max(hi_viol).max(0.0);
+            // Accepting direction, so the shared clamped form: never stricter
+            // than the absolute `tol`.
             is_negligible(viol, scale, tol)
         });
         if feasible {
@@ -2765,6 +2796,126 @@ mod tests {
             got_g,
             vec![0.0, 0.0],
             "failed eval_g must not forward stale/garbage constraint values",
+        );
+    }
+
+    /// gh #396's shape, reduced to its essentials: one `<=`-only row whose
+    /// genuine upper bound is *more negative* than the `-INF_BOUND` sentinel
+    /// that stands in for its absent lower bound, and a starting point sitting
+    /// exactly on that upper bound.
+    ///
+    /// `-1e30 · x <= -5e20` over `x ∈ [0, 1e-9]`, with `x0 = 5e-10`, so
+    /// `g(x0) == g_u` exactly. True violation: zero.
+    struct SentinelLowerBoundRow;
+    impl TNLP for SentinelLowerBoundRow {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 1,
+                m: 1,
+                nnz_jac_g: 1,
+                nnz_h_lag: 0,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l[0] = 0.0;
+            b.x_u[0] = 1e-9;
+            b.g_l[0] = -1e19; // absent — the sentinel
+            b.g_u[0] = -5e20; // real, and beyond the sentinel's magnitude
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            if sp.init_x {
+                sp.x[0] = 5e-10;
+            }
+            true
+        }
+        fn eval_f(&mut self, _x: &[Number], _new_x: bool) -> Option<Number> {
+            Some(0.0)
+        }
+        fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g[0] = 0.0;
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g[0] = -1e30 * x[0];
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow[0] = 0;
+                    jcol[0] = 0;
+                }
+                SparsityRequest::Values { values } => {
+                    values[0] = -1e30;
+                }
+            }
+            true
+        }
+        fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+            types[0] = Linearity::Linear;
+            true
+        }
+        fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+    }
+
+    /// **gh #396.** The absent-bound sentinel must not manufacture a violation,
+    /// and a genuine bound beyond the sentinel's magnitude must not be
+    /// discarded.
+    ///
+    /// Both errors landed on this one row pre-fix. `viol` had no presence test,
+    /// so it scored `g_l - v = 4.9e20` against a lower bound the row does not
+    /// have; and the magnitude test `|b| < INF_BOUND` called the row's *real*
+    /// upper bound `-5e20` absent. Either alone sinks the witness, and with no
+    /// candidate able to pass, presolve certified a feasible model infeasible
+    /// with `solve_result_num` 201 — a claimed proof.
+    #[test]
+    fn absent_bound_sentinel_does_not_manufacture_a_violation() {
+        let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(SentinelLowerBoundRow));
+        assert!(
+            witness_refutes_infeasibility(&inner, 1, 1, &[0.0], &[1e-9], &[-1e19], &[-5e20], 1e-8,),
+            "x0 = 5e-10 puts the row exactly on its only real bound — that is a \
+             witness, and the -1e19 sentinel standing in for the absent lower \
+             bound must not turn it into a 4.9e20 violation"
+        );
+    }
+
+    /// The other direction, and the reason the fix is a *directional* presence
+    /// test rather than dropping the terms: a point that genuinely violates a
+    /// real bound must still fail, so correct verdicts survive.
+    ///
+    /// Tightening the ceiling to `-5.1e20` over `x ∈ [4e-10, 5e-10]` puts every
+    /// candidate — including `x0` — strictly above it, so there is genuinely no
+    /// witness and the verdict must stand.
+    ///
+    /// This one does *not* reproduce #396: pre-fix it also returned `false`,
+    /// via the phantom lower-bound violation rather than the real upper-bound
+    /// one. It is here to pin the direction the fix could plausibly have broken
+    /// — making `up_present` admit the bound must not make real violations
+    /// invisible.
+    #[test]
+    fn a_real_bound_beyond_the_sentinel_still_blocks_the_witness() {
+        let inner: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(SentinelLowerBoundRow));
+        assert!(
+            !witness_refutes_infeasibility(
+                &inner,
+                1,
+                1,
+                &[4e-10],
+                &[5e-10],
+                &[-1e19],
+                &[-5.1e20],
+                1e-8,
+            ),
+            "no point in [4e-10, 5e-10] satisfies -1e30*x <= -5.1e20, so there \
+             is no witness — a real bound of magnitude 5.1e20 must not be \
+             discarded as the infinity sentinel"
         );
     }
 

--- a/pyomo-pounce/tests/test_infeasibility_no_false_positives.py
+++ b/pyomo-pounce/tests/test_infeasibility_no_false_positives.py
@@ -13,17 +13,22 @@ not an assumption; it is guaranteed by construction. Any verdict in AMPL's
 Magnitudes deliberately span the ranges that broke earlier rounds: float noise
 (``1e-320``), sub-tolerance gaps, unit scale, and near-overflow (``1e30``).
 
-The assertion is a *ratchet*, not zero. The floating-point interval arithmetic
-underneath is not exact, and a handful of extreme-scale knife-edge instances
-(zero-slack active constraints on ``1e-9``-wide boxes) are still misclassified.
-Pinning the measured rate stops it silently getting worse — a change that pushes
-it up is a regression even if every hand-written case still passes. Lowering
-``MAX_FALSE_POSITIVES`` as the path improves is the point.
+The assertion is a *ratchet*. Pinning the measured rate stops it silently
+getting worse — a change that pushes it up is a regression even if every
+hand-written case still passes. Lowering ``MAX_FALSE_POSITIVES`` as the paths
+improve is the point, and it has now reached zero:
 
-It has been lowered once, for gh #379: the numerical path (``solver_selection=nlp
-presolve=no``) now reports zero over 400 instances, because no path may claim
-infeasibility while the model's own starting point satisfies every constraint
-(``pounce_algorithm::infeasibility_refutation``).
+* gh #379 took the **numerical** path to 0/400. No path may claim infeasibility
+  while the model's own starting point satisfies every constraint
+  (``pounce_algorithm::infeasibility_refutation``).
+* gh #396 took the **presolve certification** path to 0/400. Its witness gate
+  was mishandling the absent-bound sentinel in both directions on one row —
+  scoring a violation of a bound the row did not have, and discarding a real
+  bound whose magnitude exceeded the sentinel.
+
+Zero is now the claim, not an aspiration: hold it there. A single false positive
+means a feasible-by-construction model is being reported infeasible, which is
+the defect this file exists to catch.
 """
 
 from __future__ import annotations
@@ -40,13 +45,11 @@ pyo = pytest.importorskip("pyomo.environ")
 #: Instances per run. Large enough to be sensitive, small enough for CI.
 N_INSTANCES = 200
 
-#: Ratchet. Landed at 3 of 400 (~0.75%); gh #379's refutation gate took the
-#: numerical path to 0 of 400, leaving 1 of 400 — seed 223, on the presolve
-#: certification path. That seed is outside this run's first ``N_INSTANCES``, so
-#: the measured count here is 0; the 1 is headroom for a machine-dependent flip
-#: on a knife-edge instance, not a known failure. Lower it again as the presolve
-#: path improves.
-MAX_FALSE_POSITIVES = 1
+#: Ratchet, now at its floor. Landed at 3 of 400 (~0.75%), then 1 of 400 after
+#: gh #379, then 0 of 400 after gh #396 — measured over the full 400-seed range
+#: on both the numerical (``presolve=no``) and full-presolve option sets.
+#: Raising this again needs a reason recorded here, not a bump.
+MAX_FALSE_POSITIVES = 0
 
 _SCALES = [1e-320, 1e-12, 1e-8, 1.0, 1e8, 1e18, 1e30]
 


### PR DESCRIPTION
Fixes #396.

## Problem

`solve_result_num` **201** claims a *proof* — the strongest thing POUNCE says. This one was false.

Property-test seed 223 is feasible by construction. POUNCE's own `check-x0` measures its declared starting point at **exactly** zero violation, and the convex QP route solves it to optimality:

```
  x0 vs bounds:                   violations: 0
  initial constraint violation:   rows violated: 0  max violation: 0.000e0
```

| route | status | `solve_result_num` |
|---|---|---|
| `presolve=yes presolve_fbbt=yes`, before | `InfeasibleProblemDetected (detected by presolve: bound propagation)` | **201** |
| `presolve=yes presolve_fbbt=yes`, after | `InvalidProblemDefinition` | 504 (see *Still open*) |
| default auto-route (convex QP IPM) | `Optimal Solution Found` | 0 |

## Cause

`witness_refutes_infeasibility` exists to stop exactly this, is applied as a single gate over both certification paths, and evaluates the model's own starting point first. I confirmed it **was** reached and **did** run — there is no early return between the certification site (`lib.rs:985`) and the gate. It simply could not find the witness sitting in front of it.

POUNCE stores an absent constraint bound as the sentinel `±INF_BOUND` (1e19), not as an infinity, so every use of a bound has to ask whether it is real first. The gate asked that question **twice, differently**, and got both wrong on the same row — `c[3]`, `-1e30·x[0] <= -5.0000000000000007e20`. Instrumented, at `x0`:

```
row 2: g=-5.0000000000000007e20  g_l=-1e19  g_u=-5.0000000000000007e20
       viol=4.9e20   scale=5.0e20   negligible=false
```

`g` and `g_u` are identical — the row sits *exactly* on its only real bound, true violation zero. Yet:

- The violation term was `(g_l - v).max(v - g_u)` with **no** presence test, so it scored `g_l - v = 4.9e20` against a lower bound the row does not have.
- The magnitude term used a **symmetric** test, `|b| < INF_BOUND`, which called the row's genuine upper bound `-5e20` absent and discarded a real constraint.

Either error alone sinks the witness. With no candidate able to pass, the certification escaped.

## Fix

One **directional** predicate, matching the convention `pounce_presolve::bound_tighten` already uses (`x_l[j] <= -INF_BOUND`, `x_u[j] >= INF_BOUND`): a lower bound is absent below `-INF_BOUND`, an upper bound above `+INF_BOUND`. The witness gate was the odd one out.

Deriving the magnitude *and* the violation from the same predicate is the load-bearing part — two spellings of one question on adjacent lines is what produced the defect, so the fix has to remove the possibility rather than correct both spellings.

Strictly one-directional, like the gate it sits in: it can only ever *withdraw* a verdict, never create one.

### What was tried and rejected

**A symmetric presence test on the violation term only.** My first attempt added the existing `|b| < INF_BOUND` test to `viol`, leaving the magnitude side alone. It fixes seed 223's headline symptom — 201 disappears — but for the wrong reason: it makes row `c[3]` *vacuously* satisfied by discarding its real upper bound, rather than satisfied because the point meets it. A unit test written against that version exposed it (`present(g_u) = false` for a bound POUNCE should honour), which is what led to the directional form. Worth recording because the symptom-level check does not distinguish the two.

## Blast radius

Only solves that would have reported a presolve-certified infeasibility, and only those where a candidate point satisfies every row. A model with no feasible point cannot produce a witness, so correct verdicts are untouched — confirmed by the must-still-detect tests below.

The `.nl` reader's sentinel convention itself is unchanged; this is a read-side fix inside one predicate.

Corpus sweep: **not run** — the benchmark `.nl` inputs are gitignored and absent from this checkout, same gap as #392. The property sweeps and the full suite are what this rests on.

Measured over 400 feasible-by-construction instances:

| configuration | before | after |
|---|---|---|
| full presolve option set | 1 (seed 223) | **0** |
| `solver_selection=nlp presolve=no` | 0 | **0** |

`MAX_FALSE_POSITIVES` ratchets **1 → 0**. That is a floor, not a target: a single false positive means a feasible-by-construction model is being called infeasible.

## Tests

**`crates/pounce-presolve/src/lib.rs`** — two unit tests on `witness_refutes_infeasibility` directly.

`absent_bound_sentinel_does_not_manufacture_a_violation` is the reproducer. Verified biting on the parent commit (`3a511fb`) by grafting it into a worktree at that commit:

```
test tests::absent_bound_sentinel_does_not_manufacture_a_violation ... FAILED
  x0 = 5e-10 puts the row exactly on its only real bound — that is a witness, and
  the -1e19 sentinel standing in for the absent lower bound must not turn it into
  a 4.9e20 violation
test result: FAILED. 232 passed; 1 failed
```

`a_real_bound_beyond_the_sentinel_still_blocks_the_witness` guards the direction the fix could plausibly have broken — admitting the bound must not make real violations invisible. It **passes on the parent** (via the phantom lower-bound violation rather than the real upper-bound one), so it is a direction-guard, not a reproducer; its doc comment says so.

**`crates/pounce-cli/tests/presolve_certified_infeasibility.rs`** — `a_feasible_model_is_never_certified_infeasible` runs the real model end to end, under both `presolve=yes` and `presolve=no`. It asserts the AMPL *band*, not a specific code, deliberately — see below.

Must-still-detect, all passing: `presolve_proves_the_contradiction_and_says_so`, `float_noise_infeasibility_is_never_certified`, `user_declared_crossed_box_is_still_rejected`, `interval_overflow_is_never_mistaken_for_a_proof`, `genuinely_infeasible_problem_is_still_detected`, `contradictory_equalities_report_infeasible_band` (#389's).

Full workspace suite (`--exclude pounce-hsl`, which needs `COINHSL_DIR` and does not link here): **158 test binaries, exit 0, zero failures**. `test_scale_invariance.py` and `test_infeasibility_no_false_positives.py` both pass. `cargo fmt --all -- --check` clean; `cargo clippy --all-targets` adds no new warnings.

## Still open on this model — #398

It does not solve. It now returns `Invalid_Problem_Definition` (504), because `TNLPAdapter` reads the same out-of-range bound as a crossed constraint pair: `g_l = -1e19` against `g_u = -5e20` trips its `lo > hi` check at `tnlp_adapter.rs:392`. That is the **identical** symmetric-sentinel confusion, living independently in the adapter, and it affects any model with a one-sided constraint bound beyond `±1e19`.

Filed as #398 rather than fixed here: it is a different crate and a different mechanism, and changing bound classification for every model is not something this diff should smuggle in. The regression test asserts the band rather than a code precisely so it does not need rewriting when #398 lands.

I did not audit for further copies of the predicate. Two spellings turned up on one line here, so more are plausible; #398 notes it.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — not needed; no user-facing behaviour is newly *documented*, and `solution-output.md`'s existing description of `201` as a proof is what this restores rather than changes
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyT66Zbb3fZEPQgtEK9tPp

---
_Generated by [Claude Code](https://claude.ai/code/session_01DyT66Zbb3fZEPQgtEK9tPp)_