### PR TITLE
covariance(n_data=) reads the solve-time objective, not the live model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — pyomo-pounce: `covariance(n_data=)` read the SSR from the live objective (#426)
+
+- The `n_data=` branch estimated the noise variance with the SSR taken
+  from `pyo.value(objective)` on the current model, which evaluates at
+  the model's current variable and Param values: anything written after
+  the solve (a measurement, a warm start for the next horizon) silently
+  rescaled the reported covariance. Same staleness class as #420, found
+  in #421's review. The `declare_residual` path was unaffected.
+- The session now stores the objective value at the solve and the
+  `n_data=` branch reads that, so post-solve writes to the model cannot
+  move the answer. Regression: solve, take the covariance, overwrite the
+  model's values, take it again; the two must be identical.
+
 ### Fixed — pyomo-pounce: `estimate()` measured its perturbation from the Param's current value (#420)
 
 - `estimate(model, perturb)` computed each step as `new value` minus the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,18 @@ changes.
   in #421's review. The `declare_residual` path was unaffected.
 - The session now stores the objective value at the solve and the
   `n_data=` branch reads that, so post-solve writes to the model cannot
-  move the answer. Regression: solve, take the covariance, overwrite the
-  model's values, take it again; the two must be identical.
+  move the answer. The stored number is the engine's `obj_val`, which is
+  `eval_f` on this model's own bridge at the final iterate — unscaled,
+  in the model's objective units, i.e. exactly what `pyo.value` returns
+  an instant after the solve. Regression: solve, take the covariance,
+  overwrite the model's values, take it again; the two must be
+  identical.
+- The unusable-objective guard tests `isfinite`, not `is None`: the
+  engine always reports `obj_val` and signals "never computed" with NaN
+  (`0.0` is an ordinary objective value), so a `None` check would have
+  been dead code guarding a condition the producer cannot emit.
+  Documented in the `covariance` docstring and the sensitivity chapter
+  alongside `estimate()`'s matching baseline guarantee.
 
 ### Fixed — pyomo-pounce: `estimate()` measured its perturbation from the Param's current value (#420)
 

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -214,7 +214,10 @@ against the analytical linear-regression covariance
 The noise variance comes from, in order of precedence: `sigma_sq=`
 (known measurement variance); the declared residuals (estimated as
 `SSR / (n - n_params)`, with both numbers derived from the container);
-or the `n_data=` fallback for models without explicit residuals. The
+or the `n_data=` fallback for models without explicit residuals, whose
+SSR is the objective value *at the solve* — like `estimate()`'s
+baseline, writing into the model afterwards (a measurement, a warm
+start for the next horizon) does not move the answer. The
 solve warns if the declared residuals do not reproduce the objective
 value (weights or regularization terms would silently corrupt the
 estimate).

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -259,6 +259,7 @@ class _Session:
         self.pins = pins              # ComponentMap: param data -> pin row
         self.con_alias = con_alias    # original con name -> clone row name
         self.base_x = None
+        self.base_obj = None          # objective value at the solve
         self.moved_bounds = {}        # var name -> (lb, ub) moved to rows
         self._columns = {}            # pin row -> full KKT-space column
 
@@ -579,6 +580,8 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     session = _Session(model, nl, solver, var_names, con_names, pins,
                        con_alias, var_row=var_row, con_row=con_row)
     session.base_x = np.asarray(x)
+    session.base_obj = (float(info["obj_val"])
+                        if info.get("obj_val") is not None else None)
     session.moved_bounds = moved_bounds
 
     # fitted parameters: their rows in the primal vector
@@ -1051,8 +1054,16 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             raise ValueError(
                 f"covariance: n_data ({n_data}) must exceed the number of "
                 f"fitted parameters ({n_params})")
-        ssr = pyo.value(
-            next(model.component_data_objects(pyo.Objective, active=True)))
+        # the objective value AT THE SOLVE, not evaluated on the live
+        # model: pyo.value(objective) reads the model's current variable
+        # and Param values, so anything written after the solve (a
+        # measurement, a warm start for the next horizon) would silently
+        # rescale the covariance (gh #426)
+        if session.base_obj is None:
+            raise RuntimeError(
+                "covariance: the session carries no solve-time objective "
+                "value; re-solve with SolverFactory('pounce') first")
+        ssr = session.base_obj
         group_sigma = {None: ssr / (n_data - n_params)}
     else:
         raise ValueError(

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -259,7 +259,14 @@ class _Session:
         self.pins = pins              # ComponentMap: param data -> pin row
         self.con_alias = con_alias    # original con name -> clone row name
         self.base_x = None
-        self.base_obj = None          # objective value at the solve
+        # Objective value at the solve. NaN, not None, is the "never
+        # computed" sentinel: that is the convention the engine itself
+        # uses for info["obj_val"] (pounce-py's problem.rs seeds
+        # final_obj with NaN precisely because 0.0 is an ordinary
+        # objective value and cannot signal it), so one isfinite check
+        # covers both an unset session and a solve that evaluated
+        # nothing.
+        self.base_obj = float("nan")
         self.moved_bounds = {}        # var name -> (lb, ub) moved to rows
         self._columns = {}            # pin row -> full KKT-space column
 
@@ -580,8 +587,11 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     session = _Session(model, nl, solver, var_names, con_names, pins,
                        con_alias, var_row=var_row, con_row=con_row)
     session.base_x = np.asarray(x)
-    session.base_obj = (float(info["obj_val"])
-                        if info.get("obj_val") is not None else None)
+    # the engine always reports obj_val (NaN when it evaluated nothing),
+    # and it is eval_f on this model's own bridge at the final iterate --
+    # unscaled, in the model's objective units, i.e. exactly what
+    # pyo.value(objective) returns an instant after the solve
+    session.base_obj = float(info.get("obj_val", float("nan")))
     session.moved_bounds = moved_bounds
 
     # fitted parameters: their rows in the primal vector
@@ -902,8 +912,10 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     when residual groups are declared); declared residuals (estimated
     per pooled or labeled group as SSR_g / (n_g - n_params)); or the
     n_data= fallback (count of data points, with SSR taken from the
-    objective value on trust). With multiple labeled groups the
-    heteroscedastic sandwich covariance is reported.
+    SOLVE-TIME objective value on trust -- writing into the model
+    first, the receding-horizon pattern of estimate(), does not change
+    the answer). With multiple labeled groups the heteroscedastic
+    sandwich covariance is reported.
 
     hessian= selects the information matrix. "lagrangian" (the default)
     inverts the exact reduced Hessian of the Lagrangian from the held
