### PR TITLE
release: 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4899,7 +4899,7 @@ fact improved that family substantially (92 → 38 failures/144) before #361 too
 it to 0.
 
 
-### ### Tests — pyomo-pounce: `test_binary_check.py` failed on any Windows checkout (#366)
+### Tests — pyomo-pounce: `test_binary_check.py` failed on any Windows checkout (#366)
 
 - Three tests were POSIX-only: the shadowing test joined `PATH` with a
   hardcoded `":"` instead of `os.pathsep`, and the fake `pounce` binaries were

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ changes.
 
 ## [Unreleased]
 
+
+## [0.10.0] - 2026-08-10
+
 ### Changed — FERAL 0.15.1, which stops assuming the host has threads
 
 The workspace pin moves `feral` 0.15.0 → 0.15.1. It is a patch release with
@@ -8866,5 +8869,13 @@ release.
 - Zenodo metadata (`.zenodo.json`) and `CITATION.cff` for
   archival on every GitHub Release.
 
+[Unreleased]: https://github.com/jkitchin/pounce/compare/v0.10.0...HEAD
+[0.10.0]: https://github.com/jkitchin/pounce/releases/tag/v0.10.0
+[0.9.0]: https://github.com/jkitchin/pounce/releases/tag/v0.9.0
+[0.8.0]: https://github.com/jkitchin/pounce/releases/tag/v0.8.0
+[0.7.0]: https://github.com/jkitchin/pounce/releases/tag/v0.7.0
+[0.6.0]: https://github.com/jkitchin/pounce/releases/tag/v0.6.0
+[0.5.0]: https://github.com/jkitchin/pounce/releases/tag/v0.5.0
+[0.4.0]: https://github.com/jkitchin/pounce/releases/tag/v0.4.0
 [0.3.0]: https://github.com/jkitchin/pounce/releases/tag/v0.3.0
 [0.2.0]: https://github.com/jkitchin/pounce/releases/tag/v0.2.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ identifiers:
   - type: doi
     value: "10.5281/zenodo.20387011"
     description: "Concept DOI — always resolves to the latest POUNCE release"
-version: 0.8.0
-date-released: 2026-07-11
+version: 0.10.0
+date-released: 2026-08-10
 authors:
   - family-names: Kitchin
     given-names: John R.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "iter-diff"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde_json",
 ]
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-algorithm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -890,7 +890,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cinterface"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -906,7 +906,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -939,7 +939,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-common"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -948,7 +948,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-convex"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -962,7 +962,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-feral"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "feral",
  "pounce-common",
@@ -972,7 +972,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-hsl"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -981,7 +981,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-l1penalty"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -989,14 +989,14 @@ dependencies = [
 
 [[package]]
 name = "pounce-linalg"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
 ]
 
 [[package]]
 name = "pounce-linsol"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1005,7 +1005,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nl"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "libloading",
  "libm",
@@ -1016,7 +1016,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-nlp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
  "pounce-linalg",
@@ -1025,7 +1025,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-observability"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstyle",
  "anstyle-query",
@@ -1039,7 +1039,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-presolve"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
  "pounce-nlp",
@@ -1048,7 +1048,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-py"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "faer",
  "feral",
@@ -1071,7 +1071,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-qp"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-common",
  "pounce-feral",
@@ -1081,7 +1081,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-restoration"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1110,7 +1110,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-sensitivity"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-solve-report"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1142,7 +1142,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-studio-pyo3"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-studio-core",
  "pyo3",
