### PR TITLE
presolve: attribute a transferred bound's multiplier to the column it came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,11 +41,17 @@ changes.
   the elimination forest, not a factorization. `.sol` and JSON solution
   blocks come back at the original model's length, in the original order,
   and can still be read positionally by AMPL and Pyomo.
-- Two documented caveats, both in `docs/src/options.md`: an eliminated
-  variable's *bound* multiplier is reported on the survivor that inherited
-  the bound (the same attribution trade the Phase-2 row drop makes), and a
-  contradictory equality system makes the pass stand down entirely rather
-  than be the first and only voice calling a model infeasible.
+- A transferred bound's multiplier is reported on the variable that
+  **declared** the bound, not on the survivor that inherited it (#493). The
+  plan records where each reduced bound came from; postsolve rescales the
+  multiplier by the substitution coefficient `α` and sends it to the other
+  side of the box when `α < 0`, so `ipopt_zL_out` / `ipopt_zU_out` match a
+  no-presolve solve. Where the survivor's own bound is active *as well*, the
+  split is genuinely non-unique and the multiplier stays on the survivor —
+  still a valid KKT point, and documented as such in `docs/src/options.md`.
+- One documented caveat remains, in `docs/src/options.md`: a contradictory
+  equality system makes the pass stand down entirely rather than be the
+  first and only voice calling a model infeasible.
 
 ### Fixed — the C working-set API validated nothing structural, and reported the wrong row order (#484 follow-up, round 4)
 

--- a/adversary/fuzz/examples/plan_dump.rs
+++ b/adversary/fuzz/examples/plan_dump.rs
@@ -1,0 +1,61 @@
+//! Dump the Phase-6 plan for an instance fed as JSON-ish text on stdin
+//! (adversary debugging tool; reads the same arrays the probe writes into `.nl`).
+//!
+//! stdin format, one item per line:
+//!   n
+//!   rows      : "col:coef,col:coef;col:coef,..."   (rows separated by ';')
+//!   row_const : comma-separated
+//!   g         : comma-separated
+//!   x_l       : comma-separated
+//!   x_u       : comma-separated
+use pounce_presolve::{PlanConfig, PlanInput, VarRecovery, build_plan};
+use std::io::Read;
+
+fn nums(s: &str) -> Vec<f64> {
+    s.trim().split(',').filter(|t| !t.is_empty()).map(|t| t.trim().parse().unwrap()).collect()
+}
+
+fn main() {
+    let mut buf = String::new();
+    std::io::stdin().read_to_string(&mut buf).unwrap();
+    let mut it = buf.lines();
+    let n: usize = it.next().unwrap().trim().parse().unwrap();
+    let rows: Vec<Vec<(usize, f64)>> = it
+        .next().unwrap().trim().split(';').filter(|s| !s.is_empty())
+        .map(|r| r.split(',').filter(|s| !s.is_empty()).map(|e| {
+            let (c, a) = e.split_once(':').unwrap();
+            (c.trim().parse().unwrap(), a.trim().parse().unwrap())
+        }).collect())
+        .collect();
+    let row_const = nums(it.next().unwrap());
+    let g = nums(it.next().unwrap());
+    let x_l = nums(it.next().unwrap());
+    let x_u = nums(it.next().unwrap());
+    let m = rows.len();
+    let eligible = vec![true; m];
+    let plan = build_plan(
+        &PlanInput { n_vars: n, n_rows: m, rows: &rows, row_const: &row_const,
+                     g_l: &g, g_u: &g, eligible: &eligible, x_l: &x_l, x_u: &x_u },
+        &PlanConfig::default(),
+    );
+    let mut collapsed = Vec::new();
+    for (red, &k) in plan.vars_kept.iter().enumerate() {
+        let (lo, hi) = (plan.x_l_red[red], plan.x_u_red[red]);
+        let pointlike = lo.is_finite() && hi.is_finite()
+            && (hi - lo).abs() <= 1e-9 * lo.abs().max(hi.abs()).max(1.0);
+        let declared_point = (x_u[k] - x_l[k]).abs() <= 1e-12;
+        if pointlike && !declared_point {
+            collapsed.push(k);
+        }
+    }
+    println!("kept={:?} steps={} collapsed_reduced_boxes={:?}",
+             plan.vars_kept, plan.steps.len(), collapsed);
+    for (red, &k) in plan.vars_kept.iter().enumerate() {
+        println!("  col{k}: reduced=[{:.12}, {:.12}] src=({},{}) declared=[{}, {}]",
+                 plan.x_l_red[red], plan.x_u_red[red],
+                 plan.x_l_src[red], plan.x_u_src[red], x_l[k], x_u[k]);
+    }
+    for (j, r) in plan.recovery.iter().enumerate() {
+        if !matches!(r, VarRecovery::Kept(_)) { println!("  col{j} -> {r:?}"); }
+    }
+}

--- a/adversary/fuzz/src/linelim_probe.rs
+++ b/adversary/fuzz/src/linelim_probe.rs
@@ -8,7 +8,7 @@
 //!
 //! Every instance is generated **around a known feasible point** `x*`: the
 //! right-hand sides are computed from `x*`, and every box is drawn to contain
-//! it. That makes `x*` an oracle the pass has never seen, and it pins five
+//! it. That makes `x*` an oracle the pass has never seen, and it pins six
 //! properties that a wrong substitution cannot fake:
 //!
 //! * **Fidelity** — projecting `x*` onto the survivors and lifting must
@@ -24,6 +24,12 @@
 //!   converse direction, and it is the one the `α < 0` bound flip breaks.
 //! * **Row fidelity at an arbitrary point** — every consumed row must hold at
 //!   the lift of a random reduced point, not just at `x*`.
+//! * **Bound provenance** — every reduced bound must lift, through the
+//!   recovery map of the column the plan says it came from, exactly onto that
+//!   column's declared bound (gh#493). This is the identity postsolve relies
+//!   on to hand a bound multiplier back to the column that owns it, and it is
+//!   invisible to a stationarity check: full-space stationarity closes with
+//!   the multiplier on either column.
 //! * **Structural integrity** — rows and columns account exactly, and every
 //!   `Affine` representative is a survivor (the wrapper's `lift_x` reads that
 //!   slot directly).
@@ -303,6 +309,73 @@ pub fn check_plan(inst: &Instance) -> PlanVerdict {
             return PlanVerdict::Failed(format!(
                 "reduced upper bound on column {full} is {hi}, below the feasible x*[{full}] = {v}"
             ));
+        }
+    }
+
+    // --- bound provenance (gh#493) ---------------------------------------
+    // Postsolve hands a reduced bound's multiplier to the column the bound
+    // was declared on, rescaled by that column's coefficient and flipped to
+    // the other side of its box when the coefficient is negative. All of
+    // that rests on one identity, which is what this checks: lifting the
+    // reduced bound through the origin's own recovery map must land exactly
+    // on the origin's declared bound. The stationarity checks elsewhere in
+    // this probe cannot see a wrong answer here — they pass with the
+    // multiplier on either column.
+    if plan.vars_kept.len() != plan.x_l_src.len() || plan.vars_kept.len() != plan.x_u_src.len() {
+        return PlanVerdict::Failed(
+            "bound provenance length disagrees with the survivor count".into(),
+        );
+    }
+    for (red, &full) in plan.vars_kept.iter().enumerate() {
+        for (src, bound, upper) in [
+            (plan.x_l_src[red], plan.x_l_red[red], false),
+            (plan.x_u_src[red], plan.x_u_red[red], true),
+        ] {
+            if src >= inst.n {
+                return PlanVerdict::Failed(format!(
+                    "bound provenance on column {full} names column {src}, out of range"
+                ));
+            }
+            // An absent bound carries no multiplier, so it needs no owner.
+            if bound <= SENTINEL_LO || bound >= SENTINEL_HI || !bound.is_finite() {
+                continue;
+            }
+            let (coeff, offset) = if src == full {
+                (1.0, 0.0)
+            } else {
+                match plan.recovery[src] {
+                    VarRecovery::Affine { rep, coeff, offset } if rep == full => (coeff, offset),
+                    other => {
+                        return PlanVerdict::Failed(format!(
+                            "column {full}'s {} bound is attributed to column {src}, whose \
+                             recovery is {other:?} rather than an affine image of {full}",
+                            if upper { "upper" } else { "lower" }
+                        ));
+                    }
+                }
+            };
+            // Which side of the origin's box: its own when α > 0, the
+            // opposite one when α < 0.
+            let declared = if upper != (coeff < 0.0) {
+                inst.x_u[src]
+            } else {
+                inst.x_l[src]
+            };
+            if declared <= SENTINEL_LO || declared >= SENTINEL_HI {
+                return PlanVerdict::Failed(format!(
+                    "column {full}'s finite {} bound {bound} is attributed to column {src}, \
+                     which declares no bound on that side",
+                    if upper { "upper" } else { "lower" }
+                ));
+            }
+            let lifted = coeff * bound + offset;
+            if (lifted - declared).abs() > tol {
+                return PlanVerdict::Failed(format!(
+                    "column {full}'s {} bound {bound} lifts to {lifted} on column {src}, whose \
+                     declared bound there is {declared}",
+                    if upper { "upper" } else { "lower" }
+                ));
+            }
         }
     }
 

--- a/adversary/log.org
+++ b/adversary/log.org
@@ -10,48 +10,21 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 
 | Family          | Tested | Last run   | Open findings |
 |-----------------+--------+------------+---------------|
-| nlp             |     12 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6) |
-| lp              |     10 | 2026-08-04 | —             |
-| qp              |     10 | 2026-08-03 | —             |
+| nlp             |     13 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6); #495 (Phase 6 produces no bound multiplier for an eliminated column whose bound is active — pre-existing, off-by-default option) |
+| lp              |     11 | 2026-08-06 | —             |
+| qp              |     11 | 2026-08-06 | —             |
 | qp-active-set   |     14 | 2026-08-05 | both probes now CLEAN. Fixed this run: false-Infeasible (14 -> 0), `Optimal` at violating points, rank-deficiency hard errors, unvalidated working-set status codes, and IpoptGet/SetWorkingSet reporting the SQP's internal row order instead of the caller's. Nothing open. |
 | socp            |     11 | 2026-08-05 | —             |
 | exp             |     10 | 2026-08-04 | #336 FIXED 2026-07-23; regression-confirmed 2026-07-29 (benign-scale PASS) |
 | power           |     10 | 2026-08-04 | #336 FIXED 2026-07-23; regression-confirmed 2026-07-29 (benign-scale PASS); constant-coordinate x-precision gap noted 2026-08-02, reconfirmed 2026-08-04 in the opposite (concave) cone orientation (not filed, see reports) |
-| sdp             |     10 | 2026-08-03 | —             |
+| sdp             |     11 | 2026-08-06 | —             |
 | sos             |     11 | 2026-08-05 | extraction bug FIXED (regression-confirmed); #124 improved (no NaN/iter-limit at tested orders) |
 | autoroute       |     10 | 2026-08-04 | — (nonconvex misrouting-resistance confirmed; routing-transparency reconfirmed on boxed QP, quadratic-objective ball QCQP, transportation LP, and bounds-only diagonal QP)  |
-| batch           |     10 | 2026-08-04 | —             |
+| batch           |     11 | 2026-08-06 | —             |
 | diff            |     11 | 2026-08-05 | — (all PASS; near-LICQ degradation expected, not filed) |
-| sensitivity     |     10 | 2026-08-03 | — (weakly-active one-sided dx/db intrinsic/known; no barrier inflation confirmed; reduced_hessian() cross-checked clean) |
+| sensitivity     |     11 | 2026-08-06 | — (weakly-active one-sided dx/db intrinsic/known; no barrier inflation confirmed; reduced_hessian() cross-checked clean) |
 
 * Problem Index
