### PR TITLE
deps: bump feral 0.14.0 -> 0.15.0 (parallel-driver task granularity, #552)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,48 @@ exercises both on every solve. A CI leg pinned to a Pyomo *below* the
 floor checks that the legacy plugin still imports there, so the floor is
 a tested property rather than a claim.
 
+### Changed — FERAL 0.15.0, which fixes the parallel-driver task granularity behind the #552 factorization gap
+
+The workspace pin moves `feral` 0.14.0 → 0.15.0. The change that matters for
+POUNCE is upstream feral#148: the parallel multifrontal driver spawned one
+boxed rayon task *per supernode* — roughly 1.8M allocations per solve on a
+chain-structured problem — so a chain-shaped KKT paid allocator and scheduling
+cost for a tree that offers no parallelism. It now spawns one task per subtree,
+and a chain-shaped tree collapses to a single task and takes the sequential
+driver outright.
+
+This lands on the path POUNCE actually ships: `FeralConfig.parallel` defaults
+to `None` and is only disabled by an explicit `FERAL_PARALLEL=0`
+(`crates/pounce-feral/src/lib.rs:399`), so every default solve was on the
+parallel driver. Paired A/B on the six KKT matrices dumped from real solves
+(alternating process launches, 12 pairs, `min` of 5 warm factorizations):
+
+| matrix | 0.14.0 | 0.15.0 | speedup | wins | p |
+|---|---:|---:|---:|---:|---:|
+| clnlbeam | 53.07 ms | 23.18 ms | **2.29×** | 12/12 | 0.0005 |
+| steering_12800 | 39.11 | 22.59 | **1.73×** | 12/12 | 0.0005 |
+| dtoc2 | 112.42 | 96.70 | 1.16× | 12/12 | 0.0005 |
+| rocket_12800 | 18.11 | 15.65 | 1.16× | 12/12 | 0.0005 |
+| dtoc1nd | 13.73 | 12.02 | 1.14× | 11/12 | 0.006 |
+| marine_1600 | 29.10 | 28.73 | 1.01× | 8/12 | 0.39 |
+
+The release also makes the x86_64 `pulp` dispatch actually vectorize — every
+pulp kernel had been executing its lane operations as outlined calls, roughly a
+10× kernel slowdown, invisible on aarch64 where NEON is baseline — and turns
+the packed BLAS-3 trailing update into an explicit SIMD kernel.
+
+All of it is scheduling- and codegen-only. Factors are byte-identical, pinned
+upstream by `tests/task_plan_parity.rs` and hardcoded `tests/golden_bits.rs`
+digests, and confirmed here by identical solve-vector hashes across both
+versions on all six matrices. 0.15.0's one breaking change is diagnostic-only
+(`SupernodeTiming` / `BucketStats` / `ProfileReport` moved from `*_us` fields
+to `*_ns`, with `.us()` accessors kept); POUNCE consumes none of that API, so
+no source change was needed anywhere in the workspace.
+
+This narrows but does not close the gap reported in #552. It is also the
+counterpart to the #562 change below: that one removes a POUNCE-side cost on
+the same code path.
+
 ### Changed — the FERAL backend stops rebuilding the CSC matrix on every factorization (#562)
 
 `pounce-feral` handed FERAL a `CscMatrix` built by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "feral"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd098b55d4d14e0807addbfdba87efccbe699f72f58acf8aa78d622933af3144"
+checksum = "916a692e1224d0aec71dfd5ab754fe54811c1ee2a453ab67ab36e64813e04058"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,13 +118,30 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.9.0"
 # fuses the D-block solve into forward substitution (~14–29% faster warm
 # solves); plus opt-in tree-parallel sparse solve (#131) and analysis-time
 # assembly maps (#125). All bit-identical numerics, no breaking API change.
-# 0.14.0 is the current pin. If you ever need to develop against an unreleased
+# 0.15.0 fixes the parallel driver's task granularity (#148): it now spawns one
+# rayon task per *subtree* rather than one boxed task per supernode (~1.8M
+# allocations per solve on chain-structured problems), and a chain-shaped tree
+# collapses to a single task and takes the sequential driver outright. This is
+# the release that addresses the factorization gap in #552: on the six dumped
+# pounce KKTs, paired A/B against 0.14.0 on the parallel driver — which is what
+# pounce ships, since `FeralConfig.parallel` defaults to `None` — gives clnlbeam
+# 2.29×, steering_12800 1.73×, dtoc2/rocket_12800 1.16×, dtoc1nd 1.14×. Also
+# makes the x86_64 pulp dispatch actually vectorize (every pulp kernel had been
+# executing its lane ops as outlined calls, ~10× kernel slowdown, invisible on
+# aarch64) and turns the packed BLAS-3 trailing update into an explicit SIMD
+# kernel. Scheduling- and codegen-only: factors are byte-identical, verified
+# upstream by `tests/task_plan_parity.rs` and hardcoded `tests/golden_bits.rs`
+# digests, and independently here by identical solve-vector hashes on all six
+# KKTs. The one breaking change is diagnostic-only — `SupernodeTiming`,
+# `BucketStats` and `ProfileReport` moved from `*_us` fields to `*_ns` (with
+# `.us()` accessors kept for migration) — and pounce consumes none of it.
+# 0.15.0 is the current pin. If you ever need to develop against an unreleased
 # feral again, add an UNCOMMITTED `[patch.crates-io]` redirecting feral to the
 # git rev — e.g.
 #   [patch.crates-io]
 #   feral = { git = "https://github.com/jkitchin/feral.git", rev = "<sha>" }
 # Do NOT commit that patch (it re-introduces the publish blocker).
-feral = { version = "0.14.0" }
+feral = { version = "0.15.0" }
 # Dense linear algebra for the debugger's numerical rank diagnosis
 # (SVD of the active-constraint Jacobian). Pure-Rust, MIT; we pull only
 # the dense `std` core — no rayon/sparse/rand/npy.


### PR DESCRIPTION
Bumps the workspace `feral` pin from 0.14.0 to 0.15.0, which went up on
crates.io today.

## Why this one matters

0.15.0 fixes the parallel multifrontal driver's task granularity
(feral#148). It spawned one boxed rayon task *per supernode* — roughly 1.8M
allocations per solve on a chain-structured problem — so a chain-shaped KKT
paid allocator and scheduling cost for a tree that offers no parallelism at
all. It now spawns one task per subtree, and a chain-shaped tree collapses to
a single task and takes the sequential driver outright.

This lands on the path POUNCE actually ships: `FeralConfig.parallel` defaults
to `None` and is only disabled by an explicit `FERAL_PARALLEL=0`
(`crates/pounce-feral/src/lib.rs:399`), so every default solve was running the
parallel driver.

Measured through `SparseSymLinearSolverInterface` on the six KKT matrices
dumped from real solves, medians of 15, `POUNCE_FERAL_REFINE=0`, MA57 pinned
single-threaded — the same harness and protocol as the 0.14.0 table in #552:

| matrix | FERAL 0.14.0 | FERAL 0.15.0 | gain | MA57 | ratio was | ratio now |
|---|---:|---:|---:|---:|---:|---:|
| clnlbeam | 57.80 ms | 25.74 ms | **2.25×** | 7.27 | 8.05× | **3.54×** |
| steering_12800 | 47.34 | 27.44 | **1.73×** | 18.96 | 2.53× | **1.45×** |
| rocket_12800 | 24.70 | 19.11 | 1.29× | 8.79 | 2.87× | 2.17× |
| dtoc2 | 139.84 | 109.01 | 1.28× | 84.21 | 1.70× | 1.29× |
| dtoc1nd | 16.84 | 13.67 | 1.23× | 3.63 | 4.85× | 3.77× |
| marine_1600 | 39.38 | 35.50 | 1.11× | 13.50 | 3.05× | 2.63× |

`number_of_neg_evals` is identical to 0.14.0 and to MA57 on every matrix. The
MA57 column moved 1–4% between the two runs, which is the run-to-run drift of
the harness and is the reason the FERAL gain column is quoted against FERAL
rather than read off the ratio columns.

## Risk

Low. Scheduling- and codegen-only upstream: factors are byte-identical, pinned
by feral's own `tests/task_plan_parity.rs` and hardcoded `tests/golden_bits.rs`
digests, and confirmed independently here by identical solve-vector hashes
across both versions on all six matrices.

0.15.0's one breaking change is diagnostic-only — `SupernodeTiming`,
`BucketStats` and `ProfileReport` moved from `*_us` fields to `*_ns`, with
`.us()` accessors kept for migration. POUNCE consumes none of that API
(grepped the workspace and `python/` for every affected symbol, zero hits), so
**no source change was needed anywhere** — this PR is the pin, the lockfile,
and a CHANGELOG entry.

## Verification

- `cargo build --workspace --all-targets` — clean
- `cargo test --workspace --release` — 218 test binaries, **2,864 passed, 0
  failed**, 6 ignored
- `scripts/check-release-consistency.sh` — OK
- `cargo update -p feral --precise 0.15.0` touched one crate; no transitive
  churn in `Cargo.lock`

## Scope

This narrows the factorization gap reported in #552 but does not close it, so
no closing keyword. Remaining ratios are 1.29–3.77×, and the sharpest fixture
is now `dtoc1nd` rather than `clnlbeam`. Details posted on that issue.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cRDjGAQETFLbE6qcE77sR
