### PR TITLE
feat(pounce-rs): feature-gated convex, active-set QP, and sensitivity modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,18 @@ jobs:
       - name: Test
         run: cargo test --workspace --exclude pounce-hsl --verbose
 
+      # The pounce-rs facade's convex / active-set-QP / sensitivity modules are
+      # behind off-by-default features (gh #561), so the workspace steps above
+      # — which build the default feature set — never compile them. Without
+      # this step a re-export could stop matching the crate it mirrors and
+      # nothing would notice until a user enabled the feature. Cheap: the
+      # crates involved are already compiled by the workspace build.
+      - name: Test pounce-rs facade with all features
+        run: |
+          cargo clippy -p pounce-rs --all-features --all-targets -- \
+            -D clippy::correctness -D clippy::suspicious
+          cargo test -p pounce-rs --all-features --verbose
+
       # pounce-hsl is excluded from the build/test/clippy steps above because
       # it FFI-links libcoinhsl (HSL is licensed and absent from CI), so those
       # steps can't link it. But it IS on the crates.io publish list

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ Enabling a feature widens the public surface, not the build: the default NLP
 path already pulls `pounce-qp`, `pounce-linsol`, and `pounce-feral`
 transitively, so only `convex` and `sensitivity` add crates to compile.
 
+The book's Rust snippets moved onto the facade too. `docs/src/sensitivity.md`,
+`docs/src/sessions.md`, and `docs/src/global-optimization.md` were telling
+readers to import `pounce_sensitivity` / `pounce_convex` / `pounce_linsol` /
+`pounce_feral` directly — the exact coupling this change removes, printed as
+the recommended way — and the SOS example hand-rolled the very backend factory
+`pounce_rs::linsol::backend()` now supplies. Each snippet names the feature it
+needs. The `pounce-qp` listings in `docs/src/active-set-sqp-warm-start.md` are
+left alone deliberately: they are annotated with the source path they quote
+(`// crates/pounce-qp/src/problem.rs`) and show that crate's own definitions,
+not user-facing imports.
+
 Each module is covered by an integration test that imports **only**
 `pounce_rs` — the property the issue is about, mechanically checked rather
 than asserted in prose. The sensitivity test pins the same upstream sIPOPT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,60 @@ changes.
 
 ## [Unreleased]
 
+### Added — `pounce-rs` covers the convex, active-set QP, and sensitivity paths (#561)
+
+The `pounce-rs` facade exists so Rust users depend on one crate and are
+insulated from churn in the internal crate layout (#168) — but its
+dependencies were `pounce-common` + `pounce-nlp` + `pounce-algorithm` +
+`pounce-observability`, which is the NLP path and nothing else. Anything past
+a single cold NLP solve — batched QPs, parametric sweeps, sensitivities —
+meant depending directly on the internal crates the facade exists to hide,
+which is exactly the coupling it was introduced to remove. The Python side
+never had this gap: `import pounce` reaches all of it.
+
+Three feature-gated modules close it. The default build is unchanged:
+
+| feature | module | covers |
+|---|---|---|
+| `convex` | `pounce_rs::convex` | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; `solve_qp_batch{,_parallel,_parallel_warm}`, `solve_qp_multi_rhs*`, `QpFactorization` symbolic reuse; `QpSensitivity` / `ReducedHessian` |
+| `qp` | `pounce_rs::qp` | sparse parametric active-set QP: `ParametricActiveSetSolver`, `QpSolver::solve_parametric`, `WorkingSet` warm starts, the `.qps` reader |
+| `sensitivity` | `pounce_rs::sensitivity` | `SensSolve` / `SensResult`, `compute_reduced_hessian`, and the long-form `SensApplication` / Schur stack |
+| `full` | — | all three |
+
+Separate modules rather than a flat re-export because `pounce-convex` and
+`pounce-qp` are different solver families that both name their types
+`QpProblem` / `QpSolution` / `QpStatus` / `QpOptions` / `QpWarmStart`; one
+flat surface cannot carry both.
+
+Two things beyond plain re-exports were needed for the modules to be usable
+from `pounce-rs` alone — without them a caller would still have had to name
+the internal crates, and the gap would have been closed only on paper:
+
+* **`pounce_rs::linsol`** (on with `convex` or `qp`). Both QP entry points are
+  parameterized over the factorization backend — `solve_qp_ipm` takes a
+  `FnMut() -> Box<dyn SparseSymLinearSolverInterface>`,
+  `ParametricActiveSetSolver::new` takes a boxed backend — so the solvers
+  alone are not callable. `backend()` and `serial_backend()` are the two
+  factories every in-tree caller writes by hand (parallel FERAL, and the
+  inner-serial one that keeps `solve_qp_batch_parallel` from
+  oversubscribing).
+* **the triplet storage** (`SymTMatrix` / `GenTMatrix` and their spaces),
+  re-exported through `pounce_rs::qp`, since `pounce_qp::QpProblem` *borrows*
+  its Hessian and Jacobian in that form.
+
+Enabling a feature widens the public surface, not the build: the default NLP
+path already pulls `pounce-qp`, `pounce-linsol`, and `pounce-feral`
+transitively, so only `convex` and `sensitivity` add crates to compile.
+
+Each module is covered by an integration test that imports **only**
+`pounce_rs` — the property the issue is about, mechanically checked rather
+than asserted in prose. The sensitivity test pins the same upstream sIPOPT
+3.14.19 `parametric_cpp` golden Δx that `pounce-sensitivity`'s own tests do,
+to 1e-8. CI grew a `cargo clippy + cargo test -p pounce-rs --all-features`
+step, because the workspace build compiles default features only and would
+never have touched the new modules; `[package.metadata.docs.rs] all-features`
+keeps the published docs from showing the NLP path alone.
+
 ### Changed — `eval_h` routes through the shared-CSE tape, amortizing prelude second-order work across summands (#557)
 
 The follow-on to #476 (`eval_g`) and #553 (`eval_jac_g`): the Lagrangian

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1098,8 +1098,14 @@ version = "0.9.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
+ "pounce-convex",
+ "pounce-feral",
+ "pounce-linalg",
+ "pounce-linsol",
  "pounce-nlp",
  "pounce-observability",
+ "pounce-qp",
+ "pounce-sensitivity",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ numerical backbone:
   infeasibility certificates, warm starts, and post-optimal sensitivity.
 - **Global optimization** — certified global optima for nonconvex
   **polynomial** problems via SOS / Lasserre relaxations. (A general-purpose
-  spatial branch-and-bound solver, `pounce-global`, is in development on the
-  `feature/global` branch and not part of this release.)
+  spatial branch-and-bound solver, `pounce-global`, is in development and not
+  part of this release.)
 
 Convex and conic problems are solved to global optimality; nonconvex problems
 are solved locally by default, or — for polynomials — to a certified global
@@ -81,7 +81,7 @@ against external suites:
   minimum and recovers the global minimizers. A general-purpose spatial
   branch-and-bound solver (`pounce-global`, with McCormick relaxations,
   OBBT/FBBT bound tightening, and a certified optimality gap) is in development
-  on the `feature/global` branch and not part of this release.
+  and not part of this release.
 
 The shipped solvers — NLP, conic, and SOS — are reachable from the CLI, the
 Python package, and the JSON solve report.

--- a/crates/pounce-rs/Cargo.toml
+++ b/crates/pounce-rs/Cargo.toml
@@ -6,7 +6,7 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 readme = "README.md"
-description = "Single-crate facade for solving nonlinear programs with POUNCE from Rust: re-exports the TNLP trait, the IpoptApplication driver, and the supporting types in one place (plus a prelude)."
+description = "Single-crate facade for POUNCE from Rust: re-exports the TNLP trait, the IpoptApplication driver, and the supporting types in one place (plus a prelude), with feature-gated modules for the convex/LP/QP, active-set QP, and sensitivity paths."
 keywords = ["ipopt", "nlp", "optimization", "solver", "nonlinear"]
 categories = ["mathematics", "science"]
 
@@ -15,6 +15,45 @@ pounce-common.workspace = true
 pounce-nlp.workspace = true
 pounce-algorithm.workspace = true
 pounce-observability.workspace = true
