### PR TITLE
Keep constraints whose bound lies past the opposite sentinel (#401)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the convex route silently dropped constraints bounded past the opposite sentinel (#401)
+
+- **An LP/QP/QCQP no longer reports `Optimal` at a point its own bounds
+  exclude.** This is the same absent-bound-sentinel confusion as #396 and #398,
+  on the convex path — where it is worse, because it does not misclassify a
+  constraint, it **deletes** it, and the solver then answers a different problem
+  than the one that was asked. Unlike its siblings it fails *silently*: #396 was
+  a false infeasibility proof and #398 a refusal to solve, both loud.
+- **Cause:** two independent copies of a symmetric magnitude test,
+  `fn is_finite_bound(v: f64) -> bool { v.abs() < NL_INF }`, in
+  `pounce-cli/src/qp_extract.rs` and `pounce-cli/src/dispatch.rs`. Presence is
+  directional — a lower bound is absent only at or below `-1e19`, an upper bound
+  only at or above `+1e19` — so a real upper bound of `-5e20` is an ordinary
+  bound and `|v| < 1e19` is simply the wrong question about it.
+- Three distinct wrong answers came out of that:
+  - **A real variable bound never entered `G`.** `x_u = -5e20` failed the test,
+    so `x_i <= -5e20` was never built and the QP was solved over a strictly
+    larger box. Mirror case for a real `x_l = +5e20`.
+  - **A row with equal bounds past the sentinel vanished from the problem
+    entirely.** `lo == hi && is_finite_bound(lo)` failed, so the row fell into
+    the inequality branch — where both `is_finite_bound(hi)` and
+    `is_finite_bound(lo)` were false too, leaving `upper` and `lower` both
+    `None`. It contributed nothing to `A` and nothing to `G`.
+  - **A real quadratic row was discarded as "vacuous".** `g(x) >= 5e20` arrives
+    as `g_l = 5e20` (real), `g_u = 1e19` (sentinel); both tests were false, so
+    `vacuous` was true and the row was skipped with "Free row: imposes
+    nothing". The model then classified as a convex QCQP and went to the conic
+    solver *as if the constraint were not there* — it is reverse-convex, and
+    the honest answer is NLP.
+- **Fix:** one shared directional pair, `lower_bound_present` /
+  `upper_bound_present`, added next to `NLP_LOWER_BOUND_INF` /
+  `NLP_UPPER_BOUND_INF` in `pounce-common::types` — so there is now one spelling
+  of this predicate in the tree to fix, rather than the several that #396, #398
+  and this issue each turned up independently. The equality test is additionally
+  gated on *both* bounds being present, as #398 did in `classify_bounds`.
+- `recover_bound_mults` walks the G-row layout with the same predicate and was
+  *consistent* with the buggy builder, so it moved in lockstep; a regression
+  test now pins the two together on a box only the directional reading admits.
+- **Worth knowing: an equality row outside `±1e19` cannot be expressed under
+  this convention at all.** An equality needs both bounds present, and the two
+  presence tests only overlap inside the band — so `g_l = g_u = -5e20` is not an
+  equality at `-5e20`, it is the one-sided `g <= -5e20` (no lower bound). The
+  original issue report described this case as a lost *equality*; the row was
+  indeed lost, but what it should become is a one-sided inequality.
+- Covered by four regression tests, all verified to fail against the old
+  symmetric predicate and pass with the fix:
+  `variable_bound_past_the_opposite_sentinel_is_kept`,
+  `a_row_with_equal_bounds_past_the_sentinel_does_not_vanish`,
+  `bound_multipliers_stay_aligned_with_the_built_rows` (all in
+  `qp_extract.rs`), and `a_quadratic_row_bounded_past_the_sentinel_is_not_vacuous`
+  (`dispatch.rs`), plus `presence_is_directional_not_symmetric` on the new
+  shared helpers.
+
 ### Fixed — a one-sided bound beyond `±1e19` was read as a crossed bound pair (#398)
 
 - **A feasible model no longer comes back `Invalid_Problem_Definition`.**

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -36,6 +36,7 @@
 //! tolerance" to the safe side, never to the convex path.
 
 use crate::nl_reader::{BinOp, Expr, NlProblem, UnaryOp};
+use pounce_common::types::{lower_bound_present, upper_bound_present};
 use std::collections::BTreeMap;
 
 /// Tolerance for the smallest-eigenvalue sign test in the convexity
@@ -87,17 +88,6 @@ const SOCP_SIZE_BUDGET: u64 = 100_000_000;
 /// convexity test itself is the cheap sparse factorization in
 /// [`coupled_hessian_is_psd`].
 const QCQP_SOCP_COUPLED_VARS: usize = 256;
-
-/// The `.nl` "infinity" sentinel for a missing bound: AMPL writes ±1e20-ish
-/// and upstream Ipopt treats any magnitude ≥ 1e19 as infinite. Used to read
-/// a quadratic constraint's *sense* (one-sided `≤` vs. equality / range / `≥`)
-/// when deciding whether a QCQP is convex — see [`classify_problem`].
-const NL_INF: f64 = 1e19;
-
-#[inline]
-fn is_finite_bound(v: f64) -> bool {
-    v.abs() < NL_INF
-}
 
 /// The mathematical class of a loaded problem, from most to least
 /// specialized. See the module docs and `dev-notes/lp-qp-routing.md`.
@@ -283,8 +273,16 @@ pub fn classify_problem(prob: &NlProblem) -> ProblemClass {
                 Some(q) => {
                     let lo = prob.g_l[row];
                     let hi = prob.g_u[row];
-                    let vacuous = !is_finite_bound(lo) && !is_finite_bound(hi);
-                    let upper_only = is_finite_bound(hi) && !is_finite_bound(lo);
+                    // Presence is directional (gh #401). The symmetric
+                    // `|v| < 1e19` test this used to run called a row with a
+                    // real bound past the *opposite* sentinel — `g(x) >= 5e20`
+                    // arrives as `g_l = 5e20`, `g_u = 1e19` — free on both
+                    // sides, and `continue` below then dropped a real
+                    // constraint from the convexity decision.
+                    let lo_present = lower_bound_present(lo);
+                    let hi_present = upper_bound_present(hi);
+                    let vacuous = !lo_present && !hi_present;
+                    let upper_only = hi_present && !lo_present;
                     if vacuous {
                         // Free row: imposes nothing, so it cannot make the
                         // problem nonconvex. Ignore it.
@@ -1157,6 +1155,43 @@ mod tests {
         );
         let prob = qp_stub(obj, vec![Expr::Const(0.0)]);
         assert_eq!(classify_problem(&prob), ProblemClass::ConvexQp);
+    }
+
+    /// **gh #401.** A quadratic row whose real bound lies past the *opposite*
+    /// sentinel must not be waved through as a free row.
+    ///
+    /// `x0² + x1² >= 5e20` arrives as `g_l = 5e20` (real), `g_u = 1e19`
+    /// (the absent-upper sentinel). The symmetric `|v| < 1e19` test called
+    /// *both* sides infinite, so `vacuous` was true and the row was skipped
+    /// with "Free row: imposes nothing" — and the model then classified as a
+    /// convex QCQP and went to the conic solver as if the constraint were not
+    /// there. It is a reverse-convex row: the honest answer is NLP.
+    #[test]
+    fn a_quadratic_row_bounded_past_the_sentinel_is_not_vacuous() {
+        let con = Expr::Binary(
+            BinOp::Add,
+            Box::new(Expr::Binary(
+                BinOp::Pow,
+                Box::new(Expr::Var(0)),
+                Box::new(Expr::Const(2.0)),
+            )),
+            Box::new(Expr::Binary(
+                BinOp::Pow,
+                Box::new(Expr::Var(1)),
+                Box::new(Expr::Const(2.0)),
+            )),
+        );
+        let mut prob = qp_stub(Expr::Const(0.0), vec![con]);
+        prob.obj_linear = vec![(0, 1.0)];
+        prob.g_l = vec![5e20]; // real lower bound
+        prob.g_u = vec![1e19]; // absent-upper sentinel
+        assert_eq!(
+            classify_problem(&prob),
+            ProblemClass::Nlp,
+            "a `>=` quadratic row is reverse-convex and must route to NLP; \
+             treating it as a free row sent the model to the conic solver \
+             with the constraint silently dropped"
+        );
     }
 
     #[test]

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -21,21 +21,21 @@
 //!   g_u`. An equality (`g_l == g_u`) becomes a row of `A`; a one- or
 //!   two-sided inequality becomes one or two rows of `G` (`row ≤ g_u`
 //!   and/or `−row ≤ −g_l`).
-//! - **Variable bounds.** Finite `x_l`/`x_u` become `G` rows
-//!   (`−x_i ≤ −x_l`, `x_i ≤ x_u`); the `.nl` "infinity" sentinel
-//!   (`|v| ≥ 1e19`) is treated as no bound.
+//! - **Variable bounds.** Present `x_l`/`x_u` become `G` rows
+//!   (`−x_i ≤ −x_l`, `x_i ≤ x_u`). The `.nl` "infinity" sentinel is
+//!   read directionally: `x_l ≤ -1e19` is no lower bound, `x_u ≥ 1e19`
+//!   is no upper bound. A bound past the *opposite* sentinel (an upper
+//!   bound of `-5e20`) is an ordinary bound and is kept.
 
 use crate::dispatch::analyze_quadratic_full;
 use crate::nl_reader::NlProblem;
+// Bound presence is read **directionally** — a lower bound is absent only at
+// or below `-1e19`, an upper bound only at or above `+1e19`. This file used a
+// symmetric `|v| < 1e19` test (gh #401): a real upper bound of `-5e20` failed
+// it and was dropped from `G` entirely, so the QP was solved over a strictly
+// larger box and reported `Optimal` at a point the model excludes.
+use pounce_common::types::{lower_bound_present, upper_bound_present};
 use pounce_convex::{ConeSpec, QpProblem, Triplet};
-
-/// The `.nl` infinity sentinel: AMPL writes ±1e20-ish for "no bound";
-/// upstream Ipopt treats anything with magnitude ≥ 1e19 as infinite.
-const NL_INF: f64 = 1e19;
-
-fn is_finite_bound(v: f64) -> bool {
-    v.abs() < NL_INF
-}
 
 /// Convert a classified LP/convex-QP `NlProblem` into `QpProblem`
 /// standard form. Returns `None` if the objective is not actually a
@@ -131,7 +131,7 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
         }
         let nonzeros = || coef.iter().enumerate().filter(|(_, v)| **v != 0.0);
 
-        if lo == hi && is_finite_bound(lo) {
+        if lo == hi && lower_bound_present(lo) && upper_bound_present(hi) {
             // Equality row.
             let eq_row = next_row(&b);
             for (var, v) in nonzeros() {
@@ -141,7 +141,7 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
             con_map.push(ConRowMap::Eq { a_row: eq_row });
         } else {
             // Upper bound: row ≤ hi.
-            let upper = if is_finite_bound(hi) {
+            let upper = if upper_bound_present(hi) {
                 let gr = next_row(&h);
                 for (var, v) in nonzeros() {
                     g.push(Triplet::new(gr, var, *v));
@@ -152,7 +152,7 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
                 None
             };
             // Lower bound: row ≥ lo  ⇔  −row ≤ −lo.
-            let lower = if is_finite_bound(lo) {
+            let lower = if lower_bound_present(lo) {
                 let gr = next_row(&h);
                 for (var, v) in nonzeros() {
                     g.push(Triplet::new(gr, var, -*v));
@@ -170,12 +170,12 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
     for i in 0..n {
         let xl = prob.x_l[i];
         let xu = prob.x_u[i];
-        if is_finite_bound(xu) {
+        if upper_bound_present(xu) {
             let gr = next_row(&h);
             g.push(Triplet::new(gr, i, 1.0)); // x_i ≤ xu
             h.push(xu);
         }
-        if is_finite_bound(xl) {
+        if lower_bound_present(xl) {
             let gr = next_row(&h);
             g.push(Triplet::new(gr, i, -1.0)); // −x_i ≤ −xl
             h.push(-xl);
@@ -293,13 +293,13 @@ pub fn recover_bound_mults(
     let mut z_ub = vec![0.0; n];
     let mut row = n_con_ineq_rows;
     for i in 0..n {
-        if is_finite_bound(prob.x_u[i]) {
+        if upper_bound_present(prob.x_u[i]) {
             if let Some(&zv) = z.get(row) {
                 z_ub[i] = zv;
             }
             row += 1;
         }
-        if is_finite_bound(prob.x_l[i]) {
+        if lower_bound_present(prob.x_l[i]) {
             if let Some(&zv) = z.get(row) {
                 z_lb[i] = zv;
             }
@@ -456,7 +456,7 @@ pub fn extract_socp_with_map(
             coef[*var] += *v;
         }
         let nonzeros = || coef.iter().enumerate().filter(|(_, v)| **v != 0.0);
-        if lo == hi && is_finite_bound(lo) {
+        if lo == hi && lower_bound_present(lo) && upper_bound_present(hi) {
             let eq_row = next_row(&b);
             for (var, v) in nonzeros() {
                 a.push(Triplet::new(eq_row, var, *v));
@@ -464,7 +464,7 @@ pub fn extract_socp_with_map(
             b.push(lo - const_shift);
             con_map.push(ConSocpMap::Eq { a_row: eq_row });
         } else {
-            let upper = if is_finite_bound(hi) {
+            let upper = if upper_bound_present(hi) {
                 let gr = next_row(&h);
                 for (var, v) in nonzeros() {
                     g.push(Triplet::new(gr, var, *v));
@@ -474,7 +474,7 @@ pub fn extract_socp_with_map(
             } else {
                 None
             };
-            let lower = if is_finite_bound(lo) {
+            let lower = if lower_bound_present(lo) {
                 let gr = next_row(&h);
                 for (var, v) in nonzeros() {
                     g.push(Triplet::new(gr, var, -*v));
@@ -492,12 +492,12 @@ pub fn extract_socp_with_map(
     for i in 0..n {
         let xl = prob.x_l[i];
         let xu = prob.x_u[i];
-        if is_finite_bound(xu) {
+        if upper_bound_present(xu) {
             let gr = next_row(&h);
             g.push(Triplet::new(gr, i, 1.0));
             h.push(xu);
         }
-        if is_finite_bound(xl) {
+        if lower_bound_present(xl) {
             let gr = next_row(&h);
             g.push(Triplet::new(gr, i, -1.0));
             h.push(-xl);
@@ -1157,5 +1157,142 @@ mod tests {
         let sol = solve_qp_ipm(&qp, &QpOptions::default(), backend);
         assert_eq!(sol.status, QpStatus::Optimal);
         assert!((sol.x[0] - 5.0).abs() < 1e-6, "x0={}", sol.x[0]);
+    }
+
+    /// **gh #401.** A real bound past the *opposite* absent-bound sentinel is
+    /// an ordinary bound, and must survive into `G`.
+    ///
+    /// `is_finite_bound` was `|v| < 1e19`, a symmetric magnitude test. An upper
+    /// bound of `-5e20` failed it and the row `x_0 <= -5e20` never entered `G`,
+    /// so the QP was solved over a strictly larger box — `min x_0` subject to
+    /// nothing, which the IPM answers `Optimal` at a point the model excludes.
+    #[test]
+    fn variable_bound_past_the_opposite_sentinel_is_kept() {
+        let prob = NlProblem {
+            n: 1,
+            m: 0,
+            num_obj: 1,
+            minimize: false, // maximize x0, so the -5e20 upper bound binds
+            obj_nonlinear: Expr::Const(0.0),
+            obj_linear: vec![(0, 1.0)],
+            obj_constant: 0.0,
+            con_nonlinear: vec![],
+            con_linear: vec![],
+            // No lower bound (`-1e21` is past the lower sentinel, so absent);
+            // a real upper bound of `-5e20`, which is *not*.
+            x_l: vec![-1e21],
+            x_u: vec![-5e20],
+            g_l: vec![],
+            g_u: vec![],
+            x0: vec![-7e20],
+            lambda0: vec![],
+            suffixes: Default::default(),
+            imported_funcs: Vec::new(),
+            var_names: Vec::new(),
+            con_names: Vec::new(),
+        };
+        let qp = extract_qp(&prob).expect("extract");
+        assert_eq!(
+            qp.m_ineq(),
+            1,
+            "`x0 <= -5e20` is a real bound and must become a G row; the \
+             symmetric |v| < 1e19 test dropped it, leaving 0 rows and an \
+             unbounded-above box the model does not declare"
+        );
+        assert_eq!(qp.h[0], -5e20, "the upper bound's RHS");
+    }
+
+    /// **gh #401.** A row with equal bounds past the sentinel used to vanish
+    /// from the problem *entirely* — contributing nothing to `A` and nothing
+    /// to `G`.
+    ///
+    /// Directionally, `g_l = g_u = -5e20` is not an equality at all: the lower
+    /// bound is absent (it is past `-1e19`) and the upper bound is real, so the
+    /// row is the one-sided `x0 + x1 <= -5e20`. The old code got there by a
+    /// different route and lost it: `lo == hi && is_finite_bound(lo)` failed, so
+    /// the row fell into the inequality branch — where `is_finite_bound(hi)` and
+    /// `is_finite_bound(lo)` were false too, leaving `upper` and `lower` both
+    /// `None`. Silently deleted.
+    ///
+    /// (Note there is no such thing as an equality row outside `±1e19` under
+    /// this convention: an equality needs both bounds present, and the two
+    /// presence tests only overlap inside the band.)
+    #[test]
+    fn a_row_with_equal_bounds_past_the_sentinel_does_not_vanish() {
+        let prob = NlProblem {
+            n: 2,
+            m: 1,
+            num_obj: 1,
+            minimize: true,
+            obj_nonlinear: Expr::Const(0.0),
+            obj_linear: vec![(0, 1.0)],
+            obj_constant: 0.0,
+            con_nonlinear: vec![Expr::Const(0.0)],
+            con_linear: vec![vec![(0, 1.0), (1, 1.0)]],
+            x_l: vec![-2e19, -2e19],
+            x_u: vec![2e19, 2e19],
+            g_l: vec![-5e20],
+            g_u: vec![-5e20],
+            x0: vec![0.0, 0.0],
+            lambda0: vec![0.0],
+            suffixes: Default::default(),
+            imported_funcs: Vec::new(),
+            var_names: Vec::new(),
+            con_names: Vec::new(),
+        };
+        let qp = extract_qp(&prob).expect("extract");
+        assert_eq!(
+            qp.m_eq(),
+            0,
+            "the lower bound is absent, so this is no equality"
+        );
+        assert_eq!(
+            qp.m_ineq(),
+            1,
+            "`x0 + x1 <= -5e20` is a real constraint and must reach G; it used \
+             to disappear from the problem entirely"
+        );
+        assert_eq!(qp.h[0], -5e20);
+    }
+
+    /// **gh #401.** `recover_bound_mults` walks the G-row layout with the same
+    /// predicate the builder uses, so the two must agree or the returned
+    /// `z_lb` / `z_ub` shift by a row. Pins them together on a box that only
+    /// the directional reading admits.
+    #[test]
+    fn bound_multipliers_stay_aligned_with_the_built_rows() {
+        let prob = NlProblem {
+            n: 2,
+            m: 0,
+            num_obj: 1,
+            minimize: true,
+            obj_nonlinear: Expr::Const(0.0),
+            obj_linear: vec![(0, 1.0), (1, 1.0)],
+            obj_constant: 0.0,
+            con_nonlinear: vec![],
+            con_linear: vec![],
+            // x0: upper bound past the *lower* sentinel, no lower bound.
+            // x1: an ordinary two-sided box.
+            x_l: vec![-2e19, 0.0],
+            x_u: vec![-5e20, 1.0],
+            g_l: vec![],
+            g_u: vec![],
+            x0: vec![-6e20, 0.5],
+            lambda0: vec![],
+            suffixes: Default::default(),
+            imported_funcs: Vec::new(),
+            var_names: Vec::new(),
+            con_names: Vec::new(),
+        };
+        let qp = extract_qp(&prob).expect("extract");
+        // x0 contributes 1 row (upper only); x1 contributes 2 (upper, lower).
+        assert_eq!(qp.m_ineq(), 3);
+        // Tag each G row with its index so a misalignment is visible.
+        let z = vec![10.0, 20.0, 30.0];
+        let (z_lb, z_ub) = recover_bound_mults(&prob, 0, &z);
+        assert_eq!(z_ub[0], 10.0, "row 0 is x0's upper bound");
+        assert_eq!(z_lb[0], 0.0, "x0 has no lower bound");
+        assert_eq!(z_ub[1], 20.0, "row 1 is x1's upper bound");
+        assert_eq!(z_lb[1], 30.0, "row 2 is x1's lower bound");
     }
 }

--- a/crates/pounce-common/src/types.rs
+++ b/crates/pounce-common/src/types.rs
@@ -16,3 +16,60 @@ pub type Index = i32;
 /// Value `1e19` is hard-coded throughout upstream; we match it.
 pub const NLP_LOWER_BOUND_INF: Number = -1e19;
 pub const NLP_UPPER_BOUND_INF: Number = 1e19;
+
+/// Is this *lower* bound a real bound, or the absent-bound sentinel?
+///
+/// The sentinel convention is **directional**, and reading it as a magnitude
+/// is a bug this codebase has now hit four separate times (#396, #398, #401,
+/// #402). A lower bound is absent only at or below [`NLP_LOWER_BOUND_INF`];
+/// `-5e20` is an ordinary finite lower bound, not "beyond infinity", and a
+/// symmetric `|b| < 1e19` test silently discards it.
+///
+/// Pair with [`upper_bound_present`] and decide presence *before* comparing a
+/// pair: `lo > hi` means nothing until both sides are known to be real, and
+/// neither does `lo == hi` (an "equality" at the sentinel is a one-sided row).
+///
+/// Callers that override the thresholds via `nlp_lower_bound_inf` /
+/// `nlp_upper_bound_inf` must test against their own values instead — these
+/// helpers hard-code the defaults.
+#[inline]
+pub fn lower_bound_present(lo: Number) -> bool {
+    lo.is_finite() && lo > NLP_LOWER_BOUND_INF
+}
+
+/// Is this *upper* bound a real bound, or the absent-bound sentinel?
+/// See [`lower_bound_present`] — an upper bound is absent only at or above
+/// [`NLP_UPPER_BOUND_INF`].
+#[inline]
+pub fn upper_bound_present(hi: Number) -> bool {
+    hi.is_finite() && hi < NLP_UPPER_BOUND_INF
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn presence_is_directional_not_symmetric() {
+        // Sentinels: absent on their own side.
+        assert!(!lower_bound_present(NLP_LOWER_BOUND_INF));
+        assert!(!upper_bound_present(NLP_UPPER_BOUND_INF));
+        assert!(!lower_bound_present(-2.0e19));
+        assert!(!upper_bound_present(2.0e19));
+
+        // Past the *opposite* sentinel: an ordinary bound, not an absent one.
+        // A symmetric `|b| < 1e19` test gets both of these wrong.
+        assert!(upper_bound_present(-5.0e20));
+        assert!(lower_bound_present(5.0e20));
+
+        // True infinities are absent on either side.
+        assert!(!lower_bound_present(Number::NEG_INFINITY));
+        assert!(!upper_bound_present(Number::INFINITY));
+        assert!(!lower_bound_present(Number::NAN));
+        assert!(!upper_bound_present(Number::NAN));
+
+        // Ordinary bounds.
+        assert!(lower_bound_present(0.0));
+        assert!(upper_bound_present(0.0));
+    }
+}


### PR DESCRIPTION
Fixes #401.

Third in the absent-bound-sentinel family, after #396 (presolve certified a
feasible model infeasible) and #398 / #400 (`TNLPAdapter` refused to solve one).
This one is the worst of the three, because it fails **silently**: it does not
misclassify a constraint, it deletes it, and the convex solver then reports
`Optimal` at a point the model's own bounds exclude.

## The predicate

Two independent copies of a symmetric magnitude test:

```rust
// pounce-cli/src/qp_extract.rs:36  and  pounce-cli/src/dispatch.rs:98
fn is_finite_bound(v: f64) -> bool {
    v.abs() < NL_INF          // NL_INF = 1e19
}
```

Presence is directional. A lower bound is absent only at or below `-1e19`, an
upper bound only at or above `+1e19`. A real upper bound of `-5e20` is an
ordinary bound — `|v| < 1e19` is the wrong question about it.

## Three wrong answers

1. **A real variable bound never entered `G`.** `x_u = -5e20` failed the test,
   so `x_i <= -5e20` was never built and the QP was solved over a strictly
   larger box. Mirror case for a real `x_l = +5e20`.
2. **A row with equal bounds past the sentinel vanished entirely.**
   `lo == hi && is_finite_bound(lo)` failed, so the row fell into the inequality
   branch — where `is_finite_bound(hi)` and `is_finite_bound(lo)` were false
   too, leaving `upper` and `lower` both `None`. Nothing in `A`, nothing in `G`.
3. **A real quadratic row was skipped as "vacuous".** `g(x) >= 5e20` arrives as
   `g_l = 5e20` (real), `g_u = 1e19` (sentinel); both tests false, so the row hit
   `continue` under the comment "Free row: imposes nothing". The model then
   classified as a convex QCQP and went to the conic solver *as if the
   constraint were not there*. It is reverse-convex — the honest answer is NLP,
   which is what it now returns.

## The fix

One shared directional pair added next to `NLP_LOWER_BOUND_INF` /
`NLP_UPPER_BOUND_INF` in `pounce-common::types`:

```rust
pub fn lower_bound_present(lo: Number) -> bool { lo.is_finite() && lo > NLP_LOWER_BOUND_INF }
pub fn upper_bound_present(hi: Number) -> bool { hi.is_finite() && hi < NLP_UPPER_BOUND_INF }
```

There is now **one** spelling of this predicate in the tree to maintain, rather
than the several that #396, #398 and this issue each turned up independently.
#402 and #403 can adopt it directly.

The equality test is additionally gated on *both* bounds being present, the same
way #398 did in `classify_bounds`. `recover_bound_mults` (`qp_extract.rs:296`)
walks the G-row layout with the same predicate and was *consistent* with the
buggy builder, so it moved in lockstep.

## A correction to the issue as I filed it

I described case 2 as a lost **equality** row. That was wrong about the
mechanism, though not about the outcome. An equality row outside `±1e19` cannot
be expressed under this convention at all: an equality needs both bounds
present, and the two presence tests only overlap *inside* the band. So
`g_l = g_u = -5e20` is not an equality at `-5e20` — it is the one-sided
`g <= -5e20` with no lower bound. The row was genuinely being lost; what it
should become is a one-sided inequality, which is what the test now pins. Same
correction noted in the CHANGELOG.

I caught this because the test I wrote from the issue's wording failed against
the *fixed* code.

## Verification

All four regression tests were run against the old symmetric predicate to
confirm they actually catch the defect:

```
test qp_extract::tests::a_row_with_equal_bounds_past_the_sentinel_does_not_vanish ... FAILED
test qp_extract::tests::bound_multipliers_stay_aligned_with_the_built_rows ... FAILED
test qp_extract::tests::variable_bound_past_the_opposite_sentinel_is_kept ... FAILED
test dispatch::tests::a_quadratic_row_bounded_past_the_sentinel_is_not_vacuous ... FAILED
test result: FAILED. 0 passed; 4 failed
```

All pass with the fix, plus `presence_is_directional_not_symmetric` on the new
shared helpers.

Full workspace suite: **163 binaries, 2254 tests, 0 failures** (up 5 from the
2249 on `main`). `cargo fmt --check` clean.

## Related

- #396 — presolve's witness gate, same sentinel
- #398 / #400 — `TNLPAdapter`, merged
- #402 — presolve can still certify infeasibility from this; open
- #403 — `verify` / `check-x0` / Python preflight under-report; open

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
