### PR TITLE
docs(rust): add the Rust chapter and the SQP Rust sections, plus a curated pounce_rs::sqp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ changes.
 
 ## [Unreleased]
 
+### Added — a Rust chapter in the book, and the SQP warm-start contract on the facade (#561 follow-ups)
+
+Two gaps left open by #561, both about the Rust surface being reachable but
+undocumented.
+
+**The book had no Rust chapter.** It has never had one — the Rust snippets
+lived inside the per-solver pages, so a Rust user had no entry point
+equivalent to `docs/src/python.md`. `docs/src/rust.md` is now that page:
+install, the `Problem` + `Nlp` builder, the `TNLP` trait for exact
+Hessians / custom sparsity / scaling, iteration capture, the feature-flag
+table, and a worked snippet per feature module. Linked from `SUMMARY.md`
+under Integrations, next to the Python API.
+
+**`docs/src/active-set-sqp.md` had Python / C / GAMS but no Rust**, in both
+§2 (switching to the SQP path) and §3 (carrying a working set across solves).
+Both now have a Rust section. Writing §3 turned up a real hole rather than a
+prose one: the round trip needs `SqpIterates` and `classify_working_set`,
+which lived in `pounce-algorithm`'s internals and were reachable only as
+`pounce_rs::pounce_algorithm::sqp::…`. A new Rust chapter telling readers to
+spell that would have re-created exactly the coupling #561 removed, so the
+facade grew a curated **`pounce_rs::sqp`** (feature `qp`): `SqpIterates`,
+`classify_working_set`, `SqpOptions` / `SqpGlobalization` /
+`SqpHessianSource`, and the `WorkingSet` / `BoundStatus` / `ConsStatus`
+status types.
+
+The split is worth stating because it decides which feature a reader needs:
+**flipping `algorithm` to `active-set-sqp` needs no feature at all** — it is
+one option string on the default build — while *carrying a working set* needs
+`features = ["qp"]`, because `WorkingSet` is the QP engine's type.
+
+`tests/sqp_surface.rs` pins the round trip through the facade alone
+(`last_sqp_working_set` → `SqpIterates` → `set_sqp_warm_start`, same answer
+warm as cold), that `classify_working_set` derives a seed from a predicted
+point, and that the algorithm flip needs none of those types. Nothing in CI
+compiles book snippets, so every runnable snippet in `rust.md` — and every
+API name its prose mentions — was compile-checked against
+`pounce-rs --all-features` before landing.
+
+Also swept up: the user-facing prose references #561 missed, because that
+pass fixed `use` lines only. `docs/src/sessions.md`'s "which layer do I want"
+table and its verification list, plus `active-set-sqp.md` §4, still pointed
+at `pounce_sensitivity::` / `pounce_linsol::` paths; all now name the facade.
+
 ### Added — `pounce-rs` covers the convex, active-set QP, and sensitivity paths (#561)
 
 The `pounce-rs` facade exists so Rust users depend on one crate and are

--- a/crates/pounce-rs/README.md
+++ b/crates/pounce-rs/README.md
@@ -99,7 +99,7 @@ flat surface could not carry both:
 | feature | module | what it covers |
 |---|---|---|
 | `convex` | `pounce_rs::convex` | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; batched and warm-started solves; symbolic-factorization reuse; QP sensitivity and reduced Hessian |
-| `qp` | `pounce_rs::qp` | sparse **parametric active-set** QP — the SQP / MPC / continuation engine, indefinite Hessians allowed |
+| `qp` | `pounce_rs::qp`, `pounce_rs::sqp` | sparse **parametric active-set** QP — the SQP / MPC / continuation engine, indefinite Hessians allowed — plus the SQP working-set warm-start contract |
 | `sensitivity` | `pounce_rs::sensitivity` | sIPOPT-style NLP sensitivity: `∂x*/∂p` predictors, parametric warm starts, reduced Hessian |
 | `full` | — | all three |
 

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -20,7 +20,7 @@
 //! | feature | module | what it covers |
 //! |---|---|---|
 //! | `convex` | [`convex`] | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; batched and warm-started solves; QP sensitivity and reduced Hessian |
-//! | `qp` | [`qp`] | sparse **parametric active-set** QP — the SQP / MPC / continuation engine, indefinite Hessians allowed |
+//! | `qp` | [`qp`], [`sqp`] | sparse **parametric active-set** QP — the SQP / MPC / continuation engine, indefinite Hessians allowed — plus the SQP working-set warm-start contract |
 //! | `sensitivity` | [`sensitivity`] | sIPOPT-style NLP sensitivity: `∂x*/∂p` predictors, parametric warm starts, reduced Hessian |
 //! | `full` | — | all three |
 //!