+
+# Feature-gated facets (gh #561). Every one of these is already in the
+# dependency graph of the default build — pounce-algorithm pulls
+# pounce-qp / pounce-linsol / pounce-feral, and pounce-sensitivity /
+# pounce-convex sit on the same linear-solver backbone — so enabling a
+# feature widens this crate's *public surface*, not the build. Only
+# pounce-convex and pounce-sensitivity add crates to compile.
+pounce-convex = { workspace = true, optional = true }
+pounce-sensitivity = { workspace = true, optional = true }
+pounce-qp = { workspace = true, optional = true }
+# The `linsol` backend factories the convex / active-set entry points need:
+# both take a `Box<dyn SparseSymLinearSolverInterface>` factory, so a facade
+# that re-exported the solvers without a backend would still leave callers
+# depending on the internal crates directly — exactly the coupling #168 set
+# out to remove.
+pounce-linsol = { workspace = true, optional = true }
+pounce-feral = { workspace = true, optional = true }
+# `pounce_qp::QpProblem` borrows its Hessian / Jacobian as pounce-linalg
+# triplet matrices, so the active-set surface is unusable without them.
+pounce-linalg = { workspace = true, optional = true }
+
+[features]
+# Lean by default: the NLP path only, as before.
+default = []
+# LP / convex QP / SOCP / SDP / SOS interior point, batched solves, and QP
+# sensitivity (`pounce_rs::convex`).
+convex = ["dep:pounce-convex", "dep:pounce-linsol", "dep:pounce-feral"]
+# Sparse parametric active-set QP (`pounce_rs::qp`).
+qp = ["dep:pounce-qp", "dep:pounce-linalg", "dep:pounce-linsol", "dep:pounce-feral"]
+# sIPOPT-style NLP sensitivity / reduced Hessian (`pounce_rs::sensitivity`).
+sensitivity = ["dep:pounce-sensitivity"]
+# Everything the facade curates.
+full = ["convex", "qp", "sensitivity"]
+
+[package.metadata.docs.rs]
+# docs.rs must render the feature-gated modules; otherwise the published
+# documentation shows only the NLP path and the gap #561 reported looks
+# like it is still there.
+all-features = true
 
 [lints]
 workspace = true

