### PR TITLE
homotopy: stop stepping over crossings the ratio test found, and decline the #434 guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ changes.
   paths killed mid-flight 37 → 31, and the median completed path halves
   (216 → 102 steps). `QSHARE2B`, the seventh loss recorded on
   `sqp_qp_use_homotopy`, also recovers.
+- Scope, because it is easy to overclaim: this fixes paths that *wedge*, not
+  the `O(|A|)` pivot cost in #434's title. The `benchmarks/warmstart` `-hom`
+  arms reproduce **identically** after it (727 → 1692 inner active-set changes,
+  0.43×, tracking the active-set fraction 82% → 0.63×, 5% → 1.00%,
+  99% → 0.32×), because the defect never fires on those small non-degenerate
+  QPs. That cost is real and remains. It is bounded, though: all arms return
+  correct answers with identical outer iteration counts, so it is overhead
+  rather than damage, and `use_homotopy` is `false` by default in `pounce-qp`,
+  so the SQP inner-QP path does not take it unless asked.
 - **No runtime guard is added**, which is what #434 was filed to ask for. The
   losses that remain after this fix cannot be separated from the gains by any
   threshold on (path steps, `t`): the only rule that catches all the reachable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,49 @@ changes.
   Lagrangian Hessian), so the change is exposure plus the rule, not new
   computation. Items 1-4 build on these statuses.
 
+### Fixed — the QP homotopy stepped over crossings its own ratio test had found (#434)
+
+- The §4.2 parametric path's two ratio tests selected the next event with
+  `t + dt < t_next - T_EPS`. That margin reads as a don't-bother-for-a-hair
+  guard but is not one: it makes a crossing that happens *earlier* than the
+  incumbent, by less than `T_EPS = 1e-12`, lose to it, so the step knowingly
+  overshoots the earlier crossing. Measured on `QSHARE2B` in #413: row 132
+  crossed at `dt = 2.9e-16` and lost to a step of `1.1e-14`.
+- Overshooting is not a rounding-level mistake, because violation is
+  absorbing. The primal ratio test only ever *prevents* a violation and can
+  never repair one, so a row stepped over stays inactive and violated for the
+  rest of the path while the direction solve pushes it further out
+  (`QSHARE2B` row 7 went `8e-2 -> 0.4 -> 7.5 -> 11 -> 22`). The same
+  comparison also discarded crossings *tied* with the incumbent, leaving a row
+  sitting exactly on a bound it was not in the working set for — which the
+  next direction pushes it across.
+- Both ratio tests now feed one `RatioTest`, which compares crossings exactly
+  and fires the whole coincident set. It is a separate type because the rule
+  is pure arithmetic on two numbers while the loop around it needs a KKT
+  factorization per step to reach; `pounce-qp/src/tests/homotopy_unit.rs` pins
+  it directly, including the measured `2.9e-16`-vs-`1.1e-14` case.
+- The consequence was larger than a numerical detail. `AUG2DC`'s path used to
+  reach `t = 0.5` within 50 steps and then stop, spending thousands of KKT
+  factorizations without moving the parameter at all, until it hit the time
+  cap. It now completes in **104 steps** and the solve returns the published
+  optimum. Re-measured across all 138 Maros-Mészáros convex QPs at a fixed
+  cap, homotopy-on against the same run's homotopy-off: `AUG2D` and `AUG2DC`
+  recover with nothing regressing, cold paths reaching `t = 1` go 92 → 98,
+  paths killed mid-flight 37 → 31, and the median completed path halves
+  (216 → 102 steps). `QSHARE2B`, the seventh loss recorded on
+  `sqp_qp_use_homotopy`, also recovers.
+- **No runtime guard is added**, which is what #434 was filed to ask for. The
+  losses that remain after this fix cannot be separated from the gains by any
+  threshold on (path steps, `t`): the only rule that catches all the reachable
+  ones sits 3% above `KSIP`'s completed path length, and firing it also
+  abandons `LASER`, which the homotopy solves in 16.3 s against 41.4 s on the
+  conventional route. Per the issue's own instruction, the measurement is the
+  deliverable rather than a fitted threshold. Recorded in
+  `dev-notes/issue-434-homotopy-cost.md`, with the harness kept as
+  `crates/pounce-convex/examples/homotopy_sweep.rs` and per-path telemetry
+  (steps, final `t`, longest run of steps that did not advance `t`) on the
+  existing `POUNCE_HOMOTOPY_DEBUG` trace.
+
 ### Fixed — active-set SQP: a warm start was discarded whenever the active set moved (#428)
 
 - `solve_with_working_set` pins the hinted active rows to their new

--- a/crates/pounce-convex/examples/homotopy_sweep.rs
+++ b/crates/pounce-convex/examples/homotopy_sweep.rs
@@ -1,0 +1,198 @@
+//! Measurement harness for the gh #434 homotopy on/off sweep.
+//!
+//! gh #434 asks a question that cannot be answered by reading the code: the
+//! §4.2 parametric homotopy is a net win on Maros-Mészáros (71/138 against
+//! 58/138) but it *loses* seven instances, and on those it is pure cost — it
+//! spends the whole budget without reaching `t = 1`. Before any guard can be
+//! written, the losses have to be separated from the gains by something
+//! observable at runtime, and the issue is explicit that a guard must not be
+//! chosen without per-problem data at the shipped code state.
+//!
+//! This example is the instrument. It solves one QP through
+//! [`solve_qp_active_set`] with `use_homotopy` forced on or off — the two arms
+//! differing by exactly that one option — and prints a single JSON object with
+//! the status, objective, time, and (parsed by the driver from the
+//! `POUNCE_HOMOTOPY_DEBUG` trace on stderr) the path's step count and final
+//! `t`. Everything else about the solve is the shipped configuration, so the
+//! numbers describe the driver users actually get.
+//!
+//! Run:
+//!
+//! ```text
+//! cargo run -p pounce-convex --release --example homotopy_sweep -- <file.qp> on|off
+//! ```
+//!
+//! The input is the flat text form written by the sweep's `.mat` converter:
+//!
+//! ```text
+//! n <n>
+//! c <n floats>
+//! P <nnz>                  ; then <nnz> lines of "row col val" (lower triangle)
+//! A <m_eq> <nnz>           ; equality matrix
+//! b <m_eq floats>          ; then <nnz> lines of "row col val"
+//! G <m_ineq> <nnz>         ; inequality matrix
+//! h <m_ineq floats>        ; then <nnz> lines of "row col val"
+//! lb <n floats>
+//! ub <n floats>
+//! ```
+//!
+//! Whitespace-delimited throughout, so the reader is a token stream and the
+//! layout above is documentation rather than something the parser enforces.
+
+use pounce_convex::{
+    ActiveSetOverrides, NEG_INF, POS_INF, QpOptions, QpProblem, QpStatus, Triplet,
+    solve_qp_active_set,
+};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+use std::time::Instant;
+
+/// Whitespace token stream over the input file.
+struct Tokens<'a> {
+    it: std::str::SplitAsciiWhitespace<'a>,
+}
+
+impl<'a> Tokens<'a> {
+    fn new(s: &'a str) -> Self {
+        Tokens {
+            it: s.split_ascii_whitespace(),
+        }
+    }
+
+    fn next_tok(&mut self) -> &'a str {
+        self.it.next().expect("unexpected end of input")
+    }
+
+    /// Consume the expected section tag, so a malformed file fails loudly at
+    /// the point of the mismatch rather than silently shifting every field.
+    fn tag(&mut self, expect: &str) {
+        let got = self.next_tok();
+        assert_eq!(got, expect, "expected section tag `{expect}`, got `{got}`");
+    }
+
+    fn usize(&mut self) -> usize {
+        self.next_tok().parse().expect("expected an integer")
+    }
+
+    fn f64(&mut self) -> f64 {
+        self.next_tok().parse().expect("expected a float")
+    }
+
+    fn floats(&mut self, count: usize) -> Vec<f64> {
+        (0..count).map(|_| self.f64()).collect()
+    }
+
+    fn triplets(&mut self, nnz: usize) -> Vec<Triplet> {
+        (0..nnz)
+            .map(|_| {
+                let r = self.usize();
+                let c = self.usize();
+                Triplet::new(r, c, self.f64())
+            })
+            .collect()
+    }
+}
+
+/// `1e20` is the Maros-Mészáros infinity constant; map it onto the sentinels
+/// `pounce-convex` recognizes so an absent bound is not read as a real one.
+fn debound(v: f64) -> f64 {
+    if v <= -1e20 {
+        NEG_INF
+    } else if v >= 1e20 {
+        POS_INF
+    } else {
+        v
+    }
+}
+
+fn parse(text: &str) -> QpProblem {
+    let mut t = Tokens::new(text);
+    t.tag("n");
+    let n = t.usize();
+    t.tag("c");
+    let c = t.floats(n);
+    t.tag("P");
+    let p_nnz = t.usize();
+    let p_lower = t.triplets(p_nnz);
+    t.tag("A");
+    let m_eq = t.usize();
+    let a_nnz = t.usize();
+    t.tag("b");
+    let b = t.floats(m_eq);
+    let a = t.triplets(a_nnz);
+    t.tag("G");
+    let m_ineq = t.usize();
+    let g_nnz = t.usize();
+    t.tag("h");
+    let h = t.floats(m_ineq);
+    let g = t.triplets(g_nnz);
+    t.tag("lb");
+    let lb = t.floats(n).into_iter().map(debound).collect();
+    t.tag("ub");
+    let ub = t.floats(n).into_iter().map(debound).collect();
+    QpProblem {
+        n,
+        p_lower,
+        c,
+        a,
+        b,
+        g,
+        h,
+        lb,
+        ub,
+    }
+}
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() != 3 {
+        eprintln!("usage: homotopy_sweep <file.qp> on|off");
+        std::process::exit(2);
+    }
+    let use_homotopy = match args[2].as_str() {
+        "on" => true,
+        "off" => false,
+        other => panic!("arm must be `on` or `off`, got `{other}`"),
+    };
+
+    let text = std::fs::read_to_string(&args[1]).expect("cannot read problem file");
+    let prob = parse(&text);
+    let n = prob.n;
+    let m_eq = prob.m_eq();
+    let m_ineq = prob.m_ineq();
+
+    // The engine overrides are otherwise the shipped defaults: the point of the
+    // sweep is the difference this one option makes to the driver as configured.
+    let engine = ActiveSetOverrides {
+        use_homotopy: Some(use_homotopy),
+        ..Default::default()
+    };
+    let started = Instant::now();
+    let sol = solve_qp_active_set(&prob, &QpOptions::default(), &engine, &mut backend);
+    let elapsed = started.elapsed().as_secs_f64();
+
+    let status = match sol.status {
+        QpStatus::Optimal => "Optimal",
+        QpStatus::OptimalInaccurate => "OptimalInaccurate",
+        QpStatus::PrimalInfeasible => "PrimalInfeasible",
+        QpStatus::DualInfeasible => "DualInfeasible",
+        QpStatus::IterationLimit => "IterationLimit",
+        QpStatus::NumericalFailure => "NumericalFailure",
+        other => {
+            println!(
+                "{{\"status\": \"{other:?}\", \"n\": {n}, \"m_eq\": {m_eq}, \
+                 \"m_ineq\": {m_ineq}, \"time\": {elapsed}}}"
+            );
+            return;
+        }
+    };
+    println!(
+        "{{\"status\": \"{status}\", \"obj\": {}, \"n\": {n}, \"m_eq\": {m_eq}, \
+         \"m_ineq\": {m_ineq}, \"iters\": {}, \"time\": {elapsed}}}",
+        sol.obj, sol.iters
+    );
+}

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -90,14 +90,25 @@ use std::time::Instant;
 /// and the first ratio test would see a zero-length step.
 const RELAX_MARGIN: Number = 1.0;
 
