### PR TITLE
fix(qp): an empty variable box is a verdict, not a panic — on every route (#491)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,18 +50,71 @@ changes.
   methods now agree at every crossing width.
 - Well-formed boxes are untouched: the screen returns the caller's problem by
   reference and every solve downstream of it is bit-identical.
-- Scope, stated precisely: this is about the `lb`/`ub` **box**, so it covers
-  `solve_qp`, the raw `_pounce` bindings, and direct `pounce-convex` callers.
-  The CLI's `.nl` route expands variable bounds into explicit `Gx ≤ h` rows
-  (`qp_extract` leaves `lb`/`ub` empty) and so never showed this defect — but
-  presolve's bound tightening writes its tightened `tlb`/`tub` back into the
-  reduced problem's box, which is the route by which a crossed box can reach a
-  solver from a model that did not have one, and is why the hairline repair
-  exists rather than a flat rejection.
 - The comment at `python/pounce/qp.py:397` claimed the finite reversed case
   "is correctly reported `primal_infeasible` by the solver". That was true of
   the IPM only — and only outside its `NaN` band — and is what left this gap
   unexamined; it now says what each path does.
+
+### Changed — `.nl` variable bounds reach the convex solvers as a box, not as rows (#491)
+
+- `qp_extract` emitted each finite `.nl` variable bound as a `G` row
+  (`x ≤ x_u`, `−x ≤ −x_l`) and left the solver's `lb`/`ub` empty. That was
+  never *wrong* — the IPM re-expands finite bounds into exactly those rows
+  internally — but it discarded the one thing only the box can carry: that
+  these rows **are** a box. Bounds now go in the box on both the QP and SOCP
+  extraction paths, and their multipliers come back in `z_lb`/`z_ub` instead
+  of being decoded out of `z` by row position.
+- Three consequences, all real. The empty-box screen above reads `lb`/`ub`, so
+  a reversed bound in a model arrived as a pair of contradictory *rows* — an
+  infeasibility that has to be certified numerically rather than seen. The
+  active-set engine handles a box with bound statuses rather than constraint
+  rows, so every `.nl` QP carried up to `2n` rows it did not need, in the one
+  dimension an active-set method pays combinatorially for. And presolve
+  reasons over `tlb`/`tub`, so bounds hidden in rows had to be rediscovered
+  before any box reduction could fire.
+
+### Fixed — presolve could not read a singleton row as the bound it is (#491)
+
+- Two defects, both of which had to go before a variable box written as a pair
+  of rows could be recognized as one:
+  - **`−∞ − (−∞) = NaN`.** The implied bound on a column needs the row's
+    activity *without* that column, and it was computed by subtracting the
+    column's own contribution from the total. The moment that contribution was
+    the infinite one the result was `NaN`, `val.is_finite()` was false, and the
+    tightening silently did nothing — for *every* column of any row holding a
+    variable unbounded on the relevant side, the singleton row `x ≤ u`
+    included. Activity is now accumulated as a finite part plus a count of
+    infinite terms, so the leave-one-out is exact and the rest is infinite only
+    if some *other* column is.
+  - **Whole-column source disjointness.** A tightening source row claimed its
+    entire column, so of the pair `x ≤ u` / `−x ≤ −l` only the first was ever
+    used and only one side of the box was derived. A **singleton** row now
+    claims just the `(column, side)` it implies. Multi-column rows keep the
+    conservative whole-column claim: their `Gᵀz` credit lands in every column
+    they touch, and relaxing it there produces a postsolved point with a
+    nonzero reduced cost at an interior variable (caught by
+    `randomized_overlapping_tightening_roundtrip`).
+- Net effect: a contradictory pair is now presolved to `Infeasible` — the
+  `1e-8` case reported `Numerical failure … obj=NaN` after 169 iterations and
+  now reports `Problem is primal infeasible` in 0 — and a consistent pair
+  becomes the box it describes, which also drops both rows as redundant.
+  Two reduction tests asserted the *old mechanism* ("the row is kept") for
+  cases that now become bounds; they assert the invariant they were named for
+  instead (the constraint still binds; both sides of a range survive).
+
+### Fixed — a `NaN` iterate could leave the convex solvers (#491)
+
+- `finite_or_failed` gates every caller-facing convex entry point
+  (`solve_qp_ipm`, `solve_qp_ipm_warm`, `solve_socp_ipm`,
+  `solve_qp_active_set`): a non-finite entry in `x`, `y`, `z`, `z_lb`, `z_ub`,
+  or `obj` is replaced by a zero-filled `NumericalFailure`. A `NaN` in a
+  returned iterate is never information — it cannot be checked against a bound,
+  printed into a `.sol`, or warm-started from, and it turns every arithmetic
+  downstream into another `NaN`, converting one solver's failure into the
+  caller's several steps removed from the cause. The status was already
+  `NumericalFailure` in the case this was written for; `obj=NaN` still reached
+  the CLI's summary line. The `*_debug` entry points deliberately pass the raw
+  iterate through — it is what the hook was attached to see.
 
 ### Added — LP and convex-QP presolve folds away two-variable equality rows (#494)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `solve_qp(method="active-set")` panicked across the FFI on a reversed box (#491)
+
+- `pounce.solve_qp(..., method="active-set")` with a crossed bound
+  (`lb > ub`) **panicked out of Rust into Python** — `pyo3_runtime.
+  PanicException: min > max, or either was NaN` — instead of returning
+  `primal_infeasible` the way `method="ipm"` does on the identical input.
+  Because `PanicException` derives from `BaseException`, a caller that had
+  defensively wrapped the solve in `except Exception` still lost its loop.
+  Found by the nightly adversary run.
+- The path: the engine's own `validate` rejects `xl > xu`, so the driver's
+  first two attempts returned `NumericalFailure` and it fell through to the
+  last-resort simplex-seeded attempt — where the seed was clamped into the
+  inverted interval and `f64::clamp` panicked. `clamp` panics on
+  `min > max`; the seed builder now uses `max`-then-`min`, so it can no
+  longer be the thing that takes the process down.
+- The real fix is a screen on the variable box at the active-set driver's
+  entry, peer to the one the IPM already runs at each of its own. It is in
+  the Rust core rather than in `qp.py`'s validation pass, so it holds for
+  the raw `_pounce` bindings, the CLI's `qp-active-set` route, and direct
+  Rust callers too. A reversed box is `PrimalInfeasible` by inspection —
+  `x_i ≥ lb_i > ub_i ≥ x_i` has no solution — which is the one
+  infeasibility claim this driver may make without re-deriving a
+  certificate. The gh #295 impossible-bound class (a *present* `+∞` lower /
+  `−∞` upper) is screened here as well; the active-set path had no check
+  for it at all.
+- A crossing of `1e-9` or less is repaired rather than rejected: presolve's
+  bound tightening tolerates exactly that much and can hand this driver a
+  reduced problem carrying one, so the variable is fixed at its box
+  midpoint and solved. That is also where the IPM draws the line — measured
+  on `min ½x² s.t. 0 ≤ x ≤ −gap`, crossings up to `1e-9` converge to the
+  midpoint and report `Optimal` — so the two methods now agree across the
+  whole range rather than splitting on it.
+- The comment at `python/pounce/qp.py:397` claimed the finite reversed case
+  "is correctly reported `primal_infeasible` by the solver". That was true
+  of the IPM only, and is what left this gap unexamined; it now says which
+  path it is describing.
+
 ### Added — LP and convex-QP presolve folds away two-variable equality rows (#494)
 
 - A row `a₁·x + a₂·y = b` linking two variables says one of them *is* the
@@ -48,6 +85,7 @@ changes.
   where presolve fixed or substituted a variable carried an `iterations`
   array offset by that constant. The final objective, the solution, and
   the duals were always right; only the trace was affected.
+
 
 ### Fixed — a constant left in a `.nl` row body made an affine row look nonlinear (#492)
 
@@ -122,6 +160,7 @@ changes.
 - One documented caveat remains, in `docs/src/options.md`: a contradictory
   equality system makes the pass stand down entirely rather than be the
   first and only voice calling a model infeasible.
+
 
 ### Fixed — the C working-set API validated nothing structural, and reported the wrong row order (#484 follow-up, round 4)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,27 +24,44 @@ changes.
   inverted interval and `f64::clamp` panicked. `clamp` panics on
   `min > max`; the seed builder now uses `max`-then-`min`, so it can no
   longer be the thing that takes the process down.
-- The real fix is a screen on the variable box at the active-set driver's
-  entry, peer to the one the IPM already runs at each of its own. It is in
-  the Rust core rather than in `qp.py`'s validation pass, so it holds for
-  the raw `_pounce` bindings, the CLI's `qp-active-set` route, and direct
-  Rust callers too. A reversed box is `PrimalInfeasible` by inspection —
-  `x_i ≥ lb_i > ub_i ≥ x_i` has no solution — which is the one
-  infeasibility claim this driver may make without re-deriving a
+- The real fix is a single screen on the variable box, `screen_variable_box`,
+  run at **every** convex solve entry point — both engines' alike. Whether a
+  box is empty is an input-domain question, and the answer must not depend on
+  which engine the caller selected. It lives in the Rust core rather than in
+  `qp.py`'s validation pass, so it holds for the raw `_pounce` bindings, the
+  CLI, and direct Rust callers too. A reversed box is `PrimalInfeasible` by
+  inspection — `x_i ≥ lb_i > ub_i ≥ x_i` has no solution — which is the one
+  infeasibility claim the active-set driver may make without re-deriving a
   certificate. The gh #295 impossible-bound class (a *present* `+∞` lower /
-  `−∞` upper) is screened here as well; the active-set path had no check
-  for it at all.
+  `−∞` upper) now runs through the same screen; the active-set path had no
+  check for it at all.
 - A crossing of `1e-9` or less is repaired rather than rejected: presolve's
-  bound tightening tolerates exactly that much and can hand this driver a
-  reduced problem carrying one, so the variable is fixed at its box
-  midpoint and solved. That is also where the IPM draws the line — measured
-  on `min ½x² s.t. 0 ≤ x ≤ −gap`, crossings up to `1e-9` converge to the
-  midpoint and report `Optimal` — so the two methods now agree across the
-  whole range rather than splitting on it.
+  bound tightening tolerates exactly that much and can hand a driver a
+  reduced problem carrying one, so the variable is fixed at its box midpoint
+  and solved.
+- **The IPM's own answer on a reversed box was not uniform either**, which
+  the same screen fixes. Measured on `min ½x² s.t. 0 ≤ x ≤ −gap` before the
+  change: crossings up to `1e-9` converged to the box midpoint and reported
+  `Optimal`, crossings of `1e-6` and wider reported `PrimalInfeasible`, and
+  the band between them — `1e-8`, `1e-7` — reported `NumericalFailure` at a
+  `NaN` iterate. The screen keeps the two outer bands (the snap-to-midpoint
+  repair *is* the answer the iteration was already reaching) and replaces the
+  `NaN` band with the verdict the bands on both sides of it imply. Both
+  methods now agree at every crossing width.
+- Well-formed boxes are untouched: the screen returns the caller's problem by
+  reference and every solve downstream of it is bit-identical.
+- Scope, stated precisely: this is about the `lb`/`ub` **box**, so it covers
+  `solve_qp`, the raw `_pounce` bindings, and direct `pounce-convex` callers.
+  The CLI's `.nl` route expands variable bounds into explicit `Gx ≤ h` rows
+  (`qp_extract` leaves `lb`/`ub` empty) and so never showed this defect — but
+  presolve's bound tightening writes its tightened `tlb`/`tub` back into the
+  reduced problem's box, which is the route by which a crossed box can reach a
+  solver from a model that did not have one, and is why the hairline repair
+  exists rather than a flat rejection.
 - The comment at `python/pounce/qp.py:397` claimed the finite reversed case
