### PR TITLE
dev-notes: the termination-status invariant, and the four holes it has had

### DIFF
--- a/.claude/commands/adversary.md
+++ b/.claude/commands/adversary.md
@@ -121,6 +121,54 @@ does not clearly discriminate. Keep all families moving.
   it. When a feature has a transparent fallback, assert that it *engaged*, not
   just that the answer is right.
 
+### Attack the option space, not only the problem space
+
+Everything above picks a *problem*. A whole class of defect is invisible to
+that, because it needs a **non-default option** to surface — and the run that
+found gh #508 was the one run that swept an option rather than choosing a new
+model. Treat the option grid as a target in its own right, worth roughly one
+run in four.
+
+The shape: take a model whose answer you already know (a previous PASS from the
+log is ideal — the answer is recorded and the formulation is already
+adjudicated), then sweep the options around it and assert that the *verdict*
+holds. Three probes, in order of yield:
+
+1. **Kill-switch ablation.** Every POUNCE-only heuristic — one with no upstream
+   Ipopt analogue — has an option that disables it: `infeas_stationarity_tol=0`
+   for rapid infeasibility detection, `presolve=no`, `acceptable_iter=0`,
+   `feral_ordering=…`. Run the model with each switch off and diff the verdict
+   against stock. **A model where *disabling* a heuristic improves the verdict
+   is a bug candidate, and the heuristic is the suspect.** This is also the
+   cheapest possible discriminator once something looks wrong: it isolates the
+   mechanism in one run, without an oracle and without reading any code.
+   gh #505's mechanism was settled by exactly this and nothing else.
+
+2. **Tolerance monotonicity, feasible direction.** Sweep each tolerance option
+   independently over 4–6 orders on a model known feasible, and assert the
+   verdict never crosses into the AMPL 200 (infeasible) or 500 (error) bands.
+   Tightening may legitimately cost iterations or downgrade
+   `Solved` → `Acceptable` → `MaxIter`; it must never manufacture an
+   infeasibility. gh #505 is precisely this failure: `constr_viol_tol=1e-6` on a
+   solved model produced `local infeasibility` at a point six orders inside
+   `acceptable_tol`.
+
+3. **Real driver option sets.** POUNCE's tests run at defaults; users do not.
+   Harvest the option sets that real stacks pass unconditionally — Pyomo
+   drivers, GAMS `option` blocks, the reporter scripts attached to filed issues
+   — and run the corpus under them. gh #505 needed `constr_viol_tol=1e-6`,
+   which the reporter's driver set on *every* solve, and which POUNCE's own
+   fixtures had never once set on a feasible model.
+
+Two properties make this arm strong. It needs **no oracle** — a verdict that
+moves when only an option moved is an internal contradiction in POUNCE's own
+semantics, which is the load-bearing evidence in both gh #505 and gh #508. And
+it needs **no new formulation**, so the usual "your script is wrong more often
+than the solver" risk largely disappears.
+
+Background and the standing invariants this arm defends:
+`dev-notes/termination-status-invariants.md`.
+
 ## Environment
 
 - **venv:** `source /Users/jkitchin/projects/pounce/.venv-qa/bin/activate`
@@ -200,6 +248,13 @@ for non-SOS; SOS degree small enough to stay under a few seconds); solvable in
 **< 10 s**; **not already in `adversary/log.org`**; not a near-duplicate of an
 existing `python/tests/` fixture. Record the **exact source** (paper/book page,
 equation, or URL) and the known optimum. Use web search if needed.
