### PR TITLE
presolve: eliminate variables determined by linear equality rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ changes.
 
 ## [Unreleased]
 
+### Added — presolve eliminates variables determined by linear equality rows (#487)
+
+- `presolve_linear_eq_reduction` was a registered option with no
+  implementation behind it. It now runs a **variable-elimination phase**
+  (Phase 6) in `pounce-presolve`, the first pass in the layer that removes
+  *columns* rather than only rows. Off by default; requires `presolve=yes`.
+- The measurement in #487: a solvent-extraction NMPC flowsheet declares
+  23,681 variables and 23,138 equality rows, and Pyomo's NL-v2 writer — with
+  the linear presolve its `ipopt_v2` interface turns on by default — hands
+  the solver 10,284 columns and 9,741 rows. POUNCE reached the solver at
+  full size on every path. It now recognises the same three shapes, iterated
+  to a fixed point so chains propagate: variables fixed by equal bounds,
+  singleton rows `a·x = b`, and two-variable rows `a₁·x + a₂·y = b`.
+- The two-variable shape is the one that mattered and the one nothing in
+  POUNCE could reach. The auxiliary-equality pipeline (#53) eliminates
+  *determined* square blocks; a row linking two otherwise-free interior
+  variables — an arc equality, a `Reference` alias, a unit-conversion link —
+  determines neither of them and so survived. Phase 6 substitutes one for
+  the other with no anchoring requirement.
+- Implemented in `pounce-presolve` (option (b) of #487's two candidate
+  homes) rather than by switching the Pyomo path onto NL-v2's presolve, so
+  the CLI, GAMS, the C interface, and Pyomo all get the same reduction from
+  one implementation — and so the sensitivity session is not asked to
+  thread a third variable space through index maps whose correctness rests
+  on there being exactly two (the #450 hazard).
+- Duals for the consumed rows are **recovered, not zeroed**. Taken as a
+  whole the recovery is a square sparse solve; taken one elimination at a
+  time in reverse order it is triangular, because every other row of the
+  problem-as-it-stood-then survives that step. So it is a linear sweep over
+  the elimination forest, not a factorization. `.sol` and JSON solution
+  blocks come back at the original model's length, in the original order,
+  and can still be read positionally by AMPL and Pyomo.
+- Two documented caveats, both in `docs/src/options.md`: an eliminated
+  variable's *bound* multiplier is reported on the survivor that inherited
+  the bound (the same attribution trade the Phase-2 row drop makes), and a
+  contradictory equality system makes the pass stand down entirely rather
+  than be the first and only voice calling a model infeasible.
+
 ### Fixed — the C working-set API validated nothing structural, and reported the wrong row order (#484 follow-up, round 4)
 
 - `IpoptSetWarmStartWorkingSet` range-checked its status codes and stopped

--- a/adversary/fuzz/Cargo.lock
+++ b/adversary/fuzz/Cargo.lock
@@ -10,6 +10,8 @@ dependencies = [
  "pounce-common",
  "pounce-feral",
  "pounce-linalg",
+ "pounce-nlp",
+ "pounce-presolve",
  "pounce-qp",
 ]
 

--- a/adversary/fuzz/Cargo.toml
+++ b/adversary/fuzz/Cargo.toml
@@ -15,6 +15,8 @@ pounce-feral = { path = "../../crates/pounce-feral" }
 pounce-common = { path = "../../crates/pounce-common" }
 pounce-linalg = { path = "../../crates/pounce-linalg" }
 pounce-cinterface = { path = "../../crates/pounce-cinterface" }
+pounce-presolve = { path = "../../crates/pounce-presolve" }
+pounce-nlp = { path = "../../crates/pounce-nlp" }
 
 [profile.release]
 debug = true

--- a/adversary/fuzz/src/linelim_probe.rs
+++ b/adversary/fuzz/src/linelim_probe.rs
@@ -1,0 +1,920 @@
+//! Adversary probe for Phase 6 — linear-equality variable elimination
+//! (`presolve_linear_eq_reduction`, gh#487).
+//!
+//! Two independent attacks, because the pass has two independent ways to be
+//! silently wrong.
+//!
+//! # 1. The plan (`plan` mode)
+//!
+//! Every instance is generated **around a known feasible point** `x*`: the
+//! right-hand sides are computed from `x*`, and every box is drawn to contain
+//! it. That makes `x*` an oracle the pass has never seen, and it pins five
+//! properties that a wrong substitution cannot fake:
+//!
+//! * **Fidelity** — projecting `x*` onto the survivors and lifting must
+//!   reproduce `x*` exactly. `x*` satisfies every row the pass consumed, so
+//!   any substitution derived from those rows must reproduce it. A sign slip
+//!   or a mis-composed chain shows up here immediately.
+//! * **Feasible-point retention** — `x*`'s survivor coordinates must lie
+//!   inside the *reduced* box. A bound transfer that is too aggressive would
+//!   quietly exclude a known-feasible point, which is how a presolve turns a
+//!   solvable model into a wrong "infeasible".
+//! * **Box soundness** — for a *random* point of the reduced box, every
+//!   lifted coordinate must sit inside its original declared box. This is the
+//!   converse direction, and it is the one the `α < 0` bound flip breaks.
+//! * **Row fidelity at an arbitrary point** — every consumed row must hold at
+//!   the lift of a random reduced point, not just at `x*`.
+//! * **Structural integrity** — rows and columns account exactly, and every
+//!   `Affine` representative is a survivor (the wrapper's `lift_x` reads that
+//!   slot directly).
+//!
+//! A consistent system inside a box containing `x*` must also never be called
+//! infeasible.
+//!
+//! # 2. The derivative transforms (`deriv` mode)
+//!
+//! The wrapper turns `∇f`, `J`, and `∇²L` into precomputed scaled gathers.
+//! The oracle is a **central finite difference of the wrapper's own reduced
+//! `eval_f` / `eval_g`** — it knows nothing about the plan, and asks only the
+//! question a wrong gather actually fails: is the published derivative the
+//! derivative of the published function? Both the model and the substitution
+//! are quadratic/affine, so the third derivative vanishes and the differences
+//! are exact to roundoff.
+//!
+//! The structure matters as much as the values: an entry the gather never
+//! emits reads as a structural zero forever. Densifying the published triplets
+//! and comparing the *whole* matrix — not just the emitted positions — is what
+//! catches that.
+//!
+//! An earlier version of this probe rebuilt the plan and compared against a
+//! dense `AᵀHA`. It reported 483 failures out of 2000, every one of them the
+//! probe's own fault: the pivot tie-break depends on the order the columns
+//! arrive in, so the rebuilt plan was a different — equally valid — reduction
+//! than the one the wrapper had chosen.
+
+use pounce_common::types::{Index, Number};
+use pounce_nlp::alg_types::SolverReturn;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_presolve::{
+    LinearEqElimTnlp, PlanConfig, PlanInput, PresolveOptions, VarRecovery, build_plan,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use crate::rng::Rng;
+
+const SENTINEL_LO: Number = -1e19;
+const SENTINEL_HI: Number = 1e19;
+
+/// A randomly generated linear-equality system with a known feasible point.
+pub struct Instance {
+    pub seed: u64,
+    pub n: usize,
+    pub m: usize,
+    pub rows: Vec<Vec<(usize, Number)>>,
+    pub row_const: Vec<Number>,
+    pub g_l: Vec<Number>,
+    pub g_u: Vec<Number>,
+    pub eligible: Vec<bool>,
+    pub x_l: Vec<Number>,
+    pub x_u: Vec<Number>,
+    /// The point every row and every box was built around.
+    pub x_star: Vec<Number>,
+}
+
+/// Generate a consistent instance around a known feasible point.
+pub fn generate(r: &mut Rng, seed: u64) -> Instance {
+    let n = r.int(3, 10);
+    let m = r.int(1, 9);
+    let x_star: Vec<Number> = (0..n).map(|_| r.range(-5.0, 5.0)).collect();
+
+    let mut rows: Vec<Vec<(usize, Number)>> = Vec::with_capacity(m);
+    let mut row_const = Vec::with_capacity(m);
+    let mut g_l = Vec::with_capacity(m);
+    let mut g_u = Vec::with_capacity(m);
+    let mut eligible = Vec::with_capacity(m);
+
+    for i in 0..m {
+        // Bias hard toward the two-term shape — it is the one the pass exists
+        // for — but keep singletons and three-term rows in the mix so the
+        // "leave it alone" path is exercised too.
+        let arity = if r.chance(0.15) {
+            1
+        } else if r.chance(0.75) {
+            2
+        } else {
+            3
+        }
+        .min(n);
+
+        // Duplicate an earlier row now and then, so substitutions render it
+        // `0 = 0` and the redundant-row path fires.
+        let entries = if i > 0 && r.chance(0.15) {
+            let j = r.int(0, i - 1);
+            rows[j].clone()
+        } else {
+            let mut cols: Vec<usize> = (0..n).collect();
+            for k in (1..n).rev() {
+                let j = r.int(0, k);
+                cols.swap(k, j);
+            }
+            cols.truncate(arity);
+            cols.iter()
+                .map(|&c| {
+                    // Keep coefficients away from zero: a coefficient the pass
+                    // treats as structurally absent is a different test, and
+                    // mixing the two would blur both.
+                    let mag = r.range(0.3, 3.0);
+                    (c, if r.chance(0.5) { mag } else { -mag })
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let c = r.range(-2.0, 2.0);
+        let body: Number = entries.iter().map(|&(j, a)| a * x_star[j]).sum::<Number>() + c;
+        rows.push(entries);
+        row_const.push(c);
+
+        // Mostly equalities (consumable); sometimes an inequality or a row
+        // tagged nonlinear, both of which the pass must leave alone.
+        if r.chance(0.12) {
+            g_l.push(body - r.range(0.5, 3.0));
+            g_u.push(body + r.range(0.5, 3.0));
+            eligible.push(true);
+        } else {
+            g_l.push(body);
+            g_u.push(body);
+            eligible.push(!r.chance(0.12));
+        }
+    }
+
+    let mut x_l = vec![SENTINEL_LO; n];
+    let mut x_u = vec![SENTINEL_HI; n];
+    for j in 0..n {
+        if r.chance(0.08) {
+            // Fixed by its own box — shape 1.
+            x_l[j] = x_star[j];
+            x_u[j] = x_star[j];
+        } else {
+            if r.chance(0.7) {
+                x_l[j] = x_star[j] - r.range(0.0, 4.0);
+            }
+            if r.chance(0.7) {
+                x_u[j] = x_star[j] + r.range(0.0, 4.0);
+            }
+        }
+    }
+
+    Instance {
+        seed,
+        n,
+        m,
+        rows,
+        row_const,
+        g_l,
+        g_u,
+        eligible,
+        x_l,
+        x_u,
+        x_star,
+    }
+}
+
+impl Instance {
+    fn plan_input(&self) -> PlanInput<'_> {
+        PlanInput {
+            n_vars: self.n,
+            n_rows: self.m,
+            rows: &self.rows,
+            row_const: &self.row_const,
+            g_l: &self.g_l,
+            g_u: &self.g_u,
+            eligible: &self.eligible,
+            x_l: &self.x_l,
+            x_u: &self.x_u,
+        }
+    }
+
+    fn row_body(&self, i: usize, x: &[Number]) -> Number {
+        self.rows[i].iter().map(|&(j, a)| a * x[j]).sum::<Number>() + self.row_const[i]
+    }
+
+    fn scale(&self) -> Number {
+        let a = self
+            .rows
+            .iter()
+            .flat_map(|r| r.iter().map(|&(_, v)| v.abs()))
+            .fold(1.0_f64, f64::max);
+        let x = self.x_star.iter().fold(1.0_f64, |m, v| m.max(v.abs()));
+        a * x
+    }
+}
+
+/// What a single plan-mode instance concluded.
+pub enum PlanVerdict {
+    Ok { elim_vars: usize, elim_rows: usize },
+    Failed(String),
+}
+
+pub fn check_plan(inst: &Instance) -> PlanVerdict {
+    let plan = build_plan(&inst.plan_input(), &PlanConfig::default());
+    let tol = 1e-7 * inst.scale();
+
+    // A consistent system, inside a box that demonstrably contains a feasible
+    // point, must never be called contradictory.
+    if plan.report.infeasible {
+        return PlanVerdict::Failed(format!(
+            "declared the equality system contradictory, but x* = {:?} satisfies every row \
+             inside its own box",
+            inst.x_star
+        ));
+    }
+
+    // --- structural integrity -------------------------------------------
+    let n_kept_rows = plan.rows_kept.len();
+    let accounted = n_kept_rows + plan.report.n_rows_eliminated + plan.report.n_redundant_rows;
+    if accounted != inst.m {
+        return PlanVerdict::Failed(format!(
+            "row accounting: {n_kept_rows} kept + {} consumed + {} redundant != {} rows",
+            plan.report.n_rows_eliminated, plan.report.n_redundant_rows, inst.m
+        ));
+    }
+    let n_elim_vars = plan
+        .recovery
+        .iter()
+        .filter(|r| !matches!(r, VarRecovery::Kept(_)))
+        .count();
+    if plan.vars_kept.len() + n_elim_vars != inst.n {
+        return PlanVerdict::Failed(format!(
+            "column accounting: {} kept + {n_elim_vars} eliminated != {} columns",
+            plan.vars_kept.len(),
+            inst.n
+        ));
+    }
+    for (i, rec) in plan.recovery.iter().enumerate() {
+        match *rec {
+            VarRecovery::Affine { rep, coeff, .. } => {
+                if !matches!(plan.recovery[rep], VarRecovery::Kept(_)) {
+                    return PlanVerdict::Failed(format!(
+                        "column {i} is affine on column {rep}, which is not a survivor"
+                    ));
+                }
+                if coeff == 0.0 || !coeff.is_finite() {
+                    return PlanVerdict::Failed(format!("column {i} has coefficient {coeff}"));
+                }
+            }
+            VarRecovery::Constant(c) if !c.is_finite() => {
+                return PlanVerdict::Failed(format!("column {i} pinned to {c}"));
+            }
+            _ => {}
+        }
+    }
+    if plan.vars_kept.len() != plan.x_l_red.len() || plan.vars_kept.len() != plan.x_u_red.len() {
+        return PlanVerdict::Failed("reduced box length disagrees with the survivor count".into());
+    }
+
+    // --- fidelity: lifting x*'s survivors must reproduce x* --------------
+    let mut y_star = vec![0.0; plan.vars_kept.len()];
+    plan.project_x(&inst.x_star, &mut y_star);
+    let mut x_hat = vec![0.0; inst.n];
+    plan.lift_x(&y_star, &mut x_hat);
+    for j in 0..inst.n {
+        if (x_hat[j] - inst.x_star[j]).abs() > tol {
+            return PlanVerdict::Failed(format!(
+                "lift(project(x*)) changed column {j}: {} -> {} (x* = {:?})",
+                inst.x_star[j], x_hat[j], inst.x_star
+            ));
+        }
+    }
+
+    // --- the reduced box must still admit the known feasible point -------
+    for (red, &full) in plan.vars_kept.iter().enumerate() {
+        let (lo, hi) = (plan.x_l_red[red], plan.x_u_red[red]);
+        let v = inst.x_star[full];
+        if lo > SENTINEL_LO && v < lo - tol {
+            return PlanVerdict::Failed(format!(
+                "reduced lower bound on column {full} is {lo}, above the feasible x*[{full}] = {v}"
+            ));
+        }
+        if hi < SENTINEL_HI && v > hi + tol {
+            return PlanVerdict::Failed(format!(
+                "reduced upper bound on column {full} is {hi}, below the feasible x*[{full}] = {v}"
+            ));
+        }
+    }
+
+    // --- soundness at an arbitrary point of the reduced box --------------
+    // Sample the corners and the interior; the corners are where a bound
+    // transfer with the wrong sign shows itself.
+    let mut probe = Rng::new(inst.seed ^ 0x5eed_1e11);
+    for trial in 0..8 {
+        let mut y = vec![0.0; plan.vars_kept.len()];
+        for (red, slot) in y.iter_mut().enumerate() {
+            let lo = if plan.x_l_red[red] > SENTINEL_LO {
+                plan.x_l_red[red]
+            } else {
+                -50.0
+            };
+            let hi = if plan.x_u_red[red] < SENTINEL_HI {
+                plan.x_u_red[red]
+            } else {
+                50.0
+            };
+            let (lo, hi) = if lo <= hi { (lo, hi) } else { (hi, lo) };
+            *slot = match trial % 4 {
+                0 => lo,
+                1 => hi,
+                _ => probe.range(lo, hi),
+            };
+        }
+        let mut x = vec![0.0; inst.n];
+        plan.lift_x(&y, &mut x);
+
+        // Every lifted coordinate inside its ORIGINAL declared box.
+        for j in 0..inst.n {
+            let slack = 1e-7 * x[j].abs().max(1.0);
+            if inst.x_l[j] > SENTINEL_LO && x[j] < inst.x_l[j] - slack {
+                return PlanVerdict::Failed(format!(
+                    "a point of the reduced box lifts to x[{j}] = {} below its declared lower \
+                     bound {} (trial {trial})",
+                    x[j], inst.x_l[j]
+                ));
+            }
+            if inst.x_u[j] < SENTINEL_HI && x[j] > inst.x_u[j] + slack {
+                return PlanVerdict::Failed(format!(
+                    "a point of the reduced box lifts to x[{j}] = {} above its declared upper \
+                     bound {} (trial {trial})",
+                    x[j], inst.x_u[j]
+                ));
+            }
+        }
+
+        // Every consumed row satisfied at the lifted point.
+        let live = x.iter().fold(1.0_f64, |m, v| m.max(v.abs()));
+        for i in 0..inst.m {
+            if plan.row_kept[i] {
+                continue;
+            }
+            let body = inst.row_body(i, &x);
+            let resid = (body - inst.g_l[i]).abs();
+            if resid > 1e-7 * live * inst.scale().max(1.0) {
+                return PlanVerdict::Failed(format!(
+                    "consumed row {i} violated by {resid:.3e} at a point of the reduced box \
+                     (trial {trial})"
+                ));
+            }
+        }
+    }
+
+    PlanVerdict::Ok {
+        elim_vars: n_elim_vars,
+        elim_rows: inst.m - n_kept_rows,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Derivative-transform probe
+// ---------------------------------------------------------------------------
+
+/// `min ½ xᵀQx + cᵀx` subject to the instance's linear rows plus one dense
+/// quadratic row, published with a dense Jacobian and a dense lower-triangular
+/// Hessian so the wrapper's mapping has nowhere to hide.
+struct QuadTnlp {
+    n: usize,
+    m: usize,
+    q: Vec<Number>,
+    c: Vec<Number>,
+    /// Symmetric matrix of each nonlinear row (all-zero for the linear ones).
+    r_quad: Vec<Vec<Number>>,
+    lin: Vec<Vec<(usize, Number)>>,
+    lin_const: Vec<Number>,
+    is_lin: Vec<bool>,
+    g_l: Vec<Number>,
+    g_u: Vec<Number>,
+    x_l: Vec<Number>,
+    x_u: Vec<Number>,
+    x0: Vec<Number>,
+    /// Whatever the wrapper handed down at the last `finalize_solution`.
+    captured_x: Option<Vec<Number>>,
+}
+
+impl QuadTnlp {
+    fn grad_f(&self, x: &[Number], out: &mut [Number]) {
+        for i in 0..self.n {
+            let mut s = self.c[i];
+            for j in 0..self.n {
+                s += self.q[i * self.n + j] * x[j];
+            }
+            out[i] = s;
+        }
+    }
+    fn jac_dense(&self, x: &[Number]) -> Vec<Number> {
+        let mut j = vec![0.0; self.m * self.n];
+        for r in 0..self.m {
+            if self.is_lin[r] {
+                for &(col, a) in &self.lin[r] {
+                    j[r * self.n + col] += a;
+                }
+            } else {
+                for i in 0..self.n {
+                    let mut s = 0.0;
+                    for k in 0..self.n {
+                        s += self.r_quad[r][i * self.n + k] * x[k];
+                    }
+                    j[r * self.n + i] = s;
+                }
+            }
+        }
+        j
+    }
+    /// Dense symmetric `∇²L = obj·Q + Σ λ_r R_r`.
+    fn hess_dense(&self, obj: Number, lambda: &[Number]) -> Vec<Number> {
+        let mut h = vec![0.0; self.n * self.n];
+        for k in 0..self.n * self.n {
+            h[k] = obj * self.q[k];
+        }
+        for r in 0..self.m {
+            if self.is_lin[r] {
+                continue;
+            }
+            for k in 0..self.n * self.n {
+                h[k] += lambda[r] * self.r_quad[r][k];
+            }
+        }
+        h
+    }
+}
+
+impl TNLP for QuadTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: self.n as Index,
+            m: self.m as Index,
+            nnz_jac_g: (self.m * self.n) as Index,
+            nnz_h_lag: (self.n * (self.n + 1) / 2) as Index,
+            index_style: IndexStyle::C,
+        })
+    }
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&self.x_l);
+        b.x_u.copy_from_slice(&self.x_u);
+        b.g_l.copy_from_slice(&self.g_l);
+        b.g_u.copy_from_slice(&self.g_u);
+        true
+    }
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&self.x0);
+        true
+    }
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        for (r, t) in types.iter_mut().enumerate() {
+            *t = if self.is_lin[r] {
+                Linearity::Linear
+            } else {
+                Linearity::NonLinear
+            };
+        }
+        true
+    }
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let mut s = 0.0;
+        for i in 0..self.n {
+            s += self.c[i] * x[i];
+            for j in 0..self.n {
+                s += 0.5 * self.q[i * self.n + j] * x[i] * x[j];
+            }
+        }
+        Some(s)
+    }
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        self.grad_f(x, g);
+        true
+    }
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for r in 0..self.m {
+            g[r] = if self.is_lin[r] {
+                self.lin[r].iter().map(|&(j, a)| a * x[j]).sum::<Number>() + self.lin_const[r]
+            } else {
+                let mut s = 0.0;
+                for i in 0..self.n {
+                    for k in 0..self.n {
+                        s += 0.5 * self.r_quad[r][i * self.n + k] * x[i] * x[k];
+                    }
+                }
+                s
+            };
+        }
+        true
+    }
+    fn eval_jac_g(&mut self, x: Option<&[Number]>, _new_x: bool, mode: SparsityRequest<'_>) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let mut k = 0;
+                for r in 0..self.m {
+                    for c in 0..self.n {
+                        irow[k] = r as Index;
+                        jcol[k] = c as Index;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                let Some(x) = x else { return false };
+                values.copy_from_slice(&self.jac_dense(x));
+            }
+        }
+        true
+    }
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let mut k = 0;
+                for r in 0..self.n {
+                    for c in 0..=r {
+                        irow[k] = r as Index;
+                        jcol[k] = c as Index;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                let zero = vec![0.0; self.m];
+                let lam = lambda.unwrap_or(&zero);
+                let h = self.hess_dense(obj_factor, lam);
+                let mut k = 0;
+                for r in 0..self.n {
+                    for c in 0..=r {
+                        values[k] = h[r * self.n + c];
+                        k += 1;
+                    }
+                }
+            }
+        }
+        true
+    }
+    fn finalize_solution(&mut self, s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.captured_x = Some(s.x.to_vec());
+    }
+}
+
+fn sym_matrix(r: &mut Rng, n: usize) -> Vec<Number> {
+    let mut m = vec![0.0; n * n];
+    for i in 0..n {
+        for j in 0..=i {
+            let v = r.range(-2.0, 2.0);
+            m[i * n + j] = v;
+            m[j * n + i] = v;
+        }
+    }
+    m
+}
+
+pub fn check_derivatives(inst: &Instance, r: &mut Rng) -> Result<usize, String> {
+    let n = inst.n;
+    // Reuse the instance's linear rows, and append one dense quadratic row so
+    // the Hessian has a constraint contribution to carry through.
+    let mut lin = inst.rows.clone();
+    let mut lin_const = inst.row_const.clone();
+    let mut is_lin: Vec<bool> = inst.eligible.clone();
+    let mut g_l = inst.g_l.clone();
+    let mut g_u = inst.g_u.clone();
+    let mut r_quad: Vec<Vec<Number>> = (0..inst.m).map(|_| vec![0.0; n * n]).collect();
+
+    lin.push(Vec::new());
+    lin_const.push(0.0);
+    is_lin.push(false);
+    r_quad.push(sym_matrix(r, n));
+    g_l.push(-1e19);
+    g_u.push(1e19);
+    let m = inst.m + 1;
+
+    for i in 0..inst.m {
+        if !inst.eligible[i] {
+            r_quad[i] = vec![0.0; n * n];
+        }
+    }
+
+    let q = sym_matrix(r, n);
+    let c: Vec<Number> = (0..n).map(|_| r.range(-2.0, 2.0)).collect();
+
+    let tnlp = Rc::new(RefCell::new(QuadTnlp {
+        n,
+        m,
+        q,
+        c,
+        r_quad,
+        lin,
+        lin_const,
+        is_lin,
+        g_l,
+        g_u,
+        x_l: inst.x_l.clone(),
+        x_u: inst.x_u.clone(),
+        x0: inst.x_star.clone(),
+        captured_x: None,
+    }));
+
+    let opts = PresolveOptions {
+        enabled: true,
+        linear_eq_reduction: true,
+        ..PresolveOptions::defaults()
+    };
+    let mut w = LinearEqElimTnlp::new(Rc::clone(&tnlp) as Rc<RefCell<dyn TNLP>>, opts);
+    let Some(info) = w.get_nlp_info() else {
+        return Err("the wrapper declined to publish dimensions".into());
+    };
+    let n_red = info.n as usize;
+    let m_red = info.m as usize;
+    if n_red == n {
+        return Ok(0); // nothing eliminated: the passthrough path, not this probe's target
+    }
+
+    // The oracle is a central finite difference of the wrapper's OWN reduced
+    // `eval_f` / `eval_g`. That deliberately knows nothing about the plan: it
+    // asks only "is the published derivative the derivative of the published
+    // function?", which is the question a wrong gather actually fails. (An
+    // earlier version of this probe rebuilt the plan and compared against a
+    // dense `AᵀHA`; it reported hundreds of false positives, because the
+    // pivot tie-break depends on column order and the rebuilt plan was a
+    // different — equally valid — reduction.)
+    //
+    // Both the model and the substitution are quadratic/affine, so the third
+    // derivative vanishes and central differences are exact to roundoff.
+    let y: Vec<Number> = (0..n_red).map(|_| r.range(-3.0, 3.0)).collect();
+    let lambda_red: Vec<Number> = (0..m_red).map(|_| r.range(-1.5, 1.5)).collect();
+    let obj_factor = r.range(0.25, 2.0);
+    let h = 1e-4;
+
+    let jac_nnz = info.nnz_jac_g as usize;
+    let mut irow = vec![0 as Index; jac_nnz];
+    let mut jcol = vec![0 as Index; jac_nnz];
+    if !w.eval_jac_g(
+        None,
+        false,
+        SparsityRequest::Structure {
+            irow: &mut irow,
+            jcol: &mut jcol,
+        },
+    ) {
+        return Err("eval_jac_g(Structure) declined".into());
+    }
+
+    // Reduced gradient of the Lagrangian at an arbitrary reduced point, built
+    // only from published quantities.
+    let mut lag_grad = |w: &mut LinearEqElimTnlp, yy: &[Number]| -> Result<Vec<Number>, String> {
+        let mut g = vec![0.0; n_red];
+        if !w.eval_grad_f(yy, true, &mut g) {
+            return Err("eval_grad_f declined".into());
+        }
+        for v in g.iter_mut() {
+            *v *= obj_factor;
+        }
+        let mut vals = vec![0.0; jac_nnz];
+        if !w.eval_jac_g(Some(yy), true, SparsityRequest::Values { values: &mut vals }) {
+            return Err("eval_jac_g(Values) declined".into());
+        }
+        for k in 0..jac_nnz {
+            let (rr, cc) = (irow[k] as usize, jcol[k] as usize);
+            g[cc] += lambda_red[rr] * vals[k];
+        }
+        Ok(g)
+    };
+
+    let scale_of = |v: &[Number]| v.iter().fold(1.0_f64, |m, x| m.max(x.abs()));
+
+    // --- gradient vs central difference of eval_f -----------------------
+    let mut got_grad = vec![0.0; n_red];
+    if !w.eval_grad_f(&y, true, &mut got_grad) {
+        return Err("eval_grad_f declined".into());
+    }
+    for j in 0..n_red {
+        let mut yp = y.clone();
+        let mut ym = y.clone();
+        yp[j] += h;
+        ym[j] -= h;
+        let fp = w.eval_f(&yp, true).ok_or("eval_f declined")?;
+        let fm = w.eval_f(&ym, true).ok_or("eval_f declined")?;
+        let fd = (fp - fm) / (2.0 * h);
+        if (got_grad[j] - fd).abs() > 1e-5 * fd.abs().max(scale_of(&got_grad)) {
+            return Err(format!(
+                "reduced gradient[{j}] = {} but a central difference of the wrapper's own \
+                 eval_f gives {fd}",
+                got_grad[j]
+            ));
+        }
+    }
+
+    // --- Jacobian vs central difference of eval_g -----------------------
+    let mut vals = vec![0.0; jac_nnz];
+    if !w.eval_jac_g(Some(&y), true, SparsityRequest::Values { values: &mut vals }) {
+        return Err("eval_jac_g(Values) declined".into());
+    }
+    let mut got_jac = vec![0.0; m_red * n_red];
+    for k in 0..jac_nnz {
+        let (rr, cc) = (irow[k] as usize, jcol[k] as usize);
+        if rr >= m_red || cc >= n_red {
+            return Err(format!("Jacobian entry {k} at ({rr},{cc}) is out of range"));
+        }
+        got_jac[rr * n_red + cc] += vals[k];
+    }
+    let mut fd_jac = vec![0.0; m_red * n_red];
+    for j in 0..n_red {
+        let mut yp = y.clone();
+        let mut ym = y.clone();
+        yp[j] += h;
+        ym[j] -= h;
+        let (mut gp, mut gm) = (vec![0.0; m_red], vec![0.0; m_red]);
+        if !w.eval_g(&yp, true, &mut gp) || !w.eval_g(&ym, true, &mut gm) {
+            return Err("eval_g declined".into());
+        }
+        for rr in 0..m_red {
+            fd_jac[rr * n_red + j] = (gp[rr] - gm[rr]) / (2.0 * h);
+        }
+    }
+    let jscale = scale_of(&fd_jac);
+    for rr in 0..m_red {
+        for cc in 0..n_red {
+            let (a, b) = (got_jac[rr * n_red + cc], fd_jac[rr * n_red + cc]);
+            if (a - b).abs() > 1e-5 * jscale {
+                return Err(format!(
+                    "reduced Jacobian[{rr}][{cc}] = {a} but a central difference of the \
+                     wrapper's own eval_g gives {b}"
+                ));
+            }
+        }
+    }
+
+    // --- Hessian vs central difference of the reduced Lagrangian gradient
+    let h_nnz = info.nnz_h_lag as usize;
+    let mut hirow = vec![0 as Index; h_nnz];
+    let mut hjcol = vec![0 as Index; h_nnz];
+    if !w.eval_h(
+        None,
+        false,
+        1.0,
+        None,
+        false,
+        SparsityRequest::Structure {
+            irow: &mut hirow,
+            jcol: &mut hjcol,
+        },
+    ) {
+        return Err("eval_h(Structure) declined".into());
+    }
+    let mut hvals = vec![0.0; h_nnz];
+    if !w.eval_h(
+        Some(&y),
+        true,
+        obj_factor,
+        Some(&lambda_red),
+        true,
+        SparsityRequest::Values {
+            values: &mut hvals,
+        },
+    ) {
+        return Err("eval_h(Values) declined".into());
+    }
+    // Densify the published lower triangle into a full symmetric matrix.
+    let mut got_h = vec![0.0; n_red * n_red];
+    for k in 0..h_nnz {
+        let (rr, cc) = (hirow[k] as usize, hjcol[k] as usize);
+        if rr >= n_red || cc >= n_red {
+            return Err(format!("Hessian entry {k} at ({rr},{cc}) is out of range"));
+        }
+        if cc > rr {
+            return Err(format!(
+                "Hessian entry {k} at ({rr},{cc}) is above the diagonal; the contract is the \
+                 lower triangle"
+            ));
+        }
+        got_h[rr * n_red + cc] += hvals[k];
+        if rr != cc {
+            got_h[cc * n_red + rr] += hvals[k];
+        }
+    }
+    let mut fd_h = vec![0.0; n_red * n_red];
+    for j in 0..n_red {
+        let mut yp = y.clone();
+        let mut ym = y.clone();
+        yp[j] += h;
+        ym[j] -= h;
+        let gp = lag_grad(&mut w, &yp)?;
+        let gm = lag_grad(&mut w, &ym)?;
+        for i in 0..n_red {
+            fd_h[i * n_red + j] = (gp[i] - gm[i]) / (2.0 * h);
+        }
+    }
+    let hscale = scale_of(&fd_h);
+    for rr in 0..n_red {
+        for cc in 0..n_red {
+            let (a, b) = (got_h[rr * n_red + cc], fd_h[rr * n_red + cc]);
+            if (a - b).abs() > 1e-5 * hscale {
+                return Err(format!(
+                    "reduced Hessian[{rr}][{cc}] = {a} but a central difference of the reduced \
+                     Lagrangian gradient gives {b}"
+                ));
+            }
+        }
+    }
+
+    // --- primal fidelity: the consumed rows must hold at the lift of an
+    // ARBITRARY reduced point ---------------------------------------------
+    //
+    // Derivatives cannot see this. The substitution is affine, and an error in
+    // its constant term `β` shifts the lifted point without touching a single
+    // derivative — `∇(αy + β)` is `α` either way. So a wrong row constant
+    // (`g_r(x) = Σ a_j x_j + c`, read off the probe point) produces a reduced
+    // problem whose solutions violate the very rows it eliminated, and every
+    // finite-difference check above passes anyway. Ask the question directly:
+    // push a reduced point through `finalize_solution` and look at what the
+    // original model receives.
+    //
+    // At least as many original rows must hold at BOTH of two different lifts
+    // as the reduction claims to have dropped. A kept row that happens to hold
+    // only inflates the count, so the bound is safe in the direction it is
+    // asserted.
+    let mut identically_satisfied = 0usize;
+    let mut resid_ok: Vec<bool> = vec![true; m];
+    for trial in 0..2 {
+        let yy: Vec<Number> = (0..n_red).map(|_| r.range(-4.0, 4.0)).collect();
+        let zeros_n = vec![0.0; n_red];
+        let zeros_m = vec![0.0; m_red];
+        w.finalize_solution(
+            Solution {
+                status: SolverReturn::Success,
+                x: &yy,
+                z_l: &zeros_n,
+                z_u: &zeros_n,
+                g: &zeros_m,
+                lambda: &zeros_m,
+                obj_value: 0.0,
+            },
+            &IpoptData::default(),
+            &IpoptCq::default(),
+        );
+        let x_full = tnlp
+            .borrow()
+            .captured_x
+            .clone()
+            .ok_or("the wrapper never forwarded finalize_solution")?;
+        if x_full.len() != n {
+            return Err(format!(
+                "finalize_solution forwarded {} coordinates for an {n}-column model",
+                x_full.len()
+            ));
+        }
+        let live = x_full.iter().fold(1.0_f64, |m, v| m.max(v.abs()));
+        for i in 0..m {
+            let is_eq = is_lin_of(&tnlp, i) && (g_of(&tnlp, i).1 - g_of(&tnlp, i).0).abs() <= 1e-12;
+            if !is_eq {
+                resid_ok[i] = false;
+                continue;
+            }
+            let body: Number = row_body_of(&tnlp, i, &x_full);
+            if (body - g_of(&tnlp, i).0).abs() > 1e-7 * live * 10.0 {
+                resid_ok[i] = false;
+            }
+        }
+        let _ = trial;
+    }
+    for i in 0..m {
+        if resid_ok[i] {
+            identically_satisfied += 1;
+        }
+    }
+    let dropped = m - m_red;
+    if identically_satisfied < dropped {
+        return Err(format!(
+            "the reduction dropped {dropped} rows, but only {identically_satisfied} of the \
+             original rows hold at the lift of an arbitrary reduced point — the eliminated \
+             rows are not satisfied by the substitution"
+        ));
+    }
+
+    Ok(n - n_red)
+}
+
+fn is_lin_of(t: &Rc<RefCell<QuadTnlp>>, i: usize) -> bool {
+    t.borrow().is_lin[i]
+}
+
+fn g_of(t: &Rc<RefCell<QuadTnlp>>, i: usize) -> (Number, Number) {
+    let b = t.borrow();
+    (b.g_l[i], b.g_u[i])
+}
+
+fn row_body_of(t: &Rc<RefCell<QuadTnlp>>, i: usize, x: &[Number]) -> Number {
+    let b = t.borrow();
+    b.lin[i].iter().map(|&(j, a)| a * x[j]).sum::<Number>() + b.lin_const[i]
+}

