### PR TITLE
docs: capture the #544/#592 trajectory-regression post-mortem, add the fixture sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,28 @@ topological order. Run it before tagging.
    `pip install pounce-solver` does not require the crates.io publish — but the
    crates.io publish is still part of a complete release.
 
+## Trajectory changes need the fixture sweep
+
+A change that reroutes **which** correction the solver reaches for, or that
+reorders/rescales the steps it takes, is a *trajectory* change. Run
+`scripts/sweep-fixtures.sh` against a baseline binary and diff, **before
+merge**, and be able to explain every line that moves.
+
+"It cannot produce a wrong answer" is **not** the relevant safety property
+here, and that exact argument is what shipped gh#544 in 0.10.0: a trajectory
+regression produces the *right* answer, slowly — or a differently-wrong
+tolerance-legal one. gh#544 took `pooling_rt2stp` from 206 to 812 iterations;
+the suite asserts status and objective, not iteration count, so nothing saw it.
+It surfaced as a CI wall-clock timeout, was misattributed, the cap was raised
+for good reasons, and the underlying defect shipped and came back as gh#592.
+
+Related: a measured regression that gets recorded as "an accepted cost of the
+fix" needs an issue and an owner. Without one it is indistinguishable from
+noise to the next reader — which is how 206 → 812 sat in a commit message
+through a release.
+
+Full post-mortem: `dev-notes/trajectory-regressions-and-the-fixture-sweep.md`.
+
 ## Working GitHub issues
 
 When opening a PR that fixes a filed issue, the PR **body** (not just the

--- a/dev-notes/trajectory-regressions-and-the-fixture-sweep.md
+++ b/dev-notes/trajectory-regressions-and-the-fixture-sweep.md
@@ -1,0 +1,124 @@
+# Trajectory regressions: how #544 shipped in 0.10.0 and came back as #592
+
+A post-mortem, written after #592 was fixed. The point is not that a bug
+shipped — that happens — but that this one was **measured, recorded, and
+reclassified as an accepted cost** three days before the release, by a chain of
+individually defensible decisions. The chain is worth knowing because every
+link in it will look reasonable again next time.
+
+The operational conclusion is one line, and it is in `CLAUDE.md`: a change that
+reroutes *which* correction the solver reaches for is a trajectory change, and
+trajectory changes need `scripts/sweep-fixtures.sh` before merge.
+
+## What happened
+
+| when | what |
+|---|---|
+| Aug 8 | `a0362be4` — #540's fix. Adds `feral_inertia_pivot_floor`, default `1e-12`. Reroutes a mismatching inertia count from the `δ_x` ladder to `δ_c`. |
+| Aug 8 | Same change takes `pooling_rt2stp` from 206 to 812 iterations. Known at the time. |
+| Aug 8 | `3eea43bb` — #547. `pooling_rt2stp` has been timing out in CI. Diagnosed correctly as a wall-clock cap sized like a perf budget; caps replaced with one 300 s hang guard. |
+| Aug 11 | `v0.10.0` tagged. |
+| ~Aug 14 | #592 filed: `Solve_Succeeded` at a point POUNCE immediately improves on restart. Same root cause. |
+
+## The four decisions
+
+**1. An explicit argument for skipping the corpus.** From `a0362be4`'s own
+commit message:
+
+> "The new feral_inertia_pivot_floor (default 1e-12) is consulted only once the
+> count has already mismatched — on a factorization the caller was going to
+> reject either way — so it can never turn a usable factor into a failure; **it
+> only changes which perturbation is reached for first. That is what makes the
+> default safe to change without the benchmark corpus.**"
+
+The premise is true and the conclusion does not follow. The safety argument
+reasons about *factorization outcomes*: no good factor becomes a failure.
+The risk lives in *step sequence*, and the same sentence names it — "changes
+which perturbation is reached for first." Correct reasoning, wrong axis, used
+to waive the one check that covers the other axis.
+
+This is the transferable lesson. "It cannot produce a wrong answer" is not the
+relevant safety property for a step-computation change, because a trajectory
+regression produces the *right* answer, slowly — or a differently-wrong
+tolerance-legal answer, which is what #592 was.
+
+**2. A dimension-dependent quantity pinned to a scalar.** The 0.10.0 release
+notes describe the default as "`1e-12`, the middle of the `n·eps` range over
+which an equilibrated pivot loses its sign." A quantity acknowledged in the
+same clause to depend on `n` was fixed by taking the middle of its range.
+`1e-12` is `n·eps` at `n ≈ 4500`; the KKT systems in #592 are order 165–311,
+where `n·eps` is 3.7e-14 … 6.9e-14 — two decades away. Nothing tied the
+constant to the system being factored. It now does
+(`pounce_feral::inertia_trust_floor`).
+
+Worth stating plainly: the defect was legible in the release notes at release
+time. Writing the rationale down was not enough; nothing re-read it against
+the models it would act on.
+
+**3. A measured regression became an accepted cost with no tracking.**
+`pooling_rt2stp` 206 → 812 was known. #547's commit calls it "a recorded cost
+of that fix — and the cap was not revisited then." A 4× iteration regression on
+a corpus model is a defect report about the fix that caused it. Recorded as a
+cost, with no issue and no owner, it is indistinguishable from noise by the
+next reader.
+
+**4. The last signal was retired for good reasons.** #547 is a *good* commit.
+Its reasoning is right: nothing in that file asserts a time, no assertion
+weakens as the cap grows, `max_wall_time` is wall clock under `cargo test`
+contention, and the timeout had been misattributed to `dual_diverging_streak`.
+Raising 10 s → 300 s was correct. But the timeout was, accidentally, the only
+instrument in the suite pointed at trajectory length — and fixing the
+instrument's calibration removed the reading without anyone deciding to.
+
+## Why nothing else caught it
+
+- **No corpus sweep runs anywhere.** CI is: Test, pounce-rs facade, hsl
+  compile-check, WASM, two Python lanes. The 57 fixtures are already in-tree at
+  `crates/pounce-cli/tests/fixtures`; nothing ran all of them.
+- **The assertions are status + objective, not trajectory.** 28 test files
+  check `iteration_count`, but each pins the single model it was written for.
+  `pooling_rt2stp` still reached the right objective with the right status —
+  four times slower. Invisible to every assertion in the suite.
+- **n = 2 confirmation.** The only models exercised were `eigena2` and
+  `eigenb2` — the two the fix was developed against. Both improved. A fix
+  validated only on the population it was tuned on has not been validated.
+
+## The structural problem, which is still open
+
+#540 and #592 are the same defect class: a wrong *first guess* between `δ_c`
+(regularise the constraint block) and `δ_x` (regularise the Hessian). Before
+#540 the guess was wrong for degenerate-Jacobian models; #540 moved it and made
+it wrong for full-rank-Jacobian models it had no visibility into. It traded one
+population for another while holding only the first in view.
+
+The #592 fix does **not** close this class. The walk-back is a bounded recovery
+from a wrong guess (three rungs, then withdraw), not a discriminator. The
+discriminator needs `min_pivot_index` from feral — which block owns the
+smallest pivot — and feral is an external crates.io dependency, so that is
+follow-up work, recorded in `issue-592-restart-non-idempotence.md`.
+
+**Anything that touches this guess should be assumed to trade populations
+until a sweep shows otherwise.**
+
+## What to do instead
+
+`scripts/sweep-fixtures.sh` — 57 fixtures already in the repo, status +
+objective + **iteration count**, sorted and diffable, about two minutes:
+
+    git stash && cargo build --release && cp target/release/pounce /tmp/p-base
+    git stash pop && cargo build --release
+    scripts/sweep-fixtures.sh /tmp/p-base           /tmp/base.txt
+    scripts/sweep-fixtures.sh target/release/pounce /tmp/new.txt
+    diff /tmp/base.txt /tmp/new.txt
+
+An empty diff is the expected result for a change not meant to move the corpus.
+Every line that moves should be explainable **before** merge. On #592 the diff
+was two lines (`eigena2` 27 → 26, `eigenb2` 68 → 67, both improvements, no
+status changes), and that is what made it safe to land a default change. Run
+against #544 it would have printed `pooling_rt2stp 206 → 812` immediately.
+
+Two things it does not do, deliberately: it is not wired into CI (57 solves is
+too slow for every PR, and it needs a *baseline* binary to be meaningful), and
+it does not assert anything. It is an instrument, not a gate. The judgment
+about which moved lines are acceptable stays with the person merging — the
+failure here was never a missing assertion, it was a missing reading.

--- a/scripts/sweep-fixtures.sh
+++ b/scripts/sweep-fixtures.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Trajectory sweep over the CLI fixture corpus.
+#
+# Runs every fixture in crates/pounce-cli/tests/fixtures and records status,
+# objective AND iteration count, one line per model, sorted and diffable.
+#
+# WHY THIS EXISTS (pounce gh#592, and gh#544 before it). The CLI test suite
+# asserts *status* and *objective*. It does not assert trajectory length, and
+# a change to the step computation can leave both of those untouched while
+# taking four times as many iterations to get there. That is exactly what
+# gh#544 did to pooling_rt2stp -- 206 -> 812 iterations -- and nothing in the
+# suite could see it; it surfaced three days before the 0.10.0 release as a
+# wall-clock timeout, was misattributed, and the cap was raised. The defect it
+# was a symptom of shipped, and came back as gh#592.
+#
+# So: any change that reroutes WHICH correction the solver reaches for, or
+# reorders/rescales the steps it takes, needs this sweep. "It cannot produce a
+# wrong answer" is not the relevant safety property -- trajectory changes are
+# invisible to the answer.
+#
+# Usage:
+#   scripts/sweep-fixtures.sh <pounce-binary> <outfile> [extra solver opts...]
+#
+#   git stash && cargo build --release && cp target/release/pounce /tmp/p-base
+#   git stash pop && cargo build --release
+#   scripts/sweep-fixtures.sh /tmp/p-base            /tmp/base.txt
+#   scripts/sweep-fixtures.sh target/release/pounce  /tmp/new.txt
+#   diff /tmp/base.txt /tmp/new.txt
+#
+# An empty diff is the expected result for a change that is not meant to move
+# the corpus. Every line that does move should be explainable before merge --
+# not after a user reports it.
+set -uo pipefail
+
+BIN="${1:?usage: sweep-fixtures.sh <pounce-binary> <outfile> [opts...]}"
+OUT="${2:?usage: sweep-fixtures.sh <pounce-binary> <outfile> [opts...]}"
+shift 2
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FX="$ROOT/crates/pounce-cli/tests/fixtures"
+[ -d "$FX" ] || { echo "no fixture dir at $FX" >&2; exit 2; }
+
+W=$(mktemp -d)
+trap 'rm -rf "$W"' EXIT
+: > "$OUT"
+
+for f in "$FX"/*.nl; do
+  n=$(basename "$f" .nl)
+  # A fixture that hangs must not hang the sweep; it shows up as NO_JSON.
+  timeout 300 "$BIN" "$f" "$W/$n.sol" --json-output "$W/$n.json" "$@" \
+    >/dev/null 2>&1
+  if [ -f "$W/$n.json" ]; then
+    python3 - "$W/$n.json" "$n" >> "$OUT" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1]))
+s = d.get("solution", {})
+st = d.get("statistics", {})
+obj = s.get("objective")
+print("%-40s %-32s it=%-6s obj=%s" % (
+    sys.argv[2],
+    s.get("status"),
+    st.get("iteration_count", "?"),
+    "%.10g" % obj if obj is not None else "none",
+))
+PY
+  else
+    printf '%-40s NO_JSON\n' "$n" >> "$OUT"
+  fi
+done
+
+sort -o "$OUT" "$OUT"
+echo "swept $(wc -l < "$OUT" | tr -d ' ') fixtures -> $OUT"


### PR DESCRIPTION
A post-mortem on how #544 shipped in 0.10.0 and came back as #592, plus the
instrument that would have caught it. No solver code changes.

## Why

#592 is not a new defect. It is #544, which shipped in 0.10.0 three days after
a 4x iteration regression on a corpus model was measured, recorded in a commit
message as "an accepted cost of that fix", and released. Every link in that
chain was individually defensible, which is exactly why it is worth writing
down — they will all look reasonable again next time.

The short version, from #540's own commit message (`a0362be4`):

> "The new feral_inertia_pivot_floor (default 1e-12) is consulted only once the
> count has already mismatched — on a factorization the caller was going to
> reject either way — so it can never turn a usable factor into a failure; **it
> only changes which perturbation is reached for first. That is what makes the
> default safe to change without the benchmark corpus.**"

The premise is true and the conclusion does not follow. The safety argument
reasons about *factorization outcomes* — no good factor becomes a failure. The
risk lives in *step sequence*, and the same sentence names it. Correct
reasoning, wrong axis, used to waive the one check that covers the other axis.

That is the transferable part: **"it cannot produce a wrong answer" is not the
relevant safety property for a step-computation change.** A trajectory
regression produces the right answer, slowly — or a differently-wrong
tolerance-legal answer, which is what #592 was.

## What is here

**`scripts/sweep-fixtures.sh`** — runs the 57 fixtures already in-tree at
`crates/pounce-cli/tests/fixtures` and records status, objective **and
iteration count**, sorted and diffable.

    git stash && cargo build --release && cp target/release/pounce /tmp/p-base
    git stash pop && cargo build --release
    scripts/sweep-fixtures.sh /tmp/p-base           /tmp/base.txt
    scripts/sweep-fixtures.sh target/release/pounce /tmp/new.txt
    diff /tmp/base.txt /tmp/new.txt

The suite asserts status and objective, not iteration count. That is why #544
taking `pooling_rt2stp` from 206 to 812 iterations was invisible to it: same
status, same objective, four times the work. Run against #544 this prints
`pooling_rt2stp 206 -> 812` immediately. On #592 the diff was two lines
(`eigena2` 27→26, `eigenb2` 68→67, both improvements, no status changes), and
that is what made a default change safe to land.

Two deliberate non-features, documented in the header:

- **Not wired into CI.** 57 solves is too slow for every PR, and the output is
  meaningless without a *baseline* binary to diff against.
- **Asserts nothing.** It is an instrument, not a gate. The failure here was a
  missing reading, not a missing assertion, and the judgment about which moved
  lines are acceptable belongs to the person merging.

**`dev-notes/trajectory-regressions-and-the-fixture-sweep.md`** — the
forensics: the Aug 8 → Aug 11 timeline, the four decisions with commit messages
quoted, why nothing else caught it (no corpus sweep anywhere; 28 test files
check `iteration_count` but each pins the one model it was written for;
`eigena2`/`eigenb2` were the only models exercised and are the two the fix was
tuned on — n=2 confirmation), and the part that is still open.

Still open, and stated as such: #540 and #592 are one defect class — a wrong
*first guess* between `δ_c` and `δ_x`. #540 moved the guess to serve
degenerate-Jacobian models and made it wrong for full-rank-Jacobian models it
had no visibility into. #592's walk-back is a bounded recovery from a wrong
guess, **not** a discriminator; that needs `min_pivot_index` from feral, an
external crates.io dependency. So anything touching this guess should be
assumed to trade populations until a sweep shows otherwise.

**`CLAUDE.md`** — the operational half, in the style of the entries already
there: trajectory changes need the sweep, "cannot produce a wrong answer" is
not the safety property, and a regression recorded as "an accepted cost" needs
an issue and an owner — without one it is indistinguishable from noise to the
next reader, which is how 206 → 812 sat in a commit message through a release.

## A note on tone

The post-mortem says plainly that #547 — which raised the wall-clock caps — is
a *good* commit whose reasoning is correct, and that it happened to retire the
only instrument in the suite pointed at trajectory length. Softening that would
turn the note into blame-avoidance and lose the lesson, but it does name a
specific decision, so it is worth seeing before this merges.

## Verification

`scripts/sweep-fixtures.sh` run end to end on the current build: 57/57
fixtures, no `NO_JSON`. `scripts/check-docs-consistency.sh` passes (the
dev-note is correctly absent from `SUMMARY.md`, as `dev-notes/` are not book
pages). `bash -n` clean. No solver source is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLnYvbmau12Ep9LzZUwahm
