### PR TITLE
Address #475 review: name the other holder of the factor, prove the release frees it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ changes.
 
 ## [Unreleased]
 
-### Added — pyomo-pounce: `release_kkt()`, the exit of the retention story
+### Added — pyomo-pounce: `release_kkt()`, the exit of the retention story (#475)
 
 - The held KKT factorization can now be dropped on demand:
   `release_kkt(model)` frees the factor's memory immediately and
   returns whether anything was held. Declarations and a prior
   `retain_kkt()` are untouched, so the next solve keeps its factor
-  again; after release the accessors raise their no-session error. A
-  `Covariance` or `Information` result created before the release
-  holds its own reference through its pending `conditioned_on`, so it
-  keeps working: release drops the model's hold, not the result's.
+  again; after release the accessors raise their no-session error.
+  Release drops the model's hold, not a result's: a `Covariance` or
+  `Information` with a pending `conditioned_on`, and a `Gradient`,
+  each hold their own reference and keep working across the release.
   The retention policy (three ways to keep, one way to release) is
   stated in one place in the docs.
 

--- a/dev-notes/covariance-information-design.md
+++ b/dev-notes/covariance-information-design.md
@@ -46,8 +46,9 @@ $S = H_{AA} - H_{AF} H_{FF}^{-1} H_{FA}$ the reduction onto $A$.
 
 One more rule completes retention: a `Covariance` or `Information` result whose
 `conditioned_on` has not been read keeps the session, and with it the
-factor, alive until first access; `release_kkt` drops the model's
-hold, not a pending result's.
+factor, alive until first access, as does a live `Gradient` (it reads
+the factor on every lookup); `release_kkt` drops the model's hold, not
+an outstanding result's.
 
 Explicit call-time forms (`solve(m, fitted=..., residuals=...)`) are
 deliberately solve-local, so repeated solves of one model do not

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -527,12 +527,12 @@ same classification the block members get, applied per candidate as a
 singleton block, so it is scale-invariant; only near-bound variables
 pay the extra backsolve.
 
-## Keeping the factor: retain_kkt()
+## Keeping and releasing the factor: retain_kkt(), release_kkt()
 
 The solve factors the KKT matrix to solve the NLP; the only question is
 whether that factor is kept for post-solve queries. Any declaration
 keeps it. `retain_kkt(model)` keeps it with no declaration at all,
-which is what the declaration-free `wrt=` flow needs: the MHE case,
+which is what `wrt=` queries with nothing declared need: the MHE case,
 where the arrival state and the parameters are each queried by `wrt=`
 and neither is THE fitted set. It defaults off, so a solve with no
 sensitivity pays nothing.
@@ -542,6 +542,7 @@ retain_kkt(m)
 SolverFactory("pounce").solve(m)
 arrival = covariance(m, sigma_sq=s2, wrt=m.x[:, t0])
 params = information(m, wrt=[m.k1, m.k2])
