### PR TITLE
Run the deep expression walks on a stack sized for them, and stop copying operands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,58 @@ that makes such a DAG trivially constructible from a frontend. Measured
 on a balanced share-DAG: depth 26 took 3.0 s through
 `get_variables_linearity` and now completes at depth 30 instantly.
 
+### Fixed — a deeply nested expression no longer kills the interpreter (#472)
+
+Every consumer of an `Expr` recurses once per level of nesting — the tape
+builder, the problem assembler, freeing one, and the `.nl` parser that
+produces one — so a deep enough model overran the thread's stack. The
+result was a SIGSEGV rather than an exception: no traceback, nothing to
+catch, and an interactive session lost with it. Both doors reached it, and
+one of them predates the `NlExpr` surface entirely: `read_nl` on a
+generated `.nl` file whose objective is a long `o0` chain died at ~4 000
+levels, inside the parser, before any tape existed.
+
+- **The walks now run on a worker thread with a 64 MB stack**, so what is
+  survivable no longer depends on the calling thread — 8 MB on a
+  macOS/Linux main thread, 1 MB on Windows, less on a `threading.Thread`.
+  That covers the tape build, the assembly, the parse, and the teardown of
+  a problem that holds deep trees.
+- **One depth limit, enforced at both doors.** `NlExpr.max_depth` is now
+  10 000 and `read_nl` / `parse_nl_text` enforce the same number on what
+  they parsed — a model that arrives already built cannot be capped as it
+  is constructed. Past it, a `ValueError` naming the flat alternative
+  (`NlExpr.sum`, or `.nl`'s `o54`). Previously `NlExpr` refused depth
+  1 001 while the parser accepted 3 000 and crashed on 4 000; the limit is
+  now a property of the machinery rather than of the door, and it sits
+  ~3x inside what the worker stack holds even in a debug build.
+- Wide models are unaffected either way: an n-ary sum is one level however
+  many terms it has.
+
+**Building an expression is no longer quadratic.** Every operator used to
+deep-copy both operands, so accumulating in a Python loop copied the whole
+chain on every iteration: 5 000 terms took over five seconds, 40 000 over
+forty. Operands are now *referenced* rather than copied, making an
+operator O(1) whatever it is applied to — that same 5 000-term loop is
+about three milliseconds.
+
+- Reusing a Python name now reuses the subexpression rather than
+  duplicating it. `t = x[0] * x[1]` used ten times is one shared body on
+  the tape — evaluated once per sweep, with its adjoint summing the ten
+  contributions, which is the same value and the same derivatives off a
+  tape a tenth the size. Expressions that are only tractable *because* of
+  the sharing now work at all: `for _ in range(40): e = e * e` describes
+  `x ** 2**40` in 40 nodes and builds, tapes, and differentiates in under
+  a millisecond, where copying would have needed a trillion nodes.
+- What reaches the solver is unchanged for anything not genuinely shared.
+  References that exist only to hand an operand to an operator are inlined
+  when the model is assembled, so `from_expressions` sees the same plain
+  tree it always did — which is what keeps each term of a sum its own
+  tape, and each tape its own small set of Hessian colors.
+
+New Rust API: `NlTnlp::problem_mut`, which is how the Python binding takes
+the expression trees out of a problem to tear them down on a stack sized
+for them.
+
 ### Added — pyomo-pounce: `wrt=` block selection on both accessors (covariance roadmap item 3, #262)
 
 - `covariance(m, wrt=...)` and `information(m, wrt=...)` reduce onto

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -2568,6 +2568,19 @@ impl NlTnlp {
         &self.prob
     }
 
+    /// Mutable access to that same problem, for a caller that owns this
+    /// TNLP outright.
+    ///
+    /// The tapes were built from the expressions in [`Self::problem`] and
+    /// are not rebuilt, so editing an expression here does **not** change
+    /// what this TNLP evaluates. It exists for teardown: the Python
+    /// binding takes the expression trees out through here so a deeply
+    /// nested one is dropped on a stack chosen for it rather than
+    /// recursively on whatever thread collected the object (pounce#472).
+    pub fn problem_mut(&mut self) -> &mut NlProblem {
+        &mut self.prob
+    }
+
     /// Hessian-vector product of the Lagrangian:
     /// `out = (obj_factor·∇²f(x) + Σ_i λ_i·∇²g_i(x)) · v`.
     ///

--- a/crates/pounce-py/src/nl_expr.rs
+++ b/crates/pounce-py/src/nl_expr.rs
@@ -35,9 +35,12 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyString;
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use pounce_common::types::Number;
 use pounce_nl::nl_reader::{
-    BinOp, CmpOp, Expr, NlProblem, NlProblemParts, NlTnlp, UnaryOp, render_expression,
+    BinOp, CmpOp, Expr, FuncallArg, NlProblem, NlProblemParts, NlTnlp, UnaryOp, render_expression,
 };
 use pounce_nl::nl_tape::Tape;
 
@@ -48,58 +51,200 @@ use crate::nl_problem::PyNlProblem;
 /// default for an omitted bound vector.
 const INF: Number = 1e19;
 
-/// Deepest expression this module will build.
+/// Deepest expression any Python entry point will hand on: what
+/// [`PyNlExpr`] will build, and what `read_nl` / `parse_nl_text` will
+/// accept from a file (pounce#472).
 ///
-/// Everything that consumes an `Expr` — `Tape::build`, the derived
-/// `Clone`, and the derived `Drop` — recurses once per level, so a
-/// sufficiently deep tree overflows the stack. That is a hard crash, not a
-/// Python exception: the interpreter dies with SIGSEGV and no traceback.
-/// Measured on Linux with the default 8 MB stack, `Tape::build` survives
-/// ~32k levels in a release build but only ~4k in a debug build, and a
-/// Python thread with a smaller stack is worse still. Capping at
-/// construction is what makes the guarantee hold for all three consumers
-/// at once: an expression that cannot be built cannot later be cloned or
-/// dropped into a crash.
+/// Everything that consumes an `Expr` — `Tape::build`, [`materialize`],
+/// the problem assembler, the derived `Drop` — recurses once per level, as
+/// does the `.nl` parser that produces one. Overrunning the stack is a
+/// hard crash, not a Python exception: the interpreter dies with SIGSEGV
+/// and no traceback. Two things together keep that unreachable, and the
+/// limit is the second of them, not the first:
 ///
-/// 1000 is far below the smallest observed failure and far above anything
-/// reachable in practice, because building depth `D` through the operators
-/// costs O(D²) anyway (see [`PyNlExpr`]) — a chain long enough to approach
-/// the real stack limit takes tens of seconds to build. Wide models are
-/// unaffected: [`PyNlExpr::sum`] is one level regardless of term count.
-const MAX_DEPTH: u32 = 1000;
+/// * every such walk runs on a worker thread with a [`WORKER_STACK`]-byte
+///   stack (see [`on_deep_stack`]), so what is survivable stops depending
+///   on the calling thread — 8 MB on a macOS/Linux main thread, 1 MB on
+///   Windows, less on a `threading.Thread`;
+/// * this limit then keeps the depth well inside what that stack holds.
+///
+/// 10 000 is the arithmetic: the deepest frames measured are ~300 bytes in
+/// a release build and ~2 KB in a debug build, so 64 MB covers ~200 000
+/// levels released and ~32 000 in debug — a 3x margin at this limit even
+/// in the worst configuration. It is also comfortably past what the parser
+/// managed before it was guarded (~3 000), so no `.nl` file that loaded
+/// before is refused now.
+///
+/// Both surfaces share the number deliberately. A cap on one door and none
+/// on the other is what the issue reported second: `NlExpr` refusing depth
+/// 1 001 while `parse_nl_text` accepted 3 000 and crashed on 4 000.
+pub(crate) const MAX_DEPTH: u32 = 10_000;
+
+/// Depth up to which recursive walks run directly on the calling thread.
+///
+/// At the ~300-byte release frame this is ~150 KB, safe on a 1 MB Windows
+/// main thread with a Python call stack above it. Past it, the walk moves
+/// to the worker.
+pub(crate) const INLINE_DEPTH: u32 = 512;
+
+/// Stack for the worker thread. Reserved, not committed: only the pages
+/// actually touched cost anything. See [`MAX_DEPTH`] for the margin this
+/// buys.
+const WORKER_STACK: usize = 64 << 20;
+
+/// Run `f` on a worker thread with a stack sized for recursion over a
+/// deep expression, whatever the caller's stack is.
+///
+/// For work whose depth is not known ahead of time — parsing a `.nl` file
+/// is exactly that, since the depth is what the file says — rather than
+/// [`on_deep_stack`], which skips the worker for shallow input.
+pub(crate) fn on_worker_stack<T, F>(f: F) -> T
+where
+    T: Send,
+    F: FnOnce() -> T + Send,
+{
+    std::thread::scope(|scope| {
+        let spawned = std::thread::Builder::new()
+            .stack_size(WORKER_STACK)
+            .spawn_scoped(scope, f);
+        let handle = match spawned {
+            Ok(h) => h,
+            // Nothing safe is left to do: running the walk here is the
+            // segfault this function exists to prevent. Panic instead, so
+            // pyo3 raises it as a Python exception.
+            Err(e) => panic!("pounce: cannot spawn the expression worker thread: {e}"),
+        };
+        match handle.join() {
+            Ok(v) => v,
+            // Carry a panic across the join so pyo3 still turns it into a
+            // Python exception rather than losing it here.
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    })
+}
+
+/// [`on_worker_stack`], skipped when `depth` says the walk fits anywhere.
+///
+/// The spawn costs on the order of 100 µs. Nothing per-operator goes
+/// through here — building an expression does not walk it — so that is
+/// paid once per query, per assembled problem, and per deep teardown.
+pub(crate) fn on_deep_stack<T, F>(depth: u32, f: F) -> T
+where
+    T: Send,
+    F: FnOnce() -> T + Send,
+{
+    if depth <= INLINE_DEPTH {
+        return f();
+    }
+    on_worker_stack(f)
+}
+
+/// Nesting depth of an already-built expression, for input that did not
+/// come through [`PyNlExpr`]'s O(1) accounting — a parsed `.nl` model.
+///
+/// Recursive, so it must itself run inside [`on_worker_stack`]. Memoized
+/// on shared `Cse` bodies: a body has one depth however many references
+/// reach it, and without the memo a sharing DAG costs one visit per path
+/// rather than per node.
+pub(crate) fn expr_depth(e: &Expr, memo: &mut HashMap<*const Expr, u32>) -> u32 {
+    let below = |kids: &mut dyn Iterator<Item = &Expr>, memo: &mut HashMap<*const Expr, u32>| {
+        kids.fold(0, |acc, k| acc.max(expr_depth(k, memo)))
+    };
+    1 + match e {
+        Expr::Const(_) | Expr::Var(_) => 0,
+        Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+            below(&mut [&**a, &**b].into_iter(), memo)
+        }
+        Expr::Unary(_, a) | Expr::Not(a) => expr_depth(a, memo),
+        Expr::Sum(args) | Expr::MinList(args) | Expr::MaxList(args) => {
+            below(&mut args.iter(), memo)
+        }
+        Expr::Cond { cond, then_, else_ } => {
+            below(&mut [&**cond, &**then_, &**else_].into_iter(), memo)
+        }
+        Expr::Funcall { args, .. } => below(
+            &mut args.iter().filter_map(|a| match a {
+                FuncallArg::Real(inner) => Some(inner),
+                FuncallArg::Str(_) => None,
+            }),
+            memo,
+        ),
+        Expr::Cse(body) => {
+            let key = Arc::as_ptr(body);
+            if let Some(&d) = memo.get(&key) {
+                d - 1
+            } else {
+                let d = expr_depth(body, memo);
+                memo.insert(key, d + 1);
+                d
+            }
+        }
+    }
+}
 
 /// A node in an expression DAG, and the building block of
 /// [`build_nl_problem`].
 ///
-/// **Operands are deep-copied, so `+` chains are quadratic.** Each
-/// operator clones its operand subtrees rather than aliasing them, which
-/// keeps the semantics obvious — every occurrence is an independent
-/// occurrence in the chain rule — but means accumulating in a Python loop
-/// is O(N²) in both time and memory:
+/// **Cheap to use as an operand.** The payload is behind an `Arc`, and an
+/// operator references it through an [`Expr::Cse`] node rather than
+/// copying it, so `a + b` costs the same whether the operands are two
+/// variables or two half-million-node models. That is what keeps
+/// accumulation in a Python loop linear:
 ///
 /// ```python
 /// e = pounce.NlExpr.const_(0.0)
-/// for t in terms:          # O(N^2): each += copies everything built so far
-///     e = e + t
+/// for t in terms:                 # O(len(terms)) — each `+` is O(1), but
+///     e = e + t                   # nests one level deeper per term
 ///
-/// e = pounce.NlExpr.sum(terms)     # O(N), one n-ary node
-/// ```
+/// e = pounce.NlExpr.sum(terms)    # O(len(terms)) and one level, whatever
+/// ```                             # the term count
 ///
-/// The difference is not marginal — 200 000 terms through `sum` is
-/// instant, while a `+` chain is measured in tens of seconds by 20 000 and
-/// hits [`MAX_DEPTH`] long before that. Reach for `sum` whenever the term
-/// count is data-driven.
+/// `sum` is still the right spelling for a many-term sum: one flat n-ary
+/// node tapes better than a chain, and it does not spend a level of
+/// nesting per term, so [`MAX_DEPTH`] never binds on a wide model however
+/// data-driven its width.
+///
+/// Sharing is invisible in the result. A subexpression reached more than
+/// once stays a `Cse` — a shared body, which the tape emits once and whose
+/// adjoint sums the contributions from every reference, i.e. exactly what
+/// duplicating it would compute — and one reached a single time is inlined
+/// when the model is assembled, so the problem sees the same plain tree it
+/// would have seen from a `.nl` file.
 #[pyclass(module = "pounce", name = "NlExpr")]
 #[derive(Clone)]
 pub struct PyNlExpr {
-    pub(crate) inner: Expr,
+    /// Shared so that using this expression as an operand is O(1). Every
+    /// consumer treats it as immutable.
+    pub(crate) inner: Arc<Expr>,
     /// Nesting depth of `inner`, maintained incrementally (O(1) per
     /// operation) so the [`MAX_DEPTH`] check never has to walk the tree.
+    /// Counts this expression's own operators; the `Cse` node each operand
+    /// reference adds can double that in the tree a walk actually sees,
+    /// which is part of why `MAX_DEPTH` leaves the worker stack so much
+    /// room.
     depth: u32,
+}
+
+/// Dropping the last handle on a deep chain releases it one `Arc` at a
+/// time, recursing once per level — and a drop is the one thing the caller
+/// cannot decline, since the interpreter runs it whenever the object is
+/// collected. Hand the teardown to the worker thread (pounce#472).
+impl Drop for PyNlExpr {
+    fn drop(&mut self) {
+        if self.depth <= INLINE_DEPTH || Arc::strong_count(&self.inner) > 1 {
+            return;
+        }
+        let doomed = std::mem::replace(&mut self.inner, Arc::new(Expr::Const(0.0)));
+        on_deep_stack(self.depth, move || drop(doomed));
+    }
 }
 
 /// An operand decoded from Python: the expression plus its depth, so the
 /// consumer can compute its own depth without a walk.
+///
+/// The expression is either a leaf or a `Cse` reference to an existing
+/// [`PyNlExpr`]'s payload, so building one, moving it, and dropping it are
+/// all O(1) however large the operand is.
 struct Operand {
     expr: Expr,
     depth: u32,
@@ -109,24 +254,51 @@ impl PyNlExpr {
     /// Wrap an expression whose depth is already known to be in range.
     /// Only for leaves (`Var` / `Const`), where depth is 1 by definition.
     fn leaf(inner: Expr) -> PyNlExpr {
-        PyNlExpr { inner, depth: 1 }
+        PyNlExpr {
+            inner: Arc::new(inner),
+            depth: 1,
+        }
     }
 
     /// Wrap a node built over operands of depth `child_depth`, rejecting
     /// it if that puts the result past [`MAX_DEPTH`].
+    ///
+    /// The `PyNlExpr` is formed *before* the check so that a rejected node
+    /// is torn down by the `Drop` above rather than recursively here.
     fn nested(inner: Expr, child_depth: u32) -> PyResult<PyNlExpr> {
         let depth = child_depth.saturating_add(1);
+        let built = PyNlExpr {
+            inner: Arc::new(inner),
+            depth,
+        };
         if depth > MAX_DEPTH {
             return Err(PyValueError::new_err(format!(
                 "NlExpr: expression nesting would reach depth {depth}, past the \
                  limit of {MAX_DEPTH}. Deeper trees overflow the stack when the \
-                 expression is taped, copied, or freed — a hard crash rather than \
+                 expression is taped, walked, or freed — a hard crash rather than \
                  an exception — so they are refused here. If you are accumulating \
                  terms in a loop (`e = e + t`), use NlExpr.sum([...]) instead: it \
-                 builds one n-ary node of depth 1 and is O(N) rather than O(N^2)."
+                 builds one n-ary node of depth 1, whatever the term count."
             )));
         }
-        Ok(PyNlExpr { inner, depth })
+        Ok(built)
+    }
+
+    /// This expression as an operand of a new node: a `Cse` reference to
+    /// the payload, not a copy of it.
+    ///
+    /// Leaves are passed through as themselves — a `Cse` around a `Var`
+    /// costs a pointer chase and a memo lookup in every walk and buys
+    /// nothing, the leaf already being the smallest thing there is.
+    fn operand(&self) -> Operand {
+        let expr = match &*self.inner {
+            leaf @ (Expr::Const(_) | Expr::Var(_)) => leaf.clone(),
+            _ => Expr::Cse(Arc::clone(&self.inner)),
+        };
+        Operand {
+            expr,
+            depth: self.depth,
+        }
     }
 }
 
@@ -134,10 +306,7 @@ impl PyNlExpr {
 /// `2 * x[0]` and `x[0] ** 2` read the way a modeler expects.
 fn coerce(v: &Bound<'_, PyAny>, what: &str) -> PyResult<Operand> {
     if let Ok(e) = v.extract::<PyRef<'_, PyNlExpr>>() {
-        return Ok(Operand {
-            expr: e.inner.clone(),
-            depth: e.depth,
-        });
+        return Ok(e.operand());
     }
     // Reject strings explicitly: Python would happily `float("nan")` some
     // of them via `extract`, and silently turning "1e-3" into a constant
@@ -362,91 +531,35 @@ impl PyNlExpr {
     }
 
     fn __add__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Add,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-            coerce(other, "+")?,
-        )
+        binary(BinOp::Add, self.operand(), coerce(other, "+")?)
     }
 
     fn __radd__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Add,
-            coerce(other, "+")?,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        binary(BinOp::Add, coerce(other, "+")?, self.operand())
     }
 
     fn __sub__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Sub,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-            coerce(other, "-")?,
