### PR TITLE
Add warm-start benchmark suite and SQP subproblem counters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,15 @@
 !/benchmarks/*/README.md
 !/benchmarks/preprocessing/*
 !/benchmarks/scripts/*
+# The warm-start suite is a Python harness rather than a directory of .nl:
+# its sources (including the two package subdirectories) are tracked, its
+# per-run results.json / results.md outputs are regenerated and ignored
+# like every other suite's.
+!/benchmarks/warmstart/*.py
+!/benchmarks/warmstart/families/
+!/benchmarks/warmstart/families/*.py
+!/benchmarks/warmstart/adapters/
+!/benchmarks/warmstart/adapters/*.py
 # Track the generated performance-profile figures: the earlier
 # `!/benchmarks/figures/*` (line ~37) is defeated by the broader
 # `/benchmarks/*/*` rule above, so re-assert it here, after that rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+### Added — a benchmark for warm starting, and the counter that makes it measurable
+
+- **`benchmarks/warmstart/` — the first suite in the tree that is not a
+  cold-solve set.** Every existing suite measures one problem, one solve,
+  from scratch; warm starting only means anything over a *sequence* of
+  related solves. The unit of work here is a parametric family plus a
+  scripted path through its parameter space, solved end to end by four arms
+  (`cold-ipm`, `cold-sqp`, `warm-ipm`, `warm-sqp`) so the warm-start effect
+  is separated from the algorithm change. Six families cover the active-set
+  regimes that decide whether warm starting pays — stable, flipping,
+  degenerate (a path that passes exactly through a zero multiplier), a clean
+  activation switch, and a closed-loop NMPC sequence — each at three step
+  sizes, because payoff is a function of how far the problem moved. Nothing
+  outside `adapters/` imports a solver. See `benchmarks/warmstart/README.md`
+  and `dev-notes/warm-start-benchmark.md`; a survey of the existing
+  literature is in the latter (nothing public covers this case).
+- **`info["n_qp_solves"]` and `info["n_qp_ws_changes"]` on the Python
+  path**, backed by `SqpResult::n_qp_working_set_changes` and
+  `SolveStatistics::sqp_qp_solves` / `sqp_qp_working_set_changes`. The inner
+  active-set work an SQP warm start exists to avoid was previously not
+  observable from any user-facing surface: `pounce-qp` counted per-QP
+  working-set changes, nothing accumulated them. Outer `iter_count` is not a
+  substitute — on a QP-shaped NLP the outer loop terminates in one iteration
+  warm or cold, so a cold/warm comparison reads exactly 1.00× while the
+  inner work differs by an order of magnitude (`simplex_proj`: 313 → 4
+  active-set changes; `nmpc_vanderpol`: 931 → 66). Both keys are 0 on the
+  interior-point path, which solves no QP subproblems.
 ### Fixed — exact-Hessian SQP gave up on unconstrained nonconvex NLPs (#423)
 
 - **`algorithm = active-set-sqp` with `sqp_hessian = exact` no longer stops at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,13 @@ changes.
   related solves. The unit of work here is a parametric family plus a
   scripted path through its parameter space, solved end to end by four arms
   (`cold-ipm`, `cold-sqp`, `warm-ipm`, `warm-sqp`) so the warm-start effect
-  is separated from the algorithm change. Six families cover the active-set
+  is separated from the algorithm change. Eight families cover the active-set
   regimes that decide whether warm starting pays — stable, flipping,
   degenerate (a path that passes exactly through a zero multiplier), a clean
-  activation switch, and a closed-loop NMPC sequence — each at three step
-  sizes, because payoff is a function of how far the problem moved. Nothing
+  activation switch, re-activation from an empty working set, an entirely
+  unconstrained path (`m = 0`, the zero mark the other speedups are read
+  against), and a closed-loop NMPC sequence — each at three step sizes,
+  because payoff is a function of how far the problem moved. Nothing
   outside `adapters/` imports a solver. See `benchmarks/warmstart/README.md`
   and `dev-notes/warm-start-benchmark.md`; a survey of the existing
   literature is in the latter (nothing public covers this case).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ changes.
   related solves. The unit of work here is a parametric family plus a
   scripted path through its parameter space, solved end to end by four arms
   (`cold-ipm`, `cold-sqp`, `warm-ipm`, `warm-sqp`) so the warm-start effect
-  is separated from the algorithm change. Eight families cover the active-set
+  is separated from the algorithm change, plus two more (`cold-qp-ipm` /
+  `warm-qp-ipm`) that route the QP-shaped families through the dedicated
+  convex solver for a three-way comparison. Eight families cover the active-set
   regimes that decide whether warm starting pays — stable, flipping,
   degenerate (a path that passes exactly through a zero multiplier), a clean
   activation switch, re-activation from an empty working set, an entirely

--- a/benchmarks/Makefile
+++ b/benchmarks/Makefile
@@ -59,6 +59,7 @@ export IPOPT_LINEAR_SOLVER
 	ipopt-reference ipopt-reference-provenance \
 	$(addprefix ipopt-ref-,$(REF_SUITES)) \
 	gams-bench gams-rerun \
+	warmstart-run warmstart-quick warmstart-selftest warmstart-report \
 	clean-bench clean-bench-large-scale clean-bench-nl clean-bench-report
 
 # Show available targets
@@ -91,6 +92,10 @@ help:
 	@echo "  lp-generate                (Re)generate the lp .nl files only (needs highspy/pyomo; downloads MPS)"
 	@echo "  lp-convex-run   / -rerun   LP head-to-head: pounce-convex (lp-ipm) vs pounce-nlp (reuses lp .nl)"
 	@echo "  qp-convex-run   / -rerun   QP head-to-head: pounce-convex (qp-ipm) vs pounce-nlp (reuses qp .nl)"
+	@echo "  warmstart-run              Warm-start suite: parametric NLP sequences, cold vs warm (needs the built Python ext)"
+	@echo "  warmstart-quick            Warm-start suite, short sweep (3 families, one scale)"
+	@echo "  warmstart-selftest         Finite-difference check of the warm-start families (no solver needed)"
+	@echo "  warmstart-report           Re-render warmstart/results.md from the existing results.json"
 	@echo "  lpopt-run       / -rerun   HARD Mittelmann lpopt LP subset (stress tier; use BENCH_TIMELIMIT=1800)"
 	@echo "  lpopt-generate             (Re)generate the lpopt .nl files only (downloads MPS from plato lptestset)"
 	@echo "  gams-bench      / gams-rerun  GAMS solver-link smoke check (10 problems; not in the report)"
@@ -318,6 +323,31 @@ qp-convex-run: $(QP_CONVEX_DIR)/convex.json $(QP_CONVEX_DIR)/nlp.json
 qp-convex-rerun:
 	rm -f $(QP_CONVEX_DIR)/convex.json $(QP_CONVEX_DIR)/nlp.json
 	$(MAKE) qp-convex-run
+
+# ---- warm-start suite ----------------------------------------------------
+# The only suite that is not .nl-driven: warm starting is a property of a
+# *sequence* of related solves, and carrying a working set between solves
+# needs an in-process handle, which the .nl CLI path does not offer. The
+# harness therefore drives the Python extension directly — build it first
+# with `cd python && maturin develop --release`. PYTHON can be pointed at
+# whichever interpreter has that extension installed.
+#
+# Outputs (warmstart/results.json, warmstart/results.md) are regenerated
+# per run and gitignored, like every other suite's results.
+PYTHON ?= python3
+
+warmstart-selftest:
+	cd $(CURDIR) && $(PYTHON) -m warmstart.selftest
+
+warmstart-run: warmstart-selftest
+	cd $(CURDIR) && $(PYTHON) -m warmstart.run -v
+
+warmstart-quick:
+	cd $(CURDIR) && $(PYTHON) -m warmstart.run --quick -v
+
+warmstart-report:
+	cd $(CURDIR) && $(PYTHON) -m warmstart.report \
+		warmstart/results.json -o warmstart/results.md
 
 # Mittelmann lpopt LP suite — the curated HARD subset of Hans Mittelmann's
 # lpopt benchmark (https://plato.asu.edu/ftp/lpopt.html). These are large,

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -97,6 +97,14 @@ reference](#pounce-runs-vs-the-ipopt-reference) below.
 | [`lp/`](lp/README.md)               | Linear programs (Netlib + small Mészáros) | small, known optima | LP *validation* set — small classic LPs pounce solves to optimality; `.nl` converted from MPS via `generate_nl.py` |
 | [`lpopt/`](lpopt/README.md)         | Hard linear programs (Mittelmann lpopt) | large/degenerate subset | LP *stress* tier from the plato lpopt benchmark (even HiGHS/ipopt time out at short limits); run with a long limit |
 | [`water/`](water/README.md)         | Water-network design | 6 problems | MINLPLib instances, signomial nonlinearities |
+| [`warmstart/`](warmstart/README.md) | Parametric NLP **sequences** | 6 families × 3 step sizes | The one suite that is not a cold-solve set: measures warm starting (cold vs warm × IPM vs active-set SQP) over paths of related NLPs. Python-driven, not `.nl` |
+
+The `warmstart/` suite sits outside the `.nl` machinery entirely — it
+has no Ipopt reference and does not feed the composite report, because
+it measures a different thing (the cost of a *sequence* of related
+solves, cold vs warm) and needs an in-process solver handle to carry a
+working set between steps. It has its own report at
+`warmstart/results.md`; see [`warmstart/README.md`](warmstart/README.md).
 
 The GAMS nlpbench harness ([`gams/nlpbench/`](../gams/nlpbench/)) is no
 longer aggregated into the composite report — its problem coverage

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -1,0 +1,184 @@
+# Warm-start benchmark
+
+Every other suite in `benchmarks/` measures **cold** solves: one
+problem, one solve, from scratch. This one measures the thing that
+only exists in sequences — how much a solver saves by starting from
+the previous problem's solution, and whether it stays correct while
+doing so.
+
+The unit of work is a **parametric family plus a path**: one NLP
+shape, one scripted sweep through its parameter space, solved end to
+end. That is deliberate. Warm starting has no meaning for a single
+isolated NLP, and the property that decides whether it pays — how the
+active set moves from one instance to the next — only exists along a
+path.
+
+## Why this suite exists at all
+
+There is no standard warm-start benchmark for NLP solvers to reuse. The
+nearest public things and why each does not cover it:
+
+| Existing | What it is | Gap |
+|---|---|---|
+| [qpbenchmark](https://github.com/qpsolvers/qpbenchmark) test sets ([MPC](https://github.com/qpsolvers/mpc_qpbenchmark), [IK](https://github.com/qpsolvers/ik_qpbenchmark), Maros-Mészáros, free-for-all) | Curated QP sets + runner | QP level, not NLP. Instances ship stripped of their sequence structure; the MPC set's README states outright that it "does not reflect the warm-starting that is frequently used on robots that do model predictive control". |
+| [WARP](https://arxiv.org/abs/2605.05728) (2026) | Benchmark for primal-dual warm starting of interior-point solvers | Closest in spirit, but interior-point only (it predicts the barrier state), AC-OPF only, and organized around *learned* predictions over i.i.d. instances rather than consecutive perturbations. No active set. |
+| [Not All Warm Starts Help](https://arxiv.org/abs/2606.08984) (2026) | Evaluation of primal-dual initializations for ACOPF | An evaluation, not a reusable set. Its central finding — warm starts frequently make things worse — is why this suite reports regressions as a first-class column. |
+| [OPFData](https://arxiv.org/abs/2406.07234) / PGLearn | 300k solved AC-OPF instances per grid, loads perturbed 80–120%, plus N-1 topologies | A dataset with no protocol or metrics, single problem class, independent samples rather than a path. |
+| CUTEst, Hock-Schittkowski, Vanderbei, Mittelmann, Maros-Mészáros | The standard NLP/QP collections (several already in `benchmarks/`) | Every problem is one cold solve. No parameter, no sequence. |
+
+## The four arms
+
+| arm | algorithm | seeded with |
+|---|---|---|
+| `cold-ipm` | interior point | nothing — the family's cold start |
+| `cold-sqp` | active-set SQP | nothing |
+| `warm-ipm` | interior point | previous step's primal-dual point and μ |
+| `warm-sqp` | active-set SQP | previous step's working set and point |
+
+Both cold arms are there so the warm-start effect can be separated
+from the algorithm change. `warm-sqp` beating `cold-ipm` proves
+nothing on its own — it mixes "warm started" with "switched
+algorithms". Each warm arm is therefore scored against its *own* cold
+counterpart.
+
+`cold-ipm` is also the **reference arm**: the arm every other is
+compared against, and the arm that generates the parameter path for
+closed-loop families. It is a baseline, not ground truth — on a
+nonconvex family it can and does converge to a worse local minimum
+than another arm finds, which is why correctness is judged the way it
+is below.
+
+## What is measured
+
+**Primary — inner active-set work.** `Σ` active-set changes (adds +
+drops) inside the QP subproblems, from `info["n_qp_ws_changes"]`.
+This is what a working-set warm start actually reduces. Outer SQP
+iterations are *not* a sufficient metric: on a family whose subproblem
+is already a QP, the outer loop terminates in one iteration whether it
+was warm started or not, so that column is flat by construction while
+the inner work varies by more than an order of magnitude.
+
+**Secondary** — outer iterations, evaluation counts (counted by the
+harness, not the solver, so they mean the same thing across solvers),
+wall time. At these problem sizes wall time is dominated by the Python
+callback round trip; read it as a cross-check, not a result.
+
+**Correctness**, and this is the point of the suite as much as the
+speed is. A warm start that converges fast to the wrong answer is not
+a win. Each step must:
+
+1. return a success status,
+2. actually achieve a small KKT residual and be feasible — checked by
+   the harness against `--kkt-gate` / `--viol-gate`, independent of
+   what the solver claims,
+3. not land on a *worse* optimum than the reference arm (by more than
+   `--obj-tol`).
+
+Finding a **better** optimum than the reference is not an error; it is
+reported in its own column. `‖x − x_ref‖` is recorded as a diagnostic
+but is not a gate, because two solves can both be optimal and still
+differ in `x` — a degenerate face, a flat direction.
+
+**Regressions.** Steps where the warm arm cost *more* than the cold
+one are counted and listed individually. A benchmark that reports only
+the mean speedup hides the failure mode that matters most.
+
+## The families
+
+| family | n | m | regime | channel | curvature |
+|---|--:|--:|---|---|---|
+| `simplex_proj` | 20 | 1 | flipping | objective | convex |
+| `moving_bound_qp` | 40 | 3 | flipping | bounds | convex |
+| `degenerate_corner` | 6 | 3 | degenerate | objective | convex |
+| `hanging_chain` | 30 | 15 | flipping | mixed | convex |
+| `rosenbrock_ring` | 10 | 1 | switch | rhs | nonconvex |
+| `nmpc_vanderpol` | 47 | 32 | closed-loop | rhs | nonconvex |
+
+*regime* is how the active set behaves along the path; *channel* is
+where the parameter enters (objective, constraint right-hand side,
+variable bounds, or several); *curvature* is the obvious thing.
+
+Each family runs at three **scales**, which multiply its natural
+per-step parameter increment: `tiny` (0.1), `small` (1.0), `large`
+(4.0). Warm-start payoff is a function of how far the problem moved,
+so a single step size would measure one point on a curve and call it
+the answer. `tiny` is the continuation regime where the active set
+barely moves; `large` is where it churns and warm starting can hurt.
+
+Two families are worth knowing about in detail:
+
+- **`degenerate_corner`** is a correctness probe, not a speed probe.
+  Its path passes exactly through a point where one constraint's and
+  one bound's multipliers are zero — strict complementarity fails, and
+  the multiplier-sign classifier that builds a working set from a
+  converged iterate has no signal to work with. The midpoint step
+  lands on the degeneracy at *every* scale, by construction.
+- **`nmpc_vanderpol`** is the only family whose path is not scripted:
+  the next parameter is the state the plant reaches after applying the
+  control the previous solve produced. Because that makes the path
+  depend on the solutions, the runner records the sequence the
+  reference arm produces and **replays** it for the other arms — the
+  arms would otherwise be solving different problems.
+
+## Running it
+
+The harness drives the solver in-process through the Python API (the
+CLI has no cross-process working-set carry for `.nl` files, so unlike
+every other suite this one is not `.nl`-driven). It needs the Python
+extension built:
+
+    cd python && maturin develop --release
+
+Then, from `benchmarks/`:
+
+    make -C benchmarks warmstart-selftest   # derivative checks, no solver needed
+    make -C benchmarks warmstart-run        # full sweep -> results.json + results.md
+    make -C benchmarks warmstart-quick      # 3 families, one scale
+
+or directly, for a narrower run:
+
+    python -m warmstart.run --families simplex_proj,nmpc_vanderpol --scales large -v
+    python -m warmstart.run --arms cold-sqp,warm-sqp --tol 1e-10
+    python -m warmstart.report results.json      # re-render without re-running
+
+`results.json` (every step of every arm) and `results.md` are
+regenerated per run and gitignored, like every other suite's outputs.
+
+## Adding a family
+
+Subclass `ParametricFamily` in `families/`, supplying the usual
+cyipopt-shaped callbacks in **dense** form — the harness derives the
+sparsity patterns and packed value vectors from them, so the structure
+and the values cannot fall out of sync. List the class in
+`families/__init__.py`, then:
+
+    python -m warmstart.selftest
+
+which finite-difference checks the gradient, Jacobian and Hessian of
+the Lagrangian at several points along the path. A wrong derivative in
+a benchmark family does not announce itself — it shows up as "the warm
+arm needed more iterations", which is the exact signal the suite
+exists to measure. Run it before believing any result.
+
+## Adding a solver
+
+Implement `SolverAdapter` in `adapters/` and register it in
+`adapters/__init__.py`. Nothing outside `adapters/` imports a solver:
+families, the protocol, and the report are solver-agnostic, and the
+warm-start payload that crosses between steps (`WarmState`) is a plain
+data record — primal point, multipliers, barrier parameter, working
+set — that an adapter consumes as much of as its solver understands.
+Arms an adapter does not support are reported as skipped rather than
+silently dropped.
+
+## Known result worth not forgetting
+
+`rosenbrock_ring` starts from the origin, not Rosenbrock's traditional
+`(−1.2, 1, −1.2, …)`. From the traditional start, pounce's SQP path
+with the default exact Hessian gives up with
+`Search_Direction_Becomes_Too_Small` at every step of the path, at a
+point with a stationarity residual of ~2.6, while `damped-bfgs` and
+`lbfgs` converge from it fine. That is a cold-robustness finding, not
+a warm-start one, and letting it sit inside this family would replace
+the measurement with a wall of failures. It is written up in
+`dev-notes/warm-start-benchmark.md`.

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -28,18 +28,34 @@ nearest public things and why each does not cover it:
 
 ## The four arms
 
-| arm | algorithm | seeded with |
-|---|---|---|
-| `cold-ipm` | interior point | nothing — the family's cold start |
-| `cold-sqp` | active-set SQP | nothing |
-| `warm-ipm` | interior point | previous step's primal-dual point and μ |
-| `warm-sqp` | active-set SQP | previous step's working set and point |
+| arm | algorithm | seeded with | runs on |
+|---|---|---|---|
+| `cold-ipm` | general NLP filter-IPM | nothing — the family's cold start | every family |
+| `cold-sqp` | active-set SQP | nothing | every family |
+| `warm-ipm` | general NLP filter-IPM | previous step's primal-dual point and μ | every family |
+| `warm-sqp` | active-set SQP | previous step's working set and point | every family |
+| `cold-qp-ipm` | dedicated convex QP IPM (`pounce.solve_qp`) | nothing | QP families only |
+| `warm-qp-ipm` | dedicated convex QP IPM | previous step's primal-dual point | QP families only |
 
 Both cold arms are there so the warm-start effect can be separated
 from the algorithm change. `warm-sqp` beating `cold-ipm` proves
 nothing on its own — it mixes "warm started" with "switched
 algorithms". Each warm arm is therefore scored against its *own* cold
 counterpart.
+
+The two `qp-ipm` arms are the dedicated convex solver, and they are
+different in kind from the other four: they take the problem as
+matrices rather than through callbacks. `qpform.py` extracts
+`(P, c, A, b, G, h, lb, ub)` from a family whose instances are QPs —
+verified by the self-test, which re-derives the family's objective,
+gradient, and every constraint row from the extracted data rather than
+trusting the family's `quadratic = True` claim. Families that are not
+QPs skip these arms with a stated reason. Two consequences worth
+holding on to when reading the numbers: the QP arms evaluate the model
+*once per step* where the others re-evaluate every iteration, and an
+interior-point iteration and an active-set pivot are not the same unit
+of work. That is why they live in their own report section, compared
+mainly against themselves cold-vs-warm.
 
 `cold-ipm` is also the **reference arm**: the arm every other is
 compared against, and the arm that generates the parameter path for

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -92,6 +92,8 @@ the mean speedup hides the failure mode that matters most.
 | `degenerate_corner` | 6 | 3 | degenerate | objective | convex |
 | `hanging_chain` | 30 | 15 | flipping | mixed | convex |
 | `rosenbrock_ring` | 10 | 1 | switch | rhs | nonconvex |
+| `rosenbrock_ring_cycle` | 10 | 1 | re-activation | rhs | nonconvex |
+| `double_well_chain` | 12 | 0 | none (empty active set) | objective | nonconvex |
 | `nmpc_vanderpol` | 47 | 32 | closed-loop | rhs | nonconvex |
 
 *regime* is how the active set behaves along the path; *channel* is
@@ -105,6 +107,29 @@ so a single step size would measure one point on a curve and call it
 the answer. `tiny` is the continuation regime where the active set
 barely moves; `large` is where it churns and warm starting can hurt.
 
+### What the active-set regimes actually cover
+
+Read off the working sets the solver returns, not off the intent:
+
+| situation | where it is exercised |
+|---|---|
+| equality rows, permanently in the working set | `nmpc_vanderpol` (32), `moving_bound_qp` (3), `simplex_proj` (1) |
+| variable bounds activating and releasing | `simplex_proj` (15→19 clamped), `moving_bound_qp` (2→22), `nmpc_vanderpol` (control saturation) |
+| inequality rows activating and releasing | `hanging_chain` (3→12 ground contacts), `degenerate_corner`, both Rosenbrock families |
+| active set held *fixed* for a whole path | `simplex_proj` and `hanging_chain` at `tiny` — 0 changes across the path |
+| a single clean active→inactive switch | `rosenbrock_ring`, on the midpoint step at every scale |
+| inactive→active **re-activation** | `rosenbrock_ring_cycle`, which crosses the switch out and back |
+| **empty** active set, whole path, no constraint rows at all | `double_well_chain` (`m = 0`, no finite bounds) |
+
+The last two exist because their absence was a real hole. A
+monotone sweep only ever tests active→inactive; carrying an *empty*
+working set into a step that needs a non-empty one is the harder
+direction and now has a family. And with every family carrying at
+least one constraint row, the suite never executed the unconstrained
+configuration at all — which is both the zero mark the speedups
+should be read against and, per pounce#416, a configuration with real
+defects hiding in it.
+
 Two families are worth knowing about in detail:
 
 - **`degenerate_corner`** is a correctness probe, not a speed probe.
@@ -113,6 +138,14 @@ Two families are worth knowing about in detail:
   the multiplier-sign classifier that builds a working set from a
   converged iterate has no signal to work with. The midpoint step
   lands on the degeneracy at *every* scale, by construction.
+- **`double_well_chain`** is the control, and it inverts the usual
+  reading of the report. With no constraints there is no working set
+  to carry, so the QP-active-set column is 0 for both arms and the
+  entire warm-start effect lands in *outer* iterations instead —
+  cold 480 → warm 62 at `tiny`. The QP-shaped families are the mirror
+  image (flat outer, all effect inner). Any interpretation of these
+  numbers that only looks at one of the two columns is wrong on half
+  the suite.
 - **`nmpc_vanderpol`** is the only family whose path is not scripted:
   the next parameter is the state the plant reaches after applying the
   control the previous solve produced. Because that makes the path

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -220,14 +220,29 @@ set — that an adapter consumes as much of as its solver understands.
 Arms an adapter does not support are reported as skipped rather than
 silently dropped.
 
-## Known result worth not forgetting
+## Two solver defects this suite has caught
 
-`rosenbrock_ring` starts from the origin, not Rosenbrock's traditional
-`(−1.2, 1, −1.2, …)`. From the traditional start, pounce's SQP path
-with the default exact Hessian gives up with
-`Search_Direction_Becomes_Too_Small` at every step of the path, at a
-point with a stationarity residual of ~2.6, while `damped-bfgs` and
-`lbfgs` converge from it fine. That is a cold-robustness finding, not
-a warm-start one, and letting it sit inside this family would replace
-the measurement with a wall of failures. It is written up in
-`dev-notes/warm-start-benchmark.md`.
+Both in the same configuration — nonconvex, indefinite Hessian, nothing
+active — which is why `double_well_chain` exists.
+
+1. **pounce#416, fixed.** From Rosenbrock's traditional
+   `(-1.2, 1, -1.2, ...)` start, the exact-Hessian SQP path gave up with
+   `Search_Direction_Becomes_Too_Small` at every step, at a stationarity
+   residual of ~2.6, while the quasi-Newton modes converged fine. The
+   inner QP was spending its entire 200-iteration budget making **zero**
+   working-set changes; a cap of 20 produced bit-identical answers ~9x
+   faster. Fixed in pounce#419 by capping the ratio test at the shifted
+   step's true minimizer instead of at alpha = 1. `rosenbrock_ring` still
+   starts from the origin, now only for continuity of its recorded
+   numbers.
+
+2. **pounce#423, open.** The fix for #416 regressed the *unconstrained*
+   case: with `m = 0` and no finite bounds, a negative-curvature
+   direction has nothing to block it, so the new recession-certificate
+   path is taken at every indefinite iterate and the solve dies at
+   iteration 1 (f = 26.03 against the IPM's 0.027). Pre-#419 it
+   converged in 24 iterations. Every `double_well_chain` row in the
+   report currently shows `bad = 20` because of it; the other 21 rows
+   are unaffected.
+
+Full write-ups in `dev-notes/warm-start-benchmark.md`.

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -220,29 +220,41 @@ set — that an adapter consumes as much of as its solver understands.
 Arms an adapter does not support are reported as skipped rather than
 silently dropped.
 
-## Two solver defects this suite has caught
+## Three solver defects this suite has caught
 
-Both in the same configuration — nonconvex, indefinite Hessian, nothing
-active — which is why `double_well_chain` exists.
+All three are fixed. They are recorded because the shapes recur, and
+because two of them lived in the same configuration — nonconvex,
+indefinite Hessian, nothing active — which is why `double_well_chain`
+exists.
 
-1. **pounce#416, fixed.** From Rosenbrock's traditional
+1. **pounce#416, fixed in #419.** From Rosenbrock's traditional
    `(-1.2, 1, -1.2, ...)` start, the exact-Hessian SQP path gave up with
-   `Search_Direction_Becomes_Too_Small` at every step, at a stationarity
-   residual of ~2.6, while the quasi-Newton modes converged fine. The
-   inner QP was spending its entire 200-iteration budget making **zero**
-   working-set changes; a cap of 20 produced bit-identical answers ~9x
-   faster. Fixed in pounce#419 by capping the ratio test at the shifted
-   step's true minimizer instead of at alpha = 1. `rosenbrock_ring` still
-   starts from the origin, now only for continuity of its recorded
-   numbers.
+   `Search_Direction_Becomes_Too_Small` at every step. The inner QP was
+   spending its entire 200-iteration budget making **zero** working-set
+   changes; a cap of 20 produced bit-identical answers ~9x faster. Fixed
+   by capping the ratio test at the shifted step's true minimizer
+   instead of at alpha = 1. `rosenbrock_ring` still starts from the
+   origin, now only for continuity of its recorded numbers.
 
-2. **pounce#423, open.** The fix for #416 regressed the *unconstrained*
-   case: with `m = 0` and no finite bounds, a negative-curvature
-   direction has nothing to block it, so the new recession-certificate
-   path is taken at every indefinite iterate and the solve dies at
-   iteration 1 (f = 26.03 against the IPM's 0.027). Pre-#419 it
-   converged in 24 iterations. Every `double_well_chain` row in the
-   report currently shows `bad = 20` because of it; the other 21 rows
-   are unaffected.
+2. **pounce#423, fixed in #424.** The fix for #416 regressed the
+   *unconstrained* case: with `m = 0` and no finite bounds a
+   negative-curvature direction has nothing to block it, so the new
+   recession-certificate path was taken at every indefinite iterate and
+   the solve died at iteration 1 (f = 26.03 against the IPM's 0.027).
+   `double_well_chain` caught it on its first run against the new base,
+   the day after it was added. The fix gives the driver a third branch
+   for "model recedes, NLP does not"; the family is back to its
+   pre-#419 numbers exactly.
+
+3. **pounce#417, fixed in #422.** `solve_qp`'s warm start was leaving
+   ~40% of its iterations unclaimed — not because of the seeding, which
+   is sound, but because the corrector's fraction-to-boundary parameter
+   was pinned at 0.95, capping progress at ~20x per iteration however
+   good the start was. Fixed by letting tau approach 1 as mu -> 0 on
+   orthant blocks (the restriction matters: doing it for every cone kind
+   loses 60% of the SOC instances the direct driver solves). The shipped
+   fix reproduced this suite's predicted iteration counts exactly — 46,
+   75 and 96 warm iterations on `simplex_proj`, against 46, 75 and 96
+   measured from the prototype.
 
 Full write-ups in `dev-notes/warm-start-benchmark.md`.

--- a/benchmarks/warmstart/__init__.py
+++ b/benchmarks/warmstart/__init__.py
@@ -1,0 +1,20 @@
+"""Warm-start benchmark suite.
+
+A benchmark for solving *sequences* of related NLPs, which is the only
+setting in which warm starting means anything. See ``README.md`` for
+the protocol, the arms, and what the numbers do and do not show.
+
+Layout::
+
+    spec.py       solver-agnostic core types (no pounce import)
+    sparsity.py   dense family callbacks -> sparse, instrumented ones
+    families/     the parametric families
+    adapters/     solver plug-ins; adapters/pounce_adapter.py is the only
+                  module that imports a solver
+    runner.py     the measurement protocol
+    report.py     JSON -> markdown
+    run.py        command line entry point
+    selftest.py   finite-difference derivative checks (no solver needed)
+"""
+
+__all__ = ["spec", "sparsity", "families", "adapters", "runner", "report"]

--- a/benchmarks/warmstart/adapters/__init__.py
+++ b/benchmarks/warmstart/adapters/__init__.py
@@ -1,0 +1,17 @@
+"""Solver adapters. Import the concrete one lazily so the core stays
+importable (and the families' derivative self-test runnable) on a
+machine with no solver installed."""
+
+from __future__ import annotations
+
+from .base import ARMS, REFERENCE_ARM, SolverAdapter, is_warm
+
+__all__ = ["ARMS", "REFERENCE_ARM", "SolverAdapter", "is_warm", "get_adapter"]
+
+
+def get_adapter(name: str, **kwargs) -> SolverAdapter:
+    if name == "pounce":
+        from .pounce_adapter import PounceAdapter
+
+        return PounceAdapter(**kwargs)
+    raise KeyError(f"unknown solver adapter {name!r} (known: pounce)")

--- a/benchmarks/warmstart/adapters/base.py
+++ b/benchmarks/warmstart/adapters/base.py
@@ -28,6 +28,15 @@ defines:
 ``warm-sqp``
     Active-set SQP seeded with the previous step's working set and
     primal point. The capability under test.
+``cold-qp-ipm`` / ``warm-qp-ipm``
+    The dedicated convex QP interior-point solver, handed the problem
+    in matrix form rather than through callbacks, cold and seeded with
+    the previous step's primal-dual point. Only defined for families
+    whose instances are literally QPs (``ParametricFamily.quadratic``);
+    on any other family these arms are skipped with a reason rather
+    than silently omitted. Note the asymmetry when reading wall time:
+    this arm receives the problem data once per step, where the
+    callback-driven arms re-evaluate every iteration.
 
 An adapter declares which arms it supports; unsupported arms are
 skipped and reported as such rather than silently omitted.
@@ -43,7 +52,17 @@ import numpy as np
 from ..spec import ParametricFamily, StepResult, WarmState
 from ..sparsity import SparseCallbacks
 
-ARMS: List[str] = ["cold-ipm", "cold-sqp", "warm-ipm", "warm-sqp"]
+ARMS: List[str] = [
+    "cold-ipm",
+    "cold-sqp",
+    "warm-ipm",
+    "warm-sqp",
+    "cold-qp-ipm",
+    "warm-qp-ipm",
+]
+
+#: Arms that need the family's instances to be QPs.
+QP_ARMS = ("cold-qp-ipm", "warm-qp-ipm")
 
 #: The arm whose per-step solutions every other arm is checked
 #: against, and which generates the parameter path for adaptive
@@ -53,6 +72,20 @@ REFERENCE_ARM = "cold-ipm"
 
 def is_warm(arm: str) -> bool:
     return arm.startswith("warm")
+
+
+def arm_applies(arm: str, family: ParametricFamily) -> Optional[str]:
+    """``None`` if the arm is defined for this family, else why not.
+
+    Separate from :meth:`SolverAdapter.supports`, which is about what
+    the *solver* can do. This is about what the *problem* admits: a
+    convex QP solver has nothing to say about a family with nonlinear
+    constraints, and running it there would be a category error rather
+    than a slow result.
+    """
+    if arm in QP_ARMS and not family.quadratic:
+        return "family is not a QP (nonlinear objective or constraints)"
+    return None
 
 
 class SolverAdapter(ABC):

--- a/benchmarks/warmstart/adapters/base.py
+++ b/benchmarks/warmstart/adapters/base.py
@@ -1,0 +1,86 @@
+"""The solver plug-in interface.
+
+An adapter's job is to solve one instance of a family at its current
+parameter, optionally seeded with a :class:`~..spec.WarmState`, and
+report back in the suite's own vocabulary. Everything
+solver-specific — option names, warm-start plumbing, status codes,
+working-set encodings — is confined to the adapter, which is what
+makes it possible to add Ipopt (or anything else) to this benchmark
+without touching a family.
+
+Arms
+----
+
+An *arm* is a (algorithm, warm-start) pairing. The four the suite
+defines:
+
+``cold-ipm``
+    Interior point, every step from the family's cold starting point.
+    This is the baseline: it is what a solver without warm-start
+    support does, and it is also the correctness reference.
+``cold-sqp``
+    Active-set SQP, every step cold. Present so that the warm-start
+    effect can be separated from the algorithm change — without it,
+    ``warm-sqp`` beating ``cold-ipm`` would confound the two.
+``warm-ipm``
+    Interior point seeded with the previous step's primal-dual point
+    and barrier parameter. The fair comparison for ``warm-sqp``.
+``warm-sqp``
+    Active-set SQP seeded with the previous step's working set and
+    primal point. The capability under test.
+
+An adapter declares which arms it supports; unsupported arms are
+skipped and reported as such rather than silently omitted.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from ..spec import ParametricFamily, StepResult, WarmState
+from ..sparsity import SparseCallbacks
+
+ARMS: List[str] = ["cold-ipm", "cold-sqp", "warm-ipm", "warm-sqp"]
+
+#: The arm whose per-step solutions every other arm is checked
+#: against, and which generates the parameter path for adaptive
+#: families.
+REFERENCE_ARM = "cold-ipm"
+
+
+def is_warm(arm: str) -> bool:
+    return arm.startswith("warm")
+
+
+class SolverAdapter(ABC):
+    """Solve one parametric instance, cold or warm."""
+
+    #: Name used in output files and the report.
+    name: str = "unnamed"
+
+    @abstractmethod
+    def supports(self, arm: str) -> bool:
+        """Whether this adapter can run the given arm."""
+
+    @abstractmethod
+    def solve(
+        self,
+        family: ParametricFamily,
+        callbacks: SparseCallbacks,
+        arm: str,
+        x0: np.ndarray,
+        warm: Optional[WarmState],
+        step: int,
+        tol: float,
+    ) -> Tuple[StepResult, Optional[WarmState]]:
+        """Solve at the family's current θ.
+
+        Returns the step's measurements and the state to hand to the
+        next step (``None`` if this arm carries nothing forward). The
+        adapter fills every :class:`~..spec.StepResult` field except
+        the correctness ones, which the runner supplies once the
+        reference solution is known.
+        """

--- a/benchmarks/warmstart/adapters/pounce_adapter.py
+++ b/benchmarks/warmstart/adapters/pounce_adapter.py
@@ -9,6 +9,8 @@ cold-ipm     ``interior-point`` (default)         none
 cold-sqp     ``active-set-sqp``                   none
 warm-ipm     ``interior-point``                   ``WarmStart`` (x, λ, z, μ)
 warm-sqp     ``active-set-sqp``                   working set + previous x
+cold-qp-ipm  ``pounce.solve_qp`` (pounce-convex)  none
+warm-qp-ipm  ``pounce.solve_qp``                  previous ``QpResult``
 ===========  ===================================  =========================
 
 Two deliberate choices worth knowing when reading the numbers:
@@ -20,6 +22,20 @@ Two deliberate choices worth knowing when reading the numbers:
   is timed. It also sidesteps the fact that ``WarmStart`` applies its
   enabling options through ``add_option``, which would otherwise
   persist on a reused handle and quietly contaminate a later solve.
+
+* **The QP arms do not go through the callback interface at all.** The
+  convex solver takes matrix data, so each step assembles ``(P, c, A,
+  b, G, h, lb, ub)`` from the family (see :mod:`..qpform`) and hands it
+  over. The assembly is inside the timed region and routed through the
+  harness's counters, because it is work a caller genuinely has to do —
+  but it happens *once per step*, where the callback-driven arms
+  re-evaluate every iteration. That is a real advantage of the QP path
+  on a QP, not a measurement artifact, and it is why the report keeps
+  these arms in their own section rather than in the headline table.
+  ``check_psd`` is off: the suite's self-test already proves ``P`` is
+  positive semidefinite for every family that claims to be a QP, so
+  leaving the guard on would time an O(n³) eigenvalue decomposition
+  that a caller who knew their problem would not pay.
 
 * **Tolerances are pinned on both paths** rather than left at their
   defaults, since the two paths have separate convergence-test knobs
@@ -38,12 +54,16 @@ import numpy as np
 
 import pounce
 
+from .. import qpform
 from ..spec import ParametricFamily, StepResult, WarmState
 from ..sparsity import SparseCallbacks
-from .base import SolverAdapter, is_warm
+from .base import QP_ARMS, SolverAdapter, is_warm
 
 # ApplicationReturnStatus values that count as a solved step.
 _OK_STATUS = (0, 1)  # SolveSucceeded, SolvedToAcceptableLevel
+
+# `solve_qp` status strings that count as a solved step.
+_OK_QP_STATUS = ("optimal", "optimal_inaccurate")
 
 
 class PounceAdapter(SolverAdapter):
@@ -53,7 +73,14 @@ class PounceAdapter(SolverAdapter):
         self.max_iter = max_iter
 
     def supports(self, arm: str) -> bool:
-        return arm in ("cold-ipm", "cold-sqp", "warm-ipm", "warm-sqp")
+        return arm in (
+            "cold-ipm",
+            "cold-sqp",
+            "warm-ipm",
+            "warm-sqp",
+            "cold-qp-ipm",
+            "warm-qp-ipm",
+        )
 
     # -- problem construction --------------------------------------
 
@@ -82,6 +109,65 @@ class PounceAdapter(SolverAdapter):
             prob.add_option("max_iter", self.max_iter)
         return prob
 
+    # -- the convex-QP path ----------------------------------------
+
+    def _solve_qp_ipm(
+        self,
+        family: ParametricFamily,
+        callbacks: SparseCallbacks,
+        arm: str,
+        warm: Optional[WarmState],
+        step: int,
+        tol: float,
+    ) -> Tuple[StepResult, Optional[WarmState]]:
+        callbacks.reset_counts()
+        seed = warm.extra.get("qp") if (warm is not None and warm.extra) else None
+
+        t0 = time.perf_counter()
+        qp = qpform.extract(family, callbacks)
+        res = pounce.solve_qp(
+            P=qp.P,
+            c=qp.c,
+            A=qp.A,
+            b=qp.b,
+            G=qp.G,
+            h=qp.h,
+            lb=qp.lb,
+            ub=qp.ub,
+            tol=tol,
+            max_iter=self.max_iter,
+            warm_start=seed if is_warm(arm) else None,
+            check_psd=False,
+        )
+        elapsed = time.perf_counter() - t0
+
+        resid = res.residuals or {}
+        result = StepResult(
+            step=step,
+            theta=[],
+            success=res.status in _OK_QP_STATUS,
+            status=0 if res.status in _OK_QP_STATUS else -1,
+            status_msg=str(res.status),
+            iters=int(res.iters),
+            solve_time=elapsed,
+            # The QP form drops the objective's constant term; add it
+            # back or every objective comparison against the other arms
+            # is off by a per-step offset.
+            obj=float(res.obj) + qp.f0,
+            kkt_error=float(resid.get("kkt_error", np.nan)),
+            constr_viol=float(resid.get("primal_infeasibility", np.nan)),
+            # No working set: this is an interior-point method.
+            n_active=None,
+            n_qp_solves=None,
+            n_qp_ws_changes=None,
+            **callbacks.counts(),
+        )
+        next_warm = WarmState(
+            x=np.asarray(res.x, dtype=float).copy(),
+            extra={"qp": res},
+        )
+        return result, next_warm
+
     # -- one step --------------------------------------------------
 
     def solve(
@@ -94,6 +180,9 @@ class PounceAdapter(SolverAdapter):
         step: int,
         tol: float,
     ) -> Tuple[StepResult, Optional[WarmState]]:
+        if arm in QP_ARMS:
+            return self._solve_qp_ipm(family, callbacks, arm, warm, step, tol)
+
         prob = self._build(family, callbacks, arm, tol)
         callbacks.reset_counts()
 

--- a/benchmarks/warmstart/adapters/pounce_adapter.py
+++ b/benchmarks/warmstart/adapters/pounce_adapter.py
@@ -1,0 +1,181 @@
+"""POUNCE adapter — the only file in the suite that imports pounce.
+
+Maps the four arms onto pounce's two algorithm paths:
+
+===========  ===================================  =========================
+arm          ``algorithm``                        warm-start payload
+===========  ===================================  =========================
+cold-ipm     ``interior-point`` (default)         none
+cold-sqp     ``active-set-sqp``                   none
+warm-ipm     ``interior-point``                   ``WarmStart`` (x, λ, z, μ)
+warm-sqp     ``active-set-sqp``                   working set + previous x
+===========  ===================================  =========================
+
+Two deliberate choices worth knowing when reading the numbers:
+
+* **The ``Problem`` is rebuilt at every step.** Several families move
+  their variable or constraint bounds with θ, and bounds are fixed at
+  construction. Rebuilding everywhere keeps the arms symmetric, and
+  costs nothing in the measurement because only the ``solve()`` call
+  is timed. It also sidesteps the fact that ``WarmStart`` applies its
+  enabling options through ``add_option``, which would otherwise
+  persist on a reused handle and quietly contaminate a later solve.
+
+* **Tolerances are pinned on both paths** rather than left at their
+  defaults, since the two paths have separate convergence-test knobs
+  and an iteration-count comparison across differently-converged
+  solves means nothing. The achieved KKT error is recorded per step
+  so any residual asymmetry is visible in the data instead of being
+  taken on trust.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Optional, Tuple
+
+import numpy as np
+
+import pounce
+
+from ..spec import ParametricFamily, StepResult, WarmState
+from ..sparsity import SparseCallbacks
+from .base import SolverAdapter, is_warm
+
+# ApplicationReturnStatus values that count as a solved step.
+_OK_STATUS = (0, 1)  # SolveSucceeded, SolvedToAcceptableLevel
+
+
+class PounceAdapter(SolverAdapter):
+    name = "pounce"
+
+    def __init__(self, max_iter: int = 500):
+        self.max_iter = max_iter
+
+    def supports(self, arm: str) -> bool:
+        return arm in ("cold-ipm", "cold-sqp", "warm-ipm", "warm-sqp")
+
+    # -- problem construction --------------------------------------
+
+    def _build(self, family: ParametricFamily, callbacks, arm: str, tol: float):
+        b = family.bounds()
+        prob = pounce.Problem(
+            n=family.n,
+            m=family.m,
+            problem_obj=callbacks,
+            lb=b.lb,
+            ub=b.ub,
+            cl=b.cl,
+            cu=b.cu,
+        )
+        prob.add_option("print_level", 0)
+        prob.add_option("sb", "yes")
+        if arm.endswith("sqp"):
+            prob.add_option("algorithm", "active-set-sqp")
+            prob.add_option("sqp_print_level", 0)
+            prob.add_option("sqp_tol", tol)
+            prob.add_option("sqp_constr_viol_tol", 1e-6)
+            prob.add_option("sqp_max_iter", self.max_iter)
+        else:
+            prob.add_option("tol", tol)
+            prob.add_option("constr_viol_tol", 1e-6)
+            prob.add_option("max_iter", self.max_iter)
+        return prob
+
+    # -- one step --------------------------------------------------
+
+    def solve(
+        self,
+        family: ParametricFamily,
+        callbacks: SparseCallbacks,
+        arm: str,
+        x0: np.ndarray,
+        warm: Optional[WarmState],
+        step: int,
+        tol: float,
+    ) -> Tuple[StepResult, Optional[WarmState]]:
+        prob = self._build(family, callbacks, arm, tol)
+        callbacks.reset_counts()
+
+        # Step 0 of a warm arm has nothing to warm from: it is a cold
+        # solve, and is reported as one.
+        use_warm = is_warm(arm) and warm is not None
+
+        kwargs = {}
+        if use_warm:
+            if arm == "warm-sqp":
+                kwargs["x0"] = warm.x
+                if warm.working_set is not None:
+                    kwargs["working_set"] = warm.working_set
+            else:
+                kwargs["warm_start"] = pounce.WarmStart(
+                    x=warm.x,
+                    lagrange=warm.mult_g,
+                    zl=warm.mult_x_L,
+                    zu=warm.mult_x_U,
+                    mu=warm.mu,
+                )
+        else:
+            kwargs["x0"] = np.asarray(x0, dtype=float)
+
+        t0 = time.perf_counter()
+        x, info = prob.solve(**kwargs)
+        elapsed = time.perf_counter() - t0
+
+        status = int(info.get("status", -99))
+        ws = info.get("working_set")
+        n_active = None
+        if ws is not None:
+            n_active = int(np.count_nonzero(ws[0]) + np.count_nonzero(ws[1]))
+
+        result = StepResult(
+            step=step,
+            theta=[],  # filled by the runner, which owns the path
+            success=status in _OK_STATUS,
+            status=status,
+            status_msg=str(info.get("status_msg", "")),
+            iters=int(info.get("iter_count", -1)),
+            solve_time=elapsed,
+            obj=float(info.get("obj_val", np.nan)),
+            kkt_error=float(
+                info.get("final_unscaled_kkt_error",
+                         info.get("final_kkt_error", np.nan))
+            ),
+            constr_viol=float(
+                info.get("final_unscaled_constr_viol",
+                         info.get("final_constr_viol", np.nan))
+            ),
+            n_active=n_active,
+            # Recorded as counts (possibly 0) on the SQP path and as
+            # None on the IPM path, which has no QP subproblems at all.
+            # Keyed off the arm rather than off the value, so a warm
+            # solve that converged without solving a single QP records
+            # an honest 0 instead of looking like "not measured".
+            n_qp_solves=int(info.get("n_qp_solves", 0))
+            if arm.endswith("sqp")
+            else None,
+            n_qp_ws_changes=int(info.get("n_qp_ws_changes", 0))
+            if arm.endswith("sqp")
+            else None,
+            **callbacks.counts(),
+        )
+
+        next_warm = WarmState(
+            x=np.asarray(x, dtype=float).copy(),
+            mult_g=np.asarray(info.get("mult_g"), dtype=float).copy()
+            if info.get("mult_g") is not None
+            else None,
+            mult_x_L=np.asarray(info.get("mult_x_L"), dtype=float).copy()
+            if info.get("mult_x_L") is not None
+            else None,
+            mult_x_U=np.asarray(info.get("mult_x_U"), dtype=float).copy()
+            if info.get("mult_x_U") is not None
+            else None,
+            mu=float(info["mu"]) if info.get("mu") else None,
+            working_set=(
+                (np.asarray(ws[0]).copy(), np.asarray(ws[1]).copy())
+                if ws is not None
+                else None
+            ),
+        )
+        return result, next_warm

--- a/benchmarks/warmstart/families/__init__.py
+++ b/benchmarks/warmstart/families/__init__.py
@@ -1,0 +1,43 @@
+"""Family registry.
+
+Adding a family is: write a :class:`~..spec.ParametricFamily`
+subclass, list it here, and run ``python -m warmstart.selftest`` to
+have its derivatives finite-difference checked. Nothing else in the
+suite needs to know about it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Type
+
+from ..spec import ParametricFamily
+from .control import VanDerPolNMPC
+from .nonlinear import HangingChain, RosenbrockRing
+from .quadratic import DegenerateCorner, MovingBoundQP, SimplexProjection
+
+_FAMILIES: List[Type[ParametricFamily]] = [
+    SimplexProjection,
+    MovingBoundQP,
+    DegenerateCorner,
+    HangingChain,
+    RosenbrockRing,
+    VanDerPolNMPC,
+]
+
+REGISTRY: Dict[str, Type[ParametricFamily]] = {f.name: f for f in _FAMILIES}
+
+__all__ = ["REGISTRY", "make", "names"]
+
+
+def names() -> List[str]:
+    return list(REGISTRY)
+
+
+def make(name: str) -> ParametricFamily:
+    """Fresh instance of the named family (families carry state)."""
+    try:
+        return REGISTRY[name]()
+    except KeyError:
+        raise KeyError(
+            f"unknown family {name!r}; known: {', '.join(REGISTRY)}"
+        ) from None

--- a/benchmarks/warmstart/families/__init__.py
+++ b/benchmarks/warmstart/families/__init__.py
@@ -12,8 +12,9 @@ from typing import Dict, List, Type
 
 from ..spec import ParametricFamily
 from .control import VanDerPolNMPC
-from .nonlinear import HangingChain, RosenbrockRing
+from .nonlinear import HangingChain, RosenbrockRing, RosenbrockRingRoundTrip
 from .quadratic import DegenerateCorner, MovingBoundQP, SimplexProjection
+from .unconstrained import DoubleWellChain
 
 _FAMILIES: List[Type[ParametricFamily]] = [
     SimplexProjection,
@@ -21,6 +22,8 @@ _FAMILIES: List[Type[ParametricFamily]] = [
     DegenerateCorner,
     HangingChain,
     RosenbrockRing,
+    RosenbrockRingRoundTrip,
+    DoubleWellChain,
     VanDerPolNMPC,
 ]
 

--- a/benchmarks/warmstart/families/control.py
+++ b/benchmarks/warmstart/families/control.py
@@ -1,0 +1,202 @@
+"""The closed-loop family: an actual receding-horizon sequence.
+
+Every other family in this suite walks a *scripted* parameter path.
+This one does not: the next problem's parameter is the state the plant
+reaches after applying the control the previous solve produced. That
+is the setting warm starting was invented for, and it behaves
+differently from a scripted sweep — the perturbation size is set by
+the closed loop rather than by us, and it shrinks as the controller
+drives the plant toward the setpoint.
+
+Because the path depends on the solutions, the runner records the
+parameter sequence produced by the reference arm once and *replays*
+it for every other arm (see :mod:`..runner`). Otherwise each arm would
+be solving a slightly different set of problems and the iteration
+counts would not be comparable.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+
+from ..spec import Bounds, ParametricFamily
+
+_INF = 1e20
+
+
+class VanDerPolNMPC(ParametricFamily):
+    """Direct-transcription NMPC of a Van der Pol oscillator.
+
+    Variables ``z = [x₀ … x_N, u₀ … u_{N−1}]`` (states first, then
+    controls), single-shooting-free: the dynamics are equality
+    constraints (explicit Euler), the initial state is an equality
+    constraint whose right-hand side is the parameter, and the
+    controls are bounded. The active set is *which controls
+    saturate*, which changes as the plant state moves — the textbook
+    reason MPC codes warm start.
+
+    Nonconvex: the ``x₁²x₂`` term in the dynamics makes the constraint
+    Hessian state-dependent.
+    """
+
+    name = "nmpc_vanderpol"
+    tags = {"regime": "closed-loop", "channel": "rhs", "curvature": "nonconvex"}
+    n_steps = 20
+    adaptive = True
+
+    _NH = 15  # horizon steps
+    _H = 0.1  # discretization step
+    _MU = 1.0  # Van der Pol parameter
+    _U_MAX = 0.75
+    _Q = np.array([1.0, 0.1])
+    _R = 0.05
+    _QT = 10.0  # terminal weight
+    _X_INIT = np.array([2.0, 0.0])
+
+    def __init__(self):
+        self._theta = self._X_INIT.copy()
+        self._plant_steps_per_move = 1.0
+
+    # -- layout ----------------------------------------------------
+
+    @property
+    def n(self) -> int:
+        return 2 * (self._NH + 1) + self._NH
+
+    @property
+    def m(self) -> int:
+        return 2 + 2 * self._NH
+
+    @property
+    def _u_off(self) -> int:
+        return 2 * (self._NH + 1)
+
+    def bounds(self) -> Bounds:
+        lb = np.full(self.n, -5.0)
+        ub = np.full(self.n, 5.0)
+        lb[self._u_off :] = -self._U_MAX
+        ub[self._u_off :] = self._U_MAX
+        return Bounds(
+            lb=lb,
+            ub=ub,
+            cl=np.zeros(self.m),
+            cu=np.zeros(self.m),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.zeros(self.n)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._theta = np.asarray(theta, dtype=float).ravel().copy()
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        return None  # adaptive
+
+    def initial_theta(self, scale: float) -> np.ndarray:
+        # `scale` sets how far the plant advances between solves, i.e.
+        # how big a perturbation the next problem sees: 1.0 is one
+        # control interval (the textbook receding-horizon step).
+        self._plant_steps_per_move = float(scale)
+        return self._X_INIT.copy()
+
+    def next_theta(self, x_solution: np.ndarray) -> np.ndarray:
+        u0 = float(x_solution[self._u_off])
+        return self._simulate(self._theta, u0, self._H * self._plant_steps_per_move)
+
+    # -- plant (RK4, finer than the controller's Euler model) -------
+
+    def _rhs(self, x, u):
+        return np.array(
+            [x[1], self._MU * (1.0 - x[0] ** 2) * x[1] - x[0] + u]
+        )
+
+    def _simulate(self, x0, u, duration, substeps=20):
+        x = np.asarray(x0, dtype=float).copy()
+        dt = duration / substeps
+        for _ in range(substeps):
+            k1 = self._rhs(x, u)
+            k2 = self._rhs(x + 0.5 * dt * k1, u)
+            k3 = self._rhs(x + 0.5 * dt * k2, u)
+            k4 = self._rhs(x + dt * k3, u)
+            x = x + (dt / 6.0) * (k1 + 2 * k2 + 2 * k3 + k4)
+        return x
+
+    # -- functions -------------------------------------------------
+
+    def _split(self, z):
+        X = z[: self._u_off].reshape(self._NH + 1, 2)
+        U = z[self._u_off :]
+        return X, U
+
+    def objective(self, z):
+        X, U = self._split(z)
+        stage = float(np.sum(self._Q * X[:-1] ** 2))
+        terminal = float(self._QT * np.sum(self._Q * X[-1] ** 2))
+        return stage + terminal + float(self._R * (U @ U))
+
+    def gradient(self, z):
+        X, U = self._split(z)
+        g = np.zeros(self.n)
+        gx = g[: self._u_off].reshape(self._NH + 1, 2)
+        gx[:-1] = 2.0 * self._Q * X[:-1]
+        gx[-1] = 2.0 * self._QT * self._Q * X[-1]
+        g[self._u_off :] = 2.0 * self._R * U
+        return g
+
+    def constraints(self, z):
+        X, U = self._split(z)
+        c = np.empty(self.m)
+        c[:2] = X[0] - self._theta
+        h, mu = self._H, self._MU
+        x1, x2 = X[:-1, 0], X[:-1, 1]
+        c[2::2] = X[1:, 0] - x1 - h * x2
+        c[3::2] = (
+            X[1:, 1] - x2 - h * (mu * (1.0 - x1**2) * x2 - x1 + U)
+        )
+        return c
+
+    def jacobian_dense(self, z):
+        X, U = self._split(z)
+        h, mu = self._H, self._MU
+        j = np.zeros((self.m, self.n))
+        j[0, 0] = 1.0
+        j[1, 1] = 1.0
+        for k in range(self._NH):
+            x1, x2 = X[k]
+            r1, r2 = 2 + 2 * k, 3 + 2 * k
+            i1, i2 = 2 * k, 2 * k + 1  # x_k
+            n1, n2 = 2 * (k + 1), 2 * (k + 1) + 1  # x_{k+1}
+            uk = self._u_off + k
+            # x1_{k+1} − x1_k − h·x2_k
+            j[r1, n1] = 1.0
+            j[r1, i1] = -1.0
+            j[r1, i2] = -h
+            # x2_{k+1} − x2_k − h(μ(1−x1²)x2 − x1 + u)
+            j[r2, n2] = 1.0
+            j[r2, i1] = 2.0 * h * mu * x1 * x2 + h
+            j[r2, i2] = -1.0 - h * mu * (1.0 - x1**2)
+            j[r2, uk] = -h
+        return j
+
+    def hessian_dense(self, z, lagrange, obj_factor):
+        X, _ = self._split(z)
+        h, mu = self._H, self._MU
+        H = np.zeros((self.n, self.n))
+        # Objective (constant, diagonal).
+        diag = np.zeros(self.n)
+        dx = diag[: self._u_off].reshape(self._NH + 1, 2)
+        dx[:-1] = 2.0 * self._Q
+        dx[-1] = 2.0 * self._QT * self._Q
+        diag[self._u_off :] = 2.0 * self._R
+        H[np.arange(self.n), np.arange(self.n)] = obj_factor * diag
+        # Constraints: only the x1²x2 term has curvature.
+        for k in range(self._NH):
+            x1, x2 = X[k]
+            lam = lagrange[3 + 2 * k]
+            i1, i2 = 2 * k, 2 * k + 1
+            H[i1, i1] += lam * 2.0 * h * mu * x2
+            H[i1, i2] += lam * 2.0 * h * mu * x1
+            H[i2, i1] += lam * 2.0 * h * mu * x1
+        return H

--- a/benchmarks/warmstart/families/nonlinear.py
+++ b/benchmarks/warmstart/families/nonlinear.py
@@ -1,0 +1,257 @@
+"""Nonlinear families: curvature and a genuinely nonconvex path.
+
+- :class:`HangingChain` — the canonical spring-chain problem with a
+  parabolic ground the chain rests on. Nonlinear inequality
+  constraints; the active set is "which nodes touch the ground", and
+  it changes as the ground rises and the anchor moves. Convex, but
+  with real constraint curvature, so a warm start has to survive
+  Jacobian *and* Hessian drift, not just a moving right-hand side.
+- :class:`RosenbrockRing` — nonconvex objective inside a trust ball
+  whose radius sweeps through the unconstrained solution's norm. The
+  path crosses a single clean activation switch at its midpoint at
+  every scale, which separates "warm start across an unchanged active
+  set" from "warm start across the one step where it changes".
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+
+from ..spec import Bounds, ParametricFamily
+
+_INF = 1e20
+
+
+class HangingChain(ParametricFamily):
+    """Spring chain resting on a parabolic ground.
+
+    Free nodes ``p_i = (x_i, y_i)``, ``i = 1..N``, with both ends
+    pinned. Minimize spring energy plus gravitational potential
+    subject to ``y_i ≥ ground(x_i)``, where
+
+        ``ground(x) = g₀(θ) + q·(x − x_c)²``.
+
+    The parameter moves the right anchor and raises the ground, so
+    nodes make and break contact along the path. Variables carry no
+    bounds — every active-set event comes from the nonlinear
+    constraint rows.
+    """
+
+    name = "hanging_chain"
+    tags = {"regime": "flipping", "channel": "mixed", "curvature": "convex"}
+    n_steps = 20
+
+    _N = 15  # free nodes
+    _K = 40.0  # spring constant
+    _W = 4.0  # node weight (m·g)
+    _Q = 0.4  # ground curvature
+    _XC = 1.5  # ground vertex
+    _ANCHOR_Y = 1.0
+    _DELTA_A = 0.02  # anchor drift per step
+    _DELTA_G = 0.015  # ground rise per step
+    _A0 = 2.5
+    _G0 = -1.6
+
+    def __init__(self):
+        self._anchor_x = self._A0
+        self._ground0 = self._G0
+
+    # -- layout: z = [x_1, y_1, x_2, y_2, ...] ---------------------
+
+    @property
+    def n(self) -> int:
+        return 2 * self._N
+
+    @property
+    def m(self) -> int:
+        return self._N
+
+    def _nodes(self, z):
+        """(N+2, 2) array of all node positions, anchors included."""
+        p = np.empty((self._N + 2, 2))
+        p[0] = (0.0, self._ANCHOR_Y)
+        p[1:-1, 0] = z[0::2]
+        p[1:-1, 1] = z[1::2]
+        p[-1] = (self._anchor_x, self._ANCHOR_Y)
+        return p
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=np.full(self.n, -_INF),
+            ub=np.full(self.n, _INF),
+            cl=np.zeros(self._N),
+            cu=np.full(self._N, _INF),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        # Straight line between the anchors at the *initial* anchor
+        # position — deliberately θ-independent, so every cold solve
+        # along the path starts from the same place.
+        t = np.arange(1, self._N + 1) / (self._N + 1)
+        z = np.empty(self.n)
+        z[0::2] = t * self._A0
+        z[1::2] = self._ANCHOR_Y
+        return z
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        t = np.asarray(theta, dtype=float).ravel()
+        self._anchor_x, self._ground0 = float(t[0]), float(t[1])
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        return [
+            np.array(
+                [
+                    self._A0 + scale * self._DELTA_A * k,
+                    self._G0 + scale * self._DELTA_G * k,
+                ]
+            )
+            for k in range(self.n_steps)
+        ]
+
+    # -- functions -------------------------------------------------
+
+    def objective(self, z):
+        p = self._nodes(z)
+        d = np.diff(p, axis=0)
+        return float(0.5 * self._K * np.sum(d * d) + self._W * np.sum(z[1::2]))
+
+    def gradient(self, z):
+        p = self._nodes(z)
+        # dE/dp_i = K·(2p_i − p_{i−1} − p_{i+1}) for free nodes.
+        g = self._K * (2.0 * p[1:-1] - p[:-2] - p[2:])
+        g[:, 1] += self._W
+        out = np.empty(self.n)
+        out[0::2] = g[:, 0]
+        out[1::2] = g[:, 1]
+        return out
+
+    def constraints(self, z):
+        x, y = z[0::2], z[1::2]
+        return y - (self._ground0 + self._Q * (x - self._XC) ** 2)
+
+    def jacobian_dense(self, z):
+        x = z[0::2]
+        j = np.zeros((self._N, self.n))
+        rows = np.arange(self._N)
+        j[rows, 2 * rows] = -2.0 * self._Q * (x - self._XC)
+        j[rows, 2 * rows + 1] = 1.0
+        return j
+
+    def hessian_dense(self, z, lagrange, obj_factor):
+        n = self.n
+        h = np.zeros((n, n))
+        # Objective: tridiagonal in node index, decoupled per coordinate.
+        for i in range(self._N):
+            for c in (0, 1):
+                idx = 2 * i + c
+                h[idx, idx] += obj_factor * 2.0 * self._K
+                if i + 1 < self._N:
+                    nxt = 2 * (i + 1) + c
+                    h[idx, nxt] += -obj_factor * self._K
+                    h[nxt, idx] += -obj_factor * self._K
+        # Constraints: −2q on each node's x-diagonal.
+        for i in range(self._N):
+            h[2 * i, 2 * i] += lagrange[i] * (-2.0 * self._Q)
+        return h
+
+
+class RosenbrockRing(ParametricFamily):
+    """``min Rosenbrock(x)  s.t.  ‖x‖² ≤ r(θ)²`` with a sweeping radius.
+
+    The unconstrained minimizer is ``x* = 1`` with ``‖x*‖ = √n``, so
+    the ball constraint is active for ``r < √n`` and inactive above
+    it. The path is centered on ``r = √n``: the switch always happens
+    at the midpoint step, at every scale, and at that step the
+    constraint is exactly weakly active. Nonconvex objective, so this
+    is also the family where a warm start can land a solver in a
+    different basin than a cold solve — which the correctness gate
+    reports rather than hides.
+
+    The cold start is the origin, not Rosenbrock's traditional
+    ``(−1.2, 1, −1.2, …)``. That start is a *robustness* test rather
+    than a warm-start test: from it, pounce's exact-Hessian SQP path
+    gives up with ``Search_Direction_Becomes_Too_Small`` at every step
+    of the path (the quasi-Newton modes converge from it fine), so
+    every arm would be measuring failure instead of warm-start effect.
+    From the origin both algorithms converge and agree at every step,
+    which is what makes the switch measurable. See
+    ``dev-notes/warm-start-benchmark.md`` for the failing case.
+    """
+
+    name = "rosenbrock_ring"
+    tags = {"regime": "switch", "channel": "rhs", "curvature": "nonconvex"}
+    n_steps = 21  # odd, so a step lands exactly on the switch
+
+    _N = 10
+    _DELTA = 0.05
+
+    def __init__(self):
+        self._r = float(np.sqrt(self._N))
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return 1
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=np.full(self._N, -5.0),
+            ub=np.full(self._N, 5.0),
+            cl=np.array([-_INF]),
+            cu=np.array([self._r**2]),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.zeros(self._N)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._r = float(np.asarray(theta).ravel()[0])
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        half = (self.n_steps - 1) // 2
+        r_switch = float(np.sqrt(self._N))
+        return [
+            np.array([r_switch + scale * self._DELTA * (k - half)])
+            for k in range(self.n_steps)
+        ]
+
+    def objective(self, x):
+        a = x[1:] - x[:-1] ** 2
+        b = 1.0 - x[:-1]
+        return float(100.0 * (a @ a) + b @ b)
+
+    def gradient(self, x):
+        n = self._N
+        g = np.zeros(n)
+        a = x[1:] - x[:-1] ** 2
+        g[:-1] += -400.0 * x[:-1] * a - 2.0 * (1.0 - x[:-1])
+        g[1:] += 200.0 * a
+        return g
+
+    def constraints(self, x):
+        return np.array([float(x @ x)])
+
+    def jacobian_dense(self, x):
+        return (2.0 * x).reshape(1, self._N)
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        n = self._N
+        h = np.zeros((n, n))
+        a = x[1:] - x[:-1] ** 2
+        # d²/dx_i² from the i-th (i < n−1) Rosenbrock term, plus the
+        # 200 from the (i−1)-th term's linear appearance in x_i.
+        diag = np.zeros(n)
+        diag[:-1] += -400.0 * a + 800.0 * x[:-1] ** 2 + 2.0
+        diag[1:] += 200.0
+        h[np.arange(n), np.arange(n)] = diag
+        off = -400.0 * x[:-1]
+        h[np.arange(n - 1), np.arange(1, n)] = off
+        h[np.arange(1, n), np.arange(n - 1)] = off
+        h *= obj_factor
+        h[np.arange(n), np.arange(n)] += 2.0 * lagrange[0]
+        return h

--- a/benchmarks/warmstart/families/nonlinear.py
+++ b/benchmarks/warmstart/families/nonlinear.py
@@ -170,14 +170,16 @@ class RosenbrockRing(ParametricFamily):
     reports rather than hides.
 
     The cold start is the origin, not Rosenbrock's traditional
-    ``(−1.2, 1, −1.2, …)``. That start is a *robustness* test rather
-    than a warm-start test: from it, pounce's exact-Hessian SQP path
-    gives up with ``Search_Direction_Becomes_Too_Small`` at every step
-    of the path (the quasi-Newton modes converge from it fine), so
-    every arm would be measuring failure instead of warm-start effect.
-    From the origin both algorithms converge and agree at every step,
-    which is what makes the switch measurable. See
-    ``dev-notes/warm-start-benchmark.md`` for the failing case.
+    ``(−1.2, 1, −1.2, …)``. That was originally forced: from the
+    traditional start the exact-Hessian SQP path used to give up with
+    ``Search_Direction_Becomes_Too_Small`` at every step, so every arm
+    measured failure instead of warm-start effect (pounce#416). That
+    bug is **fixed** — the traditional start now converges in 20
+    iterations to the classical local minimum, agreeing with the IPM —
+    and the origin is kept only so this family's numbers stay
+    comparable across the runs already recorded. Switching to the
+    traditional start is now a legitimate option; it would change every
+    `rosenbrock_ring` figure in the report.
     """
 
     name = "rosenbrock_ring"

--- a/benchmarks/warmstart/families/nonlinear.py
+++ b/benchmarks/warmstart/families/nonlinear.py
@@ -255,3 +255,38 @@ class RosenbrockRing(ParametricFamily):
         h *= obj_factor
         h[np.arange(n), np.arange(n)] += 2.0 * lagrange[0]
         return h
+
+
+class RosenbrockRingRoundTrip(RosenbrockRing):
+    """:class:`RosenbrockRing` with a radius that goes out and comes back.
+
+    The parent sweeps the radius monotonically, so its single
+    activation switch is always active → inactive. That leaves the
+    harder direction untested: carrying an *empty* working set into a
+    step whose solution needs a non-empty one, where the warm start
+    has nothing useful to hand over and the solver must find the
+    active set anyway.
+
+    The path here is a triangle — start outside the switch radius
+    (constraint inactive), sweep in past it (active), then back out
+    (inactive again) — so it crosses in both directions, at exactly
+    the quarter and three-quarter steps, at every scale. Both crossing
+    steps land precisely on ``r = √n``, where the constraint is weakly
+    active.
+    """
+
+    name = "rosenbrock_ring_cycle"
+    tags = {"regime": "re-activation", "channel": "rhs", "curvature": "nonconvex"}
+    n_steps = 21
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        half = (self.n_steps - 1) // 2
+        r_switch = float(np.sqrt(self._N))
+        amp = self._DELTA * half * scale
+        # t runs −1 → +1 → −1, so r runs (switch + amp) → (switch −
+        # amp) → (switch + amp), crossing r_switch at k = half/2 and
+        # k = 3·half/2.
+        return [
+            np.array([r_switch - amp * (1.0 - 2.0 * abs(k - half) / half)])
+            for k in range(self.n_steps)
+        ]

--- a/benchmarks/warmstart/families/quadratic.py
+++ b/benchmarks/warmstart/families/quadratic.py
@@ -41,6 +41,7 @@ class SimplexProjection(ParametricFamily):
     """
 
     name = "simplex_proj"
+    quadratic = True
     tags = {"regime": "flipping", "channel": "objective", "curvature": "convex"}
     n_steps = 20
 
@@ -118,6 +119,7 @@ class MovingBoundQP(ParametricFamily):
     """
 
     name = "moving_bound_qp"
+    quadratic = True
     tags = {"regime": "flipping", "channel": "bounds", "curvature": "convex"}
     n_steps = 20
 
@@ -207,6 +209,7 @@ class DegenerateCorner(ParametricFamily):
     """
 
     name = "degenerate_corner"
+    quadratic = True
     tags = {"regime": "degenerate", "channel": "objective", "curvature": "convex"}
     n_steps = 21  # odd, so a step lands exactly on the midpoint
 

--- a/benchmarks/warmstart/families/quadratic.py
+++ b/benchmarks/warmstart/families/quadratic.py
@@ -1,0 +1,280 @@
+"""Quadratic families: clean active-set behavior, no curvature confounds.
+
+These three isolate the *active set* as the only thing that changes
+along the path. The objective is quadratic and the constraints are
+linear, so second derivatives are constant and a Newton method solves
+each instance in a handful of iterations from a good point — which is
+exactly what makes them a sharp measurement of warm-start quality: any
+iteration a warm-started solve spends here is spent finding the active
+set, not chasing curvature.
+
+- :class:`SimplexProjection` — objective-channel perturbation, active
+  set flips one component at a time (projection onto the simplex).
+- :class:`MovingBoundQP` — bound-channel perturbation, monotonically
+  growing active set as a wall sweeps across the solution.
+- :class:`DegenerateCorner` — built so a multiplier passes exactly
+  through zero at the midpoint of the path, at every scale. This is
+  the case a sign-based working-set classifier is documented to be
+  lossy on (docs/src/active-set-sqp-warm-start.md), so it is a
+  correctness probe rather than a speed probe.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+
+from ..spec import Bounds, ParametricFamily
+
+_INF = 1e20
+
+
+class SimplexProjection(ParametricFamily):
+    """``min ½‖x − p‖²  s.t.  Σx = 1, x ≥ 0`` with drifting ``p``.
+
+    Solution is the water-filling projection ``x_i = max(p_i − λ, 0)``,
+    so the active set is "which components are clamped at zero". The
+    path drifts each component of ``p`` at a different rate, so
+    components cross the water level one at a time: at ``tiny`` scale
+    the active set never moves, at ``large`` it churns.
+    """
+
+    name = "simplex_proj"
+    tags = {"regime": "flipping", "channel": "objective", "curvature": "convex"}
+    n_steps = 20
+
+    _N = 20
+    _DELTA = 0.02  # natural per-step drift
+
+    def __init__(self):
+        self._p = self._p0()
+
+    def _p0(self) -> np.ndarray:
+        return np.linspace(-0.4, 0.6, self._N)
+
+    def _direction(self) -> np.ndarray:
+        # Different components drift at different rates and signs, so
+        # crossings of the water level are spread along the path
+        # rather than happening all at once.
+        return np.cos(2.0 * np.pi * np.arange(self._N) / self._N)
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return 1
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=np.zeros(self._N),
+            ub=np.full(self._N, _INF),
+            cl=np.array([1.0]),
+            cu=np.array([1.0]),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.full(self._N, 1.0 / self._N)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._p = np.asarray(theta, dtype=float).copy()
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        p0, d = self._p0(), self._direction()
+        return [p0 + scale * self._DELTA * k * d for k in range(self.n_steps)]
+
+    def objective(self, x):
+        d = x - self._p
+        return 0.5 * float(d @ d)
+
+    def gradient(self, x):
+        return x - self._p
+
+    def constraints(self, x):
+        return np.array([float(x.sum())])
+
+    def jacobian_dense(self, x):
+        return np.ones((1, self._N))
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        return obj_factor * np.eye(self._N)
+
+
+class MovingBoundQP(ParametricFamily):
+    """Equality-constrained QP whose lower bounds sweep upward.
+
+    ``min ½xᵀQx + cᵀx  s.t.  Ax = b,  x ≥ ℓ(θ)``
+
+    ``Q`` is tridiagonal SPD and ``c`` is set so the bound-free
+    solution is a fixed reference profile ``x_ref``; the lower bound
+    wall then rises through that profile, activating components one
+    after another. The perturbation is in the **bound** channel — the
+    objective and the constraint rows never move — which is the case
+    where an interior-point warm start is at its most awkward (the
+    previous solution sits exactly where the new bound is) and an
+    active-set method should shine.
+    """
+
+    name = "moving_bound_qp"
+    tags = {"regime": "flipping", "channel": "bounds", "curvature": "convex"}
+    n_steps = 20
+
+    _N = 40
+    _M = 3
+    _DELTA = 0.05
+
+    def __init__(self):
+        n = self._N
+        i = np.arange(n)
+        # Tridiagonal SPD Hessian (discrete 1-D Laplacian + shift).
+        self._Q = (
+            np.diag(np.full(n, 2.2))
+            + np.diag(np.full(n - 1, -1.0), 1)
+            + np.diag(np.full(n - 1, -1.0), -1)
+        )
+        self._x_ref = np.sin(2.0 * np.pi * i / n)
+        # Deterministic dense equality rows.
+        self._A = np.cos(
+            np.outer(np.arange(1, self._M + 1), i) * 0.7
+        )
+        self._b = self._A @ self._x_ref
+        self._c = -(self._Q @ self._x_ref)
+        self._shape = 0.3 * np.cos(3.0 * np.pi * i / n) - 1.2
+        self._theta = 0.0
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return self._M
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=self._theta + self._shape,
+            ub=np.full(self._N, _INF),
+            cl=self._b.copy(),
+            cu=self._b.copy(),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.zeros(self._N)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._theta = float(np.asarray(theta).ravel()[0])
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        return [
+            np.array([scale * self._DELTA * k]) for k in range(self.n_steps)
+        ]
+
+    def objective(self, x):
+        return float(0.5 * x @ self._Q @ x + self._c @ x)
+
+    def gradient(self, x):
+        return self._Q @ x + self._c
+
+    def constraints(self, x):
+        return self._A @ x
+
+    def jacobian_dense(self, x):
+        return self._A
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        return obj_factor * self._Q
+
+
+class DegenerateCorner(ParametricFamily):
+    """A path that passes exactly through a degenerate active set.
+
+    ``min ½‖x − a(θ)‖²  s.t.  Ax ≤ b,  x ≥ 0``
+
+    ``a(θ)`` sweeps along a line chosen so that at the **midpoint step
+    of the path — at every scale —** the unconstrained minimizer sits
+    exactly on one constraint's boundary and exactly on one variable's
+    lower bound. Both multipliers are zero there: the constraint is
+    weakly active, strict complementarity fails, and the
+    multiplier-sign classifier that builds a working set from a
+    converged iterate has no signal to work with.
+
+    Nothing here is fast or hard to solve. The point is whether a warm
+    start stays *correct* across the degeneracy — a solver that
+    misclassifies is free to converge to the wrong face, and only the
+    correctness gate catches it.
+    """
+
+    name = "degenerate_corner"
+    tags = {"regime": "degenerate", "channel": "objective", "curvature": "convex"}
+    n_steps = 21  # odd, so a step lands exactly on the midpoint
+
+    _N = 6
+    _DELTA = 0.04
+
+    def __init__(self):
+        n = self._N
+        self._A = np.array(
+            [
+                [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                [0.5, 0.0, 0.5, 0.0, 1.0, 1.0],
+            ]
+        )
+        # a(θ) = a_c + θ·d. The crossing configuration is at θ = 0.
+        self._a_c = np.array([0.6, 0.4, 0.3, 0.2, 0.0, 0.5])
+        self._d = np.array([0.5, 0.5, -0.2, 0.0, 0.4, -0.3])
+        # b makes row 0 exactly satisfied-with-equality at θ = 0, so
+        # its multiplier passes through zero there. Component 4 of
+        # a_c is exactly 0, so that bound is weakly active too.
+        self._b = self._A @ self._a_c
+        self._b[1] += 0.75  # rows 1,2 stay strictly inactive nearby
+        self._b[2] += 0.75
+        self._a = self._a_c.copy()
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return 3
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=np.zeros(self._N),
+            ub=np.full(self._N, _INF),
+            cl=np.full(3, -_INF),
+            cu=self._b.copy(),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.full(self._N, 0.25)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        t = float(np.asarray(theta).ravel()[0])
+        self._a = self._a_c + t * self._d
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        half = (self.n_steps - 1) // 2
+        return [
+            np.array([scale * self._DELTA * (k - half)])
+            for k in range(self.n_steps)
+        ]
+
+    def objective(self, x):
+        d = x - self._a
+        return 0.5 * float(d @ d)
+
+    def gradient(self, x):
+        return x - self._a
+
+    def constraints(self, x):
+        return self._A @ x
+
+    def jacobian_dense(self, x):
+        return self._A
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        return obj_factor * np.eye(self._N)

--- a/benchmarks/warmstart/families/unconstrained.py
+++ b/benchmarks/warmstart/families/unconstrained.py
@@ -1,0 +1,127 @@
+"""The empty-active-set control: nothing to carry but the point itself.
+
+Every other family hands the next solve a working set worth having.
+This one hands it nothing: no constraint rows at all (``m = 0``), no
+finite variable bounds, so the working set is empty at every iterate
+of every step. Whatever speedup shows up here is what a warm start
+buys from the *primal point alone* — the zero mark the other families'
+numbers should be read against.
+
+It is also the one configuration the rest of the suite never executes.
+That matters: pounce#416 (exact-Hessian SQP burning its whole inner-QP
+budget) reproduces precisely here — unconstrained, bounds inactive or
+absent, indefinite Hessian — and the suite found it only because a
+*constrained* family happened to pass through an interior iterate on
+its way somewhere else.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+import numpy as np
+
+from ..spec import Bounds, ParametricFamily
+
+_INF = 1e20
+
+
+class DoubleWellChain(ParametricFamily):
+    """Coupled double wells with drifting depths, no constraints.
+
+        min Σᵢ (xᵢ² − cᵢ(θ))²  +  κ Σᵢ (xᵢ₊₁ − xᵢ)²
+
+    Each coordinate has two symmetric minima at ``±√cᵢ``; the spring
+    coupling pulls neighbours together so the wells do not separate
+    into ``n`` independent scalar problems. Nonconvex, and the
+    Hessian is genuinely indefinite away from the solution (the well
+    term contributes ``12xᵢ² − 4cᵢ``, negative whenever
+    ``xᵢ² < cᵢ/3``), so this exercises unconstrained *and* indefinite
+    — with no active set anywhere to rescue the step computation.
+
+    The parameter drifts the well depths, which moves the minimizer
+    without ever changing which branch it sits in, so a warm start
+    should keep the solve inside the same basin. A cold solve has to
+    re-find it every step.
+    """
+
+    name = "double_well_chain"
+    tags = {"regime": "none", "channel": "objective", "curvature": "nonconvex"}
+    n_steps = 20
+
+    _N = 12
+    _K = 0.5  # coupling
+    _DELTA = 0.05
+
+    def __init__(self):
+        self._c = self._c0()
+
+    def _c0(self) -> np.ndarray:
+        # Depths in [0.6, 2.4] — the minimizers √c are then O(1) and
+        # the cold start below sits inside the indefinite region.
+        return 0.6 + 1.8 * np.arange(self._N) / (self._N - 1)
+
+    def _direction(self) -> np.ndarray:
+        return np.cos(2.0 * np.pi * np.arange(self._N) / self._N)
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return 0
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=np.full(self._N, -_INF),
+            ub=np.full(self._N, _INF),
+            cl=np.zeros(0),
+            cu=np.zeros(0),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        # Deliberately inside the negative-curvature region
+        # (x² < c/3 for every coordinate), so the path to the solution
+        # runs through an indefinite Hessian with no constraint in the
+        # working set to stabilize the step.
+        return np.full(self._N, 0.35)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._c = np.asarray(theta, dtype=float).copy()
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        c0, d = self._c0(), self._direction()
+        return [c0 + scale * self._DELTA * k * d for k in range(self.n_steps)]
+
+    def objective(self, x):
+        w = x**2 - self._c
+        d = np.diff(x)
+        return float(w @ w + self._K * (d @ d))
+
+    def gradient(self, x):
+        g = 4.0 * x * (x**2 - self._c)
+        # κ·Σ(x_{i+1} − x_i)² → κ·2·(2x_i − x_{i−1} − x_{i+1}) interior.
+        g[:-1] -= 2.0 * self._K * (x[1:] - x[:-1])
+        g[1:] += 2.0 * self._K * (x[1:] - x[:-1])
+        return g
+
+    def constraints(self, x):
+        return np.zeros(0)
+
+    def jacobian_dense(self, x):
+        return np.zeros((0, self._N))
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        n = self._N
+        h = np.zeros((n, n))
+        diag = 12.0 * x**2 - 4.0 * self._c
+        # Coupling: tridiagonal, +2κ per incident spring on the
+        # diagonal and −2κ off it.
+        diag[:-1] += 2.0 * self._K
+        diag[1:] += 2.0 * self._K
+        h[np.arange(n), np.arange(n)] = diag
+        off = np.full(n - 1, -2.0 * self._K)
+        h[np.arange(n - 1), np.arange(1, n)] = off
+        h[np.arange(1, n), np.arange(n - 1)] = off
+        return obj_factor * h

--- a/benchmarks/warmstart/families/unconstrained.py
+++ b/benchmarks/warmstart/families/unconstrained.py
@@ -7,12 +7,17 @@ of every step. Whatever speedup shows up here is what a warm start
 buys from the *primal point alone* — the zero mark the other families'
 numbers should be read against.
 
-It is also the one configuration the rest of the suite never executes.
-That matters: pounce#416 (exact-Hessian SQP burning its whole inner-QP
-budget) reproduces precisely here — unconstrained, bounds inactive or
-absent, indefinite Hessian — and the suite found it only because a
-*constrained* family happened to pass through an interior iterate on
-its way somewhere else.
+It is also the one configuration the rest of the suite never executes,
+and that has already paid for itself twice. pounce#416 (exact-Hessian
+SQP burning its whole inner-QP budget) reproduces precisely here —
+unconstrained, bounds inactive or absent, indefinite Hessian — and the
+suite originally found it only because a *constrained* family happened
+to pass through an interior iterate on its way somewhere else. Then the
+fix for #416 (pounce#419) **regressed exactly this configuration**: a
+negative-curvature direction with nothing to block it now fails the
+solve at iteration 1 where the shifted step used to converge, which
+this family caught on its first run against the new base
+(pounce#423).
 """
 
 from __future__ import annotations

--- a/benchmarks/warmstart/qpform.py
+++ b/benchmarks/warmstart/qpform.py
@@ -1,0 +1,166 @@
+"""Extract standard-form QP data from a family whose instances are QPs.
+
+Some families in this suite are literally convex QPs dressed as NLPs —
+quadratic objective, linear constraints — and a dedicated convex QP
+solver can take them directly instead of going through callbacks. This
+module does the conversion, in solver-agnostic form, so an adapter only
+has to map the result onto its own QP entry point.
+
+The conversion is exact and constructive rather than assumed. For a
+family with ``f(x) = ½xᵀPx + cᵀx + f₀`` and ``g(x) = Jx + g₀``:
+
+    P  = ∇²f            (constant, so evaluated once, anywhere)
+    c  = ∇f(0)          (since ∇f(x) = Px + c)
+    f₀ = f(0)
+    J  = ∇g             (constant)
+    g₀ = g(0)
+
+``f₀`` matters: the QP solver reports ``½xᵀPx + cᵀx`` with no constant
+term, so an objective compared against the other arms without adding
+``f₀`` back would be wrong by a fixed offset — silently, and differently
+per step, since ``f₀`` moves with the parameter.
+
+Two-sided constraint rows are split into the one-sided ``Gx ≤ h`` form
+the QP interface takes; rows with ``cl == cu`` become equalities.
+:func:`verify` re-derives the family's own callbacks from the extracted
+data and is exercised by the suite's self-test — a wrong extraction here
+would produce plausible, wrong benchmark numbers.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Optional
+
+import numpy as np
+
+from .spec import ParametricFamily
+
+#: Rows whose bounds are this close together are treated as equalities.
+_EQ_TOL = 1e-12
+
+#: Matches the ±1e19/1e20 sentinels the families use for "no bound".
+_BOUND_INF = 1e19
+
+
+@dataclasses.dataclass
+class QpData:
+    """``min ½xᵀPx + cᵀx + f₀  s.t.  Ax = b,  Gx ≤ h,  lb ≤ x ≤ ub``."""
+
+    P: np.ndarray
+    c: np.ndarray
+    f0: float
+    A: Optional[np.ndarray]
+    b: Optional[np.ndarray]
+    G: Optional[np.ndarray]
+    h: Optional[np.ndarray]
+    lb: np.ndarray
+    ub: np.ndarray
+
+
+def extract(family: ParametricFamily, callbacks=None) -> QpData:
+    """Build :class:`QpData` for the family at its *current* parameter.
+
+    Pass ``callbacks`` (a :class:`~.sparsity.SparseCallbacks`) to route
+    the three evaluations through the harness's counters, so the
+    assembly cost shows up in the step's evaluation counts the same way
+    the other arms' per-iteration callbacks do.
+    """
+    n, m = family.n, family.m
+    src = callbacks if callbacks is not None else family
+    zero = np.zeros(n)
+
+    # `SparseCallbacks` returns packed sparse values, so the dense
+    # matrices come from the family either way; the callbacks object is
+    # used for the vector evaluations, which is what the counters track.
+    lam = np.zeros(m)
+    P = np.asarray(family.hessian_dense(zero, lam, 1.0), dtype=float)
+    P = 0.5 * (P + P.T)  # symmetrize; the families build full symmetric
+    c = np.asarray(src.gradient(zero), dtype=float).copy()
+    f0 = float(src.objective(zero))
+
+    bounds = family.bounds()
+    lb = np.where(bounds.lb > -_BOUND_INF, bounds.lb, -np.inf)
+    ub = np.where(bounds.ub < _BOUND_INF, bounds.ub, np.inf)
+
+    A = b = G = h = None
+    if m:
+        J = np.asarray(family.jacobian_dense(zero), dtype=float)
+        g0 = np.asarray(src.constraints(zero), dtype=float)
+        cl, cu = bounds.cl, bounds.cu
+
+        eq = np.abs(cu - cl) <= _EQ_TOL
+        if eq.any():
+            A = J[eq]
+            b = cl[eq] - g0[eq]
+
+        g_rows, h_vals = [], []
+        for i in np.nonzero(~eq)[0]:
+            if cu[i] < _BOUND_INF:  #  Jx + g₀ ≤ cu
+                g_rows.append(J[i])
+                h_vals.append(cu[i] - g0[i])
+            if cl[i] > -_BOUND_INF:  # −(Jx + g₀) ≤ −cl
+                g_rows.append(-J[i])
+                h_vals.append(-(cl[i] - g0[i]))
+        if g_rows:
+            G = np.array(g_rows)
+            h = np.array(h_vals)
+
+    return QpData(P=P, c=c, f0=f0, A=A, b=b, G=G, h=h, lb=lb, ub=ub)
+
+
+def verify(family: ParametricFamily, qp: QpData, rng, n_points: int = 5) -> list:
+    """Re-derive the family from ``qp`` and report any disagreement.
+
+    Returns a list of human-readable failures (empty when the extraction
+    reproduces the family exactly). Checks the objective value, the
+    gradient, the constraint values, and that ``P`` is symmetric positive
+    semidefinite — the convexity the QP solver is entitled to assume and
+    would otherwise report a silently-wrong "optimal" for.
+    """
+    out = []
+    n = family.n
+    for _ in range(n_points):
+        x = rng.standard_normal(n)
+        f_qp = 0.5 * x @ qp.P @ x + qp.c @ x + qp.f0
+        f_fam = float(family.objective(x))
+        if abs(f_qp - f_fam) > 1e-9 * (1.0 + abs(f_fam)):
+            out.append(f"objective mismatch: qp={f_qp:.12g} family={f_fam:.12g}")
+        g_qp = qp.P @ x + qp.c
+        if not np.allclose(g_qp, family.gradient(x), rtol=1e-9, atol=1e-9):
+            out.append("gradient mismatch")
+        if family.m:
+            cons = np.asarray(family.constraints(x), dtype=float)
+            bounds = family.bounds()
+            eq = np.abs(bounds.cu - bounds.cl) <= _EQ_TOL
+            # Equalities: Ax − b must be the family's own residual
+            # g(x) − cl on those rows.
+            if qp.A is not None and not np.allclose(
+                qp.A @ x - qp.b, cons[eq] - bounds.cl[eq], rtol=1e-9, atol=1e-9
+            ):
+                out.append("equality row mismatch")
+            # Inequalities: each split row's slack h − Gx must be the
+            # family's own distance to the bound it came from.
+            expected = []
+            for i in np.nonzero(~eq)[0]:
+                if bounds.cu[i] < _BOUND_INF:
+                    expected.append(bounds.cu[i] - cons[i])
+                if bounds.cl[i] > -_BOUND_INF:
+                    expected.append(cons[i] - bounds.cl[i])
+            if expected:
+                if qp.G is None or not np.allclose(
+                    qp.h - qp.G @ x, np.array(expected), rtol=1e-9, atol=1e-9
+                ):
+                    out.append("inequality row mismatch")
+            elif qp.G is not None:
+                out.append("unexpected inequality rows in the extraction")
+    if not np.allclose(qp.P, qp.P.T, atol=1e-12):
+        out.append("P is not symmetric")
+    if qp.P.size:
+        w = np.linalg.eigvalsh(qp.P)
+        if w.min() < -1e-9 * max(1.0, abs(w.max())):
+            out.append(
+                f"P is indefinite (min eigenvalue {w.min():.3e}); the convex "
+                "QP solver is not applicable to this family"
+            )
+    return out

--- a/benchmarks/warmstart/report.py
+++ b/benchmarks/warmstart/report.py
@@ -221,7 +221,10 @@ def render(payload: dict) -> str:
             "| Σ time (s) | f-evals | failed | bad | better | max KKT |"
         )
         w("|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|")
-        for arm in ("cold-ipm", "warm-ipm", "cold-sqp", "warm-sqp"):
+        for arm in (
+            "cold-ipm", "warm-ipm", "cold-sqp", "warm-sqp",
+            "cold-qp-ipm", "warm-qp-ipm",
+        ):
             steps = run["arms"].get(arm)
             if not steps:
                 continue
@@ -237,6 +240,56 @@ def render(payload: dict) -> str:
             )
         for arm, why in run.get("skipped", {}).items():
             w(f"| {arm} | *skipped* | | | | | | | | | {why} |")
+        w("")
+
+    # -- three-way on the QP-shaped families ------------------------
+    qp_runs = [r for r in runs if "cold-qp-ipm" in r["arms"]]
+    if qp_runs:
+        w("## Dedicated convex QP solver vs the two general paths")
+        w("")
+        w(
+            "Only for families whose instances are literally QPs — the "
+            "others skip these arms with a reason. Read wall time with the "
+            "asymmetry in mind: the QP arms are handed the problem in "
+            "matrix form once per step, while the general paths call back "
+            "into the model at every iteration. Iteration counts are not "
+            "comparable across *methods* either (an active-set pivot and "
+            "an interior-point step are different units of work); the "
+            "column that compares like with like is each arm against "
+            "itself, cold vs warm."
+        )
+        w("")
+        w(
+            "| family | scale | qp-ipm cold→warm iters | nlp-ipm cold→warm "
+            "| sqp cold→warm (QP active-set) | qp-ipm time (ms) cold→warm "
+            "| fastest warm arm |"
+        )
+        w("|---|---|--:|--:|--:|--:|---|")
+        for run in qp_runs:
+            a = run["arms"]
+            def tot(arm, key="iters"):
+                return sum(s[key] for s in a[arm]) if arm in a else None
+            def ms(arm):
+                return sum(s["solve_time"] for s in a[arm]) * 1e3 if arm in a else None
+            qp_pair = _pair_stats(run, "warm-qp-ipm", "cold-qp-ipm")
+            sqp_pair = _pair_stats(run, "warm-sqp", "cold-sqp")
+            warm_times = {
+                arm: ms(arm)
+                for arm in ("warm-ipm", "warm-sqp", "warm-qp-ipm")
+                if ms(arm) is not None
+            }
+            fastest = min(warm_times, key=warm_times.get) if warm_times else "—"
+            w(
+                f"| `{run['family']}` | {run['scale']} "
+                f"| {tot('cold-qp-ipm')}→{tot('warm-qp-ipm')} "
+                f"({_fmt(qp_pair and qp_pair['speedup'], '.2f')}×) "
+                f"| {tot('cold-ipm')}→{tot('warm-ipm')} "
+                f"| {sqp_pair['qp_cold'] if sqp_pair else '—'}→"
+                f"{sqp_pair['qp_warm'] if sqp_pair else '—'} "
+                f"({_fmt(sqp_pair and sqp_pair.get('qp_speedup'), '.2f')}×) "
+                f"| {_fmt(ms('cold-qp-ipm'), '.1f')}→{_fmt(ms('warm-qp-ipm'), '.1f')} "
+                f"| {fastest} |"
+            )
         w("")
 
     # -- regressions ------------------------------------------------

--- a/benchmarks/warmstart/report.py
+++ b/benchmarks/warmstart/report.py
@@ -1,0 +1,336 @@
+"""Render a results JSON into markdown.
+
+The headline number is the **shifted geometric mean iteration speedup**
+of a warm arm over its own cold counterpart (``warm-sqp`` vs
+``cold-sqp``, ``warm-ipm`` vs ``cold-ipm``), taken over the steps that
+actually warm-start — step 0 has nothing to warm from and is excluded
+from the ratio, though it is still in the totals.
+
+Pairing each warm arm with its *own* algorithm is deliberate: it
+isolates the warm start. Comparing ``warm-sqp`` against ``cold-ipm``
+mixes the warm start with the algorithm switch, so that column is
+reported too, but separately.
+
+Two columns matter as much as the speedup:
+
+``worse``
+    Steps where the warm arm took strictly more iterations than the
+    cold one. Warm starting is not free — a start inside the wrong
+    active set can cost more than starting fresh — and a benchmark
+    that only reports the mean hides it.
+``bad``
+    Steps that failed to converge or converged somewhere other than
+    the reference solution. Any nonzero entry here voids the speedup
+    on that row; a fast wrong answer is not a result.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from typing import List, Optional
+
+_SHIFT = 1.0  # shifted geometric mean, the usual guard against 0-iteration steps
+
+
+def _geomean_ratio(cold: List[int], warm: List[int]) -> Optional[float]:
+    """Shifted geometric mean of cold/warm iteration counts (>1 = warm wins)."""
+    pairs = [(c, w) for c, w in zip(cold, warm) if c >= 0 and w >= 0]
+    if not pairs:
+        return None
+    logs = [math.log((c + _SHIFT) / (w + _SHIFT)) for c, w in pairs]
+    return float(math.exp(sum(logs) / len(logs)))
+
+
+def _fmt(v, spec=".2f", dash="—"):
+    return dash if v is None else format(v, spec)
+
+
+def _arm_summary(steps: List[dict]) -> dict:
+    iters = [s["iters"] for s in steps]
+    return {
+        "steps": len(steps),
+        "qp_solves": sum(s["n_qp_solves"] or 0 for s in steps),
+        "qp_ws_changes": sum(s["n_qp_ws_changes"] or 0 for s in steps),
+        "iters_total": sum(i for i in iters if i >= 0),
+        "iters_median": statistics.median(iters) if iters else 0,
+        "time_total": sum(s["solve_time"] for s in steps),
+        "obj_evals": sum(s["n_obj"] for s in steps),
+        "hess_evals": sum(s["n_hess"] for s in steps),
+        "failed": sum(1 for s in steps if not s["success"]),
+        "bad": sum(1 for s in steps if not s.get("correct", True)),
+        "max_kkt": max((s["kkt_error"] for s in steps), default=float("nan")),
+        "better": sum(1 for s in steps if s.get("better")),
+        "n_active": [s["n_active"] for s in steps if s["n_active"] is not None],
+        "ws_changed": [
+            s["ws_changed"] for s in steps if s.get("ws_changed") is not None
+        ],
+    }
+
+
+def _pair_stats(run: dict, warm_arm: str, cold_arm: str) -> Optional[dict]:
+    arms = run["arms"]
+    if warm_arm not in arms or cold_arm not in arms:
+        return None
+    warm, cold = arms[warm_arm], arms[cold_arm]
+    # Step 0 of a warm arm is a cold solve — excluded from the ratio.
+    w_it = [s["iters"] for s in warm[1:]]
+    c_it = [s["iters"] for s in cold[1:]]
+    w_qp = [s["n_qp_ws_changes"] for s in warm[1:] if s["n_qp_ws_changes"] is not None]
+    c_qp = [s["n_qp_ws_changes"] for s in cold[1:] if s["n_qp_ws_changes"] is not None]
+    return {
+        "speedup": _geomean_ratio(c_it, w_it),
+        "qp_speedup": _geomean_ratio(c_qp, w_qp) if len(w_qp) == len(c_qp) else None,
+        "qp_warm": sum(w_qp),
+        "qp_cold": sum(c_qp),
+        # `worse` tracks whichever metric this pairing is judged on:
+        # inner active-set work when the path has QP subproblems (the
+        # SQP pairing), outer iterations otherwise (the IPM pairing).
+        "worse": (
+            sum(1 for c, w in zip(c_qp, w_qp) if w > c)
+            if len(w_qp) == len(c_qp) and w_qp
+            else sum(1 for c, w in zip(c_it, w_it) if w > c)
+        ),
+        "compared": len(w_it),
+        "iters_warm": sum(w_it),
+        "iters_cold": sum(c_it),
+    }
+
+
+def render(payload: dict) -> str:
+    meta = payload["meta"]
+    runs = payload["runs"]
+    out: List[str] = []
+    w = out.append
+
+    w("# Warm-start benchmark")
+    w("")
+    w(f"- solver: **{meta['solver']}** {meta.get('solver_version', '')}")
+    w(f"- git: `{meta.get('git_sha', '?')}`  ")
+    w(f"- run: {meta.get('timestamp', '?')} on {meta.get('platform', '?')}")
+    w(
+        f"- tol: {meta['tol']:g} · converged-gate: KKT ≤ {meta['kkt_gate']:g}, "
+        f"viol ≤ {meta['viol_gate']:g} · worse-optimum margin: "
+        f"{meta['obj_tol']:g} · max_iter: {meta['max_iter']}"
+    )
+    w("")
+    w(
+        "Both speedups are shifted geometric means of cold/warm counts over "
+        "the warm-started steps (step 0 excluded — nothing to warm from), so "
+        "**>1 means warm starting won**."
+    )
+    w("")
+    w(
+        "- **SQP outer** — outer SQP iterations. On a family whose "
+        "subproblem is already a QP this is 1 either way, so the column is "
+        "flat by construction and says nothing.\n"
+        "- **SQP active-set work** — active-set changes (adds + drops) "
+        "inside the QP subproblems, with the raw cold→warm totals in "
+        "parentheses. This is where a working-set warm start actually "
+        "pays, and it is the column to read.\n"
+        "- **worse** — steps where the warm arm cost *more* than the cold "
+        "one on the metric in the column to its left. Warm starting is not "
+        "free: a start inside the wrong active set can cost more than "
+        "starting fresh.\n"
+        "- **bad** — steps that did not converge (status, KKT residual or "
+        "feasibility), or converged to a *worse* optimum than the reference "
+        "arm. **A row with a nonzero `bad` has no valid speedup.** Finding "
+        "a *better* optimum than the reference is not counted bad — on the "
+        "nonconvex families that happens, and it is listed separately."
+    )
+    w("")
+
+    # -- headline ---------------------------------------------------
+    w("## Iteration speedup from warm starting")
+    w("")
+    w(
+        "| family | regime | scale | SQP outer | SQP active-set work | "
+        "worse | bad | IPM cold→warm | worse | bad |"
+    )
+    w("|---|---|---|--:|--:|--:|--:|--:|--:|--:|")
+    for run in runs:
+        sqp = _pair_stats(run, "warm-sqp", "cold-sqp")
+        ipm = _pair_stats(run, "warm-ipm", "cold-ipm")
+        cross = _pair_stats(run, "warm-sqp", "cold-ipm")
+        arms = run["arms"]
+        bad_sqp = sum(
+            1 for s in arms.get("warm-sqp", []) if not s.get("correct", True)
+        )
+        bad_ipm = sum(
+            1 for s in arms.get("warm-ipm", []) if not s.get("correct", True)
+        )
+        qp_detail = (
+            f" ({sqp['qp_cold']}→{sqp['qp_warm']})"
+            if sqp and sqp.get("qp_speedup") is not None
+            else ""
+        )
+        w(
+            f"| `{run['family']}` | {run['tags'].get('regime', '')} "
+            f"| {run['scale']} "
+            f"| {_fmt(sqp and sqp['speedup'], '.2f')}× "
+            f"| {_fmt(sqp and sqp.get('qp_speedup'), '.2f')}×{qp_detail} "
+            f"| {sqp['worse'] if sqp else '—'} | {bad_sqp} "
+            f"| {_fmt(ipm and ipm['speedup'], '.2f')}× "
+            f"| {ipm['worse'] if ipm else '—'} | {bad_ipm} |"
+        )
+    w("")
+
+    # -- active-set behavior ---------------------------------------
+    w("## Active-set behavior along each path")
+    w("")
+    w(
+        "From the SQP arms' returned working sets. `churn` is the mean "
+        "Hamming distance between consecutive steps' working sets — the "
+        "property that decides whether warm starting can pay at all."
+    )
+    w("")
+    w("| family | scale | n | m | mean &#124;A&#124; | churn/step | max churn |")
+    w("|---|---|--:|--:|--:|--:|--:|")
+    for run in runs:
+        steps = run["arms"].get("cold-sqp") or run["arms"].get("warm-sqp")
+        if not steps:
+            continue
+        s = _arm_summary(steps)
+        churn = s["ws_changed"]
+        w(
+            f"| `{run['family']}` | {run['scale']} | {run['n']} | {run['m']} "
+            f"| {_fmt(statistics.mean(s['n_active']) if s['n_active'] else None, '.1f')} "
+            f"| {_fmt(statistics.mean(churn) if churn else None, '.2f')} "
+            f"| {max(churn) if churn else '—'} |"
+        )
+    w("")
+
+    # -- per-arm detail --------------------------------------------
+    w("## Per-arm totals")
+    w("")
+    w(
+        "Wall time includes the Python callback round trip, which dominates "
+        "at these problem sizes — read iterations and evaluation counts as "
+        "the primary measurements and time only as a cross-check."
+    )
+    w("")
+    for run in runs:
+        w(
+            f"### `{run['family']}` @ {run['scale']} "
+            f"({', '.join(f'{k}={v}' for k, v in run['tags'].items())}; "
+            f"n={run['n']}, m={run['m']}, {run['n_steps']} steps)"
+        )
+        w("")
+        w(
+            "| arm | Σ iters | median | Σ QP solves | Σ QP active-set changes "
+            "| Σ time (s) | f-evals | failed | bad | better | max KKT |"
+        )
+        w("|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|")
+        for arm in ("cold-ipm", "warm-ipm", "cold-sqp", "warm-sqp"):
+            steps = run["arms"].get(arm)
+            if not steps:
+                continue
+            s = _arm_summary(steps)
+            qp = "—" if not s["qp_solves"] else str(s["qp_solves"])
+            qp_ws = "—" if not s["qp_solves"] else str(s["qp_ws_changes"])
+            w(
+                f"| {arm} | {s['iters_total']} | {s['iters_median']:g} "
+                f"| {qp} | {qp_ws} "
+                f"| {s['time_total']:.3f} | {s['obj_evals']} "
+                f"| {s['failed']} | {s['bad']} | {s['better']} "
+                f"| {s['max_kkt']:.1e} |"
+            )
+        for arm, why in run.get("skipped", {}).items():
+            w(f"| {arm} | *skipped* | | | | | | | | | {why} |")
+        w("")
+
+    # -- regressions ------------------------------------------------
+    regressions = []
+    for run in runs:
+        for warm_arm, cold_arm in (("warm-sqp", "cold-sqp"), ("warm-ipm", "cold-ipm")):
+            arms = run["arms"]
+            if warm_arm not in arms or cold_arm not in arms:
+                continue
+            for cw, ww in zip(arms[cold_arm][1:], arms[warm_arm][1:]):
+                key = (
+                    "n_qp_ws_changes"
+                    if ww.get("n_qp_ws_changes") is not None
+                    and cw.get("n_qp_ws_changes") is not None
+                    else "iters"
+                )
+                if ww[key] > cw[key]:
+                    regressions.append(
+                        (run["family"], run["scale"], warm_arm, ww["step"],
+                         "QP active-set changes" if key != "iters" else "outer iters",
+                         cw[key], ww[key], ww.get("ws_changed"))
+                    )
+    w("## Where warm starting cost more than it saved")
+    w("")
+    if not regressions:
+        w("No step in this run was slower warm than cold.")
+    else:
+        w("| family | scale | arm | step | metric | cold | warm | churn |")
+        w("|---|---|---|--:|---|--:|--:|--:|")
+        for r in regressions:
+            w(
+                f"| `{r[0]}` | {r[1]} | {r[2]} | {r[3]} | {r[4]} | {r[5]} "
+                f"| {r[6]} | {r[7] if r[7] is not None else '—'} |"
+            )
+    w("")
+
+    # -- correctness ------------------------------------------------
+    bad_rows = []
+    for run in runs:
+        for arm, steps in run["arms"].items():
+            for s in steps:
+                if not s.get("correct", True):
+                    reason = (
+                        "did not converge"
+                        if not s.get("converged", True)
+                        else "worse optimum"
+                    )
+                    bad_rows.append(
+                        (run["family"], run["scale"], arm, s["step"],
+                         reason, s["status_msg"], s["kkt_error"],
+                         s.get("obj_err"))
+                    )
+    w("## Correctness failures")
+    w("")
+    if not bad_rows:
+        w(
+            "Every step of every arm converged (KKT ≤ "
+            f"{meta['kkt_gate']:g}, violation ≤ {meta['viol_gate']:g}) and "
+            "none landed on a worse optimum than the reference arm."
+        )
+    else:
+        w("| family | scale | arm | step | why | status | KKT | Δobj rel |")
+        w("|---|---|---|--:|---|---|--:|--:|")
+        for r in bad_rows:
+            w(
+                f"| `{r[0]}` | {r[1]} | {r[2]} | {r[3]} | {r[4]} | {r[5]} "
+                f"| {_fmt(r[6], '.1e')} | {_fmt(r[7], '.2e')} |"
+            )
+    w("")
+    return "\n".join(out)
+
+
+def main(argv=None) -> int:
+    import argparse
+    import json
+    import os
+
+    p = argparse.ArgumentParser(description="render a warm-start results JSON")
+    here = os.path.dirname(os.path.abspath(__file__))
+    p.add_argument("results", nargs="?", default=os.path.join(here, "results.json"))
+    p.add_argument("-o", "--out", default=None)
+    args = p.parse_args(argv)
+
+    with open(args.results) as fh:
+        payload = json.load(fh)
+    text = render(payload)
+    if args.out:
+        with open(args.out, "w") as fh:
+            fh.write(text)
+        print(f"wrote {args.out}")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/warmstart/run.py
+++ b/benchmarks/warmstart/run.py
@@ -1,0 +1,168 @@
+"""Command line entry point.
+
+    python -m warmstart.run                       # everything, default solver
+    python -m warmstart.run --quick               # one scale, fewer families
+    python -m warmstart.run --families simplex_proj --scales small -v
+
+Writes a JSON result file (default ``warmstart/results.json``) and,
+unless ``--no-report``, renders ``warmstart/report.md`` beside it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import subprocess
+import sys
+import time
+from typing import List
+
+from .adapters import ARMS, get_adapter
+from .families import REGISTRY
+from .report import render
+from .runner import run_family_scale
+from .spec import SCALES
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_QUICK_FAMILIES = ["simplex_proj", "rosenbrock_ring", "nmpc_vanderpol"]
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=_HERE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def _solver_version(name: str) -> str:
+    if name == "pounce":
+        try:
+            import pounce
+
+            return getattr(pounce, "__version__", "unknown")
+        except Exception:
+            return "unknown"
+    return "unknown"
+
+
+def _csv(value: str, valid, what: str) -> List[str]:
+    if value == "all":
+        return list(valid)
+    items = [v.strip() for v in value.split(",") if v.strip()]
+    bad = [i for i in items if i not in valid]
+    if bad:
+        raise SystemExit(
+            f"unknown {what}: {', '.join(bad)}\nknown: {', '.join(valid)}"
+        )
+    return items
+
+
+def main(argv=None) -> int:
+    p = argparse.ArgumentParser(
+        prog="warmstart.run", description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--solver", default="pounce", help="adapter name (default: pounce)")
+    p.add_argument("--families", default="all", help="comma-separated, or 'all'")
+    p.add_argument("--scales", default="all", help="comma-separated, or 'all'")
+    p.add_argument("--arms", default="all", help="comma-separated, or 'all'")
+    p.add_argument("--tol", type=float, default=1e-8, help="solver tolerance")
+    p.add_argument(
+        "--kkt-gate",
+        type=float,
+        default=1e-4,
+        help="KKT residual a step must actually achieve to count as "
+        "converged, independent of the solver's own status code",
+    )
+    p.add_argument(
+        "--viol-gate",
+        type=float,
+        default=1e-5,
+        help="constraint violation a step must achieve to count as converged",
+    )
+    p.add_argument(
+        "--obj-tol",
+        type=float,
+        default=1e-6,
+        help="relative objective margin: a step whose objective is worse "
+        "than the reference arm's by more than this is counted incorrect",
+    )
+    p.add_argument("--max-iter", type=int, default=500)
+    p.add_argument("--quick", action="store_true", help="3 families, one scale")
+    p.add_argument("--out", default=os.path.join(_HERE, "results.json"))
+    p.add_argument("--no-report", action="store_true")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+
+    families = _csv(args.families, list(REGISTRY), "family")
+    scales = _csv(args.scales, list(SCALES), "scale")
+    arms = _csv(args.arms, ARMS, "arm")
+    if args.quick:
+        families = [f for f in families if f in _QUICK_FAMILIES]
+        scales = ["small"]
+
+    adapter = get_adapter(args.solver, max_iter=args.max_iter)
+
+    meta = {
+        "solver": args.solver,
+        "solver_version": _solver_version(args.solver),
+        "git_sha": _git_sha(),
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "platform": platform.platform(),
+        "python": platform.python_version(),
+        "tol": args.tol,
+        "obj_tol": args.obj_tol,
+        "kkt_gate": args.kkt_gate,
+        "viol_gate": args.viol_gate,
+        "max_iter": args.max_iter,
+        "arms": arms,
+    }
+
+    runs = []
+    total = len(families) * len(scales)
+    done = 0
+    for family in families:
+        for scale in scales:
+            done += 1
+            print(f"[{done}/{total}] {family} @ {scale} ... ", end="", flush=True)
+            t0 = time.perf_counter()
+            run = run_family_scale(
+                adapter,
+                family,
+                scale,
+                arms,
+                tol=args.tol,
+                obj_tol=args.obj_tol,
+                kkt_gate=args.kkt_gate,
+                viol_gate=args.viol_gate,
+            )
+            runs.append(run)
+            print(f"{time.perf_counter() - t0:.1f}s")
+            if args.verbose:
+                for arm, steps in run["arms"].items():
+                    it = sum(s["iters"] for s in steps)
+                    bad = sum(0 if s["correct"] else 1 for s in steps)
+                    print(f"      {arm:<9} iters={it:<6} incorrect={bad}")
+
+    payload = {"meta": meta, "runs": runs}
+    with open(args.out, "w") as fh:
+        json.dump(payload, fh, indent=1)
+    print(f"\nwrote {args.out}")
+
+    if not args.no_report:
+        report_path = os.path.splitext(args.out)[0] + ".md"
+        with open(report_path, "w") as fh:
+            fh.write(render(payload))
+        print(f"wrote {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/warmstart/runner.py
+++ b/benchmarks/warmstart/runner.py
@@ -32,7 +32,7 @@ from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
-from .adapters.base import REFERENCE_ARM, SolverAdapter, is_warm
+from .adapters.base import REFERENCE_ARM, SolverAdapter, arm_applies, is_warm
 from .families import make
 from .spec import SCALES, ParametricFamily, StepResult, WarmState
 from .sparsity import SparseCallbacks
@@ -196,6 +196,10 @@ def run_family_scale(
             continue
         if not adapter.supports(arm):
             skipped[arm] = f"{adapter.name} does not support {arm}"
+            continue
+        why = arm_applies(arm, family)
+        if why is not None:
+            skipped[arm] = why
             continue
         res, sol = _run_path(adapter, family, callbacks, arm, path, tol)
         arm_results[arm] = res

--- a/benchmarks/warmstart/runner.py
+++ b/benchmarks/warmstart/runner.py
@@ -1,0 +1,232 @@
+"""The measurement protocol.
+
+For each (family, scale) the runner walks the parameter path once per
+arm and records every step. Three rules make the arms comparable, and
+they are the whole reason this file exists rather than a loop inlined
+in the CLI:
+
+1. **Every arm sees the identical parameter sequence.** For scripted
+   families that is trivial. For closed-loop families the path is
+   generated once by the reference arm and replayed for the others —
+   otherwise small solution differences would fan out into different
+   problem sequences and the iteration counts would be measuring
+   different work.
+
+2. **Warm arms start their step-0 solve cold.** There is nothing to
+   warm from at k=0. Reporting that step as warm would flatter the
+   arm; reporting the path total without it would hide real work. It
+   is recorded as-is and marked.
+
+3. **Every step is checked against the reference solution.** A warm
+   start that converges fast to the wrong point — a different local
+   minimum, or the right point on the wrong face of a degenerate
+   active set — is a failure, not a win. Speed numbers for a step
+   that fails the check are still recorded, but the step is flagged
+   and the report counts it separately.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .adapters.base import REFERENCE_ARM, SolverAdapter, is_warm
+from .families import make
+from .spec import SCALES, ParametricFamily, StepResult, WarmState
+from .sparsity import SparseCallbacks
+
+
+def _ws_distance(a, b) -> Optional[int]:
+    """Hamming distance between two working sets."""
+    if a is None or b is None:
+        return None
+    return int(np.count_nonzero(a[0] != b[0]) + np.count_nonzero(a[1] != b[1]))
+
+
+def _run_path(
+    adapter: SolverAdapter,
+    family: ParametricFamily,
+    callbacks: SparseCallbacks,
+    arm: str,
+    path: List[np.ndarray],
+    tol: float,
+) -> Tuple[List[StepResult], List[np.ndarray]]:
+    """Solve every step of a scripted path with one arm."""
+    warm: Optional[WarmState] = None
+    prev_ws = None
+    results: List[StepResult] = []
+    solutions: List[np.ndarray] = []
+
+    for k, theta in enumerate(path):
+        family.set_theta(theta)
+        res, nxt = adapter.solve(
+            family=family,
+            callbacks=callbacks,
+            arm=arm,
+            x0=family.cold_x0(),
+            warm=warm if is_warm(arm) else None,
+            step=k,
+            tol=tol,
+        )
+        res.theta = [float(v) for v in np.atleast_1d(theta)]
+        res.ws_changed = _ws_distance(prev_ws, nxt.working_set if nxt else None)
+        results.append(res)
+        solutions.append(nxt.x if nxt is not None else np.full(family.n, np.nan))
+        prev_ws = nxt.working_set if nxt is not None else None
+        warm = nxt
+
+    return results, solutions
+
+
+def _run_adaptive_reference(
+    adapter: SolverAdapter,
+    family: ParametricFamily,
+    callbacks: SparseCallbacks,
+    scale: float,
+    tol: float,
+) -> Tuple[List[StepResult], List[np.ndarray], List[np.ndarray]]:
+    """Run the reference arm on a closed-loop family, recording the path."""
+    theta = family.initial_theta(scale)
+    path: List[np.ndarray] = []
+    results: List[StepResult] = []
+    solutions: List[np.ndarray] = []
+
+    for k in range(family.n_steps):
+        family.set_theta(theta)
+        path.append(np.atleast_1d(np.asarray(theta, dtype=float)).copy())
+        res, nxt = adapter.solve(
+            family=family,
+            callbacks=callbacks,
+            arm=REFERENCE_ARM,
+            x0=family.cold_x0(),
+            warm=None,
+            step=k,
+            tol=tol,
+        )
+        res.theta = [float(v) for v in path[-1]]
+        results.append(res)
+        solutions.append(nxt.x)
+        theta = family.next_theta(nxt.x)
+
+    return results, solutions, path
+
+
+def _score_correctness(
+    results: List[StepResult],
+    solutions: List[np.ndarray],
+    ref_solutions: List[np.ndarray],
+    ref_results: List[StepResult],
+    obj_tol: float,
+    kkt_gate: float,
+    viol_gate: float,
+) -> None:
+    """Judge each step, and record how it compares to the reference arm.
+
+    Deliberately *not* "did it match the reference": on a nonconvex
+    family the reference arm is a baseline, not ground truth — it can
+    and does converge to a worse local minimum than a warm-started arm
+    finds. Judging against it would score the better answer as wrong.
+
+    So a step is judged on its own terms first — did it converge, is
+    its KKT residual actually small, is it feasible — and only then
+    compared to the reference, where the *sign* of the objective
+    difference is what matters:
+
+    * worse objective (beyond ``obj_tol``) → not correct. This is the
+      failure mode a warm start causes: seeded inside the wrong active
+      set or the wrong basin, it converges quickly to a worse point.
+    * better objective → correct, and flagged as ``better`` so the
+      report can say so rather than burying it.
+
+    ``x_err`` is recorded throughout as a diagnostic but is not a gate:
+    two solves can both be optimal and differ in ``x`` when the
+    solution is not unique (a degenerate face, a flat direction).
+    """
+    for res, x, x_ref, ref in zip(results, solutions, ref_solutions, ref_results):
+        scale = 1.0 + float(np.max(np.abs(x_ref))) if x_ref.size else 1.0
+        res.x_err = (
+            float(np.max(np.abs(x - x_ref))) / scale if x.size else float("inf")
+        )
+        res.obj_err = abs(res.obj - ref.obj) / (1.0 + abs(ref.obj))
+
+        res.converged = bool(
+            res.success
+            and np.isfinite(res.kkt_error)
+            and res.kkt_error <= kkt_gate
+            and (not np.isfinite(res.constr_viol) or res.constr_viol <= viol_gate)
+        )
+        margin = obj_tol * (1.0 + abs(ref.obj))
+        res.better = bool(ref.success and res.obj < ref.obj - margin)
+        worse = bool(ref.success and res.obj > ref.obj + margin)
+        res.correct = bool(res.converged and not worse)
+
+
+def run_family_scale(
+    adapter: SolverAdapter,
+    family_name: str,
+    scale_name: str,
+    arms: List[str],
+    tol: float = 1e-8,
+    obj_tol: float = 1e-6,
+    kkt_gate: float = 1e-4,
+    viol_gate: float = 1e-5,
+) -> dict:
+    """Run every arm over one family at one scale. Returns a JSON-able dict."""
+    scale = SCALES[scale_name]
+    family = make(family_name)
+    callbacks = SparseCallbacks(family)
+
+    arm_results: Dict[str, List[StepResult]] = {}
+    arm_solutions: Dict[str, List[np.ndarray]] = {}
+    skipped: Dict[str, str] = {}
+
+    path = family.theta_path(scale)
+    if path is None:
+        # Closed-loop: the reference arm defines the path.
+        res, sol, path = _run_adaptive_reference(
+            adapter, family, callbacks, scale, tol
+        )
+        arm_results[REFERENCE_ARM] = res
+        arm_solutions[REFERENCE_ARM] = sol
+
+    for arm in arms:
+        if arm in arm_results:
+            continue
+        if not adapter.supports(arm):
+            skipped[arm] = f"{adapter.name} does not support {arm}"
+            continue
+        res, sol = _run_path(adapter, family, callbacks, arm, path, tol)
+        arm_results[arm] = res
+        arm_solutions[arm] = sol
+
+    if REFERENCE_ARM in arm_results:
+        for arm, res in arm_results.items():
+            _score_correctness(
+                res,
+                arm_solutions[arm],
+                arm_solutions[REFERENCE_ARM],
+                arm_results[REFERENCE_ARM],
+                obj_tol,
+                kkt_gate,
+                viol_gate,
+            )
+
+    return {
+        "family": family_name,
+        "tags": dict(family.tags),
+        "n": family.n,
+        "m": family.m,
+        "nnz_jac": callbacks.nnz_jac,
+        "nnz_hess": callbacks.nnz_hess,
+        "adaptive": family.adaptive,
+        "scale": scale_name,
+        "scale_factor": scale,
+        "n_steps": len(path),
+        "arms": {
+            arm: [dataclasses.asdict(r) for r in res]
+            for arm, res in arm_results.items()
+        },
+        "skipped": skipped,
+    }

--- a/benchmarks/warmstart/selftest.py
+++ b/benchmarks/warmstart/selftest.py
@@ -1,0 +1,177 @@
+"""Finite-difference check of every family's derivatives.
+
+A wrong Jacobian or Hessian in a benchmark family does not announce
+itself — it shows up as "the warm-started arm needed more iterations",
+which is exactly the signal the benchmark exists to measure. So this
+runs before any result is believed, and in CI.
+
+Checks, at several points along each family's path:
+
+* ``gradient``          vs central differences of ``objective``
+* ``jacobian_dense``    vs central differences of ``constraints``
+* ``hessian_dense``     vs central differences of ∇ₓL, where
+  ``L = obj_factor·f + λᵀg`` (the cyipopt sign convention the
+  families are written to)
+
+Run with ``python -m warmstart.selftest`` (no solver required).
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import List
+
+import numpy as np
+
+from .families import REGISTRY, make
+from .spec import ParametricFamily
+from .sparsity import SparseCallbacks
+
+_EPS = 1e-6
+_RTOL = 2e-4
+
+
+def _fd_gradient(f, x):
+    g = np.zeros_like(x)
+    for i in range(x.size):
+        h = _EPS * max(1.0, abs(x[i]))
+        xp, xm = x.copy(), x.copy()
+        xp[i] += h
+        xm[i] -= h
+        g[i] = (f(xp) - f(xm)) / (2.0 * h)
+    return g
+
+
+def _fd_jacobian(c, x, m):
+    j = np.zeros((m, x.size))
+    for i in range(x.size):
+        h = _EPS * max(1.0, abs(x[i]))
+        xp, xm = x.copy(), x.copy()
+        xp[i] += h
+        xm[i] -= h
+        j[:, i] = (c(xp) - c(xm)) / (2.0 * h)
+    return j
+
+
+def _rel_err(a, b) -> float:
+    denom = max(1.0, float(np.max(np.abs(b))) if np.size(b) else 1.0)
+    return float(np.max(np.abs(a - b))) / denom if np.size(a) else 0.0
+
+
+def _sample_points(family: ParametricFamily, rng) -> List[np.ndarray]:
+    b = family.bounds()
+    lo = np.where(b.lb > -1e19, b.lb, -2.0)
+    hi = np.where(b.ub < 1e19, b.ub, 2.0)
+    span = np.clip(hi - lo, 1e-3, 3.0)
+    x0 = np.clip(family.cold_x0(), lo, hi)
+    return [x0] + [
+        np.clip(x0 + span * (rng.random(family.n) - 0.5), lo, hi)
+        for _ in range(3)
+    ]
+
+
+def check_family(name: str, verbose: bool = True) -> List[str]:
+    """Returns a list of failure messages (empty when the family is sound)."""
+    rng = np.random.default_rng(1234)
+    family = make(name)
+    failures: List[str] = []
+
+    path = family.theta_path(1.0)
+    if path is None:
+        path = [family.initial_theta(1.0)]
+    thetas = [path[0], path[len(path) // 2], path[-1]]
+
+    worst = {"grad": 0.0, "jac": 0.0, "hess": 0.0}
+    for theta in thetas:
+        family.set_theta(theta)
+        for x in _sample_points(family, rng):
+            e = _rel_err(family.gradient(x), _fd_gradient(family.objective, x))
+            worst["grad"] = max(worst["grad"], e)
+            if e > _RTOL:
+                failures.append(f"{name}: gradient rel-err {e:.2e} at θ={theta}")
+
+            e = _rel_err(
+                family.jacobian_dense(x),
+                _fd_jacobian(family.constraints, x, family.m),
+            )
+            worst["jac"] = max(worst["jac"], e)
+            if e > _RTOL:
+                failures.append(f"{name}: jacobian rel-err {e:.2e} at θ={theta}")
+
+            lam = rng.standard_normal(family.m)
+            for obj_factor in (1.0, 0.0):
+
+                def lag_grad(z, lam=lam, obj_factor=obj_factor):
+                    return obj_factor * family.gradient(z) + family.jacobian_dense(
+                        z
+                    ).T @ lam
+
+                fd = np.zeros((family.n, family.n))
+                for i in range(family.n):
+                    h = _EPS * max(1.0, abs(x[i]))
+                    xp, xm = x.copy(), x.copy()
+                    xp[i] += h
+                    xm[i] -= h
+                    fd[:, i] = (lag_grad(xp) - lag_grad(xm)) / (2.0 * h)
+                e = _rel_err(family.hessian_dense(x, lam, obj_factor), fd)
+                worst["hess"] = max(worst["hess"], e)
+                if e > _RTOL:
+                    failures.append(
+                        f"{name}: hessian rel-err {e:.2e} "
+                        f"(obj_factor={obj_factor}) at θ={theta}"
+                    )
+
+    # The sparse wrapper must agree with the dense source it came from.
+    cb = SparseCallbacks(family)
+    x = family.cold_x0()
+    lam = rng.standard_normal(family.m)
+    jr, jc = cb.jacobianstructure()
+    dense_j = family.jacobian_dense(x)
+    packed = cb.jacobian(x)
+    if packed.size != jr.size or not np.allclose(packed, dense_j[jr, jc]):
+        failures.append(f"{name}: sparse jacobian disagrees with dense")
+    hr, hc = cb.hessianstructure()
+    dense_h = family.hessian_dense(x, lam, 1.0)
+    packed_h = cb.hessian(x, lam, 1.0)
+    if packed_h.size != hr.size or not np.allclose(packed_h, dense_h[hr, hc]):
+        failures.append(f"{name}: sparse hessian disagrees with dense")
+    if np.any(hr < hc):
+        failures.append(f"{name}: hessian structure is not lower-triangular")
+    # Anything nonzero in the dense lower triangle must be in the pattern.
+    covered = np.zeros_like(dense_h, dtype=bool)
+    covered[hr, hc] = True
+    missed = np.tril(np.abs(dense_h) > 0) & ~covered
+    if missed.any():
+        failures.append(
+            f"{name}: {int(missed.sum())} nonzero hessian entries "
+            "outside the sampled sparsity pattern"
+        )
+
+    if verbose:
+        status = "FAIL" if failures else "ok"
+        print(
+            f"  {name:<18} n={family.n:<4} m={family.m:<4} "
+            f"grad={worst['grad']:.1e} jac={worst['jac']:.1e} "
+            f"hess={worst['hess']:.1e}  {status}"
+        )
+    return failures
+
+
+def main(argv=None) -> int:
+    names = argv or list(REGISTRY)
+    print(f"Checking derivatives for {len(names)} families "
+          f"(central differences, rtol={_RTOL:g}):")
+    failures: List[str] = []
+    for name in names:
+        failures.extend(check_family(name))
+    if failures:
+        print("\nFAILURES:")
+        for f in failures:
+            print(f"  {f}")
+        return 1
+    print("\nAll families pass.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:] or None))

--- a/benchmarks/warmstart/selftest.py
+++ b/benchmarks/warmstart/selftest.py
@@ -13,6 +13,12 @@ Checks, at several points along each family's path:
   ``L = obj_factor·f + λᵀg`` (the cyipopt sign convention the
   families are written to)
 
+For any family claiming ``quadratic = True`` it additionally re-derives
+the family from the extracted standard-form QP data (:mod:`qpform`) —
+objective, gradient, and every constraint row — and checks that ``P`` is
+symmetric positive semidefinite. A family that fails this is not a QP
+and must not be handed to the convex solver, whatever it declares.
+
 Run with ``python -m warmstart.selftest`` (no solver required).
 """
 
@@ -23,6 +29,7 @@ from typing import List
 
 import numpy as np
 
+from . import qpform
 from .families import REGISTRY, make
 from .spec import ParametricFamily
 from .sparsity import SparseCallbacks
@@ -147,12 +154,21 @@ def check_family(name: str, verbose: bool = True) -> List[str]:
             "outside the sampled sparsity pattern"
         )
 
+    # Families that claim to be QPs must survive being turned into one.
+    if family.quadratic:
+        for theta in thetas:
+            family.set_theta(theta)
+            qp = qpform.extract(family)
+            for msg in qpform.verify(family, qp, rng):
+                failures.append(f"{name}: QP extraction — {msg} (θ={theta})")
+
     if verbose:
         status = "FAIL" if failures else "ok"
+        qp_note = " qp:ok" if family.quadratic and not failures else ""
         print(
-            f"  {name:<18} n={family.n:<4} m={family.m:<4} "
+            f"  {name:<22} n={family.n:<4} m={family.m:<4} "
             f"grad={worst['grad']:.1e} jac={worst['jac']:.1e} "
-            f"hess={worst['hess']:.1e}  {status}"
+            f"hess={worst['hess']:.1e}  {status}{qp_note}"
         )
     return failures
 

--- a/benchmarks/warmstart/sparsity.py
+++ b/benchmarks/warmstart/sparsity.py
@@ -1,0 +1,170 @@
+"""Dense family callbacks → cyipopt-shaped sparse callbacks, with counters.
+
+Families in this suite write their Jacobian and Hessian densely
+(:meth:`ParametricFamily.jacobian_dense` /
+:meth:`~ParametricFamily.hessian_dense`). This module turns one into
+the ``jacobianstructure`` / ``jacobian`` / ``hessianstructure`` /
+``hessian`` quartet every Ipopt-style interface expects.
+
+Two reasons to go through here rather than hand-writing structures per
+family:
+
+1. **The structure and the values cannot disagree.** The classic
+   silent-wrong-answer bug in this interface is a structure array that
+   no longer matches the order the value callback packs entries in.
+   Here both come from the same dense matrix, so the correspondence is
+   constructive.
+2. **Evaluation counts mean the same thing for every solver.** The
+   wrapper counts calls itself instead of trusting a solver-reported
+   statistic, which is the only way ``n_hess`` compares across a
+   Newton method and a quasi-Newton one.
+
+The sparsity pattern is *sampled*: the dense callbacks are evaluated
+at a handful of randomized points (and, for the Hessian, randomized
+multipliers and objective factors) and the union of nonzeros is taken.
+That avoids pinning a pattern to an accidental zero at one special
+point. Structural entries that are zero at every sample are simply
+absent from the pattern — harmless, since they are zero wherever the
+solver would have read them, for every θ along the path (families are
+required to keep sparsity θ-invariant).
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import numpy as np
+
+from .spec import ParametricFamily
+
+#: Number of randomized probes used to infer a sparsity pattern.
+_N_PROBES = 8
+
+#: Entries with |value| below this at every probe are treated as
+#: structurally zero.
+_PATTERN_TOL = 0.0
+
+
+def _probe_points(family: ParametricFamily, rng: np.random.Generator) -> list:
+    """Points to sample the sparsity pattern at.
+
+    The cold start plus random points inside the bounds (finite bounds
+    respected so a family that would divide by zero outside its domain
+    is not evaluated there).
+    """
+    b = family.bounds()
+    lo = np.where(np.isfinite(b.lb) & (b.lb > -1e19), b.lb, -1.0)
+    hi = np.where(np.isfinite(b.ub) & (b.ub < 1e19), b.ub, 1.0)
+    # Keep the box non-degenerate and modest in size.
+    span = np.clip(hi - lo, 1e-3, 4.0)
+    base = np.clip(family.cold_x0(), lo, hi)
+    pts = [base]
+    for _ in range(_N_PROBES - 1):
+        pts.append(np.clip(base + span * (rng.random(family.n) - 0.5), lo, hi))
+    return pts
+
+
+class SparseCallbacks:
+    """cyipopt-style callback object over a :class:`ParametricFamily`.
+
+    Instances are passed straight to a solver's problem constructor.
+    The sparsity pattern is computed once at construction and reused
+    for the whole path.
+    """
+
+    def __init__(self, family: ParametricFamily, seed: int = 0):
+        self.family = family
+        rng = np.random.default_rng(seed)
+        pts = _probe_points(family, rng)
+
+        n, m = family.n, family.m
+
+        jac_pat = np.zeros((m, n), dtype=bool)
+        hess_pat = np.zeros((n, n), dtype=bool)
+        for x in pts:
+            if m:
+                jac_pat |= np.abs(family.jacobian_dense(x)) > _PATTERN_TOL
+            lam = rng.standard_normal(m) if m else np.zeros(0)
+            for obj_factor in (1.0, 0.0):
+                h = family.hessian_dense(x, lam, obj_factor)
+                hess_pat |= np.abs(h) > _PATTERN_TOL
+
+        self._jac_rows, self._jac_cols = np.nonzero(jac_pat)
+        # Ipopt-style interfaces want the *lower* triangle of the
+        # (symmetric) Hessian of the Lagrangian.
+        hess_pat = np.tril(hess_pat | hess_pat.T)
+        self._hess_rows, self._hess_cols = np.nonzero(hess_pat)
+
+        self.reset_counts()
+
+    # -- instrumentation -------------------------------------------
+
+    def reset_counts(self) -> None:
+        self.n_obj = 0
+        self.n_grad = 0
+        self.n_cons = 0
+        self.n_jac = 0
+        self.n_hess = 0
+
+    def counts(self) -> dict:
+        return {
+            "n_obj": self.n_obj,
+            "n_grad": self.n_grad,
+            "n_cons": self.n_cons,
+            "n_jac": self.n_jac,
+            "n_hess": self.n_hess,
+        }
+
+    @property
+    def nnz_jac(self) -> int:
+        return int(self._jac_rows.size)
+
+    @property
+    def nnz_hess(self) -> int:
+        return int(self._hess_rows.size)
+
+    # -- cyipopt-shaped callbacks ----------------------------------
+
+    def objective(self, x):
+        self.n_obj += 1
+        return float(self.family.objective(np.asarray(x, dtype=float)))
+
+    def gradient(self, x):
+        self.n_grad += 1
+        return np.asarray(
+            self.family.gradient(np.asarray(x, dtype=float)), dtype=float
+        )
+
+    def constraints(self, x):
+        self.n_cons += 1
+        return np.asarray(
+            self.family.constraints(np.asarray(x, dtype=float)), dtype=float
+        )
+
+    def jacobianstructure(self) -> Tuple[np.ndarray, np.ndarray]:
+        return (
+            self._jac_rows.astype(np.int64),
+            self._jac_cols.astype(np.int64),
+        )
+
+    def jacobian(self, x):
+        self.n_jac += 1
+        j = self.family.jacobian_dense(np.asarray(x, dtype=float))
+        return np.ascontiguousarray(j[self._jac_rows, self._jac_cols], dtype=float)
+
+    def hessianstructure(self) -> Tuple[np.ndarray, np.ndarray]:
+        return (
+            self._hess_rows.astype(np.int64),
+            self._hess_cols.astype(np.int64),
+        )
+
+    def hessian(self, x, lagrange, obj_factor):
+        self.n_hess += 1
+        h = self.family.hessian_dense(
+            np.asarray(x, dtype=float),
+            np.asarray(lagrange, dtype=float),
+            float(obj_factor),
+        )
+        return np.ascontiguousarray(
+            h[self._hess_rows, self._hess_cols], dtype=float
+        )

--- a/benchmarks/warmstart/spec.py
+++ b/benchmarks/warmstart/spec.py
@@ -1,0 +1,221 @@
+"""Solver-agnostic core types for the warm-start benchmark.
+
+Nothing in this module imports pounce. A *family* here is a
+parameterized NLP plus a scripted path through its parameter space;
+an *arm* is one way of solving that path (cold every step, or warm
+from the previous step); an *adapter* (see ``adapters/``) is the only
+place a concrete solver appears. Keeping the split strict is what
+lets this suite be lifted out of the pounce tree later, or pointed at
+Ipopt/knitro/whatever for a cross-solver comparison.
+
+Why families-and-paths rather than a bag of problems: warm starting
+has no meaning for a single isolated NLP. The quantity under test is
+the cost of solving a *sequence* of related problems, and the thing
+that predicts whether warm starting pays is how the active set moves
+along that sequence. So the benchmark's unit of work is the whole
+path, and every family carries tags describing the active-set regime
+it was built to exercise.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from abc import ABC, abstractmethod
+from typing import Dict, List, Optional, Sequence
+
+import numpy as np
+
+# Working-set status codes. These match pounce's int8 encoding
+# (see docs/src/active-set-sqp.md §3) but are restated here so the
+# core stays free of solver imports; an adapter for a solver with a
+# different encoding translates into these.
+WS_INACTIVE = 0
+WS_AT_LOWER = 1
+WS_AT_UPPER = 2
+WS_FIXED = 3  # Fixed (variable) / Equality (constraint)
+
+# Step-size multipliers applied to a family's natural per-step
+# parameter increment. Warm-start payoff is a function of how far the
+# problem moved, so every family is run at all three: `tiny` is the
+# continuation regime (active set almost surely unchanged), `large`
+# is where the active set churns and warm starting can *hurt*.
+SCALES: Dict[str, float] = {"tiny": 0.1, "small": 1.0, "large": 4.0}
+
+
+@dataclasses.dataclass(frozen=True)
+class Bounds:
+    """Variable and constraint bounds, cyipopt naming."""
+
+    lb: np.ndarray
+    ub: np.ndarray
+    cl: np.ndarray
+    cu: np.ndarray
+
+
+@dataclasses.dataclass
+class WarmState:
+    """What one solve hands to the next.
+
+    Deliberately a plain data record: primal point, the three
+    multiplier blocks, the barrier parameter, and the discrete working
+    set. A solver adapter consumes whichever fields its warm-start
+    path understands (an active-set method wants ``working_set``; an
+    interior-point method wants the multipliers and ``mu``) and
+    ignores the rest.
+
+    ``working_set`` is a ``(bound_status, constraint_status)`` pair of
+    int8 arrays using the ``WS_*`` codes above.
+    """
+
+    x: np.ndarray
+    mult_g: Optional[np.ndarray] = None
+    mult_x_L: Optional[np.ndarray] = None
+    mult_x_U: Optional[np.ndarray] = None
+    mu: Optional[float] = None
+    working_set: Optional[Sequence[np.ndarray]] = None
+
+
+@dataclasses.dataclass
+class StepResult:
+    """One solve of one step of one path."""
+
+    step: int
+    theta: List[float]
+    success: bool
+    status: int
+    status_msg: str
+    iters: int
+    solve_time: float
+    obj: float
+    kkt_error: float
+    constr_viol: float
+    # Evaluation counts, measured by the harness rather than reported
+    # by the solver, so they mean the same thing for every solver.
+    n_obj: int
+    n_grad: int
+    n_cons: int
+    n_jac: int
+    n_hess: int
+    # Inner subproblem work on an active-set path: QP subproblems
+    # solved and active-set changes (adds + drops) inside them. `None`
+    # for a solver/path with no QP subproblems. On a QP-shaped family
+    # the outer iteration count is 1 by construction and this is the
+    # only measurement that responds to a warm start at all.
+    n_qp_solves: Optional[int] = None
+    n_qp_ws_changes: Optional[int] = None
+    # Active-set descriptors, present only when the solver returned a
+    # working set (i.e. the active-set path).
+    n_active: Optional[int] = None
+    ws_changed: Optional[int] = None  # Hamming distance from previous step
+    # Correctness, filled in by the runner. `correct` requires the step
+    # to have converged on its own terms (status, KKT residual, feasibility)
+    # *and* to not have landed on a worse optimum than the reference arm.
+    # `better` marks a step that found a strictly better objective than the
+    # reference — on a nonconvex family that happens, and it is not an error.
+    x_err: Optional[float] = None
+    obj_err: Optional[float] = None
+    converged: Optional[bool] = None
+    better: Optional[bool] = None
+    correct: Optional[bool] = None
+
+
+class ParametricFamily(ABC):
+    """A parameterized NLP together with a path through parameter space.
+
+    Subclasses supply the usual cyipopt-shaped callbacks, but in
+    *dense* form — :mod:`sparsity` derives the sparsity patterns and
+    the packed value vectors from them, so a family author cannot get
+    the structure/value correspondence out of sync. Sizes here are
+    small enough (n ≲ 300) that dense assembly costs nothing next to
+    the solve.
+
+    The parameter enters through :meth:`set_theta`; everything else
+    about the problem — shape, bounds, sparsity — must stay fixed
+    along the path, since that is precisely the situation a warm start
+    exploits.
+    """
+
+    #: Short identifier used on the command line and in the report.
+    name: str = "unnamed"
+
+    #: Free-form descriptors, rendered in the report so a reader can
+    #: connect a result to the property that produced it. Conventional
+    #: keys: ``regime`` (stable / flipping / degenerate / none),
+    #: ``channel`` (objective / rhs / bounds / mixed),
+    #: ``curvature`` (convex / nonconvex).
+    tags: Dict[str, str] = {}
+
+    #: Number of parameter steps in the path (the k=0 solve included).
+    n_steps: int = 20
+
+    #: True when the next parameter depends on the previous solution
+    #: (closed-loop MPC / moving horizon). The runner then records the
+    #: path produced by the reference arm and *replays* it for the
+    #: others, so every arm sees an identical sequence.
+    adaptive: bool = False
+
+    # -- shape -----------------------------------------------------
+
+    @property
+    @abstractmethod
+    def n(self) -> int:
+        """Number of variables."""
+
+    @property
+    @abstractmethod
+    def m(self) -> int:
+        """Number of constraints."""
+
+    @abstractmethod
+    def bounds(self) -> Bounds:
+        """Bounds at the *current* parameter (bounds may move with θ)."""
+
+    @abstractmethod
+    def cold_x0(self) -> np.ndarray:
+        """The starting point a cold solve gets, independent of θ."""
+
+    # -- parameter path --------------------------------------------
+
+    @abstractmethod
+    def set_theta(self, theta: np.ndarray) -> None:
+        """Install parameter θ. Must not change n, m, or sparsity."""
+
+    @abstractmethod
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        """The scripted parameter path, or ``None`` when adaptive.
+
+        ``scale`` multiplies the family's natural per-step increment.
+        """
+
+    def initial_theta(self, scale: float) -> np.ndarray:
+        """First parameter of an adaptive path (adaptive families only)."""
+        raise NotImplementedError
+
+    def next_theta(self, x_solution: np.ndarray) -> np.ndarray:
+        """Advance an adaptive path using the step's solution."""
+        raise NotImplementedError
+
+    # -- problem functions (dense) ---------------------------------
+
+    @abstractmethod
+    def objective(self, x: np.ndarray) -> float: ...
+
+    @abstractmethod
+    def gradient(self, x: np.ndarray) -> np.ndarray: ...
+
+    @abstractmethod
+    def constraints(self, x: np.ndarray) -> np.ndarray: ...
+
+    @abstractmethod
+    def jacobian_dense(self, x: np.ndarray) -> np.ndarray:
+        """Constraint Jacobian, shape (m, n)."""
+
+    @abstractmethod
+    def hessian_dense(
+        self, x: np.ndarray, lagrange: np.ndarray, obj_factor: float
+    ) -> np.ndarray:
+        """Hessian of the Lagrangian, full symmetric, shape (n, n).
+
+        Sign convention matches cyipopt/Ipopt:
+        ``obj_factor·∇²f + Σ_i lagrange_i·∇²g_i``.
+        """

--- a/benchmarks/warmstart/spec.py
+++ b/benchmarks/warmstart/spec.py
@@ -73,6 +73,11 @@ class WarmState:
     mult_x_U: Optional[np.ndarray] = None
     mu: Optional[float] = None
     working_set: Optional[Sequence[np.ndarray]] = None
+    #: Adapter-private payload. An adapter whose warm start does not fit
+    #: the fields above (a conic solver's own primal-dual state, say) can
+    #: stash it here; nothing in the core inspects it, and no other
+    #: adapter should read it.
+    extra: Optional[dict] = None
 
 
 @dataclasses.dataclass
@@ -147,6 +152,14 @@ class ParametricFamily(ABC):
 
     #: Number of parameter steps in the path (the k=0 solve included).
     n_steps: int = 20
+
+    #: True when every instance along this family's path is literally a
+    #: convex QP — quadratic objective, linear constraints. Families that
+    #: set this can additionally be routed to a dedicated convex QP
+    #: solver (see :mod:`..qpform`); the suite's self-test verifies the
+    #: claim by re-deriving the family from the extracted QP data rather
+    #: than trusting the flag.
+    quadratic: bool = False
 
     #: True when the next parameter depends on the previous solution
     #: (closed-loop MPC / moving horizon). The runner then records the

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -961,6 +961,11 @@ impl IpoptApplication {
         {
             let mut stats = self.statistics.borrow_mut();
             stats.iteration_count = res.n_iter as Index;
+            // Subproblem counters. The outer iteration count alone
+            // cannot show what a working-set warm start bought — the
+            // saved work is inside the QPs — so both are reported.
+            stats.sqp_qp_solves = res.n_qp_solves as Index;
+            stats.sqp_qp_working_set_changes = res.n_qp_working_set_changes as Index;
             stats.final_objective = res.obj;
             // `final_scaled_objective` defaults to NaN; the SQP path does not
             // thread nlp_scaling through the objective (same as the residuals

--- a/crates/pounce-algorithm/src/sqp/result.rs
+++ b/crates/pounce-algorithm/src/sqp/result.rs
@@ -102,6 +102,16 @@ pub struct SqpResult {
     pub status: SqpStatus,
     pub n_iter: u32,
     pub n_qp_solves: u32,
+    /// Active-set changes (adds + drops) summed over every step QP
+    /// solved during this call — the inner work a working-set warm
+    /// start exists to avoid. Reported separately from `n_iter`
+    /// because the two move independently: on a QP-shaped NLP the
+    /// outer loop always terminates in one iteration, so the entire
+    /// warm-start effect shows up here and nowhere else.
+    ///
+    /// Excludes second-order-correction QPs, whose stats the line
+    /// search does not surface.
+    pub n_qp_working_set_changes: u32,
     /// Final stationarity residual (max-norm of `∇f + Jᵀ λ_g + λ_x`).
     pub final_stationarity: Number,
     /// Final constraint violation (max-norm of `c(x*)` for

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -150,6 +150,14 @@ impl SqpAlgorithm {
         };
 
         let mut n_qp_solves: u32 = 0;
+        // Inner active-set work: adds + drops summed over every step QP
+        // solved in this call. This — not the outer iteration count — is
+        // what a warm start is trying to reduce, and on a QP-shaped NLP
+        // (one outer iteration by construction) it is the *only* thing
+        // that moves. Second-order-correction QPs are not counted: they
+        // are solved inside the line search, which does not surface its
+        // subproblem stats.
+        let mut n_qp_working_set_changes: u32 = 0;
         let mut final_stationarity = 0.0;
         let mut final_constr_viol = 0.0;
         // l1-merit penalty parameter ν, adapted across iterations
@@ -339,6 +347,7 @@ impl SqpAlgorithm {
                     status: SqpStatus::Optimal,
                     n_iter: outer,
                     n_qp_solves,
+                    n_qp_working_set_changes,
                     final_stationarity,
                     final_constr_viol,
                     working_set: iter.working,
@@ -419,6 +428,7 @@ impl SqpAlgorithm {
                 self.qp_solver.solve(&qp, None, &self.qp_opts)?
             };
             n_qp_solves += 1;
+            n_qp_working_set_changes += sol.stats.n_working_set_changes;
 
             // Cold-start fallback: a warm start seeds the QP with the
             // previous iterate's working set, which is usually a big
@@ -434,6 +444,7 @@ impl SqpAlgorithm {
             if warm_started && matches!(sol.status, QpStatus::MaxIter | QpStatus::NumericalError) {
                 let cold = self.qp_solver.solve(&qp, None, &self.qp_opts)?;
                 n_qp_solves += 1;
+                n_qp_working_set_changes += cold.stats.n_working_set_changes;
                 if cold.status == QpStatus::Optimal {
                     sol = cold;
                 }
@@ -474,6 +485,7 @@ impl SqpAlgorithm {
                     .qp_solver
                     .solve(&qp_data.as_qp(), None, &self.qp_opts)?;
                 n_qp_solves += 1;
+                n_qp_working_set_changes += retry.stats.n_working_set_changes;
                 if retry.status == QpStatus::Optimal {
                     sol = retry;
                 }
@@ -548,6 +560,7 @@ impl SqpAlgorithm {
                         status: SqpStatus::InfeasibleSubproblem,
                         n_iter: outer,
                         n_qp_solves,
+                        n_qp_working_set_changes,
                         final_stationarity,
                         final_constr_viol,
                         working_set: iter.working,
@@ -583,6 +596,7 @@ impl SqpAlgorithm {
                         status,
                         n_iter: outer,
                         n_qp_solves,
+                        n_qp_working_set_changes,
                         final_stationarity,
                         final_constr_viol,
                         working_set: iter.working,
@@ -625,6 +639,7 @@ impl SqpAlgorithm {
                         },
                         n_iter: outer,
                         n_qp_solves,
+                        n_qp_working_set_changes,
                         final_stationarity,
                         final_constr_viol,
                         working_set: iter.working,
@@ -779,6 +794,7 @@ impl SqpAlgorithm {
                     status: SqpStatus::LineSearchFailed,
                     n_iter: outer,
                     n_qp_solves,
+                    n_qp_working_set_changes,
                     final_stationarity,
                     final_constr_viol,
                     working_set: Some(sol.working),
@@ -823,6 +839,7 @@ impl SqpAlgorithm {
             status: SqpStatus::MaxIter,
             n_iter: self.opts.max_iter,
             n_qp_solves,
+            n_qp_working_set_changes,
             final_stationarity,
             final_constr_viol,
             working_set: iter.working,

--- a/crates/pounce-algorithm/src/sqp/tests.rs
+++ b/crates/pounce-algorithm/src/sqp/tests.rs
@@ -1216,69 +1216,6 @@ impl SqpProblemSpec for RosenbrockBallNlp {
             irow,
             jcol,
             vals,
-
-// ─────────────────────────────────────────────────────────────────
-// Simplex projection with bounds — the fixture the warm-start
-// benchmark (`benchmarks/warmstart/`) is built around, shrunk to
-// n = 4:
-//
-//     min ½‖x − p‖²   s.t.  Σx = 1,  x ≥ 0,   p = (0.9, 0.4, −0.2, 0.1)
-//
-// Two components clamp at zero, so a cold QP has to *find* that
-// active set, while a warm-started one is handed it.
-// ─────────────────────────────────────────────────────────────────
-struct SimplexProjNlp;
-
-const SIMPLEX_P: [f64; 4] = [0.9, 0.4, -0.2, 0.1];
-
-impl SqpProblemSpec for SimplexProjNlp {
-    fn n(&self) -> usize {
-        4
-    }
-    fn m(&self) -> usize {
-        1
-    }
-    fn x_init(&self) -> Vec<f64> {
-        vec![0.25; 4]
-    }
-    fn variable_bounds(&self) -> (Vec<f64>, Vec<f64>) {
-        (vec![0.0; 4], vec![NLP_UPPER_BOUND_INF; 4])
-    }
-    fn constraint_bounds(&self) -> (Vec<f64>, Vec<f64>) {
-        (vec![1.0], vec![1.0])
-    }
-    fn eval_f(&mut self, x: &[f64]) -> f64 {
-        0.5 * x
-            .iter()
-            .zip(SIMPLEX_P.iter())
-            .map(|(xi, pi)| (xi - pi) * (xi - pi))
-            .sum::<f64>()
-    }
-    fn eval_grad_f(&mut self, x: &[f64]) -> Vec<f64> {
-        x.iter()
-            .zip(SIMPLEX_P.iter())
-            .map(|(xi, pi)| xi - pi)
-            .collect()
-    }
-    fn eval_c(&mut self, x: &[f64]) -> Vec<f64> {
-        vec![x.iter().sum::<f64>()]
-    }
-    fn eval_jac_c(&mut self, _x: &[f64]) -> Triplet {
-        Triplet {
-            n_rows: 1,
-            n_cols: 4,
-            irow: vec![1; 4],
-            jcol: vec![1, 2, 3, 4],
-            vals: vec![1.0; 4],
-        }
-    }
-    fn eval_hess_lag(&mut self, _x: &[f64], _lambda_g: &[f64]) -> Triplet {
-        Triplet {
-            n_rows: 4,
-            n_cols: 4,
-            irow: vec![1, 2, 3, 4],
-            jcol: vec![1, 2, 3, 4],
-            vals: vec![1.0; 4],
         }
     }
 }
@@ -1329,48 +1266,6 @@ fn issue_416_indefinite_rosenbrock_converges_at_the_default_qp_budget() {
             );
         }
     }
-#[test]
-fn sqp_reports_qp_working_set_changes_and_warm_start_removes_them() {
-    // `n_qp_working_set_changes` is the measurement a working-set
-    // warm start is judged on, and the only one that moves on a
-    // QP-shaped NLP: the outer loop terminates in one iteration
-    // either way, so an outer-iteration comparison shows nothing.
-    // Cold must pay for finding the active set; warm-started at the
-    // optimum must pay nothing.
-    let mut nlp = SimplexProjNlp;
-
-    let qp_solver_a =
-        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
-    let mut alg_a = SqpAlgorithm::new(qp_solver_a, SqpOptions::default());
-    let cold = alg_a.optimize(&mut nlp).unwrap();
-    assert_eq!(cold.status, SqpStatus::Optimal);
-    assert!(
-        cold.n_qp_working_set_changes > 0,
-        "a cold solve has to search for the active set, but reported \
-         {} working-set changes over {} QP solves",
-        cold.n_qp_working_set_changes,
-        cold.n_qp_solves
-    );
-
-    let warm = SqpIterates {
-        x: cold.x.clone(),
-        lambda_g: cold.lambda_g.clone(),
-        lambda_x: cold.lambda_x.clone(),
-        working: Some(cold.working_set.clone().expect("cold solve produces a WS")),
-    };
-    let qp_solver_b =
-        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
-    let mut alg_b = SqpAlgorithm::new(qp_solver_b, SqpOptions::default());
-    let hot = alg_b
-        .optimize_with_warm_start(&mut nlp, Some(warm))
-        .unwrap();
-    assert_eq!(hot.status, SqpStatus::Optimal);
-    assert_eq!(
-        hot.n_qp_working_set_changes, 0,
-        "warm-started at the optimum with the right working set, no \
-         active-set change should be needed"
-    );
-    assert!(hot.n_qp_working_set_changes < cold.n_qp_working_set_changes);
 }
 
 // ─────────────────────────────────────────────────────────────────
@@ -1537,4 +1432,114 @@ fn issue_423_unconstrained_nonconvex_survives_an_unbounded_model() {
             }
         }
     }
+}
+
+// ─────────────────────────────────────────────────────────────────
+// Simplex projection with bounds — the fixture the warm-start
+// benchmark (`benchmarks/warmstart/`) is built around, shrunk to
+// n = 4:
+//
+//     min ½‖x − p‖²   s.t.  Σx = 1,  x ≥ 0,   p = (0.9, 0.4, −0.2, 0.1)
+//
+// Two components clamp at zero, so a cold QP has to *find* that
+// active set, while a warm-started one is handed it.
+// ─────────────────────────────────────────────────────────────────
+struct SimplexProjNlp;
+
+const SIMPLEX_P: [f64; 4] = [0.9, 0.4, -0.2, 0.1];
+
+impl SqpProblemSpec for SimplexProjNlp {
+    fn n(&self) -> usize {
+        4
+    }
+    fn m(&self) -> usize {
+        1
+    }
+    fn x_init(&self) -> Vec<f64> {
+        vec![0.25; 4]
+    }
+    fn variable_bounds(&self) -> (Vec<f64>, Vec<f64>) {
+        (vec![0.0; 4], vec![NLP_UPPER_BOUND_INF; 4])
+    }
+    fn constraint_bounds(&self) -> (Vec<f64>, Vec<f64>) {
+        (vec![1.0], vec![1.0])
+    }
+    fn eval_f(&mut self, x: &[f64]) -> f64 {
+        0.5 * x
+            .iter()
+            .zip(SIMPLEX_P.iter())
+            .map(|(xi, pi)| (xi - pi) * (xi - pi))
+            .sum::<f64>()
+    }
+    fn eval_grad_f(&mut self, x: &[f64]) -> Vec<f64> {
+        x.iter()
+            .zip(SIMPLEX_P.iter())
+            .map(|(xi, pi)| xi - pi)
+            .collect()
+    }
+    fn eval_c(&mut self, x: &[f64]) -> Vec<f64> {
+        vec![x.iter().sum::<f64>()]
+    }
+    fn eval_jac_c(&mut self, _x: &[f64]) -> Triplet {
+        Triplet {
+            n_rows: 1,
+            n_cols: 4,
+            irow: vec![1; 4],
+            jcol: vec![1, 2, 3, 4],
+            vals: vec![1.0; 4],
+        }
+    }
+    fn eval_hess_lag(&mut self, _x: &[f64], _lambda_g: &[f64]) -> Triplet {
+        Triplet {
+            n_rows: 4,
+            n_cols: 4,
+            irow: vec![1, 2, 3, 4],
+            jcol: vec![1, 2, 3, 4],
+            vals: vec![1.0; 4],
+        }
+    }
+}
+
+#[test]
+fn sqp_reports_qp_working_set_changes_and_warm_start_removes_them() {
+    // `n_qp_working_set_changes` is the measurement a working-set
+    // warm start is judged on, and the only one that moves on a
+    // QP-shaped NLP: the outer loop terminates in one iteration
+    // either way, so an outer-iteration comparison shows nothing.
+    // Cold must pay for finding the active set; warm-started at the
+    // optimum must pay nothing.
+    let mut nlp = SimplexProjNlp;
+
+    let qp_solver_a =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let mut alg_a = SqpAlgorithm::new(qp_solver_a, SqpOptions::default());
+    let cold = alg_a.optimize(&mut nlp).unwrap();
+    assert_eq!(cold.status, SqpStatus::Optimal);
+    assert!(
+        cold.n_qp_working_set_changes > 0,
+        "a cold solve has to search for the active set, but reported \
+         {} working-set changes over {} QP solves",
+        cold.n_qp_working_set_changes,
+        cold.n_qp_solves
+    );
+
+    let warm = SqpIterates {
+        x: cold.x.clone(),
+        lambda_g: cold.lambda_g.clone(),
+        lambda_x: cold.lambda_x.clone(),
+        working: Some(cold.working_set.clone().expect("cold solve produces a WS")),
+    };
+    let qp_solver_b =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let mut alg_b = SqpAlgorithm::new(qp_solver_b, SqpOptions::default());
+    let hot = alg_b
+        .optimize_with_warm_start(&mut nlp, Some(warm))
+        .unwrap();
+    assert_eq!(hot.status, SqpStatus::Optimal);
+    assert_eq!(
+        hot.n_qp_working_set_changes, 0,
+        "warm-started at the optimum with the right working set, no \
+         active-set change should be needed"
+    );
+    assert!(hot.n_qp_working_set_changes < cold.n_qp_working_set_changes);
 }

--- a/crates/pounce-algorithm/src/sqp/tests.rs
+++ b/crates/pounce-algorithm/src/sqp/tests.rs
@@ -1216,6 +1216,69 @@ impl SqpProblemSpec for RosenbrockBallNlp {
             irow,
             jcol,
             vals,
+
+// ─────────────────────────────────────────────────────────────────
+// Simplex projection with bounds — the fixture the warm-start
+// benchmark (`benchmarks/warmstart/`) is built around, shrunk to
+// n = 4:
+//
+//     min ½‖x − p‖²   s.t.  Σx = 1,  x ≥ 0,   p = (0.9, 0.4, −0.2, 0.1)
+//
+// Two components clamp at zero, so a cold QP has to *find* that
+// active set, while a warm-started one is handed it.
+// ─────────────────────────────────────────────────────────────────
+struct SimplexProjNlp;
+
+const SIMPLEX_P: [f64; 4] = [0.9, 0.4, -0.2, 0.1];
+
+impl SqpProblemSpec for SimplexProjNlp {
+    fn n(&self) -> usize {
+        4
+    }
+    fn m(&self) -> usize {
+        1
+    }
+    fn x_init(&self) -> Vec<f64> {
+        vec![0.25; 4]
+    }
+    fn variable_bounds(&self) -> (Vec<f64>, Vec<f64>) {
+        (vec![0.0; 4], vec![NLP_UPPER_BOUND_INF; 4])
+    }
+    fn constraint_bounds(&self) -> (Vec<f64>, Vec<f64>) {
+        (vec![1.0], vec![1.0])
+    }
+    fn eval_f(&mut self, x: &[f64]) -> f64 {
+        0.5 * x
+            .iter()
+            .zip(SIMPLEX_P.iter())
+            .map(|(xi, pi)| (xi - pi) * (xi - pi))
+            .sum::<f64>()
+    }
+    fn eval_grad_f(&mut self, x: &[f64]) -> Vec<f64> {
+        x.iter()
+            .zip(SIMPLEX_P.iter())
+            .map(|(xi, pi)| xi - pi)
+            .collect()
+    }
+    fn eval_c(&mut self, x: &[f64]) -> Vec<f64> {
+        vec![x.iter().sum::<f64>()]
+    }
+    fn eval_jac_c(&mut self, _x: &[f64]) -> Triplet {
+        Triplet {
+            n_rows: 1,
+            n_cols: 4,
+            irow: vec![1; 4],
+            jcol: vec![1, 2, 3, 4],
+            vals: vec![1.0; 4],
+        }
+    }
+    fn eval_hess_lag(&mut self, _x: &[f64], _lambda_g: &[f64]) -> Triplet {
+        Triplet {
+            n_rows: 4,
+            n_cols: 4,
+            irow: vec![1, 2, 3, 4],
+            jcol: vec![1, 2, 3, 4],
+            vals: vec![1.0; 4],
         }
     }
 }
@@ -1266,6 +1329,48 @@ fn issue_416_indefinite_rosenbrock_converges_at_the_default_qp_budget() {
             );
         }
     }
+#[test]
+fn sqp_reports_qp_working_set_changes_and_warm_start_removes_them() {
+    // `n_qp_working_set_changes` is the measurement a working-set
+    // warm start is judged on, and the only one that moves on a
+    // QP-shaped NLP: the outer loop terminates in one iteration
+    // either way, so an outer-iteration comparison shows nothing.
+    // Cold must pay for finding the active set; warm-started at the
+    // optimum must pay nothing.
+    let mut nlp = SimplexProjNlp;
+
+    let qp_solver_a =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let mut alg_a = SqpAlgorithm::new(qp_solver_a, SqpOptions::default());
+    let cold = alg_a.optimize(&mut nlp).unwrap();
+    assert_eq!(cold.status, SqpStatus::Optimal);
+    assert!(
+        cold.n_qp_working_set_changes > 0,
+        "a cold solve has to search for the active set, but reported \
+         {} working-set changes over {} QP solves",
+        cold.n_qp_working_set_changes,
+        cold.n_qp_solves
+    );
+
+    let warm = SqpIterates {
+        x: cold.x.clone(),
+        lambda_g: cold.lambda_g.clone(),
+        lambda_x: cold.lambda_x.clone(),
+        working: Some(cold.working_set.clone().expect("cold solve produces a WS")),
+    };
+    let qp_solver_b =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let mut alg_b = SqpAlgorithm::new(qp_solver_b, SqpOptions::default());
+    let hot = alg_b
+        .optimize_with_warm_start(&mut nlp, Some(warm))
+        .unwrap();
+    assert_eq!(hot.status, SqpStatus::Optimal);
+    assert_eq!(
+        hot.n_qp_working_set_changes, 0,
+        "warm-started at the optimum with the right working set, no \
+         active-set change should be needed"
+    );
+    assert!(hot.n_qp_working_set_changes < cold.n_qp_working_set_changes);
 }
 
 // ─────────────────────────────────────────────────────────────────

--- a/crates/pounce-nlp/src/solve_statistics.rs
+++ b/crates/pounce-nlp/src/solve_statistics.rs
@@ -106,6 +106,21 @@ pub struct SolveStatistics {
     /// solve was restoration?" without running with high print_level.
     pub restoration_wall_secs: Number,
 
+    // ---- Active-set SQP subproblem counters. ----
+    //
+    // Populated by `IpoptApplication::optimize_sqp_tnlp`; both stay 0
+    // on the interior-point path, which has no QP subproblems.
+    //
+    /// Number of QP subproblems solved during this solve.
+    pub sqp_qp_solves: Index,
+    /// Active-set changes (adds + drops) summed over those QP
+    /// subproblems. This is the measurement a working-set warm start
+    /// is judged on: the outer iteration count can be identical
+    /// between a cold and a warm solve while this differs by an order
+    /// of magnitude, and on a QP-shaped NLP (one outer iteration by
+    /// construction) it is the only thing that moves at all.
+    pub sqp_qp_working_set_changes: Index,
+
     /// Per-iteration trajectory. Empty when the consumer doesn't ask
     /// for it (`iter_history_enabled = false` on the application or
     /// the binary's `--json-detail summary` mode). Populated in order
@@ -176,6 +191,8 @@ impl Default for SolveStatistics {
             restoration_inner_iters: 0,
             restoration_outer_iters: 0,
             restoration_wall_secs: 0.0,
+            sqp_qp_solves: 0,
+            sqp_qp_working_set_changes: 0,
             iterations: Vec::new(),
         }
     }

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -370,6 +370,8 @@ impl PyProblem {
             stats.final_unscaled_dual_inf,
             stats.final_unscaled_constr_viol,
             stats.final_unscaled_compl,
+            stats.sqp_qp_solves,
+            stats.sqp_qp_working_set_changes,
         )?;
         let ws_obj: PyObject = match &self.last_working_set {
             Some(ws) => encode_working_set(py, ws).into_any().unbind(),
@@ -716,6 +718,8 @@ impl PyProblem {
             stats.final_unscaled_dual_inf,
             stats.final_unscaled_constr_viol,
             stats.final_unscaled_compl,
+            stats.sqp_qp_solves,
+            stats.sqp_qp_working_set_changes,
         )?;
         info.set_item("dx", opt_vec_to_py(py, result.dx))?;
         info.set_item("dx_full", opt_vec_to_py(py, result.dx_full))?;
@@ -1085,6 +1089,8 @@ pub(crate) fn build_info_dict<'py>(
     final_unscaled_dual_inf: Number,
     final_unscaled_constr_viol: Number,
     final_unscaled_compl: Number,
+    sqp_qp_solves: i32,
+    sqp_qp_working_set_changes: i32,
 ) -> PyResult<Bound<'py, PyDict>> {
     let info = PyDict::new_bound(py);
     info.set_item("status", status as i32)?;
@@ -1104,6 +1110,13 @@ pub(crate) fn build_info_dict<'py>(
         bridge.state.final_z_u.clone().into_pyarray_bound(py),
     )?;
     info.set_item("iter_count", iter_count)?;
+    // Active-set SQP subproblem work. `iter_count` on that path is the
+    // *outer* iteration count, which says nothing about how much
+    // active-set searching the QPs underneath did — and that is exactly
+    // what a working-set warm start changes. Both are 0 on the IPM path,
+    // which solves no QP subproblems.
+    info.set_item("n_qp_solves", sqp_qp_solves)?;
+    info.set_item("n_qp_ws_changes", sqp_qp_working_set_changes)?;
     // Converged barrier parameter μ. Thread this into the next
     // warm-started solve's `mu_init` / `warm_start_target_mu` to seed
     // the corrector in predictor–corrector path following (pounce#86).

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -125,6 +125,8 @@ impl PySolver {
             stats.final_unscaled_dual_inf,
             stats.final_unscaled_constr_viol,
             stats.final_unscaled_compl,
+            stats.sqp_qp_solves,
+            stats.sqp_qp_working_set_changes,
         )?;
         let x_out = bridge.borrow().state.final_x.clone().into_pyarray_bound(py);
         let _ = bridge; // alive via inner's Rc<RefCell<dyn TNLP>> clone

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -112,7 +112,7 @@ one — while the outer-iteration column for both reads 1.00×.
 
 ## Finding 2: exact-Hessian SQP fails on Rosenbrock from the classic start
 
-Not fixed, recorded. On
+Filed as **#416**; not fixed here. On
 
     min Rosenbrock(x)  s.t.  ‖x‖² ≤ r²,   n = 10,  −5 ≤ x ≤ 5
 
@@ -131,10 +131,20 @@ indefinite exact Hessian, not a modelling problem:
 | `damped-bfgs` | ok, 99 iters, f=0 | ok, 28 iters | ok, 123 iters |
 | `lbfgs` | ok, 123 iters, f=0 | ok, 258 iters | ok, 98 iters |
 
+Narrowed down after filing groundwork (all in #416): the inner QP hits
+its `sqp_qp_max_iter` cap, which the outer loop maps to `QpStepFailed`
+→ `Search_Direction_Becomes_Too_Small`. Raising the cap from its
+default 200 to **250** converges. The cap is not really the bug: the
+failing QP makes **zero** working-set changes in those 200 iterations,
+and the 250 threshold is identical at n = 10, 20, 30 and 40, so a
+fixed-count internal loop is spinning rather than active-set work
+outgrowing its budget. Constraints are not involved — the same failure
+occurs with the ball made unreachable and with `m = 0`. The failure
+appears at the first iterate where ∇²L goes indefinite (min eigenvalue
+−1.4; it is +35.4 at the start).
+
 The family therefore starts from the origin, so the row measures warm
-starting rather than a wall of identical failures. The failing start
-is worth turning into its own regression test, or an issue, separately
-from this suite.
+starting rather than a wall of identical failures.
 
 ## Not done yet
 

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -165,7 +165,7 @@ Rosenbrock is the same waste with a worse ending, because there the
 
 ## Finding 3: #419's fix for #416 regressed the unconstrained case
 
-Filed as **#423**, open. #419 fixed #416 by capping the inner ratio test
+Filed as **#423**, **fixed** in #424. #419 fixed #416 by capping the inner ratio test
 at the shifted step's true minimizer `α*` instead of at 1, so a
 negative-curvature direction runs to its blocking bound and changes the
 working set. Rosenbrock from the classic start now converges in 20
@@ -187,6 +187,13 @@ is specific to the path #419 changed. The two issues are mirror images:
 #416 was "the shifted step is capped at α = 1, so the solver spins
 without pivoting"; #423 is "the shifted step is gone, so a solver with
 nothing to pivot *to* has no step at all".
+
+#424 fixes it by giving the driver a third branch: "the model recedes
+but the NLP does not" is no longer a dead end. Verified on the same
+script — `f = 0.027424` in 24 iterations, exactly the pre-#419 numbers —
+and #419's own fix still holds, with Rosenbrock from the classic start
+converging in 20 iterations. Both hold simultaneously; the family's rows
+are back to `bad = 0` and its pre-#419 speedups (8.33× / 6.46× / 5.23×).
 
 Worth recording as a process point: `double_well_chain` was added the day
 before #419 landed, purely to close a coverage hole (no family ran
@@ -240,18 +247,35 @@ Wall time over the 9 QP-family rows, geometric mean (ms):
 
 | cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
 |--:|--:|--:|--:|--:|--:|
-| 137.1 | 88.4 | 98.0 | 60.3 | **44.8** | 62.1 |
+| 97.1 | 72.8 | 75.9 | 48.5 | 37.3 | **35.8** |
+
+(Absolute wall times drift ~10–30% between runs on this machine, so read
+the ordering and the ratios, not the milliseconds. Iteration counts are
+noise-free and are quoted below.)
 
 Two results worth keeping:
 
-- **Warm-started active-set SQP is the fastest arm on 8 of the 9 rows**,
-  including against the dedicated convex solver on its home turf. The
-  one exception is `moving_bound_qp @ large`, where the active set
-  churns hardest (15 of 19 steps change it) and `warm-qp-ipm` wins.
-- **The convex IPM warm-starts weakly**: 1.17–1.50× on iterations,
-  against 4–16× for the SQP's inner active-set work — and the *general*
-  NLP filter-IPM warm-starts to ~1.4 iterations/step on the same
-  problems where the dedicated convex solver needs 5–8.
+- **The ranking flipped once #417 was fixed.** As first measured,
+  warm-started active-set SQP was fastest on 8 of 9 rows. With #422
+  landed, `warm-qp-ipm` is fastest on **6 of 9** and marginally ahead
+  overall (35.8 ms vs 37.3 ms geometric mean). On a problem that really
+  is a QP, a properly warm-started dedicated convex solver is now
+  competitive with — and usually better than — the active-set SQP.
+- **The convex IPM used to warm-start weakly** — 1.17–1.50× on
+  iterations, against 4–16× for the SQP's inner active-set work — which
+  is what prompted #417. With #422 landed it is 1.73–3.00×, and the raw
+  counts moved exactly as the prototype predicted:
+
+  | family @ scale | warm iters before #422 | predicted | after #422 |
+  |---|--:|--:|--:|
+  | `simplex_proj` @ tiny | 103 | 46 | **46** |
+  | `simplex_proj` @ small | 124 | 75 | **75** |
+  | `simplex_proj` @ large | 141 | 96 | **96** |
+
+  The prediction came from an env-gated prototype measured in this
+  suite before the issue was filed; the shipped fix reproduces it to the
+  integer, which is about as direct a confirmation of a diagnosis as a
+  benchmark can give.
 
   Chasing that down (**#417**) ruled out the explanation that first
   looked obvious. The convex path is *not* taking a plain primal-dual

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -112,7 +112,8 @@ one — while the outer-iteration column for both reads 1.00×.
 
 ## Finding 2: exact-Hessian SQP fails on Rosenbrock from the classic start
 
-Filed as **#416**; not fixed here. On
+Filed as **#416**, **fixed** in #419 — which then regressed the
+unconstrained case, see Finding 3. On
 
     min Rosenbrock(x)  s.t.  ‖x‖² ≤ r²,   n = 10,  −5 ≤ x ≤ 5
 
@@ -161,6 +162,36 @@ configuration the inner QP's iterations past ~20 change nothing. They
 are not work that ran out of budget, they are work that never mattered.
 Rosenbrock is the same waste with a worse ending, because there the
 `MaxIter` exit is not rescued.
+
+## Finding 3: #419's fix for #416 regressed the unconstrained case
+
+Filed as **#423**, open. #419 fixed #416 by capping the inner ratio test
+at the shifted step's true minimizer `α*` instead of at 1, so a
+negative-curvature direction runs to its blocking bound and changes the
+working set. Rosenbrock from the classic start now converges in 20
+iterations.
+
+But when there is **no** blocking bound — `m = 0`, no finite variable
+bounds, which is exactly `double_well_chain` — the direction runs
+forever, becomes a recession certificate, fails re-verification against
+the true NLP (the objective really is bounded below), and the solve
+ends. A/B on an identical script:
+
+| build | `active-set-sqp` + `exact` | f | iters |
+|---|---|--:|--:|
+| 301aa84 (pre-#419) | `Solve_Succeeded` | 0.027424 | 24 |
+| c15c015 (post-#419) | `Search_Direction_Becomes_Too_Small` | 26.025699 | **1** |
+
+The IPM and `damped-bfgs` are bit-identical across the two builds, so it
+is specific to the path #419 changed. The two issues are mirror images:
+#416 was "the shifted step is capped at α = 1, so the solver spins
+without pivoting"; #423 is "the shifted step is gone, so a solver with
+nothing to pivot *to* has no step at all".
+
+Worth recording as a process point: `double_well_chain` was added the day
+before #419 landed, purely to close a coverage hole (no family ran
+`m = 0`), and it caught the regression on its first run against the new
+base. The other 21 rows were bit-identical across the two commits.
 
 ## Active-set coverage, and the two families that closed the holes
 

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -218,15 +218,27 @@ Two results worth keeping:
   one exception is `moving_bound_qp @ large`, where the active set
   churns hardest (15 of 19 steps change it) and `warm-qp-ipm` wins.
 - **The convex IPM warm-starts weakly**: 1.17–1.50× on iterations,
-  against 4–16× for the SQP's inner active-set work. That is the
-  textbook asymmetry — an interior-point method cannot exploit a
-  previous solution sitting exactly on the boundary, which is precisely
-  where a QP's solution lives. Notably the *general* NLP filter-IPM
-  warm-starts better in iteration terms (e.g. 182→28 on
-  `simplex_proj @ tiny`) than the dedicated convex one does, because
-  `pounce.WarmStart` seeds `mu_init` from the converged barrier
-  parameter and tightens the bound pushes, while the convex path takes
-  a plain primal-dual seed.
+  against 4–16× for the SQP's inner active-set work — and the *general*
+  NLP filter-IPM warm-starts to ~1.4 iterations/step on the same
+  problems where the dedicated convex solver needs 5–8.
+
+  Chasing that down (**#417**) ruled out the explanation that first
+  looked obvious. The convex path is *not* taking a plain primal-dual
+  seed: `init_iterate` recenters adaptively, sizing the interior floor
+  from the warm point's KKT residual on the new problem. Scaling that
+  floor across five orders of magnitude changes the iteration count by
+  about one, and a *perfect* warm start (re-solving an identical
+  problem from its own solution) converges in 0–2 iterations, so the
+  machinery is sound. The limit is the fraction-to-boundary parameter
+  `QpOptions::tau`, pinned at 0.95: the trace shows α held at exactly
+  0.950 for every late iteration, so μ and the residuals fall a fixed
+  ~20× per step and the count is `log₂₀(μ₀/tol)` however good the
+  start is. Letting τ → 1 as μ → 0 for orthant blocks cuts warm
+  iterations 35–60% with the full `pounce-convex` suite passing; doing
+  it for *every* cone kind loses 60% of the SOC instances the direct
+  driver currently solves. A filter line-search method can take a full
+  Newton step near the solution and a barrier method with static τ
+  cannot — that, not the seeding, is the whole asymmetry.
 
 Caveat kept in the report itself: the QP arms receive matrix data once
 per step where the callback arms re-evaluate per iteration, so the wall

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -146,6 +146,56 @@ appears at the first iterate where ∇²L goes indefinite (min eigenvalue
 The family therefore starts from the origin, so the row measures warm
 starting rather than a wall of identical failures.
 
+**Corroboration from `double_well_chain`** (added later, see below).
+That family is the same configuration — unconstrained, empty working
+set, indefinite exact Hessian — but benign enough that the solve
+*survives*: on a 12-variable instance the exact-Hessian SQP needs 24
+outer iterations and 36 QP solves (12 more than outer iterations, i.e.
+the rescue re-solves firing), and takes 44 ms per QP against 0.4 ms for
+`damped-bfgs`. Capping `sqp_qp_max_iter` at **20** produces a
+**bit-identical** result — same objective and same `x` to the last bit
+at every step of the 20-step path — **8.9× faster** (33.9s → 3.8s).
+
+That is the cleanest statement of the defect available: on this
+configuration the inner QP's iterations past ~20 change nothing. They
+are not work that ran out of budget, they are work that never mattered.
+Rosenbrock is the same waste with a worse ending, because there the
+`MaxIter` exit is not rescued.
+
+## Active-set coverage, and the two families that closed the holes
+
+Audited by reading the working sets the solver actually returns, per
+family and scale, rather than by reading the intent. What was already
+covered: permanently-active equality rows, bounds activating and
+releasing, inequality rows activating and releasing, and paths where
+the active set is deliberately held fixed (`simplex_proj` and
+`hanging_chain` at `tiny`, 0 changes end to end).
+
+Two holes, both closed:
+
+- **Re-activation was never tested.** `rosenbrock_ring` sweeps its
+  radius monotonically, so its switch is always active → inactive.
+  `rosenbrock_ring_cycle` makes the path a triangle — out past the
+  switch, back in — so it crosses in both directions, at exactly the
+  quarter and three-quarter steps at every scale. It measures
+  measurably *less* warm-start payoff than the monotone version at
+  `large` (1.76× vs 2.16× on QP active-set work, 8 residual changes vs
+  1), which is the expected asymmetry: carrying an empty working set
+  into a step that needs a non-empty one gives the solver nothing.
+- **No path was unconstrained.** Every family carried at least one
+  constraint row, so the suite never executed `m = 0`, and there was no
+  zero mark to read the speedups against. `double_well_chain` is
+  `m = 0` with no finite bounds — the working set is empty at every
+  iterate of every step, confirmed in the data (`|A| = 0`, 20/20 steps,
+  all scales).
+
+`double_well_chain` also inverts the report's two headline columns,
+which is worth understanding before reading any row: with no working
+set to carry, the QP-active-set column is exactly 1.00× (0→0) and the
+*entire* warm-start effect lands in outer iterations (8.3× at `tiny`).
+The QP-shaped families are the mirror image — outer flat at 1.00×, all
+effect inner. Neither column alone is a summary of this suite.
+
 ## Not done yet
 
 - **A shift-based warm-start arm for the closed-loop family.** MPC

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -196,6 +196,42 @@ set to carry, the QP-active-set column is exactly 1.00× (0→0) and the
 The QP-shaped families are the mirror image — outer flat at 1.00×, all
 effect inner. Neither column alone is a summary of this suite.
 
+## The three-way: dedicated convex QP solver vs the two general paths
+
+Added after the first results raised the question the suite could not
+then answer. `cold-qp-ipm` / `warm-qp-ipm` route the three QP-shaped
+families through `pounce.solve_qp` (pounce-convex). `qpform.py` does the
+extraction; the self-test verifies it by re-deriving the family from the
+extracted data, because a silent extraction bug would produce plausible
+and wrong numbers rather than an error.
+
+Wall time over the 9 QP-family rows, geometric mean (ms):
+
+| cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
+|--:|--:|--:|--:|--:|--:|
+| 152.5 | 102.3 | 113.9 | 65.7 | **51.0** | 70.3 |
+
+Two results worth keeping:
+
+- **Warm-started active-set SQP is the fastest arm on 8 of the 9 rows**,
+  including against the dedicated convex solver on its home turf. The
+  one exception is `moving_bound_qp @ large`, where the active set
+  churns hardest (15 of 19 steps change it) and `warm-qp-ipm` wins.
+- **The convex IPM warm-starts weakly**: 1.17–1.50× on iterations,
+  against 4–16× for the SQP's inner active-set work. That is the
+  textbook asymmetry — an interior-point method cannot exploit a
+  previous solution sitting exactly on the boundary, which is precisely
+  where a QP's solution lives. Notably the *general* NLP filter-IPM
+  warm-starts better in iteration terms (e.g. 182→28 on
+  `simplex_proj @ tiny`) than the dedicated convex one does, because
+  `pounce.WarmStart` seeds `mu_init` from the converged barrier
+  parameter and tightens the bound pushes, while the convex path takes
+  a plain primal-dual seed.
+
+Caveat kept in the report itself: the QP arms receive matrix data once
+per step where the callback arms re-evaluate per iteration, so the wall
+time favors them by an amount this suite does not separate out.
+
 ## Not done yet
 
 - **A shift-based warm-start arm for the closed-loop family.** MPC
@@ -207,9 +243,10 @@ effect inner. Neither column alone is a summary of this suite.
   `Δx ≈ ∂x*/∂p · Δp` before the SQP corrector runs — the pattern
   documented in `docs/src/active-set-sqp.md` §4. It would slot in as a
   fifth arm and is the natural next addition.
-- **An external solver arm.** The adapter interface exists and is
-  unused; Ipopt through cyipopt would be the obvious first one, using
-  the same families unchanged.
+- **An external solver arm.** The adapter interface is exercised by
+  the pounce adapter's three paths but has no second solver behind it;
+  Ipopt through cyipopt would be the obvious first one, using the same
+  families unchanged.
 - **Composite-report integration.** The suite writes its own
   `results.md` and stays out of `BENCHMARK_REPORT.md`, which is built
   around per-problem cold-solve rows against an Ipopt reference and

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -209,7 +209,7 @@ Wall time over the 9 QP-family rows, geometric mean (ms):
 
 | cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
 |--:|--:|--:|--:|--:|--:|
-| 152.5 | 102.3 | 113.9 | 65.7 | **51.0** | 70.3 |
+| 137.1 | 88.4 | 98.0 | 60.3 | **44.8** | 62.1 |
 
 Two results worth keeping:
 

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -1,0 +1,156 @@
+# Warm-start benchmark — design notes and findings
+
+The suite lives at `benchmarks/warmstart/`; its README is the
+user-facing document. This note records *why* it is shaped the way it
+is, what the prior-art survey turned up, and the two solver findings
+that came out of building it.
+
+## Prior art (searched 2026-07-31): there isn't one
+
+No solver-agnostic, NLP-level, sequence-based warm-start benchmark
+exists to reuse. What does exist and why none of it covers the case:
+
+- **qpbenchmark family** (`qpsolvers/qpbenchmark`, `mpc_qpbenchmark`,
+  `ik_qpbenchmark`, Maros-Mészáros, free-for-all). QP level, and
+  explicitly cold-start: the MPC test set's README states it "does not
+  reflect the warm-starting that is frequently used on robots that do
+  model predictive control". Problems ship as independent instances
+  with the sequence structure discarded.
+- **WARP**, arXiv:2605.05728 (2026) — "A Benchmark for Primal-Dual
+  Warm-Starting of Interior-Point Solvers". The closest existing
+  thing. Interior-point only (it predicts the full primal-dual-barrier
+  state; reports IPOPT 23 → 3 iterations for an oracle start, 76% for
+  its learned model), AC-OPF only, and built around learned
+  predictions over i.i.d. instances rather than consecutive
+  perturbations. No active set, no working set, no path.
+- **Not All Warm Starts Help**, arXiv:2606.08984 (2026) — benchmarks
+  primal-dual initializations for ACOPF. An evaluation study, not a
+  reusable set. Its finding that warm starts frequently *hurt* is why
+  regressions are a first-class column here rather than an aggregate
+  the mean absorbs.
+- **OPFData** (arXiv:2406.07234) / PGLearn — 300k solved AC-OPF
+  instances per grid (loads perturbed 80–120%, plus N-1 topologies).
+  A dataset, no protocol; independent samples, not a path.
+- **acados / CasADi NMPC papers** — closed-loop timing comparisons
+  (chain-of-masses and friends) embedded in solver repos and papers.
+  Per-paper harnesses; nothing portable.
+- **CUTEst / Hock-Schittkowski / Vanderbei / Mittelmann /
+  Maros-Mészáros** — every problem is a single cold solve.
+
+## Why the unit is a family-plus-path
+
+Warm starting has no meaning for one isolated NLP, and the property
+that predicts payoff — how the active set moves between consecutive
+instances — only exists along a path. So the benchmark's unit of work
+is the whole sequence, families are tagged by the active-set regime
+they exercise, and every family is run at three step sizes (×0.1, ×1,
+×4 of its natural increment) because payoff is a function of how far
+the problem moved. A single step size measures one point on a curve
+and calls it the answer.
+
+Families are dense-callback and solver-free by construction; the only
+module that imports a solver is `adapters/pounce_adapter.py`. That is
+what keeps the option open to lift the suite out of the pounce tree,
+or to add an Ipopt arm, without touching a family.
+
+## Why the harness is Python-driven and not `.nl`-driven
+
+Every other suite runs `.nl` files through the CLI. That cannot work
+here: carrying a working set between solves needs an in-process
+handle, and the CLI has no cross-process working-set input (the
+debugger's `resolve` seeds a primal point only). The Python
+`Problem.solve(working_set=…)` / `WarmStart` surface is the one that
+supports the contract, so the harness drives it directly.
+
+## Correctness is judged on the step's own terms, not against the reference
+
+The first cut scored a step correct iff its solution matched the
+reference arm's (`cold-ipm`) to a tolerance. That is wrong on
+nonconvex families, and the benchmark demonstrated it immediately: on
+`rosenbrock_ring`, `cold-ipm` converges to Rosenbrock's well-known
+*local* minimum (f ≈ 3.9866 at x ≈ (−1, 1, …, 1)) while the SQP arms
+find the global one (f = 0). Scoring against the reference marked the
+better answer wrong.
+
+The criterion now is: converged on its own terms (success status, plus
+a KKT residual and feasibility the *harness* verifies rather than
+taking the solver's word for), and not a *worse* optimum than the
+reference by more than `--obj-tol`. A better optimum is reported in
+its own column. `‖x − x_ref‖` is a recorded diagnostic, not a gate,
+because two solves can both be optimal and still differ in `x` near a
+degenerate face — which the `moving_bound_qp` family produced at step
+9, where the SQP and IPM arms agreed on the objective to 1e-9 while
+differing in `x` by 2e-5.
+
+## Finding 1: the inner active-set work was not observable (fixed here)
+
+An SQP warm start's whole purpose is to skip active-set searching in
+the QP subproblems, and none of that was visible from Python. The
+outer iteration count is not a proxy: on a QP-shaped NLP the outer
+loop terminates in one iteration whether warm started or not, so a
+cold/warm comparison on `iter_count` reads exactly 1.00× while the
+inner work differs by an order of magnitude.
+
+`pounce-qp` already counted per-QP active-set changes in
+`QpStats::n_working_set_changes`; nothing accumulated them. Added:
+
+- `SqpResult::n_qp_working_set_changes` — summed over every step QP,
+  including the cold-start and quasi-Newton-reset fallbacks. Excludes
+  second-order-correction QPs, whose stats the line search does not
+  surface.
+- `SolveStatistics::sqp_qp_solves` / `sqp_qp_working_set_changes` —
+  0 on the IPM path, which solves no QP subproblems.
+- Python `info["n_qp_solves"]` / `info["n_qp_ws_changes"]`.
+
+Covered by `sqp_reports_qp_working_set_changes_and_warm_start_removes_them`
+in `crates/pounce-algorithm/src/sqp/tests.rs`.
+
+With it, the first full run shows what was previously invisible:
+`simplex_proj` goes from 313 active-set changes cold to 4 warm at the
+default step size, and `nmpc_vanderpol` from 931 to 66 at the smallest
+one — while the outer-iteration column for both reads 1.00×.
+
+## Finding 2: exact-Hessian SQP fails on Rosenbrock from the classic start
+
+Not fixed, recorded. On
+
+    min Rosenbrock(x)  s.t.  ‖x‖² ≤ r²,   n = 10,  −5 ≤ x ≤ 5
+
+started from the traditional `(−1.2, 1, −1.2, …)`, the default
+`sqp_hessian = exact` path terminates with
+`Search_Direction_Becomes_Too_Small` at **every** step of the
+parameter path, at a point with stationarity residual ≈ 2.6 and
+objective 9.62 (against 0.0 from other starts). `damped-bfgs` and
+`lbfgs` converge from the same start, and `exact` converges from the
+origin or from `0.9·1`. So it is a step-computation failure on an
+indefinite exact Hessian, not a modelling problem:
+
+| `sqp_hessian` | from (−1.2, 1, …) | from 0.9·1 | from 0 |
+|---|---|---|---|
+| `exact` | fails, 4 iters, KKT 2.6 | ok, 6 iters, f=0 | ok, 13 iters, f=0 |
+| `damped-bfgs` | ok, 99 iters, f=0 | ok, 28 iters | ok, 123 iters |
+| `lbfgs` | ok, 123 iters, f=0 | ok, 258 iters | ok, 98 iters |
+
+The family therefore starts from the origin, so the row measures warm
+starting rather than a wall of identical failures. The failing start
+is worth turning into its own regression test, or an issue, separately
+from this suite.
+
+## Not done yet
+
+- **A shift-based warm-start arm for the closed-loop family.** MPC
+  codes shift the previous horizon by one step before reusing it;
+  `warm-sqp` here carries the previous solution unshifted, which is
+  the honest baseline for "carry the previous answer" but understates
+  what an MPC implementation would do.
+- **The predictor + corrector arm.** `pounce-sensitivity` can supply
+  `Δx ≈ ∂x*/∂p · Δp` before the SQP corrector runs — the pattern
+  documented in `docs/src/active-set-sqp.md` §4. It would slot in as a
+  fifth arm and is the natural next addition.
+- **An external solver arm.** The adapter interface exists and is
+  unused; Ipopt through cyipopt would be the obvious first one, using
+  the same families unchanged.
+- **Composite-report integration.** The suite writes its own
+  `results.md` and stays out of `BENCHMARK_REPORT.md`, which is built
+  around per-problem cold-solve rows against an Ipopt reference and
+  has no shape for a per-sequence result.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -53,6 +53,7 @@
 - [Auxiliary-Equality Preprocessing](auxiliary-presolve.md)
 - [Troubleshooting Recipes](troubleshooting.md)
 - [Benchmarks](benchmarks.md)
+  - [The Warm-Start Benchmark](warm-start-benchmark.md)
 
 # Appendix
 

--- a/docs/src/active-set-sqp.md
+++ b/docs/src/active-set-sqp.md
@@ -155,6 +155,38 @@ SQP-side warm-start state doesn't leak between solves) and
 `application_default_does_not_select_sqp` (asserts the default
 solver path is IPM).
 
+### Measuring whether the warm start paid
+
+Do not judge a warm start by `info["iter_count"]`. That is the
+**outer** SQP iteration count, and on a problem whose subproblem
+is already a QP the outer loop terminates in one iteration
+whether or not you warm started — the number reads the same cold
+and warm while the work underneath differs by an order of
+magnitude. The saved work is inside the QP subproblems, and two
+further keys report it:
+
+| key | meaning |
+| --- | ------- |
+| `info["n_qp_solves"]`    | QP subproblems solved during this solve |
+| `info["n_qp_ws_changes"]`| active-set changes (adds + drops) across those QPs |
+
+Both are `0` on the IPM path, which solves no QP subproblems.
+`n_qp_ws_changes` is the measurement to watch across a sequence:
+
+```python
+prob.add_option("algorithm", "active-set-sqp")
+
+ws = None
+for k in range(horizon_steps):
+    x, info = prob.solve(x0=x_prev, working_set=ws)
+    print(k, info["iter_count"], info["n_qp_ws_changes"])
+    ws, x_prev = info["working_set"], x
+```
+
+A warm start that is working drives the second column toward
+zero while the first stays flat. `benchmarks/warmstart/` is
+built on exactly this measurement.
+
 ## 3. The working-set warm-start contract
 
 The §6 contract is the tuple `(x, λ_g, λ_x, 𝒲)` — primal, constraint

--- a/docs/src/active-set-sqp.md
+++ b/docs/src/active-set-sqp.md
@@ -184,8 +184,10 @@ for k in range(horizon_steps):
 ```
 
 A warm start that is working drives the second column toward
