### PR TITLE
sens: a released bound is computed by re-factoring, not from the converged factor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ changes.
 
 ## [Unreleased]
 
+### Fixed — a released bound is now accurate at a tight tolerance (#587 follow-up)
+
+`sens_boundcheck` / `estimate(mode="fix_relax")` could release a bound
+onto the wrong answer, and did so more badly the *better* the solve had
+converged. Asking for `tol = 1e-10` instead of `1e-6` made the released
+coordinate about 30000x less accurate, with no warning: the check that
+guards the refinement watches the condition it imposed, which a release
+does satisfy, while the error lands in the other variables.
+
+The cause is that an active bound contributes `sigma = z / s` to the
+KKT's `x` diagonal. That term grows as the solve converges, and it
+destroys the released system's information in the converged factor, so
+no amount of rearranging recovers a release from it. Releases are now
+computed by dropping the bound's `sigma` and re-factoring — one
+factorization per released set, still well under a re-solve, and none
+at all for a step that releases nothing.
+
+Measured on the release model, error against the exact answer: at
+`tol = 1e-8`, 2.4e-7 → 2.2e-12; at `tol = 1e-10`, 2.2e-4 → 9.6e-15. The
+same holds under `obj_scaling_factor`, which reaches the defect by
+moving where the solve stops: flat at ~1.5e-10 across six decades,
+against 8.7e-4 at `obj_scaling_factor = 1000` before.
+
+Pinning is unchanged, as is every path that releases no bound.
+
 ### Added — `estimate(mode="fix_relax")` bends the estimate around a bound instead of clipping it (#587)
 
 `estimate()` takes the linear step, and where that step leaves a

