### PR TITLE
feat(python): expose the convex wall-clock budget as time_limit=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ changes.
 
 ## [Unreleased]
 
+- **The convex wall-clock budget is now reachable from Python** (#585).
+  `pounce.qp.solve_qp`, `solve_socp`, `solve_qp_batch`, and
+  `solve_qp_multi_rhs` take `time_limit=` — seconds as a `float`, `None` (the
+  default) meaning unbounded. Until now the deadline machinery below existed
+  only for the CLI's `max_wall_time` and for Rust callers setting
+  `QpOptions::time_limit` directly; no Python caller could ask a convex solve
+  to stop at a budget, even though `QpResult.status` could already come back
+  `"time_limit"`. `max_iter` was never a substitute — one IPM iteration may be
+  a single KKT solve or a factorization plus several inertia-controlled
+  refactorizations (plus a possible simplex crossover on the LP route), so
+  per-iteration cost varies by more than an order of magnitude within a single
+  solve. This is what a receding-horizon controller with a fixed control
+  period, a scenario sweep that must not stall on one pathological instance,
+  or any solve behind a request needs.
+
+  The budget is **per instance, not per batch**: each solve opens its own
+  deadline scope, so `time_limit=10` over 100 problems permits 1000 s of wall
+  clock. That matches the Rust `pounce_convex::batch` semantics and is the only
+  machine-independent reading, since a shared clock would make *which*
+  instances get cancelled depend on rayon's scheduling. A verdict still
+  outranks the clock (see below), so a status of `"time_limit"` always means
+  the solve concluded nothing — never a wrong `"optimal"`. Both
+  `method="ipm"` and `method="active-set"` honour it, as do both conic drivers.
+  A negative, NaN, or infinite budget raises `ValueError` rather than being
+  read as "no limit"; `None` is how that is spelled.
+
+  Deliberately not plumbed: `pounce.jax` (and the torch layer), whose
+  `_check_status` raises on `"time_limit"` because a non-KKT iterate makes the
+  implicit-function gradient meaningless — a differentiable layer returning
+  quietly wrong gradients under load is worse than one that runs long — and
+  the build-once `QpFactorization` / `QpSensitivity` handles, which have no
+  clear per-call budget semantics yet.
+
 - Added solve-wide convex-engine wall-clock deadlines. Both
   `pounce_convex::QpOptions` and `pounce_qp::QpOptions` now expose
   `time_limit: Option<Duration>` and their status enums expose `TimeLimit`.

--- a/crates/pounce-py/src/qp.rs
+++ b/crates/pounce-py/src/qp.rs
@@ -28,6 +28,7 @@ use pounce_linsol::SparseSymLinearSolverInterface;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use std::time::Duration;
 
 fn backend() -> Box<dyn SparseSymLinearSolverInterface> {
     Box::new(FeralSolverInterface::new())
@@ -347,8 +348,13 @@ fn cone_dim(kind: &str, index: usize, v: f64, min: usize) -> PyResult<usize> {
     Ok(rounded as usize)
 }
 
-fn opts(tol: Option<f64>, max_iter: Option<usize>, collect_iterates: bool) -> QpOptions {
-    opts_tau(tol, max_iter, collect_iterates, None, None)
+fn opts(
+    tol: Option<f64>,
+    max_iter: Option<usize>,
+    collect_iterates: bool,
+    time_limit: Option<Duration>,
+) -> QpOptions {
+    opts_tau(tol, max_iter, collect_iterates, None, None, time_limit)
 }
 
 /// [`opts`] plus the fraction-to-boundary pair. `tau` is the floor of the
@@ -361,8 +367,13 @@ fn opts_tau(
     collect_iterates: bool,
     tau: Option<f64>,
     tau_max: Option<f64>,
+    time_limit: Option<Duration>,
 ) -> QpOptions {
     let mut o = QpOptions::default();
+    // `None` leaves the field at its `None` default: no deadline at all, not a
+    // huge one. Every convex entry point opens its own deadline scope from this
+    // field, so the budget is **per solve** (per instance on the batch paths).
+    o.time_limit = time_limit;
     if let Some(t) = tol {
         o.tol = t;
     }
@@ -400,6 +411,27 @@ fn check_tau(value: Option<f64>, name: &str) -> PyResult<()> {
     Ok(())
 }
 
+/// Convert a `time_limit` given in **seconds** into the `Duration` the convex
+/// options carry. `None` means unbounded (the solver default).
+///
+/// `Duration::try_from_secs_f64` rejects exactly the values that have no honest
+/// deadline behind them — negative, NaN, and anything past what a `Duration`
+/// can hold, `f64::INFINITY` included — so a bad budget raises a named
+/// `ValueError` here rather than being clamped to something enormous and
+/// silently behaving like "no limit". `0.0` is a real (immediate) deadline, the
+/// wall-clock twin of `max_iter=0`: stop before doing any work.
+fn time_limit_duration(secs: Option<f64>, func: &str) -> PyResult<Option<Duration>> {
+    match secs {
+        None => Ok(None),
+        Some(v) => Duration::try_from_secs_f64(v).map(Some).map_err(|_| {
+            PyValueError::new_err(format!(
+                "{func}: `time_limit` must be a non-negative, finite number of \
+                 seconds that fits in a duration (pass None for no limit); got {v}"
+            ))
+        }),
+    }
+}
+
 /// Solve one convex QP. Returns a dict with the primal `x`, duals `y`
 /// (equalities), `z` (inequalities), bound duals `z_lb`/`z_ub`, the
 /// objective, iteration count, and a status string.
@@ -421,8 +453,12 @@ fn check_tau(value: Option<f64>, name: &str) -> PyResult<()> {
 /// near-1 default is more aggressive (fewer iterations, especially warm
 /// starting a sequence of nearby QPs); `tau_max=tau` pins τ flat, the most
 /// conservative setting.
+///
+/// `time_limit` (seconds, default `None` = unbounded) caps the wall clock for
+/// this solve; a solve that gives up at the budget reports status
+/// `"time_limit"`, while one that reaches a verdict keeps it.
 #[pyfunction]
-#[pyo3(signature = (prob, tol=None, max_iter=None, warm_start=None, collect_iterates=false, method="ipm", tau=None, tau_max=None))]
+#[pyo3(signature = (prob, tol=None, max_iter=None, warm_start=None, collect_iterates=false, method="ipm", tau=None, tau_max=None, time_limit=None))]
 #[allow(clippy::too_many_arguments)]
 pub fn solve_qp<'py>(
     py: Python<'py>,
@@ -434,10 +470,12 @@ pub fn solve_qp<'py>(
     method: &str,
     tau: Option<f64>,
     tau_max: Option<f64>,
+    time_limit: Option<f64>,
 ) -> PyResult<Bound<'py, PyDict>> {
     check_tau(tau, "tau")?;
     check_tau(tau_max, "tau_max")?;
-    let o = opts_tau(tol, max_iter, collect_iterates, tau, tau_max);
+    let limit = time_limit_duration(time_limit, "solve_qp")?;
+    let o = opts_tau(tol, max_iter, collect_iterates, tau, tau_max, limit);
     let warm = warm_start.map(warm_from_dict).transpose()?;
 
     // `method` selects the engine, so that the *same* engine is reachable from
@@ -482,8 +520,11 @@ pub fn solve_qp<'py>(
 /// Problems containing an exponential or power cone route to the
 /// non-symmetric HSDE driver, which also handles second-order cones — so a
 /// SOC may be freely mixed with an exp/power cone.
+///
+/// `time_limit` (seconds, default `None` = unbounded) caps the wall clock for
+/// this solve; see `solve_qp`.
 #[pyfunction]
-#[pyo3(signature = (prob, cones, tol=None, max_iter=None, collect_iterates=false))]
+#[pyo3(signature = (prob, cones, tol=None, max_iter=None, collect_iterates=false, time_limit=None))]
 pub fn solve_socp<'py>(
     py: Python<'py>,
     prob: &PyQpProblem,
@@ -491,8 +532,14 @@ pub fn solve_socp<'py>(
     tol: Option<f64>,
     max_iter: Option<usize>,
     collect_iterates: bool,
+    time_limit: Option<f64>,
 ) -> PyResult<Bound<'py, PyDict>> {
-    let o = opts(tol, max_iter, collect_iterates);
+    let o = opts(
+        tol,
+        max_iter,
+        collect_iterates,
+        time_limit_duration(time_limit, "solve_socp")?,
+    );
     let specs = parse_cones(cones)?;
     // PSD (self-scaled, symmetric driver) cannot be mixed with the
     // exponential/power cones (non-symmetric driver) in one problem.
@@ -531,16 +578,27 @@ pub fn solve_socp<'py>(
 /// problem, same length as `probs`) — e.g. the previous batch's result
 /// dicts for a sequence of nearby batches. Each only affects its
 /// instance's iteration count; a per-instance mismatch is ignored.
+///
+/// `time_limit` (seconds, default `None` = unbounded) is **per instance**, not
+/// per batch: each solve opens its own deadline scope, so `time_limit=10` over
+/// 100 problems permits 1000 s of wall clock. A shared clock would make *which*
+/// instances get cancelled depend on rayon's scheduling, and so on the machine.
 #[pyfunction]
-#[pyo3(signature = (probs, tol=None, max_iter=None, warm_starts=None))]
+#[pyo3(signature = (probs, tol=None, max_iter=None, warm_starts=None, time_limit=None))]
 pub fn solve_qp_batch<'py>(
     py: Python<'py>,
     probs: Vec<PyQpProblem>,
     tol: Option<f64>,
     max_iter: Option<usize>,
     warm_starts: Option<Vec<Bound<'py, PyDict>>>,
+    time_limit: Option<f64>,
 ) -> PyResult<Vec<Bound<'py, PyDict>>> {
-    let o = opts(tol, max_iter, false);
+    let o = opts(
+        tol,
+        max_iter,
+        false,
+        time_limit_duration(time_limit, "solve_qp_batch")?,
+    );
     let inners: Vec<QpProblem> = probs.into_iter().map(|p| p.inner).collect();
     let warms: Option<Vec<QpWarmStart>> = match warm_starts {
         Some(ws) => {
@@ -568,14 +626,18 @@ pub fn solve_qp_batch<'py>(
 /// Solve one QP structure (`base`) against many linear objectives `cs`
 /// (a sequence of length-`n` vectors), in parallel. Returns a list of
 /// result dicts in order.
+///
+/// `time_limit` (seconds, default `None` = unbounded) is **per right-hand
+/// side**, not per call — see `solve_qp_batch`.
 #[pyfunction]
-#[pyo3(signature = (base, cs, tol=None, max_iter=None))]
+#[pyo3(signature = (base, cs, tol=None, max_iter=None, time_limit=None))]
 pub fn solve_qp_multi_rhs<'py>(
     py: Python<'py>,
     base: &PyQpProblem,
     cs: Vec<Vec<f64>>,
     tol: Option<f64>,
     max_iter: Option<usize>,
+    time_limit: Option<f64>,
 ) -> PyResult<Vec<Bound<'py, PyDict>>> {
     for (k, c) in cs.iter().enumerate() {
         if c.len() != base.inner.n {
@@ -586,7 +648,12 @@ pub fn solve_qp_multi_rhs<'py>(
             )));
         }
     }
