### PR TITLE
convex presolve: fold away two-variable equality rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ changes.
 
 ## [Unreleased]
 
+### Added — LP and convex-QP presolve folds away two-variable equality rows (#494)
+
+- A row `a₁·x + a₂·y = b` linking two variables says one of them *is* the
+  other, up to a scale and a shift — an arc equality, a `Reference` alias,
+  a unit conversion. Neither variable is determined by it, so the convex
+  presolve's catalog had nothing that could act on it, even though it
+  already had singleton-row fixing and free-column-singleton substitution.
+  On a flowsheet those rows are most of the model. LP and convex QP now
+  substitute one variable for the other and drop the row, iterating to a
+  fixed point so **chains** of aliases collapse to a single column.
+- This is the reduction #490 added for the general NLP path, reaching the
+  models that path never sees: the CLI dispatches LP and convex QP to
+  `pounce-convex` several hundred lines before any presolve wrapper is
+  built. Both now share one planner, so they agree on what can go.
+- On by default, as the rest of the convex presolve is. `qp_presolve=no`
+  (or `presolve=no`) turns the whole pass off. The one-line presolve
+  summary gained an `aggregated` count.
+- Any bound on an eliminated variable is carried onto the survivor, so the
+  reduced problem describes the same feasible set — and the postsolved
+  duals still describe the *original* one. Where a reduced solve reports a
+  bound force on a variable that has no such bound of its own (it inherited
+  one), the force is re-attributed to the variable that actually declares
+  it. Convexity is preserved by construction: the substitution is a
+  congruence `P' = MᵀPM`.
+- Fails closed, like Phase 6: a contradictory alias system, or one that
+  would remove every column, stands the pass down and hands the model over
+  untouched rather than being the first and only voice calling it
+  infeasible. The conic path (SOCP, exponential/power cones, SDP, SOS) opts
+  out entirely — those rows are coupled in fixed-size blocks.
+
+### Fixed — the convex presolve's iteration trace reported a reduced-problem objective
+
+- `QpIterate::objective` is documented to be in the original problem's
+  coordinates, but the trace comes back from a solve of the *reduced*
+  problem, and presolve never added back the constant its substitutions
+  moved into the objective. Any `--json-detail full` report on a model
+  where presolve fixed or substituted a variable carried an `iterations`
+  array offset by that constant. The final objective, the solution, and
+  the duals were always right; only the trace was affected.
+
 ### Added — presolve eliminates variables determined by linear equality rows (#487)
 
 - `presolve_linear_eq_reduction` was a registered option with no

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "pounce-feral",
  "pounce-linalg",
  "pounce-linsol",
+ "pounce-presolve",
  "pounce-qp",
  "rayon",
 ]

--- a/adversary/log.org
+++ b/adversary/log.org
@@ -31,7 +31,7 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 :SOURCE: randomized alias-linked convex QPs built around a known feasible point x*; no published instance
 :KNOWN_OPTIMAL: n/a (property-based)
 :POUNCE_OBJECTIVE: n/a
-:POUNCE_STATUS: 441 end-to-end .nl solves across 3 seeds, 0 failures
+:POUNCE_STATUS: 438 end-to-end .nl solves across 3 seeds, 0 failures
 :POUNCE_TIME: ~3 min total
 :ORACLE: pounce verify (independent KKT/feasibility vs the original .nl); in-script row re-evaluation; in-script bound-aware stationarity of the reported duals; qp_presolve=no objective agreement
 :ORACLE_OBJECTIVE: n/a
@@ -46,6 +46,13 @@ gradient the dual sweep is handed, and dropping the substitution offset from a
 surviving row's right-hand side, were each caught (13 and 31 failures in 40
 instances). The =Gᵀz= defect is caught only by the bound-aware stationarity
 oracle — =pounce verify= alone passes it — which is why that oracle exists.
+
+Re-run after merging gh#492 (#498), which folds a constant row body into the
+row bounds at parse. Most generated rows now carry their constant in the C
+segment rather than pre-folded: 10 of 12 sampled models, all still classified
+LP/convex-QP where before #498 they would have been NLP and never reached this
+pass. Same reduction counts, same objectives, same verdicts as the pre-folded
+spelling — which is the claim, since they are the same constraints.
 
 Measured limit, stated because it changes what this run does and does not
 cover: the CLI's QP extractor lowers every variable bound to a row of =G=, so

--- a/adversary/log.org
+++ b/adversary/log.org
@@ -11,8 +11,8 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 | Family          | Tested | Last run   | Open findings |
 |-----------------+--------+------------+---------------|
 | nlp             |     12 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6) |
-| lp              |     10 | 2026-08-04 | —             |
-| qp              |     10 | 2026-08-03 | —             |
+| lp              |     11 | 2026-08-06 | —             |
+| qp              |     11 | 2026-08-06 | —             |
 | qp-active-set   |     14 | 2026-08-05 | both probes now CLEAN. Fixed this run: false-Infeasible (14 -> 0), `Optimal` at violating points, rank-deficiency hard errors, unvalidated working-set status codes, and IpoptGet/SetWorkingSet reporting the SQP's internal row order instead of the caller's. Nothing open. |
 | socp            |     11 | 2026-08-05 | —             |
 | exp             |     10 | 2026-08-04 | #336 FIXED 2026-07-23; regression-confirmed 2026-07-29 (benign-scale PASS) |
@@ -25,6 +25,38 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 | sensitivity     |     10 | 2026-08-03 | — (weakly-active one-sided dx/db intrinsic/known; no barrier inflation confirmed; reduced_hessian() cross-checked clean) |
 
 * Problem Index