-  "is correctly reported `primal_infeasible` by the solver". That was true
-  of the IPM only, and is what left this gap unexamined; it now says which
-  path it is describing.
+  "is correctly reported `primal_infeasible` by the solver". That was true of
+  the IPM only — and only outside its `NaN` band — and is what left this gap
+  unexamined; it now says what each path does.
 
 ### Added — LP and convex-QP presolve folds away two-variable equality rows (#494)
 

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2195,20 +2195,16 @@ fn run_convex_qp(
     // report.
     let lambda = pounce_cli::qp_extract::recover_duals(prob, &con_map, &sol.y, &sol.z);
 
-    // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`). The QP extractor
-    // folds each finite variable bound into a nonnegative `G` row (so
-    // `sol.z_lb`/`z_ub` stay empty); `recover_bound_mults` reads the raw
-    // non-negative multipliers back out of `sol.z`. They are for the
-    // *internal* minimize form (`½xᵀPx + cᵀx`, a maximize objective
-    // negated), so `sign` restores the user's objective sense — the same
-    // conversion `recover_duals` applies to the constraint duals. The
-    // Ipopt output convention (verified numerically, gh #296) is
-    // `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u`, both equal to the
-    // objective-gradient component at the bound. QP variables are 1:1 with
-    // the `.nl` variables, so no remap is needed.
-    let n_con_ineq = pounce_cli::qp_extract::count_constraint_ineq_rows(&con_map);
-    let (z_lb_raw, z_ub_raw) =
-        pounce_cli::qp_extract::recover_bound_mults(prob, n_con_ineq, &sol.z);
+    // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`). The QP extractor puts
+    // the `.nl` variable bounds in the solver's explicit box, so these come
+    // back directly in `sol.z_lb`/`z_ub`. They are for the *internal* minimize
+    // form (`½xᵀPx + cᵀx`, a maximize objective negated), so `sign` restores
+    // the user's objective sense — the same conversion `recover_duals` applies
+    // to the constraint duals. The Ipopt output convention (verified
+    // numerically, gh #296) is `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u`,
+    // both equal to the objective-gradient component at the bound. QP
+    // variables are 1:1 with the `.nl` variables, so no remap is needed.
+    let (z_lb_raw, z_ub_raw) = pounce_cli::qp_extract::recover_bound_mults(prob, &sol);
     let z_l_suffix: Vec<f64> = z_lb_raw.iter().map(|&z| sign * z).collect();
     let z_u_suffix: Vec<f64> = z_ub_raw.iter().map(|&z| -sign * z).collect();
     let qp_bound_suffixes = [
@@ -2435,15 +2431,13 @@ fn run_convex_socp(
     // `recover_socp_duals`).
     let lambda = pounce_cli::qp_extract::recover_socp_duals(prob, &con_map, &sol.y, &sol.z);
 
-    // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`), recovered from the
-    // nonnegative-block multipliers `sol.z` (variable bounds are `G` rows
-    // appended right after the linear-inequality rows and before the SOC
-    // cones). `sign` restores the user objective sense and the Ipopt output
-    // convention is `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u` — same
-    // treatment as the QP path (gh #296).
-    let n_con_ineq = pounce_cli::qp_extract::count_socp_constraint_ineq_rows(&con_map);
-    let (z_lb_raw, z_ub_raw) =
-        pounce_cli::qp_extract::recover_bound_mults(prob, n_con_ineq, &sol.z);
+    // Bound multipliers (`ipopt_zL_out`/`ipopt_zU_out`). As on the QP path the
+    // variable bounds live in the solver's explicit box — outside the cone
+    // partition, which covers only the linear-inequality rows and the SOC
+    // blocks — so they come back in `sol.z_lb`/`z_ub`. `sign` restores the
+    // user objective sense and the Ipopt output convention is
+    // `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u` (gh #296).
+    let (z_lb_raw, z_ub_raw) = pounce_cli::qp_extract::recover_bound_mults(prob, &sol);
     let z_l_suffix: Vec<f64> = z_lb_raw.iter().map(|&z| sign * z).collect();
     let z_u_suffix: Vec<f64> = z_ub_raw.iter().map(|&z| -sign * z).collect();
     let socp_bound_suffixes = [

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -8,7 +8,8 @@
 //! ```text
 //! minimize    ½ xᵀP x + cᵀx
 //! subject to  A x = b          (equalities)
-//!             G x ≤ h          (inequalities, incl. finite var bounds)
+//!             G x ≤ h          (inequalities)
+//!             lb ≤ x ≤ ub      (the variable box)
 //! ```
 //!
 //! Mapping from the `.nl` representation:
@@ -21,11 +22,12 @@
 //!   g_u`. An equality (`g_l == g_u`) becomes a row of `A`; a one- or
 //!   two-sided inequality becomes one or two rows of `G` (`row ≤ g_u`
 //!   and/or `−row ≤ −g_l`).
-//! - **Variable bounds.** Present `x_l`/`x_u` become `G` rows
-//!   (`−x_i ≤ −x_l`, `x_i ≤ x_u`). The `.nl` "infinity" sentinel is
-//!   read directionally: `x_l ≤ -1e19` is no lower bound, `x_u ≥ 1e19`
-//!   is no upper bound. A bound past the *opposite* sentinel (an upper
-//!   bound of `-5e20`) is an ordinary bound and is kept.
+//! - **Variable bounds.** Present `x_l`/`x_u` become the solver's explicit
+//!   box (see [`extract_box`] for why they are no longer emitted as `G`
+//!   rows). The `.nl` "infinity" sentinel is read directionally: `x_l ≤
+//!   -1e19` is no lower bound, `x_u ≥ 1e19` is no upper bound. A bound past
+//!   the *opposite* sentinel (an upper bound of `-5e20`) is an ordinary
+//!   bound and is kept.
 
 use crate::dispatch::analyze_quadratic_full;
 use crate::nl_reader::NlProblem;
@@ -35,7 +37,7 @@ use crate::nl_reader::NlProblem;
 // it and was dropped from `G` entirely, so the QP was solved over a strictly
 // larger box and reported `Optimal` at a point the model excludes.
 use pounce_common::types::{lower_bound_present, upper_bound_present};
-use pounce_convex::{ConeSpec, QpProblem, Triplet};
+use pounce_convex::{ConeSpec, QpProblem, QpSolution, Triplet};
 
 /// Convert a classified LP/convex-QP `NlProblem` into `QpProblem`
 /// standard form. Returns `None` if the objective is not actually a
@@ -166,21 +168,8 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
         }
     }
 
-    // --- variable bounds as G rows (not part of the constraint map) ---
-    for i in 0..n {
-        let xl = prob.x_l[i];
-        let xu = prob.x_u[i];
-        if upper_bound_present(xu) {
-            let gr = next_row(&h);
-            g.push(Triplet::new(gr, i, 1.0)); // x_i ≤ xu
-            h.push(xu);
-        }
-        if lower_bound_present(xl) {
-            let gr = next_row(&h);
-            g.push(Triplet::new(gr, i, -1.0)); // −x_i ≤ −xl
-            h.push(-xl);
-        }
-    }
+    // --- variable bounds as the explicit box (not as `G` rows) ---
+    let (lb, ub) = extract_box(prob);
 
     Some((
         QpProblem {
@@ -191,14 +180,61 @@ pub fn extract_qp_with_map(prob: &NlProblem) -> Option<(QpProblem, Vec<ConRowMap
             b,
             g,
             h,
-            // Variable bounds are currently emitted as `G` rows (see the
-            // bound-handling above), so the explicit box is left empty.
-            lb: Vec::new(),
-            ub: Vec::new(),
+            lb,
+            ub,
         },
         con_map,
         obj_nl_constant,
     ))
+}
+
+/// The `.nl` variable bounds as `pounce-convex`'s explicit box, with an
+/// absent bound spelled `∓∞`.
+///
+/// Both extractors used to emit each finite bound as a `G` row (`x_i ≤ x_u`,
+/// `−x_i ≤ −x_l`) and leave `lb`/`ub` empty. That was never wrong — the IPM
+/// re-expands finite bounds into exactly those rows internally — but it threw
+/// away the one thing the solvers can only get from the box: **that these
+/// rows are a box**. Three consequences, all real:
+///
+/// * The empty-box screen ([`pounce_convex`]'s `screen_variable_box`, gh #491)
+///   reads `lb`/`ub`, so a model with a reversed bound arrived as a pair of
+///   contradictory rows instead — an infeasibility that has to be *certified*
+///   numerically rather than seen. The interior-point method managed that at
+///   most widths but returned `NumericalFailure` at a `NaN` iterate for
+///   crossings around `1e-8`.
+/// * The active-set engine handles a box with bound *statuses*, not with
+///   constraint rows; feeding it `2n` extra rows made every `.nl` QP that much
+///   larger in the one dimension an active-set method pays combinatorially
+///   for.
+/// * Presolve reasons about `tlb`/`tub` directly, so bounds hidden in rows had
+///   to be rediscovered by activity-based tightening before any box reduction
+///   could fire.
+///
+/// The bound *multipliers* now come back in the solution's `z_lb`/`z_ub`
+/// rather than being decoded out of `z` by row position.
+fn extract_box(prob: &NlProblem) -> (Vec<f64>, Vec<f64>) {
+    let lb = (0..prob.n)
+        .map(|i| {
+            let v = prob.x_l[i];
+            if lower_bound_present(v) {
+                v
+            } else {
+                f64::NEG_INFINITY
+            }
+        })
+        .collect();
+    let ub = (0..prob.n)
+        .map(|i| {
+            let v = prob.x_u[i];
+            if upper_bound_present(v) {
+                v
+            } else {
+                f64::INFINITY
+            }
+        })
+        .collect();
+    (lb, ub)
 }
 
 /// Map the QP solver's multipliers `(y, z)` back to a per-`.nl`-
@@ -239,74 +275,26 @@ fn next_row(rhs: &[f64]) -> usize {
     rhs.len()
 }
 
-/// Count the nonnegative (`G`) rows the *constraints* contributed, so the
-/// appended variable-bound rows can be located. Both extractors emit each
-/// linear inequality / range constraint as up to two `G` rows (an upper
-/// `row ≤ g_u` and/or a lower `−row ≤ −g_l`) and place the per-variable
-/// bound rows immediately after them (equalities go to `A`, and the SOCP
-/// cones are appended *after* the bound rows). This count is that offset.
-pub fn count_constraint_ineq_rows(con_map: &[ConRowMap]) -> usize {
-    con_map
-        .iter()
-        .map(|m| match m {
-            ConRowMap::Eq { .. } => 0,
-            ConRowMap::Ineq { upper, lower } => upper.is_some() as usize + lower.is_some() as usize,
-        })
-        .sum()
-}
-
-/// SOCP analogue of [`count_constraint_ineq_rows`]: only the linear
-/// inequality rows land in the nonnegative block *before* the variable
-/// bounds (equalities → `A`; quadratics → cones appended afterwards).
-pub fn count_socp_constraint_ineq_rows(con_map: &[ConSocpMap]) -> usize {
-    con_map
-        .iter()
-        .map(|m| match m {
-            ConSocpMap::Ineq { upper, lower } => {
-                upper.is_some() as usize + lower.is_some() as usize
-            }
-            ConSocpMap::Eq { .. } | ConSocpMap::Quad { .. } => 0,
-        })
-        .sum()
-}
-
-/// Recover the per-variable **bound multipliers** from the inequality
-/// multiplier vector `z`. Both extractors fold each finite variable bound
-/// into a nonnegative `G` row (`x_i ≤ x_u` and/or `−x_i ≤ −x_l`), appended
-/// right after the `n_con_ineq_rows` constraint-derived rows, in variable
-/// order with the upper row before the lower row. The `G`-row multiplier of
-/// `x_i ≤ x_u` is the (non-negative) upper-bound multiplier `z_ub[i]`; that
-/// of `−x_i ≤ −x_l` is the lower-bound multiplier `z_lb[i]`. Slots without a
-/// finite bound stay `0.0`.
+/// Recover the per-variable **bound multipliers** from a solved QP or SOCP.
+///
+/// Both extractors put the `.nl` variable bounds in the explicit box
+/// ([`extract_box`]), so the solver returns their multipliers directly in
+/// `z_lb`/`z_ub` and this is a length-normalizing read rather than the
+/// row-position decode it used to be. Variables are 1:1 with the `.nl`
+/// variables in both extractors, so no index remap is needed; a slot without
+/// a finite bound stays `0.0` because no bound was active there.
 ///
 /// The returned `z_lb` / `z_ub` are the raw non-negative multipliers of the
 /// *internal minimize* problem (a maximize objective was negated during
 /// extraction); the caller applies the maximize `sign` and the Ipopt
 /// `ipopt_zL_out = +z_l`, `ipopt_zU_out = −z_u` output convention.
-pub fn recover_bound_mults(
-    prob: &NlProblem,
-    n_con_ineq_rows: usize,
-    z: &[f64],
-) -> (Vec<f64>, Vec<f64>) {
-    let n = prob.n;
-    let mut z_lb = vec![0.0; n];
-    let mut z_ub = vec![0.0; n];
-    let mut row = n_con_ineq_rows;
-    for i in 0..n {
-        if upper_bound_present(prob.x_u[i]) {
-            if let Some(&zv) = z.get(row) {
-                z_ub[i] = zv;
-            }
-            row += 1;
-        }
-        if lower_bound_present(prob.x_l[i]) {
-            if let Some(&zv) = z.get(row) {
-                z_lb[i] = zv;
-            }
-            row += 1;
-        }
-    }
-    (z_lb, z_ub)
+pub fn recover_bound_mults(prob: &NlProblem, sol: &QpSolution) -> (Vec<f64>, Vec<f64>) {
+    let read = |v: &[f64]| -> Vec<f64> {
+        (0..prob.n)
+            .map(|i| v.get(i).copied().unwrap_or(0.0))
+            .collect()
+    };
+    (read(&sol.z_lb), read(&sol.z_ub))
 }
 
 // ===========================================================================
@@ -488,21 +476,11 @@ pub fn extract_socp_with_map(
         }
     }
 
-    // --- variable bounds as nonnegative G rows (not in the constraint map) ---
-    for i in 0..n {
-        let xl = prob.x_l[i];
-        let xu = prob.x_u[i];
-        if upper_bound_present(xu) {
-            let gr = next_row(&h);
-            g.push(Triplet::new(gr, i, 1.0));
-            h.push(xu);
-        }
-        if lower_bound_present(xl) {
-            let gr = next_row(&h);
-            g.push(Triplet::new(gr, i, -1.0));
-            h.push(-xl);
-        }
-    }
+    // Variable bounds go in the explicit box, not into this orthant block —
+    // see [`extract_box`]. `solve_socp_ipm` appends them as a trailing
+    // nonnegative block of its own, *after* the cones, so they stay outside
+    // the partition `cones` has to cover.
+    let (lb, ub) = extract_box(prob);
 
     // The nonnegative block is every G row built so far. The cones list must
     // cover G in row order: this orthant block, then one SOC per quadratic.
@@ -559,8 +537,8 @@ pub fn extract_socp_with_map(
             b,
             g,
             h,
-            lb: Vec::new(),
-            ub: Vec::new(),
+            lb,
+            ub,
         },
         con_map,
         obj_nl_constant,
@@ -1086,8 +1064,9 @@ mod tests {
             con_names: Vec::new(),
         };
         let qp = extract_qp(&prob).expect("extract");
-        // Two var-bound rows (x0 ≤ 1, −x0 ≤ 0).
-        assert_eq!(qp.m_ineq(), 2);
+        // The bounds are the box, not `G` rows.
+        assert_eq!(qp.m_ineq(), 0);
+        assert_eq!((qp.lb[0], qp.ub[0]), (0.0, 1.0));
         let sol = solve_qp_ipm(&qp, &QpOptions::default(), backend);
         assert_eq!(sol.status, QpStatus::Optimal);
         assert!((sol.x[0] - 1.0).abs() < 1e-6, "x0={}", sol.x[0]);
@@ -1119,7 +1098,9 @@ mod tests {
         };
         let qp = extract_qp(&prob).expect("extract");
         assert!(qp.p_lower.is_empty(), "LP has no Hessian");
-        assert_eq!(qp.m_ineq(), 4); // 2 vars × (upper + lower)
+        assert_eq!(qp.m_ineq(), 0, "bounds are the box, not `G` rows");
+        assert_eq!(qp.lb, vec![0.0, 0.0]);
+        assert_eq!(qp.ub, vec![1.0, 1.0]);
         let sol = solve_qp_ipm(&qp, &QpOptions::default(), backend);
         assert_eq!(sol.status, QpStatus::Optimal);
         assert!((sol.x[0] - 1.0).abs() < 1e-6);
@@ -1193,13 +1174,11 @@ mod tests {
         };
         let qp = extract_qp(&prob).expect("extract");
         assert_eq!(
-            qp.m_ineq(),
-            1,
-            "`x0 <= -5e20` is a real bound and must become a G row; the \
-             symmetric |v| < 1e19 test dropped it, leaving 0 rows and an \
+            qp.ub[0], -5e20,
+            "`x0 <= -5e20` is a real bound and must reach the box; the \
+             symmetric |v| < 1e19 test dropped it, leaving an \
              unbounded-above box the model does not declare"
         );
-        assert_eq!(qp.h[0], -5e20, "the upper bound's RHS");
     }
 
     /// **gh #401.** A row with equal bounds past the sentinel used to vanish
@@ -1255,12 +1234,17 @@ mod tests {
         assert_eq!(qp.h[0], -5e20);
     }
 
-    /// **gh #401.** `recover_bound_mults` walks the G-row layout with the same
-    /// predicate the builder uses, so the two must agree or the returned
-    /// `z_lb` / `z_ub` shift by a row. Pins them together on a box that only
-    /// the directional reading admits.
+    /// **gh #401.** The box is built with the *directional* presence test, so
+    /// a bound past the opposite sentinel survives while a genuinely absent
+    /// one becomes `∓∞`. Pins the case only the directional reading admits.
+    ///
+    /// This used to assert instead that `recover_bound_mults` walked the same
+    /// `G`-row layout the builder emitted — a real hazard when the two agreed
+    /// only by construction, and one that no longer exists: bounds are the
+    /// box, and their multipliers come back in `z_lb`/`z_ub` with no layout
+    /// to keep in step.
     #[test]
-    fn bound_multipliers_stay_aligned_with_the_built_rows() {
+    fn the_box_is_built_with_the_directional_bound_test() {
         let prob = NlProblem {
             n: 2,
             m: 0,
@@ -1285,14 +1269,64 @@ mod tests {
             con_names: Vec::new(),
         };
         let qp = extract_qp(&prob).expect("extract");
-        // x0 contributes 1 row (upper only); x1 contributes 2 (upper, lower).
-        assert_eq!(qp.m_ineq(), 3);
-        // Tag each G row with its index so a misalignment is visible.
-        let z = vec![10.0, 20.0, 30.0];
-        let (z_lb, z_ub) = recover_bound_mults(&prob, 0, &z);
-        assert_eq!(z_ub[0], 10.0, "row 0 is x0's upper bound");
-        assert_eq!(z_lb[0], 0.0, "x0 has no lower bound");
-        assert_eq!(z_ub[1], 20.0, "row 1 is x1's upper bound");
-        assert_eq!(z_lb[1], 30.0, "row 2 is x1's lower bound");
+        assert_eq!(qp.m_ineq(), 0, "bounds are the box, not `G` rows");
+        // x0: no lower bound; a real upper bound past the *lower* sentinel.
+        assert_eq!(qp.lb[0], f64::NEG_INFINITY);
+        assert_eq!(qp.ub[0], -5e20);
+        // x1: an ordinary two-sided box, carried through unchanged.
+        assert_eq!(qp.lb[1], 0.0);
+        assert_eq!(qp.ub[1], 1.0);
+    }
+
+    /// The bound multipliers a solve produces are handed back per variable,
+    /// not decoded from a row layout. A short `z_lb`/`z_ub` (a driver that
+    /// returned early without them) reads as "no bound active" rather than
+    /// panicking on the index.
+    #[test]
+    fn bound_multipliers_come_back_per_variable() {
+        let prob = NlProblem {
+            n: 2,
+            m: 0,
+            num_obj: 1,
+            minimize: true,
+            obj_nonlinear: Expr::Const(0.0),
+            obj_linear: vec![(0, 1.0), (1, 1.0)],
+            obj_constant: 0.0,
+            con_nonlinear: vec![],
+            con_linear: vec![],
+            x_l: vec![0.0, 0.0],
+            x_u: vec![1.0, 1.0],
+            g_l: vec![],
+            g_u: vec![],
+            x0: vec![0.5, 0.5],
+            lambda0: vec![],
+            suffixes: Default::default(),
+            imported_funcs: Vec::new(),
+            var_names: Vec::new(),
+            con_names: Vec::new(),
+        };
+        let sol = QpSolution {
+            status: pounce_convex::QpStatus::Optimal,
+            x: vec![0.0, 1.0],
+            y: vec![],
+            z: vec![],
+            z_lb: vec![7.0, 0.0],
+            z_ub: vec![0.0, 9.0],
+            obj: 0.0,
+            iters: 0,
+            iterates: Vec::new(),
+        };
+        let (z_lb, z_ub) = recover_bound_mults(&prob, &sol);
+        assert_eq!(z_lb, vec![7.0, 0.0]);
+        assert_eq!(z_ub, vec![0.0, 9.0]);
+
+        let empty = QpSolution {
+            z_lb: Vec::new(),
+            z_ub: Vec::new(),
+            ..sol
+        };
+        let (z_lb, z_ub) = recover_bound_mults(&prob, &empty);
+        assert_eq!(z_lb, vec![0.0, 0.0]);
+        assert_eq!(z_ub, vec![0.0, 0.0]);
     }
 }

--- a/crates/pounce-cli/tests/crossed_variable_bounds.rs
+++ b/crates/pounce-cli/tests/crossed_variable_bounds.rs
@@ -1,0 +1,139 @@
+//! A `.nl` model whose variable box is **empty** (`x_l > x_u`) reports
+//! `primal infeasible` on every convex route, at every crossing width
+//! (gh #491).
+//!
+//! Three things had to change before this held, and each of them was
+//! observable from here:
+//!
+//! 1. `qp_extract` emitted variable bounds as `G` rows and left the solver's
+//!    box empty. The empty-box screen reads `lb`/`ub`, so a reversed bound
+//!    arrived as a pair of contradictory rows instead — an infeasibility that
+//!    has to be *certified* numerically rather than seen.
+//! 2. Presolve could not fold that pair back into a box: the leave-one-out
+//!    activity for a singleton row's own column computed `−∞ − (−∞) = NaN`,
+//!    and its bound-tightening disjointness rule let only the first of the two
+//!    rows be a source anyway.
+//! 3. With neither of those, the verdict was left entirely to the iteration —
+//!    which managed it at most widths but not around `1e-8`, where it returned
+//!    `Numerical failure` at a `NaN` iterate, and printed `obj=NaN` on the
+//!    summary line.
+//!
+//! Both widths are checked because the failure was *non-monotone*: `1e0` was
+//! reported correctly while `1e-8` was not, so a single-width test would have
+//! passed throughout.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// Copy a fixture to a scratch dir and solve it, returning
+/// `(exit code, stdout)`.
+fn run(fixture_name: &str, tag: &str, opts: &[&str]) -> (Option<i32>, String) {
+    let dir = std::env::temp_dir().join(format!("pounce_crossed_{tag}"));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let nl = dir.join(fixture_name);
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures");
+    fixture.push(fixture_name);
+    std::fs::copy(&fixture, &nl).expect("copy fixture");
+
+    let out = Command::new(pounce_exe())
+        .arg(&nl)
+        .args(opts)
+        .output()
+        .expect("run pounce");
+    let _ = std::fs::remove_dir_all(&dir);
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+    )
+}
+
+/// The routes a convex-classified model can take. `auto` is what a user gets
+/// by default; the two explicit selections are the engines it chooses
+/// between, and the whole point is that they agree.
+const ROUTES: [&str; 3] = ["auto", "qp-active-set", "qp-ipm"];
+
+/// `min (x−3)²  s.t.  1 ≤ x ≤ 0` — an empty box by a wide margin.
+#[test]
+fn a_reversed_variable_bound_is_primal_infeasible_on_every_route() {
+    for (i, route) in ROUTES.iter().enumerate() {
+        let (code, stdout) = run(
+            "crossed_bound_qp.nl",
+            &format!("wide{i}"),
+            &[&format!("solver_selection={route}")],
+        );
+        assert!(
+            stdout.contains("primal infeasible"),
+            "route {route}: expected a primal-infeasible verdict, got:\n{stdout}"
+        );
+        assert!(
+            !stdout.contains("NaN"),
+            "route {route}: a verdict must not carry NaN:\n{stdout}"
+        );
+        assert_eq!(code, Some(1), "route {route}: infeasible exits 1");
+    }
+}
+
+/// The same model with the box crossed by `1e-8` — wider than the tolerance
+/// presolve absorbs, narrow enough that the interior-point iteration could
+/// neither converge nor certify. This is the case that used to print
+/// `Numerical failure (no verified KKT point).  obj=NaN`.
+#[test]
+fn a_narrowly_reversed_bound_reaches_the_same_verdict() {
+    for (i, route) in ROUTES.iter().enumerate() {
+        let (code, stdout) = run(
+            "narrow_crossed_bound_qp.nl",
+            &format!("narrow{i}"),
+            &[&format!("solver_selection={route}")],
+        );
+        assert!(
+            stdout.contains("primal infeasible"),
+            "route {route}: expected a primal-infeasible verdict, got:\n{stdout}"
+        );
+        assert!(
+            !stdout.contains("NaN"),
+            "route {route}: a verdict must not carry NaN:\n{stdout}"
+        );
+        assert_eq!(code, Some(1), "route {route}: infeasible exits 1");
+    }
+}
+
+/// The guard against over-reach: an ordinary box still solves, and a
+/// *fixed* variable (`x_l == x_u`) is a legitimate model, not an empty box.
+#[test]
+fn ordinary_and_fixed_boxes_are_untouched() {
+    for (i, route) in ROUTES.iter().enumerate() {
+        let (code, stdout) = run(
+            "boxed_qp_min.nl",
+            &format!("ok{i}"),
+            &[&format!("solver_selection={route}")],
+        );
+        assert!(
+            stdout.contains("Optimal Solution Found"),
+            "route {route}: `0 ≤ x ≤ 1` must still solve:\n{stdout}"
+        );
+        assert_eq!(code, Some(0), "route {route}");
+
+        // `x = 0.5` exactly: `lb == ub` is the boundary case the screen must
+        // *not* claim, and the objective's own minimum is elsewhere, so a
+        // dropped bound would show up in the answer.
+        let (code, stdout) = run(
+            "fixed_var_qp.nl",
+            &format!("fixed{i}"),
+            &[&format!("solver_selection={route}")],
+        );
+        assert!(
+            stdout.contains("Optimal Solution Found"),
+            "route {route}: a fixed variable is feasible:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("obj=6.25"),
+            "route {route}: `(0.5 − 3)² = 6.25`, so the bound really held:\n{stdout}"
+        );
+        assert_eq!(code, Some(0), "route {route}");
+    }
+}

--- a/crates/pounce-cli/tests/fixtures/crossed_bound_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/crossed_bound_qp.nl
@@ -1,0 +1,29 @@
+g3 1 1 0	# problem unknown
+ 1 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+O0 0
+o5
+o0
+v0
+n-3
+n2
+x1
+0 0.5
+r
+2 0.0
+b
+0 1 0
+k0
+J0 1
+0 1
+G0 1
+0 0

--- a/crates/pounce-cli/tests/fixtures/fixed_var_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/fixed_var_qp.nl
@@ -1,0 +1,29 @@
+g3 1 1 0	# problem unknown
+ 1 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+O0 0
+o5
+o0
+v0
+n-3
+n2
+x1
+0 0.5
+r
+2 0.0
+b
+0 0.5 0.5
+k0
+J0 1
+0 1
+G0 1
+0 0

--- a/crates/pounce-cli/tests/fixtures/narrow_crossed_bound_qp.nl
+++ b/crates/pounce-cli/tests/fixtures/narrow_crossed_bound_qp.nl
@@ -1,0 +1,29 @@
+g3 1 1 0	# problem unknown
+ 1 1 1 0 0 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 0 1 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+n0
+O0 0
+o5
+o0
+v0
+n-3
+n2
+x1
+0 0.5
+r
+2 0.0
+b
+0 0 -1e-8
+k0
+J0 1
+0 1
+G0 1
+0 0

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -70,7 +70,7 @@ use pounce_qp::{
     QpStatus as ActiveSetStatus, QpWarmStart, WorkingSet,
 };
 
-use crate::ipm::{FARKAS_RESID_TOL, QpOptions, dot, inf_norm};
+use crate::ipm::{FARKAS_RESID_TOL, QpOptions, dot, finite_or_failed, inf_norm};
 use crate::qp::{BoxScreen, QpProblem, QpSolution, QpStatus, screen_variable_box};
 
 /// Caller-supplied overrides for the inner `pounce-qp` engine.
@@ -179,6 +179,22 @@ fn empty_solution(n: usize, m_eq: usize, m_ineq: usize, status: QpStatus) -> QpS
 /// `make_backend` factory (the active-set engine may need more than one
 /// backend instance over a solve).
 pub fn solve_qp_active_set<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    engine: &ActiveSetOverrides,
+    make_backend: &mut F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    // One gate over every exit of the body below — see [`finite_or_failed`].
+    finite_or_failed(
+        prob,
+        solve_qp_active_set_inner(prob, opts, engine, make_backend),
+    )
+}
+
+fn solve_qp_active_set_inner<F>(
     prob: &QpProblem,
     opts: &QpOptions,
     engine: &ActiveSetOverrides,

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -71,7 +71,7 @@ use pounce_qp::{
 };
 
 use crate::ipm::{FARKAS_RESID_TOL, QpOptions, dot, inf_norm};
-use crate::qp::{QpProblem, QpSolution, QpStatus};
+use crate::qp::{BoxScreen, QpProblem, QpSolution, QpStatus, screen_variable_box};
 
 /// Caller-supplied overrides for the inner `pounce-qp` engine.
 ///
@@ -172,95 +172,6 @@ fn empty_solution(n: usize, m_eq: usize, m_ineq: usize, status: QpStatus) -> QpS
     }
 }
 
