### PR TITLE
Refuse to run the ratchet probes against an unvouched binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ changes.
 
 ## [Unreleased]
 
+### Tests — two correctness ratchets silently measured whatever `pounce` was on `PATH`
+
+- **`test_infeasibility_no_false_positives` and `test_scale_invariance` now
+  refuse to run against a binary this checkout cannot vouch for.** Both resolved
+  the solver with a bare `shutil.which("pounce")` and `subprocess.run`, so they
+  measured whatever happened to be installed. Found while fixing #403: a
+  pip-installed `pounce` from the previous day reported **49 of 200**
+  feasible-by-construction models in the AMPL infeasible band, against a ratchet
+  whose limit is `0`.
+- **Neither existing guard could reach this.** The #366 `conftest` hook covers
+  tests that go through pyomo's `SolverFactory` and fires only on
+  `ApplicationError: ... did not exit normally` — the solver producing *no*
+  result. These two use neither: no `SolverFactory`, so the plugin's
+  bundled-binary resolution never runs; and a foreign binary that answers
+  *incorrectly* exits cleanly and writes a valid `.sol`. That narrowness is
+  deliberate and still correct — #366's docstring argues a guard broad enough to
+  swallow wrong answers makes the suite meaningless — it just leaves this gap.
+- **Resolution path is not evidence; the build is.** The first cut preferred the
+  wheel-bundled binary, on the documented reasoning that it is "by construction
+  the build under test". That holds in CI, which stages it fresh, and fails in a
+  working tree, where `python/pounce/bin/pounce` is gitignored and survives
+  across days and commits — the binary that produced the 49 false positives was
+  sitting exactly there, one day and six commits stale. Both builds reported
+  `0.9.0`; only the embedded commit distinguished them (`10a6fe0c+dirty` vs
+  `e17b0279`), which is what `_build_id` exists for.
+- The new `pounce_exe` fixture compares the resolved binary's build against the
+  checkout's `HEAD` and skips with an actionable message naming both. Two
+  deliberate asymmetries:
+  - **It refuses only on a *proven* mismatch** — both ids readable and
+    different. An unreadable id must never skip, because a skipped ratchet
+    proves nothing and is the same silent loss by another route.
+    `crates/pounce-cli/build.rs` embeds `unknown` when it builds outside a git
+    checkout (a wheel built in a container without `.git`), and CI is where a
+    silent skip would hurt most.
+  - **The `+dirty` flag is ignored**, so a clean build against an edited tree
+    still runs. That staleness is real but narrow, already covered by the
+    source-mtime guard, and failing on it would fire during ordinary
+    edit-build-test work — which trains people to bypass the guard.
+- `POUNCE_TEST_EXE` names a binary explicitly and steps the guard aside.
+  Explicit beats bypassing: it records *which* binary was meant, where `PATH`
+  manipulation records nothing.
+- The guard is load-bearing, so it has its own coverage:
+  `pyomo-pounce/tests/test_exe_guard.py`, ten cases over both directions.
+
 ### Fixed — `verify` accepted a `.sol` that violates a bound past the opposite sentinel (#403)
 
 - **`pounce verify` no longer reports ACCEPTED for a solution outside the

