### PR TITLE
fix(convex/presolve): stop certifying infeasibility on a rounding residual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — false primal-infeasible certificate on redundant equality rows that disagree by one ULP (#496)
+
+- The convex presolve fixes a variable from a singleton equality row and
+  substitutes it into the remaining rows. A row that empties in the process
+  becomes the feasibility test `0 = rhs`, and that test was written against
+  **exact zero**. But `rhs` at that point is `b − Σ aⱼ vⱼ`, a computed
+  difference — so it carries the subtraction's rounding error, and a second
+  equality that pins the same variable to the same value fails the test by
+  one ULP.
+- Found by the adversary agent while probing #492; unrelated to that change
+  and reproduced on `main`. Two rows on one column, `−2.830268 x₀ =
+  0.13596324445199998` and `2.470924 x₀ = −0.11870071803600002`, imply
+  values of `x₀` that differ by `6.9e-18`. POUNCE answered *primal
+  infeasible* at iteration 0; HiGHS solves the model it was reduced from.
+  Making the right-hand sides bit-exact, or duplicating a row verbatim, made
+  it optimal again — so the redundancy was never the trigger, only its
+  inexactness.
+- The residual is now compared against a tolerance scaled by the magnitude
+  of the terms that cancelled — the scale the rounding error actually lives
+  on — so the verdict does not change when the same rows are multiplied
+  through by 1000. Real conflicts are unaffected: rows that disagree by
+  anything a solve could act on are still certified infeasible at presolve
+  time, and the empty rows present in the *input* (no substitution, no
+  rounding) keep their exact check. The emptied-inequality test `0 ≤ rhs`
+  gets the same treatment.
+- This is the worst failure mode available to a presolver: a redundant
+  balance, an alias plus its defining equation, or a unit conversion stated
+  twice is ordinary in real models, and its right-hand sides are usually
+  computed rather than typed. Regression coverage in
+  `crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs`.
+
 ### Fixed — `solve_qp(method="active-set")` panicked across the FFI on a reversed box (#491)
 
 - `pounce.solve_qp(..., method="active-set")` with a crossed bound

--- a/adversary/log.org
+++ b/adversary/log.org
@@ -10,7 +10,7 @@ Counts update as runs land. The agent picks the LEAST-tested family each run.
 
 | Family          | Tested | Last run   | Open findings |
 |-----------------+--------+------------+---------------|
-| nlp             |     14 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6); #495 (Phase 6 reports no bound multiplier for an eliminated column whose bound is active — pre-existing, off-by-default option); #496 (LP IPM false primal-infeasible on rank-deficient equalities inconsistent by 1 ULP) |
+| nlp             |     14 | 2026-08-06 | #348 (sqp_hessian=exact Internal_Error); #349 (SQP filter no-SOC Maratos/HS6); #495 (Phase 6 reports no bound multiplier for an eliminated column whose bound is active — pre-existing, off-by-default option); #496 FIXED 2026-08-06 (LP IPM false primal-infeasible on rank-deficient equalities inconsistent by 1 ULP; the row-constant-fold probe's baseline-skip count goes 1 -> 0 at seed 987654321) |
 | lp              |     11 | 2026-08-06 | —             |
 | qp              |     11 | 2026-08-06 | —             |
 | qp-active-set   |     14 | 2026-08-05 | both probes now CLEAN. Fixed this run: false-Infeasible (14 -> 0), `Optimal` at violating points, rank-deficiency hard errors, unvalidated working-set status codes, and IpoptGet/SetWorkingSet reporting the SQP's internal row order instead of the caller's. Nothing open. |

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -16,7 +16,10 @@
 //! Reductions implemented:
 //! - **Empty rows** (equality / inequality with no nonzeros): a
 //!   feasibility check, then drop. Their dual is zero. Detects trivial
