### PR TITLE
Scale the rank gates by the diagonal; log the S gate's default-path reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,12 @@ changes.
   duplicated design point, takes the same routes with its own
   message), not by LAPACK, which does not reliably raise on
   structurally singular blocks; a dedicated `_SingularBlock` exception
-  stands as the last resort.
+  stands as the last resort. The rank test runs on the diagonally
+  scaled block, so the verdict tracks collinearity and not the unit
+  spread between coordinates: a covariance block carries the square
+  of that spread, and numpy's default tolerance is relative to the
+  largest singular value, so two well-determined parameters far apart
+  in magnitude would otherwise be refused for their units alone.
 - `information()` routes: a manifold-parameterizing block (size equal
   to the degrees of freedom) gets the exact tangent construction; a
   sub-block of the fitted set gets its marginal by Schur complement
@@ -49,6 +54,24 @@ changes.
   lazily on first access, so calls that never read it cost nothing
   extra. Diagnostics stay "fitted parameter"-worded on the default
   path and speak block-relative only under an explicit wrt=.
+
+### Changed — pyomo-pounce: `information()` rank-gates the free block before the conditional-information solve
+
+- Computing `S`, the information a bound-pinned parameter carries
+  conditional on the rest of the pinned set, takes a Schur complement
+  through the free block. That step previously relied on
+  `np.linalg.solve` raising on a singular free block, which is
+  BLAS- and machine-dependent: the same refusal test flipped
+  pass/fail across adjacent CI runs on the same numpy with no numeric
+  change, because whether the pivot lands on exact zero varies by
+  build. The free block is now rank-tested first (diagonally scaled,
+  as the `wrt=` gates are), so the verdict is deterministic; the
+  exception clause stays as the last resort.
+- This applies on the DEFAULT path, not only under `wrt=`: a
+  numerically dependent free block now raises where it could
+  previously return a large-but-meaningless `S`. Well-conditioned and
+  merely ill-scaled blocks are unaffected — that is what the diagonal
+  scaling buys.
 
 ### Fixed — `sparse=True` no longer materializes a dense Jacobian/Hessian to detect the pattern (#464)
 

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1682,6 +1682,35 @@ def _conditioned_on(session, act, rows, who):
     return tuple(out)
 
 