--- a/pyomo-pounce/tests/conftest.py
+++ b/pyomo-pounce/tests/conftest.py
@@ -32,7 +32,142 @@ To run the full suite locally, give the plugin the binary you just built::
     ln -sf "$PWD/target/release/pounce" python/pounce/bin/pounce
 """
 
+import os
+import shutil
+import subprocess
+
 import pytest
+
+
+#: Escape hatch: name the executable explicitly and the guard steps aside.
+#: Explicit beats bypassing — this records *which* binary you meant, where
+#: `PATH` manipulation silently records nothing.
+_EXE_ENV = "POUNCE_TEST_EXE"
+
+
+def _resolve_pounce_exe():
+    """Resolve the `pounce` executable for tests that shell out to it directly,
+    and say why it is trustworthy — or refuse it (gh #403).
+
+    Returns ``(path, reason_to_skip)``; exactly one is None.
+
+    The suite's other guard (:func:`pytest_runtest_call` below, gh #366) covers
+    tests that go through pyomo's ``SolverFactory``, and only fires when the
+    solver produced *no result at all*. Neither half of that reaches a test that
+    calls ``shutil.which("pounce")`` and ``subprocess.run`` itself: the plugin's
+    bundled-binary resolution never runs, and a foreign binary that answers
+    *incorrectly* exits cleanly, writes a valid ``.sol``, and sails through.
+
+    That is not hypothetical. A pip-installed `pounce` from the previous day
+    reported 49 of 200 feasible-by-construction models in the AMPL infeasible
+    band — against a ratchet whose limit is 0. Both binaries said ``0.9.0``;
+    only the embedded commit distinguished them (``10a6fe0c+dirty`` vs
+    ``ad0991df``), which is exactly the discriminator ``_build_id`` exists to
+    provide.
+
+    The failure is silent in *both* directions, which is what makes it worth a
+    guard: on a different `PATH` the same setup reports a comfortable green
+    while the working tree is broken.
+    """
+    explicit = os.environ.get(_EXE_ENV)
+    if explicit:
+        if not os.path.isfile(explicit):
+            return None, f"{_EXE_ENV}={explicit!r} is not a file"
+        return explicit, None
+
+    try:
+        import pyomo_pounce
+        from pyomo_pounce.pounce_solver import _build_id, _bundled_path
+    except Exception as exc:  # noqa: BLE001 - a broken probe must not mislead
+        return None, f"cannot import pyomo_pounce to resolve the binary: {exc}"
+    del pyomo_pounce
+
+    # Resolution order mirrors the plugin's: bundled first, then PATH.
+    found = _bundled_path() or shutil.which("pounce")
+    if found is None:
+        return None, "no bundled binary and no pounce on PATH"
+
+    # ...but *where* it came from does not make it trustworthy. The bundled
+    # path is only "the build under test" when something staged it this run,
+    # which is true in CI and false in a working tree, where
+    # `python/pounce/bin/pounce` is gitignored and survives across days and
+    # commits. The binary that produced this guard's motivating failure was
+    # sitting there, six commits and a day stale. So verify the build itself.
+    # Refuse only on a *proven* mismatch — both ids known and different.
+    #
+    # The asymmetry is deliberate. Skipping costs the ratchet: a skipped
+    # `MAX_FALSE_POSITIVES = 0` proves nothing, and a suite that quietly stops
+    # checking is the failure this guard exists to prevent. So an id we cannot
+    # read must not skip. `crates/pounce-cli/build.rs` embeds "unknown" when it
+    # builds outside a git checkout — true of a wheel built in a container
+    # without `.git` — and CI is exactly where a silent skip would hurt most,
+    # so unknown-vs-anything runs. What is caught is the case that motivated
+    # this: two readable ids that disagree.
+    want = _checkout_build_id()
+    got = _build_id(found)
+    if want and got and not _same_commit(got, want):
+        return None, (
+            f"refusing to measure {found!r}: it is build {got}, but this "
+            f"checkout is {want}. These probes are correctness ratchets — a "
+            f"different build's verdicts are not evidence either way, in "
+            f"either direction. Rebuild and stage it (see this module's "
+            f"docstring), or set {_EXE_ENV} to choose a binary deliberately."
+        )
+    return found, None
+
+
+def _checkout_build_id():
+    """This checkout's build identifier, in ``_build_id`` form, or None when
+    we are not in a git checkout."""
+
+    def _git(*args):
+        return subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            cwd=os.path.dirname(os.path.abspath(__file__)),
+        )
+
+    try:
+        head = _git("rev-parse", "--short=8", "HEAD")
+        if head.returncode != 0:
+            return None
+        dirty = _git("status", "--porcelain")
+    except Exception:  # noqa: BLE001
+        return None
+    commit = head.stdout.strip()
+    if not commit:
+        return None
+    return commit + ("+dirty" if dirty.stdout.strip() else "")
+
+
+def _same_commit(got, want):
+    """Compare two build ids on the *commit* only.
+
+    The ``+dirty`` flag is deliberately ignored. A binary built from a clean
+    tree that you have since edited reports ``abc123`` against a checkout of
+    ``abc123+dirty`` — a real staleness, but the narrow kind that the
+    source-mtime guard already covers, and failing on it would make this guard
+    fire constantly during ordinary edit-build-test work. What must not slip
+    through is a *different commit*, which is the days-stale case that
+    motivated this.
+    """
+    a = got.split("+")[0]
+    b = want.split("+")[0]
+    if not a or not b:
+        return False
+    n = min(len(a), len(b))
+    return a[:n] == b[:n]
+
+
+@pytest.fixture(scope="session")
+def pounce_exe():
+    """A `pounce` executable this checkout vouches for, or a skip."""
+    exe, reason = _resolve_pounce_exe()
+    if exe is None:
+        pytest.skip(reason)
+    return exe
 
 
 def _using_bundled():

--- a/pyomo-pounce/tests/test_exe_guard.py
+++ b/pyomo-pounce/tests/test_exe_guard.py
@@ -1,0 +1,162 @@
+"""The executable guard itself (gh #403).
+
+``conftest._resolve_pounce_exe`` decides whether the probes in
+``test_infeasibility_no_false_positives`` and ``test_scale_invariance`` are
+measuring a binary this checkout vouches for. Both of those are correctness
+ratchets, so the guard is load-bearing in *both* directions:
+
+* refuse a binary we can prove is a different build — the case that motivated
+  this, where a day-stale artifact reported 49 of 200 feasible models in the
+  infeasible band against a limit of 0;
+* but never skip merely because an id is unreadable, because a skipped ratchet
+  proves nothing and that is the same silent loss by another route.
+
+These tests pin that asymmetry.
+"""
+
+import conftest
+
+
+def _resolve(monkeypatch, *, bundled, which, build_id, checkout_id, env=None):
+    """Drive `_resolve_pounce_exe` with the environment fully stubbed."""
+    monkeypatch.delenv(conftest._EXE_ENV, raising=False)
+    if env is not None:
+        monkeypatch.setenv(conftest._EXE_ENV, env)
+
+    import pyomo_pounce.pounce_solver as ps
+
+    monkeypatch.setattr(ps, "_bundled_path", lambda: bundled)
+    monkeypatch.setattr(ps, "_build_id", lambda exe: build_id)
+    monkeypatch.setattr(conftest.shutil, "which", lambda name: which)
+    monkeypatch.setattr(conftest, "_checkout_build_id", lambda: checkout_id)
+    return conftest._resolve_pounce_exe()
+
+
+def test_a_proven_different_build_is_refused(monkeypatch):
+    """The motivating case: two readable ids that disagree."""
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled="/repo/python/pounce/bin/pounce",
+        which=None,
+        build_id="10a6fe0c+dirty",
+        checkout_id="e17b0279+dirty",
+    )
+    assert exe is None
+    assert "10a6fe0c+dirty" in reason and "e17b0279+dirty" in reason
+
+
+def test_a_matching_build_is_accepted(monkeypatch):
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled="/repo/python/pounce/bin/pounce",
+        which=None,
+        build_id="e17b0279",
+        checkout_id="e17b0279",
+    )
+    assert reason is None
+    assert exe == "/repo/python/pounce/bin/pounce"
+
+
+def test_the_dirty_flag_alone_does_not_refuse(monkeypatch):
+    """A clean build against an edited tree is stale only in the narrow way the
+    source-mtime guard already covers. Refusing here would fire during ordinary
+    edit-build-test work and train people to bypass the guard."""
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled="/repo/python/pounce/bin/pounce",
+        which=None,
+        build_id="e17b0279",
+        checkout_id="e17b0279+dirty",
+    )
+    assert reason is None, reason
+    assert exe is not None
+
+
+def test_an_unreadable_binary_id_still_runs(monkeypatch):
+    """`build.rs` embeds "unknown" outside a git checkout — true of a wheel
+    built in a container without `.git`. Skipping there would silently disarm
+    the ratchet in CI, which is worse than measuring an unverifiable binary
+    that CI staged itself."""
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled="/wheel/pounce",
+        which=None,
+        build_id=None,  # `commit unknown` does not parse as a build id
+        checkout_id="e17b0279",
+    )
+    assert reason is None, reason
+    assert exe == "/wheel/pounce"
+
+
+def test_a_non_git_checkout_still_runs(monkeypatch):
+    """The mirror: an sdist or tarball has no HEAD to compare against."""
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled="/wheel/pounce",
+        which=None,
+        build_id="e17b0279",
+        checkout_id=None,
+    )
+    assert reason is None, reason
+    assert exe == "/wheel/pounce"
+
+
+def test_path_fallback_is_still_checked(monkeypatch):
+    """No bundled binary: the PATH one is subject to the same proof."""
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled=None,
+        which="/usr/local/bin/pounce",
+        build_id="10a6fe0c",
+        checkout_id="e17b0279",
+    )
+    assert exe is None
+    assert "/usr/local/bin/pounce" in reason
+
+
+def test_no_binary_anywhere_is_reported(monkeypatch):
+    exe, reason = _resolve(
+        monkeypatch, bundled=None, which=None, build_id=None, checkout_id="e17b0279"
+    )
+    assert exe is None
+    assert "no bundled binary" in reason
+
+
+def test_an_explicit_choice_overrides_the_guard(monkeypatch, tmp_path):
+    """Explicit beats bypassing: naming the binary records which one you meant,
+    where `PATH` manipulation records nothing."""
+    fake = tmp_path / "pounce"
+    fake.write_text("#!/bin/sh\n")
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled="/repo/python/pounce/bin/pounce",
+        which=None,
+        build_id="10a6fe0c",  # would otherwise be refused
+        checkout_id="e17b0279",
+        env=str(fake),
+    )
+    assert reason is None, reason
+    assert exe == str(fake)
+
+
+def test_an_explicit_choice_that_does_not_exist_is_reported(monkeypatch):
+    exe, reason = _resolve(
+        monkeypatch,
+        bundled=None,
+        which=None,
+        build_id=None,
+        checkout_id=None,
+        env="/nope/pounce",
+    )
+    assert exe is None
+    assert "is not a file" in reason
+
+
+def test_same_commit_compares_the_commit_only():
+    assert conftest._same_commit("e17b0279", "e17b0279")
+    assert conftest._same_commit("e17b0279", "e17b0279+dirty")
+    assert conftest._same_commit("e17b0279+dirty", "e17b0279")
+    # Differing widths compare on the shared prefix (short vs shorter).
+    assert conftest._same_commit("e17b0279", "e17b027")
+    assert not conftest._same_commit("10a6fe0c", "e17b0279")
+    assert not conftest._same_commit("", "e17b0279")

--- a/pyomo-pounce/tests/test_infeasibility_no_false_positives.py
+++ b/pyomo-pounce/tests/test_infeasibility_no_false_positives.py
@@ -34,7 +34,6 @@ the defect this file exists to catch.
 from __future__ import annotations
 
 import random
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -62,13 +61,6 @@ _OPTS = [
     "presolve_redundant_constraint_removal=yes",
     "print_level=0",
 ]
-
-
-def _pounce() -> str:
-    exe = shutil.which("pounce")
-    if exe is None:
-        pytest.skip("pounce not on PATH")
-    return exe
 
 
 def _build(seed: int):
@@ -109,8 +101,8 @@ def _solve_result_num(sol: Path) -> int | None:
     return None
 
 
-def test_feasible_models_are_not_reported_infeasible(tmp_path):
-    exe = _pounce()
+def test_feasible_models_are_not_reported_infeasible(tmp_path, pounce_exe):
+    exe = pounce_exe
     executed = 0
     false_positives = []
 

--- a/pyomo-pounce/tests/test_scale_invariance.py
+++ b/pyomo-pounce/tests/test_scale_invariance.py
@@ -32,7 +32,6 @@ that is the point.
 
 from __future__ import annotations
 
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -44,13 +43,6 @@ pyo = pytest.importorskip("pyomo.environ")
 KS = list(range(-12, 13, 2))
 
 _OPTS = ["solver_selection=nlp", "print_level=0"]
-
-
-def _pounce() -> str:
-    exe = shutil.which("pounce")
-    if exe is None:
-        pytest.skip("pounce not on PATH")
-    return exe
 
 
 # --- models -----------------------------------------------------------------
@@ -200,8 +192,8 @@ def _solve(exe, tmp_path, name, builder, k) -> int | None:
     return None
 
 
-def test_scale_invariance_does_not_regress(tmp_path):
-    exe = _pounce()
+def test_scale_invariance_does_not_regress(tmp_path, pounce_exe):
+    exe = pounce_exe
     executed = 0
     report = []
     regressions = []


### PR DESCRIPTION
Follow-up to #403, where this surfaced. Not a bug in the solver — a hole in how
two of its correctness ratchets choose the binary they measure.

## What happened

`test_infeasibility_no_false_positives` and `test_scale_invariance` resolved the
solver with a bare `shutil.which("pounce")` + `subprocess.run`, so they measured
whatever happened to be installed. While working #403 they reported **49 of 200**
feasible-by-construction models in the AMPL infeasible band — against a ratchet
whose limit is `0`. That reads exactly like a #396-class regression. It wasn't:
the binary was a pip install from the previous day.

## Why neither existing guard caught it

#366 built real machinery for this — `check_binary()`, `_bundled_path()`, and
the `conftest` hook. It cannot reach these two, for two independent reasons:

1. **They never touch the pyomo plugin.** Zero `SolverFactory` uses in either
   file, so `_default_executable()` and the bundled-binary preference never run.
2. **Their failure mode is the one the hook deliberately excludes.** It fires
   only on `ApplicationError: ... did not exit normally` — the solver producing
   *no result*. The stale binary ran fine and wrote a valid `.sol` every time; it
   just returned wrong verdicts. #366's docstring is explicit that a guard broad
   enough to swallow wrong answers makes the suite meaningless, and that is still
   the right call. This is a gap beside it, not a defect in it.

## Resolution path is not evidence; the build is

My first cut preferred the wheel-bundled binary, on `conftest`'s own documented
reasoning that it is "by construction the build under test."

**That reasoning is CI-only.** In a working tree `python/pounce/bin/pounce` is
gitignored and survives across days and commits — and the binary that produced
the 49 false positives was sitting exactly there, one day and six commits stale.
The first cut would have trusted it and reproduced the whole problem. Caught by
running the guard against my own tree rather than assuming.

Both builds reported `0.9.0`. Only the embedded commit told them apart
(`10a6fe0c+dirty` vs `e17b0279`) — which is precisely what `_build_id` was
written for, per its own docstring about the #271/#272 dual-sign case.

## The guard

A session-scoped `pounce_exe` fixture: resolve (bundled, then `PATH`), then
compare the binary's build id against the checkout's `HEAD`, and skip with a
message naming both. Observed output:

```
SKIPPED [1] refusing to measure '/Users/.../python/pounce/bin/pounce': it is
build 10a6fe0c+dirty, but this checkout is e17b0279+dirty. These probes are
correctness ratchets — a different build's verdicts are not evidence either
way, in either direction. Rebuild and stage it (see this module's docstring),
or set POUNCE_TEST_EXE to choose a binary deliberately.
```

Two deliberate asymmetries, both about not making things worse:

- **Refuses only on a *proven* mismatch** — both ids readable and different. An
  unreadable id must never skip: a skipped ratchet proves nothing, which is the
  same silent loss by another route. `crates/pounce-cli/build.rs` embeds
  `unknown` when built outside a git checkout (a wheel built in a container
  without `.git`), and **CI is where a silent skip would hurt most**. I nearly
  shipped the fail-closed version before checking `build.rs`.
- **`+dirty` is ignored**, so a clean build against an edited tree still runs.
  That staleness is real but narrow, already covered by the source-mtime guard,
  and failing on it would fire constantly during edit-build-test — which trains
  people to bypass the guard.

`POUNCE_TEST_EXE` names a binary explicitly and steps aside. Explicit beats
bypassing: it records *which* binary was meant, where `PATH` manipulation
records nothing.

## Verification

Four scenarios exercised against the real tree:

| scenario | result |
|---|---|
| stale binary staged as bundled | refused, message above |
| build matching `HEAD` staged | runs, both probes pass |
| `POUNCE_TEST_EXE` set to a valid binary | runs |
| `POUNCE_TEST_EXE=/nope/pounce` | skipped, `is not a file` |

The guard is load-bearing, so it has its own coverage —
`pyomo-pounce/tests/test_exe_guard.py`, 10 cases pinning both directions,
including the two asymmetries above.

Full pyomo suite: **144 passed** (was 134; +10 guard tests). No new lint: the
one `F401` in `test_scale_invariance.py` is pre-existing on `main` and untouched.

## Note

This is a test-infrastructure change only — no solver behaviour is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
