### PR TITLE
Read "zero" numerically in the scale-relative feasibility measure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — feasible convex QPs reported locally infeasible on the NLP path
+
+- With `solver_selection=nlp`, POUNCE reported `Converged to a point of
+  local infeasibility` on 15 Maros-Mészáros convex QPs that are feasible
+  and that POUNCE's own `qp-ipm` path solves to optimality (#446). A
+  confident wrong answer, not a failure: Pyomo maps
+  `Infeasible_Problem_Detected` into the infeasible family, so a caller
+  reads it as a modelling error. QSCSD1 is the clearest case — the verdict
+  was rendered at a converged KKT point whose constraint violation was
+  `9.2e-15` and dual infeasibility `2.8e-14`, with an objective agreeing
+  with the `qp-ipm` optimum to six figures.
+- One cause for all 15, in the scale-relative feasibility measure added by
+  #385 and extended to equality rows by #390. It divides a row's violation
+  by that row's *declared* magnitude — the pre-fold RHS, or the declared
+  bounds — and abstained only when that magnitude was **exactly** zero.
+  Every one of the 15 carries rows whose declared magnitude is `1e-17` to
+  `1e-16`: rounding residue from the netlib→`.nl` conversion, `2^-53`
+  written where the model says `0`. The row's residual cannot be driven
+  below its own floating-point noise floor either, so the ratio was noise
+  over noise. QSCSD1 read 81× violated, which vetoed its success
+  certificate at iteration 15, kept the solver grinding to iteration 77
+  past a solution it already had, and then armed the rapid-infeasibility
+  pre-filter that issued the verdict.
+- "Zero" is now read numerically. A row abstains once its declared
+  magnitude sinks under its own noise floor, `κ · eps · max_j |∂g_i/∂x_j| ·
+  ‖x‖_∞` — the size of the rounding error the row's own arithmetic carries,
+  which is what makes a declared magnitude below it residue rather than
+  data. The comparison keeps the scale invariance that is the whole point
+  of the measure: under a row scaling both the floor and the magnitude
+  carry `dc_i`, so the verdict is the same however the row is written. An
+  absolute cutoff on the magnitude would have thrown that away.
+- A row whose Jacobian is empty abstains outright. Every variable it
+  mentions has been fixed and substituted out, leaving a constant `0 = b`
+  that no iterate can move — a statement about the model, which presolve
+  certifies up front, rather than a residual to judge an iterate by.
+  QPILOTNO's row 150 reduces to `0 = −2.22e-16` this way and pinned the
+  relative measure at 100% for all 375 iterations.
+- Both blocks are fixed, not just the equality one: QPILOTNO also carries
+  43 inequality bounds at `1e-17`–`1e-15`, and one of them — a row sitting
+  at exactly `d(x) = 0` against a declared bound of `1.1e-16` — drove the
+  verdict from the inequality side.
+- Measured on the `qp_convex` head-to-head (`make benchmark-qp-convex`),
+  the NLP arm goes from **113/138 solved in 525.7 s to 137/138 in 504.4 s**
+  — more problems solved, in less total time. All 15 wrong
+  infeasibility verdicts are gone, and so are nine further failures with
+  the same origin — five `Search_Direction_Becomes_Too_Small` and four
+  `Solver_Error`, all cases of the veto pushing the solver past a solution
+  it had already reached until the step computation broke down. No problem
+  regressed, and the iteration counts of the newly-solved problems mostly
+  fall (QSCSD1 77→15, QSCSD8 121→20). The one remaining failure, BOYD2's
+  300 s CPU-limit timeout, is pre-existing and unrelated.
+- Masked in default use, because `solver_selection=auto` routes convex QPs
+  to `qp-ipm`. Anyone driving POUNCE as a general NLP solver on a convex QP
+  hit it.
+
 ### Fixed — restoration had no verdict when its sub-problem converged
 
 - `IpRestoConvCheck::CheckConvergence` is two layers, and pounce ported

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,12 +34,25 @@ changes.
   pre-filter that issued the verdict.
 - "Zero" is now read numerically. A row abstains once its declared
   magnitude sinks under its own noise floor, `κ · eps · max_j |∂g_i/∂x_j| ·
-  ‖x‖_∞` — the size of the rounding error the row's own arithmetic carries,
-  which is what makes a declared magnitude below it residue rather than
-  data. The comparison keeps the scale invariance that is the whole point
-  of the measure: under a row scaling both the floor and the magnitude
-  carry `dc_i`, so the verdict is the same however the row is written. An
+  ‖x‖_∞` — the finest residual the solver could drive that row to, which is
+  what makes a declared magnitude below it residue rather than data. The
+  comparison keeps the scale invariance that is the whole point of the
+  measure: under a row scaling both the floor and the magnitude carry
+  `dc_i`, so the verdict is the same however the row is written. An
   absolute cutoff on the magnitude would have thrown that away.
+- The floor models **how finely the solver can place `x`**, not how
+  accurately a row evaluates. A Newton step comes from a linear solve with
+  norm-wise backward error, so every component of `x` is positioned to
+  about `eps · ‖x‖_∞`: a variable at `1e-8` inside a vector of norm `2.7`
+  is still only resolved to `~6e-16`. The dependence on the *global*
+  `‖x‖_∞` is therefore deliberate — `x` is one vector solved for jointly.
+  The seemingly sharper per-row alternative, the exact term sum
+  `Σ_j |a_ij x_j|`, was implemented and measured: it models the row's
+  evaluation error, which is not what limits the residual, and it regressed
+  QETAMACR, QSCORPIO and QPILOTNO. QSCORPIO's row 93 parks its variables
+  near a zero bound at `~1e-8`, so the term sum drops its floor to `8.5e-22`
+  and `−5.6e-17` of rounding residue reads as real data again, at an iterate
+  resolved only to `~6e-16`. A unit test pins the `‖x‖_∞` dependence.
 - A row whose Jacobian is empty abstains outright. Every variable it
   mentions has been fixed and substituted out, leaving a constant `0 = b`
   that no iterate can move — a statement about the model, which presolve

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -29,6 +29,26 @@ use pounce_linalg::{Matrix, SymMatrix, Vector};
 use std::cell::RefCell;
 use std::rc::Rc;
 
+/// Safety factor on the per-row noise floor of
+/// [`IpoptCalculatedQuantities::row_noise_floor`]. The floor bounds the
+/// largest single term of a row by `max_j |a_ij| · ‖x‖_∞`; the row's actual
+/// rounding error accumulates over all of its nonzeros, so the bound is short
+/// by up to a factor of the row count. `64` covers a typical sparse row
+/// without reaching far enough to swallow a declared magnitude a model could
+/// have meant: at the `‖x‖_∞ ~ 1` of a well-posed problem the floor sits near
+/// `1.4e-14`, still nine orders under `constr_viol_tol`'s default. Rows it
+/// silences fall back on the absolute feasibility test, which is already
+/// scale-invariant on a row whose declared magnitude is numerically zero.
+///
+/// Measured, and not a knife edge: over gh #446's 15 problems plus the
+/// infeasibility-detection suites (`false_local_infeasibility`,
+/// `infeasible_status_tol_invariance`, `issue_390_nonlinear_equality_scale`),
+/// every value from `8` to `1024` gives the same verdicts. `1` is too small —
+/// QSCSD1's rows are wide enough that the missing nonzero-count factor still
+/// leaves its `2^-53` RHS above the bound — so `64` sits an order of magnitude
+/// inside the band from either edge.
+const ROW_NOISE_KAPPA: Number = 64.0;
+
 /// Calculated-quantities object. Holds shared handles on data and the
 /// NLP; per-quantity caches live in `RefCell`s here.
 pub struct IpoptCalculatedQuantities {
@@ -886,6 +906,23 @@ impl IpoptCalculatedQuantities {
     /// does not track the RHS at all (`declared_c_rhs` is `None` — e.g. the
     /// restoration NLP, whose `c` block is not the user's rows), the whole
     /// block abstains.
+    ///
+    /// "Homogeneous" is judged **numerically**, not by `b_i == 0` exactly: a
+    /// row abstains once `|b_i|` sinks under its own
+    /// [noise floor](`Self::row_noise_floor`). An exact-zero test is the
+    /// right idea measured with the wrong instrument — a converter that emits
+    /// `2^-53` where the model says `0` (Maros-Mészáros `QSC*`/`QSCFXM*`, and
+    /// every one of the 15 problems in gh #446, carry equality rows with an
+    /// RHS at `1e-17`–`1e-16`) declares a magnitude that is pure rounding
+    /// residue. `|c_i|` cannot be driven below the noise floor either, so the
+    /// ratio was noise over noise: QSCSD1 read 81× violated at a converged KKT
+    /// point whose absolute violation was `9.2e-15`, which vetoed its success
+    /// certificate and then armed the rapid-infeasibility pre-filter — a
+    /// feasible convex QP reported `Converged to a point of local
+    /// infeasibility`. Comparing against the row's own noise floor keeps the
+    /// scale invariance that is the whole point of the measure (both sides
+    /// carry `dc_i`), which an absolute cutoff on `|b_i|` would have thrown
+    /// away.
     pub fn relative_c_infeasibility_max(&self) -> Number {
         let c = self.curr_c();
         if c.dim() == 0 {
@@ -894,6 +931,7 @@ impl IpoptCalculatedQuantities {
         let Some(rhs) = self.nlp.borrow().declared_c_rhs() else {
             return 0.0;
         };
+        let noise = self.row_noise_floor(&*self.curr_jac_c(), &*c);
         let Some(c) = c.as_any().downcast_ref::<DenseVector>() else {
             return 0.0;
         };
@@ -905,13 +943,90 @@ impl IpoptCalculatedQuantities {
             return 0.0;
         }
         let mut worst = 0.0_f64;
-        for (&ci, &bi) in cv.iter().zip(rhs.iter()) {
+        for (i, (&ci, &bi)) in cv.iter().zip(rhs.iter()).enumerate() {
             let mag = bi.abs();
-            if mag > 0.0 && mag.is_finite() && ci.is_finite() {
+            // `0.0` when no floor could be computed, which reproduces the
+            // former `mag > 0.0` gate exactly.
+            let floor = noise.as_ref().map_or(0.0, |n| n[i]);
+            if mag > floor && mag.is_finite() && ci.is_finite() {
                 worst = worst.max(ci.abs() / mag);
             }
         }
         worst
+    }
+
+    /// Per-row floating-point noise floor of a constraint block: how large the
+    /// rounding error in the row's evaluated value can be, in the same
+    /// internally scaled units as the block's residual and declared bounds.
+    /// `jac` is the block's Jacobian and `template` any vector in the block's
+    /// space.
+    ///
+    /// Evaluating a row accumulates a relative error of order `eps` against
+    /// the magnitude of the *terms* it sums, `Σ_j |∂g_i/∂x_j · x_j|` — not
+    /// against the magnitude of the result. A row whose terms cancel (a
+    /// staircase LP row, a mass balance) therefore has a value that bottoms
+    /// out well above zero in relative terms while the value itself is tiny,
+    /// so neither the residual nor the declared bound can serve as the
+    /// reference. The Jacobian row does: `max_j |∂g_i/∂x_j| · ‖x‖_∞` bounds
+    /// the largest single term, and [`ROW_NOISE_KAPPA`] covers the sum over
+    /// the row's nonzeros.
+    ///
+    /// `‖x‖_∞` is a deliberately coarse stand-in for the row's *own*
+    /// variables — the exact `Σ_j |a_ij x_j|` would need `|J|·|x|`, which the
+    /// [`Matrix`] interface cannot express (`mult_vector` carries the signs
+    /// that are the whole problem). It over-estimates whenever the largest
+    /// variable is one the row does not mention, so the floor errs toward
+    /// abstaining. That is the safe direction: abstaining hands the row back
+    /// to the absolute `constr_viol_tol` test, whereas over-claiming is what
+    /// gh #446 was.
+    ///
+    /// Scale-invariant by construction. Under a row scaling `dc_i` the
+    /// Jacobian row carries `dc_i` exactly as the residual and the declared
+    /// bounds do (the scaling is applied in `eval_jac_c`/`eval_jac_d`), so the
+    /// floor moves with the quantities it gates and the abstention verdict is
+    /// the same at every `s`.
+    ///
+    /// A row with an **empty** Jacobian gets an infinite floor, so it always
+    /// abstains. Every variable it mentions has been fixed and substituted
+    /// out, which leaves a constant row `0 = b` that no iterate can move: it
+    /// is a statement about the *model*, and judging the *iterate* by it is a
+    /// category error. That is presolve's question, answered up front by
+    /// `presolve_infeasibility_proof` with a certificate, not a residual. The
+    /// runtime measure abstaining costs no detection that matters — the
+    /// absolute `constr_viol_tol` arm still sees the row, and an empty row
+    /// violated by anything a caller would recognise as infeasible is orders
+    /// above it. QPILOTNO is why: five variables fixed at `0` reduce row 150
+    /// to `0 = −2.22e-16`, its own rounding residue, and a measure that
+    /// insists the iterate is 100% in violation of it will never let any
+    /// iterate succeed (gh #446).
+    ///
+    /// `None` — meaning "no floor", i.e. only an exactly-zero magnitude
+    /// abstains — when the reference cannot be formed: `x = 0` (every term is
+    /// exactly zero, so the row carries no rounding error to speak of), a
+    /// non-finite iterate, or a vector type that is not dense.
+    fn row_noise_floor(&self, jac: &dyn Matrix, template: &dyn Vector) -> Option<Vec<Number>> {
+        let x_amax = self.curr_iv().x.amax();
+        if x_amax <= 0.0 || !x_amax.is_finite() {
+            return None;
+        }
+        let mut rows = template.make_new();
+        jac.compute_row_amax(&mut *rows, true);
+        let rows = rows.as_any().downcast_ref::<DenseVector>()?;
+        if !rows.is_initialized() {
+            return None;
+        }
+        Some(
+            rows.expanded_values()
+                .iter()
+                .map(|&a| {
+                    if a > 0.0 {
+                        ROW_NOISE_KAPPA * Number::EPSILON * a * x_amax
+                    } else {
+                        Number::INFINITY
+                    }
+                })
+                .collect(),
+        )
     }
 
     /// The inequality-block half of
@@ -941,7 +1056,16 @@ impl IpoptCalculatedQuantities {
     /// first place: `s·g >= 0` is the same row at every `s`, so the absolute
     /// test is already invariant there. Rows whose bounds are all zero or
     /// non-finite therefore contribute nothing (the relative measure
-    /// abstains). Equality rows are judged by
+    /// abstains) — "zero" measured against the row's own
+    /// [noise floor](`Self::row_noise_floor`) rather than exactly, for the
+    /// reason spelled out on [`Self::relative_c_infeasibility_max`]: a
+    /// converter that writes `2^-53` where the model says `0` otherwise hands
+    /// a bound made of rounding residue to a measure that then reads the row
+    /// as 100% violated. QPILOTNO carries 43 such inequality bounds at
+    /// `1e-17`–`1e-15`, and one of them — a row sitting at exactly `d(x) = 0`
+    /// against a declared bound of `1.1e-16` — pinned `rel_viol` at `1.0` for
+    /// the whole run and drove the gh #446 local-infeasibility verdict from
+    /// this block. Equality rows are judged by
     /// [`Self::relative_c_infeasibility_max`], which plumbs the pre-fold RHS
     /// back to supply the magnitude the fold into `c(x) = 0` erased.
     ///
@@ -1006,6 +1130,7 @@ impl IpoptCalculatedQuantities {
             nlp.pd_u().mult_vector(1.0, &*ones_u, 0.0, &mut *mask_u);
             (lo, hi, mask_l, mask_u)
         };
+        let noise = self.row_noise_floor(&*self.curr_jac_d(), &*dms);
         let (Some(d), Some(lo), Some(hi), Some(mask_l), Some(mask_u)) = (
             d.as_any().downcast_ref::<DenseVector>(),
             lo.as_any().downcast_ref::<DenseVector>(),
@@ -1041,7 +1166,10 @@ impl IpoptCalculatedQuantities {
                 viol = viol.max(dv[i] - hiv[i]);
                 mag = mag.max(hiv[i].abs());
             }
-            if mag > 0.0 && mag.is_finite() && viol.is_finite() && viol > 0.0 {
+            // `0.0` when no floor could be computed, which reproduces the
+            // former `mag > 0.0` gate exactly.
+            let floor = noise.as_ref().map_or(0.0, |n| n[i]);
+            if mag > floor && mag.is_finite() && viol.is_finite() && viol > 0.0 {
                 worst = worst.max(viol / mag);
             }
         }
@@ -2120,6 +2248,7 @@ mod tests {
         // Jacobian to exercise the finiteness guard in `curr_nlp_error`.
         nan_grad: bool,
         nan_jac_c: bool,
+        empty_jac_c: bool,
         // gh#390: the declared equality RHS the c-block relative measure
         // divides by. `None` (the default) is the "not tracked" contract.
         c_rhs: Option<Vec<Number>>,
@@ -2138,6 +2267,31 @@ mod tests {
 
         fn with_nan_jac_c(mut self) -> Self {
             self.nan_jac_c = true;
+            self
+        }
+
+        /// Every variable of the equality row fixed and substituted out, so
+        /// the row reduces to the constant `0 = b` — what
+        /// `IpoptCalculatedQuantities::row_noise_floor` calls a row no iterate
+        /// can move.
+        fn with_empty_jac_c(mut self) -> Self {
+            self.empty_jac_c = true;
+            self
+        }
+
+        /// Re-declare the single `d` row as the box `[−mag, +mag]`, so every
+        /// bound it has is of the chosen magnitude — the default fixture's
+        /// lower bound of `1` would otherwise supply the magnitude by itself.
+        /// `d(x) = x0 = 2` sits outside it, violating by `2 − mag`.
+        fn with_d_box(mut self, mag: Number) -> Self {
+            self.d_l = dvec(&[-mag]);
+            self.d_u = dvec(&[mag]);
+            self.pd_u = StdRc::new(ExpansionMatrix::new(ExpansionMatrixSpace::new(
+                1,
+                1,
+                &[0],
+                0,
+            )));
             self
         }
 
@@ -2181,6 +2335,7 @@ mod tests {
                 d_scale: None,
                 nan_grad: false,
                 nan_jac_c: false,
+                empty_jac_c: false,
                 c_rhs: None,
             }
         }
@@ -2222,6 +2377,13 @@ mod tests {
             dd.values_mut()[0] = xx.values()[0];
         }
         fn eval_jac_c(&mut self, _x: &dyn Vector) -> Rc<dyn Matrix> {
+            if self.empty_jac_c {
+                // No entries at all: the row carries no variable.
+                let space = GenTMatrixSpace::new(1, 2, vec![], vec![]);
+                let mut jac = GenTMatrix::new(space);
+                jac.set_values(&[]);
+                return StdRc::new(jac);
+            }
             // c(x) = x0 + x1 - 1 → Jc = [1, 1] (1×2), nonzeros (1,1),(1,2).
             let space = GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]);
             let mut jac = GenTMatrix::new(space);
@@ -2476,6 +2638,60 @@ mod tests {
         assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
         let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![Number::NAN])));
         assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+    }
+
+    /// gh #446. "Homogeneous" has to be judged numerically. The fixture's row
+    /// is `x0 + x1 == b` at `x = (2, 3)`, so its noise floor is
+    /// `ROW_NOISE_KAPPA · eps · 1 · 3 ≈ 4.3e-14`: an RHS under that is
+    /// rounding residue — a converter writing `2^-53` where the model says
+    /// `0` — and the row must abstain exactly as a declared zero does. Above
+    /// the floor the RHS is real data and is judged, however small.
+    #[test]
+    fn relative_c_infeasibility_abstains_on_rhs_below_the_row_noise_floor() {
+        let floor = ROW_NOISE_KAPPA * Number::EPSILON * 3.0;
+        // The QSCSD1 value: an RHS of exactly one machine epsilon.
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![Number::EPSILON])));
+        assert!(Number::EPSILON < floor);
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+        // Just above the floor the row still carries a magnitude, and a
+        // residual of 4 against it is judged on its merits.
+        let rhs = 2.0 * floor;
+        let cq = fixture_with(MockNlp::new().with_c_rhs(Some(vec![rhs])));
+        assert_eq!(cq.relative_c_infeasibility_max(), 4.0 / rhs);
+    }
+
+    /// gh #446. Every variable of the row fixed and substituted out leaves
+    /// `0 = b`, which no iterate can move — a statement about the model, for
+    /// presolve to certify, not a residual to judge an iterate by. QPILOTNO's
+    /// row 150 reduces to `0 = −2.22e-16` this way and pinned the relative
+    /// measure at 100% for the entire run.
+    #[test]
+    fn relative_c_infeasibility_abstains_on_a_row_no_iterate_can_move() {
+        let cq = fixture_with(
+            MockNlp::new()
+                .with_empty_jac_c()
+                .with_c_rhs(Some(vec![Number::EPSILON])),
+        );
+        assert_eq!(cq.relative_c_infeasibility_max(), 0.0);
+        // Not a licence to ignore a real one: the absolute `constr_viol_tol`
+        // arm still sees the row, and it is what governs here.
+        assert_eq!(cq.curr_primal_infeasibility_max(), 4.0);
+    }
+
+    /// gh #446. The inequality block draws its magnitude from the declared
+    /// bounds, and needs the same numeric reading of "zero" — QPILOTNO carries
+    /// 43 bounds at `1e-17`–`1e-15`. `d(x) = x0 = 2` against an upper bound
+    /// under the row's noise floor is 2e14 times its magnitude by the old
+    /// arithmetic, and unjudgeable by the new.
+    #[test]
+    fn relative_d_infeasibility_abstains_on_bound_below_the_row_noise_floor() {
+        let floor = ROW_NOISE_KAPPA * Number::EPSILON * 3.0;
+        let cq = fixture_with(MockNlp::new().with_d_box(Number::EPSILON));
+        assert_eq!(cq.relative_d_infeasibility_max(), 0.0);
+        // A bound above the floor is real, and `d = 2` violates it hugely.
+        let bound = 2.0 * floor;
+        let cq = fixture_with(MockNlp::new().with_d_box(bound));
+        assert_eq!(cq.relative_d_infeasibility_max(), (2.0 - bound) / bound);
     }
 
     /// A row-count mismatch means the RHS does not describe this `c` block;

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -30,12 +30,14 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 /// Safety factor on the per-row noise floor of
-/// [`IpoptCalculatedQuantities::row_noise_floor`]. The floor bounds the
-/// largest single term of a row by `max_j |a_ij| · ‖x‖_∞`; the row's actual
-/// rounding error accumulates over all of its nonzeros, so the bound is short
-/// by up to a factor of the row count. `64` covers a typical sparse row
-/// without reaching far enough to swallow a declared magnitude a model could
-/// have meant: at the `‖x‖_∞ ~ 1` of a well-posed problem the floor sits near
+/// [`IpoptCalculatedQuantities::row_noise_floor`]. The floor prices one
+/// component of `x` at `eps · ‖x‖_∞` and passes it through the row at
+/// `max_j |a_ij|`; the row's residual accumulates that over all of its
+/// nonzeros, and the linear solve's conditioning widens it further, so the
+/// bare product is short by a problem-dependent factor. `64` covers a typical
+/// sparse row without reaching far enough to swallow a declared magnitude a
+/// model could have meant: at the `‖x‖_∞ ~ 1` of a well-posed problem the
+/// floor sits near
 /// `1.4e-14`, still nine orders under `constr_viol_tol`'s default. Rows it
 /// silences fall back on the absolute feasibility test, which is already
 /// scale-invariant on a row whose declared magnitude is numerically zero.
