### PR TITLE
Build container images on releases only, and never in a fork

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,12 +34,18 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # On the release (workflow_run) trigger, only rebuild if the release
-    # actually succeeded; push/dispatch runs are unconditional. `deploy` needs
-    # `build`, so skipping here skips the deploy too.
+    # Two gates, both of which skip `deploy` as well (it `needs: build`).
+    #
+    # 1. Only the upstream repository can deploy this site — a fork has no
+    #    Pages environment set up for it, so `deploy` fails there. "Sync fork"
+    #    pushes to the fork's main and fires this workflow, which is how forks
+    #    ended up with a red X and an email per sync (gh#599).
+    # 2. On the release (workflow_run) trigger, only rebuild if the release
+    #    actually succeeded; push/dispatch runs are unconditional.
     if: >-
-      github.event_name != 'workflow_run' ||
-      github.event.workflow_run.conclusion == 'success'
+      github.repository == 'jkitchin/pounce' &&
+      (github.event_name != 'workflow_run' ||
+       github.event.workflow_run.conclusion == 'success')
     steps:
       # fetch-depth: 0 — the versioned build checks out each v* tag via
       # `git worktree`, so the full tag history must be present (the default

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -46,6 +46,10 @@ concurrency:
 jobs:
   publish-crates:
     name: publish to crates.io
+    # Only the upstream repository holds the crates.io token, and forks
+    # receive `v*` tags when they sync — without this a fork's sync is a
+    # failed publish run and an email (gh#599).
+    if: github.repository == 'jkitchin/pounce'
     runs-on: ubuntu-latest
     environment:
       name: crates-io

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -7,22 +7,32 @@
 #       pip-installs the published pounce-solver / pyomo-pounce wheels. This
 #       is what a user gets from `docker pull ghcr.io/<owner>/pounce`.
 #   docker/Dockerfile         -> :edge, :sha-<short>
-#       compiles the tree at that commit. For reproducing a bug on an
-#       unreleased fix; :edge always means "tip of main", never a release.
+#       compiles the tree at that commit. NO LONGER PUBLISHED AUTOMATICALLY
+#       (gh#599, see below) — built here only as a PR rot guard, or on demand
+#       via workflow_dispatch with variant=source, dry_run=false.
 #
 # Triggers:
-#   - push of a `v*` tag -> both images, linux/amd64 + linux/arm64. This is
-#     the same marker tag release-crates keys off, so cutting a release ships
-#     crates.io, PyPI, and the images together.
-#   - push to main -> the source image only, as :edge and :sha-<short>. The
-#     release image is unchanged between releases, so rebuilding it here
-#     would only churn the registry.
+#   - push of a `v*` tag -> the release image, linux/amd64 + linux/arm64.
+#     This is the same marker tag release-crates keys off, so cutting a
+#     release ships crates.io, PyPI, and the images together.
 #   - pull_request touching docker/** -> build both, push neither. A
 #     Dockerfile that no longer builds is the failure mode this guards; it
 #     is invisible until the next release otherwise.
 #   - workflow_dispatch -> manual run, DEFAULTS TO A DRY RUN (builds, pushes
 #     nothing). Set dry_run=false to publish. Use this to re-cut the release
-#     image if the PyPI wait below timed out on the tag push.
+#     image if the PyPI wait below timed out on the tag push, or to cut a
+#     one-off source image (variant=source) for a bug repro.
+#
+# NO `push: branches: [main]` (gh#599). It used to publish the source image
+# as :edge and :sha-<short> on every commit to main. Two costs, one benefit:
+# a multi-arch compile of the whole workspace on every merge, and — the
+# reason it is gone — a guaranteed failure in every fork. "Sync fork" pushes
+# to the fork's main, which fires this workflow there, where the ghcr push
+# has no package to write to; contributors got a red X and an email for a
+# workflow that was never theirs to run. The benefit it bought was an image
+# of an unreleased fix, which `make docker` builds locally in the same time
+# the download would take. The `github.repository` guard on `plan` below
+# closes the same hole for the `v*` tag, which forks also receive.
 #
 # ORDERING GOTCHA: the release image installs from PyPI, but a `v*` tag does
 # not itself publish to PyPI — `python-v*` does (release-pounce.yml). Push
