### PR TITLE
Warm-start benchmark: degeneracy families, a homotopy arm, and a large-scale sparse tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,51 @@ changes.
   Documented in the `covariance` docstring and the sensitivity chapter
   alongside `estimate()`'s matching baseline guarantee.
 
+### Fixed — `sqp_qp_use_homotopy` was registered but never read
+
+- **Setting it on the active-set SQP path did nothing.** The option was
+  registered with the parametric-homotopy work and documented in detail, but
+  `apply_qp_subproblem_options` — the function that maps the `sqp_qp_*` family
+  onto `pounce_qp::QpOptions` — never consulted it, so `pounce-qp`'s own
+  default (`false`) always stood. Only `pounce_convex::active_set` got the
+  homotopy, and it sets the field directly in Rust rather than through options.
+  A registered knob that no code reads is worse than a missing one: it
+  validates, accepts a value, and ships working documentation for behavior the
+  user never gets.
+- **The inverse of #360, and invisible to its guard.** That issue fixed
+  read-but-unregistered and left a test walking the keys the *reader* consults,
+  asserting each is registered. Nothing checked the other direction. The new
+  `application_every_registered_sqp_qp_option_is_read_by_the_subproblem_reader`
+  enumerates the registry and fails if the two sets diverge either way; both
+  guards were checked for falsifiability rather than assumed.
+- **Found by the benchmark, not by reading.** The warm-start suite's new
+  `-hom` arms measured bit-identical results to their twins — an arm that
+  cannot differ from its control is either a perfect null or a broken
+  experiment.
+
+### Added — degeneracy families and a parametric-homotopy arm in the warm-start suite
+
+- **Two degeneracy families**, completing the three distinct ways an active-set
+  QP meets degeneracy. `degenerate_corner` already covered dual degeneracy (a
+  multiplier through zero); `redundant_rows` adds rank deficiency (duplicated
+  equality rows, so LICQ fails everywhere, plus a duplicated inequality pair
+  that activates together mid-path), and `degenerate_vertex` adds primal
+  degeneracy (12 rows tight at a 4-variable vertex — the ratio-test ties Harris
+  and GMSW EXPAND exist for). Both are convex QPs, so all three solvers take
+  them; both converge on all eight arms with zero correctness failures, and the
+  reported working set confirms the LICQ-violating vertex is pruned to its
+  maximal independent subset.
+- **`cold-sqp-hom` / `warm-sqp-hom` arms**, differing from their twins in the
+  single option above, which makes the §4.2 parametric homotopy measurable for
+  the first time. It is a sharply mixed trade: 4.2–12.3× less inner active-set
+  work on `redundant_rows`, 2.0–2.9× on `degenerate_corner`, unchanged on four
+  families, and ~2× *more* on `nmpc_vanderpol` and ~1.4× more on
+  `simplex_proj`, for 0.70× over all 30 rows. It wins on the degenerate,
+  netlib-like geometry it was designed for and loses on well-conditioned
+  MPC-shaped QPs — a mechanism-level account of #412's 20-gained/7-lost
+  Maros-Mészáros result, and an argument for the default staying off while the
+  knob is reachable.
+
 ### Fixed — pyomo-pounce: `estimate()` measured its perturbation from the Param's current value (#420)
 
 - `estimate(model, perturb)` computed each step as `new value` minus the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,35 @@ changes.
   Documented in the `covariance` docstring and the sensitivity chapter
   alongside `estimate()`'s matching baseline guarantee.
 
