### PR TITLE
Translate user variable indices into factor rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — pyomo-pounce: a fixed variable shifted every sensitivity result
+
+- A variable whose bounds are equal is removed from the solve
+  (`fixed_variable_treatment = make_parameter`), so the KKT factor's
+  `x` block is shorter than the user's variable list and every later
+  column moves. The `.col`-order rows the sensitivity session hands
+  around are user-space, and were used to index the factor directly:
+  one fixed variable anywhere made every later variable read its
+  NEIGHBOUR's row. `gradient()` returned a plausible wrong number with
+  no warning (`d(y)/dp` where `d(x)/dp` was asked for); `estimate()`
+  failed on a shape mismatch; `covariance()` raised a bogus
+  "structurally unidentifiable". Models with no fixed variable — every
+  model in the test suite — were never affected, since the two spaces
+  coincide exactly then.
+- `Solver.primal_rows(x_indices)`: the factor rows of user-space
+  variable indices, `None` for a removed fixed variable. The `x`
+  counterpart of the existing `multiplier_rows`, which had always done
+  this translation for the `y_c` block. Every index the session takes
+  into the factor now routes through it, and asking for a removed
+  variable's sensitivity is an explicit refusal rather than a
+  neighbouring column.
+- Regression tests add one inert fixed variable to an existing model
+  and require every answer to be unchanged, plus a finite-difference
+  check so they pin the right value and not merely a consistent one.
+
 ### Changed — pyomo-pounce: `covariance()` membership from the solve's barrier geometry (#362, covariance roadmap item 1)
 
 - Bound and constraint activity on the fitted parameters now classifies

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -288,6 +288,36 @@ impl PySolver {
         Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
     }
 
+    /// Rows of the compound KKT vector holding the primal values for
+    /// the given 0-based **user-space** variable (`x`) indices; `None`
+    /// where the solve removed the column as a fixed variable
+    /// (`lb == ub` under `fixed_variable_treatment=make_parameter`).
+    ///
+    /// The `x` counterpart of `multiplier_rows`. User-space indices —
+    /// from the `.col` file, from `classify_activity()`, from
+    /// `row_normal()` — are NOT factor rows: one fixed variable
+    /// anywhere shifts every later column, and on a model without any
+    /// the two spaces coincide, so the mistake is invisible in testing.
+    /// Translate here before indexing `kkt_solve` / `parametric_step`
+    /// results.
+    fn primal_rows(&self, x_indices: Vec<i64>) -> PyResult<Vec<Option<i64>>> {
+        let s = self.state.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("primal_rows: no converged factor (call solve() first)")
+        })?;
+        let n_full = s.inner.n_full_x().map_err(solver_error_to_py)?;
+        let mut xs = Vec::with_capacity(x_indices.len());
+        for &i in &x_indices {
+            if i < 0 || (i as usize) >= n_full {
+                return Err(PyValueError::new_err(format!(
+                    "primal_rows: variable index {i} out of range [0, n={n_full})"
+                )));
+            }
+            xs.push(i as Index);
+        }
+        let rows = s.inner.x_primal_rows(&xs).map_err(solver_error_to_py)?;
+        Ok(rows.into_iter().map(|r| r.map(|v| v as i64)).collect())
+    }
+
     /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned
     /// rows, in **natural (unscaled) units**: any NLP scaling baked
     /// into the converged factor is undone, so `-inv(H_R)` is directly

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -406,6 +406,30 @@ impl PdSensBacksolver {
         self.nlp.borrow().full_g_to_c_block(full_idx)
     }
 
+    /// Map a 0-based **full-x** index (user-TNLP variable order) to its
+    /// 0-based position in the algorithm-side `x` block, or `None` when
+    /// the solve removed the column because `x_l == x_u` under
+    /// `fixed_variable_treatment = make_parameter`. Delegates to the
+    /// held NLP's fixed-variable map.
+    ///
+    /// The `x` counterpart of [`Self::full_g_to_c_block`], and it must
+    /// be routed through for the same reason: the flat KKT row of a
+    /// user variable is `full_x_to_var_x(i)`, NOT `i` — those differ
+    /// whenever any fixed variable precedes it in the user's `x`.
+    /// Reports and iterates are in full-x, the factor is in var-x, and
+    /// nothing about the two spaces is distinguishable by length alone
+    /// on a model that happens to have no fixed variables.
+    pub fn full_x_to_var_x(&self, full_idx: Index) -> Option<Index> {
+        self.nlp.borrow().full_x_to_var_x(full_idx)
+    }
+
+    /// The user TNLP's variable count, the domain of
+    /// [`Self::full_x_to_var_x`]. Distinct from the `x` block width
+    /// whenever the solve removed a fixed variable.
+    pub fn n_full_x(&self) -> Index {
+        self.nlp.borrow().n_full_x()
+    }
+
     /// Cumulative block offsets: `offset(i)` is the start index of
     /// block `i` in the flat slice.
     fn offsets(&self) -> [usize; 9] {

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -554,6 +554,49 @@ impl Solver {
             .collect())
     }
 