+** [2026-08-06] Doubleton-equality aggregation in the convex presolve (qp/lp, gh#494) - PASS
+:PROPERTIES:
+:FAMILY: qp
+:SOURCE: randomized alias-linked convex QPs built around a known feasible point x*; no published instance
+:KNOWN_OPTIMAL: n/a (property-based)
+:POUNCE_OBJECTIVE: n/a
+:POUNCE_STATUS: 441 end-to-end .nl solves across 3 seeds, 0 failures
+:POUNCE_TIME: ~3 min total
+:ORACLE: pounce verify (independent KKT/feasibility vs the original .nl); in-script row re-evaluation; in-script bound-aware stationarity of the reported duals; qp_presolve=no objective agreement
+:ORACLE_OBJECTIVE: n/a
+:ORACLE_TIME: n/a
+:VERDICT: PASS
+:REPORT: [[file:runs/2026-08-06_convex_doubleton_aggregation_verify.py]]
+:COVERAGE_TARGET: crates/pounce-convex/src/aggregate.rs — new file, no prior adversarial coverage
+:END:
+
+Probe validated by mutation testing rather than asserted: dropping =Gᵀz= from the
+gradient the dual sweep is handed, and dropping the substitution offset from a
+surviving row's right-hand side, were each caught (13 and 31 failures in 40
+instances). The =Gᵀz= defect is caught only by the bound-aware stationarity
+oracle — =pounce verify= alone passes it — which is why that oracle exists.
+
+Measured limit, stated because it changes what this run does and does not
+cover: the CLI's QP extractor lowers every variable bound to a row of =G=, so
+the =QpProblem= the convex presolve sees from a =.nl= has an empty box.
+Instrumenting the branch shows the transferred-bound multiplier
+re-attribution firing in 0 of 114 instances here — there is no box to
+transfer. That path is reached only by callers who build a =QpProblem= with
+=lb=/=ub= directly, and is covered at the library level by
+=crates/pounce-convex/tests/presolve_aggregation.rs= (a targeted fixture plus a
+randomized probe reaching it in 19 of 400 draws), where five injected defects
+in the recovery were each caught.
 ** [2026-08-06] Linear-equality variable elimination, Phase 6 (nlp/presolve, gh#487) - PASS
 :PROPERTIES:
 :FAMILY: nlp

--- a/adversary/runs/2026-08-06_convex_doubleton_aggregation_verify.py
+++ b/adversary/runs/2026-08-06_convex_doubleton_aggregation_verify.py
@@ -67,14 +67,23 @@ from pathlib import Path
 POUNCE = Path("/home/user/pounce/target/release/pounce")
 
 
-def write_nl(path, n, rows, rhs, lin, x_l, x_u, x0):
-    """`min Σ xⱼ² + Σ linⱼ·xⱼ  s.t.  Σ aᵢⱼ xⱼ = rhsᵢ`, boxed.
+def write_nl(path, n, rows, rhs, lin, x_l, x_u, x0, consts=None):
+    """`min Σ xⱼ² + Σ linⱼ·xⱼ  s.t.  Σ aᵢⱼ xⱼ + cᵢ = rhsᵢ + cᵢ`, boxed.
 
     A separable convex quadratic objective and linear equality rows, which is
     what the classifier needs to route the model to `pounce-convex` rather
     than the NLP path.
+
+    `consts[i]` is written into row `i`'s *expression* segment rather than
+    folded into its bound, with the bound raised to match. Before gh#492
+    that made the row read as nonlinear and the whole model as an NLP; the
+    reader now folds it at parse, so such a row reaches this pass like any
+    other. That composition is new, so the family exercises both spellings
+    — the rows are the same constraints either way, and the reduction and
+    the recovered duals must not be able to tell.
     """
     m = len(rows)
+    consts = consts or [0.0] * m
     jnnz = sum(len(r) for r in rows)
     L = [
         "g3 1 1 0\t# adversary convex doubleton aggregation",
@@ -89,7 +98,7 @@ def write_nl(path, n, rows, rhs, lin, x_l, x_u, x0):
         " 0 0 0 0 0\t# common exprs",
     ]
     for r in range(m):
-        L += [f"C{r}", "n0"]
+        L += [f"C{r}", f"n{consts[r]!r}"]
     L += ["O0 0", "o54", str(n)]
     for j in range(n):
         L += ["o5", f"v{j}", "n2"]
@@ -98,7 +107,7 @@ def write_nl(path, n, rows, rhs, lin, x_l, x_u, x0):
         L.append(f"{j} {x0[j]!r}")
     L.append("r")
     for i in range(m):
-        L.append(f"4 {rhs[i]!r}")
+        L.append(f"4 {rhs[i] + consts[i]!r}")
     L.append("b")
     for j in range(n):
         lo, hi = x_l[j], x_u[j]
@@ -216,7 +225,13 @@ def gen(rng):
         else:
             x_l.append(None), x_u.append(None)
     x0 = [round(x_star[j] + rng.uniform(-0.2, 0.2), 6) for j in range(n)]
-    return n, rows, rhs, lin, x_l, x_u, x0
+    # Most rows carry a constant in their expression segment; some carry none,
+    # so both the gh#492 fold and the plain path stay live in every run.
+    consts = [
+        0.0 if rng.random() < 0.4 else round(rng.uniform(-3, 3), 6)
+        for _ in rows
+    ]
+    return n, rows, rhs, lin, x_l, x_u, x0, consts
 
 
 def run(nl_dir, opts):
@@ -298,11 +313,11 @@ def main():
         inst = gen(rng)
         if inst is None:
             continue
-        n, rows, rhs, lin, x_l, x_u, x0 = inst
+        n, rows, rhs, lin, x_l, x_u, x0, consts = inst
         m = len(rows)
         d = Path(tempfile.mkdtemp(prefix="adv_agg_"))
         try:
-            write_nl(d / "m.nl", n, rows, rhs, lin, x_l, x_u, x0)
+            write_nl(d / "m.nl", n, rows, rhs, lin, x_l, x_u, x0, consts)
 
             off = run(d, ["qp_presolve=no"])
             if "Optimal Solution Found" not in off.stdout:

--- a/adversary/runs/2026-08-06_convex_doubleton_aggregation_verify.py
+++ b/adversary/runs/2026-08-06_convex_doubleton_aggregation_verify.py
@@ -1,0 +1,385 @@
+"""Adversary cross-check: convex-path doubleton aggregation, end to end.
+
+Family: convex   Class: convex QP / LP with alias-linked columns
+Target: the doubleton-equality aggregation in `pounce-convex`'s presolve (gh#494)
+Source: no published instance — a randomized family built around a KNOWN
+        feasible point, with `pounce verify` as the independent oracle.
+
+`crates/pounce-convex/tests/presolve_aggregation.rs` attacks the reduction
+through the library API, where the QP is handed over already extracted. This
+one attacks the stack a user actually meets: a `.nl` file on disk, the CLI's
+LP/QP classifier and extractor, the presolve, the IPM, the postsolve, and the
+`.sol` file that comes back.
+
+Four oracles, only one of which is "pounce with the option off":
+
+1. **`pounce verify <nl> <sol>`** — an independent feasibility/KKT check of the
+   claimed point against the ORIGINAL `.nl`, which knows nothing about the
+   reduction. A point that violates a row the aggregation consumed is rejected
+   here.
+2. **Direct evaluation in this script** — every row is re-evaluated in Python
+   from the same data used to write the `.nl`. That catches a `.sol` whose
+   primal block is the right length but the wrong permutation, which `verify`
+   alone cannot distinguish from a genuine solve.
+3. **Bound-aware stationarity, in this script.** With `rⱼ = ∇fⱼ + s·(Aᵀλ)ⱼ`
+   for the sign convention `s` the baseline solve establishes: `rⱼ = 0` at an
+   interior column, `rⱼ ≥ 0` at an active lower bound, `rⱼ ≤ 0` at an active
+   upper bound — the conditions a bound multiplier of the right sign has to
+   absorb. This is the oracle that sees the reduction's hardest claim, which
+   is where the bound force ends up when planning transfers a box onto a
+   column that has no such bound of its own. `verify` alone does not: it is
+   generous about columns sitting on a bound, exactly so that a missing
+   suffix is not read as a wrong answer.
+4. **`qp_presolve=no`** — the objective must agree with the un-reduced solve.
+   Weakest of the four (both sides are POUNCE), but it is the one that
+   notices a reduction that is self-consistently wrong.
+
+Each instance is generated around a random `x*` used only to compute the
+right-hand sides, so every model is feasible by construction and a "proved
+infeasible" verdict is always a bug.
+
+**What this run cannot reach, measured rather than assumed.** The CLI's QP
+extractor lowers every variable bound to a row of `G`, so the `QpProblem` the
+convex presolve receives from a `.nl` file has an *empty box*. Instrumenting
+the branch shows the transferred-bound re-attribution in
+`aggregate::postsolve` firing in 0 of 114 instances here, for that reason:
+with no box, planning has nothing to transfer, and each bound's force lands
+on an ordinary inequality multiplier the sweep already accounts for. That
+recovery matters for callers who build a `QpProblem` with `lb`/`ub` directly
+— `pounce-py`, the batch API, any embedder — and for the boxes the catalog's
+own bound tightening creates, and it is covered at that level by
+`crates/pounce-convex/tests/presolve_aggregation.rs` (a targeted fixture plus
+a randomized probe that reaches the branch in 19 of 400 draws). What this run
+does cover end to end is everything else: classification, extraction, the
+primal substitution, the row rewrite, the consumed-row dual sweep, postsolve,
+and the `.sol` that comes back.
+
+Usage:  python3 <this file> [trials] [seed]
+"""
+
+import random
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+POUNCE = Path("/home/user/pounce/target/release/pounce")
+
+
+def write_nl(path, n, rows, rhs, lin, x_l, x_u, x0):
+    """`min Σ xⱼ² + Σ linⱼ·xⱼ  s.t.  Σ aᵢⱼ xⱼ = rhsᵢ`, boxed.
+
+    A separable convex quadratic objective and linear equality rows, which is
+    what the classifier needs to route the model to `pounce-convex` rather
+    than the NLP path.
+    """
+    m = len(rows)
+    jnnz = sum(len(r) for r in rows)
+    L = [
+        "g3 1 1 0\t# adversary convex doubleton aggregation",
+        f" {n} {m} 1 0 {m} \t# vars, constraints, objectives, ranges, eqns",
+        " 0 1 0 0 0 0\t# nonlinear constrs, objs",
+        " 0 0\t# network",
+        f" 0 {n} 0 \t# nonlinear vars in constraints, objectives, both",
+        " 0 0 0 1\t# linear network vars; functions; arith, flags",
+        " 0 0 0 0 0 \t# discrete",
+        f" {jnnz} {n} \t# nonzeros in Jacobian, obj gradient",
+        " 0 0\t# max name lengths",
+        " 0 0 0 0 0\t# common exprs",
+    ]
+    for r in range(m):
+        L += [f"C{r}", "n0"]
+    L += ["O0 0", "o54", str(n)]
+    for j in range(n):
+        L += ["o5", f"v{j}", "n2"]
+    L.append(f"x{n}")
+    for j in range(n):
+        L.append(f"{j} {x0[j]!r}")
+    L.append("r")
+    for i in range(m):
+        L.append(f"4 {rhs[i]!r}")
+    L.append("b")
+    for j in range(n):
+        lo, hi = x_l[j], x_u[j]
+        if lo is None and hi is None:
+            L.append("3")
+        elif hi is None:
+            L.append(f"2 {lo!r}")
+        elif lo is None:
+            L.append(f"1 {hi!r}")
+        else:
+            L.append(f"0 {lo!r} {hi!r}")
+    colcount = [0] * n
+    for r in rows:
+        for j, _ in r:
+            colcount[j] += 1
+    L.append(f"k{n - 1}")
+    cum = 0
+    for j in range(n - 1):
+        cum += colcount[j]
+        L.append(str(cum))
+    for i, r in enumerate(rows):
+        L.append(f"J{i} {len(r)}")
+        for j, a in sorted(r):
+            L.append(f"{j} {a!r}")
+    L.append(f"G0 {n}")
+    for j in range(n):
+        L.append(f"{j} {lin[j]!r}")
+    path.write_text("\n".join(L) + "\n")
+
+
+def gen(rng):
+    """One instance: alias chains over disjoint clusters, plus wider rows."""
+    clusters = rng.randint(2, 5)
+    sizes = [rng.randint(1, 4) for _ in range(clusters)]
+    n = sum(sizes)
+    x_star = [round(rng.uniform(-3, 3), 6) for _ in range(n)]
+
+    # Column index ranges per cluster.
+    spans, base = [], 0
+    for s in sizes:
+        spans.append(list(range(base, base + s)))
+        base += s
+
+    rows, rhs = [], []
+
+    # A "blocking" instance covers one column of *every* cluster with its
+    # first wide row, so no alias row survives the disjoint-source rule and
+    # none of them is tightened. See the note on row order below.
+    blocking = clusters >= 3 and rng.random() < 0.5
+    blocking_cols = [rng.choice(sp) for sp in spans] if blocking else []
+
+    def wide_rows():
+        """Multi-cluster rows, which the aggregation must rewrite, not consume.
+
+        Kept below `clusters` in number so the system stays underdetermined
+        and the objective, not the rows, picks the point.
+        """
+        out = []
+        if blocking:
+            out.append([(c, round(rng.uniform(0.5, 2.0), 6)) for c in blocking_cols])
+        for _ in range(rng.randint(0, max(0, clusters - 2))):
+            cols = [rng.choice(sp) for sp in rng.sample(spans, min(3, clusters))]
+            if len(set(cols)) < len(cols):
+                continue
+            out.append([(c, round(rng.uniform(0.5, 2.0), 6)) for c in cols])
+        return out
+
+    def alias_rows():
+        out = []
+        for span in spans:
+            for k in range(len(span) - 1):
+                i, j = span[k], span[k + 1]
+                a = round(rng.uniform(0.4, 2.5), 6) * rng.choice([1, -1])
+                b = round(rng.uniform(0.4, 2.5), 6) * rng.choice([1, -1])
+                out.append([(i, a), (j, b)])
+        return out
+
+    # Row *order* is load-bearing, so draw both orders. The catalog's
+    # bound-tightening pass walks the equality rows in index order and takes
+    # a row as a source only if its columns are untouched by an earlier one.
+    # Put the wide rows first and they claim the alias rows' columns, so the
+    # alias rows go untightened and the eliminated column's box reaches its
+    # survivor only through the aggregation — which is the one arrangement
+    # that makes the transferred-bound multiplier need re-attributing. Put
+    # the alias rows first and tightening gets there on its own. Both
+    # arrangements are realistic; only one exercises that recovery.
+    wide, alias = wide_rows(), alias_rows()
+    for row in (wide + alias) if blocking or rng.random() < 0.5 else (alias + wide):
+        rows.append(row)
+        rhs.append(round(sum(a * x_star[c] for c, a in row), 9))
+    if not rows:
+        return None
+
+    # Linear objective term. Large enough, half the time, to push the
+    # unconstrained optimum out of the box so a bound goes active.
+    push = rng.random() < 0.5
+    lin = [
+        round(rng.uniform(-12, 12) if push else rng.uniform(-1, 1), 6) for _ in range(n)
+    ]
+
+    x_l, x_u = [], []
+    for j in range(n):
+        # A blocking row only claims its columns if it actually tightens a
+        # bound, and it can only tighten from finite ones — so those columns
+        # get two-sided boxes rather than the free draw.
+        shape = 0 if j in blocking_cols else rng.randrange(4)
+        lo = round(x_star[j] - rng.uniform(0.2, 4.0), 6)
+        hi = round(x_star[j] + rng.uniform(0.2, 4.0), 6)
+        if shape == 0:
+            x_l.append(lo), x_u.append(hi)
+        elif shape == 1:
+            x_l.append(lo), x_u.append(None)
+        elif shape == 2:
+            x_l.append(None), x_u.append(hi)
+        else:
+            x_l.append(None), x_u.append(None)
+    x0 = [round(x_star[j] + rng.uniform(-0.2, 0.2), 6) for j in range(n)]
+    return n, rows, rhs, lin, x_l, x_u, x0
+
+
+def run(nl_dir, opts):
+    cmd = [str(POUNCE), "m", "-AMPL"] + opts
+    return subprocess.run(cmd, cwd=nl_dir, capture_output=True, text=True, timeout=120)
+
+
+def read_sol(path, n, m):
+    nums = []
+    for line in path.read_text().splitlines():
+        if line.startswith("objno"):
+            break
+        try:
+            nums.append(float(line.strip()))
+        except ValueError:
+            pass
+    tail = nums[-(n + m) :]
+    return tail[:m], tail[m:]
+
+
+def objective(x, lin):
+    return sum(v * v + lin[j] * v for j, v in enumerate(x))
+
+
+def stationarity_fault(x, lam, rows, lin, x_l, x_u, sign, tol=1e-5):
+    """First column whose reduced cost no valid bound multiplier can absorb.
+
+    `∇f + s·Aᵀλ − z_l + z_u = 0` with `z_l, z_u ≥ 0` and complementarity
+    means the residual must vanish where the column is interior, be `≥ 0`
+    where it sits on its lower bound, and `≤ 0` on its upper — with no
+    reference to the reported bound multipliers at all, so a solver that
+    omits them (or attributes them to the wrong column) cannot hide here.
+    """
+    n = len(x)
+    resid = [2.0 * x[j] + lin[j] for j in range(n)]
+    for i, row in enumerate(rows):
+        for c, a in row:
+            resid[c] += sign * a * lam[i]
+    scale = 1.0 + max((abs(r) for r in resid), default=0.0)
+    for j in range(n):
+        lo = -float("inf") if x_l[j] is None else x_l[j]
+        hi = float("inf") if x_u[j] is None else x_u[j]
+        at_lo = abs(x[j] - lo) <= 1e-6
+        at_hi = abs(x[j] - hi) <= 1e-6
+        r = resid[j]
+        if at_lo and at_hi:
+            continue  # a pinned column absorbs anything
+        if at_lo:
+            if r < -tol * scale:
+                return f"x[{j}] on its lower bound with reduced cost {r:.3e} < 0"
+        elif at_hi:
+            if r > tol * scale:
+                return f"x[{j}] on its upper bound with reduced cost {r:.3e} > 0"
+        elif abs(r) > tol * scale:
+            return f"x[{j}] interior with non-zero reduced cost {r:.3e}"
+    return None
+
+
+def infer_sign(x, lam, rows, lin, x_l, x_u):
+    """Which `.sol` dual sign convention the baseline solve is written in.
+
+    Established from the *un-presolved* solve, then held against the
+    presolved one — so the check never adapts itself to whatever the
+    reduction happened to produce.
+    """
+    for s in (-1.0, 1.0):
+        if stationarity_fault(x, lam, rows, lin, x_l, x_u, s) is None:
+            return s
+    return None
+
+
+def main():
+    trials = int(sys.argv[1]) if len(sys.argv) > 1 else 150
+    seed = int(sys.argv[2]) if len(sys.argv) > 2 else 20260806
+    rng = random.Random(seed)
+
+    bad, checked, reduced_any, at_bound = [], 0, 0, 0
+    for t in range(trials):
+        inst = gen(rng)
+        if inst is None:
+            continue
+        n, rows, rhs, lin, x_l, x_u, x0 = inst
+        m = len(rows)
+        d = Path(tempfile.mkdtemp(prefix="adv_agg_"))
+        try:
+            write_nl(d / "m.nl", n, rows, rhs, lin, x_l, x_u, x0)
+
+            off = run(d, ["qp_presolve=no"])
+            if "Optimal Solution Found" not in off.stdout:
+                continue  # baseline could not solve it; not this pass's business
+            lam_off, x_off = read_sol(d / "m.sol", n, m)
+            sign = infer_sign(x_off, lam_off, rows, lin, x_l, x_u)
+            if sign is None:
+                # The baseline itself is not cleanly stationary (a degenerate
+                # draw); it cannot establish the convention, so this instance
+                # has nothing to say about the reduction.
+                continue
+
+            on = run(d, [])
+            checked += 1
+            if "aggregated 0" not in on.stdout and "Presolve:" in on.stdout:
+                reduced_any += 1
+            if "Optimal Solution Found" not in on.stdout:
+                bad.append((t, "presolved solve did not reach optimality", on.stdout[-400:]))
+                continue
+            lam_on, x_on = read_sol(d / "m.sol", n, m)
+
+            # --- oracle 1: independent KKT / feasibility check vs the .nl ---
+            v = subprocess.run(
+                [str(POUNCE), "verify", "m.nl", "m.sol"],
+                cwd=d, capture_output=True, text=True, timeout=120,
+            )
+            if v.returncode != 0 or "VERIFIED" not in v.stdout:
+                bad.append((t, f"pounce verify rejected the presolved solve (rc={v.returncode})",
+                            v.stdout[-700:] + v.stderr[-300:]))
+                continue
+
+            # --- oracle 2: re-evaluate every row here, from the source data ---
+            if len(x_on) != n or len(lam_on) != m:
+                bad.append((t, f".sol shape wrong: {len(x_on)} primals / {len(lam_on)} duals "
+                               f"for an {n}x{m} model", ""))
+                continue
+            fail = None
+            for i, row in enumerate(rows):
+                body = sum(a * x_on[c] for c, a in row)
+                if abs(body - rhs[i]) > 1e-6 * max(1.0, abs(rhs[i])):
+                    fail = f"row {i} violated by {body - rhs[i]:.3e} in the reported point"
+                    break
+            if fail is None:
+                for j in range(n):
+                    lo = -float("inf") if x_l[j] is None else x_l[j]
+                    hi = float("inf") if x_u[j] is None else x_u[j]
+                    if not (lo - 1e-6 <= x_on[j] <= hi + 1e-6):
+                        fail = f"x[{j}]={x_on[j]} outside its declared box [{lo}, {hi}]"
+                        break
+                    if abs(x_on[j] - lo) < 1e-6 or abs(x_on[j] - hi) < 1e-6:
+                        at_bound += 1
+            if fail is None:
+                # --- oracle 3: bound-aware stationarity of the reported duals ---
+                fault = stationarity_fault(x_on, lam_on, rows, lin, x_l, x_u, sign)
+                if fault is not None:
+                    fail = f"presolved duals are not stationary: {fault}"
+            if fail is None:
+                # --- oracle 4: agreement with the un-reduced solve ---
+                f_on, f_off = objective(x_on, lin), objective(x_off, lin)
+                if abs(f_on - f_off) > 1e-5 * max(1.0, abs(f_off)):
+                    fail = f"objective disagrees with the un-presolved solve: {f_on:.8e} vs {f_off:.8e}"
+            if fail is not None:
+                bad.append((t, fail, ""))
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    print(f"instances solved and checked : {checked}")
+    print(f"  where the pass aggregated  : {reduced_any}")
+    print(f"  with a bound active at x*  : {at_bound}")
+    print(f"failures                     : {len(bad)}")
+    for t, why, extra in bad[:8]:
+        print(f"  [{t}] {why}")
+        if extra:
+            print("      " + extra.replace("\n", "\n      ")[:600])
+    print("VERDICT: PASS" if not bad else f"VERDICT: FAIL ({len(bad)} failures)")
+    return 0 if not bad else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2116,7 +2116,8 @@ fn run_convex_qp(
                 if st.reduced_anything() {
                     println!(
                         "Presolve: {} → {} vars, {} → {} rows (fixed {}, \
-                         free-fixed {}, substituted {}, forcing {}, dominated {}, tightened {})",
+                         free-fixed {}, substituted {}, aggregated {}, \
+                         forcing {}, dominated {}, tightened {})",
                         st.orig_vars,
                         st.reduced_vars,
                         st.orig_rows,
@@ -2124,6 +2125,7 @@ fn run_convex_qp(
                         st.fixed_vars,
                         st.free_cols_fixed,
                         st.free_col_singletons,
+                        st.aggregated_vars,
                         st.forcing_rows,
                         st.dominated_cols,
                         st.tightened_bounds,

--- a/crates/pounce-convex/Cargo.toml
+++ b/crates/pounce-convex/Cargo.toml
@@ -19,6 +19,11 @@ pounce-linalg.workspace = true
 # Active-set QP engine, retained for the legacy crossover bridge and its
 # tests. Acyclic: pounce-qp depends only on pounce-linalg/linsol/common/feral.
 pounce-qp.workspace = true
+# The linear-equality elimination planner and its reverse-sweep dual
+# recovery, shared with the NLP presolve rather than restated here for the
+# convex path (gh #494). Acyclic: pounce-presolve depends only on
+# pounce-nlp / pounce-common, neither of which reaches pounce-convex.
+pounce-presolve.workspace = true
 # feral's unsymmetric sparse LU (factor / ftran / btran / column update) is the
 # basis engine for the revised-simplex LP crossover (`simplex.rs`). Already a
 # transitive workspace dependency via pounce-qp, so no new external crate.

--- a/crates/pounce-convex/src/aggregate.rs
+++ b/crates/pounce-convex/src/aggregate.rs
@@ -1,0 +1,800 @@
+//! **Doubleton-equality aggregation** for the convex presolve (gh #494).
+//!
+//! [`crate::presolve`]'s catalog could fix a variable from a *singleton*
+//! equality row and substitute out a *free column singleton*, but had no
+//! reduction for the row that carries a flowsheet: `a₁·x + a₂·y = b`
+//! linking two otherwise-free interior variables, with no anchoring
+//! requirement on either. That is the arc equality, the `Reference` alias,
+//! the unit-conversion link. This module adds it.
+//!
+//! # Sharing the planner, not the wrapper
+//!
+//! The *which variables can go* half is not restated here.
+//! [`pounce_presolve::linear_eq_plan`] already decides it for the general
+//! NLP path (Phase 6, gh #487), and its [`PlanInput`] is pure data —
+//! per-row `(col, coeff)` lists, right-hand sides, an eligibility mask and
+//! a box. No TNLP appears in it. So the convex path feeds its `QpProblem`
+//! equality rows straight in and inherits, for free:
+//!
+//! - the fixed-point iteration over the three shapes (equal bounds,
+//!   singleton row, two-variable row), so alias *chains* collapse;
+//! - the union-by-size pivot tie-break that keeps those chains shallow;
+//! - the fail-closed posture — a contradictory system, or one that removes
+//!   every column, returns the identity plan and this pass does nothing.
+//!
+//! What is written here is the convex half: applying `x = M·y + d` to
+//! `P`, `c`, `A`, `G`, and the postsolve in `(y, z)` conventions.
+//!
+//! # Convexity survives
+//!
+//! The substitution is a congruence, `P' = Mᵀ P M`, so `P ⪰ 0 ⇒ P' ⪰ 0`.
+//! The reduced problem is convex whenever the original was, and the LP/QP
+//! classification made upstream stays true of what the solver receives.
+//! (Pinned by `presolve_aggregation.rs`, not assumed.)
+//!
+//! # The dual, and where a bound multiplier lands
+//!
+//! Row multipliers come from [`recover_dropped_multipliers`] — the same
+//! reverse triangular sweep the NLP path uses, in the same `∇f + Jᵀλ − z_l
+//! + z_u = 0` convention `crate::presolve` already works in. Only the row
+//! block differs: the plan consumes *equality* rows, so `Gᵀz` is folded
+//! into the gradient the sweep is handed rather than resolved by it.
+//!
+//! Bound multipliers need one step the NLP path skips. Planning transfers
+//! an eliminated variable's box onto its survivor, so a reduced solve
+//! reports the *survivor* carrying a bound force that, in the original
+//! problem, belongs to the eliminated variable — and may name a bound the
+//! survivor does not even have (gh #493 documents this attribution for the
+//! NLP path, where full-space stationarity still holds because the
+//! survivor's own bound multiplier absorbs it). That is not available
+//! here: [`crate::presolve`]'s contract is a valid KKT point of the
+//! *original* problem, and a multiplier on a bound the original does not
+//! declare is not one. So the leftover reduced cost at each survivor is
+//! re-attributed to whichever cluster member is actually sitting on its
+//! own declared bound, and the sweep is re-run with that force in place.
+//! See [`postsolve`].
+//!
+//! That step is for **library callers**, and it is worth saying which,
+//! because the answer is not the obvious one. The CLI's `.nl` extractor
+//! lowers every variable bound to a row of `G`, so a model arriving that
+//! way reaches this pass with an *empty box* — nothing to transfer, and
+//! each bound's force lands on an ordinary inequality multiplier the sweep
+//! already accounts for. A box gets here only from a caller who builds a
+//! `QpProblem` with `lb`/`ub` directly (`pounce-py`, the batch API, an
+//! embedder), or from [`crate::presolve`]'s own bound tightening. The
+//! adversary run for gh #494 measured this rather than guessing at it: 0
+//! of 114 `.nl` instances reached the re-attribution, against 19 of 400
+//! library-level draws in `tests/presolve_aggregation.rs`.
+
+use std::collections::HashMap;
+
+use pounce_common::types::{Index, lower_bound_present, upper_bound_present};
+use pounce_presolve::linear_eq_elim::recover_dropped_multipliers;
+use pounce_presolve::linear_eq_plan::{
+    EliminationPlan, PlanConfig, PlanInput, VarRecovery, build_plan,
+};
+
+use crate::presolve::{ACTIVE_BOUND_TOL, group_by_row, merge_sort_coeffs};
+use crate::qp::{BOUND_INF, QpProblem, QpSolution, Triplet};
+
+/// A survivor's leftover reduced cost below this is noise, not a bound
+/// force worth re-attributing.
+const LEFTOVER_TOL: f64 = 1e-12;
+
+/// Plan the aggregation for `prob`, or `None` when there is nothing to do.
+///
+/// Only the equality block is offered to the planner: an inequality row
+/// determines nothing, and handing one over as a candidate would let it be
+/// consumed as though it did.
+pub(crate) fn plan(prob: &QpProblem) -> Option<EliminationPlan> {
+    let n = prob.n;
+    let m_eq = prob.m_eq();
+    if n == 0 || m_eq == 0 {
+        return None;
+    }
+
+    // The two crates spell "absent bound" differently: `pounce-convex`
+    // calls a bound absent past ±1e20, the planner past ±1e19. A declared
+    // bound landing in that band is *present* here and *absent* there, so
+    // the planner would drop it from the box it transfers and hand back a
+    // reduced problem with a larger feasible set than the original. Rather
+    // than lose a constraint, decline the pass outright — the band is far
+    // outside anything a real model carries, so this costs nothing real.
+    let mut x_l = Vec::with_capacity(n);
+    let mut x_u = Vec::with_capacity(n);
+    for j in 0..n {
+        let lo = prob.lb_of(j);
+        let hi = prob.ub_of(j);
+        if (lo > -BOUND_INF) != lower_bound_present(lo) {
+            return None;
+        }
+        if (hi < BOUND_INF) != upper_bound_present(hi) {
+            return None;
+        }
+        x_l.push(if lo > -BOUND_INF {
+            lo
+        } else {
+            f64::NEG_INFINITY
+        });
+        x_u.push(if hi < BOUND_INF { hi } else { f64::INFINITY });
+    }
+
+    let rows = group_by_row(&prob.a, m_eq);
+    // `QpProblem` equalities read `Σ a_j x_j = b` exactly; there is no
+    // separate row constant to fold (the `.nl` path's gh #492 hazard does
+    // not arise on this side, where extraction already folded it into `b`).
+    let row_const = vec![0.0; m_eq];
+    let eligible = vec![true; m_eq];
+    let input = PlanInput {
+        n_vars: n,
+        n_rows: m_eq,
+        rows: &rows,
+        row_const: &row_const,
+        g_l: &prob.b,
+        g_u: &prob.b,
+        eligible: &eligible,
+        x_l: &x_l,
+        x_u: &x_u,
+    };
+    let plan = build_plan(&input, &PlanConfig::default());
+    // `build_plan` returns the identity both when it found nothing and when
+    // it stood down (a contradiction, or every column removed). Either way
+    // there is no reduction to apply, and the model goes on untouched.
+    if plan.is_identity() {
+        return None;
+    }
+    Some(plan)
+}
+
+/// How one original column reads in the reduced space:
+/// `x_j = mult · y[rep] + shift`, with `rep` a *reduced* column index.
+struct ColMap {
+    /// `None` for a column the plan pinned to a constant.
+    rep: Option<usize>,
+    mult: f64,
+    shift: f64,
+}
+
+fn col_maps(plan: &EliminationPlan) -> Option<Vec<ColMap>> {
+    let mut reduced_of = vec![usize::MAX; plan.n_full];
+    for (red, &full) in plan.vars_kept.iter().enumerate() {
+        reduced_of[full] = red;
+    }
+    let mut out = Vec::with_capacity(plan.n_full);
+    for rec in &plan.recovery {
+        out.push(match *rec {
+            VarRecovery::Kept(red) => ColMap {
+                rep: Some(red),
+                mult: 1.0,
+                shift: 0.0,
+            },
+            VarRecovery::Constant(c) => ColMap {
+                rep: None,
+                mult: 0.0,
+                shift: c,
+            },
+            VarRecovery::Affine { rep, coeff, offset } => {
+                // The planner guarantees `rep` is a survivor; refuse the
+                // whole reduction rather than trust it silently.
+                let red = *reduced_of.get(rep)?;
+                if red == usize::MAX {
+                    return None;
+                }
+                ColMap {
+                    rep: Some(red),
+                    mult: coeff,
+                    shift: offset,
+                }
+            }
+        });
+    }
+    Some(out)
+}
+
+/// Apply the plan's affine map to `P`, `c`, `A`, `G` and the bounds,
+/// returning the reduced problem and the constant it moves into the
+/// objective.
+pub(crate) fn reduce(prob: &QpProblem, plan: &EliminationPlan) -> Option<(QpProblem, f64)> {
+    let maps = col_maps(plan)?;
+    let k = plan.n_reduced_vars();
+    let mut new_c = vec![0.0; k];
+    let mut offset = 0.0;
+
+    // --- objective: 0.5 xᵀPx + cᵀx under x = M y + d ---
+    // `p_lower` holds the lower triangle, so a diagonal entry `v` means the
+    // term `0.5·v·x_i²` and an off-diagonal entry means `v·x_i·x_j` (both
+    // halves at once). Both shapes are expanded below in those terms, so
+    // the emitted triangle carries the same convention back.
+    let mut pacc: HashMap<(usize, usize), f64> = HashMap::new();
+    {
+        let mut add_p = |i: usize, j: usize, v: f64| {
+            let key = if i >= j { (i, j) } else { (j, i) };
+            *pacc.entry(key).or_insert(0.0) += v;
+        };
+        for t in &prob.p_lower {
+            if t.val == 0.0 {
+                continue;
+            }
+            let v = t.val;
+            let (a, b) = (&maps[t.row], &maps[t.col]);
+            if t.row == t.col {
+                // 0.5·v·(m·y + s)² = 0.5·(v m²)·y² + (v m s)·y + 0.5·v s².
+                if let Some(p) = a.rep {
+                    if a.mult != 0.0 {
+                        add_p(p, p, v * a.mult * a.mult);
+                    }
+                    new_c[p] += v * a.mult * a.shift;
+                }
+                offset += 0.5 * v * a.shift * a.shift;
+            } else {
+                // v·(mᵢy_p + sᵢ)(mⱼy_q + s_j).
+                if let (Some(p), Some(q)) = (a.rep, b.rep) {
+                    let coef = v * a.mult * b.mult;
+                    if coef != 0.0 {
+                        if p == q {
+                            // Both columns folded onto the *same* survivor,
+                            // so an off-diagonal term became a diagonal one:
+                            // `coef·y²` is `0.5·(2·coef)·y²` in the stored
+                            // convention.
+                            add_p(p, p, 2.0 * coef);
+                        } else {
+                            add_p(p, q, coef);
+                        }
+                    }
+                }
+                if let Some(p) = a.rep {
+                    new_c[p] += v * a.mult * b.shift;
+                }
+                if let Some(q) = b.rep {
+                    new_c[q] += v * b.mult * a.shift;
+                }
+                offset += v * a.shift * b.shift;
+            }
+        }
+    }
+    for j in 0..prob.n {
+        let cj = prob.c[j];
+        if cj == 0.0 {
+            continue;
+        }
+        let m = &maps[j];
+        if let Some(p) = m.rep {
+            new_c[p] += cj * m.mult;
+        }
+        offset += cj * m.shift;
+    }
+    let mut new_p: Vec<Triplet> = pacc
+        .into_iter()
+        .filter(|&(_, v)| v != 0.0)
+        .map(|((i, j), v)| Triplet::new(i, j, v))
+        .collect();
+    // `HashMap` iteration order is unspecified; sort so the reduced problem
+    // is a deterministic function of its input (the IPM's pivot order, and
+    // therefore its iterate trace, would otherwise vary run to run).
+    new_p.sort_by_key(|t| (t.row, t.col));
+
+    // --- rows ---
+    let substitute = |entries: &[(usize, f64)], rhs0: f64| -> (Vec<(usize, f64)>, f64) {
+        let mut coeffs: Vec<(usize, f64)> = Vec::with_capacity(entries.len());
+        let mut rhs = rhs0;
+        for &(col, a) in entries {
+            let m = &maps[col];
+            if let Some(p) = m.rep {
+                if m.mult != 0.0 {
+                    coeffs.push((p, a * m.mult));
+                }
+            }
+            rhs -= a * m.shift;
+        }
+        merge_sort_coeffs(&mut coeffs);
+        (coeffs, rhs)
+    };
+
+    let a_by_row = group_by_row(&prob.a, prob.m_eq());
+    let mut new_a = Vec::new();
+    let mut new_b = Vec::with_capacity(plan.rows_kept.len());
+    for (newr, &r) in plan.rows_kept.iter().enumerate() {
+        let (coeffs, rhs) = substitute(&a_by_row[r], prob.b[r]);
+        new_b.push(rhs);
+        for (c, v) in coeffs {
+            new_a.push(Triplet::new(newr, c, v));
+        }
+    }
+    // Every inequality row survives: the plan is offered the equalities
+    // only, so it consumes none of them and their order is unchanged.
+    let g_by_row = group_by_row(&prob.g, prob.m_ineq());
+    let mut new_g = Vec::new();
+    let mut new_h = Vec::with_capacity(prob.m_ineq());
+    for (r, entries) in g_by_row.iter().enumerate() {
+        let (coeffs, rhs) = substitute(entries, prob.h[r]);
+        new_h.push(rhs);
+        for (c, v) in coeffs {
+            new_g.push(Triplet::new(r, c, v));
+        }
+    }
+
+    // --- box: the planner's reduced box already carries every bound
+    // transferred off an eliminated column ---
+    let need_bounds = plan.x_l_red.iter().any(|&v| v > -BOUND_INF && !v.is_nan())
+        || plan.x_u_red.iter().any(|&v| v < BOUND_INF && !v.is_nan());
+    let (new_lb, new_ub) = if need_bounds {
+        (plan.x_l_red.clone(), plan.x_u_red.clone())
+    } else {
+        (Vec::new(), Vec::new())
+    };
+
+    Some((
+        QpProblem {
+            n: k,
+            p_lower: new_p,
+            c: new_c,
+            a: new_a,
+            b: new_b,
+            g: new_g,
+            h: new_h,
+            lb: new_lb,
+            ub: new_ub,
+        },
+        offset,
+    ))
+}
+
+/// Jacobian of the equality block in the triplet form the shared sweep
+/// wants.
+struct EqTriplets {
+    irow: Vec<Index>,
+    jcol: Vec<Index>,
+    vals: Vec<f64>,
+}
+
+impl EqTriplets {
+    fn of(prob: &QpProblem) -> Self {
+        Self {
+            irow: prob.a.iter().map(|t| t.row as Index).collect(),
+            jcol: prob.a.iter().map(|t| t.col as Index).collect(),
+            vals: prob.a.iter().map(|t| t.val).collect(),
+        }
+    }
+}
+
+/// Is `x_j` sitting on a declared bound of `orig`? Returns `(at_lb, at_ub)`.
+fn on_bounds(orig: &QpProblem, x: &[f64], j: usize) -> (bool, bool) {
+    let lb = orig.lb_of(j);
+    let ub = orig.ub_of(j);
+    (
+        lb > -BOUND_INF && (x[j] - lb).abs() <= ACTIVE_BOUND_TOL,
+        ub < BOUND_INF && (ub - x[j]).abs() <= ACTIVE_BOUND_TOL,
+    )
+}
+
+/// Expand a reduced solution back to `orig`'s space.
+///
+/// Primal is the plan's own lift. Duals are recovered in three moves:
+///
+/// 1. **A first sweep** with no bound forces at all. It sets every consumed
+///    row's multiplier so that stationarity holds exactly at each
+///    *eliminated* column, which leaves each survivor holding its cluster's
+///    entire reduced cost.
+/// 2. **Attribution.** A survivor's leftover is a real bound force. If the
+///    survivor is itself on one of its own declared bounds, it keeps it —
+///    the same answer a solve without this pass would give. Otherwise the
+///    bound was *transferred* during planning, and the force belongs to
+///    whichever eliminated cluster member is on its own declared bound:
+///    with `x_j = α·x_rep + β`, a multiplier `μ` there enters the
+///    survivor's equation as `α·μ`, so `μ = leftover/α` (signs pick which
+///    of the two bounds it is).
+/// 3. **A second sweep**, with those multipliers in the gradient, so the
+///    row multipliers are consistent with where the force ended up. Then
+///    each survivor's own bound multiplier is read off the final reduced
+///    cost by complementarity, exactly as `Presolve::postsolve_once` does.
+///
+/// Step 2 is what the NLP path (gh #493) does not do, and does not need to:
+/// there the survivor's bound multiplier absorbs the transferred force and
+/// full-space stationarity still holds. Here the contract is a valid KKT
+/// point of the original problem, and a nonzero multiplier on a bound the
+/// original never declared would not be one.
+pub(crate) fn postsolve(orig: &QpProblem, plan: &EliminationPlan, red: &QpSolution) -> QpSolution {
+    let n = orig.n;
+    let m_eq = orig.m_eq();
+    let m_ineq = orig.m_ineq();
+
+    let mut x = vec![0.0; n];
+    plan.lift_x(&red.x, &mut x);
+
+    // Inequality rows pass through one-for-one.
+    let mut z = vec![0.0; m_ineq];
+    for (i, slot) in z.iter_mut().enumerate() {
+        *slot = red.z.get(i).copied().unwrap_or(0.0);
+    }
+    let mut y_kept = vec![0.0; m_eq];
+    for (newr, &oldr) in plan.rows_kept.iter().enumerate() {
+        y_kept[oldr] = red.y.get(newr).copied().unwrap_or(0.0);
+    }
+
+    // Everything acting on a column that the sweep does *not* resolve:
+    // the objective gradient and the inequality block. `Aᵀy` is added
+    // inside the sweep, from `y` (kept rows filled, consumed rows zero).
+    let mut base = orig.c.clone();
+    orig.p_mul(&x, &mut base);
+    orig.gt_mul(&z, &mut base);
+
+    let jac = EqTriplets::of(orig);
+    let mut y = y_kept.clone();
+    recover_dropped_multipliers(plan, &base, &jac.irow, &jac.jcol, &jac.vals, false, &mut y);
+
+    let mut grad = base.clone();
+    orig.at_mul(&y, &mut grad);
+
+    // --- attribute each survivor's leftover ---
+    let mut z_lb = vec![0.0; n];
+    let mut z_ub = vec![0.0; n];
+    let mut moved = false;
+    for &rep in &plan.vars_kept {
+        let leftover = grad[rep];
+        if leftover.abs() <= LEFTOVER_TOL {
+            continue;
+        }
+        let (rep_at_lb, rep_at_ub) = on_bounds(orig, &x, rep);
+        if (rep_at_lb && leftover > 0.0) || (rep_at_ub && leftover < 0.0) {
+            // The survivor's own declared bound carries it; leave it to the
+            // complementarity pass below.
+            continue;
+        }
+        for (j, rec) in plan.recovery.iter().enumerate() {
+            let VarRecovery::Affine { rep: r, coeff, .. } = *rec else {
+                continue;
+            };
+            if r != rep || coeff == 0.0 {
+                continue;
+            }
+            let mu = leftover / coeff;
+            let (at_lb, at_ub) = on_bounds(orig, &x, j);
+            if at_lb && mu > 0.0 {
+                z_lb[j] = mu;
+            } else if at_ub && mu < 0.0 {
+                z_ub[j] = -mu;
+            } else {
+                continue;
+            }
+            moved = true;
+            break;
+        }
+    }
+
+    if moved {
+        let mut shifted = base.clone();
+        for i in 0..n {
+            shifted[i] += z_ub[i] - z_lb[i];
+        }
+        y = y_kept;
+        recover_dropped_multipliers(
+            plan, &shifted, &jac.irow, &jac.jcol, &jac.vals, false, &mut y,
+        );
+        grad = base.clone();
+        orig.at_mul(&y, &mut grad);
+    }
+
+    // Survivors read their own bound multipliers off the final reduced cost
+    // by complementarity against their *declared* box. Eliminated columns
+    // keep what step 2 gave them (zero, unless they were the owner) — the
+    // sweep made their stationarity hold with exactly that.
+    for &rep in &plan.vars_kept {
+        let (at_lb, at_ub) = on_bounds(orig, &x, rep);
+        if at_lb && grad[rep] > 0.0 {
+            z_lb[rep] = grad[rep];
+        } else if at_ub && grad[rep] < 0.0 {
+            z_ub[rep] = -grad[rep];
+        }
+    }
+
+    let mut px = vec![0.0; n];
+    orig.p_mul(&x, &mut px);
+    let mut obj = 0.0;
+    for i in 0..n {
+        obj += 0.5 * x[i] * px[i] + orig.c[i] * x[i];
+    }
+
+    QpSolution {
+        status: red.status,
+        x,
+        y,
+        z,
+        z_lb,
+        z_ub,
+        obj,
+        iters: red.iters,
+        iterates: red.iterates.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `0.5 xᵀPx + cᵀx`, from the stored lower triangle.
+    fn objective(prob: &QpProblem, x: &[f64]) -> f64 {
+        let mut px = vec![0.0; prob.n];
+        prob.p_mul(x, &mut px);
+        (0..prob.n)
+            .map(|i| 0.5 * x[i] * px[i] + prob.c[i] * x[i])
+            .sum()
+    }
+
+    fn row_activities(triplets: &[Triplet], m: usize, x: &[f64]) -> Vec<f64> {
+        let mut out = vec![0.0; m];
+        for t in triplets {
+            out[t.row] += t.val * x[t.col];
+        }
+        out
+    }
+
+    /// The reduction must be an *identity on the objective and the rows*:
+    /// pushing any reduced point through the lift and evaluating in the
+    /// original space has to agree, term for term, with evaluating the
+    /// reduced problem directly. This is the check that bites when the
+    /// Hessian congruence, the shifted linear term or the moved constant
+    /// is wrong — none of which a solve-and-compare notices, because a
+    /// wrong-but-self-consistent reduced problem still converges.
+    fn assert_faithful(prob: &QpProblem, plan: &EliminationPlan, reduced: &QpProblem, off: f64) {
+        // A handful of arbitrary reduced points, including a non-symmetric
+        // one so a dropped cross term cannot cancel.
+        for seed in 0..5 {
+            let y: Vec<f64> = (0..reduced.n)
+                .map(|i| 0.5 + 0.75 * ((i + seed) as f64) - 0.3 * (seed as f64))
+                .collect();
+            let mut x = vec![0.0; prob.n];
+            plan.lift_x(&y, &mut x);
+
+            let full = objective(prob, &x);
+            let red = objective(reduced, &y) + off;
+            assert!(
+                (full - red).abs() <= 1e-9 * (1.0 + full.abs()),
+                "objective seed {seed}: full {full} vs reduced {red}"
+            );
+
+            let ax = row_activities(&prob.a, prob.m_eq(), &x);
+            let ay = row_activities(&reduced.a, reduced.m_eq(), &y);
+            for (newr, &oldr) in plan.rows_kept.iter().enumerate() {
+                let full_slack = ax[oldr] - prob.b[oldr];
+                let red_slack = ay[newr] - reduced.b[newr];
+                assert!(
+                    (full_slack - red_slack).abs() <= 1e-9 * (1.0 + full_slack.abs()),
+                    "eq row {oldr}→{newr} seed {seed}: {full_slack} vs {red_slack}"
+                );
+            }
+            let gx = row_activities(&prob.g, prob.m_ineq(), &x);
+            let gy = row_activities(&reduced.g, reduced.m_ineq(), &y);
+            for r in 0..prob.m_ineq() {
+                let full_slack = gx[r] - prob.h[r];
+                let red_slack = gy[r] - reduced.h[r];
+                assert!(
+                    (full_slack - red_slack).abs() <= 1e-9 * (1.0 + full_slack.abs()),
+                    "ineq row {r} seed {seed}: {full_slack} vs {red_slack}"
+                );
+            }
+            // The lift must also *satisfy* every row the plan consumed —
+            // that is the whole claim those rows were dropped on.
+            for step in &plan.steps {
+                let resid = ax[step.row] - prob.b[step.row];
+                assert!(
+                    resid.abs() <= 1e-9 * (1.0 + prob.b[step.row].abs()),
+                    "consumed row {} seed {seed} residual {resid}",
+                    step.row
+                );
+            }
+        }
+    }
+
+    fn planned(prob: &QpProblem) -> (EliminationPlan, QpProblem, f64) {
+        let plan = plan(prob).expect("a plan");
+        let (reduced, off) = reduce(prob, &plan).expect("a reduction");
+        assert_faithful(prob, &plan, &reduced, off);
+        (plan, reduced, off)
+    }
+
+    /// A plain alias `x0 − x1 = 0` collapses two columns to one.
+    #[test]
+    fn alias_pair_collapses() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 2.0)],
+            c: vec![1.0, 3.0],
+            a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -1.0)],
+            b: vec![0.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let (_, reduced, _) = planned(&prob);
+        assert_eq!(reduced.n, 1);
+        assert_eq!(reduced.m_eq(), 0);
+        // Both costs land on the survivor.
+        assert!((reduced.c[0] - 4.0).abs() < 1e-12, "{:?}", reduced.c);
+    }
+
+    /// Both signs of the aggregation coefficient, and a non-zero offset:
+    /// `x0 = α·x1 + β` for α of either sign must reproduce the objective.
+    #[test]
+    fn both_signs_and_an_offset() {
+        for a1 in [2.0_f64, -2.0] {
+            let prob = QpProblem {
+                n: 2,
+                p_lower: vec![Triplet::new(0, 0, 4.0), Triplet::new(1, 1, 1.0)],
+                c: vec![-1.0, 2.0],
+                a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, a1)],
+                b: vec![3.0],
+                g: vec![],
+                h: vec![],
+                lb: vec![],
+                ub: vec![],
+            };
+            let (_, reduced, _) = planned(&prob);
+            assert_eq!(reduced.n, 1, "a1 = {a1}");
+        }
+    }
+
+    /// A row the plan *keeps* whose columns include an eliminated one must
+    /// have that column's affine offset moved into its right-hand side.
+    ///
+    /// This shape is the one a derivative check is blind to: the reduced
+    /// row's coefficients are right either way, since `∂(αy + β)/∂y = α`
+    /// regardless of `β`. Only re-evaluating the row at a lifted point sees
+    /// the missing constant — which is exactly what `assert_faithful` does.
+    #[test]
+    fn a_surviving_row_carries_the_substitution_offset() {
+        let prob = QpProblem {
+            n: 4,
+            p_lower: (0..4).map(|i| Triplet::new(i, i, 2.0)).collect(),
+            c: vec![1.0, -1.0, 0.5, 0.25],
+            a: vec![
+                // x0 − 2·x1 = 3  ⇒  one of the pair becomes affine in the
+                // other with a non-zero offset.
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(0, 1, -2.0),
+                // Three distinct clusters, so this row survives and has to
+                // absorb that offset into its right-hand side.
+                Triplet::new(1, 0, 1.0),
+                Triplet::new(1, 2, 1.0),
+                Triplet::new(1, 3, 1.0),
+            ],
+            b: vec![3.0, 5.0],
+            g: vec![
+                Triplet::new(0, 1, 1.0),
+                Triplet::new(0, 2, -1.0),
+                Triplet::new(0, 3, 2.0),
+            ],
+            h: vec![4.0],
+            lb: vec![],
+            ub: vec![],
+        };
+        let (plan, reduced, _) = planned(&prob);
+        assert_eq!(reduced.n, 3);
+        assert_eq!(plan.rows_kept.len(), 1);
+        assert_eq!(
+            reduced.m_ineq(),
+            1,
+            "the inequality is rewritten, not dropped"
+        );
+    }
+
+    /// Two columns folded onto the *same* survivor turn an off-diagonal
+    /// Hessian entry into a diagonal one. The stored triangle counts an
+    /// off-diagonal twice and a diagonal once, so this needs the ×2 that
+    /// `reduce` applies — without it the reduced objective is off by a
+    /// factor of two in exactly this shape.
+    #[test]
+    fn two_columns_onto_one_survivor_fold_the_cross_term() {
+        let prob = QpProblem {
+            n: 3,
+            p_lower: vec![
+                Triplet::new(0, 0, 2.0),
+                Triplet::new(1, 0, 3.0), // cross term x0·x1
+                Triplet::new(1, 1, 2.0),
+            ],
+            c: vec![1.0, 1.0, 1.0],
+            a: vec![
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(0, 2, -1.0), // x0 = x2
+                Triplet::new(1, 1, 1.0),
+                Triplet::new(1, 2, -2.0), // x1 = 2·x2
+            ],
+            b: vec![0.0, 0.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let (_, reduced, _) = planned(&prob);
+        assert_eq!(reduced.n, 1);
+    }
+
+    /// A contradictory alias system stands the whole pass down rather than
+    /// declaring the model infeasible from inside an elimination pass.
+    #[test]
+    fn contradiction_abandons_the_plan() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![],
+            c: vec![1.0, 1.0],
+            a: vec![
+                Triplet::new(0, 0, 1.0),
+                Triplet::new(0, 1, -1.0), // x0 − x1 = 0
+                Triplet::new(1, 0, 1.0),
+                Triplet::new(1, 1, -1.0), // x0 − x1 = 1
+            ],
+            b: vec![0.0, 1.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        assert!(plan(&prob).is_none());
+    }
+
+    /// A model whose every column would go is handed back untouched: the
+    /// planner refuses to produce a problem with no degrees of freedom.
+    #[test]
+    fn removing_every_column_abandons_the_plan() {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![1.0],
+            a: vec![Triplet::new(0, 0, 1.0)],
+            b: vec![2.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        assert!(plan(&prob).is_none());
+    }
+
+    /// A bound in the band where the two crates disagree about "absent"
+    /// declines the pass rather than silently widening the feasible set.
+    #[test]
+    fn ambiguous_bound_sentinel_declines() {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![],
+            c: vec![1.0, 1.0],
+            a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -1.0)],
+            b: vec![0.0],
+            g: vec![],
+            h: vec![],
+            // Present to `pounce-convex` (> −1e20), absent to the planner
+            // (≤ −1e19).
+            lb: vec![-5e19, f64::NEG_INFINITY],
+            ub: vec![f64::INFINITY, f64::INFINITY],
+        };
+        assert!(plan(&prob).is_none());
+    }
+
+    /// An eliminated column's box is transferred onto its survivor, and
+    /// the transfer follows the sign of α.
+    #[test]
+    fn the_box_moves_with_the_column() {
+        // x0 = −x1, x0 ∈ [1, 4] ⇒ x1 ∈ [−4, −1].
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(1, 1, 2.0)],
+            c: vec![0.0, 0.0],
+            a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            b: vec![0.0],
+            g: vec![],
+            h: vec![],
+            lb: vec![1.0, f64::NEG_INFINITY],
+            ub: vec![4.0, f64::INFINITY],
+        };
+        let (plan, reduced, _) = planned(&prob);
+        assert_eq!(reduced.n, 1);
+        let survivor = plan.vars_kept[0];
+        let (lo, hi) = if survivor == 1 {
+            (-4.0, -1.0)
+        } else {
+            (1.0, 4.0)
+        };
+        assert!((reduced.lb_of(0) - lo).abs() < 1e-12, "{:?}", reduced.lb);
+        assert!((reduced.ub_of(0) - hi).abs() < 1e-12, "{:?}", reduced.ub);
+    }
+}

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -24,6 +24,7 @@
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
 pub mod active_set;
+pub(crate) mod aggregate;
 pub mod batch;
 pub mod cones;
 pub mod crossover;

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -240,6 +240,23 @@ enum Reduction {
         /// Tightened the upper bound? (else lower.)
         is_upper: bool,
     },
+    /// **Doubleton-equality aggregation** (gh #494): a batch of two-variable
+    /// equality rows `a₁·x + a₂·y = b`, each folding one of its columns onto
+    /// the other as `x = α·y + β` with no anchoring requirement, iterated to
+    /// a fixed point so alias chains collapse. Planned by
+    /// [`pounce_presolve::linear_eq_plan`] — shared with the general NLP
+    /// path rather than restated — and applied to `P`, `c`, `A`, `G` by
+    /// `crate::aggregate::reduce`.
+    ///
+    /// Unlike every other variant this one is a whole pass, not a single
+    /// elimination: the plan's chains and its reverse-sweep dual recovery
+    /// are only meaningful together. So an aggregation always forms a
+    /// **layer of its own** in `Presolve::chain` whose stack is exactly
+    /// this one entry, and `Presolve::postsolve_once` hands that layer
+    /// straight to `crate::aggregate::postsolve`.
+    Aggregate {
+        plan: Box<pounce_presolve::linear_eq_plan::EliminationPlan>,
+    },
 }
 
 /// Captured presolve state: the reduced problem plus the transaction
@@ -282,10 +299,10 @@ const ACTIVITY_TOL: f64 = 1e-9;
 /// recovering bound multipliers. Looser than [`BOUND_FEAS_TOL`] because an
 /// interior-point solve only drives a variable to within ~1e-8 of a bound,
 /// not to machine zero; interior variables sit far further away.
-const ACTIVE_BOUND_TOL: f64 = 1e-6;
+pub(crate) const ACTIVE_BOUND_TOL: f64 = 1e-6;
 
 /// Group nonzero entries by row index: `out[row] = [(col, val), …]`.
-fn group_by_row(triplets: &[Triplet], m: usize) -> Vec<Vec<(usize, f64)>> {
+pub(crate) fn group_by_row(triplets: &[Triplet], m: usize) -> Vec<Vec<(usize, f64)>> {
     let mut out = vec![Vec::new(); m];
     for t in triplets {
         if t.val != ZERO_TOL {
@@ -333,33 +350,63 @@ struct Row {
 /// transform, so the iterate is the composition of the per-pass transforms
 /// — postsolve folds them back in reverse — and inherits each pass's proven
 /// dual recovery with no new dual math.
+///
+/// Each round is the single-pass catalog ([`presolve_once`]) followed by a
+/// doubleton-equality aggregation ([`aggregate_once`], gh #494), which is
+/// its own layer because its plan and dual recovery are only meaningful as
+/// a unit. Both feed the same fixpoint: an aggregation can expose a
+/// singleton the catalog then fixes, and a fixing can turn a three-term row
+/// into a doubleton the next aggregation folds away.
 pub fn presolve(prob: &QpProblem) -> PresolveOutcome {
-    // Cap rounds defensively; in practice it converges in a few.
+    // Cap layers defensively; in practice it converges in a few. A round
+    // can contribute two (the catalog pass and an aggregation), so this is
+    // a bound on layers, not on rounds.
     const MAX_ROUNDS: usize = 32;
     let mut chain: Vec<Presolve> = Vec::new();
     let mut current = prob.clone();
+    // The passthrough layer from a first round that changed nothing, kept
+    // so a no-op presolve still returns a usable handle.
+    let mut passthrough: Option<Presolve> = None;
     loop {
-        match presolve_once(&current, &[]) {
+        let ps = match presolve_once(&current, &[]) {
             PresolveOutcome::Infeasible => return PresolveOutcome::Infeasible,
             PresolveOutcome::Unbounded => return PresolveOutcome::Unbounded,
-            PresolveOutcome::Reduced(ps) => {
-                if !ps.changed() {
-                    // Fixpoint: this round did nothing.
-                    if chain.is_empty() {
-                        return PresolveOutcome::Reduced(ps); // plain single pass
-                    }
-                    break;
-                }
+            PresolveOutcome::Reduced(ps) => ps,
+        };
+        let catalog_changed = ps.changed();
+        if catalog_changed {
+            current = ps.reduced.clone();
+            chain.push(ps);
+        } else if passthrough.is_none() {
+            passthrough = Some(ps);
+        }
+        // Doubleton-equality aggregation (gh #494). It runs *after* the
+        // catalog each round, so the cheap single-column reductions have
+        // already shrunk the rows it plans over, and the round that follows
+        // gets a crack at whatever the aggregation exposes.
+        let aggregated = match aggregate_once(&current) {
+            Some(ps) => {
                 current = ps.reduced.clone();
                 chain.push(ps);
-                if chain.len() >= MAX_ROUNDS {
-                    break;
-                }
+                true
             }
+            None => false,
+        };
+        if !catalog_changed && !aggregated {
+            break; // fixpoint: neither half found anything
+        }
+        if chain.len() >= MAX_ROUNDS {
+            break;
         }
     }
+    if chain.is_empty() {
+        // Nothing to do at all; hand back the verbatim-forwarding layer.
+        return PresolveOutcome::Reduced(
+            passthrough.expect("a round that changed nothing yields a passthrough layer"),
+        );
+    }
     if chain.len() == 1 {
-        return PresolveOutcome::Reduced(chain.pop().unwrap());
+        return PresolveOutcome::Reduced(chain.pop().expect("chain has one layer"));
     }
     let reduced = chain.last().expect("chain non-empty").reduced.clone();
     PresolveOutcome::Reduced(Presolve {
@@ -374,6 +421,35 @@ pub fn presolve(prob: &QpProblem) -> PresolveOutcome {
         orig: prob.clone(),
         stack: Vec::new(),
         chain,
+    })
+}
+
+/// One doubleton-equality aggregation layer over `prob`, or `None` when
+/// there is nothing to aggregate (gh #494).
+///
+/// Deliberately reached only from [`presolve`], never from
+/// [`presolve_conic`]: a non-orthant cone block is a coupled, fixed-layout
+/// set of rows over columns the substitution would rewrite, and
+/// [`Presolve::reduced_cones`] reads the surviving partition off the kept
+/// rows. The conic path therefore opts out of this reduction entirely, as
+/// it already does of the fixpoint iteration.
+fn aggregate_once(prob: &QpProblem) -> Option<Presolve> {
+    let plan = crate::aggregate::plan(prob)?;
+    let (reduced, obj_offset) = crate::aggregate::reduce(prob, &plan)?;
+    Some(Presolve {
+        reduced,
+        obj_offset,
+        orig_n: prob.n,
+        orig_m_eq: prob.m_eq(),
+        orig_m_ineq: prob.m_ineq(),
+        kept_cols: plan.vars_kept.clone(),
+        kept_eq: plan.rows_kept.clone(),
+        kept_ineq: (0..prob.m_ineq()).collect(),
+        orig: prob.clone(),
+        stack: vec![Reduction::Aggregate {
+            plan: Box::new(plan),
+        }],
+        chain: Vec::new(),
     })
 }
 
@@ -1247,7 +1323,7 @@ fn build_rows(
 
 /// Sort coefficients by column and merge any duplicate columns (a
 /// variable appearing twice in one row). Drops entries that cancel to 0.
-fn merge_sort_coeffs(coeffs: &mut Vec<(usize, f64)>) {
+pub(crate) fn merge_sort_coeffs(coeffs: &mut Vec<(usize, f64)>) {
     coeffs.sort_by_key(|&(c, _)| c);
     let mut merged: Vec<(usize, f64)> = Vec::with_capacity(coeffs.len());
     for &(c, v) in coeffs.iter() {
@@ -1434,6 +1510,9 @@ pub struct PresolveStats {
     pub dominated_cols: usize,
     /// Variable bounds tightened by domain propagation.
     pub tightened_bounds: usize,
+    /// Variables folded onto another by a two-variable equality row
+    /// (doubleton aggregation). Each also consumes its row.
+    pub aggregated_vars: usize,
 }
 
 impl PresolveStats {
@@ -1516,6 +1595,7 @@ impl Presolve {
             s.forcing_rows += ls.forcing_rows;
             s.dominated_cols += ls.dominated_cols;
             s.tightened_bounds += ls.tightened_bounds;
+            s.aggregated_vars += ls.aggregated_vars;
         }
         s
     }
@@ -1536,6 +1616,14 @@ impl Presolve {
                 Reduction::ForcingRow { .. } => s.forcing_rows += 1,
                 Reduction::DominatedColumn { .. } => s.dominated_cols += 1,
                 Reduction::BoundTightening { .. } => s.tightened_bounds += 1,
+                // A whole pass in one entry: report what its plan achieved.
+                Reduction::Aggregate { plan } => {
+                    s.aggregated_vars += plan.report.n_aggregated_vars;
+                    // A singleton row the aggregation's fixed point reached
+                    // is the same reduction `FixedVar` performs, so it is
+                    // counted in the same column.
+                    s.fixed_vars += plan.report.n_constant_vars;
+                }
             }
         }
         s
@@ -1557,6 +1645,31 @@ impl Presolve {
 
     /// Expand a single pass's reduced solution back to its original space.
     fn postsolve_once(&self, red: &QpSolution) -> QpSolution {
+        // An aggregation layer is a whole pass in one entry, with its own
+        // primal lift and dual sweep; it never shares a layer with the
+        // single-elimination catalog.
+        let mut out = if let [Reduction::Aggregate { plan }] = self.stack.as_slice() {
+            crate::aggregate::postsolve(&self.orig, plan, red)
+        } else {
+            self.postsolve_catalog(red)
+        };
+        // [`QpIterate::objective`] is documented to be in the original
+        // problem's coordinates, but the trace comes back from a solve of
+        // the *reduced* problem — which differs by exactly the constant any
+        // substitution moved into the objective. Put it back, per layer, so
+        // the chain composes to the user's objective.
+        if self.obj_offset != 0.0 {
+            for it in &mut out.iterates {
+                it.objective += self.obj_offset;
+            }
+        }
+        out
+    }
+
+    /// [`Self::postsolve_once`] for a layer built by [`presolve_once`] —
+    /// every reduction in the catalog except the aggregation, which has its
+    /// own recovery.
+    fn postsolve_catalog(&self, red: &QpSolution) -> QpSolution {
         let mut x = vec![0.0; self.orig_n];
         let mut y = vec![0.0; self.orig_m_eq];
         let mut z = vec![0.0; self.orig_m_ineq];
@@ -1608,6 +1721,10 @@ impl Presolve {
                 // The variable is kept; only its box changed, so its primal
                 // comes from the reduced solution (already mapped above).
                 Reduction::BoundTightening { .. } => {}
+                // Unreachable: an aggregation layer returned above, before
+                // any of this. Left as a no-op rather than a panic so the
+                // arm can never be the thing that fails a solve.
+                Reduction::Aggregate { .. } => {}
             }
         }
         for r in &self.stack {

--- a/crates/pounce-convex/tests/presolve_aggregation.rs
+++ b/crates/pounce-convex/tests/presolve_aggregation.rs
@@ -1,0 +1,735 @@
+//! Doubleton-equality aggregation (gh #494), end to end.
+//!
+//! `presolve.rs`'s contract is that a presolved-then-postsolved solve
+//! yields a valid primal–dual point of the **original** problem, so that
+//! is what these assert: full-space stationarity carrying the bound
+//! multipliers, primal feasibility of every row including the ones the
+//! aggregation consumed, dual signs, and complementarity — plus agreement
+//! with a bare solve on the objective.
+//!
+//! The dual is the part worth the scrutiny. Planning transfers an
+//! eliminated column's box onto its survivor, so a reduced solve reports
+//! the bound force on a variable that may not declare that bound at all;
+//! `aggregate::postsolve` re-attributes it. `alias_bound_multiplier_stays_
+//! on_the_bounded_column` is the direct pin on that, and every `assert_kkt`
+//! below would fail if the re-attribution were dropped.
+
+use pounce_convex::presolve::{PresolveOutcome, presolve, solve_with_presolve};
+use pounce_convex::{QpOptions, QpProblem, QpSolution, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn with_presolve(prob: &QpProblem) -> QpSolution {
+    solve_with_presolve(prob, |r| solve_qp_ipm(r, &QpOptions::default(), backend))
+}
+
+fn without_presolve(prob: &QpProblem) -> QpSolution {
+    solve_qp_ipm(prob, &QpOptions::default(), backend)
+}
+
+/// Full-space KKT of the *original* problem, bound multipliers included:
+/// `Px + c + Aᵀy + Gᵀz − z_lb + z_ub = 0`, `Ax = b`, `Gx ≤ h`, `z ≥ 0`,
+/// `z_lb, z_ub ≥ 0`, and both complementarities.
+fn assert_kkt(prob: &QpProblem, sol: &QpSolution, tol: f64) {
+    let n = prob.n;
+    let mut g = prob.c.clone();
+    prob.p_mul(&sol.x, &mut g);
+    prob.at_mul(&sol.y, &mut g);
+    prob.gt_mul(&sol.z, &mut g);
+    for i in 0..n {
+        let stat = g[i] - sol.z_lb[i] + sol.z_ub[i];
+        assert!(stat.abs() < tol, "stationarity[{i}] = {stat}");
+        assert!(
+            sol.z_lb[i] > -tol && sol.z_ub[i] > -tol,
+            "bound dual sign [{i}]: {} / {}",
+            sol.z_lb[i],
+            sol.z_ub[i]
+        );
+        // A bound multiplier on a bound the problem never declared is not
+        // a dual of this problem at all — the failure mode the survivor's
+        // transferred box would otherwise produce.
+        if prob.lb_of(i) <= f64::NEG_INFINITY {
+            assert!(sol.z_lb[i].abs() < tol, "z_lb on unbounded [{i}]");
+        }
+        if prob.ub_of(i) >= f64::INFINITY {
+            assert!(sol.z_ub[i].abs() < tol, "z_ub on unbounded [{i}]");
+        }
+        assert!(
+            sol.x[i] >= prob.lb_of(i) - tol && sol.x[i] <= prob.ub_of(i) + tol,
+            "box [{i}]: {} in [{}, {}]",
+            sol.x[i],
+            prob.lb_of(i),
+            prob.ub_of(i)
+        );
+        if prob.lb_of(i) > f64::NEG_INFINITY {
+            assert!(
+                (sol.z_lb[i] * (sol.x[i] - prob.lb_of(i))).abs() < 1e-4,
+                "lb complementarity [{i}]"
+            );
+        }
+        if prob.ub_of(i) < f64::INFINITY {
+            assert!(
+                (sol.z_ub[i] * (prob.ub_of(i) - sol.x[i])).abs() < 1e-4,
+                "ub complementarity [{i}]"
+            );
+        }
+    }
+    let mut ax = vec![0.0; prob.m_eq()];
+    prob.a_mul(&sol.x, &mut ax);
+    for (i, (&axi, &bi)) in ax.iter().zip(&prob.b).enumerate() {
+        assert!((axi - bi).abs() < tol, "Ax=b row {i}: {axi} vs {bi}");
+    }
+    let mut gx = vec![0.0; prob.m_ineq()];
+    prob.g_mul(&sol.x, &mut gx);
+    for i in 0..prob.m_ineq() {
+        let slack = prob.h[i] - gx[i];
+        assert!(slack > -tol, "Gx≤h row {i}: slack {slack}");
+        assert!(sol.z[i] > -tol, "z[{i}] = {}", sol.z[i]);
+        assert!(
+            (sol.z[i] * slack).abs() < 1e-4,
+            "ineq complementarity row {i}"
+        );
+    }
+}
+
+/// Reduced `(columns, rows)`, asserting the aggregation is what did it.
+///
+/// Worth the assertion rather than inferring it from the sizes: several of
+/// these shapes are also within reach of the pre-existing catalog — a free
+/// column singleton in particular eats an alias row whenever one of its two
+/// variables is unbounded and absent from `P` and `G`. A fixture that
+/// quietly took *that* path would look like a passing test of this feature
+/// while pinning none of it.
+fn reduced_size(prob: &QpProblem) -> (usize, usize) {
+    match presolve(prob) {
+        PresolveOutcome::Reduced(ps) => {
+            assert!(
+                ps.stats().aggregated_vars > 0,
+                "the aggregation did not fire on this fixture"
+            );
+            (ps.reduced.n, ps.reduced.m_eq() + ps.reduced.m_ineq())
+        }
+        other => panic!(
+            "expected a reduction, got {}",
+            match other {
+                PresolveOutcome::Infeasible => "Infeasible",
+                PresolveOutcome::Unbounded => "Unbounded",
+                PresolveOutcome::Reduced(_) => unreachable!(),
+            }
+        ),
+    }
+}
+
+/// `with_presolve`, first asserting the aggregation fired.
+fn with_aggregation(prob: &QpProblem) -> QpSolution {
+    let _ = reduced_size(prob);
+    with_presolve(prob)
+}
+
+// --- the shape the issue is about ---
+
+/// An alias-heavy LP of the gh #487 shape: a chain of arc equalities
+/// `x_i = x_{i+1}` over a block, with the objective and the real
+/// constraints touching only the ends. Before this reduction the whole
+/// chain reached the solver; the columns must actually drop.
+#[test]
+fn alias_chain_lp_columns_drop() {
+    const BLOCKS: usize = 12;
+    const CHAIN: usize = 8;
+    let n = BLOCKS * CHAIN;
+    let mut a = Vec::new();
+    let mut b = Vec::new();
+    for blk in 0..BLOCKS {
+        for k in 0..CHAIN - 1 {
+            let (i, j) = (blk * CHAIN + k, blk * CHAIN + k + 1);
+            let r = b.len();
+            a.push(Triplet::new(r, i, 1.0));
+            a.push(Triplet::new(r, j, -1.0));
+            b.push(0.0);
+        }
+    }
+    // One real inequality per block on the chain's head, and a cost on
+    // every column so no column is free/empty (which the pre-existing
+    // catalog would have removed on its own).
+    let mut g = Vec::new();
+    let mut h = Vec::new();
+    for blk in 0..BLOCKS {
+        g.push(Triplet::new(blk, blk * CHAIN, -1.0));
+        h.push(-1.0); // x_head ≥ 1
+    }
+    let prob = QpProblem {
+        n,
+        p_lower: (0..n).map(|i| Triplet::new(i, i, 2.0)).collect(),
+        c: vec![0.0; n],
+        a,
+        b,
+        g,
+        h,
+        lb: vec![],
+        ub: vec![],
+    };
+
+    let (red_n, red_rows) = reduced_size(&prob);
+    assert_eq!(red_n, BLOCKS, "one survivor per chain, got {red_n}");
+    assert_eq!(red_rows, BLOCKS, "every alias row consumed, got {red_rows}");
+
+    let sol = with_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    // Each chain sits at 1, so the objective is BLOCKS·CHAIN·(0.5·2·1²).
+    let want = (BLOCKS * CHAIN) as f64;
+    assert!((sol.obj - want).abs() < 1e-6, "obj {} vs {want}", sol.obj);
+}
+
+/// The dual half of the same story, in the smallest instance that shows
+/// it — and the direct pin on the re-attribution.
+///
+/// `x0 − 2·x1 = 0` with `x0 ≥ 1` and `x1 ∈ [−10, 10]`, minimizing `x0`.
+/// Planning eliminates `x0` and transfers `≥ 1` onto `x1` as `≥ 0.5`, so
+/// the reduced solve stops at `x1 = 0.5` reporting a bound multiplier
+/// there. But `0.5` is strictly interior to `x1`'s **declared** box, so
+/// that multiplier is not a dual of this problem at all: the force belongs
+/// to `x0`, at `1`, scaled by the substitution's `α = 2`.
+///
+/// Every constant here is load-bearing. `x1` is boxed (not free) so the
+/// free-column-singleton reduction cannot claim the row instead; `α ≠ 1`
+/// so a recovery that forgot to scale by it would be wrong rather than
+/// merely lucky; and `x1`'s own box is slack at the optimum so the
+/// survivor genuinely cannot carry the multiplier itself.
+#[test]
+fn alias_bound_multiplier_stays_on_the_bounded_column() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 0.0],
+        a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -2.0)],
+        b: vec![0.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![1.0, -10.0],
+        ub: vec![f64::INFINITY, 10.0],
+    };
+    let sol = with_aggregation(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    assert!(
+        (sol.x[0] - 1.0).abs() < 1e-6 && (sol.x[1] - 0.5).abs() < 1e-6,
+        "{:?}",
+        sol.x
+    );
+    assert!(
+        (sol.z_lb[0] - 1.0).abs() < 1e-6,
+        "the bound force belongs to x0, at unit scale: z_lb = {:?}",
+        sol.z_lb
+    );
+    assert!(
+        sol.z_lb[1].abs() < 1e-6 && sol.z_ub[1].abs() < 1e-6,
+        "x1 sits interior to its declared box and cannot carry a bound \
+         multiplier: {:?} / {:?}",
+        sol.z_lb,
+        sol.z_ub
+    );
+    assert!(
+        sol.y[0].abs() < 1e-6,
+        "consumed row multiplier should be 0 here, got {}",
+        sol.y[0]
+    );
+}
+
+/// The re-attribution, on a fixture where nothing else can do it for us.
+///
+/// Getting here takes some care. The catalog's bound-tightening pass runs
+/// *before* the aggregation and, left to itself, propagates the eliminated
+/// column's bound onto its partner anyway — after which the survivor is on
+/// a bound of the aggregation layer's own input and simply keeps the
+/// multiplier. So the alias row here is denied that: `x1 + x2 + x3 = 3` is
+/// accepted as a tightening source first and claims `x1`, which makes the
+/// alias row `x0 − 2·x1 = 0` fail the disjoint-source rule and go
+/// untightened. The transferred `x0 ≥ 1` therefore reaches `x1` only
+/// through the aggregation, and at the optimum `x1 = 0.5` sits strictly
+/// inside its own declared `[−10, 3]`.
+///
+/// Hand-solved: `x2 = x3 = 1.25`, `x1 = 0.5`, `x0 = 1`, with `λ = −2.5` on
+/// the sum row, `ν = −1.25` on the alias row, and the whole bound force
+/// `z_lb[x0] = 8.75` on `x0` — the column that actually declares it.
+#[test]
+fn re_attribution_when_tightening_cannot_pre_empt_it() {
+    let prob = QpProblem {
+        n: 4,
+        p_lower: vec![Triplet::new(2, 2, 2.0), Triplet::new(3, 3, 2.0)],
+        c: vec![10.0, 0.0, 0.0, 0.0],
+        a: vec![
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(0, 2, 1.0),
+            Triplet::new(0, 3, 1.0), // x1 + x2 + x3 = 3
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, -2.0), // x0 = 2·x1
+        ],
+        b: vec![3.0, 0.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![1.0, -10.0, 0.0, 0.0],
+        ub: vec![f64::INFINITY, 10.0, 10.0, 10.0],
+    };
+    let sol = with_aggregation(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-5);
+    for (i, want) in [1.0, 0.5, 1.25, 1.25].iter().enumerate() {
+        assert!((sol.x[i] - want).abs() < 1e-5, "x[{i}] = {}", sol.x[i]);
+    }
+    assert!((sol.y[0] + 2.5).abs() < 1e-5, "y = {:?}", sol.y);
+    assert!((sol.y[1] + 1.25).abs() < 1e-5, "y = {:?}", sol.y);
+    assert!(
+        (sol.z_lb[0] - 8.75).abs() < 1e-5,
+        "the whole bound force belongs to x0: z_lb = {:?}",
+        sol.z_lb
+    );
+    assert!(
+        sol.z_lb[1].abs() < 1e-5 && sol.z_ub[1].abs() < 1e-5,
+        "x1 is interior to its declared box: {:?} / {:?}",
+        sol.z_lb,
+        sol.z_ub
+    );
+}
+
+/// The same re-attribution with the substitution's sign reversed, so the
+/// eliminated column's *lower* bound arrives as an *upper* bound on the
+/// survivor. `x0 + 2·x1 = 0`, `x0 ≥ 1`, `x1 ∈ [−10, 10]`, minimizing `x0`.
+#[test]
+fn re_attribution_across_a_sign_flip() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 0.0],
+        a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 2.0)],
+        b: vec![0.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![1.0, -10.0],
+        ub: vec![f64::INFINITY, 10.0],
+    };
+    let sol = with_aggregation(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    assert!(
+        (sol.x[0] - 1.0).abs() < 1e-6 && (sol.x[1] + 0.5).abs() < 1e-6,
+        "{:?}",
+        sol.x
+    );
+    assert!((sol.z_lb[0] - 1.0).abs() < 1e-6, "z_lb = {:?}", sol.z_lb);
+    assert!(
+        sol.z_lb[1].abs() < 1e-6 && sol.z_ub[1].abs() < 1e-6,
+        "{:?} / {:?}",
+        sol.z_lb,
+        sol.z_ub
+    );
+}
+
+/// When the survivor *is* on one of its own declared bounds, it keeps the
+/// multiplier — the same attribution a solve without this pass produces.
+/// `x0 − x1 = 0` with both boxed at `[2, 5]` and a cost pushing to the
+/// lower bound.
+#[test]
+fn a_survivor_on_its_own_bound_keeps_the_multiplier() {
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![1.0, 1.0],
+        a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -1.0)],
+        b: vec![0.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![2.0, 2.0],
+        ub: vec![5.0, 5.0],
+    };
+    let sol = with_aggregation(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    assert!(
+        (sol.x[0] - 2.0).abs() < 1e-6 && (sol.x[1] - 2.0).abs() < 1e-6,
+        "{:?}",
+        sol.x
+    );
+    // Both columns are at their own lower bound; the total force is 2 and
+    // however it splits, stationarity (checked above) must hold.
+    let total = sol.z_lb[0] + sol.z_lb[1];
+    assert!((total - 2.0).abs() < 1e-5, "z_lb = {:?}", sol.z_lb);
+}
+
+/// Both signs of the aggregation coefficient, with the bound on the
+/// eliminated side either way round, so the `α < 0` branch of the bound
+/// transfer *and* of the multiplier re-attribution are both exercised.
+#[test]
+fn both_signs_of_the_coefficient() {
+    for (a0, a1, bnd) in [
+        (1.0, -1.0, 0.0),
+        (1.0, 1.0, 0.0),
+        (2.0, -3.0, 1.0),
+        (2.0, 3.0, -1.0),
+        (-2.0, 3.0, 1.0),
+    ] {
+        let prob = QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 1.0)],
+            c: vec![1.0, -1.0],
+            a: vec![Triplet::new(0, 0, a0), Triplet::new(0, 1, a1)],
+            b: vec![bnd],
+            g: vec![],
+            h: vec![],
+            lb: vec![-2.0, -3.0],
+            ub: vec![2.0, 3.0],
+        };
+        let (red_n, _) = reduced_size(&prob);
+        assert_eq!(red_n, 1, "coeffs ({a0}, {a1})");
+        let sol = with_presolve(&prob);
+        let bare = without_presolve(&prob);
+        assert_eq!(sol.status, QpStatus::Optimal, "coeffs ({a0}, {a1})");
+        assert_kkt(&prob, &sol, 1e-6);
+        assert!(
+            (sol.obj - bare.obj).abs() < 1e-6,
+            "coeffs ({a0}, {a1}): {} vs bare {}",
+            sol.obj,
+            bare.obj
+        );
+    }
+}
+
+/// The substitution is a congruence `P' = MᵀPM`, so a convex QP stays
+/// convex — worth a test rather than an assumption, since the whole
+/// LP/QP dispatch upstream rests on the classification made *before* the
+/// reduction runs. Checked where it matters: the reduced problem solves
+/// to the same optimum, and its Hessian is PSD on a spanning set of
+/// directions.
+#[test]
+fn convexity_survives_the_substitution() {
+    // A genuinely coupled PSD Hessian: P = LᵀL with L = [[1,1,0],[0,1,1]],
+    // then two alias rows fold x1 and x2 onto x0's cluster.
+    let prob = QpProblem {
+        n: 4,
+        p_lower: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 2.0),
+            Triplet::new(2, 1, 1.0),
+            Triplet::new(2, 2, 1.0),
+            Triplet::new(3, 3, 3.0),
+        ],
+        c: vec![1.0, -2.0, 0.5, 1.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, -2.0), // x0 = 2·x1
+            Triplet::new(1, 2, 1.0),
+            Triplet::new(1, 3, 1.5), // x2 = −1.5·x3
+        ],
+        b: vec![0.0, 0.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+
+    let ps = match presolve(&prob) {
+        PresolveOutcome::Reduced(ps) => ps,
+        _ => panic!("expected a reduction"),
+    };
+    assert_eq!(ps.reduced.n, 2);
+    let red = &ps.reduced;
+    // yᵀP'y ≥ 0 over a spanning sweep of directions.
+    for k in 0..16 {
+        let t = (k as f64) * std::f64::consts::PI / 8.0;
+        let d = [t.cos(), t.sin()];
+        let mut pd = vec![0.0; red.n];
+        red.p_mul(&d, &mut pd);
+        let quad: f64 = (0..red.n).map(|i| d[i] * pd[i]).sum();
+        assert!(quad > -1e-12, "reduced Hessian indefinite: dᵀP'd = {quad}");
+    }
+
+    let sol = with_presolve(&prob);
+    let bare = without_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    assert!(
+        (sol.obj - bare.obj).abs() < 1e-6,
+        "{} vs bare {}",
+        sol.obj,
+        bare.obj
+    );
+}
+
+/// A QP whose Hessian couples an eliminated column to a *kept* one: the
+/// coupling has to move into the survivor's linear term, and the
+/// consumed row's multiplier has to be recovered against the full `Px`.
+#[test]
+fn hessian_coupling_across_the_substitution() {
+    let prob = QpProblem {
+        n: 4,
+        p_lower: vec![
+            Triplet::new(0, 0, 2.0),
+            Triplet::new(2, 0, 1.0), // couples x0 (eliminated) to x2 (kept)
+            Triplet::new(2, 2, 2.0),
+            Triplet::new(1, 1, 2.0),
+            Triplet::new(3, 3, 2.0),
+        ],
+        c: vec![1.0, 0.5, -1.0, 0.25],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, -3.0), // x0 = 3·x1 + 6
+            // Three distinct clusters once the alias is folded, so this
+            // row survives and the substitution has to rewrite it —
+            // including moving x0's offset of 6 into its right-hand side.
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 2, 1.0),
+            Triplet::new(1, 3, 1.0),
+        ],
+        b: vec![6.0, 2.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+    let (red_n, _) = reduced_size(&prob);
+    assert_eq!(red_n, 3);
+    let sol = with_presolve(&prob);
+    let bare = without_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    assert!(
+        (sol.obj - bare.obj).abs() < 1e-6,
+        "{} vs bare {}",
+        sol.obj,
+        bare.obj
+    );
+    for i in 0..prob.n {
+        assert!(
+            (sol.x[i] - bare.x[i]).abs() < 1e-5,
+            "x[{i}] {} vs bare {}",
+            sol.x[i],
+            bare.x[i]
+        );
+    }
+}
+
+/// An inequality row over eliminated columns is rewritten, not consumed,
+/// and its multiplier comes back on the original row.
+#[test]
+fn inequalities_are_rewritten_and_keep_their_duals() {
+    let prob = QpProblem {
+        n: 3,
+        p_lower: vec![Triplet::new(2, 2, 2.0)],
+        c: vec![1.0, 1.0, 0.0],
+        a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, -1.0)], // x0 = x1
+        b: vec![0.0],
+        g: vec![
+            Triplet::new(0, 0, -1.0),
+            Triplet::new(0, 2, -1.0), // −x0 − x2 ≤ −2
+        ],
+        h: vec![-2.0],
+        // Boxed, so `x1` is not a *free* column singleton and the row is
+        // the aggregation's to consume rather than the older reduction's.
+        lb: vec![-5.0, -5.0, f64::NEG_INFINITY],
+        ub: vec![5.0, 5.0, f64::INFINITY],
+    };
+    let (red_n, red_rows) = reduced_size(&prob);
+    assert_eq!(red_n, 2);
+    assert_eq!(red_rows, 1, "the inequality survives");
+    let sol = with_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+    assert!(sol.z[0] > 1e-6, "the inequality is active: z = {:?}", sol.z);
+}
+
+/// Failing closed: a contradictory alias system is not called infeasible
+/// by the elimination pass. Either the rest of the catalog reaches that
+/// verdict on its own, or the model is handed to the solver whole — what
+/// must not happen is the aggregation inventing the answer.
+#[test]
+fn contradictory_aliases_are_not_this_passs_verdict() {
+    let prob = QpProblem {
+        n: 3,
+        p_lower: vec![Triplet::new(2, 2, 2.0)],
+        c: vec![1.0, 1.0, 0.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, -1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, -1.0),
+            Triplet::new(2, 2, 1.0),
+        ],
+        b: vec![0.0, 1.0, 3.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+    // The pass declines; the surviving verdict is whatever the rest of the
+    // stack (or the solver) concludes, and either way it is a verdict about
+    // a model that still has its contradictory rows in it.
+    match presolve(&prob) {
+        PresolveOutcome::Reduced(ps) => {
+            // The alias rows must still be there for someone else to judge.
+            assert!(ps.reduced.m_eq() >= 2, "{}", ps.reduced.m_eq());
+        }
+        PresolveOutcome::Infeasible => {
+            // Reached by the *duplicate-row* reduction, which is entitled
+            // to it: two identical rows with different right-hand sides.
+        }
+        PresolveOutcome::Unbounded => panic!("not unbounded"),
+    }
+}
+
+/// Rows that collapse to `0 = 0` under the accumulated substitutions are
+/// redundant and go, without their multiplier being invented.
+#[test]
+fn redundant_rows_collapse() {
+    let prob = QpProblem {
+        n: 3,
+        p_lower: (0..3).map(|i| Triplet::new(i, i, 2.0)).collect(),
+        c: vec![-1.0, -1.0, -1.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, -1.0), // x0 = x1
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(1, 2, -1.0), // x1 = x2
+            // x0 − x2 = 0: implied by the two above, so `0 = 0` once
+            // substituted.
+            Triplet::new(2, 0, 1.0),
+            Triplet::new(2, 2, -1.0),
+        ],
+        b: vec![0.0, 0.0, 0.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![],
+        ub: vec![],
+    };
+    let (red_n, red_rows) = reduced_size(&prob);
+    assert_eq!(red_n, 1);
+    assert_eq!(red_rows, 0, "all three rows gone");
+    let sol = with_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert_kkt(&prob, &sol, 1e-6);
+}
+
+/// Randomized roundtrip over alias-linked QPs with boxes on both sides of
+/// each link, which is where the bound transfer and the multiplier
+/// re-attribution actually get exercised in combination.
+#[test]
+fn randomized_roundtrip() {
+    // Deterministic LCG; the point is coverage of sign/box combinations,
+    // not statistical rigour.
+    let mut state: u64 = 0x5eed_1234_abcd_ef01;
+    let mut next = move || {
+        state = state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((state >> 33) as f64) / ((1u64 << 31) as f64) // [0, 1)
+    };
+
+    let mut aggregated = 0usize;
+    let mut checked = 0usize;
+    for case in 0..400 {
+        let n = 4 + (case % 4);
+        // Hessian: a positive diagonal plus an occasional off-diagonal
+        // small enough to stay diagonally dominant, so the problem is
+        // convex by construction and the congruence has something to bite
+        // on.
+        let mut p_lower: Vec<Triplet> = Vec::new();
+        for i in 0..n {
+            p_lower.push(Triplet::new(i, i, 2.0 + next()));
+        }
+        if next() < 0.5 && n >= 3 {
+            p_lower.push(Triplet::new(2, 0, 0.5 * next()));
+        }
+        let c: Vec<f64> = (0..n).map(|_| 2.0 * next() - 1.0).collect();
+        // One or two alias rows with coefficients and offsets of either
+        // sign, plus — half the time — a wider equality row that should
+        // survive and be rewritten.
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        let links = 1 + (case % 2);
+        for k in 0..links {
+            let (i, j) = (2 * k, 2 * k + 1);
+            if j >= n {
+                break;
+            }
+            let r = b.len();
+            let a0 = if next() < 0.5 { 1.0 } else { -2.0 };
+            let a1 = if next() < 0.5 { 1.5 } else { -1.0 };
+            a.push(Triplet::new(r, i, a0));
+            a.push(Triplet::new(r, j, a1));
+            b.push(2.0 * next() - 1.0);
+        }
+        if b.is_empty() {
+            continue;
+        }
+        if next() < 0.5 && n >= 4 {
+            let r = b.len();
+            for j in [0usize, 2, 3] {
+                a.push(Triplet::new(r, j, 1.0 + next()));
+            }
+            b.push(2.0 * next() - 1.0);
+        }
+        // An inequality over the same columns, so `Gᵀz` is in the gradient
+        // the sweep has to work against.
+        let (g, h) = if next() < 0.5 {
+            (
+                (0..n).map(|j| Triplet::new(0, j, next() - 0.5)).collect(),
+                vec![1.0 + next()],
+            )
+        } else {
+            (Vec::new(), Vec::new())
+        };
+        // Boxes: two-sided, one-sided either way, or absent — the four
+        // shapes the bound transfer and the re-attribution have to cope
+        // with.
+        let mut lb = vec![0.0; n];
+        let mut ub = vec![0.0; n];
+        for j in 0..n {
+            let (lo, hi) = (-1.0 - next(), next());
+            match ((next() * 4.0) as usize).min(3) {
+                0 => (lb[j], ub[j]) = (lo, hi),
+                1 => (lb[j], ub[j]) = (lo, f64::INFINITY),
+                2 => (lb[j], ub[j]) = (f64::NEG_INFINITY, hi),
+                _ => (lb[j], ub[j]) = (f64::NEG_INFINITY, f64::INFINITY),
+            }
+        }
+        let prob = QpProblem {
+            n,
+            p_lower,
+            c,
+            a,
+            b,
+            g,
+            h,
+            lb,
+            ub,
+        };
+        if let PresolveOutcome::Reduced(ps) = presolve(&prob) {
+            if ps.stats().aggregated_vars > 0 {
+                aggregated += 1;
+            }
+        }
+        let sol = with_presolve(&prob);
+        if sol.status != QpStatus::Optimal {
+            continue; // an empty box from the random draw; not this test's business
+        }
+        checked += 1;
+        assert_kkt(&prob, &sol, 1e-5);
+        let bare = without_presolve(&prob);
+        if bare.status == QpStatus::Optimal {
+            assert!(
+                (sol.obj - bare.obj).abs() < 1e-5 * (1.0 + bare.obj.abs()),
+                "case {case}: {} vs bare {}",
+                sol.obj,
+                bare.obj
+            );
+        }
+    }
+    // A probe that stopped generating aggregatable instances would pass
+    // while testing nothing; hold it to a floor.
+    assert!(aggregated > 200, "only {aggregated} instances aggregated");
+    assert!(checked > 200, "only {checked} instances solved");
+}

--- a/crates/pounce-convex/tests/presolve_reductions.rs
+++ b/crates/pounce-convex/tests/presolve_reductions.rs
@@ -317,21 +317,34 @@ fn fixpoint_cascades_chain_of_fixings() {
 
 // --- parallel rows (scalar multiples, not just exact duplicates) ---
 
-/// Parallel equality rows: `x0 + x1 = 2` and `3x0 + 3x1 = 6` are the same
-/// constraint scaled by 3. One is dropped; the recovered point is valid.
+/// Parallel equality rows: `x0 + x1 + x2 = 3` and `3x0 + 3x1 + 3x2 = 9`
+/// are the same constraint scaled by 3. One is dropped; the recovered
+/// point is valid.
+///
+/// Three columns, not two: a *doubleton* row is consumed by aggregation
+/// (gh #494) before parallel detection ever sees it, so a two-column
+/// fixture would no longer be testing this reduction at all. The
+/// duplicate-row logic is arity-agnostic; the two-column case is covered
+/// by `presolve_aggregation.rs`'s `redundant_rows_collapse`.
 #[test]
 fn parallel_equality_rows_redundant() {
     let prob = QpProblem {
-        n: 2,
-        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
-        c: vec![0.0, 0.0],
+        n: 3,
+        p_lower: vec![
+            Triplet::new(0, 0, 2.0),
+            Triplet::new(1, 1, 2.0),
+            Triplet::new(2, 2, 2.0),
+        ],
+        c: vec![0.0, 0.0, 0.0],
         a: vec![
             Triplet::new(0, 0, 1.0),
-            Triplet::new(0, 1, 1.0), // x0 + x1 = 2
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(0, 2, 1.0), // x0 + x1 + x2 = 3
             Triplet::new(1, 0, 3.0),
-            Triplet::new(1, 1, 3.0), // 3x0 + 3x1 = 6  (= 3×row0)
+            Triplet::new(1, 1, 3.0),
+            Triplet::new(1, 2, 3.0), // = 3×row0
         ],
-        b: vec![2.0, 6.0],
+        b: vec![3.0, 9.0],
         g: vec![],
         h: vec![],
         lb: vec![],
@@ -348,21 +361,28 @@ fn parallel_equality_rows_redundant() {
     assert_kkt(&prob, &sol, 1e-5);
 }
 
-/// Negatively-scaled parallel equalities: `x0 + x1 = 2` and
-/// `−2x0 − 2x1 = −4` are the same constraint. Detected and merged.
+/// Negatively-scaled parallel equalities: `x0 + x1 + x2 = 3` and
+/// `−2x0 − 2x1 − 2x2 = −6` are the same constraint. Detected and merged.
+/// Three columns for the same reason as the test above.
 #[test]
 fn parallel_equality_negative_scale() {
     let prob = QpProblem {
-        n: 2,
-        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
-        c: vec![0.0, 0.0],
+        n: 3,
+        p_lower: vec![
+            Triplet::new(0, 0, 2.0),
+            Triplet::new(1, 1, 2.0),
+            Triplet::new(2, 2, 2.0),
+        ],
+        c: vec![0.0, 0.0, 0.0],
         a: vec![
             Triplet::new(0, 0, 1.0),
             Triplet::new(0, 1, 1.0),
+            Triplet::new(0, 2, 1.0),
             Triplet::new(1, 0, -2.0),
-            Triplet::new(1, 1, -2.0), // −2×row0
+            Triplet::new(1, 1, -2.0),
+            Triplet::new(1, 2, -2.0), // −2×row0
         ],
-        b: vec![2.0, -4.0],
+        b: vec![3.0, -6.0],
         g: vec![],
         h: vec![],
         lb: vec![],
@@ -900,7 +920,12 @@ fn free_singleton_depends_on_fixed_var_postsolve_order() {
 }
 
 /// A bounded variable in one row is *not* a free column singleton (its
-/// box can bind), so it must not be substituted.
+/// box can bind), so *that* reduction must not fire on it.
+///
+/// The row does go — doubleton aggregation (gh #494) consumes it and
+/// transfers the box onto the survivor, which is sound precisely because
+/// it carries the bound across instead of dropping it. So the guard here
+/// is on the reduction under test, not on the surviving row count.
 #[test]
 fn bounded_variable_not_substituted() {
     let prob = QpProblem {
@@ -916,8 +941,11 @@ fn bounded_variable_not_substituted() {
     };
     match presolve(&prob) {
         PresolveOutcome::Reduced(ps) => {
-            // Neither var is substituted; the equality row survives.
-            assert_eq!(ps.reduced.m_eq(), 1, "bounded var must keep its row");
+            assert_eq!(
+                ps.stats().free_col_singletons,
+                0,
+                "a bounded variable is not a free column singleton"
+            );
         }
         other => panic!("expected Reduced, got {:?}", status_of(&other)),
     }

--- a/crates/pounce-presolve/src/lib.rs
+++ b/crates/pounce-presolve/src/lib.rs
@@ -92,7 +92,7 @@ pub use diagnostics::{AuxiliaryPreprocessingDiagnostics, AuxiliaryRejectionReaso
 pub use dulmage_mendelsohn::{DMPart, DulmageMendelsohnPartition};
 pub use incidence::{EqualityIncidence, InequalityIncidence, ProbeView};
 pub use licq::{EqRow, LicqVerdict, licq_check};
-pub use linear_eq_elim::{FullSolution, LinearEqElimTnlp};
+pub use linear_eq_elim::{FullSolution, LinearEqElimTnlp, recover_dropped_multipliers};
 pub use linear_eq_plan::{
     ElimStep, EliminationPlan, LinearEqElimReport, PlanConfig, PlanInput, VarRecovery, build_plan,
 };

--- a/crates/pounce-presolve/src/linear_eq_elim.rs
+++ b/crates/pounce-presolve/src/linear_eq_elim.rs
@@ -614,8 +614,16 @@ fn decode(irow: Index, jcol: Index, one_based: bool) -> (usize, usize) {
 ///
 /// Signs follow the convention `finalize_solution` uses, `∇f + Jᵀλ − z_l +
 /// z_u = 0`, so `resid` accumulates `+Jᵀλ` and each pivot solve carries the
-/// matching negation.
-fn recover_dropped_multipliers(
+/// matching negation. `grad_f` is the objective gradient **plus** every
+/// force the sweep is not itself resolving (bound multipliers, and the
+/// transpose products of any row block the plan never looks at), so a
+/// caller with more row blocks than the plan's own — `pounce-convex`, whose
+/// aggregation plans over the equalities while `Gᵀz` also acts on the same
+/// columns (gh #494) — folds those in here.
+///
+/// Public because the convex QP presolve shares this recovery rather than
+/// restating it in `(y, z)` conventions; see `pounce_convex::aggregate`.
+pub fn recover_dropped_multipliers(
     plan: &EliminationPlan,
     grad_f: &[Number],
     jac_irow: &[Index],

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -147,14 +147,38 @@ Before the convex interior-point solve, POUNCE runs a **presolve** pass
 that shrinks the problem and can detect trivial infeasibility or
 unboundedness without solving. It removes empty, duplicate, and
 activity-redundant rows; fixes and substitutes structural columns
-(singleton-row fixings, free columns, free column singletons); and
-recovers both the primal and dual of the eliminated pieces so the
-reported solution is for your original problem. When it reduces the
-model, it logs a one-line summary:
+(singleton-row fixings, free columns, free column singletons); **folds
+away two-variable equality rows** (below); and recovers both the primal
+and dual of the eliminated pieces so the reported solution is for your
+original problem. When it reduces the model, it logs a one-line summary:
 
 ```text
-Presolve: 40 → 32 vars, 12 → 8 rows (fixed 3, free-fixed 2, substituted 3)
+Presolve: 40 → 24 vars, 12 → 4 rows (fixed 3, free-fixed 2, substituted 3, aggregated 8, ...)
 ```
+
+### Two-variable equality rows (aggregation)
+
+A row `a₁·x + a₂·y = b` linking two variables says one of them *is* the
+other, up to a scale and a shift — an arc equality between two units, a
+`Reference` alias, a unit conversion. Neither variable is determined by
+it, so nothing in the older catalog could act on it, and on a flowsheet
+these rows are most of the model. POUNCE now substitutes one variable
+for the other and drops the row, iterating to a fixed point so *chains*
+of aliases collapse to a single column. Any bound on the eliminated
+variable is carried across onto the one that survives, so the reduced
+problem describes exactly the same feasible set.
+
+Two things this deliberately does **not** do:
+
+- It never calls your model infeasible. A contradictory alias system —
+  `x = y` and `x = y + 1` — makes the pass stand down and hand the model
+  over untouched, for the rest of presolve or the solver itself to judge.
+- It does not run on the conic path (SOCP, exponential/power cones, SDP,
+  SOS). Those rows are structurally coupled in fixed-size blocks that a
+  substitution would rewrite.
+
+The aggregation shares its planner with the NLP path's Phase 6, so the
+two agree on what can be eliminated (see [NLP Presolve](./options.md)).
 
 Presolve is on by default. Turn it off with `qp_presolve=no` (e.g. to
 compare timings or isolate a solver issue):

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -371,6 +371,22 @@ It is off by default because it changes the variable count, which the
 sensitivity and reduced-Hessian paths index against the original `.nl`.
 (The CLI already disables presolve entirely when those are requested.)
 
+**LP and convex QP take a different route to the same reduction.** Those
+models never reach Phase 6 — the CLI dispatches them to `pounce-convex`
+before any presolve wrapper is built — but they are not left unreduced.
+`pounce-convex` has its own presolve, on by default, and it now performs
+the two-variable aggregation as part of that catalog, sharing this
+planner rather than restating it. So the reduction is the same; only the
+switch differs (`qp_presolve=no` / `presolve=no` turns it off there, and
+`presolve_linear_eq_reduction` does not apply). See
+[LP/QP routing](lp-qp-routing.md#two-variable-equality-rows-aggregation).
+
+The dual-attribution caveat above is the one place the two differ. The
+convex path's contract is a valid KKT point of the *original* problem, so
+it cannot leave a multiplier on a bound the survivor does not declare: it
+re-attributes the force to whichever variable is actually sitting on its
+own bound. Phase 6 keeps the simpler attribution described above.
+
 ### Feasibility-based bound tightening (Phase 1b)
 
 Interval-arithmetic propagation through nonlinear constraint


### PR DESCRIPTION
Fixes #494

> Written against a fast-moving `main`: #490, #498 and #503 all landed while
> this was in flight, and each is merged in here. Four commits — the feature,
> three merges, and one probe extension #498 made possible. Earlier revisions
> of this body said to merge #490 first and described a dual-attribution
> divergence from Phase 6; both are stale and are corrected below.

## Problem

A row `a₁·x + a₂·y = b` linking two variables says one of them *is* the
other, up to a scale and a shift — an arc equality, a `Reference` alias, a
unit conversion. Neither variable is determined by it, so nothing in the
convex presolve's catalog could act on it, even though it already had
singleton-row fixing and free-column-singleton substitution. `presolve.rs:94`
already named doubleton aggregation as the next reduction to mine from
PaPILO.

On a flowsheet those rows are most of the model. Synthetic alias-heavy convex
QP of the #487 shape, release build, `pounce model.nl` vs
`pounce model.nl qp_presolve=no`:

| columns | rows | | to the solver | rows | wall time | objective |
|---|---|---|---|---|---|---|
| 10,000 | 19,998 | before | 10,000 | 19,998 | 0.555 s | 10999.86251085 |
| | | after | **400** | **798** | **0.055 s** | 10999.86253075 |
| 24,000 | 47,998 | before | 24,000 | 47,998 | 1.292 s | 26399.99995742 |
| | | after | **1,200** | **2,398** | **0.158 s** | 26399.99999917 |

Both are converged points; the objectives agree to seven figures. Column and
row counts are exact and reproducible; the wall times are single runs and
move a few percent between them. The generator is scratch, not vendored —
see *Tests*.

## Cause

Not that LP and convex QP went unpresolved. `pounce-convex` has its own
PaPILO-style reversible transaction stack, on by default. The gap was one
missing reduction: the catalog had fixed-variable elimination from a
*singleton* equality row and *free-column-singleton* substitution, but
nothing for a doubleton with **no anchoring requirement on either side** —
the free/free pair that carries a flowsheet.

## Fix

**Share the planner, not the wrapper.** `linear_eq_plan::PlanInput` is pure
data — per-row `(col, coeff)` lists, right-hand sides, an eligibility mask, a
box. No TNLP appears in it. So `pounce-convex` feeds its `QpProblem`
equalities straight in and inherits the fixed-point iteration over the three
shapes, the union-by-size pivot tie-break that keeps alias chains shallow,
and the fail-closed posture — duplicating none of it. Written here
(`crates/pounce-convex/src/aggregate.rs`): the substitution of `x = M·y + d`
into `P`, `c`, `A`, `G`, and the postsolve in `(y, z)` conventions.

The aggregation is **its own layer** in the existing stack rather than one
`Reduction` per elimination step, which is where this departs from the
issue's sketch. The plan's chains and its reverse-sweep dual recovery are
only meaningful together; splitting them across stack entries would mean
re-deriving the sweep's triangularity from the entries, for nothing. So
`Reduction::Aggregate` carries the whole plan, `presolve()`'s fixpoint
alternates catalog and aggregation, and each feeds the other (an aggregation
exposes a singleton the catalog fixes; a fixing turns a three-term row into a
doubleton the next aggregation folds away).

Two things it deliberately does not do, both from the issue's *Care* list:

- **It never calls a model infeasible.** A contradictory alias system, or one
  that would remove every column, stands the pass down and hands the model
  over untouched. `build_plan` already returns the identity in both cases, so
  this is inherited rather than restated.
- **It does not run on the conic path.** `presolve_conic` calls
  `presolve_once` directly and so opts out by construction — a non-orthant
  cone block is a coupled, fixed-layout set of rows over columns the
  substitution would rewrite, and `reduced_cones` reads the surviving
  partition off the kept rows.

### The dual

Row multipliers come from `recover_dropped_multipliers` — the same reverse
triangular sweep the NLP path uses, in the same `∇f + Jᵀλ − z_l + z_u = 0`
convention `presolve.rs` already works in. Only the row block differs: the
plan consumes *equality* rows, so `Gᵀz` is folded into the gradient the sweep
is handed rather than resolved by it. That function is now `pub`; it and a
one-line re-export are the only changes this PR makes to `pounce-presolve`.

Bound multipliers take a step of their own, and this is the part worth
reviewing, because I first implemented it the way Phase 6 then did and it was
wrong here. Planning transfers an eliminated column's box onto its survivor,
so a reduced solve reports the *survivor* carrying a bound force that belongs
to the eliminated variable — possibly naming a bound the survivor does not
have. `presolve.rs`'s stated contract is a valid KKT point of the **original**
problem, and a nonzero multiplier on a bound the original never declared is
not one. Smallest case that shows it — `min x₀` s.t. `x₀ − x₁ = 0`,
`x₀ ≥ 0`, `x₁` free — the naive recovery puts `z_lb = 1` on a free variable
and leaves stationarity violated by 1.

So `postsolve` sweeps once with no bound forces, re-attributes each
survivor's leftover reduced cost to whichever cluster member is actually on
its own declared bound (scaled by that member's `α`), and sweeps again with
that force in place. A survivor already on a bound of its own keeps it, so
the answer matches a no-presolve solve wherever it can.

**#503 reached the same conclusion for Phase 6 independently**, landing
while this was in flight. The two paths now agree on the answer and differ
only in mechanism: Phase 6 records during *planning* where each reduced bound
came from and rescales by `α`; this side reads the leftover at postsolve,
which suits a path that also carries inequality rows and a bound-tightening
layer whose own re-attribution has to compose with this one. Where the
survivor's own bound is active too, both leave the multiplier there — the
split is non-unique and either is valid. #503 also gave
`recover_dropped_multipliers` explicit `z_l_full` / `z_u_full` parameters,
which do exactly what this branch's caller had been doing by hand, so the
hand-folding is gone.

## Blast radius

**On by default**, as the rest of the convex presolve is; `qp_presolve=no` /
`presolve=no` turns the whole pass off. That is a deliberate reading of "add
… to the reduction stack" — the stack it joins is on by default — and it is
the material difference from Phase 6, which is opt-in because it changes the
variable count the sensitivity paths index against. The convex path has no
such coupling.

Everything except LP and convex QP is untouched: the NLP path, the conic
path, GAMS, the C interface, and Pyomo all reach `presolve_once` or
`PresolveTnlp`, neither of which changed behaviour.

**Three existing tests in `presolve_reductions.rs` changed**, because the new
reduction legitimately fires where nothing could before. Flagging them rather
than burying them:

- `parallel_equality_rows_redundant` and `parallel_equality_negative_scale`
  widened from two columns to three. A two-column duplicate pair is now
  consumed by aggregation before parallel detection sees it, so those
  fixtures would have been testing nothing. Duplicate-row logic is
  arity-agnostic; the two-column case is now covered by
  `redundant_rows_collapse`.
- `bounded_variable_not_substituted` now asserts
  `stats().free_col_singletons == 0` instead of a surviving row count. Its
  stated intent is that a *bounded* variable is not a free column singleton,
  which is still true and still pinned; the row count was collateral, and
  aggregation is entitled to change it (it carries the bound across rather
  than dropping it).

No other test in the workspace changed.

### Interaction with #498, checked rather than assumed

#498 (fixing #492) folds a constant left in a `.nl` row's expression segment
into the row's bounds at parse. That is exactly the prerequisite #494 named,
and it changes which models reach this pass: a row written `x0 + x1 + 3 = 6`
used to read as nonlinear, classify the whole model NLP, and never get here.
Verified on a matched pair — the same constraints written pre-folded and with
the constant in the body — giving identical presolve counts, identical
objectives, and `VERIFIED` from `pounce verify` both ways. The adversary
generator now emits both spellings; 10 of 12 sampled models carry a nonzero
row constant and all 12 still classify LP/convex-QP.

## Also fixed, because this change exposed it

`QpIterate::objective` is documented to be in the original problem's
coordinates, but the trace comes back from a solve of the *reduced* problem
and presolve never added back the constant its substitutions moved into the
objective. Any `--json-detail full` report on a model where presolve fixed or
substituted a variable carried an `iterations` array offset by that constant;
`qp_full_report_has_iteration_trace` caught it on the existing fixture the
moment aggregation gave that model a nonzero offset. The final objective, the
solution, and the duals were always right. Fixed per layer in
`postsolve_once`, so the chain composes.

## Tests

New code, so "fails on the parent commit" is not available in the usual
sense — these would not compile there. The evidence that they bite is
**thirteen injected defects, each caught and each reverted**:

| injected defect | caught by |
|---|---|
| drop the ×2 folding an off-diagonal onto a shared survivor | unit + `convexity_survives_the_substitution` |
| drop the substitution offset from a surviving row's rhs | unit + `hessian_coupling_across_the_substitution` |
| drop the objective constant from a squared diagonal | 2 unit probes |
| drop the objective constant from the linear term | 2 unit probes |
| skip the re-attribution sweep | targeted fixture + randomized probe |
| sign flip in the re-attributed force | targeted fixture |
| drop `Gᵀz` from the gradient handed to the sweep | 2 integration tests |
| ignore `α` when scaling the re-attributed multiplier | targeted fixture |
| never look past the survivor for an owner | targeted fixture |
| drop the kept-row dual mapping | 2 integration tests |
| survivor always keeps the force | targeted fixture |
| lift the primal without the affine map | 11 of 12 integration tests |
| drop `Gᵀz` (adversary, end to end) | 13 of 40 `.nl` instances |

Two of those are worth calling out. The **row-offset** defect is invisible to
any derivative check, since `∂(αy + β)/∂y = α` either way — which is why the
unit probe re-evaluates the objective *and* every row at lifted points rather
than checking coefficients. And the **re-attribution** defects were initially
caught by nothing: my first two fixtures for that path were silently served
by the pre-existing free-column-singleton reduction, and a third was
pre-empted by the catalog's bound tightening. `reduced_size` now asserts
`stats().aggregated_vars > 0` so a fixture cannot quietly test the wrong
reduction, and `re_attribution_when_tightening_cannot_pre_empt_it` is built
so an earlier wide row claims the alias row's columns under the
disjoint-source rule and tightening cannot get there first.

Layers:

- **8 unit probes** on the substitution algebra (`aggregate.rs`), asserting
  the reduction is an identity on the objective and on every row at five
  arbitrary lifted points, plus that the lift satisfies every consumed row.
- **12 integration tests** (`tests/presolve_aggregation.rs`) asserting
  full-space KKT of the *original* problem — stationarity carrying the bound
  multipliers, feasibility of consumed rows, dual signs, complementarity, and
  explicitly that no multiplier lands on a bound the problem never declared.
  Includes an alias-chain LP of the #487 shape (columns drop 96 → 12, rows
  88 → 12), both signs of the aggregation coefficient, Hessian coupling
  across the substitution, PSD-ness of `MᵀPM` on a spanning sweep of
  directions, and a 400-instance randomized roundtrip.
- **A new adversary run**,
  `adversary/runs/2026-08-06_convex_doubleton_aggregation_verify.py` — 438
  randomized `.nl` models across three seeds through the CLI, checked by
  `pounce verify` (independent KKT/feasibility against the original `.nl`),
  by in-script re-evaluation of every row, by a bound-aware stationarity
  check on the reported duals, and against `qp_presolve=no`. 0 failures. Not
  asserted to bite — demonstrated, per the table above.

### Deliberately not pinned, and why

The adversary run **cannot reach the re-attribution**, and I measured that
rather than assuming either way. The CLI's QP extractor lowers every variable
bound to a row of `G`, so a model arriving from a `.nl` reaches this pass
with an *empty box* — nothing to transfer, and each bound's force lands on an
ordinary inequality multiplier the sweep already accounts for. Instrumenting
the branch: **0 of 114** `.nl` instances, against **19 of 400** library-level
draws. That path belongs to callers who build a `QpProblem` with `lb`/`ub`
directly (`pounce-py`, the batch API, an embedder) and to the boxes the
catalog's own bound tightening creates, and it is covered at that level. Both
the module docs and the run's docstring say so.

Chasing that down turned up a wider pre-existing problem, now filed
separately as #500: because extraction empties the box, the catalog's
**dominated-column, forcing-constraint, and activity-redundancy** reductions
are unreachable on *every* `.nl` model, measured side by side against the
same models carrying a native box. Out of scope here — this PR neither
causes nor fixes it — but it is why every `Presolve:` line in the numbers
above reads `forcing 0, dominated 0, tightened 0`.

The headline flowsheet is not in the repo, so the measurement above is a
synthetic model of the same shape.

---

- [x] Tests fail on the parent commit for the stated reason — see the
      mutation table; the tests target new code that does not exist there
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`lp-qp-routing.md` gains a
      section, `options.md` gains the cross-reference and the attribution
      note; no new page, so `SUMMARY.md` unchanged)
- [x] `cargo fmt --all -- --check`, `cargo clippy` (CI gate), `cargo test
      --workspace --exclude pounce-hsl` clean; `check-docs-consistency` and
      `check-release-consistency` clean — re-run after each `main` merge
- [x] Every claim in this body and in the code comments is true of the code
      as it stands now. The Phase-6 divergence this body used to describe was
      invalidated by #503 and has been rewritten, in `docs/src/options.md`
      and in `aggregate.rs`'s module docs as well as here

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PD83nE3agUmQkHb2uaWPJD
