### PR TITLE
bench(report): disclose per-suite Ipopt time-limit overrides

### DIFF
--- a/benchmarks/BENCHMARK_REPORT.md
+++ b/benchmarks/BENCHMARK_REPORT.md
@@ -1,12 +1,12 @@
 # POUNCE Benchmark Report
 
-Generated: 2026-08-11 14:04:15
+Generated: 2026-08-11 14:51:51
 
 ## Provenance
 
 | Component | Version / Detail |
 |-----------|------------------|
-| POUNCE | v0.10.0 (main @ ce41b5bc-dirty) |
+| POUNCE | v0.10.0 (main @ 8cba2f81-dirty) |
 | POUNCE linear solver | feral (default) |
 | Ipopt | Ipopt 3.14.20 (Darwin arm64), ASL(20241202) |
 | Ipopt linear solver | ma57 (via ref/Ipopt/install-ma57) |
@@ -31,6 +31,12 @@ smoke check (`make -C benchmarks gams-bench`) and is not aggregated here.
 > and should not be compared against multi-threaded runs of this report.
 > The Ipopt reference column carries no thread record of its own; its pinning is asserted by the procedure that
 > generated it, not verified here.
+
+> **Time limits.** The saved Ipopt reference ran at `max_cpu_time` = 300s unless overridden below. The POUNCE arm carries no time-limit flag — it is wrapped in `timeout $BENCH_TIMELIMIT` (default 300s) and a kill is recorded as `Maximum_CpuTime_Exceeded` — so its limit is not stamped in the results and is inferred here from the longest run that was killed.
+> Override — **mittelmann**: Ipopt reference at 1800s (regenerated 2026-08-07, threads pinned to 1 (OMP/OPENBLAS/VECLIB/RAYON)).
+> Reason given: the 300s max_cpu_time in the base stamp was reached at ~90s wall on unpinned multithreaded BLAS, leaving 6 instances truncated; see dev-notes/research/mittelmann-post-546-sweep.md
+> POUNCE runs in this suite were cut off at ~300s, so the two columns are **not** held to the same clock here.
+> Decided by that gap: **WM_CFy** — POUNCE cut off at 300s (102 iters), Ipopt Optimal at 1147s (556 iters), i.e. past POUNCE's cutoff. It is counted here as an Ipopt-only solve, on a limit POUNCE was never given. Measured out of band on 2026-08-11 at the reference's own 1800s limit (same host, threads pinned, binary from ce41b5bc): POUNCE returns `Optimal Solution Found` in 673s / 239 iterations, vs Ipopt's 1147s / 556. Objectives differ by 0.136% (two local optima; Ipopt's is the better point). Deliberately not merged into the results, which record the sweep as configured — see dev-notes/research/wm-cfy-timelimit.md.
 
 ## Executive Summary
 

--- a/benchmarks/benchmark_report.py
+++ b/benchmarks/benchmark_report.py
@@ -344,6 +344,104 @@ def _pin_verdict(threads):
     return 'unpinned', "; ".join(bits)
 
 
