### PR TITLE
Reject false Optimal on variable-scale-spread convex QPs (#414)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,50 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the convex QP IPM certified `Optimal` at a non-KKT point when the *variables* spanned many decades (#414)
+
+- **`solve_qp(method="ipm")` returned `status="optimal"`, `success=True`,
+  objective `67.13` — with `kkt_error = 8282.5` on the very same result
+  object**, against a true optimum of `-3.9585018079`. Through the CLI the same
+  engine reported `SolveSucceeded` / `solve_result_num=0` / exit `0`, so the
+  AMPL, Pyomo, and GAMS drivers all accepted the wrong point as a solution.
+  `solver_selection=socp` and `auto` route to the same engine and inherited it.
+  pounce's own `qp-active-set` and `nlp` engines, clarabel, and scipy
+  `trust-constr` all solve the identical model correctly.
+- **The instance is not hard — it is badly *stated*.** Variables scaled
+  `10^-6‥10^6` give `cond(P) ~ 1e24`, but one diagonal rescaling `z = x/s`
+  takes it to `cond = 10`. The failure threshold tracked exactly that spread:
+  correct at `±3` decades, wrong from `±4` up.
+- **Root cause: the convergence test was measured in a metric that does not
+  bound the error.** HSDE certifies on *scale-relative* residuals once the
+  problem's natural scale puts absolute `tol` accuracy below the
+  finite-precision floor. Those normalizers are **global** ∞-norms, so once the
+  variable scales spread, the worst-scaled column dominates `‖Px̂‖` and dividing
+  every component's residual by it hands a blanket relaxation to the components
+  where the real violation lives. `±3` decades stays under the gate that opens
+  the relative arm, which is why it was correct.
+- **The check now runs in the Ruiz-equilibrated metric**, where every variable
+  and row carries an `O(1)` scale and no column can mask another. The reported
+  point reads `1.2e2` there and the true optimum of the same problem `2.9e-10`
+  — against `2e-4` for *both* in the unscaled metric, which is why the existing
+  #324 relative re-check could not see it. A rejected `Optimal` is repaired by
+  an equilibrated re-solve, the same repair #293 already applies to a
+  *non-converged* HSDE solve; on the reported instance it returns the oracle's
+  `-3.958501808`.
+- **Never a false success.** If the re-solve cannot certify a genuine optimum
+  either, the verdict is *demoted*, not upgraded — `OptimalInaccurate` would
+  still report `ok` / exit `0` through the CLI, which a relative residual of
+  `1e-3` or worse is not.
+- **Complementarity is normalized by the objective, not the gradient.** Its
+  terms `ŝᵢẑᵢ` are the duality gap's and survive the diagonal congruence
+  unchanged while the gradient scale does not, so normalizing it by a gradient
+  scale Ruiz has pulled to `O(1)` rejects the genuine #286 huge-magnitude
+  optima. Measured: the #414 false optima land in `2e-2‥1.2e2`, their repaired
+  counterparts in `1e-12‥1e-9`, and the #286 solves — the genuine optima most
+  at risk of being rejected here — at `4e-10` and `1.5e-8`.
+- Costs nothing on a solve that reaches absolute `tol` accuracy, which
+  short-circuits before any of this runs.
+
 ### Fixed — the convex IPM reported some infeasible models as unbounded
 
 - **Found while fixing #415**, by the randomized sweep written to check that

--- a/crates/pounce-convex/src/equilibrate.rs
+++ b/crates/pounce-convex/src/equilibrate.rs
@@ -296,6 +296,42 @@ impl Scaling {
         }
     }
 
+    /// Map a *solution* given in the **original** problem's coordinates into
+    /// the scaled problem's coordinates — the exact inverse of
+    /// [`Scaling::unscale_solution`]'s primal/dual maps (the same algebra
+    /// [`Scaling::scale_warm_start`] applies to a warm-start point):
+    ///
+    /// ```text
+    ///   x̂ = Dc⁻¹ x,   ŷ = σ y / R_A,        ẑ = σ z / R_G,
+    ///   ẑ_lb = σ·Dc·z_lb,                    ẑ_ub = σ·Dc·z_ub.
+    /// ```
+    ///
+    /// Used to *measure* a solution in the equilibrated metric — its KKT
+    /// residual against the scaled problem, where every variable and row
+    /// carries an `O(1)` scale, so no single badly-scaled column can mask
+    /// another's violation (gh #414, see `crate::ipm::equilibrated_kkt_rel`).
+    /// `obj` and the iterate trace are left as-is; the caller reads residuals
+    /// only.
+    pub(crate) fn scale_solution(&self, sol: &QpSolution) -> QpSolution {
+        let mut s = sol.clone();
+        for (xi, &d) in s.x.iter_mut().zip(&self.dcol) {
+            *xi /= d;
+        }
+        for (yi, &d) in s.y.iter_mut().zip(&self.drow_a) {
+            *yi *= self.sigma / d;
+        }
+        for (zi, &d) in s.z.iter_mut().zip(&self.drow_g) {
+            *zi *= self.sigma / d;
+        }
+        for (zi, &d) in s.z_lb.iter_mut().zip(&self.dcol) {
+            *zi *= self.sigma * d;
+        }
+        for (zi, &d) in s.z_ub.iter_mut().zip(&self.dcol) {
+            *zi *= self.sigma * d;
+        }
+        s
+    }
+
     /// Map a warm-start point given in the **original** problem's coordinates
     /// into the scaled problem's coordinates — the exact inverse of
     /// [`Scaling::unscale_solution`]'s primal/dual maps:

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -329,6 +329,11 @@ where
             return retry;
         }
     }