--- a/adversary/fuzz/src/main.rs
+++ b/adversary/fuzz/src/main.rs
@@ -11,6 +11,7 @@
 //! heard of pounce.
 
 mod instances;
+mod linelim_probe;
 mod qp_probe;
 mod rng;
 mod warmstart_probe;
@@ -30,8 +31,9 @@ fn main() {
         "qp" => qp_fuzz(count, seed),
         "warmstart" => warmstart_fuzz(count, seed),
         "qp-one" => qp_one(count as u64),
+        "linelim" => linelim_fuzz(count, seed),
         other => {
-            eprintln!("unknown probe {other:?}; expected `qp` or `warmstart`");
+            eprintln!("unknown probe {other:?}; expected `qp`, `warmstart`, or `linelim`");
             std::process::exit(2);
         }
     }
@@ -361,5 +363,68 @@ fn qp_one(seed: u64) {
     for ft in [1e-9, 1e-8, 1e-7, 1e-6, 1e-4, 1e-2] {
         let out = qp_probe::run_with(&inst, ft);
         println!("  feas_tol={ft:.0e} -> status={:12} verdict={:?}", out.status, out.verdict);
+    }
+}
+
+/// gh#487 Phase 6 probe: plan invariants against a known feasible point, then
+/// the derivative transforms against a dense second implementation.
+fn linelim_fuzz(count: usize, seed: u64) {
+    let mut plan_failures: Vec<(u64, String)> = Vec::new();
+    let mut deriv_failures: Vec<(u64, String)> = Vec::new();
+    let mut n_reduced = 0usize;
+    let mut n_identity = 0usize;
+    let mut total_cols = 0usize;
+    let mut total_rows = 0usize;
+
+    for k in 0..count {
+        let s = seed.wrapping_add(k as u64 * 0x1000_0001);
+        let mut r = Rng::new(s);
+        let inst = linelim_probe::generate(&mut r, s);
+
+        match linelim_probe::check_plan(&inst) {
+            linelim_probe::PlanVerdict::Ok {
+                elim_vars,
+                elim_rows,
+            } => {
+                if elim_vars == 0 {
+                    n_identity += 1;
+                } else {
+                    n_reduced += 1;
+                    total_cols += elim_vars;
+                    total_rows += elim_rows;
+                }
+            }
+            linelim_probe::PlanVerdict::Failed(why) => plan_failures.push((s, why)),
+        }
+
+        if let Err(why) = linelim_probe::check_derivatives(&inst, &mut r) {
+            deriv_failures.push((s, why));
+        }
+    }
+
+    println!("instances            : {count}");
+    println!("  reduced            : {n_reduced}");
+    println!("  nothing to do      : {n_identity}");
+    println!("  columns eliminated : {total_cols}");
+    println!("  rows dropped       : {total_rows}");
+    println!("plan invariant failures      : {}", plan_failures.len());
+    for (s, why) in plan_failures.iter().take(10) {
+        println!("  seed {s}: {why}");
+    }
+    println!("derivative transform failures: {}", deriv_failures.len());
+    for (s, why) in deriv_failures.iter().take(10) {
+        println!("  seed {s}: {why}");
+    }
+    let bad = plan_failures.len() + deriv_failures.len();
+    println!(
+        "VERDICT: {}",
+        if bad == 0 {
+            "PASS".to_string()
+        } else {
+            format!("FAIL ({bad} failing instances)")
+        }
+    );
+    if bad > 0 {
+        std::process::exit(1);
     }
 }

--- a/adversary/log.org
+++ b/adversary/log.org
@@ -10,7 +10,7 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 
 | Family          | Tested | Last run   | Open findings |
 |-----------------+--------+------------+---------------|
-| nlp             |     11 | 2026-08-05 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6) |
+| nlp             |     12 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6) |
 | lp              |     10 | 2026-08-04 | —             |
 | qp              |     10 | 2026-08-03 | —             |
 | qp-active-set   |     14 | 2026-08-05 | both probes now CLEAN. Fixed this run: false-Infeasible (14 -> 0), `Optimal` at violating points, rank-deficiency hard errors, unvalidated working-set status codes, and IpoptGet/SetWorkingSet reporting the SQP's internal row order instead of the caller's. Nothing open. |
@@ -25,6 +25,33 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 | sensitivity     |     10 | 2026-08-03 | — (weakly-active one-sided dx/db intrinsic/known; no barrier inflation confirmed; reduced_hessian() cross-checked clean) |
 
 * Problem Index
+** [2026-08-06] Linear-equality variable elimination, Phase 6 (nlp/presolve, gh#487) - PASS
+:PROPERTIES:
+:FAMILY: nlp
+:SOURCE: randomized families built around a known feasible point x*; no published instance
+:KNOWN_OPTIMAL: n/a (property-based)
+:POUNCE_OBJECTIVE: n/a
+:POUNCE_STATUS: 12000 fuzz instances + 120 end-to-end .nl solves, 0 failures
+:POUNCE_TIME: ~4 min total
+:ORACLE: pounce verify (independent KKT/feasibility vs the original .nl); central finite differences of the wrapper's own reduced eval_f/eval_g; in-script row re-evaluation
+:ORACLE_OBJECTIVE: n/a
+:ORACLE_TIME: n/a
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_nlp_linear-eq-reduction.org]]
+:COVERAGE_TARGET: linear_eq_plan.rs / linear_eq_elim.rs — new files, no prior adversarial coverage
+:END:
+
+Probes validated by mutation testing: five injected defects (Hessian
+symmetric-pair x2 factor, bound-transfer sign, row constant, lift offset, dual
+recovery) were each caught. The row-constant defect initially escaped every
+probe — derivatives are blind to an affine offset — which is why the probe now
+carries a primal-fidelity check through =finalize_solution=.
+
+Recorded non-defect: a row whose constant lives in its =.nl= expression segment
+is tagged NonLinear by the reader, so the elimination declines it. The
+row-constant branch is therefore reachable only on the general TNLP path (C
+interface, GAMS, callbacks), not via =.nl=.
+
 ** [2026-08-05] l1-elastic infeasibility certificate under nonconvex step QPs (qp-active-set/certificate-soundness) - FAIL
 :PROPERTIES:
 :FAMILY: qp-active-set

