### PR TITLE
fix(nl): fold a constant row body into the row bounds at parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a constant left in a `.nl` row body made an affine row look nonlinear (#492)
+
+- A `.nl` writer may leave a constant on the left of a constraint —
+  `x0 + x1 + 3 <= 6` rather than `x0 + x1 <= 3` — and that constant arrives
+  in the row's *nonlinear-part* expression segment. POUNCE read any
+  non-empty expression segment as "this row is nonlinear", which is an
+  identity check, not a linearity test: the row is affine.
+- The reader now folds a constant row body into the row bounds at parse.
+  The body drops by `c` and each bound drops by `c` with it, so the
+  feasible set, the active set, the objective, and every multiplier are
+  unchanged — nothing reports a raw row body to the user, and both AMPL and
+  `pounce verify` re-derive bodies from the `.nl`. The fold is by
+  *evaluation*, not syntax, so a computed constant (`sqrt(9)`, `1 + 2`) is
+  caught too.
+- Two things this unblocks:
+  - **Presolve.** The new linear-equality reduction (Phase 6, #487) only
+    consumes rows tagged linear, so it declined every row with a constant
+    body. A model whose equalities carry offsets now reduces like the same
+    model written with the offsets in the bounds.
+  - **Routing.** A model that is a plain LP apart from a *computed* row
+    constant classified NLP and never reached `pounce-convex`; forcing
+    `solver_selection=lp-ipm` on it was a hard error. It now classifies LP.
+    (A bare literal already classified LP — the classifier's polynomial
+    walk absorbed it — so only the computed form was misrouted.)
+- Absent-bound sentinels are left alone. Presence is directional (#401), so
+  shifting a ±1e19 sentinel would turn "no bound" into a real one; the fold
+  moves a bound only when that side is actually bounded. A non-finite
+  constant, or one inside an imported-function call, is left in the
+  expression rather than pushed into a bound.
+
 ### Added — presolve eliminates variables determined by linear equality rows (#487)
 
 - `presolve_linear_eq_reduction` was a registered option with no

--- a/adversary/log.org
+++ b/adversary/log.org
@@ -10,7 +10,7 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 
 | Family          | Tested | Last run   | Open findings |
 |-----------------+--------+------------+---------------|
-| nlp             |     12 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6) |
+| nlp             |     13 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6); #496 (LP IPM false primal-infeasible on rank-deficient equalities inconsistent by 1 ULP) |
 | lp              |     10 | 2026-08-04 | —             |
 | qp              |     10 | 2026-08-03 | —             |
 | qp-active-set   |     14 | 2026-08-05 | both probes now CLEAN. Fixed this run: false-Infeasible (14 -> 0), `Optimal` at violating points, rank-deficiency hard errors, unvalidated working-set status codes, and IpoptGet/SetWorkingSet reporting the SQP's internal row order instead of the caller's. Nothing open. |
@@ -25,6 +25,34 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 | sensitivity     |     10 | 2026-08-03 | — (weakly-active one-sided dx/db intrinsic/known; no barrier inflation confirmed; reduced_hessian() cross-checked clean) |
 
 * Problem Index
+** [2026-08-06] Constant row bodies folded into row bounds (nlp/.nl parse boundary, gh#492) - PASS
+:PROPERTIES:
+:FAMILY: nlp
+:SOURCE: no published instance; randomized LP family around a KNOWN feasible point, five constant spellings x five r-segment bound kinds
+:KNOWN_OPTIMAL: n/a (property-based)
+:POUNCE_OBJECTIVE: agrees with HiGHS to <1e-6 relative on all 999 instances
+:POUNCE_STATUS: Optimal Solution Found (999/999; 1 instance skipped, gh#496)
+:POUNCE_TIME: ~0.01s per instance
+:ORACLE: scipy HiGHS (linprog); rows re-evaluated in-script against the file's declared bounds; hand-folded twin model (primal + duals); interior-column stationarity
+:ORACLE_OBJECTIVE: matches
+:ORACLE_TIME: -
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_nlp_row_constant_fold.org]]
+:COVERAGE_TARGET: crates/pounce-nl/src/nl_reader.rs (parse_nl_text fold) - new code, no prior adversarial coverage
+:END:
+999 randomized LPs over 4 seeds, every row carrying a constant in its C<i>
+segment, plus 60 sentinel cases at |k| up to 1e18 and 8 decline cases. All
+999 classified LP and were accepted by pounce verify. The probe was
+mutation-tested: five of six injected defects caught, the sixth (no fold at
+all) is not a correctness defect and moved only the classified-LP counter
+(60 -> 33). Two defects in the probe itself were found and fixed en route
+(bounds rounded to 9 places made redundant equality systems inconsistent; a
+1e-6 interior margin called bound-active columns interior). One unrelated
+pre-existing pounce bug was found and filed: gh#496, a false
+primal-infeasible certificate at iteration 0 when two rank-deficient
+equality rows disagree by one ULP -- reproduced on origin/main at cad2b13
+with no C-segment content, so not reachable from gh#492.
+
 ** [2026-08-06] Linear-equality variable elimination, Phase 6 (nlp/presolve, gh#487) - PASS
 :PROPERTIES:
 :FAMILY: nlp

--- a/adversary/runs/2026-08-06_nlp_row_constant_fold.org
+++ b/adversary/runs/2026-08-06_nlp_row_constant_fold.org
@@ -1,0 +1,213 @@
+#+TITLE: Adversary Run: Constant Row Bodies Folded into Row Bounds (gh#492)
+#+DATE: <2026-08-06>
+
+* Problem
+:PROPERTIES:
+:FAMILY: nlp
+:CLASS: =.nl= parse boundary — linear rows carrying constant offsets
+:SOURCE: no published instance; randomized LP family built around a KNOWN feasible point, with scipy HiGHS as the external oracle
+:KNOWN_OPTIMAL: n/a (property-based, not a single instance)
+:N_VARIABLES: 4–8
+:N_CONSTRAINTS: 1–7
+:SELECTED_BY: topic-guidance (new code under review for gh#492)
+:COVERAGE_TARGET: crates/pounce-nl/src/nl_reader.rs — =parse_nl_text='s constant-row-body fold, brand new, zero adversarial coverage
+:END:
+
+The =.nl= format lets a writer leave a constant on the left of a constraint:
+
+\[ lo_i \le \sum_j a_{ij} x_j + k_i \le hi_i \]
+
+with $k_i$ living in the row's *nonlinear-part* expression segment rather than
+in the bound. The change under test rewrites this at the parse boundary: when
+row $i$'s =C<i>= body evaluates to a constant $k_i$, the reader subtracts
+$k_i$ from that row's bounds and replaces the body with zero, giving
+
+\[ lo_i - k_i \le \sum_j a_{ij} x_j \le hi_i - k_i . \]
+
+The claim is that this is exact — body and bound move together, so the
+feasible set, the active set, the objective, and every multiplier are
+unchanged — and that it fires on every constant and only on constants.
+
+* Method
+
+Nothing here validates pounce against pounce-with-the-fold-off; that binary
+no longer exists. Four oracles on a randomized family, plus two targeted
+batteries.
+
+The family: LPs with $n \in [4,8]$, $m \in [1,n-1]$, generated around a random
+feasible $x^*$ so every instance is feasible by construction. Every row
+carries a constant, written in one of five spellings — =literal= (=n3=),
+=add= (=o0=), =sub= (=o1=), =neg= (=o16=), =sqrt= (=o39=) — and takes one of
+all five =r=-segment bound kinds, including *free* rows, where both ±1e19
+sentinels are live at once. One row in five gets $k_i = 0$ to keep the
+nothing-to-fold path live inside the same generator.
+
+1. *scipy HiGHS* (=linprog=) on the model as the script assembles it from the
+   generator's own numbers. The constants are moved into the bounds *in
+   Python*; nothing in that path reads the =.nl=, so agreement is evidence
+   about the reader.
+2. *Rows re-evaluated against the file's own bounds.* Each row is recomputed
+   here as $\sum a_{ij} x_j + k_i$ — constant included — and checked against
+   the bounds the file *declares*, not the ones the reader derived. This is
+   the invented/lost-bound check.
+3. *The hand-folded model.* The same instance is also written with the
+   constant folded into the bound by hand and an empty =C<i>=. That file
+   reaches the reader with nothing to fold, so it exercises none of the new
+   code. Primal *and* duals must agree with the offset form.
+4. *Stationarity of the reported duals.* $(c + A^\mathsf{T}\lambda)_j \approx 0$
+   at every strictly-interior column, using only the generator's $c$/$A$ and
+   the =.sol= dual block.
+
+Two targeted batteries:
+
+- *Sentinels*, at $|k| \in \{3, 10^{17}, 10^{18}\}$ on upper-only, lower-only,
+  and free rows. The large magnitudes are the point: at everyday scale an
+  unguarded =g_l -= c= is absorbed by the sentinel's own ULP (2048 at 1e19)
+  and the defect is invisible. At 1e18 a shifted =-1e19= lands at =-9e18=, a
+  real bound.
+- *Declines*: a =log(-1)= body (non-finite) and an imported-function body
+  (=myfunc(2)=), neither of which may be pushed into a bound.
+
+=pounce verify= is also run on every instance, and is reported as the weak
+oracle it is here: it re-reads the =.nl= through the same reader, so it shares
+the fold and cannot by itself catch a bound the fold moved wrongly. It does
+catch a non-stationary or out-of-box point, so it is kept.
+
+* Results
+:PROPERTIES:
+:STATUS: PASS
+:END:
+
+| Probe                                      | Instances | Skipped | Classified LP | Failures |
+|--------------------------------------------+-----------+---------+---------------+----------|
+| row-constant fold, seed 20260806           |       250 |       0 |           250 |        0 |
+| row-constant fold, seed 987654321          |       249 |       1 |           249 |        0 |
+| row-constant fold, seed 13579              |       250 |       0 |           250 |        0 |
+| row-constant fold, seed 31415926           |       250 |       0 |           250 |        0 |
+| sentinel battery (15 cases × 4 runs)       |        60 |       - | -             |        0 |
+| decline battery (2 cases × 4 runs)         |         8 |       - | -             |        0 |
+| gh#490 linear-eq-reduction sweep, ×2 seeds |       240 |       0 | -             |        0 |
+
+The single skip is gh#496, filed from this run and unrelated to this change —
+see below. The last row is a regression check, not a new probe: gh#490's =.nl=
+sweep already emits row constants into =C<i>= segments, so it exercises
+exactly the path this change rewrites. It is unchanged and green.
+
+* Cross-check / Verification
+
+All 999 randomized instances agreed with HiGHS on the objective to better than
+1e-6 relative, satisfied every row *as the file declares it* including the
+constant, matched the hand-folded model on both the primal and the full dual
+block to better than 1e-6, and passed the interior-column stationarity check.
+All 999 were accepted by =pounce verify=. All 999 classified as LP — the
+routing claim, measured rather than asserted.
+
+* Mutation testing of the probe itself
+
+A probe that never fails is worth nothing, so six defects were injected into
+the fold one at a time, each inside an isolated git worktree so the primary
+checkout was never dirtied, and each reverted after. Run at 60 instances per
+mutation, seed 20260806.
+
+| injected defect | probe verdict | caught by |
+|-----------------+---------------+-----------|
+| =row_constant_value= always returns =None= (no fold) | PASS | *not a correctness defect* — see below |
+| shift added instead of subtracted (=+= c=) | FAIL (53) | HiGHS, row re-eval, hand-folded model, sentinels |
+| only =g_l= shifted, =g_u= forgotten | FAIL (41) | HiGHS, row re-eval, hand-folded model, sentinels |
+| sentinel presence guard removed | FAIL (2) | *sentinel battery only* |
+| finiteness check removed (fold a NaN) | FAIL (1) | decline battery |
+| funcall guard removed | FAIL (1) | decline battery, *after* strengthening |
+
+Four of these are worth recording.
+
+*The no-fold mutation passing is the correct result.* Without the fold the
+model is still solved correctly — it just goes to the general NLP solver
+instead of the convex route. The fold is a normalization, not a correctness
+fix, and the probe says so: the only number that moved was the classified-LP
+counter, 60 → 33. That counter is therefore a live signal and not decoration.
+
+*The sentinel guard was caught by nothing except the battery built for it.*
+Nearly a thousand randomized instances at ordinary magnitudes are blind to it,
+exactly as the ULP argument predicts. Property-based coverage does not
+substitute for a battery aimed at a known cliff.
+
+*The funcall mutation initially escaped, and that was this exercise's most
+useful result.* The first draft of the decline battery asserted only that the
+run did not reach optimality. But a model calling an unresolved external
+function fails either way — with the guard it dies later at external-function
+resolution ("AMPLFUNC is not set"), without it the fold reaches =eval_expr=
+with a =Funcall=, which panics by construction. "It failed" was a vacuous
+check. The battery now asserts *which* failure occurred, and the mutation is
+caught.
+
+*The non-finite mutation is worth quoting for what it produces.* Folding
+=log(-1)= into the bounds makes both bounds NaN, every bound-presence test
+then reads the row as *free*, and pounce returns "Optimal Solution Found" at
+$x = (3, 3)$ for a model containing an unsatisfiable row. That is the failure
+the finiteness guard exists to prevent, and it is a silent wrong answer rather
+than an error.
+
+* Defects found in the probe itself
+
+The first sweep reported two failures. Neither was in pounce, and in both
+cases the offset and hand-folded spellings behaved *identically* — which is
+the fold working. Both were fixed and are recorded here because they are the
+kind of thing that otherwise gets quietly deleted:
+
+1. *Bounds were rounded to 9 places* after being derived from $x^*$. The
+   generator draws several singleton equality rows on one column often enough,
+   and independently-rounded right-hand sides then pin that column to values
+   ~3e-10 apart. The model was genuinely inconsistent — the probe should not
+   have written it. Bounds now come straight from the row value at $x^*$.
+2. *The stationarity check called a column interior at 1e-6 from its bound.*
+   An IPM settles a bound-active column a small distance off that bound, so
+   such a column read as interior and the check demanded that the row duals
+   alone cancel a gradient a bound multiplier was carrying — a false positive
+   on a solve that matched HiGHS to 6e-10. The margin is now 1e-4.
+
+* Defect found in pounce (unrelated to gh#492): gh#496
+
+After fix (1), one instance still failed, and it turned out to be a real bug
+with nothing to do with this change. Reduced by exhaustive subset search to
+two rows on one column:
+
+#+begin_example
+min  -x0
+s.t. -2.830268 x0 =  0.13596324445199998
+      2.470924 x0 = -0.11870071803600002
+     -10 <= x0 <= 10
+#+end_example
+
+The system is rank-deficient (rank 1, two rows) and consistent: the two rows
+imply values of $x_0$ differing by 6.94e-18, one ULP, with row residuals
+around 1e-17. =pounce-convex= declares *primal infeasible at iteration 0*;
+HiGHS solves it. Making the right-hand sides exactly consistent fixes it, and
+so does an exact duplicate row, so it is the *inexactness* of the redundancy
+that fires, not the redundancy.
+
+Reproduced identically on =origin/main= at =cad2b13=, and the reproducer has
+no =C=-segment content at all, so it predates gh#492 and is not reachable from
+it. Filed as gh#496. The probe now counts such instances as skips rather than
+failures — visibly, with a printed counter, so it cannot silently swallow a
+regression.
+
+* Verdict
+
+PASS. No defect found in the constant-row-body fold across 999 randomized LPs
+against an external oracle, 60 sentinel cases at magnitudes where an unguarded
+shift is visible, and 8 decline cases. The probe was itself mutation-tested;
+five of six injected defects are caught and the sixth is not a defect.
+
+One unrelated pre-existing bug was found and filed (gh#496). One pre-existing
+wart was observed and *not* filed, because it is neither a correctness bug nor
+related to this change: a =.nl= that calls an imported function without
+=AMPLFUNC= set aborts with a Rust panic and a backtrace (=nl_reader.rs:2480=)
+rather than a clean solver error.
+
+* Coverage effect
+
+Not measured — this run was topic-driven (new code under review), not
+coverage-driven, and no combined-coverage report exists in this environment.
+The qualitative effect is that =parse_nl_text='s fold, its sentinel guard, and
+both of its decline paths went from zero adversarial coverage to
+mutation-verified.

--- a/adversary/runs/2026-08-06_nlp_row_constant_fold.py
+++ b/adversary/runs/2026-08-06_nlp_row_constant_fold.py
@@ -429,19 +429,42 @@ def run_decline_cases(tmp):
     finally:
         shutil.rmtree(d, ignore_errors=True)
 
-    # An imported function with a constant argument. No library is loaded, so
-    # the run must fail loudly at resolution — never fold `myfunc(2)` away and
-    # solve a model the file does not describe.
+    # An imported function with a constant argument. `myfunc(2)` looks like a
+    # constant and is not one: it resolves to a shared library long after
+    # parse. No library is loaded here, so the run must fail either way — the
+    # question is *where*, and the two failures are distinguishable.
+    #
+    #   guard present: the call survives parse, and the run dies later at
+    #     external-function resolution ("AMPLFUNC is not set"). That panic is
+    #     pre-existing and unrelated to this fold.
+    #   guard removed: the fold reaches `eval_expr` with a `Funcall`, which
+    #     panics by construction rather than guessing a value.
+    #
+    # So "the run failed" is NOT the check — a check that only asserted
+    # failure passes with the guard deleted, which is how this probe's first
+    # draft let that mutation through. The check is that the failure did not
+    # come from inside the fold's evaluator.
     d = Path(tempfile.mkdtemp(prefix="adv_fn_", dir=tmp))
     try:
         (d / "m.nl").write_text(
             "\n".join(base + ["F0 1 1 myfunc", "C0", "f0 1", "n2.0"] + tail) + "\n"
         )
         p = solve(d, "m")
-        if "Optimal Solution Found" in p.stdout:
+        out = p.stdout + p.stderr
+        if "Optimal Solution Found" in out:
             problems.append(
                 "a model calling the unresolved imported function myfunc(2) "
                 "solved to optimality; the call was folded away"
+            )
+        elif "eval_expr" in out:
+            problems.append(
+                "the fold evaluated an imported-function body: it reached "
+                "eval_expr with a Funcall instead of declining"
+            )
+        elif "AMPLFUNC" not in out:
+            problems.append(
+                f"unexpected failure mode for the funcall body (rc={p.returncode}); "
+                f"expected external-function resolution to be what fails: {out[-300:]}"
             )
     finally:
         shutil.rmtree(d, ignore_errors=True)

--- a/adversary/runs/2026-08-06_nlp_row_constant_fold.py
+++ b/adversary/runs/2026-08-06_nlp_row_constant_fold.py
@@ -499,6 +499,7 @@ def main():
 
     bad = []
     checked = 0
+    skipped_baseline = 0
     lp_routed = 0
     verify_ok = 0
     try:
@@ -521,8 +522,18 @@ def main():
                 p_off = solve(d, "off")
                 p_fold = solve(d, "fold")
                 if "Optimal Solution Found" not in p_fold.stdout:
-                    bad.append((t, "hand-folded reference did not solve",
-                                p_fold.stdout[-300:]))
+                    # The hand-folded model exercises none of the fold's code,
+                    # so a failure here is a pre-existing solver issue and not
+                    # this probe's subject. Counted, never silently dropped:
+                    # if this number is not small, the probe is measuring the
+                    # solver's bad days rather than the reader.
+                    #
+                    # One such instance is understood: gh#496, a false
+                    # primal-infeasible certificate when two equality rows are
+                    # rank-deficient and their implied values differ by one
+                    # ULP. Reproduced on origin/main with no `C`-segment
+                    # content at all, so it predates this change.
+                    skipped_baseline += 1
                     continue
                 if "Optimal Solution Found" not in p_off.stdout:
                     bad.append((t, "row-constant model did not solve",
@@ -586,6 +597,7 @@ def main():
 
     print("=== randomized LPs with constant row bodies ===")
     print(f"instances solved and checked : {checked}")
+    print(f"  skipped, baseline unsolved : {skipped_baseline}  (gh#496, pre-existing)")
     print(f"  classified LP by pounce    : {lp_routed}")
     print(f"  accepted by pounce verify  : {verify_ok}")
     print(f"failures                     : {len(bad)}")

--- a/adversary/runs/2026-08-06_nlp_row_constant_fold.py
+++ b/adversary/runs/2026-08-06_nlp_row_constant_fold.py
@@ -1,0 +1,574 @@
+"""Adversary cross-check: the `.nl` reader's constant-row-body fold.
+
+Family: nlp   Class: `.nl` parse boundary / linear rows with constant offsets
+Target: `parse_nl_text`'s constant-row-body fold (gh#492),
+        `crates/pounce-nl/src/nl_reader.rs`
+Source: no published instance — a randomized family of LPs built around a
+        KNOWN feasible point, with scipy's HiGHS as the external oracle.
+
+The change under test rewrites the model at the parse boundary: when a row's
+`C<i>` expression segment evaluates to a constant `c`, the reader subtracts
+`c` from that row's bounds and replaces the body with zero. Every row in this
+family carries such a constant, in five different spellings.
+
+Four things can go wrong, and each has its own oracle here. None of them is
+"pounce with the fold disabled" — that binary no longer exists.
+
+1. **The shift lands on the wrong bound, or with the wrong sign.** Oracle:
+   `scipy.optimize.linprog` (HiGHS) on the model as *this script* understands
+   it, assembled from the generator's own data and never from the `.nl`.
+2. **A bound is invented or lost.** Specifically the ±1e19 "absent" sentinels,
+   which are directional (gh#401): shifting one turns "no bound" into a real
+   one. Oracle: every row is re-evaluated here against its ORIGINAL declared
+   bounds — `lo <= Σaⱼxⱼ + c <= hi`, constant included — plus a targeted
+   sentinel battery at magnitudes where the shift is not absorbed by the
+   sentinel's own ULP (2048 at 1e19).
+3. **The duals move.** The fold's whole claim is that the body drops by `c`
+   and the bound drops with it, so the residual — and therefore every
+   multiplier — is untouched. Oracle: the same model written with the constant
+   folded into the bound *by hand*, which reaches the reader with nothing to
+   fold and so exercises none of the new code. Plus an independent
+   stationarity check on the reported duals.
+4. **The fold fires when it must not.** A non-finite constant, or one inside
+   an imported-function call, must be left in the expression rather than
+   pushed into a bound. Oracle: direct assertions on the resulting behavior.
+
+Both `.nl` spellings of each instance are also passed through `pounce verify`.
+That is a weaker oracle than usual here and is reported as such: `verify`
+re-reads the `.nl` through the same reader, so it shares the fold and cannot
+by itself catch a bound the fold moved wrongly. It is kept because it does
+catch a point that is non-stationary or out of its box.
+
+Usage: python 2026-08-06_nlp_row_constant_fold.py [trials] [seed]
+"""
+
+import math
+import os
+import random
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from scipy.optimize import linprog
+
+POUNCE = Path(
+    os.environ.get("POUNCE_BIN", "/home/user/pounce/target/release/pounce")
+)
+
+# `r`-segment bound kinds we generate. 3 (free) is included because a free row
+# is the one shape where BOTH sentinels are live at once.
+EQ, UPPER, LOWER, RANGE, FREE = 4, 1, 2, 0, 3
+
+
+# ---------------------------------------------------------------------
+# .nl writing
+# ---------------------------------------------------------------------
+
+
+def const_tokens(c, spelling):
+    """`C<i>` token stream for the constant `c`, written five ways.
+
+    The fold is by *evaluation*, not syntax, so every spelling must land on
+    the same model. `literal` is what a writer usually emits; the rest are
+    what the classifier's polynomial walk cannot lower, and so are the forms
+    that used to force an LP onto the NLP route.
+    """
+    if spelling == "literal":
+        return [f"n{c!r}"]
+    if spelling == "add":  # (c - 0.25) + 0.25
+        return ["o0", f"n{c - 0.25!r}", "n0.25"]
+    if spelling == "sub":  # (c + 1.5) - 1.5
+        return ["o1", f"n{c + 1.5!r}", "n1.5"]
+    if spelling == "neg":  # -(-c)
+        return ["o16", f"n{-c!r}"]
+    if spelling == "sqrt":  # sqrt(c^2), sign restored by o16 when c < 0
+        body = ["o39", f"n{c * c!r}"]
+        return body if c >= 0 else ["o16"] + body
+    raise ValueError(spelling)
+
+
+def write_nl(path, n, obj_c, rows, kinds, los, his, consts, x_l, x_u, x0, spellings):
+    """`min cᵀx  s.t.  lo_i <= Σ a_ij x_j + k_i <= hi_i,  x_l <= x <= x_u`.
+
+    Every row's constant `k_i` goes in that row's expression segment. Pass
+    `spellings=None` to fold the constants into the bounds here instead and
+    emit an empty `C<i>` — the hand-folded reference model.
+    """
+    m = len(rows)
+    jnnz = sum(len(r) for r in rows)
+    folded = spellings is None
+    L = [
+        "g3 1 1 0\t# adversary row-constant fold",
+        f" {n} {m} 1 0 0 \t# vars, constraints, objectives, ranges, eqns",
+        f" {0 if folded else m} 0 0 0 0 0\t# nonlinear constrs, objs",
+        " 0 0\t# network",
+        f" {0 if folded else n} 0 0 \t# nonlinear vars in constraints, objectives, both",
+        " 0 0 0 1\t# linear network vars; functions; arith, flags",
+        " 0 0 0 0 0 \t# discrete",
+        f" {jnnz} {n} \t# nonzeros in Jacobian, obj gradient",
+        " 0 0\t# max name lengths",
+        " 0 0 0 0 0\t# common exprs",
+    ]
+    for i in range(m):
+        L.append(f"C{i}")
+        L += ["n0"] if folded else const_tokens(consts[i], spellings[i])
+    L += ["O0 0", "n0"]
+    L.append(f"x{n}")
+    for j in range(n):
+        L.append(f"{j} {x0[j]!r}")
+    L.append("r")
+    for i in range(m):
+        # The hand-folded model states the SAME row with the constant moved
+        # onto whichever sides are actually bounded — the transformation the
+        # reader is supposed to be performing.
+        shift = consts[i] if folded else 0.0
+        if kinds[i] == EQ:
+            L.append(f"4 {los[i] - shift!r}")
+        elif kinds[i] == UPPER:
+            L.append(f"1 {his[i] - shift!r}")
+        elif kinds[i] == LOWER:
+            L.append(f"2 {los[i] - shift!r}")
+        elif kinds[i] == FREE:
+            L.append("3")
+        else:
+            L.append(f"0 {los[i] - shift!r} {his[i] - shift!r}")
+    L.append("b")
+    for j in range(n):
+        L.append(f"0 {x_l[j]!r} {x_u[j]!r}")
+    colcount = [0] * n
+    for r in rows:
+        for j, _ in r:
+            colcount[j] += 1
+    L.append(f"k{n - 1}")
+    cum = 0
+    for j in range(n - 1):
+        cum += colcount[j]
+        L.append(str(cum))
+    for i, r in enumerate(rows):
+        L.append(f"J{i} {len(r)}")
+        for j, a in sorted(r):
+            L.append(f"{j} {a!r}")
+    L.append(f"G0 {n}")
+    for j in range(n):
+        L.append(f"{j} {obj_c[j]!r}")
+    path.write_text("\n".join(L) + "\n")
+
+
+# ---------------------------------------------------------------------
+# instance generation
+# ---------------------------------------------------------------------
+
+
+def gen(rng):
+    n = rng.randint(4, 8)
+    m = rng.randint(1, max(1, n - 1))
+    x_star = [round(rng.uniform(-3, 3), 6) for _ in range(n)]
+    x_l = [round(x_star[j] - rng.uniform(1.0, 5.0), 6) for j in range(n)]
+    x_u = [round(x_star[j] + rng.uniform(1.0, 5.0), 6) for j in range(n)]
+    obj_c = [round(rng.uniform(-2, 2), 6) for _ in range(n)]
+
+    rows, kinds, los, his, consts, spellings = [], [], [], [], [], []
+    for _ in range(m):
+        cols = rng.sample(range(n), rng.randint(1, min(3, n)))
+        row = [(c, round(rng.uniform(0.3, 3.0), 6) * rng.choice([1, -1])) for c in cols]
+        # A zero constant on one row in five keeps the "nothing to fold" path
+        # live inside the same generator.
+        k = 0.0 if rng.random() < 0.2 else round(rng.uniform(-4, 4), 6)
+        lin = sum(a * x_star[c] for c, a in row)
+        body = lin + k  # the row's value at the known feasible point
+        kind = rng.choice([EQ, UPPER, LOWER, RANGE, FREE])
+        lo, hi = -math.inf, math.inf
+        if kind == EQ:
+            lo = hi = round(body, 9)
+        elif kind == UPPER:
+            hi = round(body + rng.uniform(0.0, 2.0), 9)
+        elif kind == LOWER:
+            lo = round(body - rng.uniform(0.0, 2.0), 9)
+        elif kind == RANGE:
+            lo = round(body - rng.uniform(0.1, 2.0), 9)
+            hi = round(body + rng.uniform(0.1, 2.0), 9)
+        rows.append(row)
+        kinds.append(kind)
+        los.append(lo)
+        his.append(hi)
+        consts.append(k)
+        spellings.append(rng.choice(["literal", "add", "sub", "neg", "sqrt"]))
+    return dict(
+        n=n, m=m, obj_c=obj_c, rows=rows, kinds=kinds, los=los, his=his,
+        consts=consts, x_l=x_l, x_u=x_u, x0=list(x_star), spellings=spellings,
+    )
+
+
+# ---------------------------------------------------------------------
+# oracles
+# ---------------------------------------------------------------------
+
+
+def scipy_solve(inst):
+    """The external oracle: HiGHS on the model as assembled here.
+
+    The row constants are moved into the bounds *in this function*, from the
+    generator's own numbers. Nothing here reads the `.nl`, so agreement is
+    evidence about the reader and not about this script.
+    """
+    n, m = inst["n"], inst["m"]
+    a_ub, b_ub, a_eq, b_eq = [], [], [], []
+    for i, r in enumerate(inst["rows"]):
+        row = np.zeros(n)
+        for j, a in r:
+            row[j] += a
+        lo = inst["los"][i] - inst["consts"][i]
+        hi = inst["his"][i] - inst["consts"][i]
+        if math.isfinite(lo) and math.isfinite(hi) and lo == hi:
+            a_eq.append(row)
+            b_eq.append(lo)
+            continue
+        if math.isfinite(hi):
+            a_ub.append(row)
+            b_ub.append(hi)
+        if math.isfinite(lo):
+            a_ub.append(-row)
+            b_ub.append(-lo)
+    return linprog(
+        c=np.array(inst["obj_c"]),
+        A_ub=np.array(a_ub) if a_ub else None,
+        b_ub=np.array(b_ub) if b_ub else None,
+        A_eq=np.array(a_eq) if a_eq else None,
+        b_eq=np.array(b_eq) if b_eq else None,
+        bounds=list(zip(inst["x_l"], inst["x_u"])),
+        method="highs",
+    )
+
+
+def rows_hold(inst, x, tol=1e-6):
+    """Re-evaluate every row *with its constant* against its ORIGINAL bounds.
+
+    This is the invented/lost-bound check. A fold that shifted the wrong side,
+    or that touched an absent-bound sentinel, produces a point that satisfies
+    the reader's idea of the row but not the row the file declares.
+    """
+    for i, r in enumerate(inst["rows"]):
+        body = sum(a * x[c] for c, a in r) + inst["consts"][i]
+        scale = max(1.0, abs(body))
+        if math.isfinite(inst["los"][i]) and body < inst["los"][i] - tol * scale:
+            return f"row {i} below its declared lower bound: {body} < {inst['los'][i]}"
+        if math.isfinite(inst["his"][i]) and body > inst["his"][i] + tol * scale:
+            return f"row {i} above its declared upper bound: {body} > {inst['his'][i]}"
+    for j in range(inst["n"]):
+        if not (inst["x_l"][j] - tol <= x[j] <= inst["x_u"][j] + tol):
+            return f"x[{j}]={x[j]} outside [{inst['x_l'][j]}, {inst['x_u'][j]}]"
+    return None
+
+
+def stationarity(inst, x, lam, tol=1e-5):
+    """`(c + Aᵀλ)_j ≈ 0` for every variable strictly inside its box.
+
+    An interior column has no bound multiplier, so the row duals alone must
+    cancel its objective gradient. Independent of the oracle LP and of the
+    hand-folded model: it uses only the generator's `c`/`A` and the duals the
+    `.sol` reports. The sign convention is fixed by trying both and demanding
+    that one of them hold — AMPL's is `∇f + Jᵀλ`, but the point of the check
+    is that the fold does not perturb it, not which sign it is.
+    """
+    n = inst["n"]
+    interior = [
+        j for j in range(n)
+        if inst["x_l"][j] + 1e-6 < x[j] < inst["x_u"][j] - 1e-6
+    ]
+    if not interior:
+        return None
+    for sign in (1.0, -1.0):
+        worst = 0.0
+        for j in interior:
+            g = inst["obj_c"][j]
+            for i, r in enumerate(inst["rows"]):
+                for cidx, a in r:
+                    if cidx == j:
+                        g += sign * lam[i] * a
+            worst = max(worst, abs(g))
+        if worst <= tol:
+            return None
+    return f"stationarity fails at every sign for interior columns {interior}"
+
+
+# ---------------------------------------------------------------------
+# CLI plumbing
+# ---------------------------------------------------------------------
+
+
+def solve(d, name, opts=()):
+    p = subprocess.run(
+        [str(POUNCE), name, "-AMPL", *opts],
+        cwd=d, capture_output=True, text=True, timeout=60,
+    )
+    return p
+
+
+def read_sol(path, n, m):
+    nums = []
+    for line in path.read_text().splitlines():
+        if line.startswith("objno"):
+            break
+        try:
+            nums.append(float(line.strip()))
+        except ValueError:
+            pass
+    tail = nums[-(n + m):] if (n + m) else []
+    return tail[:m], tail[m:]
+
+
+# ---------------------------------------------------------------------
+# targeted batteries
+# ---------------------------------------------------------------------
+
+
+def sentinel_battery():
+    """Constants large enough that shifting a sentinel would be visible.
+
+    At everyday magnitudes an unguarded `g_l -= c` is absorbed by the
+    sentinel's ULP and nothing happens. These sit at 1e17–1e18, where a
+    shifted `-1e19` lands at `-9e18` — a real bound, and one that would cut
+    off the true optimum of a row that is supposed to be one-sided.
+
+    Model: `min -x0 - x1` s.t. `x0 + x1 + k <= k + 2` (upper only) or
+    `-x0 - x1 + k >= k - 2` (lower only), `x ∈ [0,5]²`. Optimum is 2 either
+    way; a lower bound invented on the first row would change nothing, so the
+    row is also checked against the reader directly via the free-row case,
+    where BOTH sentinels are live and any shift is a fabricated constraint.
+    """
+    cases = []
+    for k in (1e17, -1e17, 1e18, -1e18, 3.0):
+        # one-sided upper: the lower sentinel must stay absent
+        cases.append(("upper", k))
+        # one-sided lower: the upper sentinel must stay absent
+        cases.append(("lower", k))
+        # free row: both sentinels live
+        cases.append(("free", k))
+    return cases
+
+
+def run_sentinel_case(kind, k, tmp):
+    n, m = 2, 1
+    rows = [[(0, 1.0), (1, 1.0)]]
+    if kind == "upper":
+        kinds, los, his = [UPPER], [-math.inf], [k + 2.0]
+    elif kind == "lower":
+        kinds, los, his = [LOWER], [k - 2.0], [math.inf]
+    else:
+        kinds, los, his = [FREE], [-math.inf], [math.inf]
+    inst = dict(
+        n=n, m=m, obj_c=[-1.0, -1.0], rows=rows, kinds=kinds, los=los, his=his,
+        consts=[k], x_l=[0.0, 0.0], x_u=[5.0, 5.0], x0=[0.0, 0.0],
+        spellings=["literal"],
+    )
+    d = Path(tempfile.mkdtemp(prefix="adv_sent_", dir=tmp))
+    try:
+        write_nl(d / "m.nl", n, inst["obj_c"], rows, kinds, los, his, inst["consts"],
+                 inst["x_l"], inst["x_u"], inst["x0"], inst["spellings"])
+        p = solve(d, "m")
+        if "Optimal Solution Found" not in p.stdout:
+            return f"{kind}/k={k}: not solved\n{p.stdout[-300:]}"
+        _, x = read_sol(d / "m.sol", n, m)
+        ref = scipy_solve(inst)
+        if not ref.success:
+            return f"{kind}/k={k}: oracle failed ({ref.message})"
+        got = sum(c * xi for c, xi in zip(inst["obj_c"], x))
+        if abs(got - ref.fun) > 1e-6 * max(1.0, abs(ref.fun)):
+            return (f"{kind}/k={k}: objective {got:.10e} vs HiGHS {ref.fun:.10e} "
+                    f"-- a shifted sentinel would do exactly this")
+        return rows_hold(inst, x)
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def run_decline_cases(tmp):
+    """Bodies the fold must refuse: non-finite, and an imported-function call.
+
+    Neither may be silently pushed into a bound. A NaN in `g_l`/`g_u` makes
+    every presence test downstream unanswerable, and an external function is
+    not a parse-time constant at all — it resolves to a shared library much
+    later.
+    """
+    problems = []
+    base = [
+        "g3 1 1 0\t# adversary decline case",
+        " 2 1 1 0 0 ",
+        " 1 0 0 0 0 0",
+        " 0 0",
+        " 1 0 0 ",
+        " 0 0 0 1",
+        " 0 0 0 0 0 ",
+        " 2 2 ",
+        " 0 0",
+        " 0 0 0 0 0",
+    ]
+    tail = [
+        "O0 0", "n0",
+        "r", "1 6.0",
+        "b", "0 0 3", "0 0 3",
+        "k1", "1",
+        "J0 2", "0 1", "1 1",
+        "G0 2", "0 -1", "1 -2",
+    ]
+
+    # log(-1) = NaN. The row is unsatisfiable; the one unacceptable outcome is
+    # a confident "Optimal Solution Found" on a model whose bounds have been
+    # replaced by NaN.
+    d = Path(tempfile.mkdtemp(prefix="adv_nan_", dir=tmp))
+    try:
+        (d / "m.nl").write_text("\n".join(base + ["C0", "o43", "n-1"] + tail) + "\n")
+        p = solve(d, "m")
+        if "Optimal Solution Found" in p.stdout:
+            _, x = read_sol(d / "m.sol", 2, 1)
+            problems.append(
+                f"a log(-1) row body solved to optimality at x={x}; the row is NaN"
+            )
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+    # An imported function with a constant argument. No library is loaded, so
+    # the run must fail loudly at resolution — never fold `myfunc(2)` away and
+    # solve a model the file does not describe.
+    d = Path(tempfile.mkdtemp(prefix="adv_fn_", dir=tmp))
+    try:
+        (d / "m.nl").write_text(
+            "\n".join(base + ["F0 1 1 myfunc", "C0", "f0 1", "n2.0"] + tail) + "\n"
+        )
+        p = solve(d, "m")
+        if "Optimal Solution Found" in p.stdout:
+            problems.append(
+                "a model calling the unresolved imported function myfunc(2) "
+                "solved to optimality; the call was folded away"
+            )
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+    return problems
+
+
+# ---------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------
+
+
+def main():
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 200
+    seed = int(sys.argv[2]) if len(sys.argv) > 2 else 20260806
+    rng = random.Random(seed)
+    tmp = tempfile.mkdtemp(prefix="adv_rcf_root_")
+
+    bad = []
+    checked = 0
+    lp_routed = 0
+    verify_ok = 0
+    try:
+        for t in range(trials):
+            inst = gen(rng)
+            n, m = inst["n"], inst["m"]
+            ref = scipy_solve(inst)
+            if not ref.success:
+                continue  # unbounded / degenerate oracle: not this probe's business
+
+            d = Path(tempfile.mkdtemp(prefix="adv_rcf_", dir=tmp))
+            try:
+                write_nl(d / "off.nl", n, inst["obj_c"], inst["rows"], inst["kinds"],
+                         inst["los"], inst["his"], inst["consts"], inst["x_l"],
+                         inst["x_u"], inst["x0"], inst["spellings"])
+                write_nl(d / "fold.nl", n, inst["obj_c"], inst["rows"], inst["kinds"],
+                         inst["los"], inst["his"], inst["consts"], inst["x_l"],
+                         inst["x_u"], inst["x0"], None)
+
+                p_off = solve(d, "off")
+                p_fold = solve(d, "fold")
+                if "Optimal Solution Found" not in p_fold.stdout:
+                    bad.append((t, "hand-folded reference did not solve",
+                                p_fold.stdout[-300:]))
+                    continue
+                if "Optimal Solution Found" not in p_off.stdout:
+                    bad.append((t, "row-constant model did not solve",
+                                p_off.stdout[-300:]))
+                    continue
+                checked += 1
+                if "Problem class: LP" in p_off.stdout:
+                    lp_routed += 1
+
+                lam_off, x_off = read_sol(d / "off.sol", n, m)
+                lam_fold, x_fold = read_sol(d / "fold.sol", n, m)
+
+                # --- oracle 1: HiGHS, from this script's own assembly ---
+                obj_off = sum(c * xi for c, xi in zip(inst["obj_c"], x_off))
+                if abs(obj_off - ref.fun) > 1e-6 * max(1.0, abs(ref.fun)):
+                    bad.append((t, f"objective {obj_off:.10e} vs HiGHS {ref.fun:.10e}", ""))
+                    continue
+
+                # --- oracle 2: the rows as the FILE declares them ---
+                why = rows_hold(inst, x_off)
+                if why:
+                    bad.append((t, f"reported point violates the original model: {why}", ""))
+                    continue
+
+                # --- oracle 3: the hand-folded model, primal AND dual ---
+                dx = max(abs(a - b) for a, b in zip(x_off, x_fold)) if n else 0.0
+                if dx > 1e-6:
+                    bad.append((t, f"primal differs from the hand-folded model by {dx:.3e}", ""))
+                    continue
+                dl = max((abs(a - b) for a, b in zip(lam_off, lam_fold)), default=0.0)
+                if dl > 1e-6:
+                    bad.append((t, f"duals differ from the hand-folded model by {dl:.3e}", ""))
+                    continue
+
+                # --- oracle 4: stationarity of the reported duals ---
+                why = stationarity(inst, x_off, lam_off)
+                if why:
+                    bad.append((t, why, ""))
+                    continue
+
+                # --- weak check: pounce verify (shares the reader; see docstring) ---
+                v = subprocess.run([str(POUNCE), "verify", "off.nl", "off.sol"],
+                                   cwd=d, capture_output=True, text=True, timeout=60)
+                if v.returncode == 0:
+                    verify_ok += 1
+                else:
+                    bad.append((t, f"pounce verify rejected the solve (rc={v.returncode})",
+                                v.stdout[-400:]))
+            finally:
+                shutil.rmtree(d, ignore_errors=True)
+
+        # --- targeted batteries ---
+        sentinel_fail = []
+        for kind, k in sentinel_battery():
+            why = run_sentinel_case(kind, k, tmp)
+            if why:
+                sentinel_fail.append(why)
+        decline_fail = run_decline_cases(tmp)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print("=== randomized LPs with constant row bodies ===")
+    print(f"instances solved and checked : {checked}")
+    print(f"  classified LP by pounce    : {lp_routed}")
+    print(f"  accepted by pounce verify  : {verify_ok}")
+    print(f"failures                     : {len(bad)}")
+    for t, why, extra in bad[:8]:
+        print(f"  [{t}] {why}")
+        if extra:
+            print("      " + extra.replace("\n", "\n      ")[:400])
+    print("=== sentinel battery (|c| up to 1e18, one-sided and free rows) ===")
+    print(f"cases                        : {len(sentinel_battery())}")
+    print(f"failures                     : {len(sentinel_fail)}")
+    for why in sentinel_fail[:8]:
+        print(f"  {why}")
+    print("=== decline battery (non-finite body, imported-function body) ===")
+    print(f"failures                     : {len(decline_fail)}")
+    for why in decline_fail:
+        print(f"  {why}")
+
+    total = len(bad) + len(sentinel_fail) + len(decline_fail)
+    print("VERDICT: PASS" if total == 0 else f"VERDICT: FAIL ({total} failures)")
+    return 0 if total == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/adversary/runs/2026-08-06_nlp_row_constant_fold.py
+++ b/adversary/runs/2026-08-06_nlp_row_constant_fold.py
@@ -181,15 +181,23 @@ def gen(rng):
         body = lin + k  # the row's value at the known feasible point
         kind = rng.choice([EQ, UPPER, LOWER, RANGE, FREE])
         lo, hi = -math.inf, math.inf
+        # Bounds are NOT rounded. Rounding them to 9 places was this probe's
+        # own bug: the generator happily draws several singleton equality rows
+        # on one column, and independently-rounded right-hand sides then pin
+        # that column to values ~3e-10 apart. The system is genuinely
+        # inconsistent at that point — HiGHS absorbs it inside its feasibility
+        # tolerance, pounce-convex calls it primal infeasible, and neither is
+        # wrong about a model the probe should not have written. Deriving the
+        # bounds straight from `body` keeps every row exactly satisfied at x*.
         if kind == EQ:
-            lo = hi = round(body, 9)
+            lo = hi = body
         elif kind == UPPER:
-            hi = round(body + rng.uniform(0.0, 2.0), 9)
+            hi = body + rng.uniform(0.0, 2.0)
         elif kind == LOWER:
-            lo = round(body - rng.uniform(0.0, 2.0), 9)
+            lo = body - rng.uniform(0.0, 2.0)
         elif kind == RANGE:
-            lo = round(body - rng.uniform(0.1, 2.0), 9)
-            hi = round(body + rng.uniform(0.1, 2.0), 9)
+            lo = body - rng.uniform(0.1, 2.0)
+            hi = body + rng.uniform(0.1, 2.0)
         rows.append(row)
         kinds.append(kind)
         los.append(lo)
@@ -272,11 +280,18 @@ def stationarity(inst, x, lam, tol=1e-5):
     `.sol` reports. The sign convention is fixed by trying both and demanding
     that one of them hold — AMPL's is `∇f + Jᵀλ`, but the point of the check
     is that the fold does not perturb it, not which sign it is.
+
+    The interior margin is 1e-4, not the 1e-6 this probe first used. An IPM
+    settles a *bound-active* column a small distance off that bound, and at
+    1e-6 such a column read as interior — so the check demanded that the row
+    duals alone cancel a gradient that a bound multiplier was in fact
+    carrying, and reported a false positive on a solve that matched HiGHS to
+    6e-10. Only columns clearly off both bounds are testable this way.
     """
     n = inst["n"]
     interior = [
         j for j in range(n)
-        if inst["x_l"][j] + 1e-6 < x[j] < inst["x_u"][j] - 1e-6
+        if inst["x_l"][j] + 1e-4 < x[j] < inst["x_u"][j] - 1e-4
     ]
     if not interior:
         return None

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -1543,4 +1543,74 @@ mod tests {
     fn _parse(txt: &str) -> NlProblem {
         parse_nl_text(txt).expect("valid .nl")
     }
+
+    /// **gh #492.** `min −x0 − 2·x1  s.t.  x0 + x1 + 3 <= 6, x ∈ [0,3]²`,
+    /// with the `3` written into the row's expression segment. `body` is
+    /// the `C0` token stream for that constant.
+    fn lp_with_row_constant(body: &str) -> NlProblem {
+        let nl = format!(
+            "g3 1 1 0
+ 2 1 1 0 0
+ 1 0 0 0 0 0
+ 0 0
+ 1 0 0
+ 0 0 0 1
+ 0 0 0 0 0
+ 2 2
+ 0 0
+ 0 0 0 0 0
+C0
+{body}
+O0 0
+n0
+r
+1 6.0
+b
+0 0 3
+0 0 3
+k1
+1
+J0 2
+0 1
+1 1
+G0 2
+0 -1
+1 -2
+"
+        );
+        parse_nl_text(&nl).expect("valid .nl")
+    }
+
+    /// The classifier's fast path asks `is_trivially_zero` of every
+    /// `con_nonlinear` entry, which is an *identity* test — it cannot tell
+    /// "this row has a nonlinear part" from "this row's part is the
+    /// constant 3". A bare literal survived that anyway, because the
+    /// fallback polynomial walk lowers `Const` and finds no quadratic
+    /// term; what it does not do is keep the constant, so the row's `+3`
+    /// lived on only as `qp_extract`'s `const_shift`. After the parse-time
+    /// fold the bound carries it and the fast path is exact.
+    #[test]
+    fn a_literal_row_constant_classifies_lp_and_moves_the_bound() {
+        let prob = lp_with_row_constant("n3");
+        assert_eq!(classify_problem(&prob), ProblemClass::Lp);
+        // `x0 + x1 + 3 <= 6` is `x0 + x1 <= 3`.
+        assert!((prob.g_u[0] - 3.0).abs() < 1e-12, "g_u = {}", prob.g_u[0]);
+        assert!(
+            matches!(prob.con_nonlinear[0], Expr::Const(c) if c == 0.0),
+            "the row body should be the identity zero: {:?}",
+            prob.con_nonlinear[0]
+        );
+    }
+
+    /// The case the polynomial walk cannot rescue: a constant it has to
+    /// *compute*. `sqrt(9)` is not a degree-≤2 polynomial in any variable,
+    /// so `analyze_quadratic` returns `None` and the row made the whole
+    /// model NLP — an LP that never reached the convex route. The fold
+    /// settles it at parse, where the value is known.
+    #[test]
+    fn a_computed_row_constant_does_not_make_an_lp_classify_nlp() {
+        let prob = lp_with_row_constant("o39\nn9");
+        assert_eq!(classify_problem(&prob), ProblemClass::Lp);
+        assert!((prob.g_u[0] - 3.0).abs() < 1e-12, "g_u = {}", prob.g_u[0]);
+    }
 }

--- a/crates/pounce-cli/tests/fixtures/linear_eq_aggregation_row_constant.nl
+++ b/crates/pounce-cli/tests/fixtures/linear_eq_aggregation_row_constant.nl
@@ -1,0 +1,55 @@
+g3 1 1 0	# problem linear_eq_aggregation_row_constant
+ 3 2 1 0 2 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 2 2 1 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 4 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n3
+C1
+o0
+o5
+v1
+n2
+o5
+v0
+n2
+O0 0
+o0
+o5
+o0
+v2
+n-1
+n2
+o5
+o0
+v0
+n-3
+n2
+x3
+0 1.0
+1 0.5
+2 1.0
+r
+4 3.0
+4 2.0
+b
+0 0 10
+0 -10 10
+0 -10 10
+k2
+1
+3
+J0 2
+1 -2
+2 1
+J1 2
+0 0
+1 0
+G0 2
+0 0
+2 0

--- a/crates/pounce-cli/tests/fixtures/lp_row_constant.nl
+++ b/crates/pounce-cli/tests/fixtures/lp_row_constant.nl
@@ -1,0 +1,27 @@
+g3 1 1 0	# problem lp_row_constant
+ 2 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 1 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 1 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 2 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n3
+O0 0
+n0
+r
+1 6.0
+b
+0 0 3
+0 0 3
+k1
+1
+J0 2
+0 1
+1 1
+G0 2
+0 -1
+1 -2

--- a/crates/pounce-cli/tests/fixtures/lp_row_constant_expr.nl
+++ b/crates/pounce-cli/tests/fixtures/lp_row_constant_expr.nl
@@ -1,0 +1,28 @@
+g3 1 1 0	# problem lp_row_constant_expr
+ 2 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 1 0 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 1 0 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 2 2 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o39
+n9
+O0 0
+n0
+r
+1 6.0
+b
+0 0 3
+0 0 3
+k1
+1
+J0 2
+0 1
+1 1
+G0 2
+0 -1
+1 -2

--- a/crates/pounce-cli/tests/issue_492_row_constant_fold.rs
+++ b/crates/pounce-cli/tests/issue_492_row_constant_fold.rs
@@ -1,0 +1,231 @@
+//! A constant parked in a row's `C<i>` expression segment must not change
+//! what the model *is* (issue #492).
+//!
+//! The `.nl` format lets a writer leave a constant on the left-hand side:
+//! `x0 + x1 + 3 <= 6` rather than `x0 + x1 <= 3`. That constant arrives as
+//! the row's *nonlinear-part* expression, and POUNCE read every non-empty
+//! expression segment as "this row is nonlinear". The reader now folds a
+//! constant row body into the row bounds at parse instead. Every fixture
+//! here carries a constant the equivalent committed fixture writes into
+//! the bound by hand, and must behave exactly as if it had been.
+//!
+//! Two consequences are pinned, and they bite on different shapes:
+//!
+//! * **Presolve.** The linear-equality reduction (Phase 6, #490) only
+//!   consumes rows tagged linear, so it declined *any* row with a constant
+//!   body — including a bare literal. That is
+//!   `linear_eq_aggregation_row_constant.nl` below.
+//! * **Routing.** The problem classifier lowers each row body to a
+//!   degree-≤2 polynomial, which already tolerates a bare literal (it
+//!   drops the constant and `qp_extract` re-derives it as a `const_shift`).
+//!   What it cannot lower is a constant it has to *compute* — `sqrt(9)`,
+//!   an `exp`, a `min` — so a model that is otherwise a plain LP
+//!   classified NLP and never reached `pounce-convex`. That is
+//!   `lp_row_constant_expr.nl` below.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+struct Run {
+    code: Option<i32>,
+    stdout: String,
+    stderr: String,
+    /// The `.sol` value block, in `.nl` order: duals first, then primals.
+    /// Empty when the run produced no `.sol`.
+    values: Vec<f64>,
+}
+
+/// Copy `fixture` into a scratch directory and solve it, AMPL-style.
+/// `n_values` is the number of trailing numeric entries to keep — the
+/// model's rows plus its columns.
+fn run(tag: &str, fixture: &str, n_values: usize, opts: &[&str]) -> Run {
+    let dir = std::env::temp_dir().join(format!("pounce_issue_492_{tag}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let mut src = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    src.push("tests/fixtures");
+    src.push(fixture);
+    std::fs::copy(&src, dir.join("m.nl")).expect("copy fixture");
+
+    let mut cmd = Command::new(pounce_exe());
+    cmd.current_dir(&dir).arg("m").arg("-AMPL");
+    for o in opts {
+        cmd.arg(o);
+    }
+    let out = cmd.output().expect("run pounce");
+    let values = match std::fs::read_to_string(dir.join("m.sol")) {
+        Ok(sol) => {
+            let numeric: Vec<f64> = sol
+                .lines()
+                .take_while(|l| !l.starts_with("objno"))
+                .filter_map(|l| l.trim().parse::<f64>().ok())
+                .collect();
+            assert!(
+                numeric.len() >= n_values,
+                "expected at least {n_values} entries in the .sol body, got {numeric:?}"
+            );
+            numeric[numeric.len() - n_values..].to_vec()
+        }
+        Err(_) => Vec::new(),
+    };
+    Run {
+        code: out.status.code(),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+        values,
+    }
+}
+
+// ---------------------------------------------------------------------
+// Routing: an LP with a computed row constant is an LP.
+//
+// Both LP fixtures are `min −x0 − 2·x1` subject to `x0 + x1 + 3 <= 6` over
+// `x0, x1 ∈ [0, 3]`, so the folded row is `x0 + x1 <= 3` and the optimum
+// is `x1 = 3`, `x0 = 0`, `obj = −6`. They differ only in how the `3` is
+// written: `lp_row_constant.nl` uses the literal `n3`,
+// `lp_row_constant_expr.nl` uses `sqrt(9)`.
+// ---------------------------------------------------------------------
+
+/// A constant the classifier's polynomial walk cannot lower used to make
+/// the whole model NLP. The fold replaces it with the identity zero before
+/// the classifier ever sees it.
+#[test]
+fn a_computed_row_constant_no_longer_forces_an_lp_onto_the_nlp_route() {
+    let r = run("auto_expr", "lp_row_constant_expr.nl", 3, &[]);
+    assert_eq!(r.code, Some(0), "stderr:\n{}", r.stderr);
+    assert!(
+        r.stdout.contains("Problem class: LP"),
+        "expected the classifier to say LP:\n{}",
+        r.stdout
+    );
+    assert!(
+        r.stdout.contains("pounce-convex"),
+        "an LP must reach the convex route:\n{}",
+        r.stdout
+    );
+}
+
+/// The same thing said as an error the user would actually hit: a forced
+/// solver that does not match the detected class is a hard exit-2 failure
+/// naming both, so before the fold this run failed with "NLP … lp-ipm"
+/// instead of solving.
+#[test]
+fn the_forced_lp_solver_accepts_a_model_with_a_computed_row_constant() {
+    let r = run(
+        "forced_expr",
+        "lp_row_constant_expr.nl",
+        3,
+        &["solver_selection=lp-ipm"],
+    );
+    assert_eq!(
+        r.code,
+        Some(0),
+        "forcing lp-ipm on an LP must solve, not error\nstdout:\n{}\nstderr:\n{}",
+        r.stdout,
+        r.stderr
+    );
+}
+
+/// Rerouting must not solve a different problem. The fold moves the bound
+/// with the body, so the answer is the one `x0 + x1 + 3 <= 6` describes —
+/// not the `x0 + x1 <= 6` it would describe if the constant were dropped.
+///
+/// Both spellings of the constant are checked. The literal form already
+/// routed correctly before the fold (`qp_extract` re-derived the shift),
+/// so it is here as a no-regression pin on the realistic shape rather than
+/// as a reproduction.
+#[test]
+fn the_folded_row_is_the_row_the_model_wrote() {
+    for (tag, fixture) in [
+        ("optimum_literal", "lp_row_constant.nl"),
+        ("optimum_expr", "lp_row_constant_expr.nl"),
+    ] {
+        let r = run(tag, fixture, 3, &[]);
+        assert_eq!(r.code, Some(0), "{fixture} stderr:\n{}", r.stderr);
+        // One row then two columns, in `.nl` order.
+        let (x0, x1) = (r.values[1], r.values[2]);
+        assert!(
+            (x0 - 0.0).abs() < 1e-6 && (x1 - 3.0).abs() < 1e-6,
+            "{fixture}: expected (x0, x1) = (0, 3), got ({x0}, {x1}); \
+             a dropped row constant would give x0 + x1 = 6"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------
+// Presolve Phase 6 reaches a row whose constant lived in `C<i>`.
+// ---------------------------------------------------------------------
+
+/// `linear_eq_aggregation_row_constant.nl` is the committed
+/// `linear_eq_aggregation.nl` with its first row written `x0 − 2·x1 + 3 =
+/// 3` instead of `x0 − 2·x1 = 0`. Same feasible set, same optimum — and
+/// now the same reduction, where before the pass declined the row outright
+/// because `get_constraints_linearity` tagged it NonLinear.
+///
+/// A bare literal is enough to reproduce this one; unlike the classifier,
+/// the reduction's eligibility test has no polynomial walk to fall back on.
+#[test]
+fn phase_6_reduces_a_row_whose_constant_lived_in_the_expression_segment() {
+    let r = run(
+        "phase6",
+        "linear_eq_aggregation_row_constant.nl",
+        5,
+        &["presolve=yes", "presolve_linear_eq_reduction=yes"],
+    );
+    assert_eq!(r.code, Some(0), "stderr:\n{}", r.stderr);
+    assert!(
+        r.stdout.contains("eliminated 1 columns"),
+        "the reduction declined the row-constant equality:\n{}",
+        r.stdout
+    );
+    assert!(
+        r.stdout.contains("dropped 1 rows"),
+        "the consumed row was not dropped:\n{}",
+        r.stdout
+    );
+    assert!(r.stdout.contains("Optimal Solution Found"), "{}", r.stdout);
+}
+
+/// The fold is a change of bookkeeping, not of the problem: solving the
+/// row-constant fixture through the newly-reachable reduction must land on
+/// the same point and the same duals as a bare solve of the hand-folded
+/// fixture. This is the property that keeps a `.sol` readable by AMPL —
+/// the multipliers are reported against rows whose residual the fold left
+/// alone — and it is what would break if the shift had the wrong sign or
+/// hit the wrong bound.
+#[test]
+fn the_row_constant_fixture_agrees_with_the_hand_folded_one() {
+    let folded = run("hand_folded", "linear_eq_aggregation.nl", 5, &[]);
+    let offset = run(
+        "offset",
+        "linear_eq_aggregation_row_constant.nl",
+        5,
+        &["presolve=yes", "presolve_linear_eq_reduction=yes"],
+    );
+    assert_eq!(folded.code, Some(0), "stderr:\n{}", folded.stderr);
+    assert_eq!(offset.code, Some(0), "stderr:\n{}", offset.stderr);
+    assert_eq!(
+        folded.values.len(),
+        offset.values.len(),
+        "the .sol body changed length: {:?} vs {:?}",
+        folded.values,
+        offset.values
+    );
+    for (k, (f, o)) in folded.values.iter().zip(offset.values.iter()).enumerate() {
+        assert!(
+            (f - o).abs() < 1e-6,
+            ".sol entry {k} diverged: hand-folded={f} row-constant={o}"
+        );
+    }
+    // Entries 0..2 are the duals. The consumed row's multiplier must come
+    // back recovered, not zeroed.
+    assert!(
+        offset.values[0].abs() > 1e-6,
+        "the consumed row came back with a zero multiplier: {:?}",
+        offset.values
+    );
+}

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -33,7 +33,7 @@
 //!   tests in this module.
 
 use crate::nl_tape::{HybridTape, Tape, hybrid_supported};
-use pounce_common::types::{Index, Number};
+use pounce_common::types::{Index, Number, lower_bound_present, upper_bound_present};
 use pounce_nlp::tnlp::{
     BoundsInfo, IDX_NAMES, IndexStyle, IpoptCq, IpoptData, Linearity, MetaData, NlpInfo,
     ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
@@ -541,6 +541,44 @@ fn read_name_file(path: &Path, expected: usize) -> Vec<String> {
     }
 }
 
+/// The value of a constraint's nonlinear part when that part is a
+/// constant, else `None`. Drives the constant-row-body fold in
+/// [`parse_nl_text`].
+///
+/// "Constant" is decided by *evaluation*, not by syntax: a literal
+/// `Expr::Const` is the common case, but `o0 n1 n2` is just as constant
+/// and is folded too.
+///
+/// Declines in two cases, both of which would make the fold unsound:
+/// * The expression calls an AMPL imported function. Its value depends on
+///   a shared library resolved much later (`nl_external::ExternalResolver`),
+///   so it is not a parse-time constant even with constant arguments — and
+///   [`eval_expr`] panics on `Funcall` rather than guess.
+/// * The value is not finite (`n0 / n0`, `log(-1)`, an overflow). Pushing
+///   a NaN or infinity into a bound would corrupt a row that is merely
+///   infeasible; leaving the expression in place keeps it a solver-time
+///   fact.
+fn row_constant_value(e: &Expr) -> Option<Number> {
+    // The identity zero the parser preallocates for every untouched row is
+    // by far the most common input; settle it without walking anything.
+    if let Expr::Const(c) = e {
+        return c.is_finite().then_some(*c);
+    }
+    let mut vars: BTreeSet<usize> = BTreeSet::new();
+    collect_vars(e, &mut vars);
+    if !vars.is_empty() {
+        return None;
+    }
+    let mut funcs: BTreeSet<usize> = BTreeSet::new();
+    crate::nl_external::collect_funcall_ids(e, &mut funcs);
+    if !funcs.is_empty() {
+        return None;
+    }
+    // Variable-free, so no `Expr::Var` can index into the (empty) point.
+    let v = eval_expr(e, &[]);
+    v.is_finite().then_some(v)
+}
+
 /// Parse `.nl` text content. Public so tests can use string literals.
 pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
     let mut p = Parser::new(txt);
@@ -757,6 +795,44 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
             }
             other => return Err(format!("unknown .nl segment tag '{other}'")),
         }
+    }
+
+    // Normalize constant row bodies into the row bounds, so that
+    // "the nonlinear part is the identity zero" and "this row's body is
+    // Σaⱼxⱼ" mean the same thing for every downstream consumer.
+    //
+    // A `C<i>` segment holding a variable-free expression (`n3.0`, or
+    // anything that evaluates to a constant such as `o0 n1 n2`) is an
+    // affine row — but it arrives with a non-zero `con_nonlinear[i]`,
+    // which every consumer reads as "nonlinear": the linearity predicate
+    // (`get_constraints_linearity`), which is what makes presolve's
+    // linear-equality reduction decline the row; the CLI problem
+    // classifier (`is_trivially_zero` in `dispatch.rs`, whose fallback
+    // polynomial walk absorbs a bare literal but not a constant it has to
+    // compute — so an otherwise plain LP carrying a `sqrt(9)` classified
+    // NLP and never reached the convex path); and the FBBT translator.
+    // Folding here fixes all of them at once, with no per-consumer audit.
+    //
+    // The shift is exact and invisible from outside: the body drops by `c`
+    // and each bound drops by `c` with it, so the feasible set, the active
+    // set, and the duals are unchanged (`gh #492`). This is the same
+    // normalization `qp_extract::analyze_quadratic_full` already performs
+    // ad hoc via `const_shift`, promoted to the parse boundary.
+    for i in 0..m {
+        let Some(c) = row_constant_value(&con_nonlinear[i]) else {
+            continue;
+        };
+        // Presence is directional (gh #401): shifting an *absent* bound
+        // would turn the ±1e19 sentinel into a real bound for `c < 0`
+        // (lower) or `c > 0` (upper), inventing a constraint. Leave the
+        // sentinels alone.
+        if lower_bound_present(g_l[i]) {
+            g_l[i] -= c;
+        }
+        if upper_bound_present(g_u[i]) {
+            g_u[i] -= c;
+        }
+        con_nonlinear[i] = Expr::Const(0.0);
     }
 
     Ok(NlProblem {
@@ -3282,8 +3358,12 @@ impl TNLP for NlTnlp {
 
     fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
         // A row is linear iff its nonlinear-part expression is the
-        // identity zero left over from initial allocation (post-parse
-        // identity for "no `C<idx>` segment touched this row").
+        // identity zero — either left over from initial allocation ("no
+        // `C<idx>` segment touched this row") or installed by the
+        // constant-row-body fold in `parse_nl_text`, which shifts a
+        // variable-free `C<idx>` body into the row bounds precisely so
+        // that this test is a genuine linearity test and not just an
+        // identity check (`gh #492`).
         for (i, t) in types.iter_mut().enumerate() {
             *t = match &self.prob.con_nonlinear[i] {
                 Expr::Const(c) if *c == 0.0 => Linearity::Linear,
@@ -3684,6 +3764,171 @@ J0 2
         let bad = format!("{EQ_LIN}x1\n5 0.5\n");
         let err = parse_nl_text(&bad).expect_err("out-of-range x index must error");
         assert!(err.contains("out of range"), "unexpected error: {err}");
+    }
+
+    // ---------------------------------------------------------------
+    // gh #492 — a constant `C<i>` body folds into the row bounds.
+    //
+    // `EQ_LIN` is `x0 + x1 = 1` with an empty `C0` (`n0`) and the row
+    // bound in the `r` segment (`4 1`). Rewriting `C0` gives a family of
+    // constant-body rows to fold.
+    // ---------------------------------------------------------------
+
+    /// Linearity is a *linearity* test, not "did a `C` segment touch this
+    /// row". A row whose body is the bare constant `3` is affine.
+    #[test]
+    fn a_constant_row_body_folds_into_both_bounds_and_reads_linear() {
+        // `x0 + x1 + 3 = 1`  ⇔  `x0 + x1 = -2`.
+        let nl = EQ_LIN.replace("C0\nn0\n", "C0\nn3\n");
+        assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
+        let p = parse_nl_text(&nl).expect("parse");
+
+        assert!(
+            matches!(p.con_nonlinear[0], Expr::Const(c) if c == 0.0),
+            "the constant body must be replaced by the identity zero, got {:?}",
+            p.con_nonlinear[0]
+        );
+        assert!((p.g_l[0] - (-2.0)).abs() < 1e-12, "g_l = {}", p.g_l[0]);
+        assert!((p.g_u[0] - (-2.0)).abs() < 1e-12, "g_u = {}", p.g_u[0]);
+
+        let mut lin = [Linearity::NonLinear];
+        let mut t = NlTnlp::new(p);
+        assert!(t.get_constraints_linearity(&mut lin));
+        assert_eq!(lin[0], Linearity::Linear);
+    }
+
+    /// The shift must be exact, not merely "linear now": the folded model
+    /// and the hand-folded one must be the same problem, row body for row
+    /// body and bound for bound. That is what keeps feasibility, the
+    /// active set, and the duals unchanged.
+    #[test]
+    fn folding_a_row_constant_gives_the_hand_folded_problem() {
+        // `x0 + x1 + 3 = 1` against `x0 + x1 = -2`, written directly.
+        let offset = EQ_LIN.replace("C0\nn0\n", "C0\nn3\n");
+        let folded = EQ_LIN.replace("r\n4 1\n", "r\n4 -2\n");
+        assert_ne!(offset, EQ_LIN);
+        assert_ne!(folded, EQ_LIN);
+
+        let a = parse_nl_text(&offset).expect("parse offset form");
+        let b = parse_nl_text(&folded).expect("parse folded form");
+        assert_eq!(a.g_l, b.g_l);
+        assert_eq!(a.g_u, b.g_u);
+        assert_eq!(a.con_linear, b.con_linear);
+
+        // And the row *values* agree pointwise, which is the property the
+        // duals ride on: `g(x) - g_l` is the same residual either way.
+        let mut ga = [0.0];
+        let mut gb = [0.0];
+        let x = [0.75, -1.25];
+        assert!(NlTnlp::new(a).eval_g(&x, true, &mut ga));
+        assert!(NlTnlp::new(b).eval_g(&x, true, &mut gb));
+        assert!((ga[0] - gb[0]).abs() < 1e-12, "{ga:?} vs {gb:?}");
+    }
+
+    /// The fold is by *evaluation*, not by syntax: `o0 n1 n2` is as
+    /// constant as `n3`, and AMPL emits such trees when a expression
+    /// collapses without being re-simplified.
+    #[test]
+    fn a_row_body_that_evaluates_to_a_constant_folds_too() {
+        // `C0` = `1 + 2`.
+        let nl = EQ_LIN.replace("C0\nn0\n", "C0\no0\nn1\nn2\n");
+        assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
+        let p = parse_nl_text(&nl).expect("parse");
+        assert!(matches!(p.con_nonlinear[0], Expr::Const(c) if c == 0.0));
+        assert!((p.g_l[0] - (-2.0)).abs() < 1e-12, "g_l = {}", p.g_l[0]);
+        assert!((p.g_u[0] - (-2.0)).abs() < 1e-12, "g_u = {}", p.g_u[0]);
+    }
+
+    /// Bound presence is directional (gh #401): the ±1e19 sentinels mean
+    /// "absent", not "a very large number". Shifting one turns it into a
+    /// real bound and invents a constraint that is not in the model.
+    ///
+    /// The constants here are deliberately huge. An everyday `3` is
+    /// absorbed by the sentinel's own ULP (2048 at 1e19), so a missing
+    /// presence guard would go unnoticed at ordinary magnitudes and then
+    /// bite on a model that scales its rows. The guard is what makes the
+    /// sentinel untouchable at *any* magnitude.
+    #[test]
+    fn folding_a_row_constant_leaves_the_absent_bound_sentinel_alone() {
+        // `x0 + x1 - 1e18 <= 1`: upper-bounded row (`r` kind 1), no lower
+        // bound. Shifting the lower sentinel would leave `-9e18`, a real
+        // bound, so the row would gain a floor the model never stated.
+        let nl = EQ_LIN
+            .replace("C0\nn0\n", "C0\nn-1e18\n")
+            .replace("r\n4 1\n", "r\n1 1\n");
+        let p = parse_nl_text(&nl).expect("parse");
+        assert!((p.g_u[0] - 1.0e18).abs() < 1024.0, "g_u = {}", p.g_u[0]);
+        assert!(
+            !lower_bound_present(p.g_l[0]),
+            "the absent-lower sentinel became a real bound: {}",
+            p.g_l[0]
+        );
+
+        // The mirror case: a positive constant on a lower-bounded row is
+        // the one that would pull the *upper* sentinel below 1e19.
+        let nl = EQ_LIN
+            .replace("C0\nn0\n", "C0\nn1e18\n")
+            .replace("r\n4 1\n", "r\n2 1\n");
+        let p = parse_nl_text(&nl).expect("parse");
+        assert!((p.g_l[0] + 1.0e18).abs() < 1024.0, "g_l = {}", p.g_l[0]);
+        assert!(
+            !upper_bound_present(p.g_u[0]),
+            "the absent-upper sentinel became a real bound: {}",
+            p.g_u[0]
+        );
+    }
+
+    /// A row body that mentions a variable is not a constant, however
+    /// simple it looks. Folding it would delete the term.
+    #[test]
+    fn a_row_body_with_a_variable_is_not_folded() {
+        let nl = EQ_LIN.replace("C0\nn0\n", "C0\no5\nv0\nn2\n"); // x0²
+        assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
+        let p = parse_nl_text(&nl).expect("parse");
+        assert!(
+            !matches!(p.con_nonlinear[0], Expr::Const(_)),
+            "a row in x0 was folded away: {:?}",
+            p.con_nonlinear[0]
+        );
+        assert!((p.g_l[0] - 1.0).abs() < 1e-12, "bounds moved: {}", p.g_l[0]);
+        assert!((p.g_u[0] - 1.0).abs() < 1e-12, "bounds moved: {}", p.g_u[0]);
+    }
+
+    /// A variable-free body whose value is not finite is left in place. It
+    /// makes the row infeasible (or ill-posed) and that is the solver's
+    /// verdict to report; pushing a NaN into `g_l`/`g_u` would instead
+    /// corrupt the bound pair and take every downstream presence test with
+    /// it.
+    #[test]
+    fn a_non_finite_constant_row_body_is_not_folded() {
+        // `C0` = `log(-1)` = NaN.
+        let nl = EQ_LIN.replace("C0\nn0\n", "C0\no43\nn-1\n");
+        assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
+        let p = parse_nl_text(&nl).expect("parse");
+        assert!(
+            !matches!(p.con_nonlinear[0], Expr::Const(c) if c == 0.0),
+            "a NaN body was folded into the bounds"
+        );
+        assert!(p.g_l[0].is_finite() && p.g_u[0].is_finite());
+        assert!((p.g_l[0] - 1.0).abs() < 1e-12);
+    }
+
+    /// An imported-function call is not a parse-time constant even with
+    /// constant arguments — it is resolved to a shared library much later
+    /// (`nl_external::ExternalResolver`), and `eval_expr` panics on it
+    /// rather than guess. The fold must decline before it evaluates.
+    #[test]
+    fn a_constant_argument_funcall_row_body_is_not_folded() {
+        // Declare one imported function and call it with a literal.
+        let nl = EQ_LIN.replace("C0\nn0\n", "F0 1 1 myfunc\nC0\nf0 1\nn2.0\n");
+        assert_ne!(nl, EQ_LIN, "fixture substitution must apply");
+        let p = parse_nl_text(&nl).expect("parse");
+        assert!(
+            matches!(p.con_nonlinear[0], Expr::Funcall { .. }),
+            "expected the funcall to survive the fold, got {:?}",
+            p.con_nonlinear[0]
+        );
+        assert!((p.g_l[0] - 1.0).abs() < 1e-12, "bounds moved: {}", p.g_l[0]);
     }
 
     #[test]

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -42,6 +42,14 @@ always produces a correct (locally optimal) answer. You never get a wrong
 > nonlinear expression tree. POUNCE walks that tree to recover the
 > Hessian and test convexity, the same way QP-capable AMPL solvers do.
 
+> **Note on row constants.** A `.nl` writer may leave a constant on the
+> left of a constraint — `x0 + x1 + 3 <= 6` rather than `x0 + x1 <= 3` —
+> and it too lands in the nonlinear expression tree. The reader folds such
+> a constant into the row's bounds when the file is read, so a model that
+> is otherwise an LP still classifies as one. The shift is exact: body and
+> bound move together, so the solution and every multiplier are the same
+> as for the hand-folded model.
+
 ## Choosing the solver explicitly
 
 The `solver_selection` option overrides the automatic choice. It is a

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -338,6 +338,11 @@ variables they determine, iterating to a fixed point so chains propagate:
 Rows that collapse to `0 = 0` under the accumulated substitutions are
 dropped as structurally redundant.
 
+A row written with a constant on the left — `x0 − 2·x1 + 3 = 3` — is
+eligible on the same terms as `x0 − 2·x1 = 0`. The `.nl` reader folds a
+constant row body into the row's bounds when the file is read, so the pass
+sees an ordinary linear equality.
+
 Every eliminated variable's bounds are transferred onto its survivor, so
 the reduced box is never looser than the original. `finalize_solution`
 lifts the primal back to the original variable order and recovers a


### PR DESCRIPTION
Fixes #492

## Problem

A `.nl` writer may leave a constant on the left of a constraint — `x0 + x1 + 3 <= 6` rather than `x0 + x1 <= 3` — and that constant arrives as the row's *nonlinear-part* expression. POUNCE read any non-empty expression segment as "this row is nonlinear". `get_constraints_linearity`'s own comment said what it really was: an identity check, "did any `C` segment touch this row". The row is affine.

Two consequences, both user-visible, and they bite on different shapes:

| model | before | after | oracle |
|---|---|---|---|
| `x0 − 2·x1 + 3 = 3` + a nonlinear row, `presolve_linear_eq_reduction=yes` | eliminated 0 columns | **eliminated 1 column, dropped 1 row** | same optimum and duals as the hand-folded fixture, to 1e-11 |
| LP with `sqrt(9)` as a row constant, `solver_selection=auto` | `Problem class: NLP` | **`Problem class: LP`** → `pounce-convex` | scipy HiGHS, `obj = −6` either way |
| same, `solver_selection=lp-ipm` | exit 2, "problem class NLP does not match forced solver lp-ipm" | **solves** | — |

## Cause

`NlTnlp::get_constraints_linearity` tested whether `con_nonlinear[i]` was *identically* `Const(0.0)`. Presolve Phase 6 (#487) consumes only rows tagged linear, so it declined every row carrying a constant — its row-constant branch was live only on the general TNLP path, never through `.nl`.

The classifier (`is_trivially_zero` in `dispatch.rs`) asks the same question but has a fallback: it lowers each row body to a degree-≤2 polynomial. That absorbs a bare literal — dropping the constant, which `qp_extract` then re-derived as a `const_shift` — so a literal already classified LP. What it cannot lower is a constant it has to *compute*. `sqrt(9)`, an `exp`, a `min`: `analyze_quadratic` returns `None` and the row makes the whole model NLP.

**This corrects the issue on one point.** #492 states that "a model whose rows carry constant offsets classifies as NLP and never reaches the convex path at all". That is true only for the computed form; a bare literal was already routed correctly. The presolve consequence is as reported and bites on both.

## Fix

Constant-fold at the parse boundary, as the issue recommended, rather than widening the linearity predicate. When a row's `C<i>` body evaluates to a constant `c`, subtract `c` from `g_l[i]`/`g_u[i]` and replace the body with `Const(0.0)`. The row is then genuinely linear with a zero offset, and linearity, the classifier, presolve, and the FBBT translator are all correct with no per-consumer audit. This promotes the ad hoc `const_shift` normalization in `qp_extract.rs` to where it belongs.

The narrow alternative the issue names — widening the match to `Expr::Const(_) => Linearity::Linear` — was not taken, for the reason given there: it makes "linear" stop implying "body = Σaⱼxⱼ", which then needs auditing at every consumer.

The fold is by **evaluation**, not syntax, so `o0 n1 n2` and `sqrt(9)` are caught too. It declines in two cases, each of which would make it unsound:

- an **imported-function call** — not a parse-time constant even with constant arguments, since it resolves to a shared library much later, and `eval_expr` panics on `Funcall` rather than guess;
- a **non-finite value** — pushing NaN into a bound makes every downstream presence test unanswerable. Demonstrated: with the finiteness check removed, a `log(-1)` row body gives both bounds NaN, every presence test then reads the row as *free*, and pounce returns "Optimal Solution Found" at `x = (3,3)` for a model containing an unsatisfiable row.

**Absent-bound sentinels are left alone.** Presence is directional (#401), so shifting a ±1e19 sentinel invents a constraint; a bound moves only when that side is actually bounded. The regression test uses a 1e18 constant deliberately — at ordinary magnitudes the sentinel's own ULP (2048 at 1e19) absorbs the shift and a missing guard goes unnoticed, then bites on a model that scales its rows.

## Blast radius

Bit-identical except for rows that actually carry a constant body: `row_constant_value` returns `Some(0.0)` for the preallocated identity zero, and `g_l -= 0.0` is an exact no-op. Full workspace suite green, unchanged.

Not externally visible. Nothing reports a raw constraint body to the user — the `.sol` carries duals, and both AMPL and `pounce verify` re-derive bodies from the `.nl`. The debugger's `render_constraint_equation` now prints `x0 - x1 = 0` where it printed `x0 - x1 + 3 = 3`; same relation.

`pounce-py` and `pounce-wasm` build `NlProblem` through the same `parse_nl_text`, so they get the normalization too. Callers that construct an `NlProblem` directly are untouched.

## Tests

14 tests across three layers. **9 fail on the parent commit**; the other 5 are decline-cases and no-regression pins and say so in their doc comments.

- **7 parse-level** (`nl_reader.rs`): folds both bounds and reads `Linear`; parses identically to the hand-folded model with matching row values; folds a computed constant; leaves both sentinels alone; declines a variable body, a non-finite body, a funcall body.
- **2 classifier** (`dispatch.rs`): literal and computed forms, pinning the correction above rather than the issue's claim.
- **5 end-to-end** (`tests/issue_492_row_constant_fold.rs`, 3 new fixtures): routing flip on `auto` and on forced `lp-ipm`, correct optimum for both spellings, Phase 6 eliminating 1 column / 1 row, and `.sol` primals **and duals** matching a bare solve of the hand-folded fixture to 1e-6.

Mutation-tested rather than assumed. Removing the sentinel guard fails the sentinel test with `-9e18` as an invented lower bound; disabling the fold fails the 9 tests above and no others.

### Adversarial run

`adversary/runs/2026-08-06_nlp_row_constant_fold.py` — 999 randomized LPs over 4 seeds, every row carrying a constant in its `C<i>` segment in five spellings across all five `r`-segment bound kinds including free rows, plus 60 sentinel cases at `|k|` up to 1e18 and 8 decline cases. Four oracles, none of them pounce-with-the-fold-off: scipy HiGHS on the model as the script assembles it; every row re-evaluated *with its constant* against the bounds the file declares; the hand-folded twin model compared on primal **and** duals; and stationarity of the reported duals at every interior column. All clean, all 999 classified LP. #490's `.nl` sweep re-run as a regression check on the same path (240 instances, clean).

The probe is itself mutation-tested — 5 of 6 injected defects caught. The 6th (no fold at all) is not a correctness defect and moved only the classified-LP counter, 60 → 33, which is what confirms that counter is a live signal. Two defects in the probe were found and fixed en route; both are written up in `adversary/runs/2026-08-06_nlp_row_constant_fold.org`.

**One unrelated pre-existing bug was found and filed: #496.** Two rank-deficient equality rows whose implied values differ by one ULP get a false primal-infeasible certificate at iteration 0 from the LP IPM, on a model HiGHS solves. Reproduced on `origin/main` at `cad2b13` with no `C`-segment content at all, so it predates this change and is not reachable from it. The probe counts that one instance as a visible skip, not a failure.

### Not pinned

Objective constants are **not** folded. An `O0` segment whose body is a constant still reads as a nonlinear objective, so an LP with a constant objective offset still classifies NLP. `NlProblem::obj_constant` exists and is added in `eval_f`, so the fold would be exact there too — but it is outside what #492 asks for, and a separate change deserves its own tests.

---

- [x] Tests fail on the parent commit for the stated reason — 9 of 14; the other 5 are declines / no-regression pins, marked as such
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`lp-qp-routing.md`, `options.md`; no new page, so `SUMMARY.md` unchanged)
- [x] `cargo fmt --all -- --check`, the CI clippy gate (`-D clippy::correctness -D clippy::suspicious`), and `cargo test --workspace` clean; `scripts/check-release-consistency.sh` OK
- [x] Every claim in this body and in the code comments is true of the code as it stands now — including the correction to #492's stated consequence, which the tests pin rather than restate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018o5tyhzzkwvYTzwjSq9XAg

---
_Generated by [Claude Code](https://claude.ai/code/session_018o5tyhzzkwvYTzwjSq9XAg)_