### PR TITLE
Give the Python page a real editor: highlighting, line numbers, indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,13 @@ jobs:
       - name: Solve a model in wasm
         run: node crates/pounce-wasm/tests/smoke.mjs
 
+      # The Python-page highlighter is one regex with alternation — the kind
+      # of code that breaks quietly (a mis-numbered backreference once made
+      # every string containing an escape fall apart, and the page still
+      # rendered, just wrong).
+      - name: Highlighter tokens
+        run: node crates/pounce-wasm/tests/editor_tokens.mjs
+
       # The Pyodide app's Python layer (web-python/pounce_browser.py) maps
       # the `.sol` blocks back onto Pyomo components by writer order. Getting
       # that wrong puts plausible numbers on the wrong variables, which no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ changes.
   optimum and multipliers, run in CI with Node standing in for the browser.
   It is Pyomo's modelling layer rather than POUNCE's Python API: the model
   crosses as a file, so there are no Python callbacks mid-solve.
+- The Python page's script box is an editor rather than a bare textarea:
+  syntax highlighting, line numbers, Tab / Shift-Tab block indent, and
+  indentation carried across Enter (one level deeper after a colon). No
+  editor library — a highlighted `<pre>` under a transparent `<textarea>`,
+  so the caret, selection, and undo stay the browser's, and the page keeps
+  working offline where a CDN-loaded editor would not.
 - The demos are published with the docs: `docs.yml` builds the module and
   stages both pages into the Pages site
   ([`/demo/`](https://jkitchin.github.io/pounce/demo/) and

--- a/crates/pounce-wasm/tests/editor_tokens.mjs
+++ b/crates/pounce-wasm/tests/editor_tokens.mjs
@@ -1,0 +1,52 @@
+// Unit tests for the Python highlighter in web-python/editor.js.
+//
+//   node crates/pounce-wasm/tests/editor_tokens.mjs
+//
+// The tokenizer is one regex with alternation, which is exactly the kind of
+// code that breaks quietly: a mis-numbered backreference once made every
+// string containing an escape fall apart mid-token, and the page still
+// rendered — just wrong. These cases are the ones that catch that.
+
+import assert from 'node:assert/strict';
+import { highlight } from '../web-python/editor.js';
+
+/** The classes applied, in order, so a case reads as what it should colour. */
+const classes = (code) => [...highlight(code).matchAll(/class="tok-(\w+)"/g)].map((m) => m[1]);
+
+/** The text inside the first span of `kind`. */
+function spanText(code, kind) {
+  const m = highlight(code).match(new RegExp(`<span class="tok-${kind}">([\\s\\S]*?)</span>`));
+  return m?.[1];
+}
+
+// A string is one token, escapes and all — including an escaped copy of its
+// own delimiter, and a `\n` that is not a line break.
+assert.equal(spanText(String.raw`opts = "print_level 5\ntol 1e-8"`, 'string'), String.raw`"print_level 5\ntol 1e-8"`);
+assert.equal(spanText(String.raw`x = "a\"b"`, 'string'), String.raw`"a\"b"`);
+assert.equal(spanText(String.raw`s = 'it\'s'`, 'string'), String.raw`'it\'s'`);
+
+// Triple-quoted strings span lines; f-strings keep their prefix.
+assert.equal(spanText('d = """tri\nple""" # after', 'string'), '"""tri\nple"""');
+assert.deepEqual(classes('d = """tri\nple""" # after'), ['op', 'string', 'comment']);
+assert.equal(spanText('f"{m.x[1]:.3f}"', 'string'), 'f"{m.x[1]:.3f}"');
+
+// A quote inside a comment does not open a string, and a `#` inside a
+// string does not open a comment.
+assert.deepEqual(classes('# comment with "quote'), ['comment']);
+assert.deepEqual(classes('s = "# not a comment"'), ['op', 'string']);
+
+// Keywords, the name a `def` introduces, and the Pyomo vocabulary.
+assert.deepEqual(classes('def solve(m): pass'), ['keyword', 'def', 'keyword']);
+assert.deepEqual(classes('m.x = Var(initialize=1.0)'), ['op', 'builtin', 'op', 'number']);
+assert.equal(spanText('for i in m.I:', 'keyword'), 'for');
+
+// Numbers in the shapes a model file actually uses.
+for (const n of ['0x1f', '1_000', '2.5e-3', '40', '1e19']) {
+  assert.equal(spanText(`y = ${n}`, 'number'), n, `number: ${n}`);
+}
+
+// Markup in the source is escaped, never emitted as markup.
+assert.ok(highlight('if a < b and c > d: pass').includes('&lt;'));
+assert.ok(!highlight('x = "<script>"').includes('<script>'));
+
+console.log('ok — highlighter: 20 cases');

--- a/crates/pounce-wasm/web-python/README.md
+++ b/crates/pounce-wasm/web-python/README.md
@@ -36,6 +36,26 @@ That round trip is tested off-browser, with Node standing in for the page:
 active set, and multipliers are known in closed form and checks the values
 landed on the right components. CI runs it on every PR.
 
+## The editor
+
+`editor.js` is a ~150-line Python editor: highlighting, line numbers,
+Tab / Shift-Tab block indent, and indentation carried across Enter (a level
+deeper after a colon). A highlighted `<pre>` sits under a transparent
+`<textarea>`, so the caret, selection, undo, IME, and screen-reader
+behaviour stay the browser's rather than being re-implemented on a
+`contenteditable`.
+
+It is written rather than imported on purpose. CodeMirror or Ace from a CDN
+would add bracket matching and autocomplete, at the cost of a second
+version-pinned network dependency — one that would be missing in exactly the
+offline / self-hosted setup `?pyodide=` exists to serve. If the page ever
+wants an IDE, this is the one file to replace.
+
+The tokenizer has its own tests (`crates/pounce-wasm/tests/editor_tokens.mjs`,
+run in CI): escaped quotes, triple-quoted strings, f-strings, `#` inside a
+string versus a comment, and HTML in the source never reaching the DOM as
+markup.
+
 ## What it loads, and from where
 
 | Piece | Source | Size |

--- a/crates/pounce-wasm/web-python/app.js
+++ b/crates/pounce-wasm/web-python/app.js
@@ -1,6 +1,8 @@
 // Page logic: pick an example, run it in the Pyodide worker, show what it
 // printed. The worker owns both wasm instances; this side is a console.
 
+import { attachEditor } from './editor.js';
+
 const $ = (id) => document.getElementById(id);
 const codeBox = $('code');
 const outBox = $('out');
@@ -98,10 +100,12 @@ for (const name of Object.keys(EXAMPLES)) {
   option.textContent = name;
   select.append(option);
 }
-select.addEventListener('change', () => {
-  codeBox.value = EXAMPLES[select.value];
-});
-codeBox.value = EXAMPLES[select.value];
+// The editor wraps the textarea rather than replacing it, so `codeBox.value`
+// stays the single source of truth and the page still works if this module
+// fails to load.
+const editor = attachEditor(codeBox);
+select.addEventListener('change', () => editor.set(EXAMPLES[select.value]));
+editor.set(EXAMPLES[select.value]);
 
 // --- worker ----------------------------------------------------------------
 

--- a/crates/pounce-wasm/web-python/editor.js
+++ b/crates/pounce-wasm/web-python/editor.js
@@ -1,0 +1,187 @@
+// A small Python editor: syntax highlighting, line numbers, and the two
+// indentation habits a Python editor has to have.
+//
+// Written rather than imported. The alternative — CodeMirror or Ace from a
+// CDN — buys bracket matching and autocomplete at the cost of a second
+// version-pinned network dependency on a page whose whole point is that the
+// solving happens locally, and it would stop working in exactly the
+// self-hosted/offline setup `?pyodide=` exists to support. This is ~150
+// lines and no dependency; if the page ever wants an IDE, swap this file.
+//
+// The technique is the usual one: a `<pre>` of highlighted markup sits
+// underneath a transparent `<textarea>`, aligned character-for-character.
+// The textarea keeps the caret, selection, undo history, IME, and
+// accessibility that a `contenteditable` re-implementation would have to
+// rebuild badly.
+
+const KEYWORDS = new Set(
+  ('False None True and as assert async await break class continue def del elif else except ' +
+    'finally for from global if import in is lambda nonlocal not or pass raise return try ' +
+    'while with yield match case')
+    .split(' '),
+);
+
+// Builtins worth colouring on this page: Python's own, plus the Pyomo names
+// a model is written out of — `Var`, `Constraint`, `RangeSet` read as
+// vocabulary here, not as user identifiers.
+const BUILTINS = new Set(
+  ('abs all any bool dict enumerate filter float format int len list map max min print range ' +
+    'repr reversed round set sorted str sum tuple type zip ' +
+    'ConcreteModel AbstractModel Var Param Set RangeSet Constraint ConstraintList Objective ' +
+    'Suffix Block Expression value minimize maximize exp log log10 sin cos tan sqrt ' +
+    'SolverFactory TransformationFactory')
+    .split(' '),
+);
+
+// One pass, longest-first: comments and strings must win over everything,
+// and triple quotes over single. `f"…"` is matched as a string with its
+// prefix so an f-string does not fall apart at the `f`.
+const TOKEN = new RegExp(
+  [
+    /(?<comment>#[^\n]*)/,
+    /(?<string>[rbuf]{0,2}(?<tq>"""|''')[\s\S]*?\k<tq>|[rbuf]{0,2}(?<q>"|')(?:\\.|(?!\k<q>)[^\n\\])*\k<q>?)/,
+    /(?<decorator>@[A-Za-z_]\w*)/,
+    /(?<number>\b\d[\d_]*\.?[\d_]*(?:[eE][+-]?\d+)?j?\b|\b0[xXoObB][\da-fA-F_]+\b)/,
+    /(?<def>\b(?:def|class)\s+[A-Za-z_]\w*)/,
+    /(?<word>\b[A-Za-z_]\w*\b)/,
+    /(?<op>[+\-*/%=<>!&|^~@]+)/,
+  ]
+    .map((r) => r.source)
+    .join('|'),
+  'g',
+);
+
+const escapeHtml = (s) =>
+  s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+/** Tokenize `code` into highlighted HTML. Exported for `tests/editor_tokens.mjs`. */
+export function highlight(code) {
+  let out = '';
+  let last = 0;
+  for (const m of code.matchAll(TOKEN)) {
+    out += escapeHtml(code.slice(last, m.index));
+    last = m.index + m[0].length;
+    const g = m.groups;
+    const text = escapeHtml(m[0]);
+    if (g.comment) out += `<span class="tok-comment">${text}</span>`;
+    else if (g.string) out += `<span class="tok-string">${text}</span>`;
+    else if (g.decorator) out += `<span class="tok-decorator">${text}</span>`;
+    else if (g.number) out += `<span class="tok-number">${text}</span>`;
+    else if (g.def) {
+      // `def foo` / `class Foo`: keyword, then the name it introduces.
+      const [kw, name] = m[0].split(/(\s+)/).filter((s) => s.trim());
+      out += `<span class="tok-keyword">${escapeHtml(kw)}</span> <span class="tok-def">${escapeHtml(name)}</span>`;
+    } else if (g.word) {
+      const cls = KEYWORDS.has(m[0])
+        ? 'tok-keyword'
+        : BUILTINS.has(m[0])
+          ? 'tok-builtin'
+          : null;
+      out += cls ? `<span class="${cls}">${text}</span>` : text;
+    } else if (g.op) out += `<span class="tok-op">${text}</span>`;
+    else out += text;
+  }
+  out += escapeHtml(code.slice(last));
+  return out;
+}
+
+/**
+ * Turn a plain `<textarea>` into a highlighted editor in place. Returns a
+ * `{ get, set }` handle; the textarea keeps working as itself, so a caller
+ * that only reads `.value` needs no change and the page degrades to a plain
+ * textarea if this module fails to load.
+ */
+export function attachEditor(textarea) {
+  const wrap = document.createElement('div');
+  wrap.className = 'editor';
+  const gutter = document.createElement('div');
+  gutter.className = 'editor-gutter';
+  gutter.setAttribute('aria-hidden', 'true');
+  const pre = document.createElement('pre');
+  pre.className = 'editor-highlight';
+  pre.setAttribute('aria-hidden', 'true');
+
+  textarea.parentNode.insertBefore(wrap, textarea);
+  wrap.append(gutter, pre, textarea);
+
+  const render = () => {
+    // The trailing newline keeps the last line's box alive so the caret on
+    // an empty final line still has something behind it.
+    pre.innerHTML = highlight(textarea.value) + '\n';
+    const lines = textarea.value.split('\n').length;
+    gutter.textContent = Array.from({ length: lines }, (_, i) => i + 1).join('\n');
+  };
+
+  const syncScroll = () => {
+    pre.scrollTop = textarea.scrollTop;
+    pre.scrollLeft = textarea.scrollLeft;
+    gutter.scrollTop = textarea.scrollTop;
+  };
+
+  textarea.addEventListener('input', render);
+  textarea.addEventListener('scroll', syncScroll);
+
+  textarea.addEventListener('keydown', (e) => {
+    const { value, selectionStart: start, selectionEnd: end } = textarea;
+
+    if (e.key === 'Tab') {
+      e.preventDefault();
+      const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+      if (start !== end || e.shiftKey) {
+        // Block indent / dedent over every line the selection touches.
+        const blockEnd = value.indexOf('\n', end) === -1 ? value.length : value.indexOf('\n', end);
+        const block = value.slice(lineStart, blockEnd);
+        const shifted = e.shiftKey
+          ? block.replace(/^ {1,4}/gm, '')
+          : block.replace(/^/gm, '    ');
+        replace(lineStart, blockEnd, shifted, lineStart, lineStart + shifted.length);
+      } else {
+        insert('    ');
+      }
+      return;
+    }
+
+    if (e.key === 'Enter') {
+      // Keep the current line's indentation, and add a level after a colon
+      // — the two things that make typing a `for` loop bearable.
+      const lineStart = value.lastIndexOf('\n', start - 1) + 1;
+      const line = value.slice(lineStart, start);
+      const indent = (line.match(/^[ \t]*/) ?? [''])[0];
+      const deeper = /:\s*$/.test(line) ? '    ' : '';
+      e.preventDefault();
+      insert('\n' + indent + deeper);
+    }
+  });
+
+  function insert(text) {
+    const { selectionStart: s, selectionEnd: e } = textarea;
+    replace(s, e, text, s + text.length, s + text.length);
+  }
+
+  /** Edit through `execCommand` when available so the browser's own undo
+   *  stack survives; fall back to a direct splice where it is not. */
+  function replace(from, to, text, selStart, selEnd) {
+    textarea.setSelectionRange(from, to);
+    let ok = false;
+    try {
+      ok = document.execCommand('insertText', false, text);
+    } catch {
+      ok = false;
+    }
+    if (!ok) {
+      textarea.value = textarea.value.slice(0, from) + text + textarea.value.slice(to);
+    }
+    textarea.setSelectionRange(selStart, selEnd);
+    render();
+  }
+
+  render();
+  return {
+    get: () => textarea.value,
+    set: (text) => {
+      textarea.value = text;
+      render();
+      syncScroll();
+    },
+  };
+}

--- a/crates/pounce-wasm/web-python/index.html
+++ b/crates/pounce-wasm/web-python/index.html
@@ -33,10 +33,53 @@
   .panel { background: var(--panel); border: 1px solid var(--line);
            border-radius: 12px; padding: 1.25rem; }
   .row { display: flex; gap: .75rem; align-items: center; flex-wrap: wrap; }
+  /* The editor: a highlighted <pre> under a transparent <textarea>. Every
+     metric below (font, line-height, padding, tab-size, wrapping) must match
+     between the two layers or the caret drifts from the glyphs. */
+  .editor {
+    position: relative; display: grid; grid-template-columns: auto 1fr;
+    background: var(--bg); border: 1px solid var(--line); border-radius: 8px;
+    overflow: hidden;
+  }
+  .editor:focus-within { border-color: var(--accent); }
+  .editor-gutter, .editor-highlight, textarea#code {
+    font: 13px/1.6 var(--mono); tab-size: 4;
+    padding: .8rem 0; margin: 0; border: 0;
+  }
+  .editor-gutter {
+    padding-left: .8rem; padding-right: .6rem; text-align: right;
+    color: var(--muted); opacity: .55; user-select: none;
+    white-space: pre; overflow: hidden;
+  }
+  .editor-highlight, textarea#code {
+    grid-column: 2; grid-row: 1;
+    padding-right: .9rem; padding-left: .3rem;
+    white-space: pre-wrap; overflow-wrap: break-word; word-break: normal;
+    min-height: 22rem; max-height: 40rem; overflow: auto;
+  }
+  .editor-highlight { pointer-events: none; color: var(--ink); }
   textarea#code {
-    width: 100%; min-height: 22rem; resize: vertical; padding: .8rem .9rem;
-    font: 13px/1.6 var(--mono); color: var(--ink); background: var(--bg);
-    border: 1px solid var(--line); border-radius: 8px; tab-size: 4;
+    resize: vertical; background: transparent; color: transparent;
+    caret-color: var(--accent); outline: none;
+  }
+  textarea#code::selection { background: color-mix(in srgb, var(--accent) 28%, transparent); }
+
+  .tok-keyword  { color: #a031a8; font-weight: 600; }
+  .tok-builtin  { color: #1a6fa8; }
+  .tok-string   { color: #1f7a4d; }
+  .tok-comment  { color: var(--muted); font-style: italic; }
+  .tok-number   { color: #b4530a; }
+  .tok-def      { color: #1a6fa8; font-weight: 600; }
+  .tok-decorator{ color: #8a6a12; }
+  .tok-op       { color: #7a736a; }
+  @media (prefers-color-scheme: dark) {
+    .tok-keyword  { color: #e08ae8; }
+    .tok-builtin  { color: #7cc4f0; }
+    .tok-string   { color: #8fd6a8; }
+    .tok-number   { color: #f0913f; }
+    .tok-def      { color: #7cc4f0; }
+    .tok-decorator{ color: #d8bf6a; }
+    .tok-op       { color: #9a9188; }
   }
   select {
     font: 14px system-ui, sans-serif; padding: .5rem .6rem; color: var(--ink);

--- a/docs/src/wasm.md
+++ b/docs/src/wasm.md
@@ -101,6 +101,12 @@ from the file it just wrote — `crates/pounce-wasm/tests/pyomo_roundtrip.py`
 pins that with a model whose optimum and multipliers are known in closed
 form, and CI runs it on every PR with Node standing in for the browser.
 
+The script box is a small editor — Python highlighting, line numbers,
+Tab/Shift-Tab indent, indentation carried across Enter — built from a
+highlighted `<pre>` behind a transparent `<textarea>` so the caret and undo
+stay native. No editor library: a CDN dependency would be absent in exactly
+the offline setup `?pyodide=` exists for.
+
 Two wasm runtimes are in play — Pyodide's CPython and POUNCE — with separate
 memories; all that crosses between them is `.nl` text one way and JSON plus
 `.sol` text the other.


### PR DESCRIPTION
## Problem

The script box on the Pyodide page was a bare `<textarea>`. Monospaced, and
that is all: no highlighting, no line numbers, Tab moves focus out of the
field, Enter drops you to column zero. For a page whose whole purpose is
*typing a model*, that is the part you touch most and the part that had the
least thought in it.

## Fix

`web-python/editor.js`, ~150 lines, no dependency:

- **Python highlighting** — keywords, strings (escapes, triple quotes,
  f-strings), comments, numbers, decorators, the name a `def`/`class`
  introduces, and the Pyomo vocabulary a model is written out of (`Var`,
  `Constraint`, `RangeSet`, `Objective`, …) as builtins, since here they read
  as vocabulary rather than as user identifiers.
- **Line numbers** in a gutter that tracks the line count.
- **Tab / Shift-Tab** — insert a level at the caret, or indent/dedent every
  line a selection touches.
- **Enter** keeps the current indentation, and adds a level after a colon.
- Edits go through `execCommand('insertText')` where available, so the
  browser's own undo stack survives them.

A highlighted `<pre>` sits under a transparent `<textarea>`. The textarea
keeps the caret, selection, undo, IME, and screen-reader behaviour that a
`contenteditable` re-implementation would have to rebuild badly, and
`codeBox.value` stays the single source of truth — the run path is unchanged
and the page degrades to a plain textarea if the module fails to load.

**Rejected: CodeMirror or Ace from a CDN.** They would add bracket matching
and autocomplete for a second version-pinned network dependency — one that
would be absent in exactly the offline / self-hosted setup `?pyodide=` and
`?pyomo=` exist to serve, on a page whose selling point is that the work
happens locally. `editor.js` is the swap point if the page ever wants an IDE;
until then this is the smaller promise.

## Blast radius

One page, one new module, plus CSS. Nothing outside
`crates/pounce-wasm/web-python/` and its docs, and one new CI step. No Rust,
no wasm, no change to what runs a solve.

The metrics that must agree between the two layers — font, line-height,
padding, `tab-size`, `white-space`, `overflow-wrap` — are declared once in a
shared selector, because a drift in any of them separates the caret from the
glyphs it is standing in.

## Tests

- `crates/pounce-wasm/tests/editor_tokens.mjs`, **new in CI** — 20 cases
  against the tokenizer. It exists because this code broke quietly once
  already: the first version numbered its backreferences by hand, off by
  one, so every string containing an escape fell apart mid-token —
  `"print_level 5\ntol 1e-8"` rendered as three fragments — and the page
  still looked fine at a glance. Named backreferences fixed it; the tests
  pin escaped quotes, triple quotes across lines, f-strings, `#` inside a
  string vs. a comment, hex/underscore/exponent numbers, and HTML in the
  source never reaching the DOM as markup.
- Headless Chromium: every token class present in the rendered markup; the
  gutter matching the line count; the two layers agreeing on all six layout
  metrics and on their bounding boxes to the half-pixel; Enter after a colon
  producing `    print(i)`; Tab and Shift-Tab indenting and dedenting; and
  HS071 still solving to 17.014017145 through the editor's textarea.
- Re-run green after rebasing onto `main` at #453: highlighter tokens, the
  wasm build + smoke test, the Pyomo round trip, and both
  `scripts/check-*-consistency.sh`.
- Not pinned in CI: the rendering itself. The tokenizer is tested, the
  layout contract is not — no browser driver in CI, same gap as #455/#457.

---

- [x] Tests fail on the parent commit for the stated reason — *`editor_tokens.mjs`
      fails against the first tokenizer (mis-numbered backrefs) on the
      escaped-quote and `\n`-in-string cases; that is why it exists.*
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page updated (`docs/src/wasm.md`) plus `web-python/README.md`
- [x] `scripts/check-docs-consistency.sh` and
      `scripts/check-release-consistency.sh` pass; no Rust touched
- [x] Every claim here is true of the code as it stands