@@ -240,6 +240,11 @@ pub mod linsol;
 pub mod qp;
 #[cfg(feature = "sensitivity")]
 pub mod sensitivity;
+// The SQP working-set contract. Flipping `algorithm` to `active-set-sqp` needs
+// no feature; carrying a working set across solves needs the `WorkingSet` type,
+// which is pounce-qp's.
+#[cfg(feature = "qp")]
+pub mod sqp;
 
 /// The common case in one glob import. Brings in the ergonomic [`Problem`]
 /// trait + [`Nlp`] builder, plus the low-level [`TNLP`] surface and the

--- a/crates/pounce-rs/src/sqp.rs
+++ b/crates/pounce-rs/src/sqp.rs
@@ -1,0 +1,88 @@
+//! Active-set SQP warm starting — the working-set contract, re-exported
+//! (feature `qp`).
+//!
+//! Switching the driver to the SQP path needs nothing from this module and
+//! no feature at all: it is one option string on the default build.
+//!
+//! ```
+//! use pounce_rs::prelude::*;
+//!
+//! struct Quad; // min (x0-1)^2 + (x1-2)^2  s.t. x0 + x1 == 3
+//! impl Problem for Quad {
+//!     fn objective(&self, x: &[f64]) -> f64 {
+//!         (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+//!     }
+//!     fn n_constraints(&self) -> usize { 1 }
+//!     fn constraints(&self, x: &[f64], g: &mut [f64]) { g[0] = x[0] + x[1]; }
+//! }
+//!
+//! let sol = Nlp::new(Quad)
+//!     .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+//!     .constraint_bounds(&[3.0], &[3.0])
+//!     .option_str("algorithm", "active-set-sqp")
+//!     .solve();
+//! assert!(sol.success);
+//! ```
+//!
+//! What *does* need this module is the payoff: carrying the discrete
+//! **working set** — which bounds and constraints are active — from one
+//! solve into the next. The floating-point part of a warm start (`x`, `λ_g`,
+//! `λ_x`) is available from any solve, but the active set is what lets the
+//! next QP build its KKT block correctly from iteration zero instead of
+//! rediscovering it. That is the whole reason to prefer SQP over the IPM on
+//! a sequence of nearby problems (MPC, continuation, homotopy).
+//!
+//! The round trip is [`IpoptApplication::last_sqp_working_set`] out,
+//! [`SqpIterates`] in, [`IpoptApplication::set_sqp_warm_start`] to install:
+//!
+//! ```no_run
+//! use pounce_rs::prelude::*;
+//! use pounce_rs::sqp::SqpIterates;
+//! use std::cell::RefCell;
+//! use std::rc::Rc;
+//!
+//! # fn demo(tnlp: Rc<RefCell<dyn TNLP>>, x_star: Vec<f64>) {
+//! let mut app = IpoptApplication::new();
+//! app.initialize().unwrap();
+//! app.initialize_with_options_str("algorithm active-set-sqp\n").unwrap();
+//!
+//! // Cold solve: converges and leaves a working set behind.
+//! let status = app.optimize_tnlp(Rc::clone(&tnlp));
+//! assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+//! let working = app.last_sqp_working_set().cloned();
+//!
+//! // ... the caller updates the parameter inside `tnlp` here ...
+//!
+//! // Warm solve: same shape, seeded from the previous active set.
+//! app.set_sqp_warm_start(SqpIterates {
+//!     x: x_star,
+//!     lambda_g: vec![0.0; 1],
+//!     lambda_x: vec![0.0; 2],
+//!     working,
+//! });
+//! let status = app.optimize_tnlp(tnlp);
+//! # }
+//! ```
+//!
+//! The warm start is consumed by the solve that follows it, so each
+//! iteration of a sequence installs a fresh one;
+//! [`IpoptApplication::clear_sqp_warm_start`] drops an unused one.
+//!
+//! When the seed comes from a *sensitivity predictor* rather than a previous
+//! solve — the `SensSolve` → SQP-corrector playbook in [`crate::sensitivity`]
+//! — there is no previous working set to carry, so
+//! [`classify_working_set`] derives one from a predicted point and its
+//! multipliers. Note its `lambda_x` argument is the **packed** bound
+//! multiplier `z_l − z_u`, not the pair.
+//!
+//! `λ_g` and `λ_x` are unconstrained in sign only where the corresponding
+//! row is inactive; a warm start whose multipliers disagree with its working
+//! set is repaired rather than trusted, so an approximate seed is safe.
+
+pub use pounce_algorithm::sqp::{
+    SqpGlobalization, SqpHessianSource, SqpIterates, SqpOptions, warm_start::classify_working_set,
+};
+
+/// The working set itself, and its per-row status codes. Re-exported from
+/// [`crate::qp`], where the QP engine that consumes it lives.
+pub use pounce_qp::{BoundStatus, ConsStatus, WorkingSet};