+    /// Flat rows of the compound KKT vector holding the primal values
+    /// `x` for the given 0-based **full-x** variable indices. `None`
+    /// where the solve removed the column (`x_l == x_u` under
+    /// `fixed_variable_treatment = make_parameter`), which has no row
+    /// in the factor at all.
+    ///
+    /// The `x` counterpart of [`Self::g_multiplier_rows`], and needed
+    /// for the same reason: a caller holding user-space indices — from
+    /// the `.col` file, from [`Self::classify_activity`], from
+    /// [`Self::row_normal`] — cannot index the factor with them
+    /// directly. Row `r` of a [`Self::parametric_step_full`] result is
+    /// then `∂x/∂p · Δp` for that variable, and `e_r` is the unit
+    /// vector selecting its column in a [`Self::kkt_solve`].
+    pub fn x_primal_rows(&self, x_indices: &[Index]) -> Result<Vec<Option<Index>>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        let n_full = state.backsolver.n_full_x();
+        // out of range must not masquerade as "removed as fixed": the
+        // NLP map returns None for both, and the caller's whole reason
+        // for asking is that it cannot tell the spaces apart itself
+        if let Some(&bad) = x_indices.iter().find(|&&i| i < 0 || i >= n_full) {
+            return Err(SolverError::BadShape {
+                what: "x_primal_rows variable index",
+                got: bad as usize,
+                expected: n_full as usize,
+            });
+        }
+        // the x block starts at flat index 0, so the var-x position IS
+        // the KKT row; the offset stays explicit for the day it is not
+        Ok(x_indices
+            .iter()
+            .map(|&i| state.backsolver.full_x_to_var_x(i))
+            .collect())
+    }
+
+    /// The user TNLP's variable count: the length of a full-x report
+    /// and the domain of [`Self::x_primal_rows`].
+    pub fn n_full_x(&self) -> Result<usize, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        Ok(state.backsolver.n_full_x() as usize)
+    }
+
     /// Reduced Hessian `H_R = obj_scal · B K⁻¹ Bᵀ` over the pinned
     /// equality-constraint rows, where `B` selects the
     /// `pin_constraint_indices` rows of the y_c block and `K` is the

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -444,6 +444,19 @@ constraint gradient with the solver's per-row scale divided out;
 classification happens on the scaled quantities internally, the report
 never shows them.
 
+**Variable indices are user-space, factor rows are not.** Everything
+the sensitivity API reports or accepts — the `.col` file's order, the
+activity report's `var_*` arrays, `row_normal(j)`'s entries — indexes
+the variables you wrote. The converged factor does not: a variable
+whose bounds are equal is removed from the solve
+(`fixed_variable_treatment = make_parameter`, the default), so its
+column is absent and every later variable sits one row earlier. The
+two orders coincide exactly when the model has no fixed variable,
+which makes the difference easy to miss. Translate with
+`Solver.primal_rows(indices)` — `None` marks a removed variable —
+before indexing a `kkt_solve` or `parametric_step_full` result, just
+as `multiplier_rows` has always been required for the `y_c` block.
+
 In particular, for a parameter-estimation NLP with the parameters
 pinned by equality constraints, `-inv(info["reduced_hessian"])` is
 directly the parameter covariance — no per-problem scale factor, no

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -270,9 +270,56 @@ class _Session:
         self.base_obj = float("nan")
         self.moved_bounds = {}        # var name -> (lb, ub) moved to rows
         self._columns = {}            # pin row -> full KKT-space column
+        self._primal_rows = None      # full-x -> KKT row, lazily fetched
 
     def orig_var(self, name):
         return self.model.find_component(name)
