### PR TITLE
notebooks: sparse Jacobians and Hessians with asdex (33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,8 @@ the full list and per-suite details.
 
 ## pounce in the wild
 
+You can find an external benchmark of pounce at https://plato.asu.edu/ftp/ampl-nlp.html
+
 [Opyrability](https://github.com/CODES-group/opyrability#installation) now uses pounce as its default solver.
 
 [SiNDAE](https://github.com/llueg/SiNDAE)  — A Simultaneous Approach for Training Neural Differential-Algebraic Equations

--- a/python/notebooks/33_asdex_sparsity.ipynb
+++ b/python/notebooks/33_asdex_sparsity.ipynb
@@ -1,0 +1,780 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fd9eb753",
+   "metadata": {},
+   "source": [
+    "# Sparse Jacobians and Hessians with `asdex`\n",
+    "\n",
+    "POUNCE's sparse interface wants two things for each matrix: a *structure*\n",
+    "— the `(rows, cols)` index pair naming which entries can ever be nonzero —\n",
+    "and a *values* callback returning those entries in that order. Deriving the\n",
+    "structure by hand is the tedious, error-prone part of setting up a large NLP,\n",
+    "and getting it wrong is not a crash but a wrong answer.\n",
+    "\n",
+    "[`asdex`](https://github.com/adrhill/asdex) removes that step for JAX\n",
+    "models. It walks the jaxpr with abstract interpretation to recover a global\n",
+    "sparsity pattern, then colors it so the whole matrix falls out of a handful\n",
+    "of AD passes instead of one per variable. This notebook wires it to POUNCE\n",
+    "two ways, measures what the coloring buys, and shows the case that motivates\n",
+    "using a *proved* pattern rather than a sampled one.\n",
+    "\n",
+    "`pip install asdex` alongside `pounce-solver[jax]`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2e8c65b1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:19.009679Z",
+     "iopub.status.busy": "2026-08-10T21:03:19.009404Z",
+     "iopub.status.idle": "2026-08-10T21:03:19.616213Z",
+     "shell.execute_reply": "2026-08-10T21:03:19.615764Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import asdex\n",
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "\n",
+    "import pounce\n",
+    "from pounce.jax import from_jax\n",
+    "\n",
+    "jax.config.update(\"jax_enable_x64\", True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1ba728e",
+   "metadata": {},
+   "source": [
+    "## 1. A problem with real structure\n",
+    "\n",
+    "`clnlbeam` is a standard nonconvex optimal-control benchmark: an elastic\n",
+    "beam discretized on $N+1$ nodes, with angle $t$, deflection $x$, and control\n",
+    "$u$ stacked into one vector $z = (t, x, u)$. The dynamics enter as $2N$\n",
+    "equality constraints, each touching only neighbouring nodes.\n",
+    "\n",
+    "We add a control-smoothing term $\\tfrac{\\beta h}{2}\\sum_i (u_{i+1}-u_i)^2$,\n",
+    "which is standard in optimal control and is what couples adjacent $u$'s. With\n",
+    "$\\beta = 0$ the Lagrangian Hessian is exactly diagonal; with $\\beta > 0$ it is\n",
+    "tridiagonal. The coloring below responds to that difference, which is a good\n",
+    "way to see it is reading real structure rather than guessing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c844c708",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:19.617702Z",
+     "iopub.status.busy": "2026-08-10T21:03:19.617599Z",
+     "iopub.status.idle": "2026-08-10T21:03:19.781839Z",
+     "shell.execute_reply": "2026-08-10T21:03:19.781366Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "n = 603 variables, m = 400 equality constraints\n"
+     ]
+    }
+   ],
+   "source": [
+    "N = 200\n",
+    "h = 1.0 / N\n",
+    "alpha = 350.0   # bending stiffness\n",
+    "beta = 1.0      # control smoothing\n",
+    "\n",
+    "\n",
+    "def objective(z):\n",
+    "    t, _x, u = jnp.split(z, 3)\n",
+    "    effort = jnp.sum(0.5 * h * (u[1:] ** 2 + u[:-1] ** 2))\n",
+    "    bending = jnp.sum(0.5 * alpha * h * (jnp.cos(t[1:]) + jnp.cos(t[:-1])))\n",
+    "    smoothing = 0.5 * beta * h * jnp.sum((u[1:] - u[:-1]) ** 2)\n",
+    "    return effort + bending + smoothing\n",
+    "\n",
+    "\n",
+    "def constraints(z):\n",
+    "    t, x, u = jnp.split(z, 3)\n",
+    "    return jnp.concatenate([\n",
+    "        x[1:] - x[:-1] - 0.5 * h * (jnp.sin(t[1:]) + jnp.sin(t[:-1])),\n",
+    "        t[1:] - t[:-1] - 0.5 * h * (u[1:] + u[:-1]),\n",
+    "    ])\n",
+    "\n",
+    "\n",
+    "def lagrangian(z, lam, sigma):\n",
+    "    return sigma * objective(z) + jnp.dot(lam, constraints(z))\n",
+    "\n",
+    "\n",
+    "n = 3 * (N + 1)\n",
+    "z0 = jnp.zeros(n)\n",
+    "m = int(constraints(z0).shape[0])\n",
+    "print(f\"n = {n} variables, m = {m} equality constraints\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d2f0f887",
+   "metadata": {},
+   "source": [
+    "## 2. Detecting the pattern\n",
+    "\n",
+    "`jacobian_sparsity` and `hessian_sparsity` return a `SparsityPattern` with\n",
+    "`.rows` / `.cols` — already the `(rows, cols)` pair POUNCE's structure\n",
+    "callbacks expect. Nothing here evaluates the model at a sample point in the\n",
+    "statistical sense: the pattern is derived from the computation graph and is\n",
+    "valid for *every* input.\n",
+    "\n",
+    "The Hessian POUNCE needs is the Hessian of the Lagrangian\n",
+    "$\\nabla^2(\\sigma f + \\lambda^\\top g)$, so we detect on `lagrangian`, treating\n",
+    "$z$ as the differentiated argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "47f61c14",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:19.783067Z",
+     "iopub.status.busy": "2026-08-10T21:03:19.782993Z",
+     "iopub.status.idle": "2026-08-10T21:03:19.845545Z",
+     "shell.execute_reply": "2026-08-10T21:03:19.845101Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "constraint Jacobian    (400, 603)     nnz =   1600  density = 6.63e-03\n",
+      "Lagrangian Hessian     (603, 603)     nnz =    802  density = 2.21e-03\n"
+     ]
+    }
+   ],
+   "source": [
+    "jac_pat = asdex.jacobian_sparsity(constraints, z0)\n",
+    "hess_pat = asdex.hessian_sparsity(lagrangian, z0, jnp.ones(m), 1.0)\n",
+    "\n",
+    "for name, p in ((\"constraint Jacobian\", jac_pat), (\"Lagrangian Hessian\", hess_pat)):\n",
+    "    print(f\"{name:22s} {str(p.shape):14s} nnz = {p.nnz:6d}  \"\n",
+    "          f\"density = {p.density:.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "3aaadf74",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:19.846805Z",
+     "iopub.status.busy": "2026-08-10T21:03:19.846740Z",
+     "iopub.status.idle": "2026-08-10T21:03:20.090667Z",
+     "shell.execute_reply": "2026-08-10T21:03:20.090317Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA5kAAAGZCAYAAAADyfUPAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAZYZJREFUeJzt3QmYFNX19/EzbMO+y76IgIAiooiIoCKguBEQjKgoiwSiASKQRMSIiKK4JIorrgE1IooBVPwDCgq4gCKKgigKIYKsamTYZBHqfX7XtzrdQ89Mz0xPr9/P8xQzXV3dfbu6pqlT99x7MjzP8wwAAAAAgCgoFo0nAQAAAABACDIBAAAAAFFDkAkAAAAAiBqCTAAAAABA1BBkAgAAAACihiATAAAAABA1BJkAAAAAgKghyAQAAAAARA1BJgAAAAAgaggyAQAAUCRuu+02y8jIiHczElKnTp3cEi8vv/yyVa1a1fbs2WOJ5Nhjj7UBAwYU6LF6L7/73e+sVq1a7rgbMWJE1NuXqubNm2fly5e377//PirPR5AJAAAQJVOnTnUntx9//HG8m5L29DkMGzYs7H3p/jkdPnzYxo0bZ8OHD3eBhe+uu+6y2bNnW7JS+/XZXn/99fb888/bNddcYx988IG72LFz584CPed5552X47Gk9eGWu+++22LphRdecK8b/Fn6FLCHa2Pz5s1DtrvgggusSZMmNnHixKi0qURUngUAAADI5pZbbrGbbrop3s1ISG+++WbcXvv111+3tWvX2pAhQ44K0i677DLr2bOnJaO3337bzjjjDBdA+/72t7/Z+PHjXbBVuXLlfD3fzJkzbenSpXkGof369QtZd8opp1isqPf2xhtvtHLlyuW4TWZmpj399NMh6ypVqnTUdr///e/tz3/+s9tfFSpUKFS7CDIBAABS0N69e3M98YyFEiVKuAVHK1WqVNxee8qUKdahQwerW7eupZIdO3bYCSecEJXn2r9/v/3pT3+y0aNH26233prjdscff7xdffXVFi8TJkxwAeG5556bYy+0/gYjaWPv3r1d7/aMGTPs2muvLVS7SJcFAACIoYMHD7qT1jZt2rjeBAWCZ511lr3zzjtHbfvjjz+6lL+KFSu6Xpj+/fvbZ5995tLdlBboUy+NUuXWr19vF110kTvp7Nu3r7vv3Xfftd/+9rfWoEED16NRv359GzlypP38888hr+U/x+bNm11Pln4/5phjXM+G0isL0q5wYzIV4HTu3Nlq1Kjh2qOgYPLkyWHH5l1yySX23nvv2emnn26lS5e24447zp577jkrKl999ZXrydNYRb3eaaedZq+99lrINocOHXI9PU2bNnXbVKtWzTp27GhvvfVWYJtt27bZwIEDrV69eu491q5d23r06GH/+c9/chyTGelxoefQPlUP3ZNPPmmNGzd2r9G2bVtbvnx5RMGTxt917do1ZL2eUxcmnn322UBKZfDYyE8//dQuvPBC95nr2OjSpYstW7YsbBrykiVLXK+Y9o22V0/fTz/9ZAWlVFeNr9Sxq/eqtM577rnHjhw54u5ftGiRe90NGzbYG2+8EdL+v/zlL26bRo0aBdYHfw45uffee93z6/jPi/6WtF8j9fPPP7t0VS3Bf4f//e9/3bFy5plnHvU3F84333xjDzzwgN1///15XszR8+3atSvXbfQ32apVK3v11VetsLi0BAAAEEM60VPq2pVXXmmDBw+23bt32zPPPGPdunWzjz76yFq3bu220wlu9+7d3TqNMdMJqU7+FNCF88svv7jnUMCjAKRs2bJuvXol9u3b555DJ/16vocffti+++47d1/2E1E9R7t27dxzLFiwwP7+97+7QEaPL0i7slNAeeKJJ9pvfvMbd2Ks1M0//OEP7nmHDh0asu26detc0Ddo0CD3/P/4xz9c4KBATM+RF534//DDD0etDzfZzRdffBHo3VOKr4I8TY6jgPtf//qXXXrppYHAWePWNMGMgl99nhrb+cknn7jUSb9HSM+nXiEFy+phUxC6ceNGd7swx4Vv2rRpbhsFcwqcFBT16tXL/v3vf1vJkiVz3CcrVqxwAe2pp54asl5jGP335KfR6nP3940CXgWMSs3U8z/xxBMuSF68eLE7XoJp/KIuPmhfKS1Xn/m3334bCAbzQ8fuOeec4y5+6L3qYonGWY4ZM8a2bt1qkyZNshYtWrj26+KJAnv1QMpJJ53k3uuLL77ogrHq1au79bp4kht9ThpXqeOtTJkyuW6rwPqxxx4zz/NcO5QiftVVV+X6GD2ngnkdb3/9619dkCg6/rOystxzFi9ePM99o8BbPZi6sKRjNbd9qM9OP6tUqeKOMQXp4cZw6m8rKuNyPQAAAETFlClTPJ1eLV++PMdtfvnlF+/AgQMh63766SevZs2a3rXXXhtY969//cs916RJkwLrDh8+7HXu3Nmt12v5+vfv79bddNNNR73evn37jlo3ceJELyMjw/v222+Peo7bb789ZNtTTjnFa9OmTYHaNW7cOLcur/Z069bNO+6440LWNWzY0D12yZIlgXU7duzwMjMzvT/96U9eXvTYvJbgz6lLly7eSSed5O3fvz+w7siRI96ZZ57pNW3aNLDu5JNP9i6++OIcX1efpZ77vvvuy7V955xzjlvye1xs2LDBPX+1atW8//73v4H1r776qlv/+uuv5/q6Tz/9tNtu1apVR91Xrlw5dxxk17NnT69UqVLe+vXrA+u2bNniVahQwTv77LOPOv51vBw8eDCw/t5773Xr1ca86HMPbsMdd9zh2vX111+HbKdjvXjx4t7GjRtDHpv9s9HnoNfWfovUZZdd5j53nx4/dOjQo7bTNvo70PuaPHmy17JlS7ftY489FtHrjBkzxitWrJg7xmfMmHHU31Vu5syZ45UoUcL74osv3G3tM+2n7LSfRo8e7b300kveiy++GPg779Chg3fo0KGjtr/rrrvc/du3b/cKg3RZAACAGFIPhT8eT713SpFTL6RSM9Ub5lNKo3qM1KvlK1as2FG9fcH83sZgwT0xSodUz57S8XTurBTI7K677rqQ2+rBUu9YYdqVU3vUa6P2qKdKr6HbwZRKq9f3qQeqWbNmIe3JjVJU1YOYffFTKH36DDRpzOWXX+56B9UmLUoLVk+i0hLVkybqoVPPntbl9P70+arXLj8popEeF74+ffq4Ximfv5/y2jd6TxL82Nyod1uTFKlHV+nKPqV1qsdO6czZ0zDVExrcm6rjUr3W//d//2f5pd52vTe11/9ctCjdV21Tam40KT1ZPdfqIc3L+++/bzfccIPrldffjXqJW7ZsaTfffPNR6ejhqKdXPfLqpVdvvv4O/vjHP+b5OPXOqtdWr5nXGFT1uqtXVsf2FVdc4XpJ77zzTtf2V1555ajt/eMiXAZAfhBkAgAAxJhS5TT2yR/Tp+BJY8mCgyylF+pE3k979Wk8Wjg6iVeqYLjUP6WYapyhP85SJ7OSPahTe7KnEuqkMzhYym+7stPJrQIEpaMqYNPr6aQ8XHuUGpld9vbkRvtDr5V9yX5irrRcBd1jx4517Qle/JlKlfIqt99+uxsjqAlflI6pgPXzzz8PPJfGDCoVce7cuVazZk07++yzXSqrxmlG47jIad/4wUGk++bXDrq8qW6i0iwV3Gen9FAFxJs2bQpZr/GqwXTc6Zjxx0Lq/Wh/+IsC6pwomNeFjeyfiz+m1P9cokFBvYI8jTfWGNf80kUCpQrv3LnTBZyRbK+UXI0l1cUNjVeOJJ1Yqb8KAjU2uCAUoOrCkNLhczouClvfljGZAAAAMfTPf/7TBX3qGVKAosk21IulHgdN3FNQCm504hhMPT0aJ6iTeM2SqfGTCu7UK6c2+BOn+CIZB1YYen+aMEbt0Dg0TeSiE231cOnEOdL2RBogRcp/XU3yop7LcPwgWkGj3ofGoaqHT+Mo1fbHH3/cjWn0x8pp3KrGts2fP98Fr/p81VuaU3mL/B4XBd03Cl79YDTcRYlYUO+fAmqfLnqo5zenz0bHsMaChqNgP1o0qZTGkGq8afbJgRQEap0+l+wXWILpmJbcAudgOj788cMKqDVBUW4UoGtGWfV8qgfZ70XWOGN99mqj2qd25kS97ToOwrXRv0jhj18tKIJMAACAGFKKmtIOVYMvuLcguLafNGzY0KXuqRcp+KRWvW6RWrVqlX399dfuhD64ll/wTKj5VZh2aZKfAwcOuBlbg3viws2sG0t+GqhSPLPPuhqOeoU1e6wWndwr8FTqox9k+pPmaAIaLQoeNHGPJlFSMFmY46KwFOCLes/UExssXO+Veg31OSv4Cjcbry5s+IGVT+9XE9L4tI80SY8mqBEFjMElNXJL3dV+1OMj+VzCyU+PnHr9NXuwJuQJF4BqmTVrVq51RP105WPymFxI1AOunnEdRytXrnTHj/5mw9WwDA4CtT/UO64lOwWpShPPbfIePyU8XBt1XCjAjKT9uSFdFgAAIIb8HqjgHqcPP/zwqKLv6lHTCe9TTz0V0qvz6KOPFuq19PuDDz5Y4PYXpl3h2qOeGaUJxpN6fTRTqnqwFAyFSxnNPqYxOBVUvZwKnkXBd/ZyFgqUVFbG36Ywx0VhafZQ9R5rRtzs1MutVM/s7Tr//PNdz21w79727dvdDLeazVgzlwZTaRUdIz7NLqtUVJVAEaUrB6cvq0050VhC7QO/xy+Y2qrnzY1fKzb7+wpHYxYVRGZfRAGyfvdn0g0+JoKDN43lrF69eq7vSbR/1HNdp04d9/eosZLap0plzetYDddGBfVKs9bvmnlXdByqTdndcccd7ji74IILjrpPab7t27e3wqInEwAAIMo0zkrjyMKlCar2o3qrVBLj4osvdj0HSrXUiXdwaQ31lqichHrC1EuoHij1APopbpH00OgxCnCUBqoUWQUDmtSkMDULC9MuBSsKcJRKqnIUer8KVnXiHC64iyUFyQqY1LunSY3Uq6iTfgU4KveiOqCiz0kBqYII9WgqWFMvpMbiiXqOlRKs4EjbaqysTvz1XApichLpcVFYCkT0OWg8nnrRguk9ab1SmRX8qFdMQZXSM9X7rf2jNE29JwXkCprD9aZpYhp/H6gHVCU+9FhNkJNfSh3W8aX945ev0QRW6vHTflfgm1tqpx/sqVSI9r96q3X8+cFnML92ZTjaF8E9mDpe1Fuo51KvvI5f/d2rN/T5558PTOKUE+1T9V4uXLjQXYDQWFzVSVUJFJXt8Xt9s1OvcrieVLVFpW6C79N4V6Vnq2SJ/74UrCs9XQGmejyDaXyrelcjncQrV4WamxYAAABHlXDIadm0aZMri6EyASq3oHIcKhGicgQqLaB1wb7//nvvqquucqUiKlWq5A0YMMB7//333XNNnz49sF1O5QtkzZo1XteuXb3y5ct71atX9wYPHux99tlnYcughHuOcGVIIm1XuMe+9tprXqtWrbzSpUt7xx57rHfPPfd4//jHP44qMxGuHEW40h85yansRG6lZlSio1+/fl6tWrW8kiVLenXr1vUuueQS75VXXglsM2HCBO/000/3Kleu7JUpU8Zr3ry5d+eddwZKdvzwww/udbVe+1P7p127dt7LL7+c6/uI9LjwS5iEK5Gi9drneZk5c6YrYRNc/kO++uorV5JE70vPFVxK5JNPPnGlZnQclS1b1jv33HO9Dz74IOx+Xbx4sTdkyBCvSpUqbvu+fft6P/74oxeJ7CVMZPfu3a7cR5MmTVwpFR3HKh/yt7/9LaRUSk7HjMqg6LNUuZD8ljPJ6Vh68803vfPOOy9wrOh4OP/8872FCxfm+XwrVqxw5UeGDx8esl5lbNq2bevVqVPHla/Jj3B/v3qOq6++2u03fWY6rk488UR3nAXvN5/KsGi7Xbt2eYWVoX8KH6oCAAAgFtRjod4ulY4IN3YsXhK1XTiaJoRSD6l6GpU6GS1K+dT4wuXLl7vSK0gu6vVUL70msiosxmQCAAAkqOy19hQcPPzwwy7t9dRTT6VdKBCNs1SqrFI+o5mKi+Q1b948N2GTP56zsBiTCQAAkKCGDx/uAjpNxKHxbxqz98EHH9hdd93lyhDQLhRUnz593AKIxmhG84IDQSYAAECC6ty5syt7MWfOHDdTpGYxVY+hP8kM7QKQiBiTCQAAAACIGsZkAgAAAACihiATAAAAABA1BJkAAAAAgKghyAQAAAAARA1BJgAAQAGpzuCxxx5rpUuXtnbt2tlHH30U8zbcdtttlpGREbI0b948Zq+/ZMkS6969u9WpU8e99uzZs0Pu1xyTt956q9WuXduVN+nataurxxePtgwYMOCofaXSDUVh4sSJ1rZtW6tQoYLVqFHDevbsaWvXrg3ZRjPzDh061KpVq2bly5e33r172/bt2+PWnk6dOh21f6677rqot2Xy5MnWqlUrV1dVi0rhzJ07Ny77JZL2xGq/hHP33Xe71xsxYkTc9k9BEGQCAAAUwEsvvWSjRo2ycePG2SeffGInn3yydevWzXbs2BHztpx44om2devWwPLee+/F7LX37t3r3rsC7nDuvfdee+ihh+zxxx+3Dz/80MqVK+f2k06UY90WUVAZvK9efPFFKwqLFy92gcCyZcvsrbfeskOHDtn555/v2ugbOXKkvf766zZjxgy3/ZYtW6xXr15xa48MHjw4ZP/o84u2evXqueBpxYoV9vHHH7uSOD169LAvvvgi5vslkvbEar9kt3z5cnviiSdcABws1vunQFTCBAAAAPlz+umne0OHDg3cPnz4sFenTh1v4sSJMW3HuHHjvJNPPtlLBDq1nDVrVuD2kSNHvFq1ann33XdfYN3OnTu9zMxM78UXX4xpW6R///5ejx49vHjYsWOHa9PixYsD+6FkyZLejBkzAtt8+eWXbpulS5fGvD1yzjnneDfccIMXD1WqVPGefvrpuO+X7O2J137ZvXu317RpU++tt94Kef1E2T95oScTAAAgnw4ePOh6PZT66StWrJi7vXTp0pi3R+mnShE97rjjrG/fvrZx40ZLBBs2bLBt27aF7KdKlSq51OJ47CdZtGiRSxdt1qyZXX/99fbjjz/G5HWzsrLcz6pVq7qfOn7Umxi8b5Tm3KBBg5jsm+zt8b3wwgtWvXp1a9mypY0ZM8b27dtXpO04fPiwTZ8+3fWoKk013vsle3vitV+GDh1qF198cch+kHjvn0iViHcDAAAAks0PP/zgTkZr1qwZsl63v/rqq5i2RQHb1KlTXdCkNL7x48fbWWedZatXr3bj7+JJAaaE20/+fbGkVFmlFTZq1MjWr19vN998s1144YXu5Lx48eJF9rpHjhxxY+o6dOjgghTR+y9VqpRVrlw55vsmXHvkqquusoYNG7oLFp9//rmNHj3ajducOXNm1NuwatUqF8QpbVrjCmfNmmUnnHCCrVy5Mi77Jaf2xHq/iIJcpeArXTa7eB43+UGQCQAAkMQUJPk0dktBp06IX375ZRs0aFBc25ZorrjiisDvJ510kttfjRs3dr2bXbp0KdJeKQX9sRwrW5D2DBkyJGT/aLIm7RcF5NpP0aSLIgoo1aP6yiuvWP/+/d34wnjJqT0KNGO5XzZt2mQ33HCDGzerCcWSFemyAAAA+aS0OfV8ZZ/RUbdr1apl8aQejuOPP97WrVtn8ebvi0TcT6L0Yn2WRbmvhg0bZnPmzLF33nnHTTDj0/tX2vXOnTtjum9yak84umAhRbF/1BvXpEkTa9OmjZv5VhM2Pfjgg3HbLzm1J9b7ZcWKFW7ysFNPPdVKlCjhFgW7mjxLv6vHMh77J78IMgEAAApwQqqT0YULF4akIOp28DiueNizZ4/rYVFvS7wpLVUnvsH7adeuXW6W2XjvJ/nuu+/cmMyi2Feae0gBndIu3377bbcvgun4KVmyZMi+UQqmxtMWxb7Jqz3hqGdPYnEs6e/nwIEDMd8vebUn1vulS5cuLnVXr+Evp512mhtr7f+eCPsnL6TLAgAAFIDKlyilTid9p59+uk2aNMlNFjJw4MCYtuPPf/6zqw2pFFmVMlBJFfWyXnnllTELaoN7dDTZj06GNaGMJiPR2L8JEyZY06ZNXWAzduxYN7ZNdRpj2RYtGq+qmoIKfBWI33jjja73SiVViiIlddq0afbqq6+6sbH+eDlNfKR6ofqpdGYdR2qb6jMOHz7cBQpnnHFGzNuj/aH7L7roIld/UWMPVSrj7LPPPqqERmFp4hyleev42L17t3tdpSzPnz8/5vslr/bEcr+IPpvgcbKisj96bX99rPdPgcR7elsAAIBk9fDDD3sNGjTwSpUq5UqaLFu2LOZt6NOnj1e7dm3Xhrp167rb69ati9nrv/POO658QvZF5UL8MiZjx471atas6UqXdOnSxVu7dm3M27Jv3z7v/PPP94455hhXAqJhw4be4MGDvW3bthVJW8K1Q8uUKVMC2/z888/eH/7wB1cuo2zZst6ll17qbd26NS7t2bhxo3f22Wd7VatWdZ9TkyZNvL/85S9eVlZW1Nty7bXXuv2vY1afh46JN998My77Ja/2xHK/5CR7CZVY75+CyNA/8Q50AQAAAACpgTGZAAAAAICoIcgEAAAAAEQNQSYAAAAAIGoIMgEAAAAAUUOQCQAAAACIGoJMAAAAAEDUEGQCAAAU0IEDB+y2225zPxNBIrUnkdqSaO1JpLYkWnsSqS2J1p4DCdSWvFAnEwAAoIB27dpllSpVsqysLKtYsWK8m5NQ7UmktiRaexKpLYnWnkRqS6K1Z1cCtSUv9GQCAAAAAKKGIBMAAAAAEDUlovdUAAAAqe/IkSO2ZcsWq1Chgu3evTuQxpYI/HYkQnsSqS2J1p5EakuitSeR2pJo7dkV57ZolKW+8+rUqWPFiuXeV8mYTAAAkHYeffRRu++++2zbtm128skn28MPP2ynn356RI/97rvvrH79+kXeRgBIRJs2bbJ69erlug09mQAAIK289NJLNmrUKHv88cetXbt2NmnSJOvWrZutXbvWatSokefj1YMpy1d/Y78Uzwysr1y2lNWpXKZI2w4A8aIeVF1g878Dc0NPJgAASCsKLNu2bWuPPPJIIP1VJ07Dhw+3m266KeIZHhv/+RX7pXjpwPrMEsXs7T93sroEmgBSUH5mt2XiHwAAkDYOHjxoK1assK5duwbWaWyRbi9dujTsY1STTidXwYt7rl+OhG73yxH7ae/BIn4HAJD4CDIBAEDa+OGHH+zw4cNWs2bNkPW6rfGZ4UycONFdvfcXxmMCQO4IMgEAAHIxZswYlx7mL5r0AgCQMyb+AQAAaaN69epWvHhx2759e8h63a5Vq1bYx2RmZrolu1IlitkvwduVKGZVypWKepsBINkQZAIAgLRRqlQpa9OmjS1cuNB69uwZmPhHt4cNG5av55ozvGPIxD8KMJn0BwAIMgEAQJpR+ZL+/fvbaaed5mpjqoTJ3r17beDAgfl6HpUryWmGxc07fw6ZBIgAFEA6IcgEAABppU+fPvb999/brbfe6ib7ad26tc2bN++oyYAKSgFm578tcrPN+ihvAiCdEGQCAIC0o9TY/KbHRko9mMEBZnB5E4JMAOmA2WUBAAAAAFFDkAkAAAAAiBqCTAAAgCjSJD8agxmM8iYA0gljMgEAAKJI4y41yQ+zywJIVwSZAAAAUaaAMqegkvImAFIdQSYAAECMUN4EQDpgTCYAAECM5FbeBABSBUEmAAAAACBqCDIBAAAAAFFDkAkAABAjlDcBkA6Y+AcAACBGKG8CIB0QZAIAAMQQ5U0ApDqCTAAAgARAeRMAqYIxmQAAAAmA8iYAUgVBJgAAAAAgaggyAQAAAABRQ5AJAACQAChvAiBVMPEPAABAAqC8CYBUQZAJAACQBOVNhBInAJIBQSYAAEASoMQJgGTBmEwAAIAkQIkTAMmCIBMAAAAAEDUEmQAAAACAqCHIBAAASAKUOAGQLJj4BwAAIAlQ4gRAsqAnEwAApI3bbrvNMjIyQpbmzZtbslBA2bJupcASHGBq9tnVm7MCi24DQDzQkwkAANLKiSeeaAsWLAjcLlEi+U+HKG8CIJEk/7cqAABAPiiorFWrVsTbHzhwwC2+Xbt2WTKVNyHIBBBrpMsiaUydOtWlNf3nP/+xdHvPH3/8cZ7bdurUyS3x8vLLL1vVqlVtz549lkiOPfZYGzBgQIEeq/fyu9/9zp2M6nMYMWJE1NsHs5tuusnatWsX72YgjXzzzTdWp04dO+6446xv3762cePGXLefOHGiVapUKbDUr18/Zm0FgGREkImouuuuu2z27NmWaNasWePG4UQaoPpjdn744Ycib1sqOHz4sI0bN86GDx9u5cuXT/jjIVJqvwL966+/3p5//nm75ppr7IMPPnDHx86dOwv0nOedd547toYNG3bUfdnHifnL3XffbUXtzjvvtN/85jdWs2ZN95p6j+HMmjXLunXr5k7QMzMzrV69enbZZZfZ6tWrwwb44d7PddddF7KdgvfPPvvMXnvttSJ7f4BPFzT0dz1v3jybPHmybdiwwc466yzbvXt3jo8ZM2aMZWVlBZZNmzbFtM0AkGxIl0XUT8p1wtmzZ8+oP7dO8K+44gp3YluQIHP8+PGup08nvqnozTffjNtrv/7667Z27VobMmRIzI6HWHj77bftjDPOcAG0729/+5s7ltQ7Wrly5Xw938yZM23p0qV5BqH9+vULWXfKKadYUbvllltcj61ea/78+Tlut2rVKqtSpYrdcMMNVr16ddu2bZv94x//sNNPP929t5NPPjlk+9atW9uf/vSnkHXHH398yG29bo8ePdy+VaALFKULL7ww8HurVq1c0NmwYUOXjTFo0KCwj9H/OwX5vyce5U2yj8mkvAmAeCDIRNzs3bvXypUrF/H2xYsXdwvCK1UqficSU6ZMsQ4dOljdunUtlezYscNOOOGEqDzX/v37XbA1evRou/XWW3PcTgHY1VdfbbGm3hxdgFHv/THHHJPjduHarpRi9WiqV+jxxx8PuU/HRCTv5/LLL7ff/va39u9//9ulMAKxootF+rtbt26dJTPKmwBIJKTLJqnNmze7K65+ylqjRo1cSt/Bg//7z0Unazpp0zi5smXLuh6ZN954I+R5Fi1a5NLXdAVX6XI6USxdurR16dLlqP9wNYald+/ertdB22hb9SwqdUj0PAocn3322UBanD8Wzk8/VY/iVVdd5XpCOnbs6O77/PPP3XY6sdTz6vmvvfZa+/HHH/Mck6mT4ksuucTee+8915Oix+t5nnvuuZDHaT/IueeeG2ib3nt+vPvuu+55GjRo4Pa5xuSMHDnSfv756Cniv/rqK3fSrJP1MmXKWLNmzeyvf/1ryDaffvqpu6JesWJFl2Kqfb5s2bKwr71v3z77/e9/b9WqVXPbq6frp59+ynVMpo4FBQRt2rRxY4gU0Csl7J133gl5nPan9od6kZ588klr3Lixe39t27a15cuXRxQ8Ke2sa9euIetzOx4iff/+Z75kyZI8339+KNVVKZr6DPVemzRpYvfcc48dOXIk5O9CgZf+ZoLb/5e//MVto785f30kadj33nuve/4///nPeW6rY0r7NVLaXiUYtAQfj//973+tdu3aduaZZ7qU5twUpoe/Ro0a7jsmpxRiHYs6FnLjHz+vvvpqgdsBFHTs9fr1693fSrKjvAmAREFPZhLasmWLC6h0Qqf0RJ1YKuh85ZVXXDCiHq3t27e7E0vd/uMf/+hOznWyr1Q0bXfppZeGPKfGfBUrVsydACto1AmxJkP48MMPAyeJGoel2fU07k6BoF5zzpw5rh0KYjRmTT0aapufNqmAJZiCtKZNm7o0Ss/z3Lq33nrLBcQDBw50z/vFF1+4YEc/FXToJD43CoaVkqmgu3///i51T8GAgitNU3/22We7ffDQQw/ZzTffbC1atHCP839GasaMGW5/KpjX/vzoo4/s4Ycftu+++87d51PQrGCuZMmSbj/o5F0nMEopVSAvem/aRgHTjTfe6LZ94oknXJC4ePHioyZB0fg9XW1XsK60VPUYffvtt4FgKBzNfvj000/blVdeaYMHD3bjjZ555hn3OartSmMMNm3aNLeNgjk9p46BXr16uc9G7cvJihUr3PFx6qmnhqzP7XiIxfvPiT7Dc845xx2/eq+6aKBxlhpztXXrVps0aZI7NtR+XUTQxRQ/3fOkk05y7/XFF1+0Bx54wKWLSm49f6JJRfQ3pmNTFx1yo8D6sccec38faofSWHVhJjd6Tv19qzdZFzPuv/9+t37o0KHu71nPGe0sAP3dHzp0yKXLap/peNOFgnApxwpAFeQqJVH7VKm22ek7RMfH+++/77YBior+n+vevbs7HvX/qdLh9feh78pURXkTADHnIen069fPK1asmLd8+fKj7jty5Ij7OWLECEVw3rvvvhu4b/fu3V6jRo28Y4891jt8+LBb984777jtWrRo4R04cCCw7YMPPujWr1q1yt3+9NNP3e0ZM2bk2rZy5cp5/fv3P2r9uHHj3OOvvPLKo+7bt2/fUetefPFFt/2SJUsC66ZMmeLWbdiwIbCuYcOGR223Y8cOLzMz0/vTn/4UWKd2azu930j47f3+++9zbefEiRO9jIwM79tvvw2sO/vss70KFSqErAv+bKRnz55eqVKlvPXr1wfWbdmyxT1Oj8/+ntu0aeMdPHgwsP7ee+9161999dXAunPOOcctvl9++SXkM5WffvrJq1mzpnfttdcG1ml/6rmqVavm/fe//w2s13Nr/euvv57rvnr66adDjpVIjoeieP850TES3IY77rjDtevrr78O2e6mm27yihcv7m3cuDHksRdffHHIdvfdd99Rx2FeLrvsMu/MM88M3Nbjhw4detR22mbSpEnufU2ePNlr2bKl2/axxx6L6HXGjBnjvhv09+Af83q+/NAxr8fpbyA3zZo1c9tpKV++vHfLLbcEvld83bt39+655x5v9uzZ3jPPPOOdddZZbvsbb7wx7HOef/757rsIKEp9+vTxateu7b6D6tat626vW7cuX8+RlZXljmX9TAarvtvpNRw956hF6wGgKL77SJdNMkq302ydugp72mmnHXW/36vzf//3f64HyU9JFaUkqkdJqX1KWw2mXsTgMX3qZRL1Yvm9DKIJQdQTVFDZZ5WU4J4dpQhqTJhSe+WTTz7J8zk1Zs5vr9+rpPRUv+3REtxOpf6pneotVsyg1E/5/vvvXWqn0n3VQxbus1GPjibp0WQ4wWPPlKqlHiul/mavwabPLbg3Ub2pqvOmzzknujLvf6Y6bpQ6+csvv7jjJtx+7dOnj0tjzukYyImf1hz82NzE6v3nRL3Oem9qrz5Df1G6ptqmzy+alJ78r3/9y/X25UW9eOrlU8aB/lbUS9yyZUvXAx8uLTs79fSq9149+n/4wx9cj6168YtqHK7SpNXrqh5XtS97Sq5mi1VPtSb10d+EeqnVk66eVmUAZOd/JkBRmj59uuvBVGaOjkPdzp51AwAoHILMJKMgRifgOvHMjVIJFWhl56eI6v5g2QMiP2Dwx71p/NmoUaNc+qVSBHWi+OijjwbGY0ZKz5Odgh+dWKt0ggI5BYn+dpE8f/a2++0vzJi9nFIelYarMa4K2NVOncQHt9MPyHL7fPQZKlDP6fNRQJh9enylGAfT6ysoy2ssoFIoNXuixqoqxVdt1hjDcPs1r2MgL376c16K4v3r/Sht0190TOVEY4sVHGlfBC/+mEBN9hMtCuoV5GlmZI1xzS9dJFCqsFJTFXBGsr1ScjWWVKnPCgTzm04cqfbt27vvAQX8uvj0z3/+06Uc50ZtUSqs9ku4MdE6hoqqvQAAIHYYkwknp/FawYHD3//+dxdkaWIO9UTp5FkFqjVuUuPWIhFuPJomyNGYOE2oonGCCiAUaFxwwQWBiVgK2/bCUg+NSksoeNHsoBoHq4l0NK5P+ySSdsaaTvrVNvUYat9qchbtK31mGiMarf2o4NUPRiM9DqJNFykUUPsU/Oc0sZM+K32W6mELJ3t5jcLQBFQaQ6rxptkvCCgI1Dp/0pyc+EXfcwucg/nlR5QVoIA63IWdaNMFic6dO9sLL7zgJpDKTW7vR8eQP84VQPRQ3gRArBFkJhn1uGiylHCFz4NpQgOd3Iab9dS/vyA08YkWTUaiwFATjahkwYQJE9z9+e2F0EnlwoULXd3B4NIIOjmOpsL2jqg24Ndff+0CmeAahpq0KJif/pnb56PPUEFFTp+PJmDyT8SD94dmxg2eDVGT1Fx00UU5vo4meFJ7VJsx+P0H13yMBgXcot4zHRt57feieP8KGIPLZOSWuqu0OD0++2y4RXEsqfdbk+Po7yRcAKpl1qxZudYR9XvH85pcyJ906vbbb3fp7ytXrnQTL+nY9dPdi5LSZSPJPMjt/egYyl5nE0DhUd4EQKyRLptkdAKuE1LNVPrxxx/n2Oukk2/NIBpc+F3jCDVrq2Y7zW/tP6XoKsUtmAIKtUfjWnzq3cupjEE4fu9Z9t6ySMav5YdfjzM/bcurnfr9wQcfDNlOJ86azVYpiwowgvmP1XOdf/75rkc4uHdLMwJrhleNo9WFhGD63BSs+DS7qj6P4KLikbRZswUHHxPRoFl8laYZ7ngMdzwUxfvX8ayg0V/Uppyo51z7wO/xC6a2Zj/Ow70nf9u8qMSPgsjsi/83qt/9mXSVRpydejv1t6Devdzek2j/qOdaZY10XGpGWe3TaM/UGi6dWJ+jLhYFjxNXT2X2MZpqo2bZ1fESfNFAFKCqh13jnAFEH+VNAMQSPZlJSOU/lK6qlEBNiKJxbOrV0YQmmjRFpR5uuukmV2ZBJ+FKa9U4QvXCqadAk5AoOMwPlSHQ2DCVIFE6oU7EVeJBAYNqZ/p0IrxgwQI3sYdOdpWql70cRTAFEwrKVC5DJ6Aq3K73pnZGk9Jw1VbVQtTJrGojKr1PqYqR9tapB0xT3ytFVu3Wfgw3XlGlUhQoqaSHPh/tA52EayykepdEPb/qBdV2mqBFk9gopVIBu/ZFdiqbofIQCpDUA6jJVvRYTRCTE9UPVS+mytVcfPHFbp+q11kBmXryokXjPRU06nNXL1qwnI6HWLz/nCh1WBPSaP/4pW50AUY9fur91WeVW8qmH+ypVIiCSE1IpIm4/OAzmF+7Mhzti+AeTI1x9if10vhY/U37Fyv0txY8MVc42qc6vhTsVahQwY3FVXaAsg5U4ie3Xm/Ra2istj+xlyZA8jMUNKbUz37QxSV9FvqbUo+xeplVGscPIH3ax3q8XlvvVUGnLiKol1/fYSpXFEzHiS6IaJIgALFDeRMARSLiOWuRUFQeQ6VMjjnmGFeu47jjjnMlEYJLVqg8hEonVK5c2StdurR3+umne3PmzAl5Hr+ESfbSJH5ZC5WQkH//+9+u7EXjxo3dc1WtWtU799xzvQULFoQ87quvvnIlKMqUKeMe75eOCFcSxPfdd995l156qWtnpUqVvN/+9reunEX2Mgo5lTDJXmIiXDkPeeqpp9x+UpmKvMqZ3HrrrW6b4JIea9as8bp27erKNVSvXt0bPHiw99lnn4XsJ9/q1asD70n7S+Uexo4dG7LNJ5984nXr1s09X9myZd3+/OCDD0K28d/z4sWLvSFDhnhVqlRx2/ft29f78ccfc33PKply1113uX2kY+SUU05xn78+E63L/lmrNEd2kZSykJkzZ7pSLsHlP3I7Hori/UdawsQv56NyH02aNHFlDPR5qnzI3/72t5BSKTkdXyqDotIHKheS33ImOZUwefPNN73zzjvPq1WrlleyZEl37Kikx8KFC/N8vhUrVnglSpTwhg8fHrJeZWzatm3r1alTx5WvyY2OHb8kSfYl+G9Fx8Npp53mPgu9pp77iiuu8D7//POQ5/v4449dCRPtJ+1jfW4dO3b0Xn755bCvrzISuh9IBslWwiQ3lDcBUBTffRn6p2jCVyB5aSZdpRxq8pTg0hkIT2mR6iFVT+Mdd9wRtedVyqfGFy5fvjxsyR6kBs0IrN5OlZKgJxPJQENINNZZmTHZ0/uTjdJjL3n4vaPWzxne0aXVAkBBvvsYkwmEoaCmSZMmBJgRUiqyUmWV8hnNVFykB407VRouASYAAKmBIBMIorqCGn+msa0qaI/I9enTx427UwkaID80llMTlQGIX3mTYJQ3AVBYTPwDBBk0aJCbkEQlMVQPEwCAVEZ5EwBFgTGZAAAAaTomM5LZZwlAAeT3u4+eTAAAAByF8iYACooxmQAAADiKejCDA0zR7eCeTQAIhyATAAAAABA1BJkAAAAAgNQPMlVv79hjj7XSpUtbu3bt0mJ6+4kTJ1rbtm2tQoUKVqNGDevZs6etXbs2ZJv9+/fb0KFDrVq1aq5URO/evW379u2WDiUOMjIybMSIEWm9LzZv3mxXX321e89lypRxtQU//vjjwP2ax+vWW2+12rVru/u7du1q33zzjaWaw4cP29ixY61Ro0bufTZu3NjuuOMO9/7TYV8sWbLEunfvbnXq1HF/F7Nnzw65P5L3rnIzffv2dQP3K1eu7GZWTtYap7ntj0OHDrmZovW3Uq5cObdNv379bMuWLSm7P4BoobwJgJQKMl966SUbNWqUjRs3zj755BM7+eSTrVu3brZjxw5LZYsXL3ZB07Jly+ytt95yJ0fnn3++7d27N7DNyJEj7fXXX7cZM2a47XWi1KtXL0tly5cvtyeeeMJatWoVsj7d9sVPP/1kHTp0sJIlS9rcuXNtzZo19ve//92qVKkS2Obee++1hx56yB5//HH78MMP3Um1/nYUkKeSe+65xyZPnmyPPPKIffnll+623vvDDz+cFvtC3wn6XtTFuHAiee8KqL744gv3XTNnzhwXqA0ZMsRSbX/s27fP/T+iixL6OXPmTHfx7je/+U3Idqm0P4BolzeZM7xjYGHSHwAR8RLQ6aef7g0dOjRw+/Dhw16dOnW8iRMneulkx44d6pbxFi9e7G7v3LnTK1mypDdjxozANl9++aXbZunSpV4q2r17t9e0aVPvrbfe8s455xzvhhtuSNt9MXr0aK9jx4453n/kyBGvVq1a3n333RdYp/2UmZnpvfjii14qufjii71rr702ZF2vXr28vn37pt2+0DE/a9aswO1I3vuaNWvc45YvXx7YZu7cuV5GRoa3efNmL5X2RzgfffSR2+7bb79N+f2BopGVleWOGf0EgHSRlY/vvoTryTx48KCtWLHCpXf5ihUr5m4vXbrU0olq0EjVqlXdT+0X9W4G75vmzZtbgwYNUnbfqGf34osvDnnP6bovXnvtNTvttNPst7/9rUunPuWUU+ypp54K3L9hwwbbtm1byD5RLSOlm6faPjnzzDNt4cKF9vXXX7vbn332mb333nt24YUXpt2+yC6S966fSgnV8eTT9vquVc9nOny3Kq1W+0DSfX8AhSlxsnpzVmDRbQBIyDqZP/zwgxtvVbNmzZD1uv3VV19Zujhy5Igbf6j0yJYtW7p1OnEsVapU4MQoeN/ovlQzffp0l96mdNns0m1fyL///W+XIqpU8ptvvtntlz/+8Y9uP/Tv3z/wvsP97aTaPrnppptcQWBdWChevLj7zrjzzjtdyqOk077ILpL3rp+6UBGsRIkS7oJWqu8fpQxrjOaVV14ZKCSdzvsDKChqaAJIqiAT/+vBW716teudSUebNm2yG264wY2P0uRP+PXCg3pa7rrrLndbPZk6RjTuTkFmOnn55ZfthRdesGnTptmJJ55oK1eudBdlNKlLuu0LRE7ZD5dffrmbGEkXbAAUTQ1NgkwACZcuW716ddczkX2WUN2uVauWpYNhw4a5iSfeeecdq1evXmC93r/SiXfu3Jny+0bpsJro6dRTT3U9Clo0uY8mM9Hv6pVJl33h00yhJ5xwQsi6Fi1a2MaNG93v/vtOh7+dv/zlL64384orrnCzhl5zzTVuIijN0Jxu+yK7SN67fmafSO2XX35xM6ym6v7xA8xvv/3WXbzyezHTdX8AAJBWQaZS/9q0aePGWwX34Oh2+/btLZXp6roCzFmzZtnbb7/tyjME037RzKLB+0azJCrISLV906VLF1u1apXrofIX9eIpHdL/PV32hU+p09lL2mhMYsOGDd3vOl50Qhy8T5RSqjFlqbZPNGOoxssF08UpfVek277ILpL3rp+6QKOLOT5952j/aexmqgaYKuOyYMECVwIoWLrtDwAA0jJdVmPOlPKmQOL000+3SZMmuSnqBw4caKmeIqv0v1dffdXVyvTHAmnSDtW600/VbtP+0VghXYkfPny4O0E644wzLJXo/ftjUX0qw6CTQ399uuwLn3rqNOGN0mV1wqzasU8++aRbxK8jOmHCBGvatKkLNlS2QSmkqrmaSlQTUWMwNdGT0mU//fRTu//+++3aa69Ni32h+o3r1q0LmexHF1/0t6B9ktd7Vw/4BRdcYIMHD3bp1grCdIFLPcPaLpX2hzIALrvsMje+WxkiGr/rf7fqfl3YTLX9AcSyhmb2MZnU0ATgeAnq4Ycf9ho0aOCVKlXKlTRZtmyZl+r0cYRbpkyZEtjm559/9v7whz94VapU8cqWLetdeuml3tatW710EFzCJF33xeuvv+61bNnSlaNo3ry59+STT4bcr/IVY8eO9WrWrOm26dKli7d27Vov1ezatcsdC/qOKF26tHfcccd5f/3rX70DBw6kxb545513wn5X9O/fP+L3/uOPP3pXXnmlV758ea9ixYrewIEDXcmgVNsfGzZsyPG7VY9Lxf2R7lT265JLLvFq164dtqSN//ehUj/6/tDfx9dff52v16CEya+++2mft+q7nYFFtwGkrvx892XoH+JtAACQCubOnWvvv/++G2LSq1cvNwQlOIPhnnvuceO3n3322UBPv4ZnrFmzJuKJ5pSCruwilcMJHt+L0NlnNQmQTz2cTAgEJLf8fPclZLosAABAQaherl8zNztdV9cQnFtuucV69Ojh1j333HNuMrnZs2e7FGkUHuVNACTcxD8AAABFQeN1NSa3a9eugXW6Kq8JnpYuXZrj4w4cOOCu4AcvKFh5EwDpgSATAACkBX/SJ/VcBtNt/75wlF6rYNRf6tevX+RtBYBkRpAJAACQizFjxrgxSP6yadOmeDcJABIaQSYAAEgLqiEr27dvD1mv2/594WRmZrpJLoIX5F3eJBjlTYD0wsQ/AAAgLWg2WQWTCxcutNatW7t1Gl/54Ycf2vXXXx/v5qUMTe6jSX6YXRZIXwnbk6lB9rfddpv7CfZHduyP/2FfhGJ/hGJ/hGJ/pL49e/bYypUr3eJP9qPfN27caBkZGTZixAibMGGCvfbaa650Sb9+/axOnTohZU5QeAooW9atFFiCA0zNPrt6c1Zg0W0AqSVh62RSgyoU+yMU++N/2Beh2B+h2B+h2B+pb9GiRXbuuecetb5///42depUV8Zk3Lhx9uSTT9rOnTutY8eO9thjj9nxxx8f8WtwHBUc5U2A5EWdTAAAkJY6derkAsmcqDfz9ttvdwsSq7wJQSaQOoosXfbRRx+1Y4891kqXLu3qT3300UdF9VIAAAAAgARRJD2ZL730ko0aNcoef/xxF2BOmjTJunXrZmvXrrUaNWrk+tgjR47Yli1bAlchKXhsIfuB/fEr9sf/sC9CsT9CsT9Sb3/o/8fdu3e7cYTFiiXs1AoAgDRWJGMyFVi2bdvWHnnkkUDgqMLFw4cPt5tuuilkW02+EDwBw+bNm+2EE06IdpMAAEgpqtVYr169eDcjLTEms+AYkwkkr7iOyTx48KCtWLHCFS726Upr165dbenSpUdtP3HiRBs/fvxR6+teP9WKZZYN+xov//4MO6FOpSi3HACA5PhPXhduK1SoEO+mAPlGeRMgPUQ9yPzhhx/s8OHDVrNmzZD1uv3VV18dtb2CUaXWZv/PUwFmTkHmtp+LWfndv3bA8sUEAEhHmsAGSEY6b8vp3E09nQSgQPKL++yymZmZbsmPES+t/N/jSbEAAABIeqTSAqkj6jMGVK9e3YoXL27bt28PWa/btWrVivh5lBI7qU/rPLfzp70GAABAapY3AZDmQWapUqWsTZs2tnDhwsA6Tfyj2+3bt4/4eTTmskmN8hFtu27HHlu9OctdAQMAAAAApFi6rMZY9u/f30477TQ7/fTTXQmTvXv32sCBA4vi5QLps6RUAAAAAEAKBpl9+vSx77//3m699Vbbtm2btW7d2ubNm3fUZEB50WBvBY7ZUydy4qdUEGQCAAAkl3Dnfbqt9QCSS5HUyYxm/ZXgWcaUFhs86U84Gsfpp9kyIxkAINVQozH++AyKDrPLAokrrnUyYznNdTjMPAsAAJCcKG8CpIaEDzKDkT4LAACQfihvAiSXpAoy9SWiLxMFjpGkzgIAACC1y5sQZAKJJ6mCzIKkzyoYFVIqAAAAAKDoJV2Qmd/UWcqbAAAAAEDsJG2QGZw6K3mlz5JSAQAAkJwobwKkeZB522232fjx40PWNWvWzL766qtovxSpswAAAGkge+eCcD4HpFlP5oknnmgLFiz434uUSIwOU1JnAQAAklNenQuUOAESR5FEfwoqa9WqFdG2Bw4ccEtwkc+iLm9C6iwAAEDqoMQJkFiKFcWTfvPNN1anTh077rjjrG/fvrZx48Yct504caJVqlQpsNSvX79QaRRzhne0SX1aF6L1AAAASJUSJwBSIMhs166dTZ061ebNm2eTJ0+2DRs22FlnnWW7d+8Ou/2YMWMsKysrsGzatKnAr61As2XdStakRvmIxmeu3pzlFl39AgAAAAAkYLrshRdeGPi9VatWLuhs2LChvfzyyzZo0KCjts/MzHRLNEWSOhs8Ey3pFAAAAAAQHUU+I0/lypXt+OOPt3Xr1lk8ZiDLq7SJMEYTAAAgeVHiBEizIHPPnj22fv16u+aaayyWKG8CAACQHihxAqT4mMw///nPtnjxYvvPf/5jH3zwgV166aVWvHhxu/LKKy2RqbfzkoffczOTMUYTAIDktGTJEuvevbubgDAjI8Nmz54dcv+AAQPc+uDlggsuiFt7ET3+3Bz+Ehxg6tzOn4uD+TiAJOzJ/O6771xA+eOPP9oxxxxjHTt2tGXLlrnf4yE/pU2E1FkAAJLX3r177eSTT7Zrr73WevXqFXYbBZVTpkwJ3I723BBILJQ3AVIgyJw+fbolcvpEJGM0/dRZIdUCAIDkoQkIgychDEdBZaT1vKNZ0xuJV96EczwgScdkJoL8js9k5lkAAFLXokWLrEaNGlalShXr3LmzTZgwwapVq5ZrTe/x48fHtI0AkMyiPiYz0fnps5GikC8AAKlDqbLPPfecLVy40O655x43j4R6Pg8fPpzjY6JZ0xsA0kFa9GQWprwJAABIHVdccUXg95NOOsnV9G7cuLHr3ezSpUvYxxRFTW/EDuVNgNhLuyBTKG8CAADkuOOOs+rVq7t63jkFmUhulDcBYi8tg8z8zjzr93YyPhMAgNSiWfE1I37t2rXj3RTEqYNBs88SgALRldZBZn5nnmUmMgAAEtuePXtcr6Rvw4YNtnLlSqtatapbNIFP79693eyy69evtxtvvNGaNGli3bp1i2u7ER+UNwESZOKfvIoce55nt956q7siWKZMGevatat98803lgyFe5vUKJ/n9gpEKeILAEBi+vjjj+2UU05xi4waNcr9rnOT4sWL2+eff26/+c1v7Pjjj7dBgwZZmzZt7N1332XMZZrKrbwJgBj2ZOZV5Pjee++1hx56yJ599llr1KiRjR071l0dXLNmjZUuXdqSHamzAAAkrk6dOrkL3jmZP39+TNsDAOmoRDSLHOtLfdKkSXbLLbdYjx493DpNE16zZk3X4xk8o1siFjiOdIymkDoLAAAAAEVcJ1PjHrZt2+ZSZH2VKlWydu3a2dKlS3MscKxt/KV+/foW7zGac4Z3tEl9WsetHQAAAIhP/XTKmwAJNvGPAkxRz2Uw3fbvC1fgWOMlgnsy4x1oRto76Zc2EWYiAwAASC6UNwFSdHbZRC1wHEnqbPBMtIzRBAAASD6UNwESPMjUdOCyffv2kHpTut26deukvbKVV2kTYYwmAABA6qC8CZAgYzI1m6wCzYULF4akv3744YfWvn17SzZ+eZNISpsI5U0AAABSA+VNgBj2ZOZW5LhBgwY2YsQImzBhgjVt2jRQwkQ1NXv27GmpjvImAAAAANJdiYIUOT733HMDt/1Je/r3729Tp061G2+80dXSHDJkiO3cudM6duxo8+bNS+oamfkpbSKkzgIAAABIVyWiXeQ4IyPDbr/9drek6sxjkYzR9GeeZYA4AABAanQyUN4ESJLZZZNFfkqbCKmzAAAAyYvyJkDBEWQWcfosqbMAAADJifImQMEQZMagvAkAAABSB+VNgNwRZMYgfdYfnylc5QIAAEjd8iac5wEEmTFJnQ3u6eQqFwAAAIBURpAZ49RZrnIBAAAASGXF8vuAJUuWWPfu3a1OnTquXMns2bND7h8wYIBbH7xccMEFlsoUMLasW8ma1Cgf0fYKRldvznL5/AAAAEjOTLZglDcBCtGTuXfvXjv55JPt2muvtV69eoXdRkHllClTArczMzPz+zIpjfImAAAAyYvyJkCUg8wLL7zQLblRUFmrVq2Inu/AgQNu8e3atcvSobSJkDoLAACQHjXUgXRSJGMyFy1aZDVq1LAqVapY586dbcKECVatWrWw206cONHGjx9vqXhVK5Ixmsw8CwAAkFqooYl0F/UgU6mySqNt1KiRrV+/3m6++WbX87l06VIrXrz4UduPGTPGRo0aFdKTWb9+fUuXq1rMPAsAAJA6qKEJFEGQecUVVwR+P+mkk6xVq1bWuHFj17vZpUuXsKm1qTpmk/RZAACA9EINTaAAs8vm13HHHWfVq1e3devWWbrx02fnDO9ok/q0jndzAAAAACD562R+99139uOPP1rt2rUtHeU3fdYfo0nuPgAAAIC0CDL37NkT0iu5YcMGW7lypVWtWtUtmsSnd+/ebnZZjcm88cYbrUmTJtatWzdLZ5GmzlLeBAAAILXO+aihiXST7yDz448/tnPPPTdw25+0p3///jZ58mT7/PPP7dlnn7WdO3danTp17Pzzz7c77rgjZcddFtXMs+TuAwCQP5qxfubMmfbVV19ZmTJl7Mwzz7R77rnHmjVrFthm//799qc//cmmT5/uSqjpIvhjjz1mNWvWjGvbkTqooQkUIMjs1KmTeZ6X4/3z588vbJtSFqmzAAAUncWLF9vQoUOtbdu29ssvv7gZ7nWxe82aNVauXDm3zciRI+2NN96wGTNmWKVKlWzYsGFuVvz3338/3s1HmpzzUd4E6aDIx2Si4EidBQAgcvPmzQu5PXXqVFe3e8WKFXb22WdbVlaWPfPMMzZt2jRXx1umTJliLVq0sGXLltkZZ5wRp5YjXVDeBOmiyGeXRe75+pHwU2cBAEDkFFSK5owQBZuHDh2yrl27BrZp3ry5NWjQwNXzzonSalXHO3gBol3eBEglBJlxQnkTAACKzpEjR2zEiBHWoUMHa9mypVu3bds2K1WqlFWuXDlkW43H1H25jfVUaq2/1K9fv8jbDwDJjHTZJBmj6Y/PFHL3AQDIncZmrl692t57771CP9eYMWMCEx2KejIJNAEgZwSZSVLeJHgmWnL3AQDImSbzmTNnji1ZssTq1asXWK/yagcPHnQz4Af3Zm7fvt3dlxPNkJ/us+QjOihvgnRBkJlgU13nVdpEKG8CAMDRNPv98OHDbdasWbZo0SJr1KhRyP1t2rSxkiVL2sKFC11Nb1m7dq1t3LjR2rdvH6dWI51Q3gTpIl9jMjUmQdOCV6hQwc3W1rNnT/flHEz1p5SiUq1aNStfvrz7EtcVQuROXy4t61ayJjXKR7S9gtHVm7PcLGUAAODXFNl//vOfbvZYnatonKWWn3/+9f9KjaccNGiQS31955133ERAAwcOdAEmM8si1ud8/hIcYOq8Tud3/sJ5HtKiJ5P6U4mD8iYAAISaPHlyoKZ3MJUpGTBggPv9gQcesGLFirmL4Jo1tlu3bvbYY4/Fpb1AMMqbIG2DzKKoP6UveC2+dJ8WPJLxmcFInQUA4H/psnkpXbq0Pfroo24BkqW8Ced5SKsxmfmtPxUuyFQK7vjx4wvTjJTO1Y9kjCYzzwIAAABI+iAzWvWnmBa8cKVNhJlnAQAAACR9kBmt+lNMC5470mcBAABSH+VNYOkeZEa7/hSiV94EAAAAyYfyJkjbIJP6U8mRPuuP0eSLCQAAIDXO+TT7LAEoUjLIVIqsZo599dVXA/WnRKVKypQpE1J/SpMBVaxY0QWl1J+Kbeos5U0AAABSB+VNkNJBJvWnkmvmWcZnAgAAJD/KmyDl02XzQv2pokXqLAAAAICUrZOJxEfqLAAAAIBYKhbTV0ORjNGMhJ9SAQAAgOQ/56O8CRIZPZlJjPImAAAAqY/yJkg2BJlpNEbTH58pfDEBAAAkD8qbIJkQZKZReZPgnk7GaAIAACQ/ypsg6cdkTpw40dq2betqZNaoUcN69uxpa9euDdlG5U0yMjJCluuuuy7a7UYOaRRzhne0SX1a57k9YzQBAABSu7wJkBQ9mYsXL7ahQ4e6QPOXX36xm2++2c4//3xbs2aNlStXLrDd4MGD7fbbbw/cLlu2bHRbjbAobwIAAAAgqYLMefPmhdyeOnWq69FcsWKFnX322SFBZa1ataLXShQJypsAAAAASKgSJllZWe5n1apVQ9a/8MILVr16dWvZsqWNGTPG9u3bl+NzHDhwwHbt2hWyIHalTYSUCgAAgOREeROk1MQ/R44csREjRliHDh1cMOm76qqrrGHDhlanTh37/PPPbfTo0W7c5syZM3Mc5zl+/PiCNgMRTHMdSXkTZp4FAABIPpQ3QSLK8DzPK8gDr7/+eps7d6699957Vq9evRy3e/vtt61Lly62bt06a9y4cdieTC0+9WTWr1/f9ZJWrFixIE1DNqs3Z9klD78X8fakzwJA4tL/k5UqVeL/yTjiM0CyocQJYv3dV6CezGHDhtmcOXNsyZIluQaY0q5dO/czpyAzMzPTLYhveZNw6bN8+QAAACQ3SpwgHvIVZKrTc/jw4TZr1ixbtGiRNWrUKM/HrFz5a5pm7dq1C95KRC2NIpLUWQAAAKR+iROCTCREkKnyJdOmTbNXX33V1crctm2bW69u0zJlytj69evd/RdddJFVq1bNjckcOXKkm3m2VatWRfUeEAHKmwAAAABIuCBz8uTJ7menTp1C1k+ZMsUGDBhgpUqVsgULFtikSZNs7969bmxl79697ZZbboluq1HkqbOUNwEAAAAQk3TZ3CioXLx4cYEagtjI78yzpFMAAACkVgcDJU6QsCVMkLxInQUAAEgPlDhBPIRWbgXCUE+nSqBoZjLNUAYAQCJS7e22bdu6eSNq1KhhPXv2dLW6g2nIT0ZGRshy3XXXxa3NQCwooGxZt1JgCQ4wdW6ncnf+wrkeooGezDSXn/ImpM4CABKZhuxokkIFmr/88ovdfPPNdv7559uaNWusXLlyge0GDx5st99+e+B22bJl49RiIL4ob4KiQpCZ5ihvAgBIFfPmzQu5PXXqVNejuWLFCjfTfXBQWatWrYif98CBA24JLkgOpALKm6CokC6LQApFkxrl89xWgSjpFACAZJCVleV+Vq1aNWT9Cy+8YNWrV7eWLVvamDFjbN++fXmm4apcm79ookMAQM7oyUS+UmeDezpJpwAAJKojR47YiBEjrEOHDi6Y9F111VXWsGFDq1OnjqvnPXr0aDduc+bMmTk+lwLRUaNGhfRkEmgCQJR6MlUns1WrVlaxYkW3tG/f3ubOnRu4f//+/W4sRLVq1ax8+fKuRub27dvz8xJIgNTZOcM72qQ+rfPc3k+nAAAg0eh8ZPXq1TZ9+vSQ9UOGDLFu3brZSSedZH379rXnnnvOZs2aZevXr8/xuTIzMwPnPv4CpFIHQzDKmyDmPZn16tWzu+++25o2bepqZj777LPWo0cP+/TTT+3EE0+0kSNH2htvvGEzZsxw6STDhg2zXr162fvvvx+VxqLoUd4EAJDsdP4xZ84cW7JkiTt3yU27du3cz3Xr1lnjxo1j1EIgMVDeBAkRZHbv3j3k9p133ul6N5ctW+a+xJ955hmbNm2ade7c2d0/ZcoUa9Gihbv/jDPOiG7LkRD89FlSZwEA8aYL4MOHD3c9k4sWLbJGjRrl+ZiVK3/9f6x27doxaCGQXB0Mmn+DABQxHZN5+PBh12O5d+9elzarmdsOHTpkXbt2DWzTvHlza9CggS1dujTHIJMZ25K/tIkwExkAIBFSZHWx+9VXX3W1Mrdt2+bWK7uqTJkyLiVW91900UVuaI/GZCoLSzPPajgQgP+hvAliGmSuWrXKBZUaf6lxl7paeMIJJ7grgaVKlbLKlSuHbF+zZs3Al3xOM7aNHz++YK1HzNInIilvQuosACCelF0lnTp1ClmvzKoBAwa485QFCxbYpEmT3EVyTd6j+SNuueWWOLUYSFyUN0FMg8xmzZq5gFLTgr/yyivWv39/V/y4oJixLXXGZ5I6CwCId7psbnR+UZhzFgBAEQWZugrYpEkT93ubNm1s+fLl9uCDD1qfPn3s4MGDtnPnzpDeTM0um1vBY83YpgWpkz7LVS4AAAAgfeWrhElOdag0plIBZ8mSJW3hwoWB+1R3auPGjS69FulV3gQAAADJi/ImiFlPplJbL7zwQjeZz+7du93gec3eNn/+fDeoftCgQS71tWrVqq6GlGZ4U4DJzLLplz7rj88UxmgCAAAkF8qbIGZB5o4dO6xfv362detWF1RqJjYFmOedd567/4EHHrBixYq5QfTq3VSx48cee6xQDURyps4GTxLEGE0AAIDkQ3kTFFSGl9co+RjTxD8KYDWxkHpDkZj8L5ZIZp0Vpdm2rFspJm0DgFTG/5Pxx2eAdEd5k/S0Kx/ffQWuk4n0lt+ZZylvAgAAkBoob4K8EGQiJihvAgAAAKSHQs8ui/QWbuax3PhXuQAAAACkJnoyEdWZxyIZo8nMswAAAKk1CSTlTRCMIBMxH5/JzLMAAADJi/ImyAtBJmJe3iQYg8QBAACSD+VNELUxmZMnT3a1MTVlrZb27dvb3LlzA/d36tTJMjIyQpbrrrsuPy+BFLmypZIlk/q0jndzAAAAEIfyJpc8/F5g0W2tR/rIV09mvXr17O6777amTZuayms+++yz1qNHD/v000/txBNPdNsMHjzYbr/99sBjypYtG/1WI6FR3gQAACA9Ud4E+Q4yu3fvHnL7zjvvdL2by5YtCwSZCipr1arF3kXEqbOUNwEAAABSR4HHZB4+fNhmzJhhe/fudWmzvhdeeMH++c9/ukBTQenYsWNz7c08cOCAW3y7du0qaJOQ5DPPcpULAAAASMMgc9WqVS6o3L9/v5UvX95mzZplJ5xwgrvvqquusoYNG1qdOnXs888/t9GjR9vatWtt5syZOT7fxIkTbfz48YV7F0hYpM4CAACkD8qbQDI8Da7Mh4MHD9rGjRstKyvLXnnlFXv66adt8eLFgUAz2Ntvv21dunSxdevWWePGjSPuyaxfv757fk0uhNSxenOWG/wdCVJnASA8/T9ZqVIl/p+MIz4DIHfMLpua8vPdl++ezFKlSlmTJk3c723atLHly5fbgw8+aE888cRR27Zr1879zC3IzMzMdAtSX37Km5A6CwAAkB6ZbEg9ha6TeeTIkZCeyGArV/46/q527dqFfRmk2BjNvMZnAgAAIPXQy5ke8hVkjhkzxi688EJr0KCB7d6926ZNm2aLFi2y+fPn2/r1693tiy66yKpVq+bGZI4cOdLOPvtsV1sTyO+VLX98pvAFBAAAkBo1NLOP12SIVJoHmTt27LB+/frZ1q1bXT6ugkcFmOedd55t2rTJFixYYJMmTXIzzmpcZe/eve2WW24putYjpVNng3s6+QICAABIbtTQTB/5CjKfeeaZHO9TUKkJgICiSJ3lCwgAAABIkzGZQEFR3gQAAABIPQSZSBp+byepswAAAMmHGprpo1i8GwD4XziR8lNnAQAINnnyZDdfhOq3aWnfvr3NnTs3cP/+/ftt6NChboLC8uXLu7kjtm/fHtc2A+k4XGrO8I6BhY6D1ERPJhJqfKZEMkaTmWcBANnVq1fP7r77bmvatKl5nmfPPvus9ejRwz799FM78cQT3az3b7zxhs2YMcNNYDhs2DDr1auXvf/++/FuOpA2chsuRXmT1JHh6Vs4gezatct98WdlZbmrkEg/qzdn2SUPvxfx9qTPAkgn/D+ZP1WrVrX77rvPLrvsMjvmmGNcuTX9Ll999ZW1aNHCli5dameccUbEz8lnAEQf5U0SX36++0iXRcIhfRYAUFiHDx+26dOnu7JqSptdsWKFHTp0yLp27RrYpnnz5q72t4LM3Bw4cMCdXAUvAGJX3gTJp1BBplJSMjIybMSIEYF1jHdANPP1J/VpHe/mAACSyKpVq9z5R2Zmpl133XU2a9YsO+GEE2zbtm1WqlQpq1y5csj2NWvWdPflZuLEie7qvb+obBsAoAiCzOXLl9sTTzzhBtgH03iH119/3Y13UN3MLVu2uPEOQH4DzZZ1K1mTGuUj2l5jNJVmq1QLAED6atasma1cudI+/PBDu/76661///62Zs2aQj3nmDFjXHqYv2zatClq7QWAVFSgiX/27Nljffv2taeeesomTJgQWK8v3meeecaNd+jcubNbN2XKFDfeYdmyZfka7wDkNNV1OJQ3AQCIeiubNGnifm/Tpo27KP7ggw9anz597ODBg7Zz586Q3kxlW9WqVSvX51SvqBYARYfyJqmlQEGm0mEvvvhiN64hOMjMa7xDuCBT4xy0+BjngMLMPOvn7hNkAgDkyJEj7jxDAWfJkiVt4cKFbiiPrF271jZu3OjGbAJIrHM+YXbZNAoyNYj+k08+cVcGsyvIeAeNcxg/fnx+m4E0kttU17mVN+GLCQDSi9JaL7zwQndxe/fu3S6zatGiRTZ//nw3lnLQoEE2atQoN+OsZkYcPny4CzDJtAISA+VN0jTI1BiEG264wd566y0rXbp01P5D0Bd+cE8mA+pRGKTOAkB62rFjh/Xr18+2bt3qgkrNG6EA87zzznP3P/DAA1asWDHXk6nezW7dutljjz0W72YDyAPlTVI8yFQ6rL7ATz311JApwpcsWWKPPPKI+yLP73gHxjmgKMZoCqmzAJBeNC9EbnSB/NFHH3ULgNQob8J5XgoEmV26dHFTgwcbOHCgG3c5evRo1wPJeAfEKl8/r/GZAAAAABI8yKxQoYK1bNkyZF25cuVcTUx/PeMdkEhjNP3xmULuPgAAAJCgs8vmhvEOSKTU2eCeTnL3AQAAkg/lTZJPhud5niUQTfyjwfqquameUCA3/kxjkabOzhne0VrWrRSTtgFAUeD/yfjjMwBij9llk+u7L+o9mUAsUd4EAAAg9VHeJLkQZCKtUN4EAAAgdVDeJDEVi3cDgGjm6kfKn/YaAAAAqVneBPFDTyZSrrSJRDJGk9RZAAAAIPoIMpG24zNJnQUAAACij3RZWLqnz5JSAQAAkDrnfJQ3iT96MpHy6bORljcBAABAcg+ZEoZCxV/CBZl+2U7VYQEKo0IxswoVMmzP7iN25MC+XLfds3uX7dqVEbO2AUBB+f8/JliZawCIG8qbJJ6ECzJ3797tftavXz/eTUEaaT8p3i0AgPz/f6mi2ACA8ChvEj8JF2TWqVPHNm3a5K7QNmjQwP1esWJFS3e6cq3Am/3xK/bH/7AvQrE/QrE/Um9/6P9HBZj6/xIAULDyJgSZaRZkFitWzOrVqxdIB9JJQLKeCBQF9kco9sf/sC9CsT9CsT9Sa3/QgwkASGTMLgsAAAAAiBqCTAAAAAAph/Im8ZNw6bK+zMxMGzdunPsJ9kd27I//YV+EYn+EYn+EYn8AQPqgvEn8ZHjMgQ4AABAxzRuhcbFZWVlJPbYXACVOiuq7L2F7MgEAAACgqFDipOgwJhMAAABA2smtxAkKhyATAAAAABA1BJkAAAAAgKghyATS3IABA6xnz57xbgYAAEBMUeKk6DDxDwAAAIC0Q4mTokNPJgAASAmTJ0+2Vq1auan1tbRv397mzp0buL9Tp06WkZERslx33XVxbTOA+FJA2bJupcASHGBq9tnVm7MCi24jMgSZQAo4cuSI3XvvvdakSRNXZL5BgwZ25513uvtWrVplnTt3tjJlyli1atVsyJAhtmfPnhyf69hjj7VJkyaFrGvdurXddtttgds6MXviiSfskksusbJly1qLFi1s6dKltm7dOncSV65cOTvzzDNt/fr1gcfo8Xqe559/3r2G6ixdccUVtnv37iLZJwDST7169ezuu++2FStW2Mcff+y++3r06GFffPFFYJvBgwfb1q1bA4u+OwEgp/Imlzz8XmDRbQLNyBBkAilgzJgx7sRq7NixtmbNGps2bZrVrFnT9u7da926dbMqVarY8uXLbcaMGbZgwQIbNmxYoV/zjjvusH79+tnKlSutefPmdtVVV9nvf/971xad3Hmed9TrKOicPXu2zZkzxy2LFy927QaAaOjevbtddNFF1rRpUzv++OPdxbby5cvbsmXLAtvowlitWrUCS14FxeXAgQOuCHnwAiC1Ud6kcAgygSSnnsAHH3zQXY3v37+/NW7c2Dp27Gi/+93vXLC5f/9+e+6556xly5buqv4jjzziehO3b99eqNcdOHCgXX755e5EbvTo0faf//zH+vbt64Ja9WzecMMNtmjRoqN6XKdOneractZZZ9k111xjCxcuLOQeAICjHT582KZPn+4utilt1vfCCy9Y9erV3feQLort27cvz+eaOHGiy77wl/r16xdx6wEguTHxD5DkvvzyS3eVvUuXLmHvO/nkk136qq9Dhw4u2Fu7dq3r7SwojXvy+c9z0kknhaxTgKsr/n5PgdJkK1SoENimdu3atmPHjgK3AQCy0xABBZX6/lEv5qxZs+yEE05w9ynjomHDhlanTh37/PPP3QUyfRfOnDkz1+dUMDpq1KjAbX2vEWgCQM4IMoEkp7GW0VSsWDGX6hrs0KFDR21XsmTJkDGaOa1TQBvuMf42wfcDQGE1a9bMpfFnZWXZK6+84jI8lJqvQFNj0n26KKYLXbpAp1R+ZYHkRGPdtQBIv/ImwSmzlDeJHEEmkOQ09kiBptJOlSIbTGmrSk9Vupjfm/n++++7QFInYuEcc8wxbjKM4Cv2GzZsKOJ3AQDRUapUKTcJmrRp08aNR9eQAk1Wll27du3cT01alluQCSD9UN6kcAgygSRXunRpl/J14403upMrpcN+//33bjZFjZEcN26cu5Kv2V21fvjw4W4sZE6pshq3qcBUE2hUrlzZbr31VitevHjM3xcARIOyJTSkIBz1eIp6NAEgOwWUOQWVmmWWADRnBJlACtCssiVKlHAB4ZYtW9wJk2q/aRbF+fPnu0l42rZt62737t3b7r///lzHHqnnUuVJNMGFZpGlJxNAMtD314UXXujKOGlSNE1+pgnI9D2olFjd1uyzKuekMZkjR460s88+O2SMOQBEWt4keyqtej4JNH+V4WUffAUAAJCEBg0a5IYOKOVfF8kUPCrT47zzzrNNmzbZ1VdfbatXr3ZDCDRxz6WXXmq33HJLRGVMgmkYgZ5f4z7z+1gAyW/15ixXNzO7OcM7Wsu6lSxV5ee7j55MAACQEp555pkc71NQqQmAAABFjzqZAAAAAICoIcgEAAAAgHyWNwlGeZNQpMsCAAAAQIQob5I3gkwAAAAAyAfKm+SOIBMAAAAAooDyJr9iTCYAAAAARIF6MA8EBZii28E9m+mAIBMAAAAAEDUEmQAAAACAqCHIBAAAAIAooLzJr5j4BwAAAACigPImvyLIBAAAAIAoqUt5E4JMAAAAAChqm9OovAljMgEAAACgiP2URuVNCDIBAAAAAFFDkAkAAAAAiBqCTAAAAAAoYlXSqLwJE/8AAAAAQBGrm0blTQgyAQAAACDO5U1SCUEmAAAAAMTZ5hSqoUmQCQAAAABxtDnFamgy8Q8AAAAAxNFPKVZDkyATAAAAABA1BJkAAAAAgKghyAQAAACAOKqSYjU0CTIBAEBKuvvuuy0jI8NGjBgRWLd//34bOnSoVatWzcqXL2+9e/e27du3x7WdAFD3/9fQnDO8Y2BJ1kl/hNllAQBAylm+fLk98cQT1qpVq5D1I0eOtDfeeMNmzJhhlSpVsmHDhlmvXr3s/fffj1tbASCvGprJVt6EIBMAAKSUPXv2WN++fe2pp56yCRMmBNZnZWXZM888Y9OmTbPOnTu7dVOmTLEWLVrYsmXL7IwzzohjqwEgdcqbkC4LAABSitJhL774YuvatWvI+hUrVtihQ4dC1jdv3twaNGhgS5cuzfH5Dhw4YLt27QpZACBWfkrC8ib0ZAIAgJQxffp0++STT1y6bHbbtm2zUqVKWeXKlUPW16xZ092Xk4kTJ9r48eOLpL0AkIroyQQAAClh06ZNdsMNN9gLL7xgpUuXjtrzjhkzxqXa+oteBwCQM4JMAACQEpQOu2PHDjv11FOtRIkSblm8eLE99NBD7nf1WB48eNB27twZ8jjNLlurVq0cnzczM9MqVqwYsgBArFRJwvImpMsCAICU0KVLF1u1alXIuoEDB7pxl6NHj7b69etbyZIlbeHCha50iaxdu9Y2btxo7du3j1OrASCy8ibMLgsAABBjFSpUsJYtW4asK1eunKuJ6a8fNGiQjRo1yqpWrep6JIcPH+4CTGaWBZDI6iZZeROCTAAAkDYeeOABK1asmOvJ1Kyx3bp1s8ceeyzezQKAlCpvQpAJAABS1qJFi0Jua0KgRx991C0AkMrlTerGMchk4h8AAAAAQNQQZAIAAAAAooYgEwAAAACSUJUELW/CmEwAAAAASEJ1E7S8CUEmAAAAACSpuglY3oQgEwAAAABSzOY4ljdhTCYAAAAApFF5k6JGkAkAAAAAiBqCTAAAAABA1BBkAgAAAECKqRLH8iZM/AMAAAAAKaZuHMubEGQCAAAAQAqqG6fyJgSZAAAAAJBGNhdxeRPGZAIAAABAGvmpiMubEGQCAAAAAKKGIBMAAAAAEDUEmQAAAACQRqoUcXkTJv4BAAAAgDRSt4jLmxBkAgAAAECaqZtLeZNwJU5KHN4f8XMTZAIAAAAAci1xkp8gkzGZAAAAAIBcS5wczHY7NwSZAAAAAICoIcgEAAAAAEQNQSYAAAAAINcSJ6Wy3c4NE/8AAADkg+d57ueuXbvi3RQAKBIVipm9OuRU27kveHbZA9b2b//7DswNQSYAAEA+7N692/2sX79+vJsCAHH5DqxUqVKu22R4kYSiAAAAcI4cOWJbtmyxChUquJMtBZubNm2yihUrxrtprnc1UdqTSG1JtPYkUlsSrT2J1JZEa8+uOLdFYaO+8+rUqWPFiuWeOktPJgAAQD7o5KpevXru94yMDPdTJ3zxPgENlkjtSaS2JFp7EqktidaeRGpLorWnYhzbklcPpo+JfwAAAAAAUUOQCQAAAACIGoJMAACAAsrMzLRx48a5n4kgkdqTSG1JtPYkUlsSrT2J1JZEa09mArUlL0z8AwAAAACIGnoyAQAAAABRQ5AJAAAAAIgagkwAAAAAQNQQZAIAAAAAooYgEwAAAEgQAwYMsJ49e8a7GUChEGQCAAAAAKKGIBMAAAAAEDUEmQAAAEAUHTlyxO69915r0qSJZWZmWoMGDezOO+90961atco6d+5sZcqUsWrVqtmQIUNsz549OT7Xsccea5MmTQpZ17p1a7vtttsCtzMyMuyJJ56wSy65xMqWLWstWrSwpUuX2rp166xTp05Wrlw5O/PMM239+vWBx+jxep7nn3/evUalSpXsiiuusN27dxfJPkF6IcgEAAAAomjMmDF2991329ixY23NmjU2bdo0q1mzpu3du9e6detmVapUseXLl9uMGTNswYIFNmzYsEK/5h133GH9+vWzlStXWvPmze2qq66y3//+964tH3/8sXmed9TrKOicPXu2zZkzxy2LFy927QYKq0ShnwEAAACAo57ABx980B555BHr37+/W9e4cWPr2LGjPfXUU7Z//3577rnnXO+iaLvu3bvbPffc4wLRgho4cKBdfvnl7vfRo0db+/btXZCroFZuuOEGt032HtepU6dahQoV3O1rrrnGFi5cGOh1BQqKnkwAAAAgSr788ks7cOCAdenSJex9J598ciDAlA4dOrhgb+3atYV63VatWgV+94PVk046KWSdAtxdu3YF1ilN1g8wpXbt2rZjx45CtQMQgkwAAAAgSjTWMpqKFSvmUl2DHTp06KjtSpYsGTJGM6d1CmjDPcbfJvh+oKAIMgEAAIAoadq0qQs0lXaanSbk+eyzz9zYTN/777/vAslmzZqFfb5jjjnGtm7dGritnsgNGzYUUeuB6CDIBAAAAKKkdOnSbkzkjTfe6MZeanKdZcuW2TPPPGN9+/Z192us5urVq+2dd96x4cOHu7GQOY3H1Ey0mgH23XffdTPT6rHFixeP+fsC8oOJfwAAAIAo0oQ7JUqUsFtvvdW2bNnixjped911rrzI/Pnz3SQ8bdu2dbd79+5t999/f47Ppdlh1XOp8iQqM6JZZOnJRKLL8LIneQMAAAAAUECkywIAAAAAooYgEwAAAAAQNQSZAAAAAICoIcgEAAAAAEQNQSYAAAAAIGoIMgEAAAAAUUOQCQAAAACIGoJMAAAAAEDUEGQCAAAAAKKGIBMAAAAAEDUEmQAAAACAqPl/N8y8plBcZhYAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x420 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(10, 4.2))\n",
+    "k = 45   # a corner, so the band is actually visible at this scale\n",
+    "axes[0].spy(np.asarray(jac_pat.todense())[:k, : 3 * k], markersize=3)\n",
+    "axes[0].set_title(f\"constraint Jacobian (top-left {k} x {3 * k})\")\n",
+    "axes[1].spy(np.asarray(hess_pat.todense())[:k, :k], markersize=3)\n",
+    "axes[1].set_title(f\"Lagrangian Hessian (top-left {k} x {k})\")\n",
+    "for ax in axes:\n",
+    "    ax.set_xlabel(\"column\")\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e271b94",
+   "metadata": {},
+   "source": [
+    "## 3. Coloring: how many AD passes\n",
+    "\n",
+    "A pattern alone still leaves you evaluating one AD pass per variable. Coloring\n",
+    "groups columns that share no row, so each group can be recovered in a single\n",
+    "pass and unpacked afterwards. `num_colors` is the number of AD passes the\n",
+    "matrix actually costs.\n",
+    "\n",
+    "The Hessian uses a symmetric (star) coloring and `fwd_over_rev`; the Jacobian\n",
+    "picks forward or reverse mode based on its shape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "10961336",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:20.092043Z",
+     "iopub.status.busy": "2026-08-10T21:03:20.091916Z",
+     "iopub.status.idle": "2026-08-10T21:03:20.256353Z",
+     "shell.execute_reply": "2026-08-10T21:03:20.255825Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Jacobian     4 colors  (mode=fwd)  vs 603 passes for a dense build  -> 151x fewer\n",
+      "Hessian      3 colors  (mode=fwd_over_rev)  vs 603 passes for a dense build  -> 201x fewer\n"
+     ]
+    }
+   ],
+   "source": [
+    "jac_col = asdex.jacobian_coloring(constraints, z0)\n",
+    "hess_col = asdex.hessian_coloring(lagrangian, z0, jnp.ones(m), 1.0)\n",
+    "\n",
+    "for name, c in ((\"Jacobian\", jac_col), (\"Hessian\", hess_col)):\n",
+    "    print(f\"{name:10s} {c.num_colors:3d} colors  (mode={c.mode})  \"\n",
+    "          f\"vs {n} passes for a dense build  \"\n",
+    "          f\"-> {n / c.num_colors:.0f}x fewer\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38f51184",
+   "metadata": {},
+   "source": [
+    "## 4. Handing the pattern to POUNCE\n",
+    "\n",
+    "`pounce.jax.from_jax` already speaks this language: `jac_pattern` and\n",
+    "`hess_pattern` take the same `(rows, cols)` form, and `sparse=True` switches\n",
+    "the per-evaluation cost to one JVP/HVP per color. Supplying asdex's pattern\n",
+    "short-circuits POUNCE's own detection entirely.\n",
+    "\n",
+    "`hess_pattern` wants the lower triangle, but upper-triangle entries are\n",
+    "folded onto their mirror, so asdex's full symmetric pattern can go straight\n",
+    "in.\n",
+    "\n",
+    "Three configurations, same problem — dense, POUNCE's built-in probe, and\n",
+    "asdex's pattern:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fd7973d3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:20.257737Z",
+     "iopub.status.busy": "2026-08-10T21:03:20.257647Z",
+     "iopub.status.idle": "2026-08-10T21:03:20.900849Z",
+     "shell.execute_reply": "2026-08-10T21:03:20.900414Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dense            build  0.09s  solve  0.181s  iters  37  f = 329.913793375\n",
+      "sparse + probe   build  0.08s  solve  0.106s  iters  37  f = 329.913793375\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sparse + asdex   build  0.01s  solve  0.102s  iters  37  f = 329.913793375\n",
+      "  dense            max|x - x_dense| = 0.00e+00\n",
+      "  sparse + probe   max|x - x_dense| = 1.59e-14\n",
+      "  sparse + asdex   max|x - x_dense| = 1.59e-14\n"
+     ]
+    }
+   ],
+   "source": [
+    "grid = jnp.arange(N + 1) * h\n",
+    "start = np.asarray(jnp.concatenate([\n",
+    "    0.05 * jnp.cos(grid), 0.05 * jnp.cos(grid), jnp.zeros(N + 1)]))\n",
+    "lb = np.concatenate([np.full(N + 1, -1.0), np.full(N + 1, -0.05),\n",
+    "                     np.full(N + 1, -np.inf)])\n",
+    "ub = np.concatenate([np.full(N + 1, 1.0), np.full(N + 1, 0.05),\n",
+    "                     np.full(N + 1, np.inf)])\n",
+    "cl = cu = np.zeros(m)\n",
+    "\n",
+    "jp = (np.asarray(jac_pat.rows), np.asarray(jac_pat.cols))\n",
+    "hp = (np.asarray(hess_pat.rows), np.asarray(hess_pat.cols))\n",
+    "\n",
+    "shared = dict(n=n, m=m, lb=lb, ub=ub, cl=cl, cu=cu)\n",
+    "results = {}\n",
+    "for label, extra in (\n",
+    "    (\"dense\", dict(sparse=False)),\n",
+    "    (\"sparse + probe\", dict(sparse=True)),\n",
+    "    (\"sparse + asdex\", dict(sparse=True, jac_pattern=jp, hess_pattern=hp)),\n",
+    "):\n",
+    "    t0 = time.perf_counter()\n",
+    "    prob = from_jax(objective, constraints, **shared, **extra)\n",
+    "    t_build = time.perf_counter() - t0\n",
+    "    prob.add_option(\"print_level\", 0)\n",
+    "    t0 = time.perf_counter()\n",
+    "    xs, info = prob.solve(start.copy())\n",
+    "    t_solve = time.perf_counter() - t0\n",
+    "    results[label] = xs\n",
+    "    print(f\"{label:16s} build {t_build:5.2f}s  solve {t_solve:6.3f}s  \"\n",
+    "          f\"iters {info['iter_count']:3d}  f = {info['obj_val']:.9f}\")\n",
+    "\n",
+    "ref = np.asarray(results[\"dense\"])\n",
+    "for label, xs in results.items():\n",
+    "    print(f\"  {label:16s} max|x - x_dense| = \"\n",
+    "          f\"{np.abs(np.asarray(xs) - ref).max():.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c1408c1",
+   "metadata": {},
+   "source": [
+    "All three land on the same solution. At this size the build cost is where\n",
+    "asdex shows up — the pattern comes out of one graph walk instead of repeated\n",
+    "blocked AD sweeps over the whole matrix.\n",
+    "\n",
+    "## 5. What the coloring is worth as $n$ grows\n",
+    "\n",
+    "The point of a colored pattern is that its cost tracks the *bandwidth*, not\n",
+    "the dimension. Here the color counts should stay pinned while $n$ grows,\n",
+    "because refining the discretization adds nodes without widening the stencil."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "69ac263c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:20.902174Z",
+     "iopub.status.busy": "2026-08-10T21:03:20.902093Z",
+     "iopub.status.idle": "2026-08-10T21:03:22.675527Z",
+     "shell.execute_reply": "2026-08-10T21:03:22.675080Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     N      n  J colors  H colors   sparse H    dense H   speedup  dense MB\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    50    153         4         3      0.04ms      0.04ms        1x       0.2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   100    303         4         3      0.01ms      0.10ms        7x       0.7\n",
+      "   200    603         4         3      0.02ms      0.22ms       12x       2.9\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   400   1203         4         3      0.02ms      0.71ms       32x      11.6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "   800   2403         4         3      0.03ms      5.30ms      157x      46.2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  1600   4803         4         3      0.04ms     29.06ms      656x     184.6\n"
+     ]
+    }
+   ],
+   "source": [
+    "def build(N):\n",
+    "    h = 1.0 / N\n",
+    "\n",
+    "    def obj(z):\n",
+    "        t, _x, u = jnp.split(z, 3)\n",
+    "        return (jnp.sum(0.5 * h * (u[1:] ** 2 + u[:-1] ** 2))\n",
+    "                + jnp.sum(0.5 * alpha * h * (jnp.cos(t[1:]) + jnp.cos(t[:-1])))\n",
+    "                + 0.5 * beta * h * jnp.sum((u[1:] - u[:-1]) ** 2))\n",
+    "\n",
+    "    def con(z):\n",
+    "        t, x, u = jnp.split(z, 3)\n",
+    "        return jnp.concatenate([\n",
+    "            x[1:] - x[:-1] - 0.5 * h * (jnp.sin(t[1:]) + jnp.sin(t[:-1])),\n",
+    "            t[1:] - t[:-1] - 0.5 * h * (u[1:] + u[:-1]),\n",
+    "        ])\n",
+    "\n",
+    "    return obj, con, lambda z, l, s: s * obj(z) + jnp.dot(l, con(z))\n",
+    "\n",
+    "\n",
+    "def timeit(fn, *a, reps=5):\n",
+    "    jax.block_until_ready(fn(*a))\n",
+    "    t0 = time.perf_counter()\n",
+    "    for _ in range(reps):\n",
+    "        jax.block_until_ready(fn(*a))\n",
+    "    return (time.perf_counter() - t0) / reps\n",
+    "\n",
+    "\n",
+    "print(f\"{'N':>6}{'n':>7}{'J colors':>10}{'H colors':>10}\"\n",
+    "      f\"{'sparse H':>11}{'dense H':>11}{'speedup':>10}{'dense MB':>10}\")\n",
+    "for Nk in (50, 100, 200, 400, 800, 1600):\n",
+    "    obj_k, con_k, lag_k = build(Nk)\n",
+    "    nk = 3 * (Nk + 1)\n",
+    "    zk = jnp.zeros(nk)\n",
+    "    mk = int(con_k(zk).shape[0])\n",
+    "    lk = jnp.ones(mk)\n",
+    "\n",
+    "    jc = asdex.jacobian_coloring(con_k, zk)\n",
+    "    hc = asdex.hessian_coloring(lag_k, zk, lk, 1.0)\n",
+    "    t_sparse = timeit(jax.jit(asdex.hessian_from_coloring(lag_k, hc)), zk, lk, 1.0)\n",
+    "    t_dense = timeit(jax.jit(jax.hessian(lag_k)), zk, lk, 1.0)\n",
+    "\n",
+    "    print(f\"{Nk:6d}{nk:7d}{jc.num_colors:10d}{hc.num_colors:10d}\"\n",
+    "          f\"{t_sparse * 1e3:10.2f}ms{t_dense * 1e3:10.2f}ms\"\n",
+    "          f\"{t_dense / t_sparse:9.0f}x{nk * nk * 8 / 1e6:10.1f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be7a5f05",
+   "metadata": {},
+   "source": [
+    "The color counts do not move. The sparse Hessian stays flat in wall-clock\n",
+    "while the dense one grows quadratically in both time and memory — by\n",
+    "$N = 1600$ the dense Hessian is a 185 MB array that takes roughly 650x\n",
+    "longer to form, and it is still 99.8% zeros. Note the $N = 50$ row: at\n",
+    "that size the coloring buys nothing, which is the honest lower end of\n",
+    "the range.\n",
+    "\n",
+    "## 6. Why a *proved* pattern beats a sampled one\n",
+    "\n",
+    "POUNCE detects sparsity by probing: it evaluates derivatives at a few random\n",
+    "points and unions the nonzeros. That is fast and right for structure fixed by\n",
+    "the expression graph, and `from_jax`'s own docstring is explicit about where\n",
+    "it stops — a supplied pattern is *\"the only safe one for genuinely\n",
+    "value-dependent sparsity, which no probe can detect reliably.\"*\n",
+    "\n",
+    "Here is that case. The coupling between $x_1$ and $x_2$ only switches on when\n",
+    "$x_0 > 0$, so a probe drawn in the other half of the domain sees a separable\n",
+    "function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "0482a165",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:22.676740Z",
+     "iopub.status.busy": "2026-08-10T21:03:22.676663Z",
+     "iopub.status.idle": "2026-08-10T21:03:22.703244Z",
+     "shell.execute_reply": "2026-08-10T21:03:22.702827Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "asdex, detected at a point where the gate is SHUT:\n",
+      "[[1 0 0 0]\n",
+      " [0 1 1 0]\n",
+      " [0 1 1 0]\n",
+      " [0 0 0 1]]\n",
+      "finds the (1,2) coupling: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "def gated(x):\n",
+    "    return jnp.sum(x ** 2) + jnp.where(x[0] > 0.0, x[1] * x[2], 0.0)\n",
+    "\n",
+    "\n",
+    "ng = 4\n",
+    "closed = jnp.array([-1.0, 0.7, 0.3, 0.2])   # gate shut at this point\n",
+    "gate_pat = asdex.hessian_sparsity(gated, closed)\n",
+    "\n",
+    "print(\"asdex, detected at a point where the gate is SHUT:\")\n",
+    "print(np.asarray(gate_pat.todense()).astype(int))\n",
+    "print(\"finds the (1,2) coupling:\", bool(np.asarray(gate_pat.todense())[1, 2]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4305f6d0",
+   "metadata": {},
+   "source": [
+    "asdex reports the coupling even though it detected at a point where that\n",
+    "branch is dead — the pattern is a statement about the graph, not the point.\n",
+    "\n",
+    "A probe has no way to know. Sweeping seeds, some miss it outright; and under\n",
+    "`sparse=True` a missed entry is worse than a dropped one, because it corrupts\n",
+    "the compression seed and *aliases into the entries that share its color*:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "84e53e75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:22.704376Z",
+     "iopub.status.busy": "2026-08-10T21:03:22.704295Z",
+     "iopub.status.idle": "2026-08-10T21:03:24.095781Z",
+     "shell.execute_reply": "2026-08-10T21:03:24.095340Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seeds whose probe missed the coupling: [4]  (1/24)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "probe (seed 4): nnz = 4, max abs error = 1.0\n",
+      "[[2. 0. 0. 0.]\n",
+      " [0. 3. 0. 0.]\n",
+      " [0. 0. 3. 0.]\n",
+      " [0. 0. 0. 2.]]\n",
+      "\n",
+      "asdex pattern: nnz = 5, max abs error = 0.0\n",
+      "[[2. 0. 0. 0.]\n",
+      " [0. 2. 1. 0.]\n",
+      " [0. 1. 2. 0.]\n",
+      " [0. 0. 0. 2.]]\n",
+      "\n",
+      "true Hessian at that point:\n",
+      "[[2. 0. 0. 0.]\n",
+      " [0. 2. 1. 0.]\n",
+      " [0. 1. 2. 0.]\n",
+      " [0. 0. 0. 2.]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pounce.jax._build import _JaxProblem\n",
+    "\n",
+    "misses = [\n",
+    "    s for s in range(24)\n",
+    "    if not np.any(\n",
+    "        (_JaxProblem(gated, None, n=ng, m=0, sparse=True, seed=s, n_probes=3)._hess_rows == 2)\n",
+    "        & (_JaxProblem(gated, None, n=ng, m=0, sparse=True, seed=s, n_probes=3)._hess_cols == 1)\n",
+    "    )\n",
+    "]\n",
+    "print(f\"seeds whose probe missed the coupling: {misses}  ({len(misses)}/24)\")\n",
+    "\n",
+    "open_pt = np.array([1.0, 0.7, 0.3, 0.2])    # gate live: the coupling is real\n",
+    "truth = np.asarray(jax.hessian(gated)(jnp.asarray(open_pt)))\n",
+    "\n",
+    "for label, kw in (\n",
+    "    (f\"probe (seed {misses[0]})\", dict(sparse=True, seed=misses[0], n_probes=3)),\n",
+    "    (\"asdex pattern\", dict(sparse=True, hess_pattern=(np.asarray(gate_pat.rows),\n",
+    "                                                      np.asarray(gate_pat.cols)))),\n",
+    "):\n",
+    "    po = _JaxProblem(gated, None, n=ng, m=0, **kw)\n",
+    "    H = np.zeros((ng, ng))\n",
+    "    H[po._hess_rows, po._hess_cols] = np.asarray(po.hessian(open_pt, np.zeros(0), 1.0))\n",
+    "    H = H + np.tril(H, -1).T\n",
+    "    print(f\"\\n{label}: nnz = {len(po._hess_rows)}, \"\n",
+    "          f\"max abs error = {np.abs(H - truth).max()}\")\n",
+    "    print(H)\n",
+    "\n",
+    "print(\"\\ntrue Hessian at that point:\")\n",
+    "print(truth)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a4d599d",
+   "metadata": {},
+   "source": [
+    "The missed entry does not come back as a zero. Its value is folded into the\n",
+    "diagonal — the probe-built Hessian reports $H_{11} = H_{22} = 3$ where the\n",
+    "truth is $2$ — so the solver is handed plausible, wrong curvature with no\n",
+    "error raised anywhere. asdex's pattern reproduces the Hessian exactly.\n",
+    "\n",
+    "This is the argument for `asdex` over probing even when speed is not the\n",
+    "concern: `jnp.where`, `jnp.clip`, `jnp.maximum` and friends are ordinary in\n",
+    "engineering models, and every one of them is a gate of this kind.\n",
+    "\n",
+    "## 7. Full control: the raw structure/values object\n",
+    "\n",
+    "`from_jax` is the short path. If you need the callbacks themselves — to mix\n",
+    "in hand-written derivatives, or to drive `pounce.Problem` directly — the same\n",
+    "pattern feeds the cyipopt-style protocol. The one wrinkle is ordering: asdex\n",
+    "returns values in its own BCOO index order, so build the permutation onto\n",
+    "your declared structure once, at setup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "35cbf1fa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-08-10T21:03:24.097039Z",
+     "iopub.status.busy": "2026-08-10T21:03:24.096953Z",
+     "iopub.status.idle": "2026-08-10T21:03:24.234208Z",
+     "shell.execute_reply": "2026-08-10T21:03:24.233765Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "status 0  f = 329.913793375  iters 37\n",
+      "agrees with from_jax: 9.83e-15\n"
+     ]
+    }
+   ],
+   "source": [
+    "jac_fn = jax.jit(asdex.jacobian_from_coloring(constraints, jac_col))\n",
+    "hess_fn = jax.jit(asdex.hessian_from_coloring(lagrangian, hess_col))\n",
+    "f_val, f_grad = jax.jit(objective), jax.jit(jax.grad(objective))\n",
+    "g_val = jax.jit(constraints)\n",
+    "\n",
+    "jr, jc_ = np.asarray(jac_pat.rows), np.asarray(jac_pat.cols)\n",
+    "hr_all, hc_all = np.asarray(hess_pat.rows), np.asarray(hess_pat.cols)\n",
+    "lower = hr_all >= hc_all              # POUNCE wants the lower triangle\n",
+    "hr, hc_ = hr_all[lower], hc_all[lower]\n",
+    "\n",
+    "\n",
+    "def order_map(bcoo_indices, rows, cols, ncols):\n",
+    "    \"\"\"Permutation taking asdex's value order to our declared structure.\"\"\"\n",
+    "    key_have = bcoo_indices[:, 0].astype(np.int64) * ncols + bcoo_indices[:, 1]\n",
+    "    key_want = rows.astype(np.int64) * ncols + cols\n",
+    "    order = np.argsort(key_have)\n",
+    "    pos = order[np.searchsorted(key_have[order], key_want)]\n",
+    "    assert np.array_equal(key_have[pos], key_want), \"structure/value mismatch\"\n",
+    "    return pos\n",
+    "\n",
+    "\n",
+    "jac_map = order_map(np.asarray(jac_fn(z0).indices), jr, jc_, n)\n",
+    "hess_map = order_map(np.asarray(hess_fn(z0, jnp.ones(m), 1.0).indices), hr, hc_, n)\n",
+    "\n",
+    "\n",
+    "class Beam:\n",
+    "    def objective(self, z):\n",
+    "        return float(f_val(z))\n",
+    "\n",
+    "    def gradient(self, z):\n",
+    "        return np.asarray(f_grad(z))\n",
+    "\n",
+    "    def constraints(self, z):\n",
+    "        return np.asarray(g_val(z))\n",
+    "\n",
+    "    def jacobianstructure(self):\n",
+    "        return jr, jc_\n",
+    "\n",
+    "    def jacobian(self, z):\n",
+    "        return np.asarray(jac_fn(z).data)[jac_map]\n",
+    "\n",
+    "    def hessianstructure(self):\n",
+    "        return hr, hc_\n",
+    "\n",
+    "    def hessian(self, z, lagrange, obj_factor):\n",
+    "        return np.asarray(hess_fn(z, lagrange, obj_factor).data)[hess_map]\n",
+    "\n",
+    "\n",
+    "prob = pounce.Problem(n=n, m=m, problem_obj=Beam(), lb=lb, ub=ub, cl=cl, cu=cu)\n",
+    "prob.add_option(\"print_level\", 0)\n",
+    "z_sol, info = prob.solve(start.copy())\n",
+    "print(f\"status {info['status']}  f = {info['obj_val']:.9f}  \"\n",
+    "      f\"iters {info['iter_count']}\")\n",
+    "print(f\"agrees with from_jax: \"\n",
+    "      f\"{np.abs(np.asarray(z_sol) - ref).max():.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a4084ec",
+   "metadata": {},
+   "source": [
+    "## When to reach for it\n",
+    "\n",
+    "| Situation | What to use |\n",
+    "|---|---|\n",
+    "| Small or genuinely dense model | `from_jax(..., sparse=False)` — coloring overhead buys nothing |\n",
+    "| Large model, structure fixed by the expression graph | `from_jax(..., sparse=True)` — the built-in probe is fine and needs no extra dependency |\n",
+    "| Structure known in closed form (collocation, PDE stencils) | Write `jac_pattern` / `hess_pattern` yourself |\n",
+    "| Large JAX model, structure you would rather not hand-derive | `asdex` patterns into `jac_pattern` / `hess_pattern` |\n",
+    "| Model containing `where` / `clip` / `maximum`, i.e. value-dependent structure | `asdex` — a probe can be silently wrong here |\n",
+    "\n",
+    "Practical rule: **let the probe handle straight-line algebra, and reach for\n",
+    "`asdex` the moment the model branches.** The cost difference between them is\n",
+    "modest and shows up mostly at build time; the correctness difference is not\n",
+    "modest, and it fails quietly.\n",
+    "\n",
+    "Two things worth carrying away about the mechanics. The Hessian POUNCE wants\n",
+    "is the Hessian of the *Lagrangian*, so detect on\n",
+    "$\\sigma f + \\lambda^\\top g$ rather than on the objective alone, or the\n",
+    "constraint curvature is missing from the pattern. And a pattern only has to\n",
+    "be a **superset** of the truth: extra entries report zeros and may cost a\n",
+    "color, while a missing one corrupts the result — which is exactly why a\n",
+    "conservative graph-derived pattern is the safe default."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/notebooks/README.md
+++ b/python/notebooks/README.md
@@ -46,6 +46,7 @@ jupyter lab python/notebooks/01_getting_started.ipynb
 | 11 | [`11_batched_warm_start.ipynb`](11_batched_warm_start.ipynb) | Warm-starting a batched differentiable solve. |
 | 12 | [`12_kkt_solve_many_perf.ipynb`](12_kkt_solve_many_perf.ipynb) | Batched `kkt_solve_many` performance. |
 | 14 | [`14_path_following.ipynb`](14_path_following.ipynb) | Predictor–corrector path following & inverse mapping. |
+| 33 | [`33_asdex_sparsity.ipynb`](33_asdex_sparsity.ipynb) | Automatic sparsity detection and coloring with [`asdex`](https://github.com/adrhill/asdex): derive `jac_pattern`/`hess_pattern` from the jaxpr instead of by hand, feed them to `from_jax(sparse=True)` or a raw `pounce.Problem`, and see why a graph-derived pattern beats a probed one on branchy (`where`/`clip`) models. |
 
 ## Convex & conic (`pounce.qp`)
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -70,7 +70,7 @@ Homepage = "https://github.com/jkitchin/pounce"
 Issues = "https://github.com/jkitchin/pounce/issues"
 
 [dependency-groups]
-notebooks = ["pyomo>=6.7", "pyomo-pounce", "ipykernel>=6"]
+notebooks = ["pyomo>=6.7", "pyomo-pounce", "ipykernel>=6", "asdex>=0.5"]
 
 [tool.uv]
 default-groups = ["notebooks"]


### PR DESCRIPTION
Adds `python/notebooks/33_asdex_sparsity.ipynb`, wiring
[`asdex`](https://github.com/adrhill/asdex) — automatic sparsity detection and
graph coloring for JAX — to POUNCE's sparse interface.

Executed with outputs stored, per the notebooks README convention. Nothing in CI
runs notebooks, so this was run locally against the current tree.

## What it covers

POUNCE's sparse path wants a *structure* (`(rows, cols)`) and a *values*
callback. Deriving the structure by hand is the tedious part of setting up a
large NLP, and getting it wrong is a wrong answer rather than a crash. asdex
recovers the pattern from the jaxpr by abstract interpretation, then colors it.

The model is `clnlbeam`, a standard nonconvex optimal-control benchmark, plus a
control-smoothing term — included because it makes the Lagrangian Hessian
tridiagonal instead of diagonal, so the coloring visibly responds to structure
rather than returning a trivial answer.

Both integration routes are shown:

- `from_jax(sparse=True, jac_pattern=..., hess_pattern=...)`, which is the
  idiomatic surface and already accepts exactly the `(rows, cols)` form asdex
  produces. `hess_pattern` folds upper-triangle entries onto their mirror, so
  asdex's full symmetric pattern passes straight through.
- A raw `pounce.Problem` with hand-written cyipopt callbacks, for cases needing
  full control. The one wrinkle documented there: asdex returns values in BCOO
  index order, so the notebook builds the permutation onto the declared
  structure once at setup.

## Measured results (all from the stored outputs)

At `n = 603`, `m = 400`: constraint Jacobian **4 colors**, Lagrangian Hessian
**3**, against 603 AD passes for a dense build.

Scaling — the color counts stay pinned while `n` grows, because refining the
discretization adds nodes without widening the stencil:

| N | n | J colors | H colors | sparse H | dense H | speedup | dense MB |
|---|---|---|---|---|---|---|---|
| 50 | 153 | 4 | 3 | 0.04ms | 0.04ms | 1x | 0.2 |
| 200 | 603 | 4 | 3 | 0.02ms | 0.22ms | 12x | 2.9 |
| 800 | 2403 | 4 | 3 | 0.03ms | 5.30ms | 157x | 46.2 |
| 1600 | 4803 | 4 | 3 | 0.04ms | 29.06ms | 656x | 184.6 |

The `N = 50` row shows **1x** — no benefit at small `n`. That row is kept and
called out in the prose rather than starting the table where the story looks
better; the concluding decision table says plainly to use `sparse=False` there.

Dense, probe-detected, and asdex-detected all reach the same solution
(`max|x - x_dense| = 1.59e-14`).

## The part worth reviewing closely

Section 6 makes a correctness argument, not a speed one, so it deserves a look.

POUNCE detects sparsity by evaluating derivatives at a few random points
(`rng.standard_normal`, `n_probes=3` under `sparse=True`). `from_jax`'s own
docstring already names the limit — a supplied pattern is *"the only safe one for
genuinely value-dependent sparsity, which no probe can detect reliably."* The
notebook demonstrates that case with a `jnp.where` gate whose coupling is live
only on part of the domain:

- asdex reports the coupling even when detecting at a point where that branch is
  dead — its pattern is a statement about the graph, not the point.
- The probe misses it on 1 of 24 seeds. Under `sparse=True` the miss does not
  degrade to a zero: it corrupts the compression seed and aliases into the
  entries sharing its color, so the reported Hessian has `H11 = H22 = 3` where
  the truth is `2`. Plausible, wrong curvature, no error raised anywhere.

So the framing is that asdex closes a gap POUNCE documents, not that POUNCE is
wrong. `where` / `clip` / `maximum` are ordinary in engineering models, and each
is a gate of this kind.

## Also in this PR

- Notebooks README table row under **Performance & sparsity**.
- Root `README.md`: a link to Hans Mittelmann's AMPL-NLP benchmark under
  "pounce in the wild". Unrelated to the notebook, riding along at the author's
  request rather than as its own one-line PR.
- `asdex>=0.5` added to the `notebooks` dependency group in
  `python/pyproject.toml`. This is a genuinely new external dependency and is
  needed only to run this notebook — no library code imports it, and no CI job
  installs it.
