### PR TITLE
Restore simplex seed as fallback when homotopy path loses feasibility (#413)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,67 @@ changes.
   inner work differs by an order of magnitude (`simplex_proj`: 313 → 4
   active-set changes; `nmpc_vanderpol`: 931 → 66). Both keys are 0 on the
   interior-point path, which solves no QP subproblems.
+### Fixed — the active-set QP driver lost its cold-start fallback when the homotopy's feasibility invariant broke (#413)
+
+- **#412's parametric homotopy does not keep `x(t)` feasible, and its own
+  documentation said it did.** The module header asserted that `x(t)` is
+  feasible for the `t`-problem "at every point on the path by construction".
+  Measured on Maros-Mészáros `QSHARE2B`, 14 rows are crossed uncapped on a
+  single path and the worst grows `8e-2 → 0.4 → 7.5 → 11 → 22` on the way to
+  `t = 1`. The path's primal ratio test only ever *prevents* a violation — a row
+  whose gap has gone negative yields `dt < 0`, which the test discards — so a
+  crossing is never repaired and compounds. Two mechanisms, both measured: the
+  rank-repair tabu hides a row from the ratio test rather than only from the add
+  decision (10 of 14), and events coincident in `t` or below the `T_EPS` floor
+  lose the strict comparison that would cap the step (4 of 14).
+- **The damage was not a slow solve, it was a *seedless* one.** That false claim
+  was load-bearing: `pounce-convex`'s driver switched off its simplex phase-1
+  vertex seed whenever the homotopy is on, "because the homotopy is itself the
+  cold-start mechanism". When the path's prediction turned out unusable, the
+  engine therefore had neither — and cold-started the l1-elastic phase-1 that
+  `pounce-qp` documents as not terminating on the degenerate netlib-derived QPs
+  in this set. On `QSHARE2B` that spent the whole iteration budget to return
+  `4854` against a published `11703.7`, still carrying a constraint violation of
+  `20`; the seeded route solves it in 52 iterations.
+- **The seed is restored as a last-resort retry**, after the existing
+  Ruiz-equilibration retry rather than before it, so both earlier attempts stay
+  bit-identical and nothing that already solved can be displaced — including by
+  the clock, which is how an added stage regresses a benchmark even when its
+  logic cannot. (Ordering was measured: placed first, it took `QPCBOEI1` from
+  `0.68 s` to a 60 s timeout.)
+- **The path reports its feasibility loss but does not abandon the path.**
+  Abandoning was implemented and measured *worse*: the corrector is a genuine
+  corrector and often recovers, so losing feasibility degrades the prediction
+  rather than invalidating it (`QSHIP04S` reaches a violation of `7.1e4` at
+  `t = 0.5` and still solves to the published optimum). Repairing the crossings
+  properly needs an exchange pivot at the degenerate vertex and is left to
+  follow-up.
+- **Also fixes a pre-existing infeasibility-reporting bug this exposed.**
+  `cold_general_initial` skipped every `bl == bu` row in its feasibility sweep,
+  on the reasoning that a pinned equality is satisfied by construction — true
+  only for the rows actually *kept*. An equality its own rank guard pruned as
+  linearly dependent but *inconsistent* (`x₀+x₁ = 1` with `x₀+x₁ = 3`) was never
+  re-checked, so the model came back `NumericalFailure` instead of routing to
+  the elastic phase-1 that certifies it `PrimalInfeasible` — a `500` where
+  callers needed a `200`.
+- Maros-Mészáros active-set column, 60 s cap: **58 → 59 solved, zero lost, zero
+  solved-but-wrong**. This addresses the mechanism behind #413's timeouts and
+  one of the instances; the bulk of the 49 remain and are **not** corrector-bound
+  as the issue hypothesised.
+- **What the measurement rules out, for whoever picks this up next.** 43 of 138
+  paths lose feasibility, and they solve 19% of the time against 59% for the 95
+  that stay clean — so the path really is the discriminator. But the obvious
+  repair is a dead end: a degenerate-vertex exchange pivot (active set split from
+  the KKT working set, promotion into the working set, plus a post-step capture
+  giving the ratio test the repair it lacks) was implemented and measured on
+  exactly those 43 at a 120 s cap, and moved **9/43 solved to 9/43**, repairing
+  none of the broken paths. It buys one large win (`STADAT2`, 10979 corrector
+  iterations → 22) and one real regression (`QBEACONF`, 0.43 s → 8.23 s). Kept on
+  the `experiment/413-exchange-pivot` branch rather than merged. Note also that
+  the six instances #412 regressed (`AUG2D`, `AUG2DC`, `CONT-050`, `CONT-100`,
+  `DTOC3`, `STADAT3`) all have **clean** paths, so they are slow, not broken, and
+  nothing about path feasibility will help them.
+
 ### Fixed — exact-Hessian SQP gave up on unconstrained nonconvex NLPs (#423)
 
 - **`algorithm = active-set-sqp` with `sqp_hessian = exact` no longer stops at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,10 +139,41 @@ changes.
   exactly those 43 at a 120 s cap, and moved **9/43 solved to 9/43**, repairing
   none of the broken paths. It buys one large win (`STADAT2`, 10979 corrector
   iterations → 22) and one real regression (`QBEACONF`, 0.43 s → 8.23 s). Kept on
