### PR TITLE
fix(status): ask "is this violation real" with constr_viol_tol, not tol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — infeasible models reported `internalSolverError` because the infeasibility threshold was built from `tol` (#508)
+
+- On a model with no solution, POUNCE chooses between *converged to a point
+  of local infeasibility* (AMPL 200 — "your model has no solution") and
+  *error in step computation* / *restoration failed* (AMPL 500, Pyomo
+  `internalSolverError` — "your solver broke"). That choice was made against
+  a threshold built from `tol`, a tolerance on the **KKT error**, and never
+  consulted `constr_viol_tol`, the option that declares what a violated
+  constraint is. Different quantity, different units.
+- Two measured consequences, on `min (x−5)² s.t. x²+δ = 0` — infeasible for
+  every `δ > 0`, with the reported violation exactly `δ`, so the threshold is
+  visible to the digit. Sweeping `constr_viol_tol` across four orders of
+  magnitude moved the boundary **not at all**: at `constr_viol_tol=1e-3` a
+  violation of `1e-4`, comfortably inside the user's own declared feasibility
+  tolerance, still came back 500. And sweeping `tol` moved it a great deal,
+  in the wrong direction — the failure band tracked `max(100·tol, 1e-4)`, so
+  at `tol=1e-4` every gap from `3e-4` to `1e-2` answered "internal error",
+  including a model infeasible by a full percent. Loosening `tol` is the
+  standard reaction to a struggling solve, so the failure widened exactly
+  when the user tried to help.
+- Every one of these sites now tests the constraint violation against
+  `constr_viol_tol`, and at the boundary with `>=` rather than `>` — a
+  violation *at* the tolerance the user declared too large is a violation.
+  Six thresholds changed: the restoration-cycle exit in `ipopt_alg`, which is
+  the only locally-infeasible safety net square problems have, and the five
+  locally-infeasible gates in `resto_inner_solver` that shared the same
+  `100·tol` floor. The invariant now holds across the whole sweep: a
+  violation at or above the user's declared feasibility tolerance lands in
+  the AMPL infeasible range at every `tol`, and `constr_viol_tol` is what
+  moves it.
+- Where the remaining violation is *below* `constr_viol_tol`, POUNCE still
+  declines to certify infeasibility — the iterate is primal-feasible by the
+  user's own declaration, and claiming otherwise is the false-infeasibility
+  failure from the opposite direction.
+- Also fixed alongside: after a non-promoted MC64 hypersensitivity re-solve,
+  the terminal's last `EXIT:` banner was the retry's while the `.sol`, the
+  summary and the JSON report all carried the kept first-solve verdict. Two
+  banners is expected and announced; the two disagreeing is not, and
+  `validation/p3_control.py` reads the log exactly that way. The CLI now
+  re-emits the verdict that actually shipped as the final banner.
+- Reported by the adversary agent. Regression coverage in
+  `crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs`.
+
 ### Fixed — false primal-infeasible certificate on redundant equality rows that disagree by one ULP (#496)
 
 - The convex presolve fixes a variable from a singleton equality row and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,12 @@ changes.
   `validation/p3_control.py` reads the log exactly that way. The CLI now
   re-emits the verdict that actually shipped as the final banner.
 - Reported by the adversary agent. Regression coverage in
-  `crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs`.
+  `crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs`. The banner
+  ordering is covered by an invariant guard rather than a bite-on-parent pin:
+  every non-promoted MC64 retry reachable from the fixture corpus happens to
+  return the same verdict the `.sol` keeps, so the two banners agree there by
+  luck; the mismatch is still a reachable state of the code. Noted in the test
+  so the gap is a known one.
 
 ### Fixed — false primal-infeasible certificate on redundant equality rows that disagree by one ULP (#496)
 

--- a/crates/pounce-algorithm/src/conv_check/opt_error.rs
+++ b/crates/pounce-algorithm/src/conv_check/opt_error.rs
@@ -658,6 +658,10 @@ impl ConvCheck for OptErrorConvCheck {
         self.tol
     }
 
+    fn constr_viol_tol_or_default(&self) -> Number {
+        self.constr_viol_tol
+    }
+
     fn acceptable_constr_viol_tol_or_default(&self) -> Number {
         self.acceptable_constr_viol_tol
     }
@@ -1106,6 +1110,27 @@ mod tests {
         // Gradient flat but violation below threshold → nearly
         // feasible, does not count.
         assert!(!c.is_infeasible_stationary(1e-3, 0.0, 1e-9));
+    }
+
+    /// gh #508: the status-decision sites that ask "is this violation real"
+    /// read `constr_viol_tol` off the policy, so a user setting has to reach
+    /// them — the defect was a threshold built from `tol` that no
+    /// `constr_viol_tol` value could move. `set_tolerance` is the debugger's
+    /// live hot-swap path and must be visible through the accessor too.
+    #[test]
+    fn constr_viol_tol_accessor_tracks_the_option() {
+        let mut c = OptErrorConvCheck {
+            tol: 1e-6,
+            constr_viol_tol: 1e-3,
+            ..Default::default()
+        };
+        assert_eq!(c.constr_viol_tol_or_default(), 1e-3);
+        // Independent of `tol` — retuning convergence must not retune what
+        // counts as a violated constraint.
+        c.tol = 1e-10;
+        assert_eq!(c.constr_viol_tol_or_default(), 1e-3);
+        assert!(c.set_tolerance("constr_viol_tol", 1e-7));
+        assert_eq!(c.constr_viol_tol_or_default(), 1e-7);
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/conv_check/trait.rs
+++ b/crates/pounce-algorithm/src/conv_check/trait.rs
@@ -143,6 +143,22 @@ pub trait ConvCheck {
         1e-8
     }
 
+    /// Primal-feasibility tolerance `constr_viol_tol`, in the unscaled max-norm
+    /// space `curr_unscaled_primal_infeasibility_max` reports — the option that
+    /// declares what a *violated* constraint is.
+    ///
+    /// Read by the status-decision sites that have to answer "is this violation
+    /// real" (gh #508). That question is about the constraint violation, so it
+    /// must be asked with the constraint-violation tolerance; asking it with
+    /// `tol` — a tolerance on the **KKT error**, a different quantity in
+    /// different units — makes the answer move when the user retunes
+    /// convergence and stand still when they retune feasibility. Default `1e-4`
+    /// matches upstream's default `constr_viol_tol`; policies that track no such
+    /// tolerance keep it.
+    fn constr_viol_tol_or_default(&self) -> Number {
+        1e-4
+    }
+
     /// Acceptable-level primal-feasibility band `acceptable_constr_viol_tol`, in
     /// the unscaled max-norm space `curr_unscaled_primal_infeasibility_max`
     /// reports. Read by the best-acceptable fallback's feasibility-aware ranking

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -2488,12 +2488,49 @@ impl IpoptAlgorithm {
             .as_ref()
             .expect("curr set before invoke_restoration")
             .clone();
-        // Helper: when the cycle detector fires and the orig cv is
-        // bounded away from outer tol (e.g. PFIT1's 2.73e-2), the
-        // outer is stuck at a feasibility-stationary point and the
-        // honest exit is `LocalInfeasibility`. Below that threshold
-        // the failure is numerical, not algorithmic, so retain
-        // `ErrorInStepComputation`.
+        // Helper: when the cycle detector fires and the orig cv is a
+        // violation the *user* calls a violation (e.g. PFIT1's 2.73e-2),
+        // the outer is stuck at a feasibility-stationary point and the
+        // honest exit is `LocalInfeasibility`. Below that threshold the
+        // iterate is primal-feasible by the user's own declaration, so there
+        // is no infeasibility to certify — the failure is numerical, not
+        // algorithmic, and `ErrorInStepComputation` is retained.
+        //
+        // The threshold is `constr_viol_tol`, and *only* `constr_viol_tol`
+        // (gh #508). The question this ternary asks — "is this violation
+        // real?" — is a question about the constraint violation, so it has to
+        // be asked with the option that declares what a violated constraint
+        // is. The previous form, `max(100·tol, 1e-4)`, was built from `tol`, a
+        // tolerance on the **KKT error**: different quantity, different units,
+        // and it never consulted `constr_viol_tol` at all. Two consequences,
+        // both measured on `min (x-5)² s.t. x²+δ = 0` (infeasible for every
+        // δ>0, reported violation exactly δ):
+        //
+        //   * sweeping `constr_viol_tol` over four orders moved the boundary
+        //     not at all — at `constr_viol_tol = 1e-3` a violation of `1e-4`,
+        //     comfortably inside the user's declared feasibility tolerance,
+        //     still exited 500;
+        //   * sweeping `tol` moved it a great deal, and in the wrong
+        //     direction: at `tol = 1e-4` the `1e-2` threshold swallowed every
+        //     δ from `3e-4` to `1e-2` — a model infeasible by a full percent
+        //     answered "your solver broke". Loosening `tol` is the standard
+        //     user reaction to a struggling solve, so the failure widened
+        //     exactly when the user tried to help.
+        //
+        // No `infeas_viol_kappa` margin on top, unlike the rapid-infeasibility
+        // pre-filter in `conv_check`. That detector fires *during* the solve
+        // off a streak heuristic and needs the margin to avoid convicting an
+        // iterate that is still converging; here restoration has already
+        // demonstrably cycled, so the certainty comes from the cycle evidence
+        // rather than from extra violation headroom. Widening to
+        // `kappa·constr_viol_tol` would move the default threshold from `1e-4`
+        // to `1e-2` and hand back 500 on the whole band in between.
+        //
+        // The comparison is `>=`, not `>`. A violation landing exactly on the
+        // threshold is a violation at the user's declared tolerance, and the
+        // reproducer above hits the boundary to the digit (`δ = 1e-4` at the
+        // default `constr_viol_tol`), where `>` returned 500 for a model
+        // infeasible by precisely the amount the user said was too much.
         //
         // The violation is measured **unscaled**. `reference_theta` is the
         // row-scaled residual, but the floor below is an absolute, user-facing
@@ -2512,13 +2549,20 @@ impl IpoptAlgorithm {
         // max-norm. Max-norm <= 1-norm, so the test is marginally stricter
         // about declaring infeasibility on an unscaled problem — the safe
         // direction for a verdict this consequential.
-        let outer_tol_for_cycle = self.bundle.conv_check.tol_or_default();
+        //
+        // `theta > 0` in front of the `>=` is not redundant: the options layer
+        // registers `constr_viol_tol` with a *strict* lower bound of zero, but
+        // a library embedder setting `ConvCheckOptions` directly is not bound
+        // by that, and `0 >= 0` would turn an exactly-feasible iterate into an
+        // infeasibility certificate. A zero violation never proves anything.
+        let cycle_viol_tol = self.bundle.conv_check.constr_viol_tol_or_default();
         let reference_theta_unscaled = self.cq.borrow().curr_unscaled_primal_infeasibility_max();
-        let cycle_exit = if reference_theta_unscaled > (100.0 * outer_tol_for_cycle).max(1e-4) {
-            SolverReturn::LocalInfeasibility
-        } else {
-            SolverReturn::ErrorInStepComputation
-        };
+        let cycle_exit =
+            if reference_theta_unscaled > 0.0 && reference_theta_unscaled >= cycle_viol_tol {
+                SolverReturn::LocalInfeasibility
+            } else {
+                SolverReturn::ErrorInStepComputation
+            };
         let static_cycle = if let (Some(prev_x), Some(prev_s)) = (
             self.last_resto_entry_x.as_ref(),
             self.last_resto_entry_s.as_ref(),

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -1444,6 +1444,39 @@ pub fn main() -> ExitCode {
         // statistics. See `resolve_scaling_retry_outcome` (code review L23).
         (status, solve_stats) =
             resolve_scaling_retry_outcome(retry_status, solve_stats, retry_stats);
+        // …and keep the *console* in lockstep with them too (gh #508). Both
+        // solves print their own end-of-run summary, which is expected and
+        // announced — but when the retry is not promoted the last banner on the
+        // terminal is the retry's, while the `.sol`, the summary and the JSON
+        // report all carry the original verdict. Two banners disagreeing about
+        // one solve misleads a human reading the tail of the log and a machine
+        // reading it the same way: `validation/p3_control.py` keeps the last
+        // `EXIT:` line it sees and pairs it with the `.sol`, so it recorded a
+        // status the `.sol` never held. Measured on `min (x-5)² s.t. x²+δ = 0`
+        // at `tol=1e-4`: the console ended `Error in step computation.`
+        // (δ=1e-9) and `Maximum Number of Iterations Exceeded.` (δ=1e-1) over a
+        // `.sol` that said locally infeasible in both. Re-emitting the verdict
+        // that actually shipped makes the terminal's final word the true one.
+        //
+        // Gated on `print_level >= 1` to match `Application::emit_end_summary`,
+        // which is what printed the two banners this one arbitrates; at
+        // `print_level 0` there are none to disagree.
+        if !scaling_retry_promoted(retry_status)
+            && app
+                .options()
+                .get_integer_value("print_level", "")
+                .map(|(v, _found)| v >= 1)
+                .unwrap_or(true)
+        {
+            println!();
+            println!("EXIT: {}", print::status_message(status));
+            println!();
+            println!(
+                "POUNCE {}: {}",
+                env!("CARGO_PKG_VERSION"),
+                print::status_message(status)
+            );
+        }
     }
 
     // `solve_stats` was snapshotted right after the solve loop and updated

--- a/crates/pounce-cli/tests/fixtures/issue_508_infeasible_gap_1em2.nl
+++ b/crates/pounce-cli/tests/fixtures/issue_508_infeasible_gap_1em2.nl
@@ -1,0 +1,31 @@
+g3 1 1 0	# gh508: min (x-5)^2 s.t. x^2 = -1e-2  (infeasible; violation is exactly 1e-2 at x=0)
+ 1 1 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 1 1 1 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o5
+v0
+n2
+O0 0
+o5
+o0
+v0
+n-5
+n2
+x1
+0 1.0
+r
+4 -0.01
+b
+3
+k0
+J0 1
+0 0
+G0 1
+0 0

--- a/crates/pounce-cli/tests/fixtures/issue_508_infeasible_gap_1em4.nl
+++ b/crates/pounce-cli/tests/fixtures/issue_508_infeasible_gap_1em4.nl
@@ -1,0 +1,31 @@
+g3 1 1 0	# gh508: min (x-5)^2 s.t. x^2 = -1e-4  (infeasible; violation is exactly 1e-4 at x=0)
+ 1 1 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 1 1 0 0 0 0	# nonlinear constrs, objs; ccons: lin, nonlin, nd, nzlb
+ 0 0	# network constraints: nonlinear, linear
+ 1 1 1 	# nonlinear vars in constraints, objectives, both
+ 0 0 0 1	# linear network variables; functions; arith, flags
+ 0 0 0 0 0 	# discrete variables: binary, integer, nonlinear (b,c,o)
+ 1 1 	# nonzeros in Jacobian, obj. gradient
+ 0 0	# max name lengths: constraints, variables
+ 0 0 0 0 0	# common exprs: b,c,o,c1,o1
+C0
+o5
+v0
+n2
+O0 0
+o5
+o0
+v0
+n-5
+n2
+x1
+0 1.0
+r
+4 -0.0001
+b
+3
+k0
+J0 1
+0 0
+G0 1
+0 0

--- a/crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs
+++ b/crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs
@@ -225,6 +225,23 @@ fn the_gap_models_are_never_reported_solved() {
 /// expected and announced; the two disagreeing is not, and
 /// `validation/p3_control.py` reads exactly this way (last `EXIT:` line, paired
 /// with the `.sol`).
+///
+/// **Known gap, stated deliberately: this is an invariant guard, not a
+/// bite-on-parent regression pin.** It asserts the right thing and it does
+/// exercise the non-promoted retry path (the first assertion fails loudly if a
+/// future change stops it doing so), but it passes on the pre-fix commit,
+/// because every non-promoted retry reachable from this repo's fixture corpus
+/// happens to return `InfeasibleProblemDetected` — the same verdict the `.sol`
+/// keeps, so the two banners agree by luck rather than by construction. The
+/// reporter observed the mismatch on their own `.nl` at `tol=1e-4`
+/// (`Error in step computation.` at δ=1e-9, `Maximum Number of Iterations
+/// Exceeded.` at δ=1e-1, both over a `.sol` that said locally infeasible); a
+/// sweep over `tol`, `max_iter` and every `.nl` under `tests/fixtures/` did not
+/// reproduce a divergent retry status here. The fix does not depend on
+/// reproducing one — the retry's status is not constrained to match the kept
+/// verdict, and `scaling_retry_promoted` is false for most statuses, so the
+/// mismatch is a reachable state of the code whether or not a fixture reaches
+/// it. Vendoring a model that does would upgrade this to a real pin.
 #[test]
 fn the_last_exit_banner_matches_the_sol_after_a_non_promoted_mc64_retry() {
     let sol = std::env::temp_dir().join("pounce_issue_508_banner.sol");

--- a/crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs
+++ b/crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs
@@ -1,0 +1,272 @@
+//! gh #508 — the "is this violation real?" question must be asked with
+//! `constr_viol_tol`, not with `tol`.
+//!
+//! When restoration cycles without progress on an infeasible model, `ipopt_alg`
+//! chooses between `LocalInfeasibility` (AMPL 200 — "your model has no
+//! solution") and `ErrorInStepComputation` (AMPL 500, Pyomo
+//! `internalSolverError` — "your solver broke"). That choice was made against
+//! `max(100·tol, 1e-4)`. `tol` is a tolerance on the **KKT error**; the
+//! quantity being tested is a constraint violation. Different quantity,
+//! different units, and `constr_viol_tol` — the option that declares what a
+//! violated constraint *is* — never entered into it.
+//!
+//! The probe model makes the threshold measurable to the digit:
+//!
+//! ```text
+//!   min (x - 5)^2   s.t.   x^2 + delta == 0
+//! ```
+//!
+//! Infeasible for every `delta > 0`. `½‖c‖²` has a strict local minimum at
+//! `x = 0` where the violation is exactly `delta` and `Jᵀc = 2x(x²+δ) = 0`, so
+//! restoration converges there, no local move reduces the violation, and the
+//! honest verdict at every `delta` is "converged to a point of local
+//! infeasibility". Two measured symptoms, both reproduced by the fixtures here:
+//!
+//! 1. sweeping `constr_viol_tol` over four orders moved the boundary *not at
+//!    all* — at `constr_viol_tol=1e-3` a violation of `1e-4`, comfortably
+//!    inside the user's own feasibility tolerance, still exited 500;
+//! 2. sweeping `tol` moved it a great deal and in the wrong direction: at
+//!    `tol=1e-4` the threshold widened to `1e-2` and swallowed every gap from
+//!    `3e-4` up — including a model infeasible by a full percent. Loosening
+//!    `tol` is the standard user reaction to a struggling solve, so the failure
+//!    band widened exactly when the user tried to help.
+//!
+//! The fix reads `constr_viol_tol` and compares with `>=`, so the invariant the
+//! tests below pin is the one that matters rather than any particular constant:
+//! **a violation at or above the user's declared feasibility tolerance lands in
+//! the AMPL infeasible range, at every `tol`.**
+//!
+//! Sibling coverage: `infeasible_status_tol_invariance.rs` pins the same
+//! `tol`-independence for gh #372/#446's fixtures, which reach the verdict
+//! through the restoration-side gates rather than through this cycle exit.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn solve_result_num(text: &str) -> i32 {
+    for line in text.lines() {
+        if let Some(rest) = line.trim().strip_prefix("objno ") {
+            if let Some(code) = rest.split_whitespace().nth(1) {
+                return code.parse().expect("objno code parses");
+            }
+        }
+    }
+    panic!("no `objno` line in .sol:\n{text}");
+}
+
+/// Run the model and return the `.sol` text. `extra` carries the option
+/// assignments under test.
+fn solve(model: &str, tag: &str, extra: &[String]) -> String {
+    let sol = std::env::temp_dir().join(format!("pounce_issue_508_{tag}.sol"));
+    let _ = std::fs::remove_file(&sol);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture(model))
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("print_level=0")
+        // No acceptable point exists anywhere on this model's trajectory, so
+        // the acceptable-level exit cannot mask which of the two failure
+        // statuses the decision site picks.
+        .arg("acceptable_tol=1e-12")
+        .args(extra)
+        .output()
+        .expect("spawn pounce");
+
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+    std::fs::read_to_string(&sol).expect("read .sol")
+}
+
+/// `tol` spanning four orders either side of the default. `1e-4` and `1e-5` are
+/// the values that widened the old `max(100·tol, 1e-4)` threshold to `1e-2` and
+/// `1e-3`.
+const TOLS: &[(&str, &str)] = &[
+    ("t3", "1e-3"),
+    ("t4", "1e-4"),
+    ("t5", "1e-5"),
+    ("t6", "1e-6"),
+    ("t7", "1e-7"),
+    ("t8", "1e-8"),
+    ("t10", "1e-10"),
+];
+
+/// A model infeasible by `1e-2` — two orders above the default
+/// `constr_viol_tol` — must land in the AMPL infeasible range whatever the user
+/// sets `tol` to. At `tol=1e-4` and `tol=1e-5` this returned 500.
+#[test]
+fn a_percent_wide_infeasibility_gap_is_tol_invariant() {
+    for (tag, tol) in TOLS {
+        let text = solve(
+            "issue_508_infeasible_gap_1em2.nl",
+            &format!("gap2_{tag}"),
+            &[format!("tol={tol}")],
+        );
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "tol={tol}: expected the AMPL infeasible range (200..299), got \
+             solve_result_num={srn}. This model is infeasible by 1e-2 — a full \
+             percent — and 500 surfaces through Pyomo as internalSolverError, \
+             indistinguishable from a solver bug:\n{text}"
+        );
+    }
+}
+
+/// The boundary cell. The reported violation is exactly `1e-4`, exactly the
+/// default `constr_viol_tol`; the old `>` comparison took the failure branch on
+/// it. A violation *at* the user's declared tolerance is a violation.
+#[test]
+fn a_violation_exactly_at_constr_viol_tol_is_infeasible_not_an_internal_error() {
+    for (tag, tol) in TOLS {
+        let text = solve(
+            "issue_508_infeasible_gap_1em4.nl",
+            &format!("gap4_{tag}"),
+            &[format!("tol={tol}"), "constr_viol_tol=1e-4".into()],
+        );
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "tol={tol}, constr_viol_tol=1e-4: the reported violation is exactly \
+             1e-4, so it is at the tolerance the user declared to be too much; \
+             expected the AMPL infeasible range (200..299), got \
+             solve_result_num={srn}:\n{text}"
+        );
+    }
+}
+
+/// `constr_viol_tol` is the knob that decides this, so moving it must move the
+/// verdict. Previously all four settings gave a bit-identical column.
+#[test]
+fn constr_viol_tol_moves_the_boundary() {
+    // Tightened well below the 1e-4 gap: the violation is a violation, and the
+    // model is infeasible.
+    for (tag, cvt) in [
+        ("c8", "1e-8"),
+        ("c6", "1e-6"),
+        ("c5", "1e-5"),
+        ("c4", "1e-4"),
+    ] {
+        let text = solve(
+            "issue_508_infeasible_gap_1em4.nl",
+            &format!("cvt_{tag}"),
+            &["tol=1e-6".into(), format!("constr_viol_tol={cvt}")],
+        );
+        let srn = solve_result_num(&text);
+        assert!(
+            (200..300).contains(&srn),
+            "constr_viol_tol={cvt}: a 1e-4 violation is at or above the declared \
+             feasibility tolerance, so the verdict must be infeasible \
+             (200..299); got solve_result_num={srn}:\n{text}"
+        );
+    }
+}
+
+/// The other half of that claim: with `constr_viol_tol` widened *past* the gap,
+/// the solver has no evidence of infeasibility to report — the iterate is
+/// primal-feasible by the user's own declaration — so it must not claim any.
+/// Pins the direction of the branch, not just its sensitivity.
+#[test]
+fn a_gap_inside_constr_viol_tol_is_not_claimed_infeasible() {
+    let text = solve(
+        "issue_508_infeasible_gap_1em4.nl",
+        "cvt_wide",
+        &["tol=1e-6".into(), "constr_viol_tol=1e-3".into()],
+    );
+    let srn = solve_result_num(&text);
+    assert!(
+        !(200..300).contains(&srn),
+        "constr_viol_tol=1e-3: a 1e-4 violation is inside the tolerance the user \
+         declared feasible, so POUNCE has no infeasibility to certify and must \
+         not report one; got solve_result_num={srn}:\n{text}"
+    );
+}
+
+/// Neither fixture may ever be advertised as solved — that is what makes Pyomo
+/// load the returned point as `optimal`. Separate assertion so a future change
+/// that trades one wrong verdict for a worse one is caught explicitly.
+#[test]
+fn the_gap_models_are_never_reported_solved() {
+    for model in [
+        "issue_508_infeasible_gap_1em4.nl",
+        "issue_508_infeasible_gap_1em2.nl",
+    ] {
+        for (tag, tol) in TOLS {
+            let stem = model.trim_end_matches(".nl");
+            let text = solve(model, &format!("ns_{stem}_{tag}"), &[format!("tol={tol}")]);
+            let srn = solve_result_num(&text);
+            assert!(
+                !(0..200).contains(&srn),
+                "{model} at tol={tol} reported in the AMPL solved family \
+                 (solve_result_num={srn}); 0..99 = solved and 100..199 = \
+                 solved-with-warning both make Pyomo report \
+                 TerminationCondition.optimal:\n{text}"
+            );
+        }
+    }
+}
+
+/// Secondary defect from the same report: when the MC64 hypersensitivity
+/// re-solve runs and is *not* promoted, the `.sol` keeps the first solve's
+/// verdict while the terminal's last `EXIT:` banner was the retry's — so the
+/// console and the modelling layer disagreed about one solve. Two banners is
+/// expected and announced; the two disagreeing is not, and
+/// `validation/p3_control.py` reads exactly this way (last `EXIT:` line, paired
+/// with the `.sol`).
+#[test]
+fn the_last_exit_banner_matches_the_sol_after_a_non_promoted_mc64_retry() {
+    let sol = std::env::temp_dir().join("pounce_issue_508_banner.sol");
+    let _ = std::fs::remove_file(&sol);
+
+    let out = Command::new(pounce_exe())
+        .arg(fixture("issue_508_infeasible_gap_1em2.nl"))
+        .arg("-AMPL")
+        .arg("--sol-output")
+        .arg(&sol)
+        .arg("tol=1e-8")
+        .arg("acceptable_tol=1e-12")
+        .output()
+        .expect("spawn pounce");
+    assert_eq!(out.status.code(), Some(0), "-AMPL must exit 0");
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert!(
+        stderr.contains("MC64 re-solve did not recover"),
+        "fixture no longer exercises the non-promoted retry path, so this test \
+         proves nothing — pick a model/tol that still does:\nstderr:\n{stderr}"
+    );
+
+    let text = std::fs::read_to_string(&sol).expect("read .sol");
+    let srn = solve_result_num(&text);
+    assert!(
+        (200..300).contains(&srn),
+        "expected the kept local-infeasibility verdict, got \
+         solve_result_num={srn}:\n{text}"
+    );
+
+    let last_exit = stdout
+        .lines()
+        .filter(|l| l.starts_with("EXIT:"))
+        .next_back()
+        .expect("at least one EXIT: banner on stdout");
+    assert!(
+        last_exit.contains("local infeasibility"),
+        "the terminal's final word must be the verdict that shipped in the \
+         `.sol` (solve_result_num={srn}); last EXIT: banner was {last_exit:?}. \
+         A consumer that keeps the last EXIT: line — p3_control.py does — pairs \
+         it with a `.sol` that never held it:\nstdout:\n{stdout}"
+    );
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -344,6 +344,23 @@ pub fn run_inner_resto(
     // sub-solve instead of hardcoded `(1e-8, 1e-6, 15)`. See
     // `build_resto_conv_check_adapter`.
     let outer_tol = outer_data.borrow().tol;
+    // The user's `constr_viol_tol`, carried on the same inner conv-check
+    // options (upstream reads it with the *original* prefix). It is the
+    // violation floor for all five locally-infeasible gates below, scaled by
+    // the violated row's own magnitude (`is_significant` — see
+    // `pounce_common::tolerance` for why the rejecting direction must be
+    // purely relative).
+    //
+    // That floor used to be `100·outer_tol`: a KKT-error tolerance standing in
+    // for a constraint-violation one (gh #508). Sweeping `constr_viol_tol`
+    // could not move any of these verdicts, and loosening `tol` — the standard
+    // reaction to a struggling solve — raised the floor a hundredfold and
+    // withdrew the diagnosis. On `min (x-5)² s.t. x²+δ = 0` at `tol=1e-3` that
+    // turned a model infeasible by a full percent into `Restoration_Failed`
+    // (AMPL 500, Pyomo `internalSolverError`) while the same model at the
+    // default `tol` was correctly diagnosed. Same defect, and the same repair,
+    // as the outer cycle exit in `ipopt_alg`.
+    let outer_constr_viol_tol = inner_alg_builder.conv_check.constr_viol_tol;
     let mut adapter = build_resto_conv_check_adapter(&inner_alg_builder.conv_check)
         .with_orig_progress_guard(Rc::clone(outer_nlp), orig_curr_inf_pr, kappa_resto)
         // Layer 2 of `IpRestoConvCheck::CheckConvergence` (pounce#438).
@@ -587,16 +604,17 @@ pub fn run_inner_resto(
     // `resto_no_outer_progress_count` cycle detector (5 consecutive
     // null-progress entries) bounds the worst case if the outer truly
     // can't escape; the cycle exit now surfaces `LocalInfeasibility`
-    // when the outer cv at re-entry is bounded above `max(100*tol, 1e-4)`
-    // and `ErrorInStepComputation` otherwise.
+    // when the outer cv at re-entry is at or above `constr_viol_tol`
+    // (gh #508 — "is this violation real" is a question about the
+    // constraint violation, so it is asked with the constraint-violation
+    // tolerance, not with `tol`) and `ErrorInStepComputation` otherwise.
     let strict_locally_infeasible = !is_square_problem
         && matches!(
             status,
             SolverReturn::Success | SolverReturn::StopAtAcceptablePoint
         )
         && inner_stationarity_converged
-        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol);
-
+        && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol);
     // Alt locally-infeasible gate. PFIT2/PFIT3-style: the inner
     // resto NLP is at (or near) a stationary point — `inner_kkt_err`
     // has dropped to a small value — but the inner's own line search
@@ -615,10 +633,10 @@ pub fn run_inner_resto(
     //     of similar magnitude after compl/scaling), tight enough to
     //     reject genuinely-stuck inners that haven't approached
     //     stationarity at all.
-    //   * `orig_inf_pr_at_final > max(100*outer_tol, 1e-3)` — the
-    //     orig-NLP `inf_pr` floor is non-trivial (i.e. NOT just a
-    //     little above outer tol — distinguish from the kappa-guard
-    //     near-feasible exit).
+    //   * the shared `constr_viol_tol` violation floor — the orig-NLP
+    //     `inf_pr` is a violation the user calls a violation (i.e. NOT just a
+    //     little above zero — distinguish from the kappa-guard near-feasible
+    //     exit).
     //   * `inner_iter_count >= 30` — not a premature failure on the
     //     first few inner iters.
     //
@@ -635,7 +653,7 @@ pub fn run_inner_resto(
             | SolverReturn::MaxiterExceeded
             | SolverReturn::ErrorInStepComputation
     ) && inner_kkt_err <= 1e-2
-        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
+        && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol)
         && inner_iter_count >= 30;
 
     // Cycle locally-infeasible gate (CRESC100-style). The inner has run
@@ -652,7 +670,7 @@ pub fn run_inner_resto(
     // misclassifying genuinely under-resourced solves.
     let cycle_locally_infeasible = matches!(status, SolverReturn::MaxiterExceeded)
         && inner_iter_count >= 1000
-        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
+        && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol)
         && orig_inf_pr_at_final.is_finite();
 
     // Step-failure locally-infeasible gate (qcqp750-2nc-style). The
@@ -671,7 +689,7 @@ pub fn run_inner_resto(
     // gate's "not a premature failure".
     let step_failure_locally_infeasible = matches!(status, SolverReturn::ErrorInStepComputation)
         && inner_iter_count >= 30
-        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
+        && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol)
         && orig_inf_pr_at_final.is_finite();
 
     // Tiny-step locally-infeasible gate (gh #372). At a tight user `tol`
@@ -692,11 +710,11 @@ pub fn run_inner_resto(
     // which is exactly how the case arises); it uses the `alt` gate's
     // looser `1e-2` KKT ceiling to reject inners that stalled without
     // ever approaching stationarity. `!is_square_problem` and the
-    // `max(100*outer_tol, 1e-4)` violation floor mirror `strict`.
+    // `constr_viol_tol` violation floor mirror `strict`.
     let tiny_step_locally_infeasible = !is_square_problem
         && matches!(status, SolverReturn::StopAtTinyStep)
         && inner_kkt_err <= 1e-2
-        && is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)
+        && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol)
         && orig_inf_pr_at_final.is_finite();
 
     // Layer-2 verdict, rendered from *inside* the sub-solve (pounce#438).
@@ -799,10 +817,9 @@ pub fn run_inner_resto(
 ///
 /// The unscaling is load-bearing, not cosmetic. `eval_c` / `eval_d` return the
 /// row-scaled residual (`c_scaled = dc ⊙ c_user`), while every gate above
-/// compares this value against an *absolute* floor — `max(100·outer_tol, 1e-4)`
-/// or `1e-3`. Those floors are user-facing magnitudes meaning "the constraint
-/// violation is meaningfully nonzero", so mixing them with a scaled residual
-/// compares two different unit systems.
+/// compares this value against `constr_viol_tol`, a user-facing magnitude
+/// meaning "the constraint violation is meaningfully nonzero", so feeding it a
+/// scaled residual would compare two different unit systems.
 ///
 /// On a problem whose constraint scaling is small the mismatch silently
 /// disables the gates. `infeasible_equalities.nl` is the worked example: NLP


### PR DESCRIPTION
Fixes #508

## Problem

On a model with no solution, POUNCE chooses between `LocalInfeasibility` (AMPL 200 — "your model has no solution") and `ErrorInStepComputation` / `RestorationFailure` (AMPL 500, Pyomo `internalSolverError` — "your solver broke"). That choice was made against a threshold built from `tol`, and never consulted `constr_viol_tol`.

Probe model, from the issue: `min (x-5)² s.t. x²+δ = 0`. Infeasible for every δ>0; `½‖c‖²` has a strict local minimum at `x=0` where the violation is exactly δ and `Jᵀc = 2x(x²+δ) = 0`, so restoration converges there, no local move reduces the violation, and the honest verdict at every δ is "converged to a point of local infeasibility". Because the reported violation *is* δ, the threshold is measurable to the digit.

`solve_result_num` at `acceptable_tol=1e-12`, **before** (parent commit `ec70fab`):

| `constr_viol_tol` (tol=1e-6) | 1e-6 | 3e-6 | 1e-5 | 3e-5 | **1e-4** | 3e-4 | 1e-3 | 1e-2 |
|---|---|---|---|---|---|---|---|---|
| 1e-8 | 200 | 200 | 200 | 200 | **500** | 200 | 200 | 200 |
| 1e-6 | 200 | 200 | 200 | 200 | **500** | 200 | 200 | 200 |
| 1e-5 | 200 | 200 | 200 | 200 | **500** | 200 | 200 | 200 |
| 1e-4 | 200 | 200 | 200 | 200 | **500** | 200 | 200 | 200 |
| 1e-3 | 200 | 200 | 200 | 200 | **500** | 200 | 200 | 200 |

Four orders of `constr_viol_tol`, a bit-identical column — the knob that declares what a violated constraint is has no effect on the question "is this violation real". The `δ=1e-4` column is 500 at every setting because the comparison was `>` against a threshold that landed exactly on it.

**after**:

| `constr_viol_tol` (tol=1e-6) | 1e-6 | 3e-6 | 1e-5 | 3e-5 | 1e-4 | 3e-4 | 1e-3 | 1e-2 |
|---|---|---|---|---|---|---|---|---|
| 1e-8 | 200 | 200 | 200 | 200 | 200 | 200 | 200 | 200 |
| 1e-6 | 200 | 200 | 200 | 200 | 200 | 200 | 200 | 200 |
| 1e-5 | 200 | 200 | 200 | 200 | 200 | 200 | 200 | 200 |
| 1e-4 | 200 | 200 | 200 | 200 | 200 | 200 | 200 | 200 |
| 1e-3 | 200 | 200 | 200 | 200 | **500** | **500** | 200 | 200 |

The boundary now tracks the knob. The bottom row's two 500s are the deliberate direction of the fix, not a leftover — see "Fix".

The other half: sweeping `tol` moved the boundary a great deal, and in the wrong direction. The failure band tracked `max(100·tol, 1e-4)`, so at `tol=1e-4` it widened to `1e-2`:

| `tol` (constr_viol_tol=1e-4), δ ≥ 1e-4 | 1e-4 | 3e-4 | 1e-3 | 3e-3 | 1e-2 | 1e-1 |
|---|---|---|---|---|---|---|
| before, tol=1e-5 | 500 | 500 | 500 | 200 | 200 | 200 |
| before, tol=1e-4 | 500 | 500 | 500 | 500 | 200 | 200 |
| before, tol=1e-3 | 500 | 500 | 500 | 500 | **500** | 200 |
| after, any `tol` | 200 | 200 | 200 | 200 | 200 | 200 |

A model infeasible by a full percent answering "your solver broke". Loosening `tol` is the standard reaction to a struggling solve, so the failure widened exactly when the user tried to help.

Not short-circuiting: within δ ≤ 1e-2 the `infeasible` verdicts take 22–48 iterations and the failures 65–802.

## Cause

`tol` is a tolerance on the **KKT error**. The quantity being tested is a constraint violation. Different quantity, different units, so `constr_viol_tol` could not move the verdict and `tol` moved it for no reason.

Six sites, not one. `ipopt_alg.rs`'s restoration-cycle exit is the one the issue names:

```rust
let outer_tol_for_cycle = self.bundle.conv_check.tol_or_default();
let cycle_exit = if reference_theta_unscaled > (100.0 * outer_tol_for_cycle).max(1e-4) { … }
```

It matters disproportionately because square problems are carved out of the `strict` restoration gate (`!is_square_problem`) so the outer gets another shot — which makes this cycle exit their *only* locally-infeasible safety net, and the probe model is square.

Fixing it alone left a hole. At `tol=1e-3` the δ=1e-2 model still returned 500, now via `Restoration_Failed`, because the five locally-infeasible gates in `resto_inner_solver.rs` share the same defect in the shape `is_significant(orig_inf_pr_at_final, violation_scale, 100.0 * outer_tol)`. Same tolerance standing in for the same wrong quantity.

## Fix

All six now test the constraint violation against `constr_viol_tol`, exposed on the `ConvCheck` trait as `constr_viol_tol_or_default()` (default `1e-4`, matching upstream) alongside the existing `tol_or_default()`. In `resto_inner_solver` the floor is read off the same inner conv-check options that already carry `constr_viol_tol` for the layer-2 verdict.

The boundary comparison is `>=`, not `>`. A violation landing exactly on the tolerance the user declared too large is a violation, and the probe hits the boundary to the digit.

**Rejected: `infeas_viol_kappa · constr_viol_tol`**, which the issue suggests for consistency with the rapid-infeasibility pre-filter. Two reasons, both measured:

- It is `1e-2` at defaults, a hundredfold loosening of today's effective `1e-4` threshold, so it would hand back 500 across the whole band in between — the wrong direction for the bug being fixed.
- The kappa margin exists because that detector fires *mid-solve* off a streak heuristic and must not convict an iterate that is still converging. Here restoration has already demonstrably cycled; the certainty comes from the cycle evidence, not from extra violation headroom.

Plain `constr_viol_tol` also reproduces current default behaviour exactly (`max(100·1e-8, 1e-4) = 1e-4 = ` the default `constr_viol_tol`), so the default trajectory of every model in the corpus is untouched.

**Deliberately not changed: below `constr_viol_tol`, 500 stays.** This is the issue's `constr_viol_tol=1e-3 / δ=1e-4` cell, and it answers the report's second question. After the fix, this exit no longer returns 500 on any model whose infeasibility POUNCE can *see* — a violation at or above the user's declared feasibility tolerance is always 200. Below that tolerance the iterate is primal-feasible by the user's own declaration; certifying infeasibility there would be the #505-family false-infeasibility failure from the opposite direction, which is a worse answer than an unhelpful one. The corresponding half of the invariant is pinned by its own test.

A `theta > 0.0` conjunct guards the `>=`: the options layer registers `constr_viol_tol` with a strict lower bound of zero, but a library embedder setting `ConvCheckOptions` directly is not bound by that, and `0 >= 0` would turn an exactly-feasible iterate into an infeasibility certificate.

**Secondary defect, also fixed.** After a non-promoted MC64 hypersensitivity re-solve, the terminal's last `EXIT:` banner was the retry's while the `.sol`, the summary and the JSON report all carried the kept first-solve verdict. `validation/p3_control.py` reads a log exactly that way — last `EXIT:` line, paired with the `.sol` — so it could record a status the `.sol` never held. The CLI now re-emits the verdict that shipped as the final banner, gated on `print_level >= 1` to match `Application::emit_end_summary` (at `print_level 0` there are no banners to disagree).

## Blast radius

At default options the change is bit-identical: the old threshold `max(100·tol, 1e-4)` evaluates to `1e-4` at the default `tol=1e-8`, which is exactly the default `constr_viol_tol`. Behaviour moves only when the user has retuned `tol` or `constr_viol_tol` away from their defaults, or when a violation lands exactly on the boundary.

The `resto_inner_solver` gates get *stricter* at default `tol` (floor `100·1e-8 = 1e-6` → `1e-4`), which is the intended direction: a violation the user calls feasible should not be certified infeasible. Every restoration-verdict test in the repo passes unchanged — `issue_372_infeasible_bounds_status`, `infeasible_status_tol_invariance` (which sweeps `tol` over nine values across four infeasible fixtures), `issue_387_overdetermined_infeasible`, `issue_438_resto_layer2_verdict`, `issue_439_required_infeasibility_reduction`, `false_local_infeasibility`, `scaled_feasible_not_infeasible`, `presolve_certified_infeasibility`.

No CUTE corpus sweep was run — none is available in this environment. The suites above are the closest proxy and are the ones that encode the CUTE-derived regressions the touched comments name (PFIT1–4, DECONVBNE, CRESC100, ACOPR14/30, qcqp750-2nc).

## Tests

`crates/pounce-cli/tests/issue_508_infeasibility_gap_status.rs`, six tests over two vendored fixtures (δ=1e-4 and δ=1e-2 instances of the probe model, ~30 lines of `.nl` each). Verified against the parent commit by reverting `crates/*/src` to `ec70fab` and keeping the tests:

| test | on parent |
|---|---|
| `a_percent_wide_infeasibility_gap_is_tol_invariant` | **FAILED** — `tol=1e-3`, `solve_result_num=500` (`RestorationFailed`) |
| `a_violation_exactly_at_constr_viol_tol_is_infeasible_not_an_internal_error` | **FAILED** — 500 at the `>` boundary |
| `constr_viol_tol_moves_the_boundary` | **FAILED** — the knob has no effect |
| `a_gap_inside_constr_viol_tol_is_not_claimed_infeasible` | passes — direction guard, pins the half of the invariant the fix must *not* break |
| `the_gap_models_are_never_reported_solved` | passes — explicit "never trade one wrong verdict for a worse one" guard |
| `the_last_exit_banner_matches_the_sol_after_a_non_promoted_mc64_retry` | passes — see gap below |

Plus `constr_viol_tol_accessor_tracks_the_option` in `conv_check::opt_error`, which does not compile against the parent (the accessor is new) and covers the debugger's live `set_tolerance` hot-swap path.

**Known gap, stated deliberately.** The banner test is an invariant guard, not a bite-on-parent pin. It asserts the right thing and fails loudly if a future change stops exercising the non-promoted retry path, but it passes pre-fix: every non-promoted retry reachable from this repo's fixture corpus returns `InfeasibleProblemDetected`, the same verdict the `.sol` keeps, so the two banners agree by luck rather than by construction. A sweep over `tol`, `max_iter` and every `.nl` under `tests/fixtures/` found no divergent retry status. The fix does not depend on reproducing one — the retry's status is unconstrained and `scaling_retry_promoted` is false for most statuses, so the mismatch is a reachable state either way, and the reporter observed it on their own model. Vendoring a model that diverges would upgrade this to a real pin. The gap is written into the test's doc comment so it is not rediscovered.

Also not addressed, and out of scope: the report's observation that one cell ran 3000 iterations to a violation of 1.49 against δ=0.1. That is the MC64 re-solve's trajectory under a different scaling — the hypersensitivity the retry exists to probe — and is a separate question from status selection.

---

- [x] Tests fail on the parent commit for the stated reason — three of six do, with the per-test breakdown and the one known gap above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — none needed; no user-facing option or documented behaviour is added or renamed, and `constr_viol_tol` / `tol` keep their documented meanings (this change makes the code honour them)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — full workspace green except `pounce-hsl`, which cannot link its HSL system libraries in this container (pre-existing, unrelated); clippy clean on the three touched crates
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01VZSkXGDWFkCxc8HugCJ619)_