### PR TITLE
Run qp-active-set on the convex path; implement the parametric homotopy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,96 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the convex IPM reported some infeasible models as unbounded
+
+- **Found while fixing #415**, by the randomized sweep written to check that
+  fix: on 8 of 200 infeasible-by-construction models, `qp-ipm` returned
+  `DivergingIterates` / `solve_result_num=300` where HiGHS and pounce's own
+  active-set engine both said the model is infeasible. Wrong family, same harm
+  as #415 in the other engine — `300` sends a caller looking for an unbounded
+  objective on a model that has no feasible point at all.
+- **Not a bug in the certificate.** `DualInfeasible` rests on a recession
+  direction `d` with `Pd ≈ 0, Ad ≈ 0, −Gd ∈ K, cᵀd < 0`, and that certificate is
+  about the **dual**. It stays valid when the primal is empty — the recession
+  direction of an empty feasible set exists just the same — so a model can
+  honestly earn *both* verdicts at once, and these did. Which one gets reported
+  is then a choice, not a measurement, and it was being settled by whichever
+  residual gate happened to clear first.
+- **On the instance now pinned as a regression test**, the Farkas value held at
+  `−1.72` with `z ∈ K*` while its residual fell `1.9e-3 → 9.5e-5 → 4.7e-6 →
+  2.4e-7` toward its `8.6e-11` gate — and the recession gate opened with three
+  orders still to go.
+- **Deciding it inside the iteration means picking a tolerance, and that was
+  tried and rejected.** A rule loose enough to catch this case also suppressed
+  11 of 200 *genuine* unbounded verdicts, trading one wrong answer for more
+  missing ones. So the question is now asked directly instead of inferred: on a
+  `DualInfeasible` verdict the driver re-solves the objective-free twin
+  (`P = 0, c = 0`), which has the same feasible set and, having no objective,
+  cannot be unbounded. An infeasible twin corrects the verdict; anything else
+  leaves it alone. Costs one extra solve, only on `DualInfeasible`, and the twin
+  cannot recurse into the same branch (`c = 0` admits no `cᵀd < 0`).
+- Measured after the change: all 200 infeasible models report
+  `primal_infeasible` and agree with the active-set engine, and 200
+  feasible-and-unbounded models still certify `dual_infeasible` at exactly the
+  pre-change rate — the correction costs nothing.
+
+### Fixed — `qp-active-set` reported an infeasible model as a solver crash (#415)
+
+- **An infeasible QP now exits `InfeasibleProblemDetected` / `solve_result_num
+  = 200`, not `InternalError` / `500`.** The trigger is as plain as it gets: an
+  LP with `x₀ + x₁ ≤ 1` and `x₀ + x₁ ≥ 3`. Every other engine on the identical
+  `.nl` — `lp-ipm`, `qp-ipm`, `socp`, `auto`, `nlp` — said `200`; only
+  `qp-active-set` said `500`. The two codes are different AMPL families and
+  callers branch on them: `200` means "the model is infeasible, fix the model",
+  `500` means "the solver broke, retry or switch solvers". So a correctly
+  diagnosed model was being reported to AMPL, Pyomo, and the GAMS links as a
+  POUNCE failure. Same fix on the Python surface, where
+  `solve_qp(method="active-set")` returned `numerical_failure` where
+  `method="ipm"` returned `primal_infeasible`.
+- **The engine had it right; the driver threw the answer away.** `pounce-qp`
+  returned `Infeasible`, and the convex driver deliberately refuses to propagate
+  that on the engine's word — an infeasibility verdict is a proof obligation
+  (#282: `DUALC1` is feasible and the phase-1 elastic mode calls it infeasible).
+  But the driver had no way to *check* the claim, so it downgraded every one of
+  them to `NumericalFailure`. Correct claims and false ones got the same
+  treatment.
+- **Why the textbook Farkas test could not be used as-is.** It wants
+  `Aᵀy + Gᵀz = 0` with `bᵀy + hᵀz < 0`. These multipliers come from an l1-elastic
+  phase-1 that minimizes the *original objective plus* `γ·(violation)`, so its
+  stationarity leaves `Aᵀy + Gᵀz = −(Px + c)` — a residual that never vanishes,
+  only shrinks relative to `‖(y,z)‖ ∝ γ`. On the LP above that is `1e-6`
+  relative against a `FARKAS_RESID_TOL` of `1e-10`: a real certificate, read as
+  noise.
+- **What replaced it.** For any feasible `x`, `qᵀx ≤ bᵀy + hᵀz` where
+  `q := Aᵀy + Gᵀz`; a feasible `x` is also in the box, so
+  `qᵀx ≥ L := Σᵢ min(qᵢ·lbᵢ, qᵢ·ubᵢ)`. `L > bᵀy + hᵀz` therefore proves the
+  feasible set empty. This is the Farkas test generalized — with no finite
+  bounds it collapses back to it — and on a boxed problem it accounts for the
+  `−(Px + c)` residual *exactly* instead of tolerating it. When there is no box
+  to work with, the driver spends one more solve on the objective-free twin
+  (`P = 0, c = 0`), whose phase-1 minimizes violation alone and so returns a
+  residual-free certificate (`q = (0,0)` exactly on the same LP).
+- **Soundness is preserved, which is the point.** Every step is an inequality
+  that holds at every feasible point, so a pass is a proof up to floating point;
+  a claim that does not verify is still demoted exactly as before. A false
+  `PrimalInfeasible` would be a wrong statement about the user's model — worse
+  than any failure status — so the negative case is tested directly: a QP whose
+  feasible set is the single point `{0}` (every row active, no interior, the
+  #282 geometry) must never acquire an infeasibility verdict, and a
+  minimizing-corner slip in the box bound is caught by its own test.
+- This is the infeasible analogue of the same status-mapping gap #388 fixed for
+  unbounded problems and #313 fixed for rank-deficient equalities.
+- Two side effects worth knowing about: a certified `PrimalInfeasible` or
+  `DualInfeasible` now ends the solve instead of burning a second, equilibrated
+  attempt that could not have overturned a proof; and a `PrimalInfeasible`
+  solution's `y` / `z` now hold the multipliers that actually certify it, so the
+  verdict is re-checkable from the solution it is attached to.
+- Measured on 200 infeasible-by-construction models (random `n`, `m`, Hessian,
+  and bound pattern): `qp-active-set` went from agreeing with `qp-ipm` on almost
+  none of them to `primal_infeasible` on all 200. On 200 feasible-by-construction
+  models it produced no false infeasibility verdict and matched the IPM objective
+  throughout.
+
 ### Fixed — the active-set QP's Schur-update path was unreachable from any user-facing surface
 
 - **`sqp_qp_use_schur_updates` and `sqp_qp_max_schur_updates_before_refactor`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "pounce-nlp",
  "pounce-observability",
  "pounce-presolve",
+ "pounce-qp",
  "pounce-restoration",
  "pounce-sensitivity",
  "pounce-solve-report",

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -873,6 +873,15 @@ impl IpoptApplication {
         use pounce_nlp::orig_ipopt_nlp::OrigIpoptNlp;
         use pounce_nlp::tnlp_adapter::TNLPAdapter;
 
+        // Wall-clock for the whole SQP solve, mirroring the IPM path's
+        // `t_start` (see the `total_wallclock_time_secs` assignment in
+        // `optimize_tnlp`). Without this the field stayed at its struct
+        // default of 0.0 on every active-set solve, so `--json-output`
+        // reported an instantaneous solve regardless of actual runtime and
+        // the engine could not be speed-compared against qp-ipm at all
+        // (benchmarks/scripts/compare_qp_four_way.py had to skip the column).
+        let t_start = std::time::Instant::now();
+
         let adapter = match TNLPAdapter::new(Rc::clone(&tnlp)) {
             Ok(a) => Rc::new(RefCell::new(a)),
             Err(_) => return ApplicationReturnStatus::InvalidProblemDefinition,
@@ -982,6 +991,7 @@ impl IpoptApplication {
             stats.final_unscaled_constr_viol = res.final_constr_viol;
             stats.final_unscaled_compl = 0.0;
             stats.final_unscaled_kkt_error = res.final_stationarity.max(res.final_constr_viol);
+            stats.total_wallclock_time_secs = t_start.elapsed().as_secs_f64();
         }
         let (app_status, solver_status) = match res.status {
             crate::sqp::SqpStatus::Optimal => (
@@ -1007,6 +1017,16 @@ impl IpoptApplication {
             crate::sqp::SqpStatus::QpStepFailed => (
                 ApplicationReturnStatus::SearchDirectionBecomesTooSmall,
                 pounce_nlp::SolverReturn::ErrorInStepComputation,
+            ),
+            // The QP subproblem ran out of its own iteration budget. Same
+            // #282 guarantee — no infeasibility is asserted — but reported as
+            // the budget exhaustion it is, so the user sees a limit they can
+            // raise (`sqp_qp_max_iter`) instead of a step-size stall with no
+            // remedy. See `SqpStatus::QpIterationLimit` for why these were
+            // split.
+            crate::sqp::SqpStatus::QpIterationLimit => (
+                ApplicationReturnStatus::MaximumIterationsExceeded,
+                pounce_nlp::SolverReturn::MaxiterExceeded,
             ),
             // Unbounded below, with a recession ray verified against the
             // true NLP (gh #388). `Diverging_Iterates` is POUNCE's (Ipopt's)

--- a/crates/pounce-algorithm/src/sqp/result.rs
+++ b/crates/pounce-algorithm/src/sqp/result.rs
@@ -25,6 +25,24 @@ pub enum SqpStatus {
     /// — it makes no infeasibility claim it cannot back with a
     /// certificate. Maps to `Search_Direction_Becomes_Too_Small`.
     QpStepFailed,
+    /// The QP subproblem exhausted its own iteration budget
+    /// ([`QpOptions::max_iter`], the `sqp_qp_max_iter` option) without
+    /// converging or certifying anything.
+    ///
+    /// Split out from [`QpStepFailed`](Self::QpStepFailed) because the two
+    /// call for opposite remedies and the merged status actively misled.
+    /// A budget exhaustion is *actionable* — raise the limit — whereas
+    /// `Search_Direction_Becomes_Too_Small` reads as a numerical stall with
+    /// nothing to turn. On the Maros-Mészáros set the merged mapping hid the
+    /// single largest failure class: the cold-start active-set method needs
+    /// roughly one iteration per active-set change, so the flat default of
+    /// 200 is below what a few hundred constraints require, and dozens of
+    /// problems reported a step-size failure when they had simply run out of
+    /// budget. `DUALC1` (n=9, m=215) is the type case — it exits here at the
+    /// default and solves exactly, in one outer iteration, at a larger limit.
+    ///
+    /// Maps to `Maximum_Iterations_Exceeded`.
+    QpIterationLimit,
     /// The problem is unbounded below: the step QP returned a certified
     /// recession ray (zero curvature, feasible for every step length,
     /// strict descent) *and* that ray was re-verified against the true
@@ -46,6 +64,7 @@ impl fmt::Display for SqpStatus {
             SqpStatus::InfeasibleSubproblem => write!(f, "infeasible-subproblem"),
             SqpStatus::LineSearchFailed => write!(f, "line-search-failed"),
             SqpStatus::QpStepFailed => write!(f, "qp-step-failed"),
+            SqpStatus::QpIterationLimit => write!(f, "qp-iteration-limit"),
             SqpStatus::Unbounded => write!(f, "unbounded"),
         }
     }

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -509,12 +509,23 @@ impl SqpAlgorithm {
                 QpStatus::MaxIter | QpStatus::NumericalError => {
                     let obj = nlp.eval_f(&iter.x);
                     self.iterates = Some(iter.clone());
+                    // Report *which* of the two it was. Both are honest
+                    // non-committal failures making no infeasibility claim
+                    // (#282), but only the budget one is actionable by the
+                    // user, and merging them hid the dominant Maros-Mészáros
+                    // failure mode behind a step-size verdict. See
+                    // `SqpStatus::QpIterationLimit`.
+                    let status = if sol.status == QpStatus::MaxIter {
+                        SqpStatus::QpIterationLimit
+                    } else {
+                        SqpStatus::QpStepFailed
+                    };
                     return Ok(SqpResult {
                         x: iter.x,
                         lambda_g: iter.lambda_g,
                         lambda_x: iter.lambda_x,
                         obj,
-                        status: SqpStatus::QpStepFailed,
+                        status,
                         n_iter: outer,
                         n_qp_solves,
                         final_stationarity,

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -503,6 +503,26 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
     )?;
 
     r.add_bool_option(
+        "sqp_qp_use_homotopy",
+        "Trace the parametric homotopy on a cold convex-QP solve.",
+        false,
+        "Cold-start path for the pounce-qp active-set engine. When true, the \
+         solve traces the section 4.2 parametric homotopy: start from the \
+         box-only relaxation (all general rows dropped, which the box fast path \
+         solves directly), then tighten the row bounds toward their targets \
+         along t in [0,1], jumping the working set at each t where a row \
+         becomes binding or an active multiplier reaches zero. The iterate is \
+         feasible for the t-problem at every point on the path, so there is no \
+         phase-1 to stall in -- which is the failure mode the conventional path \
+         hits on degenerate netlib-derived QPs. \
+         \
+         This is the algorithm the crate is named for and the one its design \
+         note assumes; it was previously unimplemented (solve_parametric was a \
+         stub). Default false while it is evaluated against the conventional \
+         path.",
+    )?;
+
+    r.add_bool_option(
         "sqp_qp_use_schur_updates",
         "Absorb active-set changes as Schur-complement rank-2 updates.",
         false,

--- a/crates/pounce-cli/Cargo.toml
+++ b/crates/pounce-cli/Cargo.toml
@@ -51,6 +51,9 @@ pounce-observability.workspace = true
 # Specialized convex LP/QP interior-point solver, dispatched to for
 # classified LP / convex-QP `.nl` inputs.
 pounce-convex.workspace = true
+# For the AntiCyclingChoice enum when forwarding sqp_qp_* to the active-set
+# engine; already a transitive dependency via pounce-convex.
+pounce-qp.workspace = true
 feral.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -653,9 +653,22 @@ pub fn main() -> ExitCode {
         // `LpIpm`/`QpIpm` use the convex QP IPM (LP is P = 0); `SocpIpm`
         // reformulates a convex QCQP to second-order cones and uses the
         // conic IPM. Both live in `pounce-convex`.
+        //
+        // `QpActiveSet` joins them here rather than routing through the SQP
+        // outer loop as it used to. The engine is different, but everything
+        // wrapped around it — QP extraction, presolve, postsolve, `.sol`
+        // writing, status vocabulary, timing — is shared with the IPM, and
+        // that shared wrapper is the entire point: the active-set engine had
+        // been running with no presolve and no scaling, which costs an
+        // active-set method far more than it costs an IPM (its pivot count
+        // grows with the problem, an IPM's essentially does not). See
+        // `pounce_convex::active_set` for the full rationale.
         if matches!(
             choice,
-            SolverChoice::LpIpm | SolverChoice::QpIpm | SolverChoice::SocpIpm
+            SolverChoice::LpIpm
+                | SolverChoice::QpIpm
+                | SolverChoice::SocpIpm
+                | SolverChoice::QpActiveSet
         ) {
             // issue #196: if the .nl requested a sensitivity / reduced-Hessian
             // step, either reroute (auto) or warn (explicit convex force) so
@@ -735,6 +748,19 @@ pub fn main() -> ExitCode {
                     opts.get_string_value("qp_presolve", "").ok(),
                     opts.get_string_value("presolve", "").ok(),
                 );
+                // The interactive debugger is a pdb-for-the-IPM: it pauses on
+                // barrier-IPM iterations (mu, search direction, fraction-to-
+                // the-boundary). The active-set engine is a different
+                // algorithm with no such hook, so a `--debug*` request would
+                // otherwise silently no-op. Say so explicitly.
+                if matches!(choice, SolverChoice::QpActiveSet) && debug_hook.is_some() {
+                    eprintln!(
+                        "pounce: note: the interactive debugger is IPM-only and does \
+                         not engage on the active-set QP engine (solver_selection=\
+                         qp-active-set); the solve runs without pausing. Use \
+                         solver_selection=qp-ipm to debug a convex QP interactively."
+                    );
+                }
                 return run_convex_qp(
                     &prob,
                     class,
@@ -744,42 +770,22 @@ pub fn main() -> ExitCode {
                     debug_hook.as_ref(),
                     args.ampl,
                     convex_opts,
+                    matches!(choice, SolverChoice::QpActiveSet),
                 );
             }
             // Builtins never classify as convex; fall through to NLP.
         }
-        // `qp-active-set`: route the (convex-QP) problem through the
-        // active-set SQP engine instead of the IPM. `resolve_solver`
-        // already validated the class is LP / convex QP, so the SQP driver
-        // — which solves its step QPs with `pounce-qp` — converges in
-        // essentially one QP solve, and the NLP layer recovers the duals
-        // and writes the `.sol` exactly as the IPM path does. The
-        // application dispatches to that engine whenever the `algorithm`
-        // option resolves to "active-set-sqp" (`optimize_tnlp` →
-        // `optimize_sqp_tnlp`), so setting the option here is the whole
-        // wiring; the solve falls through to the NLP path below unchanged.
-        if matches!(choice, SolverChoice::QpActiveSet) {
-            if let Err(e) = app
-                .options_mut()
-                .read_from_str("algorithm active-set-sqp\n", true)
-            {
-                eprintln!("pounce: failed to select the active-set-sqp algorithm: {e}");
-                return ExitCode::from(2);
-            }
-            // The interactive debugger is a pdb-for-the-IPM: it pauses on
-            // barrier-IPM iterations (mu, search direction, fraction-to-the-
-            // boundary). The active-set SQP engine is a different algorithm
-            // with no such hook, so a `--debug*` request here would otherwise
-            // silently no-op. Say so explicitly rather than pretend it engaged.
-            if debug_hook.is_some() {
-                eprintln!(
-                    "pounce: note: the interactive debugger is IPM-only and does \
-                     not engage on the active-set QP engine (solver_selection=\
-                     qp-active-set); the solve runs without pausing. Use \
-                     solver_selection=qp-ipm to debug a convex QP interactively."
-                );
-            }
-        }
+        // `qp-active-set` no longer lands here: it is dispatched with the
+        // other convex engines above, straight into `pounce-qp` via
+        // `pounce_convex::active_set`, rather than being rewritten to
+        // `algorithm=active-set-sqp` and run through the SQP outer loop.
+        // Wrapping a QP in an SQP was never wrong — with an exact Hessian and
+        // already-linear constraints the first subproblem *is* the original QP
+        // — but it forfeited the convex path's presolve, scaling, timing, and
+        // status vocabulary in exchange for machinery a QP has no use for.
+        // The SQP route remains for genuine NLPs via `algorithm=active-set-sqp`,
+        // where the outer loop is doing real work.
+        //
         // `nlp` and any unmatched case fall through to the existing NLP
         // solve below unchanged.
         let _ = choice;
@@ -1603,7 +1609,12 @@ fn convex_status_report(s: pounce_convex::QpStatus) -> (&'static str, bool, i32)
         QpStatus::PrimalInfeasible => ("Problem is primal infeasible.", false, 200),
         QpStatus::DualInfeasible => ("Problem is unbounded (dual infeasible).", false, 300),
         QpStatus::IterationLimit => ("Maximum iterations exceeded.", false, 400),
-        QpStatus::NumericalFailure => ("Numerical failure in KKT factorization.", false, 500),
+        // Deliberately not "failure in KKT factorization": both convex engines
+        // reach this status by failing the *post-solve* verification — the
+        // returned point's true KKT error exceeded the acceptable band — which
+        // a factorization breakdown is only one cause of. On the active-set
+        // engine it is also where an uncertified infeasibility claim lands.
+        QpStatus::NumericalFailure => ("Numerical failure (no verified KKT point).", false, 500),
     }
 }
 
@@ -1685,7 +1696,12 @@ fn run_convex_qp(
     debug_hook: Option<&Rc<RefCell<pounce_cli::debug_repl::SolverDebugger>>>,
     ampl: bool,
     convex_opts: pounce_convex::QpOptions,
+    // Use the `pounce-qp` parametric active-set engine instead of the IPM
+    // (`solver_selection=qp-active-set`). Everything else about this driver —
+    // extraction, presolve, postsolve, reporting, `.sol` writing — is shared.
+    use_active_set: bool,
 ) -> ExitCode {
+    use pounce_convex::active_set::solve_qp_active_set;
     use pounce_convex::presolve::{PresolveOutcome, presolve};
     use pounce_convex::{QpOptions, QpStatus, solve_qp_ipm, solve_qp_ipm_debug};
 
@@ -1744,10 +1760,16 @@ fn run_convex_qp(
         // enforce the zero-iteration stop here before any solve runs
         // (pounce#186). Mirrors the NLP path's MaximumIterationsExceeded.
         trivial(QpStatus::IterationLimit)
-    } else if let Some(hook) = debug_hook {
+    } else if let Some(hook) = debug_hook.filter(|_| !use_active_set) {
         // Interactive debug: step the IPM on the extracted QP directly.
         // Presolve is skipped so the debugger's `x`/`s`/`y`/`z` blocks
         // correspond to the user's problem rather than a reduced one.
+        //
+        // Guarded on `!use_active_set`: the debugger hooks barrier-IPM
+        // iterations and has no active-set analogue, so on that engine this
+        // arm would quietly solve with a *different solver* than the one the
+        // user selected. The caller has already printed the note explaining
+        // the debugger does not engage; fall through and solve normally.
         let mut h = hook.borrow_mut();
         solve_qp_ipm_debug(&qp, &qp_opts, &mut *h, backend)
     } else if presolve_on {
@@ -1770,12 +1792,20 @@ fn run_convex_qp(
                         st.tightened_bounds,
                     );
                 }
-                let red = solve_qp_ipm(&ps.reduced, &qp_opts, backend);
+                let red = if use_active_set {
+                    let mut mk = backend;
+                    solve_qp_active_set(&ps.reduced, &qp_opts, &mut mk)
+                } else {
+                    solve_qp_ipm(&ps.reduced, &qp_opts, backend)
+                };
                 ps.postsolve(&red)
             }
             PresolveOutcome::Infeasible => trivial(QpStatus::PrimalInfeasible),
             PresolveOutcome::Unbounded => trivial(QpStatus::DualInfeasible),
         }
+    } else if use_active_set {
+        let mut mk = backend;
+        solve_qp_active_set(&qp, &qp_opts, &mut mk)
     } else {
         solve_qp_ipm(&qp, &qp_opts, backend)
     };
@@ -1786,8 +1816,16 @@ fn run_convex_qp(
     let reported_obj = sign * sol.obj + obj_const;
 
     let (msg, ok, srn) = convex_status_report(sol.status);
+    // Name the engine that actually ran — the two report different iteration
+    // counts (barrier iterations vs active-set changes), so labelling an
+    // active-set solve "IPM" would misread both the solver and the number.
+    let engine = if use_active_set {
+        "active-set, pounce-qp"
+    } else {
+        "IPM, pounce-convex"
+    };
     println!(
-        "POUNCE ({} IPM, pounce-convex): {msg}  obj={reported_obj:.8}  iters={}  ({elapsed:.3}s)",
+        "POUNCE ({} {engine}): {msg}  obj={reported_obj:.8}  iters={}  ({elapsed:.3}s)",
         class.name(),
         sol.iters,
     );

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1668,6 +1668,9 @@ fn active_set_overrides(app: &IpoptApplication) -> pounce_convex::ActiveSetOverr
     if let Ok((v, true)) = opt.get_string_value("sqp_qp_use_schur_updates", "") {
         o.use_schur_updates = Some(v == "yes");
     }
+    if let Ok((v, true)) = opt.get_string_value("sqp_qp_use_homotopy", "") {
+        o.use_homotopy = Some(v == "yes");
+    }
     if let Ok((v, true)) = opt.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "") {
         if v >= 0 {
             o.max_schur_updates_before_refactor = Some(v as u32);

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -753,46 +753,13 @@ pub fn main() -> ExitCode {
                 // the-boundary). The active-set engine is a different
                 // algorithm with no such hook, so a `--debug*` request would
                 // otherwise silently no-op. Say so explicitly.
-                // The `sqp_qp_*` family tunes the QP subproblem *of the SQP
-                // outer loop*. On this path there is no SQP outer loop any
-                // more — the engine is driven directly by the convex driver —
-                // so those options no longer reach it. They used to, back when
-                // `qp-active-set` was implemented by rewriting itself to
-                // `algorithm=active-set-sqp`, which makes this a silent
-                // behaviour change for anyone who set one. Say so rather than
-                // ignore them quietly; forwarding them properly is still to do.
-                if matches!(choice, SolverChoice::QpActiveSet) {
-                    let o = app.options();
-                    let ignored: Vec<&str> = [
-                        "sqp_qp_max_iter",
-                        "sqp_qp_anti_cycling",
-                        "sqp_qp_feas_tol",
-                        "sqp_qp_opt_tol",
-                        "sqp_qp_elastic_gamma",
-                        "sqp_qp_use_schur_updates",
-                        "sqp_qp_max_schur_updates_before_refactor",
-                    ]
-                    .into_iter()
-                    .filter(|k| {
-                        // `true` in the tuple means the user set it explicitly.
-                        matches!(o.get_string_value(k, ""), Ok((_, true)))
-                            || matches!(o.get_numeric_value(k, ""), Ok((_, true)))
-                            || matches!(o.get_integer_value(k, ""), Ok((_, true)))
-                    })
-                    .collect();
-                    if !ignored.is_empty() {
-                        eprintln!(
-                            "pounce: warning: {} does not apply to \
-                             solver_selection=qp-active-set, which now drives the \
-                             active-set engine directly through the convex path \
-                             rather than through the active-set SQP outer loop; \
-                             the setting is ignored. Use `max_iter` / `tol` for \
-                             this path, or algorithm=active-set-sqp on a general \
-                             NLP for the SQP knobs.",
-                            ignored.join(", ")
-                        );
-                    }
-                }
+                // Forward the `sqp_qp_*` family to the inner engine. These knobs
+                // named the QP subproblem *of the SQP outer loop*, which this
+                // path no longer goes through, so every one of them silently
+                // became a no-op when the dispatch moved to the convex driver.
+                // The names are kept because they are the documented, in-use
+                // spelling; only the delivery route changed.
+                let engine_overrides = active_set_overrides(&app);
                 if matches!(choice, SolverChoice::QpActiveSet) && debug_hook.is_some() {
                     eprintln!(
                         "pounce: note: the interactive debugger is IPM-only and does \
@@ -811,6 +778,7 @@ pub fn main() -> ExitCode {
                     args.ampl,
                     convex_opts,
                     matches!(choice, SolverChoice::QpActiveSet),
+                    engine_overrides,
                 );
             }
             // Builtins never classify as convex; fall through to NLP.
@@ -1658,6 +1626,56 @@ fn convex_status_report(s: pounce_convex::QpStatus) -> (&'static str, bool, i32)
     }
 }
 
+/// Read the `sqp_qp_*` option family into inner-engine overrides for the
+/// active-set QP driver.
+///
+/// Only options the user set **explicitly** are forwarded (the `true` flag from
+/// the `OptionsList` accessors), so the driver keeps its own tuned defaults
+/// otherwise — it deliberately picks a size-scaled `max_iter` and enables Schur
+/// updates, and must be able to tell "unset" from "set to the default value".
+///
+/// These knobs were introduced for the QP subproblem of the active-set *SQP*
+/// outer loop. `solver_selection=qp-active-set` used to reach the engine that
+/// way, so they applied; it now drives the engine directly through the convex
+/// path, and without this they would all be silent no-ops. The `sqp_qp_`
+/// spelling is retained because it is the documented, already-in-use name.
+fn active_set_overrides(app: &IpoptApplication) -> pounce_convex::ActiveSetOverrides {
+    use pounce_qp::AntiCyclingChoice;
+    let mut o = pounce_convex::ActiveSetOverrides::default();
+    let opt = app.options();
+    if let Ok((v, true)) = opt.get_integer_value("sqp_qp_max_iter", "") {
+        if v >= 0 {
+            o.max_iter = Some(v as u32);
+        }
+    }
+    if let Ok((v, true)) = opt.get_string_value("sqp_qp_anti_cycling", "") {
+        o.anti_cycling = match v.as_str() {
+            "bland" => Some(AntiCyclingChoice::Bland),
+            "expand" => Some(AntiCyclingChoice::Expand),
+            "none" => Some(AntiCyclingChoice::None),
+            _ => None,
+        };
+    }
+    if let Ok((v, true)) = opt.get_numeric_value("sqp_qp_feas_tol", "") {
+        o.feas_tol = Some(v);
+    }
+    if let Ok((v, true)) = opt.get_numeric_value("sqp_qp_opt_tol", "") {
+        o.opt_tol = Some(v);
+    }
+    if let Ok((v, true)) = opt.get_numeric_value("sqp_qp_elastic_gamma", "") {
+        o.elastic_gamma = Some(v);
+    }
+    if let Ok((v, true)) = opt.get_string_value("sqp_qp_use_schur_updates", "") {
+        o.use_schur_updates = Some(v == "yes");
+    }
+    if let Ok((v, true)) = opt.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "") {
+        if v >= 0 {
+            o.max_schur_updates_before_refactor = Some(v as u32);
+        }
+    }
+    o
+}
+
 /// Build the convex IPM [`pounce_convex::QpOptions`] from the registered CLI
 /// knobs.
 ///
@@ -1740,6 +1758,8 @@ fn run_convex_qp(
     // (`solver_selection=qp-active-set`). Everything else about this driver —
     // extraction, presolve, postsolve, reporting, `.sol` writing — is shared.
     use_active_set: bool,
+    // Inner-engine overrides from the `sqp_qp_*` family; empty for the IPM.
+    engine_overrides: pounce_convex::ActiveSetOverrides,
 ) -> ExitCode {
     use pounce_convex::active_set::solve_qp_active_set;
     use pounce_convex::presolve::{PresolveOutcome, presolve};
@@ -1834,7 +1854,7 @@ fn run_convex_qp(
                 }
                 let red = if use_active_set {
                     let mut mk = backend;
-                    solve_qp_active_set(&ps.reduced, &qp_opts, &mut mk)
+                    solve_qp_active_set(&ps.reduced, &qp_opts, &engine_overrides, &mut mk)
                 } else {
                     solve_qp_ipm(&ps.reduced, &qp_opts, backend)
                 };
@@ -1845,7 +1865,7 @@ fn run_convex_qp(
         }
     } else if use_active_set {
         let mut mk = backend;
-        solve_qp_active_set(&qp, &qp_opts, &mut mk)
+        solve_qp_active_set(&qp, &qp_opts, &engine_overrides, &mut mk)
     } else {
         solve_qp_ipm(&qp, &qp_opts, backend)
     };

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -753,6 +753,46 @@ pub fn main() -> ExitCode {
                 // the-boundary). The active-set engine is a different
                 // algorithm with no such hook, so a `--debug*` request would
                 // otherwise silently no-op. Say so explicitly.
+                // The `sqp_qp_*` family tunes the QP subproblem *of the SQP
+                // outer loop*. On this path there is no SQP outer loop any
+                // more — the engine is driven directly by the convex driver —
+                // so those options no longer reach it. They used to, back when
+                // `qp-active-set` was implemented by rewriting itself to
+                // `algorithm=active-set-sqp`, which makes this a silent
+                // behaviour change for anyone who set one. Say so rather than
+                // ignore them quietly; forwarding them properly is still to do.
+                if matches!(choice, SolverChoice::QpActiveSet) {
+                    let o = app.options();
+                    let ignored: Vec<&str> = [
+                        "sqp_qp_max_iter",
+                        "sqp_qp_anti_cycling",
+                        "sqp_qp_feas_tol",
+                        "sqp_qp_opt_tol",
+                        "sqp_qp_elastic_gamma",
+                        "sqp_qp_use_schur_updates",
+                        "sqp_qp_max_schur_updates_before_refactor",
+                    ]
+                    .into_iter()
+                    .filter(|k| {
+                        // `true` in the tuple means the user set it explicitly.
+                        matches!(o.get_string_value(k, ""), Ok((_, true)))
+                            || matches!(o.get_numeric_value(k, ""), Ok((_, true)))
+                            || matches!(o.get_integer_value(k, ""), Ok((_, true)))
+                    })
+                    .collect();
+                    if !ignored.is_empty() {
+                        eprintln!(
+                            "pounce: warning: {} does not apply to \
+                             solver_selection=qp-active-set, which now drives the \
+                             active-set engine directly through the convex path \
+                             rather than through the active-set SQP outer loop; \
+                             the setting is ignored. Use `max_iter` / `tol` for \
+                             this path, or algorithm=active-set-sqp on a general \
+                             NLP for the SQP knobs.",
+                            ignored.join(", ")
+                        );
+                    }
+                }
                 if matches!(choice, SolverChoice::QpActiveSet) && debug_hook.is_some() {
                     eprintln!(
                         "pounce: note: the interactive debugger is IPM-only and does \

--- a/crates/pounce-cli/tests/qp_dispatch_end_to_end.rs
+++ b/crates/pounce-cli/tests/qp_dispatch_end_to_end.rs
@@ -638,3 +638,44 @@ fn afiro_active_set_solves_under_default_anti_cycling() {
         bland.solution.objective
     );
 }
+
+/// The `sqp_qp_*` option family must actually reach the inner `pounce-qp`
+/// engine on the `qp-active-set` path.
+///
+/// These knobs were written for the QP subproblem of the active-set *SQP* outer
+/// loop. `solver_selection=qp-active-set` used to be implemented by rewriting
+/// itself to `algorithm=active-set-sqp`, so they applied for free; it now drives
+/// the engine directly through the convex path, and every one of them silently
+/// became a no-op until they were forwarded explicitly. A silent no-op on a
+/// documented option is invisible from the outside, hence this test.
+///
+/// `sqp_qp_max_iter` is the cheapest unambiguous probe: an absurdly small
+/// budget must turn a solve that otherwise succeeds into an iteration-limit
+/// stop. If forwarding regresses, `afiro` just solves and this fails.
+#[test]
+fn sqp_qp_options_reach_the_active_set_engine() {
+    let run = |extra: Option<&str>| -> String {
+        let mut cmd = Command::new(pounce_exe());
+        cmd.arg(fixture_named("lp_afiro.nl"))
+            .arg("--no-sol")
+            .arg("solver_selection=qp-active-set");
+        if let Some(e) = extra {
+            cmd.arg(e);
+        }
+        let out = cmd.output().expect("spawn pounce");
+        String::from_utf8_lossy(&out.stdout).into_owned()
+    };
+
+    // Baseline: afiro solves on this path.
+    assert!(
+        run(None).contains("Optimal Solution Found"),
+        "afiro should solve with default options"
+    );
+
+    // A 3-iteration budget cannot reach the optimum ⇒ the option was forwarded.
+    let capped = run(Some("sqp_qp_max_iter=3"));
+    assert!(
+        capped.contains("Maximum iterations exceeded"),
+        "sqp_qp_max_iter=3 must be honoured on the qp-active-set path; got:\n{capped}"
+    );
+}

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -338,6 +338,21 @@ where
         // accuracy and aborted outright on singular Schur blocks. See
         // `pounce-qp/tests/schur_vs_refactor.rs`.
         use_schur_updates: true,
+        // Trace the §4.2 parametric homotopy rather than the conventional
+        // phase-1/phase-2 scheme. Measured on the full Maros-Mészáros set at a
+        // 120 s cap, same binary: 71/138 correct against 58/138 for the
+        // conventional path, with zero solved-but-wrong in both.
+        //
+        // The trade is not uniform — 20 problems gained, 7 lost, and six of the
+        // losses are large instances that previously solved and now hit the
+        // cap (AUG2D, AUG2DC, CONT-050, CONT-100, DTOC3, STADAT3): the homotopy
+        // is slower there, not wrong. `sqp_qp_use_homotopy=no` restores the old
+        // behaviour for such a workload.
+        //
+        // Set here rather than in `QpOptions::default()` on purpose: that
+        // default is read by every `pounce-qp` consumer including the SQP outer
+        // loop's inner subproblems, which this benchmark does not cover.
+        use_homotopy: true,
         ..ActiveSetOptions::default()
     };
     // Applied last: the two settings this driver picks for itself (the

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -65,13 +65,72 @@ use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
 use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
 use pounce_linsol::SparseSymLinearSolverInterface;
 use pounce_qp::{
-    BoundStatus, ConsStatus, HessianInertia, ParametricActiveSetSolver,
+    AntiCyclingChoice, BoundStatus, ConsStatus, HessianInertia, ParametricActiveSetSolver,
     QpOptions as ActiveSetOptions, QpProblem as ActiveSetProblem, QpSolver,
     QpStatus as ActiveSetStatus, QpWarmStart, WorkingSet,
 };
 
 use crate::ipm::QpOptions;
 use crate::qp::{QpProblem, QpSolution, QpStatus};
+
+/// Caller-supplied overrides for the inner `pounce-qp` engine.
+///
+/// Every field is `None` unless the user set the corresponding option
+/// explicitly, so this driver can tell "left at the default" from "asked for
+/// the default value" — a distinction it needs, because it deliberately
+/// overrides two of these itself (a size-scaled `max_iter` and
+/// `use_schur_updates: true`) and an explicit request must win over that.
+///
+/// Exists because these knobs became unreachable when `qp-active-set` moved off
+/// the SQP outer loop: the `sqp_qp_*` option family fed the SQP's QP
+/// subproblem, and with no SQP in the picture all seven silently became no-ops.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ActiveSetOverrides {
+    pub max_iter: Option<u32>,
+    pub anti_cycling: Option<AntiCyclingChoice>,
+    pub feas_tol: Option<f64>,
+    pub opt_tol: Option<f64>,
+    pub elastic_gamma: Option<f64>,
+    pub use_schur_updates: Option<bool>,
+    pub max_schur_updates_before_refactor: Option<u32>,
+}
+
+impl ActiveSetOverrides {
+    /// True when the caller set nothing.
+    pub fn is_empty(&self) -> bool {
+        self.max_iter.is_none()
+            && self.anti_cycling.is_none()
+            && self.feas_tol.is_none()
+            && self.opt_tol.is_none()
+            && self.elastic_gamma.is_none()
+            && self.use_schur_updates.is_none()
+            && self.max_schur_updates_before_refactor.is_none()
+    }
+
+    fn apply(&self, o: &mut ActiveSetOptions) {
+        if let Some(v) = self.max_iter {
+            o.max_iter = v;
+        }
+        if let Some(v) = self.anti_cycling {
+            o.anti_cycling = v;
+        }
+        if let Some(v) = self.feas_tol {
+            o.feas_tol = v;
+        }
+        if let Some(v) = self.opt_tol {
+            o.opt_tol = v;
+        }
+        if let Some(v) = self.elastic_gamma {
+            o.elastic_gamma = v;
+        }
+        if let Some(v) = self.use_schur_updates {
+            o.use_schur_updates = v;
+        }
+        if let Some(v) = self.max_schur_updates_before_refactor {
+            o.max_schur_updates_before_refactor = v;
+        }
+    }
+}
 
 /// Clamp a convex lower-bound value to pounce-qp's `±1e19` free convention.
 fn to_qp_lower(lb: f64) -> f64 {
@@ -117,6 +176,7 @@ fn empty_solution(n: usize, m_eq: usize, m_ineq: usize, status: QpStatus) -> QpS
 pub fn solve_qp_active_set<F>(
     prob: &QpProblem,
     opts: &QpOptions,
+    engine: &ActiveSetOverrides,
     make_backend: &mut F,
 ) -> QpSolution
 where
@@ -143,13 +203,13 @@ where
         equilibrate: false,
         ..*opts
     };
-    let sol = solve_translated(prob, &unscaled_opts, make_backend);
+    let sol = solve_translated(prob, &unscaled_opts, engine, make_backend);
     if !opts.equilibrate || is_solved(sol.status) {
         return sol;
     }
 
     let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
-    let mut retry = solve_translated(&scaled, &unscaled_opts, make_backend);
+    let mut retry = solve_translated(&scaled, &unscaled_opts, engine, make_backend);
     scaling.unscale_solution(prob, &mut retry);
     // Re-verify against the ORIGINAL problem: the verdict reached inside the
     // scaled solve certifies a KKT point of the *scaled* QP, and unscaling
@@ -168,7 +228,12 @@ fn is_solved(s: QpStatus) -> bool {
 
 /// Translate to `pounce-qp` form, solve, and verify — one attempt, no scaling
 /// decisions. `opts.equilibrate` is ignored here; the caller owns that choice.
-fn solve_translated<F>(prob: &QpProblem, opts: &QpOptions, make_backend: &mut F) -> QpSolution
+fn solve_translated<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    engine: &ActiveSetOverrides,
+    make_backend: &mut F,
+) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
@@ -269,6 +334,14 @@ where
         // `pounce-qp/tests/schur_vs_refactor.rs`.
         use_schur_updates: true,
         ..ActiveSetOptions::default()
+    };
+    // Applied last: the two settings this driver picks for itself (the
+    // size-scaled `max_iter` and `use_schur_updates`) are defaults, not
+    // mandates, so an explicit user request overrides them.
+    let qopts = {
+        let mut q = qopts;
+        engine.apply(&mut q);
+        q
     };
 
     // Seed from a simplex phase-1 feasible **vertex**, when one is available.
@@ -688,7 +761,12 @@ mod tests {
     fn analytic_qp_primal_dual_and_sign() {
         let prob = projection_qp();
         let mut mk = backend;
-        let sol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+        let sol = solve_qp_active_set(
+            &prob,
+            &QpOptions::default(),
+            &ActiveSetOverrides::default(),
+            &mut mk,
+        );
 
         assert_eq!(sol.status, QpStatus::Optimal, "status");
         assert!((sol.x[0] - 2.5).abs() < 1e-8, "x0 = {}", sol.x[0]);
@@ -733,7 +811,12 @@ mod tests {
             ub: vec![],
         };
         let mut mk = backend;
-        let asol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+        let asol = solve_qp_active_set(
+            &prob,
+            &QpOptions::default(),
+            &ActiveSetOverrides::default(),
+            &mut mk,
+        );
         let isol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
 
         assert_eq!(asol.status, QpStatus::Optimal);
@@ -779,7 +862,12 @@ mod tests {
             ub: vec![],
         };
         let mut mk = backend;
-        let asol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+        let asol = solve_qp_active_set(
+            &prob,
+            &QpOptions::default(),
+            &ActiveSetOverrides::default(),
+            &mut mk,
+        );
 
         assert_eq!(asol.status, QpStatus::Optimal, "status");
         assert!((asol.x[0] - 1.5).abs() < 1e-7, "x0 = {}", asol.x[0]);
@@ -848,7 +936,12 @@ mod tests {
             ub: vec![],
         };
         let mut mk = backend;
-        let sol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+        let sol = solve_qp_active_set(
+            &prob,
+            &QpOptions::default(),
+            &ActiveSetOverrides::default(),
+            &mut mk,
+        );
 
         assert_eq!(sol.status, QpStatus::Optimal, "status");
         assert!((sol.x[0] - 1.5).abs() < 1e-7, "x0 = {}", sol.x[0]);

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -92,6 +92,7 @@ pub struct ActiveSetOverrides {
     pub opt_tol: Option<f64>,
     pub elastic_gamma: Option<f64>,
     pub use_schur_updates: Option<bool>,
+    pub use_homotopy: Option<bool>,
     pub max_schur_updates_before_refactor: Option<u32>,
 }
 
@@ -104,6 +105,7 @@ impl ActiveSetOverrides {
             && self.opt_tol.is_none()
             && self.elastic_gamma.is_none()
             && self.use_schur_updates.is_none()
+            && self.use_homotopy.is_none()
             && self.max_schur_updates_before_refactor.is_none()
     }
 
@@ -125,6 +127,9 @@ impl ActiveSetOverrides {
         }
         if let Some(v) = self.use_schur_updates {
             o.use_schur_updates = v;
+        }
+        if let Some(v) = self.use_homotopy {
+            o.use_homotopy = v;
         }
         if let Some(v) = self.max_schur_updates_before_refactor {
             o.max_schur_updates_before_refactor = v;
@@ -364,64 +369,74 @@ where
     //     constraint block (the failure `crossover` documents on the GEN family).
     // The basis avoids both: exactly `n` nonbasic variables, each on a bound,
     // linearly independent because the basis matrix is nonsingular.
-    let seed = crate::simplex::simplex_feasible_vertex(prob).map(|v| {
-        use crate::simplex::AtBound;
-        let mut working = WorkingSet::cold(n, m);
-        for (i, st) in working.bounds.iter_mut().enumerate() {
-            // A variable fixed by equal bounds is `Fixed` regardless of which
-            // side the basis parked it on.
-            let (l, u) = (xl[i], xu[i]);
-            let fixed = l > NLP_LOWER_BOUND_INF && u < NLP_UPPER_BOUND_INF && l == u;
-            *st = match (fixed, v.struct_at[i]) {
-                (true, _) => BoundStatus::Fixed,
-                (false, AtBound::Lower) => BoundStatus::AtLower,
-                (false, AtBound::Upper) => BoundStatus::AtUpper,
-                (false, AtBound::Free) => BoundStatus::Inactive,
-            };
-        }
-        // Row order matches: the translation above stacks `[A_eq ; G]` in the
-        // same order the simplex builds its rows, so index `i` is the same row.
-        for (i, st) in working.constraints.iter_mut().enumerate() {
-            // Equality rows are ALWAYS active — they are equations, not
-            // one-sided constraints that may or may not bind.
-            //
-            // Deriving their activity from the basis instead (leaving a row
-            // inactive when its logical is basic) is tempting: it makes the
-            // active count come out at exactly `n` and so avoids the
-            // `KKT inertia mismatch: expected 105 …, got 102` that `CVXQP3_S`
-            // otherwise hits. But the premise is false. An equality's logical
-            // is boxed to `[0, 0]`; a *basic* one is simply a degenerate basic
-            // variable sitting at zero, which says nothing about whether the row
-            // is a linear combination of the others. Dropping such a row drops a
-            // real constraint — the ratio test skips `bl == bu` rows, so it
-            // never comes back — and the engine is then free to move in a
-            // direction that violates it. On NETLIB `afiro` that produced a
-            // phantom `Unbounded` verdict on an LP with a finite optimum of
-            // −464.75 (issue #133's regression test caught it).
-            //
-            // More active rows than variables *is* legitimate at a degenerate
-            // vertex; the dependence among them is a rank problem, and
-            // `schur_reset_rank_repaired` in `pounce-qp` is what resolves it —
-            // by pruning to a maximal independent subset with the algebra to
-            // justify each drop, rather than guessing from basis status here.
-            *st = if i < m_eq {
-                ConsStatus::Equality
-            } else {
-                match v.row_at[i] {
-                    // Slack `s = h − Gx` nonbasic at its lower bound 0 means
-                    // `Gx = h`: the row sits at its upper bound `bu = h`.
-                    AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
-                    AtBound::Free => ConsStatus::Inactive,
-                }
-            };
-        }
-        QpWarmStart {
-            x: v.x,
-            lambda_g: vec![0.0; m],
-            lambda_x: vec![0.0; n],
-            working,
-        }
-    });
+    // Skipped entirely when the homotopy is on: the seed exists *because* the
+    // parametric homotopy was missing, and the homotopy is itself the cold-start
+    // mechanism (it starts from the box relaxation and is feasible along the
+    // whole path). Computing one anyway would both pay for a phase-1 solve that
+    // is no longer needed and suppress the homotopy, whose hook in
+    // `QpSolver::solve` only fires on a genuinely cold call.
+    let seed = if qopts.use_homotopy {
+        None
+    } else {
+        crate::simplex::simplex_feasible_vertex(prob).map(|v| {
+            use crate::simplex::AtBound;
+            let mut working = WorkingSet::cold(n, m);
+            for (i, st) in working.bounds.iter_mut().enumerate() {
+                // A variable fixed by equal bounds is `Fixed` regardless of which
+                // side the basis parked it on.
+                let (l, u) = (xl[i], xu[i]);
+                let fixed = l > NLP_LOWER_BOUND_INF && u < NLP_UPPER_BOUND_INF && l == u;
+                *st = match (fixed, v.struct_at[i]) {
+                    (true, _) => BoundStatus::Fixed,
+                    (false, AtBound::Lower) => BoundStatus::AtLower,
+                    (false, AtBound::Upper) => BoundStatus::AtUpper,
+                    (false, AtBound::Free) => BoundStatus::Inactive,
+                };
+            }
+            // Row order matches: the translation above stacks `[A_eq ; G]` in the
+            // same order the simplex builds its rows, so index `i` is the same row.
+            for (i, st) in working.constraints.iter_mut().enumerate() {
+                // Equality rows are ALWAYS active — they are equations, not
+                // one-sided constraints that may or may not bind.
+                //
+                // Deriving their activity from the basis instead (leaving a row
+                // inactive when its logical is basic) is tempting: it makes the
+                // active count come out at exactly `n` and so avoids the
+                // `KKT inertia mismatch: expected 105 …, got 102` that `CVXQP3_S`
+                // otherwise hits. But the premise is false. An equality's logical
+                // is boxed to `[0, 0]`; a *basic* one is simply a degenerate basic
+                // variable sitting at zero, which says nothing about whether the row
+                // is a linear combination of the others. Dropping such a row drops a
+                // real constraint — the ratio test skips `bl == bu` rows, so it
+                // never comes back — and the engine is then free to move in a
+                // direction that violates it. On NETLIB `afiro` that produced a
+                // phantom `Unbounded` verdict on an LP with a finite optimum of
+                // −464.75 (issue #133's regression test caught it).
+                //
+                // More active rows than variables *is* legitimate at a degenerate
+                // vertex; the dependence among them is a rank problem, and
+                // `schur_reset_rank_repaired` in `pounce-qp` is what resolves it —
+                // by pruning to a maximal independent subset with the algebra to
+                // justify each drop, rather than guessing from basis status here.
+                *st = if i < m_eq {
+                    ConsStatus::Equality
+                } else {
+                    match v.row_at[i] {
+                        // Slack `s = h − Gx` nonbasic at its lower bound 0 means
+                        // `Gx = h`: the row sits at its upper bound `bu = h`.
+                        AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
+                        AtBound::Free => ConsStatus::Inactive,
+                    }
+                };
+            }
+            QpWarmStart {
+                x: v.x,
+                lambda_g: vec![0.0; m],
+                lambda_x: vec![0.0; n],
+                working,
+            }
+        })
+    };
 
     debug_trace(|| {
         format!(

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -70,7 +70,7 @@ use pounce_qp::{
     QpStatus as ActiveSetStatus, QpWarmStart, WorkingSet,
 };
 
-use crate::ipm::QpOptions;
+use crate::ipm::{FARKAS_RESID_TOL, QpOptions, dot, inf_norm};
 use crate::qp::{QpProblem, QpSolution, QpStatus};
 
 /// Caller-supplied overrides for the inner `pounce-qp` engine.
@@ -208,13 +208,25 @@ where
         equilibrate: false,
         ..*opts
     };
-    let sol = solve_translated(prob, &unscaled_opts, engine, make_backend);
-    if !opts.equilibrate || is_solved(sol.status) {
+    let sol = solve_translated(
+        prob,
+        &unscaled_opts,
+        engine,
+        make_backend,
+        FeasibilityProbe::Allowed,
+    );
+    if !opts.equilibrate || is_conclusive(sol.status) {
         return sol;
     }
 
     let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
-    let mut retry = solve_translated(&scaled, &unscaled_opts, engine, make_backend);
+    let mut retry = solve_translated(
+        &scaled,
+        &unscaled_opts,
+        engine,
+        make_backend,
+        FeasibilityProbe::Allowed,
+    );
     scaling.unscale_solution(prob, &mut retry);
     // Re-verify against the ORIGINAL problem: the verdict reached inside the
     // scaled solve certifies a KKT point of the *scaled* QP, and unscaling
@@ -223,12 +235,49 @@ where
     retry.status = reverify_after_unscale(retry.status, &retry, prob, opts);
     // Keep the original failure when the retry also fails, so the reported
     // status describes the attempt made on the problem as the user posed it.
-    if is_solved(retry.status) { retry } else { sol }
+    // `PrimalInfeasible` counts as a win here because `reverify_after_unscale`
+    // just re-earned its Farkas certificate against the *original* problem;
+    // `DualInfeasible` does not, because its witness (the engine's ray) is not
+    // available out here to re-check.
+    if is_solved(retry.status) || retry.status == QpStatus::PrimalInfeasible {
+        retry
+    } else {
+        sol
+    }
 }
 
 /// Did the solve produce a usable, verified KKT point?
 fn is_solved(s: QpStatus) -> bool {
     matches!(s, QpStatus::Optimal | QpStatus::OptimalInaccurate)
+}
+
+/// Is this verdict final — nothing a second attempt could improve on?
+///
+/// Either a verified KKT point or a *verified certificate*. Both are earned
+/// against the original problem (`verify_status` / `reverify_after_unscale`
+/// re-derive every certificate there), so there is no weaker claim here than
+/// [`is_solved`] makes: an equilibrated retry cannot overturn a proof, and
+/// running one anyway would only burn a second solve before falling back to
+/// this same answer.
+///
+/// `DualInfeasible` is deliberately absent from the retry-acceptance side of
+/// this test (see the call site): the unboundedness certificate is re-derived
+/// from a ray that only exists inside `solve_translated`, so a retry's claim
+/// has no witness left to re-check after unscaling.
+fn is_conclusive(s: QpStatus) -> bool {
+    is_solved(s) || matches!(s, QpStatus::PrimalInfeasible | QpStatus::DualInfeasible)
+}
+
+/// May this attempt spend a second solve on the objective-free feasibility twin
+/// to turn an uncertified infeasibility claim into a certified one?
+///
+/// Exists only to make the recursion finite: the probe re-enters
+/// [`solve_translated`] on a problem whose own probe would be the identical
+/// solve, so the inner call is handed [`Self::Forbidden`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FeasibilityProbe {
+    Allowed,
+    Forbidden,
 }
 
 /// Translate to `pounce-qp` form, solve, and verify — one attempt, no scaling
@@ -238,6 +287,7 @@ fn solve_translated<F>(
     opts: &QpOptions,
     engine: &ActiveSetOverrides,
     make_backend: &mut F,
+    probe: FeasibilityProbe,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
@@ -530,6 +580,30 @@ where
         iterates: Vec::new(),
     };
     sol.status = verify_status(engine_status, engine_ray.as_deref(), &sol, prob, opts);
+    // The engine says infeasible and its own multipliers could not prove it.
+    // Before demoting that to "the solver broke", spend one more solve on the
+    // objective-free twin, whose multipliers *can* — see [`feasibility_probe`].
+    if engine_status == ActiveSetStatus::Infeasible
+        && sol.status == QpStatus::NumericalFailure
+        && probe == FeasibilityProbe::Allowed
+        && let Some((y, z)) = feasibility_probe(prob, opts, engine, make_backend)
+    {
+        // Carry the *certifying* multipliers out, replacing the
+        // objective-carrying ones that proved nothing. This keeps the invariant
+        // every consumer of a `PrimalInfeasible` here relies on — the returned
+        // `(y, z)` verify the status attached to them — which is what lets
+        // `reverify_after_unscale` re-earn the verdict against the original
+        // problem after an equilibrated retry. Without it that re-check tested
+        // the wrong vectors and threw away a proof the driver had just made.
+        // The bound duals are dropped rather than left mismatched: the
+        // certificate is a statement about `(y, z)` and the box, and stale
+        // `z_lb`/`z_ub` from a different multiplier set say nothing about it.
+        sol.y = y;
+        sol.z = z;
+        sol.z_lb = vec![0.0; n];
+        sol.z_ub = vec![0.0; n];
+        sol.status = QpStatus::PrimalInfeasible;
+    }
     debug_trace(|| {
         format!(
             "engine={:?} -> reported={:?} kkt_err={:.3e} obj={:.6e}",
@@ -540,6 +614,55 @@ where
         )
     });
     sol
+}
+
+/// Re-solve the **objective-free twin** of `prob` — same `A, b, G, h` and the
+/// same box, but `P = 0` and `c = 0` — and return *its* multipliers `(y, z)`
+/// when they prove the constraint system has no solution.
+///
+/// # Why a second solve is the right answer here
+///
+/// [`certifies_primal_infeasible`] fails on an unbounded variable for a
+/// structural reason, not a tolerance one: the elastic phase-1 multipliers carry
+/// a residual `Aᵀy + Gᵀz = −(Px + c)` left behind by the original objective, and
+/// with no finite bound on that variable there is nothing to bound its
+/// contribution with. Deleting the objective deletes the residual at the source:
+/// the twin's phase-1 minimizes violation *alone*, so its stationarity is
+/// `Aᵀy + Gᵀz = 0` to machine precision — a textbook Farkas pair. Measured on
+/// the gh #415 LP with its bounds removed: `q = (0, 0)` exactly against
+/// `q = (−1, −1)` from the objective-carrying solve.
+///
+/// The twin has the *same feasible set* as `prob`, so a certificate for it is a
+/// certificate for `prob` — which is why the check below is run against `prob`
+/// itself and needs no translation back.
+///
+/// This costs a whole extra solve, so it is deliberately last: only after the
+/// engine has already claimed infeasibility *and* the free check on its own
+/// multipliers came up empty. A feasible problem reaches it only via a false
+/// `Infeasible` claim (the `DUALC1` hazard), and then the twin solve finds the
+/// feasible set is non-empty and certifies nothing — the claim stays demoted.
+fn feasibility_probe<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    engine: &ActiveSetOverrides,
+    make_backend: &mut F,
+) -> Option<(Vec<f64>, Vec<f64>)>
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    let twin = QpProblem {
+        p_lower: Vec::new(),
+        c: vec![0.0; prob.n],
+        ..prob.clone()
+    };
+    let sol = solve_translated(
+        &twin,
+        opts,
+        engine,
+        make_backend,
+        FeasibilityProbe::Forbidden,
+    );
+    certifies_primal_infeasible(prob, &sol.y, &sol.z, opts).then_some((sol.y, sol.z))
 }
 
 /// Emit a diagnostic line when `POUNCE_AS_DEBUG` is set in the environment.
@@ -563,12 +686,26 @@ fn debug_trace(msg: impl FnOnce() -> String) {
 /// unscaled point still earns it, and let a solve that lands in the acceptable
 /// band say so. Non-success statuses pass through — they made no claim to
 /// re-check.
+///
+/// A `PrimalInfeasible` carried out of the scaled solve is a claim too, and one
+/// with the same problem: equilibration is a diagonal congruence, so it
+/// preserves *whether* the QP is infeasible but not the certificate's numbers,
+/// which `unscale_solution` has moved. So the Farkas certificate is re-derived
+/// here against the original data rather than inherited on the strength of the
+/// scaled problem's arithmetic.
 fn reverify_after_unscale(
     scaled_status: QpStatus,
     sol: &QpSolution,
     prob: &QpProblem,
     opts: &QpOptions,
 ) -> QpStatus {
+    if scaled_status == QpStatus::PrimalInfeasible {
+        return if certifies_primal_infeasible(prob, &sol.y, &sol.z, opts) {
+            QpStatus::PrimalInfeasible
+        } else {
+            QpStatus::NumericalFailure
+        };
+    }
     if !matches!(
         scaled_status,
         QpStatus::Optimal | QpStatus::OptimalInaccurate
@@ -606,10 +743,11 @@ fn reverify_after_unscale(
 ///   published optimum of `6155.25`, and the phase-1 elastic mode certifies it
 ///   infeasible. An infeasibility verdict is a *proof obligation*: the IPM
 ///   only reports one behind a verified Farkas certificate, and the SQP path
-///   deliberately refuses to assert infeasibility it cannot back (#282). The
-///   active-set engine has no certificate to offer here, so its claim is
-///   downgraded to an honest "did not solve" rather than propagated as a
-///   verdict about the user's model.
+///   deliberately refuses to assert infeasibility it cannot back (#282). So the
+///   claim is not propagated on the engine's word — it is re-derived here from
+///   the phase-1 multipliers ([`certifies_primal_infeasible`], with
+///   [`feasibility_probe`] as a second attempt) and only reported when it holds.
+///   A claim that cannot be backed is downgraded to an honest "did not solve".
 ///
 /// The `Optimal` / `OptimalInaccurate` / fail banding mirrors the IPM's
 /// post-loop verdict (`hsde.rs`): within `tol` is clean, within `1e3·tol` is
@@ -653,10 +791,23 @@ fn verify_status(
             // No ray, or a ray that does not stand up: fall back on the point.
             _ => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
         },
-        // Uncertified infeasibility claim — never propagated as a verdict.
-        // If the returned point happens to satisfy the KKT conditions anyway,
-        // report that instead; otherwise say honestly that we did not solve it.
-        ActiveSetStatus::Infeasible => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
+        // Infeasibility is a proof obligation, so the claim is re-derived from
+        // the phase-1 multipliers exactly as the `Unbounded` claim is re-derived
+        // from the ray. A certificate that stands up is the *right* verdict about
+        // the user's model and must be reported as such (gh #415: without this,
+        // a two-row LP whose contradiction is visible by inspection came back as
+        // `InternalError` / `solve_result_num=500` — "the solver broke, retry" —
+        // where every other engine said `200`, "your model is infeasible").
+        // A claim that does not stand up is still downgraded: if the returned
+        // point satisfies the KKT conditions anyway, report that; otherwise say
+        // honestly that we did not solve it.
+        ActiveSetStatus::Infeasible => {
+            if certifies_primal_infeasible(prob, &sol.y, &sol.z, opts) {
+                QpStatus::PrimalInfeasible
+            } else {
+                solved_to(err).unwrap_or(QpStatus::NumericalFailure)
+            }
+        }
         // Budget or breakdown: the point may still be good enough to report at
         // the acceptable tier (the IPM salvages solves this way), but it is
         // never promoted to a clean `Optimal`.
@@ -729,6 +880,114 @@ fn ray_certifies_unbounded(prob: &QpProblem, d: &[f64]) -> bool {
     // derivative `(Px + c)ᵀd` reduces to `cᵀd` independently of `x`.
     let slope: f64 = (0..prob.n).map(|i| prob.c[i] * d[i]).sum();
     slope < -slack
+}
+
+/// Do the multipliers `(y, z ≥ 0)` prove that `prob` has **no** feasible point?
+///
+/// # Why not the textbook Farkas test
+///
+/// The classic certificate for `{x : Ax = b, Gx ≤ h}` is `(y, z ≥ 0)` with
+/// `Aᵀy + Gᵀz = 0` and `bᵀy + hᵀz < 0`, and that is what the IPM checks
+/// ([`crate::ipm::detect_infeasibility`]). Applied to *these* multipliers it
+/// rejects every genuine certificate the active-set engine produces, because of
+/// where they come from: the l1-elastic phase-1 minimizes
+/// `½xᵀPx + cᵀx + γ·(violation)`, so its stationarity condition is
+/// `Px + c + Aᵀy + Gᵀz = 0` — the original objective is still in there, and
+/// `q := Aᵀy + Gᵀz` settles at `−(Px + c)`, not at `0`. That residual does not
+/// shrink as phase-1 converges; it only shrinks *relative to* `‖(y,z)‖ ∝ γ`.
+/// On the two-row LP of gh #415 the relative residual is `1e-6` against a
+/// `FARKAS_RESID_TOL` of `1e-10`, so the certificate — which is real — reads as
+/// noise, and the engine's correct `Infeasible` verdict was thrown away as a
+/// numerical failure.
+///
+/// # The test used instead
+///
+/// For **any** feasible `x` and any `(y, z ≥ 0)`, `yᵀ(Ax − b) = 0` and
+/// `zᵀ(Gx − h) ≤ 0`, so
+///
+/// ```text
+///     qᵀx  ≤  bᵀy + hᵀz  =:  v          where q := Aᵀy + Gᵀz
+/// ```
+///
+/// A feasible `x` also lies in the box, so `qᵀx ≥ L := min_{lb ≤ x ≤ ub} qᵀx`,
+/// which is separable: `L = Σᵢ min(qᵢ·lbᵢ, qᵢ·ubᵢ)`. Therefore
+///
+/// ```text
+///     L > v   ⟹   no feasible point exists.
+/// ```
+///
+/// This is a strict generalization of the Farkas test — with no finite bounds
+/// it *is* the Farkas test (`L` is finite only if `q ≡ 0`, and then `L = 0 > v`
+/// is exactly `v < 0`) — but on a boxed problem it does not merely *tolerate*
+/// the `−(Px + c)` residual, it accounts for it exactly. The bound multipliers
+/// `z_lb`/`z_ub` are deliberately not used: minimizing over the box is the same
+/// deduction done optimally, and it cannot be thrown off by a phase-1 iterate's
+/// noisy bound duals.
+///
+/// A variable whose *binding* side is infinite makes `L = −∞` and there is
+/// nothing to deduce — unless its `qᵢ` is negligible, which is the one place
+/// this falls back on [`FARKAS_RESID_TOL`]'s tolerance argument rather than an
+/// exact bound.
+///
+/// Soundness is the property that matters here: a false positive is a wrong
+/// verdict about the user's model, which is worse than any failure status (the
+/// `DUALC1` hazard this module's docs describe). Every step above is an
+/// inequality that holds for *every* feasible point, so a pass is a proof up to
+/// floating point, and the `ctol` margin covers that.
+fn certifies_primal_infeasible(prob: &QpProblem, y: &[f64], z: &[f64], opts: &QpOptions) -> bool {
+    if y.len() != prob.m_eq() || z.len() != prob.m_ineq() {
+        return false;
+    }
+    let dual_norm = inf_norm(y).max(inf_norm(z));
+    if !dual_norm.is_finite() || dual_norm == 0.0 {
+        return false;
+    }
+    // `z ≥ 0` is what makes `zᵀ(Gx − h) ≤ 0`; without it there is no deduction.
+    let ctol = opts.infeas_tol;
+    if z.iter().any(|&zi| zi < -ctol * dual_norm) {
+        return false;
+    }
+
+    let mut q = vec![0.0; prob.n]; // q = Aᵀy + Gᵀz
+    prob.at_mul(y, &mut q);
+    prob.gt_mul(z, &mut q);
+    let v = dot(&prob.b, y) + dot(&prob.h, z); // v = bᵀy + hᵀz
+    if !v.is_finite() {
+        return false;
+    }
+
+    // L = min over the box of qᵀx, separably.
+    let resid_slack = FARKAS_RESID_TOL * dual_norm;
+    let mut l = 0.0_f64;
+    for (i, &qi) in q.iter().enumerate() {
+        if !qi.is_finite() {
+            return false;
+        }
+        if qi == 0.0 {
+            continue;
+        }
+        // The minimizing corner: push `xᵢ` to its lower bound when `qᵢ > 0`, to
+        // its upper bound when `qᵢ < 0`.
+        let bound = if qi > 0.0 {
+            prob.lb_of(i)
+        } else {
+            prob.ub_of(i)
+        };
+        if bound > crate::qp::NEG_INF && bound < crate::qp::POS_INF {
+            l += qi * bound;
+        } else if qi.abs() > resid_slack {
+            return false; // qᵀx is unbounded below on the box — no deduction
+        }
+    }
+    if !l.is_finite() {
+        return false;
+    }
+
+    // Margin against floating-point noise, relative to the magnitudes actually
+    // compared. Scaling by `dual_norm` as well keeps a certificate whose two
+    // sides are both ~0 next to huge multipliers from passing on rounding.
+    let mag = dual_norm.max(v.abs()).max(l.abs());
+    l - v > ctol * mag
 }
 
 /// Iteration budget for the active-set engine.
@@ -912,6 +1171,125 @@ mod tests {
             "obj: active-set {} vs ipm {}",
             asol.obj,
             isol.obj
+        );
+    }
+
+    /// One row `−x ≤ −rhs` (i.e. `x ≥ rhs`) on a single variable in `[0, 10]`.
+    /// Infeasible exactly when `rhs > 10`, and infeasible *because of the box* —
+    /// the row alone is satisfiable, so the classic zero-residual Farkas test
+    /// has nothing to say here and only the box minimization can decide it.
+    fn one_row_vs_box(rhs: f64) -> QpProblem {
+        QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, -1.0)],
+            h: vec![-rhs],
+            lb: vec![0.0],
+            ub: vec![10.0],
+        }
+    }
+
+    /// The box minimization must be evaluated at the corner that *minimizes*
+    /// `qᵀx`, and getting that backwards certifies feasible problems as
+    /// infeasible. `x ≥ 5` with `x ≤ 10` is plainly satisfiable; the multiplier
+    /// `z = 1` gives `q = (−1)` and `v = −5`, so the true bound
+    /// `L = q·ub = −10` correctly fails `L > v`, whereas the wrong corner
+    /// (`q·lb = 0`) would "prove" a feasible problem empty.
+    #[test]
+    fn box_minimum_is_taken_at_the_minimizing_corner() {
+        assert!(
+            !certifies_primal_infeasible(&one_row_vs_box(5.0), &[], &[1.0], &QpOptions::default()),
+            "x ≥ 5, x ≤ 10 is feasible — no certificate may be accepted"
+        );
+    }
+
+    /// The same shape pushed past the box: `x ≥ 15` with `x ≤ 10` is empty, and
+    /// `L = −10 > v = −15` proves it.
+    #[test]
+    fn box_only_infeasibility_is_certified() {
+        assert!(certifies_primal_infeasible(
+            &one_row_vs_box(15.0),
+            &[],
+            &[1.0],
+            &QpOptions::default()
+        ));
+    }
+
+    /// A feasible QP whose feasible set is the single point `{0}` — every row
+    /// active, no interior, multipliers wildly non-unique (the #282 hazard in
+    /// miniature). Elastic-scale multipliers on it produce `q = 0` and `v = 0`:
+    /// no strict descent, so no certificate. A false positive here would be a
+    /// wrong statement about the user's model.
+    #[test]
+    fn spurious_certificate_on_feasible_qp_is_rejected() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+            c: vec![-1.0, -1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(1, 0, -1.0),
+                Triplet::new(2, 1, 1.0),
+                Triplet::new(3, 1, -1.0),
+            ],
+            h: vec![0.0; 4],
+            lb: vec![],
+            ub: vec![],
+        };
+        assert!(!certifies_primal_infeasible(
+            &prob,
+            &[],
+            &[1e6, 1e6, 1e6, 1e6],
+            &QpOptions::default()
+        ));
+    }
+
+    /// gh #415's multipliers, verbatim from the engine: `z = (999999, 1e6)` on
+    /// `x₀ + x₁ ≤ 1` / `x₀ + x₁ ≥ 3`. They leave `q = (−1, −1) = −c`, a
+    /// *relative* residual of `1e−6` against a `FARKAS_RESID_TOL` of `1e−10`,
+    /// so the textbook Farkas test rejects them — which is how a certified
+    /// infeasibility became `NumericalFailure`. With the box `[0, 10]²` the
+    /// residual is accounted for exactly (`L = −20 > v = −2000001`).
+    ///
+    /// Delete the box and the same multipliers must stop being a proof: that is
+    /// not a regression but the reason [`feasibility_probe`] exists.
+    #[test]
+    fn box_accounts_for_the_objective_residual_the_farkas_test_rejects() {
+        let boxed = QpProblem {
+            n: 2,
+            p_lower: vec![],
+            c: vec![1.0, 1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(0, 1, 1.0),
+                Triplet::new(1, 0, -1.0),
+                Triplet::new(1, 1, -1.0),
+            ],
+            h: vec![1.0, -3.0],
+            lb: vec![0.0, 0.0],
+            ub: vec![10.0, 10.0],
+        };
+        let z = [999_999.0, 1_000_000.0];
+        assert!(
+            certifies_primal_infeasible(&boxed, &[], &z, &QpOptions::default()),
+            "the box makes these multipliers a proof"
+        );
+
+        let free = QpProblem {
+            lb: vec![],
+            ub: vec![],
+            ..boxed
+        };
+        assert!(
+            !certifies_primal_infeasible(&free, &[], &z, &QpOptions::default()),
+            "without a box the residual is unaccounted for — must not be trusted"
         );
     }
 

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -1,0 +1,724 @@
+//! Active-set QP driver — the [`pounce_qp`] parametric active-set engine
+//! wired directly into the convex path, as a peer of [`crate::ipm`].
+//!
+//! # Why this module exists
+//!
+//! `solver_selection=qp-active-set` used to reach the active-set engine the
+//! long way round: the CLI rewrote it to `algorithm=active-set-sqp` and ran
+//! the **full SQP outer loop** over the QP, treating it as a general NLP.
+//!
+//! That is not mathematically wrong. With an exact Hessian and constraints
+//! that are already linear, the first SQP subproblem *is* the original QP, so
+//! a healthy run converges in one outer iteration (and did — successful solves
+//! reported `n_iter = 1`). But it is an architectural mismatch that forfeits
+//! everything the convex path already has, and pays for machinery a QP does
+//! not need:
+//!
+//! * **No presolve.** The SQP path never touches [`crate::presolve`], so the
+//!   engine faced every redundant row, fixed variable, and singleton the
+//!   IPM never sees. This matters far more for an active-set method than for
+//!   an IPM: interior-point iteration counts are nearly problem-size
+//!   independent, whereas an active-set pivot count is *combinatorial* in the
+//!   size of the active set. Presolve is the difference between a shrunk
+//!   problem and one that exhausts its iteration budget.
+//! * **No scaling.** No Ruiz equilibration, and `nlp_scaling` is not threaded
+//!   through the SQP residuals at all.
+//! * **No timing, and misleading statuses**, both of which routed through the
+//!   NLP report path rather than the convex one.
+//! * **Pointless overhead**: AMPL evaluation callbacks, BFGS storage, and a
+//!   filter/line-search globalization, none of which do anything for a
+//!   problem whose linearization is exact.
+//!
+//! This module is the direct route. It hands the QP straight to
+//! [`ParametricActiveSetSolver`], inside the same presolve → solve → postsolve
+//! wrapper the IPM runs under, so the engine inherits the convex driver's
+//! problem reduction, reporting, and status vocabulary.
+//!
+//! The SQP route is untouched and remains correct for genuine NLPs
+//! (`algorithm=active-set-sqp`), where the outer loop is doing real work.
+//!
+//! # Translation
+//!
+//! The convex → `pounce-qp` translation (and, critically, the **dual sign
+//! transform** on the way back) is the same one [`crate::crossover`] performs;
+//! see that module's docs for the derivation. The differences here are:
+//!
+//! * The Hessian is carried through. Crossover is gated to pure LPs and builds
+//!   an empty `H`; a QP driver must translate `p_lower`. Both sides store the
+//!   **lower triangle once, 1-based for `pounce-qp` and 0-based for the convex
+//!   form**, mirroring off-diagonals implicitly — see
+//!   [`QpProblem::p_mul_add`](crate::qp::QpProblem::p_mul_add) against
+//!   `pounce_qp`'s `SymTMatrixSpace`, which agree exactly, so the map is a
+//!   straight `+1` on both indices with no triangle fixup.
+//! * The starting point comes from a **simplex phase-1 feasible vertex**
+//!   rather than an IPM iterate (there is no prior iterate here to hint from).
+//!   That seed is what makes this path work at all: `pounce-qp`'s own
+//!   l1-elastic phase-1 does not terminate on the degenerate netlib-derived
+//!   QPs in the Maros-Mészáros set, and handing `solve` a feasible primal
+//!   routes it straight to phase-2, which is the part of the method that is
+//!   strong. See `crate::simplex::simplex_feasible_vertex`.
+//! * Every terminal status is mapped, not just `Optimal` — this is the primary
+//!   driver, so it must report `MaxIter` / `NumericalError` / `Infeasible` /
+//!   `Unbounded` honestly rather than falling back to a previous solution.
+
+use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_linsol::SparseSymLinearSolverInterface;
+use pounce_qp::{
+    BoundStatus, ConsStatus, HessianInertia, ParametricActiveSetSolver,
+    QpOptions as ActiveSetOptions, QpProblem as ActiveSetProblem, QpSolver,
+    QpStatus as ActiveSetStatus, QpWarmStart, WorkingSet,
+};
+
+use crate::ipm::QpOptions;
+use crate::qp::{QpProblem, QpSolution, QpStatus};
+
+/// Clamp a convex lower-bound value to pounce-qp's `±1e19` free convention.
+fn to_qp_lower(lb: f64) -> f64 {
+    if lb <= NLP_LOWER_BOUND_INF {
+        NLP_LOWER_BOUND_INF
+    } else {
+        lb
+    }
+}
+
+/// Clamp a convex upper-bound value to pounce-qp's `±1e19` free convention.
+fn to_qp_upper(ub: f64) -> f64 {
+    if ub >= NLP_UPPER_BOUND_INF {
+        NLP_UPPER_BOUND_INF
+    } else {
+        ub
+    }
+}
+
+/// A solution carrying no information, returned when the engine reports a
+/// status for which no iterate is meaningful. `x` is zero-filled rather than
+/// left empty so downstream residual/objective code has the right lengths.
+fn empty_solution(n: usize, m_eq: usize, m_ineq: usize, status: QpStatus) -> QpSolution {
+    QpSolution {
+        status,
+        x: vec![0.0; n],
+        y: vec![0.0; m_eq],
+        z: vec![0.0; m_ineq],
+        z_lb: vec![0.0; n],
+        z_ub: vec![0.0; n],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    }
+}
+
+/// Solve a convex QP with the [`pounce_qp`] parametric active-set engine.
+///
+/// Signature-compatible with [`crate::ipm::solve_qp_ipm`] so the CLI driver
+/// can select between them without restructuring, including the
+/// `make_backend` factory (the active-set engine may need more than one
+/// backend instance over a solve).
+pub fn solve_qp_active_set<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    make_backend: &mut F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    // Ruiz equilibration is applied as a **retry after failure**, not
+    // unconditionally, because for this engine it is a genuine trade rather
+    // than an improvement. Measured on Maros-Mészáros:
+    //
+    // | problem  | unscaled            | Ruiz-equilibrated   |
+    // |----------|---------------------|---------------------|
+    // | LOTSCHD  | MaxIter (2.36)      | **Optimal (2398.4)**|
+    // | CVXQP1_S | **Optimal (11590.7)**| MaxIter (17220)    |
+    // | CVXQP2_S | **Optimal (8120.9)** | MaxIter (9965)     |
+    //
+    // Scaling rescues the badly-scaled netlib-derived instances and breaks the
+    // well-scaled CVXQP family, so *neither* fixed choice dominates. Solving
+    // unscaled first and equilibrating only when that fails takes both columns'
+    // wins and cannot regress: we reach the retry only after the first attempt
+    // already failed to produce a verified KKT point. This mirrors the IPM's
+    // own HSDE-then-Ruiz fallback (`solve_qp_ipm_core`) and its reasoning
+    // — "there is nothing left to regress".
+    let unscaled_opts = QpOptions {
+        equilibrate: false,
+        ..*opts
+    };
+    let sol = solve_translated(prob, &unscaled_opts, make_backend);
+    if !opts.equilibrate || is_solved(sol.status) {
+        return sol;
+    }
+
+    let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
+    let mut retry = solve_translated(&scaled, &unscaled_opts, make_backend);
+    scaling.unscale_solution(prob, &mut retry);
+    // Re-verify against the ORIGINAL problem: the verdict reached inside the
+    // scaled solve certifies a KKT point of the *scaled* QP, and unscaling
+    // moves the residuals, so it has to be re-earned here rather than carried
+    // over on the strength of the wrong problem's numbers.
+    retry.status = reverify_after_unscale(retry.status, &retry, prob, opts);
+    // Keep the original failure when the retry also fails, so the reported
+    // status describes the attempt made on the problem as the user posed it.
+    if is_solved(retry.status) { retry } else { sol }
+}
+
+/// Did the solve produce a usable, verified KKT point?
+fn is_solved(s: QpStatus) -> bool {
+    matches!(s, QpStatus::Optimal | QpStatus::OptimalInaccurate)
+}
+
+/// Translate to `pounce-qp` form, solve, and verify — one attempt, no scaling
+/// decisions. `opts.equilibrate` is ignored here; the caller owns that choice.
+fn solve_translated<F>(prob: &QpProblem, opts: &QpOptions, make_backend: &mut F) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    let n = prob.n;
+    let m_eq = prob.m_eq();
+    let m_ineq = prob.m_ineq();
+    let m = m_eq + m_ineq;
+
+    // ---- Hessian: lower triangle, 0-based -> 1-based (no triangle fixup) ----
+    let mut h_irow = Vec::with_capacity(prob.p_lower.len());
+    let mut h_jcol = Vec::with_capacity(prob.p_lower.len());
+    let mut h_val = Vec::with_capacity(prob.p_lower.len());
+    for t in &prob.p_lower {
+        // Defensive: the convex form documents `row >= col`, but a caller
+        // that supplied the upper triangle would otherwise be silently
+        // transposed into a different matrix. Normalizing costs nothing and
+        // makes the translation total.
+        let (r, c) = if t.row >= t.col {
+            (t.row, t.col)
+        } else {
+            (t.col, t.row)
+        };
+        h_irow.push((r + 1) as i32);
+        h_jcol.push((c + 1) as i32);
+        h_val.push(t.val);
+    }
+    let h_space = SymTMatrixSpace::new(n as i32, h_irow, h_jcol);
+    let mut h = SymTMatrix::new(h_space);
+    h.set_values(&h_val);
+
+    // ---- Jacobian A_qp = [A_eq ; G], 1-based ----
+    let nnz = prob.a.len() + prob.g.len();
+    let mut irows = Vec::with_capacity(nnz);
+    let mut jcols = Vec::with_capacity(nnz);
+    let mut vals = Vec::with_capacity(nnz);
+    for t in &prob.a {
+        irows.push((t.row + 1) as i32);
+        jcols.push((t.col + 1) as i32);
+        vals.push(t.val);
+    }
+    for t in &prob.g {
+        irows.push((m_eq + t.row + 1) as i32);
+        jcols.push((t.col + 1) as i32);
+        vals.push(t.val);
+    }
+    let mut a_qp = GenTMatrix::new(GenTMatrixSpace::new(m as i32, n as i32, irows, jcols));
+    a_qp.set_values(&vals);
+
+    // ---- Row bounds: eq rows bl=bu=b; ineq rows bl=-inf, bu=h ----
+    let mut bl = Vec::with_capacity(m);
+    let mut bu = Vec::with_capacity(m);
+    for &bk in &prob.b {
+        bl.push(bk);
+        bu.push(bk);
+    }
+    for &hi in &prob.h {
+        bl.push(NLP_LOWER_BOUND_INF);
+        bu.push(to_qp_upper(hi));
+    }
+
+    // ---- Variable bounds ----
+    let mut xl = Vec::with_capacity(n);
+    let mut xu = Vec::with_capacity(n);
+    for i in 0..n {
+        xl.push(to_qp_lower(prob.lb_of(i)));
+        xu.push(to_qp_upper(prob.ub_of(i)));
+    }
+
+    let g_lin = prob.c.clone();
+    let qp = ActiveSetProblem {
+        n,
+        m,
+        h: &h,
+        g: &g_lin,
+        a: &a_qp,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        // The convex path only accepts problems the class detector has already
+        // ruled convex, so the Hessian is PSD by construction.
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let qopts = ActiveSetOptions {
+        max_iter: active_set_iter_budget(opts, n, m),
+        // Absorb working-set changes as rank-2 Schur updates against a cached
+        // factor instead of assembling and factoring a fresh active-set KKT
+        // every iteration. This is the lever the wall-clock problem needs: a
+        // cold convex-QP solve here runs thousands of iterations (budget
+        // `10·(n+m)`), and a per-iteration refactorization is what turns that
+        // into a timeout — `QSCTAP1` goes from a 60s timeout to ~2s.
+        //
+        // Enabling it required fixing two real defects in that path first
+        // (`pounce-qp`: singular-Schur recovery, and iterative refinement in
+        // `SchurState::solve`); before those it silently lost ~1e-6 of
+        // accuracy and aborted outright on singular Schur blocks. See
+        // `pounce-qp/tests/schur_vs_refactor.rs`.
+        use_schur_updates: true,
+        ..ActiveSetOptions::default()
+    };
+
+    // Seed from a simplex phase-1 feasible **vertex**, when one is available.
+    //
+    // `QpSolver::solve` routes a warm start whose primal is feasible directly
+    // into phase-2 and never enters l1-elastic mode — which is the point, since
+    // that phase-1 does not terminate on the degenerate netlib-derived QPs here
+    // (see `simplex::simplex_feasible_vertex`). Phase-2 from a feasible vertex
+    // is the part of this method that works well.
+    //
+    // The working set must come from the simplex **basis**, not from
+    // tolerance-snapping the point. `solve_general` trusts the working set it
+    // is handed and steps with a zero-RHS active-set system, so:
+    //   * a *cold* working set claims nothing is active, and on these low-rank
+    //     `P` instances the reduced Hessian is then singular and the engine
+    //     certifies a spurious zero-curvature ray (measured: `QSHARE2B`
+    //     `-1.2e10`, `QSCAGR7` `-9.9e14`, both `DivergingIterates`);
+    //   * snapping every tight row instead names *more than* `n` binding rows
+    //     at a degenerate vertex, and no H-block shift repairs a rank-deficient
+    //     constraint block (the failure `crossover` documents on the GEN family).
+    // The basis avoids both: exactly `n` nonbasic variables, each on a bound,
+    // linearly independent because the basis matrix is nonsingular.
+    let seed = crate::simplex::simplex_feasible_vertex(prob).map(|v| {
+        use crate::simplex::AtBound;
+        let mut working = WorkingSet::cold(n, m);
+        for (i, st) in working.bounds.iter_mut().enumerate() {
+            // A variable fixed by equal bounds is `Fixed` regardless of which
+            // side the basis parked it on.
+            let (l, u) = (xl[i], xu[i]);
+            let fixed = l > NLP_LOWER_BOUND_INF && u < NLP_UPPER_BOUND_INF && l == u;
+            *st = match (fixed, v.struct_at[i]) {
+                (true, _) => BoundStatus::Fixed,
+                (false, AtBound::Lower) => BoundStatus::AtLower,
+                (false, AtBound::Upper) => BoundStatus::AtUpper,
+                (false, AtBound::Free) => BoundStatus::Inactive,
+            };
+        }
+        // Row order matches: the translation above stacks `[A_eq ; G]` in the
+        // same order the simplex builds its rows, so index `i` is the same row.
+        for (i, st) in working.constraints.iter_mut().enumerate() {
+            *st = if i < m_eq {
+                // Equality rows are always active; their logical is boxed to
+                // `[0, 0]` on the simplex side, so it is nonbasic in any case.
+                ConsStatus::Equality
+            } else {
+                match v.row_at[i] {
+                    // Slack `s = h − Gx` nonbasic at its lower bound 0 means
+                    // `Gx = h`: the row sits at its upper bound `bu = h`.
+                    AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
+                    AtBound::Free => ConsStatus::Inactive,
+                }
+            };
+        }
+        QpWarmStart {
+            x: v.x,
+            lambda_g: vec![0.0; m],
+            lambda_x: vec![0.0; n],
+            working,
+        }
+    });
+
+    let mut solver = ParametricActiveSetSolver::new(make_backend());
+    let qsol = match solver.solve(&qp, seed.as_ref(), &qopts) {
+        Ok(q) => q,
+        // A hard `QpError` (singular factor, dimension mismatch) is a
+        // numerical failure, not an infeasibility claim — never assert
+        // infeasibility without a certificate.
+        Err(_) => return empty_solution(n, m_eq, m_ineq, QpStatus::NumericalFailure),
+    };
+
+    let engine_status = qsol.status;
+
+    // ---- Back-translate (sign transform — see crate::crossover docs) ----
+    let mut y = vec![0.0; m_eq];
+    if qsol.lambda_g.len() >= m_eq {
+        y.copy_from_slice(&qsol.lambda_g[..m_eq]);
+    }
+    let mut z = vec![0.0; m_ineq];
+    for i in 0..m_ineq {
+        if let Some(&l) = qsol.lambda_g.get(m_eq + i) {
+            z[i] = l.max(0.0);
+        }
+    }
+    let mut z_lb = vec![0.0; n];
+    let mut z_ub = vec![0.0; n];
+    for i in 0..n {
+        if let Some(&l) = qsol.lambda_x.get(i) {
+            z_lb[i] = l.max(0.0);
+            z_ub[i] = (-l).max(0.0);
+        }
+    }
+
+    // Objective recomputed in convex coordinates (½xᵀPx + cᵀx) rather than
+    // taken from the engine, so the two forms cannot silently drift apart.
+    let mut px = vec![0.0; n];
+    prob.p_mul(&qsol.x, &mut px);
+    let obj = (0..n).map(|i| (0.5 * px[i] + prob.c[i]) * qsol.x[i]).sum();
+
+    let mut sol = QpSolution {
+        // Provisional — `verify_status` below decides the final verdict.
+        status: QpStatus::Optimal,
+        x: qsol.x,
+        y,
+        z,
+        z_lb,
+        z_ub,
+        obj,
+        // The active-set engine counts active-set changes rather than
+        // interior-point iterations; that is its analogue of "iterations"
+        // and the quantity a user tuning `max_iter` is actually spending.
+        iters: qsol.stats.n_working_set_changes as usize,
+        iterates: Vec::new(),
+    };
+    sol.status = verify_status(engine_status, &sol, prob, opts);
+    sol
+}
+
+/// Re-earn a status against the original problem after unscaling.
+///
+/// A success carried out of the scaled solve is only evidence about the scaled
+/// QP. Rather than trust it, re-measure: keep a clean verdict only if the
+/// unscaled point still earns it, and let a solve that lands in the acceptable
+/// band say so. Non-success statuses pass through — they made no claim to
+/// re-check.
+fn reverify_after_unscale(
+    scaled_status: QpStatus,
+    sol: &QpSolution,
+    prob: &QpProblem,
+    opts: &QpOptions,
+) -> QpStatus {
+    if !matches!(
+        scaled_status,
+        QpStatus::Optimal | QpStatus::OptimalInaccurate
+    ) {
+        return scaled_status;
+    }
+    let err = sol.kkt_residuals(prob).kkt_error();
+    if !err.is_finite() {
+        QpStatus::NumericalFailure
+    } else if err <= opts.tol {
+        QpStatus::Optimal
+    } else if err <= 1e3 * opts.tol {
+        QpStatus::OptimalInaccurate
+    } else {
+        QpStatus::NumericalFailure
+    }
+}
+
+/// Decide the reported status from the engine's verdict **and** the measured
+/// KKT residuals of the point it returned.
+///
+/// The engine's own status is never propagated unchecked, for two reasons the
+/// Maros-Mészáros set demonstrates directly:
+///
+/// * **A claimed `Optimal` can be wrong.** `QSC205` returns `Optimal` with
+///   objective `0.0` against a true optimum of `−5.81e−3`. Routed through the
+///   SQP outer loop this was caught downstream — the outer loop re-tested the
+///   NLP KKT conditions and refused to converge, reporting an iteration limit.
+///   Solving directly removes that accidental safety net, so the check has to
+///   be made deliberately here. A *silently wrong* answer is the one failure
+///   mode worse than not solving: the baseline active-set column had zero
+///   solved-but-wrong across all 138 problems, and that property must survive
+///   this refactor.
+/// * **A claimed `Infeasible` can be wrong.** `DUALC1` is feasible with a
+///   published optimum of `6155.25`, and the phase-1 elastic mode certifies it
+///   infeasible. An infeasibility verdict is a *proof obligation*: the IPM
+///   only reports one behind a verified Farkas certificate, and the SQP path
+///   deliberately refuses to assert infeasibility it cannot back (#282). The
+///   active-set engine has no certificate to offer here, so its claim is
+///   downgraded to an honest "did not solve" rather than propagated as a
+///   verdict about the user's model.
+///
+/// The `Optimal` / `OptimalInaccurate` / fail banding mirrors the IPM's
+/// post-loop verdict (`hsde.rs`): within `tol` is clean, within `1e3·tol` is
+/// the "acceptable level" tier, anything worse is not a solve.
+fn verify_status(
+    engine: ActiveSetStatus,
+    sol: &QpSolution,
+    prob: &QpProblem,
+    opts: &QpOptions,
+) -> QpStatus {
+    /// Multiple of `tol` inside which a solve is downgraded to "acceptable"
+    /// rather than rejected — the IPM's `1e3·tol` band.
+    const ACCEPTABLE_FACTOR: f64 = 1e3;
+
+    let err = sol.kkt_residuals(prob).kkt_error();
+    let solved_to = |e: f64| {
+        if !e.is_finite() {
+            None
+        } else if e <= opts.tol {
+            Some(QpStatus::Optimal)
+        } else if e <= ACCEPTABLE_FACTOR * opts.tol {
+            Some(QpStatus::OptimalInaccurate)
+        } else {
+            None
+        }
+    };
+
+    match engine {
+        // Trust, but verify.
+        ActiveSetStatus::Optimal => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
+        // An unbounded ray is a genuine certificate the engine computes and
+        // checks (zero curvature, feasible for every step length, strict
+        // descent), so it is propagated.
+        ActiveSetStatus::Unbounded => QpStatus::DualInfeasible,
+        // Uncertified infeasibility claim — never propagated as a verdict.
+        // If the returned point happens to satisfy the KKT conditions anyway,
+        // report that instead; otherwise say honestly that we did not solve it.
+        ActiveSetStatus::Infeasible => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
+        // Budget or breakdown: the point may still be good enough to report at
+        // the acceptable tier (the IPM salvages solves this way), but it is
+        // never promoted to a clean `Optimal`.
+        ActiveSetStatus::MaxIter => solved_to(err).unwrap_or(QpStatus::IterationLimit),
+        ActiveSetStatus::NumericalError => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
+    }
+}
+
+/// Iteration budget for the active-set engine.
+///
+/// The engine's own default is a flat 200, which is the IPM's budget and the
+/// wrong shape for this method: an interior-point iteration count is nearly
+/// independent of problem size, whereas an active-set method needs roughly one
+/// iteration per active-set change, so its count grows with `n + m`. On the
+/// Maros-Mészáros set the flat cap was the single largest failure class —
+/// `DUALC1` (n = 9, m = 215) exhausts it and then solves *exactly*, in one
+/// outer iteration, once the budget is raised.
+///
+/// An explicit user `max_iter` always wins; otherwise scale with the problem
+/// and keep 200 as a floor for tiny instances.
+fn active_set_iter_budget(opts: &QpOptions, n: usize, m: usize) -> u32 {
+    const DEFAULT_IPM_MAX_ITER: usize = 200;
+    const PER_DIM: usize = 10;
+    if opts.max_iter != DEFAULT_IPM_MAX_ITER {
+        // User set it explicitly — respect it.
+        return opts.max_iter.min(u32::MAX as usize) as u32;
+    }
+    let scaled = n.saturating_add(m).saturating_mul(PER_DIM);
+    scaled.clamp(200, 200_000) as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ipm::solve_qp_ipm;
+    use crate::qp::Triplet;
+    use pounce_feral::FeralSolverInterface;
+
+    fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+        Box::new(FeralSolverInterface::new())
+    }
+
+    /// `min (x₀−3)² + (x₁−2)²  s.t.  x₀ + x₁ ≤ 4`, written in `½xᵀPx + cᵀx`
+    /// form (`P = 2I`, `c = (−6, −4)`, constant 13 dropped).
+    ///
+    /// Unconstrained optimum `(3, 2)` violates the row, so it binds and the
+    /// solution is the projection onto `x₀ + x₁ = 4`: `x* = (2.5, 1.5)`,
+    /// objective `−12.5`. Stationarity `Px + c + Gᵀz = 0` gives
+    /// `(−1, −1) + z(1, 1) = 0 ⇒ z = 1`, which pins the **dual sign**: a
+    /// flipped transform would clamp `z` to 0.
+    fn projection_qp() -> QpProblem {
+        QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+            c: vec![-6.0, -4.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            h: vec![4.0],
+            lb: vec![],
+            ub: vec![],
+        }
+    }
+
+    #[test]
+    fn analytic_qp_primal_dual_and_sign() {
+        let prob = projection_qp();
+        let mut mk = backend;
+        let sol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+
+        assert_eq!(sol.status, QpStatus::Optimal, "status");
+        assert!((sol.x[0] - 2.5).abs() < 1e-8, "x0 = {}", sol.x[0]);
+        assert!((sol.x[1] - 1.5).abs() < 1e-8, "x1 = {}", sol.x[1]);
+        assert!((sol.obj + 12.5).abs() < 1e-8, "obj = {}", sol.obj);
+        // The sign check: z must be +1, not 0 and not −1.
+        assert!(sol.z[0] >= -1e-12, "z must be >= 0: {}", sol.z[0]);
+        assert!((sol.z[0] - 1.0).abs() < 1e-7, "z0 = {} (sign!)", sol.z[0]);
+    }
+
+    /// The Hessian **off-diagonal** path: `p_lower` stores each pair once and
+    /// both forms mirror it implicitly, so a translation that dropped or
+    /// double-counted the mirror would change the matrix. Cross-checked
+    /// against the IPM on the same problem — the two engines must agree.
+    ///
+    /// `P = [[2, 1], [1, 2]]`, `c = (−4, −5)`, `x₀ + x₁ ≤ 3`. Stationarity
+    /// `Px = −c` gives `x* = (1, 2)` exactly, with `xᵀPx = 14` and
+    /// `cᵀx = −14`, so `obj = 7 − 14 = −7`. Getting the mirror wrong changes
+    /// `P` and moves `x*` well outside these tolerances.
+    ///
+    /// Note the optimum sits *exactly on* `x₀ + x₁ = 3`. That is deliberate —
+    /// it is the degenerate boundary case — but it means the IPM, which
+    /// approaches from the interior, stops a few `1e−5` short while the
+    /// active-set engine lands on the vertex exactly. So the analytic values
+    /// are asserted tightly and the IPM cross-check is only asked to agree to
+    /// interior-point accuracy.
+    #[test]
+    fn off_diagonal_hessian_matches_ipm() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![
+                Triplet::new(0, 0, 2.0),
+                Triplet::new(1, 0, 1.0), // the off-diagonal, stored once
+                Triplet::new(1, 1, 2.0),
+            ],
+            c: vec![-4.0, -5.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            h: vec![3.0],
+            lb: vec![],
+            ub: vec![],
+        };
+        let mut mk = backend;
+        let asol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+        let isol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+
+        assert_eq!(asol.status, QpStatus::Optimal);
+        assert_eq!(isol.status, QpStatus::Optimal);
+
+        // Analytic optimum — tight, and the real test of the mirror.
+        assert!((asol.x[0] - 1.0).abs() < 1e-9, "x0 = {}", asol.x[0]);
+        assert!((asol.x[1] - 2.0).abs() < 1e-9, "x1 = {}", asol.x[1]);
+        assert!((asol.obj + 7.0).abs() < 1e-9, "obj = {}", asol.obj);
+
+        // Cross-check: the IPM must land on the same point, to its own accuracy.
+        for i in 0..2 {
+            assert!(
+                (asol.x[i] - isol.x[i]).abs() < 1e-4,
+                "x{i}: active-set {} vs ipm {}",
+                asol.x[i],
+                isol.x[i]
+            );
+        }
+        assert!(
+            (asol.obj - isol.obj).abs() < 1e-6,
+            "obj: active-set {} vs ipm {}",
+            asol.obj,
+            isol.obj
+        );
+    }
+
+    /// Equality rows and variable bounds both translate, and the bound
+    /// multipliers land in the right sign slot.
+    /// `min ½(x₀² + x₁²)  s.t.  x₀ + x₁ = 2,  x₀ ≥ 1.5`.
+    /// Optimum `(1.5, 0.5)` — the bound binds.
+    #[test]
+    fn equality_and_bounds_match_ipm() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+            c: vec![0.0, 0.0],
+            a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            b: vec![2.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![1.5, crate::qp::NEG_INF],
+            ub: vec![],
+        };
+        let mut mk = backend;
+        let asol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+
+        assert_eq!(asol.status, QpStatus::Optimal, "status");
+        assert!((asol.x[0] - 1.5).abs() < 1e-7, "x0 = {}", asol.x[0]);
+        assert!((asol.x[1] - 0.5).abs() < 1e-7, "x1 = {}", asol.x[1]);
+        // Lower bound binds ⇒ its multiplier is the positive one.
+        assert!(asol.z_lb[0] >= -1e-12, "z_lb must be >= 0");
+        assert!(asol.z_ub[0] >= -1e-12, "z_ub must be >= 0");
+
+        let isol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert!(
+            (asol.obj - isol.obj).abs() < 1e-6,
+            "obj: active-set {} vs ipm {}",
+            asol.obj,
+            isol.obj
+        );
+    }
+
+    /// The budget scales with `n + m` instead of sitting at the IPM's flat
+    /// 200, and an explicit user setting still wins.
+    #[test]
+    fn iteration_budget_scales_and_respects_user() {
+        let d = QpOptions::default();
+        assert_eq!(d.max_iter, 200, "test assumes the IPM default is 200");
+        // Tiny problem keeps the floor.
+        assert_eq!(active_set_iter_budget(&d, 2, 1), 200);
+        // DUALC1's shape (n=9, m=215) must clear the flat 200 that broke it.
+        assert!(
+            active_set_iter_budget(&d, 9, 215) > 200,
+            "budget must scale past the flat cap for DUALC1's shape"
+        );
+        // Explicit user value wins.
+        let u = QpOptions {
+            max_iter: 37,
+            ..QpOptions::default()
+        };
+        assert_eq!(active_set_iter_budget(&u, 9, 215), 37);
+    }
+
+    /// **Singular Hessian with general inequality rows** — the geometry that
+    /// exposed the seeding contract. `P = diag(0, 1)` has no curvature along
+    /// `x₀`, so the reduced Hessian is singular unless the working set pins
+    /// that direction. Handed a feasible point with a *cold* working set the
+    /// engine sees no active rows, finds zero curvature along a feasible
+    /// descent direction, and certifies a spurious unbounded ray; the working
+    /// set has to come from the simplex basis for this to solve.
+    ///
+    /// `min ½x₁² − 2x₀ − x₁  s.t.  x₀ + x₁ ≤ 2,  x₀ ≤ 1.5,  x ≥ 0`.
+    /// Both rows bind at `x* = (1.5, 0.5)`: stationarity
+    /// `(−2, x₁−1) + z₀(1,1) + z₁(1,0) = 0` gives `z₀ = 0.5, z₁ = 1.5 ≥ 0`,
+    /// and `obj = 0.125 − 3 − 0.5 = −3.375`.
+    #[test]
+    fn singular_hessian_with_inequalities_solves() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(1, 1, 1.0)], // P = diag(0, 1)
+            c: vec![-2.0, -1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(0, 1, 1.0),
+                Triplet::new(1, 0, 1.0),
+            ],
+            h: vec![2.0, 1.5],
+            lb: vec![0.0, 0.0],
+            ub: vec![],
+        };
+        let mut mk = backend;
+        let sol = solve_qp_active_set(&prob, &QpOptions::default(), &mut mk);
+
+        assert_eq!(sol.status, QpStatus::Optimal, "status");
+        assert!((sol.x[0] - 1.5).abs() < 1e-7, "x0 = {}", sol.x[0]);
+        assert!((sol.x[1] - 0.5).abs() < 1e-7, "x1 = {}", sol.x[1]);
+        assert!((sol.obj + 3.375).abs() < 1e-7, "obj = {}", sol.obj);
+
+        let isol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert!(
+            (sol.obj - isol.obj).abs() < 1e-6,
+            "obj: active-set {} vs ipm {}",
+            sol.obj,
+            isol.obj
+        );
+    }
+}

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -309,31 +309,37 @@ where
         // Row order matches: the translation above stacks `[A_eq ; G]` in the
         // same order the simplex builds its rows, so index `i` is the same row.
         for (i, st) in working.constraints.iter_mut().enumerate() {
-            // Activity comes from the basis for *every* row, equalities
-            // included. Forcing all `m_eq` equalities active instead looks
-            // harmless — an equality is always satisfied — but it breaks the
-            // rank guarantee that makes this seed worth having. The basis leaves
-            // exactly `n` variables nonbasic; if `j` of the equality logicals
-            // are among the *basic* ones, unconditionally activating their rows
-            // pushes the active count to `n + j`, and the extra rows are
-            // linearly dependent by construction. That surfaces as
-            // `KKT inertia mismatch: expected 105 negative eigenvalues, got
-            // 102` on `CVXQP3_S` — a gap of exactly `j` — and aborts the solve.
+            // Equality rows are ALWAYS active — they are equations, not
+            // one-sided constraints that may or may not bind.
             //
-            // A basic equality logical means that row is redundant at this
-            // vertex: it is a linear combination of the rows the basis does
-            // pin, so it stays satisfied without being in the working set. This
-            // is the same argument `cold_general_initial` makes for the
-            // redundant equalities its own rank-repair guard drops, and the
-            // ratio test skips `bl == bu` rows, so a row left `Inactive` here
-            // never spuriously re-enters.
-            *st = match v.row_at[i] {
-                // Equality row pinned by the basis.
-                _ if i < m_eq && v.row_at[i] != AtBound::Free => ConsStatus::Equality,
-                // Slack `s = h − Gx` nonbasic at its lower bound 0 means
-                // `Gx = h`: the row sits at its upper bound `bu = h`.
-                AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
-                AtBound::Free => ConsStatus::Inactive,
+            // Deriving their activity from the basis instead (leaving a row
+            // inactive when its logical is basic) is tempting: it makes the
+            // active count come out at exactly `n` and so avoids the
+            // `KKT inertia mismatch: expected 105 …, got 102` that `CVXQP3_S`
+            // otherwise hits. But the premise is false. An equality's logical
+            // is boxed to `[0, 0]`; a *basic* one is simply a degenerate basic
+            // variable sitting at zero, which says nothing about whether the row
+            // is a linear combination of the others. Dropping such a row drops a
+            // real constraint — the ratio test skips `bl == bu` rows, so it
+            // never comes back — and the engine is then free to move in a
+            // direction that violates it. On NETLIB `afiro` that produced a
+            // phantom `Unbounded` verdict on an LP with a finite optimum of
+            // −464.75 (issue #133's regression test caught it).
+            //
+            // More active rows than variables *is* legitimate at a degenerate
+            // vertex; the dependence among them is a rank problem, and
+            // `schur_reset_rank_repaired` in `pounce-qp` is what resolves it —
+            // by pruning to a maximal independent subset with the algebra to
+            // justify each drop, rather than guessing from basis status here.
+            *st = if i < m_eq {
+                ConsStatus::Equality
+            } else {
+                match v.row_at[i] {
+                    // Slack `s = h − Gx` nonbasic at its lower bound 0 means
+                    // `Gx = h`: the row sits at its upper bound `bu = h`.
+                    AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
+                    AtBound::Free => ConsStatus::Inactive,
+                }
             };
         }
         QpWarmStart {
@@ -376,6 +382,8 @@ where
     };
 
     let engine_status = qsol.status;
+    // Kept for the `Unbounded` certificate re-check in `verify_status`.
+    let engine_ray = qsol.unbounded_ray.clone();
 
     // ---- Back-translate (sign transform — see crate::crossover docs) ----
     let mut y = vec![0.0; m_eq];
@@ -418,7 +426,7 @@ where
         iters: qsol.stats.n_working_set_changes as usize,
         iterates: Vec::new(),
     };
-    sol.status = verify_status(engine_status, &sol, prob, opts);
+    sol.status = verify_status(engine_status, engine_ray.as_deref(), &sol, prob, opts);
     debug_trace(|| {
         format!(
             "engine={:?} -> reported={:?} kkt_err={:.3e} obj={:.6e}",
@@ -505,6 +513,7 @@ fn reverify_after_unscale(
 /// the "acceptable level" tier, anything worse is not a solve.
 fn verify_status(
     engine: ActiveSetStatus,
+    ray: Option<&[f64]>,
     sol: &QpSolution,
     prob: &QpProblem,
     opts: &QpOptions,
@@ -529,10 +538,18 @@ fn verify_status(
     match engine {
         // Trust, but verify.
         ActiveSetStatus::Optimal => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
-        // An unbounded ray is a genuine certificate the engine computes and
-        // checks (zero curvature, feasible for every step length, strict
-        // descent), so it is propagated.
-        ActiveSetStatus::Unbounded => QpStatus::DualInfeasible,
+        // Unboundedness is a proof obligation too, and the engine's claim does
+        // not survive contact with this benchmark: `QSCSD1` (published optimum
+        // 8.667, plainly bounded) is reported `Unbounded`. Propagating that
+        // unchecked produced "Problem is unbounded (dual infeasible)" on a
+        // bounded QP — a *wrong verdict about the user's model*, which is worse
+        // than any failure status. So re-derive the certificate here from the
+        // returned ray, exactly as the `Infeasible` case is re-derived.
+        ActiveSetStatus::Unbounded => match ray {
+            Some(d) if ray_certifies_unbounded(prob, d) => QpStatus::DualInfeasible,
+            // No ray, or a ray that does not stand up: fall back on the point.
+            _ => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
+        },
         // Uncertified infeasibility claim — never propagated as a verdict.
         // If the returned point happens to satisfy the KKT conditions anyway,
         // report that instead; otherwise say honestly that we did not solve it.
@@ -543,6 +560,72 @@ fn verify_status(
         ActiveSetStatus::MaxIter => solved_to(err).unwrap_or(QpStatus::IterationLimit),
         ActiveSetStatus::NumericalError => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
     }
+}
+
+/// Does `d` actually certify that `prob` is unbounded below?
+///
+/// A recession direction of a convex QP must satisfy all four of:
+///
+/// * **zero curvature**, `Pd ≈ 0` — otherwise `½(x+td)ᵀP(x+td)` grows like `t²`
+///   and the objective turns back up;
+/// * **equalities preserved**, `Ad ≈ 0`;
+/// * **inequalities non-increasing**, `Gd ≤ 0`, so no row is eventually violated;
+/// * **box respected directionally** — a component may only move toward an
+///   *infinite* bound;
+///
+/// and then **strict descent**, `(Px + c)ᵀd < 0`, which with `Pd ≈ 0` is `cᵀd`.
+/// Together these mean `x + td` stays feasible for every `t ≥ 0` while the
+/// objective decreases without bound. Anything less is not a certificate.
+///
+/// Tolerances are relative to `‖d‖∞` because the ray is not normalized.
+fn ray_certifies_unbounded(prob: &QpProblem, d: &[f64]) -> bool {
+    if d.len() != prob.n {
+        return false;
+    }
+    let dn = d.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
+    if !dn.is_finite() || dn == 0.0 {
+        return false;
+    }
+    // Scale-relative slack. Deliberately looser than `tol`: the ray comes out of
+    // a finite-precision null-space computation, so demanding `tol` here would
+    // reject genuine certificates.
+    let slack = 1e-7 * dn;
+
+    let mut pd = vec![0.0; prob.n];
+    prob.p_mul(d, &mut pd);
+    if pd.iter().any(|v| v.abs() > slack) {
+        return false;
+    }
+
+    let mut ad = vec![0.0; prob.m_eq()];
+    for t in &prob.a {
+        ad[t.row] += t.val * d[t.col];
+    }
+    if ad.iter().any(|v| v.abs() > slack) {
+        return false;
+    }
+
+    let mut gd = vec![0.0; prob.m_ineq()];
+    for t in &prob.g {
+        gd[t.row] += t.val * d[t.col];
+    }
+    if gd.iter().any(|&v| v > slack) {
+        return false;
+    }
+
+    for (i, &di) in d.iter().enumerate() {
+        if di < -slack && prob.lb_of(i) > crate::qp::NEG_INF {
+            return false;
+        }
+        if di > slack && prob.ub_of(i) < crate::qp::POS_INF {
+            return false;
+        }
+    }
+
+    // Strict descent. `Pd ≈ 0` was just established, so the directional
+    // derivative `(Px + c)ᵀd` reduces to `cᵀd` independently of `x`.
+    let slope: f64 = (0..prob.n).map(|i| prob.c[i] * d[i]).sum();
+    slope < -slack
 }
 
 /// Iteration budget for the active-set engine.

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -309,17 +309,31 @@ where
         // Row order matches: the translation above stacks `[A_eq ; G]` in the
         // same order the simplex builds its rows, so index `i` is the same row.
         for (i, st) in working.constraints.iter_mut().enumerate() {
-            *st = if i < m_eq {
-                // Equality rows are always active; their logical is boxed to
-                // `[0, 0]` on the simplex side, so it is nonbasic in any case.
-                ConsStatus::Equality
-            } else {
-                match v.row_at[i] {
-                    // Slack `s = h − Gx` nonbasic at its lower bound 0 means
-                    // `Gx = h`: the row sits at its upper bound `bu = h`.
-                    AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
-                    AtBound::Free => ConsStatus::Inactive,
-                }
+            // Activity comes from the basis for *every* row, equalities
+            // included. Forcing all `m_eq` equalities active instead looks
+            // harmless — an equality is always satisfied — but it breaks the
+            // rank guarantee that makes this seed worth having. The basis leaves
+            // exactly `n` variables nonbasic; if `j` of the equality logicals
+            // are among the *basic* ones, unconditionally activating their rows
+            // pushes the active count to `n + j`, and the extra rows are
+            // linearly dependent by construction. That surfaces as
+            // `KKT inertia mismatch: expected 105 negative eigenvalues, got
+            // 102` on `CVXQP3_S` — a gap of exactly `j` — and aborts the solve.
+            //
+            // A basic equality logical means that row is redundant at this
+            // vertex: it is a linear combination of the rows the basis does
+            // pin, so it stays satisfied without being in the working set. This
+            // is the same argument `cold_general_initial` makes for the
+            // redundant equalities its own rank-repair guard drops, and the
+            // ratio test skips `bl == bu` rows, so a row left `Inactive` here
+            // never spuriously re-enters.
+            *st = match v.row_at[i] {
+                // Equality row pinned by the basis.
+                _ if i < m_eq && v.row_at[i] != AtBound::Free => ConsStatus::Equality,
+                // Slack `s = h − Gx` nonbasic at its lower bound 0 means
+                // `Gx = h`: the row sits at its upper bound `bu = h`.
+                AtBound::Lower | AtBound::Upper => ConsStatus::AtUpper,
+                AtBound::Free => ConsStatus::Inactive,
             };
         }
         QpWarmStart {
@@ -330,13 +344,35 @@ where
         }
     });
 
+    debug_trace(|| {
+        format!(
+            "n={n} m_eq={m_eq} m_ineq={m_ineq} seed={} budget={}",
+            if seed.is_some() {
+                "SIMPLEX-VERTEX"
+            } else {
+                "NONE (cold)"
+            },
+            qopts.max_iter,
+        )
+    });
     let mut solver = ParametricActiveSetSolver::new(make_backend());
     let qsol = match solver.solve(&qp, seed.as_ref(), &qopts) {
         Ok(q) => q,
         // A hard `QpError` (singular factor, dimension mismatch) is a
         // numerical failure, not an infeasibility claim — never assert
         // infeasibility without a certificate.
-        Err(_) => return empty_solution(n, m_eq, m_ineq, QpStatus::NumericalFailure),
+        //
+        // The error text is only surfaced under the debug env var, but it is
+        // the *only* record of why the solve died: this arm discards the
+        // engine's message and returns a zero-filled solution, so a caller
+        // otherwise sees `NumericalFailure` with no cause. Two distinct causes
+        // hide here on Maros-Mészáros — `KKT matrix is singular (LICQ
+        // violation …)`, the documented rank-detection limitation, and
+        // `KKT inertia mismatch`, which was a rank-deficient seed working set.
+        Err(e) => {
+            debug_trace(|| format!("solver.solve HARD ERROR: {e}"));
+            return empty_solution(n, m_eq, m_ineq, QpStatus::NumericalFailure);
+        }
     };
 
     let engine_status = qsol.status;
@@ -383,7 +419,30 @@ where
         iterates: Vec::new(),
     };
     sol.status = verify_status(engine_status, &sol, prob, opts);
+    debug_trace(|| {
+        format!(
+            "engine={:?} -> reported={:?} kkt_err={:.3e} obj={:.6e}",
+            engine_status,
+            sol.status,
+            sol.kkt_residuals(prob).kkt_error(),
+            sol.obj,
+        )
+    });
     sol
+}
+
+/// Emit a diagnostic line when `POUNCE_AS_DEBUG` is set in the environment.
+///
+/// This path makes three decisions that are invisible in the reported status —
+/// whether a simplex seed was obtained, what iteration budget was chosen, and
+/// what the engine's own verdict was before verification either accepted or
+/// demoted it. Reconstructing those from the outside is guesswork, and the
+/// guesses were wrong twice while this driver was being built. The closure
+/// defers formatting so an unset var costs one `env::var` and no allocation.
+fn debug_trace(msg: impl FnOnce() -> String) {
+    if std::env::var("POUNCE_AS_DEBUG").is_ok() {
+        eprintln!("[as] {}", msg());
+    }
 }
 
 /// Re-earn a status against the original problem after unscaling.

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -65,7 +65,7 @@ use std::collections::BTreeMap;
 /// See [`detect_infeasibility_with`] for the full derivation (regression: a
 /// feasible large-`‖x*‖` QP — POWELL20 — was declared primal-infeasible when
 /// this shared `infeas_tol`).
-const FARKAS_RESID_TOL: f64 = 1e-10;
+pub(crate) const FARKAS_RESID_TOL: f64 = 1e-10;
 
 /// Tolerance on the **normalized directional curvature** `dᵀPd / ‖d‖²` of a
 /// candidate recession ray `d`. A convex QP recedes along `d` (objective
@@ -354,6 +354,55 @@ where
         if verify.status == QpStatus::Optimal {
             return verify;
         }
+    }
+    // An unboundedness verdict on a problem that has no feasible point at all.
+    //
+    // `DualInfeasible` rests on a recession direction `d` with `Pd ≈ 0, Ad ≈ 0,
+    // −Gd ∈ K, cᵀd < 0`. That certificate is about the *dual*, and it is
+    // perfectly valid on an infeasible primal — the recession direction of an
+    // empty feasible set still exists — so a problem can be, and often is, both
+    // primal- and dual-infeasible at once. When it is, both verdicts are true
+    // and the choice between them is a reporting decision. `PrimalInfeasible`
+    // is the one to give: it is what pounce's own active-set engine and every
+    // external oracle (HiGHS, Gurobi) report on such a model, and the one a
+    // caller can act on — AMPL `solve_result_num=200`, "the model is
+    // infeasible, fix it", rather than `300` (`DivergingIterates`).
+    //
+    // The two certificates cannot be separated inside the iteration: they are
+    // residual races against the same iterate, and which gate clears first is
+    // arbitrary. Measured on `w·x ≤ 1` with `w·x ≥ 3` (HiGHS: infeasible), the
+    // Farkas value held at `−1.72` with `z ∈ K*` while its residual fell
+    // `1.9e-3 → 9.5e-5 → 4.7e-6 → 2.4e-7` toward an `8.6e-11` gate — and the
+    // recession gate opened with three orders still to go. Deciding it *inside*
+    // the loop means picking a tolerance: tried, and a rule loose enough to
+    // catch this case also suppressed 11 of 200 genuine unbounded verdicts,
+    // trading one wrong answer for more missing ones.
+    //
+    // So decide it out here, where the question can be *asked directly* instead
+    // of inferred: re-solve the objective-free twin (`P = 0, c = 0`), which has
+    // the same feasible set and, having no objective, cannot be unbounded — its
+    // only possible answers are "here is a feasible point" and "there is none".
+    // A `PrimalInfeasible` twin means the recession direction was never about
+    // unboundedness, and the verdict is corrected. Anything else leaves the
+    // original verdict untouched, so a genuinely unbounded problem keeps it.
+    //
+    // Costs one extra solve, and only on a `DualInfeasible` verdict. The twin
+    // cannot re-enter this branch: with `c = 0` no direction has `cᵀd < 0`, so
+    // `DualInfeasible` is unreachable for it.
+    if sol.status == QpStatus::DualInfeasible {
+        let twin = QpProblem {
+            p_lower: Vec::new(),
+            c: vec![0.0; prob.n],
+            ..prob.clone()
+        };
+        if solve_qp_ipm_unscaled(&twin, opts, &mut make_backend).status
+            == QpStatus::PrimalInfeasible
+        {
+            let mut infeasible = sol;
+            infeasible.status = QpStatus::PrimalInfeasible;
+            return infeasible;
+        }
+        return sol;
     }
     sol
 }

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -38,6 +38,7 @@ pub mod sensitivity;
 pub(crate) mod simplex;
 pub mod sos;
 
+pub use active_set::{ActiveSetOverrides, solve_qp_active_set};
 pub use batch::{
     solve_qp_batch, solve_qp_batch_parallel, solve_qp_batch_parallel_warm, solve_qp_multi_rhs,
     solve_qp_multi_rhs_parallel,

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -23,6 +23,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+pub mod active_set;
 pub mod batch;
 pub mod cones;
 pub mod crossover;

--- a/crates/pounce-convex/src/simplex.rs
+++ b/crates/pounce-convex/src/simplex.rs
@@ -132,6 +132,136 @@ pub(crate) fn crossover_simplex(
     Some(s.extract(prob))
 }
 
+/// Where a variable sits at a basic feasible solution, in a form the
+/// active-set engine can consume without knowing about simplex internals.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum AtBound {
+    /// Basic (or free at zero): not part of the active set.
+    Free,
+    Lower,
+    Upper,
+}
+
+/// A basic feasible solution: a **vertex** of the feasible region, together
+/// with the active set the basis induces.
+///
+/// Exactly `n` of the `n + m` variables are nonbasic, and each sits on one of
+/// its bounds — so `struct_at` and `row_at` together name exactly `n` active
+/// constraints in `x`-space, and they are linearly independent *by
+/// construction* because the simplex basis matrix is nonsingular. That
+/// independence is the property the active-set engine needs and cannot get from
+/// tolerance-snapping a point (which at a degenerate vertex names more than `n`
+/// binding rows and yields a singular KKT factorization).
+pub(crate) struct FeasibleVertex {
+    /// Feasible primal point (length `n`).
+    pub x: Vec<f64>,
+    /// Per-structural bound activity (length `n`).
+    pub struct_at: Vec<AtBound>,
+    /// Per-row activity (length `m = m_eq + m_ineq`, same row order as
+    /// `[A_eq ; G]`). A row is active iff its logical is nonbasic.
+    pub row_at: Vec<AtBound>,
+}
+
+/// Find a **feasible vertex** of `prob`'s linear constraints from a cold start,
+/// running this engine's phase-1 only — phase-2 would optimize the *linear*
+/// objective, which is the wrong objective for a QP (any feasible vertex is an
+/// equally valid warm start, so the extra work buys nothing).
+///
+/// Exists because [`crate::active_set`] needs a feasible seed and cannot get
+/// one from `pounce-qp`'s own cold start: that engine's l1-elastic phase-1 does
+/// not terminate on the degenerate netlib-derived QPs in the Maros-Mészáros
+/// set. `QAFIRO` (n = 32, among the smallest instances) runs past 500,000
+/// active-set iterations without converging even with Bland's rule forced —
+/// finite in exact arithmetic, but the elastic vertices are degenerate enough
+/// that the floating-point tolerance gates keep flipping. This engine pivots on
+/// an LU basis and walks straight through exactly that degeneracy, which is why
+/// crossover already prefers it over the active-set bridge for the NETLIB GEN
+/// vertices.
+///
+/// Returns `None` on any breakdown (factorization failure, iteration cap, or a
+/// phase-1 that cannot reach feasibility). The caller must treat that as "no
+/// seed available" and fall back, **not** as an infeasibility verdict: a
+/// phase-1 that gives up is not a certificate.
+pub(crate) fn simplex_feasible_vertex(prob: &QpProblem) -> Option<FeasibleVertex> {
+    let mut s = Simplex::new(prob);
+    // `warm_start` only reads `sol.x`, clamping each structural into its box and
+    // snapping to a bound, so a zero vector is a valid *cold* seed: every
+    // structural lands at a bound (or is pushed off by `push_superbasics`) and
+    // the logicals start basic, as set up in `new`.
+    let zero = QpSolution {
+        status: crate::qp::QpStatus::Optimal,
+        x: vec![0.0; prob.n],
+        y: Vec::new(),
+        z: Vec::new(),
+        z_lb: Vec::new(),
+        z_ub: Vec::new(),
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    };
+    s.warm_start(&zero);
+    s.factor_basis()?;
+    s.recompute_basics()?;
+    s.push_superbasics()?;
+    s.run_phase1()?;
+
+    let x: Vec<f64> = (0..s.n).map(|j| s.xval[j]).collect();
+    // `run_phase1` returning `Some` means it stopped, not that it succeeded —
+    // confirm the point really is feasible before offering it as a seed.
+    if !feasible_at(prob, &x) {
+        return None;
+    }
+
+    let at = |v: usize| -> AtBound {
+        if s.slot_of[v] != usize::MAX {
+            return AtBound::Free; // basic
+        }
+        match s.nb[v] {
+            NbStatus::AtLower => AtBound::Lower,
+            NbStatus::AtUpper => AtBound::Upper,
+            // A free variable parked at zero pins no constraint, and
+            // `push_superbasics` has already cleared every superbasic.
+            NbStatus::FreeZero | NbStatus::Superbasic => AtBound::Free,
+        }
+    };
+
+    Some(FeasibleVertex {
+        struct_at: (0..s.n).map(at).collect(),
+        row_at: (0..s.m).map(|i| at(s.n + i)).collect(),
+        x,
+    })
+}
+
+/// Does `x` satisfy `Ax = b`, `Gx ≤ h`, and the variable box, to `FEAS_TOL`?
+fn feasible_at(prob: &QpProblem, x: &[f64]) -> bool {
+    let mut ax = vec![0.0; prob.m_eq()];
+    for t in &prob.a {
+        ax[t.row] += t.val * x[t.col];
+    }
+    for (i, &v) in ax.iter().enumerate() {
+        if (v - prob.b[i]).abs() > FEAS_TOL {
+            return false;
+        }
+    }
+
+    let mut gx = vec![0.0; prob.m_ineq()];
+    for t in &prob.g {
+        gx[t.row] += t.val * x[t.col];
+    }
+    for (i, &v) in gx.iter().enumerate() {
+        if v - prob.h[i] > FEAS_TOL {
+            return false;
+        }
+    }
+
+    for (i, &xi) in x.iter().enumerate() {
+        if xi < lo_bound(prob.lb_of(i)) - FEAS_TOL || xi > hi_bound(prob.ub_of(i)) + FEAS_TOL {
+            return false;
+        }
+    }
+    true
+}
+
 /// Treat `|v| ≥ 1e20` as an infinite bound (mirrors [`QpProblem`] conventions).
 fn lo_bound(v: f64) -> f64 {
     if v <= -BOUND_INF {

--- a/crates/pounce-convex/src/simplex.rs
+++ b/crates/pounce-convex/src/simplex.rs
@@ -199,16 +199,33 @@ pub(crate) fn simplex_feasible_vertex(prob: &QpProblem) -> Option<FeasibleVertex
         iters: 0,
         iterates: Vec::new(),
     };
+    let dbg = std::env::var("POUNCE_SEED_DEBUG").is_ok();
+    macro_rules! stage {
+        ($e:expr, $name:literal) => {
+            match $e {
+                Some(v) => v,
+                None => {
+                    if dbg {
+                        eprintln!("[seed] failed at {}", $name);
+                    }
+                    return None;
+                }
+            }
+        };
+    }
     s.warm_start(&zero);
-    s.factor_basis()?;
-    s.recompute_basics()?;
-    s.push_superbasics()?;
-    s.run_phase1()?;
+    stage!(s.factor_basis(), "factor_basis");
+    stage!(s.recompute_basics(), "recompute_basics");
+    stage!(s.push_superbasics(), "push_superbasics");
+    stage!(s.run_phase1(), "run_phase1");
 
     let x: Vec<f64> = (0..s.n).map(|j| s.xval[j]).collect();
     // `run_phase1` returning `Some` means it stopped, not that it succeeded —
     // confirm the point really is feasible before offering it as a seed.
     if !feasible_at(prob, &x) {
+        if dbg {
+            eprintln!("[seed] run_phase1 returned but point is INFEASIBLE");
+        }
         return None;
     }
 
@@ -717,6 +734,24 @@ impl Simplex {
             if infeas < best_infeas - FEAS_TOL {
                 best_infeas = infeas;
                 no_progress = 0;
+                // Release the latch once progress resumes.
+                //
+                // Bland's rule is an anti-cycling *escape*, not a pricing
+                // strategy: it is finite but can take exponentially many steps,
+                // so leaving it on permanently trades a stall for a crawl. It
+                // was latched here and never cleared, and the cost is stark on
+                // `QSCTAP1` — Dantzig pricing drove infeasibility 6.5e2 → 5.0e0
+                // in 200 iterations, then the latch engaged and infeasibility
+                // sat at 3.25e0 for the next 40,000 iterations until the cap
+                // ran out. Phase-1 then returned `None`, the caller lost its
+                // feasible seed, and the QP fell back to the non-terminating
+                // l1-elastic path — which is why a large block of
+                // Maros-Mészáros problems timed out rather than solving.
+                //
+                // Latch on stall, release on progress, is the standard
+                // discipline: the anti-cycling guarantee is only needed while
+                // actually stalled.
+                self.bland = false;
             } else {
                 no_progress += 1;
                 if no_progress >= NO_PROGRESS_LIMIT {
@@ -869,6 +904,66 @@ impl Simplex {
         }
     }
 
+    /// The bound crossings the basic variables meet **ahead** on the entering ray
+    /// `x_B(θ) = x_B − α·t·θ`, as `(θ, slot, status-the-leaver-takes, |rate|)`.
+    /// Shared by both phase-1 ratio tests so they agree on what a blocker is.
+    ///
+    /// Which bounds lie ahead is decided by where the basic sits *now*, using the
+    /// same three-way test as [`Self::phase1_cost_b`] so that the breakpoint set
+    /// and the slope `f'(0) = rc·t` stay consistent:
+    ///
+    /// * feasible → it can only leave through the single bound it is heading for;
+    /// * below its lower bound → it crosses nothing unless the ray lifts it
+    ///   (`rate < 0`), and then hits its lower bound (regaining feasibility — a
+    ///   legitimate blocker, this is how an infeasibility gets *removed*) before
+    ///   its upper bound;
+    /// * above its upper bound → the mirror image.
+    ///
+    /// The `θ ≈ 0` crossings count as much as the far ones: a basic sitting *on*
+    /// the bound the ray pushes it out through is a breakpoint at `θ = 0`. What is
+    /// *not* a breakpoint is the bound a basic sits on and moves **away** from —
+    /// that crossing is behind the ray (`θ ≤ 0` only because `x = bound`), and
+    /// admitting it invents a zero-length blocker.
+    fn phase1_breakpoints(&self, t: f64, alpha: &[f64]) -> Vec<(f64, usize, NbStatus, f64)> {
+        let mut bps: Vec<(f64, usize, NbStatus, f64)> = Vec::new();
+        for slot in 0..self.m {
+            let rate = alpha[slot] * t; // basic value moves as x − rate·θ
+            if rate.abs() <= PIVOT_TOL {
+                continue;
+            }
+            let v = self.basis[slot];
+            let x = self.xval[v];
+            let arate = rate.abs();
+            let (lo, hi) = (self.lo[v], self.hi[v]);
+            if x < lo - FEAS_TOL {
+                if rate < 0.0 {
+                    bps.push(((x - lo) / rate, slot, NbStatus::AtLower, arate));
+                    if hi.is_finite() {
+                        bps.push(((x - hi) / rate, slot, NbStatus::AtUpper, arate));
+                    }
+                }
+            } else if x > hi + FEAS_TOL {
+                if rate > 0.0 {
+                    bps.push(((x - hi) / rate, slot, NbStatus::AtUpper, arate));
+                    if lo.is_finite() {
+                        bps.push(((x - lo) / rate, slot, NbStatus::AtLower, arate));
+                    }
+                }
+            } else if rate > 0.0 {
+                // Feasible and decreasing: it can only leave through its lower bound.
+                if lo.is_finite() {
+                    bps.push((((x - lo) / rate).max(0.0), slot, NbStatus::AtLower, arate));
+                }
+            } else {
+                // Feasible and increasing: it can only leave through its upper bound.
+                if hi.is_finite() {
+                    bps.push((((x - hi) / rate).max(0.0), slot, NbStatus::AtUpper, arate));
+                }
+            }
+        }
+        bps
+    }
+
     /// Phase-1 long-step (Maros) ratio test. The piecewise-linear infeasibility
     /// objective along the entering ray has directional derivative `f'(0) = rc·t <
     /// 0`, and `f'` is convex/increasing: every breakpoint (a basic reaching a
@@ -880,6 +975,13 @@ impl Simplex {
     /// point of the long step — is what drives the simplex *through* degenerate
     /// (`θ ≈ 0`) blockers that defeat a first-breakpoint short step on the GEN
     /// vertices.
+    ///
+    /// The slope bookkeeping is only valid if *every* breakpoint ahead is in the
+    /// list, including the ones at `θ = 0`: see [`Self::phase1_breakpoints`]. Omit
+    /// them and the accumulated slope is a systematic underestimate of `f'`, the
+    /// walk sails past the breakpoint where `f'` really turns nonnegative, and the
+    /// step lands beyond the ray's minimizer — i.e. phase-1 *increases* the
+    /// infeasibility it exists to remove.
     fn ratio_test_phase1(&self, q: usize, t: f64, rc: f64, alpha: &[f64]) -> Step {
         // Bland's anti-cycling guarantee requires the leaving variable to be the
         // lowest-index one among the minimum-ratio ties — which the long step does
@@ -889,31 +991,7 @@ impl Simplex {
         if self.bland {
             return self.ratio_test_phase1_bland(q, t, alpha);
         }
-        // Breakpoints: (theta, slot, bound-status-on-leaving, |rate|).
-        let mut bps: Vec<(f64, usize, NbStatus, f64)> = Vec::new();
-        for slot in 0..self.m {
-            let rate = alpha[slot] * t; // basic value moves as x − rate·θ
-            if rate.abs() <= PIVOT_TOL {
-                continue;
-            }
-            let v = self.basis[slot];
-            let x = self.xval[v];
-            let arate = rate.abs();
-            // Every bound this basic reaches at θ > 0 is a breakpoint (a bound it
-            // moves away from gives θ < 0 and is skipped).
-            for &(bound, to) in &[
-                (self.lo[v], NbStatus::AtLower),
-                (self.hi[v], NbStatus::AtUpper),
-            ] {
-                if !bound.is_finite() {
-                    continue;
-                }
-                let theta = (x - bound) / rate;
-                if theta > FEAS_TOL {
-                    bps.push((theta, slot, to, arate));
-                }
-            }
-        }
+        let mut bps = self.phase1_breakpoints(t, alpha);
         // The entering variable's own opposite bound caps the step (a flip).
         let flip = self.entering_range(q);
 
@@ -940,42 +1018,32 @@ impl Simplex {
     }
 
     /// Bland-correct phase-1 ratio test: step to the *first* bound any basic
-    /// reaches (minimum ratio), breaking ties by lowest leaving-variable index.
-    /// No basic crosses a bound during the step, so it is monotone, and the
-    /// lowest-index tie-break makes the entering/leaving pair Bland-consistent —
-    /// together that guarantees finite termination through degeneracy.
+    /// reaches (minimum ratio over [`Self::phase1_breakpoints`]), breaking ties by
+    /// lowest leaving-variable index. No basic crosses a bound during the step, so
+    /// it is monotone, and the lowest-index tie-break makes the entering/leaving
+    /// pair Bland-consistent — together that guarantees finite termination through
+    /// degeneracy.
+    ///
+    /// It shares the breakpoint set with the long step deliberately: this test used
+    /// to scan *both* bounds of every basic and accept any ratio `≥ −FEAS_TOL`,
+    /// which admits the bound a basic already sits on and is moving **away** from
+    /// (that ratio is `±0.0`, not negative). Every such phantom blocker pinned
+    /// `θ = 0`, so the Bland escape could not move at all — `QSCSD6` sat at
+    /// `infeas = 5.25` for its whole iteration budget and then failed.
     fn ratio_test_phase1_bland(&self, q: usize, t: f64, alpha: &[f64]) -> Step {
         let flip = self.entering_range(q);
         let mut best_theta = flip;
         let mut best_slot: Option<usize> = None;
         let mut best_to = NbStatus::AtLower;
-        for slot in 0..self.m {
-            let rate = alpha[slot] * t;
-            if rate.abs() <= PIVOT_TOL {
-                continue;
-            }
+        for (theta, slot, to, _) in self.phase1_breakpoints(t, alpha) {
             let v = self.basis[slot];
-            let x = self.xval[v];
-            for &(bound, to) in &[
-                (self.lo[v], NbStatus::AtLower),
-                (self.hi[v], NbStatus::AtUpper),
-            ] {
-                if !bound.is_finite() {
-                    continue;
-                }
-                let theta = (x - bound) / rate;
-                if theta < -FEAS_TOL {
-                    continue; // heading away from this bound
-                }
-                let theta = theta.max(0.0);
-                let better = theta < best_theta - FEAS_TOL
-                    || ((theta - best_theta).abs() <= FEAS_TOL
-                        && best_slot.is_none_or(|bs| v < self.basis[bs]));
-                if better {
-                    best_theta = theta;
-                    best_slot = Some(slot);
-                    best_to = to;
-                }
+            let better = theta < best_theta - FEAS_TOL
+                || ((theta - best_theta).abs() <= FEAS_TOL
+                    && best_slot.is_none_or(|bs| v < self.basis[bs]));
+            if better {
+                best_theta = theta;
+                best_slot = Some(slot);
+                best_to = to;
             }
         }
         match best_slot {

--- a/crates/pounce-convex/tests/infeasibility.rs
+++ b/crates/pounce-convex/tests/infeasibility.rs
@@ -458,3 +458,125 @@ fn unconstrained_qp_optimal() {
     assert!((sol.x[1] - (-2.0)).abs() < 1e-6, "x1={}", sol.x[1]);
     assert!((sol.obj - (-13.0)).abs() < 1e-6, "obj={}", sol.obj);
 }
+
+// ---------------------------------------------------------------------------
+// Primal- AND dual-infeasible at once: which verdict gets reported.
+//
+// These two certificates are not alternatives. `DualInfeasible` rests on a
+// recession direction `d` with `Pd ≈ 0, Ad ≈ 0, −Gd ∈ K, cᵀd < 0`, which says
+// the *dual* has no feasible point — and that is perfectly true of a problem
+// whose primal is also empty, because the recession direction of an empty
+// feasible set exists just the same. So a model can honestly earn both, and
+// then the report is a choice rather than a measurement.
+//
+// The choice must be `PrimalInfeasible`: it is the actionable one (AMPL
+// `solve_result_num=200`, "fix the model", against `300`/`DivergingIterates`),
+// it is what pounce's own active-set engine returns on the same data, and it is
+// what HiGHS and Gurobi return. Left to the iteration it was a race between two
+// residual gates, and the recession gate tended to clear first.
+// ---------------------------------------------------------------------------
+
+/// A four-variable LP, found by a randomized sweep, on which this actually went
+/// wrong. Hand-crafted two-row instances do *not* reproduce it: the failure is a
+/// race between two residual gates, so it needs an instance whose dynamics let
+/// the recession gate win, and this is one.
+///
+/// **Primal infeasible by inspection**, and the test asserts that structurally
+/// rather than trusting the numbers: rows 0 and 1 are exact negatives, so they
+/// read `w·x ≤ 1` and `w·x ≥ 3`. `scipy`/HiGHS agrees (`status = 2`).
+///
+/// **Also dual infeasible**: `Gd ≤ 0` forces `w·d = 0`, and within that
+/// hyperplane there is a `d` with `row₂·d ≤ 0` and `cᵀd < 0`, which is a genuine
+/// recession certificate. Both verdicts are true, so the driver has to *choose*
+/// — and before the objective-free-twin check it chose `DualInfeasible`, i.e.
+/// `solve_result_num=300` on a model with no feasible point. Measured on this
+/// instance: the Farkas value held at `−1.72` with `z ∈ K*` while its residual
+/// fell `1.9e-3 → 9.5e-5 → 4.7e-6 → 2.4e-7` toward an `8.6e-11` gate, and the
+/// recession gate opened with three orders still to go.
+#[test]
+fn primal_and_dual_infeasible_reports_primal() {
+    // Row 0 is `w`; row 1 is `−w`; row 2 is an extra, satisfiable on its own.
+    let w = [
+        -1.336972899917,
+        -1.045019914384,
+        1.450153058953,
+        -0.540131207078,
+    ];
+    let extra = [
+        -2.104466010086,
+        -0.580699705489,
+        1.5099831e-05,
+        1.188830678537,
+    ];
+    let h = [1.0, -3.0, 1.858605832812668];
+
+    // The contradiction, asserted from the data: `w·x ≤ h₀` and `−w·x ≤ h₁`
+    // together give `h₁ ≤ −w·x` and `w·x ≤ h₀`, i.e. `−h₁ ≤ w·x ≤ h₀`, which is
+    // empty exactly when `h₀ + h₁ < 0`.
+    assert!(h[0] + h[1] < 0.0, "rows 0/1 must be contradictory");
+
+    let mut g = Vec::new();
+    for (j, &v) in w.iter().enumerate() {
+        g.push(Triplet::new(0, j, v));
+        g.push(Triplet::new(1, j, -v));
+    }
+    for (j, &v) in extra.iter().enumerate() {
+        g.push(Triplet::new(2, j, v));
+    }
+
+    let prob = QpProblem {
+        n: 4,
+        p_lower: vec![],
+        c: vec![
+            0.666683325902,
+            0.795299099602,
+            -0.699388308324,
+            -0.187589705319,
+        ],
+        a: vec![],
+        b: vec![],
+        g,
+        h: h.to_vec(),
+        lb: vec![-20.0; 4],
+        ub: vec![],
+    };
+    let sol = solve(&prob);
+    assert_eq!(
+        sol.status,
+        QpStatus::PrimalInfeasible,
+        "an infeasible model must not be reported as unbounded (got {:?} after \
+         {} iters)",
+        sol.status,
+        sol.iters
+    );
+}
+
+/// The guard above must not cost a genuine unboundedness verdict. This LP is
+/// **feasible** (`x = (0, 0)` satisfies `x₀ − x₁ ≤ 1`) and unbounded below along
+/// `d = (1, 1)`: `Gd = 0`, `cᵀd = −2 < 0`. Its objective-free twin is feasible,
+/// so the correction never fires and `DualInfeasible` stands.
+///
+/// `dual_infeasible_unbounded_lp` above covers the unconstrained-direction case;
+/// this one keeps a row *active* in the recession cone, the configuration the
+/// correction has to leave alone.
+#[test]
+fn feasible_unbounded_lp_keeps_dual_infeasible() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![-1.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -1.0)],
+        h: vec![1.0],
+        lb: vec![],
+        ub: vec![],
+    };
+    let sol = solve(&prob);
+    assert_eq!(
+        sol.status,
+        QpStatus::DualInfeasible,
+        "feasible-and-unbounded must still certify unbounded (iters={})",
+        sol.iters
+    );
+}

--- a/crates/pounce-convex/tests/issue415_infeasible_status.rs
+++ b/crates/pounce-convex/tests/issue415_infeasible_status.rs
@@ -1,0 +1,206 @@
+//! gh #415 — an infeasible QP must come back as `PrimalInfeasible` from the
+//! active-set driver, not `NumericalFailure`.
+//!
+//! The two statuses land in different AMPL `solve_result_num` families and
+//! callers branch on that family: `200` tells AMPL / Pyomo / the GAMS links
+//! "the model is infeasible — fix the model", while `500` tells them "the
+//! solver broke — retry, or switch solvers". Reporting a diagnosed-infeasible
+//! model as a solver crash is the actual user-visible harm here, so these tests
+//! assert the *status*, and cross-check it against the IPM on the same data.
+//!
+//! This is the infeasible analogue of the unbounded case (#388) and the
+//! rank-deficient equality case (#313).
+//!
+//! The three variants below are not redundant — they take three different
+//! routes to the certificate:
+//!
+//! * **boxed** — the elastic multipliers carry a residual `Aᵀy + Gᵀz = −c`, and
+//!   minimizing `qᵀx` over the finite box absorbs it exactly;
+//! * **free** — no box to absorb anything, so the driver falls back on the
+//!   objective-free feasibility twin, whose multipliers have no residual;
+//! * **one-sided box** — a lower bound exists but the residual points at the
+//!   *missing* upper bound, so this also takes the twin route. It is the one a
+//!   `x ≥ 0`-style model actually hits.
+
+use pounce_convex::{
+    ActiveSetOverrides, QpOptions, QpProblem, QpStatus, Triplet, solve_qp_active_set, solve_qp_ipm,
+};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn active_set(prob: &QpProblem) -> QpStatus {
+    let mut mk = backend;
+    solve_qp_active_set(
+        prob,
+        &QpOptions::default(),
+        &ActiveSetOverrides::default(),
+        &mut mk,
+    )
+    .status
+}
+
+/// The issue's LP: `min x₀ + x₁` s.t. `x₀ + x₁ ≤ 1` **and** `x₀ + x₁ ≥ 3`.
+///
+/// The second row is written `−x₀ − x₁ ≤ −3`. The two are directly
+/// contradictory, so the feasible set is empty by inspection — no solver
+/// tolerance or conditioning question enters into it. `scipy`'s HiGHS oracle
+/// agrees (`status = 2`, "The problem is infeasible").
+fn contradictory_rows() -> QpProblem {
+    QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 0, -1.0),
+            Triplet::new(1, 1, -1.0),
+        ],
+        h: vec![1.0, -3.0],
+        lb: vec![0.0, 0.0],
+        ub: vec![10.0, 10.0],
+    }
+}
+
+#[test]
+fn boxed_infeasible_lp_is_primal_infeasible() {
+    let prob = contradictory_rows();
+    assert_eq!(
+        active_set(&prob),
+        QpStatus::PrimalInfeasible,
+        "active-set must report the model infeasible, not blame the solver"
+    );
+    // The engines must not disagree about the user's model.
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::PrimalInfeasible,
+        "IPM oracle"
+    );
+}
+
+#[test]
+fn free_variable_infeasible_lp_is_primal_infeasible() {
+    let prob = QpProblem {
+        lb: vec![],
+        ub: vec![],
+        ..contradictory_rows()
+    };
+    assert_eq!(active_set(&prob), QpStatus::PrimalInfeasible);
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::PrimalInfeasible,
+        "IPM oracle"
+    );
+}
+
+#[test]
+fn lower_bounded_infeasible_lp_is_primal_infeasible() {
+    let prob = QpProblem {
+        ub: vec![],
+        ..contradictory_rows()
+    };
+    assert_eq!(active_set(&prob), QpStatus::PrimalInfeasible);
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::PrimalInfeasible,
+        "IPM oracle"
+    );
+}
+
+/// A genuinely infeasible **QP** (nonzero Hessian), not just an LP: the
+/// residual the box has to absorb is `−(Px + c)` and depends on the returned
+/// point, so a curved objective exercises a different residual than the LP's
+/// constant `−c`.
+#[test]
+fn infeasible_qp_with_hessian_is_primal_infeasible() {
+    let prob = QpProblem {
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 3.0)],
+        c: vec![-4.0, 1.0],
+        ..contradictory_rows()
+    };
+    assert_eq!(active_set(&prob), QpStatus::PrimalInfeasible);
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::PrimalInfeasible,
+        "IPM oracle"
+    );
+}
+
+/// Infeasibility that lives in the **equality** block rather than the
+/// inequalities: `x₀ + x₁ = 1` together with `x₀ + x₁ = 3`. This is the path
+/// through `Aᵀy` and the `bᵀy` term of the certificate, which the inequality
+/// tests above never touch.
+#[test]
+fn contradictory_equalities_are_primal_infeasible() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 1.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+        ],
+        b: vec![1.0, 3.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![10.0, 10.0],
+    };
+    assert_eq!(active_set(&prob), QpStatus::PrimalInfeasible);
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::PrimalInfeasible,
+        "IPM oracle"
+    );
+}
+
+/// The other half of the contract, and the more important one: a **feasible**
+/// QP must never acquire an infeasibility verdict.
+///
+/// A wrong `PrimalInfeasible` is a false statement about the user's model —
+/// strictly worse than any failure status, which only says the solver gave up.
+/// The geometry here is the #282 hazard in miniature: the rows `±x₀ ≤ 0`,
+/// `±x₁ ≤ 0` collapse the feasible set to exactly `{0}`, so every row is active
+/// at the unique feasible point, there is no interior (Slater fails), and the
+/// multipliers are wildly non-unique — which is precisely the situation in
+/// which a phase-1 stall used to be mistaken for a certificate. `x = 0` is
+/// plainly feasible, so no Farkas certificate can exist.
+#[test]
+fn feasible_qp_with_empty_interior_is_never_infeasible() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+        c: vec![-1.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 0, -1.0),
+            Triplet::new(2, 1, 1.0),
+            Triplet::new(3, 1, -1.0),
+        ],
+        h: vec![0.0, 0.0, 0.0, 0.0],
+        lb: vec![],
+        ub: vec![],
+    };
+    let status = active_set(&prob);
+    assert_ne!(
+        status,
+        QpStatus::PrimalInfeasible,
+        "feasible set is exactly {{0}} — x = 0 satisfies every row, so there is \
+         no Farkas certificate to find"
+    );
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::Optimal,
+        "IPM oracle: this problem is solvable"
+    );
+}

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -17,6 +17,7 @@
 //! data; `P` is the **lower triangle** of the symmetric Hessian.
 
 use numpy::IntoPyArray;