--- a/crates/pounce-rs/README.md
+++ b/crates/pounce-rs/README.md
@@ -2,13 +2,16 @@
 
 [![crates.io](https://img.shields.io/crates/v/pounce-rs.svg)](https://crates.io/crates/pounce-rs) [![CI](https://github.com/jkitchin/pounce/actions/workflows/ci.yml/badge.svg)](https://github.com/jkitchin/pounce/actions/workflows/ci.yml) [![docs.rs](https://img.shields.io/docsrs/pounce-rs)](https://docs.rs/pounce-rs)
 
-A single-crate entry point for solving nonlinear programs with
-[POUNCE](https://github.com/jkitchin/pounce) in Rust. It provides two APIs:
+A single-crate entry point for solving optimization problems with
+[POUNCE](https://github.com/jkitchin/pounce) in Rust. For nonlinear programs —
+the default build — it provides two APIs:
 
 - a high-level builder API (`Problem` + `Nlp`) for the common case, where only the objective is required and everything else is optional; and
 - the low-level `TNLP` trait, re-exported for full control over Hessians, sparsity patterns, scaling, and other advanced features.
 
-Both APIs are backed by the same pure-Rust interior-point solver.
+Both APIs are backed by the same pure-Rust interior-point solver. POUNCE's
+other solver paths — convex/LP/QP, active-set QP, and sensitivity analysis —
+are behind [feature flags](#feature-flags-beyond-the-nlp-path).
 
 ## Install
 
@@ -85,6 +88,42 @@ NLP scaling, implement the re-exported `TNLP` trait directly and drive it with
 
 See the [crate docs on docs.rs](https://docs.rs/pounce-rs) for a complete HS071
 `TNLP` walkthrough.
+
+## Feature flags: beyond the NLP path
+
+The default build is the NLP path only. POUNCE's other solver families live in
+their own modules behind features — separate modules because the two QP
+families both name their types `QpProblem` / `QpSolution` / `QpStatus`, so a
+flat surface could not carry both:
+
+| feature | module | what it covers |
+|---|---|---|
+| `convex` | `pounce_rs::convex` | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; batched and warm-started solves; symbolic-factorization reuse; QP sensitivity and reduced Hessian |
+| `qp` | `pounce_rs::qp` | sparse **parametric active-set** QP — the SQP / MPC / continuation engine, indefinite Hessians allowed |
+| `sensitivity` | `pounce_rs::sensitivity` | sIPOPT-style NLP sensitivity: `∂x*/∂p` predictors, parametric warm starts, reduced Hessian |
+| `full` | — | all three |
+
+```toml
+[dependencies]
+pounce-rs = { version = "0.9", features = ["convex", "sensitivity"] }
+```
+
+`convex` and `qp` also bring in `pounce_rs::linsol`, whose `backend()` supplies
+the sparse symmetric factorization those entry points take as an argument.
+
+```rust
+use pounce_rs::convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_batch_parallel};
+use pounce_rs::linsol::serial_backend;
+
+// A batch of box-constrained QPs, one per rayon worker.
+let sols = solve_qp_batch_parallel(&probs, &QpOptions::default(), serial_backend);
+assert!(sols.iter().all(|s| s.status == QpStatus::Optimal));
+```
+
+Enabling a feature widens what this crate *exports*; it is close to free at
+build time, because the default NLP path already pulls `pounce-qp`,
+`pounce-linsol`, and `pounce-feral` transitively. Only `convex` and
+`sensitivity` add crates to compile.
 
 ## License
 

--- a/crates/pounce-rs/src/convex.rs
+++ b/crates/pounce-rs/src/convex.rs
@@ -1,0 +1,113 @@
+//! LP, convex QP, and conic programming — the `pounce-convex` interior-point
+//! path, re-exported (feature `convex`).
+//!
+//! ```toml
+//! [dependencies]
+//! pounce-rs = { version = "0.9", features = ["convex"] }
+//! ```
+//!
+//! The problem is [`QpProblem`] in the standard form
+//!
+//! ```text
+//! minimize    ½ xᵀP x + cᵀx
+//! subject to  A x = b          (equality)
+//!             G x ≤ h          (inequality)
+//!             lb ≤ x ≤ ub      (first-class variable box)
+//! ```
+//!
+//! with `P` supplied as its lower triangle in [`Triplet`] form (an empty `P`
+//! is an LP). Cone blocks beyond the nonnegative orthant — second-order,
+//! exponential, power, PSD — are declared with [`ConeSpec`] and solved by
+//! [`solve_socp_ipm`].
+//!
+//! Every entry point takes a linear-solver factory; [`crate::linsol::backend`]
+//! is the default one.
+//!
+//! ```
+//! use pounce_rs::convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+//! use pounce_rs::linsol::backend;
+//!
+//! // min ‖x‖² − 0.5·x0 − 1.5·x1  s.t.  x0 + x1 == 1,  0 ≤ x ≤ 5
+//! let prob = QpProblem {
+//!     n: 2,
+//!     p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+//!     c: vec![-0.5, -1.5],
+//!     a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+//!     b: vec![1.0],
+//!     g: vec![],
+//!     h: vec![],
+//!     lb: vec![0.0, 0.0],
+//!     ub: vec![5.0, 5.0],
+//! };
+//!
+//! let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+//! assert_eq!(sol.status, QpStatus::Optimal);
+//! assert!((sol.x[0] - 0.25).abs() < 1e-5 && (sol.x[1] - 0.75).abs() < 1e-5);
+//! ```
+//!
+//! ## Batched solves
+//!
+//! [`solve_qp_batch`] solves a slice of independent instances serially (each
+//! factor parallel internally); [`solve_qp_batch_parallel`] runs one instance
+//! per rayon worker, which is the faster arrangement for many small QPs —
+//! pass [`crate::linsol::serial_backend`] there so the workers don't
+//! oversubscribe. [`solve_qp_batch_parallel_warm`] seeds each instance from a
+//! [`QpWarmStart`], and [`solve_qp_multi_rhs`] handles one problem under many
+//! right-hand sides.
+//!
+//! When the instances share a *fixed* sparsity pattern and differ only in
+//! their numbers, [`QpFactorization`] performs the AMD ordering and symbolic
+//! analysis once and reuses it across solves.
+//!
+//! ```
+//! use pounce_rs::convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_batch_parallel};
+//! use pounce_rs::linsol::serial_backend;
+//!
+//! // The same box QP under many linear terms: min ‖x‖² − 2·tᵀx, 0 ≤ x ≤ 1.
+//! let probs: Vec<QpProblem> = [0.25, 0.5, 2.0]
+//!     .iter()
+//!     .map(|t| QpProblem {
+//!         n: 1,
+//!         p_lower: vec![Triplet::new(0, 0, 2.0)],
+//!         c: vec![-2.0 * t],
+//!         a: vec![],
+//!         b: vec![],
+//!         g: vec![],
+//!         h: vec![],
+//!         lb: vec![0.0],
+//!         ub: vec![1.0],
+//!     })
+//!     .collect();
+//!
+//! let sols = solve_qp_batch_parallel(&probs, &QpOptions::default(), serial_backend);
+//! assert!(sols.iter().all(|s| s.status == QpStatus::Optimal));
+//! assert!((sols[0].x[0] - 0.25).abs() < 1e-6);
+//! assert!((sols[2].x[0] - 1.0).abs() < 1e-6);      // clamped by the box
+//! ```
+//!
+//! ## Sensitivity
+//!
+//! [`QpSensitivity`] differentiates a solved QP with respect to its data and
+//! [`ReducedHessian`] gives the curvature on the null space of the active
+//! constraints — the QP counterpart of [`crate::sensitivity`] on the NLP
+//! path.
+//!
+//! ## Beyond the curated surface
+//!
+//! [`pounce_convex`] itself is re-exported, so the modules not listed here
+//! (`crossover`, `presolve`, `hsde`, `equilibrate`, …) stay reachable
+//! without adding a dependency.
+
+pub use pounce_convex::{
+    ActiveSetOverrides, ConeSpec, NEG_INF, POS_INF, PolyProblem, Polynomial, QpFactorization,
+    QpIterate, QpOptions, QpProblem, QpResiduals, QpSensitivity, QpSolution, QpStatus, QpWarmStart,
+    ReducedHessian, SensError, SosBound, SosSolution, Triplet, solve_qp_active_set, solve_qp_batch,
+    solve_qp_batch_parallel, solve_qp_batch_parallel_warm, solve_qp_ipm, solve_qp_ipm_debug,
+    solve_qp_ipm_warm, solve_qp_multi_rhs, solve_qp_multi_rhs_parallel, solve_socp_ipm,
+    solve_socp_ipm_debug, solve_socp_ipm_warm, sos_constrained_lower_bound,
+    sos_constrained_lower_bound_opts, sos_lower_bound, sos_lower_bound_opts, sos_minimize,
+    sos_minimize_opts, sos_opts,
+};
+
+/// The underlying crate, for anything not surfaced above.
+pub use pounce_convex;

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -1,4 +1,4 @@
-//! # pounce-rs — solve nonlinear programs with POUNCE from Rust
+//! # pounce-rs — solve optimization problems with POUNCE from Rust
 //!
 //! POUNCE's solver lives across several crates (`pounce-nlp` for the
 //! [`TNLP`] problem trait, `pounce-algorithm` for the [`IpoptApplication`]
@@ -7,9 +7,35 @@
 //! so a Rust user depends on one crate and writes `use pounce_rs::prelude::*;`
 //! — the Rust counterpart to the one-import `import pounce` Python API.
 //!
-//! It is re-exports only (no logic of its own), and it pins a single curated
-//! public surface, so downstream code is insulated from churn in the internal
-//! crate layout.
+//! It is re-exports plus one ergonomic [`builder`] layer, and it pins a
+//! single curated public surface, so downstream code is insulated from churn
+//! in the internal crate layout.
+//!
+//! ## Feature flags — the paths beyond a single NLP solve
+//!
+//! The default build is the NLP path only. Everything else POUNCE solves is
+//! behind a feature, each landing in its own module so the `Qp*` type names
+//! of the two QP families never collide:
+//!
+//! | feature | module | what it covers |
+//! |---|---|---|
+//! | `convex` | [`convex`] | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; batched and warm-started solves; QP sensitivity and reduced Hessian |
+//! | `qp` | [`qp`] | sparse **parametric active-set** QP — the SQP / MPC / continuation engine, indefinite Hessians allowed |
+//! | `sensitivity` | [`sensitivity`] | sIPOPT-style NLP sensitivity: `∂x*/∂p` predictors, parametric warm starts, reduced Hessian |
+//! | `full` | — | all three |
+//!
+//! ```toml
+//! [dependencies]
+//! pounce-rs = { version = "0.9", features = ["convex", "sensitivity"] }
+//! ```
+//!
+//! `convex` and `qp` also bring in [`linsol`], which supplies the sparse
+//! symmetric factorization backend those entry points take as an argument.
+//!
+//! Enabling a feature widens what this crate *exports*; it is close to free
+//! at build time, because the default NLP path already pulls `pounce-qp`,
+//! `pounce-linsol`, and `pounce-feral` transitively. Only `convex` and
+//! `sensitivity` add crates to compile.
 //!
 //! ## Example: HS071 (Hock–Schittkowski problem 71)
 //!
@@ -200,6 +226,20 @@ pub use pounce_observability;
 // --- ergonomic builder API (argmin-style small trait + builder; #168) -------
 pub mod builder;
 pub use builder::{Nlp, Problem, Solution as NlpSolution};
+
+// --- feature-gated facets (gh #561) -----------------------------------------
+// Each path gets its own module rather than a flat re-export: `pounce-convex`
+// and `pounce-qp` are distinct solver families that both name their types
+// `QpProblem` / `QpSolution` / `QpStatus` / `QpOptions` / `QpWarmStart`, so a
+// flat surface could not carry both.
+#[cfg(feature = "convex")]
+pub mod convex;
+#[cfg(any(feature = "convex", feature = "qp"))]
+pub mod linsol;
+#[cfg(feature = "qp")]
+pub mod qp;
+#[cfg(feature = "sensitivity")]
+pub mod sensitivity;
 
 /// The common case in one glob import. Brings in the ergonomic [`Problem`]
 /// trait + [`Nlp`] builder, plus the low-level [`TNLP`] surface and the

--- a/crates/pounce-rs/src/linsol.rs
+++ b/crates/pounce-rs/src/linsol.rs
@@ -1,0 +1,60 @@
+//! The sparse symmetric linear-solver backend the QP entry points need.
+//!
+//! Both [`crate::convex`] and [`crate::qp`] are parameterized over the
+//! factorization backend rather than hard-wiring one: the interior-point
+//! driver takes a `FnMut() -> Box<dyn SparseSymLinearSolverInterface>`
+//! factory, and `ParametricActiveSetSolver::new` takes a boxed backend
+//! directly. That is deliberate — it is how POUNCE swaps FERAL for
+//! HSL MA27/MA57 — but it means re-exporting the solvers alone would still
+//! leave a caller depending on `pounce-linsol` + `pounce-feral` to produce
+//! the argument. This module closes that gap with the same two factories
+//! every in-tree caller writes by hand.
+//!
+//! Available whenever the `convex` or `qp` feature is on.
+
+pub use pounce_feral::FeralSolverInterface;
+pub use pounce_linsol::{Factorization, FactorizationError, SparseSymLinearSolverInterface};
+
+/// The default backend: FERAL's sparse symmetric indefinite (LDLᵀ)
+/// factorization, parallel inside a single factor.
+///
+/// Pass it as the factory argument — `solve_qp_ipm(&prob, &opts, backend)` —
+/// or call it to build one boxed backend for
+/// `qp::ParametricActiveSetSolver::new`.
+///
+/// ```
+/// # #[cfg(feature = "convex")] {
+/// use pounce_rs::convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+/// use pounce_rs::linsol::backend;
+///
+/// // min ½·2·(x-1)² over 0 ≤ x ≤ 5  ⇒  x* = 1
+/// let prob = QpProblem {
+///     n: 1,
+///     p_lower: vec![Triplet::new(0, 0, 2.0)],
+///     c: vec![-2.0],
+///     a: vec![],
+///     b: vec![],
+///     g: vec![],
+///     h: vec![],
+///     lb: vec![0.0],
+///     ub: vec![5.0],
+/// };
+/// let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+/// assert_eq!(sol.status, QpStatus::Optimal);
+/// assert!((sol.x[0] - 1.0).abs() < 1e-6);
+/// # }
+/// ```
+pub fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::new())
+}
+
+/// The inner-serial backend, for outer-parallel batch solving.
+///
+/// `convex::solve_qp_batch_parallel` runs one instance per rayon worker;
+/// handing each worker a backend that also parallelizes internally
+/// oversubscribes the machine and is typically *slower* than the serial
+/// factor. The serial and parallel FERAL drivers are bit-identical, so this
+/// changes throughput only, never the answer.
+pub fn serial_backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(FeralSolverInterface::serial())
+}

--- a/crates/pounce-rs/src/qp.rs
+++ b/crates/pounce-rs/src/qp.rs
@@ -1,0 +1,82 @@
+//! Sparse parametric active-set QP — the `pounce-qp` engine behind the
+//! active-set SQP path, re-exported (feature `qp`).
+//!
+//! ```toml
+//! [dependencies]
+//! pounce-rs = { version = "0.9", features = ["qp"] }
+//! ```
+//!
+//! This is a different solver family from [`crate::convex`], not a second
+//! interface to it. The interior-point path is the right default for a cold
+//! solve; the active-set path exists for the *parametric* case — an SQP outer
+//! loop, an MPC receding horizon, a continuation sweep — where each QP is a
+//! perturbation of the last and
+//! [`QpSolver::solve_parametric`] traces the homotopy from the previous
+//! solution, reusing the Schur-complement factor instead of refactorizing.
+//! It also accepts an indefinite Hessian, which the convex path by
+//! construction does not.
+//!
+//! The problem is
+//!
+//! ```text
+//! min  ½ xᵀH x + gᵀx    s.t.  bl ≤ A x ≤ bu,  xl ≤ x ≤ xu
+//! ```
+//!
+//! with two-sided bounds throughout (equality is `bl == bu`, a fixed variable
+//! is `xl == xu`, free is `±1e20`). [`QpProblem`] *borrows* `H` and `A` as
+//! [`SymTMatrix`] / [`GenTMatrix`] triplets — the solver never copies them —
+//! so those types are re-exported here too.
+//!
+//! ```
+//! use pounce_rs::linsol::backend;
+//! use pounce_rs::qp::{
+//!     GenTMatrix, GenTMatrixSpace, HessianInertia, ParametricActiveSetSolver, QpOptions,
+//!     QpProblem, QpSolver, SymTMatrix, SymTMatrixSpace,
+//! };
+//! use std::rc::Rc;
+//!
+//! // min ½(4x₀² + 4x₁²) − 2x₀ − 2x₁  s.t.  x₀ + x₁ == 1   ⇒  x* = (½, ½)
+//! // Triplet row/column indices are 1-based.
+//! let mut h = SymTMatrix::new(SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]));
+//! h.set_values(&[4.0, 4.0]);
+//! let mut a = GenTMatrix::new(GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]));
+//! a.set_values(&[1.0, 1.0]);
+//!
+//! let qp = QpProblem {
+//!     n: 2,
+//!     m: 1,
+//!     h: &h,
+//!     g: &[-2.0, -2.0],
+//!     a: &a,
+//!     bl: &[1.0],
+//!     bu: &[1.0],
+//!     xl: &[-1e20, -1e20],
+//!     xu: &[1e20, 1e20],
+//!     hessian_inertia: HessianInertia::Psd,
+//! };
+//!
+//! let mut solver = ParametricActiveSetSolver::new(backend());
+//! let sol = solver.solve(&qp, None, &QpOptions::default()).unwrap();
+//! assert!((sol.x[0] - 0.5).abs() < 1e-8 && (sol.x[1] - 0.5).abs() < 1e-8);
+//! assert!((sol.obj + 1.0).abs() < 1e-8);
+//! ```
+//!
+//! A solve returns its final [`WorkingSet`], which is what a subsequent
+//! [`QpSolver::solve`] takes as a [`QpWarmStart`] seed; [`QpSolver::solve_parametric`]
+//! goes further and carries the factor across.
+//!
+//! [`pounce_qp`] itself is re-exported for the internals — Schur factor
+//! maintenance, the l1-elastic phase-1 reformulation, the KKT assembly
+//! helpers, and the `.qps` reader.
+
+pub use pounce_qp::{
+    AntiCyclingChoice, BoundStatus, ConsStatus, ElasticReformulation, HessianInertia, KktTriplet,
+    LinearSolver, ParametricActiveSetSolver, QpAlgorithm, QpError, QpOptions, QpProblem,
+    QpSolution, QpSolver, QpStats, QpStatus, QpWarmStart, QpsModel, WorkingSet, parse_qps,
+};
+
+/// The borrowed triplet storage [`QpProblem`] is built from.
+pub use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+
+/// The underlying crate, for anything not surfaced above.
+pub use pounce_qp;

--- a/crates/pounce-rs/src/sensitivity.rs
+++ b/crates/pounce-rs/src/sensitivity.rs
@@ -1,0 +1,62 @@
+//! NLP sensitivity, parametric warm starts, and reduced Hessians — the
+//! `pounce-sensitivity` port of Ipopt's sIPOPT, re-exported (feature
+//! `sensitivity`).
+//!
+//! ```toml
+//! [dependencies]
+//! pounce-rs = { version = "0.9", features = ["sensitivity"] }
+//! ```
+//!
+//! The problem shape sIPOPT assumes: the TNLP declares equality constraints
+//! of the form `g_i(x) − p_i = 0`, and the 0-based row indices `i` of those
+//! constraints are the *pins*. [`SensSolve`] solves the NLP once and then,
+//! from the converged KKT factor, returns a first-order predictor
+//! `Δx ≈ (∂x*/∂p)·Δp` for a perturbation of the pinned parameters — no
+//! re-solve, one Schur complement.
+//!
+//! ```no_run
+//! use pounce_rs::prelude::*;
+//! use pounce_rs::sensitivity::SensSolve;
+//! use std::cell::RefCell;
+//! use std::rc::Rc;
+//!
+//! # fn demo(tnlp: Rc<RefCell<dyn TNLP>>) {
+//! let mut app = IpoptApplication::new();
+//! app.initialize().unwrap();
+//!
+//! let result = SensSolve::new(vec![2, 3])          // pinned constraint rows
+//!     .with_deltas(vec![-0.5, 0.0])                // Δp
+//!     .with_reduced_hessian()
+//!     .run(&mut app, tnlp);
+//!
+//! assert_eq!(result.status, ApplicationReturnStatus::SolveSucceeded);
+//! let dx = result.dx.expect("Δx populated when with_deltas was set");
+//! # }
+//! ```
+//!
+//! A sensitivity-stage failure is reported through [`SensResult::error`], not
+//! through `status` — the underlying solve can converge while the post-solve
+//! step fails (a pin that isn't an equality, a Schur setup error). Both
+//! "sensitivity failed" and "sensitivity not requested" leave the outputs
+//! `None`, so `error` is the only signal that separates them.
+//!
+//! [`compute_reduced_hessian`] gives the curvature on the null space of the
+//! active constraints directly, and
+//! [`SensSolve::with_reduced_hessian_eigen`] adds its eigendecomposition via
+//! the shared [`symmetric_eigen`].
+//!
+//! For the long form — [`SensApplication`] driven by an explicit
+//! [`IndexSchurData`] / [`PdSensBacksolver`] / [`DenseGenSchurDriver`] stack —
+//! every piece is re-exported below, and [`pounce_sensitivity`] itself is
+//! re-exported for anything not listed.
+
+pub use pounce_sensitivity::{
+    ConvergedState, DEFAULT_ACTIVE_TOL, DenseGenSchurDriver, DenseLuBacksolver, DiffHandoff,
+    IndexPCalculator, IndexSchurData, PCalculator, PdSensBacksolver, SchurData, SchurDriver,
+    SensApplication, SensBacksolver, SensOptions, SensResult, SensSolve, SensStepCalc, Solver,
+    SolverError, StdStepCalc, WithBacksolver, compute_reduced_hessian, register_options,
+    symmetric_eigen,
+};
+
+/// The underlying crate, for anything not surfaced above.
+pub use pounce_sensitivity;

--- a/crates/pounce-rs/tests/convex_surface.rs
+++ b/crates/pounce-rs/tests/convex_surface.rs
@@ -1,0 +1,118 @@
+//! The `convex` feature's surface, exercised end to end through the facade
+//! only — no `pounce-convex`, `pounce-linsol`, or `pounce-feral` in this
+//! file's imports. That is the point of gh #561: a downstream crate doing
+//! batched or parametric convex solves should not have to name the internal
+//! crates.
+#![cfg(feature = "convex")]
+
+use pounce_rs::convex::{
+    QpFactorization, QpOptions, QpProblem, QpStatus, Triplet, solve_qp_batch,
+    solve_qp_batch_parallel, solve_qp_ipm,
+};
+use pounce_rs::linsol::{backend, serial_backend};
+
+/// `min ‖x − t‖²` over the box `[0, 1]ⁿ`, written as `½ xᵀ(2I)x − 2tᵀx`.
+/// The unconstrained optimum is `t`, clamped componentwise to `[0, 1]`.
+fn boxed_qp(t: &[f64]) -> QpProblem {
+    let n = t.len();
+    QpProblem {
+        n,
+        p_lower: (0..n).map(|i| Triplet::new(i, i, 2.0)).collect(),
+        c: t.iter().map(|v| -2.0 * v).collect(),
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0; n],
+        ub: vec![1.0; n],
+    }
+}
+
+#[test]
+fn single_solve_hits_the_clamped_optimum() {
+    let sol = solve_qp_ipm(
+        &boxed_qp(&[0.25, 2.0, -1.0]),
+        &QpOptions::default(),
+        backend,
+    );
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    for (got, want) in sol.x.iter().zip([0.25, 1.0, 0.0]) {
+        assert!((got - want).abs() < 1e-6, "x = {:?}", sol.x);
+    }
+}
+
+#[test]
+fn equality_constrained_solve_respects_the_constraint() {
+    // min ‖x‖² − 0.5·x0 − 1.5·x1  s.t.  x0 + x1 == 1, 0 ≤ x ≤ 5.
+    // KKT: 2xᵢ = cᵢ − λ with λ = 0 ⇒ x = (0.25, 0.75), strictly inside the box.
+    let prob = QpProblem {
+        n: 2,
+        p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+        c: vec![-0.5, -1.5],
+        a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+        b: vec![1.0],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0, 0.0],
+        ub: vec![5.0, 5.0],
+    };
+
+    let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!((sol.x[0] + sol.x[1] - 1.0).abs() < 1e-6, "x = {:?}", sol.x);
+    assert!((sol.x[0] - 0.25).abs() < 1e-5, "x = {:?}", sol.x);
+    assert!((sol.x[1] - 0.75).abs() < 1e-5, "x = {:?}", sol.x);
+    assert_eq!(sol.y.len(), 1, "one equality multiplier expected");
+}
+
+#[test]
+fn batched_solves_match_the_single_solves() {
+    let targets = [[0.25, 0.75], [2.0, -1.0], [0.5, 0.5]];
+    let probs: Vec<QpProblem> = targets.iter().map(|t| boxed_qp(t)).collect();
+    let opts = QpOptions::default();
+
+    let serial = solve_qp_batch(&probs, &opts, backend);
+    let parallel = solve_qp_batch_parallel(&probs, &opts, serial_backend);
+
+    assert_eq!(serial.len(), probs.len());
+    assert_eq!(parallel.len(), probs.len());
+    for (k, prob) in probs.iter().enumerate() {
+        let single = solve_qp_ipm(prob, &opts, backend);
+        assert_eq!(single.status, QpStatus::Optimal);
+        for j in 0..prob.n {
+            assert!(
+                (serial[k].x[j] - single.x[j]).abs() < 1e-8,
+                "serial batch differs at ({k}, {j})"
+            );
+            assert!(
+                (parallel[k].x[j] - single.x[j]).abs() < 1e-8,
+                "parallel batch differs at ({k}, {j})"
+            );
+        }
+    }
+}
+
+#[test]
+fn symbolic_factorization_is_reusable_across_instances() {
+    // Fixed sparsity, varying data — the training-data / MPC shape #561 was
+    // filed for. The reused symbolic factor must not change the answers.
+    let opts = QpOptions::default();
+    let targets = [[0.25, 0.75], [2.0, -1.0]];
+    let probs: Vec<QpProblem> = targets.iter().map(|t| boxed_qp(t)).collect();
+
+    let mut fact = QpFactorization::build(&probs[0], &opts, backend)
+        .expect("symbolic analysis of a well-posed box QP");
+    for (k, prob) in probs.iter().enumerate() {
+        let reused = fact.solve(prob);
+        let cold = solve_qp_ipm(prob, &opts, backend);
+        assert_eq!(reused.status, QpStatus::Optimal, "instance {k}");
+        for j in 0..prob.n {
+            assert!(
+                (reused.x[j] - cold.x[j]).abs() < 1e-6,
+                "reused factor differs from a cold solve at ({k}, {j})"
+            );
+        }
+    }
+}

--- a/crates/pounce-rs/tests/qp_surface.rs
+++ b/crates/pounce-rs/tests/qp_surface.rs
@@ -1,0 +1,115 @@
+//! The `qp` feature's surface — the sparse parametric active-set engine —
+//! reached through the facade only (gh #561). Including the triplet storage
+//! `QpProblem` borrows: without it the re-exported solver would still not be
+//! usable from a crate that depends on `pounce-rs` alone.
+#![cfg(feature = "qp")]
+
+use pounce_rs::linsol::backend;
+use pounce_rs::qp::{
+    GenTMatrix, GenTMatrixSpace, HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem,
+    QpSolver, QpWarmStart, SymTMatrix, SymTMatrixSpace,
+};
+
+/// `min ½(4x₀² + 4x₁²) − 2x₀ − 2x₁  s.t.  x₀ + x₁ == rhs`.
+/// KKT: `4xᵢ − 2 + λ = 0` with `x₀ = x₁ = rhs/2`.
+fn equality_qp() -> (SymTMatrix, GenTMatrix) {
+    let mut h = SymTMatrix::new(SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]));
+    h.set_values(&[4.0, 4.0]);
+    let mut a = GenTMatrix::new(GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]));
+    a.set_values(&[1.0, 1.0]);
+    (h, a)
+}
+
+fn problem<'a>(
+    h: &'a SymTMatrix,
+    a: &'a GenTMatrix,
+    g: &'a [f64],
+    bl: &'a [f64],
+    bu: &'a [f64],
+    xl: &'a [f64],
+    xu: &'a [f64],
+) -> QpProblem<'a> {
+    QpProblem {
+        n: 2,
+        m: 1,
+        h,
+        g,
+        a,
+        bl,
+        bu,
+        xl,
+        xu,
+        hessian_inertia: HessianInertia::Psd,
+    }
+}
+
+#[test]
+fn cold_active_set_solve_hits_the_closed_form() {
+    let (h, a) = equality_qp();
+    let (g, bl, bu) = ([-2.0, -2.0], [1.0], [1.0]);
+    let (xl, xu) = ([-1e20, -1e20], [1e20, 1e20]);
+    let qp = problem(&h, &a, &g, &bl, &bu, &xl, &xu);
+
+    let mut solver = ParametricActiveSetSolver::new(backend());
+    let sol = solver
+        .solve(&qp, None, &QpOptions::default())
+        .expect("well-posed strictly convex QP");
+
+    assert!((sol.x[0] - 0.5).abs() < 1e-10, "x = {:?}", sol.x);
+    assert!((sol.x[1] - 0.5).abs() < 1e-10, "x = {:?}", sol.x);
+    assert!((sol.obj + 1.0).abs() < 1e-10, "obj = {}", sol.obj);
+}
+
+#[test]
+fn parametric_solve_tracks_a_shifted_rhs() {
+    let (h, a) = equality_qp();
+    let (g, xl, xu) = ([-2.0, -2.0], [-1e20, -1e20], [1e20, 1e20]);
+    let opts = QpOptions::default();
+    let mut solver = ParametricActiveSetSolver::new(backend());
+
+    let (bl0, bu0) = ([1.0], [1.0]);
+    let qp0 = problem(&h, &a, &g, &bl0, &bu0, &xl, &xu);
+    let sol0 = solver.solve(&qp0, None, &opts).expect("base solve");
+
+    // Perturb the equality right-hand side; the optimum moves to (rhs/2, rhs/2).
+    let (bl1, bu1) = ([1.4], [1.4]);
+    let qp1 = problem(&h, &a, &g, &bl1, &bu1, &xl, &xu);
+    let tracked = solver
+        .solve_parametric(&qp0, &sol0, &qp1, &opts)
+        .expect("homotopy from the base solution");
+
+    assert!((tracked.x[0] - 0.7).abs() < 1e-8, "x = {:?}", tracked.x);
+    assert!((tracked.x[1] - 0.7).abs() < 1e-8, "x = {:?}", tracked.x);
+}
+
+#[test]
+fn working_set_from_a_solve_warm_starts_the_next() {
+    let (h, a) = equality_qp();
+    let (g, bl, bu) = ([-2.0, -2.0], [1.0], [1.0]);
+    let (xl, xu) = ([-1e20, -1e20], [1e20, 1e20]);
+    let qp = problem(&h, &a, &g, &bl, &bu, &xl, &xu);
+    let opts = QpOptions::default();
+
+    let mut solver = ParametricActiveSetSolver::new(backend());
+    let cold = solver.solve(&qp, None, &opts).expect("cold solve");
+
+    let warm_seed = QpWarmStart {
+        x: cold.x.clone(),
+        lambda_g: cold.lambda_g.clone(),
+        lambda_x: cold.lambda_x.clone(),
+        working: cold.working.clone(),
+    };
+    let warm = solver
+        .solve(&qp, Some(&warm_seed), &opts)
+        .expect("warm solve from the previous working set");
+
+    // A warm start changes the iteration count, never the answer.
+    for j in 0..2 {
+        assert!(
+            (warm.x[j] - cold.x[j]).abs() < 1e-10,
+            "warm x[{j}] = {}, cold = {}",
+            warm.x[j],
+            cold.x[j]
+        );
+    }
+}

