### PR TITLE
fix(ci): build the release-image rot guard against a published version

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -134,6 +134,32 @@ jobs:
             pull_request)
               # Rot guard only — prove both still build, publish nothing.
               push=false
+              # The release image pip-installs a *pinned, published* version
+              # from PyPI, so it can only be built against a version that is
+              # actually on PyPI. On a release PR the workspace version is by
+              # definition not — the wheels come from the python-v* tag, which
+              # is pushed after the PR merges. And every release PR touches
+              # docker/Dockerfile.release, because check-release-consistency.sh
+              # requires ARG POUNCE_VERSION to be bumped in lockstep, so every
+              # release PR matches this workflow's `docker/**` path filter.
+              # Using the workspace version here therefore fails on every
+              # release PR, on both arches, after waiting out the full ~20 min
+              # PyPI poll. Build against the newest published version instead:
+              # this guard exists to prove Dockerfile.release still builds, and
+              # against a real version is exactly how you prove that.
+              # Newest version common to *both* projects: the wait below polls
+              # for one version across both, so the latest of either alone can
+              # be a version the other has not shipped.
+              if [ -z "${VERSION_INPUT:-}" ]; then
+                latest="$(python3 -c "import json, urllib.request as u; \
+                  rel = lambda p: {v for v, f in json.load(u.urlopen('https://pypi.org/pypi/' + p + '/json'))['releases'].items() if f}; \
+                  both = [v for v in rel('pounce-solver').intersection(rel('pyomo-pounce')) if v.replace('.', '').isdigit()]; \
+                  print(max(both, key=lambda v: tuple(int(x) for x in v.split('.'))) if both else '')" || true)"
+                if [ -n "$latest" ]; then
+                  version="$latest"
+                  echo "::notice::PR rot guard: building the release image against the newest published version ($version), not the workspace version ($(grep -m1 -E '^version[[:space:]]*=' Cargo.toml | sed -E 's/.*"([^"]+)".*/\1/'))."
+                fi
+              fi
               ;;
             push)
               if [ "$is_tag" = true ]; then


### PR DESCRIPTION
## The bug

`release-docker`'s `pull_request` trigger is a rot guard: build both images,
publish nothing, so a Dockerfile that quietly stopped building gets caught
before a tag depends on it.

For the **release** image that guard could never pass on a release PR — the one
PR most likely to break it, and the only one that changes the pinned version.

Three facts combine:

1. The release image `pip install`s a **pinned, published** version from PyPI.
2. The `plan` step resolved that version from the workspace `Cargo.toml`.
3. On a release PR the workspace version is by definition **not on PyPI yet** —
   the wheels are built by `release-pounce.yml` from the `python-v*` tag, which
   is pushed after the PR merges.

And every release PR reaches this workflow: `check-release-consistency.sh`
check 5 requires `ARG POUNCE_VERSION` in `docker/Dockerfile.release` to be
bumped in lockstep, which matches the `docker/**` path filter.

So every release PR waits out the full ~20 min PyPI poll on both arches and
then fails. Observed on the 0.10.0 release PR (#574, run 31439935330) — both
`linux/amd64` and `linux/arm64`:

```
Waiting for pounce-solver==0.10.0 on PyPI...
##[error]pounce-solver==0.10.0 is not on PyPI after ~20 min.
```

Not a one-off: it is structural, and would have recurred on every future
release. It has not been seen before only because `release-docker.yml`
postdates v0.9.0 — 0.10.0 is the first release to run it at all.

## The fix

On `pull_request` only, resolve the version to the newest release **common to
both** PyPI projects rather than the workspace version. The guard exists to
prove `Dockerfile.release` still builds, and building it against a version that
actually exists is how you prove that. "Common to both" because the wait step
polls a single version across `pounce-solver` and `pyomo-pounce`.

Falls back to the workspace version if PyPI is unreachable, preserving the old
behavior rather than silently passing.

## Verification

Ran the `plan` step locally against each event. Only `pull_request` changes:

| event | ref | version | push | release | source |
|---|---|---|---|---|---|
| `pull_request` | — | **0.9.0** (was 0.10.0) | false | true | true |
| `push` | `refs/tags/v0.10.0` | 0.10.0 | true | true | true |
| `push` | `refs/heads/main` | 0.10.0 | true | false | true |
| `workflow_dispatch` | `refs/heads/main` | 0.10.0 | true | true | true |

This PR touches `.github/workflows/release-docker.yml`, which is itself in the
path filter — so the PR exercises the fixed guard on itself.