--- a/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
+++ b/crates/pounce-algorithm/src/kkt/pd_full_space_solver.rs
@@ -147,6 +147,58 @@ impl PdFullSpaceSolver {
         allow_inexact: bool,
         improve_solution: bool,
     ) -> bool {
+        self.solve_with_sigma_x(
+            data,
+            cq,
+            nlp,
+            alpha,
+            beta,
+            rhs,
+            res,
+            allow_inexact,
+            improve_solution,
+            None,
+        )
+    }
+
+    /// [`Self::solve`] against the same system with `sigma_x` replaced.
+    ///
+    /// `sigma_x` is the barrier term the active bounds contribute to
+    /// the `x` diagonal, `z / s` per bound. Zeroing an entry takes that
+    /// bound back out of the active set, which is what a *released*
+    /// bound means, so factoring the result gives the released system
+    /// directly.
+    ///
+    /// This exists because the released system cannot be recovered from
+    /// the converged factor. Reaching it by a rank-1 downdate through a
+    /// Schur complement asks for the difference of two quantities that
+    /// agree to about `eps * sigma`, and on a tightly converged bound
+    /// `sigma` is large enough that the difference is noise -- measured,
+    /// the released answer degrades in proportion to how well the solve
+    /// converged. Factoring is what buys those digits back, and it is
+    /// still one factorization against the twenty to a hundred a
+    /// re-solve would run.
+    ///
+    /// Only `pounce-sensitivity` calls this; the algorithm's own step
+    /// computation goes through [`Self::solve`] and is unaffected, so no
+    /// solver trajectory moves. `sigma_x` is one of the thirteen
+    /// dependency tags, so passing a different vector misses the
+    /// factorization cache and re-factors, and the next ordinary solve
+    /// misses it back -- correctness needs no extra bookkeeping here.
+    #[allow(clippy::too_many_arguments)]
+    pub fn solve_with_sigma_x(
+        &mut self,
+        data: &IpoptDataHandle,
+        cq: &IpoptCqHandle,
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        alpha: Number,
+        beta: Number,
+        rhs: &IteratesVector,
+        res: &mut IteratesVectorMut,
+        allow_inexact: bool,
+        improve_solution: bool,
+        sigma_x_override: Option<Rc<dyn pounce_linalg::Vector>>,
+    ) -> bool {
         debug_assert!(!allow_inexact || !improve_solution);
         debug_assert!(!improve_solution || beta == 0.0);
 
@@ -169,7 +221,7 @@ impl PdFullSpaceSolver {
         let cq_ref = cq.borrow();
         let j_c = cq_ref.curr_jac_c();
         let j_d = cq_ref.curr_jac_d();
-        let sigma_x = cq_ref.curr_sigma_x();
+        let sigma_x = sigma_x_override.unwrap_or_else(|| cq_ref.curr_sigma_x());
         let sigma_s = cq_ref.curr_sigma_s();
         let slack_x_l = cq_ref.curr_slack_x_l();
         let slack_x_u = cq_ref.curr_slack_x_u();

--- a/crates/pounce-cli/src/sens.rs
+++ b/crates/pounce-cli/src/sens.rs
@@ -451,6 +451,9 @@ fn try_compute_sens_step(
             &lo,
             &hi,
             &mults,
+            // the right-hand side this path's own step came from, so a
+            // release re-solves the system it started in
+            &rhs_full,
             eps,
             16,
         ) {

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -140,6 +140,11 @@ pub struct PdSensBacksolver {
     /// `finalize_solution_z_l` / `n_full_x`-length reports come in.
     /// `None` alongside [`Self::d_var`].
     d_full: Option<Rc<Vec<Number>>>,
+    /// Var-x row of the variable each bound multiplier constrains,
+    /// `z_l` entries then `z_u` entries, read off the `px_l` / `px_u`
+    /// expansions. `None` when either expansion is not an
+    /// `ExpansionMatrix` and the map cannot be recovered.
+    bound_vars: Option<Rc<Vec<crate::backsolver::BoundRow>>>,
 }
 
 /// Left/right diagonal pair for the natural-units back-solve; see the
@@ -189,6 +194,7 @@ impl PdSensBacksolver {
         ];
         let (d_var, d_full) = Self::variable_factors(nlp, &dims)?;
         let conj = Self::natural_units_conj(nlp, &dims, d_var.as_ref().map(|v| v.as_slice()))?;
+        let bound_vars = Self::bound_variable_rows(nlp, &dims);
         Ok(Self {
             pd,
             data: Rc::clone(data),
@@ -199,7 +205,224 @@ impl PdSensBacksolver {
             conj,
             d_var,
             d_full,
+            bound_vars,
         })
+    }
+
+    /// Shared body of the two released solves. `shift` moves the
+    /// released multipliers onto their x rows, which the step needs and
+    /// a Schur complement's unit vectors must not get.
+    fn solve_released_inner(
+        &self,
+        released: &[usize],
+        rhs: &[Number],
+        lhs: &mut [Number],
+        shift: bool,
+    ) -> bool {
+        if rhs.len() != self.dim() || lhs.len() != self.dim() {
+            return false;
+        }
+        // Nothing released is an ordinary solve. Taking this early lets
+        // callers route every solve through here without paying a
+        // re-factorization for a step that releases nothing.
+        if released.is_empty() {
+            return self.solve(rhs, lhs);
+        }
+        let Some(sigma) = self.released_sigma_x(released) else {
+            return false;
+        };
+        let mut scaled: Vec<Number> = match self.conj.as_ref() {
+            Some(c) => rhs.iter().zip(c.e.iter()).map(|(&r, &e)| r * e).collect(),
+            None => rhs.to_vec(),
+        };
+        if shift && !self.shift_released_rhs(released, &mut scaled) {
+            return false;
+        }
+        if !self.solve_released_scaled(sigma, &scaled, lhs) {
+            return false;
+        }
+        if let Some(c) = self.conj.as_ref() {
+            for (l, &f) in lhs.iter_mut().zip(c.f.iter()) {
+                *l *= f;
+            }
+        }
+        true
+    }
+
+    /// `curr_sigma_x` with each released bound's own `z / s` taken off
+    /// the variable it constrains -- subtracted rather than zeroed,
+    /// since a variable bounded on both sides contributes twice and
+    /// only one side is being released.
+    fn released_sigma_x(&self, released: &[usize]) -> Option<Rc<dyn pounce_linalg::Vector>> {
+        use pounce_linalg::dense_vector::DenseVectorSpace;
+        let rows = self.bound_vars.as_deref()?;
+        let base_row = rows.first()?.row;
+        let cq_ref = self.cq.borrow();
+        let dense = |v: Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
+            v.as_any()
+                .downcast_ref::<DenseVector>()
+                .map(|d| d.expanded_values())
+        };
+        let mut sigma = dense(cq_ref.curr_sigma_x())?;
+        let slack_l = dense(cq_ref.curr_slack_x_l())?;
+        let slack_u = dense(cq_ref.curr_slack_x_u())?;
+        drop(cq_ref);
+        let (z_l, z_u) = {
+            let d = self.data.borrow();
+            let curr = d.curr.as_ref()?;
+            (dense(Rc::clone(&curr.z_l))?, dense(Rc::clone(&curr.z_u))?)
+        };
+        for &r in released {
+            let br = rows.iter().find(|b| b.row == r)?;
+            let k = r - base_row - if br.lower { 0 } else { self.dims[4] };
+            let (z, s) = if br.lower {
+                (*z_l.get(k)?, *slack_l.get(k)?)
+            } else {
+                (*z_u.get(k)?, *slack_u.get(k)?)
+            };
+            if s == 0.0 || !s.is_finite() {
+                return None;
+            }
+            *sigma.get_mut(br.var_row)? -= z / s;
+        }
+        let space = DenseVectorSpace::new(sigma.len() as Index);
+        let mut out = DenseVector::new(space);
+        out.values_mut().copy_from_slice(&sigma);
+        Some(Rc::new(out) as Rc<dyn pounce_linalg::Vector>)
+    }
+
+    /// Zero the released multipliers' own rows of a scaled-space
+    /// right-hand side and move each multiplier onto its variable's x
+    /// row.
+    ///
+    /// Dropping `sigma` gives the released *matrix*; the released
+    /// right-hand side still wants the multiplier moved across. The
+    /// elimination folds a multiplier row in as `r_z / s`, so zeroing
+    /// that row and adding the multiplier to the x row directly reaches
+    /// the same place without `s` appearing at all -- which is the
+    /// whole point of re-factoring rather than downdating.
+    fn shift_released_rhs(&self, released: &[usize], rhs: &mut [Number]) -> bool {
+        let Some(rows) = self.bound_vars.as_deref() else {
+            return false;
+        };
+        let Some(base_row) = rows.first().map(|b| b.row) else {
+            return false;
+        };
+        let d = self.data.borrow();
+        let Some(curr) = d.curr.as_ref() else {
+            return false;
+        };
+        let dense = |v: &Rc<dyn pounce_linalg::Vector>| -> Option<Vec<Number>> {
+            v.as_any()
+                .downcast_ref::<DenseVector>()
+                .map(|x| x.expanded_values())
+        };
+        let (Some(z_l), Some(z_u)) = (dense(&curr.z_l), dense(&curr.z_u)) else {
+            return false;
+        };
+        for &r in released {
+            let Some(br) = rows.iter().find(|b| b.row == r) else {
+                return false;
+            };
+            let k = r - base_row - if br.lower { 0 } else { self.dims[4] };
+            let Some(&z) = (if br.lower { z_l.get(k) } else { z_u.get(k) }) else {
+                return false;
+            };
+            if r >= rhs.len() || br.var_row >= rhs.len() {
+                return false;
+            }
+            rhs[r] = 0.0;
+            // the sign the x row carries this side's multiplier with
+            rhs[br.var_row] += if br.lower { -z } else { z };
+        }
+        true
+    }
+
+    /// One back-solve against the re-factored system, in the solver's
+    /// internal scaled space.
+    fn solve_released_scaled(
+        &self,
+        sigma: Rc<dyn pounce_linalg::Vector>,
+        rhs: &[Number],
+        lhs: &mut [Number],
+    ) -> bool {
+        let off = self.offsets();
+        let rhs_mut0 = self.template.make_new_zeroed();
+        let mut rhs_iv = rhs_mut0.freeze();
+        let mut res_iv = self.template.make_new_zeroed();
+        if !(write_rhs_block(&mut rhs_iv.x, &rhs[off[0]..off[1]])
+            && write_rhs_block(&mut rhs_iv.s, &rhs[off[1]..off[2]])
+            && write_rhs_block(&mut rhs_iv.y_c, &rhs[off[2]..off[3]])
+            && write_rhs_block(&mut rhs_iv.y_d, &rhs[off[3]..off[4]])
+            && write_rhs_block(&mut rhs_iv.z_l, &rhs[off[4]..off[5]])
+            && write_rhs_block(&mut rhs_iv.z_u, &rhs[off[5]..off[6]])
+            && write_rhs_block(&mut rhs_iv.v_l, &rhs[off[6]..off[7]])
+            && write_rhs_block(&mut rhs_iv.v_u, &rhs[off[7]..off[8]]))
+        {
+            return false;
+        }
+        if !self.pd.borrow_mut().solve_with_sigma_x(
+            &self.data,
+            &self.cq,
+            &self.nlp,
+            1.0,
+            0.0,
+            &rhs_iv,
+            &mut res_iv,
+            /* allow_inexact = */ true,
+            /* improve_solution = */ false,
+            Some(sigma),
+        ) {
+            return false;
+        }
+        read_res_block(&*res_iv.x, &mut lhs[off[0]..off[1]])
+            && read_res_block(&*res_iv.s, &mut lhs[off[1]..off[2]])
+            && read_res_block(&*res_iv.y_c, &mut lhs[off[2]..off[3]])
+            && read_res_block(&*res_iv.y_d, &mut lhs[off[3]..off[4]])
+            && read_res_block(&*res_iv.z_l, &mut lhs[off[4]..off[5]])
+            && read_res_block(&*res_iv.z_u, &mut lhs[off[5]..off[6]])
+            && read_res_block(&*res_iv.v_l, &mut lhs[off[6]..off[7]])
+            && read_res_block(&*res_iv.v_u, &mut lhs[off[7]..off[8]])
+    }
+
+    /// Var-x row behind each `z_l` then `z_u` entry, through the
+    /// `px_l` / `px_u` expansions. `None` when either is not an
+    /// `ExpansionMatrix` or reports the wrong length -- the release
+    /// half then stays off rather than guessing a mapping.
+    fn bound_variable_rows(
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        dims: &[usize; 8],
+    ) -> Option<Rc<Vec<crate::backsolver::BoundRow>>> {
+        let nlp_ref = nlp.borrow();
+        let z_l_off = dims[0] + dims[1] + dims[2] + dims[3];
+        let mut out = Vec::with_capacity(dims[4] + dims[5]);
+        for (pm, n_v, off, lower) in [
+            (nlp_ref.px_l(), dims[4], z_l_off, true),
+            (nlp_ref.px_u(), dims[5], z_l_off + dims[4], false),
+        ] {
+            if n_v == 0 {
+                continue;
+            }
+            let em = pm
+                .as_any()
+                .downcast_ref::<pounce_linalg::expansion_matrix::ExpansionMatrix>()?;
+            let pos = em.expanded_pos_indices();
+            if pos.len() != n_v {
+                return None;
+            }
+            for (k, &p) in pos.iter().enumerate() {
+                let p = p as usize;
+                if p >= dims[0] {
+                    return None;
+                }
+                out.push(crate::backsolver::BoundRow {
+                    row: off + k,
+                    var_row: p,
+                    lower,
+                });
+            }
+        }
+        Some(Rc::new(out))
     }
 
     /// Read the variable factors the solve ran under off the NLP and
@@ -924,6 +1147,22 @@ impl SensBacksolver for PdSensBacksolver {
     /// same numbers the back-solve used.
     fn natural_units_factor(&self) -> Option<&[Number]> {
         self.conj.as_ref().map(|c| c.f.as_slice())
+    }
+
+    fn bound_rows(&self) -> Option<&[crate::backsolver::BoundRow]> {
+        self.bound_vars.as_deref().map(|v| v.as_slice())
+    }
+
+    fn supports_release(&self) -> bool {
+        self.bound_vars.is_some()
+    }
+
+    fn solve_released(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+        self.solve_released_inner(released, rhs, lhs, false)
+    }
+
+    fn solve_released_step(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+        self.solve_released_inner(released, rhs, lhs, true)
     }
 
     /// Solve `K · lhs = rhs` against the converged factor, in

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -140,6 +140,11 @@ pub struct PdSensBacksolver {
     /// `finalize_solution_z_l` / `n_full_x`-length reports come in.
     /// `None` alongside [`Self::d_var`].
     d_full: Option<Rc<Vec<Number>>>,
+    /// Var-x row of the variable each bound multiplier constrains,
+    /// `z_l` entries then `z_u` entries, read off the `px_l` / `px_u`
+    /// expansions. `None` when either expansion is not an
+    /// `ExpansionMatrix` and the map cannot be recovered.
+    bound_vars: Option<Rc<Vec<crate::backsolver::BoundRow>>>,
 }
 
 /// Left/right diagonal pair for the natural-units back-solve; see the
@@ -189,6 +194,7 @@ impl PdSensBacksolver {
         ];
         let (d_var, d_full) = Self::variable_factors(nlp, &dims)?;
         let conj = Self::natural_units_conj(nlp, &dims, d_var.as_ref().map(|v| v.as_slice()))?;
+        let bound_vars = Self::bound_variable_rows(nlp, &dims);
         Ok(Self {
             pd,
             data: Rc::clone(data),
@@ -199,7 +205,48 @@ impl PdSensBacksolver {
             conj,
             d_var,
             d_full,
+            bound_vars,
         })
+    }
+
+    /// Var-x row behind each `z_l` then `z_u` entry, through the
+    /// `px_l` / `px_u` expansions. `None` when either is not an
+    /// `ExpansionMatrix` or reports the wrong length -- the release
+    /// half then stays off rather than guessing a mapping.
+    fn bound_variable_rows(
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        dims: &[usize; 8],
+    ) -> Option<Rc<Vec<crate::backsolver::BoundRow>>> {
+        let nlp_ref = nlp.borrow();
+        let z_l_off = dims[0] + dims[1] + dims[2] + dims[3];
+        let mut out = Vec::with_capacity(dims[4] + dims[5]);
+        for (pm, n_v, off, lower) in [
+            (nlp_ref.px_l(), dims[4], z_l_off, true),
+            (nlp_ref.px_u(), dims[5], z_l_off + dims[4], false),
+        ] {
+            if n_v == 0 {
+                continue;
+            }
+            let em = pm
+                .as_any()
+                .downcast_ref::<pounce_linalg::expansion_matrix::ExpansionMatrix>()?;
+            let pos = em.expanded_pos_indices();
+            if pos.len() != n_v {
+                return None;
+            }
+            for (k, &p) in pos.iter().enumerate() {
+                let p = p as usize;
+                if p >= dims[0] {
+                    return None;
+                }
+                out.push(crate::backsolver::BoundRow {
+                    row: off + k,
+                    var_row: p,
+                    lower,
+                });
+            }
+        }
+        Some(Rc::new(out))
     }
 
     /// Read the variable factors the solve ran under off the NLP and
@@ -924,6 +971,10 @@ impl SensBacksolver for PdSensBacksolver {
     /// same numbers the back-solve used.
     fn natural_units_factor(&self) -> Option<&[Number]> {
         self.conj.as_ref().map(|c| c.f.as_slice())
+    }
+
+    fn bound_rows(&self) -> Option<&[crate::backsolver::BoundRow]> {
+        self.bound_vars.as_deref().map(|v| v.as_slice())
     }
 
     /// Solve `K · lhs = rhs` against the converged factor, in

--- a/crates/pounce-sensitivity/src/algorithm_backsolver.rs
+++ b/crates/pounce-sensitivity/src/algorithm_backsolver.rs
@@ -140,11 +140,6 @@ pub struct PdSensBacksolver {
     /// `finalize_solution_z_l` / `n_full_x`-length reports come in.
     /// `None` alongside [`Self::d_var`].
     d_full: Option<Rc<Vec<Number>>>,
-    /// Var-x row of the variable each bound multiplier constrains,
-    /// `z_l` entries then `z_u` entries, read off the `px_l` / `px_u`
-    /// expansions. `None` when either expansion is not an
-    /// `ExpansionMatrix` and the map cannot be recovered.
-    bound_vars: Option<Rc<Vec<crate::backsolver::BoundRow>>>,
 }
 
 /// Left/right diagonal pair for the natural-units back-solve; see the
@@ -194,7 +189,6 @@ impl PdSensBacksolver {
         ];
         let (d_var, d_full) = Self::variable_factors(nlp, &dims)?;
         let conj = Self::natural_units_conj(nlp, &dims, d_var.as_ref().map(|v| v.as_slice()))?;
-        let bound_vars = Self::bound_variable_rows(nlp, &dims);
         Ok(Self {
             pd,
             data: Rc::clone(data),
@@ -205,48 +199,7 @@ impl PdSensBacksolver {
             conj,
             d_var,
             d_full,
-            bound_vars,
         })
-    }
-
-    /// Var-x row behind each `z_l` then `z_u` entry, through the
-    /// `px_l` / `px_u` expansions. `None` when either is not an
-    /// `ExpansionMatrix` or reports the wrong length -- the release
-    /// half then stays off rather than guessing a mapping.
-    fn bound_variable_rows(
-        nlp: &Rc<RefCell<dyn IpoptNlp>>,
-        dims: &[usize; 8],
-    ) -> Option<Rc<Vec<crate::backsolver::BoundRow>>> {
-        let nlp_ref = nlp.borrow();
-        let z_l_off = dims[0] + dims[1] + dims[2] + dims[3];
-        let mut out = Vec::with_capacity(dims[4] + dims[5]);
-        for (pm, n_v, off, lower) in [
-            (nlp_ref.px_l(), dims[4], z_l_off, true),
-            (nlp_ref.px_u(), dims[5], z_l_off + dims[4], false),
-        ] {
-            if n_v == 0 {
-                continue;
-            }
-            let em = pm
-                .as_any()
-                .downcast_ref::<pounce_linalg::expansion_matrix::ExpansionMatrix>()?;
-            let pos = em.expanded_pos_indices();
-            if pos.len() != n_v {
-                return None;
-            }
-            for (k, &p) in pos.iter().enumerate() {
-                let p = p as usize;
-                if p >= dims[0] {
-                    return None;
-                }
-                out.push(crate::backsolver::BoundRow {
-                    row: off + k,
-                    var_row: p,
-                    lower,
-                });
-            }
-        }
-        Some(Rc::new(out))
     }
 
     /// Read the variable factors the solve ran under off the NLP and
@@ -971,10 +924,6 @@ impl SensBacksolver for PdSensBacksolver {
     /// same numbers the back-solve used.
     fn natural_units_factor(&self) -> Option<&[Number]> {
         self.conj.as_ref().map(|c| c.f.as_slice())
-    }
-
-    fn bound_rows(&self) -> Option<&[crate::backsolver::BoundRow]> {
-        self.bound_vars.as_deref().map(|v| v.as_slice())
     }
 
     /// Solve `K · lhs = rhs` against the converged factor, in

--- a/crates/pounce-sensitivity/src/backsolver.rs
+++ b/crates/pounce-sensitivity/src/backsolver.rs
@@ -57,6 +57,34 @@ pub trait SensBacksolver {
     fn natural_units_factor(&self) -> Option<&[Number]> {
         None
     }
+
+    /// The variable behind each bound-multiplier row. `None` when the
+    /// backsolver cannot report it, which leaves
+    /// [`crate::boundcheck::refine_step_onto_bounds`] with no way to
+    /// release and so pinning only.
+    ///
+    /// A release is applied as a rank-1 downdate of that variable's
+    /// `sigma` off the x diagonal rather than as a condition on the
+    /// multiplier's own row, so it needs to know which variable each
+    /// row belongs to and which side it bounds. See
+    /// `refine_step_onto_bounds` for why the multiplier's row is the
+    /// wrong place to put the condition.
+    fn bound_rows(&self) -> Option<&[BoundRow]> {
+        None
+    }
+}
+
+/// One bound-multiplier row of the compound KKT vector, resolved to
+/// the variable it constrains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BoundRow {
+    /// Row of the compound KKT vector holding the multiplier.
+    pub row: usize,
+    /// Var-x row of the variable that bound constrains.
+    pub var_row: usize,
+    /// `true` for a lower bound (`z_l`), `false` for an upper (`z_u`).
+    /// The x row carries the two with opposite signs.
+    pub lower: bool,
 }
 
 /// Synthetic dense-LU backsolver. Used in this crate's tests to

--- a/crates/pounce-sensitivity/src/backsolver.rs
+++ b/crates/pounce-sensitivity/src/backsolver.rs
@@ -57,34 +57,6 @@ pub trait SensBacksolver {
     fn natural_units_factor(&self) -> Option<&[Number]> {
         None
     }
-
-    /// The variable behind each bound-multiplier row. `None` when the
-    /// backsolver cannot report it, which leaves
-    /// [`crate::boundcheck::refine_step_onto_bounds`] with no way to
-    /// release and so pinning only.
-    ///
-    /// A release is applied as a rank-1 downdate of that variable's
-    /// `sigma` off the x diagonal rather than as a condition on the
-    /// multiplier's own row, so it needs to know which variable each
-    /// row belongs to and which side it bounds. See
-    /// `refine_step_onto_bounds` for why the multiplier's row is the
-    /// wrong place to put the condition.
-    fn bound_rows(&self) -> Option<&[BoundRow]> {
-        None
-    }
-}
-
-/// One bound-multiplier row of the compound KKT vector, resolved to
-/// the variable it constrains.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct BoundRow {
-    /// Row of the compound KKT vector holding the multiplier.
-    pub row: usize,
-    /// Var-x row of the variable that bound constrains.
-    pub var_row: usize,
-    /// `true` for a lower bound (`z_l`), `false` for an upper (`z_u`).
-    /// The x row carries the two with opposite signs.
-    pub lower: bool,
 }
 
 /// Synthetic dense-LU backsolver. Used in this crate's tests to

--- a/crates/pounce-sensitivity/src/backsolver.rs
+++ b/crates/pounce-sensitivity/src/backsolver.rs
@@ -57,6 +57,78 @@ pub trait SensBacksolver {
     fn natural_units_factor(&self) -> Option<&[Number]> {
         None
     }
+
+    /// The variable behind each bound-multiplier row. `None` when the
+    /// backsolver cannot report it, which leaves
+    /// [`crate::boundcheck::refine_step_onto_bounds`] with no way to
+    /// release and so pinning only.
+    ///
+    /// A release re-factors with that variable's `sigma` removed, so it
+    /// needs to know which variable each row belongs to and which side
+    /// it bounds.
+    fn bound_rows(&self) -> Option<&[BoundRow]> {
+        None
+    }
+
+    /// Solve against the system with the bounds named by `released` --
+    /// compound multiplier rows -- taken out of the active set.
+    ///
+    /// This re-factors, and has to. An active bound puts
+    /// `sigma = z / s` on the x diagonal, and on a tightly converged
+    /// bound that term is large enough to destroy the released system's
+    /// information in the converged factor: recovering it from there
+    /// needs the difference of two quantities agreeing to about
+    /// `eps * sigma`, so the released answer comes out *worse* the
+    /// better the solve converged. Re-factoring with the term removed
+    /// is what buys those digits back, and one factorization still sits
+    /// an order of magnitude under a re-solve.
+    ///
+    /// This solves in the released *system* and does nothing to the
+    /// right-hand side, so it is the right call for every solve the
+    /// refinement makes once a bound is out -- including the unit
+    /// vectors a Schur complement is built from, which carry no
+    /// multiplier to move.
+    ///
+    /// `false` by default, which leaves the refinement pinning only.
+    fn solve_released(&self, _released: &[usize], _rhs: &[Number], _lhs: &mut [Number]) -> bool {
+        false
+    }
+
+    /// [`Self::solve_released`] against a *parametric* right-hand side,
+    /// which additionally needs the released multipliers moved onto
+    /// their variables' x rows.
+    ///
+    /// Dropping `sigma` gives the released matrix; this gives the
+    /// released right-hand side to go with it. Only the step itself
+    /// gets this treatment -- applying it to a Schur complement's unit
+    /// vectors would shift a right-hand side that has no multiplier in
+    /// it to begin with.
+    fn solve_released_step(
+        &self,
+        _released: &[usize],
+        _rhs: &[Number],
+        _lhs: &mut [Number],
+    ) -> bool {
+        false
+    }
+
+    /// Whether [`Self::solve_released`] is implemented.
+    fn supports_release(&self) -> bool {
+        false
+    }
+}
+
+/// One bound-multiplier row of the compound KKT vector, resolved to
+/// the variable it constrains.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BoundRow {
+    /// Row of the compound KKT vector holding the multiplier.
+    pub row: usize,
+    /// Var-x row of the variable that bound constrains.
+    pub var_row: usize,
+    /// `true` for a lower bound (`z_l`), `false` for an upper (`z_u`).
+    /// The x row carries the two with opposite signs.
+    pub lower: bool,
 }
 
 /// Synthetic dense-LU backsolver. Used in this crate's tests to

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -324,108 +324,38 @@ where
             .collect(),
     };
     let multipliers = &multipliers[..];
-
-    // Where the bound-multiplier blocks start, and which variable each
-    // multiplier row constrains. Without that map a bound cannot be
-    // released, since the release acts on the variable's own row.
-    let bound_rows = backsolver.bound_rows();
-
-    // One condition per pass. `x_row` is the row it acts on -- always
-    // an x row, for a release as much as for a pin -- `diag` is the
-    // bordered system's (2,2) entry, and `report_row` is what the
-    // caller is told, which stays the multiplier's own row for a
-    // release so the returned list keeps its documented meaning.
-    struct Cond {
-        x_row: usize,
-        rhs: Number,
-        diag: Number,
-        report_row: usize,
-        /// `(multiplier row, base value)` when this is a release.
-        release: Option<(usize, Number)>,
-    }
-    let mut conds: Vec<Cond> = Vec::new();
+    // (compound row, right-hand side), the rhs fixed at creation since
+    // it is measured from the plain step
+    let mut pins: Vec<(usize, Number)> = Vec::new();
 
     for _ in 0..max_passes {
-        let taken: Vec<usize> = conds.iter().map(|c| c.x_row).collect();
-        let taken_z: Vec<usize> = conds
-            .iter()
-            .filter_map(|c| c.release.map(|(r, _)| r))
-            .collect();
+        let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
 
         // one condition per pass, primal first: a variable outside its
         // bound is the more direct violation, and releasing a bound can
         // only matter once the variables it constrains have settled
         let next = match worst_violation(x_curr, &dx, lo, hi, eps, &taken) {
-            Some((i, bound)) => Some(Cond {
-                x_row: i,
-                rhs: (x_curr[i] + dx_plain[i]) - bound,
-                diag: 0.0,
-                report_row: i,
-                release: None,
-            }),
-            None => bound_rows.and_then(|br| {
-                multipliers
-                    .iter()
-                    .filter(|m| !taken_z.contains(&m.row))
-                    .filter_map(|m| br.iter().find(|b| b.row == m.row).map(|b| (m, b)))
-                    .filter(|(_, b)| !taken.contains(&b.var_row))
-                    .map(|(m, b)| (m, b, m.base + dx[m.row]))
-                    .filter(|&(_, _, v)| v < -eps)
-                    // most negative first
-                    .min_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
-                    .and_then(|(m, b, _)| {
-                        let i = b.var_row;
-                        let lower = b.lower;
-                        // The slack the bound carries at the base point.
-                        // Its reciprocal is the `sigma` this release
-                        // takes back off the x diagonal, so the tiny
-                        // number is only ever formed as `s / z`.
-                        let s = if lower {
-                            x_curr[i] - lo[i]
-                        } else {
-                            hi[i] - x_curr[i]
-                        };
-                        if !s.is_finite() || m.base == 0.0 {
-                            return None;
-                        }
-                        // Rank-1 downdate of `sigma = z / s` at row `i`,
-                        // which is what takes this bound back out of
-                        // the active set.
-                        //
-                        // The released x row also wants the multiplier
-                        // moved to the right-hand side. Most of that
-                        // shift is already carried by the parametric
-                        // right-hand side -- the barrier correction
-                        // leaves `-mu` on the multiplier's row, and the
-                        // elimination divides it by `s` -- but only most
-                        // of it, since `mu = s * z` holds at the base
-                        // point to the solve's tolerance and no better.
-                        // Taking the shift as zero on that identity
-                        // costs three orders of magnitude at a default
-                        // tolerance, so it is recovered exactly from the
-                        // step instead: the multiplier's own row gives
-                        // `r_z / s = sigma * dx_i + dz`, and what is
-                        // left is the multiplier the plain step
-                        // predicts, scaled by `s / z`.
-                        // The x row carries a lower bound's multiplier
-                        // with the opposite sign to an upper one, so
-                        // the shift is antisymmetric between the two
-                        // sides even though `sigma` is not.
-                        let shift = (s / m.base) * (m.base + dx_plain[m.row]);
-                        Some(Cond {
-                            x_row: i,
-                            rhs: if lower { -shift } else { shift },
-                            diag: s / m.base,
-                            report_row: m.row,
-                            release: Some((m.row, m.base)),
-                        })
-                    })
-            }),
+            Some((i, bound)) => Some((i, (x_curr[i] + dx_plain[i]) - bound)),
+            None => multipliers
+                .iter()
+                .filter(|m| !taken.contains(&m.row))
+                .map(|m| (m.row, m.base + dx[m.row]))
+                .filter(|&(_, v)| v < -eps)
+                // most negative first
+                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                .map(|(row, _)| {
+                    let base = multipliers
+                        .iter()
+                        .find(|m| m.row == row)
+                        .map_or(0.0, |m| m.base);
+                    // drive it to zero: the bound stops being active
+                    (row, base + dx_plain[row])
+                }),
         };
-        let Some(cond) = next else { break };
-        conds.push(cond);
+        let Some((row, rhs_row)) = next else { break };
+        pins.push((row, rhs_row));
 
-        let rows: Vec<Index> = conds.iter().map(|c| c.x_row as Index).collect();
+        let rows: Vec<Index> = pins.iter().map(|&(r, _)| r as Index).collect();
         let signs = vec![1; rows.len()];
         let mk = |r: Vec<Index>| {
             IndexSchurData::from_parts(r, signs.clone()).map_err(|e| format!("{e:?}"))
@@ -435,18 +365,17 @@ where
             ..SensOptions::default()
         };
         let mut pin_app = SensApplication::new(mk(rows.clone())?, backsolver.clone(), opts);
-        let rhs: Vec<Number> = conds.iter().map(|c| c.rhs).collect();
-        let diag: Vec<Number> = conds.iter().map(|c| c.diag).collect();
+        let rhs: Vec<Number> = pins.iter().map(|&(_, r)| r).collect();
         let mut du = vec![0.0; rows.len()];
         let mut corr = vec![0.0; n_full];
-        if !pin_app.run_sens_step_with_diag(&mk(rows)?, &rhs, &diag, &mut du, &mut corr) {
+        if !pin_app.run_sens_step(&mk(rows)?, &rhs, &mut du, &mut corr) {
             // An exactly singular augmented system, where the
             // near-singular case is what the achievement check below
             // catches. Drop the condition that could not be solved and
             // stop, rather than discarding the refinement and the plain
             // step with it: the caller is told how far it got by the
             // rows returned, which is what every other stop does.
-            conds.pop();
+            pins.pop();
             break;
         }
 
@@ -454,43 +383,17 @@ where
         // have exhausted the degrees of freedom and a dense LU returns a
         // solution around 1e15 rather than reporting it. It is not an
         // accuracy check: a healthy pass lands within a few parts per
-        // million, so demanding more than that rejects working ones.
-        //
-        // A pin is checked on the displacement it asked for. A release
-        // is checked on what it was actually for -- the multiplier
-        // reaching zero -- since its own row carries the bordered
-        // system's diagonal and so does not simply return `-rhs`.
-        let achieved = conds.iter().enumerate().all(|(k, c)| match c.release {
-            None => (corr[c.x_row] + c.rhs).abs() <= 1e-3 * c.rhs.abs().max(1.0),
-            // A release carries the bordered system's diagonal, so its
-            // row does not simply return `-rhs`. What it does hold is
-            // that row itself, `x_i = -D * u`, and a singular solve
-            // breaks it by orders of magnitude. Compared on magnitude
-            // so the check does not depend on the driver's sign
-            // convention for `u`.
-            Some(_) => {
-                let vi = dx_plain[c.x_row] + corr[c.x_row];
-                let pred = (c.diag * du[k]).abs();
-                vi.is_finite() && (vi.abs() - pred).abs() <= 1e-3 * vi.abs().max(1.0)
-            }
-        });
+        // million, so demanding more than that rejects working pins.
+        let achieved = pins
+            .iter()
+            .all(|&(r, want)| (corr[r] + want).abs() <= 1e-3 * want.abs().max(1.0));
         if !achieved {
-            conds.pop();
+            pins.pop();
             break;
         }
         for (k, d) in dx.iter_mut().enumerate() {
             *d = dx_plain[k] + corr[k];
         }
-        // The released bound's own row still carries the value the
-        // retained complementarity row produced, which is a by-product
-        // of the downdate and not the released multiplier. The released
-        // multiplier is zero by construction, so write the step that
-        // says so rather than leaving `z / s` noise in the block.
-        for c in &conds {
-            if let Some((z_row, base)) = c.release {
-                dx[z_row] = -base;
-            }
-        }
     }
-    Ok((dx, conds.into_iter().map(|c| c.report_row).collect()))
+    Ok((dx, pins.into_iter().map(|(r, _)| r).collect()))
 }

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -294,6 +294,7 @@ pub fn refine_step_onto_bounds<B>(
     lo: &[Number],
     hi: &[Number],
     multipliers: &[BoundMultiplier],
+    rhs_plain: &[Number],
     eps: Number,
     max_passes: usize,
 ) -> Result<(Vec<Number>, Vec<usize>), String>
@@ -324,9 +325,20 @@ where
             .collect(),
     };
     let multipliers = &multipliers[..];
