### PR TITLE
Take the step the model asks for on an indefinite QP (#416)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,56 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — the active-set QP crawled instead of stepping on an indefinite Hessian (#416)
+
+- **`algorithm = active-set-sqp` with `sqp_hessian = exact` now solves plain
+  Rosenbrock at the default QP budget.** The reported case — extended
+  Rosenbrock in a ball, `n = 10`, from the canonical `(−1.2, 1, …)` start —
+  gave up after 4 outer iterations with
+  `Search_Direction_Becomes_Too_Small`/`Maximum_Iterations_Exceeded` at
+  `f = 9.62214`, `KKT = 2.62`, against `f = 3.9866` from the interior-point
+  path. It now converges to `f = 3.9866` in 20 outer iterations, and does so
+  ~2.5× faster than the documented `sqp_qp_max_iter = 250` workaround.
+- **The budget was never the problem.** The tell in the report was that the
+  smallest cap that worked was 250 whether `n` was 10 or 40, and that the QP
+  made **zero** working-set changes while spending 200 iterations. Both follow
+  from a single line: after §4.5 inertia control factors `H + δI`, the inner
+  loop still capped its step at `α = 1`. The unit step is the model minimizer
+  only for an *unshifted* Newton direction — writing `r = Hx + g`, the shifted
+  system gives `pᵀr = −(pᵀHp + δ‖p‖²)`, so the model's own minimizer along `p`
+  is `α* = 1 + δ‖p‖²/pᵀHp`, and `+∞` when the true curvature along `p` is
+  non-positive. Capping at 1 turns the loop into proximal-point iteration with
+  parameter δ, whose per-eigenvalue contraction is `δ/(λ + δ)`. Since δ is
+  reached by multiplying `QpOptions::inertia_shift_initial` (1e-8) by
+  `inertia_shift_factor` (100) until the system is PD, it overshoots the
+  spectrum badly: on the reported QP `λ_min = −1.4` and δ = 100, putting
+  every factor within 3 % of 1. The trace shows it exactly — δ = 100,
+  `‖p‖∞ ≈ 2e−3`, `α = 1`, `pᵀHp < 0`, empty working set, 200 times over. The
+  crawl is dimension-independent because δ and the spectrum are, which is why
+  raising the cap looked like it fixed something.
+- **The fix is to take the step the model asks for.** The ratio test is now
+  capped at `α*` instead of at 1, so a negative-curvature direction runs to
+  its blocking bound and *changes the working set* — what an active-set method
+  is supposed to do with negative curvature (Nocedal-Wright §16.5). `δ = 0`
+  returns 1.0 without touching the data, so every non-shifted solve is
+  bit-identical. Applied on all four inner loops (box, equality-plus-bounds,
+  general, and the Schur-update variant, which now tracks the δ in its cached
+  base factor).
+- **A negative-curvature direction with nothing to block it is unboundedness**,
+  and is now reported as such — the F2 recession certificate with `pᵀHp < 0`
+  in place of `Hp = 0`. Two fixtures that the SQP path previously ran out of
+  iterations on, `unbounded_exp.nl` (`min −exp(x)`) and `unbounded_cubic.nl`,
+  now exit `Diverging_Iterates`, agreeing with the IPM path. The SQP driver
+  still re-verifies the ray against the true NLP before reporting it.
+- **Also fixed, found by the above:** l1-elastic phase-1 labelled its result
+  `Optimal` whenever the slacks reached zero, even when the phase-1 solve had
+  hit its own iteration limit on the way. Past the point where the slacks
+  vanish the augmented objective *is* the original one, so an unconverged
+  phase-1 leaves an ordinary suboptimal iterate — `afiro` with
+  `sqp_qp_max_iter = 3` returned `Optimal` carrying a KKT error of 10 at
+  objective 440 against a −464.75 optimum. The inner verdict is now carried
+  out; the point is still returned, just not dressed up.
+
 ### Fixed — the convex IPM reported some infeasible models as unbounded
 
 - **Found while fixing #415**, by the randomized sweep written to check that

--- a/crates/pounce-algorithm/src/sqp/tests.rs
+++ b/crates/pounce-algorithm/src/sqp/tests.rs
@@ -1094,3 +1094,176 @@ fn issue_349_hs6_converges() {
         );
     }
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Issue #416 fixture — extended Rosenbrock inside a ball.
+//
+//     min Σᵢ 100(xᵢ₊₁ − xᵢ²)² + (1 − xᵢ)²
+//     s.t. ‖x‖² ≤ 10 (optional),  −5 ≤ x ≤ 5
+//
+// From the canonical `(−1.2, 1, −1.2, 1, …)` start, with
+// `sqp_hessian = exact`, ∇²L turns indefinite a few iterations in. The
+// step QP then hits §4.5 inertia control, and before the `model_step_cap`
+// fix each of its "full" steps was a δ-sized crawl: the subproblem spent
+// its entire 200-iteration budget making ZERO working-set changes and
+// exited `MaxIter`, which the outer loop reported as `QpIterationLimit`
+// after 4 iterations at f = 9.62 (against 3.99 from the interior-point
+// path). The tell was that the smallest budget that converged was 250
+// whether n was 10 or 40 — a fixed-count crawl, not active-set work.
+// ─────────────────────────────────────────────────────────────────
+struct RosenbrockBallNlp {
+    n: usize,
+    /// Include the `‖x‖² ≤ 10` row. The failure reproduces identically
+    /// with and without it (issue #416: "constraints are not involved"),
+    /// and the two shapes take different paths through the QP dispatcher
+    /// — general-inequality vs. pure-box — so both are exercised.
+    ball: bool,
+}
+
+impl SqpProblemSpec for RosenbrockBallNlp {
+    fn n(&self) -> usize {
+        self.n
+    }
+    fn m(&self) -> usize {
+        usize::from(self.ball)
+    }
+    fn x_init(&self) -> Vec<Number> {
+        (0..self.n)
+            .map(|i| if i % 2 == 0 { -1.2 } else { 1.0 })
+            .collect()
+    }
+    fn variable_bounds(&self) -> (Vec<Number>, Vec<Number>) {
+        (vec![-5.0; self.n], vec![5.0; self.n])
+    }
+    fn constraint_bounds(&self) -> (Vec<Number>, Vec<Number>) {
+        if self.ball {
+            (vec![NLP_LOWER_BOUND_INF], vec![10.0])
+        } else {
+            (Vec::new(), Vec::new())
+        }
+    }
+    fn eval_f(&mut self, x: &[Number]) -> Number {
+        (0..self.n - 1)
+            .map(|i| {
+                let a = x[i + 1] - x[i] * x[i];
+                let b = 1.0 - x[i];
+                100.0 * a * a + b * b
+            })
+            .sum()
+    }
+    fn eval_grad_f(&mut self, x: &[Number]) -> Vec<Number> {
+        let mut g = vec![0.0; self.n];
+        for i in 0..self.n - 1 {
+            let a = x[i + 1] - x[i] * x[i];
+            g[i] += -400.0 * x[i] * a - 2.0 * (1.0 - x[i]);
+            g[i + 1] += 200.0 * a;
+        }
+        g
+    }
+    fn eval_c(&mut self, x: &[Number]) -> Vec<Number> {
+        if self.ball {
+            vec![x.iter().map(|v| v * v).sum()]
+        } else {
+            Vec::new()
+        }
+    }
+    fn eval_jac_c(&mut self, x: &[Number]) -> Triplet {
+        if self.ball {
+            Triplet {
+                n_rows: 1,
+                n_cols: self.n,
+                irow: vec![1; self.n],
+                jcol: (1..=self.n as Index).collect(),
+                vals: x.iter().map(|v| 2.0 * v).collect(),
+            }
+        } else {
+            Triplet {
+                n_rows: 0,
+                n_cols: self.n,
+                irow: Vec::new(),
+                jcol: Vec::new(),
+                vals: Vec::new(),
+            }
+        }
+    }
+    fn eval_hess_lag(&mut self, x: &[Number], lambda_g: &[Number]) -> Triplet {
+        let n = self.n;
+        // ∇²f: tridiagonal. ∇²c = 2I when the ball row is present.
+        let mut diag = vec![0.0; n];
+        let mut sub = vec![0.0; n - 1];
+        for i in 0..n - 1 {
+            let a = x[i + 1] - x[i] * x[i];
+            diag[i] += -400.0 * a + 800.0 * x[i] * x[i] + 2.0;
+            diag[i + 1] += 200.0;
+            sub[i] = -400.0 * x[i];
+        }
+        if self.ball {
+            for d in diag.iter_mut() {
+                *d += 2.0 * lambda_g[0];
+            }
+        }
+        let mut irow: Vec<Index> = (1..=n as Index).collect();
+        let mut jcol: Vec<Index> = (1..=n as Index).collect();
+        let mut vals = diag;
+        for (i, &s) in sub.iter().enumerate() {
+            irow.push(i as Index + 2);
+            jcol.push(i as Index + 1);
+            vals.push(s);
+        }
+        Triplet {
+            n_rows: n,
+            n_cols: n,
+            irow,
+            jcol,
+            vals,
+        }
+    }
+}
+
+/// The issue's own repro: `n = 10`, exact Hessian, **default** QP budget.
+/// Pre-fix this exits `QpIterationLimit` after 4 outer iterations; the
+/// documented workaround was `sqp_qp_max_iter = 250`, which is why the
+/// budget is left at its default here — raising it would hide the bug.
+/// Both globalizations and both problem shapes are checked, and `n = 20`
+/// bounds-only pins the dimension-independence: a budget that genuinely
+/// ran out would need more room as `n` grows, and this one did not.
+#[test]
+fn issue_416_indefinite_rosenbrock_converges_at_the_default_qp_budget() {
+    for (n, ball) in [(10, true), (10, false), (20, false)] {
+        for glob in [SqpGlobalization::Filter, SqpGlobalization::L1Elastic] {
+            let qp_solver =
+                ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+            let opts = SqpOptions {
+                hessian: SqpHessianSource::Exact,
+                globalization: glob,
+                ..SqpOptions::default()
+            };
+            let mut alg = SqpAlgorithm::new(qp_solver, opts);
+            let mut nlp = RosenbrockBallNlp { n, ball };
+            let res = alg.optimize(&mut nlp).unwrap();
+
+            assert_eq!(
+                res.status,
+                SqpStatus::Optimal,
+                "n={n} ball={ball} glob={glob:?}: {:?} after {} iters (f={:.6}, \
+                 stationarity={:.2e})",
+                res.status,
+                res.n_iter,
+                res.obj,
+                res.final_stationarity,
+            );
+            // The stall parked at f = 9.62 with a KKT error of 2.6; the
+            // interior-point path reaches 3.9866 on the same problem and start.
+            assert!(
+                res.obj < 4.1,
+                "n={n} ball={ball} glob={glob:?}: f={:.6} — the local minimum here is 3.9866",
+                res.obj,
+            );
+            assert!(
+                res.final_stationarity <= 1e-4,
+                "n={n} ball={ball} glob={glob:?}: stationarity {:.2e}",
+                res.final_stationarity,
+            );
+        }
+    }
+}

