### PR TITLE
fix(mu): reset the line-search filter where upstream does, not on "μ changed"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — adaptive μ reset the line-search filter on "μ changed" instead of upstream's every-free-mode-iteration, so stale entries forced spurious restorations (#510)
+
+- Ipopt's μ updates hold a line-search handle and call `linesearch_->Reset()`
+  themselves — which clears the entire filter — at four points:
+  `IpAdaptiveMuUpdate.cpp:339` (fixed-mode decrease), `:386` (free→fixed
+  switch), `:431` (**unconditionally, every free-mode iteration**), and
+  `IpMonotoneMuUpdate.cpp:165` (after a monotone reduction). POUNCE's
+  `MuUpdate` trait carries no line-search handle, so the main loop inferred
+  the reset from `next_mu != mu_before`. That proxy is right for the monotone
+  update and wrong for the adaptive one: upstream's line 431 does not consult
+  μ at all.
+- The gap was documented in `mu/adaptive.rs` as "primarily affects the
+  watchdog counter, not convergence". Measurement says otherwise. On the
+  unscaled reproducer from #505 (`nlp_scaling_method=none`, adaptive μ), at
+  internal iteration 69 — after a restoration that returned at the μ it left
+  with, so no reset fired — the filter still held the pre-restoration entries
+  `(θ, φ) = (0.0141, 22157.56)` and `(0.0220, 22157.56)`. Every trial step
+  from `α = 2.4e-6` down to `1e-12` was rejected on the filter alone, forcing
+  a third entry into restoration. Those entries were computed against a
+  barrier parameter and an iterate the algorithm had long since left.
+- Each μ update now raises `IpoptData::request_ls_reset` at exactly upstream's
+  call sites and the main loop honours it — the same plumbing the pounce#58
+  probing guard already uses for `request_resto`. The affected paths are the
+  adaptive ones where μ can stay numerically fixed across an iteration: the
+  whole free-mode endgame, every iteration following a restoration that
+  returns at the same μ, and the two clamp-flattened decreases. Monotone runs
+  are unchanged — its reduction loop only ever exits with a strictly smaller
+  μ, so flag and proxy agree.
+- Not a fix for #505: that model's first restoration is entered on
+  iterate-acceptability rejections, not filter rejections, so filter state is
+  irrelevant at that point. This removes the later spurious restorations only.
+
 ### Fixed — infeasible models reported `internalSolverError` because the infeasibility threshold was built from `tol` (#508)
 
 - On a model with no solution, POUNCE chooses between *converged to a point

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -1815,6 +1815,40 @@ impl IpoptAlgorithm {
         );
         self.data.borrow_mut().curr_mu = next_mu;
         timing.update_barrier_parameter.end();
+
+        // pounce#510 — line-search reset. Upstream's μ updates own a
+        // `linesearch_` handle and call `linesearch_->Reset()` (which
+        // clears the filter via `FilterLSAcceptor::Reset`,
+        // `IpFilterLSAcceptor.cpp:524-532`) at four fixed points:
+        // `IpAdaptiveMuUpdate.cpp:339` (fixed-mode decrease), `:386`
+        // (free→fixed switch), `:431` (**unconditionally** on every
+        // free-mode iteration, μ moved or not), and
+        // `IpMonotoneMuUpdate.cpp:165` (after a monotone reduction).
+        // Pounce's `MuUpdate` trait has no line-search handle, so each
+        // update raises `request_ls_reset` at exactly those points and
+        // we honour it here — the same plumbing `request_resto` uses
+        // below.
+        //
+        // This used to be inferred from `next_mu != mu_before`. That
+        // proxy is right for the monotone update but wrong for the
+        // adaptive one, which resets every free-mode iteration
+        // regardless of μ: whenever μ stayed numerically put (the
+        // free-mode endgame, and any iteration after a restoration that
+        // returns at the same μ) the filter kept entries computed
+        // against a barrier parameter and an iterate the algorithm had
+        // already left. On #505's reproducer that rejected every trial
+        // step from α=2.4e-6 down to 1e-12 on the filter alone and
+        // forced a spurious restoration.
+        let ls_reset = {
+            let mut d = self.data.borrow_mut();
+            let f = d.request_ls_reset;
+            d.request_ls_reset = false;
+            f
+        };
+        if ls_reset {
+            self.bundle.line_search.reset();
+        }
+
         if tiny_at_entry && mu_terminates_on_tiny && (next_mu - mu_before).abs() < Number::EPSILON {
             return IterateOutcome::Terminate(SolverReturn::StopAtTinyStep);
         }
@@ -1846,20 +1880,6 @@ impl IpoptAlgorithm {
                     next_mu,
                 );
             }
