### PR TITLE
Run POUNCE in the browser: WebAssembly build, drag-and-drop .nl demo, published to Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,30 @@ jobs:
   # sensitivity / path-following APIs) on every PR. The Rust `test` job
   # above covers the solver core, and `wheel-smoke` only imports the
   # package — neither runs pytest, so without this job the entire
+  # Guard the browser build (crates/pounce-wasm, docs/src/wasm.md). The
+  # `test` job type-checks pounce-wasm on the host, which catches neither of
+  # the two ways this surface breaks: a dependency that stops compiling for
+  # wasm32 (a new `libc`/`dlopen`/thread call somewhere in the tree), and one
+  # that compiles but traps at run time on a syscall WASI does not have. The
+  # smoke test drives the same C ABI the page uses — load a `.nl`, solve it,
+  # check the objective — under Node's WASI.
+  wasm:
+    name: WebAssembly build + smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Build the wasm module
+        run: crates/pounce-wasm/build.sh
+      - name: Solve a model in wasm
+        run: node crates/pounce-wasm/tests/smoke.mjs
+
   # Python feature surface lands untested in CI. Builds the wheel the
   # same way wheel-smoke does, then installs the jax + diffrax extras
   # and runs the test suite.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,6 +60,29 @@ jobs:
       - name: Build versioned site
         run: scripts/build-versioned-docs.sh "$GITHUB_WORKSPACE/site"
 
+      # The in-browser solver (docs/src/wasm.md) rides the same Pages
+      # deployment, at <site>/demo/. It is version-independent — one live
+      # demo built from main, not one per archived tag — so it is staged
+      # here rather than inside build-versioned-docs.sh, which wipes and
+      # rebuilds its output directory per version.
+      #
+      # Nothing about it needs special Pages configuration: no threads, so
+      # no SharedArrayBuffer and no COOP/COEP headers (which Pages cannot
+      # set anyway), and every URL the page fetches is relative, so it works
+      # under the /pounce/ base path unchanged.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-wasip1
+      - uses: Swatinem/rust-cache@v2
+      - name: Build the in-browser solver demo
+        run: crates/pounce-wasm/build.sh
+      - name: Stage the demo into the site
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/site/demo"
+          cp -a crates/pounce-wasm/web/. "$GITHUB_WORKSPACE/site/demo/"
+          rm -f "$GITHUB_WORKSPACE/site/demo/.gitignore"
+          test -s "$GITHUB_WORKSPACE/site/demo/pounce.wasm"
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,12 @@ changes.
   from `main`. It needs no Pages configuration — single-threaded, so no
   `SharedArrayBuffer` and no COOP/COEP headers (which Pages cannot set),
   and all URLs are relative so the `/pounce/` base path just works.
-- Numerics are unchanged: across the CLI's `.nl` fixture suite, the wasm
-  build matches the native build's exit status and iteration count on every
-  problem, and its objective to full double precision on all but one
-  degenerate case (last-bit difference). Documented in `docs/src/wasm.md`;
-  CI builds the module and solves a model under Node's WASI on every PR.
+- Numerics are unchanged. Over all 37 `.nl` fixtures in
+  `crates/pounce-cli/tests/fixtures`, wasm and native agree on exit status
+  and iteration count on every one, and the objective is bit-identical on
+  34 of the 36 that return one; the two exceptions differ by one ulp, at
+  objectives of 1e-10 and 1e-11. Documented in `docs/src/wasm.md`; CI builds the module and solves
+  a model under Node's WASI on every PR.
 - `pounce-nl` now builds for targets with no dynamic loader: `libloading`
   became a `cfg(any(unix, windows))` dependency and `ExternalLibrary::load`
   reports that AMPL imported functions are unavailable there rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+### Added — POUNCE runs in the browser (WebAssembly)
+
+- The default build has no C or Fortran dependency, so the whole solver —
+  `.nl` reader, AD tape, sparse LDL^T, interior-point algorithm — compiles
+  to `wasm32-wasip1` and runs client-side. New crate `pounce-wasm`
+  (`publish = false`) exposes a four-function C ABI (allocate, load, solve,
+  free) that takes `.nl` bytes and `ipopt.opt`-format options and returns
+  JSON: a problem summary from `pounce_load`, a solution from
+  `pounce_solve`. Both catch panics, so a malformed model returns
+  `{"error": …}` instead of trapping the instance.
+- A demo page ships with it (`crates/pounce-wasm/web`, built by
+  `crates/pounce-wasm/build.sh` or `make wasm`): drop a `.nl` file — with
+  its `.col` / `.row` name files if you have them — to see the model's
+  size, degrees of freedom, equality/inequality split, nonlinear fraction,
+  and Jacobian/Hessian sparsity, then solve it with the iteration table
+  streaming into the page. It is static files plus a ~60-line WASI shim; no
+  `wasm-bindgen`, no npm, no server. Nothing is uploaded.
+- Numerics are unchanged: across the CLI's `.nl` fixture suite, the wasm
+  build matches the native build's exit status and iteration count on every
+  problem, and its objective to full double precision on all but one
+  degenerate case (last-bit difference). Documented in `docs/src/wasm.md`;
+  CI builds the module and solves a model under Node's WASI on every PR.
+- `pounce-nl` now builds for targets with no dynamic loader: `libloading`
+  became a `cfg(any(unix, windows))` dependency and `ExternalLibrary::load`
+  reports that AMPL imported functions are unavailable there rather than
+  failing to compile. No change on unix/windows.
+
 ### Fixed — pyomo-pounce: a fixed variable shifted every sensitivity result
 
 - A variable whose bounds are equal is removed from the solve

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ changes.
   and Jacobian/Hessian sparsity, then solve it with the iteration table
   streaming into the page. It is static files plus a ~60-line WASI shim; no
   `wasm-bindgen`, no npm, no server. Nothing is uploaded.
+- The demo is published with the docs: `docs.yml` builds the module and
+  stages the page into the Pages site at
+  [`/demo/`](https://jkitchin.github.io/pounce/demo/) on every deployment
+  from `main`. It needs no Pages configuration — single-threaded, so no
+  `SharedArrayBuffer` and no COOP/COEP headers (which Pages cannot set),
+  and all URLs are relative so the `/pounce/` base path just works.
 - Numerics are unchanged: across the CLI's `.nl` fixture suite, the wasm
   build matches the native build's exit status and iteration count on every
   problem, and its objective to full double precision on all but one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1143,6 +1143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pounce-wasm"
+version = "0.9.0"
+dependencies = [
+ "pounce-algorithm",
+ "pounce-common",
+ "pounce-nl",
+ "pounce-nlp",
+ "pounce-presolve",
+ "serde_json",
+]
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/pounce-rs",
     "crates/pounce-studio-core",
     "crates/pounce-studio-pyo3",
+    "crates/pounce-wasm",
     "tools/iter-diff",
 ]
 # Default `cargo build` / `cargo test` skip pounce-hsl so the pure-Rust

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@
 #   make fmt              # rustfmt the workspace
 #   make doc              # build rustdoc
 #   make book             # build the mdbook documentation (docs/)
+#   make wasm             # build the browser (WebAssembly) solver + demo page
+#   make wasm-serve       # ...and serve it on http://localhost:8000
 #   make install          # install pounce CLI + cinterface cdylib under $(PREFIX)
 #   make uninstall        # remove installed artifacts
 #   make install-mcp      # build studio/mcp + register with Claude Code
@@ -73,7 +75,7 @@ endif
 .PHONY: all build debug test check clippy fmt fmt-check doc book screencast install uninstall clean help \
         install-mcp uninstall-mcp install-skill uninstall-skill pounce-ma57 \
         python-ext python-cli-bin python-test coverage coverage-quick \
-        benchmark benchmark-rerun benchmark-report benchmark-gams
+        benchmark benchmark-rerun benchmark-report benchmark-gams wasm wasm-serve
 
 all: build
 
@@ -118,6 +120,17 @@ fmt-check:
 
 doc:
 	$(CARGO) doc --workspace --no-deps $(CARGO_PROFILE_FLAG)
+
+# ---- WebAssembly ---------------------------------------------------------
+# Build the solver for the browser and stage it into the demo page
+# (crates/pounce-wasm/web). Needs the target once:
+#   rustup target add wasm32-wasip1
+# See docs/src/wasm.md.
+wasm:
+	crates/pounce-wasm/build.sh
+
+wasm-serve:
+	crates/pounce-wasm/build.sh --serve
 
 book:
 	mdbook build docs

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ The [FERAL](crates/pounce-feral) backend provides a sparse symmetric LDLᵀ
 factorization that is also in pure Rust. The HSL MA57 backend is available
 behind the optional `ma57` feature for users who have `libcoinhsl` installed.
 
