### PR TITLE
Follow-up to #433: trim .row to the constraint rows, resolve NaN seeds generically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — pyomo-pounce: constraint-row lookups included a non-row name
+
+- Pyomo's `.row` file lists the `m` constraint rows and then appends
+  the objective's name, and the declared-parameter surgery aliases the
+  objective along with the constraints it rewrites. The name-to-row
+  index built from that file therefore mapped the objective to row
+  `m`, one past the last constraint — a name that indexes past the end
+  of every per-row array the index is used with. The warm-start suffix
+  reader got a bounds check for this in #432; the row names are now
+  trimmed where they are read instead, so the pin map and the
+  multiplier lookups hold the same invariant structurally rather than
+  one call site at a time.
+- No public API routed an objective into those lookups (`gradient()`
+  sends an objective target to the variable lookup, which rejects it
+  by name), so this is an invariant repair, not a user-visible
+  behavior change.
+
+### Fixed — warm start: NaN seeds resolved only in densely-stored multiplier blocks
+
+- `warm_start_init_point=yes` treats NaN in a `lagrange` / `zl` / `zu`
+  seed as "unseeded, use the solver's own default" (#432). That
+  substitution ran only for densely-stored multiplier blocks. A
+  compound block kept the NaN, which would then propagate through the
+  warm-start clamps into the iterate; the guard against it was a
+  `debug_assert!`, compiled out of the release builds that ship.
+- NaN resolution now recurses into compound blocks, so the documented
+  contract holds for every multiplier-block layout rather than only
+  the one the seeding path happens to build. The seeding path builds
+  dense blocks today, so no shipped configuration reached the gap —
+  it is the contract that is now true, not a solve that changed.
+
 ### Fixed — pyomo-pounce: the sens path dropped solver options (#432)
 
 - `SolverFactory("pounce").solve(m, options={...})` and factory-level

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -124,32 +124,6 @@ pub struct AlgorithmBundle {
     pub search_dir: Option<PdSearchDirCalc>,
 }
 
-#[cfg(test)]
-mod warm_threading_tests {
-    use super::*;
-
-    #[test]
-    fn warm_options_take_the_init_default_not_their_own() {
-        let mut init = InitOptions::default();
-        init.bound_mult_init_val = 10.0; // the Mehrotra override value
-        let mut warm = WarmStartOptions::default();
-        warm.bound_mult_init_val = 123.0; // stale copy must lose
-        let resolved = resolved_warm_options(&warm, &init);
-        assert_eq!(resolved.bound_mult_init_val, 10.0);
-        // everything else passes through untouched
-        assert_eq!(resolved.mult_bound_push, warm.mult_bound_push);
-        assert_eq!(resolved.target_mu, warm.target_mu);
-    }
-
-    #[test]
-    fn default_warm_matches_default_init() {
-        assert_eq!(
-            WarmStartOptions::default().bound_mult_init_val,
-            InitOptions::default().bound_mult_init_val,
-        );
-    }
-}
-
 /// Knobs read off `OptionsList` and baked into the assembled
 /// `OptErrorConvCheck`. Defaults mirror
 /// `IpOptErrorConvCheck.cpp:RegisterOptions`.
@@ -1134,6 +1108,19 @@ impl AlgorithmBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn warm_options_take_the_init_default_not_their_own() {
+        let mut init = InitOptions::default();
+        init.bound_mult_init_val = 10.0; // the Mehrotra override value
+        let mut warm = WarmStartOptions::default();
+        warm.bound_mult_init_val = 123.0; // stale copy must lose
+        let resolved = resolved_warm_options(&warm, &init);
+        assert_eq!(resolved.bound_mult_init_val, 10.0);
+        // everything else passes through untouched
+        assert_eq!(resolved.mult_bound_push, warm.mult_bound_push);
+        assert_eq!(resolved.target_mu, warm.target_mu);
+    }
 
     #[test]
     fn default_builder_assembles() {

--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -36,6 +36,7 @@ use crate::ipopt_nlp::IpoptNlp;
 use crate::iterates_vector::IteratesVector;
 use crate::kkt::aug_system_solver::AugSystemSolver;
 use pounce_linalg::Vector;
+use pounce_linalg::compound_vector::CompoundVector;
 use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -238,6 +239,44 @@ fn is_initialized(v: &Rc<dyn Vector>) -> bool {
         .unwrap_or(true)
 }
 
+/// Replace every NaN entry of `v` with `fill`, in place.
+///
+/// NaN in a user-supplied multiplier seed means "unseeded" (see the
+/// `Problem.solve` contract), and has to be resolved before the
+/// clamps: `element_wise_min`/`element_wise_max` would propagate it
+/// into the iterate, poisoning the solve.
+///
+/// Both `Vector` storage layouts are handled. A dense block is
+/// scanned directly; a compound block recurses into its components,
+/// so the contract holds wherever the iterate's multiplier blocks
+/// live — the seed path (`seed_from_nlp`) always builds dense
+/// vectors, but the re-optimize path reuses whatever the previous
+/// solve's spaces produced, and a debug-only guard would be compiled
+/// out of exactly the release builds that ship.
+fn resolve_nan_seeds(v: &mut dyn Vector, fill: f64) {
+    // Type-test before taking the mutable borrow: `if let Some(d) =
+    // v.as_any_mut()… else` would keep that borrow live across the
+    // else arm.
+    if v.as_any().is::<DenseVector>() {
+        let d = v.as_any_mut().downcast_mut::<DenseVector>().unwrap();
+        for e in d.values_mut() {
+            if e.is_nan() {
+                *e = fill;
+            }
+        }
+    } else if v.as_any().is::<CompoundVector>() {
+        let c = v.as_any_mut().downcast_mut::<CompoundVector>().unwrap();
+        for i in 0..c.n_comps() {
+            resolve_nan_seeds(c.comp_mut(i), fill);
+        }
+    } else {
+        // `DenseVector` and `CompoundVector` are the only `Vector`
+        // implementations; a third one must be handled here, or NaN
+        // rides the clamps into the iterate as a silent poison.
+        debug_assert!(false, "resolve_nan_seeds: unhandled Vector implementation");
+    }
+}
+
 /// Clone `v` into a fresh owned vector and clamp every entry to
 /// `[lo, hi]` componentwise. Empty vectors short-circuit. Vectors that
 /// were never written to (the application's placeholder seed iterates
@@ -260,24 +299,7 @@ fn clone_clamped(v: &Rc<dyn Vector>, lo: f64, hi: f64, nan_fill: f64) -> Rc<dyn 
         out.copy(&**v);
         // NaN marks an unseeded entry; resolve it before the clamps
         // (element-wise min/max would just propagate it)
-        if let Some(d) = out.as_any_mut().downcast_mut::<DenseVector>() {
-            for e in d.values_mut() {
-                if e.is_nan() {
-                    *e = nan_fill;
-                }
-            }
-        } else {
-            // Non-dense vectors (CompoundVector on the re-optimize
-            // path) skip NaN resolution: the user-seed path always
-            // builds DenseVectors, so NaN here is an upstream contract
-            // violation, not an unseeded entry. Fail loudly in debug
-            // rather than let NaN ride the clamps into the iterate.
-            debug_assert!(
-                !out.dot(&**v).is_nan(),
-                "clone_clamped: NaN in a non-dense multiplier vector; \
-                 NaN-as-unseeded requires DenseVector storage"
-            );
-        }
+        resolve_nan_seeds(&mut *out, nan_fill);
     } else {
         out.set(0.0);
     }
@@ -293,6 +315,7 @@ fn clone_clamped(v: &Rc<dyn Vector>, lo: f64, hi: f64, nan_fill: f64) -> Rc<dyn 
 #[cfg(test)]
 mod tests_nan_seed {
     use super::*;
+    use pounce_linalg::compound_vector::CompoundVectorSpace;
     use pounce_linalg::dense_vector::DenseVectorSpace;
 
     #[test]
@@ -306,6 +329,50 @@ mod tests_nan_seed {
         assert_eq!(out.values()[0], 0.5);
         assert_eq!(out.values()[1], 7.0); // unseeded -> fill
         assert_eq!(out.values()[2], 1e6); // then the cap applies
+    }
+
+    /// The re-optimize path reuses the previous solve's vector spaces,
+    /// which are compound for a blocked NLP. NaN has to resolve there
+    /// too: a debug-only guard is compiled out of the release builds
+    /// that ship, so an unresolved NaN would ride the clamps into the
+    /// iterate and poison the solve.
+    #[test]
+    fn nan_resolves_inside_a_compound_vector() {
+        let inner = DenseVectorSpace::new(2);
+        let space = CompoundVectorSpace::new(2, 4);
+        for icomp in 0..2 {
+            let inner = Rc::clone(&inner);
+            space.set_comp(icomp, 2, move || {
+                let mut d = inner.make_new_dense();
+                d.set(0.0);
+                Box::new(d)
+            });
+        }
+        let mut cv = CompoundVector::new(Rc::clone(&space));
+        for (icomp, vals) in [[0.5, f64::NAN], [f64::NAN, 2e7]].into_iter().enumerate() {
+            let c = cv.comp_mut(icomp as pounce_common::types::Index);
+            let d = c.as_any_mut().downcast_mut::<DenseVector>().unwrap();
+            d.values_mut().copy_from_slice(&vals);
+        }
+
+        let v: Rc<dyn Vector> = Rc::from(cv);
+        let out = clone_clamped(&v, 1e-3, 1e6, 7.0);
+
+        let out = out.as_any().downcast_ref::<CompoundVector>().unwrap();
+        let flat: Vec<f64> = (0..out.n_comps())
+            .flat_map(|i| {
+                out.comp(i)
+                    .as_any()
+                    .downcast_ref::<DenseVector>()
+                    .unwrap()
+                    .values()
+                    .to_vec()
+            })
+            .collect();
+        assert_eq!(flat[0], 0.5);
+        assert_eq!(flat[1], 7.0); // unseeded -> fill, not NaN
+        assert_eq!(flat[2], 7.0);
+        assert_eq!(flat[3], 1e6); // then the cap applies
     }
 }
 

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -398,10 +398,9 @@ def _warm_start_from_suffixes(model, var_names, con_names, nl, con_alias):
     if isinstance(dual, pyo.Suffix):
         for cd, val in dual.items():
             r = con_row.get(con_alias.get(cd.name, cd.name))
-            # r < m guards the .row file's trailing objective name
-            # (and the surgery's objective alias): the objective is
-            # not a constraint row and carries no dual
-            if r is not None and r < int(nl.m):
+            # con_names is trimmed to the constraint rows at the read
+            # site, so a hit here is always a row of the dual vector
+            if r is not None:
                 y[r] = -float(val)      # AMPL marginal -> internal lambda
     for sfx_name, arr, sign in (("ipopt_zL_in", zl, 1.0),
                                 ("ipopt_zU_in", zu, -1.0)):
@@ -563,6 +562,16 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
         var_names = Path(nl_path[:-3] + ".col").read_text().splitlines()
         con_names = Path(nl_path[:-3] + ".row").read_text().splitlines()
         nl = pounce.read_nl(nl_path)
+        # The .row file lists the m constraint rows in nl order and
+        # then appends the objective's name -- it is a row file, not a
+        # constraint file. Trim to the constraint rows here so every
+        # consumer of con_names sees rows only: the name->row index
+        # feeds the pin map, mult_entry, and the warm-start suffix
+        # reader alike, and an objective-keyed lookup would otherwise
+        # return row m and index one past the end of the multiplier
+        # vector. Surgery on a declared model aliases the objective
+        # too, so the objective's name does reach these lookups.
+        con_names = con_names[:int(nl.m)]
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
 

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -759,3 +759,29 @@ def test_warm_start_dual_lands_on_the_aliased_row():
     row = _row_index(session.con_names)[clone_name]
     assert warm["lagrange"][row] == -2.5
     assert not np.isnan(warm["lagrange"][row])
+
+
+def test_row_file_objective_is_not_a_constraint_row():
+    """Pyomo's .row file appends the objective's name after the m
+    constraint rows, and the surgery aliases the objective along with
+    the constraints it replaces. con_names is trimmed to the
+    constraint rows at the read site, so every consumer of the
+    name->row index -- the pin map, mult_entry, the warm-start suffix
+    reader -- sees rows only, and an objective-keyed lookup raises the
+    usual ValueError instead of returning row m and indexing one past
+    the end of the multiplier vector."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=2.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.y = pyo.Var(initialize=1.0)
+    m.c = pyo.Constraint(expr=m.y == (m.x - m.p) ** 2)
+    # the objective mentions the declared Param, so the surgery
+    # replaces (and aliases) it too
+    m.obj = pyo.Objective(expr=m.y + (m.x - m.p) ** 4)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    session = m.__dict__["_pounce_sens"].session
+    assert len(session.con_names) == int(session.nl.m)
+    assert "obj" not in session.con_names
+    with pytest.raises(ValueError, match="not a constraint"):
+        session.mult_entry("obj")


### PR DESCRIPTION
The three loose ends the #433 review left open, tracked there as follow-up rather than held against that PR.

## Problem

Two invariants were true only by accident, and one test could not fail.

**1. The constraint name-to-row index contained a name that is not a row.** Pyomo's `.row` file lists the `m` constraint rows and then appends the objective's name, and the declared-parameter surgery aliases the objective along with the constraints it rewrites. Measured on a one-constraint declared model:

```
nl.m = 1 | .row lines = 2 -> ['c', 'obj']

# after surgery (m = 2):
con_names = ['_SENSITIVITY_TOOLBOX_DATA.constList[1]',
             '_SENSITIVITY_TOOLBOX_DATA.paramConst[1]',
             '_SENSITIVITY_TOOLBOX_DATA.obj']     # <- row 2, and m == 2
con_alias  = {'obj': '_SENSITIVITY_TOOLBOX_DATA.obj', 'c': '...constList[1]'}
```

So the index maps the objective to row `m`, one past the last constraint — a name that indexes past the end of every per-row array the index is used with. Handed to the engine as a pin it comes back as `ValueError: pin_constraint_indices[..] = 2 out of range [0, m=2)`. #433 added a bounds check at the one new call site (the warm-start suffix reader, where the write into the dual vector would have been out of range); the same index also feeds the pin map and `mult_entry`.

No public API routes an objective into those lookups — `gradient()` sends an objective target to `var_entry`, which rejects it by name — so this is an invariant repair, not a behavior change a user could observe.

**2. NaN seeds resolved only in densely-stored multiplier blocks.** `warm_start_init_point=yes` treats NaN in a `lagrange` / `zl` / `zu` seed as "unseeded, use the solver's own default". `clone_clamped` performed that substitution only after a successful downcast to `DenseVector`; a compound block kept the NaN, which would then propagate through `element_wise_min` / `element_wise_max` into the iterate. The guard was a `debug_assert!` — compiled out of exactly the release builds that ship. The seeding path builds dense blocks today, so no shipped configuration reached the gap.

**3. A test that cannot fail.** `default_warm_matches_default_init` asserted `WarmStartOptions::default().bound_mult_init_val == InitOptions::default().bound_mult_init_val` — but #433 made the former *read* the latter, so it compares a value to itself.

## Fix

Trim `con_names` to `nl.m` at the read site rather than guarding consumers one at a time, and drop the now-redundant `r < nl.m` check in the suffix reader. The alternative — keeping the guard and adding matching ones to `mult_entry` and the pin map — was rejected: three checks enforcing one invariant is exactly how the first two call sites came to disagree.

Move NaN resolution out of `clone_clamped` into `resolve_nan_seeds`, which scans a dense block and recurses into a compound one. The type test happens through an immutable `as_any().is::<T>()` before the mutable downcast, because `if let Some(d) = v.as_any_mut()… else` keeps the mutable borrow live across the else arm. The `debug_assert!` survives, now covering only a hypothetical third `Vector` implementation.

Move the warm-options threading test into the file's own `mod tests` (it sat above the types it exercised) and delete the tautological one.

## Blast radius

No solver behavior changes. Item 1 is unreachable through the public API, item 2 is unreachable through the path that constructs seeds, item 3 is test-only. The trim is a no-op on any `.row` file that already carried exactly `m` lines.

## Tests

Both new tests fail on the parent commit, for the stated reasons:

- `test_row_file_objective_is_not_a_constraint_row` — `AssertionError: assert 3 == 2` on `len(session.con_names)`, with the trailing entry shown as `_SENSITIVITY_TOOLBOX_DATA.obj`.
- `nan_resolves_inside_a_compound_vector` — builds a real two-block `CompoundVector` with a NaN in each block; panics inside `clone_clamped` on the parent.

Suites, against a release build of this checkout with the CLI staged as the bundled binary:

- `pyomo-pounce`: 107 passed, 2 skipped (both `networkx`-gated)
- `pounce-algorithm` lib: 321 passed

Worth flagging for anyone running these locally: `test_warm_start_from_suffixes_reduces_iterations` and `test_warm_start_partial_seed_solves_clean` (both from #433) **skip silently** unless the bundled binary is staged — a local run reports green while skipping the two tests that exercise the feature end to end.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — not needed; the `docs/src/python.md` and `docs/src/sensitivity.md` text added in #433 describes the contract without reference to block storage, and stays accurate
- [x] `cargo fmt --all -- --check` clean; `cargo clippy` clean under CI's `-D clippy::correctness -D clippy::suspicious`
- [x] Every claim in this body is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MqkJNiGrotacSUygcTQ73W

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqkJNiGrotacSUygcTQ73W)_