### PR TITLE
fix(convex/presolve): a bound multiplier must survive its bound's scale

### DIFF
--- a/crates/pounce-convex/src/aggregate.rs
+++ b/crates/pounce-convex/src/aggregate.rs
@@ -80,7 +80,7 @@ use pounce_presolve::linear_eq_plan::{
     EliminationPlan, PlanConfig, PlanInput, VarRecovery, build_plan,
 };
 
-use crate::presolve::{ACTIVE_BOUND_TOL, group_by_row, merge_sort_coeffs};
+use crate::presolve::{at_bound, group_by_row, merge_sort_coeffs};
 use crate::qp::{BOUND_INF, QpProblem, QpSolution, Triplet};
 
 /// A survivor's leftover reduced cost below this is noise, not a bound
@@ -368,8 +368,8 @@ fn on_bounds(orig: &QpProblem, x: &[f64], j: usize) -> (bool, bool) {
     let lb = orig.lb_of(j);
     let ub = orig.ub_of(j);
     (
-        lb > -BOUND_INF && (x[j] - lb).abs() <= ACTIVE_BOUND_TOL,
-        ub < BOUND_INF && (ub - x[j]).abs() <= ACTIVE_BOUND_TOL,
+        lb > -BOUND_INF && at_bound(x[j], lb),
+        ub < BOUND_INF && at_bound(x[j], ub),
     )
 }
 

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -310,7 +310,32 @@ const EMPTY_ROW_TOL: f64 = 1e-9;
 /// recovering bound multipliers. Looser than [`BOUND_FEAS_TOL`] because an
 /// interior-point solve only drives a variable to within ~1e-8 of a bound,
 /// not to machine zero; interior variables sit far further away.
+///
+/// Applied **relative to the bound's magnitude** — see [`at_bound`]. The
+/// "~1e-8" above is a relative statement, and reading it as an absolute
+/// window silently loses the multiplier of any bound bigger than about `1e4`.
 pub(crate) const ACTIVE_BOUND_TOL: f64 = 1e-6;
+
+/// Is `x` sitting *on* the bound `b`?
+///
+/// The window scales with the bound: an interior-point solve stops a relative
+/// ~1e-8 short of a bound, which is an absolute `5e-3` when the bound is
+/// `5e5`. Judged against a fixed `1e-6` such a variable reads as interior, and
+/// every rule keyed on this — the global bound-multiplier recovery below, and
+/// the tightened-bound re-attribution that reads its output — concludes the
+/// bound is slack and reports its multiplier as **zero**. That is a wrong dual
+/// on an ordinary model, not an edge case: `min x² − 4u·x` boxed at `x ≤ u`
+/// lost its bound multiplier for every `u ≳ 1e4` while still reporting
+/// `Optimal`, and it reaches `.sol` as `ipopt_zL_out`/`ipopt_zU_out` and as
+/// the dual of any constraint row that became a bound.
+///
+/// Widening is safe: a genuinely interior variable sits far outside even the
+/// scaled window, and both callers additionally require the reduced cost to
+/// have the sign that bound could produce, so a misread would have to carry a
+/// correctly-signed nonzero gradient to do any harm.
+pub(crate) fn at_bound(x: f64, b: f64) -> bool {
+    (x - b).abs() <= ACTIVE_BOUND_TOL * (1.0 + b.abs())
+}
 
 /// Group nonzero entries by row index: `out[row] = [(col, val), …]`.
 pub(crate) fn group_by_row(triplets: &[Triplet], m: usize) -> Vec<Vec<(usize, f64)>> {
@@ -2021,8 +2046,8 @@ impl Presolve {
         for i in 0..n {
             let lb = self.orig.lb_of(i);
             let ub = self.orig.ub_of(i);
-            let at_lb = lb > -BOUND_INF && (x[i] - lb).abs() <= ACTIVE_BOUND_TOL;
-            let at_ub = ub < BOUND_INF && (ub - x[i]).abs() <= ACTIVE_BOUND_TOL;
+            let at_lb = lb > -BOUND_INF && at_bound(x[i], lb);
+            let at_ub = ub < BOUND_INF && at_bound(x[i], ub);
             if at_lb && grad[i] > 0.0 {
                 z_lb[i] = grad[i];
             } else if at_ub && grad[i] < 0.0 {

--- a/crates/pounce-convex/tests/presolve_bound_multiplier_scale.rs
+++ b/crates/pounce-convex/tests/presolve_bound_multiplier_scale.rs
@@ -1,0 +1,136 @@
+//! Bound multipliers must survive the *scale* of the bound they sit on.
+//!
+//! Postsolve decides whether a variable is on a box bound by comparing `x` to
+//! it. An interior-point solve stops a **relative** ~1e-8 short of a bound, so
+//! at `x ≤ 5e5` it lands ~5e-3 away — and an absolute `1e-6` window reads that
+//! as interior. Everything keyed on that verdict then concludes the bound is
+//! slack and reports its multiplier as **zero**, while the status stays
+//! `Optimal`: a silently wrong dual on a completely ordinary model.
+//!
+//! It reaches users two ways. `ipopt_zL_out` / `ipopt_zU_out` in the `.sol`
+//! are these multipliers directly. And since the `.nl` extractor hands the
+//! solver a native box, a constraint row that is really a bound is folded into
+//! that box by presolve and gets its dual back *through* them — so the row's
+//! own `.sol` multiplier vanishes too.
+//!
+//! Both cases are pinned here across four decades of bound magnitude, against
+//! the no-presolve solve as the reference.
+
+use pounce_convex::presolve::solve_with_presolve;
+use pounce_convex::{QpOptions, QpProblem, QpSolution, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn direct(prob: &QpProblem) -> QpSolution {
+    solve_qp_ipm(prob, &QpOptions::default(), backend)
+}
+
+fn with_presolve(prob: &QpProblem) -> QpSolution {
+    solve_with_presolve(prob, |r| solve_qp_ipm(r, &QpOptions::default(), backend))
+}
+
+/// Bound magnitudes spanning the range where an absolute window fails: the
+/// first two pass either way, the rest only with a scaled one.
+const SCALES: [f64; 5] = [3.0, 1.0e3, 1.0e4, 5.0e5, 1.0e7];
+
+/// `min x² − 4u·x` over the **box** `0 ≤ x ≤ u` pins `x` at `u`, where the
+/// upper bound carries multiplier `4u − 2u = 2u`. Presolve has nothing to
+/// reduce here — this is the plain boxed-QP path every `.nl` model takes — so
+/// its postsolve must hand back exactly what the direct solve reports.
+#[test]
+fn a_native_box_keeps_its_bound_multiplier_at_every_scale() {
+    for u in SCALES {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![Triplet::new(0, 0, 2.0)],
+            c: vec![-4.0 * u],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![0.0],
+            ub: vec![u],
+        };
+        let d = direct(&prob);
+        let p = with_presolve(&prob);
+        assert_eq!(p.status, QpStatus::Optimal, "u={u}");
+        assert!((p.x[0] - u).abs() <= 1e-6 * u, "u={u}: x={}", p.x[0]);
+        assert!(
+            (p.z_ub[0] - 2.0 * u).abs() <= 1e-6 * u,
+            "u={u}: presolve lost the bound multiplier: {} (expected {}, \
+             direct solve reports {})",
+            p.z_ub[0],
+            2.0 * u,
+            d.z_ub[0]
+        );
+        // Stationarity in the original problem: 2x − 4u + z_ub − z_lb = 0.
+        let stat = 2.0 * p.x[0] - 4.0 * u + p.z_ub[0] - p.z_lb[0];
+        assert!(stat.abs() <= 1e-6 * u, "u={u}: stationarity {stat}");
+    }
+}
+
+/// The same bound written as a **row** — the shape a constraint that is really
+/// a bound arrives in. Presolve reads it as a bound and folds it into the box,
+/// so the row's multiplier comes back out of the box duals; if those are lost
+/// to the scale, so is the row's `.sol` dual.
+#[test]
+fn a_bound_written_as_a_row_keeps_its_multiplier_at_every_scale() {
+    for u in SCALES {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![Triplet::new(0, 0, 2.0)],
+            c: vec![-4.0 * u],
+            a: vec![],
+            b: vec![],
+            g: vec![Triplet::new(0, 0, 1.0)],
+            h: vec![u],
+            lb: vec![],
+            ub: vec![],
+        };
+        let d = direct(&prob);
+        let p = with_presolve(&prob);
+        assert_eq!(p.status, QpStatus::Optimal, "u={u}");
+        assert!((p.x[0] - u).abs() <= 1e-6 * u, "u={u}: x={}", p.x[0]);
+        assert!(
+            (p.z[0] - 2.0 * u).abs() <= 1e-6 * u,
+            "u={u}: the active row lost its multiplier: {} (expected {}, \
+             direct solve reports {})",
+            p.z[0],
+            2.0 * u,
+            d.z[0]
+        );
+        // The problem declares no box, so the whole force must be on the row.
+        let stat = 2.0 * p.x[0] - 4.0 * u + p.z[0];
+        assert!(stat.abs() <= 1e-6 * u, "u={u}: stationarity {stat}");
+    }
+}
+
+/// A scaled bound must not *invent* a multiplier either: the widened window is
+/// still far tighter than the distance an interior variable sits from its
+/// bounds, and the reduced cost at an interior optimum is zero regardless.
+#[test]
+fn an_interior_optimum_reports_no_bound_multiplier_at_any_scale() {
+    for u in SCALES {
+        // min (x − u/2)² over 0 ≤ x ≤ u: the optimum is strictly interior.
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![Triplet::new(0, 0, 2.0)],
+            c: vec![-u],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![0.0],
+            ub: vec![u],
+        };
+        let p = with_presolve(&prob);
+        assert_eq!(p.status, QpStatus::Optimal, "u={u}");
+        assert!((p.x[0] - u / 2.0).abs() <= 1e-6 * u, "u={u}: x={}", p.x[0]);
+        assert!(p.z_lb[0].abs() <= 1e-9 * u, "u={u}: z_lb={}", p.z_lb[0]);
+        assert!(p.z_ub[0].abs() <= 1e-9 * u, "u={u}: z_ub={}", p.z_ub[0]);
+    }
+}

--- a/crates/pounce-convex/tests/presolve_bound_rows.rs
+++ b/crates/pounce-convex/tests/presolve_bound_rows.rs
@@ -1,0 +1,326 @@
+//! Column-shaped reductions must still fire when the box arrived as *rows*.
+//!
+//! Presolve keys its column-shaped reductions — activity redundancy, forcing
+//! rows, dominated columns, bound tightening — on `QpProblem::lb`/`ub`. A
+//! caller that hands its bounds over as single-variable `G` rows instead
+//! leaves that box empty, so those reductions would read `±∞` for every
+//! variable and reach nothing (gh #500). Presolve now folds such a row back
+//! into the box and drops it, so both entry paths reach the same reductions.
+//!
+//! The rest of the suite builds its boxes natively, which is the *other* side
+//! of that seam — see the comment at `presolve_reductions.rs`'s activity-bound
+//! section, "need the variable box". These tests come at it from the row side:
+//! each one lowers a native box into `G` rows via `lower_box_to_rows` and
+//! asserts the reduction still fires, the primal still matches, and the dual
+//! is KKT-valid *for the row-form problem* — which is what would break if the
+//! fold were ever reordered to run after the reductions that depend on it.
+
+use pounce_convex::presolve::{PresolveOutcome, presolve, solve_with_presolve};
+use pounce_convex::{QpOptions, QpProblem, QpSolution, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn direct(prob: &QpProblem) -> QpSolution {
+    solve_qp_ipm(prob, &QpOptions::default(), backend)
+}
+
+fn with_presolve(prob: &QpProblem) -> QpSolution {
+    solve_with_presolve(prob, |r| solve_qp_ipm(r, &QpOptions::default(), backend))
+}
+
+/// Lower every finite box bound into a `G` row (`x ≤ ub`, `−x ≤ −lb`),
+/// leaving the box empty — the shape a caller produces when it treats bounds
+/// as ordinary constraints.
+fn lower_box_to_rows(p: &QpProblem) -> QpProblem {
+    let (mut g, mut h) = (p.g.clone(), p.h.clone());
+    for i in 0..p.n {
+        if p.ub_of(i).is_finite() {
+            g.push(Triplet::new(h.len(), i, 1.0));
+            h.push(p.ub_of(i));
+        }
+        if p.lb_of(i).is_finite() {
+            g.push(Triplet::new(h.len(), i, -1.0));
+            h.push(-p.lb_of(i));
+        }
+    }
+    QpProblem {
+        n: p.n,
+        p_lower: p.p_lower.clone(),
+        c: p.c.clone(),
+        a: p.a.clone(),
+        b: p.b.clone(),
+        g,
+        h,
+        lb: Vec::new(),
+        ub: Vec::new(),
+    }
+}
+
+fn reduced(prob: &QpProblem) -> pounce_convex::presolve::Presolve {
+    match presolve(prob) {
+        PresolveOutcome::Reduced(ps) => ps,
+        PresolveOutcome::Infeasible => panic!("expected Reduced, got Infeasible"),
+        PresolveOutcome::Unbounded => panic!("expected Reduced, got Unbounded"),
+    }
+}
+
+/// KKT validity of `sol` for `prob`, to tolerance `tol` — including the
+/// inequality multipliers' sign and complementarity, which is where a folded
+/// bound row's dual has to land.
+fn assert_kkt(prob: &QpProblem, sol: &QpSolution, tol: f64) {
+    let n = prob.n;
+    let mut g = prob.c.clone();
+    prob.p_mul(&sol.x, &mut g);
+    prob.at_mul(&sol.y, &mut g);
+    prob.gt_mul(&sol.z, &mut g);
+    for i in 0..n {
+        let stat = g[i] + sol.z_ub[i] - sol.z_lb[i];
+        assert!(stat.abs() < tol, "stationarity[{i}] = {stat}");
+        assert!(
+            sol.x[i] >= prob.lb_of(i) - tol && sol.x[i] <= prob.ub_of(i) + tol,
+            "box [{i}]: {}",
+            sol.x[i]
+        );
+    }
+    let mut gx = vec![0.0; prob.m_ineq()];
+    prob.g_mul(&sol.x, &mut gx);
+    for i in 0..prob.m_ineq() {
+        let slack = prob.h[i] - gx[i];
+        assert!(slack > -tol, "Gx≤h row {i}: slack {slack}");
+        assert!(sol.z[i] > -tol, "z[{i}] = {} < 0", sol.z[i]);
+        assert!(
+            (sol.z[i] * slack).abs() < 1e-4,
+            "complementarity row {i}: z={} slack={slack}",
+            sol.z[i]
+        );
+    }
+    let mut ax = vec![0.0; prob.m_eq()];
+    prob.a_mul(&sol.x, &mut ax);
+    for (i, (&axi, &bi)) in ax.iter().zip(&prob.b).enumerate() {
+        assert!((axi - bi).abs() < tol, "Ax=b row {i}: {axi} vs {bi}");
+    }
+}
+
+// --- the two entry paths reach the same reductions ---
+
+/// `x0` is absent from `P` and `A`, appears in one `≤` row with `+1`, and has
+/// `c0 > 0` — a dominated column, optimal at its lower bound. With the bounds
+/// as rows the sign test also sees the `−1` of the `−x0 ≤ 0` bound row, so
+/// the reduction cannot fire even in principle until that row is folded away.
+#[test]
+fn dominated_column_fires_with_bounds_as_rows() {
+    // min x0 − 2·x1 + x1²  s.t.  x0 + x1 ≤ 5,  x0, x1 ∈ [0, 3].
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(1, 1, 2.0)],
+        c: vec![1.0, -2.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        h: vec![5.0],
+        lb: vec![0.0, 0.0],
+        ub: vec![3.0, 3.0],
+    };
+    let rows = lower_box_to_rows(&prob);
+    assert_eq!(reduced(&prob).stats().dominated_cols, 1);
+    assert_eq!(reduced(&rows).stats().dominated_cols, 1, "gh #500");
+    // Same model, so the same solution — through either entry path.
+    let a = with_presolve(&prob);
+    let b = with_presolve(&rows);
+    assert_eq!(b.status, QpStatus::Optimal);
+    for i in 0..prob.n {
+        assert!(
+            (a.x[i] - b.x[i]).abs() < 1e-5,
+            "x[{i}]: {} vs {}",
+            a.x[i],
+            b.x[i]
+        );
+    }
+    assert_kkt(&rows, &b, 1e-5);
+}
+
+/// A row whose activity range touches its right-hand side pins every variable
+/// in it to a bound. That range is `(−∞, +∞)` without a box, so the reduction
+/// is guarded off until the bound rows fold in.
+#[test]
+fn forcing_row_fires_with_bounds_as_rows() {
+    // min x0+x1+x2 s.t. x0+x1 ≤ 0, x2 ≤ 5, x ∈ [0,1]³.
+    // min-activity of row 0 is 0 = h ⇒ forcing: x0 = x1 = 0.
+    let prob = QpProblem {
+        n: 3,
+        p_lower: vec![],
+        c: vec![1.0, 1.0, 1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 2, 1.0),
+        ],
+        h: vec![0.0, 5.0],
+        lb: vec![0.0, 0.0, 0.0],
+        ub: vec![1.0, 1.0, 1.0],
+    };
+    let rows = lower_box_to_rows(&prob);
+    assert_eq!(reduced(&prob).stats().forcing_rows, 1);
+    assert_eq!(reduced(&rows).stats().forcing_rows, 1, "gh #500");
+    let sol = with_presolve(&rows);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    for (i, v) in sol.x.iter().enumerate() {
+        assert!(v.abs() < 1e-5, "x[{i}] = {v}, all pinned to 0");
+    }
+    assert_kkt(&rows, &sol, 1e-5);
+}
+
+/// A row the box already implies is redundant should be dropped. Without a
+/// box its activity range is unbounded and nothing fires.
+#[test]
+fn activity_redundant_row_dropped_with_bounds_as_rows() {
+    // min x0²+x1²−x0−x1 s.t. x0+x1 ≤ 100, x ∈ [0,3]² — the row cannot bind.
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+        c: vec![-1.0, -1.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        h: vec![100.0],
+        lb: vec![0.0, 0.0],
+        ub: vec![3.0, 3.0],
+    };
+    let rows = lower_box_to_rows(&prob);
+    assert_eq!(reduced(&prob).reduced.m_ineq(), 0);
+    assert_eq!(reduced(&rows).reduced.m_ineq(), 0, "gh #500");
+    let sol = with_presolve(&rows);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!(
+        sol.z.iter().all(|z| z.abs() < 1e-6),
+        "no row binds: {:?}",
+        sol.z
+    );
+    assert_kkt(&rows, &sol, 1e-5);
+}
+
+// --- randomized KKT roundtrips over row-form models ---
+
+/// Tiny deterministic LCG, so the sweep is reproducible.
+struct Rng(u64);
+impl Rng {
+    fn next_u64(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+    fn unif(&mut self, lo: f64, hi: f64) -> f64 {
+        let u = (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64;
+        lo + (hi - lo) * u
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next_u64() % n as u64) as usize
+    }
+}
+
+/// Many random boxed QPs, each solved twice — once with its native box and
+/// once with the box lowered to `G` rows. The row-form solve must reach the
+/// same primal and produce a KKT-valid dual *of the row-form problem*, with
+/// every bound's multiplier on its row. This is the only randomized presolve
+/// roundtrip in the suite; the hand-built cases above pin named reductions,
+/// this one covers the combinations nobody thought to write down.
+#[test]
+fn randomized_row_form_roundtrip() {
+    let mut rng = Rng(0x5006_0500);
+    let mut solved = 0;
+    for case in 0..200 {
+        let n = 2 + rng.below(3); // 2..4 variables
+        let m = 1 + rng.below(3); // 1..3 general rows
+        // A convex diagonal Hessian keeps the optimum unique (so the two
+        // solves' primals must agree), with some purely linear columns so the
+        // dominated-column reduction has something to bite on.
+        let mut p_lower: Vec<Triplet> = Vec::new();
+        for i in 0..n {
+            if rng.unif(0.0, 1.0) < 0.7 {
+                p_lower.push(Triplet::new(i, i, rng.unif(0.5, 3.0)));
+            }
+        }
+        let c: Vec<f64> = (0..n).map(|_| rng.unif(-4.0, 4.0)).collect();
+        let mut g = Vec::new();
+        let mut h = Vec::new();
+        for row in 0..m {
+            for col in 0..n {
+                if rng.unif(0.0, 1.0) < 0.6 {
+                    g.push(Triplet::new(row, col, rng.unif(-2.0, 2.0)));
+                }
+            }
+            h.push(rng.unif(-1.0, 6.0));
+        }
+        // Sometimes an equality row, and sometimes a *singleton* one — which
+        // fixes a variable and can leave a general row with a single live
+        // column, i.e. a bound row born mid-presolve.
+        let mut a = Vec::new();
+        let mut b = Vec::new();
+        let lb: Vec<f64> = (0..n).map(|_| rng.unif(-3.0, 0.0)).collect();
+        let ub: Vec<f64> = (0..n).map(|i| lb[i] + rng.unif(0.5, 5.0)).collect();
+        if rng.unif(0.0, 1.0) < 0.5 {
+            let col = rng.below(n);
+            if rng.unif(0.0, 1.0) < 0.5 {
+                // x_col = v, inside its box so the draw stays feasible.
+                a.push(Triplet::new(0, col, 1.0));
+                b.push(rng.unif(lb[col], ub[col]));
+            } else {
+                let other = (col + 1) % n;
+                a.push(Triplet::new(0, col, 1.0));
+                a.push(Triplet::new(0, other, rng.unif(-2.0, 2.0)));
+                b.push(rng.unif(-1.0, 1.0));
+            }
+        }
+        let boxed = QpProblem {
+            n,
+            p_lower,
+            c,
+            a,
+            b,
+            g,
+            h,
+            lb,
+            ub,
+        };
+        let rows = lower_box_to_rows(&boxed);
+
+        let d = direct(&rows);
+        if d.status != QpStatus::Optimal {
+            continue; // infeasible / unbounded draw — not this test's subject
+        }
+        solved += 1;
+        let sol = with_presolve(&rows);
+        assert_eq!(sol.status, QpStatus::Optimal, "case {case}");
+        assert_kkt(&rows, &sol, 1e-4);
+        for i in 0..n {
+            assert!(
+                (sol.x[i] - d.x[i]).abs() < 1e-4,
+                "case {case} x[{i}]: {} vs direct {}",
+                sol.x[i],
+                d.x[i]
+            );
+        }
+        // The reductions the box unlocks must not change the objective.
+        assert!(
+            (sol.obj - d.obj).abs() < 1e-4,
+            "case {case} obj: {} vs {}",
+            sol.obj,
+            d.obj
+        );
+    }
+    // The draw is random but seeded: 174 of the 200 land Optimal today. Assert
+    // a floor so a future change to the generator (or to what counts as
+    // feasible) cannot quietly turn this sweep into a no-op.
+    assert!(
+        solved > 150,
+        "only {solved}/200 draws exercised the roundtrip"
+    );
+}


### PR DESCRIPTION
Closes #500.

## What happened to this PR

This branch originally carried my own fix for #500 (fold single-variable `G`
rows into the box; emit the box from the extractor). While it was open, #491,
#494 and #504 landed on `main` and **already fix #500** — by the same two
moves, with presolve reaching a singleton row through the existing
bound-tightening reduction rather than a new one.

So the original work is superseded and has been dropped rather than merged in
alongside. The branch is now rebased onto `main` and carries two things: a
real wrong-dual bug that `main`'s implementation still has, and the part of
the #500 coverage that `main` has no equivalent for.

I verified the supersession rather than assumed it — 9 of my 10 #500 tests
pass unmodified against `main`. The tenth is the bug below.

**Note on #500 itself:** it is still open. `main` fixed it, but no PR body
carried a closing keyword, so it never auto-closed — the exact failure mode
`CLAUDE.md` records for #342/#339. This PR closes it, and the three tests
below are the issue's own three measured cases, now asserted to fire.

## The bug

Postsolve decides whether a variable sits on a box bound by comparing `x` to
it against an absolute `ACTIVE_BOUND_TOL` of `1e-6`. An interior-point solve
stops a *relative* ~1e-8 short of a bound — the constant's own doc says so —
which is an absolute `5e-3` when the bound is `5e5`. Past a bound magnitude of
roughly `1e4`, every active bound reads as interior, and each rule keyed on
that verdict concludes the bound is slack and reports its multiplier as
**zero** — status still `Optimal`.

```
min x² − 4u·x   s.t.   0 ≤ x ≤ u
```

| `u` | expected `z_ub` | no presolve | with presolve |
|---|---|---|---|
| 3 | 6 | 6 | 6 |
| 1e3 | 2e3 | 2e3 | 2e3 |
| 1e4 | 2e4 | 2e4 | **0** |
| 5e5 | 1e6 | 1e6 | **0** |

The returned point violates stationarity by the whole multiplier.

Two user-visible surfaces carry it:

- `ipopt_zL_out` / `ipopt_zU_out` in the `.sol` **are** these multipliers.
- Since #491 hands the solver a native box, a constraint row that is really a
  bound is folded into that box by presolve and gets its dual back *through*
  those same values — so such a row's `.sol` multiplier vanishes too. That is
  how this surfaced: it is the one #500 test that fails on `main`.

## The fix

The window now scales with the bound, through a shared `at_bound` helper used
by both the global bound-multiplier recovery and `aggregate`'s `on_bounds`.

`aggregate.rs` has the identical pattern; I could not construct a failing case
for it, and fixed it for consistency since the reasoning is the same — worth a
reviewer's eye, as it is the one change here without a demonstrated failure.

Widening is safe: a genuinely interior variable sits far outside even the
scaled window, and both callers additionally require the reduced cost to have
the sign that bound could produce, so a misread would have to carry a
correctly-signed nonzero gradient to do any harm.

## The added coverage

`main`'s presolve suite builds its boxes **natively** — its own comment at the
activity-bound section of `presolve_reductions.rs` says these reductions "need
the variable box". The fold that turns a singleton `G` row back into a box is
the other way in, and nothing tested it from that side.

`presolve_bound_rows.rs` comes at it from the row side. Each test lowers a
native box into `G` rows, then asserts the reduction still fires, the primal
matches the box-form solve, and the dual is KKT-valid *for the row-form
problem*:

| test | #500's measured case |
|---|---|
| `dominated_column_fires_with_bounds_as_rows` | dominated column — "nothing fires" |
| `forcing_row_fires_with_bounds_as_rows` | forcing constraint — "only the #494 aggregation" |
| `activity_redundant_row_dropped_with_bounds_as_rows` | activity-redundant row — "nothing fires" |
| `randomized_row_form_roundtrip` | — |

Being straight about what these are worth: **all four pass on `main` today**.
They are regression guards, not bug-catchers. They would fail if the fold were
reordered to run after the reductions that depend on it — a change the
native-box tests cannot see. The randomized roundtrip is the suite's only
randomized presolve check (seeded LCG, 200 draws, 174 land `Optimal`); it
asserts a floor on that count so a future change to the generator cannot
quietly turn the sweep into a no-op.

The other five of the nine I dropped as genuinely redundant — `main`'s
`contradictory_singleton_rows_are_seen_as_an_empty_box`,
`consistent_bound_rows_still_bind_after_becoming_a_box` and
`singleton_inequality_tightens_and_reattributes` already cover them.

## Verification

- `presolve_bound_multiplier_scale.rs` pins both surfaces — a native box and a
  bound written as a row — across five decades of bound magnitude against the
  no-presolve solve, plus an interior-optimum case guarding the widening. The
  two failing tests fail at `u = 1e4` before this change and pass after.
- All 46 CLI `.nl` fixtures produce **byte-identical** `.sol` output, so
  nothing that was already right moves.
- Full workspace suite green (2620 tests; `pounce-hsl` excluded, it cannot
  link without CoinHSL in this environment), plus the 4 new tests.
- CI's exact clippy gate (`-D clippy::correctness -D clippy::suspicious`) and
  `cargo fmt --check` both clean.