### PR TITLE
release_kkt(): the exit of the retention story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ changes.
 
 ## [Unreleased]
 
+### Added — pyomo-pounce: `release_kkt()`, the exit of the retention story
+
+- The held KKT factorization can now be dropped on demand:
+  `release_kkt(model)` frees the factor's memory immediately and
+  returns whether anything was held. Declarations and a prior
+  `retain_kkt()` are untouched, so the next solve keeps its factor
+  again; after release the accessors raise their no-session error. A
+  `Covariance` or `Information` result created before the release
+  holds its own reference through its pending `conditioned_on`, so it
+  keeps working: release drops the model's hold, not the result's.
+  The retention policy (three ways to keep, one way to release) is
+  stated in one place in the docs.
+
 ### Fixed — every eigendecomposition now returns sign-pinned eigenvectors (#471)
 
 - An eigenvector's sign is arbitrary: `v` and `-v` are equally valid,

--- a/dev-notes/covariance-information-design.md
+++ b/dev-notes/covariance-information-design.md
@@ -33,6 +33,9 @@ $S = H_{AA} - H_{AF} H_{FF}^{-1} H_{FA}$ the reduction onto $A$.
   `gradient()`/`estimate()`; shares the session, out of scope here.
 - `retain_kkt(model)`: keep the factorization with nothing declared,
   for problems where every question arrives as an explicit `wrt=`.
+- `release_kkt(model)`: drop the held factorization now, freeing its
+  memory; declarations and the retain flag still apply to the next
+  solve.
 
 | setup | factor kept | `covariance(model)` | `covariance(model, wrt=T)` |
 |---|---|---|---|
@@ -43,7 +46,8 @@ $S = H_{AA} - H_{AF} H_{FF}^{-1} H_{FA}$ the reduction onto $A$.
 
 One more rule completes retention: a `Covariance` or `Information` result whose
 `conditioned_on` has not been read keeps the session, and with it the
-factor, alive until first access.
+factor, alive until first access; `release_kkt` drops the model's
+hold, not a pending result's.
 
 Explicit call-time forms (`solve(m, fitted=..., residuals=...)`) are
 deliberately solve-local, so repeated solves of one model do not

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -555,7 +555,12 @@ The retention policy in one place: the factor is kept if anything is
 declared or `retain_kkt()` was called, and a `Covariance` or
 `Information` result whose lazy `conditioned_on` has not been read
 keeps the session alive through its pending computation until first