-    let o = opts(tol, max_iter, false);
+    let o = opts(
+        tol,
+        max_iter,
+        false,
+        time_limit_duration(time_limit, "solve_qp_multi_rhs")?,
+    );
     let base_inner = base.inner.clone();
     let sols = py.allow_threads(|| {
         pounce_convex::solve_qp_multi_rhs_parallel(&base_inner, &cs, &o, serial_backend)
@@ -625,7 +692,10 @@ impl PyQpFactorization {
     #[new]
     #[pyo3(signature = (base, tol=None, max_iter=None))]
     fn new(base: &PyQpProblem, tol: Option<f64>, max_iter: Option<usize>) -> PyResult<Self> {
-        let o = opts(tol, max_iter, false);
+        // No `time_limit` here on purpose (gh #585): this is a build-once /
+        // solve-many handle, and a budget captured at build time would apply to
+        // every later `solve()` with no way to say what it means.
+        let o = opts(tol, max_iter, false, None);
         let inner = QpFactorization::build(&base.inner, &o, backend).ok_or_else(|| {
             PyValueError::new_err(
                 "QpFactorization: initial factorization failed (structurally singular KKT system)",
@@ -702,7 +772,9 @@ impl PyQpSensitivity {
         max_iter: Option<usize>,
         active_tol: f64,
     ) -> PyResult<Self> {
-        let o = opts(tol, max_iter, false);
+        // Unbounded on purpose (gh #585): sensitivity is only defined at an
+        // optimum, so a cancelled solve here has nothing to hand back.
+        let o = opts(tol, max_iter, false, None);
         // Both the IPM solve and the sensitivity factorization are pure Rust
         // (no Python callbacks), so run them with the GIL released — other
         // threads make progress during the solve (mirrors `solve_qp`).

--- a/docs/src/convex-solver.md
+++ b/docs/src/convex-solver.md
@@ -136,6 +136,49 @@ iterate that close to it breaks the Nesterov–Todd scaling), and **cold**
 solves are unaffected because they run the homogeneous self-dual embedding,
 a different loop.
 
+## Wall-clock budgets
+
+`solve_qp`, `solve_socp`, `solve_qp_batch`, and `solve_qp_multi_rhs` take a
+`time_limit` in **seconds** (`None`, the default, means unbounded). Reach for it
+when an answer is needed on a schedule — a receding-horizon controller with a
+fixed control period, a sweep where one pathological instance must not stall the
+rest, or any solve sitting behind a request:
+
+```python
+r = solve_qp(P=P, c=c, G=G, h=h, warm_start=previous, time_limit=0.005)
+if r.status == "time_limit":
+    ...   # `r.x` is the best iterate reached, not a KKT point
+```
+
+`max_iter` cannot express this. One interior-point iteration may be a single KKT
+solve, or a factorization plus several inertia-controlled refactorizations with
+escalating shifts, and the LP route can add a simplex crossover phase — so
+per-iteration cost varies by more than an order of magnitude *within* one solve,
+before problem size enters into it. No iteration count means "5 ms" across two
+problems.
+
+Three properties are worth knowing:
+
+- **A verdict outranks the clock.** `optimal`, `optimal_inaccurate`,
+  `primal_infeasible`, and `dual_infeasible` survive a deadline that passed
+  while the solve was finishing; only a give-up result is relabelled
+  `time_limit`. So the status is always truthful about what was proved, and a
+  budget can never turn into a wrong `optimal`.
+- **The budget is per solve, not per call.** On the batched entry points each
+  instance opens its own deadline scope, so `time_limit=10` over 100 problems
+  permits 1000 s of wall clock. A shared clock would make *which* instances get
+  cancelled depend on rayon's scheduling, and so on the machine. Bound the whole
+  call around the call.
+- **Results become machine- and load-dependent**, inherently — which is why this
+  is opt-in and absent from the default path. An in-flight factorization is not
+  interrupted, so expiry can overshoot by one such operation.
+
+The differentiable layers (`pounce.jax`, `pounce.torch`) deliberately do not
+take one: they raise on `time_limit` because a non-KKT iterate makes the
+implicit-function gradient meaningless, and silently wrong gradients under load
+are worse than a slow layer. On the CLI the same mechanism is spelled
+`max_wall_time`.
+
 ## Batching and factorization reuse
 
 ```python

--- a/python/pounce/qp.py
+++ b/python/pounce/qp.py
@@ -24,6 +24,45 @@ constraint matrices ``A``/``G`` as **scipy-sparse** matrices (e.g.
 heavier on memory at that size, and a large dense matrix triggers a
 one-time :class:`PounceSparsityWarning`.
 
+Wall-clock budgets
+------------------
+:func:`solve_qp`, :func:`solve_socp`, :func:`solve_qp_batch`, and
+:func:`solve_qp_multi_rhs` accept ``time_limit`` — a budget in **seconds**,
+``None`` (the default) meaning unbounded. It is the option to reach for when an
+answer is needed on a schedule: a receding-horizon controller with a fixed
+control period, a scenario sweep where one pathological instance must not stall
+the rest, or any solve behind a request. ``max_iter`` is not a substitute: one
+interior-point iteration may be a single KKT solve or a factorization plus
+several inertia-controlled refactorizations (and the LP route may add a simplex
+crossover phase), so per-iteration cost varies by more than an order of
+magnitude *within* one solve. There is no iteration count that means "half a
+second" across two problems.
+
+Three things to know about the semantics:
+
+- **A verdict outranks the clock.** A solve that reaches ``"optimal"``,
+  ``"optimal_inaccurate"``, ``"primal_infeasible"``, or ``"dual_infeasible"``
+  keeps that status even if the deadline passed while it was finishing. Only a
+  give-up result is relabelled ``"time_limit"``, so the status is always
+  truthful about what was proved.
+- **The budget is per solve, not per call.** On the batched entry points each
+  instance opens its own deadline scope, so ``time_limit=10`` over 100 problems
+  permits 1000 s of wall clock, not 10. That is the only machine-independent
+  reading: a shared clock would make *which* instances get cancelled depend on
+  rayon's scheduling. Enforce a budget for the whole call around the call.
+- **Results become machine- and load-dependent.** Inherent to a wall-clock
+  bound, and the reason this is opt-in and off by default. An in-flight
+  factorization is not interrupted, so expiry can overshoot by one such
+  operation.
+
+Not every convex surface takes one. The differentiable layers
+(:mod:`pounce.jax`, :mod:`pounce.torch`) deliberately do not: they raise on
+``"time_limit"`` because a non-KKT iterate makes the implicit-function gradient
+meaningless, and a layer returning quietly wrong gradients under load is worse
+than one that runs long.
+:class:`QpFactorization` and :class:`QpSensitivity` are build-once /
+solve-many handles with no clear per-call budget semantics yet.
+
 Example
 -------
 >>> import numpy as np
@@ -98,8 +137,12 @@ class QpResult:
     status:
         One of ``"optimal"``, ``"primal_infeasible"``,
         ``"dual_infeasible"`` (unbounded), ``"iteration_limit"``,
-        ``"time_limit"`` (the ``max_wall_time`` budget ran out; ``x`` is the
-        best iterate reached), ``"numerical_failure"``.
+        ``"time_limit"`` (the wall-clock budget ran out — the ``time_limit=``
+        keyword, or the CLI's ``max_wall_time``; ``x`` is the best iterate
+        reached and is **not** a KKT point), ``"numerical_failure"``.
+        Only a give-up result is labelled ``"time_limit"``: a solve that
+        reached a verdict keeps it even if the deadline passed while it was
+        finishing.
     x:
         Primal solution, shape ``(n,)``.
     y:
@@ -528,6 +571,37 @@ def _validate_solver_opts(tol, max_iter, func: str) -> None:
             )
 
 
+def _validate_time_limit(time_limit, func: str) -> None:
+    """Validate the optional wall-clock budget (seconds) accepted by the
+    one-shot and batched convex entry points (gh #585).
+
+    ``None`` means unbounded — that, not ``inf``, is how "no limit" is spelled,
+    so a non-finite value is rejected rather than quietly read as one. Negative
+    is meaningless. ``0.0`` is allowed and is a real, immediate deadline (stop
+    before doing any work), the wall-clock twin of the CLI's ``max_wall_time=0``.
+
+    Checked here — before the value reaches the PyO3 binding — so a bad budget
+    raises a clear named ``ValueError`` rather than a bare conversion error, the
+    same treatment ``max_iter`` gets (gh #277)."""
+    if time_limit is None:
+        return
+    # bool is an int subclass; `time_limit=True` is a mistake, not 1 second.
+    if isinstance(time_limit, bool) or not isinstance(
+        time_limit, (int, float, np.integer, np.floating)
+    ):
+        raise ValueError(
+            f"{func}: `time_limit` must be a number of seconds or None "
+            f"(no limit), got {time_limit!r}"
+        )
+    t = float(time_limit)
+    if not np.isfinite(t) or t < 0.0:
+        raise ValueError(
+            f"{func}: `time_limit` must be a finite, non-negative number of "
+            f"seconds; got {time_limit!r}. Pass None (the default) for an "
+            f"unbounded solve."
+        )
+
+
 def _warm_dict(warm):
     """Coerce a warm start (a :class:`QpResult` or a mapping) into the
     ``{x, y, z, z_lb, z_ub}`` dict the binding expects, or ``None``."""
@@ -563,6 +637,7 @@ def solve_qp(
     *,
     tol: Optional[float] = None,
     max_iter: Optional[int] = None,
+    time_limit: Optional[float] = None,
     warm_start=None,
     collect_iterates: bool = False,
     check_psd: Optional[bool] = None,
@@ -609,6 +684,15 @@ def solve_qp(
     ``tau_max=tau`` to pin τ flat — slower, maximally conservative — or raise
     ``tau`` to push the early iterations harder too.
 
+    ``time_limit`` (seconds, ``None`` = unbounded) caps the wall clock for this
+    solve, across retries, fallback engines, and crossover. A solve that gives
+    up at the budget returns ``status == "time_limit"`` with the best iterate
+    reached; one that reaches a verdict keeps it, even if the deadline passed
+    while it was finishing. Use it where an answer is needed on a schedule —
+    ``max_iter`` cannot express a time bound, since per-iteration cost varies
+    by more than an order of magnitude within a single solve. Honored by both
+    ``method="ipm"`` and ``method="active-set"``. See the module docstring.
+
     The returned :class:`QpResult` carries the final KKT ``residuals``;
     pass ``collect_iterates=True`` to also capture the per-iteration
     convergence trace in ``result.iterates``.
@@ -616,6 +700,7 @@ def solve_qp(
     if c is None:
         raise ValueError("solve_qp: `c` is required")
     _validate_solver_opts(tol, max_iter, "solve_qp")
+    _validate_time_limit(time_limit, "solve_qp")
     _maybe_check_psd(P, c, check_psd)
     prob = _build(P, c, A, b, G, h, lb, ub)
     return _to_result(
@@ -628,6 +713,7 @@ def solve_qp(
             method=method,
             tau=tau,
             tau_max=tau_max,
+            time_limit=None if time_limit is None else float(time_limit),
         )
     )
 
@@ -667,6 +753,7 @@ def solve_socp(
     cones,
     tol: Optional[float] = None,
     max_iter: Optional[int] = None,
+    time_limit: Optional[float] = None,
     collect_iterates: bool = False,
     check_psd: Optional[bool] = None,
 ) -> QpResult:
@@ -700,6 +787,11 @@ def solve_socp(
     on the symmetric driver, so it **cannot** be combined with exp/power
     cones in one problem (a clear error is raised if you try).
 
+    ``time_limit`` (seconds, ``None`` = unbounded) caps the wall clock for this
+    solve, with the same semantics as :func:`solve_qp`: a give-up result comes
+    back as ``status == "time_limit"``, a verdict outranks the clock. It reaches
+    both conic drivers (symmetric and non-symmetric HSDE).
+
     Examples
     --------
     >>> # min t  s.t.  (t, x − x*) ∈ SOC   (minimize ‖x − x*‖)
@@ -722,12 +814,18 @@ def solve_socp(
     if c is None:
         raise ValueError("solve_socp: `c` is required")
     _validate_solver_opts(tol, max_iter, "solve_socp")
+    _validate_time_limit(time_limit, "solve_socp")
     _maybe_check_psd(P, c, check_psd)
     prob = _build(P, c, A, b, G, h, None, None)
     specs = _normalize_cones(cones)
     return _to_result(
         _pounce.solve_socp(
-            prob, specs, tol=tol, max_iter=max_iter, collect_iterates=collect_iterates
+            prob,
+            specs,
+            tol=tol,
+            max_iter=max_iter,
+            collect_iterates=collect_iterates,
+            time_limit=None if time_limit is None else float(time_limit),
         )
     )
 
@@ -737,6 +835,7 @@ def solve_qp_batch(
     *,
     tol: Optional[float] = None,
     max_iter: Optional[int] = None,
+    time_limit: Optional[float] = None,
     warm_starts: Optional[Sequence] = None,
     check_psd: Optional[bool] = None,
 ) -> list[QpResult]:
@@ -754,8 +853,18 @@ def solve_qp_batch(
     (issue #112), with the same ``None``/``True``/``False`` semantics as
     :func:`solve_qp`; an offending problem raises ``ValueError`` before any
     solve runs.
+
+    ``time_limit`` (seconds, ``None`` = unbounded) is **per instance, not per
+    batch**: each solve opens its own deadline scope, so ``time_limit=10`` over
+    100 problems permits 1000 s of wall clock, not 10. That is the only
+    machine-independent reading — the instances run on rayon, and a shared
+    clock would make *which* ones get cancelled depend on the scheduler. To
+    bound the whole call, enforce it around the call. A cancelled instance comes
+    back with ``status == "time_limit"``; its neighbours are unaffected, which
+    is the point: one pathological problem no longer stalls the sweep.
     """
     _validate_solver_opts(tol, max_iter, "solve_qp_batch")
+    _validate_time_limit(time_limit, "solve_qp_batch")
     for pr in problems:
         _maybe_check_psd(pr.get("P"), pr["c"], check_psd)
     built = [
@@ -778,7 +887,13 @@ def solve_qp_batch(
                 f"warm_starts has length {len(warm_starts)}, expected {len(built)}"
             )
         ws = [_warm_dict(w) or {} for w in warm_starts]
-    dicts = _pounce.solve_qp_batch(built, tol=tol, max_iter=max_iter, warm_starts=ws)
+    dicts = _pounce.solve_qp_batch(
+        built,
+        tol=tol,
+        max_iter=max_iter,
+        warm_starts=ws,
+        time_limit=None if time_limit is None else float(time_limit),
+    )
     return [_to_result(d) for d in dicts]
 
 
@@ -795,6 +910,7 @@ def solve_qp_multi_rhs(
     cs: Sequence[Sequence[float]],
     tol: Optional[float] = None,
     max_iter: Optional[int] = None,
+    time_limit: Optional[float] = None,
     check_psd: Optional[bool] = None,
 ) -> list[QpResult]:
     """Solve one QP *structure* against many linear objectives, in parallel.
@@ -809,10 +925,14 @@ def solve_qp_multi_rhs(
     use it when the constraint geometry is fixed and you are sweeping the
     objective (e.g. a family of cost vectors, a parametric linear term, or
     the inner objective of a bilevel sweep).
+
+    ``time_limit`` (seconds, ``None`` = unbounded) is **per right-hand side**,
+    not per call — same reasoning as :func:`solve_qp_batch`.
     """
     if cs is None or len(cs) == 0:
         raise ValueError("solve_qp_multi_rhs: `cs` must be a non-empty sequence")
     _validate_solver_opts(tol, max_iter, "solve_qp_multi_rhs")
+    _validate_time_limit(time_limit, "solve_qp_multi_rhs")
     n = len(np.asarray(cs[0], dtype=np.float64).ravel())
     # `c` only fixes `n` for the base structure; the real objectives are `cs`.
     base_c = c if c is not None else np.zeros(n)
@@ -820,7 +940,13 @@ def solve_qp_multi_rhs(
     _maybe_check_psd(P, base_c, check_psd)
     base = _build(P, base_c, A, b, G, h, lb, ub)
     cs_list = [np.asarray(ci, dtype=np.float64).ravel().tolist() for ci in cs]
-    dicts = _pounce.solve_qp_multi_rhs(base, cs_list, tol=tol, max_iter=max_iter)
+    dicts = _pounce.solve_qp_multi_rhs(
+        base,
+        cs_list,
+        tol=tol,
+        max_iter=max_iter,
+        time_limit=None if time_limit is None else float(time_limit),
+    )
     return [_to_result(d) for d in dicts]
 
 

--- a/python/tests/test_qp_time_limit.py
+++ b/python/tests/test_qp_time_limit.py
@@ -1,0 +1,159 @@
+"""Wall-clock budgets on the Python convex entry points (gh #585).
+
+``QpOptions::time_limit`` reached the CLI (``max_wall_time``) but nothing in
+Python could ask a convex solve to stop at a wall-clock budget, even though
+``QpResult.status`` could already come back ``"time_limit"``. These cover the
+``time_limit=`` keyword on the four surfaces that take one — ``solve_qp``,
+``solve_socp``, ``solve_qp_batch``, ``solve_qp_multi_rhs`` — plus the two
+properties that make the option safe to hand a caller:
+
+* a give-up at the budget is reported as ``"time_limit"``, never as a wrong
+  ``"optimal"`` (the reason this waited on the #583 hardening, where a deadline
+  crossing inside inertia control used to return an unsolved KKT right-hand
+  side labelled ``optimal``); and
+* the budget is **per instance** on the batched paths.
+
+``time_limit=0.0`` is used wherever a *deterministic* expiry is needed: it is a
+real, immediate deadline, so the solve stops before doing any work regardless of
+how fast the machine is. Tests that need a solve to actually finish use a
+generous budget instead of relying on timing.
+"""
+
+import numpy as np
+import pytest
+
+from pounce import _pounce
+from pounce.qp import solve_qp, solve_qp_batch, solve_qp_multi_rhs, solve_socp
+
+# A verdict, if one is reported, means the solve proved something; only a
+# give-up is allowed to be relabelled by the clock.
+VERDICTS = {"optimal", "optimal_inaccurate", "primal_infeasible", "dual_infeasible"}
+
+
+def box_qp(c=(-3.0, -4.0)):
+    """min ‖x‖² + cᵀx  s.t.  0 ≤ x ≤ 1 — the module's stock tiny QP."""
+    n = len(c)
+    return dict(P=np.eye(n) * 2.0, c=list(c), lb=[0.0] * n, ub=[1.0] * n)
+
+
+def random_qp(n=120, m=60, seed=0):
+    """A non-trivial dense convex QP: strictly convex `P`, `m` inequality rows,
+    and a feasible box. Big enough that the solve is real work rather than a
+    couple of arithmetic ops, so a budget has something to interrupt."""
+    rng = np.random.default_rng(seed)
+    M = rng.standard_normal((n, n))
+    P = M.T @ M + np.eye(n)  # symmetric positive definite
+    c = rng.standard_normal(n)
+    G = rng.standard_normal((m, n))
+    h = np.abs(rng.standard_normal(m)) + 1.0  # x = 0 is strictly feasible
+    return dict(P=P, c=c, G=G, h=h, lb=[-10.0] * n, ub=[10.0] * n)
+
+
+def test_zero_budget_stops_the_solve():
+    assert solve_qp(**box_qp(), time_limit=0.0).status == "time_limit"
+
+
+def test_none_is_unbounded():
+    # The default and an explicit `None` both mean "no deadline at all" — not a
+    # huge one — so the solve runs to its verdict.
+    assert solve_qp(**box_qp()).status == "optimal"
+    assert solve_qp(**box_qp(), time_limit=None).status == "optimal"
+
+
+def test_a_generous_budget_does_not_disturb_the_answer():
+    free = solve_qp(**box_qp())
+    bounded = solve_qp(**box_qp(), time_limit=60.0)
+    assert bounded.status == "optimal"
+    np.testing.assert_allclose(bounded.x, free.x, rtol=1e-9, atol=1e-9)
+
+
+def test_active_set_method_honors_the_budget():
+    # The budget is a property of the convex driver, not of one engine: the
+    # `pounce-qp` active-set route scopes the same deadline.
+    r = solve_qp(**box_qp(), method="active-set", time_limit=0.0)
+    assert r.status == "time_limit"
+
+
+def test_a_cancelled_solve_is_never_a_wrong_optimal():
+    """The property that makes the option safe: under a budget too small to
+    finish, the status reported is a give-up, not a verdict backed by an
+    iterate that is nowhere near a KKT point.
+
+    Written as an implication rather than a hard `== "time_limit"` so it cannot
+    flake on a fast machine: whatever status comes back, an `optimal` one must
+    be backed by a genuinely small KKT error.
+    """
+    prob = random_qp()
+    r = solve_qp(**prob, time_limit=1e-4)
+    assert r.status in VERDICTS | {"time_limit", "iteration_limit"}
+    if r.status in ("optimal", "optimal_inaccurate"):
+        assert r.kkt_error is not None and r.kkt_error < 1e-3
+    # And with no budget at all the same problem solves cleanly, so the
+    # implication above is not passing vacuously on a broken problem.
+    assert solve_qp(**prob).status == "optimal"
+
+
+def test_socp_takes_a_budget():
+    # min t s.t. (t, x − x*) ∈ SOC(3): a second-order cone, so this exercises
+    # the conic driver rather than the orthant one.
+    socp = dict(c=[1.0, 0.0, 0.0], G=-np.eye(3), h=[0.0, -2.0, 1.0])
+    assert solve_socp(**socp, cones=[("soc", 3)], time_limit=0.0).status == "time_limit"
+    assert solve_socp(**socp, cones=[("soc", 3)]).status == "optimal"
+
+
+def test_batch_budget_is_per_instance():
+    problems = [box_qp((-3.0, -4.0)), box_qp((-1.0, -2.0)), box_qp((1.0, 1.0))]
+
+    stopped = solve_qp_batch(problems, time_limit=0.0)
+    assert [r.status for r in stopped] == ["time_limit"] * len(problems)
+
+    # Each instance opens its own deadline scope, so a budget that is ample for
+    # one problem is ample for all of them however many there are — the whole
+    # point of the per-instance reading (a shared clock would make *which*
+    # instances survive depend on rayon's scheduling).
+    solved = solve_qp_batch(problems * 4, time_limit=60.0)
+    assert all(r.status == "optimal" for r in solved)
+    assert len(solved) == 4 * len(problems)
+
+
+def test_multi_rhs_takes_a_budget():
+    cs = [[-3.0, -4.0], [-1.0, 0.5], [2.0, 2.0]]
+    base = dict(P=np.eye(2) * 2.0, lb=[0.0, 0.0], ub=[1.0, 1.0])
+
+    stopped = solve_qp_multi_rhs(**base, cs=cs, time_limit=0.0)
+    assert [r.status for r in stopped] == ["time_limit"] * len(cs)
+
+    solved = solve_qp_multi_rhs(**base, cs=cs, time_limit=60.0)
+    assert all(r.status == "optimal" for r in solved)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [-1.0, -1e-12, float("nan"), float("inf"), float("-inf"), "1.0", True, [1.0]],
+)
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda **kw: solve_qp(**box_qp(), **kw),
+        lambda **kw: solve_socp(
+            c=[1.0], G=[[-1.0]], h=[0.0], cones=[("nonneg", 1)], **kw
+        ),
+        lambda **kw: solve_qp_batch([box_qp()], **kw),
+        lambda **kw: solve_qp_multi_rhs(P=np.eye(2) * 2.0, cs=[[-1.0, -1.0]], **kw),
+    ],
+    ids=["solve_qp", "solve_socp", "solve_qp_batch", "solve_qp_multi_rhs"],
+)
+def test_invalid_budgets_raise_a_named_error(call, bad):
+    # `inf` is rejected rather than read as "no limit": `None` is how that is
+    # spelled, and silently accepting both spellings hides a typo'd budget.
+    with pytest.raises(ValueError, match="time_limit"):
+        call(time_limit=bad)
+
+
+def test_the_binding_itself_rejects_a_bad_budget():
+    # The host wrapper validates first, but `_pounce` is importable directly, so
+    # the PyO3 layer must not hand a negative/non-finite value to `Duration`.
+    prob = _pounce.QpProblem(n=1, c=[1.0], lb=[0.0], ub=[1.0])
+    for bad in (-1.0, float("nan"), float("inf"), 1e300):
+        with pytest.raises(ValueError, match="time_limit"):
+            _pounce.solve_qp(prob, time_limit=bad)


### PR DESCRIPTION
Fixes #585

`QpOptions::time_limit` was unreachable from Python. The pyo3 layer built
`QpOptions` internally from `tol`/`max_iter` and never set the field, so no
Python caller could ask a convex solve to stop at a wall-clock budget — even
though `QpResult.status` could already come back `"time_limit"`. The whole
convex deadline mechanism (#583 and the hardening on top of it) was reachable
only from the command line.

## What this adds

A `time_limit=` keyword — seconds as a `float`, `None` (the default) meaning
unbounded — on the four surfaces the issue scoped:

- `pounce.qp.solve_qp`
- `pounce.qp.solve_socp`
- `pounce.qp.solve_qp_batch`
- `pounce.qp.solve_qp_multi_rhs`

```python
r = solve_qp(P=P, c=c, G=G, h=h, warm_start=previous, time_limit=0.005)
if r.status == "time_limit":
    ...   # r.x is the best iterate reached, not a KKT point
```

Both `method="ipm"` and `method="active-set"` honour it (the deadline is scoped
by the convex driver, not by one engine), as do both conic drivers.

## Semantics, as documented

- **Per instance, not per batch.** Each solve opens its own deadline scope, so
  `time_limit=10` over 100 problems permits 1000 s of wall clock. This matches
  what `crates/pounce-convex/src/batch.rs` already documents on the Rust side,
  and is the only machine-independent reading: a shared clock would make *which*
  instances get cancelled depend on rayon's scheduling.
- **A verdict outranks the clock.** `optimal` / `optimal_inaccurate` /
  `primal_infeasible` / `dual_infeasible` survive a deadline that passed while
  the solve was finishing; only a give-up status is relabelled `time_limit`. So
  a budget can never turn into a wrong `optimal` — the property #583's hardening
  established, and the reason this is only landing now.
- **Results become machine- and load-dependent.** Inherent to a wall-clock
  bound, hence opt-in and absent from the default path.

## Validation

Twice, on purpose. The host wrapper (`_validate_time_limit`) rejects a
non-numeric, negative, or non-finite budget with a named `ValueError` —
`None`, not `inf`, is how "no limit" is spelled, and accepting both spellings
would hide a typo'd budget. The pyo3 layer backstops it through
`Duration::try_from_secs_f64` (which rejects negative, NaN, infinity, and
out-of-range) since `pounce._pounce` is importable directly. `0.0` is a real,
immediate deadline — the wall-clock twin of the CLI's `max_wall_time=0`.

## Out of scope, per the issue

- **`pounce.jax` / `pounce.torch`** — `_check_status` raises on `"time_limit"`
  because a non-KKT iterate makes the implicit-function gradient meaningless. A
  differentiable layer that silently returns garbage gradients under load is
  worse than one that runs long.
- **`QpFactorization` / `QpSensitivity`** — build-once/solve-many handles with
  no clear per-call budget semantics yet. Their `opts(...)` calls now pass an
  explicit `None` with a comment saying why.

## Tests

New `python/tests/test_qp_time_limit.py` (41 cases). `time_limit=0.0` is used
wherever a deterministic expiry is needed, so nothing depends on machine speed:

- a zero budget stops each of the four entry points, plus `method="active-set"`;
- `None` and the default are unbounded, and a generous budget returns the same
  `x` as an unbounded solve;
- the batch budget is per instance — a budget ample for one problem is ample for
  a batch of any size;
- **never a wrong `optimal`**: on a non-trivial dense QP (n=120, 60 inequality
  rows, ~20 ms unbounded) under a 1e-4 s budget, the status is written as an
  implication rather than a hard equality so it cannot flake — whatever comes
  back, an `optimal` must be backed by a genuinely small KKT error, and the same
  problem must solve cleanly unbudgeted so the implication is not vacuous;
- invalid budgets (`-1.0`, `nan`, `±inf`, `"1.0"`, `True`, `[1.0]`) raise
  `ValueError` on every entry point, and the raw binding rejects them too.

Full Python suite: 991 passed. `cargo fmt`, `cargo clippy -p pounce-py
--all-targets -D clippy::correctness -D clippy::suspicious`, and
`scripts/check-docs-consistency.sh` all clean.

Docs: a "Wall-clock budgets" section in `docs/src/convex-solver.md` and in the
`pounce.qp` module docstring, the per-function notes, an updated
`QpResult.status` entry, and a CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qi7vwYkRm1kPtCGx6WJWsj
