### PR TITLE
feat(pyomo): register a native pyomo.contrib.solver (v2) interface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,3 +393,42 @@ jobs:
           # AMPL/`.nl` tests exercise the CLI plugin path. Both catch
           # regressions the import smoke test misses.
           python -m pytest pyomo-pounce/tests -q
+      # The v2 interface needs Pyomo >= 6.10.1; the package as a whole
+      # supports pyomo>=6.0 through the legacy plugin. Everything above
+      # installs Pyomo unpinned, i.e. always the newest release, so
+      # nothing there exercises the declared floor — it is a claim, not a
+      # tested property, and the one time it was wrong the failure mode
+      # was `import pyomo_pounce` raising, which takes the LEGACY plugin
+      # down with it (gh #558 review).
+      #
+      # 6.10.0 is the last release below the floor and the one where this
+      # actually broke: `pyomo.contrib.solver.common` exists there, so a
+      # package-level probe passed, but the loader API is still
+      # `SolutionLoaderBase`/`get_primals`. A separate venv keeps this
+      # older Pyomo away from the job's real environment.
+      - name: Below-floor Pyomo — legacy plugin must still import
+        run: |
+          python -m venv /tmp/floorenv
+          /tmp/floorenv/bin/pip install -q "pyomo==6.10.0" numpy pandas
+          /tmp/floorenv/bin/pip install -q python/dist/*.whl
+          /tmp/floorenv/bin/pip install -q --no-deps pyomo-pounce/dist/*.whl
+          /tmp/floorenv/bin/python - <<'PY'
+          import pyomo
+          # Must NOT raise: the v2 registration is optional, and a failed
+          # import here is the regression this leg exists to catch.
+          import pyomo_pounce
+          from pyomo.opt import SolverFactory
+          print('pyomo', pyomo.version.version,
+                '| HAVE_V2_INTERFACE:', pyomo_pounce.HAVE_V2_INTERFACE)
+          assert pyomo_pounce.HAVE_V2_INTERFACE is False, (
+              "6.10.0 is below the v2 floor; the guard should report the "
+              "interface as unavailable rather than claiming it works")
+          assert SolverFactory('pounce') is not None, (
+              "the legacy plugin must keep working below the v2 floor")
+          print('legacy plugin OK below the floor')
+          PY
+          # ...and the v2 test module skips cleanly rather than erroring
+          # at collection.
+          /tmp/floorenv/bin/pip install -q pytest
+          /tmp/floorenv/bin/python -m pytest pyomo-pounce/tests/test_v2.py \
+            -q --no-header -rs 2>&1 | tail -5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,19 @@ jobs:
   # end-to-end against that binary. The pytest step exercises actual solves
   # (option forwarding, routing) that a plain import smoke test cannot —
   # without it, routing regressions like pounce#186 ship silently.
+  #
+  # This is also the ONLY job where Pyomo runs at all: it is not a
+  # dev-dependency of the workspace, so nothing else here can catch a
+  # Pyomo-side regression. Since gh#558 that includes both of the
+  # interfaces pyomo-pounce registers — the legacy ASL plugin and the
+  # `pyomo.contrib.solver` (v2) one — and `tests/test_v2.py` solves one
+  # model through both and compares primals, duals and reduced costs.
+  # That comparison is what keeps the interface table in
+  # `docs/src/pyomo.md` honest (it was hand-produced and went stale the
+  # moment Pyomo renamed anything) and what pins the two #553
+  # ASL-compatibility fixes from the Python side: quoted option values
+  # and the per-model `.sol` `Options` echo are exercised on every v2
+  # solve, where before they were covered by Rust unit tests only.
   pyomo-pounce-smoke:
     name: wheel smoke (pyomo-pounce)
     runs-on: ubuntu-latest
@@ -358,6 +371,20 @@ jobs:
           python -m pip install --no-deps pyomo-pounce/dist/*.whl
           which pounce
           python -c "import pyomo_pounce; from pyomo.opt import SolverFactory; s = SolverFactory('pounce'); print('exe:', s.executable())"
+          # Both registrations must resolve a usable binary before the
+          # suite runs. The v2 interface finds its executable and parses
+          # its version through a different code path than the legacy
+          # plugin (Pyomo's own Ipopt version parser rejects POUNCE's
+          # `pounce X.Y.Z` banner, so `available()` is NotFound without
+          # our override) — a plain `import` would not notice.
+          python - <<'PY'
+          import pyomo_pounce
+          from pyomo.contrib.solver.common.factory import SolverFactory as SF2
+          s = SF2('pounce')
+          print('v2 exe:', s.config.executable.path())
+          print('v2 version:', s.version(), 'available:', s.available())
+          assert s.version() is not None, "v2 interface could not parse the POUNCE version"
+          PY
       - name: Run pyomo-pounce tests
         run: |
           python -m pip install pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,14 +71,29 @@ through v2, ~1.8×. (On a plain `pyomo.dae` model the same comparison is
 is the documented route, users of that model class were paying the legacy
 path's cost with no supported alternative that kept the extras.
 
+**Requirements, and only for the v2 route** (`pip install
+pyomo-pounce[v2]`): **Pyomo ≥ 6.10.1**, where the `SolutionLoader` /
+`get_vars` API this builds on landed — `pyomo.contrib.solver.common`
+exists from 6.9.2, but 6.9.2–6.10.0 ship the older `SolutionLoaderBase` /
+`get_primals` — and **pounce-solver > 0.9.0**, because Pyomo's
+`asl_sol_reader` asserts `n_opts >= 2` where the legacy reader is lenient
+and so needs the per-model `.sol` `Options` echo added after 0.9.0.
+Neither applies to `SolverFactory('pounce')`: on an older Pyomo the
+legacy plugin behaves exactly as before and
+`pyomo_pounce.HAVE_V2_INTERFACE` reports `False`.
+
 **Testing.** `pyomo-pounce/tests/test_v2.py` solves the same model
 through both interfaces and compares primals, objective, duals and
 reduced costs, and does the same for the ordinary route against the
-sensitivity route. That closes the gap noted in #558: the interface table
-in `docs/src/pyomo.md` was produced by hand and nothing in CI re-checked
-it, and the #553 ASL-compatibility fixes (quoted option values, the
-per-model `.sol` `Options` echo) were pinned by Rust unit tests only —
-the v2 route exercises both on every solve.
+sensitivity route — including that they agree on `solution_status` for a
+limit-stopped solve, which decides whether `solve()` raises. That closes
+the gap noted in #558: the interface table in `docs/src/pyomo.md` was
+produced by hand and nothing in CI re-checked it, and the #553
+ASL-compatibility fixes (quoted option values, the per-model `.sol`
+`Options` echo) were pinned by Rust unit tests only — the v2 route
+exercises both on every solve. A CI leg pinned to a Pyomo *below* the
+floor checks that the legacy plugin still imports there, so the floor is
+a tested property rather than a claim.
 
 ### Fixed — a single dense Hessian row made `.nl` setup and every `eval_h` O(n²) (#552)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ changes.
 
 ## [Unreleased]
 
+### Added — `pyomo-pounce` registers a native `pyomo.contrib.solver` (v2) interface (#558)
+
+`pyomo_pounce` previously registered one solver: `POUNCE`, a subclass of
+Pyomo's *legacy* `ASL` plugin. #553 made the POUNCE binary drivable by
+Pyomo's newer `pyomo.contrib.solver` interface, but that is not the same
+as having one — a user had to point `ipopt_v2` at the executable by hand,
+and doing so silently dropped everything `pyomo-pounce` adds.
+
+`pyomo_pounce.v2.Pounce` is now registered alongside the legacy plugin:
+
+    import pyomo_pounce
+    from pyomo.contrib.solver.common.factory import SolverFactory as SF2
+    SF2('pounce')                        # v2 interface
+    SolverFactory('pounce_v2')           # v2 engine, legacy API
+    SolverFactory('pounce')              # legacy plugin, unchanged
+
+The split follows Pyomo's own `ipopt` / `ipopt_v2` convention, so the
+registration is purely additive: `SolverFactory('pounce')` still returns
+the legacy plugin and behaves exactly as before.
+
+**The extras come with it.** That is the point of the class, and each
+needed translating onto the v2 lifecycle rather than copying:
+
+- the guard that refuses a model with live integer variables instead of
+  solving the continuous relaxation and reporting a fractional value as
+  optimal (#341);
+- `scaling_factor` Suffix handling (#483 / #486);
+- bundled-binary resolution, which keeps a stale `pounce` on `PATH` from
+  being picked up silently (#315);
+- the sensitivity path (`declare_sens_param` → in-process
+  `pounce.Solver`). This one is a real translation, not an adaptation:
+  v2 returns a `Results` and hands the solution back through a solution
+  loader the caller may decline to load, where the legacy path writes
+  values onto the model as a side effect of solving. The new
+  `PounceSensSolutionLoader` serves primals, duals and reduced costs out
+  of the in-process solve, converting the engine's internal multipliers
+  to the AMPL marginal convention `dual` carries and to Ipopt's
+  `ipopt_zU_out` sign — the same two conversions the warm-start reader
+  applies in the other direction.
+
+**Inherited deliberately** from Pyomo's `Ipopt` v2 class: the `.nl`
+write, the `.sol` read, option splitting between the command line and the
+`.opt` file, and the solver-log parse. POUNCE is ASL/Ipopt-compatible on
+all of them. The one place it is not is the version banner —
+`pounce --version` prints `pounce X.Y.Z`, which Pyomo's Ipopt parser
+rejects by design — so without the override here `available()` reported
+`NotFound` and the solver refused to run.
+
+**Why it matters beyond API parity.** #552 measured the same POUNCE
+binary through both interfaces on drto/IDAES collocation models: 0.553 s
+of non-solve time per solve through the legacy path against 0.301 s
+through v2, ~1.8×. (On a plain `pyomo.dae` model the same comparison is
+1.05×, so this is model-shape dependent.) Since `SolverFactory('pounce')`
+is the documented route, users of that model class were paying the legacy
+path's cost with no supported alternative that kept the extras.
+
+**Testing.** `pyomo-pounce/tests/test_v2.py` solves the same model
+through both interfaces and compares primals, objective, duals and
+reduced costs, and does the same for the ordinary route against the
+sensitivity route. That closes the gap noted in #558: the interface table
+in `docs/src/pyomo.md` was produced by hand and nothing in CI re-checked
+it, and the #553 ASL-compatibility fixes (quoted option values, the
+per-model `.sol` `Options` echo) were pinned by Rust unit tests only —
+the v2 route exercises both on every solve.
+
 ### Fixed — a single dense Hessian row made `.nl` setup and every `eval_h` O(n²) (#552)
 
 `NlTnlp` recovers the Lagrangian Hessian by graph coloring: columns whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,16 @@ needed translating onto the v2 lifecycle rather than copying:
 **Inherited deliberately** from Pyomo's `Ipopt` v2 class: the `.nl`
 write, the `.sol` read, option splitting between the command line and the
 `.opt` file, and the solver-log parse. POUNCE is ASL/Ipopt-compatible on
-all of them. The one place it is not is the version banner —
-`pounce --version` prints `pounce X.Y.Z`, which Pyomo's Ipopt parser
-rejects by design — so without the override here `available()` reported
-`NotFound` and the solver refused to run.
+all of them, including the `Number of Iterations....:` and
+`Total seconds in POUNCE =` lines the log parser reads. The one place it
+is not is the version banner — `pounce --version` prints `pounce X.Y.Z`,
+and Pyomo's Ipopt parser requires a leading `ipopt` by design, so that
+other ASL executables are not mistaken for Ipopt. Without the override
+here, `version()` is `None` and `available()` reports `NotFound`. Solves
+still run (nothing gates on the version), but every availability check
+lies — including the `if not solver.available(): skip` pattern that
+guards most Pyomo test suites, and Pyomo tooling that selects a solver by
+availability.
 
 **Why it matters beyond API parity.** #552 measured the same POUNCE
 binary through both interfaces on drto/IDAES collocation models: 0.553 s

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -59,18 +59,20 @@ genuinely different code paths, not aliases. All of these reach POUNCE
 | call | works | carries `pyomo-pounce`'s extras |
 |---|---|---|
 | `SolverFactory('pounce')` | yes | **yes** |
+| `contrib.solver` `SolverFactory('pounce')` | yes | **yes** |
+| `SolverFactory('pounce_v2')` | yes | **yes** |
 | `SolverFactory('ipopt_v2', executable=<pounce>)` | yes | no |
 | `SolverFactory('ipopt', executable=<pounce>)` | yes | no |
 | `SolverFactory('asl', executable=<pounce>, solver='pounce')` | yes | no |
 | `SolverFactory('appsi_ipopt', …)` | no — takes no `executable` | — |
 
-`SolverFactory('pounce')` is the supported route and the only one that
-brings the rest of this page with it: the `scaling_factor` suffix
-handling, the sensitivity path, the preflight/repair helpers, the guard
-against handing a model with live integer variables to a continuous
-solver, and the bundled-binary resolution above. The generic routes run
-the same solver and return the same answer, but silently do without all
-of that.
+The first three are `pyomo-pounce`'s own registrations and the supported
+routes; they are the only ones that bring the rest of this page with
+them: the `scaling_factor` suffix handling, the sensitivity path, the
+preflight/repair helpers, the guard against handing a model with live
+integer variables to a continuous solver, and the bundled-binary
+resolution above. The generic routes run the same solver and return the
+same answer, but silently do without all of that.
 
 `ipopt` and `asl` are Pyomo's *legacy* solver interface; `ipopt_v2` is
 the newer `pyomo.contrib.solver` one. Driving POUNCE through `ipopt_v2`
@@ -81,26 +83,61 @@ options as `key="value"` in a single `argv` entry (quotes and all, since
 no shell is involved) and because POUNCE's `.sol` wrote an `Options`
 count of `0`, which the v2 `.sol` reader rejects.
 
+### Choosing between the legacy and v2 interfaces
+
+Both of `pyomo-pounce`'s interfaces carry the same extras and return the
+same numbers — a test in `pyomo-pounce/tests/test_v2.py` solves one model
+through both and compares primals, objective, duals and reduced costs, so
+this is checked on every CI run rather than asserted here.
+
+```python
+import pyomo_pounce
+from pyomo.environ import SolverFactory
+from pyomo.contrib.solver.common.factory import SolverFactory as SolverFactoryV2
+
+solver = SolverFactory('pounce')       # legacy interface
+solver = SolverFactoryV2('pounce')     # v2 interface (a Results object)
+solver = SolverFactory('pounce_v2')    # v2 engine, legacy-style API
+```
+
+They differ in API and in per-solve overhead. The v2 interface returns a
+`Results` object and hands the solution back through a solution loader
+(so `load_solutions=False` gives you the values without touching the
+model); the legacy one returns a `SolverResults` and loads into the model
+as a side effect. Options are `solver_options={...}` on v2 against
+`options={...}` on the legacy route.
+
+**The v2 route can be materially faster outside the solve**, and how much
+depends on the model's shape. Same POUNCE binary, wall clock around
+`solve()` minus POUNCE's own reported time:
+
+| model | legacy remainder | v2 remainder |
+|---|---|---|
+| plain `pyomo.dae` four-tank collocation, n = 3,010 | 0.109 s | 0.104 s |
+| drto/IDAES `quad_tank` N=100, n = 2,910 | 0.553 s | 0.301 s |
+| drto/IDAES `cart_pole` N=100, n = 2,810 | 0.566 s | 0.295 s |
+
+On the plain model the two are indistinguishable; on the IDAES-shaped
+ones the legacy interface adds roughly 0.25 s per solve (~1.8×). If your
+models are of that kind and you are solving many of them, the v2 route is
+worth taking. (Figures from the [#552](https://github.com/jkitchin/pounce/issues/552)
+measurements; the first row was measured on Linux, the other two on
+Windows, so read down the columns rather than across the rows.)
+
 **If you are benchmarking, put both solvers on the same interface.**
 `solver.solve(model)` is not only the solve: it is Pyomo writing the
 `.nl`, launching the process, reading the `.sol` back and loading it into
 the model. Timing around that call and subtracting the solver's own
-reported time leaves a remainder that is mostly *Pyomo's* work, and it is
-not the same work on every interface. On a 3,010-variable collocation
-model, wall clock around `solve()` for the same POUNCE binary:
-
-| interface | reported solve | remainder | total |
-|---|---|---|---|
-| `SolverFactory('pounce')` (legacy) | 0.223 s | 0.109 s | 0.332 s |
-| `ipopt_v2` | 0.188 s | 0.104 s | 0.292 s |
-
-and that remainder breaks down as ~0.082 s Pyomo writing the `.nl`,
-~0.020 s process spawn plus POUNCE's own `.nl` read and setup, and
-~0.008 s Pyomo reading the `.sol` and loading it. So comparing
-`SolverFactory('pounce')` against `SolverFactory('ipopt_v2', …)` compares
-two Pyomo interfaces as much as two solvers, and attributing the
-remainder to either solver's file handling will mislead you. Use the same
-interface on both sides, or compare the solvers' own reported times.
+reported time leaves a remainder that is mostly *Pyomo's* work, and — as
+the table above shows — it is not the same work on every interface. On
+the 3,010-variable collocation model that remainder breaks down as
+~0.082 s Pyomo writing the `.nl`, ~0.020 s process spawn plus POUNCE's
+own `.nl` read and setup, and ~0.008 s Pyomo reading the `.sol` and
+loading it. So comparing `SolverFactory('pounce')` against
+`SolverFactory('ipopt_v2', …)` compares two Pyomo interfaces as much as
+two solvers, and attributing the remainder to either solver's file
+handling will mislead you. Use the same interface on both sides, or
+compare the solvers' own reported times.
 
 ## User scaling with the `scaling_factor` Suffix
 

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -100,6 +100,16 @@ solver = SolverFactoryV2('pounce')     # v2 interface (a Results object)
 solver = SolverFactory('pounce_v2')    # v2 engine, legacy-style API
 ```
 
+The v2 route needs **Pyomo ≥ 6.10.1** (where the `SolutionLoader` /
+`get_vars` API it builds on landed — `pyomo.contrib.solver.common`
+exists from 6.9.2, but 6.9.2–6.10.0 ship the older
+`SolutionLoaderBase` / `get_primals`) and **pounce-solver > 0.9.0**
+(Pyomo's `asl_sol_reader` is strict where the legacy reader is lenient
+and needs the per-model `.sol` `Options` echo added after 0.9.0).
+`pip install pyomo-pounce[v2]` asks for both. Neither applies to
+`SolverFactory('pounce')`: on an older Pyomo the legacy plugin works
+exactly as before and `pyomo_pounce.HAVE_V2_INTERFACE` reports `False`.
+
 They differ in API and in per-solve overhead. The v2 interface returns a
 `Results` object and hands the solution back through a solution loader
 (so `load_solutions=False` gives you the values without touching the

--- a/pyomo-pounce/README.md
+++ b/pyomo-pounce/README.md
@@ -83,11 +83,20 @@ silently drops all of the above — the integer-variable guard, the
 `scaling_factor` handling, the sensitivity path and the bundled-binary
 resolution. Prefer one of the two registrations above.
 
-> The v2 interface needs **Pyomo ≥ 6.9.2** (where `pyomo.contrib.solver.common`
-> landed). On an older Pyomo `import pyomo_pounce` still works and the legacy
-> plugin behaves exactly as before; `pyomo_pounce.HAVE_V2_INTERFACE` reports
-> whether the v2 names are available. `pip install pyomo-pounce[v2]` asks for
-> a new enough Pyomo.
+> **Requirements for the v2 route** — `pip install pyomo-pounce[v2]` asks for
+> both:
+>
+> - **Pyomo ≥ 6.10.1**, which is where the `SolutionLoader` / `get_vars` API
+>   this builds on landed. (`pyomo.contrib.solver.common` exists from 6.9.2,
+>   but 6.9.2–6.10.0 ship the older `SolutionLoaderBase` / `get_primals`.)
+> - **pounce-solver > 0.9.0**. The v2 route reads the `.sol` through Pyomo's
+>   `asl_sol_reader`, which is strict where the legacy reader is lenient, so it
+>   needs the per-model `Options` echo added after 0.9.0.
+>
+> Neither applies to `SolverFactory('pounce')`. On an older Pyomo,
+> `import pyomo_pounce` still works and the legacy plugin behaves exactly as
+> before; `pyomo_pounce.HAVE_V2_INTERFACE` reports whether the v2 names are
+> available.
 
 ## Solver Options
 

--- a/pyomo-pounce/README.md
+++ b/pyomo-pounce/README.md
@@ -50,6 +50,45 @@ print(f"x* = {value(model.x)}")  # 2.0
 > version string — two builds can share the same `X.Y.Z` while differing in
 > behavior (as a binary from before/after a fix does).
 
+## Pyomo's modern (`pyomo.contrib.solver`) interface
+
+The same solver is registered against Pyomo's newer solver interface —
+the one `ipopt_v2` uses — carrying every extra on this page:
+
+```python
+import pyomo_pounce
+from pyomo.contrib.solver.common.factory import SolverFactory as SolverFactoryV2
+
+solver = SolverFactoryV2('pounce')          # returns a v2 Results object
+results = solver.solve(model)
+print(results.solution_status, results.incumbent_objective)
+```
+
+`SolverFactory('pounce_v2')` gives the same engine behind the legacy API,
+mirroring Pyomo's own `ipopt` / `ipopt_v2` split. `SolverFactory('pounce')`
+is unchanged and remains fully supported.
+
+Both routes return the same numbers — a test solves one model through
+each and compares primals, objective, duals and reduced costs. They
+differ in API (v2 returns `Results` and hands the solution back through a
+loader, so `load_solutions=False` gives you values without touching the
+model; options are `solver_options={...}` rather than `options={...}`)
+and in per-solve overhead outside the solve, which on IDAES-shaped
+collocation models is roughly 0.25 s/solve lower on v2. See
+[the Pyomo docs page](https://jkitchin.github.io/pounce/pyomo.html) for
+the measurements.
+
+Pointing `ipopt_v2` at the `pounce` binary by hand also works, but
+silently drops all of the above — the integer-variable guard, the
+`scaling_factor` handling, the sensitivity path and the bundled-binary
+resolution. Prefer one of the two registrations above.
+
+> The v2 interface needs **Pyomo ≥ 6.9.2** (where `pyomo.contrib.solver.common`
+> landed). On an older Pyomo `import pyomo_pounce` still works and the legacy
+> plugin behaves exactly as before; `pyomo_pounce.HAVE_V2_INTERFACE` reports
+> whether the v2 names are available. `pip install pyomo-pounce[v2]` asks for
+> a new enough Pyomo.
+
 ## Solver Options
 
 Pass options the same way as IPOPT:

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -62,19 +62,29 @@ from pyomo_pounce.preflight import (
 )
 from pyomo_pounce.repair import InitializeReport, initialize, project_to_feasible
 
-# The v2 interface needs Pyomo's `pyomo.contrib.solver.common` layout,
-# which landed in 6.9.2; this package supports pyomo>=6.0 through the
-# legacy plugin and must keep importing cleanly there. So the v2
-# registration is optional: on an older Pyomo, `import pyomo_pounce`
+# The v2 interface needs Pyomo 6.10.1+; this package supports pyomo>=6.0
+# through the legacy plugin and must keep importing cleanly there. So the
+# v2 registration is optional: on an older Pyomo, `import pyomo_pounce`
 # still works and SolverFactory('pounce') behaves exactly as before --
 # only the v2 names are absent, and `HAVE_V2_INTERFACE` says so.
+#
 # The probe is on Pyomo, not on `pyomo_pounce.v2`: wrapping the latter in
 # try/except would also swallow a genuine ImportError raised by a bug
 # inside it and report the interface as merely "unavailable". Once Pyomo
-# is known to have the layout, v2 is imported unguarded so real breakage
-# is loud.
+# is known to have the API, v2 is imported unguarded so real breakage is
+# loud.
+#
+# Probe `SolutionLoader` specifically, NOT the `pyomo.contrib.solver.
+# common` package. The package exists from 6.9.2, but 6.9.2-6.10.0 ship
+# the older `SolutionLoaderBase`/`get_primals` API that `v2.py` does not
+# target. A package-level probe therefore passes across all five of those
+# releases and lets v2.py's ImportError escape -- which took `import
+# pyomo_pounce` down with it, and the legacy plugin with that. This name
+# is the one that actually tracks the API v2.py uses.
 try:
-    import pyomo.contrib.solver.common.factory as _probe  # noqa: F401
+    from pyomo.contrib.solver.common.solution_loader import (  # noqa: F401
+        SolutionLoader as _probe,
+    )
 except ImportError:  # pragma: no cover - depends on the Pyomo version
     HAVE_V2_INTERFACE = False
 else:

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -5,6 +5,12 @@ Usage:
     from pyomo.environ import *
     solver = SolverFactory('pounce')
 
+The same solver is registered against Pyomo's newer `pyomo.contrib.solver`
+interface as well, carrying all of the extras below (see pyomo_pounce.v2):
+    from pyomo.contrib.solver.common.factory import SolverFactory as SF2
+    solver = SF2('pounce')             # v2 interface
+    solver = SolverFactory('pounce_v2')  # v2 engine, legacy API
+
 Initialization helpers (see the POUNCE docs' initialization chapter):
     report = pyomo_pounce.preflight(model)         # starting-point check
     pyomo_pounce.initialize(model, decisions=[...])  # fill -> repair -> block-solve
@@ -56,8 +62,29 @@ from pyomo_pounce.preflight import (
 )
 from pyomo_pounce.repair import InitializeReport, initialize, project_to_feasible
 
+# The v2 interface needs Pyomo's `pyomo.contrib.solver.common` layout,
+# which landed in 6.9.2; this package supports pyomo>=6.0 through the
+# legacy plugin and must keep importing cleanly there. So the v2
+# registration is optional: on an older Pyomo, `import pyomo_pounce`
+# still works and SolverFactory('pounce') behaves exactly as before --
+# only the v2 names are absent, and `HAVE_V2_INTERFACE` says so.
+# The probe is on Pyomo, not on `pyomo_pounce.v2`: wrapping the latter in
+# try/except would also swallow a genuine ImportError raised by a bug
+# inside it and report the interface as merely "unavailable". Once Pyomo
+# is known to have the layout, v2 is imported unguarded so real breakage
+# is loud.
+try:
+    import pyomo.contrib.solver.common.factory as _probe  # noqa: F401
+except ImportError:  # pragma: no cover - depends on the Pyomo version
+    HAVE_V2_INTERFACE = False
+else:
+    del _probe
+    from pyomo_pounce.v2 import LegacyPounceSolver, Pounce, PounceConfig
+    HAVE_V2_INTERFACE = True
+
 __all__ = [
     "POUNCE",
+    "HAVE_V2_INTERFACE",
     "check_binary",
     "declare_sens_param",
     "declare_fitted",
@@ -85,3 +112,6 @@ __all__ = [
     "Information",
     "structural_incidence",
 ]
+
+if HAVE_V2_INTERFACE:
+    __all__ += ["Pounce", "PounceConfig", "LegacyPounceSolver"]

--- a/pyomo-pounce/pyomo_pounce/pounce_solver.py
+++ b/pyomo-pounce/pyomo_pounce/pounce_solver.py
@@ -101,6 +101,44 @@ def _discrete_vars(model, max_list=5):
     return names, total
 
 
+def reject_discrete_vars(model):
+    """Raise if `model` has a live (active, non-fixed) Binary/Integer
+    variable, which POUNCE cannot honor.
+
+    POUNCE has no branch-and-bound: handing it such a model does not
+    fail -- it silently solves the continuous relaxation and reports a
+    fractional value as `optimal` for a variable you declared discrete
+    (gh #341). Ipopt-via-ASL has this same gap, but pyomo_pounce already
+    fails loudly elsewhere for comparable silent-wrongness risks (the
+    ambiguous curve_fit bounds shape, gh #260/#265; the stale-binary
+    check, gh #315), so it does here too rather than matching the
+    generic ASL/Ipopt behavior.
+
+    Shared by both interfaces: the legacy `POUNCE` plugin and the
+    `pyomo.contrib.solver` one in `pyomo_pounce.v2`. A guard that
+    protected only the legacy route would leave the modern route with
+    exactly the silent wrongness this exists to prevent (gh #558).
+    """
+    if model is None:
+        return
+    names, total = _discrete_vars(model)
+    if not names:
+        return
+    shown = ", ".join(names)
+    more = f" (+{total - len(names)} more)" if total > len(names) else ""
+    raise ValueError(
+        "pounce solve: model has "
+        f"{total} active, non-fixed integer/binary variable(s) "
+        f"(e.g. {shown}{more}), but POUNCE is a continuous NLP "
+        "solver with no branch-and-bound or SOS handling -- it "
+        "would silently solve the continuous relaxation and "
+        "report a fractional value as 'optimal' for a variable "
+        "declared discrete. Fix the variable's domain (or set "
+        "var.domain = pyomo.environ.Reals / relax it explicitly) "
+        "if a continuous relaxation is what you intend, or use a "
+        "MINLP-capable solver.")
+
+
 _fallback_warned = False
 
 
@@ -166,31 +204,7 @@ class POUNCE(ASL):
                 f"{', '.join(sorted(explicit))}= given but no model was "
                 "passed; call solve(model, ...) with the model positionally "
                 "or as the `model` keyword")
-        if model is not None:
-            # POUNCE has no branch-and-bound: handing it a model with a live
-            # (non-fixed) Binary/Integer variable does not fail -- it silently
-            # solves the continuous relaxation and reports a fractional value
-            # as `optimal` for a variable you declared discrete (gh #341).
-            # Ipopt-via-ASL has this same gap, but pyomo_pounce already fails
-            # loudly elsewhere for comparable silent-wrongness risks (the
-            # ambiguous curve_fit bounds shape, gh #260/#265; the stale-binary
-            # check, gh #315), so it does here too rather than matching the
-            # generic ASL/Ipopt behavior.
-            names, total = _discrete_vars(model)
-            if names:
-                shown = ", ".join(names)
-                more = f" (+{total - len(names)} more)" if total > len(names) else ""
-                raise ValueError(
-                    "pounce solve: model has "
-                    f"{total} active, non-fixed integer/binary variable(s) "
-                    f"(e.g. {shown}{more}), but POUNCE is a continuous NLP "
-                    "solver with no branch-and-bound or SOS handling -- it "
-                    "would silently solve the continuous relaxation and "
-                    "report a fractional value as 'optimal' for a variable "
-                    "declared discrete. Fix the variable's domain (or set "
-                    "var.domain = pyomo.environ.Reals / relax it explicitly) "
-                    "if a continuous relaxation is what you intend, or use a "
-                    "MINLP-capable solver.")
+        reject_discrete_vars(model)
         # Solver options as the solve will actually see them: factory-level
         # options (SolverFactory("pounce", options=...) or
         # solver.options[...]) first, per-call options={...} on top.

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -622,7 +622,7 @@ def _stream_solve(solver, x0, **solve_kwargs):
 
 
 def sens_solve(model, tee=False, sens_params=None, fitted=None,
-               residuals=None, options=None):
+               residuals=None, options=None, capture=None):
     """Solve `model` in-process with POUNCE and keep the KKT factorization
     for gradient()/estimate()/covariance(). Called automatically by
     SolverFactory('pounce').solve() when declarations are present; the
@@ -633,7 +633,19 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     them; with `warm_start_init_point=yes` among them, the initial
     multipliers come from the model's `dual` / `ipopt_zL_in` /
     `ipopt_zU_in` suffixes (see `_warm_start_from_suffixes`). Returns a
-    Pyomo SolverResults, like an ordinary solve."""
+    Pyomo SolverResults, like an ordinary solve.
+
+    `capture`, when a mutable mapping is passed, is filled in with the
+    raw outcome of the solve -- the primal iterate, the engine's `info`
+    dict (multipliers included), the `.col`/`.row` name lists, the
+    surgery alias map and the elapsed solve time. This path returns a
+    *legacy* SolverResults because that is what the legacy interface
+    needs; `pyomo_pounce.v2` builds a `pyomo.contrib.solver` `Results`
+    and solution loader from the same solve, and needs the multipliers
+    and row order to do it. Populated for a failed solve too, which is
+    exactly when the session is dropped and there is nothing else left
+    to read the outcome from. Ignored when None (the default), so the
+    legacy path pays nothing for it."""
     import pounce
 
     reg = _registry(model)
@@ -747,6 +759,16 @@ def sens_solve(model, tee=False, sens_params=None, fitted=None,
     status_msg = str(info.get("status_msg", ""))
     tc, ss = _STATUS_RESULT.get(
         status_msg, (TerminationCondition.error, SolverStatus.error))
+
+    if capture is not None:
+        # Everything the v2 interface needs to build its own Results and
+        # solution loader, recorded before the non-converged early return
+        # below (which drops the session) so a failed solve is reported
+        # there as fully as a successful one.
+        capture.update(
+            x=np.asarray(x), info=info, status_msg=status_msg,
+            var_names=var_names, con_names=con_names, con_alias=con_alias,
+            n=int(nl.n), m=int(nl.m), solve_secs=solve_secs)
 
     # Return a Pyomo SolverResults indistinguishable from an ordinary
     # solve's: same fields (counts, time, Id/Error rc, emptied Solution

--- a/pyomo-pounce/pyomo_pounce/v2.py
+++ b/pyomo-pounce/pyomo_pounce/v2.py
@@ -1,0 +1,547 @@
+"""POUNCE on Pyomo's modern solver interface (``pyomo.contrib.solver``).
+
+`pyomo_pounce.pounce_solver.POUNCE` drives POUNCE through Pyomo's
+*legacy* interface (`pyomo.solvers.plugins.solvers.ASL.ASL`). This
+module registers a second, independent interface for the same solver
+against `pyomo.contrib.solver` -- Pyomo's newer solver API, the one
+`ipopt_v2` uses -- so that the modern route is a supported way to reach
+POUNCE rather than a generic `ipopt_v2`-pointed-at-our-binary hack
+(gh #558).
+
+Both interfaces stay registered, under separate names::
+
+    import pyomo_pounce
+    from pyomo.environ import SolverFactory
+    SolverFactory('pounce')                     # legacy (unchanged)
+    SolverFactory('pounce_v2')                  # v2 engine, legacy API
+
+    from pyomo.contrib.solver.common.factory import SolverFactory as SF2
+    SF2('pounce')                               # v2 interface
+
+Why this exists rather than "just use `ipopt_v2`": pointing `ipopt_v2`
+at the POUNCE binary does solve the model, but it silently drops
+everything `pyomo-pounce` adds. This class carries all of it onto the v2
+lifecycle:
+
+* bundled-binary resolution, so a stale `pounce` on `PATH` is not picked
+  up silently (gh #315);
+* the guard that refuses a model with live integer variables rather than
+  solving the continuous relaxation and calling a fractional value
+  optimal (gh #341);
+* `scaling_factor` Suffix handling (gh #483 / #486);
+* the sensitivity path (`declare_sens_param` -> in-process
+  `pounce.Solver`), translated onto the v2 `Results`/solution-loader
+  contract rather than copied -- see :class:`PounceSensSolutionLoader`.
+
+What is inherited from Pyomo's own `Ipopt` v2 class, deliberately: the
+`.nl` write, the `.sol` read, option splitting between the command line
+and the `.opt` file, and the solver-log parse. POUNCE is
+ASL/Ipopt-compatible on every one of those surfaces -- it accepts
+`key=value` options and `option_file_name=<path>`, and its log carries
+the same ``Number of Iterations....:`` and ``Total seconds in POUNCE =``
+lines the Ipopt parser looks for. What is *not* compatible, and is
+overridden here, is the version banner: `pounce --version` prints
+``pounce X.Y.Z``, which Pyomo's Ipopt parser rejects by design (it
+requires a leading ``ipopt`` precisely so that other ASL executables are
+not mistaken for Ipopt).
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import re
+import subprocess
+from timeit import default_timer
+from typing import Any, Mapping, Sequence
+
+from pyomo.common.collections import ComponentMap
+from pyomo.core.base.constraint import Constraint
+from pyomo.core.base.var import Var
+
+try:
+    from pyomo.contrib.solver.common.base import LegacySolverWrapper
+    from pyomo.contrib.solver.common.factory import (
+        SolverFactory as ContribSolverFactory,
+    )
+    from pyomo.contrib.solver.common.results import (
+        Results,
+        SolutionStatus,
+        TerminationCondition,
+    )
+    from pyomo.contrib.solver.common.solution_loader import SolutionLoader
+    from pyomo.contrib.solver.common.util import (
+        NoOptimalSolutionError,
+        NoSolutionError,
+    )
+    from pyomo.contrib.solver.solvers.ipopt import Ipopt, IpoptConfig
+except ImportError as exc:  # pragma: no cover - depends on the Pyomo version
+    # Pyomo moved this interface into `pyomo.contrib.solver.common` (and
+    # `.solvers`) in 6.9.2. Earlier versions ship an older, materially
+    # different draft of it under `pyomo.contrib.solver.*` -- different
+    # loader base class, different accessor names -- which this module
+    # does not target. `pyomo_pounce` itself still supports pyomo>=6.0
+    # through the legacy plugin, so this is raised as a clear message
+    # rather than being papered over, and `pyomo_pounce/__init__.py`
+    # treats it as "v2 unavailable" instead of failing the import.
+    raise ImportError(
+        "pyomo_pounce.v2 needs Pyomo's `pyomo.contrib.solver.common` "
+        "interface, which is Pyomo 6.9.2 or newer. The legacy "
+        "SolverFactory('pounce') plugin works on any supported Pyomo; "
+        "upgrade Pyomo to use the v2 interface."
+    ) from exc
+
+from pyomo_pounce.pounce_solver import (
+    _bundled_path,
+    _warn_path_fallback,
+    reject_discrete_vars,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["Pounce", "PounceConfig", "LegacyPounceSolver",
+           "PounceSensSolutionLoader"]
+
+
+def _default_executable():
+    """Default for the `executable` config: the wheel-bundled binary when
+    one is installed, else the bare name for a `PATH` lookup.
+
+    Same precedence as the legacy plugin's `_default_executable`, and for
+    the same reason -- the bundled path is deterministic while `PATH` can
+    hand back a stale build that reports an identical version string
+    (gh #315). Resolved once, when the CONFIG is built at import: the
+    bundled binary's location is fixed at install time.
+    """
+    bundled = _bundled_path()
+    return bundled if bundled is not None else "pounce"
+
+
+class PounceConfig(IpoptConfig):
+    """`IpoptConfig` with the executable defaulted to POUNCE's binary.
+
+    Everything else -- `writer_config`, `solver_options`, `tee`,
+    `time_limit`, ... -- is Pyomo's, unchanged, because POUNCE takes the
+    same `.nl` input and the same `key=value` / `.opt` option forms.
+    """
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        exe = self.get("executable")
+        exe.set_default_value(_default_executable())
+        exe.reset()
+        exe._description = (
+            "Preferred executable for pounce. Defaults to the `pounce` "
+            "binary bundled in the installed `pounce-solver` wheel, "
+            "falling back to searching the ``PATH`` for the first "
+            "available ``pounce``."
+        )
+
+
+#: `pounce --version` prints ``pounce X.Y.Z``. Anchored, and requiring the
+#: program name, for the same reason Pyomo's Ipopt parser requires
+#: ``ipopt``: so that some *other* ASL executable handed to `executable=`
+#: is reported as "not found" rather than silently driven as POUNCE.
+_VERSION_RE = re.compile(r"^\s*pounce\s+(\d+(?:\.\d+)*)", re.IGNORECASE)
+
+
+#: POUNCE exit status (the engine's `status_msg`) -> the v2 pair
+#: (TerminationCondition, SolutionStatus). The legacy sensitivity path
+#: maps the same statuses onto the legacy `TerminationCondition` /
+#: `SolverStatus` pair in `sens._STATUS_RESULT`; the two enums are
+#: different sets with different members, so this is a translation of
+#: the same table, not an alias of it.
+_V2_STATUS = {
+    "Solve_Succeeded": (
+        TerminationCondition.convergenceCriteriaSatisfied,
+        SolutionStatus.optimal,
+    ),
+    "Solved_To_Acceptable_Level": (
+        TerminationCondition.convergenceCriteriaSatisfied,
+        SolutionStatus.optimal,
+    ),
+    # A feasible point that did not meet the convergence criteria: the
+    # point is usable, the run is not a success. `unknown` is the honest
+    # termination condition here -- none of the v2 members says "stopped
+    # with a feasible point".
+    "Feasible_Point_Found": (
+        TerminationCondition.unknown,
+        SolutionStatus.feasible,
+    ),
+    "Infeasible_Problem_Detected": (
+        TerminationCondition.locallyInfeasible,
+        SolutionStatus.infeasible,
+    ),
+    "Diverging_Iterates": (
+        TerminationCondition.unbounded,
+        SolutionStatus.noSolution,
+    ),
+    "Maximum_Iterations_Exceeded": (
+        TerminationCondition.iterationLimit,
+        SolutionStatus.noSolution,
+    ),
+    "Maximum_CpuTime_Exceeded": (
+        TerminationCondition.maxTimeLimit,
+        SolutionStatus.noSolution,
+    ),
+    "Maximum_WallTime_Exceeded": (
+        TerminationCondition.maxTimeLimit,
+        SolutionStatus.noSolution,
+    ),
+    "User_Requested_Stop": (
+        TerminationCondition.interrupted,
+        SolutionStatus.noSolution,
+    ),
+}
+
+
+class PounceSensSolutionLoader(SolutionLoader):
+    """v2 solution loader over an in-process sensitivity solve.
+
+    The sensitivity path never writes a `.sol`: it hands POUNCE
+    evaluator callbacks built from `pounce.read_nl` and reads the
+    converged primal/dual vectors straight out of the engine. So the
+    ASL-backed loader the ordinary v2 route uses has nothing to read,
+    and this stands in for it -- the "deliberate translation" the v2
+    lifecycle needs, since v2 returns values *through* the loader rather
+    than loading them as a side effect of `solve` the way the legacy
+    `load_from` path does.
+
+    Two sign conventions are crossed on the way out, mirroring
+    `sens._warm_start_from_suffixes` on the way in:
+
+    * `dual` is the AMPL marginal ``d obj / d b = -lambda`` (gh #271),
+      while the engine reports the internal ``+lambda`` in
+      ``info['mult_g']`` -- so duals negate.
+    * `ipopt_zU_out` is negative at an active upper bound (Ipopt's
+      convention, gh #296) while the engine's ``mult_x_U`` is the
+      internal non-negative ``z_u`` -- so it negates too; ``zL`` is
+      positive in both. The reduced cost is then combined from the two
+      bound multipliers exactly as `IpoptSolutionLoader` combines the
+      `.sol` suffixes, so `rc` means the same thing on both routes.
+    """
+
+    def __init__(self, model, capture, has_solution=True):
+        self._pyomo_model = model
+        self._capture = capture
+        self._has_solution = has_solution
+        self._var_row = {n: i for i, n in enumerate(capture["var_names"])}
+        self._con_row = {n: i for i, n in enumerate(capture["con_names"])}
+        self._con_alias = capture.get("con_alias") or {}
+
+    def get_number_of_solutions(self) -> int:
+        return 1 if self._has_solution else 0
+
+    def _require_solution(self):
+        if not self._has_solution:
+            raise NoSolutionError()
+
+    def _vector(self, key):
+        vec = self._capture.get("info", {}).get(key)
+        return None if vec is None else vec
+
+    def get_vars(
+        self, vars_to_load: Sequence[Any] | None = None
+    ) -> Mapping[Any, float]:
+        self._require_solution()
+        x = self._capture["x"]
+        out = ComponentMap()
+        if vars_to_load is None:
+            for name, val in zip(self._capture["var_names"], x):
+                vd = self._pyomo_model.find_component(name)
+                if vd is not None:
+                    out[vd] = float(val)
+            return out
+        for vd in vars_to_load:
+            row = self._var_row.get(vd.name)
+            if row is not None:
+                out[vd] = float(x[row])
+        return out
+
+    def _row_of(self, con_data):
+        """The solve's row index for a constraint of the *original* model.
+
+        A constraint the declared-parameter surgery replaced lives in the
+        solve under its clone's name, so it is reached through the alias
+        map -- the same indirection the warm-start reader applies.
+        """
+        name = con_data.name
+        return self._con_row.get(self._con_alias.get(name, name))
+
+    def get_duals(
+        self, cons_to_load: Sequence[Any] | None = None
+    ) -> dict:
+        self._require_solution()
+        lam = self._vector("mult_g")
+        if lam is None:
+            raise NoSolutionError(
+                "pounce: this solve returned no constraint multipliers, so "
+                "duals are not available")
+        if cons_to_load is None:
+            cons_to_load = self._pyomo_model.component_data_objects(
+                Constraint, active=True, descend_into=True)
+        out = {}
+        for cd in cons_to_load:
+            row = self._row_of(cd)
+            if row is not None:
+                # engine's internal +lambda -> the AMPL marginal Pyomo's
+                # `dual` suffix carries
+                out[cd] = -float(lam[row])
+        return out
+
+    def get_reduced_costs(
+        self, vars_to_load: Sequence[Any] | None = None
+    ) -> Mapping[Any, float]:
+        self._require_solution()
+        zl = self._vector("mult_x_L")
+        zu = self._vector("mult_x_U")
+        if zl is None or zu is None:
+            raise NoSolutionError(
+                "pounce: this solve returned no bound multipliers, so "
+                "reduced costs are not available")
+        if vars_to_load is None:
+            vars_to_load = [
+                vd for vd in (
+                    self._pyomo_model.find_component(n)
+                    for n in self._capture["var_names"])
+                if vd is not None
+            ]
+        out = ComponentMap()
+        for vd in vars_to_load:
+            row = self._var_row.get(vd.name)
+            if row is None:
+                continue
+            lo = float(zl[row])
+            # Ipopt's `ipopt_zU_out` convention, so that the combination
+            # below is the same arithmetic IpoptSolutionLoader does
+            hi = -float(zu[row])
+            out[vd] = hi if abs(hi) > abs(lo) else lo
+        return out
+
+
+class Pounce(Ipopt):
+    """Interface to the POUNCE NLP solver (NL file based)."""
+
+    CONFIG = PounceConfig()
+
+    #: Availability/version cache. Redeclared rather than inherited: the
+    #: cache is keyed by executable path only, and `Pounce` and `Ipopt`
+    #: parse the version banner differently -- sharing one dict would let
+    #: an `Ipopt` probe of some path poison the answer here (and vice
+    #: versa) for the same path.
+    _exe_cache: dict = {}
+
+    def _get_version(self, exe):
+        """POUNCE's version, from ``pounce --version`` (``pounce X.Y.Z``).
+
+        Pyomo's `Ipopt._get_version` demands a banner starting `ipopt`,
+        so POUNCE reads as "not found" through it -- which is why this
+        override exists, and why it is just as strict about the program
+        name: an executable that does not announce itself as `pounce`
+        must not be driven as POUNCE.
+        """
+        try:
+            return self._exe_cache[exe]
+        except KeyError:
+            pass
+        if exe is None:
+            self._exe_cache[None] = None
+            return None
+        try:
+            results = subprocess.run(
+                [str(exe), "--version"],
+                timeout=self._version_timeout,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                universal_newlines=True,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            self._exe_cache[exe] = None
+            return None
+        ver = None
+        if not results.returncode:
+            m = _VERSION_RE.match(results.stdout)
+            if m:
+                try:
+                    ver = tuple(int(i) for i in m.group(1).split("."))
+                except ValueError:
+                    ver = None
+        if ver is None:
+            logger.warning(
+                f"Failed parsing POUNCE version: '{exe} --version':"
+                f"\n\n{results.stdout}")
+        self._exe_cache[exe] = ver
+        return ver
+
+    def _check_executable(self, config):
+        """Warn once if this solve will run a `PATH` binary rather than the
+        wheel-bundled one -- the case that silently ran a stale,
+        dual-sign-flipped build before gh #315.
+
+        Only for the *default* executable: an explicitly passed
+        `executable=` is the user naming a binary on purpose, and warning
+        about it would be noise. Read off the per-solve `config`, not
+        `self.config`, so that a call-time `solve(model, executable=...)`
+        counts as explicit too -- the flag propagates into the derived
+        config, an instance-level one does not propagate back out.
+        """
+        if _bundled_path() is not None:
+            return
+        # `_userSet` is Pyomo-internal; via getattr so that a rename
+        # downgrades this to a spurious warning rather than breaking
+        # every solve.
+        if getattr(config.get("executable"), "_userSet", False):
+            return
+        path = config.executable.path()
+        if path is not None:
+            _warn_path_fallback(path)
+
+    def solve(self, model, **kwds) -> Results:
+        """Solve `model` with POUNCE, returning a v2 `Results`.
+
+        Beyond `Ipopt.solve`: the integer-variable guard, the
+        `scaling_factor` Suffix check, and the in-process sensitivity
+        route when the model carries `declare_sens_param` (or the
+        equivalent call-time keywords) declarations.
+        """
+        from pyomo_pounce.scaling import (
+            user_scaling_requested,
+            warn_if_no_suffix,
+        )
+        from pyomo_pounce.sens import has_declarations
+
+        explicit = {k: kwds.pop(k) for k in
+                    ("sens_params", "fitted", "residuals") if k in kwds}
+
+        reject_discrete_vars(model)
+
+        config: PounceConfig = self.config(value=kwds, preserve_implicit=True)
+        self._check_executable(config)
+
+        # Solver options as this solve will actually see them. Deriving
+        # `config` from `kwds` above already layered them the way
+        # `Ipopt.solve` does -- instance-level `solver.config.
+        # solver_options[...]` merged with per-call `solver_options=`,
+        # the per-call value winning -- so this reads the merged view
+        # rather than re-implementing the precedence. Reading only the
+        # per-call half here is what silently un-tuned every model the
+        # day it gained a declaration on the legacy side (gh #432).
+        opts = dict(config.solver_options.value() or {})
+        if user_scaling_requested(opts):
+            warn_if_no_suffix(model)
+
+        if has_declarations(model) or explicit:
+            return self._sens_solve(model, config, opts, explicit)
+        return super().solve(model, **kwds)
+
+    def _sens_solve(self, model, config, opts, explicit) -> Results:
+        """The sensitivity route, translated onto the v2 contract.
+
+        `sens.sens_solve` solves in-process so that the converged KKT
+        factorization stays available for `gradient()` / `estimate()` /
+        `covariance()`, and returns a *legacy* SolverResults. The v2
+        contract is a different object with a different status enum, and
+        -- the substantive difference -- it hands the solution back
+        through a solution loader that the caller may decline to load
+        (`load_solutions=False`) or read without loading. So the raw
+        solve is captured and re-expressed here rather than the legacy
+        results object being adapted.
+        """
+        from pyomo_pounce.sens import sens_solve
+
+        start_time = default_timer()
+        results = Results()
+        results.timing_info.start_timestamp = datetime.datetime.now(
+            datetime.timezone.utc)
+        results.solver_name = self.name
+        results.solver_version = self._get_version(config.executable.path())
+
+        opts = dict(opts)
+        if config.time_limit is not None:
+            # same mapping `_run_ipopt` applies for the ordinary route
+            opts.setdefault("max_cpu_time", config.time_limit)
+
+        # `sens_solve` writes the converged iterate onto the model's
+        # variables itself -- the legacy contract, where loading IS the
+        # solve's side effect. v2 promises the opposite: with
+        # `load_solutions=False` the model must come back untouched and
+        # the values are read through the loader. So snapshot first and
+        # roll back after; the loader serves the values either way, and
+        # the retained KKT session is unaffected because it answers from
+        # its own `base_x`, not from the model.
+        restore = None
+        if not config.load_solutions:
+            restore = [(vd, vd.value, vd.stale) for vd in
+                       model.component_data_objects(
+                           Var, active=True, descend_into=True)]
+
+        capture = {}
+        try:
+            sens_solve(model, tee=bool(config.tee), options=opts,
+                       capture=capture, **explicit)
+        finally:
+            if restore is not None:
+                for vd, val, stale in restore:
+                    vd.set_value(val, skip_validation=True)
+                    vd.stale = stale
+
+        tc, ss = _V2_STATUS.get(
+            capture.get("status_msg", ""),
+            (TerminationCondition.error, SolutionStatus.noSolution))
+        results.termination_condition = tc
+        results.solution_status = ss
+
+        info = capture.get("info", {})
+        iters = info.get("iter_count")
+        results.extra_info.iteration_count = (
+            None if iters is None else int(iters))
+        results.extra_info.solver_message = capture.get("status_msg")
+        # Same key the ordinary route ends up with: Pyomo's log parser
+        # turns POUNCE's `Total seconds in POUNCE = …` summary line into
+        # `timing_info.POUNCE`, so a caller reading the solver's own time
+        # finds it under one name on both routes. The quantity differs
+        # slightly -- there it is POUNCE's self-reported time, here it is
+        # measured around the in-process call (the tee stream/decode
+        # excluded) because no log is parsed.
+        results.timing_info.POUNCE = capture.get("solve_secs")
+
+        has_solution = ss is not SolutionStatus.noSolution
+        results.solution_loader = PounceSensSolutionLoader(
+            model, capture, has_solution=has_solution)
+
+        if (config.raise_exception_on_nonoptimal_result
+                and ss is not SolutionStatus.optimal):
+            raise NoOptimalSolutionError()
+
+        if config.load_solutions:
+            if not has_solution:
+                raise NoSolutionError()
+            results.solution_loader.load_solution()
+
+        if has_solution:
+            obj = info.get("obj_val")
+            if obj is not None:
+                results.incumbent_objective = float(obj)
+
+        results.solver_config = config
+        results.timing_info.wall_time = default_timer() - start_time
+        return results
+
+
+class LegacyPounceSolver(LegacySolverWrapper, Pounce):
+    """`SolverFactory('pounce_v2')`: the v2 engine behind the legacy API."""
+
+
+# Registered explicitly (not as a decorator) so the legacy wrapper above
+# is the one installed, rather than the anonymous subclass the factory
+# would synthesize. `legacy_name` is what keeps this additive: the v2
+# factory gets `pounce`, the legacy factory gets `pounce_v2`, and the
+# legacy factory's existing `pounce` -> `pounce_solver.POUNCE`
+# registration is untouched. Same split Pyomo itself uses for
+# `ipopt` / `ipopt_v2`.
+ContribSolverFactory.register(
+    name="pounce",
+    legacy_name="pounce_v2",
+    doc="The POUNCE interior-point NLP solver",
+)(Pounce, LegacyPounceSolver)

--- a/pyomo-pounce/pyomo_pounce/v2.py
+++ b/pyomo-pounce/pyomo_pounce/v2.py
@@ -52,6 +52,7 @@ import datetime
 import logging
 import re
 import subprocess
+import warnings
 from timeit import default_timer
 from typing import Any, Mapping, Sequence
 
@@ -76,19 +77,28 @@ try:
     )
     from pyomo.contrib.solver.solvers.ipopt import Ipopt, IpoptConfig
 except ImportError as exc:  # pragma: no cover - depends on the Pyomo version
-    # Pyomo moved this interface into `pyomo.contrib.solver.common` (and
-    # `.solvers`) in 6.9.2. Earlier versions ship an older, materially
-    # different draft of it under `pyomo.contrib.solver.*` -- different
-    # loader base class, different accessor names -- which this module
-    # does not target. `pyomo_pounce` itself still supports pyomo>=6.0
-    # through the legacy plugin, so this is raised as a clear message
-    # rather than being papered over, and `pyomo_pounce/__init__.py`
-    # treats it as "v2 unavailable" instead of failing the import.
+    # The floor is **6.10.1**, and the discriminator is `SolutionLoader`.
+    #
+    # `pyomo.contrib.solver.common` as a package landed in 6.9.2, which
+    # makes it a tempting thing to probe -- and the wrong one. Through
+    # 6.10.0 that package still shipped the older loader API
+    # (`SolutionLoaderBase`, `load_vars`, `get_primals`); `SolutionLoader`
+    # with `load_solution`/`get_vars`, which this module subclasses and
+    # calls, is 6.10.1. So 6.9.2 through 6.10.0 have the package and not
+    # the API, and a package-level probe passes there and then explodes
+    # here.
+    #
+    # `pyomo_pounce` supports pyomo>=6.0 through the legacy plugin, so
+    # this is raised with a clear message rather than papered over, and
+    # `pyomo_pounce/__init__.py` guards on the same name so that an old
+    # Pyomo means "v2 unavailable" and never a failed `import
+    # pyomo_pounce`.
     raise ImportError(
-        "pyomo_pounce.v2 needs Pyomo's `pyomo.contrib.solver.common` "
-        "interface, which is Pyomo 6.9.2 or newer. The legacy "
-        "SolverFactory('pounce') plugin works on any supported Pyomo; "
-        "upgrade Pyomo to use the v2 interface."
+        "pyomo_pounce.v2 needs Pyomo's `pyomo.contrib.solver` interface "
+        "as it exists in Pyomo 6.10.1 or newer (6.9.2-6.10.0 ship the "
+        "package but the older SolutionLoaderBase/get_primals API). The "
+        "legacy SolverFactory('pounce') plugin works on any supported "
+        "Pyomo; upgrade Pyomo to use the v2 interface."
     ) from exc
 
 from pyomo_pounce.pounce_solver import (
@@ -151,6 +161,31 @@ _VERSION_RE = re.compile(r"^\s*pounce\s+(\d+(?:\.\d+)*)", re.IGNORECASE)
 #: `SolverStatus` pair in `sens._STATUS_RESULT`; the two enums are
 #: different sets with different members, so this is a translation of
 #: the same table, not an alias of it.
+#:
+#: The **solution status** column deliberately agrees with what the
+#: ordinary (`.sol`) route produces, because disagreeing changes whether
+#: a solve raises. Pyomo derives it in
+#: `asl_solve_code_to_solution_status` as
+#:
+#:     status = SolutionStatus.unknown if sol_data.primals else noSolution
+#:
+#: overridden only for the optimal / feasible / infeasible code bands.
+#: So "a primal vector came back" is the rule, and the limit and
+#: divergence cases keep `unknown`. The in-process route always has a
+#: primal iterate -- the engine returns `x` regardless of status -- so
+#: they map to `unknown` here too. Mapping them to `noSolution` (as this
+#: table first did) made `solve(m, solver_options={'max_iter': 1},
+#: raise_exception_on_nonoptimal_result=False)` load the final iterate on
+#: the ordinary route and raise `NoSolutionError` on this one, for the
+#: same model and options; `noSolution` was also simply the less accurate
+#: answer, since POUNCE does return a usable iterate in both cases.
+#:
+#: The **termination condition** column does NOT follow the ordinary
+#: route, on purpose: Pyomo's table reads the AMPL solve-code *band* and
+#: cannot tell a time limit from an iteration limit (its source carries
+#: `# this is not always correct` on that line), while POUNCE names the
+#: status exactly. Reporting `maxTimeLimit` for a time limit is strictly
+#: more informative, so that difference is kept.
 _V2_STATUS = {
     "Solve_Succeeded": (
         TerminationCondition.convergenceCriteriaSatisfied,
@@ -174,23 +209,23 @@ _V2_STATUS = {
     ),
     "Diverging_Iterates": (
         TerminationCondition.unbounded,
-        SolutionStatus.noSolution,
+        SolutionStatus.unknown,
     ),
     "Maximum_Iterations_Exceeded": (
         TerminationCondition.iterationLimit,
-        SolutionStatus.noSolution,
+        SolutionStatus.unknown,
     ),
     "Maximum_CpuTime_Exceeded": (
         TerminationCondition.maxTimeLimit,
-        SolutionStatus.noSolution,
+        SolutionStatus.unknown,
     ),
     "Maximum_WallTime_Exceeded": (
         TerminationCondition.maxTimeLimit,
-        SolutionStatus.noSolution,
+        SolutionStatus.unknown,
     ),
     "User_Requested_Stop": (
         TerminationCondition.interrupted,
-        SolutionStatus.noSolution,
+        SolutionStatus.unknown,
     ),
 }
 
@@ -228,9 +263,52 @@ class PounceSensSolutionLoader(SolutionLoader):
         self._var_row = {n: i for i, n in enumerate(capture["var_names"])}
         self._con_row = {n: i for i, n in enumerate(capture["con_names"])}
         self._con_alias = capture.get("con_alias") or {}
+        self._warned_unresolved = False
 
     def get_number_of_solutions(self) -> int:
         return 1 if self._has_solution else 0
+
+    def get_solution_ids(self) -> list:
+        # The base implementation would do this too, but only by way of
+        # `get_number_of_solutions`; spelling it out keeps `solution()`
+        # from raising the base class's NotImplementedError.
+        return [None] if self._has_solution else []
+
+    def _warn_unresolved(self, kind, names):
+        """Warn about solve-space names that do not resolve on the model.
+
+        Not a plain count check against `capture['n']`: on a model with
+        `declare_sens_param` declarations the solve runs on a
+        *surgery clone*, whose `.col`/`.row` files legitimately carry
+        components that exist only there -- the pinned parameter becomes
+        `_SENSITIVITY_TOOLBOX_DATA.p`, and the pin itself becomes a
+        constraint row. Those are expected to be unresolvable on the
+        original model (`sens_solve`'s own load-back skips them the same
+        way), so counting would warn on every sensitivity model, which is
+        precisely the case this route exists for. Only names outside the
+        surgery block indicate a real mismatch -- one that would
+        otherwise leave a variable silently stale after `load_vars`.
+        """
+        if self._warned_unresolved:
+            return
+        try:
+            from pyomo.contrib.sensitivity_toolbox.sens import (
+                SensitivityInterface,
+            )
+            prefix = SensitivityInterface.get_default_block_name() + "."
+        except Exception:  # noqa: BLE001 - a broken probe must not mislead
+            prefix = "_SENSITIVITY_TOOLBOX_DATA."
+        real = [n for n in names if not n.startswith(prefix)]
+        if not real:
+            return
+        self._warned_unresolved = True
+        shown = ", ".join(real[:5])
+        more = f" (+{len(real) - 5} more)" if len(real) > 5 else ""
+        warnings.warn(
+            f"pounce: {len(real)} {kind} from the solve could not be "
+            f"resolved on the model (e.g. {shown}{more}); their values "
+            f"are missing from this solution and will not be loaded.",
+            UserWarning, stacklevel=3)
 
     def _require_solution(self):
         if not self._has_solution:
@@ -247,10 +325,15 @@ class PounceSensSolutionLoader(SolutionLoader):
         x = self._capture["x"]
         out = ComponentMap()
         if vars_to_load is None:
+            missing = []
             for name, val in zip(self._capture["var_names"], x):
                 vd = self._pyomo_model.find_component(name)
-                if vd is not None:
+                if vd is None:
+                    missing.append(name)
+                else:
                     out[vd] = float(val)
+            if missing:
+                self._warn_unresolved("variables", missing)
             return out
         for vd in vars_to_load:
             row = self._var_row.get(vd.name)
@@ -277,16 +360,26 @@ class PounceSensSolutionLoader(SolutionLoader):
             raise NoSolutionError(
                 "pounce: this solve returned no constraint multipliers, so "
                 "duals are not available")
+        report_missing = cons_to_load is None
         if cons_to_load is None:
             cons_to_load = self._pyomo_model.component_data_objects(
                 Constraint, active=True, descend_into=True)
-        out = {}
+        out, missing = {}, []
         for cd in cons_to_load:
             row = self._row_of(cd)
-            if row is not None:
+            if row is None:
+                # A model constraint with no row in the solve. This
+                # direction is the reverse of the variable one -- we are
+                # walking the model, not the clone -- so a surgery
+                # artifact cannot explain it away and it is always worth
+                # reporting.
+                missing.append(cd.name)
+            else:
                 # engine's internal +lambda -> the AMPL marginal Pyomo's
                 # `dual` suffix carries
                 out[cd] = -float(lam[row])
+        if missing and report_missing:
+            self._warn_unresolved("constraints", missing)
         return out
 
     def get_reduced_costs(
@@ -300,12 +393,13 @@ class PounceSensSolutionLoader(SolutionLoader):
                 "pounce: this solve returned no bound multipliers, so "
                 "reduced costs are not available")
         if vars_to_load is None:
-            vars_to_load = [
-                vd for vd in (
-                    self._pyomo_model.find_component(n)
-                    for n in self._capture["var_names"])
-                if vd is not None
-            ]
+            vars_to_load, missing = [], []
+            for n in self._capture["var_names"]:
+                vd = self._pyomo_model.find_component(n)
+                (vars_to_load if vd is not None else missing).append(
+                    vd if vd is not None else n)
+            if missing:
+                self._warn_unresolved("variables", missing)
         out = ComponentMap()
         for vd in vars_to_load:
             row = self._var_row.get(vd.name)
@@ -416,6 +510,15 @@ class Pounce(Ipopt):
 
         reject_discrete_vars(model)
 
+        # Derived here to read the executable and the merged solver
+        # options before deciding anything. On the ordinary route
+        # `super().solve()` derives its own from the same `kwds` and this
+        # one is discarded -- so the `_check_executable` warning below is
+        # computed off an object that is then thrown away. That is safe
+        # because deriving does not mutate `self.config` and the two
+        # derivations are identical, and it is cheap next to a solve; the
+        # alternative (reaching into `Ipopt.solve` to reuse ours) would
+        # mean copying its body.
         config: PounceConfig = self.config(value=kwds, preserve_implicit=True)
         self._check_executable(config)
 
@@ -519,7 +622,14 @@ class Pounce(Ipopt):
                 raise NoSolutionError()
             results.solution_loader.load_solution()
 
-        if has_solution:
+        # Gated exactly as `Ipopt.solve` gates it -- on {feasible,
+        # optimal}, not on "a solution exists". The looser test reported
+        # an objective for an infeasible or limit-stopped solve where the
+        # ordinary route leaves `incumbent_objective` as None, which is a
+        # route disagreement in the direction of over-claiming: the
+        # number is the objective at whatever iterate the solve stopped
+        # on, not at a solution.
+        if ss in (SolutionStatus.feasible, SolutionStatus.optimal):
             obj = info.get("obj_val")
             if obj is not None:
                 results.incumbent_objective = float(obj)

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -29,6 +29,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 
+[project.optional-dependencies]
+# The `pyomo.contrib.solver` (v2) interface registered by
+# `pyomo_pounce.v2` needs Pyomo's `contrib.solver.common` layout, which
+# landed in 6.9.2. The base dependency stays at >=6.0 because the legacy
+# SolverFactory('pounce') plugin works there and most users only need
+# that; `pip install pyomo-pounce[v2]` asks for the newer interface.
+v2 = ["pyomo>=6.9.2"]
+
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"
 Repository = "https://github.com/jkitchin/pounce"

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -31,11 +31,22 @@ classifiers = [
 
 [project.optional-dependencies]
 # The `pyomo.contrib.solver` (v2) interface registered by
-# `pyomo_pounce.v2` needs Pyomo's `contrib.solver.common` layout, which
-# landed in 6.9.2. The base dependency stays at >=6.0 because the legacy
-# SolverFactory('pounce') plugin works there and most users only need
-# that; `pip install pyomo-pounce[v2]` asks for the newer interface.
-v2 = ["pyomo>=6.9.2"]
+# `pyomo_pounce.v2`. Both floors here are strictly tighter than the base
+# dependencies, and neither applies to the legacy
+# SolverFactory('pounce') plugin -- which is why the base stays where it
+# is and this is an extra: `pip install pyomo-pounce[v2]`.
+#
+# * pyomo>=6.10.1 -- `SolutionLoader`/`get_vars`, the loader API this
+#   subclasses. `pyomo.contrib.solver.common` exists from 6.9.2, but
+#   6.9.2-6.10.0 ship the older `SolutionLoaderBase`/`get_primals`.
+# * pounce-solver>0.9.0 -- the v2 route reads the `.sol` through Pyomo's
+#   `asl_sol_reader`, which is strict where the legacy reader is lenient:
+#   it asserts `n_opts >= 2`, so it needs the per-model `Options` echo
+#   added in #553. Released 0.9.0 predates that and fails on every solve
+#   through this route. The legacy plugin is unaffected, so this floor
+#   belongs here rather than on the base dependency. CI builds the binary
+#   from source and would never catch it.
+v2 = ["pyomo>=6.10.1", "pounce-solver>0.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"

--- a/pyomo-pounce/tests/test_v2.py
+++ b/pyomo-pounce/tests/test_v2.py
@@ -1,0 +1,360 @@
+"""The `pyomo.contrib.solver` (v2) interface — gh #558.
+
+Two things are under test here, and they pull in different directions.
+
+1. **The v2 interface reaches POUNCE at all**, and carries `pyomo-pounce`'s
+   extras onto the v2 lifecycle: the integer guard, the `scaling_factor`
+   Suffix check, bundled-binary resolution, and the sensitivity route.
+2. **It agrees with the legacy interface.** These are two genuinely
+   different Pyomo code paths to one solver, so "both work" is not
+   enough — a user moving between them must get the same numbers, with
+   the same sign conventions on duals and reduced costs. Several tests
+   below therefore solve the *same* model both ways and compare, which
+   is also what pins the two ASL-compatibility behaviours from #553
+   (quoted option values, and the per-model `.sol` `Options` echo) from
+   the Python side: the v2 route exercises both on every solve and fails
+   loudly if either regresses.
+"""
+
+import pytest
+
+import pyomo_pounce  # noqa: F401  (registers both interfaces)
+
+# The v2 interface is optional -- it needs Pyomo >= 6.9.2, while the
+# package as a whole supports pyomo>=6.0 through the legacy plugin. On an
+# older Pyomo there is nothing here to test, and that is not a failure.
+if not pyomo_pounce.HAVE_V2_INTERFACE:  # pragma: no cover
+    pytest.skip(
+        "the v2 interface needs Pyomo >= 6.9.2", allow_module_level=True)
+
+from pyomo.contrib.solver.common.factory import (  # noqa: E402
+    SolverFactory as SolverFactoryV2,
+)
+from pyomo.contrib.solver.common.results import (  # noqa: E402
+    SolutionStatus,
+    TerminationCondition,
+)
+from pyomo.environ import (  # noqa: E402
+    Binary,
+    ConcreteModel,
+    Constraint,
+    Objective,
+    Param,
+    SolverFactory,
+    Suffix,
+    Var,
+    value,
+)
+
+from pyomo_pounce.v2 import LegacyPounceSolver, Pounce  # noqa: E402
+
+
+@pytest.fixture(scope="module")
+def v2():
+    s = SolverFactoryV2("pounce")
+    if not s.available():
+        pytest.skip("pounce binary not found")
+    # The duals/reduced costs compared below are only meaningful when the
+    # variables carrying them survive to the `.nl`; Pyomo's linear presolve
+    # eliminates them and (correctly) warns that the values may be wrong.
+    # The legacy interface does no such presolve, so leaving it on would
+    # make the cross-interface comparisons compare different problems.
+    s.config.writer_config.linear_presolve = False
+    return s
+
+
+def _model(with_bounds=True):
+    """A small NLP with an active constraint and an active bound, so that
+    duals and reduced costs are both non-trivial."""
+    m = ConcreteModel()
+    m.p = Param(initialize=2.0, mutable=True)
+    m.x = Var(initialize=0.5, bounds=(0.9, 10) if with_bounds else None)
+    m.y = Var(initialize=0.5, bounds=(0.1, 10) if with_bounds else None)
+    m.c = Constraint(expr=m.x + 2 * m.y == m.p)
+    m.o = Objective(expr=(m.x - 2) ** 2 + (m.y - 3) ** 2)
+    m.dual = Suffix(direction=Suffix.IMPORT)
+    m.rc = Suffix(direction=Suffix.IMPORT)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# registration: additive, and it must not disturb the legacy plugin
+# ---------------------------------------------------------------------------
+
+
+def test_v2_factory_returns_the_v2_class():
+    assert isinstance(SolverFactoryV2("pounce"), Pounce)
+
+
+def test_legacy_pounce_is_unchanged():
+    """`SolverFactory('pounce')` is the documented route and stays on the
+    legacy ASL plugin — registering the v2 interface must not silently
+    move existing users onto a different code path."""
+    from pyomo_pounce.pounce_solver import POUNCE
+
+    assert isinstance(SolverFactory("pounce"), POUNCE)
+
+
+def test_pounce_v2_registered_with_the_legacy_factory():
+    """The v2 engine is also reachable through the legacy API, under the
+    `pounce_v2` name — the same split Pyomo uses for `ipopt` / `ipopt_v2`."""
+    assert isinstance(SolverFactory("pounce_v2"), LegacyPounceSolver)
+
+
+# ---------------------------------------------------------------------------
+# version / availability
+# ---------------------------------------------------------------------------
+
+
+def test_version_is_parsed(v2):
+    """Pyomo's `Ipopt._get_version` requires a banner starting `ipopt`, so
+    POUNCE reads as unavailable through it. The override must parse
+    `pounce X.Y.Z`; without it `available()` is NotFound and the solver
+    refuses to run at all."""
+    ver = v2.version()
+    assert isinstance(ver, tuple) and len(ver) >= 2
+    assert all(isinstance(i, int) for i in ver)
+
+
+def test_version_rejects_a_non_pounce_executable(tmp_path):
+    """An executable that does not announce itself as `pounce` must not be
+    driven as POUNCE — the same strictness Pyomo applies to Ipopt, and for
+    the same reason: silently driving some other ASL binary produces
+    plausible numbers from the wrong solver."""
+    import stat
+
+    fake = tmp_path / "notpounce"
+    fake.write_text("#!/bin/sh\necho 'ipopt 3.14.20'\n")
+    fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+    s = Pounce(executable=str(fake))
+    assert s.version() is None
+
+
+# ---------------------------------------------------------------------------
+# the extras, on the v2 lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_integer_guard_fires_on_the_v2_route(v2):
+    """gh #341 on the v2 route. POUNCE has no branch-and-bound; without
+    this guard the v2 interface would solve the continuous relaxation and
+    report a fractional value as optimal — exactly the silent wrongness
+    the legacy plugin already refuses."""
+    m = _model()
+    m.b = Var(domain=Binary, initialize=0)
+    m.cb = Constraint(expr=m.x >= m.b)
+    with pytest.raises(ValueError, match="no branch-and-bound"):
+        v2.solve(m)
+
+
+def test_integer_guard_ignores_fixed_discrete_vars(v2):
+    """A *fixed* discrete variable is not a decision to relax, so it must
+    not trip the guard."""
+    m = _model()
+    m.b = Var(domain=Binary, initialize=1)
+    m.b.fix(1)
+    v2.solve(m)  # must not raise
+
+
+def test_scaling_suffix_request_without_a_suffix_warns(v2):
+    """gh #483: asking for user scaling on a model that declares none used
+    to be accepted silently and mean "none"."""
+    m = _model()
+    with pytest.warns(UserWarning):
+        v2.solve(m, solver_options={"nlp_scaling_method": "user-scaling"})
+
+
+def test_executable_defaults_to_the_bundled_binary():
+    """gh #315: PATH can hand back a stale build reporting an identical
+    version string, so the bundled binary wins when one is installed."""
+    from pyomo_pounce.pounce_solver import _bundled_path
+
+    bundled = _bundled_path()
+    if bundled is None:
+        pytest.skip("no wheel-bundled binary in this environment")
+    assert Pounce().config.executable.path() == bundled
+
+
+# ---------------------------------------------------------------------------
+# the two interfaces must agree
+# ---------------------------------------------------------------------------
+
+
+def test_v2_matches_legacy_primals_and_duals(v2):
+    """Same model, both interfaces, same answer — including the sign
+    convention on duals and reduced costs.
+
+    This is the check the interface table in `docs/src/pyomo.md` was
+    making by hand, and it also exercises both #553 fixes end-to-end:
+    the v2 route passes options as a single quoted `argv` entry and reads
+    the `.sol` with the strict `Options` reader.
+    """
+    legacy_solver = SolverFactory("pounce")
+    if not legacy_solver.available(exception_flag=False):
+        pytest.skip("pounce binary not found")
+
+    ml = _model()
+    # The legacy ASL path does not synthesize an `rc` suffix -- combining
+    # the two bound multipliers into one reduced cost is something the v2
+    # solution loader does. So read the raw suffixes on this side and do
+    # the combination by hand, which pins the sign convention explicitly
+    # rather than comparing two numbers that happen to agree.
+    ml.ipopt_zL_out = Suffix(direction=Suffix.IMPORT)
+    ml.ipopt_zU_out = Suffix(direction=Suffix.IMPORT)
+    legacy_solver.solve(ml)
+    mv = _model()
+    results = v2.solve(mv)
+
+    assert results.solution_status is SolutionStatus.optimal
+    assert results.termination_condition is (
+        TerminationCondition.convergenceCriteriaSatisfied)
+
+    assert value(mv.x) == pytest.approx(value(ml.x), rel=1e-8, abs=1e-9)
+    assert value(mv.y) == pytest.approx(value(ml.y), rel=1e-8, abs=1e-9)
+    assert results.incumbent_objective == pytest.approx(
+        value(ml.o), rel=1e-8, abs=1e-9)
+
+    assert mv.dual[mv.c] == pytest.approx(ml.dual[ml.c], rel=1e-6, abs=1e-8)
+
+    # `x` is at its lower bound, so this is a live multiplier, not a zero
+    # that would compare equal by accident.
+    zl = ml.ipopt_zL_out.get(ml.x, 0.0)
+    zu = ml.ipopt_zU_out.get(ml.x, 0.0)
+    assert zl > 1e-3
+    expected_rc = zu if abs(zu) > abs(zl) else zl
+    assert mv.rc[mv.x] == pytest.approx(expected_rc, rel=1e-6, abs=1e-8)
+
+
+def test_solver_options_reach_the_binary(v2):
+    """Options must actually take effect, not merely be accepted. A
+    one-iteration cap has to stop the solve."""
+    m = _model()
+    results = v2.solve(
+        m, solver_options={"max_iter": 1},
+        raise_exception_on_nonoptimal_result=False,
+        load_solutions=False)
+    assert results.termination_condition is TerminationCondition.iterationLimit
+
+
+def test_instance_level_options_reach_the_solve():
+    """gh #432 on the v2 route: options set on the solver instance, not
+    just per call, must reach the solver. On the legacy side dropping
+    these silently un-tuned every model that gained a declaration."""
+    s = SolverFactoryV2("pounce")
+    if not s.available():
+        pytest.skip("pounce binary not found")
+    s.config.solver_options["max_iter"] = 1
+    results = s.solve(
+        _model(),
+        raise_exception_on_nonoptimal_result=False,
+        load_solutions=False)
+    assert results.termination_condition is TerminationCondition.iterationLimit
+
+
+def test_instance_options_reach_the_sensitivity_route():
+    """The same, through the in-process path — which reads the options
+    itself rather than handing them to a subprocess, so it is a separate
+    piece of plumbing that can break on its own."""
+    pytest.importorskip("pounce")
+    s = SolverFactoryV2("pounce")
+    if not s.available():
+        pytest.skip("pounce binary not found")
+    s.config.solver_options["max_iter"] = 1
+    results = s.solve(
+        _sens_model(),
+        raise_exception_on_nonoptimal_result=False,
+        load_solutions=False)
+    assert results.termination_condition is TerminationCondition.iterationLimit
+
+
+def test_iteration_count_and_timing_are_parsed(v2):
+    """POUNCE's log is Ipopt-format on the lines Pyomo's parser reads
+    (`Number of Iterations....:` and `Total seconds in POUNCE =`), which
+    is why that parser is inherited rather than reimplemented. If POUNCE's
+    log format drifts, this is what catches it."""
+    m = _model()
+    results = v2.solve(m)
+    assert results.extra_info.iteration_count is not None
+    assert results.extra_info.iteration_count > 0
+
+
+# ---------------------------------------------------------------------------
+# the sensitivity route, translated onto the v2 contract
+# ---------------------------------------------------------------------------
+
+
+def _sens_model():
+    from pyomo_pounce import declare_sens_param
+
+    m = _model()
+    declare_sens_param(m.p)
+    return m
+
+
+def test_sens_route_solves_and_keeps_the_session(v2):
+    """A model carrying `declare_sens_param` must route through the
+    in-process session on v2 too, so that `gradient()` works afterwards —
+    the whole point of the sensitivity path. Pointing `ipopt_v2` at the
+    binary silently skips it."""
+    pytest.importorskip("pounce")
+    from pyomo_pounce import gradient
+
+    m = _sens_model()
+    results = v2.solve(m)
+    assert results.solution_status is SolutionStatus.optimal
+    # d/dp of the solution: available only because the KKT factorization
+    # was retained by the in-process solve. `x` sits on its lower bound
+    # here, so the constraint `x + 2y = p` pins dy/dp to exactly 1/2 --
+    # a value that is checkable by hand rather than merely reproducible.
+    assert gradient(m.y, wrt=m.p) == pytest.approx(0.5, rel=1e-5)
+
+
+def test_sens_route_matches_the_ordinary_route(v2):
+    """The sensitivity route is a different solver path (evaluator
+    callbacks, no `.nl` handed to a subprocess), so it has to be checked
+    against the ordinary one rather than assumed equivalent — primals,
+    objective, duals and reduced costs, with the sign conventions the
+    loader translates by hand."""
+    pytest.importorskip("pounce")
+
+    plain = _model()
+    plain_results = v2.solve(plain)
+
+    sens = _sens_model()
+    sens_results = v2.solve(sens)
+
+    assert value(sens.x) == pytest.approx(value(plain.x), rel=1e-6, abs=1e-8)
+    assert value(sens.y) == pytest.approx(value(plain.y), rel=1e-6, abs=1e-8)
+    assert sens_results.incumbent_objective == pytest.approx(
+        plain_results.incumbent_objective, rel=1e-6, abs=1e-8)
+    assert sens.dual[sens.c] == pytest.approx(
+        plain.dual[plain.c], rel=1e-5, abs=1e-7)
+    assert sens.rc[sens.x] == pytest.approx(
+        plain.rc[plain.x], rel=1e-5, abs=1e-7)
+
+
+def test_sens_route_honours_load_solutions_false(v2):
+    """The substantive difference between the legacy and v2 contracts: v2
+    hands the solution back through a loader the caller may decline to
+    load. The legacy sensitivity path writes values onto the model as a
+    side effect of solving, so this had to be translated, not copied."""
+    pytest.importorskip("pounce")
+
+    m = _sens_model()
+    before = value(m.x)
+    results = v2.solve(m, load_solutions=False)
+    assert value(m.x) == before
+    vals = results.solution_loader.get_vars()
+    assert vals[m.x] != pytest.approx(before)
+    # ...and loading on demand still works
+    results.solution_loader.load_vars()
+    assert value(m.x) == pytest.approx(vals[m.x])
+
+
+def test_sens_route_reports_iteration_count(v2):
+    pytest.importorskip("pounce")
+
+    m = _sens_model()
+    results = v2.solve(m)
+    assert results.extra_info.iteration_count is not None
+    assert results.extra_info.iteration_count > 0

--- a/pyomo-pounce/tests/test_v2.py
+++ b/pyomo-pounce/tests/test_v2.py
@@ -20,12 +20,22 @@ import pytest
 
 import pyomo_pounce  # noqa: F401  (registers both interfaces)
 
-# The v2 interface is optional -- it needs Pyomo >= 6.9.2, while the
+# The v2 interface is optional -- it needs Pyomo >= 6.10.1, while the
 # package as a whole supports pyomo>=6.0 through the legacy plugin. On an
 # older Pyomo there is nothing here to test, and that is not a failure.
+#
+# The import above is deliberately NOT wrapped in a try/skip. `import
+# pyomo_pounce` raising is never an "old Pyomo" condition to skip past --
+# it is the regression that takes SolverFactory('pounce') down with it
+# (the v2 probe on `pyomo.contrib.solver.common` did exactly that on
+# 6.9.2-6.10.0), and it has to fail loudly. `HAVE_V2_INTERFACE` is the
+# only thing that may legitimately be False here. What actually
+# exercises this guard is the below-floor CI leg in ci.yml, which
+# installs a Pyomo older than the floor and asserts the import still
+# works and the flag is False.
 if not pyomo_pounce.HAVE_V2_INTERFACE:  # pragma: no cover
     pytest.skip(
-        "the v2 interface needs Pyomo >= 6.9.2", allow_module_level=True)
+        "the v2 interface needs Pyomo >= 6.10.1", allow_module_level=True)
 
 from pyomo.contrib.solver.common.factory import (  # noqa: E402
     SolverFactory as SolverFactoryV2,
@@ -352,6 +362,93 @@ def test_sens_route_honours_load_solutions_false(v2):
     # ...and loading on demand still works
     results.solution_loader.load_vars()
     assert value(m.x) == pytest.approx(vals[m.x])
+
+
+def test_routes_agree_on_status_at_the_iteration_limit(v2):
+    """Both routes must report the same `solution_status` for a
+    limit-stopped solve, with **default** `load_solutions`.
+
+    This is the case the other two limit tests cannot see, because they
+    pass `load_solutions=False`. `noSolution` is not loadable and
+    `unknown` is, so a disagreement here is not cosmetic: it decides
+    whether `solve()` raises `NoSolutionError` for the same model and
+    options. The sens route mapped these to `noSolution` originally,
+    which both diverged from the ordinary route and over-stated the
+    outcome — POUNCE returns a usable iterate in both cases.
+    """
+    pytest.importorskip("pounce")
+
+    opts = {"max_iter": 1}
+    plain = _model()
+    plain_results = v2.solve(
+        plain, solver_options=opts,
+        raise_exception_on_nonoptimal_result=False)
+    sens = _sens_model()
+    sens_results = v2.solve(
+        sens, solver_options=opts,
+        raise_exception_on_nonoptimal_result=False)
+
+    assert sens_results.solution_status is plain_results.solution_status
+    assert sens_results.solution_status is SolutionStatus.unknown
+    # ...and both loaded the final iterate rather than raising
+    assert value(plain.x) is not None
+    assert value(sens.x) is not None
+
+
+def test_limit_stopped_solve_reports_no_incumbent_objective(v2):
+    """`incumbent_objective` is gated on {feasible, optimal} on both
+    routes: the objective at a limit-stopped iterate is not the objective
+    at a solution, and the ordinary route leaves it None."""
+    pytest.importorskip("pounce")
+
+    opts = {"max_iter": 1}
+    plain_results = v2.solve(
+        _model(), solver_options=opts,
+        raise_exception_on_nonoptimal_result=False)
+    sens_results = v2.solve(
+        _sens_model(), solver_options=opts,
+        raise_exception_on_nonoptimal_result=False)
+    assert plain_results.incumbent_objective is None
+    assert sens_results.incumbent_objective is None
+
+
+def test_sens_loader_does_not_warn_about_surgery_components(v2, recwarn):
+    """The unresolved-name check must stay quiet on a declared-sens-param
+    model. The solve there runs on a surgery clone whose `.col`/`.row`
+    legitimately name components that exist only on the clone
+    (`_SENSITIVITY_TOOLBOX_DATA.p` and the pin row), so a plain count of
+    resolved-vs-solved names would warn on every sensitivity model — the
+    exact case this route exists for."""
+    pytest.importorskip("pounce")
+
+    m = _sens_model()
+    results = v2.solve(m, load_solutions=False)
+    recwarn.clear()
+    results.solution_loader.get_vars()
+    results.solution_loader.get_duals()
+    results.solution_loader.get_reduced_costs()
+    unresolved = [w for w in recwarn
+                  if "could not be resolved" in str(w.message)]
+    assert not unresolved, [str(w.message) for w in unresolved]
+
+
+def test_sens_loader_does_warn_about_a_real_unresolved_name(v2):
+    """...but it must still fire for a name the surgery cannot explain,
+    or the test above is vacuous. A variable the solve knows about and
+    the model does not is silently skipped by `load_vars`, leaving that
+    variable stale with no diagnostic."""
+    pytest.importorskip("pounce")
+
+    m = _sens_model()
+    results = v2.solve(m, load_solutions=False)
+    loader = results.solution_loader
+    # Splice in a name that is neither on the model nor under the
+    # sensitivity-toolbox block.
+    loader._capture["var_names"] = list(loader._capture["var_names"]) + [
+        "not_a_component"]
+    loader._capture["x"] = list(loader._capture["x"]) + [0.0]
+    with pytest.warns(UserWarning, match="could not be resolved"):
+        loader.get_vars()
 
 
 def test_sens_route_reports_iteration_count(v2):

--- a/pyomo-pounce/tests/test_v2.py
+++ b/pyomo-pounce/tests/test_v2.py
@@ -109,8 +109,11 @@ def test_pounce_v2_registered_with_the_legacy_factory():
 def test_version_is_parsed(v2):
     """Pyomo's `Ipopt._get_version` requires a banner starting `ipopt`, so
     POUNCE reads as unavailable through it. The override must parse
-    `pounce X.Y.Z`; without it `available()` is NotFound and the solver
-    refuses to run at all."""
+    `pounce X.Y.Z`; without it `version()` is None and `available()` is
+    NotFound. Solves still run — nothing gates on the version — so the
+    damage is that every availability check lies, including the
+    `if not solver.available(): skip` guard this suite's own fixture
+    uses, which would silently skip the whole file."""
     ver = v2.version()
     assert isinstance(ver, tuple) and len(ver) >= 2
     assert all(isinstance(i, int) for i in ver)


### PR DESCRIPTION
Fixes #558

## Problem

`pyomo_pounce` registered exactly one solver: `POUNCE`, a subclass of Pyomo's **legacy** `ASL` plugin. #553 made the POUNCE binary *drivable* by `pyomo.contrib.solver` (v2), but that is not the same as having a v2 interface — a user had to point `ipopt_v2` at the executable by hand, and doing so silently dropped everything `pyomo-pounce` adds.

Measured against Pyomo 6.10.1 on this branch's binary, minimising `(b - 0.37)²` over a variable declared `Binary`:

| route | `version()` | `available()` | binary variable |
|---|---|---|---|
| `Ipopt(executable=<pounce>)` (generic v2) | `None` | `NotFound` | returns `b* = 0.370000` as **`optimal`** |
| `contrib.solver` `SolverFactory('pounce')` (this PR) | `(0, 9, 0)` | `FullLicense` | refuses with the #341 error |

Both cells on the top row are the bug. The `available()` one is not fatal — nothing in the v2 solve path gates on the version, so solves still run — but every availability check lies, including the `if not solver.available(): skip` guard most Pyomo suites use. The binary-variable one is the #341 silent wrongness: a fractional value reported as optimal for a variable the user declared discrete.

Beyond the extras, this is also a performance fix. [#552](https://github.com/jkitchin/pounce/issues/552#issuecomment-5229601244) measured the same POUNCE binary through both interfaces on drto/IDAES collocation models:

| model | legacy remainder | v2 remainder |
|---|---|---|
| plain `pyomo.dae` four-tank, n = 3,010 | 0.109 s | 0.104 s |
| drto/IDAES `quad_tank` N=100, n = 2,910 | 0.553 s | 0.301 s |
| drto/IDAES `cart_pole` N=100, n = 2,810 | 0.566 s | 0.295 s |

On that model class the legacy path adds ~0.25 s per solve (~1.8×), and `SolverFactory('pounce')` is the documented route — so those users were paying it with no supported alternative that kept the extras.

## Cause

Nothing was broken; the interface simply did not exist. The one substantive incompatibility uncovered while building it is the version banner: `pounce --version` prints `pounce X.Y.Z`, and Pyomo's `Ipopt._get_version` requires a leading `ipopt` **by design**, precisely so that other ASL executables are not mistaken for Ipopt. POUNCE is ASL/Ipopt-compatible on every other inherited surface — `key=value` options, `option_file_name=<path>`, and a log carrying the `Number of Iterations....:` and `Total seconds in POUNCE =` lines Pyomo's parser reads.

## Fix

`pyomo_pounce.v2.Pounce`, registered alongside the legacy plugin using Pyomo's own `ipopt` / `ipopt_v2` split, so the change is purely additive:

| call | before | after |
|---|---|---|
| `SolverFactory('pounce')` | legacy ASL plugin | **unchanged** |
| `contrib.solver` `SolverFactory('pounce')` | — | v2 interface, all extras |
| `SolverFactory('pounce_v2')` | — | v2 engine, legacy API |

**Subclass `Ipopt`, not `SolverBase`.** That inherits the `.nl` write, `.sol` read, option splitting and log parse, all of which POUNCE is compatible with. Overridden: `_get_version`, the `executable` config default (bundled binary first, #315), and `solve`.

**The extras, translated onto the v2 lifecycle.** The integer guard was extracted to a shared `reject_discrete_vars` — a guard protecting only the legacy route would leave the modern one with exactly the silent wrongness it exists to prevent. Scaling-suffix handling and bundled-binary resolution port directly.

The sensitivity path needed the deliberate translation #558 called for, not a copy. v2 returns a `Results` and hands the solution back through a loader the caller may decline to load; the legacy path writes onto the model as a side effect of solving. So:

- `sens_solve` gains an optional `capture=` mapping recording the raw solve (primal iterate, the engine's `info` with multipliers, `.col`/`.row` order, surgery aliases). Populated before the non-converged early return, so a failed solve — exactly when the session is dropped — is still reportable. The legacy path passes nothing and pays nothing.
- `PounceSensSolutionLoader` serves primals, duals and reduced costs from that capture. Two sign conventions are crossed on the way out, inverting what `_warm_start_from_suffixes` does on the way in: `dual` is the AMPL marginal `-lambda` against the engine's internal `mult_g` (#271), and `ipopt_zU_out` is negative at an active upper bound (#296) against the internal non-negative `mult_x_U`. The two bound multipliers are then combined exactly as `IpoptSolutionLoader` combines the `.sol` suffixes, so `rc` means the same thing on both routes.
- With `load_solutions=False`, variable values are snapshotted and rolled back, since `sens_solve` writes them unconditionally. The retained KKT session is unaffected — it answers from its own `base_x`, not from the model.

**Rejected:** re-deriving the sens `Results` by adapting the legacy `SolverResults` it already returns. The enums are disjoint sets, and the loader contract is the substantive difference, so an adapter would have had to reconstruct the multipliers anyway.

**Pyomo floor.** `contrib.solver.common` landed in 6.9.2; the package declares `pyomo>=6.0`. Rather than bump the floor for every legacy user, the v2 registration is optional — `import pyomo_pounce` still works on older Pyomo, `HAVE_V2_INTERFACE` reports availability, and a `[v2]` extra asks for a new enough Pyomo. The probe is on Pyomo, not on `pyomo_pounce.v2`, so a genuine `ImportError` inside the new module surfaces loudly instead of reading as "unavailable".

## Blast radius

**No Rust changed** — this is entirely `pyomo-pounce/` plus docs and CI. The solver corpus cannot move.

`SolverFactory('pounce')` is bit-identical: the only edit to `pounce_solver.py` is extracting the integer guard into a function the legacy `solve` now calls, same error text. `sens_solve` gains one keyword defaulting to `None`; with it unset the function is unchanged.

The one behaviour users could notice: `pyomo.contrib.solver`'s `SolverFactory` now resolves the name `pounce`, which previously raised. Additive.

## Tests

`pyomo-pounce/tests/test_v2.py`, 18 tests. Full suite **273 passed** against a locally-built CLI and `pounce-solver` wheel — real solves throughout, no mocks.

The tests that carry the weight are the cross-route comparisons, because "both work" is not the property that matters:

- `test_v2_matches_legacy_primals_and_duals` — one model through both interfaces, comparing primals, objective, duals and reduced costs. The legacy ASL path does not synthesise `rc` (combining the bound multipliers is a v2-loader behaviour), so it reads raw `ipopt_zL_out`/`ipopt_zU_out` and does the combination by hand, asserting the multiplier is live (`> 1e-3`) rather than a zero that would compare equal by accident.
- `test_sens_route_matches_the_ordinary_route` — the in-process path against the `.sol` path, same four quantities. This is what actually validates the hand-written sign conversions above; it failed while I had them under review and passes now.
- `test_sens_route_honours_load_solutions_false` — pins the snapshot/rollback. **This one failed for the right reason during development**, catching that `sens_solve` writes onto the model unconditionally.
- `test_instance_options_reach_the_sensitivity_route` — #432 on the in-process path, which reads options itself rather than handing them to a subprocess.

**Honest note on the parent commit:** these are new tests for a new module, so on `main` they fail at collection because `pyomo_pounce.v2` does not exist. That is the trivial case, not evidence of biting. The substantive "before" behaviour is the measured table at the top, which I ran against the generic `ipopt_v2` route.

**Deliberately not pinned:** the per-solve overhead figures. They are hardware- and model-dependent (the plain-model row was measured on Linux, the IDAES rows on Windows), and the drto/IDAES models are not vendorable here. The docs table says so and attributes the measurements to #552 rather than presenting them as a CI-checked property.

**CI.** The `wheel smoke (pyomo-pounce)` job is the only place Pyomo runs at all, so it now also asserts the v2 interface resolves a binary and parses its version before the suite runs — a check a plain `import` would not make, given `available()` fails silently.

---

- [x] Tests fail on the parent commit — but see the honest note above: trivially, because the module is new
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/pyomo.md` updated (existing page; no `SUMMARY.md` change needed)
- [ ] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` — **not run: no Rust changed by this PR**
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

On that last box: a first draft of the CHANGELOG and one test docstring claimed that without the `_get_version` override "the solver refused to run". I measured it, found solves run fine and only `available()` misreports, and corrected both in f7be47c before opening this.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PmcbDVNJrL4H9MuoJSELdB)_