--- a/adversary/runs/2026-08-06_nlp_linear-eq-reduction.org
+++ b/adversary/runs/2026-08-06_nlp_linear-eq-reduction.org
@@ -1,0 +1,145 @@
+#+TITLE: Adversary Run: Linear-Equality Variable Elimination (Phase 6, gh#487)
+#+DATE: <2026-08-06>
+
+* Problem
+:PROPERTIES:
+:FAMILY: nlp
+:CLASS: presolve — equality-constrained, linear-equality structure
+:SOURCE: no published instance; randomized families built around a KNOWN feasible point x*, plus mutation testing of the probes themselves
+:KNOWN_OPTIMAL: n/a (property-based, not a single instance)
+:N_VARIABLES: 3–10 (Rust probe), 4–9 (.nl sweep)
+:N_CONSTRAINTS: 1–9
+:SELECTED_BY: topic-guidance (new code under review for gh#487)
+:COVERAGE_TARGET: crates/pounce-presolve/src/linear_eq_plan.rs, linear_eq_elim.rs — brand new, zero adversarial coverage
+:END:
+
+Target under test: =presolve_linear_eq_reduction= (Phase 6). It rewrites the
+problem as an affine map $x = A y + c$ derived from the linear equality rows,
+solves the reduced problem, then lifts the primal and recovers a multiplier for
+every consumed row.
+
+Three shapes are recognised: a variable fixed by equal bounds, a singleton row
+$a x = b$, and a two-variable row $a_1 x + a_2 y = b$.
+
+* Method
+
+Nothing here validates pounce against pounce-with-the-option-off. Three
+independent attacks:
+
+1. *Plan invariants* (=adversary-fuzz linelim=, plan half). Every instance is
+   generated around a random feasible point $x^*$: right-hand sides are
+   computed from it and every box is drawn to contain it. $x^*$ is then an
+   oracle the pass has never seen.
+2. *Derivative transforms* (=adversary-fuzz linelim=, deriv half). Central
+   finite differences of the wrapper's *own* reduced =eval_f= / =eval_g=. This
+   deliberately knows nothing about the plan; it asks only whether the
+   published derivative is the derivative of the published function. Model and
+   substitution are quadratic/affine, so the third derivative vanishes and the
+   differences are exact to roundoff.
+3. *End to end* (=runs/2026-08-06_nlp_linear_eq_reduction_verify.py=).
+   Randomized =.nl= files through the CLI, checked with =pounce verify= — an
+   independent feasibility/KKT check against the ORIGINAL model — and with a
+   second, in-script re-evaluation of every row from the source data (which
+   =verify= alone would not distinguish from a correctly-sized but permuted
+   =.sol=).
+
+* Results
+:PROPERTIES:
+:STATUS: PASS
+:END:
+
+| Probe                          | Instances | Reduced | Failures |
+|--------------------------------+-----------+---------+----------|
+| linelim (seed 20260806)        |      4000 |    2952 |        0 |
+| linelim (seed 987654321)       |      4000 |    2953 |        0 |
+| linelim (seed 13579)           |      4000 |    2972 |        0 |
+| .nl + =pounce verify= sweep    |       120 |      82 |        0 |
+
+All four rows re-run after rebasing onto =origin/main= at #489, which changed
+=.nl= derivative evaluation (quotient rule, fused entropy opcodes) — the sweep
+above is the post-rebase result.
+
+~30k columns eliminated across the Rust runs. Every =.nl= solve was accepted by
+=pounce verify=, every reported point satisfied all its rows and bounds, and
+every objective agreed with the un-reduced solve.
+
+* Mutation testing — do the probes actually bite?
+
+A green probe is worth nothing until it has been shown to fail. Five deliberate
+defects were injected into the pass, one at a time, and reverted:
+
+| # | Injected defect                                        | Caught by                        | Signal      |
+|---+--------------------------------------------------------+----------------------------------+-------------|
+| 1 | drop the Hessian symmetric-pair ×2 factor              | derivative probe                 | 573 / 1200  |
+| 2 | ignore the sign of α when transferring bounds          | plan probe                       | 600 / 1200  |
+| 3 | forget the row constant $c$ in $g_r = \sum a_j x_j + c$ | primal-fidelity check (see below) | 459 / 1200 |
+| 4 | lift an eliminated column without its offset β         | plan probe                       | 573 / 1200  |
+| 5 | skip the dual recovery (report λ = 0)                  | integration test                 | 2 tests     |
+
+Defect 3 initially escaped *every* probe, which was the run's most useful
+result. Derivatives cannot see it: the substitution is affine, and an error in
+its constant term shifts the lifted point without touching a single
+derivative — $\nabla(\alpha y + \beta) = \alpha$ either way. The probe was
+extended with a *primal-fidelity* check that pushes an arbitrary reduced point
+through =finalize_solution= and asserts that at least as many original rows
+hold at the lift as the reduction claims to have dropped. That catches it.
+
+* Cross-check / Verification
+
+- =pounce verify= exit code 0 on all 120 =.nl= solves (it re-derives feasibility
+  and KKT from the original file and has no knowledge of the reduction).
+- Independent in-script re-evaluation: all rows within 1e-6, all bounds
+  respected, objectives matching the un-reduced solve within 1e-4 relative.
+- Plan-level: lifting $x^*$'s survivor coordinates reproduced $x^*$ exactly on
+  all 12000 instances; the reduced box retained $x^*$ every time; a random
+  point of the reduced box always lifted inside the *original* declared box.
+
+* Finding (not a defect): the =.nl= path cannot reach the row-constant branch
+
+Chasing defect 3 end to end turned up a real fact worth recording. Writing a
+row's constant into its expression segment makes pounce's =.nl= reader tag the
+row *NonLinear*, so the elimination declines it. Verified directly: the model
+=x0 - x1 + 3 = 3= with the constant in the =C0= segment reduces nothing, while
+the same model with the constant folded into the bound eliminates one column
+and one row — both reaching unscaled objective 10.125.
+
+So on the =.nl= path the row-constant branch is dead code, conservatively.
+It is live on the general TNLP path (C interface, GAMS link, callback bridges),
+which is exactly where the Rust probe exercises it. No action; recorded so a
+later reader does not mistake the =.nl= sweep's silence for coverage.
+
+* Verdict
+
+PASS — no defect found in Phase 6. Three independent attacks over ~12k
+randomized instances plus 120 end-to-end =.nl= solves found nothing, and the
+probes were shown to catch five injected defects covering the Hessian
+symmetric-pair factor, the bound-transfer sign, the row constant, the lift
+offset, and the dual recovery.
+
+The honest scope: this establishes the *transform* is faithful and the
+*reporting* is in the original space. It does not establish anything about
+models the presolve layer never sees — in particular LPs and convex QPs, which
+route to =pounce-convex= before any presolve wrapper is built.
+
+* Scale
+
+Not a correctness result, but the reason the pass exists. A synthetic
+alias-heavy model of 24000 columns / 21600 rows, mirroring the shape gh#487
+measured:
+
+| Reduction | Columns to the solver | Rows | Wall time (release) |
+|-----------+-----------------------+------+---------------------|
+| off       |                 24000 | 21600 | 1.63 s             |
+| on        |                  2400 |     0 | 0.30 s             |
+
+Same objective, =.sol= body identical in length (45600 entries), all duals
+agreeing to 1e-8, and every alias row satisfied to exactly 0.0 in the reported
+point.
+
+* Coverage effect
+
+Both target files were new in this change and had no adversarial coverage at
+all. The probes now exercise the planner's three shapes, chain propagation,
+bound transfer in both signs, the redundant-row path, the fail-closed paths,
+the three derivative gathers including the same-reduced-column Hessian case,
+and the postsolve multiplier recovery.

--- a/adversary/runs/2026-08-06_nlp_linear_eq_reduction_verify.py
+++ b/adversary/runs/2026-08-06_nlp_linear_eq_reduction_verify.py
@@ -1,0 +1,216 @@
+"""Adversary cross-check: linear-equality variable elimination, end to end.
+
+Family: nlp   Class: equality-constrained, linear-equality structure
+Target: `presolve_linear_eq_reduction` (Phase 6, gh#487)
+Source: no published instance — a randomized family built around a KNOWN
+        feasible point, with `pounce verify` as the independent oracle.
+
+The Rust probe (`adversary-fuzz linelim`) attacks the plan and the derivative
+transforms in isolation. This one attacks the whole stack the way a user meets
+it: a `.nl` file on disk, the CLI, and the `.sol` file that comes back.
+
+Two oracles, neither of which is "pounce with the option off":
+
+1. **`pounce verify <nl> <sol>`** — an independent feasibility/KKT check of the
+   claimed point against the ORIGINAL `.nl`, which knows nothing about the
+   reduction. If the reduced solve returns a point that violates a row it
+   eliminated, or that is not stationary for the original model, this rejects
+   it.
+2. **Direct evaluation in this script** — the model's rows are re-evaluated
+   here, in Python, from the same data used to write the `.nl`. That catches a
+   `.sol` whose primal block is the right length but the wrong permutation,
+   which `verify` alone would not distinguish from a genuine solve.
+
+The objective is a sum of quartics, so every column is nonlinear in the
+objective and the `.nl` variable ordering is the natural one. Every row is a
+linear equality whose right-hand side is computed from a random `x*`, so the
+system is consistent by construction and a "proved infeasible" verdict is
+always a bug.
+"""
+
+import random
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+POUNCE = Path("/home/user/pounce/target/release/pounce")
+
+
+def write_nl(path, n, rows, rhs, consts, targets, x_l, x_u, x0):
+    """`min Σ (x_j - t_j)^4  s.t.  Σ a_ij x_j + c_i = rhs_i`, all rows linear.
+
+    `c_i` goes in the row's expression segment rather than being folded into
+    the bound, because a row constant is exactly what the elimination has to
+    read off its probe point — and a generator that always emits `c_i = 0`
+    cannot tell whether it did.
+    """
+    m = len(rows)
+    jnnz = sum(len(r) for r in rows)
+    L = [
+        "g3 1 1 0\t# adversary linear-eq reduction",
+        f" {n} {m} 1 0 {m} \t# vars, constraints, objectives, ranges, eqns",
+        " 0 1 0 0 0 0\t# nonlinear constrs, objs",
+        " 0 0\t# network",
+        f" 0 {n} 0 \t# nonlinear vars in constraints, objectives, both",
+        " 0 0 0 1\t# linear network vars; functions; arith, flags",
+        " 0 0 0 0 0 \t# discrete",
+        f" {jnnz} {n} \t# nonzeros in Jacobian, obj gradient",
+        " 0 0\t# max name lengths",
+        " 0 0 0 0 0\t# common exprs",
+    ]
+    for r in range(m):
+        L += [f"C{r}", f"n{consts[r]!r}"]
+    L += ["O0 0", "o54", str(n)]
+    for j in range(n):
+        L += ["o5", "o0", f"v{j}", f"n{-targets[j]!r}", "n4"]
+    L.append(f"x{n}")
+    for j in range(n):
+        L.append(f"{j} {x0[j]!r}")
+    L.append("r")
+    for i in range(m):
+        L.append(f"4 {rhs[i]!r}")
+    L.append("b")
+    for j in range(n):
+        L.append(f"0 {x_l[j]!r} {x_u[j]!r}")
+    # cumulative Jacobian nonzeros per column, columns 0..n-2
+    colcount = [0] * n
+    for r in rows:
+        for j, _ in r:
+            colcount[j] += 1
+    L.append(f"k{n - 1}")
+    cum = 0
+    for j in range(n - 1):
+        cum += colcount[j]
+        L.append(str(cum))
+    for i, r in enumerate(rows):
+        L.append(f"J{i} {len(r)}")
+        for j, a in sorted(r):
+            L.append(f"{j} {a!r}")
+    L.append(f"G0 {n}")
+    for j in range(n):
+        L.append(f"{j} 0")
+    path.write_text("\n".join(L) + "\n")
+
+
+def gen(rng):
+    n = rng.randint(4, 9)
+    m = rng.randint(1, max(1, n - 2))
+    x_star = [round(rng.uniform(-4, 4), 6) for _ in range(n)]
+    rows, rhs, consts = [], [], []
+    for _ in range(m):
+        arity = rng.choice([1, 2, 2, 2, 3])
+        cols = rng.sample(range(n), min(arity, n))
+        row = []
+        for c in cols:
+            a = round(rng.uniform(0.3, 3.0), 6) * rng.choice([1, -1])
+            row.append((c, a))
+        rows.append(row)
+        # A nonzero constant on most rows; a few zeros to keep both paths live.
+        consts.append(0.0 if rng.random() < 0.7 else round(rng.uniform(-3, 3), 6))
+        rhs.append(round(sum(a * x_star[c] for c, a in row) + consts[-1], 9))
+    targets = [round(rng.uniform(-4, 4), 6) for _ in range(n)]
+    x_l = [round(x_star[j] - rng.uniform(1.0, 6.0), 6) for j in range(n)]
+    x_u = [round(x_star[j] + rng.uniform(1.0, 6.0), 6) for j in range(n)]
+    x0 = [round(x_star[j] + rng.uniform(-0.5, 0.5), 6) for j in range(n)]
+    return n, rows, rhs, consts, targets, x_l, x_u, x0, x_star
+
+
+def run(nl_dir, opts):
+    cmd = [str(POUNCE), "m", "-AMPL"] + opts
+    p = subprocess.run(cmd, cwd=nl_dir, capture_output=True, text=True, timeout=60)
+    return p
+
+
+def read_sol(path, n, m):
+    nums = []
+    for line in path.read_text().splitlines():
+        if line.startswith("objno"):
+            break
+        try:
+            nums.append(float(line.strip()))
+        except ValueError:
+            pass
+    tail = nums[-(n + m):]
+    return tail[:m], tail[m:]
+
+
+def main():
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 40
+    seed = int(sys.argv[2]) if len(sys.argv) > 2 else 20260806
+    rng = random.Random(seed)
+
+    bad, checked, reduced_any = [], 0, 0
+    for t in range(trials):
+        n, rows, rhs, consts, targets, x_l, x_u, x0, x_star = gen(rng)
+        m = len(rows)
+        d = Path(tempfile.mkdtemp(prefix="adv_lineq_"))
+        try:
+            nl = d / "m.nl"
+            write_nl(nl, n, rows, rhs, consts, targets, x_l, x_u, x0)
+
+            off = run(d, [])
+            if "Optimal Solution Found" not in off.stdout:
+                continue  # the baseline could not solve it; not this pass's business
+            sol_off = read_sol(d / "m.sol", n, m)
+            shutil.copy(d / "m.sol", d / "off.sol")
+
+            on = run(d, ["presolve=yes", "presolve_linear_eq_reduction=yes"])
+            checked += 1
+            if "eliminated 0 columns" not in on.stdout:
+                reduced_any += 1
+            if "Optimal Solution Found" not in on.stdout:
+                bad.append((t, "reduced solve did not reach optimality", on.stdout[-400:]))
+                continue
+            lam_on, x_on = read_sol(d / "m.sol", n, m)
+
+            # --- oracle 1: independent KKT / feasibility check vs the .nl ---
+            v = subprocess.run(
+                [str(POUNCE), "verify", "m.nl", "m.sol"],
+                cwd=d, capture_output=True, text=True, timeout=60,
+            )
+            if v.returncode != 0:
+                bad.append((t, f"pounce verify rejected the reduced solve (rc={v.returncode})",
+                            v.stdout[-600:] + v.stderr[-300:]))
+                continue
+
+            # --- oracle 2: re-evaluate the rows here, from the source data ---
+            if len(x_on) != n or len(lam_on) != m:
+                bad.append((t, f".sol shape wrong: {len(x_on)} primals / {len(lam_on)} duals "
+                               f"for an {n}x{m} model", ""))
+                continue
+            for i, row in enumerate(rows):
+                body = sum(a * x_on[c] for c, a in row) + consts[i]
+                if abs(body - rhs[i]) > 1e-6 * max(1.0, abs(rhs[i])):
+                    bad.append((t, f"row {i} violated by {body - rhs[i]:.3e} in the reduced "
+                                   f"solve's reported point", ""))
+                    break
+            else:
+                for j in range(n):
+                    if not (x_l[j] - 1e-6 <= x_on[j] <= x_u[j] + 1e-6):
+                        bad.append((t, f"x[{j}]={x_on[j]} outside its declared box "
+                                       f"[{x_l[j]}, {x_u[j]}]", ""))
+                        break
+                else:
+                    f_on = sum((x_on[j] - targets[j]) ** 4 for j in range(n))
+                    f_off = sum((sol_off[1][j] - targets[j]) ** 4 for j in range(n))
+                    if abs(f_on - f_off) > 1e-4 * max(1.0, abs(f_off)):
+                        bad.append((t, f"objective disagrees with the un-reduced solve: "
+                                       f"{f_on:.8e} vs {f_off:.8e}", ""))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    print(f"instances solved and checked : {checked}")
+    print(f"  where the pass reduced     : {reduced_any}")
+    print(f"failures                     : {len(bad)}")
+    for t, why, extra in bad[:8]:
+        print(f"  [{t}] {why}")
+        if extra:
+            print("      " + extra.replace("\n", "\n      ")[:500])
+    print("VERDICT: PASS" if not bad else f"VERDICT: FAIL ({len(bad)} failures)")
+    return 0 if not bad else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/pounce-algorithm/tests/presolve_phase6_linear_eq_elim.rs
+++ b/crates/pounce-algorithm/tests/presolve_phase6_linear_eq_elim.rs
@@ -317,3 +317,28 @@ fn duals_match_the_bare_solve() {
         );
     }
 }
+
+/// The composition path every *library* caller takes — and with it the C
+/// interface and the GAMS link, which both drive `IpoptApplication` — is
+/// `wrap_with_presolve`, not the hand-stacked pair the tests above build.
+/// It has to reach the same reduced problem, or the "one implementation
+/// serves every frontend" claim in #487's option (b) is only true of the
+/// CLI.
+#[test]
+fn the_public_wrapper_stacks_the_reduction_too() {
+    use pounce_presolve::wrap_with_presolve;
+
+    let concrete = Rc::new(RefCell::new(Fixture::default()));
+    let wrapped =
+        wrap_with_presolve(Rc::clone(&concrete) as Rc<RefCell<dyn TNLP>>, opts(true)).unwrap();
+    let info = wrapped.borrow_mut().get_nlp_info().expect("dims");
+    assert_eq!(info.n, 2, "wrap_with_presolve did not reduce the columns");
+    assert_eq!(info.m, 1);
+
+    // And leaves the problem alone when the option is off.
+    let bare = Rc::new(RefCell::new(Fixture::default()));
+    let plain = wrap_with_presolve(Rc::clone(&bare) as Rc<RefCell<dyn TNLP>>, opts(false)).unwrap();
+    let info = plain.borrow_mut().get_nlp_info().expect("dims");
+    assert_eq!(info.n, 4);
+    assert_eq!(info.m, 3);
+}

--- a/crates/pounce-algorithm/tests/presolve_phase6_linear_eq_elim.rs
+++ b/crates/pounce-algorithm/tests/presolve_phase6_linear_eq_elim.rs
@@ -1,0 +1,319 @@
+//! Phase 6 acceptance (issue #487): eliminating variables determined by
+//! linear equality rows must not change the answer.
+//!
+//! The fixture is deliberately shaped to exercise every arm of the
+//! transform at once:
+//!
+//! * `x0 − 2·x1 = 0` — a free/free two-variable row, the shape the
+//!   determined-block pipeline (#53) cannot reach, so `x0` folds onto `x1`
+//!   with a coefficient of 2.
+//! * `x3 = 1` — a singleton row, so `x3` leaves as a constant.
+//! * `x1² + x2² = 2` — a nonlinear row, which survives and must be
+//!   re-presented over the reduced columns.
+//!
+//! The objective carries an `x0·x1` cross term on purpose: both of its
+//! columns collapse onto the *same* reduced column, which is the one
+//! Hessian case that needs the symmetric pair counted twice, and an
+//! `x3·x1` term whose second derivative must vanish once `x3` is a
+//! constant.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_presolve::{LinearEqElimTnlp, PresolveOptions, PresolveTnlp};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, Default)]
+struct Captured {
+    x: Vec<Number>,
+    z_l: Vec<Number>,
+    z_u: Vec<Number>,
+    lambda: Vec<Number>,
+    g: Vec<Number>,
+    obj: Number,
+}
+
+#[derive(Default)]
+struct Fixture {
+    captured: Option<Captured>,
+}
+
+impl Fixture {
+    fn grad_f(x: &[Number], out: &mut [Number]) {
+        // f = (x0-1)² + (x2-3)² + x3·x1 + x0·x1
+        out[0] = 2.0 * (x[0] - 1.0) + x[1];
+        out[1] = x[3] + x[0];
+        out[2] = 2.0 * (x[2] - 3.0);
+        out[3] = x[1];
+    }
+}
+
+/// Row-major dense Jacobian of the fixture, for the stationarity check.
+fn jac_dense(x: &[Number]) -> [[Number; 4]; 3] {
+    [
+        [1.0, -2.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0, 1.0],
+        [0.0, 2.0 * x[1], 2.0 * x[2], 0.0],
+    ]
+}
+
+impl TNLP for Fixture {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 4,
+            m: 3,
+            nnz_jac_g: 5,
+            nnz_h_lag: 5,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-10.0, -10.0, 0.0, -10.0]);
+        b.x_u.copy_from_slice(&[10.0, 10.0, 10.0, 10.0]);
+        b.g_l.copy_from_slice(&[0.0, 1.0, 2.0]);
+        b.g_u.copy_from_slice(&[0.0, 1.0, 2.0]);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[1.0, 0.5, 1.0, 1.0]);
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.copy_from_slice(&[Linearity::Linear, Linearity::Linear, Linearity::NonLinear]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 1.0).powi(2) + (x[2] - 3.0).powi(2) + x[3] * x[1] + x[0] * x[1])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        Self::grad_f(x, g);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] - 2.0 * x[1];
+        g[1] = x[3];
+        g[2] = x[1] * x[1] + x[2] * x[2];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 1, 2, 2]);
+                jcol.copy_from_slice(&[0, 1, 3, 1, 2]);
+            }
+            SparsityRequest::Values { values } => {
+                let Some(x) = x else { return false };
+                values[0] = 1.0;
+                values[1] = -2.0;
+                values[2] = 1.0;
+                values[3] = 2.0 * x[1];
+                values[4] = 2.0 * x[2];
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1, 2, 3]);
+                jcol.copy_from_slice(&[0, 0, 1, 2, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                let lam = lambda.map(|l| l[2]).unwrap_or(0.0);
+                values[0] = obj_factor * 2.0; // ∂²/∂x0²
+                values[1] = obj_factor; // ∂²/∂x1∂x0 (the x0·x1 term)
+                values[2] = lam * 2.0; // ∂²/∂x1² (from the nonlinear row)
+                values[3] = obj_factor * 2.0 + lam * 2.0; // ∂²/∂x2²
+                values[4] = obj_factor; // ∂²/∂x1∂x3 (the x3·x1 term)
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.captured = Some(Captured {
+            x: sol.x.to_vec(),
+            z_l: sol.z_l.to_vec(),
+            z_u: sol.z_u.to_vec(),
+            lambda: sol.lambda.to_vec(),
+            g: sol.g.to_vec(),
+            obj: sol.obj_value,
+        });
+    }
+}
+
+fn opts(linear_eq_reduction: bool) -> PresolveOptions {
+    PresolveOptions {
+        enabled: true,
+        linear_eq_reduction,
+        // Keep the other phases out of the comparison: this test is about
+        // the column reduction, and a dropped row would move the duals for
+        // reasons of its own (the M24 attribution caveat).
+        bound_tightening: false,
+        redundant_constraint_removal: false,
+        licq_check: false,
+        warm_z_bounds: false,
+        ..PresolveOptions::defaults()
+    }
+}
+
+struct Outcome {
+    captured: Captured,
+    stats_obj: Number,
+    reduced_n: i32,
+    reduced_m: i32,
+}
+
+fn solve(linear_eq_reduction: bool) -> Outcome {
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    // Unscaled, so the duals handed to `finalize_solution` are directly
+    // comparable against the fixture's own analytic gradient.
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "none", true, false)
+        .unwrap();
+
+    let concrete = Rc::new(RefCell::new(Fixture::default()));
+    let presolve = Rc::new(RefCell::new(PresolveTnlp::new(
+        Rc::clone(&concrete) as Rc<RefCell<dyn TNLP>>,
+        opts(linear_eq_reduction),
+    )));
+    let elim = Rc::new(RefCell::new(LinearEqElimTnlp::new(
+        Rc::clone(&presolve) as Rc<RefCell<dyn TNLP>>,
+        opts(linear_eq_reduction),
+    )));
+    let info = elim.borrow_mut().get_nlp_info().expect("dims");
+    let _ = app.optimize_tnlp(Rc::clone(&elim) as Rc<RefCell<dyn TNLP>>);
+
+    Outcome {
+        captured: concrete.borrow().captured.clone().expect("finalized"),
+        stats_obj: app.statistics().final_objective,
+        reduced_n: info.n,
+        reduced_m: info.m,
+    }
+}
+
+#[test]
+fn the_reduction_removes_the_determined_columns_and_their_rows() {
+    let on = solve(true);
+    assert_eq!(on.reduced_n, 2, "x0 and x3 should be gone");
+    assert_eq!(on.reduced_m, 1, "only the nonlinear row should survive");
+
+    let off = solve(false);
+    assert_eq!(off.reduced_n, 4);
+    assert_eq!(off.reduced_m, 3);
+}
+
+#[test]
+fn the_solution_is_reported_in_full_space_and_matches_the_bare_solve() {
+    let on = solve(true);
+    let off = solve(false);
+
+    assert_eq!(
+        on.captured.x.len(),
+        4,
+        "finalize_solution must see all 4 columns"
+    );
+    assert_eq!(on.captured.z_l.len(), 4);
+    assert_eq!(on.captured.lambda.len(), 3, "and all 3 rows");
+    assert_eq!(on.captured.g.len(), 3);
+
+    assert!(
+        (on.captured.obj - off.captured.obj).abs() < 1e-7,
+        "objective diverged: reduced={} full={}",
+        on.captured.obj,
+        off.captured.obj
+    );
+    assert!((on.stats_obj - on.captured.obj).abs() < 1e-9);
+    for j in 0..4 {
+        assert!(
+            (on.captured.x[j] - off.captured.x[j]).abs() < 1e-6,
+            "x[{j}] diverged: reduced={} full={}",
+            on.captured.x[j],
+            off.captured.x[j]
+        );
+    }
+}
+
+#[test]
+fn the_eliminated_rows_are_satisfied_and_reported() {
+    let on = solve(true);
+    let x = &on.captured.x;
+    assert!(
+        (x[0] - 2.0 * x[1]).abs() < 1e-9,
+        "x0 = 2·x1 violated: {x:?}"
+    );
+    assert!((x[3] - 1.0).abs() < 1e-9, "x3 = 1 violated: {x:?}");
+    // `g` for the consumed rows is re-evaluated, not left at zero.
+    assert!((on.captured.g[0] - 0.0).abs() < 1e-9);
+    assert!((on.captured.g[1] - 1.0).abs() < 1e-9);
+    assert!((on.captured.g[2] - 2.0).abs() < 1e-7);
+}
+
+#[test]
+fn recovered_multipliers_satisfy_full_space_stationarity() {
+    // The whole point of the reverse sweep: the consumed rows come back
+    // with multipliers that close `∇f + Jᵀλ − z_l + z_u = 0` — POUNCE's
+    // `finalize_solution` convention — in the *original* variable space,
+    // not with zeros.
+    let on = solve(true);
+    let c = &on.captured;
+    let mut grad = [0.0; 4];
+    Fixture::grad_f(&c.x, &mut grad);
+    let jac = jac_dense(&c.x);
+    for j in 0..4 {
+        let mut resid = grad[j] - c.z_l[j] + c.z_u[j];
+        for (r, row) in jac.iter().enumerate() {
+            resid += row[j] * c.lambda[r];
+        }
+        assert!(
+            resid.abs() < 1e-6,
+            "stationarity at column {j} = {resid}; λ = {:?}",
+            c.lambda
+        );
+    }
+    assert!(
+        c.lambda[0].abs() > 1e-8 || c.lambda[1].abs() > 1e-8,
+        "the consumed rows came back with zero multipliers: {:?}",
+        c.lambda
+    );
+}
+
+#[test]
+fn duals_match_the_bare_solve() {
+    let on = solve(true);
+    let off = solve(false);
+    for r in 0..3 {
+        assert!(
+            (on.captured.lambda[r] - off.captured.lambda[r]).abs() < 1e-5,
+            "λ[{r}] diverged: reduced={} full={}",
+            on.captured.lambda[r],
+            off.captured.lambda[r]
+        );
+    }
+}

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1222,9 +1222,38 @@ pub fn main() -> ExitCode {
     } else {
         None
     };