+Being pure Rust also means the whole solver compiles to WebAssembly:
+**[try it in your browser](https://jkitchin.github.io/pounce/demo/)** — drop
+an AMPL `.nl` file on the page to see the model's structure and solve it
+client-side, with nothing uploaded anywhere. See
+[POUNCE in the Browser](https://jkitchin.github.io/pounce/wasm.html).
+
 License: EPL-2.0 (same as upstream Ipopt).
 
 ## Status

--- a/crates/pounce-nl/Cargo.toml
+++ b/crates/pounce-nl/Cargo.toml
@@ -14,8 +14,16 @@ description = "AMPL .nl reader, reverse-mode AD tape, and TNLP evaluator for pou
 [dependencies]
 pounce-common.workspace = true
 pounce-nlp = { workspace = true, features = ["serde"] }
-libloading = "0.8"
 tracing.workspace = true
+
+# AMPL imported (external) functions are `dlopen`ed at solve time, which
+# only exists on unix/windows. Targets without a dynamic loader — notably
+# `wasm32-*`, where the whole `.nl` pipeline still has to build for the
+# browser demo (`crates/pounce-wasm`) — get the stub `ExternalLibrary::load`
+# in `nl_external.rs`, which reports that such models can't be evaluated
+# there rather than failing to compile.
+[target.'cfg(any(unix, windows))'.dependencies]
+libloading = "0.8"
 
 [lints]
 workspace = true

--- a/crates/pounce-nl/src/nl_external.rs
+++ b/crates/pounce-nl/src/nl_external.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::ptr;
 use std::sync::{Arc, Mutex, OnceLock};
 
+#[cfg(any(unix, windows))]
 use libloading::{Library, Symbol};
 
 use crate::nl_reader::{Expr, FuncallArg, ImportedFunc};
@@ -309,7 +310,10 @@ impl std::fmt::Debug for ExternalLibrary {
 /// A loaded external-function library plus its registered functions.
 pub struct ExternalLibrary {
     /// Keep the library alive — it owns the code pages the function pointers
-    /// reference. Arc so `LoadedExternals` can share it.
+    /// reference. Arc so `LoadedExternals` can share it. Absent on targets
+    /// with no dynamic loader, where [`ExternalLibrary::load`] always fails
+    /// and no instance is ever built.
+    #[cfg(any(unix, windows))]
     _lib: Arc<Library>,
     /// The AmplExports we handed to `funcadd_ASL`. Must be kept alive (pinned
     /// in a Box) because some libraries may capture its address for later
@@ -320,8 +324,23 @@ pub struct ExternalLibrary {
 }
 
 impl ExternalLibrary {
+    /// Stub for targets with no dynamic loader (`wasm32-*`). A `.nl` model
+    /// that actually references an imported function cannot be evaluated
+    /// there, so report that instead of pretending the library loaded.
+    /// Models with no external functions never reach this path —
+    /// `NlTnlp::try_new` skips resolution when nothing is referenced.
+    #[cfg(not(any(unix, windows)))]
+    pub fn load(path: &Path) -> Result<Self, String> {
+        Err(format!(
+            "cannot load '{}': AMPL imported (external) functions need a \
+             dynamic library loader, which this target does not have",
+            path.display()
+        ))
+    }
+
     /// Open a shared library at `path` and invoke its `funcadd_ASL` entry
     /// point, collecting all functions it registers.
+    #[cfg(any(unix, windows))]
     pub fn load(path: &Path) -> Result<Self, String> {
         // Serialise all ABI crossings: library init code and registration
         // may touch global state that isn't safe under concurrent entry.
@@ -703,6 +722,7 @@ thread_local! {
 }
 
 /// C-callable trampoline that receives Addfunc calls from the shared library.
+#[cfg(any(unix, windows))]
 unsafe extern "C" fn trampoline_addfunc(
     name: *const c_char,
     f: Rfunc,
@@ -738,12 +758,14 @@ unsafe extern "C" fn trampoline_addfunc(
 
 /// Stub — some libraries ask us to register an AtReset callback. Pyomo logs a
 /// warning and does nothing. We do the same.
+#[cfg(any(unix, windows))]
 unsafe extern "C" fn trampoline_atreset(_ae: *mut AmplExports, _f: *mut c_void, _v: *mut c_void) {
     tracing::debug!("external library registered an AtReset callback; ignoring");
 }
 
 /// Stub — invoked by libraries that use random-valued externals. We just
 /// seed with 1 (matches Pyomo's default; no randomness in KKT paths).
+#[cfg(any(unix, windows))]
 unsafe extern "C" fn trampoline_addrandinit(
     _ae: *mut AmplExports,
     setter: RandSeedSetter,

--- a/crates/pounce-wasm/Cargo.toml
+++ b/crates/pounce-wasm/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "pounce-wasm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+repository.workspace = true
+description = "WebAssembly entry points for POUNCE: read an AMPL .nl file and solve it in the browser"
+
+# Demo/embedding surface, not a library anyone depends on from crates.io.
+publish = false
+
+[lib]
+# `cdylib` for the wasm build; `rlib` so the host-side unit tests (which
+# exercise the same JSON entry points through a normal `cargo test`) can
+# link it like any other crate.
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pounce-common.workspace = true
+pounce-nlp.workspace = true
+pounce-nl.workspace = true
+pounce-algorithm.workspace = true
+pounce-presolve.workspace = true
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/pounce-wasm/build.sh
+++ b/crates/pounce-wasm/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the POUNCE wasm module and stage it for the demo page.
+#
+#   crates/pounce-wasm/build.sh          # build + copy into web/
+#   crates/pounce-wasm/build.sh --serve  # ...and serve web/ on :8000
+#
+# Requires the wasm target once:  rustup target add wasm32-wasip1
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+target=wasm32-wasip1
+
+# The workspace release profile carries debug info (`debug = 1`), which is
+# ~10x the code size in a wasm module and useless to the page. Override it
+# for this build only rather than changing the profile everyone else uses.
+cargo build --manifest-path "$root/Cargo.toml" \
+  -p pounce-wasm --release --target "$target" \
+  --config 'profile.release.debug=false' \
+  --config 'profile.release.strip="symbols"'
+
+out="$root/target/$target/release/pounce_wasm.wasm"
+
+# wasm-opt (binaryen) is optional; it typically takes another ~15% off.
+if command -v wasm-opt >/dev/null 2>&1; then
+  wasm-opt -Oz --enable-bulk-memory "$out" -o "$here/web/pounce.wasm"
+else
+  cp "$out" "$here/web/pounce.wasm"
+fi
+
+size=$(wc -c < "$here/web/pounce.wasm")
+printf 'web/pounce.wasm  %s bytes (%.1f MB)\n' "$size" "$(echo "$size" | awk '{print $1/1048576}')"
+
+if [[ "${1:-}" == "--serve" ]]; then
+  echo "serving $here/web on http://localhost:8000"
+  # Any static server works; the page needs no headers beyond correct MIME
+  # types for .wasm and .js.
+  cd "$here/web" && python3 -m http.server 8000
+fi

--- a/crates/pounce-wasm/src/lib.rs
+++ b/crates/pounce-wasm/src/lib.rs
@@ -1,0 +1,555 @@
+//! WebAssembly entry points for POUNCE.
+//!
+//! POUNCE's solver core is pure Rust with no C/Fortran dependency on the
+//! default build, so the whole `.nl` → AD tape → interior-point pipeline
+//! compiles to `wasm32-wasip1` unchanged. This crate is the thin C-ABI
+//! shim a browser page talks to: hand it the bytes of an AMPL `.nl` file,
+//! get back a JSON problem summary, then ask it to solve.
+//!
+//! # ABI
+//!
+//! Everything crosses the boundary as UTF-8 in linear memory, because that
+//! is all the raw `WebAssembly` API can express without a bindings
+//! generator (no `wasm-bindgen` dependency — see `web/README.md`):
+//!
+//! * [`pounce_alloc`] / [`pounce_dealloc`] — let JS place input bytes in
+//!   wasm memory.
+//! * [`pounce_load`] — parse a `.nl` (plus optional `.col` / `.row` name
+//!   files), keep the built [`NlTnlp`] in a per-instance slot, and return
+//!   a JSON summary. Returns `{"error": …}` on a bad file.
+//! * [`pounce_solve`] — solve the loaded problem with an `ipopt.opt`-style
+//!   options string, returning a JSON result.
+//! * [`pounce_free_string`] — release a returned string.
+//!
+//! Returned strings are NUL-terminated so the caller can find their length
+//! without a second call. Every entry point catches panics, so a malformed
+//! model surfaces as a JSON error rather than a trapped instance the page
+//! would have to rebuild.
+//!
+//! The solver's own console output (banner, iteration table, exit line) is
+//! written to stdout as usual; under WASI the host shim receives it through
+//! `fd_write`, which is how the demo page streams the live iteration log.
+
+use std::cell::RefCell;
+use std::ffi::{CString, c_char};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_nl::nl_reader::{NlProblem, NlTnlp, parse_nl_text};
+use pounce_nlp::expression_provider::ExpressionProvider;
+use pounce_nlp::tnlp::{Linearity, TNLP};
+
+/// Bound on how many per-variable / per-constraint entries a JSON payload
+/// carries. A million-variable model would otherwise serialize a JSON array
+/// the page can neither render nor afford to parse; the arrays are for
+/// display, and the summary reports the true counts separately.
+const PREVIEW_LIMIT: usize = 2000;
+
+thread_local! {
+    /// The currently loaded model. A wasm instance drives one model at a
+    /// time (the demo runs one instance per worker), so a single slot is
+    /// enough and keeps the ABI handle-free.
+    static LOADED: RefCell<Option<Rc<RefCell<NlTnlp>>>> = const { RefCell::new(None) };
+}
+
+// ---------------------------------------------------------------------------
+// Memory
+// ---------------------------------------------------------------------------
+
+/// Allocate `len` bytes in wasm linear memory for the caller to write into.
+/// Returns null when `len` is 0 or the allocation fails.
+///
+/// # Safety
+/// The returned pointer must be released with [`pounce_dealloc`] using the
+/// same `len`, or handed to [`pounce_load`], which takes no ownership.
+#[unsafe(no_mangle)]
+pub extern "C" fn pounce_alloc(len: usize) -> *mut u8 {
+    if len == 0 {
+        return std::ptr::null_mut();
+    }
+    let mut buf = Vec::<u8>::new();
+    if buf.try_reserve_exact(len).is_err() {
+        return std::ptr::null_mut();
+    }
+    buf.resize(len, 0);
+    let mut buf = std::mem::ManuallyDrop::new(buf);
+    buf.as_mut_ptr()
+}
+
+/// Release a buffer obtained from [`pounce_alloc`].
+///
+/// # Safety
+/// `ptr`/`len` must come from a single [`pounce_alloc`] call and must not
+/// have been freed already.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pounce_dealloc(ptr: *mut u8, len: usize) {
+    if ptr.is_null() || len == 0 {
+        return;
+    }
+    // SAFETY: the caller guarantees ptr/len came from `pounce_alloc`, which
+    // built the allocation with exactly this length and capacity.
+    drop(unsafe { Vec::from_raw_parts(ptr, len, len) });
+}
+
+/// Release a string returned by [`pounce_load`] / [`pounce_solve`].
+///
+/// # Safety
+/// `ptr` must be a pointer this module returned and not yet freed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pounce_free_string(ptr: *mut c_char) {
+    if ptr.is_null() {
+        return;
+    }
+    // SAFETY: the caller guarantees this pointer came from `CString::into_raw`
+    // in `to_c_string` below.
+    drop(unsafe { CString::from_raw(ptr) });
+}
+
+/// Move a Rust string into a NUL-terminated allocation the caller owns.
+/// Interior NULs are impossible here (all payloads are `serde_json` output),
+/// but the fallback keeps the function total rather than panicking.
+fn to_c_string(s: String) -> *mut c_char {
+    match CString::new(s) {
+        Ok(c) => c.into_raw(),
+        Err(_) => match CString::new(r#"{"error":"internal: NUL in payload"}"#) {
+            Ok(c) => c.into_raw(),
+            Err(_) => std::ptr::null_mut(),
+        },
+    }
+}
+
+fn error_json(msg: impl std::fmt::Display) -> *mut c_char {
+    to_c_string(serde_json::json!({ "error": msg.to_string() }).to_string())
+}
+
+/// Borrow `len` bytes at `ptr` as `&str`. Empty when `ptr` is null or `len`
+/// is 0, so optional inputs can be passed as `(0, 0)`.
+///
+/// # Safety
+/// `ptr`/`len` must describe an initialized, readable region that stays
+/// valid for the call.
+unsafe fn str_from_parts<'a>(ptr: *const u8, len: usize) -> Result<&'a str, String> {
+    if ptr.is_null() || len == 0 {
+        return Ok("");
+    }
+    // SAFETY: the caller guarantees the region is valid and initialized.
+    let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+    std::str::from_utf8(bytes).map_err(|e| format!("input is not valid UTF-8: {e}"))
+}
+
+/// Run `f`, converting a panic into a JSON error string. `.nl` input is
+/// arbitrary user data; a panic inside the parser or the solver must not
+/// poison the wasm instance for the rest of the page's lifetime.
+fn guarded(what: &str, f: impl FnOnce() -> *mut c_char) -> *mut c_char {
+    match catch_unwind(AssertUnwindSafe(f)) {
+        Ok(p) => p,
+        Err(_) => error_json(format!("{what} panicked (see the console log for details)")),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Load + summarize
+// ---------------------------------------------------------------------------
+
+/// Parse a `.nl` file and report what is in it.
+///
+/// `col_*` / `row_*` are the optional sibling `.col` / `.row` name files
+/// AMPL writes under `option auxfiles rc;`; pass `(null, 0)` when absent.
+/// The parsed model is retained for a following [`pounce_solve`].
+///
+/// # Safety
+/// Each pointer/length pair must describe a readable region valid for the
+/// call, or be `(null, 0)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pounce_load(
+    nl_ptr: *const u8,
+    nl_len: usize,
+    col_ptr: *const u8,
+    col_len: usize,
+    row_ptr: *const u8,
+    row_len: usize,
+) -> *mut c_char {
+    guarded("load", || {
+        // SAFETY: forwarded from this function's own safety contract.
+        let (nl, col, row) = unsafe {
+            (
+                str_from_parts(nl_ptr, nl_len),
+                str_from_parts(col_ptr, col_len),
+                str_from_parts(row_ptr, row_len),
+            )
+        };
+        let (nl, col, row) = match (nl, col, row) {
+            (Ok(a), Ok(b), Ok(c)) => (a, b, c),
+            (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => return error_json(e),
+        };
+        if nl.trim().is_empty() {
+            return error_json("empty .nl input");
+        }
+
+        let mut prob = match parse_nl_text(nl) {
+            Ok(p) => p,
+            Err(e) => return error_json(format!("could not parse .nl file: {e}")),
+        };
+        attach_names(&mut prob, col, row);
+
+        let tnlp = match NlTnlp::try_new(prob) {
+            Ok(t) => t,
+            Err(e) => return error_json(e),
+        };
+        let tnlp = Rc::new(RefCell::new(tnlp));
+        let summary = summarize(&mut tnlp.borrow_mut());
+        LOADED.with(|slot| *slot.borrow_mut() = Some(Rc::clone(&tnlp)));
+        to_c_string(summary.to_string())
+    })
+}
+
+/// Scatter `.col` / `.row` line-per-name text onto the parsed problem, the
+/// same way [`pounce_nl::nl_reader::read_nl_file`] does for files on disk.
+/// A name file of the wrong length is ignored rather than mislabeling rows.
+fn attach_names(prob: &mut NlProblem, col: &str, row: &str) {
+    let lines = |txt: &str| -> Vec<String> {
+        txt.lines()
+            .map(str::trim_end)
+            .filter(|l| !l.is_empty())
+            .map(str::to_string)
+            .collect()
+    };
+    let var_names = lines(col);
+    if var_names.len() == prob.n {
+        prob.var_names = var_names;
+    }
+    let con_names = lines(row);
+    if con_names.len() == prob.m {
+        prob.con_names = con_names;
+    }
+}
+
+/// Classification of a `[lo, hi]` pair, shared by the variable and
+/// constraint tallies. `INF` here is AMPL's 1e19 sentinel convention.
+const INF: f64 = 1.0e19;
+
+#[derive(Default)]
+struct BoundTally {
+    free: usize,
+    lower_only: usize,
+    upper_only: usize,
+    boxed: usize,
+    fixed: usize,
+}
+
+impl BoundTally {
+    fn count(lo: &[f64], hi: &[f64]) -> Self {
+        let mut t = Self::default();
+        for (l, u) in lo.iter().zip(hi.iter()) {
+            let has_l = *l > -INF;
+            let has_u = *u < INF;
+            match (has_l, has_u) {
+                (false, false) => t.free += 1,
+                (true, false) => t.lower_only += 1,
+                (false, true) => t.upper_only += 1,
+                (true, true) if l == u => t.fixed += 1,
+                (true, true) => t.boxed += 1,
+            }
+        }
+        t
+    }
+
+    fn to_json(&self) -> serde_json::Value {
+        serde_json::json!({
+            "free": self.free,
+            "lower_only": self.lower_only,
+            "upper_only": self.upper_only,
+            "boxed": self.boxed,
+            "fixed": self.fixed,
+        })
+    }
+}
+
+fn preview<T: Clone>(v: &[T]) -> (&[T], bool) {
+    if v.len() > PREVIEW_LIMIT {
+        (&v[..PREVIEW_LIMIT], true)
+    } else {
+        (v, false)
+    }
+}
+
+/// Build the JSON problem summary shown before a solve: sizes, sparsity,
+/// how the bounds break down, and how much of the model is nonlinear.
+fn summarize(tnlp: &mut NlTnlp) -> serde_json::Value {
+    let info = tnlp.get_nlp_info();
+    let (n, m, nnz_jac, nnz_hess) = match info {
+        Some(i) => (
+            i.n as usize,
+            i.m as usize,
+            i.nnz_jac_g as usize,
+            i.nnz_h_lag as usize,
+        ),
+        None => (0, 0, 0, 0),
+    };
+
+    let mut var_lin = vec![Linearity::Linear; n];
+    let n_nonlinear_vars = if tnlp.get_variables_linearity(&mut var_lin) {
+        var_lin
+            .iter()
+            .filter(|l| **l == Linearity::NonLinear)
+            .count()
+    } else {
+        0
+    };
+    let mut con_lin = vec![Linearity::Linear; m];
+    let n_nonlinear_cons = if tnlp.get_constraints_linearity(&mut con_lin) {
+        con_lin
+            .iter()
+            .filter(|l| **l == Linearity::NonLinear)
+            .count()
+    } else {
+        0
+    };
+
+    let prob = tnlp.problem();
+    let var_bounds = BoundTally::count(&prob.x_l, &prob.x_u);
+    let con_bounds = BoundTally::count(&prob.g_l, &prob.g_u);
+    // A constraint whose bounds coincide is an equality; the rest of the
+    // tally reads as inequalities (one-sided or ranged).
+    let n_equality = con_bounds.fixed;
+
+    let (var_names, var_names_truncated) = preview(&prob.var_names);
+    let (con_names, con_names_truncated) = preview(&prob.con_names);
+    let (x0, x0_truncated) = preview(&prob.x0);
+
+    serde_json::json!({
+        "n_vars": n,
+        "n_cons": m,
+        "n_objs": prob.num_obj,
+        "sense": if prob.minimize { "minimize" } else { "maximize" },
+        "nnz_jac": nnz_jac,
+        "nnz_hess": nnz_hess,
+        "jac_density": if n * m > 0 { nnz_jac as f64 / (n as f64 * m as f64) } else { 0.0 },
+        "n_nonlinear_vars": n_nonlinear_vars,
+        "n_nonlinear_cons": n_nonlinear_cons,
+        "n_equality_cons": n_equality,
+        "n_inequality_cons": m - n_equality,
+        "degrees_of_freedom": n as i64 - n_equality as i64,
+        "var_bounds": var_bounds.to_json(),
+        "con_bounds": con_bounds.to_json(),
+        "external_funcs": prob.imported_funcs.iter().map(|f| f.name.clone()).collect::<Vec<_>>(),
+        "var_names": var_names,
+        "con_names": con_names,
+        "x0": x0,
+        "truncated": var_names_truncated || con_names_truncated || x0_truncated,
+        "preview_limit": PREVIEW_LIMIT,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Solve
+// ---------------------------------------------------------------------------
+
+/// Solve the model most recently loaded by [`pounce_load`].
+///
+/// `opts_*` is `ipopt.opt`-style text (`name value` per line, `#` comments)
+/// — the same option names the CLI and the Python API take. Pass
+/// `(null, 0)` for defaults.
+///
+/// # Safety
+/// `opts_ptr`/`opts_len` must describe a readable region valid for the
+/// call, or be `(null, 0)`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn pounce_solve(opts_ptr: *const u8, opts_len: usize) -> *mut c_char {
+    guarded("solve", || {
+        // SAFETY: forwarded from this function's own safety contract.
+        let opts = match unsafe { str_from_parts(opts_ptr, opts_len) } {
+            Ok(s) => s,
+            Err(e) => return error_json(e),
+        };
+        let Some(tnlp) = LOADED.with(|slot| slot.borrow().clone()) else {
+            return error_json("no model loaded — call pounce_load first");
+        };
+        to_c_string(solve_loaded(tnlp, opts).to_string())
+    })
+}
+
+fn solve_loaded(tnlp: Rc<RefCell<NlTnlp>>, opts: &str) -> serde_json::Value {
+    let mut app = IpoptApplication::new();
+    if let Err(e) = app.initialize_with_options_str(opts) {
+        return serde_json::json!({ "error": format!("bad options: {}", e.message) });
+    }
+
+    // Wrap in the auxiliary presolve exactly as the CLI does, so a model
+    // solved in the browser takes the same path — and reaches the same
+    // answer — as `pounce model.nl` on the command line. `NlTnlp` doubles as
+    // the `ExpressionProvider` presolve needs for FBBT.
+    let presolve_opts = match pounce_presolve::PresolveOptions::from_options_list(app.options()) {
+        Ok(o) => o,
+        Err(e) => return serde_json::json!({ "error": format!("presolve setup failed: {e}") }),
+    };
+    let presolve = presolve_opts.enabled.then(|| {
+        app.set_presolve_already_applied(true);
+        Rc::new(RefCell::new(
+            pounce_presolve::PresolveTnlp::with_expression_provider(
+                Rc::clone(&tnlp) as Rc<RefCell<dyn TNLP>>,
+                Rc::clone(&tnlp) as Rc<RefCell<dyn ExpressionProvider>>,
+                presolve_opts,
+            ),
+        ))
+    });
+    let target: Rc<RefCell<dyn TNLP>> = match &presolve {
+        Some(p) => Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
+        None => Rc::clone(&tnlp) as Rc<RefCell<dyn TNLP>>,
+    };
+
+    let status = app.optimize_tnlp(target);
+    let stats = app.statistics();
+    let presolve_report = presolve.as_ref().map(|p| {
+        let h = p.borrow();
+        let tr = h.tighten_report();
+        serde_json::json!({
+            "tightened_bounds": tr.n_tightened,
+            "newly_finite_bounds": tr.n_new_finite,
+            "dropped_rows": h.n_dropped_rows(),
+        })
+    });
+
+    let mut t = tnlp.borrow_mut();
+    let x: Vec<f64> = t.final_x().map(<[f64]>::to_vec).unwrap_or_default();
+    let objective = t.final_obj();
+    // Constraint values at the returned point, so the page can show which
+    // rows are tight or violated without re-evaluating the model in JS.
+    let m = t.problem().m;
+    let mut g = vec![0.0; m];
+    if x.is_empty() || !t.eval_g(&x, true, &mut g) {
+        g.clear();
+    }
+    let (g_l, g_u) = (t.problem().g_l.clone(), t.problem().g_u.clone());
+
+    let (x_prev, x_truncated) = preview(&x);
+    let (g_prev, g_truncated) = preview(&g);
+    let (g_l_prev, _) = preview(&g_l);
+    let (g_u_prev, _) = preview(&g_u);
+
+    serde_json::json!({
+        "status": format!("{status:?}"),
+        "status_code": status.as_int(),
+        "success": status.as_int() >= 0,
+        "objective": objective,
+        "iterations": stats.iteration_count,
+        "wall_time_secs": stats.total_wallclock_time_secs,
+        "dual_infeasibility": stats.final_unscaled_dual_inf,
+        "constraint_violation": stats.final_unscaled_constr_viol,
+        "complementarity": stats.final_unscaled_compl,
+        "kkt_error": stats.final_unscaled_kkt_error,
+        "restoration_calls": stats.restoration_calls,
+        "presolve": presolve_report,
+        "evals": {
+            "objective": stats.num_obj_evals,
+            "objective_grad": stats.num_obj_grad_evals,
+            "constraints": stats.num_constr_evals,
+            "constraint_jac": stats.num_constr_jac_evals,
+            "hessian": stats.num_hess_evals,
+        },
+        "x": x_prev,
+        "g": g_prev,
+        "g_l": g_l_prev,
+        "g_u": g_u_prev,
+        "truncated": x_truncated || g_truncated,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two variables, one nonlinear equality, one linear inequality —
+    /// small enough to keep inline, big enough that every field of the
+    /// summary has something to say.
+    const SIMPLE_NL: &str = include_str!("../tests/simple.nl");
+
+    /// Call the C ABI the way JS does — bytes in, JSON out — and hand back
+    /// the parsed payload.
+    fn call_load(nl: &str, col: &str, row: &str) -> serde_json::Value {
+        let ptr = unsafe {
+            pounce_load(
+                nl.as_ptr(),
+                nl.len(),
+                col.as_ptr(),
+                col.len(),
+                row.as_ptr(),
+                row.len(),
+            )
+        };
+        let s = unsafe { std::ffi::CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { pounce_free_string(ptr) };
+        serde_json::from_str(&s).expect("entry points must return JSON")
+    }
+
+    fn call_solve(opts: &str) -> serde_json::Value {
+        let ptr = unsafe { pounce_solve(opts.as_ptr(), opts.len()) };
+        let s = unsafe { std::ffi::CStr::from_ptr(ptr) }
+            .to_string_lossy()
+            .into_owned();
+        unsafe { pounce_free_string(ptr) };
+        serde_json::from_str(&s).expect("entry points must return JSON")
+    }
+
+    #[test]
+    fn load_reports_problem_shape() {
+        let s = call_load(SIMPLE_NL, "alpha\nbeta\n", "ring\nline\n");
+        assert_eq!(s["n_vars"], 2);
+        assert_eq!(s["n_cons"], 2);
+        assert_eq!(s["sense"], "minimize");
+        assert_eq!(s["var_names"][0], "alpha");
+        assert_eq!(s["con_names"][1], "line");
+        // One nonlinear row (the circle), one linear row.
+        assert_eq!(s["n_nonlinear_cons"], 1);
+        assert!(s["nnz_jac"].as_u64().unwrap_or(0) > 0);
+    }
+
+    #[test]
+    fn name_files_of_the_wrong_length_are_ignored() {
+        let s = call_load(SIMPLE_NL, "only_one\n", "");
+        assert!(
+            s["var_names"]
+                .as_array()
+                .map(Vec::is_empty)
+                .unwrap_or(false),
+            "a .col file that does not match n must not be applied"
+        );
+    }
+
+    #[test]
+    fn bad_input_is_an_error_not_a_panic() {
+        assert!(call_load("not an nl file at all", "", "")["error"].is_string());
+        assert!(call_load("", "", "")["error"].is_string());
+    }
+
+    #[test]
+    fn solve_runs_the_loaded_model() {
+        call_load(SIMPLE_NL, "", "");
+        let r = call_solve("print_level 0\n");
+        assert_eq!(r["success"], true, "solve payload: {r}");
+        assert!(r["iterations"].as_i64().unwrap_or(0) > 0);
+        // min x0 s.t. x0^2 + x1^2 == 1, x0 + x1 >= 0  ⇒  x0 = -1/√2.
+        let obj = r["objective"].as_f64().unwrap_or(f64::NAN);
+        assert!(
+            (obj + 0.5f64.sqrt()).abs() < 1e-6,
+            "unexpected objective {obj}"
+        );
+        assert_eq!(r["x"].as_array().map(Vec::len), Some(2));
+        assert_eq!(r["g"].as_array().map(Vec::len), Some(2));
+    }
+
+    #[test]
+    fn solving_with_no_model_loaded_is_an_error() {
+        LOADED.with(|slot| *slot.borrow_mut() = None);
+        assert!(call_solve("")["error"].is_string());
+    }
+
+    #[test]
+    fn bad_options_are_reported() {
+        call_load(SIMPLE_NL, "", "");
+        assert!(call_solve("max_iter not_an_integer\n")["error"].is_string());
+    }
+}

--- a/crates/pounce-wasm/tests/simple.nl
+++ b/crates/pounce-wasm/tests/simple.nl
@@ -1,0 +1,41 @@
+g3 1 1 0	# hand-written fixture for the pounce-wasm entry points
+ 2 2 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 1 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o0
+o5
+v0
+n2
+o5
+v1
+n2
+C1
+n0
+O0 0
+n0
+x2
+0 0.5
+1 0.5
+r
+4 1.0
+2 0.0
+b
+0 -10 10
+0 -10 10
+k1
+2
+J0 2
+0 0
+1 0
+J1 2
+0 1
+1 1
+G0 1
+0 1

--- a/crates/pounce-wasm/tests/smoke.mjs
+++ b/crates/pounce-wasm/tests/smoke.mjs
@@ -1,0 +1,93 @@
+// Smoke test for the wasm build: drive the same C ABI the browser page uses
+// and check that a `.nl` file loads, summarizes, and solves.
+//
+//   crates/pounce-wasm/build.sh
+//   node crates/pounce-wasm/tests/smoke.mjs
+//
+// Node's WASI stands in for the browser's `wasi.js` shim. What this catches
+// that `cargo test -p pounce-wasm` cannot: a dependency that stops
+// compiling for wasm32, or one that compiles but traps at run time (an
+// unsupported syscall, a thread spawn, a missing clock).
+
+import { readFileSync } from 'node:fs';
+import { WASI } from 'node:wasi';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import assert from 'node:assert/strict';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const wasmPath =
+  process.argv[2] ?? join(here, '../../../target/wasm32-wasip1/release/pounce_wasm.wasm');
+
+const wasi = new WASI({ version: 'preview1', args: [], env: {} });
+const instance = await WebAssembly.instantiate(
+  await WebAssembly.compile(readFileSync(wasmPath)),
+  wasi.getImportObject(),
+);
+wasi.initialize(instance);
+const wasm = instance.exports;
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+function intoWasm(str) {
+  if (!str) return [0, 0];
+  const bytes = encoder.encode(str);
+  const ptr = wasm.pounce_alloc(bytes.length);
+  assert.notEqual(ptr, 0, 'pounce_alloc returned null');
+  new Uint8Array(wasm.memory.buffer, ptr, bytes.length).set(bytes);
+  return [ptr, bytes.length];
+}
+
+function fromWasm(ptr) {
+  const mem = new Uint8Array(wasm.memory.buffer);
+  let end = ptr;
+  while (mem[end] !== 0) end++;
+  const json = JSON.parse(decoder.decode(mem.subarray(ptr, end)));
+  wasm.pounce_free_string(ptr);
+  return json;
+}
+
+function load(nl, col = '', row = '') {
+  const args = [nl, col, row].map(intoWasm);
+  try {
+    return fromWasm(wasm.pounce_load(...args.flat()));
+  } finally {
+    for (const [ptr, len] of args) if (ptr) wasm.pounce_dealloc(ptr, len);
+  }
+}
+
+function solve(options = '') {
+  const [ptr, len] = intoWasm(options);
+  try {
+    return fromWasm(wasm.pounce_solve(ptr, len));
+  } finally {
+    if (ptr) wasm.pounce_dealloc(ptr, len);
+  }
+}
+
+// min x0  s.t.  x0^2 + x1^2 == 1,  x0 + x1 >= 0   ⇒   x0 = -1/√2
+const summary = load(readFileSync(join(here, 'simple.nl'), 'utf8'), 'alpha\nbeta\n', 'ring\nline\n');
+assert.equal(summary.error, undefined, `load failed: ${summary.error}`);
+assert.equal(summary.n_vars, 2);
+assert.equal(summary.n_cons, 2);
+assert.equal(summary.n_nonlinear_cons, 1);
+assert.equal(summary.sense, 'minimize');
+assert.deepEqual(summary.var_names, ['alpha', 'beta']);
+
+const result = solve('print_level 0\n');
+assert.equal(result.error, undefined, `solve failed: ${result.error}`);
+assert.equal(result.success, true, `unexpected status ${result.status}`);
+assert.ok(
+  Math.abs(result.objective + Math.SQRT1_2) < 1e-6,
+  `objective ${result.objective} != ${-Math.SQRT1_2}`,
+);
+assert.equal(result.x.length, 2);
+
+// A malformed model must come back as JSON, not a trapped instance.
+assert.equal(typeof load('this is not an .nl file').error, 'string');
+
+console.log(
+  `ok — solved in wasm: objective ${result.objective.toFixed(9)}, ` +
+    `${result.iterations} iterations, ${(result.wall_time_secs * 1000).toFixed(1)} ms`,
+);

--- a/crates/pounce-wasm/web/.gitignore
+++ b/crates/pounce-wasm/web/.gitignore
@@ -1,0 +1,2 @@
+# Build artifact staged by build.sh — rebuild it, do not commit it.
+pounce.wasm

--- a/crates/pounce-wasm/web/README.md
+++ b/crates/pounce-wasm/web/README.md
@@ -1,0 +1,72 @@
+# POUNCE in the browser
+
+A static page that reads an AMPL `.nl` file, summarizes it, and solves it —
+entirely client-side, with the POUNCE solver compiled to WebAssembly. No
+server, no upload, no install.
+
+```sh
+rustup target add wasm32-wasip1     # once
+crates/pounce-wasm/build.sh --serve # build + serve on http://localhost:8000
+```
+
+Drag a `.nl` file onto the page (optionally with its sibling `.col` / `.row`
+name files, which AMPL writes under `option auxfiles rc;`). Deploying is a
+matter of copying this directory — after `build.sh` has staged
+`pounce.wasm` into it — to any static host.
+
+## What is here
+
+| File | Role |
+| --- | --- |
+| `index.html` | markup + styles |
+| `app.js` | file intake and rendering, main thread |
+| `worker.js` | owns the wasm instance; runs load/solve off the UI thread |
+| `wasi.js` | ~60-line `wasi_snapshot_preview1` host |
+| `pounce.wasm` | build artifact, staged by `build.sh` (not in git) |
+
+## Why WASI and not `wasm-bindgen`
+
+The module targets `wasm32-wasip1` rather than `wasm32-unknown-unknown`,
+which buys two things and costs one.
+
+It buys a working clock: `std::time::Instant::now()` panics on
+`wasm32-unknown-unknown`, and POUNCE calls it from ~20 places (per-solve
+wall time, `max_wall_time`, the restoration timer). Under WASI it is
+`clock_time_get`, which `wasi.js` answers from `performance.now()`. It also
+buys stdout: the solver's iteration table is written to fd 1 as usual, and
+the shim turns each `fd_write` into a message the page appends to the log
+pane — the live output you see during a solve is the real thing, not a
+reconstruction.
+
+It costs a host shim, since browsers do not implement WASI natively. That
+shim is `wasi.js`, and it is the whole cost: no bindings generator, no npm
+install, no build step beyond `cargo build`. Fourteen WASI functions are
+imported; four do real work (`fd_write`, `clock_time_get`, `random_get`,
+`environ_*`) and the rest return errno, because the solver never touches a
+filesystem on this path.
+
+## The interface
+
+`crates/pounce-wasm/src/lib.rs` exports a small C ABI — bytes in, JSON out:
+
+```js
+const [ptr, len] = intoWasm(nlFileText);
+const summary = fromWasm(wasm.pounce_load(ptr, len, 0, 0, 0, 0));
+const result  = fromWasm(wasm.pounce_solve(...intoWasm('max_iter 500\n')));
+```
+
+Options are `ipopt.opt`-format text, exactly as the CLI and the Python API
+take them. Both entry points catch panics and report `{"error": …}`, so a
+malformed model does not trap the instance.
+
+## Limitations
+
+- **Single-threaded.** The build never spawns a thread, so rayon-parallel
+  paths run serially. Nothing else changes: results match the native build.
+- **No AMPL imported functions.** Models that call compiled-C external
+  functions (`funcadd_ASL`, e.g. IDAES property packages) need a dynamic
+  loader the browser sandbox has none of. The summary flags such a model.
+- **No HSL.** The `ma57` feature links Fortran; the wasm build uses the
+  default pure-Rust FERAL backend, same as a stock `cargo build`.
+- **2.4 MB module** (~800 kB over the wire with gzip), compiled once per
+  page load in ~100 ms.

--- a/crates/pounce-wasm/web/README.md
+++ b/crates/pounce-wasm/web/README.md
@@ -10,9 +10,14 @@ crates/pounce-wasm/build.sh --serve # build + serve on http://localhost:8000
 ```
 
 Drag a `.nl` file onto the page (optionally with its sibling `.col` / `.row`
-name files, which AMPL writes under `option auxfiles rc;`). Deploying is a
-matter of copying this directory — after `build.sh` has staged
-`pounce.wasm` into it — to any static host.
+name files, which AMPL writes under `option auxfiles rc;`).
+
+Deploying is a matter of copying this directory — after `build.sh` has
+staged `pounce.wasm` into it — to any static host. No headers to configure:
+no threads means no `SharedArrayBuffer`, hence no COOP/COEP requirement, and
+every fetch is relative so any base path works. This repository publishes it
+to GitHub Pages at [`/pounce/demo/`](https://jkitchin.github.io/pounce/demo/)
+from `.github/workflows/docs.yml`.
 
 ## What is here
 

--- a/crates/pounce-wasm/web/app.js
+++ b/crates/pounce-wasm/web/app.js
@@ -1,0 +1,220 @@
+// Page logic: take dropped files, ask the worker to load and solve, render.
+
+const worker = new Worker('./worker.js', { type: 'module' });
+
+const $ = (id) => document.getElementById(id);
+const drop = $('drop');
+const fileInput = $('files');
+const loadError = $('loaderr');
+const solveButton = $('solve');
+const solveStatus = $('solve-status');
+const log = $('log');
+
+let summary = null;
+
+// --- file intake -----------------------------------------------------------
+
+['dragenter', 'dragover'].forEach((ev) =>
+  drop.addEventListener(ev, (e) => {
+    e.preventDefault();
+    drop.classList.add('over');
+  }),
+);
+['dragleave', 'drop'].forEach((ev) =>
+  drop.addEventListener(ev, (e) => {
+    e.preventDefault();
+    drop.classList.remove('over');
+  }),
+);
+drop.addEventListener('drop', (e) => takeFiles(e.dataTransfer.files));
+fileInput.addEventListener('change', () => takeFiles(fileInput.files));
+
+async function takeFiles(fileList) {
+  const files = [...fileList];
+  const pick = (ext) => files.find((f) => f.name.toLowerCase().endsWith(ext));
+  // Anything that is not a .col/.row is treated as the model, so a file
+  // named `stub` or `model.nl.txt` still works.
+  const nl = pick('.nl') ?? files.find((f) => !/\.(col|row)$/i.test(f.name));
+  if (!nl) {
+    showLoadError('Drop an .nl file (optionally with its .col / .row name files).');
+    return;
+  }
+  showLoadError(null);
+  $('filename').textContent = `— ${nl.name} (${formatBytes(nl.size)})`;
+  const [nlText, colText, rowText] = await Promise.all([
+    nl.text(),
+    pick('.col')?.text() ?? Promise.resolve(''),
+    pick('.row')?.text() ?? Promise.resolve(''),
+  ]);
+  worker.postMessage({ type: 'load', nl: nlText, col: colText, row: rowText });
+}
+
+function showLoadError(message) {
+  loadError.hidden = !message;
+  loadError.textContent = message ?? '';
+}
+
+// --- worker plumbing -------------------------------------------------------
+
+worker.onmessage = ({ data }) => {
+  if (data.type === 'summary') {
+    if (data.summary.error) {
+      summary = null;
+      $('summary-section').hidden = true;
+      $('solve-section').hidden = true;
+      showLoadError(data.summary.error);
+      return;
+    }
+    summary = data.summary;
+    renderSummary(summary);
+    $('result-section').hidden = true;
+    $('log-section').hidden = true;
+    log.textContent = '';
+  } else if (data.type === 'log') {
+    log.textContent += data.text;
+    log.scrollTop = log.scrollHeight;
+  } else if (data.type === 'result') {
+    solveButton.disabled = false;
+    if (data.result.error) {
+      solveStatus.textContent = data.result.error;
+      return;
+    }
+    solveStatus.textContent = '';
+    renderResult(data.result);
+  } else if (data.type === 'fatal') {
+    solveButton.disabled = false;
+    showLoadError(data.message);
+    solveStatus.textContent = data.message;
+  }
+};
+
+solveButton.addEventListener('click', () => {
+  solveButton.disabled = true;
+  solveStatus.textContent = 'solving…';
+  log.textContent = '';
+  $('log-section').hidden = false;
+  $('result-section').hidden = true;
+  worker.postMessage({ type: 'solve', options: $('options').value });
+});
+
+// --- rendering -------------------------------------------------------------
+
+const num = (v) => (v == null ? '—' : v.toLocaleString());
+const sci = (v) => {
+  if (v == null || Number.isNaN(v)) return '—';
+  if (v === 0) return '0';
+  return Math.abs(v) >= 1e-4 && Math.abs(v) < 1e6
+    ? v.toPrecision(6).replace(/\.?0+$/, '')
+    : v.toExponential(2);
+};
+
+function formatBytes(n) {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} kB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}
+
+function stats(target, entries) {
+  target.innerHTML = '';
+  for (const [label, value] of entries) {
+    const wrap = document.createElement('div');
+    const dt = document.createElement('dt');
+    dt.textContent = label;
+    const dd = document.createElement('dd');
+    if (value instanceof Node) dd.append(value);
+    else dd.textContent = value;
+    wrap.append(dt, dd);
+    target.append(wrap);
+  }
+}
+
+function renderSummary(s) {
+  const b = s.var_bounds;
+  stats($('stats'), [
+    ['Variables', num(s.n_vars)],
+    ['Constraints', num(s.n_cons)],
+    ['Objective', s.sense],
+    ['Degrees of freedom', num(s.degrees_of_freedom)],
+    ['Equalities', num(s.n_equality_cons)],
+    ['Inequalities', num(s.n_inequality_cons)],
+    ['Nonlinear rows', `${num(s.n_nonlinear_cons)} / ${num(s.n_cons)}`],
+    ['Nonlinear vars', `${num(s.n_nonlinear_vars)} / ${num(s.n_vars)}`],
+    ['Jacobian nnz', `${num(s.nnz_jac)} (${(s.jac_density * 100).toFixed(2)}%)`],
+    ['Hessian nnz', num(s.nnz_hess)],
+    ['Bounded vars', num(b.boxed + b.lower_only + b.upper_only)],
+    ['Fixed vars', num(b.fixed)],
+    ['Free vars', num(b.free)],
+  ]);
+
+  const notes = [];
+  if (s.external_funcs.length) {
+    notes.push(
+      `Model declares AMPL imported functions (${s.external_funcs.join(', ')}), ` +
+        `which need a native shared library — this build cannot evaluate them.`,
+    );
+  }
+  if (s.truncated) {
+    notes.push(`Name / value lists are truncated to the first ${num(s.preview_limit)} entries.`);
+  }
+  $('summary-note').textContent = notes.join(' ');
+
+  $('summary-section').hidden = false;
+  $('solve-section').hidden = false;
+}
+
+function renderResult(r) {
+  const badge = document.createElement('span');
+  badge.className = `tag ${r.success ? 'ok' : 'bad'}`;
+  badge.textContent = spaced(r.status);
+
+  stats($('result-stats'), [
+    ['Status', badge],
+    ['Objective', sci(r.objective)],
+    ['Iterations', num(r.iterations)],
+    ['Solve time', `${(r.wall_time_secs * 1000).toFixed(0)} ms`],
+    ['Constraint violation', sci(r.constraint_violation)],
+    ['Dual infeasibility', sci(r.dual_infeasibility)],
+    ['Complementarity', sci(r.complementarity)],
+    ['KKT error', sci(r.kkt_error)],
+    ['f / ∇f evals', `${num(r.evals.objective)} / ${num(r.evals.objective_grad)}`],
+    ['g / ∇g evals', `${num(r.evals.constraints)} / ${num(r.evals.constraint_jac)}`],
+    ['Hessian evals', num(r.evals.hessian)],
+    ['Restorations', num(r.restoration_calls)],
+  ]);
+
+  const names = summary?.var_names ?? [];
+  table($('vars'), ['Variable', 'Value'],
+    r.x.map((v, i) => [names[i] ?? `x[${i}]`, sci(v)]));
+
+  const conNames = summary?.con_names ?? [];
+  table($('cons'), ['Constraint', 'Lower', 'Value', 'Upper'],
+    r.g.map((v, i) => [
+      conNames[i] ?? `c[${i}]`,
+      finite(r.g_l[i]) ? sci(r.g_l[i]) : '−∞',
+      sci(v),
+      finite(r.g_u[i]) ? sci(r.g_u[i]) : '∞',
+    ]));
+
+  $('result-section').hidden = false;
+}
+
+// AMPL writes ±1e19 for "no bound".
+const finite = (v) => v != null && Math.abs(v) < 1e19;
+
+// `SolvedToAcceptableLevel` → `Solved To Acceptable Level`.
+const spaced = (s) => String(s).replace(/([a-z])([A-Z])/g, '$1 $2');
+
+function table(el, headers, rows) {
+  el.innerHTML = '';
+  const thead = el.createTHead().insertRow();
+  for (const h of headers) {
+    const th = document.createElement('th');
+    th.textContent = h;
+    thead.append(th);
+  }
+  const body = el.createTBody();
+  for (const row of rows) {
+    const tr = body.insertRow();
+    for (const cell of row) tr.insertCell().textContent = cell;
+  }
+}

--- a/crates/pounce-wasm/web/index.html
+++ b/crates/pounce-wasm/web/index.html
@@ -1,0 +1,175 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>POUNCE in the browser</title>
+<style>
+  :root {
+    --bg: #fbfaf8;
+    --panel: #ffffff;
+    --ink: #1b1a18;
+    --muted: #6b6660;
+    --line: #e3ded6;
+    --accent: #b4530a;
+    --accent-soft: #fdf1e5;
+    --ok: #1f7a4d;
+    --bad: #a32020;
+    --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #16150f;
+      --panel: #1f1e18;
+      --ink: #efe9df;
+      --muted: #a29a8c;
+      --line: #35322a;
+      --accent: #f0913f;
+      --accent-soft: #2a2118;
+      --ok: #6ec894;
+      --bad: #ef8080;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 2rem 1.25rem 4rem;
+    background: var(--bg); color: var(--ink);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  main { max-width: 62rem; margin: 0 auto; }
+  h1 { font-size: 1.6rem; margin: 0 0 .25rem; letter-spacing: -.01em; }
+  h2 { font-size: 1rem; margin: 0 0 .75rem; text-transform: uppercase;
+       letter-spacing: .08em; color: var(--muted); }
+  .lede { color: var(--muted); margin: 0 0 1.5rem; max-width: 46rem; }
+  .lede code { font-family: var(--mono); font-size: .9em; }
+
+  #drop {
+    display: block;
+    border: 2px dashed var(--line); border-radius: 12px;
+    padding: 2.5rem 1.5rem; text-align: center; cursor: pointer;
+    background: var(--panel); transition: border-color .15s, background .15s;
+  }
+  #drop.over { border-color: var(--accent); background: var(--accent-soft); }
+  #drop strong { display: block; font-size: 1.05rem; margin-bottom: .3rem; }
+  #drop span { color: var(--muted); font-size: .9rem; }
+  #drop input { display: none; }
+
+  section { margin-top: 1.75rem; }
+  section[hidden] { display: none; }
+  .panel { background: var(--panel); border: 1px solid var(--line);
+           border-radius: 12px; padding: 1.25rem; }
+
+  .stats { display: grid; gap: .75rem 1.5rem;
+           grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr)); margin: 0; }
+  .stats div { border-left: 3px solid var(--line); padding-left: .7rem; }
+  .stats dt { color: var(--muted); font-size: .78rem; text-transform: uppercase;
+              letter-spacing: .06em; }
+  .stats dd { margin: .1rem 0 0; font: 600 1.15rem/1.2 var(--mono); }
+
+  .row { display: flex; gap: .75rem; align-items: flex-end; flex-wrap: wrap; }
+  textarea {
+    width: 100%; min-height: 5.5rem; resize: vertical; padding: .6rem .7rem;
+    font: 13px/1.5 var(--mono); color: var(--ink); background: var(--bg);
+    border: 1px solid var(--line); border-radius: 8px;
+  }
+  button {
+    font: 600 15px/1 system-ui, sans-serif; padding: .7rem 1.4rem;
+    background: var(--accent); color: #fff; border: 0; border-radius: 8px;
+    cursor: pointer;
+  }
+  button:disabled { opacity: .5; cursor: default; }
+
+  pre#log {
+    margin: 0; padding: .9rem 1rem; max-height: 22rem; overflow: auto;
+    background: #14130f; color: #e6ded0; border-radius: 10px;
+    font: 12px/1.45 var(--mono); white-space: pre; tab-size: 4;
+  }
+
+  table { width: 100%; border-collapse: collapse; font: 13px/1.45 var(--mono); }
+  th, td { text-align: right; padding: .35rem .5rem; border-bottom: 1px solid var(--line); }
+  th:first-child, td:first-child { text-align: left; }
+  th { color: var(--muted); font: 600 11px/1.4 system-ui, sans-serif;
+       text-transform: uppercase; letter-spacing: .06em; }
+  .tables { display: grid; gap: 1.25rem; grid-template-columns: 1fr; }
+  @media (min-width: 52rem) { .tables { grid-template-columns: 1fr 1fr; } }
+  .scroll { max-height: 20rem; overflow: auto; }
+  .tag { display: inline-block; padding: .15rem .5rem; border-radius: 999px;
+         font: 600 12px/1.5 system-ui, sans-serif; }
+  .tag.ok { background: color-mix(in srgb, var(--ok) 18%, transparent); color: var(--ok); }
+  .tag.bad { background: color-mix(in srgb, var(--bad) 18%, transparent); color: var(--bad); }
+  .err { color: var(--bad); }
+  .note { color: var(--muted); font-size: .85rem; margin-top: .6rem; }
+  footer { margin-top: 3rem; color: var(--muted); font-size: .85rem; }
+  a { color: var(--accent); }
+</style>
+</head>
+<body>
+<main>
+  <h1>POUNCE in the browser</h1>
+  <p class="lede">
+    The whole solver — the AMPL <code>.nl</code> reader, the reverse-mode AD tape, the
+    sparse linear algebra, and the interior-point algorithm — compiled to WebAssembly and
+    running locally in this tab. Drop a model in; nothing is uploaded anywhere.
+  </p>
+
+  <label id="drop" for="files">
+    <input id="files" type="file" multiple accept=".nl,.col,.row">
+    <strong>Drop an <code>.nl</code> file here</strong>
+    <span>or click to choose &mdash; optionally include the sibling <code>.col</code> / <code>.row</code> name files</span>
+  </label>
+  <p id="loaderr" class="err" hidden></p>
+
+  <section id="summary-section" hidden>
+    <h2>Problem summary <span id="filename" style="text-transform:none;letter-spacing:0"></span></h2>
+    <div class="panel">
+      <dl class="stats" id="stats"></dl>
+      <p class="note" id="summary-note"></p>
+    </div>
+  </section>
+
+  <section id="solve-section" hidden>
+    <h2>Solve</h2>
+    <div class="panel">
+      <label for="options" class="note" style="margin:0 0 .4rem;display:block">
+        Solver options, <code>ipopt.opt</code> format (one <code>name value</code> per line)
+      </label>
+      <textarea id="options" spellcheck="false">print_level 5
+max_iter 3000
+tol 1e-8</textarea>
+      <div class="row" style="margin-top:.75rem">
+        <button id="solve">Solve</button>
+        <span id="solve-status" class="note"></span>
+      </div>
+    </div>
+  </section>
+
+  <section id="result-section" hidden>
+    <h2>Result</h2>
+    <div class="panel">
+      <dl class="stats" id="result-stats"></dl>
+      <div class="tables" style="margin-top:1.25rem">
+        <div>
+          <h2>Variables</h2>
+          <div class="scroll"><table id="vars"></table></div>
+        </div>
+        <div>
+          <h2>Constraints</h2>
+          <div class="scroll"><table id="cons"></table></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="log-section" hidden>
+    <h2>Solver output</h2>
+    <pre id="log"></pre>
+  </section>
+
+  <footer>
+    POUNCE is a pure-Rust nonlinear interior-point solver.
+    <a href="https://github.com/jkitchin/pounce">github.com/jkitchin/pounce</a>
+  </footer>
+</main>
+<script type="module" src="./app.js"></script>
+</body>
+</html>

--- a/crates/pounce-wasm/web/wasi.js
+++ b/crates/pounce-wasm/web/wasi.js
@@ -1,0 +1,103 @@
+// Minimal `wasi_snapshot_preview1` host for a compute-only module.
+//
+// POUNCE's wasm build imports 14 WASI functions. Only four of them do
+// anything here — the solver writes its console output through `fd_write`,
+// times itself with `clock_time_get`, seeds its PRNG from `random_get`, and
+// reads (an empty) environment. The rest are filesystem entry points that
+// exist because Rust's std links them in; the solver never reaches them on
+// this path, so they return errno rather than pretending to work.
+//
+// Keeping the shim here (~60 lines) is what lets the demo run from a plain
+// static server with no build step, no npm install, and no `wasm-bindgen`.
+
+const ERRNO_SUCCESS = 0;
+const ERRNO_BADF = 8;
+const ERRNO_NOSYS = 52;
+
+/**
+ * @param {(text: string) => void} onStdout called with each chunk the module
+ *   writes to fd 1 / fd 2.
+ */
+export function createWasi(onStdout) {
+  let memory = null;
+  const decoder = new TextDecoder();
+  const dv = () => new DataView(memory.buffer);
+
+  const wasi_snapshot_preview1 = {
+    fd_write(fd, iovs, iovsLen, nwritten) {
+      const view = dv();
+      let written = 0;
+      let text = '';
+      for (let i = 0; i < iovsLen; i++) {
+        const ptr = view.getUint32(iovs + i * 8, true);
+        const len = view.getUint32(iovs + i * 8 + 4, true);
+        if (len > 0) text += decoder.decode(new Uint8Array(memory.buffer, ptr, len));
+        written += len;
+      }
+      view.setUint32(nwritten, written, true);
+      if (text) onStdout(text);
+      return ERRNO_SUCCESS;
+    },
+
+    // Monotonic and realtime clocks both map to `performance.now()`: the
+    // solver only ever takes differences (elapsed wall time per solve).
+    clock_time_get(_id, _precision, out) {
+      dv().setBigUint64(out, BigInt(Math.round(performance.now() * 1e6)), true);
+      return ERRNO_SUCCESS;
+    },
+    clock_res_get(_id, out) {
+      dv().setBigUint64(out, 1000n, true);
+      return ERRNO_SUCCESS;
+    },
+
+    random_get(buf, len) {
+      crypto.getRandomValues(new Uint8Array(memory.buffer, buf, len));
+      return ERRNO_SUCCESS;
+    },
+
+    // No environment, no args.
+    environ_sizes_get(count, size) {
+      const view = dv();
+      view.setUint32(count, 0, true);
+      view.setUint32(size, 0, true);
+      return ERRNO_SUCCESS;
+    },
+    environ_get: () => ERRNO_SUCCESS,
+    args_sizes_get(count, size) {
+      const view = dv();
+      view.setUint32(count, 0, true);
+      view.setUint32(size, 0, true);
+      return ERRNO_SUCCESS;
+    },
+    args_get: () => ERRNO_SUCCESS,
+
+    proc_exit(code) {
+      throw new Error(`wasm called proc_exit(${code})`);
+    },
+    sched_yield: () => ERRNO_SUCCESS,
+
+    // No filesystem in the browser sandbox.
+    fd_close: () => ERRNO_BADF,
+    fd_fdstat_get: () => ERRNO_BADF,
+    fd_fdstat_set_flags: () => ERRNO_BADF,
+    fd_prestat_get: () => ERRNO_BADF,
+    fd_prestat_dir_name: () => ERRNO_BADF,
+    fd_read: () => ERRNO_BADF,
+    fd_seek: () => ERRNO_BADF,
+    path_create_directory: () => ERRNO_NOSYS,
+    path_filestat_get: () => ERRNO_NOSYS,
+    path_open: () => ERRNO_NOSYS,
+  };
+
+  return {
+    imports: { wasi_snapshot_preview1 },
+    /** Must be called with the instance's memory before any other export. */
+    bind(instance) {
+      memory = instance.exports.memory;
+      // Reactor modules expose `_initialize`; call it when present.
+      if (typeof instance.exports._initialize === 'function') {
+        instance.exports._initialize();
+      }
+    },
+  };
+}

--- a/crates/pounce-wasm/web/worker.js
+++ b/crates/pounce-wasm/web/worker.js
@@ -1,0 +1,77 @@
+// Worker that owns the POUNCE wasm instance.
+//
+// A solve is a single synchronous call into wasm that can run for seconds,
+// so it lives off the main thread; the page stays responsive and the
+// solver's console output is streamed back as it is produced.
+
+import { createWasi } from './wasi.js';
+
+let exports = null;
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+const wasi = createWasi((text) => self.postMessage({ type: 'log', text }));
+
+const ready = (async () => {
+  const response = fetch('./pounce.wasm');
+  let instance;
+  try {
+    ({ instance } = await WebAssembly.instantiateStreaming(response, wasi.imports));
+  } catch {
+    // Streaming compilation needs `Content-Type: application/wasm`; not
+    // every static server sets it, so fall back to buffering the module.
+    const bytes = await (await fetch('./pounce.wasm')).arrayBuffer();
+    ({ instance } = await WebAssembly.instantiate(bytes, wasi.imports));
+  }
+  wasi.bind(instance);
+  exports = instance.exports;
+})();
+
+/** Copy a JS string into wasm memory. Returns [ptr, len]; ptr 0 for empty. */
+function intoWasm(str) {
+  if (!str) return [0, 0];
+  const bytes = encoder.encode(str);
+  const ptr = exports.pounce_alloc(bytes.length);
+  if (!ptr) throw new Error('wasm allocation failed');
+  new Uint8Array(exports.memory.buffer, ptr, bytes.length).set(bytes);
+  return [ptr, bytes.length];
+}
+
+/** Read a NUL-terminated string the module returned, then free it. */
+function fromWasm(ptr) {
+  if (!ptr) throw new Error('wasm returned a null string');
+  const mem = new Uint8Array(exports.memory.buffer);
+  let end = ptr;
+  while (mem[end] !== 0) end++;
+  const text = decoder.decode(mem.subarray(ptr, end));
+  exports.pounce_free_string(ptr);
+  return JSON.parse(text);
+}
+
+self.onmessage = async (event) => {
+  const msg = event.data;
+  try {
+    await ready;
+    if (msg.type === 'load') {
+      const args = [msg.nl, msg.col ?? '', msg.row ?? ''].map(intoWasm);
+      try {
+        const summary = fromWasm(exports.pounce_load(...args.flat()));
+        self.postMessage({ type: 'summary', summary });
+      } finally {
+        for (const [ptr, len] of args) if (ptr) exports.pounce_dealloc(ptr, len);
+      }
+    } else if (msg.type === 'solve') {
+      const [ptr, len] = intoWasm(msg.options ?? '');
+      const started = performance.now();
+      try {
+        const result = fromWasm(exports.pounce_solve(ptr, len));
+        result.browser_ms = performance.now() - started;
+        self.postMessage({ type: 'result', result });
+      } finally {
+        if (ptr) exports.pounce_dealloc(ptr, len);
+      }
+    }
+  } catch (err) {
+    self.postMessage({ type: 'fatal', message: String(err && err.message ? err.message : err) });
+  }
+};

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -35,6 +35,7 @@
 - [ODE / DAE Initial Value Problems](ode.md)
 - [Implicit DAEs](dae.md)
 - [Glass Box / Black Box Optimization](trf.md)
+- [WebAssembly: POUNCE in the Browser](wasm.md)
 
 # Global Search
 

--- a/docs/src/wasm.md
+++ b/docs/src/wasm.md
@@ -57,9 +57,21 @@ the CLI's `.nl` fixture suite, wasm and native agree on exit status and
 iteration count on every problem, with objectives matching to full double
 precision on all but one degenerate case (which differs in the last bit).
 
-Speed is what you would expect from wasm: a few tens of milliseconds for
-small models, roughly half a second for an 813-variable / 897-constraint
-model — within about 2× of the native build.
+Speed is what you would expect from wasm. Solver-internal wall time, same
+build, same code path, native `x86_64` vs `wasm32-wasip1` under Node:
+
+| model | n × m | native | wasm | ratio |
+| --- | --- | --- | --- | --- |
+| `pooling_rt2stp` | 46 × 72 | 9.9 ms | 40 ms | 4.0× |
+| `jit1` | 25 × 32 | 8.1 ms | 43 ms | 5.3× |
+| `airport` | 84 × 42 | 20 ms | 80 ms | 4.1× |
+| `autocorr_bern55-06` | 56 × 1 | 50 ms | 101 ms | 2.0× |
+| `deb7` | 813 × 897 | 461 ms | 556 ms | 1.2× |
+
+The larger the model, the closer wasm gets: small solves are dominated by
+per-call overhead, while big ones spend their time in the sparse
+factorization, where the gap narrows. Nothing here is tuned — no SIMD, no
+`wasm-opt`.
 
 ## How it is put together
 

--- a/docs/src/wasm.md
+++ b/docs/src/wasm.md
@@ -1,0 +1,89 @@
+# WebAssembly: POUNCE in the Browser
+
+POUNCE's default build is pure Rust — no C, no Fortran, no BLAS to link —
+so the entire solver compiles to WebAssembly and runs in a browser tab:
+the AMPL `.nl` reader, the reverse-mode AD tape, the sparse LDL^T
+factorization, and the interior-point algorithm. Nothing is sent to a
+server.
+
+The repository ships a working demo: drop a `.nl` file on a page, see what
+is in the model, and solve it.
+
+```sh
+rustup target add wasm32-wasip1        # once
+crates/pounce-wasm/build.sh --serve    # http://localhost:8000
+```
+
+Or `make wasm` to build the module without serving it. The page is a
+static directory (`crates/pounce-wasm/web/`); deploying it is a copy.
+
+## What you get
+
+Dropping a model shows the problem summary POUNCE derives while building
+its evaluator — sizes, degrees of freedom, how many rows are equalities,
+how much of the model is nonlinear, Jacobian and Hessian sparsity, and how
+the variable bounds break down. Solving streams the usual iteration table
+into the page (that really is the solver's stdout) and reports the exit
+status, KKT residuals, evaluation counts, and the solution vector next to
+the `.col` / `.row` names when you drop those alongside the `.nl`.
+
+Solve options are `ipopt.opt`-format text — the same option names the CLI
+and the Python API take.
+
+## Numerical parity with the native build
+
+The wasm build runs the same code, so it produces the same answers. Across
+the CLI's `.nl` fixture suite, wasm and native agree on exit status and
+iteration count on every problem, with objectives matching to full double
+precision on all but one degenerate case (which differs in the last bit).
+
+Speed is what you would expect from wasm: a few tens of milliseconds for
+small models, roughly half a second for an 813-variable / 897-constraint
+model — within about 2× of the native build.
+
+## How it is put together
+
+| Piece | What it is |
+| --- | --- |
+| `crates/pounce-wasm` | C-ABI entry points (`pounce_load`, `pounce_solve`), bytes in / JSON out |
+| `crates/pounce-wasm/web` | the demo page: `index.html`, `app.js`, `worker.js`, `wasi.js` |
+| `crates/pounce-wasm/build.sh` | builds the module and stages it into `web/` |
+
+The target is `wasm32-wasip1`, not `wasm32-unknown-unknown`. WASI gives the
+solver a clock (`std::time::Instant::now()` panics on
+`wasm32-unknown-unknown`, and POUNCE times every solve) and a stdout to
+write its iteration table to. Browsers do not implement WASI, so the page
+carries a ~60-line shim, `wasi.js`, which answers `clock_time_get` from
+`performance.now()` and turns each `fd_write` into a line in the log pane.
+That shim is the entire cost of the approach: no `wasm-bindgen`, no npm, no
+build step beyond `cargo build`.
+
+A solve is one synchronous call into wasm that can run for seconds, so the
+module lives in a web worker and the page stays responsive.
+
+## Limitations
+
+- **Single-threaded.** No threads are spawned; rayon-parallel paths run
+  serially. Results are unaffected.
+- **No AMPL imported functions.** A model that calls compiled-C external
+  functions (`funcadd_ASL` — IDAES property packages, for instance) needs a
+  dynamic loader the browser sandbox does not provide. The summary flags
+  such a model rather than failing mysteriously mid-solve.
+- **No HSL.** The optional `ma57` backend links Fortran; the wasm build
+  uses the default FERAL backend, like any stock `cargo build`.
+- **2.4 MB module**, about 800 kB gzipped over the wire.
+
+## Embedding it in your own page
+
+`crates/pounce-wasm` is a thin shim you can copy or fork. The ABI is four
+exports — allocate, load, solve, free — and every payload is JSON:
+
+```js
+const summary = fromWasm(wasm.pounce_load(nlPtr, nlLen, 0, 0, 0, 0));
+const result  = fromWasm(wasm.pounce_solve(optsPtr, optsLen));
+```
+
+Both entry points catch panics and return `{"error": …}`, so a malformed
+model cannot trap the instance. See `crates/pounce-wasm/web/README.md` for
+the full walkthrough and `crates/pounce-wasm/tests/smoke.mjs` for a
+headless (Node) driver of the same ABI.

--- a/docs/src/wasm.md
+++ b/docs/src/wasm.md
@@ -52,10 +52,18 @@ and the Python API take.
 
 ## Numerical parity with the native build
 
-The wasm build runs the same code, so it produces the same answers. Across
-the CLI's `.nl` fixture suite, wasm and native agree on exit status and
-iteration count on every problem, with objectives matching to full double
-precision on all but one degenerate case (which differs in the last bit).
+The wasm build runs the same code, so it produces the same answers. Over
+all 37 `.nl` fixtures in `crates/pounce-cli/tests/fixtures`, driven through
+the same entry points on both sides:
+
+- exit status: identical on 37 of 37
+- iteration count: identical on 37 of 37
+- objective: bit-identical on 34 of the 36 that return one; the two
+  exceptions (`scaled_feasible_a`, `feasible_x0_sentinel_bound`) differ by
+  one ulp, at objectives of 4.5e-10 and 7.1e-11
+
+The 37th (`presolve_overflow_feasible`) returns `InvalidNumberDetected`
+with no objective on either side — that is the fixture's job.
 
 Speed is what you would expect from wasm. Solver-internal wall time, same
 build, same code path, native `x86_64` vs `wasm32-wasip1` under Node:

--- a/docs/src/wasm.md
+++ b/docs/src/wasm.md
@@ -6,16 +6,36 @@ the AMPL `.nl` reader, the reverse-mode AD tape, the sparse LDL^T
 factorization, and the interior-point algorithm. Nothing is sent to a
 server.
 
-The repository ships a working demo: drop a `.nl` file on a page, see what
-is in the model, and solve it.
+**[Try it: jkitchin.github.io/pounce/demo](https://jkitchin.github.io/pounce/demo/)**
+— drop a `.nl` file on the page, see what is in the model, and solve it. The
+demo is published from this repository's `main` branch alongside these docs,
+and it runs it locally in your tab.
+
+To run the same page from a checkout:
 
 ```sh
 rustup target add wasm32-wasip1        # once
 crates/pounce-wasm/build.sh --serve    # http://localhost:8000
 ```
 
-Or `make wasm` to build the module without serving it. The page is a
-static directory (`crates/pounce-wasm/web/`); deploying it is a copy.
+Or `make wasm` to build the module without serving it.
+
+## Hosting it
+
+The page is a static directory (`crates/pounce-wasm/web/`) — deploying it
+anywhere is a copy. It needs no special server: no threads means no
+`SharedArrayBuffer`, so none of the `Cross-Origin-Opener-Policy` /
+`Cross-Origin-Embedder-Policy` headers that thread-enabled wasm requires,
+and every URL the page fetches is relative, so it works under any base
+path. If a host serves `.wasm` as something other than `application/wasm`,
+the page falls back from streaming compilation to a buffered
+`WebAssembly.instantiate` on its own.
+
+GitHub Pages is what this repository uses: `.github/workflows/docs.yml`
+builds the module and stages `crates/pounce-wasm/web/` into the docs site
+at `/demo/`, so the live demo ships with every docs deployment from `main`.
+The demo is version-independent — one live build, not one per archived
+release tag.
 
 ## What you get
 


### PR DESCRIPTION
## Problem

POUNCE could not run anywhere except a machine with a toolchain. Trying a
model meant installing something — a wheel, a binary, a Pyomo stack — which
is a real barrier for "here is my `.nl`, what does this solver make of it?",
for teaching, and for bug reports where the reporter's environment is the
variable you actually want to remove.

The solver's default build is pure Rust — no C, no Fortran, no system BLAS —
so nothing about it *should* have prevented a browser build. Nothing had
tried it.

## Cause

Two things, both found by building it rather than by reading the tree.

1. **`wasm32-unknown-unknown` compiles clean and then traps.** The whole
   dependency graph type-checks for that target today (`cargo check -p
   pounce-rs --target wasm32-unknown-unknown` passes as-is), but the first
   solve dies on `unreachable` inside `std::time::Instant::now`, which
   panics on that target. POUNCE calls it from ~20 sites — `wallclock_time`,
   the per-solve timers in `application.rs`, `pounce-qp`, `pounce-presolve`,
   the restoration timer. Supporting it means threading a clock abstraction
   through four crates.

   `wasm32-wasip1` has a clock, so it needs none of that. The cost is that
   browsers do not implement WASI, so the page carries a host shim.

2. **`pounce-nl` could not build for any wasm target.** It depends on
   `libloading` unconditionally for AMPL imported functions (`funcadd_ASL`),
   and `libloading::Library` does not exist without a dynamic loader.

## Fix

New crate `crates/pounce-wasm` (`publish = false`): a four-function C ABI —
`pounce_alloc`, `pounce_load`, `pounce_solve`, `pounce_free_string` — taking
`.nl` bytes plus `ipopt.opt`-format options and returning JSON. `pounce_load`
returns the problem summary (sizes, degrees of freedom, equality/inequality
split, nonlinear counts from `get_constraints_linearity`, Jacobian/Hessian
sparsity, bound tallies, declared external functions); `pounce_solve` returns
status, objective, iterates, constraint values, KKT residuals, and evaluation
counts. Both wrap the call in `catch_unwind`, so a malformed model returns
`{"error": …}` rather than trapping the instance for the page's lifetime.

The solve wraps `PresolveTnlp` exactly as `pounce-cli` does when the
`presolve` option is on, so the browser takes the same path as the CLI
rather than a quietly different one.

`crates/pounce-wasm/web/` is the demo page: drop a `.nl` (plus `.col`/`.row`
if you have them), read the summary, hit Solve, watch the real iteration
table stream in — that is the solver's stdout, arriving through `fd_write`.
The module runs in a worker so a multi-second solve does not freeze the UI.

Rejected: `wasm-bindgen`. It would have replaced a 60-line `wasi.js` with a
generated-bindings toolchain (`wasm-pack`, version-locked CLI, npm) and
still left the `Instant::now` problem, since it targets
`wasm32-unknown-unknown`. Raw C ABI + WASI keeps the build at `cargo build`
and the page at static files.

`pounce-nl` change: `libloading` becomes a `cfg(any(unix, windows))`
dependency, and `ExternalLibrary::load` gets a stub for other targets that
reports imported functions are unavailable there. Unix/Windows behaviour is
byte-identical — same dependency, same code, same tests.

`docs.yml` builds the module and stages the page into the existing Pages
artifact at `/demo/`, so <https://jkitchin.github.io/pounce/demo/> tracks
`main`. It is staged in the workflow rather than in
`build-versioned-docs.sh` because the demo is version-independent (one live
build, not one per archived tag) and that script wipes its output per
version. The page needs no Pages configuration: single-threaded, so no
`SharedArrayBuffer` and no COOP/COEP headers — which Pages cannot set — and
every URL it fetches is relative, so the `/pounce/` base path works
unchanged.

## Blast radius

**No solver code changed.** The diff touches no algorithm, no linear
algebra, no option handling. `pounce-nl`'s change is a `cfg` gate that
evaluates true on every platform anyone builds on today.

Numerics, wasm vs native driven through the *same* entry points — all 37
`.nl` fixtures in `crates/pounce-cli/tests/fixtures`:

- exit status: identical on 37 of 37
- iteration count: identical on 37 of 37
- objective: bit-identical on 34 of the 36 that return one

The two exceptions are one ulp apart at objectives already at zero:
`scaled_feasible_a` (a `SearchDirectionBecomesTooSmall` case)
`4.5080781541181337e-10` vs `4.508078154118134e-10`, and
`feasible_x0_sentinel_bound` `7.095788124492583e-11` vs
`7.095788124492584e-11`. The 37th, `presolve_overflow_feasible`, returns
`InvalidNumberDetected` with no objective on either side, as it should.

Speed, solver-internal wall time, same build both sides:

| model | n × m | native | wasm | ratio |
| --- | --- | --- | --- | --- |
| `pooling_rt2stp` | 46 × 72 | 9.9 ms | 40 ms | 4.0× |
| `jit1` | 25 × 32 | 8.1 ms | 43 ms | 5.3× |
| `airport` | 84 × 42 | 20 ms | 80 ms | 4.1× |
| `autocorr_bern55-06` | 56 × 1 | 50 ms | 101 ms | 2.0× |
| `deb7` | 813 × 897 | 461 ms | 556 ms | 1.2× |

Release surface: the new crate is `publish = false`, so the crates.io
publish list is unchanged — `scripts/check-release-consistency.sh` passes,
still 20 crates.

CI: one new job (`wasm`, ~build + a Node smoke test). The `docs` job now
also builds the wasm module, so a docs-only deployment costs a cached cargo
build it did not before.

Known limitations, all documented in `docs/src/wasm.md` and surfaced in the
page: single-threaded (rayon paths run serially — results unaffected); AMPL
imported functions cannot be evaluated (the summary flags a model that
declares them); no HSL; 2.4 MB module, ~800 kB gzipped.

## Tests

- `cargo test -p pounce-wasm` — 6 tests driving the C ABI the way the page
  does (bytes in, JSON out): summary shape, `.col`/`.row` names applied only
  when the length matches, malformed input as an error rather than a panic,
  a solve reaching the analytic optimum of the fixture
  (`min x0 s.t. x0²+x1²=1, x0+x1≥0` → `-1/√2`), solve-with-nothing-loaded,
  and a rejected option string. These do not "fail on the parent commit" —
  the surface is new, and nothing in the tree behaves differently without
  them.
- `crates/pounce-wasm/tests/smoke.mjs`, run in CI under Node's WASI against
  the actual `.wasm`. This is the test that bites: it catches a dependency
  that stops compiling for wasm32 *and* one that compiles but traps at run
  time on a missing syscall — neither of which the host-side unit tests can
  see. Both failure modes are real and were hit while building this: the
  pre-fix `pounce-nl` fails the job's build step (`cargo check -p pounce-nl
  --target wasm32-wasip1` → `E0432: no Library in the root`), and the
  run-time trap is exactly what `wasm32-unknown-unknown` does at the first
  `Instant::now` — observed there with an equivalent harness before the
  target choice was settled, not reproduced through `smoke.mjs` itself.
- Manual browser verification (headless Chromium): `jit1.nl` and
  `airport.nl` loaded, summarized, and solved end-to-end; `.col`/`.row`
  names rendered against the solution; the same page served under a
  `/pounce/demo/` base path to match the Pages layout; and against a server
  that mislabels `.wasm` as `application/octet-stream`, to exercise the
  fallback from streaming compilation to a buffered `instantiate`.

**Not pinned:** the page itself. There is no browser-driver dependency in
CI, so `app.js` / `worker.js` / `wasi.js` are covered only by the manual
runs above; the smoke test covers the wasm module beneath them. Adding
Playwright to CI for one page seemed the wrong trade — flagging it as a
known gap instead.

---

- [ ] Tests fail on the parent commit for the stated reason — *n/a: new
      surface, nothing in the tree behaves differently without these tests.
      See the Tests section for what the CI smoke test does catch.*
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --exclude
      pounce-hsl --all-targets -- -D clippy::correctness -D
      clippy::suspicious`, and `cargo test --workspace --exclude pounce-hsl`
      all clean; `scripts/check-release-consistency.sh` and
      `scripts/check-docs-consistency.sh` pass
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo18npVJ6ezp3d4cN4adNU)_