### PR TITLE
Fix exact-Hessian SQP stalling on unconstrained nonconvex NLPs (#423)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — exact-Hessian SQP gave up on unconstrained nonconvex NLPs (#423)
+
+- **`algorithm = active-set-sqp` with `sqp_hessian = exact` no longer stops at
+  the first indefinite iterate of a problem with nothing to block a
+  negative-curvature direction.** The reported case — a chain of coupled
+  double wells, `n = 12`, `m = 0`, no finite bounds, started inside the
+  negative-curvature region — solved to `f = 0.027424` in 24 outer iterations
+  before #419 and afterwards exited `Search_Direction_Becomes_Too_Small` at
+  outer iteration **1**, at `f = 26.0257`: ~950× the optimum, and the value at
+  a point one step from the start. It converges to `f = 0.027424` in 24
+  iterations again.
+- **The regression is #419's own mechanism reaching a case it has no answer
+  for.** #419 made an unblocked non-positive-curvature direction a recession
+  certificate, which is right for a standalone QP and right for #416's
+  Rosenbrock, where the direction runs to a bound and pivots. But a *step* QP
+  is unbounded below at every indefinite iterate that has nothing to block
+  that direction — and with `m = 0` and no finite bounds, nothing can ever
+  block, so every indefinite iterate produced one. The driver then re-verified
+  the ray against the true NLP (#388), correctly found the quartic objective
+  bounded below, and had no third branch: not-unbounded meant `QpStepFailed`.
+  The two issues are mirror images — #416 was "the δ-shifted step is capped at
+  α = 1, so the solver spins without pivoting"; this was "the δ-shifted step is
+  gone, so a solver with nothing to pivot *to* has no step at all".
+- **An unbounded model on a bounded NLP is a signal to regularize, not to
+  stop** (Nocedal-Wright §18.4) — and δ from §4.5 inertia control already *is*
+  that regularization. When the ray fails NLP re-verification the driver now
+  re-solves the same subproblem with the certificate declined
+  (`QpOptions::certify_recession_ray = false`, new, default `true`): the shift
+  stays, the unblocked direction takes the δ-shifted proximal step (`α = 1`),
+  and the QP returns a point. `QpStepFailed` is reported only if even that
+  produces nothing. #419's ratio-test cap is untouched wherever a bound exists,
+  so #416 and every Rosenbrock row stay exactly where #419 left them, and a
+  genuinely unbounded NLP still reports `Diverging_Iterates` — the re-solve
+  happens only *after* the ray has failed re-verification.
+- Standalone `solve_qp` is unaffected: `certify_recession_ray` defaults to
+  `true`, because the point of solving a QP is to learn whether it has a
+  minimizer.
+
 ### Fixed — the active-set QP crawled instead of stepping on an indefinite Hessian (#416)
 
 - **`algorithm = active-set-sqp` with `sqp_hessian = exact` now solves plain

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -478,6 +478,61 @@ impl SqpAlgorithm {
                     sol = retry;
                 }
             }
+
+            // Unbounded-model fallback (gh #423). The step QP being
+            // unbounded below is a statement about the *linearization*, so
+            // re-test the ray against the true NLP (gh #388) — and when it
+            // does not survive, do not stop there. An unbounded model on a
+            // bounded NLP is not a dead end; it is the textbook signal that
+            // the model needs regularizing (Nocedal-Wright §18.4), and δ
+            // from §4.5 inertia control already *is* that regularization.
+            // So re-solve declining the certificate: the same subproblem,
+            // the same shift, but the unblocked direction takes the
+            // δ-shifted proximal step instead of certifying recession.
+            //
+            // This is not a corner case. A nonconvex NLP with `m = 0` and
+            // no finite bounds has *nothing that can ever block* a
+            // negative-curvature direction, so every indefinite iterate
+            // produces this certificate. gh #419 gave those iterates a real
+            // step where a bound exists and left them with none where one
+            // does not: a chain of coupled double wells (`n = 12`, `m = 0`)
+            // that converged to f = 0.027424 in 24 iterations died at
+            // iteration 1 with `QpStepFailed` at f = 26.03. The proximal
+            // step is slow — that slowness is what #416 was about — but it
+            // is a step, and it is only reached here where the alternative
+            // is no step at all.
+            let mut ray_certified = false;
+            if sol.status == QpStatus::Unbounded {
+                ray_certified = sol.unbounded_ray.as_ref().is_some_and(|d| {
+                    ray_certifies_unbounded(
+                        nlp,
+                        &iter.x,
+                        d,
+                        f_curr,
+                        &grad_f,
+                        &bl_c,
+                        &bu_c,
+                        &xl,
+                        &xu,
+                        self.opts.constr_viol_tol,
+                    )
+                });
+                if !ray_certified {
+                    tracing::debug!(target: "pounce::sqp",
+                        "unbounded step QP whose recession ray does not survive \
+                         re-testing against the NLP — re-solving for the δ-shifted \
+                         proximal step (gh #423)");
+                    let prox_opts = QpOptions {
+                        certify_recession_ray: false,
+                        ..self.qp_opts.clone()
+                    };
+                    let prox = self.qp_solver.solve(&qp_data.as_qp(), None, &prox_opts)?;
+                    n_qp_solves += 1;
+                    if prox.status == QpStatus::Optimal {
+                        sol = prox;
+                    }
+                }
+            }
             self.qp_opts = base;
 
             match sol.status {
@@ -537,11 +592,13 @@ impl SqpAlgorithm {
                 // recession ray of the LOCAL model (zero curvature,
                 // feasible for every step length, strict descent). That
                 // is a statement about the linearization, not yet about
-                // the NLP — so re-test the ray against the true
-                // objective and constraints. If it survives, the NLP
-                // itself is unbounded and we say so with the same
+                // the NLP — so it was re-tested against the true
+                // objective and constraints above. If it survived, the
+                // NLP itself is unbounded and we say so with the same
                 // `Diverging_Iterates` verdict every other POUNCE path
-                // returns; if it does not, the QP simply failed to
+                // returns. If it did not, the proximal re-solve above
+                // already had its chance to produce a step, and reaching
+                // here means even that failed: the QP simply could not
                 // produce a usable step, which is `QpStepFailed`.
                 //
                 // Neither outcome is a hard error. This used to return
@@ -553,26 +610,7 @@ impl SqpAlgorithm {
                 // linear-solver failure when no linear solver had failed
                 // (gh #388).
                 QpStatus::Unbounded => {
-                    let certified = sol.unbounded_ray.as_ref().is_some_and(|d| {
-                        ray_certifies_unbounded(
-                            nlp,
-                            &iter.x,
-                            d,
-                            f_curr,
-                            &grad_f,
-                            &bl_c,
-                            &bu_c,
-                            &xl,
-                            &xu,
-                            self.opts.constr_viol_tol,
-                        )
-                    });
-                    if !certified {
-                        tracing::debug!(target: "pounce::sqp",
-                            "unbounded step QP whose recession ray does not survive \
-                             re-testing against the NLP — reporting qp-step-failed \
-                             rather than claiming unboundedness (gh #388)");
-                    }
+                    let certified = ray_certified;
                     let obj = nlp.eval_f(&iter.x);
                     self.iterates = Some(iter.clone());
                     return Ok(SqpResult {

--- a/crates/pounce-algorithm/src/sqp/tests.rs
+++ b/crates/pounce-algorithm/src/sqp/tests.rs
@@ -1267,3 +1267,169 @@ fn issue_416_indefinite_rosenbrock_converges_at_the_default_qp_budget() {
         }
     }
 }
+
+// ─────────────────────────────────────────────────────────────────
+// Issue #423 fixture — a chain of coupled double wells.
+//
+//     min Σᵢ (xᵢ² − cᵢ)² + K Σᵢ (xᵢ₊₁ − xᵢ)²
+//
+// `m = 0`, every variable bound infinite: the configuration with
+// **nothing that can ever block a ratio test**. Started at
+// `x = 0.35·1`, where `12xᵢ² − 4cᵢ < 0` for every i, so the very
+// first ∇²L is indefinite. The objective is a sum of quartic wells
+// and is bounded below, so the NLP is not unbounded.
+//
+// #419 made an unblocked non-positive-curvature direction a
+// recession certificate. Here every indefinite iterate produces one,
+// the driver's re-verification correctly says "the NLP is not
+// unbounded", and before #423 there was no third branch: the solve
+// died at outer iteration 1 with `QpStepFailed`
+// (`Search_Direction_Becomes_Too_Small`) at f = 26.03, ~950× the
+// f = 0.027424 the interior-point path and the damped-BFGS SQP both
+// reach from the same start.
+// ─────────────────────────────────────────────────────────────────
+struct DoubleWellChainNlp {
+    n: usize,
+}
+
+impl DoubleWellChainNlp {
+    /// Coupling stiffness K.
+    const K: Number = 0.5;
+    /// Well centres `cᵢ`, spread over `[0.6, 2.4]`.
+    fn c(&self, i: usize) -> Number {
+        0.6 + 1.8 * (i as Number) / ((self.n - 1) as Number)
+    }
+}
+
+impl SqpProblemSpec for DoubleWellChainNlp {
+    fn n(&self) -> usize {
+        self.n
+    }
+    fn m(&self) -> usize {
+        0
+    }
+    fn x_init(&self) -> Vec<Number> {
+        vec![0.35; self.n]
+    }
+    fn variable_bounds(&self) -> (Vec<Number>, Vec<Number>) {
+        (
+            vec![NLP_LOWER_BOUND_INF; self.n],
+            vec![NLP_UPPER_BOUND_INF; self.n],
+        )
+    }
+    fn constraint_bounds(&self) -> (Vec<Number>, Vec<Number>) {
+        (Vec::new(), Vec::new())
+    }
+    fn eval_f(&mut self, x: &[Number]) -> Number {
+        let mut f = 0.0;
+        for (i, &xi) in x.iter().enumerate() {
+            let w = xi * xi - self.c(i);
+            f += w * w;
+        }
+        for i in 0..self.n - 1 {
+            let d = x[i + 1] - x[i];
+            f += Self::K * d * d;
+        }
+        f
+    }
+    fn eval_grad_f(&mut self, x: &[Number]) -> Vec<Number> {
+        let mut g: Vec<Number> = x
+            .iter()
+            .enumerate()
+            .map(|(i, &xi)| 4.0 * xi * (xi * xi - self.c(i)))
+            .collect();
+        for i in 0..self.n - 1 {
+            let d = 2.0 * Self::K * (x[i + 1] - x[i]);
+            g[i] -= d;
+            g[i + 1] += d;
+        }
+        g
+    }
+    fn eval_c(&mut self, _x: &[Number]) -> Vec<Number> {
+        Vec::new()
+    }
+    fn eval_jac_c(&mut self, _x: &[Number]) -> Triplet {
+        Triplet {
+            n_rows: 0,
+            n_cols: self.n,
+            irow: Vec::new(),
+            jcol: Vec::new(),
+            vals: Vec::new(),
+        }
+    }
+    fn eval_hess_lag(&mut self, x: &[Number], _lambda_g: &[Number]) -> Triplet {
+        let n = self.n;
+        let mut diag: Vec<Number> = x
+            .iter()
+            .enumerate()
+            .map(|(i, &xi)| 12.0 * xi * xi - 4.0 * self.c(i))
+            .collect();
+        for d in diag.iter_mut().take(n - 1) {
+            *d += 2.0 * Self::K;
+        }
+        for d in diag.iter_mut().skip(1) {
+            *d += 2.0 * Self::K;
+        }
+        let mut irow: Vec<Index> = (1..=n as Index).collect();
+        let mut jcol: Vec<Index> = (1..=n as Index).collect();
+        let mut vals = diag;
+        for i in 0..n - 1 {
+            irow.push(i as Index + 2);
+            jcol.push(i as Index + 1);
+            vals.push(-2.0 * Self::K);
+        }
+        Triplet {
+            n_rows: n,
+            n_cols: n,
+            irow,
+            jcol,
+            vals,
+        }
+    }
+}
+
+#[test]
+fn issue_423_unconstrained_nonconvex_survives_an_unbounded_model() {
+    // (n, local minimum reached from `0.35·1` — the value the
+    // interior-point path and the pre-#419 SQP both return).
+    for (n, f_opt) in [(12, 0.027424), (20, 0.016089)] {
+        for hess in [SqpHessianSource::Exact, SqpHessianSource::DampedBfgs] {
+            for glob in [SqpGlobalization::Filter, SqpGlobalization::L1Elastic] {
+                let qp_solver = ParametricActiveSetSolver::new(Box::new(
+                    pounce_feral::FeralSolverInterface::new(),
+                ));
+                let opts = SqpOptions {
+                    hessian: hess,
+                    globalization: glob,
+                    ..SqpOptions::default()
+                };
+                let mut alg = SqpAlgorithm::new(qp_solver, opts);
+                let mut nlp = DoubleWellChainNlp { n };
+                let res = alg.optimize(&mut nlp).unwrap();
+
+                assert_eq!(
+                    res.status,
+                    SqpStatus::Optimal,
+                    "n={n} hess={hess:?} glob={glob:?}: {:?} after {} iters \
+                     (f={:.6}, stationarity={:.2e})",
+                    res.status,
+                    res.n_iter,
+                    res.obj,
+                    res.final_stationarity,
+                );
+                // The regression parked at f = 26.03 for n = 12 — ~950x
+                // the optimum — after a single outer iteration.
+                assert!(
+                    (res.obj - f_opt).abs() < 1e-5,
+                    "n={n} hess={hess:?} glob={glob:?}: f={:.6}, expected {f_opt:.6}",
+                    res.obj,
+                );
+                assert!(
+                    res.final_stationarity <= 1e-4,
+                    "n={n} hess={hess:?} glob={glob:?}: stationarity {:.2e}",
+                    res.final_stationarity,
+                );
+            }
+        }
+    }
+}

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -127,6 +127,37 @@ pub struct QpOptions {
     pub expand_tol_initial: Number,
     pub expand_tol_growth: Number,
     pub expand_tol_max: Number,
+
+    /// May this solve conclude that the QP is unbounded below?
+    ///
+    /// `true` (default) is the F2/N1 behaviour described on
+    /// [`crate::solver`]: a feasible descent direction that nothing
+    /// blocks and that the model falls forever along is returned as
+    /// `QpStatus::Unbounded` with the recession ray attached.
+    ///
+    /// `false` asks for a **point instead of a verdict**. The
+    /// certification is skipped and the unblocked direction takes the
+    /// δ-shifted proximal step (`α = 1`, the minimizer of
+    /// `q(y) + ½δ‖y − x‖²`) so the inner loop keeps going. The solve
+    /// then exits `Optimal` — at the proximal fixed point — or
+    /// `MaxIter`, but never `Unbounded`.
+    ///
+    /// This exists for the SQP outer loop (gh #423). The *step* QP of a
+    /// nonconvex NLP is unbounded below at every indefinite iterate that
+    /// has nothing to block a negative-curvature direction — which, with
+    /// `m = 0` and no finite bounds, is every indefinite iterate there
+    /// is. That is a statement about the linearization, not about the
+    /// NLP: the driver re-tests the ray against the true problem
+    /// (`ray_certifies_unbounded`), and when the NLP turns out to be
+    /// bounded it needs a usable step out of the same subproblem rather
+    /// than a second unboundedness claim. Regularizing the model is the
+    /// textbook answer there (Nocedal-Wright §18.4), and δ from §4.5
+    /// inertia control is already exactly that regularization — so the
+    /// re-solve just declines the certificate and keeps the shift.
+    ///
+    /// Leave this `true` for a standalone `solve_qp`: the *whole point*
+    /// of solving a QP is to learn whether it has a minimizer.
+    pub certify_recession_ray: bool,
 }
 
 impl Default for QpOptions {
@@ -148,6 +179,7 @@ impl Default for QpOptions {
             expand_tol_initial: 1e-12,
             expand_tol_growth: 1e-11,
             expand_tol_max: 1e-7,
+            certify_recession_ray: true,
         }
     }
 }

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -380,6 +380,13 @@ impl ParametricActiveSetSolver {
                 }
             }
 
+            if !alpha.is_finite() && !opts.certify_recession_ray {
+                // The caller wants a point, not a verdict (gh #423): take
+                // the δ-shifted proximal step and keep iterating. See
+                // `QpOptions::certify_recession_ray`.
+                alpha = 1.0;
+            }
+
             if !alpha.is_finite() {
                 // The model falls forever along `p` and no bound blocks:
                 // a certified recession ray (same F2 certificate as
@@ -625,6 +632,11 @@ impl ParametricActiveSetSolver {
                     }
                 }
             }
+            if !alpha.is_finite() && !opts.certify_recession_ray {
+                // Point, not verdict (gh #423) — see
+                // `QpOptions::certify_recession_ray`.
+                alpha = 1.0;
+            }
             if !alpha.is_finite() {
                 // Nonpositive curvature along `p` with no blocking bound:
                 // certified recession ray (see `solve_box_constrained`).
@@ -774,7 +786,11 @@ impl ParametricActiveSetSolver {
         // clause `‖Hd‖∞ ≈ 0` (structural-zero floor, see
         // `ray_is_unbounded_descent`) rejects the former (there `‖Hd‖∞ ≈
         // ‖H‖`) and admits the latter.
-        if delta > 0.0 {
+        // `certify_recession_ray = false` skips the N1 test outright (gh
+        // #423): `x` here IS the δ-shifted proximal point — the exact
+        // minimizer of `q(y) + ½δ‖y‖²` over `Ay = b` — which is the step
+        // the caller asked for in place of the certificate.
+        if delta > 0.0 && opts.certify_recession_ray {
             // Feasibility of the candidate ray `d = x/‖x‖`: the saddle
             // solve enforced `Ax = b` exactly, so `Ad = b/‖x‖`, which the
             // blow-up drives to ~0. Verify it explicitly (cheap guard;
@@ -1244,8 +1260,14 @@ impl ParametricActiveSetSolver {
             // `Hp = 0`. `ray_is_unbounded_descent` cannot see that case (it
             // demands zero curvature, correctly, since it also serves the
             // PSD paths), so it is checked separately below.
+            //
+            // Both are suppressed by `certify_recession_ray = false`, which
+            // asks for a point rather than a verdict (gh #423); the α clamp
+            // below then turns the unblocked direction into the δ-shifted
+            // proximal step and the loop carries on.
             if candidates.is_empty()
                 && delta > 0.0
+                && opts.certify_recession_ray
                 && (!alpha.is_finite() || ray_is_unbounded_descent(qp.h, qp.g, &x, &p))
             {
                 let ray = p.clone();
@@ -1271,10 +1293,12 @@ impl ParametricActiveSetSolver {
                 alpha = 0.0;
             }
             if !alpha.is_finite() {
-                // Unreachable in principle: an infinite `alpha_cap` survives
-                // `select_blocker` only with an empty candidate list, which
-                // the F2 return above consumes. Clamp rather than propagate a
-                // non-finite iterate if a NaN ratio ever gets here.
+                // The δ-shifted proximal step. Reached either when
+                // `certify_recession_ray` declined the F2 return just above,
+                // or — in principle unreachably, since an infinite
+                // `alpha_cap` survives `select_blocker` only with an empty
+                // candidate list — if a NaN ratio ever gets here; clamping
+                // beats propagating a non-finite iterate.
                 alpha = 1.0;
             }
 
@@ -2220,7 +2244,11 @@ impl ParametricActiveSetSolver {
             // structural-zero floor), so a PD-reduced-Hessian Newton step
             // never certifies. F2(b) — the negative-curvature sibling, an
             // infinite `alpha_cap` with nothing to block it — rides along.
+            // Both are suppressed by `certify_recession_ray = false` (gh
+            // #423); the α clamp below then takes the δ-shifted proximal
+            // step instead.
             if candidates.is_empty()
+                && opts.certify_recession_ray
                 && (!alpha.is_finite() || ray_is_unbounded_descent(qp.h, qp.g, &x, &p))
             {
                 let ray = p.clone();
@@ -2246,10 +2274,12 @@ impl ParametricActiveSetSolver {
                 alpha = 0.0;
             }
             if !alpha.is_finite() {
-                // Unreachable in principle — an infinite cap survives
-                // `select_blocker` only with an empty candidate list, which
-                // the F2 return above consumes. Clamp rather than propagate
-                // a non-finite iterate if a NaN ratio ever gets here.
+                // The δ-shifted proximal step — reached when
+                // `certify_recession_ray` declined the F2 return above, or
+                // (unreachably in principle, since an infinite cap survives
+                // `select_blocker` only with an empty candidate list) if a
+                // NaN ratio ever gets here. Clamping beats propagating a
+                // non-finite iterate.
                 alpha = 1.0;
             }
             if trace && blocker.is_none() {

--- a/crates/pounce-qp/tests/recession_ray_opt_out.rs
+++ b/crates/pounce-qp/tests/recession_ray_opt_out.rs
@@ -1,0 +1,228 @@
+//! gh #423 — `QpOptions::certify_recession_ray = false`: a point, not a
+//! verdict.
+//!
+//! gh #416 taught the inner loop to run a δ-shifted negative-curvature
+//! direction out to the model's own minimizer along it, and gh #419's
+//! companion change made such a direction with *nothing to block it* a
+//! recession certificate (`QpStatus::Unbounded`). That is the right answer
+//! for a standalone QP. It is not always a usable one for the SQP outer
+//! loop, whose step QP is unbounded below at every indefinite iterate of a
+//! nonconvex NLP that has no blocking bound — with `m = 0` and no finite
+//! bounds, at *every* indefinite iterate there is. The driver re-tests the
+//! ray against the true NLP and, when the NLP turns out to be bounded, asks
+//! the same subproblem again with the certificate declined: the shift stays,
+//! the unblocked direction takes the δ-shifted proximal step (`α = 1`), and
+//! the solve returns a point.
+//!
+//! The fixtures below are the `indefinite_step_length.rs` unbounded cases
+//! with the flag flipped. Each asserts the same two things: the solve does
+//! not claim unboundedness, and it moves — a certificate replaced by a
+//! zero step would be no fix at all.
+
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+use std::rc::Rc;
+
+const NEG_INF: f64 = -1e20;
+const POS_INF: f64 = 1e20;
+
+/// `H = diag(1, −1)` — PD in `x₁`, negative curvature in `x₂`.
+fn saddle_hessian() -> SymTMatrix {
+    let space = SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&space));
+    h.set_values(&[1.0, -1.0]);
+    h
+}
+
+fn no_rows() -> GenTMatrix {
+    GenTMatrix::new(GenTMatrixSpace::new(0, 2, Vec::new(), Vec::new()))
+}
+
+fn new_solver() -> ParametricActiveSetSolver {
+    ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()))
+}
+
+fn declining() -> QpOptions {
+    QpOptions {
+        certify_recession_ray: false,
+        ..QpOptions::default()
+    }
+}
+
+/// The certificate is what a standalone `solve_qp` is for, so it stays on
+/// unless a caller deliberately turns it off.
+#[test]
+fn certification_is_on_by_default() {
+    assert!(QpOptions::default().certify_recession_ray);
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Box path (`solve_box_constrained`).
+//
+//     min ½x₁² − ½x₂² − ½x₂   s.t. −1 ≤ x₁ ≤ 1,  −1 ≤ x₂
+//
+// `x₂` is concave and unbounded above, so the model falls forever along
+// `+x₂` and no bound blocks it: `box_negative_curvature_with_no_blocker_is_
+// unbounded` in `indefinite_step_length.rs` is this exact QP under the
+// default options, and gets `Unbounded`.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn box_path_declines_the_certificate_and_steps() {
+    let h = saddle_hessian();
+    let a = no_rows();
+    let g = [0.0, -0.5];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, POS_INF];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    // Control: the same QP does certify under the defaults.
+    let certified = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("indefinite box QP must solve");
+    assert_eq!(certified.status, QpStatus::Unbounded);
+
+    let sol = new_solver()
+        .solve(&qp, None, &declining())
+        .expect("indefinite box QP must solve");
+
+    assert_ne!(
+        sol.status,
+        QpStatus::Unbounded,
+        "the caller declined the certificate"
+    );
+    assert!(sol.unbounded_ray.is_none());
+    // Proximal-point iteration on a model that really does fall forever
+    // never reaches a stationary point, so it walks until the budget runs
+    // out — but it *walks*, along the negative-curvature direction. (The
+    // SQP driver only adopts an `Optimal` re-solve, so this case still
+    // reports honestly upstream.)
+    assert!(
+        sol.x[1] > 0.0,
+        "expected progress along +x₂, got x = {:?}",
+        sol.x
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// General path (`solve_general`): the same QP plus one general row
+// `x₁ ≤ 10`. It never binds, and being an *inequality* it routes the
+// dispatcher to `solve_general`; being flat in `x₂` it cannot block the
+// negative-curvature direction either.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn general_path_declines_the_certificate_and_steps() {
+    let h = saddle_hessian();
+    let a_space = GenTMatrixSpace::new(1, 2, vec![1], vec![1]);
+    let mut a = GenTMatrix::new(a_space);
+    a.set_values(&[1.0]);
+    let g = [0.0, -0.5];
+    let bl = [NEG_INF];
+    let bu = [10.0];
+    let xl = [-1.0, -1.0];
+    let xu = [1.0, POS_INF];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 1,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let certified = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("indefinite general QP must solve");
+    assert_eq!(certified.status, QpStatus::Unbounded);
+
+    let sol = new_solver()
+        .solve(&qp, None, &declining())
+        .expect("indefinite general QP must solve");
+
+    assert_ne!(sol.status, QpStatus::Unbounded);
+    assert!(sol.unbounded_ray.is_none());
+    assert!(
+        sol.x[1] > 0.0,
+        "expected progress along +x₂, got x = {:?}",
+        sol.x
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Equality-only path (`solve_equality_only`), which is where an
+// unconstrained NLP's step QP lands: `m = 0` and no finite bound is
+// exactly the "pure equality, no bounds" predicate.
+//
+//     min ½x₁² − x₂      (H = diag(1, 0), unconstrained)
+//
+// Flat and strictly descending in `x₂` — the N1 zero-curvature recession
+// certificate, which this path detects from the blow-up of the δ-shifted
+// saddle solution. Declining it returns that saddle solution as the
+// answer, which is precisely the proximal point
+// `argmin q(y) + ½δ‖y‖²` — a real descent step, not a certificate.
+// ─────────────────────────────────────────────────────────────────
+#[test]
+fn equality_only_path_declines_the_certificate_and_returns_the_proximal_point() {
+    let space = SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&space));
+    h.set_values(&[1.0, 0.0]);
+    let a = no_rows();
+    let g = [0.0, -1.0];
+    let bl: [f64; 0] = [];
+    let bu: [f64; 0] = [];
+    let xl = [NEG_INF, NEG_INF];
+    let xu = [POS_INF, POS_INF];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Indefinite,
+    };
+
+    let certified = new_solver()
+        .solve(&qp, None, &QpOptions::default())
+        .expect("flat unbounded QP must solve");
+    assert_eq!(certified.status, QpStatus::Unbounded);
+
+    let sol = new_solver()
+        .solve(&qp, None, &declining())
+        .expect("flat unbounded QP must solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!(sol.unbounded_ray.is_none());
+    assert!(
+        sol.x[1] > 0.0 && sol.x[1].is_finite(),
+        "expected a finite proximal step along +x₂, got x = {:?}",
+        sol.x
+    );
+    // A descent step on the model, which is all the outer loop needs from
+    // it: q(0) = 0 here.
+    assert!(sol.obj < 0.0, "obj = {} is not descent", sol.obj);
+}


### PR DESCRIPTION
Fixes #423

## Problem

Exact-Hessian SQP (`algorithm = active-set-sqp` with `sqp_hessian = exact`) exits prematurely on unconstrained nonconvex NLPs with nothing to block a negative-curvature direction.

**Reported case:** A chain of coupled double wells (`n = 12`, `m = 0`, no finite bounds), started at `x = 0.35·1` inside the negative-curvature region:

| | status | objective | iters |
|---|---|---|---|
| before #419 | Optimal | 0.027424 | 24 |
| after #419 | QpStepFailed | 26.0257 | 1 |
| after this fix | Optimal | 0.027424 | 24 |

The regression is ~950× the optimum, reached in a single outer iteration — essentially the starting point.

## Cause

#419 made an unblocked non-positive-curvature direction a recession certificate (`QpStatus::Unbounded`), which is correct for a standalone QP and correct for #416's Rosenbrock case where the direction runs to a bound and pivots. However, the *step* QP of a nonconvex NLP is unbounded below at every indefinite iterate that has nothing to block that direction. With `m = 0` and no finite bounds, nothing can ever block, so every indefinite iterate produces this certificate.

The driver re-verifies the ray against the true NLP (#388), correctly finds the quartic objective bounded below, and had no third branch: not-unbounded meant `QpStepFailed`. The two issues are mirror images — #416 was "the δ-shifted step is capped at α = 1, so the solver spins without pivoting"; this was "the δ-shifted step is gone, so a solver with nothing to pivot *to* has no step at all".

The failing path is not the cold first subproblem — `m = 0` with no finite bounds routes that one to `solve_equality_only`, which returns fine. It is the warm-started second solve, through `solve_general`'s F2 branch, which is why the solve dies at outer iteration 1 rather than 0.

## Fix

An unbounded model on a bounded NLP is a signal to regularize, not to stop (Nocedal-Wright §18.4) — and δ from §4.5 inertia control already *is* that regularization. When the ray fails NLP re-verification, the driver now re-solves the same subproblem with the certificate declined (`QpOptions::certify_recession_ray = false`, new, default `true`): the shift stays, the unblocked direction takes the δ-shifted proximal step (`α = 1`), and the QP returns a point instead of a verdict. `QpStepFailed` is reported only if even that produces nothing.

**Key design decisions:**

1. **New `QpOptions::certify_recession_ray` flag** (default `true`): controls whether the QP returns `Unbounded` or takes the proximal step. Suppression is wired into all four inner loops that can certify (box, equality-plus-bounds, general, Schur) plus `solve_equality_only`'s N1 test — where the δ-shifted saddle solution *is* the proximal point, so declining the certificate just returns it.

2. **The proximal step is the δ-shifted minimizer** (`α = 1`): the exact minimizer of `q(y) + ½δ‖y − x‖²` over the feasible set. It is slow — that slowness is what #416 was about — but it is a step, and it is only reached where the alternative is no step at all.

3. **#419's ratio test is untouched wherever a bound exists.** #419 replaced the hard `α = 1` cap with the model's own minimizer `α*`, so a negative-curvature direction runs out to its blocking bound and changes the working set. That behaviour is unchanged here: the proximal branch is reached only when *nothing* blocks **and** the ray has already failed re-verification against the true NLP. So #416 and every Rosenbrock row stay exactly where #419 left them, and a genuinely unbounded NLP still reports `Diverging_Iterates`.

4. **Standalone `solve_qp` unaffected**: `certify_recession_ray` defaults to `true`, because the point of solving a QP is to learn whether it has a minimizer. Only the SQP outer loop ever sets it `false`, and only on the re-solve.

## Testing

The issue's Python repro, end to end — all three rows now match the pre-#419 / interior-point column exactly:

| algorithm | status | f | iters |
|---|---|--:|--:|
| `active-set-sqp`, `exact` | `Solve_Succeeded` | 0.027424 | 24 |
| `active-set-sqp`, `damped-bfgs` | `Solve_Succeeded` | 0.027424 | 32 |
| `interior-point` | `Solve_Succeeded` | 0.027424 | 8 |

- **New SQP fixture** `issue_423_unconstrained_nonconvex_survives_an_unbounded_model` — two scales × two Hessian sources × two globalizations, pinned to the objective the interior-point path reaches. On the parent commit it fails at exactly `QpStepFailed`, `f = 26.025699`, 1 iteration: the issue's numbers.
- **Four QP-level fixtures** (`crates/pounce-qp/tests/recession_ray_opt_out.rs`) covering the option on each path that can certify, each paired with a default-options control that must still return `Unbounded`.
- `issue_416_indefinite_rosenbrock_converges_at_the_default_qp_budget` green; `unbounded_exp.nl` / `unbounded_cubic.nl` still report `Diverging_Iterates`.
- Full workspace test suite green, plus 553 Python tests. (`pounce-hsl` was skipped locally — its tests do not link without the HSL libraries, unrelated to this change.)

## Blast radius

**Bit-identical except the targeted case.** The new branch activates only when the step QP returns `Unbounded` (requires an indefinite Hessian *and* an unblocked direction) *and* the recession ray then fails re-verification against the true NLP (requires the NLP to be bounded). Every other solve takes the same path, with the same numbers, as before.

https://claude.ai/code/session_01J9fozB3gpdBC3B1xS9Wjky