### PR TITLE
routing: hand an uncertified LP back to the NLP path under auto (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,45 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — `auto` sent the NETLIB GEN family to the convex IPM, which cannot certify it, while the NLP path solves it in a second (#535)
+
+- `solver_selection=auto` routes every detected LP to the convex
+  interior-point method. On `gen` / `gen1` that costs **194× in wall clock
+  and the certificate**: 199 of a 200-iteration budget, 190.8 s, and
+  `Solved_To_Acceptable_Level` at a primal residual of `1.374e-7` against
+  `tol = 1e-8`. The general NLP filter-IPM — the same binary, the default
+  for every other class — solves the same model in **19 iterations and
+  0.982 s** to `Solve_Succeeded`, matching Ipopt-3.14.20/MA57's objective
+  to four figures.
+- The root cause is #133 and still stands: the family is highly degenerate
+  and rank-deficient, strict complementarity fails, the
+  fraction-to-boundary step collapses, and a pure IPM cannot certify the
+  vertex. Crossover was built to close exactly this and does not (it is off
+  by default because it regressed LP-suite solve times 3×–800× while still
+  not reaching an exact vertex on GEN). This is not the #528 noise floor
+  either — the largest right-hand side in `gen.nl` is `65.16`, so #531's
+  `κ = 64` floor sits at `9.2e-13` there, five orders below the violation.
+- **The routing is now the lever, not the crossover engine.** Under `auto`,
+  an LP whose convex solve finishes *without a certificate* —
+  `OptimalInaccurate` or `IterationLimit` — is re-solved on the general NLP
+  interior-point path, which owns the whole verdict. An LP is also a valid
+  NLP, and the fallback is the same discipline the conic path has used
+  since the `airport` stall: the decision is taken above the status line,
+  the `.sol` write and the JSON report, so a rerouted run still reports
+  exactly one status.
+- It is also the *faster* answer here — one second of NLP after a failed
+  convex attempt is nothing against the 190.8 s the convex attempt costs.
+- Narrow by construction. It does not fire on a convex QP (`P ≠ 0`), on a
+  solve that certified, on a *verified* infeasible / unbounded verdict, when
+  `solver_selection` names an engine, when `max_iter` was set explicitly
+  (a user-set budget is the question being asked, and `max_iter=0` must
+  still stop without a solve, #186), or with the interactive debugger
+  attached. A tightened `tol` deliberately does **not** suppress it: that is
+  an accuracy request, so trying the engine that can meet it is the right
+  response.
+- With this the `Ipopt only` column of the benchmark report loses its last
+  two entries that POUNCE was thought unable to reach at all.
+
 ### Fixed — feasible, bounded LPs exited `Search_Direction_Becomes_Too_Small` once the data reached `~1e7` (#528)
 
 - On plain LPs with `O(1)` matrix entries but right-hand sides of magnitude

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2439,6 +2439,13 @@ fn run_convex_qp(
         collect_iterates: want_trace,
         ..convex_opts
     };
+    // What presolve did, held back until we know this solve is the one that
+    // reports (gh #535). These lines describe the reduction, not the verdict,
+    // but they are the *only* stdout a declined convex attempt would otherwise
+    // leave behind — and "the rerouted run prints nothing from the attempt it
+    // discarded" is a cleaner contract than "nothing except one line". Flushed
+    // below, immediately after the fallback check.
+    let mut presolve_log: Vec<String> = Vec::new();
     let sol = if qp_opts.max_iter == 0 {
         // AMPL/Ipopt semantics: `max_iter=0` takes no iterations and so
         // cannot reach optimality. Presolve can otherwise solve a trivial
@@ -2468,10 +2475,10 @@ fn run_convex_qp(
                 // `Infeasible_Problem_Detected` into a normal solve, and this
                 // line is the only trace of the reduction that misfired.
                 if let Some(trigger) = ps.discarded_infeasibility() {
-                    println!(
+                    presolve_log.push(format!(
                         "Presolve: discarded an unconfirmed infeasibility claim — \
                          {trigger}; solving normally"
-                    );
+                    ));
                 }
                 let st = ps.stats();
                 if st.reduced_anything() {
@@ -2491,7 +2498,7 @@ fn run_convex_qp(
                             format!(", cap-truncated after {} layers", st.rounds)
                         }
                     };
-                    println!(
+                    presolve_log.push(format!(
                         "Presolve: {} → {} vars, {} → {} rows (fixed {}, \
                          free-fixed {}, substituted {}, aggregated {}, \
                          forcing {}, dominated {}, tightened {}{})",
@@ -2507,7 +2514,7 @@ fn run_convex_qp(
                         st.dominated_cols,
                         st.tightened_bounds,
                         exit,
-                    );
+                    ));
                 }
                 let red = if use_active_set {
                     let mut mk = backend;
@@ -2521,7 +2528,7 @@ fn run_convex_qp(
                 // Name the screen and what it tripped on. A presolve
                 // infeasibility arrives with no iteration behind it, so this
                 // line is the whole record of *why* (gh #523).
-                println!("Presolve: proved primal infeasible — {trigger}");
+                presolve_log.push(format!("Presolve: proved primal infeasible — {trigger}"));
                 trivial(QpStatus::PrimalInfeasible)
             }
             PresolveOutcome::Unbounded => trivial(QpStatus::DualInfeasible),
@@ -2560,6 +2567,12 @@ fn run_convex_qp(
             qp_opts.tol,
         );
         return None;
+    }
+
+    // This solve is the one that reports, so what presolve did belongs on the
+    // record after all.
+    for line in &presolve_log {
+        println!("{line}");
     }
 
     // Report the objective in the user's original sense, including the

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -800,6 +800,19 @@ pub fn main() -> ExitCode {
         // engine and silently answering from a different one would hide it.
         let socp_nlp_fallback = matches!(selection, SolverSelection::Auto);
 
+        // gh #535: and the same bargain again for an LP the convex IPM cannot
+        // certify. `auto` for the same reason as above — the LP classification
+        // was our inference, so a failure to certify it is ours to fix, while a
+        // named engine keeps its verdict. Additionally suppressed when the user
+        // set `max_iter` (their budget is the question being answered, and
+        // `max_iter=0` must stop without a solve, pounce#186) and when the
+        // interactive debugger is attached (the user is stepping *this* engine;
+        // silently continuing into a different one would strand the session).
+        // See `lp_declines_to_nlp` for the rest of the gating.
+        let lp_nlp_fallback = matches!(selection, SolverSelection::Auto)
+            && debug_hook.is_none()
+            && !max_iter_explicitly_set(&app);
+
         // Banner-level routing line: report the detected problem class and
         // which of pounce's solvers was selected for it. Gated like the
         // banner (suppressed by `sb yes` and in JSON-debug protocol mode) so
@@ -1011,7 +1024,12 @@ pub fn main() -> ExitCode {
                              solver_selection=qp-ipm to debug a convex QP interactively."
                         );
                     }
-                    return run_convex_qp(
+                    // `None` means the convex solve finished an LP without a
+                    // certificate and declined it (gh #535, `auto` only — see
+                    // `lp_nlp_fallback`). It printed no verdict and wrote no
+                    // `.sol`/JSON, so control falls out of this whole block to
+                    // the NLP solve below, which owns the one verdict.
+                    if let Some(code) = run_convex_qp(
                         &prob,
                         class,
                         sol_path.as_deref(),
@@ -1022,7 +1040,10 @@ pub fn main() -> ExitCode {
                         convex_opts,
                         matches!(choice, SolverChoice::QpActiveSet),
                         engine_overrides,
-                    );
+                        lp_nlp_fallback,
+                    ) {
+                        return code;
+                    }
                 }
             }
             // Builtins never classify as convex; fall through to NLP.
@@ -2096,6 +2117,73 @@ fn resolve_scaling_retry_outcome(
     }
 }
 
+/// Should an LP whose convex solve came back without a certificate be handed
+/// to the general NLP interior-point path instead (gh #535)?
+///
+/// The NETLIB `gen`/`gen1` models are the case this exists for: `auto` routes
+/// them to the convex IPM, which exhausts its 200-iteration budget in 191 s and
+/// exits `OptimalInaccurate` with a primal residual of 1.4e-7 against
+/// `tol = 1e-8`, while the general NLP filter-IPM — the same binary, the
+/// default for every other class — solves the same model in 19 iterations and
+/// 1.0 s to a strict certificate. The models are highly degenerate and
+/// rank-deficient, strict complementarity fails, and a pure IPM cannot certify
+/// the vertex (gh #133); crossover was built to close that gap and does not.
+/// So the routing is the cheap lever: an LP is also a valid NLP, and the NLP
+/// path is already in the binary.
+///
+/// The three gates, all necessary:
+///
+/// * **`allow_nlp_fallback`** — set by the caller only under `auto` (the class
+///   was our inference, not the user's instruction), with no interactive
+///   debugger attached, and only when the user did **not** set `max_iter`. A
+///   user-set budget is a budget: `IterationLimit` is then the answer to the
+///   question that was asked, and `max_iter=0` in particular must stop without
+///   a solve (pounce#186), not launch a second one. An explicitly tightened
+///   `tol` is deliberately *not* a suppressor — that is an accuracy request,
+///   and trying the engine that can meet it is exactly the right response.
+/// * **`ProblemClass::Lp`** — `P = 0`, per the issue. A convex QP that stalls
+///   is a different (and unmeasured) population; leave it to the engine that
+///   was chosen for it.
+/// * **the status** — only the two that mean "no certificate": a
+///   reduced-accuracy exit and an exhausted budget. `Optimal` needs no help,
+///   and `PrimalInfeasible` / `DualInfeasible` are verdicts the convex solver
+///   *verified*, which a second solve must not be allowed to overwrite.
+///   `NumericalFailure` is left alone here for the same reason the QP path has
+///   always reported it: it is the post-solve verification refusing a point,
+///   and the LP corpus has no case of it that the NLP path recovers.
+///
+/// Note what this deliberately is **not**: the issue's "never-regress" variant,
+/// which would keep whichever of the two results certifies at the lower KKT
+/// error. That needs both verdicts in hand at reporting time, and the CLI's
+/// standing rule — the one `run_convex_socp` follows and gh #508 re-litigated
+/// for the NLP retry ladder — is that one solve prints one verdict. So the
+/// decision is taken *before* any status line, `.sol` or JSON report is
+/// emitted, and the NLP solve owns the whole report. The gates above are what
+/// bound the downside: this only ever runs on an LP that already failed to
+/// certify under a default budget.
+fn lp_declines_to_nlp(
+    class: pounce_cli::dispatch::ProblemClass,
+    status: pounce_convex::QpStatus,
+    allow_nlp_fallback: bool,
+) -> bool {
+    use pounce_convex::QpStatus;
+    allow_nlp_fallback
+        && class == pounce_cli::dispatch::ProblemClass::Lp
+        && matches!(
+            status,
+            QpStatus::OptimalInaccurate | QpStatus::IterationLimit
+        )
+}
+
+/// Did the user set `max_iter` explicitly? A user-set iteration budget
+/// suppresses the gh #535 LP→NLP fallback — see [`lp_declines_to_nlp`].
+fn max_iter_explicitly_set(app: &IpoptApplication) -> bool {
+    matches!(
+        app.options().get_integer_value("max_iter", ""),
+        Ok((_, true))
+    )
+}
+
 /// Solve a classified LP / convex-QP `.nl` problem through the
 /// specialized `pounce-convex` interior-point method, write a `.sol`,
 /// and return the process exit code. This is the LP/QP dispatch target
@@ -2274,6 +2362,14 @@ fn resolve_convex_presolve(
     }
 }
 
+/// Returns `None` when the LP→NLP fallback fires (gh #535): the problem is an
+/// LP, the caller allowed the fallback, and the convex solve finished without a
+/// certificate, so the caller falls through to the general NLP interior-point
+/// path. No status line, `.sol` or JSON report has been emitted in that case —
+/// the decision is taken above all three, so a rerouted solve produces exactly
+/// one verdict. (A `Presolve:` reduction line may already have been printed;
+/// it reports what presolve did, not what the solve concluded.) See
+/// [`lp_declines_to_nlp`] for the gating.
 fn run_convex_qp(
     prob: &nl_reader::NlProblem,
     class: pounce_cli::dispatch::ProblemClass,
@@ -2289,7 +2385,9 @@ fn run_convex_qp(
     use_active_set: bool,
     // Inner-engine overrides from the `sqp_qp_*` family; empty for the IPM.
     engine_overrides: pounce_convex::ActiveSetOverrides,
-) -> ExitCode {
+    // gh #535: may an uncertified LP solve be handed back to the NLP path?
+    allow_nlp_fallback: bool,
+) -> Option<ExitCode> {
     use pounce_convex::active_set::solve_qp_active_set;
     use pounce_convex::presolve::{FixpointExit, PresolveOutcome, presolve};
     use pounce_convex::{QpOptions, QpStatus, solve_qp_ipm, solve_qp_ipm_debug};
@@ -2301,7 +2399,7 @@ fn run_convex_qp(
                 "pounce: internal error: {} not extractable as QP",
                 class.name()
             );
-            return ExitCode::from(2);
+            return Some(ExitCode::from(2));
         }
     };
 
@@ -2435,6 +2533,34 @@ fn run_convex_qp(
         solve_qp_ipm(&qp, &qp_opts, backend)
     };
     let elapsed = t0.elapsed().as_secs_f64();
+
+    // gh #535: the convex path finished an LP without a certificate. An LP is
+    // also a valid NLP, and the general filter-IPM in this same binary solves
+    // the degenerate rank-deficient ones the interior path cannot certify
+    // (NETLIB `gen`/`gen1`: 199 iters / 191 s at reduced accuracy here, 19
+    // iters / 1.0 s and a strict certificate there). Hand it over rather than
+    // reporting the uncertified iterate as the last word.
+    //
+    // This sits above the status line, the `.sol` write and the JSON report on
+    // purpose — everything below is the verdict, and the rerouted solve owns
+    // it. See `lp_declines_to_nlp` for why each gate is there.
+    if lp_declines_to_nlp(class, sol.status, allow_nlp_fallback) {
+        let res = sol.kkt_residuals(&qp);
+        eprintln!(
+            "pounce: note: the convex ({}) solve did not certify a KKT point \
+             after {} iterations in {elapsed:.3}s (KKT error {:.2e} against \
+             tol {:.1e}); an LP is also a valid NLP, so it is being re-solved \
+             on the general NLP interior-point path, which certifies the \
+             degenerate, rank-deficient LPs the interior path stalls on (gh \
+             #133). Use solver_selection=qp-ipm to see the convex result \
+             instead.",
+            class.name(),
+            sol.iters,
+            res.kkt_error(),
+            qp_opts.tol,
+        );
+        return None;
+    }
 
     // Report the objective in the user's original sense, including the
     // dropped constant term: f_user = sign * (½xᵀPx + cᵀx) + const.
@@ -2579,7 +2705,7 @@ fn run_convex_qp(
         }
     }
 
-    convex_exit_code(ok, ampl)
+    Some(convex_exit_code(ok, ampl))
 }
 
 /// Solve a classified **convex QCQP** by reformulating it to a second-order