--- a/crates/pounce-rs/tests/sqp_surface.rs
+++ b/crates/pounce-rs/tests/sqp_surface.rs
@@ -1,0 +1,210 @@
+//! The SQP working-set contract through the facade only — the round trip
+//! `last_sqp_working_set` → [`SqpIterates`] → `set_sqp_warm_start` that
+//! `docs/src/active-set-sqp.md` §2–§3 documents for Rust. If the facade ever
+//! stops exporting enough to write that sequence, this stops compiling.
+#![cfg(feature = "qp")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_rs::prelude::*;
+use pounce_rs::sqp::{BoundStatus, ConsStatus, SqpIterates, WorkingSet, classify_working_set};
+
+/// min (x₀ − 1)² + (x₁ − 2)²  s.t.  x₀ + x₁ == 3,  0 ≤ x ≤ 5.
+/// KKT optimum is (1, 2) — the equality is already satisfied there, so the
+/// active set is the equality row alone and no bound is active.
+struct Quad {
+    x_star: Rc<RefCell<Option<Vec<Number>>>>,
+}
+
+impl TNLP for Quad {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 2,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[0.0, 0.0]);
+        b.x_u.copy_from_slice(&[5.0, 5.0]);
+        b.g_l[0] = 3.0;
+        b.g_u[0] = 3.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.5, 0.5]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 1.0);
+        g[1] = 2.0 * (x[1] - 2.0);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => values.copy_from_slice(&[1.0, 1.0]),
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values.copy_from_slice(&[2.0 * obj_factor, 2.0 * obj_factor]);
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        *self.x_star.borrow_mut() = Some(sol.x.to_vec());
+    }
+}
+
+fn sqp_app() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    app.initialize_with_options_str("algorithm active-set-sqp\n")
+        .unwrap();
+    app
+}
+
+#[test]
+fn working_set_round_trips_from_one_solve_into_the_next() {
+    let x_star = Rc::new(RefCell::new(None));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Quad {
+        x_star: Rc::clone(&x_star),
+    }));
+    let mut app = sqp_app();
+
+    // Cold solve leaves a working set behind.
+    let status = app.optimize_tnlp(Rc::clone(&tnlp));
+    assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+    let working: Option<WorkingSet> = app.last_sqp_working_set().cloned();
+    assert!(working.is_some(), "cold SQP solve must yield a working set");
+
+    let x = x_star.borrow().clone().expect("finalize_solution ran");
+    assert!(
+        (x[0] - 1.0).abs() < 1e-6 && (x[1] - 2.0).abs() < 1e-6,
+        "x = {x:?}"
+    );
+
+    // Warm solve seeded from it — same answer, and a working set again.
+    app.set_sqp_warm_start(SqpIterates {
+        x: x.clone(),
+        lambda_g: vec![0.0],
+        lambda_x: vec![0.0, 0.0],
+        working,
+    });
+    let status = app.optimize_tnlp(Rc::clone(&tnlp));
+    assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+    assert!(app.last_sqp_working_set().is_some());
+
+    let x_warm = x_star
+        .borrow()
+        .clone()
+        .expect("finalize_solution ran again");
+    for k in 0..2 {
+        assert!(
+            (x_warm[k] - x[k]).abs() < 1e-8,
+            "warm start changed the answer: {x_warm:?} vs {x:?}"
+        );
+    }
+}
+
+#[test]
+fn classify_working_set_derives_a_seed_from_a_predicted_point() {
+    // The sensitivity-predictor path: no previous solve to carry, so the
+    // working set is classified from a point and its multipliers.
+    // At (1, 2) the equality binds and neither bound is active.
+    let ws = classify_working_set(
+        &[0.0, 0.0], // lambda_x, packed z_l − z_u
+        &[0.0],      // lambda_g
+        1,           // m_eq — row 0 is the equality
+        &[1.0, 2.0], // x
+        &[0.0, 0.0], // x_l
+        &[5.0, 5.0], // x_u
+        &[3.0],      // g(x)
+        &[3.0],      // g_l
+        &[3.0],      // g_u
+        1e-8,
+        1e-6,
+    );
+
+    assert_eq!(ws.constraints[0], ConsStatus::Equality);
+    assert_eq!(ws.bounds[0], BoundStatus::Inactive);
+    assert_eq!(ws.bounds[1], BoundStatus::Inactive);
+}
+
+#[test]
+fn switching_to_the_sqp_path_needs_no_working_set_types() {
+    // The §2 claim: the algorithm flip alone is one option on the builder.
+    struct P;
+    impl pounce_rs::Problem for P {
+        fn objective(&self, x: &[f64]) -> f64 {
+            (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+        }
+        fn n_constraints(&self) -> usize {
+            1
+        }
+        fn constraints(&self, x: &[f64], g: &mut [f64]) {
+            g[0] = x[0] + x[1];
+        }
+    }
+
+    let sol = Nlp::new(P)
+        .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+        .constraint_bounds(&[3.0], &[3.0])
+        .option_str("algorithm", "active-set-sqp")
+        .solve();
+
+    assert!(sol.success, "status = {:?}", sol.status);
+    assert!(
+        (sol.x[0] - 1.0).abs() < 1e-5 && (sol.x[1] - 2.0).abs() < 1e-5,
+        "x = {:?}",
+        sol.x
+    );
+}

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -30,6 +30,7 @@
 - [Pyomo](pyomo.md)
 - [GAMS](gams.md)
 - [Python API](python.md)
+- [Rust API](rust.md)
   - [Path Following & Inverse Mapping](path-following.md)
 - [Curve Fitting](curve-fitting.md)
 - [Boundary Value Problems](bvp.md)

--- a/docs/src/active-set-sqp.md
+++ b/docs/src/active-set-sqp.md
@@ -74,6 +74,34 @@ double obj;
 int status = IpoptSolve(prob, x, NULL, &obj, NULL, NULL, NULL, NULL);
 ```
 
+### Rust
+
+The flip is one option, so it needs no cargo feature — the default
+`pounce-rs` build reaches the SQP path. On the builder API:
+
+```rust
+use pounce_rs::prelude::*;
+
+let sol = Nlp::new(MyNlp)
+    .var_bounds(&[0.0, 0.0], &[10.0, 10.0])
+    .constraint_bounds(&[1.0], &[1.0])
+    .x0(&[0.5, 0.5])
+    .option_str("algorithm", "active-set-sqp")
+    .solve();
+```
+
+or, driving `IpoptApplication` directly:
+
+```rust
+let mut app = IpoptApplication::new();
+app.initialize()?;
+app.initialize_with_options_str("algorithm active-set-sqp\n")?;
+let status = app.optimize_tnlp(tnlp);
+```
+
+Carrying a working set across solves — §3 below — additionally needs
+`features = ["qp"]`, because the `WorkingSet` type belongs to the QP engine.
+
 ### GAMS
 
 ```
@@ -263,6 +291,53 @@ for (int k = 0; k < horizon_steps; k++) {
 }
 ```
 
+### Rust: carry across solves
+
+```toml
+[dependencies]
+pounce-rs = { version = "0.9", features = ["qp"] }
+```
+
+The round trip is `last_sqp_working_set` out, `SqpIterates` in:
+
+```rust
+use pounce_rs::prelude::*;
+use pounce_rs::sqp::SqpIterates;
+
+let mut app = IpoptApplication::new();
+app.initialize()?;
+app.initialize_with_options_str("algorithm active-set-sqp\n")?;
+
+let mut working = None;
+let mut x = x0.clone();
+for _ in 0..horizon_steps {
+    // ... user code updates the parameter inside the TNLP ...
+    if let Some(w) = working.take() {
+        app.set_sqp_warm_start(SqpIterates {
+            x: x.clone(),
+            lambda_g: lambda_g.clone(),
+            lambda_x: lambda_x.clone(),   // packed: z_l − z_u
+            working: Some(w),
+        });
+    }
+    app.optimize_tnlp(Rc::clone(&tnlp));
+    working = app.last_sqp_working_set().cloned();
+    x = /* the x captured in finalize_solution */;
+}
+```
+
+The warm start is consumed by the solve that follows it, so each pass
+installs a fresh one; `clear_sqp_warm_start()` drops an unused one. Reading
+individual rows uses the same status enums the Python int8 codes above
+encode — `BoundStatus::{Inactive, AtLower, AtUpper, Fixed}` and
+`ConsStatus::{Inactive, AtLower, AtUpper, Equality}`, both re-exported from
+`pounce_rs::sqp`.
+
+When the seed comes from a *sensitivity predictor* instead of a previous
+solve (§4), there is no working set to carry —
+`pounce_rs::sqp::classify_working_set` derives one from the predicted point
+and its multipliers.
+
 ### GAMS: working set persists automatically
 
 The GAMS solver link reads variable and equation marginals (`x.m`,
@@ -297,7 +372,7 @@ playbook is:
 
 1. **Solve** at `p₀` with the IPM (better cold-start
    convergence than the SQP elastic phase).
-2. **Predictor**: ask `pounce_sensitivity::SensSolve` for
+2. **Predictor**: ask `pounce_rs::sensitivity::SensSolve` for
    `Δx ≈ ∂x*/∂p · Δp` at `p₀`.
 3. **Classify** the active set at the converged IPM iterate via
    `pounce.classify_working_set(...)`.

--- a/docs/src/rust.md
+++ b/docs/src/rust.md
@@ -1,0 +1,222 @@
+# Rust API
+
+POUNCE is written in Rust, so the Rust API is the solver itself rather than a
+binding over it. Everything is reached through one crate — **`pounce-rs`**, a
+facade that re-exports a curated public surface so your code does not depend
+on POUNCE's internal crate layout.
+
+```sh
+cargo add pounce-rs
+```
+
+```toml
+[dependencies]
+pounce-rs = "0.9"
+```
+
+The default build is the NLP path. The convex/conic, active-set QP, and
+sensitivity solvers are behind [feature flags](#feature-flags).
+
+> **Why one crate.** The solver is split across ~20 workspace crates
+> (`pounce-nlp`, `pounce-algorithm`, `pounce-convex`, …) whose boundaries move
+> as the code evolves. Depending on them directly couples you to that layout.
+> `pounce-rs` is the stability boundary; everything below is internal.
+
+## Two APIs
+
+### The builder — for the common case
+
+Implement [`Problem`] — only `objective` is required — then configure and
+solve. Anything you leave out is supplied: missing gradients and Jacobians are
+approximated by finite differences, and the Hessian defaults to a
+limited-memory (L-BFGS) approximation.
+
+```rust
+use pounce_rs::prelude::*;
+
+// min (x0−1)² + (x1−2)²  s.t.  x0 + x1 == 3,  0 ≤ x ≤ 5
+struct P;
+impl Problem for P {
+    fn objective(&self, x: &[f64]) -> f64 {
+        (x[0] - 1.0).powi(2) + (x[1] - 2.0).powi(2)
+    }
+    fn n_constraints(&self) -> usize { 1 }
+    fn constraints(&self, x: &[f64], g: &mut [f64]) { g[0] = x[0] + x[1]; }
+}
+
+let sol = Nlp::new(P)
+    .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+    .constraint_bounds(&[3.0], &[3.0])   // equality: lower == upper
+    .x0(&[0.0, 0.0])
+    .option_num("tol", 1e-10)
+    .solve();
+
+assert!(sol.success);
+assert!((sol.x[0] - 1.0).abs() < 1e-5 && (sol.x[1] - 2.0).abs() < 1e-5);
+```
+
+`n` is inferred from `var_bounds` or `x0` (they must agree). Options use the
+same names as the CLI and upstream Ipopt — `option_num`, `option_int`,
+`option_str`; see [Solver Options](options.md).
+
+The returned `Solution` carries `success` / `status`, `x`, `objective`,
+`multipliers`, the constraint values `g`, the bound multipliers `z_l` / `z_u`,
+and `stats` (wall time, iteration count, evaluation counts, final
+infeasibilities). The vector fields are filled by `finalize_solution`, so they
+stay **empty** if a solve aborts before finalizing — check `success` before
+indexing.
+
+To supply exact derivatives, implement `gradient` and `jacobian` and return
+`true`; returning `false` (the default) selects finite differences for that
+callback.
+
+### `TNLP` — for full control
+
+For an exact Hessian, custom Jacobian/Hessian *sparsity*, or NLP scaling,
+implement the [`TNLP`] trait directly and drive it with `IpoptApplication`.
+This is the same trait the CLI and the C ABI sit on.
+
+```rust
+use pounce_rs::prelude::*;
+use std::cell::RefCell;
+use std::rc::Rc;
+
+let mut app = IpoptApplication::new();
+app.initialize()?;
+let prob = Rc::new(RefCell::new(MyTnlp::default()));
+let status = app.optimize_tnlp(Rc::clone(&prob) as Rc<RefCell<dyn TNLP>>);
+assert_eq!(status, ApplicationReturnStatus::SolveSucceeded);
+```
+
+You provide `get_nlp_info` (sizes and nonzero counts), `get_bounds_info`,
+`get_starting_point`, the evaluators (`eval_f`, `eval_grad_f`, `eval_g`,
+`eval_jac_g`, `eval_h`), and `finalize_solution` to receive the answer.
+`eval_jac_g` and `eval_h` are called in two modes — `SparsityRequest::Structure`
+for the pattern, then `SparsityRequest::Values` — so the pattern is declared
+once and reused across iterations.
+
+The [crate documentation on docs.rs](https://docs.rs/pounce-rs) has a complete
+HS071 walkthrough.
+
+## Iteration capture and logging
+
+Opt into the per-iteration trajectory with `.capture_iterations()` on the
+builder; the records land in `sol.stats.iterations`. Outside the builder,
+`with_iter_capture` wraps any closure and returns the records alongside its
+result:
+
+```rust
+use pounce_rs::prelude::*;
+
+let (sol, iters) = with_iter_capture(|| {
+    Nlp::new(P)
+        .var_bounds(&[0.0, 0.0], &[5.0, 5.0])
+        .constraint_bounds(&[3.0], &[3.0])
+        .solve()
+});
+assert!(sol.success && !iters.is_empty());
+```
+
+On the `IpoptApplication` path, install `collector_scope()` for the duration of
+the solve and read the history back from `statistics()`. `init_subscriber()`
+turns on console logging without your crate taking a `tracing` dependency.
+
+## Feature flags
+
+Everything beyond the NLP path is off by default and lands in its own module.
+The two QP families both name their types `QpProblem` / `QpSolution` /
+`QpStatus`, so they cannot share one flat namespace.
+
+| feature | module | covers |
+|---|---|---|
+| `convex` | `pounce_rs::convex` | LP, convex QP, SOCP / exponential / power / PSD cones, SOS; batched and warm-started solves; symbolic-factorization reuse; QP sensitivity |
+| `qp` | `pounce_rs::qp`, `pounce_rs::sqp` | sparse **parametric active-set** QP, and the SQP working-set warm-start contract |
+| `sensitivity` | `pounce_rs::sensitivity` | sIPOPT-style `∂x*/∂p` predictors, parametric warm starts, reduced Hessian |
+| `full` | — | all three |
+
+```toml
+[dependencies]
+pounce-rs = { version = "0.9", features = ["convex", "sensitivity"] }
+```
+
+Enabling a feature widens what the crate **exports**, not what it builds: the
+default NLP path already compiles `pounce-qp`, `pounce-linsol`, and
+`pounce-feral` transitively, so `qp` costs nothing at build time and only
+`convex` and `sensitivity` add crates.
+
+`convex` and `qp` also enable **`pounce_rs::linsol`**, which supplies the
+sparse symmetric factorization those solvers take as an argument —
+`backend()` for the default parallel FERAL factor, `serial_backend()` for the
+inner-serial one used under an outer-parallel batch.
+
+### Convex: LP, QP, and conic
+
+```rust
+use pounce_rs::convex::{QpOptions, QpProblem, QpStatus, Triplet, solve_qp_ipm};
+use pounce_rs::linsol::backend;
+
+// min ‖x‖² − 0.5·x0 − 1.5·x1  s.t.  x0 + x1 == 1,  0 ≤ x ≤ 5
+let prob = QpProblem {
+    n: 2,
+    p_lower: vec![Triplet::new(0, 0, 2.0), Triplet::new(1, 1, 2.0)],
+    c: vec![-0.5, -1.5],
+    a: vec![Triplet::new(0, 0, 1.0), Triplet::new(0, 1, 1.0)],
+    b: vec![1.0],
+    g: vec![],
+    h: vec![],
+    lb: vec![0.0, 0.0],
+    ub: vec![5.0, 5.0],
+};
+
+let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
+assert_eq!(sol.status, QpStatus::Optimal);
+```
+
+`P` is the **lower triangle** of the Hessian in triplet form; an empty `P` is
+an LP. Cone blocks beyond the nonnegative orthant are declared with `ConeSpec`
+and solved by `solve_socp_ipm`. For many instances, `solve_qp_batch_parallel`
+runs one per rayon worker, and `QpFactorization` reuses the AMD ordering and
+symbolic analysis across instances that share a sparsity pattern. See
+[Convex Solver](convex-solver.md).
+
+### Active-set QP and SQP warm starts
+
+`pounce_rs::qp` is the parametric active-set engine — a different solver
+family from the convex IPM, for sequences of nearby QPs, and it accepts an
+indefinite Hessian. `pounce_rs::sqp` is the NLP-level counterpart: carrying a
+working set from one SQP solve into the next. See
+[Active-Set SQP & Warm Starts](active-set-sqp.md).
+
+### Sensitivity
+
+```rust
+use pounce_rs::prelude::*;
+use pounce_rs::sensitivity::SensSolve;
+
+let result = SensSolve::new(vec![2, 3])      // pinned constraint rows
+    .with_deltas(vec![-0.5, 0.0])            // Δp
+    .with_reduced_hessian()
+    .run(&mut app, tnlp);
+
+let dx = result.dx.expect("populated when with_deltas was set");
+```
+
+A sensitivity-stage failure is reported through `result.error`, **not**
+`result.status` — the underlying solve can converge while the post-solve step
+fails. See [Sensitivity Analysis](sensitivity.md) and
+[Sessions](sessions.md).
+
+## Escape hatch
+
+Each feature module also re-exports the crate behind it — `pounce_rs::convex`
+re-exports `pounce_convex`, and so on — so anything outside the curated
+surface stays reachable without adding a dependency. Reaching for it is a
+signal the facade is missing something; those are worth
+[filing](https://github.com/jkitchin/pounce/issues).
+
+## See also
+
+- [docs.rs/pounce-rs](https://docs.rs/pounce-rs) — the full API reference
+- [Choosing a Solver](choosing-a-solver.md) — which solver fits which problem
+- [Solver Options](options.md) — the option names shared by every frontend
+- [Python API](python.md) — the same solvers from Python

--- a/docs/src/sessions.md
+++ b/docs/src/sessions.md
@@ -21,9 +21,9 @@ rebuilding it on every call. The same machinery serves two workloads:
 |----------------------------------------------------------------------|-------------------------------------------|
 | One solve plus a few sensitivity queries, from Python                | `pounce.Solver` (Python)                  |
 | The same, from C                                                     | `IpoptSolver` (C ABI)                     |
-| The same, from Rust                                                  | `pounce_sensitivity::Solver`              |
-| Just a sparse symmetric factor — no IPM involved                     | `pounce_linsol::Factorization`            |
-| A one-shot sensitivity computation with a fluent builder             | `pounce_sensitivity::SensSolve` (Rust) or `Problem.solve_with_sens` (Python) |
+| The same, from Rust                                                  | `pounce_rs::sensitivity::Solver`          |
+| Just a sparse symmetric factor — no IPM involved                     | `pounce_rs::linsol::Factorization`        |
+| A one-shot sensitivity computation with a fluent builder             | `pounce_rs::sensitivity::SensSolve` (Rust) or `Problem.solve_with_sens` (Python) |
 
 The session API does **not** rebuild the IPM. Each `solve()` call runs
 the full barrier method from scratch. What it reuses is the **factor
@@ -174,7 +174,7 @@ corresponding one-shot APIs:
 * `pounce.Solver.reduced_hessian` ≡
   `Problem.solve_with_sens(compute_reduced_hessian=True)['reduced_hessian']`
   (1e-10).
-* `pounce_sensitivity::Solver::parametric_step` ≡
+* `pounce_rs::sensitivity::Solver::parametric_step` ≡
   `SensSolve::with_deltas` (1e-10).
 
 See `python/tests/test_solver_session.py` and


### PR DESCRIPTION
Follow-ups to #561, which merged in #564. **No closing keyword here on purpose** — #561 is already closed as completed by that merge, and these are the two gaps its PR body flagged as deliberately out of scope rather than a new filed issue.

## Problem

Two gaps, both about a Rust surface that is reachable but undocumented.

**The book has no Rust chapter.** It never has. The Rust snippets live inside the per-solver pages (`sensitivity.md`, `sessions.md`, `global-optimization.md`), so a Rust user arriving at the book has no entry point equivalent to `docs/src/python.md` — nothing that says what `pounce-rs` is, which of the two APIs to reach for, or that the other solver paths exist behind features.

**`docs/src/active-set-sqp.md` documents the SQP path for Python, C, and GAMS but not Rust** — in §2 (switching to the SQP path) and again in §3 (carrying a working set across solves). #561 made the active-set QP engine reachable from the facade, which is exactly what makes the omission worth fixing now.

## Cause

The chapter is a genuine absence rather than a regression. The §2/§3 omission is older than #561: before it, the Rust story for the active-set path would have meant naming internal crates, so there was nothing clean to write.

## Fix

**`docs/src/rust.md`** — the missing chapter. Install, the `Problem` + `Nlp` builder (only `objective` required; finite differences and L-BFGS fill the rest), the `TNLP` trait for exact Hessians / custom sparsity / NLP scaling, iteration capture, the feature-flag table, and one worked snippet per feature module. Linked from `SUMMARY.md` under Integrations, next to the Python API. The docs guard goes 43 → 44 pages, all reachable.

**`active-set-sqp.md` §2 and §3** — Rust sections alongside the existing three frontends.

**A curated `pounce_rs::sqp` (feature `qp`).** Writing §3 turned up a real hole rather than a prose one. The working-set round trip needs `SqpIterates` and `classify_working_set`, which sit in `pounce-algorithm`'s internals and were reachable only as `pounce_rs::pounce_algorithm::sqp::…`. Writing a brand-new Rust chapter that told readers to spell that would have re-created precisely the coupling #561 set out to remove, so the facade grew the module instead: `SqpIterates`, `classify_working_set`, `SqpOptions` / `SqpGlobalization` / `SqpHessianSource`, and the `WorkingSet` / `BoundStatus` / `ConsStatus` status types.

That produced the distinction most worth having in the docs:

| what you want | feature needed |
|---|---|
| flip `algorithm` to `active-set-sqp` | **none** — one option string, works on the default build |
| carry a working set across solves | `qp` — `WorkingSet` is the QP engine's type |

Both sections state it, so a reader does not add a feature they do not need.

**Prose references #561 missed.** That pass fixed `use` lines only, so it left the places that name a path in running text: `sessions.md`'s "which layer do I want" table and its verification list, and `active-set-sqp.md` §4. All now name the facade.

## Blast radius

`pounce_rs::sqp` is additive and behind the existing `qp` feature — no default build changes, no new dependency (`pounce-algorithm` is already a default dep; `pounce-qp` is already what `qp` enables). Everything else is documentation.

No solver behavior is touched, so no corpus sweep applies.

Per CONTRIBUTING's cross-solver doc ownership rule: `choosing-a-solver.md`, `lp-qp-routing.md`, and `python.md` are **untouched** — this changes no routing and no problem-class coverage. `rust.md` links to `choosing-a-solver.md` rather than restating the landscape, so the three stay the single source of that story.

## Tests

`crates/pounce-rs/tests/sqp_surface.rs`, importing only `pounce_rs`:

- **the round trip** — `last_sqp_working_set` → `SqpIterates` → `set_sqp_warm_start`, asserting the warm solve returns the same answer as the cold one to 1e-8 and yields a working set again
- **`classify_working_set`** — derives a seed from a predicted point: at the optimum of the fixture the equality row classifies `Equality` and neither bound is active
- **the §2 claim** — the algorithm flip solves correctly through the builder without touching any working-set type

Plus two new doctests on the `sqp` module.

**On "tests fail on the parent commit":** the first two do not compile there — `pounce_rs::sqp` does not exist yet. New-surface tests, not regression tests, so the usual formulation does not apply literally; their imports are what pins the property.

**Book snippets are compiled by nothing in CI**, which is the failure mode this PR is most exposed to — a chapter of plausible-looking Rust that does not build. So before landing, every runnable snippet in `rust.md` and every API name its prose mentions (`ConeSpec`, `QpFactorization`, `solve_socp_ipm`, `solve_qp_batch_parallel`, `backend` / `serial_backend`, `init_subscriber`, `collector_scope`, `SqpIterates`) was compile-checked against `pounce-rs --all-features` in a scratch test, which was then deleted. The `Solution` field names quoted in the chapter (`objective`, `multipliers`, `g`, `z_l`, `z_u`, `stats.iteration_count`, `stats.total_wallclock_time_secs`) were checked the same way. The status-enum variant names in §3 were read off `pounce-qp`'s definitions rather than recalled.

Clean locally: `cargo fmt --all -- --check`, `cargo clippy -p pounce-rs --all-features --all-targets -D clippy::correctness -D clippy::suspicious`, `cargo test -p pounce-rs --all-features` (25 tests + 11 doctests), `cargo check --workspace --exclude pounce-hsl --all-targets`, `scripts/check-release-consistency.sh`, `scripts/check-docs-consistency.sh`.

---

- [x] Tests fail on the parent commit for the stated reason — see the caveat above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new — `rust.md` is new and wired into `SUMMARY.md`
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now


---
_Generated by [Claude Code](https://claude.ai/code/session_01LkpG8JajqCDJvtbmYsfpkc)_