+
+**Option-sweep runs invert this step.** If the target is the option space (see
+"Attack the option space" above), do *not* find a new problem — reuse a model
+already logged as PASS, or one infeasible by exact construction, and let the
+option grid be the novelty. The known answer is already recorded, so the run
+spends its budget on coverage of the option space instead of on re-adjudicating
+a formulation.
 
 ### 3. Formulate as a runnable cross-check script
 Write `adversary/runs/YYYY-MM-DD_<family>_<name>.py`. It must:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ have (gh #505 is the worked example; see
   like confirmation. On gh #505 that fixture did reproduce *a* real defect,
   which was then assumed to be *the* defect; the reporter's own measurement
   falsified the route a day later, after a PR had already been opened on it.
+  The fixture was eventually dropped altogether — once the actual arming
+  condition was found and fixed (gh #519), it no longer reproduced anything.
   Reproduce on the reporter's artifact before writing the fix, and treat a
   purpose-built fixture as a regression test, never as a diagnosis.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,36 @@ Full contract and a worked transcript: **`docs/src/debugger.md`**
 `debug_session_guide` documents the underlying protocol (for callers
 driving `--debug-json` directly instead of through the proxy).
 
+## Debugging discipline
+
+Three rules, each earned on a solver bug that took far longer than it should
+have (gh #505 is the worked example; see
+`dev-notes/termination-status-invariants.md`).
+
+- **Run the kill switch first.** Most POUNCE-only heuristics can be disabled by
+  an option — `infeas_stationarity_tol=0`, `presolve=no`, `acceptable_iter=0`,
+  `nlp_scaling_method=none`. If one of them flips the outcome, that heuristic is
+  the mechanism, established in a single run with no oracle and no code reading.
+  On gh #505 this control was decisive and was not run until roughly eighteen
+  hours and fifteen comments into the investigation.
+
+- **A fixture built from a hypothesis is not evidence for that hypothesis.** A
+  reduced model constructed to sit in the regime a theory predicts will
+  reproduce the symptom whether or not the theory is right — and it will feel
+  like confirmation. On gh #505 that fixture did reproduce *a* real defect,
+  which was then assumed to be *the* defect; the reporter's own measurement
+  falsified the route a day later, after a PR had already been opened on it.
+  Reproduce on the reporter's artifact before writing the fix, and treat a
+  purpose-built fixture as a regression test, never as a diagnosis.
+
+- **Stamp every measurement with the commit it was taken on, when you take it.**
+  Numbers from two build sets get quoted across each other otherwise. That
+  happened twice on gh #505 — once publicly, caught by a reviewer who noticed a
+  "bit-identical" claim between two numbers that differed in the fourth digit.
+  When a correction lands, propagate it to *every* surface carrying the bad
+  number: issue comment, PR body, commit message, code comment. The PR body is
+  what survives as the merge commit.
+
 ## Repo conventions
 
 - Build: `cargo build --release` (CLI binary at `target/release/pounce`).

--- a/dev-notes/termination-status-invariants.md
+++ b/dev-notes/termination-status-invariants.md
@@ -1,0 +1,153 @@
+# Termination-status invariants
+
+One invariant has now been violated at four independent sites, and each was
+fixed in isolation as if it were a one-off. It is written here so the fifth one
+gets recognised as a recurrence rather than rediscovered.
+
+## The invariant
+
+> **Never claim infeasibility at a point the solver's own convergence test
+> would accept.**
+
+It is already stated in the source, at `pounce-restoration/src/resto_inner_solver.rs:756`,
+where it is enforced as a single admissibility guard over the six restoration
+gates:
+
+```rust
+let solver_would_call_it_feasible = orig_inf_pr_scaled <= outer_tol;
+let locally_infeasible = !solver_would_call_it_feasible && ( … six disjuncts … );
+```
+
+The comment on that guard is the point of this note:
+
+> *"Applied once to the combination rather than to each disjunct: the two
+> preceding safeguards in this area were each added to one path and not its
+> twin, and a hole survived both times."*
+
+It was applied to restoration and never generalised. Two more holes followed,
+in two other files.
+
+## The four holes
+
+| # | site | mechanism | fixed |
+|---|---|---|---|
+| gh #372 / #376 | restoration gates | scaled/unscaled units mismatch on `max(100·tol, 1e-4)` floors | 2026-07-22, guard above |
+| gh #385 / #390 | `conv_check` surrogate `‖Jᵀc‖/max(1,‖c‖)` | not scale-invariant; row scaling drives it to zero anywhere | no-descent confirmation |
+| gh #508 | `ipopt_alg.rs:2602` cycle exit | violation compared against a threshold built from `tol` | 097a4719 |
+| gh #505 | `conv_check/opt_error.rs:343` rapid detector | violation compared against `infeas_viol_kappa · constr_viol_tol` | PR #506 |
+
+Each was found by a different route, none by the guard that already existed.
+gh #505 came from an external reporter; gh #508 from an `/adversary` run
+attacking the same code from the opposite side, the same week.
+
+## Why gh #505 survived three releases
+
+The rapid-infeasibility detector landed in `8a711f34` (2026-05-20) and shipped
+in v0.7.0, v0.8.0 and v0.9.0. Four reinforcing reasons, each of which is a
+class of blind spot rather than an accident:
+
+1. **The defaults are safe by coincidence.** The detector's absolute arm fires
+   above `infeas_viol_kappa · constr_viol_tol` = `1e2 · 1e-4` = **1e-2**, which
+   is exactly `acceptable_constr_viol_tol` = **1e-2**. Two independently chosen
+   option defaults landing on the same number. Nothing in the code enforces the
+   equality; it just happens to hold, so at defaults the detector can only fire
+   *outside* the acceptable band. Tighten `constr_viol_tol` and the floor drops
+   inside the band while the band stays put — **asking for tighter feasibility
+   manufactures an infeasibility verdict.**
+
+2. **Every test ran at that coincidence.** Before PR #506 not one CLI test set
+   `constr_viol_tol` on a *feasible* model. `infeasible_status_tol_invariance.rs`
+   and `issue_508_infeasibility_gap_status.rs` sweep tolerances, but only on
+   infeasible models. The untested direction is precisely the one that broke.
+
+3. **The detector is POUNCE-only.** Upstream Ipopt has no equivalent, so no
+   differential test against Ipopt can see it at default options — the two
+   agree — and the divergence appears only in a feature the oracle does not
+   have.
+
+4. **The trigger was a user's driver, not a user's choice.** The reporter's
+   `paper_ocp.py` sets `constr_viol_tol=1e-6` on every solve. POUNCE's own
+   tests never sample the option distributions real drivers impose.
+
+## Enforcement
+
+Three checks, in cost order. The first two would have caught gh #505 in May.
+
+### 1. Global self-consistency postcondition (no oracle needed)
+
+Generalise `resto_inner_solver.rs:756` to every terminal status. At exit, this
+is a contradiction in POUNCE's own reported numbers:
+
+```
+status ∈ infeasible band
+  ∧ final scaled NLP error   ≤ acceptable_tol
+  ∧ final unscaled violation ≤ acceptable_constr_viol_tol
+```
+
+On gh #505's `f=1` reproducer, stock `main` reports local infeasibility at a
+scaled NLP error of **4.89e-10** against `acceptable_tol = 1e-3` — six orders
+inside the band. Ship it as a debug assert plus a CI sweep over the fixture
+corpus.
+
+### 2. Kill-switch ablation
+
+Every POUNCE-only heuristic has an option that disables it; the detector's is
+`infeas_stationarity_tol=0`. Run the corpus with each switch off and diff the
+verdicts. **Any model where disabling a heuristic improves the verdict is a bug
+candidate.** This single control settled gh #505 — disabling the detector
+produced output bit-identical to PR #506's fix on both architectures — and it
+was not run until roughly eighteen hours into the investigation. It should be a
+scheduled job, not something reached for during debugging.
+
+### 3. Tolerance monotonicity, in the feasible direction
+
+`infeasible_status_tol_invariance.rs` pins "an infeasible model's verdict must
+not depend on the user's `tol`". The missing mirror: **on a feasible model,
+tightening any tolerance must never produce an infeasible or error verdict.**
+Tightening may legitimately cost iterations, or downgrade `Solved` → `Acceptable`
+→ `MaxIter`. It must never cross into the 200 or 500 AMPL bands. Cost is the
+existing fixture corpus × ~6 tolerance options × ~6 values.
+
+## Two static audits worth doing once
+
+**Tolerance provenance.** Every numeric threshold compared against a constraint
+violation must be built from a constraint-violation tolerance; every threshold
+on a KKT error, from `tol`. gh #508 was a violation compared against
+`max(100·tol, 1e-4)`; gh #505 is the mirror — a violation compared against
+`1e2·constr_viol_tol`, gating a status that the acceptable band owns. Enumerate
+the `*_tol` reads in `conv_check/`, `ipopt_alg.rs` and `pounce-restoration/`
+together with the quantity each is compared against; the remaining instances
+are findable by inspection.
+
+**Default coincidences.** Enumerate derived thresholds that are numerically
+equal at defaults but not equal *by construction*. Each is a latent bug: safe
+today, broken by any user who moves one option. Either assert the equality as a
+test that explains why it must hold, or remove the coincidence by keying the
+threshold on a single option.
+
+## Route convergence
+
+PR #506 adds `terminate_local_infeasibility` plus a structural test asserting
+that no site in `ipopt_alg.rs` builds `IterateOutcome::Terminate(SolverReturn::LocalInfeasibility)`
+directly — two of the three routes had independently shipped the same defect of
+discarding the acceptable-point stash.
+
+Note the guard's real scope, which is narrower than its name suggests: it is a
+substring scan of one file. `rustfmt` wrapping the expression, or a temporary
+binding, defeats it, and `application.rs:1644` constructs the verdict on the
+elastic path outside its reach. It is a tripwire, not a proof.
+
+`ErrorInStepComputation` has the same shape and the same history (gh #372,
+gh #508) and has not had the equivalent treatment.
+
+## Reporting
+
+A POUNCE-only heuristic that overrides a user-configured exit should say so in
+the output. Had the banner read
+
+```
+local infeasibility (rapid detection: streak 5/5,
+  floor 1e2·constr_viol_tol = 1e-4 vs violation 1.9e-4)
+```
+
+gh #505 would have been diagnosed in one comment instead of twenty.

--- a/dev-notes/termination-status-invariants.md
+++ b/dev-notes/termination-status-invariants.md
@@ -33,12 +33,21 @@ in two other files.
 |---|---|---|---|
 | gh #372 / #376 | restoration gates | scaled/unscaled units mismatch on `max(100·tol, 1e-4)` floors | 2026-07-22, guard above |
 | gh #385 / #390 | `conv_check` surrogate `‖Jᵀc‖/max(1,‖c‖)` | not scale-invariant; row scaling drives it to zero anywhere | no-descent confirmation |
-| gh #508 | `ipopt_alg.rs:2602` cycle exit | violation compared against a threshold built from `tol` | 097a4719 |
-| gh #505 | `conv_check/opt_error.rs:343` rapid detector | violation compared against `infeas_viol_kappa · constr_viol_tol` | PR #506 |
+| gh #508 | `ipopt_alg.rs` cycle exit | violation compared against a threshold built from `tol` | 097a4719 |
+| gh #519 | `conv_check/opt_error.rs` rapid detector | violation compared against an unclamped `infeas_viol_kappa · constr_viol_tol` | PR #521, ef5d77e8 |
 
 Each was found by a different route, none by the guard that already existed.
 gh #505 came from an external reporter; gh #508 from an `/adversary` run
 attacking the same code from the opposite side, the same week.
+
+Note how the fourth one was finally stated. gh #505 is the *report* — a model
+returning local infeasibility at a point Ipopt accepts. gh #519 is the
+*defect*, filed separately once the arming condition was identified, and it is
+what actually fixed the reported symptom. PR #506, opened first and against an
+earlier hypothesis, was rescoped afterwards to the structural change it always
+should have been (below) and explicitly disclaims the fix. **The bug report and
+the defect are different objects; conflating them is what made #505 take four
+diagnoses to converge.**
 
 ## Why gh #505 survived three releases
 
@@ -55,10 +64,21 @@ class of blind spot rather than an accident:
    inside the band while the band stays put — **asking for tighter feasibility
    manufactures an infeasibility verdict.**
 
-2. **Every test ran at that coincidence.** Before PR #506 not one CLI test set
+   The strongest evidence was in the same file the whole time: the *relative*
+   arm one function up had exactly this hazard and was deliberately clamped
+   against it, `(100.0 · constr_viol_tol).max(1e-2)`, with a doc comment stating
+   the rule — *"too-loose withholds a verdict, too-tight fabricates one."* The
+   absolute arm was the same expression **without the `.max`**. Two arms of one
+   predicate, one hardened and one free to slide three orders below the floor.
+
+2. **Every test ran at that coincidence.** Not one CLI test set
    `constr_viol_tol` on a *feasible* model. `infeasible_status_tol_invariance.rs`
    and `issue_508_infeasibility_gap_status.rs` sweep tolerances, but only on
-   infeasible models. The untested direction is precisely the one that broke.
+   infeasible models. The untested direction is precisely the one that broke,
+   and **it is still untested at the CLI level**: PR #521 pins the clamp with
+   two unit tests in `opt_error.rs`, and the integration fixture that PR #506
+   originally carried was dropped when that PR was rescoped. Enforcement item 3
+   below is the missing arm, not a hypothetical one.
 
 3. **The detector is POUNCE-only.** Upstream Ipopt has no equivalent, so no
    differential test against Ipopt can see it at default options — the two
@@ -84,20 +104,24 @@ status ∈ infeasible band
   ∧ final unscaled violation ≤ acceptable_constr_viol_tol
 ```
 
-On gh #505's `f=1` reproducer, stock `main` reports local infeasibility at a
-scaled NLP error of **4.89e-10** against `acceptable_tol = 1e-3` — six orders
-inside the band. Ship it as a debug assert plus a CI sweep over the fixture
-corpus.
+On gh #505's `f=1` reproducer, `main` before gh #519's floor reported local
+infeasibility at a scaled NLP error of **4.89e-10** against
+`acceptable_tol = 1e-3` — six orders inside the band. Ship it as a debug assert
+plus a CI sweep over the fixture corpus.
 
 ### 2. Kill-switch ablation
 
 Every POUNCE-only heuristic has an option that disables it; the detector's is
 `infeas_stationarity_tol=0`. Run the corpus with each switch off and diff the
 verdicts. **Any model where disabling a heuristic improves the verdict is a bug
-candidate.** This single control settled gh #505 — disabling the detector
-produced output bit-identical to PR #506's fix on both architectures — and it
-was not run until roughly eighteen hours into the investigation. It should be a
-scheduled job, not something reached for during debugging.
+candidate.** This single control settled gh #505: `infeas_stationarity_tol=0`
+flipped the verdict on stock `main`, naming the detector as the mechanism in
+one run, with no oracle and no code reading. It was not run until roughly
+eighteen hours into the investigation, and three superseded diagnoses were
+published before it. gh #519 later confirmed it three more ways —
+`infeas_viol_kappa=1e4` (floor back to 1e-2), `infeas_max_streak=15` and
+`acceptable_iter=5` each flip it too. This should be a scheduled job, not
+something reached for during debugging.
 
 ### 3. Tolerance monotonicity, in the feasible direction
 
@@ -113,7 +137,7 @@ existing fixture corpus × ~6 tolerance options × ~6 values.
 **Tolerance provenance.** Every numeric threshold compared against a constraint
 violation must be built from a constraint-violation tolerance; every threshold
 on a KKT error, from `tol`. gh #508 was a violation compared against
-`max(100·tol, 1e-4)`; gh #505 is the mirror — a violation compared against
+`max(100·tol, 1e-4)`; gh #519 is the mirror — a violation compared against
 `1e2·constr_viol_tol`, gating a status that the acceptable band owns. Enumerate
 the `*_tol` reads in `conv_check/`, `ipopt_alg.rs` and `pounce-restoration/`
 together with the quantity each is compared against; the remaining instances
@@ -125,17 +149,33 @@ today, broken by any user who moves one option. Either assert the equality as a
 test that explains why it must hold, or remove the coincidence by keying the
 threshold on a single option.
 
+gh #519's fix is worth reading as a worked example of the trade-off. It takes
+the constant form — `MIN_INFEAS_VIOL_FLOOR: Number = 1e-2`, applied as
+`(infeas_viol_kappa · constr_viol_tol).max(MIN_INFEAS_VIOL_FLOOR)` — rather than
+keying the floor on `acceptable_constr_viol_tol`. That is the right call for
+the reported failure: it is the smaller change, it mirrors the sibling relative
+arm exactly, and it restores the monotonicity that was broken. But it hardens
+the coincidence into a constant rather than removing the coupling. The floor
+now tracks the *default* `acceptable_constr_viol_tol`, not the user's, so a
+user who **raises** `acceptable_constr_viol_tol` above `1e-2` re-opens a narrow
+version of the same window — the detector can arm on a violation the user has
+declared acceptable. Nobody has reported that; it is the residual to check
+first if this area produces a fifth hole.
+
 ## Route convergence
 
 PR #506 adds `terminate_local_infeasibility` plus a structural test asserting
 that no site in `ipopt_alg.rs` builds `IterateOutcome::Terminate(SolverReturn::LocalInfeasibility)`
 directly — two of the three routes had independently shipped the same defect of
-discarding the acceptable-point stash.
+discarding the acceptable-point stash. That PR is scoped to this and nothing
+else; it does not fix gh #505's symptom and does not claim to.
 
-Note the guard's real scope, which is narrower than its name suggests: it is a
-substring scan of one file. `rustfmt` wrapping the expression, or a temporary
-binding, defeats it, and `application.rs:1644` constructs the verdict on the
-elastic path outside its reach. It is a tripwire, not a proof.
+The guard is a substring scan of one file: `rustfmt` wrapping the expression, a
+temporary binding, or a construction in another module all evade it, and
+`application.rs` names the same variant on the SQP and ℓ₁ elastic paths, out of
+scope by design. It is a tripwire, not a proof — what it buys is that the
+obvious way to add a fourth bare exit fails loudly and points at the helper,
+which is the mistake that was actually made twice.
 
 `ErrorInStepComputation` has the same shape and the same history (gh #372,
 gh #508) and has not had the equivalent treatment.


### PR DESCRIPTION
Documentation only — no source, no test, no behaviour change.

Context: #505, #519 (fixed by #521, merged) and #508. Deliberately **no closing
keyword** — nothing here fixes anything.

## Why

"Never claim infeasibility at a point the solver's own convergence test would
accept" has now been violated at four independent sites, and each was fixed in
isolation as if it were a one-off.

The invariant is already written down in the source, at
`pounce-restoration/src/resto_inner_solver.rs:756`, where it guards the six
restoration gates as a single admissibility test. The comment on that guard is
the reason for this PR:

> *"Applied once to the combination rather than to each disjunct: the two
> preceding safeguards in this area were each added to one path and not its
> twin, and a hole survived both times."*

It was applied to restoration and never generalised. Two more holes followed,
in two other files, found the same week by unrelated routes:

| # | site | mechanism | fixed |
|---|---|---|---|
| #372 / #376 | restoration gates | scaled/unscaled units mismatch on the `max(100·tol, 1e-4)` floors | 2026-07-22 |
| #385 / #390 | `conv_check` surrogate | `‖Jᵀc‖/max(1,‖c‖)` is not scale-invariant | no-descent confirmation |
| #508 | `ipopt_alg.rs` cycle exit | violation compared against a threshold built from `tol` | 097a4719 |
| #519 | `conv_check/opt_error.rs` rapid detector | violation compared against an **unclamped** `infeas_viol_kappa · constr_viol_tol` | #521, ef5d77e8 |

`ErrorInStepComputation` has the same shape and the same history (#372, #508)
and has not had the equivalent treatment.

## What is here

**`dev-notes/termination-status-invariants.md`** (new) — the invariant, the
four sites, why the fourth survived three releases, and the checks that would
catch the fifth:

1. a global self-consistency postcondition (no oracle — a status in the
   infeasible band while the run's own reported scaled NLP error sits inside
   `acceptable_tol` is a contradiction in POUNCE's own numbers);
2. kill-switch ablation of the POUNCE-only heuristics;
3. tolerance monotonicity in the **feasible** direction — the missing mirror of
   `infeasible_status_tol_invariance.rs`.

Plus two one-off static audits: tolerance provenance (a threshold on a
constraint violation must be built from a constraint-violation tolerance) and
default coincidences.

Four things from the note worth surfacing here.

- **The evidence was in the file the whole time.** The *relative* arm one
  function up carried exactly this hazard and had been deliberately clamped —
  `(100.0 · constr_viol_tol).max(1e-2)` — with a doc comment stating the rule:
  *"too-loose withholds a verdict, too-tight fabricates one."* The absolute arm
  was the same expression **without the `.max`**. When one arm of a predicate is
  hardened against a hazard, check its twin.
- **The defaults were safe by coincidence, not construction.** `1e2 · 1e-4` =
  `1e-2` = `acceptable_constr_viol_tol`. Two independently chosen defaults
  landing on the same number, so tightening `constr_viol_tol` dragged the floor
  inside the acceptable band while the band stayed put — asking for tighter
  feasibility is what manufactured the infeasibility verdict.
- **#521 hardens that coincidence rather than removing it.** It takes the
  constant form (`MIN_INFEAS_VIOL_FLOOR = 1e-2`) rather than keying the floor on
  `acceptable_constr_viol_tol` — the right call for the reported failure, and
  the smaller change, but the floor now tracks the *default* value, not the
  user's. Raising `acceptable_constr_viol_tol` above `1e-2` re-opens a narrow
  version of the same window. Unreported; recorded as the first thing to check
  if this area produces a fifth hole.
- **The feasible-direction sweep is still missing.** Not one CLI test sets
  `constr_viol_tol` on a *feasible* model. #521 pins the clamp with two unit
  tests in `opt_error.rs`, and the integration fixture #506 originally carried
  was dropped when that PR was rescoped. Enforcement item 3 describes a real
  gap, not a hypothetical one.

**`.claude/commands/adversary.md`** — the option grid becomes a target in its
own right, worth roughly one run in four. Every run so far picks a *problem*;
the one run that swept an *option* found #508. Three probes — kill-switch
ablation, feasible-direction tolerance monotonicity, real driver option sets —
all reusing a model already logged as PASS, so the run spends its budget on the
option space instead of re-adjudicating a formulation. This arm needs no
oracle: a verdict that moves when only an option moved is an internal
contradiction, which is the load-bearing evidence in both #505 and #508.

**`AGENTS.md`** — three debugging rules from the same investigation. Run the
kill switch first (`infeas_stationarity_tol=0` named the mechanism in one run,
and was not run until ~18 hours in, after three superseded diagnoses had been
published). A fixture built from a hypothesis is not evidence for that
hypothesis — the one built for #505 was eventually dropped, because once #519
was fixed it no longer reproduced anything. Stamp measurements with the commit
they were taken on, and propagate a correction to every surface carrying the
bad number.

## Checklist

- [x] Documentation only — no `crates/` change, so no test or CHANGELOG entry
- [x] No closing keyword
- [x] Re-checked against `origin/main` after #521 merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cRDjGAQETFLbE6qcE77sR