@@ -3100,6 +3226,104 @@ mod convex_status_tests {
             qp_status_to_ars(QpStatus::Optimal),
             ApplicationReturnStatus::SolveSucceeded
         );
+    }
+}
+
+#[cfg(test)]
+mod lp_nlp_fallback_tests {
+    use super::lp_declines_to_nlp;
+    use pounce_cli::dispatch::ProblemClass;
+    use pounce_convex::QpStatus;
+
+    const ALL_STATUSES: [QpStatus; 6] = [
+        QpStatus::Optimal,
+        QpStatus::OptimalInaccurate,
+        QpStatus::PrimalInfeasible,
+        QpStatus::DualInfeasible,
+        QpStatus::IterationLimit,
+        QpStatus::NumericalFailure,
+    ];
+
+    /// gh #535: the two statuses that mean "the convex solve produced no
+    /// certificate" are what hands an LP to the NLP path. `OptimalInaccurate`
+    /// is the NETLIB `gen`/`gen1` exit (199 of 200 iterations, primal residual
+    /// 1.4e-7 against `tol = 1e-8`); `IterationLimit` is the same stall when
+    /// the reduced-accuracy band is missed too.
+    #[test]
+    fn an_uncertified_lp_is_handed_to_the_nlp_path() {
+        for status in [QpStatus::OptimalInaccurate, QpStatus::IterationLimit] {
+            assert!(
+                lp_declines_to_nlp(ProblemClass::Lp, status, true),
+                "{status:?} on an LP must reroute"
+            );
+        }
+    }
+
+    /// A certified result is the answer — there is nothing for a second solve
+    /// to improve, and running one would double the cost of every LP.
+    #[test]
+    fn a_certified_lp_is_never_rerouted() {
+        assert!(!lp_declines_to_nlp(
+            ProblemClass::Lp,
+            QpStatus::Optimal,
+            true
+        ));
+    }
+
+    /// `PrimalInfeasible` / `DualInfeasible` are verdicts the convex solver
+    /// *verified*. Rerouting them would let a second solve overwrite a proof
+    /// with a numerical opinion — the same reason `run_convex_socp` reroutes
+    /// only `NumericalFailure`. `NumericalFailure` itself is left alone here:
+    /// it is the post-solve verification refusing a point, and the LP corpus
+    /// has no case of it the NLP path recovers.
+    #[test]
+    fn verified_verdicts_and_numerical_failure_stand() {
+        for status in [
+            QpStatus::PrimalInfeasible,
+            QpStatus::DualInfeasible,
+            QpStatus::NumericalFailure,
+        ] {
+            assert!(
+                !lp_declines_to_nlp(ProblemClass::Lp, status, true),
+                "{status:?} must not reroute"
+            );
+        }
+    }
+
+    /// The issue scopes the fallback to `P = 0`. A convex QP that stalls is a
+    /// different and unmeasured population, so no status reroutes it — nor
+    /// does any class the convex QP driver never sees.
+    #[test]
+    fn only_the_lp_class_reroutes() {
+        for class in [
+            ProblemClass::ConvexQp,
+            ProblemClass::ConvexQcqp,
+            ProblemClass::NonconvexQp,
+            ProblemClass::Nlp,
+        ] {
+            for status in ALL_STATUSES {
+                assert!(
+                    !lp_declines_to_nlp(class, status, true),
+                    "{class:?}/{status:?} must not reroute"
+                );
+            }
+        }
+    }
+
+    /// The caller's gate wins outright: an explicitly named engine, a user-set
+    /// `max_iter` (including the `max_iter=0` zero-iteration contract,
+    /// pounce#186) or an attached debugger clears it, and then nothing
+    /// reroutes.
+    #[test]
+    fn the_callers_gate_suppresses_every_case() {
+        for class in [ProblemClass::Lp, ProblemClass::ConvexQp] {
+            for status in ALL_STATUSES {
+                assert!(
+                    !lp_declines_to_nlp(class, status, false),
+                    "{class:?}/{status:?} must not reroute when the caller declines"
+                );
+            }
+        }
     }
 }
 