--- a/crates/pounce-qp/src/schur.rs
+++ b/crates/pounce-qp/src/schur.rs
@@ -102,6 +102,14 @@ pub struct SchurState {
     /// is no way to detect that the SMW correction has drifted, and drift is
     /// exactly this path's failure mode (see the refinement note on `solve`).
     base_kkt: Option<KktTriplet>,
+
+    /// The §4.5 inertia shift δ carried by that factor (0.0 when the
+    /// unshifted KKT factored cleanly). Rank-2 updates never touch the
+    /// H block, so this stays valid until the next reset. Callers need
+    /// it to know whether the direction they just solved for is the
+    /// true Newton step or a shifted one — see
+    /// [`crate::solver::model_step_cap`].
+    shift: Number,
 }
 
 /// One half of a rank-2 update vector pair.
@@ -126,7 +134,13 @@ impl SchurState {
             s_matrix: Vec::new(),
             s_dim: 0,
             base_kkt: None,
+            shift: 0.0,
         }
+    }
+
+    /// The §4.5 inertia shift δ in the currently cached factor.
+    pub fn shift(&self) -> Number {
+        self.shift
     }
 
     /// Active flag for slot `s` derived from the user-facing
@@ -282,6 +296,7 @@ impl SchurState {
                 self.s_matrix.clear();
                 self.s_dim = 0;
                 self.base_kkt = Some(kkt.clone());
+                self.shift = 0.0;
                 return Ok(());
             }
             Err(ref e) if e.is_recoverable_factorization_failure() => {
@@ -303,6 +318,7 @@ impl SchurState {
                     self.s_matrix.clear();
                     self.s_dim = 0;
                     self.base_kkt = Some(kkt.clone());
+                    self.shift = current;
                     return Ok(());
                 }
                 Err(ref e) if e.is_recoverable_factorization_failure() => {

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -297,7 +297,7 @@ impl ParametricActiveSetSolver {
             // rank E_W (always full rank since selection rows pick
             // distinct columns) and PD reduced H. Inertia-control
             // retry handles indefinite reduced H via §4.5.
-            self.factorize_with_inertia_control(kkt, &mut rhs, k as i32, qp.n, opts)?;
+            let delta = self.factorize_with_inertia_control(kkt, &mut rhs, k as i32, qp.n, opts)?;
             n_refactor += 1;
 
             // ---- 3. Check ‖p‖ ----
@@ -356,7 +356,9 @@ impl ParametricActiveSetSolver {
             // alias the step buffer later.
             let p: Vec<Number> = rhs[..n].to_vec();
 
-            let mut alpha = 1.0_f64;
+            // §4.5 companion (gh #416): a δ-shifted direction is not
+            // minimized by the unit step — see `model_step_cap`.
+            let mut alpha = model_step_cap(qp.h, qp.g, &hx, &p, delta);
             let mut blocker: Option<(usize, BoundStatus)> = None;
             for i in 0..n {
                 if working.bounds[i].is_active() {
@@ -376,6 +378,28 @@ impl ParametricActiveSetSolver {
                         blocker = Some((i, BoundStatus::AtUpper));
                     }
                 }
+            }
+
+            if !alpha.is_finite() {
+                // The model falls forever along `p` and no bound blocks:
+                // a certified recession ray (same F2 certificate as
+                // `solve_general`, with `pᵀHp < 0` in place of `Hp = 0`).
+                return Ok(QpSolution {
+                    obj: Number::NEG_INFINITY,
+                    x,
+                    lambda_g: Vec::new(),
+                    lambda_x: vec![0.0; n],
+                    working,
+                    status: QpStatus::Unbounded,
+                    stats: QpStats {
+                        n_working_set_changes: n_changes,
+                        n_refactor,
+                        n_schur_updates: 0,
+                        used_phase1: false,
+                        time: started.elapsed(),
+                    },
+                    unbounded_ray: Some(p),
+                });
             }
 
             if alpha < 0.0 {
@@ -523,7 +547,8 @@ impl ParametricActiveSetSolver {
             }
             // rhs[n..n+m] and rhs[n+m..n+m+k] stay zero.
 
-            self.factorize_with_inertia_control(kkt, &mut rhs, (m + k) as i32, qp.n, opts)?;
+            let delta =
+                self.factorize_with_inertia_control(kkt, &mut rhs, (m + k) as i32, qp.n, opts)?;
             n_refactor += 1;
 
             let p_inf = rhs[..n].iter().map(|pi| pi.abs()).fold(0.0, f64::max);
@@ -577,7 +602,9 @@ impl ParametricActiveSetSolver {
 
             // Ratio test along p.
             let p: Vec<Number> = rhs[..n].to_vec();
-            let mut alpha = 1.0_f64;
+            // §4.5 companion (gh #416): a δ-shifted direction is not
+            // minimized by the unit step — see `model_step_cap`.
+            let mut alpha = model_step_cap(qp.h, qp.g, &hx, &p, delta);
             let mut blocker: Option<(usize, BoundStatus)> = None;
             for i in 0..n {
                 if working.bounds[i].is_active() {
@@ -597,6 +624,26 @@ impl ParametricActiveSetSolver {
                         blocker = Some((i, BoundStatus::AtUpper));
                     }
                 }
+            }
+            if !alpha.is_finite() {
+                // Nonpositive curvature along `p` with no blocking bound:
+                // certified recession ray (see `solve_box_constrained`).
+                return Ok(QpSolution {
+                    obj: Number::NEG_INFINITY,
+                    x,
+                    lambda_g: vec![0.0; m],
+                    lambda_x: vec![0.0; n],
+                    working,
+                    status: QpStatus::Unbounded,
+                    stats: QpStats {
+                        n_working_set_changes: n_changes,
+                        n_refactor,
+                        n_schur_updates: 0,
+                        used_phase1: false,
+                        time: started.elapsed(),
+                    },
+                    unbounded_ray: Some(p),
+                });
             }
             if alpha < 0.0 {
                 alpha = 0.0;
@@ -1171,7 +1218,13 @@ impl ParametricActiveSetSolver {
             // above: a pruned dependent row enters `candidates` only once
             // its rate along `p` leaves the linear-dependence drift band.)
 
-            let (mut alpha, blocker) = select_blocker(&candidates, opts, expand_tol, force_bland);
+            // §4.5 companion: a δ-shifted direction is not minimized by
+            // the unit step (see `model_step_cap`), so let the ratio test
+            // run out to the model's own minimizer along `p`.
+            let alpha_cap = model_step_cap(qp.h, qp.g, &hx, &p, delta);
+
+            let (mut alpha, blocker) =
+                select_blocker(&candidates, opts, expand_tol, force_bland, alpha_cap);
 
             // F2(a): certified unboundedness on the active-set path. An
             // empty candidate list means NO inactive row or bound blocks
@@ -1183,7 +1236,17 @@ impl ParametricActiveSetSolver {
             // active null space); a PD reduced Hessian gives a finite
             // Newton step and never trips here. Without this the loop
             // takes unbounded full steps until `MaxIter` (δ discarded).
-            if candidates.is_empty() && delta > 0.0 && ray_is_unbounded_descent(qp.h, qp.g, &x, &p)
+            //
+            // F2(b) is the negative-curvature sibling: `alpha_cap` is
+            // infinite exactly when the model falls forever along `p`, and
+            // `select_blocker` only returns it when nothing blocks — the
+            // same recession-ray certificate with `pᵀHp < 0` in place of
+            // `Hp = 0`. `ray_is_unbounded_descent` cannot see that case (it
+            // demands zero curvature, correctly, since it also serves the
+            // PSD paths), so it is checked separately below.
+            if candidates.is_empty()
+                && delta > 0.0
+                && (!alpha.is_finite() || ray_is_unbounded_descent(qp.h, qp.g, &x, &p))
             {
                 let ray = p.clone();
                 return Ok(QpSolution {
@@ -1206,6 +1269,13 @@ impl ParametricActiveSetSolver {
 
             if alpha < 0.0 {
                 alpha = 0.0;
+            }
+            if !alpha.is_finite() {
+                // Unreachable in principle: an infinite `alpha_cap` survives
+                // `select_blocker` only with an empty candidate list, which
+                // the F2 return above consumes. Clamp rather than propagate a
+                // non-finite iterate if a NaN ratio ever gets here.
+                alpha = 1.0;
             }
 
             // A genuine step changes the iterate, so the null space of the
@@ -1485,8 +1555,18 @@ impl ParametricActiveSetSolver {
         let feasible = reform.is_feasible(&sol_aug.x, opts.feas_tol);
         if feasible {
             // Elastic drove every slack to zero ⇒ the recovered `x` is
-            // feasible for the original QP and (barring a non-converged
-            // phase-1) optimal. Preserve the historical fast path.
+            // feasible for the original QP, and optimal for it iff the
+            // phase-1 solve *converged*: past the point where the slacks
+            // vanish the augmented objective is the original one plus a
+            // zero penalty, so an unconverged phase-1 leaves an ordinary
+            // feasible-but-suboptimal iterate. That caveat used to be a
+            // parenthetical in this comment while the code labelled the
+            // point `Optimal` regardless — a claim contradicted by the
+            // returned KKT residual (afiro, `sqp_qp_max_iter=3`: phase-1
+            // exits `MaxIter` slack-feasible at objective 440 against a
+            // −464.75 optimum, and the driver reported `Optimal` with a
+            // KKT error of 10). Carry the inner verdict instead; the point
+            // is still returned, just not dressed up.
             let obj = quad_objective(qp, &x);
             return Ok(QpSolution {
                 x,
@@ -1494,7 +1574,11 @@ impl ParametricActiveSetSolver {
                 lambda_x,
                 working,
                 obj,
-                status: QpStatus::Optimal,
+                status: if sol_aug.status == QpStatus::Optimal {
+                    QpStatus::Optimal
+                } else {
+                    QpStatus::MaxIter
+                },
                 stats: QpStats {
                     n_working_set_changes: sol_aug.stats.n_working_set_changes,
                     n_refactor: sol_aug.stats.n_refactor,
@@ -2117,19 +2201,28 @@ impl ParametricActiveSetSolver {
                     candidates.push((BlockerTarget::Cons(i, ConsStatus::AtUpper), r, ap[i].abs()));
                 }
             }
-            let (mut alpha, blocker) = select_blocker(&candidates, opts, expand_tol, false);
+            // §4.5 companion (gh #416): a δ-shifted direction is not
+            // minimized by the unit step — see `model_step_cap`. The shift
+            // lives in the cached base factor here rather than in a local,
+            // and rank-2 updates never touch the H block, so `schur.shift()`
+            // is the δ that produced this `p`.
+            let alpha_cap = model_step_cap(qp.h, qp.g, &hx, &p, schur.shift());
+
+            let (mut alpha, blocker) =
+                select_blocker(&candidates, opts, expand_tol, false, alpha_cap);
 
             // F2(a), Schur path. Same certificate as `solve_general`: an
             // empty candidate list means `+p` is feasible for every step
             // length, so a zero-curvature descent `p` is a recession ray.
-            // The Schur driver hides the per-iterate inertia shift inside
-            // `SchurState`, so unlike `solve_general` we cannot gate on
-            // `delta > 0` here — but `ray_is_unbounded_descent` rejects
-            // any direction with measurable curvature (`‖Hp‖∞` above the
-            // 1e-10·‖H‖ structural-zero floor), so a PD-reduced-Hessian
-            // Newton step never certifies and the unconditional check is
-            // still safe.
-            if candidates.is_empty() && ray_is_unbounded_descent(qp.h, qp.g, &x, &p) {
+            // The unconditional (un-gated on δ) check is safe because
+            // `ray_is_unbounded_descent` rejects any direction with
+            // measurable curvature (`‖Hp‖∞` above the 1e-10·‖H‖
+            // structural-zero floor), so a PD-reduced-Hessian Newton step
+            // never certifies. F2(b) — the negative-curvature sibling, an
+            // infinite `alpha_cap` with nothing to block it — rides along.
+            if candidates.is_empty()
+                && (!alpha.is_finite() || ray_is_unbounded_descent(qp.h, qp.g, &x, &p))
+            {
                 let ray = p.clone();
                 return Ok(QpSolution {
                     obj: Number::NEG_INFINITY,
@@ -2151,6 +2244,13 @@ impl ParametricActiveSetSolver {
 
             if alpha < 0.0 {
                 alpha = 0.0;
+            }
+            if !alpha.is_finite() {
+                // Unreachable in principle — an infinite cap survives
+                // `select_blocker` only with an empty candidate list, which
+                // the F2 return above consumes. Clamp rather than propagate
+                // a non-finite iterate if a NaN ratio ever gets here.
+                alpha = 1.0;
             }
             if trace && blocker.is_none() {
                 eprintln!(
@@ -2550,8 +2650,14 @@ fn blocker_index_key(b: BlockerTarget) -> (u8, usize) {
 /// Saunders-Wright 1989); the τ-growth and snap-to-bound
 /// machinery is a follow-up commit.
 ///
-/// Returns `(α, blocker)` with `α = 1.0` and `blocker = None`
+/// Returns `(α, blocker)` with `α = alpha_cap` and `blocker = None`
 /// when no direction blocks at less than the full step.
+///
+/// `alpha_cap` is the unconstrained step length the caller wants —
+/// the minimizer of the QP model along `p`, which is 1.0 for an
+/// unshifted Newton direction and larger (possibly `+∞`) for a
+/// δ-shifted one; see [`model_step_cap`]. It is the value returned
+/// when nothing blocks, and the ceiling on every value that is.
 ///
 /// `expand_tol` is the current GMSW EXPAND τ (only consumed when
 /// `opts.anti_cycling = Expand`; pass 0.0 to disable). Non-zero
@@ -2564,13 +2670,14 @@ fn select_blocker(
     opts: &QpOptions,
     expand_tol: f64,
     force_bland: bool,
+    alpha_cap: f64,
 ) -> (f64, Option<BlockerTarget>) {
     if candidates.is_empty() {
-        return (1.0, None);
+        return (alpha_cap, None);
     }
     // Pass 1: minimum ratio (strict and τ-relaxed).
-    let mut alpha_min = 1.0_f64;
-    let mut alpha_min_relaxed = 1.0_f64;
+    let mut alpha_min = alpha_cap;
+    let mut alpha_min_relaxed = alpha_cap;
     for &(_, r, ap_mag) in candidates {
         if r < alpha_min {
             alpha_min = r;
@@ -2584,8 +2691,8 @@ fn select_blocker(
             alpha_min_relaxed = r_relaxed;
         }
     }
-    if alpha_min >= 1.0 {
-        return (1.0, None);
+    if alpha_min >= alpha_cap {
+        return (alpha_cap, None);
     }
 
     // The anti-stall latch forces Bland (strict-min, lowest-index)
@@ -2650,21 +2757,22 @@ fn select_blocker(
             match best {
                 Some((target, r, _)) => {
                     // Floor the step length at the τ-relaxed minimum so
-                    // we never freeze at α = 0; cap at 1.0.
-                    let alpha = r.max(alpha_min_relaxed).min(1.0).max(0.0);
+                    // we never freeze at α = 0; cap at the model minimizer.
+                    let alpha = r.max(alpha_min_relaxed).min(alpha_cap).max(0.0);
                     (alpha, Some(target))
                 }
                 None => {
                     // Pass 2 admitted nothing. This happens when every
                     // candidate's τ-relaxed ratio exceeds the artificial
-                    // `α_min_relaxed = 1.0` initialization cap by more than
+                    // `α_min_relaxed = alpha_cap` initialization by more than
                     // `tol` — reachable when |a·p| ≈ feas_tol makes
-                    // `τ/|a·p|` inflate `r_relaxed` above `1 + tol` for ALL
-                    // candidates (so the recorded minimum is the cap, which
-                    // no real candidate attains). Fall back to the strict
-                    // minimum-ratio blocker (guaranteed to exist since
-                    // `α_min < 1.0`) and step exactly `α_min`: never freeze,
-                    // panic, or overstep the first blocking constraint.
+                    // `τ/|a·p|` inflate `r_relaxed` above `alpha_cap + tol`
+                    // for ALL candidates (so the recorded minimum is the cap,
+                    // which no real candidate attains). Fall back to the
+                    // strict minimum-ratio blocker (guaranteed to exist since
+                    // `α_min < alpha_cap`) and step exactly `α_min`: never
+                    // freeze, panic, or overstep the first blocking
+                    // constraint.
                     let mut fb: Option<BlockerTarget> = None;
                     for &(target, r, _) in candidates {
                         if r <= alpha_min {
@@ -3096,6 +3204,101 @@ fn ray_is_unbounded_descent(
     zero_curvature && descent
 }
 
+/// Step-length cap for the current search direction `p`: the exact
+/// minimizer of the QP model along `p`, floored at the unit step.
+///
+/// With an **unshifted** active-set KKT the unit step already *is* that
+/// minimizer. Writing `r = Hx + g`, the system solved is
+/// `H p + A_Wᵀ λ = −r` with `A_W p = 0`, so `pᵀr = −pᵀHp` and
+///
+/// ```text
+///     α* = −pᵀr / pᵀHp = 1.
+/// ```
+///
+/// §4.5 inertia control breaks the identity: on an indefinite reduced
+/// Hessian it factors `H + δI` instead, giving `pᵀr = −(pᵀHp + δ‖p‖²)`
+/// and
+///
+/// ```text
+///     α* = −pᵀr / pᵀHp = 1 + δ‖p‖² / pᵀHp    (> 1)
+///     α* = +∞                                (pᵀHp ≤ 0)
+/// ```
+///
+/// so the model asks for a step `1 + δ‖p‖²/pᵀHp` times longer than the
+/// one the loop used to take, and asks for an unbounded one whenever the
+/// true curvature along `p` is non-positive.
+///
+/// Taking the unit step anyway is gh #416: with `W` unchanged the inner
+/// loop degenerates into proximal-point iteration with parameter δ —
+/// `x ← argmin q(y) + ½δ‖y − x‖²` — whose contraction factor is
+/// `δ/(λ + δ)` per eigenvalue λ of `H`. Since δ must exceed `|λ_min|` to
+/// make the shifted system PD, and it is reached by multiplying by
+/// `inertia_shift_factor` (100 by default), δ typically *dominates* the
+/// spectrum: the reported Rosenbrock QP has `λ_min = −1.4` and δ = 100,
+/// putting every factor within 3 % of 1. The result is a sequence of
+/// ~1e-3-long "full steps" that never reach a bound, so 200 iterations
+/// pass with zero working-set changes and the QP exits `MaxIter` — the
+/// dimension-independent 200-iteration burn in the issue. With the cap
+/// the negative-curvature direction runs to its blocking bound instead,
+/// which is what an active-set method is supposed to do with it
+/// (Nocedal-Wright §16.5).
+///
+/// `hx` must be `H·x` at the current iterate and `p` the direction just
+/// solved for; `delta` is the shift that produced it. `delta == 0`
+/// returns 1.0 without touching the data, so every non-shifted solve
+/// keeps bit-identical behaviour.
+fn model_step_cap(
+    h: &pounce_linalg::triplet::SymTMatrix,
+    g: &[Number],
+    hx: &[Number],
+    p: &[Number],
+    delta: Number,
+) -> Number {
+    if delta <= 0.0 {
+        return 1.0;
+    }
+
+    let mut hp = vec![0.0; p.len()];
+    let mut h_scale: Number = 0.0;
+    let irows = h.irows();
+    let jcols = h.jcols();
+    let vals = h.values();
+    for k in 0..irows.len() {
+        let i = (irows[k] - 1) as usize;
+        let j = (jcols[k] - 1) as usize;
+        let v = vals[k];
+        h_scale = h_scale.max(v.abs());
+        hp[i] += v * p[j];
+        if i != j {
+            hp[j] += v * p[i];
+        }
+    }
+
+    let curv: Number = p.iter().zip(hp.iter()).map(|(pi, hpi)| pi * hpi).sum();
+    let slope: Number = p
+        .iter()
+        .zip(hx.iter().zip(g.iter()))
+        .map(|(pi, (hxi, gi))| pi * (hxi + gi))
+        .sum();
+
+    // Relative floor on the curvature. `pᵀHp` below the round-off level
+    // of its own accumulation is zero, not a tiny positive number —
+    // dividing by it would manufacture an α* of 1e16 and hurl the
+    // iterate out of the box. Below the floor the model is (at best)
+    // linear along `p`, so the step is bounded only by the ratio test.
+    let p_sq: Number = p.iter().map(|v| v * v).sum();
+    if curv > 1e-12 * h_scale * p_sq {
+        (-slope / curv).max(1.0)
+    } else if slope < 0.0 {
+        // A successful shifted factorization has `pᵀ(H + δI)p > 0`, hence
+        // `pᵀr = −(pᵀHp + δ‖p‖²) < 0`: descent is structural here, and the
+        // test only guards against a direction corrupted by round-off.
+        Number::INFINITY
+    } else {
+        1.0
+    }
+}
+
 fn quad_objective(qp: &QpProblem, x: &[Number]) -> Number {
     let mut quad = 0.0;
     let irows = qp.h.irows();
@@ -3145,7 +3348,7 @@ mod select_blocker_tests {
         let opts = expand_opts(1e-6);
         // expand_tol (τ) = 1e-3, ap_mag = 1e-9 ⇒ r_relaxed ≈ 0.5 + 1e6.
         let candidates = [(BlockerTarget::Bound(0, BoundStatus::AtLower), 0.5, 1e-9)];
-        let (alpha, blocker) = select_blocker(&candidates, &opts, 1e-3, false);
+        let (alpha, blocker) = select_blocker(&candidates, &opts, 1e-3, false, 1.0);
         assert!(
             matches!(blocker, Some(BlockerTarget::Bound(0, BoundStatus::AtLower))),
             "expected the sole candidate as blocker, got {:?}",
@@ -3172,7 +3375,7 @@ mod select_blocker_tests {
             (BlockerTarget::Bound(0, BoundStatus::AtLower), 0.75, 1e-9),
             (BlockerTarget::Bound(1, BoundStatus::AtUpper), 0.25, 1e-9),
         ];
-        let (alpha, blocker) = select_blocker(&candidates, &opts, 1e-3, false);
+        let (alpha, blocker) = select_blocker(&candidates, &opts, 1e-3, false, 1.0);
         assert!(
             matches!(blocker, Some(BlockerTarget::Bound(1, BoundStatus::AtUpper))),
             "expected the strict-min candidate (index 1)"
@@ -3190,7 +3393,7 @@ mod select_blocker_tests {
     fn expand_normal_case_admits_in_pass_two() {
         let opts = expand_opts(1e-6);
         let candidates = [(BlockerTarget::Bound(0, BoundStatus::AtLower), 0.5, 1.0)];
-        let (alpha, blocker) = select_blocker(&candidates, &opts, 1e-9, false);
+        let (alpha, blocker) = select_blocker(&candidates, &opts, 1e-9, false, 1.0);
         assert!(matches!(
             blocker,
             Some(BlockerTarget::Bound(0, BoundStatus::AtLower))

--- a/crates/pounce-qp/tests/indefinite_step_length.rs
+++ b/crates/pounce-qp/tests/indefinite_step_length.rs
@@ -1,0 +1,251 @@
+//! gh #416 — an indefinite QP must take the step its model asks for.
+//!
+//! §4.5 inertia control factors `H + δI` when the reduced Hessian is not PD
+//! on the active null space. The direction that comes back is a descent
+//! direction for the *true* model, but the unit step no longer minimizes
+//! along it: `α* = 1 + δ‖p‖²/pᵀHp`, which is `+∞` when the true curvature
+//! along `p` is non-positive. Capping at 1 anyway turns the inner loop into
+//! proximal-point iteration with parameter δ — and δ is chosen by
+//! multiplying `inertia_shift_initial` by `inertia_shift_factor` (100) until
+//! the shifted system is PD, so it usually *dominates* the spectrum and each
+//! "full step" is a δ-sized crawl. The reported symptom was a QP burning its
+//! whole 200-iteration budget with **zero** working-set changes, on a
+//! Rosenbrock SQP subproblem whose only obstacle was one negative eigenvalue.
+//!
+//! Each fixture below is a 2-variable indefinite QP whose answer sits at a
+//! bound reached along the negative-curvature direction. Pre-fix they all
+//! exit `MaxIter`; the iteration-count assertions are what pins the fix
+//! (the answers themselves are also wrong pre-fix, but only because the
+//! crawl was interrupted).
+
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+use std::rc::Rc;
+
+const NEG_INF: f64 = -1e20;
+const POS_INF: f64 = 1e20;
+
+/// `H = diag(1, −1)` — PD in `x₁`, negative curvature in `x₂`.
+fn saddle_hessian() -> SymTMatrix {
+    let space = SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&space));
+    h.set_values(&[1.0, -1.0]);
+    h
+}
+
+fn no_rows() -> GenTMatrix {
+    GenTMatrix::new(GenTMatrixSpace::new(0, 2, Vec::new(), Vec::new()))
+}
+
+fn new_solver() -> ParametricActiveSetSolver {
+    ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()))
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Box path (`solve_box_constrained`).
+//
+//     min ½x₁² − ½x₂² − ½x₂   s.t. −1 ≤ x ≤ 1
+//
+// x₁ is convex with zero gradient ⇒ x₁* = 0. x₂ is concave, so its
+// optimum is at a bound: −½ − ½ = −1 at x₂ = 1 versus −½ + ½ = 0 at
+// x₂ = −1. Unique optimum (0, 1), obj −1.
+//
+// The cold iterate is the origin, where the reduced Hessian is
+// indefinite ⇒ δ = 100 and the shifted step is `p₂ = 0.5/99 ≈ 5.05e−3`.
+// Capped at α = 1 that needs ~198 iterations to walk x₂ out to its
+// bound — the whole default budget, for one working-set change.
+// Uncapped, the ratio test takes it there in one.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn box_negative_curvature_reaches_its_bound_in_one_step() {
+    let h = saddle_hessian();
+    let a = no_rows();
+    let g = [0.0, -0.5];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("indefinite box QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "x = {:?}", sol.x);
+    assert!(
+        (sol.x[0]).abs() < 1e-9 && (sol.x[1] - 1.0).abs() < 1e-9,
+        "expected x* = (0, 1), got {:?}",
+        sol.x
+    );
+    assert!((sol.obj + 1.0).abs() < 1e-9, "obj = {}", sol.obj);
+    // One add for the x₂ bound, and the refactor count is the iteration
+    // count: pre-fix this was 200 refactors and a `MaxIter` exit.
+    assert_eq!(sol.stats.n_working_set_changes, 1);
+    assert!(
+        sol.stats.n_refactor <= 5,
+        "took {} refactorizations for a single active-set change",
+        sol.stats.n_refactor
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Same fixture with `x₂` unbounded above: the model now falls forever
+// along the negative-curvature direction and nothing blocks it, which
+// is exactly the recession certificate — with `pᵀHp < 0` in place of
+// the `Hp = 0` that `ray_is_unbounded_descent` looks for.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn box_negative_curvature_with_no_blocker_is_unbounded() {
+    let h = saddle_hessian();
+    let a = no_rows();
+    let g = [0.0, -0.5];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, POS_INF];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("indefinite box QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Unbounded, "x = {:?}", sol.x);
+    let ray = sol.unbounded_ray.expect("unbounded verdict carries a ray");
+    assert!(
+        ray[1] > 0.0 && ray[1].abs() > ray[0].abs(),
+        "ray {ray:?} should point along +x₂, the negative-curvature direction"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// General path (`solve_general`): same QP plus one general inequality
+// row that never binds, which is enough to route the dispatcher away
+// from the box fast path.
+//
+//     min ½x₁² − ½x₂² − ½x₂
+//     s.t. x₁ + x₂ ≤ 10,  −1 ≤ x ≤ 1
+//
+// The row is slack at every feasible point, so the optimum is the box
+// problem's: (0, 1), obj −1.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn general_path_negative_curvature_reaches_its_bound() {
+    let h = saddle_hessian();
+    let a_space = GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&[1.0, 1.0]);
+
+    let g = [0.0, -0.5];
+    let bl = [NEG_INF];
+    let bu = [10.0];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 1,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    for schur in [false, true] {
+        let opts = QpOptions {
+            use_schur_updates: schur,
+            ..QpOptions::default()
+        };
+        let sol = new_solver()
+            .solve(&qp, None, &opts)
+            .expect("indefinite general QP must solve");
+
+        assert_eq!(sol.status, QpStatus::Optimal, "schur={schur} x={:?}", sol.x);
+        assert!(
+            (sol.x[0]).abs() < 1e-9 && (sol.x[1] - 1.0).abs() < 1e-9,
+            "schur={schur}: expected x* = (0, 1), got {:?}",
+            sol.x
+        );
+        assert!(
+            sol.stats.n_refactor + sol.stats.n_schur_updates <= 6,
+            "schur={schur}: {} refactors + {} updates for one active-set change",
+            sol.stats.n_refactor,
+            sol.stats.n_schur_updates,
+        );
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Convex control: with a PD Hessian no shift fires (δ = 0), the unit
+// step IS the model minimizer, and behaviour must be untouched.
+//
+//     min ½x₁² + ½x₂² − x₁ − 3x₂,  −1 ≤ x ≤ 1
+//
+// Unconstrained minimizer (1, 3) ⇒ x* = (1, 1) at the box corner.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn convex_box_qp_is_unaffected() {
+    let space = SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&space));
+    h.set_values(&[1.0, 1.0]);
+    let a = no_rows();
+
+    let g = [-1.0, -3.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, 1.0];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let sol = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("convex box QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!(
+        (sol.x[0] - 1.0).abs() < 1e-9 && (sol.x[1] - 1.0).abs() < 1e-9,
+        "expected x* = (1, 1), got {:?}",
+        sol.x
+    );
+}


### PR DESCRIPTION
Fixes #416

## Problem

`algorithm = active-set-sqp` with `sqp_hessian = exact` gave up on plain
extended Rosenbrock in a ball (`n = 10`, no active constraint) from the
canonical `(−1.2, 1, …)` start. All rows below are at the **default** QP
budget (`sqp_qp_max_iter = 200`):

| | status | objective | stationarity | outer iters |
|---|---|---|---|---|
| before | `QpIterationLimit` | 9.622140 | 2.62e0 | 4 |
| after | `Optimal` | 3.986579 | ≤1e-4 | 20 |
| interior-point (oracle) | `Optimal` | 3.9866 | — | — |

The documented workaround — raising the cap to 250 — reached the same
answer in 277 ms; the fix reaches it at the default budget in 107 ms
(debug build, same machine).

Two facts in the report said the budget was not the real problem: the
smallest cap that worked was 250 whether `n` was 10 or 40, and the QP made
**zero** working-set changes while spending those 200 iterations. Neither
is what running out of active-set work looks like.

## Cause

The QP was doing proximal-point iteration by accident.

§4.5 inertia control factors `H + δI` when the reduced Hessian is not PD on
the active null space. The inner loop then still capped its step at `α = 1`.
But the unit step is the model minimizer only for an **unshifted** Newton
direction. Writing `r = Hx + g`, the unshifted active-set KKT gives
`pᵀr = −pᵀHp`, hence `α* = −pᵀr/pᵀHp = 1` exactly. The shifted one gives
`pᵀr = −(pᵀHp + δ‖p‖²)`, hence

```
α* = 1 + δ‖p‖² / pᵀHp      (> 1)
α* = +∞                     (pᵀHp ≤ 0 — the model falls forever along p)
```

Capping at 1 anyway leaves `x ← argmin q(y) + ½δ‖y − x‖²`, whose contraction
is `δ/(λ + δ)` per eigenvalue λ of `H`. δ is reached by multiplying
`QpOptions::inertia_shift_initial` (1e-8) by `inertia_shift_factor` (100)
until the shifted system is PD, so it overshoots the spectrum badly: on this
QP `λ_min = −1.4` against `δ = 100` puts every factor within 3 % of 1.

Instrumenting the loop shows exactly that, 200 times over:

```
qp iter 0: delta=1.000e2 |p|inf=2.662e-3 alpha=1.000e0 curv=+3.088e-3 kc=0 kb=0
qp iter 3: delta=1.000e2 |p|inf=2.084e-3 alpha=1.000e0 curv=-1.053e-5 kc=0 kb=0
qp iter 150: delta=1.000e2 |p|inf=1.716e-2 alpha=1.000e0 curv=-9.787e-4 kc=0 kb=0
```

δ-sized "full steps" that never reach a bound, with the true curvature along
`p` negative from iteration 3 on. It is dimension-independent because δ and
the spectrum are — which is why raising the cap looked like it fixed
something.

## Fix

Cap the ratio test at `α*` instead of at 1 (`model_step_cap` in
`crates/pounce-qp/src/solver.rs`). A negative-curvature direction now runs to
its blocking bound and *changes the working set* — what an active-set method
is supposed to do with negative curvature (Nocedal-Wright §16.5).

`δ = 0` returns `1.0` without touching the data, so every non-shifted solve
is bit-identical; the gate is the shift itself, not a tolerance. Applied to
all four inner loops (box, equality-plus-bounds, general, and the
Schur-update variant, which now tracks the δ in its cached base factor so it
can). Curvature below a relative floor (`1e-12·‖H‖·‖p‖²`) counts as zero
rather than tiny-positive — dividing by it would manufacture an `α*` of 1e16
and hurl the iterate out of the box.

A non-positive-curvature direction with nothing to block it is the existing
F2 recession certificate with `pᵀHp < 0` in place of `Hp = 0`, and is now
reported `Unbounded`. `ray_is_unbounded_descent` cannot serve here — it
demands zero curvature, correctly, because it also serves the PSD paths — so
that case is checked separately rather than by loosening the shared test.

Considered and not done: the issue's direction (3), an exact-Hessian
fallback to a quasi-Newton step on an inner `MaxIter`. With the crawl gone
the inner `MaxIter` is not firing on these problems, and adding a second
rescue mechanism would paper over whatever the first one hits next rather
than locating it. Direction (4), the default of 200, is unchanged. Direction
(2) — splitting the inner iteration limit out of `QpStepFailed` — is already
on `main` (`QpIterationLimit` → `Maximum_Iterations_Exceeded`), which is why
the pre-fix run above reports `QpIterationLimit` rather than the
`Search_Direction_Becomes_Too_Small` in the issue text.

**Also fixed, found by the above.** l1-elastic phase-1 labelled its result
`Optimal` whenever the slacks reached zero, even when the phase-1 solve had
hit its own iteration limit on the way. Past the point where the slacks
vanish the augmented objective *is* the original one plus a zero penalty, so
an unconverged phase-1 leaves an ordinary feasible-but-suboptimal iterate:
`afiro` with `sqp_qp_max_iter = 3` returned `Optimal` carrying a KKT error of
10 at objective 440 against a −464.75 optimum. The inner verdict is now
carried out; the point is still returned, just not dressed up.

## Blast radius

Bit-identical wherever the inertia shift does not fire, by construction.

Corpus sweep, 37 `.nl` fixtures × 2 engines (`algorithm=active-set-sqp`,
`solver_selection=qp-active-set`), 74 runs, against parent commit `301aa84`:
**71 of 74 identical**, and no solve became a failure. The three changes:

- `unbounded_exp.nl` (`min −exp(x)`) and `unbounded_cubic.nl`:
  `Maximum_Iterations_Exceeded` → `Diverging_Iterates`, agreeing with the IPM
  path on both. The SQP driver still re-verifies the ray against the true NLP
  before reporting it, so these are earned, not asserted.
- `jit1.nl` on the SQP path: `Search_Direction_Becomes_Too_Small` →
  `Maximum_Iterations_Exceeded`. Fails both ways (dual infeasibility 8e7
  before, 1.8e8 after) — a relabelled failure, not a regression. The IPM path,
  which is what `jit1`'s tests exercise, is untouched.

`afiro` through the convex driver is unchanged at the default budget: 33
pivots to `-464.75314286` before and after. Only starved budgets differ, and
that is the elastic-status fix above.

## Tests

`crates/pounce-algorithm/src/sqp/tests.rs` —
`issue_416_indefinite_rosenbrock_converges_at_the_default_qp_budget`: the
issue's own repro, `n ∈ {10, 20}` × ball/bounds-only × both globalizations,
at the **default** QP budget (raising it would hide the bug). On the parent
commit it fails with `QpIterationLimit after 4 iters (f=9.622140,
stationarity=2.62e0)` — the issue's numbers.

`crates/pounce-qp/tests/indefinite_step_length.rs` — four QP-level fixtures
on `H = diag(1, −1)`. Three fail on the parent commit:
`box_negative_curvature_reaches_its_bound_in_one_step` (200 refactors and a
`MaxIter` exit for one working-set change),
`box_negative_curvature_with_no_blocker_is_unbounded` (crawls to
`x₂ = 3.23` and stops), `general_path_negative_curvature_reaches_its_bound`
(same, both `use_schur_updates` settings). The fourth,
`convex_box_qp_is_unaffected`, passes on both sides and is there to stay that
way.

Not pinned: the issue's `double_well_chain` timing comparison, which lives in
`benchmarks/warmstart/` on an unmerged branch. The mechanism it reports is
the same one the Rosenbrock fixtures pin.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — not needed; no statement in
      `docs/src/active-set-sqp.md` was falsified by this change (the
      `sqp_hessian` table already says inertia control handles indefinite
      ∇²L, which is now true without the workaround)
- [x] `cargo fmt --all -- --check`, the CI clippy gate
      (`-D clippy::correctness -D clippy::suspicious`), and `cargo test`
      clean
- [x] Every claim in this PR body and in the code comments is true of the
      code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014uuBhNGsFqBUavAKX2DkLU

---
_Generated by [Claude Code](https://claude.ai/code/session_014uuBhNGsFqBUavAKX2DkLU)_