--- a/crates/pounce-rs/tests/sensitivity_surface.rs
+++ b/crates/pounce-rs/tests/sensitivity_surface.rs
@@ -1,0 +1,221 @@
+//! The `sensitivity` feature's surface, reached through the facade only
+//! (gh #561): solve an NLP and get `∂x*/∂p` from the converged KKT factor,
+//! without depending on `pounce-sensitivity` directly.
+//!
+//! The fixture is upstream sIPOPT's `parametric_cpp` problem, so the numbers
+//! asserted here are the same golden values `pounce-sensitivity`'s own tests
+//! pin against upstream 3.14.19 — a facade re-export that silently changed
+//! them would fail.
+#![cfg(feature = "sensitivity")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_rs::prelude::*;
+use pounce_rs::sensitivity::SensSolve;
+
+/// ```text
+/// min  x₁² + x₂² + x₃²
+/// s.t. 6x₁ + 3x₂ + 2x₃ − η₁ = 0
+///      η₂x₁ + x₂ − x₃ − 1  = 0
+///      η₁ = nominal_eta1        <- pinned parameter, row 2
+///      η₂ = nominal_eta2        <- pinned parameter, row 3
+/// ```
+/// The parameters are lifted into variables `x₄`, `x₅` and pinned by the
+/// two trailing equalities; perturbing their right-hand sides is what
+/// `SensSolve::with_deltas` differentiates against.
+struct ParametricTnlp {
+    nominal_eta1: Number,
+    nominal_eta2: Number,
+}
+
+impl TNLP for ParametricTnlp {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 5,
+            m: 4,
+            nnz_jac_g: 10,
+            nnz_h_lag: 5,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        for k in 0..3 {
+            b.x_l[k] = 0.0;
+            b.x_u[k] = 1.0e19;
+        }
+        for k in 3..5 {
+            b.x_l[k] = -1.0e19;
+            b.x_u[k] = 1.0e19;
+        }
+        b.g_l[0] = 0.0;
+        b.g_u[0] = 0.0;
+        b.g_l[1] = 0.0;
+        b.g_u[1] = 0.0;
+        b.g_l[2] = self.nominal_eta1;
+        b.g_u[2] = self.nominal_eta1;
+        b.g_l[3] = self.nominal_eta2;
+        b.g_u[3] = self.nominal_eta2;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.15, 0.15, 0.0, 0.0, 0.0]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[0] + x[1] * x[1] + x[2] * x[2])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g.copy_from_slice(&[2.0 * x[0], 2.0 * x[1], 2.0 * x[2], 0.0, 0.0]);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        let (x1, x2, x3, eta1, eta2) = (x[0], x[1], x[2], x[3], x[4]);
+        g[0] = 6.0 * x1 + 3.0 * x2 + 2.0 * x3 - eta1;
+        g[1] = eta2 * x1 + x2 - x3 - 1.0;
+        g[2] = eta1;
+        g[3] = eta2;
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 0, 0, 1, 1, 1, 1, 2, 3]);
+                jcol.copy_from_slice(&[0, 1, 2, 3, 0, 1, 2, 4, 3, 4]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_jac_g(Values) without x");
+                values.copy_from_slice(&[6.0, 3.0, 2.0, -1.0, x[4], 1.0, -1.0, x[0], 1.0, 1.0]);
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 2, 4, 0]);
+                jcol.copy_from_slice(&[0, 1, 2, 0, 0]);
+            }
+            SparsityRequest::Values { values } => {
+                let lam = lambda.expect("eval_h(Values) without lambda");
+                values.copy_from_slice(&[
+                    2.0 * obj_factor,
+                    2.0 * obj_factor,
+                    2.0 * obj_factor,
+                    lam[1],
+                    0.0,
+                ]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn quiet_app() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    app
+}
+
+fn tnlp() -> Rc<RefCell<dyn TNLP>> {
+    Rc::new(RefCell::new(ParametricTnlp {
+        nominal_eta1: 5.0,
+        nominal_eta2: 1.0,
+    }))
+}
+
+/// Upstream sIPOPT's Δx for Δη = (−0.5, 0) from the nominal (5, 1).
+const UPSTREAM_DX: [Number; 5] = [
+    0.576_530_601_168_321_9 - 0.632_653_057_519_998_2,
+    0.377_551_038_130_684_8 - 0.387_755_107_968_002_7,
+    -0.045_918_360_700_993_31 - 0.020_408_165_488_001_08,
+    -0.5,
+    0.0,
+];
+
+#[test]
+fn parametric_step_through_the_facade_matches_upstream_sipopt() {
+    let mut app = quiet_app();
+
+    let result = SensSolve::new(vec![2, 3])
+        .with_deltas(vec![-0.5, 0.0])
+        .run(&mut app, tnlp());
+
+    assert!(
+        matches!(
+            result.status,
+            ApplicationReturnStatus::SolveSucceeded
+                | ApplicationReturnStatus::SolvedToAcceptableLevel
+        ),
+        "solve failed: {:?}",
+        result.status
+    );
+    assert!(
+        result.error.is_none(),
+        "sensitivity error: {:?}",
+        result.error
+    );
+
+    let dx = result.dx.expect("dx populated when with_deltas was set");
+    assert_eq!(dx.len(), 5);
+    for k in 0..5 {
+        assert!(
+            (dx[k] - UPSTREAM_DX[k]).abs() < 1e-8,
+            "dx[{k}] = {}, upstream = {}",
+            dx[k],
+            UPSTREAM_DX[k]
+        );
+    }
+}
+
+#[test]
+fn reduced_hessian_is_reachable_through_the_facade() {
+    let mut app = quiet_app();
+
+    let result = SensSolve::new(vec![2, 3])
+        .with_reduced_hessian()
+        .run(&mut app, tnlp());
+
+    assert!(
+        result.error.is_none(),
+        "sensitivity error: {:?}",
+        result.error
+    );
+    let rh = result
+        .reduced_hessian
+        .expect("reduced Hessian populated when requested");
+    // Two pinned parameters ⇒ a 2×2 reduced Hessian, symmetric.
+    assert_eq!(rh.len(), 4, "expected a 2x2 reduced Hessian, got {rh:?}");
+    assert!(
+        (rh[1] - rh[2]).abs() < 1e-8,
+        "reduced Hessian must be symmetric: {rh:?}"
+    );
+}

--- a/docs/src/choosing-a-solver.md
+++ b/docs/src/choosing-a-solver.md
@@ -37,9 +37,9 @@ pluggable backend (FERAL by default, HSL MA57 optionally).
 > homotopy from the previous solution instead of starting over.
 
 > A general-purpose **spatial branch-and-bound** solver for factorable nonconvex
-> NLPs (`pounce-global`) is in development on the `feature/global` branch and is
-> **not part of this release** — there is no `solver_selection=global` CLI route or
-> `minimize_global` Python entry point yet. Today the only certified-global path
+> NLPs (`pounce-global`) is in development and is **not part of this release** —
+> there is no `solver_selection=global` CLI route or `minimize_global` Python
+> entry point yet. Today the only certified-global path
 > for nonconvex problems is SOS / Lasserre, for *polynomials*.
 
 ## When to choose each
@@ -117,8 +117,8 @@ enough, the shipped path to a **certified global** optimum is for polynomials:
   with the relaxation order.
 
 A general-purpose **spatial branch-and-bound** solver for factorable nonconvex
-problems (including `exp`/`ln`/trig) — `pounce-global` — is in development on
-the `feature/global` branch and is **not part of this release**.
+problems (including `exp`/`ln`/trig) — `pounce-global` — is in development and
+is **not part of this release**.
 
 See [Global Optimization](global-optimization.md) for the SOS path in depth.
 
@@ -207,8 +207,7 @@ POUNCE settles a problem globally along two routes, and locally along one:
   point, which for a nonconvex problem carries no global guarantee.
 
 A general-purpose spatial branch-and-bound route for factorable nonconvex
-problems (`pounce-global`) is in development on the `feature/global` branch but
-not in this release.
+problems (`pounce-global`) is in development but not in this release.
 
 Two practical levers for a "global" answer: **modeling** (cast as much as you
 can into the convex cone library) and, when that is not possible, the **SOS /

--- a/docs/src/global-optimization.md
+++ b/docs/src/global-optimization.md
@@ -14,11 +14,11 @@ certificate that, when exact, pins the global minimum and recovers its
 minimizer(s).
 
 > A second path — general-purpose **spatial branch-and-bound** (`pounce-global`)
-> for factorable nonconvex NLPs with `exp`/`ln`/trig — is **in development on
-> the `feature/global` branch and is not part of this release**. It is described
-> at the end of this chapter for context, but there is no `pounce-global` crate
-> in the shipped workspace, no `pounce.minimize_global` Python entry point, and
-> no `solver_selection=global` CLI route here.
+> for factorable nonconvex NLPs with `exp`/`ln`/trig — is **in development and is
+> not part of this release**. It is described at the end of this chapter for
+> context, but there is no `pounce-global` crate in the shipped workspace, no
+> `pounce.minimize_global` Python entry point, and no `solver_selection=global`
+> CLI route here.
 
 ## The SOS / Lasserre path (polynomials)
 
@@ -77,11 +77,11 @@ development (below).
 ## Spatial branch-and-bound (in development)
 
 > **Not in this release.** Everything in this section describes the
-> `pounce-global` crate as it exists on the `feature/global` branch. It is not
-> in the shipped workspace, and the Rust snippets below will not compile against
-> the published crates. There is no Python or CLI binding for it in this
-> release. The section is kept for design context and to set expectations for
-> what the general nonconvex path will look like.
+> `pounce-global` crate as it exists in development. It is not in the shipped
+> workspace, and the Rust snippets below will not compile against the published
+> crates. There is no Python or CLI binding for it in this release. The section
+> is kept for design context and to set expectations for what the general
+> nonconvex path will look like.
 
 ### The problem
 
@@ -127,7 +127,7 @@ The search stops when the frontier's lowest bound meets the incumbent within
 tolerance — at which point the incumbent is the certified global optimum.
 
 ```rust,ignore
-// On the `feature/global` branch — not in this release.
+// In-development API — not in this release.
 use pounce_global::{expr::var, solve_global, GlobalProblem, GlobalOptions, GlobalStatus};
 use pounce_feral::FeralSolverInterface;
 
@@ -229,9 +229,9 @@ There are two opt-in forms of parallelism:
 
 ### Honest limits
 
-On the `feature/global` branch, `pounce-global` is a complete, correct
-*continuous* global solver. It is not yet at commercial-solver scale (and, as
-noted, not yet wired into a shipped release):
+In development, `pounce-global` is a complete, correct *continuous* global
+solver. It is not yet at commercial-solver scale (and, as noted, not yet wired
+into a shipped release):
 
 - **Continuous only** — no integer branching (MINLP).
 - **Branching** offers widest, most-violation (default), and reliability

--- a/docs/src/global-optimization.md
+++ b/docs/src/global-optimization.md
@@ -50,13 +50,13 @@ Constraints are polynomials too, passed as `inequalities` (`g_i(x) ≥ 0`) and
 double well, a constrained problem, and a 2-D example — is in
 [`18_sos_global_optimization.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/18_sos_global_optimization.ipynb).
 