-/// Verdict on the variable box, decided before any solve is attempted.
-enum BoxScreen {
-    /// Every `[lb, ub]` is a non-empty interval; solve the problem as posed.
-    Feasible,
-    /// Some variable's box is empty by inspection — report `PrimalInfeasible`.
-    Empty,
-    /// Some box was crossed by no more than [`CROSSED_BOX_TOL`]; solve this
-    /// repaired copy, in which each such variable is fixed at its midpoint.
-    Snapped(QpProblem),
-}
-
-/// Widest box crossing (`lb − ub`) treated as a numerical artifact rather than
-/// an empty feasible set.
-///
-/// Matched to presolve's own `BOUND_FEAS_TOL`, which is the number that decides
-/// what can reach this driver: bound tightening applies an update only when it
-/// improves a bound by more than that tolerance and declares infeasibility only
-/// when `tlb > tub + BOUND_FEAS_TOL`, so a *reduced* problem handed on from
-/// presolve can carry a box crossed by up to exactly this much — with presolve
-/// having already ruled that crossing tolerable. Calling it infeasible here
-/// would overturn that ruling on the strength of arithmetic presolve had
-/// already discounted.
-///
-/// It also happens to be where the IPM draws the same line, which is the
-/// property that matters for a user comparing `method=`. Measured on
-/// `min ½x² s.t. 0 ≤ x ≤ −gap`: crossings of `1e-9` and below return `Optimal`
-/// at the box midpoint, `1e-6` and above return `PrimalInfeasible`.
-const CROSSED_BOX_TOL: f64 = 1e-9;
-
-/// Decide what an ill-formed variable box means before the engine sees it.
-///
-/// Two classes of box admit no point, and both need catching here because
-/// neither survives contact with the engine intact:
-///
-/// * **Impossible** — a *present* `+∞` lower or `−∞` upper bound (gh #295).
-/// * **Reversed** — `lb > ub` (gh #491).
-///
-/// A wide crossing is `PrimalInfeasible`, and saying so needs no arithmetic —
-/// which matters, because this driver otherwise refuses to report
-/// `PrimalInfeasible` without a certificate it re-derived itself. The
-/// certificate for this class *is* the bound pair: `x_i ≥ lb_i > ub_i ≥ x_i`
-/// has no solution, so there is nothing numerical to prove or to demote.
-///
-/// A hairline crossing is repaired instead of rejected, for the reason given on
-/// [`CROSSED_BOX_TOL`]: it is the residue of a tolerance decision made upstream,
-/// not a statement that the problem is infeasible.
-///
-/// Screening up front is not merely a shortcut — without it the reversed case
-/// **aborted the process**. The engine's own `validate` rejects `xl > xu` with
-/// `QpError::InvertedBounds`, so the first two attempts below came back
-/// `NumericalFailure` and fell through to the last-resort simplex-seeded
-/// attempt, where `simplex::Simplex::warm_start` clamped the seed into the
-/// inverted interval and `f64::clamp` panicked (`min > max`). Across the PyO3
-/// boundary that surfaced as a `pyo3_runtime.PanicException`, which derives from
-/// `BaseException` and so tore down callers that had defensively wrapped the
-/// solve in `except Exception` (gh #491). The IPM screens the impossible class
-/// at each of its own entry points; this is the peer screen for the active-set
-/// path, so the two methods agree on the same input.
-fn screen_variable_box(prob: &QpProblem) -> BoxScreen {
-    if prob.bounds_admit_no_point() {
-        return BoxScreen::Empty;
-    }
-    if !prob.bounds_are_reversed() {
-        return BoxScreen::Feasible;
-    }
-    if (0..prob.n).any(|i| prob.lb_of(i) > prob.ub_of(i) + CROSSED_BOX_TOL) {
-        return BoxScreen::Empty;
-    }
-    // Hairline: fix each crossed variable at its midpoint. Both bound vectors
-    // are necessarily length `n` here — an absent bound reads as `∓∞` and
-    // cannot be the crossed side — but index defensively anyway, since a
-    // partially-filled vector must not silently drop the repair and hand the
-    // engine the inverted box after all.
-    let mut repaired = prob.clone();
-    for i in 0..prob.n {
-        let (l, u) = (prob.lb_of(i), prob.ub_of(i));
-        if l > u {
-            let mid = 0.5 * (l + u);
-            if let (Some(lo), Some(hi)) = (repaired.lb.get_mut(i), repaired.ub.get_mut(i)) {
-                *lo = mid;
-                *hi = mid;
-            } else {
-                return BoxScreen::Empty;
-            }
-        }
-    }
-    BoxScreen::Snapped(repaired)
-}
-
 /// Solve a convex QP with the [`pounce_qp`] parametric active-set engine.
 ///
 /// Signature-compatible with [`crate::ipm::solve_qp_ipm`] so the CLI driver
