### PR TITLE
Add timelimit for convex route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,16 @@ changes.
   spent rather than zero. `pounce_convex::batch`'s `time_limit` is documented
   as per-instance, which is what it has always been.
 
+- **`max_wall_time` now bounds the whole CLI solve, not each engine that gets
+  a turn at it.** When a convex attempt declines the problem and hands it to
+  the NLP path (the gh #535 LP→NLP reroute, or `socp_nlp_fallback`), the NLP
+  solve built its `Deadline` from the option value — which still named the
+  full budget — so a run that spent most of its seconds convex-side was
+  granted them all again and the cap could buy nearly twice the wall clock it
+  promises. The declined attempt is now charged against the option before the
+  handover, the same deduction the convex path already applies internally for
+  extraction and presolve.
+
 
 ## [0.10.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,17 @@ changes.
     driver's reduced-accuracy salvage, so a cancelled solve whose last iterate
     satisfies the KKT conditions is still allowed to say so.
 
+  Both rules apply on the LP / convex-QP **active-set** route as well as the
+  IPM one: `solve_qp_active_set` shares the IPM's relabelling policy rather
+  than stamping `TimeLimit` over whatever the inner solve returned, and a
+  cancelled engine result now goes through the same verified KKT check as an
+  iteration-limited one — reaching the answer and then running out of seconds
+  used to be reported as reaching nothing, while running out of *iterations*
+  at the identical point reported `Optimal`.
+
   A cancelled active-set solve also reports the wall-clock time it actually
-  spent rather than zero.
+  spent rather than zero. `pounce_convex::batch`'s `time_limit` is documented
+  as per-instance, which is what it has always been.
 
 
 ## [0.10.0] - 2026-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ changes.
 
 ## [Unreleased]
 
+- Added solve-wide convex-engine wall-clock deadlines. Both
+  `pounce_convex::QpOptions` and `pounce_qp::QpOptions` now expose
+  `time_limit: Option<Duration>` and their status enums expose `TimeLimit`.
+  Automatic LP/QP/active-set/SOCP routing forwards an explicitly set
+  `max_wall_time`, shares it across setup and retry stages, reports AMPL result
+  400 / `MaximumWallTimeExceeded`, and never reroutes a timed-out solve to NLP.
+  This is source-breaking for exhaustive option literals and enum matches.
+
 
 ## [0.10.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,32 @@ changes.
   400 / `MaximumWallTimeExceeded`, and never reroutes a timed-out solve to NLP.
   This is source-breaking for exhaustive option literals and enum matches.
 
+  A deadline changes when a solve stops, never what it answers. Two rules
+  carry that:
+
+  * **Cancellation is an error, not a value.** In `pounce-qp` it travels as
+    the internal `QpError::DeadlineExpired`, so `?` propagation forces every
+    caller to handle it, and only the `QpSolver` entry points turn it back
+    into the soft `QpStatus::TimeLimit`. Without this,
+    `factorize_with_inertia_control` — whose "success" is a right-hand side
+    solved in place — could return `Ok` on a timeout, and
+    `solve_equality_only` would read the *un-solved* `[-g; b]` back as
+    `[x*; λ*]`, skip the guards a zero shift makes moot, and report a
+    feasible-but-wrong point as `Optimal`. Covered by a regression test that
+    reproduces the window deterministically.
+  * **A verdict outranks the clock.** Every deadline check in `pounce-convex`
+    runs after some inner solve has already returned, so the crossing can land
+    between convergence and the check. `Optimal`, `OptimalInaccurate`, and the
+    two infeasibility certificates now survive it; only `IterationLimit` /
+    `NumericalFailure`, which conclude nothing, are relabelled. A problem that
+    converges a millisecond past its budget hands back the optimum it computed
+    instead of a report that nothing was solved. `TimeLimit` also joins each
+    driver's reduced-accuracy salvage, so a cancelled solve whose last iterate
+    satisfies the KKT conditions is still allowed to say so.
+
+  A cancelled active-set solve also reports the wall-clock time it actually
+  spent rather than zero.
+
 
 ## [0.10.0] - 2026-08-11
 

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -574,7 +574,7 @@ impl SqpAlgorithm {
                 // non-committal status rather than a hard error, and — the
                 // point of #282 — WITHOUT ever asserting infeasibility on a
                 // problem we have not certified infeasible.
-                QpStatus::MaxIter | QpStatus::NumericalError => {
+                QpStatus::MaxIter | QpStatus::TimeLimit | QpStatus::NumericalError => {
                     let obj = nlp.eval_f(&iter.x);
                     self.iterates = Some(iter.clone());
                     // Report *which* of the two it was. Both are honest
@@ -583,7 +583,7 @@ impl SqpAlgorithm {
                     // user, and merging them hid the dominant Maros-Mészáros
                     // failure mode behind a step-size verdict. See
                     // `SqpStatus::QpIterationLimit`.
-                    let status = if sol.status == QpStatus::MaxIter {
+                    let status = if matches!(sol.status, QpStatus::MaxIter | QpStatus::TimeLimit) {
                         SqpStatus::QpIterationLimit
                     } else {
                         SqpStatus::QpStepFailed

--- a/crates/pounce-algorithm/src/sqp/sqp_alg.rs
+++ b/crates/pounce-algorithm/src/sqp/sqp_alg.rs
@@ -583,6 +583,15 @@ impl SqpAlgorithm {
                     // user, and merging them hid the dominant Maros-Mészáros
                     // failure mode behind a step-size verdict. See
                     // `SqpStatus::QpIterationLimit`.
+                    // `TimeLimit` rides with `MaxIter`: it is the same kind of
+                    // outcome (a budget ran out, no claim about the problem),
+                    // and it is the closest honest report `SqpStatus` can make
+                    // today. Nothing here reaches it yet — the SQP never sets
+                    // `QpOptions::time_limit` on a step subproblem, so the
+                    // active-set solver has no deadline to cross — but leaving
+                    // the arm unhandled would make the first caller that does
+                    // set one land in `QpStepFailed`, i.e. "the step broke
+                    // down", which would be false.
                     let status = if matches!(sol.status, QpStatus::MaxIter | QpStatus::TimeLimit) {
                         SqpStatus::QpIterationLimit
                     } else {

--- a/crates/pounce-cli/src/bin/pounce_cblib.rs
+++ b/crates/pounce-cli/src/bin/pounce_cblib.rs
@@ -32,6 +32,7 @@ fn qp_status_to_ars(s: QpStatus) -> ApplicationReturnStatus {
         QpStatus::PrimalInfeasible => ApplicationReturnStatus::InfeasibleProblemDetected,
         QpStatus::DualInfeasible => ApplicationReturnStatus::DivergingIterates, // unbounded
         QpStatus::IterationLimit => ApplicationReturnStatus::MaximumIterationsExceeded,
+        QpStatus::TimeLimit => ApplicationReturnStatus::MaximumWallTimeExceeded,
         QpStatus::NumericalFailure => ApplicationReturnStatus::InternalError,
     }
 }

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2197,7 +2197,9 @@ fn resolve_scaling_retry_outcome(
 ///   *verified*, which a second solve must not be allowed to overwrite.
 ///   `NumericalFailure` is left alone here for the same reason the QP path has
 ///   always reported it: it is the post-solve verification refusing a point,
-///   and the LP corpus has no case of it that the NLP path recovers.
+///   and the LP corpus has no case of it that the NLP path recovers. Nor does
+///   `TimeLimit`, which is a spent budget rather than a stall — rerouting it
+///   would answer "stop after `max_wall_time`" with a second solve.
 ///
 /// Note what this deliberately is **not**: the issue's "never-regress" variant,
 /// which would keep whichever of the two results certifies at the lower KKT
@@ -2360,11 +2362,22 @@ fn convex_cli_opts(app: &IpoptApplication) -> pounce_convex::QpOptions {
     if let Ok((v, true)) = opt.get_numeric_value("tol", "") {
         o.tol = v;
     }
+    // `max_wall_time`, honoured only when the user set it explicitly (the `true`
+    // flag) — Ipopt's default is 1e20, i.e. "no limit", and turning that into a
+    // `Duration` would put a nonsensical deadline on every solve.
+    //
+    // A value `Duration` cannot represent is *not* clamped to something huge:
+    // it means no limit, and it says so. `try_from_secs_f64` rejects exactly
+    // the values with no honest deadline — NaN, and anything past ~5.8e11
+    // years including `f64::INFINITY` and Ipopt's own 1e20 sentinel should a
+    // user type it out. Negative is invalid and likewise ignored. `0.0` is
+    // kept as a real (immediate) deadline: "take no time" is the wall-clock
+    // twin of `max_iter=0`, which pounce#186 requires to stop before solving.
     if let Ok((v, true)) = opt.get_numeric_value("max_wall_time", "")
         && v >= 0.0
+        && let Ok(d) = std::time::Duration::try_from_secs_f64(v)
     {
-        o.time_limit =
-            Some(std::time::Duration::try_from_secs_f64(v).unwrap_or(std::time::Duration::MAX));
+        o.time_limit = Some(d);
     }
     if let Ok((v, true)) = opt.get_numeric_value("qp_tau", "") {
         o.tau = v;
@@ -3327,12 +3340,13 @@ mod lp_nlp_fallback_tests {
     use pounce_cli::dispatch::ProblemClass;
     use pounce_convex::QpStatus;
 
-    const ALL_STATUSES: [QpStatus; 6] = [
+    const ALL_STATUSES: [QpStatus; 7] = [
         QpStatus::Optimal,
         QpStatus::OptimalInaccurate,
         QpStatus::PrimalInfeasible,
         QpStatus::DualInfeasible,
         QpStatus::IterationLimit,
+        QpStatus::TimeLimit,
         QpStatus::NumericalFailure,
     ];
 
@@ -3380,6 +3394,19 @@ mod lp_nlp_fallback_tests {
                 "{status:?} must not reroute"
             );
         }
+    }
+
+    /// A wall-clock budget is a budget, exactly as `max_iter` is: `TimeLimit`
+    /// is the answer to the question the user asked. Rerouting it would launch
+    /// a *second*, unbudgeted solve on a problem whose whole point was to stop
+    /// — the fallback would double the time limit it was told to respect.
+    #[test]
+    fn a_spent_time_budget_is_not_a_reason_to_solve_again() {
+        assert!(!lp_declines_to_nlp(
+            ProblemClass::Lp,
+            QpStatus::TimeLimit,
+            true
+        ));
     }
 
     /// The issue scopes the fallback to `P = 0`. A convex QP that stalls is a

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2253,6 +2253,7 @@ fn qp_status_to_ars(s: pounce_convex::QpStatus) -> ApplicationReturnStatus {
         QpStatus::PrimalInfeasible => ApplicationReturnStatus::InfeasibleProblemDetected,
         QpStatus::DualInfeasible => ApplicationReturnStatus::DivergingIterates, // unbounded
         QpStatus::IterationLimit => ApplicationReturnStatus::MaximumIterationsExceeded,
+        QpStatus::TimeLimit => ApplicationReturnStatus::MaximumWallTimeExceeded,
         QpStatus::NumericalFailure => ApplicationReturnStatus::InternalError,
     }
 }
@@ -2272,6 +2273,7 @@ fn convex_status_report(s: pounce_convex::QpStatus) -> (&'static str, bool, i32)
         QpStatus::PrimalInfeasible => ("Problem is primal infeasible.", false, 200),
         QpStatus::DualInfeasible => ("Problem is unbounded (dual infeasible).", false, 300),
         QpStatus::IterationLimit => ("Maximum iterations exceeded.", false, 400),
+        QpStatus::TimeLimit => ("Maximum wallclock time exceeded.", false, 400),
         // Deliberately not "failure in KKT factorization": both convex engines
         // reach this status by failing the *post-solve* verification — the
         // returned point's true KKT error exceeded the acceptable band — which
@@ -2358,6 +2360,12 @@ fn convex_cli_opts(app: &IpoptApplication) -> pounce_convex::QpOptions {
     if let Ok((v, true)) = opt.get_numeric_value("tol", "") {
         o.tol = v;
     }
+    if let Ok((v, true)) = opt.get_numeric_value("max_wall_time", "")
+        && v >= 0.0
+    {
+        o.time_limit =
+            Some(std::time::Duration::try_from_secs_f64(v).unwrap_or(std::time::Duration::MAX));
+    }
     if let Ok((v, true)) = opt.get_numeric_value("qp_tau", "") {
         o.tau = v;
         // A raised floor lifts the default ceiling with it, so `qp_tau` alone
@@ -2383,6 +2391,16 @@ fn convex_cli_opts(app: &IpoptApplication) -> pounce_convex::QpOptions {
         o.crossover = v != "no";
     }
     o
+}
+
+fn convex_opts_with_remaining(
+    mut opts: pounce_convex::QpOptions,
+    started: std::time::Instant,
+) -> pounce_convex::QpOptions {
+    if let Some(limit) = opts.time_limit {
+        opts.time_limit = Some(limit.saturating_sub(started.elapsed()));
+    }
+    opts
 }
 
 /// Resolve the convex LP/QP presolve switch (#139).
@@ -2435,6 +2453,7 @@ fn run_convex_qp(
     // gh #535: may an uncertified LP solve be handed back to the NLP path?
     allow_nlp_fallback: bool,
 ) -> Option<ExitCode> {
+    let t0 = std::time::Instant::now();
     use pounce_convex::active_set::solve_qp_active_set;
     use pounce_convex::presolve::{FixpointExit, PresolveOutcome, presolve};
     use pounce_convex::{QpOptions, QpStatus, solve_qp_ipm, solve_qp_ipm_debug};
@@ -2462,7 +2481,6 @@ fn run_convex_qp(
     let backend = || -> Box<dyn SparseSymLinearSolverInterface> {
         Box::new(pounce_feral::FeralSolverInterface::new())
     };
-    let t0 = std::time::Instant::now();
     // With presolve on, reduce the problem (logging what was removed),
     // solve the reduced problem, then postsolve back to the extracted-QP
     // space — so the `con_map`-based dual recovery below still applies.
@@ -2486,6 +2504,7 @@ fn run_convex_qp(
         collect_iterates: want_trace,
         ..convex_opts
     };
+    let solve_opts = || convex_opts_with_remaining(qp_opts, t0);
     // What presolve did, held back until we know this solve is the one that
     // reports (gh #535). These lines describe the reduction, not the verdict,
     // but they are the *only* stdout a declined convex attempt would otherwise
@@ -2512,7 +2531,7 @@ fn run_convex_qp(
         // user selected. The caller has already printed the note explaining
         // the debugger does not engage; fall through and solve normally.
         let mut h = hook.borrow_mut();
-        solve_qp_ipm_debug(&qp, &qp_opts, &mut *h, backend)
+        solve_qp_ipm_debug(&qp, &solve_opts(), &mut *h, backend)
     } else if presolve_on {
         match presolve(&qp) {
             PresolveOutcome::Reduced(ps) => {
@@ -2565,9 +2584,9 @@ fn run_convex_qp(
                 }
                 let red = if use_active_set {
                     let mut mk = backend;
-                    solve_qp_active_set(&ps.reduced, &qp_opts, &engine_overrides, &mut mk)
+                    solve_qp_active_set(&ps.reduced, &solve_opts(), &engine_overrides, &mut mk)
                 } else {
-                    solve_qp_ipm(&ps.reduced, &qp_opts, backend)
+                    solve_qp_ipm(&ps.reduced, &solve_opts(), backend)
                 };
                 ps.postsolve(&red)
             }
@@ -2582,9 +2601,9 @@ fn run_convex_qp(
         }
     } else if use_active_set {
         let mut mk = backend;
-        solve_qp_active_set(&qp, &qp_opts, &engine_overrides, &mut mk)
+        solve_qp_active_set(&qp, &solve_opts(), &engine_overrides, &mut mk)
     } else {
-        solve_qp_ipm(&qp, &qp_opts, backend)
+        solve_qp_ipm(&qp, &solve_opts(), backend)
     };
     let elapsed = t0.elapsed().as_secs_f64();
 
@@ -2792,6 +2811,7 @@ fn run_convex_socp(
     convex_opts: pounce_convex::QpOptions,
     allow_nlp_fallback: bool,
 ) -> Option<ExitCode> {
+    let t0 = std::time::Instant::now();
     use pounce_convex::{QpOptions, solve_socp_ipm, solve_socp_ipm_debug};
 
     let (qp, con_map, obj_nl_const, cones) =
@@ -2820,7 +2840,7 @@ fn run_convex_socp(
         collect_iterates: want_trace,
         ..convex_opts
     };
-    let t0 = std::time::Instant::now();
+    let solve_opts = || convex_opts_with_remaining(qp_opts, t0);
     let sol = if qp_opts.max_iter == 0 {
         // `max_iter=0` cannot reach optimality — stop before any solve, the
         // same zero-iteration contract the QP path enforces (pounce#186).
@@ -2837,9 +2857,9 @@ fn run_convex_socp(
         }
     } else if let Some(hook) = debug_hook {
         let mut h = hook.borrow_mut();
-        solve_socp_ipm_debug(&qp, &cones, &qp_opts, &mut *h, backend)
+        solve_socp_ipm_debug(&qp, &cones, &solve_opts(), &mut *h, backend)
     } else {
-        solve_socp_ipm(&qp, &cones, &qp_opts, backend)
+        solve_socp_ipm(&qp, &cones, &solve_opts(), backend)
     };
     let elapsed = t0.elapsed().as_secs_f64();
 
@@ -3285,6 +3305,18 @@ mod convex_status_tests {
         assert_eq!(
             qp_status_to_ars(QpStatus::Optimal),
             ApplicationReturnStatus::SolveSucceeded
+        );
+    }
+
+    #[test]
+    fn time_limit_maps_to_wall_clock_status() {
+        let (msg, ok, srn) = convex_status_report(QpStatus::TimeLimit);
+        assert_eq!(msg, "Maximum wallclock time exceeded.");
+        assert!(!ok);
+        assert_eq!(srn, 400);
+        assert_eq!(
+            qp_status_to_ars(QpStatus::TimeLimit),
+            ApplicationReturnStatus::MaximumWallTimeExceeded
         );
     }
 }

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -983,6 +983,14 @@ pub fn main() -> ExitCode {
                 // particular must not be silently raised to the (far larger)
                 // Ipopt default, so it too is forwarded only when set.
                 let convex_opts = convex_cli_opts(&app);
+                // When the convex attempt declines (gh #535 / `socp_nlp_fallback`)
+                // the NLP solve below opens its own `Deadline` from the *option
+                // value*, which still names the full budget — so a run that spent
+                // most of `max_wall_time` here would be granted it again there,
+                // and the user's cap would buy up to twice the wall clock they
+                // asked for. Charge the declined attempt against the budget; see
+                // the deduction below the block.
+                let convex_t0 = std::time::Instant::now();
                 if matches!(choice, SolverChoice::SocpIpm) {
                     // `None` means the conic solve came back without a verified
                     // KKT point and declined the problem (only possible under
@@ -1050,6 +1058,9 @@ pub fn main() -> ExitCode {
                         return code;
                     }
                 }
+                // Reaching here means the convex attempt declined and the NLP
+                // path below owns the verdict; charge it for the time it spent.
+                charge_wall_budget(app.options_mut(), convex_t0.elapsed());
             }
             // Builtins never classify as convex; fall through to NLP.
         }
@@ -2416,6 +2427,41 @@ fn convex_opts_with_remaining(
     opts
 }
 
+/// Charge `spent` against `max_wall_time`, so a solve that gets handed from one
+/// engine to another spends **one** budget rather than one per engine.
+///
+/// The convex driver already deducts its own extraction and presolve from the
+/// budget it passes down (`convex_opts_with_remaining`). The gap this closes is
+/// one level up: when a convex attempt declines the problem (gh #535's LP→NLP
+/// reroute, or the conic path's `socp_nlp_fallback`) the NLP solve that takes
+/// over builds its `Deadline` from the *option value*, which still names the
+/// whole budget. A run that spent 55 of its 60 seconds convex-side would then be
+/// granted 60 more, and `max_wall_time` would buy nearly twice the wall clock it
+/// promises.
+///
+/// Applies only when the user actually set the option. Unset it is `1e6` — the
+/// effectively-unbounded default — and rewriting that as `1e6 - 3.2` states
+/// nothing the default did not, while making the option read as explicitly
+/// chosen to everything downstream that tests the `explicitly_set` flag.
+///
+/// A budget that is entirely gone floors at [`WALL_BUDGET_FLOOR`] rather than
+/// zero: the option is registered with a *strict* lower bound of 0, so `0.0` is
+/// rejected as invalid and the write would silently do nothing — leaving the
+/// full budget in place, which is the failure this exists to prevent. The floor
+/// is small enough that the NLP path's first deadline check trips on it.
+fn charge_wall_budget(
+    opts: &mut pounce_common::options_list::OptionsList,
+    spent: std::time::Duration,
+) {
+    /// Smallest budget that can be *stored* — see [`charge_wall_budget`].
+    const WALL_BUDGET_FLOOR: f64 = 1e-9;
+
+    if let Ok((limit, true)) = opts.get_numeric_value("max_wall_time", "") {
+        let left = (limit - spent.as_secs_f64()).max(WALL_BUDGET_FLOOR);
+        let _ = opts.set_numeric_value("max_wall_time", left, true, false);
+    }
+}
+
 /// Resolve the convex LP/QP presolve switch (#139).
 ///
 /// The convex driver is gated by the `qp_presolve` option, but `presolve` is
@@ -3318,6 +3364,73 @@ mod convex_status_tests {
         assert_eq!(
             qp_status_to_ars(QpStatus::Optimal),
             ApplicationReturnStatus::SolveSucceeded
+        );
+    }
+
+    /// A declined convex attempt is charged against the wall-clock budget, so
+    /// the NLP solve that takes over cannot start a second full one.
+    ///
+    /// Built on a real `IpoptApplication` rather than a bare `OptionsList`
+    /// because the two ways this write can silently do nothing — the option's
+    /// *strict* lower bound of zero, and the clobber flag on the stored value —
+    /// both live in the registration that only the real one carries.
+    #[test]
+    fn a_declined_convex_attempt_is_charged_against_the_wall_budget() {
+        use std::time::Duration;
+
+        let mut app = super::IpoptApplication::new();
+        app.options_mut()
+            .set_numeric_value("max_wall_time", 60.0, true, false)
+            .unwrap();
+
+        super::charge_wall_budget(app.options_mut(), Duration::from_secs_f64(55.0));
+        let (left, set) = app
+            .options()
+            .get_numeric_value("max_wall_time", "")
+            .unwrap();
+        assert!(set, "the option must still read as explicitly set");
+        assert!(
+            (left - 5.0).abs() < 1e-9,
+            "60s budget minus a 55s attempt must leave 5s, got {left}"
+        );
+
+        // A budget spent outright must not silently write back as the full
+        // budget: `max_wall_time` is registered with a strict lower bound, so a
+        // literal 0.0 would be rejected and leave 5s standing.
+        super::charge_wall_budget(app.options_mut(), Duration::from_secs_f64(600.0));
+        let (gone, _) = app
+            .options()
+            .get_numeric_value("max_wall_time", "")
+            .unwrap();
+        assert!(
+            gone > 0.0 && gone < 1e-6,
+            "an exhausted budget must store as positive-but-spent, got {gone}"
+        );
+    }
+
+    /// The other half: an *unset* budget is left alone. `1e6` is the
+    /// effectively-unbounded default, and rewriting it would both say nothing
+    /// new and make the option read as user-chosen downstream.
+    #[test]
+    fn an_unset_wall_budget_is_not_rewritten() {
+        use std::time::Duration;
+
+        let mut app = super::IpoptApplication::new();
+        let (before, set_before) = app
+            .options()
+            .get_numeric_value("max_wall_time", "")
+            .unwrap();
+        assert!(!set_before, "precondition: the option starts unset");
+
+        super::charge_wall_budget(app.options_mut(), Duration::from_secs_f64(3.2));
+        let (after, set_after) = app
+            .options()
+            .get_numeric_value("max_wall_time", "")
+            .unwrap();
+        assert_eq!(after, before);
+        assert!(
+            !set_after,
+            "an untouched budget must not read as explicitly set"
         );
     }
 

--- a/crates/pounce-cli/tests/convex_time_limit.rs
+++ b/crates/pounce-cli/tests/convex_time_limit.rs
@@ -1,0 +1,69 @@
+use std::path::PathBuf;
+use std::process::Command;
+
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_solve_report::SolveReport;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn assert_timeout(name: &str, selection: &str) {
+    let json = std::env::temp_dir().join(format!(
+        "pounce-convex-time-limit-{}-{}-{}.json",
+        std::process::id(),
+        name.replace('.', "-"),
+        selection
+    ));
+    let _ = std::fs::remove_file(&json);
+    let out = Command::new(pounce_exe())
+        .arg(fixture(name))
+        .arg("--no-sol")
+        .arg("--json-output")
+        .arg(&json)
+        .arg(format!("solver_selection={selection}"))
+        .arg("max_wall_time=1e-12")
+        .output()
+        .expect("spawn pounce");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stdout.contains("Maximum wallclock time exceeded."),
+        "selection={selection}; stdout=\n{stdout}\nstderr=\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("being re-solved on the general NLP"),
+        "a timed-out convex solve must not fall back; stderr=\n{stderr}"
+    );
+    let report: SolveReport =
+        serde_json::from_str(&std::fs::read_to_string(&json).expect("read JSON report"))
+            .expect("parse JSON report");
+    assert_eq!(
+        report.solution.status,
+        ApplicationReturnStatus::MaximumWallTimeExceeded
+    );
+    assert_eq!(report.solution.solve_result_num, 400);
+    let _ = std::fs::remove_file(json);
+}
+
+#[test]
+fn auto_qp_timeout_is_final() {
+    assert_timeout("convex_qp.nl", "auto");
+}
+
+#[test]
+fn active_set_qp_timeout_is_final() {
+    assert_timeout("convex_qp.nl", "qp-active-set");
+}
+
+#[test]
+fn auto_socp_timeout_is_final() {
+    assert_timeout("qcqp_ball.nl", "auto");
+}

--- a/crates/pounce-convex/examples/homotopy_sweep.rs
+++ b/crates/pounce-convex/examples/homotopy_sweep.rs
@@ -181,14 +181,8 @@ fn main() {
         QpStatus::PrimalInfeasible => "PrimalInfeasible",
         QpStatus::DualInfeasible => "DualInfeasible",
         QpStatus::IterationLimit => "IterationLimit",
+        QpStatus::TimeLimit => "TimeLimit",
         QpStatus::NumericalFailure => "NumericalFailure",
-        other => {
-            println!(
-                "{{\"status\": \"{other:?}\", \"n\": {n}, \"m_eq\": {m_eq}, \
-                 \"m_ineq\": {m_ineq}, \"time\": {elapsed}}}"
-            );
-            return;
-        }
     };
     println!(
         "{{\"status\": \"{status}\", \"obj\": {}, \"n\": {n}, \"m_eq\": {m_eq}, \

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -187,11 +187,24 @@ pub fn solve_qp_active_set<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    // One gate over every exit of the body below — see [`finite_or_failed`].
-    finite_or_failed(
-        prob,
-        solve_qp_active_set_inner(prob, opts, engine, make_backend),
-    )
+    crate::deadline::with_deadline(opts.time_limit, || {
+        if crate::deadline::expired() {
+            return empty_solution(prob.n, prob.m_eq(), prob.m_ineq(), QpStatus::TimeLimit);
+        }
+        // One gate over every exit of the body below — see [`finite_or_failed`].
+        let sol = finite_or_failed(
+            prob,
+            solve_qp_active_set_inner(prob, opts, engine, make_backend),
+        );
+        if crate::deadline::expired() {
+            QpSolution {
+                status: QpStatus::TimeLimit,
+                ..sol
+            }
+        } else {
+            sol
+        }
+    })
 }
 
 fn solve_qp_active_set_inner<F>(
@@ -257,6 +270,12 @@ where
     if is_conclusive(sol.status) {
         return sol;
     }
+    if crate::deadline::expired() {
+        return QpSolution {
+            status: QpStatus::TimeLimit,
+            ..sol
+        };
+    }
 
     let mut best = sol;
     if opts.equilibrate {
@@ -286,6 +305,12 @@ where
         if is_conclusive(best.status) {
             return best;
         }
+        if crate::deadline::expired() {
+            return QpSolution {
+                status: QpStatus::TimeLimit,
+                ..best
+            };
+        }
     }
 
     // ---- Last resort: the simplex seed the homotopy displaced (#413) ----
@@ -313,6 +338,12 @@ where
     // needed.) When the caller already asked for `use_homotopy=no`, the first
     // attempt was seeded and there is nothing new to try.
     if engine.use_homotopy != Some(false) {
+        if crate::deadline::expired() {
+            return QpSolution {
+                status: QpStatus::TimeLimit,
+                ..best
+            };
+        }
         let seeded_engine = ActiveSetOverrides {
             use_homotopy: Some(false),
             ..*engine
@@ -351,7 +382,11 @@ fn is_solved(s: QpStatus) -> bool {
 /// from a ray that only exists inside `solve_translated`, so a retry's claim
 /// has no witness left to re-check after unscaling.
 fn is_conclusive(s: QpStatus) -> bool {
-    is_solved(s) || matches!(s, QpStatus::PrimalInfeasible | QpStatus::DualInfeasible)
+    is_solved(s)
+        || matches!(
+            s,
+            QpStatus::PrimalInfeasible | QpStatus::DualInfeasible | QpStatus::TimeLimit
+        )
 }
 
 /// May this attempt spend a second solve on the objective-free feasibility twin
@@ -460,6 +495,7 @@ where
     };
 
     let qopts = ActiveSetOptions {
+        time_limit: crate::deadline::remaining(),
         max_iter: active_set_iter_budget(opts, n, m),
         // Absorb working-set changes as rank-2 Schur updates against a cached
         // factor instead of assembling and factoring a fresh active-set KKT
@@ -898,6 +934,7 @@ fn verify_status(
         // the acceptable tier (the IPM salvages solves this way), but it is
         // never promoted to a clean `Optimal`.
         ActiveSetStatus::MaxIter => solved_to(err).unwrap_or(QpStatus::IterationLimit),
+        ActiveSetStatus::TimeLimit => QpStatus::TimeLimit,
         ActiveSetStatus::NumericalError => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
     }
 }

--- a/crates/pounce-convex/src/active_set.rs
+++ b/crates/pounce-convex/src/active_set.rs
@@ -197,10 +197,10 @@ where
             solve_qp_active_set_inner(prob, opts, engine, make_backend),
         );
         if crate::deadline::expired() {
-            QpSolution {
-                status: QpStatus::TimeLimit,
-                ..sol
-            }
+            // Shared policy with the IPM path: a deadline crossing observed
+            // *after* the inner solve returned relabels a give-up status, but
+            // never overwrites a verdict. See [`crate::ipm::mark_timed_out`].
+            crate::ipm::mark_timed_out(sol)
         } else {
             sol
         }
@@ -271,10 +271,7 @@ where
         return sol;
     }
     if crate::deadline::expired() {
-        return QpSolution {
-            status: QpStatus::TimeLimit,
-            ..sol
-        };
+        return crate::ipm::mark_timed_out(sol);
     }
 
     let mut best = sol;
@@ -306,10 +303,7 @@ where
             return best;
         }
         if crate::deadline::expired() {
-            return QpSolution {
-                status: QpStatus::TimeLimit,
-                ..best
-            };
+            return crate::ipm::mark_timed_out(best);
         }
     }
 
@@ -339,10 +333,7 @@ where
     // attempt was seeded and there is nothing new to try.
     if engine.use_homotopy != Some(false) {
         if crate::deadline::expired() {
-            return QpSolution {
-                status: QpStatus::TimeLimit,
-                ..best
-            };
+            return crate::ipm::mark_timed_out(best);
         }
         let seeded_engine = ActiveSetOverrides {
             use_homotopy: Some(false),
@@ -934,7 +925,14 @@ fn verify_status(
         // the acceptable tier (the IPM salvages solves this way), but it is
         // never promoted to a clean `Optimal`.
         ActiveSetStatus::MaxIter => solved_to(err).unwrap_or(QpStatus::IterationLimit),
-        ActiveSetStatus::TimeLimit => QpStatus::TimeLimit,
+        // The wall clock is a budget like the iteration cap, and is salvaged the
+        // same way: `solved_to` re-derives the KKT error against the original
+        // problem, so a cancelled solve that had in fact already reached the
+        // answer reports it. Discarding the point because of *when* the engine
+        // stopped — while keeping the identical point when it stopped for
+        // running out of iterations — is the same verdict erasure
+        // [`crate::ipm::mark_timed_out`] exists to prevent, one layer down.
+        ActiveSetStatus::TimeLimit => solved_to(err).unwrap_or(QpStatus::TimeLimit),
         ActiveSetStatus::NumericalError => solved_to(err).unwrap_or(QpStatus::NumericalFailure),
     }
 }
@@ -1633,5 +1631,68 @@ mod tests {
             );
             assert_eq!(isol.status, QpStatus::PrimalInfeasible, "ipm");
         }
+    }
+
+    /// The exact optimum of [`projection_qp`], as a solution the engine could
+    /// have been holding when it stopped.
+    fn projection_optimum() -> QpSolution {
+        QpSolution {
+            status: QpStatus::Optimal,
+            x: vec![2.5, 1.5],
+            y: vec![],
+            z: vec![1.0],
+            z_lb: vec![0.0; 2],
+            z_ub: vec![0.0; 2],
+            obj: -12.5,
+            iters: 0,
+            iterates: Vec::new(),
+        }
+    }
+
+    /// A cancelled solve is verified, not discarded.
+    ///
+    /// `verify_status` re-derives the KKT error against the original problem
+    /// for every engine status, so the point an engine happens to be holding
+    /// when it stops decides the verdict. Before this, `TimeLimit` alone
+    /// skipped that check: the identical point was reported `Optimal` when the
+    /// engine ran out of *iterations* and thrown away when it ran out of
+    /// *seconds*. Which budget expired is not a fact about the user's problem.
+    #[test]
+    fn a_cancelled_solve_still_gets_its_kkt_point_verified() {
+        let prob = projection_qp();
+        let opts = QpOptions::default();
+        let sol = projection_optimum();
+
+        assert_eq!(
+            verify_status(ActiveSetStatus::TimeLimit, None, &sol, &prob, &opts),
+            QpStatus::Optimal,
+            "an optimal point does not stop being optimal because the clock ran out"
+        );
+        // The iteration cap has always been salvaged this way; the two budgets
+        // must now reach the same verdict on the same point.
+        assert_eq!(
+            verify_status(ActiveSetStatus::MaxIter, None, &sol, &prob, &opts),
+            verify_status(ActiveSetStatus::TimeLimit, None, &sol, &prob, &opts),
+            "the two budgets must agree on an identical point"
+        );
+    }
+
+    /// The other half: salvage is earned, not assumed. A cancelled solve that
+    /// really was nowhere near the answer still reports `TimeLimit`.
+    #[test]
+    fn a_cancelled_solve_far_from_optimal_is_still_a_time_limit() {
+        let prob = projection_qp();
+        let opts = QpOptions::default();
+        let sol = QpSolution {
+            x: vec![0.0, 0.0],
+            z: vec![0.0],
+            obj: 0.0,
+            ..projection_optimum()
+        };
+
+        assert_eq!(
+            verify_status(ActiveSetStatus::TimeLimit, None, &sol, &prob, &opts),
+            QpStatus::TimeLimit
+        );
     }
 }

--- a/crates/pounce-convex/src/batch.rs
+++ b/crates/pounce-convex/src/batch.rs
@@ -42,6 +42,17 @@
 //! right choice when each individual factor is large enough to parallelize
 //! on its own. The `make_backend` factory is shared by reference and called
 //! once per instance, so it must be `Sync`.
+//!
+//! ## `time_limit` is **per instance**, not per batch
+//!
+//! Every entry point here forwards the same [`QpOptions`] to each solve, and
+//! each solve opens its own deadline scope — so `time_limit = 10s` over 100
+//! problems permits 1000 s of wall clock, not 10. That is the only coherent
+//! reading for [`solve_qp_batch_parallel`], where a shared clock would make
+//! which instances get cancelled depend on rayon's scheduling and so on the
+//! machine; it is kept for the sequential entry points too, so the meaning of
+//! the option does not change when a caller switches between them. A caller
+//! who wants a budget for the *batch* has to enforce it around the call.
 
 use crate::ipm::{QpOptions, QpWarmStart, solve_qp_ipm, solve_qp_ipm_warm};
 use crate::qp::{QpProblem, QpSolution};

--- a/crates/pounce-convex/src/crossover.rs
+++ b/crates/pounce-convex/src/crossover.rs
@@ -117,6 +117,12 @@ pub fn maybe_crossover<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    if crate::deadline::expired() {
+        return QpSolution {
+            status: QpStatus::TimeLimit,
+            ..sol
+        };
+    }
     // ---- Gate: pure LP, plausibly-optimal status, at least one constraint ----
     if !opts.crossover || !prob.p_lower.is_empty() {
         return sol;
@@ -143,7 +149,14 @@ where
     // degeneracy with Bland's rule — so it resolves the highly-degenerate NETLIB
     // GEN vertices (issue #133) that the active-set bridge below stalls on. On
     // any breakdown it returns `None` and we fall through to the bridge.
-    if let Some(v) = crate::simplex::crossover_simplex(prob, &sol, opts) {
+    let simplex = crate::simplex::crossover_simplex(prob, &sol, opts);
+    if crate::deadline::expired() {
+        return QpSolution {
+            status: QpStatus::TimeLimit,
+            ..sol
+        };
+    }
+    if let Some(v) = simplex {
         let candidate = QpSolution {
             status: QpStatus::Optimal,
             x: v.x,
@@ -243,6 +256,7 @@ where
 
     // ---- Solve (Bland keeps the degenerate pivot loop finite) ----
     let qopts = ActiveSetOptions {
+        time_limit: crate::deadline::remaining(),
         anti_cycling: AntiCyclingChoice::Bland,
         max_iter: CROSSOVER_MAX_ITER,
         ..ActiveSetOptions::default()
@@ -261,7 +275,19 @@ where
     let warm = warm_solver.solve_with_working_set(&qp, &working, &qopts);
     let qsol = match warm {
         Ok(q) if q.status == ActiveSetStatus::Optimal => q,
+        Ok(q) if q.status == ActiveSetStatus::TimeLimit => {
+            return QpSolution {
+                status: QpStatus::TimeLimit,
+                ..sol
+            };
+        }
         _ => {
+            if crate::deadline::expired() {
+                return QpSolution {
+                    status: QpStatus::TimeLimit,
+                    ..sol
+                };
+            }
             let mut cold_solver = ParametricActiveSetSolver::new(make_backend());
             let cold = cold_solver.solve(&qp, None, &qopts);
             match cold {

--- a/crates/pounce-convex/src/crossover.rs
+++ b/crates/pounce-convex/src/crossover.rs
@@ -117,11 +117,14 @@ pub fn maybe_crossover<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    // Out of budget: skip the refinement, exactly as every other abandonment
+    // path here does (`_ => return sol`). Crossover only ever *improves* the
+    // IPM's answer — restamping its status would turn "we declined to polish
+    // this optimum" into "this problem was not solved", discarding a result the
+    // IPM already produced. The entry point re-labels afterwards, and only when
+    // there is no verdict to lose (see [`crate::ipm::mark_timed_out`]).
     if crate::deadline::expired() {
-        return QpSolution {
-            status: QpStatus::TimeLimit,
-            ..sol
-        };
+        return sol;
     }
     // ---- Gate: pure LP, plausibly-optimal status, at least one constraint ----
     if !opts.crossover || !prob.p_lower.is_empty() {
@@ -151,10 +154,7 @@ where
     // any breakdown it returns `None` and we fall through to the bridge.
     let simplex = crate::simplex::crossover_simplex(prob, &sol, opts);
     if crate::deadline::expired() {
-        return QpSolution {
-            status: QpStatus::TimeLimit,
-            ..sol
-        };
+        return sol;
     }
     if let Some(v) = simplex {
         let candidate = QpSolution {
@@ -275,18 +275,12 @@ where
     let warm = warm_solver.solve_with_working_set(&qp, &working, &qopts);
     let qsol = match warm {
         Ok(q) if q.status == ActiveSetStatus::Optimal => q,
-        Ok(q) if q.status == ActiveSetStatus::TimeLimit => {
-            return QpSolution {
-                status: QpStatus::TimeLimit,
-                ..sol
-            };
-        }
+        // The purification ran out of budget mid-flight; `sol` is untouched and
+        // still the IPM's answer.
+        Ok(q) if q.status == ActiveSetStatus::TimeLimit => return sol,
         _ => {
             if crate::deadline::expired() {
-                return QpSolution {
-                    status: QpStatus::TimeLimit,
-                    ..sol
-                };
+                return sol;
             }
             let mut cold_solver = ParametricActiveSetSolver::new(make_backend());
             let cold = cold_solver.solve(&qp, None, &qopts);
@@ -352,6 +346,33 @@ mod tests {
 
     fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
         Box::new(FeralSolverInterface::new())
+    }
+
+    /// An expired budget makes crossover *decline to refine*; it must not cost
+    /// the caller the optimum the IPM already computed.
+    ///
+    /// Deterministic: the solve runs to `Optimal` with no limit, and only then
+    /// is `maybe_crossover` entered inside an already-expired deadline scope —
+    /// reproducing on demand the race the guard exists for (the deadline
+    /// crossing between the IPM converging and crossover starting).
+    #[test]
+    fn expired_budget_declines_crossover_without_losing_the_verdict() {
+        let prob = unique_vertex_lp();
+        let sol = solve_qp_ipm(&prob, &opts_on(), backend);
+        assert_eq!(sol.status, QpStatus::Optimal, "precondition");
+        let x = sol.x.clone();
+        let obj = sol.obj;
+
+        let out = crate::deadline::with_deadline(Some(std::time::Duration::ZERO), || {
+            maybe_crossover(&prob, sol, &opts_on(), &mut backend)
+        });
+        assert_eq!(
+            out.status,
+            QpStatus::Optimal,
+            "an expired budget restamped a solved LP as unsolved"
+        );
+        assert_eq!(out.x, x, "declining to refine must not disturb the iterate");
+        assert_eq!(out.obj, obj);
     }
 
     /// LP used across the sign/round-trip tests:

--- a/crates/pounce-convex/src/deadline.rs
+++ b/crates/pounce-convex/src/deadline.rs
@@ -1,0 +1,42 @@
+//! Solve-wide monotonic wall-clock deadline support.
+
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+thread_local! {
+    static DEADLINE: Cell<Option<Instant>> = const { Cell::new(None) };
+}
+
+pub(crate) fn with_deadline<T>(limit: Option<Duration>, f: impl FnOnce() -> T) -> T {
+    DEADLINE.with(|slot| {
+        if slot.get().is_some() {
+            return f();
+        }
+        let now = Instant::now();
+        let deadline = limit.and_then(|d| now.checked_add(d));
+        slot.set(deadline);
+        struct Reset<'a>(&'a Cell<Option<Instant>>);
+        impl Drop for Reset<'_> {
+            fn drop(&mut self) {
+                self.0.set(None);
+            }
+        }
+        let _reset = Reset(slot);
+        f()
+    })
+}
+
+#[inline]
+pub(crate) fn expired() -> bool {
+    DEADLINE.with(|slot| {
+        slot.get()
+            .is_some_and(|deadline| Instant::now() >= deadline)
+    })
+}
+
+pub(crate) fn remaining() -> Option<Duration> {
+    DEADLINE.with(|slot| {
+        slot.get()
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+    })
+}

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -1046,7 +1046,11 @@ where
         }
     }
 
-    if crate::deadline::expired() {
+    // `!is_verdict`: the loop breaks with `Optimal` as soon as its convergence
+    // test passes, and the deadline can cross during the un-homogenization and
+    // verdict work below. A conclusion this solve actually reached outranks the
+    // clock — see [`crate::ipm::mark_timed_out`].
+    if crate::deadline::expired() && !crate::ipm::is_verdict(status) {
         status = QpStatus::TimeLimit;
     }
 
@@ -1090,11 +1094,13 @@ where
     // would otherwise have no answer.
     if matches!(
         status,
-        QpStatus::NumericalFailure | QpStatus::IterationLimit
+        QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::TimeLimit
     ) {
         // `x`/`y`/`z` are already un-homogenized above, hence `τ = 1`. Strictly
         // an upgrade: a point that fails both bands leaves the loop's own
-        // verdict (breakdown *or* iteration limit) untouched.
+        // verdict (breakdown, iteration limit, *or* cancellation) untouched.
+        // `TimeLimit` qualifies for the same reason the other two do — it says
+        // the loop stopped, not that the point it stopped on is unusable.
         status = match true_kkt_error(prob, cone, &x, &y, &z, 1.0) {
             Some(e) if e < opts.tol => QpStatus::Optimal,
             Some(e) if e < 1e3 * opts.tol => QpStatus::OptimalInaccurate,

--- a/crates/pounce-convex/src/hsde.rs
+++ b/crates/pounce-convex/src/hsde.rs
@@ -338,6 +338,9 @@ pub(crate) fn solve_conic_hsde<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    if crate::deadline::expired() {
+        return timed_out(prob);
+    }
     let n = prob.n;
     let m_eq = prob.m_eq();
     let m_ineq = prob.m_ineq();
@@ -347,6 +350,9 @@ where
         Ok(pair) => pair,
         Err(()) => return failed(prob),
     };
+    if crate::deadline::expired() {
+        return timed_out(prob);
+    }
 
     // Constant border data: −b, −h (so `build_rhs` yields the `(−c, b, h)`
     // right-hand side of the constant direction `p`).
@@ -424,6 +430,10 @@ where
 
     for it in 0..opts.max_iter {
         iters = it;
+        if crate::deadline::expired() {
+            status = QpStatus::TimeLimit;
+            break;
+        }
 
         // --- quadratic-objective coupling: Px and xᵀPx (zero for an LP) ---
         for v in px_vec.iter_mut() {
@@ -998,6 +1008,10 @@ where
         }
         tau += alpha * dtau;
         kappa += alpha * dkappa;
+        if crate::deadline::expired() {
+            status = QpStatus::TimeLimit;
+            break;
+        }
 
         // Debugger checkpoint: the new homogeneous iterate is in place.
         if hook.is_some() {
@@ -1030,6 +1044,10 @@ where
                 break;
             }
         }
+    }
+
+    if crate::deadline::expired() {
+        status = QpStatus::TimeLimit;
     }
 
     // Un-homogenize: divide by τ to recover the original-space solution.
@@ -1144,6 +1162,20 @@ fn failed(prob: &QpProblem) -> QpSolution {
     }
 }
 
+fn timed_out(prob: &QpProblem) -> QpSolution {
+    QpSolution {
+        status: QpStatus::TimeLimit,
+        x: vec![0.0; prob.n],
+        y: vec![0.0; prob.m_eq()],
+        z: vec![0.0; prob.m_ineq()],
+        z_lb: vec![0.0; prob.n],
+        z_ub: vec![0.0; prob.n],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1162,6 +1194,28 @@ mod tests {
             max_iter: 200,
             ..QpOptions::default()
         }
+    }
+
+    #[test]
+    fn zero_duration_is_authoritative_in_symmetric_hsde() {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![1.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![],
+            lb: vec![],
+            ub: vec![],
+        };
+        let cone = CompositeCone::single_nonneg(0);
+        let mut o = opts();
+        o.time_limit = Some(std::time::Duration::ZERO);
+        let sol = crate::deadline::with_deadline(o.time_limit, || {
+            solve_conic_hsde(&prob, &cone, &o, backend, None)
+        });
+        assert_eq!(sol.status, QpStatus::TimeLimit);
     }
 
     /// Solve the same (P=0) problem with the HSDE driver and the direct

--- a/crates/pounce-convex/src/hsde_nonsym.rs
+++ b/crates/pounce-convex/src/hsde_nonsym.rs
@@ -1255,6 +1255,9 @@ fn run_nonsym<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    if crate::deadline::expired() {
+        return timed_out(prob);
+    }
     let n = prob.n;
     let m_eq = prob.m_eq();
     let m_ineq = prob.m_ineq();
@@ -1285,6 +1288,9 @@ where
         Ok(f) => f,
         Err(_) => return failed(prob),
     };
+    if crate::deadline::expired() {
+        return timed_out(prob);
+    }
 
     let neg_b: Vec<f64> = prob.b.iter().map(|v| -v).collect();
     let neg_h: Vec<f64> = prob.h.iter().map(|v| -v).collect();
@@ -1341,6 +1347,10 @@ where
 
     for it in 0..opts.max_iter {
         iters = it;
+        if crate::deadline::expired() {
+            status = QpStatus::TimeLimit;
+            break;
+        }
 
         for v in px_vec.iter_mut() {
             *v = 0.0;
@@ -1618,6 +1628,10 @@ where
         }
         tau += alpha * dtau;
         kappa += alpha * dkappa;
+        if crate::deadline::expired() {
+            status = QpStatus::TimeLimit;
+            break;
+        }
 
         // Debugger checkpoint: the new homogeneous iterate is in place.
         if hook.is_some() {
@@ -1649,6 +1663,10 @@ where
                 break;
             }
         }
+    }
+
+    if crate::deadline::expired() {
+        status = QpStatus::TimeLimit;
     }
 
     // Reduced-accuracy acceptance. If the driver broke down or hit the cap
@@ -1812,7 +1830,9 @@ pub fn solve_conic_hsde_nonsym<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    run_nonsym(prob, specs, opts, None, make_backend, None)
+    crate::deadline::with_deadline(opts.time_limit, || {
+        run_nonsym(prob, specs, opts, None, make_backend, None)
+    })
 }
 
 /// Debug-enabled [`solve_conic_hsde_nonsym`]: fires the interactive
@@ -1830,7 +1850,9 @@ pub fn solve_conic_hsde_nonsym_debug<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    run_nonsym(prob, specs, opts, None, make_backend, Some(hook))
+    crate::deadline::with_deadline(opts.time_limit, || {
+        run_nonsym(prob, specs, opts, None, make_backend, Some(hook))
+    })
 }
 
 /// Warm-started [`solve_conic_hsde_nonsym`]: seed the primal `x` from `warm_x`
@@ -1848,7 +1870,9 @@ pub fn solve_conic_hsde_nonsym_warm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    run_nonsym(prob, specs, opts, Some(warm_x), make_backend, None)
+    crate::deadline::with_deadline(opts.time_limit, || {
+        run_nonsym(prob, specs, opts, Some(warm_x), make_backend, None)
+    })
 }
 
 fn failed(prob: &QpProblem) -> QpSolution {
@@ -1859,6 +1883,20 @@ fn failed(prob: &QpProblem) -> QpSolution {
         // Trivial dual: `z = 0` (the cone apex) is valid in every dual cone,
         // unlike the all-ones vector, which is not a member of an SOC of
         // dimension ≥ 3. Matches `ipm::failed_solution`.
+        z: vec![0.0; prob.m_ineq()],
+        z_lb: vec![0.0; prob.n],
+        z_ub: vec![0.0; prob.n],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    }
+}
+
+fn timed_out(prob: &QpProblem) -> QpSolution {
+    QpSolution {
+        status: QpStatus::TimeLimit,
+        x: vec![0.0; prob.n],
+        y: vec![0.0; prob.m_eq()],
         z: vec![0.0; prob.m_ineq()],
         z_lb: vec![0.0; prob.n],
         z_ub: vec![0.0; prob.n],
@@ -1883,6 +1921,25 @@ mod tests {
             max_iter: 200,
             ..QpOptions::default()
         }
+    }
+
+    #[test]
+    fn zero_duration_is_authoritative_in_nonsymmetric_hsde() {
+        let prob = QpProblem {
+            n: 1,
+            p_lower: vec![],
+            c: vec![0.0],
+            a: vec![],
+            b: vec![],
+            g: vec![],
+            h: vec![0.0; 3],
+            lb: vec![],
+            ub: vec![],
+        };
+        let mut o = opts();
+        o.time_limit = Some(std::time::Duration::ZERO);
+        let sol = solve_conic_hsde_nonsym(&prob, &[NsBlock::exp()], &o, backend);
+        assert_eq!(sol.status, QpStatus::TimeLimit);
     }
 
     /// An exponential cone is always 3 rows. Declaring it over a `G` with

--- a/crates/pounce-convex/src/hsde_nonsym.rs
+++ b/crates/pounce-convex/src/hsde_nonsym.rs
@@ -1665,7 +1665,11 @@ where
         }
     }
 
-    if crate::deadline::expired() {
+    // `!is_verdict`: the loop breaks with `Optimal` the moment its convergence
+    // test passes, and the deadline can cross in the adjudication work below.
+    // A conclusion this solve actually reached outranks the clock — see
+    // [`crate::ipm::mark_timed_out`].
+    if crate::deadline::expired() && !crate::ipm::is_verdict(status) {
         status = QpStatus::TimeLimit;
     }
 
@@ -1705,9 +1709,15 @@ where
     // terminate with a certificate status (`PrimalInfeasible` / `DualInfeasible`)
     // and never reach here; a τ → 0 ray or an out-of-`K*` dual returns `None`
     // from the certificate and is never promoted.
+    // `TimeLimit` joins the set for the same reason `IterationLimit` is in it:
+    // both say the loop stopped, neither says the point it stopped on is
+    // unusable, and the adjudication below only ever upgrades.
     if matches!(
         status,
-        QpStatus::OptimalInaccurate | QpStatus::NumericalFailure | QpStatus::IterationLimit
+        QpStatus::OptimalInaccurate
+            | QpStatus::NumericalFailure
+            | QpStatus::IterationLimit
+            | QpStatus::TimeLimit
     ) {
         let reduced_acc = opts.tol.sqrt();
 

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -329,6 +329,14 @@ where
     // strict improvement. Runs against the same un-equilibrated `prob` so the
     // `z`/`s` conventions line up. See [`crate::crossover`].
     let sol = crate::crossover::maybe_crossover(prob, sol, opts, &mut make_backend);
+    // Crossover declines rather than restamps when the budget runs out mid-
+    // refinement, so account for a deadline crossed in there here — where
+    // `mark_timed_out`'s verdict rule applies and an `Optimal` cannot be lost.
+    let sol = if crate::deadline::expired() {
+        mark_timed_out(sol)
+    } else {
+        sol
+    };
     finite_or_failed(prob, sol)
 }
 
@@ -2428,7 +2436,11 @@ fn run_ipm(
         }
     }
 
-    if crate::deadline::expired() {
+    // `!is_verdict`: the loop breaks with `Optimal` the moment its convergence
+    // test passes, and the deadline can cross in the residual/objective work
+    // that follows. Stamping `TimeLimit` over that conclusion would throw away
+    // an answer this solve *did* reach — see [`mark_timed_out`].
+    if crate::deadline::expired() && !is_verdict(status) {
         status = QpStatus::TimeLimit;
     }
 
@@ -2436,9 +2448,15 @@ fn run_ipm(
     // same rule the HSDE driver applies (see `VERDICT` in `hsde.rs`), so the two
     // drivers cannot drift apart on whether a solve that ended without its own
     // verdict actually produced an answer. Strictly an upgrade.
+    //
+    // `TimeLimit` belongs in this set for the same reason `IterationLimit`
+    // does: all three are "stopped without concluding", and a cancelled solve
+    // whose last iterate happens to satisfy the KKT conditions to `tol` has an
+    // answer sitting right there. Excluding it would report `TimeLimit` on a
+    // point this very block is about to certify as optimal.
     if matches!(
         status,
-        QpStatus::NumericalFailure | QpStatus::IterationLimit
+        QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::TimeLimit
     ) {
         let candidate = QpSolution {
             status,
@@ -2752,9 +2770,40 @@ fn timed_out_solution(prob: &QpProblem) -> QpSolution {
     }
 }
 
+/// Label a *finished* solve as cancelled — but never at the cost of a verdict.
+///
+/// Every caller runs this after an inner solve has already returned, so `sol`
+/// may well carry a real answer: the deadline crossing that brought us here can
+/// land in the instant *between* convergence and the check. Overwriting an
+/// `Optimal` (or a verified infeasible/unbounded certificate) with `TimeLimit`
+/// there does not report a timeout, it discards a correct result — the user
+/// whose problem solves in 1.001 s under `time_limit = 1` loses the optimum they
+/// in fact computed, and every consumer downstream (the CLI's status mapping,
+/// the SQP fallback) reads a non-answer.
+///
+/// So only a *non-verdict* status is relabelled. `IterationLimit` and
+/// `NumericalFailure` describe a solve that stopped without concluding
+/// anything, and for those "the clock ran out" is the more useful account of
+/// why; `Optimal`, `OptimalInaccurate`, and the two certificates are
+/// conclusions, and they stand.
 fn mark_timed_out(mut sol: QpSolution) -> QpSolution {
-    sol.status = QpStatus::TimeLimit;
+    if !is_verdict(sol.status) {
+        sol.status = QpStatus::TimeLimit;
+    }
     sol
+}
+
+/// True when the status is a *conclusion about the problem* rather than a
+/// record of the solver giving up — i.e. something a deadline crossing must not
+/// erase. See [`mark_timed_out`].
+pub(crate) fn is_verdict(status: QpStatus) -> bool {
+    matches!(
+        status,
+        QpStatus::Optimal
+            | QpStatus::OptimalInaccurate
+            | QpStatus::PrimalInfeasible
+            | QpStatus::DualInfeasible
+    )
 }
 
 /// Build a `PrimalInfeasible` solution reported by a **setup-time** screen —
@@ -4046,7 +4095,7 @@ mod false_optimum_metric_tests {
 mod finite_guard_tests {
     //! gh #491: a non-finite entry never leaves the crate.
 
-    use super::finite_or_failed;
+    use super::{finite_or_failed, mark_timed_out};
     use crate::qp::{QpProblem, QpSolution, QpStatus, Triplet};
 
     fn prob() -> QpProblem {
@@ -4120,6 +4169,39 @@ mod finite_guard_tests {
             );
             assert_eq!(out.x, vec![0.0, 0.0], "case {i}");
             assert_eq!(out.iters, 7, "case {i}: the iteration count is kept");
+        }
+    }
+
+    /// A deadline crossing can only ever *land on* a finished solve — every
+    /// caller of [`mark_timed_out`] runs after an inner solve returned. So a
+    /// conclusion the solve actually reached must survive it: the user whose
+    /// problem converges a millisecond past `time_limit` gets the optimum they
+    /// computed, not a report that nothing was solved.
+    #[test]
+    fn a_verdict_outranks_the_clock() {
+        for status in [
+            QpStatus::Optimal,
+            QpStatus::OptimalInaccurate,
+            QpStatus::PrimalInfeasible,
+            QpStatus::DualInfeasible,
+        ] {
+            let s = sol(status, vec![0.25, 0.75], -0.5);
+            let out = mark_timed_out(s.clone());
+            assert_eq!(out.status, status, "a timeout erased a {status:?} verdict");
+            assert_eq!(out.x, s.x, "and it must not disturb the iterate");
+        }
+    }
+
+    /// The other half of the rule: a solve that stopped *without* concluding
+    /// anything is relabelled, because "the clock ran out" is the more useful
+    /// account of why it stopped.
+    #[test]
+    fn a_non_verdict_is_relabelled_as_cancelled() {
+        for status in [QpStatus::IterationLimit, QpStatus::NumericalFailure] {
+            let s = sol(status, vec![0.25, 0.75], -0.5);
+            let out = mark_timed_out(s.clone());
+            assert_eq!(out.status, QpStatus::TimeLimit, "from {status:?}");
+            assert_eq!(out.x, s.x, "the best iterate is still worth returning");
         }
     }
 }

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -2786,7 +2786,7 @@ fn timed_out_solution(prob: &QpProblem) -> QpSolution {
 /// anything, and for those "the clock ran out" is the more useful account of
 /// why; `Optimal`, `OptimalInaccurate`, and the two certificates are
 /// conclusions, and they stand.
-fn mark_timed_out(mut sol: QpSolution) -> QpSolution {
+pub(crate) fn mark_timed_out(mut sol: QpSolution) -> QpSolution {
     if !is_verdict(sol.status) {
         sol.status = QpStatus::TimeLimit;
     }

--- a/crates/pounce-convex/src/ipm.rs
+++ b/crates/pounce-convex/src/ipm.rs
@@ -54,6 +54,7 @@ use pounce_common::debug::{Checkpoint, DebugAction, DebugHook};
 use pounce_common::types::{Index, Number};
 use pounce_linsol::{Factorization, SparseSymLinearSolverInterface};
 use std::collections::BTreeMap;
+use std::time::Duration;
 
 /// Tolerance on the **residual** of an infeasibility/unboundedness
 /// certificate's defining equation (`‖Aᵀy+Gᵀz‖` for a Farkas pair,
@@ -118,6 +119,10 @@ fn adaptive_tau(mu: f64, opts: &QpOptions) -> f64 {
 /// Options for the QP interior-point solve.
 #[derive(Debug, Clone, Copy)]
 pub struct QpOptions {
+    /// Solve-wide wall-clock budget. Retries, fallback engines, and crossover
+    /// share one monotonic deadline. An in-flight backend factorization is not
+    /// interrupted, so expiration may overshoot by one such operation.
+    pub time_limit: Option<Duration>,
     /// Convergence tolerance on the max KKT residual and duality measure.
     pub tol: f64,
     /// Maximum iterations.
@@ -246,6 +251,7 @@ pub struct QpOptions {
 impl Default for QpOptions {
     fn default() -> Self {
         QpOptions {
+            time_limit: None,
             tol: 1e-8,
             max_iter: 200,
             tau: 0.95,
@@ -281,7 +287,19 @@ pub fn solve_qp_ipm<F>(prob: &QpProblem, opts: &QpOptions, make_backend: F) -> Q
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    crate::deadline::with_deadline(opts.time_limit, || {
+        solve_qp_ipm_scoped(prob, opts, make_backend)
+    })
+}
+
+fn solve_qp_ipm_scoped<F>(prob: &QpProblem, opts: &QpOptions, make_backend: F) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
     let mut make_backend = make_backend;
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
     // Screen the variable box before bound expansion (gh #295, gh #491):
     // `expand_bounds` is sign-agnostic, so a *present* `+∞` lower / `−∞` upper
     // bound would be mishandled as an *absent* one and a violating point
@@ -302,6 +320,9 @@ where
     // Interior-point solve in the original problem's coordinates (the core
     // already unscales any internal Ruiz equilibration before returning).
     let sol = solve_qp_ipm_core(prob, opts, &mut make_backend);
+    if crate::deadline::expired() {
+        return mark_timed_out(sol);
+    }
     // LP-crossover refinement: for a pure LP, purify the interior iterate to an
     // exact optimal vertex via the active-set engine. Gated to pure LPs and
     // never-regressing — a no-op for QPs and whenever the vertex is not a
@@ -385,6 +406,9 @@ where
         QpStatus::NumericalFailure | QpStatus::IterationLimit | QpStatus::OptimalInaccurate
     );
     if opts.use_hsde && opts.equilibrate && retry_on {
+        if crate::deadline::expired() {
+            return mark_timed_out(sol);
+        }
         let retry = equilibrated_solve(prob, opts, /* use_hsde */ true, &mut make_backend);
         let accept = match sol.status {
             QpStatus::NumericalFailure => retry.status != QpStatus::NumericalFailure,
@@ -423,6 +447,9 @@ where
         && sol.status == QpStatus::DualInfeasible
         && prob.p_lower.iter().any(|t| t.val != 0.0)
     {
+        if crate::deadline::expired() {
+            return mark_timed_out(sol);
+        }
         let verify = equilibrated_solve(prob, opts, /* use_hsde */ false, &mut make_backend);
         if verify.status == QpStatus::Optimal {
             return verify;
@@ -463,6 +490,9 @@ where
     // cannot re-enter this branch: with `c = 0` no direction has `cᵀd < 0`, so
     // `DualInfeasible` is unreachable for it.
     if sol.status == QpStatus::DualInfeasible {
+        if crate::deadline::expired() {
+            return mark_timed_out(sol);
+        }
         let twin = QpProblem {
             p_lower: Vec::new(),
             c: vec![0.0; prob.n],
@@ -699,11 +729,28 @@ pub fn solve_qp_ipm_debug<F>(
     prob: &QpProblem,
     opts: &QpOptions,
     hook: &mut dyn DebugHook,
+    make_backend: F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    crate::deadline::with_deadline(opts.time_limit, || {
+        solve_qp_ipm_debug_scoped(prob, opts, hook, make_backend)
+    })
+}
+
+fn solve_qp_ipm_debug_scoped<F>(
+    prob: &QpProblem,
+    opts: &QpOptions,
+    hook: &mut dyn DebugHook,
     mut make_backend: F,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
     // Screen the variable box before bound expansion, as the non-debug path
     // does (gh #295, gh #491).
     let snapped;
@@ -762,11 +809,22 @@ pub fn solve_qp_ipm_warm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    // One gate over every exit of the body below — see [`finite_or_failed`].
-    finite_or_failed(
-        prob,
-        solve_qp_ipm_warm_inner(prob, opts, warm, make_backend),
-    )
+    crate::deadline::with_deadline(opts.time_limit, || {
+        if crate::deadline::expired() {
+            timed_out_solution(prob)
+        } else {
+            // One gate over every exit of the body below — see [`finite_or_failed`].
+            let sol = finite_or_failed(
+                prob,
+                solve_qp_ipm_warm_inner(prob, opts, warm, make_backend),
+            );
+            if crate::deadline::expired() {
+                mark_timed_out(sol)
+            } else {
+                sol
+            }
+        }
+    })
 }
 
 fn solve_qp_ipm_warm_inner<F>(
@@ -848,8 +906,19 @@ pub fn solve_socp_ipm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
-    // One gate over every exit of the body below — see [`finite_or_failed`].
-    finite_or_failed(prob, solve_socp_ipm_inner(prob, cones, opts, make_backend))
+    crate::deadline::with_deadline(opts.time_limit, || {
+        if crate::deadline::expired() {
+            timed_out_solution(prob)
+        } else {
+            // One gate over every exit of the body below — see [`finite_or_failed`].
+            let sol = finite_or_failed(prob, solve_socp_ipm_inner(prob, cones, opts, make_backend));
+            if crate::deadline::expired() {
+                mark_timed_out(sol)
+            } else {
+                sol
+            }
+        }
+    })
 }
 
 fn solve_socp_ipm_inner<F>(
@@ -993,11 +1062,29 @@ pub fn solve_socp_ipm_debug<F>(
     cones: &[ConeSpec],
     opts: &QpOptions,
     hook: &mut dyn DebugHook,
+    make_backend: F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    crate::deadline::with_deadline(opts.time_limit, || {
+        solve_socp_ipm_debug_scoped(prob, cones, opts, hook, make_backend)
+    })
+}
+
+fn solve_socp_ipm_debug_scoped<F>(
+    prob: &QpProblem,
+    cones: &[ConeSpec],
+    opts: &QpOptions,
+    hook: &mut dyn DebugHook,
     mut make_backend: F,
 ) -> QpSolution
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
     if !cone_dims_cover(cones, prob.m_ineq()) {
         return failed_solution(
             prob,
@@ -1448,6 +1535,24 @@ pub fn solve_socp_ipm_warm<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    crate::deadline::with_deadline(opts.time_limit, || {
+        solve_socp_ipm_warm_scoped(prob, cones, warm, opts, make_backend)
+    })
+}
+
+fn solve_socp_ipm_warm_scoped<F>(
+    prob: &QpProblem,
+    cones: &[ConeSpec],
+    warm: &QpWarmStart,
+    opts: &QpOptions,
+    make_backend: F,
+) -> QpSolution
+where
+    F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
+{
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
     assert!(
         !prob.has_bounds(),
         "solve_socp_ipm_warm: encode bounds as G/h rows (bound expansion + warm not combined)"
@@ -1758,6 +1863,9 @@ fn solve_qp_core<F>(
 where
     F: FnMut() -> Box<dyn SparseSymLinearSolverInterface>,
 {
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
     // Opt-in homogeneous self-dual embedding driver. It builds its own
     // factorization and self-starts, so it bypasses the warm-start /
     // factor-reuse plumbing below (warm is ignored — it cannot change the
@@ -1833,6 +1941,9 @@ where
             );
         }
     };
+    if crate::deadline::expired() {
+        return timed_out_solution(prob);
+    }
     run_ipm(prob, cone, opts, &kkt, &mut fact, warm, None)
 }
 
@@ -2018,6 +2129,10 @@ fn run_ipm(
 
     for it in 0..opts.max_iter {
         iters = it;
+        if crate::deadline::expired() {
+            status = QpStatus::TimeLimit;
+            break;
+        }
 
         // --- residuals (unregularized; this is the convergence test) ---
         // r_d = P x + c + Aᵀ y + Gᵀ z
@@ -2267,6 +2382,10 @@ fn run_ipm(
             s[i] += step_p * ds[i];
             z[i] += step_d * dz[i];
         }
+        if crate::deadline::expired() {
+            status = QpStatus::TimeLimit;
+            break;
+        }
 
         // Debugger checkpoint: the new iterate is in place.
         if hook.is_some() {
@@ -2307,6 +2426,10 @@ fn run_ipm(
                 alpha_dual: step_d,
             });
         }
+    }
+
+    if crate::deadline::expired() {
+        status = QpStatus::TimeLimit;
     }
 
     // Final verdict from the true KKT error of the point being returned — the
@@ -2447,7 +2570,14 @@ impl QpFactorization {
     /// share the captured structure (see the type docs); otherwise a
     /// `NumericalFailure` solution is returned.
     pub fn solve(&mut self, prob: &QpProblem) -> QpSolution {
-        self.solve_inner(prob, None)
+        crate::deadline::with_deadline(self.opts.time_limit, || {
+            let sol = self.solve_inner(prob, None);
+            if crate::deadline::expired() {
+                mark_timed_out(sol)
+            } else {
+                sol
+            }
+        })
     }
 
     /// Solve `prob` reusing the captured symbolic factor **and** warm
@@ -2456,6 +2586,10 @@ impl QpFactorization {
     /// and the interior-point iteration is seeded from the warm point (see
     /// [`QpWarmStart`]). Same structure requirement as [`Self::solve`].
     pub fn solve_warm(&mut self, prob: &QpProblem, warm: &QpWarmStart) -> QpSolution {
+        crate::deadline::with_deadline(self.opts.time_limit, || self.solve_warm_scoped(prob, warm))
+    }
+
+    fn solve_warm_scoped(&mut self, prob: &QpProblem, warm: &QpWarmStart) -> QpSolution {
         let (expanded_z, _) = if prob.has_bounds() {
             // `merge_bound_duals` needs the bound-row provenance.
             let (_, bound_rows) = expand_bounds(prob);
@@ -2468,7 +2602,12 @@ impl QpFactorization {
             y: warm.y.clone(),
             z: expanded_z,
         };
-        self.solve_inner(prob, Some(&w))
+        let sol = self.solve_inner(prob, Some(&w));
+        if crate::deadline::expired() {
+            mark_timed_out(sol)
+        } else {
+            sol
+        }
     }
 
     fn solve_inner(&mut self, prob: &QpProblem, warm: Option<&WarmStart>) -> QpSolution {
@@ -2526,7 +2665,8 @@ fn cone_dims_cover(cones: &[ConeSpec], m_ineq: usize) -> bool {
 /// keeps the reported dual cone-feasible and consistent across all drivers
 /// (cf. `hsde::failed`, `hsde_nonsym::failed`).
 /// Last gate before a solution leaves the crate: a non-finite entry anywhere
-/// in it is replaced by an honest zero-filled `NumericalFailure`.
+/// in it is replaced by an honest zero-filled `NumericalFailure` (or a
+/// zero-filled `TimeLimit` when the deadline is the authoritative verdict).
 ///
 /// A `NaN` in the returned iterate is never information. It cannot be checked
 /// against a bound, printed into a `.sol`, or fed to a warm start, and every
@@ -2558,6 +2698,11 @@ pub(crate) fn finite_or_failed(prob: &QpProblem, sol: QpSolution) -> QpSolution 
         return sol;
     }
     let iters = sol.iters;
+    if sol.status == QpStatus::TimeLimit {
+        let mut timed_out = timed_out_solution(prob);
+        timed_out.iters = iters;
+        return timed_out;
+    }
     failed_solution(
         prob,
         vec![0.0; prob.n],
@@ -2591,6 +2736,25 @@ fn failed_solution(
         iters,
         iterates: Vec::new(),
     }
+}
+
+fn timed_out_solution(prob: &QpProblem) -> QpSolution {
+    QpSolution {
+        status: QpStatus::TimeLimit,
+        x: vec![0.0; prob.n],
+        y: vec![0.0; prob.m_eq()],
+        z: vec![0.0; prob.m_ineq()],
+        z_lb: vec![0.0; prob.n],
+        z_ub: vec![0.0; prob.n],
+        obj: 0.0,
+        iters: 0,
+        iterates: Vec::new(),
+    }
+}
+
+fn mark_timed_out(mut sol: QpSolution) -> QpSolution {
+    sol.status = QpStatus::TimeLimit;
+    sol
 }
 
 /// Build a `PrimalInfeasible` solution reported by a **setup-time** screen —

--- a/crates/pounce-convex/src/lib.rs
+++ b/crates/pounce-convex/src/lib.rs
@@ -28,6 +28,7 @@ pub(crate) mod aggregate;
 pub mod batch;
 pub mod cones;
 pub mod crossover;
+mod deadline;
 pub(crate) mod debug;
 pub(crate) mod equilibrate;
 pub mod hsde;

--- a/crates/pounce-convex/src/qp.rs
+++ b/crates/pounce-convex/src/qp.rs
@@ -357,6 +357,9 @@ pub enum QpStatus {
     DualInfeasible,
     /// Iteration limit reached before convergence.
     IterationLimit,
+    /// The solve-wide wall-clock budget expired. The latest finite iterate is
+    /// returned when one is available.
+    TimeLimit,
     /// The KKT factorization failed (e.g. structurally singular system).
     NumericalFailure,
 }

--- a/crates/pounce-convex/src/simplex.rs
+++ b/crates/pounce-convex/src/simplex.rs
@@ -122,9 +122,15 @@ pub(crate) fn crossover_simplex(
     sol: &QpSolution,
     _opts: &QpOptions,
 ) -> Option<VertexSolution> {
+    if crate::deadline::expired() {
+        return None;
+    }
     let mut s = Simplex::new(prob);
     s.warm_start(sol);
     s.factor_basis()?;
+    if crate::deadline::expired() {
+        return None;
+    }
     s.recompute_basics()?; // slacks absorb the residual ⇒ feasible start
     s.push_superbasics()?; // drive interior structurals to bounds / into the basis
     s.run_phase1()?; // clean the residual bound infeasibility (e.g. eq artificials)
@@ -706,6 +712,9 @@ impl Simplex {
         let mut best_infeas = self.primal_infeasibility();
         let mut no_progress: u32 = 0;
         for _it in 0..max_iter {
+            if crate::deadline::expired() {
+                return None;
+            }
             if dbg && _it % 100 == 0 {
                 eprintln!(
                     "[simplex p1] it={_it} infeas={:.3e} bland={}",
@@ -777,6 +786,9 @@ impl Simplex {
         self.stall = 0;
         let cost = self.cost.clone();
         for _ in 0..max_iter {
+            if crate::deadline::expired() {
+                return None;
+            }
             let cb: Vec<f64> = (0..self.m).map(|slot| cost[self.basis[slot]]).collect();
             let pi = self.btran(&cb)?;
             let entering = self.price(&pi, &cost)?;

--- a/crates/pounce-convex/tests/bench293.rs
+++ b/crates/pounce-convex/tests/bench293.rs
@@ -248,6 +248,7 @@ fn scaling_corpus_reaches_every_oracle_optimum() {
         QpStatus::NumericalFailure => "NUMF",
         QpStatus::PrimalInfeasible => "PINF",
         QpStatus::DualInfeasible => "DINF",
+        QpStatus::TimeLimit => "TIME",
     };
 
     let cases = corpus();

--- a/crates/pounce-convex/tests/time_limit.rs
+++ b/crates/pounce-convex/tests/time_limit.rs
@@ -1,0 +1,132 @@
+use std::time::Duration;
+
+use pounce_convex::{
+    ActiveSetOverrides, ConeSpec, QpFactorization, QpOptions, QpProblem, QpStatus, Triplet,
+    solve_qp_active_set, solve_qp_batch, solve_qp_ipm, solve_socp_ipm,
+};
+use pounce_linsol::SparseSymLinearSolverInterface;
+
+fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
+    Box::new(pounce_feral::FeralSolverInterface::new())
+}
+
+fn qp() -> QpProblem {
+    QpProblem {
+        n: 1,
+        p_lower: vec![Triplet::new(0, 0, 2.0)],
+        c: vec![-2.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![],
+        lb: vec![0.0],
+        ub: vec![2.0],
+    }
+}
+
+fn zero(use_hsde: bool) -> QpOptions {
+    QpOptions {
+        time_limit: Some(Duration::ZERO),
+        use_hsde,
+        ..QpOptions::default()
+    }
+}
+
+#[test]
+fn zero_duration_stops_direct_and_symmetric_hsde() {
+    assert_eq!(
+        solve_qp_ipm(&qp(), &zero(false), backend).status,
+        QpStatus::TimeLimit
+    );
+    assert_eq!(
+        solve_qp_ipm(&qp(), &zero(true), backend).status,
+        QpStatus::TimeLimit
+    );
+}
+
+#[test]
+fn zero_duration_stops_symmetric_and_nonsymmetric_conic_routes() {
+    let symmetric = QpProblem {
+        n: 1,
+        p_lower: vec![],
+        c: vec![0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![Triplet::new(0, 0, -1.0)],
+        h: vec![1.0, 0.0],
+        lb: vec![],
+        ub: vec![],
+    };
+    assert_eq!(
+        solve_socp_ipm(
+            &symmetric,
+            &[ConeSpec::SecondOrder(2)],
+            &zero(true),
+            backend
+        )
+        .status,
+        QpStatus::TimeLimit
+    );
+
+    let nonsymmetric = QpProblem {
+        n: 1,
+        p_lower: vec![],
+        c: vec![0.0],
+        a: vec![],
+        b: vec![],
+        g: vec![],
+        h: vec![0.0; 3],
+        lb: vec![],
+        ub: vec![],
+    };
+    assert_eq!(
+        solve_socp_ipm(
+            &nonsymmetric,
+            &[ConeSpec::Exponential],
+            &zero(true),
+            backend
+        )
+        .status,
+        QpStatus::TimeLimit
+    );
+}
+
+#[test]
+fn zero_duration_stops_active_set_and_each_batch_item_independently() {
+    let mut mk = backend;
+    let active = solve_qp_active_set(&qp(), &zero(true), &ActiveSetOverrides::default(), &mut mk);
+    assert_eq!(active.status, QpStatus::TimeLimit);
+
+    let problems = vec![qp(), qp(), qp()];
+    let batch = solve_qp_batch(&problems, &zero(true), backend);
+    assert_eq!(batch.len(), problems.len());
+    assert!(batch.iter().all(|sol| sol.status == QpStatus::TimeLimit));
+}
+
+#[test]
+fn no_limit_preserves_normal_convergence() {
+    let sol = solve_qp_ipm(&qp(), &QpOptions::default(), backend);
+    assert_eq!(sol.status, QpStatus::Optimal);
+    assert!((sol.x[0] - 1.0).abs() < 1e-7);
+}
+
+#[test]
+fn no_limit_preserves_iteration_limit_status() {
+    let opts = QpOptions {
+        max_iter: 0,
+        time_limit: None,
+        ..QpOptions::default()
+    };
+    assert_eq!(
+        solve_qp_ipm(&qp(), &opts, backend).status,
+        QpStatus::IterationLimit
+    );
+}
+
+#[test]
+fn reusable_factorization_gives_each_solve_its_own_deadline() {
+    let opts = zero(false);
+    let mut factor = QpFactorization::build(&qp(), &opts, backend).expect("build factorization");
+    assert_eq!(factor.solve(&qp()).status, QpStatus::TimeLimit);
+    assert_eq!(factor.solve(&qp()).status, QpStatus::TimeLimit);
+}

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -188,6 +188,7 @@ fn status_str(s: QpStatus) -> &'static str {
         QpStatus::PrimalInfeasible => "primal_infeasible",
         QpStatus::DualInfeasible => "dual_infeasible",
         QpStatus::IterationLimit => "iteration_limit",
+        QpStatus::TimeLimit => "time_limit",
         QpStatus::NumericalFailure => "numerical_failure",
     }
 }

--- a/crates/pounce-py/src/sos.rs
+++ b/crates/pounce-py/src/sos.rs
@@ -28,6 +28,7 @@ fn status_str(s: QpStatus) -> &'static str {
         QpStatus::PrimalInfeasible => "primal_infeasible",
         QpStatus::DualInfeasible => "dual_infeasible",
         QpStatus::IterationLimit => "iteration_limit",
+        QpStatus::TimeLimit => "time_limit",
         QpStatus::NumericalFailure => "numerical_failure",
     }
 }

--- a/crates/pounce-qp/src/deadline.rs
+++ b/crates/pounce-qp/src/deadline.rs
@@ -1,8 +1,18 @@
+//! Solve-wide monotonic wall-clock deadline for the active-set solver.
+//!
+//! One deadline per *top-level* solve: the nested stages a solve can reach —
+//! homotopy, elastic phase-1, feasibility/recovery solves, seeded retries —
+//! share the outer budget instead of each restarting the duration.
+
 use std::cell::Cell;
 use std::time::{Duration, Instant};
 
 thread_local! {
     static DEADLINE: Cell<Option<Instant>> = const { Cell::new(None) };
+    /// When the owning scope started. Used only to report how long a
+    /// cancelled solve actually ran (`QpStats::time`), so a timeout is not
+    /// recorded as an instantaneous solve.
+    static SCOPE_START: Cell<Option<Instant>> = const { Cell::new(None) };
 }
 
 pub(crate) struct Guard {
@@ -17,6 +27,7 @@ pub(crate) fn enter(limit: Option<Duration>) -> Guard {
             let now = Instant::now();
             let deadline = limit.and_then(|d| now.checked_add(d));
             slot.set(deadline);
+            SCOPE_START.with(|s| s.set(Some(now)));
             true
         }
     });
@@ -27,6 +38,7 @@ impl Drop for Guard {
     fn drop(&mut self) {
         if self.owner {
             DEADLINE.with(|slot| slot.set(None));
+            SCOPE_START.with(|s| s.set(None));
         }
     }
 }
@@ -37,4 +49,10 @@ pub(crate) fn expired() -> bool {
         slot.get()
             .is_some_and(|deadline| Instant::now() >= deadline)
     })
+}
+
+/// Wall-clock time spent inside the current top-level solve, or
+/// [`Duration::ZERO`] when there is no active scope.
+pub(crate) fn scope_elapsed() -> Duration {
+    SCOPE_START.with(|s| s.get().map_or(Duration::ZERO, |start| start.elapsed()))
 }

--- a/crates/pounce-qp/src/deadline.rs
+++ b/crates/pounce-qp/src/deadline.rs
@@ -1,0 +1,40 @@
+use std::cell::Cell;
+use std::time::{Duration, Instant};
+
+thread_local! {
+    static DEADLINE: Cell<Option<Instant>> = const { Cell::new(None) };
+}
+
+pub(crate) struct Guard {
+    owner: bool,
+}
+
+pub(crate) fn enter(limit: Option<Duration>) -> Guard {
+    let owner = DEADLINE.with(|slot| {
+        if slot.get().is_some() {
+            false
+        } else {
+            let now = Instant::now();
+            let deadline = limit.and_then(|d| now.checked_add(d));
+            slot.set(deadline);
+            true
+        }
+    });
+    Guard { owner }
+}
+
+impl Drop for Guard {
+    fn drop(&mut self) {
+        if self.owner {
+            DEADLINE.with(|slot| slot.set(None));
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn expired() -> bool {
+    DEADLINE.with(|slot| {
+        slot.get()
+            .is_some_and(|deadline| Instant::now() >= deadline)
+    })
+}

--- a/crates/pounce-qp/src/error.rs
+++ b/crates/pounce-qp/src/error.rs
@@ -17,6 +17,8 @@ pub enum QpStatus {
     Unbounded,
     /// Iteration limit reached before convergence.
     MaxIter,
+    /// Solve-wide wall-clock limit reached before convergence.
+    TimeLimit,
     /// Solver detected numerical breakdown (e.g., factor failure
     /// not recoverable by inertia correction).
     NumericalError,
@@ -29,6 +31,7 @@ impl fmt::Display for QpStatus {
             QpStatus::Infeasible => write!(f, "infeasible"),
             QpStatus::Unbounded => write!(f, "unbounded"),
             QpStatus::MaxIter => write!(f, "max-iter"),
+            QpStatus::TimeLimit => write!(f, "time-limit"),
             QpStatus::NumericalError => write!(f, "numerical-error"),
         }
     }

--- a/crates/pounce-qp/src/error.rs
+++ b/crates/pounce-qp/src/error.rs
@@ -57,6 +57,23 @@ pub enum QpError {
     /// current crate phase (e.g., one-sided inequality constraints
     /// before the working-set machinery lands).
     UnsupportedFeature(String),
+    /// **Internal cancellation signal**: the solve-wide wall-clock
+    /// deadline (`QpOptions::time_limit`) expired inside a routine whose
+    /// success value would otherwise be indistinguishable from a real
+    /// result — chiefly
+    /// [`factorize_with_inertia_control`](crate::solver::ParametricActiveSetSolver),
+    /// whose "success" is an in-place solved right-hand side.
+    ///
+    /// Cancellation is an error, not a value, precisely so that `?`
+    /// propagation makes every caller handle it: a timeout that returns
+    /// `Ok` leaves the caller consuming an *unsolved* KKT right-hand side
+    /// as if it were a solution, which `solve_equality_only` would then
+    /// label `Optimal`.
+    ///
+    /// This never escapes the crate. Every [`crate::QpSolver`] entry point
+    /// converts it to the soft `QpStatus::TimeLimit` outcome, so a timeout
+    /// remains a status on a successful solve for callers.
+    DeadlineExpired,
 }
 
 impl QpError {
@@ -95,6 +112,7 @@ impl fmt::Display for QpError {
             }
             QpError::LinearSolverFailure(s) => write!(f, "linear solver failure: {s}"),
             QpError::UnsupportedFeature(s) => write!(f, "unsupported feature: {s}"),
+            QpError::DeadlineExpired => write!(f, "wall-clock deadline expired"),
         }
     }
 }

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -759,6 +759,12 @@ impl ParametricActiveSetSolver {
                     }
                     continue;
                 }
+                // A cancelled factorization is not a path breakdown. Falling
+                // through to `Ok(None)` would report "path could not be
+                // started" and send the caller off to begin a *fresh*
+                // conventional solve with the budget already spent; propagate
+                // so the entry point turns it into `TimeLimit` directly.
+                Err(QpError::DeadlineExpired) => return Err(QpError::DeadlineExpired),
                 Err(e) => {
                     if trace {
                         eprintln!("[hom] KKT factorization failed at t={t:.6e}: {e}");

--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -472,6 +472,11 @@ impl ParametricActiveSetSolver {
             }
             match first {
                 Ok(s) if s.status == QpStatus::Optimal => s,
+                Ok(mut s) if s.status == QpStatus::TimeLimit => {
+                    s.lambda_g.resize(m, 0.0);
+                    s.working.constraints.resize(m, ConsStatus::Inactive);
+                    return Ok(Some(s));
+                }
                 _ => {
                     let Some(delta) = path_regularization_delta(qp) else {
                         return Ok(None);
@@ -491,6 +496,11 @@ impl ParametricActiveSetSolver {
                         Ok(s) if s.status == QpStatus::Optimal => {
                             h_reg_holder = Some(h_reg);
                             s
+                        }
+                        Ok(mut s) if s.status == QpStatus::TimeLimit => {
+                            s.lambda_g.resize(m, 0.0);
+                            s.working.constraints.resize(m, ConsStatus::Inactive);
+                            return Ok(Some(s));
                         }
                         _ => return Ok(None),
                     }
@@ -618,6 +628,24 @@ impl ParametricActiveSetSolver {
         // Each iteration either advances `t` or changes the working set, and the
         // budget bounds the total.
         for _step in 0..opts.max_iter {
+            if crate::deadline::expired() {
+                return Ok(Some(QpSolution {
+                    obj: crate::solver::quad_objective(qp, &x),
+                    x,
+                    lambda_g,
+                    lambda_x,
+                    working,
+                    status: QpStatus::TimeLimit,
+                    stats: QpStats {
+                        n_working_set_changes: n_changes,
+                        n_refactor,
+                        n_schur_updates: 0,
+                        used_phase1: false,
+                        time: started.elapsed(),
+                    },
+                    unbounded_ray: None,
+                }));
+            }
             if t >= 1.0 - T_EPS {
                 break;
             }

--- a/crates/pounce-qp/src/lib.rs
+++ b/crates/pounce-qp/src/lib.rs
@@ -39,6 +39,7 @@
 
 #![cfg_attr(test, allow(clippy::unwrap_used, clippy::expect_used))]
 
+mod deadline;
 pub mod elastic;
 pub mod error;
 pub mod factor;

--- a/crates/pounce-qp/src/options.rs
+++ b/crates/pounce-qp/src/options.rs
@@ -3,6 +3,7 @@
 //! `OptionsList` entries straight through without translation.
 
 use pounce_common::Number;
+use std::time::Duration;
 
 /// Active-set QP algorithm variant. Phase 5a ships only the sparse
 /// parametric active-set method; other entries are placeholders to
@@ -31,6 +32,9 @@ pub enum AntiCyclingChoice {
 
 #[derive(Debug, Clone)]
 pub struct QpOptions {
+    /// Solve-wide wall-clock budget shared by homotopy, elastic phase-1,
+    /// feasibility/recovery solves, and seeded retries.
+    pub time_limit: Option<Duration>,
     pub algorithm: QpAlgorithm,
     pub max_iter: u32,
     pub feas_tol: Number,
@@ -173,6 +177,7 @@ pub struct QpOptions {
 impl Default for QpOptions {
     fn default() -> Self {
         Self {
+            time_limit: None,
             algorithm: QpAlgorithm::default(),
             max_iter: 200,
             feas_tol: 1e-9,

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -149,12 +149,19 @@ impl ParametricActiveSetSolver {
         let mut next = opts.inertia_shift_initial;
         for _ in 0..opts.inertia_max_shifts {
             if crate::deadline::expired() {
-                // Internal cancellation sentinel: callers check the deadline
-                // immediately after this operation and return the soft
-                // `QpStatus::TimeLimit`. Restoring the original RHS avoids
-                // exposing a partially solved system on that path.
-                rhs.copy_from_slice(&rhs_snapshot);
-                return Ok(current);
+                // Cancellation is an *error*, not a value. `Ok(current)` here
+                // would hand the caller an `rhs` that was never solved — it
+                // still holds `[-g; targets]` — while claiming a shift of
+                // `current` succeeded. `solve_equality_only` reads that back as
+                // `[x*; λ*]`, sees `delta == 0` (so it also skips the
+                // masked-rank-deficiency probe and the recession-ray test), and
+                // returns `x = -g` as `QpStatus::Optimal`; `audit_and_repair`
+                // only checks primal feasibility, so any such point that
+                // happens to satisfy `Ax = b` reaches the user as a certified
+                // optimum. Propagating an error instead makes `?` force every
+                // caller to deal with it, and the entry points below convert it
+                // to the soft `QpStatus::TimeLimit`.
+                return Err(QpError::DeadlineExpired);
             }
             kkt.add_h_diagonal_shift(n_h_rows, next - current);
             current = next;
@@ -468,7 +475,7 @@ impl ParametricActiveSetSolver {
 
         for _iter in 0..opts.max_iter {
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
             // Build active-bound index list (ascending = problem
             // order) and assemble the KKT.
@@ -491,7 +498,7 @@ impl ParametricActiveSetSolver {
             let delta = self.factorize_with_inertia_control(kkt, &mut rhs, k as i32, qp.n, opts)?;
             n_refactor += 1;
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
 
             // ---- 3. Check ‖p‖ ----
@@ -737,7 +744,7 @@ impl ParametricActiveSetSolver {
         // ---- 4. Active-set inner loop ----
         for _iter in 0..opts.max_iter {
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
             let active: Vec<usize> = (0..n).filter(|&i| working.bounds[i].is_active()).collect();
             let k = active.len();
@@ -755,7 +762,7 @@ impl ParametricActiveSetSolver {
                 self.factorize_with_inertia_control(kkt, &mut rhs, (m + k) as i32, qp.n, opts)?;
             n_refactor += 1;
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
 
             let p_inf = rhs[..n].iter().map(|pi| pi.abs()).fold(0.0, f64::max);
@@ -1170,7 +1177,7 @@ impl ParametricActiveSetSolver {
 
         for _iter in 0..opts.max_iter {
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
             let active_cons: Vec<usize> = (0..m)
                 .filter(|&i| working.constraints[i].is_active())
@@ -1244,7 +1251,7 @@ impl ParametricActiveSetSolver {
             };
             n_refactor += 1;
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
 
             let p_inf = rhs[..n].iter().map(|pi| pi.abs()).fold(0.0, f64::max);
@@ -1896,7 +1903,7 @@ impl ParametricActiveSetSolver {
             .copy_from_slice(&sol_aug.working.constraints);
         working.bounds.copy_from_slice(&sol_aug.working.bounds[..n]);
         if sol_aug.status == QpStatus::TimeLimit || crate::deadline::expired() {
-            return Ok(time_limit_solution(qp, Some(&x)));
+            return Ok(time_limit_solution(qp, Some(&x), sol_aug.stats.n_refactor));
         }
 
         let feasible = reform.is_feasible(&sol_aug.x, opts.feas_tol);
@@ -1988,6 +1995,7 @@ impl ParametricActiveSetSolver {
             return Ok(time_limit_solution(
                 qp,
                 p1_point.as_deref().or(Some(x.as_slice())),
+                0,
             ));
         }
         if let Some(seed) = p1_point {
@@ -2033,10 +2041,14 @@ impl ParametricActiveSetSolver {
             };
             let rec = match rec {
                 Ok(r) => r,
+                // "This seed did not pan out" does not apply to cancellation:
+                // `continue` would start the next recovery solve on a budget
+                // that is already gone.
+                Err(QpError::DeadlineExpired) => return Err(QpError::DeadlineExpired),
                 Err(_) => continue,
             };
             if rec.status == QpStatus::TimeLimit || crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&rec.x)));
+                return Ok(time_limit_solution(qp, Some(&rec.x), rec.stats.n_refactor));
             }
             if rec.status == QpStatus::Optimal
                 && self.original_qp_feasible(qp, &rec.x, opts.feas_tol)
@@ -2727,7 +2739,7 @@ impl ParametricActiveSetSolver {
         let trace = std::env::var("POUNCE_QP_TRACE").is_ok();
         for _iter in 0..opts.max_iter {
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
             let hx = h_times_x(qp.h, &x);
             let mut rhs = vec![0.0; n + m_total];
@@ -2767,7 +2779,7 @@ impl ParametricActiveSetSolver {
                 schur.solve(&mut self.linsol, &mut rhs)?;
             }
             if crate::deadline::expired() {
-                return Ok(time_limit_solution(qp, Some(&x)));
+                return Ok(time_limit_solution(qp, Some(&x), n_refactor));
             }
 
             let p: Vec<Number> = rhs[..n].to_vec();
@@ -3594,9 +3606,66 @@ impl QpSolver for ParametricActiveSetSolver {
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
         let _deadline = crate::deadline::enter(opts.time_limit);
+        let out = self.solve_scoped(qp, ws, opts);
+        soften_deadline(qp, ws.map(|w| w.x.as_slice()), out)
+    }
+
+    fn solve_parametric(
+        &mut self,
+        qp_prev: &QpProblem,
+        sol_prev: &QpSolution,
+        qp_new: &QpProblem,
+        opts: &QpOptions,
+    ) -> Result<QpSolution, QpError> {
+        let _deadline = crate::deadline::enter(opts.time_limit);
+        let out = self.solve_parametric_scoped(qp_prev, sol_prev, qp_new, opts);
+        soften_deadline(qp_new, Some(&sol_prev.x), out)
+    }
+
+    fn solve_with_working_set(
+        &mut self,
+        qp: &QpProblem,
+        working: &crate::working_set::WorkingSet,
+        opts: &QpOptions,
+    ) -> Result<QpSolution, QpError> {
+        let _deadline = crate::deadline::enter(opts.time_limit);
+        let out = self.solve_with_working_set_scoped(qp, working, opts);
+        soften_deadline(qp, None, out)
+    }
+}
+
+/// Entry-point boundary for the internal cancellation error.
+///
+/// [`QpError::DeadlineExpired`] exists so `?` propagation forces every
+/// internal caller to handle a timeout instead of consuming a half-finished
+/// result. It is not part of the crate's contract with its callers, though:
+/// a timeout is a *soft* outcome, reported as `QpStatus::TimeLimit` on an
+/// `Ok` solution exactly like `MaxIter`. Every public entry point converts it
+/// here, so the error can never escape.
+fn soften_deadline(
+    qp: &QpProblem,
+    hint: Option<&[Number]>,
+    out: Result<QpSolution, QpError>,
+) -> Result<QpSolution, QpError> {
+    match out {
+        // `n_refactor = 0`: the cancelled inner solve's counter died with the
+        // `Err`, and inventing a number here would be worse than reporting
+        // none. `stats.time` still reflects the real budget spent.
+        Err(QpError::DeadlineExpired) => Ok(time_limit_solution(qp, hint, 0)),
+        other => other,
+    }
+}
+
+impl ParametricActiveSetSolver {
+    fn solve_scoped(
+        &mut self,
+        qp: &QpProblem,
+        ws: Option<&QpWarmStart>,
+        opts: &QpOptions,
+    ) -> Result<QpSolution, QpError> {
         qp.validate()?;
         if crate::deadline::expired() {
-            return Ok(time_limit_solution(qp, ws.map(|w| w.x.as_slice())));
+            return Ok(time_limit_solution(qp, ws.map(|w| w.x.as_slice()), 0));
         }
         if let Some(w) = ws {
             w.working.validate_dims(qp.n, qp.m)?;
@@ -3689,16 +3758,15 @@ impl QpSolver for ParametricActiveSetSolver {
         self.audit_and_repair(qp, sol, opts)
     }
 
-    fn solve_parametric(
+    fn solve_parametric_scoped(
         &mut self,
         qp_prev: &QpProblem,
         sol_prev: &QpSolution,
         qp_new: &QpProblem,
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
-        let _deadline = crate::deadline::enter(opts.time_limit);
         if crate::deadline::expired() {
-            return Ok(time_limit_solution(qp_new, Some(&sol_prev.x)));
+            return Ok(time_limit_solution(qp_new, Some(&sol_prev.x), 0));
         }
         // Trace the homotopy from the previous problem to the new one, starting
         // from the previous solution's working set.
@@ -3730,17 +3798,16 @@ impl QpSolver for ParametricActiveSetSolver {
         self.solve(qp_new, None, opts)
     }
 
-    fn solve_with_working_set(
+    fn solve_with_working_set_scoped(
         &mut self,
         qp: &QpProblem,
         working: &crate::working_set::WorkingSet,
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
-        let _deadline = crate::deadline::enter(opts.time_limit);
         qp.validate()?;
         working.validate_dims(qp.n, qp.m)?;
         if crate::deadline::expired() {
-            return Ok(time_limit_solution(qp, None));
+            return Ok(time_limit_solution(qp, None, 0));
         }
 
         // Factor the pinned KKT for a primal that satisfies the hinted active
@@ -3775,7 +3842,14 @@ impl QpSolver for ParametricActiveSetSolver {
     }
 }
 
-fn time_limit_solution(qp: &QpProblem, hint: Option<&[Number]>) -> QpSolution {
+/// The soft outcome for a cancelled solve: the best point we have, clamped
+/// into the box so it is at least a usable starting iterate, with
+/// `QpStatus::TimeLimit`.
+///
+/// `n_refactor` is the work done before the deadline hit, and `time` comes
+/// from the enclosing deadline scope — a solve that spent the whole budget
+/// must not be recorded as having taken no time.
+fn time_limit_solution(qp: &QpProblem, hint: Option<&[Number]>, n_refactor: u32) -> QpSolution {
     let mut x = hint.map_or_else(|| vec![0.0; qp.n], ToOwned::to_owned);
     x.resize(qp.n, 0.0);
     for (xi, (&l, &u)) in x.iter_mut().zip(qp.xl.iter().zip(qp.xu.iter())) {
@@ -3793,10 +3867,10 @@ fn time_limit_solution(qp: &QpProblem, hint: Option<&[Number]>) -> QpSolution {
         status: QpStatus::TimeLimit,
         stats: QpStats {
             n_working_set_changes: 0,
-            n_refactor: 0,
+            n_refactor,
             n_schur_updates: 0,
             used_phase1: false,
-            time: std::time::Duration::ZERO,
+            time: crate::deadline::scope_elapsed(),
         },
         unbounded_ray: None,
     }

--- a/crates/pounce-qp/src/solver.rs
+++ b/crates/pounce-qp/src/solver.rs
@@ -148,6 +148,14 @@ impl ParametricActiveSetSolver {
         let mut current = 0.0;
         let mut next = opts.inertia_shift_initial;
         for _ in 0..opts.inertia_max_shifts {
+            if crate::deadline::expired() {
+                // Internal cancellation sentinel: callers check the deadline
+                // immediately after this operation and return the soft
+                // `QpStatus::TimeLimit`. Restoring the original RHS avoids
+                // exposing a partially solved system on that path.
+                rhs.copy_from_slice(&rhs_snapshot);
+                return Ok(current);
+            }
             kkt.add_h_diagonal_shift(n_h_rows, next - current);
             current = next;
             let mut rhs_local = rhs_snapshot.clone();
@@ -459,6 +467,9 @@ impl ParametricActiveSetSolver {
         let mut n_changes: u32 = 0;
 
         for _iter in 0..opts.max_iter {
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
             // Build active-bound index list (ascending = problem
             // order) and assemble the KKT.
             let active: Vec<usize> = (0..n).filter(|&i| working.bounds[i].is_active()).collect();
@@ -479,6 +490,9 @@ impl ParametricActiveSetSolver {
             // retry handles indefinite reduced H via §4.5.
             let delta = self.factorize_with_inertia_control(kkt, &mut rhs, k as i32, qp.n, opts)?;
             n_refactor += 1;
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
 
             // ---- 3. Check ‖p‖ ----
             let p_inf = rhs[..n].iter().map(|pi| pi.abs()).fold(0.0, f64::max);
@@ -722,6 +736,9 @@ impl ParametricActiveSetSolver {
 
         // ---- 4. Active-set inner loop ----
         for _iter in 0..opts.max_iter {
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
             let active: Vec<usize> = (0..n).filter(|&i| working.bounds[i].is_active()).collect();
             let k = active.len();
 
@@ -737,6 +754,9 @@ impl ParametricActiveSetSolver {
             let delta =
                 self.factorize_with_inertia_control(kkt, &mut rhs, (m + k) as i32, qp.n, opts)?;
             n_refactor += 1;
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
 
             let p_inf = rhs[..n].iter().map(|pi| pi.abs()).fold(0.0, f64::max);
 
@@ -1149,6 +1169,9 @@ impl ParametricActiveSetSolver {
         const STALL_LIMIT: u32 = 50;
 
         for _iter in 0..opts.max_iter {
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
             let active_cons: Vec<usize> = (0..m)
                 .filter(|&i| working.constraints[i].is_active())
                 .collect();
@@ -1220,6 +1243,9 @@ impl ParametricActiveSetSolver {
                 Err(e) => return Err(e),
             };
             n_refactor += 1;
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
 
             let p_inf = rhs[..n].iter().map(|pi| pi.abs()).fold(0.0, f64::max);
 
@@ -1869,6 +1895,9 @@ impl ParametricActiveSetSolver {
             .constraints
             .copy_from_slice(&sol_aug.working.constraints);
         working.bounds.copy_from_slice(&sol_aug.working.bounds[..n]);
+        if sol_aug.status == QpStatus::TimeLimit || crate::deadline::expired() {
+            return Ok(time_limit_solution(qp, Some(&x)));
+        }
 
         let feasible = reform.is_feasible(&sol_aug.x, opts.feas_tol);
         if feasible {
@@ -1955,6 +1984,12 @@ impl ParametricActiveSetSolver {
         // term's bias left behind. Only `witness` — its *verified*
         // feasibility — is allowed to speak to the certificate.
         let (p1_point, p1_verdict) = self.convex_feasibility_seed(qp, opts);
+        if crate::deadline::expired() {
+            return Ok(time_limit_solution(
+                qp,
+                p1_point.as_deref().or(Some(x.as_slice())),
+            ));
+        }
         if let Some(seed) = p1_point {
             candidates.push(seed);
         }
@@ -2000,6 +2035,9 @@ impl ParametricActiveSetSolver {
                 Ok(r) => r,
                 Err(_) => continue,
             };
+            if rec.status == QpStatus::TimeLimit || crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&rec.x)));
+            }
             if rec.status == QpStatus::Optimal
                 && self.original_qp_feasible(qp, &rec.x, opts.feas_tol)
             {
@@ -2334,6 +2372,9 @@ impl ParametricActiveSetSolver {
             };
 
             let x = sol.x[..n].to_vec();
+            if sol.status == QpStatus::TimeLimit || crate::deadline::expired() {
+                return (Some(x), None);
+            }
             if !x.iter().all(|v| v.is_finite()) {
                 break;
             }
@@ -2685,6 +2726,9 @@ impl ParametricActiveSetSolver {
 
         let trace = std::env::var("POUNCE_QP_TRACE").is_ok();
         for _iter in 0..opts.max_iter {
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
+            }
             let hx = h_times_x(qp.h, &x);
             let mut rhs = vec![0.0; n + m_total];
             for (rhs_i, (hx_i, &g_i)) in rhs[..n].iter_mut().zip(hx.iter().zip(qp.g.iter())) {
@@ -2721,6 +2765,9 @@ impl ParametricActiveSetSolver {
                 // `solve` writes through `rhs`, so restore it before retrying.
                 rhs.copy_from_slice(&rhs_backup);
                 schur.solve(&mut self.linsol, &mut rhs)?;
+            }
+            if crate::deadline::expired() {
+                return Ok(time_limit_solution(qp, Some(&x)));
             }
 
             let p: Vec<Number> = rhs[..n].to_vec();
@@ -3546,7 +3593,11 @@ impl QpSolver for ParametricActiveSetSolver {
         ws: Option<&QpWarmStart>,
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
+        let _deadline = crate::deadline::enter(opts.time_limit);
         qp.validate()?;
+        if crate::deadline::expired() {
+            return Ok(time_limit_solution(qp, ws.map(|w| w.x.as_slice())));
+        }
         if let Some(w) = ws {
             w.working.validate_dims(qp.n, qp.m)?;
             if w.x.len() != qp.n {
@@ -3645,6 +3696,10 @@ impl QpSolver for ParametricActiveSetSolver {
         qp_new: &QpProblem,
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
+        let _deadline = crate::deadline::enter(opts.time_limit);
+        if crate::deadline::expired() {
+            return Ok(time_limit_solution(qp_new, Some(&sol_prev.x)));
+        }
         // Trace the homotopy from the previous problem to the new one, starting
         // from the previous solution's working set.
         //
@@ -3681,8 +3736,12 @@ impl QpSolver for ParametricActiveSetSolver {
         working: &crate::working_set::WorkingSet,
         opts: &QpOptions,
     ) -> Result<QpSolution, QpError> {
+        let _deadline = crate::deadline::enter(opts.time_limit);
         qp.validate()?;
         working.validate_dims(qp.n, qp.m)?;
+        if crate::deadline::expired() {
+            return Ok(time_limit_solution(qp, None));
+        }
 
         // Factor the pinned KKT for a primal that satisfies the hinted active
         // rows (pruning the hint first if it is rank-deficient).
@@ -3713,6 +3772,33 @@ impl QpSolver for ParametricActiveSetSolver {
             working: fwd_working,
         };
         self.solve(qp, Some(&ws), opts)
+    }
+}
+
+fn time_limit_solution(qp: &QpProblem, hint: Option<&[Number]>) -> QpSolution {
+    let mut x = hint.map_or_else(|| vec![0.0; qp.n], ToOwned::to_owned);
+    x.resize(qp.n, 0.0);
+    for (xi, (&l, &u)) in x.iter_mut().zip(qp.xl.iter().zip(qp.xu.iter())) {
+        if !xi.is_finite() {
+            *xi = 0.0;
+        }
+        *xi = xi.clamp(l, u);
+    }
+    QpSolution {
+        obj: quad_objective(qp, &x),
+        x,
+        lambda_g: vec![0.0; qp.m],
+        lambda_x: vec![0.0; qp.n],
+        working: WorkingSet::cold(qp.n, qp.m),
+        status: QpStatus::TimeLimit,
+        stats: QpStats {
+            n_working_set_changes: 0,
+            n_refactor: 0,
+            n_schur_updates: 0,
+            used_phase1: false,
+            time: std::time::Duration::ZERO,
+        },
+        unbounded_ray: None,
     }
 }
 
@@ -4028,7 +4114,7 @@ fn model_step_cap(
     }
 }
 
-fn quad_objective(qp: &QpProblem, x: &[Number]) -> Number {
+pub(crate) fn quad_objective(qp: &QpProblem, x: &[Number]) -> Number {
     let mut quad = 0.0;
     let irows = qp.h.irows();
     let jcols = qp.h.jcols();

--- a/crates/pounce-qp/tests/deadline_cancellation.rs
+++ b/crates/pounce-qp/tests/deadline_cancellation.rs
@@ -1,0 +1,163 @@
+//! A cancelled factorization must never be mistaken for a solved one.
+//!
+//! `factorize_with_inertia_control` signals success by writing the *solved*
+//! right-hand side back in place, so an early `Ok` return on a deadline hands
+//! the caller an `rhs` that still holds `[-g; targets]` while claiming it is
+//! `[x*; λ*]`. The active-set loop then reads `delta == 0`, skips its
+//! rank-deficiency and recession guards, and reports `x = -g` as `Optimal` —
+//! a fabricated answer, not a timeout. Cancellation is therefore an *error*
+//! (`QpError::DeadlineExpired`) that `?` forces every caller to handle, and
+//! only the public entry points turn it into the soft `QpStatus::TimeLimit`.
+//!
+//! Reproducing that window needs the deadline to cross *inside* a
+//! factorization — after the entry-point check has already passed — which no
+//! choice of `time_limit` alone can arrange. The backend below creates it on
+//! demand: its first solve stalls past the budget and reports the singular
+//! factor that sends the solver into the inertia-shift loop, which is exactly
+//! where the check lives.
+
+use std::rc::Rc;
+use std::time::Duration;
+
+use pounce_common::types::{Index, NLP_LOWER_BOUND_INF, NLP_UPPER_BOUND_INF, Number};
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_linsol::{EMatrixFormat, ESymSolverStatus, SparseSymLinearSolverInterface};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+
+/// Budget the solve is given. Anything the first factorization overruns works;
+/// small enough that the test costs one stall.
+const BUDGET: Duration = Duration::from_millis(5);
+/// How long the first factorization takes. An order of magnitude over `BUDGET`
+/// so the crossing does not depend on scheduling noise.
+const STALL: Duration = Duration::from_millis(50);
+
+/// A backend whose first factorization outlives the deadline and then reports
+/// a singular factor — the recoverable failure that routes the solver into the
+/// inertia-shift loop.
+struct StallThenSingular {
+    values: Vec<Number>,
+    stalled: bool,
+}
+
+impl SparseSymLinearSolverInterface for StallThenSingular {
+    fn initialize_structure(
+        &mut self,
+        _dim: Index,
+        nonzeros: Index,
+        _ia: &[Index],
+        _ja: &[Index],
+    ) -> ESymSolverStatus {
+        self.values = vec![0.0; nonzeros as usize];
+        ESymSolverStatus::Success
+    }
+
+    fn values_array_mut(&mut self) -> &mut [Number] {
+        &mut self.values
+    }
+
+    fn multi_solve(
+        &mut self,
+        _new_matrix: bool,
+        _ia: &[Index],
+        _ja: &[Index],
+        _nrhs: Index,
+        _rhs_vals: &mut [Number],
+        _check_neg_evals: bool,
+        _number_of_neg_evals: Index,
+    ) -> ESymSolverStatus {
+        // Only the first call stalls: the point is to be *inside* a
+        // factorization when the budget runs out, not to make the test slow.
+        // `rhs_vals` is deliberately left untouched — a backend that fails
+        // wrote no solution, which is the whole hazard being tested.
+        if !self.stalled {
+            self.stalled = true;
+            std::thread::sleep(STALL);
+        }
+        ESymSolverStatus::Singular
+    }
+
+    fn number_of_neg_evals(&self) -> Index {
+        0
+    }
+
+    fn increase_quality(&mut self) -> bool {
+        false
+    }
+
+    fn provides_inertia(&self) -> bool {
+        true
+    }
+
+    fn matrix_format(&self) -> EMatrixFormat {
+        EMatrixFormat::TripletFormat
+    }
+}
+
+#[test]
+fn a_deadline_crossed_inside_a_factorization_is_not_an_optimum() {
+    // `min x₁² + 4x₂² − 2x₁ − 2x₂  s.t.  x₁ + x₂ = 4`, free variables — a pure
+    // equality QP with no bounds, which takes the `solve_equality_only` fast
+    // path: the one that reads the factorization's right-hand side back as
+    // `[x*; λ*]` with no further check of its own.
+    //
+    // The data is chosen so the fabricated point is *feasible but wrong*. The
+    // un-solved RHS is `[-g; b] = [2, 2; 4]`, so `x = (2, 2)` satisfies
+    // `x₁ + x₂ = 4` — the primal-feasibility audit, the only downstream guard,
+    // waves it through. The true optimum is `(3.2, 0.8)`.
+    let h_space = SymTMatrixSpace::new(2, vec![1, 2], vec![1, 2]);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&[2.0, 8.0]);
+    let a_space = GenTMatrixSpace::new(1, 2, vec![1, 1], vec![1, 2]);
+    let mut a = GenTMatrix::new(a_space);
+    a.set_values(&[1.0, 1.0]);
+    let g = [-2.0, -2.0];
+    let bl = [4.0];
+    let bu = [4.0];
+    let xl = [NLP_LOWER_BOUND_INF; 2];
+    let xu = [NLP_UPPER_BOUND_INF; 2];
+    let qp = QpProblem {
+        n: 2,
+        m: 1,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &bl,
+        bu: &bu,
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+    let mut solver = ParametricActiveSetSolver::new(Box::new(StallThenSingular {
+        values: Vec::new(),
+        stalled: false,
+    }));
+    let opts = QpOptions {
+        time_limit: Some(BUDGET),
+        ..QpOptions::default()
+    };
+
+    let sol = solver
+        .solve(&qp, None, &opts)
+        .expect("a timeout is a soft status, never an error out of the crate");
+
+    // The load-bearing assertion. Before the typed cancellation this returned
+    // `Optimal` at `x = -g = (2, 2)` — the un-solved right-hand side read back
+    // as a solution. It is feasible, so nothing downstream objected, and it is
+    // not the optimum.
+    assert_ne!(
+        sol.status,
+        QpStatus::Optimal,
+        "a cancelled factorization was reported as a solved QP (x = {:?})",
+        sol.x
+    );
+    assert_eq!(sol.status, QpStatus::TimeLimit);
+    assert!(sol.x.iter().all(|v| v.is_finite()));
+    // The timeout is not an instantaneous solve: the stall is on the clock.
+    assert!(
+        sol.stats.time >= BUDGET,
+        "stats.time = {:?} does not account for the budget actually spent",
+        sol.stats.time
+    );
+}

--- a/crates/pounce-qp/tests/time_limit.rs
+++ b/crates/pounce-qp/tests/time_limit.rs
@@ -1,0 +1,42 @@
+use std::rc::Rc;
+use std::time::Duration;
+
+use pounce_linalg::triplet::{GenTMatrix, GenTMatrixSpace, SymTMatrix, SymTMatrixSpace};
+use pounce_qp::{
+    HessianInertia, ParametricActiveSetSolver, QpOptions, QpProblem, QpSolver, QpStatus,
+};
+
+#[test]
+fn zero_duration_returns_time_limit_before_factorization() {
+    let h_space = SymTMatrixSpace::new(1, vec![1], vec![1]);
+    let mut h = SymTMatrix::new(Rc::clone(&h_space));
+    h.set_values(&[2.0]);
+    let a = GenTMatrix::new(GenTMatrixSpace::new(0, 1, vec![], vec![]));
+    let g = [-2.0];
+    let xl = [0.0];
+    let xu = [2.0];
+    let qp = QpProblem {
+        n: 1,
+        m: 0,
+        h: &h,
+        g: &g,
+        a: &a,
+        bl: &[],
+        bu: &[],
+        xl: &xl,
+        xu: &xu,
+        hessian_inertia: HessianInertia::Psd,
+    };
+    let mut solver =
+        ParametricActiveSetSolver::new(Box::new(pounce_feral::FeralSolverInterface::new()));
+    let opts = QpOptions {
+        time_limit: Some(Duration::ZERO),
+        ..QpOptions::default()
+    };
+    let sol = solver
+        .solve(&qp, None, &opts)
+        .expect("timeout is a soft status");
+    assert_eq!(sol.status, QpStatus::TimeLimit);
+    assert_eq!(sol.x.len(), 1);
+    assert!(sol.x[0].is_finite());
+}

--- a/docs/src/active-set-sqp-warm-start.md
+++ b/docs/src/active-set-sqp-warm-start.md
@@ -388,7 +388,7 @@ pub struct QpSolution {
     pub lambda_x: Vec<f64>,
     pub working:  WorkingSet,
     pub obj:      f64,
-    pub status:   QpStatus,              // Optimal | Infeasible | Unbounded | MaxIter | …
+    pub status:   QpStatus,              // Optimal | Infeasible | Unbounded | MaxIter | TimeLimit | …
     pub stats:    QpStats,               // n_active_set_changes, n_refactor, time …
 }
 ```
@@ -423,6 +423,7 @@ pub trait QpSolver {
 }
 
 pub struct QpOptions {
+    pub time_limit: Option<std::time::Duration>, // whole solve; default None
     pub algorithm: QpAlgorithm,          // ParametricActiveSet | …
     pub linear_solver_factory: …,        // injected from pounce-algorithm
     pub max_iter: usize,
@@ -434,6 +435,12 @@ pub struct QpOptions {
     pub print_level: i32,
 }
 ```
+
+The wall-clock limit covers the complete top-level active-set solve, including
+homotopy, elastic phase-1, feasibility/recovery solves, and seeded retries.
+Those nested stages share one monotonic deadline rather than restarting the
+duration. Expiration returns `QpStatus::TimeLimit`; an in-flight backend
+factorization completes before the next check.
 
 The `linear_solver_factory` injection mirrors
 `alg_builder.rs::LinearBackendFactory` (line 50) so `pounce-qp`

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -322,6 +322,14 @@ The fallback is narrow by construction, and does not fire when:
 A tightened `tol` is deliberately **not** in that list: that is an accuracy
 request, so trying the engine that can meet it is the right response.
 
+An explicitly set `max_wall_time` is forwarded to every automatic convex LP,
+QP, active-set QP, and SOCP route. Time spent extracting and presolving the
+convex model is charged to the same budget as all engine retries. Expiration is
+reported as `MaximumWallTimeExceeded`, AMPL `solve_result_num = 400`, with the
+message “Maximum wallclock time exceeded.” A timed-out convex solve is final:
+automatic routing never starts a fresh convex attempt or falls back to the NLP
+engine. `max_cpu_time` remains an NLP-side option and is not forwarded.
+
 ### Infeasible and unbounded problems
 
 The convex solver detects infeasibility and unboundedness directly,

--- a/docs/src/rust.md
+++ b/docs/src/rust.md
@@ -172,6 +172,20 @@ let sol = solve_qp_ipm(&prob, &QpOptions::default(), backend);
 assert_eq!(sol.status, QpStatus::Optimal);
 ```
 
+Both convex engines accept a solve-wide wall-clock budget through
+`QpOptions::time_limit: Option<std::time::Duration>`. `None` (the default)
+preserves the uncapped behavior. A limit creates one monotonic deadline for
+the entire top-level solve: equilibration/HSDE retries, active-set homotopy and
+phase-1, feasibility probes, seeded retries, and LP crossover do not receive a
+fresh budget. Batch entries are separate top-level solves and each receives
+the full duration. Expiration returns `QpStatus::TimeLimit` with the latest
+finite iterate; a linear-system factorization already in flight is not
+interruptible, so the solve may overshoot by one factorization.
+
+These are public API additions. Downstream exhaustive `QpOptions { ... }`
+literals must initialize `time_limit` (or use `..QpOptions::default()`), and
+exhaustive matches on `QpStatus` must handle `TimeLimit`.
+
 `P` is the **lower triangle** of the Hessian in triplet form; an empty `P` is
 an LP. Cone blocks beyond the nonnegative orthant are declared with `ConeSpec`
 and solved by `solve_socp_ipm`. For many instances, `solve_qp_batch_parallel`

--- a/python/pounce/_minimize.py
+++ b/python/pounce/_minimize.py
@@ -129,6 +129,10 @@ _QP_STATUS_CODE = {
     "primal_infeasible": 2,
     "dual_infeasible": 3,
     "iteration_limit": 1,
+    # A spent wall-clock budget is the same kind of outcome as a spent
+    # iteration budget — the solve stopped early without converging — and scipy
+    # spells that 1 for both.
+    "time_limit": 1,
     "numerical_failure": 4,
 }
 
@@ -156,6 +160,9 @@ _QP_STATUS_MESSAGE = {
     "unbounded below over the feasible region (the convex solver returned a "
     "dual-infeasibility certificate).",
     "iteration_limit": "Maximum number of iterations reached.",
+    "time_limit": "Maximum wall-clock time reached (``max_wall_time``); the "
+    "returned point is the best iterate the solver had when the budget ran "
+    "out.",
     "numerical_failure": "Numerical difficulties encountered.",
 }
 

--- a/python/pounce/jax/_qp.py
+++ b/python/pounce/jax/_qp.py
@@ -162,8 +162,8 @@ def _check_status(status, where):
     The differentiable layer reads the primal/dual iterate and solves a
     KKT system for the gradient. If the forward solve did not converge
     (``primal_infeasible`` / ``dual_infeasible`` / ``iteration_limit`` /
-    ``numerical_failure``), that iterate is not a KKT point and the
-    implicit-function gradient is meaningless — so fail loudly rather than
+    ``time_limit`` / ``numerical_failure``), that iterate is not a KKT point
+    and the implicit-function gradient is meaningless — so fail loudly rather than
     return silent NaNs/garbage into a downstream optimizer. Use the host
     ``pounce.qp`` API (which surfaces ``QpResult.status``) to inspect the
     failure."""

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -98,7 +98,8 @@ class QpResult:
     status:
         One of ``"optimal"``, ``"primal_infeasible"``,
         ``"dual_infeasible"`` (unbounded), ``"iteration_limit"``,
-        ``"numerical_failure"``.
+        ``"time_limit"`` (the ``max_wall_time`` budget ran out; ``x`` is the
+        best iterate reached), ``"numerical_failure"``.
     x:
         Primal solution, shape ``(n,)``.
     y:

--- a/python/tests/test_qp_sensitivity.py
+++ b/python/tests/test_qp_sensitivity.py
@@ -213,47 +213,62 @@ def _big_convex_qp(n, seed):
 
 
 def test_qp_solve_releases_the_gil():
-    import os
+    """Observe GIL availability directly, rather than inferring it from speedup.
+
+    A daemon thread increments a counter in a tight pure-Python loop. While
+    another thread holds the GIL that counter cannot advance *at all* — a
+    Python thread executes no bytecode without the GIL — so comparing the
+    counter's rate during the solve against its rate while the main thread
+    sleeps (GIL fully free) separates the two regimes definitionally.
+
+    This replaces a wall-clock speedup assertion (threaded < 0.75 × serial)
+    that measured whether the machine had idle cores as much as whether the
+    GIL was released, and failed on loaded CI runners at ratio 0.77. The rate
+    ratio is robust to CPU contention because both windows are measured under
+    the same load, and it needs no minimum core count: even on one core the
+    spinner merely shares the core with the solver (ratio ≈ 0.5) instead of
+    being frozen out entirely (ratio ≈ 0).
+    """
     import threading
     import time
 
-    if (os.cpu_count() or 1) < 4:
-        pytest.skip("need ≥4 cores to observe parallel speedup")
+    stop = threading.Event()
+    counter = 0
 
-    n, k = 180, 8
-    args = [_big_convex_qp(n, s) for s in range(k)]
+    def spin():
+        nonlocal counter
+        while not stop.is_set():
+            counter += 1
 
-    def run_all():
-        for a in args:
-            QpSensitivity(**a)
+    def rate(fn):
+        """Spinner iterations per second observed while fn() runs."""
+        c0, t0 = counter, time.perf_counter()
+        fn()
+        return (counter - c0) / (time.perf_counter() - t0)
 
-    def run_all_threaded():
-        ths = [threading.Thread(target=lambda a=a: QpSensitivity(**a)) for a in args]
-        for t in ths:
-            t.start()
-        for t in ths:
-            t.join()
+    args = [_big_convex_qp(180, s) for s in range(8)]
+    spinner = threading.Thread(target=spin, daemon=True)
+    spinner.start()
+    try:
+        time.sleep(0.2)  # let the spinner reach a steady rate
+        free = rate(lambda: time.sleep(0.3))
 
-    # Best-of-2 for each to damp scheduling noise.
-    serial = min(_timed(run_all) for _ in range(2))
-    threaded = min(_timed(run_all_threaded) for _ in range(2))
+        def solves():
+            for a in args:
+                QpSensitivity(**a)
 
-    # With the GIL released the k solves overlap across cores; pre-fix they
-    # serialize (ratio ≈ 1). A generous 0.75 threshold separates the regimes
-    # (measured ≈ 0.4 released vs ≈ 0.97 held) while tolerating a busy CI box.
-    assert threaded < 0.75 * serial, (
-        f"threaded solves did not overlap (threaded={threaded:.3f}s, "
-        f"serial={serial:.3f}s, ratio={threaded / serial:.2f}); the GIL was "
-        f"not released during the QP solve"
+        during = rate(solves)
+    finally:
+        stop.set()
+        spinner.join(timeout=5)
+
+    # Measured ≈ 0.95 with the GIL released; ≈ 0 if it were held for the
+    # duration of the Rust solve. 0.25 sits far from both.
+    assert during > 0.25 * free, (
+        f"a pure-Python thread made little progress during the solve "
+        f"(during={during:.3g} it/s, free={free:.3g} it/s, "
+        f"ratio={during / free:.2f}); the GIL was not released"
     )
-
-
-def _timed(fn):
-    import time
-
-    t0 = time.perf_counter()
-    fn()
-    return time.perf_counter() - t0
 
 
 # --- weak activity / non-strict complementarity (gh #219) -------------------
@@ -335,8 +350,13 @@ def test_weakly_active_matches_the_one_sided_branches():
 
     def at(b):
         return solve_qp(
-            P=np.eye(2), c=[0.0, 0.0], A=[[1.0, 1.0]], b=[b],
-            G=[[1.0, -2.0]], h=[-0.5], tol=1e-12,
+            P=np.eye(2),
+            c=[0.0, 0.0],
+            A=[[1.0, 1.0]],
+            b=[b],
+            G=[[1.0, -2.0]],
+            h=[-0.5],
+            tol=1e-12,
         ).x
 
     fwd = (at(1.0 + delta) - s.x) / delta


### PR DESCRIPTION
## Problem

POUNCE has shared wall/CPU deadline machinery for the NLP engine, but both convex routes currently discard max_wall_time/max_cpu_time. I found this while updating oximo to pounce-rs v0.10.0.

## Fix

I added a `time_limit: Option<Duration>` and `TimeLimit` statuses to both convex engines.

Note: I didn't add a cancellation callback because it would make everything more complex, but feel free to add it if you think it is worth it.

Disclaimer: I did an initial implementation and then used ChatGPT Terra Medium to update all the relevant sites.

*— @GermanHeim (commit `afb9d2fc`)*

---

## Maintainer follow-up

Reviewing the above surfaced a latent wrong-answer bug that the change made
reachable, so rather than send a long review I pushed four commits on top
(agreed with @GermanHeim in the thread below). Two rules came out of it, and
both are now applied uniformly across the convex family.

**Cancellation is an error, not a value** (`00ee7334`)

`factorize_with_inertia_control` returned `Ok(current)` when the deadline
expired mid-shift-escalation, handing an *unsolved* KKT right-hand side back
as if it were a step. The result is `x = -g` with `delta == 0`, which skips
the step-quality guards — so the solve reported `Optimal` on a
feasible-but-wrong point. Under a time limit you could get a silently wrong
answer with a success status.

Now a typed `QpError::DeadlineExpired`, propagated by `?` and softened to
`QpStatus::TimeLimit` only at the public entry points, which let the compiler
find the remaining paths. Regression test in
`crates/pounce-qp/tests/deadline_cancellation.rs`: reverting the fix reports
`x = [2.0, 2.0]` as `Optimal` against a true optimum of `(3.2, 0.8)`.

**A verdict outranks the clock** (`00ee7334`, `ad216bbc`)

Several exits stamped `TimeLimit` over a status the solver had already earned.
A proven `Optimal` / `OptimalInaccurate` / `PrimalInfeasible` /
`DualInfeasible` now survives a deadline crossing; only a give-up status is
relabelled. Someone whose problem solves in 1.001 s under `time_limit = 1`
should not lose the optimum they already have.

Applied in the IPM, both HSDE drivers, the LP crossover, and — `ad216bbc` —
the active-set route, which had the same overwrite at its post-solve exit and
at three retry gates, so `method="active_set"` and the LP path could lose a
verdict the same way. `verify_status` also salvaged an identical KKT point to
`Optimal` when iterations ran out but discarded it when the clock did; both
now share the `mark_timed_out` policy.

**The budgets didn't compose** (`62efc742`)

`max_wall_time` bounded each *engine*, not the solve. When a convex attempt
declined and handed off to the NLP path, the NLP side built its deadline from
the option value — still naming the full budget. Spend 55 s of a 60 s budget
convex-side, get 60 more. A declined attempt is now charged against the
remaining budget before the handover.

Note for anyone touching that code: `max_wall_time` has a *strict* lower bound
of zero, so writing `0.0` for an exhausted budget is rejected as invalid and
silently leaves the full budget in place — exactly the bug being fixed. Hence
the `1e-9` floor, pinned by a test.

**Smaller items** (`82b7572d`)

`TimeLimit` was missing from the CLI's `ALL_STATUSES` retry table (a spent
budget was a reason to try again); `max_wall_time` values are validated before
becoming a `Duration`; the Python status code and message map the new status;
`batch.rs` documents that `time_limit` is *per instance*, not per batch.

**Flaky test, unrelated to this change** (`22f7781d`)

CI failed on the base commit in `test_qp_solve_releases_the_gil` — diagnosed
by @GermanHeim as a timing threshold, and correct. It asserted eight threaded
solves finish in under 0.75x the serial time, which measures whether the
runner has idle cores as much as whether the extension releases the GIL; it
failed at ratio 0.77 on a small runner.

It now observes the property directly: a daemon thread increments a counter in
a tight Python loop, and while another thread holds the GIL that counter
cannot advance at all. Comparing its rate during the solve against its rate
while the main thread sleeps separates the regimes by definition rather than
by throughput — measured 0.92-1.05 released against ~0 held, with the
threshold at 0.25. The `>= 4 core` skip is gone, so the test now runs
everywhere instead of silently opting out on small runners.

## Audited and deliberately unchanged

The NLP filter-IPM family already satisfies both rules via its own
`pounce_common::timing::Deadline` (#242/#244/#245/#246) — its KKT solver
returns `false` on an aborted factorization rather than a bogus success, which
is precisely the pattern the QP path was missing, and `opt_error.rs` checks
the clock only after the convergence verdicts. `simplex.rs` returns `None` on
every deadline exit, so it can never regress a solution.

`pounce-algorithm`'s SQP arm sets no `QpOptions::time_limit` on its inner QP
solves, so those stay bounded by iterations and by the outer `Deadline` at
iteration granularity; documented rather than wired.

## Follow-up

#585 — the Python API can *receive* the `time_limit` status but has no way to
*request* a budget, since the pyo3 layer never sets the field. That is an API
addition and wants its own PR, so it is intentionally not closed by this one.