-** [2026-08-06] Linear-equality variable elimination, Phase 6 (nlp/presolve, gh#487) - PASS
-:PROPERTIES:
-:FAMILY: nlp
-:SOURCE: randomized families built around a known feasible point x*; no published instance
-:KNOWN_OPTIMAL: n/a (property-based)
-:POUNCE_OBJECTIVE: n/a
-:POUNCE_STATUS: 12000 fuzz instances + 120 end-to-end .nl solves, 0 failures
-:POUNCE_TIME: ~4 min total
-:ORACLE: pounce verify (independent KKT/feasibility vs the original .nl); central finite differences of the wrapper's own reduced eval_f/eval_g; in-script row re-evaluation
-:ORACLE_OBJECTIVE: n/a
-:ORACLE_TIME: n/a
-:VERDICT: PASS
-:REPORT: [[file:runs/2026-08-06_nlp_linear-eq-reduction.org]]
-:COVERAGE_TARGET: linear_eq_plan.rs / linear_eq_elim.rs — new files, no prior adversarial coverage
-:END:
-
-Probes validated by mutation testing: five injected defects (Hessian
-symmetric-pair x2 factor, bound-transfer sign, row constant, lift offset, dual
-recovery) were each caught. The row-constant defect initially escaped every
-probe — derivatives are blind to an affine offset — which is why the probe now
-carries a primal-fidelity check through =finalize_solution=.
-
-Recorded non-defect: a row whose constant lives in its =.nl= expression segment
-is tagged NonLinear by the reader, so the elimination declines it. The
-row-constant branch is therefore reachable only on the general TNLP path (C
-interface, GAMS, callbacks), not via =.nl=.
-
 ** [2026-08-05] l1-elastic infeasibility certificate under nonconvex step QPs (qp-active-set/certificate-soundness) - FAIL
 :PROPERTIES:
 :FAMILY: qp-active-set
@@ -4825,3 +4798,169 @@ Hard-margin SVM posed via genuine SOC epigraph (min ||w||, not the more
 commonly-tested 1/2||w||^2 QP form) -- exercises solve_socp directly. 4
 symmetric points, all support vectors; w=(1,3.7e-22), b=5.2e-23 matches
 closed form w*=(1,0), b*=0 to float64 noise.
+
+** [2026-08-06] Soft-margin (C-SVM) dual QP (qp/box+equality, kernel Gram-matrix) - PASS
+:PROPERTIES:
+:FAMILY: qp
+:SOURCE: Cortes & Vapnik (1995); standard C-SVM dual, e.g. Bishop PRML Sec 7.1.1
+:KNOWN_OPTIMAL: none published (oracle-only)
+:POUNCE_OBJECTIVE: -8.7336244354e-01
+:POUNCE_STATUS: optimal
+:POUNCE_TIME: 0.0042s
+:ORACLE: cvxpy CLARABEL
+:ORACLE_OBJECTIVE: -8.7336244521e-01
+:ORACLE_TIME: 0.0123s
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_qp_soft_margin_svm.org]]
+:COVERAGE_TARGET: -
+:END:
+6-point non-separable 2D dataset, C=1, genuinely activates the box bound
+0<=alpha<=C (unlike the hard-margin QP already logged). obj/alpha/w all
+agree with cvxpy to ~1e-8.
+
+** [2026-08-06] MAX-CUT SDP relaxation on C4 (sdp/PSD cone, bipartite-tight) - PASS
+:PROPERTIES:
+:FAMILY: sdp
+:SOURCE: Goemans & Williamson (1995), J. ACM 42(6)
+:KNOWN_OPTIMAL: 4.0
+:POUNCE_OBJECTIVE: 3.9999999983e+00
+:POUNCE_STATUS: optimal
+:POUNCE_TIME: 0.0060s
+:ORACLE: cvxpy CLARABEL
+:ORACLE_OBJECTIVE: 3.9999999991e+00
+:ORACLE_TIME: 0.0141s
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_sdp_maxcut_c4.org]]
+:COVERAGE_TARGET: -
+:END:
+Bipartite 4-cycle -> SDP relaxation is provably tight at 4.0. First
+attempt had a self-inconsistent svec scaling (pounce and cvxpy
+disagreeing with EACH OTHER) -- caught via the explicit svec()/smat()
+helper rewrite before concluding anything about pounce; final run
+matches known-tight optimum and cvxpy to <1e-9.
+
+** [2026-08-06] 2x2 zero-sum matrix game value via LP (lp/minimax, von Neumann) - PASS
+:PROPERTIES:
+:FAMILY: lp
+:SOURCE: von Neumann minimax theorem; Chvatal, Linear Programming (1983) Ch. 15
+:KNOWN_OPTIMAL: 0.2
+:POUNCE_OBJECTIVE: 1.9999999976e-01
+:POUNCE_STATUS: optimal
+:POUNCE_TIME: 0.0059s
+:ORACLE: scipy.optimize.linprog (HiGHS)
+:ORACLE_OBJECTIVE: 2.0000000000e-01
+:ORACLE_TIME: 0.0033s
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_lp_matrix_game_value.org]]
+:COVERAGE_TARGET: -
+:END:
+A=[[2,-1],[-1,1]], no pure saddle point. Closed-form v*=1/5, p*=(0.4,0.6)
+matches pounce and scipy/HiGHS to <5e-10. New problem class for lp
+(game-theoretic minimax) with a genuinely mixed equilibrium.
+
+** [2026-08-06] Economic-dispatch QP sensitivity dP_i/dD (sensitivity/dx-db, applied power-systems) - PASS
+:PROPERTIES:
+:FAMILY: sensitivity
+:SOURCE: Wood, Wollenberg & Sheble, Power Generation Operation and Control, Ch. 3
+:KNOWN_OPTIMAL: closed-form equal-incremental-cost dP_i/dD
+:POUNCE_OBJECTIVE: n/a (sensitivity vector, see report)
+:POUNCE_STATUS: optimal
+:POUNCE_TIME: n/a
+:ORACLE: closed-form + independent numpy bordered-KKT finite-difference
+:ORACLE_OBJECTIVE: n/a
+:ORACLE_TIME: n/a
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_sensitivity_economic_dispatch.org]]
+:COVERAGE_TARGET: -
+:END:
+4-generator economic dispatch, QpSensitivity.parametric_step vs
+closed-form equal-incremental-cost formula (5.55e-17) and vs an
+independently-assembled numpy bordered-KKT finite-difference re-solve
+(1.04e-13) -- neither oracle touches pounce's own solve_qp. New applied
+problem class for sensitivity, distinct from prior generic KKT dx/db probes.
+
+** [2026-08-06] solve_qp_batch dual/multiplier consistency (batch/KKT-multiplier-parity) - PASS
+:PROPERTIES:
+:FAMILY: batch
+:SOURCE: family-table oracle = per-item solve_qp
+:KNOWN_OPTIMAL: none (parity check)
+:POUNCE_OBJECTIVE: n/a (7-instance batch, see report)
+:POUNCE_STATUS: all optimal
+:POUNCE_TIME: 0.0099s (batch total)
+:ORACLE: pounce solve_qp per item (7x)
+:ORACLE_OBJECTIVE: n/a
+:ORACLE_TIME: 0.0262s (sum)
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_batch_dual_consistency.org]]
+:COVERAGE_TARGET: -
+:END:
+7 random SPD QPs, heterogeneous eq/ineq/box shapes. Full KKT multiplier
+vectors (y, z, z_lb, z_ub) -- not just x*/obj -- checked batch vs
+per-item solve_qp: bitwise-identical across all 7 instances. No
+multiplier mis-indexing/unscaling bug found in the batched path.
+
+** [2026-08-06] Linear-equality variable elimination, Phase 6 (nlp/presolve, gh#487) - PASS
+:PROPERTIES:
+:FAMILY: nlp
+:SOURCE: randomized families built around a known feasible point x*; no published instance
+:KNOWN_OPTIMAL: n/a (property-based)
+:POUNCE_OBJECTIVE: n/a
+:POUNCE_STATUS: 12000 fuzz instances + 120 end-to-end .nl solves, 0 failures
+:POUNCE_TIME: ~4 min total
+:ORACLE: pounce verify (independent KKT/feasibility vs the original .nl); central finite differences of the wrapper's own reduced eval_f/eval_g; in-script row re-evaluation
+:ORACLE_OBJECTIVE: n/a
+:ORACLE_TIME: n/a
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_nlp_linear-eq-reduction.org]]
+:COVERAGE_TARGET: linear_eq_plan.rs / linear_eq_elim.rs — new files, no prior adversarial coverage
+:END:
+
+Probes validated by mutation testing: five injected defects (Hessian
+symmetric-pair x2 factor, bound-transfer sign, row constant, lift offset, dual
+recovery) were each caught. The row-constant defect initially escaped every
+probe — derivatives are blind to an affine offset — which is why the probe now
+carries a primal-fidelity check through =finalize_solution=.
+
+Recorded non-defect: a row whose constant lives in its =.nl= expression segment
+is tagged NonLinear by the reader, so the elimination declines it. The
+row-constant branch is therefore reachable only on the general TNLP path (C
+interface, GAMS, callbacks), not via =.nl=.
+
+** [2026-08-06] Phase 6 bound-multiplier attribution (nlp/presolve, gh#493) - PASS
+:PROPERTIES:
+:FAMILY: nlp
+:SOURCE: randomized family around a known feasible point, boxes drawn so bounds are ACTIVE on the columns Phase 6 removes; no published instance
+:KNOWN_OPTIMAL: n/a (oracle is the KKT system)
+:POUNCE_OBJECTIVE: n/a
+:POUNCE_STATUS: ~700 end-to-end .nl solves over 9 seeds, 0 gh#493 failures (parent commit: 15-22 per seed)
+:POUNCE_TIME: ~6 min total
+:ORACLE: textbook KKT (feasibility, stationarity, dual feasibility, bound complementarity) computed in-script from the generator's own arrays against the .sol ipopt_zL_out/ipopt_zU_out suffixes; no-presolve control arm; LICQ rank test for dual uniqueness; pounce verify
+:ORACLE_OBJECTIVE: n/a
+:ORACLE_TIME: n/a
+:VERDICT: PASS (gh#493); one separate pre-existing defect filed as gh#495
+:REPORT: [[file:runs/2026-08-06_nlp_phase6_bound_attribution.org]]
+:COVERAGE_TARGET: linear_eq_elim.rs postsolve / linear_eq_plan.rs bound transfer - the bound-multiplier path, which the gh#487 probes never reach (their boxes never bind)
+:END:
+
+The gh#487 probes cannot see this: their generator gives every box at least 1.0
+of margin around x*, so no bound is ever active and every bound multiplier is
+zero. This probe makes bounds active on the eliminated columns, and reads the
+zL/zU suffixes the earlier ones ignore.
+
+Bound complementarity is the discriminating condition. Parking a transferred
+bound's multiplier on the survivor leaves stationarity — the property #487's
+tests checked — intact while breaking complementarity in the original space.
+pounce verify is blind to it by construction: it reports bound-projected
+stationarity and never reads the suffixes, and it rejected none of the failing
+instances.
+
+Two formulation traps, both of which silently empty the probe: a quadratic
+objective routes the model to pounce-convex before any presolve wrapper exists
+(gh#494), and `presolve=yes` turns on Phases 1-4, whose own dual attribution
+confounds the measurement. The probe asserts engagement rather than assuming it.
+
+Separate finding, filed as gh#495 and NOT caused by the gh#493 change (residuals
+identical before and after): when Phase 6 removes a column whose declared bound
+is active, no bound multiplier is produced for it at all and the reported duals
+are not a KKT multiplier set. Minimal repro in the issue.
+

--- a/adversary/runs/2026-08-06_nlp_phase6_bound_attribution.org
+++ b/adversary/runs/2026-08-06_nlp_phase6_bound_attribution.org
@@ -1,0 +1,134 @@
+#+TITLE: Adversary Run: Phase 6 bound-multiplier attribution (gh#493)
+#+DATE: <2026-08-06>
+
+* Problem
+:PROPERTIES:
+:FAMILY: nlp
+:CLASS: bound-constrained + linear-equality structure
+:SOURCE: no published instance — a randomized family generated around a known feasible point, checked against the textbook KKT conditions
+:KNOWN_OPTIMAL: n/a (oracle is the KKT system, not a published optimum)
+:N_VARIABLES: 4–9
+:N_CONSTRAINTS: 1–7 linear equality rows
+:SELECTED_BY: topic-guidance (validating the gh#493 fix on branch claude/issue-493-u1tkfp)
+:COVERAGE_TARGET: -
+:END:
+
+Minimize a strictly convex quartic over linear equality rows, with boxes drawn
+so that bounds are **active on the columns Phase 6 eliminates**:
+
+\[
+\min_x \sum_j (x_j - t_j)^4 \quad\text{s.t.}\quad \sum_j a_{ij} x_j + c_i = b_i,\quad x_l \le x \le x_u
+\]
+
+Each instance is built around a random feasible point \(x^*\); the right-hand
+sides are computed from it, one side of each box is often pinned exactly onto
+it, and the objective targets \(t_j\) are placed beyond the pinned side so the
+objective drives \(x\) into that bound.
+
+Two formulation traps were hit and fixed while writing this, both worth
+recording because either one silently empties the probe:
+
+- **A quadratic objective routes the model away from the code under test.**
+  With squares, the model classifies as a convex QP and the CLI dispatches to
+  =pounce-convex= before any presolve wrapper is built, so Phase 6 never runs
+  (gh#494). The first draft reported "0 columns eliminated" on every instance.
+  The probe now asserts engagement and refuses to pass vacuously.
+- **=presolve=yes= turns on Phases 1–4 as well.** Phase 1 hands the solver
+  *tightened* bounds, against which a multiplier is complementary to a bound
+  this script never wrote. The probe drives Phase 6 alone and measures the
+  other phases in a separate arm.
+
+* Results
+:PROPERTIES:
+:STATUS: PASS
+:END:
+
+80 instances per seed, 9 seeds (~700 instances), each solved three ways.
+
+| Build                          | gh#493 KKT violations | gh#495 class | verdict |
+|--------------------------------+-----------------------+--------------+---------|
+| parent commit (#487 as merged) | 15–22 per seed        | 8–13         | FAIL    |
+| this branch (gh#493 fixed)     | **0** on every seed   | 10–15        | PASS    |
+
+Per-seed, fixed build: 0/0/0/0/0/0/0/0/0 gh#493 violations across seeds
+11/22/33/44/55/66/77/88/99, and 0 dual differences anywhere the multipliers are
+provably unique.
+
+The minimal case the fix targets, solved end to end through the CLI:
+
+| Model                              | reported                | matches bare solve |
+|------------------------------------+-------------------------+--------------------|
+| =min (x0-4)^2=, =x0 = 2·x1=, x0≤1  | z_u[x0] = 6, λ = 0      | yes, exactly       |
+| same with =x0 = -2·x1=             | z_u[x0] = 6, λ = 0      | yes, exactly       |
+
+Before the fix both reported z on =x1= — a bound =x1= is not sitting on.
+
+* Cross-check / Verification
+
+The oracle is the full KKT system, evaluated in the probe from the same arrays
+used to write the =.nl=, against the =ipopt_zL_out= / =ipopt_zU_out= suffixes
+that come back:
+
+1. primal feasibility (rows hold, =x= inside its declared box),
+2. stationarity =∇f + Jᵀλ − z_l + z_u = 0=,
+3. dual feasibility =z_l, z_u ≥ 0=,
+4. **bound complementarity** =z_l·(x − x_l) = 0=, =z_u·(x_u − x) = 0=.
+
+(4) is what discriminates: parking a transferred bound's multiplier on the
+survivor puts a non-zero multiplier on a bound the survivor is not sitting on,
+which breaks complementarity in the original space while leaving stationarity —
+the property #487's own tests checked — perfectly intact.
+
+Three things make the oracle trustworthy rather than merely plausible:
+
+- **A control arm.** The identical check runs on the =presolve=no= solve of
+  every instance. It certifies essentially all of them; instances it cannot
+  certify are skipped rather than judged, and a run in which more than 5% fail
+  is declared miscalibrated rather than passed.
+- **A convention self-check.** The probe solves a hand-computed model
+  (=min (x0-4)^4 + x1^4 s.t. x0 = x1, x0 ≤ 1=, where λ = 4 and z_u[0] = 104)
+  and refuses to run at all unless the =.sol= dual-negation and the
+  =ipopt_zU_out = −z_u= export behave as assumed.
+- **An exact uniqueness test.** Dual equality with the bare solve is asserted
+  only where the active constraint gradients are linearly independent (LICQ),
+  checked by a rank computation. Earlier drafts used cluster- and
+  pinned-column heuristics; both let through instances where a degenerate
+  active set made the duals legitimately non-unique, and both were replaced.
+
+=pounce verify= was run on every instance and rejected none — including the
+instances that violate KKT. That is expected and worth recording: =verify=
+reports *bound-projected* stationarity (=verify.rs=, =stationarity_residual=),
+which projects out exactly the component a bound multiplier carries, and never
+reads the =zL=/=zU= suffixes. It is a feasibility oracle here, not a
+discriminating one.
+
+The Rust =adversary-fuzz linelim= probe was extended with a bound-provenance
+property — every reduced bound must lift, through the recovery map of the column
+the plan says it came from, exactly onto that column's declared bound — and run
+over 12,000 instances across three seeds: 0 failures. Inverting the sign flip in
+the provenance makes it fail 34/4000, so it bites.
+
+* Verdict
+
+*PASS* for gh#493. The fix does what it claims: across ~700 randomized
+instances the reduced solve's bound multipliers land on the columns that own
+the bounds, complementarity holds in the original variable space, and wherever
+the multipliers are provably unique they equal the no-presolve solve's to
+tolerance. The same probe fails the parent commit on every seed, 15–22
+violations each, so this is a measured change and not an absence of testing.
+
+*One separate finding, filed as gh#495.* When Phase 6 removes a column whose
+declared bound is active, no bound multiplier is produced for it at all, and
+the reported duals are not a KKT multiplier set — stationarity misses by
+O(10²–10³). It has two routes in (a survivor whose reduced box collapses to a
+point, and a pinned constant landing on its own bound), a minimal
+hand-checkable reproduction, and **identical residuals before and after the
+gh#493 change**, so it is pre-existing #487 behaviour rather than a regression.
+It is not fixable by re-attribution: there is no multiplier to re-attribute.
+Phase 6 is off by default, so no default user is affected.
+
+Also observed, out of scope and not filed: with every presolve phase on, 22–31
+instances per seed fail the same KKT check. Phase 1 hands the solver tightened
+bounds and Phase 2 drops rows, both of which move duals for reasons of their
+own (the documented M24 attribution caveat). The probe measures this in a
+separate arm so it cannot be confused with Phase 6's behaviour.

--- a/adversary/runs/2026-08-06_nlp_phase6_bound_attribution.py
+++ b/adversary/runs/2026-08-06_nlp_phase6_bound_attribution.py
@@ -1,0 +1,759 @@
+"""Adversary cross-check: Phase 6 bound-multiplier attribution, end to end.
+
+Family: nlp   Class: bound-constrained + linear-equality structure
+Target: `presolve_linear_eq_reduction` bound attribution (gh#493, on top of #487)
+Source: no published instance — a randomized family built around a KNOWN
+        feasible point, checked against the textbook KKT conditions.
+
+# Why the existing probes cannot see this
+
+`adversary-fuzz linelim` attacks the plan and the derivative transforms.
+`2026-08-06_nlp_linear_eq_reduction_verify.py` attacks the whole stack, but its
+generator draws every box with at least 1.0 of margin around `x*`, so **no
+bound is ever active** and the bound multipliers it never inspects are all
+zero. This probe exists to make bounds active on the columns Phase 6 removes.
+
+`pounce verify` is also blind here, by construction: it reports *bound-projected*
+stationarity (`verify.rs`, `stationarity_residual`) — it projects out exactly the
+component of the residual that a bound multiplier could absorb, and never reads
+`ipopt_zL_out` / `ipopt_zU_out` at all. A model whose bound multiplier is parked
+on the wrong column passes `verify` cleanly. It is run here anyway, as a
+feasibility oracle, but it is not the discriminating one.
+
+# The oracle
+
+The full KKT system, evaluated in this script from the same data used to write
+the `.nl`, on the `.sol` that comes back:
+
+1. **Primal feasibility** — every row holds, every `x` inside its declared box.
+2. **Stationarity** — `∇f + Jᵀλ − z_l + z_u = 0`, with `∇f = 2(x − t)` and `J`
+   the row coefficients written into the file.
+3. **Dual feasibility** — `z_l ≥ 0`, `z_u ≥ 0`.
+4. **Bound complementarity** — `z_l[j]·(x[j] − x_l[j]) = 0` and
+   `z_u[j]·(x_u[j] − x[j]) = 0`.
+
+(4) is the condition that discriminates. Attributing a transferred bound's
+multiplier to the survivor puts a non-zero multiplier on a bound the survivor
+is not sitting on, which violates complementarity in the original variable
+space while leaving stationarity — the thing #487 checked — perfectly intact.
+None of these four is a pounce-defined quantity; all four are the textbook
+conditions, computed here from the generator's own arrays.
+
+A fifth check is differential rather than absolute: the reduced solve's bound
+multipliers are compared against the **no-presolve** solve of the same file.
+Those must agree wherever the multipliers are unique. Where the survivor's own
+bound and a transferred bound are active at once they are genuinely not unique,
+so such instances are detected and excluded from that comparison (they are
+still held to conditions 1-4).
+
+# Conventions
+
+`.sol` files negate the dual block (`sol_writer.rs`: AMPL wants `d obj / d b`,
+which is `−λ`), and export `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u`
+(`main.rs`). Both are asserted rather than assumed: the script solves a
+hand-checkable model first and refuses to run if either convention does not
+hold.
+
+Usage:  python 2026-08-06_nlp_phase6_bound_attribution.py [trials] [seed]
+"""
+
+import random
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+import os
+POUNCE = Path(os.environ.get("POUNCE_BIN",
+    str(Path(__file__).resolve().parents[2] / "target" / "release" / "pounce")))
+
+FEAS_TOL = 1e-6
+# Relative to the size of the gradients involved. A quartic objective is very
+# flat near its target, so the IPM sometimes stops at "Solved To Acceptable
+# Level" with a residual around 1e-4 relative; the control arm below is what
+# calibrates this, and the defects being hunted are four to six orders larger.
+KKT_TOL = 1e-4
+ACTIVE_TOL = 1e-6
+
+# A pre-existing Phase-6 defect this probe surfaces but does not test for:
+# when accumulated bound transfers squeeze a survivor's reduced box down to a
+# single point, the reduced column is a fixed variable, no bound multiplier is
+# produced for it, and the full-space duals come back incomplete. Reported
+# separately so it cannot mask a gh#493 regression, and so it cannot be
+# mistaken for one.
+SEPARATE_ISSUE = "gh#495"
+
+# Phase 6 and nothing else. `presolve=yes` alone turns on Phases 1-4 too.
+PHASE6_ONLY = [
+    "presolve=yes",
+    "presolve_linear_eq_reduction=yes",
+    "presolve_bound_tightening=no",
+    "presolve_redundant_constraint_removal=no",
+    "presolve_licq_check=no",
+    "presolve_warm_z_bounds=no",
+]
+
+
+# --------------------------------------------------------------------------
+# .nl writing:  min Σ (x_j - t_j)^2   s.t.   Σ a_ij x_j + c_i = rhs_i
+# --------------------------------------------------------------------------
+def write_nl(path, n, rows, rhs, consts, targets, x_l, x_u, x0):
+    """A strictly convex quartic objective over linear equality rows.
+
+    Quartics, not squares. A square objective makes the model classify as a
+    convex QP, and the CLI then dispatches to `pounce-convex` *before* any
+    presolve wrapper is built — Phase 6 never runs, and the probe silently
+    measures a different code path (this is gh#494, filed as a known limitation
+    of #487). A first draft of this script used squares and reported "0 columns
+    eliminated" on every instance; the `n_elim` assertion below now makes that
+    failure loud instead of silent.
+
+    `Σ (x_j - t_j)^4` is still strictly convex, so the primal optimum is unique
+    and a disagreement with the no-presolve solve cannot be waved away as a
+    different-but-equal optimum. The row constant `c_i` stays in the expression
+    segment so the row-constant branch remains live.
+    """
+    m = len(rows)
+    jnnz = sum(len(r) for r in rows)
+    L = [
+        "g3 1 1 0\t# adversary phase-6 bound attribution",
+        f" {n} {m} 1 0 {m} \t# vars, constraints, objectives, ranges, eqns",
+        " 0 1 0 0 0 0\t# nonlinear constrs, objs",
+        " 0 0\t# network",
+        f" 0 {n} 0 \t# nonlinear vars in constraints, objectives, both",
+        " 0 0 0 1\t# linear network vars; functions; arith, flags",
+        " 0 0 0 0 0 \t# discrete",
+        f" {jnnz} {n} \t# nonzeros in Jacobian, obj gradient",
+        " 0 0\t# max name lengths",
+        " 0 0 0 0 0\t# common exprs",
+    ]
+    for r in range(m):
+        L += [f"C{r}", f"n{consts[r]!r}"]
+    L += ["O0 0", "o54", str(n)]
+    for j in range(n):
+        L += ["o5", "o0", f"v{j}", f"n{-targets[j]!r}", "n4"]
+    L.append(f"x{n}")
+    for j in range(n):
+        L.append(f"{j} {x0[j]!r}")
+    L.append("r")
+    for i in range(m):
+        L.append(f"4 {rhs[i]!r}")
+    L.append("b")
+    for j in range(n):
+        L.append(f"0 {x_l[j]!r} {x_u[j]!r}")
+    colcount = [0] * n
+    for r in rows:
+        for j, _ in r:
+            colcount[j] += 1
+    L.append(f"k{n - 1}")
+    cum = 0
+    for j in range(n - 1):
+        cum += colcount[j]
+        L.append(str(cum))
+    for i, r in enumerate(rows):
+        L.append(f"J{i} {len(r)}")
+        for j, a in sorted(r):
+            L.append(f"{j} {a!r}")
+    L.append(f"G0 {n}")
+    for j in range(n):
+        L.append(f"{j} 0")
+    path.write_text("\n".join(L) + "\n")
+
+
+# --------------------------------------------------------------------------
+# Generator: bounds deliberately ACTIVE on columns the pass will eliminate
+# --------------------------------------------------------------------------
+def gen(rng):
+    n = rng.randint(4, 9)
+    m = rng.randint(1, max(1, n - 2))
+    x_star = [round(rng.uniform(-4, 4), 6) for _ in range(n)]
+
+    rows, rhs, consts = [], [], []
+    for _ in range(m):
+        # Doubletons are the shape Phase 6 exists for; keep singletons and
+        # triples in the mix so the untouched paths stay live.
+        arity = rng.choice([1, 2, 2, 2, 2, 3])
+        cols = rng.sample(range(n), min(arity, n))
+        row = [
+            (c, round(rng.uniform(0.3, 3.0), 6) * rng.choice([1, -1]))
+            for c in cols
+        ]
+        rows.append(row)
+        consts.append(0.0 if rng.random() < 0.6 else round(rng.uniform(-3, 3), 6))
+        rhs.append(round(sum(a * x_star[c] for c, a in row) + consts[-1], 9))
+
+    # Boxes: one side often pinned exactly onto x*, so that side is active the
+    # moment the objective pulls that way. Never both sides (that is the
+    # equal-bounds shape, a different branch).
+    x_l, x_u, tight = [], [], []
+    for j in range(n):
+        side = rng.choice(["lo", "hi", "lo", "hi", "none"])
+        lo_gap = 0.0 if side == "lo" else round(rng.uniform(0.4, 6.0), 6)
+        hi_gap = 0.0 if side == "hi" else round(rng.uniform(0.4, 6.0), 6)
+        x_l.append(round(x_star[j] - lo_gap, 6))
+        x_u.append(round(x_star[j] + hi_gap, 6))
+        tight.append(side)
+
+    # Targets: for a pinned side, put the unconstrained minimizer beyond the
+    # bound so the objective drives x into it.
+    targets = []
+    for j in range(n):
+        if tight[j] == "lo":
+            targets.append(round(x_l[j] - rng.uniform(0.5, 5.0), 6))
+        elif tight[j] == "hi":
+            targets.append(round(x_u[j] + rng.uniform(0.5, 5.0), 6))
+        else:
+            targets.append(round(rng.uniform(-4, 4), 6))
+
+    x0 = [
+        round(min(max(x_star[j] + rng.uniform(-0.3, 0.3), x_l[j]), x_u[j]), 6)
+        for j in range(n)
+    ]
+    return n, rows, rhs, consts, targets, x_l, x_u, x0
+
+
+# --------------------------------------------------------------------------
+# .sol parsing, including the suffix blocks
+# --------------------------------------------------------------------------
+def read_sol(path, n, m):
+    """Return (lambda_sol, x, suffixes) parsed structurally, not by tail slicing."""
+    lines = path.read_text().splitlines()
+    i = 0
+    while i < len(lines) and lines[i].strip() != "Options":
+        i += 1
+    if i >= len(lines):
+        raise ValueError("no Options section in .sol")
+    i += 1
+    nopts = int(lines[i].strip())
+    i += 1 + nopts
+    n_dual = int(lines[i].strip()); i += 1
+    _m = int(lines[i].strip()); i += 1
+    n_prim = int(lines[i].strip()); i += 1
+    _n = int(lines[i].strip()); i += 1
+    lam = [float(lines[i + k].strip()) for k in range(n_dual)]; i += n_dual
+    x = [float(lines[i + k].strip()) for k in range(n_prim)]; i += n_prim
+    if (_m, _n) != (m, n):
+        raise ValueError(f".sol declares {_n}x{_m}, expected {n}x{m}")
+
+    suffixes = {}
+    while i < len(lines):
+        s = lines[i].strip()
+        if s.startswith("suffix "):
+            parts = s.split()
+            nvalues = int(parts[2])
+            name = lines[i + 1].strip()
+            vals = {}
+            for k in range(nvalues):
+                idx, v = lines[i + 2 + k].split()
+                vals[int(idx)] = float(v)
+            suffixes[name] = vals
+            i += 2 + nvalues
+        else:
+            i += 1
+    return lam, x, suffixes
+
+
+def duals_from_sol(suffixes, n):
+    """`ipopt_zL_out = +z_l`, `ipopt_zU_out = -z_u`; absent index means zero."""
+    zl_s = suffixes.get("ipopt_zL_out", {})
+    zu_s = suffixes.get("ipopt_zU_out", {})
+    z_l = [zl_s.get(j, 0.0) for j in range(n)]
+    z_u = [-zu_s.get(j, 0.0) for j in range(n)]
+    return z_l, z_u
+
+
+# --------------------------------------------------------------------------
+# The KKT oracle
+# --------------------------------------------------------------------------
+def kkt_report(n, rows, rhs, consts, targets, x_l, x_u, x, lam_sol, z_l, z_u):
+    """Every violation of the four KKT conditions, as a list of strings.
+
+    `lam_sol` is the `.sol` dual block, which AMPL convention negates relative
+    to the Lagrangian multiplier of `L = f + λᵀg`; both signs are tried and the
+    better one kept, exactly as `pounce verify` does, so a convention slip here
+    cannot masquerade as a solver defect.
+    """
+    bad = []
+    grad = [4.0 * (x[j] - targets[j]) ** 3 for j in range(n)]
+    # Scale the residual thresholds by the size of the quantities involved: a
+    # quartic gradient runs to O(100) where the primal runs to O(10).
+    scale = max(1.0, max(abs(v) for v in x), max(abs(v) for v in targets),
+                max(abs(v) for v in grad))
+
+    # (1) primal feasibility
+    for i, row in enumerate(rows):
+        body = sum(a * x[c] for c, a in row) + consts[i]
+        if abs(body - rhs[i]) > FEAS_TOL * max(1.0, abs(rhs[i])):
+            bad.append(f"row {i} violated by {body - rhs[i]:.3e}")
+    for j in range(n):
+        if x[j] < x_l[j] - FEAS_TOL * scale or x[j] > x_u[j] + FEAS_TOL * scale:
+            bad.append(f"x[{j}]={x[j]:.6g} outside [{x_l[j]}, {x_u[j]}]")
+
+    # (2) stationarity, for whichever dual sign convention fits
+    def resid_vec(sign):
+        r = list(grad)
+        for i, row in enumerate(rows):
+            for c, a in row:
+                r[c] += sign * a * lam_sol[i]
+        for j in range(n):
+            r[j] += -z_l[j] + z_u[j]
+        return r
+
+    def resid(sign):
+        return max(abs(v) for v in resid_vec(sign))
+
+    r_pos, r_neg = resid(1.0), resid(-1.0)
+    sign = 1.0 if r_pos <= r_neg else -1.0
+    best = min(r_pos, r_neg)
+    r_vec = resid_vec(sign)
+    if best > KKT_TOL * scale:
+        bad.append(f"stationarity residual {best:.3e} (both dual signs tried)")
+
+    # (3) dual feasibility
+    for j in range(n):
+        if z_l[j] < -KKT_TOL:
+            bad.append(f"z_l[{j}]={z_l[j]:.3e} is negative")
+        if z_u[j] < -KKT_TOL:
+            bad.append(f"z_u[{j}]={z_u[j]:.3e} is negative")
+
+    # (4) bound complementarity — the discriminating condition
+    for j in range(n):
+        slack_lo = x[j] - x_l[j]
+        slack_hi = x_u[j] - x[j]
+        if abs(z_l[j]) * slack_lo > KKT_TOL * scale:
+            bad.append(
+                f"complementarity: z_l[{j}]={z_l[j]:.4g} on a lower bound with "
+                f"slack {slack_lo:.4g} (x={x[j]:.6g}, x_l={x_l[j]})"
+            )
+        if abs(z_u[j]) * slack_hi > KKT_TOL * scale:
+            bad.append(
+                f"complementarity: z_u[{j}]={z_u[j]:.4g} on an upper bound with "
+                f"slack {slack_hi:.4g} (x={x[j]:.6g}, x_u={x_u[j]})"
+            )
+    return bad, {"sign": sign, "resid": r_vec, "scale": scale}
+
+
+PLAN_DUMP = (Path(__file__).resolve().parents[1] / "fuzz" / "target" / "release"
+             / "examples" / "plan_dump")
+
+
+def collapsed_survivors(n, rows, consts, rhs, x_l, x_u):
+    """Survivors whose reduced box the accumulated transfers squeezed to a point.
+
+    Asks the planner itself, through the `plan_dump` example in
+    `adversary/fuzz` — a mechanism, not a symptom. Returns `None` when the
+    helper is not built, and the caller then refuses to classify rather than
+    guessing (build it with
+    `cd adversary/fuzz && cargo build --release --example plan_dump`).
+
+    A survivor pinned to a single point is a *fixed* column in the reduced
+    problem, which the solver drops from its internal problem, so no bound
+    multiplier is produced for it at all — while the full-space cluster it
+    stands for may have several simultaneously active bounds needing several
+    multipliers. That is the pre-existing defect tracked as gh#495; it is not
+    the misattribution gh#493 is about, and it is not fixable by
+    re-attribution, because there is nothing to re-attribute.
+    """
+    if not PLAN_DUMP.exists():
+        return None
+    inp = "\n".join([
+        str(n),
+        ";".join(",".join(f"{c}:{a!r}" for c, a in r) for r in rows),
+        ",".join(repr(v) for v in consts),
+        ",".join(repr(v) for v in rhs),
+        ",".join(repr(v) for v in x_l),
+        ",".join(repr(v) for v in x_u),
+    ])
+    out = subprocess.run([str(PLAN_DUMP)], input=inp, capture_output=True,
+                         text=True, timeout=30).stdout
+    mm = re.search(r"collapsed_reduced_boxes=\[([^\]]*)\]", out)
+    if not mm:
+        return None
+    body = mm.group(1).strip()
+    collapsed = [int(v) for v in body.split(",") if v.strip()] if body else []
+    pinned = [(int(a), float(b))
+              for a, b in re.findall(r"col(\d+) -> Constant\(([^)]+)\)", out)]
+    return collapsed, pinned
+
+
+def duals_are_unique(n, rows, x, x_l, x_u):
+    """Exact test for uniqueness of the KKT multipliers at this point.
+
+    The multipliers are unique iff the active constraint gradients are linearly
+    independent (LICQ): each equality row's gradient, plus a unit vector for
+    every active bound. Where they are dependent the multiplier set is an
+    affine family, every member of it is a valid KKT point, and demanding that
+    the reduced solve reproduce the no-presolve split is demanding something
+    that is not true of the problem.
+
+    This replaces the cluster- and pinned-column heuristics an earlier draft
+    used: both were approximations of exactly this condition, and both let
+    through instances where a degenerate active set — six active bounds and
+    two equality rows on seven columns, in the case that motivated this — made
+    the duals legitimately non-unique.
+    """
+    grads = []
+    for row in rows:
+        g = [0.0] * n
+        for c, a in row:
+            g[c] += a
+        grads.append(g)
+    for j in range(n):
+        at_lo = abs(x[j] - x_l[j]) <= ACTIVE_TOL * max(1.0, abs(x[j]))
+        at_hi = abs(x_u[j] - x[j]) <= ACTIVE_TOL * max(1.0, abs(x[j]))
+        if at_lo or at_hi:
+            e = [0.0] * n
+            e[j] = 1.0
+            grads.append(e)
+    if not grads:
+        return True
+    A = np.array(grads)
+    return int(np.linalg.matrix_rank(A, tol=1e-9)) == A.shape[0]
+
+
+def removed_columns_on_active_bounds(info, x, x_l, x_u):
+    """Columns Phase 6 took out of the problem that are sitting on a declared
+    bound of their own at the solution.
+
+    These are the columns whose bound multiplier the reduced problem has no
+    slot for. Two ways in:
+
+    * a column **pinned to a constant** whose value lands on one of its own
+      bounds, and
+    * any member of a cluster whose survivor's reduced box the transfers
+      squeezed to a **single point** — the survivor is then a fixed column,
+      which the solver drops from its internal problem entirely.
+
+    Wherever one of these carries stationarity residual, the reported duals
+    are incomplete: there is no multiplier to re-attribute, so this is not the
+    gh#493 misattribution and re-attribution cannot fix it. Tracked as
+    gh#495.
+    """
+    collapsed, pinned = info
+    out = set()
+
+    def on_bound(j, v):
+        tol = max(ACTIVE_TOL, 1e-7) * max(1.0, abs(v))
+        return abs(v - x_l[j]) <= tol or abs(v - x_u[j]) <= tol
+
+    for j, v in pinned:
+        if on_bound(j, v):
+            out.add(j)
+    if collapsed:
+        # A collapsed survivor makes every column of its cluster suspect; the
+        # dump does not name cluster membership, so treat any column on an
+        # active declared bound as covered when a collapse happened at all.
+        for j in range(len(x)):
+            if on_bound(j, x[j]):
+                out.add(j)
+    return out
+
+
+def active_columns(n, x, x_l, x_u):
+    lo = {j for j in range(n) if abs(x[j] - x_l[j]) <= ACTIVE_TOL * max(1.0, abs(x[j]))}
+    hi = {j for j in range(n) if abs(x_u[j] - x[j]) <= ACTIVE_TOL * max(1.0, abs(x[j]))}
+    return lo, hi
+
+
+def clusters_of(n, rows):
+    """Union-find over the doubleton equality rows — the columns Phase 6 can
+    fold together. Two active bounds inside one cluster is the degenerate case
+    where the multiplier split is genuinely not unique."""
+    parent = list(range(n))
+
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+
+    for row in rows:
+        if len(row) == 2:
+            a, b = find(row[0][0]), find(row[1][0])
+            if a != b:
+                parent[a] = b
+    return [find(j) for j in range(n)]
+
+
+# --------------------------------------------------------------------------
+def run_cli(nl_dir, opts):
+    return subprocess.run(
+        [str(POUNCE), "m", "-AMPL"] + opts,
+        cwd=nl_dir, capture_output=True, text=True, timeout=60,
+    )
+
+
+def convention_selfcheck(tmp):
+    """Refuse to run unless the `.sol` sign conventions are what we assume.
+
+    `min (x0-4)^4 + x1^4  s.t.  x0 - x1 = 0,  x0 <= 1` has its optimum at
+    x0 = x1 = 1 with the upper bound of x0 active, and by hand
+    `∇f = [-108, 4]`, `λ = 4`, `z_u[0] = 104`. This only pins the file format
+    and the sign conventions; the attribution question is not asked here.
+    """
+    d = Path(tempfile.mkdtemp(prefix="adv_conv_", dir=tmp))
+    try:
+        write_nl(d / "m.nl", 2, [[(0, 1.0), (1, -1.0)]], [0.0], [0.0],
+                 [4.0, 0.0], [-10.0, -10.0], [1.0, 10.0], [0.0, 0.0])
+        p = run_cli(d, [])
+        if "Optimal Solution Found" not in p.stdout:
+            return "self-check model did not solve:\n" + p.stdout[-400:]
+        lam, x, suf = read_sol(d / "m.sol", 2, 1)
+        z_l, z_u = duals_from_sol(suf, 2)
+        if abs(x[0] - 1.0) > 1e-5 or abs(x[1] - 1.0) > 1e-5:
+            return f"self-check primal wrong: {x}"
+        # x0 sits on its upper bound; z_u[0] must be positive under the
+        # documented `ipopt_zU_out = -z_u` export.
+        if abs(z_u[0] - 104.0) > 1e-2:
+            return (f"z_u[0]={z_u[0]:.6g} at an active upper bound where the "
+                    f"hand calculation gives 104 — the "
+                    f"`ipopt_zU_out = -z_u` convention this probe assumes does "
+                    f"not hold (suffixes={suf})")
+        bad, _ = kkt_report(2, [[(0, 1.0), (1, -1.0)]], [0.0], [0.0],
+                            [4.0, 0.0], [-10.0, -10.0], [1.0, 10.0],
+                            x, lam, z_l, z_u)
+        if bad:
+            return "self-check model failed its own KKT oracle: " + "; ".join(bad)
+        return None
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def main():
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 60
+    seed = int(sys.argv[2]) if len(sys.argv) > 2 else 20260806
+    rng = random.Random(seed)
+    tmp = tempfile.mkdtemp(prefix="adv_p6attr_")
+
+    why = convention_selfcheck(tmp)
+    if why:
+        print("SELF-CHECK FAILED: " + why)
+        print("VERDICT: INCONCLUSIVE (cannot trust the .sol conventions)")
+        shutil.rmtree(tmp, ignore_errors=True)
+        return 2
+
+    checked = reduced_any = with_active = elim_active = degenerate = 0
+    routed_away = 0
+    dual_diff = 0
+    kkt_bad, verify_bad, dual_bad, control_bad, other_bad = [], [], [], [], []
+    missing_mult, not_optimal, dual_diff_valid = [], [], 0
+    unclassified = []
+    pinned_deg = 0
+
+    for t in range(trials):
+        n, rows, rhs, consts, targets, x_l, x_u, x0 = gen(rng)
+        m = len(rows)
+        d = Path(tempfile.mkdtemp(prefix="adv_p6_", dir=tmp))
+        try:
+            write_nl(d / "m.nl", n, rows, rhs, consts, targets, x_l, x_u, x0)
+
+            off = run_cli(d, ["presolve=no"])
+            if "Optimal Solution Found" not in off.stdout:
+                continue
+            lam_off, x_off, suf_off = read_sol(d / "m.sol", n, m)
+            zl_off, zu_off = duals_from_sol(suf_off, n)
+
+            # Phase 6 ONLY. The other presolve phases move duals for reasons
+            # of their own — Phase 2's dropped rows carry the documented M24
+            # attribution caveat, and Phase 1 hands the solver *tightened*
+            # bounds, against which a multiplier is complementary to a bound
+            # this script never wrote. Leaving them on confounds the
+            # measurement; the second arm below quantifies exactly that.
+            on = run_cli(d, PHASE6_ONLY)
+            if "Optimal Solution Found" not in on.stdout:
+                # Not an attribution question: the reduced solve never got to a
+                # point to report duals at. Counted separately.
+                not_optimal.append((t, "reduced solve did not reach optimality",
+                                    on.stdout[-200:]))
+                continue
+            checked += 1
+            # Assert the pass ENGAGED rather than trusting that it did: a
+            # transparent fall-through to another solver or to the passthrough
+            # wrapper would otherwise read as a clean run.
+            if "Selected solver" in on.stdout and "pounce-convex" in on.stdout:
+                routed_away += 1
+            mm = re.search(r"eliminated (\d+) columns", on.stdout)
+            n_elim = int(mm.group(1)) if mm else 0
+            if n_elim:
+                reduced_any += 1
+            lam_on, x_on, suf_on = read_sol(d / "m.sol", n, m)
+            zl_on, zu_on = duals_from_sol(suf_on, n)
+
+            lo_act, hi_act = active_columns(n, x_on, x_l, x_u)
+            if lo_act or hi_act:
+                with_active += 1
+            # Was an active bound on a column that is NOT the survivor of its
+            # cluster? Survivorship is not observable from outside, but a
+            # cluster of size > 1 with an active bound is exactly the situation
+            # a transfer arises from.
+            root = clusters_of(n, rows)
+            size = {}
+            for j in range(n):
+                size[root[j]] = size.get(root[j], 0) + 1
+            act = lo_act | hi_act
+            if any(size[root[j]] > 1 for j in act):
+                elim_active += 1
+            # Degenerate: two active bounds inside one cluster.
+            per_cluster = {}
+            for j in act:
+                per_cluster[root[j]] = per_cluster.get(root[j], 0) + 1
+            is_degenerate = any(v > 1 for v in per_cluster.values())
+            if is_degenerate:
+                degenerate += 1
+
+            # --- control: the SAME oracle on the no-presolve solve --------
+            # If this fires, the oracle or the formulation is wrong, not the
+            # pass under test. It is checked every run, not once.
+            bad_off, _ = kkt_report(n, rows, rhs, consts, targets, x_l, x_u,
+                                    x_off, lam_off, zl_off, zu_off)
+            if bad_off:
+                # The oracle could not certify the *no-presolve* solve on this
+                # instance, so it is in no position to judge the reduced one.
+                # Skipped, and counted: a handful is the solver stopping at
+                # "acceptable level" on a very flat quartic, but a large
+                # fraction would mean the oracle itself is miscalibrated, which
+                # the cap below turns into a failed run.
+                control_bad.append((t, "; ".join(bad_off[:3]), ""))
+                continue
+
+            # --- oracle A: the KKT conditions, from this script's own data ---
+            bad, det = kkt_report(n, rows, rhs, consts, targets, x_l, x_u,
+                                  x_on, lam_on, zl_on, zu_on)
+            if bad:
+                # Stationarity-only violations on an instance whose reduced
+                # box collapsed to a point are the pre-existing defect, not
+                # this one. Anything else — a complementarity violation, a
+                # negative multiplier, or a residual with no collapse to
+                # explain it — is a gh#493 failure and fails the run.
+                stationarity_only = all("stationarity" in b for b in bad)
+                info = collapsed_survivors(n, rows, consts, rhs, x_l, x_u)
+                if info is None:
+                    unclassified.append((t, "; ".join(bad[:2]) +
+                                         "  [plan_dump not built; cannot classify]", ""))
+                    continue
+                tol = KKT_TOL * det["scale"]
+                offenders = [j for j in range(n) if abs(det["resid"][j]) > tol]
+                covered = removed_columns_on_active_bounds(info, x_on, x_l, x_u)
+                # Either mechanism explains it. A collapsed survivor is a fixed
+                # column in the reduced problem, and once its bound multiplier
+                # is missing the recovered row multipliers are off too, so the
+                # residual spreads across the whole cluster rather than staying
+                # on the columns that sit on bounds — which is why this is an
+                # OR and not the narrower per-column test alone.
+                # Any removed column on an active bound is enough. Once one
+                # missing multiplier is in the system, the recovered row
+                # multipliers built on top of it are off too, so the residual
+                # spreads to survivors and to columns that are not on bounds —
+                # seed 66/42 puts it on eight of nine columns. Requiring every
+                # offender to be on a bound would misfile exactly the worst
+                # cases.
+                explained = bool(info[0]) or bool(covered)
+                if stationarity_only and offenders and explained:
+                    missing_mult.append((
+                        t, "; ".join(bad[:2]) +
+                        f"  [residual at {offenders}; collapsed survivors="
+                        f"{info[0]}; removed-and-on-a-bound={sorted(covered)}]", ""))
+                else:
+                    kkt_bad.append((t, "; ".join(bad[:3]), ""))
+
+            # --- oracle B: pounce verify against the ORIGINAL .nl ---
+            v = subprocess.run([str(POUNCE), "verify", "m.nl", "m.sol"],
+                               cwd=d, capture_output=True, text=True, timeout=60)
+            if v.returncode != 0:
+                verify_bad.append((t, f"rc={v.returncode}", v.stdout[-400:]))
+
+            # --- arm 2: every presolve phase on, for scope attribution -----
+            other = run_cli(d, ["presolve=yes", "presolve_linear_eq_reduction=no"])
+            if "Optimal Solution Found" in other.stdout:
+                lam_o, x_o, suf_o = read_sol(d / "m.sol", n, m)
+                zl_o, zu_o = duals_from_sol(suf_o, n)
+                bad_o, _ = kkt_report(n, rows, rhs, consts, targets, x_l, x_u,
+                                      x_o, lam_o, zl_o, zu_o)
+                if bad_o:
+                    other_bad.append((t, "; ".join(bad_o[:2]), ""))
+                # Restore the Phase-6 .sol for anything downstream.
+                run_cli(d, PHASE6_ONLY)
+
+            # --- oracle C: the no-presolve solve, where duals are unique ---
+            # Only where they really are unique: not degenerate by the cluster
+            # test, no collapsed reduced box, and the reduced duals a valid KKT
+            # point to begin with. Anywhere else a difference is either
+            # non-uniqueness or an already-counted violation, and asserting
+            # equality would be asserting something untrue.
+            unique_duals = (not bad) and duals_are_unique(n, rows, x_on, x_l, x_u)
+            if not unique_duals:
+                pinned_deg += 1
+            if unique_duals:
+                sc = max(1.0, max(abs(v) for v in zl_off + zu_off + zl_on + zu_on))
+                worst = max(
+                    max(abs(zl_on[j] - zl_off[j]) for j in range(n)),
+                    max(abs(zu_on[j] - zu_off[j]) for j in range(n)),
+                )
+                if worst > 1e-4 * sc:
+                    dual_diff += 1
+                    jw = max(range(n), key=lambda j: max(
+                        abs(zl_on[j] - zl_off[j]), abs(zu_on[j] - zu_off[j])))
+                    dual_bad.append((
+                        t,
+                        f"bound multipliers differ from the no-presolve solve by "
+                        f"{worst:.3e} (worst at column {jw}: reduced "
+                        f"z_l={zl_on[jw]:.6g} z_u={zu_on[jw]:.6g}, bare "
+                        f"z_l={zl_off[jw]:.6g} z_u={zu_off[jw]:.6g})", ""))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    shutil.rmtree(tmp, ignore_errors=True)
+
+    print(f"instances solved by both paths     : {checked}")
+    print(f"  where the pass eliminated columns: {reduced_any}")
+    print(f"  routed away from the NLP path    : {routed_away}")
+    print(f"  with at least one active bound   : {with_active}")
+    print(f"  active bound inside a fold cluster: {elim_active}")
+    print(f"  degenerate (2 active in a cluster): {degenerate}")
+    print(f"  duals non-unique (LICQ fails)     : {pinned_deg}")
+    print(f"CONTROL uncertifiable, instance skipped: {len(control_bad)}")
+    print(f"KKT violations (Phase 6 only)      : {len(kkt_bad)}   <- gh#493, must be 0")
+    print(f"  explained by a collapsed reduced box: {len(missing_mult)}   "
+          f"<- {SEPARATE_ISSUE}, pre-existing")
+    print(f"KKT violations (other phases, no P6): {len(other_bad)}   <- scope check, not this issue")
+    print(f"pounce verify rejections           : {len(verify_bad)}")
+    print(f"reduced solve non-optimal          : {len(not_optimal)}")
+    print(f"duals differing where they are UNIQUE: {dual_diff}   <- gh#493, must be 0")
+    for label, items in (("CONTROL", control_bad), ("KKT", kkt_bad),
+                         ("collapsed-box " + SEPARATE_ISSUE, missing_mult),
+                         ("UNCLASSIFIED", unclassified),
+                         ("non-optimal", not_optimal), ("verify", verify_bad),
+                         ("dual-attribution", dual_bad)):
+        for t, wy, extra in items[:40]:
+            print(f"  [{label} {t}] {wy}")
+            if extra:
+                print("      " + extra.replace("\n", "\n      ")[:400])
+
+    vacuous = elim_active == 0 or reduced_any == 0 or routed_away > 0
+    # The verdict is about gh#493 and nothing else: a bound multiplier must
+    # never be reported against a bound its column is not sitting on, and the
+    # reduced duals must be a valid KKT point of the ORIGINAL problem. Dual
+    # differences that are themselves valid KKT points are non-uniqueness, not
+    # defects, and the pre-existing incomplete-duals class is tracked under its
+    # own issue so it can neither mask a regression nor be mistaken for one.
+    control_ok = len(control_bad) <= max(2, 0.05 * max(1, checked))
+    ok = (not kkt_bad) and (not verify_bad) and control_ok \
+        and (not unclassified) and (dual_diff == 0) \
+        and not vacuous
+    if not control_ok:
+        print(f"ORACLE MISCALIBRATED: the no-presolve solve failed the KKT check "
+              f"on {len(control_bad)} of {checked} instances")
+    if vacuous:
+        print("PROBE VACUOUS: the attribution path was not exercised "
+              f"(eliminated-columns instances={reduced_any}, "
+              f"active-in-cluster={elim_active}, routed-away={routed_away})")
+    print("VERDICT: PASS" if ok else "VERDICT: FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/pounce-algorithm/tests/presolve_phase6_bound_attribution.rs
+++ b/crates/pounce-algorithm/tests/presolve_phase6_bound_attribution.rs
@@ -1,0 +1,325 @@
+//! Phase 6 acceptance (issue #493): a bound that was *transferred* off an
+//! eliminated column must have its multiplier reported back on that column.
+//!
+//! The fixture is the smallest model that exhibits the transfer:
+//!
+//! ```text
+//!   min (x0 − 4)²   s.t.   x0 − α·x1 = 0,   x0 ≤ 1
+//! ```
+//!
+//! The row folds `x0` onto `x1` (both coefficients are comparable, so the
+//! planner's cluster-size tie-break eliminates the first column), which
+//! carries `x0 ≤ 1` onto `x1` as `x1 ≤ 1/α` — or, for `α < 0`, as
+//! `x1 ≥ 1/α`, since a negative coefficient reverses the interval. Either
+//! way the objective drives `x0` up into that bound, so the solver reports a
+//! bound multiplier against a bound `x1` never declared.
+//!
+//! Attribution is what a no-presolve solve reports, so these tests compare
+//! against the bare solve directly — *except* in the degenerate case, where
+//! the survivor's own bound is active too and the split between the two is
+//! genuinely non-unique. There the assertions are KKT validity and correct
+//! signs, the posture `pounce-convex`'s `presolve_forcing.rs` already takes
+//! for forcing constraints.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_presolve::{LinearEqElimTnlp, PresolveOptions, PresolveTnlp};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Debug, Clone, Default)]
+struct Captured {
+    x: Vec<Number>,
+    z_l: Vec<Number>,
+    z_u: Vec<Number>,
+    lambda: Vec<Number>,
+}
+
+struct Fixture {
+    /// `x0 = α·x1`, published as the row `x0 − α·x1 = 0`.
+    alpha: Number,
+    x1_lo: Number,
+    x1_hi: Number,
+    captured: Option<Captured>,
+}
+
+impl Fixture {
+    fn new(alpha: Number, x1_lo: Number, x1_hi: Number) -> Self {
+        Self {
+            alpha,
+            x1_lo,
+            x1_hi,
+            captured: None,
+        }
+    }
+}
+
+impl TNLP for Fixture {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 2,
+            nnz_h_lag: 1,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-1e19, self.x1_lo]);
+        b.x_u.copy_from_slice(&[1.0, self.x1_hi]);
+        b.g_l.copy_from_slice(&[0.0]);
+        b.g_u.copy_from_slice(&[0.0]);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.0, 0.0]);
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.copy_from_slice(&[Linearity::Linear]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 4.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 4.0);
+        g[1] = 0.0;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] - self.alpha * x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 1.0;
+                values[1] = -self.alpha;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0]);
+                jcol.copy_from_slice(&[0]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = obj_factor * 2.0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.captured = Some(Captured {
+            x: sol.x.to_vec(),
+            z_l: sol.z_l.to_vec(),
+            z_u: sol.z_u.to_vec(),
+            lambda: sol.lambda.to_vec(),
+        });
+    }
+}
+
+fn opts(linear_eq_reduction: bool) -> PresolveOptions {
+    PresolveOptions {
+        enabled: true,
+        linear_eq_reduction,
+        // Everything else off, so any dual that moves moved for the reason
+        // under test.
+        bound_tightening: false,
+        redundant_constraint_removal: false,
+        licq_check: false,
+        warm_z_bounds: false,
+        ..PresolveOptions::defaults()
+    }
+}
+
+struct Outcome {
+    captured: Captured,
+    reduced_n: i32,
+}
+
+fn solve(alpha: Number, x1_lo: Number, x1_hi: Number, linear_eq_reduction: bool) -> Outcome {
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    // Unscaled, so the reported duals are directly comparable against the
+    // fixture's own analytic gradient.
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "none", true, false)
+        .unwrap();
+
+    let concrete = Rc::new(RefCell::new(Fixture::new(alpha, x1_lo, x1_hi)));
+    let presolve = Rc::new(RefCell::new(PresolveTnlp::new(
+        Rc::clone(&concrete) as Rc<RefCell<dyn TNLP>>,
+        opts(linear_eq_reduction),
+    )));
+    let elim = Rc::new(RefCell::new(LinearEqElimTnlp::new(
+        Rc::clone(&presolve) as Rc<RefCell<dyn TNLP>>,
+        opts(linear_eq_reduction),
+    )));
+    let info = elim.borrow_mut().get_nlp_info().expect("dims");
+    let _ = app.optimize_tnlp(Rc::clone(&elim) as Rc<RefCell<dyn TNLP>>);
+
+    Outcome {
+        captured: concrete.borrow().captured.clone().expect("finalized"),
+        reduced_n: info.n,
+    }
+}
+
+/// `∇f + Jᵀλ − z_l + z_u` at both columns, in POUNCE's `finalize_solution`
+/// convention.
+fn stationarity(alpha: Number, c: &Captured) -> [Number; 2] {
+    let grad = [2.0 * (c.x[0] - 4.0), 0.0];
+    let jac = [1.0, -alpha];
+    [0, 1].map(|j| grad[j] + jac[j] * c.lambda[0] - c.z_l[j] + c.z_u[j])
+}
+
+#[test]
+fn a_transferred_upper_bounds_multiplier_lands_on_the_column_that_owns_it() {
+    let on = solve(2.0, -100.0, 100.0, true);
+    assert_eq!(on.reduced_n, 1, "x0 should be gone");
+    let off = solve(2.0, -100.0, 100.0, false);
+
+    // x0 = 1 (its own upper bound), x1 = 0.5.
+    assert!((on.captured.x[0] - 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert!((on.captured.x[1] - 0.5).abs() < 1e-6, "{:?}", on.captured.x);
+
+    // The multiplier belongs to x0's bound, scaled by 1/|α| on the way back.
+    assert!(
+        (on.captured.z_u[0] - 6.0).abs() < 1e-4,
+        "z_u[0] = {}, expected 6 (the bare solve reports {})",
+        on.captured.z_u[0],
+        off.captured.z_u[0]
+    );
+    assert!(
+        on.captured.z_u[1].abs() < 1e-4,
+        "x1 never declared that bound: z_u[1] = {}",
+        on.captured.z_u[1]
+    );
+    // With the bound multiplier where it belongs, the consumed row's own
+    // multiplier is zero — as the bare solve reports it.
+    assert!(
+        (on.captured.lambda[0] - off.captured.lambda[0]).abs() < 1e-4,
+        "λ = {} vs bare {}",
+        on.captured.lambda[0],
+        off.captured.lambda[0]
+    );
+    for j in 0..2 {
+        assert!((on.captured.z_u[j] - off.captured.z_u[j]).abs() < 1e-4);
+        assert!((on.captured.z_l[j] - off.captured.z_l[j]).abs() < 1e-4);
+    }
+}
+
+/// The sign flip is where this breaks: with `α < 0` the survivor's *lower*
+/// bound is the eliminated column's *upper* bound, so the multiplier has to
+/// change sides on the way back.
+#[test]
+fn a_negative_coefficient_sends_the_multiplier_to_the_other_side_of_the_box() {
+    let on = solve(-2.0, -100.0, 100.0, true);
+    assert_eq!(on.reduced_n, 1);
+    let off = solve(-2.0, -100.0, 100.0, false);
+
+    assert!((on.captured.x[0] - 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert!((on.captured.x[1] + 0.5).abs() < 1e-6, "{:?}", on.captured.x);
+
+    // The reduced problem reports this against x1's *lower* bound; x0's box
+    // is bounded above, and that is where it must arrive.
+    assert!(
+        (on.captured.z_u[0] - 6.0).abs() < 1e-4,
+        "z_u[0] = {}, expected 6 (the bare solve reports {})",
+        on.captured.z_u[0],
+        off.captured.z_u[0]
+    );
+    assert!(
+        on.captured.z_l[0].abs() < 1e-4,
+        "x0 has no lower bound to be active: z_l[0] = {}",
+        on.captured.z_l[0]
+    );
+    assert!(on.captured.z_l[1].abs() < 1e-4 && on.captured.z_u[1].abs() < 1e-4);
+    assert!((on.captured.lambda[0] - off.captured.lambda[0]).abs() < 1e-4);
+}
+
+#[test]
+fn both_signs_close_full_space_stationarity() {
+    for alpha in [2.0, -2.0, 0.5, -0.5, 3.0] {
+        let on = solve(alpha, -100.0, 100.0, true);
+        for (j, r) in stationarity(alpha, &on.captured).iter().enumerate() {
+            assert!(
+                r.abs() < 1e-5,
+                "α = {alpha}: stationarity at column {j} = {r}, duals = {:?}",
+                on.captured
+            );
+        }
+        for j in 0..2 {
+            assert!(on.captured.z_l[j] >= -1e-8 && on.captured.z_u[j] >= -1e-8);
+        }
+    }
+}
+
+/// When the survivor's own bound and a transferred bound are the *same*
+/// constraint, the reduced problem has one multiplier where the full problem
+/// has two, and any split summing correctly is a valid KKT point. Assert
+/// validity, not equality with the bare solve.
+#[test]
+fn the_degenerate_both_active_case_is_still_a_valid_kkt_point() {
+    // x0 ≤ 1 transfers to x1 ≤ 0.5, which x1 already declares.
+    let alpha = 2.0;
+    let on = solve(alpha, -100.0, 0.5, true);
+    assert_eq!(on.reduced_n, 1);
+    let c = &on.captured;
+
+    assert!((c.x[0] - 1.0).abs() < 1e-6, "{:?}", c.x);
+    assert!((c.x[1] - 0.5).abs() < 1e-6, "{:?}", c.x);
+    for (j, r) in stationarity(alpha, c).iter().enumerate() {
+        assert!(
+            r.abs() < 1e-5,
+            "stationarity at column {j} = {r}, duals = {c:?}"
+        );
+    }
+    for j in 0..2 {
+        assert!(c.z_l[j] >= -1e-8, "z_l[{j}] = {} is negative", c.z_l[j]);
+        assert!(c.z_u[j] >= -1e-8, "z_u[{j}] = {} is negative", c.z_u[j]);
+        // Complementarity: no multiplier on a slack bound.
+        assert!(c.z_l[j] < 1e-4, "z_l[{j}] on an inactive bound");
+    }
+    // The tie goes to the incumbent, so the multiplier stays where the
+    // solver reported it rather than moving to a bound that is only
+    // coincidentally equal.
+    assert!(
+        c.z_u[1] > 1e-3,
+        "expected the survivor to keep it: z_u = {:?}",
+        c.z_u
+    );
+}

--- a/crates/pounce-presolve/src/linear_eq_elim.rs
+++ b/crates/pounce-presolve/src/linear_eq_elim.rs
@@ -36,9 +36,11 @@
 //! in the convention POUNCE hands to `finalize_solution` (Ipopt's: the
 //! Lagrangian is `f + λᵀg`), is
 //! `∇f + J_Kᵀλ_K + J_Dᵀλ_D − z_l + z_u = 0`. Restricted to the eliminated
-//! columns (where `z_l = z_u = 0`, see the caveat below) that is a square
-//! system `J_D[:,e]ᵀ λ_D = −(∇f_e + J_K[:,e]ᵀ λ_K)` — which, taken all at
-//! once, is a sparse solve nobody wants inside presolve.
+//! columns — where the bound multipliers are known before the sweep starts,
+//! either zero or whatever the attribution below placed there — that is a
+//! square system `J_D[:,e]ᵀ λ_D = −(∇f_e + J_K[:,e]ᵀ λ_K − z_l,e + z_u,e)`
+//! — which, taken all at once, is a sparse solve nobody wants inside
+//! presolve.
 //!
 //! Taken one elimination at a time in **reverse** order it is triangular
 //! instead. Step `t` consumed row `r_t` to determine variable `v_t`; every
@@ -57,17 +59,51 @@
 //! Jacobian row is annihilated by `A` and so contributes nothing to
 //! stationarity in either space.
 //!
-//! # Dual-attribution caveat
+//! # Bound multipliers, and where they belong
 //!
-//! The recovery assumes an eliminated variable is interior to its own
-//! bounds at the optimum, so `z_l = z_u = 0` there — the same assumption
-//! [`crate::reduction_frame`] documents. When an eliminated variable's
-//! bound *is* active, that bound was transferred onto its survivor during
-//! planning, so the IPM reports the dual on the **survivor's** bound
-//! multiplier instead. The primal point, the objective, and full-space
-//! stationarity are all unaffected; only the attribution of that one dual
-//! differs from a no-presolve solve. This is the same class of caveat as
-//! the Phase-2 note in [`crate`]'s module docs (issue M24).
+//! An eliminated column's box does not disappear during planning: it is
+//! *transferred* onto its survivor, so the reduced problem's box is an
+//! intersection of boxes borrowed from the whole cluster. The IPM therefore
+//! reports one `z_l` / `z_u` pair per surviving column, for a bound that
+//! may well have been declared on a column that is no longer there.
+//!
+//! Handing that multiplier back verbatim to the survivor is a valid KKT
+//! point but the wrong *attribution*: a no-presolve solve reports it on the
+//! column that owns the bound. [`EliminationPlan::x_l_src`] /
+//! [`EliminationPlan::x_u_src`] record which column each reduced bound came
+//! from, and `attribute_bound_multiplier` routes the multiplier there
+//! (issue #493).
+//!
+//! Two details make that routing exact rather than approximate. With
+//! `x_src = α·x_kept + β`, the survivor's bound is the origin's bound
+//! divided by `α`, so the multiplier — a derivative with respect to the
+//! *other* variable — is multiplied by `1/|α|` for the chain rule to close.
+//! And a negative `α` reverses the interval, so a **lower** bound on the
+//! survivor is an **upper** bound of the eliminated column, and the
+//! multiplier has to change sides with it. That is the same flip
+//! `transfer_bounds` performs on the way in.
+//!
+//! With the bound multipliers placed first, the dual sweep below starts
+//! from the full stationarity residual `∇f + Jᵀλ − z_l + z_u` rather than
+//! from `∇f + Jᵀλ` alone, so the recovered row multipliers absorb the
+//! difference and full-space stationarity closes either way.
+//!
+//! # What is still non-unique
+//!
+//! When the survivor's *own* bound and a transferred bound are active at
+//! the same point, the reduced problem has one multiplier where the full
+//! problem has two, and any split summing correctly is a valid KKT point.
+//! The plan breaks that tie in favour of the incumbent (see
+//! `transfer_bounds`'s strict comparisons), so the multiplier stays on the
+//! survivor. Tests pin KKT validity there, not equality with a bare solve —
+//! the posture `pounce-convex` already takes for forcing constraints.
+//!
+//! A column pinned to a constant by a singleton row `a·x = b` is the other
+//! degenerate case: if `b/a` lands on that column's bound, the row
+//! multiplier and the bound multiplier are interchangeable, and the sweep
+//! puts the whole thing on the row. That too is a valid KKT point, and the
+//! same class of caveat as the Phase-2 note in [`crate`]'s module docs
+//! (issue M24).
 
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -605,6 +641,61 @@ fn decode(irow: Index, jcol: Index, one_based: bool) -> (usize, usize) {
     }
 }
 
+/// Hand one reduced bound multiplier to the full-space column whose own
+/// declared bound produced that reduced bound (issue #493).
+///
+/// `src` is the plan's recorded provenance for the bound, `survivor` the
+/// full-space index of the surviving column the IPM reported `z` against,
+/// and `upper` says which side of the *reduced* box `z` belongs to.
+///
+/// With `x_src = α·x_survivor + β`, the reduced bound is the origin's bound
+/// pulled back through that map, so the multiplier scales by `1/|α|`, and a
+/// negative `α` sends it to the opposite side of the origin's box. That
+/// keeps `Σ over the cluster of α_e·(−z_l[e] + z_u[e])` equal to what the
+/// survivor alone used to contribute, which is exactly what full-space
+/// stationarity at the survivor needs.
+///
+/// Anything the plan cannot vouch for — a provenance that is not an affine
+/// image of this survivor, a non-finite or zero coefficient — leaves the
+/// multiplier where the solver put it. A wrong attribution would be worse
+/// than the old one.
+fn attribute_bound_multiplier(
+    plan: &EliminationPlan,
+    src: usize,
+    survivor: usize,
+    z: Number,
+    upper: bool,
+    z_l_full: &mut [Number],
+    z_u_full: &mut [Number],
+) {
+    let keep_here = |z_l_full: &mut [Number], z_u_full: &mut [Number]| {
+        if upper {
+            z_u_full[survivor] += z;
+        } else {
+            z_l_full[survivor] += z;
+        }
+    };
+    if src == survivor || src >= plan.n_full || z == 0.0 {
+        keep_here(z_l_full, z_u_full);
+        return;
+    }
+    let VarRecovery::Affine { rep, coeff, .. } = plan.recovery[src] else {
+        keep_here(z_l_full, z_u_full);
+        return;
+    };
+    if rep != survivor || !coeff.is_finite() || coeff == 0.0 {
+        keep_here(z_l_full, z_u_full);
+        return;
+    }
+    // `upper XOR (α < 0)`: the side flips exactly when the map reverses the
+    // interval.
+    if upper != (coeff < 0.0) {
+        z_u_full[src] += z / coeff.abs();
+    } else {
+        z_l_full[src] += z / coeff.abs();
+    }
+}
+
 /// Recover a multiplier for every row the plan consumed.
 ///
 /// See the module docs for why a reverse sweep over the elimination steps
@@ -615,9 +706,16 @@ fn decode(irow: Index, jcol: Index, one_based: bool) -> (usize, usize) {
 /// Signs follow the convention `finalize_solution` uses, `∇f + Jᵀλ − z_l +
 /// z_u = 0`, so `resid` accumulates `+Jᵀλ` and each pivot solve carries the
 /// matching negation.
+///
+/// `z_l_full` / `z_u_full` are the full-space bound multipliers **after**
+/// attribution (gh#493). They belong in the residual the sweep cancels: an
+/// eliminated column that carries an attributed multiplier needs a
+/// correspondingly smaller row multiplier for stationarity to close there.
 fn recover_dropped_multipliers(
     plan: &EliminationPlan,
     grad_f: &[Number],
+    z_l_full: &[Number],
+    z_u_full: &[Number],
     jac_irow: &[Index],
     jac_jcol: &[Index],
     jac_values: &[Number],
@@ -634,6 +732,9 @@ fn recover_dropped_multipliers(
     // just the row it resolved.
     let mut row_entries: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m];
     let mut resid = grad_f.to_vec();
+    for (j, r) in resid.iter_mut().enumerate() {
+        *r += z_u_full.get(j).copied().unwrap_or(0.0) - z_l_full.get(j).copied().unwrap_or(0.0);
+    }
     for k in 0..jac_irow.len() {
         let (i, j) = decode(jac_irow[k], jac_jcol[k], one_based);
         if i >= m || j >= n {
@@ -928,18 +1029,37 @@ impl TNLP for LinearEqElimTnlp {
             s.plan.lift_x(sol.x, &mut x_full);
         }
 
-        // Bound multipliers: the survivors' values where they belong, zero
-        // at every eliminated column (see the dual-attribution caveat).
+        // Bound multipliers: each one routed to the column whose declared
+        // bound the reduced bound came from, which is the survivor itself
+        // unless a transfer moved that bound there (gh#493). This has to
+        // happen before the dual sweep below, which cancels the residual
+        // these leave behind.
         let mut z_l_full = vec![0.0; n_in];
         let mut z_u_full = vec![0.0; n_in];
         {
             let s = self.state.as_ref().expect("inited");
             for (red, &full) in s.plan.vars_kept.iter().enumerate() {
                 if red < sol.z_l.len() {
-                    z_l_full[full] = sol.z_l[red];
+                    attribute_bound_multiplier(
+                        &s.plan,
+                        s.plan.x_l_src.get(red).copied().unwrap_or(full),
+                        full,
+                        sol.z_l[red],
+                        false,
+                        &mut z_l_full,
+                        &mut z_u_full,
+                    );
                 }
                 if red < sol.z_u.len() {
-                    z_u_full[full] = sol.z_u[red];
+                    attribute_bound_multiplier(
+                        &s.plan,
+                        s.plan.x_u_src.get(red).copied().unwrap_or(full),
+                        full,
+                        sol.z_u[red],
+                        true,
+                        &mut z_l_full,
+                        &mut z_u_full,
+                    );
                 }
             }
         }
@@ -995,6 +1115,8 @@ impl TNLP for LinearEqElimTnlp {
                 recover_dropped_multipliers(
                     &s.plan,
                     &grad_f,
+                    &z_l_full,
+                    &z_u_full,
                     &s.jac_irow_inner,
                     &s.jac_jcol_inner,
                     &jac_values,
@@ -1389,6 +1511,8 @@ mod tests {
             row_kept,
             x_l_red: Vec::new(),
             x_u_red: Vec::new(),
+            x_l_src: Vec::new(),
+            x_u_src: Vec::new(),
             steps,
             parent,
             report: LinearEqElimReport::default(),
@@ -1409,7 +1533,17 @@ mod tests {
             1,
         );
         let mut lambda = vec![0.0];
-        recover_dropped_multipliers(&plan, &[4.0], &[0], &[0], &[1.0], false, &mut lambda);
+        recover_dropped_multipliers(
+            &plan,
+            &[4.0],
+            &[0.0],
+            &[0.0],
+            &[0],
+            &[0],
+            &[1.0],
+            false,
+            &mut lambda,
+        );
         assert!((lambda[0] + 4.0).abs() < 1e-12, "{lambda:?}");
     }
 
@@ -1446,6 +1580,8 @@ mod tests {
         recover_dropped_multipliers(
             &plan,
             &[2.0, 3.0, 5.0],
+            &[0.0; 3],
+            &[0.0; 3],
             &irow,
             &jcol,
             &vals,
@@ -1484,7 +1620,17 @@ mod tests {
         let vals = [1.0, -2.0, 1.0, -1.0, 0.3, 0.7, 1.1];
         let grad = [2.0, 3.0, 5.0];
         let mut lambda = vec![0.0, 0.0, 0.5];
-        recover_dropped_multipliers(&plan, &grad, &irow, &jcol, &vals, false, &mut lambda);
+        recover_dropped_multipliers(
+            &plan,
+            &grad,
+            &[0.0; 3],
+            &[0.0; 3],
+            &irow,
+            &jcol,
+            &vals,
+            false,
+            &mut lambda,
+        );
         for col in [0usize, 1] {
             let mut resid = grad[col];
             for k in 0..irow.len() {
@@ -1497,6 +1643,127 @@ mod tests {
                 "stationarity at eliminated column {col} = {resid}, λ = {lambda:?}"
             );
         }
+    }
+
+    /// `x0 = α·x1 + β` with x0's bound transferred onto x1: the multiplier
+    /// goes back to x0, scaled by `1/|α|`, and changes sides when α < 0
+    /// (gh#493).
+    fn plan_with_transferred_bound(coeff: Number) -> EliminationPlan {
+        let mut plan = plan_with(
+            vec![ElimStep {
+                row: 0,
+                var: 0,
+                pivot: 1.0,
+            }],
+            vec![Some((1, coeff)), None],
+            1,
+        );
+        plan.recovery = vec![
+            VarRecovery::Affine {
+                rep: 1,
+                coeff,
+                offset: 0.0,
+            },
+            VarRecovery::Kept(0),
+        ];
+        plan.vars_kept = vec![1];
+        // Both of x1's reduced bounds were born on x0.
+        plan.x_l_src = vec![0];
+        plan.x_u_src = vec![0];
+        plan
+    }
+
+    #[test]
+    fn a_positive_coefficient_keeps_the_multiplier_on_the_same_side() {
+        let plan = plan_with_transferred_bound(2.0);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        attribute_bound_multiplier(&plan, 0, 1, 12.0, true, &mut z_l, &mut z_u);
+        assert_eq!(z_u, vec![6.0, 0.0], "z_u = 12/|α| on x0");
+        assert_eq!(z_l, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn a_negative_coefficient_flips_the_side_the_multiplier_lands_on() {
+        let plan = plan_with_transferred_bound(-2.0);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        // The survivor's *lower* bound is x0's *upper* bound when α < 0.
+        attribute_bound_multiplier(&plan, 0, 1, 12.0, false, &mut z_l, &mut z_u);
+        assert_eq!(z_u, vec![6.0, 0.0]);
+        assert_eq!(z_l, vec![0.0, 0.0]);
+    }
+
+    #[test]
+    fn a_survivors_own_bound_keeps_its_multiplier() {
+        let plan = plan_with_transferred_bound(2.0);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        attribute_bound_multiplier(&plan, 1, 1, 7.0, false, &mut z_l, &mut z_u);
+        assert_eq!(z_l, vec![0.0, 7.0]);
+    }
+
+    /// A provenance the plan cannot vouch for must not move the multiplier:
+    /// a wrong attribution is worse than the old one.
+    #[test]
+    fn an_unvouched_provenance_leaves_the_multiplier_where_it_was() {
+        let mut plan = plan_with_transferred_bound(2.0);
+        plan.recovery[0] = VarRecovery::Constant(3.0);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        attribute_bound_multiplier(&plan, 0, 1, 5.0, true, &mut z_l, &mut z_u);
+        assert_eq!(z_u, vec![0.0, 5.0]);
+
+        // Out of range, and pointing at a different survivor, likewise.
+        let mut plan = plan_with_transferred_bound(2.0);
+        plan.recovery[0] = VarRecovery::Affine {
+            rep: 9,
+            coeff: 2.0,
+            offset: 0.0,
+        };
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        attribute_bound_multiplier(&plan, 0, 1, 5.0, true, &mut z_l, &mut z_u);
+        attribute_bound_multiplier(&plan, 99, 1, 4.0, true, &mut z_l, &mut z_u);
+        assert_eq!(z_u, vec![0.0, 9.0]);
+    }
+
+    /// The sweep has to see the attributed multipliers, or the row
+    /// multiplier it recovers will double-count them.
+    ///
+    /// `min 4·x0  s.t.  x0 − 2·x1 = 0`, row 0 consumed to eliminate x0.
+    /// Stationarity at x0 is `∇f + λ·1 − z_l + z_u = 0`, so with nothing
+    /// attributed there the sweep must return `λ = −4`, and with `z_u = 4`
+    /// attributed to x0 it must return `λ = −8` instead.
+    #[test]
+    fn the_sweep_absorbs_an_attributed_bound_multiplier() {
+        let plan = plan_with_transferred_bound(2.0);
+        let irow = [0, 0];
+        let jcol = [0, 1];
+        let vals = [1.0, -2.0];
+
+        let mut lambda = vec![0.0];
+        recover_dropped_multipliers(
+            &plan,
+            &[4.0, 0.0],
+            &[0.0, 0.0],
+            &[0.0, 0.0],
+            &irow,
+            &jcol,
+            &vals,
+            false,
+            &mut lambda,
+        );
+        assert!((lambda[0] + 4.0).abs() < 1e-12, "{lambda:?}");
+
+        let mut lambda = vec![0.0];
+        recover_dropped_multipliers(
+            &plan,
+            &[4.0, 0.0],
+            &[0.0, 0.0],
+            &[4.0, 0.0],
+            &irow,
+            &jcol,
+            &vals,
+            false,
+            &mut lambda,
+        );
+        assert!((lambda[0] + 8.0).abs() < 1e-12, "{lambda:?}");
     }
 
     #[test]

--- a/crates/pounce-presolve/src/linear_eq_plan.rs
+++ b/crates/pounce-presolve/src/linear_eq_plan.rs
@@ -165,6 +165,22 @@ pub struct EliminationPlan {
     /// every bound transferred off an eliminated variable.
     pub x_l_red: Vec<Number>,
     pub x_u_red: Vec<Number>,
+    /// Provenance of each reduced bound: the **full-space column whose own
+    /// declared bound** the reduced bound came from, aligned with
+    /// [`Self::x_l_red`] / [`Self::x_u_red`]. Equal to `vars_kept[i]` when
+    /// the survivor's own bound won, and some eliminated column of the same
+    /// cluster when a transferred bound did.
+    ///
+    /// Postsolve reads this to hand a reduced bound's multiplier back to the
+    /// column that actually owns the bound; see
+    /// [`crate::linear_eq_elim`]'s `attribute_bound_multiplier` (issue
+    /// #493). Which *side* of the origin column's box a reduced bound
+    /// corresponds to is not recorded separately: it is the origin's own
+    /// side when the composed coefficient `α` of `x_src = α·x_kept + β` is
+    /// positive and the opposite side when it is negative, which is exactly
+    /// the flip [`transfer_bounds`] performs on the way in.
+    pub x_l_src: Vec<usize>,
+    pub x_u_src: Vec<usize>,
     /// Accepted eliminations in application order.
     pub steps: Vec<ElimStep>,
     /// Elimination forest: `parent[i] = Some((p, α))` when `i` was folded
@@ -187,6 +203,8 @@ impl EliminationPlan {
             rows_kept: (0..n_rows).collect(),
             x_l_red: x_l.to_vec(),
             x_u_red: x_u.to_vec(),
+            x_l_src: (0..n_vars).collect(),
+            x_u_src: (0..n_vars).collect(),
             steps: Vec::new(),
             parent: vec![None; n_vars],
             report: LinearEqElimReport::default(),
@@ -238,11 +256,19 @@ impl EliminationPlan {
 struct Box2 {
     lo: Vec<Number>,
     hi: Vec<Number>,
+    /// Which full-space column's own declared bound each entry came from.
+    /// Starts as the identity and follows the bound through every transfer,
+    /// so a survivor's final box knows where each of its two sides was born
+    /// (gh#493).
+    lo_src: Vec<usize>,
+    hi_src: Vec<usize>,
 }
 
 impl Box2 {
     fn from_declared(x_l: &[Number], x_u: &[Number]) -> Self {
         Self {
+            lo_src: (0..x_l.len()).collect(),
+            hi_src: (0..x_u.len()).collect(),
             lo: x_l
                 .iter()
                 .map(|&v| {
@@ -583,11 +609,24 @@ fn transfer_bounds(
     if !derived_hi.is_finite() {
         derived_hi = Number::INFINITY;
     }
+    // The same flip the interval carries: with α < 0 it is `elim`'s *upper*
+    // bound that becomes the survivor's lower bound. Provenance rides along
+    // (gh#493), so a bound that has hopped several times still names the
+    // column that declared it.
+    let (src_lo, src_hi) = if alpha > 0.0 {
+        (bounds.lo_src[elim], bounds.hi_src[elim])
+    } else {
+        (bounds.hi_src[elim], bounds.lo_src[elim])
+    };
+    // Strict comparisons, so a tie leaves the incumbent — including the
+    // survivor's own declared bound — in place.
     if derived_lo > bounds.lo[keep] {
         bounds.lo[keep] = derived_lo;
+        bounds.lo_src[keep] = src_lo;
     }
     if derived_hi < bounds.hi[keep] {
         bounds.hi[keep] = derived_hi;
+        bounds.hi_src[keep] = src_hi;
     }
     let (lo, hi) = (bounds.lo[keep], bounds.hi[keep]);
     if lo.is_finite() && hi.is_finite() && lo > hi {
@@ -670,17 +709,23 @@ fn finish(
     // derived, so an "absent" bound stays spelled the way it arrived.
     let mut x_l_red = Vec::with_capacity(vars_kept.len());
     let mut x_u_red = Vec::with_capacity(vars_kept.len());
+    let mut x_l_src = Vec::with_capacity(vars_kept.len());
+    let mut x_u_src = Vec::with_capacity(vars_kept.len());
     for &j in &vars_kept {
-        x_l_red.push(if bounds.lo[j].is_finite() {
-            bounds.lo[j]
+        if bounds.lo[j].is_finite() {
+            x_l_red.push(bounds.lo[j]);
+            x_l_src.push(bounds.lo_src[j]);
         } else {
-            input.x_l[j]
-        });
-        x_u_red.push(if bounds.hi[j].is_finite() {
-            bounds.hi[j]
+            x_l_red.push(input.x_l[j]);
+            x_l_src.push(j);
+        }
+        if bounds.hi[j].is_finite() {
+            x_u_red.push(bounds.hi[j]);
+            x_u_src.push(bounds.hi_src[j]);
         } else {
-            input.x_u[j]
-        });
+            x_u_red.push(input.x_u[j]);
+            x_u_src.push(j);
+        }
     }
 
     EliminationPlan {
@@ -692,6 +737,8 @@ fn finish(
         rows_kept,
         x_l_red,
         x_u_red,
+        x_l_src,
+        x_u_src,
         steps,
         parent,
         report,
@@ -926,6 +973,126 @@ mod tests {
         assert_eq!(p.vars_kept, vec![1]);
         assert!((p.x_l_red[0] + 3.0).abs() < 1e-12, "{:?}", p.x_l_red);
         assert!((p.x_u_red[0] + 1.0).abs() < 1e-12, "{:?}", p.x_u_red);
+    }
+
+    /// A transferred bound records the column that declared it, so postsolve
+    /// can hand that column's multiplier back (gh#493).
+    #[test]
+    fn a_transferred_bound_names_the_column_it_came_from() {
+        // x0 = 2·x1 with x0 ∈ [-inf, 1] pins x1 ≤ 0.5; x1's own lower bound
+        // survives untouched.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, -2.0)], 0.0)
+            .bounds(0, -1e19, 1.0)
+            .bounds(1, -4.0, 1e19);
+        let p = f.plan();
+        assert_eq!(p.vars_kept, vec![1]);
+        assert!((p.x_u_red[0] - 0.5).abs() < 1e-12, "{:?}", p.x_u_red);
+        assert_eq!(p.x_u_src, vec![0], "the upper bound is x0's");
+        assert_eq!(p.x_l_src, vec![1], "the lower bound is x1's own");
+    }
+
+    /// The provenance carries the same flip the interval does: with α < 0 the
+    /// survivor's *lower* bound is the eliminated column's *upper* one.
+    #[test]
+    fn a_negative_coefficient_flips_which_side_the_provenance_lands_on() {
+        // x0 = -2·x1 with x0 ∈ [-inf, 1] pins x1 ≥ -0.5.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, 2.0)], 0.0)
+            .bounds(0, -1e19, 1.0);
+        let p = f.plan();
+        assert_eq!(p.vars_kept, vec![1]);
+        assert!((p.x_l_red[0] + 0.5).abs() < 1e-12, "{:?}", p.x_l_red);
+        assert_eq!(p.x_l_src, vec![0], "x1's lower bound is x0's upper bound");
+        assert_eq!(p.x_u_src, vec![1], "nothing tightened x1 from above");
+    }
+
+    /// Provenance follows a chain: a bound that hops twice still names the
+    /// column that declared it, and each hop composes the sign flip.
+    #[test]
+    fn provenance_survives_a_chain_of_transfers() {
+        // x0 = -x1 (row 0), then x1 = -0.1·x2 (row 1 — the lopsided
+        // coefficients make x2 the pivot, so the transfer chains rather than
+        // fanning in). x0 ≤ 1 becomes x1 ≥ -1 becomes x2 ≤ 10, still owned by
+        // x0's *upper* bound.
+        let f = Fixture::new(3)
+            .eq(&[(0, 1.0), (1, 1.0)], 0.0)
+            .eq(&[(1, 1.0), (2, 0.1)], 0.0)
+            .bounds(0, -1e19, 1.0);
+        let p = f.plan();
+        assert_eq!(p.vars_kept, vec![2]);
+        assert!((p.x_u_red[0] - 10.0).abs() < 1e-12, "{:?}", p.x_u_red);
+        assert_eq!(p.x_u_src, vec![0]);
+        assert_eq!(p.x_l_src, vec![2], "nothing tightened x2 from below");
+        // x0 = (-1)·(-0.1)·x2, so the composed α is positive: two flips put
+        // the side back where it started, and 0.1·10 is x0's own bound.
+        assert_eq!(
+            p.recovery[0],
+            VarRecovery::Affine {
+                rep: 2,
+                coeff: 0.1,
+                offset: 0.0
+            }
+        );
+    }
+
+    /// A tie leaves the incumbent alone, which is what keeps the degenerate
+    /// both-bounds-active case attributed to the survivor.
+    #[test]
+    fn a_tied_transfer_leaves_the_provenance_on_the_survivor() {
+        // x0 = 2·x1, x0 ≤ 1 and x1 ≤ 0.5 are the same constraint.
+        let f = Fixture::new(2)
+            .eq(&[(0, 1.0), (1, -2.0)], 0.0)
+            .bounds(0, -1e19, 1.0)
+            .bounds(1, -1e19, 0.5);
+        let p = f.plan();
+        assert_eq!(p.vars_kept, vec![1]);
+        assert!((p.x_u_red[0] - 0.5).abs() < 1e-12, "{:?}", p.x_u_red);
+        assert_eq!(p.x_u_src, vec![1]);
+    }
+
+    /// Every reduced bound must be the origin's own bound pulled back through
+    /// the recovery map — the identity postsolve's rescaling relies on.
+    #[test]
+    fn provenance_and_the_recovery_map_agree_on_every_reduced_bound() {
+        let f = Fixture::new(4)
+            .eq(&[(0, 1.0), (1, 3.0)], 6.0)
+            .eq(&[(1, 2.0), (2, -0.5)], 1.0)
+            .opaque(&[(2, 1.0), (3, 1.0)], 0.0, 10.0)
+            .bounds(0, -2.0, 7.0)
+            .bounds(1, -5.0, 5.0)
+            .bounds(2, -20.0, 20.0);
+        let p = f.plan();
+        assert!(!p.is_identity());
+        for (red, &kept) in p.vars_kept.iter().enumerate() {
+            for (src, red_bound, upper) in [
+                (p.x_l_src[red], p.x_l_red[red], false),
+                (p.x_u_src[red], p.x_u_red[red], true),
+            ] {
+                if src == kept || !red_bound.is_finite() || red_bound.abs() >= 1e19 {
+                    continue;
+                }
+                let VarRecovery::Affine { rep, coeff, offset } = p.recovery[src] else {
+                    panic!(
+                        "provenance {src} is not an affine image: {:?}",
+                        p.recovery[src]
+                    );
+                };
+                assert_eq!(rep, kept, "provenance {src} names a different survivor");
+                // Which side of the origin's box: its own when α > 0, the
+                // other one when α < 0.
+                let origin = if upper != (coeff < 0.0) {
+                    f.x_u[src]
+                } else {
+                    f.x_l[src]
+                };
+                let lifted = coeff * red_bound + offset;
+                assert!(
+                    (lifted - origin).abs() < 1e-12,
+                    "reduced bound {red_bound} lifts to {lifted}, not {src}'s {origin}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -346,21 +346,31 @@ original model's shape and can still be read positionally by AMPL or Pyomo.
 
 Two things to know before turning it on:
 
-* **Dual attribution.** The recovery assumes an eliminated variable is
-  interior to its own bounds at the optimum. When one of those bounds is
-  active, the dual is reported on the *survivor's* bound multiplier (which
-  carries the transferred bound) and the eliminated variable's bound
-  multiplier is zero. The primal point, the objective, and KKT stationarity
-  are unaffected — only the attribution differs, the same way Phase 2's
-  dropped rows behave.
+* **Dual attribution.** A transferred bound's multiplier comes back on the
+  variable that *declared* the bound, not on the survivor that inherited
+  it. The plan records where each reduced bound came from, and postsolve
+  rescales the multiplier by the substitution's coefficient `α` — and moves
+  it to the other side of the box when `α < 0`, since a negative
+  coefficient turns a lower bound into an upper one. On a model with a
+  single active transferred bound the reported duals match a no-presolve
+  solve exactly.
 
-  A practical consequence for `.sol` readers: the writer omits exact zeros
-  from suffix blocks (it always has), so an eliminated variable gets **no**
-  `ipopt_zL_out` / `ipopt_zU_out` entry at all rather than an entry of zero.
-  Code that indexes those suffixes must treat a missing index as zero — as
-  it already must for any variable whose bound multiplier lands exactly on
-  zero. Row multipliers are unaffected: the dual block is dense and comes
-  back at the original row count.
+  Where the survivor's *own* bound and a transferred bound are active at
+  the same point, the split between the two multipliers is genuinely
+  non-unique — the reduced problem has one where the full problem has two —
+  and the pass leaves the whole multiplier on the survivor. That is a valid
+  KKT point, but it is not the split a no-presolve solve happens to report.
+  The same holds for a variable pinned by a singleton row `a·x = b` whose
+  value lands on one of its own bounds: the row multiplier absorbs it.
+
+  A practical consequence for `.sol` readers, unchanged by any of the
+  above: the writer omits exact zeros from suffix blocks (it always has),
+  so a variable whose bound multiplier is zero gets **no**
+  `ipopt_zL_out` / `ipopt_zU_out` entry at all rather than an entry of
+  zero. Code that indexes those suffixes must treat a missing index as
+  zero — as it already must for any variable whose bound multiplier lands
+  exactly on zero. Row multipliers are unaffected: the dual block is dense
+  and comes back at the original row count.
 * **Failing closed.** If the equality system is contradictory, the pass
   stands down entirely and hands the model to the solver untouched, rather
   than being the first and only voice to call a model infeasible. The same


### PR DESCRIPTION
Fixes #493.

> **Base branch.** This targets `claude/issue-487-uj8knh` (#490), not `main`.
> The two files it changes do not exist on `main` yet — #493 is a follow-up to
> #490 and its scope is entirely inside them. Merge #490 first, or merge this
> into #490 and ship the pair.

## Problem

Phase 6 does not throw an eliminated column's box away: it *transfers* it onto
the survivor. So a reduced column's box is an intersection of boxes borrowed
from the whole cluster, and the IPM reports one `z_l` / `z_u` pair against a
bound that may have been declared on a column that is no longer there.

Postsolve handed that multiplier straight back to the survivor. #490 documented
this as an attribution difference with primal, objective, and stationarity all
unaffected. That was true as far as it went, and understated the problem:
**bound complementarity is violated in the original variable space.** The
survivor gets a non-zero multiplier on a bound it is not sitting on.

The smallest case, solved end to end through the CLI — `min (x0−4)²` subject to
`x0 = 2·x1`, `x0 ≤ 1`, `x1 ∈ [−100, 100]`:

| | z_u[x0] | z_u[x1] | λ | complementarity |
|---|---|---|---|---|
| no presolve | 6 | 0 | 0 | holds |
| before | 0 | 12 | 6 | **violated** — x1 sits at 0.5, nowhere near its bound of 100 |
| after | 6 | 0 | 0 | holds; matches the bare solve exactly |

At scale, an adversarial probe over ~700 randomized `.nl` models finds 15–22
KKT violations per seed before, 0 after.

## Cause

`finish()` intersects each cluster's boxes down into `bounds.lo/hi` and discards
which member supplied the winning bound, so postsolve had no way to know the
bound was not the survivor's own.

## Fix

**Record provenance, then split at postsolve** — option (b) of the issue.

`Box2` carries `lo_src` / `hi_src` next to each bound, updated wherever
`transfer_bounds` tightens the survivor's box, and `finish` publishes them as
`EliminationPlan::x_l_src` / `x_u_src`. Provenance rides the same flip the
interval does — with `α < 0` the survivor's lower bound is the eliminated
column's upper one — so a bound that has hopped down a chain still names the
column that declared it.

`finalize_solution` routes each multiplier through `attribute_bound_multiplier`,
which rescales by `1/|α|` (the chain rule, since the multiplier is a derivative
taken with respect to the other variable) and sends it to the opposite side of
the origin's box when `α < 0`.

Two decisions worth recording because the cheaper alternative was tried:

**The side is derived from the coefficient's sign, not stored.** A first draft
carried an explicit `upper` flag alongside each provenance index. It is
redundant: the reduced bound corresponds to the origin's own side exactly when
the composed `α` is positive. Deriving it cannot drift out of sync with the
recovery map the way a second stored field can, and the probe now pins the
identity directly (every reduced bound must lift, through its origin's recovery
map, exactly onto that origin's declared bound).

**The sweep starts from the full residual.** With multipliers now sitting on
eliminated columns, the dual recovery has to begin from `∇f + Jᵀλ − z_l + z_u`
rather than `∇f + Jᵀλ`, or the row multipliers double-count them. This is the
one change outside the attribution itself, and it is why full-space stationarity
still closes.

Anything the plan cannot vouch for — a provenance that is not an affine image of
this survivor, a zero or non-finite coefficient — leaves the multiplier where the
solver put it. A wrong attribution would be worse than the old one.

## Blast radius

Confined to the two files #490 adds, and to a code path that is off by default
(`presolve_linear_eq_reduction=no`). Every existing test is unchanged and green;
the full workspace suite, `cargo fmt --check`, the CI clippy gate, and
`check-release-consistency.sh` are clean. `pounce-hsl`'s `t_sym_solver_ma57`
fails to link in this container, on the parent commit too — pre-existing, and CI
excludes that crate.

**Deliberately not fixed here:** where the survivor's *own* bound and a
transferred bound are active at the same point, the split is genuinely
non-unique — the reduced problem has one multiplier where the full problem has
two. The tie goes to the incumbent and the multiplier stays on the survivor.
That is a valid KKT point, and the tests assert validity there rather than
equality with a bare solve, the posture `pounce-convex` already takes for
forcing constraints.

## Tests

Five defects injected one at a time into the shipped code, each reverted after:

| injected defect | caught by | signal |
|---|---|---|
| publish the survivor as its own provenance | 3 plan unit tests, 2 acceptance tests | — |
| provenance ignores the `α < 0` flip | 1 plan unit test, the `linelim` probe | 34 / 4000 |
| attribution ignores the `α < 0` flip | 1 unit test, 2 acceptance tests | — |
| drop the `1/|α|` rescale | 2 unit tests, 3 acceptance tests | — |
| sweep ignores the attributed multipliers | 1 unit test, 3 acceptance tests | — |

Layers:

- 5 planner unit tests and 5 wrapper unit tests.
- `presolve_phase6_bound_attribution.rs` — solves through the full stack on the
  smallest model that exhibits the transfer, for **both signs of α**, comparing
  the duals against the bare solve; plus the degenerate both-active case,
  asserted for KKT validity and multiplier signs rather than equality.
- The `linelim` adversary probe gains a bound-provenance property: every reduced
  bound must lift, through the recovery map of the column the plan names,
  exactly onto that column's declared bound. 12,000 instances, three seeds, 0
  failures. This is the check #493 asked for — the probe's existing stationarity
  properties pass with the multiplier on either column.
- `adversary/runs/2026-08-06_nlp_phase6_bound_attribution.py` — a new end-to-end
  probe (see below).

## Adversarial round

The existing gh#487 probes could not see this question at all: their generator
gives every box at least 1.0 of margin around `x*`, so no bound is ever active
and every bound multiplier is zero. The new probe makes bounds active on the
eliminated columns and checks the **full KKT system** — feasibility,
stationarity, dual feasibility, and bound complementarity — computed in the
script from the same arrays it wrote into the `.nl`, against the
`ipopt_zL_out` / `ipopt_zU_out` suffixes that come back.

80 instances per seed, 9 seeds: **0 failures on this branch, 15–22 per seed on
the parent commit.**

Worth recording, because it changes what `verify` can be relied on for:
`pounce verify` rejected **none** of the failing instances. It reports
*bound-projected* stationarity (`verify.rs`, `stationarity_residual`), which
projects out exactly the component a bound multiplier carries, and it never
reads the `zL`/`zU` suffixes. It is a feasibility oracle here, not a
discriminating one.

The probe keeps itself honest three ways: a control arm running the identical
check on the no-presolve solve (a run where more than 5% of those fail is
declared miscalibrated rather than passed), a self-check on a hand-computed
model that refuses to run unless the `.sol` sign conventions hold, and an exact
LICQ rank test so dual equality with the bare solve is asserted only where the
multipliers really are unique. Two earlier drafts used cluster- and
pinned-column heuristics for that last point; both let through instances where a
degenerate active set made the duals legitimately non-unique, and both were
replaced.

**One separate finding, filed as #495 and not caused by this change** — the
residuals are identical before and after. When Phase 6 removes a column whose
declared bound is active, no bound multiplier is produced for it *at all*, and
the reported duals are not a KKT multiplier set. It has a minimal
hand-checkable reproduction in the issue and is not fixable by re-attribution:
there is nothing to re-attribute. The probe classifies that family separately,
so it can neither mask a regression here nor be mistaken for one.

---

- [x] Tests fail on the parent commit for the stated reason — five injected
      defects in the table above, plus the whole-stack probe failing 15–22 per
      seed pre-fix
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`options.md`, the Phase 6 dual
      attribution note rewritten; no new page, so `SUMMARY.md` unchanged)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2XbBGaYjEVHysmB3nFbjA

---
_Generated by [Claude Code](https://claude.ai/code/session_01J2XbBGaYjEVHysmB3nFbjA)_