-    let post_presolve: Rc<RefCell<dyn TNLP>> = match &presolve_handle {
-        Some(p) => Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
-        None => Rc::clone(&inner_tnlp),
+    // Phase 6 (#487) stacks on top: it is the one pass that removes
+    // *columns*, so it must be the outermost layer, and it is the layer the
+    // `.sol` / JSON writers below read the full-space solution back out of.
+    let elim_handle = match (&presolve_handle, presolve_opts.linear_eq_reduction) {
+        (Some(p), true) => {
+            let e = Rc::new(RefCell::new(pounce_presolve::LinearEqElimTnlp::new(
+                Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
+                presolve_opts,
+            )));
+            // Force the lazy init so the summary below reports real numbers.
+            let _ = e.borrow_mut().get_nlp_info();
+            if !json_dbg {
+                let h = e.borrow();
+                let r = h.report();
+                println!(
+                    "Presolve linear-equality reduction: eliminated {} columns \
+                     ({} pinned, {} aggregated), dropped {} rows ({} redundant)",
+                    h.n_eliminated_vars(),
+                    r.n_constant_vars,
+                    r.n_aggregated_vars,
+                    h.n_eliminated_rows(),
+                    r.n_redundant_rows,
+                );
+            }
+            Some(e)
+        }
+        _ => None,
+    };
+    let post_presolve: Rc<RefCell<dyn TNLP>> = match (&elim_handle, &presolve_handle) {
+        (Some(e), _) => Rc::clone(e) as Rc<RefCell<dyn TNLP>>,
+        (None, Some(p)) => Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
+        (None, None) => Rc::clone(&inner_tnlp),
     };
 
     // The CLI owns its explicit wrapper so `.nl` input can supply an
@@ -1465,15 +1494,46 @@ pub fn main() -> ExitCode {
     // mis-aligns or is rejected. `PresolveTnlp::finalize_solution` already
     // lifted the duals back to the original row order *and* recovered
     // multipliers for the dropped rows; swap that full-length vector in.
+    // Phase 6 (#487) removes columns too, so with it active every capture
+    // taken outside the wrappers — `on_converged`, the `CountingTnlp`
+    // fallback, the bound-multiplier suffixes — is in the reduced variable
+    // space as well, and short in both directions.
+    let elim_reduced = elim_handle
+        .as_ref()
+        .map(|e| {
+            let h = e.borrow();
+            h.n_eliminated_vars() > 0 || h.n_eliminated_rows() > 0
+        })
+        .unwrap_or(false);
     if let Some(p) = &presolve_handle {
-        let lifted = if p.borrow().n_dropped_rows() > 0 {
-            p.borrow().finalized_full_solution().map(|(_x, lam)| lam)
+        let lifted = if p.borrow().n_dropped_rows() > 0 || elim_reduced {
+            p.borrow().finalized_full_solution()
         } else {
             None
         };
-        if let Some(lam_full) = lifted {
-            if let Some((_x, lambda)) = nominal_capture.borrow_mut().as_mut() {
+        if let Some((x_full, lam_full)) = lifted {
+            if let Some((x, lambda)) = nominal_capture.borrow_mut().as_mut() {
                 *lambda = lam_full;
+                if elim_reduced {
+                    *x = x_full;
+                }
+            }
+        }
+    }
+    // Bound multipliers are per *variable*, so only the column reduction can
+    // shorten them. Swap in the wrapper's full-space pair when — and only
+    // when — the captured one is the wrong length; leaving a correctly-sized
+    // capture alone keeps the scaling path that produced it untouched.
+    if elim_reduced {
+        if let Some(full) = elim_handle
+            .as_ref()
+            .and_then(|e| e.borrow().finalized_full_solution().cloned())
+        {
+            if let Some((z_l, z_u)) = bound_mult_capture.borrow_mut().as_mut() {
+                if z_l.len() != full.z_l.len() {
+                    *z_l = full.z_l;
+                    *z_u = full.z_u;
+                }
             }
         }
     }

--- a/crates/pounce-cli/tests/fixtures/linear_eq_aggregation.nl
+++ b/crates/pounce-cli/tests/fixtures/linear_eq_aggregation.nl
@@ -1,0 +1,55 @@
+g3 1 1 0	# problem linear_eq_aggregation
+ 3 2 1 0 2 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 2 1 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+C1
+o0
+o5
+v1
+n2
+o5
+v0
+n2
+O0 0
+o0
+o5
+o0
+v2
+n-1
+n2
+o5
+o0
+v0
+n-3
+n2
+x3
+0 1.0
+1 0.5
+2 1.0
+r
+4 0.0
+4 2.0
+b
+0 0 10
+0 -10 10
+0 -10 10
+k2
+1
+3
+J0 2
+1 -2
+2 1
+J1 2
+0 0
+1 0
+G0 2
+0 0
+2 0

--- a/crates/pounce-cli/tests/linear_eq_reduction.rs
+++ b/crates/pounce-cli/tests/linear_eq_reduction.rs
@@ -1,0 +1,131 @@
+//! `presolve_linear_eq_reduction` end to end through the `.nl` path
+//! (issue #487).
+//!
+//! The fixture is `min (x0−1)² + (x2−3)²` subject to `x0 − 2·x1 = 0` and
+//! `x1² + x2² = 2`, over `x2 ∈ [0, 10]`, `x0, x1 ∈ [−10, 10]`. The first
+//! row is a free/free two-variable linear equality — no bound pins either
+//! column — so it is exactly the shape the reduction exists for, and one
+//! column plus one row must disappear.
+//!
+//! What is actually at stake here is not the reduction but the *reporting*.
+//! AMPL and Pyomo read the `.sol` primal and dual blocks positionally
+//! against the originating `.nl`, so a solver that quietly hands back a
+//! shorter vector produces silently misattributed values rather than an
+//! error. Both blocks must come back at full length, in the original
+//! order, with the eliminated row's multiplier recovered rather than
+//! zeroed.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+struct Run {
+    stdout: String,
+    /// The `.sol` value block, in `.nl` order: duals first, then primals.
+    values: Vec<f64>,
+}
+
+fn run(tag: &str, opts: &[&str]) -> Run {
+    let dir = std::env::temp_dir().join(format!("pounce_lin_eq_reduction_{tag}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/linear_eq_aggregation.nl");
+    let nl = dir.join("m.nl");
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+
+    let mut cmd = Command::new(pounce_exe());
+    cmd.current_dir(&dir).arg("m").arg("-AMPL");
+    for o in opts {
+        cmd.arg(o);
+    }
+    let out = cmd.output().expect("run pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let sol = std::fs::read_to_string(dir.join("m.sol")).expect("read .sol");
+
+    // Everything numeric before `objno` is the `Options` preamble followed
+    // by the dual block then the primal block. The fixture has 2 rows and
+    // 3 columns, so the trailing five entries are the ones under test.
+    let numeric: Vec<f64> = sol
+        .lines()
+        .take_while(|l| !l.starts_with("objno"))
+        .filter_map(|l| l.trim().parse::<f64>().ok())
+        .collect();
+    assert!(
+        numeric.len() >= 5,
+        "expected 2 duals + 3 primals in the .sol body, got {numeric:?}\n{sol}"
+    );
+    let values = numeric[numeric.len() - 5..].to_vec();
+    Run { stdout, values }
+}
+
+#[test]
+fn the_reduction_reports_what_it_removed() {
+    let on = run("on", &["presolve=yes", "presolve_linear_eq_reduction=yes"]);
+    assert!(
+        on.stdout.contains("eliminated 1 columns"),
+        "no reduction summary on stdout:\n{}",
+        on.stdout
+    );
+    assert!(
+        on.stdout.contains("Optimal Solution Found"),
+        "{}",
+        on.stdout
+    );
+}
+
+#[test]
+fn the_option_is_off_by_default() {
+    let on = run("default", &["presolve=yes"]);
+    assert!(
+        !on.stdout.contains("linear-equality reduction"),
+        "the reduction ran without being asked for:\n{}",
+        on.stdout
+    );
+}
+
+#[test]
+fn the_sol_file_keeps_the_original_shape_and_values() {
+    let base = run("base", &[]);
+    let reduced = run(
+        "reduced",
+        &["presolve=yes", "presolve_linear_eq_reduction=yes"],
+    );
+
+    assert_eq!(
+        base.values.len(),
+        reduced.values.len(),
+        "the .sol body changed length: base={:?} reduced={:?}",
+        base.values,
+        reduced.values
+    );
+    for (k, (b, r)) in base.values.iter().zip(reduced.values.iter()).enumerate() {
+        assert!(
+            (b - r).abs() < 1e-6,
+            ".sol entry {k} diverged: base={b} reduced={r}"
+        );
+    }
+
+    // Entries 0..2 are the duals. The first row is the one the reduction
+    // consumed; a zero there would mean the recovery silently gave up.
+    assert!(
+        reduced.values[0].abs() > 1e-6,
+        "the consumed row came back with a zero multiplier: {:?}",
+        reduced.values
+    );
+
+    // Entries 2..5 are the primals in `.nl` order (v0 = x2, v1 = x1,
+    // v2 = x0), so the consumed row `x0 = 2·x1` must hold among them.
+    let (x2, x1, x0) = (reduced.values[2], reduced.values[3], reduced.values[4]);
+    assert!(
+        (x0 - 2.0 * x1).abs() < 1e-9,
+        "the eliminated row is violated in the reported point: {x0} != 2 * {x1}"
+    );
+    assert!(
+        (x1 * x1 + x2 * x2 - 2.0).abs() < 1e-6,
+        "the surviving row is violated: x1={x1} x2={x2}"
+    );
+}

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -34,6 +34,15 @@
 //!   user-supplied constraint metadata and scaling through the row
 //!   reduction on the way in, and expands outer→inner on the way out
 //!   in `finalize_metadata`.
+//! * **Phase 6** — linear-equality variable elimination
+//!   (`presolve_linear_eq_reduction`, issue #487). The only phase that
+//!   removes *columns*: singleton and two-variable linear equality rows
+//!   determine variables, which are substituted away and recovered at
+//!   `finalize_solution`. It lives in its own wrapper
+//!   ([`linear_eq_elim::LinearEqElimTnlp`]) stacked **outside**
+//!   [`PresolveTnlp`], so Phases 0–5 keep working in the variable space
+//!   they were written against, and it is the outer layer that
+//!   re-presents the reduced one. Off by default.
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
@@ -63,6 +72,8 @@ pub mod fbbt;
 pub mod incidence;
 pub mod inequality_projection;
 pub mod licq;
+pub mod linear_eq_elim;
+pub mod linear_eq_plan;
 pub mod matching;
 pub mod options;
 pub mod reduction_frame;
@@ -81,6 +92,10 @@ pub use diagnostics::{AuxiliaryPreprocessingDiagnostics, AuxiliaryRejectionReaso
 pub use dulmage_mendelsohn::{DMPart, DulmageMendelsohnPartition};
 pub use incidence::{EqualityIncidence, InequalityIncidence, ProbeView};
 pub use licq::{EqRow, LicqVerdict, licq_check};
+pub use linear_eq_elim::{FullSolution, LinearEqElimTnlp};
+pub use linear_eq_plan::{
+    ElimStep, EliminationPlan, LinearEqElimReport, PlanConfig, PlanInput, VarRecovery, build_plan,
+};
 pub use options::{AuxiliaryCouplingPolicy, LicqAction, PresolveOptions, register_options};
 pub use reduction_frame::{ReductionFrame, ReductionStack};
 pub use redundant::find_redundant_rows;
@@ -107,6 +122,25 @@ impl From<SolverException> for PresolveError {
     }
 }
 
+/// Stack Phase 6 on top of an already-built presolve wrapper, when the
+/// option asks for it.
+///
+/// Phase 6 goes *outside*, not inside: it is the one pass that changes the
+/// variable count, and Phases 0–5 are written against a fixed column
+/// space. Putting it on top also means it sees the row set Phase 2 already
+/// reduced, and its `finalize_solution` hands a full-length `x` back down
+/// before `PresolveTnlp` lifts the row duals — so each layer only has to
+/// undo its own reduction.
+fn stack_linear_eq_elim(
+    wrapped: Rc<RefCell<dyn TNLP>>,
+    opts: PresolveOptions,
+) -> Rc<RefCell<dyn TNLP>> {
+    if !opts.linear_eq_reduction {
+        return wrapped;
+    }
+    Rc::new(RefCell::new(LinearEqElimTnlp::new(wrapped, opts)))
+}
+
 /// Top-level entry: returns a TNLP wrapping `inner` with whatever
 /// presolve passes the option table has enabled. When the master
 /// switch is off, returns `inner` unchanged.
@@ -117,7 +151,8 @@ pub fn wrap_with_presolve(
     if !opts.enabled || inner.borrow().is_presolve_wrapper() {
         return Ok(inner);
     }
-    Ok(Rc::new(RefCell::new(PresolveTnlp::new(inner, opts))))
+    let wrapped: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(PresolveTnlp::new(inner, opts)));
+    Ok(stack_linear_eq_elim(wrapped, opts))
 }
 
 /// Same as [`wrap_with_presolve`] but also installs an
@@ -134,9 +169,10 @@ pub fn wrap_with_presolve_provider(
     if !opts.enabled || inner.borrow().is_presolve_wrapper() {
         return Ok(inner);
     }
-    Ok(Rc::new(RefCell::new(
+    let wrapped: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(
         PresolveTnlp::with_expression_provider(inner, expr_provider, opts),
-    )))
+    ));
+    Ok(stack_linear_eq_elim(wrapped, opts))
 }
 
 /// Convenience: read the `presolve_*` keys out of an `OptionsList`

--- a/crates/pounce-presolve/src/linear_eq_elim.rs
+++ b/crates/pounce-presolve/src/linear_eq_elim.rs
@@ -1,0 +1,1536 @@
+//! Phase 6 — the TNLP wrapper that applies a [`EliminationPlan`] (issue
+//! #487).
+//!
+//! [`crate::linear_eq_plan`] decides *which* variables the linear equality
+//! rows determine; this module re-presents the problem with those columns
+//! and rows gone, and puts the solution back together afterwards.
+//!
+//! # The transform
+//!
+//! The plan is an affine map `x = A·y + c`, where `A` has exactly one
+//! non-zero per row (each eliminated column is a multiple of a **single**
+//! surviving column, or a constant). Everything else follows from the
+//! chain rule:
+//!
+//! ```text
+//!   f_red(y)  = f(A y + c)
+//!   ∇f_red    = Aᵀ ∇f                     (scaled gather onto columns)
+//!   g_red(y)  = g(A y + c) at kept rows
+//!   J_red     = (J A) at kept rows        (scaled gather onto columns)
+//!   ∇²L_red   = Aᵀ ∇²L A                  (scaled gather onto both axes)
+//! ```
+//!
+//! Because `A` has one non-zero per row, none of these is a sparse
+//! matrix product: each reduced non-zero is a fixed, precomputed sum of
+//! scaled inner non-zeros, so an evaluation is one inner call plus a
+//! linear pass over a gather list.
+//!
+//! # Postsolve
+//!
+//! `finalize_solution` lifts `x` back to full space and recovers a
+//! multiplier for every consumed row. The recovery is a **triangular**
+//! sweep, not a factorization, and that is worth spelling out because it
+//! is the reason this pass scales.
+//!
+//! Write the dropped rows `D` and kept rows `K`. Full-space stationarity,
+//! in the convention POUNCE hands to `finalize_solution` (Ipopt's: the
+//! Lagrangian is `f + λᵀg`), is
+//! `∇f + J_Kᵀλ_K + J_Dᵀλ_D − z_l + z_u = 0`. Restricted to the eliminated
+//! columns (where `z_l = z_u = 0`, see the caveat below) that is a square
+//! system `J_D[:,e]ᵀ λ_D = −(∇f_e + J_K[:,e]ᵀ λ_K)` — which, taken all at
+//! once, is a sparse solve nobody wants inside presolve.
+//!
+//! Taken one elimination at a time in **reverse** order it is triangular
+//! instead. Step `t` consumed row `r_t` to determine variable `v_t`; every
+//! other row of the problem-as-it-stood-then survives step `t`, so
+//! stationarity at column `v_t` in that intermediate problem involves
+//! exactly one unknown multiplier, `λ_{r_t}` — every other dropped row in
+//! it is `r_{t+1}..r_k`, already recovered by the time the reverse sweep
+//! reaches `t`. The pivot is the step's own `pivot` (non-zero by
+//! construction), and the intermediate problem's gradient at `v_t` is the
+//! sum of the full-space stationarity residual over `v_t`'s cluster,
+//! weighted by each member's coefficient — which is just a subtree sum
+//! over the elimination forest.
+//!
+//! Rows dropped as `0 = 0` are linearly dependent on the rest and get
+//! `λ = 0`; that is a valid choice, not an approximation, because their
+//! Jacobian row is annihilated by `A` and so contributes nothing to
+//! stationarity in either space.
+//!
+//! # Dual-attribution caveat
+//!
+//! The recovery assumes an eliminated variable is interior to its own
+//! bounds at the optimum, so `z_l = z_u = 0` there — the same assumption
+//! [`crate::reduction_frame`] documents. When an eliminated variable's
+//! bound *is* active, that bound was transferred onto its survivor during
+//! planning, so the IPM reports the dual on the **survivor's** bound
+//! multiplier instead. The primal point, the objective, and full-space
+//! stationarity are all unaffected; only the attribution of that one dual
+//! differs from a no-presolve solve. This is the same class of caveat as
+//! the Phase-2 note in [`crate`]'s module docs (issue M24).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_common::types::{Index, Number};
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, InfeasibilityProof, IpoptCq, IpoptData, IterStats, Linearity, MetaData,
+    NlpInfo, ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
+};
+
+use crate::linear_eq_plan::{
+    EliminationPlan, LinearEqElimReport, PlanConfig, PlanInput, VarRecovery, build_plan,
+};
+use crate::options::PresolveOptions;
+
+/// A gather list: `out[k] = Σ scale · inner_values[src]` over the terms in
+/// `terms[start[k]..start[k+1]]`.
+#[derive(Debug, Default, Clone)]
+struct Gather {
+    start: Vec<usize>,
+    terms: Vec<(usize, Number)>,
+}
+
+impl Gather {
+    fn len(&self) -> usize {
+        self.start.len().saturating_sub(1)
+    }
+
+    fn apply(&self, src: &[Number], out: &mut [Number]) {
+        for (k, slot) in out.iter_mut().enumerate().take(self.len()) {
+            let mut acc = 0.0;
+            for &(i, s) in &self.terms[self.start[k]..self.start[k + 1]] {
+                acc += s * src[i];
+            }
+            *slot = acc;
+        }
+    }
+}
+
+/// Build a [`Gather`] from unsorted `(slot, source, scale)` triples,
+/// returning the distinct slots in ascending order alongside it.
+fn gather_from(mut triples: Vec<((Index, Index), usize, Number)>) -> (Vec<(Index, Index)>, Gather) {
+    triples.sort_by(|a, b| a.0.cmp(&b.0));
+    let mut slots: Vec<(Index, Index)> = Vec::new();
+    let mut g = Gather {
+        start: vec![0],
+        terms: Vec::with_capacity(triples.len()),
+    };
+    for (slot, src, scale) in triples {
+        if slots.last() != Some(&slot) {
+            slots.push(slot);
+            g.start.push(g.terms.len());
+        }
+        g.terms.push((src, scale));
+        let last = g.start.len() - 1;
+        g.start[last] = g.terms.len();
+    }
+    (slots, g)
+}
+
+struct ElimState {
+    info_inner: NlpInfo,
+    info_outer: NlpInfo,
+    plan: EliminationPlan,
+    /// The plan removes nothing, so every method forwards verbatim. This
+    /// is not just an optimisation: it is also the state the wrapper falls
+    /// into when the option is off or the inner TNLP cannot supply what
+    /// the transform needs, and forwarding is the only behaviour that is
+    /// certainly right there.
+    passthrough: bool,
+    /// Reduced constraint bounds, aligned with `plan.rows_kept`.
+    g_l_red: Vec<Number>,
+    g_u_red: Vec<Number>,
+    /// `col_of[i]` is where full column `i` lands: the reduced column and
+    /// the scale, or `None` when the variable became a constant.
+    col_of: Vec<Option<(usize, Number)>>,
+    /// `∇f_red = Aᵀ ∇f`, as a gather over full-space gradient entries.
+    grad_gather: Gather,
+    jac_irow_outer: Vec<Index>,
+    jac_jcol_outer: Vec<Index>,
+    jac_gather: Gather,
+    h_irow_outer: Vec<Index>,
+    h_jcol_outer: Vec<Index>,
+    h_gather: Gather,
+    /// Full-space Jacobian structure, kept for the postsolve multiplier
+    /// recovery (which reads `J` by row).
+    jac_irow_inner: Vec<Index>,
+    jac_jcol_inner: Vec<Index>,
+    /// Reduced nonlinear-variable list, `None` until first asked for.
+    nonlinear_vars: Option<Vec<Index>>,
+
+    scratch_x: Vec<Number>,
+    scratch_g: Vec<Number>,
+    scratch_grad: Vec<Number>,
+    scratch_jac: Vec<Number>,
+    scratch_h: Vec<Number>,
+    scratch_lambda: Vec<Number>,
+}
+
+/// Full-space solution quantities captured at `finalize_solution`.
+#[derive(Debug, Clone, Default)]
+pub struct FullSolution {
+    pub x: Vec<Number>,
+    pub lambda: Vec<Number>,
+    pub z_l: Vec<Number>,
+    pub z_u: Vec<Number>,
+}
+
+/// TNLP wrapper that re-presents its inner problem with the columns and
+/// rows the linear equality system determines removed.
+///
+/// Sits **outside** [`crate::PresolveTnlp`] so the phases below it keep
+/// operating on the shape they were written against; this layer is the
+/// only one that changes the variable count.
+pub struct LinearEqElimTnlp {
+    inner: Rc<RefCell<dyn TNLP>>,
+    opts: PresolveOptions,
+    state: Option<ElimState>,
+    finalized: Option<FullSolution>,
+}
+
+impl LinearEqElimTnlp {
+    pub fn new(inner: Rc<RefCell<dyn TNLP>>, opts: PresolveOptions) -> Self {
+        Self {
+            inner,
+            opts,
+            state: None,
+            finalized: None,
+        }
+    }
+
+    /// What the pass achieved. Zeroed until init has run.
+    pub fn report(&self) -> LinearEqElimReport {
+        self.state
+            .as_ref()
+            .map(|s| s.plan.report)
+            .unwrap_or_default()
+    }
+
+    /// Number of variables removed from the problem the solver sees.
+    pub fn n_eliminated_vars(&self) -> usize {
+        self.state
+            .as_ref()
+            .map(|s| s.plan.n_full - s.plan.n_reduced_vars())
+            .unwrap_or(0)
+    }
+
+    /// Number of rows removed by this pass.
+    pub fn n_eliminated_rows(&self) -> usize {
+        self.state
+            .as_ref()
+            .map(|s| s.plan.m_full - s.plan.n_reduced_rows())
+            .unwrap_or(0)
+    }
+
+    /// The full-space `(x, λ, z_l, z_u)` this wrapper handed down at the
+    /// last `finalize_solution`. `None` until a solve finalizes.
+    ///
+    /// Frontends that write a solution file positionally against the
+    /// original model — the CLI's `.sol` writer, the JSON report — must
+    /// prefer this over anything captured outside the wrapper, which is in
+    /// the reduced space and therefore the wrong length.
+    pub fn finalized_full_solution(&self) -> Option<&FullSolution> {
+        self.finalized.as_ref()
+    }
+
+    fn ensure_init(&mut self) -> Option<&ElimState> {
+        if self.state.is_some() {
+            return self.state.as_ref();
+        }
+        let info_inner = self.inner.borrow_mut().get_nlp_info()?;
+        let n = info_inner.n.max(0) as usize;
+        let m = info_inner.m.max(0) as usize;
+        let nnz_jac = info_inner.nnz_jac_g.max(0) as usize;
+        let nnz_h = info_inner.nnz_h_lag.max(0) as usize;
+        let one_based = matches!(info_inner.index_style, IndexStyle::Fortran);
+
+        let mut x_l = vec![0.0; n];
+        let mut x_u = vec![0.0; n];
+        let mut g_l = vec![0.0; m];
+        let mut g_u = vec![0.0; m];
+        if !self.inner.borrow_mut().get_bounds_info(BoundsInfo {
+            x_l: &mut x_l,
+            x_u: &mut x_u,
+            g_l: &mut g_l,
+            g_u: &mut g_u,
+        }) {
+            return None;
+        }
+
+        let mut jac_irow = vec![0 as Index; nnz_jac];
+        let mut jac_jcol = vec![0 as Index; nnz_jac];
+        if nnz_jac > 0
+            && !self.inner.borrow_mut().eval_jac_g(
+                None,
+                false,
+                SparsityRequest::Structure {
+                    irow: &mut jac_irow,
+                    jcol: &mut jac_jcol,
+                },
+            )
+        {
+            return None;
+        }
+
+        // The Hessian structure is needed up front because `nnz_h_lag` is
+        // part of `get_nlp_info`. A TNLP that declines it (quasi-Newton
+        // bridges, callback shims) simply does not get the reduction — the
+        // alternative would be publishing a variable count the Hessian
+        // transform cannot honour.
+        let mut h_irow = vec![0 as Index; nnz_h];
+        let mut h_jcol = vec![0 as Index; nnz_h];
+        if nnz_h > 0
+            && !self.inner.borrow_mut().eval_h(
+                None,
+                false,
+                1.0,
+                None,
+                false,
+                SparsityRequest::Structure {
+                    irow: &mut h_irow,
+                    jcol: &mut h_jcol,
+                },
+            )
+        {
+            tracing::warn!(
+                target: "pounce::presolve",
+                "linear-equality variable elimination is off for this solve: the \
+                 inner TNLP declined to publish its Hessian structure."
+            );
+            self.install_passthrough(info_inner, LinearEqElimReport::default());
+            return self.state.as_ref();
+        }
+
+        // The option is checked here, not only where the wrapper is
+        // stacked, so a caller that constructs it directly still honours
+        // `presolve_linear_eq_reduction=no`.
+        if !self.opts.linear_eq_reduction {
+            self.install_passthrough(info_inner, LinearEqElimReport::default());
+            return self.state.as_ref();
+        }
+
+        // Row linearity, and a probe point at which a linear row's Jacobian
+        // values are its exact coefficients.
+        let mut linearity = vec![Linearity::NonLinear; m];
+        let have_linearity = m == 0
+            || self
+                .inner
+                .borrow_mut()
+                .get_constraints_linearity(&mut linearity);
+        if !have_linearity {
+            // Without linearity tags nothing is eligible; skip the probe work.
+            self.install_passthrough(info_inner, LinearEqElimReport::default());
+            return self.state.as_ref();
+        }
+
+        let mut x_probe = vec![0.0; n];
+        let mut z_l_probe = vec![0.0; n];
+        let mut z_u_probe = vec![0.0; n];
+        let mut lambda_probe = vec![0.0; m];
+        if !self.inner.borrow_mut().get_starting_point(StartingPoint {
+            init_x: true,
+            x: &mut x_probe,
+            init_z: false,
+            z_l: &mut z_l_probe,
+            z_u: &mut z_u_probe,
+            init_lambda: false,
+            lambda: &mut lambda_probe,
+        }) {
+            return None;
+        }
+        let mut jac_values = vec![0.0; nnz_jac];
+        if nnz_jac > 0
+            && !self.inner.borrow_mut().eval_jac_g(
+                Some(&x_probe),
+                true,
+                SparsityRequest::Values {
+                    values: &mut jac_values,
+                },
+            )
+        {
+            return None;
+        }
+        let mut g_probe = vec![0.0; m];
+        if m > 0 && !self.inner.borrow_mut().eval_g(&x_probe, true, &mut g_probe) {
+            return None;
+        }
+
+        let mut rows: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m];
+        for k in 0..nnz_jac {
+            let (i, j) = decode(jac_irow[k], jac_jcol[k], one_based);
+            if i < m && j < n {
+                rows[i].push((j, jac_values[k]));
+            }
+        }
+        // `g_r(x) = Σ a_j x_j + c` for a linear row, so read `c` off the
+        // probe. Assuming `c = 0` would silently shift every row whose
+        // model text keeps a constant on the left.
+        let row_const: Vec<Number> = (0..m)
+            .map(|r| {
+                let lin: Number = rows[r].iter().map(|&(j, a)| a * x_probe[j]).sum();
+                g_probe[r] - lin
+            })
+            .collect();
+        let eligible: Vec<bool> = (0..m)
+            .map(|r| matches!(linearity[r], Linearity::Linear))
+            .collect();
+
+        let cfg = PlanConfig {
+            feas_tol: self.opts.certify_tol,
+            max_passes: (self.opts.max_passes.max(1) as usize).max(20),
+            ..PlanConfig::default()
+        };
+        let plan = build_plan(
+            &PlanInput {
+                n_vars: n,
+                n_rows: m,
+                rows: &rows,
+                row_const: &row_const,
+                g_l: &g_l,
+                g_u: &g_u,
+                eligible: &eligible,
+                x_l: &x_l,
+                x_u: &x_u,
+            },
+            &cfg,
+        );
+        if plan.report.infeasible {
+            tracing::warn!(
+                target: "pounce::presolve",
+                "linear-equality elimination found the equality system contradictory; \
+                 standing down and handing the model to the solver untouched."
+            );
+        }
+        if plan.report.pass_cap_hit {
+            tracing::info!(
+                target: "pounce::presolve",
+                passes = plan.report.passes,
+                "linear-equality elimination hit its sweep cap with candidate rows \
+                 still open; the reduction is valid but not maximal."
+            );
+        }
+
+        self.install(
+            info_inner, plan, g_l, g_u, jac_irow, jac_jcol, h_irow, h_jcol,
+        );
+        self.state.as_ref()
+    }
+
+    /// Install the do-nothing state: dimensions unchanged, every call
+    /// forwarded.
+    fn install_passthrough(&mut self, info_inner: NlpInfo, report: LinearEqElimReport) {
+        let n = info_inner.n.max(0) as usize;
+        let m = info_inner.m.max(0) as usize;
+        let mut plan = EliminationPlan::identity(n, m, &vec![0.0; n], &vec![0.0; n]);
+        plan.report = report;
+        self.state = Some(ElimState {
+            info_inner,
+            info_outer: info_inner,
+            plan,
+            passthrough: true,
+            g_l_red: Vec::new(),
+            g_u_red: Vec::new(),
+            col_of: Vec::new(),
+            grad_gather: Gather::default(),
+            jac_irow_outer: Vec::new(),
+            jac_jcol_outer: Vec::new(),
+            jac_gather: Gather::default(),
+            h_irow_outer: Vec::new(),
+            h_jcol_outer: Vec::new(),
+            h_gather: Gather::default(),
+            jac_irow_inner: Vec::new(),
+            jac_jcol_inner: Vec::new(),
+            nonlinear_vars: None,
+            scratch_x: Vec::new(),
+            scratch_g: Vec::new(),
+            scratch_grad: Vec::new(),
+            scratch_jac: Vec::new(),
+            scratch_h: Vec::new(),
+            scratch_lambda: Vec::new(),
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn install(
+        &mut self,
+        info_inner: NlpInfo,
+        plan: EliminationPlan,
+        g_l: Vec<Number>,
+        g_u: Vec<Number>,
+        jac_irow: Vec<Index>,
+        jac_jcol: Vec<Index>,
+        h_irow: Vec<Index>,
+        h_jcol: Vec<Index>,
+    ) {
+        if plan.is_identity() {
+            self.install_passthrough(info_inner, plan.report);
+            return;
+        }
+        let n = plan.n_full;
+        let m = plan.m_full;
+        let one_based = matches!(info_inner.index_style, IndexStyle::Fortran);
+        let bump = |v: usize| -> Index {
+            if one_based {
+                v as Index + 1
+            } else {
+                v as Index
+            }
+        };
+
+        let col_of: Vec<Option<(usize, Number)>> = plan
+            .recovery
+            .iter()
+            .map(|rec| match *rec {
+                VarRecovery::Kept(j) => Some((j, 1.0)),
+                VarRecovery::Constant(_) => None,
+                VarRecovery::Affine { rep, coeff, .. } => match plan.recovery[rep] {
+                    VarRecovery::Kept(j) => Some((j, coeff)),
+                    // `build_plan` guarantees a representative survives; if
+                    // that ever breaks, drop the column rather than index a
+                    // slot that does not exist.
+                    _ => None,
+                },
+            })
+            .collect();
+
+        // ∇f_red = Aᵀ ∇f.
+        let mut grad_triples: Vec<((Index, Index), usize, Number)> = Vec::new();
+        for (i, slot) in col_of.iter().enumerate() {
+            if let Some((j, s)) = *slot {
+                grad_triples.push(((j as Index, 0), i, s));
+            }
+        }
+        let (_, grad_gather) = gather_from(grad_triples);
+
+        // Row renumbering.
+        let mut row_of = vec![usize::MAX; m];
+        for (red, &full) in plan.rows_kept.iter().enumerate() {
+            row_of[full] = red;
+        }
+
+        // J_red = (J A) restricted to kept rows.
+        let mut jac_triples: Vec<((Index, Index), usize, Number)> = Vec::new();
+        for k in 0..jac_irow.len() {
+            let (i, j) = decode(jac_irow[k], jac_jcol[k], one_based);
+            if i >= m || j >= n || !plan.row_kept[i] {
+                continue;
+            }
+            if let Some((col, s)) = col_of[j] {
+                jac_triples.push(((row_of[i] as Index, col as Index), k, s));
+            }
+        }
+        let (jac_slots, jac_gather) = gather_from(jac_triples);
+        let jac_irow_outer: Vec<Index> = jac_slots.iter().map(|s| bump(s.0 as usize)).collect();
+        let jac_jcol_outer: Vec<Index> = jac_slots.iter().map(|s| bump(s.1 as usize)).collect();
+
+        // ∇²L_red = Aᵀ ∇²L A. The inner matrix is stored as one triangle;
+        // an off-diagonal entry (r, c) therefore stands for the symmetric
+        // pair, and when both of its columns land on the *same* reduced
+        // column the two orderings both hit the diagonal — hence the 2.
+        let h_upper = h_irow.iter().zip(h_jcol.iter()).any(|(&r, &c)| r < c)
+            && !h_irow.iter().zip(h_jcol.iter()).any(|(&r, &c)| r > c);
+        let mut h_triples: Vec<((Index, Index), usize, Number)> = Vec::new();
+        for k in 0..h_irow.len() {
+            let (r, c) = decode(h_irow[k], h_jcol[k], one_based);
+            if r >= n || c >= n {
+                continue;
+            }
+            let (Some((pr, sr)), Some((pc, sc))) = (col_of[r], col_of[c]) else {
+                continue;
+            };
+            let mut scale = sr * sc;
+            if r != c && pr == pc {
+                scale *= 2.0;
+            }
+            let (hi, lo) = if pr >= pc { (pr, pc) } else { (pc, pr) };
+            let slot = if h_upper {
+                (lo as Index, hi as Index)
+            } else {
+                (hi as Index, lo as Index)
+            };
+            h_triples.push((slot, k, scale));
+        }
+        let (h_slots, h_gather) = gather_from(h_triples);
+        let h_irow_outer: Vec<Index> = h_slots.iter().map(|s| bump(s.0 as usize)).collect();
+        let h_jcol_outer: Vec<Index> = h_slots.iter().map(|s| bump(s.1 as usize)).collect();
+
+        let g_l_red: Vec<Number> = plan.rows_kept.iter().map(|&r| g_l[r]).collect();
+        let g_u_red: Vec<Number> = plan.rows_kept.iter().map(|&r| g_u[r]).collect();
+
+        let info_outer = NlpInfo {
+            n: plan.n_reduced_vars() as Index,
+            m: plan.n_reduced_rows() as Index,
+            nnz_jac_g: jac_irow_outer.len() as Index,
+            nnz_h_lag: h_irow_outer.len() as Index,
+            index_style: info_inner.index_style,
+        };
+
+        self.state = Some(ElimState {
+            info_inner,
+            info_outer,
+            plan,
+            passthrough: false,
+            g_l_red,
+            g_u_red,
+            col_of,
+            grad_gather,
+            jac_irow_outer,
+            jac_jcol_outer,
+            jac_gather,
+            h_irow_outer,
+            h_jcol_outer,
+            h_gather,
+            jac_irow_inner: jac_irow,
+            jac_jcol_inner: jac_jcol,
+            nonlinear_vars: None,
+            scratch_x: vec![0.0; n],
+            scratch_g: vec![0.0; m],
+            scratch_grad: vec![0.0; n],
+            scratch_jac: vec![0.0; info_inner.nnz_jac_g.max(0) as usize],
+            scratch_h: vec![0.0; info_inner.nnz_h_lag.max(0) as usize],
+            scratch_lambda: vec![0.0; m],
+        });
+    }
+}
+
+fn decode(irow: Index, jcol: Index, one_based: bool) -> (usize, usize) {
+    if one_based {
+        (
+            (irow as isize - 1).max(0) as usize,
+            (jcol as isize - 1).max(0) as usize,
+        )
+    } else {
+        (irow.max(0) as usize, jcol.max(0) as usize)
+    }
+}
+
+/// Recover a multiplier for every row the plan consumed.
+///
+/// See the module docs for why a reverse sweep over the elimination steps
+/// is exact and triangular. `lambda_full` arrives with the kept rows filled
+/// in and zeros everywhere else, and leaves with the consumed rows filled
+/// in too. Rows dropped as `0 = 0` keep their zero.
+///
+/// Signs follow the convention `finalize_solution` uses, `∇f + Jᵀλ − z_l +
+/// z_u = 0`, so `resid` accumulates `+Jᵀλ` and each pivot solve carries the
+/// matching negation.
+fn recover_dropped_multipliers(
+    plan: &EliminationPlan,
+    grad_f: &[Number],
+    jac_irow: &[Index],
+    jac_jcol: &[Index],
+    jac_values: &[Number],
+    one_based: bool,
+    lambda_full: &mut [Number],
+) {
+    if plan.steps.is_empty() {
+        return;
+    }
+    let n = plan.n_full;
+    let m = plan.m_full;
+
+    // Row-wise view of J, so each reverse step can update the residual over
+    // just the row it resolved.
+    let mut row_entries: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m];
+    let mut resid = grad_f.to_vec();
+    for k in 0..jac_irow.len() {
+        let (i, j) = decode(jac_irow[k], jac_jcol[k], one_based);
+        if i >= m || j >= n {
+            continue;
+        }
+        resid[j] += jac_values[k] * lambda_full[i];
+        if !plan.row_kept[i] {
+            row_entries[i].push((j, jac_values[k]));
+        }
+    }
+
+    // Q[v] = Σ over v's subtree of (coefficient to v) · resid, built bottom
+    // up. A node's children are always eliminated before it is, so walking
+    // the steps forward completes every subtree in order.
+    let mut q = resid.clone();
+    for step in &plan.steps {
+        if let Some((parent, alpha)) = plan.parent[step.var] {
+            q[parent] += alpha * q[step.var];
+        }
+    }
+
+    for step in plan.steps.iter().rev() {
+        let lam = -q[step.var] / step.pivot;
+        if !lam.is_finite() {
+            continue;
+        }
+        lambda_full[step.row] = lam;
+        // Fold the newly-known multiplier into the residual, and carry the
+        // change up every affected ancestor chain so the remaining subtree
+        // sums stay exact.
+        for &(j, a) in &row_entries[step.row] {
+            let delta = lam * a;
+            resid[j] += delta;
+            let mut cur = j;
+            let mut coeff = delta;
+            q[cur] += coeff;
+            while let Some((parent, alpha)) = plan.parent[cur] {
+                coeff *= alpha;
+                q[parent] += coeff;
+                cur = parent;
+            }
+        }
+    }
+}
+
+// Every `.expect("inited")` below is guarded by the preceding
+// `ensure_init`, which is the only way `state` becomes `Some`.
+#[allow(clippy::expect_used)]
+impl TNLP for LinearEqElimTnlp {
+    fn is_presolve_wrapper(&self) -> bool {
+        true
+    }
+
+    fn presolve_infeasibility_proof(&self) -> Option<InfeasibilityProof> {
+        self.inner.borrow().presolve_infeasibility_proof()
+    }
+
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        let s = self.ensure_init()?;
+        Some(s.info_outer)
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        let Some(s) = self.ensure_init() else {
+            return false;
+        };
+        if s.passthrough {
+            return self.inner.borrow_mut().get_bounds_info(b);
+        }
+        b.x_l.copy_from_slice(&s.plan.x_l_red);
+        b.x_u.copy_from_slice(&s.plan.x_u_red);
+        b.g_l.copy_from_slice(&s.g_l_red);
+        b.g_u.copy_from_slice(&s.g_u_red);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        let Some(s) = self.ensure_init() else {
+            return false;
+        };
+        if s.passthrough {
+            return self.inner.borrow_mut().get_starting_point(sp);
+        }
+        let (n_in, m_in) = {
+            let s = self.state.as_ref().expect("inited");
+            (s.plan.n_full, s.plan.m_full)
+        };
+        let mut x_full = vec![0.0; n_in];
+        let mut z_l_full = vec![0.0; n_in];
+        let mut z_u_full = vec![0.0; n_in];
+        let mut lambda_full = vec![0.0; m_in];
+        if !self.inner.borrow_mut().get_starting_point(StartingPoint {
+            init_x: sp.init_x,
+            x: &mut x_full,
+            init_z: sp.init_z,
+            z_l: &mut z_l_full,
+            z_u: &mut z_u_full,
+            init_lambda: sp.init_lambda,
+            lambda: &mut lambda_full,
+        }) {
+            return false;
+        }
+        let s = self.state.as_ref().expect("inited");
+        for (red, &full) in s.plan.vars_kept.iter().enumerate() {
+            sp.x[red] = x_full[full];
+            sp.z_l[red] = z_l_full[full];
+            sp.z_u[red] = z_u_full[full];
+        }
+        for (red, &full) in s.plan.rows_kept.iter().enumerate() {
+            sp.lambda[red] = lambda_full[full];
+        }
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], new_x: bool) -> Option<Number> {
+        if self.ensure_init()?.passthrough {
+            return self.inner.borrow_mut().eval_f(x, new_x);
+        }
+        let s = self.state.as_mut().expect("inited");
+        s.plan.lift_x(x, &mut s.scratch_x);
+        self.inner.borrow_mut().eval_f(&s.scratch_x, new_x)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], new_x: bool, grad_f: &mut [Number]) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                return self.inner.borrow_mut().eval_grad_f(x, new_x, grad_f);
+            }
+            Some(_) => {}
+        }
+        let s = self.state.as_mut().expect("inited");
+        s.plan.lift_x(x, &mut s.scratch_x);
+        if !self
+            .inner
+            .borrow_mut()
+            .eval_grad_f(&s.scratch_x, new_x, &mut s.scratch_grad)
+        {
+            return false;
+        }
+        s.grad_gather.apply(&s.scratch_grad, grad_f);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], new_x: bool, g: &mut [Number]) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => return self.inner.borrow_mut().eval_g(x, new_x, g),
+            Some(_) => {}
+        }
+        let s = self.state.as_mut().expect("inited");
+        s.plan.lift_x(x, &mut s.scratch_x);
+        if !self
+            .inner
+            .borrow_mut()
+            .eval_g(&s.scratch_x, new_x, &mut s.scratch_g)
+        {
+            return false;
+        }
+        for (red, &full) in s.plan.rows_kept.iter().enumerate() {
+            g[red] = s.scratch_g[full];
+        }
+        true
+    }
+
+    fn eval_jac_g(&mut self, x: Option<&[Number]>, new_x: bool, mode: SparsityRequest<'_>) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                return self.inner.borrow_mut().eval_jac_g(x, new_x, mode);
+            }
+            Some(_) => {}
+        }
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let s = self.state.as_ref().expect("inited");
+                irow.copy_from_slice(&s.jac_irow_outer);
+                jcol.copy_from_slice(&s.jac_jcol_outer);
+                true
+            }
+            SparsityRequest::Values { values } => {
+                let s = self.state.as_mut().expect("inited");
+                let x_full = match x {
+                    Some(xr) => {
+                        s.plan.lift_x(xr, &mut s.scratch_x);
+                        Some(&s.scratch_x[..])
+                    }
+                    None => None,
+                };
+                if !self.inner.borrow_mut().eval_jac_g(
+                    x_full,
+                    new_x,
+                    SparsityRequest::Values {
+                        values: &mut s.scratch_jac,
+                    },
+                ) {
+                    return false;
+                }
+                s.jac_gather.apply(&s.scratch_jac, values);
+                true
+            }
+        }
+    }
+
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                return self
+                    .inner
+                    .borrow_mut()
+                    .eval_h(x, new_x, obj_factor, lambda, new_lambda, mode);
+            }
+            Some(_) => {}
+        }
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let s = self.state.as_ref().expect("inited");
+                irow.copy_from_slice(&s.h_irow_outer);
+                jcol.copy_from_slice(&s.h_jcol_outer);
+                true
+            }
+            SparsityRequest::Values { values } => {
+                let s = self.state.as_mut().expect("inited");
+                let x_full = match x {
+                    Some(xr) => {
+                        s.plan.lift_x(xr, &mut s.scratch_x);
+                        Some(&s.scratch_x[..])
+                    }
+                    None => None,
+                };
+                // Consumed rows are satisfied identically by the
+                // substitution, so they carry no curvature: λ = 0 there.
+                let lam_full = match lambda {
+                    Some(lam) => {
+                        for v in s.scratch_lambda.iter_mut() {
+                            *v = 0.0;
+                        }
+                        for (red, &full) in s.plan.rows_kept.iter().enumerate() {
+                            s.scratch_lambda[full] = lam[red];
+                        }
+                        Some(&s.scratch_lambda[..])
+                    }
+                    None => None,
+                };
+                if !self.inner.borrow_mut().eval_h(
+                    x_full,
+                    new_x,
+                    obj_factor,
+                    lam_full,
+                    new_lambda,
+                    SparsityRequest::Values {
+                        values: &mut s.scratch_h,
+                    },
+                ) {
+                    return false;
+                }
+                s.h_gather.apply(&s.scratch_h, values);
+                true
+            }
+        }
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, ip_data: &IpoptData, ip_cq: &IpoptCq) {
+        if self.ensure_init().is_none_or(|s| s.passthrough) {
+            self.inner
+                .borrow_mut()
+                .finalize_solution(sol, ip_data, ip_cq);
+            return;
+        }
+        let (n_in, m_in, nnz_in, one_based) = {
+            let s = self.state.as_ref().expect("inited");
+            (
+                s.plan.n_full,
+                s.plan.m_full,
+                s.info_inner.nnz_jac_g.max(0) as usize,
+                matches!(s.info_inner.index_style, IndexStyle::Fortran),
+            )
+        };
+
+        let mut x_full = vec![0.0; n_in];
+        {
+            let s = self.state.as_ref().expect("inited");
+            s.plan.lift_x(sol.x, &mut x_full);
+        }
+
+        // Bound multipliers: the survivors' values where they belong, zero
+        // at every eliminated column (see the dual-attribution caveat).
+        let mut z_l_full = vec![0.0; n_in];
+        let mut z_u_full = vec![0.0; n_in];
+        {
+            let s = self.state.as_ref().expect("inited");
+            for (red, &full) in s.plan.vars_kept.iter().enumerate() {
+                if red < sol.z_l.len() {
+                    z_l_full[full] = sol.z_l[red];
+                }
+                if red < sol.z_u.len() {
+                    z_u_full[full] = sol.z_u[red];
+                }
+            }
+        }
+
+        // Constraint values: re-evaluate so the dropped rows carry their
+        // real residual rather than a zero. If that fails, splice the
+        // solver's own reduced `g` into the kept rows and leave the rest at
+        // zero — never forward a partially-written scratch buffer.
+        let mut g_full = vec![0.0; m_in];
+        {
+            let ok = m_in == 0 || self.inner.borrow_mut().eval_g(&x_full, true, &mut g_full);
+            let s = self.state.as_ref().expect("inited");
+            if !ok {
+                for v in g_full.iter_mut() {
+                    *v = 0.0;
+                }
+                for (red, &full) in s.plan.rows_kept.iter().enumerate() {
+                    if red < sol.g.len() {
+                        g_full[full] = sol.g[red];
+                    }
+                }
+            }
+        }
+
+        let mut lambda_full = vec![0.0; m_in];
+        {
+            let s = self.state.as_ref().expect("inited");
+            for (red, &full) in s.plan.rows_kept.iter().enumerate() {
+                if red < sol.lambda.len() {
+                    lambda_full[full] = sol.lambda[red];
+                }
+            }
+        }
+
+        let has_steps = !self.state.as_ref().expect("inited").plan.steps.is_empty();
+        if has_steps {
+            let mut grad_f = vec![0.0; n_in];
+            let ok_grad = self
+                .inner
+                .borrow_mut()
+                .eval_grad_f(&x_full, true, &mut grad_f);
+            let mut jac_values = vec![0.0; nnz_in];
+            let ok_jac = nnz_in == 0
+                || self.inner.borrow_mut().eval_jac_g(
+                    Some(&x_full),
+                    false,
+                    SparsityRequest::Values {
+                        values: &mut jac_values,
+                    },
+                );
+            if ok_grad && ok_jac {
+                let s = self.state.as_ref().expect("inited");
+                recover_dropped_multipliers(
+                    &s.plan,
+                    &grad_f,
+                    &s.jac_irow_inner,
+                    &s.jac_jcol_inner,
+                    &jac_values,
+                    one_based,
+                    &mut lambda_full,
+                );
+            } else {
+                tracing::warn!(
+                    target: "pounce::presolve",
+                    "could not re-evaluate the model at the solution; the rows \
+                     consumed by linear-equality elimination are reported with a \
+                     zero multiplier."
+                );
+            }
+        }
+
+        self.finalized = Some(FullSolution {
+            x: x_full.clone(),
+            lambda: lambda_full.clone(),
+            z_l: z_l_full.clone(),
+            z_u: z_u_full.clone(),
+        });
+        self.inner.borrow_mut().finalize_solution(
+            Solution {
+                status: sol.status,
+                x: &x_full,
+                z_l: &z_l_full,
+                z_u: &z_u_full,
+                g: &g_full,
+                lambda: &lambda_full,
+                obj_value: sol.obj_value,
+            },
+            ip_data,
+            ip_cq,
+        );
+    }
+
+    fn get_var_con_metadata(&mut self, var: &mut MetaData, con: &mut MetaData) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                return self.inner.borrow_mut().get_var_con_metadata(var, con);
+            }
+            Some(_) => {}
+        }
+        let mut inner_var = MetaData::default();
+        let mut inner_con = MetaData::default();
+        if !self
+            .inner
+            .borrow_mut()
+            .get_var_con_metadata(&mut inner_var, &mut inner_con)
+        {
+            return false;
+        }
+        let s = self.state.as_ref().expect("inited");
+        *var = project_metadata(&inner_var, &s.plan.vars_kept, s.plan.n_full);
+        *con = project_metadata(&inner_con, &s.plan.rows_kept, s.plan.m_full);
+        true
+    }
+
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                return self.inner.borrow_mut().get_scaling_parameters(req);
+            }
+            Some(_) => {}
+        }
+        let (n_in, m_in) = {
+            let s = self.state.as_ref().expect("inited");
+            (s.plan.n_full, s.plan.m_full)
+        };
+        let mut inner_x = vec![1.0; n_in];
+        let mut inner_g = vec![1.0; m_in];
+        let mut obj_scaling = 1.0;
+        let mut use_x = false;
+        let mut use_g = false;
+        if !self
+            .inner
+            .borrow_mut()
+            .get_scaling_parameters(ScalingRequest {
+                obj_scaling: &mut obj_scaling,
+                use_x_scaling: &mut use_x,
+                x_scaling: &mut inner_x,
+                use_g_scaling: &mut use_g,
+                g_scaling: &mut inner_g,
+            })
+        {
+            return false;
+        }
+        *req.obj_scaling = obj_scaling;
+        *req.use_x_scaling = use_x;
+        *req.use_g_scaling = use_g;
+        let s = self.state.as_ref().expect("inited");
+        // A reduced column *is* its surviving variable, so it keeps that
+        // variable's declared scale factor.
+        for (red, &full) in s.plan.vars_kept.iter().enumerate() {
+            if red < req.x_scaling.len() {
+                req.x_scaling[red] = inner_x[full];
+            }
+        }
+        for (red, &full) in s.plan.rows_kept.iter().enumerate() {
+            if red < req.g_scaling.len() {
+                req.g_scaling[red] = inner_g[full];
+            }
+        }
+        true
+    }
+
+    fn get_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.project_var_linearity(types, false)
+    }
+
+    fn get_objective_variables_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        self.project_var_linearity(types, true)
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                return self.inner.borrow_mut().get_constraints_linearity(types);
+            }
+            Some(_) => {}
+        }
+        let m_in = self.state.as_ref().expect("inited").plan.m_full;
+        let mut full = vec![Linearity::NonLinear; m_in];
+        if !self.inner.borrow_mut().get_constraints_linearity(&mut full) {
+            return false;
+        }
+        let s = self.state.as_ref().expect("inited");
+        for (red, &r) in s.plan.rows_kept.iter().enumerate() {
+            types[red] = full[r];
+        }
+        true
+    }
+
+    fn get_number_of_nonlinear_variables(&mut self) -> Index {
+        match self.reduced_nonlinear_vars() {
+            Some(list) => list.len() as Index,
+            None => -1,
+        }
+    }
+
+    fn get_list_of_nonlinear_variables(&mut self, pos_nonlin_vars: &mut [Index]) -> bool {
+        let Some(list) = self.reduced_nonlinear_vars() else {
+            return false;
+        };
+        if pos_nonlin_vars.len() < list.len() {
+            return false;
+        }
+        pos_nonlin_vars[..list.len()].copy_from_slice(&list);
+        true
+    }
+
+    fn intermediate_callback(
+        &mut self,
+        stats: IterStats,
+        ip_data: &IpoptData,
+        ip_cq: &IpoptCq,
+    ) -> bool {
+        self.inner
+            .borrow_mut()
+            .intermediate_callback(stats, ip_data, ip_cq)
+    }
+
+    fn finalize_metadata(&mut self, var: &MetaData, con: &MetaData) {
+        if self.ensure_init().is_none_or(|s| s.passthrough) {
+            self.inner.borrow_mut().finalize_metadata(var, con);
+            return;
+        }
+        let s = self.state.as_ref().expect("inited");
+        let var_full = expand_metadata(var, &s.plan.vars_kept, s.plan.n_full);
+        let con_full = expand_metadata(con, &s.plan.rows_kept, s.plan.m_full);
+        self.inner
+            .borrow_mut()
+            .finalize_metadata(&var_full, &con_full);
+    }
+}
+
+#[allow(clippy::expect_used)]
+impl LinearEqElimTnlp {
+    /// A reduced column is non-linear when **any** full column folded onto
+    /// it is: `y` enters through `α·y + β`, so one non-linear member is
+    /// enough to make the objective non-linear in `y`.
+    fn project_var_linearity(&mut self, types: &mut [Linearity], objective_scoped: bool) -> bool {
+        match self.ensure_init() {
+            None => return false,
+            Some(s) if s.passthrough => {
+                let mut inner = self.inner.borrow_mut();
+                return if objective_scoped {
+                    inner.get_objective_variables_linearity(types)
+                } else {
+                    inner.get_variables_linearity(types)
+                };
+            }
+            Some(_) => {}
+        }
+        let n_in = self.state.as_ref().expect("inited").plan.n_full;
+        let mut full = vec![Linearity::NonLinear; n_in];
+        let ok = {
+            let mut inner = self.inner.borrow_mut();
+            if objective_scoped {
+                inner.get_objective_variables_linearity(&mut full)
+            } else {
+                inner.get_variables_linearity(&mut full)
+            }
+        };
+        if !ok {
+            return false;
+        }
+        let s = self.state.as_ref().expect("inited");
+        for t in types.iter_mut() {
+            *t = Linearity::Linear;
+        }
+        for (i, slot) in s.col_of.iter().enumerate() {
+            if let Some((red, _)) = *slot
+                && matches!(full[i], Linearity::NonLinear)
+                && red < types.len()
+            {
+                types[red] = Linearity::NonLinear;
+            }
+        }
+        true
+    }
+
+    /// The inner nonlinear-variable list mapped onto reduced columns, or
+    /// `None` when the inner TNLP declines to publish one.
+    fn reduced_nonlinear_vars(&mut self) -> Option<Vec<Index>> {
+        if self.ensure_init()?.passthrough {
+            let count = self.inner.borrow_mut().get_number_of_nonlinear_variables();
+            if count < 0 {
+                return None;
+            }
+            let mut list = vec![0 as Index; count as usize];
+            if !self
+                .inner
+                .borrow_mut()
+                .get_list_of_nonlinear_variables(&mut list)
+            {
+                return None;
+            }
+            return Some(list);
+        }
+        if let Some(cached) = self.state.as_ref().expect("inited").nonlinear_vars.as_ref() {
+            return Some(cached.clone());
+        }
+        let count = self.inner.borrow_mut().get_number_of_nonlinear_variables();
+        if count < 0 {
+            return None;
+        }
+        let mut inner_list = vec![0 as Index; count as usize];
+        if !self
+            .inner
+            .borrow_mut()
+            .get_list_of_nonlinear_variables(&mut inner_list)
+        {
+            return None;
+        }
+        let s = self.state.as_mut().expect("inited");
+        let one_based = matches!(s.info_inner.index_style, IndexStyle::Fortran);
+        let mut seen = vec![false; s.plan.n_reduced_vars()];
+        let mut out: Vec<Index> = Vec::new();
+        for &v in &inner_list {
+            let full = if one_based {
+                (v as isize - 1).max(0) as usize
+            } else {
+                v.max(0) as usize
+            };
+            if full >= s.col_of.len() {
+                continue;
+            }
+            if let Some((red, _)) = s.col_of[full]
+                && !seen[red]
+            {
+                seen[red] = true;
+                out.push(if one_based {
+                    red as Index + 1
+                } else {
+                    red as Index
+                });
+            }
+        }
+        out.sort_unstable();
+        s.nonlinear_vars = Some(out.clone());
+        Some(out)
+    }
+}
+
+/// Subset every per-index vector of `meta` to `kept`.
+///
+/// Per-index-ness is inferred from the vector's length, exactly as
+/// `PresolveTnlp` does for its row metadata: `MetaData` mirrors upstream's
+/// untyped map and carries no shape information of its own.
+fn project_metadata(meta: &MetaData, kept: &[usize], n_full: usize) -> MetaData {
+    let mut out = MetaData::default();
+    for (k, v) in &meta.strings {
+        out.strings.insert(
+            k.clone(),
+            if v.len() == n_full {
+                kept.iter().map(|&i| v[i].clone()).collect()
+            } else {
+                v.clone()
+            },
+        );
+    }
+    for (k, v) in &meta.integers {
+        out.integers.insert(
+            k.clone(),
+            if v.len() == n_full {
+                kept.iter().map(|&i| v[i]).collect()
+            } else {
+                v.clone()
+            },
+        );
+    }
+    for (k, v) in &meta.numerics {
+        out.numerics.insert(
+            k.clone(),
+            if v.len() == n_full {
+                kept.iter().map(|&i| v[i]).collect()
+            } else {
+                v.clone()
+            },
+        );
+    }
+    out
+}
+
+/// Inverse of [`project_metadata`]: scatter a reduced-length vector back
+/// into full-length, leaving defaults at the removed indices.
+fn expand_metadata(meta: &MetaData, kept: &[usize], n_full: usize) -> MetaData {
+    let n_red = kept.len();
+    let mut out = MetaData::default();
+    for (k, v) in &meta.strings {
+        if v.len() == n_red && n_red != n_full {
+            let mut full = vec![String::new(); n_full];
+            for (r, &i) in kept.iter().enumerate() {
+                full[i] = v[r].clone();
+            }
+            out.strings.insert(k.clone(), full);
+        } else {
+            out.strings.insert(k.clone(), v.clone());
+        }
+    }
+    for (k, v) in &meta.integers {
+        if v.len() == n_red && n_red != n_full {
+            let mut full = vec![0 as Index; n_full];
+            for (r, &i) in kept.iter().enumerate() {
+                full[i] = v[r];
+            }
+            out.integers.insert(k.clone(), full);
+        } else {
+            out.integers.insert(k.clone(), v.clone());
+        }
+    }
+    for (k, v) in &meta.numerics {
+        if v.len() == n_red && n_red != n_full {
+            let mut full = vec![0.0; n_full];
+            for (r, &i) in kept.iter().enumerate() {
+                full[i] = v[r];
+            }
+            out.numerics.insert(k.clone(), full);
+        } else {
+            out.numerics.insert(k.clone(), v.clone());
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::linear_eq_plan::ElimStep;
+
+    fn plan_with(
+        steps: Vec<ElimStep>,
+        parent: Vec<Option<(usize, Number)>>,
+        m: usize,
+    ) -> EliminationPlan {
+        let n = parent.len();
+        let mut row_kept = vec![true; m];
+        for s in &steps {
+            row_kept[s.row] = false;
+        }
+        EliminationPlan {
+            n_full: n,
+            m_full: m,
+            recovery: vec![VarRecovery::Kept(0); n],
+            vars_kept: Vec::new(),
+            rows_kept: (0..m).filter(|&r| row_kept[r]).collect(),
+            row_kept,
+            x_l_red: Vec::new(),
+            x_u_red: Vec::new(),
+            steps,
+            parent,
+            report: LinearEqElimReport::default(),
+        }
+    }
+
+    /// `min 4·x  s.t.  x = 3` (row 0 consumed). Stationarity in the
+    /// `∇f + Jᵀλ = 0` convention gives λ = −4.
+    #[test]
+    fn recovers_a_singleton_rows_multiplier() {
+        let plan = plan_with(
+            vec![ElimStep {
+                row: 0,
+                var: 0,
+                pivot: 1.0,
+            }],
+            vec![None],
+            1,
+        );
+        let mut lambda = vec![0.0];
+        recover_dropped_multipliers(&plan, &[4.0], &[0], &[0], &[1.0], false, &mut lambda);
+        assert!((lambda[0] + 4.0).abs() < 1e-12, "{lambda:?}");
+    }
+
+    /// Two chained aggregations. Row 0: `x0 - x1 = 0` eliminates x0.
+    /// Row 1: `x1 - x2 = 0` eliminates x1. Row 2 (kept) touches x2.
+    /// f = 2·x0 + 3·x1 + 5·x2.
+    ///
+    /// Stationarity at x0: 2 + λ0 = 0            → λ0 = −2
+    /// Stationarity at x1: 3 − λ0 + λ1 = 0        → λ1 = −5
+    /// (row 2 does not touch x0 or x1)
+    #[test]
+    fn reverse_sweep_resolves_a_chain() {
+        let plan = plan_with(
+            vec![
+                ElimStep {
+                    row: 0,
+                    var: 0,
+                    pivot: 1.0,
+                },
+                ElimStep {
+                    row: 1,
+                    var: 1,
+                    pivot: 1.0,
+                },
+            ],
+            vec![Some((1, 1.0)), Some((2, 1.0)), None],
+            3,
+        );
+        // J rows: r0 = [1, -1, 0], r1 = [0, 1, -1], r2 = [0, 0, 1].
+        let irow = [0, 0, 1, 1, 2];
+        let jcol = [0, 1, 1, 2, 2];
+        let vals = [1.0, -1.0, 1.0, -1.0, 1.0];
+        let mut lambda = vec![0.0, 0.0, 0.0];
+        recover_dropped_multipliers(
+            &plan,
+            &[2.0, 3.0, 5.0],
+            &irow,
+            &jcol,
+            &vals,
+            false,
+            &mut lambda,
+        );
+        assert!((lambda[0] + 2.0).abs() < 1e-12, "{lambda:?}");
+        assert!((lambda[1] + 5.0).abs() < 1e-12, "{lambda:?}");
+    }
+
+    /// The recovery must reproduce full-space stationarity, which is the
+    /// property that actually matters: `∇f + Jᵀλ = 0` at every eliminated
+    /// column.
+    #[test]
+    fn recovered_multipliers_close_full_space_stationarity() {
+        // x0 = 2·x1 + 1 (row 0), x1 = x2 (row 1), row 2 kept with λ = 0.5.
+        // J: r0 = [1, -2, 0], r1 = [0, 1, -1], r2 = [0.3, 0.7, 1.1].
+        let plan = plan_with(
+            vec![
+                ElimStep {
+                    row: 0,
+                    var: 0,
+                    pivot: 1.0,
+                },
+                ElimStep {
+                    row: 1,
+                    var: 1,
+                    pivot: 1.0,
+                },
+            ],
+            vec![Some((1, 2.0)), Some((2, 1.0)), None],
+            3,
+        );
+        let irow = [0, 0, 1, 1, 2, 2, 2];
+        let jcol = [0, 1, 1, 2, 0, 1, 2];
+        let vals = [1.0, -2.0, 1.0, -1.0, 0.3, 0.7, 1.1];
+        let grad = [2.0, 3.0, 5.0];
+        let mut lambda = vec![0.0, 0.0, 0.5];
+        recover_dropped_multipliers(&plan, &grad, &irow, &jcol, &vals, false, &mut lambda);
+        for col in [0usize, 1] {
+            let mut resid = grad[col];
+            for k in 0..irow.len() {
+                if jcol[k] as usize == col {
+                    resid += vals[k] * lambda[irow[k] as usize];
+                }
+            }
+            assert!(
+                resid.abs() < 1e-10,
+                "stationarity at eliminated column {col} = {resid}, λ = {lambda:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn one_based_structure_is_decoded() {
+        assert_eq!(decode(1, 1, true), (0, 0));
+        assert_eq!(decode(0, 0, false), (0, 0));
+        assert_eq!(decode(3, 5, true), (2, 4));
+    }
+
+    #[test]
+    fn gather_sums_scaled_sources() {
+        let (slots, g) = gather_from(vec![((0, 0), 2, 1.0), ((1, 0), 0, 3.0), ((0, 0), 1, -2.0)]);
+        assert_eq!(slots, vec![(0, 0), (1, 0)]);
+        let mut out = vec![0.0; 2];
+        g.apply(&[7.0, 5.0, 11.0], &mut out);
+        assert_eq!(out, vec![11.0 - 10.0, 21.0]);
+    }
+
+    #[test]
+    fn metadata_round_trips_through_the_reduction() {
+        let mut meta = MetaData::default();
+        meta.strings
+            .insert("idx_names".into(), vec!["a".into(), "b".into(), "c".into()]);
+        meta.numerics.insert("weights".into(), vec![1.0, 2.0, 3.0]);
+        // A vector that is not per-index must pass through untouched.
+        meta.integers.insert("scalarish".into(), vec![9]);
+        let kept = [0usize, 2];
+        let projected = project_metadata(&meta, &kept, 3);
+        assert_eq!(projected.strings["idx_names"], vec!["a", "c"]);
+        assert_eq!(projected.numerics["weights"], vec![1.0, 3.0]);
+        assert_eq!(projected.integers["scalarish"], vec![9]);
+        let expanded = expand_metadata(&projected, &kept, 3);
+        assert_eq!(expanded.strings["idx_names"], vec!["a", "", "c"]);
+        assert_eq!(expanded.numerics["weights"], vec![1.0, 0.0, 3.0]);
+        assert_eq!(expanded.integers["scalarish"], vec![9]);
+    }
+}

--- a/crates/pounce-presolve/src/linear_eq_plan.rs
+++ b/crates/pounce-presolve/src/linear_eq_plan.rs
@@ -1,0 +1,1139 @@
+//! Phase 6, planning half — decide which variables a model's linear
+//! equality rows determine (issue #487).
+//!
+//! This is the "aggregation" pass option (b) of gh#487: one
+//! implementation in `pounce-presolve` so every frontend — CLI, GAMS, the
+//! C interface, Pyomo — gets the same reduction, rather than borrowing
+//! Pyomo's NL-v2 writer presolve for the Pyomo path alone.
+//!
+//! # What it recognises
+//!
+//! A work list over three shapes, iterated to a fixed point so chains
+//! propagate (matching what Pyomo's NL-v2 linear presolve does):
+//!
+//! 1. **Variables fixed by equal bounds** (`x_l == x_u`) become
+//!    constants, so rows mentioning them shed a term.
+//! 2. **Singleton linear equality rows** `a·x = b` fix their variable at
+//!    `x := b/a`, with a bounds check.
+//! 3. **Two-variable linear equality rows** `a₁·x + a₂·y = b` substitute
+//!    one variable for the other, `x := α·y + β`, with **no anchoring
+//!    requirement** — free/free pairs (arc equalities, `Reference`
+//!    aliases, unit-conversion links) aggregate away. This is the shape
+//!    [`crate::auxiliary`]'s determined-block pipeline cannot reach, and
+//!    the one that closes the gap gh#487 measured.
+//!
+//! Rows that collapse to `0 = 0` under the accumulated substitutions are
+//! structurally redundant and are dropped too (they carry `λ = 0`; see
+//! [`crate::linear_eq_elim`] for the dual story).
+//!
+//! # What it produces
+//!
+//! An [`EliminationPlan`]: an affine map `x_full = A·y + c` in which every
+//! eliminated variable is `α·y_rep + β` for a **single** surviving
+//! variable `rep` (or an outright constant). That one-nonzero-per-row
+//! shape is what keeps the derivative transforms in
+//! [`crate::linear_eq_elim`] to a scaled gather rather than a sparse
+//! matrix product.
+//!
+//! # Failing closed
+//!
+//! Any contradiction found on the way — a singleton value outside its
+//! variable's box, a bound transfer that empties the survivor's box, a row
+//! reduced to `0 = b` with `b ≠ 0` — abandons the **whole** plan and
+//! returns the identity. Presolve's own certification path (which knows
+//! how to withdraw a verdict a witness refutes) then sees the model
+//! untouched and decides for itself. An elimination pass is the wrong
+//! place to be the first and only voice calling a model infeasible.
+
+use pounce_common::types::{Number, lower_bound_present, upper_bound_present};
+
+/// How one full-space variable is recovered from the reduced solution.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum VarRecovery {
+    /// Survives, at the given index in the reduced variable vector.
+    Kept(usize),
+    /// Eliminated to a constant.
+    Constant(Number),
+    /// Eliminated to `coeff * x[rep] + offset`, where `rep` is a
+    /// **surviving** full-space variable index and `coeff` is non-zero.
+    Affine {
+        rep: usize,
+        coeff: Number,
+        offset: Number,
+    },
+}
+
+/// One accepted elimination, in application order.
+///
+/// The postsolve multiplier recovery in [`crate::linear_eq_elim`] walks
+/// these in reverse, which is what makes the dual system triangular; see
+/// that module's `recover_dropped_multipliers` for why.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ElimStep {
+    /// Full-space row consumed by this step.
+    pub row: usize,
+    /// Full-space variable it determined.
+    pub var: usize,
+    /// The row's coefficient on `var` **in the partially substituted
+    /// problem at the moment of the step** — i.e. the pivot. Non-zero.
+    pub pivot: Number,
+}
+
+/// Tunables for [`build_plan`].
+#[derive(Debug, Clone, Copy)]
+pub struct PlanConfig {
+    /// `|g_u - g_l|` at or below this makes a row an equality.
+    pub eq_tol: Number,
+    /// An accumulated coefficient at or below `coeff_tol * row_scale` is
+    /// treated as structurally absent.
+    pub coeff_tol: Number,
+    /// How far a derived value may sit outside a declared bound before the
+    /// plan is abandoned as contradictory. Below this the value is clamped
+    /// into the box instead — the same "float noise is not an empty set"
+    /// reading `PresolveTnlp` applies to sub-margin crossings.
+    pub feas_tol: Number,
+    /// Cap on fixed-point sweeps over the candidate rows.
+    pub max_passes: usize,
+}
+
+impl Default for PlanConfig {
+    fn default() -> Self {
+        Self {
+            eq_tol: 1e-12,
+            coeff_tol: 1e-12,
+            feas_tol: 1e-8,
+            max_passes: 50,
+        }
+    }
+}
+
+/// Everything [`build_plan`] reads about the problem.
+#[derive(Debug, Clone, Copy)]
+pub struct PlanInput<'a> {
+    pub n_vars: usize,
+    pub n_rows: usize,
+    /// Per-row `(column, coefficient)` lists. Only rows flagged linear and
+    /// equality are consulted; the caller may leave the rest empty.
+    pub rows: &'a [Vec<(usize, Number)>],
+    /// Per-row constant term `c` in `g_r(x) = Σ a_j x_j + c`, so the row
+    /// reads `Σ a_j x_j = g_l[r] - c`.
+    pub row_const: &'a [Number],
+    pub g_l: &'a [Number],
+    pub g_u: &'a [Number],
+    /// `true` where the row is linear **and** eligible to be consumed.
+    pub eligible: &'a [bool],
+    pub x_l: &'a [Number],
+    pub x_u: &'a [Number],
+}
+
+/// A summary of what the pass achieved, for the `Presolve:` console line
+/// and for tests.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct LinearEqElimReport {
+    /// Variables pinned to a constant (by an equal-bounds pair, or by a
+    /// singleton row).
+    pub n_constant_vars: usize,
+    /// Variables folded onto another variable by a two-term row.
+    pub n_aggregated_vars: usize,
+    /// Rows consumed to determine a variable.
+    pub n_rows_eliminated: usize,
+    /// Rows that collapsed to `0 = 0` and were dropped as redundant.
+    pub n_redundant_rows: usize,
+    /// Fixed-point sweeps actually performed.
+    pub passes: usize,
+    /// The sweep hit [`PlanConfig::max_passes`] with work still to do.
+    pub pass_cap_hit: bool,
+    /// A contradiction was found; the returned plan is the identity.
+    pub infeasible: bool,
+}
+
+/// The affine reduction `x_full = A·y + c` plus the bookkeeping postsolve
+/// needs.
+#[derive(Debug, Clone, Default)]
+pub struct EliminationPlan {
+    pub n_full: usize,
+    pub m_full: usize,
+    /// One entry per full-space variable.
+    pub recovery: Vec<VarRecovery>,
+    /// Full-space index of each surviving variable, ascending.
+    pub vars_kept: Vec<usize>,
+    /// `true` where the full-space row survives into the reduced problem.
+    pub row_kept: Vec<bool>,
+    /// Full-space index of each surviving row, ascending.
+    pub rows_kept: Vec<usize>,
+    /// Reduced variable bounds, aligned with [`Self::vars_kept`]. Carries
+    /// every bound transferred off an eliminated variable.
+    pub x_l_red: Vec<Number>,
+    pub x_u_red: Vec<Number>,
+    /// Accepted eliminations in application order.
+    pub steps: Vec<ElimStep>,
+    /// Elimination forest: `parent[i] = Some((p, α))` when `i` was folded
+    /// onto `p` with `x_i = α·x_p + β` **at that moment** (`p` may itself
+    /// be eliminated later). `None` for survivors and for variables pinned
+    /// to a constant.
+    pub parent: Vec<Option<(usize, Number)>>,
+    pub report: LinearEqElimReport,
+}
+
+impl EliminationPlan {
+    /// The do-nothing plan: every variable and row survives.
+    pub fn identity(n_vars: usize, n_rows: usize, x_l: &[Number], x_u: &[Number]) -> Self {
+        Self {
+            n_full: n_vars,
+            m_full: n_rows,
+            recovery: (0..n_vars).map(VarRecovery::Kept).collect(),
+            vars_kept: (0..n_vars).collect(),
+            row_kept: vec![true; n_rows],
+            rows_kept: (0..n_rows).collect(),
+            x_l_red: x_l.to_vec(),
+            x_u_red: x_u.to_vec(),
+            steps: Vec::new(),
+            parent: vec![None; n_vars],
+            report: LinearEqElimReport::default(),
+        }
+    }
+
+    /// True when the plan removes nothing, so every wrapper method can take
+    /// its forwarding fast path.
+    pub fn is_identity(&self) -> bool {
+        self.steps.is_empty() && self.report.n_redundant_rows == 0
+    }
+
+    pub fn n_reduced_vars(&self) -> usize {
+        self.vars_kept.len()
+    }
+
+    pub fn n_reduced_rows(&self) -> usize {
+        self.rows_kept.len()
+    }
+
+    /// Splice a reduced primal back into full space.
+    pub fn lift_x(&self, x_red: &[Number], out: &mut [Number]) {
+        debug_assert_eq!(out.len(), self.n_full);
+        // Survivors first, so the `Affine` arm below can read its
+        // representative's value straight out of `out` regardless of index
+        // order (`rep` is always a survivor, never another eliminated var).
+        for (red, &full) in self.vars_kept.iter().enumerate() {
+            out[full] = x_red[red];
+        }
+        for (i, rec) in self.recovery.iter().enumerate() {
+            match *rec {
+                VarRecovery::Kept(_) => {}
+                VarRecovery::Constant(c) => out[i] = c,
+                VarRecovery::Affine { rep, coeff, offset } => out[i] = coeff * out[rep] + offset,
+            }
+        }
+    }
+
+    /// Project a full-space primal down, by reading the survivors.
+    pub fn project_x(&self, x_full: &[Number], out: &mut [Number]) {
+        for (red, &full) in self.vars_kept.iter().enumerate() {
+            out[red] = x_full[full];
+        }
+    }
+}
+
+/// Bounds held with `±f64::INFINITY` for "absent", so arithmetic on them
+/// behaves; converted back to the caller's sentinels on the way out.
+struct Box2 {
+    lo: Vec<Number>,
+    hi: Vec<Number>,
+}
+
+impl Box2 {
+    fn from_declared(x_l: &[Number], x_u: &[Number]) -> Self {
+        Self {
+            lo: x_l
+                .iter()
+                .map(|&v| {
+                    if lower_bound_present(v) {
+                        v
+                    } else {
+                        Number::NEG_INFINITY
+                    }
+                })
+                .collect(),
+            hi: x_u
+                .iter()
+                .map(|&v| {
+                    if upper_bound_present(v) {
+                        v
+                    } else {
+                        Number::INFINITY
+                    }
+                })
+                .collect(),
+        }
+    }
+}
+
+/// Union-find over variables, carrying the affine map to the current root.
+struct Substitutions {
+    /// `rep[i]` is `i` for a root, else a (possibly stale) ancestor.
+    rep: Vec<usize>,
+    /// `x_i = to_root[i].0 * x_{rep[i]} + to_root[i].1`.
+    to_root: Vec<(Number, Number)>,
+    /// Members in each root's cluster, for the union-by-size tie-break.
+    cluster_size: Vec<usize>,
+    /// Set once a root is pinned to a value.
+    root_const: Vec<Option<Number>>,
+}
+
+impl Substitutions {
+    fn new(n: usize) -> Self {
+        Self {
+            rep: (0..n).collect(),
+            to_root: vec![(1.0, 0.0); n],
+            cluster_size: vec![1; n],
+            root_const: vec![None; n],
+        }
+    }
+
+    /// Resolve `i` to its current root, path-compressing on the way back
+    /// down. Returns `(root, a, b)` with `x_i = a·x_root + b`.
+    fn find(&mut self, i: usize) -> (usize, Number, Number) {
+        let mut cur = i;
+        let mut path: Vec<usize> = Vec::new();
+        while self.rep[cur] != cur {
+            path.push(cur);
+            cur = self.rep[cur];
+        }
+        let root = cur;
+        let (mut acc_a, mut acc_b) = (1.0, 0.0);
+        for &node in path.iter().rev() {
+            let (a, b) = self.to_root[node];
+            let na = a * acc_a;
+            let nb = a * acc_b + b;
+            self.rep[node] = root;
+            self.to_root[node] = (na, nb);
+            acc_a = na;
+            acc_b = nb;
+        }
+        if i == root {
+            (root, 1.0, 0.0)
+        } else {
+            let (a, b) = self.to_root[i];
+            (root, a, b)
+        }
+    }
+}
+
+/// Build the reduction. Never panics on a contradictory model: see the
+/// module docs on failing closed.
+pub fn build_plan(input: &PlanInput<'_>, cfg: &PlanConfig) -> EliminationPlan {
+    let n = input.n_vars;
+    let m = input.n_rows;
+    let identity = || EliminationPlan::identity(n, m, input.x_l, input.x_u);
+    if n == 0 {
+        return identity();
+    }
+
+    let mut subs = Substitutions::new(n);
+    let mut bounds = Box2::from_declared(input.x_l, input.x_u);
+    let mut parent: Vec<Option<(usize, Number)>> = vec![None; n];
+    let mut steps: Vec<ElimStep> = Vec::new();
+    let mut row_consumed = vec![false; m];
+    let mut redundant_rows: Vec<usize> = Vec::new();
+    let mut report = LinearEqElimReport::default();
+
+    // Shape 1: variables the declared box already pins. Folding them in
+    // here (rather than leaving them to the algorithm's fixed-variable
+    // classification) is what lets a three-term row with one fixed
+    // variable become a two-term row the aggregation can consume.
+    for j in 0..n {
+        let (lo, hi) = (bounds.lo[j], bounds.hi[j]);
+        if !lo.is_finite() || !hi.is_finite() {
+            continue;
+        }
+        if hi - lo <= cfg.eq_tol * lo.abs().max(hi.abs()).max(1.0) {
+            subs.root_const[j] = Some(0.5 * (lo + hi));
+            report.n_constant_vars += 1;
+        }
+    }
+
+    // Shapes 2 and 3, swept to a fixed point.
+    let mut candidates: Vec<usize> = (0..m)
+        .filter(|&r| {
+            input.eligible[r]
+                && lower_bound_present(input.g_l[r])
+                && upper_bound_present(input.g_u[r])
+                && (input.g_u[r] - input.g_l[r]).abs() <= cfg.eq_tol * input.g_l[r].abs().max(1.0)
+        })
+        .collect();
+    if candidates.is_empty() {
+        return finish(
+            n,
+            m,
+            input,
+            subs,
+            bounds,
+            parent,
+            steps,
+            redundant_rows,
+            report,
+        );
+    }
+
+    let mut terms: Vec<(usize, Number)> = Vec::new();
+    for pass in 0..cfg.max_passes.max(1) {
+        let mut changed = false;
+        report.passes = pass + 1;
+        for &r in &candidates {
+            if row_consumed[r] {
+                continue;
+            }
+            // Re-express the row over the *current* representatives.
+            terms.clear();
+            let mut rhs = input.g_l[r] - input.row_const[r];
+            let mut row_scale: Number = 0.0;
+            let mut ok = true;
+            for &(j, a) in &input.rows[r] {
+                if a == 0.0 {
+                    continue;
+                }
+                if j >= n {
+                    ok = false;
+                    break;
+                }
+                let (root, ra, rb) = subs.find(j);
+                row_scale = row_scale.max((a * ra).abs());
+                match subs.root_const[root] {
+                    Some(c) => rhs -= a * (ra * c + rb),
+                    None => {
+                        rhs -= a * rb;
+                        match terms.iter_mut().find(|(v, _)| *v == root) {
+                            Some(slot) => slot.1 += a * ra,
+                            None => terms.push((root, a * ra)),
+                        }
+                    }
+                }
+            }
+            if !ok || !rhs.is_finite() {
+                continue;
+            }
+            let drop_below = cfg.coeff_tol * row_scale.max(1.0);
+            terms.retain(|&(_, a)| a.abs() > drop_below);
+
+            match terms.len() {
+                0 => {
+                    // `0 = rhs`. Zero (to tolerance) means the row carries no
+                    // information left and can go; anything else is a
+                    // contradiction, and the whole plan stands down.
+                    if rhs.abs() <= cfg.feas_tol * row_scale.max(1.0) {
+                        row_consumed[r] = true;
+                        redundant_rows.push(r);
+                        report.n_redundant_rows += 1;
+                        changed = true;
+                    } else {
+                        report.infeasible = true;
+                        return abandoned(identity(), report);
+                    }
+                }
+                1 => {
+                    let (v, a) = terms[0];
+                    let value = rhs / a;
+                    if !value.is_finite() {
+                        continue;
+                    }
+                    match clamp_into_box(value, bounds.lo[v], bounds.hi[v], cfg.feas_tol) {
+                        Some(pinned) => {
+                            subs.root_const[v] = Some(pinned);
+                            bounds.lo[v] = pinned;
+                            bounds.hi[v] = pinned;
+                            row_consumed[r] = true;
+                            steps.push(ElimStep {
+                                row: r,
+                                var: v,
+                                pivot: a,
+                            });
+                            report.n_constant_vars += 1;
+                            report.n_rows_eliminated += 1;
+                            changed = true;
+                        }
+                        None => {
+                            report.infeasible = true;
+                            return abandoned(identity(), report);
+                        }
+                    }
+                }
+                2 => {
+                    let (v0, a0) = terms[0];
+                    let (v1, a1) = terms[1];
+                    // Pivot on the larger coefficient so the substitution
+                    // multiplier |a_other / a_pivot| never exceeds 1. When the
+                    // two are comparable — the `x - y = 0` alias case, which is
+                    // most of them — break the tie by cluster size so the
+                    // elimination forest stays shallow; postsolve walks its
+                    // ancestor chains once per dropped-row nonzero.
+                    let (elim, keep, a_elim, a_keep) = if a0.abs() > 4.0 * a1.abs() {
+                        (v0, v1, a0, a1)
+                    } else if a1.abs() > 4.0 * a0.abs() {
+                        (v1, v0, a1, a0)
+                    } else if subs.cluster_size[v0] <= subs.cluster_size[v1] {
+                        (v0, v1, a0, a1)
+                    } else {
+                        (v1, v0, a1, a0)
+                    };
+                    let alpha = -a_keep / a_elim;
+                    let beta = rhs / a_elim;
+                    if !alpha.is_finite() || !beta.is_finite() || alpha == 0.0 {
+                        continue;
+                    }
+                    // Transfer the eliminated variable's box onto the survivor.
+                    if !transfer_bounds(&mut bounds, elim, keep, alpha, beta, cfg.feas_tol) {
+                        report.infeasible = true;
+                        return abandoned(identity(), report);
+                    }
+                    subs.rep[elim] = keep;
+                    subs.to_root[elim] = (alpha, beta);
+                    subs.cluster_size[keep] += subs.cluster_size[elim];
+                    parent[elim] = Some((keep, alpha));
+                    row_consumed[r] = true;
+                    steps.push(ElimStep {
+                        row: r,
+                        var: elim,
+                        pivot: a_elim,
+                    });
+                    report.n_aggregated_vars += 1;
+                    report.n_rows_eliminated += 1;
+                    changed = true;
+                }
+                _ => {}
+            }
+        }
+        candidates.retain(|&r| !row_consumed[r]);
+        if !changed || candidates.is_empty() {
+            break;
+        }
+        if pass + 1 == cfg.max_passes.max(1) {
+            report.pass_cap_hit = true;
+        }
+    }
+
+    finish(
+        n,
+        m,
+        input,
+        subs,
+        bounds,
+        parent,
+        steps,
+        redundant_rows,
+        report,
+    )
+}
+
+fn abandoned(mut plan: EliminationPlan, report: LinearEqElimReport) -> EliminationPlan {
+    plan.report = LinearEqElimReport {
+        infeasible: report.infeasible,
+        passes: report.passes,
+        ..LinearEqElimReport::default()
+    };
+    plan
+}
+
+/// Accept `value` as the pinned value of a variable whose box is
+/// `[lo, hi]`, or refuse when it sits outside by more than `tol`.
+///
+/// A sub-tolerance excursion is clamped rather than refused, for the same
+/// reason `PresolveTnlp` collapses a sub-margin crossed box to a point:
+/// binary float noise around a bound is not an empty feasible set, and
+/// treating it as one flips a model POUNCE solves cleanly into a
+/// contradiction verdict.
+fn clamp_into_box(value: Number, lo: Number, hi: Number, tol: Number) -> Option<Number> {
+    let scale = value
+        .abs()
+        .max(lo.abs().min(1e19))
+        .max(hi.abs().min(1e19))
+        .max(1.0);
+    if lo.is_finite() && value < lo {
+        if lo - value > tol * scale {
+            return None;
+        }
+        return Some(lo);
+    }
+    if hi.is_finite() && value > hi {
+        if value - hi > tol * scale {
+            return None;
+        }
+        return Some(hi);
+    }
+    Some(value)
+}
+
+/// Push `elim`'s box through `x_elim = α·x_keep + β` onto `keep`'s box.
+/// Returns `false` when the intersection is empty beyond `tol`.
+fn transfer_bounds(
+    bounds: &mut Box2,
+    elim: usize,
+    keep: usize,
+    alpha: Number,
+    beta: Number,
+    tol: Number,
+) -> bool {
+    let (lo_e, hi_e) = (bounds.lo[elim], bounds.hi[elim]);
+    // x_elim ∈ [lo_e, hi_e]  ⟺  x_keep ∈ [(lo_e-β)/α, (hi_e-β)/α] (α>0)
+    //                            x_keep ∈ [(hi_e-β)/α, (lo_e-β)/α] (α<0)
+    let a = (lo_e - beta) / alpha;
+    let b = (hi_e - beta) / alpha;
+    let (mut derived_lo, mut derived_hi) = if alpha > 0.0 { (a, b) } else { (b, a) };
+    if !derived_lo.is_finite() {
+        derived_lo = Number::NEG_INFINITY;
+    }
+    if !derived_hi.is_finite() {
+        derived_hi = Number::INFINITY;
+    }
+    if derived_lo > bounds.lo[keep] {
+        bounds.lo[keep] = derived_lo;
+    }
+    if derived_hi < bounds.hi[keep] {
+        bounds.hi[keep] = derived_hi;
+    }
+    let (lo, hi) = (bounds.lo[keep], bounds.hi[keep]);
+    if lo.is_finite() && hi.is_finite() && lo > hi {
+        let scale = lo.abs().max(hi.abs()).max(1.0);
+        if lo - hi > tol * scale {
+            return false;
+        }
+        // Float-noise crossing: collapse to a point rather than call the
+        // model empty.
+        let mid = 0.5 * (lo + hi);
+        bounds.lo[keep] = mid;
+        bounds.hi[keep] = mid;
+    }
+    true
+}
+
+#[allow(clippy::too_many_arguments)]
+fn finish(
+    n: usize,
+    m: usize,
+    input: &PlanInput<'_>,
+    mut subs: Substitutions,
+    bounds: Box2,
+    parent: Vec<Option<(usize, Number)>>,
+    steps: Vec<ElimStep>,
+    redundant_rows: Vec<usize>,
+    report: LinearEqElimReport,
+) -> EliminationPlan {
+    if steps.is_empty() && redundant_rows.is_empty() {
+        let mut plan = EliminationPlan::identity(n, m, input.x_l, input.x_u);
+        plan.report = report;
+        return plan;
+    }
+
+    // Roots that were never pinned survive.
+    let mut recovery = vec![VarRecovery::Kept(usize::MAX); n];
+    let mut vars_kept: Vec<usize> = Vec::new();
+    let mut reduced_of = vec![usize::MAX; n];
+    for (j, slot) in reduced_of.iter_mut().enumerate() {
+        let (root, _, _) = subs.find(j);
+        if root == j && subs.root_const[j].is_none() {
+            *slot = vars_kept.len();
+            vars_kept.push(j);
+        }
+    }
+    if vars_kept.is_empty() {
+        // Every column gone. The reduced problem has no degrees of freedom
+        // left, which the IPM has no useful shape for; hand the model back
+        // untouched rather than invent one.
+        let mut plan = EliminationPlan::identity(n, m, input.x_l, input.x_u);
+        plan.report = LinearEqElimReport {
+            passes: report.passes,
+            ..LinearEqElimReport::default()
+        };
+        return plan;
+    }
+    for j in 0..n {
+        let (root, a, b) = subs.find(j);
+        recovery[j] = match subs.root_const[root] {
+            Some(c) => VarRecovery::Constant(a * c + b),
+            None if root == j => VarRecovery::Kept(reduced_of[j]),
+            None => VarRecovery::Affine {
+                rep: root,
+                coeff: a,
+                offset: b,
+            },
+        };
+    }
+
+    let mut row_kept = vec![true; m];
+    for s in &steps {
+        row_kept[s.row] = false;
+    }
+    for &r in &redundant_rows {
+        row_kept[r] = false;
+    }
+    let rows_kept: Vec<usize> = (0..m).filter(|&r| row_kept[r]).collect();
+
+    // Reduced box: keep the caller's own sentinel where nothing was
+    // derived, so an "absent" bound stays spelled the way it arrived.
+    let mut x_l_red = Vec::with_capacity(vars_kept.len());
+    let mut x_u_red = Vec::with_capacity(vars_kept.len());
+    for &j in &vars_kept {
+        x_l_red.push(if bounds.lo[j].is_finite() {
+            bounds.lo[j]
+        } else {
+            input.x_l[j]
+        });
+        x_u_red.push(if bounds.hi[j].is_finite() {
+            bounds.hi[j]
+        } else {
+            input.x_u[j]
+        });
+    }
+
+    EliminationPlan {
+        n_full: n,
+        m_full: m,
+        recovery,
+        vars_kept,
+        row_kept,
+        rows_kept,
+        x_l_red,
+        x_u_red,
+        steps,
+        parent,
+        report,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Fixture {
+        rows: Vec<Vec<(usize, Number)>>,
+        row_const: Vec<Number>,
+        g_l: Vec<Number>,
+        g_u: Vec<Number>,
+        eligible: Vec<bool>,
+        x_l: Vec<Number>,
+        x_u: Vec<Number>,
+        n: usize,
+    }
+
+    impl Fixture {
+        fn new(n: usize) -> Self {
+            Self {
+                rows: Vec::new(),
+                row_const: Vec::new(),
+                g_l: Vec::new(),
+                g_u: Vec::new(),
+                eligible: Vec::new(),
+                x_l: vec![-1e19; n],
+                x_u: vec![1e19; n],
+                n,
+            }
+        }
+        /// `Σ a_j x_j = b`, linear and eligible.
+        fn eq(mut self, entries: &[(usize, Number)], b: Number) -> Self {
+            self.rows.push(entries.to_vec());
+            self.row_const.push(0.0);
+            self.g_l.push(b);
+            self.g_u.push(b);
+            self.eligible.push(true);
+            self
+        }
+        /// A row the pass must not consume (nonlinear, or an inequality).
+        fn opaque(mut self, entries: &[(usize, Number)], lo: Number, hi: Number) -> Self {
+            self.rows.push(entries.to_vec());
+            self.row_const.push(0.0);
+            self.g_l.push(lo);
+            self.g_u.push(hi);
+            self.eligible.push(false);
+            self
+        }
+        fn bounds(mut self, j: usize, lo: Number, hi: Number) -> Self {
+            self.x_l[j] = lo;
+            self.x_u[j] = hi;
+            self
+        }
+        fn plan(&self) -> EliminationPlan {
+            build_plan(
+                &PlanInput {
+                    n_vars: self.n,
+                    n_rows: self.rows.len(),
+                    rows: &self.rows,
+                    row_const: &self.row_const,
+                    g_l: &self.g_l,
+                    g_u: &self.g_u,
+                    eligible: &self.eligible,
+                    x_l: &self.x_l,
+                    x_u: &self.x_u,
+                },
+                &PlanConfig::default(),
+            )
+        }
+    }
+
+    /// Round-trip: lifting the reduced point must reproduce a full-space
+    /// point that satisfies every consumed row.
+    fn assert_rows_hold(f: &Fixture, plan: &EliminationPlan, y: &[Number]) {
+        let mut x = vec![0.0; f.n];
+        plan.lift_x(y, &mut x);
+        for (r, entries) in f.rows.iter().enumerate() {
+            if plan.row_kept[r] || !f.eligible[r] {
+                continue;
+            }
+            let lhs: Number =
+                entries.iter().map(|&(j, a)| a * x[j]).sum::<Number>() + f.row_const[r];
+            assert!(
+                (lhs - f.g_l[r]).abs() < 1e-9,
+                "dropped row {r} violated: {lhs} != {}",
+                f.g_l[r]
+            );
+        }
+    }
+
+    #[test]
+    fn singleton_row_pins_its_variable() {
+        let f = Fixture::new(2).eq(&[(0, 2.0)], 6.0);
+        let p = f.plan();
+        assert_eq!(p.recovery[0], VarRecovery::Constant(3.0));
+        assert_eq!(p.recovery[1], VarRecovery::Kept(0));
+        assert_eq!(p.vars_kept, vec![1]);
+        assert_eq!(p.rows_kept, Vec::<usize>::new());
+        assert_eq!(p.report.n_constant_vars, 1);
+        assert_rows_hold(&f, &p, &[7.5]);
+    }
+
+    #[test]
+    fn free_free_pair_aggregates_with_no_anchor() {
+        // The shape the determined-block pipeline cannot reach: both
+        // columns free and interior, no bound pinning either one.
+        let f = Fixture::new(2).eq(&[(0, 1.0), (1, -1.0)], 0.0);
+        let p = f.plan();
+        assert_eq!(p.n_reduced_vars(), 1);
+        assert_eq!(p.n_reduced_rows(), 0);
+        assert_eq!(p.report.n_aggregated_vars, 1);
+        assert_rows_hold(&f, &p, &[4.25]);
+        let mut x = vec![0.0; 2];
+        p.lift_x(&[4.25], &mut x);
+        assert!((x[0] - x[1]).abs() < 1e-12);
+    }
+
+    #[test]
+    fn chains_propagate_regardless_of_row_order() {
+        // Written back-to-front, so a single forward sweep cannot see the
+        // pin until it has already walked past the rows that need it. Only
+        // iterating to a fixed point collapses all four columns.
+        let f = Fixture::new(5)
+            .eq(&[(2, 1.0), (3, -1.0)], 0.0)
+            .eq(&[(1, 1.0), (2, -1.0)], 0.0)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .eq(&[(3, 2.0)], 8.0);
+        let p = f.plan();
+        // x0..x3 all pin to 4; x4 is untouched and is the only survivor.
+        assert_eq!(p.vars_kept, vec![4]);
+        assert_eq!(p.n_reduced_rows(), 0);
+        let mut x = vec![0.0; 5];
+        p.lift_x(&[9.0], &mut x);
+        for (j, v) in x.iter().take(4).enumerate() {
+            assert!((v - 4.0).abs() < 1e-12, "x{j} = {v}");
+        }
+        assert_rows_hold(&f, &p, &[9.0]);
+    }
+
+    #[test]
+    fn a_fully_determined_model_stands_down() {
+        // Every column determined would leave the IPM a zero-variable
+        // problem. Hand the square system back whole instead.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .eq(&[(1, 2.0)], 8.0);
+        let p = f.plan();
+        assert!(p.is_identity());
+        assert_eq!(p.n_reduced_vars(), 2);
+        assert_eq!(p.n_reduced_rows(), 2);
+    }
+
+    #[test]
+    fn chain_with_a_free_tail_collapses_to_one_column() {
+        // x0 = x1, x1 = x2, x2 = x3 with nothing pinning them: four
+        // columns become one.
+        let f = Fixture::new(4)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .eq(&[(1, 1.0), (2, -1.0)], 0.0)
+            .eq(&[(2, 1.0), (3, -1.0)], 0.0);
+        let p = f.plan();
+        assert_eq!(p.n_reduced_vars(), 1);
+        assert_eq!(p.n_reduced_rows(), 0);
+        let mut x = vec![0.0; 4];
+        p.lift_x(&[2.5], &mut x);
+        for v in &x {
+            assert!((v - 2.5).abs() < 1e-12, "{x:?}");
+        }
+        assert_rows_hold(&f, &p, &[2.5]);
+    }
+
+    #[test]
+    fn every_recovery_representative_is_a_survivor() {
+        // Path compression must leave no `Affine` pointing at a column that
+        // was itself eliminated — the wrapper's `lift_x` reads `out[rep]`
+        // directly and would otherwise read an unwritten slot.
+        let f = Fixture::new(5)
+            .eq(&[(0, 1.0), (1, -2.0)], 1.0)
+            .eq(&[(1, 1.0), (2, -3.0)], 2.0)
+            .eq(&[(2, 1.0), (3, -4.0)], 3.0);
+        let p = f.plan();
+        for rec in &p.recovery {
+            if let VarRecovery::Affine { rep, coeff, .. } = *rec {
+                assert!(
+                    matches!(p.recovery[rep], VarRecovery::Kept(_)),
+                    "representative {rep} is not a survivor"
+                );
+                assert!(coeff != 0.0);
+            }
+        }
+        assert_rows_hold(&f, &p, &vec![1.0; p.n_reduced_vars()]);
+    }
+
+    #[test]
+    fn a_fixed_variable_exposes_a_two_term_row() {
+        // x2 is pinned by its own box, so the three-term row becomes a
+        // two-term one and x0 folds onto x1.
+        let f = Fixture::new(3)
+            .eq(&[(0, 1.0), (1, 1.0), (2, 1.0)], 10.0)
+            .bounds(2, 4.0, 4.0);
+        let p = f.plan();
+        assert_eq!(p.recovery[2], VarRecovery::Constant(4.0));
+        assert_eq!(p.n_reduced_vars(), 1);
+        let mut x = vec![0.0; 3];
+        p.lift_x(&[1.5], &mut x);
+        assert!((x[0] + x[1] + x[2] - 10.0).abs() < 1e-12, "{x:?}");
+    }
+
+    #[test]
+    fn bounds_transfer_onto_the_survivor() {
+        // x0 = 2·x1 with x0 ∈ [4, 10] pins x1 into [2, 5].
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, -2.0)], 0.0)
+            .bounds(0, 4.0, 10.0);
+        let p = f.plan();
+        assert_eq!(p.vars_kept, vec![1]);
+        assert!((p.x_l_red[0] - 2.0).abs() < 1e-12, "{:?}", p.x_l_red);
+        assert!((p.x_u_red[0] - 5.0).abs() < 1e-12, "{:?}", p.x_u_red);
+    }
+
+    #[test]
+    fn negative_coefficient_flips_the_transferred_bounds() {
+        // x0 = -x1 with x0 ∈ [1, 3] pins x1 into [-3, -1].
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, 1.0)], 0.0)
+            .bounds(0, 1.0, 3.0);
+        let p = f.plan();
+        assert_eq!(p.vars_kept, vec![1]);
+        assert!((p.x_l_red[0] + 3.0).abs() < 1e-12, "{:?}", p.x_l_red);
+        assert!((p.x_u_red[0] + 1.0).abs() < 1e-12, "{:?}", p.x_u_red);
+    }
+
+    #[test]
+    fn absent_bounds_keep_the_callers_sentinel() {
+        let f = Fixture::new(2).eq(&[(0, 1.0), (1, -1.0)], 0.0);
+        let p = f.plan();
+        assert_eq!(p.x_l_red[0], -1e19);
+        assert_eq!(p.x_u_red[0], 1e19);
+    }
+
+    #[test]
+    fn redundant_row_after_substitution_is_dropped() {
+        // x0 = x1 and x1 = x2 make x0 = x2 vacuous.
+        let f = Fixture::new(3)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .eq(&[(1, 1.0), (2, -1.0)], 0.0)
+            .eq(&[(0, 1.0), (2, -1.0)], 0.0);
+        let p = f.plan();
+        assert_eq!(p.n_reduced_vars(), 1);
+        assert_eq!(p.n_reduced_rows(), 0);
+        assert_eq!(p.report.n_redundant_rows, 1);
+    }
+
+    #[test]
+    fn contradiction_abandons_the_whole_plan() {
+        // x0 = x1 and x0 - x1 = 1 cannot both hold.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .eq(&[(0, 1.0), (1, -1.0)], 1.0);
+        let p = f.plan();
+        assert!(p.report.infeasible);
+        assert!(
+            p.is_identity(),
+            "a contradictory model must be handed back whole"
+        );
+        assert_eq!(p.n_reduced_vars(), 2);
+        assert_eq!(p.n_reduced_rows(), 2);
+    }
+
+    #[test]
+    fn a_singleton_outside_its_box_abandons_the_plan() {
+        let f = Fixture::new(2).eq(&[(0, 1.0)], 5.0).bounds(0, 0.0, 1.0);
+        let p = f.plan();
+        assert!(p.report.infeasible);
+        assert!(p.is_identity());
+    }
+
+    #[test]
+    fn a_float_noise_excursion_clamps_instead_of_abandoning() {
+        // x0 = 0.1 + 0.2 with x0 ≤ 0.3: infeasible by 5.5e-17, which is
+        // binary float noise, not an empty set.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0)], 0.1 + 0.2)
+            .bounds(0, 0.0, 0.3);
+        let p = f.plan();
+        assert!(!p.report.infeasible);
+        assert_eq!(p.recovery[0], VarRecovery::Constant(0.3));
+    }
+
+    #[test]
+    fn an_emptied_survivor_box_abandons_the_plan() {
+        // x0 = x1 with disjoint boxes.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .bounds(0, 5.0, 6.0)
+            .bounds(1, 1.0, 2.0);
+        let p = f.plan();
+        assert!(p.report.infeasible);
+        assert!(p.is_identity());
+    }
+
+    #[test]
+    fn ineligible_rows_are_never_consumed() {
+        let f = Fixture::new(2).opaque(&[(0, 1.0), (1, -1.0)], 0.0, 0.0);
+        let p = f.plan();
+        assert!(p.is_identity());
+        assert_eq!(p.n_reduced_vars(), 2);
+    }
+
+    #[test]
+    fn an_inequality_row_is_never_consumed() {
+        let mut f = Fixture::new(2);
+        f.rows.push(vec![(0, 1.0), (1, -1.0)]);
+        f.row_const.push(0.0);
+        f.g_l.push(0.0);
+        f.g_u.push(1.0);
+        f.eligible.push(true);
+        let p = f.plan();
+        assert!(p.is_identity());
+    }
+
+    #[test]
+    fn a_one_sided_row_at_the_sentinel_is_not_an_equality() {
+        // `g_l = g_u = 1e19` is a one-sided row spelled with the absent
+        // sentinel on both ends, not an equality at 1e19 (#396 family).
+        let mut f = Fixture::new(2);
+        f.rows.push(vec![(0, 1.0), (1, -1.0)]);
+        f.row_const.push(0.0);
+        f.g_l.push(-1e19);
+        f.g_u.push(-1e19);
+        f.eligible.push(true);
+        let p = f.plan();
+        assert!(p.is_identity());
+    }
+
+    #[test]
+    fn the_row_constant_is_honoured() {
+        // g(x) = x0 - x1 + 3, constrained to 0 ⇒ x0 - x1 = -3.
+        let mut f = Fixture::new(2);
+        f.rows.push(vec![(0, 1.0), (1, -1.0)]);
+        f.row_const.push(3.0);
+        f.g_l.push(0.0);
+        f.g_u.push(0.0);
+        f.eligible.push(true);
+        let p = f.plan();
+        let mut x = vec![0.0; 2];
+        p.lift_x(&[2.0], &mut x);
+        assert!((x[0] - x[1] + 3.0).abs() < 1e-12, "{x:?}");
+    }
+
+    #[test]
+    fn three_term_rows_are_left_alone() {
+        let f = Fixture::new(3).eq(&[(0, 1.0), (1, 1.0), (2, 1.0)], 1.0);
+        let p = f.plan();
+        assert!(p.is_identity());
+    }
+
+    #[test]
+    fn steps_are_recorded_in_application_order_with_live_pivots() {
+        let f = Fixture::new(3)
+            .eq(&[(0, 2.0), (1, -1.0)], 0.0)
+            .eq(&[(1, 3.0), (2, -1.0)], 0.0);
+        let p = f.plan();
+        assert_eq!(p.steps.len(), 2);
+        assert_eq!(p.steps[0].row, 0);
+        assert!(p.steps[0].pivot != 0.0);
+        assert_eq!(p.steps[1].row, 1);
+        // Each step's variable is distinct and never a survivor.
+        for s in &p.steps {
+            assert!(!matches!(p.recovery[s.var], VarRecovery::Kept(_)));
+        }
+    }
+
+    #[test]
+    fn parent_edges_point_at_later_or_never_eliminated_columns() {
+        // The postsolve recovery relies on this: a node's parent is a root
+        // at the moment of the merge, so it is eliminated strictly later
+        // (or not at all). That is what makes the reverse sweep triangular.
+        let f = Fixture::new(4)
+            .eq(&[(0, 1.0), (1, -1.0)], 0.0)
+            .eq(&[(1, 1.0), (2, -1.0)], 0.0)
+            .eq(&[(2, 1.0), (3, -1.0)], 0.0);
+        let p = f.plan();
+        let mut step_of = [usize::MAX; 4];
+        for (t, s) in p.steps.iter().enumerate() {
+            step_of[s.var] = t;
+        }
+        for (i, edge) in p.parent.iter().enumerate() {
+            if let Some((parent, _)) = *edge {
+                let ti = step_of[i];
+                let tp = step_of[parent];
+                assert!(ti != usize::MAX);
+                assert!(tp == usize::MAX || tp > ti, "{i} -> {parent}");
+            }
+        }
+    }
+
+    #[test]
+    fn identity_plan_round_trips() {
+        let p = EliminationPlan::identity(3, 2, &[-1.0, -1.0, -1.0], &[1.0, 1.0, 1.0]);
+        assert!(p.is_identity());
+        let mut x = vec![0.0; 3];
+        p.lift_x(&[1.0, 2.0, 3.0], &mut x);
+        assert_eq!(x, vec![1.0, 2.0, 3.0]);
+        let mut y = vec![0.0; 3];
+        p.project_x(&x, &mut y);
+        assert_eq!(y, vec![1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn a_long_alias_chain_stays_shallow() {
+        // 400 aliases with equal coefficients: the union-by-size tie-break
+        // must keep the elimination forest logarithmic, because postsolve
+        // walks ancestor chains per dropped-row nonzero.
+        let mut f = Fixture::new(400);
+        for j in 0..399 {
+            f = f.eq(&[(j, 1.0), (j + 1, -1.0)], 0.0);
+        }
+        let p = f.plan();
+        assert_eq!(p.n_reduced_vars(), 1);
+        let mut depth = 0usize;
+        for i in 0..400 {
+            let mut d = 0usize;
+            let mut cur = i;
+            while let Some((parent, _)) = p.parent[cur] {
+                cur = parent;
+                d += 1;
+            }
+            depth = depth.max(d);
+        }
+        assert!(
+            depth <= 32,
+            "elimination forest depth {depth} is not shallow"
+        );
+        let mut x = vec![0.0; 400];
+        p.lift_x(&[7.0], &mut x);
+        for v in &x {
+            assert!((v - 7.0).abs() < 1e-12);
+        }
+    }
+}

--- a/crates/pounce-presolve/src/options.rs
+++ b/crates/pounce-presolve/src/options.rs
@@ -257,9 +257,19 @@ pub fn register_options(reg: &RegisteredOptions) -> Result<(), SolverException> 
         "presolve_linear_eq_reduction",
         "Eliminate variables via linear-equality rows.",
         false,
-        "Reduces problem dimension by Gauss-eliminating against \
-         linear equality rows. Off by default because it changes \
-         the variable count and complicates sensitivity integration.",
+        "Phase 6: eliminates the variables the linear equality rows \
+         determine, iterated to a fixed point so chains propagate. Three \
+         shapes — a variable fixed by equal bounds, a singleton row \
+         `a*x = b`, and a two-variable row `a1*x + a2*y = b`, the last with \
+         no anchoring requirement, so free/free pairs (arc equalities, \
+         aliases, unit-conversion links) aggregate away. Rows reduced to \
+         `0 = 0` are dropped as redundant. Bounds are transferred onto the \
+         surviving variable, and the primal and every row multiplier are \
+         recovered in the original space at finalize_solution. Off by \
+         default because it changes the variable count, which the \
+         sensitivity and reduced-Hessian paths index against the original \
+         model. An eliminated variable's *bound* multiplier is reported on \
+         the survivor that inherited the bound.",
     )?;
 
     reg.add_bool_option(

--- a/crates/pounce-wasm/src/lib.rs
+++ b/crates/pounce-wasm/src/lib.rs
@@ -455,9 +455,24 @@ fn solve_loaded(tnlp: Rc<RefCell<NlTnlp>>, opts: &str) -> serde_json::Value {
             ),
         ))
     });