+### Added — a large-scale sparse tier for the warm-start benchmark, and the defect it found
+
+- **`mpc_horizon_200/400/800`** (`--tier large`) carry the horizon sweep's
+  linear MPC to n = 602, 1202 and 2402 with a block-banded Jacobian. Nothing
+  dense is materialized: families may now declare `sparse_structure()` with
+  packed `jacobian_values()` / `hessian_values()`, and the convex-QP arm
+  receives sparse matrices — at N = 800 a dense Hessian alone would be 46 MB
+  rebuilt every iteration, and dense data costs the QP solver 60–80× by its
+  own diagnostic. The self-test finite-differences the declared structure
+  column by column and cross-checks it against the dense path wherever both
+  exist.
+- **The active-set SQP's warm start does not survive scale
+  ([#428](https://github.com/jkitchin/pounce/issues/428), open).** The
+  working-set hint is *discarded* rather than repaired the moment the true
+  active set moves by a single entry: the pinned primal then violates some
+  other row, `solve`'s admission pre-check routes it to elastic phase-1, and
+  the recovery re-solve starts from a cold working set. Cost is one inner
+  pivot per constraint row. Cold inner work is flat at 66 pivots from N = 10
+  to N = 800; warm runs 0 → 43 → 164 → 403 → 795 → 1589, tracking m; with the
+  hint admitted the same steps take 2 and reach the same optimum to 1e-11.
+  At the default `sqp_qp_max_iter` of 200 the warm-started SQP stops
+  returning an answer once m > 200 — 7 of 8 steps `Maximum_Iterations_Exceeded`
+  at every large horizon, while every other arm is clean.
+- **This corrects the horizon sweep's interpretation, not its numbers.** The
+  measured wall-time crossover stands; the explanation attached to it —
+  absolute working-set churn growing with problem size — holds for the
+  interior-point arms and is wrong for the SQP, whose cost is set by whether
+  the first entry moved rather than by how many did.
+
 ### Fixed — `sqp_qp_use_homotopy` was registered but never read
 
 - **Setting it on the active-set SQP path did nothing.** The option was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ changes.
   was not, and is withdrawn.
 - All the suite's other headline numbers moved with the fix and have been
   re-measured: `warm-sqp` total solve time over the 42-row sweep drops from
-  21.82 s to 3.11 s on identical iteration counts, and per-family inner-work
+  21.82 s to 3.46 s on identical iteration counts, and per-family inner-work
   ratios rise across the board (`mpc_horizon_80` @ `tiny` 54.75×,
   `nmpc_vanderpol` @ `tiny` 18.80×).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,28 @@ changes.
   cannot differ from its control is either a perfect null or a broken
   experiment.
 
+### Added — an MPC horizon sweep, and the crossover it locates
+
+- **`mpc_horizon_10/20/40/80`** — one linear-quadratic MPC at four horizons
+  (n = 32 → 242, block-banded Jacobian), so reading down them isolates problem
+  size from every other property. This closes the suite's last uncovered axis.
+- **The active-set SQP's warm-start advantage is eroded by absolute working-set
+  churn, and problem size inflates it.** Warm/cold wall time goes 0.84 → 1.29 →
+  1.95 → **2.57** across the four horizons at large parameter steps — at N = 80
+  a warm-started SQP solve takes 2.6× longer than solving cold. At small steps
+  it stays excellent at every horizon, including the suite's best single row
+  (0.08 at N = 40, twelve times faster than cold). The interior-point arms stay
+  between 0.25 and 1.00 across the whole grid.
+- **Mechanism, from the working sets:** the *fraction* of the active set that
+  changes per step is horizon-independent (~3% at large steps for every N), but
+  the *absolute* count grows with the problem (1.05 → 5.58 changes/step), and
+  each change costs more as the active set grows. An active-set method pays for
+  the absolute count, so two factors multiply.
+- This puts a number on the qualitative caveat in the active-set SQP docs
+  ("prefer the IPM for large-scale problems with thousands of active
+  inequalities"): the measured crossover is tens to low hundreds of active
+  constraints, not thousands. The docs now say so.
+
 ### Added — degeneracy families and a parametric-homotopy arm in the warm-start suite
 
 - **Two degeneracy families**, completing the three distinct ways an active-set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,23 +82,29 @@ changes.
   own diagnostic. The self-test finite-differences the declared structure
   column by column and cross-checks it against the dense path wherever both
   exist.
-- **The active-set SQP's warm start does not survive scale
-  ([#428](https://github.com/jkitchin/pounce/issues/428), open).** The
-  working-set hint is *discarded* rather than repaired the moment the true
-  active set moves by a single entry: the pinned primal then violates some
-  other row, `solve`'s admission pre-check routes it to elastic phase-1, and
-  the recovery re-solve starts from a cold working set. Cost is one inner
-  pivot per constraint row. Cold inner work is flat at 66 pivots from N = 10
-  to N = 800; warm runs 0 → 43 → 164 → 403 → 795 → 1589, tracking m; with the
-  hint admitted the same steps take 2 and reach the same optimum to 1e-11.
-  At the default `sqp_qp_max_iter` of 200 the warm-started SQP stops
-  returning an answer once m > 200 — 7 of 8 steps `Maximum_Iterations_Exceeded`
-  at every large horizon, while every other arm is clean.
-- **This corrects the horizon sweep's interpretation, not its numbers.** The
-  measured wall-time crossover stands; the explanation attached to it —
-  absolute working-set churn growing with problem size — holds for the
-  interior-point arms and is wrong for the SQP, whose cost is set by whether
-  the first entry moved rather than by how many did.
+- **The large tier found [#428](https://github.com/jkitchin/pounce/issues/428)
+  on its first run** (fixed above). The warm-started SQP was returning
+  `Maximum_Iterations_Exceeded` with zero outer iterations on 7 of 8 steps at
+  every one of N = 200/400/800, while every other arm solved cleanly; inner
+  working-set changes ran 0 → 43 → 164 → 403 → 795 → 1589 against a cold arm
+  flat at 66. On the fixed solver the warm arm is flat at **3** across a 75×
+  range of m, and its wall time is 0.02–0.03× its cold twin on the large
+  tier — the fastest arm on the board where it previously did not produce an
+  answer.
+- **This retracts the horizon sweep's conclusion, not its measurements.** The
+  reported crossover — warm/cold wall time 0.84 → 1.29 → 1.95 → 2.57 turning
+  harmful above N = 20 — was this defect. Re-measured on the fixed solver the
+  same sweep runs 0.24 → 0.12 → 0.11 → 0.10 at `large` and 0.17 → 0.08 →
+  0.04 → 0.02 at `tiny`: the ratio *improves* with horizon, because cold cost
+  grows with the problem while warm cost is set by how far the active set
+  moved. The churn numbers behind the original claim were correct and are
+  unchanged; the "absolute churn inflates with size" mechanism built on them
+  was not, and is withdrawn.
+- All the suite's other headline numbers moved with the fix and have been
+  re-measured: `warm-sqp` total solve time over the 42-row sweep drops from
+  21.82 s to 3.11 s on identical iteration counts, and per-family inner-work
+  ratios rise across the board (`mpc_horizon_80` @ `tiny` 54.75×,
+  `nmpc_vanderpol` @ `tiny` 18.80×).
 
 ### Fixed — `sqp_qp_use_homotopy` was registered but never read
 

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -26,7 +26,7 @@ nearest public things and why each does not cover it:
 | [OPFData](https://arxiv.org/abs/2406.07234) / PGLearn | 300k solved AC-OPF instances per grid, loads perturbed 80–120%, plus N-1 topologies | A dataset with no protocol or metrics, single problem class, independent samples rather than a path. |
 | CUTEst, Hock-Schittkowski, Vanderbei, Mittelmann, Maros-Mészáros | The standard NLP/QP collections (several already in `benchmarks/`) | Every problem is one cold solve. No parameter, no sequence. |
 
-## The four arms
+## The arms
 
 | arm | algorithm | seeded with | runs on |
 |---|---|---|---|
@@ -34,6 +34,8 @@ nearest public things and why each does not cover it:
 | `cold-sqp` | active-set SQP | nothing | every family |
 | `warm-ipm` | general NLP filter-IPM | previous step's primal-dual point and μ | every family |
 | `warm-sqp` | active-set SQP | previous step's working set and point | every family |
+| `cold-sqp-hom` | active-set SQP, homotopy inner QP | nothing | every family |
+| `warm-sqp-hom` | active-set SQP, homotopy inner QP | previous step's working set and point | every family |
 | `cold-qp-ipm` | dedicated convex QP IPM (`pounce.solve_qp`) | nothing | QP families only |
 | `warm-qp-ipm` | dedicated convex QP IPM | previous step's primal-dual point | QP families only |
 
@@ -105,7 +107,9 @@ the mean speedup hides the failure mode that matters most.
 |---|--:|--:|---|---|---|
 | `simplex_proj` | 20 | 1 | flipping | objective | convex |
 | `moving_bound_qp` | 40 | 3 | flipping | bounds | convex |
-| `degenerate_corner` | 6 | 3 | degenerate | objective | convex |
+| `degenerate_corner` | 6 | 3 | dual degenerate | objective | convex |
+| `redundant_rows` | 6 | 5 | rank-deficient (LICQ fails) | objective | convex |
+| `degenerate_vertex` | 4 | 12 | primal degenerate | objective | convex |
 | `hanging_chain` | 30 | 15 | flipping | mixed | convex |
 | `rosenbrock_ring` | 10 | 1 | switch | rhs | nonconvex |
 | `rosenbrock_ring_cycle` | 10 | 1 | re-activation | rhs | nonconvex |
@@ -168,6 +172,25 @@ Two families are worth knowing about in detail:
   depend on the solutions, the runner records the sequence the
   reference arm produces and **replays** it for the other arms — the
   arms would otherwise be solving different problems.
+
+## What QP-solver properties this exercises
+
+The suite reaches `pounce-qp` only through the SQP outer loop, so it is
+not a QP-solver benchmark — but the questions people ask about an
+active-set QP code map onto it as follows:
+
+| property | `pounce-qp` | exercised here? |
+|---|---|---|
+| sparse or dense | sparse triplet KKT + sparse LDLᵀ; the Schur block alone is dense | **no** — families are n ≤ 47 and near-dense. Sparse coverage is the cold `.nl` Maros-Mészáros suite |
+| convex only, or indefinite | indefinite, via §4.5 inertia control and negative-curvature ratio-test handling | **yes** — 5 of 10 families are nonconvex with indefinite ∇²L along the path; two solver defects were found there |
+| primal or dual | primal; l1-elastic phase-1 for an infeasible cold start, and the homotopy is primal-feasible by construction | n/a — there is no dual variant to compare |
+| parametric with hot starts | both: working-set hot start, and the §4.2 qpOASES-lineage homotopy | **yes** — hot starts are the `warm-*` arms; the homotopy is the `-hom` arms |
+| degeneracy | Harris two-pass, GMSW EXPAND, Bland latch, rank-deficient active sets pruned to a maximal independent subset | **yes**, all three kinds: dual (`degenerate_corner`), rank-deficient / LICQ (`redundant_rows`), primal (`degenerate_vertex`) |
+
+Still uncovered, and worth knowing: **scale**. Every family is small by
+design, so nothing here says how the sparse path or the Schur updates
+behave at n in the thousands. An MPC horizon sweep would be the natural
+addition.
 
 ## Running it
 

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -116,6 +116,12 @@ the mean speedup hides the failure mode that matters most.
 | `double_well_chain` | 12 | 0 | none (empty active set) | objective | nonconvex |
 | `nmpc_vanderpol` | 47 | 32 | closed-loop | rhs | nonconvex |
 | `mpc_horizon_10/20/40/80` | 32–242 | 22–162 | saturation | rhs | convex |
+| `mpc_horizon_200/400/800` | 602–2402 | 402–1602 | saturation | rhs | convex |
+
+The last row is the opt-in **`large` tier** (`--tier large`; `--tier
+all` runs both). It is out of the default sweep because one active-set
+solve at N = 800 takes seconds, and it walks 8 steps rather than 20
+since the per-step numbers are what matter, not the path length.
 
 *regime* is how the active set behaves along the path; *channel* is
 where the parameter enters (objective, constraint right-hand side,
@@ -182,19 +188,28 @@ active-set QP code map onto it as follows:
 
 | property | `pounce-qp` | exercised here? |
 |---|---|---|
-| sparse or dense | sparse triplet KKT + sparse LDLᵀ; the Schur block alone is dense | **partly** — the `mpc_horizon_*` sweep reaches n = 242 with a block-banded Jacobian and gives one scaling curve; nothing here goes to n in the thousands |
+| sparse or dense | sparse triplet KKT + sparse LDLᵀ; the Schur block alone is dense | **yes** — the `mpc_horizon_*` sweep runs the same block-banded MPC from n = 32 to n = 2402 (`--tier large`), nothing dense materialized anywhere along it |
 | convex only, or indefinite | indefinite, via §4.5 inertia control and negative-curvature ratio-test handling | **yes** — 5 of 10 families are nonconvex with indefinite ∇²L along the path; two solver defects were found there |
 | primal or dual | primal; l1-elastic phase-1 for an infeasible cold start, and the homotopy is primal-feasible by construction | n/a — there is no dual variant to compare |
 | parametric with hot starts | both: working-set hot start, and the §4.2 qpOASES-lineage homotopy | **yes** — hot starts are the `warm-*` arms; the homotopy is the `-hom` arms |
 | degeneracy | Harris two-pass, GMSW EXPAND, Bland latch, rank-deficient active sets pruned to a maximal independent subset | **yes**, all three kinds: dual (`degenerate_corner`), rank-deficient / LICQ (`redundant_rows`), primal (`degenerate_vertex`) |
 
-The horizon sweep (`mpc_horizon_10/20/40/80`, the same linear MPC at
-four sizes) is what covers the scale axis, and it is where the
-active-set path's warm-start advantage is measured turning *negative*:
-2.57× slower than cold at N = 80 with large parameter steps, against
-0.08× — twelve times faster — at N = 40 with small ones. What remains
-uncovered is genuinely large scale: nothing here reaches n in the
-thousands, where the sparse factorization and Schur updates dominate.
+The horizon sweep (`mpc_horizon_*`, the same linear MPC at seven sizes)
+is what covers the scale axis, and it is where the active-set path's
+warm-start advantage is measured turning *negative*: 2.57× slower than
+cold at N = 80 with large parameter steps, against 0.08× — twelve times
+faster — at N = 40 with small ones.
+
+Carrying it out to n = 2402 (`--tier large`) turned that into a defect
+report, [#428](https://github.com/jkitchin/pounce/issues/428): the
+working-set hint is *discarded* rather than repaired the moment the
+active set moves by one entry, costing one inner pivot per constraint
+row. Cold inner work is flat at 66 pivots from N = 10 to N = 800; warm
+runs 0 → 43 → 164 → 403 → 795 → 1589, tracking m exactly; and with the
+hint admitted the same steps take 2. At the default inner-QP budget of
+200 the warm-started SQP stops returning an answer at all above
+m = 200 — 7 of 8 steps `Maximum_Iterations_Exceeded` at every large
+horizon, while every other arm is clean.
 
 ## Running it
 
@@ -227,6 +242,15 @@ cyipopt-shaped callbacks in **dense** form — the harness derives the
 sparsity patterns and packed value vectors from them, so the structure
 and the values cannot fall out of sync. List the class in
 `families/__init__.py`, then:
+
+A family too large for a dense matrix may instead declare
+`sparse_structure()` plus `jacobian_values()` / `hessian_values()`, and
+set `tier = "large"`. Keep the dense methods as well where you can: the
+self-test cross-checks the two against each other at any size it can
+afford, and finite-differences the declared structure column by column
+above that, so a structure that disagrees with its values still cannot
+pass silently. That check is the only thing standing between a
+mis-declared pattern and a plausible, wrong benchmark number.
 
     python -m warmstart.selftest
 

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -195,21 +195,25 @@ active-set QP code map onto it as follows:
 | degeneracy | Harris two-pass, GMSW EXPAND, Bland latch, rank-deficient active sets pruned to a maximal independent subset | **yes**, all three kinds: dual (`degenerate_corner`), rank-deficient / LICQ (`redundant_rows`), primal (`degenerate_vertex`) |
 
 The horizon sweep (`mpc_horizon_*`, the same linear MPC at seven sizes)
-is what covers the scale axis, and it is where the active-set path's
-warm-start advantage is measured turning *negative*: 2.57× slower than
-cold at N = 80 with large parameter steps, against 0.08× — twelve times
-faster — at N = 40 with small ones.
+is what covers the scale axis, and carrying it to n = 2402
+(`--tier large`) is what found
+[#428](https://github.com/jkitchin/pounce/issues/428), the suite's
+fourth solver defect: the working-set hint was *discarded* rather than
+repaired the moment the active set moved by one entry, costing one
+inner pivot per constraint row. Cold inner work is flat at 66 pivots
+from N = 10 to N = 800; warm ran 0 → 43 → 164 → 403 → 795 → 1589,
+tracking m exactly. At the default inner-QP budget of 200 the
+warm-started SQP stopped returning an answer at all above m = 200 —
+7 of 8 steps `Maximum_Iterations_Exceeded` at every large horizon,
+while every other arm was clean.
 
-Carrying it out to n = 2402 (`--tier large`) turned that into a defect
-report, [#428](https://github.com/jkitchin/pounce/issues/428): the
-working-set hint is *discarded* rather than repaired the moment the
-active set moves by one entry, costing one inner pivot per constraint
-row. Cold inner work is flat at 66 pivots from N = 10 to N = 800; warm
-runs 0 → 43 → 164 → 403 → 795 → 1589, tracking m exactly; and with the
-hint admitted the same steps take 2. At the default inner-QP budget of
-200 the warm-started SQP stops returning an answer at all above
-m = 200 — 7 of 8 steps `Maximum_Iterations_Exceeded` at every large
-horizon, while every other arm is clean.
+Fixed in #429 (repair the hint instead of discarding it). Warm inner
+work is now flat at 3 across the whole range, and the sweep says the
+opposite of what it said before: the SQP's warm/cold wall ratio
+*improves* with horizon — 0.17 → 0.08 → 0.04 → 0.02 at `tiny` for
+N = 10…80, and 0.03 / 0.03 / 0.02 at N = 200/400/800 — because cold
+cost grows with the problem while warm cost is set by how far the
+active set moved.
 
 ## Running it
 
@@ -271,9 +275,9 @@ set — that an adapter consumes as much of as its solver understands.
 Arms an adapter does not support are reported as skipped rather than
 silently dropped.
 
-## Three solver defects this suite has caught
+## Four solver defects this suite has caught
 
-All three are fixed. They are recorded because the shapes recur, and
+All four are fixed. They are recorded because the shapes recur, and
 because two of them lived in the same configuration — nonconvex,
 indefinite Hessian, nothing active — which is why `double_well_chain`
 exists.
@@ -308,4 +312,21 @@ exists.
    75 and 96 warm iterations on `simplex_proj`, against 46, 75 and 96
    measured from the prototype.
 
-Full write-ups in `dev-notes/warm-start-benchmark.md`.
+4. **pounce#428, fixed in #429.** The SQP's working-set hint was
+   *discarded* rather than repaired the moment the true active set moved
+   by a single entry, costing one inner pivot per constraint row —
+   1589 at n = 2402, against 3 now, and 24x the cost of not warm
+   starting at all. Below N = 80 the penalty is smaller than a cold
+   solve, so the default tier's rows looked merely unimpressive; the
+   `large` tier found it on its first run, where it stopped the warm
+   arm returning an answer at all. It had also produced a *published
+   wrong conclusion*: the horizon sweep's "warm starting turns harmful
+   at scale" crossover was this defect, and on the fixed solver the
+   ratio improves with horizon instead.
+
+Full write-ups in `dev-notes/warm-start-benchmark.md`. The fourth is
+worth reading for how it was missed: the sweep's numbers were correct
+and a plausible mechanism was inferred from them that happened to be
+wrong, because nobody compared the warm arm's pivot count against the
+*true* active-set difference until the discrepancy grew to 164 against
+4.

--- a/benchmarks/warmstart/README.md
+++ b/benchmarks/warmstart/README.md
@@ -115,6 +115,7 @@ the mean speedup hides the failure mode that matters most.
 | `rosenbrock_ring_cycle` | 10 | 1 | re-activation | rhs | nonconvex |
 | `double_well_chain` | 12 | 0 | none (empty active set) | objective | nonconvex |
 | `nmpc_vanderpol` | 47 | 32 | closed-loop | rhs | nonconvex |
+| `mpc_horizon_10/20/40/80` | 32–242 | 22–162 | saturation | rhs | convex |
 
 *regime* is how the active set behaves along the path; *channel* is
 where the parameter enters (objective, constraint right-hand side,
@@ -181,16 +182,19 @@ active-set QP code map onto it as follows:
 
 | property | `pounce-qp` | exercised here? |
 |---|---|---|
-| sparse or dense | sparse triplet KKT + sparse LDLᵀ; the Schur block alone is dense | **no** — families are n ≤ 47 and near-dense. Sparse coverage is the cold `.nl` Maros-Mészáros suite |
+| sparse or dense | sparse triplet KKT + sparse LDLᵀ; the Schur block alone is dense | **partly** — the `mpc_horizon_*` sweep reaches n = 242 with a block-banded Jacobian and gives one scaling curve; nothing here goes to n in the thousands |
 | convex only, or indefinite | indefinite, via §4.5 inertia control and negative-curvature ratio-test handling | **yes** — 5 of 10 families are nonconvex with indefinite ∇²L along the path; two solver defects were found there |
 | primal or dual | primal; l1-elastic phase-1 for an infeasible cold start, and the homotopy is primal-feasible by construction | n/a — there is no dual variant to compare |
 | parametric with hot starts | both: working-set hot start, and the §4.2 qpOASES-lineage homotopy | **yes** — hot starts are the `warm-*` arms; the homotopy is the `-hom` arms |
 | degeneracy | Harris two-pass, GMSW EXPAND, Bland latch, rank-deficient active sets pruned to a maximal independent subset | **yes**, all three kinds: dual (`degenerate_corner`), rank-deficient / LICQ (`redundant_rows`), primal (`degenerate_vertex`) |
 
-Still uncovered, and worth knowing: **scale**. Every family is small by
-design, so nothing here says how the sparse path or the Schur updates
-behave at n in the thousands. An MPC horizon sweep would be the natural
-addition.
+The horizon sweep (`mpc_horizon_10/20/40/80`, the same linear MPC at
+four sizes) is what covers the scale axis, and it is where the
+active-set path's warm-start advantage is measured turning *negative*:
+2.57× slower than cold at N = 80 with large parameter steps, against
+0.08× — twelve times faster — at N = 40 with small ones. What remains
+uncovered is genuinely large scale: nothing here reaches n in the
+thousands, where the sparse factorization and Schur updates dominate.
 
 ## Running it
 

--- a/benchmarks/warmstart/adapters/base.py
+++ b/benchmarks/warmstart/adapters/base.py
@@ -28,6 +28,15 @@ defines:
 ``warm-sqp``
     Active-set SQP seeded with the previous step's working set and
     primal point. The capability under test.
+``cold-sqp-hom`` / ``warm-sqp-hom``
+    The same active-set SQP, but with the inner QP's **cold** solves
+    tracing the §4.2 parametric homotopy (`sqp_qp_use_homotopy`) rather
+    than the conventional phase-1/phase-2 scheme. The homotopy is the
+    algorithm ``pounce-qp`` is named for; it is off by default in the
+    crate and on only in the convex QP driver, so without these arms
+    the suite exercises working-set hot starts but never the parametric
+    path. Paired against ``cold-sqp`` / ``warm-sqp``, which differ in
+    that one option and nothing else.
 ``cold-qp-ipm`` / ``warm-qp-ipm``
     The dedicated convex QP interior-point solver, handed the problem
     in matrix form rather than through callbacks, cold and seeded with
@@ -57,9 +66,19 @@ ARMS: List[str] = [
     "cold-sqp",
     "warm-ipm",
     "warm-sqp",
+    "cold-sqp-hom",
+    "warm-sqp-hom",
     "cold-qp-ipm",
     "warm-qp-ipm",
 ]
+
+#: Arms that run the active-set SQP driver (either inner-QP variant).
+SQP_ARMS = ("cold-sqp", "warm-sqp", "cold-sqp-hom", "warm-sqp-hom")
+
+#: Arms whose inner QP traces the §4.2 parametric homotopy on a cold
+#: solve (`sqp_qp_use_homotopy`) instead of the conventional
+#: phase-1/phase-2 scheme. Paired against their non-`-hom` twins.
+HOMOTOPY_ARMS = ("cold-sqp-hom", "warm-sqp-hom")
 
 #: Arms that need the family's instances to be QPs.
 QP_ARMS = ("cold-qp-ipm", "warm-qp-ipm")
@@ -72,6 +91,15 @@ REFERENCE_ARM = "cold-ipm"
 
 def is_warm(arm: str) -> bool:
     return arm.startswith("warm")
+
+
+def is_sqp(arm: str) -> bool:
+    """Whether the arm drives the active-set SQP (either inner-QP variant)."""
+    return arm in SQP_ARMS
+
+
+def uses_homotopy(arm: str) -> bool:
+    return arm in HOMOTOPY_ARMS
 
 
 def arm_applies(arm: str, family: ParametricFamily) -> Optional[str]:

--- a/benchmarks/warmstart/adapters/pounce_adapter.py
+++ b/benchmarks/warmstart/adapters/pounce_adapter.py
@@ -57,7 +57,7 @@ import pounce
 from .. import qpform
 from ..spec import ParametricFamily, StepResult, WarmState
 from ..sparsity import SparseCallbacks
-from .base import QP_ARMS, SolverAdapter, is_warm
+from .base import ARMS, QP_ARMS, SolverAdapter, is_sqp, is_warm, uses_homotopy
 
 # ApplicationReturnStatus values that count as a solved step.
 _OK_STATUS = (0, 1)  # SolveSucceeded, SolvedToAcceptableLevel
@@ -73,14 +73,7 @@ class PounceAdapter(SolverAdapter):
         self.max_iter = max_iter
 
     def supports(self, arm: str) -> bool:
-        return arm in (
-            "cold-ipm",
-            "cold-sqp",
-            "warm-ipm",
-            "warm-sqp",
-            "cold-qp-ipm",
-            "warm-qp-ipm",
-        )
+        return arm in ARMS
 
     # -- problem construction --------------------------------------
 
@@ -97,11 +90,15 @@ class PounceAdapter(SolverAdapter):
         )
         prob.add_option("print_level", 0)
         prob.add_option("sb", "yes")
-        if arm.endswith("sqp"):
+        if is_sqp(arm):
             prob.add_option("algorithm", "active-set-sqp")
             prob.add_option("sqp_print_level", 0)
             prob.add_option("sqp_tol", tol)
             prob.add_option("sqp_constr_viol_tol", 1e-6)
+            # The only difference between an arm and its `-hom` twin.
+            prob.add_option(
+                "sqp_qp_use_homotopy", "yes" if uses_homotopy(arm) else "no"
+            )
             prob.add_option("sqp_max_iter", self.max_iter)
         else:
             prob.add_option("tol", tol)
@@ -192,7 +189,7 @@ class PounceAdapter(SolverAdapter):
 
         kwargs = {}
         if use_warm:
-            if arm == "warm-sqp":
+            if is_sqp(arm):
                 kwargs["x0"] = warm.x
                 if warm.working_set is not None:
                     kwargs["working_set"] = warm.working_set
@@ -240,12 +237,10 @@ class PounceAdapter(SolverAdapter):
             # Keyed off the arm rather than off the value, so a warm
             # solve that converged without solving a single QP records
             # an honest 0 instead of looking like "not measured".
-            n_qp_solves=int(info.get("n_qp_solves", 0))
-            if arm.endswith("sqp")
-            else None,
-            n_qp_ws_changes=int(info.get("n_qp_ws_changes", 0))
-            if arm.endswith("sqp")
-            else None,
+            n_qp_solves=int(info.get("n_qp_solves", 0)) if is_sqp(arm) else None,
+            n_qp_ws_changes=(
+                int(info.get("n_qp_ws_changes", 0)) if is_sqp(arm) else None
+            ),
             **callbacks.counts(),
         )
 

--- a/benchmarks/warmstart/families/__init__.py
+++ b/benchmarks/warmstart/families/__init__.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Type
 
 from ..spec import ParametricFamily
 from .control import VanDerPolNMPC
+from .degenerate import DegenerateVertex, RedundantRows
 from .nonlinear import HangingChain, RosenbrockRing, RosenbrockRingRoundTrip
 from .quadratic import DegenerateCorner, MovingBoundQP, SimplexProjection
 from .unconstrained import DoubleWellChain
@@ -20,6 +21,8 @@ _FAMILIES: List[Type[ParametricFamily]] = [
     SimplexProjection,
     MovingBoundQP,
     DegenerateCorner,
+    RedundantRows,
+    DegenerateVertex,
     HangingChain,
     RosenbrockRing,
     RosenbrockRingRoundTrip,

--- a/benchmarks/warmstart/families/__init__.py
+++ b/benchmarks/warmstart/families/__init__.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Type
 from ..spec import ParametricFamily
 from .control import VanDerPolNMPC
 from .degenerate import DegenerateVertex, RedundantRows
+from .mpc_horizon import HORIZON_FAMILIES
 from .nonlinear import HangingChain, RosenbrockRing, RosenbrockRingRoundTrip
 from .quadratic import DegenerateCorner, MovingBoundQP, SimplexProjection
 from .unconstrained import DoubleWellChain
@@ -28,6 +29,7 @@ _FAMILIES: List[Type[ParametricFamily]] = [
     RosenbrockRingRoundTrip,
     DoubleWellChain,
     VanDerPolNMPC,
+    *HORIZON_FAMILIES,
 ]
 
 REGISTRY: Dict[str, Type[ParametricFamily]] = {f.name: f for f in _FAMILIES}

--- a/benchmarks/warmstart/families/degenerate.py
+++ b/benchmarks/warmstart/families/degenerate.py
@@ -1,0 +1,241 @@
+"""Degeneracy the ratio test has to survive, not just weak activity.
+
+`degenerate_corner` in :mod:`.quadratic` covers *dual* degeneracy — a
+multiplier passing exactly through zero, so strict complementarity
+fails and a sign-based working-set classifier has no signal. That is
+one of the three ways an active-set QP meets degeneracy, and it was the
+only one this suite exercised.
+
+The two families here cover the other two, both of which are properties
+of the *constraint geometry* rather than of the multipliers:
+
+- :class:`RedundantRows` — the active constraints are linearly
+  dependent (LICQ fails). Exact-duplicate equality rows make the
+  Jacobian rank-deficient everywhere; a duplicated inequality pair
+  activates together partway along the path, so the rank deficiency
+  *arrives* as an event rather than sitting there from the start. The
+  solver has to prune the active set to a maximal independent subset
+  and keep going.
+- :class:`DegenerateVertex` — many more constraints are tight at the
+  solution than there are variables (12 rows, n = 4), so the ratio test
+  is a mass of ties and the vertex is the classic cycling risk that
+  Harris / GMSW EXPAND exist to handle. The path then walks the
+  solution *off* that vertex, which is where the ties actually have to
+  be broken consistently.
+
+Both are convex QPs, so all three solvers can take them.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations
+from typing import List, Optional
+
+import numpy as np
+
+from ..spec import Bounds, ParametricFamily
+
+_INF = 1e20
+
+
+class RedundantRows(ParametricFamily):
+    """``min ½‖x − a(θ)‖²`` over a constraint set that violates LICQ.
+
+    The rows, in order:
+
+    ===  =====================  ====================================
+    row  constraint             why it is here
+    ===  =====================  ====================================
+    0    ``x₀ + x₁ = 1``        an ordinary equality
+    1    ``2x₀ + 2x₁ = 2``      its exact duplicate — the equality
+                                block is rank-deficient at every
+                                point, LICQ never holds
+    2    ``x₂ + x₃ ≤ b(θ)``     activates partway along the path
+    3    ``3x₂ + 3x₃ ≤ 3b(θ)``  its exact multiple, so the two
+                                activate *together* and the active
+                                set becomes dependent as an event
+    4    ``x₄ + x₅ ≤ 2``        slack throughout, a control row
+    ===  =====================  ====================================
+
+    A solver that prunes the active set to a maximal linearly
+    independent subset handles this; one that factors the raw active-set
+    KKT hits a singular system. The multipliers on a duplicated pair are
+    not unique, which is also why the suite's correctness gate checks
+    objectives rather than multiplier values.
+    """
+
+    name = "redundant_rows"
+    quadratic = True
+    tags = {"regime": "rank-deficient", "channel": "objective", "curvature": "convex"}
+    n_steps = 21
+
+    _N = 6
+    _DELTA = 0.03
+
+    def __init__(self):
+        self._A = np.array(
+            [
+                [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [2.0, 2.0, 0.0, 0.0, 0.0, 0.0],  # duplicate of row 0
+                [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 3.0, 3.0, 0.0, 0.0],  # 3× row 2
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+            ]
+        )
+        # The inequality pair binds at 0.4; a(θ) sweeps x₂+x₃ through it.
+        self._b_ineq = 0.4
+        self._a = self._a_c()
+
+    def _a_c(self) -> np.ndarray:
+        return np.array([0.5, 0.5, 0.2, 0.2, 0.3, 0.3])
+
+    def _direction(self) -> np.ndarray:
+        # Only the x₂/x₃ block moves, and it moves *through* the
+        # duplicated inequality pair's boundary at the midpoint step.
+        return np.array([0.0, 0.0, 1.0, 1.0, 0.0, 0.0])
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return 5
+
+    def bounds(self) -> Bounds:
+        cl = np.array([1.0, 2.0, -_INF, -_INF, -_INF])
+        cu = np.array([1.0, 2.0, self._b_ineq, 3.0 * self._b_ineq, 2.0])
+        return Bounds(
+            lb=np.zeros(self._N),
+            ub=np.full(self._N, _INF),
+            cl=cl,
+            cu=cu,
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.full(self._N, 0.3)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        t = float(np.asarray(theta).ravel()[0])
+        self._a = self._a_c() + t * self._direction()
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        half = (self.n_steps - 1) // 2
+        # θ = 0 puts x₂ + x₃ exactly on the duplicated pair's boundary.
+        return [
+            np.array([scale * self._DELTA * (k - half)])
+            for k in range(self.n_steps)
+        ]
+
+    def objective(self, x):
+        d = x - self._a
+        return 0.5 * float(d @ d)
+
+    def gradient(self, x):
+        return x - self._a
+
+    def constraints(self, x):
+        return self._A @ x
+
+    def jacobian_dense(self, x):
+        return self._A
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        return obj_factor * np.eye(self._N)
+
+
+class DegenerateVertex(ParametricFamily):
+    """A vertex where 12 rows are tight in 4 variables, then a walk off it.
+
+    The feasible set is the nonnegative orthant in ``R⁴`` written three
+    times over: the four rows ``−xⱼ ≤ 0``, the six pairwise rows
+    ``−(xᵢ + xⱼ) ≤ 0``, and two triple rows. Every one of them is tight
+    at the origin and all but four are redundant, so the origin is a
+    vertex with **three times more active constraints than variables** —
+    primal degeneracy of the kind Harris's two-pass test and GMSW EXPAND
+    exist to survive, and where a naive ratio test can take a zero step
+    and cycle.
+
+    ``a(θ)`` starts deep in the polar cone (every component negative), so
+    the projection is pinned at that degenerate vertex with all 12 rows
+    active, and sweeps to strictly positive, where the solution is
+    ``a(θ)`` itself and nothing is active. The interesting steps are in
+    between: the active set has to shed rows in groups, and every drop
+    is a tie among redundant candidates.
+    """
+
+    name = "degenerate_vertex"
+    quadratic = True
+    tags = {"regime": "primal-degenerate", "channel": "objective", "curvature": "convex"}
+    n_steps = 21
+
+    _N = 4
+    _DELTA = 0.06
+
+    def __init__(self):
+        rows = [-np.eye(self._N)[j] for j in range(self._N)]
+        for i, j in combinations(range(self._N), 2):
+            r = np.zeros(self._N)
+            r[i] = r[j] = -1.0
+            rows.append(r)
+        for trip in ((0, 1, 2), (1, 2, 3)):
+            r = np.zeros(self._N)
+            for j in trip:
+                r[j] = -1.0
+            rows.append(r)
+        self._A = np.array(rows)  # 4 + 6 + 2 = 12 rows, rank 4
+        self._a = self._a_at(0.0)
+
+    def _a_at(self, t: float) -> np.ndarray:
+        # t < 0: deep in the polar cone (solution pinned at the vertex).
+        # t > 0: inside the feasible cone (solution = a, nothing active).
+        base = np.array([1.0, 0.8, 1.2, 0.9])
+        return t * base
+
+    @property
+    def n(self) -> int:
+        return self._N
+
+    @property
+    def m(self) -> int:
+        return 12
+
+    def bounds(self) -> Bounds:
+        return Bounds(
+            lb=np.full(self._N, -_INF),
+            ub=np.full(self._N, _INF),
+            cl=np.full(12, -_INF),
+            cu=np.zeros(12),
+        )
+
+    def cold_x0(self) -> np.ndarray:
+        return np.full(self._N, 0.1)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._a = self._a_at(float(np.asarray(theta).ravel()[0]))
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        half = (self.n_steps - 1) // 2
+        # θ = 0 is the fully degenerate step: a = 0, every row tight,
+        # every multiplier free to be zero. It lands exactly on a step
+        # at every scale.
+        return [
+            np.array([scale * self._DELTA * (k - half)])
+            for k in range(self.n_steps)
+        ]
+
+    def objective(self, x):
+        d = x - self._a
+        return 0.5 * float(d @ d)
+
+    def gradient(self, x):
+        return x - self._a
+
+    def constraints(self, x):
+        return self._A @ x
+
+    def jacobian_dense(self, x):
+        return self._A
+
+    def hessian_dense(self, x, lagrange, obj_factor):
+        return obj_factor * np.eye(self._N)

--- a/benchmarks/warmstart/families/mpc_horizon.py
+++ b/benchmarks/warmstart/families/mpc_horizon.py
@@ -164,13 +164,64 @@ class LinearMpcBase(ParametricFamily):
         return obj_factor * np.diag(diag)
 
 
-def _horizon_family(nh: int) -> Type[LinearMpcBase]:
+    # -- sparse path -----------------------------------------------
+    #
+    # The dense methods above stay (the self-test finite-differences
+    # them at the small horizons), but nothing calls them during a
+    # solve: at N = 800 the dense Hessian alone would be 2402² doubles,
+    # 46 MB, rebuilt at every iteration. The structure below is the
+    # block-banded pattern an MPC transcription actually has —
+    # 7 nonzeros per dynamics row pair, and a diagonal Hessian.
+
+    def sparse_structure(self):
+        jr, jc = [], []
+        jr += [0, 1]
+        jc += [0, 1]
+        for k in range(self._NH):
+            r1, r2 = 2 + 2 * k, 3 + 2 * k
+            i1, i2 = 2 * k, 2 * k + 1
+            n1, n2 = 2 * (k + 1), 2 * (k + 1) + 1
+            u = self._u_off + k
+            jr += [r1, r1, r1, r2, r2, r2, r2]
+            jc += [n1, i1, i2, n2, i1, i2, u]
+        idx = np.arange(self.n)
+        return (
+            np.array(jr, dtype=np.int64),
+            np.array(jc, dtype=np.int64),
+            idx.copy(),  # Hessian is diagonal
+            idx.copy(),
+        )
+
+    def jacobian_values(self, z):
+        h, a, b = self._H, self._A, self._B
+        vals = np.empty(2 + 7 * self._NH)
+        vals[0] = 1.0
+        vals[1] = 1.0
+        block = np.array([1.0, -1.0, -h, 1.0, a * h, -1.0 + b * h, -h])
+        vals[2:] = np.tile(block, self._NH)
+        return vals
+
+    def hessian_values(self, z, lagrange, obj_factor):
+        diag = np.zeros(self.n)
+        dx = diag[: self._u_off].reshape(self._NH + 1, 2)
+        dx[:-1] = 2.0 * self._Q
+        dx[-1] = 2.0 * self._QT * self._Q
+        diag[self._u_off :] = 2.0 * self._R
+        return obj_factor * diag
+
+
+def _horizon_family(nh: int, tier: str = "default") -> Type[LinearMpcBase]:
     return type(
         f"LinearMpc{nh}",
         (LinearMpcBase,),
         {
             "name": f"mpc_horizon_{nh}",
             "_NH": nh,
+            "tier": tier,
+            # The large tier walks fewer steps: one active-set solve at
+            # N = 800 is seconds, and the per-step numbers are what
+            # matter, not the path length.
+            "n_steps": 20 if tier == "default" else 8,
             "tags": {
                 "regime": "saturation",
                 "channel": "rhs",
@@ -181,9 +232,14 @@ def _horizon_family(nh: int) -> Type[LinearMpcBase]:
     )
 
 
+#: Opt-in tier: n = 602 → 2402, where the sparse KKT and the Schur
+#: machinery start to be what the cost is made of. Not in the default
+#: sweep because a single active-set solve here takes seconds.
+MPC_LARGE_HORIZONS = (200, 400, 800)
+
 HORIZON_FAMILIES: List[Type[LinearMpcBase]] = [
     _horizon_family(nh) for nh in MPC_HORIZONS
-]
+] + [_horizon_family(nh, tier="large") for nh in MPC_LARGE_HORIZONS]
 
 HORIZON_BY_NAME: Dict[str, Type[LinearMpcBase]] = {
     f.name: f for f in HORIZON_FAMILIES

--- a/benchmarks/warmstart/families/mpc_horizon.py
+++ b/benchmarks/warmstart/families/mpc_horizon.py
@@ -1,0 +1,190 @@
+"""The scale axis: one MPC problem, several horizons.
+
+Every other family in this suite is small and fixed-size, because the
+suite measures *warm-start behavior* and small problems measure it
+cleanly. That leaves one question unanswered: how the answers move with
+problem size. The active-set path's per-QP cost grows with the active
+set, and the sparse KKT and Schur machinery only start to matter at
+size, so "warm-sqp wins" measured at n = 47 does not automatically hold
+at n = 482.
+
+This module is the same linear MPC problem at horizons N = 10, 20, 40
+and 80 — variables 3N+2, dynamics rows 2N+2, block-banded Jacobian.
+Only N changes between the families, so reading down the horizon column
+isolates scale from every other property. It is a linear-quadratic MPC
+on purpose: a convex QP, so all three solvers can take it, and its
+sparsity is the block-banded structure real MPC codes exploit rather
+than an artificial pattern.
+
+The parameter is the initial state, walked around a circle in state
+space. Constant ‖θ‖ keeps each step about as hard as the last (unlike a
+closed-loop path, which converges and makes late steps trivial), while
+the set of saturated controls rotates — so the active set moves at
+every horizon in the same way, and the horizons stay comparable.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Type
+
+import numpy as np
+
+from ..spec import Bounds, ParametricFamily
+
+_INF = 1e20
+
+#: Horizons swept. Variables run 32 → 242, dynamics rows 22 → 162.
+MPC_HORIZONS = (10, 20, 40, 80)
+
+
+class LinearMpcBase(ParametricFamily):
+    """Linear-quadratic MPC of a damped oscillator, horizon ``_NH``.
+
+    ``z = [x₀ … x_N, u₀ … u_{N−1}]`` with
+
+        ``x⁺ = [[1, h], [−ah, 1 − bh]] x + [0, h]ᵀ u``
+
+    minimizing a quadratic stage cost with a terminal weight, subject to
+    the dynamics as equality rows, the initial state as the parameter,
+    and ``|u| ≤ u_max`` — the bound that gives the problem an active set
+    worth carrying.
+
+    Everything is linear or quadratic, so the Jacobian and Hessian are
+    constant and exact, and the instance is a convex QP.
+    """
+
+    quadratic = True
+    n_steps = 20
+
+    _NH = 10  # overridden per horizon
+    _H = 0.1
+    _A = 1.0  # stiffness
+    _B = 0.1  # damping
+    _U_MAX = 0.5
+    _Q = np.array([1.0, 0.1])
+    _R = 0.05
+    _QT = 10.0
+    _RADIUS = 1.5
+    _DPHI = 0.05  # radians per step, before the scale multiplier
+
+    def __init__(self):
+        self._theta = self._theta_at(0.0)
+
+    # -- layout ----------------------------------------------------
+
+    @property
+    def n(self) -> int:
+        return 2 * (self._NH + 1) + self._NH
+
+    @property
+    def m(self) -> int:
+        return 2 + 2 * self._NH
+
+    @property
+    def _u_off(self) -> int:
+        return 2 * (self._NH + 1)
+
+    def _theta_at(self, phi: float) -> np.ndarray:
+        return self._RADIUS * np.array([np.cos(phi), np.sin(phi)])
+
+    def bounds(self) -> Bounds:
+        lb = np.full(self.n, -10.0)
+        ub = np.full(self.n, 10.0)
+        lb[self._u_off :] = -self._U_MAX
+        ub[self._u_off :] = self._U_MAX
+        return Bounds(lb=lb, ub=ub, cl=np.zeros(self.m), cu=np.zeros(self.m))
+
+    def cold_x0(self) -> np.ndarray:
+        return np.zeros(self.n)
+
+    def set_theta(self, theta: np.ndarray) -> None:
+        self._theta = np.asarray(theta, dtype=float).ravel().copy()
+
+    def theta_path(self, scale: float) -> Optional[List[np.ndarray]]:
+        return [
+            self._theta_at(scale * self._DPHI * k) for k in range(self.n_steps)
+        ]
+
+    # -- functions -------------------------------------------------
+
+    def _split(self, z):
+        return z[: self._u_off].reshape(self._NH + 1, 2), z[self._u_off :]
+
+    def objective(self, z):
+        X, U = self._split(z)
+        stage = float(np.sum(self._Q * X[:-1] ** 2))
+        terminal = float(self._QT * np.sum(self._Q * X[-1] ** 2))
+        return stage + terminal + float(self._R * (U @ U))
+
+    def gradient(self, z):
+        X, U = self._split(z)
+        g = np.zeros(self.n)
+        gx = g[: self._u_off].reshape(self._NH + 1, 2)
+        gx[:-1] = 2.0 * self._Q * X[:-1]
+        gx[-1] = 2.0 * self._QT * self._Q * X[-1]
+        g[self._u_off :] = 2.0 * self._R * U
+        return g
+
+    def constraints(self, z):
+        X, U = self._split(z)
+        h, a, b = self._H, self._A, self._B
+        c = np.empty(self.m)
+        c[:2] = X[0] - self._theta
+        x1, x2 = X[:-1, 0], X[:-1, 1]
+        c[2::2] = X[1:, 0] - (x1 + h * x2)
+        c[3::2] = X[1:, 1] - (x2 + h * (-a * x1 - b * x2 + U))
+        return c
+
+    def jacobian_dense(self, z):
+        h, a, b = self._H, self._A, self._B
+        j = np.zeros((self.m, self.n))
+        j[0, 0] = 1.0
+        j[1, 1] = 1.0
+        for k in range(self._NH):
+            r1, r2 = 2 + 2 * k, 3 + 2 * k
+            i1, i2 = 2 * k, 2 * k + 1
+            n1, n2 = 2 * (k + 1), 2 * (k + 1) + 1
+            j[r1, n1] = 1.0
+            j[r1, i1] = -1.0
+            j[r1, i2] = -h
+            j[r2, n2] = 1.0
+            j[r2, i1] = a * h
+            j[r2, i2] = -1.0 + b * h
+            j[r2, self._u_off + k] = -h
+        return j
+
+    def hessian_dense(self, z, lagrange, obj_factor):
+        # Constant and diagonal: the objective is a separable quadratic
+        # and every constraint is linear.
+        diag = np.zeros(self.n)
+        dx = diag[: self._u_off].reshape(self._NH + 1, 2)
+        dx[:-1] = 2.0 * self._Q
+        dx[-1] = 2.0 * self._QT * self._Q
+        diag[self._u_off :] = 2.0 * self._R
+        return obj_factor * np.diag(diag)
+
+
+def _horizon_family(nh: int) -> Type[LinearMpcBase]:
+    return type(
+        f"LinearMpc{nh}",
+        (LinearMpcBase,),
+        {
+            "name": f"mpc_horizon_{nh}",
+            "_NH": nh,
+            "tags": {
+                "regime": "saturation",
+                "channel": "rhs",
+                "curvature": "convex",
+                "horizon": str(nh),
+            },
+        },
+    )
+
+
+HORIZON_FAMILIES: List[Type[LinearMpcBase]] = [
+    _horizon_family(nh) for nh in MPC_HORIZONS
+]
+
+HORIZON_BY_NAME: Dict[str, Type[LinearMpcBase]] = {
+    f.name: f for f in HORIZON_FAMILIES
+}

--- a/benchmarks/warmstart/qpform.py
+++ b/benchmarks/warmstart/qpform.py
@@ -58,6 +58,62 @@ class QpData:
     ub: np.ndarray
 
 
+def _sparse_extract(family, src) -> QpData:
+    """Sparse counterpart of :func:`extract`, for families that declare
+    a structure. Nothing dense is ever materialized — passing a dense
+    ``P`` to the convex solver at n in the thousands is 60-80× slower
+    by its own diagnostic, which would make the QP arm look bad for a
+    reason that has nothing to do with the solver."""
+    from scipy import sparse
+
+    n, m = family.n, family.m
+    jr, jc, hr, hc = (np.asarray(a) for a in family.sparse_structure())
+    zero = np.zeros(n)
+
+    hv = np.asarray(family.hessian_values(zero, np.zeros(m), 1.0), dtype=float)
+    # Stored lower triangle -> full symmetric, which is what the QP
+    # interface's `P` expects to be handed (it re-takes the triangle).
+    P = sparse.coo_matrix((hv, (hr, hc)), shape=(n, n)).tocsc()
+    strict = sparse.coo_matrix(
+        (hv[hr != hc], (hc[hr != hc], hr[hr != hc])), shape=(n, n)
+    ).tocsc()
+    P = (P + strict).tocsc()
+
+    c = np.asarray(src.gradient(zero), dtype=float).copy()
+    f0 = float(src.objective(zero))
+
+    b_ = family.bounds()
+    lb = np.where(b_.lb > -_BOUND_INF, b_.lb, -np.inf)
+    ub = np.where(b_.ub < _BOUND_INF, b_.ub, np.inf)
+
+    A = b = G = h = None
+    if m:
+        jv = np.asarray(family.jacobian_values(zero), dtype=float)
+        J = sparse.coo_matrix((jv, (jr, jc)), shape=(m, n)).tocsr()
+        g0 = np.asarray(src.constraints(zero), dtype=float)
+        cl, cu = b_.cl, b_.cu
+        eq = np.abs(cu - cl) <= _EQ_TOL
+        if eq.any():
+            A = J[np.flatnonzero(eq)]
+            b = cl[eq] - g0[eq]
+        rows, hs = [], []
+        for i in np.flatnonzero(~eq):
+            if cu[i] < _BOUND_INF:
+                rows.append(J[i])
+                hs.append(cu[i] - g0[i])
+            if cl[i] > -_BOUND_INF:
+                rows.append(-J[i])
+                hs.append(-(cl[i] - g0[i]))
+        if rows:
+            G = sparse.vstack(rows).tocsc()
+            h = np.array(hs)
+    return QpData(
+        P=P, c=c, f0=f0,
+        A=A.tocsc() if A is not None else None,
+        b=b, G=G, h=h, lb=lb, ub=ub,
+    )
+
+
 def extract(family: ParametricFamily, callbacks=None) -> QpData:
     """Build :class:`QpData` for the family at its *current* parameter.
 
@@ -66,8 +122,11 @@ def extract(family: ParametricFamily, callbacks=None) -> QpData:
     assembly cost shows up in the step's evaluation counts the same way
     the other arms' per-iteration callbacks do.
     """
-    n, m = family.n, family.m
     src = callbacks if callbacks is not None else family
+    if family.sparse_structure() is not None:
+        return _sparse_extract(family, src)
+
+    n, m = family.n, family.m
     zero = np.zeros(n)
 
     # `SparseCallbacks` returns packed sparse values, so the dense
@@ -120,13 +179,15 @@ def verify(family: ParametricFamily, qp: QpData, rng, n_points: int = 5) -> list
     """
     out = []
     n = family.n
+    dense = lambda M: (M.toarray() if hasattr(M, "toarray") else M)
+    P, A, G = dense(qp.P), dense(qp.A), dense(qp.G)
     for _ in range(n_points):
         x = rng.standard_normal(n)
-        f_qp = 0.5 * x @ qp.P @ x + qp.c @ x + qp.f0
+        f_qp = 0.5 * x @ P @ x + qp.c @ x + qp.f0
         f_fam = float(family.objective(x))
         if abs(f_qp - f_fam) > 1e-9 * (1.0 + abs(f_fam)):
             out.append(f"objective mismatch: qp={f_qp:.12g} family={f_fam:.12g}")
-        g_qp = qp.P @ x + qp.c
+        g_qp = P @ x + qp.c
         if not np.allclose(g_qp, family.gradient(x), rtol=1e-9, atol=1e-9):
             out.append("gradient mismatch")
         if family.m:
@@ -135,8 +196,8 @@ def verify(family: ParametricFamily, qp: QpData, rng, n_points: int = 5) -> list
             eq = np.abs(bounds.cu - bounds.cl) <= _EQ_TOL
             # Equalities: Ax − b must be the family's own residual
             # g(x) − cl on those rows.
-            if qp.A is not None and not np.allclose(
-                qp.A @ x - qp.b, cons[eq] - bounds.cl[eq], rtol=1e-9, atol=1e-9
+            if A is not None and not np.allclose(
+                A @ x - qp.b, cons[eq] - bounds.cl[eq], rtol=1e-9, atol=1e-9
             ):
                 out.append("equality row mismatch")
             # Inequalities: each split row's slack h − Gx must be the
@@ -148,16 +209,16 @@ def verify(family: ParametricFamily, qp: QpData, rng, n_points: int = 5) -> list
                 if bounds.cl[i] > -_BOUND_INF:
                     expected.append(cons[i] - bounds.cl[i])
             if expected:
-                if qp.G is None or not np.allclose(
-                    qp.h - qp.G @ x, np.array(expected), rtol=1e-9, atol=1e-9
+                if G is None or not np.allclose(
+                    qp.h - G @ x, np.array(expected), rtol=1e-9, atol=1e-9
                 ):
                     out.append("inequality row mismatch")
             elif qp.G is not None:
                 out.append("unexpected inequality rows in the extraction")
-    if not np.allclose(qp.P, qp.P.T, atol=1e-12):
+    if not np.allclose(P, P.T, atol=1e-12):
         out.append("P is not symmetric")
-    if qp.P.size:
-        w = np.linalg.eigvalsh(qp.P)
+    if P.size and P.shape[0] <= 400:
+        w = np.linalg.eigvalsh(P)
         if w.min() < -1e-9 * max(1.0, abs(w.max())):
             out.append(
                 f"P is indefinite (min eigenvalue {w.min():.3e}); the convex "

--- a/benchmarks/warmstart/report.py
+++ b/benchmarks/warmstart/report.py
@@ -223,7 +223,7 @@ def render(payload: dict) -> str:
         w("|---|--:|--:|--:|--:|--:|--:|--:|--:|--:|--:|")
         for arm in (
             "cold-ipm", "warm-ipm", "cold-sqp", "warm-sqp",
-            "cold-qp-ipm", "warm-qp-ipm",
+            "cold-sqp-hom", "warm-sqp-hom", "cold-qp-ipm", "warm-qp-ipm",
         ):
             steps = run["arms"].get(arm)
             if not steps:
@@ -240,6 +240,59 @@ def render(payload: dict) -> str:
             )
         for arm, why in run.get("skipped", {}).items():
             w(f"| {arm} | *skipped* | | | | | | | | | {why} |")
+        w("")
+
+    # -- parametric homotopy vs the conventional inner solve ---------
+    hom_runs = [r for r in runs if "cold-sqp-hom" in r["arms"]]
+    if hom_runs:
+        w("## Parametric homotopy vs the conventional inner QP")
+        w("")
+        w(
+            "`-hom` arms set `sqp_qp_use_homotopy`, which replaces the inner "
+            "QP's **cold** phase-1/phase-2 solve with the §4.2 parametric "
+            "homotopy (box-only relaxation, then the row bounds tightened "
+            "along `t ∈ [0,1]`). Everything else about the arm is identical to "
+            "its twin, so the difference is that one option. Warm inner QPs "
+            "mostly skip the cold path, which is why the warm columns move "
+            "less than the cold ones."
+        )
+        w("")
+        w(
+            "| family | scale | cold: conventional → homotopy | ratio "
+            "| warm: conventional → homotopy | ratio |"
+        )
+        w("|---|---|--:|--:|--:|--:|")
+        tot = {"cc": 0, "ch": 0, "wc": 0, "wh": 0}
+        for run in hom_runs:
+            a = run["arms"]
+
+            def ws(arm):
+                return sum(s["n_qp_ws_changes"] or 0 for s in a[arm])
+
+            cc, ch, wc, wh = (
+                ws("cold-sqp"), ws("cold-sqp-hom"), ws("warm-sqp"), ws("warm-sqp-hom")
+            )
+            for k, v in (("cc", cc), ("ch", ch), ("wc", wc), ("wh", wh)):
+                tot[k] += v
+            w(
+                f"| `{run['family']}` | {run['scale']} | {cc} → {ch} "
+                f"| {_fmt(cc / ch if ch else None, '.2f')}× "
+                f"| {wc} → {wh} | {_fmt(wc / wh if wh else None, '.2f')}× |"
+            )
+        w(
+            f"| **total** | | **{tot['cc']} → {tot['ch']}** "
+            f"| **{tot['cc'] / tot['ch']:.2f}×** | **{tot['wc']} → {tot['wh']}** "
+            f"| **{tot['wc'] / tot['wh']:.2f}×** |"
+            if tot["ch"] and tot["wh"]
+            else ""
+        )
+        w("")
+        w(
+            "Above 1.00× the homotopy did less inner active-set work; below "
+            "it, more. A flat 1.00× means the option changed nothing on that "
+            "family — its inner QPs never take the cold path far enough for "
+            "the homotopy to matter."
+        )
         w("")
 
     # -- three-way on the QP-shaped families ------------------------

--- a/benchmarks/warmstart/run.py
+++ b/benchmarks/warmstart/run.py
@@ -95,6 +95,14 @@ def main(argv=None) -> int:
         "than the reference arm's by more than this is counted incorrect",
     )
     p.add_argument("--max-iter", type=int, default=500)
+    p.add_argument(
+        "--tier",
+        default="default",
+        choices=("default", "large", "all"),
+        help="which size tier to run. `default` is the standard sweep; "
+        "`large` is the opt-in n = 602-2402 MPC horizons, where a single "
+        "active-set solve takes seconds; `all` runs both",
+    )
     p.add_argument("--quick", action="store_true", help="3 families, one scale")
     p.add_argument("--out", default=os.path.join(_HERE, "results.json"))
     p.add_argument("--no-report", action="store_true")
@@ -102,6 +110,10 @@ def main(argv=None) -> int:
     args = p.parse_args(argv)
 
     families = _csv(args.families, list(REGISTRY), "family")
+    if args.tier != "all" and args.families == "all":
+        # An explicitly named family is always honored; the tier filter
+        # only prunes the "all" default.
+        families = [f for f in families if REGISTRY[f].tier == args.tier]
     scales = _csv(args.scales, list(SCALES), "scale")
     arms = _csv(args.arms, ARMS, "arm")
     if args.quick:

--- a/benchmarks/warmstart/selftest.py
+++ b/benchmarks/warmstart/selftest.py
@@ -77,6 +77,70 @@ def _sample_points(family: ParametricFamily, rng) -> List[np.ndarray]:
     ]
 
 
+
+def _check_sparse(family: ParametricFamily, rng, max_cols: int = 12) -> List[str]:
+    """Verify a declared sparse structure without building anything dense.
+
+    A large family cannot be checked the way the small ones are — an
+    `(n, n)` finite-difference Hessian at n = 2402 is 46 MB per column.
+    Instead this checks the packed values directly against central
+    differences on a random subset of columns, reconstructing each
+    column from the triplets. Cheap, and it tests the code path the
+    solver actually calls rather than a dense twin of it.
+    """
+    out: List[str] = []
+    jr, jc, hr, hc = (np.asarray(a) for a in family.sparse_structure())
+    n, m = family.n, family.m
+    x = family.cold_x0() + 0.1 * rng.standard_normal(n)
+    lam = rng.standard_normal(m)
+
+    jv = np.asarray(family.jacobian_values(x), dtype=float)
+    hv = np.asarray(family.hessian_values(x, lam, 1.0), dtype=float)
+    if jv.size != jr.size:
+        out.append(f"jacobian_values has {jv.size} entries, structure has {jr.size}")
+        return out
+    if hv.size != hr.size:
+        out.append(f"hessian_values has {hv.size} entries, structure has {hr.size}")
+        return out
+    if np.any(hr < hc):
+        out.append("hessian structure is not lower-triangular")
+
+    def lag_grad(z):
+        g = 1.0 * np.asarray(family.gradient(z), dtype=float)
+        v = np.asarray(family.jacobian_values(z), dtype=float)
+        return g + np.bincount(jc, weights=v * lam[jr], minlength=n)
+
+    cols = rng.choice(n, size=min(max_cols, n), replace=False)
+    for j in cols:
+        h = _EPS * max(1.0, abs(x[j]))
+        xp, xm = x.copy(), x.copy()
+        xp[j] += h
+        xm[j] -= h
+
+        if m:
+            fd = (family.constraints(xp) - family.constraints(xm)) / (2.0 * h)
+            col = np.zeros(m)
+            sel = jc == j
+            np.add.at(col, jr[sel], jv[sel])
+            if _rel_err(col, fd) > _RTOL:
+                out.append(f"sparse jacobian column {j} disagrees with FD")
+
+        fd_h = (lag_grad(xp) - lag_grad(xm)) / (2.0 * h)
+        # Column j of the symmetric Hessian, from the stored lower triangle:
+        # entries whose column is j, plus the mirror of entries whose row is j,
+        # minus the diagonal which both selections pick up.
+        col = np.zeros(n)
+        sel = hc == j
+        np.add.at(col, hr[sel], hv[sel])
+        sel = hr == j
+        np.add.at(col, hc[sel], hv[sel])
+        diag = (hr == j) & (hc == j)
+        col[j] -= hv[diag].sum()
+        if _rel_err(col, fd_h) > _RTOL:
+            out.append(f"sparse hessian column {j} disagrees with FD")
+    return out
+
+
 def check_family(name: str, verbose: bool = True) -> List[str]:
     """Returns a list of failure messages (empty when the family is sound)."""
     rng = np.random.default_rng(1234)
@@ -87,6 +151,27 @@ def check_family(name: str, verbose: bool = True) -> List[str]:
     if path is None:
         path = [family.initial_theta(1.0)]
     thetas = [path[0], path[len(path) // 2], path[-1]]
+
+    sparse = family.sparse_structure() is not None
+    heavy = family.n > 300
+
+    if sparse:
+        for theta in thetas:
+            family.set_theta(theta)
+            for msg in _check_sparse(family, rng):
+                failures.append(f"{name}: {msg} (θ={theta})")
+    if heavy:
+        # Too large to finite-difference densely, and its dense twin is
+        # never called during a solve anyway. The sparse check above is
+        # the real one; the dense methods are exercised at the small
+        # sizes of the same family class.
+        if verbose:
+            status = "FAIL" if failures else "ok"
+            print(
+                f"  {name:<22} n={family.n:<5} m={family.m:<5} "
+                f"sparse-only (n > 300)  {status}"
+            )
+        return failures
 
     worst = {"grad": 0.0, "jac": 0.0, "hess": 0.0}
     for theta in thetas:
@@ -153,6 +238,22 @@ def check_family(name: str, verbose: bool = True) -> List[str]:
             f"{name}: {int(missed.sum())} nonzero hessian entries "
             "outside the sampled sparsity pattern"
         )
+
+    # A small family with both paths must have them agree, which is what
+    # makes the large siblings' sparse-only check trustworthy.
+    if sparse:
+        jr, jc, hr, hc = (np.asarray(a) for a in family.sparse_structure())
+        xs = family.cold_x0()
+        lam_s = rng.standard_normal(family.m)
+        if family.m and not np.allclose(
+            family.jacobian_values(xs), family.jacobian_dense(xs)[jr, jc]
+        ):
+            failures.append(f"{name}: sparse jacobian values != dense")
+        if not np.allclose(
+            family.hessian_values(xs, lam_s, 1.0),
+            family.hessian_dense(xs, lam_s, 1.0)[hr, hc],
+        ):
+            failures.append(f"{name}: sparse hessian values != dense")
 
     # Families that claim to be QPs must survive being turned into one.
     if family.quadratic:

--- a/benchmarks/warmstart/sparsity.py
+++ b/benchmarks/warmstart/sparsity.py
@@ -75,8 +75,22 @@ class SparseCallbacks:
     def __init__(self, family: ParametricFamily, seed: int = 0):
         self.family = family
         rng = np.random.default_rng(seed)
-        pts = _probe_points(family, rng)
 
+        # A family that declares its own structure never has a dense
+        # matrix built for it — the whole point at n in the thousands.
+        declared = family.sparse_structure()
+        if declared is not None:
+            jr, jc, hr, hc = declared
+            self._jac_rows = np.asarray(jr, dtype=np.int64)
+            self._jac_cols = np.asarray(jc, dtype=np.int64)
+            self._hess_rows = np.asarray(hr, dtype=np.int64)
+            self._hess_cols = np.asarray(hc, dtype=np.int64)
+            self._sparse = True
+            self.reset_counts()
+            return
+        self._sparse = False
+
+        pts = _probe_points(family, rng)
         n, m = family.n, family.m
 
         jac_pat = np.zeros((m, n), dtype=bool)
@@ -149,7 +163,12 @@ class SparseCallbacks:
 
     def jacobian(self, x):
         self.n_jac += 1
-        j = self.family.jacobian_dense(np.asarray(x, dtype=float))
+        x = np.asarray(x, dtype=float)
+        if self._sparse:
+            return np.ascontiguousarray(
+                self.family.jacobian_values(x), dtype=float
+            )
+        j = self.family.jacobian_dense(x)
         return np.ascontiguousarray(j[self._jac_rows, self._jac_cols], dtype=float)
 
     def hessianstructure(self) -> Tuple[np.ndarray, np.ndarray]:
@@ -160,6 +179,15 @@ class SparseCallbacks:
 
     def hessian(self, x, lagrange, obj_factor):
         self.n_hess += 1
+        if self._sparse:
+            return np.ascontiguousarray(
+                self.family.hessian_values(
+                    np.asarray(x, dtype=float),
+                    np.asarray(lagrange, dtype=float),
+                    float(obj_factor),
+                ),
+                dtype=float,
+            )
         h = self.family.hessian_dense(
             np.asarray(x, dtype=float),
             np.asarray(lagrange, dtype=float),

--- a/benchmarks/warmstart/spec.py
+++ b/benchmarks/warmstart/spec.py
@@ -161,6 +161,12 @@ class ParametricFamily(ABC):
     #: than trusting the flag.
     quadratic: bool = False
 
+    #: Size tier. ``"default"`` families are small and fast and make up
+    #: the standard sweep; ``"large"`` families exist to exercise the
+    #: sparse path at size and are opt-in (`--tier large`), because a
+    #: single active-set solve on them can take seconds.
+    tier: str = "default"
+
     #: True when the next parameter depends on the previous solution
     #: (closed-loop MPC / moving horizon). The runner then records the
     #: path produced by the reference arm and *replays* it for the
@@ -221,7 +227,13 @@ class ParametricFamily(ABC):
 
     @abstractmethod
     def jacobian_dense(self, x: np.ndarray) -> np.ndarray:
-        """Constraint Jacobian, shape (m, n)."""
+        """Constraint Jacobian, shape (m, n).
+
+        Families large enough that an ``(m, n)`` array is impractical
+        override :meth:`sparse_structure` and the ``*_values`` methods
+        instead; this one is then only called by the self-test, at a
+        reduced size.
+        """
 
     @abstractmethod
     def hessian_dense(
@@ -232,3 +244,31 @@ class ParametricFamily(ABC):
         Sign convention matches cyipopt/Ipopt:
         ``obj_factor·∇²f + Σ_i lagrange_i·∇²g_i``.
         """
+
+    # -- optional sparse path --------------------------------------
+    #
+    # A family whose dense Jacobian or Hessian would not fit — anything
+    # past a few hundred variables — implements these three instead.
+    # The structure is fixed for the whole path (the suite requires
+    # that of every family anyway), so it is computed once.
+
+    def sparse_structure(self):
+        """``(jac_rows, jac_cols, hess_rows, hess_cols)`` or ``None``.
+
+        ``None`` (the default) means "derive the pattern from the dense
+        callbacks", which is right for every small family. Returning a
+        structure switches :class:`~.sparsity.SparseCallbacks` onto the
+        sparse path, where the dense methods are never called during a
+        solve. The Hessian entries must be lower-triangular.
+        """
+        return None
+
+    def jacobian_values(self, x: np.ndarray) -> np.ndarray:
+        """Jacobian entries at ``sparse_structure()``'s ``jac`` indices."""
+        raise NotImplementedError
+
+    def hessian_values(
+        self, x: np.ndarray, lagrange: np.ndarray, obj_factor: float
+    ) -> np.ndarray:
+        """Hessian entries at ``sparse_structure()``'s ``hess`` indices."""
+        raise NotImplementedError

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3404,6 +3404,15 @@ fn apply_qp_subproblem_options(options: &OptionsList, opts: &mut pounce_qp::QpOp
     if let Ok((v, true)) = options.get_bool_value("sqp_qp_use_schur_updates", "") {
         opts.use_schur_updates = v;
     }
+    // Registered by the homotopy work but never read here, so the knob was a
+    // no-op on the SQP path: `pounce_qp`'s own default is `false`, and only
+    // `pounce_convex::active_set` set it (in Rust, not through options). The
+    // inverse of gh #360 — registered-but-unread rather than
+    // read-but-unregistered — and invisible to that issue's guard test, which
+    // only checked one direction.
+    if let Ok((v, true)) = options.get_bool_value("sqp_qp_use_homotopy", "") {
+        opts.use_homotopy = v;
+    }
     if let Ok((v, true)) = options.get_integer_value("sqp_qp_max_schur_updates_before_refactor", "")
     {
         if v >= 1 {
@@ -3846,7 +3855,8 @@ mod tests {
              sqp_qp_elastic_gamma 1e4\n\
              sqp_qp_anti_cycling bland\n\
              sqp_qp_use_schur_updates yes\n\
-             sqp_qp_max_schur_updates_before_refactor 12\n",
+             sqp_qp_max_schur_updates_before_refactor 12\n\
+             sqp_qp_use_homotopy yes\n",
         )
         .expect("every sqp_qp_* option must be registered (gh #360)");
 
@@ -3862,6 +3872,7 @@ mod tests {
         // of this family.
         assert!(qp.use_schur_updates);
         assert_eq!(qp.max_schur_updates_before_refactor, 12);
+        assert!(qp.use_homotopy);
 
         // Untouched options must keep the pounce-qp defaults, not be
         // overwritten with zeros by the "explicitly set" gate.
@@ -3882,6 +3893,62 @@ mod tests {
         assert_eq!(
             qp.max_schur_updates_before_refactor,
             defaults.max_schur_updates_before_refactor
+        );
+    }
+
+    /// The other direction of the gh #360 guard: every **registered**
+    /// `sqp_qp_*` option must be one `apply_qp_subproblem_options` actually
+    /// reads.
+    ///
+    /// The sister test above checks read-keys-are-registered. It cannot catch
+    /// the inverse, and the inverse happened: `sqp_qp_use_homotopy` was
+    /// registered with the homotopy work and never wired into the reader, so
+    /// setting it on the SQP path silently did nothing while the option's own
+    /// documentation described what it would do. A registered knob that no
+    /// code reads is worse than a missing one — it validates, it accepts a
+    /// value, and it lies.
+    ///
+    /// Adding a new `sqp_qp_*` option therefore fails here until it is both
+    /// read by `apply_qp_subproblem_options` and asserted in the round-trip
+    /// test above.
+    #[test]
+    fn application_every_registered_sqp_qp_option_is_read_by_the_subproblem_reader() {
+        let mut app = IpoptApplication::new();
+        app.initialize().unwrap();
+
+        let mut registered: Vec<String> = app
+            .registered_options()
+            .registered_options_in_order()
+            .iter()
+            .map(|o| o.name.clone())
+            .filter(|n| n.starts_with("sqp_qp_"))
+            .collect();
+        registered.sort();
+
+        // Kept in step by hand with the `options.get_*_value("sqp_qp_…")`
+        // calls in `apply_qp_subproblem_options`, and cross-checked by the
+        // round-trip assertions in the sister test.
+        let mut read_by_the_reader = vec![
+            "sqp_qp_anti_cycling".to_string(),
+            "sqp_qp_elastic_gamma".to_string(),
+            "sqp_qp_feas_tol".to_string(),
+            "sqp_qp_max_iter".to_string(),
+            "sqp_qp_max_schur_updates_before_refactor".to_string(),
+            "sqp_qp_opt_tol".to_string(),
+            "sqp_qp_use_homotopy".to_string(),
+            "sqp_qp_use_schur_updates".to_string(),
+        ];
+        read_by_the_reader.sort();
+
+        assert_eq!(
+            registered, read_by_the_reader,
+            "registered sqp_qp_* options and the ones \
+             `apply_qp_subproblem_options` reads have diverged. A key that is \
+             registered but unread is a no-op knob with working documentation \
+             (that is how `sqp_qp_use_homotopy` shipped); a key read but not \
+             registered is gh #360. Wire it up in both places, assert it in \
+             `application_sqp_qp_subproblem_options_are_registered_and_propagate`, \
+             then add it here."
         );
     }
 

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -299,6 +299,59 @@ Caveat kept in the report itself: the QP arms receive matrix data once
 per step where the callback arms re-evaluate per iteration, so the wall
 time favors them by an amount this suite does not separate out.
 
+## Finding 4: `sqp_qp_use_homotopy` was registered but never read
+
+Found while adding the `-hom` arms. The option was registered by the
+homotopy work (#412) and documented in detail, but
+`apply_qp_subproblem_options` — the function that maps the `sqp_qp_*`
+family onto `pounce_qp::QpOptions` — never read it. Setting it on the
+SQP path therefore did nothing at all, silently, while the option's own
+documentation described the algorithm it would select. The first
+version of the `-hom` arms measured bit-identical results to their
+twins, which is how it surfaced: an arm that cannot differ from its
+control is either a perfect null result or a broken experiment, and it
+was the second.
+
+This is the exact inverse of #360 (read-but-unregistered), and the
+guard test that issue left behind could not catch it — that test walks
+the keys the *reader* consults and asserts each is registered, which
+says nothing about a registered key no reader consults. Fixed here by
+reading the option, and by adding
+`application_every_registered_sqp_qp_option_is_read_by_the_subproblem_reader`,
+which enumerates the registry and fails if the two sets diverge in
+either direction. Both guards were checked for falsifiability: removing
+the reader fails the round-trip test, removing the name from the
+covered list fails the new one.
+
+## Finding 5: the homotopy is a sharply mixed trade, and the split is legible
+
+With the option working, the `-hom` arms measure it. On cold inner
+solves, where it engages:
+
+| family | conventional → homotopy | ratio |
+|---|--:|--:|
+| `redundant_rows` | 247 → 30 | 4.2–12.3× |
+| `degenerate_corner` | 69 → 30 | 2.0–2.9× |
+| `moving_bound_qp` | 793 → 685 | 0.87–2.75× |
+| `degenerate_vertex` | 154 → 132 | 1.1–1.3× |
+| `simplex_proj` | 978 → 1400 | 0.63–0.74× |
+| `nmpc_vanderpol` | 2745 → 5115 | 0.52–0.55× |
+| four others | unchanged | 1.00× |
+| **all 30 rows** | **5583 → 7989** | **0.70×** |
+
+It wins where it was designed to — degenerate, rank-deficient,
+netlib-like geometry, and it *improves* with perturbation size on
+`redundant_rows` because the conventional cold solve degrades there
+while the homotopy does not — and loses roughly 2× on well-conditioned
+MPC-shaped QPs. That is a mechanism-level account of #412's
+Maros-Mészáros result (20 gained, 7 lost, the losses large instances),
+and it argues for keeping the default off on the SQP path while making
+the knob reachable, which is now the case.
+
+It also bears on #413: the homotopy's cost concentrates on
+`nmpc_vanderpol`, the family closest in shape to the corrector-bound
+instances that issue is about.
+
 ## Not done yet
 
 - **A shift-based warm-start arm for the closed-loop family.** MPC
@@ -310,6 +363,10 @@ time favors them by an amount this suite does not separate out.
   `Δx ≈ ∂x*/∂p · Δp` before the SQP corrector runs — the pattern
   documented in `docs/src/active-set-sqp.md` §4. It would slot in as a
   fifth arm and is the natural next addition.
+- **Scale.** Every family is small (n ≤ 47), so nothing here measures
+  the sparse path or the Schur updates at size. An MPC horizon sweep
+  (N = 10…160) would be the natural addition and would put the
+  `-hom` arms on problems where the homotopy's cost matters.
 - **An external solver arm.** The adapter interface is exercised by
   the pounce adapter's three paths but has no second solver behind it;
   Ipopt through cyipopt would be the obvious first one, using the same

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -354,6 +354,12 @@ instances that issue is about.
 
 ## Finding 6: the SQP's warm-start advantage is eroded by absolute churn, and size inflates it
 
+> **Retracted by Finding 7.** The crossover below was #428, a defect
+> found by the large tier and fixed in #429, not a property of
+> active-set warm starts. The churn measurements are unchanged and
+> still correct; the mechanism and the conclusion drawn from them are
+> not. Kept as written, with the post-fix numbers in Finding 7.
+
 The `mpc_horizon_10/20/40/80` families are one linear-quadratic MPC at
 four horizons, so only `N` differs. Warm/cold wall-time ratio, below 1
 meaning warm won:
@@ -390,7 +396,7 @@ hundreds of active constraints, not thousands.
 Repeatability: the N = 80 numbers are deterministic — two independent
 re-runs gave 1605 → 1746 inner active-set changes to the digit.
 
-## Finding 7 — at large scale the SQP warm start is discarded, not repaired (#428)
+## Finding 7 — at large scale the SQP warm start was discarded, not repaired (#428, fixed in #429)
 
 The horizon sweep stopped at n = 242 and reported a gradual erosion.
 Carrying the same MPC to n = 2402 (`--tier large`, N = 200/400/800)
@@ -459,6 +465,61 @@ Why nothing caught it earlier: at m = 22 the penalty is smaller than a
 cold solve outright, so the default tier's numbers look merely
 unimpressive rather than wrong. It takes m in the hundreds before the
 Θ(m) term separates from the constant.
+
+### After the fix
+
+#429 repairs the hint instead of discarding it: the rows the pinned
+point violates are known, so they are pinned too and the KKT
+re-factored, keeping the |A| − 1 entries the hint got right. It declines
+— leaving the old elastic recovery in place — when an already-active row
+is violated, when the violated rows exceed a quarter of the hint's
+active set, when the repaired pin set would exceed n rows, or after
+three re-pin rounds.
+
+Re-measured on the same build:
+
+| N | n | m | cold | warm before | warm after |
+|--:|--:|--:|--:|--:|--:|
+| 10 | 32 | 22 | 11 | 0 | 0 |
+| 20 | 62 | 42 | 25 | 43 | 1 |
+| 40 | 122 | 82 | 48 | 1 | 1 |
+| 80 | 242 | 162 | 66 | 164 | 3 |
+| 200 | 602 | 402 | 66 | 403 | 3 |
+| 400 | 1202 | 802 | 66 | 795 | 3 |
+| 800 | 2402 | 1602 | 66 | 1589 | 3 |
+
+Flat at 3 across a 75× range of m, same optimum to 1e-11. The Δφ scan
+now tracks the movement instead of jumping: 0/0/0/1/3/4 warm pivots for
+true active-set diffs of 0/0/1/2/4/4, against 0/0/400/401/403 before.
+
+Large tier at default settings: every arm correct on every step (was
+7 of 8 bad on both warm SQP arms), and `warm-sqp` wall time is 0.03×,
+0.03×, 0.02× its cold twin at N = 200/400/800 — the fastest arm on the
+board, where it previously did not return an answer. Inner work 514 → 11
+per path at all three horizons. At n = 2402: 1.36 s warm against 12.04 s
+cold.
+
+**Findings 6's conclusion is retracted.** The horizon sweep's crossover
+— warm/cold wall 0.84 → 1.29 → 1.95 → 2.57 turning harmful above
+N = 20 — was this defect, not a property of active-set warm starts. On
+the fixed solver the same measurement runs 0.24 → 0.12 → 0.11 → 0.10 at
+`large` and 0.17 → 0.08 → 0.04 → 0.02 at `tiny`: the ratio *improves*
+with horizon, because cold cost grows with the problem while warm cost
+is set by how far the active set moved. The churn numbers in Finding 6
+were correct and are unchanged (1.05 / 2.26 / 4.21 / 5.58); it was the
+interpretation built on them that was wrong. The suite's original rule
+— payoff tracks how much the active set moves, and problem size has
+little to do with it — stands as first written, and the "absolute churn"
+sharpening should be dropped.
+
+A caution worth keeping: Finding 6 reasoned from a plausible mechanism
+(absolute churn grows with size, each change costs more as |A| grows)
+that fit the data and was still wrong, because the data had a defect in
+it. Two multiplying factors were invented to explain what was really a
+single discarded hint. The measurement that would have caught it was
+cheap — compare warm pivots against the *true* active-set difference,
+which is 4 where the warm arm spent 164 — and it was not run until the
+large tier made the discrepancy impossible to miss.
 
 ## Not done yet
 

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -496,7 +496,7 @@ Large tier at default settings: every arm correct on every step (was
 7 of 8 bad on both warm SQP arms), and `warm-sqp` wall time is 0.03×,
 0.03×, 0.02× its cold twin at N = 200/400/800 — the fastest arm on the
 board, where it previously did not return an answer. Inner work 514 → 11
-per path at all three horizons. At n = 2402: 1.36 s warm against 12.04 s
+per path at all three horizons. At n = 2402: 1.34 s warm against 12.12 s
 cold.
 
 **Findings 6's conclusion is retracted.** The horizon sweep's crossover

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -352,6 +352,44 @@ It also bears on #413: the homotopy's cost concentrates on
 `nmpc_vanderpol`, the family closest in shape to the corrector-bound
 instances that issue is about.
 
+## Finding 6: the SQP's warm-start advantage is eroded by absolute churn, and size inflates it
+
+The `mpc_horizon_10/20/40/80` families are one linear-quadratic MPC at
+four horizons, so only `N` differs. Warm/cold wall-time ratio, below 1
+meaning warm won:
+
+| N | mean &#124;A&#124; | `tiny` | `small` | `large` |
+|--:|--:|--:|--:|--:|
+| 10 | 31.5 | 0.27 | 0.38 | 0.84 |
+| 20 | 61.0 | 0.22 | 0.91 | 1.29 |
+| 40 | 119.6 | **0.08** | 0.66 | 1.95 |
+| 80 | 206.0 | 0.31 | 1.06 | **2.57** |
+
+Not "the SQP loses at scale": at `tiny` steps it stays excellent at
+every horizon, and its best row in the entire suite is N = 40 at 0.08.
+What degrades is the combination of size *and* movement. The IPM arms
+stay between 0.25 and 1.00 across the whole grid; the convex QP IPM is
+flatter still.
+
+The mechanism is in the working sets. The *fraction* of the active set
+that changes per step is horizon-independent (~3% at `large` for every
+N — the same angular perturbation moves proportionally the same
+constraints), but the *absolute* count grows with the problem: 1.05 →
+5.58 changes per step from N = 10 to N = 80. An active-set method pays
+for the absolute count, and each change also costs more as `|A|` grows.
+Two multiplying factors.
+
+So the suite's earlier rule — payoff tracks churn — was right but
+imprecise. It tracks **absolute** churn, and problem size inflates
+absolute churn even at a proportionally identical perturbation. It also
+puts a number on the qualitative caveat in `docs/src/active-set-sqp.md`
+("prefer the IPM for large-scale problems with thousands of active
+inequalities"): the measured crossover on this problem is tens to low
+hundreds of active constraints, not thousands.
+
+Repeatability: the N = 80 numbers are deterministic — two independent
+re-runs gave 1605 → 1746 inner active-set changes to the digit.
+
 ## Not done yet
 
 - **A shift-based warm-start arm for the closed-loop family.** MPC
@@ -363,10 +401,11 @@ instances that issue is about.
   `Δx ≈ ∂x*/∂p · Δp` before the SQP corrector runs — the pattern
   documented in `docs/src/active-set-sqp.md` §4. It would slot in as a
   fifth arm and is the natural next addition.
-- **Scale.** Every family is small (n ≤ 47), so nothing here measures
-  the sparse path or the Schur updates at size. An MPC horizon sweep
-  (N = 10…160) would be the natural addition and would put the
-  `-hom` arms on problems where the homotopy's cost matters.
+- **Genuinely large scale.** The horizon sweep reaches n = 242, which
+  is enough to find the crossover but not enough to exercise the sparse
+  factorization or the Schur updates where they dominate. n in the
+  thousands would need the `.nl` machinery rather than dense Python
+  callbacks.
 - **An external solver arm.** The adapter interface is exercised by
   the pounce adapter's three paths but has no second solver behind it;
   Ipopt through cyipopt would be the obvious first one, using the same

--- a/dev-notes/warm-start-benchmark.md
+++ b/dev-notes/warm-start-benchmark.md
@@ -390,6 +390,76 @@ hundreds of active constraints, not thousands.
 Repeatability: the N = 80 numbers are deterministic — two independent
 re-runs gave 1605 → 1746 inner active-set changes to the digit.
 
+## Finding 7 — at large scale the SQP warm start is discarded, not repaired (#428)
+
+The horizon sweep stopped at n = 242 and reported a gradual erosion.
+Carrying the same MPC to n = 2402 (`--tier large`, N = 200/400/800)
+showed the erosion was not gradual and not intrinsic — it was a defect,
+now filed as #428.
+
+At default settings the warm-started SQP does not return an answer on
+the large tier: `Maximum_Iterations_Exceeded` with `iter_count = 0` on
+7 of 8 steps at every horizon, `x` left at the warm-start point.
+Everything else — `cold-sqp`, both IPM arms, both convex-QP arms —
+solves all 8 cleanly.
+
+Raising the inner-QP budget until nothing truncates, inner working-set
+changes for one step:
+
+| N | n | m | cold | warm | warm, hint admitted |
+|--:|--:|--:|--:|--:|--:|
+| 10 | 32 | 22 | 11 | 0 | 0 |
+| 20 | 62 | 42 | 25 | 43 | 0 |
+| 40 | 122 | 82 | 48 | 1 | 1 |
+| 80 | 242 | 162 | 66 | 164 | 2 |
+| 200 | 602 | 402 | 66 | 403 | 2 |
+| 400 | 1202 | 802 | 66 | 795 | 2 |
+| 800 | 2402 | 1602 | 66 | 1589 | 2 |
+
+Cold is flat at 66 across a 75× range of m. Warm is Θ(m). The correct
+answer is flat at 2.
+
+It is a step function, not a slope. At N = 200, a parameter step that
+changes **zero** entries of the true active set gives 0 warm pivots; a
+step that changes **one** gives 400; four gives 403. The first changed
+entry costs m, every later one costs 1.
+
+Mechanism, confirmed by bisection: `solve_with_working_set` builds
+`x_init` by pinning the hinted rows to their new boundary values. When
+the active set has moved, that pinned point holds a row it should have
+released and therefore violates some *other* row — by about the
+distance the parameter moved (bracketed here to (0.01, 0.1] against a
+step of ≈0.075). `solve`'s warm-start admission pre-check
+(`pounce-qp/src/solver.rs:2855`) sees an infeasible primal and returns
+`solve_elastic`, whose recovery re-solve seeds `WorkingSet::cold(n, m)`
+— so the hint is dropped whole and every row is re-added from scratch.
+
+The causal test: raise only `sqp_qp_feas_tol` so the same hint is
+admitted, and the solve takes 2 pivots and lands on the same optimum to
+1e-11 with violation 7e-15. The work was never necessary.
+
+That tolerance is *not* a workaround, and the reason matters. `feas_tol`
+gates two unrelated decisions — whether a hint is admitted, and whether
+a converged point is accepted. At 0.1 the hint is admitted and the
+answer is right; at 0.5 the same solve returns objective 26.6175 with
+violation 6.4e-2 and KKT 2.5. There is no setting safe for both jobs.
+
+Two corrections to earlier findings this forces:
+
+- Finding 6's "warm starting turns harmful above N = 20 at large
+  steps" is this defect, not a property of active-set warm starts. The
+  wall-time crossover numbers stand as measurements; the *explanation*
+  attached to them — absolute churn growing with size — is right for
+  the IPM arms and wrong for the SQP, whose cost is set by whether the
+  first entry moved, not by how many did.
+- The suite's rule "payoff tracks absolute churn" survives for the IPM
+  and needs the caveat above for the SQP.
+
+Why nothing caught it earlier: at m = 22 the penalty is smaller than a
+cold solve outright, so the default tier's numbers look merely
+unimpressive rather than wrong. It takes m in the hundreds before the
+Θ(m) term separates from the constant.
+
 ## Not done yet
 
 - **A shift-based warm-start arm for the closed-loop family.** MPC
@@ -401,11 +471,12 @@ re-runs gave 1605 → 1746 inner active-set changes to the digit.
   `Δx ≈ ∂x*/∂p · Δp` before the SQP corrector runs — the pattern
   documented in `docs/src/active-set-sqp.md` §4. It would slot in as a
   fifth arm and is the natural next addition.
-- **Genuinely large scale.** The horizon sweep reaches n = 242, which
-  is enough to find the crossover but not enough to exercise the sparse
-  factorization or the Schur updates where they dominate. n in the
-  thousands would need the `.nl` machinery rather than dense Python
-  callbacks.
+- **Large scale beyond one problem class.** The `large` tier reaches
+  n = 2402, but it is linear-quadratic MPC — banded, mostly equalities,
+  a large active set that barely moves. Whether #428 dominates on a
+  large problem with a different sparsity pattern is untested, and a
+  second large family (a sparse least-squares or a network flow) would
+  be the way to find out.
 - **An external solver arm.** The adapter interface is exercised by
   the pounce adapter's three paths but has no second solver behind it;
   Ipopt through cyipopt would be the obvious first one, using the same

--- a/docs/src/active-set-sqp.md
+++ b/docs/src/active-set-sqp.md
@@ -26,10 +26,19 @@ set is stable, or grows by a few QP add/drop steps when one or
 two constraints flip.
 
 Stick with the IPM (the default) for **cold solves of a single
-problem** or **large-scale problems with thousands of active
-inequalities**. The IPM scales linearly in the active set; the
-active-set SQP's per-QP cost grows with the number of active
-constraints.
+problem**. The IPM scales linearly in the active set; the active-set
+SQP's per-QP cost grows with the number of active constraints, so a
+*cold* SQP solve does lose ground as the problem grows.
+
+A warm one does not, which is the case worth being precise about. On
+[the warm-start benchmark](warm-start-benchmark.md)'s MPC sweep the
+warm-started SQP's advantage over its own cold twin *improves* with
+problem size all the way to 1645 active constraints (0.17× → 0.02× wall
+time from N = 10 to N = 80, and 0.02–0.03× at n = 602–2402), because
+warm cost is set by how far the active set moved rather than by how
+large it is. An earlier version of this page warned against the SQP for
+"large-scale problems with thousands of active inequalities"; the
+measured behavior does not support that for warm-started sequences.
 
 ## 2. Switching to the SQP path
 

--- a/docs/src/warm-start-benchmark.md
+++ b/docs/src/warm-start-benchmark.md
@@ -39,8 +39,17 @@ Each runs cold and warm, giving six arms:
 | `warm-ipm` | NLP filter-IPM | previous point + μ | every family |
 | `cold-sqp` | active-set SQP | nothing | every family |
 | `warm-sqp` | active-set SQP | previous working set + point | every family |
+| `cold-sqp-hom` | active-set SQP, homotopy inner QP | nothing | every family |
+| `warm-sqp-hom` | active-set SQP, homotopy inner QP | previous working set + point | every family |
 | `cold-qp-ipm` | convex QP IPM | nothing | QP families only |
 | `warm-qp-ipm` | convex QP IPM | previous primal-dual point | QP families only |
+
+The `-hom` pair differs from `cold-sqp` / `warm-sqp` in exactly one
+option, `sqp_qp_use_homotopy`: the inner QP's **cold** solve traces the
+§4.2 parametric homotopy — start from the box-only relaxation, tighten
+the row bounds along `t ∈ [0,1]`, jump the working set at each event —
+instead of the conventional phase-1/phase-2 scheme. It is the algorithm
+`pounce-qp` is named for.
 
 Each warm arm is scored against **its own** cold counterpart. That
 pairing is the whole point: `warm-sqp` beating `cold-ipm` would confound
@@ -49,9 +58,9 @@ comparison isolates the warm start.
 
 ## The problems
 
-Eight families, each run at three step sizes (`tiny` ×0.1, `small` ×1,
-`large` ×4 of its natural per-step parameter increment), for 24 rows and
-489 solves per arm. Warm-start payoff is a function of how far the
+Ten families, each run at three step sizes (`tiny` ×0.1, `small` ×1,
+`large` ×4 of its natural per-step parameter increment), for 30 rows and
+615 solves per arm. Warm-start payoff is a function of how far the
 problem moved, so a single step size would measure one point on a curve
 and call it the answer.
 
@@ -59,12 +68,25 @@ and call it the answer.
 |---|--:|--:|---|---|---|
 | `simplex_proj` | 20 | 1 | flipping | objective | convex |
 | `moving_bound_qp` | 40 | 3 | flipping | variable bounds | convex |
-| `degenerate_corner` | 6 | 3 | degenerate (a multiplier passes through zero) | objective | convex |
+| `degenerate_corner` | 6 | 3 | dual degenerate (a multiplier passes through zero) | objective | convex |
+| `redundant_rows` | 6 | 5 | rank-deficient (LICQ fails; duplicated rows) | objective | convex |
+| `degenerate_vertex` | 4 | 12 | primal degenerate (12 rows tight in 4 variables) | objective | convex |
 | `hanging_chain` | 30 | 15 | flipping contacts | mixed | convex |
 | `rosenbrock_ring` | 10 | 1 | one clean activation switch | constraint RHS | nonconvex |
 | `rosenbrock_ring_cycle` | 10 | 1 | switch crossed in both directions | constraint RHS | nonconvex |
 | `double_well_chain` | 12 | 0 | none — empty active set throughout | objective | nonconvex |
 | `nmpc_vanderpol` | 47 | 32 | closed-loop MPC | constraint RHS | nonconvex |
+
+The three degeneracy families cover the three distinct ways an
+active-set QP meets degeneracy, which are not interchangeable:
+`degenerate_corner` fails strict complementarity (a zero multiplier),
+`redundant_rows` fails LICQ (duplicated equality rows throughout, and a
+duplicated inequality pair that activates together partway along the
+path), and `degenerate_vertex` is primally degenerate (12 constraints
+tight at a 4-variable vertex, so the ratio test is a mass of ties —
+the case Harris's two-pass test and GMSW EXPAND exist for). The
+benchmark reports that pounce prunes that vertex's active set to its
+maximal independent subset: `|A|` never exceeds 4 of the 12 tight rows.
 
 The families are deliberately small and analytic. This is a
 *measurement* of warm-start behavior, not a scaling study — the
@@ -88,8 +110,8 @@ Three rules make the arms comparable:
    *worse* optimum than the reference. A warm start that converges
    quickly to the wrong answer is a failure, not a win.
 
-In the run reported below, **every step of every arm passed** — 489
-steps × 4 arms, plus 180 QP-arm steps, with zero correctness failures.
+In the run reported below, **every step of every arm passed** — 30 rows
+× 8 arms, 4920 solves, with zero correctness failures.
 
 ## Results
 
@@ -97,14 +119,14 @@ Run on POUNCE 0.9.0, `tol = 1e-8`, one machine, all 24 rows.
 
 ### Does warm starting pay?
 
-Totals across all 489 steps of all 24 rows:
+Totals across all 615 steps of all 30 rows:
 
 | arm | Σ outer iterations | Σ solve time | incorrect steps |
 |---|--:|--:|--:|
-| `cold-ipm` | 6682 | 3.75 s | 0 |
-| `warm-ipm` | **2156** | 1.73 s | 0 |
-| `cold-sqp` | 3872 | 12.82 s | 0 |
-| `warm-sqp` | **1138** | 3.05 s | 0 |
+| `cold-ipm` | 7796 | 4.18 s | 0 |
+| `warm-ipm` | **2399** | 2.12 s | 0 |
+| `cold-sqp` | 3998 | 13.09 s | 0 |
+| `warm-sqp` | **1261** | 2.99 s | 0 |
 
 Both solvers cut outer iterations by roughly 3×. But for the active-set
 SQP that number badly understates the effect, for a reason worth
@@ -149,9 +171,15 @@ parentheses); `IPM` is the ratio of outer iterations. Higher is better;
 | `degenerate_corner` | tiny | 1.87× (19→1) | 0 | 4.67× | 0 |
 | `degenerate_corner` | small | 1.87× (19→1) | 0 | 3.56× | 0 |
 | `degenerate_corner` | large | 1.92× (26→4) | 0 | 3.08× | 0 |
+| `redundant_rows` | tiny | 2.20× (42→1) | 0 | 5.25× | 0 |
+| `redundant_rows` | small | 3.05× (73→3) | 1 | 4.08× | 0 |
+| `redundant_rows` | large | 5.31× (114→3) | 1 | 3.54× | 0 |
+| `degenerate_vertex` | tiny | 2.16× (46→4) | 1 | 4.05× | 0 |
+| `degenerate_vertex` | small | 2.23× (50→4) | 1 | 3.17× | 0 |
+| `degenerate_vertex` | large | 2.16× (46→4) | 1 | 2.97× | 0 |
 | `hanging_chain` | tiny | 4.00× (57→0) | 0 | 1.25× | 0 |
 | `hanging_chain` | small | 4.84× (99→9) | 0 | 1.54× | 0 |
-| `hanging_chain` | large | 4.19× (237→72) | 1 | **0.85×** | **17** |
+| `hanging_chain` | large | 4.19× (237→72) | 1 | 0.85× | 17 |
 | `rosenbrock_ring` | tiny | 2.37× (30→1) | 0 | 11.37× | 0 |
 | `rosenbrock_ring` | small | 2.48× (33→1) | 0 | 8.75× | 0 |
 | `rosenbrock_ring` | large | 2.16× (30→1) | 0 | 6.73× | 0 |
@@ -200,9 +228,51 @@ Two rows show it, both at the largest step size:
 This is why the benchmark reports regressions per step rather than only
 a mean. A single averaged speedup would hide both.
 
+### The parametric homotopy: a sharply mixed trade
+
+The `-hom` arms differ from their twins in one option, so the delta is
+the homotopy alone. Comparing inner QP active-set work on the **cold**
+arms, where the homotopy actually engages (warm inner QPs mostly skip
+the cold path):
+
+| family | conventional → homotopy, cold inner work | ratio across the three scales |
+|---|--:|--:|
+| `simplex_proj` | 978 → 1400 | 0.63–0.74× |
+| `moving_bound_qp` | 793 → 685 | 0.87–2.75× |
+| `degenerate_corner` | 69 → 30 | 2.00–2.90× |
+| `redundant_rows` | 247 → 30 | 4.20–12.30× |
+| `degenerate_vertex` | 154 → 132 | 1.09–1.26× |
+| `hanging_chain` | 402 → 402 | 1.00× |
+| `rosenbrock_ring` | 98 → 98 | 1.00× |
+| `rosenbrock_ring_cycle` | 97 → 97 | 1.00× |
+| `double_well_chain` | 0 → 0 | — (no inner QP work at all) |
+| `nmpc_vanderpol` | 2745 → 5115 | 0.52–0.55× |
+| **all 30 rows** | **5583 → 7989** | **0.70×** |
+
+Above 1.00× the homotopy did less work. The split is not random — it
+tracks exactly what the homotopy was built for:
+
+- **It wins on degenerate geometry.** `redundant_rows`, whose active
+  set is linearly dependent, is its best case by a wide margin, and it
+  improves with perturbation size (4.2× → 12.3× from `tiny` to
+  `large`) because the conventional cold solve degrades there while the
+  homotopy does not. `degenerate_corner` and `degenerate_vertex` follow
+  the same pattern. This is the netlib-like geometry #412 reported it
+  gaining 20 problems on.
+- **It loses on well-conditioned MPC-shaped QPs.** `nmpc_vanderpol`
+  costs about twice the inner work with the homotopy on, consistently
+  across scales, and `simplex_proj` costs ~1.4×.
+- **It is inert on four families** — exactly 1.00×, because their inner
+  QPs never take the cold path far enough for it to matter.
+
+Net over all 30 rows it does *more* inner work (0.70×), because the two
+losers are also the two largest problems. That is an argument for
+keeping it off by default on the SQP path and reaching for it on
+degenerate models, which is what the option now allows.
+
 ### Three-way: which solver for a sequence of QPs?
 
-Three families are literally convex QPs, so all three solvers can take
+Five families are literally convex QPs, so all three solvers can take
 them. Interior-point iterations and active-set pivots are not the same
 unit of work, so the like-for-like column is each solver against itself:
 
@@ -222,11 +292,13 @@ Geometric-mean wall time over those nine rows:
 
 | cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
 |--:|--:|--:|--:|--:|--:|
-| 97.1 ms | 72.8 ms | 75.9 ms | 48.5 ms | 37.3 ms | **35.8 ms** |
+| 98.9 ms | 64.3 ms | 72.4 ms | 50.9 ms | 36.1 ms | **34.9 ms** |
 
-The dedicated convex solver is fastest on 6 of the 9 rows, with the
-active-set SQP taking the other 3 — the rows where the active set churns
-hardest. Note that this ranking is recent: before
+The dedicated convex solver is fastest on 8 of the 15 rows and the
+active-set SQP on the other 7, with the SQP taking the rows where the
+active set churns hardest. The two are within 4% of each other on the
+aggregate — on a problem that really is a QP, either warm-started path
+is a reasonable default. Note that this ranking is recent: before
 [#417](https://github.com/jkitchin/pounce/issues/417) was fixed the
 convex solver's warm start was capped at 1.2–1.5× and `warm-sqp` led 8
 of 9 rows.
@@ -246,6 +318,11 @@ of 9 rows.
 - **When each step moves the problem a long way** — check whether warm
   starting is helping at all. It can cost more than a cold solve, and
   the IPM path is more exposed to this than the SQP path.
+- **On degenerate models — dependent rows, vertices where many
+  constraints meet — try `sqp_qp_use_homotopy`.** It cuts inner
+  active-set work by 2–12× on the degeneracy families and is the
+  algorithm the active-set engine was designed around. Leave it off for
+  MPC-shaped problems, where it roughly doubles the work.
 - **Always verify.** A fast wrong answer is the failure mode that
   matters, which is why the harness re-checks KKT residuals and
   objectives itself rather than trusting a status code.
@@ -266,6 +343,7 @@ Hessian, nothing active) that no other suite exercised:
 | [#416](https://github.com/jkitchin/pounce/issues/416) | Exact-Hessian SQP spent its entire inner-QP iteration budget making **zero** working-set changes; a budget of 20 gave bit-identical answers ~9× faster. Fixed in #419. |
 | [#423](https://github.com/jkitchin/pounce/issues/423) | The #416 fix regressed unconstrained problems: with nothing able to block a negative-curvature direction, the solve died at iteration 1. Caught by `double_well_chain` on its first run against the new build. Fixed in #424. |
 | [#417](https://github.com/jkitchin/pounce/issues/417) | The convex QP warm start left ~40% of its iterations unclaimed — not from the seeding but from a fraction-to-boundary parameter pinned at 0.95. Fixed in #422. |
+| `sqp_qp_use_homotopy` was a no-op | Found while adding the `-hom` arms: the option was *registered* but `apply_qp_subproblem_options` never read it, so setting it on the SQP path did nothing while its documentation described what it would do. The inverse of #360 (read-but-unregistered), and invisible to that issue's guard, which only checked one direction. Fixed here, with a bidirectional guard. |
 
 ## Running it
 

--- a/docs/src/warm-start-benchmark.md
+++ b/docs/src/warm-start-benchmark.md
@@ -58,9 +58,10 @@ comparison isolates the warm start.
 
 ## The problems
 
-Fourteen families, each run at three step sizes (`tiny` ×0.1, `small`
-×1, `large` ×4 of its natural per-step parameter increment), for 42 rows
-and 855 solves per arm. Warm-start payoff is a function of how far the
+Fourteen families in the default sweep, each run at three step sizes
+(`tiny` ×0.1, `small` ×1, `large` ×4 of its natural per-step parameter
+increment), for 42 rows and 855 solves per arm, plus three more in an
+opt-in large tier. Warm-start payoff is a function of how far the
 problem moved, so a single step size would measure one point on a curve
 and call it the answer.
 
@@ -81,11 +82,26 @@ and call it the answer.
 | `mpc_horizon_40` | 122 | 82 | control saturation | constraint RHS | convex |
 | `mpc_horizon_80` | 242 | 162 | control saturation | constraint RHS | convex |
 
-The four `mpc_horizon_*` families are **the same linear-quadratic MPC
-problem at four horizons** — only `N` differs, so reading down them
+plus an **opt-in large tier** (`--tier large`), the same MPC carried out
+to a scale where the sparse factorization is what the cost is made of:
+
+| family | n | m | nnz(J) |
+|---|--:|--:|--:|
+| `mpc_horizon_200` | 602 | 402 | 1402 |
+| `mpc_horizon_400` | 1202 | 802 | 2802 |
+| `mpc_horizon_800` | 2402 | 1602 | 5602 |
+
+The seven `mpc_horizon_*` families are **the same linear-quadratic MPC
+problem at seven horizons** — only `N` differs, so reading down them
 isolates problem size from every other property. The parameter walks the
 initial state around a circle, which keeps every step about as hard as
-the last while rotating the set of saturated controls.
+the last while rotating the set of saturated controls. Nothing dense is
+ever built for them: they declare their block-banded Jacobian and
+diagonal Hessian structurally, and the convex-QP arm receives sparse
+matrices, because at N = 800 a dense Hessian alone would be 46 MB
+rebuilt every iteration and passing dense data to the QP solver is
+60–80× slower by its own diagnostic — which would have made the QP arm
+look bad for a reason that has nothing to do with the QP arm.
 
 The three degeneracy families cover the three distinct ways an
 active-set QP meets degeneracy, which are not interchangeable:
@@ -295,6 +311,70 @@ inequalities". The measured crossover is much earlier than that
 suggests: on this problem it is tens to low hundreds of active
 constraints, not thousands.
 
+### At large scale, the SQP warm start falls off a cliff
+
+Running the same MPC out to n = 2402 turned that gradual degradation
+into something else entirely, and found a defect
+([#428](https://github.com/jkitchin/pounce/issues/428)) that the small
+families could not see.
+
+At default settings the warm-started SQP **does not produce an answer**
+on the large tier: `warm-sqp` and `warm-sqp-hom` return
+`Maximum_Iterations_Exceeded` with zero outer iterations on 7 of 8 steps
+at every one of N = 200/400/800, leaving `x` at the warm-start point.
+`cold-sqp`, both IPM arms and both convex-QP arms solve all 8 cleanly.
+
+Raising the inner-QP budget until nothing truncates shows why. Inner
+working-set changes for one step, cold against warm:
+
+| N | n | m | cold | warm | warm, hint admitted |
+|--:|--:|--:|--:|--:|--:|
+| 10 | 32 | 22 | 11 | 0 | 0 |
+| 20 | 62 | 42 | 25 | 43 | 0 |
+| 40 | 122 | 82 | 48 | 1 | 1 |
+| 80 | 242 | 162 | 66 | 164 | 2 |
+| 200 | 602 | 402 | 66 | **403** | 2 |
+| 400 | 1202 | 802 | 66 | **795** | 2 |
+| 800 | 2402 | 1602 | 66 | **1589** | 2 |
+
+Cold is constant at 66 — the cold solve does not care about the horizon
+at all. The warm arm is **Θ(m)**. And the last column is what the warm
+start *should* cost: a constant 2 pivots, reaching the same optimum to
+1e-11.
+
+The cause is not a gradual erosion. It is a step function in how far the
+problem moved (N = 200):
+
+| Δφ | entries of the true active set that changed | warm pivots |
+|--:|--:|--:|
+| 0.002 | 0 | **0** |
+| 0.005 | 0 | **0** |
+| 0.01 | 1 | **400** |
+| 0.02 | 2 | **401** |
+| 0.05 | 4 | **403** |
+
+Zero changes gives a flawless warm start at every size. *One* change
+costs the full m-sized penalty. The mechanism is an admission check:
+`solve_with_working_set` pins the hinted rows to their new boundaries,
+and when the active set has moved that pinned point violates some other
+row by roughly the distance the parameter moved. A feasibility
+pre-check in `solve` then routes the whole thing to elastic phase-1,
+whose recovery re-solve starts from a *cold* working set — so every row
+is re-added from scratch. The hint is not repaired, it is discarded.
+
+Two things follow for reading the rest of this page. The horizon sweep's
+"warm starting turns harmful above N = 20 at large steps" is now known
+to be **this defect**, not an intrinsic property of active-set warm
+starts — the same rows solve in 2 pivots once the hint is admitted. And
+the earlier rule that payoff tracks *absolute* churn holds for the IPM
+arms but understates the SQP's cliff, which is triggered by the first
+changed entry and indifferent to the rest.
+
+Until #428 is fixed: on a large problem whose active set moves between
+solves, use an interior-point path. The convex QP IPM warm start is
+0.44–0.49× cold across the whole large tier, and the NLP IPM 0.47–0.53×
+— both entirely unbothered by scale.
+
 ### The parametric homotopy: a sharply mixed trade
 
 The `-hom` arms differ from their twins in one option, so the delta is
@@ -384,6 +464,13 @@ of 9 rows.
   churn, which grows with problem size. On the horizon sweep it turned
   negative between N = 10 and N = 20 for large parameter steps, and the
   interior-point paths were the safer choice there.
+- **Above a few hundred constraints, do not warm-start the SQP across a
+  step that moves the active set** until
+  [#428](https://github.com/jkitchin/pounce/issues/428) is fixed. The
+  hint is discarded rather than repaired, at a cost of one inner pivot
+  per constraint row — on the large tier that means no answer at all at
+  the default inner-QP budget. An interior-point path is the safe
+  choice at that scale, and is flat in the horizon.
 - **For a problem with no active set to speak of** — unconstrained, or
   with constraints that never bind — the warm start still helps, but
   only through the primal point. Either solver is fine; the working set
@@ -416,6 +503,7 @@ Hessian, nothing active) that no other suite exercised:
 | [#416](https://github.com/jkitchin/pounce/issues/416) | Exact-Hessian SQP spent its entire inner-QP iteration budget making **zero** working-set changes; a budget of 20 gave bit-identical answers ~9× faster. Fixed in #419. |
 | [#423](https://github.com/jkitchin/pounce/issues/423) | The #416 fix regressed unconstrained problems: with nothing able to block a negative-curvature direction, the solve died at iteration 1. Caught by `double_well_chain` on its first run against the new build. Fixed in #424. |
 | [#417](https://github.com/jkitchin/pounce/issues/417) | The convex QP warm start left ~40% of its iterations unclaimed — not from the seeding but from a fraction-to-boundary parameter pinned at 0.95. Fixed in #422. |
+| [#428](https://github.com/jkitchin/pounce/issues/428) | **Open.** The SQP's working-set hint is discarded — not repaired — the moment the active set moves by one entry, costing one inner pivot per constraint row. Invisible below N ≈ 80; at n ≥ 602 it stops the warm-started solve from returning an answer. Found by the large tier on its first run. |
 | `sqp_qp_use_homotopy` was a no-op | Found while adding the `-hom` arms: the option was *registered* but `apply_qp_subproblem_options` never read it, so setting it on the SQP path did nothing while its documentation described what it would do. The inverse of #360 (read-but-unregistered), and invisible to that issue's guard, which only checked one direction. Fixed here, with a bidirectional guard. |
 
 ## Running it
@@ -440,7 +528,11 @@ or, for a narrower run:
 ```sh
 python -m warmstart.run --families simplex_proj,nmpc_vanderpol --scales large -v
 python -m warmstart.run --arms cold-sqp,warm-sqp --tol 1e-10
+python -m warmstart.run --tier large --scales small   # n = 602 → 2402
 ```
+
+`--tier large` is opt-in because a single active-set solve there takes
+seconds; `--tier all` runs both.
 
 Results land in `benchmarks/warmstart/results.json` (every step of every
 arm) and `results.md`. Both are regenerated per run and gitignored.
@@ -453,9 +545,15 @@ protocol are reusable against any solver with a warm-start API.
 ## Limits of these numbers
 
 - **Mostly small problems** (n ≤ 47 outside the horizon sweep, which
-  reaches n = 242). The sweep gives one scaling curve on one problem
-  shape; it is not a substitute for a large-scale study, and the
+  reaches n = 242 by default and n = 2402 with `--tier large`). The
+  sweep gives one scaling curve on one problem shape; it is not a
+  substitute for a large-scale study across problem classes, and the
   crossover it reports is specific to this MPC.
+- **The large tier is one problem class.** Linear-quadratic MPC has a
+  particular structure — banded, mostly equalities, a large active set
+  that barely moves — and #428 was found there. Whether the same cliff
+  dominates on a large problem with a different sparsity pattern is
+  untested.
 - **Wall time carries Python callback overhead** for the four
   callback-driven arms. Iteration and active-set-change counts are the
   primary measurements; times are a cross-check, and vary 10–30% between

--- a/docs/src/warm-start-benchmark.md
+++ b/docs/src/warm-start-benchmark.md
@@ -152,14 +152,14 @@ Totals across all 855 steps of all 42 rows:
 
 | arm | Σ outer iterations | Σ solve time | incorrect steps |
 |---|--:|--:|--:|
-| `cold-ipm` | 10288 | 5.97 s | 0 |
-| `warm-ipm` | **3628** | 3.17 s | 0 |
-| `cold-sqp` | 4238 | 26.01 s | 0 |
-| `warm-sqp` | **1501** | 3.11 s | 0 |
+| `cold-ipm` | 10288 | 7.71 s | 0 |
+| `warm-ipm` | **3628** | 3.55 s | 0 |
+| `cold-sqp` | 4238 | 30.31 s | 0 |
+| `warm-sqp` | **1501** | 3.46 s | 0 |
 
 Both solvers cut outer iterations by roughly 3×. But for the active-set
 SQP that number badly understates the effect — its wall time falls by
-8.4× on the same iteration count — for a reason worth understanding
+8.8× on the same iteration count — for a reason worth understanding
 before reading any further.
 
 ### The metric trap: outer iterations hide the SQP's warm start
@@ -367,13 +367,13 @@ fastest thing on the board:
 
 | N | n | `warm-sqp` wall vs its cold twin | `warm-ipm` | `warm-qp-ipm` |
 |--:|--:|--:|--:|--:|
-| 200 | 602 | **0.03** | 0.50 | 0.51 |
-| 400 | 1202 | **0.03** | 0.48 | 0.49 |
-| 800 | 2402 | **0.02** | 0.48 | 0.51 |
+| 200 | 602 | **0.03** | 0.58 | 0.48 |
+| 400 | 1202 | **0.03** | 0.57 | 0.54 |
+| 800 | 2402 | **0.02** | 0.41 | 0.50 |
 
 Inner active-set work drops 514 → 11 per path (46.7×) identically at all
-three horizons. At n = 2402 a warm-started SQP sweep takes 1.36 s
-against 12.04 s cold.
+three horizons. At n = 2402 a warm-started SQP sweep takes 1.34 s
+against 12.12 s cold.
 
 This also revises the caveat in
 [Active-Set SQP & Warm Starts](active-set-sqp.md) about preferring the
@@ -453,11 +453,11 @@ Geometric-mean wall time over those fifteen rows:
 
 | cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
 |--:|--:|--:|--:|--:|--:|
-| 90.8 ms | 58.7 ms | 66.5 ms | 45.8 ms | 30.3 ms | **30.1 ms** |
+| 99.1 ms | 62.5 ms | 61.6 ms | 50.1 ms | 30.9 ms | **29.5 ms** |
 
 The dedicated convex solver is fastest on 9 of the 15 rows and the
 active-set SQP on the other 6, with the SQP taking the rows where the
-active set churns hardest. The two are within 1% of each other on the
+active set churns hardest. The two are within 5% of each other on the
 aggregate — on a problem that really is a QP, either warm-started path
 is a reasonable default. Note that this ranking is recent: before
 [#417](https://github.com/jkitchin/pounce/issues/417) was fixed the

--- a/docs/src/warm-start-benchmark.md
+++ b/docs/src/warm-start-benchmark.md
@@ -58,9 +58,9 @@ comparison isolates the warm start.
 
 ## The problems
 
-Ten families, each run at three step sizes (`tiny` ×0.1, `small` ×1,
-`large` ×4 of its natural per-step parameter increment), for 30 rows and
-615 solves per arm. Warm-start payoff is a function of how far the
+Fourteen families, each run at three step sizes (`tiny` ×0.1, `small`
+×1, `large` ×4 of its natural per-step parameter increment), for 42 rows
+and 855 solves per arm. Warm-start payoff is a function of how far the
 problem moved, so a single step size would measure one point on a curve
 and call it the answer.
 
@@ -76,6 +76,16 @@ and call it the answer.
 | `rosenbrock_ring_cycle` | 10 | 1 | switch crossed in both directions | constraint RHS | nonconvex |
 | `double_well_chain` | 12 | 0 | none — empty active set throughout | objective | nonconvex |
 | `nmpc_vanderpol` | 47 | 32 | closed-loop MPC | constraint RHS | nonconvex |
+| `mpc_horizon_10` | 32 | 22 | control saturation | constraint RHS | convex |
+| `mpc_horizon_20` | 62 | 42 | control saturation | constraint RHS | convex |
+| `mpc_horizon_40` | 122 | 82 | control saturation | constraint RHS | convex |
+| `mpc_horizon_80` | 242 | 162 | control saturation | constraint RHS | convex |
+
+The four `mpc_horizon_*` families are **the same linear-quadratic MPC
+problem at four horizons** — only `N` differs, so reading down them
+isolates problem size from every other property. The parameter walks the
+initial state around a circle, which keeps every step about as hard as
+the last while rotating the set of saturated controls.
 
 The three degeneracy families cover the three distinct ways an
 active-set QP meets degeneracy, which are not interchangeable:
@@ -88,10 +98,9 @@ the case Harris's two-pass test and GMSW EXPAND exist for). The
 benchmark reports that pounce prunes that vertex's active set to its
 maximal independent subset: `|A|` never exceeds 4 of the 12 tight rows.
 
-The families are deliberately small and analytic. This is a
-*measurement* of warm-start behavior, not a scaling study — the
-conclusions about which solver to use transfer; the absolute timings do
-not.
+Apart from the horizon sweep, the families are deliberately small and
+analytic: this is a measurement of warm-start *behavior*, and small
+problems measure it cleanly.
 
 ## How a result is produced
 
@@ -110,23 +119,23 @@ Three rules make the arms comparable:
    *worse* optimum than the reference. A warm start that converges
    quickly to the wrong answer is a failure, not a win.
 
-In the run reported below, **every step of every arm passed** — 30 rows
-× 8 arms, 4920 solves, with zero correctness failures.
+In the run reported below, **every step of every arm passed** — 42 rows
+× 8 arms, 6840 solves, with zero correctness failures.
 
 ## Results
 
-Run on POUNCE 0.9.0, `tol = 1e-8`, one machine, all 24 rows.
+Run on POUNCE 0.9.0, `tol = 1e-8`, one machine, all 42 rows.
 
 ### Does warm starting pay?
 
-Totals across all 615 steps of all 30 rows:
+Totals across all 855 steps of all 42 rows:
 
 | arm | Σ outer iterations | Σ solve time | incorrect steps |
 |---|--:|--:|--:|
-| `cold-ipm` | 7796 | 4.18 s | 0 |
-| `warm-ipm` | **2399** | 2.12 s | 0 |
-| `cold-sqp` | 3998 | 13.09 s | 0 |
-| `warm-sqp` | **1261** | 2.99 s | 0 |
+| `cold-ipm` | 10288 | 6.40 s | 0 |
+| `warm-ipm` | **3628** | 3.30 s | 0 |
+| `cold-sqp` | 4238 | 29.38 s | 0 |
+| `warm-sqp` | **1501** | 21.82 s | 0 |
 
 Both solvers cut outer iterations by roughly 3×. But for the active-set
 SQP that number badly understates the effect, for a reason worth
@@ -228,6 +237,64 @@ Two rows show it, both at the largest step size:
 This is why the benchmark reports regressions per step rather than only
 a mean. A single averaged speedup would hide both.
 
+### How it scales: the MPC horizon sweep
+
+The same linear MPC at four horizons, warm/cold **wall-time ratio** —
+below 1.00 means warm starting won, above it means warm starting cost
+more than solving cold:
+
+| N | n | mean &#124;A&#124; | `tiny` SQP / IPM | `small` SQP / IPM | `large` SQP / IPM |
+|--:|--:|--:|--:|--:|--:|
+| 10 | 32 | 31.5 | **0.27** / 0.41 | 0.38 / 0.49 | 0.84 / 0.78 |
+| 20 | 62 | 61.0 | **0.22** / 0.40 | 0.91 / 0.58 | 1.29 / 0.76 |
+| 40 | 122 | 119.6 | **0.08** / 0.28 | 0.66 / 0.55 | 1.95 / 1.00 |
+| 80 | 242 | 206.0 | **0.31** / 0.25 | 1.06 / 0.54 | **2.57** / 0.88 |
+
+The result is two-dimensional, and reading it as "the SQP loses at
+scale" would be wrong:
+
+- **At `tiny` perturbations the SQP warm start stays excellent at every
+  horizon** — its best row in the whole suite is N = 40 at 0.08, twelve
+  times faster than cold. A nearly-unchanged active set is nearly-exact
+  information no matter how large it is.
+- **At `large` perturbations it degrades monotonically with N and turns
+  harmful**: 0.84 → 1.29 → 1.95 → 2.57. At N = 80 the warm-started SQP
+  takes **2.6× longer than solving cold**.
+- **The interior-point arms barely care.** The NLP IPM stays between
+  0.25 and 1.00 across the whole grid, and the convex QP IPM is flatter
+  still (0.48 → 0.55 as N goes 10 → 80).
+
+The mechanism is visible in the working sets. The *fraction* of the
+active set that changes per step is essentially horizon-independent —
+about 3% at `large` for every N, by construction, since the same
+angular perturbation moves proportionally the same constraints:
+
+| N | mean &#124;A&#124; | churn/step at `large` | as a fraction |
+|--:|--:|--:|--:|
+| 10 | 31.5 | 1.05 | 3.3% |
+| 20 | 61.0 | 2.26 | 3.7% |
+| 40 | 119.6 | 4.21 | 3.5% |
+| 80 | 206.0 | 5.58 | 2.7% |
+
+But an active-set method pays for the **absolute** number of changes,
+not the fraction — and that grows with the problem, while each change
+also costs more as the active set grows. Two multiplying factors, which
+is why the ratio degrades faster than either alone.
+
+So the practical rule from earlier — *payoff tracks active-set churn* —
+needs sharpening: it tracks **absolute** churn, and problem size
+inflates absolute churn even when the perturbation is proportionally
+identical. For this problem the crossover where warm-started SQP stops
+beating cold sits between N = 10 and N = 20 at `large` steps, and above
+N = 80 at `small` ones.
+
+This is the quantitative version of the caveat in
+[Active-Set SQP & Warm Starts](active-set-sqp.md), which says to prefer
+the IPM for "large-scale problems with thousands of active
+inequalities". The measured crossover is much earlier than that
+suggests: on this problem it is tens to low hundreds of active
+constraints, not thousands.
+
 ### The parametric homotopy: a sharply mixed trade
 
 The `-hom` arms differ from their twins in one option, so the delta is
@@ -309,8 +376,14 @@ of 9 rows.
   previous result. It leads on most rows and needs no callbacks.
 - **For a general NLP whose active set is stable between solves** —
   `algorithm = active-set-sqp` carrying the working set. This is where
-  the largest effects live (up to 30× less inner active-set work), and
+  the largest effects live (up to 30× less inner active-set work, and a
+  12× wall-time win on the largest horizon at small perturbations), and
   the whole reason the active-set path exists.
+- **Check the crossover if your problem is large *and* moves a lot.**
+  The SQP's warm-start advantage is eroded by absolute working-set
+  churn, which grows with problem size. On the horizon sweep it turned
+  negative between N = 10 and N = 20 for large parameter steps, and the
+  interior-point paths were the safer choice there.
 - **For a problem with no active set to speak of** — unconstrained, or
   with constraints that never bind — the warm start still helps, but
   only through the primal point. Either solver is fine; the working set
@@ -379,10 +452,10 @@ protocol are reusable against any solver with a warm-start API.
 
 ## Limits of these numbers
 
-- **Small problems by design** (n ≤ 47). The rankings reflect algorithm
-  behavior, not scaling; per-iteration costs shift with size, and the
-  active-set path is documented to lose ground when the active set grows
-  into the thousands.
+- **Mostly small problems** (n ≤ 47 outside the horizon sweep, which
+  reaches n = 242). The sweep gives one scaling curve on one problem
+  shape; it is not a substitute for a large-scale study, and the
+  crossover it reports is specific to this MPC.
 - **Wall time carries Python callback overhead** for the four
   callback-driven arms. Iteration and active-set-change counts are the
   primary measurements; times are a cross-check, and vary 10–30% between

--- a/docs/src/warm-start-benchmark.md
+++ b/docs/src/warm-start-benchmark.md
@@ -135,12 +135,16 @@ Three rules make the arms comparable:
    *worse* optimum than the reference. A warm start that converges
    quickly to the wrong answer is a failure, not a win.
 
-In the run reported below, **every step of every arm passed** — 42 rows
-× 8 arms, 6840 solves, with zero correctness failures.
+In the run reported below, **every step of every arm passed** — 42 rows,
+6228 solves (855 steps for each of the six callback arms, 549 for the
+two QP-only ones), with zero correctness failures.
 
 ## Results
 
-Run on POUNCE 0.9.0, `tol = 1e-8`, one machine, all 42 rows.
+Run on POUNCE 0.9.0, `tol = 1e-8`, one machine, all 42 rows, on a build
+that includes the fix for
+[#428](https://github.com/jkitchin/pounce/issues/428) — which this suite
+found and which moved most of the SQP numbers below.
 
 ### Does warm starting pay?
 
@@ -148,14 +152,15 @@ Totals across all 855 steps of all 42 rows:
 
 | arm | Σ outer iterations | Σ solve time | incorrect steps |
 |---|--:|--:|--:|
-| `cold-ipm` | 10288 | 6.40 s | 0 |
-| `warm-ipm` | **3628** | 3.30 s | 0 |
-| `cold-sqp` | 4238 | 29.38 s | 0 |
-| `warm-sqp` | **1501** | 21.82 s | 0 |
+| `cold-ipm` | 10288 | 5.97 s | 0 |
+| `warm-ipm` | **3628** | 3.17 s | 0 |
+| `cold-sqp` | 4238 | 26.01 s | 0 |
+| `warm-sqp` | **1501** | 3.11 s | 0 |
 
 Both solvers cut outer iterations by roughly 3×. But for the active-set
-SQP that number badly understates the effect, for a reason worth
-understanding before reading any further.
+SQP that number badly understates the effect — its wall time falls by
+8.4× on the same iteration count — for a reason worth understanding
+before reading any further.
 
 ### The metric trap: outer iterations hide the SQP's warm start
 
@@ -188,35 +193,38 @@ parentheses); `IPM` is the ratio of outer iterations. Higher is better;
 | family | scale | SQP cold→warm | worse | IPM cold→warm | worse |
 |---|---|--:|--:|--:|--:|
 | `simplex_proj` | tiny | 16.00× (285→0) | 0 | 5.05× | 0 |
-| `simplex_proj` | small | 15.55× (313→4) | 0 | 4.42× | 0 |
-| `simplex_proj` | large | 15.09× (335→7) | 0 | 4.17× | 0 |
-| `moving_bound_qp` | tiny | 6.00× (104→3) | 0 | 5.01× | 0 |
-| `moving_bound_qp` | small | 6.10× (207→29) | 0 | 2.00× | 0 |
-| `moving_bound_qp` | large | 4.99× (467→104) | 0 | 1.93× | 0 |
+| `simplex_proj` | small | 17.46× (313→0) | 0 | 4.42× | 0 |
+| `simplex_proj` | large | 18.62× (335→0) | 0 | 4.17× | 0 |
+| `moving_bound_qp` | tiny | 6.45× (104→0) | 0 | 5.01× | 0 |
+| `moving_bound_qp` | small | 11.53× (207→0) | 0 | 2.00× | 0 |
+| `moving_bound_qp` | large | 13.74× (467→19) | 0 | 1.93× | 0 |
 | `degenerate_corner` | tiny | 1.87× (19→1) | 0 | 4.67× | 0 |
 | `degenerate_corner` | small | 1.87× (19→1) | 0 | 3.56× | 0 |
-| `degenerate_corner` | large | 1.92× (26→4) | 0 | 3.08× | 0 |
-| `redundant_rows` | tiny | 2.20× (42→1) | 0 | 5.25× | 0 |
-| `redundant_rows` | small | 3.05× (73→3) | 1 | 4.08× | 0 |
-| `redundant_rows` | large | 5.31× (114→3) | 1 | 3.54× | 0 |
+| `degenerate_corner` | large | 1.98× (26→3) | 0 | 3.08× | 0 |
+| `redundant_rows` | tiny | 2.27× (42→0) | 0 | 5.25× | 0 |
+| `redundant_rows` | small | 3.16× (73→2) | 1 | 4.08× | 0 |
+| `redundant_rows` | large | 5.50× (114→2) | 1 | 3.54× | 0 |
 | `degenerate_vertex` | tiny | 2.16× (46→4) | 1 | 4.05× | 0 |
 | `degenerate_vertex` | small | 2.23× (50→4) | 1 | 3.17× | 0 |
 | `degenerate_vertex` | large | 2.16× (46→4) | 1 | 2.97× | 0 |
 | `hanging_chain` | tiny | 4.00× (57→0) | 0 | 1.25× | 0 |
-| `hanging_chain` | small | 4.84× (99→9) | 0 | 1.54× | 0 |
-| `hanging_chain` | large | 4.19× (237→72) | 1 | 0.85× | 17 |
+| `hanging_chain` | small | 4.44× (67→0) | 0 | 1.54× | 0 |
+| `hanging_chain` | large | 6.84× (124→1) | 0 | 0.85× | 17 |
 | `rosenbrock_ring` | tiny | 2.37× (30→1) | 0 | 11.37× | 0 |
-| `rosenbrock_ring` | small | 2.48× (33→1) | 0 | 8.75× | 0 |
-| `rosenbrock_ring` | large | 2.16× (30→1) | 0 | 6.73× | 0 |
-| `rosenbrock_ring_cycle` | tiny | 2.24× (29→2) | 0 | 9.16× | 0 |
-| `rosenbrock_ring_cycle` | small | 2.47× (35→2) | 0 | 8.62× | 0 |
-| `rosenbrock_ring_cycle` | large | 1.76× (30→8) | 0 | 6.14× | 0 |
+| `rosenbrock_ring` | small | 2.26× (28→1) | 0 | 8.75× | 0 |
+| `rosenbrock_ring` | large | 1.72× (18→1) | 0 | 6.73× | 0 |
+| `rosenbrock_ring_cycle` | tiny | 2.32× (29→1) | 0 | 9.16× | 0 |
+| `rosenbrock_ring_cycle` | small | 2.25× (28→1) | 0 | 8.62× | 0 |
+| `rosenbrock_ring_cycle` | large | 1.52× (17→4) | 0 | 6.14× | 0 |
 | `double_well_chain` | tiny | 1.00× (0→0) | 0 | 3.00× | 0 |
 | `double_well_chain` | small | 1.00× (0→0) | 0 | 2.29× | 0 |
 | `double_well_chain` | large | 1.00× (0→0) | 0 | 2.14× | 0 |
-| `nmpc_vanderpol` | tiny | 30.29× (931→66) | 0 | 3.63× | 0 |
-| `nmpc_vanderpol` | small | 7.76× (781→294) | 0 | 1.96× | 0 |
-| `nmpc_vanderpol` | large | 2.21× (868→693) | 8 | 1.05× | 8 |
+| `nmpc_vanderpol` | tiny | 18.80× (366→2) | 0 | 3.63× | 0 |
+| `nmpc_vanderpol` | small | 12.55× (348→14) | 0 | 1.96× | 0 |
+| `nmpc_vanderpol` | large | 7.33× (425→72) | 0 | 1.05× | 8 |
+| `mpc_horizon_80` | tiny | 54.75× (1105→2) | 0 | 5.17× | 0 |
+| `mpc_horizon_80` | small | 42.98× (1552→21) | 0 | 2.23× | 0 |
+| `mpc_horizon_80` | large | 8.21× (1176→123) | 0 | 1.12× | 3 |
 
 ### Payoff tracks active-set churn, not problem size
 
@@ -227,15 +235,19 @@ steps.
 
 | family | churn/step at tiny → large | SQP payoff at tiny → large |
 |---|---|---|
-| `nmpc_vanderpol` | 0.21 → 2.95 | 30.3× → 2.2× |
-| `moving_bound_qp` | 0.05 → 1.63 | 6.0× → 5.0× |
-| `hanging_chain` | 0.00 → 0.47 | 4.0× → 4.2× |
-| `simplex_proj` | 0.00 → 0.21 | 16.0× → 15.1× |
+| `nmpc_vanderpol` | 0.21 → 2.95 | 18.8× → 7.3× |
+| `mpc_horizon_80` | 0.21 → 5.58 | 54.8× → 8.2× |
+| `moving_bound_qp` | 0.05 → 1.63 | 6.5× → 13.7× |
+| `hanging_chain` | 0.00 → 0.47 | 4.0× → 6.8× |
+| `simplex_proj` | 0.00 → 0.21 | 16.0× → 18.6× |
 
-`nmpc_vanderpol` is the clearest case: a 14× increase in churn costs a
-14× reduction in payoff. This is the practical rule — **warm starting
-pays in proportion to how stable your active set is**, and problem size
-has little to do with it.
+The two MPC families are the clearest cases: a 14× and 27× increase in
+churn costs a 2.6× and 6.7× reduction in payoff. This is the practical
+rule — **warm starting pays in proportion to how stable your active set
+is**, and problem size has little to do with it. (The families at the
+bottom, whose churn stays below one entry per step even at `large`,
+show the opposite sign: there the warm start stays essentially exact
+while the cold solve gets harder, so the ratio rises.)
 
 ### Warm starting can make things worse
 
@@ -246,9 +258,11 @@ Two rows show it, both at the largest step size:
   previous solution sits exactly on the constraint boundary, which is
   the worst possible starting point for a barrier method when the
   active set has since moved.
-- `nmpc_vanderpol @ large`: 8 of 19 steps worse for both warm arms,
-  where a 4× control interval makes the plant state jump far enough
-  that the carried working set is a poor guess.
+- `nmpc_vanderpol @ large`, `warm-ipm`: 8 of 19 steps worse, where a 4×
+  control interval makes the plant state jump far enough that the
+  previous point is a poor guess. The SQP arm no longer regresses on
+  this row (it did before #428 was fixed), but its payoff still falls
+  from 18.8× to 7.3× across the same span.
 
 This is why the benchmark reports regressions per step rather than only
 a mean. A single averaged speedup would hide both.
@@ -256,124 +270,116 @@ a mean. A single averaged speedup would hide both.
 ### How it scales: the MPC horizon sweep
 
 The same linear MPC at four horizons, warm/cold **wall-time ratio** —
-below 1.00 means warm starting won, above it means warm starting cost
-more than solving cold:
+below 1.00 means warm starting won:
 
 | N | n | mean &#124;A&#124; | `tiny` SQP / IPM | `small` SQP / IPM | `large` SQP / IPM |
 |--:|--:|--:|--:|--:|--:|
-| 10 | 32 | 31.5 | **0.27** / 0.41 | 0.38 / 0.49 | 0.84 / 0.78 |
-| 20 | 62 | 61.0 | **0.22** / 0.40 | 0.91 / 0.58 | 1.29 / 0.76 |
-| 40 | 122 | 119.6 | **0.08** / 0.28 | 0.66 / 0.55 | 1.95 / 1.00 |
-| 80 | 242 | 206.0 | **0.31** / 0.25 | 1.06 / 0.54 | **2.57** / 0.88 |
+| 10 | 32 | 31.0 | **0.17** / 0.37 | 0.17 / 0.38 | 0.24 / 0.69 |
+| 20 | 62 | 61.2 | **0.08** / 0.37 | 0.09 / 0.70 | 0.12 / 0.74 |
+| 40 | 122 | 118.3 | **0.04** / 0.32 | 0.04 / 0.59 | 0.11 / 0.85 |
+| 80 | 242 | 204.1 | **0.02** / 0.26 | 0.03 / 0.49 | 0.10 / 0.86 |
 
-The result is two-dimensional, and reading it as "the SQP loses at
-scale" would be wrong:
+Read down the SQP columns: the warm start does not merely survive the
+horizon, it **improves with it** — 0.17 → 0.02 at `tiny`, and even at
+the largest perturbation 0.24 → 0.10. At N = 80 a warm-started solve is
+50× faster than a cold one at small steps and still 10× faster at large
+ones. The reason is that cold cost grows with the problem while warm
+cost is set by how far the problem moved, which is a property of the
+path, not of `n`.
 
-- **At `tiny` perturbations the SQP warm start stays excellent at every
-  horizon** — its best row in the whole suite is N = 40 at 0.08, twelve
-  times faster than cold. A nearly-unchanged active set is nearly-exact
-  information no matter how large it is.
-- **At `large` perturbations it degrades monotonically with N and turns
-  harmful**: 0.84 → 1.29 → 1.95 → 2.57. At N = 80 the warm-started SQP
-  takes **2.6× longer than solving cold**.
-- **The interior-point arms barely care.** The NLP IPM stays between
-  0.25 and 1.00 across the whole grid, and the convex QP IPM is flatter
-  still (0.48 → 0.55 as N goes 10 → 80).
+Reading across, the familiar pattern holds: bigger steps cost more
+(0.02 → 0.10 at N = 80), because more of the active set has to change.
 
-The mechanism is visible in the working sets. The *fraction* of the
-active set that changes per step is essentially horizon-independent —
-about 3% at `large` for every N, by construction, since the same
-angular perturbation moves proportionally the same constraints:
+The mechanism is in the working sets. The *fraction* of the active set
+that changes per step is essentially horizon-independent — about 3% at
+`large` for every N, by construction, since the same angular
+perturbation moves proportionally the same constraints:
 
-| N | mean &#124;A&#124; | churn/step at `large` | as a fraction |
-|--:|--:|--:|--:|
-| 10 | 31.5 | 1.05 | 3.3% |
-| 20 | 61.0 | 2.26 | 3.7% |
-| 40 | 119.6 | 4.21 | 3.5% |
-| 80 | 206.0 | 5.58 | 2.7% |
+| N | mean &#124;A&#124; | churn/step at `large` | as a fraction | SQP inner work, cold → warm |
+|--:|--:|--:|--:|--:|
+| 10 | 31.5 | 1.05 | 3.3% | 242 → 14 |
+| 20 | 61.2 | 2.26 | 3.7% | 486 → 41 |
+| 40 | 118.8 | 4.21 | 3.5% | 893 → 76 |
+| 80 | 203.1 | 5.58 | 2.7% | 1176 → 123 |
 
-But an active-set method pays for the **absolute** number of changes,
-not the fraction — and that grows with the problem, while each change
-also costs more as the active set grows. Two multiplying factors, which
-is why the ratio degrades faster than either alone.
+Absolute churn does grow with the problem (1.05 → 5.58 changes per
+step), and the warm arm's inner work grows with it — but the cold arm's
+grows faster, which is why the *ratio* improves. The rule stands as
+first stated: **payoff tracks how much the active set moves, and problem
+size has little to do with it.**
 
-So the practical rule from earlier — *payoff tracks active-set churn* —
-needs sharpening: it tracks **absolute** churn, and problem size
-inflates absolute churn even when the perturbation is proportionally
-identical. For this problem the crossover where warm-started SQP stops
-beating cold sits between N = 10 and N = 20 at `large` steps, and above
-N = 80 at `small` ones.
+An earlier revision of this page reported the opposite — a crossover
+where warm-started SQP turned harmful above N = 20, reaching 2.57× at
+N = 80. That was [#428](https://github.com/jkitchin/pounce/issues/428),
+found by the large tier below and now fixed; the numbers above are the
+same measurement on the fixed solver.
 
-This is the quantitative version of the caveat in
-[Active-Set SQP & Warm Starts](active-set-sqp.md), which says to prefer
-the IPM for "large-scale problems with thousands of active
-inequalities". The measured crossover is much earlier than that
-suggests: on this problem it is tens to low hundreds of active
-constraints, not thousands.
+### At large scale: where the benchmark found a defect
 
-### At large scale, the SQP warm start falls off a cliff
+Carrying the same MPC out to n = 2402 is what exposed #428, and the
+before/after is the clearest single result in the suite.
 
-Running the same MPC out to n = 2402 turned that gradual degradation
-into something else entirely, and found a defect
-([#428](https://github.com/jkitchin/pounce/issues/428)) that the small
-families could not see.
-
-At default settings the warm-started SQP **does not produce an answer**
-on the large tier: `warm-sqp` and `warm-sqp-hom` return
+At default settings the warm-started SQP **did not produce an answer**
+on the large tier: `warm-sqp` and `warm-sqp-hom` returned
 `Maximum_Iterations_Exceeded` with zero outer iterations on 7 of 8 steps
-at every one of N = 200/400/800, leaving `x` at the warm-start point.
-`cold-sqp`, both IPM arms and both convex-QP arms solve all 8 cleanly.
+at every one of N = 200/400/800, leaving `x` at the warm-start point,
+while every other arm solved all 8 cleanly.
 
-Raising the inner-QP budget until nothing truncates shows why. Inner
-working-set changes for one step, cold against warm:
+Inner working-set changes for one step, before and after the fix:
 
-| N | n | m | cold | warm | warm, hint admitted |
+| N | n | m | cold | warm, before | warm, after |
 |--:|--:|--:|--:|--:|--:|
 | 10 | 32 | 22 | 11 | 0 | 0 |
-| 20 | 62 | 42 | 25 | 43 | 0 |
+| 20 | 62 | 42 | 25 | 43 | 1 |
 | 40 | 122 | 82 | 48 | 1 | 1 |
-| 80 | 242 | 162 | 66 | 164 | 2 |
-| 200 | 602 | 402 | 66 | **403** | 2 |
-| 400 | 1202 | 802 | 66 | **795** | 2 |
-| 800 | 2402 | 1602 | 66 | **1589** | 2 |
+| 80 | 242 | 162 | 66 | 164 | 3 |
+| 200 | 602 | 402 | 66 | **403** | 3 |
+| 400 | 1202 | 802 | 66 | **795** | 3 |
+| 800 | 2402 | 1602 | 66 | **1589** | 3 |
 
-Cold is constant at 66 — the cold solve does not care about the horizon
-at all. The warm arm is **Θ(m)**. And the last column is what the warm
-start *should* cost: a constant 2 pivots, reaching the same optimum to
-1e-11.
+The warm arm was **Θ(m)** — 1589 pivots at N = 800, 24× the cost of not
+warm starting at all. It is now flat at 3 across a 75× range of m, at
+the same optimum to 1e-11.
 
-The cause is not a gradual erosion. It is a step function in how far the
-problem moved (N = 200):
+The cause was not gradual erosion but a step function in how far the
+problem moved. Before, at N = 200, *zero* changed entries of the true
+active set cost 0 pivots and *one* cost 400. `solve_with_working_set`
+pins the hinted rows to their new boundaries; once the active set has
+moved, that pinned point violates some other row by roughly the distance
+the parameter moved, and a feasibility pre-check in `solve` routed the
+whole thing to elastic phase-1 — whose recovery re-solve starts from a
+*cold* working set. The hint was discarded rather than repaired. The fix
+repairs it: the violated rows are known, so they are pinned too and the
+KKT re-factored, keeping the |A| − 1 entries the hint got right. Now the
+cost tracks the movement, as it should:
 
-| Δφ | entries of the true active set that changed | warm pivots |
-|--:|--:|--:|
-| 0.002 | 0 | **0** |
-| 0.005 | 0 | **0** |
-| 0.01 | 1 | **400** |
-| 0.02 | 2 | **401** |
-| 0.05 | 4 | **403** |
+| Δφ | entries of the true active set that changed | warm pivots, before | after |
+|--:|--:|--:|--:|
+| 0.002 | 0 | 0 | 0 |
+| 0.005 | 0 | 0 | 0 |
+| 0.01 | 1 | **400** | 0 |
+| 0.02 | 2 | **401** | 1 |
+| 0.05 | 4 | **403** | 3 |
 
-Zero changes gives a flawless warm start at every size. *One* change
-costs the full m-sized penalty. The mechanism is an admission check:
-`solve_with_working_set` pins the hinted rows to their new boundaries,
-and when the active set has moved that pinned point violates some other
-row by roughly the distance the parameter moved. A feasibility
-pre-check in `solve` then routes the whole thing to elastic phase-1,
-whose recovery re-solve starts from a *cold* working set — so every row
-is re-added from scratch. The hint is not repaired, it is discarded.
+On the large tier at default settings, the whole picture inverts. Every
+arm is now correct on every step, and the SQP goes from unusable to the
+fastest thing on the board:
 
-Two things follow for reading the rest of this page. The horizon sweep's
-"warm starting turns harmful above N = 20 at large steps" is now known
-to be **this defect**, not an intrinsic property of active-set warm
-starts — the same rows solve in 2 pivots once the hint is admitted. And
-the earlier rule that payoff tracks *absolute* churn holds for the IPM
-arms but understates the SQP's cliff, which is triggered by the first
-changed entry and indifferent to the rest.
+| N | n | `warm-sqp` wall vs its cold twin | `warm-ipm` | `warm-qp-ipm` |
+|--:|--:|--:|--:|--:|
+| 200 | 602 | **0.03** | 0.50 | 0.51 |
+| 400 | 1202 | **0.03** | 0.48 | 0.49 |
+| 800 | 2402 | **0.02** | 0.48 | 0.51 |
 
-Until #428 is fixed: on a large problem whose active set moves between
-solves, use an interior-point path. The convex QP IPM warm start is
-0.44–0.49× cold across the whole large tier, and the NLP IPM 0.47–0.53×
-— both entirely unbothered by scale.
+Inner active-set work drops 514 → 11 per path (46.7×) identically at all
+three horizons. At n = 2402 a warm-started SQP sweep takes 1.36 s
+against 12.04 s cold.
+
+This also revises the caveat in
+[Active-Set SQP & Warm Starts](active-set-sqp.md) about preferring the
+IPM for "large-scale problems with thousands of active inequalities".
+With #428 fixed, this problem shows no such crossover up to 1645 active
+constraints — the active-set path wins by 30–50× there.
 
 ### The parametric homotopy: a sharply mixed trade
 
@@ -385,16 +391,17 @@ the cold path):
 | family | conventional → homotopy, cold inner work | ratio across the three scales |
 |---|--:|--:|
 | `simplex_proj` | 978 → 1400 | 0.63–0.74× |
-| `moving_bound_qp` | 793 → 685 | 0.87–2.75× |
-| `degenerate_corner` | 69 → 30 | 2.00–2.90× |
-| `redundant_rows` | 247 → 30 | 4.20–12.30× |
-| `degenerate_vertex` | 154 → 132 | 1.09–1.26× |
-| `hanging_chain` | 402 → 402 | 1.00× |
-| `rosenbrock_ring` | 98 → 98 | 1.00× |
-| `rosenbrock_ring_cycle` | 97 → 97 | 1.00× |
+| `moving_bound_qp` | 793 → 587 | 1.02–3.33× |
+| `degenerate_corner` | 69 → 30 | 1.91–2.73× |
+| `redundant_rows` | 247 → 30 | 3.91–11.27× |
+| `degenerate_vertex` | 154 → 132 | 1.09–1.25× |
+| `hanging_chain` | 257 → 257 | 1.00× |
+| `rosenbrock_ring` | 79 → 79 | 1.00× |
+| `rosenbrock_ring_cycle` | 77 → 77 | 1.00× |
 | `double_well_chain` | 0 → 0 | — (no inner QP work at all) |
-| `nmpc_vanderpol` | 2745 → 5115 | 0.52–0.55× |
-| **all 30 rows** | **5583 → 7989** | **0.70×** |
+| `nmpc_vanderpol` | 1205 → 3575 | 0.33–0.36× |
+| `mpc_horizon_10/20/40/80` | 9179 → 29839 | 0.25–0.37× |
+| **all 42 rows** | **13038 → 36006** | **0.36×** |
 
 Above 1.00× the homotopy did less work. The split is not random — it
 tracks exactly what the homotopy was built for:
@@ -406,14 +413,15 @@ tracks exactly what the homotopy was built for:
   homotopy does not. `degenerate_corner` and `degenerate_vertex` follow
   the same pattern. This is the netlib-like geometry #412 reported it
   gaining 20 problems on.
-- **It loses on well-conditioned MPC-shaped QPs.** `nmpc_vanderpol`
-  costs about twice the inner work with the homotopy on, consistently
-  across scales, and `simplex_proj` costs ~1.4×.
+- **It loses badly on well-conditioned MPC-shaped QPs.** Every
+  `mpc_horizon_*` family and `nmpc_vanderpol` cost about **3×** the
+  inner work with the homotopy on, consistently across scales, and
+  `simplex_proj` costs ~1.4×.
 - **It is inert on four families** — exactly 1.00×, because their inner
   QPs never take the cold path far enough for it to matter.
 
-Net over all 30 rows it does *more* inner work (0.70×), because the two
-losers are also the two largest problems. That is an argument for
+Net over all 42 rows it does 2.8× *more* inner work (0.36×), because
+the losers are also the largest problems. That is an argument for
 keeping it off by default on the SQP path and reaching for it on
 degenerate models, which is what the option now allows.
 
@@ -425,25 +433,31 @@ unit of work, so the like-for-like column is each solver against itself:
 
 | family | scale | convex QP IPM cold→warm | NLP IPM cold→warm | SQP cold→warm (inner) | fastest warm arm |
 |---|---|--:|--:|--:|---|
-| `simplex_proj` | tiny | 160→46 (3.00×) | 182→28 | 285→0 (16.00×) | `warm-qp-ipm` |
-| `simplex_proj` | small | 162→75 (2.03×) | 190→38 | 313→4 (15.55×) | `warm-qp-ipm` |
-| `simplex_proj` | large | 173→96 (1.73×) | 200→45 | 335→7 (15.09×) | `warm-qp-ipm` |
-| `moving_bound_qp` | tiny | 202→94 (2.06×) | 228→43 | 104→3 (6.00×) | `warm-sqp` |
-| `moving_bound_qp` | small | 195→121 (1.58×) | 224→116 | 207→29 (6.10×) | `warm-sqp` |
-| `moving_bound_qp` | large | 229→125 (1.77×) | 240→126 | 467→104 (4.99×) | `warm-qp-ipm` |
-| `degenerate_corner` | tiny | 196→74 (2.45×) | 223→41 | 19→1 (1.87×) | `warm-qp-ipm` |
-| `degenerate_corner` | small | 174→77 (2.12×) | 170→40 | 19→1 (1.87×) | `warm-qp-ipm` |
-| `degenerate_corner` | large | 177→98 (1.73×) | 177→53 | 26→4 (1.92×) | `warm-sqp` |
+| `simplex_proj` | tiny | 160→46 | 182→28 | 300→15 | `warm-qp-ipm` |
+| `simplex_proj` | small | 162→75 | 190→38 | 328→15 | `warm-qp-ipm` |
+| `simplex_proj` | large | 173→96 | 200→45 | 350→15 | `warm-sqp` |
+| `moving_bound_qp` | tiny | 202→94 | 228→43 | 109→5 | `warm-sqp` |
+| `moving_bound_qp` | small | 195→121 | 224→116 | 212→5 | `warm-sqp` |
+| `moving_bound_qp` | large | 229→125 | 240→126 | 472→24 | `warm-sqp` |
+| `degenerate_corner` | tiny | 196→74 | 223→41 | 20→2 | `warm-qp-ipm` |
+| `degenerate_corner` | small | 174→77 | 170→40 | 20→2 | `warm-qp-ipm` |
+| `degenerate_corner` | large | 177→98 | 177→53 | 29→6 | `warm-sqp` |
+| `redundant_rows` | tiny | 189→75 | 249→41 | 42→0 | `warm-qp-ipm` |
+| `redundant_rows` | small | 173→80 | 207→44 | 82→11 | `warm-qp-ipm` |
+| `redundant_rows` | large | 171→83 | 176→43 | 123→11 | `warm-qp-ipm` |
+| `degenerate_vertex` | tiny | 215→73 | 192→39 | 50→8 | `warm-qp-ipm` |
+| `degenerate_vertex` | small | 199→87 | 149→38 | 54→8 | `warm-sqp` |
+| `degenerate_vertex` | large | 195→92 | 141→38 | 50→8 | `warm-qp-ipm` |
 
-Geometric-mean wall time over those nine rows:
+Geometric-mean wall time over those fifteen rows:
 
 | cold-ipm | cold-sqp | cold-qp-ipm | warm-ipm | warm-sqp | warm-qp-ipm |
 |--:|--:|--:|--:|--:|--:|
-| 98.9 ms | 64.3 ms | 72.4 ms | 50.9 ms | 36.1 ms | **34.9 ms** |
+| 90.8 ms | 58.7 ms | 66.5 ms | 45.8 ms | 30.3 ms | **30.1 ms** |
 
-The dedicated convex solver is fastest on 8 of the 15 rows and the
-active-set SQP on the other 7, with the SQP taking the rows where the
-active set churns hardest. The two are within 4% of each other on the
+The dedicated convex solver is fastest on 9 of the 15 rows and the
+active-set SQP on the other 6, with the SQP taking the rows where the
+active set churns hardest. The two are within 1% of each other on the
 aggregate — on a problem that really is a QP, either warm-started path
 is a reasonable default. Note that this ranking is recent: before
 [#417](https://github.com/jkitchin/pounce/issues/417) was fixed the
@@ -456,21 +470,15 @@ of 9 rows.
   previous result. It leads on most rows and needs no callbacks.
 - **For a general NLP whose active set is stable between solves** —
   `algorithm = active-set-sqp` carrying the working set. This is where
-  the largest effects live (up to 30× less inner active-set work, and a
-  12× wall-time win on the largest horizon at small perturbations), and
-  the whole reason the active-set path exists.
-- **Check the crossover if your problem is large *and* moves a lot.**
-  The SQP's warm-start advantage is eroded by absolute working-set
-  churn, which grows with problem size. On the horizon sweep it turned
-  negative between N = 10 and N = 20 for large parameter steps, and the
-  interior-point paths were the safer choice there.
-- **Above a few hundred constraints, do not warm-start the SQP across a
-  step that moves the active set** until
-  [#428](https://github.com/jkitchin/pounce/issues/428) is fixed. The
-  hint is discarded rather than repaired, at a cost of one inner pivot
-  per constraint row — on the large tier that means no answer at all at
-  the default inner-QP budget. An interior-point path is the safe
-  choice at that scale, and is flat in the horizon.
+  the largest effects live (up to 55× less inner active-set work, and a
+  50× wall-time win on the largest default horizon), and the whole
+  reason the active-set path exists.
+- **Scale is not the thing to worry about; movement is.** On the horizon
+  sweep the SQP's warm/cold ratio *improves* with N (0.17 → 0.02 at
+  small steps), because cold cost grows with the problem while warm cost
+  is set by how far the active set moved. At n = 2402 a warm-started
+  sweep runs 30–50× faster than cold. What costs you is a large step,
+  not a large problem.
 - **For a problem with no active set to speak of** — unconstrained, or
   with constraints that never bind — the warm start still helps, but
   only through the primal point. Either solver is fine; the working set
@@ -503,7 +511,7 @@ Hessian, nothing active) that no other suite exercised:
 | [#416](https://github.com/jkitchin/pounce/issues/416) | Exact-Hessian SQP spent its entire inner-QP iteration budget making **zero** working-set changes; a budget of 20 gave bit-identical answers ~9× faster. Fixed in #419. |
 | [#423](https://github.com/jkitchin/pounce/issues/423) | The #416 fix regressed unconstrained problems: with nothing able to block a negative-curvature direction, the solve died at iteration 1. Caught by `double_well_chain` on its first run against the new build. Fixed in #424. |
 | [#417](https://github.com/jkitchin/pounce/issues/417) | The convex QP warm start left ~40% of its iterations unclaimed — not from the seeding but from a fraction-to-boundary parameter pinned at 0.95. Fixed in #422. |
-| [#428](https://github.com/jkitchin/pounce/issues/428) | **Open.** The SQP's working-set hint is discarded — not repaired — the moment the active set moves by one entry, costing one inner pivot per constraint row. Invisible below N ≈ 80; at n ≥ 602 it stops the warm-started solve from returning an answer. Found by the large tier on its first run. |
+| [#428](https://github.com/jkitchin/pounce/issues/428) | The SQP's working-set hint was discarded — not repaired — the moment the active set moved by one entry, costing one inner pivot per constraint row (1589 at n = 2402, against 3 now). Invisible below N ≈ 80; at n ≥ 602 it stopped the warm-started solve returning an answer at all. Found by the large tier on its first run, fixed in #429. |
 | `sqp_qp_use_homotopy` was a no-op | Found while adding the `-hom` arms: the option was *registered* but `apply_qp_subproblem_options` never read it, so setting it on the SQP path did nothing while its documentation described what it would do. The inverse of #360 (read-but-unregistered), and invisible to that issue's guard, which only checked one direction. Fixed here, with a bidirectional guard. |
 
 ## Running it
@@ -548,12 +556,18 @@ protocol are reusable against any solver with a warm-start API.
   reaches n = 242 by default and n = 2402 with `--tier large`). The
   sweep gives one scaling curve on one problem shape; it is not a
   substitute for a large-scale study across problem classes, and the
-  crossover it reports is specific to this MPC.
+  scaling it reports is specific to this MPC.
 - **The large tier is one problem class.** Linear-quadratic MPC has a
   particular structure — banded, mostly equalities, a large active set
-  that barely moves — and #428 was found there. Whether the same cliff
-  dominates on a large problem with a different sparsity pattern is
-  untested.
+  that barely moves — and #428 was found there. Whether a large problem
+  with a different sparsity pattern behaves the same way is untested,
+  and is the obvious next family to add.
+- **A published conclusion here has already been wrong once.** The
+  horizon sweep's crossover held for one revision of this page before
+  the large tier showed it was a solver defect. The measurements were
+  right and the mechanism inferred from them was not; treat the
+  explanations here as the current best reading of the numbers rather
+  than as established behavior.
 - **Wall time carries Python callback overhead** for the four
   callback-driven arms. Iteration and active-set-change counts are the
   primary measurements; times are a cross-check, and vary 10–30% between


### PR DESCRIPTION
Continues the warm-start suite. Adds the three coverage axes it was missing — degeneracy, the parametric homotopy, and scale — and reports what each measured. The scale axis found #428.

## Problem

The suite covered active-set regimes and perturbation sizes but not: the three kinds of degeneracy an active-set QP actually meets, the §4.2 homotopy the QP engine is named for, or anything larger than n = 47. Three gaps, each hiding something.

The scale gap was hiding a defect. At n ≥ 602 the warm-started SQP did not return an answer:

| | status | inner working-set changes | correct steps |
|---|---|---|---|
| `cold-sqp` @ N=800 | `Solve_Succeeded` | 567 | 8/8 |
| `warm-sqp` @ N=800, before | `Maximum_Iterations_Exceeded`, `iter_count = 0` | 2853 (budget-capped) | **1/8** |
| `warm-sqp` @ N=800, after | `Solve_Succeeded` | **64** | 8/8 |

Filed as #428, fixed in #429 (not by this PR). This branch is the measurement that found it and the re-measurement against the fix.

## Cause

Three separate findings, one per axis:

- **The homotopy arm produced bit-identical results to its control.** `sqp_qp_use_homotopy` was *registered* and documented but `apply_qp_subproblem_options` never read it, so `pounce-qp`'s own `false` always stood. The inverse of #360, and invisible to that issue's guard, which only walked reader → registry. Fixed here.
- **#428**: with the hint one entry wrong, the pinned primal violates some other row, `solve`'s admission pre-check routed the whole thing to elastic phase-1, and the recovery re-solve seeded a *cold* working set. Cost ≈ one pivot per constraint row. Diagnosed here, fixed in #429.
- **A published conclusion was wrong.** The horizon sweep's crossover — warm/cold wall 0.84 → 1.29 → 1.95 → 2.57, "warm starting turns harmful above N = 20" — was #428, not a property of active-set warm starts. Retracted in this branch.

## Fix

**Degeneracy** — `redundant_rows` (LICQ fails, duplicated rows), `degenerate_vertex` (12 rows tight at a 4-variable vertex), alongside the existing `degenerate_corner` (strict complementarity fails). Three distinct kinds, not interchangeable.

**Homotopy** — `cold-sqp-hom` / `warm-sqp-hom`, differing from their twins in exactly one option, so the delta is the homotopy alone. Plus the option reader that makes the flag do anything, and a bidirectional guard (`application_every_registered_sqp_qp_option_is_read_by_the_subproblem_reader`) so neither direction can rot again. Both guards were checked for falsifiability: removing the reader fails the round-trip test, removing the registration fails the new one.

**Scale** — `mpc_horizon_10/20/40/80` in the default sweep and an opt-in `--tier large` at N = 200/400/800 (n = 602 → 2402). Families may now declare `sparse_structure()` with packed `jacobian_values()` / `hessian_values()`; nothing dense is materialized, and the convex-QP arm receives sparse matrices.

Rejected on the way: passing dense matrices to the QP arm at that size. It works, and it is 60–80× slower by the solver's own `PounceSparsityWarning` — which would have made the QP arm look bad for a reason unrelated to the QP arm. The first large-tier run did exactly this and the numbers were discarded.

Also rejected: raising `sqp_qp_feas_tol` as a workaround for #428. It admits the hint (403 pivots → 2) but that tolerance also gates whether a converged point is *accepted*, and at 0.5 the same solve returns objective 26.6175 with violation 6.4e-2. No setting is safe for both jobs, which is what made #428 a code fix rather than a documented knob.

## Blast radius

Rust changes are confined to `crates/pounce-algorithm/src/application.rs`: the `sqp_qp_use_homotopy` reader plus its guard test. Everything else is `benchmarks/`, `docs/`, `dev-notes/`, `CHANGELOG.md`.

Reading that option changes behavior **only** for a caller who explicitly sets `sqp_qp_use_homotopy yes` on the SQP path — previously a silent no-op. Default behavior is unchanged (`pounce-qp`'s default is `false`, which is what was already in force).

Measured against `b5eade7`: with the homotopy off, every arm's counts are bit-identical to the pre-branch build. The suite reports zero incorrect steps across all 8 arms on both tiers.

One rebase caution worth recording: this branch was rebased across #429 and #430, and #430 touches `pounce-qp/src/homotopy.rs` and `solver.rs` — the code the `-hom` arms exist to measure. Rather than assume it was inert, the whole suite was re-run on the rebased base. Every count came back identical (homotopy comparison 13038 → 36006, 0.36× over 42 rows; large tier 514 → 11); only wall times moved, by about the run-to-run variation the page documents. Every number on the book page now comes from that single run.

## What it measured

**Homotopy** — measured for the first time. It wins where it was designed to: `redundant_rows` 3.9–11.3×, `degenerate_corner` 1.9–2.7×. It loses ~3× on MPC-shaped QPs and is inert (exactly 1.00×) on four families. Net over 42 rows it does 2.8× *more* inner work, which argues for keeping it off by default and reaching for it on degenerate models — which the now-functional option allows.

**Scale, after #429** — the SQP's warm/cold ratio *improves* with horizon: 0.17 → 0.02 at `tiny` for N = 10…80, and 0.02–0.03× at n = 602–2402, where it is the fastest arm on the board. Inner work is flat at 3 pivots per step across a 75× range of m. The earlier "prefer the IPM above thousands of active inequalities" caveat in `active-set-sqp.md` is corrected: the measured behavior does not support it for warm-started sequences.

**How the wrong conclusion happened**, recorded in the dev-note because the shape recurs: the churn measurements were correct, and a plausible two-factor mechanism was inferred from them that fit the data and was wrong, because the data had a defect in it. The check that would have caught it was cheap — compare warm pivots against the *true* active-set difference, which was 4 where the warm arm spent 164 — and it was not run until the large tier made the gap impossible to miss. The book page's "Limits" section now says a conclusion here has already been wrong once.

## Tests

- `application_every_registered_sqp_qp_option_is_read_by_the_subproblem_reader` — fails on the parent commit, for the stated reason: `sqp_qp_use_homotopy` is registered and absent from the reader's covered list. Verified by removing the reader (round-trip test fails) and by removing the registration (this test fails).
- `python -m warmstart.selftest` — finite-difference checks on all 17 families. Sparse families are cross-checked dense-vs-sparse where affordable and column-subsampled above n = 300, so a structure that disagrees with its values cannot pass silently.
- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, `cargo test -p pounce-qp -p pounce-convex -p pounce-algorithm` all clean (verified on exit codes; the clippy warnings that remain are pre-existing in unrelated crates).

**Deliberately not pinned**: the benchmark's numbers themselves. `results.json` / `results.md` are gitignored like every other suite's output, and wall times vary 10–30% between runs on one machine. The counts are deterministic and reproducible; the tables in the docs are dated measurements, not assertions CI checks.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md`
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

On that last box: the branch's own history contains a claim that went stale — the horizon-sweep crossover, published for one commit before the large tier disproved it. It is retracted in the dev-note and on the book page rather than quietly edited, and the commit that retracts it says why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A1b3zspp4PWgP3X6zY6JwU

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1b3zspp4PWgP3X6zY6JwU)_