### PR TITLE
User scaling reaches the solver, and options that cannot be honoured say so (#483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ changes.
 - The check runs before solver routing, so a model that classifies as a
   convex QP gets the same verdict.
 
+### Fixed — `fast_step_computation` is wired, not refused (#483 follow-up, #191 round 2)
+
+- `PdSearchDirCalc` has owned this flag — skip the search-direction
+  residual check, allow an inexact linear solve — since it landed, and
+  consumes it at two sites; only the option's read site was missing, so
+  setting it did nothing. It now reaches the builder, default unchanged
+  (`no`).
+- It briefly sat in the refusal table above, added by hand against that
+  table's own membership rule (its name *does* appear in the sources), so
+  it would have failed a solve POUNCE can serve. The boundary test now
+  pins it.
+
 ### Added — the derivative checker (`derivative_test`) now exists (#483 follow-up)
 
 - All five `derivative_test*` options were registered and none was ever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ changes.
 
 ## [Unreleased]
 
+### Added — the derivative checker (`derivative_test`) now exists (#483 follow-up)
+
+- All five `derivative_test*` options were registered and none was ever
+  read, so `derivative_test=first-order` ran no test and printed nothing.
+  That is the worst shape an unimplemented option can take: a *checker*
+  that silently checks nothing reports success by omission — a user with
+  a hand-written `eval_grad_f` turns it on, sees no complaints, and
+  concludes the gradient is right.
+- Implemented as a port of upstream's `TNLPAdapter::CheckDerivatives`:
+  `first-order` compares `eval_grad_f` / `eval_jac_g` against finite
+  differences at the bound-projected starting point, `second-order` adds
+  `eval_h` (checked one multiplier block at a time), `only-second-order`
+  does the Hessian alone. `derivative_test_perturbation`,
+  `derivative_test_tol`, `derivative_test_first_index` and
+  `derivative_test_print_all` are all honored.
+- Two checks upstream does not make, because neither is reachable by a
+  value-by-value comparison: an entry whose finite difference is nonzero
+  but which the **sparsity structure omits** (a derivative the solver can
+  never see), and taking the perturbation **downward** when stepping up
+  would leave a variable's box, so a model using `sqrt`/`log`/`1/x` is
+  not evaluated outside its own domain by its own checker.
+- Advisory, like upstream: suspicious entries are reported and the solve
+  continues. The report goes to stderr, so it survives `print_level=0`
+  and stays out of `--json-output`'s stdout. It runs on both solver
+  routes — the convex dispatch never reaches the NLP path's copy, and the
+  check is about the model, not the engine.
+- `check_derivatives_for_naninf` (a per-iteration NaN/Inf guard) remains
+  unimplemented and is documented as such.
+
+### Fixed — `linear_solver` accepted every backend name and silently ran FERAL (#483 follow-up)
+
+- The option's registered value list is a faithful port of upstream
+  Ipopt's — `ma27`, `ma57`, `ma77`, `ma86`, `ma97`, `mumps`, `pardiso`,
+  `pardisomkl`, `spral`, `wsmp`, `custom`, `feral` — so an `ipopt.opt`
+  written for Ipopt parses unchanged. POUNCE implements two of them, and
+  the resolver mapped everything else through a `_ =>` arm to FERAL. So
+  `linear_solver=ma97` "worked": a successful run using a backend the
+  binary does not contain, and a benchmark comparing linear solvers that
+  compared FERAL against itself.
+- Selecting an unimplemented backend is now refused — exit 2 from the CLI,
+  `Invalid_Option` for library callers — with a message naming the backend
+  and what to use instead. The names stay registered, so an Ipopt
+  `ipopt.opt` still parses and gets a precise complaint rather than
+  "invalid value". Their per-backend tuning knobs (`ma97_scaling`,
+  `mumps_pivtolmax`, `pardiso_*`, …) are registered for the same reason
+  and are now unreachable.
+- Two cases deliberately still pass: the **registered default** is
+  upstream's `ma57`, which is not a user request and resolves to FERAL on
+  the pure-Rust build as it always has; and **explicit `ma57` without the
+  feature** falls back to FERAL with the banner saying so
+  (`FERAL (ma57 requested but not compiled)`) — a reported substitution,
+  not a hidden one.
+- The check runs before solver routing, so it does not depend on whether
+  the model classifies into the NLP path or the convex one.
+
 ### Fixed — a maximize request was silently dropped on the convex LP/QP route (#483 follow-up)
 
 - `obj_scaling_factor` is upstream's spelling for maximization (the IPM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,41 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a maximize request was silently dropped on the convex LP/QP route (#483 follow-up)
+
+- `obj_scaling_factor` is upstream's spelling for maximization (the IPM
+  minimizes `factor·f`, so a negative factor maximizes `f`). The convex
+  solvers in `pounce-convex` equilibrate internally and never read the
+  option — and every LP / convex-QP model routes to them by default. So
+  `min (x−3)²` over `x ∈ [0,1]` with `obj_scaling_factor=-1` returned
+  `x = 1`, the **minimizer** of the objective the user asked to maximize,
+  reported as `Optimal Solution Found`. The same file under
+  `solver_selection=nlp` answered correctly with `x = 0`.
+- A negative factor now declines the convex fast path under
+  `solver_selection=auto` (routing to the NLP path, which honors it) and
+  is **refused** — exit 2, with an explanation — under an explicit convex
+  `solver_selection`, where the alternative is not a skipped extra but a
+  wrong answer.
+- A *positive* factor is unaffected: it only rescales conditioning, the
+  convex path reports natural units either way, and both paths agree.
+
+### Fixed — `honor_original_bounds` was registered but never read (#483 follow-up)
+
+- `bound_relax_factor` (default `1e-8`) widens the variable box before the
+  solve, so a solution pinned to a bound is reported just outside it:
+  `min (x−3)² + (y+2)²` over `x ∈ [0,1]`, `y ∈ [−1,1]` returned
+  `x = 1.00000000937`, `y = −1.00000000875`. Upstream registers
+  `honor_original_bounds` to project that back; pounce registered it and
+  never read it, so there was no way to get a point inside the declared
+  box — and the value flows on into a downstream `sqrt(1−x)`, a domain
+  assertion, or a Pyomo `Var` whose bounds it is loaded back into.
+- The option is now honored on both routes a caller can read the solution
+  from: the `.sol` / JSON primal (via the CLI's converged-iterate hook)
+  and `TNLP::finalize_solution` (pounce-py, the C interface, any Rust
+  TNLP). The default stays `no`, matching upstream, and — as upstream
+  documents — the summary's constraint-violation and complementarity
+  figures remain those of the non-projected point.
+
 ### Fixed — user scaling was a silent no-op from Pyomo, and the core silently discarded `x_scaling` (#483)
 
 - **The `scaling_factor` Suffix now reaches the solver.** Tagging the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — user scaling was a silent no-op from Pyomo, and the core silently discarded `x_scaling` (#483)
+
+- **The `scaling_factor` Suffix now reaches the solver.** Tagging the
+  standard Pyomo Suffix and setting `nlp_scaling_method=user-scaling` —
+  the workflow that works with Ipopt through ASL — produced *no scaling
+  at all* and no message saying so. `NlTnlp` never implemented
+  `get_scaling_parameters`, so the `.nl`'s `scaling_factor` suffix
+  segments were parsed and then ignored, and pyomo-pounce had no scaling
+  code of its own. The option was accepted and meant "none". Objective
+  and constraint factors now apply on both paths: the ASL/subprocess
+  solve reads the suffix segments, and pyomo-pounce's in-process
+  sensitivity path installs them via `Problem.set_problem_scaling`.
+  Untagged components, and components tagged `0` (AMPL's suffix
+  default), are unscaled; entries on inactive constraints and fixed
+  variables are skipped; a container entry expands to its members.
+- **Per-variable factors are refused instead of dropped.** POUNCE models
+  objective and constraint scaling only, and `scale_user_supplied` ended
+  in `let _ = use_x_scaling;` — so a caller who supplied variable factors
+  got a converged answer to a differently-conditioned problem than the
+  one described, with the objective and constraint factors applied and
+  the variable ones gone. A non-unit `x_scaling` now fails the solve with
+  `Invalid_Option` and an explanation, `pounce.Problem.set_problem_scaling`
+  raises, and pyomo-pounce raises naming the variables. An all-ones
+  request asks for nothing and still solves. Modelling variable scaling
+  in the core is staged work tracked on #483.
+- **No silence anywhere else on the path.** `nlp_scaling_method=user-scaling`
+  on a model that classifies as LP/QP/SOCP used to route to
+  `pounce-convex`, which equilibrates internally and never reads the
+  scaling callback; `solver_selection=auto` now declines that fast path
+  so the scaling is honored, and an explicit `solver_selection` warns.
+  pyomo-pounce warns when `user-scaling` is requested with no
+  export-enabled `scaling_factor` Suffix to apply.
+- The sensitivity accessors needed no code: `natural_units_conj` already
+  translates `df`/`dc`/`dd` for any scaling method. That is now proven
+  rather than assumed — `covariance`, `information`, `gradient`,
+  `estimate`, `wrt=` blocks, the retain-only path, the classifier's
+  statuses, and the fixed-variable composition are each checked against
+  unscaled ground truth with user scaling engaged.
+
 ### Fixed — `inf_pr` reported the internal reformulation, not the original NLP (#476)
 
 - The `inf_pr` iteration column printed `max(‖c‖∞, ‖d − s‖∞)` — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,12 +55,18 @@ changes.
   "invalid value". Their per-backend tuning knobs (`ma97_scaling`,
   `mumps_pivtolmax`, `pardiso_*`, …) are registered for the same reason
   and are now unreachable.
-- Two cases deliberately still pass: the **registered default** is
-  upstream's `ma57`, which is not a user request and resolves to FERAL on
-  the pure-Rust build as it always has; and **explicit `ma57` without the
-  feature** falls back to FERAL with the banner saying so
-  (`FERAL (ma57 requested but not compiled)`) — a reported substitution,
-  not a hidden one.
+- **The registered default is now `feral`**, diverging from upstream's
+  `ma57` on purpose: a default has to name a solver the binary actually
+  contains. Under the old default a pure-Rust build advertised MA57 to
+  every `print_user_options` dump and banner-adjacent consumer while
+  running FERAL, and — the behavioural half — an **HSL-enabled build used
+  MA57 without being asked**. If you build `--features ma57` and want it,
+  select it explicitly with `linear_solver=ma57`. This also removes the
+  explicit-vs-default special case the banner, the wheel's banner, and
+  the refusal guard each had to carry.
+- Not a failure: **explicit `ma57` without the feature** falls back to
+  FERAL with the banner saying so (`FERAL (ma57 requested but not
+  compiled)`) — a reported substitution, not a hidden one.
 - The check runs before solver routing, so it does not depend on whether
   the model classifies into the NLP path or the convex one.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ changes.
 
 ## [Unreleased]
 
+### Changed — options naming unimplemented features are refused, not ignored (#483 follow-up, continuing #191)
+
+- The option registry is a faithful port of Ipopt's, so an `ipopt.opt`
+  written for Ipopt parses unchanged — and ~200 of the registered knobs
+  were silent no-ops, because registering an option says nothing about
+  implementing it. #191 fixed the half where the *feature* runs and only
+  the read site was missing; it explicitly scoped out "feature genuinely
+  unimplemented — expected no-ops". This closes that half.
+- Setting an option that configures a feature POUNCE does not have now
+  fails the solve — exit 2 from the CLI, `Invalid_Option` for library
+  callers — naming the option, the feature, and the alternative. Covered:
+  the Chen-Goldfarb (CG-penalty) / inexact-Newton line search, derivative
+  approximation by finite differences, linear-dependency detection, the
+  per-iteration NaN/Inf derivative check, multiplier recalculation,
+  a selectable constraint-violation norm, magic steps, bound replacement,
+  the L-BFGS augmented-system variants, the linear-variable hint, reading
+  options from a file, skipping the finalize callback, the dynamic HSL
+  loader, `suppress_all_output` and `debug_print_level`.
+- **An explicitly-set default is still allowed.** A generated `ipopt.opt`
+  spells out defaults and `dependency_detector=none` asks for nothing;
+  only a value differing from the registered default is refused. Without
+  this the change would break the compatibility the registry provides.
+- **Caching hints warn instead of failing.** `grad_f_constant`,
+  `hessian_constant`, `jac_c_constant`, `jac_d_constant` are hints POUNCE
+  does not exploit; ignoring them costs evaluations, never correctness, so
+  blocking the solve would be the worse trade.
+- Membership was established per option, not inferred: the name must
+  appear in no crate source outside the registry (whole-word — so
+  `penalty_max` is not counted present because `l1_penalty_max` exists)
+  *and* the feature itself must be absent. Options whose feature runs and
+  whose read site is merely missing — the restoration knobs, the
+  `limited_memory_*` tail, the corrector selectors — are deliberately
+  excluded and still solve; refusing them would fail solves whose answers
+  are correct today. A unit test pins that boundary.
+- The check runs before solver routing, so a model that classifies as a
+  convex QP gets the same verdict.
+
 ### Added — the derivative checker (`derivative_test`) now exists (#483 follow-up)
 
 - All five `derivative_test*` options were registered and none was ever

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -218,6 +218,14 @@ pub struct AlgorithmBuilder {
     /// option-parser in `application.rs` is responsible for the
     /// cascading defaults (`mu_oracle = probing` etc.).
     pub mehrotra_algorithm: bool,
+    /// `fast_step_computation` — when true, [`PdSearchDirCalc`] accepts
+    /// the search direction without the residual check and allows an
+    /// inexact linear solve. Mirrors upstream's flag of the same name,
+    /// default `no`. The field existed and was consumed from the day the
+    /// search-direction calculator landed, hard-coded to `false`; only
+    /// the option's read site was missing, so setting it did nothing
+    /// (gh#483 follow-up, #191 round 2).
+    pub fast_step_computation: bool,
     /// `kappa_sigma` — factor bounding how far the bound multipliers may
     /// deviate from their primal estimates. The clamp
     /// (`kappa_sigma_clamp`) runs after every accepted step; `< 1`
@@ -777,6 +785,7 @@ impl Default for AlgorithmBuilder {
             line_search_method: LineSearchChoice::Filter,
             warm_start_init_point: false,
             mehrotra_algorithm: false,
+            fast_step_computation: false,
             kappa_sigma: 1e10,
             kappa_d: 1e-5,
             tiny_step_tol: 10.0 * Number::EPSILON,
@@ -896,6 +905,7 @@ impl AlgorithmBuilder {
         pd_solver.residual_improvement_factor = self.refinement.residual_improvement_factor;
         let mut search_dir = PdSearchDirCalc::new(pd_solver);
         search_dir.mehrotra_algorithm = self.mehrotra_algorithm;
+        search_dir.fast_step_computation = self.fast_step_computation;
         self.build_inner(Some(search_dir))
     }
 
@@ -1190,6 +1200,7 @@ mod tests {
                             line_search_method,
                             warm_start_init_point: false,
                             mehrotra_algorithm: false,
+                            fast_step_computation: false,
                             kappa_sigma: 1e10,
                             kappa_d: 1e-5,
                             tiny_step_tol: 10.0 * Number::EPSILON,

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -693,6 +693,20 @@ pub struct RestoOptions {
     /// (`κ_resto` in `IpRestoConvCheck.cpp:58`). `0` disables the guard,
     /// i.e. restoration runs until the sub-NLP itself converges.
     pub required_infeasibility_reduction: Number,
+    /// `evaluate_orig_obj_at_resto_trial` — evaluate the *original*
+    /// objective at every restoration trial point, so an iterate the
+    /// restoration problem likes but the original cannot evaluate is
+    /// rejected there rather than after the phase exits. Upstream default
+    /// `yes`. `RestoAlgorithmBuilder` has consumed this since it landed;
+    /// only the read site was missing (gh#483, #191 round 2).
+    pub evaluate_orig_obj_at_resto_trial: bool,
+    /// `expect_infeasible_problem` — enter restoration sooner and demand
+    /// more infeasibility reduction before leaving it. Upstream default
+    /// `no`. Same story: consumed, never read.
+    pub expect_infeasible_problem: bool,
+    /// `start_with_resto` — switch to restoration in the first iteration.
+    /// Upstream default `no`. Same story.
+    pub start_with_resto: bool,
 }
 
 impl Default for RestoOptions {
@@ -703,6 +717,9 @@ impl Default for RestoOptions {
             resto_penalty_parameter: 1e3,
             resto_proximity_weight: 1.0,
             required_infeasibility_reduction: 0.9,
+            evaluate_orig_obj_at_resto_trial: true,
+            expect_infeasible_problem: false,
+            start_with_resto: false,
         }
     }
 }

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -207,6 +207,13 @@ pub struct AlgorithmBuilder {
     /// History length for the limited-memory quasi-Newton approximation
     /// (`limited_memory_max_history`). Defaults to upstream's 6.
     pub limited_memory_max_history: i32,
+    /// `limited_memory_init_val_max` / `_min` — the clamp on the initial
+    /// Hessian scalar σ before the rank-2 updates. Upstream defaults 1e8
+    /// / 1e-8, which `LimMemQuasiNewtonUpdater` has carried as hard-coded
+    /// fields and consumed in `initial_hessian_scalar` all along; only
+    /// the read sites were missing (gh#483, #191 round 2).
+    pub limited_memory_init_val_max: Number,
+    pub limited_memory_init_val_min: Number,
     pub line_search_method: LineSearchChoice,
     pub warm_start_init_point: bool,
     /// `mehrotra_algorithm` — when true, [`PdSearchDirCalc`] folds
@@ -799,6 +806,8 @@ impl Default for AlgorithmBuilder {
             hessian_approximation: HessianApproxChoice::Exact,
             limited_memory_update_type: UpdateType::Bfgs,
             limited_memory_max_history: 6,
+            limited_memory_init_val_max: 1e8,
+            limited_memory_init_val_min: 1e-8,
             line_search_method: LineSearchChoice::Filter,
             warm_start_init_point: false,
             mehrotra_algorithm: false,
@@ -1104,6 +1113,8 @@ impl AlgorithmBuilder {
             HessianApproxChoice::LimitedMemory => Box::new(LimMemQuasiNewtonUpdater {
                 update_type: self.limited_memory_update_type,
                 max_history: self.limited_memory_max_history,
+                init_val_max: self.limited_memory_init_val_max,
+                init_val_min: self.limited_memory_init_val_min,
                 ..LimMemQuasiNewtonUpdater::default()
             }),
         };
@@ -1214,6 +1225,8 @@ mod tests {
                             hessian_approximation,
                             limited_memory_update_type: UpdateType::Bfgs,
                             limited_memory_max_history: 6,
+                            limited_memory_init_val_max: 1e8,
+                            limited_memory_init_val_min: 1e-8,
                             line_search_method,
                             warm_start_init_point: false,
                             mehrotra_algorithm: false,

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1829,6 +1829,32 @@ impl IpoptApplication {
             constr_target_gradient,
         );
 
+        // `user-scaling` with per-variable factors: pounce models
+        // objective and constraint scaling only. Applying the rest and
+        // dropping the variable factors would solve a problem
+        // conditioned differently from the one described, with nothing
+        // said about it — so refuse instead (gh#483).
+        if orig_nlp.user_x_scaling_rejected() {
+            use pounce_common::journalist::JournalCategory;
+            const MSG: &str = "pounce: nlp_scaling_method=user-scaling supplied \
+                 per-variable scaling factors, but pounce models only objective \
+                 and constraint scaling. Applying the objective/constraint \
+                 factors alone would change the problem's conditioning in a way \
+                 you did not ask for, so the solve is refused rather than run. \
+                 Leave the variable factors at 1.0 (rescaling those variables in \
+                 the model itself), or drop nlp_scaling_method=user-scaling. \
+                 Tracking issue: https://github.com/jkitchin/pounce/issues/483\n";
+            // stderr, not stdout: this must reach the user even under
+            // `print_level=0` / `--json-output`, where stdout is reserved
+            // for machine-readable output. The journalist copy lands in
+            // any attached `output_file`.
+            eprint!("{MSG}");
+            self.journalist
+                .print(JournalLevel::J_ERROR, JournalCategory::J_MAIN, MSG);
+            timing.overall_alg.end();
+            return ApplicationReturnStatus::InvalidOption;
+        }
+
         let nlp_handle: Rc<RefCell<dyn IpoptNlp>> = Rc::new(RefCell::new(orig_nlp));
 
         // Build the algorithm strategy bundle. Read coarse knobs from

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1778,6 +1778,21 @@ impl IpoptApplication {
             .unwrap_or(1e-4);
         orig_nlp.relax_bounds(bound_relax_factor, constr_viol_tol);
 
+        // `honor_original_bounds` (default `no`, matching upstream):
+        // project the reported point back into the un-relaxed box. Must
+        // follow `relax_bounds`, which snapshots the bounds to project
+        // onto. Registered but never read before, so a user asking for
+        // it still got a bound-pinned solution sitting up to
+        // `min(bound_relax_factor·max(1,|b|), constr_viol_tol)` outside
+        // its own bounds (gh#483 follow-up).
+        let honor_original_bounds = self
+            .options
+            .get_bool_value("honor_original_bounds", "")
+            .ok()
+            .and_then(|(v, f)| f.then_some(v))
+            .unwrap_or(false);
+        orig_nlp.set_honor_original_bounds(honor_original_bounds);
+
         // Apply automatic NLP scaling per `nlp_scaling_method` option
         // (port of `OrigIpoptNLP::InitializeStructures` →
         // `NLPScalingObject::DetermineScaling`). Default is
@@ -3265,7 +3280,11 @@ fn finalize_via_orig_nlp(
     // TNLP receives the same shape it provided. With `make_parameter`
     // the fixed components are spliced back in by the IpoptNlp.
     let nlp_borrow = nlp.borrow();
-    let x_vec: Vec<Number> = nlp_borrow.lift_x_to_full(&*curr.x);
+    // `finalize_solution_x`, not `lift_x_to_full`: the reported point also
+    // owes the user the `honor_original_bounds` projection. `f` and `g`
+    // below are then evaluated at the point actually reported, so x/f/g
+    // agree with each other.
+    let x_vec: Vec<Number> = nlp_borrow.finalize_solution_x(&*curr.x);
     let info = tnlp.borrow_mut().get_nlp_info().ok_or(())?;
     let n = info.n as usize;
     let m = info.m as usize;
@@ -3508,7 +3527,7 @@ fn finalize_via_sqp(
 
     let mut x_dv = x_space.make_new_dense();
     x_dv.set_values(&res.x);
-    let x_vec: Vec<Number> = nlp_borrow.lift_x_to_full(&x_dv);
+    let x_vec: Vec<Number> = nlp_borrow.finalize_solution_x(&x_dv);
     debug_assert_eq!(x_vec.len(), n);
 
     // λ_x is packed signed (z_l − z_u). Split for lift.

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -880,19 +880,18 @@ impl IpoptApplication {
     /// FERAL. A run "using MUMPS" was a FERAL run; a benchmark comparing
     /// backends compared FERAL with itself (gh#483 follow-up).
     ///
-    /// The registered default is upstream's `"ma57"`, which is *not* a
-    /// user request — on a build without the `ma57` feature it resolves to
-    /// FERAL and always has. Hence the `found` gate: only an explicit
-    /// selection is judged. Explicit `ma57` on a build that lacks the
-    /// feature is left alone too; that fallback is already reported in the
-    /// banner ("ma57 requested but not compiled"), so it is visible rather
-    /// than silent, and failing a portable `ipopt.opt` over a build flag
-    /// would cost more than it buys.
+    /// The registered default is `feral`, which pounce implements, so no
+    /// explicit-vs-default distinction is needed: whatever the option
+    /// resolves to must be a backend that exists. (It is checked
+    /// unconditionally on purpose — a future default naming something
+    /// unimplemented should trip this, not slip past it.)
+    ///
+    /// Explicit `ma57` on a build that lacks the feature is *not* refused;
+    /// that fallback is reported in the banner ("ma57 requested but not
+    /// compiled"), so it is visible rather than silent, and failing a
+    /// portable `ipopt.opt` over a build flag would cost more than it buys.
     pub fn unimplemented_linear_solver(&self) -> Option<String> {
-        let (v, found) = self.options.get_string_value("linear_solver", "").ok()?;
-        if !found {
-            return None;
-        }
+        let (v, _) = self.options.get_string_value("linear_solver", "").ok()?;
         ["feral", "ma57"]
             .iter()
             .all(|ok| !v.eq_ignore_ascii_case(ok))
@@ -2597,13 +2596,19 @@ impl IpoptApplication {
         // `builder.linear_solver` disagree with the backend actually built, and
         // consumers acted on the lie: the Schur KKT gate in
         // `alg_builder::build_with_backend` tests `== Feral`, so on the
-        // pure-Rust default build — where the registry default "ma57" resolves
-        // to FERAL anyway — `set_kkt_schur_block()` silently never engaged for
-        // ANY user. Resolving here keeps the field truthful for every consumer.
+        // pure-Rust default build — where the registry default (then upstream's
+        // "ma57") resolved to FERAL anyway — `set_kkt_schur_block()` silently
+        // never engaged for ANY user. Resolving here keeps the field truthful
+        // for every consumer.
+        //
+        // The `_ =>` arm is now only reachable for `feral`: every other name
+        // is refused up front by `unimplemented_linear_solver`. It used to
+        // swallow `mumps`, `pardiso`, `ma97`, … and run FERAL instead.
         if let Ok((v, _found)) = self.options.get_string_value("linear_solver", "") {
-            let requested = match v.as_str() {
-                "ma57" => LinearSolverChoice::Ma57,
-                _ => LinearSolverChoice::Feral,
+            let requested = if v.eq_ignore_ascii_case("ma57") {
+                LinearSolverChoice::Ma57
+            } else {
+                LinearSolverChoice::Feral
             };
             builder.linear_solver =
                 if matches!(requested, LinearSolverChoice::Ma57) && !cfg!(feature = "ma57") {
@@ -4196,8 +4201,7 @@ mod tests {
     /// `builder.linear_solver` must name the backend that will actually be
     /// built, not the one the option string asked for.
     ///
-    /// The option registry defaults `linear_solver` to "ma57", but MA57 is
-    /// behind the optional `ma57` cargo feature; without it
+    /// MA57 is behind the optional `ma57` cargo feature; without it
     /// `default_backend_factory` silently substitutes FERAL. Recording `Ma57`
     /// anyway made the field disagree with reality, and the Schur KKT gate in
     /// `alg_builder::build_with_backend` (which tests `== Feral`) consumed that
@@ -4206,20 +4210,18 @@ mod tests {
     /// answer correct and every test green.
     #[test]
     fn application_linear_solver_records_the_effective_backend() {
-        // Default options: registry says "ma57"; a build without the feature
-        // must still report FERAL, because FERAL is what gets constructed.
+        // Default options resolve to FERAL in *every* build. The registry
+        // used to default to upstream's "ma57", which meant an HSL build
+        // silently ran MA57 without being asked and a pure-Rust build
+        // advertised a backend it did not contain; the default now names
+        // pounce's own solver and HSL is opt-in (gh#483 follow-up).
         let mut app = IpoptApplication::new();
         app.initialize().unwrap();
-        let got = app.algorithm_builder_from_options().linear_solver;
-        if cfg!(feature = "ma57") {
-            assert_eq!(got, LinearSolverChoice::Ma57);
-        } else {
-            assert_eq!(
-                got,
-                LinearSolverChoice::Feral,
-                "default build has no MA57; the effective backend is FERAL"
-            );
-        }
+        assert_eq!(
+            app.algorithm_builder_from_options().linear_solver,
+            LinearSolverChoice::Feral,
+            "the registered default is `feral`, in an ma57 build too"
+        );
 
         // An explicit ma57 request resolves the same way.
         let mut app = IpoptApplication::new();

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -558,6 +558,24 @@ impl IpoptApplication {
             return ApplicationReturnStatus::InvalidOption;
         }
 
+        // gh#483 follow-up: an option naming a feature pounce does not
+        // implement is refused, not shrugged off. See
+        // `unimplemented_options` for how membership was established and
+        // why an explicitly-set *default* is deliberately still allowed.
+        if let Some(msg) = self.unimplemented_option_refusal() {
+            use pounce_common::journalist::JournalCategory;
+            eprintln!("{msg}");
+            self.journalist.print(
+                JournalLevel::J_ERROR,
+                JournalCategory::J_MAIN,
+                &format!("{msg}\n"),
+            );
+            return ApplicationReturnStatus::InvalidOption;
+        }
+        for warning in self.unexploited_hint_warnings() {
+            eprintln!("{warning}");
+        }
+
         // `derivative_test`: check the caller's analytic derivatives
         // against finite differences before anything else runs — on the
         // raw TNLP, before the presolve wrapper below changes its
@@ -896,6 +914,21 @@ impl IpoptApplication {
             .iter()
             .all(|ok| !v.eq_ignore_ascii_case(ok))
             .then_some(v)
+    }
+
+    /// The message for the first option the caller set that names a
+    /// feature pounce does not implement, or `None`. Public so the CLI
+    /// can refuse before routing — the convex dispatch never reaches
+    /// `optimize_tnlp`. See [`crate::unimplemented_options`].
+    pub fn unimplemented_option_refusal(&self) -> Option<String> {
+        crate::unimplemented_options::refusal(&self.options, &self.reg_options)
+    }
+
+    /// Warnings for caching hints pounce does not exploit. These never
+    /// block a solve: the answer is identical either way, so refusing
+    /// would cost the caller more than the silence did.
+    pub fn unexploited_hint_warnings(&self) -> Vec<String> {
+        crate::unimplemented_options::hint_warnings(&self.options, &self.reg_options)
     }
 
     /// Resolve the five registered `derivative_test*` knobs. Every one

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2456,6 +2456,15 @@ impl IpoptApplication {
         // defaults (mu_strategy=adaptive, mu_oracle=probing) can be
         // overridden by an explicit user setting of those keys
         // below. Mirrors `IpAlgBuilder.cpp:Mehrotra`.
+        // `fast_step_computation` — skip the search-direction residual
+        // check and allow an inexact linear solve. `PdSearchDirCalc` has
+        // consumed this flag since it landed, hard-coded to `false`; the
+        // option's read site was simply missing, so setting it did
+        // nothing at all (gh#483 follow-up, #191 round 2).
+        if let Ok((v, true)) = self.options.get_string_value("fast_step_computation", "") {
+            builder.fast_step_computation = v.eq_ignore_ascii_case("yes");
+        }
+
         let mut mehrotra_on = false;
         if let Ok((v, found)) = self.options.get_string_value("mehrotra_algorithm", "") {
             if found && v == "yes" {

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -83,6 +83,7 @@ use pounce_linalg::dense_vector::DenseVectorSpace;
 use pounce_linsol::SparseSymLinearSolverInterface;
 use pounce_linsol::summary::LinearSolverSummary;
 use pounce_nlp::alg_types::SolverReturn;
+use pounce_nlp::derivative_test::{DerivativeTest, DerivativeTestOptions};
 use pounce_nlp::orig_ipopt_nlp::{ConstObjScaling, OrigIpoptNlp, ScalingMethod};
 use pounce_nlp::return_codes::ApplicationReturnStatus;
 use pounce_nlp::solve_statistics::SolveStatistics;
@@ -544,6 +545,25 @@ impl IpoptApplication {
             return ApplicationReturnStatus::InvalidOption;
         }
 
+        // A `linear_solver` pounce does not implement is refused rather
+        // than quietly served by FERAL (gh#483 follow-up). Checked here,
+        // before any work, so a library consumer gets the same verdict the
+        // CLI gives before its banner.
+        if let Some(value) = self.unimplemented_linear_solver() {
+            use pounce_common::journalist::JournalCategory;
+            let msg = format!("{}\n", Self::unimplemented_linear_solver_message(&value));
+            eprint!("{msg}");
+            self.journalist
+                .print(JournalLevel::J_ERROR, JournalCategory::J_MAIN, &msg);
+            return ApplicationReturnStatus::InvalidOption;
+        }
+
+        // `derivative_test`: check the caller's analytic derivatives
+        // against finite differences before anything else runs — on the
+        // raw TNLP, before the presolve wrapper below changes its
+        // coordinates.
+        self.run_derivative_test(&tnlp);
+
         // Top-level algorithm dispatch (Phase 5b §7.1). When the
         // `algorithm` option resolves to "active-set-sqp", route
         // to the Phase 5b SQP path; otherwise fall through to the
@@ -845,6 +865,126 @@ impl IpoptApplication {
         ["lp-ipm", "qp-ipm", "socp"]
             .into_iter()
             .find(|c| v.eq_ignore_ascii_case(c))
+    }
+
+    /// The `linear_solver` value when the caller explicitly asked for a
+    /// backend pounce does not implement; `None` when the request can be
+    /// served (or was never made).
+    ///
+    /// pounce ships two: **FERAL** (pure Rust, the effective default) and
+    /// **MA57** (HSL, behind the `ma57` feature). The option's valid-value
+    /// list is a faithful port of upstream Ipopt's — `ma27`, `ma77`,
+    /// `ma86`, `ma97`, `mumps`, `pardiso`, `pardisomkl`, `spral`, `wsmp`,
+    /// `custom` — so an `ipopt.opt` written for Ipopt parses here, and
+    /// every one of those names used to fall through a `_ =>` arm to
+    /// FERAL. A run "using MUMPS" was a FERAL run; a benchmark comparing
+    /// backends compared FERAL with itself (gh#483 follow-up).
+    ///
+    /// The registered default is upstream's `"ma57"`, which is *not* a
+    /// user request — on a build without the `ma57` feature it resolves to
+    /// FERAL and always has. Hence the `found` gate: only an explicit
+    /// selection is judged. Explicit `ma57` on a build that lacks the
+    /// feature is left alone too; that fallback is already reported in the
+    /// banner ("ma57 requested but not compiled"), so it is visible rather
+    /// than silent, and failing a portable `ipopt.opt` over a build flag
+    /// would cost more than it buys.
+    pub fn unimplemented_linear_solver(&self) -> Option<String> {
+        let (v, found) = self.options.get_string_value("linear_solver", "").ok()?;
+        if !found {
+            return None;
+        }
+        ["feral", "ma57"]
+            .iter()
+            .all(|ok| !v.eq_ignore_ascii_case(ok))
+            .then_some(v)
+    }
+
+    /// Resolve the five registered `derivative_test*` knobs. Every one
+    /// of them was registered and never read, so `derivative_test=
+    /// first-order` ran no test and printed nothing — a checker that
+    /// silently checks nothing reports success by omission (gh#483
+    /// follow-up).
+    fn derivative_test_options(&self) -> DerivativeTestOptions {
+        let num = |key: &str, default: Number| -> Number {
+            self.options
+                .get_numeric_value(key, "")
+                .ok()
+                .and_then(|(v, f)| f.then_some(v))
+                .unwrap_or(default)
+        };
+        DerivativeTestOptions {
+            mode: self
+                .options
+                .get_string_value("derivative_test", "")
+                .ok()
+                .and_then(|(v, f)| f.then_some(v))
+                .map(|v| DerivativeTest::from_option(&v))
+                .unwrap_or_default(),
+            perturbation: num("derivative_test_perturbation", 1e-8),
+            tol: num("derivative_test_tol", 1e-4),
+            first_index: self
+                .options
+                .get_integer_value("derivative_test_first_index", "")
+                .ok()
+                .and_then(|(v, f)| f.then_some(v))
+                .unwrap_or(-2),
+            print_all: self
+                .options
+                .get_bool_value("derivative_test_print_all", "")
+                .ok()
+                .and_then(|(v, f)| f.then_some(v))
+                .unwrap_or(false),
+        }
+    }
+
+    /// Run the derivative checker, if asked, against the **user's own**
+    /// TNLP — before presolve wraps it and before any scaling — so the
+    /// report is about the derivatives the caller wrote, in the caller's
+    /// own indices.
+    ///
+    /// Advisory, like upstream: a suspicious entry is reported and the
+    /// solve continues. The report goes to stderr so it survives
+    /// `print_level=0` and leaves `--json-output`'s stdout clean.
+    pub fn run_derivative_test(&self, tnlp: &Rc<RefCell<dyn TNLP>>) {
+        let opts = self.derivative_test_options();
+        if matches!(opts.mode, DerivativeTest::None) {
+            return;
+        }
+        let report = {
+            let mut borrowed = tnlp.borrow_mut();
+            pounce_nlp::derivative_test::run(&mut *borrowed, &opts)
+        };
+        let Some(report) = report else {
+            eprintln!(
+                "pounce: derivative_test was requested but the TNLP declined to \
+                 supply the information the check needs (dimensions, bounds, or \
+                 a starting point); no test was run."
+            );
+            return;
+        };
+        use pounce_common::journalist::JournalCategory;
+        for line in &report.lines {
+            eprintln!("{line}");
+            self.journalist.print(
+                JournalLevel::J_SUMMARY,
+                JournalCategory::J_MAIN,
+                &format!("{line}\n"),
+            );
+        }
+    }
+
+    /// The message [`Self::unimplemented_linear_solver`] earns, shared by
+    /// every frontend so they cannot drift apart.
+    pub fn unimplemented_linear_solver_message(value: &str) -> String {
+        format!(
+            "pounce: linear_solver={value} is not implemented. pounce provides \
+             `feral` (pure-Rust sparse symmetric, the default) and `ma57` (HSL, \
+             in a `--features ma57` build); the other names in the option's \
+             list come from the upstream Ipopt registry so an ipopt.opt written \
+             for Ipopt still parses. Selecting one used to run FERAL silently, \
+             which makes a backend comparison measure nothing — so it is \
+             refused instead. Use linear_solver=feral or linear_solver=ma57."
+        )
     }
 
     fn is_sqp_algorithm_selected(&self) -> bool {

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -2623,6 +2623,22 @@ impl IpoptApplication {
         // `OrigIpoptNlp::determine_scaling_from_starting_point` (see the
         // `determine_scaling_from_starting_point` call earlier in this
         // method); there is no algorithm-side scaling strategy to wire.
+        // `limited_memory_init_val_max` / `_min` — the clamp on the
+        // initial Hessian scalar. `LimMemQuasiNewtonUpdater` consumes
+        // both in `initial_hessian_scalar`; only the read sites were
+        // missing, so setting either did nothing (gh#483, #191 round 2).
+        if let Ok((v, true)) = self
+            .options
+            .get_numeric_value("limited_memory_init_val_max", "")
+        {
+            builder.limited_memory_init_val_max = v;
+        }
+        if let Ok((v, true)) = self
+            .options
+            .get_numeric_value("limited_memory_init_val_min", "")
+        {
+            builder.limited_memory_init_val_min = v;
+        }
 
         // Unlike the other options here, we always honor the registry
         // value (not just when the user set it explicitly): the option

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -3062,6 +3062,24 @@ impl IpoptApplication {
         if let Some(v) = read_num("required_infeasibility_reduction") {
             builder.resto.required_infeasibility_reduction = v;
         }
+        // gh#483 / #191 round 2: three restoration switches whose fields
+        // `RestoAlgorithmBuilder` has consumed all along — the read site
+        // was the only missing piece, so setting them did nothing.
+        let read_yes = |key: &str| -> Option<bool> {
+            match self.options.get_string_value(key, "") {
+                Ok((v, true)) => Some(v.eq_ignore_ascii_case("yes")),
+                _ => None,
+            }
+        };
+        if let Some(v) = read_yes("evaluate_orig_obj_at_resto_trial") {
+            builder.resto.evaluate_orig_obj_at_resto_trial = v;
+        }
+        if let Some(v) = read_yes("expect_infeasible_problem") {
+            builder.resto.expect_infeasible_problem = v;
+        }
+        if let Some(v) = read_yes("start_with_resto") {
+            builder.resto.start_with_resto = v;
+        }
 
         // Iteration-output options — consumed by `OrigIterationOutput`.
         if let Some(v) = read_int("print_frequency_iter") {

--- a/crates/pounce-algorithm/src/lib.rs
+++ b/crates/pounce-algorithm/src/lib.rs
@@ -46,6 +46,7 @@ pub mod restoration;
 pub mod sqp;
 pub mod strategy;
 pub mod timing_stats;
+pub mod unimplemented_options;
 pub mod upstream_options;
 
 pub use application::IpoptApplication;

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -26,10 +26,18 @@
 //! 2. the *feature* it configures is absent too.
 //!
 //! Both are needed. An option whose name is unread but whose feature
-//! runs — `max_resto_iter`, the `limited_memory_*` tail, the corrector
-//! knobs — is a missing read site, not a missing feature; refusing those
-//! would fail solves whose current answers are already correct. They are
+//! runs — the `limited_memory_*` tail, the corrector knobs — is a
+//! missing read site, not a missing feature; refusing those would fail
+//! solves whose current answers are already correct. They are
 //! deliberately **not** here; wiring them is the other half of the work.
+//!
+//! A third shape turned up while wiring that half and belongs to
+//! neither: an option for a *sub-capability* of a feature that does run.
+//! `max_resto_iter` and `resto_failure_feasibility_threshold` are the
+//! examples — restoration runs, but there is no iteration cap or failure
+//! threshold to point a read site at, so honouring them means building
+//! the capability, not adding a line. They are left out of this table
+//! until that call is made, and so remain silent for now.
 //!
 //! The clearest case is the penalty line search. pounce implements
 //! `IpPenaltyLSAcceptor` (`line_search_method=penalty`), so its knobs
@@ -400,6 +408,48 @@ mod tests {
         let mut app = crate::application::IpoptApplication::new();
         app.initialize().unwrap();
         assert!(!app.algorithm_builder_from_options().fast_step_computation);
+    }
+
+    /// The restoration switches wired in gh#483 / #191 round 2. Each
+    /// field was already consumed by `RestoAlgorithmBuilder`; only the
+    /// read site was missing, so setting the option did nothing. The
+    /// assertion that matters is that the value *reaches the builder* —
+    /// a read site populating a field nobody consumes would be a fresh
+    /// silent no-op, the very defect this work removes.
+    #[test]
+    fn the_restoration_switches_reach_the_builder() {
+        for (key, default_on) in [
+            ("evaluate_orig_obj_at_resto_trial", true),
+            ("expect_infeasible_problem", false),
+            ("start_with_resto", false),
+        ] {
+            let mut app = crate::application::IpoptApplication::new();
+            app.initialize().unwrap();
+            let resto = app.algorithm_builder_from_options().resto;
+            let got = match key {
+                "evaluate_orig_obj_at_resto_trial" => resto.evaluate_orig_obj_at_resto_trial,
+                "expect_infeasible_problem" => resto.expect_infeasible_problem,
+                _ => resto.start_with_resto,
+            };
+            assert_eq!(got, default_on, "{key}: default changed");
+
+            // Flip it and check the flip lands.
+            let flipped = if default_on { "no" } else { "yes" };
+            let mut app = crate::application::IpoptApplication::new();
+            app.initialize().unwrap();
+            app.initialize_with_options_str(&format!("{key} {flipped}\n"))
+                .unwrap();
+            let resto = app.algorithm_builder_from_options().resto;
+            let got = match key {
+                "evaluate_orig_obj_at_resto_trial" => resto.evaluate_orig_obj_at_resto_trial,
+                "expect_infeasible_problem" => resto.expect_infeasible_problem,
+                _ => resto.start_with_resto,
+            };
+            assert_eq!(
+                got, !default_on,
+                "{key}={flipped} never reached the builder"
+            );
+        }
     }
 
     /// Options whose *feature* runs and only whose read site is missing

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -1,0 +1,416 @@
+//! Options registered for `ipopt.opt` compatibility whose *feature*
+//! pounce does not implement (gh#483 follow-up, continuing #191).
+//!
+//! # Why these are refused rather than ignored
+//!
+//! `upstream_options.rs` is a faithful port of Ipopt's option registry:
+//! every name Ipopt registers is registered here, so an `ipopt.opt`
+//! written for Ipopt parses unchanged. That is a real compatibility
+//! benefit — and it silently turned ~200 knobs into no-ops, because
+//! registering an option says nothing about implementing it. Setting one
+//! did exactly nothing and said exactly nothing.
+//!
+//! Issue #191 audited this class and fixed the half where the *feature*
+//! runs and only the option's read site was missing. It explicitly
+//! scoped out "feature genuinely unimplemented — expected no-ops". This
+//! module closes that half: an option naming a feature pounce does not
+//! have is now an error, not a shrug.
+//!
+//! # What is and is not in the table
+//!
+//! Membership was established per option, not guessed:
+//!
+//! 1. the option's name appears in **no** crate source outside the
+//!    registry (whole-word — `penalty_max` does not count as present
+//!    because `l1_penalty_max` exists), **and**
+//! 2. the *feature* it configures is absent too.
+//!
+//! Both are needed. An option whose name is unread but whose feature
+//! runs — `max_resto_iter`, the `limited_memory_*` tail, the corrector
+//! knobs — is a missing read site, not a missing feature; refusing those
+//! would fail solves whose current answers are already correct. They are
+//! deliberately **not** here; wiring them is the other half of the work.
+//!
+//! The clearest case is the penalty line search. pounce implements
+//! `IpPenaltyLSAcceptor` (`line_search_method=penalty`), so its knobs
+//! (`nu_init`, `nu_inc`, `rho`, `eta_penalty`) are read sites to add.
+//! Ipopt's *other* penalty acceptor — the CG-penalty / inexact-Newton
+//! one — has no counterpart here at all, and the port registered its
+//! whole option set. Those are refused.
+//!
+//! # The default gate
+//!
+//! Only an explicit value **different from the registered default** is
+//! refused. `expect_infeasible_problem_ctol` left alone, or an
+//! `ipopt.opt` that spells out defaults, must keep working: those ask
+//! for nothing. Refusing them would break the very compatibility the
+//! registry exists to provide.
+
+use pounce_common::options_list::OptionsList;
+use pounce_common::reg_options::{DefaultValue, RegisteredOptions};
+
+/// One unimplemented feature and the options that configure it.
+pub struct UnimplementedFeature {
+    /// Named in the error, e.g. "the CG-penalty / inexact-Newton line search".
+    pub feature: &'static str,
+    /// What the caller can do instead. Empty when there is nothing.
+    pub advice: &'static str,
+    /// The options that belong to it.
+    pub options: &'static [&'static str],
+}
+
+/// Feature groups pounce does not implement. Refused when set.
+pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
+    UnimplementedFeature {
+        feature: "the Chen-Goldfarb (CG-penalty) / inexact-Newton line search \
+                  — Ipopt's `CGPenaltyLSAcceptor`",
+        advice: "pounce implements the filter line search (the default) and \
+                 `line_search_method=penalty` (`IpPenaltyLSAcceptor`); tune \
+                 those instead",
+        options: &[
+            "chi_cup",
+            "chi_hat",
+            "chi_tilde",
+            "delta_y_max",
+            "epsilon_c",
+            "eta_min",
+            "fast_des_fact",
+            "gamma_hat",
+            "gamma_tilde",
+            "kappa_x_dis",
+            "kappa_y_dis",
+            "min_alpha_primal",
+            "mult_diverg_feasibility_tol",
+            "mult_diverg_y_tol",
+            "never_use_fact_cgpen_direction",
+            "never_use_piecewise_penalty_ls",
+            "pen_des_fact",
+            "pen_init_fac",
+            "pen_theta_max_fact",
+            "penalty_init_max",
+            "penalty_init_min",
+            "penalty_max",
+            "penalty_update_compl_tol",
+            "penalty_update_infeasibility_tol",
+            "piecewisepenalty_gamma_infeasi",
+            "piecewisepenalty_gamma_obj",
+            "vartheta",
+            "inexact_algorithm",
+            "fast_step_computation",
+        ],
+    },
+    UnimplementedFeature {
+        feature: "derivative approximation by finite differences",
+        advice: "supply `eval_grad_f` / `eval_jac_g` / `eval_h`, and check them \
+                 with `derivative_test=first-order`",
+        options: &[
+            "gradient_approximation",
+            "jacobian_approximation",
+            "findiff_perturbation",
+        ],
+    },
+    UnimplementedFeature {
+        feature: "linear-dependency detection on the equality constraints",
+        advice: "pounce's presolve removes structurally redundant rows; see \
+                 `presolve`",
+        options: &[
+            "dependency_detector",
+            "dependency_detection_with_rhs",
+            "ma28_pivtol",
+        ],
+    },
+    UnimplementedFeature {
+        feature: "the per-iteration NaN/Inf check on derivative matrices",
+        advice: "`derivative_test=first-order` checks the derivatives once, at \
+                 the starting point",
+        options: &["check_derivatives_for_naninf"],
+    },
+    UnimplementedFeature {
+        feature: "multiplier recalculation by least squares",
+        advice: "",
+        options: &["recalc_y", "recalc_y_feas_tol"],
+    },
+    UnimplementedFeature {
+        feature: "a selectable constraint-violation norm",
+        advice: "pounce measures the violation in the 2-norm throughout",
+        options: &["constraint_violation_norm_type"],
+    },
+    UnimplementedFeature {
+        feature: "magic steps",
+        advice: "",
+        options: &["magic_steps"],
+    },
+    UnimplementedFeature {
+        feature: "bound replacement on the original problem",
+        advice: "",
+        options: &["replace_bounds"],
+    },
+    UnimplementedFeature {
+        feature: "the L-BFGS augmented-system and space variants",
+        advice: "`hessian_approximation=limited-memory` uses the low-rank \
+                 augmented system unconditionally",
+        options: &["hessian_approximation_space", "limited_memory_aug_solver"],
+    },
+    UnimplementedFeature {
+        feature: "the linear-variable count hint for L-BFGS",
+        advice: "",
+        options: &["num_linear_variables"],
+    },
+    UnimplementedFeature {
+        feature: "reading options from a file",
+        advice: "pass options on the command line (`pounce model.nl key=value`) \
+                 or, from a library, via `initialize_with_options_str`",
+        options: &["option_file_name"],
+    },
+    UnimplementedFeature {
+        feature: "skipping the finalize-solution callback",
+        advice: "",
+        options: &["skip_finalize_solution_call"],
+    },
+    UnimplementedFeature {
+        feature: "the dynamic HSL loader",
+        advice: "MA57 is linked at build time with `--features ma57`",
+        options: &["hsllib"],
+    },
+    UnimplementedFeature {
+        feature: "these output controls",
+        advice: "use `print_level` (0 silences the solver) and `sb=yes` to \
+                 suppress the banner",
+        options: &["suppress_all_output", "debug_print_level"],
+    },
+    UnimplementedFeature {
+        feature: "a randomly perturbed evaluation point for the derivative \
+                  checker",
+        advice: "pounce's checker tests at the (bound-projected) starting point, \
+                 which is where the solve actually begins",
+        options: &["point_perturbation_radius"],
+    },
+];
+
+/// Options that *are* honored in the sense that matters — the answer is
+/// unaffected — but whose performance hint pounce does not exploit.
+/// These warn rather than fail: refusing them would stop a solve that
+/// returns the right result today, only a little slower.
+pub const UNEXPLOITED_HINTS: &[&str] = &[
+    "grad_f_constant",
+    "hessian_constant",
+    "jac_c_constant",
+    "jac_d_constant",
+];
+
+/// An option set to something the registry says is not its default.
+///
+/// Both halves matter. `found` alone would fire on an `ipopt.opt` that
+/// spells out a default; comparing values alone would fire on nothing,
+/// since an unset option *reads back* as its default.
+fn set_to_a_non_default(options: &OptionsList, reg: &RegisteredOptions, name: &str) -> bool {
+    let Some(opt) = reg.get_option(name) else {
+        return false;
+    };
+    match &opt.default {
+        // Bools are registered as `yes`/`no` string options, so this arm
+        // covers them too.
+        DefaultValue::String(d) => {
+            matches!(options.get_string_value(name, ""), Ok((v, true)) if !v.eq_ignore_ascii_case(d))
+        }
+        DefaultValue::Number(d) => {
+            matches!(options.get_numeric_value(name, ""), Ok((v, true)) if v != *d)
+        }
+        DefaultValue::Integer(d) => {
+            matches!(options.get_integer_value(name, ""), Ok((v, true)) if v != *d)
+        }
+        DefaultValue::None => false,
+    }
+}
+
+/// The first unimplemented-feature option the caller set, with the
+/// message it earns. `None` when nothing in the table was touched.
+pub fn refusal(options: &OptionsList, reg: &RegisteredOptions) -> Option<String> {
+    for group in UNIMPLEMENTED_FEATURES {
+        for name in group.options {
+            if set_to_a_non_default(options, reg, name) {
+                let advice = if group.advice.is_empty() {
+                    String::new()
+                } else {
+                    format!(" Instead: {}.", group.advice)
+                };
+                return Some(format!(
+                    "pounce: `{name}` configures {}, which pounce does not \
+                     implement. It is registered so an ipopt.opt written for \
+                     Ipopt still parses, but setting it used to do nothing at \
+                     all — silently — so it is refused instead.{advice} \
+                     Remove it to run. Tracking issue: \
+                     https://github.com/jkitchin/pounce/issues/483",
+                    group.feature
+                ));
+            }
+        }
+    }
+    None
+}
+
+/// Warnings for hints pounce does not exploit. Never blocks a solve.
+pub fn hint_warnings(options: &OptionsList, reg: &RegisteredOptions) -> Vec<String> {
+    UNEXPLOITED_HINTS
+        .iter()
+        .filter(|name| set_to_a_non_default(options, reg, name))
+        .map(|name| {
+            format!(
+                "pounce: warning: `{name}` is a caching hint pounce does not \
+                 exploit — it re-evaluates each iteration regardless. Your \
+                 answer is unaffected; only the evaluation count is. \
+                 (gh#483)"
+            )
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn registry() -> std::rc::Rc<RegisteredOptions> {
+        let r = RegisteredOptions::new();
+        crate::upstream_options::register_all_upstream_options(&r).expect("register");
+        r
+    }
+
+    /// A fresh options list over the shared registry, plus a handle on
+    /// the registry itself for the default lookups.
+    fn fixture() -> (OptionsList, std::rc::Rc<RegisteredOptions>) {
+        let reg = registry();
+        (OptionsList::with_registered(std::rc::Rc::clone(&reg)), reg)
+    }
+
+    /// Every name in the table must actually be registered — a typo
+    /// would make its entry dead code that silently never fires, which
+    /// is the exact failure mode this module exists to remove.
+    #[test]
+    fn every_listed_option_is_registered() {
+        let (_, reg) = fixture();
+        for group in UNIMPLEMENTED_FEATURES {
+            for name in group.options {
+                assert!(
+                    reg.get_option(name).is_some(),
+                    "`{name}` is in the refusal table but is not registered",
+                );
+            }
+        }
+        for name in UNEXPLOITED_HINTS {
+            assert!(
+                reg.get_option(name).is_some(),
+                "`{name}` is in the hint table but is not registered",
+            );
+        }
+    }
+
+    /// No option may appear twice — once in two feature groups, or in
+    /// both tables — or the message a user gets would depend on table
+    /// order.
+    #[test]
+    fn the_tables_do_not_overlap() {
+        let mut seen = BTreeSet::new();
+        for name in UNIMPLEMENTED_FEATURES
+            .iter()
+            .flat_map(|g| g.options.iter())
+            .chain(UNEXPLOITED_HINTS.iter())
+        {
+            assert!(seen.insert(*name), "`{name}` is listed twice");
+        }
+    }
+
+    /// A pristine options list touches nothing.
+    #[test]
+    fn defaults_are_not_refused() {
+        let (opts, reg) = fixture();
+        assert_eq!(refusal(&opts, &reg), None);
+        assert!(hint_warnings(&opts, &reg).is_empty());
+    }
+
+    /// Explicitly writing a default is how a generated `ipopt.opt` looks;
+    /// it asks for nothing and must not fail.
+    #[test]
+    fn explicitly_setting_the_default_is_not_refused() {
+        let (mut opts, reg) = fixture();
+        // `dependency_detector` defaults to "none"; `magic_steps` to "no".
+        opts.set_string_value("dependency_detector", "none", true, false)
+            .unwrap();
+        opts.set_string_value("magic_steps", "no", true, false)
+            .unwrap();
+        assert_eq!(refusal(&opts, &reg), None);
+    }
+
+    /// …but asking for the feature is refused, by name, with a pointer.
+    #[test]
+    fn requesting_an_unimplemented_feature_is_refused() {
+        let (mut opts, reg) = fixture();
+        opts.set_string_value("dependency_detector", "mumps", true, false)
+            .unwrap();
+        let msg = refusal(&opts, &reg).expect("must refuse");
+        assert!(msg.contains("dependency_detector"), "{msg}");
+        assert!(msg.contains("linear-dependency detection"), "{msg}");
+        assert!(msg.contains("483"), "{msg}");
+    }
+
+    /// Numeric knobs of an absent feature are refused the same way.
+    #[test]
+    fn a_numeric_knob_of_an_absent_feature_is_refused() {
+        let (mut opts, reg) = fixture();
+        opts.set_numeric_value("penalty_init_max", 42.0, true, false)
+            .unwrap();
+        let msg = refusal(&opts, &reg).expect("must refuse");
+        assert!(msg.contains("CG-penalty"), "{msg}");
+    }
+
+    /// Hints warn instead of failing: the answer is the same either way,
+    /// so blocking the solve would cost the user more than the silence
+    /// did.
+    #[test]
+    fn caching_hints_warn_but_do_not_refuse() {
+        let (mut opts, reg) = fixture();
+        opts.set_string_value("hessian_constant", "yes", true, false)
+            .unwrap();
+        assert_eq!(refusal(&opts, &reg), None, "a hint must not block a solve");
+        let warnings = hint_warnings(&opts, &reg);
+        assert_eq!(warnings.len(), 1, "{warnings:?}");
+        assert!(warnings[0].contains("hessian_constant"));
+    }
+
+    /// Options whose *feature* runs and only whose read site is missing
+    /// must stay out of the table — refusing them would fail solves that
+    /// are correct today. This pins the boundary the triage drew.
+    #[test]
+    fn options_on_implemented_features_are_not_refused() {
+        for (name, value) in [
+            // restoration runs; these are missing read sites (#191 round 2)
+            ("max_resto_iter", "17"),
+            // the filter line search runs
+            ("accept_after_max_steps", "3"),
+            // L-BFGS runs
+            ("limited_memory_max_skipping", "4"),
+            // the Mehrotra corrector runs
+            ("corrector_type", "affine"),
+        ] {
+            let (mut opts, reg) = fixture();
+            // The table mixes string, integer and numeric options; try
+            // each setter until one takes the value.
+            let set = opts.set_string_value(name, value, true, false).is_ok()
+                || value
+                    .parse::<i32>()
+                    .ok()
+                    .is_some_and(|v| opts.set_integer_value(name, v, true, false).is_ok())
+                || value
+                    .parse::<f64>()
+                    .ok()
+                    .is_some_and(|v| opts.set_numeric_value(name, v, true, false).is_ok());
+            assert!(set, "could not set `{name}` to `{value}`");
+            assert_eq!(
+                refusal(&opts, &reg),
+                None,
+                "`{name}` configures a feature pounce implements; it needs a \
+                 read site, not a refusal",
+            );
+        }
+    }
+}

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -96,7 +96,6 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
             "piecewisepenalty_gamma_obj",
             "vartheta",
             "inexact_algorithm",
-            "fast_step_computation",
         ],
     },
     UnimplementedFeature {
@@ -377,6 +376,32 @@ mod tests {
         assert!(warnings[0].contains("hessian_constant"));
     }
 
+    /// `fast_step_computation` was in the refusal table for one commit,
+    /// added by hand against the membership rule above. It fails here if
+    /// it ever comes back: `PdSearchDirCalc` owns the flag and consumes
+    /// it at two sites, so refusing it would fail a solve pounce can
+    /// serve. Its read site is wired in `algorithm_builder_from_options`.
+    #[test]
+    fn fast_step_computation_is_wired_not_refused() {
+        let (mut opts, reg) = fixture();
+        opts.set_string_value("fast_step_computation", "yes", true, false)
+            .unwrap();
+        assert_eq!(refusal(&opts, &reg), None);
+
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str("fast_step_computation yes\n")
+            .unwrap();
+        assert!(
+            app.algorithm_builder_from_options().fast_step_computation,
+            "the option must reach the builder, or wiring it changed nothing",
+        );
+        // …and the default is still off.
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize().unwrap();
+        assert!(!app.algorithm_builder_from_options().fast_step_computation);
+    }
+
     /// Options whose *feature* runs and only whose read site is missing
     /// must stay out of the table — refusing them would fail solves that
     /// are correct today. This pins the boundary the triage drew.
@@ -391,6 +416,10 @@ mod tests {
             ("limited_memory_max_skipping", "4"),
             // the Mehrotra corrector runs
             ("corrector_type", "affine"),
+            // `PdSearchDirCalc` has the flag and consumes it; it was
+            // briefly in the refusal table by hand, against the rule
+            // above, which would have failed a solve it can serve.
+            ("fast_step_computation", "yes"),
         ] {
             let (mut opts, reg) = fixture();
             // The table mixes string, integer and numeric options; try

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -452,6 +452,37 @@ mod tests {
         }
     }
 
+    /// The L-BFGS σ clamp, wired in gh#483 / #191 round 2.
+    /// `LimMemQuasiNewtonUpdater` consumes both bounds in
+    /// `initial_hessian_scalar`; only the read sites were missing. Note
+    /// the fields are named `init_val_{max,min}`, not after the options —
+    /// which is why a grep for the option name found nothing and the
+    /// consumer had to be located by hand.
+    #[test]
+    fn the_lbfgs_sigma_clamp_reaches_the_builder() {
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize().unwrap();
+        let b = app.algorithm_builder_from_options();
+        assert_eq!(b.limited_memory_init_val_max, 1e8, "default changed");
+        assert_eq!(b.limited_memory_init_val_min, 1e-8, "default changed");
+
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize().unwrap();
+        app.initialize_with_options_str(
+            "limited_memory_init_val_max 5e5\nlimited_memory_init_val_min 1e-3\n",
+        )
+        .unwrap();
+        let b = app.algorithm_builder_from_options();
+        assert_eq!(
+            b.limited_memory_init_val_max, 5e5,
+            "never reached the builder"
+        );
+        assert_eq!(
+            b.limited_memory_init_val_min, 1e-3,
+            "never reached the builder"
+        );
+    }
+
     /// Options whose *feature* runs and only whose read site is missing
     /// must stay out of the table — refusing them would fail solves that
     /// are correct today. This pins the boundary the triage drew.

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -211,7 +211,14 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
         false,
         "EXPERIMENTAL!",
     )?;
-    r.add_string_option("linear_solver", "Linear solver used for step computations.", "ma57", &[("ma27", "use the Harwell routine MA27"), ("ma57", "use the Harwell routine MA57"), ("ma77", "use the Harwell routine HSL_MA77"), ("ma86", "use the Harwell routine HSL_MA86"), ("ma97", "use the Harwell routine HSL_MA97"), ("pardiso", "use the Pardiso package from pardiso-project.org"), ("pardisomkl", "use the Pardiso package from Intel MKL"), ("spral", "use the SPRAL package"), ("wsmp", "use WSMP package"), ("mumps", "use MUMPS package"), ("custom", "use custom linear solver (expert use)"), ("feral", "use FERAL pure-Rust sparse symmetric solver (pounce extension)")], "Determines which linear algebra package is to be used for the solution of the augmented linear system (for obtaining the search directions).")?;
+    // DELIBERATE DIVERGENCE from upstream, which defaults to "ma57".
+    // pounce's own backend is FERAL, and the default must name a solver
+    // this binary actually contains: the upstream default advertised
+    // MA57 to every `print_user_options` dump and every banner while a
+    // pure-Rust build ran FERAL, and an HSL build silently used MA57
+    // without being asked. Opting into HSL is now explicit. Do not
+    // "restore" this to match upstream (gh#483 follow-up).
+    r.add_string_option("linear_solver", "Linear solver used for step computations.", "feral", &[("ma27", "use the Harwell routine MA27"), ("ma57", "use the Harwell routine MA57"), ("ma77", "use the Harwell routine HSL_MA77"), ("ma86", "use the Harwell routine HSL_MA86"), ("ma97", "use the Harwell routine HSL_MA97"), ("pardiso", "use the Pardiso package from pardiso-project.org"), ("pardisomkl", "use the Pardiso package from Intel MKL"), ("spral", "use the SPRAL package"), ("wsmp", "use WSMP package"), ("mumps", "use MUMPS package"), ("custom", "use custom linear solver (expert use)"), ("feral", "use FERAL pure-Rust sparse symmetric solver (pounce extension)")], "Determines which linear algebra package is to be used for the solution of the augmented linear system (for obtaining the search directions).")?;
 
     // Pounce-extension: top-level algorithm selector (Phase 5b
     // §7.1). The default `interior-point` runs the IPOPT-lineage

--- a/crates/pounce-algorithm/tests/honor_original_bounds_finalize.rs
+++ b/crates/pounce-algorithm/tests/honor_original_bounds_finalize.rs
@@ -1,0 +1,153 @@
+//! `honor_original_bounds` at the library boundary — the `x` handed to
+//! `TNLP::finalize_solution` (gh#483 follow-up).
+//!
+//! The CLI reads its `.sol` primal from the `on_converged` hook, but
+//! every other consumer — `pounce-py`'s `Problem.solve`, the C interface,
+//! any Rust `TNLP` — reads it from `finalize_solution`. Those are two
+//! separate lifts of the same iterate, so the projection has to hold on
+//! both or the option means different things depending on who is asking.
+//! This test pins the `finalize_solution` side; `pounce-cli/tests/
+//! honor_original_bounds.rs` pins the `.sol` side.
+//!
+//! Problem: `min (x − 3)²` over `x ∈ [0, 1]` (`m = 0`). The optimum pins
+//! the upper bound, and `bound_relax_factor` (default `1e-8`) widens the
+//! box first, so the converged iterate lands just outside it.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Default)]
+struct BoundPinned {
+    final_x: Option<Vec<Number>>,
+}
+
+impl TNLP for BoundPinned {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 1,
+            m: 0,
+            nnz_jac_g: 0,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = 0.0;
+        b.x_u[0] = 1.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.5;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 3.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 3.0);
+        true
+    }
+
+    fn eval_g(&mut self, _x: &[Number], _new_x: bool, _g: &mut [Number]) -> bool {
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        _mode: SparsityRequest<'_>,
+    ) -> bool {
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow[0] = 0 as Index;
+                jcol[0] = 0 as Index;
+            }
+            SparsityRequest::Values { values } => values[0] = 2.0 * obj_factor,
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.final_x = Some(sol.x.to_vec());
+    }
+}
+
+fn solve(honor: Option<bool>) -> f64 {
+    let mut app = IpoptApplication::new();
+    if let Some(v) = honor {
+        app.options_mut()
+            .set_string_value(
+                "honor_original_bounds",
+                if v { "yes" } else { "no" },
+                true,
+                false,
+            )
+            .unwrap();
+    }
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let concrete = Rc::new(RefCell::new(BoundPinned::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unexpected status {status:?}",
+    );
+    let x = concrete
+        .borrow()
+        .final_x
+        .clone()
+        .expect("finalize_solution never ran");
+    x[0]
+}
+
+/// Unset and explicit-`no` behave identically, and both report the
+/// relaxed point — upstream's default, unchanged by the fix.
+#[test]
+fn default_hands_finalize_the_unprojected_point() {
+    let unset = solve(None);
+    let explicit_no = solve(Some(false));
+    assert!(unset > 1.0, "expected x past the bound, got {unset}");
+    assert!((unset - 1.0).abs() < 1e-6, "…but only by the relaxation");
+    assert_eq!(unset, explicit_no, "unset and `no` must agree");
+}
+
+/// `yes` projects: the TNLP is handed a point inside its own bounds.
+/// Pre-fix the option was never read and this equalled the default.
+#[test]
+fn opting_in_hands_finalize_a_point_inside_the_bounds() {
+    let x = solve(Some(true));
+    assert!(x <= 1.0, "x = {x} is outside the declared bound 1");
+    assert_eq!(x, 1.0, "an active bound should project exactly onto it");
+}

--- a/crates/pounce-algorithm/tests/user_scaling_variable_factors.rs
+++ b/crates/pounce-algorithm/tests/user_scaling_variable_factors.rs
@@ -1,0 +1,187 @@
+//! Regression test for gh#483: `nlp_scaling_method=user-scaling` with
+//! per-variable scaling factors must fail the solve, not run it with
+//! the factors quietly thrown away.
+//!
+//! pounce models objective and constraint scaling only. Until this
+//! test, `OrigIpoptNlp::scale_user_supplied` ended in
+//!
+//! ```text
+//! // `use_x_scaling`: silently ignored (not modeled — see doc).
+//! let _ = use_x_scaling;
+//! ```
+//!
+//! so a TNLP that asked for variable scaling got a converged answer to
+//! a differently-conditioned problem than the one it described, with
+//! nothing in the log to say the request had been dropped. The
+//! objective and constraint factors on the same request *were* applied,
+//! which makes the discard worse than a plain no-op: the conditioning
+//! that came back was neither what was asked for nor the unscaled
+//! problem.
+//!
+//! Problem (n = 2, m = 1): `min (x0 - 3)^2 + (x1 - 2)^2` s.t.
+//! `x0 + x1 = 1`. Small, convex, and solvable — so a failure here is
+//! the refusal, never the model.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, ScalingRequest, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `min (x0 - 3)^2 + (x1 - 2)^2` s.t. `x0 + x1 = 1`, reporting
+/// whatever `x_scaling` it is constructed with.
+struct UserScaled {
+    x_scaling: Vec<Number>,
+    solved: bool,
+}
+
+impl TNLP for UserScaled {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 2,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-1e20, -1e20]);
+        b.x_u.copy_from_slice(&[1e20, 1e20]);
+        b.g_l[0] = 1.0;
+        b.g_u[0] = 1.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.0, 0.0]);
+        true
+    }
+
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        *req.obj_scaling = 2.0;
+        *req.use_g_scaling = true;
+        req.g_scaling[0] = 4.0;
+        *req.use_x_scaling = true;
+        req.x_scaling.copy_from_slice(&self.x_scaling);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 3.0).powi(2) + (x[1] - 2.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 3.0);
+        g[1] = 2.0 * (x[1] - 2.0);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0 as Index, 0]);
+                jcol.copy_from_slice(&[0 as Index, 1]);
+            }
+            SparsityRequest::Values { values } => values.copy_from_slice(&[1.0, 1.0]),
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0 as Index, 1]);
+                jcol.copy_from_slice(&[0 as Index, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[2.0 * obj_factor, 2.0 * obj_factor])
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.solved = true;
+    }
+}
+
+/// Run the problem under `user-scaling` with the given variable
+/// factors; returns `(status, reached_finalize_solution)`.
+fn solve_with_x_scaling(x_scaling: &[Number]) -> (ApplicationReturnStatus, bool) {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "user-scaling", true, false)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+
+    let concrete = Rc::new(RefCell::new(UserScaled {
+        x_scaling: x_scaling.to_vec(),
+        solved: false,
+    }));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    let solved = concrete.borrow().solved;
+    (status, solved)
+}
+
+/// Non-unit variable factors are refused up front. Pre-fix this
+/// returned `SolveSucceeded` after solving with only the objective and
+/// constraint factors applied.
+#[test]
+fn variable_scaling_factors_are_refused() {
+    let (status, solved) = solve_with_x_scaling(&[1.0, 1e4]);
+    assert!(
+        matches!(status, ApplicationReturnStatus::InvalidOption),
+        "expected InvalidOption for an unmodelable x_scaling, got {status:?}",
+    );
+    assert!(
+        !solved,
+        "the solve must not run at all — a converged answer here is an \
+         answer to a problem the caller did not describe",
+    );
+}
+
+/// An all-ones `x_scaling` asks for nothing, so it is a no-op and the
+/// solve proceeds normally with the objective/constraint factors. The
+/// refusal must be about factors that change the problem, not about
+/// the request channel being used at all.
+#[test]
+fn unit_variable_scaling_still_solves() {
+    let (status, solved) = solve_with_x_scaling(&[1.0, 1.0]);
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "unit x_scaling must not block the solve, got {status:?}",
+    );
+    assert!(solved, "finalize_solution should have run");
+}

--- a/crates/pounce-cinterface/include/pounce.h
+++ b/crates/pounce-cinterface/include/pounce.h
@@ -197,7 +197,12 @@ bool OpenIpoptOutputFile(
 /** Install user-provided NLP scaling. Pass NULL for `x_scaling` or
  *  `g_scaling` to leave that axis unscaled. Set option
  *  `nlp_scaling_method = user-scaling` for the scaling to take
- *  effect. */
+ *  effect.
+ *
+ *  pounce models objective and constraint scaling only. A non-trivial
+ *  `x_scaling` is stored here (this call still returns true) and then
+ *  refused by IpoptSolve, which returns Invalid_Option and prints why,
+ *  rather than silently solving an unscaled-in-x problem. */
 bool SetIpoptProblemScaling(
     IpoptProblem ipopt_problem,
     ipnumber     obj_scaling,

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -491,7 +491,11 @@ pub unsafe extern "C" fn OpenIpoptOutputFile(
 /// `nlp_scaling_method=user-scaling` is set. Passing NULL for
 /// `x_scaling` / `g_scaling` disables scaling on that axis.
 ///
-/// Always returns `TRUE`.
+/// Always returns `TRUE` (the upstream contract). pounce models only
+/// objective and constraint scaling: a non-trivial `x_scaling` is not
+/// dropped here but refused at solve time, where [`IpoptSolve`] returns
+/// `Invalid_Option` and the journalist explains why (gh#483). Store-time
+/// validation is not an option — the C signature has no way to report it.
 ///
 /// # Safety
 ///

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -580,6 +580,22 @@ pub fn main() -> ExitCode {
                 || s.con_real.contains_key("scaling_factor")
                 || s.var_real.contains_key("scaling_factor")
         });
+    // gh#483 follow-up: `obj_scaling_factor` is an NLP-path knob — the convex
+    // solvers run their own equilibration and never read it. A *negative*
+    // factor is upstream's documented spelling for "maximize", so dropping it
+    // does not merely leave the conditioning alone: the convex path minimizes
+    // an objective the user asked to maximize and reports the wrong optimum
+    // with no complaint. (`min (x−3)²` over `x ∈ [0,1]` with
+    // `obj_scaling_factor=-1` returned `x = 1`, the minimizer, instead of
+    // `x = 0`.) A *positive* factor is genuinely inert on that path — it
+    // reports natural units already, so both paths give the same answer — and
+    // is deliberately not treated as a conflict.
+    let maximize_via_obj_scaling = app
+        .options()
+        .get_numeric_value("obj_scaling_factor", "")
+        .ok()
+        .and_then(|(v, set)| set.then_some(v))
+        .is_some_and(|v| v < 0.0);
     // Human-readable description of the requested post-optimal work, reused in
     // the "not available on this path" messages below.
     let postopt_what = match (wants_sens, args.compute_red_hessian) {
@@ -671,8 +687,18 @@ pub fn main() -> ExitCode {
         // callback, so routing there would accept the option and mean "none".
         let decline_convex_for_user_scaling =
             wants_user_scaling && matches!(selection, SolverSelection::Auto);
-        // Either reason declines the fast path; the messages below say which.
-        let decline_convex = decline_convex_for_postopt || decline_convex_for_user_scaling;
+
+        // gh#483 follow-up: a negative `obj_scaling_factor` means maximize,
+        // which the convex path cannot express. Unlike the two requests above
+        // — where the fast path merely skips *extra* work — taking it here
+        // returns the wrong optimum, so under an explicit `solver_selection`
+        // this is refused outright below rather than warned about.
+        let decline_convex_for_obj_scaling =
+            maximize_via_obj_scaling && matches!(selection, SolverSelection::Auto);
+        // Any of these declines the fast path; the messages below say which.
+        let decline_convex = decline_convex_for_postopt
+            || decline_convex_for_user_scaling
+            || decline_convex_for_obj_scaling;
 
         // Same bargain for a conic solve that finishes without a verified KKT
         // point: under `auto` the class was our inference, not the user's
@@ -725,6 +751,24 @@ pub fn main() -> ExitCode {
                 | SolverChoice::SocpIpm
                 | SolverChoice::QpActiveSet
         ) {
+            // gh#483 follow-up: a forced convex solver plus a negative
+            // `obj_scaling_factor` has no honest outcome — the engine cannot
+            // maximize, and running it anyway hands back the minimizer of the
+            // problem the user asked to maximize. Refuse, the way a
+            // class/solver mismatch is refused, instead of warning and
+            // returning a wrong answer.
+            if maximize_via_obj_scaling && !decline_convex_for_obj_scaling {
+                eprintln!(
+                    "pounce: obj_scaling_factor is negative (maximize), but \
+                     solver_selection={sel_str} forces the convex solver \
+                     (pounce-convex), which minimizes and does not read that \
+                     option — it would report the minimizer of the objective \
+                     you asked to maximize. Use solver_selection=nlp or auto \
+                     (which routes here automatically), or negate the \
+                     objective in the model and drop obj_scaling_factor."
+                );
+                return ExitCode::from(2);
+            }
             // issue #196: if the .nl requested a sensitivity / reduced-Hessian
             // step, either reroute (auto) or warn (explicit convex force) so
             // the fast path never silently drops it.
@@ -769,6 +813,18 @@ pub fn main() -> ExitCode {
                          Use solver_selection=nlp or auto to apply it."
                     );
                 }
+            }
+            // gh#483 follow-up: the auto-reroute half of the negative
+            // `obj_scaling_factor` case (the forced half exited above).
+            if decline_convex_for_obj_scaling {
+                eprintln!(
+                    "pounce: note: this problem classifies as {} but \
+                     obj_scaling_factor is negative (maximize), which the \
+                     convex solver (pounce-convex) cannot express; routing to \
+                     the general NLP interior-point path so the objective \
+                     sense is honored.",
+                    class.name()
+                );
             }
             // The convex solvers need the parsed `NlProblem`, but the initial
             // parse moved it into `NlTnlp`. Re-parse the file here — only on
@@ -944,7 +1000,20 @@ pub fn main() -> ExitCode {
             // Lift to full length so a fixed / eliminated variable
             // still occupies its slot — AMPL's `.sol` reader matches
             // the x block against the originating `.nl`'s var count.
-            let x = nlp.borrow().lift_x_to_full(&*curr.x);
+            let x_iterate = nlp.borrow().lift_x_to_full(&*curr.x);
+            // The `.sol` / JSON `solution.x` is the point the user is
+            // *told* is the solution, so it goes through
+            // `finalize_solution_x` — which adds the
+            // `honor_original_bounds` projection undoing the
+            // `bound_relax_factor` widening. Without it a bound-pinned
+            // solution is reported just outside its own declared bounds
+            // even with the option on, because this hook reads the raw
+            // iterate rather than the `finalize_solution` payload.
+            // `x_iterate` stays unprojected for the sensitivity /
+            // reduced-Hessian steps below: those expand around the point
+            // the KKT factorization was built at, and must not be handed
+            // a base shifted out from under it.
+            let x = nlp.borrow().finalize_solution_x(&*curr.x);
             // Reassemble the user-facing `lambda` (length `n_full_g`, in
             // original `.nl` g-row order) via `finalize_solution_lambda`, which
             // inverts the c/d split through `c_map`/`d_map`, unwinds the
@@ -1015,7 +1084,7 @@ pub fn main() -> ExitCode {
                         suffixes,
                         n_full,
                         m_full,
-                        &x,
+                        &x_iterate,
                         boundcheck_eps,
                     ) {
                         *sens_cap.borrow_mut() = Some(xp);

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -396,6 +396,17 @@ pub fn main() -> ExitCode {
         );
         return ExitCode::from(2);
     }
+    // Same treatment for every other option naming a feature pounce does
+    // not implement, and the same reason for checking here: a model that
+    // routes to `pounce-convex` never reaches `optimize_tnlp`, where the
+    // library-side copy of this guard lives.
+    if let Some(msg) = app.unimplemented_option_refusal() {
+        eprintln!("{msg}");
+        return ExitCode::from(2);
+    }
+    for warning in app.unexploited_hint_warnings() {
+        eprintln!("{warning}");
+    }
 
     // Branded logo + copyright banner, printed up-front — before the
     // problem is even read — so they head the output. `sb yes` suppresses

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -398,30 +398,30 @@ pub fn main() -> ExitCode {
     }
 
     // Branded logo + copyright banner, printed up-front — before the
-    // problem is even read — so they head the output. The registered
-    // default for `linear_solver` mirrors upstream IPOPT (`"ma57"`), but
-    // pounce's actual backend is FERAL; only treat `"ma57"` as user
-    // intent when explicitly set, else the banner would always claim
-    // "ma57 requested". `sb yes` suppresses both (mirrors upstream
-    // `IpoptApplication::Initialize`).
+    // problem is even read — so they head the output. `sb yes` suppresses
+    // both (mirrors upstream `IpoptApplication::Initialize`).
+    //
+    // The registered default is `feral`, so the option's resolved value is
+    // the whole story and the "was it explicitly set?" flag this used to
+    // consult is no longer needed: `ma57` here always means someone asked
+    // for it. (Under upstream's `ma57` default it did not, and the banner
+    // would otherwise have claimed "ma57 requested" on every run.)
     let backend_tag = {
-        let (v, explicit) = app
+        let (v, _) = app
             .options()
             .get_string_value("linear_solver", "")
             .unwrap_or_else(|_| ("feral".to_string(), false));
-        match (v.as_str(), explicit) {
-            ("ma57", true) => {
-                #[cfg(feature = "ma57")]
-                {
-                    "MA57 (HSL)"
-                }
-                #[cfg(not(feature = "ma57"))]
-                {
-                    "FERAL (ma57 requested but not compiled)"
-                }
+        if v.eq_ignore_ascii_case("ma57") {
+            #[cfg(feature = "ma57")]
+            {
+                "MA57 (HSL)"
             }
-            ("ma57", false) => "FERAL",
-            _ => "FERAL",
+            #[cfg(not(feature = "ma57"))]
+            {
+                "FERAL (ma57 requested but not compiled)"
+            }
+        } else {
+            "FERAL"
         }
     };
     let suppress_banner = app

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -563,6 +563,23 @@ pub fn main() -> ExitCode {
         .map(sens::is_sensitivity_input)
         .unwrap_or(false);
     let wants_nlp_postopt = wants_sens || args.compute_red_hessian;
+    // gh#483: does the run ask for user NLP scaling — `nlp_scaling_method=
+    // user-scaling` together with at least one `scaling_factor` suffix in the
+    // `.nl` for the solver to read? Only the general NLP path implements the
+    // scaling callback, so this gates the same "reroute or warn" treatment
+    // the post-optimal request gets, rather than the option quietly meaning
+    // "no scaling" on a specialized path.
+    let wants_user_scaling = app
+        .options()
+        .get_string_value("nlp_scaling_method", "")
+        .ok()
+        .and_then(|(v, set)| set.then_some(v))
+        .is_some_and(|v| v == "user-scaling")
+        && nl_suffixes.as_ref().is_some_and(|s| {
+            s.obj_real.contains_key("scaling_factor")
+                || s.con_real.contains_key("scaling_factor")
+                || s.var_real.contains_key("scaling_factor")
+        });
     // Human-readable description of the requested post-optimal work, reused in
     // the "not available on this path" messages below.
     let postopt_what = match (wants_sens, args.compute_red_hessian) {
@@ -647,6 +664,16 @@ pub fn main() -> ExitCode {
         let decline_convex_for_postopt =
             wants_nlp_postopt && matches!(selection, SolverSelection::Auto);
 
+        // gh#483: same bargain for user NLP scaling. `nlp_scaling_method=
+        // user-scaling` plus the `.nl`'s `scaling_factor` suffixes is honored
+        // by the general NLP interior-point path only — the convex solvers run
+        // their own internal equilibration and never see the TNLP's scaling
+        // callback, so routing there would accept the option and mean "none".
+        let decline_convex_for_user_scaling =
+            wants_user_scaling && matches!(selection, SolverSelection::Auto);
+        // Either reason declines the fast path; the messages below say which.
+        let decline_convex = decline_convex_for_postopt || decline_convex_for_user_scaling;
+
         // Same bargain for a conic solve that finishes without a verified KKT
         // point: under `auto` the class was our inference, not the user's
         // instruction, so fall through to the NLP filter-IPM (a convex QCQP is
@@ -663,7 +690,7 @@ pub fn main() -> ExitCode {
         // fast-path for a post-optimal request (#196), report the NLP path that
         // actually runs, not the convex one `resolve_solver` picked.
         if !suppress_banner && !json_dbg {
-            let described = if decline_convex_for_postopt {
+            let described = if decline_convex {
                 SolverChoice::Nlp.describe()
             } else {
                 choice.describe()
@@ -720,16 +747,41 @@ pub fn main() -> ExitCode {
                     );
                 }
             }
+            // gh#483: same treatment for `nlp_scaling_method=user-scaling`.
+            if wants_user_scaling {
+                if decline_convex_for_user_scaling {
+                    eprintln!(
+                        "pounce: note: this problem classifies as {} but \
+                         nlp_scaling_method=user-scaling asks for the .nl's \
+                         `scaling_factor` suffixes to be applied, which the \
+                         convex solver (pounce-convex) does not do; routing to \
+                         the general NLP interior-point path so the scaling is \
+                         honored.",
+                        class.name()
+                    );
+                } else {
+                    eprintln!(
+                        "pounce: warning: nlp_scaling_method=user-scaling asks \
+                         for the .nl's `scaling_factor` suffixes to be applied, \
+                         but solver_selection={sel_str} forces the convex solver \
+                         (pounce-convex), which equilibrates internally and does \
+                         not read them; the requested scaling will be skipped. \
+                         Use solver_selection=nlp or auto to apply it."
+                    );
+                }
+            }
             // The convex solvers need the parsed `NlProblem`, but the initial
             // parse moved it into `NlTnlp`. Re-parse the file here — only on
             // the convex dispatch path (LP / convex-QP / SOCP), never for a
             // general NLP solve. Only `.nl` inputs ever classify as convex, so
             // the builtin arm falls through to NLP. A parse failure surfaces
             // and exits rather than silently mis-routing to NLP (L24).
-            if decline_convex_for_postopt {
-                // Declined for #196: fall through to the NLP solve below, which
-                // runs the sensitivity / reduced-Hessian step in `on_converged`
-                // and writes `sens_sol_state_1` to the `.sol`.
+            if decline_convex {
+                // Declined for #196 / gh#483: fall through to the NLP solve
+                // below, which runs the sensitivity / reduced-Hessian step in
+                // `on_converged` (writing `sens_sol_state_1` to the `.sol`) and
+                // reads the `scaling_factor` suffixes through the TNLP scaling
+                // callback.
             } else if let ProblemSource::NlFile(path) = &args.problem {
                 let prob = match nl_reader::read_nl_file(path) {
                     Ok(p) => p,

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -384,6 +384,19 @@ pub fn main() -> ExitCode {
     );
     app.set_restoration_factory_provider(resto_provider);
 
+    // gh#483 follow-up: refuse a `linear_solver` pounce does not
+    // implement. Checked here — before the banner, and before the routing
+    // that would send an LP/QP to `pounce-convex` without ever reaching
+    // `optimize_tnlp`'s copy of this guard — so the verdict does not
+    // depend on which engine the problem happens to classify into.
+    if let Some(value) = app.unimplemented_linear_solver() {
+        eprintln!(
+            "{}",
+            IpoptApplication::unimplemented_linear_solver_message(&value)
+        );
+        return ExitCode::from(2);
+    }
+
     // Branded logo + copyright banner, printed up-front — before the
     // problem is even read — so they head the output. The registered
     // default for `linear_solver` mirrors upstream IPOPT (`"ma57"`), but
@@ -751,6 +764,13 @@ pub fn main() -> ExitCode {
                 | SolverChoice::SocpIpm
                 | SolverChoice::QpActiveSet
         ) {
+            // gh#483 follow-up: `derivative_test` is about the *model*,
+            // not the engine, so on the convex route it is run here rather
+            // than declined — this dispatch never reaches `optimize_tnlp`,
+            // where the NLP path's copy lives. Checking the raw
+            // `inner_tnlp` keeps the report in the user's own indices, and
+            // running it here (not there) means it cannot fire twice.
+            app.run_derivative_test(&inner_tnlp);
             // gh#483 follow-up: a forced convex solver plus a negative
             // `obj_scaling_factor` has no honest outcome — the engine cannot
             // maximize, and running it anyway hands back the minimizer of the

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -614,12 +614,30 @@ pub fn main() -> ExitCode {
     // `x = 0`.) A *positive* factor is genuinely inert on that path — it
     // reports natural units already, so both paths give the same answer — and
     // is deliberately not treated as a conflict.
-    let maximize_via_obj_scaling = app
+    //
+    // There are *two* channels into the same sign flip, and the guard has to
+    // watch both. The option is one. The other is the `.nl`'s objective
+    // `scaling_factor` suffix under `nlp_scaling_method=user-scaling`:
+    // `scale_user_supplied` installs it as `df` with no sign guard, so a
+    // negative entry maximizes exactly as the option does. Watching only the
+    // option left `scaling_factor[obj] = -1` plus a forced convex solver
+    // returning the minimizer with an "the requested scaling will be skipped"
+    // warning — which understates it, since what is skipped is the objective
+    // sense, not conditioning. Found by adversarial testing of this guard.
+    let negative_obj_scaling_option = app
         .options()
         .get_numeric_value("obj_scaling_factor", "")
         .ok()
         .and_then(|(v, set)| set.then_some(v))
         .is_some_and(|v| v < 0.0);
+    let negative_obj_scaling_suffix = wants_user_scaling
+        && nl_suffixes.as_ref().is_some_and(|s| {
+            s.obj_real
+                .get("scaling_factor")
+                .and_then(|v| v.first())
+                .is_some_and(|&f| f < 0.0)
+        });
+    let maximize_via_obj_scaling = negative_obj_scaling_option || negative_obj_scaling_suffix;
     // Human-readable description of the requested post-optimal work, reused in
     // the "not available on this path" messages below.
     let postopt_what = match (wants_sens, args.compute_red_hessian) {
@@ -790,8 +808,9 @@ pub fn main() -> ExitCode {
             // returning a wrong answer.
             if maximize_via_obj_scaling && !decline_convex_for_obj_scaling {
                 eprintln!(
-                    "pounce: obj_scaling_factor is negative (maximize), but \
-                     solver_selection={sel_str} forces the convex solver \
+                    "pounce: the objective scaling is negative (maximize) — via \
+                     obj_scaling_factor or the .nl's `scaling_factor` suffix — \
+                     but solver_selection={sel_str} forces the convex solver \
                      (pounce-convex), which minimizes and does not read that \
                      option — it would report the minimizer of the objective \
                      you asked to maximize. Use solver_selection=nlp or auto \

--- a/crates/pounce-cli/tests/convex_route_objective_sense.rs
+++ b/crates/pounce-cli/tests/convex_route_objective_sense.rs
@@ -1,0 +1,148 @@
+//! A negative `obj_scaling_factor` must not reach the convex solver
+//! (gh#483 follow-up).
+//!
+//! `obj_scaling_factor` is upstream's documented spelling for
+//! maximization: the IPM minimizes `factor·f`, so a negative factor
+//! maximizes `f`. The convex solvers in `pounce-convex` equilibrate
+//! internally and never read the option — and every LP / convex-QP model
+//! routes to them by default. So `obj_scaling_factor=-1` on
+//! `min (x−3)²  s.t.  x ∈ [0, 1]` returned `x = 1`: the *minimizer* of
+//! the objective the user asked to maximize, reported as
+//! `Optimal Solution Found` with nothing said about it. Solving the same
+//! file with `solver_selection=nlp` gave the right answer, `x = 0`,
+//! which is what made it a routing bug rather than a solver bug.
+//!
+//! The fix follows the routing bargain already used for the #196
+//! post-optimal request: under `auto` decline the fast path and use the
+//! general NLP interior-point solver, which honors the option. Under an
+//! explicit convex `solver_selection` the choice is *refused*, not
+//! warned about — for #196 the fast path merely skipped extra work, but
+//! here it would answer the wrong question.
+//!
+//! A **positive** factor is a different case and deliberately untouched:
+//! it only rescales conditioning, and the convex path already reports
+//! natural units, so both paths agree. Pinned below so the guard cannot
+//! quietly widen into "any non-default factor reroutes".
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// `min (x − 3)²  s.t.  x ∈ [0, 1]` (plus a trivial `x ≥ 0` row so the
+/// file has a constraint). Classifies as a convex QP, so `auto` routes
+/// it to `pounce-convex` by default. Minimizer `x = 1`; maximizer over
+/// the same box `x = 0`.
+fn run(tag: &str, opts: &[&str]) -> (Option<i32>, String, String, Option<f64>) {
+    let dir = std::env::temp_dir().join(format!("pounce_objsense_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join("boxed_qp_min.nl");
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/boxed_qp_min.nl");
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(opts)
+        .arg("print_level=0")
+        .output()
+        .expect("run pounce");
+    // `.sol` layout: message, blank, "Options", 4 header ints, then the
+    // m dual values and the n primal values. m = n = 1 here, so the
+    // solution is the last numeric line.
+    let x = std::fs::read_to_string(nl.with_extension("sol"))
+        .ok()
+        .and_then(|s| {
+            s.lines()
+                .filter_map(|l| l.trim().parse::<f64>().ok())
+                .next_back()
+        });
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        x,
+    )
+}
+
+/// Baseline: no option, convex route, the minimizer.
+#[test]
+fn default_route_minimizes() {
+    let (code, out, err, x) = run("baseline", &[]);
+    assert_eq!(code, Some(0), "stdout:\n{out}\nstderr:\n{err}");
+    assert!(out.contains("convex QP interior-point"), "stdout:\n{out}");
+    let x = x.expect("no solution in .sol");
+    assert!(
+        (x - 1.0).abs() < 1e-6,
+        "expected the minimizer x=1, got {x}"
+    );
+}
+
+/// `obj_scaling_factor=-1` under `auto`: reroute to the NLP path and
+/// return the *maximizer*. Pre-fix this stayed on the convex route and
+/// returned `x = 1`.
+#[test]
+fn negative_obj_scaling_reroutes_and_maximizes() {
+    let (code, out, err, x) = run("maximize", &["obj_scaling_factor=-1"]);
+    assert_eq!(code, Some(0), "stdout:\n{out}\nstderr:\n{err}");
+    assert!(
+        out.contains("NLP filter line-search"),
+        "should have declined the convex fast path; stdout:\n{out}",
+    );
+    assert!(
+        err.contains("cannot express"),
+        "the reroute must say why; stderr:\n{err}",
+    );
+    let x = x.expect("no solution in .sol");
+    assert!(
+        x.abs() < 1e-6,
+        "maximizing (x-3)^2 over [0,1] gives x=0; got {x} \
+         (x=1 means the objective sense was dropped again)",
+    );
+}
+
+/// Same answer when the NLP path is asked for directly — the reroute
+/// must agree with the engine it reroutes to, not merely differ from
+/// the convex one.
+#[test]
+fn forced_nlp_path_agrees_with_the_reroute() {
+    let (code, _out, err, x) = run(
+        "maximize_nlp",
+        &["obj_scaling_factor=-1", "solver_selection=nlp"],
+    );
+    assert_eq!(code, Some(0), "stderr:\n{err}");
+    assert!(x.expect("no solution in .sol").abs() < 1e-6);
+}
+
+/// A forced convex solver plus a maximize request is refused: there is
+/// no honest outcome, so exiting beats reporting the wrong optimum.
+#[test]
+fn negative_obj_scaling_with_a_forced_convex_solver_is_refused() {
+    let (code, out, err, _x) = run(
+        "forced",
+        &["obj_scaling_factor=-1", "solver_selection=qp-ipm"],
+    );
+    assert_eq!(code, Some(2), "stdout:\n{out}\nstderr:\n{err}");
+    assert!(
+        err.contains("minimizer of the objective you asked to maximize"),
+        "the refusal must name the consequence; stderr:\n{err}",
+    );
+}
+
+/// A positive factor only rescales conditioning; the convex path
+/// reports natural units either way, so it keeps the fast path and the
+/// same answer.
+#[test]
+fn positive_obj_scaling_keeps_the_convex_route() {
+    let (code, out, err, x) = run("positive", &["obj_scaling_factor=100"]);
+    assert_eq!(code, Some(0), "stdout:\n{out}\nstderr:\n{err}");
+    assert!(
+        out.contains("convex QP interior-point"),
+        "a positive factor must not reroute; stdout:\n{out}",
+    );
+    let x = x.expect("no solution in .sol");
+    assert!((x - 1.0).abs() < 1e-6, "expected x=1, got {x}");
+}

--- a/crates/pounce-cli/tests/convex_route_objective_sense.rs
+++ b/crates/pounce-cli/tests/convex_route_objective_sense.rs
@@ -19,6 +19,16 @@
 //! warned about — for #196 the fast path merely skipped extra work, but
 //! here it would answer the wrong question.
 //!
+//! The sign flip has **two** channels, and adversarial testing of the
+//! first fix found the guard watching only one. `scale_user_supplied`
+//! installs the `.nl`'s objective `scaling_factor` suffix as `df` with
+//! no sign guard, so under `nlp_scaling_method=user-scaling` a negative
+//! suffix entry maximizes exactly as the option does. With the guard
+//! reading only the option, `scaling_factor[obj] = -1` plus a forced
+//! convex solver returned the minimizer, exit 0, under a warning that
+//! said only "the requested scaling will be skipped" — understating it,
+//! since what was skipped was the objective *sense*.
+//!
 //! A **positive** factor is a different case and deliberately untouched:
 //! it only rescales conditioning, and the convex path already reports
 //! natural units, so both paths agree. Pinned below so the guard cannot
@@ -35,12 +45,17 @@ fn pounce_exe() -> PathBuf {
 /// file has a constraint). Classifies as a convex QP, so `auto` routes
 /// it to `pounce-convex` by default. Minimizer `x = 1`; maximizer over
 /// the same box `x = 0`.
-fn run(tag: &str, opts: &[&str]) -> (Option<i32>, String, String, Option<f64>) {
+fn run_on(
+    fixture_name: &str,
+    tag: &str,
+    opts: &[&str],
+) -> (Option<i32>, String, String, Option<f64>) {
     let dir = std::env::temp_dir().join(format!("pounce_objsense_{tag}"));
     std::fs::create_dir_all(&dir).expect("scratch dir");
-    let nl = dir.join("boxed_qp_min.nl");
+    let nl = dir.join(fixture_name);
     let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    fixture.push("tests/fixtures/boxed_qp_min.nl");
+    fixture.push("tests/fixtures");
+    fixture.push(fixture_name);
     std::fs::copy(&fixture, &nl).expect("copy fixture");
 
     let out = Command::new(pounce_exe())
@@ -66,6 +81,16 @@ fn run(tag: &str, opts: &[&str]) -> (Option<i32>, String, String, Option<f64>) {
         String::from_utf8_lossy(&out.stderr).into_owned(),
         x,
     )
+}
+
+/// The plain `min (x-3)^2 s.t. x in [0,1]` fixture.
+fn run(tag: &str, opts: &[&str]) -> (Option<i32>, String, String, Option<f64>) {
+    run_on("boxed_qp_min.nl", tag, opts)
+}
+
+/// The same problem carrying `scaling_factor[obj] = -1`.
+fn run_neg_suffix(tag: &str, opts: &[&str]) -> (Option<i32>, String, String, Option<f64>) {
+    run_on("boxed_qp_neg_obj_suffix.nl", tag, opts)
 }
 
 /// Baseline: no option, convex route, the minimizer.
@@ -145,4 +170,61 @@ fn positive_obj_scaling_keeps_the_convex_route() {
     );
     let x = x.expect("no solution in .sol");
     assert!((x - 1.0).abs() < 1e-6, "expected x=1, got {x}");
+}
+
+/// The suffix channel into the same sign flip. Under `auto` the
+/// user-scaling reroute already carries this case to the NLP path; the
+/// gap was the forced-convex branch, which warned and returned the
+/// minimizer. Pinned per forced selection, since each reaches the
+/// convex dispatch by its own route.
+#[test]
+fn a_negative_objective_suffix_is_refused_on_a_forced_convex_solver() {
+    for sel in ["qp-ipm", "socp", "qp-active-set"] {
+        let (code, out, err, _x) = run_neg_suffix(
+            &format!("sfx_{sel}"),
+            &[
+                "nlp_scaling_method=user-scaling",
+                &format!("solver_selection={sel}"),
+            ],
+        );
+        assert_eq!(code, Some(2), "{sel}: stdout:\n{out}\nstderr:\n{err}");
+        assert!(
+            err.contains("objective scaling is negative"),
+            "{sel}: the refusal must name the sense flip; stderr:\n{err}",
+        );
+    }
+}
+
+/// …and under `auto` it still reaches the NLP path and maximizes.
+/// `min (x-3)^2` over `[0,1]` has minimizer 1 and maximizer 0, so the
+/// two outcomes are unmistakable.
+#[test]
+fn a_negative_objective_suffix_maximizes_under_auto() {
+    let (code, out, err, x) = run_neg_suffix("sfx_auto", &["nlp_scaling_method=user-scaling"]);
+    assert_eq!(code, Some(0), "stdout:\n{out}\nstderr:\n{err}");
+    assert!(out.contains("NLP filter line-search"), "stdout:\n{out}");
+    let x = x.expect("no solution in .sol");
+    assert!(
+        x.abs() < 1e-6,
+        "expected the maximizer x=0, got {x} (x=1 means the suffix's sign was dropped)",
+    );
+}
+
+/// Control: the same suffix without `user-scaling` is inert, so both
+/// routes minimize. This is what makes the two tests above about the
+/// *sign* rather than about the suffix merely being present.
+#[test]
+fn the_negative_suffix_is_inert_without_user_scaling() {
+    for (i, sel) in ["auto", "nlp"].into_iter().enumerate() {
+        let (code, _out, err, x) = run_neg_suffix(
+            &format!("sfx_inert{i}"),
+            &[&format!("solver_selection={sel}")],
+        );
+        assert_eq!(code, Some(0), "stderr:\n{err}");
+        let x = x.expect("no solution in .sol");
+        assert!(
+            (x - 1.0).abs() < 1e-6,
+            "{sel}: expected the minimizer x=1, got {x}"
+        );
+    }
 }

--- a/crates/pounce-cli/tests/derivative_test_option.rs
+++ b/crates/pounce-cli/tests/derivative_test_option.rs
@@ -1,0 +1,162 @@
+//! `derivative_test` produced no test and no output (gh#483 follow-up).
+//!
+//! All five `derivative_test*` options were registered and none was ever
+//! read, so `derivative_test=first-order` ran nothing and printed
+//! nothing. That is the worst shape an unimplemented option can take: a
+//! *checker* that silently checks nothing reports success by omission —
+//! a user with a hand-written `eval_grad_f` turns it on, sees no
+//! complaints, and concludes the gradient is right.
+//!
+//! The checker's own correctness (does it catch a wrong gradient, a
+//! wrong Jacobian entry, a missing sparsity entry?) is pinned by unit
+//! tests in `pounce-nlp/src/derivative_test.rs`, against TNLPs with
+//! deliberately corrupted derivatives. A `.nl` model cannot express
+//! that — its derivatives come from pounce's own AD — so what is tested
+//! here is the wiring: that the option reaches the engine, on **both**
+//! solver routes, and that it stays off by default.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// Run `fixture_name` with `opts`; returns `(success, stderr)`. The
+/// report goes to stderr so it survives `print_level=0` and leaves
+/// `--json-output`'s stdout clean.
+fn run(fixture_name: &str, tag: &str, opts: &[&str]) -> (bool, String) {
+    let dir = std::env::temp_dir().join(format!("pounce_derivtest_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join(fixture_name);
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures");
+    fixture.push(fixture_name);
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(opts)
+        .arg("print_level=0")
+        .output()
+        .expect("run pounce");
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Off by default — the option's registered default is `none` and a
+/// plain run must be unchanged.
+#[test]
+fn no_report_by_default() {
+    let (ok, err) = run("user_scaling_suffix.nl", "default", &[]);
+    assert!(ok, "stderr:\n{err}");
+    assert!(
+        !err.contains("Derivative checker"),
+        "an unrequested run must print nothing; stderr:\n{err}",
+    );
+}
+
+/// `first-order` reports on the NLP interior-point route. Pre-fix this
+/// printed nothing at all.
+#[test]
+fn first_order_reports_on_the_nlp_route() {
+    let (ok, err) = run(
+        "user_scaling_suffix.nl",
+        "first",
+        &["solver_selection=nlp", "derivative_test=first-order"],
+    );
+    assert!(
+        ok,
+        "the check is advisory and must not fail the solve; {err}"
+    );
+    assert!(
+        err.contains("Derivative checker: first derivatives"),
+        "stderr:\n{err}",
+    );
+    assert!(
+        err.contains("No suspicious derivatives found"),
+        "pounce's own AD derivatives must come back clean; stderr:\n{err}",
+    );
+}
+
+/// The convex dispatch never reaches `optimize_tnlp`, so it needs — and
+/// has — its own call. A model classifying as a convex QP must still be
+/// checked; the test is about the model, not the engine.
+#[test]
+fn first_order_reports_on_the_convex_route() {
+    let (ok, err) = run(
+        "boxed_qp_min.nl",
+        "convex",
+        &["derivative_test=first-order"],
+    );
+    assert!(ok, "stderr:\n{err}");
+    assert!(
+        err.contains("Derivative checker"),
+        "the convex route must run the check too; stderr:\n{err}",
+    );
+}
+
+/// It fires exactly once — the two call sites are mutually exclusive,
+/// not stacked.
+#[test]
+fn the_report_is_not_emitted_twice() {
+    for (tag, fixture, sel) in [
+        ("once_nlp", "user_scaling_suffix.nl", "solver_selection=nlp"),
+        ("once_qp", "boxed_qp_min.nl", "solver_selection=auto"),
+    ] {
+        let (_, err) = run(fixture, tag, &[sel, "derivative_test=first-order"]);
+        assert_eq!(
+            err.matches("Derivative checker").count(),
+            1,
+            "{tag}: stderr:\n{err}",
+        );
+    }
+}
+
+/// `second-order` covers the Hessian as well, and `derivative_test_print_all`
+/// turns the summary into a full listing.
+#[test]
+fn second_order_and_print_all_reach_the_engine() {
+    let (ok, err) = run(
+        "user_scaling_suffix.nl",
+        "second",
+        &[
+            "solver_selection=nlp",
+            "derivative_test=second-order",
+            "derivative_test_print_all=yes",
+        ],
+    );
+    assert!(ok, "stderr:\n{err}");
+    assert!(
+        err.contains("first and second derivatives"),
+        "stderr:\n{err}",
+    );
+    assert!(
+        err.contains("grad_f["),
+        "print_all must list entries; {err}"
+    );
+    assert!(err.contains("h_obj["), "…including the Hessian; {err}");
+}
+
+/// `only-second-order` skips the first-order pass, so no `grad_f`
+/// comparisons appear even under `print_all`.
+#[test]
+fn only_second_order_skips_the_first_order_pass() {
+    let (ok, err) = run(
+        "user_scaling_suffix.nl",
+        "onlysecond",
+        &[
+            "solver_selection=nlp",
+            "derivative_test=only-second-order",
+            "derivative_test_print_all=yes",
+        ],
+    );
+    assert!(ok, "stderr:\n{err}");
+    assert!(err.contains("h_obj["), "stderr:\n{err}");
+    assert!(
+        !err.contains("grad_f["),
+        "the first-order pass must be skipped; stderr:\n{err}",
+    );
+}

--- a/crates/pounce-cli/tests/fixtures/boxed_qp_fixed_var.nl
+++ b/crates/pounce-cli/tests/fixtures/boxed_qp_fixed_var.nl
@@ -1,0 +1,42 @@
+g3 1 1 0	# problem unknown
+ 2 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 2 2 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 2 2 	# nonzeros in Jacobian, obj. gradient
+ 1 1	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0	#c
+o2	#*
+v0	#x
+v1	#f
+O0 0	#o
+o0	#+
+o5	#^
+o0	#+
+v0	#x
+n-3
+n2
+o5	#^
+o0	#+
+v1	#f
+n-1
+n2
+x2	# initial guess
+0 0.5	#x
+1 2.0	#f
+r	#1 ranges (rhs's)
+2 0.0	#c
+b	#2 bounds (on variables)
+0 0 1	#x
+4 2.0	#f
+k1	#intermediate Jacobian column lengths
+1
+J0 2	#c
+0 0
+1 0
+G0 2	#o
+0 0
+1 0

--- a/crates/pounce-cli/tests/fixtures/boxed_qp_min.nl
+++ b/crates/pounce-cli/tests/fixtures/boxed_qp_min.nl
@@ -1,0 +1,29 @@
+g3 1 1 0	# problem unknown
+ 1 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+O0 0
+o5
+o0
+v0
+n-3
+n2
+x1
+0 0.5
+r
+2 0.0
+b
+0 0 1
+k0
+J0 1
+0 1
+G0 1
+0 0

--- a/crates/pounce-cli/tests/fixtures/boxed_qp_neg_obj_suffix.nl
+++ b/crates/pounce-cli/tests/fixtures/boxed_qp_neg_obj_suffix.nl
@@ -1,0 +1,31 @@
+g3 1 1 0	# problem unknown
+ 1 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+S6 1 scaling_factor
+0 -1.0
+C0
+n0
+O0 0
+o5
+o0
+v0
+n-3
+n2
+x1
+0 0.5
+r
+2 0.0
+b
+0 0 1
+k0
+J0 1
+0 1
+G0 1
+0 0

--- a/crates/pounce-cli/tests/fixtures/user_scaling_suffix.nl
+++ b/crates/pounce-cli/tests/fixtures/user_scaling_suffix.nl
@@ -1,0 +1,52 @@
+g3 1 1 0	# problem unknown
+ 2 2 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 2 2 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+S5 1 scaling_factor
+0 10.0
+S6 1 scaling_factor
+0 100.0
+C0
+o2
+v0
+v1
+C1
+n0
+O0 0
+o0
+o5
+o0
+v0
+n-2
+n4
+o5
+o0
+v1
+n-3
+n2
+x2
+0 1.0
+1 1.0
+r
+2 1
+4 0.5
+b
+3
+3
+k1
+2
+J0 2
+0 0
+1 0
+J1 2
+0 1
+1 -1
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/fixtures/user_scaling_var_suffix.nl
+++ b/crates/pounce-cli/tests/fixtures/user_scaling_var_suffix.nl
@@ -1,0 +1,54 @@
+g3 1 1 0	# problem unknown
+ 2 2 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 2 2 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+S4 1 scaling_factor
+0 3.0
+S5 1 scaling_factor
+0 10.0
+S6 1 scaling_factor
+0 100.0
+C0
+o2
+v0
+v1
+C1
+n0
+O0 0
+o0
+o5
+o0
+v0
+n-2
+n4
+o5
+o0
+v1
+n-3
+n2
+x2
+0 1.0
+1 1.0
+r
+2 1
+4 0.5
+b
+3
+3
+k1
+2
+J0 2
+0 0
+1 0
+J1 2
+0 1
+1 -1
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/honor_original_bounds.rs
+++ b/crates/pounce-cli/tests/honor_original_bounds.rs
@@ -119,3 +119,68 @@ fn an_interior_solution_is_unmoved() {
     let _ = std::fs::remove_dir_all(&dir);
     assert_eq!(plain, honored);
 }
+
+/// Composition with `fixed_variable_treatment=relax_bounds`, where fixed
+/// variables stay in the algorithm's free block with tight bounds rather
+/// than being spliced back at their value. That is the path where the
+/// projection's `x_l_map` / `x_u_map` indexing could go wrong, and it is
+/// also where the relaxation does visible damage: the *fixed* variable
+/// drifts off its own fixed value by the relaxation width. Projecting
+/// repairs it.
+///
+/// Under the default `make_parameter` the fixed value is spliced back
+/// untouched, so both settings agree there — asserted too, so the test
+/// says which treatment is doing the work.
+#[test]
+fn a_fixed_variable_is_restored_under_relax_bounds() {
+    let read = |treatment: &str, honor: &str, tag: &str| -> Vec<f64> {
+        let dir = std::env::temp_dir().join(format!("pounce_honorbounds_{tag}"));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let nl = dir.join("boxed_qp_fixed_var.nl");
+        let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        fixture.push("tests/fixtures/boxed_qp_fixed_var.nl");
+        std::fs::copy(&fixture, &nl).expect("copy fixture");
+        let out = Command::new(pounce_exe())
+            .arg(&nl)
+            .arg("solver_selection=nlp")
+            .arg("print_level=0")
+            .arg(format!("fixed_variable_treatment={treatment}"))
+            .arg(format!("honor_original_bounds={honor}"))
+            .output()
+            .expect("run pounce");
+        assert!(
+            out.status.success(),
+            "{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let sol = std::fs::read_to_string(nl.with_extension("sol")).expect("read .sol");
+        let _ = std::fs::remove_dir_all(&dir);
+        let v: Vec<f64> = sol
+            .lines()
+            .filter_map(|l| l.trim().parse::<f64>().ok())
+            .collect();
+        // n = 2: `x` (bounded [0,1], pins at 1) then `f` (fixed at 2).
+        v[v.len() - 2..].to_vec()
+    };
+
+    // `relax_bounds`: the fixed variable drifts off 2.0 without the
+    // projection, and lands exactly on it with.
+    let drifted = read("relax_bounds", "no", "relax_no");
+    assert!(
+        (drifted[1] - 2.0).abs() > 1e-12,
+        "expected the fixed variable to drift under relax_bounds, got {drifted:?}",
+    );
+    let projected = read("relax_bounds", "yes", "relax_yes");
+    assert_eq!(
+        projected[1], 2.0,
+        "the fixed value must be restored exactly"
+    );
+    assert_eq!(projected[0], 1.0, "…and the bound-active variable too");
+
+    // `make_parameter` (the default) splices the fixed value back, so it
+    // is exact either way — the projection has nothing to repair there.
+    for honor in ["no", "yes"] {
+        let v = read("make_parameter", honor, &format!("param_{honor}"));
+        assert_eq!(v[1], 2.0, "make_parameter splices the fixed value exactly");
+    }
+}

--- a/crates/pounce-cli/tests/honor_original_bounds.rs
+++ b/crates/pounce-cli/tests/honor_original_bounds.rs
@@ -1,0 +1,121 @@
+//! `honor_original_bounds` was registered and never read (gh#483
+//! follow-up), so the reported solution could sit outside the bounds the
+//! user declared with no way to turn that off.
+//!
+//! `bound_relax_factor` (default `1e-8`) widens the variable box before
+//! the solve — upstream does this too — so a solution pinned to a bound
+//! comes back just past it. On
+//! `min (x−3)² + (y+2)²  s.t.  x ∈ [0,1], y ∈ [−1,1]`, whose optimum
+//! pins both, pounce reported
+//!
+//! ```text
+//! x = 1.00000000937320332      (upper bound 1)
+//! y = -1.00000000874562045     (lower bound -1)
+//! ```
+//!
+//! Upstream registers `honor_original_bounds` precisely to project that
+//! back; pounce accepted the option and did nothing, so there was no way
+//! to get a point inside the declared box. That is not cosmetic — the
+//! value flows into a downstream `sqrt(1 − x)`, a domain assertion, or a
+//! Pyomo `Var` whose bounds it is loaded back into.
+//!
+//! The default stays `no`, matching upstream: this test pins both the
+//! unchanged default and the now-working opt-in.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// Solve `bound_active_qp.nl` and return its `(x, y)` from the `.sol`.
+/// `solver_selection=nlp` because bound relaxation — and therefore the
+/// projection — belongs to the NLP interior-point path.
+fn solve(tag: &str, opts: &[&str]) -> (f64, f64) {
+    let dir = std::env::temp_dir().join(format!("pounce_honorbounds_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join("bound_active_qp.nl");
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/bound_active_qp.nl");
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .arg("solver_selection=nlp")
+        .arg("print_level=0")
+        .args(opts)
+        .output()
+        .expect("run pounce");
+    assert!(
+        out.status.success(),
+        "solve failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let sol = std::fs::read_to_string(nl.with_extension("sol")).expect("read .sol");
+    let _ = std::fs::remove_dir_all(&dir);
+    // m = 0, n = 2: the two numeric lines after the header are x and y.
+    let vals: Vec<f64> = sol
+        .lines()
+        .filter_map(|l| l.trim().parse::<f64>().ok())
+        .collect();
+    let n = vals.len();
+    (vals[n - 2], vals[n - 1])
+}
+
+/// Default (`no`): the relaxed point is reported as-is, unchanged from
+/// before this option was wired and matching upstream's default.
+#[test]
+fn default_reports_the_unprojected_point() {
+    let (x, y) = solve("default", &[]);
+    assert!(x > 1.0, "expected x just past its upper bound, got {x}");
+    assert!(y < -1.0, "expected y just past its lower bound, got {y}");
+    // …but only by the relaxation, not by anything larger.
+    assert!((x - 1.0).abs() < 1e-6 && (y + 1.0).abs() < 1e-6);
+}
+
+/// `honor_original_bounds=yes`: the reported point is inside the box the
+/// user declared, exactly on the active bounds. Pre-fix this was
+/// byte-identical to the default.
+#[test]
+fn opting_in_projects_back_into_the_declared_bounds() {
+    let (x, y) = solve("honored", &["honor_original_bounds=yes"]);
+    assert!(x <= 1.0, "x = {x} is still outside its upper bound 1");
+    assert!(y >= -1.0, "y = {y} is still below its lower bound -1");
+    assert_eq!(x, 1.0, "an active bound should project exactly onto it");
+    assert_eq!(y, -1.0);
+}
+
+/// The projection only clamps: a component strictly inside its bounds
+/// is untouched, so turning the option on cannot move an interior
+/// solution.
+#[test]
+fn an_interior_solution_is_unmoved() {
+    let dir = std::env::temp_dir().join("pounce_honorbounds_interior");
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join("boxed_qp_min.nl");
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/user_scaling_suffix.nl");
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+
+    let read = |opts: &[&str]| -> Vec<f64> {
+        let out = Command::new(pounce_exe())
+            .arg(&nl)
+            .arg("solver_selection=nlp")
+            .arg("print_level=0")
+            .args(opts)
+            .output()
+            .expect("run pounce");
+        assert!(out.status.success());
+        std::fs::read_to_string(nl.with_extension("sol"))
+            .expect("read .sol")
+            .lines()
+            .filter_map(|l| l.trim().parse::<f64>().ok())
+            .collect()
+    };
+    // `user_scaling_suffix.nl` is unbounded in x, so nothing can clamp.
+    let plain = read(&[]);
+    let honored = read(&["honor_original_bounds=yes"]);
+    let _ = std::fs::remove_dir_all(&dir);
+    assert_eq!(plain, honored);
+}

--- a/crates/pounce-cli/tests/issue_483_user_scaling.rs
+++ b/crates/pounce-cli/tests/issue_483_user_scaling.rs
@@ -1,0 +1,141 @@
+//! End-to-end guard for gh#483: the `.nl` `scaling_factor` suffixes are
+//! the AMPL/Pyomo channel for `nlp_scaling_method=user-scaling`, and
+//! pounce used to read none of them.
+//!
+//! Before this, `NlTnlp` did not implement `get_scaling_parameters` at
+//! all, so the default `TNLP` impl answered "no scaling supplied": a
+//! Pyomo user who tagged `model.scaling_factor` and set
+//! `nlp_scaling_method=user-scaling` — the workflow that works with
+//! Ipopt through ASL — got no scaling and no message saying so. The
+//! option was accepted and meant "none".
+//!
+//! Fixtures (both written by Pyomo's NL writer, so the suffix layout is
+//! the real one, not a hand-rolled approximation):
+//!
+//! ```text
+//! min (x1 - 2)^4 + (x2 - 3)^2   s.t.  x1*x2 >= 1,  x1 - x2 == 0.5
+//! scaling_factor[obj] = 100,  scaling_factor[c1] = 10
+//! ```
+//!
+//! * `user_scaling_suffix.nl` — objective + constraint factors only.
+//! * `user_scaling_var_suffix.nl` — the same, plus
+//!   `scaling_factor[x1] = 3`, a per-variable factor pounce does not
+//!   model.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// Run pounce on a fixture with extra key=value options; returns
+/// `(success, stdout, stderr)`. The `.nl` is copied into a per-test
+/// scratch directory first so the `.sol` the solver writes next to it
+/// cannot collide between concurrently running tests.
+fn run(fixture_name: &str, tag: &str, opts: &[&str]) -> (bool, String, String) {
+    let dir = std::env::temp_dir().join(format!("pounce_gh483_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join(fixture_name);
+    std::fs::copy(fixture(fixture_name), &nl).expect("copy fixture");
+
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(opts)
+        .output()
+        .expect("run pounce");
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// The `(scaled, unscaled)` objective pair from the end-of-run summary
+/// block, which is exactly where "was the scaling applied" is visible.
+fn objective_columns(stdout: &str) -> (f64, f64) {
+    let line = stdout
+        .lines()
+        .find(|l| l.trim_start().starts_with("Objective."))
+        .unwrap_or_else(|| panic!("no Objective summary line in:\n{stdout}"));
+    let nums: Vec<f64> = line
+        .split_whitespace()
+        .filter_map(|t| t.parse::<f64>().ok())
+        .collect();
+    assert_eq!(nums.len(), 2, "expected scaled + unscaled columns: {line}");
+    (nums[0], nums[1])
+}
+
+/// With `user-scaling`, the objective the IPM sees is the user's
+/// factor times the model's — and the value handed back is still in
+/// model units. Pre-fix both columns read the same, because nothing
+/// ever read the suffix.
+#[test]
+fn scaling_factor_suffix_is_applied() {
+    let (ok, stdout, stderr) = run(
+        "user_scaling_suffix.nl",
+        "applied",
+        &["nlp_scaling_method=user-scaling"],
+    );
+    assert!(ok, "solve failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    let (scaled, unscaled) = objective_columns(&stdout);
+    assert!(
+        (scaled / unscaled - 100.0).abs() < 1e-6,
+        "scaling_factor[obj]=100 should scale the IPM's objective; \
+         got scaled={scaled}, unscaled={unscaled}",
+    );
+}
+
+/// The same file without the option is untouched: the suffix alone
+/// changes nothing, matching Ipopt (and every model that carries a
+/// `scaling_factor` Suffix for `core.scale_model` rather than for the
+/// solver).
+#[test]
+fn scaling_factor_suffix_is_inert_without_the_option() {
+    let (ok, stdout, stderr) = run("user_scaling_suffix.nl", "inert", &[]);
+    assert!(ok, "solve failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+    let (scaled, unscaled) = objective_columns(&stdout);
+    assert!(
+        (scaled - unscaled).abs() < 1e-9,
+        "default scaling should leave this objective alone; \
+         got scaled={scaled}, unscaled={unscaled}",
+    );
+}
+
+/// A per-variable factor is refused with an explanation, not applied
+/// in part. Solving with the objective/constraint factors and dropping
+/// the variable one answers a question nobody asked.
+#[test]
+fn variable_scaling_factor_is_refused_with_a_message() {
+    let (ok, stdout, stderr) = run(
+        "user_scaling_var_suffix.nl",
+        "varfactor",
+        &["nlp_scaling_method=user-scaling"],
+    );
+    assert!(!ok, "expected a failing exit\nstdout:\n{stdout}");
+    assert!(
+        stderr.contains("per-variable scaling factors"),
+        "the refusal must say what was wrong; stderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("483"),
+        "the refusal should point at the tracking issue; stderr:\n{stderr}",
+    );
+}
+
+/// Without `user-scaling` the variable entry is not a request pounce
+/// is dropping, so the solve runs normally.
+#[test]
+fn variable_scaling_factor_is_inert_without_the_option() {
+    let (ok, stdout, stderr) = run("user_scaling_var_suffix.nl", "varinert", &[]);
+    assert!(ok, "solve failed\nstdout:\n{stdout}\nstderr:\n{stderr}");
+}

--- a/crates/pounce-cli/tests/linear_solver_selection.rs
+++ b/crates/pounce-cli/tests/linear_solver_selection.rs
@@ -1,0 +1,145 @@
+//! `linear_solver` accepted every backend name and silently ran FERAL
+//! (gh#483 follow-up).
+//!
+//! The option's valid-value list is a faithful port of upstream Ipopt's
+//! — `ma27`, `ma57`, `ma77`, `ma86`, `ma97`, `mumps`, `pardiso`,
+//! `pardisomkl`, `spral`, `wsmp`, `custom`, `feral` — so an `ipopt.opt`
+//! written for Ipopt parses here unchanged. pounce implements two of
+//! them. The resolver mapped everything else through a `_ =>` arm to
+//! FERAL, so `linear_solver=ma97` "worked": a run that reported success
+//! while using a backend the binary does not contain, and a benchmark
+//! comparing linear solvers that compared FERAL against itself.
+//!
+//! Two boundaries this pins, because both are load-bearing:
+//!
+//! * The **registered default is `ma57`** (upstream's), not a user
+//!   request. On the pure-Rust build it resolves to FERAL and always
+//!   has, so a default run must stay silent — erroring on it would fail
+//!   every solve.
+//! * **Explicit `ma57` on a build without the feature** still falls back.
+//!   That fallback is reported in the banner rather than hidden, and
+//!   failing a portable `ipopt.opt` over a build flag would cost more
+//!   than it buys.
+//!
+//! The refusal is checked before routing, so it does not depend on
+//! whether the model classifies into the NLP path or the convex one —
+//! the convex dispatch never reaches `optimize_tnlp`, where the sibling
+//! guard for library consumers lives.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+/// Run `fixture_name` with `opts`; returns `(exit code, stderr)`.
+fn run(fixture_name: &str, tag: &str, opts: &[&str]) -> (Option<i32>, String) {
+    let dir = std::env::temp_dir().join(format!("pounce_linsolsel_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join(fixture_name);
+    std::fs::copy(fixture(fixture_name), &nl).expect("copy fixture");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(opts)
+        .arg("print_level=0")
+        .output()
+        .expect("run pounce");
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// Every backend pounce does not implement is refused, by name, with a
+/// message that says what to use instead. Pre-fix each of these exited
+/// 0 having run FERAL.
+#[test]
+fn unimplemented_backends_are_refused() {
+    for (i, name) in [
+        "ma27",
+        "ma77",
+        "ma86",
+        "ma97",
+        "mumps",
+        "pardiso",
+        "pardisomkl",
+        "spral",
+        "wsmp",
+        "custom",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let (code, err) = run(
+            "user_scaling_suffix.nl",
+            &format!("bad{i}"),
+            &[&format!("linear_solver={name}")],
+        );
+        assert_eq!(code, Some(2), "linear_solver={name} should fail; {err}");
+        assert!(
+            err.contains(&format!("linear_solver={name} is not implemented")),
+            "the refusal must name the backend; stderr:\n{err}",
+        );
+        assert!(
+            err.contains("linear_solver=feral"),
+            "the refusal must say what to use instead; stderr:\n{err}",
+        );
+    }
+}
+
+/// The option value is case-insensitive in the registry, so the guard
+/// must be too — `MUMPS` cannot be a way around it.
+#[test]
+fn the_refusal_is_case_insensitive() {
+    let (code, err) = run("user_scaling_suffix.nl", "upper", &["linear_solver=MUMPS"]);
+    assert_eq!(code, Some(2), "stderr:\n{err}");
+}
+
+/// The two pounce implements are accepted. `ma57` is accepted on any
+/// build: without the feature it falls back to FERAL and the banner says
+/// so, which is a reported substitution rather than a hidden one.
+#[test]
+fn implemented_backends_are_accepted() {
+    for name in ["feral", "ma57"] {
+        let (code, err) = run(
+            "user_scaling_suffix.nl",
+            name,
+            &[&format!("linear_solver={name}")],
+        );
+        assert_eq!(code, Some(0), "linear_solver={name} should solve; {err}");
+    }
+}
+
+/// The registered default is upstream's `ma57`, which is not a user
+/// request — a plain run must be unaffected. This is the assertion that
+/// would have caught a guard written without the `found` gate, which
+/// would fail every default solve on the pure-Rust build.
+#[test]
+fn the_registered_default_is_not_treated_as_a_request() {
+    let (code, err) = run("user_scaling_suffix.nl", "default", &[]);
+    assert_eq!(code, Some(0), "a default run must not be refused; {err}");
+    assert!(
+        !err.contains("not implemented"),
+        "a default run must not warn either; stderr:\n{err}",
+    );
+}
+
+/// The guard runs before solver routing: a model that classifies as a
+/// convex QP dispatches to `pounce-convex`, which never reaches the
+/// library-side guard in `optimize_tnlp`.
+#[test]
+fn the_refusal_covers_the_convex_route() {
+    let (code, err) = run("boxed_qp_min.nl", "convex", &["linear_solver=mumps"]);
+    assert_eq!(code, Some(2), "stderr:\n{err}");
+    assert!(err.contains("not implemented"), "stderr:\n{err}");
+}

--- a/crates/pounce-cli/tests/linear_solver_selection.rs
+++ b/crates/pounce-cli/tests/linear_solver_selection.rs
@@ -12,10 +12,11 @@
 //!
 //! Two boundaries this pins, because both are load-bearing:
 //!
-//! * The **registered default is `ma57`** (upstream's), not a user
-//!   request. On the pure-Rust build it resolves to FERAL and always
-//!   has, so a default run must stay silent — erroring on it would fail
-//!   every solve.
+//! * The **registered default is `feral`** — pounce's own backend, and
+//!   one this binary always contains. It diverges from upstream's
+//!   `ma57` deliberately: that default advertised a solver a pure-Rust
+//!   build does not have, and made an HSL build run MA57 without being
+//!   asked. A default run must therefore solve, not be refused.
 //! * **Explicit `ma57` on a build without the feature** still falls back.
 //!   That fallback is reported in the banner rather than hidden, and
 //!   failing a portable `ipopt.opt` over a build flag would cost more
@@ -120,17 +121,38 @@ fn implemented_backends_are_accepted() {
     }
 }
 
-/// The registered default is upstream's `ma57`, which is not a user
-/// request — a plain run must be unaffected. This is the assertion that
-/// would have caught a guard written without the `found` gate, which
-/// would fail every default solve on the pure-Rust build.
+/// The registered default must name a backend this binary contains, or
+/// the guard refuses every solve that does not set the option. That is
+/// the invariant the `feral` default buys: no explicit-vs-default
+/// special case is needed anywhere, because the default is legal.
 #[test]
-fn the_registered_default_is_not_treated_as_a_request() {
+fn the_registered_default_solves() {
     let (code, err) = run("user_scaling_suffix.nl", "default", &[]);
     assert_eq!(code, Some(0), "a default run must not be refused; {err}");
     assert!(
         !err.contains("not implemented"),
         "a default run must not warn either; stderr:\n{err}",
+    );
+}
+
+/// …and it is FERAL, in every build. Under upstream's `ma57` default an
+/// HSL build silently ran MA57 without being asked, and a pure-Rust one
+/// banners a solver the option string did not name.
+#[test]
+fn the_registered_default_is_feral() {
+    let dir = std::env::temp_dir().join("pounce_linsolsel_bannerdefault");
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join("user_scaling_suffix.nl");
+    std::fs::copy(fixture("user_scaling_suffix.nl"), &nl).expect("copy fixture");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .output()
+        .expect("run pounce");
+    let _ = std::fs::remove_dir_all(&dir);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("running with linear solver FERAL"),
+        "default banner should name FERAL; stdout:\n{stdout}",
     );
 }
 

--- a/crates/pounce-cli/tests/unimplemented_options.rs
+++ b/crates/pounce-cli/tests/unimplemented_options.rs
@@ -1,0 +1,152 @@
+//! Options naming features pounce does not implement are refused
+//! (gh#483 follow-up, continuing #191).
+//!
+//! `upstream_options.rs` registers every name Ipopt registers, so an
+//! `ipopt.opt` written for Ipopt parses unchanged — a real compatibility
+//! benefit that also turned ~200 knobs into silent no-ops, because
+//! registering an option says nothing about implementing it.
+//!
+//! #191 fixed the half where the feature runs and only the read site was
+//! missing, and explicitly scoped out "feature genuinely unimplemented —
+//! expected no-ops". This is that other half.
+//!
+//! The table's membership rules, and why an explicitly-set *default* is
+//! still allowed, live in `pounce-algorithm/src/unimplemented_options.rs`
+//! alongside the unit tests for the predicate. What is checked here is
+//! the CLI's end of it: the exit code, that the message reaches stderr,
+//! and — the part only an end-to-end test can show — that the guard runs
+//! before solver routing.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn run(fixture_name: &str, tag: &str, opts: &[&str]) -> (Option<i32>, String) {
+    let dir = std::env::temp_dir().join(format!("pounce_unimplopt_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join(fixture_name);
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures");
+    fixture.push(fixture_name);
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(opts)
+        .arg("print_level=0")
+        .output()
+        .expect("run pounce");
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// One representative per feature group, so a group dropped from the
+/// table fails here rather than going quiet again.
+#[test]
+fn requesting_an_unimplemented_feature_fails_with_an_explanation() {
+    for (i, (opt, needle)) in [
+        ("penalty_init_max=42", "CG-penalty"),
+        (
+            "gradient_approximation=finite-difference-values",
+            "finite differences",
+        ),
+        ("dependency_detector=mumps", "linear-dependency detection"),
+        ("check_derivatives_for_naninf=yes", "NaN/Inf"),
+        ("recalc_y=yes", "multiplier recalculation"),
+        ("magic_steps=yes", "magic steps"),
+        ("option_file_name=other.opt", "reading options from a file"),
+        ("suppress_all_output=yes", "output controls"),
+        ("hsllib=libcoinhsl.so", "HSL loader"),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let (code, err) = run("user_scaling_suffix.nl", &format!("g{i}"), &[opt]);
+        assert_eq!(code, Some(2), "`{opt}` should fail; stderr:\n{err}");
+        assert!(
+            err.contains(needle),
+            "`{opt}` should mention `{needle}`; stderr:\n{err}",
+        );
+        assert!(err.contains("483"), "stderr:\n{err}");
+    }
+}
+
+/// The message names the option, not just the feature — with ~200
+/// registered names, "some option is unsupported" would be useless.
+#[test]
+fn the_refusal_names_the_offending_option() {
+    let (_, err) = run("user_scaling_suffix.nl", "named", &["vartheta=0.9"]);
+    assert!(err.contains("`vartheta`"), "stderr:\n{err}");
+}
+
+/// Setting an option to its registered default asks for nothing. A
+/// generated `ipopt.opt` spells out defaults, and failing on that would
+/// break the compatibility the registry exists to provide.
+#[test]
+fn explicitly_setting_a_default_still_solves() {
+    for (i, opt) in ["dependency_detector=none", "magic_steps=no", "recalc_y=no"]
+        .into_iter()
+        .enumerate()
+    {
+        let (code, err) = run("user_scaling_suffix.nl", &format!("d{i}"), &[opt]);
+        assert_eq!(code, Some(0), "`{opt}` asks for nothing; stderr:\n{err}");
+        assert!(!err.contains("does not implement"), "stderr:\n{err}");
+    }
+}
+
+/// Options whose feature *runs* and only whose read site is missing must
+/// keep solving — refusing them would fail solves that are correct
+/// today. Wiring them is separate work.
+#[test]
+fn knobs_on_implemented_features_still_solve() {
+    for (i, opt) in [
+        "max_resto_iter=17",
+        "accept_after_max_steps=3",
+        "limited_memory_max_skipping=4",
+        "corrector_type=affine",
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let (code, err) = run("user_scaling_suffix.nl", &format!("b{i}"), &[opt]);
+        assert_eq!(
+            code,
+            Some(0),
+            "`{opt}` configures an implemented feature; stderr:\n{err}",
+        );
+    }
+}
+
+/// A caching hint warns and solves: ignoring it costs evaluations, never
+/// correctness, so blocking the run would be a worse trade than the
+/// silence was.
+#[test]
+fn a_caching_hint_warns_but_solves() {
+    let (code, err) = run("user_scaling_suffix.nl", "hint", &["hessian_constant=yes"]);
+    assert_eq!(code, Some(0), "stderr:\n{err}");
+    assert!(err.contains("warning"), "stderr:\n{err}");
+    assert!(err.contains("hessian_constant"), "stderr:\n{err}");
+}
+
+/// The guard runs before routing: a convex-QP model dispatches to
+/// `pounce-convex` and never reaches the library-side guard.
+#[test]
+fn the_refusal_covers_the_convex_route() {
+    let (code, err) = run("boxed_qp_min.nl", "convex", &["magic_steps=yes"]);
+    assert_eq!(code, Some(2), "stderr:\n{err}");
+    assert!(err.contains("magic steps"), "stderr:\n{err}");
+}
+
+/// A plain run is untouched — no refusal, no warning.
+#[test]
+fn a_default_run_is_silent() {
+    let (code, err) = run("user_scaling_suffix.nl", "plain", &[]);
+    assert_eq!(code, Some(0), "stderr:\n{err}");
+    assert!(!err.contains("does not implement"), "stderr:\n{err}");
+    assert!(!err.contains("warning:"), "stderr:\n{err}");
+}

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -35,8 +35,8 @@
 use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
 use pounce_common::types::{Index, Number};
 use pounce_nlp::tnlp::{
-    BoundsInfo, IDX_NAMES, IndexStyle, IpoptCq, IpoptData, Linearity, MetaData, NlpInfo, Solution,
-    SparsityRequest, StartingPoint, TNLP,
+    BoundsInfo, IDX_NAMES, IndexStyle, IpoptCq, IpoptData, Linearity, MetaData, NlpInfo,
+    ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
 };
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
@@ -2936,6 +2936,60 @@ impl TNLP for NlTnlp {
         true
     }
 
+    /// Hand the `.nl` file's `scaling_factor` suffixes to the engine's
+    /// `nlp_scaling_method=user-scaling` pathway — the AMPL/ASL channel
+    /// Ipopt reads in `AmplTNLP::GetScalingParameters`, and the one a
+    /// Pyomo `Suffix(direction=Suffix.EXPORT)` named `scaling_factor`
+    /// writes into. Before gh#483 nothing implemented this callback for
+    /// `.nl` input, so a tagged model reached the solver with the option
+    /// accepted and *no* scaling applied, silently.
+    ///
+    /// Returns `false` (engine falls back to no scaling) when the file
+    /// declares no `scaling_factor` suffix at all — the same "user
+    /// supplied nothing" answer as the default `TNLP` impl.
+    ///
+    /// AMPL suffix vectors default to **0** for components the model did
+    /// not tag, and 0 is not a usable scale factor. A zero entry is
+    /// therefore read as "not tagged" and becomes 1.0, which is what
+    /// "unlisted components are unscaled" means. Per-variable factors
+    /// are passed straight through: `OrigIpoptNlp` does not model them
+    /// and refuses the solve with a message rather than dropping them.
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        const NAME: &str = "scaling_factor";
+        let sfx = &self.prob.suffixes;
+        let obj = sfx.obj_real.get(NAME);
+        let var = sfx.var_real.get(NAME);
+        let con = sfx.con_real.get(NAME);
+        if obj.is_none() && var.is_none() && con.is_none() {
+            return false;
+        }
+        // Objective 0 is the one `NlTnlp` evaluates (extra `O` segments
+        // are parsed and ignored), so its entry is the objective scale.
+        *req.obj_scaling = obj
+            .and_then(|v| v.first().copied())
+            .filter(|&s| s != 0.0)
+            .unwrap_or(1.0);
+        *req.use_x_scaling = match var {
+            Some(v) if v.len() == req.x_scaling.len() => {
+                for (slot, &s) in req.x_scaling.iter_mut().zip(v) {
+                    *slot = if s == 0.0 { 1.0 } else { s };
+                }
+                true
+            }
+            _ => false,
+        };
+        *req.use_g_scaling = match con {
+            Some(g) if g.len() == req.g_scaling.len() => {
+                for (slot, &s) in req.g_scaling.iter_mut().zip(g) {
+                    *slot = if s == 0.0 { 1.0 } else { s };
+                }
+                true
+            }
+            _ => false,
+        };
+        true
+    }
+
     fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
         // Reuse the shared forward-value arena (sized to `max_tape_n`) so
         // each summand sweep allocates nothing — see `Tape::eval_into`.
@@ -3882,6 +3936,68 @@ S1 2 sens_init_constr
         let s = p.suffixes.con_int.get("sens_init_constr").expect("con_int");
         // Sparse {0:1, 1:2} → dense [1, 2] at length m=2.
         assert_eq!(s.as_slice(), &[1, 2]);
+    }
+
+    /// Fill a `ScalingRequest` from `tnlp` sized for this fixture
+    /// (n = m = 2) and hand back everything the engine would see.
+    fn scaling_of(tnlp: &mut NlTnlp) -> (bool, Number, bool, Vec<Number>, bool, Vec<Number>) {
+        let mut obj = 1.0;
+        let mut use_x = false;
+        let mut x = vec![0.0; 2];
+        let mut use_g = false;
+        let mut g = vec![0.0; 2];
+        let ok = tnlp.get_scaling_parameters(ScalingRequest {
+            obj_scaling: &mut obj,
+            use_x_scaling: &mut use_x,
+            x_scaling: &mut x,
+            use_g_scaling: &mut use_g,
+            g_scaling: &mut g,
+        });
+        (ok, obj, use_x, x, use_g, g)
+    }
+
+    /// gh#483: a `.nl` carrying Pyomo/AMPL `scaling_factor` suffixes on
+    /// the objective (`S6`) and one constraint (`S5`) reaches the
+    /// engine's `user-scaling` pathway. The untagged second row is
+    /// unscaled — its AMPL suffix default is 0, which is not a usable
+    /// scale factor and reads as "not tagged".
+    #[test]
+    fn scaling_factor_suffix_feeds_obj_and_constraint_scaling() {
+        let nl = WITH_CON_SUFFIX.to_string()
+            + "S5 1 scaling_factor\n0 10.0\nS6 1 scaling_factor\n0 100.0\n";
+        let p = parse_nl_text(&nl).expect("parse");
+        let mut tnlp = NlTnlp::new(p);
+        let (ok, obj, use_x, _x, use_g, g) = scaling_of(&mut tnlp);
+        assert!(ok, "a tagged model must supply scaling");
+        assert!((obj - 100.0).abs() < 1e-12, "obj_scaling={obj}");
+        assert!(use_g);
+        assert_eq!(g, vec![10.0, 1.0]);
+        assert!(!use_x, "no variable suffix was declared");
+    }
+
+    /// Variable-level `scaling_factor` entries are passed through, not
+    /// dropped on the floor: `OrigIpoptNlp` does not model them and
+    /// refuses the solve, which is the whole point of gh#483.
+    #[test]
+    fn scaling_factor_suffix_forwards_variable_factors() {
+        let nl = WITH_CON_SUFFIX.to_string() + "S4 1 scaling_factor\n1 3.0\n";
+        let p = parse_nl_text(&nl).expect("parse");
+        let mut tnlp = NlTnlp::new(p);
+        let (ok, _obj, use_x, x, _use_g, _g) = scaling_of(&mut tnlp);
+        assert!(ok);
+        assert!(use_x, "variable factors must reach the engine");
+        assert_eq!(x, vec![1.0, 3.0]);
+    }
+
+    /// No `scaling_factor` suffix ⇒ "the user supplied nothing", the
+    /// same answer the default `TNLP` impl gives, so `user-scaling`
+    /// falls back to no scaling instead of a bogus all-zero vector.
+    #[test]
+    fn no_scaling_factor_suffix_declines() {
+        let p = parse_nl_text(WITH_CON_SUFFIX).expect("parse");
+        let mut tnlp = NlTnlp::new(p);
+        let (ok, ..) = scaling_of(&mut tnlp);
+        assert!(!ok);
     }
 
     #[test]

--- a/crates/pounce-nlp/src/derivative_test.rs
+++ b/crates/pounce-nlp/src/derivative_test.rs
@@ -323,7 +323,18 @@ pub fn run(tnlp: &mut dyn TNLP, opts: &DerivativeTestOptions) -> Option<Derivati
         check_second_order(tnlp, &fx, opts, &mut report);
     }
 
-    let summary = if report.clean() {
+    let summary = if report.checked == 0 {
+        // "No suspicious derivatives found" would be true and useless
+        // here: nothing was compared. Every variable is fixed (or the
+        // requested `derivative_test_first_index` is past the last one),
+        // so there was no direction to difference along. Saying "clean"
+        // would be this checker committing the defect it exists to
+        // remove — silence reading as a pass.
+        "No derivatives could be checked: every variable in range is fixed \
+         (or derivative_test_first_index is past the last one), so there is \
+         no direction to take a finite difference along."
+            .to_string()
+    } else if report.clean() {
         format!(
             "No suspicious derivatives found ({} entries checked, \
              {} evaluations).",
@@ -711,6 +722,82 @@ mod tests {
             tol: 1e-4,
             ..Default::default()
         }
+    }
+
+    /// A model whose variables are all fixed gives the checker nothing
+    /// to difference. Reporting "no suspicious derivatives found" there
+    /// would be the checker committing the defect it exists to remove:
+    /// a clean bill of health for a check that never ran.
+    #[test]
+    fn checking_nothing_does_not_report_clean() {
+        #[derive(Default)]
+        struct AllFixed;
+        impl TNLP for AllFixed {
+            fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+                Some(NlpInfo {
+                    n: 1,
+                    m: 0,
+                    nnz_jac_g: 0,
+                    nnz_h_lag: 1,
+                    index_style: IndexStyle::C,
+                })
+            }
+            fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+                b.x_l[0] = 3.0;
+                b.x_u[0] = 3.0;
+                true
+            }
+            fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+                sp.x[0] = 3.0;
+                true
+            }
+            fn eval_f(&mut self, x: &[Number], _n: bool) -> Option<Number> {
+                Some(x[0] * x[0])
+            }
+            fn eval_grad_f(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+                g[0] = 2.0 * x[0];
+                true
+            }
+            fn eval_g(&mut self, _x: &[Number], _n: bool, _g: &mut [Number]) -> bool {
+                true
+            }
+            fn eval_jac_g(
+                &mut self,
+                _x: Option<&[Number]>,
+                _n: bool,
+                _m: SparsityRequest<'_>,
+            ) -> bool {
+                true
+            }
+            fn eval_h(
+                &mut self,
+                _x: Option<&[Number]>,
+                _n: bool,
+                _o: Number,
+                _l: Option<&[Number]>,
+                _nl: bool,
+                mode: SparsityRequest<'_>,
+            ) -> bool {
+                if let SparsityRequest::Structure { irow, jcol } = mode {
+                    irow[0] = 0;
+                    jcol[0] = 0;
+                }
+                true
+            }
+            fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+        }
+        let mut t = AllFixed;
+        let r = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        assert_eq!(r.checked, 0);
+        let summary = r.lines.last().expect("a summary line");
+        assert!(
+            summary.contains("No derivatives could be checked"),
+            "must not read as a pass; got: {summary}"
+        );
+        assert!(
+            !summary.contains("No suspicious derivatives found"),
+            "got: {summary}"
+        );
     }
 
     #[test]

--- a/crates/pounce-nlp/src/derivative_test.rs
+++ b/crates/pounce-nlp/src/derivative_test.rs
@@ -1,0 +1,940 @@
+//! `derivative_test` — check a TNLP's analytic derivatives against
+//! finite differences before the solve. Port of upstream Ipopt's
+//! `TNLPAdapter::CheckDerivatives` (`IpTNLPAdapter.cpp`).
+//!
+//! # Why this exists
+//!
+//! Every `derivative_test*` option was registered and none was ever
+//! read, so `derivative_test=first-order` ran no test and printed
+//! nothing (gh#483 follow-up). That is the worst shape an unimplemented
+//! option can take: a *checker* that silently checks nothing reports
+//! success by omission. A user with a hand-written `eval_grad_f` turns
+//! it on, sees no complaints, and concludes the gradient is right.
+//!
+//! # What it does
+//!
+//! At the (bound-projected) starting point, each analytic derivative is
+//! compared against a one-sided finite difference with a relative step
+//! `derivative_test_perturbation · max(1, |xᵢ|)`. An entry is flagged
+//! when
+//!
+//! ```text
+//! |analytic − fd| > derivative_test_tol · max(1, |fd|)
+//! ```
+//!
+//! * `first-order` — `eval_grad_f` and `eval_jac_g`.
+//! * `second-order` — the above plus `eval_h`.
+//! * `only-second-order` — `eval_h` alone.
+//!
+//! The Hessian is checked one multiplier block at a time: with
+//! `obj_factor = 1, λ = 0` the analytic `eval_h` must match differences
+//! of `eval_grad_f`; with `obj_factor = 0, λ = e_j` it must match
+//! differences of row `j` of `eval_jac_g`.
+//!
+//! Two checks upstream does not make are included, because both catch a
+//! real and otherwise-invisible class of bug:
+//!
+//! * A Jacobian or Hessian entry that the finite difference says is
+//!   nonzero but the **sparsity structure omits**. A missing structural
+//!   entry is not a wrong number, it is a derivative the solver can
+//!   never see, and no value-by-value comparison finds it.
+//! * A perturbation that would leave the variable's box is taken
+//!   *downward* instead (with the difference negated), so a model whose
+//!   functions are undefined outside their bounds — `sqrt`, `log`,
+//!   `1/x` — is not evaluated out of its domain by the checker itself.
+//!
+//! The report is advisory: like upstream, a suspicious derivative is
+//! printed but does not stop the solve. It is emitted on **stderr**, so
+//! it survives `print_level=0` and never pollutes `--json-output`'s
+//! stdout.
+
+use crate::tnlp::{BoundsInfo, IndexStyle, SparsityRequest, StartingPoint, TNLP};
+use pounce_common::types::{Index, Number};
+
+/// `derivative_test` (default `none`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DerivativeTest {
+    #[default]
+    None,
+    FirstOrder,
+    SecondOrder,
+    OnlySecondOrder,
+}
+
+impl DerivativeTest {
+    /// Parse the registered option string; unknown values are `None`,
+    /// matching the registry's own default.
+    pub fn from_option(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "first-order" => Self::FirstOrder,
+            "second-order" => Self::SecondOrder,
+            "only-second-order" => Self::OnlySecondOrder,
+            _ => Self::None,
+        }
+    }
+
+    fn checks_first(self) -> bool {
+        matches!(self, Self::FirstOrder | Self::SecondOrder)
+    }
+
+    fn checks_second(self) -> bool {
+        matches!(self, Self::SecondOrder | Self::OnlySecondOrder)
+    }
+}
+
+/// The registered `derivative_test*` knobs, resolved.
+#[derive(Debug, Clone, Copy)]
+pub struct DerivativeTestOptions {
+    pub mode: DerivativeTest,
+    /// `derivative_test_perturbation` (1e-8). Relative: the step on
+    /// `xᵢ` is `perturbation · max(1, |xᵢ|)`.
+    pub perturbation: Number,
+    /// `derivative_test_tol` (1e-4). Relative deviation above which an
+    /// entry is flagged.
+    pub tol: Number,
+    /// `derivative_test_first_index` (-2 = everything). For the
+    /// first-order test this is the first **variable**; for the
+    /// second-order test the first **constraint**, where `-1` is the
+    /// objective's Hessian.
+    pub first_index: Index,
+    /// `derivative_test_print_all` — report every entry, not just the
+    /// suspicious ones.
+    pub print_all: bool,
+}
+
+impl Default for DerivativeTestOptions {
+    fn default() -> Self {
+        Self {
+            mode: DerivativeTest::None,
+            perturbation: 1e-8,
+            tol: 1e-4,
+            first_index: -2,
+            print_all: false,
+        }
+    }
+}
+
+/// Outcome of a run. `lines` is the formatted report, ready to print.
+#[derive(Debug, Default)]
+pub struct DerivativeTestReport {
+    /// Entries compared against a finite difference.
+    pub checked: usize,
+    /// Entries whose deviation exceeded `derivative_test_tol`.
+    pub suspicious: usize,
+    /// Structurally-absent entries whose finite difference is nonzero.
+    pub missing_structure: usize,
+    /// TNLP evaluations the test cost, so "(slow!)" is quantified.
+    pub evaluations: usize,
+    pub lines: Vec<String>,
+}
+
+impl DerivativeTestReport {
+    /// True when nothing looked wrong.
+    pub fn clean(&self) -> bool {
+        self.suspicious == 0 && self.missing_structure == 0
+    }
+}
+
+/// One analytic-vs-finite-difference comparison.
+struct Comparison {
+    label: String,
+    analytic: Number,
+    fd: Number,
+}
+
+impl Comparison {
+    fn deviation(&self) -> Number {
+        (self.analytic - self.fd).abs()
+    }
+
+    /// Upstream's relative test: the tolerance scales with the finite
+    /// difference, so a derivative of `1e6` is not flagged for an
+    /// absolute error a derivative of `1e-6` would be.
+    fn suspicious(&self, tol: Number) -> bool {
+        self.deviation() > tol * self.fd.abs().max(1.0)
+    }
+
+    fn format(&self, flagged: bool) -> String {
+        let rel = self.deviation() / self.fd.abs().max(1.0);
+        format!(
+            "{} {} = {:>23.16e}    ~ {:>23.16e}  [{:>10.3e}]",
+            if flagged { "*" } else { " " },
+            self.label,
+            self.analytic,
+            self.fd,
+            rel
+        )
+    }
+}
+
+/// Working state: the TNLP's dimensions and the point being tested.
+struct Fixture {
+    n: usize,
+    m: usize,
+    x: Vec<Number>,
+    x_l: Vec<Number>,
+    x_u: Vec<Number>,
+    jac_rows: Vec<Index>,
+    jac_cols: Vec<Index>,
+    h_rows: Vec<Index>,
+    h_cols: Vec<Index>,
+}
+
+impl Fixture {
+    /// The perturbed point for variable `i`, and the signed step taken.
+    ///
+    /// The step is relative (`perturbation · max(1, |xᵢ|)`) and is taken
+    /// downward when going up would leave the box — a `sqrt(x)` model
+    /// must not be evaluated outside its domain by its own derivative
+    /// checker. Returns `None` when the variable is fixed, which has no
+    /// usable direction and no derivative worth checking.
+    fn perturb(&self, i: usize, perturbation: Number) -> Option<(Vec<Number>, Number)> {
+        let xi = self.x[i];
+        let step = perturbation * xi.abs().max(1.0);
+        let up = xi + step;
+        let down = xi - step;
+        let signed = if up <= self.x_u[i] {
+            step
+        } else if down >= self.x_l[i] {
+            -step
+        } else {
+            return None;
+        };
+        let mut xp = self.x.clone();
+        xp[i] = xi + signed;
+        Some((xp, signed))
+    }
+}
+
+/// Run the derivative test. `None` when the mode is `none` or the TNLP
+/// declines to describe itself; otherwise a report to print.
+pub fn run(tnlp: &mut dyn TNLP, opts: &DerivativeTestOptions) -> Option<DerivativeTestReport> {
+    if matches!(opts.mode, DerivativeTest::None) {
+        return None;
+    }
+    let info = tnlp.get_nlp_info()?;
+    let (n, m) = (info.n as usize, info.m as usize);
+    let style_offset: Index = match info.index_style {
+        IndexStyle::C => 0,
+        IndexStyle::Fortran => 1,
+    };
+
+    // Starting point, projected into the box: the solver's own start is
+    // projected too, so testing anywhere else would check derivatives at
+    // a point the solve never visits — and an unprojected start can sit
+    // outside a function's domain.
+    let (mut x_l, mut x_u) = (vec![0.0; n], vec![0.0; n]);
+    let (mut g_l, mut g_u) = (vec![0.0; m], vec![0.0; m]);
+    if !tnlp.get_bounds_info(BoundsInfo {
+        x_l: &mut x_l,
+        x_u: &mut x_u,
+        g_l: &mut g_l,
+        g_u: &mut g_u,
+    }) {
+        return None;
+    }
+    let mut x = vec![0.0; n];
+    let (mut z_l, mut z_u, mut lambda) = (vec![0.0; n], vec![0.0; n], vec![0.0; m]);
+    if !tnlp.get_starting_point(StartingPoint {
+        init_x: true,
+        x: &mut x,
+        init_z: false,
+        z_l: &mut z_l,
+        z_u: &mut z_u,
+        init_lambda: false,
+        lambda: &mut lambda,
+    }) {
+        return None;
+    }
+    for i in 0..n {
+        x[i] = x[i].clamp(x_l[i], x_u[i]);
+    }
+
+    let nnz_jac = info.nnz_jac_g as usize;
+    let nnz_h = info.nnz_h_lag as usize;
+    let mut jac_rows = vec![0 as Index; nnz_jac];
+    let mut jac_cols = vec![0 as Index; nnz_jac];
+    if nnz_jac > 0
+        && !tnlp.eval_jac_g(
+            None,
+            true,
+            SparsityRequest::Structure {
+                irow: &mut jac_rows,
+                jcol: &mut jac_cols,
+            },
+        )
+    {
+        return None;
+    }
+    let mut h_rows = vec![0 as Index; nnz_h];
+    let mut h_cols = vec![0 as Index; nnz_h];
+    if nnz_h > 0
+        && !tnlp.eval_h(
+            None,
+            true,
+            1.0,
+            None,
+            true,
+            SparsityRequest::Structure {
+                irow: &mut h_rows,
+                jcol: &mut h_cols,
+            },
+        )
+    {
+        return None;
+    }
+    for v in jac_rows.iter_mut().chain(jac_cols.iter_mut()) {
+        *v -= style_offset;
+    }
+    for v in h_rows.iter_mut().chain(h_cols.iter_mut()) {
+        *v -= style_offset;
+    }
+
+    let fx = Fixture {
+        n,
+        m,
+        x,
+        x_l,
+        x_u,
+        jac_rows,
+        jac_cols,
+        h_rows,
+        h_cols,
+    };
+
+    let mut report = DerivativeTestReport::default();
+    report.lines.push(format!(
+        "Derivative checker: {} at the starting point \
+         (perturbation {:.1e}, tolerance {:.1e}).",
+        match opts.mode {
+            DerivativeTest::FirstOrder => "first derivatives",
+            DerivativeTest::SecondOrder => "first and second derivatives",
+            DerivativeTest::OnlySecondOrder => "second derivatives",
+            DerivativeTest::None => unreachable!("handled above"),
+        },
+        opts.perturbation,
+        opts.tol,
+    ));
+
+    if opts.mode.checks_first() {
+        check_first_order(tnlp, &fx, opts, &mut report);
+    }
+    if opts.mode.checks_second() {
+        check_second_order(tnlp, &fx, opts, &mut report);
+    }
+
+    let summary = if report.clean() {
+        format!(
+            "No suspicious derivatives found ({} entries checked, \
+             {} evaluations).",
+            report.checked, report.evaluations
+        )
+    } else {
+        format!(
+            "{} suspicious derivative(s) and {} missing sparsity entrie(s) \
+             out of {} checked ({} evaluations). Entries marked `*` above \
+             deviate by more than derivative_test_tol.",
+            report.suspicious, report.missing_structure, report.checked, report.evaluations
+        )
+    };
+    report.lines.push(summary);
+    Some(report)
+}
+
+/// `eval_grad_f` and `eval_jac_g` against forward differences of
+/// `eval_f` and `eval_g`.
+fn check_first_order(
+    tnlp: &mut dyn TNLP,
+    fx: &Fixture,
+    opts: &DerivativeTestOptions,
+    report: &mut DerivativeTestReport,
+) {
+    let (n, m) = (fx.n, fx.m);
+    let Some(f0) = tnlp.eval_f(&fx.x, true) else {
+        return;
+    };
+    let mut grad_f = vec![0.0; n];
+    tnlp.eval_grad_f(&fx.x, false, &mut grad_f);
+    let mut g0 = vec![0.0; m];
+    if m > 0 {
+        tnlp.eval_g(&fx.x, false, &mut g0);
+    }
+    let mut jac = vec![0.0; fx.jac_rows.len()];
+    if !fx.jac_rows.is_empty() {
+        tnlp.eval_jac_g(
+            Some(&fx.x),
+            false,
+            SparsityRequest::Values { values: &mut jac },
+        );
+    }
+    report.evaluations += 2 + usize::from(m > 0) * 2;
+
+    // Sparse column lookup: (row, col) -> position in the triplet.
+    let mut entry_at = std::collections::HashMap::new();
+    for (k, (&r, &c)) in fx.jac_rows.iter().zip(fx.jac_cols.iter()).enumerate() {
+        entry_at.insert((r as usize, c as usize), k);
+    }
+
+    // `derivative_test_first_index` selects the first *variable* here.
+    let start = if opts.first_index < 0 {
+        0
+    } else {
+        (opts.first_index as usize).min(n)
+    };
+    let mut g_pert = vec![0.0; m];
+    for i in start..n {
+        let Some((xp, step)) = fx.perturb(i, opts.perturbation) else {
+            continue;
+        };
+        let Some(f_pert) = tnlp.eval_f(&xp, true) else {
+            continue;
+        };
+        report.evaluations += 1;
+        push(
+            report,
+            opts,
+            Comparison {
+                label: format!("grad_f[{i:5}]      "),
+                analytic: grad_f[i],
+                fd: (f_pert - f0) / step,
+            },
+        );
+        if m == 0 {
+            continue;
+        }
+        tnlp.eval_g(&xp, false, &mut g_pert);
+        report.evaluations += 1;
+        for row in 0..m {
+            let fd = (g_pert[row] - g0[row]) / step;
+            match entry_at.get(&(row, i)) {
+                Some(&k) => push(
+                    report,
+                    opts,
+                    Comparison {
+                        label: format!("jac_g [{row:5},{i:5}]"),
+                        analytic: jac[k],
+                        fd,
+                    },
+                ),
+                None => {
+                    // Not in the sparsity structure, so the solver can
+                    // never see it: a nonzero here is a *structural*
+                    // error, invisible to any value comparison.
+                    if fd.abs() > opts.tol {
+                        report.missing_structure += 1;
+                        report.lines.push(format!(
+                            "! jac_g [{row:5},{i:5}] is not in the sparsity \
+                             structure, but its finite difference is \
+                             {fd:.6e}"
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `eval_h` against differences of `eval_grad_f` (objective block) and
+/// of each `eval_jac_g` row (constraint blocks).
+fn check_second_order(
+    tnlp: &mut dyn TNLP,
+    fx: &Fixture,
+    opts: &DerivativeTestOptions,
+    report: &mut DerivativeTestReport,
+) {
+    let (n, m) = (fx.n, fx.m);
+    if fx.h_rows.is_empty() {
+        report
+            .lines
+            .push("eval_h declares no nonzeros; skipping the second-order test.".to_string());
+        return;
+    }
+    let mut entry_at = std::collections::HashMap::new();
+    for (k, (&r, &c)) in fx.h_rows.iter().zip(fx.h_cols.iter()).enumerate() {
+        // The Hessian triplet is a lower triangle; normalize so a
+        // lookup by either ordering finds it.
+        let (r, c) = (r as usize, c as usize);
+        entry_at.insert((r.max(c), r.min(c)), k);
+    }
+
+    // `derivative_test_first_index` selects the first *constraint*
+    // here, with -1 meaning the objective's Hessian.
+    let start: i64 = if opts.first_index < -1 {
+        -1
+    } else {
+        opts.first_index as i64
+    };
+    let mut h_vals = vec![0.0; fx.h_rows.len()];
+    let mut base = vec![0.0; n];
+    let mut pert = vec![0.0; n];
+    let mut jac0 = vec![0.0; fx.jac_rows.len()];
+    let mut jac_p = vec![0.0; fx.jac_rows.len()];
+
+    for block in start..(m as i64) {
+        let is_obj = block < 0;
+        let mut lambda = vec![0.0; m];
+        let obj_factor = if is_obj {
+            1.0
+        } else {
+            lambda[block as usize] = 1.0;
+            0.0
+        };
+        if !tnlp.eval_h(
+            Some(&fx.x),
+            true,
+            obj_factor,
+            Some(&lambda),
+            true,
+            SparsityRequest::Values {
+                values: &mut h_vals,
+            },
+        ) {
+            continue;
+        }
+        report.evaluations += 1;
+
+        // Baseline first derivative of whichever function this block
+        // belongs to.
+        if is_obj {
+            tnlp.eval_grad_f(&fx.x, true, &mut base);
+        } else {
+            tnlp.eval_jac_g(
+                Some(&fx.x),
+                true,
+                SparsityRequest::Values { values: &mut jac0 },
+            );
+            row_of_jacobian(&fx.jac_rows, &fx.jac_cols, &jac0, block as usize, &mut base);
+        }
+        report.evaluations += 1;
+
+        let name = if is_obj {
+            "obj".to_string()
+        } else {
+            format!("g[{block}]")
+        };
+        for i in 0..n {
+            let Some((xp, step)) = fx.perturb(i, opts.perturbation) else {
+                continue;
+            };
+            if is_obj {
+                tnlp.eval_grad_f(&xp, true, &mut pert);
+            } else {
+                tnlp.eval_jac_g(
+                    Some(&xp),
+                    true,
+                    SparsityRequest::Values { values: &mut jac_p },
+                );
+                row_of_jacobian(
+                    &fx.jac_rows,
+                    &fx.jac_cols,
+                    &jac_p,
+                    block as usize,
+                    &mut pert,
+                );
+            }
+            report.evaluations += 1;
+            // Column `i` of this block's Hessian. Only the lower
+            // triangle is stored, so compare rows `j >= i`.
+            for j in i..n {
+                let fd = (pert[j] - base[j]) / step;
+                match entry_at.get(&(j, i)) {
+                    Some(&k) => push(
+                        report,
+                        opts,
+                        Comparison {
+                            label: format!("h_{name}[{j:5},{i:5}]"),
+                            analytic: h_vals[k],
+                            fd,
+                        },
+                    ),
+                    None => {
+                        if fd.abs() > opts.tol {
+                            report.missing_structure += 1;
+                            report.lines.push(format!(
+                                "! h_{name}[{j:5},{i:5}] is not in the Hessian \
+                                 sparsity structure, but its finite difference \
+                                 is {fd:.6e}"
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Scatter row `row` of a sparse Jacobian triplet into a dense vector.
+fn row_of_jacobian(
+    rows: &[Index],
+    cols: &[Index],
+    values: &[Number],
+    row: usize,
+    out: &mut [Number],
+) {
+    out.fill(0.0);
+    for (k, (&r, &c)) in rows.iter().zip(cols.iter()).enumerate() {
+        if r as usize == row {
+            out[c as usize] = values[k];
+        }
+    }
+}
+
+fn push(report: &mut DerivativeTestReport, opts: &DerivativeTestOptions, cmp: Comparison) {
+    report.checked += 1;
+    let flagged = cmp.suspicious(opts.tol);
+    if flagged {
+        report.suspicious += 1;
+    }
+    if flagged || opts.print_all {
+        report.lines.push(cmp.format(flagged));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tnlp::{IpoptCq, IpoptData, NlpInfo, Solution};
+
+    /// `min x0² + 3·x0·x1  s.t.  x0·x1 = 1`, with each derivative
+    /// independently corruptible so the checker can be shown to catch
+    /// exactly the thing that is wrong and nothing else.
+    #[derive(Default)]
+    struct Quad {
+        bad_grad: bool,
+        bad_jac: bool,
+        bad_hess: bool,
+        drop_jac_entry: bool,
+    }
+
+    impl TNLP for Quad {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 2,
+                m: 1,
+                nnz_jac_g: if self.drop_jac_entry { 1 } else { 2 },
+                nnz_h_lag: 2,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l.copy_from_slice(&[-10.0, -10.0]);
+            b.x_u.copy_from_slice(&[10.0, 10.0]);
+            b.g_l[0] = 1.0;
+            b.g_u[0] = 1.0;
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            sp.x.copy_from_slice(&[2.0, 3.0]);
+            true
+        }
+        fn eval_f(&mut self, x: &[Number], _n: bool) -> Option<Number> {
+            Some(x[0] * x[0] + 3.0 * x[0] * x[1])
+        }
+        fn eval_grad_f(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+            g[0] = 2.0 * x[0] + 3.0 * x[1];
+            g[1] = 3.0 * x[0];
+            if self.bad_grad {
+                g[1] += 0.5; // a constant offset a solver would chase forever
+            }
+            true
+        }
+        fn eval_g(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+            g[0] = x[0] * x[1];
+            true
+        }
+        fn eval_jac_g(
+            &mut self,
+            x: Option<&[Number]>,
+            _n: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow[0] = 0;
+                    jcol[0] = 0;
+                    if !self.drop_jac_entry {
+                        irow[1] = 0;
+                        jcol[1] = 1;
+                    }
+                }
+                SparsityRequest::Values { values } => {
+                    let x = x.expect("values call needs x");
+                    values[0] = x[1];
+                    if !self.drop_jac_entry {
+                        values[1] = x[0];
+                    }
+                    if self.bad_jac {
+                        values[0] *= 2.0;
+                    }
+                }
+            }
+            true
+        }
+        fn eval_h(
+            &mut self,
+            _x: Option<&[Number]>,
+            _n: bool,
+            obj_factor: Number,
+            lambda: Option<&[Number]>,
+            _nl: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    // lower triangle: (0,0) and (1,0)
+                    irow[0] = 0;
+                    jcol[0] = 0;
+                    irow[1] = 1;
+                    jcol[1] = 0;
+                }
+                SparsityRequest::Values { values } => {
+                    let l = lambda.map(|l| l[0]).unwrap_or(0.0);
+                    values[0] = 2.0 * obj_factor;
+                    values[1] = 3.0 * obj_factor + l;
+                    if self.bad_hess {
+                        values[1] += 1.0;
+                    }
+                }
+            }
+            true
+        }
+        fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+    }
+
+    fn opts(mode: DerivativeTest) -> DerivativeTestOptions {
+        DerivativeTestOptions {
+            mode,
+            // Loose enough that a correct derivative is never flagged by
+            // one-sided-difference truncation, tight enough to catch the
+            // O(1) corruptions above.
+            perturbation: 1e-7,
+            tol: 1e-4,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn none_runs_nothing() {
+        let mut t = Quad::default();
+        assert!(run(&mut t, &opts(DerivativeTest::None)).is_none());
+    }
+
+    #[test]
+    fn correct_derivatives_are_clean() {
+        let mut t = Quad::default();
+        let r = run(&mut t, &opts(DerivativeTest::SecondOrder)).expect("ran");
+        assert!(
+            r.clean(),
+            "correct derivatives must not be flagged:\n{}",
+            r.lines.join("\n")
+        );
+        assert!(r.checked > 0, "the test must actually compare something");
+    }
+
+    #[test]
+    fn a_wrong_objective_gradient_is_caught() {
+        let mut t = Quad {
+            bad_grad: true,
+            ..Default::default()
+        };
+        let r = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        assert_eq!(r.suspicious, 1, "report:\n{}", r.lines.join("\n"));
+        assert!(r.lines.iter().any(|l| l.contains("grad_f[    1]")));
+    }
+
+    #[test]
+    fn a_wrong_jacobian_entry_is_caught() {
+        let mut t = Quad {
+            bad_jac: true,
+            ..Default::default()
+        };
+        let r = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        assert_eq!(r.suspicious, 1, "report:\n{}", r.lines.join("\n"));
+        assert!(r.lines.iter().any(|l| l.contains("jac_g [    0,    0]")));
+    }
+
+    #[test]
+    fn a_wrong_hessian_entry_is_caught() {
+        let mut t = Quad {
+            bad_hess: true,
+            ..Default::default()
+        };
+        let r = run(&mut t, &opts(DerivativeTest::OnlySecondOrder)).expect("ran");
+        // The corrupted entry belongs to both the objective block and
+        // every constraint block that shares it.
+        assert!(r.suspicious >= 1, "report:\n{}", r.lines.join("\n"));
+        assert!(r.lines.iter().any(|l| l.contains("h_obj[")));
+    }
+
+    /// The check upstream does not make: a derivative that exists but is
+    /// missing from the sparsity structure. No value comparison can find
+    /// it, because there is no value to compare.
+    #[test]
+    fn a_missing_sparsity_entry_is_caught() {
+        let mut t = Quad {
+            drop_jac_entry: true,
+            ..Default::default()
+        };
+        let r = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        assert_eq!(r.missing_structure, 1, "report:\n{}", r.lines.join("\n"));
+        assert!(!r.clean());
+        assert!(
+            r.lines
+                .iter()
+                .any(|l| l.contains("not in the sparsity structure")),
+        );
+    }
+
+    /// `first-order` must not evaluate `eval_h` at all — a model with a
+    /// deliberately broken Hessian still passes the first-order test.
+    #[test]
+    fn first_order_ignores_the_hessian() {
+        let mut t = Quad {
+            bad_hess: true,
+            ..Default::default()
+        };
+        let r = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        assert!(r.clean(), "report:\n{}", r.lines.join("\n"));
+    }
+
+    /// `only-second-order` skips the first-order pass, so a broken
+    /// gradient is not reported by it.
+    #[test]
+    fn only_second_order_skips_the_first_order_pass() {
+        let mut t = Quad {
+            bad_grad: true,
+            ..Default::default()
+        };
+        let r = run(&mut t, &opts(DerivativeTest::OnlySecondOrder)).expect("ran");
+        assert!(
+            !r.lines.iter().any(|l| l.contains("grad_f")),
+            "report:\n{}",
+            r.lines.join("\n")
+        );
+    }
+
+    #[test]
+    fn print_all_reports_clean_entries_too() {
+        let mut t = Quad::default();
+        let quiet = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        let mut t = Quad::default();
+        let loud = run(
+            &mut t,
+            &DerivativeTestOptions {
+                print_all: true,
+                ..opts(DerivativeTest::FirstOrder)
+            },
+        )
+        .expect("ran");
+        assert!(loud.lines.len() > quiet.lines.len());
+        assert_eq!(loud.checked, quiet.checked);
+        assert!(loud.clean() && quiet.clean());
+    }
+
+    /// `derivative_test_first_index` narrows the first-order sweep to
+    /// variables at or after the given index.
+    #[test]
+    fn first_index_narrows_the_first_order_sweep() {
+        let mut t = Quad {
+            bad_grad: true, // the error is in grad_f[1]
+            ..Default::default()
+        };
+        let r = run(
+            &mut t,
+            &DerivativeTestOptions {
+                first_index: 1,
+                ..opts(DerivativeTest::FirstOrder)
+            },
+        )
+        .expect("ran");
+        assert_eq!(r.suspicious, 1, "the error at index 1 is still in range");
+        let mut t = Quad {
+            bad_grad: true,
+            ..Default::default()
+        };
+        let narrowed = run(
+            &mut t,
+            &DerivativeTestOptions {
+                first_index: 2, // past the last variable: nothing to check
+                ..opts(DerivativeTest::FirstOrder)
+            },
+        )
+        .expect("ran");
+        assert_eq!(narrowed.checked, 0);
+    }
+
+    /// A model whose functions are undefined outside their bounds must
+    /// not be evaluated out of domain by its own checker: the step is
+    /// taken downward when up would leave the box.
+    #[derive(Default)]
+    struct AtUpperBound;
+    impl TNLP for AtUpperBound {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Some(NlpInfo {
+                n: 1,
+                m: 0,
+                nnz_jac_g: 0,
+                nnz_h_lag: 1,
+                index_style: IndexStyle::C,
+            })
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            b.x_l[0] = 0.0;
+            b.x_u[0] = 1.0;
+            true
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            sp.x[0] = 1.0; // pinned at the upper bound
+            true
+        }
+        fn eval_f(&mut self, x: &[Number], _n: bool) -> Option<Number> {
+            assert!(
+                x[0] <= 1.0 && x[0] >= 0.0,
+                "evaluated outside the declared bounds at {}",
+                x[0]
+            );
+            Some((1.0 - x[0]).sqrt())
+        }
+        fn eval_grad_f(&mut self, x: &[Number], _n: bool, g: &mut [Number]) -> bool {
+            // d/dx sqrt(1-x) = -1/(2 sqrt(1-x)); at x = 1 exactly this is
+            // singular, so the checker's downward step is what makes the
+            // comparison possible at all.
+            g[0] = -0.5 / (1.0 - x[0]).max(1e-300).sqrt();
+            true
+        }
+        fn eval_g(&mut self, _x: &[Number], _n: bool, _g: &mut [Number]) -> bool {
+            true
+        }
+        fn eval_jac_g(&mut self, _x: Option<&[Number]>, _n: bool, _m: SparsityRequest<'_>) -> bool {
+            true
+        }
+        fn eval_h(
+            &mut self,
+            _x: Option<&[Number]>,
+            _n: bool,
+            _o: Number,
+            _l: Option<&[Number]>,
+            _nl: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            match mode {
+                SparsityRequest::Structure { irow, jcol } => {
+                    irow[0] = 0;
+                    jcol[0] = 0;
+                }
+                SparsityRequest::Values { values } => values[0] = 0.0,
+            }
+            true
+        }
+        fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+    }
+
+    #[test]
+    fn the_perturbation_stays_inside_the_box() {
+        let mut t = AtUpperBound;
+        // The assertion lives in eval_f: stepping up from x = 1 would
+        // trip it.
+        let r = run(&mut t, &opts(DerivativeTest::FirstOrder)).expect("ran");
+        assert_eq!(r.checked, 1);
+    }
+}

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -209,6 +209,17 @@ pub trait IpoptNlp: Nlp {
         dx.expanded_values().to_vec()
     }
 
+    /// The full-x to hand `TNLP::finalize_solution`: [`Self::lift_x_to_full`],
+    /// plus whatever the reported point owes the user that the working
+    /// iterate does not — today, the `honor_original_bounds` projection
+    /// back into the declared box (the `bound_relax_factor` widening
+    /// otherwise reports a bound-pinned solution just outside its own
+    /// bounds). Default impl is `lift_x_to_full`; `OrigIpoptNlp`
+    /// overrides.
+    fn finalize_solution_x(&self, x: &dyn Vector) -> Vec<Number> {
+        self.lift_x_to_full(x)
+    }
+
     /// Pack the algorithm-side `(y_c, y_d)` constraint multipliers into
     /// the user TNLP's `lambda` array (length `n_full_g`, ordered by
     /// the original `g` index). Used by `GetIpoptCurrentIterate` and

--- a/crates/pounce-nlp/src/lib.rs
+++ b/crates/pounce-nlp/src/lib.rs
@@ -22,6 +22,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod alg_types;
+pub mod derivative_test;
 pub mod expression_provider;
 pub mod ipopt_nlp;
 pub mod orig_ipopt_nlp;

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -119,10 +119,10 @@ pub enum ScalingMethod {
     GradientBased,
     /// User-supplied scaling via [`crate::tnlp::TNLP::get_scaling_parameters`].
     /// Port of upstream's `nlp_scaling_method=user-scaling`. The TNLP
-    /// fills `obj_scaling` and the per-constraint `g_scaling`; the
-    /// per-variable `x_scaling` request is honored only insofar as
-    /// `OrigIpoptNlp` currently models constraint+objective scaling
-    /// (no variable-side rescale, matching the issue #61 design).
+    /// fills `obj_scaling` and the per-constraint `g_scaling`;
+    /// `OrigIpoptNlp` models no variable-side rescale (the issue #61
+    /// design), so a non-trivial per-variable `x_scaling` request is
+    /// **refused** — see [`OrigIpoptNlp::user_x_scaling_rejected`].
     UserScaling,
 }
 
@@ -159,6 +159,15 @@ pub struct OrigIpoptNlp {
     /// live bounds).
     declared_d_l: RefCell<Option<Vec<Number>>>,
     declared_d_u: RefCell<Option<Vec<Number>>>,
+    /// Set by [`Self::scale_user_supplied`] when the TNLP asked for
+    /// **non-trivial** per-variable scaling (`use_x_scaling` with at
+    /// least one factor `!= 1.0`). pounce models objective and
+    /// constraint scaling only, so honoring the request is impossible
+    /// and *ignoring* it silently hands back a differently-conditioned
+    /// problem than the one the caller asked for (gh#483). The driver
+    /// reads this via [`Self::user_x_scaling_rejected`] and fails the
+    /// solve with `InvalidOption` instead.
+    x_scaling_rejected: Cell<bool>,
 
     // ----- vector / matrix spaces (shared via Rc) -----
     x_space: Rc<DenseVectorSpace>,
@@ -545,6 +554,7 @@ impl OrigIpoptNlp {
             d_scale: RefCell::new(None),
             declared_d_l: RefCell::new(None),
             declared_d_u: RefCell::new(None),
+            x_scaling_rejected: Cell::new(false),
             x_space,
             c_space,
             d_space,
@@ -1053,11 +1063,16 @@ impl OrigIpoptNlp {
     /// Returns `true` if the TNLP supplied scaling (matches upstream's
     /// `GetScalingParameters` return-value contract).
     ///
-    /// The `x_scaling` request channel is ignored: `OrigIpoptNlp` does
-    /// not currently model per-variable rescaling (would require
-    /// transforming `eval_grad_f`, `eval_jac_*`, and `eval_h` in
-    /// concert), and issue #61's `nlp_scaling=user` design explicitly
-    /// covers only `obj_scale` and `con_scale`.
+    /// `OrigIpoptNlp` does not model per-variable rescaling (that would
+    /// require transforming `eval_grad_f`, `eval_jac_*`, and `eval_h` in
+    /// concert); issue #61's `nlp_scaling=user` design covers only
+    /// `obj_scale` and `con_scale`. A **non-trivial** `x_scaling`
+    /// request is therefore *rejected*, not dropped: it sets
+    /// [`Self::x_scaling_rejected`] so the driver can fail the solve
+    /// with a message. Quietly discarding it used to hand back a
+    /// problem conditioned differently from the one the caller
+    /// described, with nothing in the log to say so (gh#483). An
+    /// all-ones request is a genuine no-op and passes through.
     fn scale_user_supplied(
         &self,
         cls: &BoundClassification,
@@ -1129,9 +1144,22 @@ impl OrigIpoptNlp {
             *self.c_scale.borrow_mut() = None;
             *self.d_scale.borrow_mut() = None;
         }
-        // `use_x_scaling`: silently ignored (not modeled — see doc).
-        let _ = use_x_scaling;
+        // Per-variable factors are not modeled. Flag a request that
+        // would actually change the problem so the driver can refuse
+        // loudly; an all-ones vector asks for nothing and is accepted.
+        if use_x_scaling && x_scaling.iter().any(|&s| s != 1.0) {
+            self.x_scaling_rejected.set(true);
+        }
         true
+    }
+
+    /// `true` when the last [`Self::determine_scaling_from_starting_point`]
+    /// ran `user-scaling` and the TNLP asked for per-variable scaling
+    /// factors that pounce cannot honor (see [`Self::scale_user_supplied`]).
+    /// Drivers must turn this into a hard error rather than solve a
+    /// problem the caller did not describe (gh#483).
+    pub fn user_x_scaling_rejected(&self) -> bool {
+        self.x_scaling_rejected.get()
     }
 
     /// Bring `d_l` / `d_u` into the scaled space so feasibility checks
@@ -3535,6 +3563,95 @@ mod tests {
         let mut c = nlp.c_space().make_new_dense();
         nlp.eval_c(&x, &mut c);
         assert_eq!(c.values(), &[12.0], "unscaled equality residual");
+    }
+
+    /// HS071 whose `get_scaling_parameters` asks for per-variable
+    /// factors — the channel `OrigIpoptNlp` cannot model (gh#483).
+    struct Hs071XScaled(Vec<Number>);
+    impl TNLP for Hs071XScaled {
+        fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+            Hs071::default().get_nlp_info()
+        }
+        fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+            Hs071::default().get_bounds_info(b)
+        }
+        fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+            Hs071::default().get_starting_point(sp)
+        }
+        fn eval_f(&mut self, x: &[Number], new_x: bool) -> Option<Number> {
+            Hs071::default().eval_f(x, new_x)
+        }
+        fn eval_grad_f(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+            Hs071::default().eval_grad_f(x, new_x, g)
+        }
+        fn eval_g(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+            Hs071::default().eval_g(x, new_x, g)
+        }
+        fn eval_jac_g(
+            &mut self,
+            x: Option<&[Number]>,
+            new_x: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            Hs071::default().eval_jac_g(x, new_x, mode)
+        }
+        fn eval_h(
+            &mut self,
+            x: Option<&[Number]>,
+            new_x: bool,
+            obj_factor: Number,
+            lambda: Option<&[Number]>,
+            new_lambda: bool,
+            mode: SparsityRequest<'_>,
+        ) -> bool {
+            Hs071::default().eval_h(x, new_x, obj_factor, lambda, new_lambda, mode)
+        }
+        fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+            *req.obj_scaling = 2.0;
+            *req.use_x_scaling = true;
+            req.x_scaling.copy_from_slice(&self.0);
+            *req.use_g_scaling = false;
+            true
+        }
+        fn finalize_solution(&mut self, _: Solution<'_>, _: &IpoptData, _: &IpoptCq) {}
+    }
+
+    fn user_x_scaling_run(factors: &[Number]) -> OrigIpoptNlp {
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Hs071XScaled(factors.to_vec())));
+        let adapter = Rc::new(RefCell::new(TNLPAdapter::new(tnlp).unwrap()));
+        let mut nlp = OrigIpoptNlp::new(Rc::clone(&adapter), Rc::new(NoScaling)).unwrap();
+        nlp.determine_scaling_from_starting_point(
+            ScalingMethod::UserScaling,
+            100.0,
+            1e-8,
+            0.0,
+            0.0,
+        );
+        nlp
+    }
+
+    /// gh#483: a per-variable scaling request pounce cannot honor is
+    /// flagged for the driver instead of being discarded. Before this,
+    /// `scale_user_supplied` ended in `let _ = use_x_scaling;` and the
+    /// solve ran with the caller's variable scaling silently gone.
+    #[test]
+    fn user_x_scaling_request_is_flagged_not_discarded() {
+        let nlp = user_x_scaling_run(&[1.0, 1e3, 1.0, 1.0]);
+        assert!(
+            nlp.user_x_scaling_rejected(),
+            "a non-unit x_scaling must be refused, not dropped"
+        );
+        // The objective factor is still installed — the flag is the
+        // driver's cue to abort, not a reason to skip the other axes.
+        assert!((nlp.obj_scale_factor() - 2.0).abs() < 1e-12);
+    }
+
+    /// An all-ones request asks for nothing, so it is a genuine no-op
+    /// and must not fail a solve that would otherwise run.
+    #[test]
+    fn unit_x_scaling_request_is_not_rejected() {
+        let nlp = user_x_scaling_run(&[1.0, 1.0, 1.0, 1.0]);
+        assert!(!nlp.user_x_scaling_rejected());
     }
 
     #[test]

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -159,6 +159,21 @@ pub struct OrigIpoptNlp {
     /// live bounds).
     declared_d_l: RefCell<Option<Vec<Number>>>,
     declared_d_u: RefCell<Option<Vec<Number>>>,
+    /// The *declared* compressed `x_L / x_U`, snapshotted (unrelaxed) at
+    /// [`Self::relax_bounds`] time for the same reason as
+    /// [`Self::declared_d_l`] — and used by
+    /// [`Self::finalize_solution_x`] to project the final iterate back
+    /// into the user's own box under `honor_original_bounds`.
+    declared_x_l: RefCell<Option<Vec<Number>>>,
+    declared_x_u: RefCell<Option<Vec<Number>>>,
+    /// `honor_original_bounds` (upstream default `no`). When set, the
+    /// final iterate handed to `TNLP::finalize_solution` is projected
+    /// back into the declared bounds, undoing the `bound_relax_factor`
+    /// widening. Registered but never read before gh#483's follow-up, so
+    /// `honor_original_bounds=yes` was accepted and the reported solution
+    /// still sat up to `min(bound_relax_factor·max(1,|b|), constr_viol_tol)`
+    /// outside the box the user declared.
+    honor_original_bounds: Cell<bool>,
     /// Set by [`Self::scale_user_supplied`] when the TNLP asked for
     /// **non-trivial** per-variable scaling (`use_x_scaling` with at
     /// least one factor `!= 1.0`). pounce models objective and
@@ -554,6 +569,9 @@ impl OrigIpoptNlp {
             d_scale: RefCell::new(None),
             declared_d_l: RefCell::new(None),
             declared_d_u: RefCell::new(None),
+            declared_x_l: RefCell::new(None),
+            declared_x_u: RefCell::new(None),
+            honor_original_bounds: Cell::new(false),
             x_scaling_rejected: Cell::new(false),
             x_space,
             c_space,
@@ -715,6 +733,11 @@ impl OrigIpoptNlp {
         // and only touch the live vectors.
         *self.declared_d_l.borrow_mut() = Some(self.d_l.expanded_values());
         *self.declared_d_u.borrow_mut() = Some(self.d_u.expanded_values());
+        // Same snapshot for the variable box, so `honor_original_bounds`
+        // has the user's own bounds to project back onto after the
+        // widening below.
+        *self.declared_x_l.borrow_mut() = Some(self.x_l.expanded_values());
+        *self.declared_x_u.borrow_mut() = Some(self.x_u.expanded_values());
         if bound_relax_factor <= 0.0 {
             return;
         }
@@ -1236,6 +1259,57 @@ impl OrigIpoptNlp {
         }
         for (i, &full_idx) in cls.x_fixed_map.iter().enumerate() {
             full[full_idx as usize] = cls.x_fixed_vals[i];
+        }
+        full
+    }
+
+    /// Select `honor_original_bounds`. Called once from the driver
+    /// after [`Self::relax_bounds`], which is what captures the bounds
+    /// to project back onto.
+    pub fn set_honor_original_bounds(&self, on: bool) {
+        self.honor_original_bounds.set(on);
+    }
+
+    /// The full-x handed to `TNLP::finalize_solution`: [`Self::lift_x_to_full`],
+    /// then — under `honor_original_bounds` — clamped back into the
+    /// bounds the user declared.
+    ///
+    /// `bound_relax_factor` (default `1e-8`) widens the box before the
+    /// solve, so a solution pinned to a bound comes back *outside* it:
+    /// `min (x−3)²` over `x ∈ [0, 1]` reports `x = 1.0000000094`. That
+    /// is upstream's behavior too and is why upstream registers this
+    /// option — but pounce registered it and never read it, so there was
+    /// no way to turn the projection on (gh#483 follow-up). A value
+    /// outside its declared domain is not a cosmetic difference: it
+    /// breaks a downstream `sqrt(1 − x)`, a domain assertion, or a Pyomo
+    /// `Var` whose bounds the value is loaded back into.
+    ///
+    /// Only the reported point moves. As upstream documents, the
+    /// constraint-violation and complementarity numbers in the summary
+    /// are for the **non-projected** point and are left alone.
+    pub fn finalize_solution_x(&self, x: &dyn Vector) -> Vec<Number> {
+        let mut full = self.lift_x_to_full(x);
+        if !self.honor_original_bounds.get() {
+            return full;
+        }
+        let cls = self.adapter.borrow().classification().clone();
+        // Fixed variables are spliced in at their exact fixed value, so
+        // only the free block can have drifted past a bound.
+        if let Some(x_l) = self.declared_x_l.borrow().as_ref() {
+            for (i, &var_idx) in cls.x_l_map.iter().enumerate() {
+                let full_idx = cls.x_not_fixed_map[var_idx as usize] as usize;
+                if full[full_idx] < x_l[i] {
+                    full[full_idx] = x_l[i];
+                }
+            }
+        }
+        if let Some(x_u) = self.declared_x_u.borrow().as_ref() {
+            for (i, &var_idx) in cls.x_u_map.iter().enumerate() {
+                let full_idx = cls.x_not_fixed_map[var_idx as usize] as usize;
+                if full[full_idx] > x_u[i] {
+                    full[full_idx] = x_u[i];
+                }
+            }
         }
         full
     }
@@ -2192,6 +2266,10 @@ impl IpoptNlp for OrigIpoptNlp {
 
     fn lift_x_to_full(&self, x: &dyn Vector) -> Vec<Number> {
         OrigIpoptNlp::lift_x_to_full(self, x)
+    }
+
+    fn finalize_solution_x(&self, x: &dyn Vector) -> Vec<Number> {
+        OrigIpoptNlp::finalize_solution_x(self, x)
     }
 
     fn n_full_x(&self) -> Index {

--- a/crates/pounce-py/src/lib.rs
+++ b/crates/pounce-py/src/lib.rs
@@ -55,16 +55,15 @@ pub use sparse_lu::PySparseLu;
 fn print_banner() {
     // Derive the backend tag the same way the CLI's banner does
     // (main.rs `backend_tag`) so the two frontends never disagree. The
-    // registered `linear_solver` default mirrors upstream Ipopt ("ma57"),
-    // but this wheel's actual backend is FERAL, so "ma57" counts as the
-    // backend only when a caller explicitly set it -- which a fresh
-    // application never does. The default wheel therefore banners "FERAL"
-    // rather than the registered-default "ma57".
-    let (solver, explicit) = pounce_algorithm::application::IpoptApplication::new()
+    // registered `linear_solver` default is "feral", which is this
+    // wheel's actual backend, so the resolved value is the whole story --
+    // no "was it explicitly set?" flag needed, unlike under upstream's
+    // "ma57" default.
+    let (solver, _) = pounce_algorithm::application::IpoptApplication::new()
         .options()
         .get_string_value("linear_solver", "")
         .unwrap_or_else(|_| ("feral".to_string(), false));
-    let tag = if explicit && solver == "ma57" {
+    let tag = if solver.eq_ignore_ascii_case("ma57") {
         "MA57 (HSL)"
     } else {
         "FERAL"

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -460,11 +460,11 @@ impl PyProblem {
     ///
     /// * `obj_scaling` — multiplier applied to the objective (and the
     ///   final reported value is divided back out).
-    /// * `x_scaling` — length-`n` per-variable factors, or `None` to
-    ///   leave variable scaling off. (Note: the algorithm currently
-    ///   accepts this channel but does not yet act on it; only
-    ///   `obj_scaling` and `g_scaling` affect the IPM. See
-    ///   `docs/src/scaling.md`.)
+    /// * `x_scaling` — length-`n` per-variable factors. pounce models
+    ///   objective and constraint scaling only, so anything other than
+    ///   all-`1.0` (or `None`) **raises**: these factors used to be
+    ///   accepted and then discarded, leaving the caller with a
+    ///   differently-conditioned problem and no way to tell (gh#483).
     /// * `g_scaling` — length-`m` per-constraint factors, or `None`
     ///   to leave constraint scaling off.
     ///
@@ -481,6 +481,21 @@ impl PyProblem {
         let x = x_scaling
             .map(|v| extract_f64_vec(&v, self.n as usize, "x_scaling"))
             .transpose()?;
+        if let Some(bad) = x
+            .as_ref()
+            .and_then(|v| v.iter().position(|&s| s != 1.0).map(|i| (i, v[i])))
+        {
+            let (i, s) = bad;
+            return Err(pyo3::exceptions::PyValueError::new_err(format!(
+                "set_problem_scaling: x_scaling[{i}] = {s} — pounce models only \
+                 objective and constraint scaling, so per-variable factors cannot \
+                 be honored. They were previously accepted and then discarded, \
+                 which left the solve conditioned differently than you asked for \
+                 with nothing to say so (gh#483). Pass x_scaling=None (or all \
+                 1.0) and rescale those variables in the model itself \
+                 (substitute x[{i}] = z / {s} and give the solver z)."
+            )));
+        }
         let g = g_scaling
             .map(|v| extract_f64_vec(&v, self.m as usize, "g_scaling"))
             .transpose()?;

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -155,6 +155,9 @@ fn apply_outer_resto_options(rb: &mut RestoAlgorithmBuilder, ab: &AlgorithmBuild
     rb.bound_mult_reset_threshold = ab.resto.bound_mult_reset_threshold;
     rb.constr_mult_reset_threshold = ab.resto.constr_mult_reset_threshold;
     rb.required_infeasibility_reduction = ab.resto.required_infeasibility_reduction;
+    rb.evaluate_orig_obj_at_resto_trial = ab.resto.evaluate_orig_obj_at_resto_trial;
+    rb.expect_infeasible_problem = ab.resto.expect_infeasible_problem;
+    rb.start_with_resto = ab.resto.start_with_resto;
 }
 
 /// Resolve the κ_resto the restoration sub-solve's early-exit guard runs

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -126,6 +126,13 @@ export COINHSL_DIR=/path/to/CoinHSL
 cargo build -p pounce-cli --release --features ma57
 ```
 
+The feature makes MA57 *available*; selecting it is a separate step,
+because `linear_solver` defaults to `feral` in every build:
+
+```sh
+pounce problem.nl linear_solver=ma57
+```
+
 Build CoinHSL from <https://www.hsl.rl.ac.uk/ipopt/>. MA57 is
 primarily useful for benchmarking against upstream Ipopt; the FERAL
 backend is the supported default for everyday use, and a build without

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -178,6 +178,23 @@ Both the primal solution and the constraint duals are written to the
 `.sol` file, in the same sign convention as POUNCE's NLP path (so Pyomo
 and AMPL read them identically regardless of which solver ran).
 
+### Requests the convex path does not implement
+
+The convex solvers are a specialized fast path, not a drop-in for every
+option the NLP path honors. Where a request would be *dropped* rather
+than merely unused, routing gives way rather than answering a different
+question:
+
+| Request | Under `auto` | Under an explicit `solver_selection` |
+|---|---|---|
+| `obj_scaling_factor < 0` (maximize) | re-routes to the NLP path | **refused** (exit 2) — running would report the minimizer |
+| `nlp_scaling_method=user-scaling` with `scaling_factor` suffixes | re-routes to the NLP path | warns; the scaling is skipped |
+| sIPOPT `sens_*` suffixes, `--compute-red-hessian` | re-routes to the NLP path | warns; the step is skipped |
+
+A *positive* `obj_scaling_factor` is not in this table: it only rescales
+conditioning, and the convex path reports natural units either way, so
+both paths give the same answer.
+
 ### Infeasible and unbounded problems
 
 The convex solver detects infeasibility and unboundedness directly,

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -46,6 +46,53 @@ reference page. For nonlinear bound tightening (`presolve_fbbt`,
 `fbbt_tol`, `fbbt_max_iter`, `fbbt_max_constraints`), see the
 [FBBT](fbbt.md) reference page.
 
+## Options POUNCE does not implement
+
+POUNCE's option registry is a faithful port of Ipopt's: every name Ipopt
+registers is registered here, so an `ipopt.opt` written for Ipopt parses
+unchanged. Registering an option is not the same as implementing it,
+though — and for a long time setting an unimplemented one did nothing at
+all, silently.
+
+Options naming a feature POUNCE does not have now **fail the solve**,
+naming the option, the feature, and what to use instead:
+
+```
+$ pounce model.nl dependency_detector=mumps
+pounce: `dependency_detector` configures linear-dependency detection on the
+equality constraints, which pounce does not implement. It is registered so an
+ipopt.opt written for Ipopt still parses, but setting it used to do nothing at
+all — silently — so it is refused instead. Instead: pounce's presolve removes
+structurally redundant rows; see `presolve`. Remove it to run.
+```
+
+The features in question: the Chen-Goldfarb (CG-penalty) / inexact-Newton
+line search, derivative approximation by finite differences,
+linear-dependency detection, the per-iteration NaN/Inf derivative check,
+multiplier recalculation by least squares, a selectable
+constraint-violation norm, magic steps, bound replacement, the L-BFGS
+augmented-system variants, reading options from a file, skipping the
+finalize callback, the dynamic HSL loader, and `suppress_all_output` /
+`debug_print_level`.
+
+Two deliberate exceptions:
+
+* **Setting an option to its registered default is allowed.** A generated
+  `ipopt.opt` spells out defaults, and `dependency_detector=none` asks for
+  nothing. Only a value that differs from the default is a request POUNCE
+  cannot honour.
+* **Caching hints warn instead of failing.** `grad_f_constant`,
+  `hessian_constant`, `jac_c_constant` and `jac_d_constant` tell the
+  solver a quantity does not change between iterations. POUNCE
+  re-evaluates regardless, so ignoring them costs evaluations and never
+  correctness — failing the solve would be a worse trade.
+
+Options whose *feature* runs and whose value simply is not read yet are
+**not** in this category; they still solve, with the default in effect.
+Wiring those is tracked on
+[#191](https://github.com/jkitchin/pounce/issues/191) and
+[#483](https://github.com/jkitchin/pounce/issues/483).
+
 ## Derivative checker
 
 Wrong analytic derivatives are the most common cause of an NLP that

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -28,7 +28,7 @@ file.
 | `tol`           | Overall convergence tolerance on the KKT error.                      |
 | `max_iter`      | Maximum number of outer iterations.                                  |
 | `print_level`   | Console verbosity, 0 (silent) – 12 (maximum debug).                  |
-| `linear_solver` | KKT linear-solver backend. `ma57` requires the `ma57` feature build. |
+| `linear_solver` | KKT linear-solver backend: `feral` (default) or `ma57` (needs a `--features ma57` build). Any other registered name is **refused**. See below. |
 | `mu_strategy`   | Barrier-parameter update strategy (`monotone` / `adaptive`).         |
 | `solver_selection` | Route LP/convex-QP to the specialized convex IPM. See [LP/QP Routing](lp-qp-routing.md). |
 | `qp_presolve`   | Presolve on the convex LP/QP path (`yes` / `no`, default `yes`). See [LP/QP Routing](lp-qp-routing.md#presolve). |
@@ -45,6 +45,91 @@ overrides, `linear_system_scaling`), see the [Scaling](scaling.md)
 reference page. For nonlinear bound tightening (`presolve_fbbt`,
 `fbbt_tol`, `fbbt_max_iter`, `fbbt_max_constraints`), see the
 [FBBT](fbbt.md) reference page.
+
+## Derivative checker
+
+Wrong analytic derivatives are the most common cause of an NLP that
+stalls, cycles, or converges to something that is not a solution — and
+they are invisible from the iteration log. `derivative_test` compares
+what your TNLP returns against finite differences at the (bound-projected)
+starting point, before the solve:
+
+```
+pounce problem.nl derivative_test=first-order
+```
+
+| Option | Default | Effect |
+|---|---|---|
+| `derivative_test` | `none` | `none` / `first-order` / `second-order` / `only-second-order`. |
+| `derivative_test_perturbation` | `1e-8` | Relative finite-difference step: `perturbation · max(1, |xᵢ|)`. |
+| `derivative_test_tol` | `1e-4` | Flag an entry when `\|analytic − fd\| > tol · max(1, \|fd\|)`. |
+| `derivative_test_first_index` | `-2` (all) | First **variable** for the first-order test; first **constraint** for the second-order one, where `-1` is the objective's Hessian. |
+| `derivative_test_print_all` | `no` | List every entry, not just the suspicious ones. |
+
+`first-order` checks `eval_grad_f` and `eval_jac_g`; `second-order` adds
+`eval_h`; `only-second-order` checks the Hessian alone. The Hessian is
+checked one multiplier block at a time — `obj_factor = 1, λ = 0` against
+differences of `eval_grad_f`, then `obj_factor = 0, λ = eⱼ` against
+differences of row `j` of `eval_jac_g`.
+
+Entries that look wrong are marked `*`:
+
+```
+Derivative checker: first derivatives at the starting point (perturbation 1.0e-8, tolerance 1.0e-4).
+* grad_f[    1]       =    3.5000000000000000e0    ~    3.0000000119209290e0  [  1.667e-1]
+1 suspicious derivative(s) and 0 missing sparsity entrie(s) out of 6 checked (8 evaluations).
+```
+
+Two checks beyond upstream Ipopt's, because both catch a class of bug no
+value-by-value comparison can:
+
+* A Jacobian or Hessian entry whose finite difference is nonzero but
+  which the **sparsity structure omits** (`!` in the report). A missing
+  structural entry is not a wrong number — it is a derivative the solver
+  can never see.
+* The perturbation is taken **downward** when stepping up would leave a
+  variable's box, so a model using `sqrt`, `log`, or `1/x` is not
+  evaluated outside its own domain by the checker.
+
+The test is advisory: it reports and the solve continues. It is written
+to **stderr**, so it survives `print_level=0` and never mixes into
+`--json-output`'s stdout. It is slow — the second-order test costs
+roughly `(m+1)·n` evaluations — so leave it off for production runs.
+
+> `check_derivatives_for_naninf` is a separate upstream option, for a
+> per-iteration NaN/Inf guard, and is **not implemented**.
+
+## Choosing a linear solver
+
+POUNCE implements two KKT backends:
+
+* **`feral`** — pure-Rust sparse symmetric indefinite solver. The
+  effective default; no Fortran toolchain, no HSL licence.
+* **`ma57`** — HSL MA57, available only in a `cargo build --features
+  ma57` build.
+
+The option's *registered* value list is a faithful port of upstream
+Ipopt's (`ma27`, `ma77`, `ma86`, `ma97`, `mumps`, `pardiso`,
+`pardisomkl`, `spral`, `wsmp`, `custom`), so an `ipopt.opt` written for
+Ipopt parses here unchanged. Selecting one of those **fails the solve**
+with a message naming it. They used to fall through to FERAL silently,
+which meant `linear_solver=ma97` "worked" and a benchmark comparing
+backends compared FERAL with itself.
+
+Two things deliberately do *not* fail:
+
+* The **registered default** is upstream's `ma57`. It is not a user
+  request, and on the pure-Rust build it resolves to FERAL as it always
+  has, so a plain run is unaffected.
+* **Explicit `ma57` on a build without the feature** falls back to FERAL
+  and says so in the banner (`FERAL (ma57 requested but not compiled)`).
+  That substitution is reported rather than hidden, and failing a
+  portable `ipopt.opt` over a build flag would cost more than it buys.
+
+The per-backend tuning options (`ma97_scaling`, `mumps_pivtolmax`,
+`pardiso_*`, `wsmp_*`, `spral_*`, …) remain registered for the same
+`ipopt.opt`-compatibility reason. They are unreachable now that their
+backend cannot be selected.
 
 ## Bound relaxation and `honor_original_bounds`
 

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -116,15 +116,19 @@ with a message naming it. They used to fall through to FERAL silently,
 which meant `linear_solver=ma97` "worked" and a benchmark comparing
 backends compared FERAL with itself.
 
-Two things deliberately do *not* fail:
+The **registered default is `feral`**, which diverges from upstream's
+`ma57` on purpose: a default has to name a solver the binary actually
+contains. Under the upstream default a pure-Rust build advertised MA57 to
+every `print_user_options` dump while running FERAL, and an
+HSL-enabled build used MA57 without being asked. **If you build
+`--features ma57` and want it, select it explicitly** — that is the one
+behavioural change here.
 
-* The **registered default** is upstream's `ma57`. It is not a user
-  request, and on the pure-Rust build it resolves to FERAL as it always
-  has, so a plain run is unaffected.
-* **Explicit `ma57` on a build without the feature** falls back to FERAL
-  and says so in the banner (`FERAL (ma57 requested but not compiled)`).
-  That substitution is reported rather than hidden, and failing a
-  portable `ipopt.opt` over a build flag would cost more than it buys.
+Not a failure: **explicit `ma57` on a build without the feature** falls
+back to FERAL and says so in the banner (`FERAL (ma57 requested but not
+compiled)`). That substitution is reported rather than hidden, and
+failing a portable `ipopt.opt` over a build flag would cost more than it
+buys.
 
 The per-backend tuning options (`ma97_scaling`, `mumps_pivtolmax`,
 `pardiso_*`, `wsmp_*`, `spral_*`, …) remain registered for the same

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -32,6 +32,9 @@ file.
 | `mu_strategy`   | Barrier-parameter update strategy (`monotone` / `adaptive`).         |
 | `solver_selection` | Route LP/convex-QP to the specialized convex IPM. See [LP/QP Routing](lp-qp-routing.md). |
 | `qp_presolve`   | Presolve on the convex LP/QP path (`yes` / `no`, default `yes`). See [LP/QP Routing](lp-qp-routing.md#presolve). |
+| `obj_scaling_factor` | Constant multiplier on the objective; **negative maximizes**. See below. |
+| `bound_relax_factor` | Relaxation applied to variable/constraint bounds before the solve (default `1e-8`). |
+| `honor_original_bounds` | Project the reported point back into the un-relaxed bounds (`yes` / `no`, default `no`). See below. |
 
 For the full upstream option catalogue, see the
 [Ipopt options reference](https://coin-or.github.io/Ipopt/OPTIONS.html);
@@ -42,6 +45,45 @@ overrides, `linear_system_scaling`), see the [Scaling](scaling.md)
 reference page. For nonlinear bound tightening (`presolve_fbbt`,
 `fbbt_tol`, `fbbt_max_iter`, `fbbt_max_constraints`), see the
 [FBBT](fbbt.md) reference page.
+
+## Bound relaxation and `honor_original_bounds`
+
+Before the solve, POUNCE widens every variable and constraint bound by
+`bound_relax_factor` (default `1e-8`, capped by `constr_viol_tol`),
+exactly as upstream Ipopt does — it keeps the interior-point iterates
+strictly feasible without the user's bounds becoming numerically
+degenerate. The consequence is that a solution *pinned to a bound* is
+reported just past it:
+
+```
+min (x − 3)²  s.t.  0 ≤ x ≤ 1     →     x = 1.00000000937
+```
+
+`honor_original_bounds=yes` projects the reported point back into the
+bounds you declared, so that solve returns exactly `x = 1`. Reach for it
+whenever the value flows somewhere that cares about the domain — a
+`sqrt(1 − x)`, a domain assertion, or a Pyomo `Var` the value is loaded
+back into.
+
+The default is `no`, matching upstream. As upstream also documents, the
+constraint-violation and complementarity figures in the end-of-run
+summary are for the **non-projected** point; only the reported `x` (and
+the objective and constraint values evaluated at it) move.
+
+## Objective sense and `obj_scaling_factor`
+
+`obj_scaling_factor` multiplies the objective the IPM minimizes, so a
+**negative** value maximizes — upstream's documented spelling for a
+maximization problem stated as a minimization. Because it changes what is
+being optimized rather than just its conditioning, it is honored only by
+the general NLP interior-point path: a model that would otherwise route
+to the specialized convex solvers (LP / convex QP / SOCP, see
+[LP/QP Routing](lp-qp-routing.md)) is re-routed under
+`solver_selection=auto`, and an explicit convex `solver_selection` is
+**refused** rather than silently answering with the minimizer.
+
+A positive factor is a pure conditioning knob; the convex path reports
+natural units either way, so it keeps the fast path.
 
 ## Barrier-parameter (μ) strategy
 

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -50,6 +50,56 @@ import pyomo_pounce
 pyomo_pounce.check_binary()   # prints a report; returns a dict
 ```
 
+## User scaling with the `scaling_factor` Suffix
+
+A badly conditioned model converges poorly, and often you know its
+natural units better than the solver can infer from gradients at `x0`.
+The standard Pyomo channel for saying so is the `scaling_factor`
+Suffix, read exactly as Ipopt reads it:
+
+```python
+model.scaling_factor = Suffix(direction=Suffix.EXPORT)
+model.scaling_factor[model.obj] = 1e-3           # objective in MW, not W
+model.scaling_factor[model.mass_balance] = 1e2   # one constraint
+model.scaling_factor[model.energy_balance] = 1e2 # or a whole container
+
+solver.solve(model, options={'nlp_scaling_method': 'user-scaling'})
+```
+
+Both halves are required: without `nlp_scaling_method=user-scaling` the
+Suffix is inert (a `scaling_factor` Suffix also drives Pyomo's own
+`core.scale_model` transformation, which never involves the solver), and
+without the Suffix the option has nothing to apply — pyomo-pounce warns
+in that case rather than leaving you to wonder.
+
+Rules, matching AMPL/Ipopt:
+
+* Only an **export-enabled** Suffix counts (`Suffix.EXPORT` or
+  `Suffix.IMPORT_EXPORT`).
+* Components you do not list are unscaled, as are components listed with
+  a factor of `0`.
+* An entry on a container applies to every member.
+* Entries on **inactive** constraints/objectives and on **fixed**
+  variables are skipped — none is a row or column of the problem the
+  solver is handed.
+* Scaling changes conditioning, never the answer: solutions, duals, and
+  everything the [sensitivity](sensitivity.md) accessors report come back
+  in your model's units.
+
+**Variables cannot be scaled.** POUNCE models objective and constraint
+scaling only, so a `scaling_factor` on a `Var` raises with a message
+naming the variables. It is a hard error on purpose: applying the
+objective and constraint factors while dropping the variable ones would
+solve a problem your Suffix does not describe, and say nothing about it
+([issue #483](https://github.com/jkitchin/pounce/issues/483)). Rescale
+those variables in the model itself — substitute `x = z / s`, declare
+`z`, and the change is explicit in the model rather than implicit in a
+suffix.
+
+This works on both solve paths: the ordinary ASL/subprocess solve and
+the in-process path taken when the model carries [sensitivity
+declarations](sensitivity.md).
+
 ## Preflight and initialization
 
 A `Var` whose `.value` was never set is written as **0** into the

--- a/docs/src/scaling.md
+++ b/docs/src/scaling.md
@@ -45,27 +45,60 @@ Use this when you know the natural units of your problem (e.g. mass in
 kg vs. distance in mm) and can supply better scales than the
 gradient-based heuristic.
 
-> **Note**: pounce's `OrigIpoptNlp` currently honors `obj_scaling` and
-> per-constraint `g_scaling`. The `x_scaling` request channel is
-> accepted but not yet acted on. Mirrors the design in
-> [issue #61](https://github.com/jkitchin/pounce/issues/61).
-
 If the TNLP's `get_scaling_parameters` returns false (the default),
 pounce falls back to no automatic scaling.
 
+> **Per-variable factors are refused, not ignored.** pounce's
+> `OrigIpoptNlp` models `obj_scaling` and per-constraint `g_scaling`
+> (the design in [issue #61](https://github.com/jkitchin/pounce/issues/61));
+> it does not rescale variables. A request that sets any `x_scaling`
+> entry away from `1.0` therefore **fails the solve** with
+> `Invalid_Option` and an explanatory message, rather than applying the
+> other two axes and dropping this one — which used to hand back a
+> converged answer to a differently-conditioned problem with nothing
+> said about it ([issue #483](https://github.com/jkitchin/pounce/issues/483)).
+> Rescale those variables in the model itself (substitute `x = z / s`
+> and give the solver `z`). Modelling variable scaling in the core is
+> staged work tracked on #483.
+
 #### Setting user scaling
 
+* **From an `.nl` file (AMPL, Pyomo, any NL-writing frontend)** — attach
+  a `scaling_factor` suffix to the objective, to constraints, or to
+  both, and pass `nlp_scaling_method=user-scaling`. This is the same
+  channel Ipopt reads through ASL. In Pyomo:
+
+  ```python
+  m.scaling_factor = Suffix(direction=Suffix.EXPORT)
+  m.scaling_factor[m.obj] = 1e-3
+  m.scaling_factor[m.mass_balance] = 1e2
+  SolverFactory('pounce').solve(m, options={'nlp_scaling_method': 'user-scaling'})
+  ```
+
+  Components the suffix does not list are unscaled, as are components
+  listed with a factor of `0` (AMPL's suffix default). With no
+  `scaling_factor` suffix at all the option falls back to no scaling.
+  See [Pyomo](pyomo.md) for the pyomo-pounce specifics.
 * **From C** — call `SetIpoptProblemScaling(problem, obj, x_scaling,
   g_scaling)` then `AddIpoptStrOption("nlp_scaling_method",
   "user-scaling")`. See `crates/pounce-cinterface/include/pounce.h`.
+  Pass `NULL` (or an all-ones array) for `x_scaling`.
 * **From Rust** — implement
   [`TNLP::get_scaling_parameters`](https://github.com/jkitchin/pounce/blob/main/crates/pounce-nlp/src/tnlp.rs)
   on your problem type.
 * **From Python** — `pounce.Problem.set_problem_scaling(obj_scaling,
-  x_scaling=None, g_scaling=None)`, followed by
-  `add_option("nlp_scaling_method", "user-scaling")`. Walked through
-  end-to-end in
+  g_scaling=...)`, followed by
+  `add_option("nlp_scaling_method", "user-scaling")`. A non-unit
+  `x_scaling=` raises. Walked through end-to-end in
   [`python/notebooks/07_scaling.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/07_scaling.ipynb).
+
+> **Specialized solvers.** A model that classifies as an LP, convex QP,
+> or SOCP normally routes to `pounce-convex`, which equilibrates
+> internally and never reads the TNLP scaling callback. When
+> `nlp_scaling_method=user-scaling` is set and the `.nl` carries
+> `scaling_factor` suffixes, `solver_selection=auto` declines that fast
+> path and uses the general NLP interior-point solver so the scaling is
+> honored; an explicit `solver_selection` is respected and warns.
 
 ### Target-gradient overrides
 

--- a/pyomo-pounce/README.md
+++ b/pyomo-pounce/README.md
@@ -64,6 +64,28 @@ solver.options['print_level'] = 5
 Options are forwarded to POUNCE's `OptionsList` (ipopt.opt-compatible
 keys).
 
+## User scaling
+
+The standard `scaling_factor` Suffix works as it does with IPOPT:
+
+```python
+model.scaling_factor = Suffix(direction=Suffix.EXPORT)
+model.scaling_factor[model.obj] = 1e-3
+model.scaling_factor[model.mass_balance] = 1e2
+
+solver.solve(model, options={'nlp_scaling_method': 'user-scaling'})
+```
+
+Both halves are needed — the Suffix alone is inert (it also drives
+Pyomo's own `core.scale_model`), and the option alone has nothing to
+apply, which pyomo-pounce warns about. Untagged components are
+unscaled; inactive constraints and fixed variables are skipped.
+
+POUNCE models objective and constraint scaling only, so a
+`scaling_factor` on a `Var` **raises** rather than being silently
+dropped ([#483](https://github.com/jkitchin/pounce/issues/483)) —
+rescale those variables in the model instead.
+
 ## Local development / unsupported platforms
 
 If `pounce-solver` does not ship a wheel for your platform, the pip

--- a/pyomo-pounce/pyomo_pounce/pounce_solver.py
+++ b/pyomo-pounce/pyomo_pounce/pounce_solver.py
@@ -148,6 +148,11 @@ class POUNCE(ASL):
         # available for gradient()/estimate(). Otherwise the ordinary
         # ASL/CLI path runs. The model may arrive positionally or as the
         # `model` keyword.
+        from pyomo_pounce.scaling import (
+            check_no_variable_scaling,
+            user_scaling_requested,
+            warn_if_no_suffix,
+        )
         from pyomo_pounce.sens import has_declarations, sens_solve
 
         model = args[0] if args else kwds.get("model")
@@ -187,16 +192,27 @@ class POUNCE(ASL):
                     "var.domain = pyomo.environ.Reals / relax it explicitly) "
                     "if a continuous relaxation is what you intend, or use a "
                     "MINLP-capable solver.")
+        # Solver options as the solve will actually see them: factory-level
+        # options (SolverFactory("pounce", options=...) or
+        # solver.options[...]) first, per-call options={...} on top.
+        # Dropping them here silently un-tuned every model the day it gained
+        # a declaration (gh #432).
+        # the ASL layer keeps its executable option prefix under the
+        # `solver` key; it is bookkeeping, not a solver option
+        opts = {k: v for k, v in self.options.items() if k != "solver"}
+        opts.update(kwds.get("options") or {})
+        if model is not None and user_scaling_requested(opts):
+            # gh #483: the `scaling_factor` Suffix is the standard Pyomo
+            # channel for user scaling, and it used to reach pyomo-pounce
+            # and stop -- the option was accepted and meant "none". The
+            # objective/constraint factors now flow through (the writer's
+            # `.nl` suffix segments on this path, `set_problem_scaling` on
+            # the in-process one); a variable factor POUNCE cannot model is
+            # refused here rather than discarded, and a request with nothing
+            # to apply says so.
+            check_no_variable_scaling(model)
+            warn_if_no_suffix(model)
         if model is not None and (has_declarations(model) or explicit):
-            # Solver options must survive the reroute: factory-level
-            # options (SolverFactory("pounce", options=...) or
-            # solver.options[...]) first, per-call options={...} on top.
-            # Dropping them here silently un-tuned every model the day
-            # it gained a declaration (gh #432).
-            # the ASL layer keeps its executable option prefix under
-            # the `solver` key; it is bookkeeping, not a solver option
-            opts = {k: v for k, v in self.options.items() if k != "solver"}
-            opts.update(kwds.get("options") or {})
             return sens_solve(model, tee=kwds.get("tee", False),
                               options=opts, **explicit)
         return super().solve(*args, **kwds)

--- a/pyomo-pounce/pyomo_pounce/scaling.py
+++ b/pyomo-pounce/pyomo_pounce/scaling.py
@@ -1,0 +1,216 @@
+"""User NLP scaling from Pyomo's `scaling_factor` Suffix (gh #483).
+
+The Pyomo/Ipopt workflow for hand-supplied scaling is::
+
+    model.scaling_factor = Suffix(direction=Suffix.EXPORT)
+    model.scaling_factor[model.obj] = 1e-3
+    model.scaling_factor[model.mass_balance] = 1e2
+    solver.options['nlp_scaling_method'] = 'user-scaling'
+
+Through ASL the writer emits those entries as `.nl` `S4`/`S5`/`S6`
+suffix segments and the solver reads them back. pyomo-pounce contained
+no scaling code at all, so the option was accepted and meant "none": a
+badly conditioned model kept converging badly with nothing to say the
+suffix had been ignored.
+
+Two things happen here now:
+
+* **Objective and constraint factors are honored.** The subprocess
+  (ASL) path needs nothing from this module — the writer emits the
+  suffix segments and `NlTnlp::get_scaling_parameters` now reads them.
+  The in-process sensitivity path builds no `.nl` for the solver, so
+  :func:`problem_scaling` translates the Suffix into the vectors
+  `pounce.Problem.set_problem_scaling` wants.
+* **Variable factors are refused, loudly.** pounce models objective and
+  constraint scaling only. Accepting a per-variable factor and dropping
+  it hands back a differently-conditioned problem than the one the
+  suffix describes, so :func:`check_no_variable_scaling` raises instead.
+  (Lifting this is staged behind the core work in gh #483.)
+
+Semantics, matching the AMPL/Ipopt reading of the suffix:
+
+* Only an **export-enabled** Suffix named ``scaling_factor`` counts.
+* Components the Suffix does not list are unscaled (factor 1.0), as are
+  components listed with a factor of 0 — AMPL's suffix default is 0 and
+  0 is not a usable scale.
+* Entries on **inactive** constraints/objectives and on **fixed**
+  variables are skipped: none of them is a row or column of the problem
+  the solver is handed.
+* An entry on a container (``scaling_factor[m.mass_balance]`` for an
+  IndexedConstraint) applies to every member, which is how the NL
+  writer expands it.
+"""
+
+import warnings
+
+import pyomo.environ as pyo
+
+#: The Suffix name AMPL, Ipopt, and Pyomo's own `core.scale_model` all use.
+SUFFIX_NAME = "scaling_factor"
+
+#: `nlp_scaling_method` value that turns the Suffix into actual scaling.
+USER_SCALING = "user-scaling"
+
+
+def user_scaling_requested(options):
+    """True when `options` selects `nlp_scaling_method=user-scaling`.
+
+    `options` is any mapping of solver options (Pyomo's `solver.options`,
+    a per-call `options={...}`, or the merged form the in-process path
+    receives). Anything else — including the default `gradient-based` —
+    means the Suffix is not consulted, exactly as with Ipopt.
+    """
+    value = (options or {}).get("nlp_scaling_method")
+    return value is not None and str(value).strip().lower() == USER_SCALING
+
+
+def _iter_data(comp):
+    """Every ComponentData under `comp` (itself, when scalar)."""
+    if comp.is_indexed():
+        for idx in comp:
+            yield comp[idx]
+    else:
+        yield comp
+
+
+def _suffixes(model):
+    """Every export-enabled Suffix named `scaling_factor` on the model.
+
+    Scanned across sub-blocks, since that is where the NL writer looks
+    too; a block-local `scaling_factor` is as real as a top-level one.
+    """
+    found = []
+    for sfx in model.component_objects(pyo.Suffix, active=True,
+                                       descend_into=True):
+        if sfx.local_name == SUFFIX_NAME and sfx.export_enabled():
+            found.append(sfx)
+    return found
+
+
+def read_scaling(model):
+    """Parse the model's `scaling_factor` Suffix.
+
+    Returns ``None`` when the model declares no export-enabled
+    `scaling_factor` Suffix — "the user supplied nothing", which leaves
+    the solver on its own default (no scaling under `user-scaling`).
+
+    Otherwise returns ``(obj_factor, constraints, variables)``:
+
+    * ``obj_factor`` — float factor for the active objective (1.0 when
+      untagged),
+    * ``constraints`` — ``{ConstraintData: factor}`` for active
+      constraints tagged with a usable (non-zero) factor,
+    * ``variables`` — ``[(VarData, factor)]`` for non-fixed variables
+      tagged with a factor other than 1.0, i.e. the entries pounce
+      cannot honor. Empty when the model asks for nothing on that axis.
+    """
+    suffixes = _suffixes(model)
+    if not suffixes:
+        return None
+
+    obj_factor = 1.0
+    constraints = {}
+    variables = []
+    for sfx in suffixes:
+        for key, value in sfx.items():
+            for data in _iter_data(key):
+                factor = float(value)
+                ctype = data.ctype
+                if ctype is pyo.Objective:
+                    # Only the objective actually being minimized has a
+                    # scale; a deactivated one is not in the problem.
+                    if data.active and factor != 0.0:
+                        obj_factor = factor
+                elif ctype is pyo.Constraint:
+                    if data.active and factor != 0.0:
+                        constraints[data] = factor
+                elif ctype is pyo.Var:
+                    # A fixed variable is a constant folded into the
+                    # rows, not a column the solver could rescale.
+                    if not data.fixed and factor != 1.0:
+                        variables.append((data, factor))
+    return obj_factor, constraints, variables
+
+
+def check_no_variable_scaling(model, max_list=5):
+    """Raise if the `scaling_factor` Suffix tags variables.
+
+    pounce models objective and constraint scaling only. Silently
+    dropping per-variable factors is what gh #483 is about, so this is a
+    hard error rather than a warning: the alternative is a solve whose
+    conditioning does not match the suffix the user wrote.
+    """
+    parsed = read_scaling(model)
+    if parsed is None:
+        return
+    _, _, variables = parsed
+    if not variables:
+        return
+    shown = ", ".join(f"{vd.name}={f:g}" for vd, f in variables[:max_list])
+    more = (f" (+{len(variables) - max_list} more)"
+            if len(variables) > max_list else "")
+    raise ValueError(
+        "pounce solve: nlp_scaling_method=user-scaling, and the model's "
+        f"`{SUFFIX_NAME}` Suffix sets a scaling factor on "
+        f"{len(variables)} variable(s) ({shown}{more}). POUNCE models "
+        "objective and constraint scaling only, so those factors cannot be "
+        "applied -- and applying the objective/constraint ones alone would "
+        "silently give you a differently conditioned problem than the "
+        "suffix describes. Remove the variable entries and rescale those "
+        "variables in the model itself (substitute x = z / factor and "
+        "declare z), or drop nlp_scaling_method=user-scaling. Tracking "
+        "issue: https://github.com/jkitchin/pounce/issues/483")
+
+
+def warn_if_no_suffix(model):
+    """Warn when `user-scaling` is on but the model tags nothing.
+
+    Without a Suffix the option is a no-op — the exact silence gh #483
+    is about, just with the model rather than the solver at fault (a
+    misspelled Suffix name, or one built with the default LOCAL
+    direction so it never reaches the solver)."""
+    if read_scaling(model) is None:
+        warnings.warn(
+            "pounce solve: nlp_scaling_method=user-scaling was requested, but "
+            f"the model declares no export-enabled `{SUFFIX_NAME}` Suffix, so "
+            "no scaling will be applied. Declare it with "
+            f"`model.{SUFFIX_NAME} = Suffix(direction=Suffix.EXPORT)` and tag "
+            "the objective / constraints you want scaled.",
+            UserWarning,
+            stacklevel=3)
+
+
+def problem_scaling(model, con_names, con_alias):
+    """Suffix -> `(obj_factor, g_scaling)` for `Problem.set_problem_scaling`.
+
+    Used by the in-process sensitivity path, which hands pounce
+    evaluator callbacks rather than an `.nl` file and so has no suffix
+    segments for the solver to read.
+
+    `con_names` is the solve's constraint rows in `.nl` order and
+    `con_alias` maps an original constraint's name to the clone name the
+    declared-parameter surgery gave it, exactly as in
+    `_warm_start_from_suffixes`. Rows the Suffix does not mention stay
+    at 1.0. Returns ``None`` when the model declares no Suffix.
+
+    Variable entries are not this function's business: like the `.nl`
+    writer, it translates what it can and leaves the refusal to
+    :func:`check_no_variable_scaling`, which callers run only when
+    `user-scaling` is actually on. That keeps a `scaling_factor` Suffix
+    written for Pyomo's `core.scale_model` from failing an ordinary
+    solve.
+    """
+    parsed = read_scaling(model)
+    if parsed is None:
+        return None
+    obj_factor, constraints, _ = parsed
+    con_row = {name: i for i, name in enumerate(con_names)}
+    g_scaling = [1.0] * len(con_names)
+    for cd, factor in constraints.items():
+        # A constraint the writer dropped (trivially satisfied, or
+        # absorbed into a bound) has no row to scale; skipping it
+        # matches what the ASL path does with the same suffix.
+        row = con_row.get(con_alias.get(cd.name, cd.name))
+        if row is not None:
+            g_scaling[row] = factor
+    return obj_factor, g_scaling

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -62,6 +62,13 @@ from pyomo.core.expr import identify_mutable_parameters
 from pyomo.core.expr.visitor import replace_expressions
 from pyomo.opt import SolverResults, SolverStatus, TerminationCondition
 
+from pyomo_pounce.scaling import (
+    check_no_variable_scaling,
+    problem_scaling,
+    user_scaling_requested,
+    warn_if_no_suffix,
+)
+
 _REG = "_pounce_sens"
 
 
@@ -699,6 +706,23 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     for key, val in (options or {}).items():
         prob.add_option(key, val)
     con_alias = _replaced_aliases(clone, si)
+    # gh #483: user scaling from the model's `scaling_factor` Suffix. The
+    # ASL path gets this for free -- the writer emits the suffix as `.nl`
+    # `S4`/`S5`/`S6` segments and the solver reads them -- but this path
+    # hands pounce evaluator callbacks, with no `.nl` in between, so the
+    # Suffix has to be translated into `set_problem_scaling` vectors here.
+    # Read from `model` (not the surgery clone) and mapped through
+    # `con_alias`, exactly as the warm-start suffixes are. Installing it
+    # unconditionally is safe: `nlp_scaling_method` decides whether the
+    # engine looks, so a tagged model solved without `user-scaling`
+    # behaves as before.
+    if user_scaling_requested(options):
+        check_no_variable_scaling(model)
+        warn_if_no_suffix(model)
+    scaling = problem_scaling(model, con_names, con_alias)
+    if scaling is not None:
+        obj_scale, g_scale = scaling
+        prob.set_problem_scaling(obj_scale, g_scaling=g_scale)
     warm = {}
     if _warm_start_requested(options):
         warm = _warm_start_from_suffixes(

--- a/pyomo-pounce/tests/test_user_scaling.py
+++ b/pyomo-pounce/tests/test_user_scaling.py
@@ -1,0 +1,432 @@
+"""User NLP scaling from the `scaling_factor` Suffix (gh #483).
+
+A Pyomo user who tags the standard `scaling_factor` Suffix and sets
+`nlp_scaling_method=user-scaling` — the workflow that works with Ipopt
+through ASL — used to get no scaling at all and no message saying so:
+pyomo-pounce contained no scaling code, so nothing ever populated the
+solver's user-scaling channel and the option meant "none".
+
+Three things are pinned here.
+
+1. **The Suffix is read the way AMPL/Ipopt read it** (`test_read_*`):
+   export-enabled only, containers expanded, inactive constraints and
+   fixed variables skipped, untagged components unscaled.
+2. **It reaches the solver on both paths** — the ASL/subprocess path
+   through the writer's `.nl` suffix segments, and the in-process
+   sensitivity path through `Problem.set_problem_scaling`.
+3. **Nothing it cannot honor is dropped quietly**: a per-variable
+   factor raises, and a `user-scaling` request with no Suffix to apply
+   warns.
+
+The sensitivity accessors get their own axis. `natural_units_conj`
+already translates `df` / `dc` / `dd` back to model units for any
+scaling method, so user scaling *should* be invisible to every
+accessor — but that is the kind of claim worth proving rather than
+assuming, so each one is checked against the same quantity computed
+with no scaling engaged.
+"""
+import warnings
+
+import numpy as np
+import pytest
+import pyomo.environ as pyo
+
+import pyomo_pounce  # noqa: F401  (registers 'pounce')
+from pyomo_pounce import (
+    covariance,
+    declare_fitted,
+    declare_residual,
+    declare_sens_param,
+    estimate,
+    gradient,
+    information,
+    release_kkt,
+    retain_kkt,
+)
+from pyomo_pounce.scaling import (
+    check_no_variable_scaling,
+    problem_scaling,
+    read_scaling,
+    user_scaling_requested,
+)
+
+USER_SCALING = {"nlp_scaling_method": "user-scaling"}
+
+
+# ── the Suffix reader ────────────────────────────────────────────────────────
+
+def tagged_model(**tags):
+    """`min (x1-2)^4 + (x2-3)^2` s.t. `x1*x2 >= 1`, `x1 - x2 == 0.5`,
+    with an export `scaling_factor` Suffix carrying `tags`."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var([1, 2], initialize=1.0)
+    m.o = pyo.Objective(expr=(m.x[1] - 2) ** 4 + (m.x[2] - 3) ** 2)
+    m.c1 = pyo.Constraint(expr=m.x[1] * m.x[2] >= 1)
+    m.c2 = pyo.Constraint(expr=m.x[1] - m.x[2] == 0.5)
+    if tags:
+        m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+        for name, value in tags.items():
+            key = {"o": m.o, "c1": m.c1, "c2": m.c2,
+                   "x1": m.x[1], "x2": m.x[2]}[name]
+            m.scaling_factor[key] = value
+    return m
+
+
+def test_read_no_suffix_is_none():
+    # "the user supplied nothing" must stay distinguishable from "the
+    # user asked for 1.0 everywhere": the first leaves the solver alone.
+    assert read_scaling(tagged_model()) is None
+
+
+def test_read_splits_objective_constraints_and_variables():
+    m = tagged_model(o=100.0, c1=10.0, x1=3.0)
+    obj, cons, variables = read_scaling(m)
+    assert obj == 100.0
+    assert cons == {m.c1: 10.0}
+    assert variables == [(m.x[1], 3.0)]
+
+
+def test_read_ignores_a_non_export_suffix():
+    # A LOCAL Suffix never reaches a solver, so it must not look like
+    # a scaling request here either.
+    m = tagged_model()
+    m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.LOCAL)
+    m.scaling_factor[m.o] = 100.0
+    assert read_scaling(m) is None
+
+
+def test_read_expands_a_container_entry():
+    # `scaling_factor[m.c] = s` on an IndexedConstraint applies to every
+    # member -- which is how the NL writer expands it, so both solve
+    # paths must agree.
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var([1, 2], initialize=1.0)
+    m.o = pyo.Objective(expr=m.x[1] ** 2 + m.x[2] ** 2)
+    m.c = pyo.Constraint([1, 2], rule=lambda mm, i: mm.x[i] >= 0.5)
+    m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+    m.scaling_factor[m.c] = 7.0
+    _, cons, _ = read_scaling(m)
+    assert cons == {m.c[1]: 7.0, m.c[2]: 7.0}
+
+
+def test_read_skips_inactive_constraints_and_fixed_variables():
+    # Neither is a row/column of the problem the solver is handed, so a
+    # factor on one is not a request pounce is dropping.
+    m = tagged_model(o=100.0, c1=10.0, x1=3.0)
+    m.c1.deactivate()
+    m.x[1].fix(1.0)
+    obj, cons, variables = read_scaling(m)
+    assert obj == 100.0
+    assert cons == {}
+    assert variables == []
+
+
+def test_read_treats_a_zero_factor_as_untagged():
+    # AMPL's suffix default is 0 and 0 is not a usable scale factor.
+    m = tagged_model(o=0.0, c1=0.0)
+    obj, cons, _ = read_scaling(m)
+    assert obj == 1.0
+    assert cons == {}
+
+
+def test_read_finds_a_block_local_suffix():
+    m = tagged_model()
+    m.b = pyo.Block()
+    m.b.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+    m.b.scaling_factor[m.c1] = 10.0
+    _, cons, _ = read_scaling(m)
+    assert cons == {m.c1: 10.0}
+
+
+def test_user_scaling_requested_reads_the_option():
+    assert user_scaling_requested(USER_SCALING)
+    assert user_scaling_requested({"nlp_scaling_method": " User-Scaling "})
+    assert not user_scaling_requested({"nlp_scaling_method": "gradient-based"})
+    assert not user_scaling_requested({})
+    assert not user_scaling_requested(None)
+
+
+def test_problem_scaling_builds_dense_row_vectors():
+    # Untagged rows stay at 1.0, and a tagged constraint the solve does
+    # not have a row for is skipped rather than mis-indexed.
+    m = tagged_model(o=100.0, c1=10.0)
+    obj, g = problem_scaling(m, ["c1", "c2"], {})
+    assert obj == 100.0
+    assert g == [10.0, 1.0]
+    obj, g = problem_scaling(m, ["c2"], {})
+    assert g == [1.0]
+
+
+def test_problem_scaling_follows_the_surgery_alias():
+    # The declared-parameter surgery renames replaced rows on the clone
+    # that is actually solved; the Suffix is keyed by the original.
+    m = tagged_model(c1=10.0)
+    obj, g = problem_scaling(m, ["_pounce.c1", "c2"], {"c1": "_pounce.c1"})
+    assert g == [10.0, 1.0]
+
+
+# ── refusals and warnings ────────────────────────────────────────────────────
+
+def test_variable_factor_raises():
+    with pytest.raises(ValueError, match="variable"):
+        check_no_variable_scaling(tagged_model(o=100.0, x1=3.0))
+
+
+def test_variable_factor_error_names_the_variables_and_the_issue():
+    with pytest.raises(ValueError) as exc:
+        check_no_variable_scaling(tagged_model(x1=3.0, x2=0.5))
+    msg = str(exc.value)
+    assert "x[1]" in msg and "x[2]" in msg
+    assert "483" in msg
+
+
+def test_unit_variable_factor_is_not_a_request():
+    # 1.0 asks for nothing; failing a solve over it would be noise.
+    check_no_variable_scaling(tagged_model(o=100.0, x1=1.0))
+
+
+def test_solve_refuses_a_variable_factor():
+    s = pyo.SolverFactory("pounce")
+    s.options.update(USER_SCALING)
+    with pytest.raises(ValueError, match="483"):
+        s.solve(tagged_model(o=100.0, c1=10.0, x1=3.0))
+
+
+def test_solve_warns_when_user_scaling_has_nothing_to_apply():
+    s = pyo.SolverFactory("pounce")
+    s.options.update(USER_SCALING)
+    with pytest.warns(UserWarning, match="no export-enabled"):
+        s.solve(tagged_model())
+
+
+def test_a_variable_factor_is_inert_without_the_option():
+    # A `scaling_factor` Suffix also drives Pyomo's own
+    # `core.scale_model`; carrying one must not fail a default solve.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        pyo.SolverFactory("pounce").solve(tagged_model(o=100.0, x1=3.0))
+
+
+# ── the scaling reaches the solver, and the answer does not move ─────────────
+
+def test_asl_path_solves_with_user_scaling():
+    """The subprocess path: the writer emits the Suffix as `.nl` suffix
+    segments and the solver reads them. Scaling changes conditioning,
+    never the optimum, so the tagged solve must land where the untagged
+    one does."""
+    s = pyo.SolverFactory("pounce")
+    s.options.update(USER_SCALING)
+    scaled = tagged_model(o=100.0, c1=10.0)
+    s.solve(scaled)
+    plain = tagged_model()
+    pyo.SolverFactory("pounce").solve(plain)
+    assert pyo.value(scaled.x[1]) == pytest.approx(pyo.value(plain.x[1]),
+                                                   abs=1e-6)
+    assert pyo.value(scaled.x[2]) == pytest.approx(pyo.value(plain.x[2]),
+                                                   abs=1e-6)
+    assert pyo.value(scaled.o) == pytest.approx(pyo.value(plain.o), abs=1e-8)
+
+
+# ── the in-process sensitivity path ─────────────────────────────────────────
+
+N = 25
+SIGMA = 0.3
+
+
+def linear_data():
+    rng = np.random.default_rng(42)
+    x = np.linspace(0.0, 4.0, N)
+    y = 1.5 - 0.7 * x + SIGMA * rng.standard_normal(N)
+    return x, y, np.column_stack([np.ones(N), x])
+
+
+def linear_model(x, y, scale=None, dead=False, param=False):
+    """`min sum r_i^2` with `r_i == y_i - a - b x_i`: the estimation
+    fixture the covariance/information tests use, optionally tagged
+    with a `scaling_factor` Suffix, optionally carrying an inert fixed
+    variable, optionally with a declared sensitivity parameter."""
+    m = pyo.ConcreteModel()
+    m.I = pyo.RangeSet(0, len(x) - 1)
+    m.a = pyo.Var(initialize=0.0)
+    m.b = pyo.Var(initialize=0.0)
+    m.r = pyo.Var(m.I, initialize=0.0)
+    if param:
+        m.shift = pyo.Param(initialize=0.0, mutable=True)
+        m.res = pyo.Constraint(
+            m.I, rule=lambda mm, i: mm.r[i] == float(y[i]) + mm.shift - mm.a
+            - mm.b * float(x[i]))
+    else:
+        m.res = pyo.Constraint(
+            m.I, rule=lambda mm, i: mm.r[i] == float(y[i]) - mm.a
+            - mm.b * float(x[i]))
+    if dead:
+        # A fixed variable sorted before the fitted block: the
+        # composition that shifts full-x rows against factor rows
+        # (gh #450). Scaling must not disturb it.
+        m.dead = pyo.Var(bounds=(2.0, 2.0), initialize=2.0)
+        m.deadcon = pyo.Constraint(expr=m.dead * m.dead <= 1e6)
+    m.obj = pyo.Objective(expr=sum(m.r[i] ** 2 for i in m.I))
+    declare_fitted(m.a)
+    declare_fitted(m.b)
+    declare_residual(m.r)
+    if param:
+        declare_sens_param(m.shift)
+    if scale is not None:
+        obj_s, con_s = scale
+        m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+        m.scaling_factor[m.obj] = obj_s
+        for i in m.I:
+            m.scaling_factor[m.res[i]] = con_s
+    return m
+
+
+def solve_pair(**kwargs):
+    """The same estimation model solved twice — user scaling engaged,
+    and no scaling at all — so every accessor can be compared against
+    unscaled ground truth."""
+    x, y, X = linear_data()
+    scaled = linear_model(x, y, scale=(1e-3, 50.0), **kwargs)
+    pyo.SolverFactory("pounce").solve(scaled, options=dict(USER_SCALING))
+    plain = linear_model(x, y, **kwargs)
+    pyo.SolverFactory("pounce").solve(plain)
+    return scaled, plain, X
+
+
+def session_scaling(m):
+    return m.__dict__["_pounce_sens"].session.solver.nlp_scaling
+
+
+def test_in_process_path_refuses_a_variable_factor():
+    x, y, _ = linear_data()
+    m = linear_model(x, y, scale=(1e-3, 50.0))
+    m.scaling_factor[m.a] = 4.0
+    with pytest.raises(ValueError, match="483"):
+        pyo.SolverFactory("pounce").solve(m, options=dict(USER_SCALING))
+
+
+def test_in_process_variable_factor_is_inert_without_the_option():
+    # The in-process path reads the Suffix itself rather than leaving it
+    # to the writer, so it has its own chance to raise where it should
+    # not: a `core.scale_model`-style Suffix must not fail a plain solve.
+    x, y, _ = linear_data()
+    m = linear_model(x, y, scale=(1e-3, 50.0))
+    m.scaling_factor[m.a] = 4.0
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        pyo.SolverFactory("pounce").solve(m)
+
+
+def test_in_process_path_installs_the_user_scaling():
+    """Guard for the wiring itself: without it the engine reports the
+    identity scaling and every comparison below passes vacuously."""
+    scaled, plain, _ = solve_pair()
+    assert float(session_scaling(scaled)["obj"]) == pytest.approx(1e-3)
+    assert float(session_scaling(plain)["obj"]) == pytest.approx(1.0)
+
+
+def test_estimates_are_unmoved_by_user_scaling():
+    scaled, plain, X = solve_pair()
+    for name in ("a", "b"):
+        assert pyo.value(getattr(scaled, name)) == pytest.approx(
+            pyo.value(getattr(plain, name)), rel=1e-7)
+
+
+def test_covariance_matches_unscaled_ground_truth():
+    scaled, plain, X = solve_pair()
+    np.testing.assert_allclose(
+        covariance(scaled, sigma_sq=SIGMA**2).matrix,
+        covariance(plain, sigma_sq=SIGMA**2).matrix, rtol=1e-7)
+    # and against the closed form, so both runs being wrong the same
+    # way cannot pass
+    np.testing.assert_allclose(
+        covariance(scaled, sigma_sq=SIGMA**2).matrix,
+        SIGMA**2 * np.linalg.inv(X.T @ X), rtol=1e-6)
+
+
+def test_information_matches_unscaled_ground_truth():
+    scaled, plain, X = solve_pair()
+    np.testing.assert_allclose(information(scaled).matrix,
+                               information(plain).matrix, rtol=1e-7)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               2.0 * X.T @ X, rtol=1e-6)
+    np.testing.assert_allclose(
+        information(scaled, hessian="gauss-newton").matrix,
+        2.0 * X.T @ X, rtol=1e-6)
+
+
+def test_wrt_blocks_match_unscaled_ground_truth():
+    scaled, plain, X = solve_pair()
+    C = SIGMA**2 * np.linalg.inv(X.T @ X)
+    cov_a = covariance(scaled, sigma_sq=SIGMA**2, wrt=[scaled.a])
+    assert cov_a[scaled.a] == pytest.approx(C[0, 0], rel=1e-6)
+    # the rank-deficient residual block: the prediction band
+    H = X @ np.linalg.solve(X.T @ X, X.T)
+    np.testing.assert_allclose(
+        covariance(scaled, sigma_sq=SIGMA**2, wrt=scaled.r).matrix,
+        SIGMA**2 * H, rtol=1e-6, atol=1e-12)
+    np.testing.assert_allclose(
+        information(scaled, wrt=[scaled.a, scaled.b]).matrix,
+        information(plain, wrt=[plain.a, plain.b]).matrix, rtol=1e-7)
+
+
+def test_classifier_statuses_match_unscaled():
+    scaled, plain, _ = solve_pair()
+    assert (covariance(scaled, sigma_sq=SIGMA**2).conditioned_on
+            == covariance(plain, sigma_sq=SIGMA**2).conditioned_on)
+
+
+def test_gradient_and_estimate_match_unscaled():
+    scaled, plain, _ = solve_pair(param=True)
+    for target in ("a", "b"):
+        g_scaled = gradient(getattr(scaled, target), wrt=scaled.shift)
+        g_plain = gradient(getattr(plain, target), wrt=plain.shift)
+        assert g_scaled == pytest.approx(g_plain, abs=1e-6)
+    est_scaled = estimate(scaled, [(scaled.shift, 0.25)])
+    est_plain = estimate(plain, [(plain.shift, 0.25)])
+    assert est_scaled[scaled.a] == pytest.approx(est_plain[plain.a], abs=1e-6)
+    assert est_scaled[scaled.b] == pytest.approx(est_plain[plain.b], abs=1e-6)
+
+
+def test_fixed_variable_composition_survives_user_scaling():
+    scaled, plain, X = solve_pair(dead=True)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               2.0 * X.T @ X, rtol=1e-6)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               information(plain).matrix, rtol=1e-7)
+
+
+def test_retain_only_block_matches_unscaled():
+    x, y, X = linear_data()
+
+    def build(scaled):
+        m = pyo.ConcreteModel()
+        m.I = pyo.RangeSet(0, len(x) - 1)
+        m.a = pyo.Var(initialize=0.0)
+        m.b = pyo.Var(initialize=0.0)
+        m.r = pyo.Var(m.I, initialize=0.0)
+        m.res = pyo.Constraint(
+            m.I, rule=lambda mm, i: mm.r[i] == float(y[i]) - mm.a
+            - mm.b * float(x[i]))
+        m.obj = pyo.Objective(expr=sum(m.r[i] ** 2 for i in m.I))
+        retain_kkt(m)          # no declarations: the retain-only path
+        if scaled:
+            m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+            m.scaling_factor[m.obj] = 1e-3
+            for i in m.I:
+                m.scaling_factor[m.res[i]] = 50.0
+            pyo.SolverFactory("pounce").solve(m, options=dict(USER_SCALING))
+        else:
+            pyo.SolverFactory("pounce").solve(m)
+        return m
+
+    scaled, plain = build(True), build(False)
+    try:
+        np.testing.assert_allclose(
+            information(scaled, wrt=[scaled.a, scaled.b]).matrix,
+            information(plain, wrt=[plain.a, plain.b]).matrix, rtol=1e-7)
+        np.testing.assert_allclose(
+            information(scaled, wrt=[scaled.a, scaled.b]).matrix,
+            2.0 * X.T @ X, rtol=1e-6)
+    finally:
+        release_kkt(scaled)
+        release_kkt(plain)

--- a/python/README.md
+++ b/python/README.md
@@ -57,17 +57,22 @@ print(info['status_msg'], info['obj_val'], x)
 
 ## Problem scaling
 
-For problems whose natural variable and constraint magnitudes differ
+For problems whose natural objective and constraint magnitudes differ
 by orders of magnitude, attach explicit scaling factors:
 
 ```python
 prob.set_problem_scaling(
-    obj_scaling=1.0,
-    x_scaling=np.array([1e-3, 1.0, 1.0, 1e3]),  # optional
+    obj_scaling=1e-3,
     g_scaling=np.array([1.0, 1e-2]),            # optional
 )
 prob.add_option('nlp_scaling_method', 'user-scaling')
 ```
+
+`x_scaling=` is accepted only as all-ones: POUNCE models objective and
+constraint scaling, not per-variable rescaling, and a non-unit
+`x_scaling` raises rather than being discarded ([issue
+#483](https://github.com/jkitchin/pounce/issues/483)). Rescale those
+variables in the model itself.
 
 See [`docs/src/scaling.md`](../docs/src/scaling.md) for the
 gradient-based vs. user-scaling tradeoff.

--- a/python/notebooks/07_scaling.ipynb
+++ b/python/notebooks/07_scaling.ipynb
@@ -256,7 +256,12 @@
     "g_scaling=None)`. This mirrors the C-API `SetIpoptProblemScaling`.\n",
     "\n",
     "We pair it with `nlp_scaling_method = \"user-scaling\"` so the IPM\n",
-    "consults the values we just installed instead of computing its own."
+    "consults the values we just installed instead of computing its own.\n",
+    "\n",
+    "`x_scaling` is accepted only as all-ones: pounce models objective and\n",
+    "constraint scaling, not per-variable rescaling, so a non-unit\n",
+    "`x_scaling` raises rather than being quietly discarded ([issue\n",
+    "#483](https://github.com/jkitchin/pounce/issues/483))."
    ]
   },
   {


### PR DESCRIPTION
## Problem

A Pyomo user tags the standard `scaling_factor` Suffix and sets
`nlp_scaling_method=user-scaling` — the workflow that works with Ipopt through
ASL — and gets **no scaling at all, and no message saying so**. The option is
accepted and means "none".

That is issue #483. Auditing it turned up the same shape in five more places,
two of which return a **wrong answer** rather than merely ignoring a request:

| | before | after | oracle / ground truth |
|---|---|---|---|
| `scaling_factor` suffix + `user-scaling` | no scaling applied, silent | objective ×100, constraint ×10 applied; solution unchanged in model units | Ipopt-via-ASL applies it |
| `obj_scaling_factor=-1` on an LP/QP (`min (x−3)²`, `x∈[0,1]`) | `x = 1` — the **minimizer** of the objective the user asked to maximize, `Optimal Solution Found`, exit 0 | `auto` reroutes and returns `x = 0`; a forced convex solver exits 2 | maximizer is `x = 0` (closed form, and pounce's own NLP path) |
| `scaling_factor[obj] = -1` + forced convex | same wrong answer, via a second channel | exits 2 | as above |
| `honor_original_bounds=yes` (`min (x−3)²+(y+2)²`, `x∈[0,1]`, `y∈[−1,1]`) | `x = 1.00000000937`, `y = −1.00000000875` — **outside the declared bounds** | `x = 1`, `y = −1` | upstream projects; default (`no`) is unchanged |
| `linear_solver=ma97` | runs FERAL, reports success | exits 2 naming the backend | a backend comparison was comparing FERAL with itself |
| `derivative_test=first-order` | no test, no output | full report on stderr | upstream runs a checker |
| `Problem.set_problem_scaling(x_scaling=…)` | factors discarded | raises | — |

## Cause

Two independent mechanisms.

**Nothing implemented the channel.** `NlTnlp` never implemented
`get_scaling_parameters`, so the `.nl`'s `scaling_factor` suffix segments were
parsed and then dropped; pyomo-pounce had no scaling code of its own. One layer
down, `OrigIpoptNlp::scale_user_supplied` ended in

```rust
// `use_x_scaling`: silently ignored (not modeled — see doc).
let _ = use_x_scaling;
```

so a caller who supplied per-variable factors got a converged answer to a
*differently-conditioned* problem, with the objective and constraint factors
applied and the variable ones gone.

**The option registry is a faithful port of Ipopt's**, which is a real
compatibility benefit — an `ipopt.opt` written for Ipopt parses unchanged — and
which also turned ~200 registered knobs into silent no-ops, because registering
an option says nothing about implementing it. #191 fixed the half where the
feature runs and only the read site was missing, and explicitly scoped out
"feature genuinely unimplemented — expected no-ops". #483's standard is that
accepted-and-silent is itself the defect.

Separately, the **routing layer** drops requests the specialized convex solvers
cannot serve. `pounce-convex` equilibrates internally and never reads the TNLP
scaling callback, so an LP/QP — the default route for that problem class — took
`obj_scaling_factor` with it and minimized.

## Fix

Objective and constraint scaling now flow end to end: `NlTnlp` reads the
suffixes (0 entries read as "untagged", per AMPL's suffix default), and
pyomo-pounce's new `scaling.py` translates the Suffix for the in-process
sensitivity path, which builds no `.nl` for the solver.

Requests that cannot be honoured are refused rather than dropped — per-variable
factors, unimplemented `linear_solver` backends, and 34 options naming absent
features. Two carve-outs, both of which the change is unshippable without:

- **An explicitly-set default is allowed.** A generated `ipopt.opt` spells out
  defaults and `dependency_detector=none` asks for nothing. Refusing on
  "explicitly set" alone would break the compatibility the registry exists for.
- **Caching hints warn instead of failing.** `hessian_constant` and its three
  siblings configure a feature POUNCE *has*; it just does not exploit the hint,
  so ignoring them costs evaluations and never correctness. Failing the solve
  would be the worse trade. Flipping them to errors is one line in the table.

**Rejected: refusing group (b).** ~35 further options configure features that
*do* run and whose read site is merely missing. Erroring on those would fail
solves whose answers are correct today (`max_soc=0` yields `max_soc=4` and a
good answer), and would be reverted the moment the knob is wired. They are
wired instead — 6 so far — and left solving in the meantime.

**Rejected: removing the unimplemented names from the registry.** That would
make an Ipopt `ipopt.opt` fail to *parse*, replacing a precise complaint with
"invalid value". They stay registered and are refused with a message naming the
feature and the alternative.

`linear_solver` also defaults to `feral` now rather than upstream's `ma57`. A
default has to name a solver the binary contains: under the old one a pure-Rust
build advertised MA57 while running FERAL, and an HSL build used MA57 *without
being asked*. **That is the one behavioural change for existing HSL users** —
`--features ma57` makes MA57 available, `linear_solver=ma57` selects it. It also
removed the explicit-vs-default special case the two banners and the refusal
guard each carried.

## Blast radius

Default runs are bit-identical: every new refusal is gated on an explicit
non-default value, and every wired option keeps its registered default. The full
workspace suite is green.

Who changes behaviour:

- **HSL builds** — `--features ma57` no longer selects MA57 implicitly.
- **Anyone setting one of the 34 refused options to a non-default value** — a
  previously-silent no-op becomes exit 2. Through Pyomo this surfaces as
  `ApplicationError` with the full explanation in the solver log.
- **Anyone relying on `user-scaling` being inert** — it now scales. Solutions
  and duals are unchanged in model units; conditioning and iteration counts move.
- **Anyone passing non-unit `x_scaling` to `Problem.set_problem_scaling`** —
  now raises instead of silently discarding.

The sensitivity accessors needed no code — `natural_units_conj` already
translates `df`/`dc`/`dd` for any scaling method — but that is now proven rather
than assumed.

## Tests

Fail-first is established two ways, and I want to be precise about which:

- **Run against reverted code.** `issue_483_user_scaling.rs` — stubbing
  `NlTnlp::get_scaling_parameters` back to `false` fails
  `scaling_factor_suffix_is_applied` and
  `variable_scaling_factor_is_refused_with_a_message`, for the stated reason.
- **Pre-fix behaviour observed directly, and the test asserts against exactly
  that observation** — the wrong-answer cases (`x = 1` where the maximizer is
  `x = 0`), `x = 1.00000000937` outside its bound, `linear_solver=ma97` exiting
  0 under FERAL, `derivative_test` printing nothing. Each number in the table
  above was measured on the parent commit.

Two tests exist specifically because they would have caught mistakes I made in
this branch:

- `options_on_implemented_features_are_not_refused` pins the (a)/(b) boundary.
  `fast_step_computation` was in the refusal table for one commit, hand-added
  against the table's own membership rule, and would have failed a solve POUNCE
  can serve.
- `the_negative_suffix_is_inert_without_user_scaling` is the control that makes
  the objective-sense tests about the *sign* rather than the suffix's presence.

The sensitivity axis checks `covariance`, `information`, `gradient`, `estimate`,
`wrt=` blocks, the retain-only path, the classifier's statuses and the
fixed-variable composition against unscaled ground truth with scaling engaged —
proving the no-code-needed claim rather than asserting it.

**Deliberately not pinned:** the `--features ma57` build path (no HSL in CI, so
the MA57-selected branch is unexercised); and `limited_memory_initialization`,
whose value space is wider than POUNCE's `InitialApprox` enum — wiring the two
values that map would leave the other three silently falling back, a *new*
silent no-op, so it is left alone until per-value refusal exists.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`options.md`, `scaling.md`,
      `pyomo.md`, `lp-qp-routing.md`, `installation.md`); no new pages, so
      `SUMMARY.md` is unchanged
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

Fixes #483

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnXXq6Fpyb7KepwiXPjYra)_