-    let target: Rc<RefCell<dyn TNLP>> = match &presolve {
-        Some(p) => Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
-        None => Rc::clone(&tnlp) as Rc<RefCell<dyn TNLP>>,
+    // Phase 6 (#487) stacks on top of the rest of presolve: it is the one
+    // pass that removes columns, so it has to be the outermost layer. The
+    // browser reads its results off `NlTnlp` below, which receives the
+    // full-space solution from `finalize_solution`, so nothing else here
+    // needs to know the reduced problem existed.
+    let elim = match (&presolve, presolve_opts.linear_eq_reduction) {
+        (Some(p), true) => Some(Rc::new(RefCell::new(
+            pounce_presolve::LinearEqElimTnlp::new(
+                Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
+                presolve_opts,
+            ),
+        ))),
+        _ => None,
+    };
+    let target: Rc<RefCell<dyn TNLP>> = match (&elim, &presolve) {
+        (Some(e), _) => Rc::clone(e) as Rc<RefCell<dyn TNLP>>,
+        (None, Some(p)) => Rc::clone(p) as Rc<RefCell<dyn TNLP>>,
+        (None, None) => Rc::clone(&tnlp) as Rc<RefCell<dyn TNLP>>,
     };
 
     let status = app.optimize_tnlp(target);
@@ -469,6 +484,14 @@ fn solve_loaded(tnlp: Rc<RefCell<NlTnlp>>, opts: &str) -> serde_json::Value {
             "tightened_bounds": tr.n_tightened,
             "newly_finite_bounds": tr.n_new_finite,
             "dropped_rows": h.n_dropped_rows(),
+            "eliminated_columns": elim
+                .as_ref()
+                .map(|e| e.borrow().n_eliminated_vars())
+                .unwrap_or(0),
+            "eliminated_rows": elim
+                .as_ref()
+                .map(|e| e.borrow().n_eliminated_rows())
+                .unwrap_or(0),
         })
     });
 

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -349,10 +349,18 @@ Two things to know before turning it on:
 * **Dual attribution.** The recovery assumes an eliminated variable is
   interior to its own bounds at the optimum. When one of those bounds is
   active, the dual is reported on the *survivor's* bound multiplier (which