--- a/crates/pounce-cli/tests/issue_535_lp_falls_back_to_nlp.rs
+++ b/crates/pounce-cli/tests/issue_535_lp_falls_back_to_nlp.rs
@@ -117,6 +117,34 @@ fn a_rerouted_solve_reports_one_status_not_two() {
     );
 }
 
+/// …and nothing else from the discarded attempt either. `afiro` reduces under
+/// the convex path's presolve, which used to print its summary before the
+/// solve, so a rerouted run left one line of a solve that never reported. The
+/// summary is now held back until the convex path is known to be the one that
+/// reports — a rerouted run's stdout is the NLP solve's and nothing else.
+#[test]
+fn a_rerouted_solve_leaves_no_trace_of_the_discarded_attempt() {
+    let (rerouted, stderr, _) = run(&["solver_selection=auto", UNREACHABLE_TOL]);
+    assert!(
+        stderr.to_lowercase().contains("did not certify"),
+        "precondition: this run must reroute; stderr=\n{stderr}"
+    );
+    assert!(
+        !rerouted.contains("Presolve:"),
+        "the declined convex attempt must not leave its presolve summary \
+         behind; stdout=\n{rerouted}"
+    );
+
+    // The other half: held back, not lost. A convex solve that *does* report
+    // still says what presolve did.
+    let (kept, _, _) = run(&["solver_selection=auto"]);
+    assert!(
+        kept.contains("Presolve:"),
+        "a convex solve that reports must still print its presolve summary; \
+         stdout=\n{kept}"
+    );
+}
+
 /// The common case is untouched: an LP the convex IPM certifies is still
 /// answered by the convex IPM, with no second solve. This is the 369-of-371
 /// case in the LP suite and the reason the fallback triggers on a failure to

