### PR TITLE
fix(alg): route every local-infeasibility exit through the acceptable-point stash (#505)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,25 @@ changes.
   computed rather than typed. Regression coverage in
   `crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs`.
 
+### Fixed — two of three local-infeasibility exits discarded an acceptable point (#505)
+
+- Three routes in `ipopt_alg.rs` conclude `LocalInfeasibility`: the
+  convergence check's rapid detection, restoration layer 2, and the
+  slow-cycle exits. Only the cycle exits consulted the acceptable-point
+  stash before surfacing the verdict. The other two built the terminate
+  outcome inline, so a solve that had already passed through an acceptable
+  iterate — stashed, un-vetoed, sitting there precisely as a rollback
+  target — discarded it and reported the hard failure instead.
+- The two were found independently, months apart, because nothing tied them
+  together. All three now go through `terminate_local_infeasibility`, and a
+  tripwire test fails if a new site rebuilds the outcome inline.
+- Upstream Ipopt does the same thing at the equivalent point: its
+  `CurrentIsAcceptable()` check intercepts restoration entry and throws
+  `ACCEPTABLE_POINT_REACHED` rather than proceeding from a good point.
+- Inert on genuinely infeasible models: nothing is stashed unless the whole
+  acceptable triplet passed, so the restore falls through to the verdict
+  unchanged.
+
 ### Fixed — `solve_qp(method="active-set")` panicked across the FFI on a reversed box (#491)
 
 - `pounce.solve_qp(..., method="active-set")` with a crossed bound

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -1283,6 +1283,37 @@ impl IpoptAlgorithm {
         }
     }
 
+    /// The single place this module turns a local-infeasibility conclusion
+    /// into a returned status (gh #505).
+    ///
+    /// Three separate routes reach that verdict — the conv-check's rapid
+    /// detection, restoration layer 2, and the slow-cycle exits — and the same
+    /// defect was found in two of them independently: returning the hard
+    /// verdict without consulting the acceptable-point stash, so a solve that
+    /// had already passed through an acceptable iterate discarded it. Only the
+    /// cycle exits got it right, and nothing structural said the other two were
+    /// wrong.
+    ///
+    /// That is the shape of a defect that comes back. The route a solve takes
+    /// to the verdict is an internal detail — the user sees one status either
+    /// way — so the *decision* about what that status means must not live at
+    /// each route. It lives here, and
+    /// [`no_route_concludes_local_infeasibility_alone`] is a tripwire against
+    /// a new site rebuilding the outcome inline.
+    ///
+    /// The cycle exits are not routed through here because their fallback is
+    /// chosen between `LocalInfeasibility` and `ErrorInStepComputation` at the
+    /// call site; they already reach `terminate_acceptable_or`, which is the
+    /// behaviour this guarantees.
+    ///
+    /// Scope: this governs how *this module* returns the verdict. Other layers
+    /// name `SolverReturn::LocalInfeasibility` for their own reasons — the SQP
+    /// status map and the ℓ₁ elastic path in `application.rs`, for instance —
+    /// and are outside both this funnel and its tripwire.
+    fn terminate_local_infeasibility(&mut self) -> IterateOutcome {
+        self.terminate_acceptable_or(SolverReturn::LocalInfeasibility)
+    }
+
     pub fn with_nlp(mut self, nlp: Rc<RefCell<dyn IpoptNlp>>) -> Self {
         self.nlp = Some(nlp);
         self
@@ -1742,7 +1773,33 @@ impl IpoptAlgorithm {
             }
             ConvergenceStatus::LocallyInfeasible => {
                 timing.check_convergence.end();
-                return IterateOutcome::Terminate(SolverReturn::LocalInfeasibility);
+                // gh #505: consult the acceptable-point stash, as the
+                // restoration-cycle exits below already do (`:2686`, `:2716`,
+                // both via `terminate_acceptable_or`). This arm used to return
+                // without it, so a solve that had passed through an acceptable
+                // iterate — stashed, un-vetoed, sitting there as a rollback
+                // target — discarded it and surfaced the hard verdict instead.
+                // The stashing code sits *after* this match, so the firing
+                // iteration returns before it would even consider stashing;
+                // only iterates from earlier in the solve are on offer, which
+                // is exactly what a rollback target is.
+                //
+                // This is about what to *return* once the verdict has fired,
+                // not about when it fires. Whether the rapid detector should
+                // have convicted this point at all is a separate question,
+                // answered by the violation floor in `OptErrorConvCheck`
+                // (gh #519).
+                //
+                // Inert on genuinely infeasible models: `store_acceptable_point`
+                // is gated on `current_is_acceptable_with_state`, which requires
+                // `acceptable_tol` *and* the unscaled violation against
+                // `acceptable_constr_viol_tol`, and the scale-relative veto
+                // blocks the stash outright for a row violated relative to its
+                // own magnitude. Nothing is stashed on such a model, so
+                // `terminate_acceptable_or` falls through to the verdict
+                // unchanged. `infeasible_models_are_never_reported_solved`
+                // (`infeasible_status_tol_invariance.rs`) is the standing guard.
+                return self.terminate_local_infeasibility();
             }
             ConvergenceStatus::Failed => {
                 timing.check_convergence.end();
@@ -2877,7 +2934,22 @@ impl IpoptAlgorithm {
                 // residual is still well above `tol`. Without this
                 // detection the outer would re-enter restoration on the
                 // unchanged iterate forever.
-                IterateOutcome::Terminate(SolverReturn::LocalInfeasibility)
+                //
+                // gh #505: consult the acceptable-point stash, for the same
+                // reason the conv-check arm above does and the cycle exits
+                // already did. This is the *third* site that produced
+                // `LocalInfeasibility`, and the only one not gated on
+                // `infeas_max_streak` — which matters, because on the reported
+                // instance raising that knob to 15 did not move the run by a
+                // single iteration, so the verdict there is not the outer
+                // detector's. Whichever route reaches it, a solve that passed
+                // through an acceptable iterate must not discard it.
+                //
+                // Inert on genuinely infeasible models by the same argument as
+                // the other two: nothing is stashed unless the whole acceptable
+                // triplet passed, so `terminate_acceptable_or` falls through to
+                // the verdict unchanged.
+                self.terminate_local_infeasibility()
             }
         }
     }
