### PR TITLE
Let one NlProblem serve a whole worker pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `NlProblem` can be shared across threads (#477)
+
+- `NlProblem`, `DenseLU` and `SparseLU` were `#[pyclass(unsendable)]`,
+  which gave each instance pyo3's per-object thread affinity. Touching
+  one from a thread other than its creator raised a Rust
+  `PanicException`, and merely *collecting* one on another thread wrote
+  an unraisable `RuntimeError` and leaked the payload — the latter fires
+  for code that never used an instance cross-thread at all, since
+  whichever thread runs the GC inherits every object it frees.
+- `PanicException` derives from `BaseException`, not `Exception`, so it
+  slipped past every ordinary `except Exception` in a host application.
+  In a threaded branch-and-bound host this did not surface as an error:
+  it surfaced as a **wrong answer** — a shared `NlProblem`-backed
+  evaluator reported `infeasible` on a model the reference evaluator
+  solved to optimality, and a false `infeasible` from a global optimizer
+  is a wrong certificate.
+- The marker was a conservative default, not a physical constraint:
+  `NlTnlp` is `Send` (its CSE nodes went `Arc` for #126's batched
+  solving) and the LU factors are owned matrix data. All three classes
+  are now sendable, so one evaluator can be built on one thread and used
+  or dropped on any other. Concurrency is still the GIL's — these calls
+  serialize rather than overlap — so the win is one shared tape instead
+  of one per worker, and the end of the `threading.local` ceremony hosts
+  needed to work around it. `#[test]`s pin `Send` on all three, and the
+  Python suite covers cross-thread evaluation, `variant`, batch solving,
+  and foreign-thread collection.
+- `Solver`, `QpFactorization` and `QpSensitivity` stay `unsendable`:
+  those hold `Rc`-based Ipopt state and non-`Send` linear-solver trait
+  objects, so their affinity is real rather than defensive. Each class
+  now says so at its definition, and `docs/src/python.md` documents which
+  objects cross threads and which do not.
+
 ### Fixed — every eigendecomposition now returns sign-pinned eigenvectors (#471)
 
 - An eigenvector's sign is arbitrary: `v` and `-v` are equally valid,

--- a/crates/pounce-py/src/dense_lu.rs
+++ b/crates/pounce-py/src/dense_lu.rs
@@ -26,7 +26,13 @@ use numpy::{IntoPyArray, PyReadonlyArray1};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
-#[pyclass(name = "DenseLU", module = "pounce._pounce", unsendable)]
+/// Sendable: `faer`'s `PartialPivLu` is plain owned matrix data, so a
+/// factor built on one thread may be used — or dropped — on another.
+/// It carried `unsendable` for a while; that only bought pyo3's thread
+/// check, whose cross-thread failure is a `PanicException` (a
+/// `BaseException`, invisible to `except Exception`) and whose *drop*
+/// check fires on whichever thread happens to run the GC (pounce#477).
+#[pyclass(name = "DenseLU", module = "pounce._pounce")]
 pub struct PyDenseLu {
     n: usize,
     lu: Option<PartialPivLu<f64>>,
@@ -84,5 +90,16 @@ impl PyDenseLu {
         lu.solve_in_place(rhs.as_mut());
         let out: Vec<f64> = (0..self.n).map(|i| rhs[(i, 0)]).collect();
         Ok(out.into_pyarray_bound(py))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The factor must stay movable across threads (pounce#477); see
+    /// [`super::PyDenseLu`] for why `unsendable` is the worse default.
+    #[test]
+    fn py_dense_lu_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::PyDenseLu>();
     }
 }

--- a/crates/pounce-py/src/nl_problem.rs
+++ b/crates/pounce-py/src/nl_problem.rs
@@ -42,13 +42,29 @@ use pounce_nlp::tnlp::{SparsityRequest, TNLP};
 use crate::nl_expr::{INLINE_DEPTH, MAX_DEPTH, expr_depth, on_deep_stack, on_worker_stack};
 
 /// A `.nl` model loaded through pounce's reader, exposing its evaluators.
-// `NlTnlp` itself is `Send` (its CSE nodes went `Arc` for pounce#126's
-// batched solving), but the pyclass stays `unsendable`: per-object
-// thread affinity is the conservative default under the GIL, and the
-// batch path never moves the pyclass — `solve_nlp_batch` clones the
-// owned `NlTnlp` out (see `clone_tnlp`) and moves the clone to the
-// rayon worker.
-#[pyclass(unsendable, module = "pounce", name = "NlProblem")]
+//
+// **Sendable.** `NlTnlp` is `Send` (its CSE nodes went `Arc` for
+// pounce#126's batched solving) and nothing else here is thread-affine,
+// so this pyclass carries no `unsendable` marker: one `NlProblem` can be
+// built on one thread and evaluated — or dropped — on another, which is
+// what a threaded host (a branch-and-bound worker pool) needs of a shared
+// evaluator.
+//
+// It stayed `unsendable` for a while as a conservative default, and that
+// default was actively harmful (pounce#477): pyo3's thread check raises
+// `PanicException`, which derives from `BaseException` and so slips past
+// every `except Exception` in the host — a cross-thread call surfaced not
+// as an error but as a wrong answer, and the *drop* path tripped it even
+// for code that never used an instance cross-thread (whichever thread
+// runs the GC inherits the object).
+//
+// Concurrency is still the GIL's: every `&self` method below borrows
+// `tnlp` and evaluates without releasing the GIL, so the `RefCell`
+// borrows of two threads can never overlap. Any future method that wants
+// to release the GIL around an evaluation must first take the `NlTnlp`
+// out of the `RefCell` (as `clone_tnlp` does for the batch path) rather
+// than hold a borrow across the release.
+#[pyclass(module = "pounce", name = "NlProblem")]
 pub struct PyNlProblem {
     tnlp: RefCell<NlTnlp>,
     n: usize,
@@ -748,4 +764,21 @@ pub fn parse_nl_text(
     })
     .map_err(|e| PyValueError::new_err(format!("parse_nl_text: {e}")))?;
     PyNlProblem::from_tnlp(tnlp, "parse_nl_text", depth)
+}
+
+#[cfg(test)]
+mod tests {
+    /// `NlProblem` must stay movable across threads (pounce#477): a
+    /// threaded host shares one evaluator across a worker pool, and the
+    /// alternative — pyo3's `unsendable` marker — reports a violation as
+    /// a `PanicException`, which derives from `BaseException` and so
+    /// escapes the host's `except Exception`. A cross-thread call then
+    /// reads as a wrong answer rather than an error. Regresses the
+    /// moment a `!Send` field (an `Rc`, a non-`Send` trait object)
+    /// lands in `PyNlProblem` or in `NlTnlp` beneath it.
+    #[test]
+    fn py_nl_problem_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::PyNlProblem>();
+    }
 }

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -607,6 +607,13 @@ pub fn solve_qp_multi_rhs<'py>(
 /// bounds), then reuses it across `solve()` calls that vary only the
 /// numeric data. Mirrors `pounce.jax.JaxProblem`'s build-once ergonomics
 /// for the convex QP solver.
