### PR TITLE
Read bound presence directionally in verify, check-x0 and preflight (#403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `verify` accepted a `.sol` that violates a bound past the opposite sentinel (#403)
+
+- **`pounce verify` no longer reports ACCEPTED for a solution outside the
+  model's declared box.** `verify` exists to be the *independent* check on a
+  `.sol`, so a checker that under-reports is worth more than its blast radius
+  suggests — this is the surface a user reaches for when they doubt the solver.
+- **Cause:** `is_finite_bound(b) = b > NLP_LOWER_BOUND_INF && b < NLP_UPPER_BOUND_INF`
+  — a *band* membership test, applied to `lo` and `hi` alike. A real upper bound
+  of `-5e20` failed it, so `box_violation`'s `above` term became `-inf` and the
+  violation read `0.0`. Mirror case for a real lower bound of `+5e20`. The same
+  predicate also sized `row_magnitude`, so a row written at `5e20` scale
+  reported a magnitude ignoring its own bound — which then fed the
+  scale-relative feasibility comparison.
+- The existing coverage pinned only the *sentinel* case, so it passed either
+  way. That is why this survived.
+- **`pounce check-x0` shared the helper** and used it for bound-activity
+  counting and `clamp_to_interior`, so a real out-of-range bound was not clamped
+  against and the reported starting point was not the one the solver would
+  actually begin from. Note the irony: `check-x0` measuring a fixture at exactly
+  zero violation is what established the #396/#398 model was feasible in the
+  first place.
+- Two further equality/fixed-variable tests in `verify.rs` were gated on
+  presence at the same time, the same class #398 and #402 fixed: a row with
+  `g_l = g_u = -5e20` is the one-sided `g <= -5e20`, not an equality, and
+  skipping it dropped a real complementarity term.
+- **The Python surfaces carried exact twins**, now directional too:
+  `python/pounce/_preflight.py` (`_box_violation`, `_clamp_to_interior`,
+  `at_lo`/`at_hi`), `python/pounce/_starts.py`,
+  `pyomo-pounce/pyomo_pounce/preflight.py`, and
+  `pyomo-pounce/pyomo_pounce/block_init.py` — where `_seed_var` on a variable
+  with `ub = -5e20` and no `lb` fell through to seeding `0.0`, outside the
+  variable's own declared box.
+- Five regression tests (two Rust, three Python), all verified to fail against
+  the old band predicate.
+- **This closes the sentinel family opened by #396.** Four issues, one root
+  cause: reading a directional convention as a magnitude. Every site now goes
+  through the shared `lower_bound_present` / `upper_bound_present` helpers
+  introduced in #401.
+  - Checked and deliberately left alone: `python/pounce/_route.py` uses plain
+    `np.isfinite`, which is *correct* there — its bounds come from
+    `_normalize_bounds` (scipy `±inf`) and `_wrap_constraints`, neither of which
+    uses the sentinel convention. `python/pounce/gams/link.py` and
+    `gams/gams_pounce.c` were already directional by construction.
+
 ### Fixed — presolve could still certify infeasibility from an absent-bound sentinel (#402)
 
 - **The last of the presolve machinery behind #396's witness gate now reads the

--- a/crates/pounce-cli/src/check_x0.rs
+++ b/crates/pounce-cli/src/check_x0.rs
@@ -32,8 +32,8 @@
 //! User-facing background: `docs/src/initialization.md`.
 
 use crate::nl_reader;
-use crate::verify::{RowReport, box_violation, is_finite_bound, name_at, sha256};
-use pounce_common::types::Number;
+use crate::verify::{RowReport, box_violation, name_at, sha256};
+use pounce_common::types::{Number, lower_bound_present, upper_bound_present};
 use pounce_nlp::tnlp::{BoundsInfo, SparsityRequest, StartingPoint, TNLP};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -522,9 +522,9 @@ pub fn check_tnlp(
         }
         if x[j].is_finite() {
             let at_lo =
-                is_finite_bound(x_l[j]) && (x[j] - x_l[j]).abs() <= 1e-8 * (1.0 + x_l[j].abs());
+                lower_bound_present(x_l[j]) && (x[j] - x_l[j]).abs() <= 1e-8 * (1.0 + x_l[j].abs());
             let at_hi =
-                is_finite_bound(x_u[j]) && (x_u[j] - x[j]).abs() <= 1e-8 * (1.0 + x_u[j].abs());
+                upper_bound_present(x_u[j]) && (x_u[j] - x[j]).abs() <= 1e-8 * (1.0 + x_u[j].abs());
             if at_lo || at_hi {
                 n_on_bounds += 1;
             }
@@ -719,7 +719,7 @@ pub fn clamp_to_interior(
     bound_push: Number,
     bound_frac: Number,
 ) -> Number {
-    match (is_finite_bound(lo), is_finite_bound(hi)) {
+    match (lower_bound_present(lo), upper_bound_present(hi)) {
         (true, true) => {
             let span = hi - lo;
             let p_l = (bound_push * lo.abs().max(1.0)).min(bound_frac * span);

--- a/crates/pounce-cli/src/verify.rs
+++ b/crates/pounce-cli/src/verify.rs
@@ -42,7 +42,7 @@
 
 use crate::nl_reader;
 use pounce_common::tolerance::is_negligible;
-use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF, Number};
+use pounce_common::types::{Number, lower_bound_present, upper_bound_present};
 use pounce_nlp::tnlp::{BoundsInfo, IndexStyle, SparsityRequest, TNLP};
 use std::path::PathBuf;
 use std::process::ExitCode;
@@ -192,9 +192,13 @@ pub struct RowReport {
     pub violation: Number,
 }
 
-pub(crate) fn is_finite_bound(b: Number) -> bool {
-    b > NLP_LOWER_BOUND_INF && b < NLP_UPPER_BOUND_INF
-}
+// `is_finite_bound(b) = b > NLP_LOWER_BOUND_INF && b < NLP_UPPER_BOUND_INF`
+// used to live here — a *band* membership test applied to lower and upper
+// bounds alike (gh #403). A real upper bound of `-5e20` failed it, so
+// `box_violation` scored `0.0` against it and `verify` reported ACCEPTED for a
+// `.sol` that violates a declared bound. Presence is directional; use
+// `lower_bound_present` / `upper_bound_present` from `pounce_common::types`,
+// picking the one that matches the side you hold.
 
 /// `g_l ≤ v ≤ g_u` violation: how far `v` is outside the box, 0 if inside.
 ///
@@ -211,10 +215,10 @@ pub(crate) fn is_finite_bound(b: Number) -> bool {
 /// information and are skipped.
 pub(crate) fn row_magnitude(value: Number, lo: Number, hi: Number) -> Number {
     let mut m = if value.is_finite() { value.abs() } else { 0.0 };
-    if is_finite_bound(lo) {
+    if lower_bound_present(lo) {
         m = m.max(lo.abs());
     }
-    if is_finite_bound(hi) {
+    if upper_bound_present(hi) {
         m = m.max(hi.abs());
     }
     m
@@ -250,12 +254,12 @@ pub(crate) fn box_violation(v: Number, lo: Number, hi: Number) -> Number {
     if !v.is_finite() {
         return Number::INFINITY;
     }
-    let below = if is_finite_bound(lo) {
+    let below = if lower_bound_present(lo) {
         lo - v
     } else {
         Number::NEG_INFINITY
     };
-    let above = if is_finite_bound(hi) {
+    let above = if upper_bound_present(hi) {
         v - hi
     } else {
         Number::NEG_INFINITY
@@ -522,10 +526,13 @@ fn stationarity_residual(
     // Activity tolerance for "x_j sits on a bound."
     let mut dual_inf = 0.0_f64;
     for j in 0..n {
-        let at_lo = is_finite_bound(x_l[j]) && (x[j] - x_l[j]).abs() <= 1e-8 * (1.0 + x_l[j].abs());
-        let at_hi = is_finite_bound(x_u[j]) && (x_u[j] - x[j]).abs() <= 1e-8 * (1.0 + x_u[j].abs());
-        let fixed =
-            is_finite_bound(x_l[j]) && is_finite_bound(x_u[j]) && (x_u[j] - x_l[j]).abs() <= 1e-12;
+        let at_lo =
+            lower_bound_present(x_l[j]) && (x[j] - x_l[j]).abs() <= 1e-8 * (1.0 + x_l[j].abs());
+        let at_hi =
+            upper_bound_present(x_u[j]) && (x_u[j] - x[j]).abs() <= 1e-8 * (1.0 + x_u[j].abs());
+        let fixed = lower_bound_present(x_l[j])
+            && upper_bound_present(x_u[j])
+            && (x_u[j] - x_l[j]).abs() <= 1e-12;
         let r = if fixed {
             0.0
         } else if at_lo && !at_hi {
@@ -553,15 +560,21 @@ fn constraint_complementarity(
 ) -> Number {
     let mut comp = 0.0_f64;
     for i in 0..lambda.len() {
-        if (g_u[i] - g_l[i]).abs() <= 1e-12 {
+        // An equality needs *both* bounds present (gh #403): `g_l = g_u = -5e20`
+        // is the one-sided `g <= -5e20`, not an equality at `-5e20`, and
+        // skipping it here would drop a real complementarity term.
+        if lower_bound_present(g_l[i])
+            && upper_bound_present(g_u[i])
+            && (g_u[i] - g_l[i]).abs() <= 1e-12
+        {
             continue; // equality: multiplier is free, no complementarity
         }
-        let dl = if is_finite_bound(g_l[i]) {
+        let dl = if lower_bound_present(g_l[i]) {
             (g[i] - g_l[i]).abs()
         } else {
             Number::INFINITY
         };
-        let du = if is_finite_bound(g_u[i]) {
+        let du = if upper_bound_present(g_u[i]) {
             (g_u[i] - g[i]).abs()
         } else {
             Number::INFINITY
@@ -1019,6 +1032,7 @@ pub mod sha256 {
 mod tests {
     use super::*;
     use crate::nl_writer::{SolutionFile, format_sol};
+    use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
 
     #[test]
     fn sha256_known_answers() {
@@ -1127,6 +1141,52 @@ mod tests {
         assert_eq!(
             box_violation(Number::NEG_INFINITY, NLP_LOWER_BOUND_INF, 10.0),
             Number::INFINITY
+        );
+    }
+
+    /// **gh #403.** `verify` exists to be the independent check on a `.sol`.
+    /// A checker that under-reports is worse than its blast radius suggests.
+    ///
+    /// `is_finite_bound` was a *band* membership test —
+    /// `b > NLP_LOWER_BOUND_INF && b < NLP_UPPER_BOUND_INF` — applied to `lo`
+    /// and `hi` alike. A real upper bound of `-5e20` failed it, so `above`
+    /// became `-inf` and the violation read `0.0`: **ACCEPTED for a `.sol` that
+    /// violates a declared bound.**
+    #[test]
+    fn a_bound_past_the_opposite_sentinel_still_scores_a_violation() {
+        // x <= -5e20, no lower bound. The point 0.0 violates it by 5e20.
+        let v = box_violation(0.0, NLP_LOWER_BOUND_INF, -5.0e20);
+        assert_eq!(
+            v, 5.0e20,
+            "0 is 5e20 above an upper bound of -5e20; scoring it 0.0 lets a \
+             fabricated .sol past the feasibility gate"
+        );
+        // Mirror: x >= 5e20, no upper bound.
+        assert_eq!(box_violation(0.0, 5.0e20, NLP_UPPER_BOUND_INF), 5.0e20);
+        // A point that does satisfy the same bound still scores zero.
+        assert_eq!(box_violation(-6.0e20, NLP_LOWER_BOUND_INF, -5.0e20), 0.0);
+        // And the sentinels themselves still mean "no bound".
+        assert_eq!(
+            box_violation(1e30, NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF),
+            0.0
+        );
+    }
+
+    /// The same predicate sizes a row's magnitude for the scale-relative
+    /// feasibility test. A row written at `5e20` must report that magnitude,
+    /// not fall back to its evaluated value alone.
+    #[test]
+    fn row_magnitude_counts_a_bound_past_the_opposite_sentinel() {
+        assert_eq!(
+            row_magnitude(1.0, NLP_LOWER_BOUND_INF, -5.0e20),
+            5.0e20,
+            "the row's own upper bound is its magnitude"
+        );
+        assert_eq!(row_magnitude(1.0, 5.0e20, NLP_UPPER_BOUND_INF), 5.0e20);
+        // Absent on both sides: only the evaluated value carries magnitude.
+        assert_eq!(
+            row_magnitude(3.0, NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF),
+            3.0
         );
     }
 }

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -381,16 +381,20 @@ def _seed_pin(v) -> None:
     if v.value != 0.0:
         return
     lo, hi = v.lb, v.ub
-    finite = lambda b: b is not None and abs(b) < 1e19  # noqa: E731
-    if finite(lo) and finite(hi):
+    # Directional presence (gh #403): `abs(b) < 1e19` called a real bound of
+    # -5e20 absent, and this fell through to seeding 0.0 — outside the
+    # variable's own declared box.
+    lo_ok = lo is not None and lo > -1e19
+    hi_ok = hi is not None and hi < 1e19
+    if lo_ok and hi_ok:
         for frac in (0.75, 0.6):  # midpoint was zero; try off-center
             cand = lo + frac * (hi - lo)
             if cand != 0.0:
                 v.set_value(cand, skip_validation=True)
                 return
-    elif finite(lo):
+    elif lo_ok:
         v.set_value(lo + 2.0, skip_validation=True)  # lo + 1 was zero
-    elif finite(hi):
+    elif hi_ok:
         v.set_value(hi - 2.0, skip_validation=True)  # hi - 1 was zero
     else:
         v.set_value(1.0, skip_validation=True)
@@ -826,12 +830,16 @@ def block_initialize(
 def _seed_var(v) -> None:
     """Bounds-aware Newton seed for a valueless variable."""
     lo, hi = v.lb, v.ub
-    finite = lambda b: b is not None and abs(b) < 1e19  # noqa: E731
-    if finite(lo) and finite(hi):
+    # Directional presence (gh #403): `abs(b) < 1e19` called a real bound of
+    # -5e20 absent, and this fell through to seeding 0.0 — outside the
+    # variable's own declared box.
+    lo_ok = lo is not None and lo > -1e19
+    hi_ok = hi is not None and hi < 1e19
+    if lo_ok and hi_ok:
         v.set_value(0.5 * (lo + hi), skip_validation=True)
-    elif finite(lo):
+    elif lo_ok:
         v.set_value(lo + 1.0, skip_validation=True)
-    elif finite(hi):
+    elif hi_ok:
         v.set_value(hi - 1.0, skip_validation=True)
     else:
         v.set_value(0.0, skip_validation=True)

--- a/pyomo-pounce/pyomo_pounce/preflight.py
+++ b/pyomo-pounce/pyomo_pounce/preflight.py
@@ -29,15 +29,26 @@ from typing import List, Optional, Tuple
 __all__ = ["preflight", "PyomoPreflightReport", "initialize_missing_values"]
 
 
-def _finite(b: Optional[float]) -> bool:
-    return b is not None and math.isfinite(b) and abs(b) < 1e19
+def _lower_present(b: Optional[float]) -> bool:
+    """Is this *lower* bound real, or the absent-bound sentinel?
+
+    Directional, not a magnitude test (gh #403): the ``abs(b) < 1e19`` form this
+    replaced called a real upper bound of ``-5e20`` absent, so ``_box_violation``
+    reported 0.0 against a bound the point actually violates.
+    """
+    return b is not None and math.isfinite(b) and b > -1e19
+
+
+def _upper_present(b: Optional[float]) -> bool:
+    """Is this *upper* bound real? See :func:`_lower_present`."""
+    return b is not None and math.isfinite(b) and b < 1e19
 
 
 def _box_violation(v: float, lo: Optional[float], hi: Optional[float]) -> float:
     if v is None or not math.isfinite(v):
         return math.inf
-    below = (lo - v) if _finite(lo) else -math.inf
-    above = (v - hi) if _finite(hi) else -math.inf
+    below = (lo - v) if _lower_present(lo) else -math.inf
+    above = (v - hi) if _upper_present(hi) else -math.inf
     return max(below, above, 0.0)
 
 
@@ -142,8 +153,8 @@ def preflight(model, feas_tol: float = 1e-6, max_list: int = 5) -> PyomoPrefligh
                 n_bound_violations += 1
                 bound_violations.append((v.name, val, lo, hi, viol))
             if val is not None and math.isfinite(val):
-                at_lo = _finite(lo) and abs(val - lo) <= 1e-8 * (1.0 + abs(lo))
-                at_hi = _finite(hi) and abs(hi - val) <= 1e-8 * (1.0 + abs(hi))
+                at_lo = _lower_present(lo) and abs(val - lo) <= 1e-8 * (1.0 + abs(lo))
+                at_hi = _upper_present(hi) and abs(hi - val) <= 1e-8 * (1.0 + abs(hi))
                 if at_lo or at_hi:
                     n_on_bounds += 1
         bound_violations.sort(key=lambda t: -t[4])
@@ -251,11 +262,11 @@ def initialize_missing_values(model, strategy: str = "midpoint") -> int:
         val = 0.0
         if strategy == "midpoint":
             lo, hi = v.lb, v.ub
-            if _finite(lo) and _finite(hi):
+            if _lower_present(lo) and _upper_present(hi):
                 val = 0.5 * (lo + hi)
-            elif _finite(lo):
+            elif _lower_present(lo):
                 val = lo + 1.0
-            elif _finite(hi):
+            elif _upper_present(hi):
                 val = hi - 1.0
         v.set_value(val, skip_validation=True)
         count += 1

--- a/pyomo-pounce/tests/test_preflight.py
+++ b/pyomo-pounce/tests/test_preflight.py
@@ -121,3 +121,15 @@ def test_preflight_then_init_clears_warning():
     report = pyomo_pounce.preflight(m)
     assert not report.fatal
     assert math.isfinite(report.objective)
+
+
+def test_box_violation_scores_a_bound_past_the_opposite_sentinel():
+    """gh #403. ``abs(b) < 1e19`` called a real upper bound of -5e20 absent."""
+    from pyomo_pounce.preflight import _box_violation
+
+    assert _box_violation(0.0, None, -5e20) == 5e20
+    assert _box_violation(0.0, 5e20, None) == 5e20
+    assert _box_violation(-6e20, None, -5e20) == 0.0
+    # An absent bound is still absent.
+    assert _box_violation(1e30, None, None) == 0.0
+    assert _box_violation(1e30, -1e19, 1e19) == 0.0

--- a/python/pounce/_preflight.py
+++ b/python/pounce/_preflight.py
@@ -186,15 +186,28 @@ def _as_bounds(bound, n: int, default: float) -> np.ndarray:
     return b
 
 
-def _finite_bound(b: float) -> bool:
-    return bool(np.isfinite(b)) and -_BOUND_INF < b < _BOUND_INF
+def _lower_present(b: float) -> bool:
+    """Is this *lower* bound real, or the absent-bound sentinel?
+
+    Presence is directional (gh #403). The single ``-_BOUND_INF < b <
+    _BOUND_INF`` band test this replaced was applied to both sides, so a real
+    upper bound of ``-5e20`` read as absent and ``_box_violation`` scored 0.0
+    against it — the report said a starting point was inside a box it is
+    outside of.
+    """
+    return bool(np.isfinite(b)) and b > -_BOUND_INF
+
+
+def _upper_present(b: float) -> bool:
+    """Is this *upper* bound real? See :func:`_lower_present`."""
+    return bool(np.isfinite(b)) and b < _BOUND_INF
 
 
 def _box_violation(v: float, lo: float, hi: float) -> float:
     if not np.isfinite(v):
         return float("inf")
-    below = lo - v if _finite_bound(lo) else -float("inf")
-    above = v - hi if _finite_bound(hi) else -float("inf")
+    below = lo - v if _lower_present(lo) else -float("inf")
+    above = v - hi if _upper_present(hi) else -float("inf")
     return max(below, above, 0.0)
 
 
@@ -203,7 +216,7 @@ def _clamp_to_interior(
 ) -> float:
     """The per-component interior clamp from the solver's
     ``DefaultIterateInitializer`` (see docs/src/initialization.md)."""
-    flo, fhi = _finite_bound(lo), _finite_bound(hi)
+    flo, fhi = _lower_present(lo), _upper_present(hi)
     if flo and fhi:
         span = hi - lo
         p_l = min(bound_push * max(abs(lo), 1.0), bound_frac * span)
@@ -349,10 +362,10 @@ def preflight(
                 max_bound_violation = max(max_bound_violation, viol)
             bound_violations.append((j, float(x0[j]), float(x_l[j]), float(x_u[j]), viol))
         if np.isfinite(x0[j]):
-            at_lo = _finite_bound(x_l[j]) and abs(x0[j] - x_l[j]) <= 1e-8 * (
+            at_lo = _lower_present(x_l[j]) and abs(x0[j] - x_l[j]) <= 1e-8 * (
                 1.0 + abs(x_l[j])
             )
-            at_hi = _finite_bound(x_u[j]) and abs(x_u[j] - x0[j]) <= 1e-8 * (
+            at_hi = _upper_present(x_u[j]) and abs(x_u[j] - x0[j]) <= 1e-8 * (
                 1.0 + abs(x_u[j])
             )
             if at_lo or at_hi:

--- a/python/pounce/_starts.py
+++ b/python/pounce/_starts.py
@@ -73,8 +73,15 @@ def _clip(x, bounds):
     return np.clip(x, lo, hi)
 
 
-def _finite(b) -> bool:
-    return b is not None and np.isfinite(b) and -_BOUND_INF < b < _BOUND_INF
+def _lower_present(b) -> bool:
+    """Is this *lower* bound real, or the absent-bound sentinel? Directional,
+    not a magnitude band (gh #403)."""
+    return b is not None and np.isfinite(b) and b > -_BOUND_INF
+
+
+def _upper_present(b) -> bool:
+    """Is this *upper* bound real? See :func:`_lower_present`."""
+    return b is not None and np.isfinite(b) and b < _BOUND_INF
 
 
 def _midpoint(bounds, x0, n):
@@ -87,7 +94,7 @@ def _midpoint(bounds, x0, n):
     for j, b in enumerate(bounds):
         lo = b[0] if b is not None else None
         hi = b[1] if b is not None else None
-        flo, fhi = _finite(lo), _finite(hi)
+        flo, fhi = _lower_present(lo), _upper_present(hi)
         if flo and fhi:
             out[j] = 0.5 * (lo + hi)
         elif flo:
@@ -234,8 +241,8 @@ def project_to_feasible(
 
     A_rows, b_rows, G_rows, h_rows = [], [], [], []
     for i in range(m):
-        lo_f = _finite(g_l[i])
-        hi_f = _finite(g_u[i])
+        lo_f = _lower_present(g_l[i])
+        hi_f = _upper_present(g_u[i])
         eq = abs(g_u[i] - g_l[i]) <= 1e-12 if (lo_f and hi_f) else False
         if eq:
             A_rows.append(J[i])

--- a/python/tests/test_preflight.py
+++ b/python/tests/test_preflight.py
@@ -122,3 +122,32 @@ def test_report_dict_and_str():
     assert d["fatal"] is False
     text = str(r)
     assert "VERDICT" in text and "preflight" in text
+
+
+def test_box_violation_scores_a_bound_past_the_opposite_sentinel():
+    """gh #403. Presence is directional, not a magnitude band.
+
+    ``_finite_bound`` was ``-_BOUND_INF < b < _BOUND_INF`` applied to both
+    sides, so a real upper bound of ``-5e20`` read as absent and the violation
+    scored 0.0 — the report said a starting point was inside a box it is
+    outside of.
+    """
+    from pounce._preflight import _BOUND_INF, _box_violation
+
+    # x <= -5e20, no lower bound. The point 0.0 misses it by 5e20.
+    assert _box_violation(0.0, -_BOUND_INF, -5e20) == 5e20
+    # Mirror: x >= 5e20, no upper bound.
+    assert _box_violation(0.0, 5e20, _BOUND_INF) == 5e20
+    # A point that satisfies the same bound still scores zero.
+    assert _box_violation(-6e20, -_BOUND_INF, -5e20) == 0.0
+    # The sentinels themselves still mean "no bound".
+    assert _box_violation(1e30, -_BOUND_INF, _BOUND_INF) == 0.0
+
+
+def test_clamp_to_interior_respects_a_bound_past_the_opposite_sentinel():
+    """The clamp reports the point the solver would actually start from."""
+    from pounce._preflight import _BOUND_INF, _clamp_to_interior
+
+    # Upper bound only, at -5e20: a point above it must be pulled inside.
+    out = _clamp_to_interior(0.0, -_BOUND_INF, -5e20, 1e-2, 1e-2)
+    assert out < -5e20, f"expected a point strictly inside x <= -5e20, got {out}"


### PR DESCRIPTION
Fixes #403.

Last of the absent-bound-sentinel family opened by #396, after #398/#400,
#401/#404 and #402/#405. Four issues, one root cause: reading a directional
convention as a magnitude.

## `pounce verify` accepted a `.sol` that violates a declared bound

```rust
// crates/pounce-cli/src/verify.rs
pub(crate) fn is_finite_bound(b: Number) -> bool {
    b > NLP_LOWER_BOUND_INF && b < NLP_UPPER_BOUND_INF
}
```

A *band* membership test, applied to `lo` and `hi` alike. A real upper bound of
`-5e20` failed it, so `box_violation`'s `above` term became `-inf` and the
violation read `0.0` — **ACCEPTED** for a point 5e20 outside the box. Mirror
case for a real lower bound of `+5e20`.

This matters more than the blast radius suggests: `verify` is the *independent*
check on a `.sol`, the surface a user reaches for when they doubt the solver.

The same predicate sized `row_magnitude`, so a row written at `5e20` scale
reported a magnitude that ignores its own bound — which then feeds the
scale-relative feasibility comparison.

**The existing coverage pinned only the sentinel case**, so it passed either
way. That is why this survived.

## `check-x0`, and two more equality tests

`check_x0.rs` imported the same helper for bound-activity counting and
`clamp_to_interior`, so a real out-of-range bound was not clamped against and
the reported starting point was not the one the solver would actually begin
from. (Some irony: `check-x0` measuring a fixture at exactly zero violation is
what established the #396/#398 model was feasible in the first place.)

Two equality/fixed-variable tests in `verify.rs` are gated on presence at the
same time — the same class #398 and #402 fixed. A row with `g_l = g_u = -5e20`
is the one-sided `g <= -5e20`, not an equality, and skipping it dropped a real
complementarity term.

## Python twins

Now directional too: `python/pounce/_preflight.py` (`_box_violation`,
`_clamp_to_interior`, `at_lo`/`at_hi`), `python/pounce/_starts.py`,
`pyomo-pounce/pyomo_pounce/preflight.py`, and
`pyomo-pounce/pyomo_pounce/block_init.py` — where `_seed_var` on a variable with
`ub = -5e20` and no `lb` fell through to seeding `0.0`, outside the variable's
own declared box.

**Left alone deliberately:** `python/pounce/_route.py` uses plain `np.isfinite`,
which is *correct* there — its bounds come from `_normalize_bounds` (scipy
`±inf`) and `_wrap_constraints`, neither of which uses the sentinel convention.
`python/pounce/gams/link.py` and `gams/gams_pounce.c` were already directional
by construction.

## Verification

All five regression tests (two Rust, three Python) were run against the old band
predicate to confirm they catch the defect:

```
verify::tests::row_magnitude_counts_a_bound_past_the_opposite_sentinel ... FAILED
verify::tests::a_bound_past_the_opposite_sentinel_still_scores_a_violation ... FAILED
python/tests/test_preflight.py::test_box_violation_scores_a_bound_past_the_opposite_sentinel FAILED
python/tests/test_preflight.py::test_clamp_to_interior_respects_a_bound_past_the_opposite_sentinel FAILED
pyomo-pounce/tests/test_preflight.py::test_box_violation_scores_a_bound_past_the_opposite_sentinel FAILED
```

Suites: Rust workspace **163 binaries, 2266 tests, 0 failures**; `python/tests`
**802 passed**; `pyomo-pounce/tests` **134 passed**. `cargo fmt --check` clean.

### A note on the pyomo suite

`test_infeasibility_no_false_positives` and `test_scale_invariance` initially
failed for me with 49/200 feasible models reported in the infeasible band. That
was **not** a regression — those tests resolve the solver with
`shutil.which("pounce")`, which picked up a stale pip-installed wrapper from a
previous day rather than the freshly built binary. Re-run with the build on
`PATH`, the probe executes all 200 instances with **0** false positives and the
whole suite passes. The repository's stale-extension guard was telling me
exactly this and I had bypassed it.

Worth considering separately: that probe silently measures whatever `pounce` is
on `PATH`, so a stale install makes it report on the wrong binary in either
direction. Not changed here.

## Related

- #396 — where the family started
- #398 / #400, #401 / #404, #402 / #405 — all merged
- #401 introduced the shared `lower_bound_present` / `upper_bound_present`
  helpers that every site now uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