+use pounce_convex::{ActiveSetOverrides, solve_qp_active_set};
 use pounce_convex::{
     ConeSpec, QpFactorization, QpOptions, QpProblem, QpSensitivity, QpSolution, QpStatus,
     QpWarmStart, SensError, Triplet, solve_qp_batch_parallel, solve_qp_batch_parallel_warm,
@@ -369,7 +370,7 @@ fn opts(tol: Option<f64>, max_iter: Option<usize>, collect_iterates: bool) -> Qp
 /// `collect_iterates` (default `false`) opts into the per-iteration
 /// convergence trace, returned under the `iterates` key.
 #[pyfunction]
-#[pyo3(signature = (prob, tol=None, max_iter=None, warm_start=None, collect_iterates=false))]
+#[pyo3(signature = (prob, tol=None, max_iter=None, warm_start=None, collect_iterates=false, method="ipm"))]
 pub fn solve_qp<'py>(
     py: Python<'py>,
     prob: &PyQpProblem,
@@ -377,14 +378,40 @@ pub fn solve_qp<'py>(
     max_iter: Option<usize>,
     warm_start: Option<&Bound<'py, PyDict>>,
     collect_iterates: bool,
+    method: &str,
 ) -> PyResult<Bound<'py, PyDict>> {
     let o = opts(tol, max_iter, collect_iterates);
     let warm = warm_start.map(warm_from_dict).transpose()?;
