### PR TITLE
perf(nl): route eval_h through the shared-CSE tape, amortizing prelude second-order work per color (#557)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,59 @@ changes.
 
 ## [Unreleased]
 
+### Changed — `eval_h` routes through the shared-CSE tape, amortizing prelude second-order work across summands (#557)
+
+The follow-on to #476 (`eval_g`) and #553 (`eval_jac_g`): the Lagrangian
+Hessian — the largest of the three evaluators by a wide margin, 66–69% of
+AD time on shared-CSE chain models — now takes the `HybridTape` path too,
+above its own measured op-ratio gate.
+
+Unlike the Jacobian, the Hessian can share **both** second-order sweeps of
+the prelude, which is why its crossover sits lower. The coloring hands
+every summand of a color the same seed vector `s_c`, so per color the
+prelude forward tangent runs once for the whole constraint block; and
+because reverse-over-tangent is linear in its adjoint seeds, each summand
+folds its row multiplier `λ_k` into the adjoints it deposits at `Shared`
+boundaries, and one unit-weight prelude reverse sweep per color replaces
+the per-summand sweeps. The per-summand local ops keep the exact
+arithmetic of the flat tape (`ror_dir_step` mirrors
+`Tape::hessian_directional`'s arms, writing into the dense per-color
+`compressed` buffer — no hashing), so the local contributions are
+bit-identical; the folded prelude sweep is mathematically identical and
+agrees to rounding, which the tests pin as exact equality on
+all-dyadic-arithmetic models and a few-ULP band on transcendental ones.
+
+Measured on chain models with CSE redundancy 40, varying the shared body
+size (`eval_h`, flat → hybrid, n ≈ 21,000, m = 20,000):
+
+| flat/shared op ratio | 1.94 | 2.54 | 3.12 | 3.69 | 4.24 | 5.29 | 6.76 | 8.53 |
+|---|---|---|---|---|---|---|---|---|
+| speedup | 1.04× | 1.11× | 1.30× | 1.36× | 1.33× | 1.56× | 1.50× | 1.63× |
+
+At 1.94 repeated runs straddle 1.0× — break-even inside timing noise,
+never a clear loss. The gate (`HYBRID_HESS_MIN_OP_RATIO`) is set at 2.5,
+below the Jacobian's 4, and low-ratio models stay bit-identical on the
+flat path. At ratio 4.24 with all default gates the whole AD stack drops
+34.6 → 23.8 ms/call (`eval_h` 24.8 → 18.3). Models without shared CSE
+bodies — including everything Pyomo writes, which has no `V` segments —
+never build the hybrid tape and are untouched.
+
+The dormant `HybridTape::hessian_summand` is **removed**. It was the
+wrong tool for this and had never had a caller: it re-walked
+`prelude_reach` once per seed variable (sharing no prelude work at all)
+and scattered through a `HashMap` lookup per emitted pair. Its
+replacements are `prelude_tangent` / `hessian_summand_directional` /
+`prelude_reverse_directional`.
+
+Instrumentation and coverage: `POUNCE_DBG_FORCE_HYBRID_HESS=1` forces the
+Hessian gate on (the crossover table's measurement instrument, paired
+with the existing `POUNCE_DBG_NO_HYBRID=1` flat forcing);
+`POUNCE_DBG_TAPE_STATS=1` now prints both gates' on/off state. The
+shared-CSE paths also gain their first end-to-end coverage — no
+repository fixture had a CSE shared across constraints, all 62 checked —
+via a generated model whose one defined variable feeds 16 rows, solved
+through the CLI both hybrid and flat to the same analytic optimum.
+
 ### Fixed — a single dense Hessian row made `.nl` setup and every `eval_h` O(n²) (#552)
 
 `NlTnlp` recovers the Lagrangian Hessian by graph coloring: columns whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,19 +32,34 @@ agrees to rounding, which the tests pin as exact equality on
 all-dyadic-arithmetic models and a few-ULP band on transcendental ones.
 
 Measured on chain models with CSE redundancy 40, varying the shared body
-size (`eval_h`, flat → hybrid, n ≈ 21,000, m = 20,000):
+size (`eval_h`, flat → hybrid, n ≈ 21,000, m = 20,000). Median of 5
+interleaved flat/hybrid pairs per point, with the observed range:
 
 | flat/shared op ratio | 1.94 | 2.54 | 3.12 | 3.69 | 4.24 | 5.29 | 6.76 | 8.53 |
 |---|---|---|---|---|---|---|---|---|
-| speedup | 1.04× | 1.11× | 1.30× | 1.36× | 1.33× | 1.56× | 1.50× | 1.63× |
+| median speedup | 1.00× | 1.04× | 1.18× | 1.23× | 1.31× | 1.44× | 1.36× | 1.49× |
+| min–max | 0.91–1.11 | 0.36–1.14 | 1.10–1.33 | 1.16–1.30 | 1.23–1.32 | 1.19–1.54 | 1.27–1.50 | 1.36–1.65 |
 
-At 1.94 repeated runs straddle 1.0× — break-even inside timing noise,
-never a clear loss. The gate (`HYBRID_HESS_MIN_OP_RATIO`) is set at 2.5,
-below the Jacobian's 4, and low-ratio models stay bit-identical on the
-flat path. At ratio 4.24 with all default gates the whole AD stack drops
-34.6 → 23.8 ms/call (`eval_h` 24.8 → 18.3). Models without shared CSE
-bodies — including everything Pyomo writes, which has no `V` segments —
-never build the hybrid tape and are untouched.
+The medians are what the threshold is set from: single runs on a shared
+machine scatter too widely to place a gate on — the 2.54 column spans
+0.36× to 1.14×. The gate (`HYBRID_HESS_MIN_OP_RATIO`) sits at 3.0, the
+lowest ratio where every sample wins by at least 10%; below it `eval_h`
+stays on the flat path bit-identically, so a gate set high is merely
+conservative while one set low risks a real regression. With all default
+gates the whole AD stack at ratio 4.24 speeds up 1.25× (median of 5
+interleaved pairs, range 1.14–1.44). Models without shared CSE bodies —
+including everything Pyomo writes, which has no `V` segments — never
+build the hybrid tape and are untouched.
+
+The two prelude sweeps run once per Hessian color, so they walk the union
+of that color's summands' `prelude_reach` rather than the whole prelude.
+Walking all of it would cost `n_colors × |prelude|` where the op-ratio
+gate assumes `|prelude|` — a discrepancy the gate cannot see, unbounded
+in `n_colors`. On the chain models above this is neutral (every color
+reaches nearly every body there, so there is nothing to skip: 1.02× at
+ratio 4.24, 1.12× at 8.53); it is insurance for models where a color
+reaches only part of the prelude, which a unit test on two shared bodies
+of differing width exercises directly.
 
 The dormant `HybridTape::hessian_summand` is **removed**. It was the
 wrong tool for this and had never had a caller: it re-walked

--- a/crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs
+++ b/crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs
@@ -105,8 +105,10 @@ fn shared_cse_model_nl(m: usize, pairs: usize) -> String {
 }
 
 /// Solve the generated model, optionally with `POUNCE_DBG_NO_HYBRID=1`,
-/// returning the parsed report.
-fn solve(no_hybrid: bool) -> SolveReport {
+/// returning the parsed report and the `[hybrid stats]` line from stderr
+/// (`POUNCE_DBG_TAPE_STATS=1` is always on so the caller can assert which
+/// paths the solve actually took).
+fn solve(no_hybrid: bool) -> (SolveReport, String) {
     let nl_path = tmp_path("model.nl");
     std::fs::write(&nl_path, shared_cse_model_nl(M, PAIRS)).expect("write model");
     let json_path = tmp_path("report.json");
@@ -115,20 +117,30 @@ fn solve(no_hybrid: bool) -> SolveReport {
     cmd.arg(&nl_path)
         .arg(&sol_path)
         .arg("--json-output")
-        .arg(&json_path);
+        .arg(&json_path)
+        .env("POUNCE_DBG_TAPE_STATS", "1");
     if no_hybrid {
         cmd.env("POUNCE_DBG_NO_HYBRID", "1");
     }
-    let status = cmd.status().expect("spawn pounce");
+    let out = cmd.output().expect("spawn pounce");
     assert!(
-        status.success(),
+        out.status.success(),
         "solve exited nonzero (no_hybrid={no_hybrid})"
     );
+    let stderr = String::from_utf8_lossy(&out.stderr).into_owned();
+    let stats = stderr
+        .lines()
+        .find(|l| l.contains("[hybrid stats]"))
+        .unwrap_or_default()
+        .to_string();
     let text = std::fs::read_to_string(&json_path).expect("read json report");
     let _ = std::fs::remove_file(&nl_path);
     let _ = std::fs::remove_file(&json_path);
     let _ = std::fs::remove_file(&sol_path);
-    serde_json::from_str(&text).expect("deserialize SolveReport")
+    (
+        serde_json::from_str(&text).expect("deserialize SolveReport"),
+        stats,
+    )
 }
 
 /// Analytic optimum: x0 = x1 = 0.5, x_{i+2} = 1 / 2.01.
@@ -153,10 +165,24 @@ fn assert_solved_at_optimum(report: &SolveReport, ctx: &str) {
 
 /// The default run takes the shared-CSE paths (the op ratio is past both
 /// derivative gates) and must reach the analytic optimum.
+///
+/// The gate states are asserted from the solve's own `[hybrid stats]` line
+/// rather than inferred from the model's op ratio. Without that, raising
+/// `HYBRID_HESS_MIN_OP_RATIO` past this model's ratio (≈ 8) would silently
+/// turn this into a flat-versus-flat comparison that still passes — the one
+/// thing an end-to-end test for this feature must not do (PR #559 review).
 #[test]
 fn shared_cse_model_solves_on_the_hybrid_paths() {
-    let report = solve(false);
+    let (report, stats) = solve(false);
     assert_solved_at_optimum(&report, "shared-CSE model (hybrid)");
+    assert!(
+        stats.contains("hess_gate=on"),
+        "eval_h must take the shared-CSE path on this model; stats line was: {stats:?}"
+    );
+    assert!(
+        stats.contains("jac_gate=on"),
+        "eval_jac_g must take the shared-CSE path on this model; stats line was: {stats:?}"
+    );
 }
 
 /// Same binary, hybrid disabled: the flat-tape reference solve, and the
@@ -164,9 +190,19 @@ fn shared_cse_model_solves_on_the_hybrid_paths() {
 /// a different (or failed) solution, not a panic.
 #[test]
 fn shared_cse_model_matches_the_flat_tape_solve() {
-    let hybrid = solve(false);
-    let flat = solve(true);
+    let (hybrid, hstats) = solve(false);
+    let (flat, fstats) = solve(true);
     assert_solved_at_optimum(&flat, "shared-CSE model (flat reference)");
+    // Pin that the two runs really did take different paths, so this is a
+    // comparison and not a tautology.
+    assert!(
+        hstats.contains("hess_gate=on"),
+        "hybrid run did not take the shared-CSE Hessian path: {hstats:?}"
+    );
+    assert!(
+        fstats.contains("hybrid not built"),
+        "POUNCE_DBG_NO_HYBRID run should build no hybrid tape at all: {fstats:?}"
+    );
     let (oh, of) = (hybrid.solution.objective, flat.solution.objective);
     assert!(
         (oh - of).abs() <= 1e-6 * of.abs().max(1.0),

--- a/crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs
+++ b/crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs
@@ -1,0 +1,175 @@
+//! Issue #557 end-to-end coverage: a model with a CSE (`.nl` defined
+//! variable) shared across many constraints, solved through the full
+//! CLI — no repository fixture had one, so the shared-CSE tape paths
+//! (`eval_g` always; `eval_jac_g` / `eval_h` above their op-ratio
+//! gates) were exercised by unit tests only.
+//!
+//! The generated model is
+//!
+//! ```text
+//! min  x0 + x1 + Σ_i x_{i+2}
+//! s.t. S · x_{i+2} >= 1        i = 0..m,   S = (log ∘ exp)^p(2 + 0.01 (x0 + x1))
+//!      x0, x1 ∈ [0.5, 5],  x_{i+2} ∈ [1e-3, 1e4]
+//! ```
+//!
+//! The body is mathematically the identity chain, so `S = 2 + 0.01 (x0 +
+//! x1)` and the optimum is analytic — `x0 = x1 = 0.5` (their objective
+//! coefficient dominates the constraint relief they buy), every
+//! constraint active at `x_{i+2} = 1 / 2.01` — while the AD still walks
+//! `2p` transcendental ops with nonzero curvature per body reference.
+//! With `p = 20` the flat/shared op ratio is ≈ 8, past both the Jacobian
+//! (4) and Hessian (2.5) gates, so the default run drives all three
+//! hybrid evaluators; the `POUNCE_DBG_NO_HYBRID=1` run pins the flat
+//! tapes as the reference. Both must reach the same optimum.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pounce_cli::solve_report::SolveReport;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+/// Unique temp path per call (tests run in parallel in one process).
+fn tmp_path(suffix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_issue557_{}_{}_{suffix}",
+        std::process::id(),
+        n
+    ));
+    p
+}
+
+const M: usize = 16;
+const PAIRS: usize = 20;
+
+/// `.nl` text for the model above: one `V` segment referenced by all
+/// `m` constraint rows.
+fn shared_cse_model_nl(m: usize, pairs: usize) -> String {
+    let n = m + 2;
+    let nzc = 3 * m;
+    let mut s = String::new();
+    s.push_str("g3 1 1 0\n");
+    s.push_str(&format!(" {n} {m} 1 0 0 0\n"));
+    s.push_str(&format!(" {m} 0\n 0 0\n"));
+    s.push_str(&format!(" {n} 0 0\n"));
+    s.push_str(" 0 0 0 1\n 0 0 0 0 0\n");
+    s.push_str(&format!(" {nzc} {n}\n"));
+    s.push_str(" 0 0\n 0 1 0 0 0\n");
+    // Shared body: (log ∘ exp)^pairs(2 + 0.01 (x0 + x1)).
+    s.push_str(&format!("V{n} 0 0\n"));
+    for _ in 0..pairs {
+        s.push_str("o43\no44\n");
+    }
+    s.push_str("o0\nn2\no2\nn0.01\no0\nv0\nv1\n");
+    // Rows: S * x_{i+2} >= 1.
+    for i in 0..m {
+        s.push_str(&format!("C{i}\no2\nv{n}\nv{}\n", i + 2));
+    }
+    s.push_str("O0 0\nn0\n");
+    s.push_str(&format!("x{n}\n"));
+    for j in 0..n {
+        s.push_str(&format!("{j} 1.0\n"));
+    }
+    s.push_str("r\n");
+    for _ in 0..m {
+        s.push_str("2 1\n");
+    }
+    s.push_str("b\n");
+    s.push_str("0 0.5 5\n0 0.5 5\n");
+    for _ in 0..m {
+        s.push_str("0 0.001 10000\n");
+    }
+    // Cumulative Jacobian column counts: cols 0 and 1 in every row,
+    // col i+2 in one.
+    s.push_str(&format!("k{}\n", n - 1));
+    let mut acc = 0;
+    for j in 0..n - 1 {
+        acc += if j < 2 { m } else { 1 };
+        s.push_str(&format!("{acc}\n"));
+    }
+    for i in 0..m {
+        s.push_str(&format!("J{i} 3\n0 0.0\n1 0.0\n{} 0.0\n", i + 2));
+    }
+    // Linear objective: every variable with coefficient 1.
+    s.push_str(&format!("G0 {n}\n"));
+    for j in 0..n {
+        s.push_str(&format!("{j} 1.0\n"));
+    }
+    s
+}
+
+/// Solve the generated model, optionally with `POUNCE_DBG_NO_HYBRID=1`,
+/// returning the parsed report.
+fn solve(no_hybrid: bool) -> SolveReport {
+    let nl_path = tmp_path("model.nl");
+    std::fs::write(&nl_path, shared_cse_model_nl(M, PAIRS)).expect("write model");
+    let json_path = tmp_path("report.json");
+    let sol_path = tmp_path("model.sol");
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg(&nl_path)
+        .arg(&sol_path)
+        .arg("--json-output")
+        .arg(&json_path);
+    if no_hybrid {
+        cmd.env("POUNCE_DBG_NO_HYBRID", "1");
+    }
+    let status = cmd.status().expect("spawn pounce");
+    assert!(
+        status.success(),
+        "solve exited nonzero (no_hybrid={no_hybrid})"
+    );
+    let text = std::fs::read_to_string(&json_path).expect("read json report");
+    let _ = std::fs::remove_file(&nl_path);
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&sol_path);
+    serde_json::from_str(&text).expect("deserialize SolveReport")
+}
+
+/// Analytic optimum: x0 = x1 = 0.5, x_{i+2} = 1 / 2.01.
+fn expected_objective() -> f64 {
+    1.0 + M as f64 / 2.01
+}
+
+fn assert_solved_at_optimum(report: &SolveReport, ctx: &str) {
+    let code = report.solution.solve_result_num;
+    assert!(
+        (0..100).contains(&code),
+        "{ctx}: not solved (solve_result_num={code}, status={:?})",
+        report.solution.status,
+    );
+    let obj = report.solution.objective;
+    let want = expected_objective();
+    assert!(
+        (obj - want).abs() < 1e-4 * want,
+        "{ctx}: objective {obj} is not the analytic optimum {want}",
+    );
+}
+
+/// The default run takes the shared-CSE paths (the op ratio is past both
+/// derivative gates) and must reach the analytic optimum.
+#[test]
+fn shared_cse_model_solves_on_the_hybrid_paths() {
+    let report = solve(false);
+    assert_solved_at_optimum(&report, "shared-CSE model (hybrid)");
+}
+
+/// Same binary, hybrid disabled: the flat-tape reference solve, and the
+/// two answers must agree — a wrong hybrid Hessian would surface here as
+/// a different (or failed) solution, not a panic.
+#[test]
+fn shared_cse_model_matches_the_flat_tape_solve() {
+    let hybrid = solve(false);
+    let flat = solve(true);
+    assert_solved_at_optimum(&flat, "shared-CSE model (flat reference)");
+    let (oh, of) = (hybrid.solution.objective, flat.solution.objective);
+    assert!(
+        (oh - of).abs() <= 1e-6 * of.abs().max(1.0),
+        "hybrid ({oh}) and flat ({of}) solves disagree"
+    );
+}

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -1953,6 +1953,19 @@ struct ConHybrid {
     /// hybrid analogue of `con_tape_colors`, inverted so `eval_h` walks
     /// exactly the live (color, summand) pairs.
     hess_color_summands: Vec<Vec<u32>>,
+    /// Per color: the prelude slots that color's summands actually reach,
+    /// ascending — `hess_color_reach[hess_color_reach_off[c]..off[c + 1]]`.
+    /// Both prelude sweeps run once per color, so walking the whole
+    /// prelude each time would cost `n_colors × |prelude|` where the
+    /// op-ratio gate assumes `|prelude|`; iterating the union of the
+    /// color's `prelude_reach` sets makes the cost proportional to what
+    /// is used, so the gate does not need an `n_colors` term. Stored as
+    /// a flat `u32` CSR rather than `Vec<Vec<_>>`: the total is
+    /// `Σ_c |reach_c|`, which is proportional to the work it drives, and
+    /// this struct is the one #552 made O(n²) by holding per-color dense
+    /// arrays.
+    hess_color_reach: Vec<u32>,
+    hess_color_reach_off: Vec<usize>,
     /// Per-color prelude tangent, sized to `tape.n_prelude_ops()`.
     prelude_dot: Vec<f64>,
     /// First-/second-order prelude adjoint accumulators. NOT shared
@@ -2011,18 +2024,25 @@ const HYBRID_JAC_MIN_OP_RATIO: f64 = 4.0;
 ///
 /// Measured on chain models at CSE redundancy 40 (m = 20,000, 500 shared
 /// bodies), varying the body size — the same protocol as the Jacobian
-/// gate's table (`eval_h`, flat → hybrid):
+/// gate's table (`eval_h`, flat → hybrid). **Median of 5 interleaved
+/// flat/hybrid pairs per point**, with the observed range, because
+/// single runs on a shared machine are not reproducible to the precision
+/// a threshold decision needs — one sample below spans 0.36×–1.14× at a
+/// single ratio:
 ///
 /// | op ratio | 1.94 | 2.54 | 3.12 | 3.69 | 4.24 | 5.29 | 6.76 | 8.53 |
 /// |---|---|---|---|---|---|---|---|---|
-/// | speedup | 1.04× | 1.11× | 1.30× | 1.36× | 1.33× | 1.56× | 1.50× | 1.63× |
+/// | median speedup | 1.00× | 1.04× | 1.18× | 1.23× | 1.31× | 1.44× | 1.36× | 1.49× |
+/// | min–max | 0.91–1.11 | 0.36–1.14 | 1.10–1.33 | 1.16–1.30 | 1.23–1.32 | 1.19–1.54 | 1.27–1.50 | 1.36–1.65 |
 ///
-/// At 1.94 repeated runs straddle 1.0× (0.97–1.18×) — break-even inside
-/// timing noise, never a clear loss — and from 2.5 up the win is
-/// consistent. The gate is set at 2.5 so the switch only happens where the
-/// benefit is real, and low-ratio models stay bit-identical on the flat
-/// path. For reference `robot_a` (#476) measures 4.03×.
-const HYBRID_HESS_MIN_OP_RATIO: f64 = 2.5;
+/// The gate sits at 3.0: that is the lowest ratio where **every** sample
+/// wins (by ≥ 10%), whereas at 1.94 and 2.54 the median is within noise of
+/// break-even and individual runs lose. Setting it there costs only a
+/// marginal forgone gain — below the gate `eval_h` stays on the flat path
+/// bit-identically, so a gate placed too high is merely conservative while
+/// one placed too low risks a real regression. For reference `robot_a`
+/// (#476) measures 4.03×.
+const HYBRID_HESS_MIN_OP_RATIO: f64 = 3.0;
 
 // `Clone` supports the batched-solve path (pounce#126): one parsed
 // model is cloned per batch instance (tapes are flat `Vec`s of ops, so
@@ -2884,6 +2904,8 @@ impl NlTnlp {
                     local_off: Vec::new(),
                     summand_row: Vec::new(),
                     hess_color_summands: Vec::new(),
+                    hess_color_reach: Vec::new(),
+                    hess_color_reach_off: Vec::new(),
                     prelude_dot: Vec::new(),
                     hess_prelude_adj: Vec::new(),
                     prelude_adj_dot: Vec::new(),
@@ -3034,6 +3056,36 @@ impl NlTnlp {
                     by_color[c as usize].push(si as u32);
                 }
             }
+            // Per-color prelude reach: the union of `prelude_reach` over the
+            // color's summands, ascending. A union of operand-closed
+            // ascending sets is itself operand-closed and ascending, which is
+            // exactly what the two prelude sweeps require. Deduped with an
+            // epoch-tagged buffer so the build costs
+            // `Σ_c Σ_{s ∈ c} |prelude_reach_s|` — the same order as the work
+            // it saves — rather than `n_colors × |prelude|`.
+            let np = h.tape.n_prelude_ops();
+            let mut seen: Vec<u32> = vec![0; np];
+            let mut epoch: u32 = 0;
+            let mut reach: Vec<u32> = Vec::new();
+            let mut reach_off: Vec<usize> = Vec::with_capacity(n_colors + 1);
+            for list in &by_color {
+                reach_off.push(reach.len());
+                epoch += 1;
+                let start = reach.len();
+                for &si in list {
+                    for &p in &h.tape.summands[si as usize].prelude_reach {
+                        if seen[p] != epoch {
+                            seen[p] = epoch;
+                            reach.push(p as u32);
+                        }
+                    }
+                }
+                reach[start..].sort_unstable();
+            }
+            reach_off.push(reach.len());
+            h.hess_color_reach = reach;
+            h.hess_color_reach_off = reach_off;
+
             h.hess_color_summands = by_color;
             h.prelude_dot = vec![0.0; h.tape.n_prelude_ops()];
             h.hess_prelude_adj = vec![0.0; h.tape.n_prelude_ops()];
@@ -3784,6 +3836,8 @@ impl TNLP for NlTnlp {
                             local_off,
                             summand_row,
                             hess_color_summands,
+                            hess_color_reach,
+                            hess_color_reach_off,
                             prelude_dot,
                             hess_prelude_adj,
                             prelude_adj_dot,
@@ -3816,7 +3870,9 @@ impl TNLP for NlTnlp {
                             }
                             let seed = &self.seeds[c];
                             let out = &mut self.compressed[c];
-                            tape.prelude_tangent(prelude_vals, seed, prelude_dot);
+                            let creach = &hess_color_reach
+                                [hess_color_reach_off[c]..hess_color_reach_off[c + 1]];
+                            tape.prelude_tangent(prelude_vals, seed, creach, prelude_dot);
                             for &si in list {
                                 let si = si as usize;
                                 let w = lam[summand_row[si] as usize];
@@ -3840,6 +3896,7 @@ impl TNLP for NlTnlp {
                             tape.prelude_reverse_directional(
                                 prelude_vals,
                                 prelude_dot,
+                                creach,
                                 out,
                                 hess_prelude_adj,
                                 prelude_adj_dot,
@@ -6016,6 +6073,189 @@ G0 3
                 assert!(
                     (hh[k] - hf[k]).abs() <= tol,
                     "gate-on Hessian entry {k} at scale {scale}: hybrid {} vs flat {}",
+                    hh[k],
+                    hf[k]
+                );
+            }
+            assert!(hh.iter().any(|v| *v != 0.0), "all-zero Hessian is no test");
+        }
+    }
+
+    /// `.nl` text for two independent shared-CSE blocks of different widths:
+    /// block A's body is `sin(x0 + … + x_{wide-1})`, block B's is
+    /// `sin(x_wide + … )` over `narrow` variables, each feeding `rows` rows
+    /// of the form `body * x_r`.
+    ///
+    /// The width difference is the point. A body summing `w` variables gives
+    /// its rows a dense `w × w` Hessian block, so those `w` columns pairwise
+    /// conflict and the coloring must spend `w` colors on them; the narrower
+    /// block reuses the low colors. The surplus colors therefore belong to
+    /// block A alone, and a per-color prelude walk over *both* bodies would
+    /// be doing work for a body that color cannot reach.
+    fn two_block_shared_cse_nl(wide: usize, narrow: usize, rows: usize) -> String {
+        let nvars = wide + narrow;
+        let m = 2 * rows;
+        let n = nvars + m;
+        // Block A rows touch `wide` body vars + 1 row var; block B rows
+        // touch `narrow` + 1.
+        let nzc = rows * (wide + 1) + rows * (narrow + 1);
+        let mut s = String::new();
+        s.push_str("g3 1 1 0\n");
+        s.push_str(&format!(" {n} {m} 1 0 0 0\n"));
+        s.push_str(&format!(" {m} 0\n 0 0\n"));
+        s.push_str(&format!(" {n} 0 0\n"));
+        s.push_str(" 0 0 0 1\n 0 0 0 0 0\n");
+        s.push_str(&format!(" {nzc} {n}\n"));
+        s.push_str(" 0 0\n 0 2 0 0 0\n");
+        // Two bodies: V{n} over the first `wide` vars, V{n+1} over the next
+        // `narrow`. `sin` of a left-nested sum: k terms need k-1 adds.
+        for (b, (base, count)) in [(0, wide), (wide, narrow)].iter().enumerate() {
+            s.push_str(&format!("V{} 0 0\n", n + b));
+            s.push_str("o41\n");
+            for _ in 0..count - 1 {
+                s.push_str("o0\n");
+            }
+            for j in 0..*count {
+                s.push_str(&format!("v{}\n", base + j));
+            }
+        }
+        // Rows: body_b * x_{rowvar}.
+        for i in 0..m {
+            let b = i / rows;
+            s.push_str(&format!("C{i}\no2\nv{}\nv{}\n", n + b, nvars + i));
+        }
+        s.push_str("O0 0\nn0\n");
+        s.push_str(&format!("x{n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("{j} {}\n", 0.2 + 0.01 * j as f64));
+        }
+        s.push_str("r\n");
+        for _ in 0..m {
+            s.push_str("2 0\n");
+        }
+        s.push_str("b\n");
+        for _ in 0..n {
+            s.push_str("3\n");
+        }
+        // Cumulative Jacobian column counts for the first n-1 columns.
+        s.push_str(&format!("k{}\n", n - 1));
+        let mut acc = 0;
+        for j in 0..n - 1 {
+            acc += if j < nvars { rows } else { 1 };
+            s.push_str(&format!("{acc}\n"));
+        }
+        for i in 0..m {
+            let (base, count) = if i < rows { (0, wide) } else { (wide, narrow) };
+            s.push_str(&format!("J{i} {}\n", count + 1));
+            let mut cols: Vec<usize> = (base..base + count).collect();
+            cols.push(nvars + i);
+            cols.sort_unstable();
+            for c in cols {
+                s.push_str(&format!("{c} 0.0\n"));
+            }
+        }
+        s.push_str(&format!("G0 {n}\n"));
+        for j in 0..n {
+            s.push_str(&format!("{j} 0.0\n"));
+        }
+        s
+    }
+
+    /// Both prelude sweeps run once per color, so iterating the whole prelude
+    /// each time would cost `n_colors × |prelude|` where the op-ratio gate
+    /// assumes `|prelude|` — a cost the gate cannot see (PR #559 review).
+    /// `eval_h` instead walks the union of that color's summands'
+    /// `prelude_reach`.
+    ///
+    /// What this can and cannot pin is worth being exact about, because the
+    /// change is pure performance: walking the whole prelude per color
+    /// computes the *same* Hessian, so no assertion on output values can
+    /// detect it, and a timing assertion would be flaky. So this asserts the
+    /// two things that are checkable — that the table the sweeps iterate is
+    /// strictly smaller than the naive `n_colors × |prelude|` walk on a model
+    /// where colors genuinely reach different bodies, and that each reach list
+    /// is ascending and operand-closed, the invariants that make the narrowed
+    /// walk safe — plus agreement with the flat tapes under narrowing.
+    #[test]
+    fn per_color_prelude_reach_skips_bodies_the_color_cannot_touch() {
+        let p = parse_nl_text(&two_block_shared_cse_nl(6, 2, 3)).expect("parse");
+        let mut hybrid = NlTnlp::new(p.clone());
+        let info = hybrid.get_nlp_info().unwrap();
+        let nnz = info.nnz_h_lag as usize;
+        let m = info.m as usize;
+
+        {
+            let h = hybrid
+                .con_hybrid
+                .as_mut()
+                .expect("two shared CSE bodies must build the hybrid tape");
+            h.use_for_hess = true;
+
+            let np = h.tape.n_prelude_ops();
+            let n_colors = h.hess_color_reach_off.len() - 1;
+            let total: usize = h.hess_color_reach.len();
+            assert!(np > 0 && n_colors > 1, "np={np} n_colors={n_colors}");
+            assert!(
+                total < n_colors * np,
+                "per-color reach must be strictly smaller than walking the whole \
+                 prelude per color: Σ|reach_c| = {total}, n_colors × |prelude| = {}",
+                n_colors * np
+            );
+            // Every reach list must be ascending and operand-closed, which is
+            // what makes the narrowed walk safe.
+            for c in 0..n_colors {
+                let r =
+                    &h.hess_color_reach[h.hess_color_reach_off[c]..h.hess_color_reach_off[c + 1]];
+                assert!(
+                    r.windows(2).all(|w| w[0] < w[1]),
+                    "color {c} reach is not strictly ascending"
+                );
+                let member: std::collections::HashSet<u32> = r.iter().copied().collect();
+                for &i in r {
+                    let (a, b) = crate::nl_tape::op_operands(&h.tape.prelude[i as usize]);
+                    for opnd in [a, b].into_iter().flatten() {
+                        assert!(
+                            member.contains(&(opnd as u32)),
+                            "color {c}: slot {i}'s operand {opnd} is missing from its reach"
+                        );
+                    }
+                }
+            }
+        }
+
+        let mut flat = NlTnlp::new(p);
+        flat.get_nlp_info().unwrap();
+        flat.con_hybrid = None;
+
+        let lam: Vec<f64> = (0..m).map(|k| 0.3 + 0.2 * k as f64).collect();
+        for scale in [1.0_f64, -0.6] {
+            let x: Vec<f64> = (0..info.n as usize)
+                .map(|j| scale * (0.15 + 0.02 * j as f64))
+                .collect();
+            let mut hh = vec![0.0_f64; nnz];
+            let mut hf = vec![0.0_f64; nnz];
+            assert!(hybrid.eval_h(
+                Some(&x),
+                true,
+                1.0,
+                Some(&lam),
+                true,
+                SparsityRequest::Values { values: &mut hh }
+            ));
+            assert!(flat.eval_h(
+                Some(&x),
+                true,
+                1.0,
+                Some(&lam),
+                true,
+                SparsityRequest::Values { values: &mut hf }
+            ));
+            for k in 0..nnz {
+                let tol = 1e-12 * hf[k].abs().max(1.0);
+                assert!(
+                    (hh[k] - hf[k]).abs() <= tol,
+                    "narrowed-reach Hessian entry {k} at scale {scale}: \
+                     hybrid {} vs flat {}",
                     hh[k],
                     hf[k]
                 );

--- a/crates/pounce-nl/src/nl_reader.rs
+++ b/crates/pounce-nl/src/nl_reader.rs
@@ -1908,10 +1908,11 @@ struct ColorWrite {
 /// prelude — 4.0x the arithmetic, paid ~10x per iteration inside the line
 /// search. See pounce#476.
 ///
-/// Only `eval_g` reads this; `eval_jac_g` / `eval_h` stay on `con_tapes`
-/// (their reverse / forward-over-reverse sweeps run once per iteration, not
-/// once per line-search trial, and `HybridTape`'s Hessian entry point uses a
-/// different seeding strategy than the coloring machinery here).
+/// `eval_g` reads this unconditionally; `eval_jac_g` and `eval_h` read it
+/// above their respective op-ratio gates ([`HYBRID_JAC_MIN_OP_RATIO`],
+/// [`HYBRID_HESS_MIN_OP_RATIO`]) — the hybrid traversal carries per-op
+/// overhead the flat tapes do not, so each derivative order has to earn
+/// its switch.
 #[derive(Debug, Clone)]
 struct ConHybrid {
     tape: HybridTape,
@@ -1931,6 +1932,42 @@ struct ConHybrid {
     /// on the flat per-summand tapes. See [`HYBRID_JAC_MIN_OP_RATIO`] —
     /// unlike `eval_g`, the hybrid Jacobian is not a free win.
     use_for_jac: bool,
+    /// Whether `eval_h` routes the constraint block through the shared
+    /// prelude (issue #557). See [`HYBRID_HESS_MIN_OP_RATIO`].
+    use_for_hess: bool,
+    // ---- eval_h (shared-CSE Hessian, issue #557) state. Populated in
+    // `try_new` after the Hessian coloring exists; cheap enough (a few
+    // index tables plus one f64 per local op) to build whenever the
+    // hybrid tape is, so tests can flip `use_for_hess` on directly. ----
+    /// Forward values of every summand, packed at
+    /// `local_off[si]..local_off[si + 1]`. One forward pass per `eval_h`
+    /// fills it; every color then reuses the values, mirroring the flat
+    /// path's forward-once-per-tape structure.
+    local_vals_all: Vec<f64>,
+    /// Prefix offsets into `local_vals_all`, length `n_summands + 1`.
+    local_off: Vec<usize>,
+    /// Constraint row of each summand (the inverse of `row_start`), for
+    /// the `λ[row]` weight lookup.
+    summand_row: Vec<u32>,
+    /// Per color: the summands whose variables fall in that color — the
+    /// hybrid analogue of `con_tape_colors`, inverted so `eval_h` walks
+    /// exactly the live (color, summand) pairs.
+    hess_color_summands: Vec<Vec<u32>>,
+    /// Per-color prelude tangent, sized to `tape.n_prelude_ops()`.
+    prelude_dot: Vec<f64>,
+    /// First-/second-order prelude adjoint accumulators. NOT shared
+    /// with `eval_jac_g`'s `prelude_adj`: these two carry an all-zero-
+    /// between-colors invariant (`prelude_reverse_directional`'s
+    /// consume-and-zero contract), while `gradient_summand` zeroes only
+    /// the slots it is about to use and leaves them dirty afterwards —
+    /// sharing the buffer would seed a later `eval_h` with a stale
+    /// Jacobian adjoint.
+    hess_prelude_adj: Vec<f64>,
+    prelude_adj_dot: Vec<f64>,
+    /// Local tangent / second-order adjoint arenas, sized to
+    /// `tape.max_summand_ops()`.
+    local_dot: Vec<f64>,
+    local_adj_dot: Vec<f64>,
 }
 
 /// Flat-to-shared op-count ratio above which `eval_jac_g` switches to the
@@ -1958,6 +1995,34 @@ struct ConHybrid {
 /// a model that does not clearly benefit stays on the flat path. For
 /// reference `robot_a` (#476) measures 4.03×.
 const HYBRID_JAC_MIN_OP_RATIO: f64 = 4.0;
+
+/// Flat-to-shared op-count ratio above which `eval_h` routes the constraint
+/// block through the shared-CSE prelude (issue #557).
+///
+/// The Hessian shares **both** second-order sweeps of the prelude, not just
+/// the forward one: the coloring hands every summand of a color the same
+/// seed vector, so the prelude forward tangent runs once per color, and —
+/// because reverse-over-tangent is linear in its adjoint seeds — the
+/// `λ_k`-weighted boundary adjoints of all summands accumulate into one
+/// unit-weight prelude reverse sweep per color. That is why its crossover
+/// sits *below* the Jacobian's ([`HYBRID_JAC_MIN_OP_RATIO`], set at 4): the
+/// Jacobian can only share the forward half, and per-row gradients forbid
+/// batching its reverse sweeps at all.
+///
+/// Measured on chain models at CSE redundancy 40 (m = 20,000, 500 shared
+/// bodies), varying the body size — the same protocol as the Jacobian
+/// gate's table (`eval_h`, flat → hybrid):
+///
+/// | op ratio | 1.94 | 2.54 | 3.12 | 3.69 | 4.24 | 5.29 | 6.76 | 8.53 |
+/// |---|---|---|---|---|---|---|---|---|
+/// | speedup | 1.04× | 1.11× | 1.30× | 1.36× | 1.33× | 1.56× | 1.50× | 1.63× |
+///
+/// At 1.94 repeated runs straddle 1.0× (0.97–1.18×) — break-even inside
+/// timing noise, never a clear loss — and from 2.5 up the win is
+/// consistent. The gate is set at 2.5 so the switch only happens where the
+/// benefit is real, and low-ratio models stay bit-identical on the flat
+/// path. For reference `robot_a` (#476) measures 4.03×.
+const HYBRID_HESS_MIN_OP_RATIO: f64 = 2.5;
 
 // `Clone` supports the batched-solve path (pounce#126): one parsed
 // model is cloned per batch instance (tapes are flat `Vec`s of ops, so
@@ -2793,13 +2858,19 @@ impl NlTnlp {
         // on a real model, and how a suspected hybrid-path bug is bisected
         // against a reference that computes the same derivatives a
         // different way.
-        let con_hybrid = if std::env::var("POUNCE_DBG_NO_HYBRID").is_ok() {
+        let mut con_hybrid = if std::env::var("POUNCE_DBG_NO_HYBRID").is_ok() {
             None
         } else if hybrid_supported(&con_roots) {
             let tape = HybridTape::build_multi(&con_roots);
             (tape.n_prelude_ops() > 0).then(|| {
                 let flat_ops: usize = con_tapes.iter().flatten().map(|t| t.ops.len()).sum();
                 let shared_ops = tape.n_prelude_ops() + tape.total_local_ops();
+                // `POUNCE_DBG_FORCE_HYBRID_HESS=1` turns the Hessian gate on
+                // regardless of the op ratio. Diagnostic only — it is how the
+                // crossover in `HYBRID_HESS_MIN_OP_RATIO` is measured
+                // (same-binary A/B against `POUNCE_DBG_NO_HYBRID=1`) on
+                // models that sit below the gate.
+                let force_hess = std::env::var("POUNCE_DBG_FORCE_HYBRID_HESS").is_ok();
                 ConHybrid {
                     prelude_vals: vec![0.0; tape.n_prelude_ops()],
                     local_vals: vec![0.0; tape.max_summand_ops()],
@@ -2807,6 +2878,17 @@ impl NlTnlp {
                     prelude_adj: vec![0.0; tape.n_prelude_ops()],
                     use_for_jac: flat_ops as f64
                         >= HYBRID_JAC_MIN_OP_RATIO * shared_ops.max(1) as f64,
+                    use_for_hess: force_hess
+                        || flat_ops as f64 >= HYBRID_HESS_MIN_OP_RATIO * shared_ops.max(1) as f64,
+                    local_vals_all: Vec::new(),
+                    local_off: Vec::new(),
+                    summand_row: Vec::new(),
+                    hess_color_summands: Vec::new(),
+                    prelude_dot: Vec::new(),
+                    hess_prelude_adj: Vec::new(),
+                    prelude_adj_dot: Vec::new(),
+                    local_dot: Vec::new(),
+                    local_adj_dot: Vec::new(),
                     row_start,
                     tape,
                 }
@@ -2909,6 +2991,57 @@ impl NlTnlp {
             .map(|row| row.iter().map(tape_colors).collect())
             .collect();
 
+        // Shared-CSE Hessian tables (issue #557): the per-color summand
+        // lists, row lookup, and packed forward-value arena `eval_h`'s
+        // hybrid path walks. Built whenever the hybrid tape is — not just
+        // above the gate — so flipping `use_for_hess` on (tests, the
+        // force env var) needs no extra setup; the cost is one f64 per
+        // local op plus small index tables.
+        if let Some(h) = con_hybrid.as_mut() {
+            let n_sum = h.tape.n_summands();
+            let mut local_off: Vec<usize> = Vec::with_capacity(n_sum + 1);
+            let mut acc = 0usize;
+            for s in &h.tape.summands {
+                local_off.push(acc);
+                acc += s.ops.len();
+            }
+            local_off.push(acc);
+            h.local_vals_all = vec![0.0; acc];
+            h.local_off = local_off;
+
+            let mut summand_row = vec![0u32; n_sum];
+            for i in 0..prob.m {
+                for si in h.row_start[i]..h.row_start[i + 1] {
+                    summand_row[si] = i as u32;
+                }
+            }
+            h.summand_row = summand_row;
+
+            // A summand's variable set (`all_vars`) equals its flat tape's,
+            // so this is `con_tape_colors` inverted to color-major order —
+            // the loop `eval_h` actually runs.
+            let mut by_color: Vec<Vec<u32>> = vec![Vec::new(); n_colors];
+            for (si, s) in h.tape.summands.iter().enumerate() {
+                let mut cs: Vec<u32> = s
+                    .all_vars
+                    .iter()
+                    .map(|&v| var_color[v])
+                    .filter(|&c| c != u32::MAX)
+                    .collect();
+                cs.sort_unstable();
+                cs.dedup();
+                for c in cs {
+                    by_color[c as usize].push(si as u32);
+                }
+            }
+            h.hess_color_summands = by_color;
+            h.prelude_dot = vec![0.0; h.tape.n_prelude_ops()];
+            h.hess_prelude_adj = vec![0.0; h.tape.n_prelude_ops()];
+            h.prelude_adj_dot = vec![0.0; h.tape.n_prelude_ops()];
+            h.local_dot = vec![0.0; h.tape.max_summand_ops()];
+            h.local_adj_dot = vec![0.0; h.tape.max_summand_ops()];
+        }
+
         // Per-row Jacobian sparsity = union of tape vars plus
         // linear-segment vars.
         let mut jac_cols: Vec<Vec<usize>> = Vec::with_capacity(prob.m);
@@ -2970,9 +3103,12 @@ impl NlTnlp {
                     let local = h.tape.total_local_ops();
                     eprintln!(
                         "[hybrid stats] con flat_ops={flat} prelude_ops={prelude} \
-                         local_ops={local} shared_total={} flat/shared={:.2}x",
+                         local_ops={local} shared_total={} flat/shared={:.2}x \
+                         jac_gate={} hess_gate={}",
                         prelude + local,
                         flat as f64 / (prelude + local).max(1) as f64,
+                        if h.use_for_jac { "on" } else { "off" },
+                        if h.use_for_hess { "on" } else { "off" },
                     );
                 }
                 None => eprintln!("[hybrid stats] con hybrid not built (no shared CSE bodies)"),
@@ -3631,30 +3767,111 @@ impl TNLP for NlTnlp {
                     }
                 }
 
-                if let Some(lam) = lambda {
-                    for k in 0..self.prob.m {
-                        let w = lam[k];
-                        if w == 0.0 {
-                            continue;
-                        }
-                        for (ti, t) in self.con_tapes[k].iter().enumerate() {
-                            if t.ops.is_empty() {
+                match (lambda, self.con_hybrid.as_mut()) {
+                    // Shared-CSE path (issue #557). Per color the prelude's
+                    // second-order work runs ONCE for the whole constraint
+                    // block: one forward tangent, then — because
+                    // reverse-over-tangent is linear in its adjoint seeds —
+                    // one unit-weight reverse sweep over the λ-weighted
+                    // adjoints accumulated by every summand of that color.
+                    // The flat path below repeats both sweeps over the
+                    // inlined CSE body once per referencing summand.
+                    (Some(lam), Some(h)) if h.use_for_hess => {
+                        let ConHybrid {
+                            tape,
+                            prelude_vals,
+                            local_vals_all,
+                            local_off,
+                            summand_row,
+                            hess_color_summands,
+                            prelude_dot,
+                            hess_prelude_adj,
+                            prelude_adj_dot,
+                            local_dot,
+                            local_adj,
+                            local_adj_dot,
+                            ..
+                        } = h;
+                        // Forward once (values are color-independent):
+                        // prelude for the block, then each summand of a row
+                        // with a live multiplier into its packed slice.
+                        tape.forward_prelude(x, prelude_vals);
+                        for (si, s) in tape.summands.iter().enumerate() {
+                            if lam[summand_row[si] as usize] == 0.0 {
                                 continue;
                             }
-                            t.forward_into(x, &mut self.vals_scratch);
-                            for &c in &self.con_tape_colors[k][ti] {
-                                t.hessian_directional(
-                                    &self.vals_scratch,
-                                    &self.seeds[c as usize],
+                            tape.forward_summand(
+                                s,
+                                x,
+                                prelude_vals,
+                                &mut local_vals_all[local_off[si]..local_off[si + 1]],
+                            );
+                        }
+                        for (c, list) in hess_color_summands.iter().enumerate() {
+                            if !list
+                                .iter()
+                                .any(|&si| lam[summand_row[si as usize] as usize] != 0.0)
+                            {
+                                continue;
+                            }
+                            let seed = &self.seeds[c];
+                            let out = &mut self.compressed[c];
+                            tape.prelude_tangent(prelude_vals, seed, prelude_dot);
+                            for &si in list {
+                                let si = si as usize;
+                                let w = lam[summand_row[si] as usize];
+                                if w == 0.0 {
+                                    continue;
+                                }
+                                tape.hessian_summand_directional(
+                                    &tape.summands[si],
+                                    &local_vals_all[local_off[si]..local_off[si + 1]],
+                                    prelude_dot,
+                                    seed,
                                     w,
-                                    &mut self.compressed[c as usize],
-                                    &mut self.dot_scratch,
-                                    &mut self.adj_scratch,
-                                    &mut self.adj_dot_scratch,
+                                    out,
+                                    local_dot,
+                                    local_adj,
+                                    local_adj_dot,
+                                    hess_prelude_adj,
+                                    prelude_adj_dot,
                                 );
+                            }
+                            tape.prelude_reverse_directional(
+                                prelude_vals,
+                                prelude_dot,
+                                out,
+                                hess_prelude_adj,
+                                prelude_adj_dot,
+                            );
+                        }
+                    }
+                    (Some(lam), _) => {
+                        for k in 0..self.prob.m {
+                            let w = lam[k];
+                            if w == 0.0 {
+                                continue;
+                            }
+                            for (ti, t) in self.con_tapes[k].iter().enumerate() {
+                                if t.ops.is_empty() {
+                                    continue;
+                                }
+                                t.forward_into(x, &mut self.vals_scratch);
+                                for &c in &self.con_tape_colors[k][ti] {
+                                    t.hessian_directional(
+                                        &self.vals_scratch,
+                                        &self.seeds[c as usize],
+                                        w,
+                                        &mut self.compressed[c as usize],
+                                        &mut self.dot_scratch,
+                                        &mut self.adj_scratch,
+                                        &mut self.adj_dot_scratch,
+                                    );
+                                }
                             }
                         }
                     }
+                    (None, _) => {}
                 }
 
                 // Decode each color's compressed Hessian-vector
@@ -5506,11 +5723,13 @@ G0 3
     }
 
     /// `.nl` text for `m` constraints `S * x_{i+2} >= 0`, all sharing one
-    /// CSE `S = exp^depth(0.01 * (x0 + x1))`. A deep shared body over few
-    /// local ops per row is the regime the Jacobian gate is meant to
-    /// catch: no repository fixture has a CSE shared across constraints
-    /// at all, so without this the gate-on path has no natural coverage.
-    fn deep_shared_cse_nl(m: usize, depth: usize) -> String {
+    /// CSE `S = body(x0, x1)` (the caller passes the body's expression
+    /// text, which must reference exactly `v0` and `v1`). A deep shared
+    /// body over few local ops per row is the regime the op-ratio gates
+    /// are meant to catch: no repository fixture has a CSE shared across
+    /// constraints at all, so without this the gate-on paths have no
+    /// natural coverage.
+    fn shared_body_chain_nl(m: usize, body: &str) -> String {
         let n = m + 2;
         let nzc = 3 * m;
         let mut s = String::new();
@@ -5523,10 +5742,7 @@ G0 3
         s.push_str(" 0 0\n 0 1 0 0 0\n");
         // The shared body.
         s.push_str(&format!("V{n} 0 0\n"));
-        for _ in 0..depth {
-            s.push_str("o44\n");
-        }
-        s.push_str("o2\nn0.01\no0\nv0\nv1\n");
+        s.push_str(body);
         // Rows: S * x_{i+2}.
         for i in 0..m {
             s.push_str(&format!("C{i}\no2\nv{n}\nv{}\n", i + 2));
@@ -5559,6 +5775,35 @@ G0 3
             s.push_str(&format!("{j} 0.0\n"));
         }
         s
+    }
+
+    /// [`shared_body_chain_nl`] with `S = exp^depth(0.01 * (x0 + x1))`.
+    /// The forward value saturates to `inf` past depth ≈ 5, which the
+    /// Jacobian tests tolerate (`inf == inf`); Hessian tests need the
+    /// bounded variant below instead, whose second-order terms would
+    /// otherwise mix `inf`s of both signs into `NaN`.
+    fn deep_shared_cse_nl(m: usize, depth: usize) -> String {
+        let mut body = String::new();
+        for _ in 0..depth {
+            body.push_str("o44\n");
+        }
+        body.push_str("o2\nn0.01\no0\nv0\nv1\n");
+        shared_body_chain_nl(m, &body)
+    }
+
+    /// [`shared_body_chain_nl`] with `S = (log ∘ exp)^pairs(2 + 0.01 *
+    /// (x0 + x1))` — mathematically the identity chain, so the value
+    /// stays bounded (no `inf`/`NaN` at any reasonable `x`) while every
+    /// stage still carries nonzero curvature (`exp'' ≠ 0`, `log'' ≠ 0`)
+    /// through both second-order sweeps. `2 * pairs` body ops drive the
+    /// flat/shared op ratio as high as the Hessian gate tests need.
+    fn bounded_deep_shared_cse_nl(m: usize, pairs: usize) -> String {
+        let mut body = String::new();
+        for _ in 0..pairs {
+            body.push_str("o43\no44\n");
+        }
+        body.push_str("o0\nn2\no2\nn0.01\no0\nv0\nv1\n");
+        shared_body_chain_nl(m, &body)
     }
 
     /// With a deep shared body the gate turns itself on, and the path it
@@ -5609,6 +5854,189 @@ G0 3
         assert!(
             !h.use_for_jac,
             "a 3-row model with a 2-term CSE is far below the op-ratio gate"
+        );
+    }
+
+    /// `eval_h`'s shared-CSE path (issue #557) against the flat tapes on a
+    /// polynomial model with dyadic inputs. Folding `λ_k` into the boundary
+    /// adjoints and running one prelude sweep reassociates floating-point
+    /// products, so the two paths agree only to rounding on general inputs —
+    /// but here every operation in both traversals is exact (dyadic values,
+    /// small-integer coefficients, polynomial ops), so the results must be
+    /// bit-identical, pinning the arithmetic itself and not just its
+    /// magnitude. Forced on regardless of `HYBRID_HESS_MIN_OP_RATIO` so the
+    /// path is covered independently of the size heuristic.
+    #[test]
+    fn shared_cse_hessian_matches_flat_tape_bit_for_bit() {
+        let nl = shared_cse_nl("o2\nv3\nv2");
+        let p = parse_nl_text(&nl).expect("parse shared-CSE model");
+
+        let mut hybrid = NlTnlp::new(p.clone());
+        let info = hybrid.get_nlp_info().unwrap();
+        let nnz = info.nnz_h_lag as usize;
+        hybrid
+            .con_hybrid
+            .as_mut()
+            .expect("CSE shared by 3 constraints must build the hybrid tape")
+            .use_for_hess = true;
+
+        let mut flat = NlTnlp::new(p);
+        flat.get_nlp_info().unwrap();
+        flat.con_hybrid = None;
+
+        let pairs: Vec<(usize, usize)> = hybrid
+            .h_irow
+            .iter()
+            .zip(&hybrid.h_jcol)
+            .map(|(&i, &j)| (i as usize, j as usize))
+            .collect();
+
+        // Two multiplier sets: one all-live, one with a dead row so the
+        // λ == 0 skip is exercised on the hybrid path too.
+        for lam in [[0.5, -1.25, 2.0], [0.0, 1.0, 0.5]] {
+            for x in [[1.0, 1.0, 1.0], [-2.0, 0.5, 3.0], [0.0, -1.5, -0.25]] {
+                let mut hh = vec![0.0_f64; nnz];
+                let mut hf = vec![0.0_f64; nnz];
+                assert!(hybrid.eval_h(
+                    Some(&x),
+                    true,
+                    1.0,
+                    Some(&lam),
+                    true,
+                    SparsityRequest::Values { values: &mut hh }
+                ));
+                assert!(flat.eval_h(
+                    Some(&x),
+                    true,
+                    1.0,
+                    Some(&lam),
+                    true,
+                    SparsityRequest::Values { values: &mut hf }
+                ));
+                assert_eq!(
+                    hh, hf,
+                    "hybrid Hessian differs from the flat tape at {x:?}, λ = {lam:?}"
+                );
+
+                // Analytic cross-check. V3 = 2 x0 + 3 x1 =: s with gradient
+                // dV = (2, 3, 0); the rows are V3², V3³ + x2, V3·x2 and the
+                // objective is constant, so the Lagrangian Hessian is
+                //   (2 λ0 + 6 s λ1) · dV dVᵀ + λ2 · (dV e2ᵀ + e2 dVᵀ).
+                let s = 2.0 * x[0] + 3.0 * x[1];
+                let q = 2.0 * lam[0] + 6.0 * s * lam[1];
+                let dv = [2.0, 3.0, 0.0];
+                for (k, &(i, j)) in pairs.iter().enumerate() {
+                    let mut want = q * dv[i] * dv[j];
+                    if i == 2 {
+                        want += lam[2] * dv[j];
+                    }
+                    if j == 2 {
+                        want += lam[2] * dv[i];
+                    }
+                    assert!(
+                        (hh[k] - want).abs() < 1e-9,
+                        "entry ({i}, {j}) at {x:?}, λ = {lam:?}: got {}, want {want}",
+                        hh[k]
+                    );
+                }
+            }
+        }
+    }
+
+    /// A deep (but bounded — see `bounded_deep_shared_cse_nl`) shared body
+    /// turns the Hessian gate on by itself, and the path it turns on must
+    /// agree with the flat tapes. Not bitwise here: the shared prelude
+    /// reverse sweep runs once over the `λ_k`-folded adjoints of all
+    /// summands where the flat path runs per summand, and that
+    /// reassociation moves transcendental results by rounding — so the bar
+    /// is a relative few-ULP band, with the exact-arithmetic case pinned
+    /// bitwise by `shared_cse_hessian_matches_flat_tape_bit_for_bit`.
+    #[test]
+    fn a_deep_shared_body_turns_the_hessian_gate_on_and_still_agrees() {
+        let m = 16;
+        let p = parse_nl_text(&bounded_deep_shared_cse_nl(m, 20)).expect("parse");
+
+        let mut hybrid = NlTnlp::new(p.clone());
+        let info = hybrid.get_nlp_info().unwrap();
+        let nnz = info.nnz_h_lag as usize;
+        assert!(
+            hybrid
+                .con_hybrid
+                .as_ref()
+                .expect("shared CSE must build the hybrid tape")
+                .use_for_hess,
+            "a 40-op body shared by 16 rows is well past the op-ratio gate"
+        );
+
+        let mut flat = NlTnlp::new(p);
+        flat.get_nlp_info().unwrap();
+        flat.con_hybrid = None;
+
+        let lam: Vec<f64> = (0..m).map(|k| 0.25 + 0.125 * k as f64).collect();
+        for scale in [1.0_f64, -0.7, 2.5] {
+            let x: Vec<f64> = (0..info.n as usize)
+                .map(|j| scale * (0.2 + 0.03 * j as f64))
+                .collect();
+            // Run the hybrid Jacobian first, the order a real solve
+            // iteration uses. Its `gradient_summand` sweeps leave the
+            // *Jacobian's* prelude adjoint arena dirty; the Hessian's
+            // accumulators must be its own buffers with the all-zero-
+            // between-colors invariant, or this seeds `eval_h` with a
+            // stale row gradient (caught here).
+            let mut jac = vec![0.0_f64; info.nnz_jac_g as usize];
+            assert!(hybrid.eval_jac_g(
+                Some(&x),
+                true,
+                SparsityRequest::Values { values: &mut jac }
+            ));
+            let mut hh = vec![0.0_f64; nnz];
+            let mut hf = vec![0.0_f64; nnz];
+            assert!(hybrid.eval_h(
+                Some(&x),
+                true,
+                1.0,
+                Some(&lam),
+                true,
+                SparsityRequest::Values { values: &mut hh }
+            ));
+            assert!(flat.eval_h(
+                Some(&x),
+                true,
+                1.0,
+                Some(&lam),
+                true,
+                SparsityRequest::Values { values: &mut hf }
+            ));
+            for k in 0..nnz {
+                assert!(
+                    hh[k].is_finite() && hf[k].is_finite(),
+                    "non-finite Hessian entry {k} defeats the comparison"
+                );
+                let tol = 1e-12 * hf[k].abs().max(1.0);
+                assert!(
+                    (hh[k] - hf[k]).abs() <= tol,
+                    "gate-on Hessian entry {k} at scale {scale}: hybrid {} vs flat {}",
+                    hh[k],
+                    hf[k]
+                );
+            }
+            assert!(hh.iter().any(|v| *v != 0.0), "all-zero Hessian is no test");
+        }
+    }
+
+    /// The Hessian gate is off for a model whose shared bodies are small —
+    /// below the ratio where the shared prelude sweeps pay for the hybrid
+    /// traversal's per-op overhead — leaving `eval_h` on the flat path
+    /// (which the gate keeps bit-identical for such models by definition).
+    #[test]
+    fn a_small_shared_body_leaves_the_hessian_on_the_flat_path() {
+        let p = parse_nl_text(&shared_cse_nl("o2\nv3\nv2")).expect("parse");
+        let mut t = NlTnlp::new(p);
+        t.get_nlp_info().unwrap();
+        let h = t.con_hybrid.as_ref().expect("hybrid built for eval_g");
+        assert!(
+            !h.use_for_hess,
+            "a 3-row model with a 2-term CSE is below the Hessian op-ratio gate"
         );
     }
 

--- a/crates/pounce-nl/src/nl_tape.rs
+++ b/crates/pounce-nl/src/nl_tape.rs
@@ -2316,7 +2316,12 @@ pub struct Summand {
     pub local_vars: Vec<usize>,
     /// Variables touched by Var ops inside `prelude_reach`.
     pub prelude_vars: Vec<usize>,
-    /// `local_vars ∪ prelude_vars`, sorted. Hessian j-loop set.
+    /// `local_vars ∪ prelude_vars`, sorted — every problem variable this
+    /// summand can contribute a derivative for. `eval_h` maps it through
+    /// the Hessian coloring to decide which colors the summand
+    /// participates in (issue #557); it must include `prelude_vars` or a
+    /// summand would be skipped for colors it reaches only through a
+    /// shared CSE body.
     pub all_vars: Vec<usize>,
 }
 
@@ -2521,9 +2526,28 @@ impl HybridTape {
     /// color share, and the reason the directional Hessian path
     /// exists at all (issue #557): a per-summand-per-variable seeding
     /// strategy would repeat it for every referencing summand.
-    pub fn prelude_tangent(&self, prelude_vals: &[f64], seed: &[f64], prelude_dot: &mut [f64]) {
+    /// `reach` is the set of prelude slots this color actually uses —
+    /// the union of `prelude_reach` over the color's summands. It must
+    /// be **ascending** (the prelude is emitted bottom-up, so operand
+    /// indices are always below their consumer's) and **closed under
+    /// operands**, which a union of `prelude_reach` sets is by
+    /// construction. Slots outside it are neither written nor read:
+    /// a summand only pulls `prelude_dot[k]` for `k` in its own
+    /// `prelude_reach`, so a stale tangent left in an untouched slot by
+    /// a previous color can never be observed. Passing every slot is
+    /// therefore always correct, just not always cheap — walking the
+    /// whole prelude once per color is `n_colors × |prelude|` work
+    /// against the `|prelude|` the op-ratio gate assumes.
+    pub fn prelude_tangent(
+        &self,
+        prelude_vals: &[f64],
+        seed: &[f64],
+        reach: &[u32],
+        prelude_dot: &mut [f64],
+    ) {
         debug_assert!(prelude_dot.len() >= self.prelude.len());
-        for i in 0..self.prelude.len() {
+        for &i in reach {
+            let i = i as usize;
             prelude_dot[i] = fwd_dir_step(&self.prelude[i], seed, prelude_vals, prelude_dot, i);
         }
     }
@@ -2633,11 +2657,13 @@ impl HybridTape {
         &self,
         prelude_vals: &[f64],
         prelude_dot: &[f64],
+        reach: &[u32],
         out: &mut [f64],
         prelude_adj: &mut [f64],
         prelude_adj_dot: &mut [f64],
     ) {
-        for i in (0..self.prelude.len()).rev() {
+        for &i in reach.iter().rev() {
+            let i = i as usize;
             let w = prelude_adj[i];
             let wd = prelude_adj_dot[i];
             if w == 0.0 && wd == 0.0 {
@@ -3280,7 +3306,7 @@ fn summand_sparsity(
 /// Operand indices of a `TapeOp`, normalized into a fixed-length
 /// array so callers don't need to re-match every site.
 #[inline]
-fn op_operands(op: &TapeOp) -> (Option<usize>, Option<usize>) {
+pub(crate) fn op_operands(op: &TapeOp) -> (Option<usize>, Option<usize>) {
     match op {
         TapeOp::Const(_) | TapeOp::Var(_) => (None, None),
         TapeOp::Add(a, b)
@@ -3325,7 +3351,17 @@ fn op_operands(op: &TapeOp) -> (Option<usize>, Option<usize>) {
             "op_operands: TapeOp::Min/Max are unsupported on the HybridTape path \
              (build_into_summand rejects min/max lists)"
         ),
-        TapeOp::Funcall(_) => (None, None),
+        // Returning `(None, None)` here would be a silent wrong answer, not a
+        // conservative one: a Funcall's tape arguments would be missing from
+        // `local_reach`, and the directional Hessian deliberately does NOT
+        // pre-zero `local_dot`, so those slots would be read as stale scratch
+        // from a previous summand. Unreachable today —
+        // `build_into_summand` panics on `Expr::Funcall` before any tape is
+        // built — and this keeps it loud if that ever changes.
+        TapeOp::Funcall(_) => unreachable!(
+            "op_operands: TapeOp::Funcall is unsupported on the HybridTape path \
+             (build_into_summand rejects external function calls)"
+        ),
     }
 }
 
@@ -5259,8 +5295,20 @@ mod tests {
             let mut prelude_adj_dot = vec![0.0; np];
             let (mut local_dot, mut local_adj, mut local_adj_dot) =
                 (vec![0.0; ml], vec![0.0; ml], vec![0.0; ml]);
+            // The per-color prelude reach the caller is required to pass:
+            // the union of the color's summands' `prelude_reach`, ascending.
+            // Built here rather than passing `0..np` so the test exercises the
+            // narrowed walk `eval_h` actually performs — a reach that wrongly
+            // omitted a slot would leave its tangent stale and show up below.
+            let creach: Vec<u32> = {
+                let mut u: BTreeSet<u32> = BTreeSet::new();
+                for s in &hybrid.summands {
+                    u.extend(s.prelude_reach.iter().map(|&p| p as u32));
+                }
+                u.into_iter().collect()
+            };
             hybrid.forward_prelude(&x, &mut prelude_vals);
-            hybrid.prelude_tangent(&prelude_vals, seed, &mut prelude_dot);
+            hybrid.prelude_tangent(&prelude_vals, seed, &creach, &mut prelude_dot);
             for (s, &wt) in hybrid.summands.iter().zip(&weights) {
                 let mut local_vals = vec![0.0; s.ops.len()];
                 hybrid.forward_summand(s, &x, &prelude_vals, &mut local_vals);
@@ -5281,6 +5329,7 @@ mod tests {
             hybrid.prelude_reverse_directional(
                 &prelude_vals,
                 &prelude_dot,
+                &creach,
                 &mut hyb_out,
                 &mut prelude_adj,
                 &mut prelude_adj_dot,

--- a/crates/pounce-nl/src/nl_tape.rs
+++ b/crates/pounce-nl/src/nl_tape.rs
@@ -2514,103 +2514,149 @@ impl HybridTape {
         }
     }
 
-    /// Forward-over-reverse Hessian for one summand with multiplier
-    /// `weight`. Iterates over `s.all_vars`; for each seed variable
-    /// j: (1) forward tangent through prelude_reach then local_reach,
-    /// (2) reverse over local (folding adj/adj_dot into prelude at
-    /// Shared boundaries), (3) reverse over prelude_reach. All
-    /// scratch buffers are zeroed only at the touched slots inside
-    /// the per-j loop.
+    /// Forward tangent over the whole prelude for one dense seed
+    /// vector (a Hessian color): `prelude_dot[i] = (∂prelude[i]/∂x) ·
+    /// seed`. Runs **once per color for the entire constraint block**
+    /// — this is the sweep the coloring lets every summand of that
+    /// color share, and the reason the directional Hessian path
+    /// exists at all (issue #557): a per-summand-per-variable seeding
+    /// strategy would repeat it for every referencing summand.
+    pub fn prelude_tangent(&self, prelude_vals: &[f64], seed: &[f64], prelude_dot: &mut [f64]) {
+        debug_assert!(prelude_dot.len() >= self.prelude.len());
+        for i in 0..self.prelude.len() {
+            prelude_dot[i] = fwd_dir_step(&self.prelude[i], seed, prelude_vals, prelude_dot, i);
+        }
+    }
+
+    /// Directional forward-over-reverse Hessian pass for one summand
+    /// with multiplier `weight`, sharing the per-color prelude tangent
+    /// computed by [`prelude_tangent`]: forward-tangent the local ops
+    /// (pulling `prelude_dot` at `Shared` boundaries), then
+    /// reverse-over-tangent them, writing `weight * (H · seed)[k]`
+    /// into the dense `out[k]` at each `Var(k)` — the same contract as
+    /// [`Tape::hessian_directional`], so contributions land straight
+    /// in the coloring's `compressed[c]` buffer.
+    ///
+    /// Adjoints crossing a `Shared` boundary are folded into
+    /// `prelude_adj` / `prelude_adj_dot` **scaled by `weight`**, and
+    /// left there: reverse-over-tangent is linear in its adjoint
+    /// seeds, so accumulating `λ_k`-weighted adjoints across every
+    /// summand of a color and running [`prelude_reverse_directional`]
+    /// once with unit weight computes the same second-order prelude
+    /// contribution as a per-summand sweep — while paying for the
+    /// prelude walk once per color instead of once per (summand,
+    /// color) pair.
+    ///
+    /// `local_vals` must hold this summand's forward values (see
+    /// [`forward_summand`]); `local_dot` / `local_adj` /
+    /// `local_adj_dot` are scratch arenas (≥ `s.ops.len()`), zeroed
+    /// here only at the slots the summand reaches.
+    ///
+    /// [`prelude_tangent`]: HybridTape::prelude_tangent
+    /// [`prelude_reverse_directional`]: HybridTape::prelude_reverse_directional
+    /// [`forward_summand`]: HybridTape::forward_summand
     #[allow(clippy::too_many_arguments)]
-    pub fn hessian_summand(
+    pub fn hessian_summand_directional(
         &self,
         s: &Summand,
-        prelude_vals: &[f64],
         local_vals: &[f64],
+        prelude_dot: &[f64],
+        seed: &[f64],
         weight: f64,
-        hess_map: &HashMap<(usize, usize), usize>,
-        values: &mut [f64],
+        out: &mut [f64],
         local_dot: &mut [f64],
         local_adj: &mut [f64],
         local_adj_dot: &mut [f64],
-        prelude_dot: &mut [f64],
         prelude_adj: &mut [f64],
         prelude_adj_dot: &mut [f64],
     ) {
         if weight == 0.0 || s.local_reach.is_empty() {
             return;
         }
-        for &j in &s.all_vars {
-            for &i in &s.local_reach {
-                local_dot[i] = 0.0;
-                local_adj[i] = 0.0;
-                local_adj_dot[i] = 0.0;
+        for &i in &s.local_reach {
+            local_adj[i] = 0.0;
+            local_adj_dot[i] = 0.0;
+        }
+        // `local_dot` needs no pre-zeroing: `local_reach` is ascending
+        // and every operand of a reached op is itself reached, so each
+        // slot is written before any read.
+        for &i in &s.local_reach {
+            local_dot[i] = match &s.ops[i] {
+                SummandOp::Local(op) => fwd_dir_step(op, seed, local_vals, local_dot, i),
+                SummandOp::Shared(k) => prelude_dot[*k],
+            };
+        }
+        local_adj[s.root_slot] = 1.0;
+        for &i in s.local_reach.iter().rev() {
+            let w = local_adj[i];
+            let wd = local_adj_dot[i];
+            if w == 0.0 && wd == 0.0 {
+                continue;
             }
-            for &i in &s.prelude_reach {
-                prelude_dot[i] = 0.0;
-                prelude_adj[i] = 0.0;
-                prelude_adj_dot[i] = 0.0;
-            }
-            for &i in &s.prelude_reach {
-                prelude_dot[i] = fwd_tan_step(&self.prelude[i], j, prelude_vals, prelude_dot, i);
-            }
-            for &i in &s.local_reach {
-                local_dot[i] = match &s.ops[i] {
-                    SummandOp::Local(op) => fwd_tan_step(op, j, local_vals, local_dot, i),
-                    SummandOp::Shared(k) => prelude_dot[*k],
-                };
-            }
-            local_adj[s.root_slot] = 1.0;
-            for &i in s.local_reach.iter().rev() {
-                let w = local_adj[i];
-                let wd = local_adj_dot[i];
-                if w == 0.0 && wd == 0.0 {
-                    continue;
+            match &s.ops[i] {
+                SummandOp::Local(op) => {
+                    ror_dir_step(
+                        op,
+                        i,
+                        local_vals,
+                        local_dot,
+                        local_adj,
+                        local_adj_dot,
+                        w,
+                        wd,
+                        weight,
+                        out,
+                    );
                 }
-                match &s.ops[i] {
-                    SummandOp::Local(op) => {
-                        ror_step(
-                            op,
-                            i,
-                            j,
-                            local_vals,
-                            local_dot,
-                            local_adj,
-                            local_adj_dot,
-                            w,
-                            wd,
-                            weight,
-                            hess_map,
-                            values,
-                        );
-                    }
-                    SummandOp::Shared(k) => {
-                        prelude_adj[*k] += w;
-                        prelude_adj_dot[*k] += wd;
-                    }
+                SummandOp::Shared(k) => {
+                    prelude_adj[*k] += weight * w;
+                    prelude_adj_dot[*k] += weight * wd;
                 }
             }
-            for &i in s.prelude_reach.iter().rev() {
-                let w = prelude_adj[i];
-                let wd = prelude_adj_dot[i];
-                if w == 0.0 && wd == 0.0 {
-                    continue;
-                }
-                ror_step(
-                    &self.prelude[i],
-                    i,
-                    j,
-                    prelude_vals,
-                    prelude_dot,
-                    prelude_adj,
-                    prelude_adj_dot,
-                    w,
-                    wd,
-                    weight,
-                    hess_map,
-                    values,
-                );
+        }
+    }
+
+    /// Reverse-over-tangent over the prelude with unit weight,
+    /// consuming the adjoint accumulators built by
+    /// [`hessian_summand_directional`] across all summands of one
+    /// color and writing variable contributions into the dense `out`.
+    ///
+    /// `prelude_adj` / `prelude_adj_dot` must be all-zero except for
+    /// the accumulated seeds on entry (allocate them zeroed and this
+    /// invariant maintains itself); each slot is re-zeroed as it is
+    /// consumed — adjoints only ever propagate to lower slots, which
+    /// the reverse walk has not visited yet — so the buffers come back
+    /// all-zero, ready for the next color, without an O(prelude) fill.
+    ///
+    /// [`hessian_summand_directional`]: HybridTape::hessian_summand_directional
+    pub fn prelude_reverse_directional(
+        &self,
+        prelude_vals: &[f64],
+        prelude_dot: &[f64],
+        out: &mut [f64],
+        prelude_adj: &mut [f64],
+        prelude_adj_dot: &mut [f64],
+    ) {
+        for i in (0..self.prelude.len()).rev() {
+            let w = prelude_adj[i];
+            let wd = prelude_adj_dot[i];
+            if w == 0.0 && wd == 0.0 {
+                continue;
             }
+            prelude_adj[i] = 0.0;
+            prelude_adj_dot[i] = 0.0;
+            ror_dir_step(
+                &self.prelude[i],
+                i,
+                prelude_vals,
+                prelude_dot,
+                prelude_adj,
+                prelude_adj_dot,
+                w,
+                wd,
+                1.0,
+                out,
+            );
         }
     }
 
@@ -3501,17 +3547,18 @@ fn rev_step(op: &TapeOp, i: usize, vals: &[f64], adj: &mut [f64], a: f64, grad: 
     }
 }
 
+/// Directional forward-tangent step: [`fwd_tan_step`] with a dense
+/// seed vector instead of a single seed variable. The per-op chain
+/// rule is identical (and identical to the inline arms of
+/// [`Tape::hessian_directional`], which the hybrid Hessian path must
+/// agree with); only the `Var` arm differs — it reads `seed[k]`
+/// rather than testing `k == seed_var` — which is what lets one pass
+/// carry a whole Hessian color.
 #[inline]
-fn fwd_tan_step(op: &TapeOp, seed_var: usize, vals: &[f64], dot: &[f64], i: usize) -> f64 {
+fn fwd_dir_step(op: &TapeOp, seed: &[f64], vals: &[f64], dot: &[f64], i: usize) -> f64 {
     match op {
         TapeOp::Const(_) => 0.0,
-        TapeOp::Var(k) => {
-            if *k == seed_var {
-                1.0
-            } else {
-                0.0
-            }
-        }
+        TapeOp::Var(k) => seed[*k],
         TapeOp::Add(a, b) => dot[*a] + dot[*b],
         TapeOp::Sub(a, b) => dot[*a] - dot[*b],
         TapeOp::Mul(a, b) => dot[*a] * vals[*b] + vals[*a] * dot[*b],
@@ -3550,14 +3597,14 @@ fn fwd_tan_step(op: &TapeOp, seed_var: usize, vals: &[f64], dot: &[f64], i: usiz
             let sv = vals[i];
             if sv > 0.0 { dot[*a] * 0.5 / sv } else { 0.0 }
         }
-        TapeOp::Exp(a) => dot[*a] * vals[i],
+        TapeOp::Exp(a) => vals[i] * dot[*a],
         TapeOp::Log(a) => dot[*a] / vals[*a],
         TapeOp::Log10(a) => dot[*a] / (vals[*a] * std::f64::consts::LN_10),
-        TapeOp::Sin(a) => dot[*a] * vals[*a].cos(),
-        TapeOp::Cos(a) => -dot[*a] * vals[*a].sin(),
+        TapeOp::Sin(a) => vals[*a].cos() * dot[*a],
+        TapeOp::Cos(a) => -vals[*a].sin() * dot[*a],
         TapeOp::Tan(a) => {
             let t = vals[i];
-            dot[*a] * (1.0 + t * t)
+            (1.0 + t * t) * dot[*a]
         }
         TapeOp::Atan(a) => {
             let u = vals[*a];
@@ -3571,7 +3618,7 @@ fn fwd_tan_step(op: &TapeOp, seed_var: usize, vals: &[f64], dot: &[f64], i: usiz
         TapeOp::Cosh(a) => dot[*a] * vals[*a].sinh(),
         TapeOp::Tanh(a) => {
             let t = vals[i];
-            dot[*a] * (1.0 - t * t)
+            (1.0 - t * t) * dot[*a]
         }
         TapeOp::Asin(a) => {
             let u = vals[*a];
@@ -3626,18 +3673,25 @@ fn fwd_tan_step(op: &TapeOp, seed_var: usize, vals: &[f64], dot: &[f64], i: usiz
                     k += 1;
                 }
             }
-            let _ = seed_var;
+            let _ = seed;
             acc
         }
     }
 }
 
+/// Directional reverse-over-tangent step: [`ror_step`] with the
+/// hash-map scatter replaced by the dense accumulation
+/// [`Tape::hessian_directional`] uses — at `Var(k)` the emitted
+/// second-order contribution is `out[k] += weight * wd`, landing in
+/// the coloring's per-color `compressed` buffer with no hashing. All
+/// other arms are the exact arithmetic of `hessian_directional`'s
+/// reverse sweep, so the local part of the hybrid Hessian is
+/// bit-identical to the flat tape's.
 #[allow(clippy::too_many_arguments)]
 #[inline]
-fn ror_step(
+fn ror_dir_step(
     op: &TapeOp,
     i: usize,
-    seed_var: usize,
     vals: &[f64],
     dot: &[f64],
     adj: &mut [f64],
@@ -3645,16 +3699,13 @@ fn ror_step(
     w: f64,
     wd: f64,
     weight: f64,
-    hess_map: &HashMap<(usize, usize), usize>,
-    values: &mut [f64],
+    out: &mut [f64],
 ) {
     match op {
         TapeOp::Const(_) => {}
         TapeOp::Var(k) => {
-            if wd != 0.0 && *k >= seed_var {
-                if let Some(&pos) = hess_map.get(&(*k, seed_var)) {
-                    values[pos] += weight * wd;
-                }
+            if wd != 0.0 {
+                out[*k] += weight * wd;
             }
         }
         TapeOp::Add(a, b) => {
@@ -3928,9 +3979,7 @@ fn ror_step(
                 }
                 adj_dot[tk] += wd * derivs[k] + w * second_term;
             }
-            let _ = seed_var;
-            let _ = hess_map;
-            let _ = values;
+            let _ = out;
             let _ = weight;
             let _ = i;
         }
@@ -5146,5 +5195,114 @@ mod tests {
             add(Expr::Cse(body.clone()), cnst(2.0)),
         ];
         HybridTape::build_multi(&exprs);
+    }
+
+    /// The directional hybrid Hessian (issue #557) against the flat
+    /// [`Tape::hessian_directional`] it replaces: three summands sharing one
+    /// transcendental CSE body, each with its own multiplier, swept with a
+    /// dense two-variable seed. The per-summand *local* contributions are the
+    /// exact arithmetic of the flat tape; the shared-prelude contribution
+    /// folds the multipliers into the boundary adjoints and runs one unit-
+    /// weight prelude sweep, which reassociates the floating-point products —
+    /// mathematically identical by linearity of reverse-over-tangent in the
+    /// adjoint seeds, so the comparison is at near-machine tolerance rather
+    /// than bitwise.
+    #[test]
+    fn directional_hybrid_hessian_matches_flat_directional() {
+        // body = exp(0.5*(x0 + x1)), shared by all three summands:
+        //   s0 = body^2,  s1 = body * x2,  s2 = sin(body) + x2^2.
+        let body = Arc::new(unary(UnaryOp::Exp, mul(cnst(0.5), add(var(0), var(1)))));
+        let exprs = vec![
+            pow(Expr::Cse(body.clone()), cnst(2.0)),
+            mul(Expr::Cse(body.clone()), var(2)),
+            add(
+                unary(UnaryOp::Sin, Expr::Cse(body.clone())),
+                pow(var(2), cnst(2.0)),
+            ),
+        ];
+        let weights = [1.25, -0.75, 2.5];
+        let x = [0.3, -0.1, 0.7];
+        let n = 3;
+
+        let hybrid = HybridTape::build_multi(&exprs);
+        assert!(
+            hybrid.n_prelude_ops() > 0,
+            "a CSE shared by 3 roots must be promoted into the prelude"
+        );
+
+        // Flat reference: independent tapes, one directional pass each.
+        let seeds = [[1.0, 0.0, 1.0], [0.0, 1.0, 0.0]];
+        for seed in &seeds {
+            let mut flat_out = vec![0.0; n];
+            for (e, &wt) in exprs.iter().zip(&weights) {
+                let t = Tape::build(e);
+                let vals = t.forward(&x);
+                let m = t.ops.len();
+                let (mut dot, mut adj, mut adj_dot) = (vec![0.0; m], vec![0.0; m], vec![0.0; m]);
+                t.hessian_directional(
+                    &vals,
+                    seed,
+                    wt,
+                    &mut flat_out,
+                    &mut dot,
+                    &mut adj,
+                    &mut adj_dot,
+                );
+            }
+
+            let mut hyb_out = vec![0.0; n];
+            let np = hybrid.n_prelude_ops();
+            let ml = hybrid.max_summand_ops();
+            let mut prelude_vals = vec![0.0; np];
+            let mut prelude_dot = vec![0.0; np];
+            let mut prelude_adj = vec![0.0; np];
+            let mut prelude_adj_dot = vec![0.0; np];
+            let (mut local_dot, mut local_adj, mut local_adj_dot) =
+                (vec![0.0; ml], vec![0.0; ml], vec![0.0; ml]);
+            hybrid.forward_prelude(&x, &mut prelude_vals);
+            hybrid.prelude_tangent(&prelude_vals, seed, &mut prelude_dot);
+            for (s, &wt) in hybrid.summands.iter().zip(&weights) {
+                let mut local_vals = vec![0.0; s.ops.len()];
+                hybrid.forward_summand(s, &x, &prelude_vals, &mut local_vals);
+                hybrid.hessian_summand_directional(
+                    s,
+                    &local_vals,
+                    &prelude_dot,
+                    seed,
+                    wt,
+                    &mut hyb_out,
+                    &mut local_dot,
+                    &mut local_adj,
+                    &mut local_adj_dot,
+                    &mut prelude_adj,
+                    &mut prelude_adj_dot,
+                );
+            }
+            hybrid.prelude_reverse_directional(
+                &prelude_vals,
+                &prelude_dot,
+                &mut hyb_out,
+                &mut prelude_adj,
+                &mut prelude_adj_dot,
+            );
+
+            for k in 0..n {
+                let scale = flat_out[k].abs().max(1.0);
+                assert!(
+                    (hyb_out[k] - flat_out[k]).abs() <= 1e-13 * scale,
+                    "seed {seed:?} entry {k}: hybrid {} vs flat {}",
+                    hyb_out[k],
+                    flat_out[k]
+                );
+            }
+            assert!(
+                hyb_out.iter().any(|v| *v != 0.0),
+                "an all-zero H·s is no comparison"
+            );
+            // The accumulators must come back all-zero, ready for the
+            // next color (`prelude_reverse_directional`'s contract).
+            assert!(prelude_adj.iter().all(|v| *v == 0.0));
+            assert!(prelude_adj_dot.iter().all(|v| *v == 0.0));
+        }
     }
 }


### PR DESCRIPTION
Closes #557

> **Updated after review.** All four review items are addressed, and the crossover table below has been re-measured as medians — the original was single runs per point, which this machine's variance does not support. The gate moved 2.5 → 3.0 as a result. See the review reply for detail.

## Problem

`eval_h` is 66–69% of AD time on shared-CSE models, and it was the last evaluator still on the flat per-summand tapes, which inline (and re-differentiate) a shared CSE body once per referencing summand. Everything shipped so far (#476 `eval_g`, #553 `eval_jac_g`) optimized the other third.

## Cause

Not a bug — a missing capability. The dormant `HybridTape::hessian_summand` could not fill it: it re-walks `prelude_reach` forward and backward once **per seed variable**, sharing no prelude work at all, and scatters through a `HashMap` lookup per emitted pair where the coloring path writes into a dense buffer. #553's crossover data (forward-sweep-only sharing broke even at ratio ≈ 3) predicted it would lose outright.

## Fix

The color-level design from the issue. For each Hessian color `c`, every summand uses the same seed vector `s_c`, so per color:

1. forward-tangent the prelude **once** for the whole constraint block;
2. per summand with `λ_k ≠ 0`: forward-tangent the local ops (pulling `prelude_dot` at `Shared` boundaries), reverse-over-tangent them writing `weight · wd` straight into the coloring's dense `compressed[c]` (no hashing), and fold `λ_k` into the adjoints deposited at `Shared` boundaries;
3. reverse-over-tangent the prelude **once** with unit weight — valid because reverse-over-tangent is linear in its adjoint seeds.

New kernels `fwd_dir_step` / `ror_dir_step` mirror `Tape::hessian_directional`'s arms exactly, so the per-summand local arithmetic is bit-identical to the flat tape; the folded prelude sweep is mathematically identical and agrees to rounding (the λ-fold plus cross-summand accumulation reassociates floating-point products — exact bitwise equality of the *shared* portion is unattainable by construction, which the tests pin as tightly as each case admits). `hessian_summand` and its now-unused `fwd_tan_step` / `ror_step` helpers are removed.

Both prelude sweeps run **once per color**, so they iterate the union of that color's summands' `prelude_reach` rather than the whole prelude. Walking all of it would cost `n_colors × |prelude|` where the op-ratio gate assumes `|prelude|` — a discrepancy unbounded in `n_colors` that the gate cannot see. A union of operand-closed ascending sets is itself operand-closed and ascending, which is exactly what the sweeps require.

### Measurements

Median of 5 interleaved flat/hybrid pairs per point, chain models at CSE redundancy 40, m = 20,000. Interleaved because absolute times drift over minutes on this machine while the paired ratio stays tight; medians because single runs do not reproduce to the precision a threshold needs — the 2.54 column spans 0.36× to 1.14×.

| flat/shared op ratio | 1.94 | 2.54 | 3.12 | 3.69 | 4.24 | 5.29 | 6.76 | 8.53 |
|---|---|---|---|---|---|---|---|---|
| median `eval_h` speedup | 1.00× | 1.04× | 1.18× | 1.23× | 1.31× | 1.44× | 1.36× | 1.49× |
| min–max | 0.91–1.11 | 0.36–1.14 | 1.10–1.33 | 1.16–1.30 | 1.23–1.32 | 1.19–1.54 | 1.27–1.50 | 1.36–1.65 |

`HYBRID_HESS_MIN_OP_RATIO` is **3.0** — the lowest ratio where every sample wins by ≥ 10%. At 1.94 and 2.54 the median is within noise of break-even and individual runs lose. Below the gate `eval_h` stays on the flat path bit-identically, so a gate set high is merely conservative while one set low risks a real regression. Whole AD stack at ratio 4.24: **1.25×** (median of 5 pairs, range 1.14–1.44).

Per-color reach measured in isolation is **neutral on these models** — 1.02× at ratio 4.24, 1.12× at 8.53 — as the review predicted: every color there reaches nearly every body, because a body's row-variables all share its Hessian rows and so pairwise conflict, which is exactly the 42 colors the coloring reports. Its value is removing an unbounded blind spot, not speed here.

One defect found during this work: the `eval_h` accumulators must be **separate buffers** from `eval_jac_g`'s prelude adjoint arena. `gradient_summand` leaves that arena dirty after each row, while the directional sweeps rely on an all-zero-between-colors invariant — sharing the buffer seeds `eval_h` with a stale row gradient on every real solve iteration.

## Blast radius

- Models with no CSE shared across summands (including every `.nl` Pyomo writes — zero `V` segments, see #552) never build the hybrid tape: **bit-identical**, zero cost.
- Models with shared CSEs below ratio 3.0 keep `eval_h` on the flat path: **bit-identical**.
- Above the gate, `eval_h` values move by rounding (few ULPs) relative to the flat path, same in kind as what #553 accepted for the Jacobian. All 62 repository `.nl` fixtures have no shared CSE, so none of them change at all.
- `hessian_vector_products` (matrix-free HVP) intentionally stays on the flat tapes — arbitrary user seeds don't batch by color.
- Removed pub API: `HybridTape::hessian_summand` (never had a caller in-repo or in tests; pre-1.0). `HybridTape::prelude_tangent` / `prelude_reverse_directional` take a `reach: &[u32]` argument.

## Tests

- `shared_cse_hessian_matches_flat_tape_bit_for_bit` — hybrid vs flat with `assert_eq!` on a polynomial model whose inputs and coefficients make **every** operation in both traversals exact, so bitwise equality is a theorem, not luck; plus an analytic Lagrangian-Hessian cross-check and a λ = 0 row to exercise the skip.
- `a_deep_shared_body_turns_the_hessian_gate_on_and_still_agrees` — a bounded `(log ∘ exp)^20` body turns the gate on naturally; hybrid vs flat within 1e-12 relative, with the hybrid Jacobian run first in solve order. This is the test that fails (verified by re-introducing the bug) if the Hessian accumulators share `eval_jac_g`'s arena.
- `per_color_prelude_reach_skips_bodies_the_color_cannot_touch` — two shared bodies of differing width, so surplus colors belong to the wide block alone. Asserts the reach table is strictly smaller than the naive `n_colors × |prelude|` walk, that every reach list is ascending and operand-closed, and that the Hessian still matches flat. Deliberately does *not* claim to catch a revert of the sweep body: walking the whole prelude computes the same values, so only the table's narrowness and the safety invariants are checkable.
- `a_small_shared_body_leaves_the_hessian_on_the_flat_path` — gate off below ratio.
- `directional_hybrid_hessian_matches_flat_directional` — tape-level comparison against `Tape::hessian_directional`, including the accumulators-return-to-zero contract, passing a narrowed reach rather than the full range.
- **End-to-end** (`crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs`): a generated model (one defined variable feeding 16 rows, analytic optimum) solved through the CLI with default gates and with `POUNCE_DBG_NO_HYBRID=1`; both must report Solved at the analytic optimum and agree to 1e-6. Gate states are asserted from the solve's own `[hybrid stats]` line, so raising the constant past this model's 8.25× cannot silently turn it into a flat-versus-flat comparison — verified by doing exactly that and watching both tests fail.

---

- [x] Tests bite: the interleave regression test and the e2e gate assertions were both negatively verified against the defect they guard
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [ ] Book page under `docs/src/` — not applicable: the hybrid tape is internal AD machinery with no user-facing surface, same as #476/#553 which added no page
- [x] `cargo fmt --all -- --check` clean; `cargo clippy` clean at CI strictness (`-D clippy::correctness -D clippy::suspicious`); `cargo test -p pounce-nl` (154 tests) and the CLI e2e tests pass
- [x] Every claim in this body and in the code comments is true of the code as it stands now — the measurement table and the whole-stack figure were re-measured for this revision, and the gate constant updated to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016s9XGvcs9ST6pnRusL2Z2P