### PR TITLE
Fix: wire `required_infeasibility_reduction` option to restoration guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `required_infeasibility_reduction` was registered but never read
+
+- The option appeared in the options list with upstream's default and
+  help text, but nothing consumed it: the κ_resto the restoration
+  sub-solve's early-exit guard runs with was hardcoded to upstream's
+  `0.9` in `run_inner_resto`. Setting the option was a silent no-op —
+  no error, no warning, no effect (#439).
+- The value now flows from the options list through
+  `AlgorithmBuilder::resto` into `RestoAlgorithmBuilder` alongside the
+  other restoration knobs wired up in #191, and is read at the guard.
+  Upstream's square-problem override is preserved and keeps its
+  precedence: `IpRestoMinC_1Nrm.cpp:157-163` applies that case by
+  *overwriting* the sub-option with `0` before `IpRestoConvCheck` reads
+  it, so a square problem still disables the guard regardless of what
+  the user asked for.
+- Behavior is unchanged for anyone who leaves the option alone — the
+  new default equals the previously-hardcoded `0.9`.
+
 ### Fixed — pyomo-pounce: constraint-row lookups included a non-row name
 
 - Pyomo's `.row` file lists the `m` constraint rows and then appends

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -679,6 +679,12 @@ pub struct RestoOptions {
     /// `resto_proximity_weight` — proximity-term weight (`eta_factor`;
     /// `η = eta_factor · sqrt(μ)`).
     pub resto_proximity_weight: Number,
+    /// `required_infeasibility_reduction` — the restoration sub-solve
+    /// keeps iterating until the *original* NLP's infeasibility has been
+    /// reduced to at most this fraction of its value at restoration entry
+    /// (`κ_resto` in `IpRestoConvCheck.cpp:58`). `0` disables the guard,
+    /// i.e. restoration runs until the sub-NLP itself converges.
+    pub required_infeasibility_reduction: Number,
 }
 
 impl Default for RestoOptions {
@@ -688,6 +694,7 @@ impl Default for RestoOptions {
             constr_mult_reset_threshold: 0.0,
             resto_penalty_parameter: 1e3,
             resto_proximity_weight: 1.0,
+            required_infeasibility_reduction: 0.9,
         }
     }
 }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2816,6 +2816,13 @@ impl IpoptApplication {
         if let Some(v) = read_num("resto_proximity_weight") {
             builder.resto.resto_proximity_weight = v;
         }
+        // `required_infeasibility_reduction` (#439) — the κ_resto guard the
+        // restoration sub-solve exits on. Registered since #191 but the
+        // value was hardcoded at the callsite, so setting it was a silent
+        // no-op.
+        if let Some(v) = read_num("required_infeasibility_reduction") {
+            builder.resto.required_infeasibility_reduction = v;
+        }
 
         // Iteration-output options — consumed by `OrigIterationOutput`.
         if let Some(v) = read_int("print_frequency_iter") {

--- a/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/algorithm_options_wiring.rs
@@ -297,6 +297,7 @@ fn resto_constants_default_match_registered() {
     assert_eq!(r.constr_mult_reset_threshold, 0.0);
     assert_eq!(r.resto_penalty_parameter, 1e3);
     assert_eq!(r.resto_proximity_weight, 1.0);
+    assert_eq!(r.required_infeasibility_reduction, 0.9);
 }
 
 #[test]
@@ -308,6 +309,7 @@ fn resto_constants_override_flows_through() {
             ("constr_mult_reset_threshold", 3.0),
             ("resto_penalty_parameter", 2e3),
             ("resto_proximity_weight", 2.0),
+            ("required_infeasibility_reduction", 0.25),
         ] {
             o.set_numeric_value(k, v, true, false).unwrap();
         }
@@ -317,4 +319,5 @@ fn resto_constants_override_flows_through() {
     assert_eq!(r.constr_mult_reset_threshold, 3.0);
     assert_eq!(r.resto_penalty_parameter, 2e3);
     assert_eq!(r.resto_proximity_weight, 2.0);
+    assert_eq!(r.required_infeasibility_reduction, 0.25);
 }

--- a/crates/pounce-cli/tests/issue_439_required_infeasibility_reduction.rs
+++ b/crates/pounce-cli/tests/issue_439_required_infeasibility_reduction.rs
@@ -1,0 +1,98 @@
+//! Regression test for pounce#439: `required_infeasibility_reduction`
+//! was registered as a user option (and documented with upstream's help
+//! text) but nothing read it — the κ_resto the restoration sub-solve's
+//! early-exit guard runs with was hardcoded to upstream's `0.9` default
+//! in `run_inner_resto`. Setting the option produced no error, no
+//! warning, and no effect.
+//!
+//! This pins the whole chain end-to-end through the binary: options list
+//! → `AlgorithmBuilder::resto` → `RestoAlgorithmBuilder` →
+//! `RestoConvCheck::kappa_resto`. The unit tests in `pounce-restoration`
+//! cover the links individually; only a real solve proves they are
+//! actually joined up at the callsite.
+//!
+//! `pooling_rt2stp.nl` is used because it enters restoration with a
+//! non-square original NLP, so the guard is live and the square-problem
+//! override (`IpRestoMinC_1Nrm.cpp:157-163`, which forces κ to 0) does
+//! not mask the user's value.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture_nl() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("pooling_rt2stp.nl");
+    p
+}
+
+/// Run the fixture and return every distinct `kappa_resto=` value the
+/// restoration guard logged. `POUNCE_DBG_RESTO_KAPPA` gates the trace;
+/// the guard only logs when it is live (`kappa_resto > 0`).
+fn logged_kappas(extra_args: &[&str]) -> Vec<String> {
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(fixture_nl())
+        .arg("print_level=0")
+        .arg("--no-sol")
+        .args(extra_args)
+        .env("POUNCE_DBG_RESTO_KAPPA", "1")
+        .env("RUST_LOG", "pounce::restoration=debug")
+        .env("NO_COLOR", "1");
+    let output = cmd.output().expect("spawn pounce");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    let mut seen: Vec<String> = stderr
+        .lines()
+        .filter_map(|l| l.split("kappa_resto=").nth(1))
+        .map(|rest| {
+            rest.split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .to_string()
+        })
+        .collect();
+    seen.sort();
+    seen.dedup();
+    seen
+}
+
+#[test]
+fn default_kappa_resto_is_upstreams_default() {
+    let kappas = logged_kappas(&[]);
+    assert_eq!(
+        kappas,
+        vec!["9.000e-1".to_string()],
+        "with the option unset the guard must run at upstream's 0.9 \
+         default (behavior before #439 must be unchanged)",
+    );
+}
+
+#[test]
+fn user_required_infeasibility_reduction_reaches_the_guard() {
+    let kappas = logged_kappas(&["required_infeasibility_reduction=0.05"]);
+    assert_eq!(
+        kappas,
+        vec!["5.000e-2".to_string()],
+        "pounce#439: setting `required_infeasibility_reduction` must \
+         change the κ_resto the restoration guard runs with, not be a \
+         silent no-op",
+    );
+}
+
+#[test]
+fn zero_required_infeasibility_reduction_disables_the_guard() {
+    // Upstream treats κ_resto == 0 as "no reduction requirement" — the
+    // sub-solve runs to its own convergence instead of exiting early.
+    // `RestoConvCheck` skips the whole block (and therefore the trace)
+    // in that case.
+    let kappas = logged_kappas(&["required_infeasibility_reduction=0.0"]);
+    assert!(
+        kappas.is_empty(),
+        "kappa 0 must disable the reduction guard entirely, got {kappas:?}",
+    );
+}

--- a/crates/pounce-restoration/src/resto_alg_builder.rs
+++ b/crates/pounce-restoration/src/resto_alg_builder.rs
@@ -128,6 +128,13 @@ pub struct RestoAlgorithmBuilder {
     /// `obj_max_inc` — forwarded to the resto-filter conv check's
     /// outer-iterate guard.
     pub obj_max_inc: f64,
+    /// `required_infeasibility_reduction` — κ_resto, the fraction the
+    /// *original* NLP's infeasibility must fall to before the restoration
+    /// sub-solve may hand back (`IpRestoConvCheck.cpp:58`). `0` disables
+    /// the guard. Consumed by
+    /// [`crate::resto_inner_solver::run_inner_resto`], which applies
+    /// upstream's square-problem override on top.
+    pub required_infeasibility_reduction: f64,
 }
 
 impl Default for RestoAlgorithmBuilder {
@@ -144,6 +151,7 @@ impl Default for RestoAlgorithmBuilder {
             inf_pr_output: InfPrTag::Original,
             print_info_string: PrintInfoString::No,
             obj_max_inc: 5.0,
+            required_infeasibility_reduction: 0.9,
         }
     }
 }