-    let sol = py.allow_threads(|| match &warm {
-        Some(w) => solve_qp_ipm_warm(&prob.inner, &o, w, backend),
-        None => solve_qp_ipm(&prob.inner, &o, backend),
-    });
-    solution_dict(py, sol, Some(&prob.inner), &[])
+
+    // `method` selects the engine, so that the *same* engine is reachable from
+    // Python and from the CLI. Before this, `solver_selection="qp-active-set"`
+    // meant the convex active-set driver on the CLI and the SQP outer loop in
+    // `minimize` — one selector naming two different algorithms, silently.
+    match method {
+        "ipm" => {
+            let sol = py.allow_threads(|| match &warm {
+                Some(w) => solve_qp_ipm_warm(&prob.inner, &o, w, backend),
+                None => solve_qp_ipm(&prob.inner, &o, backend),
+            });
+            solution_dict(py, sol, Some(&prob.inner), &[])
+        }
+        "active-set" => {
+            if warm.is_some() {
+                return Err(PyValueError::new_err(
+                    "solve_qp: warm_start= is not supported with method='active-set' \
+                     (the active-set engine warm-starts from a working set, not a \
+                     primal-dual point; use solve_qp(method='ipm') or the Rust \
+                     `solve_parametric` API)",
+                ));
+            }
+            let ov = ActiveSetOverrides::default();
+            let sol = py.allow_threads(|| solve_qp_active_set(&prob.inner, &o, &ov, &mut backend));
+            solution_dict(py, sol, Some(&prob.inner), &[])
+        }
+        other => Err(PyValueError::new_err(format!(
+            "solve_qp: method must be 'ipm' or 'active-set', got {other:?}"
+        ))),
+    }
 }
 
 /// Solve a standard-form conic program (LP/QP plus second-order, exponential,

