### PR TITLE
presolve: recover the bound multiplier a collapsed reduced box hides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,22 @@ changes.
   no-presolve solve. Where the survivor's own bound is active *as well*, the
   split is genuinely non-unique and the multiplier stays on the survivor —
   still a valid KKT point, and documented as such in `docs/src/options.md`.
+- A bound multiplier the reduced solve never *produced* is now recovered
+  too (#495). Re-attribution can only move a multiplier that exists, and
+  accumulated bound transfers can leave a survivor's reduced box as a
+  single point — a fixed variable, which the solver drops as a parameter,
+  so it reports `z_l = z_u = 0` even though the cluster it stands for is
+  sitting on a bound carrying load. Stationarity in the original space was
+  off by exactly the missing multiplier, and `ipopt_zL_out` /
+  `ipopt_zU_out` came back empty where Pyomo and AMPL expect a value.
+  Postsolve now reads the residual its row-multiplier sweep cannot close —
+  which is precisely that multiplier — and places it on the declared bound
+  the point is resting on, the survivor's own or, through the same `α`
+  rescale, the column the bound was borrowed from. A residual with no
+  active declared bound to carry it is left alone: trading a stationarity
+  error for a complementarity error is not a repair. A column the *model*
+  declares fixed is untouched, since the solver drops those with or without
+  the reduction and a no-presolve solve reports nothing for them either.
 - One documented caveat remains, in `docs/src/options.md`: a contradictory
   equality system makes the pass stand down entirely rather than be the
   first and only voice calling a model infeasible.

--- a/crates/pounce-algorithm/tests/presolve_phase6_missing_bound_multiplier.rs
+++ b/crates/pounce-algorithm/tests/presolve_phase6_missing_bound_multiplier.rs
@@ -1,0 +1,623 @@
+//! Phase 6 acceptance (issue #495): every column whose declared bound is
+//! active at the optimum must come back with a bound multiplier, so that
+//! what postsolve reports is a KKT multiplier set for the *original*
+//! problem.
+//!
+//! #493 moved a multiplier the solver *reported* to the column that owns
+//! the bound. This is the case where the solver reported none: accumulated
+//! bound transfers squeeze a survivor's reduced box down to a single point,
+//! the solver treats that column as a fixed variable and drops it, and no
+//! bound multiplier is produced at all — while the full-space cluster it
+//! stands for is sitting on a bound that needs one. There is nothing to
+//! re-attribute, so postsolve has to derive it.
+//!
+//! The oracle here is the textbook KKT system, evaluated from the fixture's
+//! own analytic derivatives: primal feasibility, stationarity
+//! `∇f + Jᵀλ − z_l + z_u = 0`, dual feasibility, and bound
+//! complementarity. `pounce verify` cannot stand in for it — it reports
+//! *bound-projected* stationarity, which projects out exactly the
+//! component a bound multiplier carries.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_presolve::{LinearEqElimTnlp, PresolveOptions, PresolveTnlp};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// `min Σ (x_j − t_j)^p` over linear equality rows and a box.
+///
+/// Separable and polynomial, so every derivative the KKT oracle needs is
+/// available in closed form on the test side rather than read back out of
+/// the solver.
+#[derive(Clone)]
+struct Model {
+    targets: Vec<Number>,
+    x_l: Vec<Number>,
+    x_u: Vec<Number>,
+    /// `Σ a_j x_j = b`, one entry per row.
+    rows: Vec<(Vec<(usize, Number)>, Number)>,
+    power: i32,
+}
+
+impl Model {
+    fn n(&self) -> usize {
+        self.targets.len()
+    }
+
+    fn grad(&self, x: &[Number]) -> Vec<Number> {
+        let p = self.power;
+        (0..self.n())
+            .map(|j| p as Number * (x[j] - self.targets[j]).powi(p - 1))
+            .collect()
+    }
+
+    /// `∇f + Jᵀλ − z_l + z_u`, in POUNCE's `finalize_solution` convention.
+    fn stationarity(&self, c: &Captured) -> Vec<Number> {
+        let mut r = self.grad(&c.x);
+        for (i, (entries, _)) in self.rows.iter().enumerate() {
+            for &(j, a) in entries {
+                r[j] += a * c.lambda[i];
+            }
+        }
+        for j in 0..self.n() {
+            r[j] += -c.z_l[j] + c.z_u[j];
+        }
+        r
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct Captured {
+    x: Vec<Number>,
+    z_l: Vec<Number>,
+    z_u: Vec<Number>,
+    lambda: Vec<Number>,
+}
+
+struct Fixture {
+    model: Model,
+    captured: Option<Captured>,
+}
+
+impl TNLP for Fixture {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        let nnz_jac: usize = self.model.rows.iter().map(|(e, _)| e.len()).sum();
+        Some(NlpInfo {
+            n: self.model.n() as i32,
+            m: self.model.rows.len() as i32,
+            nnz_jac_g: nnz_jac as i32,
+            nnz_h_lag: self.model.n() as i32,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&self.model.x_l);
+        b.x_u.copy_from_slice(&self.model.x_u);
+        for (i, (_, rhs)) in self.model.rows.iter().enumerate() {
+            b.g_l[i] = *rhs;
+            b.g_u[i] = *rhs;
+        }
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        for (j, slot) in sp.x.iter_mut().enumerate() {
+            // Inside the box, but nowhere near the answer.
+            let lo = self.model.x_l[j].max(-1e3);
+            let hi = self.model.x_u[j].min(1e3);
+            *slot = 0.5 * (lo + hi);
+        }
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        for t in types.iter_mut() {
+            *t = Linearity::Linear;
+        }
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(
+            (0..self.model.n())
+                .map(|j| (x[j] - self.model.targets[j]).powi(self.model.power))
+                .sum(),
+        )
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&self.model.grad(x));
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for (i, (entries, _)) in self.model.rows.iter().enumerate() {
+            g[i] = entries.iter().map(|&(j, a)| a * x[j]).sum();
+        }
+        true
+    }
+
+    fn eval_jac_g(&mut self, _x: Option<&[Number]>, _n: bool, mode: SparsityRequest<'_>) -> bool {
+        let mut k = 0;
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for (i, (entries, _)) in self.model.rows.iter().enumerate() {
+                    for &(j, _) in entries {
+                        irow[k] = i as i32;
+                        jcol[k] = j as i32;
+                        k += 1;
+                    }
+                }
+            }
+            SparsityRequest::Values { values } => {
+                for (entries, _) in &self.model.rows {
+                    for &(_, a) in entries {
+                        values[k] = a;
+                        k += 1;
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                for j in 0..self.model.n() {
+                    irow[j] = j as i32;
+                    jcol[j] = j as i32;
+                }
+            }
+            SparsityRequest::Values { values } => {
+                // The rows are linear, so λ contributes no curvature.
+                let x = x.expect("values need a point");
+                let p = self.model.power;
+                for j in 0..self.model.n() {
+                    values[j] = obj_factor
+                        * (p * (p - 1)) as Number
+                        * (x[j] - self.model.targets[j]).powi(p - 2);
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        self.captured = Some(Captured {
+            x: sol.x.to_vec(),
+            z_l: sol.z_l.to_vec(),
+            z_u: sol.z_u.to_vec(),
+            lambda: sol.lambda.to_vec(),
+        });
+    }
+}
+
+fn opts(linear_eq_reduction: bool) -> PresolveOptions {
+    PresolveOptions {
+        enabled: true,
+        linear_eq_reduction,
+        // Everything else off, so any dual that moves moved for the reason
+        // under test.
+        bound_tightening: false,
+        redundant_constraint_removal: false,
+        licq_check: false,
+        warm_z_bounds: false,
+        ..PresolveOptions::defaults()
+    }
+}
+
+struct Outcome {
+    captured: Captured,
+    reduced_n: i32,
+}
+
+fn solve(model: &Model, linear_eq_reduction: bool) -> Outcome {
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    // Unscaled, so the reported duals are directly comparable against the
+    // fixture's own analytic gradient.
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "none", true, false)
+        .unwrap();
+
+    let concrete = Rc::new(RefCell::new(Fixture {
+        model: model.clone(),
+        captured: None,
+    }));
+    let presolve = Rc::new(RefCell::new(PresolveTnlp::new(
+        Rc::clone(&concrete) as Rc<RefCell<dyn TNLP>>,
+        opts(linear_eq_reduction),
+    )));
+    let elim = Rc::new(RefCell::new(LinearEqElimTnlp::new(
+        Rc::clone(&presolve) as Rc<RefCell<dyn TNLP>>,
+        opts(linear_eq_reduction),
+    )));
+    let info = elim.borrow_mut().get_nlp_info().expect("dims");
+    let _ = app.optimize_tnlp(Rc::clone(&elim) as Rc<RefCell<dyn TNLP>>);
+
+    Outcome {
+        captured: concrete.borrow().captured.clone().expect("finalized"),
+        reduced_n: info.n,
+    }
+}
+
+/// The full KKT system, in the original variable space. Returns the list of
+/// violations, so a failure names which condition broke rather than only
+/// that one did.
+fn kkt_violations(model: &Model, c: &Captured, tol: Number) -> Vec<String> {
+    let mut out = Vec::new();
+    for (i, (entries, rhs)) in model.rows.iter().enumerate() {
+        let lhs: Number = entries.iter().map(|&(j, a)| a * c.x[j]).sum();
+        if (lhs - rhs).abs() > tol {
+            out.push(format!("row {i} violated: {lhs} != {rhs}"));
+        }
+    }
+    for (j, r) in model.stationarity(c).iter().enumerate() {
+        if r.abs() > tol {
+            out.push(format!("stationarity at column {j} = {r}"));
+        }
+    }
+    for j in 0..model.n() {
+        if c.z_l[j] < -tol {
+            out.push(format!("z_l[{j}] = {} is negative", c.z_l[j]));
+        }
+        if c.z_u[j] < -tol {
+            out.push(format!("z_u[{j}] = {} is negative", c.z_u[j]));
+        }
+        if c.x[j] < model.x_l[j] - tol || c.x[j] > model.x_u[j] + tol {
+            out.push(format!("x[{j}] = {} is outside its box", c.x[j]));
+        }
+        let slack_l = (c.x[j] - model.x_l[j]).abs();
+        let slack_u = (c.x[j] - model.x_u[j]).abs();
+        if c.z_l[j].abs() > tol && slack_l > 1e-5 {
+            out.push(format!(
+                "complementarity: z_l[{j}] = {} on a bound {} away",
+                c.z_l[j], slack_l
+            ));
+        }
+        if c.z_u[j].abs() > tol && slack_u > 1e-5 {
+            out.push(format!(
+                "complementarity: z_u[{j}] = {} on a bound {} away",
+                c.z_u[j], slack_u
+            ));
+        }
+    }
+    out
+}
+
+fn assert_kkt(tag: &str, model: &Model, c: &Captured) {
+    let v = kkt_violations(model, c, 1e-4);
+    assert!(v.is_empty(), "{tag}: {v:#?}\nduals = {c:?}");
+}
+
+/// The issue's minimal case.
+///
+/// ```text
+///   min (x0−4)⁴ + (x1−4)⁴   s.t.  x0 − x1 = 0,  x0 ∈ [1,5],  x1 ∈ [−5,1]
+/// ```
+///
+/// The transfer squeezes `x1`'s reduced box to the single point `{1}`, so
+/// the solver drops the column and reports no multiplier for it. The
+/// optimum is `x = (1,1)` with `∇f = (−108, −108)`; `λ = 108`,
+/// `z_u[1] = 216` closes stationarity.
+#[test]
+fn a_collapsed_reduced_box_still_reports_its_bound_multiplier() {
+    let model = Model {
+        targets: vec![4.0, 4.0],
+        x_l: vec![1.0, -5.0],
+        x_u: vec![5.0, 1.0],
+        rows: vec![(vec![(0, 1.0), (1, -1.0)], 0.0)],
+        power: 4,
+    };
+    let on = solve(&model, true);
+    assert_eq!(on.reduced_n, 1, "one column should be gone");
+    assert!((on.captured.x[0] - 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert!((on.captured.x[1] - 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert_kkt("reduction on", &model, &on.captured);
+
+    // The multiplier the reduced solve never produced: 216 on x1's upper
+    // bound, which is the one the collapsed box came to rest on.
+    assert!(
+        (on.captured.z_u[1] - 216.0).abs() < 1e-2,
+        "z_u = {:?}, λ = {:?}",
+        on.captured.z_u,
+        on.captured.lambda
+    );
+
+    // And the bare solve agrees the point is what it is.
+    let off = solve(&model, false);
+    assert_kkt("reduction off", &model, &off.captured);
+    for j in 0..2 {
+        assert!(
+            (on.captured.x[j] - off.captured.x[j]).abs() < 1e-5,
+            "primal moved: {:?} vs {:?}",
+            on.captured.x,
+            off.captured.x
+        );
+    }
+}
+
+/// The same collapse with the transfer running the other way: `x1`'s box is
+/// the wide one, so the point the cluster comes to rest on is the *lower*
+/// end. The multiplier has to change sides with it.
+#[test]
+fn a_collapsed_box_resting_on_a_lower_bound_reports_a_lower_multiplier() {
+    let model = Model {
+        targets: vec![-4.0, -4.0],
+        x_l: vec![-5.0, -1.0],
+        x_u: vec![-1.0, 5.0],
+        rows: vec![(vec![(0, 1.0), (1, -1.0)], 0.0)],
+        power: 4,
+    };
+    let on = solve(&model, true);
+    assert_eq!(on.reduced_n, 1);
+    assert!((on.captured.x[0] + 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert_kkt("reduction on", &model, &on.captured);
+    assert!(
+        on.captured.z_l[1] > 1e-3,
+        "no multiplier on the active lower bound: {:?}",
+        on.captured
+    );
+}
+
+/// A negative substitution coefficient reverses the interval on the way
+/// across, so the survivor's collapsed point sits on the *opposite* side of
+/// the eliminated column's box from its own.
+#[test]
+fn a_negative_coefficient_does_not_lose_the_multiplier() {
+    let model = Model {
+        targets: vec![4.0, -4.0],
+        x_l: vec![1.0, -1.0],
+        x_u: vec![5.0, 5.0],
+        // x0 + x1 = 0, i.e. x0 = −x1.
+        rows: vec![(vec![(0, 1.0), (1, 1.0)], 0.0)],
+        power: 4,
+    };
+    let on = solve(&model, true);
+    assert_eq!(on.reduced_n, 1);
+    assert!((on.captured.x[0] - 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert!((on.captured.x[1] + 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert_kkt("reduction on", &model, &on.captured);
+}
+
+/// The survivor is not always the column that can carry the multiplier.
+///
+/// ```text
+///   min (x0−10)⁴ + (x1−10)⁴   s.t.  x0 − x1 = 0,  x0 ∈ [1,3],  x1 ∈ [3,5]
+/// ```
+///
+/// `x0` folds onto `x1`, whose reduced box collapses to `{3}`. The
+/// objective pulls upwards, so the multiplier the collapse hides is an
+/// *upper*-bound one — and `x1 = 3` is sitting on its own **lower** bound,
+/// nowhere near an upper one. The only column that can carry it is `x0`,
+/// which is exactly the column whose box supplied the collapsing side.
+/// Getting there means moving the multiplier across the cluster and
+/// re-solving the consumed row for it.
+#[test]
+fn a_multiplier_the_survivor_cannot_carry_moves_to_the_column_that_can() {
+    let model = Model {
+        targets: vec![10.0, 10.0],
+        x_l: vec![1.0, 3.0],
+        x_u: vec![3.0, 5.0],
+        rows: vec![(vec![(0, 1.0), (1, -1.0)], 0.0)],
+        power: 4,
+    };
+    let on = solve(&model, true);
+    assert_eq!(on.reduced_n, 1);
+    assert!((on.captured.x[0] - 3.0).abs() < 1e-6, "{:?}", on.captured.x);
+    assert_kkt("reduction on", &model, &on.captured);
+    // ∇f = (−1372, −1372) at x = (3,3); λ = −1372 leaves 2744 for x0's
+    // upper bound to carry.
+    assert!(
+        (on.captured.z_u[0] - 2744.0).abs() < 1e-1,
+        "expected z_u[0] = 2744, got {:?}",
+        on.captured
+    );
+    assert!(
+        on.captured.z_l[1].abs() < 1e-4 && on.captured.z_u[1].abs() < 1e-4,
+        "the survivor kept a multiplier it cannot own: {:?}",
+        on.captured
+    );
+
+    // Flip the pull and the same collapse is carried by the survivor's own
+    // lower bound instead, with no hand-off at all.
+    let mirrored = Model {
+        targets: vec![-10.0, -10.0],
+        ..model.clone()
+    };
+    let on = solve(&mirrored, true);
+    assert_kkt("mirrored", &mirrored, &on.captured);
+    assert!(
+        on.captured.z_l[1] > 1e-3,
+        "expected the survivor to carry this one: {:?}",
+        on.captured
+    );
+}
+
+/// A chain, so the residual has to travel: `x0 = x1 = x2`, with the boxes
+/// arranged so the intersection is a single point contributed by the
+/// column at the far end of the chain from the survivor.
+#[test]
+fn a_chain_whose_intersection_is_a_point_still_closes_stationarity() {
+    let model = Model {
+        targets: vec![4.0, 4.0, 4.0],
+        x_l: vec![1.0, -5.0, -5.0],
+        x_u: vec![5.0, 1.0, 8.0],
+        rows: vec![
+            (vec![(0, 1.0), (1, -1.0)], 0.0),
+            (vec![(1, 1.0), (2, -1.0)], 0.0),
+        ],
+        power: 4,
+    };
+    let on = solve(&model, true);
+    assert_eq!(on.reduced_n, 1, "two columns should be gone");
+    for j in 0..3 {
+        assert!((on.captured.x[j] - 1.0).abs() < 1e-6, "{:?}", on.captured.x);
+    }
+    assert_kkt("reduction on", &model, &on.captured);
+}
+
+/// The boundary of the fix, pinned so it cannot drift.
+///
+/// ```text
+///   min (x0−4)² + (x1−4)² + (x2−1)²   s.t.  2·x0 + 3·x1 = 6,  x1 ∈ [1,1]
+/// ```
+///
+/// `x1` is a constant before the sweep starts, so the row is a singleton in
+/// `x0` and pins it at `1.5`; stationarity at `x0` fixes `λ = 2.5`, and the
+/// `3·λ` that lands on `x1` is carried by nothing. That is *not* a Phase 6
+/// defect: the model declares `x1` fixed, so the solver drops it as a
+/// parameter and reports no multiplier for it whether or not the reduction
+/// runs. The bar here is parity with the bare solve, not a KKT point —
+/// manufacturing a multiplier a no-presolve solve does not report would be
+/// a divergence, and belongs to `fixed_variable_treatment` if anywhere.
+#[test]
+fn a_declared_fixed_column_reports_exactly_what_the_bare_solve_reports() {
+    let model = Model {
+        targets: vec![4.0, 4.0, 1.0],
+        x_l: vec![-1e19, 1.0, -1e19],
+        x_u: vec![1e19, 1.0, 1e19],
+        rows: vec![(vec![(0, 2.0), (1, 3.0)], 6.0)],
+        power: 2,
+    };
+    let on = solve(&model, true);
+    let off = solve(&model, false);
+    assert!((on.captured.x[0] - 1.5).abs() < 1e-6, "{:?}", on.captured.x);
+    assert_eq!(
+        kkt_violations(&model, &on.captured, 1e-4),
+        kkt_violations(&model, &off.captured, 1e-4),
+        "the reduction changed what a declared-fixed column reports:\n\
+         on = {:?}\noff = {:?}",
+        on.captured,
+        off.captured
+    );
+    for j in 0..3 {
+        assert!((on.captured.z_l[j] - off.captured.z_l[j]).abs() < 1e-6);
+        assert!((on.captured.z_u[j] - off.captured.z_u[j]).abs() < 1e-6);
+    }
+}
+
+/// Nothing above may cost the models that were already fine: where every
+/// eliminated column is interior to its box, the duals must not move.
+#[test]
+fn an_interior_reduction_reports_exactly_what_it_did_before() {
+    let model = Model {
+        targets: vec![4.0, 4.0],
+        x_l: vec![-100.0, -100.0],
+        x_u: vec![100.0, 100.0],
+        rows: vec![(vec![(0, 1.0), (1, -2.0)], 1.0)],
+        power: 4,
+    };
+    let on = solve(&model, true);
+    assert_eq!(on.reduced_n, 1);
+    assert_kkt("reduction on", &model, &on.captured);
+    for j in 0..2 {
+        assert!(
+            on.captured.z_l[j].abs() < 1e-6 && on.captured.z_u[j].abs() < 1e-6,
+            "a bound multiplier appeared on an interior column: {:?}",
+            on.captured
+        );
+    }
+}
+
+/// A sweep over clusters whose boxes touch the same point from every
+/// combination of sides. The oracle is the whole KKT system, so this covers
+/// the cases the named tests above single out and the ones between them —
+/// in particular the ones where the collapsed point is contributed by a
+/// column that is *not* the survivor, so the multiplier has to be handed
+/// across the cluster.
+///
+/// Every column's box is built around a shared witness point, so the models
+/// are feasible by construction and a stand-down is a bug in the generator
+/// rather than a legitimate outcome to skip past.
+#[test]
+fn randomized_clusters_are_kkt_points_in_the_original_space() {
+    // A deterministic LCG: the point is coverage, not entropy, and a test
+    // that fails on Tuesdays is worse than one that fails never.
+    let mut seed: u64 = 0x5DEE_CE66_D125_1F03;
+    let mut next = move || {
+        seed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((seed >> 33) as f64) / ((1u64 << 31) as f64)
+    };
+    let mut collapsed = 0usize;
+    for case in 0..60 {
+        let n = 2 + (case % 4);
+        // x_j = c_j · v, with the whole cluster passing through v = 1.
+        let mut c = vec![1.0 as Number];
+        let mut rows = Vec::new();
+        for j in 0..n - 1 {
+            let r = [1.0, -1.0, 2.0, -0.5][(next() * 4.0) as usize % 4];
+            c.push(c[j] * r);
+            rows.push((vec![(j + 1, 1.0), (j, -r)], 0.0));
+        }
+        // A margin of zero puts the witness point exactly on that bound,
+        // which is what makes the intersection collapse.
+        let mut margin = || {
+            if next() < 0.45 {
+                0.0
+            } else {
+                0.2 + 2.0 * next()
+            }
+        };
+        let mut x_l = Vec::new();
+        let mut x_u = Vec::new();
+        for &cj in &c {
+            let (mut lo, mut hi) = (margin(), margin());
+            if lo == 0.0 && hi == 0.0 {
+                // A both-sides-zero margin declares the column fixed, which
+                // the solver drops as a parameter with or without the
+                // reduction; that boundary has its own test.
+                hi = 1.0;
+            }
+            x_l.push(cj - lo);
+            x_u.push(cj + hi);
+        }
+        let targets: Vec<Number> = (0..n).map(|_| 8.0 * next() - 4.0).collect();
+        let model = Model {
+            targets,
+            x_l,
+            x_u,
+            rows,
+            power: 4,
+        };
+        let on = solve(&model, true);
+        assert!(
+            (on.reduced_n as usize) < model.n(),
+            "case {case}: the reduction stood down on a feasible cluster"
+        );
+        if (on.captured.z_l.iter().chain(on.captured.z_u.iter())).any(|&z| z > 1e-6) {
+            collapsed += 1;
+        }
+        let v = kkt_violations(&model, &on.captured, 1e-4);
+        assert!(
+            v.is_empty(),
+            "case {case}: {v:#?}\nboxes = {:?} / {:?}, targets = {:?}\nrows = {:?}\nduals = {:?}",
+            model.x_l,
+            model.x_u,
+            model.targets,
+            model.rows,
+            on.captured
+        );
+    }
+    assert!(
+        collapsed >= 15,
+        "only {collapsed} cases came to rest on a bound; the generator has \
+         stopped exercising what this test is for"
+    );
+}

--- a/crates/pounce-cli/tests/fixtures/linear_eq_collapsed_box.nl
+++ b/crates/pounce-cli/tests/fixtures/linear_eq_collapsed_box.nl
@@ -1,0 +1,41 @@
+g3 1 1 0	# problem linear_eq_collapsed_box
+ 2 1 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs
+ 0 0	# network
+ 0 2 0 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network vars; functions; arith, flags
+ 0 0 0 0 0 	# discrete
+ 2 2 	# nonzeros in Jacobian, obj gradient
+ 0 0	# max name lengths
+ 0 0 0 0 0	# common exprs
+C0
+n0.0
+O0 0
+o54
+2
+o5
+o0
+v0
+n-4.0
+n4
+o5
+o0
+v1
+n-4.0
+n4
+x2
+0 2.0
+1 0.0
+r
+4 0.0
+b
+0 1.0 5.0
+0 -5.0 1.0
+k1
+1
+J0 2
+0 1.0
+1 -1.0
+G0 2
+0 0
+1 0

--- a/crates/pounce-cli/tests/linear_eq_collapsed_box_duals.rs
+++ b/crates/pounce-cli/tests/linear_eq_collapsed_box_duals.rs
@@ -1,0 +1,151 @@
+//! Issue #495 end to end: the bound multiplier a collapsed reduced box
+//! hides has to reach the `.sol` suffix blocks, because that is where
+//! Pyomo (`model.ipopt_zL_out`) and AMPL (`.rc`) read it from.
+//!
+//! The fixture is the issue's own minimal model:
+//!
+//! ```text
+//!   min (x0−4)⁴ + (x1−4)⁴   s.t.  x0 − x1 = 0,  x0 ∈ [1,5],  x1 ∈ [−5,1]
+//! ```
+//!
+//! Phase 6 folds `x0` onto `x1` and carries `x0 ≥ 1` across, which leaves
+//! `x1` with the reduced box `[1,1]` — a fixed variable, which the solver
+//! drops, so nothing in the reduced problem can produce a multiplier for
+//! it. The optimum is `x = (1,1)` with `∇f = (−108, −108)`, so `λ = 108`
+//! and a bound multiplier of `216` on `x1`'s upper bound close
+//! stationarity. Before the fix both suffix blocks came back empty.
+//!
+//! `presolve_bound_tightening=no` is not incidental: Phase 1 would
+//! otherwise pin both columns from the same intersection and the model
+//! would never reach Phase 6 at all.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// `(row duals, primals, zL entries, zU entries)` read out of a `.sol`.
+struct Sol {
+    duals: Vec<f64>,
+    x: Vec<f64>,
+    z_l: Vec<(usize, f64)>,
+    z_u: Vec<(usize, f64)>,
+}
+
+fn run(tag: &str, opts: &[&str]) -> Sol {
+    let dir = std::env::temp_dir().join(format!("pounce_lin_eq_collapsed_{tag}"));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/linear_eq_collapsed_box.nl");
+    std::fs::copy(&fixture, dir.join("m.nl")).expect("copy fixture");
+
+    let mut cmd = Command::new(PathBuf::from(env!("CARGO_BIN_EXE_pounce")));
+    cmd.current_dir(&dir).arg("m").arg("-AMPL");
+    for o in opts {
+        cmd.arg(o);
+    }
+    let out = cmd.output().expect("run pounce");
+    let sol = std::fs::read_to_string(dir.join("m.sol")).unwrap_or_else(|e| {
+        panic!(
+            "no .sol: {e}\n{}",
+            String::from_utf8_lossy(&out.stdout).into_owned()
+        )
+    });
+
+    // Body: the `Options` preamble, then 1 dual and 2 primals, then the
+    // suffix blocks.
+    let body: Vec<f64> = sol
+        .lines()
+        .take_while(|l| !l.starts_with("objno"))
+        .filter_map(|l| l.trim().parse::<f64>().ok())
+        .collect();
+    assert!(body.len() >= 3, "short .sol body {body:?}\n{sol}");
+    let (mut z_l, mut z_u) = (Vec::new(), Vec::new());
+    let mut into: Option<&mut Vec<(usize, f64)>> = None;
+    for line in sol.lines().skip_while(|l| !l.starts_with("objno")) {
+        match line.trim() {
+            "ipopt_zL_out" => into = Some(&mut z_l),
+            "ipopt_zU_out" => into = Some(&mut z_u),
+            other => {
+                let mut it = other.split_whitespace();
+                if let (Some(Ok(i)), Some(Ok(v)), Some(slot)) = (
+                    it.next().map(str::parse::<usize>),
+                    it.next().map(str::parse::<f64>),
+                    into.as_deref_mut(),
+                ) {
+                    slot.push((i, v));
+                }
+            }
+        }
+    }
+    Sol {
+        duals: body[body.len() - 3..body.len() - 2].to_vec(),
+        x: body[body.len() - 2..].to_vec(),
+        z_l,
+        z_u,
+    }
+}
+
+/// The `.sol` writer records `z_u` with the sign AMPL expects, so compare
+/// magnitudes against the bare solve rather than hard-coding a convention
+/// this test does not own.
+fn magnitude(entries: &[(usize, f64)], j: usize) -> f64 {
+    entries
+        .iter()
+        .find(|(i, _)| *i == j)
+        .map(|(_, v)| v.abs())
+        .unwrap_or(0.0)
+}
+
+#[test]
+fn a_collapsed_reduced_box_still_writes_its_bound_multiplier_suffix() {
+    let reduced = run(
+        "reduced",
+        &[
+            "presolve=yes",
+            "presolve_linear_eq_reduction=yes",
+            "presolve_bound_tightening=no",
+        ],
+    );
+    let bare = run("bare", &[]);
+
+    assert!(
+        (reduced.x[0] - 1.0).abs() < 1e-6 && (reduced.x[1] - 1.0).abs() < 1e-6,
+        "primal moved: {:?}",
+        reduced.x
+    );
+    assert!(
+        (reduced.duals[0] - bare.duals[0]).abs() < 1.0,
+        "row dual {} vs bare {}",
+        reduced.duals[0],
+        bare.duals[0]
+    );
+
+    // The one the reduced problem could not produce: 216 on x1's upper
+    // bound. The bare solve reports the same thing to interior-point slack.
+    let got = magnitude(&reduced.z_u, 1);
+    assert!(
+        (got - 216.0).abs() < 1.0,
+        "expected |z_u[1]| ≈ 216, got {got} (bare solve: {}); zL = {:?}, zU = {:?}",
+        magnitude(&bare.z_u, 1),
+        reduced.z_l,
+        reduced.z_u
+    );
+    assert!(
+        (got - magnitude(&bare.z_u, 1)).abs() < 1.0,
+        "diverged from the bare solve: {got} vs {}",
+        magnitude(&bare.z_u, 1)
+    );
+
+    // Complementarity: x0 sits on its lower bound and x1 on its upper, so
+    // no multiplier may appear on either slack side.
+    assert!(
+        magnitude(&reduced.z_u, 0) < 1e-4,
+        "multiplier on x0's slack upper bound: {:?}",
+        reduced.z_u
+    );
+    assert!(
+        magnitude(&reduced.z_l, 1) < 1e-4,
+        "multiplier on x1's slack lower bound: {:?}",
+        reduced.z_l
+    );
+}

--- a/crates/pounce-presolve/src/linear_eq_elim.rs
+++ b/crates/pounce-presolve/src/linear_eq_elim.rs
@@ -88,6 +88,32 @@
 //! from `∇f + Jᵀλ` alone, so the recovered row multipliers absorb the
 //! difference and full-space stationarity closes either way.
 //!
+//! # Bound multipliers the reduced solve never produced (issue #495)
+//!
+//! Re-attribution can only move a multiplier that exists, and sometimes
+//! none does. Accumulated transfers can squeeze `[x_l_red, x_u_red]` down
+//! to a single value, and a variable with equal bounds is a *fixed*
+//! variable, which the solver drops from its internal problem. It comes
+//! back with `z_l = z_u = 0` even though the full-space cluster it stands
+//! for is sitting on a bound that needs a multiplier.
+//!
+//! The sweep above cannot make that up. It closes stationarity at every
+//! column it consumed, but only because it is free to choose the row
+//! multiplier it is solving for; it has no such freedom over the bound
+//! multipliers of columns the reduced problem no longer has. So what it
+//! leaves behind at a surviving column *is* the multiplier that went
+//! unreported, and [`attribute_bound_residual`] places it on the declared
+//! bound the point is resting on — the survivor's own where that is the
+//! active one, otherwise the column the bound was borrowed from, through
+//! the same chain rule, with the sweep redone so the row multipliers
+//! account for it.
+//!
+//! Nothing is invented: a residual with no active declared bound to carry
+//! it is left alone. And a column the *original model* declares fixed is
+//! out of scope — the solver drops those as parameters whether or not
+//! Phase 6 runs, so a multiplier there would be a divergence from the
+//! no-presolve solve rather than a repair of one.
+//!
 //! # What is still non-unique
 //!
 //! When the survivor's *own* bound and a transferred bound are active at
@@ -108,7 +134,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use pounce_common::types::{Index, Number};
+use pounce_common::types::{Index, Number, lower_bound_present, upper_bound_present};
 use pounce_nlp::tnlp::{
     BoundsInfo, IndexStyle, InfeasibilityProof, IpoptCq, IpoptData, IterStats, Linearity, MetaData,
     NlpInfo, ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
@@ -177,6 +203,11 @@ struct ElimState {
     /// Reduced constraint bounds, aligned with `plan.rows_kept`.
     g_l_red: Vec<Number>,
     g_u_red: Vec<Number>,
+    /// The inner problem's **declared** variable bounds, full length. The
+    /// postsolve bound-multiplier attribution needs to know which box a
+    /// column really owns, which the reduced box no longer says.
+    x_l_full: Vec<Number>,
+    x_u_full: Vec<Number>,
     /// `col_of[i]` is where full column `i` lands: the reduced column and
     /// the scale, or `None` when the variable became a constant.
     col_of: Vec<Option<(usize, Number)>>,
@@ -448,7 +479,7 @@ impl LinearEqElimTnlp {
         }
 
         self.install(
-            info_inner, plan, g_l, g_u, jac_irow, jac_jcol, h_irow, h_jcol,
+            info_inner, plan, g_l, g_u, x_l, x_u, jac_irow, jac_jcol, h_irow, h_jcol,
         );
         self.state.as_ref()
     }
@@ -467,6 +498,8 @@ impl LinearEqElimTnlp {
             passthrough: true,
             g_l_red: Vec::new(),
             g_u_red: Vec::new(),
+            x_l_full: Vec::new(),
+            x_u_full: Vec::new(),
             col_of: Vec::new(),
             grad_gather: Gather::default(),
             jac_irow_outer: Vec::new(),
@@ -494,6 +527,8 @@ impl LinearEqElimTnlp {
         plan: EliminationPlan,
         g_l: Vec<Number>,
         g_u: Vec<Number>,
+        x_l: Vec<Number>,
+        x_u: Vec<Number>,
         jac_irow: Vec<Index>,
         jac_jcol: Vec<Index>,
         h_irow: Vec<Index>,
@@ -609,6 +644,8 @@ impl LinearEqElimTnlp {
             passthrough: false,
             g_l_red,
             g_u_red,
+            x_l_full: x_l,
+            x_u_full: x_u,
             col_of,
             grad_gather,
             jac_irow_outer,
@@ -720,6 +757,16 @@ fn attribute_bound_multiplier(
 ///
 /// Public because the convex QP presolve shares this recovery rather than
 /// restating it in `(y, z)` conventions; see `pounce_convex::aggregate`.
+///
+/// The consumed rows' multipliers are zeroed on entry and filled in on the
+/// way out, so a second call with a bound multiplier that was not there the
+/// first time re-solves from the same starting point rather than compounding
+/// the first answer.
+///
+/// The returned residual is zero at every column the sweep consumed. What
+/// survives at a *surviving* column is exactly the part of that column's
+/// bound multiplier the reduced solve did not report — see
+/// [`attribute_bound_residual`].
 pub fn recover_dropped_multipliers(
     plan: &EliminationPlan,
     grad_f: &[Number],
@@ -730,20 +777,24 @@ pub fn recover_dropped_multipliers(
     jac_values: &[Number],
     one_based: bool,
     lambda_full: &mut [Number],
-) {
-    if plan.steps.is_empty() {
-        return;
-    }
+) -> Vec<Number> {
     let n = plan.n_full;
     let m = plan.m_full;
 
-    // Row-wise view of J, so each reverse step can update the residual over
-    // just the row it resolved.
-    let mut row_entries: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m];
     let mut resid = grad_f.to_vec();
     for (j, r) in resid.iter_mut().enumerate() {
         *r += z_u_full.get(j).copied().unwrap_or(0.0) - z_l_full.get(j).copied().unwrap_or(0.0);
     }
+    if plan.steps.is_empty() {
+        return resid;
+    }
+    for step in &plan.steps {
+        lambda_full[step.row] = 0.0;
+    }
+
+    // Row-wise view of J, so each reverse step can update the residual over
+    // just the row it resolved.
+    let mut row_entries: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m];
     for k in 0..jac_irow.len() {
         let (i, j) = decode(jac_irow[k], jac_jcol[k], one_based);
         if i >= m || j >= n {
@@ -787,6 +838,139 @@ pub fn recover_dropped_multipliers(
             }
         }
     }
+    resid
+}
+
+/// How close to a declared bound the point has to sit before that bound is
+/// allowed to carry a multiplier.
+///
+/// An interior-point method stops short of its bounds by about its own
+/// convergence tolerance, and `bound_relax_factor` can leave it a little
+/// the other side, so this is looser than `tol` — but not so loose that a
+/// multiplier lands on a bound the point is not on, which is the failure
+/// mode being avoided in the first place.
+const BOUND_ACTIVE_TOL: Number = 1e-6;
+
+/// True when the model itself declares `j` fixed.
+///
+/// Such a column is dropped as a parameter by the solver whether or not
+/// Phase 6 runs, and a no-presolve solve reports no multiplier for it.
+/// Attributing one here would be a divergence from that baseline rather
+/// than a repair of one, so this pass leaves them alone.
+///
+/// The test is exact equality because that is the test that decides it:
+/// `pounce_nlp::tnlp_adapter`'s `lo == hi`. A column a hair wider than
+/// that reaches the solver, so its multiplier is one the reduction really
+/// did lose.
+fn declared_fixed(j: usize, x_l: &[Number], x_u: &[Number]) -> bool {
+    let (lo, hi) = (x_l[j], x_u[j]);
+    lower_bound_present(lo) && upper_bound_present(hi) && lo == hi
+}
+
+/// Park a leftover stationarity residual on column `j`'s own declared
+/// bound, if that is a bound the point is sitting on.
+///
+/// `∇f + Jᵀλ − z_l + z_u = 0` means a positive residual is carried by a
+/// *lower*-bound multiplier and a negative one by an *upper*-bound
+/// multiplier, and each is only admissible where its bound is active —
+/// otherwise complementarity would be traded for stationarity, which is no
+/// improvement. Returns whether the residual found a home.
+fn park_on_own_bound(
+    j: usize,
+    residual: Number,
+    x: &[Number],
+    x_l: &[Number],
+    x_u: &[Number],
+    z_l: &mut [Number],
+    z_u: &mut [Number],
+) -> bool {
+    if !residual.is_finite() || residual == 0.0 || declared_fixed(j, x_l, x_u) {
+        return false;
+    }
+    let at = |bound: Number| (x[j] - bound).abs() <= BOUND_ACTIVE_TOL * bound.abs().max(1.0);
+    if residual > 0.0 && lower_bound_present(x_l[j]) && at(x_l[j]) {
+        z_l[j] += residual;
+        return true;
+    }
+    if residual < 0.0 && upper_bound_present(x_u[j]) && at(x_u[j]) {
+        z_u[j] -= residual;
+        return true;
+    }
+    false
+}
+
+/// Give the bound multipliers the reduced solve never produced a home, and
+/// say whether the row multipliers have to be re-solved because of it
+/// (issue #495).
+///
+/// `attribute_bound_multiplier` above can only move a multiplier the solver
+/// reported. This is the case where there is none to move: accumulated
+/// transfers can leave a survivor's reduced box as a single point, and a
+/// variable with equal bounds is a *fixed* variable, which the solver drops
+/// from its internal problem and reports `z_l = z_u = 0` for.
+///
+/// After [`recover_dropped_multipliers`], `resid` is zero at every column
+/// the sweep consumed, so anything left sits on a surviving column — and,
+/// because the reduced problem's own stationarity holds at every column it
+/// still had, a non-zero residual there means the solver never enforced
+/// stationarity for that column at all. That is the identity that makes the
+/// leftover interpretable: it *is* the multiplier that went unreported.
+///
+/// It goes on the declared bound the point is resting on. When that is not
+/// the survivor's own box, it belongs to a column the survivor borrowed a
+/// bound from during planning; `x_i = coeff·x_rep + offset`, so a
+/// multiplier of `resid / coeff` there moves exactly `resid` off the
+/// survivor — the same chain rule `attribute_bound_multiplier` applies to a
+/// multiplier that does exist. Placing it changes what the consumed rows
+/// have to carry, so a `true` return asks the caller to re-sweep.
+///
+/// Only surviving columns are examined. An eliminated column with an
+/// elimination step of its own already had its residual closed by that
+/// step's row multiplier, and one without a step is a column the model
+/// declares fixed, which is out of scope here.
+fn attribute_bound_residual(
+    plan: &EliminationPlan,
+    resid: &[Number],
+    resid_tol: Number,
+    x: &[Number],
+    x_l: &[Number],
+    x_u: &[Number],
+    z_l: &mut [Number],
+    z_u: &mut [Number],
+) -> bool {
+    let mut pending: Vec<Number> = vec![0.0; plan.n_full];
+    let mut any_pending = false;
+    for j in 0..plan.n_full {
+        let r = resid[j];
+        if !r.is_finite()
+            || r.abs() <= resid_tol
+            || !matches!(plan.recovery[j], VarRecovery::Kept(_))
+        {
+            continue;
+        }
+        if park_on_own_bound(j, r, x, x_l, x_u, z_l, z_u) {
+            continue;
+        }
+        pending[j] = r;
+        any_pending = true;
+    }
+    if !any_pending {
+        return false;
+    }
+    let mut biased = false;
+    for (i, rec) in plan.recovery.iter().enumerate() {
+        let VarRecovery::Affine { rep, coeff, .. } = *rec else {
+            continue;
+        };
+        if rep >= pending.len() || pending[rep] == 0.0 || coeff == 0.0 || !coeff.is_finite() {
+            continue;
+        }
+        if park_on_own_bound(i, pending[rep] / coeff, x, x_l, x_u, z_l, z_u) {
+            pending[rep] = 0.0;
+            biased = true;
+        }
+    }
+    biased
 }
 
 // Every `.expect("inited")` below is guarded by the preceding
@@ -1121,17 +1305,43 @@ impl TNLP for LinearEqElimTnlp {
                 );
             if ok_grad && ok_jac {
                 let s = self.state.as_ref().expect("inited");
-                recover_dropped_multipliers(
+                // Below this, a residual is float noise from the sweep
+                // rather than a multiplier somebody dropped, and inventing
+                // a bound multiplier for it would only add a
+                // complementarity error where there was no stationarity
+                // error worth speaking of.
+                let resid_tol = 1e-9 * grad_f.iter().fold(1.0 as Number, |m, v| m.max(v.abs()));
+                let sweep = |z_l: &[Number], z_u: &[Number], lam: &mut [Number]| {
+                    recover_dropped_multipliers(
+                        &s.plan,
+                        &grad_f,
+                        z_l,
+                        z_u,
+                        &s.jac_irow_inner,
+                        &s.jac_jcol_inner,
+                        &jac_values,
+                        one_based,
+                        lam,
+                    )
+                };
+                let resid = sweep(&z_l_full, &z_u_full, &mut lambda_full);
+                // Whatever stationarity the row multipliers could not close
+                // is a bound multiplier the reduced solve never produced
+                // (issue #495). Handing one to an *eliminated* column
+                // changes what the consumed rows have to carry, so the
+                // sweep is redone with it in hand.
+                if attribute_bound_residual(
                     &s.plan,
-                    &grad_f,
-                    &z_l_full,
-                    &z_u_full,
-                    &s.jac_irow_inner,
-                    &s.jac_jcol_inner,
-                    &jac_values,
-                    one_based,
-                    &mut lambda_full,
-                );
+                    &resid,
+                    resid_tol,
+                    &x_full,
+                    &s.x_l_full,
+                    &s.x_u_full,
+                    &mut z_l_full,
+                    &mut z_u_full,
+                ) {
+                    sweep(&z_l_full, &z_u_full, &mut lambda_full);
+                }
             } else {
                 tracing::warn!(
                     target: "pounce::presolve",
@@ -1773,6 +1983,244 @@ mod tests {
             &mut lambda,
         );
         assert!((lambda[0] + 8.0).abs() < 1e-12, "{lambda:?}");
+    }
+
+    /// A plan that only says how each column is recovered — enough for the
+    /// residual attribution, which reads nothing else.
+    fn recovery_plan(recovery: Vec<VarRecovery>) -> EliminationPlan {
+        let n = recovery.len();
+        EliminationPlan {
+            n_full: n,
+            m_full: 0,
+            recovery,
+            vars_kept: Vec::new(),
+            rows_kept: Vec::new(),
+            row_kept: Vec::new(),
+            x_l_red: Vec::new(),
+            x_u_red: Vec::new(),
+            x_l_src: Vec::new(),
+            x_u_src: Vec::new(),
+            steps: Vec::new(),
+            parent: vec![None; n],
+            report: LinearEqElimReport::default(),
+        }
+    }
+
+    /// `x0` folded onto `x1`; the point rests on `x1`'s own upper bound, so
+    /// `x1` carries the multiplier the reduced solve never produced. This
+    /// is gh#495's minimal case, at the postsolve boundary.
+    #[test]
+    fn a_leftover_residual_lands_on_the_survivors_active_bound() {
+        let plan = recovery_plan(vec![
+            VarRecovery::Affine {
+                rep: 1,
+                coeff: 1.0,
+                offset: 0.0,
+            },
+            VarRecovery::Kept(0),
+        ]);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        let again = attribute_bound_residual(
+            &plan,
+            &[0.0, -216.0],
+            1e-6,
+            &[1.0, 1.0],
+            &[1.0, -5.0],
+            &[5.0, 1.0],
+            &mut z_l,
+            &mut z_u,
+        );
+        assert!(!again, "no hand-off was needed, so no re-sweep is either");
+        assert_eq!(z_u, vec![0.0, 216.0]);
+        assert_eq!(z_l, vec![0.0, 0.0]);
+    }
+
+    /// The survivor is sitting on its *lower* bound and the residual wants
+    /// an upper-bound multiplier, so the only column that can carry it is
+    /// the one whose box supplied the collapsing side.
+    #[test]
+    fn a_residual_the_survivor_cannot_carry_moves_to_a_cluster_member() {
+        let plan = recovery_plan(vec![
+            VarRecovery::Affine {
+                rep: 1,
+                coeff: 1.0,
+                offset: 0.0,
+            },
+            VarRecovery::Kept(0),
+        ]);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        let again = attribute_bound_residual(
+            &plan,
+            &[0.0, -2744.0],
+            1e-6,
+            &[3.0, 3.0],
+            &[1.0, 3.0],
+            &[3.0, 5.0],
+            &mut z_l,
+            &mut z_u,
+        );
+        assert!(again, "the row multipliers have to be re-solved for this");
+        assert_eq!(z_u, vec![2744.0, 0.0]);
+        assert_eq!(z_l, vec![0.0, 0.0]);
+    }
+
+    /// `x0 = −2·x1`, so the multiplier is rescaled by the substitution
+    /// coefficient on the way across — and a negative one sends it to the
+    /// other side of the origin's box, the same flip
+    /// `attribute_bound_multiplier` performs for a multiplier that exists.
+    #[test]
+    fn the_residual_hand_off_rescales_by_the_substitution_coefficient() {
+        let plan = recovery_plan(vec![
+            VarRecovery::Affine {
+                rep: 1,
+                coeff: -2.0,
+                offset: 0.0,
+            },
+            VarRecovery::Kept(0),
+        ]);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        let again = attribute_bound_residual(
+            &plan,
+            &[0.0, -4.0],
+            1e-6,
+            &[-2.0, 1.0],
+            &[-2.0, 0.0],
+            &[10.0, 5.0],
+            &mut z_l,
+            &mut z_u,
+        );
+        assert!(again);
+        // −4 / −2 = +2: a lower-bound multiplier on x0, not an upper one.
+        assert_eq!(z_l, vec![2.0, 0.0]);
+        assert_eq!(z_u, vec![0.0, 0.0]);
+    }
+
+    /// A residual with no active bound anywhere in the cluster is left
+    /// alone. Trading a stationarity error for a complementarity error is
+    /// not a repair.
+    #[test]
+    fn a_residual_with_nowhere_to_go_invents_nothing() {
+        let plan = recovery_plan(vec![
+            VarRecovery::Affine {
+                rep: 1,
+                coeff: 1.0,
+                offset: 0.0,
+            },
+            VarRecovery::Kept(0),
+        ]);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        let again = attribute_bound_residual(
+            &plan,
+            &[0.0, 5.0],
+            1e-6,
+            &[2.0, 2.0],
+            &[-10.0, -10.0],
+            &[10.0, 10.0],
+            &mut z_l,
+            &mut z_u,
+        );
+        assert!(!again);
+        assert_eq!(z_l, vec![0.0, 0.0]);
+        assert_eq!(z_u, vec![0.0, 0.0]);
+    }
+
+    /// A column the model declares fixed is dropped as a parameter with or
+    /// without this pass, so it is left reporting what a no-presolve solve
+    /// reports: nothing.
+    #[test]
+    fn a_declared_fixed_column_is_not_given_a_multiplier() {
+        let plan = recovery_plan(vec![
+            VarRecovery::Affine {
+                rep: 1,
+                coeff: 1.0,
+                offset: 0.0,
+            },
+            VarRecovery::Kept(0),
+        ]);
+        let (mut z_l, mut z_u) = (vec![0.0; 2], vec![0.0; 2]);
+        let again = attribute_bound_residual(
+            &plan,
+            &[0.0, -9.0],
+            1e-6,
+            &[4.0, 4.0],
+            &[1.0, 4.0],
+            &[7.0, 4.0],
+            &mut z_l,
+            &mut z_u,
+        );
+        assert!(!again);
+        assert_eq!(z_u, vec![0.0, 0.0]);
+    }
+
+    /// Noise below the tolerance is noise, not a multiplier.
+    #[test]
+    fn a_sub_tolerance_residual_is_left_where_it_is() {
+        let plan = recovery_plan(vec![VarRecovery::Kept(0)]);
+        let (mut z_l, mut z_u) = (vec![0.0], vec![0.0]);
+        attribute_bound_residual(
+            &plan,
+            &[-1e-12],
+            1e-9,
+            &[1.0],
+            &[-5.0],
+            &[1.0],
+            &mut z_l,
+            &mut z_u,
+        );
+        assert_eq!(z_u, vec![0.0]);
+    }
+
+    /// The sweep hands back the residual it could not close, and re-running
+    /// it with a multiplier now in hand re-solves the row rather than
+    /// compounding the first answer.
+    #[test]
+    fn the_sweep_reports_its_residual_and_can_be_re_run() {
+        // min f s.t. x0 − x1 = 0 (row 0 consumed, x0 eliminated), with
+        // ∇f = (−108, −108) — gh#495's minimal model at the optimum.
+        let plan = plan_with(
+            vec![ElimStep {
+                row: 0,
+                var: 0,
+                pivot: 1.0,
+            }],
+            vec![Some((1, 1.0)), None],
+            1,
+        );
+        let grad = [-108.0, -108.0];
+        let (irow, jcol, vals) = ([0, 0], [0, 1], [1.0, -1.0]);
+        let mut lambda = vec![0.0];
+        let resid = recover_dropped_multipliers(
+            &plan,
+            &grad,
+            &[0.0; 2],
+            &[0.0; 2],
+            &irow,
+            &jcol,
+            &vals,
+            false,
+            &mut lambda,
+        );
+        assert!((lambda[0] - 108.0).abs() < 1e-12, "{lambda:?}");
+        assert!(resid[0].abs() < 1e-12, "{resid:?}");
+        assert!((resid[1] + 216.0).abs() < 1e-12, "{resid:?}");
+
+        // Hand x1's upper bound the 216 and sweep again: λ is unchanged
+        // (nothing moved on x0's side) and the residual now closes.
+        let resid = recover_dropped_multipliers(
+            &plan,
+            &grad,
+            &[0.0; 2],
+            &[0.0, 216.0],
+            &irow,
+            &jcol,
+            &vals,
+            false,
+            &mut lambda,
+        );
+        assert!((lambda[0] - 108.0).abs() < 1e-12, "{lambda:?}");
+        for (j, r) in resid.iter().enumerate() {
+            assert!(r.abs() < 1e-12, "residual at column {j} = {r}");
+        }
     }
 
     #[test]

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -349,7 +349,7 @@ lifts the primal back to the original variable order and recovers a
 multiplier for each consumed row, so `.sol` / JSON solution blocks keep the
 original model's shape and can still be read positionally by AMPL or Pyomo.
 
-Two things to know before turning it on:
+Three things to know before turning it on:
 
 * **Dual attribution.** A transferred bound's multiplier comes back on the
   variable that *declared* the bound, not on the survivor that inherited
@@ -376,6 +376,24 @@ Two things to know before turning it on:
   zero — as it already must for any variable whose bound multiplier lands
   exactly on zero. Row multipliers are unaffected: the dual block is dense
   and comes back at the original row count.
+* **Bounds the reduced problem never saw.** Re-attribution can only move a
+  multiplier the solver reported, and sometimes there is none. The
+  transfers can leave a survivor's reduced box as a single point, and a
+  variable with equal bounds is a *fixed* variable, which the solver drops
+  — so it comes back with no bound multiplier at all even though the
+  cluster it stands for is sitting on a bound that needs one. Postsolve
+  fills that in: whatever stationarity residual the recovered row
+  multipliers cannot close is a bound multiplier that was never reported,
+  and it goes on the declared bound the point is actually resting on — the
+  survivor's own where that is the active one, otherwise the column the
+  bound was borrowed from, through the same `α` rescale as above. A
+  residual with no active declared bound to carry it is left alone rather
+  than parked somewhere that would break complementarity.
+
+  One column is deliberately outside this: one the *model* declares fixed
+  (`x_l == x_u`). The solver drops those as parameters whether or not the
+  reduction runs, and reports no multiplier for them either way, so nothing
+  here changes what they report.
 * **Failing closed.** If the equality system is contradictory, the pass
   stands down entirely and hands the model to the solver untouched, rather
   than being the first and only voice to call a model infeasible. The same


### PR DESCRIPTION
Fixes #495.

> **Rebased twice, onto #503 and then #499.** This started on the pre-#493 base. #503 landed mid-review, so the branch was rebuilt on top of it and the fix re-applied *onto* `attribute_bound_multiplier` rather than merged textually with it; #499 landed after that, and its interaction is in the comment below. The parent is `37631ec`, and every measurement here was re-taken against it.

## Problem

With `presolve_linear_eq_reduction=yes`, Phase 6 could return duals that are not a KKT multiplier set for the model as written. The primal, the objective and the row multipliers were right; a bound multiplier was simply absent, and stationarity was off by exactly its size. Anyone reading `ipopt_zL_out` / `ipopt_zU_out` — Pyomo's `model.ipopt_zL_out`, AMPL's `.rc` — saw zeros where a bound was carrying load.

The issue's minimal model, solved end to end through the CLI — `min (x0−4)⁴ + (x1−4)⁴` subject to `x0 − x1 = 0`, `x0 ∈ [1,5]`, `x1 ∈ [−5,1]`:

| | x | λ | `ipopt_zL_out` | `ipopt_zU_out` | stationarity |
|---|---|---|---|---|---|
| no presolve | (1, 1) | −108.57 | `0: 0.565` | `1: −216.57` | holds |
| before | (1, 1) | −108 | *(block empty)* | *(block empty)* | **off by 216** |
| after | (1, 1) | −108 | *(empty)* | `1: −216` | holds |

The reduced answer is exact where the bare solve carries interior-point slack; both are valid KKT points of the same problem.

On the probe filed with the issue — `adversary/runs/2026-08-06_nlp_phase6_bound_attribution.py`, which #503 brought onto `main`, 80 instances per seed:

| | seed 11 | seed 7 |
|---|---|---|
| `explained by a collapsed reduced box` (gh#495) before | 21 | 18 |
| after | **0** | **0** |
| `KKT violations (Phase 6 only)` (gh#493), before and after | 0 | 0 |
| `KKT violations (other phases, no P6)` — the probe's own scope check — before and after | 31 | 29 |

That last row is the useful one for blast radius: it does not move, so nothing outside Phase 6 changed.

## Cause

#493 fixed a multiplier being handed to the wrong column. This is the case where the solver produced none at all, so re-attribution has nothing to work with.

Phase 6 does not throw an eliminated column's box away, it *transfers* it onto the survivor. Accumulated transfers can squeeze `[x_l_red, x_u_red]` down to a single value — and a variable with equal bounds is a **fixed** variable, which `pounce_nlp::tnlp_adapter` drops from the problem as a parameter under `make_parameter`. It comes back with `z_l = z_u = 0` because the reduced problem never had it.

The dual sweep could not make that up. It closes stationarity at every column it consumed, but only because it is free to choose the row multiplier it is solving for; it has no such freedom over the bound multipliers of columns the reduced problem no longer has. In the model above the transfer collapses `x1`'s reduced box to `{1}`, and the 216 that `x1`'s upper bound should carry stayed in the residual.

## Fix

**Report the residual the sweep cannot close, and place it on the declared bound the point is resting on.**

`recover_dropped_multipliers` now returns the full-space residual, and zeroes the consumed rows' multipliers on entry so it can be re-run without compounding. That residual is zero at every column the sweep consumed, so what survives sits on a *surviving* column — and since the reduced problem's own stationarity holds at every column it still had, a non-zero residual there means the solver never enforced stationarity for that column at all. That identity is what makes the leftover interpretable rather than a heuristic: it *is* the missing multiplier.

`attribute_bound_residual` then places it, sign-aware (`∇f + Jᵀλ − z_l + z_u = 0`, so a positive residual is a lower-bound multiplier and a negative one an upper-bound multiplier):

* on the survivor's own bound where that is the active one;
* otherwise on the cluster member whose box supplied the collapsing side. `x_i = coeff·x_rep + offset`, so a multiplier of `resid / coeff` there moves exactly `resid` off the survivor — the same chain rule `attribute_bound_multiplier` applies to a multiplier that does exist, and a negative `coeff` therefore sends it to the opposite side of that column's box. Placing it changes what the consumed rows have to carry, so the sweep is redone with it in hand.

That the hand-off is a *single* column and needs exactly one re-sweep is not luck: `A` annihilates the dropped rows, so `Σ_cluster coeff_i · resid_i` is invariant under any choice of row multipliers, which fixes the size of the correction and guarantees the re-sweep lands on zero.

**It composes with #493 rather than overlapping it.** #503 already changed the sweep to start from `∇f + Jᵀλ − z_l + z_u`, which is exactly the entry point this needs — a multiplier placed here is absorbed by the same mechanism that absorbs a re-attributed one. The two are disjoint in what they can reach: one moves a reported multiplier, the other derives an unreported one. And #494 reached the same technique independently on the convex side; see the comment below.

Three things worth recording because the cheaper version was considered and rejected:

**Nothing is invented.** A residual with no active declared bound to carry it is left where it was. Parking it anyway would trade a stationarity error for a complementarity error, which is no improvement. A sub-tolerance residual (below `1e-9·‖∇f‖∞`) is float noise from the sweep and is likewise left alone, so an ordinary solve's duals do not acquire 1e-14 multipliers.

**Only surviving columns are examined.** An eliminated column with an elimination step already had its residual closed by that step's row multiplier; one without a step is a column the model declares fixed. So the first loop needs no special-casing to be safe — it structurally cannot disturb a multiplier the sweep depends on.

**A column the model declares fixed (`x_l == x_u`) is deliberately out of scope.** Those are dropped as parameters whether or not the reduction runs, and a no-presolve solve reports no multiplier for them either. Attributing one here would make Phase 6 *diverge* from the baseline rather than match it. The test is exact equality because that is the test that decides it — the adapter's `lo == hi` — so a column a hair wider reaches the solver and its multiplier is one the reduction really did lose. `a_declared_fixed_column_reports_exactly_what_the_bare_solve_reports` pins this boundary; if it should change, that belongs to `fixed_variable_treatment`, not here.

## Blast radius

Confined to `linear_eq_elim.rs` and to a code path that is off by default (`presolve_linear_eq_reduction=no`). Where nothing collapsed, the duals are unchanged: the new pass only fires on a residual the old sweep left behind, and `an_interior_reduction_reports_exactly_what_it_did_before` asserts that directly. The probe's out-of-scope counter (31 / 29) is identical before and after, and every one of #503's own unit tests passes untouched.

`recover_dropped_multipliers` gained a return value and now zeroes the consumed rows' multipliers on entry, which reaches the one external caller #499 added — `pounce_convex::aggregate::postsolve`. That caller already maintained the same invariant by hand, so it is unaffected; details in the comment below, and `cargo test -p pounce-convex` is green.

Full workspace suite (`cargo test --workspace --exclude pounce-hsl`), `cargo fmt --all -- --check`, the CI clippy gate, `check-docs-consistency.sh` and `check-release-consistency.sh` are all clean. The gh#487 probe (`2026-08-06_nlp_linear_eq_reduction_verify.py`, 80 instances) reports 0 failures.

## Tests

**Unit, in `linear_eq_elim.rs`** (7 new, alongside #503's 5): the residual lands on the survivor's active bound; a residual the survivor cannot carry moves to a cluster member; the hand-off rescales by the substitution coefficient and flips sides when it is negative; a residual with nowhere to go invents nothing; a declared-fixed column is not given a multiplier; a sub-tolerance residual is left alone; the sweep reports its residual and can be re-run without compounding.

**Through the solver stack**, `crates/pounce-algorithm/tests/presolve_phase6_missing_bound_multiplier.rs`. The fixture owns its own analytic derivatives, so the oracle is the textbook KKT system — feasibility, stationarity, dual feasibility, complementarity — not anything the solver says about itself. `pounce verify` cannot stand in: it reports *bound-projected* stationarity, which projects out exactly the component under test. Covers the issue's model, both sides of the box, a negative coefficient, a chain, the cross-cluster hand-off, and 60 randomized clusters built around a shared witness point so they are feasible by construction and a stand-down is a generator bug rather than something to skip past.

The randomized sweep asserts **all four** KKT conditions. On the pre-#503 base it had to leave complementarity out, because #493 broke it independently; with #503 in, it passes whole — which is a second, independent check that the two fixes compose.

Two of the eight assert that nothing moved — the interior reduction and the declared-fixed boundary — and both pass on the parent commit, which is the point of them.

**End to end**, `crates/pounce-cli/tests/linear_eq_collapsed_box_duals.rs`: the issue's `.nl`, through the CLI, read back out of the `ipopt_zL_out` / `ipopt_zU_out` suffix blocks. `presolve_bound_tightening=no` is not incidental — Phase 1 otherwise pins both columns from the same intersection and the model never reaches Phase 6.

Six of the eight stack tests and the CLI test fail on the parent commit with the missing multiplier.

**Six defects injected one at a time into the shipped code**, each reverted after:

| injected defect | caught by |
|---|---|
| no hand-off across the cluster | 2 unit tests, 2 stack tests |
| hand-off drops the `1/coeff` rescale | 1 unit test, the randomized sweep |
| sweep ignores the attributed multipliers | 2 unit tests (one of them #503's), 2 stack tests |
| no re-sweep after a hand-off | 2 stack tests |
| parks without checking the bound is active | 4 unit tests, 2 stack tests |
| ignores the residual tolerance | 1 unit test |

**Deliberately not pinned:** no new Python probe. #503's `2026-08-06_nlp_phase6_bound_attribution.py` already classifies this family under its own line, which is what the before/after table above measures; a second script would duplicate it.

---

- [x] Tests fail on the parent commit for the stated reason — 6 of 8 stack tests plus the CLI test, with the missing multiplier; plus the six injected defects above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms — a bullet in the #487 section, matching how #493's correction to the same unreleased feature was recorded
- [x] Book page under `docs/src/` updated (`options.md`, Phase 6's caveat list; no new page, so `SUMMARY.md` unchanged)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now — the body was rewritten after each rebase and the measurements re-taken on `1510159`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQgwy4qgX3NwNYHJJkR9iT