+    let bound_rows = backsolver.bound_rows();
+    let can_release = backsolver.supports_release() && rhs_plain.len() == n_full;
+
     // (compound row, right-hand side), the rhs fixed at creation since
-    // it is measured from the plain step
+    // it is measured from the base step
     let mut pins: Vec<(usize, Number)> = Vec::new();
+    // Multiplier rows taken out of the active set. Unlike a pin these
+    // never become a Schur condition: they change the operator, so the
+    // step is re-solved against a factorization that does not carry
+    // their `sigma` at all.
+    let mut released: Vec<usize> = Vec::new();
+    // The step corrections are measured from. It moves whenever the
+    // released set does, since that is a different system.
+    let mut dx_base = dx_plain.to_vec();
 
     for _ in 0..max_passes {
         let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
@@ -335,24 +347,54 @@ where
         // bound is the more direct violation, and releasing a bound can
         // only matter once the variables it constrains have settled
         let next = match worst_violation(x_curr, &dx, lo, hi, eps, &taken) {
-            Some((i, bound)) => Some((i, (x_curr[i] + dx_plain[i]) - bound)),
-            None => multipliers
-                .iter()
-                .filter(|m| !taken.contains(&m.row))
-                .map(|m| (m.row, m.base + dx[m.row]))
-                .filter(|&(_, v)| v < -eps)
-                // most negative first
-                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-                .map(|(row, _)| {
-                    let base = multipliers
-                        .iter()
-                        .find(|m| m.row == row)
-                        .map_or(0.0, |m| m.base);
-                    // drive it to zero: the bound stops being active
-                    (row, base + dx_plain[row])
-                }),
+            Some((i, bound)) => Some((i, (x_curr[i] + dx_base[i]) - bound)),
+            None => None,
         };
-        let Some((row, rhs_row)) = next else { break };
+
+        // Pins first. Only when nothing is outside its bound do we look
+        // at releasing, so the primal violations settle before a bound
+        // leaves the active set.
+        let Some((row, rhs_row)) = next else {
+            // A release is not a condition on the step, it is a
+            // different system: re-solve with that bound's `sigma`
+            // gone, then start over from the step that produced.
+            let worst = if can_release {
+                multipliers
+                    .iter()
+                    .filter(|m| !released.contains(&m.row))
+                    .filter(|m| bound_rows.is_some_and(|br| br.iter().any(|b| b.row == m.row)))
+                    .map(|m| (m.row, m.base + dx[m.row]))
+                    .filter(|&(_, v)| v < -eps)
+                    // most negative first
+                    .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
+                    .map(|(r, _)| r)
+            } else {
+                None
+            };
+            let Some(row) = worst else { break };
+            released.push(row);
+            let mut base = vec![0.0; n_full];
+            if !backsolver.solve_released_step(&released, rhs_plain, &mut base) {
+                // Could not factor with that bound out. Keep the step
+                // reached without it, which is what every other stop
+                // here does.
+                released.pop();
+                break;
+            }
+            // A released bound's multiplier is zero by construction; its
+            // own row of the re-solved step is a by-product of the
+            // complementarity row the factor still carries.
+            for &r in &released {
+                if let Some(m) = multipliers.iter().find(|m| m.row == r) {
+                    base[r] = -m.base;
+                }
+            }
+            dx_base = base;
+            dx.copy_from_slice(&dx_base);
+            // pins are measured from the base, which just moved
+            pins.clear();
+            continue;
+        };
         pins.push((row, rhs_row));
 
         let rows: Vec<Index> = pins.iter().map(|&(r, _)| r as Index).collect();
@@ -364,7 +406,14 @@ where
             run_sens: true,
             ..SensOptions::default()
         };
-        let mut pin_app = SensApplication::new(mk(rows.clone())?, backsolver.clone(), opts);
+        // Against the released operator, not the converged one: once a
+        // bound is out of the active set, every later condition has to
+        // be solved in the system that reflects that.
+        let view = ReleasedView {
+            base: backsolver.clone(),
+            rows: released.clone(),
+        };
+        let mut pin_app = SensApplication::new(mk(rows.clone())?, view, opts);
         let rhs: Vec<Number> = pins.iter().map(|&(_, r)| r).collect();
         let mut du = vec![0.0; rows.len()];
         let mut corr = vec![0.0; n_full];
@@ -392,8 +441,45 @@ where
             break;
         }
         for (k, d) in dx.iter_mut().enumerate() {
-            *d = dx_plain[k] + corr[k];
+            *d = dx_base[k] + corr[k];
         }
     }
-    Ok((dx, pins.into_iter().map(|(r, _)| r).collect()))
+    let mut out = released.clone();
+    out.extend(pins.into_iter().map(|(r, _)| r));
+    Ok((dx, out))
+}
+
+/// The converged backsolver with a set of bounds out of the active set,
+/// so the pin machinery can run against the released system without
+/// knowing that is what it is doing.
+#[derive(Clone)]
+struct ReleasedView<B: crate::backsolver::SensBacksolver + Clone> {
+    base: B,
+    rows: Vec<usize>,
+}
+
+impl<B: crate::backsolver::SensBacksolver + Clone> crate::backsolver::SensBacksolver
+    for ReleasedView<B>
+{
+    fn dim(&self) -> usize {
+        self.base.dim()
+    }
+    fn solve(&self, rhs: &[Number], lhs: &mut [Number]) -> bool {
+        self.base.solve_released(&self.rows, rhs, lhs)
+    }
+    fn natural_units_factor(&self) -> Option<&[Number]> {
+        self.base.natural_units_factor()
+    }
+    fn bound_rows(&self) -> Option<&[crate::backsolver::BoundRow]> {
+        self.base.bound_rows()
+    }
+    fn supports_release(&self) -> bool {
+        self.base.supports_release()
+    }
+    fn solve_released(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+        self.base.solve_released(released, rhs, lhs)
+    }
+    fn solve_released_step(&self, released: &[usize], rhs: &[Number], lhs: &mut [Number]) -> bool {
+        self.base.solve_released_step(released, rhs, lhs)
+    }
 }