+def _timeout_cutoffs(comps):
+    """Per suite, the wall-clock at which POUNCE runs were actually cut off.
+
+    The POUNCE arm gets no time-limit flag — `run_nl_bench.sh` wraps it in
+    `timeout $BENCH_TIMELIMIT` and relabels rc=124 as
+    `Maximum_CpuTime_Exceeded` — so the limit in force is not recorded
+    anywhere in the results. The longest killed run in a suite is therefore
+    the only evidence of it, and it is a tight lower bound: a run cannot be
+    killed before its limit.
+    """
+    cutoffs = {}
+    for c in comps:
+        if 'CpuTime' in c['pounce_status'] or 'Timeout' in c['pounce_status']:
+            s = c['suite']
+            cutoffs[s] = max(cutoffs.get(s, 0.0), c.get('pounce_time') or 0.0)
+    return cutoffs
+
+
+def _followup_for(prov, name):
+    """Any out-of-band result recorded for an instance the limits decide.
+
+    Keyed by instance name under `followups` in the Ipopt provenance file.
+    Such a run is deliberately *not* merged into the results — it was made
+    at a different limit than the sweep — but leaving no trace of it would
+    overstate what is unknown, so the report cites it and says where it
+    lives."""
+    return (prov.get('ipopt_followups') or {}).get(name)
+
+
+def time_limit_note(prov, comps):
+    """Build the Time limits note, disclosing any per-suite Ipopt override.
+
+    The base provenance stamp carries one `timelimit`, but
+    `ipopt_ma57.provenance.json` may override it per suite — mittelmann's
+    reference was regenerated at 1800s after a threading bug truncated it at
+    300s CPU. Printing only the base number states a limit the Ipopt column
+    did not actually run under, and hides that a suite may compare a
+    300s POUNCE arm against a 1800s reference. So: print the base, print
+    every override, and name any instance the asymmetry decides.
+    """
+    base = prov.get('ipopt_timelimit')
+    overrides = prov.get('ipopt_suite_overrides') or {}
+    if base is None and not overrides:
+        return []
+
+    lines = [f"> **Time limits.** The saved Ipopt reference ran at "
+             f"`max_cpu_time` = {base}s unless overridden below. The POUNCE arm "
+             "carries no time-limit flag — it is wrapped in "
+             "`timeout $BENCH_TIMELIMIT` (default 300s) and a kill is recorded "
+             "as `Maximum_CpuTime_Exceeded` — so its limit is not stamped in the "
+             "results and is inferred here from the longest run that was killed."]
+
+    cutoffs = _timeout_cutoffs(comps)
+    by_lower = {s.lower(): s for s in cutoffs}
+
+    affected = []
+    for suite, ov in sorted(overrides.items()):
+        lim = ov.get('timelimit', '?')
+        why = ov.get('why', '')
+        detail = f"regenerated {ov.get('generated', '?')}"
+        if ov.get('threads'):
+            detail += f", threads {ov['threads']}"
+        lines.append(f"> Override — **{suite}**: Ipopt reference at {lim}s "
+                     f"({detail}).")
+        if why:
+            lines.append(f"> Reason given: {why}")
+
+        display = by_lower.get(suite.lower())
+        if display and isinstance(lim, (int, float)):
+            cut = cutoffs[display]
+            lines.append(f"> POUNCE runs in this suite were cut off at "
+                         f"~{cut:.0f}s, so the two columns are **not** held to "
+                         f"the same clock here.")
+            # An instance is decided by the asymmetry only if POUNCE was
+            # killed AND Ipopt needed longer than POUNCE was ever allowed.
+            for c in comps:
+                if (c['suite'] == display
+                        and ('CpuTime' in c['pounce_status']
+                             or 'Timeout' in c['pounce_status'])
+                        and c['ipopt_status'] == 'Optimal'
+                        and (c.get('ipopt_time') or 0.0) > cut):
+                    affected.append((c, cut))
+
+    for c, cut in affected:
+        line = (f"> Decided by that gap: **{c['name']}** — POUNCE cut off "
+                f"at {c['pounce_time']:.0f}s ({c['pounce_iters']} iters), "
+                f"Ipopt Optimal at {c['ipopt_time']:.0f}s "
+                f"({c['ipopt_iters']} iters), i.e. past POUNCE's cutoff. It is "
+                "counted here as an Ipopt-only solve, on a limit POUNCE was "
+                "never given.")
+        followup = _followup_for(prov, c['name'])
+        if followup:
+            line += f" {followup}"
+        lines.append(line)
+
+    return lines
+
+
 def threading_note(stamps, ipopt_threads=None):
     """Build the Threading & timing note from what was actually recorded.
 
@@ -482,6 +580,9 @@ def collect_provenance():
     ipopt_linear_solver = 'ma57 (via ref/Ipopt/install-ma57)'
     ipopt_reference = None
     ipopt_threads = None
+    ipopt_timelimit = None
+    ipopt_suite_overrides = {}
+    ipopt_followups = {}
     prov_path = os.path.join(SCRIPT_DIR, 'ipopt_ma57.provenance.json')
     if os.path.exists(prov_path):
         try:
@@ -490,6 +591,9 @@ def collect_provenance():
             ipopt_version = ref.get('ipopt_version', 'unknown')
             ipopt_linear_solver = ref.get('linear_solver', ipopt_linear_solver)
             ipopt_threads = ref.get('threads')
+            ipopt_timelimit = ref.get('timelimit')
+            ipopt_suite_overrides = ref.get('suite_overrides') or {}
+            ipopt_followups = ref.get('followups') or {}
             ipopt_reference = (f"generated {ref.get('generated', '?')} on "
                                f"{ref.get('host', '?')} ({ref.get('platform', '?')}), "
                                f"git {ref.get('git_sha', '?')}, "
@@ -506,6 +610,9 @@ def collect_provenance():
         'ipopt_linear_solver': ipopt_linear_solver,
         'ipopt_reference': ipopt_reference,
         'ipopt_threads': ipopt_threads,
+        'ipopt_timelimit': ipopt_timelimit,
+        'ipopt_suite_overrides': ipopt_suite_overrides,
+        'ipopt_followups': ipopt_followups,
         'git_sha': git_sha,
         'git_branch': git_branch,
         'timestamp': datetime.now().strftime('%Y-%m-%d %H:%M:%S %Z').strip(),
@@ -813,12 +920,17 @@ def generate_report(suites, output_path, baseline=None, profile_dirs=None,
     lines.append("smoke check (`make -C benchmarks gams-bench`) and is not aggregated here.")
     lines.append("")
     lines.extend(threading_note(env_stamps or {}, prov.get('ipopt_threads')))
-    lines.append("")
 
     # Combined summary
     all_comps = []
     for name, comps in suites:
         all_comps.extend(comps)
+
+    tl_note = time_limit_note(prov, all_comps)
+    if tl_note:
+        lines.append("")
+        lines.extend(tl_note)
+    lines.append("")
 
     combined = suite_summary("Combined", all_comps)
 

--- a/benchmarks/ipopt_ma57.provenance.json
+++ b/benchmarks/ipopt_ma57.provenance.json
@@ -15,5 +15,8 @@
       "threads": "pinned to 1 (OMP/OPENBLAS/VECLIB/RAYON)",
       "why": "the 300s max_cpu_time in the base stamp was reached at ~90s wall on unpinned multithreaded BLAS, leaving 6 instances truncated; see dev-notes/research/mittelmann-post-546-sweep.md"
     }
+  },
+  "followups": {
+    "WM_CFy": "Measured out of band on 2026-08-11 at the reference's own 1800s limit (same host, threads pinned, binary from ce41b5bc): POUNCE returns `Optimal Solution Found` in 673s / 239 iterations, vs Ipopt's 1147s / 556. Objectives differ by 0.136% (two local optima; Ipopt's is the better point). Deliberately not merged into the results, which record the sweep as configured \u2014 see dev-notes/research/wm-cfy-timelimit.md."
   }
 }

--- a/dev-notes/research/wm-cfy-timelimit.md
+++ b/dev-notes/research/wm-cfy-timelimit.md
@@ -1,0 +1,87 @@
+# WM_CFy: the last "Ipopt only" solve is a time-limit artifact
+
+**Date:** 2026-08-11
+**Binary:** `target/release/pounce` built from `ce41b5bc` (merged main, 0.10.0)
+**Status:** measured, not folded into `BENCHMARK_REPORT.md`
+
+## Claim
+
+`Mittelmann/WM_CFy` is the single instance the 0.10.0 report counts as solved
+by Ipopt and not by POUNCE. It is not a capability gap. The two columns are
+run at different time limits on that suite, and POUNCE is the faster of the
+two solvers once given the same clock.
+
+## The asymmetry
+
+`benchmarks/ipopt_ma57.provenance.json` carries a per-suite override:
+
+    "mittelmann": { "timelimit": 1800, "generated": "2026-08-07",
+                    "threads": "pinned to 1 (OMP/OPENBLAS/VECLIB/RAYON)" }
+
+The POUNCE arm has no time-limit flag at all — `run_nl_bench.sh` wraps it in
+`timeout $BENCH_TIMELIMIT` (default 300) and relabels rc=124 as
+`Maximum_CpuTime_Exceeded`. A plain `make benchmark-rerun` therefore runs the
+mittelmann POUNCE arm at 300s against a reference that got 1800s.
+
+## Ipopt never solved it at 300s either
+
+Before the reference was regenerated (`e157b036`, 2026-08-08), Ipopt's own
+record for this instance was a timeout:
+
+| | `e157b036~1` | `e157b036` |
+|---|---|---|
+| status | `Maximum_CpuTime_Exceeded` | `Solve_Succeeded` |
+| time | 340.5s | 1146.5s |
+| iterations | 157 | 556 |
+| objective | 1.232202588975379 (incumbent) | 1.2218235931043862 |
+
+So `WM_CFy` used to be a *mutual* failure. It became an Ipopt-only solve on
+2026-08-08 by raising Ipopt's ceiling, not by any change in either solver.
+
+That regeneration flipped four instances, and it was justified for three of
+them — `henon120` (108.5s → 77.5s), `lane_emden120` (89.3s → 69.7s) and
+`qcqp1000-2c` (104.2s → 129.7s) were killed by the documented threading bug
+(`max_cpu_time` counts CPU summed across threads, so an unpinned run burns a
+300s budget in ~90s wall) and all three now finish *inside* 300s. Pinning
+fixed those; the raised ceiling was incidental. `WM_CFy` is the only one that
+actually consumed the extra ceiling.
+
+## POUNCE at Ipopt's clock
+
+Rerun with the driver's exact invocation (`timeout 1800 pounce <nl> --no-sol`,
+all four thread vars = 1, same host):
+
+| | POUNCE @1800s | Ipopt ma57 @1800s |
+|---|---|---|
+| status | `Optimal Solution Found` | `Solve_Succeeded` |
+| wall | **672.8s** (664.5s in solver) | 1146.5s |
+| iterations | **239** | 556 |
+| objective | 1.2234907111354598 | 1.2218235931043862 |
+| NLP error | 6.3403053477504722e-09 | — |
+| constraint violation | 9.3537964873657842e-10 | — |
+
+POUNCE converges in 59% of Ipopt's wall time and 43% of its iterations.
+
+## Caveat: different local solutions
+
+The objectives disagree by **0.136%**, well past the report's 0.01% match
+threshold. The problem minimizes (`O0 0` in the .nl), so Ipopt's 1.22182 is
+the better point and POUNCE converged to a worse local optimum. Both are
+legitimately converged — POUNCE's KKT error is 6.3e-09 with 9.4e-10 violation
+— so this is two local optima on a nonconvex problem, not an error. Folding
+this run into the report would move `WM_CFy` from "Ipopt only" to "both
+Optimal, objectives disagree", not to a clean match.
+
+## What was done about it
+
+Nothing to the numbers. `benchmarks/mittelmann/pounce.json` still records the
+300s timeout, which is the honest record of the sweep as configured. The
+report now discloses the override, the inferred POUNCE cutoff, and names
+`WM_CFy` as the instance the gap decides (`time_limit_note` in
+`benchmark_report.py`).
+
+The like-for-like fix — rerunning the mittelmann POUNCE arm at
+`BENCH_TIMELIMIT=1800` — is deferred. It is a few hours of machine time and
+only this one instance can change status, since the other five POUNCE
+timeouts in the corpus (`vanderbei/cresc132`, `drcav3lq`, `drcavty3`,
+`lpopt/ex10`, `irish-electricity`) are instances Ipopt fails as well.


### PR DESCRIPTION
The report printed a single `timelimit` from the base Ipopt provenance stamp
and never surfaced `suite_overrides`. That hid a real asymmetry: the
mittelmann Ipopt reference was regenerated at **1800s**, while the POUNCE arm
runs at the `BENCH_TIMELIMIT` default of **300s** — and the single
Ipopt-exclusive solve in the entire 1,326-model report is decided by exactly
that gap.

**No numbers change.** `BENCHMARK_REPORT.json` is byte-identical; this is
disclosure only.

## What the report now says

```
> **Time limits.** The saved Ipopt reference ran at `max_cpu_time` = 300s unless
> overridden below. The POUNCE arm carries no time-limit flag — it is wrapped in
> `timeout $BENCH_TIMELIMIT` (default 300s) and a kill is recorded as
> `Maximum_CpuTime_Exceeded` — so its limit is not stamped in the results and is
> inferred here from the longest run that was killed.
> Override — **mittelmann**: Ipopt reference at 1800s (regenerated 2026-08-07, ...).
> Reason given: the 300s max_cpu_time in the base stamp was reached at ~90s wall
> on unpinned multithreaded BLAS, leaving 6 instances truncated; ...
> POUNCE runs in this suite were cut off at ~300s, so the two columns are **not**
> held to the same clock here.
> Decided by that gap: **WM_CFy** — POUNCE cut off at 300s (102 iters), Ipopt
> Optimal at 1147s (556 iters), i.e. past POUNCE's cutoff. ...
```

Everything above is derived from the data — the suite, the instance, the
cutoff and the reason are all read from the results and the provenance file.
Nothing about mittelmann or `WM_CFy` is hardcoded, so a future override on
another suite discloses itself.

POUNCE's limit genuinely is not recorded anywhere (`run_nl_bench.sh` wraps it
in `timeout` and relabels rc=124), so the longest killed run is used as a
lower bound on it — a run cannot be killed before its limit.

## WM_CFy is not a capability gap

Measured out of band at the reference's own 1800s limit (same host, threads
pinned, binary from `ce41b5bc`):

| | POUNCE | Ipopt ma57 |
|---|---|---|
| status | `Optimal Solution Found` | `Solve_Succeeded` |
| wall | **672.8s** | 1146.5s |
| iterations | **239** | 556 |
| objective | 1.2234907111354598 | 1.2218235931043862 |

POUNCE converges in 59% of Ipopt's time and 43% of its iterations. The
objectives differ by **0.136%** — two local optima on a nonconvex problem,
and Ipopt's is the better point (the problem minimizes), so folding this in
would produce "both Optimal, objectives disagree" rather than a clean match.

That run is recorded as a `followups` entry in the provenance file and cited
by the report, but **deliberately not merged into the results**, which record
the sweep as configured. Full write-up in
`dev-notes/research/wm-cfy-timelimit.md`.

## It was never an Ipopt win at 300s

Before the reference was regenerated (`e157b036`), Ipopt's own record for
`WM_CFy` was `Maximum_CpuTime_Exceeded` at 340.5s / 157 iterations. It was a
*mutual* failure. It became an Ipopt-only solve by raising one column's
ceiling, not by any change in either solver.

The regeneration was justified for the other three instances it flipped —
`henon120`, `lane_emden120`, `qcqp1000-2c` were killed by the documented
threading bug and all three now finish *inside* 300s, so pinning fixed them
and the raised ceiling was incidental. `WM_CFy` is the only one that consumed
the extra ceiling.

## Deferred

Rerunning the mittelmann POUNCE arm at `BENCH_TIMELIMIT=1800` is the
like-for-like fix. It costs a few hours and only this one instance can change
status — the other five POUNCE timeouts are instances Ipopt fails too.

## Verification

- `BENCHMARK_REPORT.json` unchanged (no result moved).
- Degenerate provenance shapes exercised directly: absent file, base with no
  overrides, override naming an unknown suite, override with a malformed
  limit, override with no followup, and a suite with no killed runs — each
  returns sensible output, none raises.
- Report regenerated from `main` so the provenance stamp reads
  `main @ 8cba2f81`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qi7vwYkRm1kPtCGx6WJWsj
