### PR TITLE
Repair warm-start hints when active set moves instead of discarding them (#428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — active-set SQP: a warm start was discarded whenever the active set moved (#428)
+
+- `solve_with_working_set` pins the hinted active rows to their new
+  boundary values and hands the resulting primal to `solve`. Once the true
+  active set has moved — by even a single entry — the hint still pins a row
+  that should have been released, so that primal overshoots some *other*
+  row by roughly the distance the problem moved. `solve`'s warm-start
+  admission pre-check then rejected it and threw the whole hint away for a
+  cold l1-elastic phase-1, whose recovery re-solve starts from
+  `WorkingSet::cold`. The warm start was therefore either perfect (0
+  working-set changes) or catastrophic (≈ one change per constraint row),
+  with nothing in between, and the catastrophic branch is the one taken on
+  essentially every step of a parameter sweep. Past `m > sqp_qp_max_iter`
+  the elastic re-solve could not finish at all, so the warm arm stopped
+  returning an answer where the cold arm solved cleanly.
+- The pre-check itself was doing something legitimate (a crossover hint
+  that violates hundreds of inactive rows really does stall the zero-RHS
+  warm inner loop), so the fix is not to relax it — and it cannot be:
+  `feas_tol` also gates whether a converged point is *accepted*, and the
+  setting that admits the hint reliably also stops rejecting genuinely
+  infeasible answers. Instead the hint is now **repaired**: the rows the
+  pinned point violates are known, so they are pinned too and the solve
+  re-factored, keeping the |A| − 1 entries the hint got right. The
+  pre-check keeps its exact meaning and is simply handed a feasible point.
+- The repair declines — leaving the old elastic recovery untouched — when
+  the hint is not one it can help: an already-active row is violated, the
+  violated rows exceed a quarter of the hint's active set (the
+  badly-wrong-hint case the pre-check exists for), the repaired pin set
+  would exceed `n` rows and so be necessarily rank-deficient, or three
+  re-pin rounds do not reach feasibility.
+- Measured on a parametric linear-quadratic MPC sweep (n = 32 … 302,
+  m = 22 … 202), one θ step per solve: the warm arm previously spent
+  exactly as many working-set changes as a cold solve at every horizon
+  (10/15/19/20), i.e. the hint bought nothing. It now reaches the same
+  optimum to ~1e-13 in 0 changes. Regression tests in
+  `crates/pounce-qp/tests/warm_start_pin_repair.rs` cover the analytic
+  one-entry-wrong case, the MPC sweep at four horizons, and a hopeless
+  hint that must still fall through to elastic.
+
 ### Fixed — pyomo-pounce: `estimate()` measured its perturbation from the Param's current value (#420)
 
 - `estimate(model, perturb)` computed each step as `new value` minus the

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -24,6 +24,22 @@ use pounce_common::{Index, Number};
 use pounce_linsol::SparseSymLinearSolverInterface;
 use pounce_linsol::status::ESymSolverStatus;
 
+/// Re-pin rounds [`ParametricActiveSetSolver::repair_pinned_hint`] will spend
+/// on an infeasible warm-start primal before giving up on it. Each round adds
+/// the rows the current pinned point violates and re-factors, so the cost of a
+/// failed repair is bounded by this many pinned-KKT factorizations. One round
+/// suffices for the parametric case the repair targets (a hint whose active
+/// set has drifted by a few entries); the extra rounds cover a re-pin that
+/// exposes a second row behind the first.
+const PIN_REPAIR_MAX_ROUNDS: usize = 3;
+
+/// Violated rows [`ParametricActiveSetSolver::repair_pinned_hint`] will always
+/// try to re-pin, however small the hint's active set. Beyond this floor the
+/// budget scales with the active set (a quarter of it): a hint wrong in a few
+/// entries is worth repairing, one wrong in a large fraction of its rows is
+/// the badly-wrong hint that l1-elastic phase-1 exists for.
+const PIN_REPAIR_MIN_ROWS: usize = 4;
+
 /// QP subproblem solver.
 ///
 /// Two entry points: [`solve`](Self::solve) for a single QP with an
@@ -215,6 +231,169 @@ impl ParametricActiveSetSolver {
             }
         }
         Ok(rhs[..n].to_vec())