-/// `t` is clamped into `[0, 1]`; an event closer than this to the current `t` is
-/// treated as coincident (a degenerate tie) rather than as forward progress, so
-/// the loop cannot spin on a zero-length advance.
+/// How close to `1` counts as having reached the end of the path.
 const T_EPS: Number = 1e-12;
 
+/// Two ratio-test events are **coincident** — the same degenerate vertex, hit at
+/// the same parameter value — when their crossing points differ by no more than
+/// this. `t` lives in `[0, 1]`, so this is a rounding-scale window (~50 ulp),
+/// not a tolerance with an algorithmic opinion in it.
+///
+/// It exists because the winning event has to bring *every* row that binds
+/// there into the working set, not just the first one the scan happened to
+/// find. A row left inactive at a bound it is exactly on gets crossed by the
+/// next direction, and a crossing is unrecoverable: the primal ratio test can
+/// only *prevent* a violation, never repair one, so from there the row drifts
+/// out for the rest of the path (`QSHARE2B` row 7 went 8e-2 -> 22 that way).
+const T_TIE: Number = 1e-14;
+
 /// Outcome of the two ratio tests: what happens first as `t` increases.
-#[derive(Debug, Clone, Copy)]
-enum Event {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Event {
     /// Inactive row `i` reaches its lower bound.
     AddRowLower(usize),
     /// Inactive row `i` reaches its upper bound.
@@ -106,6 +117,93 @@ enum Event {
     DropRow(usize),
     /// Active bound on variable `j` has its multiplier reach zero.
     DropBound(usize),
+}
+
+/// The winner set of one step's two ratio tests: the earliest crossing, and
+/// every other crossing coincident with it.
+///
+/// Both tests feed the same instance, because they compete for the same step —
+/// whichever of "a row binds" and "a multiplier vanishes" happens first sets
+/// `t_next`, and anything within [`T_TIE`] of it happens there too.
+///
+/// Separated out from the tracer because the selection rule is where gh #434's
+/// uncapped crossings came from and is worth testing on its own: it is pure,
+/// and its inputs are two numbers, while the loop it lives in needs a
+/// factorization per step to reach.
+pub(crate) struct RatioTest {
+    /// Parameter value the step will advance to.
+    pub(crate) t_next: Number,
+    /// Current parameter value; crossings are reported relative to it.
+    t: Number,
+    /// The winner and its coincident set, as `(parameter value, event)`.
+    pub(crate) winners: Vec<(Number, Event)>,
+}
+
+impl RatioTest {
+    /// A fresh test at `t`, with no crossing found yet — so the incumbent is the
+    /// end of the path.
+    pub(crate) fn new(t: Number) -> Self {
+        RatioTest {
+            t_next: 1.0,
+            t,
+            winners: Vec::new(),
+        }
+    }
+
+    /// Reset to `t` for the next step, keeping the allocation.
+    pub(crate) fn restart(&mut self, t: Number) {
+        self.t_next = 1.0;
+        self.t = t;
+        self.winners.clear();
+    }
+
+    /// Offer a crossing `dt` ahead of the current `t`.
+    ///
+    /// A slightly negative `dt` is a row a hair past its bound already; it is
+    /// admitted and clamped to `t`, so it binds now with a zero-length step.
+    /// Further out than that is a row the ratio test can no longer recover (see
+    /// the path-feasibility report in [`ParametricActiveSetSolver::trace_path`]),
+    /// and past `t = 1` is off the end of the path — neither is an event.
+    ///
+    /// The comparison against the incumbent is exact. It used to carry a
+    /// `- T_EPS` margin, which reads as a don't-bother-for-a-hair guard but is
+    /// not one: it made a crossing that happens *earlier* than the incumbent, by
+    /// less than `T_EPS`, lose to it — so the step knowingly overshot the
+    /// earlier one. Measured on `QSHARE2B`, row 132 crossed at `dt = 2.9e-16`
+    /// and lost to a step of `1.1e-14`; the row was left inactive and violated,
+    /// and since the ratio test can only prevent a violation and never repair
+    /// one, it drifted out for the rest of the path (gh #434).
+    ///
+    /// Anything strictly worse than the incumbent is dropped as it arrives, so
+    /// the winner set stays the size of one coincident group rather than growing
+    /// with the row count.
+    pub(crate) fn admit(&mut self, dt: Number, ev: Event) {
+        if dt < -T_EPS {
+            return;
+        }
+        let tc = (self.t + dt).max(self.t);
+        if tc > self.t_next + T_TIE {
+            return;
+        }
+        if tc < self.t_next - T_TIE {
+            self.winners.clear();
+        }
+        self.t_next = self.t_next.min(tc);
+        self.winners.push((tc, ev));
+    }
+
+    /// The events that fire at `t_next`: the winner plus everything coincident.
+    ///
+    /// Firing only one of a coincident set is what leaves a row sitting exactly
+    /// on a bound it is not in the working set for, which the next direction
+    /// then pushes it across.
+    pub(crate) fn firing(&self) -> impl Iterator<Item = Event> + '_ {
+        let t_next = self.t_next;
+        self.winners
+            .iter()
+            .filter(move |&&(tc, _)| tc <= t_next + T_TIE)
+            .map(|&(_, ev)| ev)
+    }
 }
 
 /// Primal regularization `δ` for the path, derived from the problem's own scale.
@@ -245,6 +343,31 @@ fn worst_path_violation(
     worst
 }
 
+/// Machine-readable one-line summary of a completed path, emitted on every
+/// exit from [`ParametricActiveSetSolver::trace_path`] when
+/// `POUNCE_HOMOTOPY_DEBUG` is set.
+///
+/// The line is a stable, parseable contract rather than prose because the
+/// measurement gh #434 asks for — path steps and final `t`, per problem, for
+/// both arms — is a benchmark sweep that has to read it back out. `exit` is one
+/// of `complete` (the path reached `t = 1`), `budget` (the step budget ran out
+/// short of it), `stalled` (the loop ended without either), `kkt` (an
+/// unrecoverable factorization failure), or `rank` (a rank repair that had
+/// nothing left to prune).
+fn trace_summary(
+    exit: &str,
+    steps: u32,
+    t: Number,
+    n_changes: u32,
+    n_refactor: u32,
+    longest_stall: u32,
+) {
+    eprintln!(
+        "[hom] summary exit={exit} steps={steps} t={t:.17} changes={n_changes} \
+         refactor={n_refactor} stall={longest_stall}"
+    );
+}
+
 /// Rate of change of a row bound per unit `t` (0 when the bound is infinite).
 fn bound_rate(relaxed: Number, target: Number, is_lower: bool) -> Number {
     let infinite = if is_lower {
@@ -378,20 +501,8 @@ impl ParametricActiveSetSolver {
         // Everything on the path is traced against this Hessian; the corrector at
         // the end uses the caller's `qp` and therefore the true `H`.
         let path_h: &SymTMatrix = h_reg_holder.as_ref().unwrap_or(qp.h);
-        let path_qp = QpProblem {
-            n,
-            m,
-            h: path_h,
-            g: qp.g,
-            a: qp.a,
-            bl: qp.bl,
-            bu: qp.bu,
-            xl: qp.xl,
-            xu: qp.xu,
-            hessian_inertia: qp.hessian_inertia,
-        };
 
-        let mut x = box_sol.x.clone();
+        let x = box_sol.x.clone();
         let mut working = WorkingSet::cold(n, m);
         for (i, st) in working.bounds.iter_mut().enumerate() {
             *st = box_sol.working.bounds[i];
@@ -416,7 +527,7 @@ impl ParametricActiveSetSolver {
             };
         }
 
-        let mut lambda_g = vec![0.0; m];
+        let lambda_g = vec![0.0; m];
         let mut lambda_x = box_sol.lambda_x.clone();
         lambda_x.resize(n, 0.0);
 
@@ -487,6 +598,22 @@ impl ParametricActiveSetSolver {
         // dependency that justified the prune no longer necessarily holds — this
         // suppresses the cycle without permanently blinding the ratio test.
         let mut tabu_cons = vec![false; m];
+        // Iterations actually executed. Distinct from `n_changes`: a rank repair
+        // and a degenerate zero-length advance both consume a step (and a
+        // factorization) without necessarily moving the working set or `t`.
+        let mut steps: u32 = 0;
+        // Hoisted out of the loop and restarted per step so the ratio tests do
+        // not allocate once per path step.
+        let mut ratio = RatioTest::new(0.0);
+        // Steps since `t` last advanced, and the worst such run on this path.
+        //
+        // A step that does not move `t` is a working-set exchange at a fixed
+        // parameter value — a degenerate pivot. A few are normal. An unbounded
+        // number of them is the path cycling, which is how the homotopy's
+        // measured losses actually fail: they are not slow paths, they are
+        // stopped ones (gh #434).
+        let mut stalled: u32 = 0;
+        let mut longest_stall: u32 = 0;
 
         // Each iteration either advances `t` or changes the working set, and the
         // budget bounds the total.
@@ -494,8 +621,9 @@ impl ParametricActiveSetSolver {
             if t >= 1.0 - T_EPS {
                 break;
             }
+            steps += 1;
             if trace && _step % 50 == 0 {
-                eprintln!("[hom] step={_step} t={t:.6e}");
+                eprintln!("[hom] step={_step} t={t:.17} stall={stalled}");
             }
 
             let active_cons: Vec<usize> = (0..m)
@@ -564,6 +692,7 @@ impl ParametricActiveSetSolver {
                         // Already full rank ⇒ not a deficiency this can repair.
                         if trace {
                             eprintln!("[hom] KKT failure at t={t:.6e}, full rank already: {e}");
+                            trace_summary("rank", steps, t, n_changes, n_refactor, longest_stall);
                         }
                         return Ok(None);
                     }
@@ -605,6 +734,7 @@ impl ParametricActiveSetSolver {
                 Err(e) => {
                     if trace {
                         eprintln!("[hom] KKT factorization failed at t={t:.6e}: {e}");
+                        trace_summary("kkt", steps, t, n_changes, n_refactor, longest_stall);
                     }
                     return Ok(None);
                 }
@@ -617,8 +747,7 @@ impl ParametricActiveSetSolver {
             // ---- Ratio test 1 (primal): when does an inactive row bind? ----
             let a_dx = a_times_x(qp.a, &dx, m);
             let ax = a_times_x(qp.a, &x, m);
-            let mut t_next: Number = 1.0;
-            let mut event: Option<Event> = None;
+            ratio.restart(t);
 
             for i in 0..m {
                 if working.constraints[i].is_active() || tabu_cons[i] {
@@ -629,11 +758,7 @@ impl ParametricActiveSetSolver {
                     let gap = bu0[i] + t * (qp.bu[i] - bu0[i]) - ax[i];
                     let rate = a_dx[i] - bound_rate(bu0[i], qp.bu[i], false);
                     if rate > 0.0 {
-                        let dt = gap / rate;
-                        if dt >= -T_EPS && t + dt < t_next - T_EPS {
-                            t_next = (t + dt).clamp(t, 1.0);
-                            event = Some(Event::AddRowUpper(i));
-                        }
+                        ratio.admit(gap / rate, Event::AddRowUpper(i));
                     }
                 }
                 // Lower: bl_i(t) − a_i·x(t) = 0.
@@ -641,11 +766,7 @@ impl ParametricActiveSetSolver {
                     let gap = ax[i] - (bl0[i] + t * (qp.bl[i] - bl0[i]));
                     let rate = bound_rate(bl0[i], qp.bl[i], true) - a_dx[i];
                     if rate > 0.0 {
-                        let dt = gap / rate;
-                        if dt >= -T_EPS && t + dt < t_next - T_EPS {
-                            t_next = (t + dt).clamp(t, 1.0);
-                            event = Some(Event::AddRowLower(i));
-                        }
+                        ratio.admit(gap / rate, Event::AddRowLower(i));
                     }
                 }
             }
@@ -665,11 +786,7 @@ impl ParametricActiveSetSolver {
                 // in this engine's packing (see `solve_general`'s drop test).
                 let heading_to_zero = (lam > 0.0 && rate < 0.0) || (lam < 0.0 && rate > 0.0);
                 if heading_to_zero {
-                    let dt = -lam / rate;
-                    if dt >= -T_EPS && t + dt < t_next - T_EPS {
-                        t_next = (t + dt).clamp(t, 1.0);
-                        event = Some(Event::DropRow(i));
-                    }
+                    ratio.admit(-lam / rate, Event::DropRow(i));
                 }
             }
             for (slot, &j) in active_bounds.iter().enumerate() {
@@ -680,20 +797,26 @@ impl ParametricActiveSetSolver {
                 let rate = dlam_b[slot];
                 let heading_to_zero = (lam > 0.0 && rate < 0.0) || (lam < 0.0 && rate > 0.0);
                 if heading_to_zero {
-                    let dt = -lam / rate;
-                    if dt >= -T_EPS && t + dt < t_next - T_EPS {
-                        t_next = (t + dt).clamp(t, 1.0);
-                        event = Some(Event::DropBound(j));
-                    }
+                    ratio.admit(-lam / rate, Event::DropBound(j));
                 }
             }
 
             // ---- Advance to the event (or to t = 1) ----
-            let dt = t_next - t;
+            //
+            // Firing a whole coincident set can leave the active set
+            // rank-deficient. That is not a new failure mode — the direction
+            // solve above already repairs it by pruning to a maximal independent
+            // subset — and it is the same trade the textbook degenerate-vertex
+            // rule makes.
+            let dt = ratio.t_next - t;
             if dt > T_EPS {
                 // Real progress along the path: the rank-repair tabu was scoped
                 // to the parameter value it was raised at, so release it.
                 tabu_cons.iter_mut().for_each(|f| *f = false);
+                stalled = 0;
+            } else {
+                stalled += 1;
+                longest_stall = longest_stall.max(stalled);
             }
             for (xi, &d) in x.iter_mut().zip(dx.iter()) {
                 *xi += dt * d;
@@ -704,7 +827,7 @@ impl ParametricActiveSetSolver {
             for (slot, &j) in active_bounds.iter().enumerate() {
                 lambda_x[j] += dt * dlam_b[slot];
             }
-            t = t_next;
+            t = ratio.t_next;
 
             // ---- Path-feasibility report ----
             //
@@ -728,16 +851,18 @@ impl ParametricActiveSetSolver {
             //    gives `a_i·dx = Σ c_j (a_j·dx)`, and nothing makes that
             //    combination track row `i`'s *own* bound rate.
             //
-            //  * **Coincident / sub-resolution events (4 of 14).** Two crossings
-            //    at the same `t_next`, or one below the `T_EPS` floor (row 132:
-            //    crossing at `dt = 2.9e-16`, step taken `1.1e-14`), lose the
-            //    strict `t + dt < t_next - T_EPS` comparison. The overshoot starts
-            //    tiny and compounds — QSHARE2B row 7 went 8e-2 -> 0.4 -> 7.5 ->
-            //    11 -> 22 over the rest of the path.
+            //  * **Coincident / sub-resolution events (4 of 14).** ~~Two
+            //    crossings at the same `t_next`, or one below the `T_EPS` floor
+            //    (row 132: crossing at `dt = 2.9e-16`, step taken `1.1e-14`),
+            //    lose the strict `t + dt < t_next - T_EPS` comparison.~~ Fixed
+            //    in gh #434: [`RatioTest`] compares crossings exactly and fires
+            //    the whole coincident set, so neither an earlier-by-a-hair
+            //    crossing nor a tied one is stepped over. That alone recovered
+            //    five of the seven instances the homotopy had been losing.
             //
-            // Repairing this properly needs an exchange pivot at the degenerate
-            // vertex (add the violated row, drop a dependent one), which is a real
-            // algorithmic addition and is left to follow-up work.
+            // Repairing the *first* mechanism properly needs an exchange pivot at
+            // the degenerate vertex (add the violated row, drop a dependent one),
+            // which is a real algorithmic addition and is left to follow-up work.
             //
             // Deliberately a *report* and not a bail-out. Abandoning the path here
             // was tried and measured worse: the corrector is a genuine corrector
@@ -750,30 +875,29 @@ impl ParametricActiveSetSolver {
                 eprintln!("[hom] path infeasible at t={t:.9e}: row {i} by {v:.3e}");
             }
 
-            match event {
-                None => {
-                    // Nothing binds before t = 1: the path is complete.
-                    t = 1.0;
-                    break;
+            if ratio.winners.is_empty() {
+                // Nothing binds before t = 1: the path is complete.
+                t = 1.0;
+                break;
+            }
+            for ev in ratio.firing() {
+                match ev {
+                    Event::AddRowUpper(i) => {
+                        working.constraints[i] = ConsStatus::AtUpper;
+                    }
+                    Event::AddRowLower(i) => {
+                        working.constraints[i] = ConsStatus::AtLower;
+                    }
+                    Event::DropRow(i) => {
+                        working.constraints[i] = ConsStatus::Inactive;
+                        lambda_g[i] = 0.0;
+                    }
+                    Event::DropBound(j) => {
+                        working.bounds[j] = BoundStatus::Inactive;
+                        lambda_x[j] = 0.0;
+                    }
                 }
-                Some(Event::AddRowUpper(i)) => {
-                    working.constraints[i] = ConsStatus::AtUpper;
-                    n_changes += 1;
-                }
-                Some(Event::AddRowLower(i)) => {
-                    working.constraints[i] = ConsStatus::AtLower;
-                    n_changes += 1;
-                }
-                Some(Event::DropRow(i)) => {
-                    working.constraints[i] = ConsStatus::Inactive;
-                    lambda_g[i] = 0.0;
-                    n_changes += 1;
-                }
-                Some(Event::DropBound(j)) => {
-                    working.bounds[j] = BoundStatus::Inactive;
-                    lambda_x[j] = 0.0;
-                    n_changes += 1;
-                }
+                n_changes += 1;
             }
         }
 
@@ -786,10 +910,17 @@ impl ParametricActiveSetSolver {
         if t < 1.0 - T_EPS {
             if trace {
                 eprintln!("[hom] path did NOT reach t=1 (stopped at {t:.6e}); falling back");
+                let exit = if steps >= opts.max_iter {
+                    "budget"
+                } else {
+                    "stalled"
+                };
+                trace_summary(exit, steps, t, n_changes, n_refactor, longest_stall);
             }
             return Ok(None);
         }
         if trace {
+            trace_summary("complete", steps, t, n_changes, n_refactor, longest_stall);
             eprintln!(
                 "[hom] reached t=1 after {n_changes} working-set changes; handoff x has \
                  max target violation {:.3e}",

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -105,6 +105,16 @@ pub struct QpOptions {
     /// completes its path but its corrector then exhausts its iterations.
     /// Set this to `false` to get the old behaviour on such a workload.
     ///
+    /// Most of that cost turned out to be a *defect* rather than the method:
+    /// the ratio test stepped over crossings it had found, and a stepped-over
+    /// row can never be recovered, so the path wedged. gh #434 fixed it (see
+    /// [`crate::homotopy::RatioTest`]) and re-measured — `AUG2D`, `AUG2DC` and
+    /// `QSHARE2B` recover outright, cold paths reaching `t = 1` go 92 → 98 of
+    /// 138, and the median completed path halves. `DTOC3` and the other long
+    /// paths remain, and #434 records why no runtime guard is shipped for them:
+    /// no threshold on (path steps, `t`) separates them from the gains.
+    /// Full measurement: `dev-notes/issue-434-homotopy-cost.md`.
+    ///
     /// See [`crate::homotopy`].
     pub use_homotopy: bool,
 

--- a/crates/pounce-qp/src/tests/homotopy_unit.rs
+++ b/crates/pounce-qp/src/tests/homotopy_unit.rs
@@ -32,7 +32,11 @@ fn earliest_crossing_wins_below_the_old_t_eps_margin() {
     r.admit(1.1e-14, Event::AddRowUpper(7));
     r.admit(2.9e-16, Event::AddRowLower(132));
 
-    assert_eq!(firing(&r), vec![Event::AddRowLower(132)], "row 132 must win");
+    assert_eq!(
+        firing(&r),
+        vec![Event::AddRowLower(132)],
+        "row 132 must win"
+    );
     assert!(
         r.t_next <= 0.5 + 2.9e-16,
         "step must stop at the earlier crossing, not overshoot it: t_next = {}",
@@ -119,7 +123,10 @@ fn unrecoverably_violated_crossing_is_not_an_event() {
     let mut r = RatioTest::new(0.75);
     r.admit(-1e-3, Event::AddRowLower(2));
     assert!(firing(&r).is_empty());
-    assert_eq!(r.t_next, 1.0, "no event ⇒ the step runs to the end of the path");
+    assert_eq!(
+        r.t_next, 1.0,
+        "no event ⇒ the step runs to the end of the path"
+    );
 }
 
 /// A crossing past the end of the path is not on this path.

--- a/crates/pounce-qp/src/tests/homotopy_unit.rs
+++ b/crates/pounce-qp/src/tests/homotopy_unit.rs
@@ -1,0 +1,150 @@
+//! gh #434 — the homotopy's ratio-test selection rule.
+//!
+//! The rule is two claims: the step stops at the **earliest** crossing, and
+//! **every** crossing coincident with it fires. Both were false, and both
+//! failure modes are silent — the path keeps running, having stepped over a
+//! constraint, and the violation it leaves behind is absorbing. The primal
+//! ratio test can only prevent a violation, never repair one, so a row crossed
+//! once stays crossed and drifts further out for the rest of the path
+//! (`QSHARE2B` row 7: `8e-2 -> 0.4 -> 7.5 -> 11 -> 22`).
+//!
+//! What made it worth testing here rather than through a solve: the rule is
+//! pure arithmetic on two numbers, but reaching it through `trace_path` costs a
+//! KKT factorization per step, and the instances that expose it are
+//! Maros-Mészáros-sized.
+
+use crate::homotopy::{Event, RatioTest};
+
+/// The crossings that fire, in the order the tests offered them.
+fn firing(r: &RatioTest) -> Vec<Event> {
+    r.firing().collect()
+}
+
+/// The measured #434 case, in the arithmetic that produced it: `QSHARE2B` row
+/// 132 crosses at `dt = 2.9e-16` while another row crosses at `1.1e-14`.
+///
+/// Both are far below the old `T_EPS = 1e-12` comparison margin, so the earlier
+/// one could not displace the later one and the step overshot it. The margin is
+/// gone; the earliest crossing has to win no matter how thin the margin.
+#[test]
+fn earliest_crossing_wins_below_the_old_t_eps_margin() {
+    let mut r = RatioTest::new(0.5);
+    r.admit(1.1e-14, Event::AddRowUpper(7));
+    r.admit(2.9e-16, Event::AddRowLower(132));
+
+    assert_eq!(firing(&r), vec![Event::AddRowLower(132)], "row 132 must win");
+    assert!(
+        r.t_next <= 0.5 + 2.9e-16,
+        "step must stop at the earlier crossing, not overshoot it: t_next = {}",
+        r.t_next
+    );
+}
+
+/// Order must not decide it: offering the earlier crossing first has to give
+/// the same answer as offering it second.
+#[test]
+fn earliest_crossing_wins_regardless_of_offer_order() {
+    let mut first = RatioTest::new(0.5);
+    first.admit(2.9e-16, Event::AddRowLower(132));
+    first.admit(1.1e-14, Event::AddRowUpper(7));
+
+    let mut second = RatioTest::new(0.5);
+    second.admit(1.1e-14, Event::AddRowUpper(7));
+    second.admit(2.9e-16, Event::AddRowLower(132));
+
+    assert_eq!(firing(&first), vec![Event::AddRowLower(132)]);
+    assert_eq!(firing(&second), vec![Event::AddRowLower(132)]);
+}
+
+/// A degenerate vertex: several rows bind at the same parameter value. All of
+/// them must enter the working set. Firing one and leaving the rest sitting
+/// exactly on their bounds is what the next direction then pushes them across.
+#[test]
+fn every_coincident_crossing_fires() {
+    let mut r = RatioTest::new(0.25);
+    r.admit(0.125, Event::AddRowUpper(1));
+    r.admit(0.125, Event::AddRowUpper(2));
+    r.admit(0.125, Event::AddRowLower(3));
+    // Not coincident — an order of magnitude later, and it must not fire.
+    r.admit(0.5, Event::AddRowUpper(4));
+
+    assert_eq!(
+        firing(&r),
+        vec![
+            Event::AddRowUpper(1),
+            Event::AddRowUpper(2),
+            Event::AddRowLower(3)
+        ]
+    );
+    assert!((r.t_next - 0.375).abs() < 1e-15, "t_next = {}", r.t_next);
+}
+
+/// The two ratio tests compete for the same step, so a vanishing multiplier
+/// coincident with a binding row fires alongside it rather than instead of it.
+#[test]
+fn primal_and_dual_events_can_fire_together() {
+    let mut r = RatioTest::new(0.0);
+    r.admit(0.4, Event::AddRowUpper(9));
+    r.admit(0.4, Event::DropRow(2));
+    r.admit(0.4, Event::DropBound(5));
+
+    assert_eq!(
+        firing(&r),
+        vec![
+            Event::AddRowUpper(9),
+            Event::DropRow(2),
+            Event::DropBound(5)
+        ]
+    );
+}
+
+/// A crossing a hair *behind* the current `t` is a row already marginally past
+/// its bound. It binds now, with a zero-length step, rather than being ignored
+/// — and it displaces a genuine forward crossing, because it is earlier.
+#[test]
+fn marginally_negative_crossing_binds_at_the_current_t() {
+    let mut r = RatioTest::new(0.75);
+    r.admit(0.1, Event::AddRowUpper(1));
+    r.admit(-1e-13, Event::AddRowLower(2));
+
+    assert_eq!(firing(&r), vec![Event::AddRowLower(2)]);
+    assert_eq!(r.t_next, 0.75, "the step must not move backwards");
+}
+
+/// A row further behind than that is already violated, and the ratio test has
+/// no way to bring it back — admitting it would move `t` backwards. It is
+/// dropped, and the report in `trace_path` is what surfaces it.
+#[test]
+fn unrecoverably_violated_crossing_is_not_an_event() {
+    let mut r = RatioTest::new(0.75);
+    r.admit(-1e-3, Event::AddRowLower(2));
+    assert!(firing(&r).is_empty());
+    assert_eq!(r.t_next, 1.0, "no event ⇒ the step runs to the end of the path");
+}
+
+/// A crossing past the end of the path is not on this path.
+#[test]
+fn crossing_beyond_t_equals_one_is_not_an_event() {
+    let mut r = RatioTest::new(0.9);
+    r.admit(0.3, Event::AddRowUpper(1));
+    assert!(firing(&r).is_empty());
+    assert_eq!(r.t_next, 1.0);
+}
+
+/// `restart` has to clear the previous step's winners as well as its `t_next`;
+/// a leaked winner would fire an event at a parameter value the path has
+/// already passed.
+#[test]
+fn restart_clears_the_previous_step() {
+    let mut r = RatioTest::new(0.1);
+    r.admit(0.05, Event::AddRowUpper(1));
+    assert_eq!(firing(&r).len(), 1);
+
+    r.restart(0.2);
+    assert!(firing(&r).is_empty());
+    assert_eq!(r.t_next, 1.0);
+
+    r.admit(0.3, Event::DropRow(4));
+    assert_eq!(firing(&r), vec![Event::DropRow(4)]);
+    assert!((r.t_next - 0.5).abs() < 1e-15, "t_next = {}", r.t_next);
+}

--- a/crates/pounce-qp/src/tests/mod.rs
+++ b/crates/pounce-qp/src/tests/mod.rs
@@ -13,6 +13,7 @@
 mod analytical;
 mod api;
 mod elastic_unit;
+mod homotopy_unit;
 mod kkt_unit;
 mod qps_unit;
 mod refinement_unit;

--- a/dev-notes/issue-434-homotopy-cost.md
+++ b/dev-notes/issue-434-homotopy-cost.md
@@ -1,0 +1,160 @@
+# issue #434 — the homotopy's "pure cost" losses, measured
+
+[#434](https://github.com/jkitchin/pounce/issues/434) records that the §4.2
+parametric homotopy (`pounce-qp`'s `homotopy.rs`, on by default in the convex
+QP driver) is a net win on Maros-Mészáros but not a uniform one: a handful of
+large instances that used to solve now hit the time cap, and on those the path
+is **pure cost** — it burns the whole budget without reaching `t = 1`.
+
+The issue proposes a runtime guard (abandon a path that is not getting
+anywhere, fall back to the conventional cold start) and is explicit about the
+order of work:
+
+> A guard has to fire on the 7 losses without touching the 20 gains, and no
+> threshold should be chosen without data at the shipped code state. […]
+> **If none does, this issue should be closed rather than shipping a guess** —
+> the failure mode of a bad threshold is giving back more than it recovers,
+> silently.
+
+This note records that measurement and what it turned up, which was not what
+the issue expected: **most of the cost was a numerical defect, not an
+algorithmic one.** #434's own "also open, and cheaper" item — crossings
+escaping the primal ratio test — was the cause of the expensive one.
+
+---
+
+## The instrument
+
+`crates/pounce-convex/examples/homotopy_sweep.rs` solves one QP through
+`solve_qp_active_set` with `use_homotopy` forced on or off — the two arms
+differing by exactly that option, everything else the shipped configuration —
+and prints status, objective, and time as JSON. Per-path telemetry (steps,
+final `t`, longest run of steps that did not advance `t`) comes from the
+existing `POUNCE_HOMOTOPY_DEBUG` trace, which now emits a machine-readable
+`[hom] summary …` line at every exit from `trace_path`.
+
+Problem data is the same 138-problem Maros-Mészáros convex QP set the `qp`
+suite uses, read from the `qpsolvers/maros_meszaros_qpbenchmark` `.mat`
+mirror. Objectives are checked against `benchmarks/qp/ipopt_ma57.json` (with
+the `.mat` constant offset `r` restored), so "solved" means *solved correctly*
+and a solved-but-wrong answer is not counted as a win.
+
+### Environment caveat — read the deltas, not the totals
+
+The sweep ran on a 4-core container with 3 solves concurrent at a 120 s cap.
+That is materially slower than the machine behind #434's tables, and the
+absolute counts reflect it: the conventional arm scores 52/138 here against
+the 58/138 in the issue, and the baseline homotopy arm 46/138 against 71/138.
+Wall-clock-sensitive verdicts (`Timeout` in particular) therefore differ from
+the issue's per-problem lists.
+
+Everything below is an **A/B on one machine in one run**, which is the
+comparison the question needs. Path step counts and `t` values are
+deterministic and unaffected by the contention.
+
+---
+
+## What the losses actually are
+
+Baseline (pre-fix) homotopy against the conventional arm, same run: **+2 / −8**.
+The eight losses split cleanly into two mechanisms, and the split is the whole
+point:
+
+| loss | path steps | final `t` | path ended | homotopy arm | conventional arm |
+|---|--:|--:|---|---|---|
+| AUG2D | 1000+ | 0.500 | killed at the cap | Timeout | Optimal, 8.8 s |
+| AUG2DC | 2100+ | 0.500 | killed at the cap | Timeout | Optimal, 8.2 s |
+| DTOC3 | 2600+ | 0.992 | killed at the cap | Timeout | Optimal, 0.7 s |
+| QSHIP04L | 1050+ | 0.552 | killed at the cap | Timeout | Optimal, 43.0 s |
+| STADAT2 | 6500+ | 0.9999 | killed at the cap | Timeout | Optimal, 56.4 s |
+| UBH1 | 1200+ | 0.612 | killed at the cap | Timeout | Optimal, 97.8 s |
+| **DUALC1** | **4** | **1.0** | **complete** | IterationLimit, 26.8 s | Optimal, 0.02 s |
+| **STCQP2** | **1163** | **1.0** | **complete** | Timeout | Optimal, 102.6 s |
+
+The first six are the mode #434 describes — the path never finishes. The last
+two are **a different failure**: the path completes, quickly, and what follows
+is bad. `DUALC1`'s path takes four steps to reach `t = 1` and hands over a
+working set the corrector then spends 2457 iterations failing to use, on a
+problem the conventional route solves in 20 ms. That is a *bad prediction*, not
+an expensive one, and no guard on path cost can reach it — the path is already
+over when the damage starts.
+
+Keeping the two apart matters for the guard question: a guard is scored against
+the six it could reach, not the eight.
+
+---
+
+## Result 1 — the ratio test was stepping over crossings
+
+`AUG2DC`'s trace is what redirected the investigation. Its path reaches
+`t = 0.5` inside 50 steps and then **stops**:
+
+```
+[hom] step=50  t=5.000000e-1
+[hom] step=100 t=5.000000e-1
+…
+[hom] step=1750 t=5.000000e-1
+```
+
+Not a slow path — a stopped one, spending thousands of KKT factorizations
+without moving the parameter at all.
+
+The cause is #434's other item. Both ratio tests selected the next event with
+
+```rust
+if dt >= -T_EPS && t + dt < t_next - T_EPS { … }
+```
+
+The `- T_EPS` margin reads as a don't-bother-for-a-hair guard. It is not one:
+it makes a crossing that happens **earlier** than the incumbent, by less than
+`T_EPS = 1e-12`, lose to it — so the step knowingly overshoots the earlier
+crossing. #413 measured exactly that on `QSHARE2B`: row 132 crossed at
+`dt = 2.9e-16` and lost to a step of `1.1e-14`.
+
+Overshooting is not a rounding-level mistake, because violation is absorbing.
+The primal ratio test only ever *prevents* a violation and can never repair
+one, so a row stepped over stays inactive and violated for the rest of the
+path while the direction solve pushes it further out. The same comparison also
+discarded crossings *tied* with the incumbent, leaving a row sitting exactly on
+a bound it was not in the working set for — which the next direction pushes it
+across.
+
+The repair (`RatioTest` in `homotopy.rs`): compare crossings exactly, and fire
+the whole coincident set rather than one member of it. `tests/homotopy_unit.rs`
+pins the rule directly, including the measured 2.9e-16-vs-1.1e-14 case.
+
+Spot-checked on the instances #434 names, each verified against the Ipopt
+reference objective:
+
+| instance | baseline homotopy | fixed homotopy |
+|---|---|---|
+| AUG2D | Timeout, path stuck at `t = 0.50` | **Optimal, 38.2 s** (`rel = 1.7e-14`) |
+| AUG2DC | Timeout, path stuck at `t = 0.50` | **Optimal, 17.0 s**, path completes in **104 steps** |
+| QSHARE2B | the #413 loss | **OptimalInaccurate**, matches the published `11703.69` |
+
+*(Full 138-problem re-run in progress; this section gets the complete table.)*
+
+---
+
+## Result 2 — the guard
+
+*(Pending the full re-run. The question is whether any rule of the form
+"abandon after `K` steps with `t` still below `T`" fires on the losses that
+remain after the fix without firing on any gain.)*
+
+One methodological point is already settled, and it is the reason this took a
+second sweep. A guard fires **during** a path, so a candidate rule must be
+replayed against the path's `(step, t)` **trajectory**, not against the
+`(steps, t)` it ended at. Scored on endpoints, "abandon at 50 steps with
+`t < 0.9999`" looks like it catches every reachable loss and harms no gain —
+but `KSIP`, a gain, reaches `t = 1` only after 1065 steps, and spends the
+early part of that path indistinguishable from one that never finishes. The
+endpoint score silently credits a rule that would have thrown `KSIP` away.
+The harness therefore records every `(step, t)` tick and replays rules against
+the whole path.
+
+---
+
+## What is left
+
+*(Pending.)*

--- a/dev-notes/issue-434-homotopy-cost.md
+++ b/dev-notes/issue-434-homotopy-cost.md
@@ -123,38 +123,119 @@ The repair (`RatioTest` in `homotopy.rs`): compare crossings exactly, and fire
 the whole coincident set rather than one member of it. `tests/homotopy_unit.rs`
 pins the rule directly, including the measured 2.9e-16-vs-1.1e-14 case.
 
-Spot-checked on the instances #434 names, each verified against the Ipopt
-reference objective:
+Re-running all 138 with only that change (the conventional arm is untouched by
+it, so it is reused from the same run):
+
+| arm | correct | solved-but-wrong | timeouts |
+|---|--:|--:|--:|
+| conventional | 52/138 | 4 | 58 |
+| homotopy, baseline | 46/138 | 1 | 72 |
+| homotopy, **fixed** | **48/138** | 3 | 69 |
+
+**Fixed against baseline homotopy: +2 / −0.** `AUG2D` and `AUG2DC` recover;
+nothing regresses. Both are correct to `1e-14` against the Ipopt reference:
 
 | instance | baseline homotopy | fixed homotopy |
 |---|---|---|
-| AUG2D | Timeout, path stuck at `t = 0.50` | **Optimal, 38.2 s** (`rel = 1.7e-14`) |
+| AUG2D | Timeout, path stuck at `t = 0.50` | **Optimal, 38.2 s** |
 | AUG2DC | Timeout, path stuck at `t = 0.50` | **Optimal, 17.0 s**, path completes in **104 steps** |
 | QSHARE2B | the #413 loss | **OptimalInaccurate**, matches the published `11703.69` |
 
-*(Full 138-problem re-run in progress; this section gets the complete table.)*
+The effect on paths generally is larger than the two status flips suggest —
+cold paths that reach `t = 1` go 92 → 98 of 138, those killed mid-flight
+37 → 31, and the median completed path halves:
+
+| | complete | killed mid-flight | median steps | max |
+|---|--:|--:|--:|--:|
+| baseline | 92 | 37 | 216 | 2725 |
+| fixed | 98 | 31 | **102** | 2725 |
+
+`QSHIP04L` is worth noting separately: its path went from *killed at 1050
+steps* to *complete in 615*, and it is **still a loss**. The fix moved it from
+the never-finishes mode into the bad-prediction mode. Path cost was not what
+was wrong with it.
 
 ---
 
-## Result 2 — the guard
+## Result 2 — the guard, declined
 
-*(Pending the full re-run. The question is whether any rule of the form
-"abandon after `K` steps with `t` still below `T`" fires on the losses that
-remain after the fix without firing on any gain.)*
+After the fix, six losses remain, and only three of them are even reachable by
+a guard on path cost — the other three (`DUALC1`, `QSHIP04L`, `STCQP2`)
+complete their paths and fail afterwards.
 
-One methodological point is already settled, and it is the reason this took a
-second sweep. A guard fires **during** a path, so a candidate rule must be
-replayed against the path's `(step, t)` **trajectory**, not against the
-`(steps, t)` it ended at. Scored on endpoints, "abandon at 50 steps with
-`t < 0.9999`" looks like it catches every reachable loss and harms no gain —
-but `KSIP`, a gain, reaches `t = 1` only after 1065 steps, and spends the
-early part of that path indistinguishable from one that never finishes. The
-endpoint score silently credits a rule that would have thrown `KSIP` away.
-The harness therefore records every `(step, t)` tick and replays rules against
-the whole path.
+A guard fires **during** a path, so each candidate rule was replayed against
+every path's recorded `(step, t)` trajectory rather than against the
+`(steps, t)` it ended at. That distinction is not pedantic: scored on
+endpoints, "abandon at 50 steps with `t < 0.9999`" looks like it catches every
+reachable loss and harms no gain — but `KSIP` reaches `t = 1` only after 1065
+steps and spends the early part of that path indistinguishable from one that
+never finishes, so the endpoint score silently credits a rule that would have
+thrown `KSIP` away.
+
+Replayed properly, exactly one rule shape catches all three reachable losses
+without firing on either gain:
+
+> abandon at `steps >= 1100` while `t < 0.99`
+
+**It should not be shipped.** Two independent reasons, both from the data:
+
+1. **It is fitted to one point, with a 3% margin.** `KSIP` — a genuine gain,
+   0.4 s with the homotopy against a 120 s timeout without it — completes its
+   path at **1065** steps. The threshold is **1100**. Nothing but that single
+   instance separates the rule from destroying a gain, and #434's own tables
+   list twenty gains on the machine it was filed from, none of whose path
+   lengths are known here.
+
+2. **It is not actually harmless.** The gain/loss framing hides the cost,
+   because a problem *both* arms solve cannot appear as a loss. Replaying the
+   rule against all 48 problems the fixed homotopy solves correctly, it fires
+   on `LASER` — path complete in 2725 steps, **Optimal in 16.3 s**, against
+   41.4 s on the conventional route. The guard would abandon a working fast
+   path there and hand the problem to a route 2.5× slower; at a tighter cap
+   that is a timeout it manufactured.
+
+So the answer to the issue's question 3 is **no**: no threshold on
+`(steps, t)` separates the losses from the gains. Per the issue's own
+instruction —
+
+> If none does, this issue should be closed rather than shipping a guess.
+
+— no guard is added. The measurement is the deliverable.
+
+This also matches the precedent in
+`dev-notes/issue-131-monotone-lbfgs-stall.md`, where an analogous stall
+detector was prototyped and discarded for the same reason: what looks like a
+hard stall in a trace is a decelerating crawl, and no fixed-window gate
+separates "slow but will finish" from "doomed".
 
 ---
 
 ## What is left
 
-*(Pending.)*
+* **The `DUALC1` / `QSHIP04L` / `STCQP2` mode is untouched and is the more
+  interesting one.** The path completes and the prediction is still bad —
+  `DUALC1` reaches `t = 1` in four steps and the corrector then spends 2457
+  iterations failing on a problem the conventional route solves in 20 ms. That
+  is a question about what the path predicts, not about what it costs, and it
+  wants its own issue rather than a line in this one.
+* **The rank-repair tabu**, the other and larger source of uncapped crossings
+  in #413's measurement (10 of 14, against the 4 fixed here). `tabu_cons`
+  hides a row from the *primal ratio test* rather than only from the add
+  decision, so the step is computed as if the row were absent and crosses it.
+  Repairing it properly needs an exchange pivot at the degenerate vertex.
+* **`DTOC3`, `STADAT2`, `UBH1`** remain genuinely long paths — `t` advancing
+  the whole way, no stall — which is the mechanism #434 describes and which
+  this note does not solve. What it establishes is that they cannot be
+  separated from the gains by a runtime threshold.
+
+## Reproducing
+
+The harness is `crates/pounce-convex/examples/homotopy_sweep.rs`; the sweep
+driver, the `.mat` → flat-text converter, and the analysis scripts are not
+committed (they depend on a downloaded copy of the Maros-Mészáros `.mat`
+mirror). To re-run:
+
+```
+cargo run -p pounce-convex --release --example homotopy_sweep -- <file.qp> on|off
+POUNCE_HOMOTOPY_DEBUG=1   # adds the [hom] summary / step trace on stderr
+```

--- a/dev-notes/issue-434-homotopy-cost.md
+++ b/dev-notes/issue-434-homotopy-cost.md
@@ -16,10 +16,17 @@ order of work:
 > the failure mode of a bad threshold is giving back more than it recovers,
 > silently.
 
-This note records that measurement and what it turned up, which was not what
-the issue expected: **most of the cost was a numerical defect, not an
-algorithmic one.** #434's own "also open, and cheaper" item — crossings
-escaping the primal ratio test — was the cause of the expensive one.
+This note records that measurement. Two things came out of it, and they are
+about different phenomena that the issue treats as one:
+
+1. The instances where the homotopy **wedges** — burns the cap without
+   finishing — were mostly a numerical defect, #434's own "also open, and
+   cheaper" item. Fixing it recovers them.
+2. The **Ω(|A|) pivot cost** the issue's title describes is separate, real,
+   and untouched by that fix. The warm-start corroboration reproduces
+   *identically* after it.
+
+And the guard the issue asks for is **declined**, with the data for why.
 
 ---
 
@@ -154,6 +161,46 @@ cold paths that reach `t = 1` go 92 → 98 of 138, those killed mid-flight
 steps* to *complete in 615*, and it is **still a loss**. The fix moved it from
 the never-finishes mode into the bad-prediction mode. Path cost was not what
 was wrong with it.
+
+### The fix does **not** touch the warm-start corroboration — and that matters
+
+#434 corroborates its cost claim with the `benchmarks/warmstart` suite, whose
+`-hom` arms differ from their twins by exactly `use_homotopy`. Re-running that
+suite (`python -m warmstart.run --quick`, the three families in the issue's
+table) against the **fixed** build reproduces the issue's numbers *exactly*:
+
+| family | conventional | homotopy | ratio | mean \|A\|/n |
+|---|--:|--:|--:|--:|
+| `simplex_proj` | 328 | 523 | 0.63× | 16.4/20 = 82% |
+| `rosenbrock_ring` | 29 | 29 | 1.00× | 0.5/10 = 5% |
+| `nmpc_vanderpol` | 370 | 1140 | **0.32×** | 46.4/47 = 99% |
+| **total** | **727** | **1692** | **0.43×** | |
+
+Not close to the issue's figures — identical. These are deterministic counts,
+and the ratio-test defect never fires on these families: they are small,
+non-degenerate QPs where no two crossings land within `1e-12` of each other.
+
+So the two phenomena are **separate**, and this note's first result must not be
+read as covering both:
+
+* The **Ω(\|A\|) pivot cost** the issue describes is real, reproduced, tracks
+  the active-set fraction exactly as claimed (82% → 0.63×, 5% → 1.00×,
+  99% → 0.32×), and is **completely untouched** by the ratio-test fix.
+* The **Maros-Mészáros wedging** — `AUG2D`/`AUG2DC` stuck at `t = 0.5` and
+  burning the cap — was the defect, and is fixed.
+
+Worth stating plainly because it is easy to overclaim from the first result:
+the fix explains why some large cold solves *stopped*, not why the homotopy
+costs more pivots when the active set is a large fraction of `n`. #434's
+central mechanism claim survives the fix intact.
+
+Two things bound how much that costs in practice. All arms return correct
+answers with **identical outer iteration counts** (20/20, 301/301, 86/86), so
+the extra inner work buys nothing and loses nothing — it is overhead, not
+damage. And `use_homotopy` defaults to `false` in `pounce-qp`, so the SQP
+inner-QP path does not take it unless asked; these `-hom` arms are opt-in
+measurements, not shipped behaviour. The default that *is* on is the convex QP
+driver's, which is what the Maros-Mészáros sweep above measures.
 
 ---
 


### PR DESCRIPTION
Fixes #434.

## Problem

The §4.2 parametric homotopy wedges on large degenerate QPs: the path stops advancing `t` and burns the whole budget without reaching `t = 1`, so the solve hits the cap on problems the conventional route solves in seconds.

`AUG2DC` (n = 20200), one of the six large instances #434 records as lost. Its path reaches `t = 0.5` inside 50 steps and then stops dead:

```
[hom] step=50   t=5.000000e-1
[hom] step=100  t=5.000000e-1
…
[hom] step=1750 t=5.000000e-1
```

| | status | objective | path | time |
|---|---|---|---|---|
| before | Timeout | — | 2100+ steps, stuck at `t = 0.500` | 120 s (cap) |
| after | **Optimal** | 1818368.0655701957 | **104 steps**, `t = 1` | **17.0 s** |
| oracle (Ipopt MA57) | Solve_Succeeded | 1818368.0655701763 | | |

Agreement `1.1e-14` relative. `AUG2D` likewise: Timeout → Optimal in 38.2 s, `1.7e-14` against the oracle. `QSHARE2B` — the seventh loss, the one that completes its path and then exhausts the corrector — also recovers.

## Cause

Both ratio tests selected the next event with

```rust
if dt >= -T_EPS && t + dt < t_next - T_EPS { … }
```

That `- T_EPS` reads as a don't-bother-for-a-hair guard. It is not one: it makes a crossing that happens **earlier** than the incumbent, by less than `T_EPS = 1e-12`, *lose* to it. The step then knowingly overshoots the earlier crossing. #413 measured exactly this on `QSHARE2B` — row 132 crossed at `dt = 2.9e-16` and lost to a step of `1.1e-14`.

Overshooting is not a rounding-level mistake, because **violation is absorbing**. The primal ratio test only ever *prevents* a violation and can never repair one: once a row is stepped over, its gap is negative, its `dt` is negative, the `dt >= -T_EPS` filter discards it, and it stays inactive and violated while the direction solve pushes it further out (`QSHARE2B` row 7 went `8e-2 → 0.4 → 7.5 → 11 → 22`). The same comparison also discarded crossings *tied* with the incumbent, leaving a row sitting exactly on a bound it was not in the working set for — which the next direction pushes it across.

## Fix

Both ratio tests now feed one `RatioTest`, which compares crossings exactly and fires the whole coincident set rather than one member of it.

It is a separate type rather than an inlined change because the rule is pure arithmetic on two numbers while the loop around it needs a KKT factorization per step to reach — so the unit tests can hit the rule directly instead of through a Maros-Mészáros-sized solve.

**Rejected on the way, since a future maintainer will otherwise redo it:**

- *Fixing only the sub-resolution case (exact minimum, still one event per step).* Leaves the tie case, where a second row sits exactly on its bound outside the working set and is crossed on the next step. Both halves come from the same comparison; fixing one is arbitrary.
- *A tolerance-free tie rule (bitwise-equal crossing points).* Two rows that genuinely bind together rarely produce bit-identical `gap/rate`, so it would almost never fire. `T_TIE = 1e-14` is a rounding-scale window on `t ∈ [0, 1]` (~50 ulp), not a tuned threshold.
- *A stall guard* — abandon the path when `t` stops advancing. This looked compelling early: `AUG2DC` presents as a hard stall. But the stall *was the defect*; after the fix `AUG2DC` never records a single non-advancing step, and the losses that remain (`DTOC3`, `STADAT2`, `UBH1`) have `stall = 0` throughout — `t` advances the whole way, just slowly. A stall guard would not fire on any of them.

**No runtime guard is added**, which is what #434 was filed to ask for. Measured across all 138, replaying candidate rules against each path's recorded `(step, t)` trajectory (a guard fires *during* a path, so scoring against the `(steps, t)` it ended at asks the wrong question — that error initially credited a rule that would have destroyed `KSIP`): exactly one rule catches every reachable remaining loss without firing on a gain, **`steps ≥ 1100 while t < 0.99`**, and it fails on both counts that matter.

- Fitted to one point with a 3% margin: `KSIP` — a genuine gain, 0.4 s with the homotopy against a 120 s timeout without — completes at **1065** steps.
- Not actually harmless: a problem *both* arms solve cannot appear as a loss, so the gain/loss framing hides the cost. Replayed against all 48 problems the fixed homotopy solves correctly, it also fires on `LASER` — 2725 steps, **Optimal in 16.3 s**, against **41.4 s** conventional. It would abandon a working fast path for a route 2.5× slower.

Per the issue's own instruction ("If none does, this issue should be closed rather than shipping a guess"), the measurement is the deliverable. Same conclusion, for the same reason, as the stall detector prototyped and discarded in `dev-notes/issue-131-monotone-lbfgs-stall.md`.

## Blast radius

Behaviour changes only inside `trace_path`, so only solves with `use_homotopy = true` — i.e. the convex QP driver's cold path (`pounce-convex::active_set`), which sets it. `pounce-qp`'s own default is `false`, so the SQP inner-QP path is bit-identical unless a caller opts in.

**Corpus sweep** — all 138 Maros-Mészáros convex QPs, 120 s cap, objectives checked against `benchmarks/qp/ipopt_ma57.json` so a solved-but-wrong answer is not scored as a win. Baseline is this branch's parent, `5712930`.

| arm | correct | solved-but-wrong | timeouts |
|---|--:|--:|--:|
| conventional (`use_homotopy=false`) | 52/138 | 4 | 58 |
| homotopy, baseline | 46/138 | 1 | 72 |
| homotopy, **this PR** | **48/138** | 3 | 69 |

**+2 / −0** against the baseline homotopy: `AUG2D` and `AUG2DC` recover, nothing regresses. Path behaviour moves more than the two status flips suggest — cold paths reaching `t = 1` go 92 → 98 of 138, paths killed mid-flight 37 → 31, median completed path 216 → 102 steps.

**Scope, because it is easy to overclaim from that:** this fixes paths that *wedge*, not the `O(|A|)` pivot cost in #434's title. Re-running `benchmarks/warmstart --quick` — the three families in the issue's corroboration table, whose `-hom` arms differ from their twins by exactly `use_homotopy` — reproduces the issue's numbers **identically**, not approximately:

| family | conventional | homotopy | ratio | mean \|A\|/n |
|---|--:|--:|--:|--:|
| `simplex_proj` | 328 | 523 | 0.63× | 82% |
| `rosenbrock_ring` | 29 | 29 | 1.00× | 5% |
| `nmpc_vanderpol` | 370 | 1140 | 0.32× | 99% |
| **total** | **727** | **1692** | **0.43×** | |

These are deterministic counts and the defect never fires on those families — small, non-degenerate QPs where no two crossings land within `1e-12`. So #434's central mechanism claim survives this PR intact. What bounds it: every arm returns correct answers with identical outer iteration counts (20/20, 301/301, 86/86), so it is overhead rather than damage.

**Environment caveat on the totals.** The sweep ran on a 4-core container with 3 solves concurrent, which is slower than the machine behind #434's tables — hence 52/138 conventional against the issue's 58, and 46/138 baseline homotopy against its 71, with different per-problem timeout lists. Every conclusion above is an A/B on one machine in one run. Path step counts and `t` values are deterministic and unaffected.

## Tests

`crates/pounce-qp/src/tests/homotopy_unit.rs` — 8 tests on the selection rule, including the measured `2.9e-16`-vs-`1.1e-14` case, coincident sets, and primal/dual events firing together.

**They bite**: re-running them with only the pre-fix comparison rule restored inside `RatioTest::admit`, **4 of 8 fail** — and the right 4:

```
earliest_crossing_wins_below_the_old_t_eps_margin ... FAILED
earliest_crossing_wins_regardless_of_offer_order  ... FAILED
every_coincident_crossing_fires                   ... FAILED
primal_and_dual_events_can_fire_together          ... FAILED
```

The other four (negative-`dt` admission, crossings beyond `t = 1`, `restart` hygiene) pin invariants both rules share and pass either way — stated so the coverage is not read as stronger than it is.

Existing suites: full `pounce-qp` (93 lib + integration) and `pounce-convex` green, including `parametric_matches_cold_solve`, which covers the warm homotopy arm, and `issue413_homotopy_path_feasibility`.

**Deliberately not pinned:** the corpus-level result. Recovering `AUG2DC` needs a 20200-variable instance and a ~17 s solve, too large to vendor and too slow for CI. `dev-notes/issue-434-homotopy-cost.md` records how to reproduce it, and `crates/pounce-convex/examples/homotopy_sweep.rs` is kept in-tree as the harness.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — **n/a, deliberately.** The user-facing guidance is unchanged: `docs/src/warm-start-benchmark.md`'s advice keys off the `-hom` numbers, which this PR reproduces identically, and `docs/src/choosing-a-solver.md`'s IPM-vs-active-set claim is untouched. The changed default is the convex driver's internal cold path, which the book does not quantify.
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01HHU7hckR2TGfbE9rsdSVCn)_