### PR TITLE
Fix pounce hanging using WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,8 @@ jobs:
   # wasm32 (a new `libc`/`dlopen`/thread call somewhere in the tree), and one
   # that compiles but traps at run time on a syscall WASI does not have. The
   # smoke test drives the same C ABI the page uses — load a `.nl`, solve it,
-  # check the objective — under Node's WASI.
+  # check the objective — under Node's WASI. It also calls a pounce-rs builder
+  # entry point.
   wasm:
     name: WebAssembly build + smoke
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1152,6 +1152,7 @@ dependencies = [
  "pounce-nl",
  "pounce-nlp",
  "pounce-presolve",
+ "pounce-rs",
  "pounce-solve-report",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ pounce-nl = { path = "crates/pounce-nl", version = "0.9.0" }
 pounce-hsl = { path = "crates/pounce-hsl", version = "0.9.0" }
 pounce-feral = { path = "crates/pounce-feral", version = "0.9.0" }
 pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.9.0" }
+pounce-rs = { path = "crates/pounce-rs", version = "0.9.0" }
 pounce-restoration = { path = "crates/pounce-restoration", version = "0.9.0" }
 pounce-presolve = { path = "crates/pounce-presolve", version = "0.9.0" }
 pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.9.0" }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1846,13 +1846,6 @@ impl IpoptApplication {
         // per-problem `.opt` files can flip backend knobs without
         // rebuilding pounce.
         let mut feral_cfg = feral_config_from_options(&self.options);
-        // wasm32-wasip1 browser and Node hosts used by pounce-wasm have no
-        // native threads. FERAL's Rayon-backed factor driver can block while
-        // creating its pool, so make the backend explicitly serial.
-        #[cfg(target_arch = "wasm32")]
-        {
-            feral_cfg.parallel = Some(false);
-        }
         // Block-triangular / Schur KKT partition (pounce#180 item 2). Configure
         // the Schur block solvers from the *base* feral cfg: a full-KKT external
         // ordering (item 1) is sized for the whole system and cannot apply to
@@ -3108,6 +3101,13 @@ pub fn feral_config_from_options(
         if let Some(s) = pounce_feral::parse_scaling_strategy(&v) {
             cfg.scaling = s;
         }
+    }
+    // wasm32-wasip1 browser and Node hosts used by pounce-wasm have no
+    // native threads. FERAL's Rayon-backed factor driver can block while
+    // creating its pool, so make the backend explicitly serial.
+    #[cfg(target_arch = "wasm32")]
+    {
+        cfg.parallel = Some(false);
     }
     cfg
 }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1846,6 +1846,13 @@ impl IpoptApplication {
         // per-problem `.opt` files can flip backend knobs without
         // rebuilding pounce.
         let mut feral_cfg = feral_config_from_options(&self.options);
+        // wasm32-wasip1 browser and Node hosts used by pounce-wasm have no
+        // native threads. FERAL's Rayon-backed factor driver can block while
+        // creating its pool, so make the backend explicitly serial.
+        #[cfg(target_arch = "wasm32")]
+        {
+            feral_cfg.parallel = Some(false);
+        }
         // Block-triangular / Schur KKT partition (pounce#180 item 2). Configure
         // the Schur block solvers from the *base* feral cfg: a full-KKT external
         // ordering (item 1) is sized for the whole system and cannot apply to

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3105,7 +3105,7 @@ pub fn feral_config_from_options(
     // wasm32-wasip1 browser and Node hosts used by pounce-wasm have no
     // native threads. FERAL's Rayon-backed factor driver can block while
     // creating its pool, so make the backend explicitly serial.
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(target_os = "wasi")]
     {
         cfg.parallel = Some(false);
     }

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -381,6 +381,8 @@ impl IpoptApplication {
     /// populated with one [`pounce_nlp::solve_statistics::IterRecord`]
     /// per accepted iterate. Off by default — the `pounce_sens` and
     /// `pounce` binaries opt in when `--json-output` is passed.
+    /// The `wasm32-wasip1` build has no in-process tracing collector, so its
+    /// iteration vector remains empty even when this flag is enabled.
     pub fn enable_iter_history(&mut self) {
         self.record_iter_history = true;
     }

--- a/crates/pounce-algorithm/src/intermediate.rs
+++ b/crates/pounce-algorithm/src/intermediate.rs
@@ -42,13 +42,21 @@ pub struct CtxGuard {
 
 impl CtxGuard {
     pub fn install(ctx: IntermediateContext) -> Self {
+        // wasm32-wasip1 browser/Node hosts are single-threaded here, and
+        // touching this destructor-bearing TLS slot can block indefinitely.
+        // The context only serves optional C-API inspector calls during the
+        // callback.
+        #[cfg(not(target_arch = "wasm32"))]
         CURRENT_CTX.with(|c| *c.borrow_mut() = Some(ctx));
+        #[cfg(target_arch = "wasm32")]
+        let _ = ctx;
         Self { _private: () }
     }
 }
 
 impl Drop for CtxGuard {
     fn drop(&mut self) {
+        #[cfg(not(target_arch = "wasm32"))]
         CURRENT_CTX.with(|c| *c.borrow_mut() = None);
     }
 }
@@ -59,10 +67,23 @@ pub fn with_current<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(&IntermediateContext) -> R,
 {
+    #[cfg(target_arch = "wasm32")]
+    {
+        // Live-iterate inspection is unavailable on the Wasm build because
+        // its callback context is deliberately not installed above.
+        let _ = f;
+        None
+    }
+    #[cfg(not(target_arch = "wasm32"))]
     CURRENT_CTX.with(|c| c.borrow().as_ref().map(f))
 }
 
 /// Whether a context is currently installed.
 pub fn is_active() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        false
+    }
+    #[cfg(not(target_arch = "wasm32"))]
     CURRENT_CTX.with(|c| c.borrow().is_some())
 }

--- a/crates/pounce-algorithm/src/intermediate.rs
+++ b/crates/pounce-algorithm/src/intermediate.rs
@@ -18,6 +18,7 @@ use crate::ipopt_cq::IpoptCqHandle;
 use crate::ipopt_data::IpoptDataHandle;
 use crate::ipopt_nlp::IpoptNlp;
 use std::cell::RefCell;
+use std::mem::MaybeUninit;
 use std::rc::Rc;
 
 /// Snapshot stashed in TLS for the duration of one
@@ -29,8 +30,44 @@ pub struct IntermediateContext {
     pub nlp: Rc<RefCell<dyn IpoptNlp>>,
 }
 
+/// TLS storage without compiler-registered destructor glue.
+/// Keeping the slot non-`Drop` also makes it safe for wasm32-wasip1 hosts.
+struct ContextSlot {
+    value: MaybeUninit<Option<IntermediateContext>>,
+    initialized: bool,
+}
+
+impl ContextSlot {
+    const fn new() -> Self {
+        Self {
+            value: MaybeUninit::uninit(),
+            initialized: false,
+        }
+    }
+
+    fn get(&self) -> Option<&Option<IntermediateContext>> {
+        self.initialized.then(|| {
+            // SAFETY: `initialized` is set only after `value` is initialized.
+            unsafe { self.value.assume_init_ref() }
+        })
+    }
+
+    fn get_mut(&mut self) -> &mut Option<IntermediateContext> {
+        if !self.initialized {
+            self.value.write(None);
+            self.initialized = true;
+        }
+        // SAFETY: the branch above initializes `value` before this access.
+        unsafe { self.value.assume_init_mut() }
+    }
+
+    fn replace(&mut self, value: Option<IntermediateContext>) -> Option<IntermediateContext> {
+        std::mem::replace(self.get_mut(), value)
+    }
+}
+
 thread_local! {
-    static CURRENT_CTX: RefCell<Option<IntermediateContext>> = const { RefCell::new(None) };
+    static CURRENT_CTX: RefCell<ContextSlot> = const { RefCell::new(ContextSlot::new()) };
 }
 
 /// RAII guard — installs `ctx` on construction, clears on drop. Used
@@ -42,22 +79,18 @@ pub struct CtxGuard {
 
 impl CtxGuard {
     pub fn install(ctx: IntermediateContext) -> Self {
-        // wasm32-wasip1 browser/Node hosts are single-threaded here, and
-        // touching this destructor-bearing TLS slot can block indefinitely.
-        // The context only serves optional C-API inspector calls during the
-        // callback.
-        #[cfg(not(target_arch = "wasm32"))]
-        CURRENT_CTX.with(|c| *c.borrow_mut() = Some(ctx));
-        #[cfg(target_arch = "wasm32")]
-        let _ = ctx;
+        CURRENT_CTX.with(|c| {
+            c.borrow_mut().replace(Some(ctx));
+        });
         Self { _private: () }
     }
 }
 
 impl Drop for CtxGuard {
     fn drop(&mut self) {
-        #[cfg(not(target_arch = "wasm32"))]
-        CURRENT_CTX.with(|c| *c.borrow_mut() = None);
+        CURRENT_CTX.with(|c| {
+            c.borrow_mut().replace(None);
+        });
     }
 }
 
@@ -67,23 +100,20 @@ pub fn with_current<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(&IntermediateContext) -> R,
 {
-    #[cfg(target_arch = "wasm32")]
-    {
-        // Live-iterate inspection is unavailable on the Wasm build because
-        // its callback context is deliberately not installed above.
-        let _ = f;
-        None
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    CURRENT_CTX.with(|c| c.borrow().as_ref().map(f))
+    CURRENT_CTX.with(|c| c.borrow().get().and_then(|ctx| ctx.as_ref().map(f)))
 }
 
 /// Whether a context is currently installed.
 pub fn is_active() -> bool {
-    #[cfg(target_arch = "wasm32")]
-    {
-        false
+    CURRENT_CTX.with(|c| c.borrow().get().is_some_and(Option::is_some))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ContextSlot;
+
+    #[test]
+    fn context_slot_has_no_thread_local_drop_glue() {
+        assert!(!std::mem::needs_drop::<ContextSlot>());
     }
-    #[cfg(not(target_arch = "wasm32"))]
-    CURRENT_CTX.with(|c| c.borrow().is_some())
 }

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -38,8 +38,8 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
-#[cfg(not(target_arch = "wasm32"))]
 use std::cell::RefCell;
+use std::mem::MaybeUninit;
 
 use pounce_common::types::{Index, Number};
 use pounce_nlp::solve_statistics::IterRecord;
@@ -59,11 +59,45 @@ pub const RESTORATION_SPAN: &str = "restoration";
 
 // ---- Per-solve capture slot ----
 
-#[cfg(not(target_arch = "wasm32"))]
+/// A TLS cell whose storage does not register a thread-local destructor.
+struct CaptureSlot {
+    value: MaybeUninit<Option<Vec<IterRecord>>>,
+    initialized: bool,
+}
+
+impl CaptureSlot {
+    const fn new() -> Self {
+        Self {
+            value: MaybeUninit::uninit(),
+            initialized: false,
+        }
+    }
+
+    fn get(&self) -> Option<&Option<Vec<IterRecord>>> {
+        self.initialized.then(|| {
+            // SAFETY: `initialized` is set only after `value` is initialized.
+            unsafe { self.value.assume_init_ref() }
+        })
+    }
+
+    fn get_mut(&mut self) -> &mut Option<Vec<IterRecord>> {
+        if !self.initialized {
+            self.value.write(None);
+            self.initialized = true;
+        }
+        // SAFETY: the branch above initializes `value` before this access.
+        unsafe { self.value.assume_init_mut() }
+    }
+
+    fn replace(&mut self, value: Option<Vec<IterRecord>>) -> Option<Vec<IterRecord>> {
+        std::mem::replace(self.get_mut(), value)
+    }
+}
+
 thread_local! {
     /// Active capture buffer for the current solve, or `None` when no
     /// solve on this thread is recording its iteration history.
-    static CAPTURE: RefCell<Option<Vec<IterRecord>>> = const { RefCell::new(None) };
+    static CAPTURE: RefCell<CaptureSlot> = const { RefCell::new(CaptureSlot::new()) };
 }
 
 /// Set once at subscriber install when `POUNCE_LOG_FORMAT=json`, so the
@@ -90,16 +124,7 @@ pub fn iteration_event_wanted() -> bool {
     if JSON_LOGGING.load(std::sync::atomic::Ordering::Relaxed) {
         return true;
     }
-    #[cfg(target_arch = "wasm32")]
-    {
-        // CAPTURE is a destructor-bearing TLS slot. Accessing it under the
-        // single-threaded wasm32-wasip1 hosts used by pounce-wasm can block
-        // indefinitely before iteration zero. Wasm still gets the normal
-        // console stream; in-process iteration-history capture is disabled.
-        return false;
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    CAPTURE.with(|c| c.borrow().is_some())
+    CAPTURE.with(|c| c.borrow().get().is_some_and(Option::is_some))
 }
 
 /// RAII activation of per-iteration capture for one solve.
@@ -119,62 +144,38 @@ pub struct IterCaptureGuard {
 impl IterCaptureGuard {
     /// Begin capturing iteration records on this thread.
     pub fn start() -> Self {
-        #[cfg(target_arch = "wasm32")]
-        {
-            // Destructor-bearing TLS can block in the single-threaded WASI
-            // hosts supported by pounce-wasm. Iteration history is optional,
-            // so leave capture disabled while retaining the same API.
-            Self { prev: None }
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let prev = CAPTURE.with(|c| c.borrow_mut().replace(Vec::new()));
-            Self { prev }
-        }
+        let prev = CAPTURE.with(|c| c.borrow_mut().replace(Some(Vec::new())));
+        Self { prev }
     }
 
     /// End capture and return the records collected since [`start`].
     ///
     /// [`start`]: IterCaptureGuard::start
     pub fn finish(mut self) -> Vec<IterRecord> {
-        #[cfg(target_arch = "wasm32")]
-        {
-            self.prev.take();
-            std::mem::forget(self);
-            Vec::new()
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            let prev = self.prev.take();
-            let captured = CAPTURE
-                .with(|c| std::mem::replace(&mut *c.borrow_mut(), prev))
-                .unwrap_or_default();
-            // Skip `Drop`: it would re-restore `self.prev` (now `None`) and
-            // clobber the buffer we just put back for an enclosing guard.
-            std::mem::forget(self);
-            captured
-        }
+        let prev = self.prev.take();
+        let captured = CAPTURE
+            .with(|c| c.borrow_mut().replace(prev))
+            .unwrap_or_default();
+        // `Drop`would re-restore `self.prev`
+        std::mem::forget(self);
+        captured
     }
 }
 
 impl Drop for IterCaptureGuard {
     fn drop(&mut self) {
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            // Restore the previous buffer if `finish` wasn't called.
-            let prev = self.prev.take();
-            CAPTURE.with(|c| *c.borrow_mut() = prev);
-        }
+        // Restore the previous buffer if `finish` wasn't called.
+        let prev = self.prev.take();
+        CAPTURE.with(|c| {
+            c.borrow_mut().replace(prev);
+        });
     }
 }
 
 /// Append a record to the active capture slot, if any.
 fn push_record(rec: IterRecord) {
-    #[cfg(target_arch = "wasm32")]
-    let _ = rec;
-    #[cfg(not(target_arch = "wasm32"))]
     CAPTURE.with(|c| {
-        if let Some(buf) = c.borrow_mut().as_mut() {
+        if let Some(buf) = c.borrow_mut().get_mut().as_mut() {
             buf.push(rec);
         }
     });
@@ -190,14 +191,11 @@ pub fn extend_active_capture(records: &[IterRecord]) {
     if records.is_empty() {
         return;
     }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        CAPTURE.with(|c| {
-            if let Some(buf) = c.borrow_mut().as_mut() {
-                buf.extend_from_slice(records);
-            }
-        });
-    }
+    CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().get_mut().as_mut() {
+            buf.extend_from_slice(records);
+        }
+    });
 }
 
 // ---- Event → IterRecord visitor ----
@@ -584,6 +582,11 @@ mod tests {
             !iteration_event_wanted(),
             "capture ended → event suppressed"
         );
+    }
+
+    #[test]
+    fn capture_slot_has_no_thread_local_drop_glue() {
+        assert!(!std::mem::needs_drop::<CaptureSlot>());
     }
 
     #[test]

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -325,7 +325,17 @@ pub struct CollectorScope {
 /// collector already covers this thread and the scope is a no-op.
 /// Otherwise a collector-only registry is installed as the thread-default
 /// subscriber, which shadows the host's own subscriber (its log output
-/// from this thread is dropped) for the scope's lifetime.
+/// from this thread is dropped) for the scope's lifetime. On WASI this is a
+/// deliberate no-op; the platform exposes no in-process iteration collector.
+#[cfg(target_os = "wasi")]
+pub fn collector_scope() -> CollectorScope {
+    // WASI's browser/Node shim has no supported thread-scoped subscriber
+    // installation. Keep the public API usable, but make iteration capture
+    // explicitly empty rather than entering a host TLS path that can stall.
+    CollectorScope { _default: None }
+}
+
+#[cfg(not(target_os = "wasi"))]
 pub fn collector_scope() -> CollectorScope {
     use tracing_subscriber::filter::filter_fn;
     use tracing_subscriber::prelude::*;

--- a/crates/pounce-observability/src/lib.rs
+++ b/crates/pounce-observability/src/lib.rs
@@ -38,6 +38,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::cell::RefCell;
 
 use pounce_common::types::{Index, Number};
@@ -58,6 +59,7 @@ pub const RESTORATION_SPAN: &str = "restoration";
 
 // ---- Per-solve capture slot ----
 
+#[cfg(not(target_arch = "wasm32"))]
 thread_local! {
     /// Active capture buffer for the current solve, or `None` when no
     /// solve on this thread is recording its iteration history.
@@ -88,6 +90,15 @@ pub fn iteration_event_wanted() -> bool {
     if JSON_LOGGING.load(std::sync::atomic::Ordering::Relaxed) {
         return true;
     }
+    #[cfg(target_arch = "wasm32")]
+    {
+        // CAPTURE is a destructor-bearing TLS slot. Accessing it under the
+        // single-threaded wasm32-wasip1 hosts used by pounce-wasm can block
+        // indefinitely before iteration zero. Wasm still gets the normal
+        // console stream; in-process iteration-history capture is disabled.
+        return false;
+    }
+    #[cfg(not(target_arch = "wasm32"))]
     CAPTURE.with(|c| c.borrow().is_some())
 }
 
@@ -108,35 +119,60 @@ pub struct IterCaptureGuard {
 impl IterCaptureGuard {
     /// Begin capturing iteration records on this thread.
     pub fn start() -> Self {
-        let prev = CAPTURE.with(|c| c.borrow_mut().replace(Vec::new()));
-        Self { prev }
+        #[cfg(target_arch = "wasm32")]
+        {
+            // Destructor-bearing TLS can block in the single-threaded WASI
+            // hosts supported by pounce-wasm. Iteration history is optional,
+            // so leave capture disabled while retaining the same API.
+            Self { prev: None }
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let prev = CAPTURE.with(|c| c.borrow_mut().replace(Vec::new()));
+            Self { prev }
+        }
     }
 
     /// End capture and return the records collected since [`start`].
     ///
     /// [`start`]: IterCaptureGuard::start
     pub fn finish(mut self) -> Vec<IterRecord> {
-        let prev = self.prev.take();
-        let captured = CAPTURE
-            .with(|c| std::mem::replace(&mut *c.borrow_mut(), prev))
-            .unwrap_or_default();
-        // Skip `Drop`: it would re-restore `self.prev` (now `None`) and
-        // clobber the buffer we just put back for an enclosing guard.
-        std::mem::forget(self);
-        captured
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.prev.take();
+            std::mem::forget(self);
+            Vec::new()
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let prev = self.prev.take();
+            let captured = CAPTURE
+                .with(|c| std::mem::replace(&mut *c.borrow_mut(), prev))
+                .unwrap_or_default();
+            // Skip `Drop`: it would re-restore `self.prev` (now `None`) and
+            // clobber the buffer we just put back for an enclosing guard.
+            std::mem::forget(self);
+            captured
+        }
     }
 }
 
 impl Drop for IterCaptureGuard {
     fn drop(&mut self) {
-        // Restore the previous buffer if `finish` wasn't called.
-        let prev = self.prev.take();
-        CAPTURE.with(|c| *c.borrow_mut() = prev);
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            // Restore the previous buffer if `finish` wasn't called.
+            let prev = self.prev.take();
+            CAPTURE.with(|c| *c.borrow_mut() = prev);
+        }
     }
 }
 
 /// Append a record to the active capture slot, if any.
 fn push_record(rec: IterRecord) {
+    #[cfg(target_arch = "wasm32")]
+    let _ = rec;
+    #[cfg(not(target_arch = "wasm32"))]
     CAPTURE.with(|c| {
         if let Some(buf) = c.borrow_mut().as_mut() {
             buf.push(rec);
@@ -154,11 +190,14 @@ pub fn extend_active_capture(records: &[IterRecord]) {
     if records.is_empty() {
         return;
     }
-    CAPTURE.with(|c| {
-        if let Some(buf) = c.borrow_mut().as_mut() {
-            buf.extend_from_slice(records);
-        }
-    });
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        CAPTURE.with(|c| {
+            if let Some(buf) = c.borrow_mut().as_mut() {
+                buf.extend_from_slice(records);
+            }
+        });
+    }
 }
 
 // ---- Event → IterRecord visitor ----

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -211,6 +211,8 @@ impl<P: Problem + 'static> Nlp<P> {
     /// (`solver_selection=qp-active-set`/`algorithm=active-set-sqp`)
     /// `stats.iterations` stays empty even though
     /// `stats.iteration_count` still reports the iterations run.
+    /// On `wasm32-wasip1`, in-process tracing capture is unavailable, so
+    /// `stats.iterations` likewise stays empty.
     pub fn capture_iterations(mut self) -> Self {
         self.capture_iterations = true;
         self

--- a/crates/pounce-wasm/Cargo.toml
+++ b/crates/pounce-wasm/Cargo.toml
@@ -21,6 +21,7 @@ pounce-common.workspace = true
 pounce-nlp.workspace = true
 pounce-nl.workspace = true
 pounce-algorithm.workspace = true
+pounce-rs.workspace = true
 pounce-presolve.workspace = true
 # `status_to_solve_result_num` for the `.sol` objno line — the same mapping
 # the CLI writes, so a browser `.sol` and a CLI `.sol` agree.

--- a/crates/pounce-wasm/build.sh
+++ b/crates/pounce-wasm/build.sh
@@ -23,7 +23,10 @@ out="$root/target/$target/release/pounce_wasm.wasm"
 
 # wasm-opt (binaryen) is optional; it typically takes another ~15% off.
 if command -v wasm-opt >/dev/null 2>&1; then
-  wasm-opt -Oz --enable-bulk-memory "$out" -o "$here/web/pounce.wasm"
+  # Rust's wasm32-wasip1 code uses non-trapping float-to-int conversions.
+  # Keep the feature enabled when Binaryen validates the module.
+  wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --enable-simd \
+    "$out" -o "$here/web/pounce.wasm"
 else
   cp "$out" "$here/web/pounce.wasm"
 fi

--- a/crates/pounce-wasm/src/lib.rs
+++ b/crates/pounce-wasm/src/lib.rs
@@ -19,6 +19,9 @@
 //!   a JSON summary. Returns `{"error": …}` on a bad file.
 //! * [`pounce_solve`] — solve the loaded problem with an `ipopt.opt`-style
 //!   options string, returning a JSON result.
+//! * [`pounce_builder_regression`] — solve the constrained two-variable
+//!   builder fixture used by the Wasm regression smoke test. This deliberately
+//!   exercises `pounce_rs::builder::Nlp`.
 //! * [`pounce_solution_sol`] — format the last solve as an AMPL `.sol` file,
 //!   the same bytes `pounce model.nl` writes, so a browser result can be read
 //!   back by AMPL or Pyomo.
@@ -44,6 +47,7 @@ use pounce_nl::sol_writer::{
 };
 use pounce_nlp::expression_provider::ExpressionProvider;
 use pounce_nlp::tnlp::{Linearity, TNLP};
+use pounce_rs::builder::{Nlp as BuilderNlp, Problem as BuilderProblem};
 
 /// Bound on how many per-variable / per-constraint entries a JSON payload
 /// carries. A million-variable model would otherwise serialize a JSON array
@@ -640,6 +644,47 @@ fn csv_field(name: &str, index: usize, fallback: &str) -> String {
         name.to_string()
     };
     format!("\"{}\"", text.replace('"', "\"\""))
+}
+
+struct BuilderRegressionProblem;
+
+impl BuilderProblem for BuilderRegressionProblem {
+    fn objective(&self, x: &[f64]) -> f64 {
+        (1.0 - x[0]).powi(2) + 100.0 * (x[1] - x[0].powi(2)).powi(2)
+    }
+
+    fn n_constraints(&self) -> usize {
+        2
+    }
+
+    fn constraints(&self, x: &[f64], out: &mut [f64]) {
+        out[0] = x[0].powi(2) + x[1].powi(2);
+        out[1] = x[0] + x[1];
+    }
+}
+
+/// Run the constrained builder fixture used by the Wasm regression smoke.
+#[unsafe(no_mangle)]
+pub extern "C" fn pounce_builder_regression() -> *mut u8 {
+    guarded("builder regression", || {
+        let solution = BuilderNlp::new(BuilderRegressionProblem)
+            .var_bounds(&[-3.0, -3.0], &[3.0, 3.0])
+            .constraint_bounds(&[-2.0e19, 0.5], &[4.0, 2.0e19])
+            .x0(&[-1.2, 1.0])
+            .option_num("tol", 1.0e-3)
+            .option_int("print_level", 0)
+            .solve();
+        to_payload(
+            &serde_json::json!({
+                "success": solution.success,
+                "status": format!("{:?}", solution.status),
+                "objective": solution.objective,
+                "x": solution.x,
+                "iterations": solution.stats.iteration_count,
+            })
+            .to_string(),
+        )
+    })
 }
 
 #[cfg(test)]

--- a/crates/pounce-wasm/src/lib.rs
+++ b/crates/pounce-wasm/src/lib.rs
@@ -671,6 +671,7 @@ pub extern "C" fn pounce_builder_regression() -> *mut u8 {
             .var_bounds(&[-3.0, -3.0], &[3.0, 3.0])
             .constraint_bounds(&[-2.0e19, 0.5], &[4.0, 2.0e19])
             .x0(&[-1.2, 1.0])
+            .capture_iterations()
             .option_num("tol", 1.0e-3)
             .option_int("print_level", 0)
             .solve();
@@ -681,6 +682,7 @@ pub extern "C" fn pounce_builder_regression() -> *mut u8 {
                 "objective": solution.objective,
                 "x": solution.x,
                 "iterations": solution.stats.iteration_count,
+                "captured_iterations": solution.stats.iterations.len(),
             })
             .to_string(),
         )

--- a/crates/pounce-wasm/tests/smoke.mjs
+++ b/crates/pounce-wasm/tests/smoke.mjs
@@ -69,6 +69,23 @@ function solve(options = '') {
   }
 }
 
+const builderResult = fromWasmJson(wasm.pounce_builder_regression());
+assert.equal(
+  builderResult.error,
+  undefined,
+  `builder regression failed: ${builderResult.error}`,
+);
+assert.equal(
+  builderResult.success,
+  true,
+  `unexpected builder status ${builderResult.status}`,
+);
+assert.equal(builderResult.x.length, 2);
+assert.ok(
+  builderResult.objective < 1e-2,
+  `builder objective ${builderResult.objective} did not converge`,
+);
+
 // min x0  s.t.  x0^2 + x1^2 == 1,  x0 + x1 >= 0   ⇒   x0 = -1/√2
 const summary = load(readFileSync(join(here, 'simple.nl'), 'utf8'), 'alpha\nbeta\n', 'ring\nline\n');
 assert.equal(summary.error, undefined, `load failed: ${summary.error}`);
@@ -96,6 +113,29 @@ assert.ok(sol.includes('\nipopt_zL_out\n'), '.sol must carry the reduced-cost su
 const csv = fromWasm(wasm.pounce_solution_csv());
 assert.equal(csv.trimEnd().split('\n').length, 1 + 2 + 2, 'csv must cover every row');
 assert.ok(csv.includes('"alpha"'), 'csv must use the .col names');
+
+const twoInequalities = load(
+  readFileSync(join(here, 'two_inequalities.nl'), 'utf8'),
+);
+assert.equal(
+  twoInequalities.error,
+  undefined,
+  `two-inequality load failed: ${twoInequalities.error}`,
+);
+assert.equal(twoInequalities.n_vars, 2);
+assert.equal(twoInequalities.n_cons, 2);
+const twoInequalityResult = solve('print_level 0\n');
+assert.equal(
+  twoInequalityResult.error,
+  undefined,
+  `two-inequality solve failed: ${twoInequalityResult.error}`,
+);
+assert.equal(
+  twoInequalityResult.success,
+  true,
+  `unexpected two-inequality status ${twoInequalityResult.status}`,
+);
+assert.equal(twoInequalityResult.x.length, 2);
 
 // A malformed model must come back as JSON, not a trapped instance.
 assert.equal(typeof load('this is not an .nl file').error, 'string');

--- a/crates/pounce-wasm/tests/smoke.mjs
+++ b/crates/pounce-wasm/tests/smoke.mjs
@@ -81,6 +81,11 @@ assert.equal(
   `unexpected builder status ${builderResult.status}`,
 );
 assert.equal(builderResult.x.length, 2);
+assert.equal(
+  builderResult.captured_iterations,
+  0,
+  'WASI iteration capture is intentionally unavailable',
+);
 assert.ok(
   builderResult.objective < 1e-2,
   `builder objective ${builderResult.objective} did not converge`,

--- a/crates/pounce-wasm/tests/two_inequalities.nl
+++ b/crates/pounce-wasm/tests/two_inequalities.nl
@@ -1,0 +1,59 @@
+g3 1 1 0	# problem constrained_rosenbrock
+ 2 2 1 0 0	# vars, constraints, objectives, ranges, eqns
+ 1 1	# nonlinear constraints, objectives
+ 0 0	# network constraints: nonlinear, linear
+ 2 2 2	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2	# nonzeros in Jacobian, gradients
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o0
+o5
+v1
+n2
+o5
+v0
+n2
+C1
+n0
+O0 0
+o0
+o2
+o5
+o0
+v1
+o16
+o5
+v0
+n2
+n2
+n100
+o5
+o0
+o2
+n-1
+v0
+n1
+n2
+x2
+0 -1.2
+1 1
+r
+1 4
+2 0.5
+b
+0 -3 3
+0 -3 3
+k1
+2
+J0 2
+0 0
+1 0
+J1 2
+0 1
+1 1
+G0 2
+0 0
+1 0

--- a/crates/pounce-wasm/web-python/README.md
+++ b/crates/pounce-wasm/web-python/README.md
@@ -87,6 +87,9 @@ comma-separated list of wheel URLs, installed in order.
 - **The log arrives at the end.** The solver writes to stdout while Python
   is blocked in the backend call, so the whole iteration table appears when
   the solve returns rather than streaming line by line.
+- **No in-process iteration history or live-iterate inspection.** The WASI
+  backend leaves `stats.iterations` empty and reports
+  `GetIpoptCurrentIterate` / `GetIpoptCurrentViolations` as unavailable.
 - **First load is slow** — ~15 MB of runtime, cached by the browser
   afterwards. The solve is the fast part.
 - Everything the `.nl` app cannot do, this cannot either: single-threaded,

--- a/crates/pounce-wasm/web/README.md
+++ b/crates/pounce-wasm/web/README.md
@@ -79,6 +79,11 @@ re-render.
 
 - **Single-threaded.** The build never spawns a thread, so rayon-parallel
   paths run serially. Nothing else changes: results match the native build.
+- **No in-process iteration history.** `capture_iterations()` and
+  `enable_iter_history()` return an empty `stats.iterations` vector in the
+  Wasm build; the scalar iteration count remains available.
+- **No live-iterate inspection.** `GetIpoptCurrentIterate` and
+  `GetIpoptCurrentViolations` report “not available” in Wasm.
 - **No AMPL imported functions.** Models that call compiled-C external
   functions (`funcadd_ASL`, e.g. IDAES property packages) need a dynamic
   loader the browser sandbox has none of. The summary flags such a model.

--- a/docs/src/wasm.md
+++ b/docs/src/wasm.md
@@ -184,6 +184,14 @@ instead of surfacing later as an unrelated parse error.
 
 - **Single-threaded.** No threads are spawned; rayon-parallel paths run
   serially. Results are unaffected.
+- **No in-process iteration-history capture.** The Wasm build does not install
+  the thread-scoped tracing collector, so `pounce_rs::Nlp::capture_iterations()`
+  and `IpoptApplication::enable_iter_history()` (including the CLI/Python
+  full-detail paths) return an empty `stats.iterations` vector. The scalar
+  `iteration_count` remains available.
+- **No live-iterate inspection.** `GetIpoptCurrentIterate` and
+  `GetIpoptCurrentViolations` report “not available” because the callback
+  context is not installed in the Wasm build.
 - **No AMPL imported functions.** A model that calls compiled-C external
   functions (`funcadd_ASL` — IDAES property packages, for instance) needs a
   dynamic loader the browser sandbox does not provide. The summary flags


### PR DESCRIPTION
## Problem

I was trying to create an oximo-pounce example that runs in the browser using WASM, similar to the pyomo demo.
Currently, pounce hangs using wasm after:

```text
Number of nonzeros in equality constraint Jacobian...:        0
Number of nonzeros in inequality constraint Jacobian.:        4
Number of nonzeros in Lagrangian Hessian.............:        0

Total number of variables............................:        2
                     variables with only lower bounds:        0
                variables with lower and upper bounds:        2
                     variables with only upper bounds:        0
Total number of equality constraints.................:        0
Total number of inequality constraints...............:        2
        inequality constraints with only lower bounds:        1
   inequality constraints with lower and upper bounds:        0
        inequality constraints with only upper bounds:        1
```

## Cause

The causes are various:
A first Wasm-specific stall is exposed after bypassing the optional multiplier solve. Pounce hangs while installing its per-callback thread-local inspector context. That context exists only for C API inspect current iterate calls and is not needed by the builder.

Another hang was `pounce_observability::iteration_event_wanted()` touching a capture TLS slot on wasm32-wasip1.

Another stall was inside `feral::Solver::factor`, after the KKT matrix is assembled. This is the parallel FERAL driver attempting to initialize/use Rayon in a single- threaded WASI instance.

Your .nl demo avoided enough of that path to look fine. 

## Fix

I’ve made those facilities no-op/serial only on Wasm. Native behavior remains unchanged.

## Blast radius

None of the actual changes affect the model or the main IPM. They only remove startup heuristics unavailable in this host.

**Note:** The issues were diagnosed using ChatGPT Sol 5.6.