--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -324,38 +324,108 @@ where
             .collect(),
     };
     let multipliers = &multipliers[..];
-    // (compound row, right-hand side), the rhs fixed at creation since
-    // it is measured from the plain step
-    let mut pins: Vec<(usize, Number)> = Vec::new();
+
+    // Where the bound-multiplier blocks start, and which variable each
+    // multiplier row constrains. Without that map a bound cannot be
+    // released, since the release acts on the variable's own row.
+    let bound_rows = backsolver.bound_rows();
+
+    // One condition per pass. `x_row` is the row it acts on -- always
+    // an x row, for a release as much as for a pin -- `diag` is the
+    // bordered system's (2,2) entry, and `report_row` is what the
+    // caller is told, which stays the multiplier's own row for a
+    // release so the returned list keeps its documented meaning.
+    struct Cond {
+        x_row: usize,
+        rhs: Number,
+        diag: Number,
+        report_row: usize,
+        /// `(multiplier row, base value)` when this is a release.
+        release: Option<(usize, Number)>,
+    }
+    let mut conds: Vec<Cond> = Vec::new();
 
     for _ in 0..max_passes {
-        let taken: Vec<usize> = pins.iter().map(|&(r, _)| r).collect();
+        let taken: Vec<usize> = conds.iter().map(|c| c.x_row).collect();
+        let taken_z: Vec<usize> = conds
+            .iter()
+            .filter_map(|c| c.release.map(|(r, _)| r))
+            .collect();
 
         // one condition per pass, primal first: a variable outside its
         // bound is the more direct violation, and releasing a bound can
         // only matter once the variables it constrains have settled
         let next = match worst_violation(x_curr, &dx, lo, hi, eps, &taken) {
-            Some((i, bound)) => Some((i, (x_curr[i] + dx_plain[i]) - bound)),
-            None => multipliers
-                .iter()
-                .filter(|m| !taken.contains(&m.row))
-                .map(|m| (m.row, m.base + dx[m.row]))
-                .filter(|&(_, v)| v < -eps)
-                // most negative first
-                .min_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
-                .map(|(row, _)| {
-                    let base = multipliers
-                        .iter()
-                        .find(|m| m.row == row)
-                        .map_or(0.0, |m| m.base);
-                    // drive it to zero: the bound stops being active
-                    (row, base + dx_plain[row])
-                }),
+            Some((i, bound)) => Some(Cond {
+                x_row: i,
+                rhs: (x_curr[i] + dx_plain[i]) - bound,
+                diag: 0.0,
+                report_row: i,
+                release: None,
+            }),
+            None => bound_rows.and_then(|br| {
+                multipliers
+                    .iter()
+                    .filter(|m| !taken_z.contains(&m.row))
+                    .filter_map(|m| br.iter().find(|b| b.row == m.row).map(|b| (m, b)))
+                    .filter(|(_, b)| !taken.contains(&b.var_row))
+                    .map(|(m, b)| (m, b, m.base + dx[m.row]))
+                    .filter(|&(_, _, v)| v < -eps)
+                    // most negative first
+                    .min_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal))
+                    .and_then(|(m, b, _)| {
+                        let i = b.var_row;
+                        let lower = b.lower;
+                        // The slack the bound carries at the base point.
+                        // Its reciprocal is the `sigma` this release
+                        // takes back off the x diagonal, so the tiny
+                        // number is only ever formed as `s / z`.
+                        let s = if lower {
+                            x_curr[i] - lo[i]
+                        } else {
+                            hi[i] - x_curr[i]
+                        };
+                        if !s.is_finite() || m.base == 0.0 {
+                            return None;
+                        }
+                        // Rank-1 downdate of `sigma = z / s` at row `i`,
+                        // which is what takes this bound back out of
+                        // the active set.
+                        //
+                        // The released x row also wants the multiplier
+                        // moved to the right-hand side. Most of that
+                        // shift is already carried by the parametric
+                        // right-hand side -- the barrier correction
+                        // leaves `-mu` on the multiplier's row, and the
+                        // elimination divides it by `s` -- but only most
+                        // of it, since `mu = s * z` holds at the base
+                        // point to the solve's tolerance and no better.
+                        // Taking the shift as zero on that identity
+                        // costs three orders of magnitude at a default
+                        // tolerance, so it is recovered exactly from the
+                        // step instead: the multiplier's own row gives
+                        // `r_z / s = sigma * dx_i + dz`, and what is
+                        // left is the multiplier the plain step
+                        // predicts, scaled by `s / z`.
+                        // The x row carries a lower bound's multiplier
+                        // with the opposite sign to an upper one, so
+                        // the shift is antisymmetric between the two
+                        // sides even though `sigma` is not.
+                        let shift = (s / m.base) * (m.base + dx_plain[m.row]);
+                        Some(Cond {
+                            x_row: i,
+                            rhs: if lower { -shift } else { shift },
+                            diag: s / m.base,
+                            report_row: m.row,
+                            release: Some((m.row, m.base)),
+                        })
+                    })
+            }),
         };
-        let Some((row, rhs_row)) = next else { break };
-        pins.push((row, rhs_row));
+        let Some(cond) = next else { break };
+        conds.push(cond);
 
-        let rows: Vec<Index> = pins.iter().map(|&(r, _)| r as Index).collect();
+        let rows: Vec<Index> = conds.iter().map(|c| c.x_row as Index).collect();
         let signs = vec![1; rows.len()];
         let mk = |r: Vec<Index>| {
             IndexSchurData::from_parts(r, signs.clone()).map_err(|e| format!("{e:?}"))
@@ -365,17 +435,18 @@ where
             ..SensOptions::default()
         };
         let mut pin_app = SensApplication::new(mk(rows.clone())?, backsolver.clone(), opts);
-        let rhs: Vec<Number> = pins.iter().map(|&(_, r)| r).collect();
+        let rhs: Vec<Number> = conds.iter().map(|c| c.rhs).collect();
+        let diag: Vec<Number> = conds.iter().map(|c| c.diag).collect();
         let mut du = vec![0.0; rows.len()];
         let mut corr = vec![0.0; n_full];
