### PR TITLE
fix(nl): peel dense columns in the Hessian coloring so a dense row can't force ~n colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — Hessian coloring no longer collapses to ~n colors on models with a dense Hessian row (#554)
+
+The `.nl` evaluator recovers the Lagrangian Hessian from compressed
+Hessian-vector products, one per color of a greedy distance-1 coloring of
+the column-intersection graph (Coleman–Moré direct recovery). A column
+whose Hessian row is **dense** — the free-time `step`/`tf` variable of a
+COPS-style optimal-control model, which multiplies every collocation
+equation, or any shared design parameter — makes *every pair* of columns
+adjacent through that one shared row. The intersection graph degenerates
+toward a clique, the coloring toward one color per variable, and since
+the seed and compressed buffers are each `n_colors × n` doubles, memory
+and per-evaluation zeroing cost turn O(n²): `rocket_12800` (n = 51 205)
+needed ~42 GB and was OOM-killed on a 15 GB machine, and on instances
+that fit, `eval_h` — not the linear solver — was the dominant
+per-iteration cost that #554 measured (5.07 s of a 6.85 s
+`rocket_3200` solve).
+
+The coloring now **peels dense columns first**: any column whose degree
+exceeds `max(64, 8 × average degree)` gets an exclusive color, whose
+product `H·e_j` is the exact symmetric column j. The remaining columns
+are colored as before, except that conflicts routed *through a peeled
+row* are ignored — those entries decode from the peeled column's
+exclusive product instead, so recovery stays exact. With `p` peeled
+columns the color count drops from ~n to `p + χ(rest)`. The threshold is
+conservative by design: a mesh/stencil model (uniform degree) never
+trips it and keeps its historical coloring bit for bit.
+
+On `rocket_3200`, colors drop 12 800 → 5, Lagrangian-Hessian time
+5.07 s → 0.28 s, and the whole solve 6.85 s → 1.83 s, with an identical
+iterate path (same 30 iterations, objective equal to all printed
+digits). `rocket_12800` and `steering_12800` — the two cleanest signals
+in #554, previously requiring tens of GB — now solve in ~7.5 s at
+~310 MB peak. The remaining per-iteration gap against MA57 on
+fixed-horizon collocation chains is the factorization-kernel question
+tracked in #552.
+
 ### Fixed — the filter's `theta_max` ceiling is now raised on demand instead of blocking a solve forever (#476, #546)
 
 The filter rejects any trial iterate whose constraint violation exceeds

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -2395,7 +2395,7 @@ fn split_top_sums(expr: &Expr) -> Vec<Expr> {
 }
 
 /// Greedy column coloring of a symmetric sparsity pattern stored
-/// as lower-triangle pairs.
+/// as lower-triangle pairs, with dense-column peeling.
 ///
 /// Builds the column-intersection graph: columns `c1` and `c2` are
 /// adjacent iff there exists a row `r` with `H[r, c1] != 0` and