-  carries the transferred bound) and the eliminated variable's `ipopt_zL_out`
-  / `ipopt_zU_out` entry is zero. The primal point, the objective, and KKT
-  stationarity are unaffected — only the attribution differs, the same way
-  Phase 2's dropped rows behave.
+  carries the transferred bound) and the eliminated variable's bound
+  multiplier is zero. The primal point, the objective, and KKT stationarity
+  are unaffected — only the attribution differs, the same way Phase 2's
+  dropped rows behave.
+
+  A practical consequence for `.sol` readers: the writer omits exact zeros
+  from suffix blocks (it always has), so an eliminated variable gets **no**
+  `ipopt_zL_out` / `ipopt_zU_out` entry at all rather than an entry of zero.
+  Code that indexes those suffixes must treat a missing index as zero — as
+  it already must for any variable whose bound multiplier lands exactly on
+  zero. Row multipliers are unaffected: the dual block is dense and comes
+  back at the original row count.
 * **Failing closed.** If the equality system is contradictory, the pass
   stands down entirely and hands the model to the solver untouched, rather
   than being the first and only voice to call a model infeasible. The same

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -312,13 +312,56 @@ no-op for this library entry point.
 | `presolve`                              | `no`    | Master switch for the whole presolve layer. Off → wrapper is a no-op.          |
 | `presolve_bound_tightening`             | `yes`   | Phase 1 — Andersen-style bound propagation from linear rows.                   |
 | `presolve_redundant_constraint_removal` | `yes`   | Phase 2 — drop linear constraints already implied by current bounds.           |