@@ -914,7 +916,8 @@ impl IpoptCalculatedQuantities {
     /// `2^-53` where the model says `0` (Maros-Mészáros `QSC*`/`QSCFXM*`, and
     /// every one of the 15 problems in gh #446, carry equality rows with an
     /// RHS at `1e-17`–`1e-16`) declares a magnitude that is pure rounding
-    /// residue. `|c_i|` cannot be driven below the noise floor either, so the
+    /// residue — a target no iterate could be positioned finely enough to hit.
+    /// `|c_i|` cannot be driven below the same floor either, so the
     /// ratio was noise over noise: QSCSD1 read 81× violated at a converged KKT
     /// point whose absolute violation was `9.2e-15`, which vetoed its success
     /// certificate and then armed the rapid-infeasibility pre-filter — a
@@ -955,30 +958,35 @@ impl IpoptCalculatedQuantities {
         worst
     }
 
-    /// Per-row floating-point noise floor of a constraint block: how large the
-    /// rounding error in the row's evaluated value can be, in the same
-    /// internally scaled units as the block's residual and declared bounds.
-    /// `jac` is the block's Jacobian and `template` any vector in the block's
-    /// space.
+    /// Per-row noise floor of a constraint block: the finest residual the
+    /// solver could drive that row to, in the same internally scaled units as
+    /// the block's residual and declared bounds. `jac` is the block's Jacobian
+    /// and `template` any vector in the block's space.
     ///
-    /// Evaluating a row accumulates a relative error of order `eps` against
-    /// the magnitude of the *terms* it sums, `Σ_j |∂g_i/∂x_j · x_j|` — not
-    /// against the magnitude of the result. A row whose terms cancel (a
-    /// staircase LP row, a mass balance) therefore has a value that bottoms
-    /// out well above zero in relative terms while the value itself is tiny,
-    /// so neither the residual nor the declared bound can serve as the
-    /// reference. The Jacobian row does: `max_j |∂g_i/∂x_j| · ‖x‖_∞` bounds
-    /// the largest single term, and [`ROW_NOISE_KAPPA`] covers the sum over
-    /// the row's nonzeros.
+    /// The quantity being modelled is **how finely the solver can place `x`**,
+    /// not how accurately a row evaluates. A Newton step comes from a linear
+    /// solve whose backward error is norm-wise, so every component of `x` is
+    /// positioned to roughly `eps · ‖x‖_∞` in absolute terms — a variable at
+    /// `1e-8` inside a vector of norm `2.7` is still only resolved to
+    /// `~6e-16`, not to `~2e-24`. A row responds to `x` at rate
+    /// `max_j |∂g_i/∂x_j|`, so the finest residual it can be driven to is
+    /// `max_j |∂g_i/∂x_j| · eps · ‖x‖_∞`, with [`ROW_NOISE_KAPPA`] covering
+    /// accumulation across the row's nonzeros and conditioning slop. A
+    /// declared magnitude under that is a target the solver could not hit even
+    /// in exact arithmetic on the model as written.
     ///
-    /// `‖x‖_∞` is a deliberately coarse stand-in for the row's *own*
-    /// variables — the exact `Σ_j |a_ij x_j|` would need `|J|·|x|`, which the
-    /// [`Matrix`] interface cannot express (`mult_vector` carries the signs
-    /// that are the whole problem). It over-estimates whenever the largest
-    /// variable is one the row does not mention, so the floor errs toward
-    /// abstaining. That is the safe direction: abstaining hands the row back
-    /// to the absolute `constr_viol_tol` test, whereas over-claiming is what
-    /// gh #446 was.
+    /// `‖x‖_∞` is global, and that is the point rather than a compromise: `x`
+    /// is one vector solved for jointly, so a large variable anywhere really
+    /// does coarsen the resolution of every other. The per-row alternative,
+    /// the exact term sum `Σ_j |a_ij x_j|` via `|J|·|x|`, was implemented and
+    /// measured, and it is strictly worse — it models the row's *evaluation*
+    /// error, which is not what limits the residual. It regressed QETAMACR,
+    /// QSCORPIO and QPILOTNO of gh #446's 15: QSCORPIO's row 93 has all its
+    /// variables parked near a zero bound at `~1e-8`, giving a term sum of
+    /// `6e-8` and a floor of `8.5e-22`, so its `−5.6e-17` of rounding residue
+    /// read as real data again — while the iterate it is judging is only
+    /// resolved to `~6e-16`. Do not "improve" this to the term sum without
+    /// re-running those three.
     ///
     /// Scale-invariant by construction. Under a row scaling `dc_i` the
     /// Jacobian row carries `dc_i` exactly as the residual and the declared
@@ -2456,13 +2464,17 @@ mod tests {
     }
 
     fn fixture_with(nlp: MockNlp) -> IpoptCalculatedQuantities {
+        fixture_with_x(nlp, &[2.0, 3.0])
+    }
+
+    fn fixture_with_x(nlp: MockNlp, x: &[Number]) -> IpoptCalculatedQuantities {
         let mut data = IpoptData::new();
         data.curr_mu = 0.1;
-        // Iterate: x = (2, 3); s = (4); y_c = (1); y_d = (1);
+        // Iterate: x as given (2, 3 by default); s = (4); y_c = (1); y_d = (1);
         // z_L = (0.5) [bound on x[0]], z_U = (0.7) [bound on x[1]],
         // v_L = (0.3), v_U = ().
         let iv = IteratesVector::new(
-            rcv(&[2.0, 3.0]),
+            rcv(x),
             rcv(&[4.0]),
             rcv(&[1.0]),
             rcv(&[1.0]),
@@ -2692,6 +2704,28 @@ mod tests {
         let bound = 2.0 * floor;
         let cq = fixture_with(MockNlp::new().with_d_box(bound));
         assert_eq!(cq.relative_d_infeasibility_max(), (2.0 - bound) / bound);
+    }
+
+    /// The floor tracks `‖x‖_∞` **deliberately**, and this pins it. `x` is one
+    /// vector produced by a linear solve with norm-wise backward error, so a
+    /// large variable anywhere really does coarsen how finely every other
+    /// component can be placed — and a declared magnitude finer than that is a
+    /// target no iterate could hit. The per-row alternative, `Σ_j |a_ij x_j|`
+    /// via `|J|·|x|`, looks more precise and measures the wrong thing (a row's
+    /// *evaluation* error, not what limits its residual); it was implemented
+    /// and it regressed QETAMACR, QSCORPIO and QPILOTNO of gh #446's 15. Re-run
+    /// those three before changing this.
+    #[test]
+    fn row_noise_floor_tracks_the_iterate_norm() {
+        // `d(x) = x0` against a declared box of ±1e-9.
+        let bound = 1e-9;
+        // At ‖x‖_∞ = 3 the floor is ~4.3e-14: the bound is real data, judged.
+        let cq = fixture_with(MockNlp::new().with_d_box(bound));
+        assert_eq!(cq.relative_d_infeasibility_max(), (2.0 - bound) / bound);
+        // At ‖x‖_∞ = 1e8 the floor is ~1.4e-6 and the same bound is finer than
+        // the iterate can be resolved, so the row abstains.
+        let cq = fixture_with_x(MockNlp::new().with_d_box(bound), &[2.0, 1e8]);
+        assert_eq!(cq.relative_d_infeasibility_max(), 0.0);
     }
 
     /// A row-count mismatch means the RHS does not describe this `c` block;


### PR DESCRIPTION
Fixes #446

## The bug

The scale-relative feasibility measure (#385, extended to equality rows by
#390) divides a row's violation by that row's **declared** magnitude — the
pre-fold RHS, or the declared bounds — and abstained only when that magnitude
was *exactly* zero.

Every one of the 15 problems carries rows whose declared magnitude is 1e-17 to
1e-16: rounding residue from the netlib to `.nl` conversion, `2^-53` written
where the model says `0`. A row's residual cannot be driven below its own noise
floor either, so the ratio was noise over noise.

QSCSD1's trace shows the whole mechanism. At iteration 15 it sits at a
converged KKT point:

```
15  8.6666510e+00 9.22e-15 2.84e-14  -8.6 ...
INFO refusing a success certificate: a constraint row is still violated by
     more than the scale-relative threshold of its own magnitude
     rel_viol=81.6 constr_viol=9.2e-15 threshold=0.01
```

The veto blocks the certificate, the solver grinds on to iteration 77 past a
solution it already had, and the rapid-infeasibility pre-filter then issues the
verdict. The measure feeds both the certificate veto and the verdict, so a
single root-cause fix covers every consumer.

## The fix

"Zero" is now read numerically. A row abstains once its declared magnitude
sinks under its own noise floor, `κ · eps · max_j |∂g_i/∂x_j| · ‖x‖_∞`. Both
the floor and the magnitude carry the row scaling `dc_i`, so the scale
invariance that is the entire point of the measure survives — an absolute
cutoff on the magnitude would have destroyed it.

Two further pieces the investigation turned up:

- **The inequality block had the same defect.** QPILOTNO carries 43 declared
  bounds at 1e-17 to 1e-15, and one of them — a row sitting at exactly
  `d(x) = 0` against a declared bound of 1.1e-16 — drove the verdict from that
  side. Both blocks are fixed.
- **Rows with an empty Jacobian abstain outright.** QPILOTNO's row 150 has five
  variables all fixed at 0; POUNCE substitutes them out, leaving a constant
  `0 = −2.22e-16` that no iterate can move. That is a statement about the
  model, which presolve certifies up front, not a residual to judge an iterate
  by.

## What the floor actually models

Not a row's *evaluation* error — how finely the solver can **place x**. A
Newton step comes from a linear solve with norm-wise backward error, so every
component of `x` is positioned to about `eps · ‖x‖_∞`: a variable at 1e-8
inside a vector of norm 2.7 is still only resolved to ~6e-16. The dependence on
the *global* `‖x‖_∞` is therefore deliberate — `x` is one vector solved for
jointly, so a large variable anywhere genuinely does coarsen every other
component.

The seemingly sharper per-row alternative, the exact term sum `Σ_j |a_ij x_j|`
via `|J|·|x|`, was implemented and measured. It models the wrong quantity and
regressed QETAMACR, QSCORPIO and QPILOTNO: QSCORPIO's row 93 parks its
variables near a zero bound at ~1e-8, so the term sum drops its floor to
8.5e-22 and −5.6e-17 of rounding residue reads as real data again — at an
iterate resolved only to ~6e-16. The second commit records that measurement in
the source, and `row_noise_floor_tracks_the_iterate_norm` pins the `‖x‖_∞`
dependence so it is not "improved" away.

## Verification

`qp_convex` NLP arm (`make benchmark-qp-convex`), same binary, same data:

| | solved | time |
|---|---|---|
| before | 113/138 | 525.7 s |
| after | **137/138** | **504.4 s** |

More problems solved, in less total time. All 15 wrong verdicts are gone, and
so are nine further failures with the same origin — five
`Search_Direction_Becomes_Too_Small` and four `Solver_Error`, all cases of the
veto pushing the solver past a solution it had already reached until the step
computation broke down. **No problem regressed.** Iteration counts of the
newly-solved problems mostly fall (QSCSD1 77 to 15, QSCSD8 121 to 20), and all
15 objectives now agree with the `qp-ipm` reference to 1.8e-6 or better. The
one remaining failure, BOYD2's 300 s CPU-limit timeout, is pre-existing and
unrelated.

Full workspace suite: **2377 passed, 0 failed**, including
`false_local_infeasibility`, `infeasible_status_tol_invariance` and
`issue_390_nonlinear_equality_scale`. Four new unit tests cover the floor on
each block, the empty row, and the `‖x‖_∞` dependence.

No measurable performance cost: the Jacobian is already cached per iterate, and
timing the heaviest problems individually (CVXQP3_L 63.5 s to 63.2 s, CVXQP1_L
38.7 s to 38.8 s) shows no regression.

## On κ

`ROW_NOISE_KAPPA = 64` absorbs summation growth across a row's nonzeros and
conditioning slop, neither of which is measured — it is empirical, not derived.
It is not a knife edge: over the 15 problems plus the three infeasibility
suites, every value from 8 to 1024 gives identical verdicts. 1 is too small.

## Scope

Masked in default use, since `solver_selection=auto` routes convex QPs to
`qp-ipm`. Anyone driving POUNCE as a general NLP solver on a convex QP hit it,
and got `Infeasible_Problem_Detected` — which Pyomo maps into the infeasible
family, so it reads as a modelling error rather than a solver limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