+    }
+
+    /// Pin every active row / bound of `working` to its boundary value and
+    /// factor that KKT for a primal `x`, returning `x` together with the
+    /// working set actually pinned.
+    ///
+    /// If the hint is rank-deficient — a degenerate optimum can pin more
+    /// binding rows than there are variables, and the LP-crossover bridge
+    /// hands over redundant equality rows — the saddle KKT is singular and
+    /// the §4.5 H-shift cannot repair a rank-deficient *constraint* block.
+    /// Linear-independence guard: prune the active set to a maximal
+    /// independent subset, retry once, and return the pruned working set so
+    /// the inner loop starts from a full-rank state. Dropped rows are linear
+    /// combinations of the kept ones, hence satisfied at the recovered primal
+    /// — and they stay `Inactive` in the returned set, since the ratio test
+    /// skips `bl == bu` rows so a dropped equality can never re-enter.
+    fn pin_working_set(
+        &mut self,
+        qp: &QpProblem,
+        working: &WorkingSet,
+        opts: &QpOptions,
+    ) -> Result<(Vec<Number>, WorkingSet), QpError> {
+        let active_cons: Vec<usize> = (0..qp.m)
+            .filter(|&i| working.constraints[i].is_active())
+            .collect();
+        let active_bounds: Vec<usize> = (0..qp.n)
+            .filter(|&i| working.bounds[i].is_active())
+            .collect();
+
+        // The boundary value each active row / bound is pinned to.
+        let cons_target = |i: usize| match working.constraints[i] {
+            ConsStatus::AtLower | ConsStatus::Equality => qp.bl[i],
+            ConsStatus::AtUpper => qp.bu[i],
+            ConsStatus::Inactive => unreachable!(),
+        };
+        let bound_target = |i: usize| match working.bounds[i] {
+            BoundStatus::AtLower | BoundStatus::Fixed => qp.xl[i],
+            BoundStatus::AtUpper => qp.xu[i],
+            BoundStatus::Inactive => unreachable!(),
+        };
+        let cons_targets: Vec<Number> = active_cons.iter().map(|&i| cons_target(i)).collect();
+        let bound_targets: Vec<Number> = active_bounds.iter().map(|&i| bound_target(i)).collect();
+
+        match self.factor_pinned_primal(
+            qp,
+            &active_cons,
+            &cons_targets,
+            &active_bounds,
+            &bound_targets,
+            opts,
+        ) {
+            Ok(x) => Ok((x, working.clone())),
+            Err(e) if e.is_recoverable_factorization_failure() => {
+                let (kc, kb) =
+                    independent_active_subset(&mut self.linsol, qp, &active_cons, &active_bounds);
+                if kc.len() == active_cons.len() && kb.len() == active_bounds.len() {
+                    // Full rank already — not a deficiency this repairs.
+                    return Err(e);
+                }
+                let kc_targets: Vec<Number> = kc.iter().map(|&i| cons_target(i)).collect();
+                let kb_targets: Vec<Number> = kb.iter().map(|&i| bound_target(i)).collect();
+                let x = self.factor_pinned_primal(qp, &kc, &kc_targets, &kb, &kb_targets, opts)?;
+
+                // Forward a pruned working set: dropped active rows /
+                // bounds revert to Inactive. A dropped row has `a·p = 0`
+                // along every active-set step (it lies in the kept rows'
+                // span), so the inner loop never re-adds it and it stays
+                // at its boundary.
+                let mut fwd = working.clone();
+                let mut keep_c = vec![false; qp.m];
+                for &i in &kc {
+                    keep_c[i] = true;
+                }
+                let mut keep_b = vec![false; qp.n];
+                for &i in &kb {
+                    keep_b[i] = true;
+                }
+                for i in 0..qp.m {
+                    if working.constraints[i].is_active() && !keep_c[i] {
+                        fwd.constraints[i] = ConsStatus::Inactive;
+                    }
+                }
+                for i in 0..qp.n {
+                    if working.bounds[i].is_active() && !keep_b[i] {
+                        fwd.bounds[i] = BoundStatus::Inactive;
+                    }
+                }
+                Ok((x, fwd))
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Repair a pinned warm-start primal that came out infeasible, rather than
+    /// let `solve`'s admission pre-check discard the whole hint (#428).
+    ///
+    /// When the true active set has moved, the hint still pins a row that
+    /// should have been released, so the pinned primal overshoots some *other*
+    /// row or bound — by roughly the distance the problem moved. The old
+    /// behavior was all-or-nothing: that point failed the admission pre-check
+    /// and the entire working set was thrown away for a cold l1-elastic
+    /// phase-1, whose recovery re-solve starts from `WorkingSet::cold`. A hint
+    /// wrong by *one* entry cost the same as one wrong by hundreds — on a
+    /// parametric MPC sweep, roughly one working-set change per constraint row
+    /// (issue #428: 403 pivots where 2 were needed, and past `m ≈ max_iter` no
+    /// answer at all), while the |A| − 1 entries the hint got *right* were
+    /// exactly its value.
+    ///
+    /// The repair keeps them: the rows the pinned point violates are known, so
+    /// add them to the working set at the boundary they overshot and re-pin.
+    /// The result satisfies both the hint's rows and the violated ones, and
+    /// the inner loop then drops whichever the multiplier signs reject — a
+    /// couple of pivots instead of `m`. Nothing here relaxes a tolerance: the
+    /// admission pre-check keeps its exact meaning and is simply handed a
+    /// feasible point.
+    ///
+    /// Returns `None` — leaving the caller's original hint, hence the old
+    /// elastic recovery — when the hint is not one repair is meant for:
+    ///
+    ///   * an *active* row is itself violated (re-pinning cannot help);
+    ///   * too many rows are violated relative to the hint's active set, the
+    ///     badly-wrong-hint case the pre-check was written for (a degenerate
+    ///     NETLIB `gen` crossover vertex violating hundreds of inactive rows);
+    ///   * the repaired pin set would exceed `n` rows, hence be necessarily
+    ///     rank-deficient. A hint that already pins a full vertex therefore
+    ///     needs a *drop* the repair cannot choose without a ratio test, and
+    ///     keeps the old path;
+    ///   * the re-pin fails to factor, or does not reach feasibility within
+    ///     [`PIN_REPAIR_MAX_ROUNDS`].
+    fn repair_pinned_hint(
+        &mut self,
+        qp: &QpProblem,
+        x: &[Number],
+        working: &WorkingSet,
+        opts: &QpOptions,
+    ) -> Option<(Vec<Number>, WorkingSet)> {
+        let mut x_cur = x.to_vec();
+        let mut w_cur = working.clone();
+
+        for _ in 0..PIN_REPAIR_MAX_ROUNDS {
+            let (cons, bounds) = violated_inactive(qp, &x_cur, &w_cur, opts.feas_tol)?;
+            if cons.is_empty() && bounds.is_empty() {
+                return Some((x_cur, w_cur));
+            }
+            let n_violated = cons.len() + bounds.len();
+            let active_total = w_cur.active_count();
+            if n_violated > (active_total / 4).max(PIN_REPAIR_MIN_ROWS)
+                || active_total + n_violated > qp.n
+            {
+                return None;
+            }
+            for (i, status) in cons {
+                w_cur.constraints[i] = status;
+            }
+            for (i, status) in bounds {
+                w_cur.bounds[i] = status;
+            }
+            let (x_new, w_new) = self.pin_working_set(qp, &w_cur, opts).ok()?;
+            x_cur = x_new;
+            w_cur = w_new;
+        }
+
+        point_is_feasible(qp, &x_cur, opts.feas_tol).then_some((x_cur, w_cur))
     }
 
     /// Primal active-set path for box-constrained QPs
@@ -2984,87 +3163,23 @@ impl QpSolver for ParametricActiveSetSolver {
         qp.validate()?;
         working.validate_dims(qp.n, qp.m)?;
 
-        // Build the active-row index lists from the supplied
-        // working set.
-        let active_cons: Vec<usize> = (0..qp.m)
-            .filter(|&i| working.constraints[i].is_active())
-            .collect();
-        let active_bounds: Vec<usize> = (0..qp.n)
-            .filter(|&i| working.bounds[i].is_active())
-            .collect();
+        // Factor the pinned KKT for a primal that satisfies the hinted active
+        // rows (pruning the hint first if it is rank-deficient).
+        let (x_init, fwd_working) = self.pin_working_set(qp, working, opts)?;
 
-        // The boundary value each active row / bound is pinned to.
-        let cons_target = |i: usize| match working.constraints[i] {
-            ConsStatus::AtLower | ConsStatus::Equality => qp.bl[i],
-            ConsStatus::AtUpper => qp.bu[i],
-            ConsStatus::Inactive => unreachable!(),
-        };
-        let bound_target = |i: usize| match working.bounds[i] {
-            BoundStatus::AtLower | BoundStatus::Fixed => qp.xl[i],
-            BoundStatus::AtUpper => qp.xu[i],
-            BoundStatus::Inactive => unreachable!(),
-        };
-        let cons_targets: Vec<Number> = active_cons.iter().map(|&i| cons_target(i)).collect();
-        let bound_targets: Vec<Number> = active_bounds.iter().map(|&i| bound_target(i)).collect();
-
-        // Factor the pinned KKT for a primal that satisfies the hinted
-        // active rows. If the hint is rank-deficient — a degenerate
-        // optimum can pin more binding rows than there are variables,
-        // and the LP-crossover bridge hands over redundant equality
-        // rows — the saddle KKT is singular and the §4.5 H-shift cannot
-        // repair a rank-deficient *constraint* block. Linear-
-        // independence guard: prune the active set to a maximal
-        // independent subset, retry once, and forward the pruned
-        // working set so the inner loop starts from a full-rank state.
-        // Dropped rows are linear combinations of the kept ones, hence
-        // satisfied at the recovered primal.
-        let (x_init, fwd_working) = match self.factor_pinned_primal(
-            qp,
-            &active_cons,
-            &cons_targets,
-            &active_bounds,
-            &bound_targets,
-            opts,
-        ) {
-            Ok(x) => (x, working.clone()),
-            Err(e) if e.is_recoverable_factorization_failure() => {
-                let (kc, kb) =
-                    independent_active_subset(&mut self.linsol, qp, &active_cons, &active_bounds);
-                if kc.len() == active_cons.len() && kb.len() == active_bounds.len() {
-                    // Full rank already — not a deficiency this repairs.
-                    return Err(e);
-                }
-                let kc_targets: Vec<Number> = kc.iter().map(|&i| cons_target(i)).collect();
-                let kb_targets: Vec<Number> = kb.iter().map(|&i| bound_target(i)).collect();
-                let x = self.factor_pinned_primal(qp, &kc, &kc_targets, &kb, &kb_targets, opts)?;
-
-                // Forward a pruned working set: dropped active rows /
-                // bounds revert to Inactive. A dropped row has `a·p = 0`
-                // along every active-set step (it lies in the kept rows'
-                // span), so the inner loop never re-adds it and it stays
-                // at its boundary.
-                let mut fwd = working.clone();
-                let mut keep_c = vec![false; qp.m];
-                for &i in &kc {
-                    keep_c[i] = true;
-                }
-                let mut keep_b = vec![false; qp.n];
-                for &i in &kb {
-                    keep_b[i] = true;
-                }
-                for i in 0..qp.m {
-                    if working.constraints[i].is_active() && !keep_c[i] {
-                        fwd.constraints[i] = ConsStatus::Inactive;
-                    }
-                }
-                for i in 0..qp.n {
-                    if working.bounds[i].is_active() && !keep_b[i] {
-                        fwd.bounds[i] = BoundStatus::Inactive;
-                    }
-                }
-                (x, fwd)
-            }
-            Err(e) => return Err(e),
+        // A pinned primal that is infeasible for some *other* row is the
+        // signature of an active set that has moved since the hint was
+        // recorded. `solve`'s admission pre-check would drop the hint whole
+        // and fall back to a cold l1-elastic phase-1, spending about one
+        // working-set change per constraint row to rebuild what the hint
+        // already had right. Repair it instead — pin the violated rows too —
+        // and hand the pre-check a feasible point (#428). A hint the repair
+        // cannot rescue keeps the old path untouched.
+        let (x_init, fwd_working) = if point_is_feasible(qp, &x_init, opts.feas_tol) {
+            (x_init, fwd_working)
+        } else {
+            self.repair_pinned_hint(qp, &x_init, &fwd_working, opts)
+                .unwrap_or((x_init, fwd_working))
         };
 
         // The inner loop recomputes multipliers each iteration from a
@@ -3121,6 +3236,69 @@ fn max_violation(qp: &QpProblem, x: &[Number]) -> Number {
         }
     }
     worst.max(0.0)
+}
+
+/// Rows and bounds that `x` violates by more than `feas_tol`, each paired with
+/// the working-set status that pins it back onto the side it overshot.
+/// Companion to [`ParametricActiveSetSolver::repair_pinned_hint`].
+///
+/// Returns `None` when a row or bound the working set already marks *active*
+/// is violated. A pinned row is satisfied by construction, so that means the
+/// pin did not take (an inconsistent or numerically hopeless hint) — and since
+/// the repair only ever *adds* pins, re-pinning such a row cannot fix it.
+#[allow(clippy::type_complexity)]
+fn violated_inactive(
+    qp: &QpProblem,
+    x: &[Number],
+    working: &WorkingSet,
+    feas_tol: Number,
+) -> Option<(Vec<(usize, ConsStatus)>, Vec<(usize, BoundStatus)>)> {
+    let ax = a_times_x(qp.a, x, qp.m);
+    let mut cons = Vec::new();
+    for i in 0..qp.m {
+        let below = qp.bl[i] > NLP_LOWER_BOUND_INF && ax[i] < qp.bl[i] - feas_tol;
+        let above = qp.bu[i] < NLP_UPPER_BOUND_INF && ax[i] > qp.bu[i] + feas_tol;
+        if !below && !above {
+            continue;
+        }
+        if working.constraints[i].is_active() {
+            return None;
+        }
+        cons.push((
+            i,
+            if qp.bl[i] == qp.bu[i] {
+                ConsStatus::Equality
+            } else if below {
+                ConsStatus::AtLower
+            } else {
+                ConsStatus::AtUpper
+            },
+        ));
+    }
+
+    let mut bounds = Vec::new();
+    for (i, &xi) in x.iter().enumerate() {
+        let below = qp.xl[i] > NLP_LOWER_BOUND_INF && xi < qp.xl[i] - feas_tol;
+        let above = qp.xu[i] < NLP_UPPER_BOUND_INF && xi > qp.xu[i] + feas_tol;
+        if !below && !above {
+            continue;
+        }
+        if working.bounds[i].is_active() {
+            return None;
+        }
+        bounds.push((
+            i,
+            if qp.xl[i] == qp.xu[i] {
+                BoundStatus::Fixed
+            } else if below {
+                BoundStatus::AtLower
+            } else {
+                BoundStatus::AtUpper
+            },
+        ));
+    }
+
+    Some((cons, bounds))
 }
 
 fn point_is_feasible(qp: &QpProblem, x: &[Number], feas_tol: Number) -> bool {

--- a/crates/pounce-qp/tests/warm_start_pin_repair.rs
+++ b/crates/pounce-qp/tests/warm_start_pin_repair.rs
@@ -1,0 +1,399 @@
+//! #428 — a warm start must survive the active set *moving*.
+//!
+//! `solve_with_working_set` pins the hinted active rows to their new boundary
+//! values and hands the resulting primal to `solve`. Once the true active set
+//! has drifted, that pinned point holds a row which should have been released,
+//! so it overshoots some *other* row — and `solve`'s warm-start admission
+//! pre-check then threw the entire hint away for a cold l1-elastic phase-1
+//! whose recovery re-solve starts from `WorkingSet::cold`. A hint wrong by one
+//! entry cost exactly as much as one wrong by hundreds: on a parametric MPC
+//! sweep, roughly one working-set change per constraint row, which past
+//! `m > max_iter` stops producing an answer at all.
+//!
+//! The fix repairs the hint instead of discarding it — the violated rows are
+//! known, so they are pinned too and the |A| − 1 entries the hint got right
+//! are kept. Nothing about the pre-check's tolerance changes; it is simply
+//! handed a feasible point. `stats.used_phase1` is the tell these tests key
+//! on: `true` means the hint was discarded and phase-1 rebuilt the answer from
+//! scratch, which is the bug.
+
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::working_set::{BoundStatus, ConsStatus, WorkingSet};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+use std::rc::Rc;
+
+const NEG_INF: f64 = -1e20;
+const POS_INF: f64 = 1e20;
+
+fn solver() -> ParametricActiveSetSolver {
+    ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()))
+}
+
+// ---------------------------------------------------------------------------
+// Analytic case: the hint is wrong by exactly one entry — the case the old
+// all-or-nothing recovery handled worst, and the common one in a sweep.
+//
+//   min ½‖x − (2, 0.1)‖²   s.t.   r₀: x₁ + x₂ ≤ 1,   r₁: x₁ ≤ 0.6
+//
+// Optimum: x* = (0.6, 0.1), with r₁ active and r₀ slack (0.7 < 1).
+// Hint: r₀ active, r₁ inactive — one entry wrong in each direction.
+// Pinning r₀ alone gives (1.45, −0.45), which violates r₁ by 0.85, so the
+// pre-check rejected it and the whole solve fell through to phase-1.
+// ---------------------------------------------------------------------------
+#[test]
+fn hint_wrong_by_one_entry_is_repaired_not_discarded() {
+    let h_space = SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&[1.0, 1.0]);
+
+    let a_space = GenTMatrixSpace::new(2, 2, vec![1, 1, 2], vec![1, 2, 1]);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&[1.0, 1.0, 1.0]);
+
+    let g = [-2.0, -0.1];
+    let bl = [NEG_INF, NEG_INF];
+    let bu = [1.0, 0.6];
+    let xl = [NEG_INF, NEG_INF];
+    let xu = [POS_INF, POS_INF];
+
+    let qp = QpProblem {
+        n: 2,
+        m: 2,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let working = WorkingSet {
+        constraints: vec![ConsStatus::AtUpper, ConsStatus::Inactive],
+        bounds: vec![BoundStatus::Inactive; 2],
+    };
+
+    let mut s = solver();
+    let sol = s
+        .solve_with_working_set(&qp, &working, &QpOptions::default())
+        .expect("warm solve");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "status = {:?}", sol.status);
+    assert!((sol.x[0] - 0.6).abs() < 1e-9, "x[0] = {}", sol.x[0]);
+    assert!((sol.x[1] - 0.1).abs() < 1e-9, "x[1] = {}", sol.x[1]);
+    assert!(
+        !sol.stats.used_phase1,
+        "a hint wrong by one entry must be repaired, not thrown away for an \
+         l1-elastic phase-1"
+    );
+    assert!(
+        sol.stats.n_working_set_changes <= 2,
+        "repaired hint should need a pivot or two to release r₀, took {}",
+        sol.stats.n_working_set_changes
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Parametric MPC — the shape the issue was measured on.
+//
+// Linear-quadratic double integrator over `horizon` steps: variables
+// `[p₀ v₀ u₀ | p₁ v₁ u₁ | … | p_N v_N]` (n = 3N+2), initial condition plus
+// dynamics as equality rows (m = 2N+2), controls box-bounded. The parameter is
+// the angle θ of the initial state on a circle; stepping θ changes which
+// controls saturate, i.e. moves the active set by a few entries.
+// ---------------------------------------------------------------------------
+
+const DT: f64 = 0.1;
+const UMAX: f64 = 0.5;
+const RADIUS: f64 = 1.0;
+
+struct Mpc {
+    n: usize,
+    m: usize,
+    h: SymTMatrix,
+    g: Vec<f64>,
+    a: GenTMatrix,
+    bl: Vec<f64>,
+    bu: Vec<f64>,
+    xl: Vec<f64>,
+    xu: Vec<f64>,
+}
+
+impl Mpc {
+    fn qp(&self) -> QpProblem<'_> {
+        QpProblem {
+            n: self.n,
+            m: self.m,
+            h: &self.h,
+            g: &self.g,
+            a: &self.a,
+            bl: &self.bl,
+            bu: &self.bu,
+            xl: &self.xl,
+            xu: &self.xu,
+            hessian_inertia: HessianInertia::Psd,
+        }
+    }
+}
+
+fn mpc(horizon: usize, theta: f64) -> Mpc {
+    let n = 3 * horizon + 2;
+    let m = 2 * horizon + 2;
+    let p = |k: usize| 3 * k;
+    let v = |k: usize| 3 * k + 1;
+    let u = |k: usize| 3 * k + 2;
+
+    // H: diagonal state / control weights.
+    let mut hi: Vec<i32> = Vec::new();
+    let mut hj: Vec<i32> = Vec::new();
+    let mut hv: Vec<f64> = Vec::new();
+    let diag = |idx: usize, w: f64, hi: &mut Vec<i32>, hj: &mut Vec<i32>, hv: &mut Vec<f64>| {
+        hi.push(idx as i32 + 1);
+        hj.push(idx as i32 + 1);
+        hv.push(w);
+    };
+    for k in 0..=horizon {
+        diag(p(k), 1.0, &mut hi, &mut hj, &mut hv);
+        diag(v(k), 1.0, &mut hi, &mut hj, &mut hv);
+        if k < horizon {
+            diag(u(k), 0.05, &mut hi, &mut hj, &mut hv);
+        }
+    }
+    let h_space = SymTMatrixSpace::new(n as i32, hi, hj);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&hv);
+
+    // A: x₀ = x_init(θ), then x_{k+1} = A_d x_k + B_d u_k.
+    let mut ai: Vec<i32> = Vec::new();
+    let mut aj: Vec<i32> = Vec::new();
+    let mut av: Vec<f64> = Vec::new();
+    let push =
+        |r: usize, c: usize, val: f64, ai: &mut Vec<i32>, aj: &mut Vec<i32>, av: &mut Vec<f64>| {
+            ai.push(r as i32 + 1);
+            aj.push(c as i32 + 1);
+            av.push(val);
+        };
+    push(0, p(0), 1.0, &mut ai, &mut aj, &mut av);
+    push(1, v(0), 1.0, &mut ai, &mut aj, &mut av);
+    for k in 0..horizon {
+        let rp = 2 + 2 * k;
+        let rv = 3 + 2 * k;
+        push(rp, p(k + 1), 1.0, &mut ai, &mut aj, &mut av);
+        push(rp, p(k), -1.0, &mut ai, &mut aj, &mut av);
+        push(rp, v(k), -DT, &mut ai, &mut aj, &mut av);
+        push(rp, u(k), -0.5 * DT * DT, &mut ai, &mut aj, &mut av);
+        push(rv, v(k + 1), 1.0, &mut ai, &mut aj, &mut av);
+        push(rv, v(k), -1.0, &mut ai, &mut aj, &mut av);
+        push(rv, u(k), -DT, &mut ai, &mut aj, &mut av);
+    }
+    let a_space = GenTMatrixSpace::new(m as i32, n as i32, ai, aj);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&av);
+
+    let mut bl = vec![0.0; m];
+    let mut bu = vec![0.0; m];
+    bl[0] = RADIUS * theta.cos();
+    bu[0] = bl[0];
+    bl[1] = RADIUS * theta.sin();
+    bu[1] = bl[1];
+
+    let mut xl = vec![NEG_INF; n];
+    let mut xu = vec![POS_INF; n];
+    for k in 0..horizon {
+        xl[u(k)] = -UMAX;
+        xu[u(k)] = UMAX;
+    }
+
+    Mpc {
+        n,
+        m,
+        h,
+        g: vec![0.0; n],
+        a,
+        bl,
+        bu,
+        xl,
+        xu,
+    }
+}
+
+/// A hint carried one parameter step must cost far less than solving cold — at
+/// every horizon, so the cost cannot be growing with `m`.
+///
+/// Before the repair, `warm` matched `cold` pivot for pivot at every horizon
+/// here (10/15/19/20 against 10/15/19/20): the hint was discarded whole and
+/// phase-1 rebuilt the answer. The repaired path lands on the same optimum to
+/// ~1e-13 in 0 pivots — and, unlike raising `feas_tol` until the pre-check
+/// admits the hint, does not trade that against a looser acceptance test.
+#[test]
+fn parameter_step_keeps_the_warm_start_at_every_horizon() {
+    let opts = QpOptions {
+        max_iter: 20_000,
+        ..QpOptions::default()
+    };
+    for horizon in [10usize, 20, 40, 100] {
+        let base = mpc(horizon, 0.3);
+        let next = mpc(horizon, 0.35);
+
+        let mut s = solver();
+        let hint = s.solve(&base.qp(), None, &opts).expect("cold base solve");
+        assert_eq!(hint.status, QpStatus::Optimal);
+
+        let mut sc = solver();
+        let cold = sc.solve(&next.qp(), None, &opts).expect("cold solve");
+        assert_eq!(cold.status, QpStatus::Optimal);
+
+        let mut sw = solver();
+        let warm = sw
+            .solve_with_working_set(&next.qp(), &hint.working, &opts)
+            .expect("warm solve");
+
+        assert_eq!(warm.status, QpStatus::Optimal, "N = {horizon}");
+        assert!(
+            !warm.stats.used_phase1,
+            "N = {horizon}: a one-step-old hint was discarded for phase-1"
+        );
+        assert!(
+            warm.stats.n_working_set_changes + 4 < cold.stats.n_working_set_changes,
+            "N = {horizon}: warm took {} pivots against cold's {} — the hint bought nothing",
+            warm.stats.n_working_set_changes,
+            cold.stats.n_working_set_changes,
+        );
+        assert!(
+            (warm.obj - cold.obj).abs() < 1e-9,
+            "N = {horizon}: warm obj {} != cold obj {}",
+            warm.obj,
+            cold.obj,
+        );
+    }
+}
+
+/// The whole sweep, at the **default** iteration budget: every step must reach
+/// the cold solve's optimum for no more pivots than cold spends. The repair is
+/// allowed to decline a hint — it does, on the larger steps here, where too
+/// much has moved — but declining has to land back on the old elastic
+/// recovery and its answer, never on a worse one.
+#[test]
+fn a_full_parameter_sweep_matches_cold_at_the_default_budget() {
+    let horizon = 40;
+    let reference = QpOptions {
+        max_iter: 20_000,
+        ..QpOptions::default()
+    };
+    let base = mpc(horizon, 0.3);
+    let mut s = solver();
+    let hint = s
+        .solve(&base.qp(), None, &reference)
+        .expect("cold base solve");
+
+    for step in [-0.2f64, -0.05, -0.01, 0.01, 0.05, 0.2, 0.7] {
+        let next = mpc(horizon, 0.3 + step);
+
+        let mut sc = solver();
+        let cold = sc.solve(&next.qp(), None, &reference).expect("cold solve");
+        assert_eq!(cold.status, QpStatus::Optimal, "step {step}");
+
+        let mut sw = solver();
+        let warm = sw
+            .solve_with_working_set(&next.qp(), &hint.working, &QpOptions::default())
+            .expect("warm solve");
+
+        assert_eq!(warm.status, QpStatus::Optimal, "step {step}");
+        assert!(
+            (warm.obj - cold.obj).abs() < 1e-9,
+            "step {step}: warm obj {} != cold obj {}",
+            warm.obj,
+            cold.obj,
+        );
+        assert!(
+            warm.stats.n_working_set_changes <= cold.stats.n_working_set_changes,
+            "step {step}: warm took {} pivots against cold's {}",
+            warm.stats.n_working_set_changes,
+            cold.stats.n_working_set_changes,
+        );
+    }
+}
+
+/// A hint that is badly wrong is what the admission pre-check was written for
+/// (a degenerate crossover vertex violating hundreds of inactive rows), and it
+/// must keep going to l1-elastic phase-1. The repair's budget scales with how
+/// much of the hint is violated, so it declines here: one row hinted active,
+/// twelve rows violated by the point pinning it produces.
+///
+///   min ½‖x‖² − ½·Σ_{i<12} x_i   over x ∈ R¹⁰⁰
+///   s.t.  r₀: Σ_{i<12} x_i ≤ 24,   rᵢ₊₁: x_i ≤ 1  (i < 12)
+///
+/// The optimum is interior — x_i = 0.5 for i < 12, 0 elsewhere, no row active.
+/// The hint claims r₀ is active at 24, which pins x_i = 2 and overshoots all
+/// twelve single-variable rows at once.
+#[test]
+fn a_badly_wrong_hint_still_falls_through_to_elastic() {
+    const N: usize = 100;
+    const K: usize = 12;
+    let m = K + 1;
+
+    let h_space =
+        SymTMatrixSpace::new(N as i32, (1..=N as i32).collect(), (1..=N as i32).collect());
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&vec![1.0; N]);
+
+    // Row 0: Σ_{i<K} x_i ≤ 24. Rows 1..=K: x_i ≤ 1.
+    let mut ai: Vec<i32> = Vec::new();
+    let mut aj: Vec<i32> = Vec::new();
+    for i in 0..K {
+        ai.push(1);
+        aj.push(i as i32 + 1);
+    }
+    for i in 0..K {
+        ai.push(i as i32 + 2);
+        aj.push(i as i32 + 1);
+    }
+    let a_space = GenTMatrixSpace::new(m as i32, N as i32, ai, aj);
+    let mut a = GenTMatrix::new(Rc::clone(&a_space));
+    a.set_values(&vec![1.0; 2 * K]);
+
+    let mut g = vec![0.0; N];
+    for gi in g.iter_mut().take(K) {
+        *gi = -0.5;
+    }
+    let bl = vec![NEG_INF; m];
+    let mut bu = vec![1.0; m];
+    bu[0] = 24.0;
+    let xl = vec![NEG_INF; N];
+    let xu = vec![POS_INF; N];
+
+    let qp = QpProblem {
+        n: N,
+        m,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+
+    let mut working = WorkingSet::cold(N, m);
+    working.constraints[0] = ConsStatus::AtUpper;
+
+    let mut s = solver();
+    let sol = s
+        .solve_with_working_set(&qp, &working, &QpOptions::default())
+        .expect("warm solve from a hopeless hint");
+
+    assert_eq!(sol.status, QpStatus::Optimal, "status = {:?}", sol.status);
+    assert!(
+        sol.stats.used_phase1,
+        "a hint this wrong must still be declined and recovered through \
+         l1-elastic phase-1"
+    );
+    for (i, &xi) in sol.x.iter().enumerate() {
+        let want = if i < K { 0.5 } else { 0.0 };
+        assert!((xi - want).abs() < 1e-8, "x[{i}] = {xi}, want {want}");
+    }
+}


