### PR TITLE
covariance() membership from the barrier geometry (roadmap item 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ changes.
 
 ## [Unreleased]
 
+### Changed — pyomo-pounce: `covariance()` membership from the solve's barrier geometry (#362, covariance roadmap item 1)
+
+- Bound and constraint activity on the fitted parameters now classifies
+  through the item-0 rule applied at the reduced fitted block, where a
+  fitted parameter's curvature actually lives (its raw Lagrangian diagonal
+  is zero in the residual-variable idiom, so the per-coordinate report
+  alone cannot decide membership there). The slack-only test
+  (`tol = 1e-6 * (1 + |x|)`) and its moved-bounds re-injection are gone.
+- Dispositions per the item-1 table: strongly active projects (zero
+  variance, conditional, warned); weakly active is KEPT at its full
+  finite variance, where the slack test deleted it and the raw factor
+  would have halved it; ambiguous and unidentified are kept and warned.
+- The value correction subtracts the fitted rows' retained barrier
+  diagonal (`var_sigma`, new in the activity report along with
+  `row_sigma`) from the factor's reduced Hessian: a weakly active kept
+  parameter reports its true curvature `q`, not the factor's `2q`, and
+  inactive rows shed an O(μ) drift. On kept rows Σ is at most the
+  curvature's own size, so nothing cancels; pinned coordinates and
+  binding directions never enter (excluded by the free restriction and
+  annihilated by the projection, which also annihilates the binding
+  rows' huge barrier weight exactly).
+- A strongly active inequality row whose normal touches the fitted
+  block pins a combination, not a coordinate: both accessor paths
+  (Lagrangian and Gauss-Newton) project on the null space of the
+  binding normals, the matrix goes singular by one per binding row,
+  and the warning names the constraint, the pinned combination, and
+  its conditional information. A bound moved onto a row
+  (jkitchin/pounce#357) is the single-coordinate case and returns
+  exactly the variable-bound disposition, so the two spellings of one
+  limit agree in the matrices (#362), not only in the classification.
+- Declaration-triggered solves set `bound_relax_factor=0`: the
+  classifier reads slacks as distances to the user's own bounds.
+- `Solver.row_normal(j)`: a constraint row's gradient at the converged
+  iterate in user variable order, serving the projection direction.
+- Tests pin the analytics: the weakly active kept variance equals the
+  unconstrained `σ²(XᵀX)⁻¹` entry; a binding `a + b <= cap` matches
+  restricted least squares with corr −1 and a rank drop; bound and row
+  spellings agree to 1e-6; an inactive far bound changes nothing to
+  1e-7; Gauss-Newton matches on the linear model, projection included.
+
+
 ### Fixed — feasible convex QPs reported locally infeasible on the NLP path
 
 - With `solver_selection=nlp`, POUNCE reported `Converged to a point of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,11 +49,13 @@ changes.
   equally blind, so such a row takes item 0's raw classification, is
   kept unprojected, and warns explicitly. The general treatment is
   the row's reduced normal through the elimination, item 2 territory.
-- The report's `Σ` is the solver's scaled-space value while the
-  factor block is natural-units (kkt_solve, pounce#128): the value
-  correction normalizes by the objective scale (the per-row
-  constraint scale cancels algebraically), tested against a solve
-  with gradient-based scaling engaged.
+- The report's `var_sigma`/`row_sigma` and `row_normal` follow the
+  documented natural-units contract like every other sensitivity
+  output: classification runs on the solver's scaled quantities (the
+  ratio is scale-invariant), the exported values are unscaled at the
+  boundary. Tested by pinning the weak scalar row's `Σ = 1/c²` under
+  both scaling modes and `row_normal` returning the user's own
+  coefficient.
 - Declaration-triggered solves set `bound_relax_factor=0`: the
   classifier reads slacks as distances to the user's own bounds.
 - `Solver.row_normal(j)`: a constraint row's gradient at the converged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ changes.
   (jkitchin/pounce#357) is the single-coordinate case and returns
   exactly the variable-bound disposition, so the two spellings of one
   limit agree in the matrices (#362), not only in the classification.
+- The restricted normal is honest only when the row's support outside
+  the fitted block is pinned (declared-parameter pin columns do not
+  count as outside: they cannot move). A binding row reaching the
+  fitted parameters through FREE eliminated variables pins a
+  direction the restricted normal cannot represent (`a + r_1 <= cap`
+  with `r_1 = y_1 - a - b x_1` pins a `b`-direction while the
+  restricted normal reads `e_a`), and the reduced-level ratio is
+  equally blind, so such a row takes item 0's raw classification, is
+  kept unprojected, and warns explicitly. The general treatment is
+  the row's reduced normal through the elimination, item 2 territory.
+- The report's `Σ` is the solver's scaled-space value while the
+  factor block is natural-units (kkt_solve, pounce#128): the value
+  correction normalizes by the objective scale (the per-row
+  constraint scale cancels algebraically), tested against a solve
+  with gradient-based scaling engaged.
 - Declaration-triggered solves set `bound_relax_factor=0`: the
   classifier reads slacks as distances to the user's own bounds.
 - `Solver.row_normal(j)`: a constraint row's gradient at the converged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,10 @@ changes.
   restricted least squares with corr −1 and a rank drop; bound and row
   spellings agree to 1e-6; an inactive far bound changes nothing to
   1e-7; Gauss-Newton matches on the linear model, projection included.
-
+- `_classify_ratio` mirrors the Rust rule in Python, so a drift test
+  checks the two against each other on real solves: every classified
+  entry of a `classify_activity()` report must re-derive its own
+  status from the reported `(ratio, mu)` through the Python rule.
 
 ### Fixed — feasible convex QPs reported locally infeasible on the NLP path
 

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -422,7 +422,15 @@ impl PySolver {
     /// - `"var_sigma"`, `"row_sigma"`: ndarray of the barrier
     ///   diagonal `Σ` itself (both sides summed; 0 where nothing was
     ///   classified), the quantity item 1 of the covariance roadmap
-    ///   subtracts from the factor's reduced Hessian.
+    ///   subtracts from the factor's reduced Hessian. In **natural
+    ///   (unscaled) units** like every other sensitivity output:
+    ///   classification runs on the solver's scaled quantities (the
+    ///   ratios above are scale-invariant), and the exported `Σ` is
+    ///   unscaled at the boundary, so it composes directly with a
+    ///   natural-units reduced Hessian. `row_sigma` is additionally
+    ///   the RAW diagonal, not the geometric weight `Σ‖∇d‖²` the
+    ///   classification uses, so a consumer applies whichever `‖a‖²`
+    ///   its own restriction of the normal calls for.
     ///
     /// Requires the **held solve** to have run with
     /// `bound_relax_factor=0` (raises `ValueError` otherwise; the
@@ -484,7 +492,10 @@ impl PySolver {
     }
 
     /// The gradient of user constraint row `j` at the converged
-    /// iterate, as an ndarray in user variable order (length n).
+    /// iterate, as an ndarray in user variable order (length n), in
+    /// **natural (unscaled) units**: the solver's internal Jacobian
+    /// row carries its per-row `d_scale`/`c_scale`, which is divided
+    /// out here, so this is the gradient of the row the user wrote.
     /// Equality and inequality rows alike; entries for fixed
     /// (`lb == ub`) variables are 0 because the solve removed their
     /// columns. A binding row's normal restricted to the fitted

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -419,6 +419,10 @@ impl PySolver {
     /// - `"var_contaminated"`, `"row_contaminated"`: list of bool,
     ///   true where classified inactive yet carrying non-negligible
     ///   barrier curvature.
+    /// - `"var_sigma"`, `"row_sigma"`: ndarray of the barrier
+    ///   diagonal `Σ` itself (both sides summed; 0 where nothing was
+    ///   classified), the quantity item 1 of the covariance roadmap
+    ///   subtracts from the factor's reduced Hessian.
     ///
     /// Requires the **held solve** to have run with
     /// `bound_relax_factor=0` (raises `ValueError` otherwise; the
@@ -462,6 +466,7 @@ impl PySolver {
         )?;
         out.set_item("var_off_central_path", rep.var_off_central_path)?;
         out.set_item("var_contaminated", rep.var_contaminated)?;
+        out.set_item("var_sigma", rep.var_sigma.into_pyarray_bound(py))?;
         out.set_item("row_status", status_str(&rep.row_status))?;
         out.set_item("row_ratio", rep.row_ratio.into_pyarray_bound(py))?;
         out.set_item(
@@ -474,7 +479,29 @@ impl PySolver {
         )?;
         out.set_item("row_off_central_path", rep.row_off_central_path)?;
         out.set_item("row_contaminated", rep.row_contaminated)?;
+        out.set_item("row_sigma", rep.row_sigma.into_pyarray_bound(py))?;
         Ok(out)
+    }
+
+    /// The gradient of user constraint row `j` at the converged
+    /// iterate, as an ndarray in user variable order (length n).
+    /// Equality and inequality rows alike; entries for fixed
+    /// (`lb == ub`) variables are 0 because the solve removed their
+    /// columns. A binding row's normal restricted to the fitted
+    /// columns is the projection direction of the covariance
+    /// roadmap's item 1.
+    fn row_normal<'py>(&self, py: Python<'py>, j: i64) -> PyResult<Bound<'py, PyArray1<Number>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("row_normal: no converged factor (call solve() first)")
+        })?;
+        if j < 0 || (j as usize) >= s.m {
+            return Err(PyValueError::new_err(format!(
+                "row_normal: constraint index {j} out of range [0, m={})",
+                s.m
+            )));
+        }
+        let g = s.inner.row_normal(j as usize).map_err(solver_error_to_py)?;
+        Ok(g.into_pyarray_bound(py))
     }
 }
 

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -112,9 +112,12 @@ pub struct ActivityReport {
     /// where none should be.
     pub var_contaminated: Vec<bool>,
     /// The barrier diagonal `Σ_i = z/s` itself per user variable, both
-    /// sides summed; 0 where not classified. The covariance roadmap's
-    /// item 1 subtracts exactly this from the factor's reduced
-    /// Hessian, so it is reported rather than only its ratio to `q`.
+    /// sides summed; 0 where not classified. In **natural (unscaled)
+    /// units**, the repo's sensitivity-output contract: classification
+    /// runs on the solver's scaled quantities (the ratio is
+    /// scale-invariant), the report does not. The covariance roadmap's
+    /// item 1 subtracts exactly this from the factor's natural-units
+    /// reduced Hessian.
     pub var_sigma: Vec<Number>,
     /// Status per user constraint row.
     pub row_status: Vec<i8>,
@@ -128,9 +131,10 @@ pub struct ActivityReport {
     /// Contamination check per row, as for variables.
     pub row_contaminated: Vec<bool>,
     /// The row barrier diagonal `Σ_j = v/s` per user row, both sides
-    /// summed; 0 where not classified. RAW, not the geometric weight
-    /// the classification uses: item 1 restricts the normal to its own
-    /// fitted block and applies its own `‖a‖²` factor there.
+    /// summed; 0 where not classified. In **natural (unscaled) units**
+    /// like [`Self::var_sigma`], and RAW rather than the geometric
+    /// weight the classification uses: item 1 restricts the normal to
+    /// its own fitted block and applies its own `‖a‖²` factor there.
     pub row_sigma: Vec<Number>,
 }
 
@@ -333,9 +337,16 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
             curr.s.dim() as usize,
         )
     };
-    let (px_l, px_u, pd_l, pd_u) = {
+    let (px_l, px_u, pd_l, pd_u, obj_scale, d_scale) = {
         let nl = nlp.borrow();
-        (nl.px_l(), nl.px_u(), nl.pd_l(), nl.pd_u())
+        (
+            nl.px_l(),
+            nl.px_u(),
+            nl.pd_l(),
+            nl.pd_u(),
+            nl.obj_scaling_factor(),
+            nl.d_scale_vec(),
+        )
     };
     let cq = cq.borrow();
 
@@ -364,6 +375,11 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
         let mut e = classify_entry(sigma_x[i], diag[i], floor, mu);
         e.off_path = (has_l[i] && off_path(s_l[i], z_l[i], mu))
             || (has_u[i] && off_path(s_u[i], z_u[i], mu));
+        // the ratio is scale-invariant, so classification ran in the
+        // solver's scaled space; the REPORTED sigma follows the repo's
+        // natural-units contract: internal z carries the objective
+        // scale (x is never scaled), so Sigma_nat = Sigma / df
+        e.sigma /= obj_scale;
         vars[i] = e;
     }
 
@@ -493,6 +509,11 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
         }
         rows[j].off_path = (rhas_l[j] && off_path(rs_l[j], v_l[j], mu))
             || (rhas_u[j] && off_path(rs_u[j], v_u[j], mu));
+        // natural-units report, as for variables: the scaled row
+        // multiplier carries df/dg and the scaled slack dg, so
+        // Sigma_nat = Sigma * dg^2 / df
+        let dg = d_scale.as_ref().map_or(1.0, |v| v[j]);
+        rows[j].sigma *= dg * dg / obj_scale;
     }
 
     // --- scatter to user space --------------------------------------------
@@ -545,9 +566,12 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
 }
 
 /// The gradient of one user constraint row at the converged iterate,
-/// in user variable order (length `n_full_x`). Works for equality and
-/// inequality rows alike; entries for `make_parameter`-removed fixed
-/// variables are 0 because the solve dropped their columns.
+/// in user variable order (length `n_full_x`) and **natural (unscaled)
+/// units**: the internal Jacobian row carries the solver's per-row
+/// scale, which is divided out here per the sensitivity-output
+/// contract. Works for equality and inequality rows alike; entries for
+/// `make_parameter`-removed fixed variables are 0 because the solve
+/// dropped their columns.
 pub(crate) fn row_normal(bs: &PdSensBacksolver, user_row: usize) -> Result<Vec<Number>, usize> {
     let (data, cq, nlp) = bs.activity_handles();
     let n = {
@@ -577,6 +601,15 @@ pub(crate) fn row_normal(bs: &PdSensBacksolver, user_row: usize) -> Result<Vec<N
         }
     };
 
+    let row_scale = {
+        let nl = nlp.borrow();
+        let sv = if c_pos.is_some() {
+            nl.c_scale_vec()
+        } else {
+            nl.d_scale_vec()
+        };
+        sv.map_or(1.0, |v| v[block_pos])
+    };
     let cq = cq.borrow();
     let jac = if c_pos.is_some() {
         cq.curr_jac_c()
@@ -598,7 +631,7 @@ pub(crate) fn row_normal(bs: &PdSensBacksolver, user_row: usize) -> Result<Vec<N
     let mut full = vec![0.0; n_full_x];
     let g = grad.values_mut();
     for (i, slot) in g.iter().enumerate() {
-        full[nl.var_x_to_full_x(i as Index) as usize] = *slot;
+        full[nl.var_x_to_full_x(i as Index) as usize] = *slot / row_scale;
     }
     Ok(full)
 }

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -111,6 +111,11 @@ pub struct ActivityReport {
     /// Classified inactive yet `r` non-negligible: barrier curvature
     /// where none should be.
     pub var_contaminated: Vec<bool>,
+    /// The barrier diagonal `Σ_i = z/s` itself per user variable, both
+    /// sides summed; 0 where not classified. The covariance roadmap's
+    /// item 1 subtracts exactly this from the factor's reduced
+    /// Hessian, so it is reported rather than only its ratio to `q`.
+    pub var_sigma: Vec<Number>,
     /// Status per user constraint row.
     pub row_status: Vec<i8>,
     /// `Σ_j / q_j` per user row; `NaN` where not classified.
@@ -122,6 +127,11 @@ pub struct ActivityReport {
     pub row_off_central_path: Vec<bool>,
     /// Contamination check per row, as for variables.
     pub row_contaminated: Vec<bool>,
+    /// The row barrier diagonal `Σ_j = v/s` per user row, both sides
+    /// summed; 0 where not classified. RAW, not the geometric weight
+    /// the classification uses: item 1 restricts the normal to its own
+    /// fitted block and applies its own `‖a‖²` factor there.
+    pub row_sigma: Vec<Number>,
 }
 
 /// The classification rule of the roadmap's item 0.
@@ -235,6 +245,7 @@ fn zero_gradient_row(sigma: Number, floor: Number) -> Entry {
         q_sign: 0,
         off_path: false,
         contaminated: false,
+        sigma,
     }
 }
 
@@ -262,6 +273,8 @@ struct Entry {
     q_sign: i8,
     off_path: bool,
     contaminated: bool,
+    /// The RAW barrier diagonal, whatever weight classification used.
+    sigma: Number,
 }
 
 const NOT_CLASSIFIED: Entry = Entry {
@@ -270,6 +283,7 @@ const NOT_CLASSIFIED: Entry = Entry {
     q_sign: 0,
     off_path: false,
     contaminated: false,
+    sigma: 0.0,
 };
 
 /// Classify one bounded variable or row from its `Σ` and signed `q`.
@@ -285,6 +299,7 @@ fn classify_entry(sigma: Number, q_signed: Number, floor: Number, mu: Number) ->
             q_sign,
             off_path: false,
             contaminated: false,
+            sigma,
         };
     }
     let r = sigma / q;
@@ -295,6 +310,7 @@ fn classify_entry(sigma: Number, q_signed: Number, floor: Number, mu: Number) ->
         q_sign,
         off_path: false,
         contaminated: contaminated(status, r, mu),
+        sigma,
     }
 }
 
@@ -423,8 +439,11 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
                         scratch[k] = 0.0;
                     }
                     // Σ·‖∇d‖² against curvature along the unit
-                    // normal: invariant to rescaling the row
-                    classify_entry(sigma_s[j] * norm2, ghg / norm2, floor, mu)
+                    // normal: invariant to rescaling the row; the
+                    // report keeps the raw Σ
+                    let mut e = classify_entry(sigma_s[j] * norm2, ghg / norm2, floor, mu);
+                    e.sigma = sigma_s[j];
+                    e
                 };
             }
             true
@@ -462,7 +481,9 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
                         .map(|(g, h)| g * h)
                         .sum()
                 };
-                classify_entry(sigma_s[j] * norm2, ghg / norm2, floor, mu)
+                let mut e = classify_entry(sigma_s[j] * norm2, ghg / norm2, floor, mu);
+                e.sigma = sigma_s[j];
+                e
             };
         }
     }
@@ -513,12 +534,73 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
         var_q_sign: var_full.iter().map(|e| e.q_sign).collect(),
         var_off_central_path: var_full.iter().map(|e| e.off_path).collect(),
         var_contaminated: var_full.iter().map(|e| e.contaminated).collect(),
+        var_sigma: var_full.iter().map(|e| e.sigma).collect(),
         row_status: row_full.iter().map(|e| e.status).collect(),
         row_ratio: row_full.iter().map(|e| e.ratio).collect(),
         row_q_sign: row_full.iter().map(|e| e.q_sign).collect(),
         row_off_central_path: row_full.iter().map(|e| e.off_path).collect(),
         row_contaminated: row_full.iter().map(|e| e.contaminated).collect(),
+        row_sigma: row_full.iter().map(|e| e.sigma).collect(),
     }
+}
+
+/// The gradient of one user constraint row at the converged iterate,
+/// in user variable order (length `n_full_x`). Works for equality and
+/// inequality rows alike; entries for `make_parameter`-removed fixed
+/// variables are 0 because the solve dropped their columns.
+pub(crate) fn row_normal(bs: &PdSensBacksolver, user_row: usize) -> Result<Vec<Number>, usize> {
+    let (data, cq, nlp) = bs.activity_handles();
+    let n = {
+        let d = data.borrow();
+        d.curr
+            .as_ref()
+            .expect("converged state has an iterate")
+            .x
+            .dim() as usize
+    };
+    // position of the row within its own c/d block, by the same
+    // ascending scan the report's scatter uses
+    let c_pos = {
+        let nl = nlp.borrow();
+        if user_row >= nl.n_full_g() as usize {
+            return Err(nl.n_full_g() as usize);
+        }
+        nl.full_g_to_c_block(user_row as Index)
+    };
+    let block_pos = match c_pos {
+        Some(p) => p as usize,
+        None => {
+            let nl = nlp.borrow();
+            (0..user_row)
+                .filter(|&g| nl.full_g_to_c_block(g as Index).is_none())
+                .count()
+        }
+    };
+
+    let cq = cq.borrow();
+    let jac = if c_pos.is_some() {
+        cq.curr_jac_c()
+    } else {
+        cq.curr_jac_d()
+    };
+    let m_block = jac.n_rows() as usize;
+    let mspace = DenseVectorSpace::new(m_block as i32);
+    let mut e_row = DenseVector::new(mspace);
+    let nspace = DenseVectorSpace::new(n as i32);
+    let mut grad = DenseVector::new(nspace);
+    e_row.values_mut().fill(0.0);
+    e_row.values_mut()[block_pos] = 1.0;
+    grad.values_mut().fill(0.0);
+    jac.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
+
+    let nl = nlp.borrow();
+    let n_full_x = nl.n_full_x() as usize;
+    let mut full = vec![0.0; n_full_x];
+    let g = grad.values_mut();
+    for (i, slot) in g.iter().enumerate() {
+        full[nl.var_x_to_full_x(i as Index) as usize] = *slot;
+    }
+    Ok(full)
 }
 
 #[cfg(test)]

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -289,8 +289,11 @@ impl Solver {
     }
 
     /// The gradient of user constraint row `user_row` at the converged
-    /// iterate, in user variable order (length `n_full_x`). Equality
-    /// and inequality rows alike; entries for fixed
+    /// iterate, in user variable order (length `n_full_x`) and in
+    /// **natural (unscaled) units**: the internal Jacobian row carries
+    /// the solver's per-row `c_scale`/`d_scale`, which is divided out
+    /// here, so this is the gradient of the row as the user wrote it.
+    /// Equality and inequality rows alike; entries for fixed
     /// (`make_parameter`-removed) variables are 0 because the solve
     /// dropped their columns. Errors on an out-of-range row.
     ///

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -288,6 +288,26 @@ impl Solver {
         Ok(crate::activity::compute(&state.backsolver))
     }
 
+    /// The gradient of user constraint row `user_row` at the converged
+    /// iterate, in user variable order (length `n_full_x`). Equality
+    /// and inequality rows alike; entries for fixed
+    /// (`make_parameter`-removed) variables are 0 because the solve
+    /// dropped their columns. Errors on an out-of-range row.
+    ///
+    /// Serves the covariance roadmap's item 1: a binding row's normal
+    /// restricted to the fitted block is the projection direction.
+    pub fn row_normal(&self, user_row: usize) -> Result<Vec<Number>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        crate::activity::row_normal(&state.backsolver, user_row).map_err(|m| {
+            SolverError::BadShape {
+                what: "row_normal constraint index",
+                got: user_row,
+                expected: m,
+            }
+        })
+    }
+
     /// Solve `K · lhs = rhs` against the converged KKT factor. Both
     /// slices must have length `kkt_dim()`; the layout is the flat
     /// `x || s || y_c || y_d || z_l || z_u || v_l || v_u` packing.

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -269,11 +269,33 @@ problem: its eigenvector is the parameter combination the data cannot
 pin down, and the corresponding `cov.correlation` entries approach
 +/-1. `covariance` warns when the held factor carries
 inertia-correction perturbations (typically an exactly unidentifiable
-parameterization), when a fitted parameter sits on a bound at the
-optimum (its direction is projected out: zero variance, the covariance
-conditional on the active bound, correlation entries reported as 0),
-and when the covariance diagonal comes out negative (not a
-least-squares minimum).
+parameterization) and when the covariance diagonal comes out negative
+(not a least-squares minimum).
+
+Bound and constraint activity is classified from the solve's own
+barrier geometry, not a slack threshold. A STRONGLY ACTIVE bound pins
+its parameter: zero variance, correlations 0, conditional on the
+bound, warned. A WEAKLY ACTIVE bound (slack and multiplier vanish
+together) is KEPT at its full finite variance, corrected for the
+barrier weight the held factor carries; AMBIGUOUS (loosely converged)
+and UNIDENTIFIED (curvature below the model's own noise scale) stay
+in the free block, each with a warning. A strongly active inequality
+CONSTRAINT over the fitted parameters pins a combination rather than
+a coordinate: the matrix is projected on the constraint's null space,
+going singular by one per binding row, and the warning names the
+constraint, the pinned combination, and its conditional information.
+The same limit written as a bound or as a row returns the same matrix.
+A binding row that reaches the fitted parameters through free
+eliminated variables cannot be represented by a restricted normal and
+is kept unprojected with an explicit warning.
+
+To classify honestly, the declaration-triggered solve sets
+`bound_relax_factor = 0` (slacks must measure distance to your own
+bounds). This applies to every solve routed through the sensitivity
+session, not only ones that end in `covariance()`. If you need the
+relaxation, pass `bound_relax_factor` explicitly in `options=`: your
+value wins, and `covariance()` then refuses with a clear error rather
+than classifying against shifted slacks.
 
 **Relation to `pounce.curve_fit`.** This uses the same
 scale-and-invert-the-reduced-Hessian recipe as
@@ -415,7 +437,12 @@ construction rather than by undoing anything: its ratios are formed so
 that rescaling a variable, a constraint row, or the objective leaves
 them fixed. Writing a constraint as `1000·x ≥ 0` instead of `x ≥ 0`
 does not move a status, and neither does the solver's own per-row
-`d_scale`.
+`d_scale`. The values the report exports follow the natural-units
+contract like everything else: `var_sigma` and `row_sigma` are the
+barrier diagonals in the model's own units, and `row_normal(j)` is the
+constraint gradient with the solver's per-row scale divided out;
+classification happens on the scaled quantities internally, the report
+never shows them.
 
 In particular, for a parameter-estimation NLP with the parameters
 pinned by equality constraints, `-inv(info["reduced_hessian"])` is

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -582,8 +582,16 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         # Pyomo convention is silence unless tee=True; print_level 0 makes
         # the engine emit nothing at all.
         prob.add_option("print_level", 0)
-    # user options land after the tee default so an explicit
-    # print_level (or anything else) wins
+    # covariance() classifies bound activity off this solve's iterate
+    # (Solver.classify_activity), which requires slacks measured against
+    # the user's own bounds: bound relaxation (default 1e-8) would shift
+    # every slack the classifier reads. Set BEFORE the user options so
+    # an explicit bound_relax_factor still wins; covariance() then
+    # refuses with its clean error rather than classifying shifted
+    # slacks.
+    prob.add_option("bound_relax_factor", 0.0)
+    # user options land after the defaults so an explicit print_level
+    # (or anything else) wins
     for key, val in (options or {}).items():
         prob.add_option(key, val)
     con_alias = _replaced_aliases(clone, si)
@@ -984,6 +992,61 @@ class Covariance(_ParamMatrix):
         return np.linalg.eigh(self.matrix)
 
 
+def _classify_ratio(r, mu):
+    """The activity rule of covariance roadmap item 0, applied at the
+    reduced fitted block (mirrors pounce_sensitivity::activity)."""
+    if mu > 1e-4:
+        if r < 1e-1:
+            return "inactive"
+        if r > 1e1:
+            return "strongly_active"
+        return "ambiguous"
+    if r < np.sqrt(mu):
+        return "inactive"
+    if r > 1.0 / np.sqrt(mu):
+        return "strongly_active"
+    if 1e-1 <= r <= 1e1:
+        return "weakly_active"
+    return "ambiguous"
+
+
+def _free_nullspace(bind_normals, free):
+    """Projection basis over the free fitted coordinates: the null
+    space of the binding row normals restricted to `free`. A normal
+    that vanished with the pinned coordinates is dropped (its content
+    is already excluded by the free restriction)."""
+    nf = len(free)
+    rows_ = []
+    for a in bind_normals:
+        af = np.asarray(a)[free]
+        nn = float(np.linalg.norm(af))
+        if nn > 1e-12:
+            rows_.append(af / nn)
+    A = np.array(rows_) if rows_ else np.zeros((0, nf))
+    return _nullspace(A)
+
+
+def _nullspace(A):
+    """Orthonormal basis of the null space of A's rows (columns of the
+    returned matrix); the projection basis Z of item 1's row handling."""
+    if A.shape[0] == 0:
+        return np.eye(A.shape[1])
+    _, sv, vh = np.linalg.svd(A, full_matrices=True)
+    tol = max(A.shape) * np.finfo(float).eps * (sv[0] if sv.size else 1.0)
+    rank = int(np.sum(sv > tol))
+    return vh[rank:].T
+
+
+def _minv(M):
+    try:
+        return np.linalg.inv(M)
+    except np.linalg.LinAlgError as e:
+        raise RuntimeError(
+            "covariance: the parameter block of the inverse KKT matrix "
+            "is singular; the fitted parameters are linearly "
+            "dependent (structurally unidentifiable)") from e
+
+
 def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     """Asymptotic covariance of the fitted parameters of a
     least-squares problem, from ONE ordinary solve.
@@ -1048,14 +1111,26 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     callable-model-plus-data surface
     (starting point, robust losses, confidence intervals, prediction
     bands, active-bound projection); use this for a model already written
-    in Pyomo. Like ``curve_fit``, a fitted parameter detected on its
-    bound at the optimum is projected out: the covariance is computed in
-    the remaining free directions (the covariance CONDITIONAL on the
-    active bound) and the pinned parameter reports zero variance, with
-    correlation entries involving it reported as 0. A warning still
-    fires, because boundary asymptotics are nonstandard whichever number
-    is reported. Only variable bounds ON the fitted parameters are
-    detected; other active constraints involving them are not.
+    in Pyomo.
+
+    Bound and constraint activity is classified from the solve's own
+    barrier geometry (the ratio of each direction's barrier weight to
+    its curvature; pounce's covariance roadmap item 1), not from a
+    slack threshold. A STRONGLY ACTIVE bound pins its parameter: zero
+    variance, correlation entries 0, conditional on the bound, with a
+    warning. A WEAKLY ACTIVE bound (slack and multiplier vanish
+    together) is KEPT: the parameter keeps its full finite variance,
+    corrected for the barrier weight the held factor carries, and a
+    warning notes the nonstandard boundary asymptotics. AMBIGUOUS
+    (loosely converged) and UNIDENTIFIED (curvature below the model's
+    own noise scale) parameters stay in the free block with warnings.
+    A strongly active inequality CONSTRAINT involving fitted
+    parameters pins a combination rather than a coordinate: the matrix
+    is projected on the constraint's null space, going singular by one
+    per binding row, and the surviving correlations say what the data
+    still determines (for a + b <= cap binding, corr(a, b) = -1: only
+    the difference is determined). The same limit written as a bound
+    or as a row returns the same matrix (jkitchin/pounce#362).
     """
     if hessian not in ("lagrangian", "gauss-newton"):
         raise ValueError(
@@ -1083,30 +1158,6 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             f"perturbations {pert.tolist()}, so the covariance is "
             "regularized rather than exact. Linearly dependent (structurally"
             " unidentifiable) parameters are the usual cause.")
-    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
-    # a bound moved to a constraint row reads as the no-bound sentinel
-    # +/-1e19 here (finite, so isinf() would never catch it), which would
-    # silently skip the projection for that parameter; put the value the
-    # bound had at the solve point back for the test only
-    for name, (mlo, mhi) in session.moved_bounds.items():
-        r = session.var_entry(name)
-        if mlo is not None:
-            lo[r] = mlo
-        if mhi is not None:
-            hi[r] = mhi
-    active = []
-    for i, p in enumerate(params):
-        r = session.fit_rows[p]
-        xv = float(session.base_x[r])
-        tol = 1e-6 * (1.0 + abs(xv))
-        if xv - lo[r] < tol or hi[r] - xv < tol:
-            active.append(i)
-            warnings.warn(
-                f"covariance: fitted parameter {p.name} sits on its "
-                "bound at the optimum; its direction is projected out "
-                "(zero variance, conditional on the active bound) and "
-                "the boundary asymptotics are nonstandard.")
-
     # ── parameter block of the inverse KKT matrix ─────────────────────────
     dim = session.solver.kkt_dim
     rows = [session.fit_rows[p] for p in params]
@@ -1118,6 +1169,133 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     M = np.array([[zcols[j][rows[i]] for j in range(n_params)]
                   for i in range(n_params)])
     M = 0.5 * (M + M.T)
+
+    # ── membership from the barrier activity classification ──────────────
+    # (covariance roadmap item 1). The classifier's per-coordinate rule
+    # scales Sigma by the coordinate's own Lagrangian curvature, which is
+    # zero for a fitted parameter in the residual-variable idiom (the
+    # curvature lives on the residuals), so the same rule runs HERE on
+    # the reduced fitted block, where the parameter's curvature actually
+    # is: q = the reduced Hessian diagonal with the parameter's own
+    # barrier term removed, Sigma retained by the solve. A weakly active
+    # parameter is KEPT and warned rather than silently pinned; no slack
+    # threshold can make that distinction, because slack and multiplier
+    # are both O(sqrt(mu)) at weak activity.
+    act = session.solver.classify_activity()
+    mu = float(act["mu"])
+    R_W = _minv(M)                # reduced Hessian off the factor, W-based
+    sig_fit = np.array([float(act["var_sigma"][session.fit_rows[p]])
+                        for p in params])
+    q_red = np.abs(np.diag(R_W) - sig_fit)
+    floor = np.sqrt(np.finfo(float).eps) * max(
+        1.0, float(np.abs(np.diag(R_W)).max()))
+    active = []
+    for i, p in enumerate(params):
+        st = act["var_status"][session.fit_rows[p]]
+        if st in ("unbounded", "fixed"):
+            continue                       # no variable bound to classify
+        ri = float(sig_fit[i]) / max(float(q_red[i]), floor)
+        if q_red[i] < floor and ri <= 1e1:
+            # curvature AND barrier weight both below scale: the bound
+            # question does not arise, but the direction is poorly
+            # identified (a dominant Sigma cancelling inside q_red
+            # instead lands ri astronomically high and classifies
+            # strongly active)
+            status = "unidentified"
+        else:
+            status = _classify_ratio(ri, mu)
+        if status == "strongly_active":
+            active.append(i)
+            warnings.warn(
+                f"covariance: fitted parameter {p.name} is held by its "
+                "bound at the optimum (strongly active); its direction is "
+                "projected out (zero variance, conditional on the active "
+                "bound) and the boundary asymptotics are nonstandard.")
+        elif status == "weakly_active":
+            warnings.warn(
+                f"covariance: fitted parameter {p.name} sits exactly on "
+                "its bound with a vanishing multiplier (weakly active). "
+                "It is kept in the free block with finite variance; "
+                "boundary asymptotics are nonstandard.")
+        elif status == "ambiguous":
+            warnings.warn(
+                f"covariance: fitted parameter {p.name} has ambiguous "
+                "bound activity at the solve's final barrier parameter; "
+                "re-solve with a tighter tol to settle it. It is kept in "
+                "the free block.")
+        elif status == "unidentified":
+            warnings.warn(
+                f"covariance: fitted parameter {p.name} has curvature "
+                "below the model's own noise scale (unidentified); its "
+                "variance is large rather than small. It is kept in the "
+                "free block.")
+
+    # ── binding general rows on the fitted block ──────────────────────────
+    # (item 1 row projection, jkitchin/pounce#362). A strongly active
+    # inequality row whose normal touches the fitted parameters pins a
+    # DIRECTION of the fitted block: no per-parameter disposition can
+    # state that, so the free block is reduced on the null space of the
+    # binding normals and pushed back, singular by the number of binding
+    # rows. Rows classify at the reduced level exactly as the variable
+    # bounds above: the row's barrier weight against the curvature along
+    # its own normal. A bound moved onto a row by declared-parameter
+    # reformulation (jkitchin/pounce#357) is the single-coordinate case
+    # and reproduces the variable disposition exactly.
+    R_corr = R_W - np.diag(sig_fit)
+    bind_normals = []                  # unit normals over the fitted block
+    for j, rst in enumerate(act["row_status"]):
+        if rst in ("equality", "unbounded"):
+            continue
+        a = np.asarray(session.solver.row_normal(j), dtype=float)[rows]
+        na = float(np.linalg.norm(a))
+        if na == 0.0:
+            continue                   # row does not touch the fitted block
+        a = a / na
+        # the row's slack elimination contributes Sigma_j * (raw normal
+        # outer product) to the reduced block; in the unit-normal basis
+        # that coefficient is Sigma_j * ||raw normal||^2
+        sig_row = float(act["row_sigma"][j]) * na * na
+        q_w = float(a @ R_corr @ a)
+        q_row = abs(q_w - sig_row)
+        ri = sig_row / max(q_row, floor)
+        if q_row < floor and ri <= 1e1:
+            status = "unidentified"
+        else:
+            status = _classify_ratio(ri, mu)
+        cname = (session.con_names[j] if j < len(session.con_names)
+                 else f"row {j}")
+        combo = " + ".join(
+            f"{a[k]:.3g}*{params[k].name}" for k in range(n_params)
+            if abs(a[k]) > 1e-12)
+        if status == "strongly_active":
+            bind_normals.append(a)
+            # conditional information along the pinned combination: the
+            # factor's curvature along the normal with the row's own
+            # barrier weight removed. Loses log10(Sigma/q) digits at
+            # tight mu; item 2's exact-Hessian construction replaces it.
+            s_a = max(q_w - sig_row, 0.0)
+            warnings.warn(
+                f"covariance: constraint {cname} is strongly active and "
+                f"pins the fitted combination {combo}; variance along it "
+                "is projected to zero (conditional on the constraint). "
+                f"Conditional information along the combination: {s_a:.6g}.")
+        elif status == "weakly_active":
+            warnings.warn(
+                f"covariance: constraint {cname} is weakly active on the "
+                f"fitted combination {combo} (multiplier and slack vanish "
+                "together). It is kept unprojected with finite variance; "
+                "boundary asymptotics are nonstandard.")
+        elif status == "ambiguous":
+            warnings.warn(
+                f"covariance: constraint {cname} has ambiguous activity "
+                f"on the fitted combination {combo} at the solve's final "
+                "barrier parameter; re-solve with a tighter tol to "
+                "settle it. It is kept unprojected.")
+        if status in ("weakly_active", "ambiguous"):
+            # the row analog of the variable value correction: remove a
+            # kept row's own barrier weight from the reduced block (for
+            # an inactive row that weight is O(mu) and is left alone)
+            R_corr = R_corr - sig_row * np.outer(a, a)
 
     # ── noise variance per group ──────────────────────────────────────────
     groups = dict(session.res_rows)
@@ -1194,13 +1372,7 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     )
 
     def minv():
-        try:
-            return np.linalg.inv(M)
-        except np.linalg.LinAlgError as e:
-            raise RuntimeError(
-                "covariance: the parameter block of the inverse KKT matrix "
-                "is singular; the fitted parameters are linearly "
-                "dependent (structurally unidentifiable)") from e
+        return _minv(M)
 
     def group_jacobians():
         # The Jacobian rows are recovered from the same backsolves: the
@@ -1238,8 +1410,12 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
         # Grouped: cov = inv(J^T J) (sum_g s_g^2 Jg^T Jg) inv(J^T J).
         Js = {g: Jg[:, free] for g, Jg in group_jacobians().items()}
         G = sum(Jg.T @ Jg for Jg in Js.values())
+        Zb = _free_nullspace(bind_normals, free)
         try:
-            Ginv = np.linalg.inv(G)
+            if Zb.shape[1] == 0:
+                Ginv = np.zeros((len(free), len(free)))
+            else:
+                Ginv = Zb @ np.linalg.inv(Zb.T @ G @ Zb) @ Zb.T
         except np.linalg.LinAlgError as e:
             raise RuntimeError(
                 "covariance: the Gauss-Newton matrix J^T J is singular; "
@@ -1253,17 +1429,28 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
                 B += group_sigma[g] * (Jg.T @ Jg)
             cov = embed(Ginv @ B @ Ginv)
     else:
-        if len(free) == n_params:
-            Mc = M
-        else:
-            try:
-                Mc = np.linalg.inv(minv()[np.ix_(free, free)])
-            except np.linalg.LinAlgError as e:
-                raise RuntimeError(
-                    "covariance: the reduced Hessian restricted to the "
-                    "free (off-bound) parameters is singular; the "
-                    "remaining fitted parameters are linearly dependent"
-                ) from e
+        # R_corr is the reduced Hessian with the item-1 value
+        # corrections applied: the fitted rows' own barrier diagonal
+        # subtracted (a weakly active kept parameter reports its true
+        # curvature q, not the factor's 2q) and kept rows' barrier
+        # weight removed. Active rows and binding normals never enter:
+        # coordinates are excluded by the free restriction, directions
+        # are annihilated by the projection basis Z (which also
+        # annihilates the binding rows' huge barrier weight, exactly).
+        Rff = R_corr[np.ix_(free, free)]
+        Zb = _free_nullspace(bind_normals, free)
+        try:
+            if Zb.shape[1] == 0:
+                Mc = np.zeros((len(free), len(free)))
+            else:
+                Mc = Zb @ np.linalg.inv(Zb.T @ Rff @ Zb) @ Zb.T
+        except np.linalg.LinAlgError as e:
+            raise RuntimeError(
+                "covariance: the reduced Hessian restricted to the "
+                "free (off-bound, off-constraint) parameters is "
+                "singular; the remaining fitted parameters are "
+                "linearly dependent"
+            ) from e
         if homoscedastic:
             s2 = sig_vals[0]
             cov = embed(2.0 * s2 * Mc)

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1184,8 +1184,17 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     act = session.solver.classify_activity()
     mu = float(act["mu"])
     R_W = _minv(M)                # reduced Hessian off the factor, W-based
+    # M (and so R_W) is natural-units by the kkt_solve contract
+    # (pounce#128), while the report's Sigma is the solver's
+    # scaled-space value: with objective scaling active it carries the
+    # factor df, and subtracting it unnormalized would miscorrect by
+    # exactly that factor. The per-row constraint scale cancels
+    # algebraically in the row block below (Sigma gains dg^-2, the
+    # scaled normal's squared length gains dg^2), so df is the only
+    # factor to remove there too.
+    obj_scale = float(session.solver.nlp_scaling["obj"] or 1.0)
     sig_fit = np.array([float(act["var_sigma"][session.fit_rows[p]])
-                        for p in params])
+                        for p in params]) / obj_scale
     q_red = np.abs(np.diag(R_W) - sig_fit)
     floor = np.sqrt(np.finfo(float).eps) * max(
         1.0, float(np.abs(np.diag(R_W)).max()))
@@ -1242,19 +1251,72 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     # reformulation (jkitchin/pounce#357) is the single-coordinate case
     # and reproduces the variable disposition exactly.
     R_corr = R_W - np.diag(sig_fit)
+    # columns held constant by the declared-parameter pins: a row's
+    # support there contributes nothing through elimination (the pin
+    # variable cannot move), so it does not make the row "mixed". The
+    # pin constraint's normal is e_{pin var}, so its support IS the
+    # pin column.
+    pin_cols = set()
+    for _pr in session.pins.values():
+        _pn = np.asarray(session.solver.row_normal(int(_pr)), dtype=float)
+        pin_cols.update(int(i) for i in np.nonzero(_pn)[0])
+    fit_cols = set(int(r) for r in rows)
     bind_normals = []                  # unit normals over the fitted block
     for j, rst in enumerate(act["row_status"]):
         if rst in ("equality", "unbounded"):
             continue
-        a = np.asarray(session.solver.row_normal(j), dtype=float)[rows]
+        a_full = np.asarray(session.solver.row_normal(j), dtype=float)
+        a = a_full[rows]
         na = float(np.linalg.norm(a))
         if na == 0.0:
             continue                   # row does not touch the fitted block
+        # A row whose normal also touches NON-fitted variables pins a
+        # combination that reaches the fitted block through the
+        # eliminated variables, not along the restricted normal: e.g.
+        # a + r_1 <= cap with r_1 = y_1 - a - b*x_1 actually pins a
+        # b-direction, while the restricted normal reads e_a. The
+        # restricted projection would delete the wrong direction, so a
+        # mixed binding row is kept unprojected with an explicit
+        # warning instead. The general treatment needs the row's
+        # reduced normal through the elimination (roadmap item 2's
+        # machinery).
+        nf = float(np.linalg.norm(a_full))
+        outside = [i for i in np.nonzero(a_full)[0]
+                   if int(i) not in fit_cols and int(i) not in pin_cols]
+        mixed = bool(outside) and (
+            float(np.linalg.norm(a_full[outside])) > 1e-8 * max(1.0, nf))
+        cname = (session.con_names[j] if j < len(session.con_names)
+                 else f"row {j}")
+        if mixed:
+            # the reduced-level rule is also unreliable here: the row's
+            # barrier weight lands through elimination on a direction
+            # the restricted normal cannot see, so re-classifying
+            # against it manufactures a wrong ratio. Item 0's raw
+            # classification (scale-invariant along the full normal) is
+            # the honest status for a mixed row.
+            if rst == "strongly_active":
+                warnings.warn(
+                    f"covariance: constraint {cname} is strongly active "
+                    "and involves non-fitted variables; the direction "
+                    "it pins reaches the fitted parameters through the "
+                    "eliminated variables and cannot be represented by "
+                    "a restricted normal, so it is NOT projected. Treat "
+                    "the returned variances as not conditioned on this "
+                    "constraint.")
+            elif rst in ("weakly_active", "ambiguous", "unidentified"):
+                warnings.warn(
+                    f"covariance: constraint {cname} is {rst} and "
+                    "involves non-fitted variables; it is kept "
+                    "unprojected and its barrier weight is not "
+                    "corrected for (the restricted direction would be "
+                    "the wrong one). Boundary asymptotics are "
+                    "nonstandard.")
+            continue
         a = a / na
         # the row's slack elimination contributes Sigma_j * (raw normal
         # outer product) to the reduced block; in the unit-normal basis
-        # that coefficient is Sigma_j * ||raw normal||^2
-        sig_row = float(act["row_sigma"][j]) * na * na
+        # that coefficient is Sigma_j * ||raw normal||^2. df as above.
+        sig_row = float(act["row_sigma"][j]) * na * na / obj_scale
         q_w = float(a @ R_corr @ a)
         q_row = abs(q_w - sig_row)
         ri = sig_row / max(q_row, floor)
@@ -1262,8 +1324,6 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             status = "unidentified"
         else:
             status = _classify_ratio(ri, mu)
-        cname = (session.con_names[j] if j < len(session.con_names)
-                 else f"row {j}")
         combo = " + ".join(
             f"{a[k]:.3g}*{params[k].name}" for k in range(n_params)
             if abs(a[k]) > 1e-12)

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -141,9 +141,10 @@ def _reformulate_param_bounds(clone):
     Runs after `setup_sensitivity`, so the Param-to-Var map it needs is the
     one the surgery has already built. Returns {var name: (lb, ub)} of the
     numeric values the moved bounds had at the solve point, with None on the
-    side that was not moved; covariance()'s active-bound projection reads
-    NL bounds, which for these rows now hold the reader's no-bound sentinel
-    of +/-1e19. That value is finite, so an isinf() test would never fire.
+    side that was not moved. covariance() classifies these rows through the
+    activity report: a moved bound is a single-coordinate constraint row
+    and projects exactly as the original bound would, so no bound
+    re-injection is needed anywhere.
     """
     block = clone.component(SensitivityInterface.get_default_block_name())
     if block is None:
@@ -994,7 +995,13 @@ class Covariance(_ParamMatrix):
 
 def _classify_ratio(r, mu):
     """The activity rule of covariance roadmap item 0, applied at the
-    reduced fitted block (mirrors pounce_sensitivity::activity)."""
+    reduced fitted block. Mirrors pounce_sensitivity::activity with one
+    deliberate divergence: the Rust classifier maps q below the floor
+    to `unidentified` unconditionally, while the caller here first
+    checks the ratio, because at the reduced level a huge Sigma
+    cancelling inside q_red would otherwise misfile a strongly active
+    entry as unidentified. Exposing the rule from pounce-py so one
+    implementation serves both is item-2 follow-up."""
     if mu > 1e-4:
         if r < 1e-1:
             return "inactive"
@@ -1185,16 +1192,11 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
     mu = float(act["mu"])
     R_W = _minv(M)                # reduced Hessian off the factor, W-based
     # M (and so R_W) is natural-units by the kkt_solve contract
-    # (pounce#128), while the report's Sigma is the solver's
-    # scaled-space value: with objective scaling active it carries the
-    # factor df, and subtracting it unnormalized would miscorrect by
-    # exactly that factor. The per-row constraint scale cancels
-    # algebraically in the row block below (Sigma gains dg^-2, the
-    # scaled normal's squared length gains dg^2), so df is the only
-    # factor to remove there too.
-    obj_scale = float(session.solver.nlp_scaling["obj"] or 1.0)
+    # (pounce#128), and so are the report's sigmas and row_normal
+    # (unscaled at the classifier boundary per the same contract), so
+    # everything here composes without scale factors.
     sig_fit = np.array([float(act["var_sigma"][session.fit_rows[p]])
-                        for p in params]) / obj_scale
+                        for p in params])
     q_red = np.abs(np.diag(R_W) - sig_fit)
     floor = np.sqrt(np.finfo(float).eps) * max(
         1.0, float(np.abs(np.diag(R_W)).max()))
@@ -1262,14 +1264,19 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
         pin_cols.update(int(i) for i in np.nonzero(_pn)[0])
     fit_cols = set(int(r) for r in rows)
     bind_normals = []                  # unit normals over the fitted block
+    row_corrections = []               # (weight, unit normal), applied after
     for j, rst in enumerate(act["row_status"]):
-        if rst in ("equality", "unbounded"):
+        if rst in ("equality", "unbounded", "inactive"):
+            # inactive rows carry O(mu) geometric weight (the invariant
+            # form), the same order as every other accepted O(mu) term;
+            # skipping them also avoids fetching every row normal on
+            # wide models (an O(m*n) sweep). The bound and row
+            # spellings of an INACTIVE limit therefore agree to O(mu)
+            # rather than exactly, tested at that tolerance.
             continue
         a_full = np.asarray(session.solver.row_normal(j), dtype=float)
         a = a_full[rows]
         na = float(np.linalg.norm(a))
-        if na == 0.0:
-            continue                   # row does not touch the fitted block
         # A row whose normal also touches NON-fitted variables pins a
         # combination that reaches the fitted block through the
         # eliminated variables, not along the restricted normal: e.g.
@@ -1285,6 +1292,10 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
                    if int(i) not in fit_cols and int(i) not in pin_cols]
         mixed = bool(outside) and (
             float(np.linalg.norm(a_full[outside])) > 1e-8 * max(1.0, nf))
+        if na <= 1e-12 * max(1.0, nf):
+            # entirely outside the fitted block: the extreme mixed case
+            # (relative tolerance, matching the mixed test above)
+            mixed = True
         cname = (session.con_names[j] if j < len(session.con_names)
                  else f"row {j}")
         if mixed:
@@ -1315,9 +1326,13 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
         a = a / na
         # the row's slack elimination contributes Sigma_j * (raw normal
         # outer product) to the reduced block; in the unit-normal basis
-        # that coefficient is Sigma_j * ||raw normal||^2. df as above.
-        sig_row = float(act["row_sigma"][j]) * na * na / obj_scale
+        # that coefficient is Sigma_j * ||raw normal||^2 (all natural
+        # units: the report unscales at the classifier boundary)
+        sig_row = float(act["row_sigma"][j]) * na * na
         q_w = float(a @ R_corr @ a)
+        # |q|, matching the Rust classifier: indefinite curvature
+        # classifies on magnitude, and indefiniteness still surfaces
+        # through the negative-variance warning downstream
         q_row = abs(q_w - sig_row)
         ri = sig_row / max(q_row, floor)
         if q_row < floor and ri <= 1e1:
@@ -1351,11 +1366,21 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
                 f"on the fitted combination {combo} at the solve's final "
                 "barrier parameter; re-solve with a tighter tol to "
                 "settle it. It is kept unprojected.")
+        elif status == "unidentified":
+            warnings.warn(
+                f"covariance: constraint {cname} has curvature below "
+                f"the fitted block's noise scale on {combo} "
+                "(unidentified); it is kept unprojected and its "
+                "variance is large rather than small.")
         if status in ("weakly_active", "ambiguous"):
-            # the row analog of the variable value correction: remove a
-            # kept row's own barrier weight from the reduced block (for
-            # an inactive row that weight is O(mu) and is left alone)
-            R_corr = R_corr - sig_row * np.outer(a, a)
+            # collected, applied after the loop: every row classifies
+            # against the same snapshot, so results do not depend on
+            # the order rows happen to be visited in
+            row_corrections.append((sig_row, a))
+    for _w, _a in row_corrections:
+        # the row analog of the variable value correction: remove a
+        # kept row's own barrier weight from the reduced block
+        R_corr = R_corr - _w * np.outer(_a, _a)
 
     # ── noise variance per group ──────────────────────────────────────────
     groups = dict(session.res_rows)
@@ -1438,6 +1463,14 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
         # The Jacobian rows are recovered from the same backsolves: the
         # residual rows of the z-columns equal J * inv(d2f/dp2), so
         # J = Z_r * inv(M).
+        # No Sigma correction is needed on this path, by an exact
+        # identity: the residual rows of the K-inverse columns are J
+        # times the W-based parameter sensitivities, Z_r = J @ M, so
+        # Z_r @ inv(M) = J exactly and the factor's barrier weight
+        # cancels regardless of Sigma. The Lagrangian branch corrects
+        # R_W because it USES the W-based reduced Hessian; Gauss-Newton
+        # rebuilds from the exact J instead. Pinned empirically by the
+        # GN counterpart of the weakly-active analytic test.
         Mi = minv()
         out = {}
         for g, rws in groups.items():
@@ -1489,28 +1522,37 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
                 B += group_sigma[g] * (Jg.T @ Jg)
             cov = embed(Ginv @ B @ Ginv)
     else:
-        # R_corr is the reduced Hessian with the item-1 value
-        # corrections applied: the fitted rows' own barrier diagonal
-        # subtracted (a weakly active kept parameter reports its true
-        # curvature q, not the factor's 2q) and kept rows' barrier
-        # weight removed. Active rows and binding normals never enter:
-        # coordinates are excluded by the free restriction, directions
-        # are annihilated by the projection basis Z (which also
-        # annihilates the binding rows' huge barrier weight, exactly).
-        Rff = R_corr[np.ix_(free, free)]
-        Zb = _free_nullspace(bind_normals, free)
-        try:
-            if Zb.shape[1] == 0:
-                Mc = np.zeros((len(free), len(free)))
-            else:
-                Mc = Zb @ np.linalg.inv(Zb.T @ Rff @ Zb) @ Zb.T
-        except np.linalg.LinAlgError as e:
-            raise RuntimeError(
-                "covariance: the reduced Hessian restricted to the "
-                "free (off-bound, off-constraint) parameters is "
-                "singular; the remaining fitted parameters are "
-                "linearly dependent"
-            ) from e
+        if (not bind_normals and not row_corrections
+                and len(free) == n_params
+                and float(np.abs(sig_fit).max()) <= floor):
+            # nothing active, nothing to correct above noise scale: M
+            # is already the answer, and skipping inv(inv(M)) spares
+            # the conditioning round-trip on the common all-free path
+            Mc = M
+        else:
+            # R_corr is the reduced Hessian with the item-1 value
+            # corrections applied: the fitted rows' own barrier
+            # diagonal subtracted (a weakly active kept parameter
+            # reports its true curvature q, not the factor's 2q) and
+            # kept rows' barrier weight removed. Active rows and
+            # binding normals never enter: coordinates are excluded by
+            # the free restriction, directions are annihilated by the
+            # projection basis Z (which also annihilates the binding
+            # rows' huge barrier weight, exactly).
+            Rff = R_corr[np.ix_(free, free)]
+            Zb = _free_nullspace(bind_normals, free)
+            try:
+                if Zb.shape[1] == 0:
+                    Mc = np.zeros((len(free), len(free)))
+                else:
+                    Mc = Zb @ np.linalg.inv(Zb.T @ Rff @ Zb) @ Zb.T
+            except np.linalg.LinAlgError as e:
+                raise RuntimeError(
+                    "covariance: the reduced Hessian restricted to the "
+                    "free (off-bound, off-constraint) parameters is "
+                    "singular; the remaining fitted parameters are "
+                    "linearly dependent"
+                ) from e
         if homoscedastic:
             s2 = sig_vals[0]
             cov = embed(2.0 * s2 * Mc)

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -640,3 +640,18 @@ def test_issue_362_row_pinned_variable_projects():
             cov = covariance(m, sigma_sq=0.05**2)
         assert cov.std_err[m.A] == 0.0, spelling
         assert any("strongly active" in str(x.message) for x in w), spelling
+
+
+def test_explicit_bound_relax_refuses_covariance():
+    """An explicit user bound_relax_factor wins over the sens solve's
+    forced 0 (options land after defaults), and covariance() then
+    refuses with the classifier's clean error instead of classifying
+    slacks measured against relaxed bounds."""
+    x, y, X = linear_data()
+    m = linear_model(x, y, declare=False)
+    declare_fitted(m.a, m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(
+        m, options={"bound_relax_factor": 1e-8})
+    with pytest.raises(ValueError, match="bound_relax_factor"):
+        covariance(m, sigma_sq=SIGMA_LIN**2)

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -703,3 +703,101 @@ def test_inactive_row_spelling_agrees_to_o_mu():
         covA = covariance(mA, sigma_sq=SIGMA_LIN**2)
         covB = covariance(mB, sigma_sq=SIGMA_LIN**2)
     np.testing.assert_allclose(covB.matrix, covA.matrix, rtol=1e-7)
+
+
+
+class _ScalarStudy:
+    """min ½x² − p·x, the activity-classification study model.
+
+    Moving the unconstrained minimizer `p` walks the three regimes the
+    Rust and Python rules share: p > 0 puts it strictly inside the
+    limit x ≥ 0 (inactive), p < 0 outside (strongly active), p = 0
+    exactly on it (weakly active). Curvature is 1 by construction, so
+    `q` never sinks under the identification floor and the Rust
+    classifier returns a real status instead of `unidentified` --
+    unlike a fitted parameter in the residual-variable idiom, whose
+    raw Lagrangian diagonal is zero. `row` spells the same limit as a
+    constraint row (x unbounded, row x ≥ 0) instead of a bound.
+    """
+
+    def __init__(self, p, row):
+        self.p, self.row = p, row
+
+    def objective(self, x):
+        return 0.5 * x[0] ** 2 - self.p * x[0]
+
+    def gradient(self, x):
+        return np.array([x[0] - self.p])
+
+    def constraints(self, x):
+        return np.array([x[0]]) if self.row else np.array([])
+
+    def jacobianstructure(self):
+        if not self.row:
+            e = np.array([], dtype=np.int64)
+            return e, e
+        return np.array([0]), np.array([0])
+
+    def jacobian(self, x):
+        return np.array([1.0]) if self.row else np.array([])
+
+    def hessianstructure(self):
+        z = np.array([0], dtype=np.int64)
+        return z, z
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([obj_factor])
+
+
+def _study_report(p, row):
+    import pounce
+
+    prob = pounce.Problem(
+        n=1, m=1 if row else 0, problem_obj=_ScalarStudy(p, row),
+        lb=[-1e19] if row else [0.0], ub=[1e19],
+        cl=[0.0] if row else [], cu=[1e19] if row else [],
+    )
+    for k, v in (("tol", 1e-10), ("bound_relax_factor", 0.0),
+                 ("print_level", 0), ("sb", "yes")):
+        prob.add_option(k, v)
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([0.5]))
+    assert info["status_msg"] == "Solve_Succeeded", (p, row, info)
+    return solver.classify_activity()
+
+
+def test_classify_ratio_agrees_with_the_rust_classifier():
+    """Drift guard: `_classify_ratio` re-implements
+    pounce_sensitivity::activity's rule in Python, and today nothing
+    fails if only one of the two moves. Both are branch-tested in
+    isolation (`test_classify_ratio_covers_all_branches` here, the
+    `classify` tests in activity.rs), but neither pins them to EACH
+    OTHER. This drives real solves through the Rust classifier and
+    requires every classified entry to re-derive its own status from
+    the report's own `(ratio, mu)` through the Python rule.
+
+    `unidentified` is the one deliberate divergence and is exempt:
+    Rust maps `q` below the identification floor there unconditionally
+    and reports `Σ/floor` as a lower bound rather than the ratio, so
+    the Python rule -- which only ever sees a ratio -- neither can nor
+    should reproduce it.
+    """
+    from pyomo_pounce.sens import _classify_ratio
+
+    seen = set()
+    for p, expected in ((1.0, "inactive"), (0.0, "weakly_active"),
+                        (-1.0, "strongly_active")):
+        for row in (False, True):
+            rep = _study_report(p, row)
+            mu = float(rep["mu"])
+            key = "row" if row else "var"
+            st = rep[f"{key}_status"][0]
+            r = float(rep[f"{key}_ratio"][0])
+            assert st == expected, (p, row, st)      # fixture still valid
+            assert np.isfinite(r)
+            assert _classify_ratio(r, mu) == st, (
+                f"{key} spelling, p={p}: Rust says {st}, the Python rule "
+                f"says {_classify_ratio(r, mu)} for r={r:.6g}, mu={mu:.6g}")
+            seen.add(st)
+
+    assert seen == {"inactive", "weakly_active", "strongly_active"}, seen

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -504,3 +504,107 @@ def test_bound_and_row_spellings_agree():
         covB = covariance(mB, sigma_sq=SIGMA_LIN**2)
     np.testing.assert_allclose(covB.matrix, covA.matrix,
                                rtol=1e-6, atol=1e-12)
+
+
+def test_weak_row_and_bound_spellings_agree():
+    # the weak regime through the row machinery: optimum exactly on the
+    # limit spelled as a constraint row. Kept, warned, value-corrected
+    # (the kept row's barrier weight is subtracted), and identical to
+    # the bound spelling and to the unconstrained analytic covariance.
+    x, y, X = linear_data()
+    beta = np.linalg.solve(X.T @ X, X.T @ y)
+    y2 = y + (2.0 - beta[0])
+
+    mA = linear_model(x, y2, declare=False)
+    mA.a.setlb(2.0)
+    declare_fitted(mA.a)
+    declare_fitted(mA.b)
+    declare_residual(mA.r)
+    pyo.SolverFactory("pounce").solve(mA)
+
+    mB = linear_model(x, y2, declare=False)
+    mB.lim = pyo.Constraint(expr=mB.a >= 2.0)
+    declare_fitted(mB.a)
+    declare_fitted(mB.b)
+    declare_residual(mB.r)
+    pyo.SolverFactory("pounce").solve(mB)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        covA = covariance(mA, sigma_sq=SIGMA_LIN**2)
+        covB = covariance(mB, sigma_sq=SIGMA_LIN**2)
+    assert sum("weakly active" in str(wi.message) for wi in w) == 2
+    cov_true = SIGMA_LIN**2 * np.linalg.inv(X.T @ X)
+    np.testing.assert_allclose(covA.matrix, cov_true, rtol=1e-4)
+    np.testing.assert_allclose(covB.matrix, covA.matrix, rtol=1e-4)
+
+
+def test_objective_scaling_does_not_move_the_correction():
+    # data two orders larger, pushing the max gradient past
+    # nlp_scaling_max_gradient so gradient-based scaling engages
+    # (df != 1). The report's Sigma is scaled-space; unnormalized it
+    # would miscorrect the weakly active kept variance by exactly df.
+    scale = 400.0
+    rng = np.random.default_rng(7)
+    x = np.linspace(0.0, 4.0, N_LIN)
+    y = scale * (1.5 - 0.7 * x) + (scale * SIGMA_LIN) * rng.standard_normal(N_LIN)
+    X = np.column_stack([np.ones(N_LIN), x])
+    beta = np.linalg.solve(X.T @ X, X.T @ y)
+    y2 = y + (2.0 - beta[0])
+    m = linear_model(x, y2, declare=False)
+    m.a.setlb(2.0)
+    # gradient-based scaling reads the STARTING point; residuals
+    # initialize to 0 there (gradient 2r = 0), so seed them large to
+    # push the max objective gradient past nlp_scaling_max_gradient
+    for i in m.I:
+        m.r[i].set_value(400.0)
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+    session = m.__dict__["_pounce_sens"].session
+    assert abs(float(session.solver.nlp_scaling["obj"]) - 1.0) > 1e-6
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cov = covariance(m, sigma_sq=(scale * SIGMA_LIN) ** 2)
+    assert any("weakly active" in str(wi.message) for wi in w)
+    cov_true = (scale * SIGMA_LIN) ** 2 * np.linalg.inv(X.T @ X)
+    np.testing.assert_allclose(cov.matrix, cov_true, rtol=1e-4)
+
+
+def test_mixed_normal_binding_row_warns_not_projects():
+    # a + r[0] <= cap: after eliminating r[0] = y0 - a - b*x0 the row
+    # actually pins y0 - b*x0, a b-direction; the restricted normal
+    # reads e_a and would project the wrong direction. The honest
+    # v0.10 behavior: keep unprojected, warn explicitly.
+    x, y, X = linear_data()
+    beta = np.linalg.solve(X.T @ X, X.T @ y)
+    k = 12                                   # x[k] != 0, so b survives
+    rk = float(y[k] - beta[0] - beta[1] * x[k])
+    cap = float(beta[0] + rk) - 0.5          # binds at the optimum
+    m = linear_model(x, y, declare=False)
+    m.capcon = pyo.Constraint(expr=m.a + m.r[k] <= cap)
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cov = covariance(m, sigma_sq=SIGMA_LIN**2)
+    assert any("involves non-fitted variables" in str(wi.message)
+               for wi in w)
+    # unprojected: full rank, no zero direction
+    ev = np.linalg.eigvalsh(cov.matrix)
+    assert ev[0] > 1e-12 * ev[-1]
+
+
+def test_classify_ratio_covers_all_branches():
+    from pyomo_pounce.sens import _classify_ratio
+    assert _classify_ratio(1e-12, 1e-10) == "inactive"
+    assert _classify_ratio(1.0, 1e-10) == "weakly_active"
+    assert _classify_ratio(1e12, 1e-10) == "strongly_active"
+    assert _classify_ratio(1e-4, 1e-10) == "ambiguous"     # gap low
+    assert _classify_ratio(1e4, 1e-10) == "ambiguous"      # gap high
+    assert _classify_ratio(0.05, 1e-2) == "inactive"       # mu branch
+    assert _classify_ratio(1.0, 1e-2) == "ambiguous"
+    assert _classify_ratio(50.0, 1e-2) == "strongly_active"

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -608,3 +608,35 @@ def test_classify_ratio_covers_all_branches():
     assert _classify_ratio(0.05, 1e-2) == "inactive"       # mu branch
     assert _classify_ratio(1.0, 1e-2) == "ambiguous"
     assert _classify_ratio(50.0, 1e-2) == "strongly_active"
+
+
+def test_issue_362_row_pinned_variable_projects():
+    """The defect of gh #362, its own reproduction: five residuals pull
+    A above a cap of 1.0. As a variable bound the old code projected
+    (std_err 0.0, warned); as a Constraint it silently returned the
+    barrier's leftover variance (7.9e-6 in the report) with no signal.
+    Both spellings must project to exactly zero and warn."""
+    def build(spelling):
+        m = pyo.ConcreteModel()
+        m.I = pyo.RangeSet(5)
+        if spelling == "bound":
+            m.A = pyo.Var(bounds=(None, 1.0), initialize=0.5)
+        else:
+            m.A = pyo.Var(initialize=0.5)
+            m.cap = pyo.Constraint(expr=m.A <= 1.0)
+        m.r = pyo.Var(m.I, initialize=0.0)
+        m.res = pyo.Constraint(
+            m.I, rule=lambda mm, i: mm.r[i] == 3.0 - mm.A)
+        m.obj = pyo.Objective(expr=sum(m.r[i] ** 2 for i in m.I))
+        declare_fitted(m.A)
+        declare_residual(m.r)
+        return m
+
+    for spelling in ("bound", "row"):
+        m = build(spelling)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            pyo.SolverFactory("pounce").solve(m)
+            cov = covariance(m, sigma_sq=0.05**2)
+        assert cov.std_err[m.A] == 0.0, spelling
+        assert any("strongly active" in str(x.message) for x in w), spelling

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -402,3 +402,105 @@ def test_varargs_declarations_equal_singles():
     pyo.SolverFactory("pounce").solve(m2)
     cov_single = covariance(m2)
     np.testing.assert_allclose(cov_va.matrix, cov_single.matrix, rtol=1e-9)
+
+
+def test_weakly_active_bound_kept_with_true_variance():
+    # data shifted so the unconstrained intercept optimum sits EXACTLY
+    # on its bound: slack and multiplier vanish together (weakly
+    # active). The classifier keeps the parameter and the value
+    # correction removes the barrier diagonal, so the variance is the
+    # full unconstrained one; the factor alone would report half of it
+    # (W = H + Sigma with Sigma = q at weak activity), and the old
+    # slack test would have deleted it outright.
+    x, y, X = linear_data()
+    beta = np.linalg.solve(X.T @ X, X.T @ y)
+    y2 = y + (2.0 - beta[0])
+    m = linear_model(x, y2, declare=False)
+    m.a.setlb(2.0)
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cov = covariance(m, sigma_sq=SIGMA_LIN**2)
+    assert any("weakly active" in str(wi.message) for wi in w)
+    cov_true = SIGMA_LIN**2 * np.linalg.inv(X.T @ X)
+    np.testing.assert_allclose(cov.matrix, cov_true, rtol=1e-5)
+
+
+def test_inactive_bound_changes_nothing():
+    # a far-away bound classifies inactive: no warning, and the
+    # numbers match the boundless model to solver precision (the
+    # Sigma subtraction removes an O(mu) drift, never adds one)
+    x, y, X = linear_data()
+    m = linear_model(x, y, declare=False)
+    m.a.setlb(-50.0)
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cov = covariance(m, sigma_sq=SIGMA_LIN**2)
+    assert not w
+    cov_true = SIGMA_LIN**2 * np.linalg.inv(X.T @ X)
+    np.testing.assert_allclose(cov.matrix, cov_true, rtol=1e-7)
+
+
+def test_binding_row_projects_the_combination():
+    # a + b <= cap binding: zero variance along (1,1), finite along
+    # the difference, correlation -1, and the matrix equals the
+    # restricted-least-squares covariance of the equality-constrained
+    # fit. Gauss-Newton agrees on this linear model (step-6 parity).
+    x, y, X = linear_data()
+    beta = np.linalg.solve(X.T @ X, X.T @ y)
+    cap = float(beta[0] + beta[1]) - 0.5
+    m = linear_model(x, y, declare=False)
+    m.capcon = pyo.Constraint(expr=m.a + m.b <= cap)
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        cov = covariance(m, sigma_sq=SIGMA_LIN**2)
+    assert any("pins the fitted combination" in str(wi.message) for wi in w)
+    C = cov.matrix
+    u = np.array([1.0, 1.0])
+    assert abs(u @ C @ u) < 1e-9 * max(1.0, float(np.abs(C).max()))
+    assert cov.correlation[m.a, m.b] == pytest.approx(-1.0, abs=1e-6)
+    # restricted least squares: C_r = C0 - C0 u (u' C0 u)^-1 u' C0
+    C0 = SIGMA_LIN**2 * np.linalg.inv(X.T @ X)
+    Cr = C0 - np.outer(C0 @ u, u @ C0) / float(u @ C0 @ u)
+    np.testing.assert_allclose(C, Cr, rtol=1e-5, atol=1e-12)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cov_gn = covariance(m, sigma_sq=SIGMA_LIN**2,
+                            hessian="gauss-newton")
+    np.testing.assert_allclose(cov_gn.matrix, C, rtol=1e-6, atol=1e-12)
+
+
+def test_bound_and_row_spellings_agree():
+    # jkitchin/pounce#362 at the matrix level: the same limit spelled
+    # as a variable bound and as a constraint row returns identical
+    # covariance matrices, not only identical classifications
+    x, y, X = linear_data()
+    mA = linear_model(x, y, declare=False)
+    mA.a.setlb(2.0)
+    declare_fitted(mA.a)
+    declare_fitted(mA.b)
+    declare_residual(mA.r)
+    pyo.SolverFactory("pounce").solve(mA)
+    mB = linear_model(x, y, declare=False)
+    mB.bnd = pyo.Constraint(expr=mB.a >= 2.0)
+    declare_fitted(mB.a)
+    declare_fitted(mB.b)
+    declare_residual(mB.r)
+    pyo.SolverFactory("pounce").solve(mB)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        covA = covariance(mA, sigma_sq=SIGMA_LIN**2)
+        covB = covariance(mB, sigma_sq=SIGMA_LIN**2)
+    np.testing.assert_allclose(covB.matrix, covA.matrix,
+                               rtol=1e-6, atol=1e-12)

--- a/pyomo-pounce/tests/test_covariance.py
+++ b/pyomo-pounce/tests/test_covariance.py
@@ -443,7 +443,7 @@ def test_inactive_bound_changes_nothing():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         cov = covariance(m, sigma_sq=SIGMA_LIN**2)
-    assert not w
+    assert not [x for x in w if "covariance:" in str(x.message)]
     cov_true = SIGMA_LIN**2 * np.linalg.inv(X.T @ X)
     np.testing.assert_allclose(cov.matrix, cov_true, rtol=1e-7)
 
@@ -655,3 +655,51 @@ def test_explicit_bound_relax_refuses_covariance():
         m, options={"bound_relax_factor": 1e-8})
     with pytest.raises(ValueError, match="bound_relax_factor"):
         covariance(m, sigma_sq=SIGMA_LIN**2)
+
+
+def test_weakly_active_bound_gauss_newton_matches():
+    # the GN branch rebuilds from the exact recovered Jacobian
+    # (Z_r @ inv(M) = J, the W-based factor cancels identically), so a
+    # weakly active kept parameter needs no Sigma correction there and
+    # must match the same unconstrained analytic covariance the
+    # Lagrangian branch reaches via the correction
+    x, y, X = linear_data()
+    beta = np.linalg.solve(X.T @ X, X.T @ y)
+    y2 = y + (2.0 - beta[0])
+    m = linear_model(x, y2, declare=False)
+    m.a.setlb(2.0)
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    pyo.SolverFactory("pounce").solve(m)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cov_gn = covariance(m, sigma_sq=SIGMA_LIN**2,
+                            hessian="gauss-newton")
+    cov_true = SIGMA_LIN**2 * np.linalg.inv(X.T @ X)
+    np.testing.assert_allclose(cov_gn.matrix, cov_true, rtol=1e-4)
+
+
+def test_inactive_row_spelling_agrees_to_o_mu():
+    # inactive rows are skipped by design (their geometric weight is
+    # O(mu), and fetching every normal costs an O(m*n) sweep on wide
+    # models), so the two spellings of an INACTIVE limit agree to
+    # O(mu) rather than exactly
+    x, y, X = linear_data()
+    mA = linear_model(x, y, declare=False)
+    mA.a.setlb(-50.0)
+    declare_fitted(mA.a)
+    declare_fitted(mA.b)
+    declare_residual(mA.r)
+    pyo.SolverFactory("pounce").solve(mA)
+    mB = linear_model(x, y, declare=False)
+    mB.far = pyo.Constraint(expr=mB.a >= -50.0)
+    declare_fitted(mB.a)
+    declare_fitted(mB.b)
+    declare_residual(mB.r)
+    pyo.SolverFactory("pounce").solve(mB)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        covA = covariance(mA, sigma_sq=SIGMA_LIN**2)
+        covB = covariance(mB, sigma_sq=SIGMA_LIN**2)
+    np.testing.assert_allclose(covB.matrix, covA.matrix, rtol=1e-7)

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -491,7 +491,7 @@ def test_rewritten_bound_still_projects_in_covariance():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         covariance(m)
-    assert any("sits on its bound" in str(x.message) for x in w)
+    assert any("strongly active" in str(x.message) for x in w)
     # and the projected answer, not just the warning: identical to what the
     # same model gives with the bound left alone
     assert covariance(m).std_err[m.A] == 0.0

--- a/python/tests/test_activity.py
+++ b/python/tests/test_activity.py
@@ -358,6 +358,34 @@ def test_mixed_model_reports_in_user_space():
     assert not any(rep["var_contaminated"]) and not any(rep["row_contaminated"])
 
 
+def test_sigma_is_natural_units():
+    # the weak scalar row g = c*x >= 0 has natural geometric weight
+    # Sigma*||grad||^2 = q = 1, so Sigma_nat = 1/c^2 exactly. At
+    # c = 1000 the default gradient-based scaling engages a per-row
+    # d_scale, and a scaled-space report would differ by df/dg^2;
+    # asserting 1/c^2 under both scaling modes pins the natural-units
+    # contract at the boundary.
+    for scaling in ("gradient-based", "none"):
+        c = 1000.0
+        prob = pounce.Problem(
+            n=1, m=1, problem_obj=ScalarRow(0.0, c),
+            lb=[-1e19], ub=[1e19], cl=[0.0], cu=[1e19],
+        )
+        prob.add_option("tol", 1e-10)
+        prob.add_option("bound_relax_factor", 0.0)
+        prob.add_option("nlp_scaling_method", scaling)
+        prob.add_option("print_level", 0)
+        prob.add_option("sb", "yes")
+        solver = pounce.Solver(prob)
+        _, info = solver.solve(x0=np.array([0.5]))
+        assert info["status_msg"] == "Solve_Succeeded"
+        rep = solver.classify_activity()
+        assert rep["row_status"] == ["weakly_active"], scaling
+        assert rep["row_sigma"][0] == pytest.approx(1.0 / c**2, rel=0.5), scaling
+        # row_normal is natural too: the user's coefficient, not dg*c
+        np.testing.assert_allclose(solver.row_normal(0), [c], rtol=1e-9)
+
+
 def test_sigma_is_reported_raw():
     # with unit curvature the ratio IS Σ/1, so the reported sigma must
     # reproduce it; Σ ≈ 1 at weak activity and ≈ μ when inactive

--- a/python/tests/test_activity.py
+++ b/python/tests/test_activity.py
@@ -356,3 +356,47 @@ def test_mixed_model_reports_in_user_space():
     assert rep["var_q_sign"][0] == 1 and rep["var_q_sign"][3] == 1
     assert rep["row_q_sign"][1] == 1
     assert not any(rep["var_contaminated"]) and not any(rep["row_contaminated"])
+
+
+def test_sigma_is_reported_raw():
+    # with unit curvature the ratio IS Σ/1, so the reported sigma must
+    # reproduce it; Σ ≈ 1 at weak activity and ≈ μ when inactive
+    rep = _solve_bound(0.0)
+    assert rep["var_sigma"][0] == pytest.approx(rep["var_ratio"][0], rel=1e-12)
+    assert rep["var_sigma"][0] == pytest.approx(1.0, rel=0.5)
+    rep = _solve_bound(1.0)
+    assert rep["var_sigma"][0] == pytest.approx(rep["mu"], rel=10.0)
+    rep = _solve_row(0.0)
+    assert rep["row_sigma"][0] == pytest.approx(rep["row_ratio"][0], rel=1e-12)
+    assert rep["var_sigma"][0] == 0.0  # unbounded: nothing classified
+
+
+def _mixed_solver():
+    prob = _options(pounce.Problem(
+        n=4, m=2, problem_obj=MixedModel(),
+        lb=[0.0, -1e19, 2.0, 0.0], ub=[10.0, 1e19, 2.0, 1e19],
+        cl=[7.0, 0.0], cu=[7.0, 1e19],
+    ))
+    solver = pounce.Solver(prob)
+    _, info = solver.solve(x0=np.array([4.0, 0.5, 2.0, 0.5]))
+    assert info["status_msg"] == "Solve_Succeeded"
+    return solver
+
+
+def test_row_normal_in_user_space():
+    solver = _mixed_solver()
+    # g0 = x0 + x2 (equality; the fixed x2's column was removed from
+    # the solve, so its entry reports 0), g1 = x1
+    np.testing.assert_allclose(solver.row_normal(0), [1.0, 0.0, 0.0, 0.0])
+    np.testing.assert_allclose(solver.row_normal(1), [0.0, 1.0, 0.0, 0.0])
+    with pytest.raises(ValueError, match="out of range"):
+        solver.row_normal(2)
+
+
+def test_row_normal_before_solve_raises():
+    prob = _options(pounce.Problem(
+        n=1, m=1, problem_obj=ScalarRow(1.0),
+        lb=[-1e19], ub=[1e19], cl=[0.0], cu=[1e19],
+    ))
+    with pytest.raises(RuntimeError, match="no converged factor"):
+        pounce.Solver(prob).row_normal(0)


### PR DESCRIPTION
Closes #362. Item 1 of the covariance/information roadmap (#262); items 2-4 follow separately.

**The defect.** `covariance()` tested activity against NL variable bounds only, so a fitted parameter held by an active constraint *row* was treated as free: the same cap written as a bound gave `std_err = 0.0` with the nonstandard-asymptotics warning, while written as a Constraint it gave the barrier's leftover variance silently (`7.9e-6` in the issue's report; `1.8e-7` re-measured on current main, zero warnings). On this branch #362's own reproduction returns exactly `0.0`, warned, in both spellings — `test_issue_362_row_pinned_variable_projects`, verified causally by swapping only `sens.py` back to main's.

**Membership.** `covariance()` classifies bound and constraint activity through item 0's rule applied at the reduced fitted block, where a fitted parameter's curvature actually lives: in the residual-variable idiom its raw Lagrangian diagonal is zero, so the per-coordinate report honestly says `unidentified` and cannot decide membership alone. The slack-only test and its moved-bounds re-injection are gone. Dispositions: strongly active projects (zero variance, conditional, warned); weakly active is **kept** at its full finite variance, where the slack test deleted it and the raw factor would have halved it; ambiguous and unidentified stay with warnings.

**Value correction.** The fitted rows' retained barrier diagonal (`var_sigma`/`row_sigma`, new in the activity report) is subtracted from the factor's reduced Hessian: a weakly active kept parameter reports its true curvature q, not the factor's 2q. The report's Σ is the solver's scaled-space value while the factor block is natural-units (kkt_solve, pounce#128), so the correction normalizes by the objective scale — the per-row constraint scale cancels algebraically — tested against a solve with gradient-based scaling engaged.

**Row projection.** A strongly active inequality row over the fitted block pins a combination, not a coordinate: both accessor paths project on the null space of the binding normals, the matrix goes singular by one per binding row, and the warning names the constraint, the combination, and its conditional information. A bound moved onto a row (#357) is the single-coordinate case and returns exactly the variable disposition. The restricted normal is honest only while the row's support outside the fitted block is pinned (pin columns cannot move); a row reaching the fitted parameters through *free* eliminated variables pins a direction the restricted normal cannot represent — and the reduced-level ratio is equally blind — so such rows take item 0's raw classification, stay unprojected, and warn explicitly. The general treatment (the reduced normal through elimination) is item 2 territory, recorded in the roadmap. `Solver.row_normal(j)` supplies the projection direction; declaration-triggered solves set `bound_relax_factor=0` for the classifier's precondition.

**Tests** pin analytics, and each pillar is mutation-verified (the value correction, the row projection, and the reduced-level membership were each disabled in turn; only their own tests fail, and all do): the weakly active kept variance equals the unconstrained σ²(XᵀX)⁻¹ entry in both the bound and row spellings; binding `a + b <= cap` matches restricted least squares with correlation exactly −1 and a rank-one drop; an objective-scaled solve returns the same numbers; the mixed `a + r_k` row warns and stays full-rank; an inactive far bound changes nothing; Gauss-Newton agrees with projection included.

Suites: Rust 57, Python activity 26, pyomo-pounce 156, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)