@@ -44,7 +54,6 @@ name: release-docker
 on:
   push:
     tags: ["v*"]
-    branches: [main]
   pull_request:
     paths:
       - "docker/**"
@@ -85,6 +94,14 @@ jobs:
   # reads these outputs rather than re-deriving the same event logic.
   plan:
     name: plan
+    # Nothing here can succeed outside the upstream repository: the ghcr
+    # package is jkitchin/pounce's, and a fork's GITHUB_TOKEN cannot write to
+    # it. Forks receive tags along with commits, so `v*` fires there too —
+    # this is what keeps that from being a failed run and an email in someone
+    # else's inbox (gh#599). `pull_request` runs in the *base* repo's context,
+    # so contributor PRs still get the rot guard; a PR opened inside a fork
+    # against the fork's own main does not, which is the point.
+    if: github.repository == 'jkitchin/pounce'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.plan.outputs.version }}
@@ -162,11 +179,19 @@ jobs:
               fi
               ;;
             push)
-              if [ "$is_tag" = true ]; then
-                : # release: both images, both pushed
-              else
-                # main: :edge tracks the tip; the release image is unchanged.
-                build_release=false
+              # `v*` tags are the only push trigger left (gh#599). The source
+              # image is not published on a release: it would compile the same
+              # commit the wheels were built from, so :edge would be a slower
+              # second spelling of :latest rather than "an unreleased fix",
+              # which is the only thing it was ever for. It still builds on
+              # docker/** PRs so it cannot rot, and workflow_dispatch with
+              # variant=source can cut one on demand.
+              build_source=false
+              if [ "$is_tag" != true ]; then
+                # Unreachable given the trigger list; a `push` that is not a
+                # `v*` tag means someone widened `on:` without reading this.
+                echo "::error::release-docker fired on a non-tag push ($REF); refusing to publish." >&2
+                exit 1
               fi
               ;;
             workflow_dispatch)
@@ -390,8 +415,11 @@ jobs:
             # pre-1.0, a bare `0` would span breaking changes.
             tags+=("$VERSION" "${VERSION%.*}" "latest")
           else
-            # sha-<short> pins an exact commit for a bug report; edge floats
-            # with main. Never `latest` — that must mean "released".
+            # Reachable only from a manual variant=source run now (gh#599),
+            # so :edge means "the last commit someone cut a source image
+            # from", not "tip of main" — sha-<short> is the honest tag of the
+            # two and the one to quote in a bug report. Never `latest`; that
+            # must mean "released".
             tags+=("edge" "sha-${SHA:0:8}")
           fi
 

--- a/.github/workflows/release-pounce.yml
+++ b/.github/workflows/release-pounce.yml
@@ -37,6 +37,11 @@ jobs:
   # job is a no-op pass and the build proceeds.
   verify-version:
     name: verify tag matches manifest
+    # Gate the whole workflow on the upstream repository: only it can publish
+    # to PyPI, and forks receive `python-v*` tags when they sync. Every other
+    # job here reaches this one through `needs`, so skipping it skips them all
+    # (gh#599).
+    if: github.repository == 'jkitchin/pounce'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-pyomo-pounce.yml
+++ b/.github/workflows/release-pyomo-pounce.yml
@@ -34,6 +34,11 @@ jobs:
   # workflow_dispatch, which carries no release tag.
   verify-version:
     name: verify tag matches manifest
+    # Gate the whole workflow on the upstream repository: only it can publish
+    # to PyPI, and forks receive `pyomo-pounce-v*` tags when they sync. Every
+    # other job here reaches this one through `needs`, so skipping it skips
+    # them all (gh#599).
+    if: github.repository == 'jkitchin/pounce'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -482,6 +482,33 @@ the contrib `SolverFactory('pounce')` build the same session, because
 `Pounce.solve` sends a model carrying declarations down the same
 in-process route. The messages now name all three.
 