-The same solver from Rust:
+The same solver from Rust, via the `pounce-rs` facade with the `convex`
+feature on (`pounce-rs = { version = "0.9", features = ["convex"] }`):
 
 ```rust
-use pounce_convex::{sos_minimize, PolyProblem, Polynomial};
-# use pounce_feral::FeralSolverInterface;
-# use pounce_linsol::SparseSymLinearSolverInterface;
-# fn backend() -> Box<dyn SparseSymLinearSolverInterface> { Box::new(FeralSolverInterface::new()) }
+use pounce_rs::convex::{sos_minimize, PolyProblem, Polynomial};
+use pounce_rs::linsol::backend;      // the sparse LDLᵀ factory the solver takes
+
 // x⁴ − 2x² + 3 → global minimum 2 at x = ±1.
 let p = Polynomial::new(1, vec![(vec![4], 1.0), (vec![2], -2.0), (vec![0], 3.0)]);
 let sol = sos_minimize(&PolyProblem::new(p), None, backend);
@@ -64,7 +64,9 @@ let sol = sos_minimize(&PolyProblem::new(p), None, backend);
 // the global minimizer(s) — here both x = +1 and x = −1.
 ```
 
-The full treatment lives in the `pounce_convex::sos` module documentation.
+The full treatment lives in the `pounce_convex::sos` module documentation —
+reachable without a second dependency, since `pounce_rs::convex` re-exports
+the `pounce_convex` crate itself for anything outside its curated surface.
 
 **When SOS fits:** polynomials of modest degree and dimension — one SDP,
 recovers all global minimizers, but the SDP grows with the relaxation order.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -25,8 +25,8 @@ into a *family* of solvers sharing that backbone:
   cones, each solved to the global optimum.
 - **Global optimization** — certified global optima for nonconvex
   **polynomial** problems via SOS / Lasserre relaxations. (A general-purpose
-  spatial branch-and-bound solver, `pounce-global`, is in development on the
-  `feature/global` branch and not part of this release.)
+  spatial branch-and-bound solver, `pounce-global`, is in development and not
+  part of this release.)
 
 See [Choosing a Solver](choosing-a-solver.md) for which solver fits which
 problem.