-        if !pin_app.run_sens_step(&mk(rows)?, &rhs, &mut du, &mut corr) {
+        if !pin_app.run_sens_step_with_diag(&mk(rows)?, &rhs, &diag, &mut du, &mut corr) {
             // An exactly singular augmented system, where the
             // near-singular case is what the achievement check below
             // catches. Drop the condition that could not be solved and
             // stop, rather than discarding the refinement and the plain
             // step with it: the caller is told how far it got by the
             // rows returned, which is what every other stop does.
-            pins.pop();
+            conds.pop();
             break;
         }
 
@@ -383,17 +454,43 @@ where
         // have exhausted the degrees of freedom and a dense LU returns a
         // solution around 1e15 rather than reporting it. It is not an
         // accuracy check: a healthy pass lands within a few parts per
-        // million, so demanding more than that rejects working pins.
-        let achieved = pins
-            .iter()
-            .all(|&(r, want)| (corr[r] + want).abs() <= 1e-3 * want.abs().max(1.0));
+        // million, so demanding more than that rejects working ones.
+        //
+        // A pin is checked on the displacement it asked for. A release
+        // is checked on what it was actually for -- the multiplier
+        // reaching zero -- since its own row carries the bordered
+        // system's diagonal and so does not simply return `-rhs`.
+        let achieved = conds.iter().enumerate().all(|(k, c)| match c.release {
+            None => (corr[c.x_row] + c.rhs).abs() <= 1e-3 * c.rhs.abs().max(1.0),
+            // A release carries the bordered system's diagonal, so its
+            // row does not simply return `-rhs`. What it does hold is
+            // that row itself, `x_i = -D * u`, and a singular solve
+            // breaks it by orders of magnitude. Compared on magnitude
+            // so the check does not depend on the driver's sign
+            // convention for `u`.
+            Some(_) => {
+                let vi = dx_plain[c.x_row] + corr[c.x_row];
+                let pred = (c.diag * du[k]).abs();
+                vi.is_finite() && (vi.abs() - pred).abs() <= 1e-3 * vi.abs().max(1.0)
+            }
+        });
         if !achieved {
-            pins.pop();
+            conds.pop();
             break;
         }
         for (k, d) in dx.iter_mut().enumerate() {
             *d = dx_plain[k] + corr[k];
         }
+        // The released bound's own row still carries the value the
+        // retained complementarity row produced, which is a by-product
+        // of the downdate and not the released multiplier. The released
+        // multiplier is zero by construction, so write the step that
+        // says so rather than leaving `z / s` noise in the block.
+        for c in &conds {
+            if let Some((z_row, base)) = c.release {
+                dx[z_row] = -base;
+            }
+        }
     }
-    Ok((dx, pins.into_iter().map(|(r, _)| r).collect()))
+    Ok((dx, conds.into_iter().map(|c| c.report_row).collect()))
 }

