### PR TITLE
perf(nl): evaluate shared .nl subexpressions once per sweep, not per reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@
 !/benchmarks/*/README.md
 !/benchmarks/preprocessing/*
 !/benchmarks/scripts/*
+# Model generators that reproduce a Mittelmann instance *without* an AMPL
+# licence (the .mod sources and their .nl translations stay untracked).
+!/benchmarks/mittelmann/gen_*.py
 # The warm-start suite is a Python harness rather than a directory of .nl:
 # its sources (including the two package subdirectories) are tracked, its
 # per-run results.json / results.md outputs are regenerated and ignored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ changes.
 
 ## [Unreleased]
 
+### Performance — shared `.nl` subexpressions are evaluated once per sweep (#476)
+
+- Constraint values (`eval_g`) now go through a problem-wide tape with a
+  **shared prelude**: every `.nl` defined variable (`V` segment) referenced
+  by two or more summands is evaluated once per sweep instead of once per
+  reference. Previously each summand got an independent flat tape, so a
+  defined variable feeding many rows was re-evaluated for each of them.
+- Invisible on most models, dominant on constraint-heavy ones. Mittelmann's
+  `robot_a` (n = 1001, m = 52013, 12003 defined variables each feeding 13
+  rows) went from 3.6M to 894k tape ops per constraint sweep — 4.0x less
+  arithmetic, on the line search's inner loop. End to end: **22 % faster**
+  on `robot_a`/`robot_c`, with a bit-identical iteration trajectory.
+- `eval_g` / `eval_f` also stopped allocating a `Vec` per summand (~148k
+  allocations per call on `robot_a`, ~20 % of `eval_g`); they reuse the
+  scratch arena `eval_jac_g` / `eval_grad_f` already used.
+- Both are transparent: models using opcodes the shared-prelude path does
+  not support (comparisons, AND/OR/NOT, if-then-else, min/max lists,
+  external functions), and models with nothing shared to hoist, keep the
+  previous path. All 42 `.nl` fixtures in the tree produce identical
+  status, objective and iteration counts.
+- `benchmarks/mittelmann/gen_robot_nl.py` reproduces `robot_a`/`b`/`c` as
+  `.nl` without an AMPL licence. Full investigation, including why the
+  iteration count is inherited from Ipopt rather than a POUNCE weakness:
+  `dev-notes/research/robot-abc-per-iteration-cost.md`.
+
 ### Fixed — `NlProblem` can be shared across threads (#477)
 
 - `NlProblem`, `DenseLU` and `SparseLU` were `#[pyclass(unsendable)]`,

--- a/benchmarks/mittelmann/README.md
+++ b/benchmarks/mittelmann/README.md
@@ -52,6 +52,28 @@ make all         # fetch + translate + run-all + report
 Default per-instance timeout is 7200s, matching Mittelmann's published convention.
 Override with `make run-pounce TIMELIMIT=300`.
 
+## `robot_a` / `robot_b` / `robot_c` without AMPL
+
+`gen_robot_nl.py` writes those three instances straight to `.nl`, so the
+per-iteration cost work in pounce#476 is reproducible with no AMPL licence and
+no `make translate`:
+
+```
+curl -O http://plato.asu.edu/ftp/ampl-nlp-source/robot_a.mod
+python3 gen_robot_nl.py robot_a.mod robot_a.nl     # n=1001 m=52013 nzJ=196781
+pounce robot_a.nl max_iter=200 --no-sol
+ipopt  robot_a -AMPL                               # same file, for comparison
+```
+
+It emits the `V` segments for the model's `SUM`/`SUM1`/`SUM2` defined variables
+rather than inlining them, so the tape the solver builds matches what AMPL would
+hand it — which matters here, because those 12003 shared subexpressions *are* the
+performance story (see `dev-notes/research/robot-abc-per-iteration-cost.md`).
+Sizes match the published `n`/`m` exactly; see the script header for the one
+AMPL presolve step (six duplicate linear rows per collocation point collapsing to
+one) that it reproduces by hand. `--no-merge` emits the unpresolved 18-family
+form for comparison.
+
 ## Licensing & redistribution
 
 The .mod sources are fetched from Mittelmann's public mirror and **not redistributed

--- a/benchmarks/mittelmann/gen_robot_nl.py
+++ b/benchmarks/mittelmann/gen_robot_nl.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Generate a .nl file for the Mittelmann robot_a/b/c models.
+
+The .mod source (plato.asu.edu/ftp/ampl-nlp-source/robot_a.mod) declares
+
+    var X{1..N};
+    var SUM{i in 1..M}  = sum{j in 1..N} VI [i,j]*X[j];
+    var SUM1{i in 1..M} = sum{j in 1..N} VI1[i,j]*X[j];
+    var SUM2{i in 1..M} = sum{j in 1..N} VI2[i,j]*X[j];
+    minimize obj: sum{i in 1..N} BB[i]*X[i];
+    s.t. gx1..gx18{i in 1..M}: ... >= 0
+
+SUM/SUM1/SUM2 are AMPL *defined* variables, so they land in the .nl as
+common subexpressions (V segments) rather than as extra columns; that is
+why the published size is n = 1001 rather than 1001 + 3*4001.
+
+Constraint families gx1/gx2, gx7/gx8, gx13/gx14 are all lower bounds on
+the *same* linear form SUM[i]:
+
+    C11*SUM[i] -+ V11[i] >= 0   <=>   SUM[i] >= +-V11[i]/C11
+    C21*SUM[i] -+ V21[i] >= 0   <=>   SUM[i] >= +-V21[i]/C21
+    C31*SUM[i] -+ V31[i] >= 0   <=>   SUM[i] >= +-V31[i]/C31
+
+so they collapse to the single row SUM[i] >= max(|V11|/C11, |V21|/C21,
+|V31|/C31).  With that merge the model has 13*M = 52013 rows, matching the
+published m for robot_a/b/c.  `--no-merge` emits all 18*M = 72018 rows
+instead (used to confirm which variant the benchmark measured).
+
+Usage:  gen_robot_nl.py robot_a.mod out.nl [--no-merge]
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import sys
+
+
+# ----------------------------------------------------------------- model data
+
+
+def read_data(path):
+    """Pull the `data;` section params out of a robot_[abc].mod."""
+    text = open(path).read()
+    data = {}
+    for m in re.finditer(r"param\s+(\w+)\s*:=\s*([-\d.eE+]+)\s*;", text):
+        data[m.group(1)] = float(m.group(2))
+    return data
+
+
+def ampl_round(x):
+    """AMPL's round(): half away from zero (Python's round() is banker's)."""
+    return math.floor(x + 0.5) if x >= 0 else math.ceil(x - 0.5)
+
+
+class Robot:
+    def __init__(self, mod_path):
+        d = read_data(mod_path)
+        self.N = N = int(d["N"])
+        self.M = M = int(d["M"])
+        self.C = {k: d[k] for k in d if re.fullmatch(r"C\d\d", k)}
+        self.H = H = 1.0 / (N - 1)
+        self.TP = [None] + [(i - 1) / (M - 1) for i in range(1, M + 1)]
+        self.K = [None] + [
+            int(ampl_round(self.TP[i] / H + 1e-6 + 1)) for i in range(1, M + 1)
+        ]
+        self.BB = [None] + [
+            0.5 * H
+            if i == 1
+            else 23 * H / 24
+            if i == 2
+            else 0.5 * H
+            if i == N
+            else 23 * H / 24
+            if i == N - 1
+            else H
+            for i in range(1, N + 1)
+        ]
+        self._basis()
+        self._vparams()
+
+    def _basis(self):
+        """VI/VI1/VI2 rows: at most four nonzeros, at n-index K-1..K+2."""
+        H, N = self.H, self.N
+        self.VI, self.VI1, self.VI2 = [None], [None], [None]
+        for j in range(1, self.M + 1):
+            K, TP = self.K[j], self.TP[j]
+            t1 = TP - (K - 1) * H  # "TP - (K-1)*H"
+            t2 = K * H - TP  # "K*H - TP"
+            row, row1, row2 = {}, {}, {}
+            for i in range(K - 1, K + 3):
+                if i < 1 or i > N:
+                    continue
+                case = K - i + 3  # 4,3,2,1 for i = K-1,K,K+1,K+2
+                if case == 1:
+                    v = t1**3 / 6 / H**3
+                    v1 = t1**2 / 2.0 / H**3
+                    v2 = t1 / H**3
+                elif case == 2:
+                    v = 1.0 / 6.0 + t1 * 0.5 / H + t1**2 * 0.5 / H**2 - t1**3 * 0.5 / H**3
+                    v1 = 0.5 / H + t1 / H**2 - t1**2 * 1.50 / H**3
+                    v2 = 1.0 / H**2 - t1 * 3.0 / H**3
+                elif case == 3:
+                    v = 1.0 / 6.0 + t2 * 0.5 / H + t2**2 * 0.5 / H**2 - t2**3 * 0.5 / H**3
+                    v1 = -0.5 / H - t2 / H**2 + t2**2 * 1.50 / H**3
+                    v2 = 1.0 / H**2 - t2 * 3.0 / H**3
+                else:  # case == 4
+                    v = t2**3 / 6.0 / H**3
+                    v1 = -(t2**2) / 2.0 / H**3
+                    v2 = t2 / H**3
+                if v != 0.0:
+                    row[i] = v
+                if v1 != 0.0:
+                    row1[i] = v1
+                if v2 != 0.0:
+                    row2[i] = v2
+            self.VI.append(row)
+            self.VI1.append(row1)
+            self.VI2.append(row2)
+
+    def _vparams(self):
+        """V11..V33: the tracking-trajectory derivative data, per row."""
+        self.V = {k: [None] for k in ("11", "12", "13", "21", "22", "23", "31", "32", "33")}
+        for i in range(1, self.M + 1):
+            t = self.TP[i]
+            A = 30 * t**2 * ((t - 2) * t + 1)
+            B = 60 * t * ((2 * t - 3) * t + 1)
+            Cc = (360 * t - 360) * t + 60
+            g = 4.7 * t**3 * ((6 * t - 15) * t + 10)
+            cg, sg = math.cos(g), math.sin(g)
+            self.V["11"].append(1.5 * A)
+            self.V["12"].append(1.5 * B)
+            self.V["13"].append(1.5 * Cc)
+            self.V["21"].append(-0.5 * (cg * 4.7 * A))
+            self.V["22"].append(-0.5 * (-sg * (4.7 * A) ** 2 + cg * 4.7 * B))
+            self.V["23"].append(
+                -0.5
+                * (
+                    -cg * (4.7 * A) ** 3
+                    - sg * 3 * 4.7**2 * A * B
+                    + cg * Cc * 4.7
+                )
+            )
+            self.V["31"].append(-1.3 * A)
+            self.V["32"].append(-1.3 * B)
+            self.V["33"].append(-1.3 * Cc)
+
+
+# ------------------------------------------------------------- .nl generation
+
+
+def num(x):
+    return repr(float(x))
+
+
+def gen(mod_path, out_path, merge=True, x0=1.491400623321533):
+    r = Robot(mod_path)
+    N, M = r.N, r.M
+    n = N  # columns: X[1..N] -> 0-based 0..N-1
+
+    # CSE numbering: SUM[i] -> n+(i-1), SUM1[i] -> n+M+(i-1), SUM2 -> n+2M+(i-1)
+    def cse_S(i):
+        return n + (i - 1)
+
+    def cse_S1(i):
+        return n + M + (i - 1)
+
+    def cse_S2(i):
+        return n + 2 * M + (i - 1)
+
+    groups = [("1", "11", "12", "13"), ("2", "21", "22", "23"), ("3", "31", "32", "33")]
+
+    # ---- constraint list -------------------------------------------------
+    # rows: (kind, group, i).  Nonlinear rows must precede linear rows.
+    rows = []
+    for g, _, _, _ in groups:
+        for kind in ("cube_minus", "cube_plus", "quint_minus", "quint_plus"):
+            for i in range(1, M + 1):
+                rows.append((kind, g, i))
+    if merge:
+        for i in range(1, M + 1):
+            rows.append(("lin_merged", None, i))
+    else:
+        # unmerged: six linear rows per i, in declaration order gx1,2,7,8,13,14
+        for g, _, _, _ in groups:
+            for sgn in ("-", "+"):
+                for i in range(1, M + 1):
+                    rows.append(("lin", (g, sgn), i))
+    n_nl_rows = 12 * M
+    m = len(rows)
+
+    def support(kind, i):
+        """Columns the row touches (0-based), i.e. union of referenced CSEs."""
+        if kind in ("lin", "lin_merged"):
+            s = set(r.VI[i])
+        elif kind in ("cube_minus", "cube_plus"):
+            s = set(r.VI[i]) | set(r.VI1[i])
+        else:
+            s = set(r.VI[i]) | set(r.VI1[i]) | set(r.VI2[i])
+        return sorted(j - 1 for j in s)
+
+    # ---- Jacobian: linear coefficients + counts --------------------------
+    jac = []  # per row: list of (col0, coef)
+    colcount = [0] * n
+    for kind, g, i in rows:
+        cols = support(kind, i)
+        if kind == "lin_merged":
+            coefs = {j - 1: v for j, v in r.VI[i].items()}
+        elif kind == "lin":
+            grp, sgn = g
+            c = r.C["C" + grp + "1"]
+            coefs = {j - 1: c * v for j, v in r.VI[i].items()}
+        elif kind in ("cube_minus", "cube_plus"):
+            # nonlinear part is C_a2*S^3; the -+(V_a2*S - V_a1*S1) part is linear
+            V1 = r.V[g + "1"][i]
+            V2 = r.V[g + "2"][i]
+            s = -1.0 if kind == "cube_minus" else 1.0
+            coefs = {}
+            for j, v in r.VI[i].items():
+                coefs[j - 1] = coefs.get(j - 1, 0.0) + s * V2 * v
+            for j, v in r.VI1[i].items():
+                coefs[j - 1] = coefs.get(j - 1, 0.0) - s * V1 * v
+        else:
+            coefs = {}  # purely nonlinear row
+        entries = [(j, coefs.get(j, 0.0)) for j in cols]
+        jac.append(entries)
+        for j, _ in entries:
+            colcount[j] += 1
+    nzc = sum(len(e) for e in jac)
+
+    out = []
+    w = out.append
+
+    # ---- header ----------------------------------------------------------
+    w(f"g3 1 1 0\t# problem robot")
+    w(f" {n} {m} 1 0 0 0\t# vars, constraints, objectives, ranges, eqns, lcons")
+    w(f" {n_nl_rows} 0\t# nonlinear constraints, objectives")
+    w(" 0 0\t# network constraints: nonlinear, linear")
+    w(f" {n} 0 0\t# nonlinear vars in constraints, objectives, both")
+    w(" 0 0 0 1\t# linear network variables; functions; arith, flags")
+    w(" 0 0 0 0 0\t# discrete variables: binary, integer, nonlinear (b,c,o)")
+    w(f" {nzc} {n}\t# nonzeros in Jacobian, obj. gradient")
+    w(" 0 0\t# max name lengths: constraints, variables")
+    w(f" 0 {3 * M} 0 0 0\t# common exprs: b,c,o,c1,o1")
+
+    # ---- V segments (defined variables) ----------------------------------
+    for rowdata, base in ((r.VI, 0), (r.VI1, M), (r.VI2, 2 * M)):
+        for i in range(1, M + 1):
+            ent = sorted(rowdata[i].items())
+            w(f"V{n + base + (i - 1)} {len(ent)} 0")
+            for j, v in ent:
+                w(f"{j - 1} {num(v)}")
+            w("n0")
+
+    # ---- C segments ------------------------------------------------------
+    def emit_cube(g, i):
+        """C_a2 * SUM[i]^3"""
+        c2 = r.C["C" + g + "2"]
+        w("o2")
+        w(f"n{num(c2)}")
+        w("o5")
+        w(f"v{cse_S(i)}")
+        w("n3")
+
+    def emit_quint(g, i, plus):
+        """C_a3*S^5 -+ (V_a3*S^2 - 3 V_a2 S S1 + 3 V_a1 S1^2 + V_a1 S S2)"""
+        c3 = r.C["C" + g + "3"]
+        V1, V2, V3 = r.V[g + "1"][i], r.V[g + "2"][i], r.V[g + "3"][i]
+        w("o0" if plus else "o1")
+        w("o2")
+        w(f"n{num(c3)}")
+        w("o5")
+        w(f"v{cse_S(i)}")
+        w("n5")
+        w("o54")
+        w("4")
+        # V3*S^2
+        w("o2")
+        w(f"n{num(V3)}")
+        w("o5")
+        w(f"v{cse_S(i)}")
+        w("n2")
+        # -3*V2*S*S1
+        w("o2")
+        w(f"n{num(-3.0 * V2)}")
+        w("o2")
+        w(f"v{cse_S(i)}")
+        w(f"v{cse_S1(i)}")
+        # 3*V1*S1^2
+        w("o2")
+        w(f"n{num(3.0 * V1)}")
+        w("o5")
+        w(f"v{cse_S1(i)}")
+        w("n2")
+        # V1*S*S2
+        w("o2")
+        w(f"n{num(V1)}")
+        w("o2")
+        w(f"v{cse_S(i)}")
+        w(f"v{cse_S2(i)}")
+
+    for ridx, (kind, g, i) in enumerate(rows):
+        w(f"C{ridx}")
+        if kind == "cube_minus" or kind == "cube_plus":
+            emit_cube(g, i)
+        elif kind == "quint_minus":
+            emit_quint(g, i, plus=False)
+        elif kind == "quint_plus":
+            emit_quint(g, i, plus=True)
+        else:
+            w("n0")
+
+    # ---- objective (linear) ---------------------------------------------
+    w("O0 0")
+    w("n0")
+
+    # ---- initial point ---------------------------------------------------
+    w(f"x{n}")
+    xs = num(x0)
+    for j in range(n):
+        w(f"{j} {xs}")
+
+    # ---- constraint bounds ----------------------------------------------
+    w(f"r")
+    for kind, g, i in rows:
+        if kind == "lin_merged":
+            lo = max(
+                abs(r.V["11"][i]) / r.C["C11"],
+                abs(r.V["21"][i]) / r.C["C21"],
+                abs(r.V["31"][i]) / r.C["C31"],
+            )
+            w(f"2 {num(lo)}")
+        elif kind == "lin":
+            grp, sgn = g
+            v = r.V[grp + "1"][i]
+            w(f"2 {num(v if sgn == '-' else -v)}")
+        else:
+            w("2 0")
+
+    # ---- variable bounds (all free) --------------------------------------
+    w("b")
+    for _ in range(n):
+        w("3")
+
+    # ---- k segment (cumulative column counts) ----------------------------
+    w(f"k{n - 1}")
+    acc = 0
+    for j in range(n - 1):
+        acc += colcount[j]
+        w(str(acc))
+
+    # ---- J segments ------------------------------------------------------
+    for ridx, entries in enumerate(jac):
+        w(f"J{ridx} {len(entries)}")
+        for j, c in entries:
+            w(f"{j} {num(c)}")
+
+    # ---- G segment -------------------------------------------------------
+    w(f"G0 {n}")
+    for j in range(n):
+        w(f"{j} {num(r.BB[j + 1])}")
+
+    with open(out_path, "w") as f:
+        f.write("\n".join(out))
+        f.write("\n")
+    sys.stderr.write(
+        f"{out_path}: n={n} m={m} (nonlinear rows {n_nl_rows}) nzJ={nzc} cse={3 * M}\n"
+    )
+
+
+if __name__ == "__main__":
+    merge = "--no-merge" not in sys.argv
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    gen(args[0], args[1], merge=merge)

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -32,7 +32,7 @@
 //! * `ref/Ipopt/test/mytoy.nl` — annotated example used for the unit
 //!   tests in this module.
 
-use crate::nl_tape::Tape;
+use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
 use pounce_common::types::{Index, Number};
 use pounce_nlp::tnlp::{
     BoundsInfo, IDX_NAMES, IndexStyle, IpoptCq, IpoptData, Linearity, MetaData, NlpInfo, Solution,
@@ -1750,6 +1750,35 @@ struct ColorWrite {
     hess_idx: u32,
 }
 
+/// Constraint-block [`HybridTape`]: one local op list per summand plus a
+/// **shared prelude** holding every CSE body referenced by two or more
+/// summands, evaluated once per sweep.
+///
+/// `con_tapes` builds an independent flat `Tape` per summand, so a `.nl`
+/// defined variable (`V` segment) referenced from many rows is re-emitted —
+/// and re-evaluated — once per reference. That is invisible on most models
+/// but quadratic-ish in the wrong shape: on Mittelmann's `robot_a`
+/// (n = 1001, m = 52013, 12003 defined variables each feeding 13 rows) the
+/// flat tapes total 3.6M ops per `eval_g` against 894k for the shared
+/// prelude — 4.0x the arithmetic, paid ~10x per iteration inside the line
+/// search. See pounce#476.
+///
+/// Only `eval_g` reads this; `eval_jac_g` / `eval_h` stay on `con_tapes`
+/// (their reverse / forward-over-reverse sweeps run once per iteration, not
+/// once per line-search trial, and `HybridTape`'s Hessian entry point uses a
+/// different seeding strategy than the coloring machinery here).
+#[derive(Debug, Clone)]
+struct ConHybrid {
+    tape: HybridTape,
+    /// `row_start[i]..row_start[i + 1]` are the summands of constraint `i`.
+    /// Length `m + 1`.
+    row_start: Vec<usize>,
+    /// Prelude forward values, sized to `tape.n_prelude_ops()`.
+    prelude_vals: Vec<f64>,
+    /// Per-summand local forward values, sized to `tape.max_summand_ops()`.
+    local_vals: Vec<f64>,
+}
+
 // `Clone` supports the batched-solve path (pounce#126): one parsed
 // model is cloned per batch instance (tapes are flat `Vec`s of ops, so
 // the clone is cheap relative to a solve) and each clone gets its own
@@ -1763,6 +1792,10 @@ pub struct NlTnlp {
     /// Per-constraint, per-summand tapes. Length `m`; row `i` holds
     /// one `Tape` per summand of constraint `i`.
     con_tapes: Vec<Vec<Tape>>,
+    /// Constraint-block tape with a **shared** CSE prelude, used by
+    /// `eval_g` when the model benefits (see [`ConHybrid`]). `None` keeps
+    /// `eval_g` on the per-summand `con_tapes` above.
+    con_hybrid: Option<ConHybrid>,
     /// Lower-triangle Hessian sparsity (row >= col), one entry per
     /// structurally nonzero second derivative in the Lagrangian.
     h_irow: Vec<i32>,
@@ -2373,15 +2406,42 @@ impl NlTnlp {
             .collect();
 
         let mut con_tapes: Vec<Vec<Tape>> = Vec::with_capacity(prob.m);
+        let mut con_roots: Vec<Expr> = Vec::new();
+        let mut row_start: Vec<usize> = Vec::with_capacity(prob.m + 1);
         for k in 0..prob.m {
             let summands = split_top_sums(&prob.con_nonlinear[k]);
+            row_start.push(con_roots.len());
             con_tapes.push(
                 summands
                     .iter()
                     .map(|e| Tape::build_with_externals(e, &resolver))
                     .collect(),
             );
+            // Move (not clone) the split summands into the root list: their
+            // `Expr::Cse` payloads are `Arc`s, and `build_multi` keys CSE
+            // sharing on `Arc` pointer identity, so the roots must be the
+            // same allocations the parse produced.
+            con_roots.extend(summands);
         }
+        row_start.push(con_roots.len());
+
+        // Shared-CSE constraint tape for `eval_g` (pounce#476). Worth
+        // building only when some CSE body is actually referenced from two
+        // or more summands — otherwise the prelude comes out empty and the
+        // hybrid tape is the flat tape plus an indirection. `hybrid_supported`
+        // gates the opcodes `build_multi` would panic on.
+        let con_hybrid = if hybrid_supported(&con_roots) {
+            let tape = HybridTape::build_multi(&con_roots);
+            (tape.n_prelude_ops() > 0).then(|| ConHybrid {
+                prelude_vals: vec![0.0; tape.n_prelude_ops()],
+                local_vals: vec![0.0; tape.max_summand_ops()],
+                row_start,
+                tape,
+            })
+        } else {
+            None
+        };
+        drop(con_roots);
 
         // Hessian-of-Lagrangian sparsity: union of each tape's own
         // structural Hessian sparsity.
@@ -2516,6 +2576,7 @@ impl NlTnlp {
             prob,
             obj_tapes,
             con_tapes,
+            con_hybrid,
             h_irow,
             h_jcol,
             jac_cols,
@@ -2876,9 +2937,12 @@ impl TNLP for NlTnlp {
     }
 
     fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        // Reuse the shared forward-value arena (sized to `max_tape_n`) so
+        // each summand sweep allocates nothing — see `Tape::eval_into`.
+        let (obj_tapes, vals) = (&self.obj_tapes, &mut self.vals_scratch);
         let mut nl: Number = 0.0;
-        for t in &self.obj_tapes {
-            nl += t.eval(x);
+        for t in obj_tapes {
+            nl += t.eval_into(x, vals);
         }
         let lin: Number = self.prob.obj_linear.iter().map(|(i, c)| c * x[*i]).sum();
         let v = self.prob.obj_constant + nl + lin;
@@ -2906,12 +2970,43 @@ impl TNLP for NlTnlp {
     }
 
     fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
-        for i in 0..self.prob.m {
-            let mut nl: Number = 0.0;
-            for t in &self.con_tapes[i] {
-                nl += t.eval(x);
+        // Constraint values are the line search's inner loop: on a
+        // constraint-heavy model (m >> n) this runs ~10x per iteration over
+        // every summand tape in the problem. Reuse the shared forward-value
+        // arena so the sweep allocates nothing — the per-summand `Vec` the
+        // allocating `Tape::eval` used to build was ~20% of `eval_g` on
+        // Mittelmann's `robot_a` (52013 rows / 148037 summands). See
+        // `Tape::eval_into`.
+        let m = self.prob.m;
+        let con_linear = &self.prob.con_linear;
+        if let Some(h) = &mut self.con_hybrid {
+            // Shared CSE bodies once for the whole constraint block, then one
+            // local sweep per summand (pounce#476).
+            let ConHybrid {
+                tape,
+                row_start,
+                prelude_vals,
+                local_vals,
+            } = h;
+            tape.forward_prelude(x, prelude_vals);
+            for i in 0..m {
+                let mut nl: Number = 0.0;
+                for s in &tape.summands[row_start[i]..row_start[i + 1]] {
+                    tape.forward_summand(s, x, prelude_vals, local_vals);
+                    nl += tape.root_value(s, local_vals);
+                }
+                let lin: Number = con_linear[i].iter().map(|(j, c)| c * x[*j]).sum();
+                g[i] = nl + lin;
             }
-            let lin: Number = self.prob.con_linear[i].iter().map(|(j, c)| c * x[*j]).sum();
+            return true;
+        }
+        let (con_tapes, vals) = (&self.con_tapes, &mut self.vals_scratch);
+        for i in 0..m {
+            let mut nl: Number = 0.0;
+            for t in &con_tapes[i] {
+                nl += t.eval_into(x, vals);
+            }
+            let lin: Number = con_linear[i].iter().map(|(j, c)| c * x[*j]).sum();
             g[i] = nl + lin;
         }
         true
@@ -4275,6 +4370,139 @@ S1 2 sens_init_constr
         assert!(tnlp.eval_grad_f(&[-2.0, 1.0], true, &mut g));
         assert!((g[0] - 12.0).abs() < 1e-9, "df/dx0 = {}", g[0]);
         assert!((g[1] - 3.0).abs() < 1e-9, "df/dx1 = {}", g[1]);
+    }
+
+    // ---- Shared-CSE constraint tape (issue #476) ----------------------
+
+    /// Three constraints over one `V` segment (a `.nl` *defined variable*),
+    /// `V3 = 2*x0 + 3*x1`, referenced by all three:
+    ///   C0: V3^2        C1: V3^3 + x2        C2: V3*x2
+    /// `{BODY2}` is a substitution point so a variant can drop an opcode the
+    /// hybrid path rejects into C2.
+    const SHARED_CSE: &str = "g3 1 1 0
+ 3 3 1 0 0
+ 3 0
+ 0 0
+ 3 0 0
+ 0 0 0 1
+ 0 0 0 0 0
+ 8 3
+ 0 0
+ 0 1 0 0 0
+V3 2 0
+0 2.0
+1 3.0
+n0
+C0
+o5
+v3
+n2
+C1
+o0
+o5
+v3
+n3
+v2
+C2
+{BODY2}
+O0 0
+n0
+r
+2 0
+2 0
+2 0
+b
+3
+3
+3
+k2
+3
+6
+J0 2
+0 0
+1 0
+J1 3
+0 0
+1 0
+2 0
+J2 3
+0 0
+1 0
+2 0
+G0 3
+0 1.0
+1 1.0
+2 1.0
+";
+
+    fn shared_cse_nl(body2: &str) -> String {
+        SHARED_CSE.replace("{BODY2}", body2)
+    }
+
+    /// A CSE referenced from several constraints is evaluated once per
+    /// `eval_g` via the shared prelude instead of once per reference. The
+    /// values must be bit-identical to the flat per-summand `Tape` path,
+    /// which is what makes the optimization safe to apply unconditionally.
+    #[test]
+    fn shared_cse_constraint_tape_matches_flat_tape_bit_for_bit() {
+        let nl = shared_cse_nl("o2\nv3\nv2");
+        let p = parse_nl_text(&nl).expect("parse shared-CSE model");
+        let mut hybrid = NlTnlp::new(p.clone());
+        hybrid.get_nlp_info().unwrap();
+        let h = hybrid
+            .con_hybrid
+            .as_ref()
+            .expect("CSE shared by 3 constraints must take the hybrid path");
+        assert!(
+            h.tape.n_prelude_ops() > 0,
+            "shared CSE body must land in the prelude"
+        );
+
+        // Same model with the hybrid path switched off: the reference.
+        let mut flat = NlTnlp::new(p);
+        flat.get_nlp_info().unwrap();
+        flat.con_hybrid = None;
+
+        for x in [[1.0, 1.0, 1.0], [-2.0, 0.5, 3.0], [0.0, -1.5, -0.25]] {
+            let mut gh = [0.0_f64; 3];
+            let mut gf = [0.0_f64; 3];
+            assert!(hybrid.eval_g(&x, true, &mut gh));
+            assert!(flat.eval_g(&x, true, &mut gf));
+            // V3 = 2 x0 + 3 x1.
+            let s = 2.0 * x[0] + 3.0 * x[1];
+            let want = [s * s, s * s * s + x[2], s * x[2]];
+            for i in 0..3 {
+                assert_eq!(gh[i], gf[i], "row {i} differs from the flat tape at {x:?}");
+                assert!(
+                    (gh[i] - want[i]).abs() < 1e-9,
+                    "row {i}: got {}, want {}",
+                    gh[i],
+                    want[i]
+                );
+            }
+        }
+    }
+
+    /// `HybridTape::build_multi` *panics* on comparisons, AND/OR/NOT,
+    /// if-then-else, min/max lists and external funcalls, so `eval_g` may only
+    /// take that path after `hybrid_supported` clears the model. Here a
+    /// min-list in one constraint has to disable it for the whole block —
+    /// falling back, not panicking.
+    #[test]
+    fn unsupported_opcode_falls_back_to_the_flat_tape() {
+        let nl = shared_cse_nl("o11\n2\nv3\nv2");
+        let p = parse_nl_text(&nl).expect("parse min-list model");
+        let mut tnlp = NlTnlp::new(p);
+        tnlp.get_nlp_info().unwrap();
+        assert!(
+            tnlp.con_hybrid.is_none(),
+            "a min-list anywhere in the constraint block must disable the hybrid path"
+        );
+        let mut g = [0.0_f64; 3];
+        assert!(tnlp.eval_g(&[-2.0, 0.5, 3.0], true, &mut g));
+        let s = 2.0 * -2.0 + 3.0 * 0.5; // -2.5
+        assert!((g[0] - s * s).abs() < 1e-9);
+        assert!((g[2] - s.min(3.0)).abs() < 1e-9, "min(V3, x2) = {}", g[2]);
     }
 
     // ---- In-memory construction + HVP (issue #469) --------------------

--- a/crates/pounce-nl/src/nl_tape.rs
+++ b/crates/pounce-nl/src/nl_tape.rs
@@ -726,6 +726,25 @@ impl Tape {
         }
     }
 
+    /// Scalar tape value, reusing a caller-supplied scratch buffer
+    /// (`vals.len() >= self.ops.len()`) instead of allocating a fresh
+    /// forward-value `Vec` per call like [`eval`]. The `.nl` design emits
+    /// one tiny tape per summand — 10⁵–10⁶ on large models — so a single
+    /// `eval_f` / `eval_g` drives this once per summand and the per-call
+    /// allocation dominated the sweep itself (same motivation as
+    /// [`gradient_seed_into`], M18).
+    ///
+    /// [`eval`]: Tape::eval
+    /// [`gradient_seed_into`]: Tape::gradient_seed_into
+    pub fn eval_into(&self, x: &[f64], vals: &mut [f64]) -> f64 {
+        let n = self.ops.len();
+        if n == 0 {
+            return 0.0;
+        }
+        self.forward_into(x, vals);
+        vals[n - 1]
+    }
+
     /// Directional Hessian-vector product: emits
     /// `weight * (∇²f · seed)[k]` into `out[k]` for every problem
     /// variable `k` the tape references. Caller supplies the
@@ -1960,7 +1979,7 @@ pub struct Summand {
     pub all_vars: Vec<usize>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HybridTape {
     /// Shared CSE bodies. Slot indices in `SummandOp::Shared`
     /// point here; this Vec is built bottom-up by `build_recursive`,
@@ -2285,6 +2304,46 @@ impl HybridTape {
 /// summand path raises. Pre-scanning makes both paths report the same
 /// reason. (Funcalls are unsupported on the hybrid path regardless of
 /// whether the id would resolve, so this never rejects a buildable tape.)
+/// Whether [`HybridTape::build_multi`] can build `exprs`, i.e. none of
+/// them uses an opcode the hybrid (partial-separability) path rejects:
+/// comparisons, AND/OR/NOT, if-then-else, min/max lists, or AMPL external
+/// function calls. `build_into_summand` *panics* on those, so a caller
+/// choosing between the hybrid path and the flat [`Tape`] path has to ask
+/// first — there is nothing to catch.
+///
+/// Walks with an explicit stack (expression DAGs from `.nl` files can be
+/// deeper than the default thread stack) and visits each shared CSE body
+/// once, so the cost is linear in the DAG rather than in its unfolding.
+pub fn hybrid_supported(exprs: &[Expr]) -> bool {
+    let mut stack: Vec<&Expr> = exprs.iter().collect();
+    let mut seen_cse: HashSet<*const Expr> = HashSet::new();
+    while let Some(e) = stack.pop() {
+        match e {
+            Expr::Const(_) | Expr::Var(_) => {}
+            Expr::Binary(_, a, b) => {
+                stack.push(a);
+                stack.push(b);
+            }
+            Expr::Unary(_, a) => stack.push(a),
+            Expr::Sum(args) => stack.extend(args.iter()),
+            Expr::Cse(body) => {
+                if seen_cse.insert(Arc::as_ptr(body)) {
+                    stack.push(body);
+                }
+            }
+            Expr::Compare(..)
+            | Expr::And(..)
+            | Expr::Or(..)
+            | Expr::Not(_)
+            | Expr::Cond { .. }
+            | Expr::MinList(_)
+            | Expr::MaxList(_)
+            | Expr::Funcall { .. } => return false,
+        }
+    }
+    true
+}
+
 fn cse_contains_funcall(expr: &Expr) -> bool {
     match expr {
         Expr::Funcall { .. } => true,

--- a/dev-notes/research/robot-abc-per-iteration-cost.md
+++ b/dev-notes/research/robot-abc-per-iteration-cost.md
@@ -1,0 +1,418 @@
+# `robot_a` / `robot_b` / `robot_c`: where the time actually goes
+
+Investigation for [pounce#476](https://github.com/jkitchin/pounce/issues/476).
+On the Mittelmann `ampl-nlp` run of 3 Aug 2026 these three instances were the
+single largest contributor to POUNCE's scaled shifted geometric mean: ~2140 s /
+2122 s / 2298 s against IPOPT's ~690 s and KNITRO's 1 s. They share the shape
+**m ≫ n** — 52013 constraints on 1001 variables, ~52:1 — which `robot_1600`
+(n ≫ m, 5 s) does not.
+
+The issue asked to separate two candidate causes, iteration *count* and *cost
+per iteration*, before optimizing either. They separate cleanly, and they belong
+to two different comparisons:
+
+- **Against IPOPT (3.1x) the whole gap is per-iteration cost.** The iteration
+  count is not merely similar, it is *identical* — POUNCE reproduces Ipopt's
+  iterates digit for digit (§1). The dominant component was an evaluation
+  strategy that re-evaluates shared subexpressions once per reference (§3);
+  fixing it took 1.28x, and condensing the KKT is worth perhaps the rest (§5).
+- **Against KNITRO (2000x) essentially none of it is per-iteration cost.** Both
+  POUNCE and IPOPT *stall*: the barrier parameter moves one level in 3000
+  iterations, on 1e-4 steps with 10–15 backtracks (§4b). Converging costs order
+  5000–10000 iterations. No amount of making an iteration cheaper closes that,
+  and POUNCE's own active-set SQP does not currently help either (§4c).
+
+§4b is the important one and it was not on the issue's checklist.
+
+## Reproducing without AMPL
+
+`benchmarks/mittelmann/gen_robot_nl.py` writes `robot_a.nl` directly from the
+`.mod` source, emitting `V` segments for the model's `SUM`/`SUM1`/`SUM2` defined
+variables. That fidelity is the whole point: inlining them (which a generic
+`.nl` writer would do) changes the tape the solver builds and would have hidden
+the finding below.
+
+It reproduces the published sizes exactly — `n = 1001`, `m = 52013`,
+`nzJ = 196781` — and IPOPT's published failure mode: 3000 iterations, no
+convergence. (Matching `m` requires one AMPL presolve step by hand: the six
+linear families `gx1/gx2/gx7/gx8/gx13/gx14` are all lower bounds on the *same*
+linear form `SUM[i]`, so they collapse to one row per collocation point,
+18·4001 → 13·4001 = 52013.)
+
+All numbers below: Apple M-series, single instance at a time, POUNCE 0.9.0 with
+FERAL, `ipopt` 3.14.19 with MUMPS 5.6.2, both reading the same `robot_a.nl`.
+
+## 1. Not a basin artifact — the iterates are Ipopt's
+
+`dev-notes/research/narx-cfy-iteration-count.md` closed a superficially similar
+symptom as a basin-of-attraction artifact, so that was ruled out first by diffing
+the two iteration logs column by column.
+
+| iterations | what matches |
+| --- | --- |
+| 0–71 | **every printed column**: objective, `inf_du`, `lg(mu)`, `‖d‖`, `alpha_du`, `alpha_pr`, `ls` — all 8 digits |
+| 72–112 | objective differs in the 7th–8th digit; every step-control column still exact |
+| 113+ | step-control columns begin to differ; by iteration 176 the objectives are 41 % apart |
+
+That is roundoff (FERAL vs MUMPS) amplified by a chaotic non-converging
+trajectory, not a different algorithm. The same sensitivity shows up *within*
+Ipopt: MUMPS reaches 8.526 at iteration 3000 here where the checked-in MA57
+reference reaches 8.173.
+
+**Conclusion:** POUNCE takes the same steps Ipopt takes, so it needs the same
+number of them. There is no iteration-count win available by making POUNCE
+*more* like Ipopt — the count is a property of the filter line-search method on
+this model, and §4b shows it is the filter's acceptance test specifically.
+
+## 2. Splitting the wall clock
+
+With the iteration count settled, the ratio is per-iteration cost, measured over
+200 iterations on the same file:
+
+| | s / iteration | vs IPOPT |
+| --- | --- | --- |
+| IPOPT 3.14.19 + MUMPS | 0.138 | 1.0× |
+| POUNCE 0.9.0 (before) | 0.270 | 1.96× |
+| POUNCE (after this change) | 0.221 | 1.60× |
+
+Main-thread profile (`sample`, 30 s window, before):
+
+| share | what |
+| --- | --- |
+| 44 % | line search — **30 % constraint evaluation** (`eval_g`), 12 % second-order correction |
+| 33 % | search direction (KKT solve) |
+| 17 % | exact Hessian (`eval_h`) |
+| 4 % | constraint Jacobian (`eval_jac_g`) |
+
+`print_timing_statistics yes` after the change, same 200 iterations (42.2 s
+total) — instrumented, and the number to plan against rather than the sampled
+percentages above:
+
+| seconds | share | |
+| --- | --- | --- |
+| 13.006 | 30.8 % | `LinearSystemFactorization` |
+| 8.559 | 20.3 % | `LinearSystemBackSolve` |
+| 9.342 | 22.1 % | `LagrangianHessianEvaluations` |
+| 4.294 | 10.2 % | `ConstraintEvaluations` |
+| 2.452 | 5.8 % | `ConstraintJacobianEvaluations` |
+
+So the linear solver is 51 % of the run split roughly 60/40 between factorizing
+and solving, and AD is 38 %. `eval_g` is the inner loop:
+the line search averages ~10 trial points per iteration on this model (Ipopt's
+own counters agree: 35398 constraint evaluations over 3000 iterations).
+
+## 3. The finding: shared subexpressions evaluated once per *reference*
+
+`NlTnlp` splits each constraint into summands and builds an independent flat
+`Tape` per summand. `Tape::build` deduplicates CSE bodies by `Arc` identity
+*within one tape*, so a `.nl` defined variable referenced from many summands is
+re-emitted — and re-evaluated — once per reference. The construction site said
+as much: "bodies shared across summands are duplicated, which we accept as a
+simplicity tradeoff".
+
+That tradeoff is invisible on most models and brutal on this shape. `robot_a`
+has 12003 defined variables (`SUM[i]`, `SUM1[i]`, `SUM2[i]` — the cubic-spline
+evaluations), each feeding 13 constraint rows, and `SUM[i]` alone is referenced
+~30 times per sweep across those rows' summands:
+
+```
+flat per-summand tapes   3 606 095 ops per eval_g
+shared-CSE prelude         893 790 ops per eval_g     (4.03x fewer)
+```
+
+`HybridTape` — per-summand local ops plus a prelude holding every CSE body
+referenced by ≥2 summands — already existed in `nl_tape.rs`, fully written with
+forward / gradient / Hessian entry points, but had **zero callers** outside its
+own tests (flagged as dead code by the 2026-06 review, item L34). It is exactly
+the fix, and it builds in 87 ms on this model.
+
+### What was changed
+
+- `eval_g` (and `eval_f`) evaluate through a problem-wide `HybridTape`: one
+  `forward_prelude` for the whole constraint block, then one local sweep per
+  summand. Gated on `hybrid_supported` — the hybrid builder *panics* on
+  comparisons, AND/OR/NOT, if-then-else, min/max lists and external funcalls, so
+  models using those keep the flat path — and on the prelude coming out
+  non-empty, so models with nothing to share are untouched.
+- `eval_g`/`eval_f` also stopped allocating: they called `Tape::eval`, which
+  allocates a `Vec<f64>` per summand — ~148k allocations per call here, ~20 % of
+  `eval_g`. New `Tape::eval_into` reuses the existing `vals_scratch` arena, the
+  same fix `eval_jac_g`/`eval_grad_f` already had (M18).
+
+Result on `robot_a`, 200 iterations, median of 3 interleaved runs:
+**56.9 s → 44.2 s (−22 %)**, with a bit-identical iteration trajectory.
+`eval_g` fell from 30 % of the run to 9.5 %.
+
+### Why `eval_jac_g` / `eval_h` were left on the flat path
+
+The prelude is only shared in the *forward value* sweep, where one pass serves
+all 148037 summands. `gradient_summand` / `hessian_summand` each walk their own
+summand's `prelude_reach` for their adjoint pass, so nothing amortizes across
+summands — measured op counts come out roughly even with the flat tapes, for a
+much larger change (`hessian_summand` seeds per variable and would displace the
+Hessian-coloring machinery). Not worth it on this evidence.
+
+## 4. The linear algebra is not the problem
+
+Worth recording, because the issue suspected "a bad path in factorization or in
+how we assemble/scale the augmented system" on the 52:1 shape. It is not:
+
+- KKT is 105027 × 105027 with 356818 nonzeros; the factor has 565826. Max fill
+  ratio 1.586 — the ordering is doing its job on this block structure.
+  (Dimension is `n_x + n_s + n_c + n_d` = 1001 + 52013 + 0 + 52013: Ipopt's
+  formulation carries one slack *and* one multiplier per inequality row. The
+  nonzero count confirms the layout exactly — 3998 `W` + 52013 `(2,2)` +
+  196781 `J_d` + 52013 `-I` + 52013 `(4,4)` = 356818.)
+- 372 factorizations over 200 iterations (1.86/iteration, i.e. inertia
+  correction is retrying about once per iteration).
+- Inside FERAL the *refinement* outweighs the factorization (4820 vs 3231
+  worker-pool samples). If the KKT share is attacked next, iterative refinement
+  is where the time is, not the numeric factorization.
+
+Inequality/bound handling is not the driver either: all 52013 rows are one-sided
+inequalities, there are no equalities and no variable bounds, and POUNCE's steps
+match Ipopt's exactly (§1). The control instance is consistent with the CSE
+story rather than with an aspect-ratio story per se — `robot_1600` also has
+defined variables (`I_the`, `I_phi`), but each is referenced by only 2
+constraints, so its redundancy factor is ~2 rather than ~13.
+
+## 4b. The barrier parameter barely moves — this is a *stall*, not slowness
+
+Counting `lg(mu)` across the iteration logs reframes everything above:
+
+| solver | iterations | distinct `mu` values reached |
+| --- | --- | --- |
+| POUNCE | 201 | `1e-1` only — **`mu` never decreased once** |
+| IPOPT + MUMPS | 3000 | `1e-1` for 370 iterations, then `~2e-2` for 2631 |
+
+An interior-point method has to walk `mu` down to ~`1e-9` to hit `tol = 1e-8`,
+i.e. nine or ten barrier levels. IPOPT managed **one** in 3000 iterations. Both
+solvers sit at tiny steps with 10–15 backtracks per iteration (`alpha_pr` of
+1e-4 to 1e-5) for the entire run.
+
+So `robot_a` is not a model where the filter line-search IPM is *slow*; it is
+one where it **stalls on the barrier subproblem**, and the published times
+(IPOPT 688 s, POUNCE 2140 s) are what it costs to grind through the stall —
+order 5000 and 10000 iterations respectively at the per-iteration costs measured
+in §2.
+
+That resets the priority order. Per-iteration cost is worth maybe 1.5–1.7x more
+(§3 already took 1.28x of it, condensing might take the rest). The stall is
+worth two to three orders of magnitude, and it is shared with IPOPT — which
+means it is a property of the algorithm on this model, and the place to look is
+why the filter admits only 1e-4 steps here, not how fast each one is computed.
+That deserves its own issue, and it is the honest answer to "what would close
+the gap to KNITRO".
+
+### The stall is the filter's acceptance test — and it costs ~80x
+
+`accept_every_trial_step=yes` (accept the first trial point; no filter, no
+Armijo test) turns the instance from "does not converge in 3000 iterations" into
+a converged, independently verified solution:
+
+| | iterations | wall clock | objective | status |
+| --- | --- | --- | --- | --- |
+| POUNCE default | 3000+ | 2140 s (Mittelmann) | — | grinds |
+| **POUNCE `accept_every_trial_step=yes`** | **119** | **13.8 s** | 1.0431952 | Optimal |
+| IPOPT default | 3000+ | 688 s (Mittelmann) | — | grinds |
+| **IPOPT `accept_every_trial_step=yes`** | **116** | **8.7 s** | 1.0432009 | Optimal |
+
+`pounce verify` on the POUNCE result, independently of the solver that produced
+it: max constraint violation `0.000e0`, KKT stationarity residual `2.297e-11`,
+complementarity `1.022e-9` — **VERIFIED**. And the objective is far *better*
+than what either solver reaches by grinding (IPOPT sits at 8.17 with MA57 /
+8.53 with MUMPS at its 3000-iteration cap).
+
+Both solvers agree to 6 digits, so this is a property of the filter
+line-search method, not a POUNCE defect — the same conclusion §1 reached from
+the other direction. It also demystifies KNITRO: on this machine a solver that
+simply does not fall into this stall finishes in ~10 s. No decomposition or
+exotic algorithm is needed to explain 1 s on a faster box with MA57.
+
+**This is a diagnostic, not a fix.** `accept_every_trial_step` discards the
+global convergence safeguard and must not become a default. What it establishes
+is *where* the 80x lives: the acceptance test rejects a path that is not merely
+viable but better.
+
+### None of the safe knobs reproduce it
+
+All of Ipopt's anti-stall machinery is present (`mu_strategy`, `mu_oracle`,
+`corrector_type`, `max_soc`, watchdog, restoration, `nlp_scaling_method`).
+Tried, 200 iterations unless noted, `lg(mu)` reached being the progress metric —
+the barrier has to walk from -1 to about -9:
+
+| variant | `lg(mu)` reached | levels | note |
+| --- | --- | --- | --- |
+| default | **-1.0** | 1 | never moves |
+| `nlp_scaling_method=none` | -1.7 | 2 | |
+| `mu_strategy=adaptive` | -1.8 | 4 | |
+| `+ corrector_type=affine` | -1.8 | 4 | identical to plain adaptive |
+| `+ mu_oracle=probing` | -3.5 | 5 | best safe result; still short at 2950 iters |
+| `max_soc=0` (3000 iters) | -8.6 | 5 | μ moves, but lands on obj 22.1 vs 1.04 |
+| `accept_every_trial_step=yes` | **-9.0** | 6 | converges, 119 iterations |
+
+So this is a research question, not an option-tuning exercise.
+
+**Lead hypothesis for whoever picks this up.** With 52013 inequalities and *no*
+equalities, the slacks track `c(x)` exactly and the filter's `theta` is
+structurally ~0 (that is precisely why Ipopt prints `inf_pr = 0.00e+00`
+throughout — see §6). A filter whose `theta` is always zero degenerates into a
+pure Armijo test on the barrier objective `phi_mu = f - mu * sum(ln s_i)`. On
+this shape that sum has 52013 terms against a 1001-variable `f`, so the barrier
+utterly dominates the objective and the predicted decrease is a poor model of
+the actual one — which is exactly the regime where Armijo drives `alpha` to
+1e-4. That would explain all three observations at once: the stall, its being
+shared with Ipopt, and its being specific to m >> n.
+
+Check first, because it is cheap and would change the diagnosis: confirm
+POUNCE's filter really is using Ipopt's `theta` and not the different quantity
+it *reports* as `inf_pr` (§6). The identical 71-iteration trajectory says it is,
+but that assumption is load-bearing for the hypothesis above.
+
+## 4c. POUNCE's own active-set SQP is much worse here, not better
+
+`algorithm=active-set-sqp` is the obvious thing to try given §5's hypothesis
+that an active-set route is what makes this model cheap. It does not work on
+this instance:
+
+| `sqp_qp_max_iter` | wall clock | SQP major iterations completed |
+| --- | --- | --- |
+| 5 | 1.5 s | 0 |
+| 20 | 4.8 s | 0 |
+| 50 | 11.1 s | 0 |
+| 200 (default) | 42.8 s | 0 |
+
+Time is exactly linear in the QP pivot cap at ~0.22 s per pivot, and the **first
+QP subproblem never completes** — the solver evaluates the model once and then
+exhausts its pivot budget. A cold-start working set for a 1001-variable QP needs
+on the order of 1001 pivots, i.e. ≳ 220 s for the first subproblem alone, before
+any SQP major iteration happens.
+
+0.22 s per pivot is itself anomalous for a 1001-variable QP — pricing 52013
+rows is a 196781-nonzero matvec, microseconds. Unverified hypothesis: the QP
+inner solver is refactorizing a KKT that still carries all 52013 constraint
+rows rather than just the working set (`sqp_qp_max_schur_updates_before_refactor`
+would set the cadence). Worth checking before anyone concludes "active-set does
+not suit this model" — the current evidence only says *our* active-set path does
+not, and it may be for an incidental reason.
+
+## 5. What is left, and the KNITRO question
+
+After this change the profile is KKT-dominated: search direction 43 %, exact
+Hessian 22 %, line search 26 % (of which `eval_g` is 9.5 %), Jacobian 5 %.
+
+The remaining structural idea is **condensing the augmented system**. With only
+inequalities, blocks 2 and 4 of the KKT layout in `std_aug_system_solver.rs`
+have diagonal (2,2) and (4,4) and a `-I` at (4,2), so `Δs` and `Δv_d` can be
+eliminated analytically, leaving
+
+```text
+  (W + D_x + δ_x + J_dᵀ Σ J_d) Δx = rhs,   Σ = (D_s+δ_s)[I + (D_d+δ_d)(D_s+δ_s)]⁻¹
+```
+
+with `Σ` diagonal. On `robot_a` that replaces a **105027 × 105027** indefinite
+factorization (565826 factor nonzeros, ~1.86 of them per iteration) with a
+**1001 × 1001** one. And `J_dᵀ Σ J_d` costs nothing here: every row of `J_d`
+touches 4 *consecutive* variables (the cubic-spline support), so the product is
+banded with half-bandwidth 3 and 3998 lower-triangle nonzeros — bit-for-bit the
+same sparsity as `W` itself. A banded Cholesky on that is microseconds.
+
+Three things make it real work rather than a rewrite of `solve_once`:
+
+- **Inertia.** The full-space `LDLᵀ` hands the algorithm its inertia, which is
+  what drives `δ_x` regularization (the `lg(rg)` column, and the 1.86
+  factorizations per iteration). Condensed, the eliminated block has known sign,
+  so Sylvester's law fixes its inertia a priori and a *failed Cholesky* stands
+  in for "wrong inertia" — the same argument `schur_aug_system_solver.rs`
+  already makes for its partition.
+- **Conditioning.** `Σ ~ z/s` spans many orders of magnitude near convergence,
+  so `JᵀΣJ` squares an already-bad condition number. This is exactly why Ipopt
+  defaults to the full space. Refinement has to run against the *unreduced*
+  residual — which POUNCE already does, and where its linear-solver time
+  already goes.
+- **A gate.** `JᵀΣJ` is only sparse when `J`'s rows have small overlapping
+  support; one dense-ish row makes it dense. Needs a symbolic `nnz(JᵀJ)`
+  estimate up front and a permanent, transparent fallback — the discipline
+  `SchurAugSystemSolver` already implements against `max_schur_frac`.
+
+The seam exists: `AugSystemSolver` is a trait, and `SchurAugSystemSolver` is
+already a second implementation that wraps `StdAugSystemSolver`, reuses its
+assembly and RHS packing, routes the factorization elsewhere, and falls back
+permanently on a cheap structural test. A condensed solver is a third
+implementation of the same shape, not surgery on the algorithm.
+
+**Expected value, and why it should be spiked before it is scheduled.** Against
+the instrumented split in §2: the 13.0 s of factorization (31 %) is what
+collapses — 105027 indefinite → 1001 banded. The 8.6 s of back-solve (20 %)
+mostly does *not*. The triangular solves shrink with the factor, but the
+expansion back to `Δs` / `Δv_d` is still O(m) per solve, and iterative
+refinement has to run against the unreduced residual to be trustworthy, which
+means a matvec with the full 356818-nonzero KKT on every refinement step. Best
+case is therefore roughly 42 s → 25 s, ~1.7x, putting POUNCE at ~0.12 s per
+iteration against IPOPT/MUMPS's 0.138 — ahead, for the first time on this shape.
+
+Two things could eat that, and one of them is serious:
+
+- **Conditioning (the real risk).** The reported pivot range on the full-space
+  system is already `min_abs_pivot = 6.1e-08` against `max_abs_pivot = 1.6e+07`
+  — fourteen orders of magnitude before condensing. `Σ ~ z/s` grows without
+  bound as the barrier parameter falls, and `JᵀΣJ` *squares* the condition
+  number. If that forces more refinement steps, the 20 % back-solve grows and
+  can swallow the 31 % that was saved. This is not a hypothetical concern; it is
+  the documented reason Ipopt keeps the full space by default.
+- **Forming the product.** `JᵀΣJ` is rebuilt whenever `Σ` changes: 52013 rows ×
+  a 4×4 outer product ≈ 0.8M FMAs plus scatter, per assembly, ~372 assemblies
+  per 200 iterations. Small against 13 s, but not zero.
+
+One thing gets *better*: at 372 factorizations per 200 iterations the algorithm
+is retrying inertia correction ~1.86 times per iteration, and in condensed form
+each retry is a failed Cholesky rather than a fresh indefinite factorization.
+
+So the cheap experiment first: dump `J_d`, `Σ` and `W` from a *late* iterate
+(small `mu`, where conditioning is worst), form the condensed matrix offline,
+and check that Cholesky succeeds and the refined solution matches the
+full-space one. That costs an afternoon and either de-risks the whole feature
+or kills it before anyone writes a `CondensedAugSystemSolver`.
+
+**And it is a per-iteration play only** — see §4b, which is the bigger term by
+two or three orders of magnitude. Scope condensing as "beat IPOPT on m ≫ n",
+not "match KNITRO".
+
+On KNITRO, being careful about what is measured and what is inferred. Nothing
+here was run against KNITRO — the 1 s is Mittelmann's published wall clock, and
+wall clock to a verified solution is the only cross-solver quantity that is
+apples-to-apples. *Iteration* counts are not: KNITRO is a different algorithm
+family, and an SLQP major iteration (an LP subproblem plus its simplex minors)
+is not the same unit of work as a filter-IPM iteration. So "KNITRO takes fewer
+iterations" is not a claim this note can make.
+
+What it can bound: one constraint sweep of this model costs 2.1 ms
+(4.294 s / 2056 evaluations), which is a floor per iteration for anything doing
+comparable AD over 52013 rows. Even with free linear algebra and no line search
+that is at most ~500 sweeps inside 1 s, against the 3000+ iterations IPOPT
+burns here *without converging*. So whatever KNITRO does, it is doing an order
+of magnitude less total work — not the same work faster.
+
+The plausible mechanism is the one the issue proposed. `robot_a` is a
+discretized semi-infinite program: one continuous constraint family sampled at
+4001 collocation points × 18 families. At a nondegenerate solution at most
+n = 1001 of the 52013 rows can be active, so ~98 % are slack — and an
+active-set method only ever works with the small active set, while an IPM
+carries every row in the KKT system at every iteration and assigns all of them
+a nonzero multiplier. Our own run shows exactly that: at iteration 200, 99.8 %
+of the 52013 multipliers are above 1e-8 of the largest. That is a different
+project from condensing, and the more likely route to KNITRO's number.
+
+## 6. Loose end: `inf_pr` means something different from Ipopt's
+
+Not a performance issue, but it surfaced while diffing the logs and is worth its
+own look. On this pure-inequality model Ipopt reports `inf_pr = 0.00e+00` for
+almost every iteration and a final "Constraint violation: 0.0"; POUNCE reports
+1.25e+00 scaled / 2.79e+04 unscaled at the same iterate. The trajectories are
+identical, so the filter is not being driven by different values — the two are
+reporting different quantities: Ipopt's is the residual ‖c(x) − s‖ of its own
+slack reformulation (structurally zero while the slacks track), POUNCE's is the
+violation of the original row bounds. POUNCE's number is arguably the more
+useful one, but for a solver that advertises drop-in Ipopt compatibility a
+headline metric that reads "infeasible" where Ipopt reads "feasible" is a
+compatibility wart.

--- a/dev-notes/research/robot-abc-per-iteration-cost.md
+++ b/dev-notes/research/robot-abc-per-iteration-cost.md
@@ -253,21 +253,61 @@ the barrier has to walk from -1 to about -9:
 
 So this is a research question, not an option-tuning exercise.
 
-**Lead hypothesis for whoever picks this up.** With 52013 inequalities and *no*
-equalities, the slacks track `c(x)` exactly and the filter's `theta` is
-structurally ~0 (that is precisely why Ipopt prints `inf_pr = 0.00e+00`
-throughout — see §6). A filter whose `theta` is always zero degenerates into a
-pure Armijo test on the barrier objective `phi_mu = f - mu * sum(ln s_i)`. On
-this shape that sum has 52013 terms against a 1001-variable `f`, so the barrier
-utterly dominates the objective and the predicted decrease is a poor model of
-the actual one — which is exactly the regime where Armijo drives `alpha` to
-1e-4. That would explain all three observations at once: the stall, its being
-shared with Ipopt, and its being specific to m >> n.
+**Mechanism: characterized, not yet diagnosed.** An earlier draft of this note
+proposed that with no equality constraints the filter's `theta` is structurally
+~0, degenerating the filter into a pure Armijo test. **That is wrong** —
+`POUNCE_DBG_LS=1 RUST_LOG=pounce::linesearch=debug` dumps the acceptor's own
+`theta`/`phi` per accepted step, and `theta` is ~1e4, not 0:
 
-Check first, because it is cheap and would change the diagnosis: confirm
-POUNCE's filter really is using Ipopt's `theta` and not the different quantity
-it *reports* as `inf_pr` (§6). The identical 71-iteration trajectory says it is,
-but that assumption is load-bearing for the hypothesis above.
+```
+iter=14 mu=1.0e-1 alpha=2.062e-5 mode=f theta=9.820150e3 phi=-1.447839e4 n_steps=6
+iter=17 mu=1.0e-1 alpha=4.883e-4 mode=f theta=9.935307e3 phi=-1.464936e4 n_steps=11
+iter=25 mu=1.0e-1 alpha=1.562e-2 mode=f theta=9.716279e3 phi=-1.574878e4 n_steps=6
+```
+
+What is actually established:
+
+- `theta` climbs from 0 to ~9.9e3 in the first 14 iterations and then **pins
+  there** — the iterates are not converging to feasibility at all.
+- `phi` decreases steadily and monotonically the whole time.
+- `alpha` is 1e-5 to 1e-2 with 5–11 backtracks per iteration.
+- Every accepted step in POUNCE's first 200 iterations is **f-type** (`f`=155,
+  `w`=36, `F`=9) — Armijo-governed, filter not consulted. POUNCE and IPOPT have
+  *identical* accept-character sequences over those 200, another confirmation of
+  §1.
+- Over IPOPT's full 3000 the profile inverts: `h`=2014, `w`=679, `f`=294. So the
+  governing test **changes character** across the run — Armijo early,
+  filter-dominated late, with 2014 entries accumulating in the filter.
+
+So the honest state is: we know the barrier subproblem at `mu = 1e-1` is never
+solved, that `theta` stalls at ~1e4 while `phi` falls, and that bypassing the
+acceptance test entirely reaches a verified solution. We do **not** yet know
+which of the two regimes above is causal. Nobody should design a fix before
+running the `POUNCE_DBG_LS` trace out to several hundred iterations and through
+the f-type-to-h-type transition — that trace is cheap and is the obvious next
+step.
+
+**A caution on the "better objective".** `robot_a` is nonconvex (the constraint
+bodies carry `S^3` and `S^5`), so `accept_every_trial_step` landing at 1.0432
+against 8.17 may simply be a different basin rather than evidence the filter
+steers wrong. The 80x — converges at all, versus does not — is solid. "Finds a
+better optimum" is weaker evidence than it first looks.
+
+**Sizing a safe fix.** Three tiers, in increasing risk:
+
+1. *Detect and report* (low risk, useful regardless). `mu` failing to move for N
+   iterations while steps are still being accepted is a crisp, cheap signal.
+   POUNCE already has the machinery — `DiagnosticsState`, and a `find_stalls`
+   tool in the studio MCP server. Turning a silent 2140 s grind into "barrier
+   stalled at mu=1e-1 since iteration 14" is worth doing on its own.
+2. *Escalate on detection* (medium). There is in-repo precedent: the
+   `mu_strategy_fallback` option is a POUNCE addition with no Ipopt counterpart,
+   so "strategy X stalled, switch to Y" is an established pattern here. Safety
+   depends entirely on the escalation being bounded and revertible.
+3. *Change the acceptance test* (high — a research project, not a patch). It
+   touches every model, it forfeits the digit-for-digit Ipopt equivalence that
+   made this whole investigation tractable (§1), and it needs its own global
+   convergence argument. Gate on the full benchmark suite, not on `robot_a`.
 
 ## 4c. POUNCE's own active-set SQP is much worse here, not better
 


### PR DESCRIPTION
Investigation of the `robot_a`/`robot_b`/`robot_c` gap, plus the one fix it
turned up that is safe to land now.

Refs #476 — **deliberately not a closing keyword.** This lands one of the two
causes found. The larger one is a filter stall that no code here addresses; see
"What this does *not* fix" below, which is the more important half of this PR.

## What changed

`NlTnlp` builds an independent flat `Tape` per constraint summand, and
`Tape::build` deduplicates CSE bodies only *within* one tape — so a `.nl`
defined variable (`V` segment) referenced from many summands was re-emitted, and
re-evaluated, once per reference. The construction site said so outright:
"bodies shared across summands are duplicated, which we accept as a simplicity
tradeoff".

Invisible on most models, dominant when m >> n. `robot_a` (n=1001, m=52013) has
12003 defined variables each feeding 13 rows, so `SUM[i]` alone is evaluated
~30 times per constraint sweep. `eval_g` is the line search's inner loop
(~10 trial points per iteration), so that redundancy was 30% of the run.

`HybridTape` — per-summand local ops plus a prelude of every CSE body referenced
by >=2 summands — already existed in `nl_tape.rs`, fully written with forward /
gradient / Hessian entry points, and had **zero callers** outside its own tests
(flagged as dead code by the 2026-06 review, item L34). It is exactly the fix.
Wired into `eval_g`: one `forward_prelude` for the whole constraint block, then
one local sweep per summand.

```
flat per-summand tapes   3 606 095 ops per eval_g
shared-CSE prelude         893 790 ops per eval_g     (4.03x fewer, 87 ms to build)
```

Also: `eval_g`/`eval_f` stopped allocating. They called `Tape::eval`, which
builds a `Vec<f64>` per summand — ~148k allocations per call here, ~20% of
`eval_g`. New `Tape::eval_into` reuses the `vals_scratch` arena
`eval_jac_g`/`eval_grad_f` already use (M18).

## Results

`robot_a`, 200 iterations, median of 3 interleaved runs: **56.9 s -> 44.2 s
(-22%)**, iteration trajectory **bit-identical**. `eval_g` fell from 30% of the
run to 9.5%. Per-iteration cost against `ipopt` 3.14.19 + MUMPS on the same
`.nl` went from 1.96x to 1.60x.

`eval_jac_g`/`eval_h` stay on the flat tapes deliberately — the prelude is only
shared in the forward *value* sweep, so their per-summand adjoint passes gain
nothing for a much larger change.

## Safety

Gated two ways, so nothing else changes path:

- `hybrid_supported` rejects the opcodes `build_multi` *panics* on (comparisons,
  AND/OR/NOT, if-then-else, min/max lists, external funcalls) — there is nothing
  to catch, so the caller has to ask first.
- An empty prelude means nothing was shared, so the hybrid tape would be the
  flat tape plus an indirection.

Verification:

- All **42** `.nl` fixtures in the tree: identical status, objective and
  iteration count before/after.
- **2404** workspace tests pass (`--exclude pounce-hsl`); `cargo fmt --check`
  clean; CI's gated clippy (`-D clippy::correctness -D clippy::suspicious`)
  clean.
- Adds the **first V-segment test coverage in the repo** — there was none. One
  test pins the hybrid path bit-for-bit against the flat path; one pins the
  fallback. Fail-first confirmed on the fallback test: forcing
  `hybrid_supported` to return `true` makes it panic with the
  hybrid-unsupported message.

## Reproducing

`benchmarks/mittelmann/gen_robot_nl.py` writes `robot_a`/`b`/`c` straight to
`.nl` with **no AMPL licence** — it emits the `V` segments rather than inlining
them, which is the whole point here, and hits the published `n=1001`,
`m=52013`, `nzJ=196781` exactly.

## What this does *not* fix — please read before closing #476

Full write-up: `dev-notes/research/robot-abc-per-iteration-cost.md`.

**1. The iteration count is inherited from Ipopt, not a POUNCE weakness.**
POUNCE reproduces Ipopt's iterates *digit for digit* on every printed column for
the first 71 iterations from the same file. Not a basin artifact.

**2. The dominant cost is a filter stall worth ~80x, and no code here touches
it.** `mu` moves one barrier level in 3000 iterations. With
`accept_every_trial_step=yes` — a diagnostic, not a shippable default, since it
discards the global convergence safeguard — **both** solvers converge:

| | iterations | wall clock | objective | status |
| --- | --- | --- | --- | --- |
| POUNCE default | 3000+ | 2140 s (Mittelmann) | — | grinds |
| POUNCE `accept_every_trial_step=yes` | **119** | **13.8 s** | 1.0431952 | Optimal |
| IPOPT default | 3000+ | 688 s (Mittelmann) | — | grinds |
| IPOPT `accept_every_trial_step=yes` | **116** | **8.7 s** | 1.0432009 | Optimal |

`pounce verify` on the POUNCE result, independent of the solver that produced
it: max constraint violation `0.000e0`, KKT stationarity residual `2.297e-11`,
complementarity `1.022e-9` — VERIFIED. The objective is far *better* than the
8.17 IPOPT reaches by grinding to its cap. No safe option combination
reproduces it (`mu_strategy=adaptive` + `mu_oracle=probing` is the best, at
`lg(mu) = -3.5`). This also demystifies KNITRO's 1 s: a solver that simply does
not fall into this stall finishes in ~10 s on this machine — no decomposition or
exotic algorithm needed to explain it.

**3. Condensing the KKT** (105027x105027 -> 1001x1001 banded, which on this
model has the same sparsity as `W` itself) is worth ~1.7x, with a real
conditioning risk — the note recommends spiking it before scheduling it.
Separately, POUNCE's own `algorithm=active-set-sqp` completes **zero** major
iterations on this instance at ~0.22 s per QP pivot, possibly for an incidental
reason worth checking before concluding anything about the method.

**4. Loose end:** POUNCE's `inf_pr` reports a different quantity from Ipopt's on
pure-inequality models (row violation vs slack residual). Cosmetic here, but a
drop-in-compatibility wart.

Items 2–4 want their own issues. Item 2 is the one that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WfUwpgSMtNmWtdgSC6jqah