-        )
+        binary(BinOp::Sub, self.operand(), coerce(other, "-")?)
     }
 
     fn __rsub__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Sub,
-            coerce(other, "-")?,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        binary(BinOp::Sub, coerce(other, "-")?, self.operand())
     }
 
     fn __mul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Mul,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-            coerce(other, "*")?,
-        )
+        binary(BinOp::Mul, self.operand(), coerce(other, "*")?)
     }
 
     fn __rmul__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Mul,
-            coerce(other, "*")?,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        binary(BinOp::Mul, coerce(other, "*")?, self.operand())
     }
 
     fn __truediv__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Div,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-            coerce(other, "/")?,
-        )
+        binary(BinOp::Div, self.operand(), coerce(other, "/")?)
     }
 
     fn __rtruediv__(&self, other: &Bound<'_, PyAny>) -> PyResult<PyNlExpr> {
-        binary(
-            BinOp::Div,
-            coerce(other, "/")?,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        binary(BinOp::Div, coerce(other, "/")?, self.operand())
     }
 
     fn __pow__(
@@ -459,14 +572,7 @@ impl PyNlExpr {
                 "NlExpr ** exp % mod: three-argument pow is not supported",
             ));
         }
-        binary(
-            BinOp::Pow,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-            coerce(other, "**")?,
-        )
+        binary(BinOp::Pow, self.operand(), coerce(other, "**")?)
     }
 
     fn __rpow__(
@@ -479,24 +585,11 @@ impl PyNlExpr {
                 "base ** NlExpr % mod: three-argument pow is not supported",
             ));
         }
