### PR TITLE
Expose the active-set QP's Schur-update options (they were unreachable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the active-set QP's Schur-update path was unreachable from any user-facing surface
+
+- **`sqp_qp_use_schur_updates` and `sqp_qp_max_schur_updates_before_refactor`
+  are now registered options.** `pounce-qp` has implemented Schur-complement
+  rank-2 working-set updates (Kirches 2011 / qpOASES-extended) for some time,
+  but the only way to enable them was `SqpAlgorithm::with_qp_options` — a
+  library-only entry point. No CLI user, no `.nl` run, and no benchmark could
+  reach it. That is the same unreachable-knob defect #360 fixed for the rest of
+  the `sqp_qp_*` family, and the guard test added there now covers these two.
+- **What it costs to leave off.** With updates disabled, every working-set
+  change assembles a fresh active-set KKT and factors it from scratch,
+  repeating the full symbolic analysis (fill-reducing ordering + MC64
+  matching). Profiling `Q25FV47` put **32% of total runtime** in symbolic
+  factorization, across 1000+ factorizations. Enabling updates: 19.7s → 0.5s.
+  Measured 28-88× on the instances tried.
+- **Why the default nevertheless stays `false`.** The speedup above is measured
+  on instances that fail either way — a biased sample. Re-running the 46
+  Maros-Mészáros instances the default path solves *correctly*, with updates
+  enabled: **9 regress** (4 `InternalError`, 2 stalls, 2 timeouts, 1 wrong
+  objective) and total wall time rises 107s → 251s. So this is opt-in for
+  warm-started workloads where the speedup dominates, not a general
+  accelerator. The option's own documentation records those numbers, and the
+  test asserts the default rather than leaving it to drift.
+- Caching the *symbolic* analysis was tried first and does not work: the KKT
+  pattern genuinely changes on every working-set change (instrumented:
+  0 cache hits, 1000+ misses, dimension oscillating 1620/1720/6365). The
+  reusable object is the factorization, which is exactly what the Schur path
+  maintains.
+- **Not fixed here.** Enabling updates does not make the failing instances
+  solve; it changes `Search Direction is becoming Too Small` into
+  `KKT matrix is singular (LICQ violation or rank-deficient Jacobian)`, faster.
+  The underlying rank-deficient active-set KKT on degenerate Netlib-derived
+  QPs is a separate defect, tracked on its own.
+
 ### Tests — two correctness ratchets silently measured whatever `pounce` was on `PATH`
 
 - **`test_infeasibility_no_false_positives` and `test_scale_invariance` now

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3376,6 +3376,15 @@ fn apply_qp_subproblem_options(options: &OptionsList, opts: &mut pounce_qp::QpOp
     if let Ok((v, true)) = options.get_numeric_value("sqp_qp_elastic_gamma", "") {
         opts.elastic_gamma = v;
     }
+    if let Ok((v, true)) = options.get_bool_value("sqp_qp_use_schur_updates", "") {
+        opts.use_schur_updates = v;
+    }
+    if let Ok((v, true)) = options.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "")
+    {
+        if v >= 1 {
+            opts.max_schur_updates_before_refactor = v as u32;
+        }
+    }
     if let Ok((s, true)) = options.get_string_value("sqp_qp_anti_cycling", "") {
         opts.anti_cycling = match s.as_str() {
             "expand" => AntiCyclingChoice::Expand,
@@ -3810,7 +3819,9 @@ mod tests {
              sqp_qp_feas_tol 1e-7\n\
              sqp_qp_opt_tol 2e-7\n\
              sqp_qp_elastic_gamma 1e4\n\
-             sqp_qp_anti_cycling bland\n",
+             sqp_qp_anti_cycling bland\n\
+             sqp_qp_use_schur_updates yes\n\
+             sqp_qp_max_schur_updates_before_refactor 12\n",
         )
         .expect("every sqp_qp_* option must be registered (gh #360)");
 
@@ -3820,6 +3831,12 @@ mod tests {
         assert!((qp.opt_tol - 2e-7).abs() < 1e-20);
         assert!((qp.elastic_gamma - 1e4).abs() < 1e-9);
         assert_eq!(qp.anti_cycling, AntiCyclingChoice::Bland);
+        // The Schur update path was implemented but reachable only through
+        // `SqpAlgorithm::with_qp_options`, so no CLI/library user could turn
+        // it on — the same unreachable-knob defect gh #360 fixed for the rest
+        // of this family.
+        assert!(qp.use_schur_updates);
+        assert_eq!(qp.max_schur_updates_before_refactor, 12);
 
         // Untouched options must keep the pounce-qp defaults, not be
         // overwritten with zeros by the "explicitly set" gate.
@@ -3833,6 +3850,14 @@ mod tests {
         assert!((qp.feas_tol - defaults.feas_tol).abs() < 1e-20);
         assert!((qp.opt_tol - defaults.opt_tol).abs() < 1e-20);
         assert_eq!(qp.anti_cycling, defaults.anti_cycling);
+        // Default stays OFF, and that is a measured choice: enabling it breaks
+        // 9 of the 46 Maros-Meszaros instances the default path solves
+        // correctly. Do not flip this without re-running that comparison.
+        assert!(!qp.use_schur_updates);
+        assert_eq!(
+            qp.max_schur_updates_before_refactor,
+            defaults.max_schur_updates_before_refactor
+        );
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -502,6 +502,41 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
          subproblem ratio test. Default expand.",
     )?;
 
+    r.add_bool_option(
+        "sqp_qp_use_schur_updates",
+        "Absorb active-set changes as Schur-complement rank-2 updates.",
+        false,
+        "Active-set SQP only. When true, the QP subproblem keeps a cached \
+         factor of the fixed-dimension K_max matrix and absorbs each \
+         working-set change as a Sherman-Morrison-Woodbury rank-2 update, \
+         refactoring only every \"sqp_qp_max_schur_updates_before_refactor\" \
+         updates (Kirches 2011; qpOASES-extended). When false each iteration \
+         assembles a fresh active-set KKT and factors it from scratch -- \
+         algorithmically identical but far more expensive, since every \
+         working-set change repeats the full symbolic analysis (fill-reducing \
+         ordering and MC64 matching), which measured 32% of runtime on \
+         Q25FV47. \
+         \
+         Default false, and that is a measured choice rather than an \
+         oversight. On Maros-Meszaros instances the update path is 28-88x \
+         faster where it works (Q25FV47: 19.7s -> 0.5s), but it is currently \
+         less robust: of the 46 instances the default path solves correctly, \
+         enabling updates breaks 9 (InternalError, TimeOut, or a wrong \
+         objective), and total wall over that set rises 107s -> 251s because \
+         of the new timeouts. Treat it as opt-in for warm-started workloads \
+         where the speedup dominates, not as a general accelerator.",
+    )?;
+    r.add_lower_bounded_integer_option(
+        "sqp_qp_max_schur_updates_before_refactor",
+        "Schur updates to absorb before refactoring from scratch.",
+        1,
+        50,
+        "Active-set SQP only, and only consulted when \
+         \"sqp_qp_use_schur_updates\" is true. The dense Schur block grows by \
+         2 per working-set change, so its solve cost grows quadratically; \
+         refactoring periodically bounds that. Default 50.",
+    )?;
+
     r.add_string_option("linear_system_scaling", "Method for scaling the linear system.", "none", &[("none", "no scaling will be performed"), ("mc19", "use the Harwell routine MC19 (Curtis-Reid; minimizes sum of log^2 |a_ij|)"), ("ruiz", "use iterative symmetric infinity-norm equilibration (Ruiz, 2001)"), ("slack-based", "use the slack values")], "Determines the method used to compute symmetric scaling factors for the augmented system (see also the \"linear_scaling_on_demand\" option). This scaling is independent of the NLP problem scaling.")?;
     r.add_string_option("nlp_scaling_method", "Select the technique used for scaling the NLP.", "gradient-based", &[("none", "no problem scaling will be performed"), ("user-scaling", "scaling parameters will come from the user"), ("gradient-based", "scale the problem so the maximum gradient at the starting point is nlp_scaling_max_gradient"), ("equilibration-based", "scale the problem so that first derivatives are of order 1 at random points (uses Harwell routine MC19)")], "Selects the technique used for scaling the problem internally before it is solved. For user-scaling, the parameters come from the NLP.")?;
 


### PR DESCRIPTION
Fix A from the investigation in #408. **A performance fix and a reachability
fix — not a correctness fix.** The failing instances still fail; see the last
section.

## The knob existed and nobody could turn it

`pounce-qp` implements Schur-complement rank-2 working-set updates (Kirches
2011 / qpOASES-extended) in `schur.rs`: a fixed-dimension `K_max` where a
working-set change is a rank-2 update instead of a refactorization. The only way
to enable it was `SqpAlgorithm::with_qp_options`, a library-only entry point. No
CLI user, no `.nl` run, and no benchmark could reach it.

That is the same unreachable-knob defect #360 fixed for the rest of the
`sqp_qp_*` family. Its guard test — written precisely because "the documented
knobs were unusable" — now covers these two keys.

## What leaving it off costs

With updates disabled, every working-set change assembles a fresh active-set KKT
and factors from scratch, repeating the full symbolic analysis (fill-reducing
ordering + MC64 matching). Profiling `Q25FV47` with `macOS sample`:

```
ParametricActiveSetSolver::solve            100.0%
  solve_elastic (phase 1)                    65.7%
    factorize_with_inertia_control           57.0%
      symbolic_factorize_with_method         32.0%   <- per refactorization
```

Enabling updates:

| problem | off | on | speedup |
|---|---|---|---|
| QSHARE2B | 0.28s | 0.01s | 28× |
| QSCTAP1 | 1.76s | 0.02s | 88× |
| Q25FV47 | 19.71s | 0.53s | 37× |

## Why the default still stays `false`

Because I measured the other half before recommending it, and it changes the
answer. Those speedups come from instances that fail **either way** — a biased
sample. Re-running the 46 Maros-Mészáros instances the default path solves
*correctly*, with updates enabled:

- **9 of 46 regress** — 4 `InternalError` (`ZECEVIC2`, `QAFIRO`, `PRIMALC8`,
  `MOSARQP1/2`), 2 stalls, 2 timeouts, 1 wrong objective
- total wall over that set **rises 107s → 251s**, from the new timeouts

So this is opt-in for warm-started workloads where the speedup dominates, not a
general accelerator. Both numbers are recorded in the option's own long
description, and the test asserts the default so it cannot drift silently.

## A wrong turn worth recording

I first hypothesised redundant symbolic analysis that should be cached, and
implemented that cache. It changed nothing — 20.18s → 20.18s. Instrumenting the
guard showed why: **0 cache hits, 1000+ misses**, with the KKT dimension
oscillating 1620 → 1720 → 6365. The pattern genuinely differs on every
working-set change, so no pattern cache can apply. The reusable object is the
*factorization*, which is exactly what the Schur path maintains. That failed
experiment is what identified the real mechanism.

## What this does NOT fix

Enabling updates does not make the failing instances solve. It converts

```
EXIT: Search Direction is becoming Too Small          (20.18s, 0 iterations)
```

into

```
QpFailure(LinearSolverFailure("KKT matrix is singular
                              (LICQ violation or rank-deficient Jacobian)"))   (0.53s)
```

Same verdict on every instance tried. So the 72 failures in #408 are **not**
caused by the missing update path — the slow path was dying on a symptom and
obscuring the real defect, which is a rank-deficient active-set KKT during the
l1-elastic phase 1, concentrated in degenerate Netlib-derived QPs. That is a
separate piece of work.

## Verification

`pounce-algorithm` + `pounce-qp`: 41 binaries, 591 tests, 0 failures.
`cargo fmt --check` clean. Option rejects invalid values (confirming real
registration, not a silently-ignored key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
