### PR TITLE
fix(pyomo-pounce): rename the `v2` extra, which broke every docker source build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,7 +212,7 @@ is the documented route, users of that model class were paying the legacy
 path's cost with no supported alternative that kept the extras.
 
 **Requirements, and only for the v2 route** (`pip install
-pyomo-pounce[v2]`): **Pyomo ≥ 6.10.1**, where the `SolutionLoader` /
+pyomo-pounce[pyomo-v2]`): **Pyomo ≥ 6.10.1**, where the `SolutionLoader` /
 `get_vars` API this builds on landed — `pyomo.contrib.solver.common`
 exists from 6.9.2, but 6.9.2–6.10.0 ship the older `SolutionLoaderBase` /
 `get_primals` — and **pounce-solver > 0.9.0**, because Pyomo's

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -106,7 +106,7 @@ exists from 6.9.2, but 6.9.2–6.10.0 ship the older
 `SolutionLoaderBase` / `get_primals`) and **pounce-solver > 0.9.0**
 (Pyomo's `asl_sol_reader` is strict where the legacy reader is lenient
 and needs the per-model `.sol` `Options` echo added after 0.9.0).
-`pip install pyomo-pounce[v2]` asks for both. Neither applies to
+`pip install pyomo-pounce[pyomo-v2]` asks for both. Neither applies to
 `SolverFactory('pounce')`: on an older Pyomo the legacy plugin works
 exactly as before and `pyomo_pounce.HAVE_V2_INTERFACE` reports `False`.
 

--- a/pyomo-pounce/README.md
+++ b/pyomo-pounce/README.md
@@ -83,8 +83,8 @@ silently drops all of the above — the integer-variable guard, the
 `scaling_factor` handling, the sensitivity path and the bundled-binary
 resolution. Prefer one of the two registrations above.
 
-> **Requirements for the v2 route** — `pip install pyomo-pounce[v2]` asks for
-> both:
+> **Requirements for the v2 route** — `pip install pyomo-pounce[pyomo-v2]`
+> asks for both:
 >
 > - **Pyomo ≥ 6.10.1**, which is where the `SolutionLoader` / `get_vars` API
 >   this builds on landed. (`pyomo.contrib.solver.common` exists from 6.9.2,

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -34,7 +34,32 @@ classifiers = [
 # `pyomo_pounce.v2`. Both floors here are strictly tighter than the base
 # dependencies, and neither applies to the legacy
 # SolverFactory('pounce') plugin -- which is why the base stays where it
-# is and this is an extra: `pip install pyomo-pounce[v2]`.
+# is and this is an extra: `pip install pyomo-pounce[pyomo-v2]`.
+#
+# NAME: this extra must NOT be called `v2`, and more generally must never
+# parse as a PEP 440 version. An extra emits `; extra == "<name>"` into the
+# wheel metadata, and packaging's marker evaluator tries `Specifier("==" +
+# name)` first, falling back to a string comparison only if that is invalid.
+# PEP 440 accepts a leading `v`, so `Specifier("==v2")` *parses* -- the
+# marker then takes the version path, and pip's dependency walk (which
+# evaluates markers with `extra` set to "") ends up calling `Version("")`
+# and raising `InvalidVersion: Invalid version: ''`. That took down every
+# `docker/Dockerfile` source build for a day (release-docker on main,
+# 2026-08-09 -> 2026-08-10) while `Dockerfile.release` stayed green,
+# because the latter installs from PyPI where the extra was not yet
+# published.
+#
+# It reproduces only on packaging < 26 (pip <= 25.x), which is what the
+# `python:3.12-slim` runtime stage ships; packaging 26 changed the marker
+# evaluator and swallows it. So a modern local pip will NOT show the bug --
+# do not conclude from a clean `pip install` on your laptop that an extra
+# name is safe.
+#
+# `pyomo-v2` is safe: the trailing text defeats the version parse, so the
+# marker takes the string path. Verify any rename with:
+#
+#   python3 -c 'from packaging.markers import Marker; \
+#     print(Marker("extra == \"NEW\"").evaluate({"extra": ""}))'
 #
 # * pyomo>=6.10.1 -- `SolutionLoader`/`get_vars`, the loader API this
 #   subclasses. `pyomo.contrib.solver.common` exists from 6.9.2, but
@@ -46,7 +71,7 @@ classifiers = [
 #   through this route. The legacy plugin is unaffected, so this floor
 #   belongs here rather than on the base dependency. CI builds the binary
 #   from source and would never catch it.
-v2 = ["pyomo>=6.10.1", "pounce-solver>0.9.0"]
+pyomo-v2 = ["pyomo>=6.10.1", "pounce-solver>0.9.0"]
 
 [project.urls]
 Homepage = "https://github.com/jkitchin/pounce"


### PR DESCRIPTION
## Symptom

`release-docker` has been red on `main` since the **#560 merge (2026-08-09 14:49)** — four merges, every run since. Within each run `build release` passes on both arches; only **`build source`** fails, on both arches, in the runtime stage:

```
RUN pip install --no-cache-dir /tmp/wheels/*.whl /tmp/pyomo-pounce
  → pip._vendor.packaging.version.InvalidVersion: Invalid version: ''
```

## Cause

It is the **name** of the extra #560 added, not its dependencies.

An extra emits `; extra == "<name>"` into the wheel metadata. packaging's marker evaluator tries `Specifier("==" + name)` first and falls back to a string comparison only when that is *invalid*. PEP 440 accepts a leading `v`, so `Specifier("==v2")` **parses** — the marker takes the version path, and pip's dependency walk evaluates markers with `extra` set to `""`, so it ends up calling `Version("")`:

```
v2       Specifier("==v2")  valid: True   → evaluate(extra="") → InvalidVersion
jax      Specifier("==jax") valid: False  → evaluate(extra="") → False
```

Every other extra in the project (`jax`, `torch`, `scipy`, `diffrax`, `viz`, `gams`, `dev`) is unparseable as a version, which is why this had never come up.

## Fix

`v2` → **`pyomo-v2`**. The trailing text defeats the version parse, so the marker takes the string path. Keeps the "v2" wording, since the extra gates the `pyomo.contrib.solver` (v2) interface.

**No user impact**: published `pyomo-pounce` 0.9.0 reports `provides_extra: None` — the extra has never shipped. The `pyomo_pounce.v2` module and `tests/test_v2.py` are unrelated to the extra name and are untouched.

## Why this was easy to miss

Both recorded in a comment above the extra so it doesn't get re-broken:

1. **`Dockerfile.release` stayed green the whole time**, because it installs from PyPI where the extra isn't published. Only the source Dockerfile builds the wheel carrying the bad metadata — so the failure looked isolated and cosmetic.
2. **It only reproduces on packaging < 26 (pip ≤ 25.x)**, which is what the `python:3.12-slim` runtime stage ships. packaging 26 changed the marker evaluator and swallows it, so a modern local `pip install` shows nothing at all.

## Verification

Built the wheel both ways and ran pip's real resolution under pip 25.2 (vendored packaging 25.0, matching the runtime image):

| extra name | pip 25.2 (packaging 25.0) | pip 26.2.1 (packaging 26.2) |
|---|---|---|
| `v2` | `InvalidVersion: Invalid version: ''` — the CI error | resolves |
| `pyomo-v2` | `Would install …`, exit 0 | resolves |

Also confirmed the shipped wheel metadata is clean, and that `scripts/check-release-consistency.sh` passes:

```
Provides-Extra: pyomo-v2
Requires-Dist: pyomo>=6.10.1; extra == "pyomo-v2"
Requires-Dist: pounce-solver>0.9.0; extra == "pyomo-v2"
```

Docs updated in the three places that mention the install command: `pyomo-pounce/README.md`, `docs/src/pyomo.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cRDjGAQETFLbE6qcE77sR