-| `presolve_linear_eq_reduction`          | `no`    | Phase ≥2 — eliminate fixed singleton variables exposed by linear equalities.   |
+| `presolve_linear_eq_reduction`          | `no`    | Phase 6 — eliminate variables determined by linear equality rows (see below).   |
 | `presolve_licq_check`                   | `yes`   | Phase 3 — detect rank-deficient equality blocks before the IPM starts.         |
 | `presolve_licq_action`                  | `warn`  | What to do on degeneracy: `warn` (just report) or `auto_l1` (turn on ℓ₁).      |
 | `presolve_warm_z_bounds`                | `yes`   | Phase 4 — warm-start bound multipliers when bounds get tightened by Phase 1.   |
 | `presolve_bound_mult_init_val`          | `1.0`   | Value used by Phase 4 for those warm-start hints.                              |
 | `presolve_max_passes`                   | `3`     | Fixed-point iteration cap across the bound-tightening passes.                  |
 | `presolve_print_level`                  | `0`     | Per-pass verbosity (0 silent, 5 per-pass, 8 per-transformation).               |
+
+### Linear-equality variable elimination (Phase 6)
+
+`presolve_linear_eq_reduction=yes` is the only pass that removes
+**columns**. It reads the model's linear equality rows and eliminates the
+variables they determine, iterating to a fixed point so chains propagate:
+
+* a variable whose declared bounds are equal becomes a constant;
+* a singleton row `a·x = b` pins its variable at `b/a`;
+* a two-variable row `a₁·x + a₂·y = b` substitutes one variable for the
+  other, `x := α·y + β`. There is **no anchoring requirement**: a row
+  linking two otherwise-free interior variables — an arc equality, a
+  `Reference` alias, a unit-conversion link — aggregates away, which is
+  the case the [auxiliary-equality pass](auxiliary-presolve.md) cannot
+  reach because it only solves *determined* square blocks.
+
+Rows that collapse to `0 = 0` under the accumulated substitutions are
+dropped as structurally redundant.
+
+Every eliminated variable's bounds are transferred onto its survivor, so
+the reduced box is never looser than the original. `finalize_solution`
+lifts the primal back to the original variable order and recovers a
+multiplier for each consumed row, so `.sol` / JSON solution blocks keep the
+original model's shape and can still be read positionally by AMPL or Pyomo.
+
+Two things to know before turning it on:
+
+* **Dual attribution.** The recovery assumes an eliminated variable is
+  interior to its own bounds at the optimum. When one of those bounds is
+  active, the dual is reported on the *survivor's* bound multiplier (which
+  carries the transferred bound) and the eliminated variable's `ipopt_zL_out`
+  / `ipopt_zU_out` entry is zero. The primal point, the objective, and KKT
+  stationarity are unaffected — only the attribution differs, the same way
+  Phase 2's dropped rows behave.
+* **Failing closed.** If the equality system is contradictory, the pass
+  stands down entirely and hands the model to the solver untouched, rather
+  than being the first and only voice to call a model infeasible. The same
+  goes for a model whose every column is determined: a zero-variable problem
+  is not a shape worth handing the IPM.
+
+It is off by default because it changes the variable count, which the
+sensitivity and reduced-Hessian paths index against the original `.nl`.
+(The CLI already disables presolve entirely when those are requested.)
 
 ### Feasibility-based bound tightening (Phase 1b)
 


