### PR TITLE
Stop the benchmark drivers writing .sol into the data directory

### DIFF
--- a/benchmarks/scripts/compare_pounce_clarabel.py
+++ b/benchmarks/scripts/compare_pounce_clarabel.py
@@ -298,8 +298,10 @@ def run_pounce(nl_path, selection, time_limit):
         out = tf.name
     t = time.perf_counter()
     try:
+        # `--no-sol`: the AMPL sibling `<stub>.sol` is never read (results come
+        # from `--json-output`), and the caller unlinks the `.nl` but not it.
         subprocess.run([POUNCE_BIN, nl_path, f"solver_selection={selection}",
-                        "--json-output", out],
+                        "--no-sol", "--json-output", out],
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
                        timeout=time_limit)
     except subprocess.TimeoutExpired:

--- a/benchmarks/scripts/run_nl_bench.sh
+++ b/benchmarks/scripts/run_nl_bench.sh
@@ -185,16 +185,25 @@ run_one() {
   logtag="${POUNCE_SOLVER_LABEL:-$label}"
   log="${LOGDIR}/${problem}.${logtag}.log"
 
+  # `--no-sol` on the pounce arms: by AMPL convention a `.nl` input gets a
+  # sibling `<stub>.sol`, so a sweep rewrites one per problem *inside the
+  # data directory*. Nothing here reads them back — status, objective and
+  # iteration counts are all scraped from "$log" — and `make clean-bench-nl`
+  # exists purely to delete them again. When POUNCE_BENCH_DATA lives in a
+  # synced folder (Dropbox, iCloud) those writes also kick off a sync
+  # cascade mid-run, which contends for I/O with the very timings the sweep
+  # is measuring. Ipopt's `-AMPL` protocol has no equivalent opt-out, but
+  # that arm is the saved reference and reruns rarely.
   start=$(python3 -c 'import time; print(time.time())')
   if [ "$ampl_protocol" = "yes" ]; then
     timeout "$TIMELIMIT" "$bin" "$nl" -AMPL \
       linear_solver="$IPOPT_LINEAR_SOLVER" max_cpu_time="$TIMELIMIT" > "$log" 2>&1
     rc=$?
   elif [ ${#POUNCE_EXTRA_ARR[@]} -gt 0 ]; then
-    timeout "$TIMELIMIT" "$bin" "$nl" "${POUNCE_EXTRA_ARR[@]}" > "$log" 2>&1
+    timeout "$TIMELIMIT" "$bin" "$nl" --no-sol "${POUNCE_EXTRA_ARR[@]}" > "$log" 2>&1
     rc=$?
   else
-    timeout "$TIMELIMIT" "$bin" "$nl" > "$log" 2>&1
+    timeout "$TIMELIMIT" "$bin" "$nl" --no-sol > "$log" 2>&1
     rc=$?
   fi
   end=$(python3 -c 'import time; print(time.time())')


### PR DESCRIPTION
## The problem

By AMPL convention a `.nl` input gets a sibling `<stub>.sol`, so every
sweep rewrites one file per problem **inside `POUNCE_BENCH_DATA`** —
the data directory, not the results directory.

Nothing reads them back:

- `run_nl_bench.sh` scrapes status, objective and iteration counts out
  of the `.log` it redirects to.
- `compare_pounce_clarabel.py` takes its results from `--json-output`.

The only consumer of those files anywhere in the tree is
`make clean-bench-nl`, whose job is to delete them again.

When `POUNCE_BENCH_DATA` lives in a synced folder (Dropbox, iCloud) the
writes also kick off a sync cascade partway through a run, which
contends for I/O with the very timings the sweep is measuring — a
benchmark perturbing itself. A recent `qp_convex` sweep rewrote 138 of
them.

## The change

`--no-sol` already exists on the CLI, so this just passes it: both
pounce arms of the bash driver (the plain one and the
`POUNCE_EXTRA_ARR` one) and the pounce call in the Clarabel
comparison.

Ipopt's `-AMPL` protocol has no equivalent opt-out, so that arm still
writes a `.sol`. It is the saved reference and reruns rarely, so it is
left alone rather than worked around.

## Verification

Checked against the CLI rather than assumed, on a scratch copy of
`AUG2D.nl` so nothing touched the real data directory:

| invocation | exit | `.sol` |
|---|---|---|
| `pounce AUG2D.nl` | 0 | **`AUG2D.sol` written** |
| `pounce AUG2D.nl --no-sol` | 0 | none |
| `pounce AUG2D.nl --no-sol solver_selection=nlp` | 0 | none |

The third covers the `POUNCE_EXTRA_ARR` branch, where `--no-sol` is
followed by pass-through arguments. `bash -n` and an `ast.parse` cover
the two files for syntax.

Results are unaffected — this removes a write, not a read. The
`qp_convex` NLP sweep that motivated it (137/138) reproduced unchanged
with the flag in place.

## Note

`benchmarks/scripts/adversarial_convex.py` has the same one-line change
applied locally, but it is gitignored, so it is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
