### PR TITLE
Guard classify_activity on the solve's bound_relax_factor; document it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,15 @@ changes.
   the threshold is μ-relative and reachable).
   `classify_activity` refuses to run with `bound_relax_factor != 0` (the
   Ipopt default is `1e-8`): relaxed bounds shift the slacks the classifier
-  reads.
+  reads. The guard tests the value **the held solve ran under**, now
+  snapshotted as `ConvergedState::bound_relax_factor`, not the
+  application's live options: the bounds were relaxed (or not) once,
+  during that solve, so setting the option afterwards neither unlocks a
+  relaxed state nor invalidates an unrelaxed one. Re-solve to change the
+  answer.
+- Documented in `docs/src/sensitivity.md` ("Activity classification", plus
+  the scale-invariance note under "Units and NLP scaling") and listed with
+  the other session entry points in `docs/src/sessions.md`.
 - Item 0 of `dev-notes/covariance-information-roadmap.md` (#262).
   Everything the classifier reads was already retained at convergence
   (`Σ`, the solver's slacks, the bound multipliers, `μ`, and the exact

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -417,9 +417,13 @@ impl PySolver {
     ///   true where classified inactive yet carrying non-negligible
     ///   barrier curvature.
     ///
-    /// Requires `bound_relax_factor=0` (raises `ValueError` otherwise;
-    /// the Ipopt default is `1e-8`): relaxed bounds shift the slacks
-    /// the classifier reads.
+    /// Requires the **held solve** to have run with
+    /// `bound_relax_factor=0` (raises `ValueError` otherwise; the
+    /// Ipopt default is `1e-8`): relaxed bounds shift the slacks the
+    /// classifier reads. The guard reads the value that solve ran
+    /// under, so setting the option afterwards neither unlocks a
+    /// relaxed solve nor invalidates an unrelaxed one — set it on the
+    /// `Problem` and solve again.
     fn classify_activity<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err("classify_activity: no converged factor (call solve() first)")

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -102,6 +102,14 @@ pub struct ConvergedState {
     pub x: Vec<Number>,
     /// Final objective value `f(x*)`.
     pub obj_val: Number,
+    /// `bound_relax_factor` **as the solve that produced this state
+    /// ran with it**, not as the application's options read today.
+    /// The bounds were relaxed (or not) once, during this solve; a
+    /// later `set_numeric_value` cannot change what the held slacks
+    /// were measured against, so post-solve calls whose validity
+    /// depends on unrelaxed bounds must guard on this value. See
+    /// [`Solver::classify_activity`].
+    pub bound_relax_factor: Number,
     /// Converged KKT-factor wrapper. Owns `Rc` handles to the
     /// `PdFullSpaceSolver`, the IpoptData / Cq, and the NLP, so it
     /// outlives the IPM call frame.
@@ -172,6 +180,20 @@ impl Solver {
         // a stale factor visible.
         self.state.borrow_mut().take();
 
+        // Snapshot the options this solve will run under, before it
+        // runs. `bound_relax_factor` is consumed once, when the NLP
+        // relaxes its bounds; reading it back at query time would
+        // describe the application's options rather than the state
+        // being queried. The registry supplies its own default when
+        // the option is unset, so no second copy of the default lives
+        // here.
+        let brf = self
+            .app
+            .options()
+            .get_numeric_value("bound_relax_factor", "")
+            .map(|(v, _)| v)
+            .expect("bound_relax_factor is a registered core option");
+
         let state_cb = Rc::clone(&self.state);
         self.app
             .set_on_converged(Box::new(move |data, cq, nlp, pd| {
@@ -197,6 +219,7 @@ impl Solver {
                     status: ApplicationReturnStatus::InternalError,
                     x,
                     obj_val,
+                    bound_relax_factor: brf,
                     backsolver,
                 });
             }));
@@ -238,28 +261,30 @@ impl Solver {
     /// [`crate::activity`] and
     /// `dev-notes/covariance-information-roadmap.md` item 0 (gh #362).
     ///
-    /// Requires `bound_relax_factor=0` (the Ipopt default is `1e-8`):
-    /// with relaxed bounds the solver's slacks are measured against
-    /// perturbed bounds, and the complementarity products the
-    /// classifier reads no longer track `μ`.
+    /// Requires the held solve to have run with `bound_relax_factor=0`
+    /// (the Ipopt default is `1e-8`): with relaxed bounds the solver's
+    /// slacks are measured against perturbed bounds, and the
+    /// complementarity products the classifier reads no longer track
+    /// `μ`.
+    ///
+    /// The guard reads
+    /// [`ConvergedState::bound_relax_factor`] — the value that solve
+    /// ran under — not the application's current options. Setting the
+    /// option after the fact neither unlocks a state whose bounds were
+    /// relaxed nor invalidates one whose bounds were not; re-solve to
+    /// change the answer.
     pub fn classify_activity(&self) -> Result<ActivityReport, SolverError> {
-        // the registry supplies its own default when the option is
-        // unset, so no second copy of the default lives here
-        let brf = self
-            .app
-            .options()
-            .get_numeric_value("bound_relax_factor", "")
-            .map(|(v, _)| v)
-            .expect("bound_relax_factor is a registered core option");
-        if brf != 0.0 {
-            return Err(SolverError::BadOptions(format!(
-                "classify_activity requires bound_relax_factor=0 \
-                 (currently {brf:e}): relaxed bounds shift the slacks \
-                 the classifier reads"
-            )));
-        }
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let brf = state.bound_relax_factor;
+        if brf != 0.0 {
+            return Err(SolverError::BadOptions(format!(
+                "classify_activity requires bound_relax_factor=0, but the \
+                 held solve ran with {brf:e}: relaxed bounds shift the \
+                 slacks the classifier reads. Set the option and solve() \
+                 again — changing it now does not re-measure the slacks."
+            )));
+        }
         Ok(crate::activity::compute(&state.backsolver))
     }
 

--- a/crates/pounce-sensitivity/tests/solver_session.rs
+++ b/crates/pounce-sensitivity/tests/solver_session.rs
@@ -336,3 +336,66 @@ fn solver_converged_none_before_solve() {
     assert!(solver.converged().is_none());
     assert!(solver.kkt_dim().is_none());
 }
+
+/// `classify_activity` guards the `bound_relax_factor` the held solve
+/// ran under, not the application's live options. Both directions
+/// matter: the bounds were relaxed (or not) once, during the solve,
+/// and no later `set_numeric_value` re-measures the slacks the
+/// classifier reads.
+#[test]
+fn classify_activity_guards_the_solves_bound_relax_factor() {
+    let mut app = make_app();
+    app.options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ParametricTNLP::new(5.0, 1.0)));
+    let mut solver = Solver::new(app, tnlp);
+    solver.solve();
+    assert_eq!(
+        solver
+            .converged()
+            .expect("converged state captured")
+            .bound_relax_factor,
+        0.0,
+    );
+    assert!(solver.classify_activity().is_ok());
+
+    // Raising the option cannot invalidate a report the held state is
+    // still perfectly good for: those bounds were never relaxed.
+    solver
+        .app_mut()
+        .options_mut()
+        .set_numeric_value("bound_relax_factor", 1e-8, true, false)
+        .unwrap();
+    assert!(
+        solver.classify_activity().is_ok(),
+        "the guard must read the solve's value, not the live option",
+    );
+}
+
+#[test]
+fn classify_activity_refuses_a_solve_that_relaxed_its_bounds() {
+    // make_app leaves bound_relax_factor at the 1e-8 default.
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ParametricTNLP::new(5.0, 1.0)));
+    let mut solver = Solver::new(make_app(), tnlp);
+    solver.solve();
+    assert!(matches!(
+        solver.classify_activity(),
+        Err(pounce_sensitivity::SolverError::BadOptions(_)),
+    ));
+
+    // Clearing the option afterwards must NOT unlock the stale state:
+    // its slacks were measured against relaxed bounds and still are.
+    solver
+        .app_mut()
+        .options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    assert!(
+        matches!(
+            solver.classify_activity(),
+            Err(pounce_sensitivity::SolverError::BadOptions(_)),
+        ),
+        "clearing the option must not retroactively un-relax the held slacks",
+    );
+}

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -312,6 +312,60 @@ See
 for a worked example with a Monte Carlo validated confidence ellipse
 and an identifiability diagnosis.
 
+## Activity classification
+
+Which bounds and constraint rows are actually *holding* the solution
+is a question the converged iterate answers only ambiguously: at a
+weakly active bound the slack and its multiplier are both `O(√μ)`, so
+no fixed threshold on either one alone separates "just touching" from
+"not binding". `Solver.classify_activity()` keys on the ratio of
+barrier curvature to the model's own curvature instead, which is
+`O(μ)`, `O(1)` and `O(1/μ)` in the three regimes:
+
+```python
+solver = pounce.Solver(problem)   # problem.add_option("bound_relax_factor", 0.0)
+x, info = solver.solve(x0=x0)
+
+rep = solver.classify_activity()
+rep["var_status"]        # ["inactive", "unbounded", "fixed", "strongly_active"]
+rep["row_status"]        # ["equality", "strongly_active"]
+rep["var_ratio"]         # the ratio behind each call (NaN where nothing was classified)
+rep["mu"]                # the barrier parameter the calls were made at
+```
+
+Statuses are `inactive`, `weakly_active`, `strongly_active`,
+`ambiguous` (the ratio fell in a gap where this `μ` cannot decide —
+re-solve tighter), and `unidentified` (the curvature is below noise
+scale, so the question does not arise). `unbounded`, `fixed` and
+`equality` mark entries with no barrier geometry to classify.
+
+Both arrays are indexed in **user space**: `var_*` follows your `n`
+variables and `row_*` your `m` constraints, in your order. A variable
+that `fixed_variable_treatment = make_parameter` removed from the
+solve (`lb == ub`) reports `fixed` at its own index rather than
+shifting everything after it.
+
+Two per-entry flags report on the assumptions rather than the
+geometry: `off_central_path` (`s·z` differs from `μ` by more than 10×
+on some side) and `contaminated` (classified inactive yet carrying
+barrier curvature well above the `O(μ)` an inactive bound should have
+— typically a bound that sits close enough to the optimum to bend it).
+
+Inequality rows classify through the same rule, via the curvature
+along the constraint normal. That is the point of classifying rows at
+all: move a bound off a variable and onto a row and the activity
+disappears from the bound-multiplier view entirely, while any
+covariance or identifiability heuristic keyed on `z` alone silently
+stops seeing it
+([#362](https://github.com/jkitchin/pounce/issues/362)).
+
+The call requires the solve to have run with `bound_relax_factor=0`
+(the Ipopt default is `1e-8`) and raises `ValueError` otherwise:
+relaxed bounds shift the very slacks the classifier reads. The guard
+tests the value that solve ran under, so setting the option after the
+fact does not change the answer — set it on the `Problem` and solve
+again.
+
 ## Units and NLP scaling
 
 All sensitivity outputs are in **natural (unscaled) units**. The IPM
@@ -323,6 +377,13 @@ pounce undoes that scaling in every held-factor back-solve, so `dx`,
 `kkt_solve`, and the reduced Hessian are independent of how the
 problem was scaled internally
 ([#128](https://github.com/jkitchin/pounce/issues/128)).
+
+`classify_activity()` is scale-invariant for the same reason, and by
+construction rather than by undoing anything: its ratios are formed so
+that rescaling a variable, a constraint row, or the objective leaves
+them fixed. Writing a constraint as `1000·x ≥ 0` instead of `x ≥ 0`
+does not move a status, and neither does the solver's own per-row
+`d_scale`.
 
 In particular, for a parameter-estimation NLP with the parameters
 pinned by equality constraints, `-inv(info["reduced_hessian"])` is

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -52,6 +52,10 @@ hr = solver.reduced_hessian([2, 3])
 dim = solver.kkt_dim
 rhs = np.zeros(dim)
 lhs = solver.kkt_solve(rhs)
+
+# Which bounds and rows actually hold the solution, in user index order.
+rep = solver.classify_activity()          # needs bound_relax_factor=0
+rep["var_status"], rep["row_status"]
 ```
 
 The KKT compound vector is laid out as


### PR DESCRIPTION
Follow-ups from the #371 review that did not block that merge. No behaviour change to the classification itself.

## Problem

`classify_activity()` refuses to run unless `bound_relax_factor = 0`, because relaxed bounds shift the very slacks it reads. But the guard read `self.app.options()` — the application's options *now* — rather than what the held solve actually ran under. Those are different facts, and the guard was wrong in both directions:

| | held solve ran with | option set to | before | after |
|---|---|---|---|---|
| stale unlock | `1e-8` (bounds relaxed) | `0.0` after the solve | **`Ok(report)`** — slacks measured against perturbed bounds | `BadOptions` |
| spurious refusal | `0.0` (bounds not relaxed) | `1e-8` after the solve | **`BadOptions`** | `Ok(report)` |

The first row is the damaging one: a report that reads as authoritative, computed from slacks the precondition exists to reject. Nothing in the report says which bounds it was measured against, so there is no downstream check that would catch it — and roadmap items 1-4 consume these statuses.

Neither row is exotic. `Solver` is a session type whose whole point is holding one solve across many queries, and `app_mut()` is the documented way to reconfigure between them.

## Cause

The bounds are relaxed once, inside the solve, when the NLP applies `bound_relax_factor`. After that the value is a property of the captured state, not of the application. `ConvergedState` recorded the iterate, the objective and the KKT factor, but not the option that determines whether the first two are admissible input to this particular query.

## Fix

Snapshot it. `solve()` reads `bound_relax_factor` before installing the `on_converged` callback and moves it into `ConvergedState.bound_relax_factor` (public, since it is a genuine property of the state); `classify_activity()` guards on that. The error message now names re-solving as the thing that changes the answer, since setting the option no longer does.

Reading it at solve entry rather than in the callback is deliberate: the callback fires mid-`optimize_tnlp`, and the value that matters was already consumed by then. Both give the same answer today; taking it at entry is the one that stays correct if bound relaxation ever moves.

Rejected: validating in the callback against the NLP's relaxed bounds directly. That measures the same fact one layer further from where it is decided, and would need a new accessor on the NLP for no gain in what it can detect.

The guard now runs after the `NotConverged` check rather than before it, so `classify_activity()` on a fresh `Solver` reports "not converged" instead of an option complaint. That is the better message, and the Python wrapper's own pre-check already made this the observed order there.

## Blast radius

`ConvergedState` gains a public field — additive, and the struct is constructed only inside `solve()`. `SolverError` variants are unchanged (`BadOptions` still, with different text). No numerical path is touched: `classify_activity` computes exactly what it computed before on every input it accepts, and `kkt_solve` / `parametric_step` / `reduced_hessian` are untouched. The classification rule, thresholds and report contents are all unchanged.

Docs are additive: a new "Activity classification" section in `docs/src/sensitivity.md` (statuses, the user-space indexing, the two honesty flags, and the #362 rows-too rationale), a note under "Units and NLP scaling" that these ratios are scale-invariant by construction rather than by undoing scaling, and the call listed with the other session entry points in `docs/src/sessions.md`. Both are existing pages, so `SUMMARY.md` is unchanged. Before this, the docstring was the only surface — the feature was undiscoverable from the book.

## Tests

Two tests in `crates/pounce-sensitivity/tests/solver_session.rs`, one per row of the table above. Verified failing on the parent commit by reverting only the guard body and keeping the tests:

```
test classify_activity_guards_the_solves_bound_relax_factor ... FAILED
  panicked at solver_session.rs:370: the guard must read the solve's value, not the live option
test classify_activity_refuses_a_solve_that_relaxed_its_bounds ... FAILED
  panicked at solver_session.rs:394: clearing the option must not retroactively un-relax the held slacks
test result: FAILED. 6 passed; 2 failed
```

Each fails for its own stated reason, not a shared compile error. With the fix: 8 passed.

Not pinned: the Python surface. The only Python-visible changes are the docstring and the error text, and the existing `python/tests/test_activity.py` assertions match substrings that survive (`"bound_relax_factor"`, `"no converged factor"`). I could not run that suite locally — maturin is not installed in this environment — so CI is the check on it.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

Refs #262 (covariance roadmap item 0), #362, #371. No closing keyword: #362 stays open until roadmap item 1 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WQ3LZBZTqJCcY7WR5qDP1

---
_Generated by [Claude Code](https://claude.ai/code/session_018WQ3LZBZTqJCcY7WR5qDP1)_