### PR TITLE
Port IpRestoConvCheck layer 2: a verdict when the restoration sub-problem converges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — restoration had no verdict when its sub-problem converged
+
+- `IpRestoConvCheck::CheckConvergence` is two layers, and pounce ported
+  only the first. Layer 1 — the κ_resto reduction guard, the
+  square-problem fast path, and the outer-filter acceptance test —
+  answers *can the trial point leave restoration?*. Layer 2
+  (`IpRestoConvCheck.cpp:200-240`) answers *has the restoration
+  sub-problem itself converged?*, and it is the only thing that bounds a
+  restoration which can never satisfy layer 1 (#438).
+- Without it, a sub-problem sitting at its own KKT point — the moment it
+  has provably done everything it can — was indistinguishable from one
+  still making progress. When the κ_resto target is out of reach (the
+  outer enters restoration at a nearly-feasible point, restoration moves
+  the iterate away, and the reduction test then fails at every subsequent
+  iteration), the only remaining exits were the `maximum_iters` /
+  `max_resto_iter` caps: the wrong status, reported after orders of
+  magnitude more work than the diagnosis needed.
+- Layer 2's four-way verdict is now rendered inside the restoration
+  sub-solve: tighten the sub-problem tolerance once and continue,
+  converged-to-acceptable on a feasible square problem,
+  converged-to-a-feasible-point, or `LOCALLY_INFEASIBLE`. The tightening
+  arm keeps upstream's `tol > 1e-1 · orig_tol` guard, without which it is
+  an infinite loop.
+- Two deliberate deviations from upstream, both scoped so that #438
+  changes only the arm that had no verdict at all: the
+  converged-to-a-feasible-point arm hands the recovered point back to the
+  outer phase instead of throwing (upstream reports a restoration
+  failure), and square problems are exempt from the locally-infeasible
+  arm, matching the carve-out the post-hoc detection in
+  `resto_inner_solver` already made for them.
+- Set `POUNCE_DBG_RESTO_LAYER2=1` with `RUST_LOG=pounce::restoration=debug`
+  to trace the verdict.
 ### Fixed — port gap: no `ACCEPTABLE_POINT_REACHED` at the restoration doorway
 
 - **Upstream refuses to enter restoration from an acceptable point; pounce did

--- a/crates/pounce-cli/tests/issue_438_resto_layer2_verdict.rs
+++ b/crates/pounce-cli/tests/issue_438_resto_layer2_verdict.rs
@@ -1,0 +1,129 @@
+//! Regression test for pounce#438: the restoration convergence check had
+//! no layer 2.
+//!
+//! `IpRestoConvCheck::CheckConvergence` is two layers. Layer 1 — the
+//! `kappa_resto` reduction guard, the square-problem fast path, and the
+//! outer-filter acceptance test — answers *can the trial point leave
+//! restoration?*. Layer 2 (`IpRestoConvCheck.cpp:200-240`) answers the
+//! complementary question, *has the restoration sub-problem itself
+//! converged?*, and renders one of four verdicts when it has.
+//!
+//! Pounce ported layer 1 and omitted layer 2, so a restoration whose
+//! sub-problem had provably done everything it could was indistinguishable
+//! from one still making progress: it reported the sub-problem's own
+//! status and let the outer re-enter, or — when the kappa target was out
+//! of reach, which it is at every iteration once restoration moves the
+//! iterate away from a nearly-feasible entry point — ground on until an
+//! iteration cap turned "restoration cannot succeed" into "the solve ran
+//! out of iterations".
+//!
+//! This pins the verdict end-to-end through the binary, because the unit
+//! tests in `pounce-restoration` cover [`resto_orig_verdict`]'s arms
+//! individually and only a real solve proves the query is wired to the
+//! nested IPM's convergence check at all.
+//!
+//! `issue_372_infeasible_bounds.nl` (`0 <= x <= 0.6` with `x >= 0.7`) is
+//! used because it is a one-inequality contradiction: restoration drives
+//! the sub-problem to its KKT point in ten inner iterations at an
+//! original-NLP violation of `1e-1`, which is exactly layer 2's
+//! locally-infeasible arm and nothing else.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture_nl(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// Run a fixture with the layer-2 trace enabled and return `(stdout, stderr)`.
+fn run_with_layer2_trace(fixture: &str) -> (String, String) {
+    let output = Command::new(pounce_exe())
+        .arg(fixture_nl(fixture))
+        .arg("--no-sol")
+        .env("POUNCE_DBG_RESTO_LAYER2", "1")
+        .env("RUST_LOG", "pounce::restoration=debug")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("spawn pounce");
+    (
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+/// Every distinct layer-2 verdict the run logged, in first-seen order.
+fn logged_verdicts(stderr: &str) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for line in stderr.lines() {
+        let Some(rest) = line.split("[PN_RESTO_LAYER2] verdict=").nth(1) else {
+            continue;
+        };
+        let v = rest
+            .split_whitespace()
+            .next()
+            .unwrap_or_default()
+            .to_string();
+        if !seen.contains(&v) {
+            seen.push(v);
+        }
+    }
+    seen
+}
+
+/// The core of #438: layer 2 is reached, and on a model whose restoration
+/// sub-problem converges at a violated point it renders the
+/// locally-infeasible verdict rather than no verdict at all.
+#[test]
+fn sub_problem_convergence_renders_a_locally_infeasible_verdict() {
+    let (_, stderr) = run_with_layer2_trace("issue_372_infeasible_bounds.nl");
+    assert_eq!(
+        logged_verdicts(&stderr),
+        vec!["LocallyInfeasible".to_string()],
+        "pounce#438: once the restoration sub-problem converges, layer 2 \
+         must render a verdict; a violation of 1e-1 against tol=1e-8 is \
+         upstream's `LOCALLY_INFEASIBLE` arm \
+         (`IpRestoConvCheck.cpp:240`).\n--- stderr ---\n{stderr}",
+    );
+}
+
+/// The verdict must reach the user as the status it means. Before #438
+/// this model was diagnosed by a post-hoc heuristic in
+/// `resto_inner_solver` that reconstructed the same conclusion from the
+/// inner solver's terminal status and KKT residual (the `tiny_step` gate,
+/// added for gh #372); the verdict now supplies it directly, and the
+/// user-facing status is unchanged.
+#[test]
+fn locally_infeasible_verdict_surfaces_as_the_infeasibility_status() {
+    let (stdout, stderr) = run_with_layer2_trace("issue_372_infeasible_bounds.nl");
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.contains("local infeasibility"),
+        "expected the local-infeasibility exit status, got:\n{combined}",
+    );
+}
+
+/// Layer 2 must stay silent while restoration is still working — it is
+/// gated on the sub-problem's *own* convergence check, not on elapsed
+/// iterations. `pooling_rt2stp.nl` enters restoration, leaves it via
+/// layer 1, and solves; no verdict should ever be rendered.
+#[test]
+fn no_verdict_while_the_sub_problem_is_still_making_progress() {
+    let (stdout, stderr) = run_with_layer2_trace("pooling_rt2stp.nl");
+    assert!(
+        logged_verdicts(&stderr).is_empty(),
+        "layer 2 fired on a restoration that left via layer 1: {:?}",
+        logged_verdicts(&stderr),
+    );
+    assert!(
+        format!("{stdout}{stderr}").contains("Optimal Solution Found"),
+        "fixture is expected to solve; layer 2 must not have changed that",
+    );
+}

--- a/crates/pounce-restoration/src/conv_check.rs
+++ b/crates/pounce-restoration/src/conv_check.rs
@@ -79,23 +79,41 @@ pub enum RestoOrigVerdict {
 /// loop, which is why it is part of the port rather than an optimisation.
 pub fn resto_orig_verdict(
     orig_trial_inf_pr: f64,
+    orig_trial_rel_inf_pr: f64,
     tol: f64,
     orig_tol: f64,
     orig_constr_viol_tol: f64,
+    rel_viol_threshold: f64,
     is_square_problem: bool,
 ) -> RestoOrigVerdict {
+    // Every arm but the last asks "is this nearly feasible for the orig NLP?"
+    // and upstream asks it with an absolute threshold alone. That is not
+    // scale-invariant: `s*g(x) >= s*b` is the same constraint for every s > 0,
+    // but its residual carries s. Measured on `inf_372` (0 <= x <= 0.6 with
+    // s*x >= s*0.7, infeasible by 14% of the row at every s): the violation is
+    // 1.0e-1 at s = 1 and 1.0e-9 at s = 1e-8, so the same model clears
+    // `1e2 * tol` at small s and the arms read a decisively infeasible point as
+    // nearly feasible. gh #390 (residual of #387) settled this for the outer
+    // check; the same invariant is needed the moment layer 2 judges
+    // feasibility. Rows with no declared magnitude contribute 0 and fall back
+    // to the absolute test, which is already invariant for them.
+    let nearly_feasible =
+        orig_trial_inf_pr <= 1e2 * tol && orig_trial_rel_inf_pr <= rel_viol_threshold;
     // `IpRestoConvCheck.cpp:212` — nearly feasible for the orig NLP, and
     // there is tolerance budget left to spend chasing the rest.
-    if orig_trial_inf_pr <= 1e2 * tol && tol > 1e-1 * orig_tol {
+    if nearly_feasible && tol > 1e-1 * orig_tol {
         return RestoOrigVerdict::TightenAndContinue;
     }
     // `IpRestoConvCheck.cpp:222` — a square problem has nothing to
     // optimise, so any point feasible to `constr_viol_tol` is the answer.
-    if is_square_problem && orig_trial_inf_pr <= orig_constr_viol_tol {
+    if is_square_problem
+        && orig_trial_inf_pr <= orig_constr_viol_tol
+        && orig_trial_rel_inf_pr <= rel_viol_threshold
+    {
         return RestoOrigVerdict::ConvergedToAcceptable;
     }
     // `IpRestoConvCheck.cpp:227`.
-    if orig_trial_inf_pr <= 1e2 * tol {
+    if nearly_feasible {
         return RestoOrigVerdict::ConvergedToFeasiblePoint;
     }
     // `IpRestoConvCheck.cpp:240`.
@@ -115,6 +133,10 @@ pub struct RestoConvCheck {
     /// `constr_viol_tol` from the restoration sub-options; used in the
     /// square-problem fast path.
     pub orig_constr_viol_tol: f64,
+    /// Fraction of a row's own magnitude the violation must fall under before
+    /// layer 2 will call the orig NLP nearly feasible. `1e-2` matches the band
+    /// `OptErrorConvCheck::relative_viol_threshold` uses on the outer side.
+    pub rel_viol_threshold: f64,
     /// The restoration sub-problem's own tolerance (`IpData().tol()` of
     /// the resto algorithm). Layer 2's tightening arm shrinks it; see
     /// [`resto_orig_verdict`].
@@ -131,6 +153,7 @@ impl Default for RestoConvCheck {
             maximum_iters: 3000,
             maximum_resto_iters: 3000,
             orig_constr_viol_tol: 1e-4,
+            rel_viol_threshold: 1e-2,
             tol: 1e-8,
             first_resto_iter: true,
             successive_resto_iter: 0,
@@ -176,6 +199,7 @@ impl RestoConvCheck {
         is_square_problem: bool,
         orig_curr_inf_pr: f64,
         orig_trial_inf_pr: f64,
+        orig_trial_rel_inf_pr: f64,
         orig_tol: f64,
         acceptable_to_outer: impl FnOnce() -> bool,
         sub_problem_converged: impl FnOnce() -> bool,
@@ -231,9 +255,11 @@ impl RestoConvCheck {
         if sub_problem_converged() {
             match resto_orig_verdict(
                 orig_trial_inf_pr,
+                orig_trial_rel_inf_pr,
                 self.tol,
                 orig_tol,
                 self.orig_constr_viol_tol,
+                self.rel_viol_threshold,
                 is_square_problem,
             ) {
                 RestoOrigVerdict::TightenAndContinue => {
@@ -389,6 +415,8 @@ pub struct RestoConvCheckAdapter {
     /// (`IpRestoConvCheck::InitializeImpl` reads it with the *original*
     /// prefix). Consulted only on layer 2's square-problem arm.
     orig_constr_viol_tol: f64,
+    /// See [`RestoConvCheck::rel_viol_threshold`].
+    rel_viol_threshold: f64,
     /// Whether the original NLP is square (`IpCq().IsSquareProblem()`).
     is_square_problem: bool,
     /// Times layer 2's tightening arm has fired this restoration entry.
@@ -429,6 +457,7 @@ impl RestoConvCheckAdapter {
             // upstream arms unchanged.
             orig_tol: tol,
             orig_constr_viol_tol: 1e-4,
+            rel_viol_threshold: 1e-2,
             is_square_problem: false,
             resto_tol_tightenings: 0,
         }
@@ -530,18 +559,21 @@ impl RestoConvCheckAdapter {
         let tol = self.inner.tol;
         let verdict = resto_orig_verdict(
             m.inf_pr_unscaled,
+            m.inf_pr_relative,
             tol,
             self.orig_tol,
             self.orig_constr_viol_tol,
+            self.rel_viol_threshold,
             self.is_square_problem,
         );
 
         if std::env::var_os("POUNCE_DBG_RESTO_LAYER2").is_some() {
             tracing::debug!(target: "pounce::restoration",
-                "[PN_RESTO_LAYER2] verdict={:?} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} tol={:.6e} orig_tol={:.6e} orig_constr_viol_tol={:.6e} square={} tightenings={}",
+                "[PN_RESTO_LAYER2] verdict={:?} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} orig_inf_pr_rel={:.6e} tol={:.6e} orig_tol={:.6e} orig_constr_viol_tol={:.6e} square={} tightenings={}",
                 verdict,
                 m.inf_pr_unscaled,
                 m.inf_pr_scaled,
+                m.inf_pr_relative,
                 tol,
                 self.orig_tol,
                 self.orig_constr_viol_tol,
@@ -754,6 +786,20 @@ struct OrigTrialMeasures {
     /// row-scaled residual mixes two unit systems — the same mismatch
     /// documented at `resto_inner_solver::eval_orig_inf_pr_at_inner_curr`.
     inf_pr_unscaled: f64,
+    /// The orig NLP's constraint violation as a fraction of the violated
+    /// row's own magnitude, `max_i viol_i / max(|d_l_i|, |d_u_i|)`.
+    ///
+    /// Neither absolute measure above can be scale-invariant: a user may write
+    /// any row as `s*g(x) >= s*b` for `s > 0` without changing the feasible
+    /// set, and the residual then carries `s`. gh #390 (residual of #387)
+    /// settled this for the outer check; layer 2 needs the same invariant the
+    /// moment it makes a feasibility judgement of its own.
+    ///
+    /// Measured against the row's **bounds**, not against the restoration
+    /// slack: it is the orig row that has a declared magnitude. Rows with no
+    /// finite bound, or a declared magnitude of zero, contribute nothing — the
+    /// absolute measures are already invariant there.
+    inf_pr_relative: f64,
     /// Unscaled `f(x_orig)`.
     f: f64,
 }
@@ -815,11 +861,97 @@ fn eval_orig_trial_measures(
         (0.0, 0.0)
     };
 
+    // Scale-free companion, mirroring `IpoptCq::relative_d_infeasibility_max`.
+    // The bound vectors are **compressed** — one entry per row that has that
+    // side — so they must be expanded through `pd_l`/`pd_u` before they can be
+    // indexed against a row. Projecting an all-ones vector the same way gives
+    // the presence masks, without which a projected `0` is ambiguous between
+    // "no bound this side" and "a declared bound of zero".
+    let inf_pr_relative = if m_ineq > 0 {
+        let mut d_row = DenseVectorSpace::new(m_ineq).make_new_dense();
+        orig.eval_d(x_orig, &mut d_row);
+
+        // Prefer the declared bounds: on the live vectors a relaxed zero bound
+        // reads as ~1e-8 and would fabricate a magnitude for a row with none.
+        let (mut cl, mut cu) = (orig.d_l().make_new(), orig.d_u().make_new());
+        cl.copy(orig.d_l());
+        cu.copy(orig.d_u());
+        if let Some((dl, du)) = orig.declared_d_bounds() {
+            if let (Some(cld), Some(cud)) = (
+                cl.as_any_mut()
+                    .downcast_mut::<pounce_linalg::dense_vector::DenseVector>(),
+                cu.as_any_mut()
+                    .downcast_mut::<pounce_linalg::dense_vector::DenseVector>(),
+            ) {
+                cld.set_values(&dl);
+                cud.set_values(&du);
+            }
+        }
+
+        let mut lo = d_row.make_new();
+        lo.set(0.0);
+        orig.pd_l().mult_vector(1.0, &*cl, 0.0, &mut *lo);
+        let mut hi = d_row.make_new();
+        hi.set(0.0);
+        orig.pd_u().mult_vector(1.0, &*cu, 0.0, &mut *hi);
+
+        let mut ones_l = orig.d_l().make_new();
+        ones_l.set(1.0);
+        let mut mask_l = d_row.make_new();
+        mask_l.set(0.0);
+        orig.pd_l().mult_vector(1.0, &*ones_l, 0.0, &mut *mask_l);
+        let mut ones_u = orig.d_u().make_new();
+        ones_u.set(1.0);
+        let mut mask_u = d_row.make_new();
+        mask_u.set(0.0);
+        orig.pd_u().mult_vector(1.0, &*ones_u, 0.0, &mut *mask_u);
+
+        use pounce_linalg::dense_vector::DenseVector;
+        match (
+            d_row.as_any().downcast_ref::<DenseVector>(),
+            (&*lo).as_any().downcast_ref::<DenseVector>(),
+            (&*hi).as_any().downcast_ref::<DenseVector>(),
+            (&*mask_l).as_any().downcast_ref::<DenseVector>(),
+            (&*mask_u).as_any().downcast_ref::<DenseVector>(),
+        ) {
+            (Some(d), Some(lo), Some(hi), Some(ml), Some(mu)) => {
+                let (dv, lov, hiv, mlv, muv) = (
+                    d.expanded_values(),
+                    lo.expanded_values(),
+                    hi.expanded_values(),
+                    ml.expanded_values(),
+                    mu.expanded_values(),
+                );
+                let mut worst = 0.0_f64;
+                for i in 0..dv.len() {
+                    let (has_l, has_u) = (mlv[i] > 0.5, muv[i] > 0.5);
+                    let (mut viol, mut mag) = (0.0_f64, 0.0_f64);
+                    if has_l {
+                        viol = viol.max(lov[i] - dv[i]);
+                        mag = mag.max(lov[i].abs());
+                    }
+                    if has_u {
+                        viol = viol.max(dv[i] - hiv[i]);
+                        mag = mag.max(hiv[i].abs());
+                    }
+                    if mag > 0.0 && mag.is_finite() && viol.is_finite() && viol > 0.0 {
+                        worst = worst.max(viol / mag);
+                    }
+                }
+                worst
+            }
+            _ => 0.0,
+        }
+    } else {
+        0.0
+    };
+
     let f = orig.eval_f(x_orig);
 
     Some(OrigTrialMeasures {
         inf_pr_scaled: c_amax.1.max(d_minus_s_amax.1),
         inf_pr_unscaled: c_amax.0.max(d_minus_s_amax.0),
+        inf_pr_relative,
         f,
     })
 }
@@ -844,7 +976,7 @@ mod tests {
     #[test]
     fn first_iteration_always_continues() {
         let mut cc = RestoConvCheck::new();
-        let s = cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || false);
+        let s = cc.check_convergence(0, false, 1.0, 0.5, 0.0, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -852,7 +984,7 @@ mod tests {
     fn outer_iter_cap_triggers_max() {
         let mut cc = RestoConvCheck::new();
         cc.maximum_iters = 5;
-        let s = cc.check_convergence(6, false, 1.0, 0.5, 1e-8, || true, || false);
+        let s = cc.check_convergence(6, false, 1.0, 0.5, 0.0, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::MaxIterExceeded);
     }
 
@@ -861,10 +993,10 @@ mod tests {
         let mut cc = RestoConvCheck::new();
         cc.maximum_resto_iters = 2;
         // Burn through 3 calls — fourth should hit the cap.
-        cc.check_convergence(0, false, 1.0, 0.9, 1e-8, || false, || false);
-        cc.check_convergence(1, false, 1.0, 0.8, 1e-8, || false, || false);
-        cc.check_convergence(2, false, 1.0, 0.7, 1e-8, || false, || false);
-        let s = cc.check_convergence(3, false, 1.0, 0.6, 1e-8, || false, || false);
+        cc.check_convergence(0, false, 1.0, 0.9, 0.0, 1e-8, || false, || false);
+        cc.check_convergence(1, false, 1.0, 0.8, 0.0, 1e-8, || false, || false);
+        cc.check_convergence(2, false, 1.0, 0.7, 0.0, 1e-8, || false, || false);
+        let s = cc.check_convergence(3, false, 1.0, 0.6, 0.0, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::MaxIterExceeded);
     }
 
@@ -873,9 +1005,9 @@ mod tests {
         let mut cc = RestoConvCheck::new();
         cc.orig_constr_viol_tol = 1e-4;
         // Burn the first-iter freebie.
-        cc.check_convergence(0, true, 1.0, 0.5, 1e-8, || false, || false);
+        cc.check_convergence(0, true, 1.0, 0.5, 0.0, 1e-8, || false, || false);
         // Now feed a feasible trial.
-        let s = cc.check_convergence(1, true, 0.5, 1e-10, 1e-8, || false, || false);
+        let s = cc.check_convergence(1, true, 0.5, 1e-10, 0.0, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
@@ -883,9 +1015,9 @@ mod tests {
     fn insufficient_reduction_keeps_going() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.95, 1e-8, || true, || false);
+        cc.check_convergence(0, false, 1.0, 0.95, 0.0, 1e-8, || true, || false);
         // trial_inf_pr (0.95) > 0.9 * curr_inf_pr (1.0) — not enough.
-        let s = cc.check_convergence(1, false, 1.0, 0.95, 1e-8, || true, || false);
+        let s = cc.check_convergence(1, false, 1.0, 0.95, 0.0, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -893,8 +1025,8 @@ mod tests {
     fn sufficient_reduction_plus_filter_accept_converges() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || false);
-        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true, || false);
+        cc.check_convergence(0, false, 1.0, 0.5, 0.0, 1e-8, || true, || false);
+        let s = cc.check_convergence(1, false, 1.0, 0.5, 0.0, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
@@ -902,8 +1034,8 @@ mod tests {
     fn sufficient_reduction_but_filter_rejects_continues() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || false, || false);
-        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || false, || false);
+        cc.check_convergence(0, false, 1.0, 0.5, 0.0, 1e-8, || false, || false);
+        let s = cc.check_convergence(1, false, 1.0, 0.5, 0.0, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -911,18 +1043,18 @@ mod tests {
     fn kappa_zero_disables_reduction_guard() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.0;
-        cc.check_convergence(0, false, 1.0, 1.5, 1e-8, || true, || false);
+        cc.check_convergence(0, false, 1.0, 1.5, 0.0, 1e-8, || true, || false);
         // Even with trial > curr, the guard is bypassed and we go to
         // the outer-filter check, which accepts.
-        let s = cc.check_convergence(1, false, 1.0, 1.5, 1e-8, || true, || false);
+        let s = cc.check_convergence(1, false, 1.0, 1.5, 0.0, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
     #[test]
     fn reset_clears_state() {
         let mut cc = RestoConvCheck::new();
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || false);
-        cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true, || false);
+        cc.check_convergence(0, false, 1.0, 0.5, 0.0, 1e-8, || true, || false);
+        cc.check_convergence(1, false, 1.0, 0.5, 0.0, 1e-8, || true, || false);
         cc.reset();
         assert!(cc.first_resto_iter);
         assert_eq!(cc.successive_resto_iter, 0);
@@ -941,7 +1073,7 @@ mod tests {
         // Near-feasible for the orig NLP: `inf_pr` well inside `1e2 · tol`
         // at every tolerance the loop can reach.
         let inf_pr = 1e-12;
-        while resto_orig_verdict(inf_pr, tol, orig_tol, 1e-4, false)
+        while resto_orig_verdict(inf_pr, 0.0, tol, orig_tol, 1e-4, 1e-2, false)
             == RestoOrigVerdict::TightenAndContinue
         {
             tol *= 1e-2;
@@ -956,10 +1088,10 @@ mod tests {
     fn layer2_square_problem_feasible_within_constr_viol_tol_is_acceptable() {
         // Square, violation under `constr_viol_tol` but above `1e2 · tol`
         // so the tightening arm cannot claim it first.
-        let v = resto_orig_verdict(1e-5, 1e-10, 1e-8, 1e-4, true);
+        let v = resto_orig_verdict(1e-5, 0.0, 1e-10, 1e-8, 1e-4, 1e-2, true);
         assert_eq!(v, RestoOrigVerdict::ConvergedToAcceptable);
         // The same numbers on a non-square problem are a local infeasibility.
-        let v = resto_orig_verdict(1e-5, 1e-10, 1e-8, 1e-4, false);
+        let v = resto_orig_verdict(1e-5, 0.0, 1e-10, 1e-8, 1e-4, 1e-2, false);
         assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
     }
 
@@ -967,7 +1099,7 @@ mod tests {
     fn layer2_feasible_point_when_tolerance_budget_is_spent() {
         // `tol` already tightened past the guard, so the tightening arm is
         // closed; the violation is still inside `1e2 · tol`.
-        let v = resto_orig_verdict(1e-11, 1e-10, 1e-8, 1e-4, false);
+        let v = resto_orig_verdict(1e-11, 0.0, 1e-10, 1e-8, 1e-4, 1e-2, false);
         assert_eq!(v, RestoOrigVerdict::ConvergedToFeasiblePoint);
     }
 
@@ -979,11 +1111,87 @@ mod tests {
     fn layer2_locally_infeasible_when_violation_is_bounded_away_from_zero() {
         // qcqp1000-1nc's numbers: orig violation pinned at ~5e-3 with the
         // sub-problem at its own KKT point, default tolerances.
-        let v = resto_orig_verdict(5.05e-3, 1e-8, 1e-8, 1e-4, false);
+        let v = resto_orig_verdict(5.05e-3, 0.0, 1e-8, 1e-8, 1e-4, 1e-2, false);
         assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
         // Square problems reach the same verdict once the violation clears
         // `constr_viol_tol`; the caller applies pounce's square carve-out.
-        let v = resto_orig_verdict(5.05e-3, 1e-8, 1e-8, 1e-4, true);
+        let v = resto_orig_verdict(5.05e-3, 0.0, 1e-8, 1e-8, 1e-4, 1e-2, true);
+        assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
+    }
+
+    /// The property the whole relative measure exists for: multiplying a row
+    /// by a positive constant cannot change the verdict, because it cannot
+    /// change the feasible set.
+    ///
+    /// `inf_372` (`0 <= x <= 0.6` with `s*x >= s*0.7`) is infeasible by 14% of
+    /// the row at every `s`, but its *absolute* violation is `1.0e-1` at
+    /// `s = 1` and `1.0e-9` at `s = 1e-8`. On the absolute test alone the
+    /// second reads as nearly feasible and the arms mis-fire — the regression
+    /// `pyomo-pounce/tests/test_scale_invariance.py` caught.
+    #[test]
+    fn layer2_verdict_is_invariant_to_row_scaling() {
+        for (abs_viol, rel_viol) in [
+            (1.0e-1, 1.428571e-1),      // s = 1
+            (1.005193e-9, 1.432384e-1), // s = 1e-8, same model
+        ] {
+            let v = resto_orig_verdict(abs_viol, rel_viol, 1e-8, 1e-8, 1e-4, 1e-2, false);
+            assert_eq!(
+                v,
+                RestoOrigVerdict::LocallyInfeasible,
+                "abs={abs_viol:e} rel={rel_viol:e} must reach the same verdict at every row scaling"
+            );
+        }
+    }
+
+    /// The relative measure only ever *withholds* near-feasibility; it can
+    /// never manufacture it. A point tiny on both measures still tightens.
+    #[test]
+    fn layer2_relative_gate_blocks_but_never_creates_near_feasibility() {
+        // Tiny absolutely, but 14% of the row: not nearly feasible.
+        let v = resto_orig_verdict(1e-9, 1.4e-1, 1e-8, 1e-8, 1e-4, 1e-2, false);
+        assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
+        // Tiny on both: unchanged from the absolute-only behaviour.
+        let v = resto_orig_verdict(1e-9, 1e-6, 1e-8, 1e-8, 1e-4, 1e-2, false);
+        assert_eq!(v, RestoOrigVerdict::TightenAndContinue);
+        // Large absolutely but small relatively is still not nearly feasible:
+        // both tests must pass, so neither can override the other.
+        let v = resto_orig_verdict(5.05e-3, 1e-6, 1e-8, 1e-8, 1e-4, 1e-2, false);
+        assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
+    }
+
+    /// A row with no declared magnitude — homogeneous, or an NLP that does not
+    /// track one — contributes `0` to the relative measure and must fall back
+    /// to the absolute test, which is already scale-invariant there
+    /// (`s*g(x) == 0` is the same row at every `s`).
+    ///
+    /// This also pins the meaning of the `0.0` the other unit tests pass: it
+    /// is the abstaining case, not a way of switching the gate off.
+    #[test]
+    fn layer2_abstains_when_the_row_has_no_declared_magnitude() {
+        // Same three inputs as the arms' own tests, with an abstaining
+        // relative measure: each must land exactly where it did before.
+        assert_eq!(
+            resto_orig_verdict(1e-11, 0.0, 1e-10, 1e-8, 1e-4, 1e-2, false),
+            RestoOrigVerdict::ConvergedToFeasiblePoint
+        );
+        assert_eq!(
+            resto_orig_verdict(1e-5, 0.0, 1e-10, 1e-8, 1e-4, 1e-2, true),
+            RestoOrigVerdict::ConvergedToAcceptable
+        );
+        assert_eq!(
+            resto_orig_verdict(5.05e-3, 0.0, 1e-8, 1e-8, 1e-4, 1e-2, false),
+            RestoOrigVerdict::LocallyInfeasible
+        );
+    }
+
+    /// The square-problem arm is gated too. It is a feasibility judgement like
+    /// the others (`orig_trial_inf_pr <= constr_viol_tol`), so leaving it on
+    /// the absolute test alone would reopen the same hole one arm along.
+    #[test]
+    fn layer2_square_arm_is_gated_on_the_relative_measure_too() {
+        // Absolutely inside `constr_viol_tol`, but 14% of the row.
+        let v = resto_orig_verdict(1e-5, 1.4e-1, 1e-10, 1e-8, 1e-4, 1e-2, true);
+        assert_ne!(v, RestoOrigVerdict::ConvergedToAcceptable);
         assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
     }
 
@@ -996,10 +1204,10 @@ mod tests {
         cc.kappa_resto = 0.9;
         cc.tol = 1e-8;
         // Burn the first-iter freebie.
-        cc.check_convergence(0, false, 5.96e-8, 5.05e-3, 1e-8, || false, || false);
+        cc.check_convergence(0, false, 5.96e-8, 5.05e-3, 0.0, 1e-8, || false, || false);
         // Reduction is five orders out of reach, so layer 1 is `Continue`
         // forever — but the sub-problem has converged.
-        let s = cc.check_convergence(1, false, 5.96e-8, 5.05e-3, 1e-8, || false, || true);
+        let s = cc.check_convergence(1, false, 5.96e-8, 5.05e-3, 0.0, 1e-8, || false, || true);
         assert_eq!(s, RestoConvergenceStatus::LocallyInfeasible);
     }
 
@@ -1010,8 +1218,8 @@ mod tests {
     fn unconverged_sub_problem_still_continues() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 5.96e-8, 5.05e-3, 1e-8, || false, || false);
-        let s = cc.check_convergence(1, false, 5.96e-8, 5.05e-3, 1e-8, || false, || false);
+        cc.check_convergence(0, false, 5.96e-8, 5.05e-3, 0.0, 1e-8, || false, || false);
+        let s = cc.check_convergence(1, false, 5.96e-8, 5.05e-3, 0.0, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -1022,8 +1230,8 @@ mod tests {
     fn layer1_acceptance_outranks_layer2() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || true);
-        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true, || true);
+        cc.check_convergence(0, false, 1.0, 0.5, 0.0, 1e-8, || true, || true);
+        let s = cc.check_convergence(1, false, 1.0, 0.5, 0.0, 1e-8, || true, || true);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
@@ -1032,12 +1240,12 @@ mod tests {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
         cc.tol = 1e-8;
-        cc.check_convergence(0, false, 1.0, 1e-12, 1e-8, || false, || true);
-        let s = cc.check_convergence(1, false, 1.0, 1e-12, 1e-8, || false, || true);
+        cc.check_convergence(0, false, 1.0, 1e-12, 0.0, 1e-8, || false, || true);
+        let s = cc.check_convergence(1, false, 1.0, 1e-12, 0.0, 1e-8, || false, || true);
         assert_eq!(s, RestoConvergenceStatus::Continue);
         assert_eq!(cc.tol, 1e-10);
         // Second visit: budget spent, so the verdict is now terminal.
-        let s = cc.check_convergence(2, false, 1.0, 1e-12, 1e-8, || false, || true);
+        let s = cc.check_convergence(2, false, 1.0, 1e-12, 0.0, 1e-8, || false, || true);
         assert_eq!(s, RestoConvergenceStatus::Converged);
         assert_eq!(cc.tol, 1e-10, "no further tightening");
     }

--- a/crates/pounce-restoration/src/conv_check.rs
+++ b/crates/pounce-restoration/src/conv_check.rs
@@ -12,11 +12,97 @@
 pub enum RestoConvergenceStatus {
     Continue,
     Converged,
+    /// Restoration reached the sub-problem's *acceptable* level and the
+    /// recovered point is feasible for the original NLP. Upstream's
+    /// `CONVERGED_TO_ACCEPTABLE_POINT` on the square-problem arm of
+    /// `IpRestoConvCheck.cpp:225`.
+    ConvergedToAcceptable,
+    /// The restoration sub-problem converged at a point whose original-NLP
+    /// constraint violation is still bounded away from zero — upstream's
+    /// `LOCALLY_INFEASIBLE` throw (`IpRestoConvCheck.cpp:240`).
+    LocallyInfeasible,
     MaxIterExceeded,
     UserStop,
 }
 
-/// Scalar core of `IpRestoConvCheck::CheckConvergence` (lines 132-220).
+/// The verdict upstream renders once the restoration sub-problem has
+/// converged in its own right — layer 2 of `IpRestoConvCheck::
+/// CheckConvergence` (`IpRestoConvCheck.cpp:200-240`).
+///
+/// Layer 1 (the `kappa_resto` reduction guard, the square-problem fast
+/// path, and the outer-filter acceptance test) answers *can the trial
+/// point leave restoration?*. Layer 2 answers the complementary question
+/// — *has restoration provably done everything it can?* — and it is the
+/// only thing that bounds a restoration which can never satisfy layer 1.
+/// Without it, a sub-problem sitting at its own KKT point is
+/// indistinguishable from one still making progress, and restoration
+/// grinds to an iteration cap that reports the wrong status (pounce#438).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoOrigVerdict {
+    /// The original NLP is nearly feasible here and the sub-problem
+    /// tolerance can still be tightened: shrink it by `1e-2` and keep
+    /// iterating (`IpRestoConvCheck.cpp:212-217`). Bounded by
+    /// construction — see [`resto_orig_verdict`].
+    TightenAndContinue,
+    /// Square problem, feasible within `constr_viol_tol`
+    /// (`IpRestoConvCheck.cpp:222-226`).
+    ConvergedToAcceptable,
+    /// Restoration converged to a feasible point of the original NLP that
+    /// the outer phase nevertheless would not accept
+    /// (`IpRestoConvCheck.cpp:227-234`).
+    ConvergedToFeasiblePoint,
+    /// The sub-problem is at a stationary point of the constraint
+    /// violation whose residual is bounded away from zero
+    /// (`IpRestoConvCheck.cpp:235-241`).
+    LocallyInfeasible,
+}
+
+/// Pure core of upstream's layer-2 four-way verdict
+/// (`IpRestoConvCheck.cpp:200-240`), evaluated once the restoration
+/// sub-problem's own convergence check has reported
+/// `CONVERGED` / `CONVERGED_TO_ACCEPTABLE_POINT`.
+///
+/// * `orig_trial_inf_pr` — original-NLP constraint violation at the
+///   converged restoration iterate, in **unscaled** (user) units,
+///   because every threshold below is an absolute user-facing magnitude.
+/// * `tol` — the *restoration sub-problem's* current tolerance, which
+///   [`RestoOrigVerdict::TightenAndContinue`] shrinks.
+/// * `orig_tol` — the original NLP's `tol`, the floor the tightening arm
+///   is bounded against.
+/// * `orig_constr_viol_tol` — the original NLP's `constr_viol_tol`,
+///   consulted only on the square-problem arm.
+///
+/// The tightening arm terminates by construction: it fires only while
+/// `tol > 1e-1 · orig_tol` and shrinks `tol` by `1e-2` each time, so from
+/// `tol == orig_tol` it fires exactly once (`1e-2 · orig_tol` is no
+/// longer `> 1e-1 · orig_tol`). Without that guard the arm is an infinite
+/// loop, which is why it is part of the port rather than an optimisation.
+pub fn resto_orig_verdict(
+    orig_trial_inf_pr: f64,
+    tol: f64,
+    orig_tol: f64,
+    orig_constr_viol_tol: f64,
+    is_square_problem: bool,
+) -> RestoOrigVerdict {
+    // `IpRestoConvCheck.cpp:212` — nearly feasible for the orig NLP, and
+    // there is tolerance budget left to spend chasing the rest.
+    if orig_trial_inf_pr <= 1e2 * tol && tol > 1e-1 * orig_tol {
+        return RestoOrigVerdict::TightenAndContinue;
+    }
+    // `IpRestoConvCheck.cpp:222` — a square problem has nothing to
+    // optimise, so any point feasible to `constr_viol_tol` is the answer.
+    if is_square_problem && orig_trial_inf_pr <= orig_constr_viol_tol {
+        return RestoOrigVerdict::ConvergedToAcceptable;
+    }
+    // `IpRestoConvCheck.cpp:227`.
+    if orig_trial_inf_pr <= 1e2 * tol {
+        return RestoOrigVerdict::ConvergedToFeasiblePoint;
+    }
+    // `IpRestoConvCheck.cpp:240`.
+    RestoOrigVerdict::LocallyInfeasible
+}
+
+/// Scalar core of `IpRestoConvCheck::CheckConvergence` (lines 132-240).
 /// The full upstream implementation needs the restoration NLP and the
 /// outer filter; this struct holds only the per-call mutable state and
 /// exposes a pure `check_convergence` taking the relevant scalars and a
@@ -29,6 +115,10 @@ pub struct RestoConvCheck {
     /// `constr_viol_tol` from the restoration sub-options; used in the
     /// square-problem fast path.
     pub orig_constr_viol_tol: f64,
+    /// The restoration sub-problem's own tolerance (`IpData().tol()` of
+    /// the resto algorithm). Layer 2's tightening arm shrinks it; see
+    /// [`resto_orig_verdict`].
+    pub tol: f64,
     first_resto_iter: bool,
     successive_resto_iter: i32,
 }
@@ -41,6 +131,7 @@ impl Default for RestoConvCheck {
             maximum_iters: 3000,
             maximum_resto_iters: 3000,
             orig_constr_viol_tol: 1e-4,
+            tol: 1e-8,
             first_resto_iter: true,
             successive_resto_iter: 0,
         }
@@ -59,7 +150,8 @@ impl RestoConvCheck {
         self.successive_resto_iter = 0;
     }
 
-    /// Port of `IpRestoConvCheck.cpp:132-220` excluding the bits that
+    /// Port of `IpRestoConvCheck.cpp:132-240` (both layers) excluding the
+    /// bits that
     /// require the live `IpoptData` / outer filter — those are passed
     /// in as scalars and a closure.
     ///
@@ -72,6 +164,12 @@ impl RestoConvCheck {
     /// * `orig_tol`             — the outer `tol` option.
     /// * `acceptable_to_outer`  — closure returning whether the restoration trial
     ///   would be accepted by the outer filter / penalty acceptor.
+    /// * `sub_problem_converged` — closure returning whether the restoration
+    ///   *sub-problem* has converged in its own right, i.e. upstream's
+    ///   `OptimalityErrorConvergenceCheck::CheckConvergence(false)` at
+    ///   `IpRestoConvCheck.cpp:202`. This is the layer-2 query; without it a
+    ///   restoration that has provably done everything it can is
+    ///   indistinguishable from one still making progress (pounce#438).
     pub fn check_convergence(
         &mut self,
         iter_count: i32,
@@ -80,6 +178,7 @@ impl RestoConvCheck {
         orig_trial_inf_pr: f64,
         orig_tol: f64,
         acceptable_to_outer: impl FnOnce() -> bool,
+        sub_problem_converged: impl FnOnce() -> bool,
     ) -> RestoConvergenceStatus {
         // Outer iter cap (line 137).
         if iter_count > self.maximum_iters {
@@ -111,17 +210,49 @@ impl RestoConvCheck {
 
         // kappa_resto reduction guard (line 175). When kappa_resto == 0
         // upstream disables this guard entirely.
-        if self.kappa_resto > 0.0 && orig_trial_inf_pr > self.kappa_resto * orig_curr_inf_pr {
-            return RestoConvergenceStatus::Continue;
-        }
+        let reduction_sufficient =
+            self.kappa_resto <= 0.0 || orig_trial_inf_pr <= self.kappa_resto * orig_curr_inf_pr;
 
         // Reduction was sufficient — defer to the outer-phase filter /
         // penalty acceptor (line 198).
-        if acceptable_to_outer() {
-            RestoConvergenceStatus::Converged
-        } else {
-            RestoConvergenceStatus::Continue
+        if reduction_sufficient && acceptable_to_outer() {
+            return RestoConvergenceStatus::Converged;
         }
+
+        // ---- Layer 2 (lines 200-240). ---------------------------------
+        //
+        // Everything above answers "can the trial point leave
+        // restoration?" and, when the answer is no, upstream's `status`
+        // is still `CONTINUE`. Only then does it ask the second, entirely
+        // separate question: has the restoration *sub-problem* itself
+        // converged? A sub-problem at its own KKT point has provably done
+        // all it can, so "continue" is no longer an available answer —
+        // one of four verdicts is (pounce#438).
+        if sub_problem_converged() {
+            match resto_orig_verdict(
+                orig_trial_inf_pr,
+                self.tol,
+                orig_tol,
+                self.orig_constr_viol_tol,
+                is_square_problem,
+            ) {
+                RestoOrigVerdict::TightenAndContinue => {
+                    self.tol *= 1e-2;
+                    return RestoConvergenceStatus::Continue;
+                }
+                RestoOrigVerdict::ConvergedToAcceptable => {
+                    return RestoConvergenceStatus::ConvergedToAcceptable;
+                }
+                RestoOrigVerdict::ConvergedToFeasiblePoint => {
+                    return RestoConvergenceStatus::Converged;
+                }
+                RestoOrigVerdict::LocallyInfeasible => {
+                    return RestoConvergenceStatus::LocallyInfeasible;
+                }
+            }
+        }
+
+        RestoConvergenceStatus::Continue
     }
 }
 
@@ -188,19 +319,31 @@ pub struct RestoPenaltyConvCheck {
 /// nested IPM in [`crate::resto_inner_solver`] can swap out the
 /// regular-phase [`pounce_algorithm::conv_check::opt_error::OptErrorConvCheck`].
 ///
-/// v0.1 scope (Phase 9): implements the resto-side iteration-cap
-/// state machine (`maximum_iters` / `maximum_resto_iters` from
-/// `IpRestoConvCheck.cpp:RegisterOptions`) and delegates the
-/// stationarity convergence check to a wrapped `OptErrorConvCheck`
-/// against the inner resto-problem stationarity. The kappa-reduction
-/// guard (`orig_trial_inf_pr <= kappa_resto * orig_curr_inf_pr`) and
-/// the outer-filter acceptance test require the inner iterate's
-/// orig-NLP infeasibility, which the v0.1 trait surface
-/// `(nlp_err, iter_count) -> ConvergenceStatus` doesn't supply; those
-/// stay deferred to the outer line search's post-restoration recheck
-/// per the comment at `resto_inner_solver.rs:27-33`. Snapshots the
-/// outer scalars at construction (option (b) from the task design
-/// note) so that surface stays narrow.
+/// This is the live path — `run_inner_resto` installs it as the nested
+/// IPM's `conv_check` — and it carries both layers of
+/// `IpRestoConvCheck::CheckConvergence`:
+///
+/// * the resto-side iteration-cap state machine (`maximum_iters` /
+///   `maximum_resto_iters` from `IpRestoConvCheck.cpp:RegisterOptions`);
+/// * **layer 1**, *can the trial point leave restoration?* — the
+///   kappa-reduction guard (`orig_trial_inf_pr <= kappa_resto ·
+///   orig_curr_inf_pr`, wired by [`Self::with_orig_progress_guard`])
+///   followed by the outer filter / iterate acceptance test (wired by
+///   [`Self::with_orig_progress_callback`]);
+/// * the sub-problem's own stationarity check, delegated to a wrapped
+///   `OptErrorConvCheck`;
+/// * **layer 2**, *has the sub-problem provably done everything it can?*
+///   — the four-way verdict of [`resto_orig_verdict`], wired by
+///   [`Self::with_orig_convergence_verdict`] (pounce#438).
+///
+/// Only layer 2 can bound a restoration whose kappa target is out of
+/// reach: layer 1 answers `Continue` at every such iterate, forever, so
+/// without a verdict at sub-problem convergence the only remaining exits
+/// are the iteration caps — which report "the solve ran out of
+/// iterations" for what is really "restoration cannot succeed here".
+///
+/// Snapshots the outer scalars at construction (option (b) from the task
+/// design note) so the trait surface stays narrow.
 pub struct RestoConvCheckAdapter {
     inner: pounce_algorithm::conv_check::opt_error::OptErrorConvCheck,
     /// `IpRestoConvCheck.cpp:137` outer-iter cap.
@@ -237,6 +380,21 @@ pub struct RestoConvCheckAdapter {
     /// `RestoConvCheck`-base behavior — the filter-aware variant only
     /// fires when the outer phase's acceptor is `FilterLsAcceptor`).
     orig_progress_callback: Option<pounce_algorithm::restoration::OrigProgressCallback>,
+    /// The *original* NLP's `tol`. Layer 2's tightening arm is bounded
+    /// against it (`IpRestoConvCheck.cpp:213`'s
+    /// `IpData().tol() > 1e-1 * orig_ip_data->tol()`); the sub-problem's
+    /// own, tightenable tolerance lives on [`Self::inner`].
+    orig_tol: f64,
+    /// The original NLP's `constr_viol_tol`
+    /// (`IpRestoConvCheck::InitializeImpl` reads it with the *original*
+    /// prefix). Consulted only on layer 2's square-problem arm.
+    orig_constr_viol_tol: f64,
+    /// Whether the original NLP is square (`IpCq().IsSquareProblem()`).
+    is_square_problem: bool,
+    /// Times layer 2's tightening arm has fired this restoration entry.
+    /// Bounded by construction (see [`resto_orig_verdict`]); tracked for
+    /// the debug trace only.
+    resto_tol_tightenings: i32,
 }
 
 impl RestoConvCheckAdapter {
@@ -265,6 +423,14 @@ impl RestoConvCheckAdapter {
             orig_curr_inf_pr: f64::INFINITY,
             kappa_resto: 0.9,
             orig_progress_callback: None,
+            // Defaults keep layer 2 inert-but-consistent for callers that
+            // don't wire it: `orig_tol == tol` means the tightening arm
+            // fires exactly once, and a non-square problem takes the
+            // upstream arms unchanged.
+            orig_tol: tol,
+            orig_constr_viol_tol: 1e-4,
+            is_square_problem: false,
+            resto_tol_tightenings: 0,
         }
     }
 
@@ -321,6 +487,111 @@ impl RestoConvCheckAdapter {
         self.orig_curr_inf_pr = orig_curr_inf_pr;
         self.kappa_resto = kappa_resto;
         self
+    }
+
+    /// Wire the original-NLP scalars layer 2 needs
+    /// (`IpRestoConvCheck.cpp:200-240`, pounce#438): the original `tol`
+    /// that bounds the tolerance-tightening arm, the original
+    /// `constr_viol_tol` the square-problem arm compares against, and
+    /// whether the original NLP is square.
+    ///
+    /// Layer 2 additionally needs the orig NLP itself to evaluate the
+    /// recovered point's constraint violation, so it only becomes live
+    /// once [`Self::with_orig_progress_guard`] has been called too;
+    /// without it the adapter keeps its pre-#438 behaviour of reporting
+    /// whatever the sub-problem's own convergence check said.
+    pub fn with_orig_convergence_verdict(
+        mut self,
+        orig_tol: f64,
+        orig_constr_viol_tol: f64,
+        is_square_problem: bool,
+    ) -> Self {
+        self.orig_tol = orig_tol;
+        self.orig_constr_viol_tol = orig_constr_viol_tol;
+        self.is_square_problem = is_square_problem;
+        self
+    }
+
+    /// Layer 2 of `IpRestoConvCheck::CheckConvergence`
+    /// (`IpRestoConvCheck.cpp:200-240`), evaluated once the restoration
+    /// sub-problem's own convergence check has fired.
+    ///
+    /// Returns `Some(status)` when the verdict overrides what the
+    /// sub-problem reported, `None` when it does not (the caller then
+    /// keeps the sub-problem's own status).
+    fn orig_convergence_verdict(
+        &mut self,
+        data: &pounce_algorithm::ipopt_data::IpoptDataHandle,
+    ) -> Option<pounce_algorithm::conv_check::r#trait::ConvergenceStatus> {
+        use pounce_algorithm::conv_check::r#trait::ConvergenceStatus;
+
+        let orig_rc = self.orig_nlp.clone()?;
+        let m = eval_orig_trial_measures(data, &orig_rc)?;
+        let tol = self.inner.tol;
+        let verdict = resto_orig_verdict(
+            m.inf_pr_unscaled,
+            tol,
+            self.orig_tol,
+            self.orig_constr_viol_tol,
+            self.is_square_problem,
+        );
+
+        if std::env::var_os("POUNCE_DBG_RESTO_LAYER2").is_some() {
+            tracing::debug!(target: "pounce::restoration",
+                "[PN_RESTO_LAYER2] verdict={:?} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} tol={:.6e} orig_tol={:.6e} orig_constr_viol_tol={:.6e} square={} tightenings={}",
+                verdict,
+                m.inf_pr_unscaled,
+                m.inf_pr_scaled,
+                tol,
+                self.orig_tol,
+                self.orig_constr_viol_tol,
+                self.is_square_problem,
+                self.resto_tol_tightenings,
+            );
+        }
+
+        match verdict {
+            RestoOrigVerdict::TightenAndContinue => {
+                self.inner.tol = 1e-2 * tol;
+                self.resto_tol_tightenings += 1;
+                Some(ConvergenceStatus::Continue)
+            }
+            RestoOrigVerdict::ConvergedToAcceptable => {
+                Some(ConvergenceStatus::ConvergedToAcceptable)
+            }
+            // Upstream throws `RESTORATION_CONVERGED_TO_FEASIBLE_POINT`
+            // here, which surfaces at the outer level as a restoration
+            // *failure*. Pounce instead hands the recovered — and by this
+            // arm's own test, feasible — point back to the outer phase,
+            // which is what it already did before #438 and is strictly
+            // more useful than discarding it. Deliberate deviation, scoped
+            // so that #438 changes only the arm that was missing a verdict
+            // entirely.
+            RestoOrigVerdict::ConvergedToFeasiblePoint => None,
+            RestoOrigVerdict::LocallyInfeasible => {
+                // Square problems are exempt. `MinC_1NrmRestorationPhase`
+                // returns the recovered point to the outer unconditionally
+                // on a square problem (`IpRestoMinC_1Nrm.cpp:357-371`), and
+                // pounce found short-circuiting that path regresses
+                // PFIT3/PFIT4 — the outer needs the extra shots. Same
+                // carve-out the post-hoc `strict_locally_infeasible` gate
+                // in `resto_inner_solver` makes, for the same reason.
+                if self.is_square_problem {
+                    return None;
+                }
+                // Never claim infeasibility at a point the solver's own
+                // convergence test would call feasible. `inf_pr_unscaled`
+                // is measured in user units (correctly — the thresholds
+                // above are absolute user-facing magnitudes) while `tol`
+                // is applied in the scaled space, so on a model whose rows
+                // are scaled down the two disagree. Mirrors the guard
+                // `resto_inner_solver` applies to its post-hoc gates.
+                if m.inf_pr_scaled <= self.orig_tol {
+                    return None;
+                }
+                Some(ConvergenceStatus::LocallyInfeasible)
+            }
+        }
     }
 
     /// Construct from a base [`RestoConvCheck`] using the resto-side
@@ -407,8 +678,11 @@ impl pounce_algorithm::conv_check::r#trait::ConvCheck for RestoConvCheckAdapter 
         //    `first_resto_iter` freebie at line 152.
         if iter_count > 0 && self.kappa_resto > 0.0 {
             if let Some(orig_rc) = self.orig_nlp.clone() {
-                if let Some((orig_trial_inf_pr, orig_trial_f)) =
-                    eval_orig_inf_pr_and_f(data, &orig_rc)
+                if let Some(OrigTrialMeasures {
+                    inf_pr_scaled: orig_trial_inf_pr,
+                    f: orig_trial_f,
+                    ..
+                }) = eval_orig_trial_measures(data, &orig_rc)
                 {
                     if std::env::var_os("POUNCE_DBG_RESTO_KAPPA").is_some() {
                         tracing::debug!(target: "pounce::restoration",
@@ -439,17 +713,59 @@ impl pounce_algorithm::conv_check::r#trait::ConvCheck for RestoConvCheckAdapter 
             }
         }
 
-        // 3. Inner-stationarity fallback (resto NLP's own KKT residual).
-        self.inner.check_convergence(nlp_err, iter_count)
+        // 3. Inner-stationarity check (resto NLP's own KKT residual) —
+        //    upstream's `OptimalityErrorConvergenceCheck::CheckConvergence`
+        //    call at `IpRestoConvCheck.cpp:202`.
+        let inner_status = self.inner.check_convergence(nlp_err, iter_count);
+
+        // 4. Layer 2 (`IpRestoConvCheck.cpp:200-240`, pounce#438). Steps
+        //    1-3 above only ever answer "can the trial point leave
+        //    restoration?"; when the sub-problem has converged in its own
+        //    right, that question is no longer the operative one. A
+        //    restoration whose sub-NLP is at its KKT point has provably
+        //    done everything it can, so it must render a verdict instead
+        //    of reporting the sub-problem's status and letting the outer
+        //    re-enter — or, when the kappa target is out of reach,
+        //    grinding to an iteration cap that reports the wrong status.
+        if !matches!(
+            inner_status,
+            ConvergenceStatus::Converged | ConvergenceStatus::ConvergedToAcceptable
+        ) {
+            return inner_status;
+        }
+        // `None` means the verdict declines to override — the caller then
+        // keeps whatever the sub-problem's own check said.
+        self.orig_convergence_verdict(data).unwrap_or(inner_status)
     }
 }
 
-/// Evaluate the orig-NLP `(inf_pr, f)` pair at the inner iterate's
+/// Original-NLP measurements at the restoration sub-solve's current
+/// iterate, in both unit systems.
+struct OrigTrialMeasures {
+    /// `max(||c(x_orig)||∞, ||d(x_orig) − s||∞)` in the solver's internal
+    /// (row-scaled) space. This is the units the kappa-reduction guard
+    /// wants, because it compares against `orig_curr_inf_pr` — itself a
+    /// scaled quantity from `IpoptCalculatedQuantities` — and because a
+    /// ratio test cancels the scaling anyway.
+    inf_pr_scaled: f64,
+    /// The same quantity in unscaled (user) units. This is the units
+    /// layer 2 wants: its thresholds (`1e2 · tol`, `constr_viol_tol`) are
+    /// absolute user-facing magnitudes, so comparing them against a
+    /// row-scaled residual mixes two unit systems — the same mismatch
+    /// documented at `resto_inner_solver::eval_orig_inf_pr_at_inner_curr`.
+    inf_pr_unscaled: f64,
+    /// Unscaled `f(x_orig)`.
+    f: f64,
+}
+
+/// Evaluate the orig-NLP measurements at the inner iterate's
 /// `(x_orig, s)` slice:
 ///
-/// * `inf_pr = max(||c(x_orig)||∞, ||d(x_orig) − s||∞)` — used by both
-///   the kappa-reduction guard and as the orig-trial-theta passed to
-///   the outer-progress callback.
+/// * `inf_pr = max(||c(x_orig)||∞, ||d(x_orig) − s||∞)` — used by the
+///   kappa-reduction guard, by layer 2's verdict, and as the
+///   orig-trial-theta passed to the outer-progress callback. Returned in
+///   both the scaled and unscaled unit systems; see [`OrigTrialMeasures`]
+///   for which consumer wants which.
 /// * `f = unscaled f(x_orig)` — used as the orig-trial-barr proxy for
 ///   the outer-progress callback. v0.1 simplification: the upstream
 ///   `TestOrigProgress` consults `trial_barrier_obj()`, which folds in
@@ -463,10 +779,11 @@ impl pounce_algorithm::conv_check::r#trait::ConvCheck for RestoConvCheckAdapter 
 ///
 /// Returns `None` on any downcast / dim failure (caller falls back to
 /// the scalar inner-stationarity path).
-fn eval_orig_inf_pr_and_f(
+fn eval_orig_trial_measures(
     data: &pounce_algorithm::ipopt_data::IpoptDataHandle,
     orig_rc: &std::rc::Rc<std::cell::RefCell<dyn pounce_nlp::ipopt_nlp::IpoptNlp>>,
-) -> Option<(f64, f64)> {
+) -> Option<OrigTrialMeasures> {
+    use pounce_algorithm::ipopt_cq::unscaled_block_amax;
     use pounce_linalg::dense_vector::DenseVectorSpace;
     use pounce_linalg::{CompoundVector, Vector};
 
@@ -478,27 +795,33 @@ fn eval_orig_inf_pr_and_f(
     let mut orig = orig_rc.borrow_mut();
     let m_eq = orig.m_eq();
     let m_ineq = orig.m_ineq();
+    let (dc, dd) = (orig.c_scale_vec(), orig.d_scale_vec());
 
+    // Each pair is `(unscaled, scaled)`.
     let c_amax = if m_eq > 0 {
         let mut c_buf = DenseVectorSpace::new(m_eq).make_new_dense();
         orig.eval_c(x_orig, &mut c_buf);
-        c_buf.amax()
+        (unscaled_block_amax(&c_buf, dc.as_deref()), c_buf.amax())
     } else {
-        0.0
+        (0.0, 0.0)
     };
 
     let d_minus_s_amax = if m_ineq > 0 {
         let mut d_buf = DenseVectorSpace::new(m_ineq).make_new_dense();
         orig.eval_d(x_orig, &mut d_buf);
         d_buf.axpy(-1.0, s_inner);
-        d_buf.amax()
+        (unscaled_block_amax(&d_buf, dd.as_deref()), d_buf.amax())
     } else {
-        0.0
+        (0.0, 0.0)
     };
 
     let f = orig.eval_f(x_orig);
 
-    Some((c_amax.max(d_minus_s_amax), f))
+    Some(OrigTrialMeasures {
+        inf_pr_scaled: c_amax.1.max(d_minus_s_amax.1),
+        inf_pr_unscaled: c_amax.0.max(d_minus_s_amax.0),
+        f,
+    })
 }
 
 impl RestoPenaltyConvCheck {
@@ -521,7 +844,7 @@ mod tests {
     #[test]
     fn first_iteration_always_continues() {
         let mut cc = RestoConvCheck::new();
-        let s = cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true);
+        let s = cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -529,7 +852,7 @@ mod tests {
     fn outer_iter_cap_triggers_max() {
         let mut cc = RestoConvCheck::new();
         cc.maximum_iters = 5;
-        let s = cc.check_convergence(6, false, 1.0, 0.5, 1e-8, || true);
+        let s = cc.check_convergence(6, false, 1.0, 0.5, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::MaxIterExceeded);
     }
 
@@ -538,10 +861,10 @@ mod tests {
         let mut cc = RestoConvCheck::new();
         cc.maximum_resto_iters = 2;
         // Burn through 3 calls — fourth should hit the cap.
-        cc.check_convergence(0, false, 1.0, 0.9, 1e-8, || false);
-        cc.check_convergence(1, false, 1.0, 0.8, 1e-8, || false);
-        cc.check_convergence(2, false, 1.0, 0.7, 1e-8, || false);
-        let s = cc.check_convergence(3, false, 1.0, 0.6, 1e-8, || false);
+        cc.check_convergence(0, false, 1.0, 0.9, 1e-8, || false, || false);
+        cc.check_convergence(1, false, 1.0, 0.8, 1e-8, || false, || false);
+        cc.check_convergence(2, false, 1.0, 0.7, 1e-8, || false, || false);
+        let s = cc.check_convergence(3, false, 1.0, 0.6, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::MaxIterExceeded);
     }
 
@@ -550,9 +873,9 @@ mod tests {
         let mut cc = RestoConvCheck::new();
         cc.orig_constr_viol_tol = 1e-4;
         // Burn the first-iter freebie.
-        cc.check_convergence(0, true, 1.0, 0.5, 1e-8, || false);
+        cc.check_convergence(0, true, 1.0, 0.5, 1e-8, || false, || false);
         // Now feed a feasible trial.
-        let s = cc.check_convergence(1, true, 0.5, 1e-10, 1e-8, || false);
+        let s = cc.check_convergence(1, true, 0.5, 1e-10, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
@@ -560,9 +883,9 @@ mod tests {
     fn insufficient_reduction_keeps_going() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.95, 1e-8, || true);
+        cc.check_convergence(0, false, 1.0, 0.95, 1e-8, || true, || false);
         // trial_inf_pr (0.95) > 0.9 * curr_inf_pr (1.0) — not enough.
-        let s = cc.check_convergence(1, false, 1.0, 0.95, 1e-8, || true);
+        let s = cc.check_convergence(1, false, 1.0, 0.95, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -570,8 +893,8 @@ mod tests {
     fn sufficient_reduction_plus_filter_accept_converges() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true);
-        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true);
+        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || false);
+        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
@@ -579,8 +902,8 @@ mod tests {
     fn sufficient_reduction_but_filter_rejects_continues() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.9;
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || false);
-        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || false);
+        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || false, || false);
+        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || false, || false);
         assert_eq!(s, RestoConvergenceStatus::Continue);
     }
 
@@ -588,21 +911,135 @@ mod tests {
     fn kappa_zero_disables_reduction_guard() {
         let mut cc = RestoConvCheck::new();
         cc.kappa_resto = 0.0;
-        cc.check_convergence(0, false, 1.0, 1.5, 1e-8, || true);
+        cc.check_convergence(0, false, 1.0, 1.5, 1e-8, || true, || false);
         // Even with trial > curr, the guard is bypassed and we go to
         // the outer-filter check, which accepts.
-        let s = cc.check_convergence(1, false, 1.0, 1.5, 1e-8, || true);
+        let s = cc.check_convergence(1, false, 1.0, 1.5, 1e-8, || true, || false);
         assert_eq!(s, RestoConvergenceStatus::Converged);
     }
 
     #[test]
     fn reset_clears_state() {
         let mut cc = RestoConvCheck::new();
-        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true);
-        cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true);
+        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || false);
+        cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true, || false);
         cc.reset();
         assert!(cc.first_resto_iter);
         assert_eq!(cc.successive_resto_iter, 0);
+    }
+
+    // ---- Layer 2 (`IpRestoConvCheck.cpp:200-240`, pounce#438) ---------
+
+    /// The tightening arm fires while there is tolerance budget left, and
+    /// stops on its own — the guard `tol > 1e-1 · orig_tol` is the only
+    /// thing that makes it terminate, so it is the property worth pinning.
+    #[test]
+    fn layer2_tightening_arm_is_bounded_by_construction() {
+        let orig_tol = 1e-8;
+        let mut tol = orig_tol;
+        let mut fired = 0;
+        // Near-feasible for the orig NLP: `inf_pr` well inside `1e2 · tol`
+        // at every tolerance the loop can reach.
+        let inf_pr = 1e-12;
+        while resto_orig_verdict(inf_pr, tol, orig_tol, 1e-4, false)
+            == RestoOrigVerdict::TightenAndContinue
+        {
+            tol *= 1e-2;
+            fired += 1;
+            assert!(fired < 10, "tightening arm failed to terminate");
+        }
+        assert_eq!(fired, 1, "one round from tol == orig_tol");
+        assert_eq!(tol, 1e-2 * orig_tol);
+    }
+
+    #[test]
+    fn layer2_square_problem_feasible_within_constr_viol_tol_is_acceptable() {
+        // Square, violation under `constr_viol_tol` but above `1e2 · tol`
+        // so the tightening arm cannot claim it first.
+        let v = resto_orig_verdict(1e-5, 1e-10, 1e-8, 1e-4, true);
+        assert_eq!(v, RestoOrigVerdict::ConvergedToAcceptable);
+        // The same numbers on a non-square problem are a local infeasibility.
+        let v = resto_orig_verdict(1e-5, 1e-10, 1e-8, 1e-4, false);
+        assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
+    }
+
+    #[test]
+    fn layer2_feasible_point_when_tolerance_budget_is_spent() {
+        // `tol` already tightened past the guard, so the tightening arm is
+        // closed; the violation is still inside `1e2 · tol`.
+        let v = resto_orig_verdict(1e-11, 1e-10, 1e-8, 1e-4, false);
+        assert_eq!(v, RestoOrigVerdict::ConvergedToFeasiblePoint);
+    }
+
+    /// The #438 case: the sub-problem has converged at a point whose
+    /// original-NLP violation is orders of magnitude above anything the
+    /// tolerances would accept. Before layer 2 this returned no verdict at
+    /// all and restoration ran to an iteration cap.
+    #[test]
+    fn layer2_locally_infeasible_when_violation_is_bounded_away_from_zero() {
+        // qcqp1000-1nc's numbers: orig violation pinned at ~5e-3 with the
+        // sub-problem at its own KKT point, default tolerances.
+        let v = resto_orig_verdict(5.05e-3, 1e-8, 1e-8, 1e-4, false);
+        assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
+        // Square problems reach the same verdict once the violation clears
+        // `constr_viol_tol`; the caller applies pounce's square carve-out.
+        let v = resto_orig_verdict(5.05e-3, 1e-8, 1e-8, 1e-4, true);
+        assert_eq!(v, RestoOrigVerdict::LocallyInfeasible);
+    }
+
+    /// Layer 2 runs when layer 1 says `Continue`, which includes the case
+    /// the issue is about: a `kappa_resto` target the restoration can never
+    /// reach. An insufficient reduction must no longer swallow the verdict.
+    #[test]
+    fn insufficient_reduction_still_renders_a_layer2_verdict() {
+        let mut cc = RestoConvCheck::new();
+        cc.kappa_resto = 0.9;
+        cc.tol = 1e-8;
+        // Burn the first-iter freebie.
+        cc.check_convergence(0, false, 5.96e-8, 5.05e-3, 1e-8, || false, || false);
+        // Reduction is five orders out of reach, so layer 1 is `Continue`
+        // forever — but the sub-problem has converged.
+        let s = cc.check_convergence(1, false, 5.96e-8, 5.05e-3, 1e-8, || false, || true);
+        assert_eq!(s, RestoConvergenceStatus::LocallyInfeasible);
+    }
+
+    /// ... and while the sub-problem has *not* converged, the answer is
+    /// still `Continue` — layer 2 must not fire on a restoration that is
+    /// simply still working.
+    #[test]
+    fn unconverged_sub_problem_still_continues() {
+        let mut cc = RestoConvCheck::new();
+        cc.kappa_resto = 0.9;
+        cc.check_convergence(0, false, 5.96e-8, 5.05e-3, 1e-8, || false, || false);
+        let s = cc.check_convergence(1, false, 5.96e-8, 5.05e-3, 1e-8, || false, || false);
+        assert_eq!(s, RestoConvergenceStatus::Continue);
+    }
+
+    /// Layer 1 keeps precedence: when the trial point can leave
+    /// restoration, that is the answer regardless of the sub-problem's own
+    /// state.
+    #[test]
+    fn layer1_acceptance_outranks_layer2() {
+        let mut cc = RestoConvCheck::new();
+        cc.kappa_resto = 0.9;
+        cc.check_convergence(0, false, 1.0, 0.5, 1e-8, || true, || true);
+        let s = cc.check_convergence(1, false, 1.0, 0.5, 1e-8, || true, || true);
+        assert_eq!(s, RestoConvergenceStatus::Converged);
+    }
+
+    #[test]
+    fn layer2_tightening_arm_shrinks_the_sub_problem_tolerance() {
+        let mut cc = RestoConvCheck::new();
+        cc.kappa_resto = 0.9;
+        cc.tol = 1e-8;
+        cc.check_convergence(0, false, 1.0, 1e-12, 1e-8, || false, || true);
+        let s = cc.check_convergence(1, false, 1.0, 1e-12, 1e-8, || false, || true);
+        assert_eq!(s, RestoConvergenceStatus::Continue);
+        assert_eq!(cc.tol, 1e-10);
+        // Second visit: budget spent, so the verdict is now terminal.
+        let s = cc.check_convergence(2, false, 1.0, 1e-12, 1e-8, || false, || true);
+        assert_eq!(s, RestoConvergenceStatus::Converged);
+        assert_eq!(cc.tol, 1e-10, "no further tightening");
     }
 
     #[test]
@@ -684,6 +1121,44 @@ mod tests {
         let a =
             RestoConvCheckAdapter::new(1e-8, 1e-6, 15, 3000, 3000).with_orig_progress_callback(cb);
         assert!(a.orig_progress_callback.is_some());
+    }
+
+    /// Layer 2 is inert until the orig NLP is wired, because the verdict
+    /// cannot be rendered without evaluating the recovered point. An
+    /// adapter carrying only the scalars must keep reporting whatever the
+    /// sub-problem's own check said.
+    #[test]
+    fn layer2_is_inert_without_the_orig_nlp() {
+        use pounce_algorithm::conv_check::r#trait::{ConvCheck, ConvergenceStatus};
+        let mut a = RestoConvCheckAdapter::new(1e-8, 1e-6, 15, 3000, 3000)
+            .with_orig_convergence_verdict(1e-8, 1e-4, false);
+        assert!(a.orig_nlp.is_none());
+        assert_eq!(a.check_convergence(1e-12, 0), ConvergenceStatus::Converged);
+    }
+
+    #[test]
+    fn with_orig_convergence_verdict_records_the_orig_scalars() {
+        // The wired-in verdict needs a live `(data, cq)` pair and an orig
+        // NLP; the four arms themselves are covered by the
+        // `resto_orig_verdict` tests above, and the end-to-end path by the
+        // `restoration_triggers` integration test.
+        let a = RestoConvCheckAdapter::new(1e-8, 1e-6, 15, 3000, 3000)
+            .with_orig_convergence_verdict(1e-7, 1e-3, true);
+        assert_eq!(a.orig_tol, 1e-7);
+        assert_eq!(a.orig_constr_viol_tol, 1e-3);
+        assert!(a.is_square_problem);
+        assert_eq!(a.resto_tol_tightenings, 0);
+    }
+
+    /// `new` must leave the verdict's scalars self-consistent for callers
+    /// that never wire them: `orig_tol == tol` is what makes the tightening
+    /// arm's bound meaningful rather than accidental.
+    #[test]
+    fn adapter_defaults_orig_tol_to_the_sub_problem_tol() {
+        let a = RestoConvCheckAdapter::new(1e-5, 1e-4, 15, 3000, 3000);
+        assert_eq!(a.orig_tol, 1e-5);
+        assert_eq!(a.inner_tol(), 1e-5);
+        assert!(!a.is_square_problem);
     }
 
     #[test]

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -340,8 +340,18 @@ pub fn run_inner_resto(
     // (carried on the inner builder's conv_check options) into the resto
     // sub-solve instead of hardcoded `(1e-8, 1e-6, 15)`. See
     // `build_resto_conv_check_adapter`.
+    let outer_tol = outer_data.borrow().tol;
     let mut adapter = build_resto_conv_check_adapter(&inner_alg_builder.conv_check)
-        .with_orig_progress_guard(Rc::clone(outer_nlp), orig_curr_inf_pr, kappa_resto);
+        .with_orig_progress_guard(Rc::clone(outer_nlp), orig_curr_inf_pr, kappa_resto)
+        // Layer 2 of `IpRestoConvCheck::CheckConvergence` (pounce#438).
+        // `constr_viol_tol` is read with the *original* prefix upstream
+        // (`IpRestoConvCheck::InitializeImpl`), which is exactly what the
+        // inner builder's conv-check options carry here.
+        .with_orig_convergence_verdict(
+            outer_tol,
+            inner_alg_builder.conv_check.constr_viol_tol,
+            is_square_problem,
+        );
     if let Some(cb) = orig_progress_cb {
         adapter = adapter.with_orig_progress_callback(cb);
     }
@@ -546,7 +556,6 @@ pub fn run_inner_resto(
     // `tol`). Without this gate, we'd misclassify any kappa-guard
     // exit at exactly the entry `inf_pr` as locally-infeasible
     // (HATFLDF, POLAK6, ROSENMMX, ... regress).
-    let outer_tol = outer_data.borrow().tol;
     let (orig_inf_pr_at_final, orig_inf_pr_scaled) =
         eval_orig_inf_pr_at_inner_curr(&*final_iv.x, &*final_iv.s, outer_nlp).unwrap_or((0.0, 0.0));
     // Row magnitude implied by the two measures of the same violation:
@@ -687,6 +696,22 @@ pub fn run_inner_resto(
         && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
         && orig_inf_pr_at_final.is_finite();
 
+    // Layer-2 verdict, rendered from *inside* the sub-solve (pounce#438).
+    // The inner convergence check asked, at the moment the restoration
+    // sub-problem reached its own KKT point, whether the recovered point is
+    // feasible for the ORIGINAL NLP, and answered no — upstream's
+    // `LOCALLY_INFEASIBLE` throw at `IpRestoConvCheck.cpp:240`, which
+    // `IpoptAlgorithm` turns into `LOCAL_INFEASIBILITY`.
+    //
+    // Unlike every gate above, this one needs no signature heuristics: the
+    // verdict was issued at a point the sub-solve itself certified, against
+    // the sub-solve's own (possibly tightened) tolerance, rather than
+    // reconstructed after the fact from a terminal status and a KKT residual.
+    // The gates above remain because they cover the exits where the inner
+    // never gets to render a verdict at all — line-search failure, step
+    // explosion, tiny step, iteration cap.
+    let verdict_locally_infeasible = matches!(status, SolverReturn::LocalInfeasibility);
+
     // Admissibility guard over ALL of the gates above, in one place.
     //
     // Never claim infeasibility at a point the solver's own convergence test
@@ -716,7 +741,8 @@ pub fn run_inner_resto(
     // twin, and a hole survived both times.
     let solver_would_call_it_feasible = orig_inf_pr_scaled <= outer_tol;
     let locally_infeasible = !solver_would_call_it_feasible
-        && (strict_locally_infeasible
+        && (verdict_locally_infeasible
+            || strict_locally_infeasible
             || alt_locally_infeasible
             || cycle_locally_infeasible
             || step_failure_locally_infeasible
@@ -724,13 +750,14 @@ pub fn run_inner_resto(
 
     if std::env::var_os("POUNCE_DBG_RESTO_LOCINF").is_some() {
         tracing::debug!(target: "pounce::restoration",
-            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} outer_tol={:.6e} strict={} alt={} cycle={} step_fail={} tiny_step={} → loc_inf={}",
+            "[PN_RESTO_LOCINF] status={:?} iter={} inner_kkt_err={:.6e} orig_inf_pr={:.6e} orig_inf_pr_scaled={:.6e} outer_tol={:.6e} verdict={} strict={} alt={} cycle={} step_fail={} tiny_step={} → loc_inf={}",
             status,
             inner_iter_count,
             inner_kkt_err,
             orig_inf_pr_at_final,
             orig_inf_pr_scaled,
             outer_tol,
+            verdict_locally_infeasible,
             strict_locally_infeasible,
             alt_locally_infeasible,
             cycle_locally_infeasible,


### PR DESCRIPTION
Fixes #438

## Problem

A restoration whose sub-problem has converged — the moment it has provably done everything it can — was indistinguishable from one still making progress. It reported the sub-problem's own status and let the outer re-enter, or, when the κ_resto target was out of reach, ground on until an iteration cap converted "restoration cannot succeed" into "the solve ran out of iterations".

`issue_372_infeasible_bounds.nl` (`0 <= x <= 0.6` with `x >= 0.7`) is the smallest instance of the shape available in-tree. Its user-facing status was already right, but only because a post-hoc heuristic reconstructed it:

| | status | route to the status | outer iters |
|---|---|---|---|
| before | local infeasibility | `tiny_step_locally_infeasible` heuristic in `resto_inner_solver` (inner exits `StopAtTinyStep`, gate infers the diagnosis from the terminal status + KKT residual) | 56 |
| after | local infeasibility | layer-2 verdict at inner iteration 10, on a point the sub-solve itself certified | 56 |

No oracle comparison: I have no Ipopt binary here, and the instance from the issue (`qcqp1000-1nc`) needs an AMPL CE licence to translate, so I could not run it — see **Tests** for what that leaves unpinned.

## Cause

`IpRestoConvCheck::CheckConvergence` is two layers. Layer 1 — the κ_resto reduction guard, the square-problem fast path, and the outer-filter acceptance test — answers *can the trial point leave restoration?*. Layer 2 (`IpRestoConvCheck.cpp:200-240`) asks whether the restoration *sub-problem* has converged in its own right and, when it has, renders one of four verdicts.

Pounce ported layer 1 faithfully and omitted layer 2. In the live path (`RestoConvCheckAdapter::check_convergence_with_state`, the adapter `run_inner_resto` installs as the nested IPM's `conv_check`) step 3 delegated to the sub-problem's own `OptErrorConvCheck` and returned whatever it said. Nothing ever asked the layer-2 question.

That matters most exactly when layer 1 can never succeed. The outer enters restoration at a nearly-feasible point, so the κ target is a fraction of an already-tiny infeasibility; restoration moves the iterate away; the reduction test then fails at every subsequent iteration unconditionally. The remaining exits are the `maximum_iters` / `max_resto_iter` caps — the wrong status, after orders of magnitude more work than the diagnosis needed. Layer 2 *is* the bound.

## Fix

The four arms are factored into a pure `resto_orig_verdict` (`conv_check.rs:80`) so each is unit-testable without a live NLP, and rendered inside the restoration sub-solve — in `RestoConvCheckAdapter` (the live path) and in the scalar `RestoConvCheck` the port is documented against. `run_inner_resto` treats an inner `LocalInfeasibility` as an authoritative verdict.

The existing post-hoc gates (`strict`/`alt`/`cycle`/`step_failure`/`tiny_step`) stay. They cover the exits where the inner never gets to render a verdict at all — line-search failure, step explosion, tiny step, iteration cap — and layer 2 does not subsume them.

The tightening arm keeps upstream's `tol > 1e-1 · orig_tol` guard. Without it the arm is an infinite loop rather than the at-most-one-round step it is meant to be; `layer2_tightening_arm_is_bounded_by_construction` pins that as a property rather than as a fixed count.

The violation the arms compare against is measured **unscaled**, because their thresholds (`1e2 · tol`, `constr_viol_tol`) are absolute user-facing magnitudes. The κ guard keeps its scaled measurement, where the ratio cancels the scaling anyway. This is the same units trap documented at `eval_orig_inf_pr_at_inner_curr`, and the locally-infeasible arm carries the same guard `resto_inner_solver` applies to its gates: never claim infeasibility at a point the solver's own convergence test would call feasible.

Two deliberate deviations, both scoped so this changes only the arm that had no verdict at all:

* **converged-to-a-feasible-point.** Upstream throws `RESTORATION_CONVERGED_TO_FEASIBLE_POINT`, which surfaces as a restoration failure. Pounce hands the recovered — and by that arm's own test, feasible — point back to the outer phase. That is what it already did, and discarding a feasible point to report a failure is strictly worse.
* **square problems are exempt from the locally-infeasible arm.** `MinC_1NrmRestorationPhase` returns the recovered point unconditionally on a square problem (`IpRestoMinC_1Nrm.cpp:357-371`), and short-circuiting that regresses PFIT3/PFIT4 — the same carve-out `strict_locally_infeasible` already makes, for the same reason.

Not attempted: a bounded-restoration iteration budget. The issue rules it out and I agree — it answers "how long have we spent" when the question is "can this still succeed", it is not scale-free, and its constant would end up tuned to whichever instance prompted it.

`POUNCE_DBG_RESTO_LAYER2=1` with `RUST_LOG=pounce::restoration=debug` traces the verdict, alongside the existing `POUNCE_DBG_RESTO_KAPPA` / `POUNCE_DBG_RESTO_LOCINF`.

## Blast radius

Measured over the 12 CLI `.nl` fixtures that reach the solver, against parent `c35edca`. Bit-identical on 11 of 12 — status and outer iteration count both. The one difference:

| fixture | before | after | note |
|---|---|---|---|
| `deb7` | 180 iters, `Error in step computation` | 189 iters, `Error in step computation` | tightening arm fires once (tol 1e-8 → 1e-10) then terminates; same pre-existing status |

`deb7` is the only fixture that exercises the tightening arm, and it is the arm's expected cost: layer 1 refused, the orig NLP was near-feasible (`inf_pr = 8.0e-13`), so upstream spends one round chasing a 100× tighter sub-problem tolerance before declaring the point feasible.

Not a corpus sweep — the Mittelmann harness needs an AMPL CE licence to translate `.mod` → `.nl` and the instances are gitignored, so I could not run one. Full workspace suite (171 test binaries), `cargo fmt --all -- --check`, and the CI clippy gate are all clean.

## Tests

`crates/pounce-cli/tests/issue_438_resto_layer2_verdict.rs` — three end-to-end tests through the binary. Verified against parent `c35edca` (parent's `crates/pounce-restoration/src/` checked out under the new test file):

* `sub_problem_convergence_renders_a_locally_infeasible_verdict` — **fails on the parent**, for the stated reason: no verdict is rendered at all, so the trace is empty where it should read `LocallyInfeasible`. This is the one that pins the fix.
* `locally_infeasible_verdict_surfaces_as_the_infeasibility_status` — passes on the parent. It pins that the user-facing status did not move, not the fix.
* `no_verdict_while_the_sub_problem_is_still_making_progress` — passes on the parent (trivially, the trace does not exist there). It pins that layer 2 stays silent on a restoration that leaves via layer 1, which is the regression this could plausibly cause.

Unit tests in `pounce-restoration` cover the four arms individually, the tightening arm's boundedness, layer 1's precedence over layer 2, and that an unconverged sub-problem still yields `Continue`.

**Deliberately not pinned, and a real gap:** whether this bites on `qcqp1000-1nc`, the instance in the issue. Layer 2 fires only once the sub-problem's own convergence check reports convergence, and in that trace the sub-problem ran 2965 iterations without doing so. That is consistent with two readings — it converges late (layer 2 now catches it), or it never converges by pounce's `nlp_err` measure (layer 2 is correct but silent there, and the residual gap is in the sub-problem's own convergence check). I could not distinguish them without the instance. Worth a confirming run before closing #438.

---

- [x] Tests fail on the parent commit for the stated reason (one of the three; the other two are non-regression pins and say so above)
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — none applies; no user-facing option or status is added or changed
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now


---
_Generated by [Claude Code](https://claude.ai/code/session_01RcQrUMw3gs5D3fDS6UoK31)_