--- a/crates/pounce-cli/tests/issue_535_lp_falls_back_to_nlp.rs
+++ b/crates/pounce-cli/tests/issue_535_lp_falls_back_to_nlp.rs
@@ -1,0 +1,204 @@
+//! gh #535: an LP the convex interior-point method cannot certify must be
+//! re-solved on the general NLP path under `auto`, not reported as the last
+//! word.
+//!
+//! The models that motivate this are NETLIB `gen`/`gen1`. `auto` classifies
+//! them LP and routes them to the convex IPM, which exhausts its 200-iteration
+//! budget in 190.8 s and exits `Solved_To_Acceptable_Level` with a primal
+//! residual of 1.374e-7 against `tol = 1e-8`; `solver_selection=nlp` solves the
+//! same model in 19 iterations and 0.982 s to `Solve_Succeeded`, matching
+//! Ipopt-3.14.20/MA57's objective to four figures. They are highly degenerate
+//! and rank-deficient, strict complementarity fails, and a pure IPM cannot
+//! certify the vertex (gh #133); crossover was built to close that and does
+//! not. So the router — not the crossover engine — is the lever, and this is
+//! the same defect shape `socp_unverified_falls_back_to_nlp.rs` documents for
+//! the conic path: a specialized fast path displaced a general one, and when
+//! the fast path failed there was no fallback left.
+//!
+//! `gen.nl` is n=2560 / m=769 / 63085 Jacobian nonzeros and takes three
+//! minutes to fail, so it is not a repo fixture. `lp_afiro.nl` under a
+//! tolerance no double-precision solver can reach reproduces the *trigger*
+//! exactly and deterministically: the convex IPM's KKT error floors at ~5.7e-14
+//! and it burns all 199 iterations, which is the `IterationLimit` half of the
+//! contract. The gating tests below — a named engine, a user-set budget, a
+//! certified solve, a non-LP class — are the half that keeps the fallback from
+//! firing anywhere it should not.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Well below the ~5.7e-14 KKT error the convex IPM floors at on `afiro`, so
+/// the solve provably cannot certify — on any machine, without depending on a
+/// fixture that happens to sit on the accuracy knife-edge.
+const UNREACHABLE_TOL: &str = "tol=1e-20";
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    let mut p = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    p.push("tests");
+    p.push("fixtures");
+    p.push(name);
+    p
+}
+
+fn run_on(name: &str, args: &[&str]) -> (String, String, Option<i32>) {
+    let out = Command::new(pounce_exe())
+        .arg(fixture(name))
+        .arg("--no-sol")
+        .args(args)
+        .output()
+        .expect("spawn pounce");
+    (
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+        out.status.code(),
+    )
+}
+
+fn run(args: &[&str]) -> (String, String, Option<i32>) {
+    run_on("lp_afiro.nl", args)
+}
+
+/// The convex status line, which a rerouted solve must not print.
+fn convex_verdict_lines(stdout: &str) -> Vec<&str> {
+    stdout
+        .lines()
+        .filter(|l| l.contains("IPM, pounce-convex"))
+        .collect()
+}
+
+/// The headline contract: an LP the convex path could not certify continues on
+/// the NLP path instead of ending there.
+#[test]
+fn an_uncertified_lp_is_re_solved_on_the_nlp_path() {
+    let (stdout, stderr, _code) = run(&["solver_selection=auto", UNREACHABLE_TOL]);
+    assert!(
+        stderr
+            .to_lowercase()
+            .contains("did not certify a kkt point"),
+        "the convex solve must decline; stderr=\n{stderr}"
+    );
+    assert!(
+        stdout.contains("EXIT:"),
+        "the NLP path must run and report; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+}
+
+/// The reroute must be announced, and must name where the solve went. A run
+/// that silently answers from a different engine than the routing banner named
+/// misleads anyone comparing the two.
+#[test]
+fn the_fallback_says_so() {
+    let (_stdout, stderr, _) = run(&["solver_selection=auto", UNREACHABLE_TOL]);
+    let lower = stderr.to_lowercase();
+    assert!(
+        lower.contains("nlp interior-point path"),
+        "the reroute must say where the solve went; stderr=\n{stderr}"
+    );
+    assert!(
+        lower.contains("solver_selection=qp-ipm"),
+        "the note must say how to see the convex result instead; stderr=\n{stderr}"
+    );
+}
+
+/// Exactly one verdict. The decision is taken above the convex status line, the
+/// `.sol` write and the JSON report, so a rerouted solve leaves no stray convex
+/// result for a log scraper (or the benchmark harness) to pick up.
+#[test]
+fn a_rerouted_solve_reports_one_status_not_two() {
+    let (stdout, stderr, _) = run(&["solver_selection=auto", UNREACHABLE_TOL]);
+    assert!(
+        convex_verdict_lines(&stdout).is_empty(),
+        "a rerouted solve must not also print the convex status line; \
+         stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+}
+
+/// The common case is untouched: an LP the convex IPM certifies is still
+/// answered by the convex IPM, with no second solve. This is the 369-of-371
+/// case in the LP suite and the reason the fallback triggers on a failure to
+/// certify rather than on a class.
+#[test]
+fn a_certified_lp_still_answers_from_the_convex_path() {
+    let (stdout, stderr, code) = run(&["solver_selection=auto"]);
+    assert_eq!(code, Some(0), "stdout=\n{stdout}\nstderr=\n{stderr}");
+    assert!(
+        stdout.contains("Optimal Solution Found"),
+        "stdout=\n{stdout}"
+    );
+    assert_eq!(
+        convex_verdict_lines(&stdout).len(),
+        1,
+        "the convex engine must report its own result; stdout=\n{stdout}"
+    );
+    assert!(
+        !stderr.to_lowercase().contains("did not certify"),
+        "a certified solve must not reroute; stderr=\n{stderr}"
+    );
+}
+
+/// A named engine keeps its verdict. This is what makes the convex stall
+/// observable at all, and how the convex result stays available to anyone
+/// working on the convex solver itself.
+#[test]
+fn an_explicitly_selected_convex_solve_is_not_rerouted() {
+    for sel in ["solver_selection=qp-ipm", "solver_selection=lp-ipm"] {
+        let (stdout, stderr, _code) = run(&[sel, UNREACHABLE_TOL]);
+        assert_eq!(
+            convex_verdict_lines(&stdout).len(),
+            1,
+            "{sel} must report the convex engine's own result; stdout=\n{stdout}"
+        );
+        assert!(
+            stdout.contains("Maximum iterations exceeded"),
+            "{sel}: the convex verdict must stand; stdout=\n{stdout}"
+        );
+        assert!(
+            !stderr.to_lowercase().contains("did not certify"),
+            "{sel} must not be rerouted; stderr=\n{stderr}"
+        );
+    }
+}
+
+/// A user-set iteration budget is the question being asked, so its answer
+/// stands. `max_iter=0` is the sharp end of this: the zero-iteration contract
+/// (pounce#186) must stop without a solve, and rerouting would launch a full
+/// NLP solve for a request that asked for no iterations at all.
+#[test]
+fn a_user_set_iteration_budget_is_not_a_fallback_trigger() {
+    for budget in ["max_iter=0", "max_iter=5"] {
+        let (stdout, stderr, _) = run(&["solver_selection=auto", budget]);
+        assert!(
+            stdout.contains("Maximum iterations exceeded"),
+            "{budget} must report the iteration limit; stdout=\n{stdout}"
+        );
+        assert!(
+            !stderr.to_lowercase().contains("did not certify"),
+            "{budget} must not trigger the NLP fallback; stderr=\n{stderr}"
+        );
+    }
+}
+
+/// The fallback is scoped to `P = 0`. A convex QP is a different (and
+/// unmeasured) population — it keeps the engine chosen for it whatever the
+/// tolerance.
+#[test]
+fn a_convex_qp_is_not_rerouted() {
+    let (stdout, stderr, _) = run_on("convex_qp.nl", &["solver_selection=auto", UNREACHABLE_TOL]);
+    assert!(
+        stdout.contains("Problem class: convex QP"),
+        "fixture must classify as a convex QP; stdout=\n{stdout}"
+    );
+    assert_eq!(
+        convex_verdict_lines(&stdout).len(),
+        1,
+        "a convex QP must report from the convex engine; stdout=\n{stdout}"
+    );
+    assert!(
+        !stderr.to_lowercase().contains("did not certify"),
+        "a convex QP must not reroute; stderr=\n{stderr}"
+    );
+}

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -288,6 +288,40 @@ A *positive* `obj_scaling_factor` is not in this table: it only rescales
 conditioning, and the convex path reports natural units either way, so
 both paths give the same answer.
 
+### When the convex path cannot certify an LP
+
+Routing gives way one more time, and this one is decided *after* the solve
+rather than before it. Under `auto`, an **LP** whose convex solve finishes
+without a KKT certificate — `Solved to acceptable level (reduced accuracy)`
+or `Maximum iterations exceeded` — is re-solved on the general NLP
+interior-point path, which owns the whole verdict. Nothing from the
+declined convex solve is printed or written, so a rerouted run still
+reports exactly one status.
+
+The case this exists for is the NETLIB `gen` / `gen1` family. They are
+highly degenerate and rank-deficient, strict complementarity fails, and a
+pure interior-point method cannot certify the optimal vertex: the convex
+IPM spends its whole 200-iteration budget (190.8 s) and stops at a primal
+residual of `1.4e-7` against `tol = 1e-8`. The NLP filter-IPM — the same
+binary, the default for every other class — solves the same model in 19
+iterations and 0.98 s to a strict certificate, matching Ipopt-3.14.20/MA57
+to four figures. Rerouting is also the *faster* answer here: a second solve
+of one second is nothing against the three minutes the first one costs.
+
+The fallback is narrow by construction, and does not fire when:
+
+| | why |
+|---|---|
+| the class is not LP (`P ≠ 0`) | a stalling convex QP is a different, unmeasured population |
+| the solve certified (`Optimal Solution Found`) | there is nothing to improve, and a second solve would double the cost of every LP |
+| the status is infeasible or unbounded | those verdicts carry a *verified* certificate (see below); a second solve must not overwrite a proof |
+| `solver_selection` names an engine | a named engine keeps its verdict — that is what makes the stall observable |
+| `max_iter` was set explicitly | a user-set budget is the question being asked; `max_iter=0` in particular must stop without a solve |
+| the interactive debugger is attached | you are stepping *this* engine |
+
+A tightened `tol` is deliberately **not** in that list: that is an accuracy
+request, so trying the engine that can meet it is the right response.
+
 ### Infeasible and unbounded problems
 
 The convex solver detects infeasibility and unboundedness directly,
@@ -302,7 +336,8 @@ reporting a clean status instead of exhausting the iteration budget:
 Each verdict is backed by a *verified* certificate (a Farkas
 infeasibility proof or an unbounded recession direction that is checked,
 not merely inferred), so these statuses are never reported in error; a
-problem the solver cannot certify simply runs to the iteration limit.
+problem the solver cannot certify simply runs to the iteration limit —
+and, if it is an LP under `auto`, is then handed to the NLP path (above).
 
 `solver_selection=qp-active-set` follows the same contract. Its inner QP
 certifies the recession ray of the *linearization*, which on a nonlinear


### PR DESCRIPTION
Fixes #535.

## Problem

`solver_selection=auto` routes every detected LP to the convex IPM. On the NETLIB GEN family that costs 194× in wall clock **and** the certificate, while the NLP path — already in the binary, already the default for every other class — solves the same model in under a second.

`gen.nl` (n=2560, m=769, 63085 Jacobian nonzeros, pure LP), **numbers from the issue, not measured in this PR** (see Tests):

| | status | objective | NLP error | iters | wall |
|---|---|---|---|---|---|
| before (`auto` → convex IPM) | `Solved_To_Acceptable_Level` | `-1.5564769679e-08` | `1.374e-07` | 199 | 190.8 s |
| after (`auto` → NLP fallback) | `Solve_Succeeded` | `-1.0975644150e-05` | `4.260e-09` | 19 | 0.982 s |
| oracle (Ipopt 3.14.20/MA57) | `Optimal` | `-1.0974845560e-05` | — | — | — |

The "after" row is the issue's `solver_selection=nlp` measurement. This PR makes `auto` reach that path; see Tests for exactly how far I could verify that here.

`gen1` is the same model under a second name and behaves identically. The two are the last of the 7 `Ipopt only` entries in the benchmark report at `880b360b`, and the only ones where the conclusion had been that POUNCE genuinely could not reach the answer.

## Cause

Not a tolerance-gating bug. The sole blocker is the primal residual at `1.374e-07` against `tol = 1e-8`; dual infeasibility (`1.16e-12`) and complementarity (`2.33e-09`) are both fine. `199` is `QpOptions::default().max_iter - 1` — it is exhausting the budget, not converging.

Two hypotheses were checked and rejected in the issue before this PR:

- **#528's noise floor.** Parsing the `r` segment of `gen.nl`: 518 nonzero `|rhs|` entries, max `65.16`, none `≥ 1e6`. #531's `κ = 64` floor lands at `9.2e-13` there, five orders below the violation. No sane `κ` forgives this, and none should.
- **Crossover.** #133's diagnosis stands: the model is degenerate and rank-deficient, strict complementarity fails, the fraction-to-boundary step collapses, and a pure IPM cannot certify the vertex. `pounce-convex::crossover` was built for exactly this and is off by default because it regressed LP-suite solve times 3×–800× while *still* not reaching an exact vertex on GEN.

What #133 records but does not act on: the NLP path already solves it. So GEN does not need the crossover engine fixed to be solved correctly — it needs the router not to send it somewhere that cannot solve it.

## Fix

Under `auto`, an LP whose convex solve finishes **without a certificate** (`OptimalInaccurate` / `IterationLimit`) is re-solved on the general NLP interior-point path. An LP is also a valid NLP.

This is the same shape as the conic path's `airport` fallback: the decision is taken in `run_convex_qp` *above* the status line, the `.sol` write and the JSON report, and the function returns `None` so the caller falls through. The NLP solve then owns the whole report — one solve, one verdict.

Gating (`lp_declines_to_nlp`, a pure function so it is unit-testable):

| does not fire when | why |
|---|---|
| class ≠ `Lp` (`P ≠ 0`) | a stalling convex QP is a different, unmeasured population |
| status is `Optimal` | nothing to improve, and a second solve would double the cost of every LP |
| status is `PrimalInfeasible` / `DualInfeasible` | those verdicts carry a *verified* certificate; a second solve must not overwrite a proof |
| status is `NumericalFailure` | the post-solve verification refusing a point; no LP-corpus case where the NLP path recovers it |
| `solver_selection` names an engine | a named engine keeps its verdict — that is what keeps the stall observable |
| `max_iter` set explicitly | a user budget is the question being asked; `max_iter=0` must still stop without a solve (#186) |
| the interactive debugger is attached | the user is stepping *this* engine |

A tightened `tol` deliberately does **not** suppress it: that is an accuracy request, so trying the engine that can meet it is the right response. (It is also what makes the trigger testable — see Tests.)

**Rejected: the issue's "never-regress" variant** — keep whichever result certifies at the lower KKT error. That needs both verdicts in hand at reporting time, which collides with the CLI's one-solve-one-verdict rule (`run_convex_socp`, and gh #508, which re-litigated exactly this for the NLP retry ladder and settled on re-emitting the verdict that shipped). Implementing it means deferring the convex report and arbitrating two banners. The gating table above is what bounds the downside instead: this only ever runs on an LP that already failed to certify under a default budget, where a second solve of one second is nothing against the 190.8 s the first one costs. Worth revisiting if a corpus sweep turns up an LP where the convex reduced-accuracy result beats the NLP one.

Second commit: the convex path's `Presolve:` summary printed before the solve, so a rerouted run left behind exactly one line of the attempt it discarded. It is now buffered and flushed after the fallback check.

## Blast radius

Confined to `.nl` inputs that classify as `Lp`, run under `auto`, and fail to certify. Everything else is bit-identical:

- A certified LP under `auto` — the 369-of-371 case in the LP suite — takes the same path and prints the same thing.
- Convex QP, convex QCQP, nonconvex QP and NLP classes are untouched (class gate).
- Any explicit `solver_selection` is untouched.
- `run_convex_qp` now returns `Option<ExitCode>` instead of `ExitCode`; it has one caller.

When it does fire, **the rerouted solve is `solver_selection=nlp`** — I diffed full stdout of `auto` against `solver_selection=nlp` on two models (`lp_afiro.nl` at `tol=1e-20`, and an ill-conditioned Hilbert-equality LP that reroutes at default `tol`), and after the presolve fix the only remaining differences are the routing banner line and wall clock. Status, iteration count, every residual, objective, `.sol` and JSON report all match.

**No corpus sweep.** The `.nl` benchmark data is gitignored and this environment's network policy 403s both `netlib.org` and `old.sztaki.hu`, so I could not run `benchmarks/lp`. The claim above is reasoning from the gate plus the equivalence diff, not a measured sweep — `make -C benchmarks lp-rerun` on this branch is the check I could not perform.

## Tests

`crates/pounce-cli/tests/issue_535_lp_falls_back_to_nlp.rs` (8) and `lp_nlp_fallback_tests` in `main.rs` (5, over every class × status combination).

**On the parent commit (`880b360`), 4 of the 8 end-to-end tests fail and 4 pass**, which is the correct split — the 4 that fail assert the reroute happens, the 4 that pass assert it does *not* happen under the gates, and pre-fix nothing rerouted at all:

```
a_rerouted_solve_leaves_no_trace_of_the_discarded_attempt ... FAILED
a_rerouted_solve_reports_one_status_not_two               ... FAILED
an_uncertified_lp_is_re_solved_on_the_nlp_path            ... FAILED
the_fallback_says_so                                      ... FAILED
a_certified_lp_still_answers_from_the_convex_path         ... ok
a_convex_qp_is_not_rerouted                               ... ok
a_user_set_iteration_budget_is_not_a_fallback_trigger     ... ok
an_explicitly_selected_convex_solve_is_not_rerouted       ... ok
```

The 4 failures are for the stated reason: no note on stderr, the convex status line present, the presolve line present.

**Deliberately not pinned: the GEN result itself.** `gen.nl` is 63k Jacobian nonzeros and three minutes of failure, so it is not vendorable, and I could not fetch it here (network policy, above). I also could not synthesize the pathology small — degenerate transportation LPs and rank-deficient random LPs both solve in ~10 iterations, and the ill-conditioned Hilbert-equality LP that *does* reproduce the exit signature (199 iters, reduced accuracy, primal residual the blocker) flips between `Optimal` and `OptimalInaccurate` across adjacent `n`, which would be a flaky fixture.

So the end-to-end trigger is `lp_afiro.nl` under `tol=1e-20`. Its KKT error floors at `~5.7e-14`, so the solve provably cannot certify on any machine and lands on `IterationLimit` deterministically. That pins the *routing decision* exactly. It does **not** pin the GEN outcome — that rests on the issue's two measurements (the convex exit status, which is what makes the gate fire, and `solver_selection=nlp`'s 19 iterations, which is where the reroute lands) plus the verified equivalence of the reroute to `solver_selection=nlp`. One run of `pounce gen.nl solver_selection=auto` on this branch settles it.

`cargo fmt --all -- --check` clean; `cargo test -p pounce-cli` green across all 60 targets; `cargo clippy` introduces no new findings (`run_convex_qp`'s `too_many_arguments` count goes 10→11 on a lint it already tripped).

---

- [x] Tests fail on the parent commit for the stated reason — 4 of 8; the other 4 are gating tests that correctly pass pre-fix
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `lp-qp-routing.md`, new section plus a correction to the infeasible/unbounded paragraph; already in `SUMMARY.md`
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now — the GEN numbers are labelled as the issue's rather than measured here, and the absence of a corpus sweep is stated rather than implied