-access. Noise is a separate question: `retain_kkt()` keeps the
+access. `release_kkt(model)` is the exit: it drops the model's hold
+on the factor immediately, freeing the memory, while declarations and
+the retain flag still apply to the next solve. A result created
+before the release holds its own reference through its pending
+`conditioned_on`, so it keeps working; release drops the model's
+hold, not the result's. Noise is a separate question: `retain_kkt()` keeps the
 factor, not a noise model, and with nothing declared fitted the
 degrees of freedom for a noise ESTIMATE are unknown, so
 `covariance()` under retain-only needs `sigma_sq=`; the estimation

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -46,6 +46,7 @@ from pyomo_pounce.sens import (
     gradient,
     information,
     Information,
+    release_kkt,
     retain_kkt,
 )
 from pyomo_pounce.preflight import (
@@ -61,6 +62,7 @@ __all__ = [
     "declare_sens_param",
     "declare_fitted",
     "declare_residual",
+    "release_kkt",
     "retain_kkt",
     "covariance",
     "Covariance",

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1928,8 +1928,8 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian",
     if session is None:
         raise RuntimeError(
             "no sensitivity session: declare_fitted() (and optionally "
-            "declare_residual()), or retain_kkt() for the "
-            "declaration-free wrt= flow, then solve with "
+            "declare_residual()), or retain_kkt() for "
+            "wrt= queries with nothing declared, then solve with "
             "SolverFactory('pounce') first")
     # the block: the declared fitted parameters by default, or any
     # block of the solve's variables via wrt= (each call re-reduces
@@ -2311,8 +2311,8 @@ def information(model, hessian="lagrangian", wrt=None):
     if session is None:
         raise RuntimeError(
             "no sensitivity session: declare_fitted() (and optionally "
-            "declare_residual()), or retain_kkt() for the "
-            "declaration-free wrt= flow, then solve with "
+            "declare_residual()), or retain_kkt() for "
+            "wrt= queries with nothing declared, then solve with "
             "SolverFactory('pounce') first")
     params, rows = _resolve_wrt(session, wrt, "information")
     n_params = len(params)

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -145,7 +145,8 @@ def retain_kkt(model):
     declare_residual), or if retain_kkt() was called; and a
     Covariance/Information result whose lazy conditioned_on has not
     been read keeps the session alive through its pending computation
-    until first access.
+    until first access. release_kkt(model) drops the held factor on
+    demand.
 
     Like any declaration, this routes the solve through the
     in-process sensitivity path, whose solve() surface is not
@@ -154,6 +155,27 @@ def retain_kkt(model):
     existing script changes how the solve runs, not just what is
     kept."""
     _registry(model).retain = True
+
+
+def release_kkt(model):
+    """Drop the held KKT factorization now, freeing its memory.
+
+    The exit of the retention story, for the current factor only:
+    declarations and a prior retain_kkt() are untouched and apply to
+    the NEXT solve, which keeps its factor again. After release the
+    accessors raise their no-session error until another solve. A
+    Covariance or Information result whose conditioned_on is still
+    pending holds its own reference to the session, so such a result
+    keeps the factor alive until the attribute is read or the result
+    is discarded; release drops the model's hold, not theirs.
+
+    Returns True if a factorization was held and is now released,
+    False if there was nothing to release."""
+    reg = model.__dict__.get(_REG)
+    if reg is None or reg.session is None:
+        return False
+    reg.session = None
+    return True
 
 
 def _reformulate_param_bounds(clone):

--- a/pyomo-pounce/tests/test_retain_kkt.py
+++ b/pyomo-pounce/tests/test_retain_kkt.py
@@ -14,6 +14,7 @@ from pyomo_pounce import (
     declare_fitted,
     declare_residual,
     information,
+    release_kkt,
     retain_kkt,
 )
 
@@ -147,3 +148,59 @@ def test_retain_only_sigma_still_required():
     pyo.SolverFactory("pounce").solve(m)
     with pytest.raises(ValueError, match="noise variance is unknown"):
         covariance(m, wrt=[m.a])
+
+
+def test_release_kkt_drops_the_factor():
+    # release frees the model's hold; the accessors then raise their
+    # no-session error, and a second release reports nothing to do
+    x, y, X = linear_data()
+    m = linear_model(x, y)
+    pyo.SolverFactory("pounce").solve(m)
+    assert release_kkt(m) is True
+    with pytest.raises(RuntimeError, match="no sensitivity session"):
+        covariance(m, sigma_sq=SIGMA**2)
+    assert release_kkt(m) is False
+
+
+def test_release_kkt_with_nothing_held():
+    # no registry at all: a clean False, no error
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - 1.0) ** 2)
+    assert release_kkt(m) is False
+
+
+def test_release_kkt_keeps_intent_for_the_next_solve():
+    # declarations and the retain flag survive release: the next solve
+    # keeps its factor again, on both the declared and retain-only
+    # paths
+    x, y, X = linear_data()
+    m = linear_model(x, y)
+    pyo.SolverFactory("pounce").solve(m)
+    release_kkt(m)
+    pyo.SolverFactory("pounce").solve(m)
+    C = np.linalg.inv(X.T @ X)
+    assert covariance(m, sigma_sq=SIGMA**2)[m.a] == pytest.approx(
+        SIGMA**2 * C[0, 0], rel=1e-9)
+    m2 = linear_model(x, y, declare=False)
+    retain_kkt(m2)
+    pyo.SolverFactory("pounce").solve(m2)
+    release_kkt(m2)
+    pyo.SolverFactory("pounce").solve(m2)
+    assert covariance(m2, sigma_sq=SIGMA**2,
+                      wrt=[m2.a])[m2.a] == pytest.approx(
+        SIGMA**2 * np.linalg.inv(X.T @ X)[0, 0], rel=1e-9)
+
+
+def test_release_kkt_pending_conditioned_on_survives():
+    # a result created before release holds its own reference through
+    # the pending conditioned_on computation, so reading it afterwards
+    # still works: release drops the model's hold, not the result's
+    x, y, X = linear_data()
+    m = linear_model(x, y)
+    pyo.SolverFactory("pounce").solve(m)
+    cov = covariance(m, sigma_sq=SIGMA**2)
+    assert release_kkt(m) is True
+    assert cov.conditioned_on == ()
+    assert cov[m.a] == pytest.approx(
+        SIGMA**2 * np.linalg.inv(X.T @ X)[0, 0], rel=1e-9)

--- a/python/notebooks/32_wrt_blocks_and_retain_kkt.ipynb
+++ b/python/notebooks/32_wrt_blocks_and_retain_kkt.ipynb
@@ -50,10 +50,10 @@
    "id": "168a289a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:31.797126Z",
-     "iopub.status.busy": "2026-08-04T14:44:31.796037Z",
-     "iopub.status.idle": "2026-08-04T14:44:34.529507Z",
-     "shell.execute_reply": "2026-08-04T14:44:34.527491Z"
+     "iopub.execute_input": "2026-08-04T15:08:21.747862Z",
+     "iopub.status.busy": "2026-08-04T15:08:21.747862Z",
+     "iopub.status.idle": "2026-08-04T15:08:24.632552Z",
+     "shell.execute_reply": "2026-08-04T15:08:24.632552Z"
     }
    },
    "outputs": [
@@ -125,7 +125,7 @@
       "Number of equality constraint Jacobian evaluations   = 6\n",
       "Number of inequality constraint Jacobian evaluations = 6\n",
       "Number of Lagrangian Hessian evaluations             = 6\n",
-      "Total seconds in POUNCE                              = 0.018\n",
+      "Total seconds in POUNCE                              = 0.012\n",
       "\n",
       "EXIT: Optimal Solution Found.\n",
       "\n",
@@ -152,7 +152,7 @@
     "import pyomo_pounce\n",
     "from pyomo_pounce import (\n",
     "    covariance, declare_fitted, declare_residual, information,\n",
-    "    retain_kkt)\n",
+    "    release_kkt, retain_kkt)\n",
     "\n",
     "rng = np.random.default_rng(4)\n",
     "A_TRUE, K_TRUE, SIG_TRUE = 2.0, 0.9, 0.05\n",
@@ -213,10 +213,10 @@
    "id": "d522ac63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:34.535129Z",
-     "iopub.status.busy": "2026-08-04T14:44:34.535129Z",
-     "iopub.status.idle": "2026-08-04T14:44:34.549491Z",
-     "shell.execute_reply": "2026-08-04T14:44:34.548883Z"
+     "iopub.execute_input": "2026-08-04T15:08:24.638135Z",
+     "iopub.status.busy": "2026-08-04T15:08:24.637114Z",
+     "iopub.status.idle": "2026-08-04T15:08:24.647261Z",
+     "shell.execute_reply": "2026-08-04T15:08:24.647261Z"
     }
    },
    "outputs": [
@@ -276,10 +276,10 @@
    "id": "17931680",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:34.552543Z",
-     "iopub.status.busy": "2026-08-04T14:44:34.552543Z",
-     "iopub.status.idle": "2026-08-04T14:44:34.849006Z",
-     "shell.execute_reply": "2026-08-04T14:44:34.847993Z"
+     "iopub.execute_input": "2026-08-04T15:08:24.650771Z",
+     "iopub.status.busy": "2026-08-04T15:08:24.650771Z",
+     "iopub.status.idle": "2026-08-04T15:08:24.800754Z",
+     "shell.execute_reply": "2026-08-04T15:08:24.800754Z"
     }
    },
    "outputs": [
@@ -354,10 +354,10 @@
    "id": "6ba4df0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:34.853524Z",
-     "iopub.status.busy": "2026-08-04T14:44:34.853524Z",
-     "iopub.status.idle": "2026-08-04T14:44:34.915063Z",
-     "shell.execute_reply": "2026-08-04T14:44:34.913039Z"
+     "iopub.execute_input": "2026-08-04T15:08:24.804067Z",
+     "iopub.status.busy": "2026-08-04T15:08:24.804067Z",
+     "iopub.status.idle": "2026-08-04T15:08:24.847604Z",
+     "shell.execute_reply": "2026-08-04T15:08:24.847604Z"
     }
    },
    "outputs": [
@@ -409,10 +409,10 @@
    "id": "cfe2a23e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:34.920276Z",
-     "iopub.status.busy": "2026-08-04T14:44:34.919280Z",
-     "iopub.status.idle": "2026-08-04T14:44:35.198404Z",
-     "shell.execute_reply": "2026-08-04T14:44:35.197393Z"
+     "iopub.execute_input": "2026-08-04T15:08:24.851468Z",
+     "iopub.status.busy": "2026-08-04T15:08:24.851468Z",
+     "iopub.status.idle": "2026-08-04T15:08:24.966345Z",
+     "shell.execute_reply": "2026-08-04T15:08:24.965336Z"
     }
    },
    "outputs": [
@@ -472,10 +472,10 @@
    "id": "0314af87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:35.202464Z",
-     "iopub.status.busy": "2026-08-04T14:44:35.202464Z",
-     "iopub.status.idle": "2026-08-04T14:44:35.266070Z",
-     "shell.execute_reply": "2026-08-04T14:44:35.266070Z"
+     "iopub.execute_input": "2026-08-04T15:08:24.969868Z",
+     "iopub.status.busy": "2026-08-04T15:08:24.968862Z",
+     "iopub.status.idle": "2026-08-04T15:08:25.018845Z",
+     "shell.execute_reply": "2026-08-04T15:08:25.017627Z"
     }
    },
    "outputs": [
@@ -483,7 +483,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "parameter information via retain_kkt only:\n",
+      "parameter information via retain_kkt only:"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
       "[[ 9.024 -8.718]\n",
       " [-8.718 19.169]]\n",
       "\n",
@@ -538,10 +545,10 @@
    "id": "eda9879d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-04T14:44:35.272081Z",
-     "iopub.status.busy": "2026-08-04T14:44:35.272081Z",
-     "iopub.status.idle": "2026-08-04T14:44:35.281738Z",
-     "shell.execute_reply": "2026-08-04T14:44:35.280725Z"
+     "iopub.execute_input": "2026-08-04T15:08:25.022856Z",
+     "iopub.status.busy": "2026-08-04T15:08:25.022856Z",
+     "iopub.status.idle": "2026-08-04T15:08:25.031330Z",
+     "shell.execute_reply": "2026-08-04T15:08:25.030316Z"
     }
    },
    "outputs": [
@@ -557,8 +564,6 @@
     }
    ],
    "source": [
-    "from pyomo_pounce import release_kkt\n",
-    "\n",
     "print(\"released:\", release_kkt(m3))\n",
     "try:\n",
     "    information(m3, wrt=[m3.A, m3.k])\n",

--- a/python/notebooks/32_wrt_blocks_and_retain_kkt.ipynb
+++ b/python/notebooks/32_wrt_blocks_and_retain_kkt.ipynb
@@ -50,10 +50,10 @@
    "id": "168a289a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T23:14:30.761840Z",
-     "iopub.status.busy": "2026-08-03T23:14:30.760742Z",
-     "iopub.status.idle": "2026-08-03T23:14:32.814489Z",
-     "shell.execute_reply": "2026-08-03T23:14:32.811213Z"
+     "iopub.execute_input": "2026-08-04T14:44:31.797126Z",
+     "iopub.status.busy": "2026-08-04T14:44:31.796037Z",
+     "iopub.status.idle": "2026-08-04T14:44:34.529507Z",
+     "shell.execute_reply": "2026-08-04T14:44:34.527491Z"
     }
    },
    "outputs": [
@@ -125,7 +125,7 @@
       "Number of equality constraint Jacobian evaluations   = 6\n",
       "Number of inequality constraint Jacobian evaluations = 6\n",
       "Number of Lagrangian Hessian evaluations             = 6\n",
-      "Total seconds in POUNCE                              = 0.011\n",
+      "Total seconds in POUNCE                              = 0.018\n",
       "\n",
       "EXIT: Optimal Solution Found.\n",
       "\n",
@@ -213,10 +213,10 @@
    "id": "d522ac63",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T23:14:32.824124Z",
-     "iopub.status.busy": "2026-08-03T23:14:32.823236Z",
-     "iopub.status.idle": "2026-08-03T23:14:32.833827Z",
-     "shell.execute_reply": "2026-08-03T23:14:32.832817Z"
+     "iopub.execute_input": "2026-08-04T14:44:34.535129Z",
+     "iopub.status.busy": "2026-08-04T14:44:34.535129Z",
+     "iopub.status.idle": "2026-08-04T14:44:34.549491Z",
+     "shell.execute_reply": "2026-08-04T14:44:34.548883Z"
     }
    },
    "outputs": [
@@ -276,10 +276,10 @@
    "id": "17931680",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T23:14:32.836958Z",
-     "iopub.status.busy": "2026-08-03T23:14:32.835937Z",
-     "iopub.status.idle": "2026-08-03T23:14:32.978316Z",
-     "shell.execute_reply": "2026-08-03T23:14:32.978316Z"
+     "iopub.execute_input": "2026-08-04T14:44:34.552543Z",
+     "iopub.status.busy": "2026-08-04T14:44:34.552543Z",
+     "iopub.status.idle": "2026-08-04T14:44:34.849006Z",
+     "shell.execute_reply": "2026-08-04T14:44:34.847993Z"
     }
    },
    "outputs": [
@@ -354,10 +354,10 @@
    "id": "6ba4df0d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T23:14:32.984339Z",
-     "iopub.status.busy": "2026-08-03T23:14:32.983342Z",
-     "iopub.status.idle": "2026-08-03T23:14:33.017482Z",
-     "shell.execute_reply": "2026-08-03T23:14:33.015963Z"
+     "iopub.execute_input": "2026-08-04T14:44:34.853524Z",
+     "iopub.status.busy": "2026-08-04T14:44:34.853524Z",
+     "iopub.status.idle": "2026-08-04T14:44:34.915063Z",
+     "shell.execute_reply": "2026-08-04T14:44:34.913039Z"
     }
    },
    "outputs": [
@@ -409,10 +409,10 @@
    "id": "cfe2a23e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T23:14:33.019481Z",
-     "iopub.status.busy": "2026-08-03T23:14:33.019481Z",
-     "iopub.status.idle": "2026-08-03T23:14:33.173367Z",
-     "shell.execute_reply": "2026-08-03T23:14:33.172798Z"
+     "iopub.execute_input": "2026-08-04T14:44:34.920276Z",
+     "iopub.status.busy": "2026-08-04T14:44:34.919280Z",
+     "iopub.status.idle": "2026-08-04T14:44:35.198404Z",
+     "shell.execute_reply": "2026-08-04T14:44:35.197393Z"
     }
    },
    "outputs": [
@@ -472,10 +472,10 @@
    "id": "0314af87",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-08-03T23:14:33.176909Z",
-     "iopub.status.busy": "2026-08-03T23:14:33.176378Z",
-     "iopub.status.idle": "2026-08-03T23:14:33.221233Z",
-     "shell.execute_reply": "2026-08-03T23:14:33.221233Z"
+     "iopub.execute_input": "2026-08-04T14:44:35.202464Z",
+     "iopub.status.busy": "2026-08-04T14:44:35.202464Z",
+     "iopub.status.idle": "2026-08-04T14:44:35.266070Z",
+     "shell.execute_reply": "2026-08-04T14:44:35.266070Z"
     }
    },
    "outputs": [
@@ -522,15 +522,63 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ba86aae9",
+   "metadata": {},
+   "source": [
+    "The retention story also has an exit. `release_kkt(model)` drops the\n",
+    "model's hold on the factorization immediately, freeing its memory;\n",
+    "the accessors raise their no-session error until another solve, and\n",
+    "declarations or a prior `retain_kkt()` still apply to that next\n",
+    "solve."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "eda9879d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-04T14:44:35.272081Z",
+     "iopub.status.busy": "2026-08-04T14:44:35.272081Z",
+     "iopub.status.idle": "2026-08-04T14:44:35.281738Z",
+     "shell.execute_reply": "2026-08-04T14:44:35.280725Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "released: True\n",
+      "  no sensitivity session: declare_fitted() (and optionally\n",
+      "  declare_residual()), or retain_kkt() for wrt= queries with nothing\n",
+      "  declared, then solve with SolverFactory('pounce') first\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pyomo_pounce import release_kkt\n",
+    "\n",
+    "print(\"released:\", release_kkt(m3))\n",
+    "try:\n",
+    "    information(m3, wrt=[m3.A, m3.k])\n",
+    "except RuntimeError as e:\n",
+    "    print(textwrap.fill(str(e), width=72, initial_indent=\"  \",\n",
+    "                        subsequent_indent=\"  \"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "92003155",
    "metadata": {},
    "source": [
     "One policy covers retention: the factorization is kept if anything is\n",
-    "declared or `retain_kkt()` was called. A `Covariance` or\n",
-    "`Information` result computes its `conditioned_on` list only when the\n",
-    "attribute is first read; until then the result keeps the solver\n",
-    "session, and with it the factorization, in memory. An undeclared\n",
-    "solve without the call pays nothing."
+    "declared or `retain_kkt()` was called, and released on demand with\n",
+    "`release_kkt()`. A `Covariance` or `Information` result computes its\n",
+    "`conditioned_on` list only when the attribute is first read; until\n",
+    "then the result keeps the solver session, and with it the\n",
+    "factorization, in memory. An undeclared solve without the call pays\n",
+    "nothing."
    ]
   }
  ],


### PR DESCRIPTION
`release_kkt(model)` drops the model's hold on the held KKT factorization immediately and returns whether anything was held. The retention policy had three ways to keep a factor — declarations, `retain_kkt()`, a result's pending `conditioned_on` — and no exit (noted in the #468 review: "no off-switch, and no way to release a retained session"); a held factorization lived until the next solve or model collection, which for a large NLP is a substantial block of memory in exactly the long-lived processes `retain_kkt()` exists for.

Scope decisions, stated in the docstring: declarations and a prior `retain_kkt()` are untouched, so the next solve keeps its factor again — release frees memory now, it does not change future behavior. A `Covariance`/`Information` result whose `conditioned_on` is still pending holds its own reference (the lifetime documented in #468), so such a result keeps working — release drops the model's hold, not the result's. Between release and the next solve the accessors raise their existing no-session error.

Tests cover the drop, the double release, the no-registry no-op, intent surviving into the next solve on both the declared and retain-only paths, and the pending result surviving. Docs and the design record now state the policy as three ways to keep, one way to release; notebook 32's retention section ends with a two-line demonstration (release, then the no-session error in full). One message cleanup rides along: the no-session error now says "retain_kkt() for wrt= queries with nothing declared" instead of "the declaration-free wrt= flow".

Suite: pyomo-pounce 218, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