+    // gh #414: the mirror image of the retry above — an HSDE solve that believes
+    // it converged but did not. See [`verify_or_repair_optimum`]. Touches only
+    // an `Optimal` verdict, so it composes with (and cannot disturb) the
+    // certificate handling below.
+    let sol = verify_or_repair_optimum(prob, opts, sol, &mut make_backend);
     // gh #293 (extreme tail): refute a *spurious* unboundedness certificate on a
     // QP with genuine curvature. A `DualInfeasible` verdict rests on finding a
     // recession ray whose normalized curvature `dᵀPd/‖d‖²` is below
@@ -431,6 +436,168 @@ where
     let mut sol = solve_qp_ipm_unscaled(&scaled, &inner, make_backend);
     scaling.unscale_solution(prob, &mut sol);
     sol
+}
+
+/// The relative-KKT cut separating a genuine optimum from a scaling artifact,
+/// shared by [`equilibrated_kkt_rel`] (gh #414) and
+/// [`normalized_optimum_is_genuine`] (gh #324).
+///
+/// Measured on the #414 family, the false optima land in `2e-2‥1.2e2` and the
+/// repaired optima of the very same problems in `1e-12‥1e-9`; the #286
+/// huge-magnitude solves — genuine optima that only the *relative* arm can
+/// certify, the regime most at risk of being rejected here — sit at `4e-10` and
+/// `1.5e-8`. The cut therefore has better than an order of margin above every
+/// genuine solve and four below every observed failure.
+const FALSE_OPTIMUM_REL_TOL: f64 = 1e-3;
+
+/// `sol`'s KKT residual relative to the scale of its own terms, measured **in
+/// the Ruiz-equilibrated metric** — the scale-invariant answer to "is this
+/// actually a KKT point of `prob`?".
+///
+/// Each residual is normalized by the natural magnitude of its own terms, the
+/// same shape as HSDE's in-loop relative test (`crate::hsde`): stationarity by
+/// the gradient scale `‖P̂x̂‖ ∨ ‖ĉ‖ ∨ ‖Ĝᵀẑ‖ ∨ ‖Âᵀŷ‖ ∨ ‖ẑ_lb‖ ∨ ‖ẑ_ub‖`, primal
+/// by the rhs scale, and complementarity by the **objective** magnitude (its
+/// terms `ŝᵢẑᵢ` are the duality gap's, and the gap's scale is the objective's,
+/// not the gradient's — normalizing complementarity by a gradient scale that
+/// Ruiz has pulled down to `O(1)` while `ŝᵀẑ` stays invariant would reject the
+/// #286 huge-magnitude optima).
+///
+/// What makes it work where the *unscaled* relative test
+/// ([`normalized_optimum_is_genuine`]) does not is the metric, not the formula.
+/// Normalizing by a *global* ∞-norm in the original coordinates is blind to a
+/// spread in the **variable** scales: one badly-scaled column makes `‖Px‖∞`
+/// enormous, and dividing every component's residual by it grants a blanket
+/// relaxation to the well-scaled components, where the real violation lives. On
+/// the #414 family — `x_i ~ 1e-6‥1e6`, `cond(P) ~ 1e24`, trivially
+/// well-conditioned after `z = x/s` — the returned point's unscaled relative
+/// residual reads `2e-4`, inside any sane cut, while its true error is `O(1e3)`.
+/// Ruiz equilibration is exactly the diagonal change of variables that removes
+/// that spread, so in the scaled problem every variable and every row carries an
+/// `O(1)` scale and no column can mask another: measured there, the same point
+/// reads `1.2e2` against `2.9e-10` for the true optimum.
+///
+/// Orthant/box only: Ruiz is a per-row scaling, which is unsound for a
+/// non-orthant cone (see [`crate::equilibrate`]), so callers must gate on the
+/// cones being nonnegative.
+fn equilibrated_kkt_rel(prob: &QpProblem, sol: &QpSolution) -> f64 {
+    let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
+    let ssol = scaling.scale_solution(sol);
+    let res = ssol.kkt_residuals(&scaled);
+    let mut px = vec![0.0; scaled.n];
+    scaled.p_mul(&ssol.x, &mut px);
+    let mut gtz = vec![0.0; scaled.n];
+    scaled.gt_mul(&ssol.z, &mut gtz);
+    let mut aty = vec![0.0; scaled.n];
+    scaled.at_mul(&ssol.y, &mut aty);
+    let mut gx = vec![0.0; scaled.m_ineq()];
+    scaled.g_mul(&ssol.x, &mut gx);
+    let mut ax = vec![0.0; scaled.m_eq()];
+    scaled.a_mul(&ssol.x, &mut ax);
+    let gscale = inf_norm(&px)
+        .max(inf_norm(&scaled.c))
+        .max(inf_norm(&gtz))
+        .max(inf_norm(&aty))
+        .max(inf_norm(&ssol.z_lb))
+        .max(inf_norm(&ssol.z_ub))
+        .max(1.0);
+    let pscale = inf_norm(&scaled.b)
+        .max(inf_norm(&scaled.h))
+        .max(inf_norm(&gx))
+        .max(inf_norm(&ax))
+        .max(1.0);
+    // The objective of the *scaled* problem, not `sol.obj`. Every other
+    // quantity here is measured in the equilibrated metric, and for a pure LP
+    // the equilibration carries a cost scaling σ = 1/max|ĉ| that multiplies
+    // `ĉ`, `ẑ` and hence both the dual residual and `ŝᵀẑ`. Dividing a
+    // σ-scaled complementarity by an unscaled objective would leave the ratio
+    // off by σ — up to `1e8` either way, a false accept on a large-cost LP and
+    // a false *reject* on a tiny-cost one. Recomputing here keeps numerator
+    // and denominator in one metric, and `σ` cancels exactly. (A QP keeps
+    // σ = 1, so this is a no-op there.)
+    let cscale = ssol
+        .x
+        .iter()
+        .zip(&px)
+        .zip(&scaled.c)
+        .map(|((&xi, &pxi), &ci)| 0.5 * xi * pxi + ci * xi)
+        .sum::<f64>()
+        .abs()
+        .max(1.0);
+    (res.dual_infeasibility / gscale)
+        .max(res.primal_infeasibility / pscale)
+        .max(res.complementarity / cscale)
+}
+
+/// Whether an `Optimal` verdict is backed by a point that really is one.
+///
+/// Short-circuits on the *absolute* KKT residual: a point already accurate to
+/// `tol` in the original coordinates is unimpeachable, needs no metric
+/// argument, and pays nothing for this check — which is every well- and
+/// moderately-scaled solve. Only a solve that reached `Optimal` through HSDE's
+/// scale-*relative* convergence arm (`crate::hsde::relative_stop_permitted`,
+/// the arm that opens once absolute `tol` accuracy is below the
+/// finite-precision floor) is measured in the equilibrated metric.
+fn optimum_is_genuine(prob: &QpProblem, sol: &QpSolution, tol: f64) -> bool {
+    sol.kkt_residuals(prob).kkt_error() <= tol
+        || equilibrated_kkt_rel(prob, sol) <= FALSE_OPTIMUM_REL_TOL
+}
+
+/// Re-check an HSDE `Optimal` and, when it is a scaling artifact, repair or
+/// demote it — never let a false success out (gh #414).
+///
+/// HSDE certifies convergence on *scale-relative* residuals once the problem's
+/// natural scale puts absolute `tol` accuracy below the finite-precision floor
+/// (`hsde::relative_stop_permitted`). Those normalizers are global ∞-norms, so
+/// on a QP whose **variables** span many decades they are dominated by the
+/// worst-scaled column and the test stops bounding the error in every other
+/// direction: the embedding reports `Optimal` at a point whose own
+/// `kkt_error` is `8.3e3` and whose objective is `67.13` against a true
+/// `-3.96`. Downstream this is a success everywhere — `success=True` from
+/// `solve_qp`, `SolveSucceeded` / `solve_result_num=0` / exit 0 from the
+/// AMPL/Pyomo/GAMS drivers — so the wrong point is consumed as an answer.
+///
+/// The instance is not hard: it is well-conditioned after a diagonal rescaling,
+/// which is precisely what Ruiz equilibration finds. So when the verdict fails
+/// [`optimum_is_genuine`], re-solve equilibrated — the same repair gh #293
+/// already applies to a *non*-converged HSDE solve, extended to the case where
+/// the driver wrongly believes it converged. On the reported instance that
+/// retry returns the oracle's `-3.958501808`.
+///
+/// If the retry cannot certify a genuine optimum either, the original verdict
+/// is demoted to [`QpStatus::NumericalFailure`] rather than upgraded: the
+/// solver has no certified answer, and saying so is the floor this function
+/// guarantees. `OptimalInaccurate` would be the wrong demotion — it means
+/// "usable at reduced accuracy" and still reports `ok` / exit 0 through the CLI,
+/// which a relative residual of `1e-3` or worse is not.
+///
+/// A no-op unless the solve is HSDE-with-equilibration-allowed and ended
+/// `Optimal`; the direct driver already runs *inside* the equilibrated metric
+/// (its absolute test is applied to the Ruiz-scaled problem), so it cannot
+/// reach this failure.
+fn verify_or_repair_optimum<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    sol: QpSolution,
+    make_backend: &mut F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    if !(opts.use_hsde && opts.equilibrate)
+        || sol.status != QpStatus::Optimal
+        || optimum_is_genuine(prob, &sol, opts.tol)
+    {
+        return sol;
+    }
+    let retry = equilibrated_solve(prob, opts, /* use_hsde */ true, make_backend);
+    if retry.status == QpStatus::Optimal && optimum_is_genuine(prob, &retry, opts.tol) {
+        return retry;
+    }
+    QpSolution {
+        status: QpStatus::NumericalFailure,
+        ..sol
+    }
 }
 
 /// The bounds-aware orthant solve without equilibration (the historical