-//!   primal infeasibility (`0 = b≠0` or `0 ≤ h<0`).
+//!   primal infeasibility (`0 = b≠0` or `0 ≤ h<0`). A row emptied by
+//!   *substitution* is judged against the rounding error of the terms
+//!   that cancelled, not against exact zero — otherwise two equalities
+//!   that agree to all but the last bit read as contradictory (gh#496).
 //! - **Fixed-variable elimination** from a singleton equality row
 //!   (`a·x_k = b ⇒ x_k = b/a`): substitute `x_k` out of `P`, `c`, `A`,
 //!   `G` (adjusting the objective constant and the row right-hand
@@ -295,6 +298,14 @@ const ZERO_TOL: f64 = 0.0;
 const BOUND_FEAS_TOL: f64 = 1e-9;
 /// Slack allowed in activity-bound comparisons (redundancy / feasibility).
 const ACTIVITY_TOL: f64 = 1e-9;
+/// Relative slack allowed when a row emptied by substitution is checked for
+/// feasibility (`0 = rhs` / `0 ≤ rhs`). Scaled by the size of the terms that
+/// cancelled, because that is where the residual's rounding error lives —
+/// judging it against exact zero declares a redundant equality inconsistent
+/// at one ULP (gh#496). Matches [`ACTIVITY_TOL`], the same feasibility
+/// question asked of a row that kept its coefficients, and sits far above
+/// accumulated `f64` cancellation yet far below any real conflict.
+const EMPTY_ROW_TOL: f64 = 1e-9;
 /// How close `x_i` must be to a box bound to count it *active* when
 /// recovering bound multipliers. Looser than [`BOUND_FEAS_TOL`] because an
 /// interior-point solve only drives a variable to within ~1e-8 of a bound,
@@ -342,6 +353,12 @@ struct Row {
     coeffs: Vec<(usize, f64)>,
     rhs: f64,
     orig: usize,
+    /// Magnitude of the largest term that went into `rhs` — the original
+    /// `|b|` and every substituted `|aⱼ vⱼ|`. This is the scale the
+    /// subtraction's rounding error lives on, so it is what an emptied
+    /// row's residual must be judged against (see [`build_rows`]); a row
+    /// that keeps coefficients never consults it.
+    scale: f64,
 }
 
 /// Run presolve on `prob`, iterating the reduction passes to a **fixpoint**
@@ -1353,8 +1370,16 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
 /// Build per-row coefficient lists in the reduced column space,
 /// substituting fixed variables into the right-hand side. Rows that
 /// become empty after substitution trigger a feasibility check:
-/// `0 = rhs` (equality) requires `rhs == 0`; `0 ≤ rhs` (inequality)
-/// requires `rhs ≥ 0`. Returns `Err(())` on detected infeasibility.
+/// `0 = rhs` (equality) requires `rhs ≈ 0`; `0 ≤ rhs` (inequality)
+/// requires `rhs ⪆ 0`. Returns `Err(())` on detected infeasibility.
+///
+/// The residual `rhs` of an emptied row is `b − Σ aⱼ vⱼ`, a *computed*
+/// difference of terms of size up to [`Row::scale`], so it carries that
+/// subtraction's rounding error — testing it against exact zero would call
+/// a redundant-but-inexact row (two equalities implying the same value to
+/// the last bit) infeasible. Compare against
+/// [`EMPTY_ROW_TOL`] × the cancellation scale instead; see
+/// `tests/issue496_ulp_inconsistent_equalities.rs`.
 fn build_rows(
     triplets: &[Triplet],
     m: usize,
@@ -1380,6 +1405,7 @@ fn build_rows(
                     coeffs: Vec::new(),
                     rhs: base_rhs[r],
                     orig: r,
+                    scale: base_rhs[r].abs(),
                 })
             }
         })
@@ -1391,7 +1417,9 @@ fn build_rows(
         }
         let row = acc[t.row].as_mut().expect("non-dropped row");
         if let Some(v) = fixed[t.col] {
-            row.rhs -= t.val * v;
+            let term = t.val * v;
+            row.rhs -= term;
+            row.scale = row.scale.max(term.abs());
         } else {
             row.coeffs.push((col_new[t.col], t.val));
         }
@@ -1408,12 +1436,15 @@ fn build_rows(
                 out.push(row);
                 continue;
             }
