### PR TITLE
deps: bump feral 0.15.0 -> 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,63 @@ changes.
 
 ## [Unreleased]
 
+### Changed — FERAL 0.15.1, which stops assuming the host has threads
+
+The workspace pin moves `feral` 0.15.0 → 0.15.1. It is a patch release with
+no API change and no source change anywhere in the workspace, but two of its
+items are the upstream half of the `FERAL_PARALLEL` fix directly below.
+
+**`Solver` derives `use_parallel` from the platform (feral#154).**
+`Solver::new()` / `Solver::with_params()` previously hardcoded
+`use_parallel = true` and built a rayon `ThreadPool` on every `factor()`.
+That is wrong wherever the host has no usable threads, and POUNCE has such a
+host: feral is in the `pounce-wasm` dependency tree, and on
+`wasm32-wasip1` both `available_parallelism()` and `thread::spawn` report
+`Unsupported`, while a threads-enabled wasm host whose worker pool has not
+been stood up makes `build()` wait for workers that never arrive. The default
+is now `available_parallelism() > 1`.
+
+**A failed pool falls back to the sequential driver (feral#156).** When
+`use_parallel` is on but the `Solver`-owned pool could not be built, `factor()`
+(including the MC64 retry), `solve_refined` and `solve_many_refined` previously
+ran the parallel driver with no `install` — i.e. on rayon's *global* pool,
+defeating the per-`Solver` isolation exactly when nesting is least welcome
+(compare the latent nested-rayon self-deadlock in feral#102). All four now run
+the sequential driver. `Solver` also no longer initializes rayon's global
+registry on any path. No numerical change: the two drivers carry a bit-exact
+per-supernode contract.
+
+Together these are why `FERAL_PARALLEL`'s force-on arm matters, and this bump
+is what makes the comment at `crates/pounce-feral/src/lib.rs:424` true rather
+than aspirational.
+
+The release also carries three items we get for free:
+
+- **MC64 scaling-cache gate fixed.** The value-bound gate that decides whether
+  a cached MC64 scaling may be reused compared the current *minimum* scaled
+  diagonal against the baseline *mean* — different statistics, so it behaved as
+  an absolute property of the matrix rather than the drift measure it was meant
+  to be, and rejected reuse on matrices that had not moved. The fix is a strict
+  widening. Across 53 gate evaluations on the seven corpus families that route
+  to MC64, exactly two decisions change, both on `robot_1600`: factorization
+  time −14.3%, scaling time −39.8%. Inertia is unchanged on every iterate of
+  every family, and a genuine diagonal collapse is still rejected.
+- **MC64 Hungarian matching 4–5% faster** on large matchings (the min-heap now
+  stores the key inline instead of a random access into the distance array per
+  comparison). Verified bit-identical on 51 matrices across 39 families.
+- **`Supernode.nrow` corrected after amalgamation.** `find_supernodes` used
+  `col_counts[first_col].max(ncol)`, exact for a *fundamental* supernode but
+  wrong after a size-based merge; undercounts reached 40%. Numeric factors and
+  inertia are unaffected — `build_row_indices` always recomputed the true row
+  set — but everything that *estimates* from `nrow` was working from a wrong
+  number. The one edge that reaches us: `estimate_assembly_flops` rises 2–3×,
+  so matrices sitting just under `PAR_MIN_FLOPS` can now route to the parallel
+  driver where they previously fell to sequential. `FeralConfig.min_par_flops`
+  defaults to `None`, so we inherit feral's threshold — which was itself
+  calibrated against the understated estimate and may now sit in the wrong
+  place. `feral_min_par_flops` / `POUNCE_FERAL_MIN_PAR_FLOPS` is the override
+  if it needs re-tuning.
+
 ### Fixed — `FERAL_PARALLEL` is now bidirectional and speaks the same grammar as every other knob
 
 `FERAL_PARALLEL` was the one boolean environment variable in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,9 +305,9 @@ dependencies = [
 
 [[package]]
 name = "feral"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916a692e1224d0aec71dfd5ab754fe54811c1ee2a453ab67ab36e64813e04058"
+checksum = "b6bd1f036fdba1dba54becef3a5ea7e9cfbfc367ab6abcb9adff765217590de4"
 dependencies = [
  "feral-amd",
  "feral-amf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,13 +135,34 @@ pounce-observability = { path = "crates/pounce-observability", version = "0.9.0"
 # KKTs. The one breaking change is diagnostic-only — `SupernodeTiming`,
 # `BucketStats` and `ProfileReport` moved from `*_us` fields to `*_ns` (with
 # `.us()` accessors kept for migration) — and pounce consumes none of it.
-# 0.15.0 is the current pin. If you ever need to develop against an unreleased
+# 0.15.1 is a patch release with no API change, and is the counterpart to
+# pounce #567: feral's `Solver` now derives `use_parallel` from
+# `available_parallelism()` instead of hardcoding `true` (feral#154), and a
+# `ThreadPoolBuilder::build()` failure falls back to the *sequential* driver
+# rather than silently running on rayon's global pool (feral#156). Both matter
+# to us — feral is in the `pounce-wasm` dependency tree, where the hardcoded
+# `true` was simply wrong — and #567 already wrote `pounce-feral` against these
+# semantics, so this bump is what makes that comment true. It also fixes an
+# MC64 scaling-cache gate that compared a *minimum* against a *mean* and so
+# rejected reuse on matrices that had not drifted at all (robot_1600:
+# factorization −14.3%, scaling −39.8%), speeds the MC64 Hungarian matching
+# 4–5% on large matchings (bit-identical over 51 matrices), and corrects a
+# post-amalgamation `Supernode.nrow` underestimate. That last one is the only
+# item with a behavioral edge: numeric factors and inertia are unaffected
+# (`build_row_indices` always recomputed the true row set), but
+# `estimate_assembly_flops` rises 2–3×, so matrices sitting just under
+# `PAR_MIN_FLOPS` can now route to the parallel driver. We do not pin that
+# threshold — `FeralConfig.min_par_flops` defaults to `None` — so we inherit
+# feral's, and `feral_min_par_flops` / `POUNCE_FERAL_MIN_PAR_FLOPS` remain the
+# override if the calibration turns out to want re-tuning.
+#
+# 0.15.1 is the current pin. If you ever need to develop against an unreleased
 # feral again, add an UNCOMMITTED `[patch.crates-io]` redirecting feral to the
 # git rev — e.g.
 #   [patch.crates-io]
 #   feral = { git = "https://github.com/jkitchin/feral.git", rev = "<sha>" }
 # Do NOT commit that patch (it re-introduces the publish blocker).
-feral = { version = "0.15.0" }
+feral = { version = "0.15.1" }
 # Dense linear algebra for the debugger's numerical rank diagnosis
 # (SVD of the active-constraint Jacobian). Pure-Rust, MIT; we pull only
 # the dense `std` core — no rayon/sparse/rand/npy.


### PR DESCRIPTION
Bumps the workspace `feral` pin 0.15.0 → 0.15.1. Three files, the same
shape as the 0.14.0 → 0.15.0 bump (`c2a3b8d5`): `Cargo.toml`, `Cargo.lock`,
`CHANGELOG.md`. No source change anywhere in the workspace — 0.15.1 has no
API change.

## Why now

Two of the four items in 0.15.1 are the upstream half of #567, merged
yesterday.

**`Solver` derives `use_parallel` from the platform (feral#154).**
`Solver::new()` / `Solver::with_params()` hardcoded `use_parallel = true` and
built a rayon `ThreadPool` on every `factor()`. POUNCE has a host where that
is wrong: feral is in the `pounce-wasm` dependency tree, and on
`wasm32-wasip1` both `available_parallelism()` and `thread::spawn` report
`Unsupported`, while a threads-enabled wasm host whose worker pool has not
been stood up makes `build()` wait for workers that never arrive. The default
is now `available_parallelism() > 1`.

**A failed pool falls back to the sequential driver (feral#156).** When
`use_parallel` is on but the `Solver`-owned pool could not be built,
`factor()` (including the MC64 retry), `solve_refined` and
`solve_many_refined` previously ran the parallel driver with no `install` —
on rayon's *global* pool, defeating the isolation the per-`Solver` pool
exists to provide. All four now run the sequential driver, and `Solver` no
longer initializes rayon's global registry on any path. No numerical change;
the drivers carry a bit-exact per-supernode contract.

Together these are why `FERAL_PARALLEL`'s force-on arm matters. #567 already
wrote the comment at `crates/pounce-feral/src/lib.rs:424` against these
semantics — this bump is what makes it true rather than aspirational.

## What else comes along

- **MC64 scaling-cache gate fixed.** The value-bound gate compared the
  current *minimum* scaled diagonal against the baseline *mean* — different
  statistics, so it acted as an absolute property of the matrix rather than
  the drift measure intended, and rejected reuse on matrices that had not
  moved. Strict widening. Two of 53 gate evaluations change, both on
  `robot_1600`: factorization −14.3%, scaling −39.8%. Inertia unchanged on
  every iterate of every family; a genuine diagonal collapse is still
  rejected.
- **MC64 Hungarian matching 4–5% faster** on large matchings. Bit-identical
  on 51 matrices across 39 families.
- **`Supernode.nrow` corrected after amalgamation.** Exact for fundamental
  supernodes, wrong after a size-based merge; undercounts reached 40%.

## The one thing worth watching

The `Supernode.nrow` fix is the only item with a behavioral edge. Numeric
factors and inertia are unaffected — `build_row_indices` always recomputed
the true row set — but `estimate_assembly_flops` rises 2–3×, so matrices
sitting just under `PAR_MIN_FLOPS` can now route to the parallel driver where
they previously fell to sequential. `FeralConfig.min_par_flops` defaults to
`None`, so we inherit feral's threshold, which was itself calibrated against
the understated estimate and may now sit in the wrong place.
`feral_min_par_flops` / `POUNCE_FERAL_MIN_PAR_FLOPS` is the override if it
needs re-tuning. Flagged in both the `Cargo.toml` comment and the CHANGELOG
rather than acted on, since re-calibrating upstream's threshold is not this
PR's job.

## Verification

- `cargo check --workspace --all-targets` — clean (only pre-existing warnings)
- `cargo check -p pounce-wasm --target wasm32-unknown-unknown` — clean; this
  is the target the #154 default change actually affects
- `cargo test --workspace --release` — see below
- `scripts/check-release-consistency.sh` — OK

`cargo test --workspace --release`: **219 suites, 2865 tests, 0 failures.**
