### PR TITLE
debugger: reject KKT commands on the convex backend as unavailable (#462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,30 @@ changes.
   became a `cfg(any(unix, windows))` dependency and `ExternalLibrary::load`
   reports that AMPL imported functions are unavailable there rather than
   failing to compile. No change on unix/windows.
+### Fixed — debugger: convex backend answered `print kkt` with a self-referential hint (#462)
+
+- On the convex / conic IPM, `print kkt` replied *"no KKT factorization yet —
+  stop at `after_search_dir`"* — and repeated it verbatim once you were
+  stopped at `after_search_dir`. The advice could never pay off: that backend
+  has no augmented system to report inertia for at any checkpoint, so the
+  suggestion sent a user (or an agent driving `--debug-json`) round a loop
+  with no exit. Diagnostics only; no numerical result was affected.
+- The backend-conditional commands now reject on a **capability** basis
+  before any timing check, matching the documented contract and their
+  siblings (`print rank`, `diagnose`, `resolve`): `print kkt`, `print
+  residuals`, `print active` / `inactive`, `viz kkt`, and `viz L` answer
+  *"only available for the NLP solver (not the convex/conic solver)"*.
+  `print active` previously reported "no bounded variables or inequality
+  slacks" there — a silent no-op the docs explicitly rule out. The NLP
+  filter-IPM is unchanged, including the genuine "not factored yet" hint at
+  a pre-factorization checkpoint.
+- The `hello` handshake is now answered for the backend that is running, so
+  a JSON client feature-detecting off `capabilities` is told the truth:
+  `kkt_inspect`, `diagnose`, `mutate_mu`, `resolve`, `sweep`, `load`, and
+  `structural_diagnose` are `false` on the convex path, `viz` drops to
+  `["block","delta"]`, and `blocks` lists that solver's own iterate blocks
+  (`x`/`s`/`y`/`z`, plus `tau`/`kappa` on HSDE) instead of the NLP names.
+
 ### Fixed — Linux wheels shipped a CLI that could not start on most clusters (#452)
 
 - The published Linux wheels were tagged `manylinux2014` (glibc 2.17) but

--- a/crates/pounce-cli/src/debug_repl.rs
+++ b/crates/pounce-cli/src/debug_repl.rs
@@ -1550,17 +1550,29 @@ impl SolverDebugger {
         let Some(&what) = rest.first() else {
             return self.cmd_info(ctx);
         };
+        // The backend-conditional sub-commands are rejected on a capability
+        // basis *before* any timing check: on a backend that can never
+        // answer them (the convex/conic IPM has no augmented system, no
+        // per-component residual pool, no bound slacks), a "not yet — stop
+        // later" message would send the user round a loop that never ends
+        // in an answer. #462.
         if what == "kkt" {
-            return self.cmd_print_kkt(ctx);
+            return match as_nlp(ctx) {
+                Some(_) => self.cmd_print_kkt(ctx),
+                None => nlp_only("print kkt"),
+            };
         }
-        if what == "active" {
-            return self.cmd_print_bounds(ctx, true);
-        }
-        if what == "inactive" {
-            return self.cmd_print_bounds(ctx, false);
+        if what == "active" || what == "inactive" {
+            return match as_nlp(ctx) {
+                Some(_) => self.cmd_print_bounds(ctx, what == "active"),
+                None => nlp_only(&format!("print {what}")),
+            };
         }
         if what == "residuals" || what == "resid" {
-            return self.cmd_print_residuals(&rest[1..], ctx);
+            return match as_nlp(ctx) {
+                Some(_) => self.cmd_print_residuals(&rest[1..], ctx),
+                None => nlp_only("print residuals"),
+            };
         }
         if what == "equation" || what == "eqn" || what == "eq" {
             return self.cmd_print_equation(&rest[1..]);
@@ -3131,6 +3143,10 @@ impl SolverDebugger {
         // `viz kkt` writes the assembled augmented-system matrix (triplets
         // → heatmap) plus the inertia/regularization summary.
         if target == "kkt" {
+            // Capability first, timing second (see `print kkt`, #462).
+            if as_nlp(ctx).is_none() {
+                return nlp_only("viz kkt");
+            }
             let Some(k) = ctx.kkt() else {
                 return CmdOut::err(
                     "no KKT factorization captured yet — nothing has been factored (iter 0), \
@@ -3172,6 +3188,9 @@ impl SolverDebugger {
         // the debugger is stepping (same as the matrix), so it shows the
         // previous iteration's factorization at `iter_start`.
         if target == "L" {
+            if as_nlp(ctx).is_none() {
+                return nlp_only("viz L");
+            }
             match ctx.kkt_l_factor() {
                 Some((n, perm, l_irn, l_jcn, l_vals)) => {
                     // Iteration the factor came from (previous iter at `iter_start`).
@@ -3350,7 +3369,20 @@ impl SolverDebugger {
     /// version, advertised capabilities, and the command / metric
     /// vocabulary — everything a visual debugger needs to configure its
     /// UI before the first `pause`.
-    fn emit_hello(&self) {
+    ///
+    /// The backend-conditional entries are answered for the backend that is
+    /// actually running: a client feature-detecting off `capabilities` must
+    /// not be told the convex/conic IPM can do `print kkt` / `diagnose`
+    /// when the REPL rejects those with "not available for this solver"
+    /// (#462). Likewise `blocks` names *this* solver's iterate blocks.
+    fn emit_hello(&self, ctx: &dyn DebugState) {
+        let nlp = as_nlp(ctx).is_some();
+        // `viz kkt` / `viz L` need an augmented system to show.
+        let viz: &[&str] = if nlp {
+            &["block", "delta", "kkt", "L"]
+        } else {
+            &["block", "delta"]
+        };
         let ev = serde_json::json!({
             "event": "hello",
             "protocol": "pounce-dbg/1",
@@ -3358,25 +3390,27 @@ impl SolverDebugger {
             "capabilities": {
                 "inspect": true,
                 "mutate_iterate": true,
-                "mutate_mu": true,
+                // The convex μ is derived from ⟨s, z⟩; `set mu` is rejected
+                // there (edit the `s`/`z` blocks instead).
+                "mutate_mu": nlp,
                 "conditional_breakpoints": "compound",
                 "request_ids": true,
-                "viz": ["block", "delta", "kkt", "L"],
+                "viz": viz,
                 "save": true,
-                "load": true,
-                "sweep": self.restart.is_some(),
-                "kkt_inspect": true,
+                "load": nlp,
+                "sweep": nlp && self.restart.is_some(),
+                "kkt_inspect": nlp,
                 // `print equation <name|row>` is available when a source
                 // model (`.nl`) supplied constraint algebra to render.
                 "equations": self.equation_book.is_some(),
                 // Live `diagnose` — point-in-time named health findings.
-                "diagnose": true,
+                "diagnose": nlp,
                 // `diagnose`'s structural rank pass (Dulmage–Mendelsohn)
                 // names dependent equations; available with a `.nl` model.
-                "structural_diagnose": self.structure_book.is_some(),
+                "structural_diagnose": nlp && self.structure_book.is_some(),
                 "llm_assist": true,
                 "rewind": "primal_dual",
-                "resolve": self.restart.is_some(),
+                "resolve": nlp && self.restart.is_some(),
                 "terminal_checkpoint": true,
                 "interruptible": self.interruptible,
                 // #72 §1 / §5.
@@ -3389,7 +3423,7 @@ impl SolverDebugger {
             "checkpoints": CHECKPOINTS,
             "events": EVENTS,
             "commands": COMMANDS,
-            "blocks": BLOCK_NAMES,
+            "blocks": block_names(ctx),
             "metrics": METRICS,
         });
         emit_json(&ev);
@@ -3884,7 +3918,7 @@ impl DebugHook for SolverDebugger {
         // One-time handshake so a JSON client learns the protocol /
         // capabilities before the first pause.
         if matches!(self.mode, DebugMode::Json) && !self.hello_sent {
-            self.emit_hello();
+            self.emit_hello(&*ctx);
             self.hello_sent = true;
         }
         // Terminal post-mortem checkpoint: pause if configured (and, for

--- a/crates/pounce-cli/tests/issue_462_convex_capability_errors.rs
+++ b/crates/pounce-cli/tests/issue_462_convex_capability_errors.rs
@@ -1,0 +1,210 @@
+//! #462 — on the convex/conic IPM the debugger must answer the commands it
+//! *cannot* implement with a capability error, not a timing hint.
+//!
+//! `print kkt` used to reply "no KKT factorization yet — stop at
+//! `after_search_dir`" on the convex backend, and emitted the same message
+//! when already stopped at `after_search_dir`: a self-referential loop, since
+//! that backend has no augmented-system inertia at any checkpoint. The
+//! documented contract (`docs/src/debugger.md`, capability matrix) is that a
+//! command unavailable on the current backend "returns an explicit 'not
+//! available for this solver' error (it never silently no-ops)" — which the
+//! sibling commands (`print rank`, `diagnose`, `resolve`) already did.
+//!
+//! Covered here, driven over the JSON protocol against the real convex IPM:
+//!   - `print kkt` / `print residuals` / `print active` / `print inactive` /
+//!     `viz kkt` / `viz L` are rejected as unavailable on the convex backend,
+//!     at the very checkpoint the old hint named,
+//!   - `print kkt` still works on the NLP filter-IPM at that checkpoint (the
+//!     fix is a capability gate, not a blanket disable),
+//!   - `hello.capabilities` — what a JSON client is told to feature-detect
+//!     off — agrees with the REPL on both backends.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// `min x0² + x1²  s.t.  x0 + x1 = 2` — routed to the convex IPM under
+/// `solver_selection=qp-ipm`, solvable by the NLP path under `nlp`.
+fn fixture() -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push("convex_qp.nl");
+    p
+}
+
+/// Drive `--debug-json` with `cmds`, stopping at `after_search_dir` first
+/// (the checkpoint the old hint pointed at). Returns the `hello` event and
+/// the `result` events keyed by the command that produced them.
+fn drive(solver: &str, cmds: &[&str]) -> (serde_json::Value, Vec<serde_json::Value>) {
+    let mut child = Command::new(pounce_exe())
+        .arg(fixture())
+        .arg("--no-sol")
+        .arg("--debug-json")
+        .arg(format!("solver_selection={solver}"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn pounce --debug-json");
+
+    {
+        // Taken (not borrowed) so the pipe is *closed* at the end of this
+        // block: after `quit` the debugger parks at the terminal checkpoint
+        // and reads again, so an open stdin would hang the child forever.
+        let mut stdin = child.stdin.take().expect("stdin");
+        for (i, c) in cmds.iter().enumerate() {
+            writeln!(
+                stdin,
+                "{{\"cmd\":{},\"id\":{}}}",
+                serde_json::json!(c),
+                i + 1
+            )
+            .expect("write command");
+        }
+        writeln!(stdin, "{{\"cmd\":\"quit\"}}").expect("write quit");
+        stdin.flush().expect("flush");
+    }
+
+    let stdout = child.stdout.take().expect("stdout");
+    let mut hello = serde_json::Value::Null;
+    let mut results = Vec::new();
+    for line in BufReader::new(stdout).lines() {
+        let line = line.expect("read line");
+        let Ok(ev) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue; // solver banner / report lines are not protocol events
+        };
+        match ev.get("event").and_then(|e| e.as_str()) {
+            Some("hello") => hello = ev,
+            Some("result") => results.push(ev),
+            _ => {}
+        }
+    }
+    let _ = child.wait();
+    (hello, results)
+}
+
+fn result_for<'a>(results: &'a [serde_json::Value], cmd: &str) -> &'a serde_json::Value {
+    results
+        .iter()
+        .find(|r| r.get("command").and_then(|c| c.as_str()) == Some(cmd))
+        .unwrap_or_else(|| panic!("no `result` event for `{cmd}`; got {results:#?}"))
+}
+
+/// The commands the capability matrix marks ➖ for the convex/conic IPM must
+/// fail with the backend message — not with a "stop later" timing hint,
+/// which is the loop #462 reported.
+#[test]
+fn convex_backend_rejects_kkt_commands_as_unavailable() {
+    let probes = [
+        "print kkt",
+        "print residuals",
+        "print active",
+        "print inactive",
+        "viz kkt",
+        "viz L",
+    ];
+    let mut cmds = vec!["stop-at kkt", "step"];
+    cmds.extend_from_slice(&probes);
+    let (_, results) = drive("qp-ipm", &cmds);
+
+    for probe in probes {
+        let r = result_for(&results, probe);
+        assert_eq!(
+            r.get("ok").and_then(|o| o.as_bool()),
+            Some(false),
+            "`{probe}` must be an error on the convex backend: {r}"
+        );
+        let out = r.get("output").and_then(|o| o.as_array()).expect("output");
+        let msg = out
+            .iter()
+            .filter_map(|l| l.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        assert!(
+            msg.contains("only available for the NLP solver"),
+            "`{probe}` must report a capability error, got: {msg}"
+        );
+        // The specific regression: no timing hint that names a checkpoint
+        // we are already stopped at.
+        assert!(
+            !msg.contains("after_search_dir") && !msg.contains("yet"),
+            "`{probe}` must not answer with a timing hint, got: {msg}"
+        );
+    }
+}
+
+/// The same command at the same checkpoint still works on the NLP
+/// filter-IPM: #462 is a capability gate on the convex backend, not a
+/// blanket removal.
+#[test]
+fn nlp_backend_still_prints_kkt_at_after_search_dir() {
+    let (_, results) = drive("nlp", &["stop-at kkt", "step", "print kkt"]);
+    let r = result_for(&results, "print kkt");
+    assert_eq!(
+        r.get("ok").and_then(|o| o.as_bool()),
+        Some(true),
+        "`print kkt` must still work on the NLP backend: {r}"
+    );
+    assert!(
+        r.pointer("/data/dim").and_then(|d| d.as_i64()).is_some(),
+        "`print kkt` must report the augmented-system dimension: {r}"
+    );
+}
+
+/// `hello.capabilities` is what the protocol tells clients to feature-detect
+/// off, so it must agree with what the REPL actually does on each backend.
+#[test]
+fn hello_capabilities_match_the_running_backend() {
+    let (convex, _) = drive("qp-ipm", &[]);
+    let (nlp, _) = drive("nlp", &[]);
+
+    for (name, expected) in [
+        ("kkt_inspect", false),
+        ("diagnose", false),
+        ("mutate_mu", false),
+        ("resolve", false),
+    ] {
+        assert_eq!(
+            convex.pointer(&format!("/capabilities/{name}")),
+            Some(&serde_json::json!(expected)),
+            "convex `capabilities.{name}` disagrees with the REPL: {convex}"
+        );
+    }
+    assert_eq!(
+        convex.pointer("/capabilities/viz"),
+        Some(&serde_json::json!(["block", "delta"])),
+        "convex must not advertise `viz kkt` / `viz L`: {convex}"
+    );
+    // The advertised iterate blocks are the ones this backend really has.
+    assert_eq!(
+        convex.pointer("/blocks/0").and_then(|b| b.as_str()),
+        Some("x")
+    );
+    assert!(
+        convex
+            .pointer("/blocks")
+            .and_then(|b| b.as_array())
+            .expect("blocks")
+            .iter()
+            .any(|b| b.as_str() == Some("z")),
+        "convex blocks must include `z`: {convex}"
+    );
+
+    // The NLP backend keeps every capability it had.
+    for name in ["kkt_inspect", "diagnose", "mutate_mu", "resolve"] {
+        assert_eq!(
+            nlp.pointer(&format!("/capabilities/{name}")),
+            Some(&serde_json::json!(true)),
+            "NLP `capabilities.{name}` regressed: {nlp}"
+        );
+    }
+    assert_eq!(
+        nlp.pointer("/capabilities/viz"),
+        Some(&serde_json::json!(["block", "delta", "kkt", "L"])),
+    );
+}

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -1158,6 +1158,14 @@ and `structural_diagnose` are `true` only when the solve came from an
 `.nl` file (which carries the source algebra and structural metadata) and
 `false` for a built-in problem, as shown above.
 
+The handshake above is the NLP filter-IPM's. Capabilities are answered for
+the backend that is actually running, so they agree with what the REPL will
+do: on the convex / conic IPM the backend-conditional entries
+(`kkt_inspect`, `diagnose`, `mutate_mu`, `resolve`, `sweep`, `load`,
+`structural_diagnose`) are `false`, `viz` is `["block","delta"]`, and
+`blocks` names *that* solver's iterate blocks (`x`/`s`/`y`/`z`, plus
+`tau`/`kappa` on the HSDE drivers) — see the capability matrix below.
+
 ### `pause`
 
 ```json


### PR DESCRIPTION
Fixes #462.

## The bug

On the convex/conic IPM, `print kkt` answered with a **timing** hint —
"no KKT factorization yet — stop at `after_search_dir`" — and emitted the
identical message when the session was already stopped at
`after_search_dir`. The convex backend has no augmented-system inertia at
any checkpoint, so following the hint can never produce a KKT view: a
human at the REPL loops. The documented contract (`docs/src/debugger.md`
capability matrix) is that a command unavailable on the current backend
reports "not available for this solver" and never silently no-ops, which
the sibling commands (`print rank`, `diagnose`, `resolve`) already did.

## The fix

Reject the backend-conditional commands on a **capability** basis before
any timing check, using the same `as_nlp` gate and message as the
siblings:

| command | convex before | convex after |
|---|---|---|
| `print kkt` | "no KKT factorization yet — stop at `after_search_dir`" | `only available for the NLP solver …` |
| `print residuals` | "no iterate yet — residuals unavailable" | ditto |
| `print active` / `inactive` | ok: "no bounded variables or inequality slacks" (a silent no-op) | ditto |
| `viz kkt` / `viz L` | "not captured yet — `step` once to capture" | ditto |

The NLP filter-IPM is untouched, including its genuine "not factored yet"
hint at a pre-factorization checkpoint.

While here: the `hello` handshake — what JSON clients are told to
feature-detect off — advertised `kkt_inspect`/`diagnose`/`mutate_mu` as
`true` and the NLP block names on *every* backend, so a client that
believed it hit exactly the same wall. `hello` is now answered for the
backend that is actually running: those flags plus `resolve`, `sweep`,
`load` and `structural_diagnose` are `false` on the convex path, `viz`
drops to `["block","delta"]`, and `blocks` lists that solver's own
iterate blocks (`x`/`s`/`y`/`z`, plus `tau`/`kappa` on HSDE).

## Verification

Issue reproduction, now:

```
pounce-dbg> `print kkt` is only available for the NLP solver (not the convex/conic solver)
```

and unchanged on `solver_selection=nlp`:

```
dim       = 4
inertia   = n+=3 n-=1 (expected n-=1) → correct
```

New `crates/pounce-cli/tests/issue_462_convex_capability_errors.rs` drives
both backends over `--debug-json` at the checkpoint the old hint named and
asserts (a) the six commands fail with the capability message and no
timing wording, (b) `print kkt` still works on the NLP path, and (c)
`hello.capabilities` agrees with the REPL on both backends. `cargo test -p
pounce-cli --lib` and the new test pass; `cargo fmt --check` and clippy on
the touched code are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQyLEbvQBBSuRYtwuFsTn4