-            // Row reduced to `0 (cmp) rhs`: a feasibility check.
+            // Row reduced to `0 (cmp) rhs`: a feasibility check, on a
+            // residual that is only meaningful down to the rounding error
+            // of the substitution that produced it.
+            let tol = EMPTY_ROW_TOL * (1.0 + row.scale);
             if is_equality {
-                if row.rhs.abs() > 0.0 {
+                if row.rhs.abs() > tol {
                     return Err(());
                 }
-            } else if row.rhs < 0.0 {
+            } else if row.rhs < -tol {
                 return Err(());
             }
             // Feasible empty row: drop it (no coefficients, no dual).

--- a/crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs
+++ b/crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs
@@ -1,0 +1,230 @@
+//! gh#496 — a false primal-infeasible certificate on rank-deficient
+//! equality rows that are consistent to within floating-point rounding.
+//!
+//! Two equality rows on one column, each a singleton, are redundant: both
+//! pin `x0`. Presolve fixes `x0` from the first and substitutes it into the
+//! second, which empties to `0 = residual`. When the two right-hand sides
+//! were *computed* rather than typed — a duplicated balance, an alias plus
+//! its defining equation, a unit conversion stated twice — that residual is
+//! a rounding artifact of size ~1e-17, not a contradiction. Testing it
+//! against exact zero rejected the model at one ULP, at iteration 0, with a
+//! confident infeasibility certificate.
+//!
+//! The check now scales with the magnitude of the terms that cancelled, so
+//! rounding-level residuals pass and real conflicts still fail.
+
+use pounce_convex::presolve::{PresolveOutcome, presolve, solve_with_presolve};
+use pounce_convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn with_presolve(prob: &QpProblem) -> pounce_convex::QpSolution {
+    solve_with_presolve(prob, |reduced| {
+        solve_qp_ipm(reduced, &QpOptions::default(), backend)
+    })
+}
+
+/// `min −x0 s.t. a0·x0 = b0, a1·x0 = b1, −10 ≤ x0 ≤ 10`.
+fn two_row_lp(a0: f64, b0: f64, a1: f64, b1: f64) -> QpProblem {
+    QpProblem {
+        n: 1,
+        p_lower: vec![],
+        c: vec![-1.0],
+        a: vec![Triplet::new(0, 0, a0), Triplet::new(1, 0, a1)],
+        b: vec![b0, b1],
+        g: vec![],
+        h: vec![],
+        lb: vec![-10.0],
+        ub: vec![10.0],
+    }
+}
+
+/// The exact instance from the issue: the two rows imply values of `x0`
+/// that differ by 6.94e-18 — one ULP at that magnitude.
+const A0: f64 = -2.830268;
+const B0: f64 = 0.13596324445199998;
+const A1: f64 = 2.470924;
+const B1: f64 = -0.11870071803600002;
+
+/// The reduction must not fire. `x0 = b0/a0` satisfies both rows to ~1e-17,
+/// so the model is feasible and the LP has a finite optimum.
+#[test]
+fn ulp_inconsistent_redundant_equalities_are_feasible() {
+    let prob = two_row_lp(A0, B0, A1, B1);
+
+    // The two rows really are inconsistent in exact arithmetic — this is
+    // the rounding-level disagreement the old check rejected, not a
+    // problem that happens to be exactly consistent.
+    let x_from_row0 = B0 / A0;
+    let x_from_row1 = B1 / A1;
+    assert_ne!(x_from_row0, x_from_row1, "instance lost its 1-ULP gap");
+    assert!((x_from_row0 - x_from_row1).abs() < 1e-16);
+
+    assert!(
+        !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+        "presolve wrongly certified infeasibility at 1 ULP (gh#496)"
+    );
+
+    let sol = with_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal, "obj={}", sol.obj);
+    assert!(
+        (sol.x[0] - x_from_row0).abs() < 1e-9,
+        "x0={} expected ≈{x_from_row0}",
+        sol.x[0]
+    );
+    assert!((sol.obj - (-x_from_row0)).abs() < 1e-9, "obj={}", sol.obj);
+}
+
+/// The certificate must not be recoverable by scaling either: the residual
+/// tolerance is relative to the size of the terms that cancelled, so
+/// multiplying both rows by 1000 (which multiplies the residual by 1000)
+/// changes nothing.
+#[test]
+fn ulp_inconsistency_stays_feasible_under_scaling() {
+    for s in [1e-3, 1.0, 1e3, 1e6] {
+        let prob = two_row_lp(A0 * s, B0 * s, A1 * s, B1 * s);
+        assert!(
+            !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+            "scale {s}: presolve wrongly certified infeasibility"
+        );
+        assert_eq!(with_presolve(&prob).status, QpStatus::Optimal, "scale {s}");
+    }
+}
+
+/// Exactly consistent variants were never affected; they must stay optimal.
+#[test]
+fn exactly_consistent_redundant_equalities_still_optimal() {
+    for (name, prob) in [
+        ("exact rhs", two_row_lp(A0, B0, A1, A1 * (B0 / A0))),
+        ("duplicate row", two_row_lp(A0, B0, A0, B0)),
+        ("clean integers", two_row_lp(2.0, 2.0, 3.0, 3.0)),
+        ("both rhs zero", two_row_lp(A0, 0.0, A1, 0.0)),
+    ] {
+        assert_eq!(
+            with_presolve(&prob).status,
+            QpStatus::Optimal,
+            "{name} regressed"
+        );
+    }
+}
+
+/// The widened tolerance must not blunt real detection: rows that disagree
+/// by anything a solve could act on are still certified infeasible at
+/// presolve time.
+#[test]
+fn genuinely_inconsistent_equalities_still_infeasible() {
+    for gap in [1e-6, 1e-3, 1.0, 100.0] {
+        let prob = two_row_lp(A0, B0, A1, B1 - gap);
+        assert!(
+            matches!(presolve(&prob), PresolveOutcome::Infeasible),
+            "gap {gap}: real conflict went undetected"
+        );
+        assert_eq!(
+            with_presolve(&prob).status,
+            QpStatus::PrimalInfeasible,
+            "gap {gap}"
+        );
+    }
+}
+
+/// Deterministic splitmix64, so the sweep below reproduces bit for bit.
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E3779B97F4A7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+    z ^ (z >> 31)
+}
+
+/// The generator that surfaced this: build the instance *around* a known
+/// feasible point, so both right-hand sides are computed (`bᵢ = aᵢ·x*`)
+/// rather than typed, and their implied values of `x0` agree only to the
+/// last bit or two. Before the fix this rejected roughly 1 instance in 250;
+/// every one of them is feasible by construction.
+#[test]
+fn random_redundant_equalities_around_a_feasible_point() {
+    let mut state: u64 = 987_654_321;
+    let draw = |lo: f64, hi: f64, state: &mut u64| {
+        // 53-bit uniform in [0,1), mapped to [lo, hi).
+        let u = (splitmix64(state) >> 11) as f64 / (1u64 << 53) as f64;
+        lo + u * (hi - lo)
+    };
+
+    for trial in 0..2000 {
+        let x_star = draw(-1.0, 1.0, &mut state);
+        let a0 = draw(-3.0, 3.0, &mut state);
+        let a1 = draw(-3.0, 3.0, &mut state);
+        if a0.abs() < 1e-3 || a1.abs() < 1e-3 {
+            continue; // a near-zero pivot is a conditioning question, not this one
+        }
+        // Right-hand sides computed from the feasible point — the rounding
+        // in each product is what makes the pair inexactly redundant.
+        let prob = two_row_lp(a0, a0 * x_star, a1, a1 * x_star);
+
+        assert!(
+            !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+            "trial {trial}: a0={a0} a1={a1} x*={x_star} wrongly certified infeasible"
+        );
+        let sol = with_presolve(&prob);
+        assert_eq!(
+            sol.status,
+            QpStatus::Optimal,
+            "trial {trial}: a0={a0} a1={a1} x*={x_star}"
+        );
+        assert!(
+            (sol.x[0] - x_star).abs() < 1e-9,
+            "trial {trial}: x0={} expected ≈{x_star}",
+            sol.x[0]
+        );
+    }
+}
+
+/// The inequality analogue, end to end: `x0 = b0/a0` together with an
+/// inequality the same point meets only to the last bit. `0 ≤ −1.4e-17` is
+/// a rounding artifact, not a violation, and the model must solve.
+///
+/// This shape passed before the fix too — the activity-bound pass sees the
+/// row while `x0` is already fixed, and *it* has always used a tolerance
+/// (`ACTIVITY_TOL`), so it drops the row as redundant before `build_rows`
+/// ever looks. The `0 ≤ rhs` check in `build_rows` is the backstop for the
+/// rows that reach it instead (fixings made *after* the activity pass —
+/// forcing rows, dominated columns, bound tightening); it used to disagree
+/// with the activity pass by rejecting at exact zero, and now agrees. So
+/// this is a guard against that divergence reopening, not a reproducer.
+///
+/// The orientation is chosen from the residual's actual sign rather than
+/// assumed — with the other one the residual lands on the nonnegative side
+/// and there is nothing to reject.
+#[test]
+fn ulp_violated_emptied_inequality_is_feasible() {
+    let x0 = B0 / A0; // the value presolve fixes from the equality row
+    let residual = B1 - A1 * x0; // `a1·x0 ≤ b1` leaves `0 ≤ residual`
+    assert_ne!(residual, 0.0, "instance lost its rounding residual");
+    let sign = if residual < 0.0 { 1.0 } else { -1.0 };
+    assert!(
+        (sign * residual).abs() < 1e-16 && sign * residual < 0.0,
+        "expected a rounding-level negative residual, got {}",
+        sign * residual
+    );
+
+    let prob = QpProblem {
+        n: 1,
+        p_lower: vec![],
+        c: vec![-1.0],
+        a: vec![Triplet::new(0, 0, A0)],
+        b: vec![B0],
+        g: vec![Triplet::new(0, 0, sign * A1)],
+        h: vec![sign * B1],
+        lb: vec![-10.0],
+        ub: vec![10.0],
+    };
+    assert!(
+        !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+        "emptied inequality wrongly certified infeasible at 1 ULP"
+    );
+    assert_eq!(with_presolve(&prob).status, QpStatus::Optimal);
+}