@@ -2405,13 +2405,43 @@ fn split_top_sums(expr: &Expr) -> Vec<Expr> {
 /// pairwise disjoint row supports, so a single H·s product
 /// recovers them all unambiguously.
 ///
-/// Returns `(var_color, n_colors)` where `var_color[k]` is the
-/// color assigned to variable `k`, or `u32::MAX` for variables
-/// not in any Hessian pair (they contribute nothing and don't
-/// need a color).
-fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32>, usize) {
+/// **Dense-column peeling (pounce#554).** A column whose degree is
+/// far above the average — the free-time `step`/`tf` variable of a
+/// COPS-style optimal-control model couples with *every* state, so
+/// its Hessian row is dense — makes every pair of columns adjacent
+/// through that shared row, collapsing the intersection graph
+/// toward a clique and the coloring toward `n` colors. Since the
+/// seed and compressed buffers are `n_colors × n`, that is O(n²)
+/// memory and O(n²) zeroing per `eval_h` (rocket_12800: ~42 GB,
+/// OOM). The classical remedy: peel such columns out first, giving
+/// each an **exclusive** color whose product `H·e_j` recovers the
+/// whole symmetric column j directly, and color the remaining graph
+/// while ignoring conflicts routed through peeled rows — those
+/// entries are decoded from the peeled column's side instead (see
+/// the decode-table construction in `NlTnlp::try_new`). With p
+/// peeled columns the count drops to `p + χ(rest)`; for the
+/// collocation models that is ~5 instead of ~n.
+///
+/// Recovery stays exact: a lower pair `(i, j)` with `j` (or `i`)
+/// peeled reads `H[i, j]` out of the peeled column's exclusive
+/// product, and a pair with both sparse decodes from `color(j)` at
+/// row `i`, which cannot collide — any column sharing the
+/// (non-peeled) row `i` with `j` was seen by the conflict scan and
+/// forced into a different color.
+///
+/// Returns `(var_color, n_colors, is_dense)` where `var_color[k]`
+/// is the color assigned to variable `k`, or `u32::MAX` for
+/// variables not in any Hessian pair (they contribute nothing and
+/// don't need a color), and `is_dense[k]` marks peeled columns
+/// (each alone in its color). When no column crosses the peeling
+/// threshold the coloring is identical to the historical un-peeled
+/// one.
+fn greedy_hessian_coloring(
+    n: usize,
+    lower_pairs: &[(usize, usize)],
+) -> (Vec<u32>, usize, Vec<bool>) {
     if n == 0 {
-        return (Vec::new(), 0);
+        return (Vec::new(), 0, Vec::new());
     }
 
     // For each variable k, list of rows in which column k has a
@@ -2429,21 +2459,64 @@ fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32
         }
     }
 
+    // Peel columns whose degree dwarfs the average. The threshold is
+    // deliberately conservative — max(64, 8·avg) — so a mesh/stencil
+    // model (degree ≈ stencil size, uniform) never trips it and keeps
+    // its historical coloring bit-for-bit; only genuinely dense
+    // rows/columns (free-time variables, shared design parameters)
+    // are peeled. Each peeled column costs exactly one extra H·s
+    // product per eval, which a dense column costs under any exact
+    // scheme.
+    let mut is_dense = vec![false; n];
+    let nz_cols = col_rows.iter().filter(|r| !r.is_empty()).count();
+    if nz_cols > 0 {
+        let total_deg: usize = col_rows.iter().map(|r| r.len()).sum();
+        let avg_deg = total_deg as f64 / nz_cols as f64;
+        let threshold = (8.0 * avg_deg).max(64.0);
+        for j in 0..n {
+            if col_rows[j].len() as f64 > threshold {
+                is_dense[j] = true;
+            }
+        }
+    }
+
     let mut var_color = vec![u32::MAX; n];
-    let mut forbidden = vec![u32::MAX; n + 1];
     let mut n_colors: u32 = 0;