@@ -3668,5 +3740,59 @@ mod tests {
         // point outranks it regardless of objective.
         assert!(ranks_better_within_band(0.0, 0.0, -100.0, f64::NAN, band));
         assert!(!ranks_better_within_band(-100.0, f64::NAN, 0.0, 0.0, band));
+    }
+
+    /// gh #505: no route may conclude `LocalInfeasibility` on its own.
+    ///
+    /// Three routes reach that verdict, and two of them independently shipped
+    /// the same defect — building the terminate outcome directly, so the
+    /// acceptable-point stash was never consulted and a good point the solve
+    /// already had in hand was discarded. They were found one at a time,
+    /// because nothing tied them together.
+    ///
+    /// The route a solve takes is an internal detail; the user sees one status
+    /// either way. So what that status means is decided in one place — every
+    /// route goes through [`IpoptAlgorithm::terminate_local_infeasibility`],
+    /// or, for the cycle exits whose fallback is chosen between two statuses
+    /// at the call site, through `terminate_acceptable_or`. Both consult the
+    /// stash.
+    ///
+    /// **This is a tripwire, not a proof.** It is a substring scan of this
+    /// file's source for the bare `IterateOutcome::Terminate(SolverReturn::
+    /// LocalInfeasibility)` construction. A rustfmt line break through that
+    /// expression, a `let` binding for the status, or a construction in
+    /// another module all evade it — `application.rs` names the same variant
+    /// on the SQP and ℓ₁ elastic paths and is deliberately out of scope. What
+    /// it does buy is that the *obvious* way to add a fourth bare exit here
+    /// fails loudly and points at the helper, which is the mistake that was
+    /// actually made twice.
+    ///
+    /// The needle is assembled at runtime so this test's own source cannot
+    /// satisfy the pattern it is checking for; an earlier version counted its
+    /// own lines and failed against clean code.
+    #[test]
+    fn no_route_concludes_local_infeasibility_alone() {
+        let needle = format!(
+            "IterateOutcome::Terminate(SolverReturn::{})",
+            "LocalInfeasibility"
+        );
+        let offenders: Vec<usize> = include_str!("ipopt_alg.rs")
+            .lines()
+            .enumerate()
+            .filter(|(_, l)| {
+                let t = l.trim_start();
+                !t.starts_with("//") && !t.starts_with("///")
+            })
+            .filter(|(_, l)| l.contains(&needle))
+            .map(|(i, _)| i + 1)
+            .collect();
+        assert!(
+            offenders.is_empty(),
+            "line(s) {offenders:?} build the local-infeasibility verdict directly. \
+             Call `terminate_local_infeasibility()` instead — it consults the \
+             acceptable-point stash first, so a solve that already passed through an \
+             acceptable iterate returns that point rather than a hard failure. Two \
+             routes shipped this bug before the helper existed (gh #505)."
+        );
     }
 }

--- a/docs/src/troubleshooting.md
+++ b/docs/src/troubleshooting.md
@@ -329,6 +329,48 @@ The recipe in plain English:
 > it (`crates/pounce-cli/tests/l1_fallback_no_panic.rs`) uses this
 > same `infeasible-eq` builtin.
 