-zero while the first stays flat. `benchmarks/warmstart/` is
-built on exactly this measurement.
+zero while the first stays flat.
+[The warm-start benchmark](warm-start-benchmark.md) is built on
+exactly this measurement, and reports what the effect is worth
+across eight problem families and all three solve paths.
 
 ## 3. The working-set warm-start contract
 

--- a/docs/src/benchmarks.md
+++ b/docs/src/benchmarks.md
@@ -20,6 +20,14 @@ make benchmark-mittelmann
 make benchmark-vanderbei    # Vanderbei CUTE-in-AMPL collection (733 problems)
 ```
 
+One suite is deliberately not `.nl`-driven:
+[the warm-start benchmark](warm-start-benchmark.md) measures the cost of
+solving a *sequence* of related problems, cold versus warm, across all
+three of POUNCE's solve paths. Carrying a working set between solves
+needs an in-process handle, so it runs through the Python API instead of
+the CLI, and it reports on its own rather than into the composite
+report.
+
 The benchmark inputs themselves — the `.nl` problem files — and the
 per-run logs and JSON results are regenerated locally and not tracked in
 the repository. See

--- a/docs/src/warm-start-benchmark.md
+++ b/docs/src/warm-start-benchmark.md
@@ -1,0 +1,317 @@
+# The Warm-Start Benchmark
+
+Every other suite in `benchmarks/` answers "how fast does POUNCE solve
+this problem?" This one answers a different question: **when you solve a
+sequence of related problems, how much does starting from the previous
+answer actually save — and which of POUNCE's three solvers should you
+use?**
+
+That question has no meaning for a single isolated solve, which is why
+it needs its own suite. The unit of work here is a *parametric family
+plus a path*: one problem shape, one scripted sweep through its
+parameter space, solved end to end. MPC horizons, continuation and
+homotopy, sensitivity sweeps, and design exploration all have this
+shape.
+
+There is no standard public benchmark for this. The nearest things —
+the [qpbenchmark](https://github.com/qpsolvers/qpbenchmark) test sets,
+[WARP](https://arxiv.org/abs/2605.05728), the AC-OPF learning datasets —
+are either QP-only, interior-point-only, or ship their instances
+stripped of the sequence structure that makes warm starting meaningful.
+`benchmarks/warmstart/README.md` has the full survey.
+
+## The three solvers under test
+
+POUNCE has three solve paths that can take a sequence, and they warm
+start in genuinely different ways:
+
+| solver | `algorithm` / entry point | what it carries between solves |
+|---|---|---|
+| **general NLP filter-IPM** | `interior-point` (the default) | the previous primal-dual point and the converged barrier parameter μ |
+| **active-set SQP** | `algorithm = active-set-sqp` | the previous **working set** — which bounds and constraints were active — plus the point |
+| **convex QP interior point** | `pounce.solve_qp` (`solver_selection=qp-ipm`) | the previous primal-dual point |
+
+Each runs cold and warm, giving six arms:
+
+| arm | solver | seeded with | runs on |
+|---|---|---|---|
+| `cold-ipm` | NLP filter-IPM | nothing | every family |
+| `warm-ipm` | NLP filter-IPM | previous point + μ | every family |
+| `cold-sqp` | active-set SQP | nothing | every family |
+| `warm-sqp` | active-set SQP | previous working set + point | every family |
+| `cold-qp-ipm` | convex QP IPM | nothing | QP families only |
+| `warm-qp-ipm` | convex QP IPM | previous primal-dual point | QP families only |
+
+Each warm arm is scored against **its own** cold counterpart. That
+pairing is the whole point: `warm-sqp` beating `cold-ipm` would confound
+"warm started" with "switched algorithms", and only the paired
+comparison isolates the warm start.
+
+## The problems
+
+Eight families, each run at three step sizes (`tiny` ×0.1, `small` ×1,
+`large` ×4 of its natural per-step parameter increment), for 24 rows and
+489 solves per arm. Warm-start payoff is a function of how far the
+problem moved, so a single step size would measure one point on a curve
+and call it the answer.
+
+| family | n | m | active-set regime | perturbation enters | curvature |
+|---|--:|--:|---|---|---|
+| `simplex_proj` | 20 | 1 | flipping | objective | convex |
+| `moving_bound_qp` | 40 | 3 | flipping | variable bounds | convex |
+| `degenerate_corner` | 6 | 3 | degenerate (a multiplier passes through zero) | objective | convex |
+| `hanging_chain` | 30 | 15 | flipping contacts | mixed | convex |
+| `rosenbrock_ring` | 10 | 1 | one clean activation switch | constraint RHS | nonconvex |
+| `rosenbrock_ring_cycle` | 10 | 1 | switch crossed in both directions | constraint RHS | nonconvex |
+| `double_well_chain` | 12 | 0 | none — empty active set throughout | objective | nonconvex |
+| `nmpc_vanderpol` | 47 | 32 | closed-loop MPC | constraint RHS | nonconvex |
+
+The families are deliberately small and analytic. This is a
+*measurement* of warm-start behavior, not a scaling study — the
+conclusions about which solver to use transfer; the absolute timings do
+not.
+
+## How a result is produced
+
+Three rules make the arms comparable:
+
+1. **Every arm sees the identical parameter sequence.** For
+   `nmpc_vanderpol`, whose path depends on its own solutions, the
+   sequence is recorded once from the reference arm and replayed for
+   the others.
+2. **Step 0 of a warm arm is a cold solve** — there is nothing to warm
+   from — and is excluded from the speedup ratios while still counting
+   in the totals.
+3. **Every step is checked.** A step must return success, actually
+   achieve a small KKT residual and be feasible (verified by the
+   harness, not taken from the solver's status), and not land on a
+   *worse* optimum than the reference. A warm start that converges
+   quickly to the wrong answer is a failure, not a win.
+
+In the run reported below, **every step of every arm passed** — 489
+steps × 4 arms, plus 180 QP-arm steps, with zero correctness failures.
+
+## Results
+
+Run on POUNCE 0.9.0, `tol = 1e-8`, one machine, all 24 rows.
+
+### Does warm starting pay?
+
+Totals across all 489 steps of all 24 rows:
+
+| arm | Σ outer iterations | Σ solve time | incorrect steps |
+|---|--:|--:|--:|
+| `cold-ipm` | 6682 | 3.75 s | 0 |
+| `warm-ipm` | **2156** | 1.73 s | 0 |
+| `cold-sqp` | 3872 | 12.82 s | 0 |
+| `warm-sqp` | **1138** | 3.05 s | 0 |
+
+Both solvers cut outer iterations by roughly 3×. But for the active-set
+SQP that number badly understates the effect, for a reason worth
+understanding before reading any further.
+
+### The metric trap: outer iterations hide the SQP's warm start
+
+On a problem whose subproblem is already a QP, the SQP outer loop
+terminates in **one** iteration whether or not it was warm started. The
+work a working-set warm start actually saves is *inside* the QP
+subproblems, and it is reported separately as
+`info["n_qp_ws_changes"]` — active-set changes (adds + drops) summed
+over the step QPs.
+
+The two extremes make the point:
+
+| family | SQP outer iterations, cold→warm | QP active-set changes, cold→warm |
+|---|--:|--:|
+| `simplex_proj` @ tiny (a QP) | 1.00× — flat | **16.0×** (285 → 0) |
+| `double_well_chain` @ tiny (unconstrained) | **8.33×** | 1.00× (0 → 0) |
+
+They are mirror images. On a QP, everything happens inside; with no
+constraints there is no working set to carry, so the entire effect is in
+the outer loop and comes from the primal point alone. **Neither column
+alone summarizes this benchmark.** `double_well_chain` exists precisely
+to be that zero mark.
+
+### Warm-start effect per family
+
+`SQP` is the ratio of inner QP active-set changes (raw totals in
+parentheses); `IPM` is the ratio of outer iterations. Higher is better;
+`worse` counts steps where warm cost *more* than cold.
+
+| family | scale | SQP cold→warm | worse | IPM cold→warm | worse |
+|---|---|--:|--:|--:|--:|
+| `simplex_proj` | tiny | 16.00× (285→0) | 0 | 5.05× | 0 |
+| `simplex_proj` | small | 15.55× (313→4) | 0 | 4.42× | 0 |
+| `simplex_proj` | large | 15.09× (335→7) | 0 | 4.17× | 0 |
+| `moving_bound_qp` | tiny | 6.00× (104→3) | 0 | 5.01× | 0 |
+| `moving_bound_qp` | small | 6.10× (207→29) | 0 | 2.00× | 0 |
+| `moving_bound_qp` | large | 4.99× (467→104) | 0 | 1.93× | 0 |
+| `degenerate_corner` | tiny | 1.87× (19→1) | 0 | 4.67× | 0 |
+| `degenerate_corner` | small | 1.87× (19→1) | 0 | 3.56× | 0 |
+| `degenerate_corner` | large | 1.92× (26→4) | 0 | 3.08× | 0 |
+| `hanging_chain` | tiny | 4.00× (57→0) | 0 | 1.25× | 0 |
+| `hanging_chain` | small | 4.84× (99→9) | 0 | 1.54× | 0 |
+| `hanging_chain` | large | 4.19× (237→72) | 1 | **0.85×** | **17** |
+| `rosenbrock_ring` | tiny | 2.37× (30→1) | 0 | 11.37× | 0 |
+| `rosenbrock_ring` | small | 2.48× (33→1) | 0 | 8.75× | 0 |
+| `rosenbrock_ring` | large | 2.16× (30→1) | 0 | 6.73× | 0 |
+| `rosenbrock_ring_cycle` | tiny | 2.24× (29→2) | 0 | 9.16× | 0 |
+| `rosenbrock_ring_cycle` | small | 2.47× (35→2) | 0 | 8.62× | 0 |
+| `rosenbrock_ring_cycle` | large | 1.76× (30→8) | 0 | 6.14× | 0 |
+| `double_well_chain` | tiny | 1.00× (0→0) | 0 | 3.00× | 0 |
+| `double_well_chain` | small | 1.00× (0→0) | 0 | 2.29× | 0 |
+| `double_well_chain` | large | 1.00× (0→0) | 0 | 2.14× | 0 |
+| `nmpc_vanderpol` | tiny | 30.29× (931→66) | 0 | 3.63× | 0 |
+| `nmpc_vanderpol` | small | 7.76× (781→294) | 0 | 1.96× | 0 |
+| `nmpc_vanderpol` | large | 2.21× (868→693) | 8 | 1.05× | 8 |
+
+### Payoff tracks active-set churn, not problem size
+
+Read down any family and the pattern is the same: **the further the
+problem moves per step, the less a warm start buys.** `churn` is the
+mean number of working-set entries that change between consecutive
+steps.
+
+| family | churn/step at tiny → large | SQP payoff at tiny → large |
+|---|---|---|
+| `nmpc_vanderpol` | 0.21 → 2.95 | 30.3× → 2.2× |
+| `moving_bound_qp` | 0.05 → 1.63 | 6.0× → 5.0× |
+| `hanging_chain` | 0.00 → 0.47 | 4.0× → 4.2× |
+| `simplex_proj` | 0.00 → 0.21 | 16.0× → 15.1× |
+
+`nmpc_vanderpol` is the clearest case: a 14× increase in churn costs a
+14× reduction in payoff. This is the practical rule — **warm starting
+pays in proportion to how stable your active set is**, and problem size
+has little to do with it.
+
+### Warm starting can make things worse
+
+Two rows show it, both at the largest step size:
+
+- `hanging_chain @ large`, `warm-ipm`: **0.85×** — the warm-started IPM
+  needed *more* iterations than a cold solve on **17 of 19 steps**. The
+  previous solution sits exactly on the constraint boundary, which is
+  the worst possible starting point for a barrier method when the
+  active set has since moved.
+- `nmpc_vanderpol @ large`: 8 of 19 steps worse for both warm arms,
+  where a 4× control interval makes the plant state jump far enough
+  that the carried working set is a poor guess.
+
+This is why the benchmark reports regressions per step rather than only
+a mean. A single averaged speedup would hide both.
+
+### Three-way: which solver for a sequence of QPs?
+
+Three families are literally convex QPs, so all three solvers can take
+them. Interior-point iterations and active-set pivots are not the same
+unit of work, so the like-for-like column is each solver against itself:
+
+| family | scale | convex QP IPM cold→warm | NLP IPM cold→warm | SQP cold→warm (inner) | fastest warm arm |
+|---|---|--:|--:|--:|---|
+| `simplex_proj` | tiny | 160→46 (3.00×) | 182→28 | 285→0 (16.00×) | `warm-qp-ipm` |
+| `simplex_proj` | small | 162→75 (2.03×) | 190→38 | 313→4 (15.55×) | `warm-qp-ipm` |
+| `simplex_proj` | large | 173→96 (1.73×) | 200→45 | 335→7 (15.09×) | `warm-qp-ipm` |
+| `moving_bound_qp` | tiny | 202→94 (2.06×) | 228→43 | 104→3 (6.00×) | `warm-sqp` |
+| `moving_bound_qp` | small | 195→121 (1.58×) | 224→116 | 207→29 (6.10×) | `warm-sqp` |
+| `moving_bound_qp` | large | 229→125 (1.77×) | 240→126 | 467→104 (4.99×) | `warm-qp-ipm` |
+| `degenerate_corner` | tiny | 196→74 (2.45×) | 223→41 | 19→1 (1.87×) | `warm-qp-ipm` |
+| `degenerate_corner` | small | 174→77 (2.12×) | 170→40 | 19→1 (1.87×) | `warm-qp-ipm` |
+| `degenerate_corner` | large | 177→98 (1.73×) | 177→53 | 26→4 (1.92×) | `warm-sqp` |
+
+Geometric-mean wall time over those nine rows:
+
+| cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
+|--:|--:|--:|--:|--:|--:|
+| 97.1 ms | 72.8 ms | 75.9 ms | 48.5 ms | 37.3 ms | **35.8 ms** |
+
+The dedicated convex solver is fastest on 6 of the 9 rows, with the
+active-set SQP taking the other 3 — the rows where the active set churns
+hardest. Note that this ranking is recent: before
+[#417](https://github.com/jkitchin/pounce/issues/417) was fixed the
+convex solver's warm start was capped at 1.2–1.5× and `warm-sqp` led 8
+of 9 rows.
+
+## What to take from this
+
+- **For a sequence of convex QPs** — `solve_qp` warm-started with the
+  previous result. It leads on most rows and needs no callbacks.
+- **For a general NLP whose active set is stable between solves** —
+  `algorithm = active-set-sqp` carrying the working set. This is where
+  the largest effects live (up to 30× less inner active-set work), and
+  the whole reason the active-set path exists.
+- **For a problem with no active set to speak of** — unconstrained, or
+  with constraints that never bind — the warm start still helps, but
+  only through the primal point. Either solver is fine; the working set
+  buys nothing (`double_well_chain`: 0 → 0).
+- **When each step moves the problem a long way** — check whether warm
+  starting is helping at all. It can cost more than a cold solve, and
+  the IPM path is more exposed to this than the SQP path.
+- **Always verify.** A fast wrong answer is the failure mode that
+  matters, which is why the harness re-checks KKT residuals and
+  objectives itself rather than trusting a status code.
+
+See [Active-Set SQP & Warm Starts](active-set-sqp.md) for how to drive
+the warm-start APIs, and
+[Initialization and Warm Starts](initialization.md) for the
+interior-point side.
+
+## Defects this benchmark found
+
+All three are fixed. They are listed because they show what the suite is
+for — two of them lived in the same configuration (nonconvex, indefinite
+Hessian, nothing active) that no other suite exercised:
+
+| issue | what it was |
+|---|---|
+| [#416](https://github.com/jkitchin/pounce/issues/416) | Exact-Hessian SQP spent its entire inner-QP iteration budget making **zero** working-set changes; a budget of 20 gave bit-identical answers ~9× faster. Fixed in #419. |
+| [#423](https://github.com/jkitchin/pounce/issues/423) | The #416 fix regressed unconstrained problems: with nothing able to block a negative-curvature direction, the solve died at iteration 1. Caught by `double_well_chain` on its first run against the new build. Fixed in #424. |
+| [#417](https://github.com/jkitchin/pounce/issues/417) | The convex QP warm start left ~40% of its iterations unclaimed — not from the seeding but from a fraction-to-boundary parameter pinned at 0.95. Fixed in #422. |
+
+## Running it
+
+The harness drives POUNCE in-process through the Python API, so it needs
+the extension built:
+
+```sh
+cd python && maturin develop --release
+```
+
+Then:
+
+```sh
+make -C benchmarks warmstart-selftest   # finite-difference checks, no solver needed
+make -C benchmarks warmstart-run        # full sweep -> results.json + results.md
+make -C benchmarks warmstart-quick      # 3 families, one scale
+```
+
+or, for a narrower run:
+
+```sh
+python -m warmstart.run --families simplex_proj,nmpc_vanderpol --scales large -v
+python -m warmstart.run --arms cold-sqp,warm-sqp --tol 1e-10
+```
+
+Results land in `benchmarks/warmstart/results.json` (every step of every
+arm) and `results.md`. Both are regenerated per run and gitignored.
+
+Adding a problem family or a new solver is documented in
+[`benchmarks/warmstart/README.md`](https://github.com/jkitchin/pounce/blob/main/benchmarks/warmstart/README.md);
+nothing outside `adapters/` imports a solver, so the families and the
+protocol are reusable against any solver with a warm-start API.
+
+## Limits of these numbers
+
+- **Small problems by design** (n ≤ 47). The rankings reflect algorithm
+  behavior, not scaling; per-iteration costs shift with size, and the
+  active-set path is documented to lose ground when the active set grows
+  into the thousands.
+- **Wall time carries Python callback overhead** for the four
+  callback-driven arms. Iteration and active-set-change counts are the
+  primary measurements; times are a cross-check, and vary 10–30% between
+  runs on the same machine.
+- **The QP arms are handed matrix data once per step**, where the other
+  arms re-evaluate the model every iteration. That is a real advantage
+  of the QP path on a QP, not an artifact, but it does mean the wall
+  times are not measuring identical work.
+- **One machine, one run.** Iteration counts are deterministic and
+  reproducible; timings are not.


### PR DESCRIPTION
## Problem

There is no standard benchmark for measuring warm-start effectiveness in NLP solvers. Existing suites (qpbenchmark, WARP, CUTEst, etc.) either operate at the QP level, are interior-point-only, or ship problems stripped of the sequence structure that makes warm starting meaningful. This makes it impossible to quantify whether POUNCE's warm-start capabilities actually save iterations in realistic use cases.

Additionally, the active-set SQP solver has no visibility into its inner working-set changes — only the outer iteration count is reported, which conflates "finding the active set" with "solving the subproblem," making it impossible to measure warm-start quality on SQP.

## Cause

1. **No warm-start measurement protocol exists.** Warm starting only has meaning for sequences of related problems, not isolated solves. The active-set behavior that predicts payoff only exists along a path through parameter space.

2. **SQP subproblem work is invisible.** The SQP algorithm solves a QP at each outer iteration, and the working set of that QP is what warm starting carries between solves. Without counting working-set changes (adds + drops), you cannot separate "warm start found the active set faster" from "warm start happened to start in the right region."

## Fix

### 1. Warm-start benchmark suite (`benchmarks/warmstart/`)

A complete, solver-agnostic benchmark harness for measuring warm-start effectiveness:

- **Eight parametric families** (quadratic and nonlinear, convex and nonconvex) with scripted paths through parameter space at three step sizes each (tiny ×0.1, small ×1, large ×4). Families are deliberately designed to exercise different active-set regimes: flipping bounds, flipping constraints, degeneracy, closed-loop MPC.

- **Six arms** (cold-ipm, warm-ipm, cold-sqp, warm-sqp, cold-qp-ipm, warm-qp-ipm) measuring three solver paths: general NLP filter-IPM, active-set SQP, and dedicated convex QP IPM.

- **Paired scoring**: each warm arm is scored against its own cold counterpart, isolating the warm start from algorithm changes.

- **Correctness checking**: every step is validated against a reference solution; a fast wrong answer is flagged, not celebrated.

- **Headline metric**: shifted geometric mean iteration speedup of warm over cold, excluding step 0 (which has nothing to warm from).

- **Regression visibility**: a dedicated "worse" column counts steps where warm starting actually hurt, because the mean hides it.

Key design decisions documented in `dev-notes/warm-start-benchmark.md`:
- Families are dense-callback and solver-free; only `adapters/pounce_adapter.py` imports pounce, so the suite can be lifted out or pointed at other solvers.
- The harness is Python-driven (not `.nl`-driven) because carrying a working set between solves requires an in-process handle.
- Correctness is judged on each step's own terms, not against a reference arm, because nonconvex families may have multiple local minima.

### 2. SQP subproblem counters

Added to `SolveStatistics` and `SqpResult`:
- `sqp_qp_solves`: count of QP subproblems solved
- `sqp_qp_working_set_changes`: sum of active-set adds + drops across all subproblems

These are exposed through the Python `Problem.solve()` return dict and the Rust solver interface, making it possible to measure whether warm starting actually reduced inner working-set churn.

## Blast radius

**Solver changes**: Minimal. Two new fields added to `SolveStatistics` and `SqpResult` (both are additive, no existing fields changed). The counters are computed during SQP solve and reported; they do not affect convergence behavior or iteration counts. Corpus sweep: bit-identical except for the new counter fields in the result struct.

**Benchmark changes**: Entirely new suite under `benchmarks/warmstart/`. No changes to existing benchmark families or runners. The suite is

https://claude.ai/code/session_01A1b3zspp4PWgP3X6zY6JwU