+### Fixed — publishing workflows no longer fail in forks (#599)
+
+Syncing a fork failed three checks — `Deploy docs` and both architectures
+of `release-docker`'s source-image build — every time, because both
+workflows fired on a push to `main` and neither can succeed anywhere but
+this repository: the fork has no Pages environment, and its `GITHUB_TOKEN`
+cannot write to `ghcr.io/jkitchin/pounce`. Contributors got a failed run
+and an email for work that was never theirs to publish.
+
+The container images are now cut from releases only. `release-docker.yml`
+has no `main` trigger at all: the source-built image was what that trigger
+published, as `:edge` and `:sha-<short>`, and it existed to hand out an
+image of an unreleased fix — which `make docker` builds locally in about
+the time the pull would take. The image itself is unchanged and still
+builds on every PR touching `docker/**`, so it cannot rot, and a manual
+run of the workflow (`variant=source`, `dry_run=false`) still publishes one
+when a bug report needs it. `:edge` and `:sha-*` already in the registry
+stay where they are and no longer move; `docs/src/docker.md` says so rather
+than promising a tag that tracks `main`.
+
+Tags reach forks too, so trigger changes alone would not have covered the
+`v*`, `python-v*` and `pyomo-pounce-v*` paths. All four publishing
+workflows and the docs deploy now gate their first job on
+`github.repository == 'jkitchin/pounce'`. Pull requests are unaffected —
+`pull_request` runs in the base repository's context, so a contributor's PR
+still gets the full CI and the Docker rot guard.
+
 ## [0.10.0] - 2026-08-11
 
 ### Fixed — an ill-scaled dense Hessian column no longer costs the solve its certificate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,25 @@ topological order. Run it before tagging.
    `pip install pounce-solver` does not require the crates.io publish — but the
    crates.io publish is still part of a complete release.
 
