### PR TITLE
ci: compile tests at opt-level 2 and stop running CI twice per commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,23 @@
 name: CI
 
+# A bare `push:` alongside `pull_request:` runs the entire workflow twice for
+# every commit on a branch with an open PR — once per event, on the same SHA.
+# Both runs are full duplicates (measured on 40a1e9e0's parent: Test took 1256s
+# and 1270s in the two runs of the same commit), so scoping push to `main`
+# halves CI for PR work. The trade-off: a branch pushed *without* an open PR no
+# longer gets a run. Open the PR (draft is enough) to get CI on it.
 on:
   push:
+    branches: [main]
   pull_request:
+
+# Superseded runs are wasted work — a force-push or a quick follow-up commit
+# leaves the earlier run grinding for its full ~20 minutes with nobody reading
+# the result. Cancel in-flight runs for the same ref, but never on `main`,
+# where each commit's result is the record of that commit.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,3 +205,26 @@ expect_used = "warn"
 lto = "thin"
 codegen-units = 1
 debug = 1
+
+# `cargo test` defaults to opt-level 0, which is the wrong default for this
+# workspace: most of what the suite does is run a numerical solver, and
+# unoptimized floating-point kernels are ~10x off. Measured on the full
+# `cargo test --workspace --exclude pounce-hsl`:
+#
+#              build (cold)   test run
+#   opt 0           29s          542s
+#   opt 2           86s           52s
+#
+# A 9.9x cut in the test run for +57s of build — net ~4x on total wall-clock,
+# and the CI `Test` job is the long pole that sets overall CI time. The worst
+# single offender was `pounce_nl`'s harness at 707s of CI's 1182s, dominated by
+# two `greedy_hessian_coloring` tests that build multi-million-element pair
+# vectors; those two alone go 368s -> 26s.
+#
+# This is deliberately `profile.test` and not `profile.dev`: it leaves plain
+# `cargo build` untouched for local work. Measured separately, `profile.test`
+# alone captures the entire win (86s / 52s), so raising `dev` buys nothing.
+# `debug_assertions` and overflow checks stay on at opt-level 2, so the tests
+# still assert everything they did before.
+[profile.test]
+opt-level = 2


### PR DESCRIPTION
CI's total wall-clock is set entirely by the `Test (ubuntu-latest)` job — 20m56s
of a 20m56s run. Two independent causes, both measured rather than guessed.

## 1. The test suite compiles unoptimized

`cargo test` uses the dev profile, i.e. opt-level 0. Most of what this suite does
is run a numerical solver, and unoptimized floating-point kernels cost about 10x.

Full `cargo test --workspace --exclude pounce-hsl`, cold target dir, both passing:

|              | build (cold) | test run  | total    |
|--------------|-------------:|----------:|---------:|
| opt 0 (today)|          29s |  **542s** |     571s |
| opt 2        |          86s |   **52s** |     142s |

A **9.9x** cut in the test run for +57s of build — net ~4x on total wall-clock.

Where it was going, from the CI log of run 31424661114 (`Test` step = 1182s):

| test binary                  | time  |
|------------------------------|------:|
| `pounce_nl`                  | 707s  |
| `masked_certificate_fuzz`    | 123s  |
| `pounce_convex`              |  81s  |
| everything else (220 binaries)| ~155s |

Inside `pounce_nl`'s 154 tests, all but two finish instantly. The two are
`peeling_is_capped_and_keeps_the_worst_offenders` and
`thousands_of_medium_degree_cols_are_not_peeled`, which build multi-million-element
pair vectors and run `greedy_hessian_coloring` over them. Those two alone:
**368s → 26s**, and 29s with this `Cargo.toml` change and no env overrides.

### Why `profile.test` and not `profile.dev`

`[profile.test]` leaves plain `cargo build` at opt-level 0, so local edit/build
loops are unaffected. I measured the alternative to check it wasn't leaving
anything on the table — `profile.test` alone gives 86s build / 52s test, against
87s / 55s with `profile.dev` raised as well. Raising `dev` buys nothing here.

`debug_assertions` and integer-overflow checks remain on at opt-level 2, so the
tests still assert exactly what they did before. All tests pass.

### The alternative I rejected

Deleting or shrinking the two slow tests. They guard a real regression whose
docstring records the numbers — the buggy peeling rule colored those patterns to
306 and 290 against a plain walk's 50 and 34. And shrinking is not actually
available for `peeling_is_capped_and_keeps_the_worst_offenders`: with
`MAX_PEELED_COLS = 256` it needs `dense_rows > 256`, and the cap regime only
exists while `n` exceeds ~16x the average degree, which puts `n = 20_000` close
to the minimum size at which the test tests anything. Shrinking it would have
quietly made it vacuous. Compiling it optimized keeps the coverage and costs
nothing.

## 2. Every commit ran the whole workflow twice

`on: { push:, pull_request: }` with a bare `push:` fires both events for any
commit on a branch with an open PR, producing two complete duplicate runs of the
same SHA. On `d82b4563`:

```
31424661114  pull_request  Test 1256s
31424656763  push          Test 1270s
```

Scoping push to `main` halves CI for PR work. The trade-off, called out in a
comment in the workflow: a branch pushed *without* an open PR no longer gets a
run — opening the PR (draft is enough) restores it. The release workflows already
scope their triggers and are untouched.

Also adds a concurrency group so a force-push or quick follow-up commit cancels
the superseded in-flight run instead of leaving it grinding for 20 minutes.
`cancel-in-progress` is disabled on `main`, where each commit's result is the
record for that commit.

## Expected effect

CI runs per PR commit go 2 → 1, and the `Test` job should drop from ~21 minutes
to a few. The runner is slower than the machine these numbers came from, so the
ratio is the transferable part, not the absolute seconds — this PR's own CI run
is the first real measurement of that.
