### PR TITLE
Register and validate the cold-start initialization options (#604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ changes.
 
 ## [Unreleased]
 
+- **The cold-start initialization options are settable** (#604).
+  `bound_push`, `bound_frac`, `slack_bound_push`, `slack_bound_frac`,
+  `constr_mult_init_max`, `bound_mult_init_val`, `bound_mult_init_method`
+  and `least_square_init_primal` were read by the algorithm builder but
+  never registered, so every frontend rejected them at the *set* call
+  with `Unknown option "bound_push"` — the documentation described knobs
+  that no supported path could reach. This is the inverse of #551
+  (registered-but-unread), and the same class of silence.
+
+  They now register under upstream's `Initialization` category with
+  upstream's types, defaults and ranges. The registered defaults equal
+  the values the builder already hard-coded and the read sites still fire
+  only when a caller sets the key explicitly, so nothing moves unless you
+  ask it to: the fixture sweep is identical across all 57 models, status,
+  objective and iteration count.
+
+  Two of upstream's knobs name behaviour POUNCE does not have, and both
+  now say so instead of doing something else. `bound_mult_init_method=
+  mu-based` used to fall through to a third path — the NLP's own `y`
+  guess — that is neither documented mode; it is refused, as is
+  `least_square_init_duals=yes`. Both values still *parse*, so an
+  `ipopt.opt` written for Ipopt loads unchanged.
+
+  A registry invariant test now runs in CI in both directions: no option
+  is read without being registered, and no `Initialization` option is
+  registered without being either consumed or explicitly refused.
+
 - **A feasible NLP whose constraint rows sit at their own floating-point
   resolution is no longer refused a certificate — or convicted of local
   infeasibility** (#590). Reported against LyoPRONTO's pseudosteady-limit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,29 @@ changes.
   is read without being registered, and no `Initialization` option is
   registered without being either consumed or explicitly refused.
 
+- **The convex LP/QP knobs are registered core-side and refused where
+  they configure nothing** (#604). `qp_tau`, `qp_tau_max`, `qp_reg`,
+  `qp_infeas_tol`, `qp_hsde`, `qp_equilibrate` and `qp_crossover` were
+  registered by the `pounce` CLI at startup, onto the same registry the
+  core builds. Setting one from Python or the C interface therefore
+  failed with `Unknown option "qp_tau"` — naming an option that exists —
+  and adding any `qp_*` name to the core registry would have aborted the
+  CLI binary at startup with `OPTION_ALREADY_REGISTERED`, a hazard
+  documented in a comment and tested by nothing. #360 moved the
+  `sqp_qp_*` block out of the CLI for those two reasons; this is the
+  other half.
+
+  They now live beside `solver_selection` and `qp_presolve` in the core
+  registry, so every frontend parses them. Parsing is not honouring: only
+  the CLI classifies a `.nl` model and routes it to the convex engines,
+  so a library solve now **refuses** a non-default `qp_*` (including
+  `qp_presolve`, previously a documented silent no-op there) with a
+  message naming the surfaces that do honour it — `option_file_name`'s
+  treatment from #518, one feature over. Explicitly-set defaults still
+  pass, as everywhere else. CLI behaviour is unchanged, including the
+  fallback where a convex attempt hands the model to the NLP path having
+  genuinely used those values.
+
 - **A feasible NLP whose constraint rows sit at their own floating-point
   resolution is no longer refused a certificate — or convicted of local
   infeasibility** (#590). Reported against LyoPRONTO's pseudosteady-limit

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -771,8 +771,12 @@ impl IpoptApplication {
         // gh#518: same treatment for `option_file_name` on an entry point
         // that cannot resolve it. Separate from the table above because
         // the *feature* now exists — just not here.
+        // gh#604: same treatment one level down, for a registered *value*
+        // of an option pounce otherwise reads (`bound_mult_init_method=
+        // mu-based`).
         if let Some(msg) = self
             .unimplemented_option_refusal()
+            .or_else(|| self.unimplemented_option_value_refusal())
             .or_else(|| self.unhonored_option_file_name())
         {
             use pounce_common::journalist::JournalCategory;
@@ -1134,6 +1138,17 @@ impl IpoptApplication {
     /// `optimize_tnlp`. See [`crate::unimplemented_options`].
     pub fn unimplemented_option_refusal(&self) -> Option<String> {
         crate::unimplemented_options::refusal(&self.options, &self.reg_options)
+    }
+
+    /// The message for the first string option the caller set to a
+    /// registered *value* pounce does not implement, or `None`.
+    ///
+    /// Separate from [`Self::unimplemented_option_refusal`] because the
+    /// option itself is read and its other values work — it is one mode
+    /// that is missing, not the feature. See
+    /// [`crate::unimplemented_options::UNIMPLEMENTED_VALUES`].
+    pub fn unimplemented_option_value_refusal(&self) -> Option<String> {
+        crate::unimplemented_options::value_refusal(&self.options)
     }
 
     /// `option_file_name` set on a surface that never resolves it.

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -196,6 +196,14 @@ pub struct IpoptApplication {
     /// setting the option on a surface that cannot honor it is refused
     /// rather than dropped (gh#518).
     option_file_resolved: bool,
+    /// Whether this caller can route a model to the convex LP/QP/SOCP
+    /// engines — i.e. whether the `qp_*` knobs those engines read
+    /// configure anything here. Only the `pounce` CLI can (it owns the
+    /// `.nl` structure extraction that classifies a model), and it says
+    /// so via [`Self::set_convex_routing_available`]. The guard in
+    /// [`Self::unhonored_convex_option`] reads this, on the same
+    /// contract as `option_file_resolved` above (gh#604).
+    convex_routing_available: bool,
     /// Shared sink that the linear-solver backend writes a rolling
     /// [`LinearSolverSummary`] into after every factor. Reset at the
     /// top of every solve (so back-to-back `optimize_tnlp` calls don't
@@ -299,6 +307,7 @@ impl IpoptApplication {
             on_converged: None,
             record_iter_history: false,
             option_file_resolved: false,
+            convex_routing_available: false,
             linsol_summary_sink: Arc::new(Mutex::new(LinearSolverSummary::default())),
             sqp_warm_start: None,
             sqp_last_working_set: None,
@@ -774,10 +783,14 @@ impl IpoptApplication {
         // gh#604: same treatment one level down, for a registered *value*
         // of an option pounce otherwise reads (`bound_mult_init_method=
         // mu-based`).
+        // gh#604: and for a convex-engine knob on an entry point that
+        // cannot route to that engine — `option_file_name`'s case, one
+        // feature over.
         if let Some(msg) = self
             .unimplemented_option_refusal()
             .or_else(|| self.unimplemented_option_value_refusal())
             .or_else(|| self.unhonored_option_file_name())
+            .or_else(|| self.unhonored_convex_option())
         {
             use pounce_common::journalist::JournalCategory;
             eprintln!("{msg}");
@@ -1194,6 +1207,70 @@ impl IpoptApplication {
             )),
             _ => None,
         }
+    }
+
+    /// Declare that this caller can route a model to the convex LP/QP /
+    /// SOCP engines, so the `qp_*` knobs they read configure something.
+    ///
+    /// The `pounce` CLI calls this: it owns the `.nl` structure
+    /// extraction that classifies a model, which is the whole of what
+    /// `solver_selection`'s convex values need. No library frontend can
+    /// (see [`Self::unsupported_library_solver_selection`]), so the
+    /// default is `false` and [`Self::unhonored_convex_option`] refuses
+    /// the knobs there.
+    ///
+    /// Declaring it also covers the CLI's *fallback*: a convex attempt
+    /// that returns no verified point hands the model to
+    /// [`Self::optimize_tnlp`], and the `qp_*` values it was given
+    /// configured that attempt for real. Refusing them at the handoff
+    /// would fail a run that used them.
+    pub fn set_convex_routing_available(&mut self, available: bool) {
+        self.convex_routing_available = available;
+    }
+
+    /// The convex LP/QP knobs are registered core-side so every frontend
+    /// parses them — but only the CLI can reach the engines that read
+    /// them. On any other entry point the option names a whole
+    /// configuration and applies none of it; this is the message that
+    /// says so, in place of the silence.
+    ///
+    /// gh#604. Same shape and same default gate as
+    /// [`Self::unhonored_option_file_name`]: an explicitly-set *default*
+    /// asks for nothing and must keep working, so only a value that
+    /// differs is refused.
+    pub fn unhonored_convex_option(&self) -> Option<String> {
+        if self.convex_routing_available {
+            return None;
+        }
+        const CONVEX_ONLY: &[&str] = &[
+            "qp_presolve",
+            "qp_tau",
+            "qp_tau_max",
+            "qp_reg",
+            "qp_infeas_tol",
+            "qp_hsde",
+            "qp_equilibrate",
+            "qp_crossover",
+        ];
+        let name = CONVEX_ONLY.iter().find(|name| {
+            crate::unimplemented_options::set_to_a_non_default(
+                &self.options,
+                &self.reg_options,
+                name,
+            )
+        })?;
+        Some(format!(
+            "pounce: `{name}` tunes the convex LP/QP interior-point engine, but \
+             this entry point cannot route a model to it — the option would \
+             configure nothing. The `pounce` CLI reaches that engine on `.nl` \
+             input (`solver_selection=lp-ipm` / `qp-ipm` / `socp`, or `auto` on \
+             a model that classifies as one); from Python, `pounce.solve_qp` / \
+             `pounce.solve_cone` drive it directly and take the same knobs as \
+             typed arguments. On this path, `solver_selection=qp-active-set` \
+             (or `algorithm=active-set-sqp`) is the nearest thing, tuned by the \
+             `sqp_qp_*` options. Tracking issue: \
+             https://github.com/jkitchin/pounce/issues/604"
+        ))
     }
 
     /// Warnings for caching hints pounce does not exploit. These never

--- a/crates/pounce-algorithm/src/init/default.rs
+++ b/crates/pounce-algorithm/src/init/default.rs
@@ -12,19 +12,16 @@
 //!    [`DefaultIterateInitializer::push_to_interior`].
 //! 2. Set `s = d(x)` (evaluated through CQ on a transient iterate)
 //!    and push it into the interior of `[d_l, d_u]`.
-//! 3. Initialize `y_c`, `y_d`:
-//!    * `bound_mult_init_method == "constant"` — leave at zero (the
-//!      default y-targets that the linear-solver sweep will refine).
-//!    * `bound_mult_init_method == "least-square"` — call
-//!      [`crate::eq_mult::least_square::LeastSquareMults`] via the
-//!      provided `aug_solver`. **Phase 7 default is "constant"** to
-//!      avoid pulling the aug-system through this path on bring-up.
+//! 3. Initialize `y_c`, `y_d` to zero, then revise them with the
+//!    least-square estimate from
+//!    [`crate::eq_mult::least_square::LeastSquareMults`] when an
+//!    `EqMultCalculator` is wired and `constr_mult_init_max > 0`
+//!    (an estimate above that cap is discarded, per upstream).
 //! 4. Initialize `z_l`, `z_u`, `v_l`, `v_u` to `bound_mult_init_val`
-//!    (component-wise).
-//!
-//! The fully-loaded mu-based / least-square multiplier paths land
-//! once `LeastSquareMults` and the iterate-trace gold tests are
-//! online.
+//!    (component-wise) — i.e. `bound_mult_init_method = "constant"`,
+//!    the only mode pounce implements. `"mu-based"` is registered for
+//!    `ipopt.opt` compatibility and refused rather than silently
+//!    served as `"constant"` (gh#604).
 
 use crate::eq_mult::r#trait::EqMultCalculator;
 use crate::init::r#trait::IterateInitializer;
@@ -46,7 +43,10 @@ pub struct DefaultIterateInitializer {
     pub slack_bound_frac: Number,
     pub constr_mult_init_max: Number,
     pub bound_mult_init_val: Number,
-    /// "constant" / "mu-based" / "least-square".
+    /// `bound_mult_init_method`. Must be `"constant"` — upstream's
+    /// `"mu-based"` is registered for `ipopt.opt` compatibility but not
+    /// implemented, and `set_initial_iterates` returns `false` on it
+    /// rather than serving a third, undocumented behaviour (gh#604).
     pub bound_mult_init_method: String,
     /// Equality-multiplier calculator used by the
     /// `least_square_mults` step at the end of `set_initial_iterates`,
@@ -329,22 +329,36 @@ impl IterateInitializer for DefaultIterateInitializer {
             );
         }
 
+        // `bound_mult_init_method` — pounce implements `constant` only
+        // (gh#604). The refusal that a caller actually sees is raised at
+        // the application layer, before any work
+        // (`unimplemented_options::UNIMPLEMENTED_VALUES`); this is the
+        // backstop for a caller who builds the initializer directly.
+        //
+        // It used to fall through to `nlp.get_starting_y` here, which is
+        // neither of the documented modes — an unsupported value silently
+        // bought a *third* behaviour. Failing is the honest answer.
+        if !self.bound_mult_init_method.eq_ignore_ascii_case("constant") {
+            tracing::error!(
+                target: "pounce::algorithm",
+                method = %self.bound_mult_init_method,
+                "pounce: bound_mult_init_method must be \"constant\"; \
+                 \"mu-based\" is registered for ipopt.opt compatibility but \
+                 not implemented (gh#604)."
+            );
+            return false;
+        }
+
         // Step 3: y_c, y_d initial guesses. `constant` mode leaves
-        // them at zero (the algorithm refines on the first KKT solve).
+        // them at zero (the algorithm refines on the first KKT solve),
+        // and the least-square step below revises them when an
+        // `EqMultCalculator` is wired.
         let mut y_c = DenseVectorSpace::new(n_yc).make_new_dense();
         let mut y_d = DenseVectorSpace::new(n_yd).make_new_dense();
-        if self.bound_mult_init_method == "constant" {
-            // Materialize as homogeneous-zero so callers' asum / values
-            // probes don't trip the `initialized` debug-assert.
-            y_c.set(0.0);
-            y_d.set(0.0);
-        } else {
-            // Other modes (mu-based, least-square) require the
-            // aug-system path; fall back to NLP's own y-init for now.
-            nlp.borrow_mut().get_starting_y(&mut y_c, &mut y_d);
-            cap_constraint_multipliers(&mut y_c, self.constr_mult_init_max);
-            cap_constraint_multipliers(&mut y_d, self.constr_mult_init_max);
-        }
+        // Materialize as homogeneous-zero so callers' asum / values
+        // probes don't trip the `initialized` debug-assert.
+        y_c.set(0.0);
+        y_d.set(0.0);
 
         // Step 4: bound multipliers — constant init.
         let mut z_l = DenseVectorSpace::new(n_zl).make_new_dense();
@@ -510,18 +524,6 @@ fn expand_packed_into_dense(
     }
 }
 
-/// Clamp every component of `y` to `[-max, max]`. Mirrors the
-/// upstream `constr_mult_init_max` cap.
-fn cap_constraint_multipliers(y: &mut DenseVector, max: Number) {
-    for v in y.values_mut() {
-        if *v > max {
-            *v = max;
-        } else if *v < -max {
-            *v = -max;
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -585,5 +587,428 @@ mod tests {
         // x=0 → 0 + 1e-6 = 1e-6.
         let v = DefaultIterateInitializer::push_to_interior(1e-2, 1e-2, 0.0, Some(0.0), Some(1e-4));
         assert!((v - 1e-6).abs() < 1e-18);
+    }
+}
+
+/// Behavior tests for the cold-start options (gh#604).
+///
+/// The wiring tests in `tests/init_options_wiring.rs` prove each option
+/// reaches [`crate::alg_builder::InitOptions`]; these prove the value
+/// then changes the iterate the initializer produces. An option that is
+/// registered, read, threaded onto the strategy and then ignored is the
+/// same silent no-op with more steps.
+#[cfg(test)]
+mod option_behavior {
+    use super::*;
+    use crate::ipopt_cq::IpoptCalculatedQuantities;
+    use crate::ipopt_data::IpoptData;
+    use pounce_linalg::{IdentityMatrix, Matrix, SymMatrix};
+    use pounce_linsol::status::ESymSolverStatus;
+
+    const N_X: Index = 2;
+    const N_S: Index = 1;
+    const N_C: Index = 1;
+
+    /// `x0 = [0, 10]` sits on both bounds of `[0, 10]^2`, and
+    /// `d(x) = -5` sits on the lower inequality bound, so every push
+    /// knob has something visible to move.
+    struct StubNlp {
+        x_l: DenseVector,
+        x_u: DenseVector,
+        d_l: DenseVector,
+        d_u: DenseVector,
+        p2: Rc<dyn Matrix>,
+        p1: Rc<dyn Matrix>,
+    }
+
+    impl StubNlp {
+        fn new() -> Self {
+            let s2 = DenseVectorSpace::new(N_X);
+            let mut x_l = DenseVector::new(Rc::clone(&s2));
+            x_l.set_values(&[0.0, 0.0]);
+            let mut x_u = DenseVector::new(Rc::clone(&s2));
+            x_u.set_values(&[10.0, 10.0]);
+            let s1 = DenseVectorSpace::new(N_S);
+            let mut d_l = DenseVector::new(Rc::clone(&s1));
+            d_l.set_values(&[-5.0]);
+            let mut d_u = DenseVector::new(Rc::clone(&s1));
+            d_u.set_values(&[5.0]);
+            Self {
+                x_l,
+                x_u,
+                d_l,
+                d_u,
+                p2: Rc::new(IdentityMatrix::new(N_X)),
+                p1: Rc::new(IdentityMatrix::new(N_S)),
+            }
+        }
+    }
+
+    impl crate::ipopt_nlp::Nlp for StubNlp {
+        fn n(&self) -> Index {
+            N_X
+        }
+        fn m_eq(&self) -> Index {
+            N_C
+        }
+        fn m_ineq(&self) -> Index {
+            N_S
+        }
+        fn eval_f(&mut self, _x: &dyn Vector) -> Number {
+            0.0
+        }
+        fn eval_grad_f(&mut self, _x: &dyn Vector, g: &mut dyn Vector) {
+            g.set(0.0);
+        }
+        fn eval_c(&mut self, _x: &dyn Vector, c: &mut dyn Vector) {
+            c.set(1.0);
+        }
+        fn eval_d(&mut self, _x: &dyn Vector, d: &mut dyn Vector) {
+            d.set(-5.0);
+        }
+        fn eval_jac_c(&mut self, _x: &dyn Vector) -> Rc<dyn Matrix> {
+            Rc::new(IdentityMatrix::new(N_X))
+        }
+        fn eval_jac_d(&mut self, _x: &dyn Vector) -> Rc<dyn Matrix> {
+            Rc::new(IdentityMatrix::new(N_X))
+        }
+        fn eval_h(
+            &mut self,
+            _x: &dyn Vector,
+            _obj_factor: Number,
+            _y_c: &dyn Vector,
+            _y_d: &dyn Vector,
+        ) -> Rc<dyn SymMatrix> {
+            let s = pounce_linalg::DenseSymMatrixSpace::new(N_X);
+            Rc::new(pounce_linalg::DenseSymMatrix::new(s))
+        }
+    }
+
+    impl crate::ipopt_nlp::IpoptNlp for StubNlp {
+        fn x_l(&self) -> &dyn Vector {
+            &self.x_l
+        }
+        fn x_u(&self) -> &dyn Vector {
+            &self.x_u
+        }
+        fn d_l(&self) -> &dyn Vector {
+            &self.d_l
+        }
+        fn d_u(&self) -> &dyn Vector {
+            &self.d_u
+        }
+        fn px_l(&self) -> Rc<dyn Matrix> {
+            self.p2.clone()
+        }
+        fn px_u(&self) -> Rc<dyn Matrix> {
+            self.p2.clone()
+        }
+        fn pd_l(&self) -> Rc<dyn Matrix> {
+            self.p1.clone()
+        }
+        fn pd_u(&self) -> Rc<dyn Matrix> {
+            self.p1.clone()
+        }
+        fn get_starting_x(&mut self, x: &mut dyn Vector) -> bool {
+            let dense = x
+                .as_any_mut()
+                .downcast_mut::<DenseVector>()
+                .expect("dense x");
+            dense.set_values(&[0.0, 10.0]);
+            true
+        }
+    }
+
+    /// Fails every solve, so the least-square primal step is a no-op.
+    /// Nothing else in the tested paths touches the aug solver.
+    struct FailingAugSolver;
+    /// Returns a fixed `sol_x`, so `least_square_init_primal=yes` lands
+    /// on a point the bound push alone could never produce.
+    struct FixedAugSolver;
+
+    macro_rules! aug_solver_boilerplate {
+        () => {
+            fn provides_inertia(&self) -> bool {
+                false
+            }
+            fn number_of_neg_evals(&self) -> Index {
+                0
+            }
+            fn increase_quality(&mut self) -> bool {
+                false
+            }
+            fn last_solve_status(&self) -> ESymSolverStatus {
+                ESymSolverStatus::Success
+            }
+        };
+    }
+
+    impl AugSystemSolver for FailingAugSolver {
+        aug_solver_boilerplate!();
+        fn solve(
+            &mut self,
+            _coeffs: &AugSysCoeffs<'_>,
+            _rhs: &AugSysRhs<'_>,
+            _sol: &mut AugSysSol<'_>,
+            _check_neg_evals: bool,
+            _num_neg_evals: Index,
+        ) -> ESymSolverStatus {
+            ESymSolverStatus::Singular
+        }
+    }
+
+    impl AugSystemSolver for FixedAugSolver {
+        aug_solver_boilerplate!();
+        fn solve(
+            &mut self,
+            _coeffs: &AugSysCoeffs<'_>,
+            _rhs: &AugSysRhs<'_>,
+            sol: &mut AugSysSol<'_>,
+            _check_neg_evals: bool,
+            _num_neg_evals: Index,
+        ) -> ESymSolverStatus {
+            // The initializer negates this, so `x_ls = [1, 3]`.
+            sol.sol_x
+                .as_any_mut()
+                .downcast_mut::<DenseVector>()
+                .expect("dense sol_x")
+                .set_values(&[-1.0, -3.0]);
+            sol.sol_s.set(0.0);
+            sol.sol_c.set(0.0);
+            sol.sol_d.set(0.0);
+            ESymSolverStatus::Success
+        }
+    }
+
+    /// Hands back a fixed equality-multiplier estimate so the
+    /// `constr_mult_init_max` cap has something to accept or discard.
+    struct FixedEqMults(Number);
+    impl EqMultCalculator for FixedEqMults {
+        fn calculate_y_eq(
+            &mut self,
+            _data: &IpoptDataHandle,
+            _cq: &IpoptCqHandle,
+            _nlp: &Rc<RefCell<dyn IpoptNlp>>,
+            _aug_solver: &mut dyn AugSystemSolver,
+            y_c: &mut dyn Vector,
+            y_d: &mut dyn Vector,
+        ) -> bool {
+            y_c.set(self.0);
+            y_d.set(self.0);
+            true
+        }
+    }
+
+    fn zeros(n: Index) -> Rc<DenseVector> {
+        let mut v = DenseVectorSpace::new(n).make_new_dense();
+        v.set(0.0);
+        Rc::new(v)
+    }
+
+    /// A data/cq pair over [`StubNlp`] with a correctly-shaped `curr`
+    /// installed — the initializer reads the block dimensions off it.
+    fn fixture() -> (IpoptDataHandle, IpoptCqHandle, Rc<RefCell<dyn IpoptNlp>>) {
+        let nlp: Rc<RefCell<dyn IpoptNlp>> = Rc::new(RefCell::new(StubNlp::new()));
+        let data: IpoptDataHandle = Rc::new(RefCell::new(IpoptData::new()));
+        let cq: IpoptCqHandle = Rc::new(RefCell::new(IpoptCalculatedQuantities::new(
+            Rc::clone(&data),
+            Rc::clone(&nlp),
+        )));
+        let template = IteratesVector::new(
+            zeros(N_X),
+            zeros(N_S),
+            zeros(N_C),
+            zeros(N_S),
+            zeros(N_X),
+            zeros(N_X),
+            zeros(N_S),
+            zeros(N_S),
+        );
+        data.borrow_mut().set_curr(template);
+        (data, cq, nlp)
+    }
+
+    /// Run the initializer and return the installed `curr`.
+    fn run(init: &mut DefaultIterateInitializer, aug: &mut dyn AugSystemSolver) -> IteratesVector {
+        let (data, cq, nlp) = fixture();
+        assert!(
+            init.set_initial_iterates(&data, &cq, &nlp, aug),
+            "initializer should succeed"
+        );
+        data.borrow().curr.clone().expect("curr installed")
+    }
+
+    /// `expanded_values` rather than `values`: a block the initializer
+    /// filled with `set` stays in the homogeneous representation, which
+    /// `values` refuses to hand out.
+    fn values_of(v: &Rc<dyn Vector>) -> Vec<Number> {
+        v.as_any()
+            .downcast_ref::<DenseVector>()
+            .expect("dense")
+            .expanded_values()
+    }
+    fn x_of(iv: &IteratesVector) -> Vec<Number> {
+        values_of(&iv.x)
+    }
+
+    /// `bound_push` moves `x0` off its lower bound by
+    /// `min(bound_push * max(|lo|, 1), bound_frac * span)`.
+    #[test]
+    fn bound_push_changes_the_initial_primal() {
+        let mut aug = FailingAugSolver;
+
+        let mut d = DefaultIterateInitializer::new();
+        let base = x_of(&run(&mut d, &mut aug));
+        assert!((base[0] - 1e-2).abs() < 1e-15, "default: {base:?}");
+
+        let mut pushed = DefaultIterateInitializer {
+            bound_push: 5e-2,
+            ..DefaultIterateInitializer::new()
+        };
+        let moved = x_of(&run(&mut pushed, &mut aug));
+        assert!(
+            (moved[0] - 5e-2).abs() < 1e-15,
+            "bound_push=5e-2: {moved:?}"
+        );
+        assert_ne!(base[0], moved[0]);
+    }
+
+    /// `bound_frac` is the other arm of the same min, and it binds when
+    /// the interval is narrow relative to `bound_push`.
+    #[test]
+    fn bound_frac_changes_the_initial_primal() {
+        let mut aug = FailingAugSolver;
+        let mut init = DefaultIterateInitializer {
+            bound_frac: 5e-4,
+            ..DefaultIterateInitializer::new()
+        };
+        // span = 10, so the frac arm gives 5e-3 < bound_push's 1e-2.
+        let x = x_of(&run(&mut init, &mut aug));
+        assert!((x[0] - 5e-3).abs() < 1e-15, "bound_frac=5e-4: {x:?}");
+    }
+
+    /// The slack knobs do the same job for `s`, which starts on the
+    /// lower inequality bound `-5`.
+    #[test]
+    fn slack_bound_push_and_frac_change_the_initial_slack() {
+        let mut aug = FailingAugSolver;
+
+        let mut d = DefaultIterateInitializer::new();
+        // p_l = min(1e-2 * max(|-5|, 1), 1e-2 * 10) = 5e-2.
+        let base = values_of(&run(&mut d, &mut aug).s);
+        assert!((base[0] - -4.95).abs() < 1e-14, "default: {base:?}");
+
+        let mut pushed = DefaultIterateInitializer {
+            slack_bound_push: 1e-1,
+            ..DefaultIterateInitializer::new()
+        };
+        // p_l = min(1e-1 * 5, 1e-2 * 10) = 1e-1 — the frac arm still binds.
+        let s = values_of(&run(&mut pushed, &mut aug).s);
+        assert!((s[0] - -4.9).abs() < 1e-14, "slack_bound_push=1e-1: {s:?}");
+
+        let mut fracced = DefaultIterateInitializer {
+            slack_bound_frac: 1e-3,
+            ..DefaultIterateInitializer::new()
+        };
+        // p_l = min(1e-2 * 5, 1e-3 * 10) = 1e-2.
+        let s = values_of(&run(&mut fracced, &mut aug).s);
+        assert!((s[0] - -4.99).abs() < 1e-14, "slack_bound_frac=1e-3: {s:?}");
+    }
+
+    /// `bound_mult_init_val` is the value every bound multiplier takes.
+    #[test]
+    fn bound_mult_init_val_changes_the_bound_multipliers() {
+        let mut aug = FailingAugSolver;
+
+        let base = run(&mut DefaultIterateInitializer::new(), &mut aug);
+        assert_eq!(values_of(&base.z_l), vec![1.0, 1.0]);
+        assert_eq!(values_of(&base.v_u), vec![1.0]);
+
+        let mut init = DefaultIterateInitializer {
+            bound_mult_init_val: 7.5,
+            ..DefaultIterateInitializer::new()
+        };
+        let iv = run(&mut init, &mut aug);
+        assert_eq!(values_of(&iv.z_l), vec![7.5, 7.5]);
+        assert_eq!(values_of(&iv.z_u), vec![7.5, 7.5]);
+        assert_eq!(values_of(&iv.v_l), vec![7.5]);
+        assert_eq!(values_of(&iv.v_u), vec![7.5]);
+    }
+
+    /// `constr_mult_init_max` caps the least-square equality-multiplier
+    /// estimate: above the cap upstream discards it and leaves zeros.
+    #[test]
+    fn constr_mult_init_max_gates_the_equality_multipliers() {
+        let mut aug = FailingAugSolver;
+
+        let mut accepted = DefaultIterateInitializer {
+            constr_mult_init_max: 1e3,
+            ..DefaultIterateInitializer::with_eq_mult_calculator(Box::new(FixedEqMults(2.0)))
+        };
+        assert_eq!(values_of(&run(&mut accepted, &mut aug).y_c), vec![2.0]);
+
+        let mut capped = DefaultIterateInitializer {
+            constr_mult_init_max: 1.0,
+            ..DefaultIterateInitializer::with_eq_mult_calculator(Box::new(FixedEqMults(2.0)))
+        };
+        assert_eq!(
+            values_of(&run(&mut capped, &mut aug).y_c),
+            vec![0.0],
+            "an estimate above the cap is discarded, not clamped"
+        );
+
+        // 0 switches the least-square step off entirely.
+        let mut off = DefaultIterateInitializer {
+            constr_mult_init_max: 0.0,
+            ..DefaultIterateInitializer::with_eq_mult_calculator(Box::new(FixedEqMults(2.0)))
+        };
+        assert_eq!(values_of(&run(&mut off, &mut aug).y_c), vec![0.0]);
+    }
+
+    /// `least_square_init_primal=yes` replaces the user's `x0` with the
+    /// solution of the linearized-constraint system.
+    #[test]
+    fn least_square_init_primal_replaces_the_starting_point() {
+        let mut fixed = FixedAugSolver;
+
+        let mut off = DefaultIterateInitializer::new();
+        let base = x_of(&run(&mut off, &mut fixed));
+        assert!((base[0] - 1e-2).abs() < 1e-15, "user x0, pushed: {base:?}");
+
+        let mut on = DefaultIterateInitializer {
+            least_square_init_primal: true,
+            ..DefaultIterateInitializer::new()
+        };
+        let ls = x_of(&run(&mut on, &mut fixed));
+        assert_eq!(
+            ls,
+            vec![1.0, 3.0],
+            "the least-square point, already interior"
+        );
+    }
+
+    /// The one mode pounce implements runs; anything else fails rather
+    /// than quietly running a third behaviour (gh#604). The refusal a
+    /// caller actually sees is raised earlier, at the application layer.
+    #[test]
+    fn an_unsupported_bound_mult_init_method_fails_instead_of_falling_back() {
+        let (data, cq, nlp) = fixture();
+        let mut aug = FailingAugSolver;
+        let mut init = DefaultIterateInitializer {
+            bound_mult_init_method: "mu-based".into(),
+            ..DefaultIterateInitializer::new()
+        };
+        assert!(
+            !init.set_initial_iterates(&data, &cq, &nlp, &mut aug),
+            "`mu-based` is not implemented and must not be served as `constant`"
+        );
+
+        // Spelling is the only thing that varies — case does not.
+        let (data, cq, nlp) = fixture();
+        let mut cased = DefaultIterateInitializer {
+            bound_mult_init_method: "CONSTANT".into(),
+            ..DefaultIterateInitializer::new()
+        };
+        assert!(cased.set_initial_iterates(&data, &cq, &nlp, &mut aug));
     }
 }

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -144,6 +144,15 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         options: &["recalc_y", "recalc_y_feas_tol"],
     },
     UnimplementedFeature {
+        feature: "least-square initialization of *all* dual variables \
+                  (the first-order-optimality fit)",
+        advice: "the equality multipliers are least-square initialized \
+                 regardless (capped by `constr_mult_init_max`), and the bound \
+                 multipliers take `bound_mult_init_val` — which is what \
+                 `least_square_init_duals=no` asks for",
+        options: &["least_square_init_duals"],
+    },
+    UnimplementedFeature {
         feature: "a selectable constraint-violation norm",
         advice: "pounce measures the violation in the 2-norm throughout",
         options: &["constraint_violation_norm_type"],
@@ -193,6 +202,36 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         options: &["point_perturbation_radius"],
     },
 ];
+
+/// One registered *value* of a string option that pounce does not
+/// implement, even though the option itself is read and other values of
+/// it work.
+///
+/// [`UNIMPLEMENTED_FEATURES`] refuses a whole option; this refuses one
+/// mode of one. The registry keeps upstream's full value list so an
+/// `ipopt.opt` written for Ipopt still parses — but a value that parses
+/// and then quietly behaves as a *different* mode is the same lie the
+/// module docstring is about, one level down.
+pub struct UnimplementedValue {
+    /// The option's registered name.
+    pub option: &'static str,
+    /// The value pounce does not implement.
+    pub value: &'static str,
+    /// What that value would mean, named in the error.
+    pub feature: &'static str,
+    /// What the caller can do instead. Empty when there is nothing.
+    pub advice: &'static str,
+}
+
+/// String-option values pounce does not implement. Refused when set.
+pub const UNIMPLEMENTED_VALUES: &[UnimplementedValue] = &[UnimplementedValue {
+    option: "bound_mult_init_method",
+    value: "mu-based",
+    feature: "initializing each bound multiplier to mu_init divided by its \
+              own slack",
+    advice: "`bound_mult_init_method=constant` (the default) initializes them \
+             all to `bound_mult_init_val`, which you can set",
+}];
 
 /// Options that *are* honored in the sense that matters — the answer is
 /// unaffected — but whose performance hint pounce does not exploit.
@@ -256,6 +295,39 @@ pub fn refusal(options: &OptionsList, reg: &RegisteredOptions) -> Option<String>
                 ));
             }
         }
+    }
+    None
+}
+
+/// The first unimplemented *value* the caller selected, with the message
+/// it earns. `None` when every string option holds a mode pounce runs.
+///
+/// No default gate here, unlike [`refusal`]: a value that equals the
+/// registered default is by construction the implemented one, so it
+/// never reaches the table.
+pub fn value_refusal(options: &OptionsList) -> Option<String> {
+    for entry in UNIMPLEMENTED_VALUES {
+        let selected = matches!(
+            options.get_string_value(entry.option, ""),
+            Ok((v, true)) if v.eq_ignore_ascii_case(entry.value)
+        );
+        if !selected {
+            continue;
+        }
+        let advice = if entry.advice.is_empty() {
+            String::new()
+        } else {
+            format!(" Instead: {}.", entry.advice)
+        };
+        return Some(format!(
+            "pounce: `{}={}` selects {}, which pounce does not implement. The \
+             value is registered so an ipopt.opt written for Ipopt still \
+             parses; falling back to another mode would silently run a \
+             different initialization than the one you asked for, so it is \
+             refused instead.{advice} Tracking issue: \
+             https://github.com/jkitchin/pounce/issues/604",
+            entry.option, entry.value, entry.feature,
+        ));
     }
     None
 }

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -382,11 +382,119 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
             ("no", "Solve the extracted problem directly, without presolve."),
         ],
         "Only affects the convex LP/QP path (`solver_selection` routing to \
-         pounce-convex), which runs only in the pounce CLI on `.nl` input; it \
-         has no effect on a library (`IpoptApplication`) solve. When on, \
-         presolve removes empty / duplicate / redundant rows, fixes and \
+         pounce-convex), which runs only in the pounce CLI on `.nl` input; a \
+         library (`IpoptApplication`) solve cannot route there, and refuses a \
+         non-default value rather than accepting one it would ignore (gh#604). \
+         When on, presolve removes empty / duplicate / redundant rows, fixes and \
          substitutes structural columns, and may report infeasible / unbounded \
          without invoking the solver.",
+    )?;
+
+    // The rest of `pounce_convex::QpOptions`, in the same category and on the
+    // same contract as `qp_presolve` above: read by the CLI's convex dispatch,
+    // refused by an entry point that cannot reach it.
+    //
+    // These lived in `pounce-cli/src/main.rs` until gh#604, registered onto
+    // this same registry at startup. That put them out of reach of every
+    // library frontend — `set_numeric_value("qp_tau", …)` from Python or the C
+    // interface raised `Unknown option "qp_tau"`, naming an option that exists
+    // — and it made adding any `qp_*` name here abort the CLI binary at
+    // startup with OPTION_ALREADY_REGISTERED. gh#360 moved the `sqp_qp_*`
+    // block out of the CLI for the same two reasons; this is the other half.
+    r.add_bounded_number_option(
+        "qp_tau",
+        "Convex IPM fraction-to-boundary parameter τ ∈ (0,1).",
+        0.0,
+        true,
+        1.0,
+        true,
+        0.95,
+        "Convex LP/QP interior-point only. Caps each Newton step at a fraction \
+         τ of the distance to the cone boundary; nearer 1 is more aggressive. \
+         The floor of the adaptive rule capped by qp_tau_max, and the flat \
+         value on the predictor step and on second-order / PSD cone blocks. \
+         Default 0.95.",
+    )?;
+    r.add_bounded_number_option(
+        "qp_tau_max",
+        "Convex IPM adaptive fraction-to-boundary ceiling τ_max ∈ (0,1).",
+        0.0,
+        true,
+        1.0,
+        true,
+        1.0 - 1e-12,
+        "Convex LP/QP interior-point only. As the solve converges, the \
+         corrector's τ on nonnegative-orthant blocks follows the Mehrotra tail \
+         τ = clamp(1 − μ, qp_tau, qp_tau_max), so a near-optimal iterate can \
+         take a near-full Newton step — worth 35–60% of the iterations when \
+         warm starting a sequence of nearby QPs. Set equal to qp_tau to pin τ \
+         flat (the most conservative setting). Default 1 − 1e-12.",
+    )?;
+    r.add_lower_bounded_number_option(
+        "qp_reg",
+        "Convex IPM static KKT regularization δ ≥ 0.",
+        0.0,
+        false,
+        1e-10,
+        "Convex LP/QP interior-point only. Added on the (block) diagonal to \
+         keep the reduced KKT quasi-definite for a stable LDLᵀ inertia. Too \
+         large freezes the primal residual on badly-scaled LPs; the default \
+         1e-10 is centered in the band that converges the LP/QP suites.",
+    )?;
+    r.add_lower_bounded_number_option(
+        "qp_infeas_tol",
+        "Convex IPM infeasibility-certificate value tolerance > 0.",
+        0.0,
+        true,
+        1e-7,
+        "Convex LP/QP interior-point only. Relative tolerance on the value and \
+         cone-membership parts of an infeasibility / unboundedness \
+         certificate. The certificate's defining-equation residual is held to a \
+         far tighter internal tolerance; this only governs when a status is \
+         backed by a verified proof. Default 1e-7.",
+    )?;
+    r.add_string_option(
+        "qp_hsde",
+        "Use the homogeneous self-dual embedding for the convex IPM.",
+        "yes",
+        &[
+            ("yes", "Self-dual embedding: self-starting, native certificates, robust on ill-conditioned data."),
+            ("no", "Infeasible-start primal–dual method (the warm-start / build-once substrate)."),
+        ],
+        "Convex LP/QP interior-point only. HSDE (default) self-starts and \
+         produces infeasibility / unboundedness certificates natively; it is \
+         also the substrate for non-symmetric cones. Default yes.",
+    )?;
+    r.add_string_option(
+        "qp_equilibrate",
+        "Ruiz-equilibrate the data before the direct convex IPM solve.",
+        "yes",
+        &[
+            (
+                "yes",
+                "Apply Ruiz row/column scaling before solving (direct, non-HSDE path).",
+            ),
+            ("no", "Solve the raw data without equilibration."),
+        ],
+        "Convex LP/QP interior-point only, and only when `qp_hsde=no` (the \
+         direct infeasible-start path): a conditioning aid for the raw KKT \
+         factorization. HSDE conditions internally and ignores this. Default \
+         yes.",
+    )?;
+    r.add_string_option(
+        "qp_crossover",
+        "Run LP crossover to purify the IPM iterate to an exact vertex.",
+        "no",
+        &[
+            ("yes", "After the IPM, pivot the interior iterate to an exact optimal vertex (active-set purification)."),
+            ("no", "Return the interior-point iterate directly (default)."),
+        ],
+        "Convex LP path only (pure LP, P=0); a no-op for genuine QPs. Correct \
+         (never-regress) but currently slow on the degenerate / large NETLIB \
+         LPs it targets and does not yet reach an exact `Optimal` vertex on the \
+         GEN family (issue #133), so it is off by default and offered as an \
+         opt-in for small, well-behaved LPs that want exact-vertex refinement. \
+         Default no.",
     )?;
 
     // SQP outer-loop options. Inactive when `algorithm =

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -163,6 +163,81 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
     r.add_lower_bounded_number_option("adaptive_mu_monotone_init_factor", "Determines the initial value of the barrier parameter when switching to the monotone mode.", 0.0, true, 0.8, "When the globalization strategy for the adaptive barrier algorithm switches to the monotone mode and fixed_mu_oracle is chosen as \"average_compl\", the barrier parameter is set to the current average complementarity times the value of \"adaptive_mu_monotone_init_factor\".")?;
     r.add_string_option("adaptive_mu_kkt_norm_type", "Norm used for the KKT error in the adaptive mu globalization strategies.", "2-norm-squared", &[("1-norm", "use the 1-norm (abs sum)"), ("2-norm-squared", "use the 2-norm squared (sum of squares)"), ("max-norm", "use the infinity norm (max)"), ("2-norm", "use 2-norm")], "When computing the KKT error for the globalization strategies, the norm to be used is specified with this option. Note, this option is also used in the QualityFunctionMuOracle.")?;
 