-  the `experiment/413-exchange-pivot` branch rather than merged. Note also that
-  the six instances #412 regressed (`AUG2D`, `AUG2DC`, `CONT-050`, `CONT-100`,
-  `DTOC3`, `STADAT3`) all have **clean** paths, so they are slow, not broken, and
-  nothing about path feasibility will help them.
+  the `experiment/413-exchange-pivot` branch rather than merged.
+- **And the other half of #413's timeouts is not a defect at all — it is the
+  method's complexity class.** The 39 remaining unsolved instances have
+  perfectly *clean* paths, including all six #412 regressed (`AUG2D`, `AUG2DC`,
+  `CONT-050`, `CONT-100`, `DTOC3`, `STADAT3`); they are all large, and they time
+  out because the **optimal active set is a constant fraction of `n`**:
+
+  | instance | `n` | active at the optimum |
+  |---|---|---|
+  | LISWET1 (and 11 siblings) | 10002 | 10000 (100%) |
+  | POWELL20 | 10000 | 10000 (100%) |
+  | QSHIP08L | 4283 | 4200 (98%) |
+  | CONT-050 | 2597 | 2402 (92%) |
+  | CVXQP1_M | 1000 | 887 (89%) |
+  | DTOC3 | 14999 | 7901 (53%) |
+  | AUG2D | 20200 | 10000 (50%) |
+
+  An active-set method changes the working set by one row per pivot, so from a
+  cold start these need 10³–10⁴ pivots, each at minimum a back-solve on an
+  O(`n`) KKT. The interior-point engine takes **21 iterations on LISWET1
+  regardless of size** — which is why `auto` routes cold convex QPs there and
+  why pounce solves 137/138 overall. No amount of work on the active-set path
+  closes an Ω(`n`)-versus-O(1) iteration-count gap.
+
+  #413's headline — that the timeouts are "corrector-bound, not path-bound" —
+  does not hold for these either: at a 60 s cap `LISWET1` reaches only
+  `t = 0.976` after 7050 path steps, `AUG2D` only `t = 0.50`, `QSHIP08L`
+  `t = 0.655`. The path *is* the runtime. The 4% figure in the issue was
+  profiled on `QSCTAP1` (n=480) and `QSCSD6` (n=1350) and does not generalise.
+  The Schur-update remedy that observation rules out was nonetheless tried here
+  (rank-2 updates of a cached K_max, the machinery `solve_general_schur`
+  already uses) and it made the path **slower** — 4850 steps in 60 s against
+  7050 — because K_max is fixed at dimension `n + m + n` and the SMW solve plus
+  refinement costs several back-solves per step against one factorization of a
+  smaller active-set KKT.
 
 ### Fixed — exact-Hessian SQP gave up on unconstrained nonconvex NLPs (#423)
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,8 @@ the full list and per-suite details.
 
 [Opyrability](https://github.com/CODES-group/opyrability#installation) now uses pounce as its default solver.
 
+[SiNDAE](https://github.com/llueg/SiNDAE)  — A Simultaneous Approach for Training Neural Differential-Algebraic Equations
+
 Devin Griffith has been creating a series of interactive optimization examples that use pounce:
 - https://quadtank.griffith-pse.com/
 - https://cstr-sensitivity.griffith-pse.com/

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -215,35 +215,82 @@ where
         make_backend,
         FeasibilityProbe::Allowed,
     );
-    if !opts.equilibrate || is_conclusive(sol.status) {
+    if is_conclusive(sol.status) {
         return sol;
     }
 
-    let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
-    let mut retry = solve_translated(
-        &scaled,
-        &unscaled_opts,
-        engine,
-        make_backend,
-        FeasibilityProbe::Allowed,
-    );
-    scaling.unscale_solution(prob, &mut retry);
-    // Re-verify against the ORIGINAL problem: the verdict reached inside the
-    // scaled solve certifies a KKT point of the *scaled* QP, and unscaling
-    // moves the residuals, so it has to be re-earned here rather than carried
-    // over on the strength of the wrong problem's numbers.
-    retry.status = reverify_after_unscale(retry.status, &retry, prob, opts);
-    // Keep the original failure when the retry also fails, so the reported
-    // status describes the attempt made on the problem as the user posed it.
-    // `PrimalInfeasible` counts as a win here because `reverify_after_unscale`
-    // just re-earned its Farkas certificate against the *original* problem;
-    // `DualInfeasible` does not, because its witness (the engine's ray) is not
-    // available out here to re-check.
-    if is_solved(retry.status) || retry.status == QpStatus::PrimalInfeasible {
-        retry
-    } else {
-        sol
+    let mut best = sol;
+    if opts.equilibrate {
+        let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
+        let mut retry = solve_translated(
+            &scaled,
+            &unscaled_opts,
+            engine,
+            make_backend,
+            FeasibilityProbe::Allowed,
+        );
+        scaling.unscale_solution(prob, &mut retry);
+        // Re-verify against the ORIGINAL problem: the verdict reached inside the
+        // scaled solve certifies a KKT point of the *scaled* QP, and unscaling
+        // moves the residuals, so it has to be re-earned here rather than carried
+        // over on the strength of the wrong problem's numbers.
+        retry.status = reverify_after_unscale(retry.status, &retry, prob, opts);
+        // Keep the original failure when the retry also fails, so the reported
+        // status describes the attempt made on the problem as the user posed it.
+        // `PrimalInfeasible` counts as a win here because `reverify_after_unscale`
+        // just re-earned its Farkas certificate against the *original* problem;
+        // `DualInfeasible` does not, because its witness (the engine's ray) is not
+        // available out here to re-check.
+        if is_solved(retry.status) || retry.status == QpStatus::PrimalInfeasible {
+            best = retry;
+        }
+        if is_conclusive(best.status) {
+            return best;
+        }
     }
+
+    // ---- Last resort: the simplex seed the homotopy displaced (#413) ----
+    //
+    // Turning the homotopy on also turned the simplex phase-1 vertex seed *off*
+    // (see the `seed` binding in `solve_translated`), on the stated premise that
+    // the homotopy "is feasible along the whole path" and so is itself the
+    // cold-start mechanism. That premise is false — see the path-feasibility
+    // guard in `pounce_qp::homotopy` — and when it fails the engine is left with
+    // *neither* mechanism: no usable path, and no seed, so it cold-starts the
+    // l1-elastic phase-1 that this module's own header records as not
+    // terminating on the degenerate netlib-derived QPs in Maros-Mészáros.
+    //
+    // That is the #413 timeout mode, and it is not a slow corrector. On
+    // `QSHARE2B` the seedless route spends its entire iteration budget to return
+    // `4854` against a published `11703.7`, still carrying a constraint
+    // violation of 20; the seeded route solves it in 52 iterations / 0.03 s.
+    //
+    // Ordering is load-bearing. This runs *after* the Ruiz retry, not before:
+    // both earlier attempts are then bit-identical to what they were, so nothing
+    // that used to solve can be displaced — including by the clock, which is the
+    // way an added stage can regress a benchmark even when its logic cannot.
+    // (Measured: with this stage first, `QPCBOEI1` went from 0.68 s to a 60 s
+    // timeout, because the seeded attempt consumed the budget the Ruiz retry
+    // needed.) When the caller already asked for `use_homotopy=no`, the first
+    // attempt was seeded and there is nothing new to try.
+    if engine.use_homotopy != Some(false) {
+        let seeded_engine = ActiveSetOverrides {
+            use_homotopy: Some(false),
+            ..*engine
+        };
+        let seeded = solve_translated(
+            prob,
+            &unscaled_opts,
+            &seeded_engine,
+            make_backend,
+            FeasibilityProbe::Allowed,
+        );
+        if is_solved(seeded.status) || seeded.status == QpStatus::PrimalInfeasible {
+            return seeded;
+        }
+    }
+
+    best
 }
 
 /// Did the solve produce a usable, verified KKT point?

--- a/crates/pounce-convex/tests/issue413_homotopy_path_feasibility.rs
+++ b/crates/pounce-convex/tests/issue413_homotopy_path_feasibility.rs
@@ -1,0 +1,227 @@
+//! gh #413 — the parametric homotopy must not hand back a prediction built on a
+//! point that has fallen off the feasible set, and the driver must still have a
+//! working cold start when it doesn't.
+//!
+//! #412 turned the §4.2 homotopy on by default and, in the same change, turned
+//! `pounce-convex`'s simplex phase-1 vertex seed *off* whenever it is on. The
+//! justification was the homotopy module's own claim that `x(t)` is feasible for
+//! the `t`-problem "at every point on the path by construction".
+//!
+//! It is not. The path's primal ratio test can only *prevent* a violation — a
+//! row whose gap has already gone negative yields a negative `dt`, which the
+//! test discards — so a row it fails to cap stays violated for the remainder of
+//! the path and drifts further out. Measured on Maros-Mészáros `QSHARE2B`, 14
+//! rows were crossed uncapped on a single path (10 of them because the
+//! rank-repair tabu hides a row from the ratio test, 4 because two events
+//! coincide in `t`), and the worst grew `8e-2 -> 0.4 -> 7.5 -> 11 -> 22` on the
+//! way to `t = 1`.
+//!
+//! The damage was not a slow solve, it was a *seedless* one: the working set at
+//! `t = 1` pinned an infeasible vertex, the corrector's warm-start pre-check
+//! rejected it, and with no simplex seed left to fall back on the engine
+//! cold-started the l1-elastic phase-1 that `pounce-qp` documents as not
+//! terminating on this problem family. `QSHARE2B` burned its whole iteration
+//! budget to return `4854` (published optimum `11703.7`) still carrying a
+//! constraint violation of `20`; with the seed it solves in 52 iterations.
+//!
+//! These tests cover the three pieces of the repair that are reachable without
+//! the benchmark set:
+//!
+//! * an infeasible QP is still certified `PrimalInfeasible` on the *seeded*
+//!   route — which it was not, because `cold_general_initial` never re-checked
+//!   an equality row its own rank guard had pruned;
+//! * a degenerate QP with a rank-deficient active set — the geometry that makes
+//!   the path abandon — is still solved, and solved correctly;
+//! * a solve that reports `Optimal` reports a genuinely feasible point.
+
+use pounce_convex::{
+    ActiveSetOverrides, QpOptions, QpProblem, QpSolution, QpStatus, Triplet, solve_qp_active_set,
+    solve_qp_ipm,
+};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn solve_with(prob: &QpProblem, engine: &ActiveSetOverrides) -> QpSolution {
+    let mut mk = backend;
+    solve_qp_active_set(prob, &QpOptions::default(), engine, &mut mk)
+}
+
+fn solve(prob: &QpProblem) -> QpSolution {
+    solve_with(prob, &ActiveSetOverrides::default())
+}
+
+/// Worst violation of `a·x` against `[b, b]` rows, `G x <= h` rows, and the box.
+fn max_violation(prob: &QpProblem, x: &[f64]) -> f64 {
+    let mut worst: f64 = 0.0;
+    let mut ax = vec![0.0; prob.b.len()];
+    for t in &prob.a {
+        ax[t.row] += t.val * x[t.col];
+    }
+    for (i, &axi) in ax.iter().enumerate() {
+        worst = worst.max((axi - prob.b[i]).abs());
+    }
+    let mut gx = vec![0.0; prob.h.len()];
+    for t in &prob.g {
+        gx[t.row] += t.val * x[t.col];
+    }
+    for (i, &gxi) in gx.iter().enumerate() {
+        worst = worst.max(gxi - prob.h[i]);
+    }
+    for (j, &xj) in x.iter().enumerate() {
+        worst = worst.max(prob.lb[j] - xj).max(xj - prob.ub[j]);
+    }
+    worst
+}
+
+/// `x₀ + x₁ = 1` together with `x₀ + x₁ = 3`, solved on the route the #413
+/// seeded retry uses — the homotopy explicitly off.
+///
+/// The two rows are linearly *dependent* and mutually *inconsistent*. Pinning
+/// both makes the KKT singular, so `cold_general_initial`'s rank guard prunes
+/// one and recovers a point satisfying the survivor. Its feasibility sweep then
+/// skipped every `bl == bu` row outright — on the reasoning that a pinned
+/// equality is satisfied by construction, which is true only for the rows that
+/// were actually *kept*. The pruned row, violated by 2, was never looked at, so
+/// the caller ran phase-2 on an infeasible iterate and reported the model as a
+/// solver failure instead of routing to the elastic phase-1 that certifies it
+/// infeasible.
+///
+/// This was masked for as long as the homotopy always reached `t = 1`: the
+/// corrector's own pre-check caught the bad point and sent it to elastic. It
+/// surfaced the moment the path started abandoning early.
+#[test]
+fn contradictory_equalities_are_infeasible_on_the_seeded_route() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 1.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+        ],
+        b: vec![1.0, 3.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![10.0, 10.0],
+    };
+
+    let seeded = ActiveSetOverrides {
+        use_homotopy: Some(false),
+        ..Default::default()
+    };
+    assert_eq!(
+        solve_with(&prob, &seeded).status,
+        QpStatus::PrimalInfeasible,
+        "homotopy off: a pruned, inconsistent equality must route to elastic"
+    );
+    // And on the default route, which is what #412 shipped.
+    assert_eq!(solve(&prob).status, QpStatus::PrimalInfeasible);
+    assert_eq!(
+        solve_qp_ipm(&prob, &QpOptions::default(), backend).status,
+        QpStatus::PrimalInfeasible,
+        "IPM oracle"
+    );
+}
+
+/// A degenerate QP whose optimal active set is rank-deficient: four constraints
+/// meet at the single feasible point `(1, 1)`, two of them duplicates.
+///
+/// This is the geometry that drives the path into its rank-repair branch — the
+/// branch whose tabu is what hides rows from the primal ratio test. Whatever the
+/// path decides to do here, the driver must still return the right answer.
+#[test]
+fn degenerate_rank_deficient_vertex_still_solves() {
+    // min ½‖x − (3,3)‖²  s.t.  x₀ + x₁ ≤ 2 (×2 duplicated), x₀ ≤ 1, x₁ ≤ 1.
+    // The three distinct rows all bind at (1,1), which is the unique optimum.
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 1, 1.0)],
+        c: vec![-3.0, -3.0],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(2, 0, 1.0),
+            Triplet::new(3, 1, 1.0),
+        ],
+        h: vec![2.0, 2.0, 1.0, 1.0],
+        lb: vec![0.0, 0.0],
+        ub: vec![10.0, 10.0],
+    };
+
+    let sol = solve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal, "obj={}", sol.obj);
+    assert!(
+        (sol.x[0] - 1.0).abs() < 1e-6 && (sol.x[1] - 1.0).abs() < 1e-6,
+        "expected the degenerate vertex (1,1), got {:?}",
+        sol.x
+    );
+    assert!(
+        max_violation(&prob, &sol.x) < 1e-6,
+        "reported Optimal at an infeasible point (violation {:.3e})",
+        max_violation(&prob, &sol.x)
+    );
+}
+
+/// The contract the path guard exists to protect, stated end-to-end: an
+/// `Optimal` verdict must come with a feasible point and the IPM's objective.
+///
+/// Run over a small ladder of degenerate / duplicated-row instances, because the
+/// failure this guards against was silent — #413's engine returned `Optimal`-
+/// shaped answers that were `4854` against a true `11703.7`, and it was only
+/// visible by checking the point rather than the status.
+#[test]
+fn optimal_is_never_reported_at_an_infeasible_point() {
+    // Each entry duplicates its rows a different number of times, which is what
+    // pushes the active set at the optimum past full rank.
+    for dup in 1..=4usize {
+        let mut g = Vec::new();
+        for k in 0..dup {
+            g.push(Triplet::new(k, 0, 1.0));
+            g.push(Triplet::new(k, 1, 2.0));
+        }
+        g.push(Triplet::new(dup, 0, -1.0));
+        let mut h = vec![4.0; dup];
+        h.push(0.0);
+
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 1.0)],
+            c: vec![-8.0, -3.0],
+            a: vec![],
+            b: vec![],
+            g,
+            h,
+            lb: vec![0.0, 0.0],
+            ub: vec![5.0, 5.0],
+        };
+
+        let sol = solve(&prob);
+        let ipm = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        assert_eq!(ipm.status, QpStatus::Optimal, "IPM oracle, dup={dup}");
+
+        if sol.status == QpStatus::Optimal {
+            assert!(
+                max_violation(&prob, &sol.x) < 1e-6,
+                "dup={dup}: Optimal at an infeasible point (violation {:.3e})",
+                max_violation(&prob, &sol.x)
+            );
+            assert!(
+                (sol.obj - ipm.obj).abs() <= 1e-6 * (1.0 + ipm.obj.abs()),
+                "dup={dup}: Optimal with obj={} against IPM {}",
+                sol.obj,
+                ipm.obj
+            );
+        }
+    }
+}

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -45,9 +45,24 @@
 //! `H` and `g` are held fixed, so the `-g` block above never moves and the
 //! direction solve has a zero primal right-hand side.
 //!