-        binary(
-            BinOp::Pow,
-            coerce(other, "**")?,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        binary(BinOp::Pow, coerce(other, "**")?, self.operand())
     }
 
     fn __neg__(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Neg,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Neg, self.operand())
     }
 
     fn __pos__(&self) -> PyNlExpr {
@@ -550,194 +643,92 @@ impl PyNlExpr {
     }
 
     fn __abs__(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Abs,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Abs, self.operand())
     }
 
     fn sqrt(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Sqrt,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Sqrt, self.operand())
     }
 
     fn exp(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Exp,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Exp, self.operand())
     }
 
     /// Natural logarithm.
     fn log(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Log,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Log, self.operand())
     }
 
     fn log10(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Log10,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Log10, self.operand())
     }
 
     fn sin(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Sin,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Sin, self.operand())
     }
 
     fn cos(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Cos,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Cos, self.operand())
     }
 
     fn tan(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Tan,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Tan, self.operand())
     }
 
     fn asin(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Asin,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Asin, self.operand())
     }
 
     fn acos(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Acos,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Acos, self.operand())
     }
 
     fn atan(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Atan,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Atan, self.operand())
     }
 
     fn sinh(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Sinh,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Sinh, self.operand())
     }
 
     fn cosh(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Cosh,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Cosh, self.operand())
     }
 
     fn tanh(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Tanh,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Tanh, self.operand())
     }
 
     fn asinh(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Asinh,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Asinh, self.operand())
     }
 
     fn acosh(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Acosh,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Acosh, self.operand())
     }
 
     fn atanh(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Atanh,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Atanh, self.operand())
     }
 
     /// Gauss error function. Reachable only from here — AMPL has no `erf`
     /// opcode, so no `.nl` round trip can carry it (issue #469).
     fn erf(&self) -> PyResult<PyNlExpr> {
-        unary(
-            UnaryOp::Erf,
-            Operand {
-                expr: self.inner.clone(),
-                depth: self.depth,
-            },
-        )
+        unary(UnaryOp::Erf, self.operand())
     }
 
     /// Value of this expression alone at `x`, through the same AD tape a
     /// model uses. `x` must be long enough to cover every variable index
     /// the expression references.
     fn eval(&self, x: Vec<Number>) -> PyResult<Number> {
-        let tape = self.checked_tape(x.len(), "eval")?;
-        Ok(tape.eval(&x))
+        let inner = &self.inner;
+        // The tape build recurses once per level, so it runs under the
+        // depth guard; only plain data crosses back (pounce#472).
+        let value: Result<Number, String> = on_deep_stack(self.depth, move || {
+            let tape = checked_tape(inner, x.len(), "eval")?;
+            Ok(tape.eval(&x))
+        });
+        value.map_err(PyValueError::new_err)
     }
 
     /// Gradient of this expression alone at `x`, length `len(x)`.
@@ -746,15 +737,20 @@ impl PyNlExpr {
         py: Python<'py>,
         x: Vec<Number>,
     ) -> PyResult<Bound<'py, PyArray1<Number>>> {
-        let tape = self.checked_tape(x.len(), "gradient")?;
-        let mut grad = vec![0.0; x.len()];
-        tape.gradient_seed(&x, 1.0, &mut grad);
-        Ok(grad.into_pyarray_bound(py))
+        let inner = &self.inner;
+        let grad: Result<Vec<Number>, String> = on_deep_stack(self.depth, move || {
+            let tape = checked_tape(inner, x.len(), "gradient")?;
+            let mut grad = vec![0.0; x.len()];
+            tape.gradient_seed(&x, 1.0, &mut grad);
+            Ok(grad)
+        });
+        Ok(grad.map_err(PyValueError::new_err)?.into_pyarray_bound(py))
     }
 
     /// Sorted variable indices this expression references.
     fn variables(&self) -> Vec<usize> {
-        Tape::build(&self.inner).variables()
+        let inner = &self.inner;
+        on_deep_stack(self.depth, move || Tape::build(inner).variables())
     }
 
     fn __repr__(&self) -> String {
@@ -769,19 +765,151 @@ impl PyNlExpr {
     }
 }
 