### PR DESCRIPTION
Fixes #487

## Problem

`presolve_linear_eq_reduction` was a registered option with nothing behind it — `PresolveOptions` read the key and no code ever consulted it.

The gap it left is the one #487 measured: a solvent-extraction NMPC flowsheet declares 23,681 variables and 23,138 equality rows, and Pyomo's NL-v2 writer — with the linear presolve its `ipopt_v2` interface turns on by default — hands the solver 10,284 columns and 9,741 rows. POUNCE reached the solver at full size on every path.

Reproduced here on a synthetic alias-heavy model of the same shape (24,000 columns / 21,600 rows, release build):

| | columns to the solver | rows | wall time | objective |
|---|---|---|---|---|
| before | 24,000 | 21,600 | 1.63 s | 1.61e-09 |
| after | **2,400** | **0** | **0.30 s** | 8.06e-09 |

Both are converged points of a deliberately flat quartic; the objectives agree to the reported tolerance and the `.sol` body is 45,600 entries either way.

## Cause

Two of the three shapes NL-v2 recognises had no home in POUNCE.

The auxiliary-equality pipeline (#53) eliminates *determined* square linear blocks. A row linking two otherwise-free interior variables — an arc equality, a `Reference` alias, a unit-conversion link — determines neither of its columns, so it fell straight through. That free/free pair is most of the reduction on a flowsheet.

## Fix

Option (b) of #487's two candidate homes: an aggregation phase in `pounce-presolve`, so the CLI, GAMS, the C interface, and Pyomo all get one implementation — and the sensitivity session is not asked to thread a third variable space through index maps whose correctness currently rests on there being exactly two (the #450 hazard).

Three shapes, iterated to a fixed point so chains propagate: a variable fixed by equal bounds, a singleton row `a·x = b`, and a two-variable row `a₁·x + a₂·y = b` with **no anchoring requirement**. Rows reduced to `0 = 0` are dropped as redundant.

Two design choices worth recording, because both had a cheaper alternative that was tried and rejected:

**The wrapper stacks outside `PresolveTnlp`, not inside it.** Phases 0–5 are written against a fixed column space; threading a variable reduction through them means touching every one of ~15k lines of carefully-tested presolve. Stacking on top means the new layer is the only thing that changes `n`, and each layer undoes exactly its own reduction at `finalize_solution`.

**Duals are recovered by a reverse sweep, not a factorization.** Restricted to the eliminated columns, the dual system is `J_D[:,e]ᵀ λ_D = −(∇f_e + J_K[:,e]ᵀ λ_K)` — square, sparse, and not something anyone wants inside presolve. Taken one elimination at a time in reverse order it is triangular instead: every other row of the problem-as-it-stood-then survives that step, so stationarity at that step's column has exactly one unknown multiplier. That makes the recovery a linear sweep over the elimination forest. The pivot tie-break uses union-by-size so alias chains stay shallow, since postsolve walks ancestor chains per dropped-row nonzero.

Correcting my own first attempt: I had the recovery in the `∇f − Jᵀλ` convention that `reduction_frame.rs` documents. What `finalize_solution` actually delivers is Ipopt's `∇f + Jᵀλ − z_l + z_u = 0`, verified empirically against a bare solve. The shipped code uses the latter.

## Blast radius

**Off by default**, and a no-op in three further ways: the wrapper falls into a verbatim-forwarding passthrough when the option is off, when the inner TNLP declines to publish its Hessian structure, and when the plan finds nothing to remove. Every existing presolve test is unchanged and green.

Fails closed. A contradictory equality system, or a model whose every column is determined, abandons the plan entirely and hands the model over untouched — an elimination pass is the wrong place to be the first and only voice calling a model infeasible.

Three limits worth stating plainly. Each is now filed as a follow-up:

- **LP and convex-QP models never see this phase** (#494), because the CLI dispatches to `pounce-convex` before any presolve wrapper is built. That is pre-existing and applies to the whole presolve layer, not just this phase. It does *not* mean those models go unpresolved — `pounce-convex` has its own PaPILO-style reduction stack, on by default. The real gap is narrower: that stack has singleton-row and free-column-singleton reductions but no **doubleton aggregation**, which is the shape that carries a flowsheet. Its own module docs name it as a known gap.
- **The `.nl` path cannot reach the row-constant branch** (#492). `get_constraints_linearity` tests whether a row's expression segment is *identically* zero, not whether it is affine, so a row carrying a bare constant is tagged NonLinear and the pass declines it. Verified directly; the branch is live only on the general TNLP path. The same predicate makes such a model classify as NLP rather than LP, so folding the constant into the bound at parse fixes both.
- **An eliminated column whose bound is active reports that multiplier on its survivor** (#493), because the bound was transferred there during planning. Primal, objective, and full-space stationarity are unaffected; only that one dual's attribution differs from a no-presolve solve. Documented at the head of `linear_eq_elim.rs`. The absent `ipopt_zL_out` / `ipopt_zU_out` entry is a symptom of this, not a `.sol` writer defect — sparse suffixes are the AMPL convention and readers zero-initialize, so the omission is lossless.

## Tests

New tests exercise new code, so "fails on the parent commit" is not available in the usual sense — they would not compile there. The evidence that they bite is mutation testing instead: five defects injected one at a time into the shipped code, each reverted after.

| injected defect | caught by | signal |
|---|---|---|
| drop the Hessian symmetric-pair ×2 factor | derivative probe | 573 / 1200 |
| ignore the sign of α when transferring bounds | plan probe | 600 / 1200 |
| forget the row constant `c` in `g_r = Σaⱼxⱼ + c` | primal-fidelity check | 459 / 1200 |
| lift an eliminated column without its offset β | plan probe | 573 / 1200 |
| skip the dual recovery (report λ = 0) | integration test | 2 tests |

The row-constant defect escaped **every** probe on the first pass, which was the most useful result of the exercise: derivatives are blind to an affine offset, since `∇(αy + β) = α` either way. The probe now pushes a reduced point through `finalize_solution` and checks the consumed rows still hold at the lift.

Layers:

- 30 unit tests on the planner and the transforms.
- `presolve_phase6_linear_eq_elim.rs` — solves through the full stack and checks full-space KKT stationarity of the returned duals, plus exact agreement with the bare solve. Also covers `wrap_with_presolve`, the composition point every library caller, the C interface, and the GAMS link go through.
- `linear_eq_reduction.rs` + a new `.nl` fixture — the `.sol` blocks come back at the original length and order with the consumed row's multiplier recovered.
- `adversary/fuzz` `linelim` probe — 12,000 randomized instances across three seeds, generated around a known feasible point the pass never sees. 0 failures.
- `adversary/runs/2026-08-06_nlp_linear_eq_reduction_verify.py` — 120 randomized `.nl` models through the CLI, checked by `pounce verify` (independent KKT/feasibility against the original file) and by in-script re-evaluation of every row. 0 failures.

Everything re-run after rebasing onto #489, which changed `.nl` derivative evaluation. Full workspace suite, `cargo fmt --check`, the CI clippy gate, and `check-release-consistency.sh` all clean.

Deliberately not pinned: the 23,681-variable flowsheet itself is not in the repo, so the headline measurement is reproduced on a synthetic model of the same shape rather than the original.

---

- [x] Tests fail on the parent commit for the stated reason — see the mutation table above; the tests target new code that does not exist on the parent
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`options.md`, new Phase 6 section; no new page, so `SUMMARY.md` unchanged)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016JAvpSWoMKnBjNEoviZgVW

---
_Generated by [Claude Code](https://claude.ai/code/session_016JAvpSWoMKnBjNEoviZgVW)_