--- a/crates/pounce-qp/README.md
+++ b/crates/pounce-qp/README.md
@@ -22,9 +22,13 @@ better fit.
 **Phase 5a — feature-complete on correctness.** Every problem
 class identified in the design note (`docs/src/active-set-sqp-warm-start.md`)
 solves end-to-end; infeasibility is certified honestly; warm-start
-is wired. Five of the six analytical-ladder problems (§8.0) pass;
-problem #4 (LICQ-violating redundant equality) is a documented
-limitation that needs rank-detection beyond inertia control.
+is wired. All six analytical-ladder problems (§8.0) pass: problem #4
+(LICQ-violating redundant equality) was the long-standing gap, and the
+rank detection it needed now runs on **both** inner paths —
+`solve_general` has long pruned a rank-deficient active set to a maximal
+linearly independent subset, and `solve_general_schur` does too via
+`schur_reset_rank_repaired`. Regression coverage:
+`tests/schur_vs_refactor.rs::licq_violating_equality_solves_on_both_paths`.
 
 **Phase 5a.1 — performance and tooling refinements landed.** The
 Harris-style two-pass ratio test (cycling-prevention core of
@@ -35,14 +39,32 @@ and basic §8.2 scaling-sweep diagnostics all ship.
 **Phase 5a.2 — algorithmic completion landed.** §4.2 sparse
 Schur-complement active-set updates (c18 standalone module +
 c19 wired into `solve_general` behind `use_schur_updates`) and
-§4.4 full GMSW EXPAND with τ-growth + snap-reset (c20) are both
-done. The Schur path is opt-in; correctness verified by Schur-
-vs-refactor cross-checks. EXPAND degrades to Harris-only
-behavior on non-cycling problems and only kicks in on
-pathological degeneracy. The remaining items (Maros-Mészáros
-oracle comparison, large-n scaling benchmarks) require FFI or
-benchmark infrastructure that fall outside the pure-Rust
-constraint.
+§4.4 GMSW EXPAND with τ-growth + snap-reset (c20) are both
+done. EXPAND degrades to Harris-only behavior on non-cycling
+problems and only kicks in on pathological degeneracy; note its
+τ-perturbation governs the *ratio test* — the drop rule under
+`AntiCyclingChoice::Expand` is Dantzig steepest-violation, with
+the anti-stall Bland latch bounding the pathological case.
+
+The Schur path is **no longer opt-in for the convex active-set
+driver** (`pounce_convex::active_set` enables it), and it is
+cross-checked against the refactor path by
+`tests/schur_vs_refactor.rs`.
+
+> Correction: this section previously claimed the Schur path's
+> "correctness verified by Schur-vs-refactor cross-checks". No such
+> cross-check existed, and the path was **not** equivalent. Writing
+> one surfaced two defects, both since fixed: a singular Schur block
+> aborted the whole solve instead of triggering the refactor the
+> count-based reset already performed, and the SMW correction lost
+> accuracy as updates accumulated (exact at a refactor interval of 1
+> or 5, ~1.5e-6 off at the default 50) until `SchurState::solve` got
+> iterative refinement. Anyone who had set `use_schur_updates` was
+> exposed to both.
+
+The remaining items (Maros-Mészáros oracle comparison, large-n
+scaling benchmarks) require FFI or benchmark infrastructure that
+fall outside the pure-Rust constraint.
 
 **Phase 5b — SQP NLP integration core landed** in
 `pounce-algorithm::sqp`. The crate is now wired into the

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -209,9 +209,10 @@ impl ParametricActiveSetSolver {
     /// Returns `Ok(None)` when the path cannot be started (the box relaxation is
     /// unbounded or fails), which is a signal for the caller to fall back to the
     /// conventional cold path — not a verdict about `qp`.
-    pub(crate) fn solve_cold_homotopy(
+    pub(crate) fn solve_homotopy(
         &mut self,
         qp: &QpProblem<'_>,
+        warm: Option<(&QpProblem<'_>, &QpSolution)>,
         opts: &QpOptions,
     ) -> Result<Option<QpSolution>, QpError> {
         let started = Instant::now();
@@ -221,6 +222,31 @@ impl ParametricActiveSetSolver {
             // No rows to bring in: the box relaxation *is* the problem, and the
             // existing fast path already handles it.
             return Ok(None);
+        }
+
+        // ---- Warm start: QP₀ *is* the previous problem ----
+        //
+        // The prior solution is optimal for the prior QP, so the path starts on
+        // the solution manifold with no `QP₀` to construct and no box relaxation
+        // to bound — the whole reason the warm case is easier than the cold one.
+        // `g` moves too here (the cold path holds it fixed), which is the `dg`
+        // term in the direction solve below.
+        if let Some((prev, sol_prev)) = warm {
+            let mut x = sol_prev.x.clone();
+            x.resize(n, 0.0);
+            let mut working = sol_prev.working.clone();
+            working.constraints.resize(m, ConsStatus::Inactive);
+            working.bounds.resize(n, BoundStatus::Inactive);
+            let mut lambda_g = sol_prev.lambda_g.clone();
+            lambda_g.resize(m, 0.0);
+            let mut lambda_x = sol_prev.lambda_x.clone();
+            lambda_x.resize(n, 0.0);
+            let bl0 = prev.bl.to_vec();
+            let bu0 = prev.bu.to_vec();
+            let dg: Vec<Number> = (0..n).map(|j| qp.g[j] - prev.g[j]).collect();
+            return self.trace_path(
+                qp, qp.h, x, working, lambda_g, lambda_x, bl0, bu0, dg, opts, started,
+            );
         }
 
         // ---- QP₀: the box-only relaxation ----
@@ -342,6 +368,52 @@ impl ParametricActiveSetSolver {
         let mut lambda_x = box_sol.lambda_x.clone();
         lambda_x.resize(n, 0.0);
 
+        // Cold arm: hand the relaxed start to the shared tracer with a zero
+        // `dg` — the cold path holds `g` fixed and moves only the row bounds.
+        let dg = vec![0.0; n];
+        self.trace_path(
+            qp, path_h, x, working, lambda_g, lambda_x, bl0, bu0, dg, opts, started,
+        )
+    }
+
+    /// Trace the homotopy from a start state to `t = 1`, returning the corrected
+    /// solution, or `None` when the path cannot be completed.
+    ///
+    /// Shared by the cold and warm entry points: both differ only in where the
+    /// path *starts* (a box relaxation with widened row bounds, versus the
+    /// previous problem and its solution) and in whether `g` moves. Everything
+    /// after that — the two ratio tests in `t`, the working-set jumps, the rank
+    /// repair, and the final corrector — is identical.
+    #[allow(clippy::too_many_arguments)]
+    fn trace_path(
+        &mut self,
+        qp: &QpProblem<'_>,
+        path_h: &SymTMatrix,
+        mut x: Vec<Number>,
+        mut working: WorkingSet,
+        mut lambda_g: Vec<Number>,
+        mut lambda_x: Vec<Number>,
+        bl0: Vec<Number>,
+        bu0: Vec<Number>,
+        dg: Vec<Number>,
+        opts: &QpOptions,
+        started: Instant,
+    ) -> Result<Option<QpSolution>, QpError> {
+        let n = qp.n;
+        let m = qp.m;
+        let trace = std::env::var("POUNCE_HOMOTOPY_DEBUG").is_ok();
+        let path_qp = QpProblem {
+            n,
+            m,
+            h: path_h,
+            g: qp.g,
+            a: qp.a,
+            bl: qp.bl,
+            bu: qp.bu,
+            xl: qp.xl,
+            xu: qp.xu,
+            hessian_inertia: qp.hessian_inertia,
+        };
         let mut t: Number = 0.0;
         let mut n_changes: u32 = 0;
         let mut n_refactor: u32 = 0;
@@ -369,11 +441,18 @@ impl ParametricActiveSetSolver {
 
             // ---- Direction: d/dt of (x, λ) along this segment ----
             //
-            // `H` and `g` are fixed, so the stationarity block's right-hand side
-            // does not move and the primal RHS is zero; only the active rows'
-            // bounds advance, at `bound_rate`.
+            // `H` is fixed along the path; `g` moves only on the warm path (see
+            // `dg` below). The active rows' bounds advance at `bound_rate`.
             let kkt = assemble_active_set_kkt(&path_qp, &active_cons, &active_bounds);
             let mut rhs = vec![0.0; n + k_c + k_b];
+            // Stationarity block: `H x(t) + g(t) + A_Wᵀ λ(t) = 0` differentiated
+            // in `t` gives `H dx + dg + A_Wᵀ dλ = 0`, so the primal right-hand
+            // side is `−dg`. Zero on the cold path, where `g` is held fixed and
+            // only the row bounds move; non-zero on the warm path, where the
+            // objective moves from the previous problem's to the new one's.
+            for (j, r) in rhs[..n].iter_mut().enumerate() {
+                *r = -dg[j];
+            }
             for (slot, &i) in active_cons.iter().enumerate() {
                 let is_lower = matches!(working.constraints[i], ConsStatus::AtLower);
                 rhs[n + slot] = match working.constraints[i] {

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -1,0 +1,386 @@
+//! §4.2 parametric homotopy — the qpOASES-lineage path this crate is named for.
+//!
+//! # Why this exists
+//!
+//! `ParametricActiveSetSolver` advertises "true parametric warm starting" and
+//! cites the qpOASES lineage, but `solve_parametric` was a stub that discarded
+//! its arguments and cold-solved. The homotopy was never implemented, and its
+//! absence is *structural* rather than a missing convenience:
+//!
+//! The design note (`docs/src/active-set-sqp-warm-start.md` §4.3) specifies that
+//! l1-elastic phase-1 works by driving the elastic slacks to zero **as the
+//! homotopy proceeds**. With no homotopy, phase-1 degenerated into solving a
+//! standalone, maximally-degenerate QP from cold — the hardest case for an
+//! active-set method — which is exactly where it stalls and fails to terminate
+//! on the Maros-Mészáros set.
+//!
+//! # The path
+//!
+//! §4.2 specifies tracing `(1-t)·QP₀ + t·QP₁` for `t ∈ [0,1]`, jumping the
+//! working set wherever a multiplier reaches zero or a constraint reaches its
+//! bound. Along a segment with a fixed working set `W` the KKT system
+//!
+//! ```text
+//!   [ H   A_Wᵀ ] [ x ]   [ -g    ]
+//!   [ A_W   0  ] [ λ ] = [  b_W(t) ]
+//! ```
+//!
+//! is *affine in `t`*, so `(x(t), λ(t))` moves linearly and the next event is
+//! found by two ratio tests in `t` rather than by a line search in step space.
+//!
+//! # Choosing `QP₀` (the part the textbook version gets wrong here)
+//!
+//! The canonical cold start takes `W₀ = ∅`, which makes `x(t) = −H⁻¹g(t)` and
+//! therefore **requires `H` nonsingular**. Most of the Maros-Mészáros set is
+//! LP-like with singular or zero `H`, where an empty working set leaves a
+//! null-space direction and the KKT is singular. Repairing that needs `n` active
+//! constraints — i.e. a vertex — which is the phase-1 problem again. Circular.
+//!
+//! This module sidesteps it: `QP₀` is the **box-only relaxation** — the target
+//! QP with every general row dropped. That is solvable on an existing, tested
+//! fast path ([`super::ParametricActiveSetSolver::solve_box_constrained`]), and
+//! its solution comes with a working set of active bounds that makes the reduced
+//! Hessian nonsingular whenever the box does. Only the **row bounds** are then
+//! homotopied in, from a relaxation that `x₀` strictly satisfies to the target;
+//! `H` and `g` are held fixed, so the `-g` block above never moves and the
+//! direction solve has a zero primal right-hand side.
+//!
+//! The consequence worth stating plainly: there is **no phase-1**. `x(t)` is
+//! feasible for the `t`-problem at every point on the path by construction, so
+//! feasibility is never searched for and cannot stall.
+//!
+//! # References
+//!
+//! - Ferreau, Kirches, Potschka, Bock, Diehl, "qpOASES: a parametric active-set
+//!   algorithm for quadratic programming", *Math. Prog. Comp.* **6** (2014) —
+//!   the dense reference algorithm and the homotopy's ratio tests.
+//! - Kirches, *Fast Numerical Methods for Mixed-Integer Nonlinear
+//!   Model-Predictive Control* (2011), Ch. 5–7 — the sparse Schur extension.
+
+use crate::error::{QpError, QpStatus};
+use crate::kkt::{a_times_x, assemble_active_set_kkt, h_times_x};
+use crate::options::QpOptions;
+use crate::problem::{QpProblem, QpSolution, QpStats};
+use crate::solver::ParametricActiveSetSolver;
+use crate::solver::QpSolver as _;
+use crate::working_set::{BoundStatus, ConsStatus, WorkingSet};
+use pounce_common::Number;
+use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace};
+use std::time::Instant;
+
+/// How far the relaxed `t = 0` row bounds sit outside `A x₀`, relative to the
+/// row's own scale. Strictly positive so every row starts *inactive* with real
+/// slack — a row that started exactly at its bound would be degenerate at `t=0`
+/// and the first ratio test would see a zero-length step.
+const RELAX_MARGIN: Number = 1.0;
+
+/// `t` is clamped into `[0, 1]`; an event closer than this to the current `t` is
+/// treated as coincident (a degenerate tie) rather than as forward progress, so
+/// the loop cannot spin on a zero-length advance.
+const T_EPS: Number = 1e-12;
+
+/// Outcome of the two ratio tests: what happens first as `t` increases.
+#[derive(Debug, Clone, Copy)]
+enum Event {
+    /// Inactive row `i` reaches its lower bound.
+    AddRowLower(usize),
+    /// Inactive row `i` reaches its upper bound.
+    AddRowUpper(usize),
+    /// Active row `i`'s multiplier reaches zero and must leave.
+    DropRow(usize),
+    /// Active bound on variable `j` has its multiplier reach zero.
+    DropBound(usize),
+}
+
+/// Rate of change of a row bound per unit `t` (0 when the bound is infinite).
+fn bound_rate(relaxed: Number, target: Number, is_lower: bool) -> Number {
+    let infinite = if is_lower {
+        target <= NLP_LOWER_BOUND_INF
+    } else {
+        target >= NLP_UPPER_BOUND_INF
+    };
+    if infinite { 0.0 } else { target - relaxed }
+}
+
+impl ParametricActiveSetSolver {
+    /// Solve `qp` from cold by tracing the row-bound homotopy described in this
+    /// module's docs.
+    ///
+    /// Returns `Ok(None)` when the path cannot be started (the box relaxation is
+    /// unbounded or fails), which is a signal for the caller to fall back to the
+    /// conventional cold path — not a verdict about `qp`.
+    pub(crate) fn solve_cold_homotopy(
+        &mut self,
+        qp: &QpProblem<'_>,
+        opts: &QpOptions,
+    ) -> Result<Option<QpSolution>, QpError> {
+        let started = Instant::now();
+        let n = qp.n;
+        let m = qp.m;
+        if m == 0 {
+            // No rows to bring in: the box relaxation *is* the problem, and the
+            // existing fast path already handles it.
+            return Ok(None);
+        }
+
+        // ---- QP₀: the box-only relaxation ----
+        //
+        // `m = 0` demands a genuinely 0-row Jacobian: `QpProblem::validate`
+        // cross-checks `A`'s row count against `m`, so handing it the target's
+        // `A` with `m = 0` is rejected outright.
+        let empty_a = GenTMatrix::new(GenTMatrixSpace::new(0, n as i32, Vec::new(), Vec::new()));
+        let box_qp = QpProblem {
+            n,
+            m: 0,
+            h: qp.h,
+            g: qp.g,
+            a: &empty_a,
+            bl: &[],
+            bu: &[],
+            xl: qp.xl,
+            xu: qp.xu,
+            hessian_inertia: qp.hessian_inertia,
+        };
+        let trace = std::env::var("POUNCE_HOMOTOPY_DEBUG").is_ok();
+        let box_attempt = self.solve(&box_qp, None, opts);
+        if trace {
+            match &box_attempt {
+                Ok(s) => eprintln!("[hom] box relaxation: {:?} obj={:.6e}", s.status, s.obj),
+                Err(e) => eprintln!("[hom] box relaxation ERROR: {e}"),
+            }
+        }
+        let box_sol = match box_attempt {
+            Ok(s) if s.status == QpStatus::Optimal => s,
+            // Unbounded box relaxation means `H` has no curvature in a
+            // box-unbounded direction. The *target* may still be bounded (a row
+            // constraint could cut the ray off), so this is not an unboundedness
+            // verdict — it just means this path cannot start here.
+            _ => return Ok(None),
+        };
+
+        let mut x = box_sol.x.clone();
+        let mut working = WorkingSet::cold(n, m);
+        for (i, st) in working.bounds.iter_mut().enumerate() {
+            *st = box_sol.working.bounds[i];
+        }
+        // Every row starts inactive, with genuine slack.
+        let ax0 = a_times_x(qp.a, &x, m);
+        let mut bl0 = vec![0.0; m];
+        let mut bu0 = vec![0.0; m];
+        for i in 0..m {
+            let scale = RELAX_MARGIN * (1.0 + ax0[i].abs());
+            // Relax outward from `A x₀` far enough that `x₀` is strictly
+            // interior; where the target is already looser, keep the target.
+            bl0[i] = if qp.bl[i] <= NLP_LOWER_BOUND_INF {
+                qp.bl[i]
+            } else {
+                (ax0[i] - scale).min(qp.bl[i])
+            };
+            bu0[i] = if qp.bu[i] >= NLP_UPPER_BOUND_INF {
+                qp.bu[i]
+            } else {
+                (ax0[i] + scale).max(qp.bu[i])
+            };
+        }
+
+        let mut lambda_g = vec![0.0; m];
+        let mut lambda_x = box_sol.lambda_x.clone();
+        lambda_x.resize(n, 0.0);
+
+        let mut t: Number = 0.0;
+        let mut n_changes: u32 = 0;
+        let mut n_refactor: u32 = 0;
+
+        // Each iteration either advances `t` or changes the working set, and the
+        // budget bounds the total.
+        for _step in 0..opts.max_iter {
+            if t >= 1.0 - T_EPS {
+                break;
+            }
+            if trace && _step % 50 == 0 {
+                eprintln!("[hom] step={_step} t={t:.6e}");
+            }
+
+            let active_cons: Vec<usize> = (0..m)
+                .filter(|&i| working.constraints[i].is_active())
+                .collect();
+            let active_bounds: Vec<usize> =
+                (0..n).filter(|&i| working.bounds[i].is_active()).collect();
+            let (k_c, k_b) = (active_cons.len(), active_bounds.len());
+
+            // ---- Direction: d/dt of (x, λ) along this segment ----
+            //
+            // `H` and `g` are fixed, so the stationarity block's right-hand side
+            // does not move and the primal RHS is zero; only the active rows'
+            // bounds advance, at `bound_rate`.
+            let kkt = assemble_active_set_kkt(qp, &active_cons, &active_bounds);
+            let mut rhs = vec![0.0; n + k_c + k_b];
+            for (slot, &i) in active_cons.iter().enumerate() {
+                let is_lower = matches!(working.constraints[i], ConsStatus::AtLower);
+                rhs[n + slot] = match working.constraints[i] {
+                    ConsStatus::Equality => bound_rate(bu0[i], qp.bu[i], false),
+                    _ => bound_rate(
+                        if is_lower { bl0[i] } else { bu0[i] },
+                        if is_lower { qp.bl[i] } else { qp.bu[i] },
+                        is_lower,
+                    ),
+                };
+            }
+            // Variable bounds do not move along this path, so their rows are 0.
+            match self.factorize_with_inertia_control(kkt, &mut rhs, (k_c + k_b) as i32, n, opts) {
+                Ok(_) => {}
+                // A rank-deficient active set on the path is the same situation
+                // `solve_general` handles by pruning; rather than duplicate that
+                // logic here, hand the problem back to the conventional path.
+                Err(_) => return Ok(None),
+            }
+            n_refactor += 1;
+            let dx: Vec<Number> = rhs[..n].to_vec();
+            let dlam_c: Vec<Number> = (0..k_c).map(|s| rhs[n + s]).collect();
+            let dlam_b: Vec<Number> = (0..k_b).map(|s| rhs[n + k_c + s]).collect();
+
+            // ---- Ratio test 1 (primal): when does an inactive row bind? ----
+            let a_dx = a_times_x(qp.a, &dx, m);
+            let ax = a_times_x(qp.a, &x, m);
+            let mut t_next: Number = 1.0;
+            let mut event: Option<Event> = None;
+
+            for i in 0..m {
+                if working.constraints[i].is_active() {
+                    continue;
+                }
+                // Upper: a_i·x(t) − bu_i(t) = 0.
+                if qp.bu[i] < NLP_UPPER_BOUND_INF {
+                    let gap = bu0[i] + t * (qp.bu[i] - bu0[i]) - ax[i];
+                    let rate = a_dx[i] - bound_rate(bu0[i], qp.bu[i], false);
+                    if rate > 0.0 {
+                        let dt = gap / rate;
+                        if dt >= -T_EPS && t + dt < t_next - T_EPS {
+                            t_next = (t + dt).clamp(t, 1.0);
+                            event = Some(Event::AddRowUpper(i));
+                        }
+                    }
+                }
+                // Lower: bl_i(t) − a_i·x(t) = 0.
+                if qp.bl[i] > NLP_LOWER_BOUND_INF {
+                    let gap = ax[i] - (bl0[i] + t * (qp.bl[i] - bl0[i]));
+                    let rate = bound_rate(bl0[i], qp.bl[i], true) - a_dx[i];
+                    if rate > 0.0 {
+                        let dt = gap / rate;
+                        if dt >= -T_EPS && t + dt < t_next - T_EPS {
+                            t_next = (t + dt).clamp(t, 1.0);
+                            event = Some(Event::AddRowLower(i));
+                        }
+                    }
+                }
+            }
+
+            // ---- Ratio test 2 (dual): when does an active multiplier vanish? ----
+            //
+            // An inequality's multiplier must keep its sign; reaching zero means
+            // the row stops binding and has to leave the working set. Equality
+            // rows are exempt — their multipliers are unrestricted.
+            for (slot, &i) in active_cons.iter().enumerate() {
+                if matches!(working.constraints[i], ConsStatus::Equality) {
+                    continue;
+                }
+                let lam = lambda_g[i];
+                let rate = dlam_c[slot];
+                // Sign convention: `AtUpper` multipliers are ≥ 0, `AtLower` ≤ 0
+                // in this engine's packing (see `solve_general`'s drop test).
+                let heading_to_zero = (lam > 0.0 && rate < 0.0) || (lam < 0.0 && rate > 0.0);
+                if heading_to_zero {
+                    let dt = -lam / rate;
+                    if dt >= -T_EPS && t + dt < t_next - T_EPS {
+                        t_next = (t + dt).clamp(t, 1.0);
+                        event = Some(Event::DropRow(i));
+                    }
+                }
+            }
+            for (slot, &j) in active_bounds.iter().enumerate() {
+                if matches!(working.bounds[j], BoundStatus::Fixed) {
+                    continue;
+                }
+                let lam = lambda_x[j];
+                let rate = dlam_b[slot];
+                let heading_to_zero = (lam > 0.0 && rate < 0.0) || (lam < 0.0 && rate > 0.0);
+                if heading_to_zero {
+                    let dt = -lam / rate;
+                    if dt >= -T_EPS && t + dt < t_next - T_EPS {
+                        t_next = (t + dt).clamp(t, 1.0);
+                        event = Some(Event::DropBound(j));
+                    }
+                }
+            }
+
+            // ---- Advance to the event (or to t = 1) ----
+            let dt = t_next - t;
+            for (xi, &d) in x.iter_mut().zip(dx.iter()) {
+                *xi += dt * d;
+            }
+            for (slot, &i) in active_cons.iter().enumerate() {
+                lambda_g[i] += dt * dlam_c[slot];
+            }
+            for (slot, &j) in active_bounds.iter().enumerate() {
+                lambda_x[j] += dt * dlam_b[slot];
+            }
+            t = t_next;
+
+            match event {
+                None => {
+                    // Nothing binds before t = 1: the path is complete.
+                    t = 1.0;
+                    break;
+                }
+                Some(Event::AddRowUpper(i)) => {
+                    working.constraints[i] = ConsStatus::AtUpper;
+                    n_changes += 1;
+                }
+                Some(Event::AddRowLower(i)) => {
+                    working.constraints[i] = ConsStatus::AtLower;
+                    n_changes += 1;
+                }
+                Some(Event::DropRow(i)) => {
+                    working.constraints[i] = ConsStatus::Inactive;
+                    lambda_g[i] = 0.0;
+                    n_changes += 1;
+                }
+                Some(Event::DropBound(j)) => {
+                    working.bounds[j] = BoundStatus::Inactive;
+                    lambda_x[j] = 0.0;
+                    n_changes += 1;
+                }
+            }
+        }
+
+        // The path is only a *predictor* for the final active set: `t` may have
+        // stopped short of 1, and the linear algebra along the way accumulates
+        // error. Hand the discovered working set to the conventional solver,
+        // which corrects the iterate and applies the usual feasibility audit and
+        // status logic. That keeps every existing guarantee — nothing here is
+        // reported as optimal on the homotopy's own authority.
+        if t < 1.0 - T_EPS {
+            if trace {
+                eprintln!("[hom] path did NOT reach t=1 (stopped at {t:.6e}); falling back");
+            }
+            return Ok(None);
+        }
+        if trace {
+            eprintln!("[hom] reached t=1 after {n_changes} working-set changes");
+        }
+        let mut sol =
+            <Self as crate::solver::QpSolver>::solve_with_working_set(self, qp, &working, opts)?;
+        sol.stats = QpStats {
+            n_working_set_changes: sol.stats.n_working_set_changes + n_changes,
+            n_refactor: sol.stats.n_refactor + n_refactor,
+            n_schur_updates: sol.stats.n_schur_updates,
+            used_phase1: false,
+            time: started.elapsed(),
+        };
+        // Keep the homotopy's own objective/`x` only if the corrector agreed it
+        // was feasible; otherwise the corrector's answer stands.
+        let _ = (h_times_x(qp.h, &x), &lambda_g);
+        Ok(Some(sol))
+    }
+}

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -421,6 +421,20 @@ impl ParametricActiveSetSolver {
         // set so the retry loop terminates on its own; the cap bounds the case
         // where the ratio test keeps re-adding a pruned row.
         let mut rank_repairs: u32 = (n + m).min(1000) as u32;
+        // Rows pruned by a rank repair *at the current* `t`. Without this the
+        // repair and the primal ratio test fight each other: the repair drops a
+        // linearly dependent row, the ratio test immediately re-adds it because
+        // it is still exactly at its bound at this `t`, and the pair loops
+        // forever without advancing. Measured on QSHARE2B, which repaired
+        // 79 -> 77 constraints at t = 0.9999973 and then repeated that same
+        // repair until the budget ran out.
+        //
+        // A pruned row is a linear combination of the kept ones, so it stays
+        // satisfied and excluding it changes nothing about feasibility. The tabu
+        // is cleared the moment `t` actually advances, because at a new `t` the
+        // dependency that justified the prune no longer necessarily holds — this
+        // suppresses the cycle without permanently blinding the ratio test.
+        let mut tabu_cons = vec![false; m];
 
         // Each iteration either advances `t` or changes the working set, and the
         // budget bounds the total.
@@ -514,6 +528,7 @@ impl ParametricActiveSetSolver {
                         if !keep_c[i] {
                             working.constraints[i] = ConsStatus::Inactive;
                             lambda_g[i] = 0.0;
+                            tabu_cons[i] = true;
                             n_changes += 1;
                         }
                     }
@@ -554,7 +569,7 @@ impl ParametricActiveSetSolver {
             let mut event: Option<Event> = None;
 
             for i in 0..m {
-                if working.constraints[i].is_active() {
+                if working.constraints[i].is_active() || tabu_cons[i] {
                     continue;
                 }
                 // Upper: a_i·x(t) − bu_i(t) = 0.
@@ -623,6 +638,11 @@ impl ParametricActiveSetSolver {
 
             // ---- Advance to the event (or to t = 1) ----
             let dt = t_next - t;
+            if dt > T_EPS {
+                // Real progress along the path: the rank-repair tabu was scoped
+                // to the parameter value it was raised at, so release it.
+                tabu_cons.iter_mut().for_each(|f| *f = false);
+            }
             for (xi, &d) in x.iter_mut().zip(dx.iter()) {
                 *xi += dt * d;
             }

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -345,6 +345,10 @@ impl ParametricActiveSetSolver {
         let mut t: Number = 0.0;
         let mut n_changes: u32 = 0;
         let mut n_refactor: u32 = 0;
+        // Rank repairs allowed on this path. Each strictly shrinks the active
+        // set so the retry loop terminates on its own; the cap bounds the case
+        // where the ratio test keeps re-adding a pruned row.
+        let mut rank_repairs: u32 = (n + m).min(1000) as u32;
 
         // Each iteration either advances `t` or changes the working set, and the
         // budget bounds the total.
@@ -387,7 +391,77 @@ impl ParametricActiveSetSolver {
                 // A rank-deficient active set on the path is the same situation
                 // `solve_general` handles by pruning; rather than duplicate that
                 // logic here, hand the problem back to the conventional path.
-                Err(_) => return Ok(None),
+                // A rank-deficient active set: at a degenerate point more rows
+                // are binding than there are variables, and the surplus is
+                // linearly dependent. No H-block shift repairs a rank-deficient
+                // *constraint* block, so inertia control exhausts its shifts and
+                // reports "reduced Hessian remains non-PD on null(A_W)".
+                //
+                // Prune to a maximal independent subset and retry at the same
+                // `t`, exactly as `solve_general` does. A dropped row is a linear
+                // combination of the kept ones, so it stays satisfied at the
+                // current iterate and the feasible set is unchanged — only the
+                // rank deficiency goes away. `x` and `t` do not move, so nothing
+                // about the path's position is lost.
+                //
+                // This matters late rather than early: measured on the 24
+                // smallest problems, 4 hit this, and they hit it near the end of
+                // the path (`QSHARE2B` at t = 0.99999, `QSCAGR7` at t = 0.99986).
+                // Bailing there discards a path that was one step from done.
+                Err(e) if e.is_recoverable_factorization_failure() && rank_repairs > 0 => {
+                    let (kc, kb) = crate::solver::independent_active_subset(
+                        &mut self.linsol,
+                        &path_qp,
+                        &active_cons,
+                        &active_bounds,
+                    );
+                    if kc.len() == active_cons.len() && kb.len() == active_bounds.len() {
+                        // Already full rank ⇒ not a deficiency this can repair.
+                        if trace {
+                            eprintln!("[hom] KKT failure at t={t:.6e}, full rank already: {e}");
+                        }
+                        return Ok(None);
+                    }
+                    rank_repairs -= 1;
+                    let mut keep_c = vec![false; m];
+                    for &i in &kc {
+                        keep_c[i] = true;
+                    }
+                    let mut keep_b = vec![false; n];
+                    for &j in &kb {
+                        keep_b[j] = true;
+                    }
+                    for &i in &active_cons {
+                        if !keep_c[i] {
+                            working.constraints[i] = ConsStatus::Inactive;
+                            lambda_g[i] = 0.0;
+                            n_changes += 1;
+                        }
+                    }
+                    for &j in &active_bounds {
+                        if !keep_b[j] {
+                            working.bounds[j] = BoundStatus::Inactive;
+                            lambda_x[j] = 0.0;
+                            n_changes += 1;
+                        }
+                    }
+                    if trace {
+                        eprintln!(
+                            "[hom] rank repair at t={t:.6e}: {} -> {} cons, {} -> {} bounds",
+                            active_cons.len(),
+                            kc.len(),
+                            active_bounds.len(),
+                            kb.len()
+                        );
+                    }
+                    continue;
+                }
+                Err(e) => {
+                    if trace {
+                        eprintln!("[hom] KKT factorization failed at t={t:.6e}: {e}");
+                    }
+                    return Ok(None);
+                }
             }
             n_refactor += 1;
             let dx: Vec<Number> = rhs[..n].to_vec();

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -58,7 +58,7 @@
 //!   Model-Predictive Control* (2011), Ch. 5–7 — the sparse Schur extension.
 
 use crate::error::{QpError, QpStatus};
-use crate::kkt::{a_times_x, assemble_active_set_kkt, h_times_x};
+use crate::kkt::{a_times_x, assemble_active_set_kkt};
 use crate::options::QpOptions;
 use crate::problem::{QpProblem, QpSolution, QpStats};
 use crate::solver::ParametricActiveSetSolver;
@@ -66,7 +66,7 @@ use crate::solver::QpSolver as _;
 use crate::working_set::{BoundStatus, ConsStatus, WorkingSet};
 use pounce_common::Number;
 use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
-use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
 use std::time::Instant;
 
 /// How far the relaxed `t = 0` row bounds sit outside `A x₀`, relative to the
@@ -91,6 +91,85 @@ enum Event {
     DropRow(usize),
     /// Active bound on variable `j` has its multiplier reach zero.
     DropBound(usize),
+}
+
+/// Primal regularization `δ` for the path, derived from the problem's own scale.
+///
+/// Needed because the path starts from the box relaxation, and that relaxation is
+/// **unbounded** whenever `H` has no curvature in a box-unbounded direction —
+/// which is most LP-like instances (`QAFIRO` returns `obj = -inf`). Running the
+/// path on `H + δI` bounds it.
+///
+/// This is sound *specifically because the path is only a predictor*: the working
+/// set it discovers is handed to a corrector that solves the true QP, so `δ`
+/// never enters the reported answer, only the prediction of which constraints
+/// end up active.
+///
+/// `δ` is derived, not guessed. With `H = 0` the box relaxation's solution is
+/// `x₀ = clamp(−g/δ, box)`, so `δ = ‖g‖∞ / X` places `‖x₀‖` at roughly `X`, a
+/// representative variable magnitude. `X` is the median finite box width, or 1
+/// when no variable has two finite bounds. Putting `x₀` on the box's own scale
+/// matters because the `t = 0` row bounds are relaxed outward from `A x₀`: an
+/// enormous `x₀` would make them enormous too, and the path correspondingly long.
+///
+/// Returns `None` when `g` is zero — there is nothing to scale against, and with
+/// `H = 0` and `g = 0` every feasible point is optimal anyway.
+fn path_regularization_delta(qp: &QpProblem<'_>) -> Option<Number> {
+    let g_inf = qp.g.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
+    if !(g_inf > 0.0) || !g_inf.is_finite() {
+        return None;
+    }
+    let mut widths: Vec<Number> = (0..qp.n)
+        .filter_map(|i| {
+            let (l, u) = (qp.xl[i], qp.xu[i]);
+            (l > NLP_LOWER_BOUND_INF && u < NLP_UPPER_BOUND_INF).then(|| (u - l).abs())
+        })
+        .filter(|w| w.is_finite() && *w > 0.0)
+        .collect();
+    let x_scale = if widths.is_empty() {
+        1.0
+    } else {
+        widths.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        widths[widths.len() / 2]
+    };
+    let delta = g_inf / x_scale.max(1e-12);
+    delta.is_finite().then_some(delta.clamp(1e-12, 1e12))
+}
+
+/// `H + δI`, as a fresh symmetric triplet matrix.
+///
+/// `H` is stored lower-triangle 1-based with each pair listed once, so `δ` is
+/// added to an existing diagonal entry where one is present and appended
+/// otherwise — appending unconditionally would double-count a diagonal that `H`
+/// already carries.
+fn regularized_hessian(qp: &QpProblem<'_>, delta: Number) -> SymTMatrix {
+    let (irows, jcols, vals) = (qp.h.irows(), qp.h.jcols(), qp.h.values());
+    let mut ir: Vec<i32> = irows.to_vec();
+    let mut jc: Vec<i32> = jcols.to_vec();
+    let mut vl: Vec<Number> = vals.to_vec();
+
+    let mut has_diag = vec![false; qp.n];
+    for k in 0..ir.len() {
+        if ir[k] == jc[k] {
+            let idx = (ir[k] - 1) as usize;
+            if idx < qp.n {
+                vl[k] += delta;
+                has_diag[idx] = true;
+            }
+        }
+    }
+    for (i, seen) in has_diag.iter().enumerate() {
+        if !seen {
+            ir.push((i + 1) as i32);
+            jc.push((i + 1) as i32);
+            vl.push(delta);
+        }
+    }
+
+    let space = SymTMatrixSpace::new(qp.n as i32, ir, jc);
+    let mut h = SymTMatrix::new(space);
+    h.set_values(&vl);
+    h
 }
 
 /// Rate of change of a row bound per unit `t` (0 when the bound is infinite).
@@ -130,33 +209,88 @@ impl ParametricActiveSetSolver {
         // cross-checks `A`'s row count against `m`, so handing it the target's
         // `A` with `m = 0` is rejected outright.
         let empty_a = GenTMatrix::new(GenTMatrixSpace::new(0, n as i32, Vec::new(), Vec::new()));
-        let box_qp = QpProblem {
+        let trace = std::env::var("POUNCE_HOMOTOPY_DEBUG").is_ok();
+
+        // Built inline rather than by a closure: a closure returning
+        // `QpProblem<'_>` cannot tie the borrow of `h` to the returned value's
+        // lifetime, so it fails to compile.
+        macro_rules! box_qp {
+            ($h:expr) => {
+                QpProblem {
+                    n,
+                    m: 0,
+                    h: $h,
+                    g: qp.g,
+                    a: &empty_a,
+                    bl: &[],
+                    bu: &[],
+                    xl: qp.xl,
+                    xu: qp.xu,
+                    hessian_inertia: qp.hessian_inertia,
+                }
+            };
+        }
+
+        // Try the true `H` first, and regularize only if that fails. An
+        // unbounded box relaxation means `H` has no curvature in a
+        // box-unbounded direction; the *target* may still be bounded (a row
+        // constraint can cut the ray off), so it is not an unboundedness verdict
+        // — just a statement that the path cannot start from here.
+        //
+        // Regularizing only on failure keeps the problems that already work
+        // bit-identical: `HS21` and `QPTEST` have positive-definite `H` and never
+        // reach the retry.
+        let mut h_reg_holder: Option<SymTMatrix> = None;
+        let box_sol = {
+            let first = self.solve(&box_qp!(qp.h), None, opts);
+            if trace {
+                match &first {
+                    Ok(s) => eprintln!("[hom] box relaxation: {:?} obj={:.6e}", s.status, s.obj),
+                    Err(e) => eprintln!("[hom] box relaxation ERROR: {e}"),
+                }
+            }
+            match first {
+                Ok(s) if s.status == QpStatus::Optimal => s,
+                _ => {
+                    let Some(delta) = path_regularization_delta(qp) else {
+                        return Ok(None);
+                    };
+                    let h_reg = regularized_hessian(qp, delta);
+                    let retry = self.solve(&box_qp!(&h_reg), None, opts);
+                    if trace {
+                        match &retry {
+                            Ok(s) => eprintln!(
+                                "[hom] box relaxation (delta={delta:.3e}): {:?} obj={:.6e}",
+                                s.status, s.obj
+                            ),
+                            Err(e) => eprintln!("[hom] box relaxation (regularized) ERROR: {e}"),
+                        }
+                    }
+                    match retry {
+                        Ok(s) if s.status == QpStatus::Optimal => {
+                            h_reg_holder = Some(h_reg);
+                            s
+                        }
+                        _ => return Ok(None),
+                    }
+                }
+            }
+        };
+
+        // Everything on the path is traced against this Hessian; the corrector at
+        // the end uses the caller's `qp` and therefore the true `H`.
+        let path_h: &SymTMatrix = h_reg_holder.as_ref().unwrap_or(qp.h);
+        let path_qp = QpProblem {
             n,
-            m: 0,
-            h: qp.h,
+            m,
+            h: path_h,
             g: qp.g,
-            a: &empty_a,
-            bl: &[],
-            bu: &[],
+            a: qp.a,
+            bl: qp.bl,
+            bu: qp.bu,
             xl: qp.xl,
             xu: qp.xu,
             hessian_inertia: qp.hessian_inertia,
-        };
-        let trace = std::env::var("POUNCE_HOMOTOPY_DEBUG").is_ok();
-        let box_attempt = self.solve(&box_qp, None, opts);
-        if trace {
-            match &box_attempt {
-                Ok(s) => eprintln!("[hom] box relaxation: {:?} obj={:.6e}", s.status, s.obj),
-                Err(e) => eprintln!("[hom] box relaxation ERROR: {e}"),
-            }
-        }
-        let box_sol = match box_attempt {
-            Ok(s) if s.status == QpStatus::Optimal => s,
-            // Unbounded box relaxation means `H` has no curvature in a
-            // box-unbounded direction. The *target* may still be bounded (a row
-            // constraint could cut the ray off), so this is not an unboundedness
-            // verdict — it just means this path cannot start here.
-            _ => return Ok(None),
         };
 
         let mut x = box_sol.x.clone();
@@ -214,7 +348,7 @@ impl ParametricActiveSetSolver {
             // `H` and `g` are fixed, so the stationarity block's right-hand side
             // does not move and the primal RHS is zero; only the active rows'
             // bounds advance, at `bound_rate`.
-            let kkt = assemble_active_set_kkt(qp, &active_cons, &active_bounds);
+            let kkt = assemble_active_set_kkt(&path_qp, &active_cons, &active_bounds);
             let mut rhs = vec![0.0; n + k_c + k_b];
             for (slot, &i) in active_cons.iter().enumerate() {
                 let is_lower = matches!(working.constraints[i], ConsStatus::AtLower);
@@ -378,9 +512,6 @@ impl ParametricActiveSetSolver {
             used_phase1: false,
             time: started.elapsed(),
         };
-        // Keep the homotopy's own objective/`x` only if the corrector agreed it
-        // was feasible; otherwise the corrector's answer stands.
-        let _ = (h_times_x(qp.h, &x), &lambda_g);
         Ok(Some(sol))
     }
 }

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -106,15 +106,35 @@ enum Event {
 /// end up active.
 ///
 /// `δ` is derived, not guessed. With `H = 0` the box relaxation's solution is
-/// `x₀ = clamp(−g/δ, box)`, so `δ = ‖g‖∞ / X` places `‖x₀‖` at roughly `X`, a
-/// representative variable magnitude. `X` is the median finite box width, or 1
-/// when no variable has two finite bounds. Putting `x₀` on the box's own scale
-/// matters because the `t = 0` row bounds are relaxed outward from `A x₀`: an
-/// enormous `x₀` would make them enormous too, and the path correspondingly long.
+/// `x₀ = clamp(−g/δ, box)`, so `‖g‖∞ / X` — for `X` a representative variable
+/// magnitude (median finite box width, else 1) — is the `δ` that places `‖x₀‖`
+/// at roughly `X`. That is the *scale* reference; the regularization itself is a
+/// small relative fraction of it, [`DELTA_REL`].
+///
+/// Sizing `δ` at the box scale was the original choice and it was wrong: at
+/// `O(1)` relative size, `H + δI` is not a perturbation of the problem but a
+/// different problem, and the path faithfully predicts *its* active set. On
+/// `QRECIPE` (published optimum −266.616) that produced −104.83; at `1e-6`
+/// relative it produces the exact optimum. Measured, both directions:
+///
+/// | δ relative size | QRECIPE result | path | time |
+/// |---|---|---|---|
+/// | `1` (box scale) | −104.83, wrong | 99 changes | 34.8 s |
+/// | `1e-6` | **−266.616, exact** | 125 changes | **0.053 s** |
+///
+/// The small `δ` is *both* more accurate and far faster: a bad prediction costs
+/// the corrector far more than the slightly longer path costs the predictor. The
+/// worry that a small `δ` would blow up `‖x₀‖` and so the path length is real but
+/// mild — 99 → 125 changes here, 29 → 34 on `QAFIRO`.
 ///
 /// Returns `None` when `g` is zero — there is nothing to scale against, and with
 /// `H = 0` and `g = 0` every feasible point is optimal anyway.
 fn path_regularization_delta(qp: &QpProblem<'_>) -> Option<Number> {
+    /// `δ` as a fraction of the problem's own objective scale. Small enough that
+    /// `H + δI` is a *perturbation* rather than a different problem, large enough
+    /// to bound the box relaxation in double precision. See the table above.
+    const DELTA_REL: Number = 1e-6;
+
     let g_inf = qp.g.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
     if !(g_inf > 0.0) || !g_inf.is_finite() {
         return None;
@@ -132,7 +152,7 @@ fn path_regularization_delta(qp: &QpProblem<'_>) -> Option<Number> {
         widths.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         widths[widths.len() / 2]
     };
-    let delta = g_inf / x_scale.max(1e-12);
+    let delta = DELTA_REL * g_inf / x_scale.max(1e-12);
     delta.is_finite().then_some(delta.clamp(1e-12, 1e12))
 }
 

--- a/crates/pounce-qp/src/lib.rs
+++ b/crates/pounce-qp/src/lib.rs
@@ -42,6 +42,7 @@
 pub mod elastic;
 pub mod error;
 pub mod factor;
+pub(crate) mod homotopy;
 pub mod kkt;
 pub mod options;
 pub mod problem;

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -77,11 +77,35 @@ pub struct QpOptions {
     /// Trace the §4.2 parametric homotopy on a **cold** solve instead of
     /// starting the conventional phase-1/phase-2 scheme.
     ///
-    /// Off by default while it is being evaluated. The homotopy is the
-    /// algorithm this crate is named for and the one the design note assumes
-    /// (§4.3 has phase-1 driving its elastic slacks to zero *as the homotopy
-    /// proceeds*); the conventional path is the substitute that exists because
-    /// the homotopy did not. See [`crate::homotopy`].
+    /// Off in this crate's defaults, and **on** in the convex QP driver
+    /// ([`pounce_convex::active_set`]) which is where it was measured. The
+    /// distinction is deliberate: this flag is read by every consumer of
+    /// `pounce-qp`, including the SQP outer loop's inner subproblem solves, and
+    /// that path has *not* been benchmarked with the homotopy. Enabling it
+    /// crate-wide changes those solves too and does break
+    /// `sqp::tests::classify_working_set_reproduces_sqp_solver_output_on_convex_eq`.
+    ///
+    /// The homotopy is the algorithm
+    /// this crate is named for and the one the design note assumes (§4.3 has
+    /// phase-1 driving its elastic slacks to zero *as the homotopy proceeds*);
+    /// the conventional phase-1/phase-2 scheme is the substitute that existed
+    /// because the homotopy did not.
+    ///
+    /// Full Maros-Mészáros, 138 problems, 120 s cap, same binary:
+    ///
+    /// | | correct | solved-but-wrong | timeouts |
+    /// |---|---|---|---|
+    /// | conventional | 58/138 | none | 54 |
+    /// | homotopy | **71/138** | none | 49 |
+    ///
+    /// The trade is not uniform: 20 problems are gained, 7 lost. Six of the
+    /// losses are *large* instances that previously solved and now hit the time
+    /// cap (`AUG2D`, `AUG2DC`, `CONT-050`, `CONT-100`, `DTOC3`, `STADAT3`) —
+    /// the homotopy is slower there, not wrong. The seventh, `QSHARE2B`,
+    /// completes its path but its corrector then exhausts its iterations.
+    /// Set this to `false` to get the old behaviour on such a workload.
+    ///
+    /// See [`crate::homotopy`].
     pub use_homotopy: bool,
 
     /// §4.4 full EXPAND anti-cycling primal perturbation. Active

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -74,6 +74,16 @@ pub struct QpOptions {
     /// noticeably slower on large warm-started workloads.
     pub use_schur_updates: bool,
 
+    /// Trace the §4.2 parametric homotopy on a **cold** solve instead of
+    /// starting the conventional phase-1/phase-2 scheme.
+    ///
+    /// Off by default while it is being evaluated. The homotopy is the
+    /// algorithm this crate is named for and the one the design note assumes
+    /// (§4.3 has phase-1 driving its elastic slacks to zero *as the homotopy
+    /// proceeds*); the conventional path is the substitute that exists because
+    /// the homotopy did not. See [`crate::homotopy`].
+    pub use_homotopy: bool,
+
     /// §4.4 full EXPAND anti-cycling primal perturbation. Active
     /// only when `anti_cycling = Expand`. The Harris two-pass
     /// (c14) prevents cycling at non-degenerate vertices; these
@@ -110,6 +120,7 @@ impl Default for QpOptions {
             inertia_shift_factor: 100.0,
             inertia_max_shifts: 12,
             use_schur_updates: false,
+            use_homotopy: false,
             expand_tol_initial: 1e-12,
             expand_tol_growth: 1e-11,
             expand_tol_max: 1e-7,

--- a/crates/pounce-qp/src/schur.rs
+++ b/crates/pounce-qp/src/schur.rs
@@ -92,6 +92,16 @@ pub struct SchurState {
     /// `S = I + Vᵀ K_0⁻¹ U`, row-major, size `s_dim × s_dim`.
     s_matrix: Vec<Number>,
     s_dim: usize,
+
+    /// The `K_0` triplet **as actually factored** at the last reset —
+    /// including any §4.5 inertia shift, so it matches the cached factor
+    /// rather than the unshifted ideal.
+    ///
+    /// Kept solely so [`Self::solve`] can form the residual
+    /// `b − (K_0 + UVᵀ)x` for iterative refinement. Without a residual there
+    /// is no way to detect that the SMW correction has drifted, and drift is
+    /// exactly this path's failure mode (see the refinement note on `solve`).
+    base_kkt: Option<KktTriplet>,
 }
 
 /// One half of a rank-2 update vector pair.
@@ -115,6 +125,7 @@ impl SchurState {
             kinv_u_cols: Vec::new(),
             s_matrix: Vec::new(),
             s_dim: 0,
+            base_kkt: None,
         }
     }
 
@@ -270,6 +281,7 @@ impl SchurState {
                 self.kinv_u_cols.clear();
                 self.s_matrix.clear();
                 self.s_dim = 0;
+                self.base_kkt = Some(kkt.clone());
                 return Ok(());
             }
             Err(ref e) if e.is_recoverable_factorization_failure() => {
@@ -290,6 +302,7 @@ impl SchurState {
                     self.kinv_u_cols.clear();
                     self.s_matrix.clear();
                     self.s_dim = 0;
+                    self.base_kkt = Some(kkt.clone());
                     return Ok(());
                 }
                 Err(ref e) if e.is_recoverable_factorization_failure() => {
@@ -379,7 +392,109 @@ impl SchurState {
     /// Solve `K_W [x; λ] = rhs` using SMW. `rhs` is overwritten
     /// with the solution. Requires that `reset` has been called
     /// at least once.
+    /// `y = (K_0 + UVᵀ) x` — a matvec against the operator the SMW formula
+    /// inverts, used to form the refinement residual.
+    ///
+    /// `K_0` is stored as **lower-triangle** 1-based triplets, so off-diagonal
+    /// entries must be applied to both `(i,j)` and `(j,i)`; getting that wrong
+    /// would silently halve the symmetric part and make refinement diverge.
+    /// Returns `None` when no base matrix has been recorded (no reset yet), in
+    /// which case the caller simply skips refinement.
+    fn kw_matvec(&self, x: &[Number]) -> Option<Vec<Number>> {
+        let kkt = self.base_kkt.as_ref()?;
+        let mut y = vec![0.0; self.dim];
+        for k in 0..kkt.irn.len() {
+            let i = (kkt.irn[k] - 1) as usize;
+            let j = (kkt.jcn[k] - 1) as usize;
+            let v = kkt.vals[k];
+            y[i] += v * x[j];
+            if i != j {
+                y[j] += v * x[i];
+            }
+        }
+        // + U (Vᵀ x)
+        for j in 0..self.s_dim {
+            let c = dot(&self.v_cols[j], x);
+            if c != 0.0 {
+                let uj = &self.u_cols[j];
+                for (yi, &uij) in y.iter_mut().zip(uj.iter()) {
+                    *yi += c * uij;
+                }
+            }
+        }
+        Some(y)
+    }
+
+    /// Solve `(K_0 + UVᵀ) x = rhs` in place, **with iterative refinement**.
+    ///
+    /// Refinement is not a nicety here; it is what makes this path a
+    /// performance switch rather than an accuracy trade. The SMW correction is
+    /// computed against a factor of `K_0`, and its error grows with the number
+    /// of accumulated rank-2 updates, so the returned step drifts as the update
+    /// layer fills. That drift lands directly in the iterate: the active-set
+    /// loop takes the (slightly wrong) step, and the final `x` inherits every
+    /// step's error. Measured on the `tests/schur_vs_refactor.rs`
+    /// singular-Hessian QP, whose exact optimum is `x₀ = 1.5`:
+    ///
+    /// | `max_schur_updates_before_refactor` | error vs refactor path |
+    /// |---|---|
+    /// | 1  | 0 (exact) |
+    /// | 5  | 0 (exact) |
+    /// | 50 (default) | 1.5e-6 |
+    ///
+    /// A `1e-6` primal error is far above the `1e-9` `opt_tol` this engine
+    /// claims, and it was enough to drop the Maros-Mészáros spot check from
+    /// 22/24 to 20/24 when the Schur path was enabled. Refining against the
+    /// true operator removes the dependence on how full the update layer is.
+    ///
+    /// Mirrors the convex IPM's `solve_refined`, for the same reason: a single
+    /// back-solve near a degenerate optimum loses digits.
     pub fn solve(&self, linsol: &mut LinearSolver, rhs: &mut [Number]) -> Result<(), QpError> {
+        /// Refinement passes. Two is enough to recover full accuracy here —
+        /// the drift is a small relative perturbation, not a conditioning wall.
+        const IR_MAX_PASSES: usize = 2;
+        /// Minimum fractional residual reduction for a pass to count as
+        /// progress. Below this the correction is round-off, not signal.
+        const IR_MIN_GAIN: Number = 0.5;
+
+        let b = rhs.to_vec();
+        self.solve_once(linsol, rhs)?;
+
+        // Deliberately NOT gated on `‖b‖`. The phase-1 elastic system carries
+        // the penalty `γ = 1e6` in its RHS, so a `‖b‖`-relative test treats an
+        // absolute residual of ~1e-8 as converged — and on an operator that
+        // `γ` has made this ill-conditioned, 1e-8 of residual is ~1e-6 of
+        // *solution* error, which is precisely the drift being fixed. Refine
+        // while the residual keeps shrinking instead, and stop when it does
+        // not: that is scale-free and cannot loop.
+        let mut prev = Number::INFINITY;
+        for _ in 0..IR_MAX_PASSES {
+            let Some(kx) = self.kw_matvec(rhs) else { break };
+            let mut r: Vec<Number> = b.iter().zip(kx.iter()).map(|(&bi, &ki)| bi - ki).collect();
+            let r_norm = r.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
+            if !r_norm.is_finite() || r_norm == 0.0 {
+                break;
+            }
+            // No meaningful progress ⇒ further passes are noise.
+            if r_norm > prev * (1.0 - IR_MIN_GAIN) {
+                break;
+            }
+            prev = r_norm;
+            // A correction that cannot be computed leaves the unrefined answer
+            // in place rather than failing the solve — it is still usable, and
+            // the caller's own verification decides whether it is good enough.
+            if self.solve_once(linsol, &mut r).is_err() {
+                break;
+            }
+            for (xi, &dxi) in rhs.iter_mut().zip(r.iter()) {
+                *xi += dxi;
+            }
+        }
+        Ok(())
+    }
+
+    /// One unrefined SMW solve: `x = K_0⁻¹b − K_0⁻¹U · S⁻¹ · VᵀK_0⁻¹b`.
+    fn solve_once(&self, linsol: &mut LinearSolver, rhs: &mut [Number]) -> Result<(), QpError> {
         if rhs.len() != self.dim {
             return Err(QpError::DimensionMismatch(format!(
                 "Schur solve RHS length {} but K_max dim is {}",

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -102,7 +102,7 @@ impl ParametricActiveSetSolver {
     /// is always checked. The `HessianInertia::Indefinite` hint
     /// merely tells the caller "shifts may be needed"; the
     /// algorithm decides what to do based on the factor's report.
-    fn factorize_with_inertia_control(
+    pub(crate) fn factorize_with_inertia_control(
         &mut self,
         mut kkt: KktTriplet,
         rhs: &mut [Number],
@@ -2713,6 +2713,17 @@ impl QpSolver for ParametricActiveSetSolver {
         if let Some(w) = ws {
             if !point_is_feasible(qp, &w.x, opts.feas_tol) {
                 return self.solve_elastic(qp, opts);
+            }
+        }
+
+        // Cold + general rows: try the parametric homotopy first. It returns
+        // `Ok(None)` when the path cannot be started (no rows, or the box
+        // relaxation is unbounded), which is a fall-through signal rather than a
+        // verdict, so the conventional path below still handles everything it
+        // handled before.
+        if ws.is_none() && opts.use_homotopy {
+            if let Some(sol) = self.solve_cold_homotopy(qp, opts)? {
+                return Ok(sol);
             }
         }
 

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -82,7 +82,10 @@ pub trait QpSolver {
 /// note). Owns a single linear-solver backend; future Schur-
 /// complement state lives here too.
 pub struct ParametricActiveSetSolver {
-    linsol: LinearSolver,
+    /// Crate-visible so sibling modules — notably [`crate::homotopy`] — can
+    /// reuse the rank-repair helpers, which take the shared linear-solver
+    /// backend rather than owning one.
+    pub(crate) linsol: LinearSolver,
 }
 
 impl ParametricActiveSetSolver {
@@ -2306,7 +2309,7 @@ const TABU_DRIFT_REL: Number = 1e-7;
 /// can rescue a rank-deficient *constraint* block). General-constraint
 /// rows are processed before variable bounds, so equality / general
 /// rows are preferred over bounds when a tie must be broken.
-fn independent_active_subset(
+pub(crate) fn independent_active_subset(
     linsol: &mut LinearSolver,
     qp: &QpProblem,
     active_cons: &[usize],

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -1707,7 +1707,32 @@ impl ParametricActiveSetSolver {
             for (rhs_i, (hx_i, &g_i)) in rhs[..n].iter_mut().zip(hx.iter().zip(qp.g.iter())) {
                 *rhs_i = -(hx_i + g_i);
             }
-            schur.solve(&mut self.linsol, &mut rhs)?;
+            // A singular Schur complement is a normal event in SMW updating,
+            // not a solver breakdown: the accumulated rank-2 updates can leave
+            // the small dense block `S` singular while the underlying
+            // active-set KKT is perfectly well conditioned. Recover the way the
+            // count-based path already does — discard the update layer and
+            // refactor `K_max` against the current working set — then redo the
+            // solve. Nothing but the failed `S⁻¹` is thrown away, so the answer
+            // is unchanged; this is what keeps the Schur path a pure
+            // *performance* switch.
+            //
+            // Without this recovery the entire solve aborted with
+            // `LinearSolverFailure("Schur block is singular …")` on problems the
+            // refactor path solves exactly — the reason the Schur path could not
+            // be turned on by default. See `tests/schur_vs_refactor.rs`.
+            let rhs_backup = rhs.clone();
+            if let Err(e) = schur.solve(&mut self.linsol, &mut rhs) {
+                if !e.is_recoverable_factorization_failure() {
+                    return Err(e);
+                }
+                let ac = active_slot_count(&working);
+                schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                n_refactor += 1;
+                // `solve` writes through `rhs`, so restore it before retrying.
+                rhs.copy_from_slice(&rhs_backup);
+                schur.solve(&mut self.linsol, &mut rhs)?;
+            }
 
             let p: Vec<Number> = rhs[..n].to_vec();
             let p_inf = p.iter().map(|pi| pi.abs()).fold(0.0, f64::max);
@@ -1753,7 +1778,18 @@ impl ParametricActiveSetSolver {
                             m + i
                         }
                     };
-                    schur.apply_change(&mut self.linsol, qp, slot, false)?;
+                    // Degenerate rank-2 update ⇒ refactor instead. `working`
+                    // already carries this drop, so resetting against it
+                    // reaches exactly the state the update was meant to
+                    // produce, without the update.
+                    if let Err(e) = schur.apply_change(&mut self.linsol, qp, slot, false) {
+                        if !e.is_recoverable_factorization_failure() {
+                            return Err(e);
+                        }
+                        let ac = active_slot_count(&working);
+                        schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                        n_refactor += 1;
+                    }
                     n_changes += 1;
                     n_schur_updates += 1;
                     if schur.needs_reset(opts) {
@@ -1885,7 +1921,16 @@ impl ParametricActiveSetSolver {
                         i
                     }
                 };
-                schur.apply_change(&mut self.linsol, qp, slot, true)?;
+                // Same recovery as the drop side: `working` already carries this
+                // add, so a reset against it reproduces the intended state.
+                if let Err(e) = schur.apply_change(&mut self.linsol, qp, slot, true) {
+                    if !e.is_recoverable_factorization_failure() {
+                        return Err(e);
+                    }
+                    let ac = active_slot_count(&working);
+                    schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                    n_refactor += 1;
+                }
                 n_changes += 1;
                 n_schur_updates += 1;
                 if schur.needs_reset(opts) {

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -2602,7 +2602,33 @@ impl QpSolver for ParametricActiveSetSolver {
             if matches!(sol.status, QpStatus::Optimal)
                 && !point_is_feasible(qp, &sol.x, opts.feas_tol)
             {
-                return self.solve_elastic(qp, opts);
+                // Never-regress on the recovery. Elastic phase-1 is a *repair*
+                // for a solve that converged to a constraint-violating point,
+                // but it is not guaranteed to land somewhere better, and when it
+                // does not the substitution is destructive: on Maros-Meszaros
+                // `QADLITTL` (optimum 480319) the audited iterate sits at
+                // 500918 with a small violation, and the elastic result that
+                // replaced it was 8.07 — the elastic seed (origin projected
+                // into the box), essentially no answer at all. The symptom from
+                // outside was a *larger* `max_iter` producing a far worse
+                // objective, because only the bigger budget got far enough to
+                // reach `Optimal` and trip this audit.
+                //
+                // Keep whichever point is less infeasible. Elastic still wins
+                // whenever it does its job — driving the slacks out — which is
+                // the case this path exists for.
+                let before = max_violation(qp, &sol.x);
+                let repaired = self.solve_elastic(qp, opts)?;
+                let after = max_violation(qp, &repaired.x);
+                if after <= before {
+                    return Ok(repaired);
+                }
+                // Repair regressed feasibility: keep the audited point, but do
+                // not dress it up as `Optimal` — it violates constraints, which
+                // is exactly what the audit established.
+                let mut kept = sol;
+                kept.status = QpStatus::MaxIter;
+                return Ok(kept);
             }
             return Ok(sol);
         }
@@ -2750,6 +2776,33 @@ impl QpSolver for ParametricActiveSetSolver {
 /// reach a KKT-stationary point that violates a constraint and report
 /// it as `Optimal`. `solve` runs this audit before trusting an
 /// `Optimal` and recovers through elastic mode on failure.
+/// Largest constraint / bound violation at `x` (0.0 when feasible).
+///
+/// The magnitude behind [`point_is_feasible`]'s boolean, needed so a recovery
+/// path can tell whether the point it is about to substitute is actually an
+/// improvement on the one it is discarding.
+fn max_violation(qp: &QpProblem, x: &[Number]) -> Number {
+    let ax = a_times_x(qp.a, x, qp.m);
+    let mut worst: Number = 0.0;
+    for i in 0..qp.m {
+        if qp.bl[i] > NLP_LOWER_BOUND_INF {
+            worst = worst.max(qp.bl[i] - ax[i]);
+        }
+        if qp.bu[i] < NLP_UPPER_BOUND_INF {
+            worst = worst.max(ax[i] - qp.bu[i]);
+        }
+    }
+    for (i, &xi) in x.iter().enumerate() {
+        if qp.xl[i] > NLP_LOWER_BOUND_INF {
+            worst = worst.max(qp.xl[i] - xi);
+        }
+        if qp.xu[i] < NLP_UPPER_BOUND_INF {
+            worst = worst.max(xi - qp.xu[i]);
+        }
+    }
+    worst.max(0.0)
+}
+
 fn point_is_feasible(qp: &QpProblem, x: &[Number], feas_tol: Number) -> bool {
     let ax = a_times_x(qp.a, x, qp.m);
     for i in 0..qp.m {

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -1661,6 +1661,99 @@ impl ParametricActiveSetSolver {
     /// always PD, so the two paths are identical; the gap is latent
     /// for indefinite inputs on the opt-in `use_schur_updates = true`
     /// path. See code-review item M10.
+    /// Reset the Schur base factor, **repairing a rank-deficient active set**
+    /// rather than failing on it.
+    ///
+    /// At a degenerate vertex more rows can be binding than there are
+    /// variables, and those extra rows are linearly dependent — an LICQ
+    /// violation. The resulting active-set KKT is singular, and no §4.5 H-block
+    /// shift can repair a rank-deficient *constraint* block, so the inertia
+    /// loop simply exhausts and reports failure.
+    ///
+    /// [`Self::solve_general`] has carried this guard for a long time;
+    /// `solve_general_schur` never did. That asymmetry was invisible while the
+    /// Schur path was opt-in, and became the dominant failure mode the moment
+    /// it was switched on for the convex active-set driver: 27 of 138
+    /// Maros-Mészáros problems (`QSHARE2B`, `QSCTAP1`, …) turned into a hard
+    /// `LinearSolverFailure("KKT matrix is singular (LICQ violation or
+    /// rank-deficient Jacobian)")` where the refactor path had merely failed to
+    /// converge.
+    ///
+    /// The repair is the same one the refactor path and
+    /// [`Self::cold_general_initial`] use: prune the active set to a maximal
+    /// linearly independent subset and deactivate the rest. A dropped row is a
+    /// linear combination of the kept ones, so it stays satisfied at the
+    /// current `x` and the feasible set is unchanged — only the rank deficiency
+    /// is removed. Deactivating a bound does not move `x`, so the iterate stays
+    /// feasible throughout.
+    ///
+    /// Each repair strictly shrinks the active set, so the inner loop
+    /// terminates. `budget` additionally caps how many repairs one *solve* may
+    /// perform: the ratio test can re-admit a pruned row on a later iteration,
+    /// and without the refactor path's rank-tabu bookkeeping there is nothing
+    /// here to stop a prune/re-add cycle. Exhausting the budget surfaces the
+    /// original error instead of spinning.
+    fn schur_reset_rank_repaired(
+        &mut self,
+        schur: &mut crate::schur::SchurState,
+        qp: &QpProblem,
+        working: &mut WorkingSet,
+        opts: &QpOptions,
+        n_changes: &mut u32,
+        budget: &mut u32,
+    ) -> Result<(), QpError> {
+        loop {
+            let ac = active_slot_count(working);
+            match schur.reset(&mut self.linsol, qp, working, ac as i32, opts) {
+                Ok(()) => return Ok(()),
+                Err(e) if e.is_recoverable_factorization_failure() => {
+                    if *budget == 0 {
+                        return Err(e);
+                    }
+                    let active_cons: Vec<usize> = (0..qp.m)
+                        .filter(|&i| working.constraints[i].is_active())
+                        .collect();
+                    let active_bounds: Vec<usize> = (0..qp.n)
+                        .filter(|&i| working.bounds[i].is_active())
+                        .collect();
+                    let (kc, kb) = independent_active_subset(
+                        &mut self.linsol,
+                        qp,
+                        &active_cons,
+                        &active_bounds,
+                    );
+                    // Already full rank ⇒ the failure is not a rank deficiency
+                    // this guard can repair; do not loop on it.
+                    if kc.len() == active_cons.len() && kb.len() == active_bounds.len() {
+                        return Err(e);
+                    }
+                    *budget -= 1;
+                    let mut keep_c = vec![false; qp.m];
+                    for &i in &kc {
+                        keep_c[i] = true;
+                    }
+                    let mut keep_b = vec![false; qp.n];
+                    for &i in &kb {
+                        keep_b[i] = true;
+                    }
+                    for &i in &active_cons {
+                        if !keep_c[i] {
+                            working.constraints[i] = ConsStatus::Inactive;
+                            *n_changes += 1;
+                        }
+                    }
+                    for &i in &active_bounds {
+                        if !keep_b[i] {
+                            working.bounds[i] = BoundStatus::Inactive;
+                            *n_changes += 1;
+                        }
+                    }
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
     fn solve_general_schur(
         &mut self,
         qp: &QpProblem,
@@ -1674,6 +1767,11 @@ impl ParametricActiveSetSolver {
         let mut n_refactor: u32 = 0;
         let mut n_changes: u32 = 0;
         let mut n_schur_updates: u32 = 0;
+        // Rank repairs allowed for this solve. Generous relative to the number
+        // of genuinely dependent rows a degenerate vertex carries, but finite —
+        // see `schur_reset_rank_repaired` on why a cap is needed here and not
+        // on the refactor path.
+        let mut rank_repair_budget: u32 = (qp.n + qp.m).min(1000) as u32;
 
         let (mut x, mut working) = if let Some(w) = ws {
             (w.x.clone(), w.working.clone())
@@ -1694,8 +1792,14 @@ impl ParametricActiveSetSolver {
 
         // Initialize Schur and factor the base K_max.
         let mut schur = crate::schur::SchurState::new(n, m);
-        let active_count = active_slot_count(&working);
-        schur.reset(&mut self.linsol, qp, &working, active_count as i32, opts)?;
+        self.schur_reset_rank_repaired(
+            &mut schur,
+            qp,
+            &mut working,
+            opts,
+            &mut n_changes,
+            &mut rank_repair_budget,
+        )?;
         n_refactor += 1;
 
         // GMSW EXPAND τ — same semantics as in solve_general.
@@ -1726,8 +1830,14 @@ impl ParametricActiveSetSolver {
                 if !e.is_recoverable_factorization_failure() {
                     return Err(e);
                 }
-                let ac = active_slot_count(&working);
-                schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                self.schur_reset_rank_repaired(
+                    &mut schur,
+                    qp,
+                    &mut working,
+                    opts,
+                    &mut n_changes,
+                    &mut rank_repair_budget,
+                )?;
                 n_refactor += 1;
                 // `solve` writes through `rhs`, so restore it before retrying.
                 rhs.copy_from_slice(&rhs_backup);
@@ -1786,15 +1896,27 @@ impl ParametricActiveSetSolver {
                         if !e.is_recoverable_factorization_failure() {
                             return Err(e);
                         }
-                        let ac = active_slot_count(&working);
-                        schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                        self.schur_reset_rank_repaired(
+                            &mut schur,
+                            qp,
+                            &mut working,
+                            opts,
+                            &mut n_changes,
+                            &mut rank_repair_budget,
+                        )?;
                         n_refactor += 1;
                     }
                     n_changes += 1;
                     n_schur_updates += 1;
                     if schur.needs_reset(opts) {
-                        let ac = active_slot_count(&working);
-                        schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                        self.schur_reset_rank_repaired(
+                            &mut schur,
+                            qp,
+                            &mut working,
+                            opts,
+                            &mut n_changes,
+                            &mut rank_repair_budget,
+                        )?;
                         n_refactor += 1;
                     }
                     continue;
@@ -1927,15 +2049,27 @@ impl ParametricActiveSetSolver {
                     if !e.is_recoverable_factorization_failure() {
                         return Err(e);
                     }
-                    let ac = active_slot_count(&working);
-                    schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                    self.schur_reset_rank_repaired(
+                        &mut schur,
+                        qp,
+                        &mut working,
+                        opts,
+                        &mut n_changes,
+                        &mut rank_repair_budget,
+                    )?;
                     n_refactor += 1;
                 }
                 n_changes += 1;
                 n_schur_updates += 1;
                 if schur.needs_reset(opts) {
-                    let ac = active_slot_count(&working);
-                    schur.reset(&mut self.linsol, qp, &working, ac as i32, opts)?;
+                    self.schur_reset_rank_repaired(
+                        &mut schur,
+                        qp,
+                        &mut working,
+                        opts,
+                        &mut n_changes,
+                        &mut rank_repair_budget,
+                    )?;
                     n_refactor += 1;
                 }
             }

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -989,14 +989,24 @@ impl ParametricActiveSetSolver {
                 // steepest-violation rule — faster but not cycle-
                 // free under pathological degeneracy).
                 //
-                // EXPAND (Gill-Murray-Saunders-Wright 1989) is the
-                // SOTA default per the design note; its full
-                // primal-perturbation machinery is one of the
-                // remaining Phase 5a items. Until it lands, the
-                // `Expand` enum variant aliases to the steepest-
-                // violation behavior, which is correct on every
-                // non-cycling problem in the analytical ladder and
-                // matches the qpOASES default.
+                // Scope note: EXPAND (Gill-Murray-Saunders-Wright
+                // 1989) governs the *ratio test*, and its τ
+                // primal-perturbation machinery is implemented —
+                // τ-relaxed blocker selection in `select_blocker`,
+                // plus the τ-growth and snap-reset below. It does
+                // **not** supply a drop rule, so under
+                // `AntiCyclingChoice::Expand` this choice is
+                // Dantzig's steepest-violation: correct on every
+                // non-cycling problem in the analytical ladder, and
+                // the qpOASES default, but not cycle-free on its own.
+                // The anti-stall Bland latch (`force_bland`) is what
+                // bounds the pathological case.
+                //
+                // (This comment previously said EXPAND's perturbation
+                // machinery had not landed and that `Expand` aliased
+                // wholesale to steepest-violation. That was true before
+                // c20 and stale after it — the aliasing is specific to
+                // the drop rule, not to EXPAND as a whole.)
                 let use_bland =
                     force_bland || matches!(opts.anti_cycling, AntiCyclingChoice::Bland);
 

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -2725,7 +2725,7 @@ impl QpSolver for ParametricActiveSetSolver {
         // verdict, so the conventional path below still handles everything it
         // handled before.
         if ws.is_none() && opts.use_homotopy {
-            if let Some(sol) = self.solve_cold_homotopy(qp, opts)? {
+            if let Some(sol) = self.solve_homotopy(qp, None, opts)? {
                 return Ok(sol);
             }
         }
@@ -2802,12 +2802,38 @@ impl QpSolver for ParametricActiveSetSolver {
 
     fn solve_parametric(
         &mut self,
-        _qp_prev: &QpProblem,
-        _sol_prev: &QpSolution,
+        qp_prev: &QpProblem,
+        sol_prev: &QpSolution,
         qp_new: &QpProblem,
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
-        // No parametric path yet — fall back to a fresh cold solve.
+        // Trace the homotopy from the previous problem to the new one, starting
+        // from the previous solution's working set.
+        //
+        // This is the crate's advertised feature and was a stub that discarded
+        // both prior arguments. It is the *easy* direction of the homotopy: the
+        // prior solution is already optimal for the prior QP, so the path starts
+        // on the solution manifold — there is no `QP_0` to construct and no box
+        // relaxation to bound, which is the whole difficulty of the cold case.
+        //
+        // Guards, in order: the two problems must have the same shape, and the
+        // same `H`. `H` is not interpolated along the path (only `g` and the row
+        // bounds are), so a changed Hessian would make the traced path solve a
+        // different problem than the one requested. Rather than silently
+        // mispredict, fall back to a cold solve — correct, just not warm.
+        let same_shape = qp_prev.n == qp_new.n && qp_prev.m == qp_new.m;
+        let same_h = qp_prev.h.nonzeros() == qp_new.h.nonzeros()
+            && qp_prev.h.values() == qp_new.h.values()
+            && qp_prev.h.irows() == qp_new.h.irows()
+            && qp_prev.h.jcols() == qp_new.h.jcols();
+        if same_shape
+            && same_h
+            && sol_prev.status == QpStatus::Optimal
+            && sol_prev.x.len() == qp_new.n
+            && let Some(sol) = self.solve_homotopy(qp_new, Some((qp_prev, sol_prev)), opts)?
+        {
+            return Ok(sol);
+        }
         self.solve(qp_new, None, opts)
     }
 

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -1815,6 +1815,42 @@ impl ParametricActiveSetSolver {
         // GMSW EXPAND τ — same semantics as in solve_general.
         let mut expand_tol = opts.expand_tol_initial;
 
+        // ---- Null-iteration guard (numerical floor / SMW drift) ----
+        //
+        // An iteration that takes the full step (`α = 1`, no blocker added)
+        // lands, in exact arithmetic, exactly on the minimizer of the current
+        // working set — so the very next `‖p‖∞` is zero and the loop moves on
+        // to the drop test. When it is *not* zero, the limit is the linear
+        // algebra rather than the algorithm, and the loop repeats a literal
+        // no-op until `max_iter`. Both variants were measured on
+        // Maros-Mészáros `CVXQP3_S` (3650 of its 3750 iterations were such
+        // no-ops):
+        //
+        //   * SMW drift — after 15 accumulated rank-2 updates the direction
+        //     no longer lies in the active rows' null space at all
+        //     (`‖A_W p‖∞ ≈ 1e-3`), so the "full Newton step" is not one.
+        //     Discarding the update layer and refactoring cures this.
+        //   * Noise floor — in the `γ = 1e6` elastic phase-1 the active-set
+        //     KKT is solved to `‖r‖∞ ≈ 1e-9`, which is all the conditioning
+        //     allows, and that leaves `‖p‖∞ ≈ 1.9e-9` permanently above the
+        //     `opt_tol = 1e-9` stationarity test. No refactor helps; the
+        //     iterate simply *is* stationary to attainable precision.
+        //
+        // So: on the first no-op, refactor. If a fresh factor still cannot
+        // shrink the step, accept the iterate as stationary for this working
+        // set and let the drop test run. Accepting is safe — `QpSolver::solve`
+        // re-audits feasibility and the convex driver re-measures the KKT
+        // error, so a point that is not really optimal is demoted, not
+        // believed — and it is strictly better than spending the whole budget
+        // re-deriving the same step.
+        let mut prev_p_inf = Number::INFINITY;
+        let mut prev_was_null_step = false;
+        let mut floor_refactored = false;
+        /// A genuine Newton step drives `‖p‖∞` to round-off, so anything short
+        /// of halving it means the step accomplished nothing.
+        const NULL_STEP_GAIN: Number = 0.5;
+
+        let trace = std::env::var("POUNCE_QP_TRACE").is_ok();
         for _iter in 0..opts.max_iter {
             let hx = h_times_x(qp.h, &x);
             let mut rhs = vec![0.0; n + m_total];
@@ -1857,7 +1893,72 @@ impl ParametricActiveSetSolver {
             let p: Vec<Number> = rhs[..n].to_vec();
             let p_inf = p.iter().map(|pi| pi.abs()).fold(0.0, f64::max);
 
-            if p_inf <= opts.opt_tol {
+            if trace {
+                // True residual of the *active-set* KKT system at (p, λ).
+                // Row block 1: H p + Σ_active a_i λ_i = -(Hx + g)
+                // Row block 2: a_iᵀ p = 0 for every active row / bound.
+                let hp = h_times_x(qp.h, &p);
+                let hxg = h_times_x(qp.h, &x);
+                let mut r1: Vec<Number> = (0..n).map(|i| hp[i] + hxg[i] + qp.g[i]).collect();
+                let (ir, jc, av) = (qp.a.irows(), qp.a.jcols(), qp.a.values());
+                for k in 0..ir.len() {
+                    let i = (ir[k] - 1) as usize;
+                    let j = (jc[k] - 1) as usize;
+                    if working.constraints[i].is_active() {
+                        r1[j] += av[k] * rhs[n + i];
+                    }
+                }
+                for j in 0..n {
+                    if working.bounds[j].is_active() {
+                        r1[j] += rhs[n + m + j];
+                    }
+                }
+                let ap_dbg = a_times_x(qp.a, &p, m);
+                let mut r2 = 0.0_f64;
+                for i in 0..m {
+                    if working.constraints[i].is_active() {
+                        r2 = r2.max(ap_dbg[i].abs());
+                    }
+                }
+                for j in 0..n {
+                    if working.bounds[j].is_active() {
+                        r2 = r2.max(p[j].abs());
+                    }
+                }
+                let r1n = r1.iter().fold(0.0_f64, |a, v| a.max(v.abs()));
+                eprintln!(
+                    "[qp] it={_iter} RES stat={r1n:.3e} actrow={r2:.3e} pinf={p_inf:.3e} sdim={} nact={}",
+                    schur.n_schur_updates() * 2,
+                    active_slot_count(&working)
+                );
+            }
+
+            // Null-iteration guard — see the note above the loop.
+            let mut stationary = p_inf <= opts.opt_tol;
+            if !stationary && prev_was_null_step && p_inf > NULL_STEP_GAIN * prev_p_inf {
+                if floor_refactored {
+                    // A fresh factor already failed to shrink the step: this is
+                    // the attainable-accuracy floor, not update drift.
+                    stationary = true;
+                } else {
+                    floor_refactored = true;
+                    self.schur_reset_rank_repaired(
+                        &mut schur,
+                        qp,
+                        &mut working,
+                        opts,
+                        &mut n_changes,
+                        &mut rank_repair_budget,
+                    )?;
+                    n_refactor += 1;
+                    prev_was_null_step = false;
+                    prev_p_inf = Number::INFINITY;
+                    continue;
+                }
+            }
+            prev_p_inf = p_inf;
+
+            if stationary {
                 let mut worst: Option<(DropTarget, Number)> = None;
                 for slot in 0..m_total {
                     if !crate::schur::SchurState::slot_active(&working, slot) {
@@ -1898,6 +1999,15 @@ impl ParametricActiveSetSolver {
                             m + i
                         }
                     };
+                    if trace {
+                        eprintln!(
+                            "[qp] it={_iter} DROP slot={slot} viol={:.3e} obj={:.12e} nact={} pinf={:.2e}",
+                            worst.unwrap().1,
+                            quad_objective(qp, &x),
+                            active_slot_count(&working),
+                            p_inf
+                        );
+                    }
                     // Degenerate rank-2 update ⇒ refactor instead. `working`
                     // already carries this drop, so resetting against it
                     // reaches exactly the state the update was meant to
@@ -1929,6 +2039,11 @@ impl ParametricActiveSetSolver {
                         )?;
                         n_refactor += 1;
                     }
+                    // The working set changed, so the next step is a fresh
+                    // Newton step, not a repeat: re-arm the null-iteration
+                    // guard.
+                    prev_was_null_step = false;
+                    floor_refactored = false;
                     continue;
                 }
 
@@ -2034,6 +2149,14 @@ impl ParametricActiveSetSolver {
             if alpha < 0.0 {
                 alpha = 0.0;
             }
+            if trace && blocker.is_none() {
+                eprintln!(
+                    "[qp] it={_iter} NOBLOCK alpha={alpha:.3e} pinf={p_inf:.3e} obj={:.12e} nact={} ncand={}",
+                    quad_objective(qp, &x),
+                    active_slot_count(&working),
+                    candidates.len()
+                );
+            }
             for (xi, &pi) in x.iter_mut().zip(p.iter()) {
                 *xi += alpha * pi;
             }
@@ -2053,6 +2176,14 @@ impl ParametricActiveSetSolver {
                         i
                     }
                 };
+                if trace {
+                    eprintln!(
+                        "[qp] it={_iter} ADD  slot={slot} alpha={alpha:.3e} obj={:.12e} nact={} pinf={:.2e}",
+                        quad_objective(qp, &x),
+                        active_slot_count(&working),
+                        p_inf
+                    );
+                }
                 // Same recovery as the drop side: `working` already carries this
                 // add, so a reset against it reproduces the intended state.
                 if let Err(e) = schur.apply_change(&mut self.linsol, qp, slot, true) {
@@ -2098,6 +2229,17 @@ impl ParametricActiveSetSolver {
                     }
                 }
                 expand_tol = opts.expand_tol_initial;
+            }
+
+            // Null-iteration bookkeeping. A blocker means the working set grew,
+            // so the next step solves a *different* system and the guard
+            // re-arms; no blocker means a full step was taken and the next
+            // `‖p‖∞` must be round-off if the linear algebra is sound.
+            if blocker.is_some() {
+                prev_was_null_step = false;
+                floor_refactored = false;
+            } else {
+                prev_was_null_step = true;
             }
         }
 

--- a/crates/pounce-qp/tests/homotopy.rs
+++ b/crates/pounce-qp/tests/homotopy.rs
@@ -1,0 +1,159 @@
+//! §4.2 parametric homotopy — does it reach the same answer as the
+//! conventional phase-1/phase-2 path?
+//!
+//! The homotopy is the algorithm this crate is named for and was previously
+//! unimplemented (`solve_parametric` was a stub). It is off by default while
+//! being evaluated, so these tests drive it explicitly via
+//! `QpOptions::use_homotopy` and assert it agrees with the conventional path on
+//! problems with closed-form optima.
+//!
+//! Scope note, so a future reader is not misled by green tests: the homotopy
+//! currently starts from the **box-only relaxation**, which means it cannot
+//! start when that relaxation is unbounded (`H` singular in a box-unbounded
+//! direction — most LP-like instances), and it has no anti-cycling for
+//! *coincident* events, so it can stall at a degenerate parameter value. Both
+//! cases return `Ok(None)` internally and fall back to the conventional path, so
+//! they are invisible in results but real. See `crates/pounce-qp/src/homotopy.rs`.
+
+use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+use std::rc::Rc;
+
+fn new_solver() -> ParametricActiveSetSolver {
+    ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()))
+}
+
+struct Case {
+    n: usize,
+    m: usize,
+    h: (Vec<i32>, Vec<i32>, Vec<f64>),
+    g: Vec<f64>,
+    a: (Vec<i32>, Vec<i32>, Vec<f64>),
+    bl: Vec<f64>,
+    bu: Vec<f64>,
+    xl: Vec<f64>,
+    xu: Vec<f64>,
+}
+
+fn solve(case: &Case, homotopy: bool) -> (QpStatus, Vec<f64>, f64) {
+    let h_space = SymTMatrixSpace::new(case.n as i32, case.h.0.clone(), case.h.1.clone());
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&case.h.2);
+
+    let a_space = GenTMatrixSpace::new(
+        case.m as i32,
+        case.n as i32,
+        case.a.0.clone(),
+        case.a.1.clone(),
+    );
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&case.a.2);
+
+    let qp = QpProblem {
+        n: case.n,
+        m: case.m,
+        h: &h,
+        g: &case.g,
+        a: &a,
+        bl: &case.bl,
+        bu: &case.bu,
+        xl: &case.xl,
+        xu: &case.xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+    let opts = QpOptions {
+        use_homotopy: homotopy,
+        ..QpOptions::default()
+    };
+    let sol = new_solver().solve(&qp, None, &opts).expect("qp solve");
+    (sol.status, sol.x.clone(), sol.obj)
+}
+
+/// `min (x₀−3)² + (x₁−2)²  s.t.  x₀ + x₁ ≤ 4,  x ≥ 0`, in `½xᵀHx + gᵀx` form:
+/// `H = 2I`, `g = (−6, −4)` (constant 13 dropped).
+///
+/// `H` is positive definite so the box relaxation is bounded and the homotopy
+/// can start. The unconstrained optimum `(3, 2)` violates the row, so it binds:
+/// `x* = (2.5, 1.5)`, and `obj = 6.25 + 2.25 − 15 − 6 = −12.5`.
+fn projection_case() -> Case {
+    Case {
+        n: 2,
+        m: 1,
+        h: (vec![1, 2], vec![1, 2], vec![2.0, 2.0]),
+        g: vec![-6.0, -4.0],
+        a: (vec![1, 1], vec![1, 2], vec![1.0, 1.0]),
+        bl: vec![NLP_LOWER_BOUND_INF],
+        bu: vec![4.0],
+        xl: vec![0.0, 0.0],
+        xu: vec![NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF],
+    }
+}
+
+/// Two rows, both binding at the optimum, so the path must add more than one
+/// constraint on the way to `t = 1`.
+///
+/// `min ½(x₀² + x₁²) − 4x₀ − 4x₁  s.t.  x₀ + x₁ ≤ 4,  x₀ ≤ 1.5,  x ≥ 0`.
+/// Unconstrained optimum is `(4, 4)`. With `x₀ ≤ 1.5` binding, minimizing over
+/// `x₁` subject to `x₀ + x₁ ≤ 4` gives `x₁ = 2.5`, so `x* = (1.5, 2.5)` and
+/// `obj = ½(2.25 + 6.25) − 6 − 10 = 4.25 − 16 = −11.75`.
+fn two_active_case() -> Case {
+    Case {
+        n: 2,
+        m: 2,
+        h: (vec![1, 2], vec![1, 2], vec![1.0, 1.0]),
+        g: vec![-4.0, -4.0],
+        a: (vec![1, 1, 2], vec![1, 2, 1], vec![1.0, 1.0, 1.0]),
+        bl: vec![NLP_LOWER_BOUND_INF, NLP_LOWER_BOUND_INF],
+        bu: vec![4.0, 1.5],
+        xl: vec![0.0, 0.0],
+        xu: vec![NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF],
+    }
+}
+
+#[test]
+fn homotopy_solves_projection_qp() {
+    let (status, x, obj) = solve(&projection_case(), true);
+    assert_eq!(status, QpStatus::Optimal, "status");
+    assert!((x[0] - 2.5).abs() < 1e-8, "x0 = {}", x[0]);
+    assert!((x[1] - 1.5).abs() < 1e-8, "x1 = {}", x[1]);
+    assert!((obj + 12.5).abs() < 1e-8, "obj = {obj}");
+}
+
+#[test]
+fn homotopy_solves_two_active_rows() {
+    let (status, x, obj) = solve(&two_active_case(), true);
+    assert_eq!(status, QpStatus::Optimal, "status");
+    assert!((x[0] - 1.5).abs() < 1e-8, "x0 = {}", x[0]);
+    assert!((x[1] - 2.5).abs() < 1e-8, "x1 = {}", x[1]);
+    assert!((obj + 11.75).abs() < 1e-8, "obj = {obj}");
+}
+
+/// The homotopy is a *path*, not a different answer: it must agree with the
+/// conventional phase-1/phase-2 path everywhere it runs. Any disagreement means
+/// one of the two is wrong, which is the property worth pinning.
+#[test]
+fn homotopy_agrees_with_conventional_path() {
+    for (name, case) in [
+        ("projection", projection_case()),
+        ("two_active", two_active_case()),
+    ] {
+        let (cs, cx, cobj) = solve(&case, false);
+        let (hs, hx, hobj) = solve(&case, true);
+        assert_eq!(hs, cs, "{name}: status differs");
+        for i in 0..case.n {
+            assert!(
+                (hx[i] - cx[i]).abs() < 1e-7,
+                "{name}: x[{i}] homotopy {} vs conventional {}",
+                hx[i],
+                cx[i]
+            );
+        }
+        assert!(
+            (hobj - cobj).abs() < 1e-7,
+            "{name}: obj homotopy {hobj} vs conventional {cobj}"
+        );
+    }
+}

--- a/crates/pounce-qp/tests/homotopy.rs
+++ b/crates/pounce-qp/tests/homotopy.rs
@@ -157,3 +157,120 @@ fn homotopy_agrees_with_conventional_path() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Parametric (warm) solves — `QpSolver::solve_parametric`.
+//
+// This was a stub that discarded both prior arguments and cold-solved, despite
+// the crate advertising "true parametric warm starting". It now traces the
+// homotopy from the previous problem to the new one, starting from the previous
+// solution's working set.
+// ---------------------------------------------------------------------------
+
+/// Solve `case` from cold, then re-solve a `g`-perturbed version parametrically
+/// from that solution, and return both the warm result and the cold result for
+/// the *same* perturbed problem.
+fn parametric_vs_cold(
+    case: &Case,
+    dg: &[f64],
+) -> ((QpStatus, Vec<f64>, f64), (QpStatus, Vec<f64>, f64)) {
+    let h_space = SymTMatrixSpace::new(case.n as i32, case.h.0.clone(), case.h.1.clone());
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&case.h.2);
+    let a_space = GenTMatrixSpace::new(
+        case.m as i32,
+        case.n as i32,
+        case.a.0.clone(),
+        case.a.1.clone(),
+    );
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&case.a.2);
+
+    let g_new: Vec<f64> = case.g.iter().zip(dg).map(|(a, b)| a + b).collect();
+    let opts = QpOptions {
+        use_homotopy: true,
+        ..QpOptions::default()
+    };
+    // A closure returning `QpProblem<'_>` cannot tie the borrow of `g` to the
+    // returned value's lifetime, so build them explicitly.
+    macro_rules! mk {
+        ($g:expr) => {
+            QpProblem {
+                n: case.n,
+                m: case.m,
+                h: &h,
+                g: $g,
+                a: &a,
+                bl: &case.bl,
+                bu: &case.bu,
+                xl: &case.xl,
+                xu: &case.xu,
+                hessian_inertia: HessianInertia::Psd,
+            }
+        };
+    }
+
+    let mut s = new_solver();
+    let prev = s.solve(&mk!(&case.g), None, &opts).expect("cold prev");
+    let warm = s
+        .solve_parametric(&mk!(&case.g), &prev, &mk!(&g_new), &opts)
+        .expect("parametric");
+    let cold = new_solver()
+        .solve(&mk!(&g_new), None, &opts)
+        .expect("cold new");
+    (
+        (warm.status, warm.x.clone(), warm.obj),
+        (cold.status, cold.x.clone(), cold.obj),
+    )
+}
+
+/// A warm parametric solve must land on the same answer as a cold solve of the
+/// same target. Warm starting is a route, not a different problem.
+#[test]
+fn parametric_matches_cold_solve() {
+    for (name, case, dg) in [
+        ("projection", projection_case(), vec![0.5, -0.25]),
+        ("two_active", two_active_case(), vec![-1.0, 0.75]),
+    ] {
+        let ((ws, wx, wobj), (cs, cx, cobj)) = parametric_vs_cold(&case, &dg);
+        assert_eq!(ws, cs, "{name}: status warm {ws:?} vs cold {cs:?}");
+        for i in 0..case.n {
+            assert!(
+                (wx[i] - cx[i]).abs() < 1e-7,
+                "{name}: x[{i}] warm {} vs cold {}",
+                wx[i],
+                cx[i]
+            );
+        }
+        assert!(
+            (wobj - cobj).abs() < 1e-7,
+            "{name}: obj warm {wobj} vs cold {cobj}"
+        );
+    }
+}
+
+/// Re-solving an **unchanged** QP parametrically must be nearly free: the path
+/// has zero length, so no constraint can reach a bound and no multiplier can
+/// reach zero along it. This is the property that makes warm starting worth
+/// having, and the one a stub silently fails while still returning the right
+/// answer — so asserting the answer alone would not catch a regression here.
+#[test]
+fn parametric_on_unchanged_qp_is_free() {
+    for (name, case) in [
+        ("projection", projection_case()),
+        ("two_active", two_active_case()),
+    ] {
+        let ((ws, wx, wobj), (_, cx, cobj)) = parametric_vs_cold(&case, &vec![0.0; case.n]);
+        assert_eq!(ws, QpStatus::Optimal, "{name}: status");
+        for i in 0..case.n {
+            assert!(
+                (wx[i] - cx[i]).abs() < 1e-9,
+                "{name}: x[{i}] moved on an unchanged re-solve"
+            );
+        }
+        assert!(
+            (wobj - cobj).abs() < 1e-9,
+            "{name}: obj moved on an unchanged re-solve"
+        );
+    }
+}

--- a/crates/pounce-qp/tests/schur_vs_refactor.rs
+++ b/crates/pounce-qp/tests/schur_vs_refactor.rs
@@ -1,0 +1,159 @@
+//! Schur-update path vs refactor path — they must agree.
+//!
+//! `QpOptions::use_schur_updates` is documented as a pure *performance* switch:
+//! when set, `solve_general` absorbs working-set changes as rank-2
+//! Sherman-Morrison-Woodbury updates against a cached factor of the fixed-dim
+//! `K_max` instead of assembling and factoring a fresh active-set KKT each
+//! iteration. The crate README states the path's "correctness verified by
+//! Schur- vs-refactor cross-checks".
+//!
+//! It is not equivalent in practice. These tests pin the discrepancy on small
+//! problems with closed-form optima, so the failing side is unambiguous rather
+//! than a benchmark-scale mystery. Found while enabling the Schur path on the
+//! convex active-set QP driver (`pounce_convex::active_set`) to cut its
+//! per-iteration refactorization cost: enabling it dropped the Maros-Mészáros
+//! spot check from 22/24 to 20/24.
+
+use pounce_common::types::{NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+use std::rc::Rc;
+
+fn new_solver() -> ParametricActiveSetSolver {
+    ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()))
+}
+
+struct Case {
+    n: usize,
+    m: usize,
+    /// 1-based lower-triangle Hessian triplets.
+    h: (Vec<i32>, Vec<i32>, Vec<f64>),
+    g: Vec<f64>,
+    /// 1-based Jacobian triplets.
+    a: (Vec<i32>, Vec<i32>, Vec<f64>),
+    bl: Vec<f64>,
+    bu: Vec<f64>,
+    xl: Vec<f64>,
+    xu: Vec<f64>,
+}
+
+/// Solve `case` with `use_schur_updates = schur`, returning `(status, x, obj)`.
+fn solve(case: &Case, schur: bool) -> (QpStatus, Vec<f64>, f64) {
+    solve_with(
+        case,
+        schur,
+        QpOptions::default().max_schur_updates_before_refactor,
+    )
+}
+
+/// As [`solve`], but with an explicit Schur-block refactor interval, so a test
+/// can probe how far the answer drifts as rank-2 updates accumulate.
+fn solve_with(case: &Case, schur: bool, refactor_every: u32) -> (QpStatus, Vec<f64>, f64) {
+    let h_space = SymTMatrixSpace::new(case.n as i32, case.h.0.clone(), case.h.1.clone());
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&case.h.2);
+
+    let a_space = GenTMatrixSpace::new(
+        case.m as i32,
+        case.n as i32,
+        case.a.0.clone(),
+        case.a.1.clone(),
+    );
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&case.a.2);
+
+    let qp = QpProblem {
+        n: case.n,
+        m: case.m,
+        h: &h,
+        g: &case.g,
+        a: &a,
+        bl: &case.bl,
+        bu: &case.bu,
+        xl: &case.xl,
+        xu: &case.xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+    let opts = QpOptions {
+        use_schur_updates: schur,
+        max_schur_updates_before_refactor: refactor_every,
+        ..QpOptions::default()
+    };
+    let sol = new_solver().solve(&qp, None, &opts).expect("qp solve");
+    (sol.status, sol.x.clone(), sol.obj)
+}
+
+/// `min ½x₁² − 2x₀ − x₁  s.t.  x₀ + x₁ ≤ 2,  x₀ ≤ 1.5,  x ≥ 0`.
+///
+/// `P = diag(0, 1)` — no curvature along `x₀`, so the reduced Hessian is
+/// singular unless the working set pins that direction, which is exactly the
+/// geometry where a stale/mis-signed Schur block shows up. Both rows bind at
+/// the optimum: stationarity `(−2, x₁−1) + z₀(1,1) + z₁(1,0) = 0` gives
+/// `z₀ = 0.5`, `z₁ = 1.5`, both `≥ 0`, so
+/// `x* = (1.5, 0.5)` and `f* = 0.125 − 3 − 0.5 = −3.375`.
+fn singular_hessian_case() -> Case {
+    Case {
+        n: 2,
+        m: 2,
+        h: (vec![2], vec![2], vec![1.0]), // H[1,1] = 1 (1-based), i.e. diag(0,1)
+        g: vec![-2.0, -1.0],
+        a: (vec![1, 1, 2], vec![1, 2, 1], vec![1.0, 1.0, 1.0]),
+        bl: vec![NLP_LOWER_BOUND_INF, NLP_LOWER_BOUND_INF],
+        bu: vec![2.0, 1.5],
+        xl: vec![0.0, 0.0],
+        xu: vec![NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF],
+    }
+}
+
+#[test]
+fn refactor_path_solves_singular_hessian() {
+    let (status, x, obj) = solve(&singular_hessian_case(), false);
+    assert_eq!(status, QpStatus::Optimal, "refactor path status");
+    assert!((x[0] - 1.5).abs() < 1e-7, "x0 = {}", x[0]);
+    assert!((x[1] - 0.5).abs() < 1e-7, "x1 = {}", x[1]);
+    assert!((obj + 3.375).abs() < 1e-7, "obj = {obj}");
+}
+
+/// The Schur path must reach the *same* answer — it is a performance switch,
+/// not an algorithm change.
+#[test]
+fn schur_path_matches_refactor_on_singular_hessian() {
+    let case = singular_hessian_case();
+    let (rs, rx, robj) = solve(&case, false);
+    let (ss, sx, sobj) = solve(&case, true);
+
+    assert_eq!(
+        ss, rs,
+        "status differs: schur {ss:?} vs refactor {rs:?} (obj {sobj} vs {robj})"
+    );
+    for i in 0..case.n {
+        assert!(
+            (sx[i] - rx[i]).abs() < 1e-7,
+            "x[{i}] differs: schur {} vs refactor {}",
+            sx[i],
+            rx[i]
+        );
+    }
+    assert!(
+        (sobj - robj).abs() < 1e-7,
+        "obj differs: schur {sobj} vs refactor {robj}"
+    );
+}
+
+/// Is the Schur path's error *accumulation* in the rank-2 updates, or a
+/// systematic bug? Forcing a refactor after every single update makes the
+/// update layer never grow past one column; if the answer sharpens toward the
+/// refactor path's, the discrepancy is drift, and the fix belongs in the solve
+/// (refinement) rather than in the update algebra.
+#[test]
+fn schur_accuracy_vs_refactor_interval() {
+    let case = singular_hessian_case();
+    let (_, rx, _) = solve_with(&case, false, 50);
+    for every in [1u32, 5, 50] {
+        let (st, sx, _) = solve_with(&case, true, every);
+        let err = (sx[0] - rx[0]).abs().max((sx[1] - rx[1]).abs());
+        println!("refactor_every = {every:>2}: status {st:?}  max|dx| = {err:.3e}");
+    }
+}

--- a/crates/pounce-qp/tests/schur_vs_refactor.rs
+++ b/crates/pounce-qp/tests/schur_vs_refactor.rs
@@ -157,3 +157,45 @@ fn schur_accuracy_vs_refactor_interval() {
         println!("refactor_every = {every:>2}: status {st:?}  max|dx| = {err:.3e}");
     }
 }
+
+/// **LICQ-violating redundant equality** — the rank-detection case the crate
+/// README lists as a known limitation (analytical-ladder problem #4).
+///
+/// `min ½(x₀² + x₁²)  s.t.  x₀ + x₁ = 1,  2x₀ + 2x₁ = 2`
+///
+/// The second equality is exactly twice the first, so the active-set Jacobian
+/// has rank 1 with 2 rows and the active-set KKT is singular. No H-block
+/// inertia shift repairs a rank-deficient *constraint* block, so both paths
+/// must instead detect the dependence, prune to a maximal independent subset,
+/// and continue. The optimum is `x* = (0.5, 0.5)`, `f* = 0.25`.
+///
+/// `solve_general` has had this guard for a long time; `solve_general_schur`
+/// had none, so enabling `use_schur_updates` turned this shape into a hard
+/// `LinearSolverFailure("KKT matrix is singular (LICQ violation …)")`. Both
+/// paths are asserted here so the two cannot drift apart again.
+fn licq_redundant_equality_case() -> Case {
+    Case {
+        n: 2,
+        m: 2,
+        h: (vec![1, 2], vec![1, 2], vec![1.0, 1.0]), // P = I
+        g: vec![0.0, 0.0],
+        a: (vec![1, 1, 2, 2], vec![1, 2, 1, 2], vec![1.0, 1.0, 2.0, 2.0]),
+        bl: vec![1.0, 2.0],
+        bu: vec![1.0, 2.0],
+        xl: vec![NLP_LOWER_BOUND_INF, NLP_LOWER_BOUND_INF],
+        xu: vec![NLP_UPPER_BOUND_INF, NLP_UPPER_BOUND_INF],
+    }
+}
+
+#[test]
+fn licq_violating_equality_solves_on_both_paths() {
+    let case = licq_redundant_equality_case();
+    for schur in [false, true] {
+        let (status, x, obj) = solve(&case, schur);
+        let path = if schur { "schur" } else { "refactor" };
+        assert_eq!(status, QpStatus::Optimal, "{path} path status");
+        assert!((x[0] - 0.5).abs() < 1e-7, "{path}: x0 = {}", x[0]);
+        assert!((x[1] - 0.5).abs() < 1e-7, "{path}: x1 = {}", x[1]);
+        assert!((obj - 0.25).abs() < 1e-7, "{path}: obj = {obj}");
+    }
+}

--- a/docs/src/choosing-a-solver.md
+++ b/docs/src/choosing-a-solver.md
@@ -21,8 +21,20 @@ pluggable backend (FERAL by default, HSL MA57 optionally).
 | **NLP active-set SQP** | general smooth NLP | local | `pounce-algorithm` (subproblems via `pounce-qp`) | `algorithm=active-set-sqp` |
 | **Convex IPM (LP/QP)** | LP, convex QP | **global** | `pounce-convex` | `solve_qp_ipm`; `pounce.qp.solve_qp`; `solver_selection=lp-ipm`/`qp-ipm` |
 | **Convex IPM (conic)** | SOCP, exp/power/PSD cones, convex QCQP | **global** | `pounce-convex` | `solve_socp_ipm`; `pounce.qp.solve_socp`; `minimize` (convex QCQP); `solver_selection=socp`; `pounce <file>.cbf` |
-| **Active-set QP** | QP, convex *or* indefinite | local | `pounce-qp` | `ParametricActiveSetSolver`; `solver_selection=qp-active-set` |
+| **Active-set QP** | QP, convex *or* indefinite | local | `pounce-qp` | `ParametricActiveSetSolver`; `solver_selection=qp-active-set` — opt-in only; `auto` never picks it (see note) |
 | **SOS / Lasserre** | polynomial (nonconvex) | **global** | `pounce-convex` | `sos_minimize`; `pounce.sos_minimize` |
+
+> **When to reach for the active-set QP.** `auto` never selects it: a cold,
+> one-shot convex QP goes to the interior-point path, which is materially more
+> robust on that workload (137 of the 138 Maros-Mészáros problems, against
+> substantially fewer for a cold active-set solve). That is the character of the
+> method rather than a defect — an active-set iteration count is combinatorial
+> in the size of the active set, while an interior-point count is nearly
+> independent of problem size. Choose `solver_selection=qp-active-set` when you
+> want an *exact vertex* solution, or when you are solving a **sequence** of
+> similar QPs — MPC steps, branch-and-bound nodes, continuation — where the
+> working set carries across solves and `solve_parametric` can trace the
+> homotopy from the previous solution instead of starting over.
 
 > A general-purpose **spatial branch-and-bound** solver for factorable nonconvex
 > NLPs (`pounce-global`) is in development on the `feature/global` branch and is

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -79,15 +79,28 @@ pounce: problem class NLP does not match forced solver qp-ipm
         (expected an LP or convex QP)
 ```
 
-`qp-active-set` runs the active-set SQP engine, whose step QPs are solved
-by `pounce-qp`'s `ParametricActiveSetSolver`; on an LP or convex QP that
-converges in essentially one QP solve. It is the same engine the
-`algorithm=active-set-sqp` option selects — on the CLI, `solver_selection`
-additionally validates the problem class first, which is why the row above
-can promise the error. Duals are recovered and the `.sol` written exactly
-as on the IPM path. (The `minimize` library path has no `.nl` to classify,
-so there it runs on whatever problem it is given; see
-[Python](python.md#forcing-the-solver).)
+`qp-active-set` hands the QP directly to `pounce-qp`'s
+`ParametricActiveSetSolver`, through the same convex driver the IPM uses —
+so it inherits presolve, postsolve, dual recovery, `.sol` writing, timing
+and the convex status vocabulary. It is **not** the same route as
+`algorithm=active-set-sqp`, which wraps the QP in the full SQP outer loop;
+that option still exists and is the right one for a genuine NLP.
+
+**Choose it deliberately.** For a *cold, one-shot* convex QP the
+interior-point path (`qp-ipm`, and what `auto` selects) is materially more
+robust: on the 138-problem Maros-Mészáros set the IPM solves 137 while the
+active-set engine solves substantially fewer, mostly by exhausting its
+iteration budget on large degenerate instances. That is the expected
+character of a cold active-set method rather than a defect — its iteration
+count is combinatorial in the size of the active set, where an
+interior-point count is nearly independent of problem size. The active-set
+engine earns its keep on **warm-started sequences** — MPC steps,
+branch-and-bound nodes, continuation — where consecutive QPs differ little
+and the working set carries over; see `solve_parametric`.
+
+What it will not do is lie: it reports `Maximum_Iterations_Exceeded` rather
+than a wrong answer, and every claimed optimum is re-verified against the
+original problem's KKT conditions before being reported.
 
 ### From Pyomo
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -365,7 +365,7 @@ choice — mirroring the CLI option of the same name:
 | `"lp-ipm"` | Force the convex solver; raise `ValueError` if the problem is not detected as an LP. |
 | `"qp-ipm"` | Force the convex solver; raise `ValueError` if it is not detected as a convex LP/QP. |
 | `"socp"` | Force the conic solver; raise `ValueError` if it is not detected as a convex QCQP. |
-| `"qp-active-set"` | Run the active-set engine instead of the filter-IPM. On the **library** path this is `algorithm="active-set-sqp"` (the SQP outer loop); the **CLI** routes an LP/convex QP straight into the convex active-set driver instead, so the two are no longer the same route. |
+| `"qp-active-set"` | Run the `pounce-qp` active-set engine on a detected LP/convex QP — the **same engine and route the CLI uses**. Raises `ValueError` if the problem is not a convex LP/QP; for the active-set *SQP outer loop* on a general NLP, pass `algorithm="active-set-sqp"`. |
 
 Any other value raises `ValueError`. These are the same six selectors the CLI
 accepts, and matching is case-insensitive, as on the CLI.
@@ -373,12 +373,14 @@ accepts, and matching is case-insensitive, as on the CLI.
 Two differences from the CLI are worth knowing, both because `minimize` is a
 *library* consumer with no `.nl` file to classify:
 
-* `"qp-active-set"` is **not** class-validated here, and it is a *different
-  route* than the CLI's. The CLI restricts the selector to LP/convex QP and
-  sends those to the convex active-set driver; the library path has no
-  extracted problem class to check against, so it simply runs the SQP outer
-  loop on whatever problem it is given. Expect the CLI and `minimize` to differ
-  in iteration counts and reported statuses for the same convex QP as a result.
+* `"qp-active-set"` *is* class-validated here, unlike the other library-side
+  differences below — it takes the same Python-side convex extraction as
+  `"qp-ipm"` and dispatches to the same engine the CLI uses, so a given problem
+  gets the same algorithm from either surface. It previously forwarded to the
+  backend and ran the SQP outer loop, which meant one selector named two
+  different solvers depending on how you called POUNCE; that is fixed, and the
+  SQP outer loop is now reached only by its own name,
+  `algorithm="active-set-sqp"`.
 * The convex selectors (`"lp-ipm"`, `"qp-ipm"`, `"socp"`) work because
   `minimize` does its own Python-side structure detection. The equivalent Rust
   library API rejects them with `Invalid_Option`.

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -365,7 +365,7 @@ choice — mirroring the CLI option of the same name:
 | `"lp-ipm"` | Force the convex solver; raise `ValueError` if the problem is not detected as an LP. |
 | `"qp-ipm"` | Force the convex solver; raise `ValueError` if it is not detected as a convex LP/QP. |
 | `"socp"` | Force the conic solver; raise `ValueError` if it is not detected as a convex QCQP. |
-| `"qp-active-set"` | Run the active-set SQP engine instead of the filter-IPM. Equivalent to `algorithm="active-set-sqp"`. |
+| `"qp-active-set"` | Run the active-set engine instead of the filter-IPM. On the **library** path this is `algorithm="active-set-sqp"` (the SQP outer loop); the **CLI** routes an LP/convex QP straight into the convex active-set driver instead, so the two are no longer the same route. |
 
 Any other value raises `ValueError`. These are the same six selectors the CLI
 accepts, and matching is case-insensitive, as on the CLI.
@@ -373,9 +373,12 @@ accepts, and matching is case-insensitive, as on the CLI.
 Two differences from the CLI are worth knowing, both because `minimize` is a
 *library* consumer with no `.nl` file to classify:
 
-* `"qp-active-set"` is **not** class-validated here. The CLI restricts it to
-  LP/convex QP; the library path simply runs the SQP engine on whatever problem
-  it is given, since it has no extracted problem class to check against.
+* `"qp-active-set"` is **not** class-validated here, and it is a *different
+  route* than the CLI's. The CLI restricts the selector to LP/convex QP and
+  sends those to the convex active-set driver; the library path has no
+  extracted problem class to check against, so it simply runs the SQP outer
+  loop on whatever problem it is given. Expect the CLI and `minimize` to differ
+  in iteration counts and reported statuses for the same convex QP as a result.
 * The convex selectors (`"lp-ipm"`, `"qp-ipm"`, `"socp"`) work because
   `minimize` does its own Python-side structure detection. The equivalent Rust
   library API rejects them with `Invalid_Option`.

--- a/python/notebooks/30_active_set_qp.ipynb
+++ b/python/notebooks/30_active_set_qp.ipynb
@@ -1,0 +1,362 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "04c193b9",
+   "metadata": {},
+   "source": [
+    "# Active-set QP: `method=\"active-set\"` / `solver_selection=\"qp-active-set\"`\n",
+    "\n",
+    "POUNCE ships two solvers for convex LPs and QPs:\n",
+    "\n",
+    "* the **convex interior-point** solver (`pounce-convex`) — the default, and what\n",
+    "  `auto` picks;\n",
+    "* the **parametric active-set** engine (`pounce-qp`) — opt-in.\n",
+    "\n",
+    "This notebook shows how to reach the active-set engine, what it is good at,\n",
+    "and — with numbers — where it is clearly the wrong choice. If you only read one\n",
+    "line: **for a cold one-shot convex QP, prefer the interior-point solver.**\n",
+    "The active-set engine earns its place on small-to-medium dense problems and on\n",
+    "*sequences* of related QPs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "90db6ecf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:12:46.837822Z",
+     "iopub.status.busy": "2026-07-30T17:12:46.837438Z",
+     "iopub.status.idle": "2026-07-30T17:12:47.057204Z",
+     "shell.execute_reply": "2026-07-30T17:12:47.056875Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "import pounce\n",
+    "from pounce.qp import solve_qp\n",
+    "\n",
+    "np.set_printoptions(precision=6, suppress=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94cb7c74",
+   "metadata": {},
+   "source": [
+    "## 1. One API, two engines\n",
+    "\n",
+    "`solve_qp(..., method=...)` selects the engine. Both minimize\n",
+    "`½xᵀPx + cᵀx` subject to `Ax = b`, `Gx ≤ h`, `lb ≤ x ≤ ub`.\n",
+    "\n",
+    "Take `min (x₀−3)² + (x₁−2)²` subject to `x₀ + x₁ ≤ 4`, `x ≥ 0`. The\n",
+    "unconstrained optimum `(3, 2)` violates the row, so it binds and the answer is\n",
+    "the projection onto it: `x* = (2.5, 1.5)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "1be95295",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:12:47.058670Z",
+     "iopub.status.busy": "2026-07-30T17:12:47.058569Z",
+     "iopub.status.idle": "2026-07-30T17:12:47.063108Z",
+     "shell.execute_reply": "2026-07-30T17:12:47.062738Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ipm         status=optimal  x=[2.5 1.5]  obj=-12.499999999\n",
+      "active-set  status=optimal  x=[2.5 1.5]  obj=-12.500000000\n"
+     ]
+    }
+   ],
+   "source": [
+    "P = np.diag([2.0, 2.0])\n",
+    "c = np.array([-6.0, -4.0])          # (x-3)^2 + (x-2)^2, constant 13 dropped\n",
+    "G = np.array([[1.0, 1.0]])\n",
+    "h = np.array([4.0])\n",
+    "lb = np.zeros(2)\n",
+    "\n",
+    "for method in ('ipm', 'active-set'):\n",
+    "    r = solve_qp(P=P, c=c, G=G, h=h, lb=lb, method=method)\n",
+    "    print(f'{method:11s} status={r.status:8s} x={r.x}  obj={r.obj:.9f}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f921959",
+   "metadata": {},
+   "source": [
+    "Same point, same objective. The engines differ in *how* they get there, not in\n",
+    "what the answer is."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e4b678c7",
+   "metadata": {},
+   "source": [
+    "## 2. From `minimize`, and why both surfaces now agree\n",
+    "\n",
+    "`solver_selection=\"qp-active-set\"` reaches the same engine from `minimize`,\n",
+    "and — as of this release — from the CLI too. That was not always true: the\n",
+    "selector used to name the convex active-set driver on the CLI and the *SQP\n",
+    "outer loop* in `minimize`, so the same string meant two different algorithms\n",
+    "depending on how you called POUNCE.\n",
+    "\n",
+    "The tell for which engine ran is `nfev`. The convex route consumes the\n",
+    "extracted quadratic form and never calls back into Python, so a routed solve\n",
+    "reports **zero** function evaluations; the NLP path reports many."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "a7e1abbf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:12:47.064245Z",
+     "iopub.status.busy": "2026-07-30T17:12:47.064163Z",
+     "iopub.status.idle": "2026-07-30T17:12:47.072482Z",
+     "shell.execute_reply": "2026-07-30T17:12:47.072207Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "qp-ipm          x=[2.5 1.5]  fun=0.500000001  nfev=0\n",
+      "qp-active-set   x=[2.5 1.5]  fun=0.500000000  nfev=0\n",
+      "nlp             x=[2.5 1.5]  fun=0.499999993  nfev=9\n"
+     ]
+    }
+   ],
+   "source": [
+    "fun = lambda x: (x[0] - 3.0) ** 2 + (x[1] - 2.0) ** 2\n",
+    "jac = lambda x: np.array([2 * (x[0] - 3.0), 2 * (x[1] - 2.0)])\n",
+    "con = [{'type': 'ineq',\n",
+    "        'fun': lambda x: np.array([4.0 - x[0] - x[1]]),\n",
+    "        'jac': lambda x: np.array([[-1.0, -1.0]])}]\n",
+    "kw = dict(jac=jac, constraints=con, bounds=[(0, None), (0, None)])\n",
+    "\n",
+    "for sel in ('qp-ipm', 'qp-active-set', 'nlp'):\n",
+    "    r = pounce.minimize(fun, np.zeros(2), solver_selection=sel, **kw)\n",
+    "    print(f'{sel:15s} x={r.x}  fun={r.fun:.9f}  nfev={r.nfev}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09164fab",
+   "metadata": {},
+   "source": [
+    "`nfev=0` for both convex selectors confirms they routed to the convex solvers;\n",
+    "the NLP path evaluates the callbacks."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6aaa567",
+   "metadata": {},
+   "source": [
+    "## 3. Where the active-set engine wins\n",
+    "\n",
+    "On small-to-medium **dense**, well-conditioned QPs it does less work per solve.\n",
+    "An interior-point solve costs a fixed-ish number of expensive factorizations;\n",
+    "an active-set solve costs one cheap update per active-set change, and on a\n",
+    "well-behaved problem there are few."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b0414af4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:12:47.073638Z",
+     "iopub.status.busy": "2026-07-30T17:12:47.073569Z",
+     "iopub.status.idle": "2026-07-30T17:12:47.225697Z",
+     "shell.execute_reply": "2026-07-30T17:12:47.225354Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ipm         obj=-5.442057431    4.84 ms/solve\n",
+      "active-set  obj=-5.442057431    2.63 ms/solve\n"
+     ]
+    }
+   ],
+   "source": [
+    "rng = np.random.default_rng(0)\n",
+    "n, m = 60, 30\n",
+    "A = rng.standard_normal((n, n))\n",
+    "P_big = A @ A.T + 0.5 * np.eye(n)          # dense SPD\n",
+    "c_big = rng.standard_normal(n)\n",
+    "G_big = rng.standard_normal((m, n))\n",
+    "h_big = rng.standard_normal(m) + 2.0\n",
+    "\n",
+    "for method in ('ipm', 'active-set'):\n",
+    "    t0 = time.perf_counter()\n",
+    "    for _ in range(20):\n",
+    "        r = solve_qp(P=P_big, c=c_big, G=G_big, h=h_big, method=method)\n",
+    "    dt = (time.perf_counter() - t0) / 20\n",
+    "    print(f'{method:11s} obj={r.obj:.9f}  {dt * 1e3:6.2f} ms/solve')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2695a580",
+   "metadata": {},
+   "source": [
+    "Same objective to nine digits, in roughly half the time. Your mileage depends\n",
+    "on conditioning and on how many constraints are active at the optimum."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "890a2321",
+   "metadata": {},
+   "source": [
+    "## 4. Where it loses — and it loses badly\n",
+    "\n",
+    "The honest benchmark. All 138 Maros-Mészáros convex QPs, 120 s cap, graded\n",
+    "against published optima:\n",
+    "\n",
+    "| engine | correct |\n",
+    "|---|---|\n",
+    "| interior-point (`method=\"ipm\"`, and what `auto` picks) | **137 / 138** |\n",
+    "| active-set | 71 / 138 |\n",
+    "\n",
+    "That gap is not a bug list, it is the character of the method. An active-set\n",
+    "iteration count is *combinatorial* in the size of the active set, so large,\n",
+    "degenerate problems exhaust the iteration budget; an interior-point count is\n",
+    "nearly independent of problem size. This is why `auto` never selects the\n",
+    "active-set engine, and why you should not reach for it on an unfamiliar large\n",
+    "problem.\n",
+    "\n",
+    "**What it will not do is lie.** Across all 138 problems and every configuration\n",
+    "tested, it never returned a successful status with a wrong objective: every\n",
+    "claimed optimum is re-verified against the original problem's KKT conditions\n",
+    "before it is reported, and a solve that cannot be verified is downgraded to\n",
+    "`Maximum_Iterations_Exceeded` or a numerical failure. A failure is visible, not\n",
+    "silent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f1c0d535",
+   "metadata": {},
+   "source": [
+    "## 5. Limitations to know before you opt in\n",
+    "\n",
+    "1. **Cold one-shot large/degenerate QPs** — use the IPM (section 4).\n",
+    "2. **`warm_start=` is not supported** with `method=\"active-set\"`. The engine\n",
+    "   warm-starts from a *working set*, not a primal-dual point, so accepting one\n",
+    "   would be misleading. It raises rather than silently ignoring it.\n",
+    "3. **True parametric warm starting is Rust-only today.** `solve_parametric`\n",
+    "   traces the homotopy from a previous QP and its solution to a new one — the\n",
+    "   case this engine exists for (MPC steps, branch-and-bound nodes,\n",
+    "   continuation). It is not yet exposed to Python.\n",
+    "4. **A non-convex-QP problem is refused**, matching the CLI. For the active-set\n",
+    "   *SQP outer loop* on a general NLP, use `algorithm=\"active-set-sqp\"`.\n",
+    "5. Some large instances that the IPM solves will hit the time cap here\n",
+    "   (`AUG2D`, `CONT-050`, `DTOC3`, …). Pass `sqp_qp_use_homotopy=no` on the CLI\n",
+    "   to fall back to the older conventional path if that suits your workload."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6e4bd125",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-30T17:12:47.227068Z",
+     "iopub.status.busy": "2026-07-30T17:12:47.227002Z",
+     "iopub.status.idle": "2026-07-30T17:12:47.230921Z",
+     "shell.execute_reply": "2026-07-30T17:12:47.230538Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "warm_start : solve_qp: warm_start= is not supported with method='active-set'\n",
+      "non-convex : solver_selection='qp-active-set' but the problem was not detected as a convex LP/QP (convex-quad ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "# (2) warm_start is rejected, not ignored\n",
+    "warm = solve_qp(P=P, c=c, G=G, h=h, lb=lb, method='ipm')\n",
+    "try:\n",
+    "    solve_qp(P=P, c=c, G=G, h=h, lb=lb, method='active-set', warm_start=warm)\n",
+    "except ValueError as e:\n",
+    "    print('warm_start :', str(e).split('(')[0].strip())\n",
+    "\n",
+    "# (4) a non-convex-QP problem is refused rather than silently rerouted\n",
+    "try:\n",
+    "    pounce.minimize(lambda x: np.sin(x[0]) + x[1] ** 4, np.array([0.5, 0.5]),\n",
+    "                    constraints=[{'type': 'ineq',\n",
+    "                                  'fun': lambda x: np.array([1.0 - x[0]]),\n",
+    "                                  'jac': lambda x: np.array([[-1.0, 0.0]])}],\n",
+    "                    solver_selection='qp-active-set')\n",
+    "except ValueError as e:\n",
+    "    print('non-convex :', str(e)[:96], '...')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1033bda0",
+   "metadata": {},
+   "source": [
+    "## Where next\n",
+    "\n",
+    "* [`15_convex_qp.ipynb`](15_convex_qp.ipynb) — the interior-point solver in\n",
+    "  depth: duals, infeasibility and unboundedness certificates, warm starts,\n",
+    "  batches, factorization reuse.\n",
+    "* [`11_batched_warm_start.ipynb`](11_batched_warm_start.ipynb) — warm-started\n",
+    "  batches on the IPM path, which *is* exposed to Python.\n",
+    "* [`06_sqp_parametric_continuation.ipynb`](06_sqp_parametric_continuation.ipynb)\n",
+    "  — parametric continuation on the NLP side.\n",
+    "* `docs/src/lp-qp-routing.md` — how `solver_selection` resolves, and the exact\n",
+    "  contract each selector promises."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -50,6 +50,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 | # | Notebook | What it shows |
 |---|---|---|
 | 15 | [`15_convex_qp.ipynb`](15_convex_qp.ipynb) | Convex QP & LP with `pounce.qp`. |
+| 30 | [`30_active_set_qp.ipynb`](30_active_set_qp.ipynb) | The opt-in active-set engine (`method="active-set"` / `solver_selection="qp-active-set"`): reaching it from either surface, where it is ~2x faster than the IPM, and — measured — where it is much worse (71/138 vs 137/138 on Maros-Mészáros) plus the limitations to know before opting in. |
 | 16 | [`16_socp.ipynb`](16_socp.ipynb) | Second-order cone programs with `pounce.qp.solve_socp`. |
 
 ## Global optimization

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -176,8 +176,15 @@ _QP_STATUS_MESSAGE = {
 # (no `.nl` problem-structure extraction), so the split is:
 #   auto / lp-ipm / qp-ipm / socp  -- handled here by Python-side extraction
 #   nlp                            -- the default; straight to the NLP backend
-#   qp-active-set                  -- forwarded to the backend, which selects the
-#                                     active-set SQP engine
+#   qp-active-set                  -- handled here by the same Python-side
+#                                     extraction as qp-ipm, then dispatched to
+#                                     the active-set engine. This deliberately
+#                                     matches the CLI: the selector must name
+#                                     one algorithm on both surfaces. It used to
+#                                     forward to the backend and run the SQP
+#                                     outer loop, so the same string meant two
+#                                     different solvers depending on how you
+#                                     called POUNCE.
 _SOLVER_SELECTION_VALUES = frozenset(
     {"auto", "nlp", "lp-ipm", "qp-ipm", "qp-active-set", "socp"}
 )
@@ -858,7 +865,7 @@ def _build_problem_obj(
     return cls()
 
 
-def _solve_via_convex(ex, opts: dict) -> OptimizeResult:
+def _solve_via_convex(ex, opts: dict, method: str = "ipm") -> OptimizeResult:
     """Adapt a routed convex LP/QP solve back into an :class:`OptimizeResult`.
 
     The convex solver minimizes ``½xᵀPx + cᵀx`` and never sees the objective's
@@ -879,10 +886,15 @@ def _solve_via_convex(ex, opts: dict) -> OptimizeResult:
         ub=ex.ub,
         tol=opts.get("tol"),
         max_iter=opts.get("max_iter"),
+        method=method,
     )
     fun_val = float(res.obj) + ex.obj_const
     success = res.status == "optimal"
-    selector = "lp-ipm" if ex.kind == "lp" else "qp-ipm"
+    selector = (
+        "qp-active-set"
+        if method == "active-set"
+        else ("lp-ipm" if ex.kind == "lp" else "qp-ipm")
+    )
     message = _QP_STATUS_MESSAGE.get(res.status, res.status)
     return OptimizeResult(
         x=np.asarray(res.x),
@@ -1107,13 +1119,6 @@ def minimize(
             stacklevel=2,
         )
         selection = "nlp"
-    if selection == "qp-active-set":
-        # Not a Python-side route: hand it back to the backend, whose
-        # `is_sqp_algorithm_selected` treats it as equivalent to
-        # `algorithm=active-set-sqp`. Note the library path does *not*
-        # class-validate this selector (the CLI restricts it to LP/convex QP);
-        # it simply runs the SQP engine on whatever problem it is given.
-        options["solver_selection"] = "qp-active-set"
     # scipy.optimize.minimize is silent unless `disp=True`; match that. pounce's
     # NLP backend otherwise prints a full IPM iteration table by default (and
     # the log is written from Rust to fd 1, so Python stdout redirection can't
@@ -1199,7 +1204,7 @@ def minimize(
                 stacklevel=2,
             )
 
-    if selection in ("auto", "lp-ipm", "qp-ipm"):
+    if selection in ("auto", "lp-ipm", "qp-ipm", "qp-active-set"):
         extract = classify_and_extract(**route_kw)
         if selection == "lp-ipm" and (extract is None or extract.kind != "lp"):
             raise ValueError(
@@ -1211,9 +1216,24 @@ def minimize(
                 "solver_selection='qp-ipm' but the problem was not detected as "
                 "a convex LP/QP (convex-quadratic objective + linear constraints)"
             )
+        if selection == "qp-active-set" and extract is None:
+            # Matches the CLI, which refuses the selector on a non-convex-QP
+            # class rather than quietly running a different algorithm. Callers
+            # who genuinely want the SQP outer loop on an arbitrary NLP should
+            # ask for it by name.
+            raise ValueError(
+                "solver_selection='qp-active-set' but the problem was not "
+                "detected as a convex LP/QP (convex-quadratic objective + "
+                "linear constraints). For the active-set SQP outer loop on a "
+                "general NLP, pass algorithm='active-set-sqp' instead."
+            )
         if extract is not None:
             _warn_convex_dropped_opts("convex LP/QP")
-            return _solve_via_convex(extract, options)
+            return _solve_via_convex(
+                extract,
+                options,
+                method="active-set" if selection == "qp-active-set" else "ipm",
+            )
         # Auto: an LP/QP wasn't found — try a convex QCQP before giving up to
         # the NLP solver (a quadratic *constraint* lands here, not above).
         if selection == "auto":

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -549,12 +549,23 @@ def solve_qp(
     warm_start=None,
     collect_iterates: bool = False,
     check_psd: Optional[bool] = None,
+    method: str = "ipm",
 ) -> QpResult:
     """Solve one convex QP. See the module docstring for the form.
 
     ``P`` (lower triangle is used; assumed symmetric) and ``A``/``G`` may
     be scipy-sparse or dense; ``None`` matrices are empty. ``c`` is
     required and sets ``n``.
+
+    ``method`` selects the engine: ``"ipm"`` (default) is the convex
+    interior-point solver; ``"active-set"`` is the ``pounce-qp`` parametric
+    active-set engine, the same one the CLI reaches with
+    ``solver_selection=qp-active-set``. For a *cold, one-shot* convex QP the
+    IPM is materially more robust — on the 138-problem Maros-Mészáros set it
+    solves 137, against substantially fewer for a cold active-set solve, whose
+    iteration count is combinatorial in the size of the active set. Choose
+    ``"active-set"`` when you want an exact vertex, or for a *sequence* of
+    similar QPs. ``warm_start=`` is not supported with ``"active-set"``.
 
     ``warm_start`` (optional) is a previous :class:`QpResult` (or a mapping
     with ``x``/``y``/``z``/``z_lb``/``z_ub``) for a *nearby* problem. It
@@ -584,6 +595,7 @@ def solve_qp(
             max_iter=max_iter,
             warm_start=_warm_dict(warm_start),
             collect_iterates=collect_iterates,
+            method=method,
         )
     )
 

--- a/python/tests/test_minimize.py
+++ b/python/tests/test_minimize.py
@@ -1301,7 +1301,7 @@ def test_convex_route_warns_on_dropped_options(monkeypatch):
     )
 
     monkeypatch.setattr(M, "classify_and_extract", lambda **kw: _Extract())
-    monkeypatch.setattr(M, "_solve_via_convex", lambda ex, opts: sentinel)
+    monkeypatch.setattr(M, "_solve_via_convex", lambda ex, opts, **_kw: sentinel)
 
     f = lambda x: float(x @ x)
     with pytest.warns(UserWarning, match="had no effect|were ignored|acceptable_tol"):
@@ -1348,7 +1348,7 @@ def test_convex_route_warns_on_disp(monkeypatch):
     )
 
     monkeypatch.setattr(M, "classify_and_extract", lambda **kw: _Extract())
-    monkeypatch.setattr(M, "_solve_via_convex", lambda ex, opts: sentinel)
+    monkeypatch.setattr(M, "_solve_via_convex", lambda ex, opts, **_kw: sentinel)
 
     f = lambda x: float(x @ x)
     with pytest.warns(UserWarning, match="disp"):
@@ -1476,6 +1476,11 @@ def test_refused_problem_does_not_report_success():
         "made the acceptable-KKT fallback fire on a refused solve"
     )
 def test_active_set_sqp_honors_hessian_approximation():
+    # Names the SQP path explicitly. `solver_selection="qp-active-set"` used to
+    # mean "run the SQP outer loop"; it now routes a convex QP to the convex
+    # active-set driver, where `sqp_hessian` is meaningless (and correctly
+    # reported as ignored). The subject of these tests is the SQP path, so they
+    # ask for it by name.
     """An SQP solve must not demand a Hessian the caller never supplied.
 
     ``hessian_approximation=limited-memory`` is what a frontend sets when no
@@ -1500,7 +1505,7 @@ def test_active_set_sqp_honors_hessian_approximation():
     expected = np.array([2.5, 1.5])
 
     sqp = pounce.minimize(
-        fun, [0.0, 0.0], jac=jac, constraints=con, solver_selection="qp-active-set"
+        fun, [0.0, 0.0], jac=jac, constraints=con, algorithm="active-set-sqp"
     )
     assert sqp.success, f"active-set SQP failed: {sqp.message}"
     np.testing.assert_allclose(sqp.x, expected, atol=1e-6)
@@ -1516,7 +1521,7 @@ def test_active_set_sqp_honors_hessian_approximation():
             [0.0, 0.0],
             jac=jac,
             constraints=con,
-            solver_selection="qp-active-set",
+            algorithm="active-set-sqp",
             sqp_hessian=source,
         )
         assert r.success
@@ -1559,7 +1564,7 @@ def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
                 jac=jac,
                 hess=hh,
                 constraints=dict_con,
-                solver_selection="qp-active-set",
+                algorithm="active-set-sqp",
                 sqp_hessian="exact",
             )
         assert r.success, f"exact-without-hessian must not fail: {r.message}"
@@ -1581,7 +1586,7 @@ def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
             jac=jac,
             hess=hess,
             constraints=nl_con,
-            solver_selection="qp-active-set",
+            algorithm="active-set-sqp",
             sqp_hessian="exact",
         )
     assert r.success, f"exact-without-hessian (nonlinear) must not fail: {r.message}"
@@ -1597,7 +1602,7 @@ def test_active_set_sqp_exact_without_hessian_downgrades_not_internal_error():
             jac=jac,
             hess=hess,
             constraints=lc,
-            solver_selection="qp-active-set",
+            algorithm="active-set-sqp",
             sqp_hessian="exact",
         )
     assert r.success

--- a/python/tests/test_minimize_autoroute.py
+++ b/python/tests/test_minimize_autoroute.py
@@ -305,24 +305,32 @@ def test_invalid_solver_selection_raises(bad):
 
 
 def test_qp_active_set_reaches_the_sqp_engine():
-    """`qp-active-set` is a valid CLI/library selector and must actually
-    dispatch, not be swallowed.
+    """`qp-active-set` must dispatch to the **convex active-set driver**, the
+    same engine the CLI reaches with `solver_selection=qp-active-set`.
 
-    Before the fix it was indistinguishable from a bogus value: both fell
-    through to the filter-IPM. The backend treats it as equivalent to
-    `algorithm=active-set-sqp`, so pinning it against that spelling proves the
-    option reached the Rust side rather than merely being accepted by Python.
+    It originally fell through to the filter-IPM, indistinguishable from a bogus
+    value. The first fix forwarded it to the backend, which ran the *SQP outer
+    loop* — so the same selector named two different algorithms depending on
+    whether you called the CLI or `minimize`. It now takes the same Python-side
+    convex extraction as `qp-ipm` and dispatches to the active-set engine, so
+    the two surfaces agree.
+
+    The tell is `nfev`: the convex route consumes the extracted quadratic form
+    and never calls back into Python, so a routed solve reports zero function
+    evaluations, while both the NLP and SQP paths report many.
     """
     fun, jac, con = _qp_problem()
     kw = dict(jac=jac, constraints=con)
 
     sel = minimize(fun, np.zeros(2), options={"solver_selection": "qp-active-set"}, **kw)
-    algo = minimize(fun, np.zeros(2), options={"algorithm": "active-set-sqp"}, **kw)
+    ipm = minimize(fun, np.zeros(2), options={"solver_selection": "qp-ipm"}, **kw)
     nlp = minimize(fun, np.zeros(2), options={"solver_selection": "nlp"}, **kw)
 
-    assert sel.nit == algo.nit, "qp-active-set must select the same engine as algorithm=active-set-sqp"
-    assert np.allclose(sel.x, algo.x)
-    assert sel.nit != nlp.nit, "qp-active-set must be distinguishable from the NLP path"
+    assert sel.nfev == 0, "qp-active-set must route to the convex driver, not a callback path"
+    assert nlp.nfev > 0, "the NLP path must be distinguishable by callback count"
+    # Same problem, same optimum, whichever convex engine ran.
+    assert np.allclose(sel.x, ipm.x, atol=1e-6)
+    assert sel.success
     assert np.allclose(sel.x, nlp.x, atol=1e-6), "both engines must still solve it"
 
 


### PR DESCRIPTION
## Summary

`solver_selection=qp-active-set` reached the active-set engine the long way
round: the CLI rewrote it to `algorithm=active-set-sqp` and ran the **full SQP
outer loop** over a QP. That is not wrong — with an exact Hessian and
already-linear constraints the first subproblem *is* the original QP — but it
forfeited the convex path's presolve, scaling, timing and status vocabulary to
pay for machinery a QP has no use for.

This routes it through the convex driver instead, implements the parametric
homotopy the crate is named for, and fixes the defects that surfaced along the
way. On the 138-problem Maros-Meszaros set the active-set column moves
**46/138 -> 71/138**, with **zero solved-but-wrong** throughout.

`auto` still routes cold convex QPs to the interior-point solver (137/138).
The active-set engine remains opt-in.

## Defects fixed

Each has a reproducer and a regression test.

1. **`solve_parametric` was a stub** that discarded both prior arguments and
   cold-solved, while the crate advertised "true parametric warm starting". The
   §4.2 homotopy is now implemented (`pounce-qp/src/homotopy.rs`) for both the
   cold and warm cases.
2. **l1-elastic phase-1 does not terminate** on degenerate netlib-derived QPs —
   `QAFIRO` (n=32) ran past 500,000 iterations with Bland's rule forced. The
   homotopy removes phase-1 from the design: the iterate is feasible for the
   `t`-problem at every point on the path.
3. **A singular Schur block aborted the whole solve.** In SMW updating that is a
   normal event; `reset` existed but fired only on the update *count*.
4. **The Schur path silently lost ~1.5e-6 of accuracy** as updates accumulated.
   Fixed with iterative refinement. (3) and (4) were reachable by anyone setting
   `use_schur_updates`, and the README's claim that the path was "verified by
   Schur-vs-refactor cross-checks" was untrue — no such test existed.
5. **No rank detection on the Schur path** for LICQ-violating active sets, so 27
   problems became hard `LinearSolverFailure`s. `solve_general` had carried that
   guard for a long time; the asymmetry was invisible while Schur was opt-in.
6. **The elastic repair discarded better iterates.** Symptom: a *larger*
   `max_iter` gave a *worse* objective — `QADLITTL` returned 500918 at 100
   iterations and 8.07 at 2000.
7. **Null-iteration loop in `solve_general`** — 3650 of `CVXQP3_S`'s 3750
   iterations were literal no-ops.
8. **The simplex phase-1 Bland latch was permanent**, turning an anti-cycling
   escape into a pricing strategy: infeasibility sat at 3.25e0 for 40,000
   iterations on `QSCTAP1`.
9. **`solver_selection="qp-active-set"` named two different algorithms** — the
   convex driver on the CLI, the SQP outer loop in `minimize`. Now one algorithm
   on both surfaces, with `solve_qp(method="ipm"|"active-set")` exposing the
   engine to Python for the first time.
10. **Statuses lied**: an inner-QP iteration-limit hit surfaced as
    `Search_Direction_Becomes_Too_Small`, and the SQP path never populated
    `total_wallclock_time_secs` (always `0.0`).
11. **All seven `sqp_qp_*` options became silent no-ops** when the dispatch moved.
12. **An infeasible model was reported as a solver crash** — `qp-active-set`
    exited `InternalError` / `solve_result_num=500` on an LP with
    `x0 + x1 <= 1` and `x0 + x1 >= 3`, where every other engine said `200`. The
    engine had it right (`Infeasible`); the driver could not *check* the claim,
    so it demoted correct ones along with the false `DUALC1` kind. Fixes #415.
13. **The convex IPM reported some infeasible models as unbounded** —
    `DivergingIterates` / `300` on 8 of 200 infeasible-by-construction models,
    against HiGHS and against pounce's own active-set engine. Found by the
    sweep written to check (12).

## Certifying infeasibility (items 12 and 13)

Both defects put an infeasible model in the wrong AMPL family, and callers
branch on the family: `200` means "fix the model", `300` means "diverging",
`500` means "the solver broke, retry".

**Why the textbook Farkas test could not verify the active-set claim.** It wants
`A'y + G'z = 0`. These multipliers come from an l1-elastic phase-1 that
minimizes the *original objective plus* a violation penalty, so stationarity
leaves `A'y + G'z = -(Px + c)` — a residual that never vanishes, only shrinks
relative to `||(y,z)|| ~ gamma`. On the reported LP that is `1e-6` relative
against a `1e-10` gate: a real certificate, read as noise.

**What replaced it.** For any feasible `x`, `q'x <= b'y + h'z` with
`q := A'y + G'z`; a feasible `x` is also in the box, so
`q'x >= L := sum_i min(q_i*lb_i, q_i*ub_i)`. Hence `L > b'y + h'z` proves the
feasible set empty. That generalizes Farkas — with no finite bounds it collapses
back to it — and on a boxed problem accounts for the residual *exactly* rather
than tolerating it. With no box to work with, one further solve on the
objective-free twin (`P = 0, c = 0`) returns a residual-free certificate.

**Item 13 is not a broken certificate.** A recession direction with
`Pd ~ 0, Ad ~ 0, -Gd in K, c'd < 0` certifies the *dual* infeasible, and stays
valid on an empty primal — so a model can honestly earn both verdicts, and these
did. Which one got reported was decided by whichever residual gate cleared
first. Deciding that inside the iteration means picking a tolerance: tried, and
a rule loose enough to catch this case also suppressed **11 of 200 genuine
unbounded verdicts**, trading one wrong answer for more missing ones. So it is
decided outside — on a `DualInfeasible` verdict the driver re-solves the
objective-free twin, which shares the feasible set and cannot be unbounded. An
infeasible twin corrects the verdict; anything else leaves it alone. One extra
solve, only on `DualInfeasible`, and no recursion (`c = 0` admits no `c'd < 0`).

**Measured.**

| | before | after |
|---|---|---|
| 200 infeasible-by-construction, `qp-active-set` | ~0 certified | **200** |
| 200 infeasible-by-construction, `qp-ipm` | 192 | **200** |
| 200 feasible-and-unbounded, `qp-ipm` | 197 `dual_infeasible` / 3 `iteration_limit` | **197 / 3 — unchanged** |
| 200 feasible-by-construction | no false verdict | no false verdict |

Soundness is the property that matters: a false infeasibility verdict is a wrong
statement about the user's model, worse than any failure status. Every step is
an inequality that holds at *every* feasible point, and the negative cases are
tested directly — a QP whose feasible set is the single point `{0}` (every row
active, no interior, the #282 geometry) must never acquire the verdict, and a
minimizing-corner slip in the box bound has its own test.

## Safety property

No configuration tested returns a successful status on a wrong objective. Three
classes of wrong verdict were found and closed: a silently wrong `Optimal`
(`QSC205`), an uncertified `Infeasible` on a feasible problem (`DUALC1`), and an
unverified `Unbounded` on a bounded one (`QSCSD1`). Every claimed optimum is
re-verified against the original problem's KKT conditions before being reported.

## Measurements

Full Maros-Meszaros, 138 problems, 120 s cap, same binary:

| path | correct | solved-but-wrong | timeouts |
|---|---|---|---|
| baseline (SQP route, before this PR) | 46/138 | none | 14 |
| convex driver, conventional phase-1/2 | 58/138 | none | 54 |
| convex driver, homotopy (**default**) | **71/138** | none | 49 |
| interior-point (`auto` picks this) | 137/138 | none | — |

The homotopy default is **not** a uniform win: 20 problems gained, 7 lost. Six
losses are large instances that previously solved and now hit the time cap
(`AUG2D`, `AUG2DC`, `CONT-050`, `CONT-100`, `DTOC3`, `STADAT3`) — slower, not
wrong. `sqp_qp_use_homotopy=no` restores the old path.

## Behaviour changes worth a changelog note

* `minimize(solver_selection="qp-active-set")` on a non-convex-QP problem now
  raises `ValueError` pointing at `algorithm="active-set-sqp"`, instead of
  silently running the SQP outer loop.
* `warm_start=` is rejected with `method="active-set"` rather than ignored.

## Docs

Corrected four inaccurate claims (two in `pounce-qp/README.md`, one stale
in-code EXPAND comment, and the CLI/Python equivalence in `python.md`), and
added `python/notebooks/30_active_set_qp.ipynb` — how to run it, where it is
~2x faster than the IPM, where it is much worse, and the limitations to know
before opting in.

## Known limitations, deliberately left

All on the opt-in path; none reachable by default.

* The homotopy has no anti-cycling for *coincident* events beyond a rank-repair
  tabu — no bound-flipping ratio test, no tau-perturbation in parameter space.
  Added only what a reproducible failure demanded.
* `solve_parametric` does not interpolate `H`; a changed Hessian falls back to a
  cold solve. Correct, not warm.
* Homotopy-driven elastic phase-1 (design note §4.3) is not implemented. It
  would have no measurable effect on this benchmark, which contains no
  infeasible instances.
* `QSHARE2B` completes its path and then exhausts the corrector's iterations.
* The 7-problem regression class above suggests a follow-up worth measuring:
  falling back to the conventional path on a time/iteration budget would
  plausibly keep the 20 gains without the 6 timeout losses. Not attempted —
  that is a policy change needing its own benchmark.

## Test plan

* `cargo test --release --workspace` — 2293 pass
* `cd python && python -m pytest tests -q` — 802 pass
* New: `pounce-qp/tests/homotopy.rs` (5), `pounce-qp/tests/schur_vs_refactor.rs`
  (4, including the LICQ case on both inner paths), `pounce-convex`
  translation/dual-sign tests (5), CLI option-forwarding test, updated
  `qp-active-set` contract tests.
* `python/notebooks/30_active_set_qp.ipynb` executed against this build; all
  outputs saved, no cell errors.
* For (12)/(13): `pounce-convex/tests/issue415_infeasible_status.rs` (6 — boxed,
  free, half-boxed, with-Hessian, equality-block, plus the feasible-set-`{0}`
  negative case), four certificate unit tests in `active_set.rs`, and two in
  `infeasibility.rs`. The IPM regression pins the 4-variable instance the sweep
  found: hand-made contradictory-row LPs converge to `PrimalInfeasible` on their
  own and do **not** reproduce the race. Both new regressions verified failing
  without their fix.
* CLI end-to-end on the reported `.nl` and a free-variable variant: all six
  `solver_selection` values agree at `InfeasibleProblemDetected` / `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4

