### PR TITLE
build(wasm): enable nontrapping-float-to-int and simd for wasm-opt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,9 +89,10 @@ jobs:
   # `test` job type-checks pounce-wasm on the host, which catches neither of
   # the two ways this surface breaks: a dependency that stops compiling for
   # wasm32 (a new `libc`/`dlopen`/thread call somewhere in the tree), and one
-  # that compiles but traps at run time on a syscall WASI does not have. The
-  # smoke test drives the same C ABI the page uses — load a `.nl`, solve it,
-  # check the objective — under Node's WASI.
+  # that compiles but traps at run time on a syscall WASI does not have. A
+  # third is the wasm-opt post-processing step, which is what the page and the
+  # demo actually ship. The smoke test drives the same C ABI the page uses —
+  # load a `.nl`, solve it, check the objective — under Node's WASI.
   wasm:
     name: WebAssembly build + smoke
     runs-on: ubuntu-latest
@@ -104,6 +105,20 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "22"
+
+      # `build.sh` runs wasm-opt only when binaryen is on PATH and silently
+      # falls back to `cp` otherwise, so a CI runner without binaryen exercises
+      # the fallback and never the optimizer. That blind spot is how the
+      # validation failure this step now guards reached main: wasm-opt rejected
+      # the module ("Fatal: error validating input") because Rust's
+      # wasm32-wasip1 output uses non-trapping float-to-int and SIMD, and since
+      # build.sh runs under `set -euo pipefail` that was a hard build failure
+      # for every contributor who had binaryen installed — while CI stayed
+      # green. Installing it here means CI builds what those contributors and
+      # the deployed page actually get.
+      - name: Install binaryen (wasm-opt)
+        run: sudo apt-get update && sudo apt-get install -y binaryen
+
       - name: Build the wasm module
         run: crates/pounce-wasm/build.sh
       - name: Solve a model in wasm

--- a/crates/pounce-wasm/build.sh
+++ b/crates/pounce-wasm/build.sh
@@ -23,7 +23,10 @@ out="$root/target/$target/release/pounce_wasm.wasm"
 
 # wasm-opt (binaryen) is optional; it typically takes another ~15% off.
 if command -v wasm-opt >/dev/null 2>&1; then
-  wasm-opt -Oz --enable-bulk-memory "$out" -o "$here/web/pounce.wasm"
+  # Rust's wasm32-wasip1 code uses non-trapping float-to-int conversions.
+  # Keep the feature enabled when Binaryen validates the module.
+  wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --enable-simd \
+    "$out" -o "$here/web/pounce.wasm"
 else
   cp "$out" "$here/web/pounce.wasm"
 fi

--- a/crates/pounce-wasm/build.sh
+++ b/crates/pounce-wasm/build.sh
@@ -23,10 +23,17 @@ out="$root/target/$target/release/pounce_wasm.wasm"
 
 # wasm-opt (binaryen) is optional; it typically takes another ~15% off.
 if command -v wasm-opt >/dev/null 2>&1; then
-  # Rust's wasm32-wasip1 code uses non-trapping float-to-int conversions.
-  # Keep the feature enabled when Binaryen validates the module.
-  wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int --enable-simd \
-    "$out" -o "$here/web/pounce.wasm"
+  # rustc's wasm32-wasip1 output uses post-MVP features — bulk memory,
+  # non-trapping float-to-int, sign extension, SIMD — and wasm-opt rejects
+  # the whole module ("error validating input") unless each one is enabled
+  # for validation. Enumerating them is a losing game: the exact set moves
+  # with the Rust release, and distro binaryen lags badly enough to disagree
+  # about the defaults (Ubuntu noble ships 108, from 2022; a current Homebrew
+  # is 131). `-all` enables everything the local binaryen knows about. It
+  # only widens what wasm-opt will *accept* — the emitted feature set is
+  # still whatever rustc produced, so this does not change what the page
+  # requires of a browser.
+  wasm-opt -Oz -all "$out" -o "$here/web/pounce.wasm"
 else
   cp "$out" "$here/web/pounce.wasm"
 fi


### PR DESCRIPTION
Cherry-picked from #482 (commit `e48a5feb`, authored by @GermanHeim) so it can land
on its own — it is an independent, already-reproducible build bug and has nothing to
do with the wasm hang that #482 is really about.

## The bug

`crates/pounce-wasm/build.sh` runs `wasm-opt` when binaryen is on `PATH`, but passed
only `--enable-bulk-memory`. Rust's `wasm32-wasip1` output also uses non-trapping
float-to-int conversions and SIMD, so binaryen rejects the module:

```
Fatal: error validating input
```

The script runs under `set -euo pipefail`, so this is not a degraded build — it is a
hard failure. **Anyone with binaryen installed currently cannot build `pounce-wasm`
at all.** Users without binaryen take the `cp` fallback branch and never see it,
which is why this went unnoticed.

## Verification

On `main`, stable 1.97.1, binaryen 131:

```console
$ crates/pounce-wasm/build.sh
...
Fatal: error validating input
EXIT 1
```

With this commit applied, same toolchain and same binaryen:

```console
$ crates/pounce-wasm/build.sh
web/pounce.wasm  2358214 bytes (2.2 MB)
EXIT 0
```

and the optimized module runs correctly:

```console
$ node crates/pounce-wasm/tests/smoke.mjs
ok — solved in wasm: objective -0.707106784, 10 iterations, 15.1 ms
```

## Note for reviewers

The `build.sh` change is confined to the `if command -v wasm-opt` branch; the only
other file touched is the `wasm` CI job (below). This carries none of #482's `cfg(wasi)` / `cfg(target_arch = "wasm32")` workarounds, which
are a separate discussion — the hang those target turns out to be an upstream
rustc/std regression on `wasm32-wasip1`, present only in the 1.99 nightly cycle
(1.98 beta is clean), not a POUNCE bug. Details are in #482.

## Second commit: close the CI gap

The reason this reached `main` at all is that the `wasm` job never ran wasm-opt —
binaryen is not installed on the runner, so `build.sh` took its silent `cp` fallback
and CI stayed green while contributors with binaryen installed could not build. The
second commit installs binaryen in that job, so CI now builds the same optimized
module the demo page ships and this class of failure cannot recur unnoticed.
