### PR TITLE
fix(mu): terminate the adaptive barrier update on a tiny step (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,47 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `mu_strategy=adaptive` kept iterating at a frozen point instead of stopping (#512)
+
+- When the line search takes two consecutive steps so small that any nonzero
+  step length is floating-point noise, the barrier update gets one chance to
+  move μ. If it cannot, nothing else can change either: every later iteration
+  recomputes the same point. IPOPT stops there and reports *search direction
+  is becoming too small* — "solved to the best accuracy this problem allows".
+  With `mu_strategy=adaptive`, POUNCE did not stop; it kept going until it hit
+  `max_iter` and then reported *maximum iterations exceeded*, which reads as
+  "your model was too hard" when the truth is "we finished 280 iterations
+  ago". A code comment asserted that only the monotone update terminates this
+  way; upstream's adaptive update does too, at two places
+  (`IpAdaptiveMuUpdate.cpp:330-333` and `:377-380`), and both are now ported.
+- Measured on the existing fixture corpus with `mu_strategy=adaptive`.
+  `airport.nl` at `tol=1e-12` went from 300 iterations and *maximum
+  iterations exceeded* to 16 and a clean tiny-step exit — with the final
+  objective, dual infeasibility and constraint violation agreeing to every
+  digit printed, so the 284 extra iterations moved nothing. Twelve other
+  models in the same sweep stop between 7 and 20 iterations where they
+  previously burned the whole budget. At **default** tolerances the same
+  models keep their status and reach it 4–6× faster: `hs71_obj1e8.nl`
+  certifies the same optimum in 11 iterations rather than 70, the `jit1`
+  family in 15–20 rather than 73–77.
+- Nothing changes for the default `mu_strategy` (monotone) — the fixture
+  corpus is bit-identical there — and no model in the sweep traded a better
+  status for a worse one.
+- Restoration runs the same inner solve, so it gained the same exit, and that
+  exposed a hole underneath it: `resto_inner_solver`'s tiny-step
+  locally-infeasible gate excluded square problems, so a square model that is
+  genuinely infeasible lost its AMPL 200 verdict to *restoration failed*
+  (AMPL 500, Pyomo `internalSolverError`) whenever the inner solve reached its
+  stationary point by tiny step. Upstream throws local-infeasibility on that
+  branch (`IpRestoMinC_1Nrm.cpp:278-291`) with no test on problem shape, and
+  POUNCE now matches. This also fixes the same wrong verdict on the default
+  monotone path, where it was already reachable: #508's own probe model at
+  `tol=1e-12` reported 500 before this change and reports 200 now.
+- Found by source comparison against upstream rather than by a failing model;
+  the reproducers above were found afterwards, in the fixtures already in the
+  repository. Regression coverage in
+  `crates/pounce-cli/tests/issue_512_adaptive_tiny_step.rs`.
+
 ### Fixed — infeasible models reported `internalSolverError` because the infeasibility threshold was built from `tol` (#508)
 
 - On a model with no solution, POUNCE chooses between *converged to a point

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -1799,10 +1799,21 @@ impl IpoptAlgorithm {
         // tiny-step branch) and the entry mu — if μ can't reduce while
         // the flag is on, upstream `IpMonotoneMuUpdate.cpp:158-161`
         // throws TINY_STEP_DETECTED → STOP_AT_TINY_STEP, which we
-        // realise as a clean termination here. Only the monotone update
-        // throws: `IpAdaptiveMuUpdate.cpp` consumes the tiny-step flag
-        // via its `force_no_progress` path (fix μ, keep iterating), so
-        // the termination is gated on `terminates_on_tiny_step()`.
+        // realise as a clean termination here.
+        //
+        // Both updates terminate, by different routes (pounce#512).
+        // Monotone has one throw site covering its whole update, so the
+        // μ-unchanged comparison below reconstructs it exactly, gated on
+        // `terminates_on_tiny_step()`. `IpAdaptiveMuUpdate.cpp` throws at
+        // two specific sites (`:330-333`, `:377-380`) and merely fixes μ
+        // and keeps iterating elsewhere, so the comparison would over-fire
+        // there — on the no-bounds short-circuit, which returns before
+        // upstream even reads the flag, and on a free-mode oracle that
+        // re-picks the current μ. The adaptive update therefore raises
+        // `request_tiny_step_stop` at its own two sites and opts out of
+        // the comparison. (An earlier comment here claimed the adaptive
+        // update never self-terminates; it does — `force_no_progress` is
+        // what happens on the iterations that do *not* throw.)
         timing.update_barrier_parameter.start();
         let tiny_at_entry = self.data.borrow().tiny_step_flag;
         let mu_before = self.data.borrow().curr_mu;
@@ -1815,7 +1826,17 @@ impl IpoptAlgorithm {
         );
         self.data.borrow_mut().curr_mu = next_mu;
         timing.update_barrier_parameter.end();
-        if tiny_at_entry && mu_terminates_on_tiny && (next_mu - mu_before).abs() < Number::EPSILON {
+        let tiny_step_stop_requested = {
+            let mut d = self.data.borrow_mut();
+            let f = d.request_tiny_step_stop;
+            d.request_tiny_step_stop = false;
+            f
+        };
+        if tiny_step_stop_requested
+            || (tiny_at_entry
+                && mu_terminates_on_tiny
+                && (next_mu - mu_before).abs() < Number::EPSILON)
+        {
             return IterateOutcome::Terminate(SolverReturn::StopAtTinyStep);
         }
 

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -118,6 +118,24 @@ pub struct IpoptData {
     /// counterpart. See pounce#58.
     pub request_resto: bool,
 
+    /// Tiny-step termination request from the μ-update layer (pounce#512).
+    /// Upstream signals "problem solved to best possible numerical
+    /// accuracy" by throwing `TINY_STEP_DETECTED` from inside
+    /// `UpdateBarrierParameter`; a Rust port returns a μ instead, so the
+    /// two throw sites in `IpAdaptiveMuUpdate.cpp` (`:330-333` fixed
+    /// mode, `:377-380` on the free→fixed switch) raise this flag and
+    /// the main loop turns it into `SolverReturn::StopAtTinyStep`.
+    ///
+    /// The flag exists because the throw's exact branch matters:
+    /// "a tiny step was flagged and μ came back unchanged" is also true
+    /// on adaptive paths where upstream does *not* throw (the no-bounds
+    /// short-circuit, and a free-mode oracle that happens to re-pick the
+    /// current μ), so it cannot be reconstructed from the μ values alone.
+    /// [`MonotoneMuUpdate`](crate::mu::monotone::MonotoneMuUpdate) has a
+    /// single throw site covering its whole update and is served by the
+    /// main loop's `terminates_on_tiny_step()` μ-comparison instead.
+    pub request_tiny_step_stop: bool,
+
     /// One-char marker the iteration output puts in front of
     /// `alpha_primal` (e.g. `'f'` for filter, `'r'` for restoration,
     /// `'h'` for the very first iterate). Mirrors
@@ -188,6 +206,7 @@ impl IpoptData {
             info_string: String::new(),
             tiny_step_flag: false,
             request_resto: false,
+            request_tiny_step_stop: false,
             info_alpha_primal_char: ' ',
             info_ls_count: 0,
             info_last_output: -1.0,

--- a/crates/pounce-algorithm/src/mu/adaptive.rs
+++ b/crates/pounce-algorithm/src/mu/adaptive.rs
@@ -436,6 +436,24 @@ impl AdaptiveMuUpdate {
         let new_mu = self.adaptive_mu_monotone_init_factor * avrg;
         new_mu.clamp(mu_min, self.mu_max)
     }
+
+    /// Upstream's tiny-step termination test (pounce#512), shared by the
+    /// two sites that throw `TINY_STEP_DETECTED` in
+    /// `IpAdaptiveMuUpdate.cpp` — `:330-333` in the fixed-mode
+    /// Fiacco-McCormick decrease and `:377-380` on the free→fixed switch.
+    /// Both read `tiny_step_flag && new_mu == mu`: a tiny step was
+    /// detected *and* the update could not move μ, so no further
+    /// progress is available and the honest exit is "problem solved to
+    /// best possible numerical accuracy" (`STOP_AT_TINY_STEP`) rather
+    /// than iterating to the limit.
+    ///
+    /// Exact equality, like upstream. Both callers reach "unchanged" by
+    /// clamping to the same bound, which is bit-exact; an epsilon band
+    /// would instead swallow a genuine — if minute — reduction and stop
+    /// an iteration early.
+    fn tiny_step_is_terminal(tiny_step_flag: bool, new_mu: Number, curr_mu: Number) -> bool {
+        tiny_step_flag && new_mu == curr_mu
+    }
 }
 
 impl MuUpdate for AdaptiveMuUpdate {
@@ -586,7 +604,18 @@ impl MuUpdate for AdaptiveMuUpdate {
 
         if !self.free_mu_mode {
             // Fixed-mu branch — `cpp:299-342`.
-            let sufficient_progress = !force_no_progress && self.check_sufficient_progress(cq);
+            //
+            // The gate is `sufficient_progress && !tiny_step_flag`
+            // (`cpp:304`) — plain `tiny_step_flag`, *not* the
+            // globalization-conditional `force_no_progress`, which
+            // upstream applies only in the free-mode branch below
+            // (`cpp:347-351`). Reusing `force_no_progress` here let
+            // `adaptive_mu_globalization=never-monotone-mode` switch back
+            // to free mode on a flagged tiny step, which upstream never
+            // does and which routed around the termination at `cpp:330`.
+            // At the default `obj-constr-filter` the two are equal, so
+            // this distinction only moves never-monotone-mode (pounce#512).
+            let sufficient_progress = !tiny_step_flag && self.check_sufficient_progress(cq);
             if sufficient_progress {
                 // Switch back to free mode and record the iterate —
                 // upstream `cpp:303-311`. Upstream does NOT return
@@ -611,6 +640,15 @@ impl MuUpdate for AdaptiveMuUpdate {
                     let lin = self.mu_linear_decrease_factor * curr_mu;
                     let sup = curr_mu.powf(self.mu_superlinear_decrease_power);
                     let new_mu = lin.min(sup).max(mu_min).min(self.mu_max);
+                    // `cpp:330-333` — a tiny step was flagged and the
+                    // decrease left μ where it was (it is pinned at the
+                    // floor), so there is nothing left to try. Upstream
+                    // throws TINY_STEP_DETECTED *before* `Set_mu`/`Set_tau`;
+                    // the flag is unchanged by construction, so returning
+                    // it below is the same iterate either way.
+                    if Self::tiny_step_is_terminal(tiny_step_flag, new_mu, curr_mu) {
+                        data.borrow_mut().request_tiny_step_stop = true;
+                    }
                     let new_tau = self.tau_min.max(1.0 - new_mu);
                     data.borrow_mut().curr_tau = new_tau;
                     return new_mu;
@@ -666,6 +704,15 @@ impl MuUpdate for AdaptiveMuUpdate {
                     }
                 }
                 let new_mu = self.new_fixed_mu(cq, mu_min);
+                // `cpp:377-380` — the same termination on the other
+                // throw site: the switch into fixed mode re-seeded μ to
+                // the value it already had, so the tiny step cannot be
+                // walked off by changing μ either. Ordered after the
+                // free-mode flip and the accepted-iterate restore, as
+                // upstream is.
+                if Self::tiny_step_is_terminal(tiny_step_flag, new_mu, curr_mu) {
+                    data.borrow_mut().request_tiny_step_stop = true;
+                }
                 let new_tau = self.tau_min.max(1.0 - new_mu);
                 data.borrow_mut().curr_tau = new_tau;
                 return new_mu;
@@ -971,6 +1018,39 @@ mod tests {
         // not propagate: `avrg > 0.0` is false for NaN, so we fall back.
         let mu_max = AdaptiveMuUpdate::lazy_mu_max(a.mu_max_fact, f64::NAN, a.mu_init, a.mu_min);
         assert!(mu_max.is_finite() && mu_max >= a.mu_min);
+    }
+
+    // pounce#512 — the shared condition behind both of upstream's
+    // `TINY_STEP_DETECTED` throws (`IpAdaptiveMuUpdate.cpp:330-333`,
+    // `:377-380`). Both conjuncts are load-bearing in opposite
+    // directions: without the flag the update is just at its floor and
+    // must keep iterating, and without the μ test a tiny step that the
+    // update *can* still respond to would stop the solve early.
+    #[test]
+    fn tiny_step_is_terminal_needs_the_flag_and_an_unmoved_mu() {
+        let mu = 1e-11;
+        assert!(AdaptiveMuUpdate::tiny_step_is_terminal(true, mu, mu));
+        // μ moved — the update has something left to try.
+        assert!(!AdaptiveMuUpdate::tiny_step_is_terminal(true, 0.2 * mu, mu));
+        // No tiny step: μ pinned at its floor is the ordinary end-game,
+        // not a reason to stop.
+        assert!(!AdaptiveMuUpdate::tiny_step_is_terminal(false, mu, mu));
+        assert!(!AdaptiveMuUpdate::tiny_step_is_terminal(
+            false,
+            0.2 * mu,
+            mu
+        ));
+    }
+
+    /// Equality is exact, as upstream's `new_mu == mu` is. A reduction of
+    /// one ulp is a reduction; an epsilon band would call it "unchanged"
+    /// and terminate an iteration early.
+    #[test]
+    fn tiny_step_is_terminal_does_not_round_a_reduction_away() {
+        let mu = 1e-11;
+        let nudged = mu - f64::EPSILON * 1e-4;
+        assert!(nudged < mu, "test setup: the nudge must actually reduce μ");
+        assert!(!AdaptiveMuUpdate::tiny_step_is_terminal(true, nudged, mu));
     }
 
     #[test]

--- a/crates/pounce-algorithm/src/mu/trait.rs
+++ b/crates/pounce-algorithm/src/mu/trait.rs
@@ -34,13 +34,22 @@ pub trait MuUpdate {
         pd_search_dir: Option<&mut PdSearchDirCalc>,
     ) -> Number;
 
-    /// Whether a flagged tiny step with μ unable to decrease should
-    /// terminate the algorithm with `STOP_AT_TINY_STEP`. Upstream
-    /// `IpMonotoneMuUpdate.cpp` throws `TINY_STEP_DETECTED` in exactly
-    /// that case; `IpAdaptiveMuUpdate.cpp` instead routes the tiny-step
-    /// flag through its `force_no_progress` path — it fixes μ and keeps
-    /// iterating, never self-terminating. Default `false` matches the
-    /// adaptive behaviour; `MonotoneMuUpdate` overrides to `true`.
+    /// Whether the main loop may infer `STOP_AT_TINY_STEP` from
+    /// "tiny-step flag set and μ came back unchanged".
+    ///
+    /// Upstream `IpMonotoneMuUpdate.cpp:158-161` throws
+    /// `TINY_STEP_DETECTED` in exactly that case, and it is the update's
+    /// only throw site, so the inference is exact — `MonotoneMuUpdate`
+    /// overrides to `true`.
+    ///
+    /// `IpAdaptiveMuUpdate.cpp` also terminates on a tiny step (`:330-333`
+    /// and `:377-380`), but only at those two sites; elsewhere it routes
+    /// the flag through `force_no_progress`, fixing μ and continuing. The
+    /// μ comparison cannot tell the two apart, so the adaptive update
+    /// signals its own termination through
+    /// [`IpoptData::request_tiny_step_stop`](crate::ipopt_data::IpoptData::request_tiny_step_stop)
+    /// and leaves this `false` (pounce#512). A `false` here means "does
+    /// not use the inference", not "never terminates".
     fn terminates_on_tiny_step(&self) -> bool {
         false
     }

--- a/crates/pounce-cli/tests/issue_512_adaptive_tiny_step.rs
+++ b/crates/pounce-cli/tests/issue_512_adaptive_tiny_step.rs
@@ -1,0 +1,232 @@
+//! gh #512 — the adaptive μ update must terminate on a tiny step.
+//!
+//! When the line search takes two consecutive steps so small that any
+//! nonzero α is floating-point noise, `IpoptData::tiny_step_flag` goes up
+//! and the barrier update gets one chance to move μ. If it cannot, the
+//! iterate is frozen: every later iteration recomputes the same point and
+//! the solve burns its budget standing still. Upstream stops there and
+//! says so — `TINY_STEP_DETECTED` → `STOP_AT_TINY_STEP`, "problem solved
+//! to best possible numerical accuracy".
+//!
+//! `IpMonotoneMuUpdate.cpp:158-161` throws once, and pounce reconstructed
+//! it from "flag was set, μ came back the same". `IpAdaptiveMuUpdate.cpp`
+//! throws in *two* places — `:330-333` after the fixed-mode
+//! Fiacco-McCormick decrease, `:377-380` on the free→fixed switch — and a
+//! comment in `ipopt_alg.rs` asserted the opposite, that the adaptive
+//! update only ever routes the flag through `force_no_progress` and keeps
+//! iterating. So `mu_strategy=adaptive` never stopped.
+//!
+//! The issue was filed from a source comparison, without a model. There
+//! are several already in this directory. `airport.nl` at `tol=1e-12`:
+//!
+//! ```text
+//!   before   300 iterations   Maximum_Iterations_Exceeded
+//!   after     16 iterations   Search_Direction_Becomes_Too_Small
+//! ```
+//!
+//! and the two runs' final objective, dual infeasibility and constraint
+//! violation agree to every digit printed — the 284 extra iterations moved
+//! nothing. `hs71_obj1e8.nl` shows the same at *default* tolerances (70 →
+//! 11), where iterations 11..70 are all tagged `T` at one frozen point.
+//!
+//! The tests below pin the invariant rather than those counts: **an
+//! adaptive-μ solve that reaches a flagged tiny step must stop there**,
+//! and must stop at a point no worse than the one it would have ground out
+//! at the iteration cap.
+//!
+//! Restoration is on the same hook — see
+//! `a_square_infeasible_model_survives_a_tiny_step_exit_from_restoration`,
+//! which guards the interaction with gh #508's verdict machinery.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pounce_cli::solve_report::SolveReport;
+use pounce_nlp::ApplicationReturnStatus;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn tmp_path(suffix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_issue512_{}_{}_{suffix}",
+        std::process::id(),
+        n
+    ));
+    p
+}
+
+fn solve(fixture_name: &str, extra_opts: &[&str]) -> SolveReport {
+    let json_path = tmp_path(&format!("{fixture_name}.json"));
+    let sol_path = tmp_path(&format!("{fixture_name}.sol"));
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(fixture(fixture_name))
+        .arg(&sol_path)
+        .arg("--json-output")
+        .arg(&json_path)
+        .arg("print_level=0");
+    for opt in extra_opts {
+        cmd.arg(opt);
+    }
+    let _ = cmd.status().expect("spawn pounce");
+    let text = std::fs::read_to_string(&json_path).expect("read json report");
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&sol_path);
+    serde_json::from_str(&text).expect("deserialize SolveReport")
+}
+
+/// The iteration cap the tight-tolerance runs are given. Small enough to
+/// keep the tests quick, large enough that hitting it means the solve was
+/// genuinely stuck rather than under-resourced — the fix stops these
+/// models inside 20 iterations.
+const MAX_ITER: &str = "max_iter=300";
+
+/// Tight-`tol` option set. `acceptable_tol` is pushed below anything
+/// reachable so the acceptable-level exit cannot pre-empt the tiny-step
+/// one and mask the behaviour under test.
+fn tight_adaptive() -> Vec<&'static str> {
+    vec![
+        "mu_strategy=adaptive",
+        "tol=1e-12",
+        "acceptable_tol=1e-15",
+        MAX_ITER,
+    ]
+}
+
+/// gh #512 proper. `airport.nl` settles onto a tiny step at iteration 16
+/// and cannot move μ again; before the fix it recomputed that same point
+/// until `max_iter`.
+///
+/// Asserted as "did not burn the budget", not as "returned status X": what
+/// the issue is about is the solve continuing past the point where nothing
+/// can change. Which of the honest terminal statuses it lands on is the
+/// certificate machinery's call, and both `StopAtTinyStep` and an upgrade
+/// to a solved status are correct answers to "you stopped in time".
+#[test]
+fn an_adaptive_solve_stops_at_a_flagged_tiny_step() {
+    let r = solve("airport.nl", &tight_adaptive());
+    assert_ne!(
+        r.solution.status,
+        ApplicationReturnStatus::MaximumIterationsExceeded,
+        "adaptive μ ran out the iteration budget at a frozen iterate \
+         instead of stopping at the tiny step (gh #512); \
+         iteration_count={}",
+        r.statistics.iteration_count,
+    );
+    assert!(
+        r.statistics.iteration_count < 300,
+        "iteration_count={} means the solve reached the cap; the tiny step \
+         is detected around iteration 16 and nothing after it moves",
+        r.statistics.iteration_count,
+    );
+}
+
+/// Direction guard, and the reason stopping early is not giving up: the
+/// point the solve stops at is converged. Passes before the fix too — the
+/// pre-fix run reaches the *same* point and then keeps recomputing it —
+/// which is exactly what makes it the right guard. If a future change
+/// makes the tiny-step exit fire somewhere genuinely unconverged, this
+/// fails while the test above still passes.
+#[test]
+fn the_tiny_step_exit_lands_on_a_converged_point() {
+    let r = solve("airport.nl", &tight_adaptive());
+    let s = &r.statistics;
+    assert!(
+        s.final_constr_viol < 1e-8,
+        "stopped at constraint violation {} — a tiny step is only a valid \
+         reason to stop if the iterate is feasible",
+        s.final_constr_viol,
+    );
+    assert!(
+        s.final_dual_inf < 1e-6,
+        "stopped at dual infeasibility {} — that is a stall, not \
+         convergence to best available accuracy",
+        s.final_dual_inf,
+    );
+}
+
+/// The same defect at **default** tolerances, where it costs iterations
+/// rather than a status. `hs71_obj1e8.nl` (HS71 × 1e8, the gh #266
+/// fixture) converges at iteration 11 and then, before the fix, spent
+/// iterations 11..70 re-deriving one frozen iterate — every row tagged `T`
+/// with an unchanged objective, `inf_pr` and `lg(mu)`.
+///
+/// The bound is deliberately loose: 11 after the fix, 70 before it.
+#[test]
+fn adaptive_does_not_grind_at_a_frozen_iterate_at_default_tolerances() {
+    let r = solve("hs71_obj1e8.nl", &["mu_strategy=adaptive"]);
+    assert!(
+        (0..100).contains(&r.solution.solve_result_num),
+        "expected the known optimum to be certified, got \
+         solve_result_num={} ({:?})",
+        r.solution.solve_result_num,
+        r.solution.status,
+    );
+    assert!(
+        r.statistics.iteration_count <= 35,
+        "iteration_count={} — the solve reaches its optimum at ~11 \
+         iterations and the rest are tiny steps at a point that no longer \
+         moves (gh #512)",
+        r.statistics.iteration_count,
+    );
+}
+
+/// The default `mu_strategy` is monotone, which already terminated on a
+/// tiny step through the main loop's μ-comparison. Nothing in gh #512
+/// touches that route; this pins the default path against a regression
+/// from the adaptive-side plumbing.
+#[test]
+fn the_monotone_route_is_untouched() {
+    let r = solve("hs71_obj1e8.nl", &[]);
+    assert!(
+        (0..100).contains(&r.solution.solve_result_num),
+        "default (monotone) solve regressed: solve_result_num={} ({:?})",
+        r.solution.solve_result_num,
+        r.solution.status,
+    );
+}
+
+/// Restoration runs the same inner IPM, so it acquired the same new exit —
+/// and gh #508's verdict machinery had a hole underneath it.
+///
+/// `issue_508_infeasible_gap_1em2.nl` is `min (x-5)² s.t. x²+1e-2 = 0`:
+/// square, and infeasible by a full percent. At `tol=1e-12` the inner
+/// restoration solve reaches its stationary point by tiny step rather than
+/// by a certified convergence, and `resto_inner_solver`'s tiny-step gate
+/// carried a `!is_square_problem` exclusion — so the verdict fell through
+/// to `Restoration_Failed`, AMPL 500, Pyomo `internalSolverError`. Upstream
+/// throws `LOCALLY_INFEASIBLE` on that branch (`IpRestoMinC_1Nrm.cpp:278-291`)
+/// with no test on problem shape.
+///
+/// Bites on the parent through the `monotone` arm, which could already
+/// reach the inner tiny-step exit; the `adaptive` arm guards the
+/// interaction gh #512 newly creates.
+#[test]
+fn a_square_infeasible_model_survives_a_tiny_step_exit_from_restoration() {
+    for strategy in ["mu_strategy=monotone", "mu_strategy=adaptive"] {
+        let r = solve(
+            "issue_508_infeasible_gap_1em2.nl",
+            &[strategy, "tol=1e-12", "acceptable_tol=1e-15", MAX_ITER],
+        );
+        assert_eq!(
+            r.solution.solve_result_num, 200,
+            "{strategy}: a model infeasible by 1e-2 must report local \
+             infeasibility (AMPL 200), got {} ({:?}) — 500 tells the user \
+             their solver broke (gh #508, #512)",
+            r.solution.solve_result_num, r.solution.status,
+        );
+    }
+}

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -709,10 +709,30 @@ pub fn run_inner_resto(
     // 10*outer_tol` (a threshold the inner cannot reach at tight `tol`,
     // which is exactly how the case arises); it uses the `alt` gate's
     // looser `1e-2` KKT ceiling to reject inners that stalled without
-    // ever approaching stationarity. `!is_square_problem` and the
-    // `constr_viol_tol` violation floor mirror `strict`.
-    let tiny_step_locally_infeasible = !is_square_problem
-        && matches!(status, SolverReturn::StopAtTinyStep)
+    // ever approaching stationarity. The `constr_viol_tol` violation floor
+    // mirrors `strict`.
+    //
+    // Unlike `strict`, this gate is NOT carved out for square problems
+    // (pounce#512). The two carve-outs looked alike but rest on different
+    // upstream branches. `strict`'s case is `resto_status == SUCCESS`
+    // (`IpRestoMinC_1Nrm.cpp:249-268`), which sets `retval = 0` — return
+    // the recovered point, render no verdict — so declaring infeasibility
+    // there is pounce-specific and rightly withheld on square problems.
+    // A tiny-step exit is upstream's *other* branch, `:278-291`:
+    //
+    //     else if( resto_status == STOP_AT_TINY_STEP || ... )
+    //        ... THROW_EXCEPTION(LOCALLY_INFEASIBLE, ...)
+    //
+    // which throws on any problem shape; the only square-specific test
+    // upstream has in this region (`:269`) is the *feasible* case, a
+    // `STOP_AT_ACCEPTABLE_POINT` below `constr_viol_tol`, and the
+    // violation floor below already excludes that. Carrying the exclusion
+    // here cost the #508 probe model — square, and infeasible by a full
+    // percent — its `LocalInfeasibility` verdict whenever the inner
+    // reached its stationary point by tiny step rather than by a
+    // certified convergence, which is what `tol=1e-12` produces: the
+    // honest AMPL 200 degraded to `Restoration_Failed`, AMPL 500.
+    let tiny_step_locally_infeasible = matches!(status, SolverReturn::StopAtTinyStep)
         && inner_kkt_err <= 1e-2
         && is_significant(orig_inf_pr_at_final, violation_scale, outer_constr_viol_tol)
         && orig_inf_pr_at_final.is_finite();


### PR DESCRIPTION
Fixes #512

## Problem

With `mu_strategy=adaptive`, a solve that reaches a flagged tiny step never stopped. It kept recomputing one frozen iterate until `max_iter`, then reported *maximum iterations exceeded* — "your model was too hard" — when the truth was "we finished 280 iterations ago".

The issue was filed from a source comparison, with no model ("I have not constructed a model that demonstrates it"). There were several already in `crates/pounce-cli/tests/fixtures/`. `airport.nl`, `mu_strategy=adaptive tol=1e-12 acceptable_tol=1e-15 max_iter=300`:

| | status | objective | inf_du | inf_pr | iters |
|---|---|---|---|---|---|
| before (`dc088d9`) | `Maximum_Iterations_Exceeded` | 4.7952701646951951e+04 | 9.4235776213748805e-13 | 5.5511151231257827e-16 | 300 |
| after | `Search_Direction_Becomes_Too_Small` | 4.7952701646951951e+04 | 9.4235776213748805e-13 | 5.5511151231257827e-16 | 16 |

Every reported KKT component agrees to the last digit — the 284 extra iterations moved nothing. `hs71_obj1e8.nl` shows the mechanism in the iteration table at **default** tolerances; rows 11 through 70 are all this row:

```
  11  1.7014017e+09 2.50e-07 1.73e-14  -12.1 1.18e-15      - 1.00e+00 1.00e+00T  0
  ...
  70  1.7014017e+09 2.50e-07 3.15e-14  -12.1 1.18e-15      - 1.00e+00 1.00e+00T  0
```

Same objective, same `inf_pr`, same `lg(mu)`, `T` (tiny step, flag set) every row. 71 function evaluations to reach what 13 reached.

## Cause

`crates/pounce-algorithm/src/ipopt_alg.rs` gated the tiny-step termination on `terminates_on_tiny_step()`, which only `MonotoneMuUpdate` sets, under this comment:

> Only the monotone update throws: `IpAdaptiveMuUpdate.cpp` consumes the tiny-step flag via its `force_no_progress` path (fix μ, keep iterating), so the termination is gated on `terminates_on_tiny_step()`.

That is wrong, and the issue is right about why. `IpAdaptiveMuUpdate.cpp` throws `TINY_STEP_DETECTED` in two places — `:330-333` after the fixed-mode Fiacco–McCormick decrease, `:377-380` on the free→fixed switch — both on `tiny_step_flag && new_mu == mu`. `force_no_progress` is what happens on the iterations that do **not** throw, which is presumably where the comment's reading came from.

## Fix

Both throw sites ported, with upstream's exact condition.

**Not** by flipping `terminates_on_tiny_step()` to `true` for the adaptive update, which was the obvious move and is wrong. The main loop's inference is "flag was set and μ came back unchanged", and for the adaptive update that is also true on paths where upstream does not throw:

- the no-bounds short-circuit (`cpp:292-295`), which returns *before* upstream even reads the flag, and unconditionally returns `mu_min` — so an iterate already at `mu_min` would falsely terminate;
- a free-mode oracle that happens to re-pick the current μ.

Monotone has a single throw site covering its whole update, so the inference is exact there and stays. The adaptive update instead raises `IpoptData::request_tiny_step_stop` at its own two sites, and the main loop turns that into `StopAtTinyStep`. The condition is factored into `AdaptiveMuUpdate::tiny_step_is_terminal` so both sites and the unit tests read the same predicate.

Equality is **exact** (`new_mu == curr_mu`), as upstream is, not the `(a-b).abs() < EPSILON` idiom the monotone comparison uses. Both callers reach "unchanged" by clamping to the same bound, which is bit-exact; at μ ≈ 1e-11 an absolute-epsilon band is a 2e-5 *relative* window and would swallow a genuine reduction, stopping an iteration early.

**Also ported: `cpp:304`'s fixed-mode gate.** Upstream's fixed-mode branch reads `sufficient_progress && !tiny_step_flag` — plain `tiny_step_flag`, not the globalization-conditional `force_no_progress`, which upstream applies only in the free-mode branch (`cpp:347-351`). Reusing `force_no_progress` here let `adaptive_mu_globalization=never-monotone-mode` switch back to free mode on a flagged tiny step, routing around the `cpp:330` termination. At the default `obj-constr-filter` the two expressions are equal, so this moves never-monotone-mode only. Stated plainly: **this half is unobserved** — I could not produce a corpus model where it changes an answer (in never-monotone-mode the free branch never hands control to fixed mode on these fixtures). It is in because it removes a real deviation from `cpp:304` and makes the fixed-mode throw reachable at all under that option, not because it fixed a measured symptom.

**Second defect, found by the fix and fixed with it.** Restoration runs the same inner IPM, so it acquired the same new exit — and `resto_inner_solver`'s tiny-step locally-infeasible gate carried a `!is_square_problem` exclusion. #508's own probe model is square. At `tol=1e-12` its inner restoration reaches the stationary point by tiny step rather than by certified convergence, the gate declined, and the verdict fell through to `Restoration_Failed` — AMPL 500, Pyomo `internalSolverError`, on a model infeasible by a full percent. Exactly the failure #509 had just removed, re-entering by another door.

The two square carve-outs look alike but rest on different upstream branches:

| gate | upstream branch | what upstream does |
|---|---|---|
| `strict` | `resto_status == SUCCESS` (`IpRestoMinC_1Nrm.cpp:249-268`) | `retval = 0` — return the recovered point, render no verdict |
| `tiny_step` | `resto_status == STOP_AT_TINY_STEP` (`:278-291`) | `THROW_EXCEPTION(LOCALLY_INFEASIBLE, ...)` |

So `strict`'s exclusion is right — declaring infeasibility there is pounce-specific and rightly withheld for square problems, per #509's reasoning. The tiny-step gate's is not: upstream throws on any problem shape, and the only square-specific test in that region (`:269`) is the *feasible* case, a `STOP_AT_ACCEPTABLE_POINT` below `constr_viol_tol`, which the gate's existing violation floor already excludes. Dropping it also fixes the same wrong verdict on the **default monotone** path, where it was already reachable pre-fix.

**Rejected: suppressing the tiny-step termination inside restoration.** It would have kept this PR to one file and dodged the verdict question entirely. Ruled out because upstream's restoration phase runs a full algorithm with its own μ update and does throw there — and because the wrong verdict is reachable on `main` today without this PR (monotone, `tol=1e-12`), so suppressing would have hidden a live bug rather than fixed one.

## Blast radius

Baseline `dc088d9` (this PR's parent), whole `.nl` fixture corpus, four sweeps, diffed on status and iteration count:

| sweep | fixtures that differ |
|---|---|
| **default options** (monotone, default tol) | **none — bit-identical** |
| adaptive, default tol | 4, all same status, 4–6× fewer iterations |
| adaptive, `tol=1e-12 acceptable_tol=1e-15 max_iter=300` | 13, all improvements |
| monotone, `tol=1e-12 acceptable_tol=1e-15 max_iter=300` | 1 — `issue_508_infeasible_gap_1em2.nl`, 500 → 200 |

No model in any sweep traded a better status for a worse one. The default path — the one nearly every user is on, since `mu_strategy` defaults to monotone — does not move at all.

Detail on the adaptive sweeps. Default tol, same status, faster: `hs71_obj1e8` 70 → 11, `jit1` 77 → 20, `jit1_boxed` 76 → 18, `jit1_node` 73 → 15. Tight tol, budget burn → clean exit: `airport` 300 → 16, `boxed_qp_fixed_var` 300 → 7, `linear_eq_aggregation` 300 → 7, `linear_eq_aggregation_row_constant` 300 → 7, `linear_eq_collapsed_box` 300 → 12, `nonconvex_qp` 300 → 8, `parametric` 300 → 11, `user_scaling_suffix` 300 → 9, `user_scaling_var_suffix` 300 → 9, plus the four above.

The 6×6 grid behind the restoration change (`{monotone, adaptive} × tol {1e-8, 1e-10, 1e-12} × {δ=1e-2, δ=1e-4}`) is unchanged from baseline in every cell but one, which improves: monotone / `tol=1e-12` / δ=1e-2, `Restoration_Failed` → `Converged to a point of local infeasibility`.

No CUTE corpus sweep — none is available in this environment. The fixture corpus and the suites below are the proxy.

## Tests

`crates/pounce-cli/tests/issue_512_adaptive_tiny_step.rs`, five tests off fixtures already in the repo — no new `.nl` vendored. Verified by reverting `crates/*/src` to `dc088d9` and keeping the tests:

| test | on parent |
|---|---|
| `an_adaptive_solve_stops_at_a_flagged_tiny_step` | **FAILED** — `iteration_count=300`, `Maximum_Iterations_Exceeded` |
| `adaptive_does_not_grind_at_a_frozen_iterate_at_default_tolerances` | **FAILED** — `iteration_count=70` |
| `a_square_infeasible_model_survives_a_tiny_step_exit_from_restoration` | **FAILED** — `mu_strategy=monotone` returns 500 (`RestorationFailed`) |
| `the_tiny_step_exit_lands_on_a_converged_point` | passes — direction guard |
| `the_monotone_route_is_untouched` | passes — default-path guard |

The two that pass pre-fix are deliberate. The first pins that stopping early is not giving up: the pre-fix run reaches the *same* point and then recomputes it, so the guard holds on both sides and fails only if a future change makes the exit fire somewhere genuinely unconverged. The second pins the default `mu_strategy` against regression from the adaptive-side plumbing.

Plus two unit tests on `tiny_step_is_terminal` in `mu::adaptive`, covering both conjuncts in both directions and the exact-equality choice (a one-ulp reduction is a reduction).

**Deliberately not pinned.** The `cpp:304` fixed-mode gate change has no test: it is unobservable on this corpus, as described under Fix. A test asserting the never-monotone-mode branch structure would pin the implementation rather than a behaviour, so the reasoning lives in the code comment at the site instead.

The assertions are invariants, not the measured counts — "did not reach the cap", "iteration_count ≤ 35" against 11 after and 70 before — so a platform that lands a couple of iterations either side still passes while the defect still fails.

Full workspace `cargo test` green (198 test binaries, 0 failures), except `pounce-hsl`, which cannot link its HSL system libraries in this container — the crate CI covers with a compile-check. `cargo fmt --all -- --check` clean; the CI clippy gate (`cargo clippy --workspace --exclude pounce-hsl --all-targets -- -D clippy::correctness -D clippy::suspicious`) clean; `scripts/check-release-consistency.sh` and `scripts/check-docs-consistency.sh` both OK.

---

- [x] Tests fail on the parent commit for the stated reason — three of five do, with the per-test breakdown and the one deliberate gap above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` updated — none needed; no user-facing option is added or renamed, and `mu_strategy` / `adaptive_mu_globalization` keep their documented meanings (this change makes the code honour upstream's semantics for them)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now