### PR TITLE
Make feasibility projection sparse and safeguard the linearized normal step (#605)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,11 +55,19 @@ changes.
   and termination reason.
 
   Trajectory: the fixture sweep is **bit-identical across all 57 fixtures**
-  under default options — `least_square_init_primal` is off by default and is
-  reachable only through `mehrotra_algorithm=yes`. Under that option 12 lines
-  move; the set of solved fixtures (27), every solved objective, and the total
-  iteration count across them are unchanged. See #605 for the per-fixture
-  accounting.
+  under default options — `least_square_init_primal` is off by default, so
+  nothing moves unless you turn it on. There are two ways to do that: set it
+  directly (registered by #604, the entry below) or `mehrotra_algorithm=yes`,
+  whose cascade turns it on for you. Under `mehrotra_algorithm=yes` 12 lines
+  move, and the set of solved fixtures (27), every solved objective and the
+  total iteration count across them (292) are unchanged. Under
+  `least_square_init_primal=yes` on its own 14 lines move: the same 46 fixtures
+  reach a solved-or-acceptable status and the total iteration count across them
+  falls from 2067 to 1687, but two of the 46 (`csfi2`, `eigenb2`) come back
+  `SolvedToAcceptableLevel` where they were `SolveSucceeded`, and on two
+  nonconvex models the different starting point finds a different local optimum
+  — `deb7` a better one, `pooling_rt2stp` a worse one. See #605 for the
+  per-fixture accounting.
 
 - **The cold-start initialization options are settable** (#604).
   `bound_push`, `bound_frac`, `slack_bound_push`, `slack_bound_frac`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ changes.
 
 ## [Unreleased]
 
+- **The feasibility projection is sparse, and the linearized normal step is
+  safeguarded against making the true violation worse** (#605). Two related
+  defects, one in the Python helper and one in the Rust core.
+
+  `pounce.project_to_feasible` built a dense `P = eye(n)` and a dense
+  `m × n` Jacobian regardless of how sparse the model was — an `O(n²)`
+  allocation on a problem whose data is `O(n)`. Measured peak allocation on a
+  chain-structured model (2 nonzeros per row) quadrupled on every doubling of
+  `n`: 32.3 MB at `n = 1000`, 225.7 MB at `n = 3000`, 901.3 MB at `n = 6000`.
+  The library's own `PounceSparsityWarning` fired on the way through. It now
+  builds a diagonal `P` and keeps the Jacobian in scipy-sparse form, so the
+  same three sizes cost 1.5 MB, 4.7 MB and 9.4 MB — linear, and 96× smaller at
+  `n = 6000`.
+
+  Both the helper and the solver's `least_square_init_primal` step also
+  accepted the linearized least-squares point unconditionally. A linearized
+  solution is a local model step, not automatically a better starting point:
+  where the Jacobian is small relative to the residual, the correction is huge
+  and the true nonlinear violation at the far end is far worse than where it
+  started. On `x₀² + x₁² = 1` started at `(0.05, 0.05)` the projection took the
+  violation from `0.995` to `49.5`, and the Rust initializer took it from
+  `0.995` to `48.5` — a starting point roughly 50× worse than the user's own.
+
+  Both paths now score every trial step on the true nonlinear violation and
+  accept only a step whose *actual* feasibility reduction is a documented
+  fraction of what the linear model predicted, backtracking otherwise and
+  keeping the original point if nothing qualifies. The Python side additionally
+  carries elastic variables, so an inconsistent or rank-deficient linearization
+  returns the least-violating point instead of raising.
+
+  **Behaviour changes.** `project_to_feasible` no longer raises `RuntimeError`
+  on an inconsistent linearization — that case is now absorbed by the elastic
+  variables and reported through the new `ProjectionReport`. It also
+  re-linearizes up to `max_iter` times (default 3) rather than once, so it
+  costs more constraint evaluations and returns a smaller residual; pass
+  `max_iter=1` for the old single-linearization budget. In the Rust
+  initializer, a starting point that is *already* feasible is now left alone
+  rather than being replaced by the min-norm point, since no step can improve a
+  violation of zero.
+
+  Diagnostics are new on both sides: `ProjectionReport` in Python
+  (`return_report=True`) and `IpoptApplication::least_square_init_report()` in
+  Rust, each carrying initial/final violation, step norm, rejected-trial count
+  and termination reason.
+
+  Trajectory: the fixture sweep is **bit-identical across all 57 fixtures**
+  under default options — `least_square_init_primal` is off by default and is
+  reachable only through `mehrotra_algorithm=yes`. Under that option 12 lines
+  move; the set of solved fixtures (27), every solved objective, and the total
+  iteration count across them are unchanged. See #605 for the per-fixture
+  accounting.
+
 - **A feasible NLP whose constraint rows sit at their own floating-point
   resolution is no longer refused a certificate — or convicted of local
   infeasibility** (#590). Reported against LyoPRONTO's pseudosteady-limit

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -128,6 +128,11 @@ use std::time::Instant;
 
 pub struct IpoptApplication {
     options: OptionsList,
+    /// Diagnostics from the safeguarded `least_square_init_primal`
+    /// initializer step of the most recent solve (gh#605). `None` when
+    /// the step was not run. Read with
+    /// [`Self::least_square_init_report`].
+    least_square_init_report: Option<crate::init::default::LeastSquareInitReport>,
     /// Per-variable scaling factors applied by the wrapper installed in
     /// [`Self::optimize_tnlp`] (gh#486). Recorded so consumers that read
     /// the algorithm's own iterate rather than the `finalize_solution`
@@ -285,6 +290,7 @@ impl IpoptApplication {
         let reg = Rc::new(reg);
         Self {
             options: OptionsList::with_registered(Rc::clone(&reg)),
+            least_square_init_report: None,
             variable_scaling: RefCell::new(None),
             presolve_already_applied: false,
             reg_options: reg,
@@ -618,6 +624,16 @@ impl IpoptApplication {
     /// the full IPM path covers every entry shape.
     pub fn problem_dimensions(&self, tnlp: &mut dyn TNLP) -> Option<NlpInfo> {
         tnlp.get_nlp_info()
+    }
+
+    /// Diagnostics from the safeguarded `least_square_init_primal`
+    /// initializer step of the last solve (gh#605): the nonlinear
+    /// violation before and after, the accepted step norm, how many
+    /// backtracking trials were rejected, and why it stopped. `None`
+    /// when `least_square_init_primal` was off or the model had no
+    /// constraints.
+    pub fn least_square_init_report(&self) -> Option<crate::init::default::LeastSquareInitReport> {
+        self.least_square_init_report.clone()
     }
 
     pub fn statistics(&self) -> SolveStatistics {
@@ -2505,6 +2521,9 @@ impl IpoptApplication {
             .then(pounce_observability::IterCaptureGuard::start);
 
         let solver_status = alg.optimize();
+        // Keep the initializer's feasibility diagnostics reachable
+        // after the algorithm goes out of scope (gh#605).
+        self.least_square_init_report = alg.least_square_init_report();
 
         let captured_iters = iter_capture.map(|g| g.finish()).unwrap_or_default();
         // Propagate to any enclosing capture (e.g. `with_iter_capture`

--- a/crates/pounce-algorithm/src/init/default.rs
+++ b/crates/pounce-algorithm/src/init/default.rs
@@ -38,9 +38,11 @@ use std::rc::Rc;
 
 /// What the safeguarded least-square initializer did. Returned by
 /// [`DefaultIterateInitializer::safeguarded_least_square_x`] and
-/// printed at `print_level >= 5`, so a starting point that silently
-/// got worse is visible in the log instead of only in the iteration
-/// count.
+/// readable after the solve through
+/// [`crate::application::IpoptApplication::least_square_init_report`],
+/// so a starting point that silently got worse is visible somewhere
+/// other than the iteration count. Nothing prints it: it is a
+/// programmatic accessor, not a log line.
 #[derive(Debug, Clone, Default)]
 pub struct LeastSquareInitReport {
     /// Nonlinear violation at the user's `x0`, after the interior push.
@@ -884,8 +886,24 @@ mod option_behavior {
         fn eval_grad_f(&mut self, _x: &dyn Vector, g: &mut dyn Vector) {
             g.set(0.0);
         }
-        fn eval_c(&mut self, _x: &dyn Vector, c: &mut dyn Vector) {
-            c.set(1.0);
+        /// `c(x) = x0 + x1 - 4`, which [`FixedAugSolver`]'s `x_ls =
+        /// [1, 3]` satisfies exactly.
+        ///
+        /// This was a constant `1.0` when gh#604 wrote these tests, and
+        /// a constant will not do since gh#605: the least-square step is
+        /// now taken only when it reduces the *true* nonlinear
+        /// violation, and against a constant `c` no step ever can, so
+        /// `least_square_init_primal` would be correctly declined and
+        /// the option untestable here. An `x`-dependent row also makes
+        /// the stub honest — `x_ls` is supposed to be the point that
+        /// solves the linearized constraints, and now it is one.
+        fn eval_c(&mut self, x: &dyn Vector, c: &mut dyn Vector) {
+            let v = x
+                .as_any()
+                .downcast_ref::<DenseVector>()
+                .expect("dense x")
+                .expanded_values();
+            c.set(v[0] + v[1] - 4.0);
         }
         fn eval_d(&mut self, _x: &dyn Vector, d: &mut dyn Vector) {
             d.set(-5.0);

--- a/crates/pounce-algorithm/src/init/default.rs
+++ b/crates/pounce-algorithm/src/init/default.rs
@@ -39,6 +39,29 @@ use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
 use std::cell::RefCell;
 use std::rc::Rc;
 
+/// What the safeguarded least-square initializer did. Returned by
+/// [`DefaultIterateInitializer::safeguarded_least_square_x`] and
+/// printed at `print_level >= 5`, so a starting point that silently
+/// got worse is visible in the log instead of only in the iteration
+/// count.
+#[derive(Debug, Clone, Default)]
+pub struct LeastSquareInitReport {
+    /// Nonlinear violation at the user's `x0`, after the interior push.
+    pub violation_initial: Number,
+    /// Nonlinear violation at the point actually handed to the
+    /// algorithm. Equal to `violation_initial` when nothing was
+    /// accepted.
+    pub violation_final: Number,
+    /// `alpha * ||x_ls - x0||_2` for the accepted trial; 0 if none was.
+    pub step_norm: Number,
+    /// Step fraction of the accepted trial; 0 if none was.
+    pub alpha: Number,
+    /// Backtracking trials whose true violation failed the test.
+    pub rejected_trials: Index,
+    /// Why the safeguard stopped.
+    pub termination: &'static str,
+}
+
 pub struct DefaultIterateInitializer {
     pub bound_push: Number,
     pub bound_frac: Number,
@@ -61,6 +84,24 @@ pub struct DefaultIterateInitializer {
     /// (`IpIpoptAlg.cpp:182`) to dramatically reduce iter-0 primal
     /// infeasibility on LP-shaped problems.
     pub least_square_init_primal: bool,
+    /// `least_square_init_primal_max_trials` — how many backtracking
+    /// trials the safeguard in [`Self::safeguarded_least_square_x`] may
+    /// take before it gives up and keeps the user's point. Each trial
+    /// costs one constraint evaluation (`c` and `d`); none of them
+    /// costs a Jacobian or a KKT solve, because the step direction is
+    /// computed once and only its length changes.
+    pub least_square_init_max_trials: Index,
+    /// Armijo-style acceptance ratio for the safeguard: a trial at
+    /// step fraction `alpha` is accepted when the true nonlinear
+    /// violation satisfies `theta(alpha) <= (1 - eta*alpha) * theta_0`,
+    /// i.e. when the *actual* feasibility reduction is at least `eta`
+    /// times the reduction the linearization *predicted*.
+    pub least_square_init_accept_ratio: Number,
+    /// Diagnostics from the most recent safeguarded least-square
+    /// initialization: initial/final violation, accepted step norm,
+    /// rejected trial count, termination reason. `None` when the step
+    /// was never attempted.
+    pub last_least_square_report: Option<LeastSquareInitReport>,
 }
 
 impl Default for DefaultIterateInitializer {
@@ -75,6 +116,9 @@ impl Default for DefaultIterateInitializer {
             bound_mult_init_method: "constant".into(),
             eq_mult_calculator: None,
             least_square_init_primal: false,
+            least_square_init_max_trials: 4,
+            least_square_init_accept_ratio: 1e-2,
+            last_least_square_report: None,
         }
     }
 }
@@ -201,6 +245,173 @@ impl DefaultIterateInitializer {
         Some(Rc::new(sol_x))
     }
 
+    /// Stage `x_cand` as the current iterate and return the true
+    /// nonlinear constraint violation there.
+    ///
+    /// The merit is `curr_unscaled_nlp_constraint_violation_max()` —
+    /// `max(||c(x)||_inf, ||max(d_l - d(x), d(x) - d_u, 0)||_inf)` in
+    /// unscaled NLP units. It is the same quantity the CLI reports as
+    /// the model's constraint violation, so "the initializer improved
+    /// feasibility" means the number a user can read improved.
+    ///
+    /// Costs one `c`/`d` evaluation. No Jacobian, no KKT solve.
+    fn violation_at(
+        data: &IpoptDataHandle,
+        cq: &IpoptCqHandle,
+        template: &IteratesVector,
+        x_cand: &dyn Vector,
+    ) -> Number {
+        let mut x_stage = DenseVectorSpace::new(x_cand.dim()).make_new_dense();
+        x_stage.copy(x_cand);
+        let staged = template.with_x(Rc::new(x_stage));
+        data.borrow_mut().set_curr(staged);
+        cq.borrow().curr_unscaled_nlp_constraint_violation_max()
+    }
+
+    /// Safeguarded least-square normal step.
+    ///
+    /// `calculate_least_square_primals` returns the minimum-norm
+    /// solution of the *linearized* constraints. That is a local model
+    /// step, not automatically a better NLP starting point: where the
+    /// Jacobian is small relative to the residual the linearization
+    /// asks for a huge correction, and the true nonlinear violation at
+    /// the far end can be orders of magnitude worse than where it
+    /// started. Accepting it unconditionally (which is what upstream
+    /// `IpDefaultIterateInitializer.cpp:200-222` does, and what pounce
+    /// did through 0.10.0) hands the algorithm a worse starting point
+    /// than the user supplied.
+    ///
+    /// So: compute the direction once, then walk it back.
+    ///
+    /// * Trial `k` uses `alpha = 2^-k` for `k` in `0..max_trials`.
+    /// * Every candidate is pushed into the bound interior *before*
+    ///   its violation is measured, so the accepted merit is the merit
+    ///   of the point the algorithm will actually start from, and
+    ///   bound interiority is preserved by construction.
+    /// * A trial is accepted when
+    ///   `theta(alpha) <= (1 - eta*alpha) * theta_0`. The linear model
+    ///   predicts `theta -> 0` at `alpha = 1`, so the predicted
+    ///   reduction at `alpha` is `alpha * theta_0` and this test is
+    ///   exactly "actual reduction is at least `eta` times predicted".
+    /// * The first accepted trial wins (they are tried longest-first,
+    ///   so that is also the best available reduction on this ray).
+    /// * If no trial is accepted the user's `x` is returned unchanged.
+    ///
+    /// Returns `(accepted_x, diagnostics)`.
+    #[allow(clippy::too_many_arguments)]
+    fn safeguarded_least_square_x(
+        &self,
+        data: &IpoptDataHandle,
+        cq: &IpoptCqHandle,
+        nlp: &Rc<RefCell<dyn IpoptNlp>>,
+        aug_solver: &mut dyn AugSystemSolver,
+        template: &IteratesVector,
+        x0: &dyn Vector,
+        n_x: Index,
+    ) -> (Option<Box<dyn Vector>>, LeastSquareInitReport) {
+        let mut report = LeastSquareInitReport::default();
+
+        // theta_0 at the user's point, measured after the interior
+        // push so it is comparable with every trial below.
+        let mut x_base = DenseVectorSpace::new(n_x).make_new_dense();
+        x_base.copy(x0);
+        self.push_into_bounds(nlp, &mut x_base);
+        let theta_0 = Self::violation_at(data, cq, template, &x_base);
+        report.violation_initial = theta_0;
+        report.violation_final = theta_0;
+
+        if !theta_0.is_finite() {
+            report.termination = "x0 violation is not finite";
+            return (None, report);
+        }
+        if theta_0 == 0.0 {
+            report.termination = "x0 already feasible";
+            return (None, report);
+        }
+
+        // The direction. Computed at the user's point, so re-stage it
+        // first: `calculate_least_square_primals` linearizes at
+        // whatever `data.curr` holds.
+        let staged = template.with_x({
+            let mut xs = DenseVectorSpace::new(n_x).make_new_dense();
+            xs.copy(x0);
+            Rc::new(xs)
+        });
+        data.borrow_mut().set_curr(staged);
+        let x_ls = match self.calculate_least_square_primals(cq, nlp, aug_solver, n_x) {
+            Some(v) => v,
+            None => {
+                report.termination = "augmented system solve failed";
+                return (None, report);
+            }
+        };
+
+        // d = x_ls - x0, formed once and reused at every trial.
+        let mut dir = DenseVectorSpace::new(n_x).make_new_dense();
+        dir.copy(&*x_ls);
+        dir.axpy(-1.0, x0);
+        let dir_norm = dir.nrm2();
+        if !dir_norm.is_finite() {
+            report.termination = "least-square step is not finite";
+            return (None, report);
+        }
+
+        let mut alpha = 1.0;
+        for _ in 0..self.least_square_init_max_trials.max(1) {
+            let mut cand = DenseVectorSpace::new(n_x).make_new_dense();
+            if alpha == 1.0 {
+                // Use `x_ls` itself rather than `x0 + 1.0*(x_ls - x0)`.
+                // The two differ in the last bit, and that is enough to
+                // move a borderline model by an iteration — so the
+                // full-length trial stays bit-identical to what the
+                // unsafeguarded path produced, and the only trajectory
+                // change is on the models where the step is actually
+                // rejected.
+                cand.copy(&*x_ls);
+            } else {
+                cand.copy(x0);
+                cand.axpy(alpha, &dir);
+            }
+            self.push_into_bounds(nlp, &mut cand);
+
+            let theta = Self::violation_at(data, cq, template, &cand);
+            let predicted = alpha * theta_0;
+            let actual = theta_0 - theta;
+            if theta.is_finite()
+                && actual >= self.least_square_init_accept_ratio * predicted
+                && theta < theta_0
+            {
+                report.violation_final = theta;
+                report.step_norm = alpha * dir_norm;
+                report.alpha = alpha;
+                report.termination = "accepted";
+                return (Some(Box::new(cand)), report);
+            }
+            report.rejected_trials += 1;
+            alpha *= 0.5;
+        }
+
+        report.termination = "no trial improved the nonlinear violation";
+        (None, report)
+    }
+
+    /// Push `x` into the interior of `[x_l, x_u]` with this
+    /// initializer's `bound_push` / `bound_frac`. Split out so the
+    /// safeguard can measure candidates at the point the algorithm
+    /// would actually use.
+    fn push_into_bounds(&self, nlp: &Rc<RefCell<dyn IpoptNlp>>, x: &mut DenseVector) {
+        let nlp_ref = nlp.borrow();
+        push_x_into_interior(
+            x,
+            &*nlp_ref.px_l(),
+            nlp_ref.x_l(),
+            &*nlp_ref.px_u(),
+            nlp_ref.x_u(),
+            self.bound_push,
+            self.bound_frac,
+        );
+    }
+
     pub fn push_to_interior(
         bound_push: Number,
         bound_frac: Number,
@@ -229,6 +440,10 @@ impl DefaultIterateInitializer {
 }
 
 impl IterateInitializer for DefaultIterateInitializer {
+    fn least_square_report(&self) -> Option<LeastSquareInitReport> {
+        self.last_least_square_report.clone()
+    }
+
     fn set_initial_iterates(
         &mut self,
         data: &IpoptDataHandle,
@@ -293,11 +508,20 @@ impl IterateInitializer for DefaultIterateInitializer {
                 Rc::new(v_l_zero),
                 Rc::new(v_u_zero),
             );
-            data.borrow_mut().set_curr(stage_iv);
+            data.borrow_mut().set_curr(stage_iv.clone());
 
-            if let Some(x_ls) = self.calculate_least_square_primals(cq, nlp, aug_solver, n_x) {
-                x.copy(&*x_ls);
+            // The linearized least-squares point is only accepted when
+            // it actually reduces the *true* nonlinear violation; see
+            // `safeguarded_least_square_x`. Rejecting it leaves `x` as
+            // the user gave it, which is the pre-0.11 behaviour minus
+            // the cases where the linearization sent the starting
+            // point somewhere worse.
+            let (accepted, report) =
+                self.safeguarded_least_square_x(data, cq, nlp, aug_solver, &stage_iv, &x, n_x);
+            if let Some(x_new) = accepted {
+                x.copy(&*x_new);
             }
+            self.last_least_square_report = Some(report);
         }
 
         {

--- a/crates/pounce-algorithm/src/init/trait.rs
+++ b/crates/pounce-algorithm/src/init/trait.rs
@@ -1,5 +1,6 @@
 //! `IterateInitializer` trait — port of `IpIterateInitializer.hpp`.
 
+use crate::init::default::LeastSquareInitReport;
 use crate::ipopt_cq::IpoptCqHandle;
 use crate::ipopt_data::IpoptDataHandle;
 use crate::ipopt_nlp::IpoptNlp;
@@ -21,4 +22,13 @@ pub trait IterateInitializer {
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
         aug_solver: &mut dyn AugSystemSolver,
     ) -> bool;
+
+    /// Diagnostics from the safeguarded `least_square_init_primal`
+    /// step (gh#605): initial/final nonlinear violation, accepted step
+    /// norm, rejected-trial count, termination reason. `None` for
+    /// initializers that do not run that step, or when it was not
+    /// attempted on this solve.
+    fn least_square_report(&self) -> Option<LeastSquareInitReport> {
+        None
+    }
 }

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -379,6 +379,12 @@ pub struct IpoptAlgorithm {
 }
 
 impl IpoptAlgorithm {
+    /// Diagnostics from the safeguarded `least_square_init_primal`
+    /// initializer step (gh#605). `None` when the step was not run.
+    pub fn least_square_init_report(&self) -> Option<crate::init::default::LeastSquareInitReport> {
+        self.bundle.init.least_square_report()
+    }
+
     pub fn new(data: IpoptDataHandle, cq: IpoptCqHandle, mut bundle: AlgorithmBundle) -> Self {
         // The builder may pre-populate `bundle.search_dir` when given a
         // `LinearBackendFactory`; lift it onto the algorithm so the

--- a/crates/pounce-algorithm/src/iterates_vector.rs
+++ b/crates/pounce-algorithm/src/iterates_vector.rs
@@ -76,6 +76,14 @@ impl IteratesVector {
         }
     }
 
+    /// Clone this iterate with `x` swapped out and every other
+    /// component shared. `Rc` makes it a pointer copy, so this is the
+    /// cheap way to re-stage a candidate `x` for a CQ evaluation
+    /// without rebuilding the other seven blocks.
+    pub fn with_x(&self, x: Rc<dyn Vector>) -> Self {
+        Self { x, ..self.clone() }
+    }
+
     /// Total dimension across all eight components.
     pub fn dim(&self) -> i32 {
         self.x.dim()

--- a/crates/pounce-algorithm/tests/issue_605_safeguarded_ls_init.rs
+++ b/crates/pounce-algorithm/tests/issue_605_safeguarded_ls_init.rs
@@ -1,0 +1,208 @@
+//! gh#605 — the least-square primal initializer must not hand the
+//! algorithm a *worse* starting point than the user supplied.
+//!
+//! `least_square_init_primal` replaces `x0` with the minimum-norm
+//! solution of the **linearized** constraints. Where the Jacobian is
+//! small relative to the residual, that linearization asks for a huge
+//! correction and the true nonlinear violation at the far end is far
+//! worse than where it started.
+//!
+//! This model is the smallest case that shows it:
+//!
+//! ```text
+//! min  (x0 - 3)^2 + (x1 - 3)^2
+//! s.t. x0^2 + x1^2 = 1          started at (0.05, 0.05)
+//! ```
+//!
+//! At `x0 = (0.05, 0.05)` the constraint residual is `-0.995` and the
+//! Jacobian is `(0.1, 0.1)`. The min-norm linearized correction is
+//! `d = (4.975, 4.975)`, landing at `(5.025, 5.025)` where the true
+//! violation is `2*5.025^2 - 1 ≈ 49.5` — **50x worse** than the
+//! `0.995` it started with.
+//!
+//! The safeguard added in gh#605 scores every trial step on the true
+//! nonlinear violation and backtracks (or declines outright) when it
+//! does not improve, so the algorithm never starts from the far point.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::Number;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+#[derive(Default)]
+struct PoorLinearization;
+
+impl TNLP for PoorLinearization {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 2,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[-10.0, -10.0]);
+        b.x_u.copy_from_slice(&[10.0, 10.0]);
+        b.g_l[0] = 1.0;
+        b.g_u[0] = 1.0;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.copy_from_slice(&[0.05, 0.05]);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 3.0).powi(2) + (x[1] - 3.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 3.0);
+        g[1] = 2.0 * (x[1] - 3.0);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] * x[0] + x[1] * x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_jac_g(Values) without x");
+                values[0] = 2.0 * x[0];
+                values[1] = 2.0 * x[1];
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                let lam = lambda.expect("eval_h(Values) without lambda");
+                values[0] = obj_factor * 2.0 + lam[0] * 2.0;
+                values[1] = obj_factor * 2.0 + lam[0] * 2.0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn solve_with_ls_init() -> IpoptApplication {
+    let mut app = IpoptApplication::new();
+    // The Mehrotra cascade is the route that turns
+    // `least_square_init_primal` on.
+    app.options_mut()
+        .set_string_value("mehrotra_algorithm", "yes", true, false)
+        .unwrap();
+    // The initializer runs once, before iteration 1, so the report is
+    // fully populated no matter where the solve goes afterwards. Cap
+    // the iterations and silence the log: this test is about the
+    // starting point, not about what Mehrotra does with it.
+    app.options_mut()
+        .set_integer_value("max_iter", 5, true, false)
+        .unwrap();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(PoorLinearization));
+    let _ = app.optimize_tnlp(tnlp);
+    app
+}
+
+/// The unsafeguarded step lands at `(5.025, 5.025)`, whose true
+/// violation is `2*5.025^2 - 1 = 49.50125`. Anything at or above this
+/// means the raw linearized point was taken.
+const UNSAFEGUARDED_VIOLATION: Number = 49.50125;
+
+#[test]
+fn least_square_init_never_worsens_the_nonlinear_violation() {
+    let app = solve_with_ls_init();
+    let report = app
+        .least_square_init_report()
+        .expect("least_square_init_primal ran, so it must report");
+    eprintln!("gh605: {report:?}");
+
+    assert!(
+        (report.violation_initial - 0.995).abs() < 1e-6,
+        "expected theta0 = 0.995 at (0.05, 0.05), got {}",
+        report.violation_initial,
+    );
+    // The contract: the point handed to the algorithm is never worse
+    // than the one the user gave.
+    assert!(
+        report.violation_final <= report.violation_initial,
+        "initializer made the starting point WORSE: {} -> {}",
+        report.violation_initial,
+        report.violation_final,
+    );
+    // And specifically, nowhere near the unsafeguarded landing point.
+    assert!(
+        report.violation_final < UNSAFEGUARDED_VIOLATION * 0.5,
+        "initializer accepted (or nearly accepted) the raw linearized \
+         step: violation_final = {} (unsafeguarded lands at {})",
+        report.violation_final,
+        UNSAFEGUARDED_VIOLATION,
+    );
+}
+
+#[test]
+fn poor_linearization_backtracks_before_accepting() {
+    let app = solve_with_ls_init();
+    let report = app
+        .least_square_init_report()
+        .expect("least_square_init_primal ran, so it must report");
+    // alpha = 1 lands at violation ~49.5, alpha = 1/2 at ~11.8,
+    // alpha = 1/4 at ~2.4 -- all worse than 0.995. The first trial
+    // that improves is alpha = 1/8.
+    assert!(
+        report.rejected_trials > 0,
+        "expected the full-length step to be rejected, but {} trials \
+         were rejected (report: {report:?})",
+        report.rejected_trials,
+    );
+    assert!(
+        report.alpha < 1.0,
+        "expected a backtracked step, got alpha = {}",
+        report.alpha,
+    );
+    assert_eq!(report.termination, "accepted");
+    assert!(
+        report.step_norm > 0.0,
+        "an accepted step must have a positive norm",
+    );
+}

--- a/crates/pounce-algorithm/tests/issue_605_safeguarded_ls_init.rs
+++ b/crates/pounce-algorithm/tests/issue_605_safeguarded_ls_init.rs
@@ -123,10 +123,16 @@ impl TNLP for PoorLinearization {
 
 fn solve_with_ls_init() -> IpoptApplication {
     let mut app = IpoptApplication::new();
-    // The Mehrotra cascade is the route that turns
-    // `least_square_init_primal` on.
+    // Set the option under test directly. Before gh#604 registered it
+    // this had to go through `mehrotra_algorithm=yes`, which turns on
+    // `least_square_init_primal` as part of a cascade that also
+    // rewrites `bound_push`, `bound_frac` and `bound_mult_init_val` —
+    // three confounds in a test about one code path. (The report is
+    // the same either way here: this model's `x` bounds are far enough
+    // from every point the safeguard visits that neither push moves
+    // it. The point is that the test no longer depends on that.)
     app.options_mut()
-        .set_string_value("mehrotra_algorithm", "yes", true, false)
+        .set_string_value("least_square_init_primal", "yes", true, false)
         .unwrap();
     // The initializer runs once, before iteration 1, so the report is
     // fully populated no matter where the solve goes afterwards. Cap

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -71,7 +71,7 @@ The knobs, all Ipopt-compatible:
 | `bound_mult_init_val` | `1.0` | Initial bound-multiplier value. |
 | `bound_mult_init_method` | `constant` | `constant` / `mu-based` / `least-square`. |
 | `constr_mult_init_max` | `1e3` | Cap on the least-square constraint-multiplier estimate; `0` keeps `y = 0`. |
-| `least_square_init_primal` | `no` | Replace the starting `x` with the min-norm solution of the linearized constraints before the interior push. |
+| `least_square_init_primal` | `no` | Replace the starting `x` with the min-norm solution of the linearized constraints before the interior push — but only if that actually reduces the true nonlinear violation (see [Safeguarding the least-square start](#safeguarding-the-least-square-start)). |
 | `mu_init` | `0.1` | Initial barrier parameter (monotone strategy). |
 | `start_with_resto` | `no` | Jump straight into feasibility restoration at iteration 1 (aborts if the start is already feasible). |
 
@@ -82,6 +82,49 @@ iteration-0 infeasibility on mostly-linear models (the
 more aggressive `bound_push` / `bound_frac` / `bound_mult_init_val`).
 A point where a function *fails to evaluate* is not fine; see
 [Diagnosing a bad start](#diagnosing-a-bad-start).
+
+### Safeguarding the least-square start
+
+The min-norm solution of the *linearized* constraints is a local model
+step, not automatically a better starting point. Where the Jacobian is
+small relative to the residual, the linearization asks for a very large
+correction and the true nonlinear violation at the far end can be far
+worse than where it started. On `x₀² + x₁² = 1` from `(0.05, 0.05)` the
+Jacobian is `(0.1, 0.1)`, the linearized correction is about 7 units
+long, and the violation at the far end is `48.5` against the `0.995` it
+started with.
+
+So the step is scored before it is taken. Writing `θ(x)` for the
+unscaled max-norm nonlinear violation —
+`max(‖c(x)‖∞, ‖max(d_l − d(x), d(x) − d_u, 0)‖∞)`, the same quantity the
+CLI reports as the model's constraint violation — the initializer:
+
+1. evaluates `θ₀` at your point, after the interior push;
+2. computes the least-square direction `d = x_ls − x₀` once;
+3. tries `α = 1, ½, ¼, …` (at most `least_square_init_max_trials`,
+   default 4), pushing each candidate into the bound interior *before*
+   measuring it, so the accepted merit is the merit of the point the
+   algorithm will really start from;
+4. accepts the first `α` with `θ(α) ≤ (1 − η·α)·θ₀`, where
+   `η = least_square_init_accept_ratio` (default `1e-2`). The linear
+   model predicts `θ → 0` at `α = 1`, so this is exactly "the actual
+   feasibility reduction is at least `η` times the predicted one";
+5. keeps your original `x` if no trial qualifies.
+
+Each trial costs one constraint evaluation; none costs a Jacobian or a
+KKT solve, because only the length of the step changes. A point that is
+already feasible is left alone — no step can improve a violation of
+zero.
+
+The decision is readable after the solve:
+
+```rust
+if let Some(r) = app.least_square_init_report() {
+    println!("{} -> {} (alpha {}, {} rejected, {})",
+             r.violation_initial, r.violation_final,
+             r.alpha, r.rejected_trials, r.termination);
+}
+```
 
 ## Warm-starting the interior-point path
 
@@ -255,9 +298,15 @@ workflows from Python:
 # jitter / bounds midpoint. Feed them to solve_nlp_batch or race them.
 starts = pounce.generate_starts(16, bounds=bounds, seed=0)
 
-# Min-norm repair of a candidate onto the linearized constraints +
-# bounds (the standalone form of least_square_init_primal).
+# Safeguarded sparse elastic repair of a candidate onto the constraints
+# + bounds (the standalone form of least_square_init_primal). Never
+# returns a point whose true nonlinear violation is worse than the one
+# you gave it; pass return_report=True for the diagnostics.
 x0 = pounce.project_to_feasible(problem_obj, x0, lb=lb, ub=ub, cl=cl, cu=cu)
+x0, rep = pounce.project_to_feasible(problem_obj, x0, lb=lb, ub=ub,
+                                     cl=cl, cu=cu, return_report=True)
+# rep.violation_initial / .violation_final / .step_norm /
+# .rejected_trials / .elastic_total / .termination
 
 # Cheap tournament: a few iterations from each start, ranked; continue
 # the winner at full effort with a WarmStart.

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -32,7 +32,12 @@ from ._curve_fit import (
 from ._minima import find_minima, MinimaResult
 from .trf import trf_minimize, TRFResult, TRFConfig
 from ._preflight import preflight, PreflightReport
-from ._starts import generate_starts, project_to_feasible, race_starts
+from ._starts import (
+    ProjectionReport,
+    generate_starts,
+    project_to_feasible,
+    race_starts,
+)
 from ._critical import (
     find_critical_points, find_saddles, reaction_network,
     CriticalPoint, CriticalPointResult, Connection, ReactionNetwork,
@@ -90,6 +95,7 @@ __all__ = [
     "WarmStart",
     "generate_starts",
     "project_to_feasible",
+    "ProjectionReport",
     "race_starts",
     # Convex QP / SOCP (the same solvers also live under ``pounce.qp``)
     "ActiveSet",

--- a/python/pounce/_starts.py
+++ b/python/pounce/_starts.py
@@ -17,11 +17,17 @@ keep the private helpers' signatures stable.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any, List, Optional
 
 import numpy as np
 
-__all__ = ["generate_starts", "project_to_feasible", "race_starts"]
+__all__ = [
+    "generate_starts",
+    "project_to_feasible",
+    "ProjectionReport",
+    "race_starts",
+]
 
 # Bounds at or beyond this magnitude count as infinite (the solver's
 # NLP_*_BOUND_INF sentinels).
@@ -180,6 +186,64 @@ def generate_starts(
     return np.array([_clip(s, bounds) for s in starts])
 
 
+@dataclass
+class ProjectionReport:
+    """What :func:`project_to_feasible` did.
+
+    ``violation_initial`` / ``violation_final`` are the nonlinear
+    violation merit ``‖max(cl − g(x), g(x) − cu, 0)‖₂`` — the *true*
+    constraint violation, evaluated at the returned point, not the
+    linearized one. ``accepted`` is False when no trial improved it
+    and the original point was returned unchanged.
+    """
+
+    violation_initial: float = 0.0
+    violation_final: float = 0.0
+    step_norm: float = 0.0
+    #: Trust-region radius in effect when the last step was accepted.
+    radius: float = 0.0
+    #: Trial steps whose true violation failed the acceptance test.
+    rejected_trials: int = 0
+    #: Outer re-linearizations performed.
+    iterations: int = 0
+    n_constraint_evals: int = 0
+    n_jacobian_evals: int = 0
+    accepted: bool = False
+    termination: str = ""
+    #: Sum of the elastic variables at the last solve. Nonzero means the
+    #: linearization was inconsistent and some rows were relaxed rather
+    #: than the whole solve failing.
+    elastic_total: float = 0.0
+
+
+def _violation(g, g_l, g_u):
+    """Nonlinear violation merit: ``‖max(cl − g, g − cu, 0)‖₂``."""
+    if g.size == 0:
+        return 0.0
+    return float(np.linalg.norm(np.maximum(np.maximum(g_l - g, g - g_u), 0.0)))
+
+
+def _jacobian_coo(problem_obj, x, m, n):
+    """Jacobian at ``x`` as a scipy COO matrix, without ever forming a
+    dense ``m × n``.
+
+    Uses ``jacobianstructure()`` when the problem provides one (the
+    cyipopt convention, and the only shape that carries sparsity).
+    Without it the values are a dense row-major block and we have no
+    choice but to reshape — but we still hand a sparse matrix onward.
+    """
+    import scipy.sparse as sp
+
+    jv = np.asarray(problem_obj.jacobian(x), dtype=float).ravel()
+    if hasattr(problem_obj, "jacobianstructure"):
+        rows, cols = problem_obj.jacobianstructure()
+        rows = np.asarray(rows, dtype=int).ravel()
+        cols = np.asarray(cols, dtype=int).ravel()
+        return sp.coo_matrix((jv, (rows, cols)), shape=(m, n)).tocsc()
+    dense = jv.reshape(m, n)
+    return sp.csc_matrix(dense)
+
+
 def project_to_feasible(
     problem_obj: Any,
     x0,
@@ -189,89 +253,275 @@ def project_to_feasible(
     cl=None,
     cu=None,
     tol: Optional[float] = None,
+    max_iter: int = 3,
+    radius: Optional[float] = None,
+    rho: float = 1e3,
+    sigma: float = 1.0,
+    margin: float = 0.0,
+    accept_ratio: float = 1e-2,
+    max_trials: int = 5,
+    return_report: bool = False,
 ) -> np.ndarray:
-    """Min-norm repair of ``x0`` onto the linearized constraints + bounds.
+    """Repair ``x0`` onto the constraints and bounds by a safeguarded,
+    sparse elastic normal step.
 
-    Solves the convex QP ``min ½‖x − x0‖²`` subject to
-    ``cl ≤ g(x0) + J(x0)(x − x0) ≤ cu`` and ``lb ≤ x ≤ ub`` — the
-    standalone form of the solver's ``least_square_init_primal`` step
-    (see ``docs/src/initialization.md``). For mostly-linear models this
-    slashes iteration-0 infeasibility; for a strongly nonlinear ``g``
-    the linearization is only a local repair (it may be worth a second
-    call at the projected point).
+    Each outer iteration linearizes ``g`` at the current point and
+    solves the sparse convex QP
 
-    Parameters mirror :class:`pounce.Problem` /
-    :func:`pounce.preflight`: a cyipopt-style ``problem_obj`` (only
-    ``constraints`` and ``jacobian`` are used) and bound arrays.
+    .. code-block:: text
 
-    Returns the repaired point. With no constraints it is simply the
-    clip of ``x0`` into the box. Raises ``RuntimeError`` when the
-    projection QP fails (e.g. the linearized constraints are themselves
-    inconsistent).
+        min_{d,p,q}  σ/2 ‖D d‖² + ½ ‖W p‖² + ½ ‖W q‖² + ρ 1ᵀ(p + q)
+        s.t.         cl − p ≤ g(x) + J d + 0 ≤ cu + q
+                     max(lb − x + margin, −Δ/D) ≤ d ≤ min(ub − x − margin, Δ/D)
+                     p, q ≥ 0
+
+    where ``D`` is a diagonal variable scaling, ``W`` a diagonal row
+    scaling, and ``Δ`` the trust-region radius (an ∞-norm/box region,
+    which keeps the subproblem a QP rather than a QCQP and composes
+    directly with the bound box).
+
+    Three things this buys over a plain min-norm projection:
+
+    * **Sparsity.** ``P`` is diagonal and ``J`` is kept in scipy-sparse
+      form throughout, so nothing here allocates an ``n × n`` identity
+      or a dense ``m × n`` Jacobian. On a chain-structured model with
+      ``n = 3000`` that is the difference between ~226 MB and ~5 MB.
+    * **Elasticity.** ``p``/``q`` relax rows the linearization cannot
+      satisfy, so an inconsistent or rank-deficient linearization
+      returns the least-violating step instead of failing outright.
+    * **Safeguarding.** A linearized solution is a local model step,
+      not automatically a better starting point. Every trial step is
+      scored on the *true* nonlinear violation; a trial is accepted
+      only when the actual reduction is at least ``accept_ratio``
+      times the reduction the model predicted. Otherwise ``Δ`` is
+      halved and the step retried, up to ``max_trials`` times. If
+      nothing is accepted, ``x0`` is returned unchanged.
+
+    The returned point therefore *never* has a worse nonlinear
+    violation than ``x0`` — which the previous linearize-once-and-copy
+    behaviour did not guarantee.
+
+    Parameters mirror :class:`pounce.Problem` / :func:`pounce.preflight`:
+    a cyipopt-style ``problem_obj`` (only ``constraints``, ``jacobian``
+    and optionally ``jacobianstructure`` are used) and bound arrays.
+
+    ``sigma`` defaults to ``1``, which makes the ``d``-term exactly the
+    ``½‖x − x0‖²`` of a min-norm projection: when the linearization is
+    consistent the elastics price themselves out (``rho`` is large) and
+    the step is the same minimum-norm repair this function has always
+    returned. Lower it only if you want the repair to travel further in
+    exchange for a smaller residual.
+
+    ``max_iter`` outer re-linearizations (default 3) let the repair
+    follow a curved feasible set instead of stopping at the first
+    tangent step. ``margin`` keeps the result strictly inside the box.
+    ``return_report=True`` additionally returns a
+    :class:`ProjectionReport` with initial/final violation, step norm,
+    rejected-trial count and termination reason.
+
+    Raises ``RuntimeError`` only when the projection QP itself fails
+    for a reason elasticity cannot absorb (e.g. the solver errors).
+    An inconsistent linearization is no longer an error — it is
+    absorbed by the elastic variables and reported through
+    ``ProjectionReport.elastic_total``.
     """
+    import scipy.sparse as sp
+
     from .qp import solve_qp
 
     x0 = np.asarray(x0, dtype=float).ravel()
     n = x0.size
     x_l = np.full(n, -np.inf) if lb is None else np.asarray(lb, dtype=float).ravel()
     x_u = np.full(n, np.inf) if ub is None else np.asarray(ub, dtype=float).ravel()
+    x_l = np.where(x_l <= -_BOUND_INF, -np.inf, x_l)
+    x_u = np.where(x_u >= _BOUND_INF, np.inf, x_u)
+
+    report = ProjectionReport()
 
     m = 0
     if cl is not None:
         m = np.asarray(cl, dtype=float).ravel().size
     if m == 0:
-        return np.clip(x0, x_l, x_u)
+        report.termination = "no constraints; box clip only"
+        x = np.clip(x0, x_l, x_u)
+        report.step_norm = float(np.linalg.norm(x - x0))
+        return (x, report) if return_report else x
 
     g_l = np.asarray(cl, dtype=float).ravel()
     g_u = np.full(m, np.inf) if cu is None else np.asarray(cu, dtype=float).ravel()
+    g_l = np.where(g_l <= -_BOUND_INF, -np.inf, g_l)
+    g_u = np.where(g_u >= _BOUND_INF, np.inf, g_u)
 
-    g0 = np.asarray(problem_obj.constraints(x0), dtype=float).ravel()
-    jv = np.asarray(problem_obj.jacobian(x0), dtype=float).ravel()
-    J = np.zeros((m, n))
-    if hasattr(problem_obj, "jacobianstructure"):
-        rows, cols = problem_obj.jacobianstructure()
-        J[np.asarray(rows, dtype=int), np.asarray(cols, dtype=int)] = jv
-    else:
-        J = jv.reshape(m, n)
+    # Rows split by kind. Equalities go to A; one- or two-sided
+    # inequalities to G. Free rows (no finite side) are dropped —
+    # they constrain nothing and would only add elastic columns.
+    eq_mask = np.isfinite(g_l) & np.isfinite(g_u) & (np.abs(g_u - g_l) <= 1e-12)
+    lo_mask = np.isfinite(g_l) & ~eq_mask
+    hi_mask = np.isfinite(g_u) & ~eq_mask
 
-    # Linearized rows: J x ∈ [cl − g0 + J x0, cu − g0 + J x0].
-    shift = J @ x0 - g0
-    row_lo = g_l + shift
-    row_hi = g_u + shift
+    def _clip_box(v):
+        return np.clip(v, x_l, x_u)
 
-    A_rows, b_rows, G_rows, h_rows = [], [], [], []
-    for i in range(m):
-        lo_f = _lower_present(g_l[i])
-        hi_f = _upper_present(g_u[i])
-        eq = abs(g_u[i] - g_l[i]) <= 1e-12 if (lo_f and hi_f) else False
-        if eq:
-            A_rows.append(J[i])
-            b_rows.append(row_lo[i])
-            continue
-        if hi_f:
-            G_rows.append(J[i])
-            h_rows.append(row_hi[i])
-        if lo_f:
-            G_rows.append(-J[i])
-            h_rows.append(-row_lo[i])
+    x = _clip_box(x0.copy())
+    g = np.asarray(problem_obj.constraints(x), dtype=float).ravel()
+    report.n_constraint_evals += 1
+    theta = _violation(g, g_l, g_u)
+    report.violation_initial = theta
+    report.violation_final = theta
+    best_x = x.copy()
 
-    res = solve_qp(
-        P=np.eye(n),
-        c=-x0,
-        A=np.array(A_rows) if A_rows else None,
-        b=np.array(b_rows) if b_rows else None,
-        G=np.array(G_rows) if G_rows else None,
-        h=np.array(h_rows) if h_rows else None,
-        lb=x_l,
-        ub=x_u,
-        tol=tol,
-    )
-    if not res.success:
-        raise RuntimeError(
-            f"project_to_feasible: projection QP ended with status "
-            f"{res.status!r} — the linearized constraints may be inconsistent"
+    if theta == 0.0:
+        report.termination = "x0 already feasible"
+        report.accepted = True
+        return (best_x, report) if return_report else best_x
+
+    # Variable scaling D: unit for now, but kept explicit so the
+    # trust region and the σ term are expressed in scaled units.
+    d_scale = np.ones(n)
+    # Row scaling W: damp rows whose Jacobian is large so one stiff row
+    # does not dominate the least-squares residual.
+    for _outer in range(max(1, int(max_iter))):
+        report.iterations += 1
+        J = _jacobian_coo(problem_obj, x, m, n)
+        report.n_jacobian_evals += 1
+        row_norm = np.sqrt(np.asarray(abs(J).power(2).sum(axis=1)).ravel())
+        w = 1.0 / np.maximum(row_norm, 1.0)
+
+        if radius is None:
+            delta = max(1.0, float(np.linalg.norm(x, ord=np.inf)))
+        else:
+            delta = float(radius)
+
+        # Elastic column count: one p and one q per constrained row.
+        n_p = int(np.count_nonzero(eq_mask | lo_mask))
+        n_q = int(np.count_nonzero(eq_mask | hi_mask))
+        p_idx = np.full(m, -1, dtype=int)
+        p_idx[eq_mask | lo_mask] = np.arange(n_p)
+        q_idx = np.full(m, -1, dtype=int)
+        q_idx[eq_mask | hi_mask] = np.arange(n_q)
+        nz = n + n_p + n_q
+
+        # Diagonal Hessian — never an n×n identity.
+        w_p = w[eq_mask | lo_mask]
+        w_q = w[eq_mask | hi_mask]
+        P = sp.diags(
+            np.concatenate([sigma * d_scale**2, w_p**2, w_q**2]),
+            format="csc",
         )
-    return np.asarray(res.x)
+        c_lin = np.concatenate([np.zeros(n), rho * np.ones(n_p + n_q)])
+
+        Ep = sp.coo_matrix(
+            (np.ones(n_p), (np.flatnonzero(eq_mask | lo_mask), np.arange(n_p))),
+            shape=(m, n_p),
+        ).tocsc()
+        Eq = sp.coo_matrix(
+            (np.ones(n_q), (np.flatnonzero(eq_mask | hi_mask), np.arange(n_q))),
+            shape=(m, n_q),
+        ).tocsc()
+        # Row block: g + J d + p − q, in the elastic column layout.
+        row_block = sp.hstack([J, Ep, -Eq], format="csc")
+
+        A = b = G = h = None
+        if eq_mask.any():
+            A = row_block.tocsr()[np.flatnonzero(eq_mask)].tocsc()
+            b = (g_l - g)[eq_mask]
+        g_blocks, h_blocks = [], []
+        if hi_mask.any():
+            g_blocks.append(row_block.tocsr()[np.flatnonzero(hi_mask)].tocsc())
+            h_blocks.append((g_u - g)[hi_mask])
+        if lo_mask.any():
+            g_blocks.append(-row_block.tocsr()[np.flatnonzero(lo_mask)].tocsc())
+            h_blocks.append(-(g_l - g)[lo_mask])
+        if g_blocks:
+            G = sp.vstack(g_blocks, format="csc")
+            h = np.concatenate(h_blocks)
+
+        accepted_this_outer = False
+        trial_delta = delta
+        for _trial in range(max(1, int(max_trials))):
+            tr = trial_delta / d_scale
+            d_lo = np.maximum(x_l - x + margin, -tr)
+            d_hi = np.minimum(x_u - x - margin, tr)
+            # A margin wider than the box would invert it; a degenerate
+            # box just pins d to 0 for that component.
+            d_hi = np.maximum(d_hi, d_lo)
+            z_lo = np.concatenate([d_lo, np.zeros(n_p + n_q)])
+            z_hi = np.concatenate([d_hi, np.full(n_p + n_q, np.inf)])
+
+            # `check_psd=False` is a fact here, not an optimism: `P`
+            # is built above as a diagonal with entries `sigma*D**2`
+            # and `w**2`, all non-negative, so it is PSD by
+            # construction. Letting the default fire would run a dense
+            # O(k^3) eigenvalue solve on the (n + n_p + n_q) block
+            # whenever that stays under the solver's 1500 threshold —
+            # which on a sparse model is the single largest allocation
+            # in the whole routine.
+            res = solve_qp(
+                P=P,
+                c=c_lin,
+                A=A,
+                b=b,
+                G=G,
+                h=h,
+                lb=z_lo,
+                ub=z_hi,
+                tol=tol,
+                check_psd=False,
+            )
+            if not res.success:
+                report.rejected_trials += 1
+                trial_delta *= 0.5
+                continue
+
+            z = np.asarray(res.x, dtype=float).ravel()
+            d = z[:n]
+            report.elastic_total = float(np.sum(np.abs(z[n:])))
+
+            # Predicted violation at the linearized point.
+            g_lin = g + J @ d
+            theta_pred = _violation(g_lin, g_l, g_u)
+            predicted = theta - theta_pred
+
+            x_try = _clip_box(x + d)
+            g_try = np.asarray(problem_obj.constraints(x_try), dtype=float).ravel()
+            report.n_constraint_evals += 1
+            theta_try = _violation(g_try, g_l, g_u)
+            actual = theta - theta_try
+
+            # Accept only on a real reduction in the TRUE violation,
+            # and only when it is a defensible fraction of what the
+            # model promised.
+            if (
+                np.isfinite(theta_try)
+                and theta_try < theta
+                and actual >= accept_ratio * max(predicted, 0.0)
+            ):
+                x, g, theta = x_try, g_try, theta_try
+                best_x = x_try
+                report.radius = trial_delta
+                report.accepted = True
+                accepted_this_outer = True
+                break
+
+            report.rejected_trials += 1
+            trial_delta *= 0.5
+
+        if not accepted_this_outer:
+            report.termination = (
+                "no trial improved the nonlinear violation"
+                if not report.accepted
+                else "converged (no further improvement available)"
+            )
+            break
+        if theta <= (tol if tol is not None else 1e-10):
+            report.termination = "violation below tolerance"
+            break
+    else:
+        report.termination = "max_iter reached"
+
+    report.violation_final = theta
+    report.step_norm = float(np.linalg.norm(best_x - x0))
+    return (best_x, report) if return_report else best_x
 
 
 def race_starts(

--- a/python/tests/test_starts.py
+++ b/python/tests/test_starts.py
@@ -89,22 +89,34 @@ def test_project_to_feasible_box_only():
     np.testing.assert_allclose(x, [1.0, 0.0])
 
 
-def test_project_to_feasible_inconsistent_raises():
-    with pytest.raises(RuntimeError):
-        # x0 + x1 == 1 AND x0 + x1 == 3 (same row twice via cl==cu rows).
-        class TwoRows:
-            def constraints(self, x):
-                return np.array([x[0] + x[1], x[0] + x[1]])
+def test_project_to_feasible_inconsistent_is_absorbed_by_elastics():
+    """gh#605 behaviour change: an inconsistent linearization no longer
+    raises. Before #605 the projection QP was infeasible and the helper
+    raised RuntimeError, returning nothing usable. It now carries elastic
+    variables, so the same input yields the least-violating point."""
 
-            def jacobianstructure(self):
-                return (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))
+    # x0 + x1 == 1 AND x0 + x1 == 3 (same row twice via cl==cu rows).
+    class TwoRows:
+        def constraints(self, x):
+            return np.array([x[0] + x[1], x[0] + x[1]])
 
-            def jacobian(self, x):
-                return np.array([1.0, 1.0, 1.0, 1.0])
+        def jacobianstructure(self):
+            return (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))
 
-        pounce.project_to_feasible(
-            TwoRows(), [0.0, 0.0], cl=[1.0, 3.0], cu=[1.0, 3.0]
-        )
+        def jacobian(self, x):
+            return np.array([1.0, 1.0, 1.0, 1.0])
+
+    x = pounce.project_to_feasible(
+        TwoRows(), [0.0, 0.0], cl=[1.0, 3.0], cu=[1.0, 3.0]
+    )
+    # The rows conflict by 2, so the best any point can do is split the
+    # difference: x0 + x1 = 2 leaves a residual of 1 on each row.
+    total = x[0] + x[1]
+    assert 1.0 <= total <= 3.0
+    g = TwoRows().constraints(x)
+    before = np.linalg.norm([1.0 - 0.0, 3.0 - 0.0])
+    after = np.linalg.norm([1.0 - g[0], 3.0 - g[1]])
+    assert after < before
 
 
 def test_race_starts_picks_the_better_basin():
@@ -124,3 +136,178 @@ def test_race_starts_picks_the_better_basin():
     res = pounce.minimize(f, best[0].x, warm_start=ws)
     assert res.success
     assert res.x[0] == pytest.approx(-1.0290, abs=1e-2)
+
+
+# --------------------------------------------------------------------------
+# gh#605 — sparse elastic normal step + safeguarding.
+# --------------------------------------------------------------------------
+class Circle:
+    """g(x) = x0^2 + x1^2 = 1. At (0.05, 0.05) the Jacobian is (0.1, 0.1):
+    the min-norm linearized correction is ~7 units long and lands where the
+    TRUE violation is ~50x worse than it started."""
+
+    def constraints(self, x):
+        x = np.asarray(x, dtype=float)
+        return np.array([x[0] ** 2 + x[1] ** 2])
+
+    def jacobianstructure(self):
+        return (np.array([0, 0]), np.array([0, 1]))
+
+    def jacobian(self, x):
+        x = np.asarray(x, dtype=float)
+        return np.array([2 * x[0], 2 * x[1]])
+
+
+class DupRows:
+    """Two identical rows: J is rank 1 with m = 2."""
+
+    def constraints(self, x):
+        x = np.asarray(x, dtype=float)
+        return np.array([x[0] + x[1], x[0] + x[1]])
+
+    def jacobianstructure(self):
+        return (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))
+
+    def jacobian(self, x):
+        return np.array([1.0, 1.0, 1.0, 1.0])
+
+
+class Chain:
+    """n vars, n-1 rows, 2 nonzeros per row: g_i = x_i + x_{i+1} + 0.1 x_i^2."""
+
+    def __init__(self, n):
+        self.n, self.m = n, n - 1
+        r = np.repeat(np.arange(self.m), 2)
+        c = np.empty(2 * self.m, dtype=int)
+        c[0::2] = np.arange(self.m)
+        c[1::2] = np.arange(1, self.m + 1)
+        self._rows, self._cols = r, c
+
+    def constraints(self, x):
+        x = np.asarray(x, dtype=float)
+        return x[:-1] + x[1:] + 0.1 * x[:-1] ** 2
+
+    def jacobianstructure(self):
+        return (self._rows, self._cols)
+
+    def jacobian(self, x):
+        x = np.asarray(x, dtype=float)
+        v = np.empty(2 * self.m)
+        v[0::2] = 1.0 + 0.2 * x[:-1]
+        v[1::2] = 1.0
+        return v
+
+
+def _violation(prob, x, cl, cu):
+    g = np.asarray(prob.constraints(x), dtype=float)
+    return float(np.linalg.norm(np.maximum(np.maximum(cl - g, g - cu), 0.0)))
+
+
+def test_poor_linearization_never_worsens_violation():
+    """gh#605: the safeguard's contract. The linearized step at (0.05, 0.05)
+    lands where the violation is ~49.5; the returned point must be better
+    than the 0.995 it started with, not worse."""
+    prob = Circle()
+    x0 = np.array([0.05, 0.05])
+    cl = cu = np.array([1.0])
+    v0 = _violation(prob, x0, cl, cu)
+    x, rep = pounce.project_to_feasible(
+        prob, x0, cl=cl, cu=cu, lb=[-10.0, -10.0], ub=[10.0, 10.0],
+        return_report=True,
+    )
+    vN = _violation(prob, x, cl, cu)
+    assert vN <= v0, f"projection made the violation worse: {v0} -> {vN}"
+    assert vN < 0.5 * v0
+    # The full-length step had to be rejected to get there.
+    assert rep.rejected_trials > 0
+    assert rep.violation_final <= rep.violation_initial
+
+
+def test_rank_deficient_jacobian_still_projects():
+    """Duplicate rows with a consistent RHS: rank-1 J, m = 2."""
+    prob = DupRows()
+    cl = cu = np.array([1.0, 1.0])
+    x = pounce.project_to_feasible(
+        prob, [0.0, 0.0], cl=cl, cu=cu, lb=[-10.0, -10.0], ub=[10.0, 10.0]
+    )
+    assert _violation(prob, x, cl, cu) < 1e-6
+    # Min-norm solution of x0 + x1 = 1 is (0.5, 0.5).
+    np.testing.assert_allclose(x, [0.5, 0.5], atol=1e-5)
+
+
+def test_inconsistent_rows_degrade_via_elastics():
+    """gh#605: an inconsistent linearization is absorbed by the elastic
+    variables and returns the least-violating point, instead of raising."""
+    prob = DupRows()
+    # x0 + x1 == 1 AND x0 + x1 == 3 cannot both hold.
+    cl = cu = np.array([1.0, 3.0])
+    x0 = np.array([0.0, 0.0])
+    v0 = _violation(prob, x0, cl, cu)
+    x, rep = pounce.project_to_feasible(
+        prob, x0, cl=cl, cu=cu, lb=[-10.0, -10.0], ub=[10.0, 10.0],
+        return_report=True,
+    )
+    vN = _violation(prob, x, cl, cu)
+    assert vN < v0, f"elastic solve did not improve: {v0} -> {vN}"
+    # It cannot reach zero -- the rows genuinely conflict by 2.
+    assert vN > 1e-3
+    assert rep.elastic_total > 0.0
+
+
+def test_large_sparse_model_allocates_no_dense_blocks():
+    """gh#605 acceptance: no O(n^2) identity, no dense m x n Jacobian.
+
+    A dense `P = eye(n)` alone would be 8*n^2 bytes = 72 MB at n = 3000;
+    a dense Jacobian another 72 MB. Cap well under that but well over
+    what the sparse path legitimately needs.
+    """
+    import tracemalloc
+
+    n = 3000
+    prob = Chain(n)
+    x0 = np.full(n, 0.3)
+    cl = cu = np.ones(n - 1)
+    lb, ub = np.full(n, -10.0), np.full(n, 10.0)
+    # Warm-up so lazily-allocated solver workspace is not attributed to
+    # the measured call.
+    pounce.project_to_feasible(
+        prob, x0, cl=cl, cu=cu, lb=lb, ub=ub, max_iter=1, max_trials=1
+    )
+    tracemalloc.start()
+    x = pounce.project_to_feasible(
+        prob, x0, cl=cl, cu=cu, lb=lb, ub=ub, max_iter=1, max_trials=1
+    )
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    assert peak < 24e6, f"peak allocation {peak / 1e6:.1f} MB suggests a dense block"
+    assert _violation(prob, x, cl, cu) < _violation(prob, x0, cl, cu)
+
+
+def test_projection_preserves_bound_interiority():
+    """A positive `margin` keeps the result strictly inside the box."""
+    prob = Chain(50)
+    n = 50
+    lb, ub = np.zeros(n), np.ones(n)
+    x, rep = pounce.project_to_feasible(
+        prob, np.full(n, 0.9), cl=np.ones(n - 1), cu=np.ones(n - 1),
+        lb=lb, ub=ub, margin=1e-4, return_report=True,
+    )
+    assert np.all(x >= lb + 1e-4 - 1e-9), "left the lower bound margin"
+    assert np.all(x <= ub - 1e-4 + 1e-9), "left the upper bound margin"
+
+
+def test_report_diagnostics_are_populated():
+    prob = Chain(20)
+    x, rep = pounce.project_to_feasible(
+        prob, np.full(20, 0.3), cl=np.ones(19), cu=np.ones(19),
+        lb=np.full(20, -10.0), ub=np.full(20, 10.0), return_report=True,
+    )
+    assert isinstance(rep, pounce.ProjectionReport)
+    assert rep.violation_initial > 0
+    assert rep.violation_final < rep.violation_initial
+    assert rep.step_norm > 0
+    assert rep.iterations >= 1
+    assert rep.n_constraint_evals >= 1
+    assert rep.n_jacobian_evals >= 1
+    assert rep.termination
+    assert rep.accepted


### PR DESCRIPTION
Fixes #605

## Problem

`pounce.project_to_feasible` materialized dense projection matrices, and both it and the solver's `least_square_init_primal` accepted the linearized least-squares point without checking whether it improved the *true* nonlinear constraints. Two independent defects with one root cause.

**1. The projection allocates `O(n²)` on `O(n)` data.** It built `P = eye(n)` and a dense `m × n` Jacobian regardless of sparsity. On a chain model with 2 nonzeros per row, peak allocation quadruples on every doubling of `n` — the signature of a quadratic allocation on linear data. The library's own `PounceSparsityWarning` fires on the way through.

| `n` (chain, 2 nnz/row) | before | after | ratio |
|---|---|---|---|
| 300 | 2.97 MB | 0.41 MB | 7.2× |
| 1000 | 32.32 MB | 1.52 MB | 21× |
| 3000 | 225.66 MB | 4.65 MB | 49× |
| 6000 | 901.31 MB | 9.37 MB | 96× |

Before: ×4.0 per doubling. After: ×2.0 per doubling.

**2. The linearized step can make the true violation far worse.** On `x₀² + x₁² = 1` started at `(0.05, 0.05)`, the Jacobian is `(0.1, 0.1)`: the min-norm linearized correction is ~7 units long and lands at `(5.025, 5.025)`.

| | violation at `x₀` | violation at returned point | |
|---|---|---|---|
| Python, before | 0.995 | **49.50** | 49.7× **worse** |
| Python, after | 0.995 | 0.000976 | 1019× better |
| Rust init, before | 0.995 | **48.50** | 48.7× **worse** |
| Rust init, after | 0.995 | 0.1139 | 8.7× better |

Merit is `‖max(cl − g, g − cu, 0)‖₂` (Python) and `curr_unscaled_nlp_constraint_violation_max()` (Rust) — the quantity the CLI already reports as the model's constraint violation.

**3. An inconsistent linearization is all-or-nothing.** Two conflicting rows (`x₀+x₁ = 1` and `x₀+x₁ = 3`) made the projection QP infeasible, and the helper raised `RuntimeError`, returning nothing usable. Violation 3.162 → 3.162.

## Cause

A linearized solution is a local model step, not automatically a better NLP starting point. Where `‖J‖` is small relative to the residual, the linear model demands a correction long enough to leave the region where it is valid; the true violation at the far end is unrelated to the residual the model predicted it would close. Neither code path had a trust region, a fraction-to-boundary control, or an actual-versus-predicted reduction test, so there was nothing to detect that.

The dense allocation is separate and simpler: `solve_qp` accepts scipy-sparse inputs, and the projection just never built them.

## Fix

**Python** — each outer iteration solves the sparse elastic QP

```
min_{d,p,q}  σ/2‖Dd‖² + ½‖Wp‖² + ½‖Wq‖² + ρ1ᵀ(p+q)
s.t.         cl − p ≤ g(x) + Jd ≤ cu + q
             max(lb − x + margin, −Δ/D) ≤ d ≤ min(ub − x − margin, Δ/D)
             p, q ≥ 0
```

`P` is diagonal, `J` stays scipy-sparse. The trust region is the ∞-norm box, not `‖Dd‖₂ ≤ Δ` as the issue wrote it: the box keeps the subproblem a QP rather than a QCQP and composes directly with the bound box, at the cost of a slightly larger trust region in the corners. `P` is PSD by construction, so `solve_qp`'s dense `O(k³)` PSD check is disabled — with the elastic columns widening the variable block, that check had become the largest single allocation left (it is what made `n=300` cost 6.7 MB before it was turned off).

`σ` defaults to **1**, not the issue's small regularizer. At `σ = 1e-8` the step-norm term is negligible against `ρ = 1e3` and the QP returns an arbitrary feasible point: the existing `test_project_to_feasible_equality_and_inequality` caught this, returning `(0.155, 0.845)` where min-norm is `(0.5, 0.5)`. At `σ = 1` the `d` term is exactly the `½‖x − x0‖²` of a min-norm projection, and with a consistent linearization the elastics price themselves out.

**Rust** — the direction is computed once, then walked back: `α = 1, ½, ¼, …`, accepting the first with `θ(α) ≤ (1 − ηα)θ₀`. Since the linear model predicts `θ → 0` at `α = 1`, predicted reduction is `αθ₀` and this is exactly "actual reduction ≥ η × predicted". Each candidate is pushed into the bound interior *before* being measured, so the accepted merit is the merit of the point the algorithm really starts from and interiority holds by construction. If nothing qualifies, the user's point is kept.

Each trial costs one constraint evaluation and no Jacobian or KKT solve.

**Resolved — `least_square_init_primal` is now a registered option, and this branch is rebased onto that.** The original plan rejected registering it here because PR #613 was already doing exactly that and duplicating it would have conflicted. #613 has since merged (it is in this branch's merge base), so the option is settable from every frontend and this branch simply uses it. The tests now set `least_square_init_primal=yes` directly rather than reaching the path through `mehrotra_algorithm=yes`, whose cascade also rewrites `bound_push`, `bound_frac` and `bound_mult_init_val` — three confounds in a test about one code path. The report is the same either way on that model (its `x` bounds are far enough from every point the safeguard visits that neither push moves it); the point is that the test no longer depends on that.

**Corrected:** `LeastSquareInitReport`'s doc comment claimed the report is "printed at `print_level >= 5`". Nothing prints it — there is no such call site. It is reachable only through `IpoptApplication::least_square_init_report()`, and the comment now says so.

**Deliberate:** the full-length trial reuses `x_ls` itself rather than `x0 + 1.0·(x_ls − x0)`. Those differ in the last bit, which was enough to move two fixtures by an iteration each; reusing `x_ls` keeps an accepted step bit-identical so the only trajectory change is on models where the step is actually rejected.

## Merging #613

#613 registered the cold-start initialization options and refused two unimplemented option *values*. It touched `init/default.rs`, `application.rs`, `CHANGELOG.md` and `docs/src/initialization.md` — most of this branch's footprint — so the branch was merged against it and re-measured rather than re-reported.

`CHANGELOG.md` was the only textual conflict: both changes prepended to `[Unreleased]`. Both entries are kept.

The code files auto-merged, and the hunks compose. In `init/default.rs` the two changes are adjacent but disjoint: this branch rewrote step 1.5 (the `least_square_init_primal` block), #613 removed the `bound_mult_init_method` fallback in step 3 and the `cap_constraint_multipliers` helper it was the only caller of. That removal did not land inside rewritten code, and nothing references the deleted helper. #613's new `mu-based` refusal sits *after* the safeguard rather than inside it, so a caller who builds the initializer directly with both `least_square_init_primal=yes` and `bound_mult_init_method=mu-based` pays for the safeguard's constraint evaluations before being refused; the refusal a real caller sees is raised at the application layer before any work, so this is only reachable from the library backstop. In `application.rs` the two changes do not touch the same regions.

`least_square_init_max_trials` and `least_square_init_accept_ratio` are struct fields, never read from the options registry, so they do not trip #613's new "read implies registered" invariant test. `docs/src/initialization.md` now says they are not settable, which #613 made worth stating: every other knob on that page now is.

**One thing did not compose, and it was not in a merged hunk.** #613 added `option_behavior::least_square_init_primal_replaces_the_starting_point`, which asserts that `least_square_init_primal=yes` moves the iterate to the stub solver's `x_ls = [1, 3]`. Its stub NLP has `c(x) ≡ 1.0` — a *constant* violation, which no step can reduce — so under this branch the safeguard correctly declines the step and the starting point stays at the user's pushed `x0`. The test encoded the pre-#605 contract: take the step unconditionally. The stub's row is now `c(x) = x0 + x1 − 4`, which `x_ls = [1, 3]` satisfies exactly. That keeps #613's assertion and its intent — the option is wired and visibly moves the iterate, not a silent no-op — and makes the stub more honest than it was, since `x_ls` is supposed to be the point that solves the linearized constraints and now is one. All seven `option_behavior` tests pass.

## Blast radius

Baseline: **`70bf53ded3d893cfa2da6ead5195fda5ac096f68`** (`main` with #613), release binary built from a `git worktree` at that commit, same machine, both sides swept with `scripts/sweep-fixtures.sh`.

**Default options: bit-identical across all 57 fixtures.** `least_square_init_primal` is `no` by default, so nothing moves unless it is turned on. Since #613 there are two ways to turn it on — setting it directly, or `mehrotra_algorithm=yes`, whose cascade turns it on — and both are swept below.

### `mehrotra_algorithm=yes`: 12 lines move

| | baseline | after |
|---|---|---|
| fixtures solved | 27 | 27 (same set) |
| objectives on those 27 | — | all bit-identical |
| total iterations across those 27 | 292 | 292 |

**The set of moving fixtures is exactly the twelve measured against the old `5d8ad36` baseline, and each moves the same way.** #613 was itself bit-identical across the corpus, and re-measuring against it reproduces the earlier result line for line. No fixture changed between success and failure in either direction.

Every initializer decision below was re-measured against `70bf53d` from a temporary probe compiled into the initializer, not carried over from the earlier report:

| fixture | movement | initializer decision |
|---|---|---|
| `eigena2` | Succeeded, 21→20 it, same obj | full step rejected, accepted α=½ (θ 1.0→0.25) |
| `eigenb2` | Succeeded, 20→21 it, same obj | full step rejected, accepted α=½ (θ 1.0→0.25) |
| `boxed_qp_fixed_var` | RestorationFailed both | θ₀=0, step declined ("x0 already feasible") |
| `unbounded_cubic` | RestorationFailed both | θ₀=0, step declined |
| `unbounded_exp` | ErrorInStepComputation → InvalidNumberDetected | θ₀=0, step declined |
| `pooling_rt2stp` | RestorationFailed both | all 4 trials rejected, declined (θ 31.4 unchanged) |
| `deb7` | InfeasibleProblemDetected both | all 4 trials rejected, declined (θ 287.5 unchanged) |
| `hs71_obj1e8` | RestorationFailed → InfeasibleProblemDetected | all 4 trials rejected, declined (θ 1.76 unchanged) |
| `issue_372_infeasible_bounds` | RestorationFailed both | all 4 trials rejected, declined (θ 0.22 unchanged) |
| `cresc4` | InfeasibleProblemDetected → RestorationFailed | accepted α=¼ (θ 14014.45→13869.92) |
| `user_scaling_suffix` | RestorationFailed → InfeasibleProblemDetected | accepted α=⅛ (θ 0.5→0.4375) |
| `user_scaling_var_suffix` | RestorationFailed → InfeasibleProblemDetected | accepted α=⅛ (θ 0.5→0.4375) |

`eigena2`/`eigenb2` are the only two that solve; they move by one iteration in opposite directions and cancel. The other ten all fail under Mehrotra on both sides — Mehrotra disables globalization outright (`adaptive_mu_globalization=never-monotone-mode`), and all ten solve or fail identically under default options. Only *how* they fail changes.

`airport`, the LP-shaped case the code comments call this step critical for, still accepts the **full-length step at α=1 with zero rejections** (θ 103.6 → 25.96) and does not move: 9 iterations, `RestorationFailed`, identical objective on both sides.

### `least_square_init_primal=yes`: 14 lines move — new, and not all good

This route did not exist when the original sweep was run: before #613 the option was not settable, so `mehrotra_algorithm=yes` was the only way in. It is now the cleaner way to reach the changed path, since it changes one thing instead of four, and it shows a materially different picture that the Mehrotra sweep hides.

| | baseline | after |
|---|---|---|
| `SolveSucceeded` | 46 | **44** |
| solved-or-acceptable | 46 | 46 (same set) |
| total iterations across those 46 | 2067 | **1687** (−18%) |
| fixtures using fewer iterations | — | 10 |
| fixtures using more iterations | — | 2 |

Ten fixtures get to the same answer in fewer iterations, several by a lot: `deb7` 479→202, `pooling_rt2stp` 134→81, `hs71_obj1e8` 19→11, `eigena2` 78→65, `linear_eq_aggregation` and `..._row_constant` 8→6, `user_scaling_suffix` and `..._var_suffix` 11→8, `boxed_qp_fixed_var` 9→6, `csfi2` 53→35.

**Three regressions, stated plainly — now tracked as #616:**

- **`csfi2` and `eigenb2` come back `SolvedToAcceptableLevel` where the baseline returned `SolveSucceeded`.** Both still return an objective (`csfi2` bit-identical at 55.0176045, `eigenb2` 1.6 → 1.599999991), but they no longer meet the tight tolerance. This is a real quality downgrade on two of 57 models. Verified deterministic across repeated runs.
- **`pooling_rt2stp` lands on a worse local optimum**, −4391.83 → −3273.95. `deb7` moves the other way on the same mechanism, 249.75 → 97.56 (better). Both are nonconvex; a different starting point is entitled to a different local minimum, and the safeguard changes the starting point by design. It is still a worse answer on that model.
- `unbounded_cubic` takes 290 iterations to reach `DivergingIterates` where the baseline took 91. It diverges either way.

None of this is reachable without explicitly setting the option, and the default-options sweep is bit-identical. But "the safeguard never makes things worse" is true only of the *starting point's violation*, which is what it measures and guarantees. It is not true of the trajectory that follows, and on this route two fixtures pay for it.

**Behaviour changes, all deliberate and all in the CHANGELOG:**

- `project_to_feasible` no longer raises `RuntimeError` on an inconsistent linearization — the issue asks for elastic handling instead of an all-or-nothing solve. `test_project_to_feasible_inconsistent_raises` was rewritten to pin the new contract.
- It re-linearizes up to `max_iter` (default 3) times rather than once, so it spends more constraint evaluations and returns a smaller residual. `max_iter=1` restores the old budget.
- The Rust initializer leaves an already-feasible start alone rather than replacing it with the min-norm point. No step can improve a violation of zero, but it does change what three already-failing Mehrotra fixtures do.

**Not measured:** `nuffield2_trap`, named in the code comments as the model this step exists for, is not in the CLI fixture corpus, so the sweep says nothing about it.

## Feasibility gained per evaluation

The benchmark the issue asks for, both methods in one process on one machine. The baseline is given repeated calls, since its own docstring recommends them.

| model | evals before → after | gain/eval before → after | evals to θ<1e-6 |
|---|---|---|---|
| chain n=300 | 10 → 9 | 0.676 → 0.751 | 9 → 8 |
| chain n=1000 | 10 → 9 | 1.236 → 1.373 | 9 → 8 |
| chain n=3000 | 10 → 9 | 2.141 → 2.379 | 9 → 8 |
| circle | 19 → 10 | 0.052 → 0.099 | never / never |
| rank-deficient | 4 → **5** | 0.354 → **0.283** | 3 → **4** |
| inconsistent rows | 3 (raised) → 9 | 0 → 0.194 | never / never |

Better on four of six. **Rank-deficient is a real regression: one extra constraint evaluation**, the price of verifying a step that was going to be accepted anyway. On a model where the linearization is already good, the safeguard is pure overhead. That is the cost of the guarantee and it is bounded at one evaluation per accepted step. Inconsistent rows go from "raises, returns nothing" to 9 evaluations for a real improvement — more work, but the baseline number is not a saving.

## Tests

`crates/pounce-algorithm/tests/issue_605_safeguarded_ls_init.rs` (2 tests) and 6 new tests in `python/tests/test_starts.py`. Plus the stub-row fix to #613's `option_behavior` module described under **Merging #613** above.

**Verified to fail on the parent commit, for the right reason:**

Python — the three new assertions were run against the verbatim pre-#605 implementation with the new-API kwargs stripped, so each failure is behavioural rather than a `TypeError`:

```
FAIL poor_linearization_never_worsens_violation
     AssertionError: projection made the violation worse: 0.995 -> 49.501249991749454
FAIL inconsistent_rows_degrade_via_elastics
     RuntimeError: project_to_feasible: projection QP ended with status
     'primal_infeasible' — the linearized constraints may be inconsistent
FAIL large_sparse_model_allocates_no_dense_blocks
     AssertionError: peak allocation 225.6 MB suggests a dense block
```

Rust — the parent exposes no report accessor, so the assertion was expressed against a probe compiled into the parent's initializer in the baseline worktree:

```
GH605-PARENT-PROBE theta0=0.995000 thetaN=48.501200
```

**Not pinned:** the end-to-end solve on the poor-linearization model. It hits its iteration cap on both sides — a nonlinear equality from that start is not something this configuration solves regardless of where it begins. The tests assert on the initializer's own diagnostics instead, which is the unit of behaviour that actually changed.

## Follow-up filed

- **#616** — the three `least_square_init_primal=yes` regressions above. Unassigned; needs an owner.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms, alongside #613's
- [x] Book page under `docs/src/` updated (`initialization.md`; existing page, already in `SUMMARY.md`)
- [x] `cargo fmt --all -- --check` clean; `cargo clippy --workspace --exclude pounce-hsl --all-targets -- -D clippy::correctness -D clippy::suspicious` (CI's gate) clean
- [x] `cargo test --workspace --exclude pounce-hsl --no-fail-fast` — 2928 passed / 0 failed / 6 ignored across 225 test binaries; Python 779 passed / 38 skipped; `check-release-consistency.sh` and `check-docs-consistency.sh` both OK
- [x] Every claim in this body is re-checked against the merged diff and re-measured against `70bf53d`

**One pre-existing flaky test.** `optimize_hs71::hs071_max_cpu_time_terminates` sets `max_cpu_time = 1e-12` and expects `MaximumCpuTimeExceeded`; when the solve beats the timer's granularity it returns `SolveSucceeded` instead. It fails intermittently on the *unmodified* `70bf53d` baseline at about the same rate as on this branch (2 of 6 runs there, 1 of 5 here, same binary, no code change between runs). It touches nothing this branch changes and is not a regression from it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXUyBXwW7GQQAX6byMXnw4)_