-//! The consequence worth stating plainly: there is **no phase-1**. `x(t)` is
-//! feasible for the `t`-problem at every point on the path by construction, so
-//! feasibility is never searched for and cannot stall.
+//! The consequence worth stating plainly: there is **no phase-1**. `x(t)` starts
+//! feasible for the `t`-problem, and the primal ratio test is what keeps it that
+//! way, so feasibility is never *searched* for.
+//!
+//! It can still be *lost*, and this module used to claim otherwise — that
+//! feasibility held "at every point on the path by construction". That claim was
+//! wrong and it was load-bearing: `pounce-convex`'s driver switched off its
+//! simplex phase-1 seed on the strength of it, leaving nothing to fall back on
+//! when the path's prediction turned out unusable (#413). The ratio test only
+//! ever *prevents* a violation and cannot repair one, so a row it fails to cap
+//! stays violated for the rest of the path and drifts further out; see the
+//! path-feasibility report in [`ParametricActiveSetSolver::trace_path`] for the
+//! two measured ways that happens.
+//!
+//! The path is still only a **predictor** — the corrector re-derives the primal
+//! from the working set and often recovers from a path that drifted — so losing
+//! feasibility degrades the prediction rather than invalidating it, and the path
+//! reports the loss instead of abandoning itself over it.
 //!
 //! # References
 //!