@@ -241,6 +249,7 @@ mod tests {
         assert_eq!(b.inf_pr_output, InfPrTag::Original);
         assert_eq!(b.print_info_string, PrintInfoString::No);
         assert_eq!(b.obj_max_inc, 5.0);
+        assert_eq!(b.required_infeasibility_reduction, 0.9);
     }
 
     #[test]

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -154,6 +154,25 @@ fn apply_outer_resto_options(rb: &mut RestoAlgorithmBuilder, ab: &AlgorithmBuild
     rb.eta_factor = ab.resto.resto_proximity_weight;
     rb.bound_mult_reset_threshold = ab.resto.bound_mult_reset_threshold;
     rb.constr_mult_reset_threshold = ab.resto.constr_mult_reset_threshold;
+    rb.required_infeasibility_reduction = ab.resto.required_infeasibility_reduction;
+}
+
+/// Resolve the κ_resto the restoration sub-solve's early-exit guard runs
+/// with, from the user's `required_infeasibility_reduction` and whether
+/// the original NLP is square.
+///
+/// Upstream applies the square-problem case by *overriding* the
+/// sub-option: `IpRestoMinC_1Nrm.cpp:157-163` sets
+/// `required_infeasibility_reduction = 0.` on `actual_resto_options`
+/// when `IsSquareProblem()`, and `IpRestoConvCheck.cpp:58` then reads
+/// that overridden value. So the square-problem case wins over whatever
+/// the user asked for — matched here rather than, say, taking the min.
+fn effective_kappa_resto(required_infeasibility_reduction: f64, is_square_problem: bool) -> f64 {
+    if is_square_problem {
+        0.0
+    } else {
+        required_infeasibility_reduction
+    }
 }
 
 pub fn make_default_restoration_factory(
@@ -285,8 +304,15 @@ pub fn run_inner_resto(
     // exits on PFIT3/PFIT4 after only a 10% feasibility reduction
     // (kappa_resto=0.9), the outer Newton step from the partially-
     // recovered iterate blows up, and we re-enter resto in a loop.
+    //
+    // The non-square value is the user's `required_infeasibility_reduction`
+    // (#439); it was hardcoded to upstream's 0.9 default here, so setting
+    // the registered option did nothing.
     let is_square_problem = n_orig == m_eq;
-    let kappa_resto = if is_square_problem { 0.0 } else { 0.9 };
+    let kappa_resto = effective_kappa_resto(
+        resto_builder.required_infeasibility_reduction,
+        is_square_problem,
+    );
 
     // ---- 4. Build the inner alg bundle and override its init /
     //         conv_check / iter_output slots with resto-side ones. ----
@@ -987,6 +1013,7 @@ mod tests {
         ab.resto.resto_proximity_weight = 4.0;
         ab.resto.bound_mult_reset_threshold = 7.0e2;
         ab.resto.constr_mult_reset_threshold = 9.0;
+        ab.resto.required_infeasibility_reduction = 0.25;
 
         let mut rb = RestoAlgorithmBuilder::new();
         apply_outer_resto_options(&mut rb, &ab);
@@ -995,6 +1022,28 @@ mod tests {
         assert_eq!(rb.eta_factor, 4.0);
         assert_eq!(rb.bound_mult_reset_threshold, 7.0e2);
         assert_eq!(rb.constr_mult_reset_threshold, 9.0);
+        assert_eq!(rb.required_infeasibility_reduction, 0.25);
+    }
+
+    /// #439: `required_infeasibility_reduction` was registered but the
+    /// κ_resto the guard runs with was hardcoded to upstream's 0.9, so
+    /// setting the option was a silent no-op.
+    #[test]
+    fn effective_kappa_resto_honors_user_option() {
+        assert_eq!(effective_kappa_resto(0.9, false), 0.9);
+        assert_eq!(effective_kappa_resto(0.25, false), 0.25);
+        // `0` disables the guard entirely — the sub-solve then runs to its
+        // own convergence.
+        assert_eq!(effective_kappa_resto(0.0, false), 0.0);
+    }
+
+    /// The square-problem case wins over the user's value, because that is
+    /// how upstream applies it: `IpRestoMinC_1Nrm.cpp:157-163` *overwrites*
+    /// the sub-option with 0 before `IpRestoConvCheck` reads it.
+    #[test]
+    fn effective_kappa_resto_square_problem_overrides_user_option() {
+        assert_eq!(effective_kappa_resto(0.9, true), 0.0);
+        assert_eq!(effective_kappa_resto(0.25, true), 0.0);
     }
 
     #[test]
@@ -1014,6 +1063,10 @@ mod tests {
         assert_eq!(
             rb.constr_mult_reset_threshold,
             baseline.constr_mult_reset_threshold
+        );
+        assert_eq!(
+            rb.required_infeasibility_reduction,
+            baseline.required_infeasibility_reduction
         );
     }
 


### PR DESCRIPTION
## Problem

The `required_infeasibility_reduction` option was registered in the options list with upstream's default (0.9) and help text, but setting it had no effect — it was a silent no-op. The κ_resto parameter that controls the restoration sub-solve's early-exit guard was hardcoded to 0.9 in `run_inner_resto`, so the user's value was never read.

## Cause

Nothing read the option anywhere — the only other mention of it in the workspace was the hardcoded `0.9` at the guard callsite. #191 wired up the neighbouring restoration knobs (`resto_penalty_parameter`, `resto_proximity_weight`, `bound_mult_reset_threshold`, `constr_mult_reset_threshold`) along the options-list → `AlgorithmBuilder::resto` → `RestoAlgorithmBuilder` route, but `required_infeasibility_reduction` was not among them, so no link of that chain existed for it.

## Fix

Threads the option along the same route #191 established for the other restoration knobs:

- Added `required_infeasibility_reduction` to `RestoOptions` (`alg_builder.rs`), default 0.9
- Read it from the options list in `algorithm_builder_from_options` (`application.rs`), next to the other `resto` reads
- Added the matching field to `RestoAlgorithmBuilder` and copied it across in `apply_outer_resto_options`
- Extracted the κ_resto resolution into `effective_kappa_resto()`, which:
  - Returns the user's `required_infeasibility_reduction` for non-square problems
  - Returns 0 for square problems (matching upstream's override in `IpRestoMinC_1Nrm.cpp:157-163`)
- Updated `run_inner_resto` to call `effective_kappa_resto()` instead of hardcoding 0.9

The square-problem override is preserved and keeps its precedence: upstream applies it by *overwriting* the sub-option with 0 before the convergence check reads it, so a square problem still disables the guard regardless of what the user asked for. Factoring it into one function states that precedence once rather than leaving it implicit at the callsite.

Behavior is unchanged for anyone who leaves the option alone — the new default equals the previously-hardcoded 0.9.

## Blast radius

Bit-identical except for the targeted case: users who set `required_infeasibility_reduction` will now see it take effect. Users who leave it unset continue to get 0.9 (the previous hardcoded value).

## Tests

- Added regression test `issue_439_required_infeasibility_reduction.rs` that runs the full binary end-to-end with `pooling_rt2stp.nl` (a non-square problem that enters restoration) and asserts the κ_resto reaching the guard tracks the option: unset → `9.000e-1`, `=0.05` → `5.000e-2`, `=0.0` → guard disabled entirely. The individual links were each unit-testable, but only a real solve pins that they are joined at the callsite.
- Added unit tests for `effective_kappa_resto()` covering the non-square and square cases
- Extended the existing `apply_outer_resto_options` and `algorithm_options_wiring` tests to cover the new field's default and override

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry added
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] All claims verified against final code

Fixes #439

https://claude.ai/code/session_01UpLzF1AUL38QKQY232ypMf