@@ -680,7 +847,19 @@ where
         }
         return sol;
     }
-    solve_socp_symmetric(prob, cones, opts, make_backend)
+    let mut make_backend = make_backend;
+    let sol = solve_socp_symmetric(prob, cones, opts, &mut make_backend);
+    // gh #414: a cone program whose cones are *all* nonnegative is an LP/QP
+    // wearing the conic entry point's clothes (`solver_selection=socp` on a
+    // box-constrained QP lands here), and it inherits the same false `Optimal`
+    // under a variable-scale spread. Ruiz equilibration — which the repair
+    // rests on — is a per-row scaling and stays sound exactly on the orthant,
+    // so the check is gated on that and every genuine cone program is
+    // untouched. See [`verify_or_repair_optimum`].
+    if cones.iter().all(|c| matches!(c, ConeSpec::Nonneg(_))) {
+        return verify_or_repair_optimum(prob, opts, sol, &mut make_backend);
+    }
+    sol
 }
 
 /// Debug-enabled [`solve_socp_ipm`]: fires the interactive [`DebugHook`] at
@@ -3282,5 +3461,177 @@ mod non_finite_guard_tests {
             assert_eq!(demote_unusable(keep, &bad, f64::NAN), keep);
             assert_eq!(demote_unusable(keep, &good, 1.0), keep);
         }
+    }
+}
+
+#[cfg(test)]
+mod false_optimum_metric_tests {
+    //! gh #414: the measurement the false-optimum repair rests on, and the
+    //! floor it guarantees when the repair cannot succeed.
+
+    use super::{
+        FALSE_OPTIMUM_REL_TOL, QpOptions, SparseSymLinearSolverInterface, equilibrated_kkt_rel,
+        normalized_optimum_is_genuine, optimum_is_genuine, solve_qp_ipm_unscaled,
+        verify_or_repair_optimum,
+    };
+    use crate::qp::{QpProblem, QpStatus, Triplet};
+    use pounce_feral::FeralSolverInterface;
+
+    fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+        Box::new(FeralSolverInterface::new())
+    }
+
+    /// The reported instance: a strictly convex box- and inequality-constrained
+    /// QP stated in variables scaled `10^-6‥10^6` (`cond(P) ~ 1e24`, `cond = 10`
+    /// after `z = x/s`). True optimum `-3.9585018079`.
+    fn illscaled_qp() -> QpProblem {
+        QpProblem {
+            n: 3,
+            p_lower: vec![
+                Triplet::new(0, 0, 8395050448209.196),
+                Triplet::new(1, 0, -1902145.0448367258),
+                Triplet::new(1, 1, 3.251598903330246),
+                Triplet::new(2, 0, 2.8600351667480353),
+                Triplet::new(2, 1, 1.1387032854093064e-07),
+                Triplet::new(2, 2, 2.5156283086289338e-12),
+            ],
+            c: vec![
+                -2410857.501637979,
+                -0.47196110542608866,
+                1.9297552321865365e-06,
+            ],
+            a: vec![],
+            b: vec![],
+            g: vec![
+                Triplet::new(0, 0, -1363466.266639565),
+                Triplet::new(0, 1, -0.34926083632221316),
+                Triplet::new(0, 2, -3.621387263107342e-07),
+            ],
+            h: vec![2.455293068675696],
+            lb: vec![
+                -1.1096628522428714e-05,
+                -10.254262623099589,
+                -9953548.897040607,
+            ],
+            ub: vec![8.903371477571285e-06, 9.745737376900411, 10046451.102959393],
+        }
+    }
+
+    /// Why the metric had to change, stated as a measurement rather than an
+    /// argument: on the *same point*, the unscaled relative test (gh #324) sees
+    /// nothing wrong and the equilibrated one sees an `O(100)` violation.
+    ///
+    /// This is the load-bearing claim of the fix. If a future change to the
+    /// normalizers makes the unscaled test able to catch this on its own, this
+    /// test fails loudly rather than leaving the extra machinery unexplained.
+    #[test]
+    fn the_false_optimum_is_invisible_unscaled_and_obvious_equilibrated() {
+        let prob = illscaled_qp();
+        let opts = QpOptions::default();
+        // The un-repaired HSDE solve: exactly what `solve_qp_ipm` used to return.
+        let bad = solve_qp_ipm_unscaled(&prob, &opts, backend);
+        assert_eq!(
+            bad.status,
+            QpStatus::Optimal,
+            "premise: the embedding certifies this point"
+        );
+        let abs = bad.kkt_residuals(&prob).kkt_error();
+        assert!(
+            abs > 1e3,
+            "premise: the certified point's own KKT error is huge (got {abs:.3e}, \
+             the issue reports 8.3e3)"
+        );
+
+        // The gh #324 test normalizes by *global* ∞-norms in the original
+        // coordinates, where the badly-scaled column inflates ‖Px‖ enough to
+        // hide the violation — it passes this point.
+        assert!(
+            normalized_optimum_is_genuine(&prob, &bad),
+            "premise: the unscaled relative test cannot see this failure"
+        );
+
+        // Measured in the equilibrated metric the same point is plainly not a
+        // KKT point, by orders of magnitude either side of the cut.
+        let rel = equilibrated_kkt_rel(&prob, &bad);
+        assert!(
+            rel > 1.0,
+            "equilibrated relative KKT should be O(1) or worse, got {rel:.3e}"
+        );
+        assert!(!optimum_is_genuine(&prob, &bad, opts.tol));
+
+        // And the repaired solve — the same problem, the real optimum — sits far
+        // below the cut, so the two are separated with room to spare.
+        let good = super::solve_qp_ipm(&prob, &opts, backend);
+        assert_eq!(good.status, QpStatus::Optimal);
+        let good_rel = equilibrated_kkt_rel(&prob, &good);
+        assert!(
+            good_rel < 1e-6,
+            "the true optimum must be far inside the cut, got {good_rel:.3e}"
+        );
+        assert!(
+            good_rel < FALSE_OPTIMUM_REL_TOL / 100.0 && rel > FALSE_OPTIMUM_REL_TOL * 100.0,
+            "cut {FALSE_OPTIMUM_REL_TOL:.0e} must sit with margin between \
+             {good_rel:.3e} and {rel:.3e}"
+        );
+    }
+
+    /// The floor: when the equilibrated re-solve cannot certify an optimum
+    /// either, the verdict is demoted — never handed back as a success.
+    ///
+    /// Forced deterministically by capping the retry at a single iteration, so
+    /// the repair provably cannot converge. What must survive is the guarantee,
+    /// not the repair: no `Optimal`, and no `OptimalInaccurate` either, since
+    /// that still reports `ok` / exit 0 through the CLI.
+    #[test]
+    fn an_unrepairable_false_optimum_is_demoted_never_reported_optimal() {
+        let prob = illscaled_qp();
+        let bad = solve_qp_ipm_unscaled(&prob, &QpOptions::default(), backend);
+        assert_eq!(bad.status, QpStatus::Optimal, "premise");
+
+        let starved = QpOptions {
+            max_iter: 1,
+            ..QpOptions::default()
+        };
+        let mut mb = backend;
+        let out = verify_or_repair_optimum(&prob, &starved, bad, &mut mb);
+        assert_eq!(
+            out.status,
+            QpStatus::NumericalFailure,
+            "an uncertifiable point must not keep a success status (got {:?})",
+            out.status
+        );
+    }
+
+    /// The check must not tax a solve that is simply correct: a well-scaled QP
+    /// reaches absolute `tol` accuracy, short-circuits before any equilibration,
+    /// and is returned untouched.
+    #[test]
+    fn a_well_scaled_optimum_short_circuits_without_equilibrating() {
+        // min ½‖x‖² − xᵀ[1,2]  s.t.  −5 ≤ x ≤ 5 — optimum x* = [1, 2].
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+            c: vec![-1.0, -2.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![-5.0, -5.0],
+            ub: vec![5.0, 5.0],
+        };
+        let opts = QpOptions::default();
+        let sol = solve_qp_ipm_unscaled(&prob, &opts, backend);
+        assert_eq!(sol.status, QpStatus::Optimal);
+        assert!(
+            sol.kkt_residuals(&prob).kkt_error() <= opts.tol,
+            "premise: this solve is absolutely tol-accurate"
+        );
+        assert!(optimum_is_genuine(&prob, &sol, opts.tol));
+
+        let x = sol.x.clone();
+        let mut mb = backend;
+        let out = verify_or_repair_optimum(&prob, &opts, sol, &mut mb);
+        assert_eq!(out.status, QpStatus::Optimal);
+        assert_eq!(out.x, x, "a genuine optimum must be returned unchanged");
     }
 }