### PR DESCRIPTION
Fixes #496

## Problem

Two equality rows on one column, redundant and consistent, but with right-hand sides that imply values of `x0` differing by `6.9e-18` — one ULP. POUNCE certifies the model primal infeasible at iteration 0.

```
min  -x0
s.t. -2.830268 x0 =  0.13596324445199998
      2.470924 x0 = -0.11870071803600002
     -10 <= x0 <= 10
```

| | status | objective | constraint violation | iters |
|---|---|---|---|---|
| before | Problem is primal infeasible | 0 | 1.36e-01 (at the *initial* point) | 0 |
| after | Optimal Solution Found | 0.04803900 | 1.39e-17 | 0 |
| oracle (scipy HiGHS `linprog`) | optimal | `-14.060284628789999` on the 7-column instance this was reduced from | — | — |

A known feasible point exists by construction and satisfies both rows to ~1e-17.

## Cause

`crates/pounce-convex/src/presolve.rs`. Presolve fixes `x0` from the first singleton equality row and substitutes it into the second, which empties to `0 = rhs`. That feasibility test was written against exact zero:

```rust
if row.rhs.abs() > 0.0 { return Err(()); }   // -> PresolveOutcome::Infeasible
```

But `rhs` at that point is `b - Σ aⱼ vⱼ`, a *computed* difference, so it carries the subtraction's rounding error. The residual here is 1.4e-17 and reads as a contradiction.

