### PR TITLE
Cover the container images and wasm demos at release time

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -33,11 +33,12 @@
 #
 # AUTH: GITHUB_TOKEN with packages:write. No secrets to configure.
 #
-# FIRST PUBLISH: a new GHCR package is created PRIVATE. After the first
-# successful push, make it public once by hand under
-# github.com/users/<owner>/packages/container/pounce/settings — otherwise
-# `docker pull` and `apptainer pull docker://...` fail with an auth error
-# for everyone but you, which reads like the image is missing.
+# FIRST PUBLISH: the package inherits the repository's visibility, so on a
+# public repo it comes out public and anonymous pulls work straight away
+# (verified on the first real publish). If it ever lands private instead,
+# `docker pull` and `apptainer pull docker://...` fail for everyone but you
+# with an auth error that reads like the image is missing — flip it under
+# github.com/users/<owner>/packages/container/pounce/settings.
 name: release-docker
 
 on:

--- a/dev-notes/cargo-release.md
+++ b/dev-notes/cargo-release.md
@@ -106,10 +106,16 @@ note they all share the `pounce-` prefix under account `jkitchin`.
    X.Y.Z. `scripts/check-release-consistency.sh` verifies all three agree; run
    it before tagging. If the version bump is non-trivial, do it as its own
    commit.
-3. Bump `CITATION.cff` to match: set `version:` to the new release version and
+3. Bump `ARG POUNCE_VERSION` in `docker/Dockerfile.release` to the same
+   X.Y.Z. `scripts/check-release-consistency.sh` fails if you forget — and
+   it is worth knowing why it is checked rather than trusted: the release
+   image *pip-installs* that pinned version, so a stale ARG produces an
+   image **tagged** X.Y.Z that **contains** the previous release. The build
+   succeeds and the smoke test passes, because the old wheel works fine.
+4. Bump `CITATION.cff` to match: set `version:` to the new release version and
    `date-released:` to the release date. GitHub's "Cite this repository"
    widget reads these. (The `doi:` is the Zenodo *concept* DOI and stays put.)
-4. Run `scripts/publish-crates.sh --dry-run` to catch missing metadata, broken
+5. Run `scripts/publish-crates.sh --dry-run` to catch missing metadata, broken
    links, or dirty-tree errors. This dry-runs every crate end-to-end, so any
    breakage appears here, not three crates into the real release.
 
@@ -157,10 +163,63 @@ crates and drives `release-crates.yml`.)
 | crates.io (20 crates)   | `release-crates.yml`                  | `v*` tag / manual        |
 | PyPI `pounce-solver`    | `release-pounce.yml`                  | `python-v*` tag          |
 | PyPI `pyomo-pounce`     | `release-pyomo-pounce.yml`            | `pyomo-pounce-v*` tag    |
+| ghcr.io container images| `release-docker.yml`                  | `v*` tag / push to main  |
+| wasm demo pages         | `docs.yml`                            | push to main             |
 
 `release-crates.yml` needs the `CARGO_REGISTRY_TOKEN` secret and runs in the
 `crates-io` environment. The GitHub Release itself is still created by hand
 (`gh release create vX.Y.Z --notes-file <file>`); no workflow makes it.