+//
+// Genuinely `!Send`, so `unsendable` stays (pounce#477): the captured
+// KKT factor holds `dyn SparseSymLinearSolverInterface` /
+// `dyn TSymScalingMethod` trait objects, neither of which is `Send`.
+// This is why `solve` below has to reach for `SendGuard` to cross its
+// own `allow_threads` boundary. Same reasoning as `PySolver`; contrast
+// `NlProblem`, whose marker was a policy default and is gone.
 #[pyclass(name = "QpFactorization", module = "pounce._pounce", unsendable)]
 pub struct PyQpFactorization {
     inner: QpFactorization,
@@ -667,6 +674,10 @@ impl PyQpFactorization {
 /// each `parametric_step` is a single back-substitution. Mirrors the NLP
 /// `Solver` session (which caches the converged factor for
 /// `parametric_step` / `reduced_hessian`), specialized to a QP.
+//
+// `!Send` for the same reason [`PyQpFactorization`] is (pounce#477):
+// the held active-set KKT factorization owns non-`Send` linear-solver
+// trait objects.
 #[pyclass(name = "QpSensitivity", module = "pounce._pounce", unsendable)]
 pub struct PyQpSensitivity {
     inner: QpSensitivity,

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -33,6 +33,22 @@ use std::rc::Rc;
 use crate::problem::{PyProblem, build_info_dict};
 
 /// Session-style wrapper around [`pounce_sensitivity::Solver`].
+//
+// Still `unsendable`, unlike `NlProblem` / `DenseLU` / `SparseLU`
+// (pounce#477). This one is not a policy default: `RustSolver` is
+// genuinely `!Send` — the ported Ipopt object graph is `Rc`-based
+// (`Rc<RefCell<dyn TNLP>>`, `Rc<RegisteredOptions>`, `Rc<Journalist>`,
+// …) and holds non-`Send` linear-solver and restoration trait objects,
+// so there is nothing to drop the marker in favor of.
+//
+// The cost is the one #477 describes: a cross-thread call raises
+// `PanicException` (a `BaseException`, so `except Exception` misses it)
+// and a foreign-thread collection writes an unraisable and leaks. The
+// Python layer keeps `Solver` instances on their creating thread via
+// `threading.local` for exactly this reason — see
+// `pounce/jax/_problem.py`. Trading the panic for a catchable error
+// would mean an `unsafe impl Send` wrapper doing the affinity check by
+// hand; not worth it while the callers are already thread-pinned.
 #[pyclass(name = "Solver", module = "pounce._pounce", unsendable)]
 pub struct PySolver {
     /// Reference to the owning Python `Problem`. Used to re-prepare an

--- a/crates/pounce-py/src/sparse_lu.rs
+++ b/crates/pounce-py/src/sparse_lu.rs
@@ -19,7 +19,11 @@ use numpy::{IntoPyArray, PyReadonlyArray1};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
-#[pyclass(name = "SparseLU", module = "pounce._pounce", unsendable)]
+/// Sendable, for the reason [`crate::dense_lu::PyDenseLu`] gives: FERAL's
+/// symbolic and numeric factors are owned data with no thread affinity,
+/// and `unsendable` bought only pyo3's uncatchable thread check
+/// (pounce#477).
+#[pyclass(name = "SparseLU", module = "pounce._pounce")]
 pub struct PySparseLu {
     n: usize,
     nnz: usize,
@@ -206,5 +210,16 @@ impl PySparseLu {
             out[r * nn..(r + 1) * nn].copy_from_slice(&rhs);
         }
         Ok(out.into_pyarray_bound(py))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    /// The factor must stay movable across threads (pounce#477); see
+    /// [`super::PySparseLu`] for why `unsendable` is the worse default.
+    #[test]
+    fn py_sparse_lu_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<super::PySparseLu>();
     }
 }

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -383,6 +383,40 @@ block-diagonal Hessian with `v = [nan, 0, 1, 0]`, the dense product is
 better semantics, but it does mean the HVP is not bit-equivalent to a
 dense product on non-finite input.
 
+### Sharing one `NlProblem` across threads
+
+An `NlProblem` may be built on one thread and evaluated — or garbage
+collected — on any other. Threaded hosts (a branch-and-bound worker pool,
+a `ThreadPoolExecutor`) can hold **one** shared evaluator rather than one
+tape per worker:
+
+```python
+p = pounce.read_nl("model.nl")
+
+with ThreadPoolExecutor(max_workers=8) as pool:
+    values = list(pool.map(p.objective, points))   # one tape, N workers
+```
+
+The evaluators do not release the GIL, so concurrent calls serialize
+rather than overlap — the win is memory (one copy of the tapes) and the
+absence of thread-affinity ceremony, not parallel throughput. For actual
+parallelism across instances, use
+[`solve_nlp_batch`](#batched-nlp-solving-solve_nlp_batch), which releases
+the GIL and runs the whole batch on a Rayon pool.
+
+`DenseLU` and `SparseLU` carry the same guarantee: factor on one thread,
+back-solve on another.
+
+`Solver`, `QpFactorization` and `QpSensitivity` are the exceptions —
+their held Ipopt / KKT factorizations are genuinely thread-affine, so
+each must be used and released on the thread that created it. Keep them
+in a `threading.local` (not a dict keyed by thread id: CPython clears a
+`threading.local` on the owning thread as it exits, so the object is both
+built and dropped where it belongs), which is what `pounce.jax`'s
+`JaxProblem` does internally. Using one from another thread raises a
+`PanicException` — note that this derives from `BaseException`, so an
+`except Exception` will *not* catch it.
+
 ## Batched NLP solving (`solve_nlp_batch`)
 
 `pounce.solve_nlp_batch` solves N **independent** NLPs and returns one

--- a/python/tests/test_thread_affinity.py
+++ b/python/tests/test_thread_affinity.py
@@ -1,0 +1,182 @@
+"""Cross-thread use of the evaluator objects (issue #477).
+
+``NlProblem``, ``DenseLU`` and ``SparseLU`` used to be
+``#[pyclass(unsendable)]``, which gave them pyo3's per-object thread
+affinity. That default was not merely restrictive, it was *unsafe for the
+host*:
+
+* touching an instance from a thread other than its creator raised a Rust
+  ``PanicException``, which derives from ``BaseException`` and therefore
+  slips past every ordinary ``except Exception`` handler. In a
+  branch-and-bound host this did not surface as an error at all — it
+  surfaced as a wrong answer (a false ``infeasible``, which from a global
+  optimizer is a wrong certificate);
+* the *drop* path tripped separately, and fired even for code that never
+  used an instance cross-thread: whichever thread happens to run the
+  garbage collector inherits the object, and freeing it there wrote an
+  unraisable ``RuntimeError`` and leaked the payload.
+
+None of these types has any real thread affinity — ``NlTnlp`` is ``Send``,
+and the LU factors are owned matrix data — so the marker is gone and the
+tests below pin that. Concurrency is still the GIL's: the evaluators do
+not release it, so these calls serialize rather than overlap.
+"""
+
+import gc
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+import pytest
+
+import pounce
+from pounce._pounce import DenseLU, SparseLU
+
+
+def _quadratic():
+    """``min x0² + 3·x1·x2 + sin(x0)`` s.t. ``x0 + x1 + x2 = 1``."""
+    x = [pounce.NlExpr.var(i) for i in range(3)]
+    obj = x[0] * x[0] + 3.0 * x[1] * x[2] + pounce.NlExpr.sin(x[0])
+    return pounce.build_nl_problem(
+        3, obj, constraints=[x[0] + x[1] + x[2]], g_l=[1.0], g_u=[1.0]
+    )
+
+
+def _run_on_thread(fn):
+    """Call ``fn()`` on a fresh thread, re-raising whatever it raised.
+
+    ``BaseException`` on purpose: a ``PanicException`` is exactly what this
+    module exists to keep out, and an ``except Exception`` here would drop
+    it on the floor the same way the reporting host did.
+    """
+    box = {}
+
+    def target():
+        try:
+            box["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 - see docstring
+            box["error"] = exc
+
+    t = threading.Thread(target=target)
+    t.start()
+    t.join()
+    if "error" in box:
+        raise box["error"]
+    return box["value"]
+
+
+def test_nl_problem_evaluates_on_a_foreign_thread():
+    """The reproduction from the issue, method by method."""
+    p = _quadratic()
+    x = [1.0, 2.0, 3.0]
+    expected = (
+        p.objective(x),
+        p.gradient(x).tolist(),
+        p.constraints(x).tolist(),
+        p.jacobian(x).tolist(),
+        p.hessian(x).tolist(),
+        p.hessian_vector_product(x, [1.0, 0.0, 0.0]).tolist(),
+        repr(p),
+    )
+
+    def evaluate():
+        return (
+            p.objective(x),
+            p.gradient(x).tolist(),
+            p.constraints(x).tolist(),
+            p.jacobian(x).tolist(),
+            p.hessian(x).tolist(),
+            p.hessian_vector_product(x, [1.0, 0.0, 0.0]).tolist(),
+            repr(p),
+        )
+
+    assert _run_on_thread(evaluate) == expected
+
+
+def test_nl_problem_built_on_one_thread_variant_on_another():
+    """``variant`` clones the tapes, so it moves the model too."""
+    p = _run_on_thread(_quadratic)
+    v = _run_on_thread(lambda: p.variant(x_l=[0.0, 0.0, 0.0]))
+    assert v.x_l.tolist() == [0.0, 0.0, 0.0]
+    assert v.objective([1.0, 2.0, 3.0]) == p.objective([1.0, 2.0, 3.0])
+
+
+def test_nl_problem_drops_cleanly_on_a_foreign_thread():
+    """Collecting on a thread that did not build the model is silent.
+
+    The old behavior wrote an unraisable ``RuntimeError`` ("is unsendable,
+    but is being dropped on another thread") and leaked the tapes — for
+    code that had merely let the GC run somewhere else.
+    """
+    holder = {"p": _run_on_thread(_quadratic)}
+    unraisable = []
+    previous = sys.unraisablehook
+    sys.unraisablehook = unraisable.append
+    try:
+        del holder["p"]
+        gc.collect()
+    finally:
+        sys.unraisablehook = previous
+    assert unraisable == []
+
+
+def test_shared_nl_problem_agrees_across_workers():
+    """The host's actual usage: one evaluator, a pool of workers.
+
+    Exact equality, not a tolerance — the same tape on the same input has
+    no license to differ by a bit across threads.
+    """
+    p = _quadratic()
+    x = [1.0, 2.0, 3.0]
+    reference = (p.objective(x), p.gradient(x).tolist(), p.hessian(x).tolist())
+
+    def hammer(_):
+        for _ in range(500):
+            got = (p.objective(x), p.gradient(x).tolist(), p.hessian(x).tolist())
+            if got != reference:
+                return got
+        return reference
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(hammer, range(8)))
+    assert results == [reference] * 8
+
+
+def test_nl_problem_built_on_a_worker_solves_in_a_batch():
+    """`solve_nlp_batch` clones the tape out; the pyclass itself is now
+    free to have been built anywhere."""
+    p = _run_on_thread(_quadratic)
+    results = pounce.solve_nlp_batch([p, p.variant(x0=[0.5, 0.5, 0.5])], parallel=True)
+    assert len(results) == 2
+    for x, _info in results:
+        assert x.shape == (3,)
+
+
+@pytest.mark.parametrize("factory", ["dense", "sparse"])
+def test_lu_factor_crosses_threads(factory):
+    """A factor built on one thread back-solves on another, and is
+    collected there without complaint."""
+    values = np.array([4.0, 1.0, 1.0, 3.0])
+    if factory == "dense":
+        build = lambda: DenseLU(2)  # noqa: E731
+    else:
+        build = lambda: SparseLU(2, [0, 0, 1, 1], [0, 1, 0, 1])  # noqa: E731
+
+    lu = _run_on_thread(build)
+    lu.factor(values)
+    b = np.array([1.0, 2.0])
+    expected = lu.solve(b).tolist()
+
+    assert _run_on_thread(lambda: lu.solve(b).tolist()) == expected
+    assert np.allclose(np.array(expected) @ np.array([[4.0, 1.0], [1.0, 3.0]]).T, b)
+
+    unraisable = []
+    previous = sys.unraisablehook
+    sys.unraisablehook = unraisable.append
+    try:
+        del lu
+        gc.collect()
+    finally:
+        sys.unraisablehook = previous
+    assert unraisable == []


### PR DESCRIPTION
Fixes #477

## Problem

`NlProblem` could not be shared by a threaded host. Every instance was pinned to
its creating thread, and pyo3 reports a violation by panicking — and
`PanicException` derives from `BaseException`, not `Exception`, so an ordinary
`except Exception` in the host never saw it.

The consequence was not a loud error, it was a wrong certificate. In discopt
(jkitchin/discopt#75) a shared `NlProblem`-backed evaluator called from B&B
worker threads reported, on `clay0303hfsg`:

| arm | status | objective |
|---|---|---|
| incumbent JAX evaluator | `feasible` | 26669.109551433947 |
| `NlProblem`-backed evaluator | **`infeasible`** | `None` |

A false `infeasible` from a global optimizer is a wrong answer, not a failure.

The drop path was separate and worse, because it fires for code that never used
an instance cross-thread at all — whichever thread runs the GC inherits every
object it frees, so a plain dict of per-thread tapes wrote an unraisable
`RuntimeError: ... is unsendable, but is being dropped on another thread` at
teardown and leaked the tapes.

## Cause

`#[pyclass(unsendable)]` on `PyNlProblem`, `PyDenseLu`, and `PySparseLu`. The
marker gives pyo3's `ThreadCheckerImpl`, whose `ensure()` is an `assert_eq!` on
the thread id (hence the panic) and whose `can_drop()` writes an unraisable and
skips the destructor (hence the leak).

The marker was a conservative default, not a physical constraint. The class
comment already said as much, and the compiler confirms it: `NlTnlp` is `Send`
(its CSE nodes went `Arc` for #126's batched solving), so `RefCell<NlTnlp>` is
too, and the LU factors are owned matrix data with no affinity.

## Fix

Drop `unsendable` from all three classes. One evaluator can now be built on one
thread and evaluated or collected on any other.

Concurrency is still the GIL's — none of these methods release it, so
cross-thread calls serialize rather than overlap. The win is a single shared
tape instead of one per worker, and the end of the `threading.local` ceremony
hosts needed to work around this. The struct comment states the one invariant
that must hold going forward: a future method that wants to release the GIL
around an evaluation has to take the `NlTnlp` out of the `RefCell` first (as
`clone_tnlp` already does for the batch path) rather than hold a borrow across
the release.

**Not changed: `Solver`, `QpFactorization`, `QpSensitivity`.** I checked these
against the compiler rather than assuming, and their affinity is real:
`Rc<RefCell<dyn TNLP>>`, `Rc<RegisteredOptions>`, `Rc<Journalist>`,
`dyn SparseSymLinearSolverInterface`, `dyn TSymScalingMethod`. Each now says so
where it is defined, so the next reader does not repeat the audit.

The issue's fallback ask — a catchable error in place of the panic — was
considered and rejected for those three. It is not reachable in pyo3 0.22:
`PyRef::try_borrow` calls the panicking `ensure_threadsafe()`, not the
`PyBorrowError`-returning `check_threadsafe()`, so there is no non-panicking
borrow path for an unsendable class. Getting there means making the structs
`Send` behind an `unsafe impl Send` wrapper that does the affinity check by
hand, and leaking on foreign-thread drop — which is what pyo3 already does
today, so the only net change would be losing the stderr warning that tells you
about the leak. Not worth that trade while every caller is already thread-pinned
via `threading.local` (see `pounce/jax/_problem.py`). Happy to do it as a
follow-up if the asymmetry is worth closing.

## Blast radius

Relaxing `Send` cannot break a caller: every use that worked before still works,
and uses that previously panicked now succeed. No evaluator logic, numerics, or
signature changed — the diff outside comments and tests is three attribute
lists.

`solve_nlp_batch` is unaffected by construction: it already cloned the owned
`NlTnlp` out under the GIL (`clone_tnlp`) and moved the clone to the rayon
worker, so no `RefCell` borrow was ever live across `allow_threads`.

`Solver`/`QpFactorization`/`QpSensitivity` and everything built on them
(`pounce.jax`, `pounce.torch`) are untouched.

## Tests

Two layers, because neither alone is sufficient.

`#[test]`s in `nl_problem.rs`, `dense_lu.rs`, `sparse_lu.rs` assert `Send` on
each class. These guard against a `!Send` field creeping back in — but they
would *not* catch someone re-adding `unsendable`, since the marker does not make
a type `!Send`. Hence:

`python/tests/test_thread_affinity.py` (7 tests) covers what those cannot —
every `NlProblem` method called from a foreign thread, `variant` across threads,
`solve_nlp_batch` on a foreign-built problem, an 8-worker × 500-iteration
agreement check (exact equality, not a tolerance — the same tape on the same
input has no license to differ by a bit across threads), and foreign-thread
collection asserted silent via `sys.unraisablehook`. `DenseLU`/`SparseLU` are
parameterized over the same build/use/collect split.

**All 7 fail on the parent commit, for the stated reason.** Verified by
restoring `unsendable` on the three classes, rebuilding with
`maturin develop --release`, and re-running: 7 failed, with
`pyo3_runtime.PanicException: ... is unsendable, but sent to another thread` on
the use paths and `PytestUnraisableExceptionWarning` carrying
`RuntimeError: _pounce::nl_problem::PyNlProblem is unsendable, but is being
dropped on another thread` on the drop paths. Then reverted and confirmed 7
passed.

Also clean: `cargo test -p pounce-py` (11 passed), `cargo fmt --check`,
`cargo clippy -p pounce-py --all-targets` (no new warnings; the ones on the
touched files are pre-existing `type_complexity` / `unwrap_used`),
`scripts/check-release-consistency.sh`, and `655 passed / 27 skipped` across the
Python suite.

**Known gap:** the jax/torch test files were not run here (those deps are not
installed in this environment). They exercise `Solver`, which this PR does not
touch — CI covers them.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — new "Sharing an `NlProblem` across
      threads" section in `docs/src/python.md` (existing page, no `SUMMARY.md`
      change needed)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now


---
_Generated by [Claude Code](https://claude.ai/code/session_013zJ5taJYPwBH8RXY3kQFG3)_