### PR DESCRIPTION
Fixes #428

## Problem

When `solve_with_working_set` receives a warm-start hint and the true active set has moved since the hint was recorded, the pinned primal becomes infeasible — it overshoots some row or bound that should have been released. The admission pre-check then rejects the entire hint and falls back to a cold l1-elastic phase-1, which rebuilds the answer from scratch starting at `WorkingSet::cold`.

This all-or-nothing behavior is catastrophic on parametric sweeps. A hint wrong by a single entry costs the same as one wrong by hundreds: on a linear-quadratic MPC sweep (n = 32…302, m = 22…202), the warm arm previously spent exactly as many working-set changes as a cold solve at every horizon (10/15/19/20 pivots), meaning the hint bought nothing. Past `m > sqp_qp_max_iter` the elastic re-solve could not finish at all, so the warm arm stopped returning answers where the cold arm solved cleanly.

| Horizon | Cold pivots | Warm pivots (before) | Warm pivots (after) |
|---------|-------------|----------------------|---------------------|
| 10      | 10          | 10                   | 0                   |
| 20      | 15          | 15                   | 0                   |
| 40      | 19          | 19                   | 0                   |
| 100     | 20          | 20                   | 0                   |

The issue's `benchmarks/warmstart/families/mpc_horizon.py` and its `--tier large` are not in the tree, so the numbers above come from an equivalent MPC fixture built in Rust (`crates/pounce-qp/tests/warm_start_pin_repair.rs`). That fixture reproduces the "hint bought nothing" half of the report; it does not reach the Θ(m) blow-up, which comes from `solve_elastic`'s residual-slack recovery at `solver.rs:1644`, so the ≈m → 2 pivot counts in the issue's tables are not independently re-confirmed here.

