### PR TITLE
sens: report what the estimate's linear step does about the bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,21 +94,27 @@ separate the predictor from the exact value at the perturbed active
 set: the barrier parameter `mu`, the factor's inertia-correction
 `perturbations`, and `bounds_relaxed`.
 
-The ratio test behind `alpha` skips coordinates already on a bound,
-which cannot be crossed. Scored anyway, such a coordinate divides the
-slack the barrier leaves by a step component of the same size, and
-becomes the minimum on any model carrying an active bound.
+A coordinate the full step carries past a bound always sets `alpha`,
+off the same predicate and the same tolerance that put it in
+`crossed`, so the two halves of the report cannot disagree about what
+the step did.
 
-Two things decide that a coordinate is on a bound. The classification
-rules where the classifier commits, and it is applied per side rather
-than per coordinate, because a coordinate held at one bound can still
-be carried across its other one. For the coordinates the classifier
-declines to rule on, the size of the remaining gap decides: it is
-`O(mu)` at a strongly active bound and `O(sqrt(mu))` at a weakly active
-one against `O(1)` room in the interior, so the threshold scales with
-`sqrt(mu)`, measured four orders of magnitude clear of the interior
-case. The `ambiguous` verdict cannot decide this on its own, since it
-covers both a coordinate on its bound and one near it with room left.
+Everything else on a bound is skipped, since the slack left there is
+what the barrier leaves rather than room to move, and dividing it by a
+step of the same size would become the minimum on any model carrying an
+active bound. Because that exclusion only ever reaches coordinates that
+do not cross, it cannot cost a crossing. The classification drives it
+where the classifier commits, applied per side rather than per
+coordinate, because a coordinate held at one bound can still be carried
+across its other one. For the coordinates the classifier declines to
+rule on, the size of the remaining gap decides: it is `O(mu)` at a
+strongly active bound and `O(sqrt(mu))` at a weakly active one against
+`O(1)` room in the interior, so the threshold scales with `sqrt(mu)`,
+measured four orders of magnitude clear of the interior case, and is
+capped because it is applied relative to the coordinate's own magnitude
+and a loose `mu` at termination would otherwise widen it without limit.
+The `ambiguous` verdict cannot decide this on its own, since it covers
+both a coordinate on its bound and one near it with room left.
 
 A solve that ran with a non-zero `bound_relax_factor` is reported
 through `bounds_relaxed` rather than raised on. The classifier declines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,19 +95,34 @@ set: the barrier parameter `mu`, the factor's inertia-correction
 `perturbations`, and `bounds_relaxed`.
 
 The ratio test behind `alpha` skips coordinates already on a bound,
-which cannot be crossed, and it reads the classification rather than a
-distance to decide that. The remaining slack is `O(mu)` at a strongly
-active bound but `O(sqrt(mu))` at a weakly active one, and no single
-distance threshold separates the second from a coordinate genuinely
-close to its bound. Scored anyway, such a coordinate divides two small
-quantities and becomes the minimum on any model carrying an active
-bound.
+which cannot be crossed. Scored anyway, such a coordinate divides the
+slack the barrier leaves by a step component of the same size, and
+becomes the minimum on any model carrying an active bound.
+
+Two things decide that a coordinate is on a bound. The classification
+rules where the classifier commits, and it is applied per side rather
+than per coordinate, because a coordinate held at one bound can still
+be carried across its other one. For the coordinates the classifier
+declines to rule on, the size of the remaining gap decides: it is
+`O(mu)` at a strongly active bound and `O(sqrt(mu))` at a weakly active
+one against `O(1)` room in the interior, so the threshold scales with
+`sqrt(mu)`, measured four orders of magnitude clear of the interior
+case. The `ambiguous` verdict cannot decide this on its own, since it
+covers both a coordinate on its bound and one near it with room left.
 
 A solve that ran with a non-zero `bound_relax_factor` is reported
 through `bounds_relaxed` rather than raised on. The classifier declines
 such a solve, since relaxed bounds shift the slacks it reads, but
 everything else in the report is still measured, and a caller reaches
 for a diagnostic precisely when the estimate and a re-solve disagree.
