### PR TITLE
perf(nl): dense-Hessian-row O(n^2) fix, gated shared-CSE Jacobian, and Pyomo v2 interop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,80 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a single dense Hessian row made `.nl` setup and every `eval_h` O(n²) (#552)
+
+`NlTnlp` recovers the Lagrangian Hessian by graph coloring: columns whose
+nonzero rows are pairwise disjoint share a color, and one directional
+product `H·s_c` per color recovers all of them at once. The seed and
+result buffers are `n_colors × n` dense arrays, which is fine while the
+coloring works.
+
+It does not work when the Hessian has one **dense row**. A variable that
+multiplies a sum over all the others — a total-cost variable, a shared
+design parameter, a scalar entering every constraint — puts a nonzero in
+*every* column at its own row, so no two columns may share a color and
+the greedy walk hands out one color per variable. `seeds` and
+`compressed` then become O(n²), on a model whose Hessian is otherwise
+perfectly sparse.
+
+A second, independent O(n²) sat behind it in `Tape::hessian_sparsity`,
+which kept a `BTreeSet` of dependent variables alive for *every* tape
+slot. A long additive chain — exactly what a dense row is built from —
+left one full-size set per partial sum and copied the whole running set
+at each union. (`split_top_sums` keeps top-level sums out of a single
+tape, so this only bit when the sum fed an enclosing operator.)
+
+**What is new.** Columns whose nonzero-row count exceeds
+`DENSE_COL_FACTOR` (16) times the average — never fewer than
+`DENSE_COL_MIN` (32) entries, at most `MAX_PEELED_COLS` (256) of them —
+are peeled out of the coloring and given a singleton color each. One
+product with seed `e_d` recovers the whole of column `d`, and because
+`H[d, j] == H[j, d]` that same pass also supplies every entry in row `d`.
+Row `d` therefore stops constraining anyone else's color and drops out of
+the conflict structure, leaving the rest to color on their real sparsity.
+`hessian_sparsity` additionally computes slot lifetimes up front and
+moves a dying operand's set into its consumer instead of copying it.
+
+Measured on `min Σ(xⱼ−1)² + x₀·Σxⱼ` discretized alongside a sparse
+constraint chain — one dense row, `nnz_h ≈ 2n`:
+
+| n = 8,010 | before | after |
+|---|---|---|
+| colors | 8,010 | 6 |
+| peak RSS through setup | 1,038 MB | 59 MB |
+| setup wall clock | 2.69 s | 0.18 s |
+
+| n = 4,010, 10 iterations | before | after |
+|---|---|---|
+| `LagrangianHessianEvaluations` | 2.069 s | 0.019 s |
+| `OverallAlgorithm` | 2.385 s | 0.284 s |
+
+Memory is now linear in `n` where it was quadratic, so what used to
+extrapolate to ~6.4 GB at n = 20,000 (and an OOM at flowsheet sizes) is a
+few tens of MB. Models without a dense row are untouched: a banded
+Hessian peels nothing and colors by its bandwidth exactly as before, and
+every one of the repository's 62 `.nl` fixtures returns a bit-identical
+objective and exit status.
+
+### Changed — the `.nl` reader's parse and setup paths allocate far less (#552)
+
+Reading a `.nl` put two heap allocations on every data line: one for the
+`String` the reader handed over, another for the `Vec<&str>` that
+`parse_var_coef` / `parse_bound_line` collected from it. `parse_expr`
+allocated a `String` per expression token — one per node of every
+expression tree in the file, ~620k of them for a 20k-variable model. All
+of these now borrow from the source buffer. Setup also replaced the
+global Hessian-pair `BTreeSet`, the per-row Jacobian column sets, and the
+per-summand color sets with `Vec` + `sort_unstable` + `dedup`, and
+dropped a `HashMap` that was built with one entry per Hessian nonzero,
+read once, and discarded — the decode tables are now built straight from
+the sorted pair list, which also makes the `eval_h` scatter walk `values`
+forward instead of in `HashMap` order.
+
+This is a constant-factor cleanup, not a complexity change: total setup
+on ordinary sparse models moves 1.00–1.07×. The dense-row case above is
+where the compounding shows up.
+
 ### Fixed — the filter's `theta_max` ceiling is now raised on demand instead of blocking a solve forever (#476, #546)
 
 The filter rejects any trial iterate whose constraint violation exceeds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,47 @@ Hessian peels nothing and colors by its bandwidth exactly as before, and
 every one of the repository's 62 `.nl` fixtures returns a bit-identical
 objective and exit status.
 
+### Changed — `eval_jac_g` takes the shared-CSE path when the shared bodies are big enough to pay for it (#476)
+
+`HybridTape` — the constraint tape that evaluates a CSE body once for the
+whole block instead of once per referencing summand — has driven `eval_g`
+since #476, while `eval_jac_g` stayed on the flat per-summand tapes whose
+CSE bodies are duplicated. The Jacobian now uses it too, but only above a
+measured threshold, because unlike `eval_g` it is not a free win.
+
+The asymmetry is structural. `eval_g` needs only values, so the prelude
+is swept once for the entire constraint block and the saving is the full
+op-count ratio. The Jacobian needs a gradient *per row*, so only the
+forward sweep can be shared — the reverse sweep still walks each
+summand's `prelude_reach` separately, and it pays a per-op cost the flat
+tape does not: a nested `SummandOp` dispatch and an indirected walk over
+a reach list rather than a straight loop over a contiguous `Vec<TapeOp>`.
+
+Measured on chain models with CSE redundancy 40, varying the shared body
+size (`eval_jac_g`, flat → hybrid, n ≈ 20,000):
+
+| flat/shared op ratio | 1.94 | 2.20 | 2.84 | 3.53 | 4.20 | 5.16 | 6.35 | 8.00 |
+|---|---|---|---|---|---|---|---|---|
+| speedup | 0.77× | 0.63× | 0.88× | 1.21× | 1.21× | 1.18× | 1.50× | 1.32× |
+
+The crossover sits near 3, so the gate is set at 4 to keep a margin: a
+model that does not clearly benefit stays on the flat path bit-for-bit.
+With the gate in place the same sweep shows 1.00–1.03× below it (i.e.
+unchanged) and 1.13–1.30× above it. `robot_a` (#476) measures 4.03×.
+
+`eval_h` is **not** changed and remains the larger prize — it is ~69% of
+AD time on these models against the Jacobian's ~19%. The dormant
+`HybridTape::hessian_summand` is not the tool for it: it re-walks
+`prelude_reach` once per seed variable, so it shares no prelude work at
+all, and it scatters through a `HashMap` lookup per emitted pair where
+the coloring path writes into a dense buffer. Amortizing prelude
+second-order work across summands needs a new directional routine, which
+is its own piece of work.
+
+`POUNCE_DBG_TAPE_STATS=1` now also prints the flat-versus-shared op counts
+for the constraint block, and `POUNCE_DBG_NO_HYBRID=1` forces the flat
+path, so the trade above is reproducible on any model.
+
 ### Changed — the `.nl` reader's parse and setup paths allocate far less (#552)
 
 Reading a `.nl` put two heap allocations on every data line: one for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,36 @@ Hessian peels nothing and colors by its bandwidth exactly as before, and
 every one of the repository's 62 `.nl` fixtures returns a bit-identical
 objective and exit status.
 
+### Fixed — Pyomo's modern solver interface could not drive POUNCE at all (#552)
+
+`SolverFactory('ipopt_v2', executable=<pounce>)` — the v2 interface that
+is becoming Pyomo's default `ipopt` — failed on every model. Two
+independent gaps, both places where POUNCE diverged from what the ASL
+does and every reader therefore expects:
+
+1. **Quoted option values.** The v2 interface builds each option as
+   `option_file_name="/tmp/…/x.opt"` and passes it as a single `argv`
+   entry. With no shell in between, the quotes arrive as literal
+   characters. Ipopt's ASL option parser strips them; POUNCE did not, so
+   it looked for a file whose name began with `"`, failed to load it, and
+   aborted the run. `key=value` now drops one matching pair of surrounding
+   `"` or `'` quotes. A quote on one side only is left as content.
+
+2. **The `.sol` `Options` block.** POUNCE wrote a count of `0`. AMPL and
+   Pyomo's *legacy* reader accept that, but no ASL solver emits it: the
+   v2 reader reads the first two option words unconditionally (to detect
+   the documented quirk where a second word of `3` means two extra words
+   follow the `z` block) and so asserts `n_opts >= 2`. A POUNCE `.sol`
+   could not be parsed through the modern interface at all. POUNCE now
+   writes the same `3 / 1 / 1 / 0` the ASL's own `writesol.c` and Ipopt
+   write.
+
+With both fixed, the same model solved through `SolverFactory('pounce')`
+and through `SolverFactory('ipopt_v2', executable=<pounce>)` returns
+identical objectives and identical primal values. This also makes it
+possible to benchmark POUNCE against Ipopt through *one* Pyomo interface,
+which #552's overhead comparison could not do.
+
 ### Changed — `eval_jac_g` takes the shared-CSE path when the shared bodies are big enough to pay for it (#476)
 
 `HybridTape` — the constraint tape that evaluates a CSE body once for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ tape, so this only bit when the sum fed an enclosing operator.)
 **What is new.** Columns whose nonzero-row count exceeds
 `DENSE_COL_FACTOR` (16) times the average — never fewer than
 `DENSE_COL_MIN` (32) entries, at most `MAX_PEELED_COLS` (256) of them —
-are peeled out of the coloring and given a singleton color each. One
+become *candidates* for peeling, and those that pay for themselves are
+peeled out of the coloring and given a singleton color each. One
 product with seed `e_d` recovers the whole of column `d`, and because
 `H[d, j] == H[j, d]` that same pass also supplies every entry in row `d`.
 Row `d` therefore stops constraining anyone else's color and drops out of
@@ -64,6 +65,29 @@ Hessian peels nothing and colors by its bandwidth exactly as before, and
 every one of the repository's 62 `.nl` fixtures returns a bit-identical
 objective and exit status.
 
+**Which candidates actually get peeled.** Each peeled column costs
+exactly one color, so peeling only pays when it removes more conflict
+than it adds — and simply truncating an over-long candidate list to
+`MAX_PEELED_COLS` does not bound the damage. The columns that miss the
+cut stay in the conflict structure, so the base color count is unchanged
+and the singleton colors are pure addition. On disjoint 50x50 blocks
+scattered through a 200,000-variable Hessian that colors to `50 + 256`
+where a plain walk needs 50 — a 6x regression in the very quantity
+peeling exists to reduce, and 8.5x on 34x34 blocks.
+
+The candidate set is therefore chosen by estimating the result: for
+peeling nothing and for the top `k` candidates by degree over a doubling
+ladder, `|peeled| + max surviving row degree` is a lower bound on the
+resulting color count (a row with `d` surviving entries makes those `d`
+columns pairwise conflict), computable in one O(nnz) pass. The best
+scoring option wins, ties going to fewer peels. On the block patterns
+above every `k > 0` now scores strictly worse than peeling nothing, so
+nothing is peeled and the coloring matches the plain walk exactly; the
+one-dense-row case still collapses n = 20,000 to 2 colors. Note the plain
+coloring cannot serve as a comparison baseline here — on that same
+one-dense-row case the plain walk is itself O(n²), which is the blowup
+peeling exists to avoid — so the choice has to be made from a bound.
+
 ### Fixed — Pyomo's modern solver interface could not drive POUNCE at all (#552)
 
 `SolverFactory('ipopt_v2', executable=<pounce>)` — the v2 interface that
@@ -84,9 +108,19 @@ does and every reader therefore expects:
    v2 reader reads the first two option words unconditionally (to detect
    the documented quirk where a second word of `3` means two extra words
    follow the `z` block) and so asserts `n_opts >= 2`. A POUNCE `.sol`
-   could not be parsed through the modern interface at all. POUNCE now
-   writes the same `3 / 1 / 1 / 0` the ASL's own `writesol.c` and Ipopt
-   write.
+   could not be parsed through the modern interface at all.
+
+   POUNCE now echoes the model's own option words, which is what Ipopt
+   and the ASL's `writesol.c` do — they are AMPL's flags, passed through
+   rather than interpreted, and they are per-model: `.nl` header line 0
+   is `g<count> <opt0> …`, so `bearing_400` (`g3 1 1 0`) gets
+   `3 / 1 / 1 / 0` while `arki0003` and `camshape_6400` (`g3 10 1 0`) get
+   `3 / 10 / 1 / 0`. Verified byte-for-byte against Ipopt 3.14.20 `-AMPL`
+   output on all three. Where there is no originating header — a problem
+   built through `NlProblem::from_expressions`, the WASM entry point, or
+   a header whose declared count does not match the words present — a
+   generic `3 / 1 / 1 / 0` goes out instead, which satisfies the v2
+   reader without claiming to be the model's own.
 
 With both fixed, the same model solved through `SolverFactory('pounce')`
 and through `SolverFactory('ipopt_v2', executable=<pounce>)` returns

--- a/crates/pounce-cli/src/cli.rs
+++ b/crates/pounce-cli/src/cli.rs
@@ -823,14 +823,38 @@ impl Args {
 /// Parse `key=value` (or `key:=value`, ipopt-compatible). Returns
 /// `None` if the token does not contain `=`. Whitespace around the
 /// separator is trimmed; empty key or value yields `None`.
+///
+/// A value wrapped in a matching pair of quotes has them stripped. No
+/// shell is involved when a driver `exec`s us directly, so quotes the
+/// driver added for its own quoting rules arrive as literal characters:
+/// Pyomo's v2 solver interface builds every option as
+/// `option_file_name="/tmp/…/x.opt"` (`_option_to_cmd` in
+/// `pyomo/contrib/solver/solvers/ipopt.py`) and passes it as one argv
+/// entry. Ipopt's ASL option parser strips those quotes; until we did
+/// too, POUNCE looked for a file whose name literally began with `"`,
+/// failed to load it, and aborted the run — so `SolverFactory('ipopt_v2',
+/// executable=<pounce>)`, the interface that is becoming Pyomo's default
+/// `ipopt`, could not drive POUNCE at all whenever any option was set.
 fn parse_kv(s: &str) -> Option<(String, String)> {
     let (k, v) = s.split_once('=')?;
     let k = k.trim().trim_end_matches(':');
-    let v = v.trim();
+    let v = unquote(v.trim());
     if k.is_empty() || v.is_empty() {
         return None;
     }
     Some((k.to_string(), v.to_string()))
+}
+
+/// Strip one matching pair of surrounding `"` or `'` quotes. A lone
+/// quote on one side is left alone — it is more likely part of the value
+/// than a quoting artifact.
+fn unquote(v: &str) -> &str {
+    let b = v.as_bytes();
+    if b.len() >= 2 && (b[0] == b'"' || b[0] == b'\'') && b[b.len() - 1] == b[0] {
+        &v[1..v.len() - 1]
+    } else {
+        v
+    }
 }
 
 /// Parse the AMPL `pounce_options` environment variable into
@@ -1333,6 +1357,30 @@ mod tests {
         assert_eq!(parse_kv("plain_path.nl"), None);
         assert_eq!(parse_kv("=value"), None);
         assert_eq!(parse_kv("key="), None);
+    }
+
+    /// Pyomo's v2 solver interface emits every option as `key="value"`
+    /// and `exec`s the solver directly, so with no shell in between the
+    /// quotes reach us as literal characters. Ipopt's ASL parser strips
+    /// them; so must we, or `option_file_name` names a file that cannot
+    /// exist and the run aborts.
+    #[test]
+    fn parse_kv_strips_the_quotes_a_driver_added() {
+        assert_eq!(
+            parse_kv(r#"option_file_name="/tmp/pyomo/x.opt""#),
+            Some(("option_file_name".into(), "/tmp/pyomo/x.opt".into()))
+        );
+        assert_eq!(
+            parse_kv("option_file_name='/tmp/has space/x.opt'"),
+            Some(("option_file_name".into(), "/tmp/has space/x.opt".into()))
+        );
+        // A quote on one side only is content, not quoting.
+        assert_eq!(
+            parse_kv(r#"msg="unbalanced"#),
+            Some(("msg".into(), r#""unbalanced"#.into()))
+        );
+        // An empty quoted value is still empty.
+        assert_eq!(parse_kv(r#"key="""#), None);
     }
 
     #[test]

--- a/crates/pounce-cli/src/dispatch.rs
+++ b/crates/pounce-cli/src/dispatch.rs
@@ -1131,6 +1131,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1312,6 +1313,7 @@ mod tests {
             lambda0: vec![0.0; m],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         }
@@ -1367,6 +1369,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         }
@@ -1532,6 +1535,7 @@ mod tests {
             lambda0: vec![0.0; m],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         }

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -527,6 +527,10 @@ pub fn main() -> ExitCode {
     // read off `NlProblem` before `NlTnlp` consumes it.
     let mut nl_suffixes: Option<nl_reader::NlSuffixes> = None;
     let mut nl_dims: Option<(usize, usize)> = None;
+    // The model's own AMPL option words, echoed back in the `.sol`
+    // `Options` block the way an ASL solver does. Empty for problems
+    // that did not come from a `.nl` header.
+    let mut nl_ampl_options: Vec<i64> = Vec::new();
     // Problem class captured from the *first* `.nl` parse below, so the
     // LP/QP dispatch never has to re-read the file just to classify it
     // (re-parsing doubled parse time / peak memory on large models — code
@@ -557,6 +561,7 @@ pub fn main() -> ExitCode {
                 Ok(prob) => {
                     nl_suffixes = Some(prob.suffixes.clone());
                     nl_dims = Some((prob.n, prob.m));
+                    nl_ampl_options = prob.ampl_options.clone();
                     let elapsed = t0.elapsed().as_secs_f64();
                     // Render the source constraint equations and hand them to
                     // the debugger so `print equation <name|row>` can show a
@@ -1987,7 +1992,7 @@ pub fn main() -> ExitCode {
             solve_result_num: srn,
             suffixes: &sol_suffixes,
         };
-        match nl_writer::write_sol_file(sol_path, &payload) {
+        match nl_writer::write_sol_file_with_options(sol_path, &payload, &nl_ampl_options) {
             Ok(_) => eprintln!("pounce: wrote {}", sol_path.display()),
             Err(e) => eprintln!("pounce: failed to write {}: {e}", sol_path.display()),
         }
@@ -2700,7 +2705,7 @@ fn run_convex_qp(
         // Log a `.sol` write failure but do not early-return a distinct exit
         // code: the NLP path (main.rs:1091-1093) only logs, and under `-AMPL`
         // the final exit must still follow the solve-outcome contract.
-        if let Err(e) = nl_writer::write_sol_file(path, &payload) {
+        if let Err(e) = nl_writer::write_sol_file_with_options(path, &payload, &prob.ampl_options) {
             eprintln!("pounce: failed to write {}: {e}", path.display());
         }
     }

--- a/crates/pounce-cli/src/qp_extract.rs
+++ b/crates/pounce-cli/src/qp_extract.rs
@@ -685,6 +685,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -750,6 +751,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -805,6 +807,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -866,6 +869,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -913,6 +917,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -968,6 +973,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1021,6 +1027,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1060,6 +1067,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1093,6 +1101,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1129,6 +1138,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1169,6 +1179,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1216,6 +1227,7 @@ mod tests {
             lambda0: vec![0.0],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1265,6 +1277,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };
@@ -1302,6 +1315,7 @@ mod tests {
             lambda0: vec![],
             suffixes: Default::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names: Vec::new(),
             con_names: Vec::new(),
         };

--- a/crates/pounce-nl/examples/adbench.rs
+++ b/crates/pounce-nl/examples/adbench.rs
@@ -1,0 +1,80 @@
+//! Scratch harness: time the three TNLP evaluators in isolation.
+//!
+//! `cargo run --release -p pounce-nl --example adbench -- model.nl [reps]`
+//!
+//! Not a regression test — this exists to size AD work against solver work
+//! without the solver's own dynamics (restoration, line-search retries)
+//! confounding the measurement.
+
+use pounce_nl::nl_reader::{self, NlTnlp};
+use pounce_nlp::tnlp::{SparsityRequest, TNLP};
+use std::time::Instant;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = std::path::PathBuf::from(&args[1]);
+    let reps: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(50);
+
+    let t0 = Instant::now();
+    let prob = nl_reader::read_nl_file(&path).expect("read");
+    let (n, m) = (prob.n, prob.m);
+    let x0 = prob.x0.clone();
+    let mut t = NlTnlp::new(prob);
+    let info = t.get_nlp_info().expect("info");
+    let setup = t0.elapsed().as_secs_f64();
+
+    let nnz_j = info.nnz_jac_g as usize;
+    let nnz_h = info.nnz_h_lag as usize;
+    println!("n={n} m={m} nnz_jac={nnz_j} nnz_h={nnz_h} setup={setup:.3}s");
+
+    // Perturb off the (often degenerate) start so every branch is live.
+    let x: Vec<f64> = x0
+        .iter()
+        .enumerate()
+        .map(|(i, v)| v + 0.01 * ((i % 7) as f64) + 0.001)
+        .collect();
+    let lambda: Vec<f64> = (0..m).map(|i| 0.5 + 0.01 * ((i % 5) as f64)).collect();
+
+    let mut g = vec![0.0; m];
+    let mut jac = vec![0.0; nnz_j];
+    let mut hess = vec![0.0; nnz_h];
+    let mut grad = vec![0.0; n];
+
+    macro_rules! bench {
+        ($name:literal, $body:expr) => {{
+            $body; // warm
+            let t = Instant::now();
+            for _ in 0..reps {
+                $body;
+            }
+            let per = t.elapsed().as_secs_f64() / reps as f64;
+            println!("  {:28} {:9.3} ms/call", $name, per * 1000.0);
+            per
+        }};
+    }
+
+    let t_g = bench!("eval_g", {
+        t.eval_g(&x, true, &mut g);
+    });
+    let t_gf = bench!("eval_grad_f", {
+        t.eval_grad_f(&x, true, &mut grad);
+    });
+    let t_j = bench!("eval_jac_g (values)", {
+        t.eval_jac_g(Some(&x), true, SparsityRequest::Values { values: &mut jac });
+    });
+    let t_h = bench!("eval_h (values)", {
+        t.eval_h(
+            Some(&x),
+            true,
+            1.0,
+            Some(&lambda),
+            true,
+            SparsityRequest::Values { values: &mut hess },
+        );
+    });
+    println!(
+        "  {:28} {:9.3} ms/call",
+        "TOTAL",
+        (t_g + t_gf + t_j + t_h) * 1000.0
+    );
+}

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -1901,7 +1901,42 @@ struct ConHybrid {
     prelude_vals: Vec<f64>,
     /// Per-summand local forward values, sized to `tape.max_summand_ops()`.
     local_vals: Vec<f64>,
+    /// Reverse-mode adjoint arenas for `eval_jac_g`, sized like the two
+    /// value arenas above. `gradient_summand` zeroes only the slots a
+    /// summand actually reaches, so these are allocated once and reused.
+    local_adj: Vec<f64>,
+    prelude_adj: Vec<f64>,
+    /// Whether `eval_jac_g` should take the shared-CSE path too, or stay
+    /// on the flat per-summand tapes. See [`HYBRID_JAC_MIN_OP_RATIO`] —
+    /// unlike `eval_g`, the hybrid Jacobian is not a free win.
+    use_for_jac: bool,
 }
+
+/// Flat-to-shared op-count ratio above which `eval_jac_g` switches to the
+/// shared-CSE prelude.
+///
+/// `eval_g` takes the hybrid path unconditionally because it only needs
+/// *values*: the prelude is swept once for the whole constraint block and
+/// the saving is the full op-count ratio. The Jacobian is different. Each
+/// row needs its own gradient, so only the forward sweep can be shared —
+/// the reverse sweep still walks each summand's `prelude_reach`
+/// separately, and it pays a per-op cost the flat tape does not: a nested
+/// `SummandOp` dispatch and an indirected walk over a reach list instead
+/// of a straight loop over a contiguous `Vec<TapeOp>`.
+///
+/// So the hybrid Jacobian wins only when the shared bodies are large
+/// enough for the halved forward sweep to outweigh that overhead.
+/// Measured on chain models at CSE redundancy 40, varying the body size
+/// (`eval_jac_g`, flat → hybrid):
+///
+/// | op ratio | 1.94 | 2.20 | 2.84 | 3.53 | 4.20 | 5.16 | 6.35 | 8.00 |
+/// |---|---|---|---|---|---|---|---|---|
+/// | speedup | 0.77× | 0.63× | 0.88× | 1.21× | 1.21× | 1.18× | 1.50× | 1.32× |
+///
+/// The crossover sits near 3; this gate is set at 4 to keep a margin, so
+/// a model that does not clearly benefit stays on the flat path. For
+/// reference `robot_a` (#476) measures 4.03×.
+const HYBRID_JAC_MIN_OP_RATIO: f64 = 4.0;
 
 // `Clone` supports the batched-solve path (pounce#126): one parsed
 // model is cloned per batch instance (tapes are flat `Vec`s of ops, so
@@ -2642,13 +2677,29 @@ impl NlTnlp {
         // or more summands — otherwise the prelude comes out empty and the
         // hybrid tape is the flat tape plus an indirection. `hybrid_supported`
         // gates the opcodes `build_multi` would panic on.
-        let con_hybrid = if hybrid_supported(&con_roots) {
+        // `POUNCE_DBG_NO_HYBRID=1` forces the flat per-summand tapes for the
+        // whole constraint block. Diagnostic only: it is how the
+        // flat-versus-shared trade in `HYBRID_JAC_MIN_OP_RATIO` is measured
+        // on a real model, and how a suspected hybrid-path bug is bisected
+        // against a reference that computes the same derivatives a
+        // different way.
+        let con_hybrid = if std::env::var("POUNCE_DBG_NO_HYBRID").is_ok() {
+            None
+        } else if hybrid_supported(&con_roots) {
             let tape = HybridTape::build_multi(&con_roots);
-            (tape.n_prelude_ops() > 0).then(|| ConHybrid {
-                prelude_vals: vec![0.0; tape.n_prelude_ops()],
-                local_vals: vec![0.0; tape.max_summand_ops()],
-                row_start,
-                tape,
+            (tape.n_prelude_ops() > 0).then(|| {
+                let flat_ops: usize = con_tapes.iter().flatten().map(|t| t.ops.len()).sum();
+                let shared_ops = tape.n_prelude_ops() + tape.total_local_ops();
+                ConHybrid {
+                    prelude_vals: vec![0.0; tape.n_prelude_ops()],
+                    local_vals: vec![0.0; tape.max_summand_ops()],
+                    local_adj: vec![0.0; tape.max_summand_ops()],
+                    prelude_adj: vec![0.0; tape.n_prelude_ops()],
+                    use_for_jac: flat_ops as f64
+                        >= HYBRID_JAC_MIN_OP_RATIO * shared_ops.max(1) as f64,
+                    row_start,
+                    tape,
+                }
             })
         } else {
             None
@@ -2798,6 +2849,24 @@ impl NlTnlp {
                  n_colors={n_colors} avg_decode_per_color={avg_decode:.1} nnz_h={nnz_h}",
                 sum_ops as f64 / t as f64,
             );
+            // Flat vs shared-CSE op counts for the constraint block. The
+            // ratio is how much duplicated CSE work `eval_g`'s hybrid path
+            // avoids, and the ceiling on what routing the Jacobian /
+            // Hessian through the same prelude could save.
+            match &con_hybrid {
+                Some(h) => {
+                    let flat: usize = con_tapes.iter().flatten().map(|t| t.ops.len()).sum();
+                    let prelude = h.tape.n_prelude_ops();
+                    let local = h.tape.total_local_ops();
+                    eprintln!(
+                        "[hybrid stats] con flat_ops={flat} prelude_ops={prelude} \
+                         local_ops={local} shared_total={} flat/shared={:.2}x",
+                        prelude + local,
+                        flat as f64 / (prelude + local).max(1) as f64,
+                    );
+                }
+                None => eprintln!("[hybrid stats] con hybrid not built (no shared CSE bodies)"),
+            }
         }
 
         let compressed: Vec<Vec<f64>> = vec![vec![0.0; prob.n]; n_colors];
@@ -3271,6 +3340,7 @@ impl TNLP for NlTnlp {
                 row_start,
                 prelude_vals,
                 local_vals,
+                ..
             } = h;
             tape.forward_prelude(x, prelude_vals);
             for i in 0..m {
@@ -3316,31 +3386,77 @@ impl TNLP for NlTnlp {
             }
             SparsityRequest::Values { values } => {
                 let n = self.prob.n;
-                let xs = x.unwrap_or(&self.prob.x0);
                 if self.scratch_row_grad.len() < n {
                     self.scratch_row_grad.resize(n, 0.0);
                 }
+                let Self {
+                    prob,
+                    con_tapes,
+                    con_hybrid,
+                    jac_cols,
+                    scratch_row_grad,
+                    vals_scratch,
+                    adj_scratch,
+                    ..
+                } = self;
+                let xs = x.unwrap_or(&prob.x0);
                 let mut k = 0;
-                for i in 0..self.prob.m {
-                    for &j in &self.jac_cols[i] {
-                        self.scratch_row_grad[j] = 0.0;
+                // Shared-CSE path: the forward sweep over the CSE bodies runs
+                // once for the whole constraint block instead of once per
+                // referencing summand. The reverse sweep cannot be shared —
+                // each row needs its own gradient — so a summand still walks
+                // its own `prelude_reach` backwards.
+                if let Some(h) = con_hybrid.as_mut().filter(|h| h.use_for_jac) {
+                    let ConHybrid {
+                        tape,
+                        row_start,
+                        prelude_vals,
+                        local_vals,
+                        local_adj,
+                        prelude_adj,
+                        ..
+                    } = h;
+                    tape.forward_prelude(xs, prelude_vals);
+                    for i in 0..prob.m {
+                        for &j in &jac_cols[i] {
+                            scratch_row_grad[j] = 0.0;
+                        }
+                        for s in &tape.summands[row_start[i]..row_start[i + 1]] {
+                            tape.forward_summand(s, xs, prelude_vals, local_vals);
+                            tape.gradient_summand(
+                                s,
+                                prelude_vals,
+                                local_vals,
+                                1.0,
+                                scratch_row_grad,
+                                local_adj,
+                                prelude_adj,
+                            );
+                        }
+                        for &(v, c) in &prob.con_linear[i] {
+                            scratch_row_grad[v] += c;
+                        }
+                        for &j in &jac_cols[i] {
+                            values[k] = scratch_row_grad[j];
+                            k += 1;
+                        }
                     }
-                    for t in &self.con_tapes[i] {
+                    return true;
+                }
+                for i in 0..prob.m {
+                    for &j in &jac_cols[i] {
+                        scratch_row_grad[j] = 0.0;
+                    }
+                    for t in &con_tapes[i] {
                         // Allocation-free reverse-AD per summand tape (M18):
                         // reuse the shared forward/adjoint scratch arenas.
-                        t.gradient_seed_into(
-                            xs,
-                            1.0,
-                            &mut self.scratch_row_grad,
-                            &mut self.vals_scratch,
-                            &mut self.adj_scratch,
-                        );
+                        t.gradient_seed_into(xs, 1.0, scratch_row_grad, vals_scratch, adj_scratch);
                     }
-                    for &(v, c) in &self.prob.con_linear[i] {
-                        self.scratch_row_grad[v] += c;
+                    for &(v, c) in &prob.con_linear[i] {
+                        scratch_row_grad[v] += c;
                     }
-                    for &j in &self.jac_cols[i] {
-                        values[k] = self.scratch_row_grad[j];
+                    for &j in &jac_cols[i] {
+                        values[k] = scratch_row_grad[j];
                         k += 1;
                     }
                 }
@@ -5099,6 +5215,170 @@ G0 3
 
     fn shared_cse_nl(body2: &str) -> String {
         SHARED_CSE.replace("{BODY2}", body2)
+    }
+
+    /// `eval_jac_g`'s shared-CSE path must return exactly what the flat
+    /// per-summand tapes return — it is a different traversal of the same
+    /// DAG, not a different derivative. Forced on here regardless of
+    /// `HYBRID_JAC_MIN_OP_RATIO` so the path is covered independently of
+    /// the size heuristic that decides when to use it.
+    #[test]
+    fn shared_cse_jacobian_matches_flat_tape_bit_for_bit() {
+        let nl = shared_cse_nl("o2\nv3\nv2");
+        let p = parse_nl_text(&nl).expect("parse shared-CSE model");
+
+        let mut hybrid = NlTnlp::new(p.clone());
+        let info = hybrid.get_nlp_info().unwrap();
+        let nnz = info.nnz_jac_g as usize;
+        hybrid
+            .con_hybrid
+            .as_mut()
+            .expect("CSE shared by 3 constraints must build the hybrid tape")
+            .use_for_jac = true;
+
+        let mut flat = NlTnlp::new(p);
+        flat.get_nlp_info().unwrap();
+        flat.con_hybrid = None;
+
+        for x in [[1.0, 1.0, 1.0], [-2.0, 0.5, 3.0], [0.0, -1.5, -0.25]] {
+            let mut jh = vec![0.0_f64; nnz];
+            let mut jf = vec![0.0_f64; nnz];
+            assert!(hybrid.eval_jac_g(Some(&x), true, SparsityRequest::Values { values: &mut jh }));
+            assert!(flat.eval_jac_g(Some(&x), true, SparsityRequest::Values { values: &mut jf }));
+            assert_eq!(
+                jh, jf,
+                "hybrid Jacobian differs from the flat tape at {x:?}"
+            );
+
+            // V3 = 2 x0 + 3 x1; rows are V3^2, V3^3 + x2, V3 * x2.
+            let s = 2.0 * x[0] + 3.0 * x[1];
+            let want = [
+                4.0 * s,
+                6.0 * s,
+                6.0 * s * s,
+                9.0 * s * s,
+                1.0,
+                2.0 * x[2],
+                3.0 * x[2],
+                s,
+            ];
+            assert_eq!(nnz, want.len());
+            for k in 0..nnz {
+                assert!(
+                    (jh[k] - want[k]).abs() < 1e-9,
+                    "entry {k} at {x:?}: got {}, want {}",
+                    jh[k],
+                    want[k]
+                );
+            }
+        }
+    }
+
+    /// `.nl` text for `m` constraints `S * x_{i+2} >= 0`, all sharing one
+    /// CSE `S = exp^depth(0.01 * (x0 + x1))`. A deep shared body over few
+    /// local ops per row is the regime the Jacobian gate is meant to
+    /// catch: no repository fixture has a CSE shared across constraints
+    /// at all, so without this the gate-on path has no natural coverage.
+    fn deep_shared_cse_nl(m: usize, depth: usize) -> String {
+        let n = m + 2;
+        let nzc = 3 * m;
+        let mut s = String::new();
+        s.push_str("g3 1 1 0\n");
+        s.push_str(&format!(" {n} {m} 1 0 0 0\n"));
+        s.push_str(&format!(" {m} 0\n 0 0\n"));
+        s.push_str(&format!(" {n} 0 0\n"));
+        s.push_str(" 0 0 0 1\n 0 0 0 0 0\n");
+        s.push_str(&format!(" {nzc} {n}\n"));
+        s.push_str(" 0 0\n 0 1 0 0 0\n");
+        // The shared body.
+        s.push_str(&format!("V{n} 0 0\n"));
+        for _ in 0..depth {
+            s.push_str("o44\n");
+        }
+        s.push_str("o2\nn0.01\no0\nv0\nv1\n");
+        // Rows: S * x_{i+2}.
+        for i in 0..m {
+            s.push_str(&format!("C{i}\no2\nv{n}\nv{}\n", i + 2));
+        }
+        s.push_str("O0 0\nn0\n");
+        s.push_str(&format!("x{n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("{j} {}\n", 0.3 + 0.05 * j as f64));
+        }
+        s.push_str("r\n");
+        for _ in 0..m {
+            s.push_str("2 0\n");
+        }
+        s.push_str("b\n");
+        for _ in 0..n {
+            s.push_str("3\n");
+        }
+        // Column counts: cols 0 and 1 appear in every row, col i+2 in one.
+        s.push_str(&format!("k{}\n", n - 1));
+        let mut acc = 0;
+        for j in 0..n - 1 {
+            acc += if j < 2 { m } else { 1 };
+            s.push_str(&format!("{acc}\n"));
+        }
+        for i in 0..m {
+            s.push_str(&format!("J{i} 3\n0 0.0\n1 0.0\n{} 0.0\n", i + 2));
+        }
+        s.push_str(&format!("G0 {n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("{j} 0.0\n"));
+        }
+        s
+    }
+
+    /// With a deep shared body the gate turns itself on, and the path it
+    /// turns on must still agree with the flat tapes exactly.
+    #[test]
+    fn a_deep_shared_body_turns_the_jacobian_gate_on_and_still_agrees() {
+        let p = parse_nl_text(&deep_shared_cse_nl(16, 40)).expect("parse");
+
+        let mut hybrid = NlTnlp::new(p.clone());
+        let info = hybrid.get_nlp_info().unwrap();
+        let nnz = info.nnz_jac_g as usize;
+        assert!(
+            hybrid
+                .con_hybrid
+                .as_ref()
+                .expect("shared CSE must build the hybrid tape")
+                .use_for_jac,
+            "a 40-deep body shared by 16 rows is well past the op-ratio gate"
+        );
+
+        let mut flat = NlTnlp::new(p);
+        flat.get_nlp_info().unwrap();
+        flat.con_hybrid = None;
+
+        for scale in [1.0_f64, -0.7, 2.5] {
+            let x: Vec<f64> = (0..info.n as usize)
+                .map(|j| scale * (0.2 + 0.03 * j as f64))
+                .collect();
+            let mut jh = vec![0.0_f64; nnz];
+            let mut jf = vec![0.0_f64; nnz];
+            assert!(hybrid.eval_jac_g(Some(&x), true, SparsityRequest::Values { values: &mut jh }));
+            assert!(flat.eval_jac_g(Some(&x), true, SparsityRequest::Values { values: &mut jf }));
+            assert_eq!(jh, jf, "gate-on Jacobian differs from the flat tape");
+            assert!(jh.iter().any(|v| *v != 0.0), "all-zero Jacobian is no test");
+        }
+    }
+
+    /// The Jacobian gate is off for a model whose shared bodies are small,
+    /// because there the hybrid traversal's per-op overhead outweighs the
+    /// halved forward sweep. `eval_g` still takes the hybrid path — that
+    /// one is a win at any ratio.
+    #[test]
+    fn a_small_shared_body_leaves_the_jacobian_on_the_flat_path() {
+        let p = parse_nl_text(&shared_cse_nl("o2\nv3\nv2")).expect("parse");
+        let mut t = NlTnlp::new(p);
+        t.get_nlp_info().unwrap();
+        let h = t.con_hybrid.as_ref().expect("hybrid built for eval_g");
+        assert!(
+            !h.use_for_jac,
+            "a 3-row model with a 2-term CSE is far below the op-ratio gate"
+        );
     }
 
     /// A CSE referenced from several constraints is evaluated once per

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -226,6 +226,12 @@ pub struct NlProblem {
     /// <https://ampl.com/REFS/hooking2.pdf> §6 and the upstream `.nl`
     /// reader in `ref/Ipopt/src/Apps/AmplSolver/AmplTNLP.cpp`.
     pub suffixes: NlSuffixes,
+    /// The model's own AMPL option words, taken verbatim from `.nl`
+    /// header line 0 (`g<count> <opt0> <opt1> ...`). A solver echoes
+    /// these back in the `.sol` `Options` block rather than interpreting
+    /// them — see [`crate::sol_writer::format_sol_with_options`]. Empty
+    /// for problems not built from a `.nl` file.
+    pub ampl_options: Vec<i64>,
     /// AMPL imported (external) functions declared via top-level `F` segments.
     /// Empty unless the `.nl` file calls compiled-C user functions (typically
     /// emitted by IDAES property packages — see issue #49).
@@ -375,6 +381,7 @@ impl NlProblem {
             lambda0: vec![0.0; m],
             suffixes: NlSuffixes::default(),
             imported_funcs: Vec::new(),
+            ampl_options: Vec::new(),
             var_names,
             con_names,
         })
@@ -852,6 +859,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
         x0,
         lambda0,
         suffixes,
+        ampl_options: p.ampl_options.clone(),
         imported_funcs,
         // `.nl` text carries no names; `read_nl_file` fills these from the
         // sibling `.col`/`.row` files when present.
@@ -1076,6 +1084,7 @@ struct Parser<'a> {
     num_obj: usize,
     /// Number of AMPL imported (external) functions declared in the header.
     n_funcs: usize,
+    ampl_options: Vec<i64>,
     /// Common subexpressions (`V` segments). Index in this vec is the
     /// CSE-local index, i.e. the global `.nl` index minus `n`.
     cses: Vec<Arc<Expr>>,
@@ -1091,6 +1100,7 @@ impl<'a> Parser<'a> {
             m: 0,
             num_obj: 0,
             n_funcs: 0,
+            ampl_options: Vec::new(),
             cses: Vec::new(),
         }
     }
@@ -1137,6 +1147,17 @@ impl<'a> Parser<'a> {
             return Err(format!(
                 "only ASCII (g-) .nl files supported; got header '{trimmed}'"
             ));
+        }
+        // Line 0 is `g<count> <opt0> <opt1> ...`: the digits glued to the
+        // `g` say how many AMPL option words follow on the same line.
+        // A solver echoes them back in the `.sol` `Options` block, so
+        // keep them verbatim. Malformed or truncated option lists are not
+        // fatal — the writer falls back to a generic block.
+        let mut words = trimmed.split_whitespace();
+        let n_opts: usize = words.next().and_then(|w| w[1..].parse().ok()).unwrap_or(0);
+        let opts: Vec<i64> = words.filter_map(|w| w.parse().ok()).collect();
+        if opts.len() >= n_opts {
+            self.ampl_options = opts[..n_opts].to_vec();
         }
 
         // Header line 2: n_vars n_cons n_objs ranges eqns
@@ -2475,10 +2496,103 @@ fn split_top_sums(expr: &Expr) -> Vec<Expr> {
 /// a very sparse average from declaring a 10-entry column "dense".
 const DENSE_COL_FACTOR: usize = 16;
 const DENSE_COL_MIN: usize = 32;
-/// Hard cap on how many columns get peeled. Each peeled column costs
-/// exactly one color, so this bounds the damage if the heuristic
-/// misfires on an unusual pattern.
+/// Hard cap on how many columns get peeled, applied on top of the
+/// pay-for-itself rule in [`select_peeled_cols`].
 const MAX_PEELED_COLS: usize = 256;
+
+/// Lower bound on the color count that results from peeling `peeled`.
+///
+/// Peeling costs one color per peeled column. On what remains, any row
+/// with `d` surviving entries makes those `d` columns pairwise
+/// conflicting, so the greedy walk needs at least `d` colors. Hence
+/// `|peeled| + max surviving row degree` is a lower bound on the total,
+/// computable in one O(nnz) pass — no coloring required.
+///
+/// The bound is what makes the choice decidable at all: the plain
+/// coloring cannot be run as a comparison baseline, because on the
+/// one-dense-row case the plain walk is itself O(n^2) — precisely the
+/// blowup peeling exists to avoid.
+fn peel_color_bound(n: usize, lower_pairs: &[(usize, usize)], peeled: &[bool]) -> usize {
+    let mut deg = vec![0usize; n];
+    for &(i, j) in lower_pairs {
+        if peeled[i] || peeled[j] {
+            continue;
+        }
+        deg[j] += 1;
+        if i != j {
+            deg[i] += 1;
+        }
+    }
+    let n_peeled = peeled.iter().filter(|&&p| p).count();
+    n_peeled + deg.iter().copied().max().unwrap_or(0)
+}
+
+/// Choose which of the candidate dense columns to actually peel.
+///
+/// Evaluates [`peel_color_bound`] for peeling nothing and for peeling the
+/// top `k` candidates by degree, over a doubling ladder of `k` up to
+/// [`MAX_PEELED_COLS`], and keeps the best. Ties go to the smaller `k`,
+/// so peeling has to earn its colors.
+///
+/// **Why not just truncate an over-long candidate list.** Cutting the
+/// candidates down to `MAX_PEELED_COLS` is not a damage bound: the
+/// columns that miss the cut stay in the conflict structure, so the base
+/// color count is untouched and the singleton colors are pure addition.
+/// On disjoint 50x50 blocks scattered through a 200k-variable Hessian
+/// that colors to `50 + 256` where a plain walk needs 50 — a 6x
+/// regression in exactly the quantity peeling exists to reduce. The
+/// bound above sees it: peeling `k` of several thousand equal-degree
+/// columns leaves the surviving max degree unchanged, so every `k > 0`
+/// scores strictly worse than peeling nothing.
+///
+/// **Why not a simple degree rule.** "Peel only columns denser than some
+/// fraction of `n`" would refuse three rows of degree 10,000 in a
+/// 200,000-variable model, where peeling three columns takes the
+/// coloring from >= 10,000 down to a handful. The win depends on what
+/// peeling leaves behind, not on the peeled column's degree alone.
+fn select_peeled_cols(
+    n: usize,
+    lower_pairs: &[(usize, usize)],
+    deg: &[usize],
+    mut candidates: Vec<usize>,
+) -> Vec<usize> {
+    if candidates.is_empty() {
+        return candidates;
+    }
+    // Worst offenders first; they remove the most conflict per color spent.
+    candidates.sort_unstable_by(|&a, &b| deg[b].cmp(&deg[a]).then(a.cmp(&b)));
+    candidates.truncate(MAX_PEELED_COLS);
+
+    let mut mask = vec![false; n];
+    let mut best_k = 0usize;
+    // Peeling nothing: the bound is just the largest row degree.
+    let mut best_bound = peel_color_bound(n, lower_pairs, &mask);
+
+    // Doubling ladder 1, 2, 4, ... capped at the candidate count, so the
+    // cost is O(nnz log MAX_PEELED_COLS) rather than O(nnz) per k. The
+    // mask only ever gains entries, so each step just marks the new slice.
+    let mut marked = 0usize;
+    let mut k = 1usize;
+    loop {
+        let k_now = k.min(candidates.len());
+        for &j in &candidates[marked..k_now] {
+            mask[j] = true;
+        }
+        marked = k_now;
+        let bound = peel_color_bound(n, lower_pairs, &mask);
+        if bound < best_bound {
+            best_bound = bound;
+            best_k = k_now;
+        }
+        if k_now == candidates.len() {
+            break;
+        }
+        k *= 2;
+    }
+
+    candidates.truncate(best_k);
+    candidates
+}
 
 /// Greedy distance-1 coloring of the Hessian's column-intersection
 /// graph, with **dense columns peeled out**.
@@ -2531,12 +2645,8 @@ fn greedy_hessian_coloring(
     let total: usize = deg.iter().sum();
     let threshold = DENSE_COL_MIN.max(DENSE_COL_FACTOR.saturating_mul(total / n));
     let mut peeled = vec![false; n];
-    let mut dense: Vec<usize> = (0..n).filter(|&j| deg[j] > threshold).collect();
-    if dense.len() > MAX_PEELED_COLS {
-        // Keep the worst offenders: they remove the most conflicts.
-        dense.sort_unstable_by(|&a, &b| deg[b].cmp(&deg[a]).then(a.cmp(&b)));
-        dense.truncate(MAX_PEELED_COLS);
-    }
+    let candidates: Vec<usize> = (0..n).filter(|&j| deg[j] > threshold).collect();
+    let dense = select_peeled_cols(n, lower_pairs, &deg, candidates);
     for &j in &dense {
         peeled[j] = true;
     }
@@ -3839,6 +3949,7 @@ b
             lambda0: vec![],
             suffixes: NlSuffixes::default(),
             imported_funcs: vec![],
+            ampl_options: vec![],
             var_names: vec![],
             con_names: vec![],
         };
@@ -3893,6 +4004,7 @@ b
             lambda0: vec![0.0],
             suffixes: NlSuffixes::default(),
             imported_funcs: vec![],
+            ampl_options: vec![],
             var_names: vec![],
             con_names: vec![],
         };
@@ -4389,6 +4501,125 @@ J0 2
             "a tridiagonal Hessian needs a handful of colors, got {n_colors}"
         );
         assert!(var_color.iter().all(|&c| c != u32::MAX));
+    }
+
+    /// Build a Hessian of `blocks` disjoint dense `size`x`size` blocks
+    /// scattered through an otherwise diagonal `n`-variable problem.
+    /// A plain coloring needs exactly `size` colors no matter how many
+    /// blocks there are, because the blocks share no rows.
+    fn disjoint_blocks(n: usize, blocks: usize, size: usize) -> Vec<(usize, usize)> {
+        let mut pairs: Vec<(usize, usize)> = (0..n).map(|j| (j, j)).collect();
+        let stride = n / blocks;
+        for b in 0..blocks {
+            let base = b * stride;
+            for i in 0..size {
+                for j in 0..=i {
+                    if i != j {
+                        pairs.push((base + i, base + j));
+                    }
+                }
+            }
+        }
+        pairs
+    }
+
+    /// Many medium-degree columns must not be peeled.
+    ///
+    /// Regression: selecting candidates by "degree > 16x average" and then
+    /// *truncating* the list to `MAX_PEELED_COLS` is not a damage bound.
+    /// The columns that miss the cut stay in the conflict structure, so the
+    /// base color count is untouched and the singleton colors are pure
+    /// addition — these two patterns colored to 306 and 290 against a plain
+    /// walk's 50 and 34.
+    #[test]
+    fn thousands_of_medium_degree_cols_are_not_peeled() {
+        for (n, blocks, size) in [(200_000, 100, 50), (200_000, 300, 34)] {
+            let pairs = disjoint_blocks(n, blocks, size);
+            let (_, n_colors, peeled) = greedy_hessian_coloring(n, &pairs);
+            let n_peeled = peeled.iter().filter(|&&p| p).count();
+            assert_eq!(
+                n_peeled, 0,
+                "degree-{size} columns do not pay for a singleton color \
+                 (n={n}, blocks={blocks}), yet {n_peeled} were peeled"
+            );
+            assert!(
+                n_colors <= size + 1,
+                "disjoint {size}x{size} blocks color by block size regardless \
+                 of block count; got {n_colors} for n={n}, blocks={blocks}"
+            );
+        }
+    }
+
+    /// The pay-for-itself rule must not throw away the case peeling exists
+    /// for: a handful of genuinely dense rows still get peeled, and still
+    /// collapse the coloring.
+    #[test]
+    fn a_few_truly_dense_rows_are_still_peeled() {
+        let n = 5_000;
+        let dense_rows = 4;
+        let mut pairs: Vec<(usize, usize)> = (0..n).map(|j| (j, j)).collect();
+        for d in 0..dense_rows {
+            for j in 0..n {
+                if j != d {
+                    pairs.push((j.max(d), j.min(d)));
+                }
+            }
+        }
+        let (_, n_colors, peeled) = greedy_hessian_coloring(n, &pairs);
+        let n_peeled = peeled.iter().filter(|&&p| p).count();
+        assert_eq!(n_peeled, dense_rows, "every full row should peel");
+        assert!(
+            n_colors <= dense_rows + 2,
+            "peeling {dense_rows} full rows should leave a diagonal remainder, \
+             got {n_colors} colors"
+        );
+    }
+
+    /// The cap still binds, and when it does the kept columns are the
+    /// highest-degree ones.
+    #[test]
+    fn peeling_is_capped_and_keeps_the_worst_offenders() {
+        let n = 20_000;
+        let dense_rows = 400;
+        let mut pairs: Vec<(usize, usize)> = (0..n).map(|j| (j, j)).collect();
+        for d in 0..dense_rows {
+            // Row d touches the first (n - d) columns, so degree strictly
+            // decreases with d and the ordering is unambiguous.
+            for j in 0..(n - d) {
+                if j != d {
+                    pairs.push((j.max(d), j.min(d)));
+                }
+            }
+        }
+        let (_, _, peeled) = greedy_hessian_coloring(n, &pairs);
+        let n_peeled = peeled.iter().filter(|&&p| p).count();
+        assert_eq!(n_peeled, MAX_PEELED_COLS, "cap binds at {MAX_PEELED_COLS}");
+        assert!(
+            (0..MAX_PEELED_COLS).all(|d| peeled[d]),
+            "the {MAX_PEELED_COLS} densest rows are the ones kept"
+        );
+    }
+
+    /// Header line 0 is `g<count> <opt0> ...`; the option words are the
+    /// model's own and a solver echoes them into the `.sol` `Options`
+    /// block. `EQ_LIN`'s header is `g3 0 1 0`, so three words follow.
+    #[test]
+    fn header_option_words_are_kept_verbatim() {
+        let p = parse_nl_text(EQ_LIN).expect("parse");
+        assert_eq!(p.ampl_options, vec![0, 1, 0]);
+    }
+
+    /// A count that does not match the words present must not be
+    /// guessed at — the writer falls back rather than emit a wrong block.
+    #[test]
+    fn a_truncated_option_list_is_dropped_not_padded() {
+        let text = EQ_LIN.replacen("g3 0 1 0", "g9 0 1 0", 1);
+        let p = parse_nl_text(&text).expect("parse");
+        assert!(
+            p.ampl_options.is_empty(),
+            "9 declared but 3 present: {:?}",
+            p.ampl_options
+        );
     }
 
     #[test]

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -39,7 +39,7 @@ use pounce_nlp::tnlp::{
     ScalingRequest, Solution, SparsityRequest, StartingPoint, TNLP,
 };
 use std::cell::RefCell;
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -611,7 +611,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
             'C' => {
                 let (_hdr, rest) = p.eat_segment_header()?;
                 let _ = rest;
-                let idx = parse_segment_index(&_hdr, 'C')?;
+                let idx = parse_segment_index(_hdr, 'C')?;
                 if idx >= m {
                     return Err(format!("C{idx} out of range; m={m}"));
                 }
@@ -637,7 +637,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 p.eat_segment_header()?;
                 for i in 0..m {
                     let line = p.next_data_line()?;
-                    let (lo, hi) = parse_bound_line(&line)?;
+                    let (lo, hi) = parse_bound_line(line)?;
                     g_l[i] = lo;
                     g_u[i] = hi;
                 }
@@ -646,7 +646,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 p.eat_segment_header()?;
                 for i in 0..n {
                     let line = p.next_data_line()?;
-                    let (lo, hi) = parse_bound_line(&line)?;
+                    let (lo, hi) = parse_bound_line(line)?;
                     x_l[i] = lo;
                     x_u[i] = hi;
                 }
@@ -665,7 +665,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 // far-removed error. Validate against the expected `n-1`
                 // so a mismatch surfaces here, clearly, at its source.
                 let (hdr, _) = p.eat_segment_header()?;
-                let declared = parse_segment_index(&hdr, 'k')?;
+                let declared = parse_segment_index(hdr, 'k')?;
                 let expected = if n == 0 { 0 } else { n - 1 };
                 if declared != expected {
                     return Err(format!(
@@ -690,7 +690,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 }
                 for _ in 0..nz {
                     let line = p.next_data_line()?;
-                    let (var, coef) = parse_var_coef(&line)?;
+                    let (var, coef) = parse_var_coef(line)?;
                     // Validate the column index here: an out-of-range `var`
                     // would otherwise be stored and panic as a slice OOB
                     // (`x[var]`) during constraint evaluation. Mirror the
@@ -714,7 +714,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                 let mut acc = Vec::with_capacity(nz);
                 for _ in 0..nz {
                     let line = p.next_data_line()?;
-                    let (var, coef) = parse_var_coef(&line)?;
+                    let (var, coef) = parse_var_coef(line)?;
                     // Same as J: reject an out-of-range gradient column index
                     // up front rather than letting it panic on `x[var]` later.
                     if var >= n {
@@ -737,7 +737,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                     .ok_or_else(|| format!("malformed x-segment header: {hdr}"))?;
                 for _ in 0..nx {
                     let line = p.next_data_line()?;
-                    let (idx, val) = parse_var_coef(&line)?;
+                    let (idx, val) = parse_var_coef(line)?;
                     // Reject out-of-range indices as a parse error, matching
                     // J/G strictness, rather than silently dropping the entry
                     // (which hides a corrupt initial-primal segment).
@@ -758,7 +758,7 @@ pub fn parse_nl_text(txt: &str) -> Result<NlProblem, String> {
                     .ok_or_else(|| format!("malformed d-segment header: {hdr}"))?;
                 for _ in 0..nd {
                     let line = p.next_data_line()?;
-                    let (idx, val) = parse_var_coef(&line)?;
+                    let (idx, val) = parse_var_coef(line)?;
                     // Reject out-of-range indices as a parse error, matching
                     // J/G strictness, rather than silently dropping the entry
                     // (which hides a corrupt initial-dual segment).
@@ -997,37 +997,45 @@ fn parse_segment_index(s: &str, tag: char) -> Result<usize, String> {
         .map_err(|e| format!("malformed {tag}-segment index '{s}': {e}"))
 }
 
+// `parse_bound_line` and `parse_var_coef` run once per `r` / `b` / `J` /
+// `G` / `x` / `d` data line, so between them they see every Jacobian and
+// gradient nonzero in the file. Both walk the whitespace iterator
+// directly instead of collecting a `Vec<&str>` first — that collect was
+// a heap allocation per line on top of the one the reader used to make
+// handing the line over.
 fn parse_bound_line(line: &str) -> Result<(Number, Number), String> {
-    let parts: Vec<&str> = line.split_whitespace().collect();
-    if parts.is_empty() {
-        return Err("empty bound line".into());
-    }
-    let kind: i32 = parts[0].parse().map_err(|e| format!("bound kind: {e}"))?;
+    let mut parts = line.split_whitespace();
+    let kind: i32 = parts
+        .next()
+        .ok_or("empty bound line")?
+        .parse()
+        .map_err(|e| format!("bound kind: {e}"))?;
     let lo;
     let hi;
     match kind {
         0 => {
             // 0  lo  hi
-            if parts.len() < 3 {
+            let (l, h) = (parts.next(), parts.next());
+            let (Some(l), Some(h)) = (l, h) else {
                 return Err(format!("bound kind 0 needs 2 values: '{line}'"));
-            }
-            lo = parts[1].parse().map_err(|e| format!("lo: {e}"))?;
-            hi = parts[2].parse().map_err(|e| format!("hi: {e}"))?;
+            };
+            lo = l.parse().map_err(|e| format!("lo: {e}"))?;
+            hi = h.parse().map_err(|e| format!("hi: {e}"))?;
         }
         1 => {
             // 1  hi
-            if parts.len() < 2 {
+            let Some(h) = parts.next() else {
                 return Err(format!("bound kind 1 needs 1 value: '{line}'"));
-            }
+            };
             lo = -1e19;
-            hi = parts[1].parse().map_err(|e| format!("hi: {e}"))?;
+            hi = h.parse().map_err(|e| format!("hi: {e}"))?;
         }
         2 => {
             // 2  lo
-            if parts.len() < 2 {
+            let Some(l) = parts.next() else {
                 return Err(format!("bound kind 2 needs 1 value: '{line}'"));
-            }
-            lo = parts[1].parse().map_err(|e| format!("lo: {e}"))?;
+            };
+            lo = l.parse().map_err(|e| format!("lo: {e}"))?;
             hi = 1e19;
         }
         3 => {
@@ -1037,10 +1045,10 @@ fn parse_bound_line(line: &str) -> Result<(Number, Number), String> {
         }
         4 => {
             // 4  eq
-            if parts.len() < 2 {
+            let Some(v) = parts.next() else {
                 return Err(format!("bound kind 4 needs 1 value: '{line}'"));
-            }
-            let v: Number = parts[1].parse().map_err(|e| format!("eq: {e}"))?;
+            };
+            let v: Number = v.parse().map_err(|e| format!("eq: {e}"))?;
             lo = v;
             hi = v;
         }
@@ -1051,12 +1059,12 @@ fn parse_bound_line(line: &str) -> Result<(Number, Number), String> {
 }
 
 fn parse_var_coef(line: &str) -> Result<(usize, Number), String> {
-    let parts: Vec<&str> = line.split_whitespace().collect();
-    if parts.len() < 2 {
+    let mut parts = line.split_whitespace();
+    let (Some(v), Some(c)) = (parts.next(), parts.next()) else {
         return Err(format!("malformed var/coef line: '{line}'"));
-    }
-    let v: usize = parts[0].parse().map_err(|e| format!("var idx: {e}"))?;
-    let c: Number = parts[1].parse().map_err(|e| format!("coef: {e}"))?;
+    };
+    let v: usize = v.parse().map_err(|e| format!("var idx: {e}"))?;
+    let c: Number = c.parse().map_err(|e| format!("coef: {e}"))?;
     Ok((v, c))
 }
 
@@ -1102,11 +1110,23 @@ impl<'a> Parser<'a> {
         None
     }
 
-    fn next_data_line(&mut self) -> Result<String, String> {
-        let raw = self
-            .next_line()
-            .ok_or_else(|| "unexpected end of file in data line".to_string())?;
-        Ok(strip_comment(raw).trim().to_string())
+    /// Next non-blank line, comment stripped and trimmed.
+    ///
+    /// Borrows from the source text rather than allocating: the result
+    /// is `&'a str`, tied to the `.nl` buffer and not to `self`, so it
+    /// outlives the `&mut self` this took. A large `.nl` is mostly data
+    /// lines — 620k of them for a 20k-variable model — and returning an
+    /// owned `String` put one heap allocation on every single one.
+    fn next_data_line(&mut self) -> Result<&'a str, String> {
+        while self.pos < self.lines.len() {
+            let l = self.lines[self.pos];
+            self.pos += 1;
+            let trimmed = strip_comment(l).trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed);
+            }
+        }
+        Err("unexpected end of file in data line".to_string())
     }
 
     fn parse_header(&mut self) -> Result<(), String> {
@@ -1153,19 +1173,22 @@ impl<'a> Parser<'a> {
 
     /// Eat the next non-blank line as a segment header. Returns the
     /// whole header (after stripping comments) and the comment text.
-    fn eat_segment_header(&mut self) -> Result<(String, String), String> {
+    fn eat_segment_header(&mut self) -> Result<(&'a str, &'a str), String> {
         let raw = self
             .next_line()
             .ok_or_else(|| "expected segment header".to_string())?;
         let (hdr, comment) = split_comment(raw);
-        Ok((hdr.trim().to_string(), comment.trim().to_string()))
+        Ok((hdr.trim(), comment.trim()))
     }
 
     fn parse_expr(&mut self) -> Result<Expr, String> {
         let raw = self
             .next_line()
             .ok_or_else(|| "expected expression token".to_string())?;
-        let tok = strip_comment(raw).trim().to_string();
+        // Borrowed, not owned: this runs once per node of every
+        // expression tree in the file, so an owned `String` here is one
+        // heap allocation per tape op in the whole model.
+        let tok = strip_comment(raw).trim();
         if tok.is_empty() {
             return Err("empty expression token".into());
         }
@@ -1469,7 +1492,7 @@ impl<'a> Parser<'a> {
         let mut linear: Vec<(usize, Number)> = Vec::with_capacity(nlin);
         for _ in 0..nlin {
             let line = self.next_data_line()?;
-            let (var, coef) = parse_var_coef(&line)?;
+            let (var, coef) = parse_var_coef(line)?;
             linear.push((var, coef));
         }
         let nonlin = self.parse_expr()?;
@@ -2409,18 +2432,89 @@ fn split_top_sums(expr: &Expr) -> Vec<Expr> {
 /// color assigned to variable `k`, or `u32::MAX` for variables
 /// not in any Hessian pair (they contribute nothing and don't
 /// need a color).
-fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32>, usize) {
+/// A column is treated as **dense** — and peeled out of the coloring —
+/// once its nonzero-row count exceeds `DENSE_COL_FACTOR` times the
+/// average, but never below `DENSE_COL_MIN`. Both guards matter: the
+/// factor keeps uniformly-dense Hessians (where every column looks like
+/// every other) on the plain coloring path, and the absolute floor stops
+/// a very sparse average from declaring a 10-entry column "dense".
+const DENSE_COL_FACTOR: usize = 16;
+const DENSE_COL_MIN: usize = 32;
+/// Hard cap on how many columns get peeled. Each peeled column costs
+/// exactly one color, so this bounds the damage if the heuristic
+/// misfires on an unusual pattern.
+const MAX_PEELED_COLS: usize = 256;
+
+/// Greedy distance-1 coloring of the Hessian's column-intersection
+/// graph, with **dense columns peeled out**.
+///
+/// Returns `(var_color, n_colors, peeled)`. `var_color[j] == u32::MAX`
+/// marks a column that needs no directional product of its own: either
+/// it has no Hessian entries at all, or every entry it has is recovered
+/// from a peeled column's pass (see below).
+///
+/// # Why peeling
+///
+/// The plain coloring rule is "two columns may share a color when they
+/// have no common nonzero row". A single **dense row** — one variable
+/// multiplying a sum over all the others, a total-cost variable, a
+/// shared design parameter — puts a nonzero in *every* column at that
+/// row, so every pair of columns conflicts and the greedy walk hands out
+/// `n` colors for a Hessian that may have only ~3n nonzeros. Since
+/// `NlTnlp` holds `n_colors × n` dense `seeds` and `compressed` arrays,
+/// that turns into O(n²) memory (6.4 GB at n = 20,000) and O(n²) work
+/// per `eval_h`, on a problem whose Hessian is perfectly sparse.
+///
+/// Peeling exploits the Hessian's symmetry. Give a dense column `d` its
+/// own singleton color: one directional product with seed `e_d` recovers
+/// the whole of column `d` exactly. Every pair `(d, j)` — row `d`,
+/// column `j` — is then already known, because `H[d, j] == H[j, d]` sits
+/// at row `j` of that same pass. So row `d` no longer constrains any
+/// other column's color and is dropped from the conflict structure, and
+/// the remaining columns colour on their genuine sparsity. On the
+/// one-dense-row case above this takes `n_colors` from `n` to a handful.
+fn greedy_hessian_coloring(
+    n: usize,
+    lower_pairs: &[(usize, usize)],
+) -> (Vec<u32>, usize, Vec<bool>) {
     if n == 0 {
-        return (Vec::new(), 0);
+        return (Vec::new(), 0, Vec::new());
     }
 
-    // For each variable k, list of rows in which column k has a
-    // nonzero in the FULL (symmetric) Hessian. Built from lower
-    // pairs: (i, j) with i >= j contributes row i to column j and
-    // row j to column i (when i != j); diagonals contribute once.
+    // Column degrees in the FULL (symmetric) Hessian: pair (i, j) with
+    // i >= j contributes row i to column j and row j to column i; a
+    // diagonal contributes once.
+    let mut deg = vec![0usize; n];
+    for &(i, j) in lower_pairs {
+        deg[j] += 1;
+        if i != j {
+            deg[i] += 1;
+        }
+    }
+
+    // Pick the dense columns to peel.
+    let total: usize = deg.iter().sum();
+    let threshold = DENSE_COL_MIN.max(DENSE_COL_FACTOR.saturating_mul(total / n));
+    let mut peeled = vec![false; n];
+    let mut dense: Vec<usize> = (0..n).filter(|&j| deg[j] > threshold).collect();
+    if dense.len() > MAX_PEELED_COLS {
+        // Keep the worst offenders: they remove the most conflicts.
+        dense.sort_unstable_by(|&a, &b| deg[b].cmp(&deg[a]).then(a.cmp(&b)));
+        dense.truncate(MAX_PEELED_COLS);
+    }
+    for &j in &dense {
+        peeled[j] = true;
+    }
+
+    // Conflict structure over the *non-peeled* columns only. Pairs with
+    // a peeled endpoint are recovered from that endpoint's own pass, so
+    // they neither need a color nor constrain one.
     let mut col_rows: Vec<Vec<u32>> = vec![Vec::new(); n];
     let mut row_cols: Vec<Vec<u32>> = vec![Vec::new(); n];
     for &(i, j) in lower_pairs {
+        if peeled[i] || peeled[j] {
+            continue;
+        }
         col_rows[j].push(i as u32);
         row_cols[i].push(j as u32);
         if i != j {
@@ -2434,8 +2528,9 @@ fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32
     let mut n_colors: u32 = 0;
 
     for j in 0..n {
-        // Variable `j` has no Hessian entries → skip (no color).
-        if col_rows[j].is_empty() {
+        // Peeled columns are colored below; a column with no surviving
+        // Hessian entries needs no color at all.
+        if peeled[j] || col_rows[j].is_empty() {
             continue;
         }
         // Mark colors used by any column sharing a row with `j`.
@@ -2463,7 +2558,14 @@ fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32
         }
     }
 
-    (var_color, n_colors as usize)
+    // One singleton color per peeled column, appended after the shared
+    // ones so the non-peeled numbering is untouched.
+    for &j in &dense {
+        var_color[j] = n_colors;
+        n_colors += 1;
+    }
+
+    (var_color, n_colors as usize, peeled)
 }
 
 impl NlTnlp {
@@ -2555,30 +2657,36 @@ impl NlTnlp {
 
         // Hessian-of-Lagrangian sparsity: union of each tape's own
         // structural Hessian sparsity.
-        let mut pairs: BTreeSet<(usize, usize)> = BTreeSet::new();
+        // One flat `Vec`, sorted and deduped once, rather than a global
+        // `BTreeSet` fed a single insert at a time across every summand
+        // in the model: sort+dedup walks contiguous memory where the tree
+        // chased a pointer and allocated a node per entry. The result is
+        // exactly the ascending order the rest of this function wants, so
+        // it doubles as `lower_pairs` instead of being copied into it.
+        let mut lower_pairs: Vec<(usize, usize)> = Vec::new();
         for t in &obj_tapes {
-            pairs.extend(t.hessian_sparsity());
+            lower_pairs.extend(t.hessian_sparsity());
         }
         for row in &con_tapes {
             for t in row {
-                pairs.extend(t.hessian_sparsity());
+                lower_pairs.extend(t.hessian_sparsity());
             }
         }
-        let mut h_irow = Vec::with_capacity(pairs.len());
-        let mut h_jcol = Vec::with_capacity(pairs.len());
-        let mut hess_map = HashMap::with_capacity(pairs.len());
-        for (k, (hi, lo)) in pairs.iter().enumerate() {
-            h_irow.push(*hi as i32);
-            h_jcol.push(*lo as i32);
-            hess_map.insert((*hi, *lo), k);
+        lower_pairs.sort_unstable();
+        lower_pairs.dedup();
+
+        let mut h_irow = Vec::with_capacity(lower_pairs.len());
+        let mut h_jcol = Vec::with_capacity(lower_pairs.len());
+        for &(hi, lo) in &lower_pairs {
+            h_irow.push(hi as i32);
+            h_jcol.push(lo as i32);
         }
 
         // Hessian column coloring. The chromatic number of the
         // column-intersection graph bounds how many directional
         // Hessian-vector products we need per `eval_h` call —
         // typically O(stencil) for PDE-mesh problems.
-        let lower_pairs: Vec<(usize, usize)> = pairs.iter().copied().collect();
-        let (var_color, n_colors) = greedy_hessian_coloring(prob.n, &lower_pairs);
+        let (var_color, n_colors, peeled) = greedy_hessian_coloring(prob.n, &lower_pairs);
 
         // Per-color seed vectors (dense for O(1) Var lookup in
         // `Tape::hessian_directional`).
@@ -2594,15 +2702,28 @@ impl NlTnlp {
         // computing compressed_{c_j} = (H · s_{c_j}), the value at
         // row i is exactly H[i, j] (coloring guarantees no other
         // column in c_j has a nonzero at row i).
+        // Built straight from `lower_pairs`, which is sorted, so each
+        // color's table is in ascending `hess_idx` order and the decode
+        // scatter walks `values` forward instead of hopping (the old
+        // build drained a `HashMap`, whose iteration order is arbitrary).
         let mut decoding: Vec<Vec<ColorWrite>> = vec![Vec::new(); n_colors];
-        for (&(i, j), &idx) in hess_map.iter() {
-            let c = var_color[j];
+        for (idx, &(i, j)) in lower_pairs.iter().enumerate() {
+            // Which directional product recovers H[i, j]? Column `j`'s,
+            // read at row `i` — except when `i` is a peeled column and
+            // `j` is not: then `j` may have no color of its own, and the
+            // entry is already in column `i`'s pass at row `j`, since
+            // H[i, j] == H[j, i].
+            let (c, row) = if peeled[i] && !peeled[j] {
+                (var_color[i], j)
+            } else {
+                (var_color[j], i)
+            };
             debug_assert!(
                 c != u32::MAX,
-                "column {j} has Hessian pair {idx} but no color"
+                "Hessian pair ({i}, {j}) at index {idx} has no color"
             );
             decoding[c as usize].push(ColorWrite {
-                row: i as u32,
+                row: row as u32,
                 hess_idx: idx as u32,
             });
         }
@@ -2611,14 +2732,15 @@ impl NlTnlp {
         // its variables fall into. `eval_h` loops over only these
         // (tape, color) pairs instead of n_tapes × n_colors.
         let tape_colors = |t: &Tape| -> Vec<u32> {
-            let mut s: BTreeSet<u32> = BTreeSet::new();
-            for v in t.variables() {
-                let c = var_color[v];
-                if c != u32::MAX {
-                    s.insert(c);
-                }
-            }
-            s.into_iter().collect()
+            let mut s: Vec<u32> = t
+                .variables()
+                .into_iter()
+                .map(|v| var_color[v])
+                .filter(|&c| c != u32::MAX)
+                .collect();
+            s.sort_unstable();
+            s.dedup();
+            s
         };
         let obj_tape_colors: Vec<Vec<u32>> = obj_tapes.iter().map(tape_colors).collect();
         let con_tape_colors: Vec<Vec<Vec<u32>>> = con_tapes
@@ -2630,17 +2752,15 @@ impl NlTnlp {
         // linear-segment vars.
         let mut jac_cols: Vec<Vec<usize>> = Vec::with_capacity(prob.m);
         let mut jac_nnz = 0;
-        for i in 0..prob.m {
-            let mut set: BTreeSet<usize> = BTreeSet::new();
-            for t in &con_tapes[i] {
-                for v in t.variables() {
-                    set.insert(v);
-                }
+        for (i, row_tapes) in con_tapes.iter().enumerate() {
+            let mut cols: Vec<usize> = Vec::with_capacity(prob.con_linear[i].len());
+            for t in row_tapes {
+                cols.extend(t.variables());
             }
-            for (v, _) in &prob.con_linear[i] {
-                set.insert(*v);
-            }
-            let cols: Vec<usize> = set.into_iter().collect();
+            cols.extend(prob.con_linear[i].iter().map(|(v, _)| *v));
+            cols.sort_unstable();
+            cols.dedup();
+            cols.shrink_to_fit();
             jac_nnz += cols.len();
             jac_cols.push(cols);
         }
@@ -4006,6 +4126,153 @@ J0 2
             vec![7.0],
             "without init_lambda the multiplier buffer must be untouched"
         );
+    }
+
+    /// `.nl` text for `minimize sum_j (x_j - 1)^2 + x_0 * sum_j x_j`,
+    /// unconstrained, `n` variables. The trailing product puts a nonzero
+    /// in row 0 of *every* Hessian column, which is the shape that used
+    /// to force the greedy coloring to hand out one color per variable.
+    fn dense_row_objective_nl(n: usize) -> String {
+        let mut s = String::new();
+        s.push_str("g3 1 1 0\n");
+        s.push_str(&format!(" {n} 0 1 0 0 0\n"));
+        s.push_str(" 0 1\n 0 0\n");
+        s.push_str(&format!(" {n} {n} {n}\n"));
+        s.push_str(" 0 0 0 1\n 0 0 0 0 0\n");
+        s.push_str(&format!(" 0 {n}\n"));
+        s.push_str(" 0 0\n 0 0 0 0 0\n");
+        // objective
+        s.push_str("O0 0\n");
+        s.push_str(&format!("o54\n{}\n", n + 1));
+        for j in 0..n {
+            s.push_str(&format!("o5\no1\nv{j}\nn1.0\nn2\n"));
+        }
+        s.push_str(&format!("o2\nv0\no54\n{n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("v{j}\n"));
+        }
+        // start, bounds, gradient
+        s.push_str(&format!("x{n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("{j} 0.5\n"));
+        }
+        s.push_str("b\n");
+        for _ in 0..n {
+            s.push_str("3\n");
+        }
+        s.push_str(&format!("G0 {n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("{j} 0.0\n"));
+        }
+        s
+    }
+
+    /// A single dense Hessian row must not blow the coloring up to one
+    /// color per variable. It used to: every column shares row 0, so no
+    /// two columns could be colored alike, and `seeds` / `compressed`
+    /// — both `n_colors × n` dense — became O(n²) memory and O(n²) work
+    /// per `eval_h` on a Hessian holding only ~2n nonzeros.
+    #[test]
+    fn a_dense_hessian_row_does_not_explode_the_coloring() {
+        let n = 200;
+        let p = parse_nl_text(&dense_row_objective_nl(n)).expect("parse");
+        let t = NlTnlp::new(p);
+        // 2n - 1 entries: the diagonal (j, j) for every j, plus (j, 0)
+        // for j >= 1 from the coupling term.
+        assert_eq!(t.h_irow.len(), 2 * n - 1);
+        assert!(
+            t.seeds.len() <= 4,
+            "one dense row should cost one extra color, not n; got {} colors for n={n}",
+            t.seeds.len()
+        );
+        assert_eq!(t.seeds.len(), t.compressed.len());
+    }
+
+    /// Peeling changes *which* directional product recovers an entry, so
+    /// the recovered Hessian must still be exactly right — including the
+    /// entries read out of a peeled column's pass by symmetry.
+    #[test]
+    fn peeled_dense_column_still_recovers_the_exact_hessian() {
+        let n = 200;
+        let p = parse_nl_text(&dense_row_objective_nl(n)).expect("parse");
+        let mut t = NlTnlp::new(p);
+        let info = t.get_nlp_info().unwrap();
+        let nnz = info.nnz_h_lag as usize;
+
+        let mut irow = vec![0_i32; nnz];
+        let mut jcol = vec![0_i32; nnz];
+        assert!(t.eval_h(
+            None,
+            true,
+            1.0,
+            None,
+            true,
+            SparsityRequest::Structure {
+                irow: &mut irow,
+                jcol: &mut jcol
+            }
+        ));
+
+        // f = sum_j (x_j - 1)^2 + x_0 * sum_j x_j
+        //   H[0,0] = 2 + 2 = 4;  H[j,j] = 2 (j >= 1);  H[j,0] = 1 (j >= 1).
+        let x: Vec<f64> = (0..n).map(|j| 0.1 * j as f64).collect();
+        let obj_factor = 2.5;
+        let mut vals = vec![0.0_f64; nnz];
+        assert!(t.eval_h(
+            Some(&x),
+            true,
+            obj_factor,
+            None,
+            true,
+            SparsityRequest::Values { values: &mut vals }
+        ));
+
+        let mut seen_diag = 0;
+        let mut seen_coupling = 0;
+        for k in 0..nnz {
+            let (i, j) = (irow[k] as usize, jcol[k] as usize);
+            let want = if i == 0 && j == 0 {
+                4.0
+            } else if i == j {
+                seen_diag += 1;
+                2.0
+            } else {
+                assert_eq!(j, 0, "unexpected off-diagonal ({i}, {j})");
+                seen_coupling += 1;
+                1.0
+            } * obj_factor;
+            assert!(
+                (vals[k] - want).abs() < 1e-12,
+                "H[{i},{j}] = {}, want {want}",
+                vals[k]
+            );
+        }
+        assert_eq!(seen_diag, n - 1);
+        assert_eq!(seen_coupling, n - 1);
+    }
+
+    /// The peeling threshold must leave ordinary sparse models on
+    /// exactly the coloring they had before: a banded Hessian colors by
+    /// its bandwidth, with nothing peeled.
+    #[test]
+    fn a_sparse_hessian_is_colored_by_its_bandwidth_not_peeled() {
+        let n = 400;
+        let pairs: Vec<(usize, usize)> = (0..n)
+            .flat_map(|j| {
+                let mut v = vec![(j, j)];
+                if j + 1 < n {
+                    v.push((j + 1, j));
+                }
+                v
+            })
+            .collect();
+        let (var_color, n_colors, peeled) = greedy_hessian_coloring(n, &pairs);
+        assert!(!peeled.iter().any(|&p| p), "nothing in a band is dense");
+        assert!(
+            n_colors <= 3,
+            "a tridiagonal Hessian needs a handful of colors, got {n_colors}"
+        );
+        assert!(var_color.iter().all(|&c| c != u32::MAX));
     }
 
     #[test]

--- a/crates/pounce-nl/src/nl_tape.rs
+++ b/crates/pounce-nl/src/nl_tape.rs
@@ -1737,6 +1737,66 @@ impl Tape {
         let mut var_sets: Vec<BTreeSet<usize>> = Vec::with_capacity(n);
         let mut pairs: BTreeSet<(usize, usize)> = BTreeSet::new();
 
+        // Slot lifetimes: `last_use[i]` is the highest-numbered op that
+        // reads slot `i` (or `i` itself when nothing does). A slot's
+        // variable set is dead the moment its last reader has been
+        // processed, so it can be *moved into* that reader's result
+        // instead of copied, and dropped otherwise.
+        //
+        // Without this the pass is O(n²) in both time and memory on any
+        // tape carrying a long additive chain — `v0 * (v0 + v1 + … + vk)`,
+        // the shape a dense Hessian row comes from — because every
+        // partial sum leaves behind its own full-size `BTreeSet` and each
+        // union copies the whole running set. `split_top_sums` keeps
+        // *top-level* sums out of a single tape, so this only bites when
+        // the sum feeds an enclosing operator, which is exactly the dense
+        // case. With reuse, a left-leaning chain extends one set in place.
+        let mut last_use: Vec<usize> = (0..n).collect();
+        for (i, op) in self.ops.iter().enumerate() {
+            for_each_input(op, |a| last_use[a] = i);
+        }
+        // Union of two operand sets, taking ownership of whichever dies
+        // at this op rather than copying. `a == b` is handled first:
+        // taking one would empty the other.
+        macro_rules! merge {
+            ($a:expr, $b:expr, $i:expr) => {{
+                let (a, b, i) = ($a, $b, $i);
+                if a == b {
+                    if last_use[a] == i {
+                        std::mem::take(&mut var_sets[a])
+                    } else {
+                        var_sets[a].clone()
+                    }
+                } else {
+                    // Prefer moving the larger of the two dead sets.
+                    let take_a = last_use[a] == i
+                        && (last_use[b] != i || var_sets[a].len() >= var_sets[b].len());
+                    if take_a {
+                        let mut s = std::mem::take(&mut var_sets[a]);
+                        s.extend(var_sets[b].iter().copied());
+                        s
+                    } else if last_use[b] == i {
+                        let mut s = std::mem::take(&mut var_sets[b]);
+                        s.extend(var_sets[a].iter().copied());
+                        s
+                    } else {
+                        var_sets[a].union(&var_sets[b]).copied().collect()
+                    }
+                }
+            }};
+        }
+        // Same, for the one-operand ops.
+        macro_rules! carry {
+            ($a:expr, $i:expr) => {{
+                let (a, i) = ($a, $i);
+                if last_use[a] == i {
+                    std::mem::take(&mut var_sets[a])
+                } else {
+                    var_sets[a].clone()
+                }
+            }};
+        }
+
         let emit_cross =
             |s1: &BTreeSet<usize>, s2: &BTreeSet<usize>, pairs: &mut BTreeSet<(usize, usize)>| {
                 for &v1 in s1 {
@@ -1756,7 +1816,7 @@ impl Tape {
             }
         };
 
-        for op in &self.ops {
+        for (i, op) in self.ops.iter().enumerate() {
             let vset = match op {
                 TapeOp::Const(_) => BTreeSet::new(),
                 TapeOp::Var(j) => {
@@ -1764,22 +1824,19 @@ impl Tape {
                     s.insert(*j);
                     s
                 }
-                TapeOp::Add(a, b) | TapeOp::Sub(a, b) => {
-                    var_sets[*a].union(&var_sets[*b]).copied().collect()
-                }
-                TapeOp::Neg(a) | TapeOp::Abs(a) => var_sets[*a].clone(),
+                TapeOp::Add(a, b) | TapeOp::Sub(a, b) => merge!(*a, *b, i),
+                TapeOp::Neg(a) | TapeOp::Abs(a) => carry!(*a, i),
                 TapeOp::Mul(a, b) => {
                     emit_cross(&var_sets[*a], &var_sets[*b], &mut pairs);
-                    var_sets[*a].union(&var_sets[*b]).copied().collect()
+                    merge!(*a, *b, i)
                 }
                 TapeOp::Div(a, b) => {
                     emit_cross(&var_sets[*a], &var_sets[*b], &mut pairs);
                     emit_self(&var_sets[*b], &mut pairs);
-                    var_sets[*a].union(&var_sets[*b]).copied().collect()
+                    merge!(*a, *b, i)
                 }
                 TapeOp::Pow(a, b) => {
-                    let combined: BTreeSet<usize> =
-                        var_sets[*a].union(&var_sets[*b]).copied().collect();
+                    let combined = merge!(*a, *b, i);
                     emit_self(&combined, &mut pairs);
                     combined
                 }
@@ -1802,15 +1859,14 @@ impl Tape {
                 | TapeOp::XLogX(a)
                 | TapeOp::Atanh(a) => {
                     emit_self(&var_sets[*a], &mut pairs);
-                    var_sets[*a].clone()
+                    carry!(*a, i)
                 }
                 // atan2(y, x) and centropy(a, b) are nonlinear in both
                 // operands with a full 2×2 second-derivative block; the
                 // structural superset is every self/cross pair within the
                 // combined operand set.
                 TapeOp::Atan2(a, b) | TapeOp::CEntropy(a, b) => {
-                    let combined: BTreeSet<usize> =
-                        var_sets[*a].union(&var_sets[*b]).copied().collect();
+                    let combined = merge!(*a, *b, i);
                     emit_self(&combined, &mut pairs);
                     combined
                 }
@@ -1828,16 +1884,14 @@ impl Tape {
                 // (either may become active as x varies — conservative
                 // and correct for a structural superset). The condition
                 // contributes no derivative and is excluded.
-                TapeOp::Select(_c, t, e) => var_sets[*t].union(&var_sets[*e]).copied().collect(),
+                TapeOp::Select(_c, t, e) => merge!(*t, *e, i),
                 // min/max are piecewise linear: the active operand passes
                 // through with unit derivative, so the second derivative is
                 // identically zero (no pairs). Their dependence set is the
                 // union of both operands (either may become active as x
                 // varies — conservative and correct for a structural
                 // superset), mirroring Select.
-                TapeOp::Min(a, b) | TapeOp::Max(a, b) => {
-                    var_sets[*a].union(&var_sets[*b]).copied().collect()
-                }
+                TapeOp::Min(a, b) | TapeOp::Max(a, b) => merge!(*a, *b, i),
                 TapeOp::Funcall(fc) => {
                     let args = &fc.args;
                     let mut combined: BTreeSet<usize> = BTreeSet::new();
@@ -1852,9 +1906,83 @@ impl Tape {
                     combined
                 }
             };
+            // Release any operand whose last reader was this op and which
+            // `merge!` / `carry!` did not already move out (already-moved
+            // slots are empty, so this is a no-op for them). Without it a
+            // tape's peak memory is the sum of every intermediate set
+            // rather than the live ones.
+            for_each_input(op, |a| {
+                if last_use[a] == i {
+                    var_sets[a].clear();
+                }
+            });
             var_sets.push(vset);
         }
         pairs
+    }
+}
+
+/// Call `f` on every tape slot `op` reads.
+///
+/// Deliberately written as an exhaustive match with **no catch-all arm**:
+/// a new `TapeOp` variant must be added here or this stops compiling.
+/// A silent "reads nothing" default would let `hessian_sparsity`'s
+/// liveness analysis drop an operand's variable set while it is still
+/// needed, which would quietly under-report Hessian sparsity — the kind
+/// of wrong answer that surfaces as a bad search direction, not a panic.
+/// Over-reporting an input is merely a missed optimization, so when in
+/// doubt list the slot.
+fn for_each_input(op: &TapeOp, mut f: impl FnMut(usize)) {
+    match op {
+        TapeOp::Const(_) | TapeOp::Var(_) => {}
+        TapeOp::Neg(a)
+        | TapeOp::Abs(a)
+        | TapeOp::Sqrt(a)
+        | TapeOp::Exp(a)
+        | TapeOp::Log(a)
+        | TapeOp::Log10(a)
+        | TapeOp::Sin(a)
+        | TapeOp::Cos(a)
+        | TapeOp::Tan(a)
+        | TapeOp::Atan(a)
+        | TapeOp::Acos(a)
+        | TapeOp::Sinh(a)
+        | TapeOp::Cosh(a)
+        | TapeOp::Tanh(a)
+        | TapeOp::Asin(a)
+        | TapeOp::Acosh(a)
+        | TapeOp::Asinh(a)
+        | TapeOp::Atanh(a)
+        | TapeOp::Erf(a)
+        | TapeOp::XLogX(a)
+        | TapeOp::Not(a) => f(*a),
+        TapeOp::Add(a, b)
+        | TapeOp::Sub(a, b)
+        | TapeOp::Mul(a, b)
+        | TapeOp::Div(a, b)
+        | TapeOp::Pow(a, b)
+        | TapeOp::CEntropy(a, b)
+        | TapeOp::Atan2(a, b)
+        | TapeOp::Min(a, b)
+        | TapeOp::Max(a, b)
+        | TapeOp::And(a, b)
+        | TapeOp::Or(a, b)
+        | TapeOp::Cmp(_, a, b) => {
+            f(*a);
+            f(*b);
+        }
+        TapeOp::Select(c, t, e) => {
+            f(*c);
+            f(*t);
+            f(*e);
+        }
+        TapeOp::Funcall(fc) => {
+            for arg in &fc.args {
+                if let TapeFuncallArg::Tape(t) = arg {
+                    f(*t);
+                }
+            }
+        }
     }
 }
 

--- a/crates/pounce-nl/src/sol_writer.rs
+++ b/crates/pounce-nl/src/sol_writer.rs
@@ -128,13 +128,29 @@ pub struct SolutionFile<'a> {
 pub fn format_sol(payload: &SolutionFile<'_>) -> String {
     let mut out = String::new();
 
-    // Header: message + a blank line + "Options" + zero options.
+    // Header: message + a blank line + the `Options` block.
+    //
+    // The block is a count followed by that many integer option words.
+    // We used to write a count of `0`, which AMPL and Pyomo's *legacy*
+    // `.sol` reader accept — but no ASL solver emits it, and Pyomo's
+    // v2 reader (`pyomo.contrib.solver.solvers.asl_sol_reader`, the one
+    // behind `ipopt_v2` and the future default `ipopt`) reads the first
+    // two option words unconditionally, to detect the documented ASL
+    // quirk where a second word of `3` means two extra words follow the
+    // `z` block. It therefore asserts `n_opts >= 2` and a count of `0`
+    // aborts the parse, so a `.sol` POUNCE wrote could not be loaded
+    // through the modern interface at all.
+    //
+    // Emit the same three words Ipopt and the ASL's own `writesol.c`
+    // emit. They are AMPL's option flags, which a solver echoes rather
+    // than interprets; every reader either ignores them or uses only
+    // the `3`-quirk test above, which `1` does not trigger.
     for line in payload.message.lines() {
         let _ = writeln!(out, "{line}");
     }
     out.push('\n');
     out.push_str("Options\n");
-    out.push_str("0\n");
+    out.push_str("3\n1\n1\n0\n");
 
     // Count block: the canonical AMPL four-integer form
     //   <n_dual_written> <n_con> <n_primal_written> <n_var>
@@ -257,7 +273,11 @@ mod tests {
         let s = format_sol(&payload);
         // Header banner present.
         assert!(s.starts_with("POUNCE: SolveSucceeded\n"));
-        assert!(s.contains("\nOptions\n0\n"));
+        // The ASL option block, as `writesol.c` and Ipopt emit it. A
+        // count of `0` here trips `assert n_opts >= 2` in Pyomo's v2
+        // `.sol` reader, which is what `ipopt_v2` (and the future
+        // default `ipopt`) uses — see `format_sol`.
+        assert!(s.contains("\nOptions\n3\n1\n1\n0\n"), "option block:\n{s}");
         // Four-integer count block: n_dual=2, m=2, n_primal=3, n=3.
         assert!(s.contains("\n2\n2\n3\n3\n"), "counts missing:\n{s}");
         // First dual line: 0.1 in exponent form.

--- a/crates/pounce-nl/src/sol_writer.rs
+++ b/crates/pounce-nl/src/sol_writer.rs
@@ -124,8 +124,30 @@ pub struct SolutionFile<'a> {
     pub suffixes: &'a [SolSuffix],
 }
 
-/// Format `payload` into AMPL `.sol` ASCII text.
+/// Format `payload` into AMPL `.sol` ASCII text, with a generic
+/// `Options` block.
+///
+/// Prefer [`format_sol_with_options`] whenever the originating `.nl` is
+/// available: a real ASL solver echoes *that model's* option words, and
+/// this entry point has none to echo.
 pub fn format_sol(payload: &SolutionFile<'_>) -> String {
+    format_sol_with_options(payload, &[])
+}
+
+/// Format `payload` into AMPL `.sol` ASCII text, echoing `ampl_options`.
+///
+/// `ampl_options` are the model's own option words, read verbatim from
+/// `.nl` header line 0 (`NlProblem::ampl_options`). Ipopt and the ASL's
+/// `writesol.c` echo them back unchanged rather than interpreting them,
+/// and the values are per-model: `bearing_400` (`g3 1 1 0`) yields
+/// `3 / 1 / 1 / 0`, while `arki0003` and `camshape_6400` (`g3 10 1 0`)
+/// yield `3 / 10 / 1 / 0`. Verified against Ipopt 3.14.20 `-AMPL` output.
+///
+/// Pass an empty slice when there is no originating header — problems
+/// built through `NlProblem::from_expressions`, the WASM entry point —
+/// and a generic `3 / 1 / 1 / 0` goes out instead. That is a valid block
+/// (see the count discussion below); it simply is not this model's.
+pub fn format_sol_with_options(payload: &SolutionFile<'_>, ampl_options: &[i64]) -> String {
     let mut out = String::new();
 
     // Header: message + a blank line + the `Options` block.
@@ -141,16 +163,24 @@ pub fn format_sol(payload: &SolutionFile<'_>) -> String {
     // aborts the parse, so a `.sol` POUNCE wrote could not be loaded
     // through the modern interface at all.
     //
-    // Emit the same three words Ipopt and the ASL's own `writesol.c`
-    // emit. They are AMPL's option flags, which a solver echoes rather
-    // than interprets; every reader either ignores them or uses only
-    // the `3`-quirk test above, which `1` does not trigger.
+    // Echo the model's own option words, which is what Ipopt and the
+    // ASL's `writesol.c` do — they are AMPL's flags, passed through
+    // rather than interpreted. With no header to echo, fall back to a
+    // generic three-word block; `1` in the second slot deliberately does
+    // not trigger the `3`-quirk test above.
     for line in payload.message.lines() {
         let _ = writeln!(out, "{line}");
     }
     out.push('\n');
     out.push_str("Options\n");
-    out.push_str("3\n1\n1\n0\n");
+    if ampl_options.len() >= 2 {
+        let _ = writeln!(out, "{}", ampl_options.len());
+        for opt in ampl_options {
+            let _ = writeln!(out, "{opt}");
+        }
+    } else {
+        out.push_str("3\n1\n1\n0\n");
+    }
 
     // Count block: the canonical AMPL four-integer form
     //   <n_dual_written> <n_con> <n_primal_written> <n_var>
@@ -252,7 +282,17 @@ fn write_suffix_header(out: &mut String, kind: u32, nvalues: usize, name: &str) 
 /// Convenience: write `payload` to `path` (truncating any existing
 /// file). Returns the bytes written on success.
 pub fn write_sol_file(path: &Path, payload: &SolutionFile<'_>) -> std::io::Result<usize> {
-    let s = format_sol(payload);
+    write_sol_file_with_options(path, payload, &[])
+}
+
+/// As [`write_sol_file`], echoing the model's own `ampl_options` (see
+/// [`format_sol_with_options`]).
+pub fn write_sol_file_with_options(
+    path: &Path,
+    payload: &SolutionFile<'_>,
+    ampl_options: &[i64],
+) -> std::io::Result<usize> {
+    let s = format_sol_with_options(payload, ampl_options);
     std::fs::write(path, &s)?;
     Ok(s.len())
 }
@@ -260,6 +300,52 @@ pub fn write_sol_file(path: &Path, payload: &SolutionFile<'_>) -> std::io::Resul
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn options_block(text: &str) -> Vec<String> {
+        let mut lines = text.lines().skip_while(|l| *l != "Options");
+        lines.next();
+        let n: usize = lines.next().unwrap().parse().unwrap();
+        std::iter::once(n.to_string())
+            .chain(lines.take(n).map(str::to_string))
+            .collect()
+    }
+
+    /// A solver echoes the model's own AMPL option words rather than
+    /// inventing them. `arki0003` and `camshape_6400` carry `g3 10 1 0`,
+    /// and Ipopt 3.14.20 writes `3 / 10 / 1 / 0` for both — verified
+    /// against real `-AMPL` output, not just the spec.
+    #[test]
+    fn options_block_echoes_the_models_own_words() {
+        let payload = SolutionFile {
+            message: "POUNCE: SolveSucceeded",
+            x: &[1.0],
+            mult_g: &[],
+            solve_result_num: 0,
+            suffixes: &[],
+        };
+        let text = format_sol_with_options(&payload, &[10, 1, 0]);
+        assert_eq!(options_block(&text), ["3", "10", "1", "0"]);
+    }
+
+    /// With no originating header, a generic block goes out. It must
+    /// still satisfy Pyomo's v2 reader: at least two words, and a second
+    /// word that is not the `3` that signals two extra trailing values.
+    #[test]
+    fn options_block_falls_back_when_there_is_no_header() {
+        let payload = SolutionFile {
+            message: "POUNCE: SolveSucceeded",
+            x: &[1.0],
+            mult_g: &[],
+            solve_result_num: 0,
+            suffixes: &[],
+        };
+        for opts in [vec![], vec![7]] {
+            let text = format_sol_with_options(&payload, &opts);
+            let block = options_block(&text);
+            assert_eq!(block, ["3", "1", "1", "0"], "opts={opts:?}");
+            assert_ne!(block[2], "3", "must not trigger the vbtol quirk");
+        }
+    }
 
     #[test]
     fn writes_basic_primal_dual_block() {

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -50,6 +50,58 @@ import pyomo_pounce
 pyomo_pounce.check_binary()   # prints a report; returns a dict
 ```
 
+### Which *interface* runs — and why it matters for timing
+
+Pyomo has more than one way to drive an NL/SOL solver, and they are
+genuinely different code paths, not aliases. All of these reach POUNCE
+(verified against Pyomo 6.10.1):
+
+| call | works | carries `pyomo-pounce`'s extras |
+|---|---|---|
+| `SolverFactory('pounce')` | yes | **yes** |
+| `SolverFactory('ipopt_v2', executable=<pounce>)` | yes | no |
+| `SolverFactory('ipopt', executable=<pounce>)` | yes | no |
+| `SolverFactory('asl', executable=<pounce>, solver='pounce')` | yes | no |
+| `SolverFactory('appsi_ipopt', …)` | no — takes no `executable` | — |
+
+`SolverFactory('pounce')` is the supported route and the only one that
+brings the rest of this page with it: the `scaling_factor` suffix
+handling, the sensitivity path, the preflight/repair helpers, the guard
+against handing a model with live integer variables to a continuous
+solver, and the bundled-binary resolution above. The generic routes run
+the same solver and return the same answer, but silently do without all
+of that.
+
+`ipopt` and `asl` are Pyomo's *legacy* solver interface; `ipopt_v2` is
+the newer `pyomo.contrib.solver` one. Driving POUNCE through `ipopt_v2`
+needs a build carrying the two ASL-compatibility fixes noted in the
+CHANGELOG under "Pyomo's modern solver interface could not drive POUNCE
+at all" — before them it failed on every model, because Pyomo v2 passes
+options as `key="value"` in a single `argv` entry (quotes and all, since
+no shell is involved) and because POUNCE's `.sol` wrote an `Options`
+count of `0`, which the v2 `.sol` reader rejects.
+
+**If you are benchmarking, put both solvers on the same interface.**
+`solver.solve(model)` is not only the solve: it is Pyomo writing the
+`.nl`, launching the process, reading the `.sol` back and loading it into
+the model. Timing around that call and subtracting the solver's own
+reported time leaves a remainder that is mostly *Pyomo's* work, and it is
+not the same work on every interface. On a 3,010-variable collocation
+model, wall clock around `solve()` for the same POUNCE binary:
+
+| interface | reported solve | remainder | total |
+|---|---|---|---|
+| `SolverFactory('pounce')` (legacy) | 0.223 s | 0.109 s | 0.332 s |
+| `ipopt_v2` | 0.188 s | 0.104 s | 0.292 s |
+
+and that remainder breaks down as ~0.082 s Pyomo writing the `.nl`,
+~0.020 s process spawn plus POUNCE's own `.nl` read and setup, and
+~0.008 s Pyomo reading the `.sol` and loading it. So comparing
+`SolverFactory('pounce')` against `SolverFactory('ipopt_v2', …)` compares
+two Pyomo interfaces as much as two solvers, and attributing the
+remainder to either solver's file handling will mislead you. Use the same
+interface on both sides, or compare the solvers' own reported times.
+
 ## User scaling with the `scaling_factor` Suffix
 
 A badly conditioned model converges poorly, and often you know its


### PR DESCRIPTION
Fixes #554.

Found while exploring #552. **No closing keyword for #552**: this fixes neither
of the two improvement areas that issue reports (per-solve overhead on small
models; FERAL factorization on chain-structured KKT). It fixes three different
problems found while investigating the first of those. #552 should stay open on
its own terms — though the measurement in commit 3 revises what its overhead
section is actually measuring; details posted there.

It does close #554. The dense-Hessian-row fix in commit 1 is the same root cause
#554's per-iteration gap concentrates on: the coloring collapsed to ~one color
per variable on collocation-discretized models, making `eval_h` — not the linear
solver — the dominant per-iteration term, at O(n²) memory. #556 was opened
independently against #554 with the same mechanism and is closed in favor of
this PR; see the review there for why its fixed `max(64, 8 × avg)` threshold
reintroduces the blowup on mixed degree profiles, and why the bound-based
selection here does not. The residual factorization-kernel gap on fixed-horizon
chains stays with #552.

Four commits, independently reviewable:

1. `fa20c20` — a dense Hessian row cost O(n²) in setup and every `eval_h`
2. `0f9a6a3` — `eval_jac_g` on the shared-CSE tape, gated (#476 follow-on)
3. `13e8417` — Pyomo's modern solver interface could not drive POUNCE at all
4. `73edff5` — document the several Pyomo interfaces, and the timing trap

---

# 1. A dense Hessian row cost O(n²) in setup and every `eval_h`

## Problem

`NlTnlp` recovers the Lagrangian Hessian by graph coloring and holds two
`n_colors × n` dense `f64` arrays (`seeds`, `compressed`). A model with a
single **dense Hessian row** — a variable multiplying a sum over all the
others: a total-cost variable, a shared design parameter, a scalar entering
every constraint — makes every pair of columns conflict, so the greedy walk
hands out one color per variable and both arrays go quadratic. The Hessian
itself stays perfectly sparse throughout.

Measured on `min Σ(xⱼ−1)² + x₀·Σxⱼ` alongside a sparse constraint chain,
`nnz_h ≈ 2n`:

| n = 8,010 | before | after |
|---|---|---|
| colors | 8,010 | **6** |
| peak RSS through setup | 1,038 MB | **59 MB** |
| setup wall clock | 2.69 s | **0.18 s** |

| n = 4,010, 10 iterations | before | after |
|---|---|---|
| `LagrangianHessianEvaluations` | 2.069 s | **0.019 s** |
| `OverallAlgorithm` | 2.385 s | **0.284 s** |
| objective | 3.4255625875830601e+03 | *bit-identical* |

Measured peak RSS matched `2·n²·8` bytes to within 1%, so the two arrays were
the entire footprint. That extrapolated to ~6.4 GB at n = 20,000 and an OOM at
the flowsheet sizes in #552. It is now linear in `n`.

## Cause

Two independent O(n²)s, stacked. Fixing only the first leaves RSS quadratic —
which is what happened on the first attempt here.

1. **The coloring.** `greedy_hessian_coloring` is a distance-1 column coloring:
   columns may share a color only when their nonzero rows are disjoint. A dense
   row puts a nonzero in every column at that row, so no two columns are ever
   compatible. `n_colors` collapses to `n`.

2. **`Tape::hessian_sparsity`.** It kept a `BTreeSet` of dependent variables
   alive for *every* tape slot. A long additive chain — precisely what a dense
   row is built from — leaves one full-size set per partial sum and copies the
   whole running set at each union. `split_top_sums` keeps top-level sums out of
   a single tape, so this only bites when the sum feeds an enclosing operator,
   which is exactly the dense case.

## Fix

**Peeling.** Columns whose nonzero-row count exceeds `DENSE_COL_FACTOR` (16)
times the average — never fewer than `DENSE_COL_MIN` (32) entries — become
*candidates* for peeling. A peeled column leaves the coloring and takes a
singleton color: one product with seed `e_d` recovers all of column `d`, and
because `H[d, j] == H[j, d]` that same pass also supplies every entry of row
`d`. Row `d` therefore stops constraining anyone else's color and drops out of
the conflict structure, and the remaining columns color on their real sparsity.
The decode table picks the peeled endpoint's pass when a pair has one.

**Which candidates actually get peeled.** Being far above the average is not the
same as being worth a singleton color. A model with a low-degree bulk and many
medium-degree columns whose row supports are *pairwise disjoint* drags the
average down until the whole medium-degree population clears any fixed
threshold — and peeling them is pure loss, since disjoint supports would have
shared one color. So the candidate list is scored, not thresholded:
`select_peeled_cols` walks a doubling ladder over the degree-sorted candidates
and keeps the prefix minimizing

    peel_color_bound = |peeled| + max surviving row degree

which is a lower bound on the resulting color count (a row with `d` surviving
entries makes those `d` columns pairwise conflict) and costs one O(nnz) pass to
evaluate. `MAX_PEELED_COLS` (256) caps the ladder on top of that.

A plain coloring cannot be used as the comparison baseline here: on the
one-dense-row case the greedy walk is itself O(n²) — for each of `n` columns it
iterates the dense row's `n` columns — which is precisely the blowup peeling
exists to avoid. The decision has to come from a cheap bound.

Measured against a plain greedy coloring of the same pattern, on a degree-3
chain plus pairwise-disjoint dense blocks:

| bulk | blocks | plain | peeled path | peeled |
|---|---|---|---|---|
| 190 000 chain | 100 × 100 | 100 | 100 | 0 |
| 190 000 chain | 200 × 70 | 70 | 70 | 0 |
| 100 000 chain | 50 × 200 | 200 | 200 | 0 |
| 50 000 chain | 20 × 100 | 100 | 100 | 0 |

Exact parity, while the motivating one-dense-row case still collapses to 2
colors (n = 200 and n = 20 000 alike) and three rows of degree 10 000 in a
20 000-variable model still peel — a fraction-of-`n` degree rule would have
refused those.

**Rejected: capping `n_colors` with a fallback evaluator.** It bounds memory but
not the work — the dense summand's tape still gets one directional pass per
color. Peeling removes both, and needs no second code path.

**Slot liveness in `hessian_sparsity`.** Compute last-use per slot up front, then
move a dying operand's set into its consumer instead of copying. A left-leaning
chain now extends one set in place. The `for_each_input` helper driving this is
an exhaustive match with **no catch-all arm**: a future `TapeOp` variant fails to
compile rather than silently reporting "reads nothing", which would drop a live
set and under-report sparsity — a wrong answer that surfaces as a bad search
direction, not a panic. Over-reporting an input is only a missed optimization,
so the doc comment says to list a slot when in doubt.

Also in this commit, as a constant-factor cleanup on the same paths: `parse_expr`
/ `next_data_line` / `eat_segment_header` borrow from the source buffer instead
of allocating a `String` per token and per line (~620k of them for a
20k-variable model); `parse_var_coef` / `parse_bound_line` walk the whitespace
iterator instead of collecting a `Vec` of `&str`; the Hessian-pair,
Jacobian-column and tape-color `BTreeSet`s became `Vec` + `sort_unstable` +
`dedup`; and a `HashMap` built with one entry per Hessian nonzero, read once and
discarded, is gone — decode tables come straight from the sorted pair list,
which also makes the `eval_h` scatter walk `values` forward instead of in
`HashMap` order.

I measured that part against a binary built from the parent commit rather than
estimating it: **total setup on ordinary sparse models moves 1.00–1.07×**. It is
a cleanup, not a speedup; the dense-row case is where it compounds.

---

# 2. `eval_jac_g` on the shared-CSE tape, gated on op ratio

## Problem

`HybridTape` has driven `eval_g` since #476 while `eval_jac_g` stayed on the
flat per-summand tapes, whose CSE bodies are duplicated per reference — so the
4.03× op-count reduction #476 measured was unavailable to the Jacobian.

## Cause of the gate

Wiring it through naively **regresses** low-redundancy models. `eval_g` needs
only values, so the prelude is swept once for the whole constraint block and
the saving is the full op-count ratio. The Jacobian needs a gradient per row,
so only the forward sweep can be shared: the reverse sweep still walks each
summand's `prelude_reach` separately, and it pays a per-op cost the flat tape
does not — a nested `SummandOp` dispatch and an indirected walk over a reach
list instead of a straight loop over a contiguous `Vec` of `TapeOp`.

A clean A/B in one binary (`POUNCE_DBG_NO_HYBRID`), chain model, n ≈ 20,000,
op ratio 2.20×:

| | flat | hybrid |
|---|---|---|
| `eval_g` | 0.975 ms | **0.618 ms** (1.58× faster) |
| `eval_jac_g` | **1.778 ms** | 2.824 ms (1.59× *slower*) |

## Fix

Sweeping body size at CSE redundancy 40 locates the crossover (`eval_jac_g`,
flat → hybrid):

| op ratio | 1.94 | 2.20 | 2.84 | 3.53 | 4.20 | 5.16 | 6.35 | 8.00 |
|---|---|---|---|---|---|---|---|---|
| speedup | 0.77× | 0.63× | 0.88× | 1.21× | 1.21× | 1.18× | 1.50× | 1.32× |

Crossover near 3, so `HYBRID_JAC_MIN_OP_RATIO` is **4** for margin. With the
gate in place the same sweep reads 1.00–1.03× below it (unchanged, flat path)
and 1.13–1.30× above it. `robot_a` measures 4.03×.

## Not done, and why

**`eval_h` is untouched, and it is the larger prize** — ~69% of AD time on
these models against the Jacobian's ~19%. The dormant
`HybridTape::hessian_summand` is the wrong tool for it: it re-walks
`prelude_reach` once per seed variable, so it shares no prelude work at all,
and it scatters through a `HashMap` lookup per emitted pair where the coloring
path writes into a dense buffer. Given that the *Jacobian* only broke even at
op ratio ≈ 3 with the forward sweep shared, a routine sharing nothing and
adding a hash lookup would be worse. Doing it properly means a new directional
routine that accumulates prelude adjoints across all summands and does one
reverse-over-tangent pass over the prelude per color. That is new AD code, not
a wiring change, and wants its own PR.

---

# 3. Pyomo's modern solver interface could not drive POUNCE at all

`SolverFactory('ipopt_v2', executable=PATH)` — the newer `pyomo.contrib.solver`
interface — failed on every model. Two independent gaps, both places where
POUNCE diverged from what the ASL does and every reader therefore expects:

1. **Quoted option values.** The v2 interface builds each option as
   `option_file_name="/tmp/…/x.opt"` (`_option_to_cmd` in
   `pyomo/contrib/solver/solvers/ipopt.py`) and passes it as one `argv` entry.
   With no shell in between the quotes arrive as literal characters. Ipopt's
   ASL option parser strips them; POUNCE did not, so it looked for a file whose
   name began with `"`, failed to load it, and aborted the run. `parse_kv` now
   drops one matching pair of surrounding `"` or `'`; a quote on one side only
   stays content.

2. **The `.sol` `Options` block.** POUNCE wrote a count of `0`. AMPL and
   Pyomo's *legacy* reader accept that, but no ASL solver emits it: the v2
   reader reads the first two option words unconditionally (to detect the
   documented quirk where a second word of `3` means two extra words follow the
   `z` block) and so asserts `n_opts >= 2`. The block is not a constant: a
   solver echoes back **the model's own AMPL option words**, which arrive on
   `.nl` header line 0 as `g<count> <opt0> <opt1> …`. `NlProblem` now carries
   them and the writer emits them verbatim. Checked byte-for-byte against
   Ipopt 3.14.20 `-AMPL` on three models — `arki0003` (`3 10 1 0`),
   `bearing_400` (`3 1 1 0`), `camshape_6400` (`3 10 1 0`) — POUNCE now writes
   what Ipopt writes on each. A hard-coded `3 / 1 / 1 / 0` would have matched
   only `bearing_400`. Models with no usable header option list fall back to
   `3 / 1 / 1 / 0`, which keeps `n_opts >= 2` satisfied.

With both fixed, one model solved through `SolverFactory('pounce')` and through
`SolverFactory('ipopt_v2', executable=PATH)` returns the same objective to 12
digits and identical primal values. This also makes it possible to benchmark
POUNCE against Ipopt through *one* Pyomo interface, which #552's overhead
comparison could not do — that is how these were found.

---

# 4. Documenting the interfaces, and the timing trap

Pyomo has several NL/SOL solver interfaces and they are different code paths,
not aliases. Verified against Pyomo 6.10.1 by running each one, with `PATH`
below standing for the path to the POUNCE binary:

| call | works | carries `pyomo-pounce`'s extras |
|---|---|---|
| `SolverFactory('pounce')` | yes | **yes** |
| `SolverFactory('ipopt_v2', executable=PATH)` | yes | no |
| `SolverFactory('ipopt', executable=PATH)` | yes | no |
| `SolverFactory('asl', executable=PATH, solver='pounce')` | yes | no |
| `SolverFactory('appsi_ipopt', …)` | no — takes no `executable` | — |

The generic routes run the same solver and return the same answer, but silently
do without the `scaling_factor` suffix handling, the sensitivity path, the
preflight/repair helpers, and the guard against handing a model with live
integer variables to a continuous solver. That is worth a user knowing before
they reach for one.

The section also records the timing trap, since it has already caught someone
(#552): `solver.solve(model)` is Pyomo writing the `.nl`, spawning the process,
reading the `.sol` and loading it. Timing around that call and subtracting the
solver's own reported time leaves a remainder that is mostly *Pyomo's* work,
and it is not the same work on every interface — so comparing
`SolverFactory('pounce')` against `SolverFactory('ipopt_v2', …)` compares two
Pyomo interfaces as much as two solvers.

Two claims came back out of the page while writing it, as unverifiable: which
version number the fixes ship in (it points at the CHANGELOG entry instead),
and that `ipopt_v2` is on track to become the default `ipopt` (that is Pyomo's
roadmap, not something I checked).

---

## Blast radius

Bit-identical except the targeted cases. All **62 `.nl` fixtures** in the
repository return an identical objective and exit status under a parent-commit
binary and this one, including the dense model (same 17 digits, same iteration
count). A banded Hessian peels nothing and colors by its bandwidth exactly as
before; peak RSS on a sparse n = 20,010 chain is 127 MB on both. `pounce verify`
still round-trips a `.sol` POUNCE wrote, and Pyomo's legacy reader — which
accepted the old `Options 0` — accepts the new block too (it is the same shape
every other ASL solver emits).

**These changes do not speed up the models in #552, and I checked rather than
assuming.** Old binary vs new through the same Pyomo path, quad_tank at the
horizons that issue reports, median of 5: 1.00× / 0.99× / 1.03× on total, same
iteration count. The reason is structural — inspecting the `.nl` Pyomo writes
for that model, there are **zero `V` segments** (no shared CSE bodies, so the
hybrid tape is never built and the Jacobian gate cannot fire) and
**`n_colors = 1`** (the coloring was already optimal, so peeling has nothing to
peel), with `avg_ops = 4.0`. The fixes target model shapes these three do not
have. Whether the two flowsheet models in #552 have either shape is unknown and
cheap to check — `POUNCE_DBG_TAPE_STATS=1 pounce model.nl max_iter=0` prints
both numbers — but needs IDAES to build them.

**Coverage gap worth naming:** *no repository fixture has a CSE shared across
constraints* — I checked all 62. So neither the new Jacobian path nor the
existing `eval_g` hybrid path has any fixture coverage; both are covered by
unit tests only, and the 62-fixture sweep proves no regression rather than
proving the new path correct.

`docs/src/pyomo.md` gains a section (commit 4); it is an existing page, so
`SUMMARY.md` is unchanged. No user-facing option is added and no solver default
changes.

## Tests

Hessian coloring:

- `a_dense_hessian_row_does_not_explode_the_coloring` — the real regression
  test. **Verified to fail on the parent commit for the stated reason**: the
  exact model it builds (n = 200) colors in 200 colors there versus 2 here,
  with `nnz_h = 399` both ways, so the `seeds.len() <= 4` assertion fails
  with 200.
- `peeled_dense_column_still_recovers_the_exact_hessian` — every recovered
  entry against the closed-form Hessian, including entries read out of a peeled
  column's pass by symmetry. **Passes on the parent**: a correctness guard on
  the new recovery rule, not a regression test, and the test that would catch a
  wrong peeling rule.
- `a_sparse_hessian_is_colored_by_its_bandwidth_not_peeled` — pins the
  no-regression direction. Does not compile against the parent (the coloring
  signature gained the peeled mask), so "fails pre-fix" does not apply.
- `thousands_of_medium_degree_cols_are_not_peeled`,
  `a_few_truly_dense_rows_are_still_peeled`,
  `peeling_is_capped_and_keeps_the_worst_offenders` — pin the selection rule
  from both sides: a disjoint-block model must peel nothing, three degree-10 000
  rows in a 20 000-variable model must still peel, and the cap must keep the
  highest-degree candidates. The first fails against a fixed threshold with no
  pay-for-itself check.
- `header_option_words_are_kept_verbatim`,
  `a_truncated_option_list_is_dropped_not_padded`,
  `options_block_echoes_the_models_own_words`,
  `options_block_falls_back_when_there_is_no_header` — the header parse and the
  `.sol` emission, including the fallback that keeps `n_opts >= 2` valid.

Jacobian:

- `shared_cse_jacobian_matches_flat_tape_bit_for_bit` — forces the path on
  below the gate; asserts exact equality with the flat tapes plus the closed
  form.
- `a_deep_shared_body_turns_the_jacobian_gate_on_and_still_agrees` — a 40-deep
  shared body over 16 rows trips the gate by itself; asserts exact equality
  with the flat tapes on the gate-on path.
- `a_small_shared_body_leaves_the_jacobian_on_the_flat_path` — pins the gate
  staying off where the hybrid would lose.

Pyomo interop:

- `parse_kv_strips_the_quotes_a_driver_added` — the `key="value"` forms Pyomo
  v2 emits, including the one-sided-quote case that must stay content.
- `writes_basic_primal_dual_block` — updated to pin the ASL option block.

The `for_each_input` exhaustiveness guarantee is enforced by the compiler
rather than by a test, which is the stronger pin — but it means a variant added
with the wrong operand list would still slip through, and no test pins that.
The two Pyomo interop fixes are pinned by unit tests, not by an end-to-end
Pyomo test — Pyomo is not a dev-dependency of this workspace, and I did not add
one for this. The interface table in commit 4 was produced by running each
call against Pyomo 6.10.1 by hand; nothing in CI re-checks it, so it will go
stale when Pyomo renames an interface.

`cargo fmt --all -- --check` clean, `cargo clippy` introduces no new warnings
(checked hunk-by-hunk against the diff ranges), 111 test suites green across
`pounce-nl` / `pounce-cli` / `pounce-algorithm` with zero failures,
`scripts/check-release-consistency.sh` OK. (`hs071_max_cpu_time_terminates`
failed once under concurrent load — it is a CPU-time-limit test; it passes in
isolation and on a clean full run.) CI on this branch is green: 12/12 check runs
on `73edff5`.

## Instruments

Added so the tables above are reproducible rather than asserted:

- `POUNCE_DBG_NO_HYBRID=1` — force the flat per-summand path.
- `POUNCE_DBG_TAPE_STATS=1` now also prints flat-versus-shared constraint op
  counts, which is the gate's own input.
- `cargo run --release -p pounce-nl --example adbench -- model.nl [reps]` —
  times `eval_g` / `eval_grad_f` / `eval_jac_g` / `eval_h` in isolation, with
  no solver dynamics confounding the measurement.

---

- [x] Tests fail on the parent commit for the stated reason — one of eight; the others are scoped above
- [x] `CHANGELOG.md` `[Unreleased]` entries, in the user's terms
- [x] Book page updated — `docs/src/pyomo.md`, an existing page, so `SUMMARY.md` needs no change
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this body is true of the code as it stands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TEe95bNcfxEBpgcvZTvWNx