+release_kkt(m)          # done asking: give the memory back now
 ```
 
 | setup | factor kept | `covariance(model)` | `covariance(model, wrt=T)` |
@@ -557,10 +558,12 @@ declared or `retain_kkt()` was called, and a `Covariance` or
 keeps the session alive through its pending computation until first
 access. `release_kkt(model)` is the exit: it drops the model's hold
 on the factor immediately, freeing the memory, while declarations and
-the retain flag still apply to the next solve. A result created
-before the release holds its own reference through its pending
-`conditioned_on`, so it keeps working; release drops the model's
-hold, not the result's. Noise is a separate question: `retain_kkt()` keeps the
+the retain flag still apply to the next solve. Release drops the
+model's hold, not a result's: a `Covariance` or `Information` with a
+pending `conditioned_on`, and a `Gradient` (which reads the factor on
+every lookup), each hold their own reference, so they keep working
+across the release and keep the factor in memory until they are
+discarded. Noise is a separate question: `retain_kkt()` keeps the
 factor, not a noise model, and with nothing declared fitted the
 degrees of freedom for a noise ESTIMATE are unknown, so
 `covariance()` under retain-only needs `sigma_sq=`; the estimation

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -163,11 +163,15 @@ def release_kkt(model):
     The exit of the retention story, for the current factor only:
     declarations and a prior retain_kkt() are untouched and apply to
     the NEXT solve, which keeps its factor again. After release the
-    accessors raise their no-session error until another solve. A
-    Covariance or Information result whose conditioned_on is still
-    pending holds its own reference to the session, so such a result
-    keeps the factor alive until the attribute is read or the result
-    is discarded; release drops the model's hold, not theirs.
+    accessors raise their no-session error until another solve.
+
+    Release drops the MODEL's hold, not a result's, and two kinds of
+    result hold their own reference to the session: a Covariance or
+    Information whose conditioned_on is still pending (until the
+    attribute is read), and a Gradient handed back by gradient()
+    (which uses the session on every lookup). Such a result keeps
+    working after the release, and keeps the factor in memory until
+    it too is discarded.
 
     Returns True if a factorization was held and is now released,
     False if there was nothing to release."""

--- a/pyomo-pounce/tests/test_retain_kkt.py
+++ b/pyomo-pounce/tests/test_retain_kkt.py
@@ -4,6 +4,9 @@ work on any block without a declared default. The roadmap's truth
 table: no declarations and no retain means no factor and the no-session
 error; retain alone keeps the factor but covariance(m) has no default
 and stays an error; retain plus declarations changes nothing."""
+import gc
+import weakref
+
 import numpy as np
 import pytest
 import pyomo.environ as pyo
@@ -13,6 +16,8 @@ from pyomo_pounce import (
     covariance,
     declare_fitted,
     declare_residual,
+    declare_sens_param,
+    gradient,
     information,
     release_kkt,
     retain_kkt,
@@ -170,10 +175,22 @@ def test_release_kkt_with_nothing_held():
     assert release_kkt(m) is False
 
 
-def test_release_kkt_keeps_intent_for_the_next_solve():
-    # declarations and the retain flag survive release: the next solve
-    # keeps its factor again, on both the declared and retain-only
-    # paths
+def test_release_kkt_frees_the_session():
+    # the point of the call: with no result outstanding, nothing else
+    # holds the session, so the factor is collected at the release and
+    # not merely hidden from the accessors
+    x, y, X = linear_data()
+    m = linear_model(x, y)
+    pyo.SolverFactory("pounce").solve(m)
+    held = weakref.ref(m.__dict__["_pounce_sens"].session)
+    assert held() is not None
+    assert release_kkt(m) is True
+    assert held() is None
+
+
+def test_release_kkt_keeps_declarations_for_the_next_solve():
+    # the declarations survive release: the next solve keeps its
+    # factor again and covariance(m) still has its default block
     x, y, X = linear_data()
     m = linear_model(x, y)
     pyo.SolverFactory("pounce").solve(m)
@@ -182,14 +199,20 @@ def test_release_kkt_keeps_intent_for_the_next_solve():
     C = np.linalg.inv(X.T @ X)
     assert covariance(m, sigma_sq=SIGMA**2)[m.a] == pytest.approx(
         SIGMA**2 * C[0, 0], rel=1e-9)
-    m2 = linear_model(x, y, declare=False)
-    retain_kkt(m2)
-    pyo.SolverFactory("pounce").solve(m2)
-    release_kkt(m2)
-    pyo.SolverFactory("pounce").solve(m2)
-    assert covariance(m2, sigma_sq=SIGMA**2,
-                      wrt=[m2.a])[m2.a] == pytest.approx(
-        SIGMA**2 * np.linalg.inv(X.T @ X)[0, 0], rel=1e-9)
+
+
+def test_release_kkt_keeps_the_retain_flag_for_the_next_solve():
+    # same on the retain-only path: release does not undo retain_kkt()
+    x, y, X = linear_data()
+    m = linear_model(x, y, declare=False)
+    retain_kkt(m)
+    pyo.SolverFactory("pounce").solve(m)
+    release_kkt(m)
+    pyo.SolverFactory("pounce").solve(m)
+    C = np.linalg.inv(X.T @ X)
+    assert covariance(m, sigma_sq=SIGMA**2,
+                      wrt=[m.a])[m.a] == pytest.approx(
+        SIGMA**2 * C[0, 0], rel=1e-9)
 
 
 def test_release_kkt_pending_conditioned_on_survives():
@@ -202,5 +225,26 @@ def test_release_kkt_pending_conditioned_on_survives():
     cov = covariance(m, sigma_sq=SIGMA**2)
     assert release_kkt(m) is True
     assert cov.conditioned_on == ()
-    assert cov[m.a] == pytest.approx(
-        SIGMA**2 * np.linalg.inv(X.T @ X)[0, 0], rel=1e-9)
+    C = np.linalg.inv(X.T @ X)
+    assert cov[m.a] == pytest.approx(SIGMA**2 * C[0, 0], rel=1e-9)
+
+
+def test_release_kkt_leaves_a_gradient_working():
+    # the other result that holds the session: a Gradient reads the
+    # factor on every lookup, so it too keeps working -- and keeps the
+    # factor alive -- across a release
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=3.0, mutable=True)
+    m.x = pyo.Var(initialize=0.0)
+    m.con = pyo.Constraint(expr=m.x == 2.0 * m.p)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    g = gradient(wrt=m.p)
+    held = weakref.ref(m.__dict__["_pounce_sens"].session)
+    assert release_kkt(m) is True
+    assert held() is not None                 # the Gradient still holds it
+    assert g[m.x, m.p] == pytest.approx(2.0, rel=1e-9)
+    del g
+    gc.collect()
+    assert held() is None

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -35,7 +35,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 | 25 | [`25_pyomo_sensitivity.ipynb`](25_pyomo_sensitivity.ipynb) | Declared-parameter sensitivity from Pyomo: an optimal-control example whose first-move gradients are the NMPC feedback gains (needs `pyomo-cvp`). |
 | 26 | [`26_parameter_covariance.ipynb`](26_parameter_covariance.ipynb) | Parameter covariance and identifiability from the reduced Hessian: standard errors, a Monte Carlo validated confidence ellipse, and a sloppy-direction diagnosis. |
 | 31 | [`31_information_identifiability.ipynb`](31_information_identifiability.ipynb) | The information matrix as the un-inverted view of the covariance: eigen() naming a poorly identified combination, the duality check, and zero variance versus finite information at a bound. |
-| 32 | [`32_wrt_blocks_and_retain_kkt.ipynb`](32_wrt_blocks_and_retain_kkt.ipynb) | One solve, many questions: wrt= sub-block marginals, confidence and prediction bands on undeclared prediction variables, conditioned_on, and retain_kkt() with nothing declared. |
+| 32 | [`32_wrt_blocks_and_retain_kkt.ipynb`](32_wrt_blocks_and_retain_kkt.ipynb) | One solve, many questions: wrt= sub-block marginals, confidence and prediction bands on undeclared prediction variables, conditioned_on, retain_kkt() with nothing declared, and release_kkt() to give the factor's memory back. |
 
 ## Performance & sparsity
 


### PR DESCRIPTION
Follow-up to #475 (merged), carrying the review's findings. #475's head branch is on a fork this session cannot push to, so the fixes land here instead of as commits on that PR.

## Problem

Two gaps in the merged `release_kkt()`, one behavioural-doc, one coverage:

1. **The docs name one holder of the session; there are two.** `release_kkt()`'s docstring, `docs/src/sensitivity.md`, the design record and the CHANGELOG all say a `Covariance`/`Information` with a pending `conditioned_on` keeps the factor alive across a release. A `Gradient` does too — `Gradient.__init__` stores `self._session` (`sens.py:849`) and reads the factor on every lookup — so `g = gradient(wrt=m.p)` silently defeats the headline promise ("frees the factor's memory immediately") with nothing in the docs to warn of it.
2. **Nothing tested the thing the feature exists for.** The four merged tests check that the accessors raise afterwards and that intent survives — all of which a factor that was merely *hidden* from the accessors would also pass. The memory claim itself was unpinned, so a future refactor that stashed the session anywhere else (a plugin cache, a module-level registry) would keep every test green.

## Cause

Both trace to the same thing: the retention story was written from the model's side (`reg.session`), and the result objects that also hold the session were only partly enumerated when the exit was added.

## Fix

Docstring, `docs/src/sensitivity.md`, `dev-notes/covariance-information-design.md` and the CHANGELOG entry now name both holders and say what each means for the memory. No code change — the behaviour was already correct, only under-described.

Considered and rejected: normalizing the registry lookup to `model.model().__dict__` so `release_kkt(some_block)` stops silently returning `False`. It trades one silent hole for a worse one — `retain_kkt(block)` writes the registry onto whatever object it is handed, so after `retain_kkt(b); solve(b)` the session lives on `b`, and a root-normalized release would miss it. The lookup as written matches `covariance()` and `information()` exactly (`sens.py:1904`, `sens.py:2288`); making the whole family agree on where a registry lives is a separate change, not a rider on this one.

Docs also pick up: the section heading and its example now carry `release_kkt()`, so the exit is reachable from the table of contents rather than buried mid-paragraph; the `retain_kkt()` paragraph drops "the declaration-free `wrt=` flow", the phrasing #475 deliberately removed from the error messages; notebook 32's README row mentions the release; the CHANGELOG heading carries `(#475)` like its neighbours.

## Blast radius

`pyomo-pounce` only, and within it docstrings, markdown and tests — the sole non-test package change is `release_kkt()`'s docstring. No solver behaviour, no corpus sweep implicated.

## Tests

- `test_release_kkt_frees_the_session` — holds a `weakref` to the `_Session` and asserts it is `None` immediately after the release. This is the feature's actual contract: no `gc.collect()`, which also confirms nothing keeps the session in a reference cycle.
- `test_release_kkt_leaves_a_gradient_working` — a `Gradient` taken before the release still answers `g[m.x, m.p] == 2.0` afterwards, the weakref is still alive while it is held, and dies once it is dropped. Pins the newly documented behaviour in both directions.
- `test_release_kkt_keeps_intent_for_the_next_solve` splits into the declared and retain-only halves, so a failure on the first no longer masks the second; the retain-only half was unreachable on any declared-path failure.

Honest about the checkbox below: **these tests pass on the parent commit** and are not regression tests — #475's behaviour is correct as merged. They pin behaviour that was previously unpinned (the memory actually being freed) and behaviour that was previously undocumented (the `Gradient` holder). The `Gradient` test is the one that would have caught the doc gap, by making the second holder visible in the suite.

Locally: `pyomo-pounce/tests/test_retain_kkt.py` 13 passed, 1 skipped. Full `pyomo-pounce/tests` 148 passed, 19 skipped, 2 failed — `test_infeasibility_no_false_positives` and `test_scale_invariance`, both of which shell out to the `pounce` CLI and fail in this container on the stale PATH binary ("generated zero solvable instances"), untouched by this diff.

---

- [ ] Tests fail on the parent commit for the stated reason — **no, deliberately**: see above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`sensitivity.md`; no new page, no `SUMMARY.md` change)
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — no Rust in this diff
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VxkqU4SE7hUQmghE2RQub

---
_Generated by [Claude Code](https://claude.ai/code/session_015VxkqU4SE7hUQmghE2RQub)_