### PR TITLE
Add container images for POUNCE (#449)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,63 @@
+# Docker build context filter for docker/Dockerfile (the source build).
+#
+# ALLOWLIST, not a deny-list, and deliberately so: a full POUNCE working tree
+# is tens of gigabytes (target/ alone is ~40G after a few builds, plus
+# benchmarks/ problem corpora and local research scratch). A deny-list would
+# ship all of that to the daemon the first time someone added a directory
+# without updating this file. Excluding everything and naming what the build
+# actually needs fails safe — a new directory is ignored until someone opts
+# it in here.
+#
+# Two entries are load-bearing beyond mere size:
+#
+#   .cargo/config.toml — gitignored and machine-specific: it hard-codes a
+#     local COINHSL_DIR and a macOS rpath. If it reached the build context,
+#     pounce-hsl/build.rs would assert on a $COINHSL_DIR/lib that does not
+#     exist in the image and the build would fail. The leading `*` covers it
+#     (dotfiles included) and nothing re-adds it.
+#
+#   .git — excluded for size (~90M). crates/pounce-cli/build.rs stamps the
+#     commit SHA into `pounce --about` by shelling out to git, so without
+#     .git it would read "unknown". The Dockerfile passes the SHA in as a
+#     POUNCE_BUILD_GIT build arg instead; see docker/README.md.
+
+# Ignore everything, then re-add what the build reads.
+*
+
+# --- Rust workspace -------------------------------------------------------
+!Cargo.toml
+!Cargo.lock
+!crates
+!tools
+
+# --- Python packages (wheel built by maturin in the builder stage) --------
+!python
+!pyomo-pounce
+
+# --- Referenced by the manifests -----------------------------------------
+# python/pyproject.toml and pyomo-pounce/pyproject.toml both set
+# `readme = "README.md"`; those live inside the directories above. LICENSE is
+# copied into the runtime image so the shipped image carries its own terms.
+!LICENSE
+!README.md
+
+# --- Re-exclude build output that lives under the paths re-added above ----
+# `cargo build` in a checkout leaves target/ inside the workspace, and a local
+# `maturin develop` leaves an in-place extension module plus a staged CLI
+# binary under python/pounce/. All are host artifacts: shipping them into the
+# context is wasted transfer at best, and a stale host-arch .so shadowing the
+# freshly built one at worst.
+**/target
+python/.venv
+python/build
+python/dist
+python/.pytest_cache
+python/pounce/bin
+python/pounce/_pounce*.so
+python/pounce/_pounce*.pyd
+pyomo-pounce/build
+pyomo-pounce/*.egg-info
+python/*.egg-info
+**/__pycache__
+**/*.pyc
+**/.DS_Store

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -1,0 +1,391 @@
+# Publish the POUNCE container images to the GitHub Container Registry.
+#
+# One package, ghcr.io/<owner>/pounce, holding two kinds of image built from
+# the two Dockerfiles in docker/ (see docker/README.md):
+#
+#   docker/Dockerfile.release -> :X.Y.Z, :X.Y, :latest
+#       pip-installs the published pounce-solver / pyomo-pounce wheels. This
+#       is what a user gets from `docker pull ghcr.io/<owner>/pounce`.
+#   docker/Dockerfile         -> :edge, :sha-<short>
+#       compiles the tree at that commit. For reproducing a bug on an
+#       unreleased fix; :edge always means "tip of main", never a release.
+#
+# Triggers:
+#   - push of a `v*` tag -> both images, linux/amd64 + linux/arm64. This is
+#     the same marker tag release-crates keys off, so cutting a release ships
+#     crates.io, PyPI, and the images together.
+#   - push to main -> the source image only, as :edge and :sha-<short>. The
+#     release image is unchanged between releases, so rebuilding it here
+#     would only churn the registry.
+#   - pull_request touching docker/** -> build both, push neither. A
+#     Dockerfile that no longer builds is the failure mode this guards; it
+#     is invisible until the next release otherwise.
+#   - workflow_dispatch -> manual run, DEFAULTS TO A DRY RUN (builds, pushes
+#     nothing). Set dry_run=false to publish. Use this to re-cut the release
+#     image if the PyPI wait below timed out on the tag push.
+#
+# ORDERING GOTCHA: the release image installs from PyPI, but a `v*` tag does
+# not itself publish to PyPI — `python-v*` does (release-pounce.yml). Push
+# `python-v*` first, or accept that this workflow waits. The
+# "Wait for PyPI" step below polls for up to ~20 minutes so the usual
+# push-both-tags-together flow just works; if it times out, nothing is
+# half-published — re-run via workflow_dispatch once the wheels are live.
+#
+# AUTH: GITHUB_TOKEN with packages:write. No secrets to configure.
+#
+# FIRST PUBLISH: a new GHCR package is created PRIVATE. After the first
+# successful push, make it public once by hand under
+# github.com/users/<owner>/packages/container/pounce/settings — otherwise
+# `docker pull` and `apptainer pull docker://...` fail with an auth error
+# for everyone but you, which reads like the image is missing.
+name: release-docker
+
+on:
+  push:
+    tags: ["v*"]
+    branches: [main]
+  pull_request:
+    paths:
+      - "docker/**"
+      - ".dockerignore"
+      - ".github/workflows/release-docker.yml"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (build only, no push)"
+        type: boolean
+        default: true
+      variant:
+        description: "Which image(s) to build"
+        type: choice
+        options: [both, release, source]
+        default: both
+      version:
+        description: "Version for the release image (default: Cargo.toml)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+# Serialize per ref. Superseded PR builds are worth cancelling; a tag push
+# that is mid-publish is not.
+concurrency:
+  group: release-docker-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/pounce
+
+jobs:
+  # Resolve once, in one place, what the rest of the run does: which images,
+  # which version, and whether anything gets pushed. Every downstream `if:`
+  # reads these outputs rather than re-deriving the same event logic.
+  plan:
+    name: plan
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.plan.outputs.version }}
+      push: ${{ steps.plan.outputs.push }}
+      build_release: ${{ steps.plan.outputs.build_release }}
+      build_source: ${{ steps.plan.outputs.build_source }}
+    steps:
+      - uses: actions/checkout@v5
+
+      # Tag-vs-manifest guard (M38), same as release-crates. A `v0.10.0` tag
+      # with the workspace still at 0.9.0 would build and publish an image
+      # labelled 0.10.0 containing 0.9.0 wheels.
+      - name: Verify tag matches manifest version
+        if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          GITHUB_REF: ${{ github.ref }}
+        run: python3 scripts/check_tag_version.py "$GITHUB_REF"
+
+      - name: Resolve build plan
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          REF: ${{ github.ref }}
+          DRY_RUN_INPUT: ${{ inputs.dry_run }}
+          VARIANT_INPUT: ${{ inputs.variant }}
+          VERSION_INPUT: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          # The workspace version is the single source of truth for the image
+          # tag; scripts/check-release-consistency.sh already guarantees the
+          # two PyPI manifests agree with it.
+          version="${VERSION_INPUT:-}"
+          if [ -z "$version" ]; then
+            version="$(grep -m1 -E '^version[[:space:]]*=' Cargo.toml \
+              | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')"
+          fi
+
+          is_tag=false
+          case "$REF" in refs/tags/v*) is_tag=true ;; esac
+
+          push=true
+          build_release=true
+          build_source=true
+
+          case "$EVENT_NAME" in
+            pull_request)
+              # Rot guard only — prove both still build, publish nothing.
+              push=false
+              ;;
+            push)
+              if [ "$is_tag" = true ]; then
+                : # release: both images, both pushed
+              else
+                # main: :edge tracks the tip; the release image is unchanged.
+                build_release=false
+              fi
+              ;;
+            workflow_dispatch)
+              # Full `if`, not `[ ... ] && push=false`: under `set -e` the
+              # && list returns 1 when the test is false and kills the step.
+              if [ "$DRY_RUN_INPUT" = "true" ]; then push=false; fi
+              case "$VARIANT_INPUT" in
+                release) build_source=false ;;
+                source)  build_release=false ;;
+              esac
+              ;;
+          esac
+
+          {
+            echo "version=$version"
+            echo "push=$push"
+            echo "build_release=$build_release"
+            echo "build_source=$build_source"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "::notice::version=$version push=$push release=$build_release source=$build_source"
+
+  # One job per (image, architecture). Both arches build natively — arm64 on
+  # a real arm runner rather than QEMU, which for the source image is the
+  # difference between minutes and most of an hour of emulated rustc.
+  #
+  # Each pushes an untagged, by-digest image; the merge job below assembles
+  # the digests into one multi-arch tag. Tagging here instead would have the
+  # two arches race to overwrite each other's tag.
+  build:
+    name: build ${{ matrix.image }} (${{ matrix.platform }})
+    needs: plan
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      # Enumerated rather than image × arch with `include:` overlays. The
+      # overlay form silently mis-expands here: an include entry naming only
+      # keys absent from the base matrix is merged into EVERY combination, so
+      # the two platform overlays would fight and every job would end up on
+      # whichever arch was listed last.
+      matrix:
+        include:
+          - image: release
+            dockerfile: docker/Dockerfile.release
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - image: release
+            dockerfile: docker/Dockerfile.release
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - image: source
+            dockerfile: docker/Dockerfile
+            platform: linux/amd64
+            arch: amd64
+            runner: ubuntu-latest
+          - image: source
+            dockerfile: docker/Dockerfile
+            platform: linux/arm64
+            arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v5
+
+      # Skipping via `if:` on every step rather than on the job: a matrix
+      # cannot be filtered by a needs output, and a skipped job would still
+      # need its own merge-side special casing.
+      - name: Should this combination run?
+        id: gate
+        env:
+          BUILD_RELEASE: ${{ needs.plan.outputs.build_release }}
+          BUILD_SOURCE: ${{ needs.plan.outputs.build_source }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          if [ "$IMAGE" = "release" ]; then run="$BUILD_RELEASE"; else run="$BUILD_SOURCE"; fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        if: steps.gate.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ghcr.io
+        if: steps.gate.outputs.run == 'true' && needs.plan.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # The release image pip-installs from PyPI, so it cannot be built until
+      # release-pounce.yml has actually uploaded the wheels for this version.
+      # Poll rather than fail: on a normal release both tags are pushed within
+      # seconds of each other and the wheel build takes a while.
+      - name: Wait for PyPI
+        if: steps.gate.outputs.run == 'true' && matrix.image == 'release'
+        env:
+          VERSION: ${{ needs.plan.outputs.version }}
+        run: |
+          set -euo pipefail
+          for pkg in pounce-solver pyomo-pounce; do
+            echo "Waiting for ${pkg}==${VERSION} on PyPI..."
+            for attempt in $(seq 1 40); do
+              code="$(curl -sS -o /dev/null -w '%{http_code}' \
+                "https://pypi.org/pypi/${pkg}/${VERSION}/json" || echo 000)"
+              if [ "$code" = "200" ]; then
+                echo "  found after ${attempt} attempt(s)"
+                break
+              fi
+              if [ "$attempt" = "40" ]; then
+                echo "::error::${pkg}==${VERSION} is not on PyPI after ~20 min. Push the python-v${VERSION} / pyomo-pounce-v${VERSION} tags, then re-run this workflow via workflow_dispatch with dry_run=false." >&2
+                exit 1
+              fi
+              sleep 30
+            done
+          done
+
+      - name: Build${{ needs.plan.outputs.push == 'true' && ' and push' || '' }}
+        id: build
+        if: steps.gate.outputs.run == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          build-args: |
+            POUNCE_VERSION=${{ needs.plan.outputs.version }}
+            POUNCE_BUILD_GIT=${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}-${{ matrix.arch }}
+          # push-by-digest leaves the image untagged; the merge job names it.
+          # On a dry run this whole expression collapses to a plain local
+          # build with no registry write.
+          outputs: ${{ needs.plan.outputs.push == 'true' && format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) || 'type=cacheonly' }}
+
+      - name: Export digest
+        if: steps.gate.outputs.run == 'true' && needs.plan.outputs.push == 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/digests
+          # Filename is the digest hex; contents are irrelevant. The merge job
+          # reconstructs `image@sha256:<name>` from the filenames alone.
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        if: steps.gate.outputs.run == 'true' && needs.plan.outputs.push == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.image }}-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Assemble each image's per-arch digests into one multi-arch manifest list
+  # and attach the human-facing tags. This is the step that makes
+  # `docker pull ghcr.io/<owner>/pounce` resolve to the right architecture.
+  merge:
+    name: tag ${{ matrix.image }}
+    needs: [plan, build]
+    if: needs.plan.outputs.push == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [release, source]
+    steps:
+      - name: Should this image be tagged?
+        id: gate
+        env:
+          BUILD_RELEASE: ${{ needs.plan.outputs.build_release }}
+          BUILD_SOURCE: ${{ needs.plan.outputs.build_source }}
+          IMAGE: ${{ matrix.image }}
+        run: |
+          set -euo pipefail
+          if [ "$IMAGE" = "release" ]; then run="$BUILD_RELEASE"; else run="$BUILD_SOURCE"; fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
+      - name: Download digests
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digests-${{ matrix.image }}-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Log in to ghcr.io
+        if: steps.gate.outputs.run == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Buildx
+        if: steps.gate.outputs.run == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create manifest list and tag
+        if: steps.gate.outputs.run == 'true'
+        env:
+          IMAGE: ${{ matrix.image }}
+          VERSION: ${{ needs.plan.outputs.version }}
+          REPO: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          tags=()
+          if [ "$IMAGE" = "release" ]; then
+            # X.Y.Z is immutable; X.Y and latest float forward. No `X` tag —
+            # pre-1.0, a bare `0` would span breaking changes.
+            tags+=("$VERSION" "${VERSION%.*}" "latest")
+          else
+            # sha-<short> pins an exact commit for a bug report; edge floats
+            # with main. Never `latest` — that must mean "released".
+            tags+=("edge" "sha-${SHA:0:8}")
+          fi
+
+          args=()
+          for t in "${tags[@]}"; do
+            args+=(--tag "${REPO}:${t}")
+          done
+
+          # Rebuild `repo@sha256:...` from the uploaded digest filenames.
+          srcs=()
+          for f in /tmp/digests/*; do
+            srcs+=("${REPO}@sha256:$(basename "$f")")
+          done
+          if [ "${#srcs[@]}" -eq 0 ]; then
+            echo "::error::no digests found for the ${IMAGE} image" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${args[@]}" "${srcs[@]}"
+
+          for t in "${tags[@]}"; do
+            echo "::notice::published ${REPO}:${t}"
+            docker buildx imagetools inspect "${REPO}:${t}" | head -20
+          done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,42 @@ changes.
   pre-existing wheel smoke test could not have caught this: it ran on the
   same host that built the binary, the one platform where the floor is
   invisible.
+### Added — container images (#449)
+
+- Two Dockerfiles under `docker/`, both producing the same three
+  interfaces (the `pounce` CLI, `import pounce`, and Pyomo's
+  `SolverFactory('pounce')`) so a job script written against one runs
+  unchanged on the other. `Dockerfile.release` pip-installs the
+  published wheels for a pinned `X.Y.Z` and builds in seconds;
+  `Dockerfile` compiles the working tree you hand it, for testing an
+  unreleased commit. `make docker` / `make docker-release` build them
+  locally with the version and commit filled in.
+- Published to `ghcr.io/jkitchin/pounce` by
+  `.github/workflows/release-docker.yml`: `:X.Y.Z`, `:X.Y` and
+  `:latest` from the release image on a `v*` tag, `:edge` and
+  `:sha-<short>` from the source image on every push to `main`. Both
+  are multi-arch (linux/amd64 + linux/arm64, each built natively).
+  Primarily aimed at clusters, where Apptainer/Singularity can pull
+  them directly — see the new [Docker & Containers](docs/src/docker.md)
+  page.
+- Each image runs a smoke test as its final build step (a CLI solve,
+  `import pounce`, and a Pyomo plugin lookup), so a build that succeeds
+  is an image that works.
+- Neither image enables the `ma57` feature: CoinHSL is
+  license-restricted and not redistributable. The pure-Rust FERAL
+  backend is the default and needs nothing external.
+- Both images sit on Debian trixie rather than bookworm, which the
+  release image has no choice about *yet*: the wheels published through
+  0.9.0 are tagged `manylinux2014` but bundle a CLI needing glibc 2.39,
+  so `pounce --version` fails outright on bookworm. The build-time smoke
+  test is what surfaced that, and it is fixed in #452 / #456 — but this
+  image installs from PyPI, so the pin stays until a `python-v*` tag
+  rebuilds the wheels, after which it can drop to bookworm or lower.
+- `crates/pounce-cli/build.rs` now honors a `POUNCE_BUILD_GIT`
+  override for the SHA it stamps into `pounce --about`. The source
+  image keeps `.git` out of its build context (~90M the compile never
+  reads), which previously left every such image reporting `unknown`
+  with no way to tell which commit it contained.
 
 ### Fixed — pyomo-pounce: a fixed variable shifted every sensitivity result
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 #   make wasm-serve       # ...and serve it on http://localhost:8000
 #   make install          # install pounce CLI + cinterface cdylib under $(PREFIX)
 #   make uninstall        # remove installed artifacts
+#   make docker           # container image compiled from the current tree
+#   make docker-release   # container image from the published PyPI wheels
 #   make install-mcp      # build studio/mcp + register with Claude Code
 #   make uninstall-mcp    # unregister + remove the studio/mcp venv
 #   make install-skill    # build pounce + pounce-studio, drop SKILL.md into ~/.claude/skills/
@@ -75,7 +77,8 @@ endif
 .PHONY: all build debug test check clippy fmt fmt-check doc book screencast install uninstall clean help \
         install-mcp uninstall-mcp install-skill uninstall-skill pounce-ma57 \
         python-ext python-cli-bin python-test coverage coverage-quick \
-        benchmark benchmark-rerun benchmark-report benchmark-gams wasm wasm-serve
+        benchmark benchmark-rerun benchmark-report benchmark-gams wasm wasm-serve \
+        docker docker-release
 
 all: build
 
@@ -155,6 +158,42 @@ uninstall:
 clean:
 	$(CARGO) clean
 
+# ---- Container images ----------------------------------------------------
+# Both Dockerfiles must be built from the repository root, because the source
+# build's context has to contain Cargo.toml, crates/, python/ and
+# pyomo-pounce/. These targets exist mostly to supply the two build args that
+# are easy to forget by hand; see docker/README.md.
+#
+# The images run their own smoke test as the final build step (CLI solve,
+# import pounce, Pyomo plugin lookup), so a build that succeeds is an image
+# that works — there is no separate `docker-test`.
+DOCKER        ?= docker
+DOCKER_IMAGE  ?= pounce
+# Read straight out of Cargo.toml so the tag cannot drift from the release.
+# scripts/check-release-consistency.sh already guarantees the two PyPI
+# manifests agree with this value.
+POUNCE_VERSION := $(shell grep -m1 -E '^version[[:space:]]*=' Cargo.toml \
+                    | sed -E 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+
+# Compile the current working tree. POUNCE_BUILD_GIT is passed in because
+# .git is deliberately kept out of the build context (see .dockerignore) —
+# without it the image cannot report which commit it came from. Falls back to
+# "unknown" outside a git checkout rather than failing the build.
+docker:
+	$(DOCKER) build -f docker/Dockerfile -t "$(DOCKER_IMAGE):dev" \
+	  --build-arg POUNCE_BUILD_GIT="$$(git rev-parse --short=8 HEAD 2>/dev/null || echo unknown)" \
+	  --build-arg POUNCE_VERSION="$(POUNCE_VERSION)" \
+	  .
+
+# Install the published wheels. No Rust toolchain involved; builds in
+# seconds. Requires $(POUNCE_VERSION) to actually be on PyPI, which it is
+# only after the python-v$(POUNCE_VERSION) tag has been released.
+docker-release:
+	$(DOCKER) build -f docker/Dockerfile.release \
+	  -t "$(DOCKER_IMAGE):$(POUNCE_VERSION)" \
+	  --build-arg POUNCE_VERSION="$(POUNCE_VERSION)" \
+	  .
+
 # Build pounce-cli with the HSL MA57 backend enabled and emit the
 # binary as `pounce-ma57` so it sits alongside the default `pounce`.
 # Requires libcoinhsl discoverable to the linker.
@@ -169,7 +208,7 @@ pounce-ma57:
 	@echo "to invoke it as just 'pounce-ma57'."
 
 help:
-	@sed -n 's/^# \{0,1\}//p' Makefile | sed -n '1,45p'
+	@sed -n 's/^# \{0,1\}//p' Makefile | sed -n '1,48p'
 
 # ---- Python extension + tests -------------------------------------------
 # Rebuild the native extension in place, then run the Python test suite.

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ This drops the `pounce` binary into `$PREFIX/bin` and the
 `libpounce_cinterface` shared library into `$PREFIX/lib`. Make sure
 `$HOME/.local/bin` is on your `PATH`.
 
+### Container image
+
+No toolchain, no `pip install` — useful on a cluster, where you often
+cannot install one anyway. The image carries the CLI, the Python API,
+and the Pyomo plugin:
+
+```sh
+docker run --rm -v "$PWD:/work" ghcr.io/jkitchin/pounce:latest problem.nl
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.9.0
+```
+
+`make docker` builds the same image from your working tree instead. See
+[docs/src/docker.md](docs/src/docker.md).
+
 ## Usage
 
 Solve an AMPL `.nl` file:

--- a/crates/pounce-cli/build.rs
+++ b/crates/pounce-cli/build.rs
@@ -11,17 +11,30 @@ fn main() {
     // The .git/HEAD path is relative to this crate's manifest dir.
     println!("cargo:rerun-if-changed=../../.git/HEAD");
     println!("cargo:rerun-if-changed=../../.git/index");
+    println!("cargo:rerun-if-env-changed=POUNCE_BUILD_GIT");
     println!("cargo:rerun-if-env-changed=PROFILE");
     println!("cargo:rerun-if-env-changed=TARGET");
     println!("cargo:rerun-if-env-changed=HOST");
     println!("cargo:rerun-if-env-changed=SOURCE_DATE_EPOCH");
 
-    let git_sha =
-        run("git", &["rev-parse", "--short=8", "HEAD"]).unwrap_or_else(|| "unknown".into());
-    let dirty = run("git", &["status", "--porcelain"])
-        .map(|s| if s.is_empty() { "" } else { "+dirty" })
-        .unwrap_or("");
-    let git = format!("{git_sha}{dirty}");
+    // POUNCE_BUILD_GIT lets a caller supply the revision when git itself is
+    // not reachable from the build. The Docker source build is the motivating
+    // case: .git is kept out of the build context (~90M of history the
+    // compile does not need), so without the override every image would
+    // report "unknown" and you could not tell which commit you were running.
+    // Same escape hatch as SOURCE_DATE_EPOCH below — an explicit value wins,
+    // otherwise fall back to interrogating git.
+    let git = std::env::var("POUNCE_BUILD_GIT")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| {
+            let git_sha =
+                run("git", &["rev-parse", "--short=8", "HEAD"]).unwrap_or_else(|| "unknown".into());
+            let dirty = run("git", &["status", "--porcelain"])
+                .map(|s| if s.is_empty() { "" } else { "+dirty" })
+                .unwrap_or("");
+            format!("{git_sha}{dirty}")
+        });
 
     // UTC ISO-8601 timestamp. Honor SOURCE_DATE_EPOCH for reproducible
     // builds; otherwise fall back to `date -u` at compile time.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,165 @@
+# syntax=docker/dockerfile:1
+#
+# POUNCE — source build. Compiles the working tree you hand it, so this is
+# the image for "the current commit": a PR branch, an unreleased fix, a
+# bisect. For a released version use docker/Dockerfile.release, which pulls
+# prebuilt wheels from PyPI in seconds instead of compiling for minutes.
+#
+# Build from the REPOSITORY ROOT (the context must include Cargo.toml,
+# crates/, python/ and pyomo-pounce/ — see .dockerignore):
+#
+#   docker build -f docker/Dockerfile -t pounce:dev \
+#     --build-arg POUNCE_BUILD_GIT="$(git rev-parse --short=8 HEAD)" .
+#
+# or just `make docker`, which fills in the SHA for you.
+#
+# The image carries both interfaces, because on a cluster you rarely know in
+# advance which one a job will want:
+#   * the `pounce` CLI (plus `pounce_sens` and `pounce_cblib`) on PATH
+#   * `import pounce` — the Python API, with numpy/scipy
+#   * `pyomo-pounce` — SolverFactory('pounce') from a Pyomo model
+#
+# NOT built with `--features ma57`: CoinHSL is license-restricted and cannot
+# be redistributed in an image. The pure-Rust FERAL backend is the default
+# and needs no external libraries.
+
+# Any toolchain new enough for edition 2024 / resolver 3 (>= 1.85) works;
+# pinned rather than floating so an image rebuilt months from now compiles
+# the same way. CI builds on `stable`, so bumping this is safe and routine.
+ARG RUST_VERSION=1.96
+# abi3-py39 means the extension module works on any newer CPython, so the
+# runtime Python version is a free choice; it is not tied to the builder's.
+ARG PYTHON_VERSION=3.12
+# Used for BOTH stages, and they must stay in step: the runtime's glibc has
+# to be at least the builder's or the binaries it copies will not start.
+# Nothing external forces the choice here — this image compiles everything it
+# runs — but it matches docker/Dockerfile.release, which does not have that
+# freedom (see the note there). One base, one story.
+ARG DEBIAN_RELEASE=trixie
+
+# ---------------------------------------------------------------------------
+# Stage 1 — compile the CLI and build the pounce-solver wheel.
+# ---------------------------------------------------------------------------
+FROM rust:${RUST_VERSION}-${DEBIAN_RELEASE} AS builder
+
+# Redeclared: ARGs before the first FROM are outside every build stage.
+ARG DEBIAN_RELEASE
+
+# Stamped into `pounce --about` so an image can name the commit it came from.
+# .git is deliberately not in the build context (see .dockerignore), so the
+# value has to be passed in; it reads "unknown" if you omit it, which is
+# honest but unhelpful when someone hands you a container and asks what is in
+# it. crates/pounce-cli/build.rs consumes this env var directly.
+ARG POUNCE_BUILD_GIT=unknown
+
+# Note on SOURCE_DATE_EPOCH: build.rs honors it for a reproducible build
+# timestamp, but do NOT plumb it through as an ARG here. An ARG with no
+# default exports as the empty string, and cargo-cyclonedx (pulled in by
+# maturin) parses the variable unconditionally — an empty value panics the
+# wheel build with "Invalid reproducible build timestamp: ParseIntError".
+# Set it in the environment for a specific build if you need it.
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# maturin needs a Python interpreter and headers to build the extension.
+# python3-venv gets us a writable environment to pip-install maturin into
+# without fighting Debian's PEP 668 externally-managed marker.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        python3 python3-dev python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/build-venv
+ENV PATH="/opt/build-venv/bin:${PATH}"
+RUN pip install --no-cache-dir "maturin>=1.4,<2.0"
+
+# Must be set before the compile, not after: build.rs reads it at compile
+# time and bakes the result into the binary with cargo:rustc-env.
+ENV POUNCE_BUILD_GIT=${POUNCE_BUILD_GIT}
+
+WORKDIR /src
+COPY . .
+
+# One RUN for the whole compile. The cache mounts make an incremental local
+# rebuild cheap, but their contents do NOT survive into the next layer — so
+# every artifact the runtime stage needs must be copied out of /src/target
+# to /out before this command ends. Splitting this into several RUN steps
+# would silently produce an image with no binaries in it.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,target=/src/target,sharing=locked \
+    set -eux; \
+    cargo build --release --locked \
+        --bin pounce --bin pounce_sens --bin pounce_cblib; \
+    mkdir -p /out/bin; \
+    # Only the two auxiliary binaries. `pounce` itself is deliberately NOT
+    # staged here: the wheel installs a console script of the same name into
+    # the same directory, so pip would overwrite whatever we put there and
+    # the copy would be a silent no-op. Letting the wheel own it also makes
+    # this image byte-for-byte equivalent to the release image in how the
+    # CLI resolves — the shim os.execv's straight into the bundled binary,
+    # so signals and exit codes are unaffected.
+    cp target/release/pounce_sens target/release/pounce_cblib /out/bin/; \
+    # The wheel ships the CLI inside the package (python/pounce/_cli.py execs
+    # it), and maturin only builds the extension module — nothing stages the
+    # binary on its own. Same step `make python-cli-bin` performs locally.
+    install -d python/pounce/bin; \
+    install -m 0755 target/release/pounce python/pounce/bin/pounce; \
+    # --compatibility linux tags the wheel linux_<arch> rather than running
+    # auditwheel for a manylinux tag. We install it in the very next stage on
+    # the same glibc, so a portable tag buys nothing and auditwheel's vendoring
+    # would only add weight.
+    cd python && maturin build --release --compatibility linux --out /out/wheels
+
+# ---------------------------------------------------------------------------
+# Stage 2 — runtime. No Rust toolchain, no build deps.
+# ---------------------------------------------------------------------------
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_RELEASE} AS runtime
+
+ARG POUNCE_BUILD_GIT=unknown
+ARG POUNCE_VERSION=dev
+
+LABEL org.opencontainers.image.title="POUNCE" \
+      org.opencontainers.image.description="Interior-point optimization solver (CLI + Python + Pyomo), built from source" \
+      org.opencontainers.image.source="https://github.com/jkitchin/pounce" \
+      org.opencontainers.image.documentation="https://jkitchin.github.io/pounce/" \
+      org.opencontainers.image.licenses="EPL-2.0" \
+      org.opencontainers.image.revision="${POUNCE_BUILD_GIT}" \
+      org.opencontainers.image.version="${POUNCE_VERSION}"
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY --from=builder /out/bin/ /usr/local/bin/
+COPY --from=builder /out/wheels/ /tmp/wheels/
+COPY --from=builder /src/pyomo-pounce/ /tmp/pyomo-pounce/
+COPY --from=builder /src/LICENSE /usr/share/doc/pounce/LICENSE
+
+# pyomo-pounce declares `pounce-solver>=X`, which pip would otherwise satisfy
+# from PyPI — quietly replacing the wheel we just compiled with a released
+# one. Installing both in a single resolve with the local wheel present lets
+# it satisfy that requirement without reaching for the network.
+RUN set -eux; \
+    pip install --no-cache-dir /tmp/wheels/*.whl /tmp/pyomo-pounce; \
+    rm -rf /tmp/wheels /tmp/pyomo-pounce
+
+# Non-root by default. Apptainer/Singularity on a cluster runs as the calling
+# user regardless, but under plain `docker run` this keeps output files in a
+# bind-mounted /work from landing root-owned on the host.
+RUN useradd --create-home --uid 1000 pounce \
+    && mkdir -p /work \
+    && chown pounce:pounce /work
+USER pounce
+WORKDIR /work
+
+# Fail the build rather than ship a broken image. Covers all three surfaces:
+# the CLI can solve (--problem needs no input file), the extension module
+# imports, and the Pyomo plugin is registered and finds the executable.
+RUN set -eux; \
+    pounce --version; \
+    pounce --problem rosenbrock --no-sol >/dev/null; \
+    python -c "import pounce; print('pounce', pounce.__version__)"; \
+    python -c "import pyomo.environ as pyo; assert pyo.SolverFactory('pounce').available(exception_flag=False)"
+
+ENTRYPOINT ["pounce"]
+CMD ["--help"]

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,0 +1,97 @@
+# syntax=docker/dockerfile:1
+#
+# POUNCE — released version. Installs the published wheels from PyPI; no
+# Rust toolchain, no compile, builds in well under a minute. This is the
+# image to use unless you specifically need an unreleased commit, in which
+# case see docker/Dockerfile.
+#
+# The build context is irrelevant here (nothing is COPYed in), so it can be
+# built from anywhere — including straight off GitHub without a clone:
+#
+#   docker build -f docker/Dockerfile.release -t pounce:0.9.0 \
+#     --build-arg POUNCE_VERSION=0.9.0 .
+#
+# or `make docker-release`, which reads the version out of Cargo.toml.
+#
+# Same surface as the source image, so a job script written against one runs
+# unchanged on the other:
+#   * the `pounce` CLI on PATH (bundled inside the pounce-solver wheel)
+#   * `import pounce` — the Python API, with numpy/scipy
+#   * `pyomo-pounce` — SolverFactory('pounce') from a Pyomo model
+#
+# The published wheels are built without `--features ma57`: CoinHSL is
+# license-restricted and cannot be redistributed. The pure-Rust FERAL
+# backend is the default and needs no external libraries.
+
+ARG PYTHON_VERSION=3.12
+# trixie (glibc 2.41), not bookworm (2.36), and not by preference — the
+# ALREADY-PUBLISHED wheels force it, and only until the next release.
+#
+# #452: through 0.9.0, the Linux wheels were tagged manylinux2014 (glibc
+# 2.17) but bundled a `pounce` CLI built on the release runner's host
+# (Ubuntu 24.04, glibc 2.39) rather than inside the manylinux container. The
+# wheel advertised far more compatibility than its binary had:
+#
+#   pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6:
+#     version `GLIBC_2.39' not found
+#
+# on bookworm, on both amd64 and arm64.
+#
+# That is FIXED in main (#456) — the CLI is now built in the container and
+# CI asserts the floor stays within manylinux2014 — but the fix reaches PyPI
+# only when a `python-v*` tag rebuilds the wheels. This image installs from
+# PyPI, so until that release it must run on glibc >= 2.39.
+#
+# WHEN THE NEXT RELEASE SHIPS: drop this to bookworm (or lower — the floor
+# is now 2.16) and delete this comment. `scripts/check-cli-portability.sh`
+# in CI is what keeps that safe.
+ARG DEBIAN_RELEASE=trixie
+
+FROM python:${PYTHON_VERSION}-slim-${DEBIAN_RELEASE}
+
+# Keep in step with the release being built. All three POUNCE distributions
+# share one X.Y.Z (scripts/check-release-consistency.sh enforces that), so a
+# single arg pins both wheels. Pinned rather than floating on purpose: an
+# image tagged 0.9.0 should contain 0.9.0 forever, not whatever was newest
+# the day it was rebuilt.
+ARG POUNCE_VERSION=0.9.0
+
+LABEL org.opencontainers.image.title="POUNCE" \
+      org.opencontainers.image.description="Interior-point optimization solver (CLI + Python + Pyomo), released build from PyPI" \
+      org.opencontainers.image.source="https://github.com/jkitchin/pounce" \
+      org.opencontainers.image.documentation="https://jkitchin.github.io/pounce/" \
+      org.opencontainers.image.licenses="EPL-2.0" \
+      org.opencontainers.image.version="${POUNCE_VERSION}"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+# --only-binary=:all: is deliberate. pounce-solver has no usable sdist path
+# in a toolchain-free image — a fallback to source would try to compile Rust
+# that is not installed and fail with a confusing error deep in maturin.
+# Failing at resolution with "no matching distribution" instead names the
+# real problem: no wheel for this platform/version.
+RUN pip install --no-cache-dir --only-binary=:all: \
+        "pounce-solver==${POUNCE_VERSION}" \
+        "pyomo-pounce==${POUNCE_VERSION}"
+
+# Non-root by default. Apptainer/Singularity on a cluster runs as the calling
+# user regardless, but under plain `docker run` this keeps output files in a
+# bind-mounted /work from landing root-owned on the host.
+RUN useradd --create-home --uid 1000 pounce \
+    && mkdir -p /work \
+    && chown pounce:pounce /work
+USER pounce
+WORKDIR /work
+
+# Fail the build rather than ship a broken image. Covers all three surfaces:
+# the CLI can solve (--problem needs no input file), the extension module
+# imports, and the Pyomo plugin is registered and finds the executable.
+RUN set -eux; \
+    pounce --version; \
+    pounce --problem rosenbrock --no-sol >/dev/null; \
+    python -c "import pounce; print('pounce', pounce.__version__)"; \
+    python -c "import pyomo.environ as pyo; assert pyo.SolverFactory('pounce').available(exception_flag=False)"
+
+ENTRYPOINT ["pounce"]
+CMD ["--help"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,113 @@
+# POUNCE container images
+
+Two Dockerfiles, one published image. Both produce the same three
+interfaces — the `pounce` CLI, `import pounce`, and Pyomo's
+`SolverFactory('pounce')` — so a job script written against one runs
+unchanged on the other. They differ only in where the solver comes from.
+
+| File | Solver comes from | Build time | Published as |
+|---|---|---|---|
+| `Dockerfile.release` | PyPI wheels, pinned to `X.Y.Z` | seconds | `:X.Y.Z`, `:X.Y`, `:latest` |
+| `Dockerfile` | compiled from the tree you hand it | minutes | `:edge`, `:sha-<short>` |
+
+User-facing documentation lives in [`docs/src/docker.md`](../docs/src/docker.md)
+— pull commands, Apptainer/Singularity usage, bind mounts. This file covers
+the build side.
+
+## Building locally
+
+Both must be built **from the repository root**, because the source build's
+context has to contain `Cargo.toml`, `crates/`, `python/`, and
+`pyomo-pounce/`. The Makefile targets fill in the version and commit for you:
+
+```sh
+make docker          # source build -> pounce:dev
+make docker-release  # released build -> pounce:<version from Cargo.toml>
+```
+
+The equivalents by hand:
+
+```sh
+docker build -f docker/Dockerfile -t pounce:dev \
+  --build-arg POUNCE_BUILD_GIT="$(git rev-parse --short=8 HEAD)" .
+
+docker build -f docker/Dockerfile.release -t pounce:0.9.0 \
+  --build-arg POUNCE_VERSION=0.9.0 .
+```
+
+Each image runs its own smoke test as the final build step — CLI solve,
+`import pounce`, Pyomo plugin lookup — so a build that succeeds is an image
+that works. There is no separate test to run.
+
+## Things that will bite you
+
+**The `.dockerignore` is an allowlist.** A full POUNCE working tree is tens
+of gigabytes (`target/` alone reaches ~40G), so the root `.dockerignore`
+excludes everything and re-adds the handful of paths the build reads. **If
+you add a new top-level directory the build needs, you must re-add it
+there** — otherwise it is silently absent from the context and the build
+fails with a missing-file error that points nowhere near the cause.
+
+Two of its entries are load-bearing beyond size:
+
+- `.cargo/config.toml` is gitignored and machine-specific — it hard-codes a
+  local `COINHSL_DIR`. In the context it would make `pounce-hsl/build.rs`
+  assert on a path that does not exist in the image.
+- `.git` is excluded for size (~90M of history the compile does not read).
+  That is why the commit SHA is passed in as `POUNCE_BUILD_GIT` instead:
+  `crates/pounce-cli/build.rs` normally shells out to `git` to stamp
+  `pounce --about`, and without either the SHA *or* the build arg an image
+  cannot say which commit it contains.
+
+**The source build's artifacts must be copied out inside the compiling
+`RUN`.** It uses `--mount=type=cache` for the cargo registry and `target/`,
+and cache-mount contents do not survive into the next layer. Splitting that
+step in two produces an image with no binaries in it and no error to explain
+why.
+
+**Both images are based on Debian trixie, and the release image has no
+choice.** The published Linux wheels are tagged `manylinux2014` (glibc 2.17)
+but bundle a `pounce` CLI built on the release runner's host — Ubuntu 24.04,
+glibc 2.39 — because `release-pounce.yml` runs `cargo build` outside the
+manylinux container that maturin builds the extension module in. On bookworm
+(glibc 2.36) the smoke test fails outright:
+
+```
+pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
+```
+
+on both amd64 and arm64 — a bug in the wheels, not in the image, and one that
+also broke `pip install pounce-solver` on most HPC distributions.
+
+That is **fixed in main** (#452 / #456): the CLI is now built inside the
+manylinux container and `scripts/check-cli-portability.sh` fails CI if its
+glibc floor ever exceeds the wheel's manylinux tag. But this image installs
+from PyPI, and the fix only lands there when a `python-v*` tag rebuilds the
+wheels. **Once the next release ships, drop `DEBIAN_RELEASE` to bookworm or
+lower** — the floor is now 2.16 — and delete the note in
+`Dockerfile.release`. The source image is self-contained and does not care;
+it tracks the release image only so there is one base to reason about.
+
+**Neither image enables `--features ma57`.** CoinHSL is license-restricted
+and cannot be redistributed. The pure-Rust FERAL backend is the default and
+needs no external libraries; `linear_solver=ma57` in a container will not
+work.
+
+## Publishing
+
+`.github/workflows/release-docker.yml` pushes both images to
+`ghcr.io/jkitchin/pounce`. Read the header comment there for the trigger
+matrix; two points matter when cutting a release:
+
+1. **Tag order.** The release image installs from PyPI, but the `v*` tag
+   this workflow fires on does not publish to PyPI — `python-v*` does. Push
+   the `python-v*` and `pyomo-pounce-v*` tags at or before `v*`. The
+   workflow polls PyPI for ~20 minutes to absorb the normal lag; if it times
+   out, nothing is half-published — re-run it from the Actions tab with
+   `dry_run=false` once the wheels are live.
+
+2. **First publish is private.** A newly created GHCR package defaults to
+   private. After the first successful push, make it public once by hand
+   under *Packages → pounce → Package settings*. Until then every
+   `docker pull` and `apptainer pull` from anyone but you fails with an auth
+   error that reads like the image does not exist.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,6 +5,7 @@
 # Getting Started
 
 - [Installation](installation.md)
+- [Docker & Containers](docker.md)
 - [Quick Start](quick-start.md)
 - [Choosing a Solver](choosing-a-solver.md)
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -1,0 +1,144 @@
+# Docker & Containers
+
+Prebuilt images carry the whole POUNCE surface — the `pounce` CLI, the
+Python API, and the Pyomo plugin — with no Rust toolchain and no `pip
+install` on your side. This is the path of least resistance on a cluster,
+where you often cannot install a toolchain anyway, and the quickest way to
+try POUNCE without touching your environment.
+
+```sh
+docker pull ghcr.io/jkitchin/pounce:latest
+docker run --rm ghcr.io/jkitchin/pounce:latest --version
+```
+
+## Which tag
+
+| Tag | Contains | Use it when |
+|---|---|---|
+| `latest` | the newest release | you just want POUNCE |
+| `X.Y.Z` (e.g. `0.9.0`) | exactly that release, forever | reproducibility — papers, cluster job scripts, CI |
+| `X.Y` (e.g. `0.9`) | newest patch of that minor series | you want fixes but not feature changes |
+| `edge` | tip of `main`, compiled from source | testing an unreleased fix |
+| `sha-<short>` | one specific commit | reproducing a bug report against a known commit |
+
+Pin `X.Y.Z` for anything you intend to re-run months later. `latest` and
+`edge` both move under you.
+
+## Running solves
+
+The entrypoint is the `pounce` CLI, so arguments after the image name go
+straight to it:
+
+```sh
+docker run --rm ghcr.io/jkitchin/pounce:latest --list-problems
+docker run --rm ghcr.io/jkitchin/pounce:latest --problem rosenbrock
+```
+
+Your own problems live on the host, so mount a directory. The working
+directory inside the image is `/work`:
+
+```sh
+docker run --rm -v "$PWD:/work" ghcr.io/jkitchin/pounce:latest \
+  problem.nl print_level=5 tol=1e-10
+```
+
+That writes `problem.sol` next to `problem.nl` in the mounted directory —
+see [Running Solves](cli.md) for the full option surface. The image runs as
+UID 1000 rather than root, so files it creates in a bind mount are not
+root-owned on the host. If your host UID differs, add `--user "$(id -u):$(id
+-g)"`.
+
+## Python and Pyomo
+
+Override the entrypoint to get a shell or an interpreter:
+
+```sh
+docker run --rm -it --entrypoint python ghcr.io/jkitchin/pounce:latest
+docker run --rm -it --entrypoint bash -v "$PWD:/work" ghcr.io/jkitchin/pounce:latest
+```
+
+Both `import pounce` (with numpy and scipy) and Pyomo's
+`SolverFactory('pounce')` work out of the box:
+
+```sh
+docker run --rm -v "$PWD:/work" --entrypoint python \
+  ghcr.io/jkitchin/pounce:latest my_model.py
+```
+
+The optional extras are *not* installed — no JAX, no PyTorch, no `plotly`,
+no GAMS bindings. Add what you need in a derived image:
+
+```dockerfile
+FROM ghcr.io/jkitchin/pounce:0.9.0
+USER root
+RUN pip install --no-cache-dir "pounce-solver[jax]==0.9.0"
+USER pounce
+```
+
+## On a cluster (Apptainer / Singularity)
+
+Most HPC sites run Apptainer (formerly Singularity) rather than Docker,
+because it needs no daemon and no root. It pulls Docker images directly:
+
+```sh
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.9.0
+apptainer run pounce.sif problem.nl
+```
+
+Two differences from `docker run` are worth knowing before you write a job
+script:
+
+- **You are yourself.** Apptainer runs the container as your own user, not
+  the image's, so output files land with your ownership and no `--user`
+  flag is needed.
+- **`$HOME` and `$PWD` are already there.** Apptainer bind-mounts them by
+  default, so a `.nl` file in your submit directory is usually visible with
+  no `-B` flag at all. Add `-B /scratch:/scratch` (or your site's
+  equivalent) for anything outside them.
+
+Build the `.sif` once on a login node and reuse it — pulling on every array
+task hammers the registry and will get rate-limited. In a Slurm script:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=pounce
+#SBATCH --cpus-per-task=4
+
+apptainer exec $HOME/images/pounce.sif \
+  pounce $SLURM_SUBMIT_DIR/problem.nl --json-output result.json
+```
+
+Pin the digest rather than the tag if the run has to be reproducible years
+later — a tag can be re-pushed, a digest cannot:
+
+```sh
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce@sha256:<digest>
+```
+
+## Building your own
+
+You do not need the images to be published — both Dockerfiles are in the
+repository and build from a clone. From the repository root:
+
+```sh
+make docker          # compiles the current working tree -> pounce:dev
+make docker-release  # installs the released wheels -> pounce:<version>
+```
+
+`make docker` is the one to reach for when testing a branch: it compiles
+whatever is checked out, and stamps the commit into `pounce --about` so the
+image can say what it contains. `make docker-release` needs no Rust
+toolchain and takes seconds. See [`docker/README.md`](https://github.com/jkitchin/pounce/blob/main/docker/README.md)
+for build arguments and the `.dockerignore` caveat.
+
+## What is not in the image
+
+The **HSL MA57 backend** is absent, and cannot be added by us: CoinHSL is
+license-restricted and not redistributable. Passing `linear_solver=ma57`
+will not work in a container. The pure-Rust FERAL backend is the default
+everywhere and needs no external libraries — see
+[Installation](installation.md#hsl-ma57-backend-optional) if you have a
+CoinHSL license and want a local build with it.
+
+The **GAMS link** is likewise absent, since it needs your own GAMS install
+and license on the host. See [GAMS](gams.md).


### PR DESCRIPTION
Closes #449

Two Dockerfiles under `docker/`, plus a workflow that publishes both to GHCR.

## What you get

Both images carry the same three interfaces — the `pounce` CLI, `import pounce`, and Pyomo's `SolverFactory('pounce')` — so a job script written against one runs unchanged on the other.

| File | Solver comes from | Build time | Published as |
|---|---|---|---|
| `docker/Dockerfile.release` | PyPI wheels, pinned to `X.Y.Z` | ~30s | `:X.Y.Z`, `:X.Y`, `:latest` |
| `docker/Dockerfile` | compiled from the tree you hand it | ~10min cold | `:edge`, `:sha-<short>` |

```sh
docker run --rm -v "$PWD:/work" ghcr.io/jkitchin/pounce:latest problem.nl
apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.9.0
make docker          # build the current working tree instead
make docker-release
```

Both run as UID 1000 with `WORKDIR /work`, so files written into a bind mount are not root-owned on the host. Apptainer runs them as the calling user anyway, which is the cluster case from the issue.

## Verified locally

Not just "it builds" — every image runs a smoke test as its **final build step** (a CLI solve, `import pounce`, a Pyomo plugin lookup), so a build that succeeds is an image that works. Beyond that I ran both end to end on arm64 and the release image on amd64:

- `pounce airport.nl` / `bound_active_qp.nl` through a bind mount, `.sol` written and owned by the host user
- `pounce.minimize` converging to the right answer
- a Pyomo `ConcreteModel` solving to `optimal` with the correct optimum
- `pounce --about` in the source image reporting the actual HEAD commit
- `pounce_sens` and `pounce_cblib` present (the wheel ships neither)

## Found a real bug on the way: #452

The first release-image build failed its own smoke test:

```
pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

The published Linux wheels are tagged `manylinux2014` (glibc 2.17) but bundle a `pounce` CLI built on the release runner's host (Ubuntu 24.04, glibc 2.39) — `release-pounce.yml` runs `cargo build` *outside* the manylinux container maturin builds the extension module in, and auditwheel never inspects the bundled binary. Reproduced on 0.9.0 on **both** amd64 and arm64.

`import pounce` is fine; anything shelling out to the CLI is not — including pyomo-pounce. That breaks `pip install pounce-solver` on Debian 12, Ubuntu 22.04, RHEL 8/9, and most HPC images, which is exactly the audience #449 is about. **This is a pre-existing wheel bug, not something this PR introduces**; filed as #452 with a proposed fix. The workaround here is `DEBIAN_RELEASE=trixie` (glibc 2.41) in both images, commented and cross-referenced so it can drop back down once #452 lands.

## Notes on the design

- **`.dockerignore` is an allowlist**, not a deny-list. A full working tree is tens of gigabytes (`target/` alone ~40G); a deny-list would ship all of it the first time someone added a directory without updating the file. It also *must* exclude `.cargo/config.toml`, which is gitignored and hard-codes a machine-local `COINHSL_DIR` that would make `pounce-hsl/build.rs` assert inside the image.
- **`build.rs` gains a `POUNCE_BUILD_GIT` override.** `.git` stays out of the build context (~90M the compile never reads), which would otherwise leave every source image reporting `commit unknown` — no way to tell what you were handed. Same escape-hatch shape as the existing `SOURCE_DATE_EPOCH` handling. Verified both paths (override honored, git fallback unchanged).
- **`pounce` on PATH is the wheel's console script in both images**, deliberately. pip installs it into the same directory, so a copied binary would be silently overwritten; letting the wheel own it makes the two images resolve the CLI identically. The shim `os.execv`s into the binary, so signals and exit codes are unaffected. Only `pounce_sens` / `pounce_cblib`, which the wheel does not ship, are copied in.
- **Multi-arch, both arches built natively** (`ubuntu-latest` + `ubuntu-24.04-arm`, digest push then manifest merge). arm64 under QEMU would emulate rustc for the better part of an hour; `release-pounce.yml` already moved off QEMU for the same reason.
- **PyPI ordering.** The release image installs from PyPI, but the `v*` tag this workflow fires on does not publish wheels — `python-v*` does. The workflow polls PyPI for ~20 min to absorb the lag, and fails with an actionable message (re-run via `workflow_dispatch`) rather than half-publishing.
- Neither image enables `--features ma57` — CoinHSL is license-restricted and not redistributable.

## After merge, one manual step

A new GHCR package is created **private**. After the first successful push, make `pounce` public once under *Packages → pounce → Package settings*, or every `docker pull` / `apptainer pull` from anyone but you fails with an auth error that reads like the image does not exist. Noted in `docker/README.md` and the workflow header.

## Checks

`actionlint`, `check-docs-consistency.sh`, `check-release-consistency.sh`, `cargo fmt --all --check`, the CI clippy gate on `pounce-cli`, and `cargo test -p pounce-cli --lib` (184 passed) all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
