### PR TITLE
Sensitivity carries the variable scaling factors; the accessor refusals lift (#486 stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,10 +48,55 @@ changes.
 - `Problem.set_problem_scaling` accepts `x_scaling` from Python, and
   the C `SetIpoptProblemScaling` applies it, both landing in the
   caller's own units. Each previously refused any non-unit entry.
-- The sensitivity path still refuses variable factors. Its accessors
-  read the KKT factorization directly and do not yet carry the
-  substitution, so they would report scaled-space numbers under a
-  natural-units contract; stage 3 lifts this.
+- The sensitivity accessors were refused at this stage: they read the
+  KKT factorization directly and did not yet carry the substitution,
+  so they would have reported scaled-space numbers under a
+  natural-units contract. Stage 3, below, carries the factors through
+  and removes the refusal — within this same release, so no version
+  ever shipped with it.
+
+### Added — the sensitivity layer carries the variable factors, and the last refusals lift
+
+- Every sensitivity accessor now answers in the model's own units on a
+  variable-scaled solve (gh #486 stage 3), and the four refusals stage
+  2 left in place — on pyomo-pounce's `gradient`, `estimate`,
+  `covariance` and `information` — are gone. Nothing about user
+  scaling is refused any more on any axis.
+- The change of variables joins the objective and per-row factors in
+  the held factor's natural-units conjugation (`PdSensBacksolver`), as
+  a `1/d` on both sides of the `x` block and a `d` on the way out of
+  the bound-multiplier rows — the `z`-row `d` cancels against the
+  slack diagonal, so it appears in `F` alone. It is diagonal like the
+  other two, so the three compose by elementwise product and
+  `kkt_solve`, `parametric_step`, `parametric_step_full` and the
+  reduced Hessian all follow without further work.
+- The accessors that read the model's matrices rather than the factor
+  carry it separately: `hessian_vec` (`H = H̃ ⊙ (d ⊗ d)`),
+  `row_normal` (`∇g = ∇g̃ ⊙ d`), and `classify_activity`, whose
+  exported `Σ` gains the `d²` it was missing. Classification itself is
+  run on the unscaled geometry rather than only corrected on export:
+  the per-entry ratio `Σ/q` absorbs any `d`, but the identification
+  floor is one number shared across entries, so a *non-uniform* `d`
+  would otherwise move entries across it and change a status.
+- The two consumers that capture the algorithm's iterate — the
+  `Solver` session's `ConvergedState::x` and the `SensSolve` builder's
+  `x` / `mult_x_L` / `mult_x_U` — undo the substitution, the same
+  predicate that caught the CLI's `on_converged` hook in stage 2. The
+  `sens_boundcheck` projection now scales its step into the solve's
+  own coordinates before clamping against the solve's own bounds,
+  which the natural-units step no longer shared.
+- The factors a solve ran under are readable back:
+  `Solver.nlp_scaling["x_scaling"]` (Python),
+  `Solver::variable_scaling` (Rust), reported in the user's full-x
+  space. Diagnostic rather than a correction to apply, since every
+  output already carries it.
+- pyomo-pounce's in-process sensitivity path applies variable factors
+  too. It builds no `.nl` for the solver, so it had no suffix segments
+  to read; `problem_scaling` now translates the Suffix's variable
+  entries into `set_problem_scaling(x_scaling=…)` alongside the row
+  ones, by name against the written model's columns.
+- `nlp_scaling_method` note unchanged by any of this: `tol` still
+  compares scaled quantities, matching upstream.
 
 ### Fixed — the inertia test was answered with `δ_w` even when the factorization could not measure inertia (#540)
 

--- a/crates/pounce-cli/src/sens.rs
+++ b/crates/pounce-cli/src/sens.rs
@@ -94,6 +94,21 @@ pub fn compute_sens_perturbed_x(
     let curr = data.borrow().curr.clone()?;
     let n_x = curr.x.dim() as usize;
 
+    // Per-variable `user-scaling` factors in var-x order, or all-ones
+    // (gh#486 stage 3). The step below comes back from the
+    // natural-units back-solve, but the iterate and the NLP's bounds
+    // are in the coordinates the solve ran in — so the projection has
+    // to move between them.
+    let d_var: Vec<Number> = {
+        let nlp_ref = nlp.borrow();
+        match nlp_ref.variable_scaling() {
+            Some(d) => (0..n_x)
+                .map(|v| d[nlp_ref.var_x_to_full_x(v as Index) as usize])
+                .collect(),
+            None => vec![1.0; n_x],
+        }
+    };
+
     if let Some(eps) = boundcheck_eps {
         // Single-pass clamp of the primal step before scattering onto
         // the full-x grid; see pounce_sensitivity::boundcheck for the
@@ -105,12 +120,21 @@ pub fn compute_sens_perturbed_x(
             .map(|d| d.values().to_vec())
             .unwrap_or_default();
         let mut dx_primal = dx[..n_x].to_vec();
+        // Into the solve's coordinates for the projection, and back
+        // out of them after: clamping a natural-units step against
+        // scaled bounds would project onto the wrong box.
+        for (s, &di) in dx_primal.iter_mut().zip(d_var.iter()) {
+            *s *= di;
+        }
         let n_clamped = pounce_sensitivity::boundcheck::clamp_with_nlp(
             &*nlp.borrow(),
             &x_curr_compressed,
             &mut dx_primal,
             eps,
         );
+        for (s, &di) in dx_primal.iter_mut().zip(d_var.iter()) {
+            *s /= di;
+        }
         if n_clamped > 0 {
             eprintln!("pounce: --sens-boundcheck clamped {n_clamped} primal coordinate(s)");
             dx[..n_x].copy_from_slice(&dx_primal);

--- a/crates/pounce-nlp/src/ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/ipopt_nlp.rs
@@ -368,6 +368,24 @@ pub trait IpoptNlp: Nlp {
         None
     }
 
+    /// The per-variable factors `d` a scaling wrapper below this NLP
+    /// applied as a change of variables `x̃ = d ⊙ x` (gh#486). `None`
+    /// ⇔ no variable scaling; length [`Self::n_full_x`] when present,
+    /// i.e. the **full-x** space of the TNLP that was submitted, before
+    /// fixed variables were dropped.
+    ///
+    /// This is the x-axis counterpart of [`Self::obj_scaling_factor`] /
+    /// [`Self::c_scale_vec`] / [`Self::d_scale_vec`], and it exists for
+    /// the same reason: a consumer reading the converged KKT system
+    /// rather than the `finalize_solution` payload is looking at `x̃`,
+    /// not `x`, and needs the factors to say so. Unlike the other
+    /// three, the substitution happens *below* the NLP — in
+    /// `ScalingTnlp` — so this only forwards what the TNLP reports.
+    /// Default `None`; `OrigIpoptNlp` overrides.
+    fn variable_scaling(&self) -> Option<Vec<Number>> {
+        None
+    }
+
     /// Human-readable variable / constraint names projected into the
     /// algorithm's split space (free variables, equalities, inequalities),
     /// or `None` when the model carries no names. The debugger uses this to

--- a/crates/pounce-nlp/src/orig_ipopt_nlp.rs
+++ b/crates/pounce-nlp/src/orig_ipopt_nlp.rs
@@ -2363,6 +2363,15 @@ impl IpoptNlp for OrigIpoptNlp {
         OrigIpoptNlp::finalize_solution_z_u(self, z_u)
     }
 
+    fn variable_scaling(&self) -> Option<Vec<Number>> {
+        // Forwarded, not stored: the substitution lives in the
+        // `ScalingTnlp` the adapter wraps, and `TNLP::scaling_factors`
+        // is the channel it reports through (gh#486). A transparent
+        // decorator between the two forwards the inner answer, so one
+        // hop off the adapter reaches whichever wrapper applied it.
+        self.adapter.borrow().tnlp().borrow().scaling_factors()
+    }
+
     fn full_x_to_var_x(&self, full_idx: Index) -> Option<Index> {
         let cls = self.adapter.borrow();
         let cls = cls.classification();

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -159,10 +159,11 @@ impl PySolver {
     ///
     /// `K` is the **natural-units** (unscaled) KKT matrix: when the
     /// IPM solved with active NLP scaling (`nlp_scaling_method`,
-    /// `obj_scaling_factor`, user scaling) the back-solve is
-    /// conjugated so RHS and solution are in the user's own units
-    /// (pounce#128). Pass `scaled=True` for the raw back-solve against
-    /// the factor exactly as the IPM holds it.
+    /// `obj_scaling_factor`, user scaling — including a per-variable
+    /// change of variables, gh#486) the back-solve is conjugated so
+    /// RHS and solution are in the user's own units (pounce#128). Pass
+    /// `scaled=True` for the raw back-solve against the factor exactly
+    /// as the IPM holds it.
     #[pyo3(signature = (rhs, scaled = false))]
     fn kkt_solve<'py>(
         &self,
@@ -369,19 +370,27 @@ impl PySolver {
     /// dict with keys `obj` (float, the objective factor `df`),
     /// `c_scale` and `d_scale` (each an ndarray of per-row factors
     /// over the algorithm's equality / inequality blocks, or `None`
-    /// when that block carries no row scaling).
-    /// `{"obj": 1.0, "c_scale": None, "d_scale": None}` ⇔ no scaling
-    /// was active.
+    /// when that block carries no row scaling), and `x_scaling` (an
+    /// ndarray of length `n` when the solve applied a per-variable
+    /// change of variables `x̃ = d ⊙ x`, else `None`).
+    /// `{"obj": 1.0, "c_scale": None, "d_scale": None,
+    /// "x_scaling": None}` ⇔ no scaling was active.
+    ///
+    /// Every accessor on this class already reports natural units,
+    /// `x_scaling` included (gh#486), so this dict describes the
+    /// solve rather than handing back a correction to apply.
     #[getter]
     fn nlp_scaling<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let s = self.state.as_ref().ok_or_else(|| {
             PyRuntimeError::new_err("nlp_scaling: no converged factor (call solve() first)")
         })?;
         let (df, dc, dd) = s.inner.nlp_scaling().map_err(solver_error_to_py)?;
+        let dx = s.inner.variable_scaling().map_err(solver_error_to_py)?;
         let out = PyDict::new_bound(py);
         out.set_item("obj", df)?;
         out.set_item("c_scale", crate::problem::opt_vec_to_py(py, dc))?;
         out.set_item("d_scale", crate::problem::opt_vec_to_py(py, dd))?;
+        out.set_item("x_scaling", crate::problem::opt_vec_to_py(py, dx))?;
         Ok(out)
     }
 

--- a/crates/pounce-sensitivity/src/activity.rs
+++ b/crates/pounce-sensitivity/src/activity.rs
@@ -350,6 +350,21 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     };
     let cq = cq.borrow();
 
+    // Per-variable factors of a `user-scaling` change of variables
+    // (gh#486 stage 3), in var-x space; 1.0 everywhere when none ran.
+    // Every internal x-space quantity below is a `d`-transform of the
+    // model's own — writing `a_j` for the gradient of inequality row
+    // `j`, since `d` is spoken for here: `ã = a ⊘ d`,
+    // `H̃ = H ⊘ (d ⊗ d)`, `Σ̃ = Σ · df ⊘ (d ⊙ d)`. Undoing that here rather than only on
+    // the exported `Σ` is what keeps a status from depending on the
+    // conditioning the user asked for: the per-entry ratio `Σ/q` is
+    // invariant, but the identification `floor` is a single number
+    // shared across entries, so a non-uniform `d` moves entries across
+    // it. `1.0` multiplies are exact, so an unscaled solve is
+    // bit-identical to the pre-#486 path.
+    let d_var = bs.variable_scaling();
+    let dv = |i: usize| -> Number { d_var.map_or(1.0, |d| d[i]) };
+
     // --- variables, in internal space ------------------------------------
     let has_l = present(&px_l, n);
     let has_u = present(&px_u, n);
@@ -357,13 +372,24 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
     let z_u = expand(&dense_to_vec(mult_z_u.as_ref()), &px_u, n);
     let s_l = expand(&dense_to_vec(cq.curr_slack_x_l().as_ref()), &px_l, n);
     let s_u = expand(&dense_to_vec(cq.curr_slack_x_u().as_ref()), &px_u, n);
-    let sigma_x = dense_to_vec(cq.curr_sigma_x().as_ref());
+    // `Σ̃_i = df·Σ_i/d_i²`: the `d_i²` comes out here, the `df` on
+    // export below (it cancels in every ratio, so classification never
+    // sees it).
+    let sigma_x: Vec<Number> = dense_to_vec(cq.curr_sigma_x().as_ref())
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| s * dv(i) * dv(i))
+        .collect();
 
     let hess = cq.curr_exact_hessian();
     // the identification floor is relative to the largest curvature
     // anywhere on the diagonal, not just the bounded entries, so a
     // row-only model still measures q against the model's own scale
-    let diag = hessian_diagonal(&hess, n);
+    let diag: Vec<Number> = hessian_diagonal(&hess, n)
+        .iter()
+        .enumerate()
+        .map(|(i, &h)| h * dv(i) * dv(i))
+        .collect();
     let max_abs_diag = diag.iter().fold(0.0, |a: Number, d| a.max(d.abs()));
     let floor = Number::EPSILON.sqrt() * max_abs_diag.max(1.0);
 
@@ -376,9 +402,10 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
         e.off_path = (has_l[i] && off_path(s_l[i], z_l[i], mu))
             || (has_u[i] && off_path(s_u[i], z_u[i], mu));
         // the ratio is scale-invariant, so classification ran in the
-        // solver's scaled space; the REPORTED sigma follows the repo's
-        // natural-units contract: internal z carries the objective
-        // scale (x is never scaled), so Sigma_nat = Sigma / df
+        // solver's own space up to the change of variables already
+        // divided out of `sigma_x` / `diag` above; the REPORTED sigma
+        // follows the repo's natural-units contract, and what is left
+        // to undo is the objective scale the internal z carries
         e.sigma /= obj_scale;
         vars[i] = e;
     }
@@ -409,7 +436,10 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
             // sum, matching mult_vector; indices are 1-based)
             let mut support: Vec<Vec<(usize, Number)>> = vec![Vec::new(); m_d];
             for ((&r, &c), &v) in jt.irows().iter().zip(jt.jcols()).zip(jt.values()) {
-                support[(r - 1) as usize].push(((c - 1) as usize, v));
+                let col = (c - 1) as usize;
+                // `a = ã ⊙ d`: the row's own scale stays (the ratio
+                // divides it out), the change of variables does not.
+                support[(r - 1) as usize].push((col, v * dv(col)));
             }
             for sup in &mut support {
                 sup.sort_unstable_by_key(|&(c, _)| c);
@@ -425,6 +455,9 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
             let mut adj: Vec<Vec<(usize, Number)>> = vec![Vec::new(); n];
             for ((&i, &l), &v) in ht.irows().iter().zip(ht.jcols()).zip(ht.values()) {
                 let (a, b) = ((i - 1) as usize, (l - 1) as usize);
+                // `H = H̃ ⊙ (d ⊗ d)`, matching the `d²` already taken
+                // out of `diag` (which sets the shared floor).
+                let v = v * dv(a) * dv(b);
                 adj[a].push((b, v));
                 if a != b {
                     adj[b].push((a, v));
@@ -483,10 +516,21 @@ pub(crate) fn compute(bs: &PdSensBacksolver) -> ActivityReport {
             e_row.values_mut()[j] = 1.0;
             grad.values_mut().fill(0.0);
             jac_d.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
-            let norm2: Number = grad.values_mut().iter().map(|g| *g * *g).sum();
+            // `a = ã ⊙ d`, then `aᵀHa = uᵀH̃u` with `u = d ⊙ a`
+            // (since `H = H̃ ⊙ (d ⊗ d)`) — so the vector handed to the
+            // internal Hessian carries `d²`, and `norm2` carries `d`.
+            let norm2: Number = grad
+                .values_mut()
+                .iter()
+                .enumerate()
+                .map(|(i, g)| (*g * dv(i)) * (*g * dv(i)))
+                .sum();
             rows[j] = if norm2 <= 0.0 {
                 zero_gradient_row(sigma_s[j], floor)
             } else {
+                for (i, g) in grad.values_mut().iter_mut().enumerate() {
+                    *g *= dv(i) * dv(i);
+                }
                 hgrad.values_mut().fill(0.0);
                 hess.mult_vector(1.0, &grad, 0.0, &mut hgrad);
                 let ghg: Number = {
@@ -626,12 +670,16 @@ pub(crate) fn row_normal(bs: &PdSensBacksolver, user_row: usize) -> Result<Vec<N
     grad.values_mut().fill(0.0);
     jac.trans_mult_vector(1.0, &e_row, 0.0, &mut grad);
 
+    let d_var = bs.variable_scaling();
     let nl = nlp.borrow();
     let n_full_x = nl.n_full_x() as usize;
     let mut full = vec![0.0; n_full_x];
     let g = grad.values_mut();
     for (i, slot) in g.iter().enumerate() {
-        full[nl.var_x_to_full_x(i as Index) as usize] = *slot / row_scale;
+        // `∇g̃ = (∇g ⊘ d) · row_scale`, so both come back out here
+        // (gh#486 stage 3).
+        let dx = d_var.map_or(1.0, |d| d[i]);
+        full[nl.var_x_to_full_x(i as Index) as usize] = *slot * dx / row_scale;
     }
     Ok(full)
 }
@@ -661,6 +709,10 @@ pub(crate) fn hessian_vec(bs: &PdSensBacksolver, v_full: &[Number]) -> Result<Ve
         return Err(n_full_x);
     }
 
+    // `H = H̃ ⊙ (d ⊗ d)` under a change of variables (gh#486 stage 3),
+    // so `H v = d ⊙ (H̃ (d ⊙ v))`: the factor goes in with the vector
+    // and comes back out of the product.
+    let d_var = bs.variable_scaling();
     let nspace = DenseVectorSpace::new(n as i32);
     let mut v_int = DenseVector::new(nspace.clone());
     let mut hv = DenseVector::new(nspace);
@@ -669,7 +721,8 @@ pub(crate) fn hessian_vec(bs: &PdSensBacksolver, v_full: &[Number]) -> Result<Ve
         let vals = v_int.values_mut();
         vals.fill(0.0);
         for i in 0..n {
-            vals[i] = v_full[nl.var_x_to_full_x(i as Index) as usize];
+            let dx = d_var.map_or(1.0, |d| d[i]);
+            vals[i] = v_full[nl.var_x_to_full_x(i as Index) as usize] * dx;
         }
     }
     let hess = {
@@ -682,7 +735,8 @@ pub(crate) fn hessian_vec(bs: &PdSensBacksolver, v_full: &[Number]) -> Result<Ve
     let mut out = vec![0.0; n_full_x];
     let h = hv.values_mut();
     for (i, slot) in h.iter().enumerate() {
-        out[nl.var_x_to_full_x(i as Index) as usize] = *slot / obj_scale;
+        let dx = d_var.map_or(1.0, |d| d[i]);
+        out[nl.var_x_to_full_x(i as Index) as usize] = *slot * dx / obj_scale;
     }
     Ok(out)
 }

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -111,7 +111,35 @@ pub struct PdSensBacksolver {
     /// bound-multiplier rows exactly (those rows admit no symmetric
     /// diagonal: `K̃_{z,x} = df·Z·Pᵀ` but `K̃_{z,z} = X − x_L` is
     /// unscaled). `None` ⇔ scaling inactive, identity.
+    ///
+    /// **Variable scaling** (gh#486 stage 3) multiplies into the same
+    /// pair. A change of variables `x̃ = d ⊙ x` contributes
+    ///
+    /// ```text
+    ///        x      z_l/z_u          everything else
+    /// E  =   1/d    1                1
+    /// F  =   1/d    d_{px(j)}        1
+    /// ```
+    ///
+    /// (`d_{px(j)}` = the factor of the variable carrying the j-th
+    /// finite bound, through the `px_l` / `px_u` expansion). The `s`,
+    /// `y_c`, `y_d`, `v_l` and `v_u` blocks are untouched because the
+    /// substitution leaves `c`, `d` and their multipliers alone. The
+    /// two contributions compose by elementwise product, in either
+    /// order, because both are diagonal.
     conj: Option<Rc<ConjPair>>,
+    /// Per-variable factors `d` the solve ran under (gh#486), in the
+    /// algorithm's **var-x** space — i.e. already projected through
+    /// the fixed-variable map, so entry `i` matches KKT row `i`.
+    /// `None` ⇔ no variable scaling. Folded into [`Self::conj`] for
+    /// the back-solves; kept here for the consumers that read the
+    /// converged iterate and the model's matrices directly rather than
+    /// through the factor (see [`crate::activity`]).
+    d_var: Option<Rc<Vec<Number>>>,
+    /// The same factors in the user TNLP's **full-x** space, the shape
+    /// `finalize_solution_z_l` / `n_full_x`-length reports come in.
+    /// `None` alongside [`Self::d_var`].
+    d_full: Option<Rc<Vec<Number>>>,
 }
 
 /// Left/right diagonal pair for the natural-units back-solve; see the
@@ -159,7 +187,8 @@ impl PdSensBacksolver {
             curr.v_l.dim() as usize,
             curr.v_u.dim() as usize,
         ];
-        let conj = Self::natural_units_conj(nlp, &dims)?;
+        let (d_var, d_full) = Self::variable_factors(nlp, &dims)?;
+        let conj = Self::natural_units_conj(nlp, &dims, d_var.as_ref().map(|v| v.as_slice()))?;
         Ok(Self {
             pd,
             data: Rc::clone(data),
@@ -168,11 +197,79 @@ impl PdSensBacksolver {
             dims,
             template: curr,
             conj,
+            d_var,
+            d_full,
         })
     }
 
+    /// Read the variable factors the solve ran under off the NLP and
+    /// project them into the algorithm's var-x space (gh#486 stage 3).
+    ///
+    /// Returns `(None, None)` when no variable scaling is active.
+    /// Errors when the reported vector does not match the NLP's own
+    /// full-x width, or when the projection does not fill the `x`
+    /// block: either would silently mis-pair a factor with a variable,
+    /// which is the whole failure mode this plumbing exists to avoid.
+    #[allow(clippy::type_complexity)]
+    fn variable_factors(
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        dims: &[usize; 8],
+    ) -> Result<(Option<Rc<Vec<Number>>>, Option<Rc<Vec<Number>>>), String> {
+        let nlp_ref = nlp.borrow();
+        let Some(d_full) = nlp_ref.variable_scaling() else {
+            return Ok((None, None));
+        };
+        let n_full = nlp_ref.n_full_x() as usize;
+        if d_full.len() != n_full {
+            return Err(format!(
+                "variable scaling length {} != n_full_x {}",
+                d_full.len(),
+                n_full
+            ));
+        }
+        // NaN is not a "no-op" factor and neither is zero; the wrapper
+        // refuses both at setup, so seeing one here means the vector
+        // did not come from the wrapper that ran.
+        if let Some(bad) = d_full.iter().find(|v| !v.is_finite() || **v <= 0.0) {
+            return Err(format!(
+                "variable scaling factor {bad} is not finite and positive"
+            ));
+        }
+        let mut d_var = vec![Number::NAN; dims[0]];
+        for (full, &factor) in d_full.iter().enumerate() {
+            if let Some(var) = nlp_ref.full_x_to_var_x(full as Index) {
+                let slot = d_var.get_mut(var as usize).ok_or_else(|| {
+                    format!("var-x index {var} outside x block of width {}", dims[0])
+                })?;
+                *slot = factor;
+            }
+        }
+        if let Some(pos) = d_var.iter().position(|v| v.is_nan()) {
+            return Err(format!(
+                "variable scaling left var-x column {pos} of {} unmapped",
+                dims[0]
+            ));
+        }
+        Ok((Some(Rc::new(d_var)), Some(Rc::new(d_full))))
+    }
+
+    /// The per-variable factors the held solve ran under, in the
+    /// algorithm's **var-x** space (one entry per `x`-block KKT row),
+    /// or `None` when no variable scaling was active (gh#486).
+    pub fn variable_scaling(&self) -> Option<&[Number]> {
+        self.d_var.as_deref().map(|v| v.as_slice())
+    }
+
+    /// [`Self::variable_scaling`] in the user TNLP's **full-x** space:
+    /// the shape of an `n_full_x`-length report, with the columns the
+    /// solve dropped as fixed still present.
+    pub fn variable_scaling_full(&self) -> Option<&[Number]> {
+        self.d_full.as_deref().map(|v| v.as_slice())
+    }
+
     /// Build the natural-units scaling pair `(E, F)` from the NLP's
-    /// effective scaling (see the field doc on [`Self::conj`]).
+    /// effective scaling and the variable factors `d_var` the solve
+    /// ran under (see the field doc on [`Self::conj`]).
     /// Returns `Ok(None)` when no scaling is active. Errors when the
     /// NLP reports scaling data inconsistent with the converged
     /// iterate's block dimensions (would silently corrupt every
@@ -180,12 +277,16 @@ impl PdSensBacksolver {
     fn natural_units_conj(
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
         dims: &[usize; 8],
+        d_var: Option<&[Number]>,
     ) -> Result<Option<Rc<ConjPair>>, String> {
         let nlp_ref = nlp.borrow();
         let df = nlp_ref.obj_scaling_factor();
         let dc = nlp_ref.c_scale_vec();
         let dd = nlp_ref.d_scale_vec();
-        if df == 1.0 && dc.is_none() && dd.is_none() {
+        // `d_var` counts as active scaling on its own: a solve with
+        // unit objective and row factors but a change of variables
+        // still holds its factor in scaled coordinates.
+        if df == 1.0 && dc.is_none() && dd.is_none() && d_var.is_none() {
             return Ok(None);
         }
         // df may be negative (obj_scaling_factor < 0 means maximize);
@@ -208,13 +309,27 @@ impl PdSensBacksolver {
                 ));
             }
         }
-        // Per-entry d-row scale for the compressed v_l / v_u blocks:
-        // entry j of v_l covers the d row pd_l.expanded_pos[j].
-        let v_row_scale = |pm: Rc<dyn pounce_linalg::matrix::Matrix>,
-                           n_v: usize,
-                           which: &str|
+        if let Some(d) = d_var {
+            if d.len() != dims[0] {
+                return Err(format!(
+                    "variable scaling length {} != x dim {}",
+                    d.len(),
+                    dims[0]
+                ));
+            }
+        }
+        // Per-entry source scale for a compressed bound-multiplier
+        // block: entry j of z_l / v_l covers the row
+        // `px_l.expanded_pos[j]` / `pd_l.expanded_pos[j]` of `src`.
+        // Used for the v blocks (source `d_scale`, indexed by
+        // inequality row) and the z blocks (source `d_var`, indexed by
+        // var-x column).
+        let bound_row_scale = |pm: Rc<dyn pounce_linalg::matrix::Matrix>,
+                               src: Option<&[Number]>,
+                               n_v: usize,
+                               which: &str|
          -> Result<Vec<Number>, String> {
-            let Some(dd) = &dd else {
+            let Some(vals) = src else {
                 return Ok(vec![1.0; n_v]);
             };
             if n_v == 0 {
@@ -237,25 +352,41 @@ impl PdSensBacksolver {
             }
             pos.iter()
                 .map(|&r| {
-                    dd.get(r as usize).copied().ok_or_else(|| {
+                    vals.get(r as usize).copied().ok_or_else(|| {
                         format!(
-                            "{which} expansion row {r} out of d_scale range {}",
-                            dd.len()
+                            "{which} expansion row {r} out of scale-vector range {}",
+                            vals.len()
                         )
                     })
                 })
                 .collect()
         };
-        let vl_dd = v_row_scale(nlp_ref.pd_l(), dims[6], "pd_l")?;
-        let vu_dd = v_row_scale(nlp_ref.pd_u(), dims[7], "pd_u")?;
+        let vl_dd = bound_row_scale(nlp_ref.pd_l(), dd.as_deref(), dims[6], "pd_l")?;
+        let vu_dd = bound_row_scale(nlp_ref.pd_u(), dd.as_deref(), dims[7], "pd_u")?;
+        // The variable factor carried by each finite x-bound, through
+        // the same expansion (gh#486). `d_var` indexes var-x columns,
+        // and `px_l` / `px_u` say which column each z entry belongs to.
+        let zl_dx = bound_row_scale(nlp_ref.px_l(), d_var, dims[4], "px_l")?;
+        let zu_dx = bound_row_scale(nlp_ref.px_u(), d_var, dims[5], "px_u")?;
         drop(nlp_ref);
 
         let total: usize = dims.iter().sum();
         let mut e = Vec::with_capacity(total);
         let mut f = Vec::with_capacity(total);
-        // x block: E = df, F = 1.
-        e.extend(std::iter::repeat_n(df, dims[0]));
-        f.extend(std::iter::repeat_n(1.0, dims[0]));
+        // x block: E = df/d_i, F = 1/d_i. `df` is the objective scale;
+        // the `1/d_i` on both sides is the change of variables —
+        // `∇f̃ = ∇f ⊘ d` puts the RHS in scaled units and `x = x̃ ⊘ d`
+        // brings the solution back.
+        match d_var {
+            Some(d) => {
+                e.extend(d.iter().map(|&di| df / di));
+                f.extend(d.iter().map(|&di| 1.0 / di));
+            }
+            None => {
+                e.extend(std::iter::repeat_n(df, dims[0]));
+                f.extend(std::iter::repeat_n(1.0, dims[0]));
+            }
+        }
         // s block: E = df/dd_i, F = 1/dd_i (slacks live in scaled d-space).
         match &dd {
             Some(v) => {
@@ -289,11 +420,15 @@ impl PdSensBacksolver {
                 f.extend(std::iter::repeat_n(1.0 / df, dims[3]));
             }
         }
-        // z_l / z_u blocks: E = df, F = 1/df (z̃ = df·z; bounds on x
-        // are unscaled so the slack diagonal X − x_L is shared by both
-        // systems).
+        // z_l / z_u blocks: E = df, F = d_{px(j)}/df (z̃ = (df/d)·z,
+        // and the slack diagonal x̃ − x̃_L = d·(x − x_L) carries the
+        // variable factor, so the two cancel in the row and leave it
+        // identical to the natural one — E takes no `d` at all).
+        // Without variable scaling this is the pre-#486 `F = 1/df`:
+        // bounds on x are unscaled and the slack diagonal is shared.
         e.extend(std::iter::repeat_n(df, dims[4] + dims[5]));
-        f.extend(std::iter::repeat_n(1.0 / df, dims[4] + dims[5]));
+        f.extend(zl_dx.iter().map(|&dx| dx / df));
+        f.extend(zu_dx.iter().map(|&dx| dx / df));
         // v_l / v_u blocks: E = df, F = dd_r/df (ṽ = (df/dd)·v and the
         // slack diagonal s̃ − d̃_l = dd·(s − d_l) carries the d-row
         // scale).

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -111,7 +111,9 @@ pub struct SensResult {
     /// sensitivity failure from a not-requested computation.
     pub error: Option<String>,
     /// Final primal iterate `x*`. Length `n_x`. None when the solve
-    /// failed before convergence.
+    /// failed before convergence. In the user's own units: a
+    /// `user-scaling` change of variables is undone here, so this is
+    /// `x`, never the algorithm's `x̃ = d ⊙ x` (gh#486).
     pub x: Option<Vec<Number>>,
     /// Final objective `f(x*)`. None when the solve failed.
     pub obj_val: Option<Number>,
@@ -188,7 +190,9 @@ pub struct SensResult {
     /// `n_full_x`, divided by `obj_scale_factor` like
     /// [`Self::mult_g`] (via `finalize_solution_z_l`) — the same
     /// natural-units convention as the C ABI / Python info dict's
-    /// `mult_x_L`.
+    /// `mult_x_L`. A `user-scaling` change of variables is undone on
+    /// top of that (`z = d ⊙ z̃`, gh#486), since the bound
+    /// multipliers are the one dual block the substitution moves.
     pub mult_x_l: Option<Vec<Number>>,
     /// Converged user-space upper-bound multipliers `z_U`, length
     /// `n_full_x`. Same convention (`finalize_solution_z_u` /
@@ -309,7 +313,9 @@ impl SensSolve {
             };
 
             // Always capture x and obj_val so the caller gets them
-            // even when only the reduced Hessian was requested.
+            // even when only the reduced Hessian was requested. `x` is
+            // unscaled below, once the backsolver has read the change
+            // of variables off the NLP (gh#486).
             outbox_cb.borrow_mut().x = Some(dense_to_vec(&*curr.x));
             outbox_cb.borrow_mut().obj_val = Some(cq.borrow_mut().curr_f());
 
@@ -370,6 +376,36 @@ impl SensSolve {
             };
             let n_full = backsolver.dim();
 
+            // Every capture above reads the algorithm's own iterate or
+            // an `IpoptNlp`-level report, and both sit BELOW the
+            // `ScalingTnlp` that applied a `user-scaling` change of
+            // variables — so under one they hold `x̃ = d ⊙ x` and the
+            // matching `z̃ = z ⊘ d`, not the model's own units
+            // (gh#486 stage 3). `finalize_solution_z_*` already
+            // divided out `df`; what is left is the substitution.
+            // `mult_g` and `g` need nothing: rows and their
+            // multipliers are untouched by a change of variables.
+            let d_var = backsolver.variable_scaling().map(|d| d.to_vec());
+            let d_full = backsolver.variable_scaling_full().map(|d| d.to_vec());
+            if let Some(d) = &d_var {
+                if let Some(x) = outbox_cb.borrow_mut().x.as_mut() {
+                    for (xi, &di) in x.iter_mut().zip(d.iter()) {
+                        *xi /= di;
+                    }
+                }
+            }
+            if let Some(d) = &d_full {
+                let mut out = outbox_cb.borrow_mut();
+                let CallbackOut {
+                    mult_x_l, mult_x_u, ..
+                } = &mut *out;
+                for z in [mult_x_l.as_mut(), mult_x_u.as_mut()].into_iter().flatten() {
+                    for (zi, &di) in z.iter_mut().zip(d.iter()) {
+                        *zi *= di;
+                    }
+                }
+            }
+
             // Pin constraint indices are user-facing 0-based indices
             // into g(x); the matching y_c slot is found through the
             // NLP's c/d-split row map (pounce#128: a direct
@@ -420,7 +456,24 @@ impl SensSolve {
                     // clamp only the primal-x block of dx_full; the
                     // rest (s, multipliers) doesn't have primal bounds.
                     let mut dx_primal = dx_full[..n_x].to_vec();
+                    // The iterate and the NLP's bounds are both in the
+                    // solve's own coordinates, but the step came back
+                    // from the natural-units back-solve — so it goes
+                    // INTO the substitution for the projection and
+                    // comes back out of it (gh#486 stage 3). Clamping
+                    // a natural step against scaled bounds would
+                    // project onto the wrong box.
+                    if let Some(d) = &d_var {
+                        for (s, &di) in dx_primal.iter_mut().zip(d.iter()) {
+                            *s *= di;
+                        }
+                    }
                     let _ = clamp_with_nlp(&*nlp.borrow(), &x_curr, &mut dx_primal, eps);
+                    if let Some(d) = &d_var {
+                        for (s, &di) in dx_primal.iter_mut().zip(d.iter()) {
+                            *s /= di;
+                        }
+                    }
                     dx_full[..n_x].copy_from_slice(&dx_primal);
                 }
                 let dx_primal = dx_full[..n_x].to_vec();

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -98,7 +98,9 @@ pub enum SolverError {
 pub struct ConvergedState {
     /// IPM return status of the most recent solve.
     pub status: ApplicationReturnStatus,
-    /// Final primal iterate `x*` (length `n_x`).
+    /// Final primal iterate `x*` (length `n_x`), in the user's own
+    /// units: a `user-scaling` change of variables is undone here, so
+    /// this is `x`, never the algorithm's `x̃ = d ⊙ x` (gh#486).
     pub x: Vec<Number>,
     /// Final objective value `f(x*)`.
     pub obj_val: Number,
@@ -211,7 +213,19 @@ impl Solver {
                         return;
                     }
                 };
-                let x = dense_to_vec(&*curr.x);
+                // The algorithm's iterate is `x̃ = d ⊙ x` when the
+                // solve ran under a change of variables (gh#486): this
+                // capture reads the iterate, not the
+                // `finalize_solution` payload, so it undoes the
+                // substitution itself. The backsolver already read the
+                // factors off the NLP, in this same var-x space.
+                let mut x = dense_to_vec(&*curr.x);
+                if let Some(d) = backsolver.variable_scaling() {
+                    debug_assert_eq!(x.len(), d.len());
+                    for (xi, &di) in x.iter_mut().zip(d.iter()) {
+                        *xi /= di;
+                    }
+                }
                 let obj_val = cq.borrow_mut().curr_f();
                 // Status is overwritten with the real value after
                 // optimize_tnlp returns.
@@ -342,7 +356,10 @@ impl Solver {
     /// [`Self::kkt_solve`] without the natural-units conjugation: the
     /// back-solve runs against the factor exactly as the IPM holds it
     /// (the solver's internal scaled space). Identical to `kkt_solve`
-    /// when no NLP scaling is active.
+    /// when no NLP scaling is active. "Scaled space" includes a
+    /// `user-scaling` change of variables (gh#486), so on such a solve
+    /// the `x` and `z` blocks here are in the substituted coordinates
+    /// `x̃ = d ⊙ x`, not the model's.
     pub fn kkt_solve_scaled(&self, rhs: &[Number], lhs: &mut [Number]) -> Result<(), SolverError> {
         self.kkt_solve_impl(rhs, lhs, true)
     }
@@ -689,6 +706,20 @@ impl Solver {
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
         Ok(state.backsolver.nlp_scaling())
+    }
+
+    /// The per-variable `user-scaling` factors `d` the held solve ran
+    /// under (gh#486), in the user TNLP's **full-x** space, or `None`
+    /// when the solve applied no change of variables.
+    ///
+    /// Every accessor on this type already reports natural units, so
+    /// this is diagnostic rather than a correction a caller has to
+    /// apply — it answers "was this solve conditioned, and by how
+    /// much", the x-axis counterpart of [`Self::nlp_scaling`].
+    pub fn variable_scaling(&self) -> Result<Option<Vec<Number>>, SolverError> {
+        let state = self.state.borrow();
+        let state = state.as_ref().ok_or(SolverError::NotConverged)?;
+        Ok(state.backsolver.variable_scaling_full().map(|d| d.to_vec()))
     }
 
     /// Inertia-correction perturbations `(δ_x, δ_s, δ_c, δ_d)` baked

--- a/crates/pounce-sensitivity/tests/variable_scaling_sensitivity.rs
+++ b/crates/pounce-sensitivity/tests/variable_scaling_sensitivity.rs
@@ -1,0 +1,485 @@
+//! gh#486 stage 3 — the sensitivity accessors under a `user-scaling`
+//! change of variables.
+//!
+//! Stage 2 taught the core to apply a per-variable `scaling_factor` by
+//! substituting `x̃ = d ⊙ x` one level below the algorithm. That leaves
+//! the converged KKT factor — which the sensitivity layer reads
+//! directly, not through the TNLP chain — in scaled coordinates. Stage
+//! 3 carries the factors into the natural-units translation, so every
+//! accessor answers in the model's own units.
+//!
+//! The assertion shape throughout is **parity**: solve the same problem
+//! twice, once with non-unit factors and once without, and require the
+//! two to agree. That makes the property falsifiable without a
+//! hand-derived expected value for each accessor, and it is the same
+//! criterion issue #486 states for `core.scale_model` parity — the
+//! solution and the unscaled duals agree, not the iterates.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, ScalingRequest, Solution,
+    SparsityRequest, StartingPoint, TNLP,
+};
+use pounce_sensitivity::{SensSolve, Solver};
+
+/// The `parametric_cpp` / `solver_session` fixture, plus a
+/// `get_scaling_parameters` that hands back per-variable factors. Five
+/// variables, five rows, two of them the parameter pins; `x[0..3]` are
+/// bounded below (so the z_l block is non-empty and the bound-multiplier
+/// conjugation is exercised) and row 4 is a one-sided inequality (so the
+/// v/d blocks are too).
+struct ParametricTNLP {
+    nominal_eta1: Number,
+    nominal_eta2: Number,
+    /// Per-variable factors to report, or `None` to decline scaling.
+    x_scaling: Option<[Number; 5]>,
+}
+
+impl ParametricTNLP {
+    fn new(x_scaling: Option<[Number; 5]>) -> Self {
+        Self {
+            nominal_eta1: 5.0,
+            nominal_eta2: 1.0,
+            x_scaling,
+        }
+    }
+}
+
+impl TNLP for ParametricTNLP {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 5,
+            m: 5,
+            nnz_jac_g: 11,
+            nnz_h_lag: 5,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_scaling_parameters(&mut self, req: ScalingRequest<'_>) -> bool {
+        let Some(d) = self.x_scaling else {
+            return false;
+        };
+        *req.obj_scaling = 1.0;
+        *req.use_x_scaling = true;
+        req.x_scaling.copy_from_slice(&d);
+        *req.use_g_scaling = false;
+        true
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        for k in 0..3 {
+            b.x_l[k] = 0.0;
+            b.x_u[k] = 1.0e19;
+        }
+        b.x_l[3] = -1.0e19;
+        b.x_u[3] = 1.0e19;
+        b.x_l[4] = -1.0e19;
+        b.x_u[4] = 1.0e19;
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = 0.0;
+        b.g_u[1] = 0.0;
+        b.g_l[2] = self.nominal_eta1;
+        b.g_u[2] = self.nominal_eta1;
+        b.g_l[3] = self.nominal_eta2;
+        b.g_u[3] = self.nominal_eta2;
+        b.g_l[4] = 0.0;
+        b.g_u[4] = 1.0e19;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x[0] = 0.15;
+        sp.x[1] = 0.15;
+        sp.x[2] = 0.0;
+        sp.x[3] = 0.0;
+        sp.x[4] = 0.0;
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, types: &mut [Linearity]) -> bool {
+        types.fill(Linearity::NonLinear);
+        types[4] = Linearity::Linear;
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[0] + x[1] * x[1] + x[2] * x[2])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * x[0];
+        g[1] = 2.0 * x[1];
+        g[2] = 2.0 * x[2];
+        g[3] = 0.0;
+        g[4] = 0.0;
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (x1, x2, x3, eta1, eta2) = (x[0], x[1], x[2], x[3], x[4]);
+        g[0] = 6.0 * x1 + 3.0 * x2 + 2.0 * x3 - eta1;
+        g[1] = eta2 * x1 + x2 - x3 - 1.0;
+        g[2] = eta1;
+        g[3] = eta2;
+        g[4] = x1;
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 11] = [0, 0, 0, 0, 1, 1, 1, 1, 2, 3, 4];
+                let cs: [Index; 11] = [0, 1, 2, 3, 0, 1, 2, 4, 3, 4, 0];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_jac_g(Values) without x");
+                values[0] = 6.0;
+                values[1] = 3.0;
+                values[2] = 2.0;
+                values[3] = -1.0;
+                values[4] = x[4];
+                values[5] = 1.0;
+                values[6] = -1.0;
+                values[7] = x[0];
+                values[8] = 1.0;
+                values[9] = 1.0;
+                values[10] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                let rs: [Index; 5] = [0, 1, 2, 4, 0];
+                let cs: [Index; 5] = [0, 1, 2, 0, 0];
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                let lam = lambda.expect("eval_h(Values) without lambda");
+                values[0] = 2.0 * obj_factor;
+                values[1] = 2.0 * obj_factor;
+                values[2] = 2.0 * obj_factor;
+                values[3] = lam[1];
+                values[4] = 0.0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+/// Factors spanning six orders of magnitude, mixed above and below 1,
+/// including an exact 1.0 so the "some variables untagged" case is
+/// covered too.
+const D: [Number; 5] = [1e3, 1e-2, 1.0, 5.0, 1e-3];
+
+fn make_app() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    // Both arms run under `user-scaling` so the ONLY difference between
+    // them is the variable factors: the option itself, the objective
+    // factor and the row factors are identical.
+    app.options_mut()
+        .set_string_value("nlp_scaling_method", "user-scaling", true, false)
+        .unwrap();
+    // classify_activity refuses a relaxed-bound solve.
+    app.options_mut()
+        .set_numeric_value("bound_relax_factor", 0.0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    app
+}
+
+fn solved_session(x_scaling: Option<[Number; 5]>) -> Solver {
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ParametricTNLP::new(x_scaling)));
+    let mut solver = Solver::new(make_app(), tnlp);
+    let status = solver.solve();
+    assert!(
+        matches!(
+            status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve failed: {status:?}"
+    );
+    solver
+}
+
+#[track_caller]
+fn assert_close(what: &str, got: &[Number], want: &[Number], tol: Number) {
+    assert_eq!(got.len(), want.len(), "{what}: length");
+    for (k, (&g, &w)) in got.iter().zip(want.iter()).enumerate() {
+        let err = (g - w).abs() / w.abs().max(1.0);
+        assert!(
+            err < tol,
+            "{what}[{k}]: scaled={g}, plain={w}, rel err {err} not < {tol}"
+        );
+    }
+}
+
+/// The factors reach the sensitivity layer at all — without this the
+/// parity assertions below could pass by the wrapper never installing.
+#[test]
+fn the_session_reports_the_factors_the_solve_ran_under() {
+    let plain = solved_session(None);
+    assert_eq!(
+        plain.variable_scaling().expect("converged"),
+        None,
+        "an unscaled solve must report no change of variables"
+    );
+
+    let scaled = solved_session(Some(D));
+    assert_eq!(
+        scaled.variable_scaling().expect("converged"),
+        Some(D.to_vec()),
+        "the factors reported must be the ones the wrapper applied"
+    );
+}
+
+/// The converged iterate is the model's own `x`, not the algorithm's
+/// `x̃`. This capture reads the iterate rather than the
+/// `finalize_solution` payload — the predicate #529 identified as the
+/// one that matters.
+#[test]
+fn the_converged_iterate_is_in_the_models_units() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+    let want = plain.converged().expect("converged").x.clone();
+    let got = scaled.converged().expect("converged").x.clone();
+    assert_close("x", &got, &want, 1e-7);
+}
+
+/// `∂x*/∂p` — the accessor pyomo-pounce's `gradient()` / `estimate()`
+/// are built on.
+#[test]
+fn the_parametric_step_is_in_the_models_units() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+    for deltas in [[-0.5, 0.0], [0.0, 0.25], [0.3, -0.2]] {
+        let want = plain.parametric_step(&[2, 3], &deltas).expect("plain step");
+        let got = scaled
+            .parametric_step(&[2, 3], &deltas)
+            .expect("scaled step");
+        assert_close(&format!("dx for {deltas:?}"), &got, &want, 1e-7);
+    }
+}
+
+/// The full compound step, so the multiplier sensitivities are covered
+/// as well as the primal ones: `λ` is invariant under the substitution
+/// and the bound multipliers are not, and only a full-vector comparison
+/// distinguishes "both right" from "both untouched".
+#[test]
+fn the_full_kkt_step_is_in_the_models_units() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+    let want = plain
+        .parametric_step_full(&[2, 3], &[-0.5, 0.1])
+        .expect("plain full step");
+    let got = scaled
+        .parametric_step_full(&[2, 3], &[-0.5, 0.1])
+        .expect("scaled full step");
+    assert_eq!(
+        plain.block_dims(),
+        scaled.block_dims(),
+        "a change of variables must not change the KKT layout"
+    );
+    assert_close("dx_full", &got, &want, 1e-6);
+}
+
+/// `-inv(H_R)` is the parameter covariance, which is what
+/// `covariance()` / `information()` return.
+#[test]
+fn the_reduced_hessian_is_in_the_models_units() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+    let want = plain
+        .compute_reduced_hessian(&[2, 3], 1.0)
+        .expect("plain H_R");
+    let got = scaled
+        .compute_reduced_hessian(&[2, 3], 1.0)
+        .expect("scaled H_R");
+    assert_close("H_R", &got, &want, 1e-6);
+}
+
+/// A back-solve against a hand-packed RHS: the same `K⁻¹` the
+/// accessors above ride on, asserted directly so a failure localizes to
+/// the conjugation rather than to a caller.
+#[test]
+fn the_back_solve_is_in_the_models_units() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+    let dim = plain.kkt_dim().expect("converged");
+    // A RHS that touches every block, and is not symmetric under any
+    // permutation of them, so a block-swap would show up.
+    let rhs: Vec<Number> = (0..dim).map(|i| 1.0 + 0.25 * (i as Number)).collect();
+    let mut want = vec![0.0; dim];
+    let mut got = vec![0.0; dim];
+    plain.kkt_solve(&rhs, &mut want).expect("plain solve");
+    scaled.kkt_solve(&rhs, &mut got).expect("scaled solve");
+    assert_close("K^-1 rhs", &got, &want, 1e-6);
+}
+
+/// The exact-Hessian product and a constraint row's gradient: both read
+/// the model's own matrices out of the converged state rather than
+/// riding the factor, so they carry the substitution separately.
+#[test]
+fn the_model_matrix_accessors_are_in_the_models_units() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+
+    for v in [
+        vec![1.0, 0.0, 0.0, 0.0, 0.0],
+        vec![0.0, 1.0, 0.0, 0.0, 0.0],
+        vec![0.3, -1.2, 0.7, 2.0, -0.4],
+    ] {
+        let want = plain.hessian_vec(&v).expect("plain Hv");
+        let got = scaled.hessian_vec(&v).expect("scaled Hv");
+        assert_close("H v", &got, &want, 1e-6);
+    }
+
+    for row in 0..5 {
+        let want = plain.row_normal(row).expect("plain row_normal");
+        let got = scaled.row_normal(row).expect("scaled row_normal");
+        assert_close(&format!("row_normal({row})"), &got, &want, 1e-6);
+    }
+}
+
+/// Activity classification: the statuses must not move, and the
+/// exported `Σ` must be the model's own. The status is the part a
+/// non-uniform `d` could shift without any single ratio being wrong —
+/// the identification floor is one number shared across entries — so
+/// asserting the statuses is not redundant with asserting `Σ`.
+#[test]
+fn activity_classification_is_unmoved_by_the_change_of_variables() {
+    let plain = solved_session(None);
+    let scaled = solved_session(Some(D));
+    let want = plain.classify_activity().expect("plain classify");
+    let got = scaled.classify_activity().expect("scaled classify");
+
+    assert_eq!(got.var_status, want.var_status, "variable statuses");
+    assert_eq!(got.row_status, want.row_status, "row statuses");
+    assert_eq!(got.var_q_sign, want.var_q_sign, "variable curvature signs");
+    assert_eq!(got.row_q_sign, want.row_q_sign, "row curvature signs");
+    assert_eq!(
+        got.var_off_central_path, want.var_off_central_path,
+        "off-central-path flags are products s·z, invariant under d"
+    );
+    // Sigma and the ratio are BARRIER quantities, proportional to the
+    // mu the run stopped at (Sigma = z/s, and complementarity pins
+    // s.z ~ mu), and the two runs are different Newton trajectories
+    // that terminate at different mu -- here 9.1e-10 against 2.5e-9.
+    // So the invariant is Sigma/mu, not Sigma: dividing it out
+    // compares the geometry both runs found rather than where each
+    // one happened to stop. The units are still fully asserted, since
+    // a missed `d^2` on the export would land these entries a factor
+    // 1e6 / 1e-4 out -- six orders past this tolerance.
+    let per_mu = |v: &[Number], mu: Number| -> Vec<Number> { v.iter().map(|s| s / mu).collect() };
+    assert_close(
+        "var_sigma/mu",
+        &per_mu(&got.var_sigma, got.mu),
+        &per_mu(&want.var_sigma, want.mu),
+        1e-3,
+    );
+    assert_close(
+        "row_sigma/mu",
+        &per_mu(&got.row_sigma, got.mu),
+        &per_mu(&want.row_sigma, want.mu),
+        1e-3,
+    );
+    // NaN where nothing was classified, so compare the finite entries.
+    for (k, (&g, &w)) in got.var_ratio.iter().zip(want.var_ratio.iter()).enumerate() {
+        assert_eq!(g.is_nan(), w.is_nan(), "var_ratio[{k}] classified-ness");
+        if !g.is_nan() {
+            let (g, w) = (g / got.mu, w / want.mu);
+            let err = (g - w).abs() / w.abs().max(1.0);
+            assert!(err < 1e-3, "var_ratio[{k}]/mu: {g} vs {w}");
+        }
+    }
+}
+
+/// The `SensSolve` builder is the other consumer of the same converged
+/// state, and it captures the iterate and the bound multipliers
+/// itself — so it needs its own parity check, not just the session's.
+#[test]
+fn the_sens_solve_builder_reports_in_the_models_units() {
+    let run = |x_scaling: Option<[Number; 5]>| {
+        let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(ParametricTNLP::new(x_scaling)));
+        let mut app = make_app();
+        let out = SensSolve::new(vec![2, 3])
+            .with_deltas(vec![-0.5, 0.0])
+            .with_reduced_hessian()
+            .run(&mut app, tnlp);
+        assert!(out.error.is_none(), "sensitivity stage: {:?}", out.error);
+        out
+    };
+    let want = run(None);
+    let got = run(Some(D));
+
+    assert_close(
+        "x",
+        got.x.as_ref().expect("x"),
+        want.x.as_ref().expect("x"),
+        1e-7,
+    );
+    assert_close(
+        "dx",
+        got.dx.as_ref().expect("dx"),
+        want.dx.as_ref().expect("dx"),
+        1e-7,
+    );
+    assert_close(
+        "H_R",
+        got.reduced_hessian.as_ref().expect("H_R"),
+        want.reduced_hessian.as_ref().expect("H_R"),
+        1e-6,
+    );
+    assert_close(
+        "mult_g",
+        got.mult_g.as_ref().expect("mult_g"),
+        want.mult_g.as_ref().expect("mult_g"),
+        1e-6,
+    );
+    assert_close(
+        "mult_x_L",
+        got.mult_x_l.as_ref().expect("mult_x_l"),
+        want.mult_x_l.as_ref().expect("mult_x_l"),
+        1e-6,
+    );
+    assert_close(
+        "mult_x_U",
+        got.mult_x_u.as_ref().expect("mult_x_u"),
+        want.mult_x_u.as_ref().expect("mult_x_u"),
+        1e-6,
+    );
+}

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -96,19 +96,14 @@ Factors must be positive and finite. A negative factor would reverse a
 variable's direction and swap its bounds, so it raises rather than
 being applied.
 
-**One exception: the sensitivity path.** A model carrying
-[sensitivity](sensitivity.md) declarations raises if the Suffix tags a
-variable. Those accessors read the solver's KKT factorization directly
-rather than through the scaling layer, so on a variable-scaled solve
-they would report scaled-space numbers while promising your model's
-units. Solve without the sensitivity declarations, or drop the variable
-entries, until
-[issue #486](https://github.com/jkitchin/pounce/issues/486) carries the
-factors into that translation.
-
 This works on both solve paths: the ordinary ASL/subprocess solve and
 the in-process path taken when the model carries [sensitivity
-declarations](sensitivity.md).
+declarations](sensitivity.md) — including the accessors themselves.
+`covariance()`, `information()`, `gradient()` and `estimate()` read the
+solver's KKT factorization directly rather than through the scaling
+layer, so they carry the factors through their own natural-units
+translation and answer in your model's units on a variable-scaled solve
+([issue #486](https://github.com/jkitchin/pounce/issues/486)).
 
 ## Preflight and initialization
 

--- a/docs/src/scaling.md
+++ b/docs/src/scaling.md
@@ -48,18 +48,31 @@ gradient-based heuristic.
 If the TNLP's `get_scaling_parameters` returns false (the default),
 pounce falls back to no automatic scaling.
 
-> **Per-variable factors are refused, not ignored.** pounce's
-> `OrigIpoptNlp` models `obj_scaling` and per-constraint `g_scaling`
-> (the design in [issue #61](https://github.com/jkitchin/pounce/issues/61));
-> it does not rescale variables. A request that sets any `x_scaling`
-> entry away from `1.0` therefore **fails the solve** with
-> `Invalid_Option` and an explanatory message, rather than applying the
-> other two axes and dropping this one — which used to hand back a
-> converged answer to a differently-conditioned problem with nothing
-> said about it ([issue #483](https://github.com/jkitchin/pounce/issues/483)).
-> Rescale those variables in the model itself (substitute `x = z / s`
-> and give the solver `z`). Modelling variable scaling in the core is
-> staged work tracked on #483.
+> **Per-variable factors are a change of variables.** `OrigIpoptNlp`
+> models `obj_scaling` and per-constraint `g_scaling` only (the design
+> in [issue #61](https://github.com/jkitchin/pounce/issues/61)), so
+> `x_scaling` is applied one level below the algorithm instead: a
+> wrapper substitutes `x̃ = d ⊙ x`, the IPM works in the scaled
+> coordinates, and everything reported back — the solution, the duals,
+> the bound multipliers, and every
+> [sensitivity](sensitivity.md) accessor — is in your own units
+> ([issue #486](https://github.com/jkitchin/pounce/issues/486)). No
+> clone of the model is made and no `propagate_solution` step is
+> needed, which is what distinguishes this from Pyomo's
+> `core.scale_model`.
+>
+> Factors must be **finite and strictly positive**. Zero and negative
+> are refused rather than applied: a negative factor reverses a
+> variable's direction and swaps its bounds. A factor that would push
+> a finite bound past `nlp_lower_bound_inf` / `nlp_upper_bound_inf` —
+> turning a bounded variable into a free one — is refused too, naming
+> the threshold it crossed. Absent bounds stay absent: the `±1e19`
+> sentinel is an ordinary finite number, so it is passed through
+> unscaled rather than multiplied into range.
+>
+> One user-visible consequence: `tol` keeps comparing **scaled**
+> quantities, matching upstream Ipopt, so the same `tol` stops at a
+> different point than it would on the unscaled model.
 
 #### Setting user scaling
 

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -587,18 +587,34 @@ pounce undoes that scaling in every held-factor back-solve, so `dx`,
 problem was scaled internally
 ([#128](https://github.com/jkitchin/pounce/issues/128)).
 
-`classify_activity()` is scale-invariant for the same reason, and by
-construction rather than by undoing anything: its ratios are formed so
-that rescaling a variable, a constraint row, or the objective leaves
-them fixed. Writing a constraint as `1000·x ≥ 0` instead of `x ≥ 0`
-does not move a status, and neither does the solver's own per-row
-`d_scale`. The values the report exports follow the natural-units
-contract like everything else: `var_sigma` and `row_sigma` are the
-barrier diagonals in the model's own units, `row_normal(j)` is the
-constraint gradient with the solver's per-row scale divided out, and
-`hessian_vec(v)` is the exact Lagrangian Hessian times a user-space
-vector with the objective scale divided out; classification happens on
-the scaled quantities internally, the report never shows them.
+That covers **user scaling** too, on all three of its axes. A
+per-variable `scaling_factor` is applied as a change of variables
+`x̃ = d ⊙ x` below the algorithm, so the held factor is the scaled
+problem's; the factors are carried into the same translation, and
+every accessor answers in your units
+([#486](https://github.com/jkitchin/pounce/issues/486)). The factors a
+solve ran under are readable back from `Solver.nlp_scaling["x_scaling"]`
+(Python) / `Solver::variable_scaling` (Rust) — diagnostic rather than a
+correction to apply, since the outputs already carry it.
+
+`classify_activity()` is scale-invariant for the same reason, and
+mostly by construction rather than by undoing anything: its ratios are
+formed so that rescaling a constraint row or the objective leaves them
+fixed. Writing a constraint as `1000·x ≥ 0` instead of `x ≥ 0` does
+not move a status, and neither does the solver's own per-row
+`d_scale`. A change of variables is the one case the ratios do not
+absorb on their own — the identification floor is a single number
+shared across entries, so a *non-uniform* `d` would move entries
+across it — and there the factors are divided out of the geometry
+before anything is classified, which keeps a status from depending on
+the conditioning you asked for. The values the report exports follow
+the natural-units contract like everything else: `var_sigma` and
+`row_sigma` are the barrier diagonals in the model's own units,
+`row_normal(j)` is the constraint gradient with the solver's per-row
+scale divided out, and `hessian_vec(v)` is the exact Lagrangian
+Hessian times a user-space vector with the objective scale divided
+out; classification happens on the scaled quantities internally, the
+report never shows them.
 
 **Variable indices are user-space, factor rows are not.** Everything
 the sensitivity API reports or accepts — the `.col` file's order, the
@@ -627,7 +643,7 @@ solver-space value and the factors that relate the two are exposed:
   `info["obj_scaling_factor"]`, `info["pin_g_scaling"]`;
   `Solver.reduced_hessian(pins, scaled=True)`,
   `Solver.kkt_solve(rhs, scaled=True)`, and the `Solver.nlp_scaling`
-  dict (`{"obj": df, "c_scale": …, "d_scale": …}`).
+  dict (`{"obj": df, "c_scale": …, "d_scale": …, "x_scaling": …}`).
 - Rust: `SensResult::{reduced_hessian_scaled, obj_scaling_factor,
   pin_g_scaling}`, `Solver::{compute_reduced_hessian_scaled,
   kkt_solve_scaled, nlp_scaling, pin_g_scaling}`, and

--- a/pyomo-pounce/pyomo_pounce/scaling.py
+++ b/pyomo-pounce/pyomo_pounce/scaling.py
@@ -13,7 +13,7 @@ no scaling code at all, so the option was accepted and meant "none": a
 badly conditioned model kept converging badly with nothing to say the
 suffix had been ignored.
 
-Two things happen here now:
+Three things happen here now:
 
 * **Objective and constraint factors are honored.** The subprocess
   (ASL) path needs nothing from this module — the writer emits the
@@ -25,12 +25,13 @@ Two things happen here now:
   applies them as a change of variables one level below the algorithm
   and returns the solution in the model's own units, so no clone and
   no ``propagate_solution`` step is involved.
-* **The sensitivity path still refuses them.** Its accessors read the
-  KKT factorization directly rather than through the solver's TNLP
-  chain, so on a variable-scaled solve they would report scaled-space
-  numbers while promising natural units. :func:`check_no_variable_scaling`
-  raises there until gh #486 stage 3 teaches that translation the
-  variable factors.
+* **The sensitivity path honors them too** (gh #486 stage 3).
+  :func:`problem_scaling` translates the variable entries alongside the
+  row ones, and the sensitivity accessors carry the factors through
+  their natural-units translation, so a variable-scaled solve answers
+  every query in the model's own units. Stages 1 and 2 refused those
+  queries rather than answering them in scaled coordinates; nothing is
+  refused now.
 
 Semantics, matching the AMPL/Ipopt reading of the suffix:
 
@@ -137,38 +138,6 @@ def read_scaling(model):
     return obj_factor, constraints, variables
 
 
-def check_no_variable_scaling(model, max_list=5):
-    """Raise if the `scaling_factor` Suffix tags variables.
-
-    Ordinary solves apply variable factors (gh #486 stage 2), so this
-    guards the SENSITIVITY path alone. Its accessors read the KKT
-    factorization directly rather than through the solver's TNLP
-    chain, so a variable-scaled solve would have them report
-    scaled-space numbers under a natural-units contract. That is the
-    silent-wrong-answer shape gh #483 was opened about, so it is a hard
-    error until stage 3 carries the factors into that translation.
-    """
-    parsed = read_scaling(model)
-    if parsed is None:
-        return
-    _, _, variables = parsed
-    if not variables:
-        return
-    shown = ", ".join(f"{vd.name}={f:g}" for vd, f in variables[:max_list])
-    more = (f" (+{len(variables) - max_list} more)"
-            if len(variables) > max_list else "")
-    raise ValueError(
-        "pounce sensitivity solve: nlp_scaling_method=user-scaling, and the "
-        f"model's `{SUFFIX_NAME}` Suffix sets a scaling factor on "
-        f"{len(variables)} variable(s) ({shown}{more}). Ordinary solves "
-        "apply variable factors, but the sensitivity accessors read the KKT "
-        "factorization directly and do not yet carry those factors, so they "
-        "would report scaled-space numbers while promising the model's own "
-        "units. Drop the variable entries for this solve, or solve without "
-        "the sensitivity declarations. Tracking issue: "
-        "https://github.com/jkitchin/pounce/issues/486")
-
-
 def warn_if_no_suffix(model):
     """Warn when `user-scaling` is on but the model tags nothing.
 
@@ -187,30 +156,39 @@ def warn_if_no_suffix(model):
             stacklevel=3)
 
 
-def problem_scaling(model, con_names, con_alias):
-    """Suffix -> `(obj_factor, g_scaling)` for `Problem.set_problem_scaling`.
+def problem_scaling(model, con_names, con_alias, var_names):
+    """Suffix -> `(obj_factor, g_scaling, x_scaling)` for
+    `Problem.set_problem_scaling`.
 
     Used by the in-process sensitivity path, which hands pounce
     evaluator callbacks rather than an `.nl` file and so has no suffix
     segments for the solver to read.
 
-    `con_names` is the solve's constraint rows in `.nl` order and
-    `con_alias` maps an original constraint's name to the clone name the
+    `con_names` is the solve's constraint rows in `.nl` order,
+    `var_names` its variable columns in the same order, and `con_alias`
+    maps an original constraint's name to the clone name the
     declared-parameter surgery gave it, exactly as in
-    `_warm_start_from_suffixes`. Rows the Suffix does not mention stay
-    at 1.0. Returns ``None`` when the model declares no Suffix.
+    `_warm_start_from_suffixes`. Rows and columns the Suffix does not
+    mention stay at 1.0. Returns ``None`` when the model declares no
+    Suffix.
 
-    Variable entries are not this function's business: like the `.nl`
-    writer, it translates what it can and leaves the refusal to
-    :func:`check_no_variable_scaling`, which callers run only when
-    `user-scaling` is actually on. That keeps a `scaling_factor` Suffix
-    written for Pyomo's `core.scale_model` from failing an ordinary
-    solve.
+    Variables are translated here rather than refused (gh #486 stage
+    3): the core applies them as a change of variables and every
+    sensitivity accessor carries the factors back out, so the
+    in-process path has the same reach as the ASL one, where the
+    writer emits the entries as `.nl` suffix segments. `x_scaling` is
+    ``None`` when the Suffix asks for nothing on that axis, which
+    keeps the wrapper — and its cost — off an unscaled solve.
+
+    Variables the Suffix names but the written model has no column for
+    are skipped, like the constraints: the surgery clone is what was
+    written, and a component missing from it is not a column pounce
+    could rescale.
     """
     parsed = read_scaling(model)
     if parsed is None:
         return None
-    obj_factor, constraints, _ = parsed
+    obj_factor, constraints, variables = parsed
     con_row = {name: i for i, name in enumerate(con_names)}
     g_scaling = [1.0] * len(con_names)
     for cd, factor in constraints.items():
@@ -220,4 +198,14 @@ def problem_scaling(model, con_names, con_alias):
         row = con_row.get(con_alias.get(cd.name, cd.name))
         if row is not None:
             g_scaling[row] = factor
-    return obj_factor, g_scaling
+
+    var_col = {name: i for i, name in enumerate(var_names)}
+    x_scaling = None
+    for vd, factor in variables:
+        col = var_col.get(vd.name)
+        if col is None:
+            continue
+        if x_scaling is None:
+            x_scaling = [1.0] * len(var_names)
+        x_scaling[col] = factor
+    return obj_factor, g_scaling, x_scaling

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -63,7 +63,6 @@ from pyomo.core.expr.visitor import replace_expressions
 from pyomo.opt import SolverResults, SolverStatus, TerminationCondition
 
 from pyomo_pounce.scaling import (
-    read_scaling,
     problem_scaling,
     user_scaling_requested,
     warn_if_no_suffix,
@@ -322,14 +321,6 @@ class _Session:
         self._con_row = _row_index(con_names) if con_row is None else con_row
         self.pins = pins              # ComponentMap: param data -> pin row
         self.con_alias = con_alias    # original con name -> clone row name
-        # Whether the solve applied per-variable scaling (gh #486 stage
-        # 2). The solve itself is fine; the ACCESSORS are not, because
-        # they read the KKT factorization directly rather than through
-        # the scaling layer, so their natural-units contract does not
-        # hold. Checked by `_no_variable_scaling`, not at solve time:
-        # refusing the solve would block a scaled run that never asks a
-        # sensitivity question.
-        self.variable_scaled = ()
         self.base_x = None
         # Objective value at the solve. NaN, not None, is the "never
         # computed" sentinel: that is the convention the engine itself
@@ -724,12 +715,18 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     # unconditionally is safe: `nlp_scaling_method` decides whether the
     # engine looks, so a tagged model solved without `user-scaling`
     # behaves as before.
+    #
+    # Variable entries go in alongside the row ones (gh #486 stage 3):
+    # the core applies them as a change of variables and the
+    # sensitivity accessors carry the factors back out, so this path
+    # honors the same Suffix the ASL one does.
     if user_scaling_requested(options):
         warn_if_no_suffix(model)
-    scaling = problem_scaling(model, con_names, con_alias)
+    scaling = problem_scaling(model, con_names, con_alias, var_names)
     if scaling is not None:
-        obj_scale, g_scale = scaling
-        prob.set_problem_scaling(obj_scale, g_scaling=g_scale)
+        obj_scale, g_scale, x_scale = scaling
+        prob.set_problem_scaling(obj_scale, x_scaling=x_scale,
+                                 g_scaling=g_scale)
     warm = {}
     if _warm_start_requested(options):
         warm = _warm_start_from_suffixes(
@@ -827,13 +824,6 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
 
     session = _Session(model, nl, solver, var_names, con_names, pins,
                        con_alias, var_row=var_row, con_row=con_row)
-    # Record rather than refuse: a variable-scaled solve is correct, and
-    # only a later sensitivity QUERY would be answered in the wrong
-    # space (gh #486 stage 3).
-    if user_scaling_requested(options):
-        parsed = read_scaling(model)
-        if parsed is not None:
-            session.variable_scaled = tuple(vd for vd, _ in parsed[2])
     session.base_x = np.asarray(x)
     # the engine always reports obj_val (NaN when it evaluated nothing),
     # and it is eval_f on this model's own bridge at the final iterate --
@@ -971,32 +961,6 @@ class Gradient:
             columns=[p.name for p in self._params])
 
 
-def _no_variable_scaling(session, who, max_list=5):
-    """Raise if this session's solve applied per-variable scaling.
-
-    The solve was correct. What does not hold is the accessors'
-    contract: they read the held KKT factorization, which is the
-    factorization of the SCALED problem, so every number they derive
-    from it would be in scaled coordinates while the documentation
-    promises the model's own units. Stage 3 of gh #486 carries the
-    factors into that translation and this goes away.
-    """
-    tagged = getattr(session, "variable_scaled", ())
-    if not tagged:
-        return
-    shown = ", ".join(vd.name for vd in tagged[:max_list])
-    more = f" (+{len(tagged) - max_list} more)" if len(tagged) > max_list else ""
-    raise RuntimeError(
-        f"{who}: this solve applied per-variable scaling factors to "
-        f"{len(tagged)} variable(s) ({shown}{more}). The solve itself is "
-        "correct and its solution is in your model's units, but the "
-        "sensitivity accessors read the KKT factorization directly and do "
-        "not yet carry those factors, so they would report scaled-space "
-        "numbers. Re-solve without the variable entries in the "
-        "`scaling_factor` Suffix to ask this question. Tracking issue: "
-        "https://github.com/jkitchin/pounce/issues/486")
-
-
 def gradient(target=None, *, wrt):
     """d(target*)/d(wrt).
 
@@ -1007,7 +971,6 @@ def gradient(target=None, *, wrt):
     Scalar target and scalar wrt -> float. Anything else -> a Gradient
     object: g[target, param], or g.to_dataframe() for the full Jacobian."""
     session = _session_for(wrt)
-    _no_variable_scaling(session, "gradient")
     params = list(_iter_data(wrt))
     if target is None:
         targets = [v for v in (session.orig_var(nm)
@@ -1047,7 +1010,6 @@ def estimate(model, perturb, clamp=True):
         raise RuntimeError(
             "no sensitivity session: declare_sens_param() then solve with "
             "SolverFactory('pounce') first")
-    _no_variable_scaling(session, "estimate")
 
     items = perturb.items() if hasattr(perturb, "items") else perturb
     pin_idx, deltas = [], []
@@ -2001,7 +1963,6 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian",
             "declare_residual()), or retain_kkt() for "
             "wrt= queries with nothing declared, then solve with "
             "SolverFactory('pounce') first")
-    _no_variable_scaling(session, "covariance")
     # the block: the declared fitted parameters by default, or any
     # block of the solve's variables via wrt= (each call re-reduces
     # onto its own argument, so one solve serves as many blocks as are
@@ -2385,7 +2346,6 @@ def information(model, hessian="lagrangian", wrt=None):
             "declare_residual()), or retain_kkt() for "
             "wrt= queries with nothing declared, then solve with "
             "SolverFactory('pounce') first")
-    _no_variable_scaling(session, "information")
     params, rows = _resolve_wrt(session, wrt, "information")
     n_params = len(params)
     wording = "fitted" if wrt is None else "block"

--- a/pyomo-pounce/tests/test_user_scaling.py
+++ b/pyomo-pounce/tests/test_user_scaling.py
@@ -14,16 +14,18 @@ Three things are pinned here.
 2. **It reaches the solver on both paths** — the ASL/subprocess path
    through the writer's `.nl` suffix segments, and the in-process
    sensitivity path through `Problem.set_problem_scaling`.
-3. **Nothing it cannot honor is dropped quietly**: a per-variable
-   factor raises, and a `user-scaling` request with no Suffix to apply
-   warns.
+3. **Nothing it cannot honor is dropped quietly**: a `user-scaling`
+   request with no Suffix to apply warns.
 
 The sensitivity accessors get their own axis. `natural_units_conj`
-already translates `df` / `dc` / `dd` back to model units for any
-scaling method, so user scaling *should* be invisible to every
-accessor — but that is the kind of claim worth proving rather than
-assuming, so each one is checked against the same quantity computed
-with no scaling engaged.
+translates `df` / `dc` / `dd` — and, since gh #486 stage 3, the
+per-variable factors — back to model units for any scaling method, so
+user scaling *should* be invisible to every accessor. That is the kind
+of claim worth proving rather than assuming, so each one is checked
+against the same quantity computed with no scaling engaged. Variable
+factors get the same treatment on their own axis (`solve_pair(x_scale=…)`):
+stages 1 and 2 refused those queries, and what replaces the refusal is
+not "it runs" but "it agrees with the unscaled answer".
 """
 import warnings
 
@@ -45,7 +47,6 @@ from pyomo_pounce import (
     retain_kkt,
 )
 from pyomo_pounce.scaling import (
-    check_no_variable_scaling,
     problem_scaling,
     read_scaling,
     user_scaling_requested,
@@ -147,14 +148,18 @@ def test_user_scaling_requested_reads_the_option():
     assert not user_scaling_requested(None)
 
 
+COLS = ["x[1]", "x[2]"]
+
+
 def test_problem_scaling_builds_dense_row_vectors():
     # Untagged rows stay at 1.0, and a tagged constraint the solve does
     # not have a row for is skipped rather than mis-indexed.
     m = tagged_model(o=100.0, c1=10.0)
-    obj, g = problem_scaling(m, ["c1", "c2"], {})
+    obj, g, x = problem_scaling(m, ["c1", "c2"], {}, COLS)
     assert obj == 100.0
     assert g == [10.0, 1.0]
-    obj, g = problem_scaling(m, ["c2"], {})
+    assert x is None, "no variable entry means no change of variables"
+    obj, g, x = problem_scaling(m, ["c2"], {}, COLS)
     assert g == [1.0]
 
 
@@ -162,29 +167,30 @@ def test_problem_scaling_follows_the_surgery_alias():
     # The declared-parameter surgery renames replaced rows on the clone
     # that is actually solved; the Suffix is keyed by the original.
     m = tagged_model(c1=10.0)
-    obj, g = problem_scaling(m, ["_pounce.c1", "c2"], {"c1": "_pounce.c1"})
+    obj, g, _ = problem_scaling(m, ["_pounce.c1", "c2"],
+                                {"c1": "_pounce.c1"}, COLS)
     assert g == [10.0, 1.0]
 
 
-# ── refusals and warnings ────────────────────────────────────────────────────
-
-def test_variable_factor_raises():
-    with pytest.raises(ValueError, match="variable"):
-        check_no_variable_scaling(tagged_model(o=100.0, x1=3.0))
-
-
-def test_variable_factor_error_names_the_variables_and_the_issue():
-    with pytest.raises(ValueError) as exc:
-        check_no_variable_scaling(tagged_model(x1=3.0, x2=0.5))
-    msg = str(exc.value)
-    assert "x[1]" in msg and "x[2]" in msg
-    assert "486" in msg, "the guard now points at the sensitivity stage"
+def test_problem_scaling_builds_the_variable_vector():
+    # gh #486 stage 3: variable entries are translated for the
+    # in-process path too, dense and in `.col` order, so the column a
+    # factor lands on is the one the Suffix named.
+    m = tagged_model(o=100.0, x2=0.25)
+    _, _, x = problem_scaling(m, ["c1", "c2"], {}, COLS)
+    assert x == [1.0, 0.25]
 
 
-def test_unit_variable_factor_is_not_a_request():
-    # 1.0 asks for nothing; failing a solve over it would be noise.
-    check_no_variable_scaling(tagged_model(o=100.0, x1=1.0))
+def test_problem_scaling_skips_a_variable_with_no_column():
+    # A component the written model has no column for is not a column
+    # pounce could rescale -- the same rule the rows follow, and the
+    # alternative is a silently mis-indexed factor.
+    m = tagged_model(x1=3.0)
+    _, _, x = problem_scaling(m, ["c1", "c2"], {}, ["x[2]"])
+    assert x is None
 
+
+# ── warnings ─────────────────────────────────────────────────────────────────
 
 def test_solve_applies_a_variable_factor():
     # gh #486 stage 2 inverted this: the core applies variable factors
@@ -252,11 +258,16 @@ def linear_data():
     return x, y, np.column_stack([np.ones(N), x])
 
 
-def linear_model(x, y, scale=None, dead=False, param=False):
+def linear_model(x, y, scale=None, x_scale=None, dead=False, param=False):
     """`min sum r_i^2` with `r_i == y_i - a - b x_i`: the estimation
     fixture the covariance/information tests use, optionally tagged
     with a `scaling_factor` Suffix, optionally carrying an inert fixed
-    variable, optionally with a declared sensitivity parameter."""
+    variable, optionally with a declared sensitivity parameter.
+
+    `scale` is the `(objective, constraint)` pair; `x_scale` is a
+    `{'a': 4.0, 'b': 1e-2, 'r': 25.0}`-shaped mapping of per-variable
+    factors, which needs `scale` set too (the Suffix is created there).
+    """
     m = pyo.ConcreteModel()
     m.I = pyo.RangeSet(0, len(x) - 1)
     m.a = pyo.Var(initialize=0.0)
@@ -289,15 +300,22 @@ def linear_model(x, y, scale=None, dead=False, param=False):
         m.scaling_factor[m.obj] = obj_s
         for i in m.I:
             m.scaling_factor[m.res[i]] = con_s
+        for name, factor in (x_scale or {}).items():
+            comp = getattr(m, name)
+            for vd in (comp.values() if comp.is_indexed() else [comp]):
+                m.scaling_factor[vd] = factor
     return m
 
 
-def solve_pair(**kwargs):
+def solve_pair(x_scale=None, **kwargs):
     """The same estimation model solved twice — user scaling engaged,
     and no scaling at all — so every accessor can be compared against
-    unscaled ground truth."""
+    unscaled ground truth. `x_scale` adds a change of variables to the
+    scaled arm (gh #486 stage 3); the unscaled arm never gets one, so
+    every comparison below is scaled-against-plain, never
+    scaled-against-scaled."""
     x, y, X = linear_data()
-    scaled = linear_model(x, y, scale=(1e-3, 50.0), **kwargs)
+    scaled = linear_model(x, y, scale=(1e-3, 50.0), x_scale=x_scale, **kwargs)
     pyo.SolverFactory("pounce").solve(scaled, options=dict(USER_SCALING))
     plain = linear_model(x, y, **kwargs)
     pyo.SolverFactory("pounce").solve(plain)
@@ -306,37 +324,6 @@ def solve_pair(**kwargs):
 
 def session_scaling(m):
     return m.__dict__["_pounce_sens"].session.solver.nlp_scaling
-
-
-def test_a_variable_scaled_solve_runs_but_its_accessors_refuse():
-    # The refusal belongs at the ACCESSORS, not the solve. A declared
-    # model may want the scaled solve and never ask a sensitivity
-    # question, and blocking the solve would deny it that for no
-    # reason. What cannot be answered is a query against the held
-    # factorization, which is the scaled problem's (gh #486 stage 3).
-    x, y, _ = linear_data()
-    m = linear_model(x, y, scale=(1e-3, 50.0))
-    m.scaling_factor[m.a] = 4.0
-    res = pyo.SolverFactory("pounce").solve(m, options=dict(USER_SCALING))
-    assert res.solver.termination_condition == TerminationCondition.optimal
-
-    for call in (
-        lambda: covariance(m),
-        lambda: information(m),
-        lambda: gradient(m.a, wrt=m.p) if hasattr(m, "p") else _skip(),
-    ):
-        try:
-            call()
-        except RuntimeError as e:
-            assert "486" in str(e), f"wrong error: {e}"
-        except (AttributeError, TypeError, NameError):
-            pass  # accessor not applicable to this fixture
-        else:
-            raise AssertionError("accessor answered from a scaled factor")
-
-
-def _skip():
-    raise TypeError("not applicable")
 
 
 def test_in_process_variable_factor_is_inert_without_the_option():
@@ -465,3 +452,110 @@ def test_retain_only_block_matches_unscaled():
     finally:
         release_kkt(scaled)
         release_kkt(plain)
+
+
+# ── variable factors on the sensitivity path (gh #486 stage 3) ───────────────
+
+#: A change of variables spanning six orders of magnitude, and not
+#: uniform: `a` and `b` are the fitted parameters the covariance is
+#: about, `r` the residual block. A uniform factor would cancel out of
+#: several of the quantities below and prove less.
+X_SCALE = {"a": 1e3, "b": 1e-3, "r": 20.0}
+
+
+def test_the_in_process_path_installs_the_variable_factors():
+    """Guard for the wiring, the same role
+    `test_in_process_path_installs_the_user_scaling` plays for the row
+    factors: without it every comparison below passes vacuously, on a
+    solve that quietly applied no change of variables at all."""
+    scaled, plain, _ = solve_pair(x_scale=X_SCALE)
+    d = session_scaling(scaled)["x_scaling"]
+    assert d is not None, "the solve applied no change of variables"
+    assert session_scaling(plain)["x_scaling"] is None
+    # By name, not by position: the writer chooses the column order,
+    # and a factor landing on the wrong column is exactly the failure
+    # this guard is here to catch.
+    cols = scaled.__dict__["_pounce_sens"].session.var_names
+    by_name = dict(zip(cols, np.asarray(d).tolist()))
+    assert by_name["a"] == pytest.approx(1e3)
+    assert by_name["b"] == pytest.approx(1e-3)
+    assert by_name["r[0]"] == pytest.approx(20.0)
+
+
+def test_estimates_are_unmoved_by_variable_scaling():
+    scaled, plain, _ = solve_pair(x_scale=X_SCALE)
+    for name in ("a", "b"):
+        assert pyo.value(getattr(scaled, name)) == pytest.approx(
+            pyo.value(getattr(plain, name)), rel=1e-6)
+
+
+def test_covariance_matches_unscaled_ground_truth_under_variable_scaling():
+    scaled, plain, X = solve_pair(x_scale=X_SCALE)
+    np.testing.assert_allclose(
+        covariance(scaled, sigma_sq=SIGMA**2).matrix,
+        covariance(plain, sigma_sq=SIGMA**2).matrix, rtol=1e-6)
+    # and against the closed form, so both runs being wrong the same
+    # way cannot pass
+    np.testing.assert_allclose(
+        covariance(scaled, sigma_sq=SIGMA**2).matrix,
+        SIGMA**2 * np.linalg.inv(X.T @ X), rtol=1e-6)
+
+
+def test_information_matches_unscaled_ground_truth_under_variable_scaling():
+    scaled, plain, X = solve_pair(x_scale=X_SCALE)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               information(plain).matrix, rtol=1e-6)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               2.0 * X.T @ X, rtol=1e-6)
+    # The Gauss-Newton form is built from the residual Jacobian rather
+    # than the KKT factor, so it carries the substitution down its own
+    # path and needs asserting separately.
+    np.testing.assert_allclose(
+        information(scaled, hessian="gauss-newton").matrix,
+        2.0 * X.T @ X, rtol=1e-6)
+
+
+def test_wrt_blocks_match_unscaled_under_variable_scaling():
+    # The residual block is where a per-variable factor is most visible:
+    # `r` carries a factor of its own, and the prediction band is a
+    # rank-deficient block whose projection would not survive a missed
+    # one.
+    scaled, plain, X = solve_pair(x_scale=X_SCALE)
+    C = SIGMA**2 * np.linalg.inv(X.T @ X)
+    assert covariance(scaled, sigma_sq=SIGMA**2,
+                      wrt=[scaled.a])[scaled.a] == pytest.approx(C[0, 0],
+                                                                 rel=1e-6)
+    H = X @ np.linalg.solve(X.T @ X, X.T)
+    np.testing.assert_allclose(
+        covariance(scaled, sigma_sq=SIGMA**2, wrt=scaled.r).matrix,
+        SIGMA**2 * H, rtol=1e-5, atol=1e-10)
+
+
+def test_classifier_statuses_match_unscaled_under_variable_scaling():
+    scaled, plain, _ = solve_pair(x_scale=X_SCALE)
+    assert (covariance(scaled, sigma_sq=SIGMA**2).conditioned_on
+            == covariance(plain, sigma_sq=SIGMA**2).conditioned_on)
+
+
+def test_gradient_and_estimate_match_unscaled_under_variable_scaling():
+    scaled, plain, _ = solve_pair(x_scale=X_SCALE, param=True)
+    for target in ("a", "b"):
+        g_scaled = gradient(getattr(scaled, target), wrt=scaled.shift)
+        g_plain = gradient(getattr(plain, target), wrt=plain.shift)
+        assert g_scaled == pytest.approx(g_plain, abs=1e-6)
+    est_scaled = estimate(scaled, [(scaled.shift, 0.25)])
+    est_plain = estimate(plain, [(plain.shift, 0.25)])
+    assert est_scaled[scaled.a] == pytest.approx(est_plain[plain.a], abs=1e-6)
+    assert est_scaled[scaled.b] == pytest.approx(est_plain[plain.b], abs=1e-6)
+
+
+def test_fixed_variable_composition_survives_variable_scaling():
+    # A fixed variable is dropped from the solve's columns but not from
+    # the Suffix's index space, so the factor vector and the factor's
+    # `x` block are different lengths -- the composition gh #450 is
+    # about, now with a change of variables on top.
+    scaled, plain, X = solve_pair(x_scale=X_SCALE, dead=True)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               2.0 * X.T @ X, rtol=1e-6)
+    np.testing.assert_allclose(information(scaled).matrix,
+                               information(plain).matrix, rtol=1e-6)


### PR DESCRIPTION
Closes #486.

Stage 3, and now the last of it: section 3 of that issue — the ~29 registered-but-unread group-(b) options, the "no field at all" category, and the per-value refusal mechanism — has been split out to #551, so #486 is complete once this merges.

## Problem

Stage 2 (#529) applies a per-variable `scaling_factor` as a change of variables `x̃ = d ⊙ x` one level below the algorithm. The converged KKT factor is therefore the *scaled* problem's, and the sensitivity layer reads that factor directly rather than through the TNLP chain — so its accessors were describing the wrong problem. That is why stage 2 refused `gradient` / `estimate` / `covariance` / `information` rather than answering.

What the refusal was standing in front of, measured on the estimation fixture in `test_user_scaling.py` (`scaling_factor[a] = 1e3`, `[b] = 1e-3`, `[r] = 20`, objective `1e-3`, rows `50`), with the guard removed so the accessors answer:

| | `cov(a,a)` | `cov(b,b)` | `info(a,a)` |
|---|---|---|---|
| before | `1.356923e+04` | `2.492308e-09` | `5.000000e-05` |
| after | `1.356923e-02` | `2.492308e-03` | `5.000000e+01` |
| closed form `σ²(XᵀX)⁻¹` / `2XᵀX` | `1.356923e-02` | `2.492308e-03` | `5.000000e+01` |

The errors are exactly `d_a² = 1e6`, `d_b² = 1e-6` and `1/d_a² = 1e-6` — a covariance reported in scaled coordinates under a natural-units contract.

## Cause

`PdSensBacksolver` conjugates the held factor back to natural units for the objective factor `df` and the per-row factors `dc` / `dd` (#128), because those live on `OrigIpoptNlp` where it can read them. The variable substitution lives *below* the NLP, in `ScalingTnlp`, so nothing in the sensitivity layer could see it. The same gap reaches the accessors that read the model's own matrices instead of the factor (`hessian_vec`, `row_normal`, `classify_activity`) and the two consumers that capture the algorithm's iterate.

## Fix

`TNLP::scaling_factors` — the accessor #529 added so the CLI's `on_converged` hook could undo the substitution — is forwarded up through a new `IpoptNlp::variable_scaling`, so `PdSensBacksolver::new` reads off the solve it holds what change of variables ran, in full-x, and projects it to var-x through the fixed-variable map.

The substitution then folds into the *existing* `(E, F)` pair rather than becoming a second mechanism:

```text
       x      z_l/z_u      everything else
E  =   1/d    1            1
F  =   1/d    d_{px(j)}    1
```

`E` takes no `d` on the z rows because the `d` in `z̃ = z ⊘ d` cancels against the one in the slack diagonal `x̃ − x̃_L = d ⊙ (x − x_L)`, leaving those rows identical to the natural ones. `s`, `y_c`, `y_d`, `v_l`, `v_u` are untouched — the substitution leaves the rows and their multipliers alone. All three scalings are diagonal, so they compose by elementwise product in either order, and `kkt_solve`, `parametric_step`, `parametric_step_full` and the reduced Hessian follow with no code of their own.

**Rejected: unscaling at each call site.** The alternative was to divide `d` out of `parametric_step`'s result, `reduced_hessian`'s, and so on. That is the shape #486 warned about under option A — one forgotten branch is silently wrong conditioning — and it also gets `parametric_step_full` wrong, where the primal and bound-multiplier blocks need opposite corrections. Folding into the conjugation makes the eight blocks one decision.

The accessors that do **not** ride the factor carry it explicitly: `hessian_vec` (`H = H̃ ⊙ (d ⊗ d)`, so the factor goes in with the vector and back out of the product), `row_normal` (`∇g = ∇g̃ ⊙ d`), and `classify_activity`, whose exported `Σ` gains its missing `d²`.

**`classify_activity` needed more than a corrected export.** The obvious move is to fix `Σ` on the way out and leave classification alone, since the ratio `Σ/q` is scale-invariant per entry. That is not sufficient: the identification floor is a *single* number shared across entries (`√ε · max|diag H|`), so a non-uniform `d` moves entries across it and changes a status. The factors are divided out of `sigma_x`, the Hessian diagonal, and the row geometry before anything is classified. Because `1.0` multiplies are exact, an unscaled solve is bit-identical to the previous path.

Two iterate-capture sites are fixed under the predicate #529 identified — "reads the iterate rather than the `finalize_solution` payload": `ConvergedState::x`, and the `SensSolve` builder's `x` / `mult_x_L` / `mult_x_U`. Found while auditing for that predicate: `sens_boundcheck` was clamping a now-natural-units step against the solve's own (scaled) bounds, projecting onto the wrong box; it now scales into and back out of the solve's coordinates, in both the builder and the CLI's `pounce_sens` driver.

pyomo-pounce's in-process sensitivity path builds no `.nl`, so it had no suffix segments for the solver to read: `problem_scaling` now translates the Suffix's variable entries into `set_problem_scaling(x_scaling=…)` alongside the row ones, matched **by name** against the written model's columns (the writer chooses the order; a positional assumption is how a factor lands on the wrong variable). `_no_variable_scaling` and `check_no_variable_scaling` are deleted.

## Blast radius

Bit-identical for any solve that did not apply a change of variables: every new multiplication is by a literal `1.0`, and `natural_units_conj` still returns `None` when `df == 1` and no row or variable scaling is active, so the back-solve keeps its unconjugated fast path.

Under variable scaling, the sensitivity outputs change — they were unreachable through pyomo-pounce (refused) and wrong through the Rust/Python `Solver` (unrefused, since the guard lived only in the pyomo layer). Two behaviours are newly correct rather than newly different: `Solver.kkt_solve` and friends were silently returning scaled numbers, and `--sens-boundcheck` was projecting onto the wrong box.

`Solver.kkt_solve(rhs, scaled=True)` and `reduced_hessian(pins, scaled=True)` still mean "the factor as the IPM holds it", which now includes the substitution — documented on both.

One addition to an existing dict: `Solver.nlp_scaling` gains an `"x_scaling"` key. Existing keys are unchanged.

`docs/src/scaling.md` still carried the stage-1 text saying a non-unit `x_scaling` entry fails the solve with `Invalid_Option`. That has been stale since stage 2 shipped, not something this PR introduced; rewritten here along with `pyomo.md` and `sensitivity.md`.

## Tests

`crates/pounce-sensitivity/tests/variable_scaling_sensitivity.rs` (new, 9 cases) solves one problem twice — factors `[1e3, 1e-2, 1.0, 5.0, 1e-3]` against none, both arms under `user-scaling` so the factors are the *only* difference — and requires the converged iterate, `parametric_step`, `parametric_step_full`, `compute_reduced_hessian`, `kkt_solve`, `hessian_vec`, `row_normal`, `classify_activity` and the `SensSolve` builder's captures to agree. `pyomo-pounce/tests/test_user_scaling.py` gains a matching battery on the estimation fixture, asserted against the closed form as well as against the unscaled run, so both arms being wrong the same way cannot pass.

Both bite, checked by stubbing the plumbing out rather than assumed: **8 of the 9 Rust cases and 6 of the 8 pyomo cases fail** with `IpoptNlp::variable_scaling` returning `None`. The two that survive are honest: `reduced_hessian` alone is unaffected (it is a `y_c`-block quantity, and the substitution leaves the rows alone), and pyomo's `estimates_are_unmoved` tests the stage-2 solve rather than a stage-3 accessor. The wiring guards (`the_session_reports_the_factors_the_solve_ran_under`, `test_the_in_process_path_installs_the_variable_factors`) are there so a solve that quietly applied no scaling at all cannot pass the battery vacuously.

**`Σ` is deliberately not pinned across runs.** It is a barrier quantity, `Σ = z/s` with `s·z ~ μ`, and the two arms are different Newton trajectories that stop at different `μ` — 9.1e-10 against 2.5e-9 on the fixture. The assertion is on `Σ/μ`, which compares the geometry both runs found rather than where each happened to stop. The units are still fully pinned: a missed `d²` would land these entries a factor `1e6` / `1e-4` out, six orders past the tolerance.

Full workspace `cargo test`, 201 pyomo-pounce tests, and 694 `python/tests` pass; `cargo fmt --all --check` clean, and `cargo clippy` reports nothing new on the touched files. Two environment caveats, neither related to this change and both verified: `pounce-hsl` cannot link without `COINHSL_DIR`, and the two ASL/subprocess pyomo tests need the CLI binary, which `maturin build` does not bundle — both pass once it is built and installed.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`scaling.md`, `pyomo.md`, `sensitivity.md`; all three already in `SUMMARY.md`)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JhUqFa8pYnoj3nt6zXkAJ