--- a/crates/pounce-sensitivity/src/convenience.rs
+++ b/crates/pounce-sensitivity/src/convenience.rs
@@ -446,6 +446,12 @@ impl SensSolve {
 
             if let Some(d) = &deltas {
                 let mut dx_full = vec![0.0; n_full];
+                let mut rhs_plain = vec![0.0; n_full];
+                if !sens_app.parametric_rhs(d, &mut rhs_plain) {
+                    outbox_cb.borrow_mut().error =
+                        Some("SensApplication::parametric_rhs failed".into());
+                    return;
+                }
                 if !sens_app.parametric_step(d, &mut dx_full) {
                     outbox_cb.borrow_mut().error =
                         Some("SensApplication::parametric_step failed".into());
@@ -463,6 +469,12 @@ impl SensSolve {
                     let mut rhs = vec![0.0; n_full];
                     for r in rhs.iter_mut().take(end).skip(start) {
                         *r = mu;
+                    }
+                    // the same term on the right-hand side a release
+                    // re-solves against, since the step carries it as a
+                    // correction to the solution instead
+                    for r in rhs_plain.iter_mut().take(end).skip(start) {
+                        *r += mu * crate::solver::BARRIER_SIGN;
                     }
                     let mut bc = vec![0.0; n_full];
                     if !backsolver_for_refine.solve(&rhs, &mut bc) {
@@ -531,6 +543,7 @@ impl SensSolve {
                         &lo,
                         &hi,
                         &mults,
+                        &rhs_plain,
                         eps,
                         16,
                     ) {

--- a/crates/pounce-sensitivity/src/schur_driver.rs
+++ b/crates/pounce-sensitivity/src/schur_driver.rs
@@ -44,32 +44,6 @@ pub trait SchurDriver {
     /// any backend failure (PCalculator solve, factor singular, …).
     fn schur_build_and_factor(&mut self, b: &dyn crate::SchurData) -> bool;
 
-    /// [`Self::schur_build_and_factor`] with a diagonal `d` added to
-    /// the Schur complement, i.e. factoring `S + diag(d)` rather than
-    /// `S`. `d` is empty or all-zero for the plain case.
-    ///
-    /// This is the `(2,2)` block of the bordered system
-    ///
-    /// ```text
-    /// [ K   E ] [ corr ]   [ 0     ]
-    /// [ Eᵀ  D ] [ du   ] = [ rhs_u ]
-    /// ```
-    ///
-    /// which is an exact condition on the selected row when `D = 0`
-    /// and a rank-1 downdate of `1/D` off `K` at that row otherwise.
-    /// [`crate::boundcheck::refine_step_onto_bounds`] uses the second
-    /// form to release a bound without ever asking `K⁻¹` for a
-    /// multiplier row.
-    ///
-    /// The default implementation refuses a non-zero `d`, so a driver
-    /// that has not opted in cannot silently drop it.
-    fn schur_build_and_factor_with_diag(&mut self, b: &dyn crate::SchurData, d: &[Number]) -> bool {
-        if d.iter().any(|&v| v != 0.0) {
-            return false;
-        }
-        self.schur_build_and_factor(b)
-    }
-
     /// Solve `S x = rhs` against the factored Schur complement.
     /// `rhs` and `x` are both of length `n_b` (the row count of the
     /// `B` matrix used at build time). Returns `false` if the driver
@@ -124,10 +98,6 @@ impl<P: PCalculator, B: SensBacksolver> DenseGenSchurDriver<P, B> {
 
 impl<P: PCalculator, B: SensBacksolver> SchurDriver for DenseGenSchurDriver<P, B> {
     fn schur_build_and_factor(&mut self, b: &dyn crate::SchurData) -> bool {
-        self.schur_build_and_factor_with_diag(b, &[])
-    }
-
-    fn schur_build_and_factor_with_diag(&mut self, b: &dyn crate::SchurData, d: &[Number]) -> bool {
         let n_b = b.nrows() as usize;
         let n_a = self.pcalc.data_a().nrows() as usize;
         if n_b != n_a {
@@ -149,16 +119,6 @@ impl<P: PCalculator, B: SensBacksolver> SchurDriver for DenseGenSchurDriver<P, B
         for i in 0..n_b {
             for j in 0..n_a {
                 s_row_major[i * n_a + j] = s_col_major[j * n_b + i];
-            }
-        }
-        // The bordered system's (2,2) block. Added after the transpose
-        // so it lands on the diagonal of the matrix actually factored.
-        if !d.is_empty() {
-            if d.len() != n_b {
-                return false;
-            }
-            for (i, &di) in d.iter().enumerate() {
-                s_row_major[i * n_a + i] += di;
             }
         }
         match DenseLuBacksolver::from_dense(n_b, &s_row_major) {

--- a/crates/pounce-sensitivity/src/schur_driver.rs
+++ b/crates/pounce-sensitivity/src/schur_driver.rs
@@ -44,6 +44,32 @@ pub trait SchurDriver {
     /// any backend failure (PCalculator solve, factor singular, …).
     fn schur_build_and_factor(&mut self, b: &dyn crate::SchurData) -> bool;
 
+    /// [`Self::schur_build_and_factor`] with a diagonal `d` added to
+    /// the Schur complement, i.e. factoring `S + diag(d)` rather than
+    /// `S`. `d` is empty or all-zero for the plain case.
+    ///
+    /// This is the `(2,2)` block of the bordered system
+    ///
+    /// ```text
+    /// [ K   E ] [ corr ]   [ 0     ]
+    /// [ Eᵀ  D ] [ du   ] = [ rhs_u ]
+    /// ```
+    ///
+    /// which is an exact condition on the selected row when `D = 0`
+    /// and a rank-1 downdate of `1/D` off `K` at that row otherwise.
+    /// [`crate::boundcheck::refine_step_onto_bounds`] uses the second
+    /// form to release a bound without ever asking `K⁻¹` for a
+    /// multiplier row.
+    ///
+    /// The default implementation refuses a non-zero `d`, so a driver
+    /// that has not opted in cannot silently drop it.
+    fn schur_build_and_factor_with_diag(&mut self, b: &dyn crate::SchurData, d: &[Number]) -> bool {
+        if d.iter().any(|&v| v != 0.0) {
+            return false;
+        }
+        self.schur_build_and_factor(b)
+    }
+
     /// Solve `S x = rhs` against the factored Schur complement.
     /// `rhs` and `x` are both of length `n_b` (the row count of the
     /// `B` matrix used at build time). Returns `false` if the driver
@@ -98,6 +124,10 @@ impl<P: PCalculator, B: SensBacksolver> DenseGenSchurDriver<P, B> {
 
 impl<P: PCalculator, B: SensBacksolver> SchurDriver for DenseGenSchurDriver<P, B> {
     fn schur_build_and_factor(&mut self, b: &dyn crate::SchurData) -> bool {
+        self.schur_build_and_factor_with_diag(b, &[])
+    }
+
+    fn schur_build_and_factor_with_diag(&mut self, b: &dyn crate::SchurData, d: &[Number]) -> bool {
         let n_b = b.nrows() as usize;
         let n_a = self.pcalc.data_a().nrows() as usize;
         if n_b != n_a {
@@ -119,6 +149,16 @@ impl<P: PCalculator, B: SensBacksolver> SchurDriver for DenseGenSchurDriver<P, B
         for i in 0..n_b {
             for j in 0..n_a {
                 s_row_major[i * n_a + j] = s_col_major[j * n_b + i];
+            }
+        }
+        // The bordered system's (2,2) block. Added after the transpose
+        // so it lands on the diagonal of the matrix actually factored.
+        if !d.is_empty() {
+            if d.len() != n_b {
+                return false;
+            }
+            for (i, &di) in d.iter().enumerate() {
+                s_row_major[i * n_a + i] += di;
             }
         }
         match DenseLuBacksolver::from_dense(n_b, &s_row_major) {

--- a/crates/pounce-sensitivity/src/sens_app.rs
+++ b/crates/pounce-sensitivity/src/sens_app.rs
@@ -208,6 +208,18 @@ impl<B: SensBacksolver> SensApplication<B> {
     /// the Schur factor's only role in sIPOPT's std flow is the
     /// active-set bound-check refinement after a violating step, and
     /// that refinement is a follow-up (sens_boundcheck = yes).
+    /// The right-hand side [`Self::parametric_step`] solves against,
+    /// without solving it. A release re-solves in a system the
+    /// converged factor does not describe, so it needs the right-hand
+    /// side rather than the step.
+    pub fn parametric_rhs(&self, delta_p: &[Number], out: &mut [Number]) -> bool {
+        if out.len() != self.backsolver.dim() || delta_p.len() != self.a_data.nrows() as usize {
+            return false;
+        }
+        out.iter_mut().for_each(|v| *v = 0.0);
+        self.a_data.trans_multiply(delta_p, out).is_ok()
+    }
+
     pub fn parametric_step(&self, delta_p: &[Number], dx_full: &mut [Number]) -> bool {
         let n_full = self.backsolver.dim();
         if dx_full.len() != n_full {

--- a/crates/pounce-sensitivity/src/sens_app.rs
+++ b/crates/pounce-sensitivity/src/sens_app.rs
@@ -184,28 +184,10 @@ impl<B: SensBacksolver> SensApplication<B> {
     where
         B: Clone,
     {
-        self.run_sens_step_with_diag(b_data, rhs_u, &[], du, dx_full)
-    }
-
-    /// [`Self::run_sens_step`] against the bordered system carrying
-    /// `diag` as its `(2,2)` block -- see
-    /// [`SchurDriver::schur_build_and_factor_with_diag`]. An empty or
-    /// all-zero `diag` is exactly [`Self::run_sens_step`].
-    pub fn run_sens_step_with_diag(
-        &mut self,
-        b_data: &IndexSchurData,
-        rhs_u: &[Number],
-        diag: &[Number],
-        du: &mut [Number],
-        dx_full: &mut [Number],
-    ) -> bool
-    where
-        B: Clone,
-    {
         let backsolver = self.backsolver.clone();
         let pcalc = IndexPCalculator::new(backsolver, self.a_data.clone());
         let mut driver = DenseGenSchurDriver::<_, B>::new(pcalc);
-        if !driver.schur_build_and_factor_with_diag(b_data, diag) {
+        if !driver.schur_build_and_factor(b_data) {
             return false;
         }
         let step = StdStepCalc::new(&driver, driver.pcalc());

--- a/crates/pounce-sensitivity/src/sens_app.rs
+++ b/crates/pounce-sensitivity/src/sens_app.rs
@@ -184,10 +184,28 @@ impl<B: SensBacksolver> SensApplication<B> {
     where
         B: Clone,
     {
+        self.run_sens_step_with_diag(b_data, rhs_u, &[], du, dx_full)
+    }
+
+    /// [`Self::run_sens_step`] against the bordered system carrying
+    /// `diag` as its `(2,2)` block -- see
+    /// [`SchurDriver::schur_build_and_factor_with_diag`]. An empty or
+    /// all-zero `diag` is exactly [`Self::run_sens_step`].
+    pub fn run_sens_step_with_diag(
+        &mut self,
+        b_data: &IndexSchurData,
+        rhs_u: &[Number],
+        diag: &[Number],
+        du: &mut [Number],
+        dx_full: &mut [Number],
+    ) -> bool
+    where
+        B: Clone,
+    {
         let backsolver = self.backsolver.clone();
         let pcalc = IndexPCalculator::new(backsolver, self.a_data.clone());
         let mut driver = DenseGenSchurDriver::<_, B>::new(pcalc);
-        if !driver.schur_build_and_factor(b_data) {
+        if !driver.schur_build_and_factor_with_diag(b_data, diag) {
             return false;
         }
         let step = StdStepCalc::new(&driver, driver.pcalc());

--- a/crates/pounce-sensitivity/src/solver.rs
+++ b/crates/pounce-sensitivity/src/solver.rs
@@ -64,7 +64,7 @@ use crate::vec_util::dense_to_vec;
 
 /// Sign of the barrier correction term, set from a comparison
 /// against sIPOPT rather than derived.
-const BARRIER_SIGN: Number = -1.0;
+pub const BARRIER_SIGN: Number = -1.0;
 
 /// Errors returned by post-convergence operations on [`Solver`].
 #[derive(Debug, Clone)]
@@ -526,6 +526,56 @@ impl Solver {
         // so the two agree on their shared block.
     }
 
+    /// The right-hand side [`Self::parametric_step_full`] answers,
+    /// barrier term included. That method adds the term as a correction
+    /// to the solution rather than to the right-hand side, which is the
+    /// same thing by linearity.
+    ///
+    /// The parameter rows go through `map_pin_g_to_kkt_rows` exactly as
+    /// they do there. Passing the constraint indices raw instead puts
+    /// the perturbation on the x rows, where it contributes nothing --
+    /// a release then sees only its own multiplier shift and lands on
+    /// the wrong answer without failing.
+    fn parametric_rhs_full(
+        &self,
+        pin_constraint_indices: &[Index],
+        deltas: &[Number],
+    ) -> Result<Vec<Number>, SolverError> {
+        let state = self.converged().ok_or(SolverError::NotConverged)?;
+        let state = &*state;
+        let dims = state.backsolver.block_dims();
+        let n_full = state.backsolver.dim();
+        let param_rows = state
+            .backsolver
+            .map_pin_g_to_kkt_rows(pin_constraint_indices)
+            .map_err(SolverError::SensComputationFailed)?;
+        let signs = vec![1; pin_constraint_indices.len()];
+        let a_data = IndexSchurData::from_parts(param_rows, signs)
+            .map_err(|e| SolverError::SensComputationFailed(format!("{e:?}")))?;
+        let opts = SensOptions {
+            run_sens: true,
+            ..SensOptions::default()
+        };
+        let sens_app = SensApplication::new(a_data, state.backsolver.clone(), opts);
+        let mut rhs = vec![0.0; n_full];
+        if !sens_app.parametric_rhs(deltas, &mut rhs) {
+            return Err(SolverError::SensComputationFailed(
+                "SensApplication::parametric_rhs failed".into(),
+            ));
+        }
+        let mu = {
+            let (data, _, _) = state.backsolver.activity_handles();
+            let d = data.borrow();
+            d.curr_mu
+        };
+        let start = dims[0] + dims[1] + dims[2] + dims[3];
+        let end = start + dims[4] + dims[5] + dims[6] + dims[7];
+        for r in rhs.iter_mut().take(end).skip(start) {
+            *r += mu * BARRIER_SIGN;
+        }
+        Ok(rhs)
+    }
+
     /// The barrier correction of the parametric step: the paper's
     /// equation 11 term, which carries the step from the solution of
     /// the barrier problem at `mu > 0` toward the one at `mu = 0`.
@@ -606,6 +656,7 @@ impl Solver {
         max_passes: usize,
     ) -> Result<(Vec<Number>, Vec<Index>), SolverError> {
         let dx_full = self.parametric_step_full(pin_constraint_indices, deltas)?;
+        let rhs_plain = self.parametric_rhs_full(pin_constraint_indices, deltas)?;
         let state = self.state.borrow();
         let state = state.as_ref().ok_or(SolverError::NotConverged)?;
         let n_x = state.backsolver.block_dims()[0];
@@ -672,6 +723,7 @@ impl Solver {
             &lo,
             &hi,
             &mults,
+            &rhs_plain,
             eps,
             max_passes,
         )

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -185,13 +185,25 @@ uncorrected step differs by 9e-6 at `tol = 1e-3` and by 2e-9 at
 `tol = 1e-8`. There is no option for it, since there is no reason to
 want the barrier problem's answer.
 
-Each pass rebuilds the Schur complement over the conditions so far,
-so pass `k` costs one dense `k × k` solve and `k + 1` back-solves and
-the total grows quadratically. The default `max_passes` of 16 is 136
-back-solves. The factorization itself is never rebuilt, which is what
-keeps this cheaper than re-solving. `max_passes` bounds that work and
-is a budget rather than a safeguard: the refinement is only worth
-running while it stays cheaper than the re-solve it replaces.
+Each pass rebuilds the Schur complement over the pins so far, so pass
+`k` costs one dense `k × k` solve and `k + 1` back-solves and the total
+grows quadratically. The default `max_passes` of 16 is 136 back-solves.
+A pin never rebuilds the factorization, which is what keeps it cheaper
+than re-solving. `max_passes` bounds that work and is a budget rather
+than a safeguard: the refinement is only worth running while it stays
+cheaper than the re-solve it replaces.
+
+A **release** does re-factor, once per released set. It has to. An
+active bound contributes `sigma = z / s` to the KKT's `x` diagonal, and
+the tighter the solve the larger that term, so the released system's
+information is destroyed in the converged factor to about `eps · sigma`.
+Computing a release from the held factorization therefore gets *worse*
+the better the solve converged — at `tol = 1e-10` the released answer
+was off by 2e-4 while at a looser `1e-6` it was off by 7e-9. Dropping
+the bound's `sigma` and re-factoring removes the dependence entirely.
+One factorization still sits an order of magnitude under the twenty to
+a hundred a re-solve runs, and a step that releases nothing pays
+nothing.
 
 Two things stop it short of holding every bound. The pass budget, which
 a caller can raise. And the problem's degrees of freedom, which no

--- a/pyomo-pounce/tests/test_fix_relax.py
+++ b/pyomo-pounce/tests/test_fix_relax.py
@@ -245,7 +245,7 @@ def test_an_absent_bound_does_not_widen_the_tolerance():
     assert fix[m.y] == pytest.approx(2 * fix[m.x] + 1, abs=1e-6)
 
 
-def active_at_base(p=-1.0):
+def releasing(p=-1.0):
     """x wants to be negative, so its lower bound is active at the base
     point and carries a positive multiplier. A large enough upward
     perturbation should release it."""
@@ -256,6 +256,11 @@ def active_at_base(p=-1.0):
     m.link = pyo.Constraint(expr=m.y == 2 * m.x + 1)
     m.obj = pyo.Objective(expr=(m.x - m.p) ** 2 + 0.5 * (m.y - m.p) ** 2)
     declare_sens_param(m.p)
+    return m
+
+
+def active_at_base(p=-1.0):
+    m = releasing(p)
     pyo.SolverFactory("pounce").solve(m)
     return m
 
@@ -292,6 +297,47 @@ def test_a_release_is_not_triggered_when_the_bound_should_stay():
     fix = estimate(m, [(m.p, -3.0)], mode="fix_relax")
     assert fix[m.x] == pytest.approx(0.0, abs=1e-6)
     assert fix[m.y] == pytest.approx(1.0, abs=1e-6)
+
+
+def scaled_releasing(p=-1.0):
+    """The release model under a change of variables, with the two
+    factors far apart and on both sides of 1."""
+    m = releasing(p)
+    m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+    m.scaling_factor[m.x] = 1000.0
+    m.scaling_factor[m.y] = 0.001
+    return m
+
+
+def test_a_release_holds_under_user_scaling():
+    """The release right-hand side is a bound multiplier read off the
+    converged iterate, so it is in the solve's own coordinates, while
+    the step it joins is in the model's units. Handing over an
+    unconverted multiplier puts a scaled right-hand side into a Schur
+    complement whose other rows are natural, which moves every
+    coordinate of the answer rather than the released one.
+
+    The other release tests cannot catch this: with no scaling active
+    the conversion is the identity, so they pass whichever way round it
+    goes -- which is how the defect survived its first review. Here
+    `d` is 1000 on the released variable, so dropping the conversion
+    or inverting it misses by orders of magnitude rather than by a
+    tolerance.
+    """
+    m = scaled_releasing()
+    pyo.SolverFactory("pounce").solve(
+        m, options={"nlp_scaling_method": "user-scaling"})
+    assert pyo.value(m.x) == pytest.approx(0.0, abs=1e-6), "bound is active"
+
+    # the plain step still cannot leave the bound, scaled or not
+    lin = estimate(m, [(m.p, 3.0)])
+    assert lin[m.x] == pytest.approx(0.0, abs=1e-6)
+
+    # and releasing it reaches the same re-solve the unscaled model does
+    fix = estimate(m, [(m.p, 3.0)], mode="fix_relax")
+    assert fix[m.x] == pytest.approx(1.666667, abs=1e-5)
+    assert fix[m.y] == pytest.approx(4.333333, abs=1e-5)
+    assert fix[m.y] == pytest.approx(2 * fix[m.x] + 1, abs=1e-6)
 
 
 def nonlinear(p=1.0):

--- a/pyomo-pounce/tests/test_fix_relax.py
+++ b/pyomo-pounce/tests/test_fix_relax.py
@@ -290,6 +290,30 @@ def test_fix_relax_releases_a_bound_the_step_wants_to_leave():
     assert fix[m.y] == pytest.approx(2 * fix[m.x] + 1, abs=1e-6)
 
 
+def test_a_release_holds_at_a_tight_tolerance():
+    """A release is accurate in proportion to how well the solve
+    converged, not inversely.
+
+    The released system is not recoverable from the converged factor: an
+    active bound puts `sigma = z/s` on the x diagonal, and the tighter
+    the solve the larger that term, so a release computed from the held
+    factorization degrades as the slack shrinks. It used to obey
+    err * s ~ 1e-16 -- at this tolerance the answer was off by 2.2e-4,
+    while at a *looser* 1e-6 it was off by 7e-9. Re-factoring without
+    the bound's sigma is what removes the dependence.
+
+    The assertion is four orders tighter than the old error, and the
+    loose-tolerance tests cannot stand in for it: they pass either way.
+    """
+    m = releasing()
+    pyo.SolverFactory("pounce").solve(m, options={"tol": 1e-10})
+    assert pyo.value(m.x) == pytest.approx(0.0, abs=1e-6), "bound is active"
+
+    fix = estimate(m, [(m.p, 3.0)], mode="fix_relax")
+    assert fix[m.x] == pytest.approx(5 / 3, abs=1e-8)
+    assert fix[m.y] == pytest.approx(2 * fix[m.x] + 1, abs=1e-8)
+
+
 def test_a_release_is_not_triggered_when_the_bound_should_stay():
     """A perturbation that pushes further INTO the bound must not
     release it: the multiplier grows rather than going negative."""


### PR DESCRIPTION
Follow-up to #587. The release half of fix-relax shipped with a defect that gets worse the better the solve converges, and two unit/coverage gaps alongside it.

## Problem

`sens_boundcheck` / `estimate(mode="fix_relax")` could release a bound onto the wrong answer, silently, and **more badly the tighter the solve**. On the release model already in the suite (`y = 2x + 1`, `x` on its lower bound, exact answer `5/3`):

| `tol` | base slack `s` | before | after |
|---|---|---|---|
| 1e-6 | 1.5e-08 | 7.3e-09 | 8.1e-11 |
| 1e-8 *(default)* | 4.2e-10 | 2.4e-07 | 2.2e-12 |
| 1e-9 | 1.5e-11 | 1.6e-05 | 8.2e-14 |
| 1e-10 | 1.7e-12 | 2.2e-04 | **9.6e-15** |

Asking for `tol = 1e-10` instead of `1e-6` made the released coordinate ~30000× less accurate. `obj_scaling_factor` reaches the same defect by moving where the solve stops: flat at ~1.5e-10 across six decades after, against 8.7e-4 at `obj_scaling_factor = 1000` before.

Nothing caught it. The refinement's guard watches the condition it imposed — which a release does satisfy — while the error lands in the other coordinates.

## Cause

The error obeyed `err × s ≈ 1e-16` across four decades: machine epsilon over the base slack. A release conditioned the step on the multiplier's own row, so building the Schur complement asked `K⁻¹` for a `z` row. That recovery is `(r_z − z·Δx)/s`, and with a unit right-hand side the numerator is `1 − z·Δx` with `z·Δx` within `eps` of 1 — the digits cancel, then get divided by the slack.

This also explains why pins were unaffected: they constrain **x** rows, whose diagonal is the Hessian, not a slack. Measured, the pin path is flat at 1.4e-10 across every `obj_scaling_factor` tried.

## Fix

The released system is not recoverable from the converged factor. An active bound puts `sigma = z/s` on the `x` diagonal, and reaching the released system from there needs the difference of `1/sigma` and `eᵀK⁻¹e`, which agree to about `eps·sigma`. So it is now formed directly: drop the bound's `z/s` from `sigma_x` and re-factor, via a new `PdFullSpaceSolver::solve_with_sigma_x`. Dropping `sigma` gives the released matrix; the released right-hand side additionally wants the multiplier moved onto its variable's `x` row, which reaches the same place as the elimination's `r_z/s` without `s` appearing anywhere.

**Two approaches were tried and rejected first** — both are in the history with their measurements, so nobody repeats them:

- **Iterative refinement.** `PdFullSpaceSolver` has a refinement loop and the sensitivity path skips it, which looked like the whole answer. Forcing the refined path produced *identical numbers to the last digit*: refinement fixes backward error, this is forward error from cancellation.
- **Rank-1 downdate through the Schur complement** (ecf5527, reverted in 7851dbe). It removes the z-row cancellation and replaces it with another of the same order — `S = D − α` with `D = 1/sigma` and `α = eᵀK⁻¹e` agreeing to ~11 digits. Predicted `eps·D/(D−α)` vs measured: 5.3e-7/3.1e-7, 1.5e-5/1.1e-5, 1.3e-4/1.7e-4. Across the sweep it was a wash. Extended-precision `S` fails for the same reason: `α` is already wrong before any subtraction happens.

Also included, from reviewing #587: a test covering the release path's unit conversion under a change of variables (`4510c67`), which nothing exercised — with no scaling active that conversion is the identity, so the existing release tests passed whichever way round it went.

## Blast radius

Confined to the sensitivity path. `pounce-algorithm` gains one new entry point; `solve` delegates to it with no override, so its behaviour is unchanged by construction and the algorithm's own step computation never passes one. **No solver trajectory moves, so no corpus sweep applies.**

Pinning is unchanged. A step that releases no bound pays nothing — `solve_released` short-circuits on an empty set. A step that does release pays one factorization per released set, still an order of magnitude under the twenty to a hundred a re-solve runs.

## Tests

- `test_a_release_holds_at_a_tight_tolerance` — new, pins the defect. Solves at `tol = 1e-10` and asserts `abs=1e-8`. **Verified against the parent commit 4b2122e: it fails there, returning 1.6668887936521868 for 5/3.** The existing release tests cannot stand in for it — they run at a default tolerance where the old error was 2e-7 and an `abs=1e-5` assert passes either way.
- `test_a_release_holds_under_user_scaling` — new, pins the unit conversion. Verified fail-first against both defect forms by rebuilding each: inverted conversion returns 2.6667, dropped returns 2.6657, against 1.6667. In both runs every other test in the file passed, which is the coverage gap it closes.
- `test_a_release_and_a_pin_in_the_same_step` (existing) caught a real bug during this work: the multiplier shift belongs to the step's right-hand side alone, and the Schur complement is built from unit vectors carrying no multiplier. Hence the split between `solve_released` and `solve_released_step`.

**Not pinned:** the `obj_scaling_factor` route to the same defect has no test. It reaches the identical code path as the `tol` route — both by moving where the solve stops — so a test would be redundant with the one above rather than covering new ground. Noting it so the gap is a known one.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `sensitivity.md` said the factorization is never rebuilt, which is still true of a pin and no longer true of a release
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — 289 pyomo-pounce tests pass, along with every `pounce-sensitivity`, `pounce-cli` and `pounce-algorithm` suite
- [x] Every claim in this body and in the code comments is true of the code as it stands now

Two notes on that last box, since it is not boilerplate. Every number above was re-measured against the final diff, after `cargo fmt` last touched a file. And the CLI binary was rebuilt and restaged before the final run — the repo's build-identity ratchet had otherwise been skipping four correctness probes against a stale binary.

## One thing found and not fixed

`crates/pounce-cli/src/sens.rs` appears to build its step with no barrier correction, unlike `solver.rs` and `convenience.rs`. If that is real it is a fourth-surface inconsistency of the same kind as the `&[]` multiplier bug from the #587 review. Out of scope here and left alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWvXVdXLWR1rYJ1aQ2u6Eb)_