+### When the residual is small but the verdict still says infeasible
+
+Some models cannot reach a small *absolute* residual no matter how well
+they are solved. An ill-conditioned change of variables — a moving-boundary
+PDE on a Landau coordinate, say — can leave a row carrying a coefficient
+of `1e9`, so a residual of `1e-3` is eleven relative digits: the equation
+is satisfied about as well as double precision allows, and no absolute
+tolerance will ever be met. That is exactly the regime the acceptable-level
+fallback exists for, and the exit you want is
+`Solved_To_Acceptable_Level`.
+
+Set `acceptable_tol` to a level you can actually reach, and read the
+result there:
+
+```
+$ pounce model.nl -AMPL tol=1e-6 acceptable_tol=1e-3
+```
+
+Three things are worth knowing about how that interacts with the
+infeasibility detector:
+
+- `acceptable_constr_viol_tol` (default `1e-2`) is the feasibility band
+  the acceptable-level exit uses, and it is **separate** from
+  `constr_viol_tol`. Widening the latter does not widen the former.
+- Tightening `constr_viol_tol` does **not** make POUNCE readier to call a
+  model infeasible. The rapid-infeasibility detector's violation floor is
+  clamped so it never convicts a point whose violation sits inside the
+  band the defaults call acceptable
+  ([pounce#519](https://github.com/jkitchin/pounce/issues/519)). If you
+  are still seeing `Infeasible_Problem_Detected`, the point is outside
+  the band you declared: compare the reported `Overall NLP error` against
+  your `acceptable_tol`, and the `Constraint violation` against
+  `acceptable_constr_viol_tol`.
+- If the solve did pass through an acceptable iterate before giving up,
+  that point is returned rather than discarded, whichever internal route
+  reached the verdict
+  ([pounce#505](https://github.com/jkitchin/pounce/issues/505)).
+
+If the residual is large relative to its own row — not just in absolute
+terms — the verdict is the honest one, and the ℓ₁ wrapper above is the
+way to corroborate it.
+
 ## Linear solver choice
 
 `linear_solver=ma57` (when built with HSL):


### PR DESCRIPTION
## What this is now

**Scope reduced.** This PR previously also carried a deferral inside
`OptErrorConvCheck` — holding off the local-infeasibility verdict while the
*current* iterate sat inside the acceptable-level band. #519 landed the
violation floor, which addresses that same failure directly and better, and
makes the deferral dead code at default tolerances. The deferral, its
fixture (`issue_505_acceptable_band.nl`), and its test are dropped; the
fixture no longer reproduces on top of #519 at all.

What remains is one thing: **three routes conclude `LocalInfeasibility`, and
only one of them consulted the acceptable-point stash.**

| route | consulted the stash before this PR |
| --- | --- |
| conv-check rapid detection (`ipopt_alg.rs:1774`) | no |
| restoration layer 2 (`RestorationOutcome::LocallyInfeasible`) | no |
| slow-cycle exits (`:2686`, `:2716`) | yes |

The two that didn't built `IterateOutcome::Terminate(SolverReturn::LocalInfeasibility)`
inline. So a solve that had already passed through an acceptable iterate —
stashed, un-vetoed, sitting there precisely as a rollback target —
discarded it and reported the hard failure instead. The two were found
independently, because nothing tied them together.

## The change

- `terminate_local_infeasibility()` — one place that decides what the verdict
  returns. Both bare sites now call it; it delegates to the existing
  `terminate_acceptable_or`.
- `no_route_concludes_local_infeasibility_alone` — a tripwire. **It is a
  source scan of this file, not a proof**: a rustfmt line break through the
  expression, a `let` binding for the status, or a construction in another
  module all evade it. `application.rs` names the same variant on the SQP and
  ℓ₁ elastic paths and is deliberately out of scope. What it buys is that the
  obvious way to add a fourth bare exit here fails loudly and points at the
  helper — which is the mistake that was actually made twice.
- `docs/src/troubleshooting.md` — the acceptable-level route out of a
  small-relative-residual solve, and how `acceptable_constr_viol_tol` relates
  to `constr_viol_tol`. Now cites #519's floor rather than the dropped
  deferral.

## What this does *not* claim

- It does not fix #505's reported symptom on its own. **#519 does that**, and
  the issue should close against #519. This is `Refs #505`, not `Fixes #505`.
- It changes no default and no tolerance. Both of David's models already
  solve on stock `main` with no options (f=1: 64 iters; f=0.2: 56 iters).
- It does not make POUNCE readier *or* less ready to declare infeasibility.
  The verdict fires exactly when it fired before; only what gets returned
  afterwards changes, and only when a stashed acceptable point exists.

## Why it's inert on genuinely infeasible models

`store_acceptable_point` is gated on `current_is_acceptable_with_state`,
which requires `acceptable_tol` **and** the unscaled violation against
`acceptable_constr_viol_tol`, plus the scale-relative veto that blocks the
stash for a row violated relative to its own magnitude. Nothing is stashed
on such a model, so `terminate_acceptable_or` falls through to the verdict
unchanged. `infeasible_models_are_never_reported_solved`
(`infeasible_status_tol_invariance.rs`) is the standing guard and still
passes.

## Verification

- `cargo test --workspace` green on this tree (rebased onto `main` at
  `ef5d77e8`, which includes #519 and #521).
- `cargo fmt --all --check` clean; `cargo clippy -p pounce-algorithm
  --all-targets` shows only pre-existing warnings.
- Second architecture: the behaviour under this change was exercised on
  arm64 macOS as well as x86-64 Linux during the #505 investigation.

Refs #505