@@ -61,8 +61,8 @@ Benchmark Format (`.cbf`) reader cross-checked against the CBLIB tier —
 and adds SOS / Lasserre polynomial global optimization (`sos_minimize`).
 These are reachable from the CLI, the Python package, and the JSON solve
 report. A deterministic spatial branch-and-bound solver for general
-factorable nonconvex problems (`pounce-global`) is in development on the
-`feature/global` branch and not part of this release.
+factorable nonconvex problems (`pounce-global`) is in development and not part
+of this release.
 
 ## License
 

--- a/docs/src/python.md
+++ b/docs/src/python.md
@@ -684,9 +684,8 @@ coefficient dict and returns a certificate, *not* callables and SciPy dicts. See
 [Choosing a Solver](choosing-a-solver.md) for the full map.
 
 > A `minimize_global` entry point for factorable nonconvex problems (spatial
-> branch-and-bound) is in development on the `feature/global` branch and is not
-> exposed in this release; today the certified-global Python path is
-> `sos_minimize`, for polynomials.
+> branch-and-bound) is in development and is not exposed in this release; today
+> the certified-global Python path is `sos_minimize`, for polynomials.
 
 ## Curve fitting
 

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -35,11 +35,19 @@ Related flags:
 
 ## Rust library
 
+Reach the sensitivity path through the `pounce-rs` facade, with the
+`sensitivity` feature on:
+
+```toml
+[dependencies]
+pounce-rs = { version = "0.9", features = ["sensitivity"] }
+```
+
 `SensSolve` is a builder that wraps the `on_converged` callback
 plumbing into a single call:
 
 ```rust
-use pounce_sensitivity::SensSolve;
+use pounce_rs::sensitivity::SensSolve;
 
 let result = SensSolve::new(vec![2, 3])
     .with_deltas(vec![0.05, 0.0])

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -118,8 +118,12 @@ handle lives alongside it.
 
 ## Rust
 
+Both session APIs come through the `pounce-rs` facade. `Solver` needs the
+`sensitivity` feature; the bare `Factorization` below needs `convex` or `qp`,
+whichever you are already using — either one enables `pounce_rs::linsol`.
+
 ```rust
