### PR TITLE
fix(convex): stop a near-forcing row from falsifying a feasible LP (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,56 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `pounce-convex` reported false `Infeasible_Problem_Detected` at iteration 0 on `bore3d` / `QBORE3D` (#523)
+
+- Netlib `bore3d` and its Maros-Mészáros quadratic twin `QBORE3D` (both
+  n=315, m=233, both feasible) came back from the convex path as
+  `Infeasible_Problem_Detected` in ~5 ms with `iters=0` and no diagnostic,
+  while the NLP path (`solver_selection=nlp`) solved both to the committed
+  Ipopt-MA57 reference objectives. They were the only non-matching failure
+  in the `lp` suite and the only one in the `qp` suite.
+- The claim came from presolve's **forcing-constraint** reduction. Bound
+  tightening propagated a group of nonnegative variables' upper bounds
+  geometrically toward their true limit of zero; by round 21 of the
+  presolve fixpoint those boxes were ~1e-8 wide, and one equality row's
+  activity range `[-6.29e-10, 4.87e-8]` came within `ACTIVITY_TOL` (1e-9)
+  of its right-hand side `0`. Forcing read that as "this row can hold only
+  at its min vertex" and pinned all six of its variables to bounds — two of
+  them, with coefficients `-1.14e-1` and `-5.7e-3`, to *upper* bounds
+  `4.8e-9` and `1.5e-8` from zero. A gap of `6.29e-10` had licensed a
+  displacement of `1.5e-8`. Substituted into the next row those two
+  appeared in, the residual was `2.0e-8` against a tolerance of `1.0e-9`,
+  and a feasible problem was declared infeasible.
+- **Forcing now requires the pin to be tight.** A row whose activity range
+  only *approximately* touches its right-hand side may still spend the
+  residual gap, moving each variable up to `gap / |coefⱼ|` (capped by its
+  box width) off the bound the pin claims it must occupy. Forcing fires
+  only when that displacement is within `FORCING_PIN_TOL` for **every**
+  variable in the row, so a pin is a deduction rather than a guess. A row
+  that genuinely touches (gap 0) is unaffected.
+- **An infeasibility verdict is now re-derived before it is emitted.**
+  Two reductions — forcing constraints and dominated columns — fix a
+  variable at a value chosen from a tolerance judgment, and a wrong one is
+  substituted into every row that variable touches until some row reads as
+  contradictory. When any screen reports infeasible, presolve re-runs from
+  the original problem with those two withheld; only a verdict that pass
+  reaches on its own is returned as `PrimalInfeasible`. Otherwise the
+  reduction is solved normally and the discarded claim is kept on the
+  handle (`Presolve::discarded_infeasibility`). Everything that only
+  *reports* — empty rows, activity ranges, parallel rows, emptied-row
+  residuals — is retained, so no infeasibility class detectable before is
+  lost. Verified: with the forcing fix reverted, the guard alone still
+  solves both problems to the reference objective.
+- **The screen that fired is now named.** `PresolveOutcome::Infeasible`
+  carries an `InfeasibleTrigger` (the screen plus the row / column / bound
+  and the compared values), and the CLI prints it — `Presolve: proved
+  primal infeasible — <screen> (<detail>)`, or `Presolve: discarded an
+  unconfirmed infeasibility claim — …; solving normally`. Previously even
+  `print_level=8` emitted nothing on the way out.
+- **Breaking (pounce-convex API):** `PresolveOutcome::Infeasible` is now a
+  tuple variant; `matches!(…, PresolveOutcome::Infeasible)` becomes
+  `PresolveOutcome::Infeasible(_)`.
+
 ### Fixed — tightening `constr_viol_tol` made POUNCE more likely to report local infeasibility (#519)
 
 - Rapid infeasibility detection counted an iterate toward its streak when

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2194,6 +2194,17 @@ fn run_convex_qp(
     } else if presolve_on {
         match presolve(&qp) {
             PresolveOutcome::Reduced(ps) => {
+                // A screen claimed infeasibility and the re-derivation without
+                // the speculative fixings would not reproduce it, so presolve
+                // solved on instead (gh #523). Say so: the guard turns a false
+                // `Infeasible_Problem_Detected` into a normal solve, and this
+                // line is the only trace of the reduction that misfired.
+                if let Some(trigger) = ps.discarded_infeasibility() {
+                    println!(
+                        "Presolve: discarded an unconfirmed infeasibility claim — \
+                         {trigger}; solving normally"
+                    );
+                }
                 let st = ps.stats();
                 if st.reduced_anything() {
                     println!(
@@ -2221,7 +2232,13 @@ fn run_convex_qp(
                 };
                 ps.postsolve(&red)
             }
-            PresolveOutcome::Infeasible => trivial(QpStatus::PrimalInfeasible),
+            PresolveOutcome::Infeasible(trigger) => {
+                // Name the screen and what it tripped on. A presolve
+                // infeasibility arrives with no iteration behind it, so this
+                // line is the whole record of *why* (gh #523).
+                println!("Presolve: proved primal infeasible — {trigger}");
+                trivial(QpStatus::PrimalInfeasible)
+            }
             PresolveOutcome::Unbounded => trivial(QpStatus::DualInfeasible),
         }
     } else if use_active_set {

--- a/crates/pounce-convex/examples/presolve_reductions.rs
+++ b/crates/pounce-convex/examples/presolve_reductions.rs
@@ -16,7 +16,7 @@ fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
 fn report(name: &str, prob: &QpProblem) {
     print!("{name:<34} {}×{} → ", prob.n, prob.m_eq() + prob.m_ineq());
     match presolve(prob) {
-        PresolveOutcome::Infeasible => println!("INFEASIBLE (detected in presolve)"),
+        PresolveOutcome::Infeasible(_) => println!("INFEASIBLE (detected in presolve)"),
         PresolveOutcome::Unbounded => println!("UNBOUNDED (detected in presolve)"),
         PresolveOutcome::Reduced(ps) => {
             let r = &ps.reduced;

--- a/crates/pounce-convex/src/presolve.rs
+++ b/crates/pounce-convex/src/presolve.rs
@@ -162,11 +162,39 @@ pub enum PresolveOutcome {
     Reduced(Presolve),
     /// Presolve proved the problem primal-infeasible (e.g. an empty row
     /// `0 = b` with `b ≠ 0`, contradictory fixed bounds, or duplicate
-    /// equality rows with different right-hand sides).
-    Infeasible,
+    /// equality rows with different right-hand sides). Carries the screen
+    /// that fired and what it tripped on — see [`InfeasibleTrigger`].
+    Infeasible(InfeasibleTrigger),
     /// Presolve proved the problem unbounded below (a free column with a
     /// nonzero objective coefficient).
     Unbounded,
+}
+
+/// Which screen concluded that the problem is primal-infeasible, and what it
+/// tripped on.
+///
+/// A presolve infeasibility comes back in milliseconds with no iteration
+/// behind it, so when it is wrong it is the most expensive failure the solver
+/// has: a confident wrong answer with no trace. Carrying the trigger makes
+/// the claim auditable — the CLI prints it, and a bug report names a row, a
+/// column and the numbers that were compared instead of `iters=0` (gh #523).
+#[derive(Debug, Clone, PartialEq)]
+pub struct InfeasibleTrigger {
+    /// The screen that fired, e.g. `"empty equality row"`.
+    pub screen: &'static str,
+    /// The row / column / bound it tripped on, with the compared values.
+    pub detail: String,
+}
+
+impl std::fmt::Display for InfeasibleTrigger {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ({})", self.screen, self.detail)
+    }
+}
+
+/// Build a [`PresolveOutcome::Infeasible`] with its trigger recorded.
+fn infeasible(screen: &'static str, detail: String) -> PresolveOutcome {
+    PresolveOutcome::Infeasible(InfeasibleTrigger { screen, detail })
 }
 
 /// A reversible presolve transaction. Each variant stores exactly what
@@ -290,6 +318,11 @@ pub struct Presolve {
     /// `postsolve` folds the layers in reverse. The single-pass fields
     /// above are unused in that case.
     chain: Vec<Presolve>,
+    /// An infeasibility claim the full catalog raised that the confirming
+    /// re-derivation would not reproduce, so it was discarded and this
+    /// reduction returned instead (gh #523). `None` on the normal path. Read
+    /// it with [`Presolve::discarded_infeasibility`].
+    discarded_infeasibility: Option<InfeasibleTrigger>,
 }
 
 /// Coefficients are treated as nonzero unless exactly 0.0.
@@ -298,6 +331,18 @@ const ZERO_TOL: f64 = 0.0;
 const BOUND_FEAS_TOL: f64 = 1e-9;
 /// Slack allowed in activity-bound comparisons (redundancy / feasibility).
 const ACTIVITY_TOL: f64 = 1e-9;
+/// How far a **forcing** reduction may be wrong about where it pins a
+/// variable before the pin stops counting as a deduction (gh #523).
+///
+/// A forcing row's vertex is only ever recognized to within [`ACTIVITY_TOL`],
+/// so a residual gap of that size survives the test — and the row can still
+/// spend it. Spent on one variable it moves that variable `gap / |coefⱼ|` off
+/// the bound the pin claims it must sit at, which for a small coefficient is
+/// orders of magnitude more than the gap that licensed the pin. Matching
+/// [`BOUND_FEAS_TOL`] keeps a pinned value inside the same window presolve
+/// judges every other fixed value's box feasibility by. See
+/// [`forcing_pin_is_tight`].
+const FORCING_PIN_TOL: f64 = BOUND_FEAS_TOL;
 /// Relative slack allowed when a row emptied by substitution is checked for
 /// feasibility (`0 = rhs` / `0 ≤ rhs`). Scaled by the size of the terms that
 /// cancelled, because that is where the residual's rounding error lives —
@@ -371,6 +416,53 @@ where
     (amin, amax)
 }
 
+/// Does a row whose activity range *touches* its right-hand side to within
+/// [`ACTIVITY_TOL`] really **force** its variables onto the touched vertex?
+///
+/// `gap` is the leftover activity at the vertex (`b − amin` for a row pinned
+/// to its min vertex, `amax − b` for the max vertex, `h − amin` for a `≤`
+/// row); the forcing test accepted the row because `|gap| ≤ ACTIVITY_TOL`.
+/// A *genuine* forcing row has `gap == 0`: the vertex is the only point of
+/// the box the row admits, so pinning every variable there is a deduction.
+/// A merely-near-zero gap is not. The row can still spend that activity, and
+/// spending all of it on variable `j` moves it `gap / |coefⱼ|` off the bound
+/// the pin claims it must occupy — capped by `j`'s own box width, since it
+/// cannot leave its box either way.
+///
+/// With a small coefficient, or a box that bound tightening has already
+/// narrowed toward rounding-noise width, that displacement runs orders of
+/// magnitude past the gap that licensed it. The pin is then not a deduction
+/// but a guess: it fixes variables at values the feasible set does not
+/// require, and the next row those variables appear in reads as
+/// contradictory — a **false primal infeasibility** on a feasible problem.
+///
+/// That is exactly gh #523 (netlib `bore3d` / Maros-Mészáros `QBORE3D`),
+/// where a gap of `6.3e-10` on a row with coefficients `−1.14e-1` and
+/// `−5.7e-3` pinned two variables `4.8e-9` and `1.5e-8` away from their true
+/// values, and a later row emptied by those fixings was declared inconsistent
+/// by `2.0e-8`.
+///
+/// So a forcing row must clear a stronger bar than "the gap is small": the
+/// gap must be small enough that **every** pinned variable lands within
+/// [`FORCING_PIN_TOL`] of where the pin says it is.
+fn forcing_pin_is_tight<L, U>(row: &[(usize, f64)], gap: f64, lb: &L, ub: &U) -> bool
+where
+    L: Fn(usize) -> f64,
+    U: Fn(usize) -> f64,
+{
+    // A gap the wrong side of zero means the vertex slightly *violates* the
+    // right-hand side (the activity screen tolerates that much before calling
+    // the row infeasible); there is no leftover activity to spend, so the
+    // displacement it licenses is zero, not negative.
+    let gap = gap.max(0.0);
+    row.iter().all(|&(c, coef)| {
+        // Coefficients reaching here are nonzero (`group_by_row` drops exact
+        // zeros), so the division is safe.
+        let displacement = (gap / coef.abs()).min(ub(c) - lb(c));
+        displacement <= FORCING_PIN_TOL
+    })
+}
+
 /// A single constraint row in the reduced column space, tagged with its
 /// original row index. Used for duplicate detection and final assembly.
 struct Row {
@@ -399,7 +491,84 @@ struct Row {
 /// a unit. Both feed the same fixpoint: an aggregation can expose a
 /// singleton the catalog then fixes, and a fixing can turn a three-term row
 /// into a doubleton the next aggregation folds away.
+///
+/// # Infeasibility is re-derived before it is believed (gh #523)
+///
+/// A presolve infeasibility is the worst answer this solver can give when it
+/// is wrong: `Infeasible_Problem_Detected` in five milliseconds, with no
+/// iteration behind it, on a problem that has an optimum. And the catalog can
+/// manufacture one. Two of its reductions — forcing constraints and dominated
+/// columns — do not merely drop or rewrite constraints, they **fix a variable
+/// at a value they chose from a tolerance judgment**. A fixing that is wrong
+/// is substituted into every row the variable appears in, and the first row
+/// that cannot absorb it reads as contradictory: a false infeasibility, in a
+/// row nowhere near the reduction that caused it.
+///
+/// So an infeasibility verdict is not emitted on the strength of the pass
+/// that raised it. It is **re-derived from the original problem with those
+/// two reductions switched off** ([`Catalog::NoSpeculativeFixings`]), and
+/// only a verdict the re-derivation reaches on its own is returned as
+/// `Infeasible`. If the re-derivation instead reduces, the claim depended on
+/// a fixing that was not forced, and the reduction it hands back is solved
+/// normally — a misfiring reduction costs a few eliminations instead of the
+/// answer. The discarded claim rides along on the returned handle
+/// ([`Presolve::discarded_infeasibility`]) so the near-miss is reportable
+/// rather than silent.
+///
+/// The re-derivation keeps everything else, including the screens that reason
+/// through tolerances but only ever *report* — empty rows, activity ranges,
+/// parallel rows, an emptied row's residual — so no infeasibility class the
+/// catalog could detect before is lost.
 pub fn presolve(prob: &QpProblem) -> PresolveOutcome {
+    match presolve_fixpoint(prob, Catalog::Full) {
+        PresolveOutcome::Infeasible(trigger) => {
+            match presolve_fixpoint(prob, Catalog::NoSpeculativeFixings) {
+                // Confirmed without the speculative fixings: the problem
+                // really is infeasible, and this is the trigger that shows it.
+                confirmed @ PresolveOutcome::Infeasible(_) => confirmed,
+                PresolveOutcome::Reduced(mut ps) => {
+                    ps.discarded_infeasibility = Some(trigger);
+                    PresolveOutcome::Reduced(ps)
+                }
+                unbounded => unbounded,
+            }
+        }
+        other => other,
+    }
+}
+
+/// Which reductions a presolve pass may apply.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Catalog {
+    /// The whole catalog.
+    Full,
+    /// The catalog minus its **speculative fixings**: the two reductions that
+    /// pick a *value* for a variable out of a tolerance judgment instead of
+    /// deriving it — forcing constraints (pin every variable of a row whose
+    /// activity range comes within [`ACTIVITY_TOL`] of touching its
+    /// right-hand side) and dominated columns (fix a variable at a bound on
+    /// sign conditions read off the rows the activity screen left live).
+    ///
+    /// Those two are singled out by *how* a wrong one fails. Every other
+    /// reduction drops a constraint, narrows a box, or rewrites a row — being
+    /// wrong loses a reduction. A wrong fixing instead substitutes a
+    /// fabricated value into every row the variable appears in, and the first
+    /// row that cannot absorb it reads as contradictory. That is the
+    /// mechanism behind gh #523, and the one an infeasibility verdict is
+    /// re-derived without; see [`presolve`].
+    NoSpeculativeFixings,
+}
+
+impl Catalog {
+    /// Whether the speculative fixings — forcing rows, dominated columns —
+    /// may run.
+    fn speculative_fixings(self) -> bool {
+        self == Catalog::Full
+    }
+}
+
+/// The fixpoint iteration itself, over the reductions `catalog` permits.
+fn presolve_fixpoint(prob: &QpProblem, catalog: Catalog) -> PresolveOutcome {
     // Cap layers defensively; in practice it converges in a few. A round
     // can contribute two (the catalog pass and an aggregation), so this is
     // a bound on layers, not on rounds.
@@ -410,8 +579,8 @@ pub fn presolve(prob: &QpProblem) -> PresolveOutcome {
     // so a no-op presolve still returns a usable handle.
     let mut passthrough: Option<Presolve> = None;
     loop {
-        let ps = match presolve_once(&current, &[]) {
-            PresolveOutcome::Infeasible => return PresolveOutcome::Infeasible,
+        let ps = match presolve_once(&current, &[], catalog) {
+            infeasible @ PresolveOutcome::Infeasible(_) => return infeasible,
             PresolveOutcome::Unbounded => return PresolveOutcome::Unbounded,
             PresolveOutcome::Reduced(ps) => ps,
         };
@@ -463,6 +632,7 @@ pub fn presolve(prob: &QpProblem) -> PresolveOutcome {
         orig: prob.clone(),
         stack: Vec::new(),
         chain,
+        discarded_infeasibility: None,
     })
 }
 
@@ -492,6 +662,7 @@ fn aggregate_once(prob: &QpProblem) -> Option<Presolve> {
             plan: Box::new(plan),
         }],
         chain: Vec::new(),
+        discarded_infeasibility: None,
     })
 }
 
@@ -526,7 +697,22 @@ pub fn presolve_conic(prob: &QpProblem, cones: &[ConeSpec]) -> PresolveOutcome {
         }
         row += d;
     }
-    presolve_once(prob, &protected_row)
+    // Same guard as [`presolve`] (gh #523): an infeasibility verdict is
+    // re-derived without the speculative fixings before it is emitted, and
+    // downgraded to that pass's reduction when it will not confirm.
+    match presolve_once(prob, &protected_row, Catalog::Full) {
+        PresolveOutcome::Infeasible(trigger) => {
+            match presolve_once(prob, &protected_row, Catalog::NoSpeculativeFixings) {
+                confirmed @ PresolveOutcome::Infeasible(_) => confirmed,
+                PresolveOutcome::Reduced(mut ps) => {
+                    ps.discarded_infeasibility = Some(trigger);
+                    PresolveOutcome::Reduced(ps)
+                }
+                unbounded => unbounded,
+            }
+        }
+        other => other,
+    }
 }
 
 /// A single presolve pass (the reduction catalog applied once). [`presolve`]
@@ -541,7 +727,11 @@ pub fn presolve_conic(prob: &QpProblem, cones: &[ConeSpec]) -> PresolveOutcome {
 /// columns, free-column singletons, fixed-variable substitution) apply
 /// regardless. Marked rows are never dropped, so the conic partition is
 /// recoverable from the kept rows.
-fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
+///
+/// `catalog` selects which reductions run: [`Catalog::NoSpeculativeFixings`]
+/// withholds the two that fix a variable at a tolerance-chosen value, leaving
+/// the pass unable to manufacture a contradiction that way (gh #523).
+fn presolve_once(prob: &QpProblem, soc_row: &[bool], catalog: Catalog) -> PresolveOutcome {
     let n = prob.n;
     let m_eq = prob.m_eq();
     let m_ineq = prob.m_ineq();
@@ -551,8 +741,16 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
     // front so an impossible bound is never mistaken for an *absent* one (the
     // normal one-sided `±∞` encoding, which stays feasible). See
     // [`QpProblem::bounds_admit_no_point`].
-    if prob.bounds_admit_no_point() {
-        return PresolveOutcome::Infeasible;
+    if let Some(k) = (0..n).find(|&i| prob.lb_of(i) >= BOUND_INF || prob.ub_of(i) <= -BOUND_INF) {
+        debug_assert!(prob.bounds_admit_no_point());
+        return infeasible(
+            "impossible variable bound",
+            format!(
+                "column {k} has lb={:e}, ub={:e}",
+                prob.lb_of(k),
+                prob.ub_of(k)
+            ),
+        );
     }
     let is_soc_row = |i: usize| soc_row.get(i).copied().unwrap_or(false);
     // A column is conic-coupled if it appears in any SOC inequality row.
@@ -614,7 +812,10 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         match eq_nnz[row] {
             0 => {
                 if prob.b[row] != 0.0 {
-                    return PresolveOutcome::Infeasible;
+                    return infeasible(
+                        "empty equality row",
+                        format!("equality row {row} is `0 = {:e}`", prob.b[row]),
+                    );
                 }
                 eq_dropped[row] = true;
             }
@@ -626,7 +827,15 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
                     if value < prob.lb_of(col) - BOUND_FEAS_TOL
                         || value > prob.ub_of(col) + BOUND_FEAS_TOL
                     {
-                        return PresolveOutcome::Infeasible;
+                        return infeasible(
+                            "singleton equality outside variable box",
+                            format!(
+                                "equality row {row} fixes column {col} to {value:e}, \
+                                 outside its box [{:e}, {:e}]",
+                                prob.lb_of(col),
+                                prob.ub_of(col)
+                            ),
+                        );
                     }
                     fixed[col] = Some(value);
                     eq_dropped[row] = true;
@@ -694,7 +903,10 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
     for row in 0..m_ineq {
         if !is_soc_row(row) && ineq_nnz[row] == 0 {
             if prob.h[row] < 0.0 {
-                return PresolveOutcome::Infeasible;
+                return infeasible(
+                    "empty inequality row",
+                    format!("inequality row {row} is `0 <= {:e}`", prob.h[row]),
+                );
             }
             ineq_dropped[row] = true;
         }
@@ -719,7 +931,13 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         }
         let (amin, amax) = activity(&g_by_row[row], &eff_lb, &eff_ub);
         if amin > prob.h[row] + ACTIVITY_TOL {
-            return PresolveOutcome::Infeasible;
+            return infeasible(
+                "inequality activity above right-hand side",
+                format!(
+                    "inequality row {row}: min activity {amin:e} > h {:e}",
+                    prob.h[row]
+                ),
+            );
         }
         if amax <= prob.h[row] + ACTIVITY_TOL {
             ineq_dropped[row] = true;
@@ -736,7 +954,13 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         }
         let (amin, amax) = activity(&a_by_row[row], &eff_lb, &eff_ub);
         if prob.b[row] < amin - ACTIVITY_TOL || prob.b[row] > amax + ACTIVITY_TOL {
-            return PresolveOutcome::Infeasible;
+            return infeasible(
+                "equality right-hand side outside activity range",
+                format!(
+                    "equality row {row}: b {:e} outside [{amin:e}, {amax:e}]",
+                    prob.b[row]
+                ),
+            );
         }
     }
 
@@ -803,7 +1027,16 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         true
     };
 
-    for row in 0..m_ineq {
+    // A forcing pin is a speculative fixing, so a confirming pass withholds it
+    // (gh #523) — an empty range rather than a wrapper block, to keep the two
+    // loops below at their original indentation.
+    let (forcing_ineq, forcing_eq) = if catalog.speculative_fixings() {
+        (m_ineq, m_eq)
+    } else {
+        (0, 0)
+    };
+
+    for row in 0..forcing_ineq {
         if ineq_dropped[row] || is_soc_row(row) || g_by_row[row].is_empty() {
             continue;
         }
@@ -812,6 +1045,12 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         });
         if amin.is_finite()
             && (prob.h[row] - amin).abs() <= ACTIVITY_TOL
+            && forcing_pin_is_tight(
+                &g_by_row[row],
+                prob.h[row] - amin,
+                &|c| eff_lb_at(&fixed, c),
+                &|c| eff_ub_at(&fixed, c),
+            )
             && try_force(
                 &g_by_row[row],
                 row,
@@ -826,7 +1065,7 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         }
     }
 
-    for row in 0..m_eq {
+    for row in 0..forcing_eq {
         if eq_dropped[row] || a_by_row[row].len() < 2 {
             continue;
         }
@@ -834,9 +1073,16 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
             eff_ub_at(&fixed, c)
         });
         let b = prob.b[row];
-        let at_max = if amin.is_finite() && (b - amin).abs() <= ACTIVITY_TOL {
+        // Both vertices are candidates; each must clear the pin-tightness bar
+        // (gh #523) on its own gap before it may fix anything.
+        let tight = |gap: f64| {
+            forcing_pin_is_tight(&a_by_row[row], gap, &|c| eff_lb_at(&fixed, c), &|c| {
+                eff_ub_at(&fixed, c)
+            })
+        };
+        let at_max = if amin.is_finite() && (b - amin).abs() <= ACTIVITY_TOL && tight(b - amin) {
             Some(false)
-        } else if amax.is_finite() && (amax - b).abs() <= ACTIVITY_TOL {
+        } else if amax.is_finite() && (amax - b).abs() <= ACTIVITY_TOL && tight(amax - b) {
             Some(true)
         } else {
             None
@@ -867,7 +1113,11 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
     // for the upper) make nonnegative — so the recovered dual is valid by
     // construction. This is PaPILO's dominated-column reduction, restricted
     // to the case with a clean, sign-guaranteed dual.
-    {
+    //
+    // It reads `ineq_dropped`, which the activity screen writes, so it can fix
+    // a variable at a bound that a row dropped as redundant would have
+    // forbidden: a speculative fixing, withheld by a confirming pass.
+    if catalog.speculative_fixings() {
         // Per-column G-coefficient sign summary over *live* inequality rows.
         let mut g_all_nonneg = vec![true; n];
         let mut g_all_nonpos = vec![true; n];
@@ -981,8 +1231,8 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
 
     // Tighten variable boxes from one row whose activity lies in `[lo, hi]`
     // (inequality `≤ h`: `lo = −∞, hi = h`; equality: `lo = hi = b`).
-    // `None` ⇒ a detected empty domain (infeasible); `Some(k)` ⇒ `k` bounds
-    // were tightened.
+    // `Err((col, lb, ub))` ⇒ a detected empty domain (infeasible), naming the
+    // column whose box crossed; `Ok(k)` ⇒ `k` bounds were tightened.
     let tighten_from_row = |entries: &[(usize, f64)],
                             lo: f64,
                             hi: f64,
@@ -992,7 +1242,7 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
                             tub: &mut [f64],
                             ub_src: &mut [Option<(usize, f64, bool)>],
                             lb_src: &mut [Option<(usize, f64, bool)>]|
-     -> Option<usize> {
+     -> Result<usize, (usize, f64, f64)> {
         // Row activity as a *finite part plus a count of infinite terms*,
         // rather than the plain sum [`activity`] returns.
         //
@@ -1100,10 +1350,10 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
                 tightened += 1;
             }
             if tlb[k] > tub[k] + BOUND_FEAS_TOL {
-                return None;
+                return Err((k, tlb[k], tub[k]));
             }
         }
-        Some(tightened)
+        Ok(tightened)
     };
 
     // A source row claims its columns (blocking overlapping sources, so the
@@ -1132,9 +1382,14 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
             &mut ub_src,
             &mut lb_src,
         ) {
-            None => return PresolveOutcome::Infeasible,
-            Some(0) => {}
-            Some(_) => {
+            Err((c, lo, hi)) => {
+                return infeasible(
+                    "bound tightening emptied a variable box",
+                    format!("inequality row {row} tightened column {c} to [{lo:e}, {hi:e}]"),
+                );
+            }
+            Ok(0) => {}
+            Ok(_) => {
                 for (c, up) in row_claims(&g_by_row[row], false) {
                     if up {
                         bt_used_upper[c] = true;
@@ -1164,9 +1419,14 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
             &mut ub_src,
             &mut lb_src,
         ) {
-            None => return PresolveOutcome::Infeasible,
-            Some(0) => {}
-            Some(_) => {
+            Err((c, lo, hi)) => {
+                return infeasible(
+                    "bound tightening emptied a variable box",
+                    format!("equality row {row} tightened column {c} to [{lo:e}, {hi:e}]"),
+                );
+            }
+            Ok(0) => {}
+            Ok(_) => {
                 for (c, up) in row_claims(&a_by_row[row], true) {
                     if up {
                         bt_used_upper[c] = true;
@@ -1303,7 +1563,7 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         &[],
     ) {
         Ok(rows) => rows,
-        Err(()) => return PresolveOutcome::Infeasible,
+        Err(trigger) => return PresolveOutcome::Infeasible(trigger),
     };
     let ineq_rows = match build_rows(
         &prob.g,
@@ -1316,12 +1576,12 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         soc_row,
     ) {
         Ok(rows) => rows,
-        Err(()) => return PresolveOutcome::Infeasible,
+        Err(trigger) => return PresolveOutcome::Infeasible(trigger),
     };
 
     let eq_rows = match dedup_rows(eq_rows, true, &[]) {
         Ok(rows) => rows,
-        Err(()) => return PresolveOutcome::Infeasible,
+        Err(trigger) => return PresolveOutcome::Infeasible(trigger),
     };
     // SOC rows are coupled and must survive verbatim — exclude them from
     // parallel/duplicate merging.
@@ -1389,6 +1649,7 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
         orig: prob.clone(),
         stack,
         chain: Vec::new(),
+        discarded_infeasibility: None,
     })
 }
 
@@ -1396,7 +1657,8 @@ fn presolve_once(prob: &QpProblem, soc_row: &[bool]) -> PresolveOutcome {
 /// substituting fixed variables into the right-hand side. Rows that
 /// become empty after substitution trigger a feasibility check:
 /// `0 = rhs` (equality) requires `rhs ≈ 0`; `0 ≤ rhs` (inequality)
-/// requires `rhs ⪆ 0`. Returns `Err(())` on detected infeasibility.
+/// requires `rhs ⪆ 0`. Returns `Err` with the trigger on detected
+/// infeasibility.
 ///
 /// The residual `rhs` of an emptied row is `b − Σ aⱼ vⱼ`, a *computed*
 /// difference of terms of size up to [`Row::scale`], so it carries that
@@ -1414,7 +1676,7 @@ fn build_rows(
     col_new: &[usize],
     is_equality: bool,
     protected: &[bool],
-) -> Result<Vec<Row>, ()> {
+) -> Result<Vec<Row>, InfeasibleTrigger> {
     // A coupled cone row (second-order / exp / power / PSD) is kept verbatim
     // even when substitution empties its coefficients: an empty `G` row with
     // `s = h` is a legal cone slack (e.g. `h<0` is in `K_exp`), so it must
@@ -1465,12 +1727,25 @@ fn build_rows(
             // residual that is only meaningful down to the rounding error
             // of the substitution that produced it.
             let tol = EMPTY_ROW_TOL * (1.0 + row.scale);
-            if is_equality {
-                if row.rhs.abs() > tol {
-                    return Err(());
-                }
-            } else if row.rhs < -tol {
-                return Err(());
+            let kind = if is_equality {
+                "equality"
+            } else {
+                "inequality"
+            };
+            let violated = if is_equality {
+                row.rhs.abs() > tol
+            } else {
+                row.rhs < -tol
+            };
+            if violated {
+                return Err(InfeasibleTrigger {
+                    screen: "row emptied by substitution is inconsistent",
+                    detail: format!(
+                        "{kind} row {}: residual {:e} exceeds tolerance {tol:e} \
+                         (cancellation scale {:e})",
+                        row.orig, row.rhs, row.scale
+                    ),
+                });
             }
             // Feasible empty row: drop it (no coefficients, no dual).
             continue;
@@ -1559,7 +1834,11 @@ fn approx_parallel(a: &[(usize, f64)], b: &[(usize, f64)]) -> bool {
 /// - inequalities — positive multiples of one direction; keep the **most
 ///   restrictive** original row (smallest normalized rhs `h / |pivot|`)
 ///   and drop the looser ones, which it implies.
-fn dedup_rows(rows: Vec<Row>, is_equality: bool, protected: &[bool]) -> Result<Vec<Row>, ()> {
+fn dedup_rows(
+    rows: Vec<Row>,
+    is_equality: bool,
+    protected: &[bool],
+) -> Result<Vec<Row>, InfeasibleTrigger> {
     if rows.len() < 2 {
         return Ok(rows);
     }
@@ -1617,7 +1896,16 @@ fn dedup_rows(rows: Vec<Row>, is_equality: bool, protected: &[bool]) -> Result<V
                 let r0 = norm_rhs(group[0]);
                 for &g in &group[1..] {
                     if (norm_rhs(g) - r0).abs() > PARALLEL_TOL * (1.0 + r0.abs()) {
-                        return Err(());
+                        return Err(InfeasibleTrigger {
+                            screen: "parallel equalities disagree",
+                            detail: format!(
+                                "equality rows {} and {} are scalar multiples with \
+                                 normalized right-hand sides {r0:e} and {:e}",
+                                rows[group[0]].orig,
+                                rows[g].orig,
+                                norm_rhs(g)
+                            ),
+                        });
                     }
                 }
                 for &g in &group[1..] {
@@ -1682,6 +1970,20 @@ impl PresolveStats {
 }
 
 impl Presolve {
+    /// An infeasibility claim the full catalog raised that the confirming
+    /// re-derivation would not reproduce, so [`presolve`] discarded it and
+    /// returned this reduction instead (gh #523).
+    ///
+    /// `None` on every normal solve. When it is `Some`, presolve came within
+    /// one speculative fixing of answering `Infeasible_Problem_Detected` on a
+    /// problem it could not otherwise prove infeasible — worth surfacing,
+    /// because the guard turns that into a few lost eliminations rather than
+    /// a wrong answer, and nobody finds the underlying bug if the near-miss
+    /// is silent.
+    pub fn discarded_infeasibility(&self) -> Option<&InfeasibleTrigger> {
+        self.discarded_infeasibility.as_ref()
+    }
+
     /// The cone partition of the *reduced* inequality block, given the
     /// original `cones`. Walks the kept inequality rows (a cone-aware
     /// presolve never drops or reorders a second-order-cone block, so each
@@ -2097,7 +2399,7 @@ where
         iterates: Vec::new(),
     };
     match presolve(prob) {
-        PresolveOutcome::Infeasible => trivial(QpStatus::PrimalInfeasible),
+        PresolveOutcome::Infeasible(_) => trivial(QpStatus::PrimalInfeasible),
         PresolveOutcome::Unbounded => trivial(QpStatus::DualInfeasible),
         PresolveOutcome::Reduced(ps) => {
             let red = solve(&ps.reduced);

--- a/crates/pounce-convex/tests/bounded_form.rs
+++ b/crates/pounce-convex/tests/bounded_form.rs
@@ -202,7 +202,7 @@ fn presolve_rejects_present_infinite_bound() {
         lb: vec![POS_INF],
         ub: vec![POS_INF],
     };
-    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible(_)));
 }
 
 /// Box-constrained LP: min −x0 − x1 with 0 ≤ x ≤ 1. Optimum (1, 1).

--- a/crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs
+++ b/crates/pounce-convex/tests/issue496_ulp_inconsistent_equalities.rs
@@ -65,7 +65,7 @@ fn ulp_inconsistent_redundant_equalities_are_feasible() {
     assert!((x_from_row0 - x_from_row1).abs() < 1e-16);
 
     assert!(
-        !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+        !matches!(presolve(&prob), PresolveOutcome::Infeasible(_)),
         "presolve wrongly certified infeasibility at 1 ULP (gh#496)"
     );
 
@@ -88,7 +88,7 @@ fn ulp_inconsistency_stays_feasible_under_scaling() {
     for s in [1e-3, 1.0, 1e3, 1e6] {
         let prob = two_row_lp(A0 * s, B0 * s, A1 * s, B1 * s);
         assert!(
-            !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+            !matches!(presolve(&prob), PresolveOutcome::Infeasible(_)),
             "scale {s}: presolve wrongly certified infeasibility"
         );
         assert_eq!(with_presolve(&prob).status, QpStatus::Optimal, "scale {s}");
@@ -120,7 +120,7 @@ fn genuinely_inconsistent_equalities_still_infeasible() {
     for gap in [1e-6, 1e-3, 1.0, 100.0] {
         let prob = two_row_lp(A0, B0, A1, B1 - gap);
         assert!(
-            matches!(presolve(&prob), PresolveOutcome::Infeasible),
+            matches!(presolve(&prob), PresolveOutcome::Infeasible(_)),
             "gap {gap}: real conflict went undetected"
         );
         assert_eq!(
@@ -166,7 +166,7 @@ fn random_redundant_equalities_around_a_feasible_point() {
         let prob = two_row_lp(a0, a0 * x_star, a1, a1 * x_star);
 
         assert!(
-            !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+            !matches!(presolve(&prob), PresolveOutcome::Infeasible(_)),
             "trial {trial}: a0={a0} a1={a1} x*={x_star} wrongly certified infeasible"
         );
         let sol = with_presolve(&prob);
@@ -223,7 +223,7 @@ fn ulp_violated_emptied_inequality_is_feasible() {
         ub: vec![10.0],
     };
     assert!(
-        !matches!(presolve(&prob), PresolveOutcome::Infeasible),
+        !matches!(presolve(&prob), PresolveOutcome::Infeasible(_)),
         "emptied inequality wrongly certified infeasible at 1 ULP"
     );
     assert_eq!(with_presolve(&prob).status, QpStatus::Optimal);

--- a/crates/pounce-convex/tests/issue523_false_forcing_infeasibility.rs
+++ b/crates/pounce-convex/tests/issue523_false_forcing_infeasibility.rs
@@ -1,0 +1,249 @@
+//! gh #523 — a near-forcing row must not pin, and an infeasibility verdict
+//! must survive a re-derivation without the speculative fixings.
+//!
+//! Netlib `bore3d` and its Maros-Mészáros quadratic twin `QBORE3D` (both
+//! n=315, m=233, both feasible, both solved to the Ipopt-MA57 reference by
+//! POUNCE's NLP path) came back from the convex path as
+//! `Infeasible_Problem_Detected` at iteration 0, in five milliseconds, with
+//! no diagnostic.
+//!
+//! The chain: bound tightening propagated a group of nonnegative variables'
+//! upper bounds geometrically toward their true limit of zero, round after
+//! round. By round 21 those boxes were ~1e-8 wide, and one equality row's
+//! activity range `[-6.3e-10, 4.9e-8]` came within `ACTIVITY_TOL` of its
+//! right-hand side `0` at the *min* vertex. The forcing reduction read that
+//! as "this row can hold only at that vertex" and pinned all six of its
+//! variables to bounds — including two, with coefficients `-1.14e-1` and
+//! `-5.7e-3`, to *upper* bounds `4.8e-9` and `1.5e-8` away from zero. A gap
+//! of `6.3e-10` had licensed a displacement of `1.5e-8`. Substituted into the
+//! next row those two appeared in, the residual was `2.0e-8` against a
+//! tolerance of `1.0e-9`, and presolve called a feasible problem infeasible.
+//!
+//! The first test below is that geometry, distilled to the two rows that
+//! matter. The rest guard the two halves of the fix: forcing must still fire
+//! when a row really is forcing, and an infeasibility verdict must still be
+//! reached — and now be *explained* — when the problem really is infeasible.
+
+use pounce_convex::presolve::{PresolveOutcome, presolve, solve_with_presolve};
+use pounce_convex::{QpOptions, QpProblem, QpSolution, QpStatus, Triplet, solve_qp_ipm};
+use pounce_feral::FeralSolverInterface;
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+fn with_presolve(prob: &QpProblem) -> QpSolution {
+    solve_with_presolve(prob, |r| solve_qp_ipm(r, &QpOptions::default(), backend))
+}
+
+fn without_presolve(prob: &QpProblem) -> QpSolution {
+    solve_qp_ipm(prob, &QpOptions::default(), backend)
+}
+
+/// The `bore3d` geometry: two equality rows over six nonnegative variables
+/// whose boxes bound tightening has already narrowed to ~1e-8, plus a
+/// seventh variable carrying the objective so the solve is not trivial.
+///
+/// Row A is the near-forcing one — activity range `[-6.29e-10, 4.87e-8]`
+/// against `b = 0`, so its min vertex is `6.29e-10` short of the right-hand
+/// side, inside `ACTIVITY_TOL`. Pinning there puts `x3` at `4.76e-9` and `x4`
+/// at `1.52e-8`. Row B is the row that then cannot hold: it wants those five
+/// to sum to `x5`, and `x5`'s pin is `0`.
+///
+/// The whole system is satisfied at the origin, and `x6 = 10` is the optimum.
+fn near_forcing_pair() -> QpProblem {
+    QpProblem {
+        n: 7,
+        p_lower: vec![],
+        c: vec![0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+        a: vec![
+            // Row A: 8.17e-2 x0 + 5.32e-2 x1 + 8.3e-3 x2
+            //        − 1.14e-1 x3 − 5.7e-3 x4 + x5 = 0
+            Triplet::new(0, 0, 8.17e-2),
+            Triplet::new(0, 1, 5.32e-2),
+            Triplet::new(0, 2, 8.3e-3),
+            Triplet::new(0, 3, -1.14e-1),
+            Triplet::new(0, 4, -5.7e-3),
+            Triplet::new(0, 5, 1.0),
+            // Row B: x0 + x1 + x2 + x3 + x4 − x5 = 0
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 1.0),
+            Triplet::new(1, 2, 1.0),
+            Triplet::new(1, 3, 1.0),
+            Triplet::new(1, 4, 1.0),
+            Triplet::new(1, 5, -1.0),
+        ],
+        b: vec![0.0, 0.0],
+        // x6 ≥ 10, as a row so the objective survives presolve as a solve.
+        g: vec![Triplet::new(0, 6, -1.0)],
+        h: vec![-10.0],
+        lb: vec![0.0; 7],
+        ub: vec![
+            1.980622733188442e-7,
+            3.041670625967964e-7,
+            2.206593781384032e-8,
+            4.759319920632226e-9,
+            1.5170332247015222e-8,
+            1.618168773014957e-8,
+            100.0,
+        ],
+    }
+}
+
+#[test]
+fn near_forcing_row_does_not_falsify_a_feasible_lp() {
+    let prob = near_forcing_pair();
+
+    // The origin (with x6 = 10) satisfies every row and every box, so any
+    // infeasibility verdict here is false by construction.
+    match presolve(&prob) {
+        PresolveOutcome::Reduced(ps) => assert!(
+            ps.discarded_infeasibility().is_none(),
+            "presolve should not even reach an infeasibility claim, got {:?}",
+            ps.discarded_infeasibility().map(|t| t.to_string())
+        ),
+        PresolveOutcome::Infeasible(t) => {
+            panic!("feasible LP reported primal infeasible by presolve: {t}")
+        }
+        PresolveOutcome::Unbounded => panic!("bounded LP reported unbounded"),
+    }
+
+    let sol = with_presolve(&prob);
+    let bare = without_presolve(&prob);
+    assert_eq!(
+        sol.status,
+        QpStatus::Optimal,
+        "presolved solve must succeed"
+    );
+    assert_eq!(bare.status, QpStatus::Optimal, "bare solve must succeed");
+    assert!(
+        (sol.obj - bare.obj).abs() <= 1e-6 * (1.0 + bare.obj.abs()),
+        "presolved objective {} != bare objective {}",
+        sol.obj,
+        bare.obj
+    );
+    assert!(
+        (sol.obj - 10.0).abs() < 1e-6,
+        "optimum is x6 = 10, got {}",
+        sol.obj
+    );
+}
+
+/// The pin-tightness guard must not cost the reduction its normal case: a row
+/// whose activity range touches its right-hand side *exactly* is still
+/// forcing, and still fixes every variable in it.
+#[test]
+fn an_exactly_touching_row_still_forces() {
+    // x0 + x1 = 0 with x ∈ [0, 1]²: min activity is exactly 0, so both
+    // variables are pinned to their lower bounds — a real forcing row.
+    let prob = QpProblem {
+        n: 3,
+        p_lower: vec![],
+        c: vec![1.0, 1.0, 1.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 2, 1.0),
+            Triplet::new(1, 0, 1.0),
+        ],
+        b: vec![0.0, 0.5],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0; 3],
+        ub: vec![1.0; 3],
+    };
+    match presolve(&prob) {
+        PresolveOutcome::Reduced(ps) => assert!(
+            ps.stats().forcing_rows >= 1,
+            "an exactly-touching row must still be recognized as forcing"
+        ),
+        other => panic!(
+            "expected Reduced, got {}",
+            match other {
+                PresolveOutcome::Infeasible(t) => format!("Infeasible ({t})"),
+                _ => "Unbounded".to_string(),
+            }
+        ),
+    }
+    let sol = with_presolve(&prob);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!(
+        (sol.obj - 0.5).abs() < 1e-6,
+        "optimum is 0.5, got {}",
+        sol.obj
+    );
+}
+
+/// A real infeasibility is still proved in presolve — and now says which
+/// screen proved it and on what, which is the whole diagnostic a caller gets
+/// for a verdict reached in zero iterations.
+#[test]
+fn a_real_infeasibility_is_reported_with_its_trigger() {
+    // x0 + x1 = 5 with x ∈ [0, 1]²: the activity range is [0, 2].
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![0.0, 0.0],
+        a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        b: vec![5.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![1.0, 1.0],
+    };
+    match presolve(&prob) {
+        PresolveOutcome::Infeasible(t) => {
+            assert!(!t.screen.is_empty(), "the screen must be named");
+            assert!(
+                t.detail.contains("row 0"),
+                "the trigger must name the row it tripped on, got {t}"
+            );
+        }
+        _ => panic!("an out-of-range equality must presolve to Infeasible"),
+    }
+    assert_eq!(with_presolve(&prob).status, QpStatus::PrimalInfeasible);
+}
+
+/// The guard's cost, stated as a test: when a *genuine* infeasibility is only
+/// reachable through a forcing pin, the re-derivation has to find it another
+/// way — here domain propagation does, by shrinking the same box the pin
+/// would have chosen — so the verdict survives.
+///
+/// This is what keeps the guard from being a blanket "never report
+/// infeasible": it withholds only the fixings, and everything that merely
+/// narrows or screens is still there to confirm.
+#[test]
+fn a_genuine_forcing_infeasibility_is_still_confirmed() {
+    // x0 + x1 = 0 forces x0 = x1 = 0 (both nonnegative); x0 + 2·x1 = 1 then
+    // cannot hold.
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![],
+        c: vec![0.0, 0.0],
+        a: vec![
+            Triplet::new(0, 0, 1.0),
+            Triplet::new(0, 1, 1.0),
+            Triplet::new(1, 0, 1.0),
+            Triplet::new(1, 1, 2.0),
+        ],
+        b: vec![0.0, 1.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![1.0, 1.0],
+    };
+    match presolve(&prob) {
+        PresolveOutcome::Infeasible(_) => {}
+        PresolveOutcome::Reduced(_) => {
+            // Acceptable only if the solver itself still says infeasible —
+            // the guard may cost the fast path, never the answer.
+            assert_eq!(
+                with_presolve(&prob).status,
+                QpStatus::PrimalInfeasible,
+                "downgraded verdict must still come out infeasible"
+            );
+        }
+        PresolveOutcome::Unbounded => panic!("not unbounded"),
+    }
+}

--- a/crates/pounce-convex/tests/presolve_aggregation.rs
+++ b/crates/pounce-convex/tests/presolve_aggregation.rs
@@ -116,7 +116,7 @@ fn reduced_size(prob: &QpProblem) -> (usize, usize) {
         other => panic!(
             "expected a reduction, got {}",
             match other {
-                PresolveOutcome::Infeasible => "Infeasible",
+                PresolveOutcome::Infeasible(_) => "Infeasible",
                 PresolveOutcome::Unbounded => "Unbounded",
                 PresolveOutcome::Reduced(_) => unreachable!(),
             }
@@ -580,7 +580,7 @@ fn contradictory_aliases_are_not_this_passs_verdict() {
             // The alias rows must still be there for someone else to judge.
             assert!(ps.reduced.m_eq() >= 2, "{}", ps.reduced.m_eq());
         }
-        PresolveOutcome::Infeasible => {
+        PresolveOutcome::Infeasible(_) => {
             // Reached by the *duplicate-row* reduction, which is entitled
             // to it: two identical rows with different right-hand sides.
         }

--- a/crates/pounce-convex/tests/presolve_bound_rows.rs
+++ b/crates/pounce-convex/tests/presolve_bound_rows.rs
@@ -63,7 +63,7 @@ fn lower_box_to_rows(p: &QpProblem) -> QpProblem {
 fn reduced(prob: &QpProblem) -> pounce_convex::presolve::Presolve {
     match presolve(prob) {
         PresolveOutcome::Reduced(ps) => ps,
-        PresolveOutcome::Infeasible => panic!("expected Reduced, got Infeasible"),
+        PresolveOutcome::Infeasible(_) => panic!("expected Reduced, got Infeasible"),
         PresolveOutcome::Unbounded => panic!("expected Reduced, got Unbounded"),
     }
 }

--- a/crates/pounce-convex/tests/presolve_bound_tightening.rs
+++ b/crates/pounce-convex/tests/presolve_bound_tightening.rs
@@ -215,7 +215,7 @@ fn randomized_bound_tightening_roundtrip() {
         // Skip presolve-detected infeasible instances (random RHS can make
         // a group infeasible); the direct solve agrees by status.
         match presolve(&prob) {
-            PresolveOutcome::Infeasible => {
+            PresolveOutcome::Infeasible(_) => {
                 assert_eq!(direct(&prob).status, QpStatus::PrimalInfeasible);
                 continue;
             }
@@ -290,7 +290,7 @@ fn randomized_overlapping_tightening_roundtrip() {
         };
 
         match presolve(&prob) {
-            PresolveOutcome::Infeasible => {
+            PresolveOutcome::Infeasible(_) => {
                 assert_eq!(direct(&prob).status, QpStatus::PrimalInfeasible);
                 continue;
             }

--- a/crates/pounce-convex/tests/presolve_conic.rs
+++ b/crates/pounce-convex/tests/presolve_conic.rs
@@ -125,7 +125,7 @@ fn exp_cone_empty_row_negative_h_is_not_infeasible() {
             assert_eq!(ps.reduced.m_ineq(), 3, "exp block rows must all survive");
             assert_eq!(ps.reduced_cones(&cones), vec![ConeSpec::Exponential]);
         }
-        PresolveOutcome::Infeasible => {
+        PresolveOutcome::Infeasible(_) => {
             panic!("empty exp row with h<0 wrongly reported Infeasible (H9)")
         }
         PresolveOutcome::Unbounded => panic!("unexpected Unbounded"),
@@ -164,7 +164,7 @@ fn exp_cone_activity_redundant_row_not_dropped() {
         }
         other => panic!(
             "expected Reduced with 3 rows, got {}",
-            matches!(other, PresolveOutcome::Infeasible)
+            matches!(other, PresolveOutcome::Infeasible(_))
         ),
     }
 }

--- a/crates/pounce-convex/tests/presolve_reductions.rs
+++ b/crates/pounce-convex/tests/presolve_reductions.rs
@@ -196,7 +196,7 @@ fn duplicate_equality_rows_conflicting_infeasible() {
         lb: vec![],
         ub: vec![],
     };
-    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible(_)));
     assert_eq!(with_presolve(&prob).status, QpStatus::PrimalInfeasible);
 }
 
@@ -417,7 +417,7 @@ fn parallel_equality_inconsistent_infeasible() {
         lb: vec![],
         ub: vec![],
     };
-    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible(_)));
 }
 
 /// Parallel inequalities (positive multiple): `x0 + x1 ≤ 3` and
@@ -690,7 +690,7 @@ fn activity_infeasible_inequality() {
         lb: vec![2.0],
         ub: vec![3.0],
     };
-    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible(_)));
     assert_eq!(with_presolve(&prob).status, QpStatus::PrimalInfeasible);
 }
 
@@ -709,7 +709,7 @@ fn activity_infeasible_equality() {
         lb: vec![0.0, 0.0],
         ub: vec![1.0, 1.0],
     };
-    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible(_)));
     assert_eq!(with_presolve(&prob).status, QpStatus::PrimalInfeasible);
 }
 
@@ -781,7 +781,7 @@ fn unbounded_variable_row_becomes_the_bound_it_is() {
 fn status_of(o: &PresolveOutcome) -> &'static str {
     match o {
         PresolveOutcome::Reduced(_) => "Reduced",
-        PresolveOutcome::Infeasible => "Infeasible",
+        PresolveOutcome::Infeasible(_) => "Infeasible",
         PresolveOutcome::Unbounded => "Unbounded",
     }
 }
@@ -1081,7 +1081,10 @@ fn contradictory_singleton_rows_are_seen_as_an_empty_box() {
     // without any arithmetic on the solver's part.
     for gap in [1e-8, 1e-7, 1e-6, 1.0] {
         assert!(
-            matches!(presolve(&boxed_by_rows(gap)), PresolveOutcome::Infeasible),
+            matches!(
+                presolve(&boxed_by_rows(gap)),
+                PresolveOutcome::Infeasible(_)
+            ),
             "gap={gap:e} must presolve to Infeasible"
         );
     }

--- a/crates/pounce-convex/tests/presolve_roundtrip.rs
+++ b/crates/pounce-convex/tests/presolve_roundtrip.rs
@@ -164,7 +164,7 @@ fn empty_row_infeasible_detected() {
         lb: vec![],
         ub: vec![],
     };
-    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible));
+    assert!(matches!(presolve(&prob), PresolveOutcome::Infeasible(_)));
     assert_eq!(with_presolve(&prob).status, QpStatus::PrimalInfeasible);
 }
 
@@ -288,7 +288,7 @@ fn heavily_reduced_mixed_reductions_recovers_primal_and_dual() {
                 ps.reduced.n
             );
         }
-        PresolveOutcome::Infeasible => panic!("expected Reduced, got Infeasible"),
+        PresolveOutcome::Infeasible(_) => panic!("expected Reduced, got Infeasible"),
         PresolveOutcome::Unbounded => panic!("expected Reduced, got Unbounded"),
     }
 

--- a/dev-notes/termination-status-invariants.md
+++ b/dev-notes/termination-status-invariants.md
@@ -1,8 +1,10 @@
 # Termination-status invariants
 
-One invariant has now been violated at four independent sites, and each was
-fixed in isolation as if it were a one-off. It is written here so the fifth one
-gets recognised as a recurrence rather than rediscovered.
+One invariant has now been violated at five independent sites, and the first
+four were each fixed in isolation as if it were a one-off. It is written here
+so the next one gets recognised as a recurrence rather than rediscovered — the
+fifth (gh #523) was, and it turned up in a different subsystem, by a mechanism
+the first four do not share.
 
 ## The invariant
 
@@ -27,7 +29,7 @@ The comment on that guard is the point of this note:
 It was applied to restoration and never generalised. Two more holes followed,
 in two other files.
 
-## The four holes
+## The holes
 
 | # | site | mechanism | fixed |
 |---|---|---|---|
@@ -35,6 +37,7 @@ in two other files.
 | gh #385 / #390 | `conv_check` surrogate `‖Jᵀc‖/max(1,‖c‖)` | not scale-invariant; row scaling drives it to zero anywhere | no-descent confirmation |
 | gh #508 | `ipopt_alg.rs` cycle exit | violation compared against a threshold built from `tol` | 097a4719 |
 | gh #519 | `conv_check/opt_error.rs` rapid detector | violation compared against an unclamped `infeas_viol_kappa · constr_viol_tol` | PR #521, ef5d77e8 |
+| gh #523 | `pounce-convex/src/presolve.rs` forcing rows | a *reduction*, not a threshold: an approximate touch pinned variables far enough off to contradict another row | see below |
 
 Each was found by a different route, none by the guard that already existed.
 gh #505 came from an external reporter; gh #508 from an `/adversary` run
@@ -48,6 +51,70 @@ earlier hypothesis, was rescoped afterwards to the structural change it always
 should have been (below) and explicitly disclaims the fix. **The bug report and
 the defect are different objects; conflating them is what made #505 take four
 diagnoses to converge.**
+
+## The fifth hole is in a different subsystem (gh #523)
+
+The note above was written so a fifth instance would be recognised rather than
+rediscovered. It was — but not where the first four pointed. gh #523 is a false
+infeasibility from **presolve** in `pounce-convex`, not from the NLP
+termination path, and its mechanism is not a threshold at all.
+
+The four holes above are all one shape: *a violation compared against a
+threshold built from the wrong tolerance*. Audit the comparisons and you find
+them. gh #523 has no such comparison. Its screens were individually fine; the
+**state they screened** was wrong. Presolve's forcing reduction saw an equality
+row whose activity range `[-6.29e-10, 4.87e-8]` came within `ACTIVITY_TOL` of
+its right-hand side `0`, concluded the row could hold only at that vertex, and
+pinned six variables to bounds. Two of them, with coefficients `-1.14e-1` and
+`-5.7e-3`, went to *upper* bounds `4.8e-9` and `1.5e-8` from zero: a gap of
+`6.29e-10` licensed a displacement 24× larger, because the displacement a gap
+buys is `gap / |coef|`, not `gap`. Substituted forward, the next row those two
+appeared in read as inconsistent by `2.0e-8`, and presolve returned
+`Infeasible_Problem_Detected` in five milliseconds on a feasible LP.
+
+So the generalisation the earlier holes suggest — *audit every threshold* —
+would not have found this one. The generalisation that would is:
+
+> **A tolerance that gates a *model change* is not the same risk as one that
+> gates a *report*.** A wrong report is one wrong answer. A wrong model change
+> propagates: it substitutes a fabricated value into every row the variable
+> touches, and the failure surfaces somewhere else entirely, in a screen that
+> is behaving correctly on data that is not.
+
+Two of presolve's reductions have that shape — forcing constraints and
+dominated columns fix a variable at a value chosen from a tolerance judgment.
+Everything else in the catalog drops a constraint, narrows a box, or rewrites a
+row; being wrong there loses a reduction. The fix is in two layers, and the
+second is the one worth generalising:
+
+1. **Root cause.** Forcing now fires only when the residual gap is small enough
+   that *every* variable in the row lands within `FORCING_PIN_TOL` of the bound
+   it is pinned to — `min(gap / |coefⱼ|, widthⱼ) ≤ tol`, not `gap ≤ tol`.
+2. **Structural guard.** An infeasibility verdict is no longer emitted on the
+   strength of the pass that raised it. It is re-derived from the original
+   problem with those two reductions withheld, and only a verdict *that* pass
+   reaches on its own is returned. Otherwise the reduction is solved normally
+   and the discarded claim is kept on the handle so the near-miss is
+   reportable. A misfiring reduction now costs a few eliminations instead of
+   the answer.
+
+Layer 2 was verified to stand on its own: with layer 1 reverted, `bore3d` and
+`QBORE3D` still solve to the reference objectives, with the discarded claim
+reported. That is the property to want from every "confident fast answer" path
+— **the fast path must be checkable against a slower one that does not share
+its assumptions**, not merely correct.
+
+The reporting lesson from the last section of this note recurred verbatim:
+`print_level=8` emitted nothing on the way out, so a five-millisecond wrong
+answer had no trace at all. `PresolveOutcome::Infeasible` now carries the
+screen and the row/column/bound it tripped on, and the CLI prints it.
+
+Worth noting how the bug advertised itself and was ignored: the termination
+block printed alongside the false verdict reported a constraint violation of
+`1.79e+01` and dual infeasibility of `3.35e+02` at the returned point — i.e. a
+point that is neither feasible nor a certificate of anything. **A status block
+internally inconsistent with its own status is enforcement item 1 of this note,
+already written down, and it was printing.**
 
 ## Why gh #505 survived three releases
 

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -188,6 +188,39 @@ Two things this deliberately does **not** do:
 The aggregation shares its planner with the NLP path's Phase 6, so the
 two agree on what can be eliminated (see [NLP Presolve](./options.md)).
 
+### Infeasibility verdicts are re-derived before they are reported
+
+A presolve infeasibility comes back in milliseconds with no iteration
+behind it, so when it is wrong it is the most expensive answer the solver
+can give. Two reductions — forcing constraints and dominated columns —
+*fix a variable* at a value they choose from a tolerance judgment, and a
+fixing that is wrong is substituted into every row that variable appears
+in until some row reads as contradictory: a false infeasibility, reported
+against a row nowhere near the reduction that caused it.
+
+So presolve does not report an infeasibility on the strength of the pass
+that found it. It re-derives the verdict from your original model with
+those two reductions switched off, and reports `Infeasible_Problem_Detected`
+only if that pass reaches the same conclusion on its own. If it does not,
+the model is solved normally and presolve says so:
+
+```text
+Presolve: discarded an unconfirmed infeasibility claim — <screen> (<detail>); solving normally
+```
+
+A confirmed verdict now names the screen that proved it and the row,
+column, or bound it tripped on, rather than exiting silently:
+
+```text
+Presolve: proved primal infeasible — empty equality row (equality row 7 is `0 = 3e0`)
+```
+
+Nothing that only *reports* is withheld from the re-derivation — empty
+rows, activity ranges, parallel rows, and emptied-row residuals all still
+apply — so no infeasibility presolve could detect before goes undetected
+now. What the guard costs, in the rare case it fires, is a handful of
+eliminations.
+
 Presolve is on by default. Turn it off with `qp_presolve=no` (e.g. to
 compare timings or isolate a solver issue):
 


### PR DESCRIPTION
Fixes #523

## Problem

`pounce-convex` returned `Infeasible_Problem_Detected` at iteration 0, in ~5 ms with no diagnostic, on two feasible problems: netlib `bore3d` and its Maros-Mészáros quadratic twin `QBORE3D` (both n=315, m=233 — the same model, the latter adding a convex quadratic objective). They were the only non-matching failure in the `lp` suite and the only one in the `qp` suite.

`bore3d`:

| | status | objective | iters |
|---|---|---|---|
| before | Infeasible_Problem_Detected | 0.0 | 0 |
| after | Optimal | 1373.0803943 | 21 |
| oracle (ipopt-ma57) | Solved_To_Acceptable_Level | 1373.0803839 | — |

`QBORE3D`:

| | status | objective | iters |
|---|---|---|---|
| before | Infeasible_Problem_Detected | 0.0 | 0 |
| after | Optimal | 3100.2008018 | 21 |
| oracle (ipopt-ma57) | Solve_Succeeded | 3100.2007904 | — |

The reported termination block was internally inconsistent with its own status — constraint violation `1.79e+01`, dual infeasibility `3.35e+02` at the returned point, i.e. a point that is neither feasible nor a certificate. That inconsistency is enforcement item 1 of `dev-notes/termination-status-invariants.md`, already written down, and it was printing.

The benchmark corpus is not vendored, so these were reproduced by fetching `bore3d` from the COIN-OR netlib mirror and `QBORE3D.mat` from `qpsolvers/maros_meszaros_qpbenchmark`, converted to `QpProblem` directly. Both reproduced the reported failure exactly (`PrimalInfeasible`, `obj=0`, `iters=0`).

## Cause

Presolve's **forcing-constraint** reduction — none of the three screens the issue nominated.

Bound tightening propagates a group of nonnegative variables' upper bounds geometrically toward their true limit of zero, round after round; the cascade converges but never terminates, so the fixpoint runs to its layer cap. By round 21 those boxes are ~1e-8 wide, and one equality row's activity range `[-6.29e-10, 4.87e-8]` comes within `ACTIVITY_TOL` (1e-9) of its right-hand side `0` at the min vertex:

```
row 11 (b = 0):  8.17e-2·x0 + 5.32e-2·x1 + 8.3e-3·x2 − 1.14e-1·x3 − 5.7e-3·x4 + x5 = 0
boxes: [0, 1.98e-7] [0, 3.04e-7] [0, 2.21e-8] [0, 4.76e-9] [0, 1.52e-8] [0, 1.62e-8]
amin = −6.29e-10   amax = 4.87e-8
```

Forcing read that as "this row can hold only at that vertex" and pinned all six variables to bounds — `x0, x1, x2, x5` to `0`, and `x3, x4` (negative coefficients) to *upper* bounds `4.76e-9` and `1.52e-8`. But `b = 0` lies strictly inside `[amin, amax]`; the row is not forcing, it merely looks forcing at 1e-9.

The key quantity: a residual gap `g` licenses a displacement of `g/|coefⱼ|` on variable `j`, not `g`. Here `6.29e-10` bought `1.52e-8` — 24× larger — because the coefficients are small. Substituted forward, the next row those two appear in (`x0+x1+x2+x3+x4−x5 = 0`) read as inconsistent by `2.0e-8` against a tolerance of `1.0e-9`, and presolve called a feasible problem infeasible.

## Fix

**1. Forcing must be tight, not merely close.** A forcing row now has to clear a stronger bar than "the gap is small": the gap must be small enough that *every* pinned variable lands within `FORCING_PIN_TOL` of where the pin claims it is — `min(gap/|coefⱼ|, widthⱼ) ≤ tol`, capped by the box width since a variable cannot leave its box either way. A row that genuinely touches (`gap == 0`) is unaffected, which is every legitimate forcing row in the existing suite.

**2. An infeasibility verdict is re-derived before it is emitted** — the guard the issue asked for. When any screen reports infeasible, presolve re-runs from the original problem with the two reductions that *fix a variable at a tolerance-chosen value* withheld (forcing constraints, dominated columns), and only a verdict that pass reaches on its own is returned as `PrimalInfeasible`. Otherwise the reduction is solved normally and the discarded claim is kept on the handle (`Presolve::discarded_infeasibility`).

Considered and rejected: withholding *all* tolerance-based reductions in the confirming pass. That reads as the safer line but is the wrong one — it costs real detection power. Bound tightening is what proves `x ≤ −gap ∧ x ≥ 0` infeasible (`contradictory_singleton_rows_are_seen_as_an_empty_box`), and the activity screens are what prove `x0+x1 = 5` over `[0,1]²` infeasible; both would have downgraded to a full solve. The line that actually matters is **fix vs. report**: a wrong report is one wrong answer, while a wrong *fixing* propagates into every row the variable touches and surfaces somewhere else entirely, in a screen behaving correctly on data that is not. Only forcing and dominated columns have that shape. Everything that narrows, drops, or screens is retained, so no infeasibility class detectable before is lost.

**3. The silent exit is gone.** `PresolveOutcome::Infeasible` carries an `InfeasibleTrigger` (the screen, plus the row/column/bound and the compared values), printed by the CLI for both the proved and the discarded case. Previously even `print_level=8` emitted nothing on the way out — which is most of why this cost so much to localize.

Layer 2 was verified to stand alone: with layer 1 reverted, both problems still solve to the reference objective, reporting

```
Presolve: discarded an unconfirmed infeasibility claim — row emptied by substitution is
inconsistent (equality row 33: residual -1.992965e-8 exceeds tolerance 1.000000e-9
(cancellation scale 1.517033e-8)); solving normally
```

**Deliberately out of scope:** the bound-tightening cascade itself. It never converges on this model — it shaves those boxes geometrically until the layer cap cuts it off, burning ~20 fixpoint rounds. That is sound (it is approaching the true bound of zero) and no longer dangerous now that forcing will not pin on it, but it is wasted work. Worth a separate issue; fixing it here would have mixed a performance change into a correctness fix. The sweep below shows no runtime cost, so it is not urgent.

## Blast radius

- **`pounce-convex` presolve**, all callers (CLI convex path, `pounce-py`, `solve_with_presolve`). The forcing change only withholds pins that were previously made on a near-touch; an exact touch behaves identically. The re-derivation runs only when a verdict is raised — a cold path — so there is no cost on any solve that does not claim infeasibility.
- **Breaking (`pounce-convex` API):** `PresolveOutcome::Infeasible` is now a tuple variant. `matches!(…, PresolveOutcome::Infeasible)` becomes `PresolveOutcome::Infeasible(_)`. 24 in-tree call sites updated, all mechanical; noted in the CHANGELOG.
- **Corpus sweep: run, clean** ([comment](https://github.com/jkitchin/pounce/pull/525#issuecomment-5219879702)). `lp` 368/371 (baseline 367/371), `qp` 138/138 (baseline 137/138), against `a664dc05` on the same host and corpus. Across all **509 problems**: `FIXED=2` (the two intended), `BROKE=0`, `obj-drift=0`. Runtime within noise both ways (`lp` 580s vs 583s, `qp` 220s vs 218s), consistent with the re-derivation being a cold path. This is the check that would catch a legitimate forcing pin the fix now declines; nothing in either corpus had one declined. Presolve still reports `forcing 17` on `bore3d` after the fix — the reduction is not disabled on the model that motivated the change.
- **NLP suites not swept**, but the exposure is ruled out by static reachability rather than reasoning: `pounce_convex::presolve` has exactly one production call site (`crates/pounce-cli/src/main.rs:2124`, inside `run_convex_qp`), which has exactly one caller in the convex dispatch branch, and both `main.rs` hunks in this diff are inside that function. `pounce-py` never touches the presolve module; `pounce-algorithm` names `pounce_convex` only in a comment. The NLP path's presolve is `pounce-presolve`, a separate crate, untouched.
- **`presolve_conic` got the same guard and no sweep touched it** — the conic path is `cblib`/SOCP/SDP, not `lp`/`qp`. Same three-line wrapper as the orthant path, and the in-tree conic presolve tests pass, but that gap is real and named here rather than left implicit.

## Tests

`crates/pounce-convex/tests/issue523_false_forcing_infeasibility.rs`, four tests:

- `near_forcing_row_does_not_falsify_a_feasible_lp` — the `bore3d` geometry distilled to the two rows that matter, with the exact coefficients and box widths from round 21. **Fails on the parent commit**, and for the right reason twice over: with the guard active it fails on the `discarded_infeasibility().is_none()` assertion (the guard caught it and downgraded); with both layers reverted it fails on `panic!("feasible LP reported primal infeasible by presolve")`, the original bug. That is how each layer was verified independently.
- `an_exactly_touching_row_still_forces` — over-correction guard; a row with `gap == 0` still fires and still fixes.
- `a_real_infeasibility_is_reported_with_its_trigger` — a genuine infeasibility still proves out, and names its screen and row.
- `a_genuine_forcing_infeasibility_is_still_confirmed` — the guard's cost, stated as a test: an infeasibility only reachable through a forcing pin must still come out infeasible (domain propagation re-derives it), or at minimum survive to the solver.

**Not pinned:** `bore3d` and `QBORE3D` themselves. The `.nl` inputs are ~2 GB of gitignored corpus, too large to vendor, so the regression test carries the distilled geometry instead and the full instances stay a benchmark-sweep check — which is the sweep recorded above.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`lp-qp-routing.md`, convex presolve section — the reported output changed; no new page, so `SUMMARY.md` is unchanged)
- [x] `cargo fmt --all -- --check`, `cargo clippy` (CI gate: `-D clippy::correctness -D clippy::suspicious`), `cargo test --workspace --exclude pounce-hsl` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

`dev-notes/termination-status-invariants.md` records this as the fifth instance of that note's invariant — the note exists so a fifth would be recognised rather than rediscovered, and this one is the first in a different subsystem, by a mechanism the other four do not share (a reduction, not a threshold). The generalisation the earlier four suggest — *audit every threshold* — would not have found it.