+    // ===== DefaultIterateInitializer::RegisterOptions (Algorithm/IpDefaultIterateInitializer.cpp) =====
+    //
+    // gh#604: these have read sites in
+    // `IpoptApplication::algorithm_builder_from_options` (the
+    // `builder.init.*` block) but were missing from the registry, so
+    // `set_numeric_value("bound_push", …)` raised `Unknown option` and
+    // the cold-start initializer was untunable from every frontend.
+    // The inverse of gh#551 (registered-but-unread).
+    //
+    // Defaults, types and ranges are upstream's, and they equal the
+    // hard-coded `InitOptions::default()` / `DefaultIterateInitializer::
+    // default()` values, so registering them changes no trajectory: the
+    // read sites use the `found` flag and only override when the caller
+    // set the key explicitly.
+    //
+    // `warm_start_init_point` is registered by this same upstream class
+    // but is left where it already sits (in the `OrigIpoptNLP` section,
+    // under "Warm Start") so registration order — and with it the
+    // `--print-options` ordering — does not shift for an option that was
+    // already reachable.
+    r.set_registering_category("Initialization");
+    r.add_lower_bounded_number_option("bound_push", "Desired minimum absolute distance from the initial point to bound.", 0.0, true, 1e-2, "Determines how much the initial point might have to be modified in order to be sufficiently inside the bounds (together with \"bound_frac\"). (This is kappa_1 in Section 3.6 of implementation paper.)")?;
+    r.add_bounded_number_option("bound_frac", "Desired minimum relative distance from the initial point to bound.", 0.0, true, 0.5, false, 1e-2, "Determines how much the initial point might have to be modified in order to be sufficiently inside the bounds (together with \"bound_push\"). (This is kappa_2 in Section 3.6 of implementation paper.)")?;
+    r.add_lower_bounded_number_option("slack_bound_push", "Desired minimum absolute distance from the initial slack to bound.", 0.0, true, 1e-2, "Determines how much the initial slack variables might have to be modified in order to be sufficiently inside the inequality bounds (together with \"slack_bound_frac\"). (This is kappa_1 in Section 3.6 of implementation paper.)")?;
+    r.add_bounded_number_option("slack_bound_frac", "Desired minimum relative distance from the initial slack to bound.", 0.0, true, 0.5, false, 1e-2, "Determines how much the initial slack variables might have to be modified in order to be sufficiently inside the inequality bounds (together with \"slack_bound_push\"). (This is kappa_2 in Section 3.6 of implementation paper.)")?;
+    r.add_lower_bounded_number_option("constr_mult_init_max", "Maximum allowed least-square guess of constraint multipliers.", 0.0, false, 1e3, "Determines how large the initial least-square guesses of the constraint multipliers are allowed to be (in max-norm). If the guess is larger than this value, it is discarded and all constraint multipliers are set to zero. This options is also used when initializing the restoration phase. By default, \"resto.constr_mult_init_max\" (the one used in RestoIterateInitializer) is set to zero.")?;
+    r.add_lower_bounded_number_option(
+        "bound_mult_init_val",
+        "Initial value for the bound multipliers.",
+        0.0,
+        true,
+        1.0,
+        "All dual variables corresponding to bound constraints are initialized to this value.",
+    )?;
+    r.add_string_option(
+        "bound_mult_init_method",
+        "Initialization method for bound multipliers",
+        "constant",
+        &[
+            (
+                "constant",
+                "set all bound multipliers to the value of bound_mult_init_val",
+            ),
+            (
+                "mu-based",
+                "initialize to mu_init/(x_i-x_L_i) (NOT IMPLEMENTED in pounce; refused, see gh#604)",
+            ),
+        ],
+        "This option defines how the iterates for the bound multipliers are initialized. If \"constant\" is chosen, then all bound multipliers are initialized to the value of \"bound_mult_init_val\". If \"mu-based\" is chosen, the each value is initialized to the the value of \"mu_init\" divided by the corresponding slack variable. This latter option might be useful if the starting point is close to the optimal solution. pounce implements \"constant\" only; \"mu-based\" is registered so an ipopt.opt written for Ipopt still parses, and is refused with a message rather than silently served as \"constant\" (gh#604).",
+    )?;
+    r.add_string_option(
+        "least_square_init_primal",
+        "Least square initialization of the primal variables",
+        "no",
+        &[
+            ("no", "take user-provided point"),
+            (
+                "yes",
+                "overwrite user-provided point with least-square estimates",
+            ),
+        ],
+        "If set to yes, Ipopt ignores the user provided point and solves a least square problem for the primal variables (x and s) to fit the linearized equality and inequality constraints. This might be useful if the user doesn't know anything about the starting point, or for solving an LP or QP. This option is enabled by the \"mehrotra_algorithm\" cascade.",
+    )?;
+    r.add_string_option(
+        "least_square_init_duals",
+        "Least square initialization of all dual variables",
+        "no",
+        &[
+            ("no", "use bound_mult_init_val and least-square equality constraint multipliers"),
+            ("yes", "overwrite user-provided point with least-square estimates"),
+        ],
+        "If set to yes, Ipopt tries to solve a least square problem for the primal and dual variables to fit the linearized equality and inequality constraints as well as the first-order optimality conditions. NOT IMPLEMENTED in pounce: registered so an ipopt.opt written for Ipopt still parses, and refused when set to \"yes\" rather than silently ignored (gh#604). The equality multipliers are always least-square initialized (subject to constr_mult_init_max), and the bound multipliers always take bound_mult_init_val — i.e. exactly the \"no\" behaviour.",
+    )?;
+    r.set_registering_category("");
+
     // ===== AlgorithmBuilder::RegisterOptions (Algorithm/IpAlgBuilder.cpp) =====
     r.set_registering_category("");
     r.set_registering_category("Linear Solver");