+
+    // Exclusive colors 0..p for the peeled columns. The greedy pass
+    // below starts at `first_shared` so no sparse column ever joins
+    // a peeled color and the `H·e_j` products stay pure columns.
+    for j in 0..n {
+        if is_dense[j] {
+            var_color[j] = n_colors;
+            n_colors += 1;
+        }
+    }
+    let first_shared = n_colors;
+
+    let mut forbidden = vec![u32::MAX; n + 1];
 
     for j in 0..n {
         // Variable `j` has no Hessian entries → skip (no color).
-        if col_rows[j].is_empty() {
+        // Peeled columns already hold their exclusive color.
+        if col_rows[j].is_empty() || is_dense[j] {
             continue;
         }
         // Mark colors used by any column sharing a row with `j`.
         // Row-of-col -> col-in-row visit pattern collects all
         // distance-1 neighbors in the column-intersection graph.
+        // Conflicts routed through a peeled row are skipped: those
+        // Hessian entries are decoded from the peeled column's
+        // exclusive product, never from a shared color, so they
+        // impose no constraint here. Peeled neighbor columns are
+        // likewise irrelevant (their colors are below
+        // `first_shared`, which the greedy never picks).
         for &r in &col_rows[j] {
+            if is_dense[r as usize] {
+                continue;
+            }
             for &c in &row_cols[r as usize] {
-                if c as usize == j {
+                if c as usize == j || is_dense[c as usize] {
                     continue;
                 }
                 let cc = var_color[c as usize];
@@ -2452,8 +2525,8 @@ fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32
                 }
             }
         }
-        // First color not stamped with `j as u32`.
-        let mut chosen: u32 = 0;
+        // First shared color not stamped with `j as u32`.
+        let mut chosen: u32 = first_shared;
         while (chosen as usize) < forbidden.len() && forbidden[chosen as usize] == j as u32 {
             chosen += 1;
         }
@@ -2463,7 +2536,7 @@ fn greedy_hessian_coloring(n: usize, lower_pairs: &[(usize, usize)]) -> (Vec<u32
         }
     }
 
-    (var_color, n_colors as usize)
+    (var_color, n_colors as usize, is_dense)
 }
 
 impl NlTnlp {
@@ -2578,7 +2651,7 @@ impl NlTnlp {
         // Hessian-vector products we need per `eval_h` call —
         // typically O(stencil) for PDE-mesh problems.
         let lower_pairs: Vec<(usize, usize)> = pairs.iter().copied().collect();
-        let (var_color, n_colors) = greedy_hessian_coloring(prob.n, &lower_pairs);
+        let (var_color, n_colors, is_dense) = greedy_hessian_coloring(prob.n, &lower_pairs);
 
         // Per-color seed vectors (dense for O(1) Var lookup in
         // `Tape::hessian_directional`).
@@ -2594,15 +2667,29 @@ impl NlTnlp {
         // computing compressed_{c_j} = (H · s_{c_j}), the value at
         // row i is exactly H[i, j] (coloring guarantees no other
         // column in c_j has a nonzero at row i).
+        //
+        // Peeled-column exception (pounce#554): a pair whose row `i`
+        // is a peeled (dense) column but whose column `j` is not must
+        // decode from the *peeled* side — `H[i, j] = H[j, i]`, read at
+        // row j of column i's exclusive `H·e_i` product. Row `i` of a
+        // shared color may mix several columns' entries (the conflict
+        // scan deliberately ignores peeled rows), so it must never be
+        // read. Pairs whose column `j` is peeled already sit in an
+        // exclusive color and decode as usual.
         let mut decoding: Vec<Vec<ColorWrite>> = vec![Vec::new(); n_colors];
         for (&(i, j), &idx) in hess_map.iter() {
-            let c = var_color[j];
+            let (col, row) = if is_dense[i] && !is_dense[j] {
+                (i, j)
+            } else {
+                (j, i)
+            };
+            let c = var_color[col];
             debug_assert!(
                 c != u32::MAX,
-                "column {j} has Hessian pair {idx} but no color"
+                "column {col} has Hessian pair {idx} but no color"
             );
             decoding[c as usize].push(ColorWrite {
-                row: i as u32,
+                row: row as u32,
                 hess_idx: idx as u32,
             });
         }
@@ -2672,10 +2759,12 @@ impl NlTnlp {
             let nnz_h = h_irow.len();
             let avg_decode =
                 decoding.iter().map(|d| d.len()).sum::<usize>() as f64 / n_colors.max(1) as f64;
+            let n_dense = is_dense.iter().filter(|&&d| d).count();
             eprintln!(
                 "[tape stats] summands={total} (obj={n_obj} con={n_con}) \
                  total_ops={sum_ops} avg_ops={:.1} max_ops={max_tape_n} \
-                 n_colors={n_colors} avg_decode_per_color={avg_decode:.1} nnz_h={nnz_h}",
+                 n_colors={n_colors} dense_cols={n_dense} \
+                 avg_decode_per_color={avg_decode:.1} nnz_h={nnz_h}",
                 sum_ops as f64 / t as f64,
             );
         }
@@ -5447,5 +5536,123 @@ G0 3
         t.hessian_vector_product(&[1.0], &[1.0], 1.0, None, &mut out)
             .expect("hvp");
         assert!((out[0] + 2.0).abs() < 1e-12, "out = {out:?}");
+    }
+
+    /// A hub column (dense Hessian row — the free-time variable of a
+    /// collocation model) must be peeled into an exclusive color
+    /// instead of collapsing the column-intersection graph to a
+    /// clique and the coloring to ~n colors (pounce#554: the seed and
+    /// compressed buffers are `n_colors × n`, so rocket_12800 needed
+    /// ~42 GB and OOM'd).
+    #[test]
+    fn dense_column_peeling_caps_colors() {
+        // Star pattern: hub column 0 couples with every other
+        // variable; everyone has a diagonal. Un-peeled, every pair of
+        // columns shares row 0 → all 200 columns conflict → 200
+        // colors. Peeled, the hub takes one exclusive color and the
+        // rest — pairwise disjoint once hub-routed conflicts are
+        // ignored — share one.
+        let n = 200;
+        let mut pairs: Vec<(usize, usize)> = (0..n).map(|j| (j, j)).collect();
+        pairs.extend((1..n).map(|j| (j, 0)));
+        let (var_color, n_colors, is_dense) = greedy_hessian_coloring(n, &pairs);
+        assert!(is_dense[0], "hub column must be peeled");
+        assert!(!is_dense[1], "spoke columns must not be peeled");
+        assert!(
+            n_colors <= 3,
+            "peeling must cap the coloring; got {n_colors} colors"
+        );
+        // The hub's color is exclusive — the H·e_hub product must be a
+        // pure column for the decode to be exact.
+        let hub_color = var_color[0];
+        assert!(
+            (1..n).all(|j| var_color[j] != hub_color),
+            "no spoke may share the hub's color"
+        );
+
+        // A uniform-degree chain (no dense column) keeps the
+        // historical behavior: nothing peeled.
+        let chain: Vec<(usize, usize)> = (0..n)
+            .map(|j| (j, j))
+            .chain((1..n).map(|j| (j, j - 1)))
+            .collect();
+        let (_, chain_colors, chain_dense) = greedy_hessian_coloring(n, &chain);
+        assert!(chain_dense.iter().all(|&d| !d), "chain must not peel");
+        assert!(chain_colors <= 3, "chain colors: {chain_colors}");
+    }
+
+    /// End-to-end `eval_h` exactness through the peeled-column decode
+    /// path: `min Σ_i t·x_i²` has ∂²/∂x_i² = 2t and the mixed
+    /// ∂²/(∂t ∂x_i) = 2x_i sitting in the hub variable's dense row,
+    /// which is recovered from the peeled column's exclusive `H·e_t`
+    /// product rather than a shared color.
+    #[test]
+    fn dense_hub_hessian_evaluates_exactly() {
+        // Var 0 is the hub `t`; vars 1..=N are the spokes.
+        let nspokes = 100;
+        let n = nspokes + 1;
+        let obj = Expr::Sum(
+            (1..=nspokes)
+                .map(|i| bin(BinOp::Mul, v(0), bin(BinOp::Pow, v(i), c(2.0))))
+                .collect(),
+        );
+        let prob = NlProblem::from_expressions(parts(n, obj, Vec::new())).expect("build");
+        let mut t = NlTnlp::try_new(prob).expect("tnlp");
+        let info = t.get_nlp_info().unwrap();
+        let nnz = info.nnz_h_lag as usize;
+
+        let (mut irow, mut jcol) = (vec![0_i32; nnz], vec![0_i32; nnz]);
+        assert!(t.eval_h(
+            None,
+            false,
+            1.0,
+            None,
+            false,
+            SparsityRequest::Structure {
+                irow: &mut irow,
+                jcol: &mut jcol
+            }
+        ));
+
+        // The model must actually exercise the peeled path: the hub's
+        // degree (nspokes) is far past max(64, 8·avg).
+        let lower: Vec<(usize, usize)> = (0..nnz)
+            .map(|k| (irow[k] as usize, jcol[k] as usize))
+            .collect();
+        let (_, n_colors, is_dense) = greedy_hessian_coloring(n, &lower);
+        assert!(is_dense[0], "hub variable must be peeled");
+        assert!(n_colors <= 4, "colors must stay bounded; got {n_colors}");
+
+        let mut x = vec![0.0; n];
+        x[0] = 0.7; // t
+        for i in 1..=nspokes {
+            x[i] = 0.01 * i as f64 - 0.3;
+        }
+        let obj_factor = 1.5;
+        let mut hvals = vec![0.0_f64; nnz];
+        assert!(t.eval_h(
+            Some(&x),
+            true,
+            obj_factor,
+            None,
+            true,
+            SparsityRequest::Values { values: &mut hvals }
+        ));
+
+        for k in 0..nnz {
+            let (i, j) = (irow[k] as usize, jcol[k] as usize);
+            let expect = if i == j && i >= 1 {
+                2.0 * obj_factor * x[0] // ∂²(t·x_i²)/∂x_i²
+            } else if j == 0 && i >= 1 {
+                2.0 * obj_factor * x[i] // ∂²(t·x_i²)/(∂t ∂x_i)
+            } else {
+                0.0 // structural (t,t) if present
+            };
+            assert!(
+                (hvals[k] - expect).abs() < 1e-12,
+                "H[{i},{j}] = {} but expected {expect}",
+                hvals[k]
+            );
+        }
     }
 }


### PR DESCRIPTION
Fixes #554

## Problem

The per-iteration cost gap #554 tracks concentrates in collocation-discretized models, with `steering_12800` / `rocket_12800` as the cleanest signals (~8.5× IPOPT+MA57 wall at identical iteration counts). Profiling those instances (regenerated at the same `nh` via Pyomo) shows the dominant term is **not** the linear solver: on `rocket_3200`, `LagrangianHessianEvaluations` is 5.07 s of a 6.85 s solve (76%), against 1.20 s of factorization. The cost is also O(n²) in both time and memory — `rocket_12800` (n = 51 205) allocates ~42 GB and is OOM-killed on a 15 GB machine, even though #554 records it solving in 15.8 s on a larger one.

| rocket_3200 (n = 12 805) | status | objective | iters | Hessian eval | total solve | peak RSS |
|---|---|---|---|---|---|---|
| before | Optimal | -1.0128257882438041 | 30 | 5.07 s | 6.85 s | 2 582 MB |
| after | Optimal | -1.0128257882438041 | 30 | 0.28 s | 1.83 s | ~180 MB |

| 12 800-point instances | before | after |
|---|---|---|
| `rocket_12800` | OOM-killed (>15 GB) | Optimal, 30 iters, 7.6 s, 310 MB |
| `steering_12800` | OOM-killed (>15 GB) | Optimal, 15 iters, 7.3 s, 318 MB |

The 30-iteration count on `rocket_12800` matches the 30/30 recorded in #554, so this is the same convergence path the benchmark measured.

## Cause

The `.nl` evaluator recovers the Lagrangian Hessian from compressed Hessian-vector products, one per color of a greedy distance-1 coloring of the column-intersection graph (Coleman–Moré direct recovery). Columns `c1`, `c2` are adjacent iff they share any nonzero row. A column whose Hessian row is **dense** — the free-time `step`/`tf` variable of a COPS-style optimal-control model, which multiplies every collocation equation — makes *every pair* of columns adjacent through that one shared row. The intersection graph degenerates to a clique and the coloring to ~one color per variable: `POUNCE_DBG_TAPE_STATS` reports **n_colors = 12 800** on `rocket_3200` and 9 599 on `steering_3200`, versus 4 with `step` fixed. Since the seed and compressed buffers are each `n_colors × n` doubles, memory is O(n²) (2 × 12 805² × 8 B = 2.6 GB — exactly the observed 2 582 MB plateau) and `eval_h` zeroes all of it per call (~130 ms of the ~168 ms per-eval cost).

## Fix

`greedy_hessian_coloring` now **peels dense columns first**: any column whose full-symmetric degree exceeds `max(64, 8 × average degree)` gets an exclusive color. Its product `H·e_j` is the exact symmetric column j, so every entry in a peeled row/column decodes from the exclusive product. The remaining columns are colored by the same greedy pass as before, except conflicts routed *through a peeled row* are ignored — those entries never decode from a shared color, so direct recovery stays exact: for a pair `(i, j)` with both columns sparse, any column sharing the (non-peeled) row `i` with `j` is still seen by the conflict scan and forced into a different color. With `p` peeled columns the count drops from ~n to `p + χ(rest)` — 5 on `rocket_3200`.

A peeled color costs one extra H·s product per eval, which a dense column costs under any exact scheme — that is the floor, not an overhead.

The threshold is deliberately conservative (`max(64, 8×avg)`): a mesh/stencil model has uniform degree ≈ stencil size and never trips it, so the peeling can only fire on columns that are genuinely far out of family. Rejected alternative: routing dense models to the matrix-free HVP path instead — that changes the algorithm's linear-system interface per model class, where peeling is a strictly local change to color assignment and decode routing with an empty-set no-op on every existing model.

## Blast radius

`.nl`-driven evaluation only (`pounce-nl`); the tape, HVP, gradient, and Jacobian paths are untouched. When no column crosses the threshold, `is_dense` is all-false, the greedy starts at color 0, and both the coloring and the decode tables are **bit-for-bit the historical ones** — models without a dense Hessian row cannot observe this change. On the affected models the recovered Hessian is exact, pinned by the identical iterate path above (same iterations, objective equal to all printed digits, NLP error unchanged).

Not addressed here: the 3.5–4.8× factorization-kernel gap on *fixed*-horizon chains (hicks/quad_tank/cart_pole) measured in #552 lives in the `feral` crate (pinned at 0.14.0, the latest release) and remains with #552. After this fix, factorization is the dominant remaining term on the 12 800-point instances (~5 s of ~7.5 s), so #552 is the next lever. A re-run of the 47-instance Mittelmann sweep would be the definitive check on #554's matched-iteration statistic; this environment cannot fetch the AMPL sources (plato.asu.edu egress-blocked).

## Tests

- `dense_column_peeling_caps_colors` — star pattern (hub + 199 spokes): asserts the hub is peeled, spokes are not, `n_colors ≤ 3`, and the hub's color is exclusive; also asserts a uniform chain peels nothing. Fails on the parent commit for the stated reason: un-peeled, the star colors to 200 (the test does not compile against the parent's 2-tuple signature; ported to it, the `n_colors ≤ 3` assert is what fails).
- `dense_hub_hessian_evaluates_exactly` — end-to-end `eval_h` on `min Σ t·x_i²` (101 vars, hub degree 100): asserts the hub is actually peeled and every recovered entry matches the analytic Hessian to 1e-12. This pins the *new decode routing's* exactness; it passes on the parent too (the old path was exact, just O(n²)) — the performance component is pinned by the coloring test's cap, not by a timing assertion, which would be flaky.

`cargo fmt --all -- --check`, `cargo clippy` (CI lint set), and `cargo test --workspace --exclude pounce-hsl` are clean.

---

- [x] Tests fail on the parent commit for the stated reason (`dense_column_peeling_caps_colors`; the exactness test is a correctness pin, see Tests)
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` — not updated: no user-facing option or documented behavior changed; the coloring is internal to the `.nl` evaluator
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HzCfuP37kNMCseKRbAJkqW

---
_Generated by [Claude Code](https://claude.ai/code/session_01HzCfuP37kNMCseKRbAJkqW)_