### PR TITLE
Build the bundled Linux CLI inside the manylinux container (#452)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,13 @@ jobs:
           sccache: "true"
           before-script-linux: |
             set -eux
+            # sccache: "true" exports RUSTC_WRAPPER=sccache and the action
+            # forwards it into the container, but sccache is installed on the
+            # HOST — inside here cargo would try to exec a wrapper that does
+            # not exist ("could not execute process `sccache ...`"). maturin's
+            # own build later gets a container-local sccache; this pre-step
+            # does not need one.
+            unset RUSTC_WRAPPER
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
             cd "$d"
@@ -286,6 +293,13 @@ jobs:
           sccache: "true"
           before-script-linux: |
             set -eux
+            # sccache: "true" exports RUSTC_WRAPPER=sccache and the action
+            # forwards it into the container, but sccache is installed on the
+            # HOST — inside here cargo would try to exec a wrapper that does
+            # not exist ("could not execute process `sccache ...`"). maturin's
+            # own build later gets a container-local sccache; this pre-step
+            # does not need one.
+            unset RUSTC_WRAPPER
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
             cd "$d"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,14 @@ jobs:
             # "missing field `package`".
             (
               cd "$d"
+              # actions/checkout marks the repo safe in the RUNNER's git
+              # config, but this container has its own HOME (/root), so git
+              # here sees a mounted tree owned by another uid and refuses it
+              # as dubiously-owned. crates/pounce-cli/build.rs shells out to
+              # git for the commit it stamps into `pounce --about`; without
+              # this the binary reports "unknown" and pyomo-pounce's
+              # build-id checks fail against it.
+              git config --global --add safe.directory "$d" || true
               ldd --version
               cargo build --release --locked --bin pounce
               mkdir -p python/pounce/bin
@@ -316,6 +324,14 @@ jobs:
             # "missing field `package`".
             (
               cd "$d"
+              # actions/checkout marks the repo safe in the RUNNER's git
+              # config, but this container has its own HOME (/root), so git
+              # here sees a mounted tree owned by another uid and refuses it
+              # as dubiously-owned. crates/pounce-cli/build.rs shells out to
+              # git for the commit it stamps into `pounce --about`; without
+              # this the binary reports "unknown" and pyomo-pounce's
+              # build-id checks fail against it.
+              git config --global --add safe.directory "$d" || true
               cargo build --release --locked --bin pounce
               mkdir -p python/pounce/bin
               cp target/release/pounce python/pounce/bin/pounce

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,12 +191,11 @@ jobs:
           python-version: "3.11"
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - name: Build pounce CLI binary
-        run: cargo build --release --bin pounce
-      - name: Stage CLI binary into wheel
-        run: |
-          mkdir -p python/pounce/bin
-          cp target/release/pounce python/pounce/bin/pounce
+      # Mirrors release-pounce.yml: the bundled CLI is built INSIDE the
+      # manylinux container, not on this runner (#452). Building it here with
+      # a plain `cargo build` is precisely what let a glibc-2.39 binary ship
+      # inside a manylinux2014-tagged wheel — and nothing downstream could
+      # notice, because every check ran on the same host that built it.
       - name: Build wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -205,6 +204,17 @@ jobs:
           manylinux: manylinux2014
           args: --release --out dist
           sccache: "true"
+          before-script-linux: |
+            set -eux
+            d="$PWD"
+            while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
+            cd "$d"
+            ldd --version | head -1
+            cargo build --release --locked --bin pounce
+            mkdir -p python/pounce/bin
+            cp target/release/pounce python/pounce/bin/pounce
+      - name: Verify bundled CLI honors the manylinux2014 floor
+        run: scripts/check-cli-portability.sh python/pounce/bin/pounce 2.17
       - name: Install + smoke (Python API + CLI)
         run: |
           ls -l python/dist/
@@ -216,6 +226,24 @@ jobs:
           # round-trip without needing an actual .nl input file.
           which pounce
           pounce --help | head -5
+      # The check the previous arrangement could not make. Everything above
+      # runs on the host that built the binary, where a glibc floor is
+      # invisible by construction (#452). Install the same wheel on a distro
+      # far older than the runner and actually solve a problem on it.
+      # manylinux2014 is glibc 2.17 — the floor the wheel advertises, and
+      # older than any machine we care about.
+      - name: Solve with the wheel on old glibc (glibc 2.17)
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD:/w" -w /w quay.io/pypa/manylinux2014_x86_64 bash -euxc '
+            ldd --version | head -1
+            PY=/opt/python/cp39-cp39/bin/python
+            "$PY" -m pip install -q /w/python/dist/*.whl
+            BIN=$("$PY" -c "import pounce,os;print(os.path.join(os.path.dirname(pounce.__file__),\"bin\",\"pounce\"))")
+            "$BIN" --version
+            "$BIN" --problem rosenbrock --no-sol
+            "$PY" -c "import pounce; print(\"import ok on glibc 2.17:\", pounce.__version__)"
+          '
 
   # Smoke-build the pyomo-pounce wheel and run its test suite. Pure-Python
   # now: the `pounce` binary comes from the `pounce-solver` dep, not bundled
@@ -247,12 +275,7 @@ jobs:
       # the CLI. The wheel bundles the CLI, so its console script also satisfies
       # the SolverFactory plugin's `.solve()` path. The pyomo-pounce sensitivity
       # tests exercise both.
-      - name: Build pounce CLI binary
-        run: cargo build --release --bin pounce
-      - name: Stage CLI binary into pounce-solver wheel
-        run: |
-          mkdir -p python/pounce/bin
-          cp target/release/pounce python/pounce/bin/pounce
+      # As in wheel-smoke: CLI built inside the manylinux container (#452).
       - name: Build pounce-solver wheel
         uses: PyO3/maturin-action@v1
         with:
@@ -261,6 +284,14 @@ jobs:
           manylinux: manylinux2014
           args: --release --out dist
           sccache: "true"
+          before-script-linux: |
+            set -eux
+            d="$PWD"
+            while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
+            cd "$d"
+            cargo build --release --locked --bin pounce
+            mkdir -p python/pounce/bin
+            cp target/release/pounce python/pounce/bin/pounce
       - name: Install + smoke
         run: |
           # pyomo + numpy (sensitivity needs numpy); networkx + scipy so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
             cd "$d"
-            ldd --version | head -1
+            ldd --version
             cargo build --release --locked --bin pounce
             mkdir -p python/pounce/bin
             cp target/release/pounce python/pounce/bin/pounce
@@ -236,7 +236,7 @@ jobs:
         run: |
           set -euo pipefail
           docker run --rm -v "$PWD:/w" -w /w quay.io/pypa/manylinux2014_x86_64 bash -euxc '
-            ldd --version | head -1
+            ldd --version
             PY=/opt/python/cp39-cp39/bin/python
             "$PY" -m pip install -q /w/python/dist/*.whl
             BIN=$("$PY" -c "import pounce,os;print(os.path.join(os.path.dirname(pounce.__file__),\"bin\",\"pounce\"))")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,11 +215,18 @@ jobs:
             unset RUSTC_WRAPPER
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
-            cd "$d"
-            ldd --version
-            cargo build --release --locked --bin pounce
-            mkdir -p python/pounce/bin
-            cp target/release/pounce python/pounce/bin/pounce
+            # Subshell, deliberately. maturin runs from this SAME script
+            # afterwards and expects to still be in python/. A bare `cd` here
+            # leaked the workspace root into that invocation, where maturin
+            # parsed the workspace Cargo.toml and died with
+            # "missing field `package`".
+            (
+              cd "$d"
+              ldd --version
+              cargo build --release --locked --bin pounce
+              mkdir -p python/pounce/bin
+              cp target/release/pounce python/pounce/bin/pounce
+            )
       - name: Verify bundled CLI honors the manylinux2014 floor
         run: scripts/check-cli-portability.sh python/pounce/bin/pounce 2.17
       - name: Install + smoke (Python API + CLI)
@@ -302,10 +309,17 @@ jobs:
             unset RUSTC_WRAPPER
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
-            cd "$d"
-            cargo build --release --locked --bin pounce
-            mkdir -p python/pounce/bin
-            cp target/release/pounce python/pounce/bin/pounce
+            # Subshell, deliberately. maturin runs from this SAME script
+            # afterwards and expects to still be in python/. A bare `cd` here
+            # leaked the workspace root into that invocation, where maturin
+            # parsed the workspace Cargo.toml and died with
+            # "missing field `package`".
+            (
+              cd "$d"
+              cargo build --release --locked --bin pounce
+              mkdir -p python/pounce/bin
+              cp target/release/pounce python/pounce/bin/pounce
+            )
       - name: Install + smoke
         run: |
           # pyomo + numpy (sensitivity needs numpy); networkx + scipy so

--- a/.github/workflows/release-pounce.yml
+++ b/.github/workflows/release-pounce.yml
@@ -167,12 +167,19 @@ jobs:
             # workspace root rather than assuming a fixed mount path.
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
-            cd "$d"
-            ldd --version
-            cargo build --release --locked --bin pounce
-            mkdir -p python/pounce/bin
-            cp target/release/pounce python/pounce/bin/pounce
-            ls -l python/pounce/bin/
+            # Subshell, deliberately. maturin runs from this SAME script
+            # afterwards and expects to still be in python/. A bare `cd` here
+            # leaked the workspace root into that invocation, where maturin
+            # parsed the workspace Cargo.toml and died with
+            # "missing field `package`".
+            (
+              cd "$d"
+              ldd --version
+              cargo build --release --locked --bin pounce
+              mkdir -p python/pounce/bin
+              cp target/release/pounce python/pounce/bin/pounce
+              ls -l python/pounce/bin/
+            )
 
       # The guard that was missing (#452). Every pre-existing check ran on
       # the host that built the binary — the one platform where a glibc floor

--- a/.github/workflows/release-pounce.yml
+++ b/.github/workflows/release-pounce.yml
@@ -174,6 +174,14 @@ jobs:
             # "missing field `package`".
             (
               cd "$d"
+              # actions/checkout marks the repo safe in the RUNNER's git
+              # config, but this container has its own HOME (/root), so git
+              # here sees a mounted tree owned by another uid and refuses it
+              # as dubiously-owned. crates/pounce-cli/build.rs shells out to
+              # git for the commit it stamps into `pounce --about`; without
+              # this the binary reports "unknown" and pyomo-pounce's
+              # build-id checks fail against it.
+              git config --global --add safe.directory "$d" || true
               ldd --version
               cargo build --release --locked --bin pounce
               mkdir -p python/pounce/bin

--- a/.github/workflows/release-pounce.yml
+++ b/.github/workflows/release-pounce.yml
@@ -156,6 +156,13 @@ jobs:
           # for this matrix entry (x86_64 or aarch64 manylinux2014).
           before-script-linux: |
             set -eux
+            # sccache: "true" exports RUSTC_WRAPPER=sccache and the action
+            # forwards it into the container, but sccache is installed on the
+            # HOST — inside here cargo would try to exec a wrapper that does
+            # not exist ("could not execute process `sccache ...`"). maturin's
+            # own build later gets a container-local sccache; this pre-step
+            # does not need one.
+            unset RUSTC_WRAPPER
             # The action's working directory is python/; walk up to the
             # workspace root rather than assuming a fixed mount path.
             d="$PWD"

--- a/.github/workflows/release-pounce.yml
+++ b/.github/workflows/release-pounce.yml
@@ -161,7 +161,7 @@ jobs:
             d="$PWD"
             while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
             cd "$d"
-            ldd --version | head -1
+            ldd --version
             cargo build --release --locked --bin pounce
             mkdir -p python/pounce/bin
             cp target/release/pounce python/pounce/bin/pounce

--- a/.github/workflows/release-pounce.yml
+++ b/.github/workflows/release-pounce.yml
@@ -107,10 +107,16 @@ jobs:
       # Build the standalone pounce CLI binary and stage it inside the
       # Python package source tree. `[tool.maturin] include` in
       # pyproject.toml then pulls it into the wheel under pounce/bin/.
+      #
+      # macOS / Windows ONLY. On Linux this moved into the manylinux
+      # container — see `before-script-linux` on the maturin step below and
+      # the explanation there (#452).
       - name: Build pounce CLI binary
+        if: runner.os != 'Linux'
         run: cargo build --release --bin pounce --target ${{ matrix.rust_target }}
 
       - name: Stage CLI binary into the wheel
+        if: runner.os != 'Linux'
         shell: bash
         run: |
           mkdir -p python/pounce/bin
@@ -127,6 +133,48 @@ jobs:
           # abi3-py39 means one wheel per platform covers py39+.
           args: --release --out dist
           sccache: "true"
+          # THE FIX FOR #452. On Linux the bundled CLI is built HERE, inside
+          # the manylinux container, rather than on the runner beforehand.
+          #
+          # The old arrangement built it on the host and only then handed the
+          # tree to maturin. maturin then built the extension module inside
+          # manylinux2014 (glibc 2.17) and labelled the wheel to match — but
+          # the CLI sitting next to it had been linked against the runner's
+          # glibc (Ubuntu 24.04 = 2.39). auditwheel does not inspect
+          # pounce/bin/pounce; to the wheel format it is opaque data, not a
+          # linked object. So the wheel promised 2.17 and shipped a binary
+          # needing 2.39, and `pounce` could not start on Debian 12, RHEL
+          # 8/9, or most cluster images — while every CI check passed,
+          # because they all ran on the same 2.39 host that built it.
+          #
+          # Building in the container makes the promise and the artifact come
+          # from the same place, which is the only arrangement that cannot
+          # drift. Nothing about the source changes: POUNCE is pure Rust, so
+          # the container only has to supply a linker.
+          #
+          # No --target: the container's host triple is already the right one
+          # for this matrix entry (x86_64 or aarch64 manylinux2014).
+          before-script-linux: |
+            set -eux
+            # The action's working directory is python/; walk up to the
+            # workspace root rather than assuming a fixed mount path.
+            d="$PWD"
+            while [ "$d" != "/" ] && [ ! -f "$d/Cargo.toml" ]; do d="$(dirname "$d")"; done
+            cd "$d"
+            ldd --version | head -1
+            cargo build --release --locked --bin pounce
+            mkdir -p python/pounce/bin
+            cp target/release/pounce python/pounce/bin/pounce
+            ls -l python/pounce/bin/
+
+      # The guard that was missing (#452). Every pre-existing check ran on
+      # the host that built the binary — the one platform where a glibc floor
+      # cannot show up. Assert the property on the artifact instead. Runs on
+      # the host after the container build; the staged binary persists there
+      # because the workspace is mounted into the container.
+      - name: Verify bundled CLI honors the manylinux2014 floor
+        if: runner.os == 'Linux'
+        run: scripts/check-cli-portability.sh python/pounce/bin/pounce 2.17
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,41 @@ changes.
   became a `cfg(any(unix, windows))` dependency and `ExternalLibrary::load`
   reports that AMPL imported functions are unavailable there rather than
   failing to compile. No change on unix/windows.
+### Fixed — Linux wheels shipped a CLI that could not start on most clusters (#452)
+
+- The published Linux wheels were tagged `manylinux2014` (glibc 2.17) but
+  bundled a `pounce` CLI requiring **glibc 2.39**. On anything older the
+  binary refused to exec:
+
+      pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6:
+        version `GLIBC_2.39' not found
+
+  `import pounce` was unaffected, but everything driving the CLI —
+  the `pounce` console script and all of pyomo-pounce, which shells out
+  to it — failed on Debian 12, Ubuntu 22.04, RHEL/Rocky/Alma 8 and 9, and
+  most HPC images. `pip install` reported success; the failure came at
+  exec time.
+- Cause: `release-pounce.yml` built the CLI on the runner host (Ubuntu
+  24.04, glibc 2.39) and only then handed the tree to maturin, which built
+  the extension module inside the manylinux container and labelled the
+  wheel accordingly. auditwheel never inspects `pounce/bin/pounce` — to the
+  wheel format it is opaque data, not a linked object — so the mismatch
+  shipped silently. Exactly two symbols set the floor, `pidfd_spawnp` and
+  `pidfd_getpid`, from Rust std's process-spawn path; everything else the
+  binary needed topped out at glibc 2.34.
+- Fix: build the CLI **inside** the manylinux container, via maturin's
+  `before-script-linux`, so the artifact and the compatibility promise come
+  from the same place. No source change — POUNCE is pure Rust, so the
+  container only has to supply a linker. The resulting floor is glibc 2.16,
+  and wall-clock on the large_scale `sparseqp` / `optcontrol` / `rosenbrock`
+  problems is unchanged (same allocator, same codegen).
+- Guard: `scripts/check-cli-portability.sh` asserts the bundled binary's
+  highest referenced glibc symbol version stays within the wheel's
+  manylinux floor, and CI now installs the built wheel in a glibc-2.17
+  container and solves with it. Neither check existed before, and the
+  pre-existing wheel smoke test could not have caught this: it ran on the
+  same host that built the binary, the one platform where the floor is
+  invisible.
 
 ### Fixed — pyomo-pounce: a fixed variable shifted every sensitivity result
 

--- a/scripts/check-cli-portability.sh
+++ b/scripts/check-cli-portability.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Assert that a bundled Linux `pounce` CLI can actually run everywhere the
+# wheel claims it can.
+#
+# WHY THIS EXISTS (#452). The wheels ship the CLI as an opaque file inside
+# pounce/bin/. auditwheel never looks at it — as far as the wheel format is
+# concerned it is data, not a linked object — so a wheel can advertise
+# manylinux2014 (glibc 2.17) while the binary beside it demands something far
+# newer. That is exactly what shipped in 0.9.0: the CLI was built on the
+# release runner (Ubuntu 24.04, glibc 2.39) rather than inside the manylinux
+# container maturin builds the extension module in, so it refused to start on
+# Debian 12, RHEL 8/9, and most cluster images with
+#
+#   pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6:
+#     version `GLIBC_2.39' not found
+#
+# Exactly two symbols caused it — pidfd_spawnp and pidfd_getpid, from Rust
+# std's process-spawn path. Nothing in POUNCE's numerics. Everything else the
+# binary needed topped out at glibc 2.34.
+#
+# The existing wheel-smoke job could not catch this: it runs on the same host
+# that built the binary, the one platform where the floor is invisible by
+# construction. So check the property on the artifact instead of inferring it
+# from a successful run.
+#
+# Usage:
+#   scripts/check-cli-portability.sh <binary> [max-glibc]
+#
+# max-glibc defaults to 2.17, the manylinux2014 floor that python/pyproject
+# builds against. Raise it only by also raising the wheel's manylinux tag —
+# they are two halves of the same promise.
+
+set -euo pipefail
+
+BIN="${1:?usage: check-cli-portability.sh <binary> [max-glibc]}"
+MAX="${2:-2.17}"
+
+[[ -f "$BIN" ]] || { echo "check-cli-portability: no such file: $BIN" >&2; exit 1; }
+command -v objdump >/dev/null 2>&1 || {
+  echo "check-cli-portability: objdump not found (install binutils)" >&2
+  exit 1
+}
+
+echo "== $BIN =="
+file "$BIN" || true
+
+# Versioned glibc symbol references are what actually break at exec time: the
+# dynamic loader refuses to start a binary asking for a symbol version the
+# host's libc does not define. The highest one referenced IS the floor.
+vers="$(objdump -T "$BIN" 2>/dev/null | grep -o 'GLIBC_[0-9.]*' | sort -uV || true)"
+
+if [[ -z "$vers" ]]; then
+  # A static build (e.g. musl) references no versioned symbols at all. Not
+  # what we produce today, but it trivially satisfies any floor.
+  echo "  OK — no versioned glibc symbols (static; no runtime floor)"
+  echo "check-cli-portability: OK"
+  exit 0
+fi
+
+highest="$(echo "$vers" | tail -1)"
+highest_num="${highest#GLIBC_}"
+
+echo "  glibc versions referenced: $(echo "$vers" | tr '\n' ' ')"
+echo "  highest (the runtime floor): $highest_num"
+echo "  allowed maximum:             $MAX"
+
+# sort -V puts the larger version last; if that is not $MAX, the binary needs
+# something newer than we promise.
+if [[ "$(printf '%s\n%s\n' "$highest_num" "$MAX" | sort -V | tail -1)" != "$MAX" ]]; then
+  echo
+  echo "  FAIL — the bundled CLI requires glibc $highest_num but the wheel"
+  echo "         promises $MAX. It will not start on anything older."
+  echo "         Symbols forcing the floor:"
+  objdump -T "$BIN" | grep "GLIBC_${highest_num}\b" | awk '{print $NF}' | sort -u \
+    | while IFS= read -r s; do printf '           %s\n' "$s"; done
+  echo
+  echo "check-cli-portability: FAILED — the CLI must be built INSIDE the" >&2
+  echo "  manylinux container, not on the runner host. See #452." >&2
+  exit 1
+fi
+
+echo "  OK — floor is within the manylinux2014 promise"
+echo "check-cli-portability: OK"


### PR DESCRIPTION
Fixes #452

## The bug

`pounce-solver`'s Linux wheels are tagged `manylinux2014` (glibc 2.17) but bundle a `pounce` CLI that requires **glibc 2.39**:

```
pounce/bin/pounce: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found
```

`import pounce` works. Everything that runs the CLI does not — the console script, and all of pyomo-pounce, which shells out to the binary. That breaks Debian 12, Ubuntu 22.04, RHEL/Rocky/Alma 8 and 9, and most HPC images. `pip install` reports success; the failure comes later, at exec time.

## Cause

`release-pounce.yml` built the CLI on the runner host and *then* handed the tree to maturin:

```yaml
- run: cargo build --release --bin pounce --target ...    # runner: Ubuntu 24.04, glibc 2.39
- uses: PyO3/maturin-action@v1
  with: { manylinux: manylinux2014 }                      # container: glibc 2.17
```

The extension module genuinely is manylinux2014. The CLI beside it never entered that container. **auditwheel never inspects `pounce/bin/pounce`** — to the wheel format it is opaque data, not a linked object — so the mismatch shipped silently.

Exactly two symbols set the floor, both from Rust std's process-spawn path (reached via `debug_repl.rs` launching an external viewer):

```
pidfd_spawnp
pidfd_getpid
```

Everything else the binary needs tops out at glibc 2.34. Nothing in POUNCE's numerics is involved.

## Fix

Build the CLI **inside** the container maturin already uses, via `before-script-linux`, so the artifact and the compatibility promise come from the same place.

**No source change.** POUNCE is pure Rust, so the container only has to supply a linker.

Verified by building the real CLI in `quay.io/pypa/manylinux2014_x86_64`:

```
glibc versions referenced: GLIBC_2.2.5 ... GLIBC_2.15 GLIBC_2.16
highest (the runtime floor): 2.16          <- was 2.39
  OK — floor is within the manylinux2014 promise
EXIT: Optimal Solution Found.
```

Wall-clock is unchanged within noise (same allocator, same codegen):

| problem | before | manylinux build |
|---|---|---|
| sparseqp | 18100–19500 ms | 18247 ms |
| optcontrol | 6900–7100 ms | 7145 ms |
| rosenbrock | ~4600 ms | 4781 ms |

glibc 2.17 reaches back to RHEL 7 / Ubuntu 14.04 / Debian 8 (all 2014), which covers every machine this realistically runs on.

## Guards

The reason this shipped is that **nothing could have caught it**. `wheel smoke (pounce-solver)` runs on `ubuntu-latest` and builds the CLI on that same host — the one platform where a glibc floor is invisible by construction. It passed on every commit, including the PR that first introduced the problem.

Two new checks:

1. **`scripts/check-cli-portability.sh`** — asserts the highest glibc symbol version the binary references stays within the wheel's manylinux floor, and names the offending symbols when it doesn't. Verified against both a good and a bad binary; on the 0.9.0-style build it prints exactly `pidfd_getpid` / `pidfd_spawnp` and exits 1.
2. **An old-glibc end-to-end test** — CI installs the built wheel inside a glibc-2.17 container and actually solves a problem with it.

Both CI wheel-smoke jobs now build the CLI the same way the release does, so the two can't drift apart again.

## A note on how I got here

I initially recommended a static musl build, and implemented it, before measuring anything. Two things came out of actually testing it:

- **musl alone is 1.6× slower** — 29.9 s vs 18.1 s on `sparseqp`, 11.2 s vs 7.1 s on `optcontrol` — because of musl's `mallocng` under the sparse factorization's allocation load.
- Recovering that needed **mimalloc**, i.e. adding a **C dependency** to a project whose headline claim is not having one, plus a `#[global_allocator]` swap and a dedicated CI job to test an allocator that no other job would compile.

@jkitchin caught that this was disproportionate, and was right. The manylinux route costs nothing, changes no code, and reaches every distro that matters. All of the musl/mimalloc work is reverted in this branch; the diff is 3 workflow edits plus one new script.

One loose thread worth recording separately: musl+mimalloc measured **2.8× faster** than the glibc build on `sparseqp` (7.0 s vs 19.5 s). That result is **confounded** — two variables changed at once, and I never ran gnu+mimalloc — so it proves nothing on its own. But it's a strong enough hint that the solver may be allocator-bound on some problems to be worth its own investigation, separate from this fix.

## Release note

0.9.0 on PyPI stays broken regardless of what merges here; the wheels need rebuilding. This fix takes effect on the next `python-v*` tag. Once that ships, `docker/Dockerfile.release` (PR #453) can drop its `trixie` pin back to `bookworm` — the comment there points at #452.

## Checks

`actionlint` (all workflows), `shellcheck`, `check-docs-consistency.sh`, `check-release-consistency.sh` pass locally. The workflow change itself is exercised by this PR's own CI run — both wheel-smoke jobs use the new container build, and the new old-glibc job proves the resulting wheel runs on glibc 2.17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