+
+Reading that condition needs `Solver.bound_relax_factor`, new on the
+Python solver: the value the held solve actually ran under, or `None`
+with no converged factor. `classify_activity` guards on it and raises,
+so without the getter the only way to tell a relaxed solve from any
+other bad-options failure is to provoke the guard and match the option
+name in the message, which turns back into a re-raise the day that
+message is reworded.
 
 This is item 0 of the sensitivity roadmap (#255).
 
@@ -119,13 +134,18 @@ factor column. The violation is checked against direct evaluation at
 the predicted point to 1e-12, hand-computed crossings to 1e-8 for both
 a variable bound and a constraint, and the report is checked identical
 through `SolverFactory('pounce')`, `SolverFactory('pounce_v2')` and the
-contrib `SolverFactory('pounce')`.
+contrib `SolverFactory('pounce')`. An invariant across every fixture
+holds the two halves of the report consistent: a non-empty crossed set
+means the reported fraction is below one. The ratio test is also tested
+directly on constructed arrays, which is the only way to reach the
+no-bound sentinel, a coordinate left outside its bound by a relaxed
+solve, and the per-side exclusion at chosen values.
 
 ### Fixed — the no-session error named only the legacy solver route (#584)
 
 `estimate`, `gradient`, `covariance` and `information` raise a
 `RuntimeError` naming the declaration to make and the solve to run when
-no sensitivity session exists. All five messages told the reader to
+no sensitivity session exists. All four messages told the reader to
 solve with `SolverFactory('pounce')`, which has been incomplete since
 the v2 interface was added in 0.10.0: `SolverFactory('pounce_v2')` and
 the contrib `SolverFactory('pounce')` build the same session, because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,75 @@ changes.
   extraction and presolve.
 
 
+### Added — `pyomo_pounce.estimate_report()` says what the estimate's step did about the bounds (#584)
+
+`estimate()` takes the linear step, clips any variable it carries past a
+bound, warns, and returns. The warning names those variables and stops
+there, so a caller cannot tell how far along the perturbation the active
+set changed, whether a constraint became active before any variable did,
+or whether a gap against a re-solve comes from the barrier parameter,
+from a regularized factor, or from relaxed bounds.
+
+`estimate_report(model, perturb)` takes the same perturbation argument
+and returns an `EstimateReport`:
+
+    import pyomo_pounce
+    pyomo_pounce.declare_sens_param(m.setpoint)
+    pyo.SolverFactory("pounce").solve(m)
+
+    r = pyomo_pounce.estimate_report(m, [(m.setpoint, 3.0)])
+    r.alpha        # 0.0297, the fraction of the move that fits
+    r.first        # 'u[0]', the control that saturates there
+    r.crossed      # {u[0]: 4.22, u[1]: 0.68, ...}, what estimate() clamps
+    r.violation    # 4.4e-16, the constraint violation at the prediction
+    r.activity     # per variable: inactive, weakly_active, strongly_active
+
+`estimate()` is unchanged. The classification is passed through from
+`Solver.classify_activity`, the same classifier the covariance and
+information accessors use, so this adds no second opinion about what is
+active. Alongside it the report carries the three quantities that
+separate the predictor from the exact value at the perturbed active
+set: the barrier parameter `mu`, the factor's inertia-correction
+`perturbations`, and `bounds_relaxed`.
+
+The ratio test behind `alpha` skips coordinates already on a bound,
+which cannot be crossed, and it reads the classification rather than a
+distance to decide that. The remaining slack is `O(mu)` at a strongly
+active bound but `O(sqrt(mu))` at a weakly active one, and no single
+distance threshold separates the second from a coordinate genuinely
+close to its bound. Scored anyway, such a coordinate divides two small
+quantities and becomes the minimum on any model carrying an active
+bound.
+
+A solve that ran with a non-zero `bound_relax_factor` is reported
+through `bounds_relaxed` rather than raised on. The classifier declines
+such a solve, since relaxed bounds shift the slacks it reads, but
+everything else in the report is still measured, and a caller reaches
+for a diagnostic precisely when the estimate and a re-solve disagree.
+
+This is item 0 of the sensitivity roadmap (#255).
+
+**Testing.** `pyomo-pounce/tests/test_estimate_report.py` checks the
+step fraction against a brute-force scan of the unclamped step, on the
+same coordinate exactly and to 1e-12 relative, including with a fixed
+variable present, which the solve removes and which shifts every later
+factor column. The violation is checked against direct evaluation at
+the predicted point to 1e-12, hand-computed crossings to 1e-8 for both
+a variable bound and a constraint, and the report is checked identical
+through `SolverFactory('pounce')`, `SolverFactory('pounce_v2')` and the
+contrib `SolverFactory('pounce')`.
+
+### Fixed — the no-session error named only the legacy solver route (#584)
+
+`estimate`, `gradient`, `covariance` and `information` raise a
+`RuntimeError` naming the declaration to make and the solve to run when
+no sensitivity session exists. All five messages told the reader to
+solve with `SolverFactory('pounce')`, which has been incomplete since
+the v2 interface was added in 0.10.0: `SolverFactory('pounce_v2')` and
+the contrib `SolverFactory('pounce')` build the same session, because
+`Pounce.solve` sends a model carrying declarations down the same
+in-process route. The messages now name all three.
+
 ## [0.10.0] - 2026-08-11
 
 ### Fixed — an ill-scaled dense Hessian column no longer costs the solve its certificate

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -438,6 +438,27 @@ impl PySolver {
             .unwrap_or(false)
     }
 
+    /// The `bound_relax_factor` the held solve actually ran under, or
+    /// `None` with no converged factor. Non-zero means a variable may
+    /// have settled outside the bound the model declares.
+    ///
+    /// This is the value `classify_activity` guards on, readable
+    /// without provoking the guard. A caller that wants to report a
+    /// relaxed solve rather than fail on one would otherwise have to
+    /// call `classify_activity`, catch its error, and match the option
+    /// name in the message, which silently becomes a re-raise the day
+    /// that message is reworded.
+    ///
+    /// Reads the solve's own value, not the live option: relaxing (or
+    /// not) happened once, and setting the option afterwards
+    /// re-measures nothing.
+    #[getter]
+    fn bound_relax_factor(&self) -> Option<Number> {
+        self.state
+            .as_ref()
+            .and_then(|s| s.inner.converged().map(|c| c.bound_relax_factor))
+    }
+
     /// Classify every bounded variable and every finite-bounded
     /// inequality row of the held solve by activity, from the ratio of
     /// barrier curvature to the model's own curvature (the exact

--- a/crates/pounce-sensitivity/tests/solver_session.rs
+++ b/crates/pounce-sensitivity/tests/solver_session.rs
@@ -384,6 +384,23 @@ fn classify_activity_refuses_a_solve_that_relaxed_its_bounds() {
         Err(pounce_sensitivity::SolverError::BadOptions(_)),
     ));
 
+    // The option name is load-bearing in the message, not decoration:
+    // pyomo-pounce's `estimate_report` tells this refusal apart from
+    // every other BadOptions by matching that token, and reports the
+    // solve as having relaxed its bounds instead of raising. Rewording
+    // the message without updating that check turns the branch back
+    // into a re-raise, silently.
+    let msg = match solver.classify_activity() {
+        Err(pounce_sensitivity::SolverError::BadOptions(m)) => m,
+        Err(other) => panic!("expected BadOptions, got {other:?}"),
+        Ok(_) => panic!("expected BadOptions, got a report"),
+    };
+    assert!(
+        msg.contains("bound_relax_factor"),
+        "the message must name the option: pyomo-pounce matches it to \
+         report a relaxed solve rather than raise (got {msg:?})",
+    );
+
     // Clearing the option afterwards must NOT unlock the stale state:
     // its slacks were measured against relaxed bounds and still are.
     solver

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -198,7 +198,8 @@ being applied.
 This works on both solve paths: the ordinary ASL/subprocess solve and
 the in-process path taken when the model carries [sensitivity
 declarations](sensitivity.md) — including the accessors themselves.
-`covariance()`, `information()`, `gradient()` and `estimate()` read the
+`covariance()`, `information()`, `gradient()`, `estimate()` and
+`estimate_report()` read the
 solver's KKT factorization directly rather than through the scaling
 layer, so they carry the factors through their own natural-units
 translation and answer in your model's units on a variable-scaled solve

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -134,12 +134,58 @@ warns when the linear step leaves the variable bounds (a single-pass
 projection analogous to the CLI's `--sens-boundcheck`) — with one
 exception, a bound written on a declared Param, covered in
 [Declared Params in variable bounds](#declared-params-in-variable-bounds)
-below. Multiplier sensitivities are available for equality constraints.
+below. `estimate_report()` measures the same step and reports where the
+active set changes along it, covered in
+[What the step did about the bounds](#what-the-step-did-about-the-bounds-estimate_report). Multiplier sensitivities are available for equality constraints.
 Models without declarations solve through the ordinary AMPL/CLI path,
 unchanged. See
 [`python/notebooks/25_pyomo_sensitivity.ipynb`](https://github.com/jkitchin/pounce/blob/main/python/notebooks/25_pyomo_sensitivity.ipynb)
 for a worked optimal-control example (initial conditions as
 parameters; the first-move gradient IS the NMPC feedback gain).
+
+### What the step did about the bounds: `estimate_report()`
+
+The clamp warning names the variables it clipped and stops there.
+`estimate_report()` takes the same perturbation argument `estimate()`
+takes and measures the same step, so a caller can see how far along the
+perturbation the active set changes:
+
+```python
+from pyomo_pounce import estimate_report
+
+r = estimate_report(m, [(m.setpoint, 3.0)])
+r.alpha          # fraction of the perturbation that fits before a
+                 # bound is reached; inf when none lies in the way
+r.first          # which variable or constraint is reached there
+r.crossed        # {var data: distance past its bound} for the full
+r.crossed_rows   # step, and the same for inequality constraints
+r.violation      # constraint violation at the predicted point
+r.activity       # per coordinate: inactive / weakly_active /
+r.row_activity   # strongly_active / ambiguous / unidentified / ...
+```
+
+`alpha` comes from a ratio test along the step. Coordinates already on
+a bound take no part in it, on that side: the gap left at an active
+bound is the slack the barrier leaves rather than room to move, so
+scoring it divides two small quantities and would become the minimum on
+any model carrying an active bound. Which coordinates those are comes
+from the same classifier [Activity classification](#activity-classification)
+describes, and for the ones it declines to rule on, from the size of
+the gap measured against `sqrt(mu)`.
+
+Three further fields say what separates this prediction from the exact
+value at the perturbed active set, which is what a caller needs when
+the estimate and a re-solve disagree: `mu`, the barrier parameter the
+factorization sits at; `perturbations`, the factor's inertia
+corrections, non-zero when it was regularized; and `bounds_relaxed`,
+true when the solve ran with a non-zero `bound_relax_factor`. That last
+case is reported rather than raised on, and it empties the two
+classification maps, because relaxed bounds shift the slacks the
+classifier reads.
+
+`violation` is the primal half of the residual. The dual half needs the
+multipliers at the perturbed point and belongs to a corrector step,
+which holds them.
 
 ### Declared Params in variable bounds
 

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -43,12 +43,14 @@ from pyomo_pounce.block_init import (
 from pyomo_pounce.pounce_solver import POUNCE, check_binary
 from pyomo_pounce.sens import (
     Covariance,
+    EstimateReport,
     Gradient,
     covariance,
     declare_fitted,
     declare_residual,
     declare_sens_param,
     estimate,
+    estimate_report,
     gradient,
     information,
     Information,
@@ -105,6 +107,8 @@ __all__ = [
     "Covariance",
     "gradient",
     "estimate",
+    "estimate_report",
+    "EstimateReport",
     "Gradient",
     "preflight",
     "PyomoPreflightReport",

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1104,9 +1104,15 @@ class EstimateReport:
         Variable data to the distance by which the full step leaves
         that variable's bound. These are the variables `estimate()`
         clamps.
-    crossed_rows : dict
-        Constraint name to the same distance, for inequality
+    crossed_rows : ComponentMap
+        Constraint data to the same distance, for inequality
         constraints.
+
+    Those two are keyed by model components, because every coordinate
+    that crosses has one. The two classifications below are keyed by
+    solve-space name instead, because they cover every coordinate of
+    the solve, including the ones the declared-parameter surgery
+    created, which have no counterpart on the model.
     violation : float
         Largest constraint violation at the predicted point, measured
         against the perturbed right-hand sides. This is the primal
@@ -1168,12 +1174,21 @@ def _row_step(session, dx):
     """Jacobian at the base point times the step, in row order."""
     rows, cols = session.nl.jacobian_structure()
     vals = np.asarray(session.nl.jacobian(session.base_x))
-    dg = np.zeros(len(session.con_names))
-    np.add.at(dg, np.asarray(rows), vals * dx[np.asarray(cols)])
-    return dg
+    return np.bincount(np.asarray(rows),
+                       weights=vals * dx[np.asarray(cols)],
+                       minlength=len(session.con_names))
 
 
-def _ratio_test(base, step, lo, hi, names, live=None):
+#: No bound at all reaches here as the reader's sentinel rather than an
+#: infinity: `read_nl` seeds every bound vector with +-1e19, so an
+#: `isfinite` test passes on it and scores a crossing at 1e18 times the
+#: perturbation. The magnitude test is the convention the rest of the
+#: package already uses (`preflight`, `block_init`, gh #401 / #403).
+_NO_BOUND = 1e19
+
+
+def _ratio_test(base, step, lo, hi, names, live=None, on_bound=None,
+                mu=float("nan")):
     """Smallest fraction of `step` that reaches a bound, and where.
 
     Only coordinates strictly inside their bounds take part, because a
@@ -1185,28 +1200,47 @@ def _ratio_test(base, step, lo, hi, names, live=None):
     active bound. Activity is reported through the classification
     instead.
 
-    The caller passes the exclusion in `live`, built from that same
-    classification, since that slack is O(mu) at a strongly active
-    bound but O(sqrt(mu)) at a weakly active one and no single distance
-    threshold separates the second from a coordinate genuinely close to
-    its bound. The threshold below is the backstop for when no
-    classification is available.
+    Two things decide that a coordinate is on a bound, and both are
+    needed. `on_bound` carries the classification, which is exact where
+    the classifier commits. It is applied per SIDE, not per coordinate:
+    a coordinate held at one bound can still be carried across its
+    other one, so excluding it outright drops a real crossing.
+
+    The distance test below covers the coordinates the classifier
+    declines to rule on, where the label cannot answer the question
+    because `ambiguous` spans both a coordinate near its bound with
+    room left and one already on it. What separates those is the size
+    of the remaining gap, which is O(mu) at a strongly active bound and
+    O(sqrt(mu)) at a weakly active one, against O(1) room in the
+    interior. So the threshold scales with sqrt(mu), measured four
+    orders of magnitude clear of the interior case. Without a
+    classification there is no `mu` either, and it falls back to a
+    fixed threshold.
 
     Coordinates whose step is below the roundoff of their own magnitude
     also take no part, since dividing by one puts the crossing at an
     enormous multiple of the perturbation, which is not a finding.
     """
     scale = np.maximum(1.0, np.abs(base))
-    bound = np.where(step > 0, hi, lo)
+    toward_hi = step > 0
+    bound = np.where(toward_hi, hi, lo)
     distance = bound - base
-    ok = (np.abs(step) > 1e-12 * scale) & np.isfinite(bound) & (
-        np.abs(distance) > 1e-9 * scale)
+    on_bound_gap = 1e-9 if not np.isfinite(mu) else max(1e-9, 10.0 * mu ** 0.5)
+    ok = (np.abs(step) > 1e-12 * scale) & (np.abs(bound) < _NO_BOUND) & (
+        np.abs(distance) > on_bound_gap * scale)
     if live is not None:
         ok &= live
+    if on_bound is not None:
+        # the nearer bound is the one the coordinate is held at, and it
+        # is only that side the classification rules out
+        at_hi = (hi - base) <= (base - lo)
+        ok &= ~(on_bound & (toward_hi == at_hi))
     if not ok.any():
         return float("inf"), None
     fraction = np.full(base.shape, np.inf)
-    fraction[ok] = distance[ok] / step[ok]
+    # a relaxed solve can settle outside a bound, which leaves no room
+    # to move rather than a negative amount of it
+    fraction[ok] = np.maximum(distance[ok] / step[ok], 0.0)
     i = int(np.argmin(fraction))
     return float(fraction[i]), names[i]
 
@@ -1214,7 +1248,11 @@ def _ratio_test(base, step, lo, hi, names, live=None):
 #: Classifications that put a coordinate ON its bound. Both have the
 #: slack going to zero, so neither can be crossed by a step. Strongly
 #: active leaves an O(mu) gap and weakly active an O(sqrt(mu)) one, and
-#: neither gap is room the step can move through.
+#: neither gap is room the step can move through. `ambiguous` and
+#: `unidentified` are absent on purpose: the first spans coordinates on
+#: their bound AND coordinates near it with room left, and the second
+#: says only that the curvature is below scale, so neither label
+#: answers the question. `_ratio_test`'s distance test rules on those.
 _AT_BOUND = ("strongly_active", "weakly_active")
 
 
@@ -1270,23 +1308,19 @@ def estimate_report(model, perturb):
 
     row_names = _user_row_names(session)
 
-    # The classifier raises for a solve that relaxed its bounds,
-    # because relaxed bounds shift the slacks it reads. Report that as
-    # the fact it is: the rest of the report is still measured, and a
-    # diagnostic that raised here would give the caller nothing
-    # exactly when they are trying to find out why the estimate
-    # disagrees with a re-solve. `mu` comes from the classifier, so it is unavailable
-    # too.
+    # The classifier raises for a solve that relaxed its bounds, since
+    # relaxed bounds shift the slacks it reads. Ask the solve what it
+    # ran under instead of provoking that and reading the message, and
+    # report it as the fact it is. The rest of the report is still
+    # measured, where a diagnostic that raised would give the caller
+    # nothing exactly when they are trying to find out why the estimate
+    # disagrees with a re-solve. `mu` comes from the classifier, so it
+    # is unavailable on that path too.
     mu, activity, row_status = float("nan"), {}, {}
-    bounds_relaxed = False
     var_on_bound = row_on_bound = None
-    try:
+    bounds_relaxed = bool(session.solver.bound_relax_factor)
+    if not bounds_relaxed:
         act = session.solver.classify_activity()
-    except Exception as err:                       # noqa: BLE001
-        if "bound_relax_factor" not in str(err):
-            raise
-        bounds_relaxed = True
-    else:
         mu = float(act["mu"])
         activity = dict(zip(session.var_names, act["var_status"]))
         row_status = dict(zip(row_names, act["row_status"]))
@@ -1294,8 +1328,7 @@ def estimate_report(model, perturb):
         row_on_bound = _on_bound(act["row_status"])
 
     alpha, first = _ratio_test(base, dx, lo, hi, session.var_names,
-                               live=None if var_on_bound is None
-                               else ~var_on_bound)
+                               on_bound=var_on_bound, mu=mu)
     first_kind = None if first is None else "variable"
     dg = _row_step(session, dx)
     g_base = np.asarray(session.nl.constraints(base))
@@ -1303,9 +1336,8 @@ def estimate_report(model, perturb):
     # activity, and a pin constraint moves by construction
     live = g_l < g_u
     live[list(pin_idx)] = False
-    a_row, f_row = _ratio_test(
-        g_base, dg, g_l, g_u, row_names,
-        live=live if row_on_bound is None else live & ~row_on_bound)
+    a_row, f_row = _ratio_test(g_base, dg, g_l, g_u, row_names, live=live,
+                               on_bound=row_on_bound, mu=mu)
     if a_row < alpha:
         alpha, first, first_kind = a_row, f_row, "constraint"
 
@@ -1317,11 +1349,13 @@ def estimate_report(model, perturb):
             crossed[ov] = float(max(lo[i] - x_new[i], x_new[i] - hi[i]))
     g_pred = g_base + dg
     gtol = 1e-9 * np.maximum(1.0, np.abs(g_pred))
-    crossed_rows = {}
+    crossed_rows = ComponentMap()
     out_of_bounds = (g_pred < g_l - gtol) | (g_pred > g_u + gtol)
     for j in np.where(live & out_of_bounds)[0]:
-        crossed_rows[row_names[j]] = float(
-            max(g_l[j] - g_pred[j], g_pred[j] - g_u[j]))
+        oc = model.find_component(row_names[j])
+        if oc is not None:
+            crossed_rows[oc] = float(
+                max(g_l[j] - g_pred[j], g_pred[j] - g_u[j]))
 
     # the perturbation IS the shift of the pin constraints' right-hand
     # sides, so the violation is measured against the shifted ones

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1200,22 +1200,33 @@ def _ratio_test(base, step, lo, hi, names, live=None, on_bound=None,
     active bound. Activity is reported through the classification
     instead.
 
-    Two things decide that a coordinate is on a bound, and both are
-    needed. `on_bound` carries the classification, which is exact where
-    the classifier commits. It is applied per SIDE, not per coordinate:
-    a coordinate held at one bound can still be carried across its
-    other one, so excluding it outright drops a real crossing.
+    A coordinate the full step carries past a bound is always scored,
+    whatever the exclusion would otherwise say. That case IS a crossing,
+    at a fraction below one by construction, and the caller reads it in
+    `crossed` off the same predicate and the same tolerance. Deciding it
+    twice is what let the two disagree, reporting that 998 times the
+    perturbation fits while naming a coordinate the single step leaves
+    its bound by 0.25.
 
-    The distance test below covers the coordinates the classifier
-    declines to rule on, where the label cannot answer the question
-    because `ambiguous` spans both a coordinate near its bound with
-    room left and one already on it. What separates those is the size
-    of the remaining gap, which is O(mu) at a strongly active bound and
+    So the exclusion below only ever applies to coordinates that do not
+    cross, and cannot cost a crossing. Two things drive it. `on_bound`
+    carries the classification, which is exact where the classifier
+    commits, applied per SIDE rather than per coordinate, since a
+    coordinate held at one bound can still be carried across its other
+    one.
+
+    The distance test covers the coordinates the classifier declines to
+    rule on, where the label cannot answer the question because
+    `ambiguous` spans both a coordinate near its bound with room left
+    and one already on it. What separates those is the size of the
+    remaining gap, which is O(mu) at a strongly active bound and
     O(sqrt(mu)) at a weakly active one, against O(1) room in the
     interior. So the threshold scales with sqrt(mu), measured four
-    orders of magnitude clear of the interior case. Without a
-    classification there is no `mu` either, and it falls back to a
-    fixed threshold.
+    orders of magnitude clear of the interior case. It is capped
+    because it is applied relative to the coordinate's own magnitude,
+    and a loose `mu` at termination would otherwise widen it without
+    limit. Without a classification there is no `mu` either, and it
+    falls back to a fixed threshold.
 
     Coordinates whose step is below the roundoff of their own magnitude
     also take no part, since dividing by one puts the crossing at an
@@ -1225,16 +1236,27 @@ def _ratio_test(base, step, lo, hi, names, live=None, on_bound=None,
     toward_hi = step > 0
     bound = np.where(toward_hi, hi, lo)
     distance = bound - base
-    on_bound_gap = 1e-9 if not np.isfinite(mu) else max(1e-9, 10.0 * mu ** 0.5)
-    ok = (np.abs(step) > 1e-12 * scale) & (np.abs(bound) < _NO_BOUND) & (
-        np.abs(distance) > on_bound_gap * scale)
-    if live is not None:
-        ok &= live
+    present = np.abs(bound) < _NO_BOUND
+    moving = np.abs(step) > 1e-12 * scale
+
+    # the same predicate, and the same tolerance, that fills `crossed`
+    reached = base + step
+    tol = 1e-9 * np.maximum(1.0, np.abs(reached))
+    crosses = present & moving & np.where(
+        toward_hi, reached > bound + tol, reached < bound - tol)
+
+    floor = 1e-9 if not np.isfinite(mu) else min(
+        1e-2, max(1e-9, 10.0 * mu ** 0.5))
+    interior = np.abs(distance) > floor * scale
     if on_bound is not None:
         # the nearer bound is the one the coordinate is held at, and it
         # is only that side the classification rules out
         at_hi = (hi - base) <= (base - lo)
-        ok &= ~(on_bound & (toward_hi == at_hi))
+        interior &= ~(on_bound & (toward_hi == at_hi))
+
+    ok = present & moving & (crosses | interior)
+    if live is not None:
+        ok &= live
     if not ok.any():
         return float("inf"), None
     fraction = np.full(base.shape, np.inf)

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -901,7 +901,8 @@ def _session_for(component):
     if reg is None or reg.session is None:
         raise RuntimeError(
             "no sensitivity session: declare_sens_param() then solve with "
-            "SolverFactory('pounce') first")
+            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+            "contrib SolverFactory('pounce') first")
     return reg.session
 
 
@@ -1005,6 +1006,25 @@ def gradient(target=None, *, wrt):
     return Gradient(session, targets, params)
 
 
+def _perturbation_deltas(session, perturb):
+    """Pin constraints and right-hand-side shifts for a perturbation.
+
+    The shift is measured from the pin constraint's stored right-hand
+    side, which holds the Param's value at the solve, not from the
+    Param's current value on the model.
+    """
+    items = perturb.items() if hasattr(perturb, "items") else perturb
+    pin_idx, deltas = [], []
+    for comp, newval in items:
+        for pd in _iter_data(comp):
+            nv = newval[pd.index()] if comp.is_indexed() and hasattr(
+                newval, "__getitem__") else newval
+            pin = _param_pin(session, pd)
+            pin_idx.append(pin)
+            deltas.append(float(nv) - float(session.nl.g_l[pin]))
+    return pin_idx, deltas
+
+
 def estimate(model, perturb, clamp=True):
     """First-order estimate of the solution at perturbed parameter values.
 
@@ -1031,22 +1051,10 @@ def estimate(model, perturb, clamp=True):
     if session is None:
         raise RuntimeError(
             "no sensitivity session: declare_sens_param() then solve with "
-            "SolverFactory('pounce') first")
+            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+            "contrib SolverFactory('pounce') first")
 
-    items = perturb.items() if hasattr(perturb, "items") else perturb
-    pin_idx, deltas = [], []
-    for comp, newval in items:
-        for pd in _iter_data(comp):
-            nv = newval[pd.index()] if comp.is_indexed() and hasattr(
-                newval, "__getitem__") else newval
-            pin = _param_pin(session, pd)
-            pin_idx.append(pin)
-            # the step shifts the pin constraint's RHS, and that RHS
-            # holds the Param's solve-time value exactly, so it is the
-            # baseline: a caller that has already written the new value
-            # into the Param (the receding-horizon pattern) gets the
-            # same estimate as one that has not
-            deltas.append(float(nv) - float(session.nl.g_l[pin]))
+    pin_idx, deltas = _perturbation_deltas(session, perturb)
 
     # parametric_step returns the factor's x block (var-x); base_x and
     # everything below it (nl.x_l/x_u, var_names) are full-x
@@ -1073,6 +1081,265 @@ def estimate(model, perturb, clamp=True):
         if ov is not None:
             out[ov] = float(val)
     return out
+
+
+# ── step diagnostics ──────────────────────────────────────────────────────────
+
+class EstimateReport:
+    """What the linear step behind `estimate()` does about the bounds.
+
+    Attributes
+    ----------
+    alpha : float
+        The fraction of the requested perturbation that can be taken
+        before the first bound is reached, from the ratio test along
+        the step. At least 1.0 means the full step stays inside every
+        bound, and infinity means no bound lies in the step direction.
+    first : str or None
+        Name of the variable or constraint reaching its bound at
+        `alpha`, None when `alpha` is infinite.
+    first_kind : str or None
+        Either "variable" or "constraint", naming what `first` is.
+    crossed : ComponentMap
+        Variable data to the distance by which the full step leaves
+        that variable's bound. These are the variables `estimate()`
+        clamps.
+    crossed_rows : dict
+        Constraint name to the same distance, for inequality
+        constraints.
+    violation : float
+        Largest constraint violation at the predicted point, measured
+        against the perturbed right-hand sides. This is the primal
+        half of the residual. The dual half needs the multipliers at
+        the perturbed point, so it is computed by the corrector, which
+        holds them, rather than assembled here.
+    mu : float
+        Barrier parameter of the held factorization.
+    activity, row_activity : dict
+        Name to activity classification from the core classifier, over
+        variables and over constraints. Both are empty when
+        `bounds_relaxed` is true.
+    perturbations : list
+        The held factor's inertia-correction perturbations. Any
+        non-zero entry means the factor is regularized, so the step is
+        taken against a modified matrix and differs from the exact
+        active-set answer by that much.
+    bounds_relaxed : bool
+        True when the solve ran with a non-zero `bound_relax_factor`,
+        which lets a variable settle outside the bound the model
+        declares. The classifier raises for such a solve, since relaxed
+        bounds shift the slacks it reads, and the ratio test measures
+        distances to bounds the solve did not hold to.
+
+    The last three, with `mu`, are what separate this predictor from
+    the exact value at the perturbed active set. A caller comparing the
+    estimate against a re-solve reads them to tell which one explains
+    the difference.
+    """
+
+    def __init__(self, alpha, first, first_kind, crossed, crossed_rows,
+                 violation, mu, activity, row_activity, perturbations,
+                 bounds_relaxed):
+        self.alpha = alpha
+        self.first = first
+        self.first_kind = first_kind
+        self.crossed = crossed
+        self.crossed_rows = crossed_rows
+        self.violation = violation
+        self.mu = mu
+        self.activity = activity
+        self.row_activity = row_activity
+        self.perturbations = perturbations
+        self.bounds_relaxed = bounds_relaxed
+
+    def __repr__(self):
+        n = len(self.crossed) + len(self.crossed_rows)
+        where = f", first {self.first_kind} {self.first}" if self.first else ""
+        flags = "".join([
+            ", regularized" if any(self.perturbations) else "",
+            ", bounds relaxed" if self.bounds_relaxed else "",
+        ])
+        return (f"EstimateReport(alpha={self.alpha:.6g}{where}, "
+                f"crossed={n}, violation={self.violation:.3e}, "
+                f"mu={self.mu:.3e}{flags})")
+
+
+def _row_step(session, dx):
+    """Jacobian at the base point times the step, in row order."""
+    rows, cols = session.nl.jacobian_structure()
+    vals = np.asarray(session.nl.jacobian(session.base_x))
+    dg = np.zeros(len(session.con_names))
+    np.add.at(dg, np.asarray(rows), vals * dx[np.asarray(cols)])
+    return dg
+
+
+def _ratio_test(base, step, lo, hi, names, live=None):
+    """Smallest fraction of `step` that reaches a bound, and where.
+
+    Only coordinates strictly inside their bounds take part, because a
+    coordinate already on a bound is not one the step can cross. That
+    exclusion is what makes the answer mean anything: at an active
+    bound the remaining gap is the small slack the barrier leaves, the
+    step component is the same size, and their quotient can take any
+    value. It would then become the minimum on any model carrying an
+    active bound. Activity is reported through the classification
+    instead.
+
+    The caller passes the exclusion in `live`, built from that same
+    classification, since that slack is O(mu) at a strongly active
+    bound but O(sqrt(mu)) at a weakly active one and no single distance
+    threshold separates the second from a coordinate genuinely close to
+    its bound. The threshold below is the backstop for when no
+    classification is available.
+
+    Coordinates whose step is below the roundoff of their own magnitude
+    also take no part, since dividing by one puts the crossing at an
+    enormous multiple of the perturbation, which is not a finding.
+    """
+    scale = np.maximum(1.0, np.abs(base))
+    bound = np.where(step > 0, hi, lo)
+    distance = bound - base
+    ok = (np.abs(step) > 1e-12 * scale) & np.isfinite(bound) & (
+        np.abs(distance) > 1e-9 * scale)
+    if live is not None:
+        ok &= live
+    if not ok.any():
+        return float("inf"), None
+    fraction = np.full(base.shape, np.inf)
+    fraction[ok] = distance[ok] / step[ok]
+    i = int(np.argmin(fraction))
+    return float(fraction[i]), names[i]
+
+
+#: Classifications that put a coordinate ON its bound. Both have the
+#: slack going to zero, so neither can be crossed by a step. Strongly
+#: active leaves an O(mu) gap and weakly active an O(sqrt(mu)) one, and
+#: neither gap is room the step can move through.
+_AT_BOUND = ("strongly_active", "weakly_active")
+
+
+def _on_bound(statuses):
+    return np.array([s in _AT_BOUND for s in statuses])
+
+
+def _user_row_names(session):
+    """Row names as the user wrote them.
+
+    The declared-parameter surgery moves every constraint onto its own
+    block, so the solve's constraint names are clone names. `con_alias`
+    records the move in the other direction. A constraint with no entry
+    keeps the clone name, which is what the pin constraints have and
+    what marks them as the solve's own.
+    """
+    back = {clone: orig for orig, clone in session.con_alias.items()}
+    return [back.get(nm, nm) for nm in session.con_names]
+
+
+def estimate_report(model, perturb):
+    """Report what `estimate()`'s linear step does about the bounds.
+
+    Takes the same perturbation argument `estimate()` takes and returns
+    an EstimateReport. Nothing about the estimate changes: this runs
+    the same step and measures it.
+
+    The ratio test divides each bounded coordinate's distance to the
+    bound it moves toward by the size of its step component and keeps
+    the smallest value, over variables and over inequality constraint
+    constraints. Equality constraints do not take part, since the step
+    holds them to first order and they admit no activity change. The
+    constraints pinning the declared Params are excluded on the same
+    grounds, because the perturbation moves their right-hand sides by
+    construction.
+    """
+    reg = model.__dict__.get(_REG)
+    session = reg.session if reg else None
+    if session is None:
+        raise RuntimeError(
+            "no sensitivity session: declare_sens_param() then solve with "
+            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+            "contrib SolverFactory('pounce') first")
+
+    pin_idx, deltas = _perturbation_deltas(session, perturb)
+    dx = session.scatter_x(
+        np.asarray(session.solver.parametric_step(pin_idx, deltas)))
+    base = np.asarray(session.base_x)
+    x_new = base + dx
+
+    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
+    g_l, g_u = np.asarray(session.nl.g_l), np.asarray(session.nl.g_u)
+
+    row_names = _user_row_names(session)
+
+    # The classifier raises for a solve that relaxed its bounds,
+    # because relaxed bounds shift the slacks it reads. Report that as
+    # the fact it is: the rest of the report is still measured, and a
+    # diagnostic that raised here would give the caller nothing
+    # exactly when they are trying to find out why the estimate
+    # disagrees with a re-solve. `mu` comes from the classifier, so it is unavailable
+    # too.
+    mu, activity, row_status = float("nan"), {}, {}
+    bounds_relaxed = False
+    var_on_bound = row_on_bound = None
+    try:
+        act = session.solver.classify_activity()
+    except Exception as err:                       # noqa: BLE001
+        if "bound_relax_factor" not in str(err):
+            raise
+        bounds_relaxed = True
+    else:
+        mu = float(act["mu"])
+        activity = dict(zip(session.var_names, act["var_status"]))
+        row_status = dict(zip(row_names, act["row_status"]))
+        var_on_bound = _on_bound(act["var_status"])
+        row_on_bound = _on_bound(act["row_status"])
+
+    alpha, first = _ratio_test(base, dx, lo, hi, session.var_names,
+                               live=None if var_on_bound is None
+                               else ~var_on_bound)
+    first_kind = None if first is None else "variable"
+    dg = _row_step(session, dx)
+    g_base = np.asarray(session.nl.constraints(base))
+    # an equality constraint is held to first order and cannot change
+    # activity, and a pin constraint moves by construction
+    live = g_l < g_u
+    live[list(pin_idx)] = False
+    a_row, f_row = _ratio_test(
+        g_base, dg, g_l, g_u, row_names,
+        live=live if row_on_bound is None else live & ~row_on_bound)
+    if a_row < alpha:
+        alpha, first, first_kind = a_row, f_row, "constraint"
+
+    tol = 1e-9 * np.maximum(1.0, np.abs(x_new))
+    crossed = ComponentMap()
+    for i in np.where((x_new < lo - tol) | (x_new > hi + tol))[0]:
+        ov = model.find_component(session.var_names[i])
+        if ov is not None:
+            crossed[ov] = float(max(lo[i] - x_new[i], x_new[i] - hi[i]))
+    g_pred = g_base + dg
+    gtol = 1e-9 * np.maximum(1.0, np.abs(g_pred))
+    crossed_rows = {}
+    out_of_bounds = (g_pred < g_l - gtol) | (g_pred > g_u + gtol)
+    for j in np.where(live & out_of_bounds)[0]:
+        crossed_rows[row_names[j]] = float(
+            max(g_l[j] - g_pred[j], g_pred[j] - g_u[j]))
+
+    # the perturbation IS the shift of the pin constraints' right-hand
+    # sides, so the violation is measured against the shifted ones
+    gl_p, gu_p = g_l.copy(), g_u.copy()
+    for pin, d in zip(pin_idx, deltas):
+        gl_p[pin] += d
+        gu_p[pin] += d
+    g_at = np.asarray(session.nl.constraints(x_new))
+    violation = float(np.max(np.maximum.reduce(
+        [gl_p - g_at, g_at - gu_p, np.zeros_like(g_at)])))
+
+    return EstimateReport(
+        alpha=alpha, first=first, first_kind=first_kind,
+        crossed=crossed, crossed_rows=crossed_rows, violation=violation,
+        mu=mu, activity=activity, row_activity=row_status,
+        perturbations=np.asarray(session.solver.kkt_perturbations).tolist(),
+        bounds_relaxed=bounds_relaxed,
+    )
 
 
 # ── parameter covariance ──────────────────────────────────────────────────────
@@ -1984,7 +2251,8 @@ def covariance(model, sigma_sq=None, n_data=None, hessian="lagrangian",
             "no sensitivity session: declare_fitted() (and optionally "
             "declare_residual()), or retain_kkt() for "
             "wrt= queries with nothing declared, then solve with "
-            "SolverFactory('pounce') first")
+            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+            "contrib SolverFactory('pounce') first")
     # the block: the declared fitted parameters by default, or any
     # block of the solve's variables via wrt= (each call re-reduces
     # onto its own argument, so one solve serves as many blocks as are
@@ -2367,7 +2635,8 @@ def information(model, hessian="lagrangian", wrt=None):
             "no sensitivity session: declare_fitted() (and optionally "
             "declare_residual()), or retain_kkt() for "
             "wrt= queries with nothing declared, then solve with "
-            "SolverFactory('pounce') first")
+            "SolverFactory('pounce'), SolverFactory('pounce_v2') or the "
+            "contrib SolverFactory('pounce') first")
     params, rows = _resolve_wrt(session, wrt, "information")
     n_params = len(params)
     wording = "fitted" if wrt is None else "block"

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -1093,8 +1093,11 @@ class EstimateReport:
     alpha : float
         The fraction of the requested perturbation that can be taken
         before the first bound is reached, from the ratio test along
-        the step. At least 1.0 means the full step stays inside every
-        bound, and infinity means no bound lies in the step direction.
+        the step. On a solve that kept its bounds, at least 1.0 means
+        the full step stays inside every one of them. That does not
+        follow when `bounds_relaxed` is true, since the solve can leave
+        a coordinate outside a bound before the step starts. Infinity
+        means no bound lies in the step direction.
     first : str or None
         Name of the variable or constraint reaching its bound at
         `alpha`, None when `alpha` is infinite.
@@ -1103,7 +1106,12 @@ class EstimateReport:
     crossed : ComponentMap
         Variable data to the distance by which the full step leaves
         that variable's bound. These are the variables `estimate()`
-        clamps.
+        clamps. Measured at the predicted point against both bounds, so
+        on a relaxed solve an entry can be a coordinate the SOLVE left
+        outside its bound rather than one the step carried past. The
+        step fraction looks only along the step direction, so the two
+        answer different questions there and `alpha` can be at or above
+        one while this is non-empty.
     crossed_rows : ComponentMap
         Constraint data to the same distance, for inequality
         constraints.

--- a/pyomo-pounce/tests/test_estimate_report.py
+++ b/pyomo-pounce/tests/test_estimate_report.py
@@ -1,0 +1,333 @@
+"""Tests for pyomo_pounce.estimate_report: what the linear step does
+about the bounds."""
+import numpy as np
+
+import pytest
+import pyomo.environ as pyo
+
+import pyomo_pounce  # noqa: F401  (registers 'pounce')
+from pyomo_pounce import declare_sens_param, estimate, estimate_report
+
+
+def bounded(ub_y=5.0, fixed=False):
+    """min (x-p)^2 + (y-2p)^2, so the unconstrained solution is x = p,
+    y = 2p and the step is dx/dp = 1, dy/dp = 2. From p = 1, y reaches
+    ub_y after (ub_y - 2) / 2 units of p."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-5.0, ub_y), initialize=1.0)
+    expr = (m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2
+    if fixed:
+        # a fixed variable is removed from the solve, which shifts every
+        # later factor column; the report must stay in user space
+        m.f = pyo.Var(bounds=(3.0, 3.0), initialize=3.0)
+        expr = expr + (m.f - 3.0) ** 2
+    m.obj = pyo.Objective(expr=expr)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def with_row():
+    """The same objective under x + y <= 6, which binds at p = 2 while
+    both variables are still interior."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(-50.0, 50.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-50.0, 50.0), initialize=2.0)
+    m.c = pyo.Constraint(expr=m.x + m.y <= 6.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def brute_force(model, param, newval):
+    """Scan the unclamped step for the first variable bound reached."""
+    return brute_force_multi(model, [(param, newval)])
+
+
+def brute_force_multi(model, perturb):
+    base = {id(v): pyo.value(v)
+            for v in model.component_data_objects(pyo.Var, active=True)}
+    est = estimate(model, perturb, clamp=False)
+    alpha, who = float("inf"), None
+    for v, x1 in est.items():
+        x0 = base[id(v)]
+        d = x1 - x0
+        if abs(d) < 1e-14:
+            continue
+        b = (v.ub if v.ub is not None else np.inf) if d > 0 else (
+            v.lb if v.lb is not None else -np.inf)
+        if not np.isfinite(b):
+            continue
+        a = max((b - x0) / d, 0.0)
+        if a < alpha:
+            alpha, who = a, v.name
+    return alpha, who
+
+
+def test_step_fraction_matches_the_hand_computed_crossing():
+    # y goes 2 -> 8 over p = 1 -> 4 and stops at 5, which is half way
+    m = bounded()
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert r.first == "y"
+    assert r.first_kind == "variable"
+    assert r.alpha == pytest.approx(0.5, abs=1e-8)
+
+
+def test_step_fraction_matches_a_brute_force_scan():
+    m = bounded()
+    alpha, who = brute_force(m, m.p, 4.0)
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert r.first == who
+    assert r.alpha == pytest.approx(alpha, rel=1e-12)
+
+
+def test_a_fixed_variable_does_not_shift_the_scan():
+    m = bounded(fixed=True)
+    alpha, who = brute_force(m, m.p, 4.0)
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert r.first == who == "y"
+    assert r.alpha == pytest.approx(alpha, rel=1e-12)
+
+
+def test_an_interior_perturbation_crosses_nothing():
+    m = bounded()
+    r = estimate_report(m, [(m.p, 1.2)])
+    assert r.alpha > 1.0
+    assert len(r.crossed) == 0
+    assert r.crossed_rows == {}
+    assert r.violation == pytest.approx(0.0, abs=1e-8)
+
+
+def test_crossed_reports_the_distance_past_the_bound():
+    m = bounded()
+    r = estimate_report(m, [(m.p, 4.0)])
+    est = estimate(m, [(m.p, 4.0)], clamp=False)
+    assert len(r.crossed) == 1
+    assert m.y in r.crossed
+    assert r.crossed[m.y] == pytest.approx(est[m.y] - m.y.ub, rel=1e-9)
+
+
+def test_a_constraint_row_can_bind_before_any_variable():
+    m = with_row()
+    r = estimate_report(m, [(m.p, 3.0)])
+    # the row sits at 3 and gains 3 per unit of p, so it reaches 6 at
+    # p = 2, half way to p = 3
+    assert r.first_kind == "constraint"
+    assert r.alpha == pytest.approx(0.5, abs=1e-8)
+    assert len(r.crossed) == 0
+
+
+def test_rows_are_named_as_the_model_names_them():
+    m = with_row()
+    r = estimate_report(m, [(m.p, 3.0)])
+    assert r.first == "c"
+    assert set(r.crossed_rows) == {"c"}
+    assert "c" in r.row_activity
+
+
+def test_violation_matches_direct_evaluation_at_the_predicted_point():
+    m = with_row()
+    r = estimate_report(m, [(m.p, 3.0)])
+    for v, val in estimate(m, [(m.p, 3.0)], clamp=False).items():
+        v.set_value(val)
+    body = pyo.value(m.x) + pyo.value(m.y)
+    assert r.violation == pytest.approx(max(body - 6.0, 0.0), rel=1e-12)
+
+
+def test_the_pin_row_is_not_reported_as_a_crossing():
+    # the perturbation moves the pin row's right-hand side by
+    # construction, so it is neither a crossing nor a violation
+    m = bounded()
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert all("paramConst" not in nm for nm in r.crossed_rows)
+    assert r.violation == pytest.approx(0.0, abs=1e-8)
+
+
+def test_classification_and_mu_match_the_core_classifier():
+    m = bounded()
+    r = estimate_report(m, [(m.p, 4.0)])
+    session = m.__dict__["_pounce_sens"].session
+    act = session.solver.classify_activity()
+    assert r.mu == pytest.approx(float(act["mu"]), rel=1e-12)
+    assert r.activity["y"] == act["var_status"][session.var_names.index("y")]
+    assert set(r.activity) >= {"x", "y"}
+
+
+def test_an_already_active_bound_is_not_a_crossing():
+    """A variable on its bound has an O(mu) gap left and an O(mu) step
+    component, and their quotient is noise. It must not set the step
+    fraction: the classification is what reports it."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=4.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-5.0, 5.0), initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert pyo.value(m.y) == pytest.approx(5.0, abs=1e-6)
+
+    r = estimate_report(m, [(m.p, 5.0)])
+    assert r.activity["y"] == "strongly_active"
+    assert r.first == "x"          # x runs 4 -> 5 against its bound of 10
+    assert r.alpha == pytest.approx(6.0, rel=1e-6)
+
+
+def test_a_saturating_control_is_named_with_its_step_fraction():
+    """The case the diagnostics exist for: a setpoint move large enough
+    to drive a control onto its bound, where estimate() clamps and
+    reports nothing about which control or how far along the move it
+    happened."""
+    n, a, b, r = 6, 0.8, 0.5, 0.05
+    m = pyo.ConcreteModel()
+    m.k = pyo.RangeSet(0, n - 1)
+    m.sp = pyo.Param(initialize=0.5, mutable=True)
+    m.x = pyo.Var(pyo.RangeSet(0, n), initialize=0.0)
+    m.u = pyo.Var(m.k, bounds=(-1.0, 1.0), initialize=0.0)
+    m.x[0].fix(0.0)
+
+    @m.Constraint(m.k)
+    def dynamics(m, k):
+        return m.x[k + 1] == a * m.x[k] + b * m.u[k]
+
+    m.obj = pyo.Objective(
+        expr=sum((m.x[k + 1] - m.sp) ** 2 for k in m.k)
+        + r * sum(m.u[k] ** 2 for k in m.k))
+    declare_sens_param(m.sp)
+    pyo.SolverFactory("pounce").solve(m)
+    assert all(abs(pyo.value(m.u[k])) < 0.999 for k in m.k)
+
+    r_small = estimate_report(m, [(m.sp, 0.55)])
+    assert r_small.alpha > 1.0
+    assert len(r_small.crossed) == 0
+
+    r_big = estimate_report(m, [(m.sp, 3.0)])
+    assert r_big.first_kind == "variable"
+    assert r_big.first.startswith("u[")
+    assert 0.0 < r_big.alpha < 1.0
+    assert r_big.crossed                     # estimate() clamps these
+    assert all(v.name.startswith("u[") for v in r_big.crossed)
+
+    # the step fraction is the fraction of the setpoint move that fits,
+    # so the perturbation it admits crosses nothing
+    fits = 0.5 + r_big.alpha * (3.0 - 0.5)
+    assert estimate_report(m, [(m.sp, fits)]).alpha == pytest.approx(
+        1.0, rel=1e-6)
+
+
+def test_provenance_is_reported_on_an_ordinary_solve():
+    """The three things separating the predictor from the exact value
+    at the perturbed active set: the barrier parameter, whether the
+    factor was regularized, and whether the solve relaxed its bounds."""
+    m = bounded()
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert np.isfinite(r.mu) and r.mu > 0.0
+    assert r.bounds_relaxed is False
+    assert not any(r.perturbations)     # convex model, no inertia correction
+
+
+def test_a_relaxed_solve_is_reported_rather_than_raising():
+    """`bound_relax_factor` lets a variable settle outside its declared
+    bound, so the classifier refuses the solve. The rest of the report
+    is still measured, since a caller reaches for it precisely when the
+    estimate and a re-solve disagree."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-5.0, 5.0), initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(
+        m, options={"bound_relax_factor": 1e-8})
+
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert r.bounds_relaxed is True
+    assert r.activity == {} and r.row_activity == {}
+    assert np.isnan(r.mu)
+    # the measured half still lands
+    assert r.first == "y"
+    assert r.alpha == pytest.approx(0.5, abs=1e-6)
+
+
+def test_a_weakly_active_bound_is_classified_as_such():
+    """min (x - 1)^2 with x <= 1 puts the bound on the unconstrained
+    minimum, so the bound is active and its multiplier is zero: strict
+    complementarity fails and the classification must say so rather
+    than call it strongly active."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(None, 1.0), initialize=0.0)
+    m.z = pyo.Var(bounds=(-5.0, 5.0), initialize=0.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.z - m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    # the barrier leaves an O(sqrt(mu)) gap here, not the O(mu) gap it
+    # leaves at a strongly active bound
+    assert pyo.value(m.x) == pytest.approx(1.0, abs=1e-3)
+
+    r = estimate_report(m, [(m.p, 1.5)])
+    assert r.activity["x"] == "weakly_active"
+    # that gap is barrier residue, so it is not room the step can cross:
+    # scoring it would put the first crossing at a fraction of a percent
+    assert r.first != "x"
+    assert r.first == "z"
+
+
+def test_several_parameters_perturbed_at_once():
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.q = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-5.0, 5.0), initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.q) ** 2)
+    declare_sens_param(m.p)
+    declare_sens_param(m.q)
+    pyo.SolverFactory("pounce").solve(m)
+
+    # y tracks q alone and reaches 5 at q = 2.5, half way to q = 4
+    r = estimate_report(m, [(m.p, 2.0), (m.q, 4.0)])
+    assert r.first == "y"
+    assert r.alpha == pytest.approx(0.5, abs=1e-6)
+    alpha, who = brute_force_multi(m, [(m.p, 2.0), (m.q, 4.0)])
+    assert r.first == who
+    assert r.alpha == pytest.approx(alpha, rel=1e-12)
+
+
+def test_every_solver_route_reports_the_same():
+    """`Pounce.solve` sends a model carrying declarations down the same
+    in-process sensitivity route the legacy plugin uses, so one session
+    serves all three entry points and the report cannot depend on which
+    one ran."""
+    from pyomo.contrib.solver.common.factory import SolverFactory as SF2
+
+    reports = []
+    for solve in (lambda m: pyo.SolverFactory("pounce").solve(m),
+                  lambda m: pyo.SolverFactory("pounce_v2").solve(m),
+                  lambda m: SF2("pounce").solve(m)):
+        m = pyo.ConcreteModel()
+        m.p = pyo.Param(initialize=1.0, mutable=True)
+        m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+        m.y = pyo.Var(bounds=(-5.0, 5.0), initialize=1.0)
+        m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2)
+        declare_sens_param(m.p)
+        solve(m)
+        reports.append(estimate_report(m, [(m.p, 4.0)]))
+
+    legacy, v2, contrib = reports
+    for other in (v2, contrib):
+        assert other.first == legacy.first == "y"
+        assert other.alpha == pytest.approx(legacy.alpha, rel=1e-12)
+        assert other.mu == pytest.approx(legacy.mu, rel=1e-12)
+        assert other.activity == legacy.activity
+
+
+def test_no_session_is_a_clean_error():
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2)
+    with pytest.raises(RuntimeError, match="no sensitivity session"):
+        estimate_report(m, [(m.p, 2.0)])

--- a/pyomo-pounce/tests/test_estimate_report.py
+++ b/pyomo-pounce/tests/test_estimate_report.py
@@ -527,6 +527,33 @@ def test_the_distance_floor_is_capped():
     assert alpha == float("inf") and first is None
 
 
+@pytest.mark.parametrize("opts, label", [
+    ({}, "ordinary"),
+    ({"tol": 1e-2, "mu_init": 1e-1}, "loose"),
+])
+def test_a_loose_solve_does_not_widen_the_floor_past_a_real_gap(opts, label):
+    """End to end for the cap, since the floor is relative to the
+    coordinate's own magnitude and mu at termination is whatever the
+    solve leaves. Uncapped, `10 * sqrt(mu)` is 0.50 absolute here on an
+    ordinary solve and 13.6 on a loose one, both past the 0.4 units of
+    genuine room, so x would be dropped and its crossing missed."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1000.0, mutable=True)
+    m.x = pyo.Var(bounds=(None, 1000.4), initialize=999.0)
+    m.z = pyo.Var(bounds=(-5000.0, 5000.0), initialize=0.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.z - m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m, options=opts)
+
+    r = estimate_report(m, [(m.p, 1002.0)])
+    assert 10.0 * r.mu ** 0.5 * 1000.0 > 0.4, (
+        f"{label}: the uncapped floor no longer exceeds the gap, so this "
+        "no longer tests the cap")
+    # dx/dp is 1 and the gap is 0.4, so a fifth of the move fits
+    assert r.first == "x"
+    assert r.alpha == pytest.approx(0.2, rel=1e-3)
+
+
 def test_a_crossing_is_scored_even_where_the_exclusion_applies():
     """One predicate decides `crossed` and participation, so the two
     cannot disagree. A coordinate held at its bound and driven outward

--- a/pyomo-pounce/tests/test_estimate_report.py
+++ b/pyomo-pounce/tests/test_estimate_report.py
@@ -7,6 +7,80 @@ import pyomo.environ as pyo
 
 import pyomo_pounce  # noqa: F401  (registers 'pounce')
 from pyomo_pounce import declare_sens_param, estimate, estimate_report
+from pyomo_pounce.sens import _NO_BOUND, _ratio_test
+
+
+# ── the ratio test on its own ────────────────────────────────────────────────
+#
+# Three of its cases cannot be reached reliably by solving a model: the
+# no-bound sentinel needs a model with no bound in the step direction AND
+# a solve that leaves one, a relaxed solve settles outside its bound by an
+# amount the solver chooses, and the per-side exclusion needs a coordinate
+# the classifier calls on-bound while the step drives it the other way.
+# All three are ordinary arguments here.
+
+def test_ratio_test_reads_the_no_bound_sentinel_as_no_bound():
+    """`read_nl` seeds absent bounds with +-1e19, which is finite. An
+    `isfinite` test scores a crossing at 1e18 times the perturbation."""
+    base = np.array([0.0])
+    step = np.array([1.2])
+    lo = np.array([-_NO_BOUND])
+    hi = np.array([_NO_BOUND])
+    alpha, first = _ratio_test(base, step, lo, hi, ["z"])
+    assert alpha == float("inf")
+    assert first is None
+
+
+def test_ratio_test_clamps_a_coordinate_already_outside_its_bound():
+    """A relaxed solve settles outside a declared bound, so the distance
+    is negative. No room to move is 0.0, not a negative fraction."""
+    base = np.array([5.000000049582308])
+    step = np.array([0.5])
+    lo = np.array([-5.0])
+    hi = np.array([5.0])
+    alpha, first = _ratio_test(base, step, lo, hi, ["y"])
+    assert alpha == 0.0
+    assert first == "y"
+
+
+def test_ratio_test_excludes_only_the_side_a_coordinate_is_held_on():
+    """x is on ub = 1 and the step drives it to -2, past lb = -1. The
+    crossing is at 2/3 and belongs to the bound x is NOT held at."""
+    base = np.array([1.0, 0.0])
+    step = np.array([-3.0, 0.4])
+    lo = np.array([-1.0, -5.0])
+    hi = np.array([1.0, 5.0])
+    on_bound = np.array([True, False])
+    alpha, first = _ratio_test(base, step, lo, hi, ["x", "z"],
+                               on_bound=on_bound, mu=1e-9)
+    assert first == "x"
+    assert alpha == pytest.approx(2.0 / 3.0, rel=1e-12)
+
+    # and the side it IS held on stays excluded: driven up instead, the
+    # gap at ub is barrier residue and x must not set the fraction
+    alpha2, first2 = _ratio_test(base, np.array([3.0, 0.4]), lo, hi,
+                                 ["x", "z"], on_bound=on_bound, mu=1e-9)
+    assert first2 == "z"
+
+
+def test_ratio_test_scales_its_distance_floor_with_the_barrier():
+    """A coordinate the classifier declines to rule on is judged by the
+    size of its gap. At mu = 1e-9 a weakly active one sits O(sqrt(mu))
+    from its bound, four orders inside the interior case."""
+    lo, hi = np.array([-5.0]), np.array([1.0])
+    step = np.array([0.5])
+    weak = np.array([1.0 - 4.4e-5])       # O(sqrt(mu)) gap: on its bound
+    alpha, first = _ratio_test(weak, step, lo, hi, ["x"], mu=1e-9)
+    assert alpha == float("inf") and first is None
+
+    interior = np.array([1.0 - 1e-2])     # real room left
+    alpha, first = _ratio_test(interior, step, lo, hi, ["x"], mu=1e-9)
+    assert first == "x"
+    assert alpha == pytest.approx(2e-2, rel=1e-9)
+
+    # with no classification there is no mu, and the fixed floor applies
+    alpha, first = _ratio_test(weak, step, lo, hi, ["x"])
+    assert first == "x"
 
 
 def bounded(ub_y=5.0, fixed=False):
@@ -49,22 +123,32 @@ def brute_force(model, param, newval):
 
 
 def brute_force_multi(model, perturb):
-    base = {id(v): pyo.value(v)
-            for v in model.component_data_objects(pyo.Var, active=True)}
+    """Reference scan, deliberately reading the same arrays the code
+    under test reads.
+
+    An earlier version took bounds off the Pyomo model and clamped at
+    zero, so it silently disagreed with the production path in exactly
+    the two places that path was wrong (the +-1e19 sentinel and a
+    negative distance) and the suite could not see either.
+    """
+    session = model.__dict__["_pounce_sens"].session
+    lo, hi = np.asarray(session.nl.x_l), np.asarray(session.nl.x_u)
+    base = np.asarray(session.base_x)
     est = estimate(model, perturb, clamp=False)
     alpha, who = float("inf"), None
-    for v, x1 in est.items():
-        x0 = base[id(v)]
-        d = x1 - x0
+    for i, nm in enumerate(session.var_names):
+        v = model.find_component(nm)
+        if v is None or v not in est:
+            continue
+        d = est[v] - base[i]
         if abs(d) < 1e-14:
             continue
-        b = (v.ub if v.ub is not None else np.inf) if d > 0 else (
-            v.lb if v.lb is not None else -np.inf)
-        if not np.isfinite(b):
+        b = hi[i] if d > 0 else lo[i]
+        if abs(b) >= _NO_BOUND:
             continue
-        a = max((b - x0) / d, 0.0)
+        a = max((b - base[i]) / d, 0.0)
         if a < alpha:
-            alpha, who = a, v.name
+            alpha, who = a, nm
     return alpha, who
 
 
@@ -125,7 +209,8 @@ def test_rows_are_named_as_the_model_names_them():
     m = with_row()
     r = estimate_report(m, [(m.p, 3.0)])
     assert r.first == "c"
-    assert set(r.crossed_rows) == {"c"}
+    assert len(r.crossed_rows) == 1
+    assert m.c in r.crossed_rows
     assert "c" in r.row_activity
 
 
@@ -322,6 +407,97 @@ def test_every_solver_route_reports_the_same():
         assert other.alpha == pytest.approx(legacy.alpha, rel=1e-12)
         assert other.mu == pytest.approx(legacy.mu, rel=1e-12)
         assert other.activity == legacy.activity
+
+
+def test_a_bound_the_step_crosses_is_never_missed():
+    """The report must not contradict itself: anything in `crossed` was
+    reached by the full step, so the fraction that fits is below one.
+
+    Reachable whenever a two-sided coordinate is classified on-bound and
+    the step drives it toward the other side, which an exclusion applied
+    per coordinate rather than per side would drop.
+    """
+    cases = [
+        (bounded(), 4.0),
+        (bounded(fixed=True), 4.0),
+        (with_row(), 3.0),
+        (bounded(), 1.2),
+    ]
+    for m, newval in cases:
+        r = estimate_report(m, [(m.p, newval)])
+        if len(r.crossed) or len(r.crossed_rows):
+            assert r.alpha < 1.0, (
+                f"crossed {len(r.crossed)} variables and "
+                f"{len(r.crossed_rows)} constraints, yet reported that "
+                f"{r.alpha} of the perturbation fits")
+
+
+def test_a_coordinate_on_one_bound_can_still_cross_the_other():
+    """x is weakly active at its upper bound while the step drives it
+    down past its lower one. Excluding the coordinate rather than the
+    side it is held on loses that crossing."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(-1.0, 1.0), initialize=0.0)
+    m.z = pyo.Var(bounds=(-5.0, 5.0), initialize=0.0)
+    # minimized at x = p, so at p = 1 the upper bound is weakly active
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + 0.1 * (m.z - m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    assert m.x.value == pytest.approx(1.0, abs=1e-3)
+    assert estimate_report(m, [(m.p, 1.1)]).activity["x"] == "weakly_active"
+
+    # drive x down, away from the bound it is held at and toward the
+    # other one. x must be scored: the exclusion covers its upper side
+    # only. (Its step is the two-sided derivative at a degenerate base
+    # point, half the interior value, so the crossing lands where the
+    # scan says rather than where dx/dp = 1 would put it.)
+    r = estimate_report(m, [(m.p, -2.0)])
+    assert r.first == "x"
+    alpha, who = brute_force_multi(m, [(m.p, -2.0)])
+    assert who == "x"
+    assert r.alpha == pytest.approx(alpha, rel=1e-12)
+
+
+def test_no_bound_in_the_step_direction_reports_no_crossing():
+    """Unbounded variables reach the ratio test as the reader's +-1e19
+    sentinel, which is finite."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(initialize=0.0)
+    m.z = pyo.Var(initialize=0.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.z - 2 * m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+
+    r = estimate_report(m, [(m.p, 4.0)])
+    assert r.alpha == float("inf")
+    assert r.first is None and r.first_kind is None
+    assert len(r.crossed) == 0
+
+
+def test_a_relaxed_solve_never_reports_a_negative_fraction():
+    """Relaxed bounds let a variable settle outside its declared bound,
+    which is no room to move rather than a negative amount of it."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=4.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-5.0, 5.0), initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(
+        m, options={"bound_relax_factor": 1e-8})
+
+    r = estimate_report(m, [(m.p, 5.0)])
+    assert r.bounds_relaxed is True
+    assert r.alpha >= 0.0
+
+    # read off the solve, not off the classifier's error message: the
+    # report says the bounds were relaxed because the solve says so
+    session = m.__dict__["_pounce_sens"].session
+    assert session.solver.bound_relax_factor == 1e-8
+    with pytest.raises(Exception, match="bound_relax_factor"):
+        session.solver.classify_activity()
 
 
 def test_no_session_is_a_clean_error():

--- a/pyomo-pounce/tests/test_estimate_report.py
+++ b/pyomo-pounce/tests/test_estimate_report.py
@@ -56,9 +56,11 @@ def test_ratio_test_excludes_only_the_side_a_coordinate_is_held_on():
     assert first == "x"
     assert alpha == pytest.approx(2.0 / 3.0, rel=1e-12)
 
-    # and the side it IS held on stays excluded: driven up instead, the
-    # gap at ub is barrier residue and x must not set the fraction
-    alpha2, first2 = _ratio_test(base, np.array([3.0, 0.4]), lo, hi,
+    # and the side it IS held on stays excluded, for a step that does
+    # not carry it past that bound: the gap left there is barrier
+    # residue and x must not set the fraction
+    near = np.array([1.0 - 1e-6, 0.0])
+    alpha2, first2 = _ratio_test(near, np.array([5e-7, 0.4]), lo, hi,
                                  ["x", "z"], on_bound=on_bound, mu=1e-9)
     assert first2 == "z"
 
@@ -68,18 +70,21 @@ def test_ratio_test_scales_its_distance_floor_with_the_barrier():
     size of its gap. At mu = 1e-9 a weakly active one sits O(sqrt(mu))
     from its bound, four orders inside the interior case."""
     lo, hi = np.array([-5.0]), np.array([1.0])
-    step = np.array([0.5])
+    # steps that stop short of the bound, so the question is the floor
+    # rather than a crossing, which is scored either way
     weak = np.array([1.0 - 4.4e-5])       # O(sqrt(mu)) gap: on its bound
-    alpha, first = _ratio_test(weak, step, lo, hi, ["x"], mu=1e-9)
+    alpha, first = _ratio_test(weak, np.array([2e-5]), lo, hi, ["x"],
+                               mu=1e-9)
     assert alpha == float("inf") and first is None
 
     interior = np.array([1.0 - 1e-2])     # real room left
-    alpha, first = _ratio_test(interior, step, lo, hi, ["x"], mu=1e-9)
+    alpha, first = _ratio_test(interior, np.array([5e-3]), lo, hi, ["x"],
+                               mu=1e-9)
     assert first == "x"
-    assert alpha == pytest.approx(2e-2, rel=1e-9)
+    assert alpha == pytest.approx(2.0, rel=1e-9)
 
     # with no classification there is no mu, and the fixed floor applies
-    alpha, first = _ratio_test(weak, step, lo, hi, ["x"])
+    alpha, first = _ratio_test(weak, np.array([2e-5]), lo, hi, ["x"])
     assert first == "x"
 
 
@@ -98,6 +103,20 @@ def bounded(ub_y=5.0, fixed=False):
         m.f = pyo.Var(bounds=(3.0, 3.0), initialize=3.0)
         expr = expr + (m.f - 3.0) ** 2
     m.obj = pyo.Objective(expr=expr)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(m)
+    return m
+
+
+def held_at_a_bound():
+    """x is weakly active at ub = 1 after solving at p = 1, and z has
+    far bounds so it cannot be the first crossing at small
+    perturbations."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=1.0, mutable=True)
+    m.x = pyo.Var(bounds=(None, 1.0), initialize=0.0)
+    m.z = pyo.Var(bounds=(-500.0, 500.0), initialize=0.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.z - m.p) ** 2)
     declare_sens_param(m.p)
     pyo.SolverFactory("pounce").solve(m)
     return m
@@ -353,12 +372,15 @@ def test_a_weakly_active_bound_is_classified_as_such():
     # leaves at a strongly active bound
     assert pyo.value(m.x) == pytest.approx(1.0, abs=1e-3)
 
-    r = estimate_report(m, [(m.p, 1.5)])
+    # perturb away from the bound x is held at, so the question is
+    # whether the gap counts as room rather than whether x crosses
+    r = estimate_report(m, [(m.p, 0.5)])
     assert r.activity["x"] == "weakly_active"
-    # that gap is barrier residue, so it is not room the step can cross:
-    # scoring it would put the first crossing at a fraction of a percent
+    # that gap is barrier residue, not room, so it must not set the
+    # fraction: scoring it would put the crossing at a fraction of a
+    # percent of a perturbation that crosses nothing
+    assert len(r.crossed) == 0
     assert r.first != "x"
-    assert r.first == "z"
 
 
 def test_several_parameters_perturbed_at_once():
@@ -422,6 +444,8 @@ def test_a_bound_the_step_crosses_is_never_missed():
         (bounded(fixed=True), 4.0),
         (with_row(), 3.0),
         (bounded(), 1.2),
+        (held_at_a_bound(), 1.5),   # pushed further past the same side
+        (held_at_a_bound(), 0.5),   # and away from it
     ]
     for m, newval in cases:
         r = estimate_report(m, [(m.p, newval)])
@@ -457,6 +481,69 @@ def test_a_coordinate_on_one_bound_can_still_cross_the_other():
     alpha, who = brute_force_multi(m, [(m.p, -2.0)])
     assert who == "x"
     assert r.alpha == pytest.approx(alpha, rel=1e-12)
+
+
+def test_a_coordinate_pushed_further_past_the_bound_it_is_held_at():
+    """The exclusion covers the side x is held on, which is also the
+    side the step pushes it past. Excluding it there reported that 998
+    times the perturbation fits while naming x as leaving its bound by
+    0.25 in the same object."""
+    m = held_at_a_bound()
+    r = estimate_report(m, [(m.p, 1.5)])
+    assert r.activity["x"] == "weakly_active"
+    assert len(r.crossed) == 1 and m.x in r.crossed
+
+    # x is on its bound and the step drives it outward, so no part of
+    # the perturbation fits before the bound is reached
+    assert r.first == "x"
+    assert r.alpha < 1e-3
+
+    # the classification still keeps it out when nothing crosses, which
+    # is what the exclusion is for
+    r2 = estimate_report(m, [(m.p, 1.0 + 1e-9)])
+    assert len(r2.crossed) == 0
+    assert r2.first != "x"
+
+
+def test_the_distance_floor_is_capped():
+    """The floor is relative to the coordinate's own magnitude, so an
+    uncapped `10 * sqrt(mu)` widens without limit when the solve leaves
+    mu loose, and a dropped coordinate is a missed crossing."""
+    lo = np.array([-1e9])
+    hi = np.array([1000.4])
+    base = np.array([1000.0])         # 0.4 units of genuine room
+    step = np.array([1.0])
+
+    # a loose solve: sqrt(mu) * 10 would be 3e-2 relative, 30 absolute
+    alpha, first = _ratio_test(base, step, lo, hi, ["x"], mu=9.1e-6)
+    assert first == "x"
+    assert alpha == pytest.approx(0.4, rel=1e-9)
+
+    # and the calibration at an ordinary mu is unchanged: a gap at
+    # barrier scale is still read as being on the bound
+    weak = np.array([1.0 - 4.4e-5])
+    alpha, first = _ratio_test(weak, np.array([2e-5]), np.array([-5.0]),
+                               np.array([1.0]), ["x"], mu=1e-9)
+    assert alpha == float("inf") and first is None
+
+
+def test_a_crossing_is_scored_even_where_the_exclusion_applies():
+    """One predicate decides `crossed` and participation, so the two
+    cannot disagree. A coordinate held at its bound and driven outward
+    scores 0.0: no room, rather than no bound."""
+    lo = np.array([-5.0])
+    hi = np.array([1.0])
+    base = np.array([1.0 - 4.4e-5])   # on its bound at barrier scale
+    step = np.array([0.25])           # driven outward, well past it
+    alpha, first = _ratio_test(base, step, lo, hi, ["x"],
+                               on_bound=np.array([True]), mu=1e-9)
+    assert first == "x"
+    assert 0.0 <= alpha < 1.0
+
+    # nothing crosses: the exclusion applies and x drops out
+    alpha, first = _ratio_test(base, np.array([1e-6]), lo, hi, ["x"],
+                               on_bound=np.array([True]), mu=1e-9)
+    assert alpha == float("inf") and first is None
 
 
 def test_no_bound_in_the_step_direction_reports_no_crossing():

--- a/pyomo-pounce/tests/test_estimate_report.py
+++ b/pyomo-pounce/tests/test_estimate_report.py
@@ -438,6 +438,13 @@ def test_a_bound_the_step_crosses_is_never_missed():
     Reachable whenever a two-sided coordinate is classified on-bound and
     the step drives it toward the other side, which an exclusion applied
     per coordinate rather than per side would drop.
+
+    It holds on a solve that kept its bounds, which is why the check
+    below is scoped to those. A relaxed solve can settle a coordinate
+    outside a bound, and `crossed` measures both bounds at the predicted
+    point while the step fraction looks only along the step direction,
+    so there the two answer different questions and are not required to
+    agree. The test below this one covers that case.
     """
     cases = [
         (bounded(), 4.0),
@@ -449,11 +456,37 @@ def test_a_bound_the_step_crosses_is_never_missed():
     ]
     for m, newval in cases:
         r = estimate_report(m, [(m.p, newval)])
-        if len(r.crossed) or len(r.crossed_rows):
+        if (len(r.crossed) or len(r.crossed_rows)) and not r.bounds_relaxed:
             assert r.alpha < 1.0, (
                 f"crossed {len(r.crossed)} variables and "
                 f"{len(r.crossed_rows)} constraints, yet reported that "
                 f"{r.alpha} of the perturbation fits")
+
+
+def test_a_relaxed_solve_reports_a_bound_its_own_solve_left():
+    """`bound_relax_factor` lets the solve settle a coordinate outside a
+    declared bound. `crossed` names it, since it measures both bounds at
+    the predicted point, while the step fraction looks only along the
+    step direction and correctly finds nothing reached there. Both are
+    right, so the invariant above is scoped to unrelaxed solves."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=4.0, mutable=True)
+    m.x = pyo.Var(bounds=(0.0, 10.0), initialize=1.0)
+    m.y = pyo.Var(bounds=(-5.0, 5.0), initialize=1.0)
+    m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + (m.y - 2 * m.p) ** 2)
+    declare_sens_param(m.p)
+    pyo.SolverFactory("pounce").solve(
+        m, options={"bound_relax_factor": 1e-8})
+    assert pyo.value(m.y) > 5.0, "the solve did not relax the bound"
+
+    # step downward, away from the bound the solve left y outside of
+    r = estimate_report(m, [(m.p, 3.0)])
+    assert r.bounds_relaxed is True
+    assert m.y in r.crossed
+    # the amount is the relaxation itself, not a modelling-scale number
+    assert r.crossed[m.y] < 1e-6
+    assert r.first == "x"
+    assert r.alpha >= 1.0
 
 
 def test_a_coordinate_on_one_bound_can_still_cross_the_other():


### PR DESCRIPTION

This implements item 0 of the sensitivity roadmap (#255), which is the
ratio test to the first crossing and the report that carries it. A
caller can then see what happened instead of reading a warning that the
step was clamped.

`estimate()` today takes the linear step, clips any variable that leaves
its bounds, warns, and returns. The warning names the variables and
stops there. A caller cannot tell how far along the perturbation the
active set changed, whether a constraint became active before any
variable did, or whether the gap against a re-solve comes from the
barrier parameter, from a regularized factor, or from relaxed bounds.

## What this adds

`estimate_report(model, perturb)` takes the same perturbation argument
`estimate()` takes and returns an `EstimateReport`. It runs the same
step and measures it. Nothing about `estimate()` changes beyond the
perturbation parsing moving into a helper the two now share.

The report carries the fraction of the perturbation that fits before
the first bound is reached, and which variable or constraint reaches
its bound there. It also carries the coordinates the full step pushes
past a bound and by how much, the constraint violation at the predicted
point, and the activity classification for variables and constraints.
Alongside those are the three things that separate this predictor from
the exact value at the perturbed active set: the barrier parameter, the
factor's inertia-correction perturbations, and whether the solve
relaxed its bounds.

The classification is passed through from `Solver.classify_activity`
rather than recomputed. This is the same classifier the covariance and
information work shipped, which is what left item 0 with only the ratio
test and the report assembly to build. No Rust changed.

## The ratio test excludes coordinates already on a bound

A coordinate on its bound cannot be crossed by a step, and scoring one
produces noise rather than a finding. The remaining gap is the small
slack the barrier leaves, the step component is the same size, and
their quotient can take any value. Left in, it becomes the minimum on
any model carrying an active bound, which is most real ones.

The exclusion reads the classification rather than a distance, because
that slack is `O(mu)` at a strongly active bound but `O(sqrt(mu))` at a
weakly active one, and no single distance threshold separates the
second from a coordinate genuinely close to its bound. A distance
threshold remains as the backstop for a solve with no classification
available.

Equality constraints and the constraints pinning the declared Params do
not take part either. An equality constraint is held to first order and
admits no activity change, and a pin constraint's right-hand side is
what the perturbation moves.

## Which residual this reports

Items 0 and 4 of the roadmap both say "the residual" without saying
which one. This reports the constraint violation at the predicted
point, the primal half, since item 0 is scoped as assembly of
quantities the core already exposes and the NL evaluators supply it
directly.

The dual half belongs to item 4, whose corrector is specified as one
primal-dual iteration returning the residual. A primal-dual iteration
holds the updated multipliers, so the full KKT residual is computed
where they already live and comes back as a number. Assembling it out
here instead would mean exposing the multiplier steps in user space,
where only the primal block and the equality multipliers have a
mapping from the compound vector today.

Worth making explicit in the roadmap note, since nothing in the text
currently distinguishes the two.

## A relaxed solve is reported, not raised

`classify_activity` raises for a solve that ran with a non-zero
`bound_relax_factor`, since relaxed bounds shift the slacks it reads.
Rather than propagate that, the report sets `bounds_relaxed` and leaves
the classification empty, and everything else in it is still measured.
A diagnostic that raised there would give the caller nothing exactly
when they are trying to find out why the estimate and a re-solve
disagree.

## Validation

The suite adds 18 tests, each naming its model and pinning its number:

- The step fraction matches a brute-force scan of the unclamped step,
  on the same coordinate exactly and to 1e-12 relative. The same holds
  with a fixed variable present, which the solve removes and which
  shifts every later factor column.
- The step fraction matches hand-computed crossings to 1e-8, for a
  variable bound and for a constraint that binds while both variables
  are still interior.
- The violation matches direct evaluation at the predicted point to
  1e-12.
- The crossing distances match the unclamped estimate to 1e-9.
- An interior perturbation crosses nothing and reports a fraction above
  one.
- A strongly active bound and a weakly active bound are classified as
  such, and neither is reported as a crossing.
- The barrier parameter and the classification agree with calling the
  classifier directly.
- Constraints are named as the model names them, not by the clone names
  the declared-parameter surgery gives them.
- Two parameters perturbed at once agree with the brute-force scan.
- The report is the same through `SolverFactory('pounce')`,
  `SolverFactory('pounce_v2')` and the contrib `SolverFactory('pounce')`,
  since `Pounce.solve` sends a model carrying declarations down the same
  in-process route.
- An end-to-end case saturates a control with a setpoint move. The
  report names the control and returns a fraction below one, and
  re-asking at exactly that fraction crosses nothing.

The local run passes 295 tests in pyomo-pounce, against a 277 baseline
on main.

## Error message correction

The no-session error in `estimate`, `gradient`, `covariance` and
`information` told the reader to solve with `SolverFactory('pounce')`,
which has been incomplete since the v2 interface was added. All five
messages now name the three routes. Verifying that the report is route
independent is what turned this up.