-        }
-
-        // Mirror upstream `IpAdaptiveMuUpdate.cpp:339, 386, 431` and
-        // `IpMonotoneMuUpdate.cpp:165`: every code path that *changes*
-        // μ calls `linesearch_->Reset()`, which clears the filter via
-        // `FilterLSAcceptor::Reset` (`IpFilterLSAcceptor.cpp:524-532`).
-        // Rationale: filter entries are computed against the current
-        // barrier — when μ changes, prior entries no longer apply and
-        // would over-constrain acceptance. The two upstream paths that
-        // do NOT reset (stay-fixed-no-decrease and fixed→free transition)
-        // both keep μ at curr_mu, so the `mu_changed` check captures
-        // the intended distinction.
-        if next_mu != mu_before {
-            self.bundle.line_search.reset();
         }
 
         // Sub-iteration checkpoint: μ has been updated for this iteration.

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -118,6 +118,18 @@ pub struct IpoptData {
     /// counterpart. See pounce#58.
     pub request_resto: bool,
 
+    /// Line-search reset request from the μ-update layer (pounce#510).
+    /// Upstream's μ updates hold a `linesearch_` handle and call
+    /// `linesearch_->Reset()` themselves at fixed points
+    /// (`IpAdaptiveMuUpdate.cpp:339, 386, 431`,
+    /// `IpMonotoneMuUpdate.cpp:165`); pounce's [`MuUpdate`] trait has no
+    /// such handle, so the updates raise this flag instead and the main
+    /// loop performs the reset immediately after
+    /// `update_barrier_parameter` returns. Consuming the flag clears it.
+    ///
+    /// [`MuUpdate`]: crate::mu::MuUpdate
+    pub request_ls_reset: bool,
+
     /// One-char marker the iteration output puts in front of
     /// `alpha_primal` (e.g. `'f'` for filter, `'r'` for restoration,
     /// `'h'` for the very first iterate). Mirrors
@@ -188,6 +200,7 @@ impl IpoptData {
             info_string: String::new(),
             tiny_step_flag: false,
             request_resto: false,
+            request_ls_reset: false,
             info_alpha_primal_char: ' ',
             info_ls_count: 0,
             info_last_output: -1.0,

--- a/crates/pounce-algorithm/src/mu/adaptive.rs
+++ b/crates/pounce-algorithm/src/mu/adaptive.rs
@@ -492,11 +492,22 @@ impl MuUpdate for AdaptiveMuUpdate {
     /// `nlp` / `pd_search_dir` are unavailable (mirrors upstream
     /// lines 402-408).
     ///
-    /// Note: line-search reset (upstream's `linesearch_->Reset()` at
-    /// lines 339, 386, 431) is not yet wired here — that handle is
-    /// not part of the [`MuUpdate`] trait surface. This is a
-    /// deliberate v1.0 deviation; it primarily affects the watchdog
-    /// counter, not convergence.
+    /// Line-search reset: upstream calls `linesearch_->Reset()` at
+    /// three points — line 339 (fixed-mode decrease), line 386
+    /// (free→fixed switch) and line 431 (**every** free-mode
+    /// iteration, whether or not μ moved). The [`MuUpdate`] trait
+    /// surface carries no line-search handle, so we raise
+    /// [`IpoptData::request_ls_reset`] at exactly those three points
+    /// and `IpoptAlgorithm::iterate` performs the reset right after
+    /// this call returns — the same plumbing the pounce#58 probing
+    /// guard uses for [`IpoptData::request_resto`]. See pounce#510:
+    /// the previous "reset when μ changed" proxy in the caller is
+    /// correct for the monotone update but not for this one, and left
+    /// the filter holding pre-restoration entries whenever μ happened
+    /// to stay put.
+    ///
+    /// [`IpoptData::request_ls_reset`]: crate::ipopt_data::IpoptData::request_ls_reset
+    /// [`IpoptData::request_resto`]: crate::ipopt_data::IpoptData::request_resto
     fn update_barrier_parameter(
         &mut self,
         data: &IpoptDataHandle,
@@ -612,10 +623,16 @@ impl MuUpdate for AdaptiveMuUpdate {
                     let sup = curr_mu.powf(self.mu_superlinear_decrease_power);
                     let new_mu = lin.min(sup).max(mu_min).min(self.mu_max);
                     let new_tau = self.tau_min.max(1.0 - new_mu);
-                    data.borrow_mut().curr_tau = new_tau;
+                    let mut d = data.borrow_mut();
+                    d.curr_tau = new_tau;
+                    // Upstream `cpp:339` — reset inside this branch,
+                    // unconditionally, even when the clamps leave μ
+                    // where it was (pounce#510).
+                    d.request_ls_reset = true;
                     return new_mu;
                 }
-                // Subproblem not yet solved — keep μ.
+                // Subproblem not yet solved — keep μ. Upstream does NOT
+                // reset the line search on this path (`cpp:335-341`).
                 let new_tau = self.tau_min.max(1.0 - curr_mu);
                 data.borrow_mut().curr_tau = new_tau;
                 return curr_mu;
@@ -667,7 +684,12 @@ impl MuUpdate for AdaptiveMuUpdate {
                 }
                 let new_mu = self.new_fixed_mu(cq, mu_min);
                 let new_tau = self.tau_min.max(1.0 - new_mu);
-                data.borrow_mut().curr_tau = new_tau;
+                let mut d = data.borrow_mut();
+                d.curr_tau = new_tau;
+                // Upstream `cpp:386` — the free→fixed switch resets the
+                // line search whether or not `new_fixed_mu` differs from
+                // the μ we came in with (pounce#510).
+                d.request_ls_reset = true;
                 return new_mu;
             }
         }
@@ -727,6 +749,10 @@ impl MuUpdate for AdaptiveMuUpdate {
                             self.probing_iterate_quality_factor,
                         );
                     }
+                    // No `request_ls_reset` here: this early return is a
+                    // pounce-specific guard with no upstream counterpart,
+                    // it leaves μ untouched, and the caller hands the
+                    // iterate straight to restoration.
                     data.borrow_mut().request_resto = true;
                     return curr_mu;
                 }