--- a/crates/pounce-algorithm/tests/init_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/init_options_wiring.rs
@@ -281,12 +281,13 @@ fn least_square_init_duals_parses_and_is_refused_when_requested() {
 /// `OptionsList`, harvested from the sources themselves so a read site
 /// added tomorrow is covered without anyone editing a list here.
 ///
-/// Scope is the crates whose reads are served by the registry a bare
-/// [`IpoptApplication::new`] builds: `pounce-algorithm` and
-/// `pounce-presolve`. `pounce-cli` is deliberately out — it registers
-/// its own `qp_*` convex knobs onto the app's registry at startup, so a
-/// static check against a bare application would report them missing
-/// when they are not.
+/// Scope is every crate whose reads are served by the registry a bare
+/// [`IpoptApplication::new`] builds — which, since gh#604 moved the
+/// `qp_*` convex knobs out of `pounce-cli`'s startup path and into the
+/// core registry, includes the CLI. Nothing registers options onto that
+/// registry from outside it any more, so a name read anywhere here and
+/// missing from the registry is a real defect rather than a scoping
+/// artifact.
 ///
 /// Only literal tags are visible this way — a call whose tag is a
 /// variable (`read_num(key)`) is invisible, which is why the reverse
@@ -302,7 +303,7 @@ fn option_names_read_by_the_solver_crates() -> BTreeSet<String> {
         "get_integer_value(",
         "get_enum_value(",
     ];
-    const CRATES: &[&str] = &["pounce-algorithm", "pounce-presolve"];
+    const CRATES: &[&str] = &["pounce-algorithm", "pounce-cli", "pounce-presolve"];
 
     fn collect(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
         let Ok(entries) = std::fs::read_dir(dir) else {

--- a/crates/pounce-algorithm/tests/init_options_wiring.rs
+++ b/crates/pounce-algorithm/tests/init_options_wiring.rs
@@ -1,0 +1,431 @@
+//! Cold-start (`DefaultIterateInitializer`) option wiring — gh#604.
+//!
+//! The eight knobs below had read sites in
+//! `IpoptApplication::algorithm_builder_from_options` all along, but no
+//! registry entries, so every frontend refused them at the *set* call
+//! with `Unknown option "bound_push"`. That is the inverse of gh#551
+//! (registered-but-unread): the feature ran, and the only way to reach
+//! it was to not use the option system.
+//!
+//! Three things are asserted here:
+//!
+//! 1. each option is settable, flows to the builder, and defaults to
+//!    the value the builder already hard-coded (so registering them
+//!    moved no trajectory);
+//! 2. the registered ranges refuse the values upstream refuses, and an
+//!    unimplemented *mode* fails with a message instead of quietly
+//!    running a different one;
+//! 3. the bidirectional registry invariant — no option is read without
+//!    being registered, and no Initialization option is registered
+//!    without being either consumed or explicitly refused.
+
+use pounce_algorithm::alg_builder::AlgorithmBuilder;
+use pounce_algorithm::application::IpoptApplication;
+use std::collections::BTreeSet;
+
+fn builder_from(setup: impl FnOnce(&mut IpoptApplication)) -> AlgorithmBuilder {
+    let mut app = IpoptApplication::new();
+    setup(&mut app);
+    app.algorithm_builder_from_options()
+}
+
+/// The cold-start options, as the issue lists them.
+const COLD_START_OPTIONS: &[&str] = &[
+    "bound_push",
+    "bound_frac",
+    "slack_bound_push",
+    "slack_bound_frac",
+    "constr_mult_init_max",
+    "bound_mult_init_val",
+    "bound_mult_init_method",
+    "least_square_init_primal",
+];
+
+#[test]
+fn every_cold_start_option_is_registered() {
+    let app = IpoptApplication::new();
+    let reg = app.registered_options();
+    for name in COLD_START_OPTIONS {
+        let opt = reg
+            .get_option(name)
+            .unwrap_or_else(|| panic!("`{name}` is read by the builder but not registered"));
+        assert_eq!(
+            opt.category, "Initialization",
+            "`{name}` should register under upstream's Initialization category"
+        );
+    }
+}
+
+#[test]
+fn cold_start_defaults_match_the_hard_coded_builder_values() {
+    // Registering an option whose default disagrees with the struct
+    // default silently re-tunes the solver. These must agree exactly.
+    let b = builder_from(|_| {}).init;
+    assert_eq!(b.bound_push, 1e-2);
+    assert_eq!(b.bound_frac, 1e-2);
+    assert_eq!(b.slack_bound_push, 1e-2);
+    assert_eq!(b.slack_bound_frac, 1e-2);
+    assert_eq!(b.constr_mult_init_max, 1e3);
+    assert_eq!(b.bound_mult_init_val, 1.0);
+    assert_eq!(b.bound_mult_init_method, "constant");
+    assert!(!b.least_square_init_primal);
+
+    let app = IpoptApplication::new();
+    let reg = app.registered_options();
+    for (name, expected) in [
+        ("bound_push", 1e-2),
+        ("bound_frac", 1e-2),
+        ("slack_bound_push", 1e-2),
+        ("slack_bound_frac", 1e-2),
+        ("constr_mult_init_max", 1e3),
+        ("bound_mult_init_val", 1.0),
+    ] {
+        let opt = reg.get_option(name).expect("registered");
+        match opt.default {
+            pounce_common::reg_options::DefaultValue::Number(d) => assert_eq!(
+                d, expected,
+                "registered default for `{name}` must equal the builder's"
+            ),
+            ref other => panic!("`{name}` should be a number option, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn numeric_cold_start_overrides_flow_through() {
+    let b = builder_from(|app| {
+        let o = app.options_mut();
+        o.set_numeric_value("bound_push", 0.25, true, false)
+            .unwrap();
+        o.set_numeric_value("bound_frac", 0.3, true, false).unwrap();
+        o.set_numeric_value("slack_bound_push", 0.4, true, false)
+            .unwrap();
+        o.set_numeric_value("slack_bound_frac", 0.45, true, false)
+            .unwrap();
+        o.set_numeric_value("constr_mult_init_max", 0.0, true, false)
+            .unwrap();
+        o.set_numeric_value("bound_mult_init_val", 7.5, true, false)
+            .unwrap();
+    })
+    .init;
+
+    assert_eq!(b.bound_push, 0.25);
+    assert_eq!(b.bound_frac, 0.3);
+    assert_eq!(b.slack_bound_push, 0.4);
+    assert_eq!(b.slack_bound_frac, 0.45);
+    // 0 is the documented "discard the least-square guess" value and
+    // must survive: the lower bound is non-strict.
+    assert_eq!(b.constr_mult_init_max, 0.0);
+    assert_eq!(b.bound_mult_init_val, 7.5);
+}
+
+#[test]
+fn string_cold_start_overrides_flow_through() {
+    let b = builder_from(|app| {
+        let o = app.options_mut();
+        o.set_string_value("least_square_init_primal", "yes", true, false)
+            .unwrap();
+        o.set_string_value("bound_mult_init_method", "constant", true, false)
+            .unwrap();
+    })
+    .init;
+    assert!(b.least_square_init_primal);
+    assert_eq!(b.bound_mult_init_method, "constant");
+}
+
+/// The Mehrotra cascade sets its own aggressive push defaults with
+/// upstream's `SetNumericValueIfUnset` semantics — an *explicit* user
+/// value has to win. Before gh#604 there was no way to express one.
+#[test]
+fn an_explicit_value_beats_the_mehrotra_cascade() {
+    let cascade = builder_from(|app| {
+        app.options_mut()
+            .set_string_value("mehrotra_algorithm", "yes", true, false)
+            .unwrap();
+    })
+    .init;
+    assert_eq!(cascade.bound_push, 10.0, "cascade default");
+    assert_eq!(cascade.bound_frac, 0.2);
+    assert_eq!(cascade.bound_mult_init_val, 10.0);
+    assert_eq!(cascade.constr_mult_init_max, 0.0);
+
+    let overridden = builder_from(|app| {
+        let o = app.options_mut();
+        o.set_string_value("mehrotra_algorithm", "yes", true, false)
+            .unwrap();
+        o.set_numeric_value("bound_push", 1e-3, true, false)
+            .unwrap();
+        o.set_numeric_value("bound_mult_init_val", 2.0, true, false)
+            .unwrap();
+    })
+    .init;
+    assert_eq!(overridden.bound_push, 1e-3, "explicit user value wins");
+    assert_eq!(overridden.bound_mult_init_val, 2.0);
+    // Untouched cascade values stay put.
+    assert_eq!(overridden.bound_frac, 0.2);
+}
+
+#[test]
+fn out_of_range_values_are_refused_at_the_set_call() {
+    let mut app = IpoptApplication::new();
+    let o = app.options_mut();
+
+    // bound_push / slack_bound_push / bound_mult_init_val: lower bound 0, strict.
+    for name in ["bound_push", "slack_bound_push", "bound_mult_init_val"] {
+        assert!(
+            o.set_numeric_value(name, 0.0, true, false).is_err(),
+            "`{name}` must refuse 0 (strict lower bound)"
+        );
+        assert!(
+            o.set_numeric_value(name, -1.0, true, false).is_err(),
+            "`{name}` must refuse a negative value"
+        );
+    }
+
+    // bound_frac / slack_bound_frac: (0, 0.5].
+    for name in ["bound_frac", "slack_bound_frac"] {
+        assert!(
+            o.set_numeric_value(name, 0.0, true, false).is_err(),
+            "`{name}` must refuse 0"
+        );
+        assert!(
+            o.set_numeric_value(name, 0.51, true, false).is_err(),
+            "`{name}` must refuse a value above 0.5"
+        );
+        assert!(
+            o.set_numeric_value(name, 0.5, true, false).is_ok(),
+            "`{name}` must accept exactly 0.5 (upper bound is non-strict)"
+        );
+    }
+
+    // constr_mult_init_max: lower bound 0, NOT strict.
+    assert!(
+        o.set_numeric_value("constr_mult_init_max", 0.0, true, false)
+            .is_ok()
+    );
+    assert!(
+        o.set_numeric_value("constr_mult_init_max", -1.0, true, false)
+            .is_err()
+    );
+
+    // The string options take their registered values and nothing else.
+    assert!(
+        o.set_string_value("bound_mult_init_method", "least-square", true, false)
+            .is_err(),
+        "an unregistered method name must fail at the set call"
+    );
+    assert!(
+        o.set_string_value("least_square_init_primal", "maybe", true, false)
+            .is_err()
+    );
+}
+
+/// `mu-based` parses — an `ipopt.opt` written for Ipopt must still be
+/// readable — and is then refused with a message, because pounce
+/// implements `constant` only. What it must never do is quietly run
+/// `constant` under a name the user chose for something else.
+#[test]
+fn the_unimplemented_bound_mult_init_method_is_refused_not_served() {
+    let mut app = IpoptApplication::new();
+    assert_eq!(app.unimplemented_option_value_refusal(), None, "unset");
+
+    app.options_mut()
+        .set_string_value("bound_mult_init_method", "constant", true, false)
+        .expect("the implemented mode parses");
+    assert_eq!(
+        app.unimplemented_option_value_refusal(),
+        None,
+        "the implemented mode is not refused"
+    );
+
+    app.options_mut()
+        .set_string_value("bound_mult_init_method", "mu-based", true, false)
+        .expect("upstream's value must still parse");
+    let msg = app
+        .unimplemented_option_value_refusal()
+        .expect("`mu-based` must be refused");
+    assert!(msg.contains("bound_mult_init_method"), "{msg}");
+    assert!(msg.contains("mu-based"), "{msg}");
+    assert!(msg.contains("604"), "message should name the issue: {msg}");
+}
+
+/// `least_square_init_duals` is the one option upstream registers in
+/// this class that pounce has no read site for. It is registered (so
+/// the options file parses) and refused (so it does not lie).
+#[test]
+fn least_square_init_duals_parses_and_is_refused_when_requested() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_string_value("least_square_init_duals", "no", true, false)
+        .expect("parses");
+    assert_eq!(
+        app.unimplemented_option_refusal(),
+        None,
+        "`no` is exactly what pounce does — it asks for nothing"
+    );
+
+    app.options_mut()
+        .set_string_value("least_square_init_duals", "yes", true, false)
+        .expect("parses");
+    let msg = app
+        .unimplemented_option_refusal()
+        .expect("`yes` names a feature pounce does not have");
+    assert!(msg.contains("least_square_init_duals"), "{msg}");
+}
+
+// ---------------------------------------------------------------------
+// The bidirectional registry invariant (gh#604 acceptance criterion 3).
+// ---------------------------------------------------------------------
+
+/// The literal option tags the solver's own crates pull out of an
+/// `OptionsList`, harvested from the sources themselves so a read site
+/// added tomorrow is covered without anyone editing a list here.
+///
+/// Scope is the crates whose reads are served by the registry a bare
+/// [`IpoptApplication::new`] builds: `pounce-algorithm` and
+/// `pounce-presolve`. `pounce-cli` is deliberately out — it registers
+/// its own `qp_*` convex knobs onto the app's registry at startup, so a
+/// static check against a bare application would report them missing
+/// when they are not.
+///
+/// Only literal tags are visible this way — a call whose tag is a
+/// variable (`read_num(key)`) is invisible, which is why the reverse
+/// direction below keys off the registry rather than this set alone.
+fn option_names_read_by_the_solver_crates() -> BTreeSet<String> {
+    const READERS: &[&str] = &[
+        "read_num(",
+        "read_int(",
+        "read_yes(",
+        "get_string_value(",
+        "get_bool_value(",
+        "get_numeric_value(",
+        "get_integer_value(",
+        "get_enum_value(",
+    ];
+    const CRATES: &[&str] = &["pounce-algorithm", "pounce-presolve"];
+
+    fn collect(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                collect(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+
+    let crates_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/ dir")
+        .to_path_buf();
+    let mut files = Vec::new();
+    for name in CRATES {
+        // Only `src` — this test file itself quotes the reader patterns.
+        let src_dir = crates_dir.join(name).join("src");
+        assert!(
+            src_dir.is_dir(),
+            "{} must be readable, or this test silently checks nothing",
+            src_dir.display()
+        );
+        collect(&src_dir, &mut files);
+    }
+
+    let mut found = BTreeSet::new();
+    for file in files {
+        let Ok(src) = std::fs::read_to_string(&file) else {
+            continue;
+        };
+        for reader in READERS {
+            for (idx, _) in src.match_indices(reader) {
+                let rest = src[idx + reader.len()..].trim_start();
+                // Only a literal first argument is a tag we can resolve.
+                let Some(rest) = rest.strip_prefix('"') else {
+                    continue;
+                };
+                let Some(end) = rest.find('"') else { continue };
+                let tag = &rest[..end];
+                if tag.is_empty() {
+                    continue;
+                }
+                found.insert(tag.to_string());
+            }
+        }
+    }
+    assert!(
+        found.len() > 150,
+        "the source scan found only {} tags — the reader patterns have \
+         drifted and this test is no longer checking anything",
+        found.len()
+    );
+    found
+}
+
+/// Forward direction: every option a solver component reads is
+/// registered. gh#604's bug was exactly a violation of this — the read
+/// site existed and the registry entry did not, so the option was
+/// unreachable through every documented path.
+#[test]
+fn every_option_read_by_the_solver_crates_is_registered() {
+    let app = IpoptApplication::new();
+    let reg = app.registered_options();
+    let mut unregistered: Vec<String> = option_names_read_by_the_solver_crates()
+        .into_iter()
+        .filter(|tag| reg.get_option(tag).is_none())
+        .collect();
+    unregistered.sort();
+    assert!(
+        unregistered.is_empty(),
+        "these options are read but never registered, so setting them \
+         raises `Unknown option` and the code reading them can never fire: \
+         {unregistered:?}"
+    );
+}
+
+/// Reverse direction: every registered Initialization option is either
+/// consumed by a read site or explicitly refused. A registered knob
+/// that nothing reads validates, accepts a value, and lies.
+#[test]
+fn every_registered_initialization_option_is_consumed_or_refused() {
+    use pounce_algorithm::unimplemented_options::{UNIMPLEMENTED_FEATURES, UNIMPLEMENTED_VALUES};
+
+    let app = IpoptApplication::new();
+    let read = option_names_read_by_the_solver_crates();
+    let refused: BTreeSet<&str> = UNIMPLEMENTED_FEATURES
+        .iter()
+        .flat_map(|g| g.options.iter().copied())
+        .chain(UNIMPLEMENTED_VALUES.iter().map(|v| v.option))
+        .collect();
+
+    let mut dangling = Vec::new();
+    for opt in app.registered_options().registered_options_in_order() {
+        if opt.category != "Initialization" {
+            continue;
+        }
+        if read.contains(&opt.name) || refused.contains(opt.name.as_str()) {
+            continue;
+        }
+        dangling.push(opt.name.clone());
+    }
+    assert!(
+        dangling.is_empty(),
+        "these Initialization options are registered but neither read nor \
+         refused — setting one does nothing, silently: {dangling:?}"
+    );
+
+    // The category is non-empty, or the loop above proves nothing.
+    let n = app
+        .registered_options()
+        .registered_options_in_order()
+        .iter()
+        .filter(|o| o.category == "Initialization")
+        .count();
+    assert_eq!(
+        n,
+        COLD_START_OPTIONS.len() + 1,
+        "expected the eight cold-start options plus least_square_init_duals"
+    );
+}

--- a/crates/pounce-algorithm/tests/solver_selection_library_option.rs
+++ b/crates/pounce-algorithm/tests/solver_selection_library_option.rs
@@ -195,3 +195,97 @@ fn solver_selection_and_qp_presolve_are_registered() {
         "an unregistered value must be rejected by the validating registry"
     );
 }
+
+// ---------------------------------------------------------------------
+// The convex `qp_*` knobs on an entry point that cannot reach the engine
+// that reads them (gh#604).
+// ---------------------------------------------------------------------
+
+/// All eight convex knobs live in the core registry, so every frontend
+/// *parses* them. Until gh#604 the seven `qp_tau`-family names were
+/// registered by `pounce-cli` at startup instead, which made setting one
+/// from Python or the C interface fail with `Unknown option "qp_tau"` —
+/// naming an option that exists — and made adding any `qp_*` name to the
+/// core registry abort the CLI binary at startup.
+#[test]
+fn every_convex_knob_is_registered_core_side() {
+    let mut app = IpoptApplication::new();
+    let o = app.options_mut();
+    for (name, value) in [
+        ("qp_tau", 0.9),
+        ("qp_tau_max", 0.99),
+        ("qp_reg", 1e-9),
+        ("qp_infeas_tol", 1e-6),
+    ] {
+        assert!(
+            o.set_numeric_value(name, value, true, true).is_ok(),
+            "`{name}` should be a registered library option"
+        );
+    }
+    for name in ["qp_hsde", "qp_equilibrate", "qp_crossover", "qp_presolve"] {
+        assert!(
+            o.set_string_value(name, "no", true, true).is_ok(),
+            "`{name}` should be a registered library option"
+        );
+    }
+    // The registered ranges still bite: τ ∈ (0,1) open at both ends.
+    assert!(o.set_numeric_value("qp_tau", 1.0, true, true).is_err());
+    assert!(o.set_numeric_value("qp_reg", -1.0, true, true).is_err());
+    assert!(o.set_string_value("qp_hsde", "maybe", true, true).is_err());
+}
+
+/// Parsing is not honouring. A library solve cannot route to the convex
+/// engines at all (`forced_convex_selection_is_rejected_in_library`
+/// above), so a `qp_*` value set here would configure nothing — and is
+/// refused with a message rather than accepted and dropped.
+#[test]
+fn a_convex_knob_is_refused_on_a_library_solve() {
+    let (_app, status, _out) = solve_hs35_with("print_level 0\nqp_tau 0.9\n");
+    assert_eq!(
+        status,
+        ApplicationReturnStatus::InvalidOption,
+        "a convex-only knob must not be silently ignored on a library solve"
+    );
+
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    app.initialize_with_options_str("qp_crossover yes\n")
+        .unwrap();
+    let msg = app
+        .unhonored_convex_option()
+        .expect("a non-default convex knob must be refused");
+    assert!(msg.contains("qp_crossover"), "{msg}");
+    assert!(msg.contains("604"), "message should name the issue: {msg}");
+}
+
+/// The same default gate the rest of the refusals use: an `ipopt.opt`
+/// that spells out defaults, or a round-tripped full option dump, asks
+/// for nothing and must keep solving.
+#[test]
+fn a_convex_knob_at_its_default_asks_nothing_of_a_library_solve() {
+    let (_app, status, _out) =
+        solve_hs35_with("print_level 0\nqp_presolve yes\nqp_hsde yes\nqp_tau 0.95\n");
+    assert!(
+        converged(status),
+        "explicitly-set defaults must not fail the solve; status = {status:?}"
+    );
+}
+
+/// The `pounce` CLI *can* route to those engines, and says so. That is
+/// also what keeps its NLP fallback working: a convex attempt that
+/// returns no verified point hands the model to `optimize_tnlp`, having
+/// genuinely used the `qp_*` values on the way.
+#[test]
+fn declaring_convex_routing_silences_the_guard() {
+    let mut app = IpoptApplication::new();
+    app.initialize().unwrap();
+    app.initialize_with_options_str("qp_tau 0.9\n").unwrap();
+    assert!(app.unhonored_convex_option().is_some(), "library default");
+
+    app.set_convex_routing_available(true);
+    assert_eq!(
+        app.unhonored_convex_option(),
+        None,
+        "a caller that can reach the convex engines honours the knob"
+    );
+}

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -439,7 +439,10 @@ pub fn main() -> ExitCode {
     // not implement, and the same reason for checking here: a model that
     // routes to `pounce-convex` never reaches `optimize_tnlp`, where the
     // library-side copy of this guard lives.
-    if let Some(msg) = app.unimplemented_option_refusal() {
+    if let Some(msg) = app
+        .unimplemented_option_refusal()
+        .or_else(|| app.unimplemented_option_value_refusal())
+    {
         eprintln!("{msg}");
         return ExitCode::from(2);
     }

--- a/crates/pounce-cli/src/main.rs
+++ b/crates/pounce-cli/src/main.rs
@@ -150,128 +150,24 @@ pub fn main() -> ExitCode {
 
     let mut app = IpoptApplication::new();
 
-    // ---- Convex LP/QP interior-point knobs (pounce-convex `QpOptions`) ----
-    // These only affect the `solver_selection` paths that route to
-    // pounce-convex (`lp-ipm` / `qp-ipm` / `auto` on an LP / convex QP, and
-    // the SOCP IPM). Each forwards only when the user *explicitly* sets it
-    // (see the convex dispatch below); otherwise the driver keeps its own
-    // tuned default. The standard `tol` and `max_iter` options feed the
-    // convex solve too — these `qp_*` knobs cover the rest of `QpOptions`.
-    let convex_knobs: Result<(), pounce_common::SolverException> = (|| {
-        let r = app.registered_options();
-        // τ ∈ (0,1): fraction-to-boundary step damping (Mehrotra σ is adaptive).
-        r.add_bounded_number_option(
-            "qp_tau",
-            "Convex IPM fraction-to-boundary parameter τ ∈ (0,1).",
-            0.0,
-            true,
-            1.0,
-            true,
-            0.95,
-            "Convex LP/QP interior-point only. Caps each Newton step at a \
-             fraction τ of the distance to the cone boundary; nearer 1 is more \
-             aggressive. The floor of the adaptive rule capped by qp_tau_max, \
-             and the flat value on the predictor step and on second-order / \
-             PSD cone blocks. Default 0.95.",
-        )?;
-        // Ceiling of the adaptive (Mehrotra-tail) τ on orthant blocks.
-        r.add_bounded_number_option(
-            "qp_tau_max",
-            "Convex IPM adaptive fraction-to-boundary ceiling τ_max ∈ (0,1).",
-            0.0,
-            true,
-            1.0,
-            true,
-            1.0 - 1e-12,
-            "Convex LP/QP interior-point only. As the solve converges, the \
-             corrector's τ on nonnegative-orthant blocks follows the Mehrotra \
-             tail τ = clamp(1 − μ, qp_tau, qp_tau_max), so a near-optimal \
-             iterate can take a near-full Newton step — worth 35–60% of the \
-             iterations when warm starting a sequence of nearby QPs. Set equal \
-             to qp_tau to pin τ flat (the most conservative setting). Default \
-             1 − 1e-12.",
-        )?;
-        // Static KKT regularization δ ≥ 0.
-        r.add_lower_bounded_number_option(
-            "qp_reg",
-            "Convex IPM static KKT regularization δ ≥ 0.",
-            0.0,
-            false,
-            1e-10,
-            "Convex LP/QP interior-point only. Added on the (block) diagonal to \
-             keep the reduced KKT quasi-definite for a stable LDLᵀ inertia. Too \
-             large freezes the primal residual on badly-scaled LPs; the default \
-             1e-10 is centered in the band that converges the LP/QP suites.",
-        )?;
-        // Certificate value / cone-membership tolerance > 0.
-        r.add_lower_bounded_number_option(
-            "qp_infeas_tol",
-            "Convex IPM infeasibility-certificate value tolerance > 0.",
-            0.0,
-            true,
-            1e-7,
-            "Convex LP/QP interior-point only. Relative tolerance on the value \
-             and cone-membership parts of an infeasibility / unboundedness \
-             certificate. The certificate's defining-equation residual is held \
-             to a far tighter internal tolerance; this only governs when a \
-             status is backed by a verified proof. Default 1e-7.",
-        )?;
-        r.add_string_option(
-            "qp_hsde",
-            "Use the homogeneous self-dual embedding for the convex IPM.",
-            "yes",
-            &[
-                ("yes", "Self-dual embedding: self-starting, native certificates, robust on ill-conditioned data."),
-                ("no", "Infeasible-start primal–dual method (the warm-start / build-once substrate)."),
-            ],
-            "Convex LP/QP interior-point only. HSDE (default) self-starts and \
-             produces infeasibility / unboundedness certificates natively; it \
-             is also the substrate for non-symmetric cones. Default yes.",
-        )?;
-        r.add_string_option(
-            "qp_equilibrate",
-            "Ruiz-equilibrate the data before the direct convex IPM solve.",
-            "yes",
-            &[
-                (
-                    "yes",
-                    "Apply Ruiz row/column scaling before solving (direct, non-HSDE path).",
-                ),
-                ("no", "Solve the raw data without equilibration."),
-            ],
-            "Convex LP/QP interior-point only, and only when `qp_hsde=no` (the \
-             direct infeasible-start path): a conditioning aid for the raw KKT \
-             factorization. HSDE conditions internally and ignores this. \
-             Default yes.",
-        )?;
-        r.add_string_option(
-            "qp_crossover",
-            "Run LP crossover to purify the IPM iterate to an exact vertex.",
-            "no",
-            &[
-                ("yes", "After the IPM, pivot the interior iterate to an exact optimal vertex (active-set purification)."),
-                ("no", "Return the interior-point iterate directly (default)."),
-            ],
-            "Convex LP path only (pure LP, P=0); a no-op for genuine QPs. \
-             Correct (never-regress) but currently slow on the degenerate / \
-             large NETLIB LPs it targets and does not yet reach an exact \
-             `Optimal` vertex on the GEN family (issue #133), so it is off by \
-             default and offered as an opt-in for small, well-behaved LPs that \
-             want exact-vertex refinement. Default no.",
-        )?;
-        Ok(())
-    })();
-    if let Err(e) = convex_knobs {
-        eprintln!("pounce: failed to register convex LP/QP options: {e}");
-        return ExitCode::from(2);
-    }
+    // This binary is the one entry point that can route a model to the
+    // convex LP/QP/SOCP engines (`solver_selection` + the structure
+    // extraction that classifies the `.nl`), so the `qp_*` knobs those
+    // engines read configure something here. Declaring that is what keeps
+    // `IpoptApplication`'s guard from refusing them on the NLP fallback
+    // path — a convex attempt that hands off to `optimize_tnlp` used them
+    // for real (gh#604).
+    app.set_convex_routing_available(true);
 
-    // NOTE: the active-set SQP QP-subproblem knobs (`sqp_qp_feas_tol`,
-    // `sqp_qp_opt_tol`, `sqp_qp_max_iter`, `sqp_qp_elastic_gamma`,
-    // `sqp_qp_anti_cycling`) used to be registered here. They now live in the
-    // core registry (`pounce_algorithm::upstream_options`) so the library and
-    // Python paths see them too — registering them here as well would raise
-    // OPTION_ALREADY_REGISTERED and abort the binary at startup (gh #360).
+    // NOTE: the convex LP/QP knobs (`qp_tau`, `qp_tau_max`, `qp_reg`,
+    // `qp_infeas_tol`, `qp_hsde`, `qp_equilibrate`, `qp_crossover`) and the
+    // active-set SQP QP-subproblem knobs (`sqp_qp_feas_tol`, `sqp_qp_opt_tol`,
+    // `sqp_qp_max_iter`, `sqp_qp_elastic_gamma`, `sqp_qp_anti_cycling`) used to
+    // be registered here. They now live in the core registry
+    // (`pounce_algorithm::upstream_options`) so the library and Python paths
+    // see them too — registering them here as well would raise
+    // OPTION_ALREADY_REGISTERED and abort the binary at startup (gh #360 for
+    // the SQP block, gh #604 for the convex one).
 
     // Opt into iter-history capture when the user asked for a JSON
     // report at Full detail — saves the per-iter alloc when they

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -55,13 +55,18 @@ The default interior-point path ports Ipopt's iterate initializer
    behave like one.
 2. **Slacks** are set to `s = d(x)` and pushed into the slack bounds
    the same way.
-3. **Duals** get fixed defaults: constraint multipliers `y = 0` (or a
-   least-square estimate, see `bound_mult_init_method` below) and
-   bound multipliers `z = v = bound_mult_init_val = 1.0`.
+3. **Duals** get fixed defaults: constraint multipliers start at
+   `y = 0` and are then replaced by a least-square estimate, unless
+   that estimate exceeds `constr_mult_init_max` (in which case it is
+   discarded and `y` stays at zero); bound multipliers are
+   `z = v = bound_mult_init_val = 1.0`.
 4. **The barrier parameter** starts at `mu_init = 0.1` (monotone
    `mu_strategy`, the default) regardless of how good your point is.
 
-The knobs, all Ipopt-compatible:
+The knobs, all Ipopt-compatible, and all settable through every
+frontend's option path (`Problem.solve(options={...})`, `pounce
+model.nl bound_push=0.1`, an `ipopt.opt` line, `IpoptApplication::
+options_mut`):
 
 | Option | Default | Meaning |
 |---|---|---|
@@ -69,7 +74,7 @@ The knobs, all Ipopt-compatible:
 | `bound_frac` | `1e-2` | Cap on the push as a fraction of the bound interval. |
 | `slack_bound_push` / `slack_bound_frac` | `1e-2` | Same, for inequality slacks. |
 | `bound_mult_init_val` | `1.0` | Initial bound-multiplier value. |
-| `bound_mult_init_method` | `constant` | `constant` / `mu-based` / `least-square`. |
+| `bound_mult_init_method` | `constant` | `constant` is the only implemented mode; upstream's `mu-based` parses and is then refused rather than silently served as `constant`. |
 | `constr_mult_init_max` | `1e3` | Cap on the least-square constraint-multiplier estimate; `0` keeps `y = 0`. |
 | `least_square_init_primal` | `no` | Replace the starting `x` with the min-norm solution of the linearized constraints before the interior push. |
 | `mu_init` | `0.1` | Initial barrier parameter (monotone strategy). |

--- a/docs/src/lp-qp-routing.md
+++ b/docs/src/lp-qp-routing.md
@@ -256,6 +256,29 @@ compare timings or isolate a solver issue):
 pounce model.nl qp_presolve=no
 ```
 
+## Tuning the convex IPM
+
+Beyond the shared `tol` and `max_iter`, the convex engine takes these:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `qp_presolve` | `yes` | Presolve before the solve (above). |
+| `qp_tau` | `0.95` | Fraction-to-boundary τ ∈ (0,1): the floor of the adaptive rule, and the flat value on the predictor step and on second-order / PSD cone blocks. |
+| `qp_tau_max` | `1 − 1e-12` | Ceiling of the adaptive (Mehrotra-tail) τ on orthant blocks. Set equal to `qp_tau` to pin τ flat. |
+| `qp_reg` | `1e-10` | Static KKT regularization δ ≥ 0, for a stable LDLᵀ inertia. |
+| `qp_infeas_tol` | `1e-7` | Relative tolerance on the value and cone-membership parts of an infeasibility / unboundedness certificate. |
+| `qp_hsde` | `yes` | Homogeneous self-dual embedding (self-starting, native certificates) vs. the infeasible-start primal–dual method. |
+| `qp_equilibrate` | `yes` | Ruiz-equilibrate the data first. Only when `qp_hsde=no`; HSDE conditions internally. |
+| `qp_crossover` | `no` | Pure LPs only: purify the interior iterate to an exact vertex. Opt-in; slow on large degenerate LPs (#133). |
+
+These reach the engine through the `pounce` CLI, which is the one entry
+point that classifies a `.nl` model and routes it. **A library solve
+refuses a non-default value** rather than accepting one it would drop —
+`IpoptApplication` has no structure extraction, so it cannot route to the
+convex engines at all (the same reason `solver_selection=lp-ipm` errors
+there). From Python, `pounce.solve_qp` / `pounce.solve_cone` drive the
+engine directly and take these knobs as typed arguments.
+
 ## Scope and limitations
 
 - **Convex problems only.** Nonconvex (indefinite-Hessian) QPs, quadratic

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -119,6 +119,15 @@ only its default `constant` is implemented; `mu-based` parses (an
 serving it as `constant` would run a different initialization than the
 one you asked for under the name you asked for.
 
+And it applies per *entry point*, for an option whose feature exists but
+sits somewhere this caller cannot reach. `option_file_name` is refused by
+a library caller that reads no options file, and the convex `qp_*` knobs
+(see [LP/QP Routing](lp-qp-routing.md#tuning-the-convex-ipm)) are refused
+by one that cannot route a model to the convex engines. Both are
+registered centrally, so they parse everywhere and the message can say
+which surface honours them — rather than the caller getting `Unknown
+option` for a name that exists.
+
 `option_file_name` was on that list until
 [#518](https://github.com/jkitchin/pounce/issues/518) implemented it;
 refusing an option is the cheap half of "implement it or fail loudly",

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -106,10 +106,18 @@ structurally redundant rows; see `presolve`. Remove it to run.
 The features in question: the Chen-Goldfarb (CG-penalty) / inexact-Newton
 line search, derivative approximation by finite differences,
 linear-dependency detection, the per-iteration NaN/Inf derivative check,
-multiplier recalculation by least squares, a selectable
+multiplier recalculation by least squares, least-square initialization of
+*all* duals (`least_square_init_duals`), a selectable
 constraint-violation norm, magic steps, bound replacement, the L-BFGS
 augmented-system variants, skipping the finalize callback, the dynamic
 HSL loader, and `suppress_all_output` / `debug_print_level`.
+
+The same rule applies one level down, to a single *value* of an option
+that otherwise works. `bound_mult_init_method` is read and honoured, but
+only its default `constant` is implemented; `mu-based` parses (an
+`ipopt.opt` written for Ipopt still loads) and is then refused, because
+serving it as `constant` would run a different initialization than the
+one you asked for under the name you asked for.
 
 `option_file_name` was on that list until
 [#518](https://github.com/jkitchin/pounce/issues/518) implemented it;


### PR DESCRIPTION
Fixes #604

## Problem

Fifteen registered-nowhere option names, in two groups.

**The eight cold-start knobs** (`bound_push`, `bound_frac`, `slack_bound_push`, `slack_bound_frac`, `constr_mult_init_max`, `bound_mult_init_val`, `bound_mult_init_method`, `least_square_init_primal`) had read sites in `algorithm_builder_from_options` but no registry entries. `OptionsList::set_*` rejects unregistered names, so every frontend — Python, the C interface, an `ipopt.opt`, the CLI — failed at the *set* call:

```
Unknown option "bound_push".
```

`docs/src/initialization.md` documented all eight in a table headed "The knobs, all Ipopt-compatible" the entire time. The feature ran; the only way to reach it was to not use the option system.

**The seven convex knobs** (`qp_tau`, `qp_tau_max`, `qp_reg`, `qp_infeas_tol`, `qp_hsde`, `qp_equilibrate`, `qp_crossover`) were registered by `pounce-cli` at startup — onto the same `RegisteredOptions` the core builds. Same `Unknown option` from every library frontend, plus a second failure mode: adding any `qp_*` name to the core registry would abort the CLI binary at startup with `OPTION_ALREADY_REGISTERED`. That hazard was documented in a comment above the block and tested by nothing. This group was found while fixing the first.

There is no before/after table because no answer changes — the defect is reachability, not numerics.

## Cause

Two independent gaps, both in what the registry does and does not contain.

For the cold-start block, `tools/optport/gen.py` lists `Algorithm/IpDefaultIterateInitializer.cpp` in `CLASS_ORDER`, but the generated file has no section for it: the whole class was dropped at some point, and only `warm_start_init_point` (which upstream registers in that same file) survived, hand-placed into the `OrigIpoptNLP` section with a comment. Nothing noticed, because a read site and a registry entry are checked by different code and by no test.

For the convex block, #360 moved the `sqp_qp_*` knobs out of the CLI and into the core registry for exactly these two reasons and left a NOTE saying so; the `qp_*` block beside it was not moved.

## Fix

**Register the cold-start options** under upstream's `Initialization` category with upstream's types, defaults and ranges. This moves no trajectory *by construction*: the registered defaults equal the values `InitOptions::default()` already hard-coded, and the read sites gate on the `found` flag, so an unset option is still an unset option. It is measured as well as argued — see Blast radius.

**Refuse what is registered but unimplemented, at three granularities.** The repo already refuses a whole option whose feature is missing (#483) and a whole option on an entry point that cannot honour it (#518, `option_file_name`). This adds the middle case and reuses the third:

| | Refused | Mechanism |
|---|---|---|
| feature missing | `least_square_init_duals=yes` | `UNIMPLEMENTED_FEATURES` (existing) |
| *value* missing | `bound_mult_init_method=mu-based` | `UNIMPLEMENTED_VALUES` (new) |
| unreachable from here | non-default `qp_*` on a library solve | `unhonored_convex_option` (new, mirrors `unhonored_option_file_name`) |

`mu-based` earns its own table because the option is read and its default value works — it is one mode that is missing, not the feature. It used to fall through to `nlp.get_starting_y()`, which is *neither* documented mode: an unsupported value silently bought a third behaviour. That branch is gone. Both values still **parse**, so an `ipopt.opt` written for Ipopt loads unchanged — the same bargain the rest of the registry makes.

**Move the convex knobs into the core registry** beside `solver_selection` and `qp_presolve`, verbatim. Parsing is not honouring: only the CLI classifies a `.nl` model and routes it to the convex engines (which is why `solver_selection=lp-ipm` already errors on a library solve), so a library caller now gets a message naming the surfaces that *do* honour the knob instead of `Unknown option` for a name that exists. `qp_presolve` joins them — it was a *documented* silent no-op on library paths, which is the same lie with a footnote.

### Rejected: refusing `qp_*` by reaching `optimize_tnlp`

The obvious gate — refuse in `optimize_tnlp`, since the CLI's convex dispatch never gets there — is wrong, and it took a live run to see it. A convex attempt that returns no verified KKT point **falls back** to `optimize_tnlp`, having genuinely used the `qp_*` values on the way. Gating that way fails a legitimate run:

```
$ pounce airport.nl qp_tau=0.9
pounce: note: the conic (convex QCQP) solve returned no verified KKT point after 31 iterations …
        being re-solved on the general NLP interior-point path
```

(31 iterations against 30 at the default τ — the knob reached the engine, then the model was handed on.) So the guard is gated on `set_convex_routing_available`, which the CLI declares once at startup, on the same contract as the existing `option_file_resolved` flag.

### Rejected: implementing `mu-based`

`z_L = mu_init / (x − x_L)` is a small function, and the option is unreachable today so nothing could regress. But it is a numerical feature the issue does not ask for (its scope item 2 says refuse), and I have no fixture evidence for what it does to a trajectory. Refusing is reversible; shipping an untested initializer mode is not.

## Blast radius

**Bit-identical.** `scripts/sweep-fixtures.sh` against a release binary built from the parent commit (5d8ad36): no diff across all 57 fixtures on status, objective **and iteration count**. Run twice — once for each commit, the second against the first as its baseline.

Behaviour changes only for callers who set one of these options, which was previously impossible on every path except `qp_*` from the CLI (unchanged, sweep included). The one *existing* behaviour that changes is `qp_presolve` set to a non-default on a library solve: today accepted and ignored, now refused. Explicitly-set defaults still pass everywhere, so a generated `ipopt.opt` or a round-tripped option dump is unaffected.

Docs updated: `initialization.md` (the `bound_mult_init_method` row was wrong on two of its three listed values), `options.md`, and a new tuning table in `lp-qp-routing.md` — the `qp_*` knobs had no book page at all, only `--print-options`.

## Tests

Verified against the parent commit in a worktree, with the assertions needing new API stripped so the failures are behavioural rather than compile errors. All four fail, for the stated reason:

```
`bound_push` is not registered
Unknown option "bound_push".
`qp_tau` should be a registered library option
read but never registered: ["bound_frac", "bound_mult_init_method", "bound_mult_init_val",
  "bound_push", "constr_mult_init_max", "least_square_init_primal", "qp_crossover",
  "qp_equilibrate", "qp_hsde", "qp_infeas_tol", "qp_reg", "qp_tau", "qp_tau_max",
  "slack_bound_frac", "slack_bound_push"]
```

That last list is exactly the fifteen options this PR fixes, produced by the invariant test rather than by hand.

- `tests/init_options_wiring.rs` (10) — set → builder round trips; registered defaults equal the builder's; the ranges (`bound_frac ≤ 0.5` non-strict, `constr_mult_init_max ≥ 0` non-strict so the documented `0` survives); the Mehrotra cascade's "an explicit value wins" semantics, which had no way to be expressed before; both refusals; and the bidirectional invariant, scanning `pounce-algorithm` / `pounce-cli` / `pounce-presolve` sources for literal read tags.
- `init/default.rs` `option_behavior` (7) — drives the initializer over a stub NLP whose `x0` sits on both bounds and whose `d(x)` sits on the slack bound, and asserts each option moves the iterate or the multipliers it produces (`constr_mult_init_max` discarding rather than clamping an over-cap least-square estimate; `least_square_init_primal` replacing the starting point).
- `tests/solver_selection_library_option.rs` (+4) — the convex knobs parse core-side and keep their ranges; a library solve returns `InvalidOption` on a non-default; an explicitly-set default still converges; declaring convex routing silences the guard.

Not pinned: the CLI's startup `OPTION_ALREADY_REGISTERED` hazard is now structurally impossible rather than tested — there is one registration site. And the invariant scan sees only literal tags; a `read_num(key)` with a variable tag is invisible to it, which is why the reverse direction keys off the registry instead.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md` if new
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

`check-docs-consistency.sh` and `check-release-consistency.sh` both pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXUyBXwW7GQQAX6byMXnw4)_