@@ -1152,7 +1152,7 @@ dependencies = [
 
 [[package]]
 name = "pounce-wasm"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "pounce-algorithm",
  "pounce-common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "EPL-2.0"
 authors = ["John Kitchin <jkitchin@andrew.cmu.edu>"]
@@ -67,23 +67,23 @@ repository = "https://github.com/jkitchin/pounce"
 # deps lack a registry version). Crates pick these up via
 # `pounce-foo.workspace = true`.
 [workspace.dependencies]
-pounce-common = { path = "crates/pounce-common", version = "0.9.0" }
-pounce-linalg = { path = "crates/pounce-linalg", version = "0.9.0" }
-pounce-linsol = { path = "crates/pounce-linsol", version = "0.9.0" }
-pounce-nlp = { path = "crates/pounce-nlp", version = "0.9.0" }
-pounce-nl = { path = "crates/pounce-nl", version = "0.9.0" }
-pounce-hsl = { path = "crates/pounce-hsl", version = "0.9.0" }
-pounce-feral = { path = "crates/pounce-feral", version = "0.9.0" }
-pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.9.0" }
-pounce-restoration = { path = "crates/pounce-restoration", version = "0.9.0" }
-pounce-presolve = { path = "crates/pounce-presolve", version = "0.9.0" }
-pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.9.0" }
-pounce-qp = { path = "crates/pounce-qp", version = "0.9.0" }
-pounce-convex = { path = "crates/pounce-convex", version = "0.9.0" }
-pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.9.0" }
-pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.9.0" }
-pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.9.0" }
-pounce-observability = { path = "crates/pounce-observability", version = "0.9.0" }
+pounce-common = { path = "crates/pounce-common", version = "0.10.0" }
+pounce-linalg = { path = "crates/pounce-linalg", version = "0.10.0" }
+pounce-linsol = { path = "crates/pounce-linsol", version = "0.10.0" }
+pounce-nlp = { path = "crates/pounce-nlp", version = "0.10.0" }
+pounce-nl = { path = "crates/pounce-nl", version = "0.10.0" }
+pounce-hsl = { path = "crates/pounce-hsl", version = "0.10.0" }
+pounce-feral = { path = "crates/pounce-feral", version = "0.10.0" }
+pounce-algorithm = { path = "crates/pounce-algorithm", version = "0.10.0" }
+pounce-restoration = { path = "crates/pounce-restoration", version = "0.10.0" }
+pounce-presolve = { path = "crates/pounce-presolve", version = "0.10.0" }
+pounce-l1penalty = { path = "crates/pounce-l1penalty", version = "0.10.0" }
+pounce-qp = { path = "crates/pounce-qp", version = "0.10.0" }
+pounce-convex = { path = "crates/pounce-convex", version = "0.10.0" }
+pounce-sensitivity = { path = "crates/pounce-sensitivity", version = "0.10.0" }
+pounce-solve-report = { path = "crates/pounce-solve-report", version = "0.10.0" }
+pounce-studio-core = { path = "crates/pounce-studio-core", version = "0.10.0" }
+pounce-observability = { path = "crates/pounce-observability", version = "0.10.0" }
 # feral: pinned to the published crates.io release so the pounce crates stay
 # publishable — a git rev would block the crates.io publish and is rejected by
 # scripts/check-release-consistency.sh ("git dependency … needs a crates.io

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Most HPC sites run Apptainer/Singularity rather than Docker; it pulls the
 same image and runs it as your own user:
 
 ```sh
-apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.9.0
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.10.0
 apptainer run pounce.sif problem.nl
 ```
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -8,8 +8,8 @@
 # The build context is irrelevant here (nothing is COPYed in), so it can be
 # built from anywhere — including straight off GitHub without a clone:
 #
-#   docker build -f docker/Dockerfile.release -t pounce:0.9.0 \
-#     --build-arg POUNCE_VERSION=0.9.0 .
+#   docker build -f docker/Dockerfile.release -t pounce:0.10.0 \
+#     --build-arg POUNCE_VERSION=0.10.0 .
 #
 # or `make docker-release`, which reads the version out of Cargo.toml.
 #
@@ -54,7 +54,7 @@ FROM python:${PYTHON_VERSION}-slim-${DEBIAN_RELEASE}
 # single arg pins both wheels. Pinned rather than floating on purpose: an
 # image tagged 0.9.0 should contain 0.9.0 forever, not whatever was newest
 # the day it was rebuilt.
-ARG POUNCE_VERSION=0.9.0
+ARG POUNCE_VERSION=0.10.0
 
 LABEL org.opencontainers.image.title="POUNCE" \
       org.opencontainers.image.description="Interior-point optimization solver (CLI + Python + Pyomo), released build from PyPI" \

--- a/docker/README.md
+++ b/docker/README.md
@@ -31,7 +31,7 @@ The equivalents by hand:
 docker build -f docker/Dockerfile -t pounce:dev \
   --build-arg POUNCE_BUILD_GIT="$(git rev-parse --short=8 HEAD)" .
 
-docker build -f docker/Dockerfile.release -t pounce:0.9.0 \
+docker build -f docker/Dockerfile.release -t pounce:0.10.0 \
   --build-arg POUNCE_VERSION=0.9.0 .
 ```
 

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -69,7 +69,7 @@ The optional extras are *not* installed — no JAX, no PyTorch, no `plotly`,
 no GAMS bindings. Add what you need in a derived image:
 
 ```dockerfile
-FROM ghcr.io/jkitchin/pounce:0.9.0
+FROM ghcr.io/jkitchin/pounce:0.10.0
 USER root
 RUN pip install --no-cache-dir "pounce-solver[jax]==0.9.0"
 USER pounce
@@ -81,7 +81,7 @@ Most HPC sites run Apptainer (formerly Singularity) rather than Docker,
 because it needs no daemon and no root. It pulls Docker images directly:
 
 ```sh
-apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.9.0
+apptainer pull pounce.sif docker://ghcr.io/jkitchin/pounce:0.10.0
 apptainer run pounce.sif problem.nl
 ```
 

--- a/pyomo-pounce/pyproject.toml
+++ b/pyomo-pounce/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pyomo-pounce"
-version = "0.9.0"
+version = "0.10.0"
 description = "Pyomo solver plugin for the POUNCE interior-point NLP solver"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 # because maturin's `module-name = "pounce._pounce"` and
 # `python-source = "."` keep the package folder named `pounce`.
 name = "pounce-solver"
-version = "0.9.0"
+version = "0.10.0"
 description = "Python interface to POUNCE — a pure-Rust interior-point optimization solver for nonlinear, conic (LP/QP/SOCP/SDP/exp/power), and global problems (NLP core ported from Ipopt). cyipopt-style Problem class, scipy-style minimize() facade, solve_qp/solve_socp/sos_minimize, and JAX-friendly autodiff / implicit differentiation."
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Version bump for the 0.10.0 release. No code change — every hunk is a version
string, plus the CHANGELOG cut.

0.10.0 covers 553 commits and 129 merged PRs since `v0.9.0` (2026-07-24). The
CHANGELOG section is 4,903 lines, about three times the size of 0.9.0's.

## Surfaces bumped

- Root `Cargo.toml`: `[workspace.package]` and all 17 `[workspace.dependencies]`
  pins that point at our own crates (they must match, or `cargo publish` resolves
  a dependent against the previous release).
- `python/pyproject.toml`, `pyomo-pounce/pyproject.toml`.
- `docker/Dockerfile.release`: the pinned `ARG POUNCE_VERSION` and the usage
  example above it.
- `Cargo.lock`.
- The `ghcr.io/jkitchin/pounce:0.9.0` tags quoted in `README.md`,
  `docs/src/docker.md`, and `docker/README.md` — the consistency script's
  advisory grep covers exactly these files and would have reported them stale.

`scripts/check-release-consistency.sh` passes at 0.10.0.

## CITATION.cff was two releases stale

It sat at `version: 0.8.0` / `date-released: 2026-07-11` through the entire
0.9.0 cycle, so GitHub's "Cite this repository" widget has been offering 0.8.0
since July. `dev-notes/cargo-release.md` step 4 says to bump it, but
`check-release-consistency.sh` does not verify it — which is why the drift was
silent where every other surface's drift is caught. Now at 0.10.0 / 2026-08-10.

Adding CITATION.cff to that guard is worth a follow-up; a checklist item that
was already missed once will be missed again.

## What deliberately did not move

- `pounce-solver>=0.9.0` in `pyomo-pounce`'s base dependencies — a deliberately
  loose compatibility floor, documented as such in the file.
- `pounce-solver>0.9.0` in the `pyomo-v2` extra — encodes that released 0.9.0
  predates the per-model `Options` echo (#553) the v2 route needs. Bumping it
  with the release would erase a real compatibility fact.
- The `#452` history comment in `Dockerfile.release`, which is about what 0.9.0
  shipped.

## CHANGELOG link references

The reference block stopped at `[0.3.0]`, so every version from 0.4.0 up —
including `[Unreleased]` — rendered as unlinked literal text. Added the seven
missing ones.

## Release preflight, and a broken step in the docs

`scripts/publish-crates.sh --dry-run` **fails at the second crate**, and will
fail for any release that bumps the version:

```
error: failed to prepare local package for uploading
  failed to select a version for the requirement `pounce-common = "^0.10.0"`
  candidate versions found which didn't match: 0.9.0, 0.8.0, 0.7.0, ...
  location searched: crates.io index
```

`cargo publish -p <crate> --dry-run` resolves that crate's workspace siblings
against the **crates.io index**. At a bumped version none of them are there yet,
so only the leaves (`pounce-common`, `pounce-studio-core`) can pass. The
procedure in `dev-notes/cargo-release.md` claims this step "dry-runs every crate
end-to-end, so any breakage appears here, not three crates into the real
release" — that is not achievable this way. Run before the bump it passes
trivially, having validated nothing about the version being shipped; run after
the bump it fails on crate 2. Either way it never did the job described.

`cargo publish --workspace --dry-run` (cargo 1.96) resolves siblings against the
locally packaged crates instead of the index, which is the check the docs
describe. Its result is reported in a comment below. Switching the script's
`--dry-run` path to it is the natural follow-up.

The real publish is unaffected: it publishes in topological order, so each
crate's dependencies genuinely are live by the time it uploads.