That also accounts for the full variant table in the issue, which the redundancy-based explanations do not: exact duplicates, clean integers, and both-rhs-zero all leave a residual of exactly 0, so they never fired; scaling both rows by 1000 scales the residual by 1000, which a fixed zero threshold cannot survive.

## Fix

Each row tracks `Row::scale` — the largest term that went into its `rhs` (the original `|b|` and every substituted `|aⱼvⱼ|`). That is the scale the rounding error lives on, so the emptied-row check compares against `EMPTY_ROW_TOL * (1 + scale)` with `EMPTY_ROW_TOL = 1e-9`, matching `ACTIVITY_TOL` — the same feasibility question asked of a row that kept its coefficients.

Scaling the cancellation scale rather than using a flat absolute tolerance is what makes the verdict invariant under multiplying the rows through by a constant; a flat threshold would just move the issue's reproducer to a different magnitude, which is exactly the failure the `x1000` row of the issue's table demonstrates.

Two deliberate limits on the blast radius:

- **Empty rows present in the *input* keep their exact check** (`prob.b[row] != 0.0`). No substitution happened, so there is no rounding to forgive, and `0 = 1e-18` written literally by a model is a statement about the model, not an artifact. Those rows are also the only ones that reach that check — `build_rows` drops emptied rows, so a fixpoint pass never feeds one back in.
- **The `0 <= rhs` inequality branch gets the same treatment**, for consistency rather than to fix a live defect — see Tests.