+
+    def _primal_row_map(self):
+        if self._primal_rows is None:
+            self._primal_rows = self.solver.primal_rows(
+                list(range(len(self.var_names))))
+        return self._primal_rows
+
+    def primal_row(self, full_idx, what):
+        """The KKT-factor row of a user-space (`.col`) variable index.
+
+        `.col` order -- what `var_entry`, `fit_rows` and `res_rows` all
+        hold -- is the user's FULL-x space. The factor's `x` block is
+        the algorithm's var-x space, which drops every variable the
+        solve removed as fixed (`lb == ub` under the default
+        `fixed_variable_treatment=make_parameter`). The two spaces
+        coincide exactly when the model has no fixed variable, which is
+        every model in the test suite and most models anywhere, so
+        indexing the factor with a full-x row is invisible until it is
+        not: one fixed variable shifts every later column and the
+        back-solve quietly returns a NEIGHBOURING variable's
+        sensitivity, a plausible number with nothing wrong-looking
+        about it. Route every factor index through here.
+        """
+        row = self._primal_row_map()[full_idx]
+        if row is None:
+            raise ValueError(
+                f"{what}: {self.var_names[full_idx]} was removed from the "
+                "solve as a fixed variable (its bounds are equal), so it "
+                "has no row in the KKT factor and no sensitivity "
+                "information. Give it distinct bounds to keep it in the "
+                "solve.")
+        return row
+
+    def scatter_x(self, dx_var):
+        """Full-x vector from an algorithm-space (var-x) one.
+
+        `parametric_step` truncates its result to the factor's `x`
+        block, so it is var-x while `base_x`, `nl.x_l/x_u` and
+        `var_names` are all full-x. Variables the solve removed as
+        fixed get 0: a fixed variable does not move.
+        """
+        out = np.zeros(len(self.var_names))
+        for full_idx, row in enumerate(self._primal_row_map()):
+            if row is not None:
+                out[full_idx] = dx_var[row]
+        return out
 
     def column(self, pin_idx):
         """Full KKT-space derivative column for a unit perturbation."""
@@ -778,7 +825,11 @@ class Gradient:
     def _entry(self, td):
         if td.ctype is Constraint:
             return self._session.mult_entry(td.name)
-        return self._session.var_entry(td.name)
+        # var_entry is full-x; the column being indexed is the factor's
+        # KKT vector, so it needs the var-x row -- the same translation
+        # mult_entry already does for the y_c block
+        return self._session.primal_row(
+            self._session.var_entry(td.name), f"gradient({td.name})")
 
     @staticmethod
     def _convention_sign(td):
@@ -891,7 +942,10 @@ def estimate(model, perturb, clamp=True):
             # same estimate as one that has not
             deltas.append(float(nv) - float(session.nl.g_l[pin]))
 
-    dx = np.asarray(session.solver.parametric_step(pin_idx, deltas))
+    # parametric_step returns the factor's x block (var-x); base_x and
+    # everything below it (nl.x_l/x_u, var_names) are full-x
+    dx = session.scatter_x(
+        np.asarray(session.solver.parametric_step(pin_idx, deltas)))
     x_new = session.base_x + dx
 
     lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
@@ -1166,14 +1220,20 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
             "regularized rather than exact. Linearly dependent (structurally"
             " unidentifiable) parameters are the usual cause.")
     # ── parameter block of the inverse KKT matrix ─────────────────────────
+    # `rows` is full-x (the space of the activity report and of
+    # row_normal, both read below); `krows` is the same variables as
+    # factor rows. Keep the two apart -- they differ exactly when the
+    # model has a fixed variable, and agree everywhere else.
     dim = session.solver.kkt_dim
     rows = [session.fit_rows[p] for p in params]
+    krows = [session.primal_row(r, f"covariance({p.name})")
+             for r, p in zip(rows, params)]
     zcols = []
-    for r in rows:
+    for r in krows:
         e = np.zeros(dim)
         e[r] = 1.0
         zcols.append(np.asarray(session.solver.kkt_solve(e)))