@@ -1059,10 +1071,12 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
         # and Param values, so anything written after the solve (a
         # measurement, a warm start for the next horizon) would silently
         # rescale the covariance (gh #426)
-        if session.base_obj is None:
+        if not np.isfinite(session.base_obj):
             raise RuntimeError(
-                "covariance: the session carries no solve-time objective "
-                "value; re-solve with SolverFactory('pounce') first")
+                "covariance: the solve reported no usable objective value "
+                f"({session.base_obj}), so n_data= cannot estimate the "
+                "noise variance. Pass sigma_sq= (known variance), or "
+                "declare the residual container with declare_residual().")
         ssr = session.base_obj
         group_sigma = {None: ssr / (n_data - n_params)}
     else:
@@ -1070,7 +1084,7 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             "covariance: the noise variance is unknown; declare the "
             "residual container(s) with declare_residual(), or pass "
             "sigma_sq= (known variance), or pass n_data= (data count, "
-            "with the SSR taken from the objective value)")
+            "with the SSR taken from the solve-time objective value)")
 
     # ── assemble ──────────────────────────────────────────────────────────
     # Pooled covariance when there is one group or all group variances are

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -116,6 +116,24 @@ def test_n_data_fallback():
     np.testing.assert_allclose(cov.matrix, cov_classical, rtol=1e-9)
 
 
+def test_n_data_ssr_is_the_solve_time_objective():
+    """Writing into the model after the solve must not move the
+    n_data= covariance: the SSR is the solve-time objective value, not
+    an evaluation on the live model (gh #426)."""
+    x, y, X = linear_data()
+    m = linear_model(x, y, declare=False)
+    declare_fitted(m.a, m.b)
+    pyo.SolverFactory("pounce").solve(m)
+    cov_before = covariance(m, n_data=N_LIN)
+    for i in m.I:
+        m.r[i].set_value(999.0)          # the receding-horizon write
+    m.a.set_value(0.0)
+    cov_after = covariance(m, n_data=N_LIN)
+    assert cov_after.sigma_sq == cov_before.sigma_sq
+    np.testing.assert_allclose(cov_after.matrix, cov_before.matrix,
+                               rtol=0, atol=0)
+
+
 def test_n_data_ignored_when_residuals_declared_warns(linear):
     m, x, y, X = linear                     # fixture declares residuals
     with warnings.catch_warnings(record=True) as w:

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -134,6 +134,21 @@ def test_n_data_ssr_is_the_solve_time_objective():
                                rtol=0, atol=0)
 
 
+def test_n_data_rejects_an_unevaluated_objective():
+    """A session whose solve evaluated no objective reports NaN, and
+    n_data= must refuse it rather than hand back a NaN covariance. NaN
+    is the sentinel the engine uses (0.0 is an ordinary objective
+    value), so the guard tests isfinite, not None."""
+    x, y, X = linear_data()
+    m = linear_model(x, y, declare=False)
+    declare_fitted(m.a, m.b)
+    pyo.SolverFactory("pounce").solve(m)
+    session = m.__dict__["_pounce_sens"].session
+    session.base_obj = float("nan")
+    with pytest.raises(RuntimeError, match="no usable objective value"):
+        covariance(m, n_data=N_LIN)
+
+
 def test_n_data_ignored_when_residuals_declared_warns(linear):
     m, x, y, X = linear                     # fixture declares residuals
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Fixes #426.

The `n_data=` branch of `covariance()` took its SSR from `pyo.value(objective)` on the current model, which evaluates at the model's current variable and Param values: any write after the solve (a measurement, a warm start for the next horizon) silently rescaled the reported covariance. The session now stores the objective value at the solve (`base_obj`, defaulted in the constructor) and the `n_data=` branch reads that, with a clean error if a session somehow lacks it. The `declare_residual` path already read stored state and is untouched.

Regression test `test_n_data_ssr_is_the_solve_time_objective`: solve, take the covariance, overwrite the model's variable values, take it again; the two must be bit-identical. Fails on the current code, passes with the fix. Suite: 143 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)