### PR TITLE
fix(options): read the options file — option_file_name and ./ipopt.opt (#518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,10 @@ changes.
   is refused (`Invalid_Option`) naming the alternative, rather than
   accepted and dropped. It was the blanket #483 refusal that covered this
   before; the guard now sits exactly where the feature still does not
-  reach. Those entry points deliberately do *not* gain the implicit
+  reach, and keeps that machinery's default gate — `option_file_name` set
+  to its registered `ipopt.opt` asks for nothing and still solves, so a
+  caller replaying a full option dump is unaffected. Those entry points
+  deliberately do *not* gain the implicit
   `./ipopt.opt` lookup: action at a distance under Python or the GAMS C
   link would be worse than not having it, and `pounce.opt` already means
   something else to GAMS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — options files were silently ignored: `option_file_name` configured nothing and `./ipopt.opt` was never read (#518)
+
+- `option_file_name=` was *refused* (it named a feature POUNCE did not
+  implement) and there was no implicit options-file lookup at all, so the
+  only way to configure a run from a file was `--options-file`. On 0.9.0,
+  as released, `option_file_name=` was accepted and did nothing: a run
+  configured entirely through an options file executed at stock defaults
+  and still reported success. Nothing in the output said so, which
+  silently invalidates any benchmark set up that way — and the POUNCE side
+  looks *better* precisely because it dropped the stricter settings.
+- `option_file_name=<path>` is now implemented, and `--options-file` is
+  the same thing spelled as a flag (the flag wins if both are given).
+- With no file named, POUNCE probes the working directory for
+  `pounce.opt`, then `ipopt.opt`, and reads the first that exists — the
+  `ipopt` behaviour the issue found most visibly missing. Both present:
+  `pounce.opt` wins and the shadowed file is named in a warning. The run
+  prints `Using option file "<path>".`, on the same `sb` gate as the
+  banner, so a discovered file cannot steer a solve anonymously.
+- `--no-options-file` skips the lookup, for a directory holding an options
+  file meant for some other run.
+- Precedence is unchanged and now uniform: command-line `KEY=VALUE` and
+  `$pounce_options` override the file, never the reverse.
+- A file that was *named* but cannot be read is an error rather than a
+  shrug — upstream's `ifstream` reads nothing and says nothing there,
+  which is the same silence in a smaller box. `option_file_name` set
+  *inside* an options file still chains nowhere (the file is chosen before
+  it is read), but now warns instead of being ignored.
+
 ### Fixed — `pounce verify` printed "complementarity residual" for a quantity that is not the solver's complementarity (#516)
 
 - `verify` computed *constraint* complementarity — `max_i |λ_i| · dist(g_i,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ changes.
   which is the same silence in a smaller box. `option_file_name` set
   *inside* an options file still chains nowhere (the file is chosen before
   it is read), but now warns instead of being ignored.
+- Naming two different files at once — `--options-file a.opt` beside
+  `option_file_name=b.opt`, or either beside `--no-options-file` — is an
+  error. A precedence rule there would mean one of the files the user
+  named was quietly not read, which is the reported failure reintroduced
+  by the fix for it.
+- **Library callers still cannot set it.** `option_file_name` reaches a
+  file only through the CLI's resolution path; Python, the C interface and
+  WASM set their options directly and read no files, so there the option
+  is refused (`Invalid_Option`) naming the alternative, rather than
+  accepted and dropped. It was the blanket #483 refusal that covered this
+  before; the guard now sits exactly where the feature still does not
+  reach. Those entry points deliberately do *not* gain the implicit
+  `./ipopt.opt` lookup: action at a distance under Python or the GAMS C
+  link would be worse than not having it, and `pounce.opt` already means
+  something else to GAMS.
 
 ### Fixed — `pounce verify` printed "complementarity residual" for a quantity that is not the solver's complementarity (#516)
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,9 @@ pounce problem.nl linear_solver=ma57       # with --features ma57
 ```
 
 Trailing `KEY=VALUE` pairs follow the same syntax and semantics as the
-upstream Ipopt CLI; they override values loaded from `--options-file`.
+upstream Ipopt CLI; they override values loaded from an options file —
+`--options-file <path>`, `option_file_name=<path>`, or a `pounce.opt` /
+`ipopt.opt` found in the working directory.
 
 List available built-in test problems:
 

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -1073,6 +1073,18 @@ impl IpoptApplication {
         if self.option_file_resolved {
             return None;
         }
+        // Same default gate as the table: an explicitly-set *default*
+        // asks for nothing, so it must not fail. `option_file_name`
+        // defaults to `ipopt.opt`, and a caller round-tripping a full
+        // option dump — or a generated config that spells out every
+        // registered name — hits that value without asking for anything.
+        if !crate::unimplemented_options::set_to_a_non_default(
+            &self.options,
+            &self.reg_options,
+            "option_file_name",
+        ) {
+            return None;
+        }
         match self.options.get_string_value("option_file_name", "") {
             Ok((name, true)) if !name.is_empty() => Some(format!(
                 "pounce: `option_file_name` was set to `{name}`, but this entry \

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -181,6 +181,14 @@ pub struct IpoptApplication {
     /// by default so library callers that never read the iterations
     /// vector don't pay the per-iter alloc.
     record_iter_history: bool,
+    /// Whether [`Self::initialize_with_option_file`] ran — i.e. whether
+    /// anything on this application actually consulted
+    /// `option_file_name` and resolved it to a file. Only the `pounce`
+    /// CLI does; a library caller sets its options directly. The guard
+    /// in [`Self::unhonored_option_file_name`] reads this so that
+    /// setting the option on a surface that cannot honor it is refused
+    /// rather than dropped (gh#518).
+    option_file_resolved: bool,
     /// Shared sink that the linear-solver backend writes a rolling
     /// [`LinearSolverSummary`] into after every factor. Reset at the
     /// top of every solve (so back-to-back `optimize_tnlp` calls don't
@@ -282,6 +290,7 @@ impl IpoptApplication {
             restoration_factory_provider: None,
             on_converged: None,
             record_iter_history: false,
+            option_file_resolved: false,
             linsol_summary_sink: Arc::new(Mutex::new(LinearSolverSummary::default())),
             sqp_warm_start: None,
             sqp_last_working_set: None,
@@ -433,6 +442,12 @@ impl IpoptApplication {
         explicit: Option<&Path>,
     ) -> Result<OptionFileLoad, SolverException> {
         let mut load = OptionFileLoad::default();
+        // Set before the early returns below: what this flag records is
+        // that `option_file_name` was *consulted*, not that a file turned
+        // up. A caller on this path who names nothing and has no
+        // `pounce.opt` to find still gets the option honored — there was
+        // simply nothing to read.
+        self.option_file_resolved = true;
         let path = match explicit {
             Some(p) => {
                 if !p.is_file() {
@@ -670,7 +685,13 @@ impl IpoptApplication {
         // implement is refused, not shrugged off. See
         // `unimplemented_options` for how membership was established and
         // why an explicitly-set *default* is deliberately still allowed.
-        if let Some(msg) = self.unimplemented_option_refusal() {
+        // gh#518: same treatment for `option_file_name` on an entry point
+        // that cannot resolve it. Separate from the table above because
+        // the *feature* now exists — just not here.
+        if let Some(msg) = self
+            .unimplemented_option_refusal()
+            .or_else(|| self.unhonored_option_file_name())
+        {
             use pounce_common::journalist::JournalCategory;
             eprintln!("{msg}");
             self.journalist.print(
@@ -1030,6 +1051,39 @@ impl IpoptApplication {
     /// `optimize_tnlp`. See [`crate::unimplemented_options`].
     pub fn unimplemented_option_refusal(&self) -> Option<String> {
         crate::unimplemented_options::refusal(&self.options, &self.reg_options)
+    }
+
+    /// `option_file_name` set on a surface that never resolves it.
+    ///
+    /// The option reaches a file through exactly one path —
+    /// [`Self::initialize_with_option_file`], which the `pounce` CLI
+    /// drives. A library caller (Python, the C interface, WASM) sets its
+    /// options directly and calls no such thing, so on those surfaces the
+    /// option names a whole configuration and applies none of it: gh#518's
+    /// failure mode, one surface over. It used to be caught by the blanket
+    /// [`crate::unimplemented_options`] refusal, which no longer covers it
+    /// now that the feature exists; this keeps the guard exactly where the
+    /// feature still doesn't.
+    ///
+    /// Deliberately *not* fixed by having the library read an options file
+    /// too: an implicit `./ipopt.opt` lookup under Python or the GAMS C
+    /// link would be a surprising action at a distance, and `pounce.opt`
+    /// already means something else to GAMS.
+    pub fn unhonored_option_file_name(&self) -> Option<String> {
+        if self.option_file_resolved {
+            return None;
+        }
+        match self.options.get_string_value("option_file_name", "") {
+            Ok((name, true)) if !name.is_empty() => Some(format!(
+                "pounce: `option_file_name` was set to `{name}`, but this entry \
+                 point does not read options files — it would configure nothing. \
+                 The `pounce` CLI honors it (and `./pounce.opt` / `./ipopt.opt`); \
+                 from a library, read the file yourself and pass its contents to \
+                 `initialize_with_options_str`, or set the options directly. \
+                 Tracking issue: https://github.com/jkitchin/pounce/issues/518"
+            )),
+            _ => None,
+        }
     }
 
     /// Warnings for caching hints pounce does not exploit. These never

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -30,6 +30,32 @@ use crate::iterates_vector::IteratesVector;
 use crate::restoration::RestorationPhase;
 use crate::upstream_options::register_all_upstream_options;
 
+/// Options-file names probed in the working directory when the caller
+/// names none, in probe order: pounce's own name first, then upstream's
+/// so an `ipopt.opt` written for Ipopt is honored unchanged.
+///
+/// Upstream probes only `ipopt.opt` (the registered default of
+/// `option_file_name`). Both are read here because a port that answers
+/// to `ipopt.opt` but not to its own name is the more surprising of the
+/// two behaviours — and gh#518 reported trying both.
+pub const DEFAULT_OPTION_FILE_NAMES: &[&str] = &["pounce.opt", "ipopt.opt"];
+
+/// What [`IpoptApplication::initialize_with_option_file`] did — enough
+/// for a caller to tell the user which file (if any) configured the run.
+#[derive(Debug, Default, Clone)]
+pub struct OptionFileLoad {
+    /// The file actually read. `None` means no options file was read:
+    /// nobody named one and neither default was present.
+    pub path: Option<PathBuf>,
+    /// Whether [`Self::path`] was named by the caller rather than found
+    /// by probing the working directory.
+    pub explicit: bool,
+    /// Non-fatal notes about option-file settings that did *not* take
+    /// effect. Nothing here stops a solve; the point is that it not
+    /// happen silently.
+    pub warnings: Vec<String>,
+}
+
 /// Factory that constructs a fresh restoration-phase strategy on
 /// demand. The outer algorithm owns at most one restoration object,
 /// so the factory is invoked once per `optimize_tnlp` call. The
@@ -95,7 +121,7 @@ use pounce_nlp::tnlp_adapter::{
 };
 use std::cell::RefCell;
 use std::fmt;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
@@ -384,6 +410,88 @@ impl IpoptApplication {
     /// `pounce` binaries opt in when `--json-output` is passed.
     pub fn enable_iter_history(&mut self) {
         self.record_iter_history = true;
+    }
+
+    /// Read the run's options file, resolving *which* file the way
+    /// upstream's `IpoptApplication::Initialize` does — with one
+    /// deliberate difference, below.
+    ///
+    /// `explicit` is the file the caller named (upstream: the
+    /// `option_file_name` option, read out of the option store before
+    /// this point). With `None`, the working directory is probed for
+    /// [`DEFAULT_OPTION_FILE_NAMES`] and the first hit is read; an
+    /// absent default file is not an error, it just means "no file".
+    ///
+    /// The difference: upstream opens a named file with a bare
+    /// `std::ifstream` and reads nothing if the open fails, so a typo'd
+    /// `option_file_name` runs at stock defaults without a word. That
+    /// silence is what gh#518 was reported for — a benchmark that
+    /// measured defaults while claiming to measure a configuration — so
+    /// a named file that cannot be read is an error here.
+    pub fn initialize_with_option_file(
+        &mut self,
+        explicit: Option<&Path>,
+    ) -> Result<OptionFileLoad, SolverException> {
+        let mut load = OptionFileLoad::default();
+        let path = match explicit {
+            Some(p) => {
+                if !p.is_file() {
+                    return Err(SolverException::new(
+                        ExceptionKind::IPOPT_APPLICATION_ERROR,
+                        format!(
+                            "options file \"{}\" does not exist. It was named by \
+                             --options-file / option_file_name, so the run would \
+                             otherwise proceed at stock defaults with none of its \
+                             settings applied.",
+                            p.display()
+                        ),
+                        file!(),
+                        line!() as Index,
+                    ));
+                }
+                load.explicit = true;
+                p.to_path_buf()
+            }
+            None => {
+                let present: Vec<&&str> = DEFAULT_OPTION_FILE_NAMES
+                    .iter()
+                    .filter(|n| Path::new(n).is_file())
+                    .collect();
+                let Some(first) = present.first() else {
+                    return Ok(load);
+                };
+                // Both default names in one directory: say which one lost,
+                // rather than let the unread one look applied.
+                for other in &present[1..] {
+                    load.warnings.push(format!(
+                        "`{first}` and `{other}` are both present; reading `{first}` \
+                         only (pounce's own name wins). Pass \
+                         `option_file_name={other}` to read that one instead."
+                    ));
+                }
+                PathBuf::from(**first)
+            }
+        };
+        self.initialize_with_options_file(&path)?;
+        // `option_file_name` set *inside* an options file chains nowhere —
+        // by the time it is read, the file naming it has already been
+        // chosen. Upstream documents that ("it does not make any sense to
+        // specify this option within the options file") and then ignores
+        // it; name it instead, since an ignored setting that looks live is
+        // the whole complaint behind gh#518.
+        if let Ok((named, true)) = self.options.get_string_value("option_file_name", "")
+            && !named.is_empty()
+            && Path::new(&named) != path
+        {
+            load.warnings.push(format!(
+                "`{}` sets option_file_name to `{named}`, which has no effect: \
+                 the options file is chosen before it is read. Pass \
+                 `option_file_name={named}` on the command line to read that file.",
+                path.display()
+            ));
+        }
+        load.path = Some(path);
+        Ok(load)
     }
 
     /// Read an `ipopt.opt`-format options file. Equivalent to

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -46,6 +46,12 @@
 //! one — has no counterpart here at all, and the port registered its
 //! whole option set. Those are refused.
 //!
+//! An entry leaves the table by being implemented. `option_file_name`
+//! was here — refusing it was the cheap half of gh#518's "implement it
+//! or fail loudly" — until gh#518 got the other half:
+//! [`crate::application::IpoptApplication::initialize_with_option_file`]
+//! reads the named file, so the option now configures something.
+//!
 //! # The default gate
 //!
 //! Only an explicit value **different from the registered default** is
@@ -162,12 +168,6 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         feature: "the linear-variable count hint for L-BFGS",
         advice: "",
         options: &["num_linear_variables"],
-    },
-    UnimplementedFeature {
-        feature: "reading options from a file",
-        advice: "pass options on the command line (`pounce model.nl key=value`) \
-                 or, from a library, via `initialize_with_options_str`",
-        options: &["option_file_name"],
     },
     UnimplementedFeature {
         feature: "skipping the finalize-solution callback",
@@ -408,6 +408,18 @@ mod tests {
         let mut app = crate::application::IpoptApplication::new();
         app.initialize().unwrap();
         assert!(!app.algorithm_builder_from_options().fast_step_computation);
+    }
+
+    /// `option_file_name` left the table when gh#518 implemented the
+    /// feature it names. Refusing it again would be a regression in the
+    /// other direction: it now configures the run, so a user who sets it
+    /// gets what they asked for rather than an error.
+    #[test]
+    fn option_file_name_is_implemented_not_refused() {
+        let (mut opts, reg) = fixture();
+        opts.set_string_value("option_file_name", "tiny.opt", true, false)
+            .unwrap();
+        assert_eq!(refusal(&opts, &reg), None);
     }
 
     /// The restoration switches wired in gh#483 / #191 round 2. Each

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -411,15 +411,58 @@ mod tests {
     }
 
     /// `option_file_name` left the table when gh#518 implemented the
-    /// feature it names. Refusing it again would be a regression in the
-    /// other direction: it now configures the run, so a user who sets it
-    /// gets what they asked for rather than an error.
+    /// feature it names. Refusing it *from the table* again would be a
+    /// regression in the other direction: it now configures the run, so
+    /// a user who sets it gets what they asked for rather than an error.
     #[test]
-    fn option_file_name_is_implemented_not_refused() {
+    fn option_file_name_is_implemented_not_in_the_table() {
         let (mut opts, reg) = fixture();
         opts.set_string_value("option_file_name", "tiny.opt", true, false)
             .unwrap();
         assert_eq!(refusal(&opts, &reg), None);
+    }
+
+    /// …but leaving the table must not hand the option back its silence
+    /// on the surfaces that still cannot honor it. Only
+    /// `initialize_with_option_file` resolves it, and library callers
+    /// (Python, the C interface, WASM) never call it — so there, setting
+    /// the option is still refused, just by a different guard.
+    #[test]
+    fn option_file_name_is_refused_where_nothing_resolves_it() {
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize().unwrap();
+        assert_eq!(app.unhonored_option_file_name(), None, "unset asks nothing");
+
+        app.initialize_with_options_str("option_file_name tiny.opt\n")
+            .unwrap();
+        let msg = app
+            .unhonored_option_file_name()
+            .expect("a library caller cannot honor it");
+        assert!(msg.contains("tiny.opt"), "{msg}");
+        assert!(msg.contains("does not read options files"), "{msg}");
+        assert!(msg.contains("518"), "{msg}");
+    }
+
+    /// On the CLI's path the option *is* resolved, so the guard stays
+    /// quiet — including when the resolver finds no file to read, which
+    /// still means the option was honored (there was nothing to read).
+    #[test]
+    fn the_guard_is_quiet_once_the_option_file_path_has_run() {
+        let dir = std::env::temp_dir().join(format!("pounce_gh518_lib_{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("tiny.opt");
+        std::fs::write(&path, "max_iter 5\n").unwrap();
+
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize_with_option_file(Some(&path)).unwrap();
+        assert_eq!(app.unhonored_option_file_name(), None);
+        assert_eq!(
+            app.options().get_integer_value("max_iter", "").unwrap(),
+            (5, true),
+            "the file must actually have been read",
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// The restoration switches wired in gh#483 / #191 round 2. Each

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -210,7 +210,11 @@ pub const UNEXPLOITED_HINTS: &[&str] = &[
 /// Both halves matter. `found` alone would fire on an `ipopt.opt` that
 /// spells out a default; comparing values alone would fire on nothing,
 /// since an unset option *reads back* as its default.
-fn set_to_a_non_default(options: &OptionsList, reg: &RegisteredOptions, name: &str) -> bool {
+pub(crate) fn set_to_a_non_default(
+    options: &OptionsList,
+    reg: &RegisteredOptions,
+    name: &str,
+) -> bool {
     let Some(opt) = reg.get_option(name) else {
         return false;
     };
@@ -441,6 +445,19 @@ mod tests {
         assert!(msg.contains("tiny.opt"), "{msg}");
         assert!(msg.contains("does not read options files"), "{msg}");
         assert!(msg.contains("518"), "{msg}");
+    }
+
+    /// The default gate applies here too: `option_file_name` defaults to
+    /// `ipopt.opt`, so a caller replaying a full option dump sets that
+    /// value while asking for nothing. Failing them would break the same
+    /// compatibility the explicitly-set-default rule protects everywhere
+    /// else.
+    #[test]
+    fn option_file_name_at_its_default_asks_nothing_of_a_library_caller() {
+        let mut app = crate::application::IpoptApplication::new();
+        app.initialize_with_options_str("option_file_name ipopt.opt\n")
+            .unwrap();
+        assert_eq!(app.unhonored_option_file_name(), None);
     }
 
     /// On the CLI's path the option *is* resolved, so the guard stays

--- a/crates/pounce-cli/README.md
+++ b/crates/pounce-cli/README.md
@@ -33,11 +33,15 @@ cargo build -p pounce-cli --release --features ma57
 pounce problem.nl
 pounce problem.nl print_level=8 max_iter=500 tol=1e-10
 pounce problem.nl linear_solver=ma57            # with --features ma57
-pounce problem.nl --options-file ipopt.opt      # upstream-format options file
+pounce problem.nl --options-file tuned.opt      # upstream-format options file
+pounce problem.nl option_file_name=tuned.opt   # the Ipopt spelling; same thing
+pounce problem.nl --no-options-file            # ignore ./pounce.opt, ./ipopt.opt
 ```
 
 Trailing `KEY=VALUE` pairs follow the same syntax and semantics as the
-upstream Ipopt CLI; they override values loaded from `--options-file`.
+upstream Ipopt CLI; they override values loaded from the options file.
+With no options file named, `./pounce.opt` or `./ipopt.opt` is read if
+present, as `ipopt` reads `./ipopt.opt`.
 
 ### Degenerate / MPCC NLPs — ℓ₁-exact penalty-barrier wrapper
 
@@ -201,7 +205,8 @@ look-up. Trailing `KEY=VALUE` pairs are option overrides, not flags.
 |------|----------|-------|
 | `--problem` | `NAME` | Run a built-in TNLP. See `--list-problems`. |
 | `--nl-file` | `PATH` | Explicit form of the positional `.nl` argument; useful when scripting alongside other flags. |
-| `--options-file` | `PATH` | Upstream-format options file; trailing `KEY=VALUE` pairs override it. |
+| `--options-file` | `PATH` | Upstream-format options file; trailing `KEY=VALUE` pairs override it. Same as `option_file_name=PATH`. |
+| `--no-options-file` | — | Read no options file: skip the implicit `./pounce.opt` / `./ipopt.opt` lookup. |
 | `--sol-output` | `PATH` | Override the default `<input>.sol` output path. |
 | `--no-sol` | — | Suppress `.sol` writing entirely (used by harnesses that only consume `--json-output`). |
 | `--json-output` | `PATH` | Emit a `pounce.solve-report/v1` JSON report. |

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -771,21 +771,32 @@ impl Args {
     /// options beat file options, not the other way round — and
     /// `option_file_name` is itself one of those overrides.
     ///
-    /// Precedence: `--no-options-file` beats everything; then the
-    /// explicit `--options-file <path>` flag; then `option_file_name=`
-    /// (from the command line or `$pounce_options`, last occurrence
-    /// winning, as for every other `key=value`); otherwise probe the
-    /// working directory. Upstream reads `option_file_name` out of the
-    /// option store at the same point for the same reason.
+    /// `--options-file <path>` and `option_file_name=<path>` are two
+    /// spellings of one thing; `option_file_name=` may repeat, in which
+    /// case the last wins as it does for every other `key=value`. With
+    /// no file named, the working directory is probed. Upstream reads
+    /// `option_file_name` out of the option store at the same point for
+    /// the same reason.
     ///
-    /// Errors when `--no-options-file` is combined with a named file:
-    /// the two ask for opposite things, and guessing which one the user
-    /// meant is exactly the silence gh#518 is about.
+    /// Every way of asking for *two different things at once* is an
+    /// error rather than a precedence rule — `--no-options-file` beside
+    /// a named file, or the two spellings naming different files. A
+    /// precedence rule here would mean one of the two files the user
+    /// named was quietly not read, which is the failure gh#518 reports,
+    /// reintroduced by the fix for it.
     pub fn option_file_choice(&self) -> Result<OptionFileChoice, String> {
-        let named = self
-            .options_file
-            .clone()
-            .or_else(|| self.option_file_name_override());
+        let named = match (&self.options_file, self.option_file_name_override()) {
+            (Some(flag), Some(kv)) if *flag != kv => {
+                return Err(format!(
+                    "--options-file '{}' and option_file_name={} name different \
+                     options files; only one is read, so pass one or the other",
+                    flag.display(),
+                    kv.display()
+                ));
+            }
+            (Some(flag), _) => Some(flag.clone()),
+            (None, kv) => kv,
+        };
         match (self.no_options_file, named) {
             (true, Some(p)) => Err(format!(
                 "--no-options-file conflicts with the options file '{}' named on \
@@ -998,8 +1009,26 @@ mod tests {
         );
     }
 
+    /// The two spellings agreeing is fine; disagreeing is an error, not
+    /// a precedence rule — picking a winner would silently not read the
+    /// other file the user named.
     #[test]
-    fn options_file_flag_beats_option_file_name() {
+    fn the_two_spellings_may_agree() {
+        let a = Args::parse_argv(argv(&[
+            "/tmp/foo.nl",
+            "--options-file",
+            "same.opt",
+            "option_file_name=same.opt",
+        ]))
+        .unwrap();
+        assert_eq!(
+            a.option_file_choice(),
+            Ok(OptionFileChoice::Named(PathBuf::from("same.opt")))
+        );
+    }
+
+    #[test]
+    fn the_two_spellings_disagreeing_is_rejected() {
         let a = Args::parse_argv(argv(&[
             "/tmp/foo.nl",
             "--options-file",
@@ -1007,10 +1036,8 @@ mod tests {
             "option_file_name=kv.opt",
         ]))
         .unwrap();
-        assert_eq!(
-            a.option_file_choice(),
-            Ok(OptionFileChoice::Named(PathBuf::from("flag.opt")))
-        );
+        let err = a.option_file_choice().unwrap_err();
+        assert!(err.contains("flag.opt") && err.contains("kv.opt"), "{err}");
     }
 
     #[test]

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -9,10 +9,33 @@ pub enum ProblemSource {
     NlFile(PathBuf),
 }
 
+/// Which options file a run should read, decided from argv (and
+/// `$pounce_options`) *before* any file is opened. See
+/// [`Args::option_file_choice`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptionFileChoice {
+    /// The user named a file: `--options-file <path>` or
+    /// `option_file_name=<path>`. A named file that does not exist is a
+    /// hard error — silently running at stock defaults is the failure
+    /// mode this whole path exists to remove (gh#518).
+    Named(PathBuf),
+    /// Nobody named one: probe the working directory for the default
+    /// names (`pounce.opt`, then `ipopt.opt`), reading whichever exists.
+    Discover,
+    /// `--no-options-file`: read none, probe nothing.
+    Suppressed,
+}
+
 #[derive(Debug, Clone)]
 pub struct Args {
     pub problem: ProblemSource,
     pub options_file: Option<PathBuf>,
+    /// `--no-options-file` — read no options file at all: neither an
+    /// implicit `pounce.opt` / `ipopt.opt` from the working directory nor
+    /// anything named by `option_file_name`. The escape hatch for a
+    /// directory holding an options file written for another run (or for
+    /// Ipopt), since that file is otherwise picked up automatically.
+    pub no_options_file: bool,
     /// `key=value` options collected from the command line. Forwarded to
     /// the application's `OptionsList` after the options-file load (so
     /// CLI args override file values), mirroring upstream ipopt's
@@ -257,6 +280,13 @@ Options may also be supplied via the `pounce_options` environment
 variable (AMPL's `<solver>_options` convention): a whitespace-separated
 list of KEY=VALUE tokens. Command-line KEY=VALUE options override it.
 
+Options are also read from an ipopt.opt-format options file: the one
+named by --options-file or by option_file_name=<path>, or — when
+neither names one — `pounce.opt` or `ipopt.opt` from the working
+directory, if present. A named file that does not exist is an error.
+KEY=VALUE options (command line or environment) override the file.
+--no-options-file reads none.
+
 Subcommands:
   pounce verify <problem.nl> <claim.sol> [--feas-tol T] [--json-output P]
                             independently check that a .sol solution
@@ -292,6 +322,10 @@ Required (one of):
 
 Options:
   --options-file <path>     read solver options from an ipopt.opt-format file
+                            (same as option_file_name=<path>)
+  --no-options-file         read no options file at all — skip the implicit
+                            pounce.opt / ipopt.opt lookup in the working
+                            directory
   --json-output <path>      write a JSON solve report to PATH after the solve
                             (pounce#8 — machine-readable, FAIR-aligned)
   --json-detail LEVEL       summary | full (default: summary). `full` adds
@@ -402,6 +436,7 @@ Multistart / find-minima (search for several local minima, not one):
     pub fn parse_argv(argv: Vec<String>) -> Result<Self, String> {
         let mut problem: Option<ProblemSource> = None;
         let mut options_file: Option<PathBuf> = None;
+        let mut no_options_file = false;
         let mut set_options: Vec<(String, String)> = Vec::new();
         let mut json_output: Option<PathBuf> = None;
         let mut json_detail = crate::solve_report::ReportDetail::Summary;
@@ -503,6 +538,7 @@ Multistart / find-minima (search for several local minima, not one):
                         .ok_or_else(|| "--options-file requires a value".to_string())?;
                     options_file = Some(PathBuf::from(v));
                 }
+                "--no-options-file" => no_options_file = true,
                 "--dump" => {
                     let v = it
                         .next()
@@ -667,6 +703,7 @@ Multistart / find-minima (search for several local minima, not one):
             return Ok(Self {
                 problem,
                 options_file,
+                no_options_file,
                 set_options,
                 json_output,
                 json_detail,
@@ -697,6 +734,7 @@ Multistart / find-minima (search for several local minima, not one):
         Ok(Self {
             problem: ProblemSource::Builtin(String::new()),
             options_file,
+            no_options_file,
             set_options,
             json_output,
             json_detail,
@@ -722,6 +760,52 @@ Multistart / find-minima (search for several local minima, not one):
             debug_script,
             minima,
         })
+    }
+}
+
+impl Args {
+    /// Which options file this run should read.
+    ///
+    /// Decided before any file is opened, because the file has to be read
+    /// *before* the `key=value` overrides are applied — command-line
+    /// options beat file options, not the other way round — and
+    /// `option_file_name` is itself one of those overrides.
+    ///
+    /// Precedence: `--no-options-file` beats everything; then the
+    /// explicit `--options-file <path>` flag; then `option_file_name=`
+    /// (from the command line or `$pounce_options`, last occurrence
+    /// winning, as for every other `key=value`); otherwise probe the
+    /// working directory. Upstream reads `option_file_name` out of the
+    /// option store at the same point for the same reason.
+    ///
+    /// Errors when `--no-options-file` is combined with a named file:
+    /// the two ask for opposite things, and guessing which one the user
+    /// meant is exactly the silence gh#518 is about.
+    pub fn option_file_choice(&self) -> Result<OptionFileChoice, String> {
+        let named = self
+            .options_file
+            .clone()
+            .or_else(|| self.option_file_name_override());
+        match (self.no_options_file, named) {
+            (true, Some(p)) => Err(format!(
+                "--no-options-file conflicts with the options file '{}' named on \
+                 the command line; pass one or the other",
+                p.display()
+            )),
+            (true, None) => Ok(OptionFileChoice::Suppressed),
+            (false, Some(p)) => Ok(OptionFileChoice::Named(p)),
+            (false, None) => Ok(OptionFileChoice::Discover),
+        }
+    }
+
+    /// The last `option_file_name=<path>` among the `key=value` options,
+    /// if any. Last-wins matches the order they are applied in.
+    fn option_file_name_override(&self) -> Option<PathBuf> {
+        self.set_options
+            .iter()
+            .rev()
+            .find(|(k, _)| k.eq_ignore_ascii_case("option_file_name"))
+            .map(|(_, v)| PathBuf::from(v))
     }
 }
 
@@ -877,6 +961,75 @@ mod tests {
     fn options_file_captured() {
         let a = Args::parse_argv(argv(&["--problem", "x", "--options-file", "ipopt.opt"])).unwrap();
         assert_eq!(a.options_file.unwrap().to_str(), Some("ipopt.opt"));
+    }
+
+    /// gh#518: which options file a run reads, decided from argv alone.
+    /// The filesystem end of it (the implicit lookup, a named file that
+    /// is missing) lives in `tests/issue_518_option_files.rs`.
+    #[test]
+    fn option_file_choice_defaults_to_discovery() {
+        let a = Args::parse_argv(argv(&["/tmp/foo.nl"])).unwrap();
+        assert_eq!(a.option_file_choice(), Ok(OptionFileChoice::Discover));
+    }
+
+    #[test]
+    fn option_file_choice_from_option_file_name() {
+        let a = Args::parse_argv(argv(&["/tmp/foo.nl", "option_file_name=tiny.opt"])).unwrap();
+        assert_eq!(
+            a.option_file_choice(),
+            Ok(OptionFileChoice::Named(PathBuf::from("tiny.opt")))
+        );
+    }
+
+    /// `set_options` are applied last-wins, so the file they name is too
+    /// — including a command-line value landing on top of one from
+    /// `$pounce_options` (which is merged in ahead of them).
+    #[test]
+    fn option_file_choice_takes_the_last_option_file_name() {
+        let a = Args::parse_argv(argv(&[
+            "/tmp/foo.nl",
+            "option_file_name=first.opt",
+            "option_file_name=second.opt",
+        ]))
+        .unwrap();
+        assert_eq!(
+            a.option_file_choice(),
+            Ok(OptionFileChoice::Named(PathBuf::from("second.opt")))
+        );
+    }
+
+    #[test]
+    fn options_file_flag_beats_option_file_name() {
+        let a = Args::parse_argv(argv(&[
+            "/tmp/foo.nl",
+            "--options-file",
+            "flag.opt",
+            "option_file_name=kv.opt",
+        ]))
+        .unwrap();
+        assert_eq!(
+            a.option_file_choice(),
+            Ok(OptionFileChoice::Named(PathBuf::from("flag.opt")))
+        );
+    }
+
+    #[test]
+    fn no_options_file_suppresses_discovery() {
+        let a = Args::parse_argv(argv(&["/tmp/foo.nl", "--no-options-file"])).unwrap();
+        assert!(a.no_options_file);
+        assert_eq!(a.option_file_choice(), Ok(OptionFileChoice::Suppressed));
+    }
+
+    #[test]
+    fn no_options_file_plus_a_named_file_is_rejected() {
+        let a = Args::parse_argv(argv(&[
+            "/tmp/foo.nl",
+            "--no-options-file",
+            "--options-file",
+            "tiny.opt",
+        ]))
+        .unwrap();
+        assert!(a.option_file_choice().is_err());
     }
 
     #[test]

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -280,14 +280,53 @@ pub fn main() -> ExitCode {
         app.enable_iter_history();
     }
 
-    if let Some(path) = &args.options_file {
-        if let Err(e) = app.initialize_with_options_file(path) {
-            eprintln!("pounce: failed to load options file: {e}");
+    // Load the options file before the `key=value` overrides below, so a
+    // command-line option beats a file option and not the other way round
+    // — which is also why `option_file_name` has to be read off argv here
+    // rather than out of the option store (upstream reads it from the
+    // store at this same point, before the store has the CLI's values).
+    //
+    // Until gh#518 the only way in was `--options-file`: `option_file_name`
+    // was refused, and the implicit `pounce.opt` / `ipopt.opt` lookup did
+    // not exist, so a run configured entirely through an option file ran
+    // at stock defaults and still reported success.
+    let option_file_choice = match args.option_file_choice() {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("pounce: {msg}");
             return ExitCode::from(2);
         }
-    } else if let Err(e) = app.initialize() {
-        eprintln!("pounce: initialize failed: {e}");
-        return ExitCode::from(2);
+    };
+    let mut option_file_read: Option<PathBuf> = None;
+    match &option_file_choice {
+        pounce_cli::cli::OptionFileChoice::Suppressed => {
+            if let Err(e) = app.initialize() {
+                eprintln!("pounce: initialize failed: {e}");
+                return ExitCode::from(2);
+            }
+        }
+        choice => {
+            let explicit = match choice {
+                pounce_cli::cli::OptionFileChoice::Named(p) => Some(p.as_path()),
+                _ => None,
+            };
+            match app.initialize_with_option_file(explicit) {
+                Ok(load) => {
+                    for warning in &load.warnings {
+                        eprintln!("pounce: warning: {warning}");
+                    }
+                    option_file_read = load.path;
+                }
+                Err(e) => {
+                    // `e.message` rather than the full `Display`: this one
+                    // is read by whoever wrote the options file, and the
+                    // C++-style "in file … at line …" prefix names a
+                    // pounce source location, not theirs.
+                    eprintln!("pounce: failed to load options file: {}", e.message);
+                    return ExitCode::from(2);
+                }
+            }
+        }
     }
 
     // Apply CLI `key=value` overrides after initialization, mirroring
@@ -444,6 +483,16 @@ pub fn main() -> ExitCode {
     if !suppress_banner && !json_dbg {
         print::print_logo();
         print::print_banner(backend_tag);
+    }
+    // Which options file configured this run, on the same `sb` gate as the
+    // banner (upstream prints its "Using option file" line here too). A
+    // discovered file especially has to announce itself: nothing on the
+    // command line hints that a `pounce.opt` sitting in the working
+    // directory is steering the solve.
+    if let Some(path) = &option_file_read {
+        if !suppress_banner && !json_dbg {
+            println!("Using option file \"{}\".\n", path.display());
+        }
     }
 
     // Snapshot the problem source as a string — needed downstream by

--- a/crates/pounce-cli/tests/issue_518_option_files.rs
+++ b/crates/pounce-cli/tests/issue_518_option_files.rs
@@ -1,0 +1,247 @@
+//! Options files actually configure the run (gh#518).
+//!
+//! `option_file_name=` used to be accepted and do nothing, and there was
+//! no implicit `ipopt.opt` lookup at all, so a run configured entirely
+//! through an options file executed at stock defaults *and reported
+//! success* — which silently invalidates any benchmark set up that way.
+//!
+//! Everything here is end-to-end for that reason: what matters is not
+//! that a file parses but that its settings reach the solve, so each
+//! test picks an option whose effect is unmistakable in the output
+//! (`max_iter 1` on a fixture that needs 11 iterations) and reads the
+//! verdict back off the console.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// Fresh scratch dir holding `m.nl`, a fixture that needs 11 iterations
+/// (so `max_iter 1` is a loud, deterministic signal). Runs happen *in*
+/// this directory: the implicit lookup probes the working directory.
+fn scratch(tag: &str) -> PathBuf {
+    static N: AtomicU64 = AtomicU64::new(0);
+    let seq = N.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("pounce_gh518_{}_{seq}_{tag}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/hs71_obj1e8.nl");
+    std::fs::copy(&fixture, dir.join("m.nl")).expect("copy fixture");
+    dir
+}
+
+fn write(dir: &Path, name: &str, body: &str) {
+    std::fs::write(dir.join(name), body).unwrap();
+}
+
+/// Run `pounce m.nl --no-sol <args>` with `dir` as the working
+/// directory. Returns (exit code, stdout+stderr).
+fn run(dir: &Path, args: &[&str]) -> (Option<i32>, String) {
+    let out = Command::new(pounce_exe())
+        .current_dir(dir)
+        .arg("m.nl")
+        .arg("--no-sol")
+        .args(args)
+        .output()
+        .expect("spawn pounce");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    (out.status.code(), combined)
+}
+
+const CAPPED: &str = "Maximum Number of Iterations Exceeded";
+
+#[test]
+fn option_file_name_is_honored() {
+    let dir = scratch("named");
+    write(&dir, "tiny.opt", "max_iter 1\n");
+    let (_, out) = run(&dir, &["option_file_name=tiny.opt"]);
+    assert!(out.contains(CAPPED), "tiny.opt was ignored; output:\n{out}");
+    assert!(
+        out.contains("Using option file \"tiny.opt\""),
+        "the run should say which file configured it; output:\n{out}"
+    );
+}
+
+/// The `--options-file` spelling of the same thing, which was the only
+/// way in before gh#518.
+#[test]
+fn options_file_flag_is_honored() {
+    let dir = scratch("flag");
+    write(&dir, "tiny.opt", "max_iter 1\n");
+    let (_, out) = run(&dir, &["--options-file", "tiny.opt"]);
+    assert!(out.contains(CAPPED), "tiny.opt was ignored; output:\n{out}");
+}
+
+/// Ipopt's documented default options file, read from the working
+/// directory with nothing on the command line pointing at it. This is
+/// the divergence from Ipopt the issue found most visible.
+#[test]
+fn implicit_ipopt_opt_is_read() {
+    let dir = scratch("implicit_ipopt");
+    write(&dir, "ipopt.opt", "max_iter 1\n");
+    let (_, out) = run(&dir, &[]);
+    assert!(
+        out.contains(CAPPED),
+        "./ipopt.opt was ignored; output:\n{out}"
+    );
+    assert!(
+        out.contains("Using option file \"ipopt.opt\""),
+        "a discovered file must announce itself — nothing on the command \
+         line hints it is steering the solve; output:\n{out}"
+    );
+}
+
+/// pounce's own name is probed first, and the shadowed file is named
+/// rather than left to look applied.
+#[test]
+fn pounce_opt_wins_over_ipopt_opt_and_says_so() {
+    let dir = scratch("both");
+    write(&dir, "pounce.opt", "max_iter 1\n");
+    write(&dir, "ipopt.opt", "max_iter 500\n");
+    let (_, out) = run(&dir, &[]);
+    assert!(
+        out.contains(CAPPED),
+        "pounce.opt should have won; output:\n{out}"
+    );
+    assert!(
+        out.contains("both present") && out.contains("ipopt.opt"),
+        "the unread file should be named; output:\n{out}"
+    );
+}
+
+/// Precedence, the direction that matters: a `key=value` typed on the
+/// command line beats the file, so an options file cannot silently
+/// override an explicit request.
+#[test]
+fn command_line_overrides_the_option_file() {
+    let dir = scratch("override");
+    write(&dir, "ipopt.opt", "max_iter 1\n");
+    let (code, out) = run(&dir, &["max_iter=3000"]);
+    assert_eq!(code, Some(0), "override solve failed; output:\n{out}");
+    assert!(
+        !out.contains(CAPPED),
+        "the file's max_iter beat the command line; output:\n{out}"
+    );
+}
+
+/// `$pounce_options` is the same layer as the command line, so it wins
+/// over the file too (AMPL passes directives that way).
+#[test]
+fn pounce_options_env_overrides_the_option_file() {
+    let dir = scratch("env");
+    write(&dir, "ipopt.opt", "max_iter 1\n");
+    let out = Command::new(pounce_exe())
+        .current_dir(&dir)
+        .arg("m.nl")
+        .arg("--no-sol")
+        .env("pounce_options", "max_iter=3000")
+        .output()
+        .expect("spawn pounce");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        !combined.contains(CAPPED),
+        "the file's max_iter beat $pounce_options; output:\n{combined}"
+    );
+}
+
+/// The failure mode the issue is about, in its remaining form: a file
+/// that was named but cannot be read configures nothing, so the run
+/// must stop rather than quietly proceed at defaults. (Upstream opens
+/// it with a bare ifstream and shrugs; this is the one deliberate
+/// divergence.)
+#[test]
+fn a_named_options_file_that_does_not_exist_is_an_error() {
+    let dir = scratch("missing");
+    let (code, out) = run(&dir, &["option_file_name=nope.opt"]);
+    assert_eq!(code, Some(2), "should fail; output:\n{out}");
+    assert!(
+        out.contains("nope.opt") && out.contains("does not exist"),
+        "the message should name the file; output:\n{out}"
+    );
+    assert!(
+        !out.contains("EXIT:"),
+        "the solve must not run; output:\n{out}"
+    );
+}
+
+/// A bad option name in a discovered file is rejected the same way one
+/// on the command line is — the file is genuinely read, not scanned.
+#[test]
+fn an_invalid_option_in_a_discovered_file_is_rejected() {
+    let dir = scratch("badopt");
+    write(&dir, "ipopt.opt", "definitely_not_an_option 1\n");
+    let (code, out) = run(&dir, &[]);
+    assert_eq!(code, Some(2), "should fail; output:\n{out}");
+    assert!(
+        out.contains("definitely_not_an_option"),
+        "the message should name the option; output:\n{out}"
+    );
+}
+
+/// `option_file_name` *inside* an options file chains nowhere — the
+/// file has already been chosen by then. Upstream ignores it silently;
+/// gh#518 is a report about exactly that class of silence.
+#[test]
+fn option_file_name_set_inside_a_file_warns() {
+    let dir = scratch("chain");
+    write(&dir, "ipopt.opt", "option_file_name other.opt\n");
+    write(&dir, "other.opt", "max_iter 1\n");
+    let (_, out) = run(&dir, &[]);
+    assert!(
+        out.contains("no effect") && out.contains("other.opt"),
+        "chaining should be called out; output:\n{out}"
+    );
+    assert!(
+        !out.contains(CAPPED),
+        "other.opt must not actually be read; output:\n{out}"
+    );
+}
+
+/// The escape hatch: a stale options file in the working directory must
+/// not be inescapable now that it is picked up automatically.
+#[test]
+fn no_options_file_skips_the_implicit_lookup() {
+    let dir = scratch("suppressed");
+    write(&dir, "ipopt.opt", "max_iter 1\n");
+    let (code, out) = run(&dir, &["--no-options-file"]);
+    assert_eq!(code, Some(0), "solve failed; output:\n{out}");
+    assert!(
+        !out.contains(CAPPED) && !out.contains("Using option file"),
+        "ipopt.opt should have been skipped; output:\n{out}"
+    );
+}
+
+#[test]
+fn no_options_file_conflicts_with_a_named_one() {
+    let dir = scratch("conflict");
+    write(&dir, "tiny.opt", "max_iter 1\n");
+    let (code, out) = run(&dir, &["--no-options-file", "option_file_name=tiny.opt"]);
+    assert_eq!(code, Some(2), "should fail; output:\n{out}");
+    assert!(out.contains("conflicts"), "output:\n{out}");
+}
+
+/// `sb yes` silences the banner; the option-file line rides the same
+/// gate, so a driver that suppresses the preamble still gets clean
+/// output.
+#[test]
+fn the_option_file_line_respects_sb() {
+    let dir = scratch("sb");
+    write(&dir, "ipopt.opt", "sb yes\n");
+    let (_, out) = run(&dir, &[]);
+    assert!(
+        !out.contains("Using option file"),
+        "sb yes should silence it; output:\n{out}"
+    );
+}

--- a/crates/pounce-cli/tests/issue_518_option_files.rs
+++ b/crates/pounce-cli/tests/issue_518_option_files.rs
@@ -223,6 +223,22 @@ fn no_options_file_skips_the_implicit_lookup() {
     );
 }
 
+/// Two spellings naming two files: reading one and dropping the other
+/// would be gh#518's failure reintroduced by the fix for it, so neither
+/// wins.
+#[test]
+fn the_two_option_file_spellings_may_not_disagree() {
+    let dir = scratch("two_names");
+    write(&dir, "a.opt", "max_iter 1\n");
+    write(&dir, "b.opt", "max_iter 1\n");
+    let (code, out) = run(&dir, &["--options-file", "a.opt", "option_file_name=b.opt"]);
+    assert_eq!(code, Some(2), "should fail; output:\n{out}");
+    assert!(
+        out.contains("a.opt") && out.contains("b.opt"),
+        "the message should name both; output:\n{out}"
+    );
+}
+
 #[test]
 fn no_options_file_conflicts_with_a_named_one() {
     let dir = scratch("conflict");

--- a/crates/pounce-cli/tests/unimplemented_options.rs
+++ b/crates/pounce-cli/tests/unimplemented_options.rs
@@ -59,7 +59,6 @@ fn requesting_an_unimplemented_feature_fails_with_an_explanation() {
         ("check_derivatives_for_naninf=yes", "NaN/Inf"),
         ("recalc_y=yes", "multiplier recalculation"),
         ("magic_steps=yes", "magic steps"),
-        ("option_file_name=other.opt", "reading options from a file"),
         ("suppress_all_output=yes", "output controls"),
         ("hsllib=libcoinhsl.so", "HSL loader"),
     ]

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -11,12 +11,16 @@ per-iteration table, and final summary, so anyone used to reading
 pounce problem.nl
 pounce problem.nl print_level=8 max_iter=500 tol=1e-10
 pounce problem.nl linear_solver=ma57            # with --features ma57
-pounce problem.nl --options-file ipopt.opt      # upstream-format options file
+pounce problem.nl --options-file tuned.opt      # upstream-format options file
+pounce problem.nl option_file_name=tuned.opt   # the Ipopt spelling; same thing
+pounce problem.nl --no-options-file            # ignore ./pounce.opt, ./ipopt.opt
 ```
 
 Trailing `KEY=VALUE` pairs follow the same syntax and semantics as the
-upstream Ipopt CLI; they override values loaded from `--options-file`.
-See [Solver Options](options.md).
+upstream Ipopt CLI; they override values loaded from the options file.
+With no options file named, `./pounce.opt` or `./ipopt.opt` is read if
+present, as `ipopt` reads `./ipopt.opt`. See
+[Solver Options](options.md).
 
 ## Built-in problems
 

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -12,14 +12,51 @@ and semantics follow Ipopt's, so an existing Ipopt options file or
 pounce problem.nl tol=1e-10 max_iter=500 print_level=8
 ```
 
-**From an options file** — upstream `ipopt.opt` format:
+**From an options file** — upstream `ipopt.opt` format (one `name value`
+pair per line, `#` comments):
 
 ```sh
-pounce problem.nl --options-file ipopt.opt
+pounce problem.nl --options-file tuned.opt
+pounce problem.nl option_file_name=tuned.opt   # the Ipopt spelling; same thing
 ```
 
-Command-line `KEY=VALUE` pairs override values loaded from the options
-file.
+**From an options file nobody named.** With neither of the above, POUNCE
+looks in the working directory for `pounce.opt`, then `ipopt.opt`, and
+reads the first one it finds — the way `ipopt` picks up `./ipopt.opt`:
+
+```sh
+printf 'max_iter 5\n' > ipopt.opt
+pounce problem.nl        # → Using option file "ipopt.opt".
+```
+
+The run says which file configured it (on the same `sb` gate as the
+banner). If both default names are present, `pounce.opt` wins and the
+other is named in a warning rather than left to look applied.
+`--no-options-file` skips the lookup entirely — the escape hatch for a
+directory holding an options file written for some other run.
+
+Command-line `KEY=VALUE` pairs — and `$pounce_options`, AMPL's
+`<solver>_options` channel — override values loaded from the options
+file, never the reverse.
+
+An options file that was *named* but cannot be read is an error, not a
+shrug:
+
+```
+$ pounce problem.nl option_file_name=typo.opt
+pounce: failed to load options file: options file "typo.opt" does not exist. …
+```
+
+Upstream opens a named file with a bare `ifstream` and reads nothing if
+that fails, so a typo there runs at stock defaults without a word. That
+silence is the one thing this path exists to remove
+([#518](https://github.com/jkitchin/pounce/issues/518)): a run configured
+entirely through an options file that quietly ran at defaults still
+*reported success*, which invalidates any benchmark set up that way.
+
+One upstream quirk is inherited: `option_file_name` set *inside* an
+options file chains nowhere, because the file has already been chosen by
+the time it is read. POUNCE warns about that rather than ignoring it.
 
 ## Commonly used options
 
@@ -71,9 +108,13 @@ line search, derivative approximation by finite differences,
 linear-dependency detection, the per-iteration NaN/Inf derivative check,
 multiplier recalculation by least squares, a selectable
 constraint-violation norm, magic steps, bound replacement, the L-BFGS
-augmented-system variants, reading options from a file, skipping the
-finalize callback, the dynamic HSL loader, and `suppress_all_output` /
-`debug_print_level`.
+augmented-system variants, skipping the finalize callback, the dynamic
+HSL loader, and `suppress_all_output` / `debug_print_level`.
+
+`option_file_name` was on that list until
+[#518](https://github.com/jkitchin/pounce/issues/518) implemented it;
+refusing an option is the cheap half of "implement it or fail loudly",
+and an entry leaves this table by getting the other half.
 
 Two deliberate exceptions:
 

--- a/python/tests/test_issue_518_option_file.py
+++ b/python/tests/test_issue_518_option_file.py
@@ -1,0 +1,95 @@
+"""gh#518 on the Python surface: `option_file_name` is not silently dropped,
+and the CLI's implicit options-file lookup does not leak into the library.
+
+#518 was reported against the CLI — an options file that configured nothing
+while the run reported success. The fix implements `option_file_name` *there*,
+which leaves this surface with two ways to reproduce the same failure:
+
+1. Options reach a file only through the CLI's resolution path. A Python
+   caller who sets `option_file_name` would otherwise get exactly the reported
+   bug — an option naming a whole configuration, applying none of it, and
+   still returning a solution. It is refused instead.
+2. The implicit `./pounce.opt` / `./ipopt.opt` lookup is deliberately *not*
+   extended here. A stray file in the working directory silently steering a
+   `pounce.Solver` call inside a notebook or a GAMS link would be action at a
+   distance, and worse than not having the lookup. The A/B below is the test
+   that keeps it that way.
+"""
+
+import os
+
+os.environ.setdefault("RUST_LOG", "off")
+
+import numpy as np
+import pytest
+
+import pounce
+
+
+class Quadratic:
+    """min (x-3)^2 over [-10, 10]; unconstrained, optimum x = 3."""
+
+    def objective(self, x):
+        return float((x[0] - 3.0) ** 2)
+
+    def gradient(self, x):
+        return np.array([2.0 * (x[0] - 3.0)])
+
+    def constraints(self, x):
+        return np.array([])
+
+    def jacobianstructure(self):
+        empty = np.array([], dtype=np.int64)
+        return empty, empty
+
+    def jacobian(self, x):
+        return np.array([])
+
+    def hessianstructure(self):
+        idx = np.array([0], dtype=np.int64)
+        return idx, idx
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([2.0 * obj_factor])
+
+
+def solve(**options):
+    p = pounce.Problem(
+        n=1, m=0, problem_obj=Quadratic(), lb=[-10.0], ub=[10.0], cl=[], cu=[]
+    )
+    p.add_option("print_level", 0)
+    p.add_option("sb", "yes")
+    for k, v in options.items():
+        p.add_option(k, v)
+    return pounce.Solver(p).solve(x0=np.array([0.0]))
+
+
+def test_option_file_name_is_refused_not_dropped():
+    """Naming a file the library will never read must not look like it worked."""
+    _, info = solve(option_file_name="tiny.opt")
+    assert info["status_msg"] == "Invalid_Option"
+
+
+def test_option_file_name_at_its_registered_default_still_solves():
+    """`ipopt.opt` is the registered default, so setting it asks for nothing —
+    the same rule that lets a generated options file spell out defaults."""
+    x, info = solve(option_file_name="ipopt.opt")
+    assert info["status_msg"] == "Solve_Succeeded"
+    assert x[0] == pytest.approx(3.0, abs=1e-6)
+
+
+def test_a_stray_options_file_does_not_steer_a_library_solve(tmp_path, monkeypatch):
+    """The CLI reads `./ipopt.opt`; the library must not. Same solve, run with
+    and without the file present — `max_iter 1` would be unmistakable if it
+    leaked (the solve needs more than one iteration)."""
+    monkeypatch.chdir(tmp_path)
+
+    x_clean, info_clean = solve()
+    assert info_clean["status_msg"] == "Solve_Succeeded"
+
+    (tmp_path / "ipopt.opt").write_text("max_iter 1\n")
+    (tmp_path / "pounce.opt").write_text("max_iter 1\n")
+    x_stray, info_stray = solve()
+
+    assert info_stray["status_msg"] == "Solve_Succeeded"
+    assert x_stray[0] == pytest.approx(x_clean[0], abs=1e-12)


### PR DESCRIPTION
Fixes #518

## Problem

An options file configured nothing. `option_file_name=` did not work and there was no implicit `./ipopt.opt` lookup, so `--options-file` was the only way in. A run configured entirely through an options file ran at stock defaults **and reported success**, with nothing in the output saying so — which silently invalidates any benchmark set up that way, and makes the POUNCE side look *better* precisely because it dropped the stricter settings.

Measured on `crates/pounce-cli/tests/fixtures/hs71_obj1e8.nl` with `max_iter 5` in the options file (the model needs 11 iterations at defaults):

| | `option_file_name=tiny.opt` | bare `./ipopt.opt` | iters | status |
|---|---|---|---|---|
| 0.9.0 as released | accepted, ignored | ignored | 11 | `Solve_Succeeded` |
| `main` today | **refused**, exit 2 | ignored | — | no solve |
| this PR | read | read | 5 | `Maximum_Iterations_Exceeded` |

The reporter's `ipopt` 3.14.16 comparison (5 iterations, honored, on their model) is theirs — no `ipopt` was run here.

Note the middle row: the refusal landed in #483 on 2026-08-05, after the 0.9.0 release of 2026-07-24, so `main` already did the cheap half of the issue's "implement it or fail loudly". The reporter is on 0.9.0 and saw the silence.

## Cause

Two independent gaps.

`option_file_name` sat in `unimplemented_options::UNIMPLEMENTED_FEATURES` as "reading options from a file" — seen by the #483 audit, categorized, and deliberately parked at *refuse* rather than *implement*.

The implicit lookup was never in scope of any audit. Both #191 and #483 swept the option *registry*: every finding started from a registered name, and #483's membership rule is "the name appears in no crate source outside the registry, and the feature is absent". "Read a file the user never named" has no registered name to be found by, so it was invisible to the shape of both sweeps. It surfaces only by diffing behaviour against `ipopt`, which is what the reporter did.

## Fix

- `option_file_name=PATH` is implemented; `--options-file PATH` is the same thing spelled as a flag.
- With no file named, probe the working directory for `pounce.opt`, then `ipopt.opt`, and read the first that exists. Both present: `pounce.opt` wins and the shadowed file is named in a warning. The run prints a `Using option file "pounce.opt".` line, on the same `sb` gate as the banner, so a discovered file cannot steer a solve anonymously.
- `--no-options-file` skips the lookup, for a directory holding a file meant for another run.
- Command-line `KEY=VALUE` and `$pounce_options` override the file, never the reverse. That is why the file is resolved from argv rather than from the option store — upstream reads `option_file_name` out of the store at this same point, before the store has the command line's values.
- A file that was *named* but cannot be read is an error. Upstream opens it with a bare `ifstream` and reads nothing if that fails; a typo there runs at stock defaults without a word, which is the reported silence in a smaller box. This is the one deliberate divergence.

**Rejected: a precedence rule for conflicting spellings.** `--options-file a.opt` beside `option_file_name=b.opt` first resolved to "flag wins" — which quietly does not read `b.opt`. That is the reported failure reintroduced by the fix for it, so naming two different files is now an error, as is `--no-options-file` beside a named file.

**Rejected: giving the library the same lookup.** Python, the C interface and WASM keep no implicit lookup. A stray `./ipopt.opt` steering a `pounce.Solver` call in a notebook would be action at a distance, and `pounce.opt` already means something else to the GAMS link.

## Blast radius

Behaviour changes for any CLI run in a directory containing `pounce.opt` or `ipopt.opt` — that file is now read where it was previously ignored. Intended, and the `ipopt` behaviour being matched, but it is the one way an existing invocation can change without the command line changing. `--no-options-file` is the opt-out, and the `Using option file` line means it is never silent.

Removing `option_file_name` from the refusal table would have handed it back its silence on every non-CLI surface, since the blanket `optimize_tnlp` guard was what covered Python/C/WASM. A targeted guard replaces it there, keyed on whether resolution actually ran, and keeps that machinery's default gate: `option_file_name` at its registered `ipopt.opt` asks for nothing and still solves.

Library solve paths are otherwise untouched — no change to the IPM, so no corpus sweep is implicated. `optimize_tnlp` gains one option read before the solve starts.

## Tests

**Rust — 13 end-to-end** (`crates/pounce-cli/tests/issue_518_option_files.rs`). Each asserts the setting reached the *solve*, not that the file parsed: `max_iter 1` against a fixture needing 11 iterations, verdict read off the console.

Run against the merge base `4a5dca8`: **9 of 13 fail**, for the stated reasons — `option_file_name_is_honored`, `implicit_ipopt_opt_is_read`, `pounce_opt_wins_over_ipopt_opt_and_says_so`, `option_file_name_set_inside_a_file_warns`, `a_named_options_file_that_does_not_exist_is_an_error`, `an_invalid_option_in_a_discovered_file_is_rejected`, `no_options_file_skips_the_implicit_lookup`, `no_options_file_conflicts_with_a_named_one`, `the_two_option_file_spellings_may_not_disagree`.

The other 4 pass on the merge base, and 3 of them pass *vacuously*: `command_line_overrides_the_option_file`, `pounce_options_env_overrides_the_option_file` and `the_option_file_line_respects_sb` are all trivially true when no file is read at all. They pin the precedence once a file *is* read. `options_file_flag_is_honored` covers the pre-existing `--options-file` path and is a guard, not a regression test.

**Rust — 7 argv-level** in `cli.rs` for the precedence rules without touching disk, and **4** in `unimplemented_options.rs`: the option left the refusal table, is still refused where nothing resolves it, is *not* refused at its registered default, and the guard goes quiet once resolution has run.

**Python — 3** (`python/tests/test_issue_518_option_file.py`), against a `maturin develop --release` build. These do **not** fail on the merge base — the blanket refusal covered that surface there. They pin the regression this branch's own first commit introduced, verified by building at `4cf88a4` and running them: `test_option_file_name_is_refused_not_dropped` fails there with `Solve_Succeeded` where `Invalid_Option` is required. The other two pass at `4cf88a4`; the A/B one (same solve with and without a `max_iter 1` file in the working directory, asserting bit-identical results) is what keeps the CLI's lookup out of the library path in future.

**Suites:** `cargo test -p pounce-cli -p pounce-algorithm` → 991 passed, 0 failed. `cargo build --workspace` clean. Python suite → 688 passed, 37 skipped, 0 failed. CI on this head: all 12 checks green.

**Known gap:** the C interface and WASM reach the same `optimize_tnlp` guard as Python, but only Python was exercised — those two are confirmed by source, not by execution.

A note on the debug build, since it cost time: running the Python suite against a plain `maturin develop` artifact segfaults in `test_nl_build.py::test_parsed_nl_deeper_than_the_caller_stack_would_take`, which deliberately recurses past depth 5 000. Larger debug frames overflow the stack; it passes on `--release`, which is what `make python-ext` builds. Unrelated to this change.

---

- [x] Tests fail on the parent commit for the stated reason — 9 of 13 CLI tests on `4a5dca8`; the Python guard tests fail on `4cf88a4` instead, as described above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`options.md`, `cli.md`; both already in `SUMMARY.md`)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now