### PR TITLE
fix(sol): report an accepted solve in AMPL's solved band

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ changes.
   clean. Any solver-swappable application whose accepted-solve contract
   includes `status == ok` had to special-case POUNCE.
 
+  On the **v2** route the same code was worse than a warning: Pyomo's v2
+  `.sol` reader maps `100`–`199` to `TerminationCondition.error`, so an
+  accepted solve raised `NoOptimalSolutionError` under the default
+  `raise_exception_on_nonoptimal_result=True`. That is fixed by the same
+  change.
+
   The fix is in the emitted code, so it covers both routes into Pyomo: the
   `SolverFactory("pounce")` plugin and driving the POUNCE binary through
   Pyomo's generic `ipopt` ASL interface. The in-process sensitivity route

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ changes.
 
 ## [Unreleased]
 
+- **An accepted solve no longer loads into Pyomo as a warning** (#591).
+  `Solved_To_Acceptable_Level` is written into the `.sol` as AMPL
+  `solve_result_num = 1` — IPOPT's own code for the same outcome
+  (`STOP_AT_ACCEPTABLE_POINT`) — instead of `100`. Nothing reads that number
+  in isolation; consumers key on the *band*, and the two bands are not
+  interchangeable. Pyomo's legacy `.sol` reader maps `0`–`99` to
+  `SolverStatus.ok` and `100`–`199` to `SolverStatus.warning`, both with
+  `TerminationCondition.optimal`, so an accepted POUNCE solve arrived as
+
+  ```text
+  solver.status          warning
+  termination_condition  optimal
+  message                POUNCE 0.10.0: SolvedToAcceptableLevel
+  ```
+
+  and Pyomo logged "Loading a SolverResults object with a warning status"
+  while the equivalent IPOPT solve ("Solved To Acceptable Level.") loaded
+  clean. Any solver-swappable application whose accepted-solve contract
+  includes `status == ok` had to special-case POUNCE.
+
+  The fix is in the emitted code, so it covers both routes into Pyomo: the
+  `SolverFactory("pounce")` plugin and driving the POUNCE binary through
+  Pyomo's generic `ipopt` ASL interface. The in-process sensitivity route
+  (`pyomo_pounce.sens`) does not read a `.sol`, and its own table reported
+  `SolverStatus.warning` for the same status; it now reports `ok`, agreeing
+  with the `.sol` route and with the v2 interface (which already mapped it to
+  `convergenceCriteriaSatisfied` / `SolutionStatus.optimal`). The convex
+  engines' `OptimalInaccurate`, which maps onto the same NLP status, moves
+  from `100` to `1` with it.
+
+  Reduced accuracy is not swept under the rug: the distinction stays in the
+  code (`1`, not `0`), in the `.sol` message line, in the JSON report's
+  `status`, and in the console summary. `Feasible_Point_Found` — a usable
+  point that did *not* meet the convergence criteria, which POUNCE's own
+  interfaces do not call a success — deliberately stays in the `100`
+  "solved, with a warning" band.
+
 - **The convex wall-clock budget is now reachable from Python** (#585).
   `pounce.qp.solve_qp`, `solve_socp`, `solve_qp_batch`, and
   `solve_qp_multi_rhs` take `time_limit=` — seconds as a `float`, `None` (the

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -3081,9 +3081,9 @@ impl IpoptAlgorithm {
                 // `inf_pr = 1.7e-10` and `inf_du = 8.8e+47`; before gh #274
                 // the finiteness check was the only gate, `-8.8e47` is
                 // finite, and the solve was reported as
-                // `Solved_To_Acceptable_Level` with `solve_result_num = 100`.
-                // Pyomo maps that into the *solved* family and loads the
-                // diverging iterate as an optimal solution.
+                // `Solved_To_Acceptable_Level` — which Pyomo maps into the
+                // *solved* family, loading the diverging iterate as an
+                // optimal solution.
                 //
                 // So require the point to pass the full acceptable-level
                 // triplet (which includes `acceptable_dual_inf_tol`) before

--- a/crates/pounce-algorithm/src/mu/adaptive.rs
+++ b/crates/pounce-algorithm/src/mu/adaptive.rs
@@ -406,8 +406,8 @@ impl AdaptiveMuUpdate {
     /// `|df| ≈ mu_min·(barrier_tol_factor+1)/compl_inf_tol` an uncapped
     /// floor pins the unscaled complementarity above `compl_inf_tol` and
     /// the strict certificate is unreachable — in adaptive mode the solve
-    /// then degrades to `Solved_To_Acceptable_Level` (code 100, outside
-    /// AMPL's 0..99 solved band) on an iterate sitting at the optimum.
+    /// then degrades to `Solved_To_Acceptable_Level` (reduced accuracy, on an
+    /// iterate sitting at the optimum).
     ///
     /// The restoration sub-builder's `mu_min = 100 · outer_mu_min`
     /// safeguard is unaffected for the same reason as in monotone mode:
@@ -1033,7 +1033,7 @@ mod tests {
     /// clamp must yield to `compl_inf_tol·|df|/(barrier_tol_factor+1)` once
     /// |df| drops below `df* = mu_min·(barrier_tol_factor+1)/compl_inf_tol`,
     /// or the strict certificate is unreachable and the solve degrades to
-    /// `Solved_To_Acceptable_Level` (code 100) at the optimum.
+    /// `Solved_To_Acceptable_Level` at the optimum.
     #[test]
     fn adaptive_mu_min_is_capped_so_certificate_stays_reachable() {
         let a = AdaptiveMuUpdate::new();

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -2273,16 +2273,20 @@ fn qp_status_to_ars(s: pounce_convex::QpStatus) -> ApplicationReturnStatus {
 
 /// Map a convex-solver status onto the AMPL `.sol` terminal line: the message,
 /// whether the solve is treated as a success (drives the exit code), and the
-/// `solve_result_num`. AMPL convention: 0 solved, 100–199 solved to reduced
-/// accuracy, 200–299 infeasible, 300–399 unbounded, 400–499 limit, 500–599
+/// `solve_result_num`. AMPL convention: 0 solved, 100–199 solved with a
+/// warning, 200–299 infeasible, 300–399 unbounded, 400–499 limit, 500–599
 /// failure. Shared by the QP/LP and SOCP report paths so the two cannot drift.
+///
+/// `OptimalInaccurate` reports `1` — Ipopt's code for the same
+/// reduced-accuracy convergence, and the same code the NLP path's
+/// `SolvedToAcceptableLevel` reports (`status_to_solve_result_num`), which
+/// this status maps onto in `qp_status_to_ars`. One status, one code: a model
+/// must not change its `.sol` verdict band depending on which engine took it.
 fn convex_status_report(s: pounce_convex::QpStatus) -> (&'static str, bool, i32) {
     use pounce_convex::QpStatus;
     match s {
         QpStatus::Optimal => ("Optimal Solution Found.", true, 0),
-        QpStatus::OptimalInaccurate => {
-            ("Solved to acceptable level (reduced accuracy).", true, 100)
-        }
+        QpStatus::OptimalInaccurate => ("Solved to acceptable level (reduced accuracy).", true, 1),
         QpStatus::PrimalInfeasible => ("Problem is primal infeasible.", false, 200),
         QpStatus::DualInfeasible => ("Problem is unbounded (dual infeasible).", false, 300),
         QpStatus::IterationLimit => ("Maximum iterations exceeded.", false, 400),
@@ -3333,15 +3337,29 @@ mod convex_status_tests {
     /// Code review 2026-06 item M20: the reduced-accuracy convex status
     /// (`OptimalInaccurate`) must surface to the user as a *distinct* outcome —
     /// not silently folded into a clean `Optimal`. It maps to AMPL
-    /// `solve_result_num` 100 (the "solved to acceptable/reduced accuracy"
-    /// band) with a distinct message, and onto the NLP-side
+    /// `solve_result_num` 1 (Ipopt's own code for an accepted reduced-accuracy
+    /// solve) with a distinct message, and onto the NLP-side
     /// `SolvedToAcceptableLevel` status, so callers reading either the `.sol`
     /// terminal line or the JSON report can tell it apart from a full-accuracy
     /// solve.
+    ///
+    /// The code moved out of the 100 band in gh #591 — see
+    /// `pounce_solve_report::status_to_solve_result_num` — and must agree with
+    /// the NLP path, which reports the same status.
     #[test]
     fn optimal_inaccurate_is_distinct_from_optimal() {
         let (msg, ok, srn) = convex_status_report(QpStatus::OptimalInaccurate);
-        assert_eq!(srn, 100, "reduced-accuracy solve must use the 100 band");
+        assert_eq!(
+            srn,
+            pounce_cli::solve_report::status_to_solve_result_num(
+                ApplicationReturnStatus::SolvedToAcceptableLevel
+            ),
+            "the convex and NLP paths must report one code for one status",
+        );
+        assert_eq!(
+            srn, 1,
+            "Ipopt's code for an accepted reduced-accuracy solve"
+        );
         assert!(ok, "a reduced-accuracy solve is still a usable success");
         assert!(
             msg.contains("acceptable"),

--- a/crates/pounce-cli/tests/issue_250_dual_guard_never_worse.rs
+++ b/crates/pounce-cli/tests/issue_250_dual_guard_never_worse.rs
@@ -227,9 +227,12 @@ fn pooling_rt2stp_solves_at_default_settings() {
     // Ipopt on the identical .nl: -3273.9549927585640, NLP error ~1e-8.
     const EXPECTED: f64 = -3_273.954_991_374_754_6;
     let report = solve("pooling_rt2stp.nl", &[HANG_GUARD]);
+    // `0` exactly: since gh #591 the `0..=99` solved band also holds `1`
+    // (`Solved_To_Acceptable_Level`), which is not what this model did before
+    // the guard was defaulted off.
     let code = report.solution.solve_result_num;
     assert!(
-        (0..100).contains(&code),
+        code == 0,
         "pooling_rt2stp did not converge at default settings \
          (solve_result_num={code}, status={:?}) — has dual_diverging_streak been \
          re-enabled by default? At 15 this model returns \
@@ -326,7 +329,7 @@ fn hair_trigger_guard_returns_a_valid_honestly_labelled_point() {
 /// Pre-fix numbers (dev host): guard on returned objective -2307.32 at a
 /// constraint violation of **9.94** — below the true optimum -2304.0 precisely
 /// because the point is infeasible — while guard off returned -2298.57 at
-/// violation 1.06e-4. Both reported `solve_result_num` 100.
+/// violation 1.06e-4. Both terminated `Solved_To_Acceptable_Level`.
 #[test]
 fn best_acceptable_fallback_does_not_trade_feasibility_for_objective() {
     // A widened acceptable band. `acceptable_constr_viol_tol` alone is not

--- a/crates/pounce-cli/tests/issue_257_jit1_node_certificate.rs
+++ b/crates/pounce-cli/tests/issue_257_jit1_node_certificate.rs
@@ -77,13 +77,15 @@ fn solve(fixture_name: &str, extra_opts: &[&str]) -> SolveReport {
 /// evaluator, starting point, and box: `173345.37683089852`.
 const NODE_OPTIMUM: f64 = 173_345.376_830_898_52;
 
-/// `solve_result_num` 0..100 is AMPL's "solved" band. A driver that maps
-/// anything else onto its own status enum is what turned this into a spurious
-/// UNBOUNDED downstream, so assert on the band, not on one code.
+/// `solve_result_num` 0 is the strict termination certificate. A driver that
+/// maps anything else onto its own status enum is what turned this into a
+/// spurious UNBOUNDED downstream. The wider `0..=99` solved band would also
+/// admit `1` (`Solved_To_Acceptable_Level`) since gh #591; this node has a
+/// certifiable optimum and must reach it.
 fn assert_solved_at_optimum(report: &SolveReport, ctx: &str) {
     let code = report.solution.solve_result_num;
     assert!(
-        (0..100).contains(&code),
+        code == 0,
         "{ctx}: did not converge (solve_result_num={code}, status={:?}); \
          this node has a finite optimum ~{NODE_OPTIMUM} (issue #257)",
         report.solution.status,

--- a/crates/pounce-cli/tests/issue_266_mu_min_scaled_floor.rs
+++ b/crates/pounce-cli/tests/issue_266_mu_min_scaled_floor.rs
@@ -84,13 +84,15 @@ fn solve(fixture_name: &str, extra_opts: &[&str]) -> SolveReport {
 const HS71_OPTIMUM: f64 = 17.014_017_140_2;
 const OBJ_MULTIPLIER: f64 = 1e8;
 
-/// `solve_result_num` 0..100 is AMPL's "solved" band; anything else is what a
-/// B&B driver turns into a spurious UNBOUNDED. Assert on the band, not one
-/// code.
+/// `solve_result_num` 0 is the strict termination certificate; anything else
+/// is what a B&B driver turns into a spurious UNBOUNDED. The wider `0..=99`
+/// solved band would also admit `1` (`Solved_To_Acceptable_Level`) since
+/// gh #591 — that is the acceptable-level *fallback* this issue is about
+/// escaping, so it is not enough here.
 fn assert_solved_at_optimum(report: &SolveReport, ctx: &str) {
     let code = report.solution.solve_result_num;
     assert!(
-        (0..100).contains(&code),
+        code == 0,
         "{ctx}: did not converge (solve_result_num={code}, status={:?}); \
          this problem has a finite optimum ~{HS71_OPTIMUM}·{OBJ_MULTIPLIER:e} \
          that Ipopt certifies (issue #266)",
@@ -175,8 +177,8 @@ fn hs71_obj1e8_certifies_with_loosened_compl_inf_tol() {
 /// (`adaptive.rs`: the fixed-mode reduction, the fixed-mode re-seed, the
 /// oracles' internal `[mu_min, mu_max]` bands, and the final band clamp).
 /// The consequence there is milder — the acceptable-level fallback rescues
-/// the solve into `Solved_To_Acceptable_Level` — but code 100 is still
-/// outside AMPL's 0..99 solved band. Post-fix the strict certificate must be
+/// the solve into `Solved_To_Acceptable_Level` — but that is reduced
+/// accuracy, not the certificate. Post-fix the strict certificate must be
 /// issued.
 #[test]
 fn hs71_obj1e8_certifies_under_adaptive_mu_strategy() {

--- a/crates/pounce-cli/tests/issue_512_adaptive_tiny_step.rs
+++ b/crates/pounce-cli/tests/issue_512_adaptive_tiny_step.rs
@@ -168,8 +168,11 @@ fn the_tiny_step_exit_lands_on_a_converged_point() {
 #[test]
 fn adaptive_does_not_grind_at_a_frozen_iterate_at_default_tolerances() {
     let r = solve("hs71_obj1e8.nl", &["mu_strategy=adaptive"]);
+    // `0` exactly — the strict certificate. Since gh #591 the `0..=99` solved
+    // band also holds `1` (`Solved_To_Acceptable_Level`), which is the
+    // fallback this fixture must not need.
     assert!(
-        (0..100).contains(&r.solution.solve_result_num),
+        r.solution.solve_result_num == 0,
         "expected the known optimum to be certified, got \
          solve_result_num={} ({:?})",
         r.solution.solve_result_num,
@@ -192,7 +195,7 @@ fn adaptive_does_not_grind_at_a_frozen_iterate_at_default_tolerances() {
 fn the_monotone_route_is_untouched() {
     let r = solve("hs71_obj1e8.nl", &[]);
     assert!(
-        (0..100).contains(&r.solution.solve_result_num),
+        r.solution.solve_result_num == 0,
         "default (monotone) solve regressed: solve_result_num={} ({:?})",
         r.solution.solve_result_num,
         r.solution.status,

--- a/crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs
+++ b/crates/pounce-cli/tests/issue_557_shared_cse_hessian.rs
@@ -149,9 +149,12 @@ fn expected_objective() -> f64 {
 }
 
 fn assert_solved_at_optimum(report: &SolveReport, ctx: &str) {
+    // `0` exactly, not the whole `0..=99` solved band: since gh #591 the band
+    // also holds `1` (`Solved_To_Acceptable_Level`), and this fixture must
+    // reach the strict certificate.
     let code = report.solution.solve_result_num;
     assert!(
-        (0..100).contains(&code),
+        code == 0,
         "{ctx}: not solved (solve_result_num={code}, status={:?})",
         report.solution.status,
     );

--- a/crates/pounce-cli/tests/issue_591_acceptable_level_solved_band.rs
+++ b/crates/pounce-cli/tests/issue_591_acceptable_level_solved_band.rs
@@ -1,0 +1,134 @@
+//! Issue #591 regression: an accepted (reduced-accuracy) solve must leave
+//! AMPL's *solved* band in the `.sol`, with Ipopt's own code.
+//!
+//! `Solved_To_Acceptable_Level` used to be written as `solve_result_num =
+//! 100`. Nothing reads that number in isolation — consumers key on the band —
+//! and the two bands are not equivalent: Pyomo's legacy `.sol` reader turns
+//! `0..=99` into `SolverStatus.ok` and `100..=199` into `SolverStatus.warning`,
+//! both with `TerminationCondition.optimal`. So an accepted POUNCE solve loaded
+//! as
+//!
+//! ```text
+//! solver.status          warning
+//! termination_condition  optimal
+//! message                POUNCE 0.10.0: SolvedToAcceptableLevel
+//! ```
+//!
+//! and Pyomo logged "Loading a SolverResults object with a warning status",
+//! while the equivalent Ipopt solve ("Solved To Acceptable Level.") loaded as
+//! `status=ok`. Ipopt's ASL driver emits `1` for `STOP_AT_ACCEPTABLE_POINT`
+//! (`Ipopt/src/Apps/AmplSolver/AmplTNLP.cpp`), so POUNCE does too — which fixes
+//! the plugin route and the route where the POUNCE binary is driven through
+//! Pyomo's generic `ipopt` ASL interface alike, since both read this file.
+//!
+//! The scientific distinction is not lost: it stays in the status name on the
+//! `.sol` message line, in `solve_result_num` itself (`1`, not `0`), and in the
+//! JSON report's status field.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pounce_cli::solve_report::SolveReport;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+
+fn pounce_exe() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_pounce"))
+}
+
+fn tmp_path(suffix: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "pounce_issue591_{}_{}_{suffix}",
+        std::process::id(),
+        n
+    ));
+    p
+}
+
+/// Solve a built-in problem and return `(report, .sol text)`.
+fn solve(problem: &str, extra_opts: &[&str]) -> (SolveReport, String) {
+    let json_path = tmp_path(&format!("{problem}.json"));
+    let sol_path = tmp_path(&format!("{problem}.sol"));
+    let mut cmd = Command::new(pounce_exe());
+    cmd.arg("--problem")
+        .arg(problem)
+        .arg("--sol-output")
+        .arg(&sol_path)
+        .arg("--json-output")
+        .arg(&json_path)
+        .arg("print_level=0");
+    for opt in extra_opts {
+        cmd.arg(opt);
+    }
+    let _ = cmd.status().expect("spawn pounce");
+    let json = std::fs::read_to_string(&json_path).expect("read json report");
+    let sol = std::fs::read_to_string(&sol_path).expect("read .sol");
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&sol_path);
+    (
+        serde_json::from_str(&json).expect("deserialize SolveReport"),
+        sol,
+    )
+}
+
+/// The `objno <objno> <solve_result_num>` line every `.sol` ends with.
+fn objno_code(sol: &str) -> i32 {
+    let line = sol
+        .lines()
+        .find(|l| l.starts_with("objno "))
+        .unwrap_or_else(|| panic!("no objno line in .sol:\n{sol}"));
+    line.split_whitespace()
+        .nth(2)
+        .and_then(|t| t.parse().ok())
+        .unwrap_or_else(|| panic!("unparsable objno line {line:?}"))
+}
+
+/// `tol` below anything reachable plus a generous `acceptable_tol` routes the
+/// solve through the acceptable-level fallback — the same recipe as the
+/// `optimize_hs71` and `pounce.minimize` (#119) acceptable-level tests.
+const FORCE_ACCEPTABLE: [&str; 3] = ["tol=1e-30", "acceptable_tol=1e-4", "acceptable_iter=1"];
+
+#[test]
+fn acceptable_level_writes_ipopts_code_in_the_solved_band() {
+    let (report, sol) = solve("rosenbrock", &FORCE_ACCEPTABLE);
+    assert_eq!(
+        report.solution.status,
+        ApplicationReturnStatus::SolvedToAcceptableLevel,
+        "fixture no longer reaches the acceptable-level fallback, so this test \
+         is not exercising #591 — .sol was:\n{sol}",
+    );
+
+    let code = objno_code(&sol);
+    assert_eq!(code, 1, "Ipopt's STOP_AT_ACCEPTABLE_POINT code");
+    assert!(
+        (0..=99).contains(&code),
+        "an accepted solve must be in AMPL's solved band, which Pyomo's legacy \
+         .sol reader loads as status=ok; {code} is not (gh #591)",
+    );
+    // The `.sol` and the JSON report cannot disagree about the same run.
+    assert_eq!(report.solution.solve_result_num, code);
+
+    // Reduced accuracy is still legible to the caller: the status name reaches
+    // the message line verbatim, exactly as before the code change.
+    let message = sol.lines().next().unwrap_or_default();
+    assert!(
+        message.contains("SolvedToAcceptableLevel"),
+        "the acceptable-level distinction must stay visible in the message, \
+         got {message:?}",
+    );
+}
+
+/// The control: a full-accuracy solve still reports `0`, so the two outcomes
+/// remain distinguishable by code and not merely by message.
+#[test]
+fn a_strict_solve_still_writes_zero() {
+    let (report, sol) = solve("rosenbrock", &[]);
+    assert_eq!(
+        report.solution.status,
+        ApplicationReturnStatus::SolveSucceeded,
+    );
+    assert_eq!(objno_code(&sol), 0);
+}

--- a/crates/pounce-solve-report/src/lib.rs
+++ b/crates/pounce-solve-report/src/lib.rs
@@ -556,11 +556,33 @@ fn empty_stats() -> StatisticsInfo {
 /// upstream Ipopt's ASL driver and the CLI's own convex path, which
 /// reports `QpStatus::DualInfeasible` (unbounded) as 300 (`main.rs`). It
 /// is *not* a limit (400) condition.
+///
+/// `SolvedToAcceptableLevel` is `1`, not the 100 band, matching Ipopt's
+/// ASL driver exactly (`Ipopt/src/Apps/AmplSolver/AmplTNLP.cpp`:
+/// `STOP_AT_ACCEPTABLE_POINT` → `solve_result_num = 1`, message
+/// "Solved To Acceptable Level."). The band is what consumers key on, and
+/// the two bands are not interchangeable here: Pyomo's legacy `.sol`
+/// reader turns `0..=99` into `status=ok` but `100..=199` into
+/// `status=warning` with the same `termination_condition=optimal`, so the
+/// 100 band made Pyomo log a "Loading a SolverResults object with a
+/// warning status" warning on an accepted solve that Ipopt loads clean —
+/// breaking solver-swappable clients whose accepted-solve contract
+/// includes `status == ok` (gh #591). The reduced-accuracy convergence
+/// stays visible in the status name and the `.sol` message line; it just
+/// no longer reads as a warning.
+///
+/// `FeasiblePointFound` deliberately stays in the 100 "solved, with a
+/// warning" band even though Ipopt emits `2` for it. The two statuses do
+/// not mean the same thing: Ipopt returns `FEASIBLE_POINT_FOUND` only for
+/// a square problem, where a feasible point *is* the solution, while
+/// POUNCE uses it for a usable feasible point that did not meet the
+/// convergence criteria — a run its own interfaces do not call a success
+/// (`pyomo_pounce.v2._V2_STATUS`, `pyomo_pounce.sens._STATUS_RESULT`).
 pub fn status_to_solve_result_num(status: ApplicationReturnStatus) -> i32 {
     use ApplicationReturnStatus::*;
     match status {
         SolveSucceeded => 0,
-        SolvedToAcceptableLevel => 100,
+        SolvedToAcceptableLevel => 1,
         FeasiblePointFound => 100,
         InfeasibleProblemDetected => 200,
         DivergingIterates => 300,
@@ -803,6 +825,35 @@ mod tests {
             400,
         );
         assert_eq!(status_to_solve_result_num(RestorationFailed), 500);
+    }
+
+    /// gh #591: an accepted (reduced-accuracy) solve must land in AMPL's
+    /// `0..=99` *solved* band with Ipopt's own code, `1`. In the 100 band
+    /// Pyomo's legacy `.sol` reader loads the result as
+    /// `status=warning, termination_condition=optimal` and logs a warning,
+    /// while the identical Ipopt solve loads as `status=ok` — so a
+    /// solver-swappable client that treats `status == ok` as part of its
+    /// accepted-solve contract had to special-case POUNCE.
+    #[test]
+    fn solved_to_acceptable_level_is_in_the_solved_band_like_ipopt() {
+        use ApplicationReturnStatus::*;
+        let code = status_to_solve_result_num(SolvedToAcceptableLevel);
+        assert_eq!(
+            code, 1,
+            "Ipopt's ASL driver emits 1 for STOP_AT_ACCEPTABLE_POINT",
+        );
+        assert!(
+            (0..=99).contains(&code),
+            "must be in the solved band Pyomo maps to status=ok, got {code}",
+        );
+        // Still distinguishable from a full-accuracy solve: the two codes
+        // differ, and the status name carries the distinction verbatim into
+        // the `.sol` message line.
+        assert_ne!(code, status_to_solve_result_num(SolveSucceeded));
+
+        // A feasible-but-unconverged point is a different claim and keeps
+        // the warning band — see the mapping's doc comment.
+        assert_eq!(status_to_solve_result_num(FeasiblePointFound), 100);
     }
 
     #[test]

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -149,6 +149,30 @@ two solvers, and attributing the remainder to either solver's file
 handling will mislead you. Use the same interface on both sides, or
 compare the solvers' own reported times.
 
+### How an accepted solve is reported
+
+POUNCE reports the AMPL solve codes IPOPT's own driver reports, so a model
+that swaps `ipopt` for `pounce` gets the same `SolverResults` shape. In
+particular a solve that stops at the
+[acceptable level](options.md#solved_to_acceptable_level-and-acceptable_progress_kappa)
+— the strict tolerances were missed, `acceptable_tol` was met — is an
+*accepted* solve on every route:
+
+| interface | reported as |
+|---|---|
+| legacy `SolverFactory('pounce')` | `status=ok`, `termination_condition=optimal` |
+| v2 | `TerminationCondition.convergenceCriteriaSatisfied`, `SolutionStatus.optimal` |
+| declared-parameter (in-process) | `status=ok`, `termination_condition=optimal` |
+
+Which convergence you got is in the solver message
+(`POUNCE X.Y.Z: SolvedToAcceptableLevel` against
+`POUNCE X.Y.Z: SolveSucceeded`) and, on the `.sol` route, in
+`results.solver.id` — the AMPL code, `1` against `0`. Up to and including
+0.10.0 the legacy route reported the acceptable-level solve as
+`status=warning`, which made Pyomo log a load warning that IPOPT does not
+([#591](https://github.com/jkitchin/pounce/issues/591)); if your code
+special-cased POUNCE there, it no longer needs to.
+
 ## User scaling with the `scaling_factor` Suffix
 
 A badly conditioned model converges poorly, and often you know its

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -166,12 +166,18 @@ particular a solve that stops at the
 
 Which convergence you got is in the solver message
 (`POUNCE X.Y.Z: SolvedToAcceptableLevel` against
-`POUNCE X.Y.Z: SolveSucceeded`) and, on the `.sol` route, in
-`results.solver.id` — the AMPL code, `1` against `0`. Up to and including
-0.10.0 the legacy route reported the acceptable-level solve as
-`status=warning`, which made Pyomo log a load warning that IPOPT does not
-([#591](https://github.com/jkitchin/pounce/issues/591)); if your code
-special-cased POUNCE there, it no longer needs to.
+`POUNCE X.Y.Z: SolveSucceeded`) and, on the legacy `.sol` route, in
+`results.solver.id` — the AMPL code, `1` against `0`.
+
+Up to and including 0.10.0 the acceptable-level solve was written as AMPL
+code `100`, which put it in the "solved, with a warning" band
+([#591](https://github.com/jkitchin/pounce/issues/591)). The legacy route
+then reported `status=warning` and Pyomo logged a load warning that IPOPT
+does not; the v2 route, whose reader maps that band to
+`TerminationCondition.error`, went further and raised
+`NoOptimalSolutionError` under the default
+`raise_exception_on_nonoptimal_result=True`. If your code special-cased
+POUNCE for either, it no longer needs to.
 
 ## User scaling with the `scaling_factor` Suffix
 

--- a/docs/src/schema/solve-report-v1.md
+++ b/docs/src/schema/solve-report-v1.md
@@ -162,7 +162,7 @@ Problem dimensions reported by the TNLP at `get_nlp_info()`.
 | Field | Type | Notes |
 |---|---|---|
 | `status` | string | `ApplicationReturnStatus` enum variant name verbatim (e.g. `"SolveSucceeded"`, `"MaximumIterationsExceeded"`). |
-| `solve_result_num` | integer | AMPL-style solve-result code (Gay 2005, "Hooking Your Solver to AMPL" §5, p. 23 table): 0 = solved, 100-range = warning, 200-range = infeasible, 400-range = limit reached, 500-range = failure. |
+| `solve_result_num` | integer | AMPL-style solve-result code (Gay 2005, "Hooking Your Solver to AMPL" §5, p. 23 table): 0 = solved, 100-range = warning, 200-range = infeasible, 400-range = limit reached, 500-range = failure. Within the solved range, `0` is `SolveSucceeded` and `1` is `SolvedToAcceptableLevel` — IPOPT's codes ([solution output](../solution-output.md#solved-strict-vs-acceptable)). Identical to the `objno` code in the `.sol`. |
 | `objective` | float | Final unscaled objective value. `0.0` (not NaN) when the solve never completed; check `statistics.iteration_count > 0` to distinguish. |
 | `x` | array of float \| empty | Primal vector, length `problem.n_variables`. Empty when the binary doesn't capture the final iterate (currently: `pounce` on the `newton_driver` fast-path). Omitted from JSON when empty. |
 | `lambda` | array of float \| empty | Constraint multipliers, length `problem.n_constraints`. Same omission convention as `x`. |

--- a/docs/src/solution-output.md
+++ b/docs/src/solution-output.md
@@ -36,6 +36,34 @@ Solver to AMPL* §5). Consumers key on the **band**, not the exact number:
 Pyomo maps each band to a `TerminationCondition`, so anything in `200`–`299`
 arrives as `TerminationCondition.infeasible`.
 
+### Solved: strict vs. acceptable
+
+POUNCE writes the same codes IPOPT's AMPL driver writes, so a model can be
+moved between the two solvers without a reader change:
+
+| Code | Verdict | What it means |
+|---|---|---|
+| `0` | `Solve_Succeeded` | The convergence criteria (`tol` and friends) were met. |
+| `1` | `Solved_To_Acceptable_Level` | The [acceptable-level fallback](options.md#solved_to_acceptable_level-and-acceptable_progress_kappa): the strict tolerances were not met, but `acceptable_tol` was, for `acceptable_iter` consecutive iterations. |
+
+Both are accepted solves and both sit in the `0`–`99` band. That matters
+beyond tidiness: Pyomo's legacy `.sol` reader loads the `0`–`99` band as
+`SolverStatus.ok` and the `100`–`199` band as `SolverStatus.warning`, with
+`TerminationCondition.optimal` either way. POUNCE reported acceptable-level
+solves as `100` up to and including 0.10.0, so Pyomo logged
+
+```text
+WARNING: Loading a SolverResults object with a warning status into model...
+    - termination condition: optimal
+    - message from solver: POUNCE 0.10.0: SolvedToAcceptableLevel
+```
+
+on a solve IPOPT loads clean
+([#591](https://github.com/jkitchin/pounce/issues/591)). The distinction
+between strict and acceptable convergence is still there — in the code itself
+(`1`, not `0`), in the `.sol` message line, and in the JSON report's `status`
+field — it simply no longer reads as a warning.
+
 ### Infeasible: proved vs. local
 
 Within the infeasible band POUNCE distinguishes *how* it knows:

--- a/pyomo-pounce/pyomo_pounce/sens.py
+++ b/pyomo-pounce/pyomo_pounce/sens.py
@@ -427,11 +427,19 @@ def _iter_data(comp):
 # Engine status -> (termination condition, solver status), mirroring the
 # semantics Pyomo's .sol reader gives the ordinary path via the AMPL
 # exit-code ranges (optimal / infeasible / unbounded / limit / error).
+#
+# `Solved_To_Acceptable_Level` is `ok`, not `warning`: the solve is an
+# accepted one, and the AMPL code POUNCE emits for it (1, Ipopt's own) puts
+# the ordinary `.sol` route in the 0..99 band that Pyomo's reader loads as
+# `ok`. Reporting `warning` here would make the sensitivity route disagree
+# with both the `.sol` route and `v2._V2_STATUS`, and would make Pyomo log a
+# load warning on a result IPOPT loads clean (gh #591). The reduced-accuracy
+# distinction stays in the solver message, not the severity.
 _STATUS_RESULT = {
     "Solve_Succeeded":
         (TerminationCondition.optimal, SolverStatus.ok),
     "Solved_To_Acceptable_Level":
-        (TerminationCondition.optimal, SolverStatus.warning),
+        (TerminationCondition.optimal, SolverStatus.ok),
     "Feasible_Point_Found":
         (TerminationCondition.feasible, SolverStatus.warning),
     "Infeasible_Problem_Detected":

--- a/pyomo-pounce/tests/test_issue_591_acceptable_level_status.py
+++ b/pyomo-pounce/tests/test_issue_591_acceptable_level_status.py
@@ -12,7 +12,15 @@ That covers the `SolverFactory("pounce")` plugin and the route where the
 POUNCE binary is driven through Pyomo's generic `ipopt` ASL interface alike,
 since both read the same `.sol`. The in-process sensitivity route does not go
 through a `.sol` at all, so its table is fixed here too.
+
+The v2 route reads the same `.sol` through a *stricter* table
+(`pyomo.contrib.solver.solvers.asl_sol_reader`), which maps `100..199` to
+`TerminationCondition.error` rather than a warning — so with the default
+`raise_exception_on_nonoptimal_result` an accepted solve raised
+`NoOptimalSolutionError` there. That is pinned below too.
 """
+import pytest
+
 import pyomo.environ as pyo
 
 import pyomo_pounce  # noqa: F401  (registers 'pounce')
@@ -86,5 +94,30 @@ def test_sol_route_loads_an_accepted_solve_as_ok(pounce_exe):
         "an accepted solve must load without Pyomo's warning-status warning; "
         "IPOPT reports the equivalent solve as ok (gh #591)"
     )
-    # The scientific distinction stays visible where it belongs: the message.
-    assert "SolvedToAcceptableLevel" in message
+    # The scientific distinction stays visible where it belongs: the message,
+    # and the AMPL code itself (`1`, not `0`) which Pyomo keeps as `solver.id`.
+    assert results.solver.id == 1
+
+
+@pytest.mark.skipif(not pyomo_pounce.HAVE_V2_INTERFACE,
+                    reason="the v2 interface needs Pyomo >= 6.10.1")
+def test_v2_route_does_not_reject_an_accepted_solve(pounce_exe):
+    """The v2 route reads the same `.sol` through a stricter table than the
+    legacy one: `pyomo.contrib.solver.solvers.asl_sol_reader` maps `100..199`
+    to `TerminationCondition.error` (not a warning), so with the default
+    `raise_exception_on_nonoptimal_result=True` an accepted solve did not
+    merely log — it raised `NoOptimalSolutionError`."""
+    from pyomo.contrib.solver.common.factory import (
+        SolverFactory as SolverFactoryV2,
+    )
+    from pyomo.contrib.solver.common.results import (
+        SolutionStatus,
+        TerminationCondition,
+    )
+
+    m = build()
+    results = SolverFactoryV2("pounce").solve(
+        m, executable=pounce_exe, solver_options=FORCE_ACCEPTABLE)
+    assert results.termination_condition is \
+        TerminationCondition.convergenceCriteriaSatisfied
+    assert results.solution_status is SolutionStatus.optimal

--- a/pyomo-pounce/tests/test_issue_591_acceptable_level_status.py
+++ b/pyomo-pounce/tests/test_issue_591_acceptable_level_status.py
@@ -1,0 +1,90 @@
+"""gh #591: an accepted (reduced-accuracy) solve must load as `status=ok`.
+
+POUNCE used to write `Solved_To_Acceptable_Level` into the `.sol` as AMPL
+`solve_result_num = 100`. Pyomo's legacy reader maps the `100..199` band to
+`SolverStatus.warning` (with `TerminationCondition.optimal`) and the `0..99`
+band to `SolverStatus.ok`, so an accepted POUNCE solve arrived as a warning —
+Pyomo logging "Loading a SolverResults object with a warning status" — while
+the equivalent IPOPT solve ("Solved To Acceptable Level.") arrived as `ok`.
+POUNCE now emits IPOPT's own code, `1`.
+
+That covers the `SolverFactory("pounce")` plugin and the route where the
+POUNCE binary is driven through Pyomo's generic `ipopt` ASL interface alike,
+since both read the same `.sol`. The in-process sensitivity route does not go
+through a `.sol` at all, so its table is fixed here too.
+"""
+import pyomo.environ as pyo
+
+import pyomo_pounce  # noqa: F401  (registers 'pounce')
+from pyomo_pounce.sens import _STATUS_RESULT
+from pyomo_pounce.v2 import _V2_STATUS
+
+#: `tol` below anything reachable plus a generous `acceptable_tol` routes the
+#: solve through the acceptable-level fallback (the recipe the Rust-side
+#: `issue_591_acceptable_level_solved_band` and `#119` tests use).
+FORCE_ACCEPTABLE = {
+    "tol": 1e-30,
+    "acceptable_tol": 1e-4,
+    "acceptable_iter": 1,
+    "print_level": 0,
+}
+
+
+def build():
+    """A small smooth NLP with an active constraint. Deliberately not a
+    quadratic: a QP is dispatched to the convex engine, whose own
+    reduced-accuracy status is a different code path."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(initialize=1.0, bounds=(None, 3.0))
+    m.y = pyo.Var(initialize=1.0)
+    m.c = pyo.Constraint(expr=m.x + m.y >= 1.0)
+    m.obj = pyo.Objective(
+        expr=(m.x - 2.0) ** 2 + (m.y - 1.0) ** 2 + 0.1 * pyo.exp(m.x + m.y))
+    return m
+
+
+def test_acceptable_level_is_not_a_warning_in_the_sens_table():
+    """The in-process (declared-parameter) route reports the same severity as
+    a clean solve — an accepted solve is accepted."""
+    tc, status = _STATUS_RESULT["Solved_To_Acceptable_Level"]
+    assert tc is pyo.TerminationCondition.optimal
+    assert status is pyo.SolverStatus.ok
+    # Same severity as Solve_Succeeded; the two differ in the solver message,
+    # not in whether the result loads clean.
+    assert status is _STATUS_RESULT["Solve_Succeeded"][1]
+
+
+def test_the_three_interfaces_agree_that_it_is_a_success():
+    """v2 already treated it as a success. The point of #591 is that POUNCE's
+    own interfaces must not disagree about the severity of one status."""
+    v2_tc, v2_soln = _V2_STATUS["Solved_To_Acceptable_Level"]
+    assert (v2_tc, v2_soln) == _V2_STATUS["Solve_Succeeded"]
+    assert _STATUS_RESULT["Solved_To_Acceptable_Level"] == \
+        _STATUS_RESULT["Solve_Succeeded"]
+
+
+def test_sol_route_loads_an_accepted_solve_as_ok(pounce_exe):
+    """End-to-end over the ordinary `.sol` route: the reported symptom.
+
+    Driven through the `pounce_exe` fixture rather than plain resolution: the
+    assertion is about the code *this* build writes, and a stale binary would
+    answer for a different one."""
+    m = build()
+    results = pyo.SolverFactory("pounce", executable=pounce_exe).solve(
+        m, options=FORCE_ACCEPTABLE)
+
+    message = str(results.solver.message)
+    # Guard the fixture: if the recipe stops reaching the acceptable-level
+    # fallback, this test silently stops testing #591.
+    assert "SolvedToAcceptableLevel" in message, (
+        f"expected the acceptable-level fallback, got message {message!r} "
+        f"with status {results.solver.status}"
+    )
+    assert results.solver.termination_condition is \
+        pyo.TerminationCondition.optimal
+    assert results.solver.status is pyo.SolverStatus.ok, (
+        "an accepted solve must load without Pyomo's warning-status warning; "
+        "IPOPT reports the equivalent solve as ok (gh #591)"
+    )
+    # The scientific distinction stays visible where it belongs: the message.
+    assert "SolvedToAcceptableLevel" in message


### PR DESCRIPTION
Fixes #591.

## Problem

An accepted `Solved_To_Acceptable_Level` solve came back through Pyomo as a warning, where the equivalent IPOPT solve comes back clean. Measured on a small smooth NLP forced through the acceptable-level fallback (`tol=1e-30`, `acceptable_tol=1e-4`, `acceptable_iter=1`), Pyomo 6.10.1:

| | AMPL code | legacy `solver.status` | legacy `termination_condition` | v2 |
|---|---|---|---|---|
| before | `100` | `warning` | `optimal` | **raises `NoOptimalSolutionError`** |
| after | `1` | `ok` | `optimal` | `convergenceCriteriaSatisfied` / `SolutionStatus.optimal` |
| oracle (IPOPT 3.13.2) | `1` | `ok` | `optimal` | — |

The legacy symptom is the one reported: Pyomo logs `Loading a SolverResults object with a warning status`, and every solver-swappable client whose accepted-solve contract includes `status == ok` has to special-case POUNCE.

The v2 row was not in the issue and is worse. Pyomo's v2 `.sol` reader (`pyomo.contrib.solver.solvers.asl_sol_reader.asl_solve_code_to_solution_status`) maps `100`–`199` to `TerminationCondition.error`, not to a warning, so with the default `raise_exception_on_nonoptimal_result=True` an accepted solve *raised* rather than logging. Measured directly against the released 0.10.0 binary versus this build.

## Cause

`status_to_solve_result_num` (`crates/pounce-solve-report/src/lib.rs`) wrote `SolvedToAcceptableLevel` as `100`. Nothing reads that integer in isolation — consumers key on the band — and the two bands are not interchangeable: Pyomo's legacy reader (`pyomo/opt/plugins/sol.py`) splits `0`–`99` → `SolverStatus.ok` from `100`–`199` → `SolverStatus.warning`, both with `TerminationCondition.optimal`.

IPOPT's ASL driver emits `1` here: `Ipopt/src/Apps/AmplSolver/AmplTNLP.cpp`, `case STOP_AT_ACCEPTABLE_POINT: solve_result_num = 1` with the message `"Solved To Acceptable Level."`. POUNCE claims drop-in compatibility on this surface and was one band off.

## Fix

Emit IPOPT's code, `1`. Fixing the *emitted* code rather than normalising in the plugin is what the issue suggested, and it is the only fix that covers both routes into Pyomo — `SolverFactory("pounce")` and the POUNCE binary driven through Pyomo's generic `ipopt` ASL interface — since both read the same file. It also fixes AMPL itself and any other `.sol` consumer.

Three consequential decisions:

- **The convex engines move with it.** `QpStatus::OptimalInaccurate` (`convex_status_report` in `pounce-cli/src/main.rs`) also reported `100`, and `qp_status_to_ars` maps it onto `SolvedToAcceptableLevel`. One status must not report two codes depending on which engine took the model, so it is now `1`, asserted equal to the NLP path's code rather than to a literal.
- **`pyomo_pounce.sens._STATUS_RESULT` reports `ok`.** That route reads no `.sol`, and its own table said `warning` — the disagreement the issue points at. It now matches the `.sol` route and the v2 table, which already treated the status as a success.
- **`Feasible_Point_Found` deliberately stays at `100`,** even though IPOPT emits `2` for it. The statuses are not the same claim: IPOPT returns `FEASIBLE_POINT_FOUND` only for a square problem, where a feasible point *is* the solution, while POUNCE uses it for a usable point that did not meet the convergence criteria — a run `v2._V2_STATUS` and `sens._STATUS_RESULT` both decline to call a success. Moving it into the solved band would have made the `.sol` route contradict them. Reasoning recorded on the mapping so the asymmetry with IPOPT is not read as an oversight and "fixed" later.

Rejected: normalising in the legacy plugin. It leaves the generic-ASL users the issue explicitly names, leaves AMPL wrong, and puts the mapping in two places.

Reduced accuracy is not swept under the rug. It stays in the code (`1`, not `0` — Pyomo keeps it as `results.solver.id`), in the `.sol` message line, in the JSON report's `status`, and in the console summary.

## Blast radius

Only `Solved_To_Acceptable_Level` / `OptimalInaccurate` change; every other status keeps its code, including the whole infeasible band and the `200`/`201` distinction. No numerical behaviour changes — same iterates, same statuses, only the integer written next to `objno`.

Consumers that read the band see a solve move from "solved, with a warning" to "solved". That is the point, and it is a behaviour change worth knowing about for anyone who keyed on `100` to detect reduced accuracy: the status name and `solver.id == 1` are the supported ways to detect it, and both are now pinned by tests. Nothing in the repo did key on `100` — the studio fixtures carry `0` and `400` only.

The five convergence regressions that asserted `(0..100).contains(&code)` (#250, #257, #266, #512, #557) were equivalent to `code == 0` before this change, since `0` was the only code in that band. They would have silently started admitting the acceptable-level fallback — exactly what #266's own doc comment says it must not accept — so they now say `code == 0` explicitly. No test loses strength; #266's stale "code 100 is outside the solved band" comment is corrected.

## Tests

New, and both fail on the parent commit for the stated reason:

- `crates/pounce-cli/tests/issue_591_acceptable_level_solved_band.rs` — runs the CLI on a solve forced through the fallback, asserts the `.sol` carries `objno 0 1`, that the code is in the band Pyomo loads as `ok`, that the JSON report agrees with the `.sol`, and that the status name still reaches the message line. Plus a strict-solve control that must still write `0`. On the parent commit: `assertion left == right failed: Ipopt's STOP_AT_ACCEPTABLE_POINT code, left: 100, right: 1`.
- `pyomo-pounce/tests/test_issue_591_acceptable_level_status.py` — the three interfaces agree the status is a success; the legacy `.sol` route loads `status=ok` with `solver.id == 1`; the v2 route returns instead of raising. Run against the released 0.10.0 binary (which emits `100`), the two `.sol`-route tests fail with `SolverStatus.warning is SolverStatus.ok` and `NoOptimalSolutionError` respectively.
- A unit test in `pounce-solve-report` pins the code, the band, its distinctness from `SolveSucceeded`, and `Feasible_Point_Found` staying at `100`.
- The existing convex `optimal_inaccurate_is_distinct_from_optimal` now asserts the convex code *equals* the NLP path's, so the two cannot drift apart again.

Not pinned: the acceptable-level fallback is reached through an options recipe (`tol=1e-30` + a generous `acceptable_tol`), not a fixture that guarantees it. Both new end-to-end tests assert the status they got is the acceptable-level one before asserting anything about it, so if the recipe ever stops reaching the fallback they fail loudly rather than passing vacuously.

Whole `pounce-cli` suite green (195 + all integration binaries), `pounce-solve-report` green, `cargo fmt --all -- --check` clean, `cargo clippy --all-targets -- -D clippy::correctness -D clippy::suspicious` clean on both touched crates. The `pyomo-pounce` suite is green except 25 pre-existing failures in `test_estimate_report.py`, all `AttributeError: 'Solver' object has no attribute 'bound_relax_factor'` — this container's installed wheel predates that API, unrelated to this change.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`solution-output.md` strict-vs-acceptable table, a status section in `pyomo.md`, the schema note; no new page, so no `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now


---
_Generated by [Claude Code](https://claude.ai/code/session_012yRtq4TX9gfhBiZxJ98FaP)_