-impl PyNlExpr {
-    /// Tape for this expression, rejecting a variable index `x` cannot
-    /// supply. Without the check the tape's forward sweep would index
-    /// `x` out of bounds — a panic across the pyo3 boundary rather than a
-    /// catchable Python error.
-    fn checked_tape(&self, x_len: usize, what: &str) -> PyResult<Tape> {
-        let tape = Tape::build(&self.inner);
-        match tape.variables().iter().max() {
-            Some(&max) if max >= x_len => Err(PyValueError::new_err(format!(
-                "{what}: expression references variable {max} but x has length {x_len}"
-            ))),
-            _ => Ok(tape),
+impl PyNlExpr {}
+
+/// Rebuild `root` with a `Cse` node left only where the same
+/// subexpression really is reached more than once.
+///
+/// Operators reference their operands rather than copying them, so a
+/// freshly built expression is a chain of `Cse` nodes even when nothing is
+/// shared. The tape does not care — it walks through a `Cse` and memoizes
+/// the body — but the problem assembler does: `split_top_sums` treats a
+/// `Cse` as an opaque leaf, so an un-inlined `a + b + c` would tape as one
+/// summand instead of three, and the whole model would share one tape and
+/// one color set in `eval_h` instead of a small one per term. Inlining the
+/// references that are not really shared gives `from_expressions` exactly
+/// the tree it would have gotten from a copy-on-every-operator build, at
+/// one pass over the DAG instead of one per operator.
+///
+/// Genuine sharing (`t` used twice) is *kept* as a `Cse`, which is better
+/// than the copy it replaces: the body is taped once and its adjoint sums
+/// the contributions from every reference — the same value and the same
+/// derivatives, off a smaller tape.
+fn materialize(root: &Expr) -> Expr {
+    let mut refs: HashMap<*const Expr, usize> = HashMap::new();
+    count_refs(root, &mut refs);
+    let mut shared: HashMap<*const Expr, Arc<Expr>> = HashMap::new();
+    rebuild(root, &refs, &mut shared)
+}
+
+/// Count how many references reach each `Cse` body. Descends into a body
+/// only the first time it is seen, so a DAG costs one visit per distinct
+/// node rather than one per path to it.
+fn count_refs(e: &Expr, refs: &mut HashMap<*const Expr, usize>) {
+    match e {
+        Expr::Const(_) | Expr::Var(_) => {}
+        Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+            count_refs(a, refs);
+            count_refs(b, refs);
         }
+        Expr::Unary(_, a) | Expr::Not(a) => count_refs(a, refs),
+        Expr::Sum(args) | Expr::MinList(args) | Expr::MaxList(args) => {
+            for a in args {
+                count_refs(a, refs);
+            }
+        }
+        Expr::Cond { cond, then_, else_ } => {
+            count_refs(cond, refs);
+            count_refs(then_, refs);
+            count_refs(else_, refs);
+        }
+        Expr::Funcall { args, .. } => {
+            for a in args {
+                if let FuncallArg::Real(inner) = a {
+                    count_refs(inner, refs);
+                }
+            }
+        }
+        Expr::Cse(body) => {
+            let seen = refs.entry(Arc::as_ptr(body)).or_insert(0);
+            *seen += 1;
+            if *seen == 1 {
+                count_refs(body, refs);
+            }
+        }
+    }
+}
+
+fn rebuild(
+    e: &Expr,
+    refs: &HashMap<*const Expr, usize>,
+    shared: &mut HashMap<*const Expr, Arc<Expr>>,
+) -> Expr {
+    match e {
+        Expr::Const(_) | Expr::Var(_) => e.clone(),
+        Expr::Binary(op, a, b) => Expr::Binary(
+            *op,
+            Box::new(rebuild(a, refs, shared)),
+            Box::new(rebuild(b, refs, shared)),
+        ),
+        Expr::Unary(op, a) => Expr::Unary(*op, Box::new(rebuild(a, refs, shared))),
+        Expr::Compare(op, a, b) => Expr::Compare(
+            *op,
+            Box::new(rebuild(a, refs, shared)),
+            Box::new(rebuild(b, refs, shared)),
+        ),
+        Expr::And(a, b) => Expr::And(
+            Box::new(rebuild(a, refs, shared)),
+            Box::new(rebuild(b, refs, shared)),
+        ),
+        Expr::Or(a, b) => Expr::Or(
+            Box::new(rebuild(a, refs, shared)),
+            Box::new(rebuild(b, refs, shared)),
+        ),
+        Expr::Not(a) => Expr::Not(Box::new(rebuild(a, refs, shared))),
+        Expr::Sum(args) => Expr::Sum(args.iter().map(|a| rebuild(a, refs, shared)).collect()),
+        Expr::MinList(args) => {
+            Expr::MinList(args.iter().map(|a| rebuild(a, refs, shared)).collect())
+        }
+        Expr::MaxList(args) => {
+            Expr::MaxList(args.iter().map(|a| rebuild(a, refs, shared)).collect())
+        }
+        Expr::Cond { cond, then_, else_ } => Expr::Cond {
+            cond: Box::new(rebuild(cond, refs, shared)),
+            then_: Box::new(rebuild(then_, refs, shared)),
+            else_: Box::new(rebuild(else_, refs, shared)),
+        },
+        Expr::Funcall { id, args } => Expr::Funcall {
+            id: *id,
+            args: args
+                .iter()
+                .map(|a| match a {
+                    FuncallArg::Real(inner) => FuncallArg::Real(rebuild(inner, refs, shared)),
+                    FuncallArg::Str(s) => FuncallArg::Str(s.clone()),
+                })
+                .collect(),
+        },
+        Expr::Cse(body) => {
+            let key = Arc::as_ptr(body);
+            if refs.get(&key).copied().unwrap_or(0) < 2 {
+                // One reference: this is an operand hand-off, not sharing.
+                return rebuild(body, refs, shared);
+            }
+            if let Some(done) = shared.get(&key) {
+                return Expr::Cse(Arc::clone(done));
+            }
+            let built = Arc::new(rebuild(body, refs, shared));
+            shared.insert(key, Arc::clone(&built));
+            Expr::Cse(built)
+        }
+    }
+}
+
+/// Tape for `inner`, rejecting a variable index `x` cannot supply.
+/// Without the check the tape's forward sweep would index `x` out of
+/// bounds — a panic across the pyo3 boundary rather than a catchable
+/// Python error.
+///
+/// A free function returning `Result<_, String>` rather than a method
+/// returning `PyResult`: it is called from inside [`on_deep_stack`], and
+/// only `Send` plain data may cross back out of that worker.
+fn checked_tape(inner: &Expr, x_len: usize, what: &str) -> Result<Tape, String> {
+    let tape = Tape::build(inner);
+    match tape.variables().iter().max() {
+        Some(&max) if max >= x_len => Err(format!(
+            "{what}: expression references variable {max} but x has length {x_len}"
+        )),
+        _ => Ok(tape),
     }
 }
 
@@ -851,12 +979,18 @@ pub fn build_nl_problem(
     var_names: Option<Vec<String>>,
     con_names: Option<Vec<String>>,
 ) -> PyResult<PyNlProblem> {
-    let objective = coerce(objective, "build_nl_problem: objective")?.expr;
-    let constraints = match constraints {
-        None => Vec::new(),
-        Some(c) => coerce_all(c, "build_nl_problem: constraints")?.0,
+    let objective = coerce(objective, "build_nl_problem: objective")?;
+    let (constraints, con_depth) = match constraints {
+        None => (Vec::new(), 0),
+        Some(c) => coerce_all(c, "build_nl_problem: constraints")?,
     };
     let m = constraints.len();
+    // Assembly walks every expression recursively — materialization, the
+    // variable-index validation, the top-level sum split, and one tape
+    // build per summand — so it runs under the depth guard the query
+    // methods use (pounce#472).
+    let depth = objective.depth.max(con_depth);
+    let objective = objective.expr;
 
     let parts = NlProblemParts {
         minimize,
@@ -872,9 +1006,202 @@ pub fn build_nl_problem(
         con_names: con_names.unwrap_or_default(),
     };
 
-    let prob = NlProblem::from_expressions(parts)
-        .map_err(|e| PyValueError::new_err(format!("build_nl_problem: {e}")))?;
-    let tnlp = NlTnlp::try_new(prob)
-        .map_err(|e| PyValueError::new_err(format!("build_nl_problem: {e}")))?;
-    PyNlProblem::from_tnlp(tnlp, "build_nl_problem")
+    let tnlp = on_deep_stack(depth, move || {
+        // Each row is materialized on its own, so an expression used in
+        // two of them is a plain tree in both rather than a `Cse` shared
+        // across them — a row whose *root* were a `Cse` would tape as a
+        // single summand.
+        let mut parts = parts;
+        parts.objective = materialize(&parts.objective);
+        for c in &mut parts.constraints {
+            *c = materialize(c);
+        }
+        let prob = NlProblem::from_expressions(parts)?;
+        NlTnlp::try_new(prob)
+    })
+    .map_err(|e| PyValueError::new_err(format!("build_nl_problem: {e}")))?;
+    // The problem keeps the expression trees it taped, so it inherits
+    // their depth for its own copies and teardown.
+    PyNlProblem::from_tnlp(tnlp, "build_nl_problem", depth)
+}
+
+#[cfg(test)]
+mod tests {
+    //! Unit tests for the sharing/materialization pair (issue #472). They
+    //! drive the real constructors — `binary`, `unary`, `operand` — which
+    //! never touch the interpreter on the success path, so no Python is
+    //! needed to build an expression exactly as a modeler would.
+
+    use super::*;
+
+    fn num(v: Number) -> Operand {
+        Operand {
+            expr: Expr::Const(v),
+            depth: 1,
+        }
+    }
+
+    fn node(inner: Expr, child_depth: u32) -> PyNlExpr {
+        PyNlExpr::nested(inner, child_depth).unwrap()
+    }
+
+    /// `x0 + 1 + 1 + ...`, the accumulation loop, `adds` operators long.
+    fn chain(adds: usize) -> PyNlExpr {
+        let mut e = PyNlExpr::leaf(Expr::Var(0));
+        for _ in 0..adds {
+            e = binary(BinOp::Add, e.operand(), num(1.0)).unwrap();
+        }
+        e
+    }
+
+    /// The same expression a copy-on-every-operator build would produce.
+    fn plain_chain(adds: usize) -> Expr {
+        let mut e = Expr::Var(0);
+        for _ in 0..adds {
+            e = Expr::Binary(BinOp::Add, Box::new(e), Box::new(Expr::Const(1.0)));
+        }
+        e
+    }
+
+    fn count_cse(e: &Expr) -> usize {
+        let mut refs = HashMap::new();
+        count_refs(e, &mut refs);
+        refs.values().sum()
+    }
+
+    #[test]
+    fn building_a_chain_shares_rather_than_copies() {
+        // One reference per operator, less the first, whose operand is the
+        // bare `Var` leaf: the payload is never copied.
+        assert_eq!(count_cse(&chain(4).inner), 3);
+    }
+
+    #[test]
+    fn materialize_inlines_operand_references() {
+        // Those references are hand-offs, not sharing, so the assembled
+        // model gets the plain left-leaning chain — which is what lets
+        // `split_top_sums` see the `+`s and give each term its own tape.
+        let flat = materialize(&chain(4).inner);
+        assert_eq!(count_cse(&flat), 0);
+        assert_eq!(format!("{flat:?}"), format!("{:?}", plain_chain(4)));
+    }
+
+    #[test]
+    fn a_leaf_operand_is_never_wrapped() {
+        let x = PyNlExpr::leaf(Expr::Var(0));
+        let y = PyNlExpr::leaf(Expr::Var(1));
+        let e = binary(BinOp::Mul, x.operand(), y.operand()).unwrap();
+        assert_eq!(count_cse(&e.inner), 0);
+        assert!(matches!(&*e.inner, Expr::Binary(BinOp::Mul, _, _)));
+    }
+
+    #[test]
+    fn materialize_keeps_a_twice_used_subexpression_shared() {
+        let t = unary(UnaryOp::Sin, PyNlExpr::leaf(Expr::Var(0)).operand()).unwrap();
+        let e = binary(BinOp::Add, t.operand(), t.operand()).unwrap();
+        match materialize(&e.inner) {
+            Expr::Binary(BinOp::Add, a, b) => match (*a, *b) {
+                // One body, referenced twice — not two copies of it.
+                (Expr::Cse(x), Expr::Cse(y)) => {
+                    assert!(Arc::ptr_eq(&x, &y));
+                    assert!(matches!(&*x, Expr::Unary(UnaryOp::Sin, _)));
+                }
+                other => panic!("expected two references to one body, got {other:?}"),
+            },
+            other => panic!("expected an Add, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn sharing_survives_the_n_ary_and_control_flow_nodes() {
+        // `count_refs` / `rebuild` have an arm per variant; this walks the
+        // ones the binary tests do not reach.
+        let t = unary(UnaryOp::Exp, PyNlExpr::leaf(Expr::Var(0)).operand()).unwrap();
+        let cond = node(
+            Expr::Cond {
+                cond: Box::new(t.operand().expr),
+                then_: Box::new(t.operand().expr),
+                else_: Box::new(num(0.0).expr),
+            },
+            t.depth,
+        );
+        let min = node(
+            Expr::MinList(vec![t.operand().expr, cond.operand().expr]),
+            cond.depth,
+        );
+        let e = node(
+            Expr::Sum(vec![min.operand().expr, t.operand().expr]),
+            min.depth,
+        );
+
+        // `t` is reached four times, `min` and `cond` once each.
+        let flat = materialize(&e.inner);
+        assert_eq!(count_cse(&flat), 4, "{flat:?}");
+        let mut bodies = Vec::new();
+        collect_cse_ptrs(&flat, &mut bodies);
+        bodies.sort_unstable();
+        bodies.dedup();
+        assert_eq!(bodies.len(), 1, "one shared body, four references");
+    }
+
+    fn collect_cse_ptrs(e: &Expr, out: &mut Vec<*const Expr>) {
+        match e {
+            Expr::Cse(body) => {
+                out.push(Arc::as_ptr(body));
+                collect_cse_ptrs(body, out);
+            }
+            Expr::Binary(_, a, b) | Expr::Compare(_, a, b) | Expr::And(a, b) | Expr::Or(a, b) => {
+                collect_cse_ptrs(a, out);
+                collect_cse_ptrs(b, out);
+            }
+            Expr::Unary(_, a) | Expr::Not(a) => collect_cse_ptrs(a, out),
+            Expr::Sum(args) | Expr::MinList(args) | Expr::MaxList(args) => {
+                for a in args {
+                    collect_cse_ptrs(a, out);
+                }
+            }
+            Expr::Cond { cond, then_, else_ } => {
+                collect_cse_ptrs(cond, out);
+                collect_cse_ptrs(then_, out);
+                collect_cse_ptrs(else_, out);
+            }
+            Expr::Const(_) | Expr::Var(_) | Expr::Funcall { .. } => {}
+        }
+    }
+
+    #[test]
+    fn a_shared_body_is_taped_and_differentiated_like_the_copy_it_replaces() {
+        // sin(x0) used twice, against the same thing written out twice.
+        let t = unary(UnaryOp::Sin, PyNlExpr::leaf(Expr::Var(0)).operand()).unwrap();
+        let shared = materialize(&binary(BinOp::Mul, t.operand(), t.operand()).unwrap().inner);
+        let copied = Expr::Binary(
+            BinOp::Mul,
+            Box::new(Expr::Unary(UnaryOp::Sin, Box::new(Expr::Var(0)))),
+            Box::new(Expr::Unary(UnaryOp::Sin, Box::new(Expr::Var(0)))),
+        );
+        let x = [0.7];
+        let (ts, tc) = (Tape::build(&shared), Tape::build(&copied));
+        assert!((ts.eval(&x) - tc.eval(&x)).abs() < 1e-15);
+        let (mut gs, mut gc) = (vec![0.0], vec![0.0]);
+        ts.gradient_seed(&x, 1.0, &mut gs);
+        tc.gradient_seed(&x, 1.0, &mut gc);
+        assert!((gs[0] - gc[0]).abs() < 1e-15, "{gs:?} vs {gc:?}");
+        // The point of keeping it shared: one `Sin` on the tape, not two.
+        assert!(
+            ts.ops.len() < tc.ops.len(),
+            "{} vs {}",
+            ts.ops.len(),
+            tc.ops.len()
+        );
+    }
+
+    #[test]
+    fn the_depth_limit_still_bites() {
+        let mut e = PyNlExpr::leaf(Expr::Var(0));
+        for _ in 0..MAX_DEPTH - 1 {
+            e = binary(BinOp::Add, e.operand(), num(1.0)).unwrap();
+        }
+        assert_eq!(e.depth, MAX_DEPTH);
+        assert!(binary(BinOp::Add, e.operand(), num(1.0)).is_err());
+    }
 }

--- a/crates/pounce-py/src/nl_problem.rs
+++ b/crates/pounce-py/src/nl_problem.rs
@@ -34,8 +34,12 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
 use pounce_common::types::{Index, Number};
-use pounce_nl::nl_reader::{NlTnlp, NlVariation, parse_nl_text as parse_nl_text_rs, read_nl_file};
+use pounce_nl::nl_reader::{
+    Expr, NlProblem, NlTnlp, NlVariation, parse_nl_text as parse_nl_text_rs, read_nl_file,
+};
 use pounce_nlp::tnlp::{SparsityRequest, TNLP};
+
+use crate::nl_expr::{INLINE_DEPTH, MAX_DEPTH, expr_depth, on_deep_stack, on_worker_stack};
 
 /// A `.nl` model loaded through pounce's reader, exposing its evaluators.
 // `NlTnlp` itself is `Send` (its CSE nodes went `Arc` for pounce#126's
@@ -51,6 +55,11 @@ pub struct PyNlProblem {
     m: usize,
     nnz_jac: usize,
     nnz_h: usize,
+    /// Nesting depth of the expressions inside `tnlp`. `NlTnlp` keeps the
+    /// `Expr` trees it taped, so copying or dropping this pyclass recurses
+    /// once per level — the same hazard `NlExpr` guards, reached through
+    /// the problem instead (pounce#472).
+    expr_depth: u32,
     // Metadata captured before `prob` was moved into `NlTnlp`.
     minimize: bool,
     obj_constant: Number,
@@ -529,12 +538,15 @@ impl PyNlProblem {
             g_l: dec(g_l, self.m, "variant: g_l")?,
             g_u: dec(g_u, self.m, "variant: g_u")?,
         };
-        let tnlp = self
-            .tnlp
-            .borrow()
-            .variant(&variation)
-            .map_err(PyValueError::new_err)?;
-        PyNlProblem::from_tnlp(tnlp, "variant")
+        // `variant` copies the model, expressions included, so it carries
+        // the same recursion depth (pounce#472).
+        let tnlp = {
+            let held = self.tnlp.borrow();
+            let src: &NlTnlp = &held;
+            on_deep_stack(self.expr_depth, move || src.variant(&variation))
+                .map_err(PyValueError::new_err)?
+        };
+        PyNlProblem::from_tnlp(tnlp, "variant", self.expr_depth)
     }
 
     fn __repr__(&self) -> String {
@@ -548,7 +560,11 @@ impl PyNlProblem {
 impl PyNlProblem {
     /// Build the pyclass around an owned `NlTnlp`, capturing the
     /// metadata the getters serve. `what` labels error messages.
-    pub(crate) fn from_tnlp(mut tnlp: NlTnlp, what: &str) -> PyResult<PyNlProblem> {
+    pub(crate) fn from_tnlp(
+        mut tnlp: NlTnlp,
+        what: &str,
+        expr_depth: u32,
+    ) -> PyResult<PyNlProblem> {
         let info = tnlp
             .get_nlp_info()
             .ok_or_else(|| PyValueError::new_err(format!("{what}: get_nlp_info returned None")))?;
@@ -569,6 +585,7 @@ impl PyNlProblem {
             m,
             nnz_jac: info.nnz_jac_g as usize,
             nnz_h: info.nnz_h_lag as usize,
+            expr_depth,
             minimize,
             obj_constant,
             x0,
@@ -585,7 +602,11 @@ impl PyNlProblem {
     /// the pyclass) moves to a rayon worker. Cheap relative to a
     /// solve — tapes are flat `Vec`s of ops.
     pub(crate) fn clone_tnlp(&self) -> NlTnlp {
-        self.tnlp.borrow().clone()
+        let held = self.tnlp.borrow();
+        let tnlp: &NlTnlp = &held;
+        // The clone copies the `Expr` trees along with the tapes, so it
+        // recurses once per level of nesting (pounce#472).
+        on_deep_stack(self.expr_depth, move || tnlp.clone())
     }
 
     pub(crate) fn dims(&self) -> (usize, usize) {
@@ -604,6 +625,53 @@ impl PyNlProblem {
     }
 }
 
+/// Tear the expression trees down on a stack sized for them, for a
+/// problem deep enough that the recursive drop could overrun the
+/// collecting thread's (pounce#472). The tapes the evaluators actually
+/// use are flat `Vec`s and drop normally.
+impl Drop for PyNlProblem {
+    fn drop(&mut self) {
+        if self.expr_depth <= INLINE_DEPTH {
+            return;
+        }
+        let prob = self.tnlp.get_mut().problem_mut();
+        let mut doomed = Vec::with_capacity(prob.con_nonlinear.len() + 1);
+        doomed.push(std::mem::replace(&mut prob.obj_nonlinear, Expr::Const(0.0)));
+        for c in &mut prob.con_nonlinear {
+            doomed.push(std::mem::replace(c, Expr::Const(0.0)));
+        }
+        on_deep_stack(self.expr_depth, move || drop(doomed));
+    }
+}
+
+/// Depth of the deepest expression in `prob`, and a `ValueError`-shaped
+/// message when that is past what the machinery will carry.
+///
+/// A parsed model arrives already built, so the construction-time cap
+/// `NlExpr` enforces cannot cover it — this is the same limit applied at
+/// the only point on this path where it can be: after the parse, before
+/// anything else walks the result (pounce#472).
+fn checked_depth(prob: &NlProblem) -> Result<u32, String> {
+    let mut memo = std::collections::HashMap::new();
+    let depth = prob
+        .con_nonlinear
+        .iter()
+        .fold(expr_depth(&prob.obj_nonlinear, &mut memo), |acc, c| {
+            acc.max(expr_depth(c, &mut memo))
+        });
+    if depth > MAX_DEPTH {
+        return Err(format!(
+            "the model nests an expression {depth} levels deep, past the \
+             limit of {MAX_DEPTH}. Deeper trees overflow the stack when the model \
+             is taped, walked, or freed — a hard crash rather than an exception — \
+             so they are refused here. A `.nl` writer that emits `o0` (binary +) \
+             chains for a long sum will do this; `o54` (n-ary sum) is one level \
+             whatever the term count."
+        ));
+    }
+    Ok(depth)
+}
+
 /// Parse an AMPL `.nl` file and return its evaluable [`PyNlProblem`].
 ///
 /// Sibling `.col` / `.row` files (if present) supply variable / constraint
@@ -611,14 +679,23 @@ impl PyNlProblem {
 /// as the CLI does.
 #[pyfunction]
 pub fn read_nl(path: &str) -> PyResult<PyNlProblem> {
-    let prob = read_nl_file(std::path::Path::new(path))
-        .map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
-
-    // `try_new` (not `new`): a model that names an AMPL imported function with
-    // no resolvable `$AMPLFUNC` library must raise a catchable Python error,
-    // not panic across the pyo3 boundary as an uncatchable PanicException.
-    let tnlp = NlTnlp::try_new(prob).map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
-    PyNlProblem::from_tnlp(tnlp, "read_nl")
+    // The parser recurses once per level of nesting in the file, and so
+    // does everything downstream of it, so the whole load runs on a stack
+    // sized for that rather than on whatever the caller has — the depth is
+    // whatever the file says, and there is no way to know it beforehand
+    // (pounce#472).
+    let path = std::path::Path::new(path);
+    let (tnlp, depth) = on_worker_stack(move || {
+        let prob = read_nl_file(path)?;
+        let depth = checked_depth(&prob)?;
+        // `try_new` (not `new`): a model that names an AMPL imported function
+        // with no resolvable `$AMPLFUNC` library must raise a catchable Python
+        // error, not panic across the pyo3 boundary as an uncatchable
+        // PanicException.
+        Ok::<_, String>((NlTnlp::try_new(prob)?, depth))
+    })
+    .map_err(|e| PyValueError::new_err(format!("read_nl: {e}")))?;
+    PyNlProblem::from_tnlp(tnlp, "read_nl", depth)
 }
 
 /// Parse `.nl` *text* — the same content [`read_nl`] would read off disk —
@@ -640,31 +717,35 @@ pub fn parse_nl_text(
     var_names: Option<Vec<String>>,
     con_names: Option<Vec<String>>,
 ) -> PyResult<PyNlProblem> {
-    let mut prob =
-        parse_nl_text_rs(text).map_err(|e| PyValueError::new_err(format!("parse_nl_text: {e}")))?;
+    // On a stack sized for the parse, for the reason `read_nl` gives:
+    // the text says how deep the recursion goes (pounce#472).
+    let (tnlp, depth) = on_worker_stack(move || {
+        let mut prob = parse_nl_text_rs(text)?;
+        let depth = checked_depth(&prob)?;
 
-    let check = |what: &str, names: &[String], want: usize| -> PyResult<()> {
-        if names.len() == want {
-            Ok(())
-        } else {
-            Err(PyValueError::new_err(format!(
-                "parse_nl_text: {what} has length {}, expected {want}",
-                names.len()
-            )))
+        let check = |what: &str, names: &[String], want: usize| -> Result<(), String> {
+            if names.len() == want {
+                Ok(())
+            } else {
+                Err(format!(
+                    "{what} has length {}, expected {want}",
+                    names.len()
+                ))
+            }
+        };
+        if let Some(names) = var_names {
+            check("var_names", &names, prob.n)?;
+            prob.var_names = names;
         }
-    };
-    if let Some(names) = var_names {
-        check("var_names", &names, prob.n)?;
-        prob.var_names = names;
-    }
-    if let Some(names) = con_names {
-        check("con_names", &names, prob.m)?;
-        prob.con_names = names;
-    }
+        if let Some(names) = con_names {
+            check("con_names", &names, prob.m)?;
+            prob.con_names = names;
+        }
 
-    // `try_new` for the same reason `read_nl` uses it: an unresolvable
-    // AMPL imported function must be a catchable Python error, not a panic.
-    let tnlp =
-        NlTnlp::try_new(prob).map_err(|e| PyValueError::new_err(format!("parse_nl_text: {e}")))?;
-    PyNlProblem::from_tnlp(tnlp, "parse_nl_text")
+        // `try_new` for the same reason `read_nl` uses it: an unresolvable
+        // AMPL imported function must be a catchable Python error, not a panic.
+        Ok::<_, String>((NlTnlp::try_new(prob)?, depth))
+    })
+    .map_err(|e| PyValueError::new_err(format!("parse_nl_text: {e}")))?;
+    PyNlProblem::from_tnlp(tnlp, "parse_nl_text", depth)
 }

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -255,30 +255,49 @@ p = pounce.build_nl_problem(n=2, objective=pounce.NlExpr.sum([
 ]))
 ```
 
-**Use `NlExpr.sum` for accumulation — `+` chains are quadratic.** Each
-operator deep-copies its operands, so building a sum with `e = e + t` in a
-loop copies everything built so far on every iteration: O(N²) in time and
-memory. `NlExpr.sum` builds one n-ary node instead.
+**Operands are shared, not copied.** `a * b` references its operands
+rather than deep-copying them, so building an expression costs the same
+whether the pieces are two variables or two half-million-node models. Two
+consequences worth knowing:
+
+* Accumulating in a Python loop is linear in the number of terms. It still
+  nests one level deeper per term, though, and nesting is capped (below) —
+  so a many-term sum still belongs in one flat `NlExpr.sum(terms)` node,
+  which tapes better and is one level whatever its length. The same goes
+  for `min` / `max`, flat in their argument count too.
+* Reusing a Python name reuses the subexpression. `t = x[0] * x[1]` used
+  in ten places is one shared body on the tape, evaluated once per sweep,
+  with its adjoint summing the ten contributions — the same value and the
+  same derivatives as writing it out ten times, off a tape a tenth the
+  size. Expressions that are *only* tractable as a DAG work too: `for _ in
+  range(40): e = e * e` is 40 nodes describing `x ** 2**40`, and it builds,
+  tapes, and differentiates in under a millisecond.
 
 ```python
 e = pounce.NlExpr.const_(0.0)
-for t in terms:                    # O(N^2) — avoid
+for t in terms:                    # linear, but len(terms) levels deep
     e = e + t
 
-e = pounce.NlExpr.sum(terms)       # O(N), one node
+e = pounce.NlExpr.sum(terms)       # linear and one level — prefer this
 ```
 
-The difference is not marginal: 200 000 terms through `sum` is instant,
-while a `+` chain is measured in tens of seconds by 20 000 terms.
+**Nesting is capped at `NlExpr.max_depth` (10 000)**, and exceeding it
+raises `ValueError`. Every consumer of an expression — the tape builder,
+the problem assembler, freeing it, and the `.nl` parser that produces one
+— recurses once per level, so a deep enough tree overflows the stack,
+which is a hard crash rather than an exception. Two things keep that
+unreachable: those walks run on a worker thread with a 64 MB stack, so
+what is survivable does not depend on the calling thread (8 MB on a
+macOS/Linux main thread, 1 MB on Windows, less on a `threading.Thread`),
+and the cap then keeps the depth well inside it.
 
-Relatedly, nesting is capped at `NlExpr.max_depth` (1000), and exceeding
-it raises `ValueError`. Every consumer of an expression — the tape
-builder, copying, and freeing — recurses once per level, so a deep enough
-tree overflows the stack, which is a hard crash rather than an exception.
-The cap is enforced at construction so an expression that cannot be built
-can never be cloned or dropped into one. It bounds *nesting*, not size:
-`NlExpr.sum` is one level regardless of how many terms it holds, so wide
-models are unaffected. Each expression's `.depth` is readable.
+**The same limit applies to `read_nl` and `parse_nl_text`,** which enforce
+it on what they parsed rather than as it is built — a model that arrives
+already built cannot be capped during construction. A `.nl` file that
+spells a long sum as an `o0` (binary `+`) chain rather than `o54` (n-ary
+sum) is the way to hit it. The cap bounds *nesting*, not size: `NlExpr.sum`
+and `o54` are one level regardless of term count, so wide models are
+unaffected. Each expression's `.depth` is readable.
 
 For checking a subexpression before wiring it into a model, `NlExpr` has
 `.eval(x)`, `.gradient(x)`, and `.variables()`, which build a one-off tape

--- a/python/tests/test_nl_build.py
+++ b/python/tests/test_nl_build.py
@@ -12,6 +12,9 @@ Three surfaces, all of which used to be Rust-only:
 """
 
 import math
+import subprocess
+import sys
+import time
 
 import numpy as np
 import pytest
@@ -655,12 +658,19 @@ def test_hvp_empty_block_is_legal():
 # ---- Expression depth guard -------------------------------------------
 #
 # Every consumer of an `Expr` recurses once per nesting level — the tape
-# builder, the derived Clone, and the derived Drop — so a deep enough tree
-# overflows the stack. That is a SIGSEGV, not an exception: the interpreter
-# dies with no traceback and nothing to catch. Measured on Linux with an
-# 8 MB stack, taping survives ~32k levels in a release build but only ~4k
-# in a debug build. The cap is enforced at construction, which is what
-# makes the guarantee cover cloning and freeing too.
+# builder, the problem assembler, the teardown when the last handle goes,
+# and the `.nl` parser that produces one in the first place — so a deep
+# enough tree overflows the stack. That is a SIGSEGV, not an exception: the
+# interpreter dies with no traceback and nothing to catch.
+#
+# Two things together make it unreachable. Those walks run on a worker
+# thread with a 64 MB stack, so what is survivable stops depending on the
+# calling thread (8 MB on a macOS/Linux main thread, 1 MB on Windows, less
+# on a `threading.Thread`); and a limit then keeps the depth well inside
+# what that stack holds. Both doors share the limit: `NlExpr` enforces it
+# as it builds, and `read_nl` / `parse_nl_text` enforce it on what they
+# parsed, since a model that arrives already built cannot be capped as it
+# is constructed.
 
 
 def test_deep_chain_raises_instead_of_crashing():
@@ -671,8 +681,8 @@ def test_deep_chain_raises_instead_of_crashing():
 
 
 def test_depth_error_points_at_the_cheap_alternative():
-    """The error has to teach, because `e = e + t` in a loop is the first
-    thing a modeler writes and it is also O(N^2)."""
+    """The error has to teach: `e = e + t` in a loop is the first thing a
+    modeler writes, and one flat `sum` node is the fix."""
     e = pounce.NlExpr.var(0)
     with pytest.raises(ValueError) as excinfo:
         for _ in range(pounce.NlExpr.max_depth + 10):
@@ -727,6 +737,213 @@ def test_expression_just_under_the_cap_still_tapes_and_evaluates():
     # And one more level is refused.
     with pytest.raises(ValueError, match="nesting would reach depth"):
         _ = e + 1.0
+
+
+# ---- Operands are shared, not copied ----------------------------------
+
+
+def test_building_an_expression_does_not_copy_its_operands():
+    """A regression guard on the O(N^2) build, not a benchmark.
+
+    Each operator used to deep-copy both operands, so accumulating in a
+    loop copied the whole chain every iteration: 5 000 terms took over five
+    seconds. Referencing the operands instead makes it a few milliseconds,
+    so the budget can be loose enough that machine speed does not matter
+    and still catch a return to copying.
+    """
+    started = time.perf_counter()
+    e = pounce.NlExpr.var(0)
+    for _ in range(5_000):
+        e = e + 1.0
+    p = pounce.build_nl_problem(n=1, objective=e)
+    elapsed = time.perf_counter() - started
+    assert p.objective([1.0]) == pytest.approx(5_001.0)
+    assert elapsed < 1.0, f"building 5 000 terms took {elapsed:.2f}s"
+
+
+def test_a_reused_subexpression_evaluates_like_a_written_out_copy():
+    """Reusing a Python name shares the subtree now rather than copying it.
+    The tape emits a shared body once and sums the adjoint contributions
+    from every reference, which is the same function and the same
+    derivatives.
+
+    Values match exactly — the forward sweep does the identical arithmetic,
+    just once. Derivatives are compared to rounding: the reverse sweep sums
+    one slot's contributions where the copy sums two, and floating-point
+    addition does not promise the same order gives the same last bit."""
+
+    def model(reuse):
+        x = pounce.NlExpr.vars(2)
+        if reuse:
+            t = x[0] * x[1] + x[0].sin()
+            obj, con = t * t + t, t.exp()
+        else:
+            # The same thing with nothing shared: a fresh `t` per use.
+            def t():
+                return x[0] * x[1] + x[0].sin()
+
+            obj, con = t() * t() + t(), t().exp()
+        return pounce.build_nl_problem(n=2, objective=obj, constraints=[con])
+
+    shared, copied = model(True), model(False)
+    pt = [0.7, -1.3]
+    assert shared.objective(pt) == copied.objective(pt)
+    np.testing.assert_array_equal(shared.constraints(pt), copied.constraints(pt))
+    np.testing.assert_allclose(shared.gradient(pt), copied.gradient(pt), rtol=1e-14)
+    np.testing.assert_allclose(shared.jacobian(pt), copied.jacobian(pt), rtol=1e-14)
+
+    rows, cols = shared.hessian_structure()
+    np.testing.assert_array_equal(rows, copied.hessian_structure()[0])
+    np.testing.assert_array_equal(cols, copied.hessian_structure()[1])
+    lam = np.array([0.6])
+    np.testing.assert_allclose(
+        shared.hessian(pt, lam), copied.hessian(pt, lam), rtol=1e-14
+    )
+
+
+def test_a_shared_subexpression_is_not_expanded():
+    """`e = e * e` doubles the *size* of a copied expression every step, so
+    40 steps is a trillion nodes and no machine builds it. Referencing the
+    operand keeps it 40 nodes, and every walk over the result — the tape
+    build, the variable scan, the assembly — visits a shared body once
+    rather than following each of the 2^40 paths to it."""
+    e = pounce.NlExpr.var(0)
+    for _ in range(40):
+        e = e * e
+    # x ** (2 ** 40), whose derivative at 1 is 2 ** 40.
+    assert e.eval([1.0]) == 1.0
+    np.testing.assert_allclose(e.gradient([1.0]), [2.0**40])
+    p = pounce.build_nl_problem(n=1, objective=e)
+    assert p.objective([1.0]) == 1.0
+    np.testing.assert_allclose(p.gradient([1.0]), [2.0**40])
+    np.testing.assert_allclose(p.hessian([1.0]), [2.0**40 * (2.0**40 - 1)])
+
+
+def test_a_loop_built_objective_still_tapes_per_term():
+    """Sharing must not cost the summand split. Operand references are
+    inlined when the model is assembled, so `from_expressions` sees the
+    plain `+` chain and gives each term its own tape — the same problem the
+    flat `sum` spelling produces, entry for entry."""
+    n = 60
+    x = pounce.NlExpr.vars(n)
+    terms = [(x[i] * x[i + 1]) ** 2 for i in range(n - 1)]
+    looped = terms[0]
+    for t in terms[1:]:
+        looped = looped + t
+    by_loop = pounce.build_nl_problem(n=n, objective=looped)
+    by_sum = pounce.build_nl_problem(n=n, objective=pounce.NlExpr.sum(terms))
+
+    pt = np.linspace(0.1, 1.0, n)
+    assert by_loop.objective(pt) == pytest.approx(by_sum.objective(pt))
+    for got, want in zip(by_loop.hessian_structure(), by_sum.hessian_structure()):
+        np.testing.assert_array_equal(got, want)
+    np.testing.assert_allclose(by_loop.hessian(pt), by_sum.hessian(pt), rtol=1e-14)
+
+
+# ---- Depth reached through the parser, not the builder -----------------
+
+
+def _deep_nl(depth):
+    """`.nl` text whose objective is `((v0 + 1) + 1) ...`, `depth` deep."""
+    body = "o0\n" * depth + "v0\n" + "n1\n" * depth
+    return (
+        "g3 0 1 0\n1 0 1 0 0\n0 1\n0 0\n0 1 0\n0 0 0 1\n0 0 0 0 0\n"
+        f"0 0\n0 0\n0 0 0 0 0\nO0 0\n{body}x0\nr\nb\n3\nk0\n"
+    )
+
+
+def test_parsed_nl_deeper_than_the_caller_stack_would_take():
+    """A `.nl` file arrives already built, so the construction-time cap
+    cannot see it — this used to segfault at depth 4 000, and predates the
+    `NlExpr` surface entirely."""
+    for depth in (3_000, 5_000, pounce.NlExpr.max_depth - 1):
+        p = pounce.parse_nl_text(_deep_nl(depth))
+        assert p.objective([0.0]) == pytest.approx(float(depth))
+
+
+def test_read_nl_takes_the_same_depth_from_a_file(tmp_path):
+    path = tmp_path / "deep.nl"
+    path.write_text(_deep_nl(5_000))
+    p = pounce.read_nl(str(path))
+    assert p.objective([0.0]) == pytest.approx(5_000.0)
+
+
+def test_both_doors_enforce_the_same_depth_limit():
+    """The inconsistency the issue called out: `NlExpr` refused depth 1 001
+    while the parser accepted 3 000 and crashed on 4 000. One limit now,
+    enforced wherever an expression can enter."""
+    limit = pounce.NlExpr.max_depth
+
+    with pytest.raises(ValueError) as parsed:
+        pounce.parse_nl_text(_deep_nl(limit + 1))
+    assert str(limit) in str(parsed.value)
+    assert "o54" in str(parsed.value), "the parser's error names the flat form"
+
+    e = pounce.NlExpr.var(0)
+    with pytest.raises(ValueError) as built:
+        for _ in range(limit + 10):
+            e = e + 1.0
+    assert str(limit) in str(built.value)
+
+
+# Deep enough that the walks need more stack than the thread below has.
+_SMALL_STACK_SCRIPT = """
+import threading
+import pounce
+
+threading.stack_size(256 * 1024)
+out = []
+
+
+def deep_nl(depth):
+    body = "o0\\n" * depth + "v0\\n" + "n1\\n" * depth
+    return (
+        "g3 0 1 0\\n1 0 1 0 0\\n0 1\\n0 0\\n0 1 0\\n0 0 0 1\\n0 0 0 0 0\\n"
+        "0 0\\n0 0\\n0 0 0 0 0\\nO0 0\\n" + body + "x0\\nr\\nb\\n3\\nk0\\n"
+    )
+
+
+def work():
+    e = pounce.NlExpr.var(0)
+    for _ in range(1999):
+        e = e + 1.0
+    assert e.variables() == [0]
+    assert e.eval([1.0]) == 2000.0
+    p = pounce.build_nl_problem(n=1, objective=e)
+    assert p.objective([1.0]) == 2000.0
+    assert p.variant(x0=[2.0]).objective([1.0]) == 2000.0
+    del p, e
+
+    # The parser reaches the same recursion from the other side.
+    q = pounce.parse_nl_text(deep_nl(2000))
+    assert q.objective([0.0]) == 2000.0
+    del q
+    out.append(True)
+
+
+t = threading.Thread(target=work)
+t.start()
+t.join()
+assert out == [True]
+"""
+
+
+def test_deep_work_survives_a_small_caller_stack():
+    """The limit is only half the fix: the walks whose frames are too big
+    to fit run on a worker thread with a stack sized for them, so what is
+    safe does not depend on the caller's stack. 256 KB is well under any
+    platform's main thread, and a 2 000-deep tape build wants roughly twice
+    that on its own.
+
+    Out-of-process because the failure being guarded is a SIGSEGV, which
+    would take the test session down with it rather than fail a test.
+    """
+    proc = subprocess.run(
+        [sys.executable, "-c", _SMALL_STACK_SCRIPT],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (proc.returncode, proc.stdout, proc.stderr)
 
 
 # ---- Other NlExpr surface details -------------------------------------


### PR DESCRIPTION
Fixes #472

## Problem

Two halves, the second of which is what the issue's follow-up comment showed the construction-time cap from #473 cannot reach.

**A deep model still kills the interpreter, through a door the cap does not cover.** Measured on `361222ec` (merged `main`, #470 and #473 both in), release build:

| entry point | depth | before | after |
|---|---|---|---|
| `NlExpr` chain | 1 001 | `ValueError` | ok |
| `parse_nl_text` | 3 000 | ok | ok |
| `parse_nl_text` | 4 000 | **SIGSEGV** (exit 139) | ok |
| `parse_nl_text` | 9 999 | **SIGSEGV** | ok |
| `read_nl` (file) | 5 000 | **SIGSEGV** | ok |
| either, past the limit | 10 001 | **SIGSEGV** | `ValueError` naming the flat form |

The `read_nl` crash predates the `NlExpr` surface entirely — anyone can hit it with a generated `.nl` file — and at depth 4 000 the process dies *inside* the parser, before any tape is built.

**Building an expression is quadratic.** Each operator deep-copied both operands, so accumulating in a Python loop copied the whole chain every iteration:

| | before | after |
|---|---|---|
| 5 000-term `e = e + t` loop, through `build_nl_problem` | 5 326 ms | **3 ms** |
| `for _ in range(40): e = e * e` (`x ** 2**40`) | 2⁴⁰ nodes — does not finish | **0.16 ms**, correct through the Hessian |

## Cause

Every consumer of an `Expr` recurses once per level of nesting: `Tape::build`, the problem assembler, the teardown of a problem that holds the trees, and the `.nl` parser's own recursive descent. A cap enforced *as an expression is built* cannot see a model that arrives already built, so it can only ever be half the answer — the issue's words, and the measurements above agree.

The quadratic is separate: `Expr` children are `Box<Expr>`, so cloning an operand is a deep copy, and `e = e + t` copies everything built so far on each iteration.

## Fix

**The walks run on a worker thread with a 64 MB stack.** That is option (3) from the issue. It moves the question from "how much stack did the caller happen to have" — 8 MB on a macOS/Linux main thread, 1 MB on Windows, less on a `threading.Thread`, none of which the caller chose with this in mind — to one we picked. It covers the tape build, the assembly, the parse, and the teardown. Below 512 levels the walk runs inline, so nothing shallow pays the ~100 µs spawn.

**One limit, enforced at both doors.** `NlExpr.max_depth` is now 10 000, and `read_nl` / `parse_nl_text` enforce the same number on what they parsed — the only point on that path where it can be applied. 10 000 is the arithmetic: the deepest frames measured are ~300 bytes released and ~2 KB in a debug build, so 64 MB covers ~200 000 levels and ~32 000 respectively — a 3× margin at this limit even in the worst configuration, and comfortably past the ~3 000 the parser managed before it was guarded, so no `.nl` file that loaded before is refused now.

**Operands are referenced, not copied.** The payload sits behind an `Arc` and an operator references it through an `Expr::Cse` node, so `a + b` costs the same on two variables as on two half-million-node models. Reuse becomes real sharing: `t` used ten times is one body on the tape, evaluated once per sweep with its adjoint summing the ten contributions — the same value and the same derivatives, off a tape a tenth the size.

**What reaches the solver is unchanged where nothing is genuinely shared.** This is the part that needed care. `split_top_sums` treats a `Cse` as an opaque leaf, so handing it the as-built chain would collapse a whole model into one summand — one tape and one color set in `eval_h` instead of a small one per term. `materialize` runs before assembly and inlines every reference reached exactly once, which is all of them for an ordinary tree, so `from_expressions` sees the same plain expression it saw from the copying build. Genuine sharing is kept as a `Cse`, which is the better tape anyway.

**Rejected alternatives.**

- *Cap only, tuned lower.* What #473 did, and what the issue's follow-up rules out: it cannot cover `read_nl`, and the two surfaces then disagree about what the machinery can carry.
- *Iterative rewrites of `Tape::build` / `Clone` / `Drop`* — option (2). It lifts the limit furthest, but `build_recursive` carries the const-`pow` rewrite, and a hand-rolled iterative clone of a 14-variant enum in the binding layer is a correctness hazard for a payoff the worker stack already delivers. Not taken; the parser would still have needed its own answer.
- *Sharing without `materialize`* — measured, and it is the summand-split regression above. The alternative was teaching `split_top_sums` to walk through `Cse`, which is exponential on the layered sharing a `.nl` V-segment produces.
- *Raising the cap far enough that the issue's 40 000 repro just works.* The build is now fast enough to make that tempting, but every walk is still O(depth) recursion and a debug build spends ~2 KB a level. The flat `sum` form has no limit at all, and the error names it.

## Blast radius

Additive at the Python surface; no signature changed. `NlExpr.max_depth` reads 10 000 instead of 1 000, which only ever admits more.

- **`.nl` loading:** files that loaded before still load (the limit is >3× the previous crash point), files that crashed the interpreter between ~4 000 and 10 000 now load, and past 10 000 the answer is a `ValueError` instead of a SIGSEGV. Every path is strictly better or identical.
- **Model semantics:** unchanged. A loop-built objective produces the same problem as the flat `sum` spelling, entry for entry, pinned by a test. A shared subexpression agrees with the written-out copy exactly in value and to rounding in derivatives — the reverse sweep sums one slot's contributions where the copy sums two, and float addition does not promise the same order gives the same last bit.
- **Rust:** one new API, `NlTnlp::problem_mut`, which is how the binding takes the trees out of a problem to tear them down on a sized stack. Nothing else in the workspace calls it.
- **Cost:** the worker spawn is ~100 µs, paid once per query, per assembled problem, per parse, and per deep teardown — never per operator, since building no longer walks anything.

## Tests

Against the parent commit `361222ec`, run individually because two of them take the session down:

| test | on parent |
|---|---|
| `test_parsed_nl_deeper_than_the_caller_stack_would_take` | **SIGSEGV**, exit 139 |
| `test_read_nl_takes_the_same_depth_from_a_file` | **SIGSEGV**, exit 139 |
| `test_a_shared_subexpression_is_not_expanded` | **does not finish** in 180 s |
| `test_both_doors_enforce_the_same_depth_limit` | FAILED |
| `test_building_an_expression_does_not_copy_its_operands` | FAILED |
| `test_deep_work_survives_a_small_caller_stack` | FAILED |
| `test_a_loop_built_objective_still_tapes_per_term` | passes |
| `test_a_reused_subexpression_evaluates_like_a_written_out_copy` | passes |

The last two pass on the parent deliberately, and saying so is the point: they are guards on *this* change, not regression tests. They are what fails if `materialize` stops inlining (the model collapses to one summand) or if sharing changes an answer.

`test_deep_work_survives_a_small_caller_stack` runs out-of-process, because the failure it guards is a SIGSEGV that would take pytest down rather than fail a test. It is mutation-tested: with the worker stack disabled it returns −11 on a 256 KB caller stack, from both the `NlExpr` and the `parse_nl_text` side.

Rust unit tests pin the construct/materialize pair directly — a chain carries one reference per operator and materializes back to the plain left-leaning tree with **zero** `Cse` left; a twice-used body stays one body reached twice; the n-ary and control-flow arms keep their sharing; a shared body evaluates and differentiates like the copy it replaces off a strictly smaller tape.

Not pinned: the exact frame sizes behind the 10 000 figure. They are compiler- and platform-dependent, so the margin is documented at the constant rather than asserted.

Verification run: `cargo fmt --all -- --check` clean; `cargo clippy -D clippy::correctness -D clippy::suspicious` clean on both touched crates; `cargo test --workspace --exclude pounce-hsl` — 175 test binaries, no failures; `pytest python/tests` — 666 passed, 37 skipped; `scripts/check-release-consistency.sh` OK.

---

- [x] Tests fail on the parent commit for the stated reason — table above, with the two deliberate exceptions called out
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `docs/src/python.md`, already linked from `SUMMARY.md`
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bvm8vuLQ2vpZYH2df86gWz)_