--- a/crates/pounce-convex/tests/issue414_varscale_false_optimal.rs
+++ b/crates/pounce-convex/tests/issue414_varscale_false_optimal.rs
@@ -1,0 +1,356 @@
+//! Regression for gh #414: a convex QP whose **variables** span many decades
+//! must not be reported `Optimal` at a point that is not a KKT point.
+//!
+//! Construction (the adversary's): pick variable scales `s_i ∈ [10⁻ᵈ, 10ᵈ]` and
+//! state a well-conditioned QP in `z = x/s`, then write it in `x`. The result
+//! is a strictly convex box- and inequality-constrained QP with `cond(P) ~ 1e24`
+//! at `d = 6` — and yet trivially easy, since one diagonal rescaling (`cond = 10`)
+//! recovers the well-conditioned twin. pounce's own active-set engine, its NLP
+//! engine, clarabel, and scipy `trust-constr` all agree on the optimum.
+//!
+//! Root cause: HSDE certifies convergence on *scale-relative* residuals once the
+//! problem's natural scale puts absolute `tol` accuracy below the
+//! finite-precision floor (`hsde::relative_stop_permitted`). Those normalizers
+//! are **global** ∞-norms, so once the variable scales spread, the worst-scaled
+//! column dominates `‖Px̂‖` and dividing every component's residual by it grants
+//! a blanket relaxation to the components where the real violation lives. At
+//! `d = 3` the absolute test still governs and the solve is correct; from
+//! `d = 4` up the relative arm opens and the embedding stopped at a point whose
+//! own `kkt_error` was `8.3e3`, objective `67.13` against a true `-3.96` — under
+//! `status = Optimal`, i.e. `success=True` / `SolveSucceeded` / exit 0.
+//!
+//! The fix measures a claimed optimum in the Ruiz-**equilibrated** metric, where
+//! no column can mask another (the bad point reads `6.9e2` there and the true
+//! optimum `2.2e-10`, against `2e-4` for both in the unscaled metric), and
+//! repairs it with an equilibrated re-solve — the same repair gh #293 already
+//! applies to a non-converged HSDE solve.
+//!
+//! The oracle is clarabel on the identical problem stated in `z = x/s`, agreeing
+//! with pounce's active-set engine to 10 digits.
+
+use pounce_convex::{
+    ConeSpec, QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm, solve_socp_ipm,
+};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
+    let mut px = vec![0.0; prob.n];
+    prob.p_mul_add_pub(x, &mut px);
+    (0..prob.n)
+        .map(|i| 0.5 * x[i] * px[i] + prob.c[i] * x[i])
+        .sum()
+}
+
+/// `n = 3`, scales `10^±3`: *below* the threshold where HSDE's relative
+/// convergence arm opens. Already correct before the fix — pinned so the fix
+/// cannot regress the regime it does not target.
+fn n3_dec3() -> QpProblem {
+    QpProblem {
+        n: 3,
+        p_lower: vec![
+            Triplet::new(0, 0, 8395050.448209196),
+            Triplet::new(1, 0, -1902.145044836726),
+            Triplet::new(1, 1, 3.251598903330246),
+            Triplet::new(2, 0, 2.8600351667480353),
+            Triplet::new(2, 1, 0.00011387032854093065),
+            Triplet::new(2, 2, 2.5156283086289337e-06),
+        ],
+        c: vec![
+            -2410.8575016379787,
+            -0.47196110542608866,
+            0.0019297552321865365,
+        ],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, -1363.466266639565),
+            Triplet::new(0, 1, -0.34926083632221316),
+            Triplet::new(0, 2, -0.00036213872631073423),
+        ],
+        h: vec![2.4552930686756964],
+        lb: vec![
+            -0.011096628522428714,
+            -10.254262623099589,
+            -9953.548897040608,
+        ],
+        ub: vec![0.008903371477571287, 9.745737376900411, 10046.451102959392],
+    }
+}
+
+/// `n = 3`, scales `10^±4`: the first decade at which the defect appeared.
+fn n3_dec4() -> QpProblem {
+    QpProblem {
+        n: 3,
+        p_lower: vec![
+            Triplet::new(0, 0, 839505044.8209198),
+            Triplet::new(1, 0, -19021.450448367257),
+            Triplet::new(1, 1, 3.251598903330246),
+            Triplet::new(2, 0, 2.8600351667480357),
+            Triplet::new(2, 1, 1.1387032854093064e-05),
+            Triplet::new(2, 2, 2.5156283086289342e-08),
+        ],
+        c: vec![
+            -24108.575016379786,
+            -0.47196110542608866,
+            0.00019297552321865367,
+        ],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, -13634.662666395649),
+            Triplet::new(0, 1, -0.34926083632221316),
+            Triplet::new(0, 2, -3.6213872631073426e-05),
+        ],
+        h: vec![2.455293068675696],
+        lb: vec![
+            -0.0011096628522428713,
+            -10.254262623099589,
+            -99535.48897040608,
+        ],
+        ub: vec![0.0008903371477571286, 9.745737376900411, 100464.51102959392],
+    }
+}
+
+/// The instance reported in gh #414: `n = 3`, scales `10^±6`, `cond(P) ~ 1e24`.
+/// `solve_qp` returned `status=optimal, success=True, obj=67.13411102` with
+/// `kkt_error=8282.49679691473` on the very same result object.
+fn n3_dec6() -> QpProblem {
+    QpProblem {
+        n: 3,
+        p_lower: vec![
+            Triplet::new(0, 0, 8395050448209.196),
+            Triplet::new(1, 0, -1902145.0448367258),
+            Triplet::new(1, 1, 3.251598903330246),
+            Triplet::new(2, 0, 2.8600351667480353),
+            Triplet::new(2, 1, 1.1387032854093064e-07),
+            Triplet::new(2, 2, 2.5156283086289338e-12),
+        ],
+        c: vec![
+            -2410857.501637979,
+            -0.47196110542608866,
+            1.9297552321865365e-06,
+        ],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, -1363466.266639565),
+            Triplet::new(0, 1, -0.34926083632221316),
+            Triplet::new(0, 2, -3.621387263107342e-07),
+        ],
+        h: vec![2.455293068675696],
+        lb: vec![
+            -1.1096628522428714e-05,
+            -10.254262623099589,
+            -9953548.897040607,
+        ],
+        ub: vec![8.903371477571285e-06, 9.745737376900411, 10046451.102959393],
+    }
+}
+
+/// `n = 4`, scales `10^±4` — a denser Hessian and a differently-oriented
+/// inequality, so the failure is not an artifact of one sparsity pattern.
+fn n4_dec4() -> QpProblem {
+    QpProblem {
+        n: 4,
+        p_lower: vec![
+            Triplet::new(0, 0, 402865426.6568016),
+            Triplet::new(1, 0, -135775.05946876763),
+            Triplet::new(1, 1, 1913.5369545367312),
+            Triplet::new(2, 0, 354.22953694689227),
+            Triplet::new(2, 1, 0.6929769838082036),
+            Triplet::new(2, 2, 0.0063346701154133956),
+            Triplet::new(3, 0, -3.264478040673124),
+            Triplet::new(3, 1, -0.0017689547554672362),
+            Triplet::new(3, 2, -1.2619277561696707e-05),
+            Triplet::new(3, 3, 6.704485454332412e-08),
+        ],
+        c: vec![
+            -2542.6262309958797,
+            1.0007586760595901,
+            0.00042322029453420934,
+            -2.4182384602113466e-05,
+        ],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 14796.737397512617),
+            Triplet::new(0, 1, 18.04148227139861),
+            Triplet::new(0, 2, 0.03236962077437109),
+            Triplet::new(0, 3, -7.267931986554799e-05),
+        ],
+        h: vec![-2.8460530841924774],
+        lb: vec![
+            -0.0011202255925231168,
+            -0.46765189691097764,
+            -224.92520875544545,
+            -84085.25914629847,
+        ],
+        ub: vec![
+            0.0008797744074768833,
+            0.46066586981157787,
+            205.961729250931,
+            115914.74085370153,
+        ],
+    }
+}
+
+/// `n = 6`, scales `10^±6` — the widest spread in the report.
+fn n6_dec6() -> QpProblem {
+    QpProblem {
+        n: 6,
+        p_lower: vec![
+            Triplet::new(0, 0, 4856251966963.262),
+            Triplet::new(1, 0, 5613717544.627589),
+            Triplet::new(1, 1, 29052429.43414988),
+            Triplet::new(2, 0, -21372575.653614767),
+            Triplet::new(2, 1, -20195.486710036217),
+            Triplet::new(2, 2, 797.6268702598865),
+            Triplet::new(3, 0, 125181.59528943096),
+            Triplet::new(3, 1, 177.96448164812205),
+            Triplet::new(3, 2, -1.0904525675371035),
+            Triplet::new(3, 3, 0.01615930198769556),
+            Triplet::new(4, 0, 155.4188314072008),
+            Triplet::new(4, 1, 0.7848493607162925),
+            Triplet::new(4, 2, -0.006937841395298172),
+            Triplet::new(4, 3, 1.311288537574924e-05),
+            Triplet::new(4, 4, 2.767140072085592e-07),
+            Triplet::new(5, 0, 0.7657035769063948),
+            Triplet::new(5, 1, 0.0036104087965541133),
+            Triplet::new(5, 2, 9.872670170359158e-07),
+            Triplet::new(5, 3, 4.727104589430104e-08),
+            Triplet::new(5, 4, 5.668405227071561e-10),
+            Triplet::new(5, 5, 7.078024066540731e-12),
+        ],
+        c: vec![
+            1328619.0859474859,
+            938.6271165901893,
+            8.328718243103483,
+            0.010608966961930871,
+            -5.6871835063293957e-05,
+            -6.53528505743659e-07,
+        ],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 526075.14322749),
+            Triplet::new(0, 1, -160.73512951962238),
+            Triplet::new(0, 2, -7.344017827017593),
+            Triplet::new(0, 3, 0.006739359670159433),
+            Triplet::new(0, 4, 0.00025973058904486254),
+            Triplet::new(0, 5, -6.047724374034646e-07),
+        ],
+        h: vec![1.406699584001822],
+        lb: vec![
+            -1.0991735677298826e-05,
+            -0.002458925393251575,
+            -0.5317893358898369,
+            -152.71878271324712,
+            -31449.428840612563,
+            -9341661.687928105,
+        ],
+        ub: vec![
+            9.008264322701172e-06,
+            0.002564847469767584,
+            0.7301253530705492,
+            164.2598557789751,
+            48172.00527008682,
+            10658338.312071895,
+        ],
+    }
+}
+
+/// The family, with the clarabel-on-`z = x/s` oracle optimum of each.
+fn family() -> Vec<(&'static str, QpProblem, f64)> {
+    vec![
+        ("n=3 10^±3", n3_dec3(), -3.958501807911171),
+        ("n=3 10^±4", n3_dec4(), -3.958501807911169),
+        ("n=3 10^±6", n3_dec6(), -3.9585018079111713),
+        ("n=4 10^±4", n4_dec4(), 3.830698737611161),
+        ("n=6 10^±6", n6_dec6(), -0.43521733351107683),
+    ]
+}
+
+/// The headline guarantee: **no false success**. An `Optimal`/`OptimalInaccurate`
+/// verdict — everything the drivers report as a solved model — must come with a
+/// point that actually optimizes the problem.
+///
+/// Deliberately phrased as an implication rather than "must solve": a solver is
+/// allowed to fail on a hard instance and say so. What it may not do is hand
+/// back `obj = 67.13` for a `-3.96` problem under `success=True`.
+#[test]
+fn issue_414_reported_optimal_is_never_a_non_kkt_point() {
+    for (label, prob, oracle) in family() {
+        let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        if !matches!(sol.status, QpStatus::Optimal | QpStatus::OptimalInaccurate) {
+            continue;
+        }
+        let obj = objective(&prob, &sol.x);
+        let rel = (obj - oracle).abs() / oracle.abs().max(1.0);
+        assert!(
+            rel < 1e-6,
+            "{label}: {:?} at objective {obj} — oracle {oracle} (rel {rel:.2e}), \
+             kkt_error {:.3e}",
+            sol.status,
+            sol.kkt_residuals(&prob).kkt_error(),
+        );
+    }
+}
+
+/// The repair itself: every instance in the family is solvable, and the default
+/// IPM must in fact solve it — the equilibrated re-solve recovers the optimum
+/// rather than merely refusing to claim the bad point.
+#[test]
+fn issue_414_variable_scale_spread_still_reaches_the_optimum() {
+    for (label, prob, oracle) in family() {
+        let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert_eq!(sol.status, QpStatus::Optimal, "{label}: {:?}", sol.status);
+        let obj = objective(&prob, &sol.x);
+        let rel = (obj - oracle).abs() / oracle.abs().max(1.0);
+        assert!(
+            rel < 1e-6,
+            "{label}: objective {obj} vs oracle {oracle} (rel {rel:.2e})"
+        );
+        // Feasibility is not implied by the objective matching: check the box
+        // and the inequality row directly.
+        for i in 0..prob.n {
+            let slack = (sol.x[i] - prob.lb[i]).min(prob.ub[i] - sol.x[i]);
+            let span = prob.ub[i] - prob.lb[i];
+            assert!(
+                slack > -1e-6 * span.max(1.0),
+                "{label}: x[{i}] = {} outside [{}, {}]",
+                sol.x[i],
+                prob.lb[i],
+                prob.ub[i]
+            );
+        }
+    }
+}
+
+/// `solver_selection=socp` routes a box-constrained QP through the conic entry
+/// point, which reaches the same embedding and inherited the same false
+/// `Optimal`. With every cone nonnegative the problem *is* the LP/QP case, so
+/// the repair applies there too.
+#[test]
+fn issue_414_socp_entry_point_on_an_orthant_problem_agrees() {
+    for (label, prob, oracle) in family() {
+        let cones = [ConeSpec::Nonneg(prob.m_ineq())];
+        let sol = solve_socp_ipm(&prob, &cones, &QpOptions::default(), backend);
+        assert_eq!(
+            sol.status,
+            QpStatus::Optimal,
+            "{label} (socp): {:?}",
+            sol.status
+        );
+        let obj = objective(&prob, &sol.x);
+        let rel = (obj - oracle).abs() / oracle.abs().max(1.0);
+        assert!(
+            rel < 1e-6,
+            "{label} (socp): objective {obj} vs oracle {oracle} (rel {rel:.2e})"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #414

## The report

`pounce.solve_qp(method="ipm")` returned `status="optimal"`, `success=True`, objective `67.13` — with `kkt_error = 8282.5` on the very same result object — against a true optimum of `-3.9585018079`. Through the CLI the same engine reported `SolveSucceeded` / `solve_result_num=0` / exit `0`, so the AMPL, Pyomo, and GAMS drivers all accepted the wrong point as a solution. `solver_selection=socp` and `auto` route to the same engine and inherited it.

The instance is not hard, it is badly *stated*: variables scaled `10^-6..10^6` give `cond(P) ~ 1e24`, but one diagonal rescaling `z = x/s` takes it to `cond = 10`. pounce's own `qp-active-set` and `nlp` engines, clarabel, and scipy `trust-constr` all solve it correctly.

## Root cause

HSDE certifies convergence on **scale-relative** residuals once the problem's natural scale puts absolute `tol` accuracy below the finite-precision floor. Those normalizers are *global* infinity-norms, so once the variable scales spread, the worst-scaled column dominates `||Px||` and dividing every component's residual by it hands a blanket relaxation to the components where the real violation lives.

That mechanism predicts the threshold in the issue's table exactly: correct at ±3 decades (still under the gate that opens the relative arm), wrong from ±4 up.

## Fix

Re-check a claimed `Optimal` in the Ruiz-**equilibrated** metric, where every variable and row carries an `O(1)` scale and no column can mask another:

| point | unscaled relative KKT | equilibrated relative KKT |
|---|---|---|
| the returned (bad) point | `2e-4` | `1.2e2` |
| the true optimum | `2e-4` | `2.9e-10` |

That is why the existing #324 relative re-check could not see this — the metric, not the formula. A rejected `Optimal` is repaired by an equilibrated re-solve, the same repair #293 already applies to a *non-converged* HSDE solve; on the reported instance it returns the oracle's `-3.958501808`.

**Never a false success.** If the re-solve cannot certify a genuine optimum either, the verdict is *demoted*, not upgraded. `OptimalInaccurate` would be the wrong demotion — it still reports `ok` / exit `0` through the CLI, which a relative residual of `1e-3` or worse is not.

Applied at both entry points, so `solver_selection=socp` on an all-orthant problem is covered too.

## Two subtleties worth review

1. **Complementarity is normalized by the objective, not the gradient.** Its terms `s_i*z_i` are the duality gap's and survive the diagonal congruence unchanged, while the gradient scale does not. Normalizing it by a gradient scale that Ruiz has pulled to `O(1)` rejects the genuine #286 huge-magnitude optima — caught as a real regression while developing this.
2. **The objective is taken from the *scaled* problem.** Ruiz applies a cost scaling `sigma = 1/max|c|` to a **pure LP**, which multiplies both the dual residual and `s'z`. Dividing a sigma-scaled complementarity by an unscaled objective would leave the ratio off by up to `1e8` — a false *reject* on a small-cost LP. Recomputing in one metric makes sigma cancel exactly. (No-op for QPs, where `sigma = 1`.)

## Threshold margin

The `1e-3` cut, measured:

- #414 false optima: `2e-2 .. 1.2e2`
- their repaired counterparts: `1e-12 .. 1e-9`
- #286 huge-magnitude solves (genuine optima that *only* the relative arm can certify — the regime most at risk of being wrongly rejected here): `4e-10` and `1.5e-8`

Costs nothing on a solve that reaches absolute `tol` accuracy, which short-circuits before any equilibration runs.

## Tests

New: 3 integration tests over a 5-instance family (±3 through ±6 decades, `n = 3/4/6`) against clarabel oracles computed on the rescaled twin, plus 3 unit tests — one pinning the load-bearing claim (the unscaled test passes the bad point, the equilibrated one rejects it, so a future normalizer change cannot silently make this machinery redundant), one forcing the demotion path via a starved retry, one checking a well-scaled solve short-circuits untouched.

| suite | result |
|---|---|
| `pounce-convex` | 319 passed |
| `pounce-cli` | 343 passed |
| Python | 802 passed |
| workspace | 1639 passed / 112 targets |
| fmt + clippy | clean, zero warnings in new code |

One unrelated flake seen in the workspace run: `pounce-observability::collector_scope_feeds_manual_guard`. That crate has no dependency on `pounce-convex` and the test passes 3/3 in isolation — process-global tracing-subscriber state under parallel load. Not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