-use pounce_sensitivity::Solver;
+use pounce_rs::sensitivity::Solver;
 
 let mut solver = Solver::new(app, tnlp);
 solver.solve();
@@ -135,9 +139,9 @@ solver.kkt_solve(&rhs, &mut lhs)?;
 For purely linear-algebra uses with no IPM in the loop:
 
 ```rust
-use pounce_linsol::Factorization;
+use pounce_rs::linsol::{Factorization, backend};
 
-let mut fact = Factorization::new(dim, ia, ja, &values, backend)?;
+let mut fact = Factorization::new(dim, ia, ja, values, backend())?;
 fact.solve(&mut rhs, 1)?;          // back-substitute in place
 fact.refactor(&new_values)?;       // pattern preserved; numeric reuse
 fact.solve_one(&mut another_rhs)?;


### PR DESCRIPTION
Fixes #561.

Three commits: the facade change, the book snippets that were teaching the coupling it removes, and — unrelated, kept here by request — a stale branch reference the docs work turned up.

## Problem

`pounce-rs` says it "pins a single curated public surface, so downstream code is insulated from churn in the internal crate layout" (#168), but its dependencies were `pounce-common` + `pounce-nlp` + `pounce-algorithm` + `pounce-observability` — the NLP path and nothing else.

So a Rust consumer doing anything past a single cold NLP solve had to depend directly on the internal-layout crates the facade exists to hide, and took on exactly the churn #168 set out to insulate them from. The Python side has no equivalent gap: `import pounce` reaches the QP, sensitivity, and batch surfaces uniformly.

| consumer | before | after |
|---|---|---|
| cold NLP solve | `pounce-rs` | `pounce-rs` |
| batched parametric QPs + sensitivities (the #561 motivating case) | `pounce-convex` + `pounce-sensitivity` + `pounce-common` + `pounce-linsol` + `pounce-feral` | `pounce-rs` with `features = ["convex", "sensitivity"]` |
| active-set QP / MPC / continuation | `pounce-qp` + `pounce-linalg` + `pounce-linsol` + `pounce-feral` | `pounce-rs` with `features = ["qp"]` |

The book was propagating the gap. Three user-facing pages carried Rust snippets that imported the internal crates as the recommended way — `sensitivity.md` (`pounce_sensitivity::SensSolve`), `sessions.md` (`pounce_sensitivity::Solver`, `pounce_linsol::Factorization`), and `global-optimization.md` (`pounce_convex::{sos_minimize, …}` plus a hand-rolled `backend()` over `pounce_feral` + `pounce_linsol`).

## Cause

Not a bug — an omission at the time #168 landed, which only covered the NLP path. Nothing since re-checked the facade against what POUNCE actually solves.

## Fix

Option 1 from the issue: extend `pounce-rs` with feature-gated modules. It keeps the default build lean and the facade one crate, and per the issue is "probably the least surprising to someone arriving from #168". Option 2 (sibling facades) was rejected on the issue's own grounds — it multiplies the thing #168 was reducing. Option 3 (document the NLP path as the only stable one) contradicts the facade's doc comment and does nothing for the motivating consumer.

| feature | module | covers |
|---|---|---|
| `convex` | `pounce_rs::convex` | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; `solve_qp_batch{,_parallel,_parallel_warm}`, `solve_qp_multi_rhs*`, `QpFactorization` symbolic reuse; `QpSensitivity` / `ReducedHessian` |
| `qp` | `pounce_rs::qp` | sparse parametric active-set QP: `ParametricActiveSetSolver`, `QpSolver::solve_parametric`, `WorkingSet` warm starts, the `.qps` reader |
| `sensitivity` | `pounce_rs::sensitivity` | `SensSolve` / `SensResult`, `compute_reduced_hessian`, and the long-form `SensApplication` / Schur stack |
| `full` | — | all three |

**Separate modules, not a flat re-export.** `pounce-convex` and `pounce-qp` are different solver families that both name their types `QpProblem` / `QpSolution` / `QpStatus` / `QpOptions` / `QpWarmStart`. One flat surface cannot carry both, so this is forced rather than stylistic.

**Two additions beyond plain re-exports.** Without them the modules are not callable from `pounce-rs` alone, and the gap would have been closed only on paper:

- **`pounce_rs::linsol`** (on with `convex` or `qp`). Both QP entry points are parameterized over the factorization backend — `solve_qp_ipm` takes an `FnMut` closure returning a boxed `SparseSymLinearSolverInterface`, and `ParametricActiveSetSolver::new` takes that boxed backend directly — so re-exporting the solvers alone still leaves the caller needing `pounce-linsol` + `pounce-feral` to build the argument. `backend()` and `serial_backend()` are the two factories every in-tree caller writes by hand (parallel FERAL, and the inner-serial one that keeps `solve_qp_batch_parallel` from oversubscribing).
- **The triplet storage** (`SymTMatrix` / `GenTMatrix` and their spaces), re-exported through `pounce_rs::qp`, since `pounce_qp::QpProblem` *borrows* its Hessian and Jacobian in that form.

These two are the only new code; everything else is re-exports.

## Blast radius

**The default build is unchanged** — same dependencies, same exports, same compile. Verified by `cargo tree -p pounce-rs -e normal --depth 1`: still exactly the four original crates.

**Enabling a feature widens the public surface, not the build.** `pounce-algorithm` already pulls `pounce-qp`, `pounce-linsol`, and `pounce-feral` transitively, so `qp` adds no compilation at all; only `convex` and `sensitivity` add crates.

No solver behavior is touched — this is re-exports plus two backend factories, so nothing numerical moves and no corpus sweep applies.

`scripts/check-release-consistency.sh` and `scripts/check-docs-consistency.sh` are both clean: `pounce-rs` is still last in the publish list, so the new dependency edges stay topological, and all 43 book pages remain reachable.

## Docs

- **Crate docs** — a feature-flag table on `lib.rs` linking each module, plus per-module docs with executed examples (`convex`, `qp`, `sensitivity`, `linsol`).
- **`crates/pounce-rs/README.md`** — mirrors the table.
- **The book** — the three pages above now go through `pounce_rs`, each naming the feature it needs, and the SOS example drops its hand-rolled factory for `pounce_rs::linsol::backend`. Checking that those paths resolve turned up two pre-existing inaccuracies in the `Factorization` snippet, fixed here: it passed a factory where the signature takes a value, and borrowed `values` where it takes ownership. Nothing in CI compiles book snippets, so the edited imports were compile-checked against `pounce-rs --all-features` by hand.
- **Deliberately not changed** — the `pounce-qp` listings in `docs/src/active-set-sqp-warm-start.md`. They are annotated with the source path they quote (`// crates/pounce-qp/src/problem.rs`) and show that crate's own type definitions, not user-facing imports; rewriting them would misrepresent the file.
- **`docs.rs`** — `all-features = true`, so the published page shows all four modules rather than the NLP path alone.