-    M = np.array([[zcols[j][rows[i]] for j in range(n_params)]
+    M = np.array([[zcols[j][krows[i]] for j in range(n_params)]
                   for i in range(n_params)])
     M = 0.5 * (M + M.T)
 
@@ -1474,7 +1534,9 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian"):
         Mi = minv()
         out = {}
         for g, rws in groups.items():
-            Zr = np.array([[zcols[j][r] for j in range(n_params)]
+            # res_rows is full-x like fit_rows; zcols are factor rows
+            Zr = np.array([[zcols[j][session.primal_row(r, "covariance")]
+                            for j in range(n_params)]
                            for r in rws])
             out[g] = Zr @ Mi                  # d r_g / d p
         return out

--- a/pyomo-pounce/tests/test_sens.py
+++ b/pyomo-pounce/tests/test_sens.py
@@ -785,3 +785,73 @@ def test_row_file_objective_is_not_a_constraint_row():
     assert "obj" not in session.con_names
     with pytest.raises(ValueError, match="not a constraint"):
         session.mult_entry("obj")
+
+
+def _fixed_var_pair(with_fixed):
+    """`build()`'s model, optionally carrying an inert variable whose
+    bounds are equal. Pyomo prunes a fixed variable that appears only
+    with a zero coefficient, so `dead` is referenced by a real (slack,
+    never binding) constraint to force the writer to emit a column for
+    it."""
+    m = build()
+    if with_fixed:
+        m.dead = pyo.Var(bounds=(2.0, 2.0), initialize=2.0)
+        m.deadcon = pyo.Constraint(expr=m.dead * m.dead <= 1e6)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def test_a_fixed_variable_does_not_shift_the_factor_rows():
+    """A variable with equal bounds is removed from the solve
+    (`fixed_variable_treatment=make_parameter`), so the factor's `x`
+    block is SHORTER than the user's variable list and every later
+    column moves. The `.col`-order rows the session hands around are
+    user-space, so indexing the factor with one read a neighbouring
+    variable.
+
+    It was invisible because the two spaces coincide on any model
+    without a fixed variable -- which is every other model in this
+    suite. Adding one inert fixed variable must change nothing: it is
+    pinned by its own bounds and enters neither objective nor active
+    set.
+
+    Before the fix `gradient` returned d(y)/dp where d(x)/dp was asked
+    for -- a plausible number, silently wrong -- while `estimate` and
+    `covariance` failed loudly (a broadcast error and a bogus
+    "structurally unidentifiable" respectively).
+    """
+    base, fixed = _fixed_var_pair(False), _fixed_var_pair(True)
+
+    # the fixed variable really did reach the solve and really was
+    # removed from the factor, or the test proves nothing
+    sess = fixed.__dict__["_pounce_sens"].session
+    n_full = len(sess.var_names)
+    assert n_full == len(base.__dict__["_pounce_sens"].session.var_names) + 1
+    rows = sess.solver.primal_rows(list(range(n_full)))
+    assert rows.count(None) == 1, rows
+    assert sess.var_names.index("dead") < sess.var_names.index("x"), (
+        "the fixed column must precede a queried variable to shift it")
+
+    for m in (base, fixed):
+        assert gradient(m.x, wrt=m.p) == pytest.approx(
+            gradient(base.x, wrt=base.p), rel=1e-9)
+        assert gradient(m.y, wrt=m.p) == pytest.approx(
+            gradient(base.y, wrt=base.p), rel=1e-9)
+        est = estimate(m, [(m.p, 2.1)])
+        assert est[m.x] == pytest.approx(
+            estimate(base, [(base.p, 2.1)])[base.x], rel=1e-9)
+
+    # and the answer is right, not merely consistent: finite difference
+    g_fd = (estimate(fixed, [(fixed.p, 2.0 + FD_H)])[fixed.x]
+            - estimate(fixed, [(fixed.p, 2.0 - FD_H)])[fixed.x]) / (2 * FD_H)
+    assert gradient(fixed.x, wrt=fixed.p) == pytest.approx(g_fd, rel=1e-6)
+
+
+def test_a_removed_fixed_variable_is_refused_not_mis_read():
+    """Asking for the sensitivity OF the fixed variable itself has no
+    answer in the factor -- it has no row there. That must be an
+    explicit refusal, not the neighbouring column."""
+    m = _fixed_var_pair(True)
+    with pytest.raises(ValueError, match="removed from the solve"):
+        gradient(m.dead, wrt=m.p)

--- a/python/tests/test_activity.py
+++ b/python/tests/test_activity.py
@@ -428,3 +428,29 @@ def test_row_normal_before_solve_raises():
     ))
     with pytest.raises(RuntimeError, match="no converged factor"):
         pounce.Solver(prob).row_normal(0)
+
+
+def test_primal_rows_skips_the_fixed_column():
+    # MixedModel fixes x2 (lb == ub == 2.0), so make_parameter removes
+    # its column and every LATER user variable sits one row earlier in
+    # the factor than its user index. That shift is the whole reason
+    # this accessor exists: user-space indices (the .col file, the
+    # activity report, row_normal) are not factor rows.
+    solver = _mixed_solver()
+    assert solver.primal_rows([0, 1, 2, 3]) == [0, 1, None, 2]
+    # and the identity case, so a caller cannot conclude from one model
+    # that user index == factor row in general
+    assert solver.primal_rows([0]) == [0]
+    with pytest.raises(ValueError, match="out of range"):
+        solver.primal_rows([4])
+    with pytest.raises(ValueError, match="out of range"):
+        solver.primal_rows([-1])
+
+
+def test_primal_rows_before_solve_raises():
+    prob = _options(pounce.Problem(
+        n=1, m=1, problem_obj=ScalarRow(1.0),
+        lb=[-1e19], ub=[1e19], cl=[0.0], cu=[1e19],
+    ))
+    with pytest.raises(RuntimeError, match="no converged factor"):
+        pounce.Solver(prob).primal_rows([0])


### PR DESCRIPTION
Found while reviewing #436. Not caused by it — #436 added a second,
*correct*, consumer of the index space, which is what made the existing
one visible.

## The bug

A variable whose bounds are equal is removed from the solve under
`fixed_variable_treatment = make_parameter` (the default). The KKT
factor's `x` block is then shorter than the user's variable list, and
every variable after the removed one sits one row earlier.

The rows the sensitivity session passes around — `var_entry`,
`fit_rows`, `res_rows` — all come from the `.col` file and are
user-space. They were used to index the factor directly. So one fixed
variable anywhere made every later variable read its **neighbour's**
row.

`multiplier_rows` had always done this translation for the `y_c` block,
and `full_g_to_c_block`'s doc comment already carried an explicit
warning about precisely this shape of bug on the `g` side. The `x` side
had neither.

## What it did

The same model, with and without one inert `Var(bounds=(2.0, 2.0))`
that enters neither the objective nor the active set:

| | no fixed var | with fixed var |
|---|---|---|
| `gradient(m.x, wrt=m.p)` | `1.4442` | **`-0.6774`** |
| `estimate(m, [(m.p, 2.1)])` | ok | `ValueError: operands could not be broadcast together with shapes (29,) (28,)` |
| `covariance(m)` | ok | `RuntimeError: ... the fitted parameters are linearly dependent (structurally unidentifiable)` |

`gradient` is the one that matters. `-0.6774` is `d(y)/dp` — the next
variable's sensitivity, returned for `x` with no warning and nothing
wrong-looking about it. The other two fail loudly, and `covariance`'s
message actively misleads: it blames the user's model for a defect in
the indexing.

None of this showed up before because the two orders coincide *exactly*
on a model with no fixed variable — which is every model in the suite,
and most models anywhere.

## The fix

`Solver.primal_rows(x_indices)` — the factor rows of user-space
variable indices, `None` where the solve removed the column. The `x`
counterpart of `multiplier_rows`. Every index the session takes into
the factor now routes through it:

- `Gradient._entry` translates, exactly as the `Constraint` branch
  beside it already did.
- `estimate` scatters `parametric_step`'s var-x result back to full-x
  before adding it to `base_x` (fixed variables get 0 — they do not
  move).
- `covariance` keeps `rows` in full-x for the activity report and
  `row_normal`, and uses a separate `krows` for the factor. The two
  spaces are now named apart rather than silently conflated.

Asking for a *removed* variable's own sensitivity now refuses
explicitly instead of handing back a neighbouring column.

Rust side: `PdSensBacksolver` gains `full_x_to_var_x` and `n_full_x`
beside the existing `full_g_to_c_block`; `Solver::x_primal_rows`
validates the range itself, because out-of-range and removed-as-fixed
both come back as `None` from the NLP map and a caller asking this
question is precisely one that cannot tell the spaces apart.

## Verification

The regression adds one inert fixed variable to an existing model and
requires every answer to be unchanged, plus a finite difference so it
pins the right value rather than a merely consistent one. It also
asserts the fixed column really reached the solve, really was removed
from the factor, and really precedes a queried variable — otherwise the
test proves nothing. Both new `test_sens.py` tests fail without the
`sens.py` change and pass with it. `primal_rows` itself is tested
against the activity suite's `MixedModel`, which already carries a
removed fixed column at `x2`.

- `pyomo-pounce/tests`: 117 passed, 7 skipped (was 115 — +2 new)
- `python/tests`: 586 passed, 33 skipped (+2 new)
- `cargo test -p pounce-sensitivity`: 89 passed
- `cargo check --workspace --all-targets`: no new warnings (the two
  `homotopy_sweep.rs:185` ones are pre-existing, confirmed by count on
  a clean tree)

## Scope

Anyone whose model has no equal-bounds variable is unaffected, and
their numbers do not move. `pounce.curve_fit` and the CLI are
untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