+## Container images build for stable releases only
+
+A fourth surface, `ghcr.io/jkitchin/pounce`, is **not** covered by the
+version guard above and ships **only on a `v*` tag** (gh#599).
+`.github/workflows/release-docker.yml` has no `main` trigger: the
+source-built image no longer goes out as `:edge` / `:sha-<short>` on every
+merge, so those tags sit frozen at whatever commit last published them and
+must not be read as "tip of `main`". `make docker` is how you get an image
+of an unreleased fix; a manual workflow run (`variant=source`,
+`dry_run=false`) publishes one if a bug report needs it.
+
+Every publishing workflow — the three registry releases, this one, and the
+docs deploy — gates its first job on `github.repository ==
+'jkitchin/pounce'`. Forks receive tags when they sync, and none of these can
+succeed there, so without the gate a contributor's fork sync is a failed run
+and an email. Keep the gate on the job every other job reaches through
+`needs`; `pull_request` runs in the base repo's context, so PR checks are
+unaffected.
+
 ## Trajectory changes need the fixture sweep
 
 A change that reroutes **which** correction the solver reaches for, or that

--- a/dev-notes/cargo-release.md
+++ b/dev-notes/cargo-release.md
@@ -184,9 +184,12 @@ version number, so they need their own attention.
   half-published, so re-run it from the Actions tab with `dry_run=false` once
   the wheels are live.
 - **What each tag means.** `v*` publishes `:X.Y.Z`, `:X.Y`, `:latest` from
-  the PyPI-based image. A push to `main` publishes `:edge` and
-  `:sha-<short>` from the source-built image. `:latest` therefore always
-  means "released", never "tip of main".
+  the PyPI-based image, and that is the whole of the automatic publishing.
+  The source-built image no longer goes out as `:edge` / `:sha-<short>` on
+  every push to `main` (gh#599) — those tags are frozen at whatever commit
+  last published them. Cut a fresh one from the Actions tab with
+  `variant=source`, `dry_run=false` if a bug report needs an image of an
+  unreleased commit; otherwise `make docker` builds it locally.
 - **After the release, check the base image pin.** `docker/Dockerfile.release`
   is pinned to Debian trixie because the wheels published through 0.9.0
   bundled a CLI needing glibc 2.39 (#452, fixed in #456). Once a release

--- a/docker/README.md
+++ b/docker/README.md
@@ -7,8 +7,15 @@ unchanged on the other. They differ only in where the solver comes from.
 
 | File | Solver comes from | Build time | Published as |
 |---|---|---|---|
-| `Dockerfile.release` | PyPI wheels, pinned to `X.Y.Z` | seconds | `:X.Y.Z`, `:X.Y`, `:latest` |
-| `Dockerfile` | compiled from the tree you hand it | minutes | `:edge`, `:sha-<short>` |
+| `Dockerfile.release` | PyPI wheels, pinned to `X.Y.Z` | seconds | `:X.Y.Z`, `:X.Y`, `:latest` on a `v*` tag |
+| `Dockerfile` | compiled from the tree you hand it | minutes | nothing automatic; `:edge`, `:sha-<short>` on a manual run |
+
+Only the release image publishes on its own (gh#599). The source image used
+to go out as `:edge` on every commit to `main`; that trigger is gone, so
+`:edge` in the registry is stale and `make docker` is how you get an image of
+an unreleased fix. It still builds on every PR that touches `docker/**`, so
+it cannot rot, and `release-docker.yml` → *Run workflow* with
+`variant=source`, `dry_run=false` cuts one on demand.
 
 User-facing documentation lives in [`docs/src/docker.md`](../docs/src/docker.md)
 — pull commands, Apptainer/Singularity usage, bind mounts. This file covers
@@ -95,9 +102,9 @@ work.
 
 ## Publishing
 
-`.github/workflows/release-docker.yml` pushes both images to
-`ghcr.io/jkitchin/pounce`. Read the header comment there for the trigger
-matrix; two points matter when cutting a release:
+`.github/workflows/release-docker.yml` pushes the release image to
+`ghcr.io/jkitchin/pounce` on a `v*` tag. Read the header comment there for
+the trigger matrix; two points matter when cutting a release:
 
 1. **Tag order.** The release image installs from PyPI, but the `v*` tag
    this workflow fires on does not publish to PyPI — `python-v*` does. Push

--- a/docs/src/docker.md
+++ b/docs/src/docker.md
@@ -18,11 +18,22 @@ docker run --rm ghcr.io/jkitchin/pounce:latest --version
 | `latest` | the newest release | you just want POUNCE |
 | `X.Y.Z` (e.g. `0.9.0`) | exactly that release, forever | reproducibility — papers, cluster job scripts, CI |
 | `X.Y` (e.g. `0.9`) | newest patch of that minor series | you want fixes but not feature changes |
-| `edge` | tip of `main`, compiled from source | testing an unreleased fix |
-| `sha-<short>` | one specific commit | reproducing a bug report against a known commit |
 
-Pin `X.Y.Z` for anything you intend to re-run months later. `latest` and
-`edge` both move under you.
+Pin `X.Y.Z` for anything you intend to re-run months later — `latest` and
+`X.Y` both move under you.
+
+Published images are cut from releases only. There are `edge` and
+`sha-<short>` tags in the registry from when every commit to `main` was
+built, but they are **frozen at whatever commit last published them** — do
+not read `edge` as "tip of `main`". To run an unreleased fix, build the
+image yourself from a checkout; it takes minutes and needs no Rust
+toolchain on your side beyond Docker:
+
+```sh
+git clone https://github.com/jkitchin/pounce && cd pounce
+make docker          # -> pounce:dev, compiled from the tree you checked out
+docker run --rm pounce:dev --version
+```
 
 ## Running solves
 


### PR DESCRIPTION
## Problem

Syncing a fork fails three checks, every time (gh#599):

| check | why it fails in a fork |
|---|---|
| `Deploy docs / build (push)` | the fork has no Pages environment to deploy to |
| `release-docker / build source (linux/amd64)` | the fork's `GITHUB_TOKEN` cannot write to `ghcr.io/jkitchin/pounce` |
| `release-docker / build source (linux/arm64)` | same |

Both workflows fired on a push to `main`, and "Sync fork" is a push to the
fork's `main`. Neither can succeed anywhere but this repository, so a
contributor gets a red X and a failure email for work that was never theirs
to publish.

## Cause

Two separate holes, and closing only the obvious one leaves the other open.

1. `release-docker.yml` carried `push: branches: [main]`, which published
   the source-built image as `:edge` / `:sha-<short>` on every merge.
   `docs.yml` carried the same `main` trigger. Both run in the fork.
2. Forks receive **tags** when they sync too, so `v*`, `python-v*` and
   `pyomo-pounce-v*` fire there as well — every registry publish, not just
   Docker. Dropping the `main` trigger does nothing about those.

## Fix

**Container images now ship on a `v*` tag and nowhere else.**
`release-docker.yml` loses its `main` trigger outright rather than gating
it. What that trigger bought was an image of an unreleased fix; `make
docker` builds exactly that from a checkout, in about the time the pull
would take. The source image is otherwise untouched: it still builds on
every PR touching `docker/**`, so it cannot rot unnoticed, and a manual run
with `variant=source, dry_run=false` still publishes one when a bug report
needs it. Publishing it on the release tag was the other option considered
and rejected — it would compile the same commit the wheels were built from,
making `:edge` a slower second spelling of `:latest`.

**Every publishing workflow gates on `github.repository ==
'jkitchin/pounce'`** — the three registry releases, `release-docker`, and
the docs deploy. Each gate sits on the job every other job in that workflow
reaches through `needs` (`plan`, `verify-version`, `publish-crates`,
`build`), so the whole run skips rather than half of it. `pull_request`
events run in the base repository's context, so `github.repository` is
`jkitchin/pounce` there and contributor PRs keep full CI and the Docker rot
guard; a PR opened inside a fork against the fork's own `main` does not,
which is the point.

The `push` branch of the build plan now fails loudly on a non-tag push
instead of publishing, since nothing but a `v*` tag should reach it —
cheap insurance against someone widening `on:` later.

## Blast radius

One user-visible consequence: `:edge` and `:sha-*` already in the registry
stop moving. They are frozen at whatever commit last published them and must
not be read as "tip of `main`". `docs/src/docker.md` drops both from the tag
table and says so, pointing at `make docker` instead of promising a tag that
tracks `main`. `docker/README.md`, `dev-notes/cargo-release.md` and
`CLAUDE.md` are updated to match.

Nothing changes for `:latest` / `:X.Y.Z` / `:X.Y`, for any of the three
registry publishes, or for CI on pull requests. No solver code is touched —
this is workflows and docs only, so there is no trajectory surface here and
no fixture sweep to run.

## Tests

Not pinnable by the test suite: GitHub only evaluates a workflow trigger by
firing it, and the fork failure needs a fork to reproduce. What was checked
instead:

- The build-plan shell was extracted and run against all five
  event/ref combinations, asserting the outputs:

  | event | ref | version | push | release | source |
  |---|---|---|---|---|---|
  | push | `refs/tags/v0.10.0` | 0.10.0 | true | true | false |
  | push | `refs/heads/main` | — | — | — | — (errors, as intended) |
  | workflow_dispatch | dry_run=true, both | 0.10.0 | false | true | true |
  | workflow_dispatch | dry_run=false, source | 0.10.0 | true | false | true |
  | pull_request | `refs/pull/N/merge` | newest on PyPI | false | true | true |

- All six workflow files parse, and `scripts/check-release-consistency.sh`
  is clean.

The `github.repository` gates themselves are one-line expressions whose only
failure mode is a typo in the repository name; that shows up as every
publish silently skipping on the next release tag, which is worth knowing
about when reading the next release run.

---

- [x] Tests fail on the parent commit for the stated reason — n/a, see above
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`docker.md`; no new page, no `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean — no Rust changed
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

Fixes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBMpFtrGcki6hZfU3uHbRf

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBMpFtrGcki6hZfU3uHbRf)_