Still absent: a Rust chapter in the book. There has never been one — the Rust snippets live inside the per-solver pages — so writing it is a larger piece of work than this issue. Related gap, now visible: `docs/src/active-set-sqp.md` §2 has Python / C / GAMS sections but no Rust, which the `qp` feature makes worth adding. Both are follow-ups.

## Unrelated: the `feature/global` branch does not exist

Third commit, `30952e2`. Twelve places across `README.md` and four book pages told readers `pounce-global` "is in development on the `feature/global` branch". `git ls-remote origin` lists 60 heads and no ref in any namespace matches "global"; origin is the only remote. The docs pointed at a location a reader cannot reach.

Every other claim in those passages is verifiable and stays: not part of this release, no `pounce-global` crate in the shipped workspace, no `minimize_global` Python entry point, no `solver_selection=global` CLI route, and the two `rust,ignore` snippets that will not compile against the published crates. Only the branch pointer is removed — now "in development and not part of this release". **No replacement location is asserted**, because where that work lives is not visible from this repository; if it has a current home, say so and I will point at it.

Sites: `README.md` (2), `docs/src/introduction.md` (2), `docs/src/global-optimization.md` (4), `docs/src/choosing-a-solver.md` (3), `docs/src/python.md` (1).

**Reviewer note.** This is the only part of the PR that touches the cross-solver landscape pages CONTRIBUTING assigns to the maintainer (`choosing-a-solver.md`, `python.md` — two of the three). It changes neither routing nor problem-class coverage, and leaves the shipped/not-shipped story identical across all three pages, but it is maintainer-owned text so it is called out rather than buried. It is a clean standalone commit if you would rather it move elsewhere. The rest of the PR — including the `#561` doc work — leaves those three pages untouched.

## Tests

One integration test per module, each importing **only** `pounce_rs` — no `pounce-convex`, `pounce-qp`, `pounce-sensitivity`, `pounce-linsol`, `pounce-feral`, or `pounce-linalg` in their `use` lines. That is the property this PR is about, checked mechanically rather than asserted in prose: if the facade ever stops being sufficient on its own, these stop compiling.

- `tests/convex_surface.rs` — clamped box solve, equality-constrained solve against its closed-form KKT point, batch (serial and parallel) agreeing with per-instance solves to 1e-8, and `QpFactorization` symbolic reuse agreeing with cold solves.
- `tests/qp_surface.rs` — cold active-set solve against the closed form, `solve_parametric` tracking a shifted RHS, and a `WorkingSet` warm start reproducing the cold answer to 1e-10.
- `tests/sensitivity_surface.rs` — upstream sIPOPT 3.14.19's `parametric_cpp` golden Δx to 1e-8, the same values `pounce-sensitivity`'s own tests pin, plus reduced-Hessian shape and symmetry.

Plus four new doctests (one per module, one on `linsol::backend`), all executed.

**On "tests fail on the parent commit":** they do not compile on it — `pounce_rs::convex`, `::qp`, `::sensitivity`, and `::linsol` do not exist there. These are new-surface tests, not regression tests for a fixed bug, so the usual "fails pre-fix for the right reason" check does not apply in its literal form; the honest statement is that each test's imports are what pins the property, and they cannot be satisfied without the change.

**CI would not have run any of this.** The workspace `clippy`/`build`/`test` steps compile default features only, so the new modules would have been invisible until a user enabled a feature — a re-export could silently stop matching the crate it mirrors. Added a `cargo clippy + cargo test -p pounce-rs --all-features` step.

Locally clean: `cargo fmt --all -- --check`, `cargo clippy -p pounce-rs --all-features --all-targets -D clippy::correctness -D clippy::suspicious`, `cargo test -p pounce-rs --all-features` (22 tests + 9 doctests), `cargo check --workspace --exclude pounce-hsl --all-targets`, `scripts/check-release-consistency.sh`, `scripts/check-docs-consistency.sh`.

---

- [x] Tests fail on the parent commit for the stated reason — see the caveat above: they fail to *compile* there, being new-surface rather than regression tests
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book pages under `docs/src/` updated (no new page, so no `SUMMARY.md` change); see **Docs** for what was left alone and why
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now