@@ -781,6 +807,16 @@ impl MuUpdate for AdaptiveMuUpdate {
         let lower = self.lower_mu_safeguard(dual_inf, primal_inf, candidate);
         let mu = candidate.max(mu_min).max(lower).min(self.mu_max);
 
+        // Upstream `cpp:431` — the free-mode block closes with an
+        // unconditional `linesearch_->Reset()`. This is the point the
+        // old caller-side "μ changed" proxy missed (pounce#510): it
+        // fires on every free-mode iteration, including the ones where
+        // the oracle re-picks the μ we already had, and including the
+        // fixed→free transition that falls through to here. Filter
+        // entries are keyed on a barrier parameter *and* an iterate;
+        // "μ is unchanged" does not make yesterday's entries valid.
+        data.borrow_mut().request_ls_reset = true;
+
         // NB: upstream `IpAdaptiveMuUpdate.cpp:410-426` does NOT require
         // `mu ≤ curr_mu` in free mode — the oracle is allowed to bump
         // μ back up. A prior attempt to cap growth here ("HAIFAM
@@ -797,6 +833,107 @@ impl MuUpdate for AdaptiveMuUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mu::test_fixture;
+
+    /// pounce#510: upstream resets the line search on **every** free-mode
+    /// iteration (`IpAdaptiveMuUpdate.cpp:431`), not only when μ moves.
+    /// The caller used to infer the reset from `next_mu != mu_before`,
+    /// which silently skipped it whenever the oracle re-picked the μ we
+    /// already had — leaving the filter holding entries computed against
+    /// an iterate and a barrier parameter the algorithm had left behind.
+    #[test]
+    fn free_mode_requests_ls_reset_even_when_mu_is_unchanged() {
+        let mut a = AdaptiveMuUpdate::new();
+        // Never-monotone globalization keeps the state machine in free
+        // mode across both calls, which is the endgame this issue is
+        // about; the filter/KKT variants are covered below.
+        a.adaptive_mu_globalization = AdaptiveMuGlobalization::NeverMonotoneMode;
+        let (data, cq) = test_fixture::fixture(0.1);
+        // First pass: free mode with an empty filter ⇒ sufficient
+        // progress ⇒ the oracle picks μ.
+        let mu1 = a.update_barrier_parameter(&data, &cq, None, None);
+        assert!(a.free_mu_mode);
+        assert!(data.borrow().request_ls_reset);
+
+        // Re-enter at exactly the μ the oracle just chose, on the same
+        // (unchanged) iterate: μ cannot move, and the pre-fix caller
+        // would therefore never reset.
+        data.borrow_mut().request_ls_reset = false;
+        data.borrow_mut().curr_mu = mu1;
+        let mu2 = a.update_barrier_parameter(&data, &cq, None, None);
+        assert_eq!(mu2, mu1, "fixture must hold μ still for this test");
+        assert!(
+            data.borrow().request_ls_reset,
+            "free-mode iteration must request a line-search reset with μ unchanged"
+        );
+    }
+
+    /// pounce#510: the free→fixed switch is upstream's `cpp:386` reset,
+    /// which likewise does not care whether `new_fixed_mu` differs from
+    /// the incoming μ.
+    #[test]
+    fn free_to_fixed_switch_requests_ls_reset() {
+        let mut a = AdaptiveMuUpdate::new();
+        let (data, cq) = test_fixture::fixture(0.1);
+        // Seed the filter with the current point, then re-run: the same
+        // (θ, f) is now dominated, so progress is insufficient and the
+        // update drops into fixed mode.
+        let _ = a.update_barrier_parameter(&data, &cq, None, None);
+        data.borrow_mut().request_ls_reset = false;
+        let _ = a.update_barrier_parameter(&data, &cq, None, None);
+        assert!(
+            !a.free_mu_mode,
+            "fixture must fall out of free mode for this test"
+        );
+        assert!(data.borrow().request_ls_reset);
+    }
+
+    /// pounce#510: the fixed-mode μ decrease is upstream's `cpp:339`
+    /// reset. Note it fires inside the branch, so a decrease that the
+    /// `mu_min`/`mu_max` clamps flatten still resets.
+    #[test]
+    fn fixed_mode_decrease_requests_ls_reset() {
+        let mut a = AdaptiveMuUpdate::new();
+        let (data, cq) = test_fixture::fixture(0.1);
+        a.free_mu_mode = false;
+        // Force "no sufficient progress" so the update stays in fixed
+        // mode, and a barrier tolerance loose enough that the decrease
+        // branch fires on this (far-from-optimal) iterate.
+        a.adaptive_mu_globalization = AdaptiveMuGlobalization::KktError;
+        a.adaptive_mu_kkterror_red_iters = 1;
+        a.adaptive_mu_kkterror_red_fact = 0.0;
+        a.refs_vals.push_back(1.0);
+        a.barrier_tol_factor = 1e6;
+        // Degenerate decrease factors: `min(1·μ, μ^1) = μ`. The branch is
+        // taken but μ does not move, so the pre-fix `next_mu != mu_before`
+        // proxy would have skipped the reset here as well.
+        a.mu_linear_decrease_factor = 1.0;
+        a.mu_superlinear_decrease_power = 1.0;
+        let mu = a.update_barrier_parameter(&data, &cq, None, None);
+        assert!(!a.free_mu_mode, "must stay in fixed mode for this test");
+        assert_eq!(mu, 0.1, "flat decrease leaves μ where it was");
+        assert!(data.borrow().request_ls_reset);
+    }
+
+    /// The one fixed-mode path upstream leaves alone (`cpp:335-341`):
+    /// the barrier subproblem is not solved yet, μ stays, no reset.
+    #[test]
+    fn fixed_mode_without_decrease_does_not_request_ls_reset() {
+        let mut a = AdaptiveMuUpdate::new();
+        let (data, cq) = test_fixture::fixture(1e-8);
+        a.free_mu_mode = false;
+        // A far-from-optimal iterate at a tiny μ: the barrier error is
+        // way above `barrier_tol_factor · μ`, and the filter is empty so
+        // `check_sufficient_progress` must be forced to fail.
+        a.adaptive_mu_globalization = AdaptiveMuGlobalization::KktError;
+        a.adaptive_mu_kkterror_red_iters = 1;
+        a.adaptive_mu_kkterror_red_fact = 0.0;
+        a.refs_vals.push_back(1.0);
+        let mu = a.update_barrier_parameter(&data, &cq, None, None);
+        assert!(!a.free_mu_mode);
+        assert_eq!(mu, 1e-8);
+        assert!(!data.borrow().request_ls_reset);
+    }
 
     /// pounce#266, adaptive twin of the monotone test: the raw `mu_min`
     /// clamp must yield to `compl_inf_tol·|df|/(barrier_tol_factor+1)` once

--- a/crates/pounce-algorithm/src/mu/mod.rs
+++ b/crates/pounce-algorithm/src/mu/mod.rs
@@ -10,6 +10,8 @@
 pub mod adaptive;
 pub mod monotone;
 pub mod oracle;
+#[cfg(test)]
+pub(crate) mod test_fixture;
 pub mod r#trait;
 
 pub use r#trait::MuUpdate;

--- a/crates/pounce-algorithm/src/mu/monotone.rs
+++ b/crates/pounce-algorithm/src/mu/monotone.rs
@@ -215,6 +215,15 @@ impl MuUpdate for MonotoneMuUpdate {
     /// `barrier_tol_factor · μ` (or a tiny step was just detected).
     /// Each successful reduction also refreshes `curr_tau` and the new
     /// μ in `data`. Returns the post-update μ.
+    ///
+    /// A reduction also raises [`IpoptData::request_ls_reset`], which the
+    /// main loop turns into the `linesearch_->Reset()` upstream issues at
+    /// `IpMonotoneMuUpdate.cpp:165`. This is the same behaviour the
+    /// caller previously inferred from "μ changed" — the loop below only
+    /// ever exits with a strictly smaller μ — but the flag is now the
+    /// single source of truth for both μ strategies (pounce#510).
+    ///
+    /// [`IpoptData::request_ls_reset`]: crate::ipopt_data::IpoptData::request_ls_reset
     fn update_barrier_parameter(
         &mut self,
         data: &IpoptDataHandle,
@@ -225,6 +234,7 @@ impl MuUpdate for MonotoneMuUpdate {
         let mut mu = data.borrow().curr_mu;
         let mut tau = data.borrow().curr_tau;
         let tiny_step = data.borrow().tiny_step_flag;
+        let mu_at_entry = mu;
 
         // `first_iter_resto_` (upstream `IpMonotoneMuUpdate.cpp:144`):
         // on the first inner iteration of restoration, skip the μ
@@ -313,6 +323,11 @@ impl MuUpdate for MonotoneMuUpdate {
         let mut d = data.borrow_mut();
         d.curr_mu = mu;
         d.curr_tau = tau;
+        // Upstream `IpMonotoneMuUpdate.cpp:165` resets the line search
+        // once the reduction loop has moved μ, and not otherwise.
+        if mu < mu_at_entry {
+            d.request_ls_reset = true;
+        }
         mu
     }
 }
@@ -320,6 +335,35 @@ impl MuUpdate for MonotoneMuUpdate {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mu::test_fixture;
+
+    /// pounce#510: the monotone update raises `request_ls_reset` at
+    /// upstream's `IpMonotoneMuUpdate.cpp:165` — after the reduction
+    /// loop moved μ, and only then. This is the behaviour the caller
+    /// used to infer from `next_mu != mu_before`, so monotone runs are
+    /// unaffected by moving the decision onto the flag.
+    #[test]
+    fn requests_ls_reset_on_a_reduction() {
+        let mut m = MonotoneMuUpdate::new();
+        // A barrier tolerance loose enough that the far-from-optimal
+        // fixture counts as "subproblem solved" and μ is reduced.
+        m.barrier_tol_factor = 1e6;
+        let (data, cq) = test_fixture::fixture(0.1);
+        let mu = m.update_barrier_parameter(&data, &cq, None, None);
+        assert!(mu < 0.1, "fixture must reduce μ for this test");
+        assert!(data.borrow().request_ls_reset);
+    }
+
+    #[test]
+    fn no_ls_reset_when_mu_stands_still() {
+        let mut m = MonotoneMuUpdate::new();
+        let (data, cq) = test_fixture::fixture(0.1);
+        // Default `barrier_tol_factor`: the fixture's barrier error is
+        // far above `10 · μ`, so the loop never runs.
+        let mu = m.update_barrier_parameter(&data, &cq, None, None);
+        assert_eq!(mu, 0.1);
+        assert!(!data.borrow().request_ls_reset);
+    }
 
     #[test]
     fn picks_smaller_of_linear_and_superlinear() {

--- a/crates/pounce-algorithm/src/mu/test_fixture.rs
+++ b/crates/pounce-algorithm/src/mu/test_fixture.rs
@@ -1,0 +1,187 @@
+//! Shared `(IpoptData, IpoptCq)` fixture for the μ-update unit tests.
+//!
+//! Both μ strategies need a live [`IpoptCalculatedQuantities`] to read
+//! `curr_barrier_error`, `curr_avrg_compl`, `curr_nlp_error` and friends,
+//! so the tests that exercise `update_barrier_parameter` end-to-end (as
+//! opposed to the scalar helpers) need a real NLP behind the handles.
+//! The NLP below is the same 2-variable / 1-equality / 1-inequality mock
+//! the `ipopt_cq` tests use, trimmed to what the μ path touches.
+
+use crate::ipopt_cq::{IpoptCalculatedQuantities, IpoptCqHandle};
+use crate::ipopt_data::{IpoptData, IpoptDataHandle};
+use crate::ipopt_nlp::{IpoptNlp, Nlp};
+use crate::iterates_vector::IteratesVector;
+use pounce_common::types::{Index, Number};
+use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
+use pounce_linalg::expansion_matrix::{ExpansionMatrix, ExpansionMatrixSpace};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace};
+use pounce_linalg::{Matrix, SymMatrix, Vector};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+fn dvec(values: &[Number]) -> DenseVector {
+    let space = DenseVectorSpace::new(values.len() as Index);
+    let mut v = space.make_new_dense();
+    v.values_mut().copy_from_slice(values);
+    v
+}
+
+fn rcv(values: &[Number]) -> Rc<dyn Vector> {
+    Rc::new(dvec(values))
+}
+
+/// 2 vars, 1 equality, 1 inequality. Bounds: `x[0] ≥ 0`, `x[1] ≤ 5`,
+/// `d ≥ 1`. `f(x) = x0² + x1²`, `c(x) = x0 + x1 - 1`, `d(x) = x0`.
+struct MuMockNlp {
+    x_l: DenseVector,
+    x_u: DenseVector,
+    d_l: DenseVector,
+    d_u: DenseVector,
+    px_l: Rc<dyn Matrix>,
+    px_u: Rc<dyn Matrix>,
+    pd_l: Rc<dyn Matrix>,
+    pd_u: Rc<dyn Matrix>,
+}
+
+impl MuMockNlp {
+    fn new() -> Self {
+        Self {
+            x_l: dvec(&[0.0]),
+            x_u: dvec(&[5.0]),
+            d_l: dvec(&[1.0]),
+            d_u: dvec(&[]),
+            px_l: Rc::new(ExpansionMatrix::new(ExpansionMatrixSpace::new(
+                2,
+                1,
+                &[0],
+                0,
+            ))),
+            px_u: Rc::new(ExpansionMatrix::new(ExpansionMatrixSpace::new(
+                2,
+                1,
+                &[1],
+                0,
+            ))),
+            pd_l: Rc::new(ExpansionMatrix::new(ExpansionMatrixSpace::new(
+                1,
+                1,
+                &[0],
+                0,
+            ))),
+            pd_u: Rc::new(ExpansionMatrix::new(ExpansionMatrixSpace::new(
+                1,
+                0,
+                &[],
+                0,
+            ))),
+        }
+    }
+}
+
+impl Nlp for MuMockNlp {
+    fn n(&self) -> Index {
+        2
+    }
+    fn m_eq(&self) -> Index {
+        1
+    }
+    fn m_ineq(&self) -> Index {
+        1
+    }
+    fn eval_f(&mut self, x: &dyn Vector) -> Number {
+        let xx = x.as_any().downcast_ref::<DenseVector>().unwrap();
+        xx.values()[0] * xx.values()[0] + xx.values()[1] * xx.values()[1]
+    }
+    fn eval_grad_f(&mut self, x: &dyn Vector, g: &mut dyn Vector) {
+        let xx = x.as_any().downcast_ref::<DenseVector>().unwrap();
+        let gg = g.as_any_mut().downcast_mut::<DenseVector>().unwrap();
+        gg.values_mut()[0] = 2.0 * xx.values()[0];
+        gg.values_mut()[1] = 2.0 * xx.values()[1];
+    }
+    fn eval_c(&mut self, x: &dyn Vector, c: &mut dyn Vector) {
+        let xx = x.as_any().downcast_ref::<DenseVector>().unwrap();
+        let cc = c.as_any_mut().downcast_mut::<DenseVector>().unwrap();
+        cc.values_mut()[0] = xx.values()[0] + xx.values()[1] - 1.0;
+    }
+    fn eval_d(&mut self, x: &dyn Vector, d: &mut dyn Vector) {
+        let xx = x.as_any().downcast_ref::<DenseVector>().unwrap();
+        let dd = d.as_any_mut().downcast_mut::<DenseVector>().unwrap();
+        dd.values_mut()[0] = xx.values()[0];
+    }
+    fn eval_jac_c(&mut self, _x: &dyn Vector) -> Rc<dyn Matrix> {
+        let space = GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]);
+        let mut jac = GenTMatrix::new(space);
+        jac.set_values(&[1.0, 1.0]);
+        Rc::new(jac)
+    }
+    fn eval_jac_d(&mut self, _x: &dyn Vector) -> Rc<dyn Matrix> {
+        let space = GenTMatrixSpace::new(1, 2, vec![1], vec![1]);
+        let mut jac = GenTMatrix::new(space);
+        jac.set_values(&[1.0]);
+        Rc::new(jac)
+    }
+    fn eval_h(
+        &mut self,
+        _x: &dyn Vector,
+        _obj_factor: Number,
+        _y_c: &dyn Vector,
+        _y_d: &dyn Vector,
+    ) -> Rc<dyn SymMatrix> {
+        unimplemented!("the μ path never asks for the Hessian")
+    }
+}
+
+impl IpoptNlp for MuMockNlp {
+    fn x_l(&self) -> &dyn Vector {
+        &self.x_l
+    }
+    fn x_u(&self) -> &dyn Vector {
+        &self.x_u
+    }
+    fn d_l(&self) -> &dyn Vector {
+        &self.d_l
+    }
+    fn d_u(&self) -> &dyn Vector {
+        &self.d_u
+    }
+    fn px_l(&self) -> Rc<dyn Matrix> {
+        self.px_l.clone()
+    }
+    fn px_u(&self) -> Rc<dyn Matrix> {
+        self.px_u.clone()
+    }
+    fn pd_l(&self) -> Rc<dyn Matrix> {
+        self.pd_l.clone()
+    }
+    fn pd_u(&self) -> Rc<dyn Matrix> {
+        self.pd_u.clone()
+    }
+}
+
+/// Handles seeded at `x = (2, 3)`, `s = (4)`, all bound multipliers at
+/// `0.5`, with the given μ. The iterate is deliberately far from
+/// optimal, so `curr_barrier_error()` is O(1) — tests that need the
+/// "barrier subproblem solved" branch loosen `barrier_tol_factor`
+/// rather than hand-tuning an iterate onto the central path.
+pub(crate) fn fixture(mu: Number) -> (IpoptDataHandle, IpoptCqHandle) {
+    let (x, s, z) = ([2.0, 3.0], 4.0, 0.5);
+    let mut data = IpoptData::new();
+    data.curr_mu = mu;
+    data.curr_tau = 0.99;
+    // z_L is the multiplier for x[0] ≥ 0, z_U for x[1] ≤ 5, v_L for d ≥ 1;
+    // there is no upper bound on d, hence the empty v_U block.
+    data.set_curr(IteratesVector::new(
+        rcv(&x),
+        rcv(&[s]),
+        rcv(&[1.0]),
+        rcv(&[1.0]),
+        rcv(&[z]),
+        rcv(&[z]),
+        rcv(&[z]),
+        rcv(&[]),
+    ));
+    let data_handle: IpoptDataHandle = Rc::new(RefCell::new(data));
+    let nlp: Rc<RefCell<dyn IpoptNlp>> = Rc::new(RefCell::new(MuMockNlp::new()));
+    let cq = IpoptCalculatedQuantities::new(data_handle.clone(), nlp);
+    (data_handle, Rc::new(RefCell::new(cq)))
+}


### PR DESCRIPTION
Fixes #510

## Problem

On adaptive μ, the line-search filter kept entries that were computed against a barrier parameter and an iterate the algorithm had already left, and those stale entries rejected every trial step until the solve fell into restoration.

Measured on #505's unscaled reproducer (`nlp_scaling_method=none`, adaptive μ), internal iteration 69 — after a restoration that returned at the μ it left with, so no reset fired:

```
filter still held: (θ, φ) = (0.0141, 22157.56)
                   (θ, φ) = (0.0220, 22157.56)
```

Every trial step from α = 2.4e-6 down to α = 1e-12 was rejected **purely on the filter**, forcing a third entry into restoration. That is a convergence effect, not the "watchdog counter" effect the code comment claimed.

That measurement is from the issue's instrumented build on a model outside this checkout. The fixture-corpus effect this change produces on its own is in Blast radius below.

## Cause

Upstream's μ updates hold a `linesearch_` handle and call `linesearch_->Reset()` themselves — which clears the entire filter (`FilterLSAcceptor::Reset`, `IpFilterLSAcceptor.cpp:520-532`) — at four points:

| site | trigger |
|---|---|
| `IpAdaptiveMuUpdate.cpp:339` | fixed-mode decrease |
| `IpAdaptiveMuUpdate.cpp:386` | free→fixed switch |
| `IpAdaptiveMuUpdate.cpp:431` | **unconditionally, every free-mode iteration** |
| `IpMonotoneMuUpdate.cpp:165` | after a monotone reduction |

POUNCE's `MuUpdate` trait carries no line-search handle, so `ipopt_alg.rs` inferred the reset from `next_mu != mu_before`. That proxy is right for the monotone update — its reduction loop only ever exits with a strictly smaller μ — and wrong for the adaptive one, because line 431 does not consult μ at all. Whenever μ stayed numerically put, no reset fired.

The old comment also mis-stated which paths upstream leaves alone: it named the fixed→free transition as a non-resetting path, but that transition falls through into the free-mode block and hits line 431. The only genuinely non-resetting adaptive path is stay-fixed-no-decrease.

## Fix

Each μ update raises `IpoptData::request_ls_reset` at exactly upstream's four call sites, and `IpoptAlgorithm::iterate` performs the reset immediately after `update_barrier_parameter` returns. This is the reset-request-flag route the issue proposed, using the plumbing pounce#58's probing guard established for `request_resto` — the alternative, putting a line-search handle on the `MuUpdate` trait surface, would have pushed a line-search dependency into every implementor and into the oracles' construction path for no behavioural gain.

Consumption happens right after the call rather than at the old reset site further down, so the flag can never survive an early return (tiny-step termination, `request_resto` → restoration) into the next iteration.

The monotone update raises the flag too, rather than leaving that strategy on the caller's μ comparison, so there is one rule instead of two. The probing guard's early return deliberately does not raise it: pounce-specific path, μ untouched, iterate handed straight to restoration.

The falsified "primarily affects the watchdog counter, not convergence" note on `AdaptiveMuUpdate::update_barrier_parameter` is replaced with what was measured.

**Merged with #512**, which landed the same shape of fix (a flag raised by the μ update, consumed by the main loop) on the same lines while this was open. Both fields are kept; one consume block clears both; and the tiny-step stop is answered *before* the line-search reset, because at each adaptive site raising it, upstream's `TINY_STEP_DETECTED` throw sits above the reset it would otherwise reach (`cpp:330-333` before `:339`, `:377-380` before `:386`) — a terminating iteration must not reset the filter.

## Blast radius

Adaptive runs change wherever μ can stay numerically fixed across an iteration: the whole free-mode endgame, every iteration following a restoration that returns at the same μ, and the two decreases that the `mu_min`/`mu_max` clamps flatten. Monotone is unaffected by construction — flag and old proxy agree there.

Swept the 52 committed `.nl` fixtures under `crates/pounce-cli/tests/fixtures`, merge head `e9f0623` against base `c34a4ca`, comparing status / iterations / objective / dual infeasibility / constraint violation / restoration calls. (The 2 GB benchmark corpus is gitignored and not in this checkout; this is the corpus #512 measured on.)

**`mu_strategy=adaptive`: 51 of 52 bit-identical. One model moved, and it moved forward:**

| `autocorr_bern55-06.nl` | status | iters | objective | dual inf | viol |
|---|---|---|---|---|---|
| base `c34a4ca` | `SolvedToAcceptableLevel` (AMPL 100) | 73 | -2320.000029769513 | 3.249e-8 | 1.27e-13 |
| merge `e9f0623` | `SolveSucceeded` (AMPL 0) | 85 | -2320.000029769511 | 5.670e-9 | 1.97e-12 |

Twelve more iterations buy the strict certificate: this is the predicted mechanism running forwards — the endgame filter no longer holds entries keyed to a barrier parameter the solve has left, so the final steps are acceptable and the solve converges instead of settling for acceptable level. Reproduced identically across repeated runs of both binaries.

**`mu_strategy=monotone`: 52 of 52 bit-identical** — 1682 iterations and 40 restoration calls on both sides, confirming by measurement the claim the code argues structurally.

Totals under adaptive: 1541 → 1553 iterations (all 12 from the model above), restoration calls 10 → 10.

## Tests

Six unit tests in `mu/adaptive.rs` and `mu/monotone.rs`, over a new shared fixture (`mu/test_fixture.rs` — the 2-var / 1-equality / 1-inequality mock the `ipopt_cq` tests use, trimmed to what the μ path reads), one per upstream trigger point plus the two paths that must stay silent:

| test | pins |
|---|---|
| `free_mode_requests_ls_reset_even_when_mu_is_unchanged` | `cpp:431`, with μ provably unmoved across two calls |
| `free_to_fixed_switch_requests_ls_reset` | `cpp:386` |
| `fixed_mode_decrease_requests_ls_reset` | `cpp:339`, with degenerate decrease factors so μ does not move |
| `fixed_mode_without_decrease_does_not_request_ls_reset` | the one adaptive path upstream leaves alone |
| `requests_ls_reset_on_a_reduction` | `IpMonotoneMuUpdate.cpp:165` |
| `no_ls_reset_when_mu_stands_still` | monotone equivalence with the old proxy |

The two μ-does-not-move cases are the ones the old proxy missed, so they are the regression tests proper. Verified they bite: with the four flag assignments reverted in place, the four positive tests fail on `assertion failed: data.borrow().request_ls_reset` and the two negative tests still pass.

Not pinned: the #505 reproducer itself, which needs a model outside this checkout, and the end-to-end "restoration is no longer entered at iteration 69" behaviour that goes with it. The `autocorr_bern55-06.nl` improvement above is not pinned as a test either — it is a corpus measurement, not an assertion.

`cargo test --workspace --exclude pounce-hsl` passes with zero failures on the merge commit (2637 passed before the merge; the merge adds #512's suites). #512's end-to-end adaptive-μ tests pass here too, including the `airport.nl` tiny-step exit — the case where the two fixes interact. `cargo fmt --all -- --check` clean; clippy clean at the CI gate (`-D clippy::correctness -D clippy::suspicious`); the new rustdoc intra-doc links resolve.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — n/a, no user-facing option or behaviour contract changes
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now