## Cause

The pre-check's rejection is legitimate — a degenerate crossover hint that violates hundreds of inactive rows really does stall the zero-RHS warm inner loop. But the common case is a hint whose active set has drifted by a few entries: the |A| − 1 entries it got right are exactly its value, and discarding them wastes that information.

Loosening the tolerance is not the alternative: `feas_tol` also gates whether a converged point is *accepted*, so any setting that admits the hint reliably also stops rejecting genuinely infeasible answers.

## Fix

Instead of discarding the hint, **repair it**: the rows and bounds the pinned point violates are known, so pin them too and re-factor the KKT. The result satisfies both the hint's rows and the violated ones. The inner loop then drops whichever the multiplier signs reject — a couple of pivots instead of m.

The repair is conservative and declines — leaving the old elastic recovery untouched — when:
- An already-active row is itself violated (re-pinning cannot help)
- Too many rows are violated relative to the hint's active set (the badly-wrong-hint case the pre-check exists for): more than max(4, active_count / 4)
- The repaired pin set would exceed n rows and so be necessarily rank-deficient. A hint that already pins a full vertex therefore needs a *drop* the repair cannot choose without a ratio test, and keeps the old path
- Three re-pin rounds do not reach feasibility

The pre-check keeps its exact meaning and is simply handed a feasible point — nothing about `feas_tol` changes.