@@ -192,6 +207,44 @@ fn regularized_hessian(qp: &QpProblem<'_>, delta: Number) -> SymTMatrix {
     h
 }
 
+/// How far outside its `t`-interpolated bound a row may sit before the path is
+/// reported as having lost feasibility, relative to the row's own magnitude.
+///
+/// Has to straddle two regimes measured on the same QSHARE2B path: benign
+/// accumulated round-off in the direction solves, which ran at `2e-8` for a
+/// hundred steps and never grew, versus a genuine uncapped crossing, which
+/// entered at `8e-2` and compounded to `22` by `t = 1`. Two orders of magnitude
+/// above the drift and six below the break.
+const PATH_FEAS_TOL_REL: Number = 1e-6;
+
+/// The worst `t`-problem row violation at `x`, or `None` when every row is
+/// within [`PATH_FEAS_TOL_REL`] of its interpolated bound.
+///
+/// This is the invariant the module header used to assert held by construction;
+/// see the report in [`ParametricActiveSetSolver::trace_path`] for why it does
+/// not. Row bounds interpolate `bl0 -> qp.bl` and `bu0 -> qp.bu` in `t`; variable
+/// bounds do not move along this path, so they are not checked here.
+fn worst_path_violation(
+    qp: &QpProblem<'_>,
+    x: &[Number],
+    bl0: &[Number],
+    bu0: &[Number],
+    t: Number,
+    m: usize,
+) -> Option<(usize, Number)> {
+    let ax = a_times_x(qp.a, x, m);
+    let mut worst: Option<(usize, Number)> = None;
+    for i in 0..m {
+        let blt = bl0[i] + t * bound_rate(bl0[i], qp.bl[i], true);
+        let but = bu0[i] + t * bound_rate(bu0[i], qp.bu[i], false);
+        let v = (blt - ax[i]).max(ax[i] - but);
+        if v > PATH_FEAS_TOL_REL * (1.0 + ax[i].abs()) && worst.is_none_or(|(_, prev)| v > prev) {
+            worst = Some((i, v));
+        }
+    }
+    worst
+}
+
 /// Rate of change of a row bound per unit `t` (0 when the bound is infinite).
 fn bound_rate(relaxed: Number, target: Number, is_lower: bool) -> Number {
     let infinite = if is_lower {
@@ -206,9 +259,8 @@ impl ParametricActiveSetSolver {
     /// Solve `qp` from cold by tracing the row-bound homotopy described in this
     /// module's docs.
     ///
-    /// Returns `Ok(None)` when the path cannot be started (the box relaxation is
-    /// unbounded or fails), which is a signal for the caller to fall back to the
-    /// conventional cold path — not a verdict about `qp`.
+    /// `Ok(None)` is a signal for the caller to fall back to the conventional
+    /// cold path — not a verdict about `qp`.
     pub(crate) fn solve_homotopy(
         &mut self,
         qp: &QpProblem<'_>,
@@ -654,6 +706,50 @@ impl ParametricActiveSetSolver {
             }
             t = t_next;
 
+            // ---- Path-feasibility report ----
+            //
+            // The module header used to claim `x(t)` is feasible for the
+            // `t`-problem at every point "by construction". It is not. The primal
+            // ratio test only ever *prevents* a violation and cannot repair one:
+            // a row whose gap has gone negative yields `dt < 0`, which the
+            // `dt >= -T_EPS` filter rejects, so the row stays inactive and
+            // violated for the rest of the path while the direction solve pushes
+            // it further out. Violation is absorbing.
+            //
+            // Two measured ways in (QSHARE2B, 14 crossings on one path):
+            //
+            //  * **Rank-repair tabu (10 of 14).** `tabu_cons` exists to break a
+            //    prune -> re-add cycle, but it skips the row in the *primal ratio
+            //    test*, not just in the add decision. The pruned row sits on its
+            //    bound with a large rate (`a_i·dx = 2.6e5` on row 19), the step is
+            //    computed as if it were absent, and it is crossed. The comment
+            //    justifying the tabu — "a pruned row is a linear combination of
+            //    the kept ones, so it stays satisfied" — is false: dependence
+            //    gives `a_i·dx = Σ c_j (a_j·dx)`, and nothing makes that
+            //    combination track row `i`'s *own* bound rate.
+            //
+            //  * **Coincident / sub-resolution events (4 of 14).** Two crossings
+            //    at the same `t_next`, or one below the `T_EPS` floor (row 132:
+            //    crossing at `dt = 2.9e-16`, step taken `1.1e-14`), lose the
+            //    strict `t + dt < t_next - T_EPS` comparison. The overshoot starts
+            //    tiny and compounds — QSHARE2B row 7 went 8e-2 -> 0.4 -> 7.5 ->
+            //    11 -> 22 over the rest of the path.
+            //
+            // Repairing this properly needs an exchange pivot at the degenerate
+            // vertex (add the violated row, drop a dependent one), which is a real
+            // algorithmic addition and is left to follow-up work.
+            //
+            // Deliberately a *report* and not a bail-out. Abandoning the path here
+            // was tried and measured worse: the corrector is a genuine corrector
+            // and often recovers from a path that drifted off (`QSHIP04S` reaches
+            // a violation of 7.1e4 at `t = 0.5` and still solves to the published
+            // optimum). What the caller needs is not for this path to give up, but
+            // a *fallback that exists* when its prediction turns out unusable —
+            // which is what `pounce-convex`'s seeded last-resort retry restores.
+            if trace && let Some((i, v)) = worst_path_violation(qp, &x, &bl0, &bu0, t, m) {
+                eprintln!("[hom] path infeasible at t={t:.9e}: row {i} by {v:.3e}");
+            }
+
             match event {
                 None => {
                     // Nothing binds before t = 1: the path is complete.
@@ -694,7 +790,11 @@ impl ParametricActiveSetSolver {
             return Ok(None);
         }
         if trace {
-            eprintln!("[hom] reached t=1 after {n_changes} working-set changes");
+            eprintln!(
+                "[hom] reached t=1 after {n_changes} working-set changes; handoff x has \
+                 max target violation {:.3e}",
+                crate::solver::max_violation(qp, &x)
+            );
         }
         let mut sol =
             <Self as crate::solver::QpSolver>::solve_with_working_set(self, qp, &working, opts)?;

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -1447,9 +1447,41 @@ impl ParametricActiveSetSolver {
             };
         *n_refactor += 1;
 
-        // Inequality-row feasibility check — any violation routes
-        // the caller to elastic mode.
+        // Row feasibility check — any violation routes the caller to
+        // elastic mode.
         let ax = a_times_x(qp.a, &x, m);
+
+        // Equality rows first. Every equality was *pinned* in the KKT
+        // above, so the kept ones are satisfied by construction and
+        // this costs nothing — but the rank guard may have PRUNED
+        // some, and a pruned equality is only satisfied if it is both
+        // linearly dependent on the kept ones *and consistent* with
+        // them. Contradictory equalities (`x₀+x₁ = 1` and `x₀+x₁ = 3`)
+        // are exactly the dependent-but-inconsistent case: the guard
+        // prunes one, `x` satisfies the survivor, and the pruned row
+        // is violated by 2.
+        //
+        // This loop used to `continue` past every `bl == bu` row, so
+        // that violation was never seen: the caller took the returned
+        // point as feasible, ran phase-2 on an infeasible iterate, and
+        // reported `NumericalError` instead of routing to the elastic
+        // phase-1 that would have certified the QP infeasible.
+        //
+        // It stayed hidden because the homotopy masked it — the path
+        // reached `t = 1`, the corrector's own warm-start pre-check
+        // caught the bad point, and elastic got its chance anyway. Only
+        // the *seedless* cold route reaches this loop with a pruned
+        // equality, and before #413 added a seeded retry nothing
+        // exercised it on an infeasible model.
+        for i in 0..m {
+            if qp.bl[i] != qp.bu[i] {
+                continue;
+            }
+            if (ax[i] - qp.bl[i]).abs() > opts.feas_tol {
+                return Ok(None);
+            }
+        }
+
         for i in 0..m {
             if qp.bl[i] == qp.bu[i] {
                 continue;
@@ -3101,7 +3133,7 @@ impl QpSolver for ParametricActiveSetSolver {
 /// The magnitude behind [`point_is_feasible`]'s boolean, needed so a recovery
 /// path can tell whether the point it is about to substitute is actually an
 /// improvement on the one it is discarding.
-fn max_violation(qp: &QpProblem, x: &[Number]) -> Number {
+pub(crate) fn max_violation(qp: &QpProblem, x: &[Number]) -> Number {
     let ax = a_times_x(qp.a, x, qp.m);
     let mut worst: Number = 0.0;
     for i in 0..qp.m {


### PR DESCRIPTION
## Problem

The parametric homotopy introduced in #412 was documented as keeping `x(t)` feasible "at every point on the path by construction", but this claim is false. On Maros-Mészáros `QSHARE2B`, 14 rows are crossed uncapped on a single path, with the worst violation growing `8e-2 → 0.4 → 7.5 → 11 → 22` toward `t = 1`.

The damage was not a slow solve but a *seedless* one: #412 disabled the simplex phase-1 vertex seed whenever the homotopy is on, relying on the false feasibility guarantee. When the path's prediction became unusable, the engine had no fallback and cold-started the l1-elastic phase-1 that pounce-qp documents as not terminating on degenerate netlib-derived QPs. On `QSHARE2B` this spent the entire iteration budget returning `4854` against the published optimum `11703.7`, still carrying a constraint violation of `20`. The seeded route solves it in 52 iterations.

| instance | status | objective | violation |
|---|---|---|---|
| QSHARE2B (seedless) | timeout | 4854 | 20 |
| QSHARE2B (seeded) | optimal | 11703.7 | <1e-6 |

## Cause

The primal ratio test in the homotopy path only ever *prevents* a violation — a row whose gap has gone negative yields `dt < 0`, which the test discards. It cannot repair a violation that has already occurred. Two measured mechanisms cause crossings:

1. **Rank-repair tabu (10 of 14 crossings):** The tabu skips pruned rows in the primal ratio test, not just in the add decision. A pruned row sits on its bound with a large rate, the step is computed as if it were absent, and it is crossed. The justification — "a pruned row is a linear combination of kept ones, so it stays satisfied" — is false: linear dependence gives `a_i·dx = Σ c_j (a_j·dx)`, and nothing makes that combination track row `i`'s own bound rate.

2. **Coincident/sub-resolution events (4 of 14):** Two crossings at the same `t_next`, or one below the `T_EPS` floor, lose the strict `t + dt < t_next - T_EPS` comparison. The overshoot starts tiny and compounds.

Additionally, `cold_general_initial` had a pre-existing bug: it skipped every `bl == bu` row in its feasibility sweep, assuming pinned equalities are satisfied by construction. This is true only for rows actually *kept* by the rank guard. A pruned equality that is inconsistent with the kept ones (e.g., `x₀+x₁ = 1` and `x₀+x₁ = 3`) was never re-checked, so infeasible models were reported as `NumericalFailure` instead of routing to elastic phase-1.

## Fix

Three changes:

1. **Restore the simplex seed as a last-resort retry** in `pounce-convex`'s driver, after the existing Ruiz-equilibration retry. This preserves bit-identity of earlier attempts (nothing that already solved can be displaced, including by the clock) and provides a fallback when the homotopy path's prediction is unusable. When the caller already requested `use_homotopy=no`, the first attempt was seeded and there is nothing new to try.

2. **Report path feasibility loss without abandoning the path.** The homotopy now detects when `x(t)` violates its `t`-interpolated bounds and logs the violation, but continues. Abandoning was tried and measured worse: the corrector is a genuine corrector and often recovers from a drifted path (`QSHIP04S` reaches a violation of `7.1e4` at `t = 0.5` and still solves to the published optimum). Repairing the crossings properly requires an exchange pivot at the

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4