+
+## Container images and the wasm demos
+
+Two surfaces ship on every release but are **not** covered by bumping a
+version number, so they need their own attention.
+
+### Container images (`release-docker.yml` -> `ghcr.io/<owner>/pounce`)
+
+- **Tag ordering matters.** The release image pip-installs from PyPI, but
+  the `v*` tag it fires on does not publish to PyPI — `python-v*` does. Push
+  `python-v*` and `pyomo-pounce-v*` **at or before** `v*`. The workflow polls
+  PyPI for ~20 minutes to absorb the normal lag; if it times out nothing is
+  half-published, so re-run it from the Actions tab with `dry_run=false` once
+  the wheels are live.
+- **What each tag means.** `v*` publishes `:X.Y.Z`, `:X.Y`, `:latest` from
+  the PyPI-based image. A push to `main` publishes `:edge` and
+  `:sha-<short>` from the source-built image. `:latest` therefore always
+  means "released", never "tip of main".
+- **After the release, check the base image pin.** `docker/Dockerfile.release`
+  is pinned to Debian trixie because the wheels published through 0.9.0
+  bundled a CLI needing glibc 2.39 (#452, fixed in #456). Once a release
+  after 0.9.0 is on PyPI, drop that pin to bookworm or lower and delete the
+  note — `scripts/check-cli-portability.sh` in CI is what makes lowering it
+  safe. This is the one item here with an expiry date.
+- **Verify the published image, do not assume.** The images smoke-test
+  themselves at build time, but that proves the build, not the publish:
+
+  ```sh
+  docker run --rm ghcr.io/<owner>/pounce:X.Y.Z --version
+  docker run --rm --entrypoint python ghcr.io/<owner>/pounce:X.Y.Z \
+    -c "import pounce; print(pounce.__version__)"
+  ```
+
+### wasm demos (`docs.yml` -> GitHub Pages)
+
+The `pounce-wasm` crate is `publish = false` and inherits
+`version.workspace`, so it cannot drift on version — the risk is different:
+the demo pages are rebuilt and deployed from `main` on every docs
+deployment, so a change that breaks the wasm build breaks the *published
+demo*, not a release artifact you can yank.
+
+- CI runs `WebAssembly build + smoke` on every PR, and the wasm/native
+  parity check covers the whole `crates/pounce-cli/tests/fixtures` set. If
+  you add a solver feature reachable from a `.nl` file, that check is what
+  tells you whether it survives the wasm boundary.
+- A feature that needs threads, the filesystem, or process spawning will
+  **not** work in the browser build (single-threaded, no
+  `SharedArrayBuffer`, WASI shim only). Better to find that in the parity
+  check than in a demo page.
+- After a docs deployment, the pages are live immediately at `/demo/` and
+  `/demo/python/` — there is no release gate in front of them.
 
 ## Yanking
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -106,8 +106,21 @@ matrix; two points matter when cutting a release:
    out, nothing is half-published — re-run it from the Actions tab with
    `dry_run=false` once the wheels are live.
 
-2. **First publish is private.** A newly created GHCR package defaults to
-   private. After the first successful push, make it public once by hand
-   under *Packages → pounce → Package settings*. Until then every
-   `docker pull` and `apptainer pull` from anyone but you fails with an auth
-   error that reads like the image does not exist.
+2. **Check the package visibility once, after the first publish.** For this
+   repo the package inherited the repository's public visibility and
+   anonymous pulls worked immediately — no manual step was needed. That is
+   worth verifying rather than assuming, because if a package ever does come
+   out private, `docker pull` and `apptainer pull` fail for everyone but you
+   with an auth error that reads like the image does not exist. The honest
+   check is an unauthenticated one:
+
+   ```sh
+   docker logout ghcr.io
+   curl -s "https://ghcr.io/token?scope=repository:<owner>/pounce:pull" \
+     | python3 -c 'import sys,json;print(json.load(sys.stdin)["token"])' \
+     | xargs -I{} curl -so /dev/null -w '%{http_code}\n' -H "Authorization: Bearer {}" \
+         https://ghcr.io/v2/<owner>/pounce/manifests/edge
+   ```
+
+   `200` means public. If it is not, flip it under *Packages → pounce →
+   Package settings → Change visibility*.

--- a/scripts/check-release-consistency.sh
+++ b/scripts/check-release-consistency.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # Release consistency guard — run in CI before tagging, and locally before a
-# release. POUNCE ships to three registries (PyPI pounce-solver, PyPI
-# pyomo-pounce, and 19 crates.io workspace crates); this script fails loudly
-# if any of the facts a release depends on have drifted apart:
+# release. POUNCE ships to four surfaces (PyPI pounce-solver, PyPI
+# pyomo-pounce, 20 crates.io workspace crates, and the ghcr.io container
+# images); this script fails loudly if any of the facts a release depends on
+# have drifted apart:
 #
 #   1. VERSIONS AGREE. The Rust [workspace.package] version, the
 #      pounce-solver wheel version, and the pyomo-pounce version must be the
@@ -28,6 +29,13 @@
 #      tag would publish the leading crates and hard-fail mid-batch at the first
 #      crate carrying such a dep — an irreversible partial release. See
 #      scripts/check_dep_publishability.py (e.g. the `feral` git pin).
+#
+#   5. THE RELEASE IMAGE INSTALLS THIS VERSION. docker/Dockerfile.release
+#      pip-installs a pinned X.Y.Z. Forgetting to bump it builds an image
+#      TAGGED with the new version but CONTAINING the old one — silently,
+#      because the build succeeds and the smoke test passes against a
+#      perfectly good older wheel. Stale version references in the docs are
+#      reported too, but only as advisory.
 #
 # `cargo metadata` is the single source of truth: it is the real workspace and
 # cannot drift. The explicit list in publish-crates.sh stays because it makes
@@ -144,6 +152,44 @@ if cargo metadata --format-version 1 2>/dev/null \
   :
 else
   fail=1
+fi
+echo
+
+# --- 5. The release container image installs the version we are releasing ---
+# docker/Dockerfile.release pins the wheels it pip-installs. If that ARG is not
+# bumped with everything else, `make docker-release` on a 0.10.0 tree builds an
+# image tagged 0.10.0 that contains 0.9.0 — wrong, and silent: the build
+# succeeds and the smoke test passes, because 0.9.0 is a perfectly good wheel.
+# Nothing else catches this, so it is checked rather than left to a checklist.
+echo "== docker release image version =="
+docker_ver="$(grep -m1 -E '^ARG POUNCE_VERSION=' docker/Dockerfile.release \
+  | sed -E 's/^ARG POUNCE_VERSION=([^[:space:]]+).*/\1/')"
+note "docker/Dockerfile.release ARG   : ${docker_ver:-<not found>}"
+if [[ "$docker_ver" == "$cargo_ver" ]]; then
+  note "OK — matches the workspace version"
+else
+  note "DRIFT — the release image would install ${docker_ver:-?}, not ${cargo_ver}."
+  note "Bump ARG POUNCE_VERSION in docker/Dockerfile.release."
+  fail=1
+fi
+echo
+
+# Documentation examples pin a version too. Cosmetic rather than load-bearing —
+# a stale `pounce:0.9.0` in a doc still works, it just tells a new reader to
+# pull an old image — so this warns and does not fail.
+echo "== docker version references in docs (advisory) =="
+stale=0
+while IFS= read -r hit; do
+  [[ -z "$hit" ]] && continue
+  note "stale: $hit"
+  stale=1
+done < <(grep -rn -E "pounce:[0-9]+\.[0-9]+\.[0-9]+" \
+           README.md docs/src/docker.md docker/README.md docker/Dockerfile.release 2>/dev/null \
+         | grep -v "pounce:${cargo_ver}" || true)
+if [[ $stale -eq 0 ]]; then
+  note "OK — no stale version references"
+else
+  note "(advisory only — update these when convenient)"
 fi
 echo
 


### PR DESCRIPTION
The container images and the wasm demos both ship on every release, and the release procedure mentions neither — it predates both.

## The mechanical half is checked, not written down

`docker/Dockerfile.release` carries `ARG POUNCE_VERSION=0.9.0`, and that is what the release image **pip-installs**. Forget to bump it and you get an image **tagged** `0.10.0` that **contains** `0.9.0` — silently. The build succeeds. The smoke test passes. Because 0.9.0 is a perfectly good wheel.

That failure mode is invisible to every existing check, so it goes in `scripts/check-release-consistency.sh` (already run in CI on every PR) rather than in a checklist someone skims at 11pm:

```
== docker release image version ==
  docker/Dockerfile.release ARG   : 0.8.0
  DRIFT — the release image would install 0.8.0, not 0.9.0.
  Bump ARG POUNCE_VERSION in docker/Dockerfile.release.
check-release-consistency: FAILED
```

Verified both directions — **exit 1** on a simulated forgotten bump, **exit 0** when clean — because a guard that has only ever been observed passing hasn't been tested.

Stale `pounce:X.Y.Z` references in the docs get reported too, but **advisory only**: a stale example misleads a reader without breaking anything, and failing CI over it would train people to ignore the check.

## The judgment half goes in `dev-notes/cargo-release.md`

A new section covering what a version bump alone doesn't handle:

- **Tag ordering** — the release image installs from PyPI, but the `v*` tag it fires on doesn't publish to PyPI; `python-v*` does. Push `python-v*` at or before `v*`. The workflow polls PyPI ~20 min to absorb the lag, and fails recoverably rather than half-publishing.
- **What each tag means** — `v*` → `:X.Y.Z`, `:X.Y`, `:latest` (PyPI-based). Push to `main` → `:edge`, `:sha-<short>` (source-built). So `:latest` always means *released*, never *tip of main*.
- **Verify the published image** — the images smoke-test themselves at build time, but that proves the build, not the publish.
- **One item with an expiry date**, flagged as such: `Dockerfile.release`'s trixie pin should drop once a post-0.9.0 release is on PyPI.
- **wasm has a different risk profile** — `publish = false` + `version.workspace` means it *can't* drift on version. But the demos deploy straight to Pages from `main`, so a broken wasm build breaks the **live demo**, not a release artifact you can yank. Also noted: anything needing threads, filesystem, or process spawning won't survive the wasm boundary, and the parity check over the full fixture set is what surfaces that.

Automation table updated with both new surfaces.

## A correction

I claimed — twice, in `docker/README.md` and the `release-docker.yml` header, and to @jkitchin in conversation — that a new GHCR package is created **private** and must be made public by hand. That's the widely-repeated behavior and I wrote it in as fact without checking.

It's wrong. The package inherited the repository's public visibility, and anonymous pulls worked immediately after the first publish:

```
anon token obtained: yes
HTTP 200
=> PUBLIC already — anonymous pull works
architectures: ['amd64', 'arm64']
```

Both places now describe what actually happens, and give an unauthenticated command to verify it rather than asserting a default. Left as "check this once" rather than deleted, since a private package really would fail confusingly — but it's no longer stated as a required manual step.

## Checks

`shellcheck` (no new findings — the one hit is pre-existing SC2086 on line 143), `actionlint`, and `check-release-consistency.sh` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