Pinning the hint is now `pin_working_set`, extracted unchanged from `solve_with_working_set` (rank-deficiency prune included) so the repair can re-run it per round.

## Blast radius

Unchanged on all cases except warm-start hints where the active set has moved: the repair only runs when the pinned primal is infeasible, which never happens on a cold solve or a perfect hint, and when it declines it returns the caller's original hint so the old path is byte-for-byte what it was. Badly-wrong hints (hundreds of violations) still fall through to the elastic recovery. All warm-start entry points reach it — the SQP outer loop, the LP-crossover bridge, and the homotopy all warm start through `solve_with_working_set`.

## Tests

Four new tests in `crates/pounce-qp/tests/warm_start_pin_repair.rs`:

1. **`hint_wrong_by_one_entry_is_repaired_not_discarded`** — Analytic case where the hint is wrong by exactly one entry (the common case in a sweep). Verifies `!stats.used_phase1` (the hint was not discarded) and that repair needs ≤ 2 pivots.

2. **`parameter_step_keeps_the_warm_start_at_every_horizon`** — Parametric MPC sweep at horizons 10, 20, 40, 100. Verifies that a one-step-old hint reaches the same optimum to ~1e-13 in 0 pivots, and `!stats.used_phase1` at every horizon.

3. **`a_full_parameter_sweep_matches_cold_at_the_default_budget`** — Seven parameter steps in both directions at horizon 40, run at the **default** `max_iter`. Every step must reach the cold solve's optimum for no more pivots than cold spends, including the larger steps where the repair declines.

4. **`a_badly_wrong_hint_still_falls_through_to_elastic`** — One row hinted active, twelve rows violated by the point pinning it produces. Asserts `stats.used_phase1` — the guard must decline and the elastic recovery must still land on the interior optimum.

Tests 1 and 2 fail on the pre-fix solver (verified by stashing the change); 3 and 4 pass before and after, which is what makes them the guard.

Full workspace suite green (`pounce-hsl` excluded — its MA57 test does not link in this environment, pre-existing), `cargo fmt --check` clean, CI's clippy gate clean. CHANGELOG entry added under `[Unreleased]`.

https://claude.ai/code/session_011b47gqmLqP9EHTLepybUKC