### PR TITLE
Read bound presence directionally, not as a magnitude (#398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,70 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a one-sided bound beyond `±1e19` was read as a crossed bound pair (#398)
+
+- **A feasible model no longer comes back `Invalid_Problem_Definition`.**
+  `TNLPAdapter` rejected any model carrying a legitimate one-sided bound whose
+  value lies past the *opposite* absent-bound sentinel, reporting AMPL
+  `solve_result_num` **504** / Pyomo `internalSolverError` before the first
+  iteration — so there was no solver output to diagnose it from. The model in
+  question (property-test seed 223, the same one #396 stopped presolve from
+  certifying infeasible) has a starting point `pounce check-x0` measures at
+  *exactly* zero violation, and the convex QP route solves it to optimality.
+  It now solves on the NLP route too.
+- **Cause: a symmetric reading of a directional convention.** A `<=`-only row
+  reaches the adapter with its absent lower bound filled in by the `-1e19`
+  sentinel. On row `-1e30·x[0] <= -5.0000000000000007e20` that gives
+  `g_l = -1e19`, `g_u = -5e20`, and the adapter's `lo > hi` test fired.
+  Nothing is inconsistent — `-5e20` is an ordinary finite upper bound, and the
+  sentinel standing in for the absent lower bound is not a bound to compare it
+  against at all. The bound is only "beyond infinity" if you read the sentinel
+  as a magnitude.
+- **Fix:** `classify_bounds` now derives presence directionally, the same
+  convention `pounce_presolve::bound_tighten` and the #396 witness gate use — a
+  lower bound is absent iff `lo <= nlp_lower_bound_inf`, an upper bound iff
+  `hi >= nlp_upper_bound_inf` — and classifies equality / one-sided /
+  two-sided / free from the *present* bounds only. This closes an asymmetry
+  that had been live for some time: a *variable* bound past the sentinel was
+  already handled directionally by `bound_tighten`, while a *constraint* bound
+  past it was a hard error.
+- `INCONSISTENT_BOUNDS` is now reserved for the case it was meant for — both
+  bounds present and genuinely crossed, a modelling error. `x in [5, 3]` still
+  returns 504 on both the `presolve=yes` and `presolve=no` routes
+  (`user_declared_crossed_box_is_still_rejected`).
+- The equality and fixed-variable tests are gated on presence for the same
+  reason: `g_l == g_u == 1e20` describes `g >= 1e20`, a one-sided row, not an
+  equality at `1e20`, and `x_l = 5e20` with no upper bound is a
+  lower-bounded variable, not one fixed at `5e20`.
+- **Scope.** Any model with a one-sided bound outside `±1e19` — unusual but not
+  pathological. `nlp_lower_bound_inf` / `nlp_upper_bound_inf` are user-settable
+  options, so a well-scaled model trips this the moment someone lowers the
+  threshold, and an `.nl` may legitimately carry a bound of `1e20`.
+- **One sibling of the same predicate fixed alongside it.**
+  `starting_point_refutes_infeasibility`'s crossed-box guard
+  (`pounce-algorithm/src/infeasibility_refutation.rs`) tested the raw pair too,
+  and was the only bound test in that file not already directional — so a
+  variable declared `x <= -5e20` with no lower bound made it decline to refute,
+  withholding a witness the model plainly admits. Failing that way is safe (the
+  gate can only *withdraw* an infeasibility verdict, never issue one), which is
+  why it had gone unnoticed; it is now consistent with the two clamps
+  immediately below it.
+- **A deliberate divergence from upstream**, noted in the source so it is not
+  "corrected" back by a future porter. `IpTNLPAdapter` runs the same raw
+  `lower == upper` / `lower > upper` tests before consulting the sentinels, and
+  inherits the same rejection. Models upstream accepts classify identically
+  here; the divergence is confined to bounds outside the sentinels, which
+  upstream cannot express at all.
+- Covered by `feasible_sentinel_bound_model_solves` in
+  `crates/pounce-cli/tests/presolve_certified_infeasibility.rs` (asserts
+  `Solve_Succeeded`, on both the presolve and no-presolve routes) and four unit
+  tests on `classify_bounds` in `crates/pounce-nlp/src/tnlp_adapter.rs`
+  covering the row, the variable box, the still-rejected crossed pair, and the
+  sentinel-valued equality. The existing property sweep does not see this class
+  of defect: `test_infeasibility_no_false_positives.py` watches the `200..299`
+  infeasible band, and `504` is outside it — a feasible model answered with
+  `Invalid_Problem_Definition` is a wrong answer of a different shape.
+
 ### Fixed — equality rows had no scale-relative runtime feasibility measure (#390)
 
 - **A nonlinear equality contradiction is no longer accepted as solved once its
@@ -239,13 +303,14 @@ changes.
     instances, false positives in the AMPL infeasible band go `1 → 0` on the full
     presolve option set (and stay at 0 on the numerical path from #379).
     `MAX_FALSE_POSITIVES` ratchets `1 → 0` — a floor, not a target.
-  - **Still open on this model:** it does not solve. It now returns
-    `Invalid_Problem_Definition` (504), because `TNLPAdapter` reads the same
+  - **Was still open on this model:** it did not solve. It returned
+    `Invalid_Problem_Definition` (504), because `TNLPAdapter` read the same
     out-of-range bound as a crossed constraint pair — `g_l = -1e19` against
-    `g_u = -5e20` trips the `lo > hi` check. That is a separate defect in the
+    `g_u = -5e20` tripped the `lo > hi` check. That is a separate defect in the
     sentinel convention for constraint bounds, affecting any model with a
-    one-sided bound beyond `±1e19`; it is tracked on its own. The regression test
-    here asserts the *band*, not a specific code, for that reason.
+    one-sided bound beyond `±1e19`; it was tracked and fixed as #398 (above).
+    The regression test here asserts the *band*, not a specific code, for that
+    reason, and did not have to be rewritten.
 
 ### Fixed — the NLP path reported `Infeasible_Problem_Detected` on models whose own starting point is feasible (#379)
 

--- a/crates/pounce-algorithm/src/infeasibility_refutation.rs
+++ b/crates/pounce-algorithm/src/infeasibility_refutation.rs
@@ -129,15 +129,21 @@ pub fn starting_point_refutes_infeasibility(
     // clamped point still is one if it satisfies the rows, since it is inside
     // the box by construction.
     for j in 0..n {
+        let lo_present = x_l[j].is_finite() && x_l[j] > lower_bound_inf;
+        let hi_present = x_u[j].is_finite() && x_u[j] < upper_bound_inf;
         // A crossed box (`x_l > x_u`) cannot be clamped into; that is presolve's
-        // territory and not something to refute from.
-        if x_l[j].is_finite() && x_u[j].is_finite() && x_l[j] > x_u[j] {
+        // territory and not something to refute from. The test is on *present*
+        // bounds only, matching the two clamps below and the row magnitudes
+        // farther down (gh #398): an absent lower bound sitting at the `-1e19`
+        // sentinel is not crossed with a real upper bound of `-5e20`, and
+        // bailing there would withhold a perfectly good witness.
+        if lo_present && hi_present && x_l[j] > x_u[j] {
             return None;
         }
-        if x_l[j].is_finite() && x_l[j] > lower_bound_inf && x[j] < x_l[j] {
+        if lo_present && x[j] < x_l[j] {
             x[j] = x_l[j];
         }
-        if x_u[j].is_finite() && x_u[j] < upper_bound_inf && x[j] > x_u[j] {
+        if hi_present && x[j] > x_u[j] {
             x[j] = x_u[j];
         }
     }
@@ -473,5 +479,24 @@ mod tests {
             ))
             .is_none()
         );
+    }
+
+    /// **gh #398.** A box with no lower bound and a real upper bound past the
+    /// *opposite* sentinel is not crossed — it is `x <= -5e20`. Testing the raw
+    /// pair saw `LO_INF > -5e20` and bailed, withholding a witness the row
+    /// plainly admits, in the one file whose every other bound test is already
+    /// directional.
+    #[test]
+    fn an_upper_bound_past_the_lower_sentinel_is_not_a_crossed_box() {
+        let w = refute(OneRow::new(
+            vec![0.0],
+            vec![LO_INF],
+            vec![-5.0e20],
+            vec![1.0],
+            LO_INF,
+            -1.0e20,
+        ))
+        .expect("x0 clamps to -5e20, which satisfies x <= -1e20");
+        assert_eq!(w.x, vec![-5.0e20]);
     }
 }

--- a/crates/pounce-cli/tests/presolve_certified_infeasibility.rs
+++ b/crates/pounce-cli/tests/presolve_certified_infeasibility.rs
@@ -99,11 +99,11 @@ fn solve_fixture(model: &str, tag: &str, extra: &[&str]) -> String {
 /// the row's real *upper* bound because `|−5e20|` exceeds that same sentinel's
 /// magnitude. See `pounce_presolve::witness_refutes_infeasibility`.
 ///
-/// The assertion is on the band, not on a specific code. This model still does
-/// not solve — it returns `Invalid_Problem_Definition` (504) because the
-/// adapter reads the same out-of-range bound as a crossed constraint pair,
-/// which is tracked separately. What must never come back is a claim that a
-/// model with a feasible point has none.
+/// The assertion is on the band, not on a specific code — what must never come
+/// back is a claim that a model with a feasible point has none. (The model also
+/// failed to solve at all, with `Invalid_Problem_Definition` (504), until the
+/// adapter learned the same directional reading of the sentinel; that is gh
+/// #398, pinned by `feasible_sentinel_bound_model_solves` below.)
 #[test]
 fn a_feasible_model_is_never_certified_infeasible() {
     for (tag, opts) in [
@@ -118,6 +118,51 @@ fn a_feasible_model_is_never_certified_infeasible() {
              `rows violated: 0  max violation: 0.000e0` at its own starting \
              point, and the convex route solves it — so no code in the AMPL \
              infeasible band is defensible, least of all the certified 201 \
+             (got {srn}):\n{text}"
+        );
+    }
+}
+
+/// **gh #398.** The same model must actually *solve*, not merely stay out of
+/// the infeasible band.
+///
+/// `TNLPAdapter` classified row `c[3]` — `-1e30·x[0] <= -5.0000000000000007e20`,
+/// which the `.nl` hands over as `g_l = -1e19` (the absent-lower sentinel),
+/// `g_u = -5e20` — as a *crossed* bound pair, because `-1e19 > -5e20` under a
+/// symmetric magnitude reading. Nothing is inconsistent: `-5e20` is an ordinary
+/// finite upper bound, and the absent lower bound is not a bound to compare it
+/// against. The constructor errored before the first iteration, so the model
+/// came back `Invalid_Problem_Definition` — AMPL 504, Pyomo
+/// `internalSolverError` — on a model whose declared `x0` POUNCE itself
+/// measures at exactly zero violation.
+///
+/// A feasible model answered with 504 is a wrong answer of a different shape
+/// than a false infeasibility, and `test_infeasibility_no_false_positives.py`
+/// does not see it: 504 is outside the 200..299 band that test watches.
+#[test]
+fn feasible_sentinel_bound_model_solves() {
+    for (tag, opts) in [
+        (
+            "s223_solves_nlp",
+            vec!["solver_selection=nlp", "presolve=no"],
+        ),
+        (
+            "s223_solves_presolve",
+            vec!["solver_selection=nlp", "presolve=yes", "presolve_fbbt=yes"],
+        ),
+    ] {
+        let text = solve_fixture("feasible_x0_sentinel_bound.nl", tag, &opts);
+        let srn = solve_result_num(&text);
+        assert_ne!(
+            srn, 504,
+            "{opts:?}: a one-sided constraint bound of -5e20 is a legitimate \
+             finite bound, not a crossed pair — the adapter must not reject \
+             the model as Invalid_Problem_Definition:\n{text}"
+        );
+        assert_eq!(
+            srn, 0,
+            "{opts:?}: this model is feasible and the convex QP route solves it \
+             to optimality; the NLP route must reach Solve_Succeeded too \
              (got {srn}):\n{text}"
         );
     }

--- a/crates/pounce-nlp/src/tnlp_adapter.rs
+++ b/crates/pounce-nlp/src/tnlp_adapter.rs
@@ -305,6 +305,27 @@ impl TNLPAdapter {
     }
 }
 
+/// Split the full variable / constraint sets into fixed vs. free variables and
+/// equality vs. inequality rows, recording which sides carry a real bound.
+///
+/// **Deliberate divergence from upstream (gh #398).** `IpTNLPAdapter` tests
+/// `lower == upper` and `lower > upper` on the *raw* bound pair, before asking
+/// whether either side is present, and only consults `nlp_lower_bound_inf` /
+/// `nlp_upper_bound_inf` afterwards. That is safe only while every real bound
+/// sits inside the sentinels. A `<=`-only row arrives with its absent lower
+/// bound filled in at `-1e19`; if the row's genuine upper bound is more
+/// negative than that (`-5e20` is perfectly ordinary, and both sentinels are
+/// user-settable options besides), the raw pair reads as crossed and a feasible
+/// model is rejected as `Invalid_Problem_Definition`.
+///
+/// So presence is decided first, and *directionally* — a lower bound is absent
+/// at or below `lo_inf`, an upper bound at or above `up_inf`, the convention
+/// `pounce_presolve::bound_tighten` already uses. Equality, fixed-variable, and
+/// crossed-pair tests then run on the present bounds only, which leaves
+/// `INCONSISTENT_BOUNDS` for what it is meant for: a modeller who declared both
+/// sides and crossed them. Models upstream accepts classify identically; the
+/// divergence is confined to bounds outside the sentinels, which upstream
+/// cannot express at all.
 #[allow(clippy::too_many_arguments)]
 fn classify_bounds(
     n_full_x: Index,
@@ -332,7 +353,14 @@ fn classify_bounds(
     for i in 0..nx {
         let lo = x_l[i];
         let hi = x_u[i];
-        if lo > hi {
+        // Presence is *directional*, not a symmetric magnitude test: a lower
+        // bound is absent only at or below `lo_inf`, an upper bound only at or
+        // above `up_inf`. A finite bound past the opposite sentinel (say an
+        // upper bound of -5e20) is an ordinary bound, not an "infinite" one, so
+        // it must not be compared against the absent side's sentinel value.
+        let lo_present = lo > lo_inf;
+        let hi_present = hi < up_inf;
+        if lo_present && hi_present && lo > hi {
             return Err(SolverException::new(
                 ExceptionKind::INCONSISTENT_BOUNDS,
                 format!(
@@ -343,7 +371,7 @@ fn classify_bounds(
                 line!() as Index,
             ));
         }
-        if lo == hi {
+        if lo_present && hi_present && lo == hi {
             match treatment {
                 FixedVarTreatment::MakeParameter => {
                     // Drop fixed vars from x_var entirely. Their values are
@@ -371,10 +399,10 @@ fn classify_bounds(
         let var_idx = x_not_fixed_map.len() as Index;
         x_not_fixed_map.push(i as Index);
         full_to_var[i] = var_idx;
-        if lo > lo_inf {
+        if lo_present {
             x_l_map.push(var_idx);
         }
-        if hi < up_inf {
+        if hi_present {
             x_u_map.push(var_idx);
         }
     }
@@ -388,27 +416,36 @@ fn classify_bounds(
     for i in 0..ng {
         let lo = g_l[i];
         let hi = g_u[i];
-        if lo == hi {
-            c_map.push(i as Index);
-        } else if lo > hi {
-            return Err(SolverException::new(
-                ExceptionKind::INCONSISTENT_BOUNDS,
-                format!(
-                    "There are inconsistent bounds on constraint function {i}: \
-                     lower = {lo:25.16e} and upper = {hi:25.16e}."
-                ),
-                file!(),
-                line!() as Index,
-            ));
-        } else {
-            let d_idx = d_map.len() as Index;
-            d_map.push(i as Index);
-            if lo > lo_inf {
-                d_l_map.push(d_idx);
+        // Same directional presence test as the variable box above. A
+        // `<=`-only row arrives with `g_l` at the `-1e19` sentinel; if its real
+        // upper bound is more negative than that (a legitimate `-5e20`), the
+        // pair only looks crossed under a symmetric reading of the sentinel.
+        let lo_present = lo > lo_inf;
+        let hi_present = hi < up_inf;
+        if lo_present && hi_present {
+            if lo > hi {
+                return Err(SolverException::new(
+                    ExceptionKind::INCONSISTENT_BOUNDS,
+                    format!(
+                        "There are inconsistent bounds on constraint function {i}: \
+                         lower = {lo:25.16e} and upper = {hi:25.16e}."
+                    ),
+                    file!(),
+                    line!() as Index,
+                ));
             }
-            if hi < up_inf {
-                d_u_map.push(d_idx);
+            if lo == hi {
+                c_map.push(i as Index);
+                continue;
             }
+        }
+        let d_idx = d_map.len() as Index;
+        d_map.push(i as Index);
+        if lo_present {
+            d_l_map.push(d_idx);
+        }
+        if hi_present {
+            d_u_map.push(d_idx);
         }
     }
 
@@ -790,5 +827,152 @@ mod tests {
         let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Bad));
         let err = TNLPAdapter::new(tnlp).unwrap_err();
         assert_eq!(err.kind, ExceptionKind::INCONSISTENT_BOUNDS);
+    }
+
+    /// A TNLP that reports whatever bounds it is handed and nothing else —
+    /// enough to drive `classify_bounds` through the adapter constructor.
+    struct BoundsOnly {
+        x_l: Vec<Number>,
+        x_u: Vec<Number>,
+        g_l: Vec<Number>,
+        g_u: Vec<Number>,
+    }
+    impl TNLP for BoundsOnly {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: self.x_l.len() as Index,
+                m: self.g_l.len() as Index,
+                nnz_jac_g: 0,
+                nnz_h_lag: 0,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l.copy_from_slice(&self.x_l);
+            b.x_u.copy_from_slice(&self.x_u);
+            b.g_l.copy_from_slice(&self.g_l);
+            b.g_u.copy_from_slice(&self.g_u);
+            true
+        }
+        fn get_starting_point(&mut self, _sp: StartingPoint<'_>) -> bool {
+            true
+        }
+        fn eval_f(&mut self, _x: &[Number], _new_x: bool) -> Option<Number> {
+            Some(0.0)
+        }
+        fn eval_grad_f(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g.fill(0.0);
+            true
+        }
+        fn eval_g(&mut self, _x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+            g.fill(0.0);
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            _x: Option<&[Number]>,
+            _new_x: bool,
+            _m: SparsityRequest<'_>,
+        ) -> bool {
+            true
+        }
+        fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+    }
+
+    fn classify(b: BoundsOnly) -> Result<BoundClassification, SolverException> {
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(b));
+        TNLPAdapter::new(tnlp).map(|a| a.classification().clone())
+    }
+
+    /// **gh #398.** A `<=`-only row whose real upper bound is *more negative*
+    /// than the absent-lower sentinel is an ordinary one-sided row, not a
+    /// crossed pair.
+    ///
+    /// `.nl` fills the absent lower bound of `-1e30·x <= -5e20` with the
+    /// `-1e19` sentinel, so a symmetric magnitude reading sees
+    /// `-1e19 > -5e20` and calls the pair inconsistent — `504
+    /// Invalid_Problem_Definition` on a model whose declared `x0` sits at
+    /// exactly zero violation. Presence is directional: a *lower* bound is
+    /// absent only at or below `nlp_lower_bound_inf`, so the sentinel is not a
+    /// bound to compare against at all.
+    #[test]
+    fn one_sided_row_beyond_the_sentinel_is_not_a_crossed_pair() {
+        let c = classify(BoundsOnly {
+            x_l: vec![-2.0e19],
+            x_u: vec![2.0e19],
+            g_l: vec![DEFAULT_NLP_LOWER_BOUND_INF],
+            g_u: vec![-5.0000000000000007e20],
+        })
+        .expect("a one-sided row at -5e20 must classify, not error");
+        assert_eq!(c.n_c, 0, "not an equality row");
+        assert_eq!(c.n_d, 1);
+        assert!(
+            c.d_l_map.is_empty(),
+            "the -1e19 lower bound is the absent-bound sentinel"
+        );
+        assert_eq!(c.d_u_map, vec![0], "-5e20 is a real, present upper bound");
+    }
+
+    /// The mirror image on the variable box: a lower bound past `+INF` with no
+    /// upper bound. Symmetrically read, `+5e20 > +1e19` looked like a crossed
+    /// box (and `lo == hi` at the sentinel looked like a *fixed* variable);
+    /// directionally it is a lower-bounded-only variable.
+    #[test]
+    fn one_sided_var_bound_beyond_the_sentinel_is_not_crossed() {
+        let c = classify(BoundsOnly {
+            x_l: vec![5.0e20],
+            x_u: vec![DEFAULT_NLP_UPPER_BOUND_INF],
+            g_l: vec![],
+            g_u: vec![],
+        })
+        .expect("x >= 5e20 with no upper bound must classify, not error");
+        assert_eq!(c.n_x_fixed, 0, "an absent upper bound does not fix the var");
+        assert_eq!(c.n_x_var(), 1);
+        assert_eq!(c.x_l_map, vec![0]);
+        assert!(c.x_u_map.is_empty());
+    }
+
+    /// The guard that must survive the fix: when *both* bounds are present and
+    /// crossed, that is a genuine modelling error and still an error here.
+    #[test]
+    fn genuinely_crossed_present_bounds_are_still_rejected() {
+        let err = classify(BoundsOnly {
+            x_l: vec![-2.0e19],
+            x_u: vec![2.0e19],
+            g_l: vec![5.0],
+            g_u: vec![3.0],
+        })
+        .expect_err("5 <= g <= 3 is inconsistent");
+        assert_eq!(err.kind, ExceptionKind::INCONSISTENT_BOUNDS);
+
+        let err = classify(BoundsOnly {
+            x_l: vec![5.0],
+            x_u: vec![3.0],
+            g_l: vec![],
+            g_u: vec![],
+        })
+        .expect_err("x in [5, 3] is inconsistent");
+        assert_eq!(err.kind, ExceptionKind::INCONSISTENT_BOUNDS);
+    }
+
+    /// Equality detection is likewise gated on both bounds being present: two
+    /// equal bounds that are *both* the same sentinel value describe a
+    /// one-sided row, not an equality. `g_l = g_u = 1e20` is `g >= 1e20`.
+    #[test]
+    fn equal_bounds_past_the_sentinel_are_one_sided_not_an_equality() {
+        let c = classify(BoundsOnly {
+            x_l: vec![-2.0e19],
+            x_u: vec![2.0e19],
+            g_l: vec![1.0e20],
+            g_u: vec![1.0e20],
+        })
+        .expect("classify");
+        assert_eq!(
+            c.n_c, 0,
+            "the upper bound is absent, so this is no equality"
+        );
+        assert_eq!(c.n_d, 1);
+        assert_eq!(c.d_l_map, vec![0]);
+        assert!(c.d_u_map.is_empty());
     }
 }


### PR DESCRIPTION
Fixes #398.

## What was wrong

`TNLPAdapter` rejected any model carrying a legitimate one-sided bound whose
value lies past the **opposite** absent-bound sentinel, returning
`Invalid_Problem_Definition` — AMPL `solve_result_num` 504, Pyomo
`internalSolverError` — from the constructor, before the first iteration, so
there was no solver output to diagnose it from.

A `<=`-only row reaches the adapter with its absent lower bound filled in at the
`-1e19` sentinel. On row `c[3]` of the fixture:

```
-1e30*x[0] <= -5.0000000000000007e20
    g_l = -1e19   (sentinel, absent)
    g_u = -5e20   (real)
    -1e19 > -5e20  ->  INCONSISTENT_BOUNDS
```

Nothing is inconsistent. `-5e20` is an ordinary finite upper bound, and the
sentinel standing in for the absent lower bound is not a bound to compare it
against. The pair only looks crossed if the sentinel is read as a *magnitude*.

## The fix

`classify_bounds` now decides presence first, and **directionally** — the
convention `pounce_presolve::bound_tighten` and the #396 witness gate already
use:

- `lo` is absent iff `lo <= nlp_lower_bound_inf`
- `hi` is absent iff `hi >= nlp_upper_bound_inf`

Equality / fixed-variable / crossed-pair tests then run on the **present**
bounds only, which leaves `INCONSISTENT_BOUNDS` for what it was meant for: a
modeller who declared both sides and crossed them.

Two consequences worth calling out:

- `g_l == g_u == 1e20` describes `g >= 1e20`, a one-sided row, not an equality
  at `1e20`; `x_l = 5e20` with no upper bound is a lower-bounded variable, not
  one fixed at `5e20`. Both now classify that way.
- This closes an asymmetry that had been live for a while: a *variable* bound
  past the sentinel was already handled directionally by `bound_tighten`, while
  a *constraint* bound past it was a hard error.

### One sibling of the same predicate, fixed alongside

`starting_point_refutes_infeasibility`'s crossed-box guard tested the raw pair
too, and was the only bound test in that file not already directional — so a
variable declared `x <= -5e20` with no lower bound made it decline to refute,
withholding a witness the model plainly admits. Failing that way is *safe* (the
gate can only ever withdraw an infeasibility verdict, never issue one), which is
why it had gone unnoticed. It is now consistent with the two clamps immediately
below it.

## Deliberate divergence from upstream

`IpTNLPAdapter` tests `lower == upper` / `lower > upper` on the raw pair before
consulting the sentinels, and inherits the same rejection. The divergence is
documented in the `classify_bounds` doc comment so a future porter does not
"correct" it back. Models upstream accepts classify identically here; the
divergence is confined to bounds outside the sentinels, which upstream cannot
express at all.

## Verification

Before, on `crates/pounce-cli/tests/fixtures/feasible_x0_sentinel_bound.nl`
(property-test seed 223, the same model #396 stopped presolve from certifying
infeasible):

```
objno 0 504     # POUNCE 0.9.0: InvalidProblemDefinition
```

After — both the `presolve=no` and `presolve=yes presolve_fbbt=yes` routes:

```
objno 0 0       # Optimal Solution Found
```

12 iterations, constraint violation `8.4e-39`, variable bound violation `0`,
matching the convex QP route that already solved this model.

### Coverage

- `feasible_sentinel_bound_model_solves` (`crates/pounce-cli/tests/presolve_certified_infeasibility.rs`)
  — asserts `Solve_Succeeded`, on both routes.
- Four unit tests on `classify_bounds` (`crates/pounce-nlp/src/tnlp_adapter.rs`):
  the row, the variable box, the still-rejected genuinely-crossed pair, and the
  sentinel-valued "equality". All three of the first ones fail on `main`.
- `an_upper_bound_past_the_lower_sentinel_is_not_a_crossed_box`
  (`crates/pounce-algorithm/src/infeasibility_refutation.rs`).
- `user_declared_crossed_box_is_still_rejected` still passes unchanged —
  `x in [5, 3]` still returns 504 on both routes.
- The #396 regression test did not have to be rewritten: it asserts the *band*,
  deliberately. Its doc comment is updated to point here.

Full workspace suite: **163 binaries, 2249 tests, 0 failures**. `cargo fmt
--check` clean, `cargo clippy --workspace --all-targets` reports no new
findings, `scripts/check-release-consistency.sh` OK.

## Not covered by the property test

`test_infeasibility_no_false_positives.py` watches the `200..299` infeasible
band, and `504` is outside it — a feasible model answered with
`Invalid_Problem_Definition` is a wrong answer of a different shape, and needed
its own coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