@@ -277,6 +188,11 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     // ---- Screen the variable box before anything else (gh #295, gh #491) ----
+    //
+    // Peer to the screen [`crate::ipm`] runs at each of its own entry points;
+    // see [`screen_variable_box`] for why an empty box must not be left to the
+    // engine (on this path it panicked) and why a hairline crossing is repaired
+    // rather than rejected.
     let snapped;
     let prob = match screen_variable_box(prob) {
         BoxScreen::Feasible => prob,
@@ -1171,6 +1087,7 @@ fn active_set_iter_budget(opts: &QpOptions, n: usize, m: usize) -> u32 {
 mod tests {
     use super::*;
     use crate::ipm::solve_qp_ipm;
+    use crate::qp::CROSSED_BOX_TOL;
     use crate::qp::Triplet;
     use pounce_feral::FeralSolverInterface;
 
@@ -1556,7 +1473,17 @@ mod tests {
     /// test binary rather than failed an assertion.
     #[test]
     fn reversed_box_is_primal_infeasible_not_a_panic() {
-        for (lb, ub) in [(1.0, 0.0), (5.0, 3.0), (0.0, -1e-6), (-1.0, -1e3)] {
+        for (lb, ub) in [
+            (1.0, 0.0),
+            (5.0, 3.0),
+            (0.0, -1e-6),
+            (-1.0, -1e3),
+            // The band the IPM used to resolve neither way, returning
+            // `NumericalFailure` at a `NaN` iterate: wider than the tolerated
+            // crossing, narrower than what its arithmetic could certify.
+            (0.0, -1e-8),
+            (0.0, -1e-7),
+        ] {
             let (asol, isol) = boxed_scalar(lb, ub);
             assert_eq!(
                 asol.status,
@@ -1587,14 +1514,17 @@ mod tests {
         assert!(asol.x[0].abs() < 1e-8, "x = {}", asol.x[0]);
     }
 
-    /// A crossing no wider than [`CROSSED_BOX_TOL`] is a tolerance artifact —
-    /// presolve's bound tightening can hand this driver a reduced problem
-    /// carrying one, having already ruled it tolerable — so it is repaired to a
-    /// fixed variable at the box midpoint rather than called infeasible.
+    /// A crossing no wider than [`crate::qp::CROSSED_BOX_TOL`] is a tolerance
+    /// artifact — presolve's bound tightening can hand a driver a reduced
+    /// problem carrying one, having already ruled it tolerable — so it is
+    /// repaired to a fixed variable at the box midpoint rather than called
+    /// infeasible.
     ///
-    /// That is also what the IPM does with the same input (it converges to the
-    /// midpoint and reports `Optimal`), which is the property a user comparing
-    /// `method=` actually observes, so both engines are checked here.
+    /// That is also where the IPM's own iteration landed on this input before
+    /// the screen existed (it converged to the midpoint and reported
+    /// `Optimal`), so the repair preserves its answer rather than replacing
+    /// it. Both engines are checked: the property a user comparing `method=`
+    /// observes is that they agree.
     #[test]
     fn hairline_crossing_is_repaired_not_rejected() {
         for gap in [1e-14, 1e-12, 1e-10, CROSSED_BOX_TOL] {

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -172,6 +172,95 @@ fn empty_solution(n: usize, m_eq: usize, m_ineq: usize, status: QpStatus) -> QpS
     }
 }
 
+/// Verdict on the variable box, decided before any solve is attempted.
+enum BoxScreen {
+    /// Every `[lb, ub]` is a non-empty interval; solve the problem as posed.
+    Feasible,
+    /// Some variable's box is empty by inspection — report `PrimalInfeasible`.
+    Empty,
+    /// Some box was crossed by no more than [`CROSSED_BOX_TOL`]; solve this
+    /// repaired copy, in which each such variable is fixed at its midpoint.
+    Snapped(QpProblem),
+}
+
+/// Widest box crossing (`lb − ub`) treated as a numerical artifact rather than
+/// an empty feasible set.
+///
+/// Matched to presolve's own `BOUND_FEAS_TOL`, which is the number that decides
+/// what can reach this driver: bound tightening applies an update only when it
+/// improves a bound by more than that tolerance and declares infeasibility only
+/// when `tlb > tub + BOUND_FEAS_TOL`, so a *reduced* problem handed on from
+/// presolve can carry a box crossed by up to exactly this much — with presolve
+/// having already ruled that crossing tolerable. Calling it infeasible here
+/// would overturn that ruling on the strength of arithmetic presolve had
+/// already discounted.
+///
+/// It also happens to be where the IPM draws the same line, which is the
+/// property that matters for a user comparing `method=`. Measured on
+/// `min ½x² s.t. 0 ≤ x ≤ −gap`: crossings of `1e-9` and below return `Optimal`
+/// at the box midpoint, `1e-6` and above return `PrimalInfeasible`.
+const CROSSED_BOX_TOL: f64 = 1e-9;
+
+/// Decide what an ill-formed variable box means before the engine sees it.
+///
+/// Two classes of box admit no point, and both need catching here because
+/// neither survives contact with the engine intact:
+///
+/// * **Impossible** — a *present* `+∞` lower or `−∞` upper bound (gh #295).
+/// * **Reversed** — `lb > ub` (gh #491).
+///
+/// A wide crossing is `PrimalInfeasible`, and saying so needs no arithmetic —
+/// which matters, because this driver otherwise refuses to report
+/// `PrimalInfeasible` without a certificate it re-derived itself. The
+/// certificate for this class *is* the bound pair: `x_i ≥ lb_i > ub_i ≥ x_i`
+/// has no solution, so there is nothing numerical to prove or to demote.
+///
+/// A hairline crossing is repaired instead of rejected, for the reason given on
+/// [`CROSSED_BOX_TOL`]: it is the residue of a tolerance decision made upstream,
+/// not a statement that the problem is infeasible.
+///
+/// Screening up front is not merely a shortcut — without it the reversed case
+/// **aborted the process**. The engine's own `validate` rejects `xl > xu` with
+/// `QpError::InvertedBounds`, so the first two attempts below came back
+/// `NumericalFailure` and fell through to the last-resort simplex-seeded
+/// attempt, where `simplex::Simplex::warm_start` clamped the seed into the
+/// inverted interval and `f64::clamp` panicked (`min > max`). Across the PyO3
+/// boundary that surfaced as a `pyo3_runtime.PanicException`, which derives from
+/// `BaseException` and so tore down callers that had defensively wrapped the
+/// solve in `except Exception` (gh #491). The IPM screens the impossible class
+/// at each of its own entry points; this is the peer screen for the active-set
+/// path, so the two methods agree on the same input.
+fn screen_variable_box(prob: &QpProblem) -> BoxScreen {
+    if prob.bounds_admit_no_point() {
+        return BoxScreen::Empty;
+    }
+    if !prob.bounds_are_reversed() {
+        return BoxScreen::Feasible;
+    }
+    if (0..prob.n).any(|i| prob.lb_of(i) > prob.ub_of(i) + CROSSED_BOX_TOL) {
+        return BoxScreen::Empty;
+    }
+    // Hairline: fix each crossed variable at its midpoint. Both bound vectors
+    // are necessarily length `n` here — an absent bound reads as `∓∞` and
+    // cannot be the crossed side — but index defensively anyway, since a
+    // partially-filled vector must not silently drop the repair and hand the
+    // engine the inverted box after all.
+    let mut repaired = prob.clone();
+    for i in 0..prob.n {
+        let (l, u) = (prob.lb_of(i), prob.ub_of(i));
+        if l > u {
+            let mid = 0.5 * (l + u);
+            if let (Some(lo), Some(hi)) = (repaired.lb.get_mut(i), repaired.ub.get_mut(i)) {
+                *lo = mid;
+                *hi = mid;
+            } else {
+                return BoxScreen::Empty;
+            }
+        }
+    }
+    BoxScreen::Snapped(repaired)
+}
+
 /// Solve a convex QP with the [`pounce_qp`] parametric active-set engine.
 ///
 /// Signature-compatible with [`crate::ipm::solve_qp_ipm`] so the CLI driver
@@ -187,6 +276,24 @@ pub fn solve_qp_active_set<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    // ---- Screen the variable box before anything else (gh #295, gh #491) ----
+    let snapped;
+    let prob = match screen_variable_box(prob) {
+        BoxScreen::Feasible => prob,
+        BoxScreen::Empty => {
+            return empty_solution(
+                prob.n,
+                prob.m_eq(),
+                prob.m_ineq(),
+                QpStatus::PrimalInfeasible,
+            );
+        }
+        BoxScreen::Snapped(p) => {
+            snapped = p;
+            &snapped
+        }
+    };
+
     // Ruiz equilibration is applied as a **retry after failure**, not
     // unconditionally, because for this engine it is a genuine trade rather
     // than an improvement. Measured on Maros-Mészáros:
@@ -1410,5 +1517,138 @@ mod tests {
             sol.obj,
             isol.obj
         );
+    }
+
+    /// `min ½x² s.t. lb ≤ x ≤ ub`, solved by both engines. Returns
+    /// `(active-set, ipm)` so the two can be held to the same answer.
+    fn boxed_scalar(lb: f64, ub: f64) -> (QpSolution, QpSolution) {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![Triplet::new(0, 0, 1.0)],
+            c: vec![0.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![lb],
+            ub: vec![ub],
+        };
+        let mut mk = backend;
+        let asol = solve_qp_active_set(
+            &prob,
+            &QpOptions::default(),
+            &ActiveSetOverrides::default(),
+            &mut mk,
+        );
+        let isol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+        (asol, isol)
+    }
+
+    /// gh #491: a **reversed** box (`lb > ub`) is `PrimalInfeasible`, not a
+    /// panic — and the two engines must agree on it.
+    ///
+    /// Before the fix the engine's `validate` rejected `xl > xu` outright, so
+    /// both the first attempt and the Ruiz retry returned `NumericalFailure`
+    /// and the last-resort simplex-seeded attempt ran — where the seed was
+    /// clamped into the inverted interval and `f64::clamp` panicked with
+    /// `min > max`. Through the Python bindings that became an uncatchable
+    /// `pyo3_runtime.PanicException`, so this test would have *aborted* the
+    /// test binary rather than failed an assertion.
+    #[test]
+    fn reversed_box_is_primal_infeasible_not_a_panic() {
+        for (lb, ub) in [(1.0, 0.0), (5.0, 3.0), (0.0, -1e-6), (-1.0, -1e3)] {
+            let (asol, isol) = boxed_scalar(lb, ub);
+            assert_eq!(
+                asol.status,
+                QpStatus::PrimalInfeasible,
+                "active-set on lb={lb} ub={ub}"
+            );
+            assert_eq!(
+                isol.status,
+                QpStatus::PrimalInfeasible,
+                "ipm on lb={lb} ub={ub}"
+            );
+        }
+    }
+
+    /// The screen must not swallow the adjacent well-formed boxes: `lb == ub`
+    /// is a fixed variable, and `±∞` on the absent side is the ordinary
+    /// one-sided encoding. Both are feasible and must still solve.
+    #[test]
+    fn well_formed_boxes_are_untouched_by_the_screen() {
+        let (asol, isol) = boxed_scalar(2.0, 2.0);
+        assert_eq!(asol.status, QpStatus::Optimal, "active-set on lb == ub");
+        assert_eq!(isol.status, QpStatus::Optimal, "ipm on lb == ub");
+        assert!((asol.x[0] - 2.0).abs() < 1e-8, "x = {}", asol.x[0]);
+
+        let (asol, isol) = boxed_scalar(f64::NEG_INFINITY, f64::INFINITY);
+        assert_eq!(asol.status, QpStatus::Optimal, "active-set on a free var");
+        assert_eq!(isol.status, QpStatus::Optimal, "ipm on a free var");
+        assert!(asol.x[0].abs() < 1e-8, "x = {}", asol.x[0]);
+    }
+
+    /// A crossing no wider than [`CROSSED_BOX_TOL`] is a tolerance artifact —
+    /// presolve's bound tightening can hand this driver a reduced problem
+    /// carrying one, having already ruled it tolerable — so it is repaired to a
+    /// fixed variable at the box midpoint rather than called infeasible.
+    ///
+    /// That is also what the IPM does with the same input (it converges to the
+    /// midpoint and reports `Optimal`), which is the property a user comparing
+    /// `method=` actually observes, so both engines are checked here.
+    #[test]
+    fn hairline_crossing_is_repaired_not_rejected() {
+        for gap in [1e-14, 1e-12, 1e-10, CROSSED_BOX_TOL] {
+            let (asol, isol) = boxed_scalar(0.0, -gap);
+            assert_eq!(asol.status, QpStatus::Optimal, "active-set on gap={gap:e}");
+            assert_eq!(isol.status, QpStatus::Optimal, "ipm on gap={gap:e}");
+            // Midpoint of the crossed box, to well inside the crossing itself.
+            assert!(
+                (asol.x[0] + 0.5 * gap).abs() <= gap,
+                "x = {} for gap={gap:e}",
+                asol.x[0]
+            );
+        }
+    }
+
+    /// The reversed box reached through an `n > 1` problem with real
+    /// constraints, so the screen is exercised where the engine would otherwise
+    /// have work to do. Only one variable is reversed; the rest of the box is
+    /// ordinary.
+    #[test]
+    fn reversed_box_on_one_variable_of_many() {
+        let prob = QpProblem {
+            lb: vec![0.0, 1.0],
+            ub: vec![10.0, 0.0], // variable 1 is reversed
+            ..projection_qp()
+        };
+        let mut mk = backend;
+        let sol = solve_qp_active_set(
+            &prob,
+            &QpOptions::default(),
+            &ActiveSetOverrides::default(),
+            &mut mk,
+        );
+        assert_eq!(sol.status, QpStatus::PrimalInfeasible);
+        assert_eq!(sol.x.len(), prob.n, "x is returned at full length");
+    }
+
+    /// The impossible-bound class (gh #295) reaches the same verdict on this
+    /// path. The IPM screens it at every entry point; before this the
+    /// active-set driver screened it nowhere, so the raw Rust caller and the
+    /// CLI's `qp-active-set` route got whatever the engine happened to do.
+    #[test]
+    fn impossible_bounds_are_primal_infeasible_on_the_active_set_path() {
+        for (lb, ub) in [
+            (f64::INFINITY, f64::INFINITY),
+            (f64::NEG_INFINITY, f64::NEG_INFINITY),
+        ] {
+            let (asol, isol) = boxed_scalar(lb, ub);
+            assert_eq!(
+                asol.status,
+                QpStatus::PrimalInfeasible,
+                "active-set on lb={lb} ub={ub}"
+            );
+            assert_eq!(isol.status, QpStatus::PrimalInfeasible, "ipm");
+        }
     }
 }

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -49,7 +49,7 @@
 
 use crate::cones::{CompositeCone, Cone, ConeBlock, ConeSpec};
 use crate::debug::{ConvexDebugState, fire};
-use crate::qp::{QpIterate, QpProblem, QpSolution, QpStatus};
+use crate::qp::{BoxScreen, QpIterate, QpProblem, QpSolution, QpStatus, screen_variable_box};
 use pounce_common::debug::{Checkpoint, DebugAction, DebugHook};
 use pounce_common::types::{Index, Number};
 use pounce_linsol::{Factorization, SparseSymLinearSolverInterface};
@@ -282,13 +282,23 @@ where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
     let mut make_backend = make_backend;
-    // gh #295: reject a box that admits no finite point (a *present* `+∞`
-    // lower / `−∞` upper bound) before bound expansion — `expand_bounds` is
-    // sign-agnostic and would otherwise mishandle it and report a violating
-    // point `Optimal`.
-    if prob.bounds_admit_no_point() {
-        return trivial_primal_infeasible_solution(prob);
-    }
+    // Screen the variable box before bound expansion (gh #295, gh #491):
+    // `expand_bounds` is sign-agnostic, so a *present* `+∞` lower / `−∞` upper
+    // bound would be mishandled as an *absent* one and a violating point
+    // reported `Optimal`; and a box crossed by more than a tolerance is empty,
+    // which the iteration resolved only for wide crossings — in between it
+    // returned `NumericalFailure` at a `NaN` iterate. A hairline crossing is
+    // repaired to the midpoint the iteration converged to anyway. See
+    // [`screen_variable_box`].
+    let snapped;
+    let prob = match screen_variable_box(prob) {
+        BoxScreen::Feasible => prob,
+        BoxScreen::Empty => return trivial_primal_infeasible_solution(prob),
+        BoxScreen::Snapped(p) => {
+            snapped = p;
+            &snapped
+        }
+    };
     // Interior-point solve in the original problem's coordinates (the core
     // already unscales any internal Ruiz equilibration before returning).
     let sol = solve_qp_ipm_core(prob, opts, &mut make_backend);
@@ -693,11 +703,17 @@ pub fn solve_qp_ipm_debug<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    // gh #295: reject an impossible box (present `+∞` lower / `−∞` upper
-    // bound) before bound expansion, as the non-debug path does.
-    if prob.bounds_admit_no_point() {
-        return trivial_primal_infeasible_solution(prob);
-    }
+    // Screen the variable box before bound expansion, as the non-debug path
+    // does (gh #295, gh #491).
+    let snapped;
+    let prob = match screen_variable_box(prob) {
+        BoxScreen::Feasible => prob,
+        BoxScreen::Empty => return trivial_primal_infeasible_solution(prob),
+        BoxScreen::Snapped(p) => {
+            snapped = p;
+            &snapped
+        }
+    };
     // Build the factorization and run the core loop directly with the hook
     // (mirrors `solve_qp_core`'s non-HSDE path; `solve_qp_core` itself can't
     // carry the borrowed hook through its generic plumbing). When the HSDE
@@ -751,11 +767,20 @@ where
     // otherwise the warm start would silently do nothing. A caller that
     // warm-starts is doing nearby reoptimization (a known-solvable
     // neighborhood), where the direct path's fragility is not a concern.
-    // gh #295: reject an impossible box (present `+∞` lower / `−∞` upper
-    // bound) before equilibration and bound expansion.
-    if prob.bounds_admit_no_point() {
-        return trivial_primal_infeasible_solution(prob);
-    }
+    // Screen the variable box before equilibration and bound expansion
+    // (gh #295, gh #491). Equilibration is a diagonal congruence and scales
+    // the bounds with the variables, so a crossing survives it — but only the
+    // *unscaled* widths are comparable to `CROSSED_BOX_TOL`, which is why the
+    // screen runs here and not after.
+    let snapped;
+    let prob = match screen_variable_box(prob) {
+        BoxScreen::Feasible => prob,
+        BoxScreen::Empty => return trivial_primal_infeasible_solution(prob),
+        BoxScreen::Snapped(p) => {
+            snapped = p;
+            &snapped
+        }
+    };
     let direct = QpOptions {
         use_hsde: false,
         equilibrate: false,
@@ -806,11 +831,19 @@ pub fn solve_socp_ipm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    // gh #295: reject an impossible box (present `+∞` lower / `−∞` upper
-    // bound) before bound expansion; `expand_bounds` is sign-agnostic.
-    if prob.bounds_admit_no_point() {
-        return trivial_primal_infeasible_solution(prob);
-    }
+    // Screen the variable box before bound expansion (gh #295, gh #491);
+    // `expand_bounds` is sign-agnostic. The screen reads only `lb`/`ub`, which
+    // this path appends as a trailing nonnegative block exactly as the QP path
+    // does, so the cones are unaffected by it either way.
+    let snapped;
+    let prob = match screen_variable_box(prob) {
+        BoxScreen::Feasible => prob,
+        BoxScreen::Empty => return trivial_primal_infeasible_solution(prob),
+        BoxScreen::Snapped(p) => {
+            snapped = p;
+            &snapped
+        }
+    };
     // The cones must partition the inequality rows exactly; otherwise the
     // cone vectors and the `m_ineq` slack disagree and the driver would read
     // out of bounds (an exp/power cone is always 3 rows). Fail cleanly here.

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -307,7 +307,8 @@ where
     // never-regressing — a no-op for QPs and whenever the vertex is not a
     // strict improvement. Runs against the same un-equilibrated `prob` so the
     // `z`/`s` conventions line up. See [`crate::crossover`].
-    crate::crossover::maybe_crossover(prob, sol, opts, &mut make_backend)
+    let sol = crate::crossover::maybe_crossover(prob, sol, opts, &mut make_backend);
+    finite_or_failed(prob, sol)
 }
 
 /// The interior-point solve (the historical [`solve_qp_ipm`] body): bounds-aware
@@ -761,6 +762,22 @@ pub fn solve_qp_ipm_warm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    // One gate over every exit of the body below — see [`finite_or_failed`].
+    finite_or_failed(
+        prob,
+        solve_qp_ipm_warm_inner(prob, opts, warm, make_backend),
+    )
+}
+
+fn solve_qp_ipm_warm_inner<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    warm: &QpWarmStart,
+    make_backend: F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
     // Warm-starting requires the direct infeasible-start solver: HSDE
     // self-starts and ignores a warm point (see `QpOptions::use_hsde`). So this
     // path always runs the direct method, independent of the (HSDE) default —
@@ -792,7 +809,7 @@ where
     if opts.equilibrate {
         let (scaled, scaling) = crate::equilibrate::equilibrate(prob);
         let scaled_warm = scaling.scale_warm_start(warm);
-        let mut sol = solve_qp_ipm_warm(&scaled, &direct, &scaled_warm, make_backend);
+        let mut sol = solve_qp_ipm_warm_inner(&scaled, &direct, &scaled_warm, make_backend);
         scaling.unscale_solution(prob, &mut sol);
         return sol;
     }
@@ -823,6 +840,19 @@ where
 /// `m_ineq` rows. Variable bounds (`lb`/`ub`) are appended as a trailing
 /// nonnegative block.
 pub fn solve_socp_ipm<F>(
+    prob: &QpProblem,
+    cones: &[ConeSpec],
+    opts: &QpOptions,
+    make_backend: F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    // One gate over every exit of the body below — see [`finite_or_failed`].
+    finite_or_failed(prob, solve_socp_ipm_inner(prob, cones, opts, make_backend))
+}
+
+fn solve_socp_ipm_inner<F>(
     prob: &QpProblem,
     cones: &[ConeSpec],
     opts: &QpOptions,
@@ -2495,6 +2525,48 @@ fn cone_dims_cover(cones: &[ConeSpec], m_ineq: usize) -> bool {
 /// even a member (e.g. `(1,…,1)` violates an SOC of dimension ≥ 3). This
 /// keeps the reported dual cone-feasible and consistent across all drivers
 /// (cf. `hsde::failed`, `hsde_nonsym::failed`).
+/// Last gate before a solution leaves the crate: a non-finite entry anywhere
+/// in it is replaced by an honest zero-filled `NumericalFailure`.
+///
+/// A `NaN` in the returned iterate is never information. It cannot be checked
+/// against a bound, printed into a `.sol`, or fed to a warm start, and every
+/// arithmetic it touches downstream returns `NaN` in turn — so it converts one
+/// solver's failure into the caller's, several steps removed from the cause.
+/// The status was already `NumericalFailure` in the case this was written for
+/// (a `Gx ≤ h` system infeasible by about `1e-8`, where the iteration neither
+/// converged nor certified), and `obj = NaN` still reached the CLI's own
+/// summary line.
+///
+/// Deliberately a *guard*, not a repair: it does not attempt to salvage a
+/// point, and it fires only on data no consumer could have used. A solve that
+/// returns finite numbers passes through untouched, including one that failed.
+///
+/// Applied at the entry points a caller reaches — [`solve_qp_ipm`],
+/// [`solve_qp_ipm_warm`], [`solve_socp_ipm`], and the active-set driver — and
+/// deliberately **not** on the `*_debug` ones, where the raw iterate is the
+/// thing being inspected and replacing it would hide what the hook was
+/// attached to see.
+pub(crate) fn finite_or_failed(prob: &QpProblem, sol: QpSolution) -> QpSolution {
+    let finite = |v: &[f64]| v.iter().all(|x| x.is_finite());
+    if finite(&sol.x)
+        && finite(&sol.y)
+        && finite(&sol.z)
+        && finite(&sol.z_lb)
+        && finite(&sol.z_ub)
+        && sol.obj.is_finite()
+    {
+        return sol;
+    }
+    let iters = sol.iters;
+    failed_solution(
+        prob,
+        vec![0.0; prob.n],
+        vec![0.0; prob.m_eq()],
+        vec![0.0; prob.m_ineq()],
+        iters,
+    )
+}
+
 fn failed_solution(
     prob: &QpProblem,
     x: Vec<f64>,
@@ -3803,5 +3875,87 @@ mod false_optimum_metric_tests {
         let out = verify_or_repair_optimum(&prob, &opts, sol, &mut mb);
         assert_eq!(out.status, QpStatus::Optimal);
         assert_eq!(out.x, x, "a genuine optimum must be returned unchanged");
+    }
+}
+
+#[cfg(test)]
+mod finite_guard_tests {
+    //! gh #491: a non-finite entry never leaves the crate.
+
+    use super::finite_or_failed;
+    use crate::qp::{QpProblem, QpSolution, QpStatus, Triplet};
+
+    fn prob() -> QpProblem {
+        QpProblem {
+            n: 2,
+            p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+            c: vec![-1.0, -1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+            h: vec![1.0],
+            lb: vec![],
+            ub: vec![],
+        }
+    }
+
+    fn sol(status: QpStatus, x: Vec<f64>, obj: f64) -> QpSolution {
+        QpSolution {
+            status,
+            x,
+            y: vec![],
+            z: vec![0.0],
+            z_lb: vec![0.0; 2],
+            z_ub: vec![0.0; 2],
+            obj,
+            iters: 7,
+            iterates: Vec::new(),
+        }
+    }
+
+    /// A finite solution passes through untouched — *including* a failed one,
+    /// whose iterate a caller may still want to look at.
+    #[test]
+    fn finite_solutions_are_returned_unchanged() {
+        for status in [QpStatus::Optimal, QpStatus::NumericalFailure] {
+            let s = sol(status, vec![0.25, 0.75], -0.5);
+            let out = finite_or_failed(&prob(), s.clone());
+            assert_eq!(out.status, status);
+            assert_eq!(out.x, s.x);
+            assert_eq!(out.obj, s.obj);
+            assert_eq!(out.iters, 7, "the iteration count is not a casualty");
+        }
+    }
+
+    /// A `NaN` anywhere — the iterate, a multiplier, or the objective — is
+    /// replaced by a zero-filled `NumericalFailure`. `NaN` is never
+    /// information: it cannot be checked against a bound, printed into a
+    /// `.sol`, or warm-started from, and it turns every arithmetic downstream
+    /// into another `NaN`.
+    #[test]
+    fn non_finite_solutions_become_an_honest_failure() {
+        let cases = [
+            sol(QpStatus::NumericalFailure, vec![f64::NAN, 0.0], f64::NAN),
+            sol(QpStatus::Optimal, vec![f64::INFINITY, 0.0], 1.0),
+            sol(QpStatus::Optimal, vec![0.0, 0.0], f64::NAN),
+            QpSolution {
+                z: vec![f64::NAN],
+                ..sol(QpStatus::Optimal, vec![0.0, 0.0], 0.0)
+            },
+            QpSolution {
+                z_ub: vec![0.0, f64::NAN],
+                ..sol(QpStatus::Optimal, vec![0.0, 0.0], 0.0)
+            },
+        ];
+        for (i, s) in cases.into_iter().enumerate() {
+            let out = finite_or_failed(&prob(), s);
+            assert_eq!(out.status, QpStatus::NumericalFailure, "case {i}");
+            assert!(
+                out.x.iter().chain(&out.z).all(|v| v.is_finite()) && out.obj.is_finite(),
+                "case {i}: still non-finite"
+            );
+            assert_eq!(out.x, vec![0.0, 0.0], "case {i}");
+            assert_eq!(out.iters, 7, "case {i}: the iteration count is kept");
+        }
     }
 }

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -882,21 +882,60 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
     let mut lb_src: Vec<Option<(usize, f64, bool)>> = vec![None; n];
 
     // Re-attributing an active tightened bound's multiplier to its source
-    // row is only *independent* when source rows share no columns (and
-    // touch no already-reduced column); otherwise the re-attributions
-    // couple. So a row may serve as a tightening source only if all its
-    // columns are kept (not fixed/substituted) and disjoint from every
-    // other accepted source row — a conservative but always-correct
-    // restriction, exactly like forcing's disjoint-column rule.
+    // row is only *independent* when no two source rows can claim the same
+    // bound; otherwise the re-attributions couple. So a row may serve as a
+    // tightening source only if all its columns are kept (not
+    // fixed/substituted) and none of the bounds it would claim has already
+    // been taken — the same disjointness rule forcing uses.
+    //
+    // The claim is per **column** for a row with more than one column, and
+    // per `(column, side)` for a **singleton** row. The split matters because
+    // a variable bound written as a pair of rows — `x ≤ u` and `−x ≤ −l`,
+    // which is how a model reaches here whenever its bounds were not carried
+    // in the box — puts both rows on the same single column. Under a
+    // whole-column rule the first row claimed the column and the second was
+    // skipped, so only one side of that box was ever derived and a
+    // *contradictory* pair (`u < l`) could not be seen at all. It reached the
+    // solver as two rows whose infeasibility had to be certified numerically,
+    // which the interior-point method managed at most widths but not around
+    // `1e-8`, where it returned `NumericalFailure` at a `NaN` iterate.
+    //
+    // For a singleton the relaxation is sound, and only for a singleton:
+    // postsolve credits the source row with `z_ub[col]` or `z_lb[col]`, at
+    // most one of which complementarity allows to be nonzero, and the
+    // credited row has no *other* column whose stationarity that credit could
+    // disturb. A multi-column row does — its `Gᵀz` contribution lands in
+    // every column it touches — so it keeps the conservative whole-column
+    // claim. (Measured: relaxing it there breaks
+    // `randomized_overlapping_tightening_roundtrip`, which chains two-column
+    // rows and finds a postsolved point with a nonzero reduced cost at an
+    // interior variable.)
     let reduction_touched: Vec<bool> = (0..n)
         .map(|c| fixed[c].is_some() || substituted[c])
         .collect();
-    let mut bt_col_used = vec![false; n];
-    let row_is_clean = |entries: &[(usize, f64)], used: &[bool]| {
+    let mut bt_used_upper = vec![false; n];
+    let mut bt_used_lower = vec![false; n];
+    // Which `(column, side)` bounds a row claims. A singleton inequality
+    // `a·x_c ≤ h` implies one bound, and which side is fixed by the sign of
+    // `a` (`a > 0` bounds `x_c` above, `a < 0` below); everything else claims
+    // both sides of every column it touches.
+    let row_claims = |entries: &[(usize, f64)], is_eq: bool| -> Vec<(usize, bool)> {
+        if !is_eq && entries.len() == 1 {
+            let (c, a) = entries[0];
+            return vec![(c, a > 0.0)];
+        }
         entries
             .iter()
-            .all(|&(c, _)| !reduction_touched[c] && !used[c])
+            .flat_map(|&(c, _)| [(c, true), (c, false)])
+            .collect()
     };
+    let row_is_clean =
+        |entries: &[(usize, f64)], is_eq: bool, used_upper: &[bool], used_lower: &[bool]| {
+            entries.iter().all(|&(c, _)| !reduction_touched[c])
+                && row_claims(entries, is_eq)
+                    .into_iter()
+                    .all(|(c, up)| !if up { used_upper[c] } else { used_lower[c] })
+        };
 
     // Tighten variable boxes from one row whose activity lies in `[lo, hi]`
     // (inequality `≤ h`: `lo = −∞, hi = h`; equality: `lo = hi = b`).
@@ -912,7 +951,44 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
                             ub_src: &mut [Option<(usize, f64, bool)>],
                             lb_src: &mut [Option<(usize, f64, bool)>]|
      -> Option<usize> {
-        let (amin, amax) = activity(entries, &|c| tlb[c], &|c| tub[c]);
+        // Row activity as a *finite part plus a count of infinite terms*,
+        // rather than the plain sum [`activity`] returns.
+        //
+        // The implied bound on column `k` needs the activity of the row
+        // **without** `k`, and subtracting `k`'s own contribution from a total
+        // is wrong the moment that contribution is the infinite one: `−∞ −
+        // (−∞)` is `NaN`, `val` came out `NaN`, `val.is_finite()` was false,
+        // and the tightening silently did nothing. That is not a rare corner —
+        // it fired for *every* column of any row holding a variable unbounded
+        // on the relevant side, including the singleton row `x ≤ u`, which is
+        // nothing but a bound and should always imply one. Counting instead
+        // makes the leave-one-out exact: drop `k`'s term from whichever
+        // accumulator held it, and the rest is infinite only if some *other*
+        // column is.
+        let (mut min_finite, mut max_finite) = (0.0_f64, 0.0_f64);
+        let (mut min_infs, mut max_infs) = (0usize, 0usize);
+        let contrib = |k: usize, a: f64, tlb: &[f64], tub: &[f64]| -> (f64, f64) {
+            if a == 0.0 {
+                (0.0, 0.0)
+            } else if a > 0.0 {
+                (a * tlb[k], a * tub[k])
+            } else {
+                (a * tub[k], a * tlb[k])
+            }
+        };
+        for &(c, a) in entries {
+            let (cmin, cmax) = contrib(c, a, tlb, tub);
+            if cmin.is_finite() {
+                min_finite += cmin;
+            } else {
+                min_infs += 1;
+            }
+            if cmax.is_finite() {
+                max_finite += cmax;
+            } else {
+                max_infs += 1;
+            }
+        }
         // Compute all implied bounds against the row-start state, then
         // apply (so within-row order doesn't matter).
         let mut updates: Vec<(usize, bool, f64, f64)> = Vec::new(); // (col,is_upper,val,coef)
@@ -920,10 +996,29 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
             if fixed[k].is_some() || a == 0.0 {
                 continue;
             }
-            let contrib_min = if a > 0.0 { a * tlb[k] } else { a * tub[k] };
-            let contrib_max = if a > 0.0 { a * tub[k] } else { a * tlb[k] };
-            let amin_mk = amin - contrib_min;
-            let amax_mk = amax - contrib_max;
+            let (contrib_min, contrib_max) = contrib(k, a, tlb, tub);
+            // An infinite *min* contribution is `−∞` and an infinite *max* one
+            // is `+∞`, so a leftover infinity has a known sign.
+            let amin_mk = if min_infs > usize::from(!contrib_min.is_finite()) {
+                f64::NEG_INFINITY
+            } else {
+                min_finite
+                    - if contrib_min.is_finite() {
+                        contrib_min
+                    } else {
+                        0.0
+                    }
+            };
+            let amax_mk = if max_infs > usize::from(!contrib_max.is_finite()) {
+                f64::INFINITY
+            } else {
+                max_finite
+                    - if contrib_max.is_finite() {
+                        contrib_max
+                    } else {
+                        0.0
+                    }
+            };
             if hi.is_finite() {
                 let val = (hi - amin_mk) / a;
                 if val.is_finite() {
@@ -980,7 +1075,7 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         if ineq_dropped[row]
             || is_soc_row(row)
             || g_by_row[row].is_empty()
-            || !row_is_clean(&g_by_row[row], &bt_col_used)
+            || !row_is_clean(&g_by_row[row], false, &bt_used_upper, &bt_used_lower)
         {
             continue;
         }
@@ -998,8 +1093,12 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
             None => return PresolveOutcome::Infeasible,
             Some(0) => {}
             Some(_) => {
-                for &(c, _) in &g_by_row[row] {
-                    bt_col_used[c] = true;
+                for (c, up) in row_claims(&g_by_row[row], false) {
+                    if up {
+                        bt_used_upper[c] = true;
+                    } else {
+                        bt_used_lower[c] = true;
+                    }
                 }
             }
         }
@@ -1007,7 +1106,7 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
     for row in 0..m_eq {
         if eq_dropped[row]
             || a_by_row[row].is_empty()
-            || !row_is_clean(&a_by_row[row], &bt_col_used)
+            || !row_is_clean(&a_by_row[row], true, &bt_used_upper, &bt_used_lower)
         {
             continue;
         }
@@ -1026,8 +1125,12 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
             None => return PresolveOutcome::Infeasible,
             Some(0) => {}
             Some(_) => {
-                for &(c, _) in &a_by_row[row] {
-                    bt_col_used[c] = true;
+                for (c, up) in row_claims(&a_by_row[row], true) {
+                    if up {
+                        bt_used_upper[c] = true;
+                    } else {
+                        bt_used_lower[c] = true;
+                    }
                 }
             }
         }

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -111,19 +111,14 @@ impl QpProblem {
     /// True when some variable's box is **reversed** (`lb > ub`), so the
     /// feasible set is empty for a reason that needs no arithmetic to see.
     ///
-    /// Kept separate from [`Self::bounds_admit_no_point`] on purpose, and the
-    /// comparison is deliberately *exact* rather than tolerance-banded:
-    /// presolve's bound tightening legitimately produces a box crossed by up
-    /// to `BOUND_FEAS_TOL` and has its own toleranced test for it, so folding
-    /// this into the screen every presolve pass runs would turn a tolerated
-    /// near-crossing into a false infeasibility claim. This one is for the
-    /// *user-supplied* box, at a solve entry point.
-    ///
-    /// The interior-point path reaches `PrimalInfeasible` on such a box by
-    /// solving; the active-set path did not — its simplex seed clamped a
-    /// starting point into the inverted interval and `f64::clamp` panics on
-    /// `min > max`, which crossed the PyO3 boundary as an uncatchable
-    /// `PanicException` (gh #491). See [`crate::active_set`].
+    /// Kept separate from [`Self::bounds_admit_no_point`] on purpose: this is
+    /// the cheap *exact* test, and what a crossing of a given width should
+    /// mean is [`screen_variable_box`]'s decision, not this predicate's. Do
+    /// not fold the two together — presolve consults
+    /// `bounds_admit_no_point` on every pass, and its own bound tightening
+    /// legitimately leaves a box crossed by up to `BOUND_FEAS_TOL`, so an
+    /// exact reversal test there would turn a tolerated near-crossing into a
+    /// false infeasibility claim.
     pub(crate) fn bounds_are_reversed(&self) -> bool {
         (0..self.n).any(|i| self.lb_of(i) > self.ub_of(i))
     }
@@ -230,6 +225,109 @@ impl QpProblem {
     pub fn p_mul(&self, x: &[f64], y: &mut [f64]) {
         self.p_mul_add(x, y);
     }
+}
+
+/// Verdict on the variable box, decided before any solve is attempted.
+pub(crate) enum BoxScreen {
+    /// Every `[lb, ub]` is a non-empty interval; solve the problem as posed.
+    Feasible,
+    /// Some variable's box is empty by inspection — report `PrimalInfeasible`.
+    Empty,
+    /// Some box was crossed by no more than [`CROSSED_BOX_TOL`]; solve this
+    /// repaired copy, in which each such variable is fixed at its midpoint.
+    Snapped(QpProblem),
+}
+
+/// Widest box crossing (`lb − ub`) treated as a numerical artifact rather than
+/// an empty feasible set.
+///
+/// Matched to presolve's own `BOUND_FEAS_TOL`, which is the number that decides
+/// what can reach a solve entry point: bound tightening applies an update only
+/// when it improves a bound by more than that tolerance and declares
+/// infeasibility only when `tlb > tub + BOUND_FEAS_TOL`, so a *reduced* problem
+/// handed on from presolve can carry a box crossed by up to exactly this much —
+/// with presolve having already ruled that crossing tolerable. Calling it
+/// infeasible downstream would overturn that ruling on the strength of
+/// arithmetic presolve had already discounted.
+///
+/// It is also where the interior-point method drew this line of its own accord,
+/// which is why snapping here is a repair rather than a change of answer.
+/// Measured on `min ½x² s.t. 0 ≤ x ≤ −gap`, before this screen existed:
+///
+/// | crossing        | IPM verdict                       |
+/// |-----------------|-----------------------------------|
+/// | `1e-14 … 1e-9`  | `Optimal`, at the box midpoint    |
+/// | `1e-8 … 1e-7`   | `NumericalFailure`, `x = NaN`     |
+/// | `1e-6 … 1e0`    | `PrimalInfeasible`                |
+///
+/// So the screen preserves the top row (that midpoint is exactly what
+/// [`BoxScreen::Snapped`] hands back) and the bottom row, and replaces the
+/// middle one — a `NaN` iterate from a box the IPM's own arithmetic could not
+/// resolve either way — with the verdict the rows on both sides of it imply.
+pub(crate) const CROSSED_BOX_TOL: f64 = 1e-9;
+
+/// Decide what an ill-formed variable box means before a solver sees it.
+///
+/// Two classes of box admit no point, and neither survives contact with a
+/// solver intact:
+///
+/// * **Impossible** — a *present* `+∞` lower or `−∞` upper bound (gh #295).
+///   The bound-presence tests are sign-agnostic, so such a bound was dropped as
+///   if *absent* and a point violating it came back `Optimal`.
+/// * **Reversed** — `lb > ub` (gh #491). On the active-set path this **aborted
+///   the process**: the engine's `validate` rejects `xl > xu` with
+///   `QpError::InvertedBounds`, so the driver's first attempts failed and it
+///   fell through to its simplex-seeded last resort, where the seed was clamped
+///   into the inverted interval and `f64::clamp` panicked (`min > max`). Across
+///   the PyO3 boundary that surfaced as a `pyo3_runtime.PanicException`, which
+///   derives from `BaseException` and so tore down callers that had defensively
+///   wrapped the solve in `except Exception`.
+///
+/// A wide crossing is [`BoxScreen::Empty`], and saying so needs no arithmetic —
+/// which matters because the active-set driver otherwise refuses to report
+/// `PrimalInfeasible` without a certificate it re-derived itself. The
+/// certificate for this class *is* the bound pair: `x_i ≥ lb_i > ub_i ≥ x_i`
+/// has no solution, so there is nothing numerical to prove or to demote.
+///
+/// A hairline crossing is repaired instead, for the reason given on
+/// [`CROSSED_BOX_TOL`]: it is the residue of a tolerance decision made upstream,
+/// not a statement that the problem is infeasible.
+///
+/// **Every solve entry point runs this**, both engines' alike — which is the
+/// point. The two methods are alternatives for the same problem, so an
+/// input-domain question like "is this box empty?" must not be answered by
+/// whichever engine happens to be selected. Screening in the core rather than in
+/// the Python `_validate` pass also keeps the answer the same on the raw
+/// `_pounce` bindings, the CLI, and direct Rust callers.
+pub(crate) fn screen_variable_box(prob: &QpProblem) -> BoxScreen {
+    if prob.bounds_admit_no_point() {
+        return BoxScreen::Empty;
+    }
+    if !prob.bounds_are_reversed() {
+        return BoxScreen::Feasible;
+    }
+    if (0..prob.n).any(|i| prob.lb_of(i) > prob.ub_of(i) + CROSSED_BOX_TOL) {
+        return BoxScreen::Empty;
+    }
+    // Hairline: fix each crossed variable at its midpoint. Both bound vectors
+    // are necessarily length `n` here — an absent bound reads as `∓∞` and
+    // cannot be the crossed side — but index defensively anyway, since a
+    // partially-filled vector must not silently drop the repair and hand the
+    // solver the inverted box after all.
+    let mut repaired = prob.clone();
+    for i in 0..prob.n {
+        let (l, u) = (prob.lb_of(i), prob.ub_of(i));
+        if l > u {
+            let mid = 0.5 * (l + u);
+            if let (Some(lo), Some(hi)) = (repaired.lb.get_mut(i), repaired.ub.get_mut(i)) {
+                *lo = mid;
+                *hi = mid;
+            } else {
+                return BoxScreen::Empty;
+            }
+        }
+    }
+    BoxScreen::Snapped(repaired)
 }
 
 /// Termination status of an IPM solve.

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -108,6 +108,26 @@ impl QpProblem {
         (0..self.n).any(|i| self.lb_of(i) >= BOUND_INF || self.ub_of(i) <= -BOUND_INF)
     }
 
+    /// True when some variable's box is **reversed** (`lb > ub`), so the
+    /// feasible set is empty for a reason that needs no arithmetic to see.
+    ///
+    /// Kept separate from [`Self::bounds_admit_no_point`] on purpose, and the
+    /// comparison is deliberately *exact* rather than tolerance-banded:
+    /// presolve's bound tightening legitimately produces a box crossed by up
+    /// to `BOUND_FEAS_TOL` and has its own toleranced test for it, so folding
+    /// this into the screen every presolve pass runs would turn a tolerated
+    /// near-crossing into a false infeasibility claim. This one is for the
+    /// *user-supplied* box, at a solve entry point.
+    ///
+    /// The interior-point path reaches `PrimalInfeasible` on such a box by
+    /// solving; the active-set path did not — its simplex seed clamped a
+    /// starting point into the inverted interval and `f64::clamp` panics on
+    /// `min > max`, which crossed the PyO3 boundary as an uncatchable
+    /// `PanicException` (gh #491). See [`crate::active_set`].
+    pub(crate) fn bounds_are_reversed(&self) -> bool {
+        (0..self.n).any(|i| self.lb_of(i) > self.ub_of(i))
+    }
+
     /// A copy of this problem with the **objective** data scaled by `factor`
     /// (`P ← factor·P`, `c ← factor·c`); constraints, bounds, and the feasible
     /// set are untouched. Scaling the objective by a positive constant leaves

--- a/crates/pounce-convex/src/simplex.rs
+++ b/crates/pounce-convex/src/simplex.rs
@@ -417,7 +417,16 @@ impl Simplex {
     fn warm_start(&mut self, sol: &QpSolution) {
         for j in 0..self.n {
             let (lo, hi) = (self.lo[j], self.hi[j]);
-            let xj = sol.x.get(j).copied().unwrap_or(0.0).clamp(lo, hi);
+            // Written as max-then-min rather than `clamp`, which *panics* on an
+            // inverted interval (`min > max`). Callers are expected to have
+            // screened an empty box out before reaching here — both convex
+            // drivers do — but this is a seed builder, not a feasibility
+            // verdict, and it must not be the thing that takes the process down
+            // if one ever does not: the panic crossed the PyO3 boundary as an
+            // uncatchable `PanicException` (gh #491). On a reversed box this
+            // parks the variable at `hi`; the solve that follows is answering a
+            // problem with no feasible point either way.
+            let xj = sol.x.get(j).copied().unwrap_or(0.0).max(lo).min(hi);
             let (status, val) = if lo.is_finite() && (xj - lo).abs() <= BOUND_SNAP {
                 (NbStatus::AtLower, lo)
             } else if hi.is_finite() && (hi - xj).abs() <= BOUND_SNAP {

--- a/crates/pounce-convex/tests/presolve_aggregation.rs
+++ b/crates/pounce-convex/tests/presolve_aggregation.rs
@@ -175,7 +175,14 @@ fn alias_chain_lp_columns_drop() {
 
     let (red_n, red_rows) = reduced_size(&prob);
     assert_eq!(red_n, BLOCKS, "one survivor per chain, got {red_n}");
-    assert_eq!(red_rows, BLOCKS, "every alias row consumed, got {red_rows}");
+    // Zero, not `BLOCKS`: the per-block "real inequality" `-x_head <= -1` is
+    // itself a *singleton* row, and a singleton row is a bound — it folds into
+    // the box as `x_head >= 1` and is then redundant as a row (gh #491). So the
+    // alias rows this test is named for are all consumed, and so is every row
+    // that survived them. The column count above is the aggregation's own
+    // claim and is unchanged; the KKT and objective checks below are what
+    // prove nothing was lost with them.
+    assert_eq!(red_rows, 0, "every row consumed, got {red_rows}");
 
     let sol = with_presolve(&prob);
     assert_eq!(sol.status, QpStatus::Optimal);

--- a/crates/pounce-convex/tests/presolve_reductions.rs
+++ b/crates/pounce-convex/tests/presolve_reductions.rs
@@ -455,9 +455,17 @@ fn parallel_inequality_keeps_tightest() {
 }
 
 /// Opposite-direction inequalities are *not* merged: `x0 ≤ 3` and
-/// `−x0 ≤ −1` (i.e. x0 ≥ 1) form a range, not a duplicate — both kept.
+/// `−x0 ≤ −1` (i.e. `x0 ≥ 1`) form a range, not a duplicate. Treating them
+/// as duplicates would drop one side and enlarge the feasible set.
+///
+/// They used to be kept as two rows — the only representation available when
+/// a singleton row could not imply a bound (`−∞ − (−∞) = NaN` in the
+/// leave-one-out activity). Now the pair is recognized for what it is and
+/// becomes the box `1 ≤ x0 ≤ 3`, with both rows then redundant. Merging is
+/// still exactly what must not happen, so the assertion is on the *range*:
+/// both sides survive, and the optimum sits on the lower one.
 #[test]
-fn antiparallel_inequalities_not_merged() {
+fn antiparallel_inequalities_become_a_range_not_a_duplicate() {
     let prob = QpProblem {
         n: 1,
         p_lower: vec![Triplet::new(0, 0, 2.0)],
@@ -470,11 +478,17 @@ fn antiparallel_inequalities_not_merged() {
         ub: vec![],
     };
     match presolve(&prob) {
-        PresolveOutcome::Reduced(ps) => assert_eq!(ps.reduced.m_ineq(), 2, "both kept"),
+        PresolveOutcome::Reduced(ps) => {
+            assert_eq!(ps.reduced.lb_of(0), 1.0, "the `x0 >= 1` side survives");
+            assert_eq!(ps.reduced.ub_of(0), 3.0, "and so does `x0 <= 3`");
+        }
         other => panic!("expected Reduced, got {}", status_of(&other)),
     }
     let sol = with_presolve(&prob);
     assert_eq!(sol.status, QpStatus::Optimal);
+    // `min x0²` over `[1, 3]` is at the lower end. Losing the `x0 >= 1` side
+    // to a duplicate-merge would put it at 0.
+    assert!((sol.x[0] - 1.0).abs() < 1e-5, "x0={}", sol.x[0]);
     assert_kkt(&prob, &sol, 1e-5);
 }
 
@@ -725,11 +739,18 @@ fn redundant_inequality_negative_coeffs() {
     assert_kkt(&prob, &sol, 1e-5);
 }
 
-/// Unbounded variables must *not* make a row look redundant: with x0
-/// free (no upper bound), `x0 ≤ 1` has max activity +∞, so the row is
-/// kept and genuinely binds the solution.
+/// Unbounded variables must *not* make a row's content vanish: with x0
+/// free, `x0 ≤ 1` genuinely binds the solution and has to keep doing so
+/// however presolve chooses to represent it.
+///
+/// It used to be kept as a row, because the leave-one-out activity for its
+/// only column computed `−∞ − (−∞) = NaN` and no bound could be derived. That
+/// was a defect, not a policy: a singleton row *is* a bound, and it now
+/// becomes one — `ub = 1` — after which the row is redundant and dropped. So
+/// this asserts what the name always meant: the constraint is still there,
+/// enforced, and binding at the optimum.
 #[test]
-fn unbounded_variable_row_not_dropped() {
+fn unbounded_variable_row_becomes_the_bound_it_is() {
     let prob = QpProblem {
         n: 1,
         p_lower: vec![Triplet::new(0, 0, 2.0)],
@@ -743,13 +764,17 @@ fn unbounded_variable_row_not_dropped() {
     };
     match presolve(&prob) {
         PresolveOutcome::Reduced(ps) => {
-            assert_eq!(ps.reduced.m_ineq(), 1, "row must be kept (activity +∞)");
+            assert_eq!(ps.reduced.ub_of(0), 1.0, "the row became the bound");
+            assert_eq!(ps.reduced.m_ineq(), 0, "and is then redundant as a row");
         }
         other => panic!("expected Reduced, got {:?}", status_of(&other)),
     }
     let sol = with_presolve(&prob);
     assert_eq!(sol.status, QpStatus::Optimal);
+    // The point of the test: the constraint still binds. Without it the
+    // unconstrained optimum of `x0² − 10x0` is 5.
     assert!((sol.x[0] - 1.0).abs() < 1e-5, "x0={}", sol.x[0]);
+    assert_kkt(&prob, &sol, 1e-5);
 }
 
 /// Helper for panic messages: name the non-Reduced outcome.
@@ -1017,5 +1042,85 @@ fn presolve_stats_noop() {
             assert_eq!(s.reduced_rows, s.orig_rows);
         }
         other => panic!("expected Reduced, got {:?}", status_of(&other)),
+    }
+}
+
+// --- contradictory bound rows (gh #491) ---------------------------------
+
+/// A variable box written as a **pair of singleton rows** must be read as a
+/// box, including when the two sides contradict each other.
+///
+/// `x ≤ −gap` with `−x ≤ 0` is the shape any model reaches here with when its
+/// variable bounds were not carried in the box — `.nl` extraction used to emit
+/// exactly this. The pair is empty for any `gap > 0`, and presolve is where
+/// that has to be seen: as two rows it is an infeasibility that must be
+/// *certified* numerically, which the interior-point method did at most widths
+/// but not around `1e-8`, where it returned `NumericalFailure` at a `NaN`
+/// iterate.
+///
+/// Two separate defects kept presolve from seeing it, and both had to go:
+/// the leave-one-out activity for a singleton's own column was `−∞ − (−∞)` =
+/// `NaN`, so no bound was implied at all; and the tightening's disjointness
+/// rule let only the *first* of the two rows be a source, so even with that
+/// fixed only one side of the box would have been derived.
+#[test]
+fn contradictory_singleton_rows_are_seen_as_an_empty_box() {
+    let boxed_by_rows = |gap: f64| QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 2.0)],
+        c: vec![-6.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 0, -1.0)],
+        h: vec![-gap, 0.0], // x ≤ −gap and x ≥ 0
+        lb: vec![],
+        ub: vec![],
+    };
+
+    // Wider than the tolerance presolve absorbs ⇒ infeasible, and seen
+    // without any arithmetic on the solver's part.
+    for gap in [1e-8, 1e-7, 1e-6, 1.0] {
+        assert!(
+            matches!(presolve(&boxed_by_rows(gap)), PresolveOutcome::Infeasible),
+            "gap={gap:e} must presolve to Infeasible"
+        );
+    }
+
+    // At or below it, the pair still becomes the box — presolve tolerates the
+    // hairline crossing exactly as it does one of its own making, and leaves
+    // the verdict to the solver's box screen.
+    for gap in [1e-12, 1e-9] {
+        match presolve(&boxed_by_rows(gap)) {
+            PresolveOutcome::Reduced(ps) => {
+                assert_eq!(ps.reduced.m_ineq(), 0, "gap={gap:e}: rows became the box");
+                assert_eq!(ps.reduced.ub_of(0), -gap);
+                assert_eq!(ps.reduced.lb_of(0), 0.0);
+            }
+            other => panic!("gap={gap:e}: expected Reduced, got {}", status_of(&other)),
+        }
+    }
+}
+
+/// The same pair with a **consistent** box must not be called infeasible, and
+/// must still bind: `1 ≤ x ≤ 3` written as rows, against an objective whose
+/// unconstrained optimum is outside it on both ends.
+#[test]
+fn consistent_bound_rows_still_bind_after_becoming_a_box() {
+    for (c0, want) in [(-100.0, 3.0), (100.0, 1.0)] {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![Triplet::new(0, 0, 2.0)],
+            c: vec![c0],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, 1.0), Triplet::new(1, 0, -1.0)],
+            h: vec![3.0, -1.0],
+            lb: vec![],
+            ub: vec![],
+        };
+        let sol = with_presolve(&prob);
+        assert_eq!(sol.status, QpStatus::Optimal, "c0={c0}");
+        assert!((sol.x[0] - want).abs() < 1e-5, "c0={c0}: x0={}", sol.x[0]);
+        assert_kkt(&prob, &sol, 1e-5);
     }
 }

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -394,10 +394,19 @@ def _validate(P, c, A, b, G, h, lb, ub, n: int) -> None:
     # The solver's presence test (`lb > -BOUND_INF`, `ub < BOUND_INF`) is
     # sign-agnostic, so `lb = +inf` / `ub = -inf` were dropped as if unbounded
     # and the solve returned `status="optimal"` at a point violating the stated
-    # bound by an infinite margin. Note the *finite* analogue (`lb=1 > ub=0`)
-    # is correctly reported `primal_infeasible` by the solver, so this rejects
-    # only the degenerate spellings that silently produced a wrong answer.
-    # See gh #275.
+    # bound by an infinite margin. So this rejects only the degenerate
+    # spellings that silently produced a wrong answer. See gh #275.
+    #
+    # The *finite* analogue (`lb=1 > ub=0`) is deliberately NOT rejected here:
+    # an empty box is a legitimate problem with a status, and both engines
+    # report `primal_infeasible` for it. That claim used to hold only for
+    # `method="ipm"` — the active-set path reached a `f64::clamp` on the
+    # inverted interval and *panicked* across the FFI boundary, which arrives
+    # in Python as a `pyo3_runtime.PanicException` (a `BaseException`, so not
+    # caught by a caller's `except Exception`). Fixed in the core rather than
+    # by widening this guard, since the Rust entry point is reachable from the
+    # other bindings too — see `pounce-convex`'s `screen_variable_box` and
+    # gh #491.
     for name, vec, bad_val, cmp_txt in (
         ("lb", lb, np.inf, ">= +inf"),
         ("ub", ub, -np.inf, "<= -inf"),

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -399,14 +399,15 @@ def _validate(P, c, A, b, G, h, lb, ub, n: int) -> None:
     #
     # The *finite* analogue (`lb=1 > ub=0`) is deliberately NOT rejected here:
     # an empty box is a legitimate problem with a status, and both engines
-    # report `primal_infeasible` for it. That claim used to hold only for
-    # `method="ipm"` — the active-set path reached a `f64::clamp` on the
-    # inverted interval and *panicked* across the FFI boundary, which arrives
-    # in Python as a `pyo3_runtime.PanicException` (a `BaseException`, so not
-    # caught by a caller's `except Exception`). Fixed in the core rather than
-    # by widening this guard, since the Rust entry point is reachable from the
-    # other bindings too — see `pounce-convex`'s `screen_variable_box` and
-    # gh #491.
+    # report `primal_infeasible` for it. Neither did reliably. `method=
+    # "active-set"` reached a `f64::clamp` on the inverted interval and
+    # *panicked* across the FFI boundary — which arrives in Python as a
+    # `pyo3_runtime.PanicException`, a `BaseException`, so not caught by a
+    # caller's `except Exception`. `method="ipm"` was right at most crossing
+    # widths but returned `numerical_failure` with `x = nan` in a band around
+    # `1e-8`. Both are fixed in the core rather than by widening this guard,
+    # since those entry points are reachable from the other bindings too —
+    # see `pounce-convex`'s `screen_variable_box` and gh #491.
     for name, vec, bad_val, cmp_txt in (
         ("lb", lb, np.inf, ">= +inf"),
         ("ub", ub, -np.inf, "<= -inf"),

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -390,6 +390,28 @@ def test_solve_qp_reversed_bounds_never_panic_across_the_ffi(method):
     assert r.status == "primal_infeasible"
 
 
+@pytest.mark.parametrize("gap", [1e-8, 1e-7, 1e-6, 1.0])
+@pytest.mark.parametrize("method", ["ipm", "active-set"])
+def test_solve_qp_reversed_bounds_agree_across_methods(method, gap):
+    """gh #491: whether a box is empty is an input-domain question, so the two
+    methods must not split on it at any crossing width.
+
+    ``ipm`` used to return ``numerical_failure`` with ``x = [nan]`` for
+    crossings in a band around ``1e-8`` — wider than the tolerance it silently
+    absorbed, narrower than what its arithmetic could certify — while
+    reporting ``primal_infeasible`` on either side of that band.
+    """
+    r = solve_qp(
+        P=np.array([[1.0]]),
+        c=np.zeros(1),
+        lb=np.array([0.0]),
+        ub=np.array([-gap]),
+        method=method,
+    )
+    assert r.status == "primal_infeasible"
+    assert np.isfinite(r.x).all(), "an infeasible verdict must not carry a NaN"
+
+
 @pytest.mark.parametrize("method", ["ipm", "active-set"])
 def test_solve_qp_hairline_reversed_bounds_agree_across_methods(method):
     """A crossing below the solvers' feasibility tolerance is a numerical

--- a/python/tests/test_qp_host.py
+++ b/python/tests/test_qp_host.py
@@ -366,6 +366,50 @@ def test_solve_qp_finite_reversed_bounds_still_report_infeasible():
     assert r.status == "primal_infeasible"
 
 
+@pytest.mark.parametrize("method", ["ipm", "active-set"])
+def test_solve_qp_reversed_bounds_never_panic_across_the_ffi(method):
+    """gh #491: a reversed box is ``primal_infeasible`` on *both* methods.
+
+    ``method="active-set"`` used to reach an ``f64::clamp`` on the inverted
+    interval and panic. A Rust panic crosses PyO3 as ``PanicException``, which
+    derives from ``BaseException`` — so it is not caught by ``except
+    Exception`` and tears down a caller's loop even when the caller wrapped
+    the solve defensively. That is what the bare ``except Exception`` below
+    asserts: if the panic came back, this test errors rather than failing.
+    """
+    try:
+        r = solve_qp(
+            P=np.array([[1.0]]),
+            c=np.zeros(1),
+            lb=np.array([1.0]),
+            ub=np.array([0.0]),
+            method=method,
+        )
+    except Exception as exc:  # a panic would NOT be caught here
+        pytest.fail(f"solve_qp(method={method!r}) raised {type(exc).__name__}: {exc}")
+    assert r.status == "primal_infeasible"
+
+
+@pytest.mark.parametrize("method", ["ipm", "active-set"])
+def test_solve_qp_hairline_reversed_bounds_agree_across_methods(method):
+    """A crossing below the solvers' feasibility tolerance is a numerical
+    artifact, not an empty feasible set, and the two methods must not split on
+    it: both fix the variable at the box midpoint and report ``optimal``.
+
+    ``lb=0, ub=-1e-12`` panicked on ``active-set`` too (gh #491) — the trigger
+    was strictly ``ub < lb``, at any width.
+    """
+    r = solve_qp(
+        P=np.array([[1.0]]),
+        c=np.zeros(1),
+        lb=np.array([0.0]),
+        ub=np.array([-1e-12]),
+        method=method,
+    )
+    assert r.status == "optimal"
+    assert abs(r.x[0]) <= 1e-11
+
+
 def test_solve_qp_batch_inherits_the_bound_guard():
     with pytest.raises(ValueError, match=r"`lb\[0\]` is inf"):
         solve_qp_batch(


### PR DESCRIPTION
Fixes #491.

> **Rebased onto `37631ec`** (originally branched from `e0eeaac`). Measurements below were re-taken, not carried over — see Tests.

## Problem

`pounce.solve_qp(..., method="active-set")` on a crossed bound (`lb > ub`) **panicked out of Rust into Python** instead of returning `primal_infeasible` the way `method="ipm"` does on the identical input:

```
thread '' panicked at core/src/num/f64.rs:1503:9:
min > max, or either was NaN. min = 1.0, max = 0.0
pyo3_runtime.PanicException: min > max, or either was NaN. min = 1.0, max = 0.0
```

`PanicException` derives from `BaseException`, so a caller that had defensively wrapped the solve in `except Exception` still lost its loop.

Chasing it turned up three more disagreements on the same question — *is this box empty?* — each on a different surface. Measured on `min ½x² s.t. 0 ≤ x ≤ −gap`:

| crossing | `solve_qp` ipm | `solve_qp` active-set | CLI `.nl` (all routes) |
|---|---|---|---|
| `1e-12 … 1e-9` | `optimal`, at the midpoint | **panic** | `optimal` |
| `1e-8 … 1e-7` | **`numerical_failure`, `x=[nan]`** | **panic** | **`Numerical failure`, `obj=NaN`** |
| `1e-6 … 1e0` | `primal_infeasible` | **panic** | `primal_infeasible` |

The failures are *non-monotone* in the crossing width, which is why a single-width check would have missed most of this. After:

| crossing | all three, agreeing |
|---|---|
| `1e-12 … 1e-9` | `optimal`, at the box midpoint |
| `1e-8 … 1e0` | `primal_infeasible`, in 0 iterations, no `NaN` |

Oracles used: the `ipm` path on the same data, the CLI/`.nl` route, `pounce.minimize(bounds=[(1.0, 0.0)])` (already a clean `ValueError`), and clarabel (`PrimalInfeasible`).

## Cause

Four independent defects, found in this order.

**1. `f64::clamp` panics on an inverted interval.** The engine's own `validate` rejects `xl > xu` with `QpError::InvertedBounds`, so the active-set driver's first attempt and its Ruiz retry both returned `NumericalFailure` and it fell through to the last-resort simplex-seeded attempt — where `simplex::Simplex::warm_start` clamped the seed into `[1.0, 0.0]`.

**2. No screen on the active-set path.** The IPM screened the gh #295 impossible-bound class (`+∞` lower / `−∞` upper) at each of its own entry points; the active-set driver screened nothing at all, and neither path screened a *reversed* box.

**3. `.nl` variable bounds were not a box.** `qp_extract` emitted each finite bound as a `G` row (`x ≤ x_u`, `−x ≤ −x_l`) and left `lb`/`ub` empty. Never *wrong* — the IPM re-expands finite bounds into exactly those rows internally — but it discarded the one thing only the box carries: that these rows **are** a box. So on the CLI a reversed bound arrived as a pair of contradictory rows, an infeasibility that has to be *certified numerically* rather than seen.

**4. Presolve could not read a singleton row as the bound it is** — so it could not repair (3) either. Two reasons, both required:

- **`−∞ − (−∞) = NaN`.** The implied bound on a column needs the row's activity *without* that column, computed by subtracting the column's own contribution from the total. The moment that contribution was the infinite one the result was `NaN`, `val.is_finite()` was false, and the tightening silently did nothing — for *every* column of any row holding a variable unbounded on the relevant side, the singleton row `x ≤ u` included.
- **Whole-column source disjointness.** A tightening source row claimed its entire column, so of the pair `x ≤ u` / `−x ≤ −l` only the first was ever used and only one side of the box was derived. A contradictory pair could not be seen even in principle.

With (3) and (4) both in place, the verdict was left entirely to the iteration — which managed it at most widths but not around `1e-8`, where it returned `NumericalFailure` at a `NaN` iterate and printed `obj=NaN` on the CLI's summary line.

## Fix

**One screen, at every convex solve entry point.** `screen_variable_box` lives in `qp.rs` and runs in `solve_qp_ipm`, `solve_qp_ipm_warm`, `solve_qp_ipm_debug`, `solve_socp_ipm`, and `solve_qp_active_set`. Whether a box is empty is an input-domain question; it must not be answered by whichever engine the caller selected. In the core rather than in `qp.py`'s validation pass, so the answer is the same through the raw `_pounce` bindings, the CLI, and direct Rust callers.

A reversed box is `PrimalInfeasible` *by inspection* — `x_i ≥ lb_i > ub_i ≥ x_i` has no solution. That matters because the active-set driver otherwise refuses to report `PrimalInfeasible` without a certificate it re-derived itself; here the bound pair **is** the certificate, with nothing numerical to prove or to demote.

**A crossing ≤ `CROSSED_BOX_TOL = 1e-9` is repaired, not rejected** — the variable is fixed at its box midpoint. Two independent reasons converge on that number:

- presolve's bound tightening declares infeasibility only at `tlb > tub + BOUND_FEAS_TOL` (`1e-9`) and writes its tightened bounds back into the reduced problem's box, so it can legitimately hand a solver a box crossed by up to exactly that much, having already ruled the crossing tolerable. Rejecting it downstream would overturn that ruling on arithmetic presolve had discounted.
- it is where the IPM drew the line of its own accord: at `1e-9` and below its iteration converged to the box midpoint and reported `Optimal`. So the repair *preserves* its answer rather than replacing it — the screen keeps both outer bands and replaces only the `NaN` one.

**Rejected alternatives**, so nobody repeats them:

- *Reject `lb > ub` in `qp.py::_validate` with a `ValueError`* (one of the issue's two suggestions). It fixes only the Python surface, leaves the panic reachable from the raw bindings and Rust, and would change `ipm`'s long-standing `primal_infeasible` into an exception — `test_solve_qp_finite_reversed_bounds_still_report_infeasible` pins that as deliberate. The comment at `qp.py:397` that asserted the finite case was already safe is corrected instead.
- *A flat exact `lb > ub` → infeasible screen, no tolerance band.* Turns presolve's tolerated near-crossing into a false infeasibility claim, and contradicts the IPM at widths where it was already answering.
- *Per-`(column, side)` tightening claims for **all** rows.* Tried first; it breaks `randomized_overlapping_tightening_roundtrip`, which chains two-column rows and finds a postsolved point with a nonzero reduced cost at an interior variable. A multi-column row's `Gᵀz` credit lands in every column it touches. The relaxation is singleton-only — where the row has no other column to disturb, and row-active ⟺ implied-bound-active exactly — and multi-column rows keep the conservative whole-column claim.

**Supporting changes.** `warm_start` uses `max`-then-`min` instead of `clamp`, so a seed builder can never be what takes the process down. `qp_extract` puts `.nl` bounds in the box on both the QP and SOCP paths, with multipliers returned in `z_lb`/`z_ub` instead of decoded from `z` by row position (the two `count_*_ineq_rows` offset helpers are gone). Row activity is accumulated as a finite part plus a count of infinite terms, making the leave-one-out exact. `finite_or_failed` gates every caller-facing convex entry point: a non-finite entry in `x`/`y`/`z`/`z_lb`/`z_ub`/`obj` becomes a zero-filled `NumericalFailure`, because a `NaN` iterate is never information — it cannot be checked against a bound, printed into a `.sol`, or warm-started from, and it turns every downstream arithmetic into another `NaN`. The `*_debug` entry points deliberately pass it through; that is what the hook was attached to see.

## Blast radius

**The box screen is bit-identical for well-formed boxes.** `BoxScreen::Feasible` hands back the caller's `&QpProblem` — no clone, no copy — so no solve downstream of it can differ. Only an already-broken input takes a different path.

**The presolve changes are not bit-identical, and that is the real risk here.** Two reductions now fire that previously could not: a singleton row over a variable unbounded on the relevant side becomes a bound (and the row is then usually redundant and dropped), and both rows of a bound *pair* can now be sources. Any model with such rows presolves to a smaller problem than before. The reductions are correct — this is standard domain propagation that was disabled by an arithmetic accident — but they change reduced problems on the default path.

The guard for exactly this is `presolve_bound_tightening.rs`: two randomized suites, 300 instances each, every postsolved `(x, y, z, z_lb, z_ub)` checked as a valid KKT point of the *original* problem and primal-matched against a direct solve. Both are green, and one of them is what caught the over-broad first attempt above.

**Interaction with the presolve work that landed while this was open.** `main` gained three presolve changes in the same subsystem during review — #487 (variable elimination from linear equalities), #503 (transferred-bound multiplier attribution), and #494 (two-variable equality folding). All three compose with this: full suite green on the rebased tree. One needed a test update, in its own commit: #494's `alias_chain_lp_columns_drop` asserted `BLOCKS` rows survive presolve, and now **zero** do, because that fixture's per-block "real inequality" `-x_head ≤ -1` is itself a singleton row and therefore a bound. The survivor-column count is unchanged and the test's own KKT and objective assertions still pass exactly — the reduction got strictly more complete, and the assertion was on the mechanism rather than the claim.

**`.nl` convex QPs get up to `2n` fewer inequality rows**, which the active-set engine in particular pays combinatorially for.

**No Maros-Mészáros sweep was run.** The corpus `.nl` are not vendored (`$POUNCE_BENCH_DATA` is generated, not checked in), so I have no wall-clock or solved-count numbers against a baseline commit for the presolve change. That is the gap in this PR's evidence; the randomized KKT suites and the 2595-test workspace run are what stand in for it.

## Tests

Each new test was copied into a worktree at the base commit and run there, to confirm it bites and for the stated reason:

| test | on the base | for the stated reason |
|---|---|---|
| `active_set::tests::reversed_box_is_primal_infeasible_not_a_panic` | **aborts** | `panicked at f64.rs: min > max, or either was NaN. min = 1.0, max = 0.0` — the issue's exact message |
| `contradictory_singleton_rows_are_seen_as_an_empty_box` | **fails** | `gap=1e-8 must presolve to Infeasible` |
| `a_narrowly_reversed_bound_reaches_the_same_verdict` | **fails** | `route auto: expected a primal-infeasible verdict` |

That verification was run twice — at the original branch point `e0eeaac` and again at `c1205c4` after the first rebase, because #487 had landed a presolve elimination pass in between that could plausibly have caught these. It does not. `main` has since advanced to `37631ec`; rather than re-run the worktree a third time against a moving target, note the direct evidence that the base still lacks the reduction: it is *this* PR's singleton→bound fold that empties the rows in #494's own alias-chain test, which was written against a `main` that kept them.

**Two of the new tests pass on the base and are guards, not regression tests** — stated plainly so the distinction is not lost: `a_reversed_variable_bound_is_primal_infeasible_on_every_route` (the CLI already reported a *wide* crossing correctly — the issue says so, and it is now pinned against the screen over-reaching) and `consistent_bound_rows_still_bind_after_becoming_a_box`.

Also added: `hairline_crossing_is_repaired_not_rejected` and `well_formed_boxes_are_untouched_by_the_screen` (both engines, cross-checked against each other); `impossible_bounds_are_primal_infeasible_on_the_active_set_path` (gh #295 on the path that never had the check); 5 unit tests for `finite_or_failed`; 12 parametrized Python cases over both `method=` values and four crossing widths; 3 CLI end-to-end tests over all three convex routes with new `.nl` fixtures.

**Three existing tests changed, and they deserve a look.** `unbounded_variable_row_not_dropped` and `antiparallel_inequalities_not_merged` asserted `m_ineq()` counts — the old *mechanism*, in which a singleton row stayed a row precisely because no bound could be derived from it. `alias_chain_lp_columns_drop` (from #494) asserted the same kind of count. All three now assert the invariant each was named for — the constraint still binds at the optimum; both sides of a range survive rather than being merged away; every alias row is consumed and the KKT point is unchanged — with a comment saying what moved and why. If you would rather any of them kept pinning the row counts, that is a judgment call worth reversing.

**Not pinned:** the `pounce-hsl` MA57 test does not link in this environment (`COINHSL_DIR not set`), so the workspace run excludes that crate — unrelated to this change and failing identically before it.

---

- [x] Tests fail on the base commit for the stated reason — table above, verified at `e0eeaac` and again at `c1205c4`; two new tests are guards and say so
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — none applies; no documented behaviour changes, `solve_qp`'s contract for an empty box (`primal_infeasible`) is what it always claimed
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean **on the rebased tree** — workspace **2595 passed / 0 failed** (excl. `pounce-hsl`, above); Python **685 passed, 37 skipped**; no new clippy warnings in the changed files
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now