+def _rank_deficient(A):
+    """True when the symmetric block `A` is rank-deficient, tested on
+    its diagonally scaled form so the verdict is a statement about
+    COLLINEARITY and not about units.
+
+    `np.linalg.matrix_rank` thresholds the singular values at
+    `sigma_max * n * eps`, which is relative to the largest singular
+    value and so is not invariant under rescaling the coordinates
+    against each other: a covariance block carries the SQUARE of any
+    unit spread between its members, so two perfectly well-determined
+    parameters ~1e8 apart in magnitude (a rate prefactor against a
+    reaction order) push `cond(M)` past the default tolerance and read
+    as dependent on unit spread alone. Scaling by `sqrt(|diag|)` first
+    — the correlation form — makes the test the same kind of
+    scale-invariant ratio as the block-membership rule (roadmap item 1)
+    and the conditioned_on rule, rather than a threshold that tracks
+    the user's choice of units. Second review of gh #466.
+
+    A zero diagonal leaves its own row and column unscaled: there is no
+    scale to divide by, and a genuinely zero row is rank-deficient
+    either way."""
+    n = A.shape[0]
+    if n == 0:
+        return False
+    d = np.sqrt(np.abs(np.diag(A)))
+    d = np.where(d > 0.0, d, 1.0)
+    return int(np.linalg.matrix_rank(A / np.outer(d, d))) < n
+
+
 class _SingularBlock(RuntimeError):
     """The requested block of the inverse KKT matrix is singular.
     A dedicated type so callers that rescue this case (the wrt
@@ -1861,12 +1890,14 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian",
     if wrt is not None:
         if n_params > n_var - n_eq:
             deficient = "count"
-        elif np.linalg.matrix_rank(M) < n_params:
+        elif _rank_deficient(M):
             # the count gate's own justification, one step to its
             # left: LAPACK does not reliably raise on a structurally
             # singular M, so a within-count dependent block needs its
             # own gate (fp-detectable dependence; anything softer is
-            # caught by _SingularBlock below as a last resort)
+            # caught by _SingularBlock below as a last resort).
+            # Diagonally scaled, so a badly-scaled but well-determined
+            # block is not refused for its units (second review)
             deficient = "dependent"
     if deficient is not None:
         cb = None
@@ -2218,9 +2249,11 @@ def information(model, hessian="lagrangian", wrt=None):
         if n_params > n_var - n_eq:
             _refuse_rank("more coordinates than the fit has degrees "
                          "of freedom")
-        if np.linalg.matrix_rank(M) < n_params:
+        if _rank_deficient(M):
             # the count gate one step to its left: LAPACK does not
-            # reliably raise on a structurally singular M
+            # reliably raise on a structurally singular M. Diagonally
+            # scaled, so the refusal tracks collinearity and not the
+            # user's units (second review)
             _refuse_rank("linearly dependent coordinates")
     try:
         cb = _classify_fitted_block(session, params, rows, M, zcols,
@@ -2309,9 +2342,15 @@ def information(model, hessian="lagrangian", wrt=None):
             # raises on a singular system is BLAS-dependent (the CI
             # wheel job's fresh numpy returned garbage where the local
             # build raised), the same non-determinism the wrt gates
-            # exist for; the exception clause stays as the last resort
+            # exist for; the exception clause stays as the last resort.
+            # Applies on the DEFAULT path too, not only under wrt=: a
+            # numerically dependent free block now refuses where it
+            # could previously return a large-but-meaningless S
+            # (CHANGELOG "Changed"). Diagonally scaled like the wrt
+            # gates, so an ill-scaled but well-determined free block
+            # keeps its answer (second review)
             R_FF = R[np.ix_(free, free)]
-            singular = np.linalg.matrix_rank(R_FF) < len(free)
+            singular = _rank_deficient(R_FF)
             if not singular:
                 try:
                     S = (R[np.ix_(active, active)]

--- a/pyomo-pounce/tests/test_wrt.py
+++ b/pyomo-pounce/tests/test_wrt.py
@@ -19,6 +19,7 @@ from pyomo_pounce import (
     declare_residual,
     information,
 )
+from pyomo_pounce.sens import _rank_deficient
 
 N = 25
 SIGMA = 0.3
@@ -372,6 +373,31 @@ def test_wrt_binding_row_falls_back_smoothly():
     assert np.isfinite(cov_a[m.a]) and np.isfinite(info_a[m.a])
     assert cov_a[m.a] * info_a[m.a] == pytest.approx(
         2.0 * SIGMA**2, rel=1e-6)
+
+
+def test_rank_gate_is_scale_invariant():
+    # the rank gates decide collinearity, not units. numpy's default
+    # tolerance is relative to the largest singular value, and a
+    # covariance block carries the SQUARE of any unit spread between
+    # its members, so a well-determined block whose coordinates differ
+    # by ~1e9 in magnitude reads as rank-deficient to the raw test and
+    # would be refused for its units alone. Unit-level, because the
+    # spread needed to trip it is past what a fixture can solve
+    # cleanly -- the matrices are exactly what the gates see.
+    C = np.array([[1.0, 0.5], [0.5, 1.0]])       # full rank, cond 3
+    D = np.diag([1e9, 1.0])
+    M = D @ C @ D                                # cond ~1e18, by units
+    assert np.linalg.matrix_rank(M) < 2          # the raw test is fooled
+    assert not _rank_deficient(M)                # the scaled one is not
+    # and genuine dependence is still caught at any scale
+    dep = np.array([[1.0, 1.0], [1.0, 1.0]])
+    assert _rank_deficient(D @ dep @ D)
+    assert _rank_deficient(dep)
+    # an indefinite block (the information side, where the diagonal
+    # can be negative) and a zero diagonal are both handled
+    indef = np.array([[-4.0, 1.0], [1.0, 9.0]])
+    assert not _rank_deficient(indef)
+    assert _rank_deficient(np.zeros((2, 2)))
 
 
 def test_wrt_within_count_dependent_block():


### PR DESCRIPTION
Two follow-ups from the second review of #466, which merged before these could be pushed to its branch.

## Problem

**The rank gates decided collinearity with numpy's default tolerance.** `np.linalg.matrix_rank` thresholds singular values at `sigma_max * n * eps` — relative to the *largest* singular value, so the verdict moves when you rescale coordinates against each other. A covariance block carries the **square** of any unit spread between its members, so two perfectly well-determined parameters far enough apart in magnitude (a rate prefactor against a reaction order) push `cond(M)` past that tolerance and read as dependent on their units alone:

```
C = [[1, 0.5], [0.5, 1]]        # full rank, cond 3
D = diag(1e9, 1);  M = D C D    # same block, one coordinate rescaled

np.linalg.matrix_rank(M)  ->  1     # "dependent"
```

Consequence: `information(wrt=...)` refuses outright, `covariance(wrt=...)` silently routes to the rank-deficient marginal bypass — for a block that is fully determined. This is the one place in #466 where the scale-invariance the rest of it argues for (the item-1 membership rule, the `conditioned_on` rule, both deliberately ratios) was not held onto.

**The free-block rank gate reaches the default path, and the CHANGELOG did not say so.** The gate in front of the `S` solve is not behind `wrt is not None`, unlike both `wrt=` gates. `information(m)` with no `wrt=` now refuses on a numerically dependent free block where it previously returned a large-but-meaningless `S`. That is the right trade — whether LAPACK raises there is BLAS-dependent, which is what made the refusal test flip pass/fail across adjacent CI runs on #466 — but it is a behavior change outside the feature's stated surface.

## Cause

`matrix_rank`'s default tolerance is a statement about the matrix as presented, not about the geometry it represents. The gates want the second.

## Fix

New `_rank_deficient(A)`, used at all three call sites (`covariance`'s wrt gate, `information`'s wrt gate, the `S` free-block gate). It rank-tests the diagonally scaled form, `D^-1/2 A D^-1/2` with `D = diag(|A|)` — the correlation form — so the tolerance measures collinearity and nothing else. A zero diagonal leaves its own row and column unscaled: there is no scale to divide by, and a genuinely zero row is rank-deficient either way. `abs` on the diagonal because the information side can be indefinite.

Rejected: raising the tolerance passed to `matrix_rank`. That trades one arbitrary threshold for another and still tracks the user's units — it moves the false-refusal boundary rather than removing the dependence on unit spread.

The `S` gate keeps its behavior and gets a `### Changed` CHANGELOG entry rather than riding along in `### Added`, since it touches a call the feature otherwise leaves alone.

## Blast radius

Bit-identical except the targeted case. The three call sites are the only consumers; a block that was accepted before is still accepted, and genuine dependence is still caught at any scale — the duplicated-design-point block from `test_wrt_within_count_dependent_block` still trips it (`[[h,h],[h,h]]` scales to `[[1,1],[1,1]]`). What changes is a block that was refused *for its units*, which is now answered.

## Tests

`test_rank_gate_is_scale_invariant` in `pyomo-pounce/tests/test_wrt.py`, asserting the raw test is fooled and the scaled one is not, that dependence is caught both scaled and plain, and that indefinite and zero-diagonal blocks are handled.

It bites: dropping the diagonal scaling from `_rank_deficient` fails it with `assert not True` on exactly the `[[1e18, 5e8], [5e8, 1]]` matrix, verified by mutation.

Deliberately unit-level on the matrices the gates actually see, rather than driven through a solve: the ~1e8 coordinate spread needed to trip the raw test is past what a fixture solves cleanly, so a model-level version would be testing the solver's scaling, not the gate.

Suites: `test_wrt.py` + `test_covariance.py` + `test_information.py`, 64 passed. Two failures elsewhere in `pyomo-pounce` (`test_infeasibility_no_false_positives`, `test_scale_invariance`) reproduce identically on the parent commit with these changes stashed, so they are not from this diff — they look like a local BLAS/numpy difference from CI, which is the same class of non-determinism the `S` gate exists for.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — `sensitivity.md`'s account of the rank gates stays accurate; this narrows when they fire, it does not add a surface
- [ ] `cargo fmt`/`clippy`/`test` — no Rust touched, pure `pyomo-pounce`
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nq8RB7kEwoqxdiXXWCdpva

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nq8RB7kEwoqxdiXXWCdpva)_