## Blast radius

Behaviour changes only for a row that (a) empties after substitution and (b) has a residual in `(0, 1e-9*(1+scale)]`. Every other input is bit-identical: the tolerance is consulted on exactly one branch, one that previously compared to zero.

Real conflicts are unaffected — injected disagreements of 1e-6, 1e-3, and 1.0 are still certified infeasible at presolve time, against a 1e-9 relative bar.

I did **not** run the benchmark corpus sweep. The models it contains do not exercise the changed branch except by the coincidence this PR is about, and a sweep would report no diff without that being evidence of anything. The evidence offered instead is the full workspace suite plus the 2000-instance randomized sweep below.

## Tests

New: `crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs`, six tests.

- the issue's exact instance, asserting first that the 1-ULP gap is really there (so the test cannot silently degrade into an exactly-consistent case);
- the same instance at scales 1e-3 / 1 / 1e3 / 1e6, which is what pins the residual tolerance to the cancellation scale rather than to a constant;
- the exactly-consistent variants (bit-exact rhs, duplicated row, clean integers, both rhs zero), guarding against a fix that trades one direction for the other;
- genuine conflicts at gaps 1e-6 / 1e-3 / 1 / 100, still infeasible;
- a 2000-instance deterministic sweep (in-file splitmix64) reproducing the generator that surfaced this — instances built around a random feasible point so both right-hand sides are *computed* rather than typed. This is the shape the adversary run hit at roughly 1 in 250.

**Three of the six fail on the parent commit** (`cad2b13`), for the stated reason — a `PresolveOutcome::Infeasible` on a feasible instance. Verified by stashing only `presolve.rs` and re-running.

One gap, stated so it is a known one: `ulp_violated_emptied_inequality_is_feasible` passes with *and* without the fix, so it is not a regression test. The activity-bound pass sees that row while `x0` is already fixed and has always used `ACTIVITY_TOL`, so it drops the row before `build_rows` looks. The `0 <= rhs` branch is only reachable via fixings made *after* the activity pass (forcing rows, dominated columns, bound tightening), which I did not find a compact instance for. The test is kept as a guard against that divergence reopening if the pass order changes, and its doc comment says exactly this rather than letting it read as a reproducer.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] ~Book page under `docs/src/`~ — n/a; the tolerance is internal to presolve and not a documented option
- [x] `cargo fmt --all -- --check`, CI's clippy gate (`-D clippy::correctness -D clippy::suspicious`), and `cargo test --workspace --exclude pounce-hsl` all clean. `pounce-hsl` excluded as CI does — it FFI-links the licensed CoinHSL, absent here.
- [x] Every claim in this body is true of the diff as it stands

---
_Generated by [Claude Code](https://claude.ai/code/session_01NRUVKiyXAfdSM9GzJXZ6hw)_