### PR TITLE
Add residual-adaptive, complete NLP warm-start recentering (#606)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,74 @@ changes.
 
 ## [Unreleased]
 
+- **A warm start now completes the iterate you gave it, and adapts the
+  barrier to how good it was** (#606). Two things were wrong with the
+  interior-point warm start, and both were invisible.
+
+  First, you cannot seed every multiplier block.
+  `TNLP::get_starting_point` — what `lagrange` / `zl` / `zu` reach on
+  every frontend — carries the constraint multipliers and the
+  *variable*-bound multipliers. The IPM also needs a multiplier for
+  each inequality row's slack, and no frontend has a field for one. On
+  every warm start POUNCE has ever run, those arrived as zero and were
+  floored at `warm_start_mult_bound_push` — a constant with no relation
+  to the slacks it is paired against. The "warm" point handed to the
+  solver was therefore not a stationary point of anything, and the
+  first few iterations went on repairing it.
+
+  Second, `mu_init` was taken on trust. A restart at the optimum and a
+  stale point from a different parameter both started on exactly the
+  barrier the caller named.
+
+  `warm_start_recentering` (new, default `residual`) fixes both. A
+  bound multiplier that arrives as exactly `0` or `NaN` is not a legal
+  barrier multiplier, so it was never a seed; it is re-derived from the
+  stationarity identity against the multipliers you *did* supply, and
+  floored at `μ / slack` so an inactive bound still gets the value
+  complementarity implies. A constraint-multiplier block of all zeros
+  goes through the same regularized least-squares solve the cold path
+  uses (and the same `constr_mult_init_max` cap). And `mu` is raised to
+  the point's measured complementarity when that overshoots `mu_init`
+  by more than 10x. `warm_start_target_mu` still pins `mu` outright,
+  and `warm_start_recentering=none` restores the old behaviour exactly.
+
+  Measured over the 27 parametric paths of `benchmarks/warmstart`,
+  against `70bf53de`: a full warm start re-converges in 677 iterations
+  instead of 715 (-5.3%) and 1068 objective evaluations instead of 1207
+  (-11.5%); a partial one (bound multipliers kept, `lagrange` dropped)
+  in 709 instead of 718. Exact same-model restarts improve or hold on
+  every family, two of them from 2 iterations to 0. The CLI fixture
+  sweep is bit-identical across all 57 models both cold and with
+  `warm_start_init_point=yes`; under the tightened-push recipe from
+  `docs/src/initialization.md` three models move (`hs13_bigstart`
+  30 -> 29, `jit1_boxed` 16 -> 17, `jit1_node` 19 -> 21), same status
+  and same objective.
+
+  Deliberately **not** reconstructed: a seed carrying no dual
+  information at all. Completing a partial warm start is well-posed;
+  manufacturing a whole one from a primal point is not, and doing it
+  anyway measured 1102 -> 1211 iterations on the same corpus. Such a
+  seed is reported as `unseeded` and left exactly as before.
+
+  What the initializer decided is now readable rather than guessed at:
+  `info["warm_start"]` from Python,
+  `IpoptApplication::warm_start_diagnostics()` from Rust, and `wz` /
+  `wy` / `wy0` / `wmu` tags on the `print_level=5` iteration line.
+
+- **`warm_start_same_structure` and `warm_start_entire_iterate` are
+  refused instead of silently doing nothing** (#606). Both parsed, set
+  a field on the initializer, and changed nothing whatsoever — verified
+  bit-for-bit before the change: same iteration count, same objective,
+  same KKT error to the last digit with either set to `yes`. They name
+  Ipopt's `TNLP::GetWarmStartIterate` surface, which POUNCE does not
+  expose, so they now fail with a message pointing at
+  `warm_start_init_point=yes` — the route that does carry the primal
+  point and every multiplier block the TNLP surface has. Both still
+  *parse*, so an `ipopt.opt` written for Ipopt loads unchanged, and
+  `=no` (the registered default) asks for nothing and keeps working.
+  The registry invariant test from #604 now runs over the `Warm Start`
+  category too, which is what would have caught this.
+
 - **The cold-start initialization options are settable** (#604).
   `bound_push`, `bound_frac`, `slack_bound_push`, `slack_bound_frac`,
   `constr_mult_init_max`, `bound_mult_init_val`, `bound_mult_init_method`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,7 +110,22 @@ changes.
   `warm_start_init_point=yes`; under the tightened-push recipe from
   `docs/src/initialization.md` three models move (`hs13_bigstart`
   30 -> 29, `jit1_boxed` 16 -> 17, `jit1_node` 19 -> 21), same status
-  and same objective.
+  and same objective. Re-swept against `369f13e` after #605 landed:
+  the same three lines, and no others.
+
+  The reconstruction reaches a model with only equality rows or only
+  inequality rows, which is most real NLPs and 12 of the 14 families in
+  `benchmarks/warmstart`. It did not in the first cut of this change —
+  an empty multiplier block read as "seeded", so the least-squares step
+  was skipped and then reported as though it had run. What that repair
+  is worth, measured on the stationarity residual the warm point is
+  handed to the solver with: `mpc_horizon_10` 2.3e+1 -> 3.7e-6,
+  `nmpc_vanderpol` 9.7e+0 -> 4.3e-6, `simplex_proj` 4.1e-1 -> 2.0e-2.
+  In iterations it is close to a wash on that corpus — 3052 -> 3050
+  over 42 partial-seed paths, 8 of them moving, the best `rosenbrock_ring`
+  at `tiny` 49 -> 43 and the worst `nmpc_vanderpol` at `large` 195 -> 209.
+  A full-seed run does not move at all, because a supplied `lagrange`
+  was never the block at issue.
 
   Deliberately **not** reconstructed: a seed carrying no dual
   information at all. Completing a partial warm start is well-posed;

--- a/crates/pounce-algorithm/src/alg_builder.rs
+++ b/crates/pounce-algorithm/src/alg_builder.rs
@@ -375,14 +375,12 @@ impl Default for InitOptions {
 /// [`WarmStartIterateInitializer`]. Defaults mirror
 /// `IpWarmStartIterateInitializer.cpp:RegisterOptions`.
 ///
-/// Wired today: `mult_init_max` (clamps |y_c|, |y_d| and caps z/v
-/// blocks) and `target_mu` (overrides `data.curr_mu` at iter 0).
-/// The remaining knobs (`bound_push`, `bound_frac`, `slack_bound_push`,
-/// `slack_bound_frac`, `mult_bound_push`, `entire_iterate`,
-/// `same_structure`) are stored on the initializer but not yet
-/// consumed — `WarmStartIterateInitializer::set_initial_iterates`
-/// currently trusts the caller-populated `data.curr` rather than
-/// re-running the upstream `push_variables` machinery.
+/// Wired today: every knob above plus the gh#606 recentering pair.
+/// `warm_start_entire_iterate` / `warm_start_same_structure` are
+/// deliberately *not* here — they name the `GetWarmStartIterate` TNLP
+/// surface pounce does not expose, and are refused by
+/// [`crate::unimplemented_options`] rather than parsed into a field
+/// nothing reads (gh#606).
 #[derive(Debug, Clone)]
 pub struct WarmStartOptions {
     pub bound_push: Number,
@@ -392,14 +390,51 @@ pub struct WarmStartOptions {
     pub mult_bound_push: Number,
     pub mult_init_max: Number,
     pub target_mu: Number,
-    pub entire_iterate: bool,
-    pub same_structure: bool,
     /// The value a NaN-seeded bound multiplier takes: NaN in a
     /// user-supplied `z`/`v` seed means "unseeded, use the default".
     /// Threaded from `builder.init.bound_mult_init_val` at build time
     /// so the Mehrotra override and any user setting stay the single
     /// source of truth.
     pub bound_mult_init_val: Number,
+    /// `constr_mult_init_max`, threaded from the init options at build
+    /// time (gh#606). The warm path's reconstruction of an unseeded
+    /// equality-multiplier block runs the *cold* path's least-squares
+    /// solve, so it is capped by the cold path's cap — not by
+    /// `warm_start_mult_init_max`, which caps multipliers a caller
+    /// actually supplied and is three orders looser (1e6 vs 1e3).
+    /// Measured: on `redundant_rows`, whose duplicated equality rows
+    /// make the least-squares system singular, the looser cap let an
+    /// arbitrary estimate through and cost 7 -> 25 iterations.
+    pub constr_mult_init_max: Number,
+    /// `warm_start_recentering` (gh#606). Whether the initializer
+    /// measures the supplied point and adapts μ / the multiplier fills
+    /// to it, or keeps the pre-gh#606 universal constants.
+    pub recentering: WarmStartRecentering,
+}
+
+/// Value of `warm_start_recentering` (gh#606).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WarmStartRecentering {
+    /// Pre-gh#606 behaviour: constant pushes and floors, `y` left at
+    /// zero when unseeded, μ untouched unless `warm_start_target_mu`
+    /// is set. The kill switch.
+    None,
+    /// Measure the supplied iterate's residuals and derive μ, the
+    /// bound-multiplier fills, and the equality-multiplier
+    /// reconstruction from them.
+    Residual,
+}
+
+impl WarmStartOptions {
+    /// `mult_init_max` as a usable cap: the registered `0` sentinel
+    /// means "no cap".
+    pub(crate) fn mult_init_max_or_inf(&self) -> Number {
+        if self.mult_init_max > 0.0 {
+            self.mult_init_max
+        } else {
+            Number::INFINITY
+        }
+    }
 }
 
 impl Default for WarmStartOptions {
@@ -412,26 +447,27 @@ impl Default for WarmStartOptions {
             mult_bound_push: 1e-3,
             mult_init_max: 1e6,
             target_mu: 0.0,
-            entire_iterate: false,
-            same_structure: false,
             // seeded from the init options so the default has one
             // home; build() re-resolves it from the live init options
             // anyway (see `resolved_warm_options`)
             bound_mult_init_val: InitOptions::default().bound_mult_init_val,
+            constr_mult_init_max: InitOptions::default().constr_mult_init_max,
+            recentering: WarmStartRecentering::Residual,
         }
     }
 }
 
 /// The warm-start options as the initializer actually receives them:
-/// `bound_mult_init_val` comes from the (option-read,
-/// Mehrotra-resolved) init options, never from `WarmStartOptions`'s
-/// own copy. Split out of `build()` so the threading is testable.
+/// `bound_mult_init_val` and `constr_mult_init_max` come from the
+/// (option-read, Mehrotra-resolved) init options, never from
+/// `WarmStartOptions`'s own copy. Split out of `build()` so the threading is testable.
 pub(crate) fn resolved_warm_options(
     warm: &WarmStartOptions,
     init: &InitOptions,
 ) -> WarmStartOptions {
     let mut w = warm.clone();
     w.bound_mult_init_val = init.bound_mult_init_val;
+    w.constr_mult_init_max = init.constr_mult_init_max;
     w
 }
 

--- a/crates/pounce-algorithm/src/application.rs
+++ b/crates/pounce-algorithm/src/application.rs
@@ -235,6 +235,11 @@ pub struct IpoptApplication {
     /// re-optimize branch of `WarmStartIterateInitializer` keeps the
     /// installed iterate. Wire-set via [`Self::set_warm_start_iterate`].
     warm_start_iterate: Option<crate::debug::IterateSnapshot>,
+    /// The warm-start initializer's verdict on the most recent solve's
+    /// supplied iterate (gh#606). Lifted off the solve-local
+    /// `IpoptData` so a caller can read it after `optimize_tnlp`
+    /// returns; `None` when the last solve was a cold start.
+    warm_start_diag: RefCell<Option<crate::init::warm_start::WarmStartDiagnostics>>,
     /// Caller-supplied fill-reducing permutation for the KKT linear
     /// solver (pounce#180 item 1 / FERAL#107). When `Some`, it overrides
     /// whatever `feral_ordering` / `POUNCE_FERAL_ORDERING` resolves to,
@@ -312,6 +317,7 @@ impl IpoptApplication {
             sqp_warm_start: None,
             sqp_last_working_set: None,
             warm_start_iterate: None,
+            warm_start_diag: RefCell::new(None),
             external_ordering: None,
             kkt_schur_block: None,
         }
@@ -631,6 +637,19 @@ impl IpoptApplication {
 
     pub fn statistics(&self) -> SolveStatistics {
         self.statistics.borrow().clone()
+    }
+
+    /// What the warm-start initializer made of the iterate the caller
+    /// supplied to the most recent solve (gh#606): the residuals it
+    /// measured, whether each multiplier block was accepted,
+    /// reconstructed or discarded, and the barrier parameter it
+    /// settled on.
+    ///
+    /// `None` when the last solve was a cold start
+    /// (`warm_start_init_point=no`), or when no solve has run. Reset at
+    /// the top of every solve, like [`Self::timing_stats`].
+    pub fn warm_start_diagnostics(&self) -> Option<crate::init::warm_start::WarmStartDiagnostics> {
+        self.warm_start_diag.borrow().clone()
     }
 
     /// Shared timing accumulator from the most recent `optimize_tnlp`
@@ -2147,6 +2166,10 @@ impl IpoptApplication {
         // via [`Self::timing_stats`].
         let timing = Rc::new(TimingStatistics::new());
         *self.timing.borrow_mut() = Rc::clone(&timing);
+        // gh#606: same lifetime as the timings — a solve that bails out
+        // before the initializer runs must not report the previous
+        // solve's warm-start verdict.
+        *self.warm_start_diag.borrow_mut() = None;
         // Gate the *detailed* per-subsystem timers on `timing_statistics`
         // (default "no"), matching upstream Ipopt. Without this, every
         // timed `eval_*` / phase section pays two `getrusage` syscalls per
@@ -2621,6 +2644,10 @@ impl IpoptApplication {
                 // for predictor–corrector path following (pounce#86).
                 stats.final_mu = d.curr_mu;
             }
+            // gh#606: the warm-start initializer's verdict on what the
+            // caller supplied. Lifted off the (solve-local) data handle
+            // so it outlives the solve; `None` on a cold start.
+            *self.warm_start_diag.borrow_mut() = alg.data.borrow().warm_start_diagnostics.clone();
             stats.total_wallclock_time_secs = t_start.elapsed().as_secs_f64();
             // Restoration-phase audit counters (pounce#12). Zero on
             // problems where restoration never fires; populated by
@@ -3501,11 +3528,6 @@ impl IpoptApplication {
                 builder.warm_start_init_point = v;
             }
         }
-        if let Ok((v, found)) = self.options.get_bool_value("warm_start_same_structure", "") {
-            if found {
-                builder.warm.same_structure = v;
-            }
-        }
         if let Some(v) = read_num("warm_start_bound_push") {
             builder.warm.bound_push = v;
         }
@@ -3527,12 +3549,18 @@ impl IpoptApplication {
         if let Some(v) = read_num("warm_start_target_mu") {
             builder.warm.target_mu = v;
         }
-        if let Ok((v, found)) = self
-            .options
-            .get_string_value("warm_start_entire_iterate", "")
-        {
+        // gh#606: residual-adaptive recentering. `warm_start_entire_iterate`
+        // and `warm_start_same_structure` used to be parsed here into
+        // fields nothing read; they are refused by
+        // `unimplemented_options` instead (they name the
+        // `GetWarmStartIterate` TNLP surface pounce does not expose).
+        if let Ok((v, found)) = self.options.get_string_value("warm_start_recentering", "") {
             if found {
-                builder.warm.entire_iterate = v == "yes";
+                builder.warm.recentering = if v.eq_ignore_ascii_case("none") {
+                    crate::alg_builder::WarmStartRecentering::None
+                } else {
+                    crate::alg_builder::WarmStartRecentering::Residual
+                };
             }
         }
 

--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -261,15 +261,26 @@ impl IterateInitializer for WarmStartIterateInitializer {
             // circular, and measurably so (see the fn docs). Only a
             // caller-supplied `y` earns it.
             if diag.eq_duals != BlockVerdict::Reconstructed {
-                refine_bound_duals_from_stationarity(data, cq, nlp, &self.opts, mu_hat, &unseeded);
-                diag.stationarity_split = true;
+                // Reported from the function's own return value, not
+                // from the fact that it was called: it returns early
+                // with nothing to do when every bound multiplier
+                // arrived seeded, and claiming the split ran there
+                // made `info["warm_start"]` say something untrue
+                // (gh#606 review).
+                diag.stationarity_split = refine_bound_duals_from_stationarity(
+                    data, cq, nlp, &self.opts, mu_hat, &unseeded,
+                );
             }
             Some(mu_hat)
         } else if self.opts.recentering == WarmStartRecentering::Residual {
             diag.primal_residual = cq.borrow().curr_primal_infeasibility_max();
             diag.bound_duals = BlockVerdict::Unseeded;
             diag.eq_duals = BlockVerdict::Unseeded;
-            Some(safe_mu(data.borrow().curr_mu))
+            // Only the `is_some()` is read on this path — `final_mu`
+            // re-reads `curr_mu` itself — so this carried a clamp that
+            // was computed and thrown away. Left as the plain value so
+            // it does not read as a policy it never was.
+            Some(data.borrow().curr_mu)
         } else {
             None
         };
@@ -538,13 +549,15 @@ fn refine_bound_duals_from_stationarity(
     opts: &WarmStartOptions,
     mu_hat: Number,
     unseeded: &[Vec<bool>; 4],
-) {
+) -> bool {
+    // `true` only when the split actually rewrote a multiplier, so the
+    // caller can report `stationarity_split` honestly (gh#606 review).
     if unseeded.iter().all(|m| m.is_empty()) {
-        return;
+        return false;
     }
     let curr = match data.borrow().curr.clone() {
         Some(c) => c,
-        None => return,
+        None => return false,
     };
 
     // r_x = ∇f + J_cᵀ y_c + J_dᵀ y_d, and r_s = −y_d.
@@ -621,7 +634,7 @@ fn refine_bound_duals_from_stationarity(
     }
 
     if rebuilt.iter().all(|r| r.is_none()) {
-        return;
+        return false;
     }
     let pick = |i: usize, orig: &Rc<dyn Vector>| -> Rc<dyn Vector> {
         rebuilt[i].clone().unwrap_or_else(|| Rc::clone(orig))
@@ -637,6 +650,7 @@ fn refine_bound_duals_from_stationarity(
         pick(3, &curr.v_u),
     );
     data.borrow_mut().set_curr(new_curr);
+    true
 }
 
 /// `sign · Pᵀ r`, as a plain slice of length `n_out`. `P` is one of the
@@ -782,11 +796,24 @@ fn final_mu(data: &IpoptDataHandle, cq: &IpoptCqHandle, diag: &mut WarmStartDiag
     diag.dual_residual = inf_du;
 
     let mu_in = data.borrow().curr_mu;
-    let mut mu = mu_in;
-    if compl.is_finite() && compl > MU_ESCALATION_TRIGGER * mu_in {
-        mu = compl;
+    // A non-finite or non-positive barrier is not a setting, it is a
+    // broken one, and the band's fallback still applies to it.
+    if !mu_in.is_finite() || mu_in <= 0.0 {
+        return MU_CEILING;
     }
-    safe_mu(mu).max(mu_in.min(MU_CEILING))
+    // Clamp the *measurement*, never the caller's setting (gh#606
+    // review). The previous form applied `safe_mu` to the pass-through
+    // value too, so an explicit `mu_init = 1.0` silently started the
+    // solve at `MU_CEILING` — on every warm start, escalation or not,
+    // and without printing anything, since the `wmu` token only fires
+    // when μ goes up. `.max(mu_in)` keeps the floor semantics this
+    // function documents without capping a barrier the caller chose on
+    // purpose.
+    if compl.is_finite() && compl > MU_ESCALATION_TRIGGER * mu_in {
+        safe_mu(compl).max(mu_in)
+    } else {
+        mu_in
+    }
 }
 
 /// Clamp a candidate μ into the band a warm start may use, and reject
@@ -847,9 +874,17 @@ fn scatter(v: &mut dyn Vector, src: &[Number]) -> bool {
 /// equality-multiplier block that no caller seeded. An uninitialized
 /// block counts as zero: that is what the clamp step below fills it
 /// with.
+///
+/// An **empty** block is zero vacuously, and saying so is what makes
+/// [`reconstruct_eq_duals`] work on a model that has only equality
+/// rows or only inequality rows. Returning `false` there — "this
+/// zero-dimension block carries a seed" — short-circuited the
+/// reconstruction on every single-block model and then reported the
+/// result as `Accepted` (gh#606 review). The two [`any_dual_seeded`]
+/// call sites already guard on `dim() > 0`, so they are unaffected.
 fn is_identically_zero(v: &Rc<dyn Vector>) -> bool {
     if v.dim() == 0 {
-        return false;
+        return true;
     }
     match flatten(&**v) {
         Some(vals) => vals.iter().all(|e| *e == 0.0),

--- a/crates/pounce-algorithm/src/init/warm_start.rs
+++ b/crates/pounce-algorithm/src/init/warm_start.rs
@@ -22,12 +22,57 @@
 //! `mult_init_max`, `target_mu`. `mult_bound_push` floors the four
 //! bound-multiplier blocks (mirroring upstream's `ElementWiseMax`
 //! with `warm_start_mult_bound_push`): a user-seeded `z = 0` would
-//! otherwise start the barrier on its boundary. The remaining knobs
-//! (`entire_iterate`, `same_structure`) are parsed for Ipopt option
-//! compatibility but not yet consumed — they require the
-//! `GetWarmStartIterate` TNLP surface, which pounce does not expose.
+//! otherwise start the barrier on its boundary.
+//!
+//! # Residual-adaptive recentering (gh#606)
+//!
+//! `warm_start_recentering=residual` (the default) adds a pass over
+//! the *supplied* point before the clamps: measure what was actually
+//! handed in, reconstruct what is missing, and choose μ from the
+//! measurement rather than from a universal constant.
+//!
+//! 1. **Measure.** `inf_pr` comes first because it is the one residual
+//!    that does not depend on the duals, so it is meaningful even when
+//!    every multiplier block is absent. It is reported rather than
+//!    acted on (step 4 explains why).
+//! 2. **Reconstruct bound multipliers.** An entry that arrives as
+//!    exactly `0` (or NaN) is not a legal barrier multiplier — the
+//!    barrier needs `z > 0` — so it was never a seed. Upstream floors
+//!    it at the constant `warm_start_mult_bound_push`; here it takes
+//!    `μ̂ / slack` instead, the same complementarity relation the
+//!    solver is about to enforce. Seeded (strictly positive) entries
+//!    are left alone.
+//! 3. **Reconstruct equality multipliers.** A `y` block that is
+//!    identically zero is likewise unseeded, and is re-derived from
+//!    stationarity by the same regularized least-squares augmented
+//!    solve the cold path uses ([`LeastSquareMults`]) — now with the
+//!    reconstructed `z` in its right-hand side, so the estimate is not
+//!    forced to absorb the bound multipliers.
+//! 4. **Choose μ.** With the point complete, μ is raised to the
+//!    measured `avrg_compl` when that overshoots what `mu_init` asked
+//!    for by more than [`MU_ESCALATION_TRIGGER`], clamped to
+//!    `[MU_FLOOR, MU_CEILING]`. A KKT-quality point
+//!    measures its own converged complementarity and keeps it; a stale
+//!    one, whose multipliers and slacks no longer pair up, measures a
+//!    large one and gets a correspondingly loose barrier — the "safely
+//!    fall back to stronger recentering" half. The primal and dual
+//!    residuals are deliberately *not* in that max; see [`final_mu`].
+//!    `warm_start_target_mu` still wins outright when set.
+//!
+//! `warm_start_recentering=none` restores the pre-gh#606 behaviour
+//! exactly: constant floor, zero-filled `y`, μ untouched. It is the
+//! kill switch for this whole block.
+//!
+//! Every branch above records what it did on
+//! [`WarmStartDiagnostics`], which lands on `IpoptData` and is
+//! readable afterwards through
+//! `IpoptApplication::warm_start_diagnostics()`.
+//!
+//! [`LeastSquareMults`]: crate::eq_mult::least_square::LeastSquareMults
 
-use crate::alg_builder::WarmStartOptions;
+use crate::alg_builder::{WarmStartOptions, WarmStartRecentering};
+use crate::eq_mult::least_square::LeastSquareMults;
+use crate::eq_mult::r#trait::EqMultCalculator;
 use crate::init::default::push_x_into_interior;
 use crate::init::r#trait::IterateInitializer;
 use crate::ipopt_cq::IpoptCqHandle;
@@ -35,11 +80,109 @@ use crate::ipopt_data::IpoptDataHandle;
 use crate::ipopt_nlp::IpoptNlp;
 use crate::iterates_vector::IteratesVector;
 use crate::kkt::aug_system_solver::AugSystemSolver;
+use pounce_common::types::Number;
 use pounce_linalg::Vector;
 use pounce_linalg::compound_vector::CompoundVector;
 use pounce_linalg::dense_vector::{DenseVector, DenseVectorSpace};
 use std::cell::RefCell;
 use std::rc::Rc;
+
+/// Hard floor on the residual-derived μ. Below this the barrier term
+/// is at the noise level of a `tol=1e-8` solve's complementarity and
+/// carries no information; letting a measurement drive μ further down
+/// would start the solve on a boundary the line search then has to
+/// climb back off.
+const MU_FLOOR: Number = 1e-11;
+
+/// Hard ceiling on the residual-derived μ: upstream's registered
+/// `mu_init` default. A warm start that measures badly should degrade
+/// *to* a cold start, never past one.
+const MU_CEILING: Number = 0.1;
+
+/// How far the measured complementarity has to exceed `mu_init` before
+/// it is allowed to override it.
+///
+/// Moving μ reroutes the entire trajectory, so the move has to be
+/// worth it. The cases this exists for — a stale seed, a caller who
+/// kept only the primal point — miss by three to six orders of
+/// magnitude; a good seed misses by a factor of two, and overriding
+/// there buys nothing and costs whatever the reroute costs. On
+/// `cresc4` (a nonconvex model that enters restoration on iteration 2,
+/// where small perturbations compound) a measurement of `5e-7` against
+/// a `mu_init` of `1e-7` moved μ by half an order and the solve from
+/// 85 iterations to 206 — same status, same objective, 2.4x the work.
+/// With this gate that model is bit-identical again, and the
+/// three-order cases still fire.
+const MU_ESCALATION_TRIGGER: Number = 10.0;
+
+/// What happened to one multiplier block of the supplied warm point.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BlockVerdict {
+    /// The block has dimension zero — the model has no such block.
+    #[default]
+    Absent,
+    /// Every entry arrived seeded and was kept (modulo the clamps).
+    Accepted,
+    /// Some or all entries arrived unseeded and were rebuilt.
+    Reconstructed,
+    /// A reconstruction ran and was thrown away (it exceeded
+    /// `constr_mult_init_max`, or the augmented solve failed); the
+    /// block fell back to the pre-gh#606 constant fill.
+    Discarded,
+    /// The caller supplied no dual information *at all*, so there was
+    /// nothing to reconstruct this block from and it kept the
+    /// pre-gh#606 constant fill. See [`any_dual_seeded`].
+    Unseeded,
+}
+
+/// What the warm-start initializer accepted, reconstructed, or
+/// discarded, and the residuals it based those calls on (gh#606).
+///
+/// Written once per solve, at initialization. `mu_in` is what
+/// `mu_init` / `warm_start_target_mu` asked for; `mu_out` is what the
+/// iterate actually starts at.
+#[derive(Debug, Clone)]
+pub struct WarmStartDiagnostics {
+    /// `‖c(x)‖_∞` of the supplied primal point, measured before any
+    /// dual reconstruction (it does not depend on the duals).
+    pub primal_residual: Number,
+    /// `‖∇_x L‖_∞` after reconstruction.
+    pub dual_residual: Number,
+    /// Average complementarity after reconstruction.
+    pub complementarity: Number,
+    pub mu_in: Number,
+    pub mu_out: Number,
+    pub bound_duals: BlockVerdict,
+    pub eq_duals: BlockVerdict,
+    /// Bound-multiplier entries that arrived unseeded and were filled
+    /// from `μ̂ / slack` rather than from the constant floor.
+    pub bound_duals_reconstructed: usize,
+    /// `true` when the unseeded bound multipliers were re-derived from
+    /// the stationarity identity rather than left at `μ̂ / slack`. That
+    /// needs a caller-supplied `y`; see
+    /// [`refine_bound_duals_from_stationarity`].
+    pub stationarity_split: bool,
+    /// `true` when `warm_start_recentering=none` turned all of the
+    /// above off and the fields are the legacy constants.
+    pub recentering_disabled: bool,
+}
+
+impl Default for WarmStartDiagnostics {
+    fn default() -> Self {
+        Self {
+            primal_residual: Number::NAN,
+            dual_residual: Number::NAN,
+            complementarity: Number::NAN,
+            mu_in: Number::NAN,
+            mu_out: Number::NAN,
+            bound_duals: BlockVerdict::Absent,
+            eq_duals: BlockVerdict::Absent,
+            bound_duals_reconstructed: 0,
+            stationarity_split: false,
+            recentering_disabled: false,
+        }
+    }
+}
 
 pub struct WarmStartIterateInitializer {
     opts: WarmStartOptions,
@@ -67,9 +210,9 @@ impl IterateInitializer for WarmStartIterateInitializer {
     fn set_initial_iterates(
         &mut self,
         data: &IpoptDataHandle,
-        _cq: &IpoptCqHandle,
+        cq: &IpoptCqHandle,
         nlp: &Rc<RefCell<dyn IpoptNlp>>,
-        _aug_solver: &mut dyn AugSystemSolver,
+        aug_solver: &mut dyn AugSystemSolver,
     ) -> bool {
         // Two entry points share this initializer: the re-optimize path
         // (curr.x carries values from the prior solve) and the first
@@ -89,6 +232,48 @@ impl IterateInitializer for WarmStartIterateInitializer {
             return false;
         }
 
+        let mut diag = WarmStartDiagnostics {
+            mu_in: data.borrow().curr_mu,
+            recentering_disabled: self.opts.recentering == WarmStartRecentering::None,
+            ..Default::default()
+        };
+
+        // gh#606 steps 1-3: measure the supplied point, then rebuild
+        // whatever it did not carry. Runs *before* the clamp block
+        // below, which still has the last word on the caps.
+        //
+        // Reconstruction completes a *partial* warm start: each missing
+        // block is derived from the blocks that were supplied. When
+        // nothing at all was supplied there is nothing to derive from,
+        // and what comes out is the cold path's estimate wearing the
+        // warm path's barrier — measured over `benchmarks/warmstart`,
+        // reconstructing from a primal-only seed cost 1102 -> 1211
+        // iterations across 27 parametric paths (`degenerate_corner`
+        // 17 -> 38 at every step size). So a seed with no duals in it
+        // keeps the pre-gh#606 fills, and only μ is still measured.
+        let dual_info =
+            self.opts.recentering == WarmStartRecentering::Residual && any_dual_seeded(data);
+        let mu_hat = if dual_info {
+            let (mu_hat, unseeded) = recenter_from_residuals(data, cq, &self.opts, &mut diag);
+            reconstruct_eq_duals(data, cq, nlp, aug_solver, &self.opts, &mut diag);
+            // The split below reads `y`; running it against a `y` this
+            // same pass just derived *from* the provisional `z` is
+            // circular, and measurably so (see the fn docs). Only a
+            // caller-supplied `y` earns it.
+            if diag.eq_duals != BlockVerdict::Reconstructed {
+                refine_bound_duals_from_stationarity(data, cq, nlp, &self.opts, mu_hat, &unseeded);
+                diag.stationarity_split = true;
+            }
+            Some(mu_hat)
+        } else if self.opts.recentering == WarmStartRecentering::Residual {
+            diag.primal_residual = cq.borrow().curr_primal_infeasibility_max();
+            diag.bound_duals = BlockVerdict::Unseeded;
+            diag.eq_duals = BlockVerdict::Unseeded;
+            Some(safe_mu(data.borrow().curr_mu))
+        } else {
+            None
+        };
+
         {
             // Rebuild `curr` with clamped multipliers. Components are
             // shared via `Rc` with previous solves, so we make fresh
@@ -104,9 +289,12 @@ impl IterateInitializer for WarmStartIterateInitializer {
             // means "unseeded", and takes `bound_mult_init_val` for
             // bound multipliers, or 0 for equality multipliers. That 0
             // is the warm path's existing unseeded value (what
-            // `seed_from_nlp` produced already), NOT the cold path's
-            // least-squares estimate; routing NaN duals through the
-            // least-squares calculator is a possible refinement.
+            // `seed_from_nlp` produced already).
+            //
+            // Under `warm_start_recentering=residual` the unseeded
+            // entries have already been rebuilt above, so what reaches
+            // here is a complete point and the constants only act as
+            // the outer caps.
             let mut borrow = data.borrow_mut();
             let curr = borrow.curr.as_ref().unwrap();
             let cap = if self.opts.mult_init_max > 0.0 {
@@ -129,11 +317,544 @@ impl IterateInitializer for WarmStartIterateInitializer {
             borrow.set_curr(new_curr);
         }
 
+        // `warm_start_target_mu` is an explicit instruction and still
+        // wins outright; the residual estimate only fills the gap the
+        // user left. gh#606 step 4.
         if self.opts.target_mu > 0.0 {
             data.borrow_mut().curr_mu = self.opts.target_mu;
+        } else if mu_hat.is_some() {
+            let mu = final_mu(data, cq, &mut diag);
+            data.borrow_mut().curr_mu = mu;
+        }
+
+        {
+            let mut borrow = data.borrow_mut();
+            diag.mu_out = borrow.curr_mu;
+            for token in diag.info_string_tokens() {
+                borrow.append_info_string(token);
+            }
+            borrow.warm_start_diagnostics = Some(diag);
         }
 
         true
+    }
+}
+
+impl WarmStartDiagnostics {
+    /// Single-token summaries for the iteration line, in the same
+    /// spirit as the cold path's `y` / `y0` / `yc`
+    /// (`DefaultIterateInitializer`). `wz` = bound multipliers
+    /// reconstructed, `wy` = equality multipliers reconstructed,
+    /// `wy0` = a reconstruction was discarded, `wmu` = μ was raised
+    /// above what `mu_init` asked for (the stale-point fallback).
+    fn info_string_tokens(&self) -> Vec<&'static str> {
+        let mut out = Vec::new();
+        if self.bound_duals == BlockVerdict::Reconstructed {
+            out.push("wz");
+        }
+        match self.eq_duals {
+            BlockVerdict::Reconstructed => out.push("wy"),
+            BlockVerdict::Discarded => out.push("wy0"),
+            _ => {}
+        }
+        if self.mu_out > self.mu_in * 10.0 {
+            out.push("wmu");
+        }
+        out
+    }
+}
+
+/// gh#606 steps 1-2. Measure the dual-free primal residual of the
+/// supplied point, turn it into a provisional barrier parameter `μ̂`,
+/// and fill every *unseeded* bound-multiplier entry with `μ̂ / slack`.
+///
+/// "Unseeded" is `0` exactly, or NaN. Neither is a legal barrier
+/// multiplier — the barrier needs `z > 0` — so neither can have come
+/// from a converged solve, and both are already special-cased today
+/// (floored at the constant `warm_start_mult_bound_push`). What
+/// changes is the value they take.
+///
+/// Returns `μ̂` — which [`final_mu`] then refines once the whole point
+/// is assembled — and, per block, the mask of entries that were
+/// unseeded, so [`refine_bound_duals_from_stationarity`] can revisit
+/// exactly those and nothing else.
+fn recenter_from_residuals(
+    data: &IpoptDataHandle,
+    cq: &IpoptCqHandle,
+    opts: &WarmStartOptions,
+    diag: &mut WarmStartDiagnostics,
+) -> (Number, [Vec<bool>; 4]) {
+    let inf_pr = cq.borrow().curr_primal_infeasibility_max();
+    diag.primal_residual = inf_pr;
+
+    // The fill barrier is the one the *caller* asked for, not the one
+    // the residual will argue for below. `z_i = μ / slack_i` is the
+    // complementarity relation at barrier μ, so filling from `mu_init`
+    // makes the reconstructed multipliers consistent with the point
+    // that produced the slacks — on an exact restart it reproduces the
+    // converged multiplier to a few digits. Substituting a
+    // residual-inflated μ here instead multiplies every reconstructed
+    // entry by that inflation, which on a converged point (tiny slacks)
+    // is precisely where it does the most damage: measured on HS071, a
+    // 8x-inflated μ̂ put the reconstructed slack multiplier 8x high and
+    // took the exact restart from 1 iteration to 5. The residual has
+    // its say in [`final_mu`], after the point is assembled.
+    let mu_hat = safe_mu(data.borrow().curr_mu);
+
+    let mut unseeded: [Vec<bool>; 4] = [vec![], vec![], vec![], vec![]];
+    let curr = match data.borrow().curr.clone() {
+        Some(c) => c,
+        None => return (mu_hat, unseeded),
+    };
+    let cq_ref = cq.borrow();
+    let slacks = [
+        cq_ref.curr_slack_x_l(),
+        cq_ref.curr_slack_x_u(),
+        cq_ref.curr_slack_s_l(),
+        cq_ref.curr_slack_s_u(),
+    ];
+    drop(cq_ref);
+    let blocks = [&curr.z_l, &curr.z_u, &curr.v_l, &curr.v_u];
+
+    let mut rebuilt: [Option<Rc<dyn Vector>>; 4] = [None, None, None, None];
+    let mut n_reconstructed = 0usize;
+    let mut n_total = 0usize;
+    for (i, (z, slack)) in blocks.iter().zip(slacks.iter()).enumerate() {
+        if z.dim() == 0 {
+            continue;
+        }
+        n_total += z.dim() as usize;
+        let Some(mut vals) = flatten(&***z) else {
+            continue;
+        };
+        let Some(sl) = flatten(&**slack) else {
+            continue;
+        };
+        if sl.len() != vals.len() {
+            // Shapes disagree (a layout this helper does not model):
+            // leave the block to the constant floor below rather than
+            // pair up entries that may not correspond.
+            continue;
+        }
+        let mut touched = 0usize;
+        let mut mask = vec![false; vals.len()];
+        for (k, (v, s)) in vals.iter_mut().zip(sl.iter()).enumerate() {
+            if !(v.is_nan() || *v == 0.0) {
+                continue;
+            }
+            touched += 1;
+            mask[k] = true;
+            // `slack` can be tiny (an active bound) or non-finite on a
+            // point outside its bounds; both are clamped into the band
+            // the caps below would have allowed anyway.
+            let filled = if s.is_finite() && *s > 0.0 {
+                mu_hat / *s
+            } else {
+                mu_hat
+            };
+            *v = filled.clamp(
+                opts.mult_bound_push.max(MU_FLOOR),
+                opts.mult_init_max_or_inf(),
+            );
+        }
+        if touched == 0 {
+            continue;
+        }
+        unseeded[i] = mask;
+        n_reconstructed += touched;
+        let mut out = z.make_new();
+        if scatter(&mut *out, &vals) {
+            rebuilt[i] = Some(Rc::from(out));
+        }
+    }
+
+    if n_total > 0 {
+        diag.bound_duals = if n_reconstructed == 0 {
+            BlockVerdict::Accepted
+        } else {
+            BlockVerdict::Reconstructed
+        };
+    }
+    diag.bound_duals_reconstructed = n_reconstructed;
+
+    if rebuilt.iter().any(|r| r.is_some()) {
+        let pick = |i: usize, orig: &Rc<dyn Vector>| -> Rc<dyn Vector> {
+            rebuilt[i].clone().unwrap_or_else(|| Rc::clone(orig))
+        };
+        let new_curr = IteratesVector::new(
+            Rc::clone(&curr.x),
+            Rc::clone(&curr.s),
+            Rc::clone(&curr.y_c),
+            Rc::clone(&curr.y_d),
+            pick(0, &curr.z_l),
+            pick(1, &curr.z_u),
+            pick(2, &curr.v_l),
+            pick(3, &curr.v_u),
+        );
+        data.borrow_mut().set_curr(new_curr);
+    }
+
+    (mu_hat, unseeded)
+}
+
+/// gh#606 step 3b. Having reconstructed the equality multipliers,
+/// revisit the bound multipliers that were unseeded and replace the
+/// `μ̂ / slack` guess with the value stationarity actually implies.
+///
+/// `∇_x L = ∇f + J_cᵀ y_c + J_dᵀ y_d − P_L z_L + P_U z_U`, so at a
+/// stationary point `P_L z_L − P_U z_U = r_x` with
+/// `r_x = ∇f + J_cᵀ y_c + J_dᵀ y_d`; splitting `r_x` by sign and
+/// selecting through `P_Lᵀ` / `P_Uᵀ` is the positivity-preserving
+/// solution of that identity. The slack block is the same identity one
+/// row down: `∇_s L = −y_d − P_L v_L + P_U v_U`, so `−y_d` splits into
+/// `v_L` / `v_U`.
+///
+/// Only runs when the equality multipliers came from the caller. When
+/// they were themselves reconstructed a few lines earlier, `r_x` is
+/// built from a `y` that the least-squares solve derived *from* the
+/// provisional `μ̂ / slack` fill, so the split re-derives its own
+/// input — and the round trip is lossy at exactly the points that make
+/// it hard. Measured over `benchmarks/warmstart`, running it anyway
+/// cost a primal-only warm start 1102 -> 1263 iterations across 27
+/// paths (`degenerate_corner` 17 -> 38, `rosenbrock_ring` 28 -> 66),
+/// with the wins concentrated where `y` *was* supplied.
+///
+/// Why this and not `μ̂ / slack` alone: the slacks reaching here have
+/// already been shoved into the bound interior by
+/// `warm_start_slack_bound_push`, so on a converged point — where the
+/// true slack sits at `μ / z` and the push dominates it — `μ̂ / slack`
+/// is off by exactly the push's inflation. Measured on HS071, that put
+/// the reconstructed inequality multiplier 5.5x low and took an exact
+/// restart from 1 iteration to 5. The stationarity split is immune to
+/// it because it never looks at a slack.
+///
+/// The `μ̂ / slack` value survives as the *floor*: at an inactive bound
+/// the split contributes nothing and complementarity is what says how
+/// big the multiplier should be.
+fn refine_bound_duals_from_stationarity(
+    data: &IpoptDataHandle,
+    cq: &IpoptCqHandle,
+    nlp: &Rc<RefCell<dyn IpoptNlp>>,
+    opts: &WarmStartOptions,
+    mu_hat: Number,
+    unseeded: &[Vec<bool>; 4],
+) {
+    if unseeded.iter().all(|m| m.is_empty()) {
+        return;
+    }
+    let curr = match data.borrow().curr.clone() {
+        Some(c) => c,
+        None => return,
+    };
+
+    // r_x = ∇f + J_cᵀ y_c + J_dᵀ y_d, and r_s = −y_d.
+    let (r_x, r_s, slacks) = {
+        let cq_ref = cq.borrow();
+        let grad_f = cq_ref.curr_grad_f();
+        let jc_t = cq_ref.curr_jac_c_t_times_curr_y_c();
+        let jd_t = cq_ref.curr_jac_d_t_times_curr_y_d();
+        let mut r_x = grad_f.make_new();
+        r_x.copy(&*grad_f);
+        r_x.add_two_vectors(1.0, &*jc_t, 1.0, &*jd_t, 1.0);
+        let mut r_s = curr.y_d.make_new();
+        r_s.copy(&*curr.y_d);
+        r_s.scal(-1.0);
+        let slacks = [
+            cq_ref.curr_slack_x_l(),
+            cq_ref.curr_slack_x_u(),
+            cq_ref.curr_slack_s_l(),
+            cq_ref.curr_slack_s_u(),
+        ];
+        (r_x, r_s, slacks)
+    };
+
+    let nlp_ref = nlp.borrow();
+    // Rearranged, the two identities read `P_L z_L − P_U z_U = r_x`
+    // and `P_L v_L − P_U v_U = r_s`, so each lower block takes `+Pᵀr`
+    // and each upper block `−Pᵀr`; the `max(·, 0)` that makes the
+    // split well-posed is the `.max(floor)` in the loop below.
+    let targets: [Option<Vec<Number>>; 4] = [
+        project(&*r_x, &*nlp_ref.px_l(), 1.0, &curr.z_l),
+        project(&*r_x, &*nlp_ref.px_u(), -1.0, &curr.z_u),
+        project(&*r_s, &*nlp_ref.pd_l(), 1.0, &curr.v_l),
+        project(&*r_s, &*nlp_ref.pd_u(), -1.0, &curr.v_u),
+    ];
+    drop(nlp_ref);
+
+    let blocks = [&curr.z_l, &curr.z_u, &curr.v_l, &curr.v_u];
+    let mut rebuilt: [Option<Rc<dyn Vector>>; 4] = [None, None, None, None];
+    for (i, block) in blocks.iter().enumerate() {
+        let mask = &unseeded[i];
+        if mask.is_empty() {
+            continue;
+        }
+        let (Some(target), Some(mut vals), Some(sl)) =
+            (targets[i].clone(), flatten(&***block), flatten(&*slacks[i]))
+        else {
+            continue;
+        };
+        if target.len() != vals.len() || sl.len() != vals.len() || mask.len() != vals.len() {
+            continue;
+        }
+        let cap = opts.mult_init_max_or_inf();
+        let hard_floor = opts.mult_bound_push.max(MU_FLOOR);
+        for k in 0..vals.len() {
+            if !mask[k] {
+                continue;
+            }
+            let compl_floor = if sl[k].is_finite() && sl[k] > 0.0 {
+                mu_hat / sl[k]
+            } else {
+                mu_hat
+            };
+            let split = if target[k].is_finite() {
+                target[k]
+            } else {
+                0.0
+            };
+            vals[k] = split.max(compl_floor).max(hard_floor).min(cap);
+        }
+        let mut out = block.make_new();
+        if scatter(&mut *out, &vals) {
+            rebuilt[i] = Some(Rc::from(out));
+        }
+    }
+
+    if rebuilt.iter().all(|r| r.is_none()) {
+        return;
+    }
+    let pick = |i: usize, orig: &Rc<dyn Vector>| -> Rc<dyn Vector> {
+        rebuilt[i].clone().unwrap_or_else(|| Rc::clone(orig))
+    };
+    let new_curr = IteratesVector::new(
+        Rc::clone(&curr.x),
+        Rc::clone(&curr.s),
+        Rc::clone(&curr.y_c),
+        Rc::clone(&curr.y_d),
+        pick(0, &curr.z_l),
+        pick(1, &curr.z_u),
+        pick(2, &curr.v_l),
+        pick(3, &curr.v_u),
+    );
+    data.borrow_mut().set_curr(new_curr);
+}
+
+/// `sign · Pᵀ r`, as a plain slice of length `n_out`. `P` is one of the
+/// packed bound-selection matrices, so the transpose picks out the
+/// components that actually carry that bound.
+fn project(
+    r: &dyn Vector,
+    p: &dyn pounce_linalg::Matrix,
+    sign: Number,
+    template: &Rc<dyn Vector>,
+) -> Option<Vec<Number>> {
+    if template.dim() == 0 {
+        return None;
+    }
+    let mut out = template.make_new();
+    out.set(0.0);
+    p.trans_mult_vector(sign, r, 0.0, &mut *out);
+    flatten(&*out)
+}
+
+/// gh#606 step 3. Re-derive an identically-zero `y` block from
+/// stationarity.
+///
+/// A converged equality multiplier vector is zero only when every
+/// equality is inactive in the Lagrangian, which the least-squares
+/// solve reproduces anyway — so treating an all-zero block as
+/// "unseeded" is self-correcting on a genuinely-zero one, and is the
+/// only signal available: an absent `lagrange=` seed and a supplied
+/// vector of zeros reach this initializer as the same bytes.
+///
+/// This is the same [`LeastSquareMults`] augmented solve the cold path
+/// runs, so the "sparse regularized stationarity least-squares"
+/// machinery is shared rather than duplicated — the difference is that
+/// here it runs with real seeded bound multipliers in its right-hand
+/// side instead of the cold path's constant `bound_mult_init_val`.
+fn reconstruct_eq_duals(
+    data: &IpoptDataHandle,
+    cq: &IpoptCqHandle,
+    nlp: &Rc<RefCell<dyn IpoptNlp>>,
+    aug_solver: &mut dyn AugSystemSolver,
+    opts: &WarmStartOptions,
+    diag: &mut WarmStartDiagnostics,
+) {
+    let curr = match data.borrow().curr.clone() {
+        Some(c) => c,
+        None => return,
+    };
+    let (n_yc, n_yd) = (curr.y_c.dim(), curr.y_d.dim());
+    if n_yc + n_yd == 0 {
+        return;
+    }
+    // Upstream's own guard from the cold path: with as many equalities
+    // as variables the least-squares system is square and the estimate
+    // is not a projection of anything.
+    if n_yc == curr.x.dim() {
+        diag.eq_duals = BlockVerdict::Accepted;
+        return;
+    }
+    let seeded = !is_identically_zero(&curr.y_c) || !is_identically_zero(&curr.y_d);
+    if seeded {
+        diag.eq_duals = BlockVerdict::Accepted;
+        return;
+    }
+
+    let mut new_y_c = DenseVectorSpace::new(n_yc).make_new_dense();
+    let mut new_y_d = DenseVectorSpace::new(n_yd).make_new_dense();
+    new_y_c.set(0.0);
+    new_y_d.set(0.0);
+    let ok = LeastSquareMults::new().calculate_y_eq(
+        data,
+        cq,
+        nlp,
+        aug_solver,
+        &mut new_y_c,
+        &mut new_y_d,
+    );
+    if !ok {
+        diag.eq_duals = BlockVerdict::Discarded;
+        return;
+    }
+    let norm = new_y_c.amax().max(new_y_d.amax());
+    if !norm.is_finite() || (opts.constr_mult_init_max > 0.0 && norm > opts.constr_mult_init_max) {
+        // Same verdict, and the same cap, the cold path reaches on an
+        // over-large estimate: keep the zeros rather than start the
+        // solve on a multiplier the cap was written to exclude. On a
+        // rank-deficient model the least-squares system is singular and
+        // this is the branch that catches it.
+        diag.eq_duals = BlockVerdict::Discarded;
+        return;
+    }
+    diag.eq_duals = BlockVerdict::Reconstructed;
+    let new_curr = IteratesVector::new(
+        Rc::clone(&curr.x),
+        Rc::clone(&curr.s),
+        Rc::new(new_y_c),
+        Rc::new(new_y_d),
+        Rc::clone(&curr.z_l),
+        Rc::clone(&curr.z_u),
+        Rc::clone(&curr.v_l),
+        Rc::clone(&curr.v_u),
+    );
+    data.borrow_mut().set_curr(new_curr);
+}
+
+/// gh#606 step 4. The barrier parameter the assembled point deserves.
+///
+/// Measured on the reconstructed iterate, so `avrg_compl` reflects the
+/// multipliers the solve will actually start from rather than the
+/// holes the caller left.
+///
+/// **Only the complementarity moves μ.** That is not an oversight: of
+/// the three KKT residuals, complementarity is the one μ *is*, and the
+/// other two are what the Newton step is for. A warm point at a
+/// slightly moved parameter carries a primal and a dual residual of
+/// order `Δθ` by construction — that is the premise of warm starting —
+/// and raising μ to meet them throws away the warm start to pay for a
+/// step the solver was about to take anyway. Measured over the
+/// `benchmarks/warmstart` corpus, a `μ ≥ κ·max(inf_pr, inf_du)` rule
+/// cost 715 → 1129 iterations across 27 parametric paths: on
+/// `simplex_proj/tiny` a re-solve that needed one iteration measured
+/// `inf_du = 2e-3`, took `μ = 2e-3`, and needed five. `avrg_compl` on
+/// the same point read `2.6e-9` — the converged barrier, correctly
+/// recognised. A genuinely stale point is still caught, because its
+/// multipliers and its slacks no longer pair up and `avrg_compl` rises
+/// with them.
+///
+/// `mu_in` is a floor, never a ceiling: `mu_init` is an explicit
+/// statement about the barrier the caller wants, and the measurement
+/// is here to catch a point that cannot support it, not to
+/// second-guess a good one downward. It also has to miss by
+/// [`MU_ESCALATION_TRIGGER`] before it is overridden at all.
+fn final_mu(data: &IpoptDataHandle, cq: &IpoptCqHandle, diag: &mut WarmStartDiagnostics) -> Number {
+    let (compl, inf_du) = {
+        let cq_ref = cq.borrow();
+        (
+            cq_ref.curr_avrg_compl(),
+            cq_ref.curr_dual_infeasibility_max(),
+        )
+    };
+    diag.complementarity = compl;
+    // Recorded but deliberately not fed into μ — see above. It is the
+    // number that says whether the reconstruction worked.
+    diag.dual_residual = inf_du;
+
+    let mu_in = data.borrow().curr_mu;
+    let mut mu = mu_in;
+    if compl.is_finite() && compl > MU_ESCALATION_TRIGGER * mu_in {
+        mu = compl;
+    }
+    safe_mu(mu).max(mu_in.min(MU_CEILING))
+}
+
+/// Clamp a candidate μ into the band a warm start may use, and reject
+/// non-finite candidates outright.
+fn safe_mu(mu: Number) -> Number {
+    if !mu.is_finite() || mu <= 0.0 {
+        return MU_CEILING;
+    }
+    mu.clamp(MU_FLOOR, MU_CEILING)
+}
+
+/// Copy a vector's scalars out, whatever storage it uses. `None` for a
+/// layout this module does not model, or one that was never written.
+fn flatten(v: &dyn Vector) -> Option<Vec<Number>> {
+    if let Some(d) = v.as_any().downcast_ref::<DenseVector>() {
+        // `expanded_values`, not `values`: a block written with
+        // `set(c)` is stored homogeneously and `values` asserts on it.
+        return d.is_initialized().then(|| d.expanded_values());
+    }
+    if let Some(c) = v.as_any().downcast_ref::<CompoundVector>() {
+        let mut out = Vec::with_capacity(v.dim() as usize);
+        for i in 0..c.n_comps() {
+            out.extend(flatten(c.comp(i))?);
+        }
+        return Some(out);
+    }
+    None
+}
+
+/// Inverse of [`flatten`]. `false` when the layout or the length does
+/// not match, in which case the caller must leave the block alone.
+fn scatter(v: &mut dyn Vector, src: &[Number]) -> bool {
+    if v.dim() as usize != src.len() {
+        return false;
+    }
+    if v.as_any().is::<DenseVector>() {
+        let d = v.as_any_mut().downcast_mut::<DenseVector>().unwrap();
+        d.values_mut().copy_from_slice(src);
+        return true;
+    }
+    if v.as_any().is::<CompoundVector>() {
+        let c = v.as_any_mut().downcast_mut::<CompoundVector>().unwrap();
+        let mut off = 0usize;
+        for i in 0..c.n_comps() {
+            let comp = c.comp_mut(i);
+            let n = comp.dim() as usize;
+            if !scatter(comp, &src[off..off + n]) {
+                return false;
+            }
+            off += n;
+        }
+        return true;
+    }
+    false
+}
+
+/// `true` when every entry is exactly `0` — the signature of an
+/// equality-multiplier block that no caller seeded. An uninitialized
+/// block counts as zero: that is what the clamp step below fills it
+/// with.
+fn is_identically_zero(v: &Rc<dyn Vector>) -> bool {
+    if v.dim() == 0 {
+        return false;
+    }
+    match flatten(&**v) {
+        Some(vals) => vals.iter().all(|e| *e == 0.0),
+        // Never written -> the clamp block collapses it to zero.
+        None => true,
     }
 }
 
@@ -444,4 +1165,40 @@ mod tests {
         let out = clone_clamped(&v, 0.0, 1e6, 0.0);
         assert_eq!(out.amax(), 0.0);
     }
+}
+
+/// Did the caller supply *any* dual information?
+///
+/// True when some equality multiplier is non-zero, or some bound
+/// multiplier is strictly positive and finite. Both are the
+/// signatures the per-block "unseeded" tests use, taken across every
+/// block at once: an entry that is exactly `0` cannot have come from a
+/// converged solve, and neither can a whole `y` block of zeros.
+///
+/// This is the gate on the reconstruction as a whole. Completing a
+/// partial warm start is well-posed — the supplied blocks pin the
+/// missing ones through stationarity. Manufacturing all of them from a
+/// primal point alone is not: the result is the cold path's estimate
+/// paired with the warm path's barrier, and it measured worse than the
+/// constants it replaced.
+fn any_dual_seeded(data: &IpoptDataHandle) -> bool {
+    let Some(curr) = data.borrow().curr.clone() else {
+        return false;
+    };
+    for y in [&curr.y_c, &curr.y_d] {
+        if y.dim() > 0 && !is_identically_zero(y) {
+            return true;
+        }
+    }
+    for z in [&curr.z_l, &curr.z_u, &curr.v_l, &curr.v_u] {
+        if z.dim() == 0 {
+            continue;
+        }
+        if let Some(vals) = flatten(&**z) {
+            if vals.iter().any(|v| v.is_finite() && *v > 0.0) {
+                return true;
+            }
+        }
+    }
+    false
 }

--- a/crates/pounce-algorithm/src/ipopt_data.rs
+++ b/crates/pounce-algorithm/src/ipopt_data.rs
@@ -10,6 +10,7 @@
 //! search, mu update, etc.) read/write fields here as their inputs
 //! and outputs.
 
+use crate::init::warm_start::WarmStartDiagnostics;
 use crate::iterates_vector::IteratesVector;
 use pounce_common::timing::{Deadline, TimingStatistics};
 use pounce_common::types::{Index, Number};
@@ -118,6 +119,13 @@ pub struct IpoptData {
     /// counterpart. See pounce#58.
     pub request_resto: bool,
 
+    /// What the warm-start initializer accepted, reconstructed, or
+    /// discarded from the supplied iterate, and the residuals it based
+    /// those calls on (gh#606). `None` on the cold path, which has no
+    /// supplied iterate to report on. Read back after a solve through
+    /// [`crate::application::IpoptApplication::warm_start_diagnostics`].
+    pub warm_start_diagnostics: Option<WarmStartDiagnostics>,
+
     /// Line-search reset request from the μ-update layer (pounce#510).
     /// Upstream's μ updates hold a `linesearch_` handle and call
     /// `linesearch_->Reset()` themselves at fixed points
@@ -218,6 +226,7 @@ impl IpoptData {
             info_string: String::new(),
             tiny_step_flag: false,
             request_resto: false,
+            warm_start_diagnostics: None,
             request_ls_reset: false,
             request_tiny_step_stop: false,
             info_alpha_primal_char: ' ',

--- a/crates/pounce-algorithm/src/unimplemented_options.rs
+++ b/crates/pounce-algorithm/src/unimplemented_options.rs
@@ -71,11 +71,14 @@ pub struct UnimplementedFeature {
     pub advice: &'static str,
     /// The options that belong to it.
     pub options: &'static [&'static str],
+    /// Issue tracking the missing feature, named in the error.
+    pub issue: u32,
 }
 
 /// Feature groups pounce does not implement. Refused when set.
 pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
     UnimplementedFeature {
+        issue: 483,
         feature: "the Chen-Goldfarb (CG-penalty) / inexact-Newton line search \
                   — Ipopt's `CGPenaltyLSAcceptor`",
         advice: "pounce implements the filter line search (the default) and \
@@ -113,6 +116,7 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         ],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "derivative approximation by finite differences",
         advice: "supply `eval_grad_f` / `eval_jac_g` / `eval_h`, and check them \
                  with `derivative_test=first-order`",
@@ -123,6 +127,7 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         ],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "linear-dependency detection on the equality constraints",
         advice: "pounce's presolve removes structurally redundant rows; see \
                  `presolve`",
@@ -133,17 +138,20 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         ],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "the per-iteration NaN/Inf check on derivative matrices",
         advice: "`derivative_test=first-order` checks the derivatives once, at \
                  the starting point",
         options: &["check_derivatives_for_naninf"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "multiplier recalculation by least squares",
         advice: "",
         options: &["recalc_y", "recalc_y_feas_tol"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "least-square initialization of *all* dual variables \
                   (the first-order-optimality fit)",
         advice: "the equality multipliers are least-square initialized \
@@ -153,53 +161,72 @@ pub const UNIMPLEMENTED_FEATURES: &[UnimplementedFeature] = &[
         options: &["least_square_init_duals"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "a selectable constraint-violation norm",
         advice: "pounce measures the violation in the 2-norm throughout",
         options: &["constraint_violation_norm_type"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "magic steps",
         advice: "",
         options: &["magic_steps"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "bound replacement on the original problem",
         advice: "",
         options: &["replace_bounds"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "the L-BFGS augmented-system and space variants",
         advice: "`hessian_approximation=limited-memory` uses the low-rank \
                  augmented system unconditionally",
         options: &["hessian_approximation_space", "limited_memory_aug_solver"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "the linear-variable count hint for L-BFGS",
         advice: "",
         options: &["num_linear_variables"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "skipping the finalize-solution callback",
         advice: "",
         options: &["skip_finalize_solution_call"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "the dynamic HSL loader",
         advice: "MA57 is linked at build time with `--features ma57`",
         options: &["hsllib"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "these output controls",
         advice: "use `print_level` (0 silences the solver) and `sb=yes` to \
                  suppress the banner",
         options: &["suppress_all_output", "debug_print_level"],
     },
     UnimplementedFeature {
+        issue: 483,
         feature: "a randomly perturbed evaluation point for the derivative \
                   checker",
         advice: "pounce's checker tests at the (bound-projected) starting point, \
                  which is where the solve actually begins",
         options: &["point_perturbation_radius"],
+    },
+    UnimplementedFeature {
+        issue: 606,
+        feature: "reuse of a previously-solved iterate or problem structure \
+                  through Ipopt's `TNLP::GetWarmStartIterate` surface",
+        advice: "pounce's warm start goes through `TNLP::get_starting_point` \
+                 with `warm_start_init_point=yes`, which carries the primal \
+                 point and all three multiplier blocks; from Python, \
+                 `pounce.WarmStart.from_info` packages it",
+        options: &["warm_start_entire_iterate", "warm_start_same_structure"],
     },
 ];
 
@@ -290,8 +317,8 @@ pub fn refusal(options: &OptionsList, reg: &RegisteredOptions) -> Option<String>
                      Ipopt still parses, but setting it used to do nothing at \
                      all — silently — so it is refused instead.{advice} \
                      Remove it to run. Tracking issue: \
-                     https://github.com/jkitchin/pounce/issues/483",
-                    group.feature
+                     https://github.com/jkitchin/pounce/issues/{}",
+                    group.feature, group.issue
                 ));
             }
         }

--- a/crates/pounce-algorithm/src/upstream_options.rs
+++ b/crates/pounce-algorithm/src/upstream_options.rs
@@ -1256,6 +1256,22 @@ pub fn register_all_upstream_options(r: &RegisteredOptions) -> Result<(), Solver
         "",
     )?;
     r.add_number_option("warm_start_target_mu", "", 0.0, "Experimental!")?;
+    r.add_string_option(
+        "warm_start_recentering",
+        "How the warm-start initializer adapts to the quality of the supplied iterate.",
+        "residual",
+        &[
+            (
+                "residual",
+                "measure the supplied point and derive mu, the bound-multiplier fills, and the equality-multiplier reconstruction from it",
+            ),
+            (
+                "none",
+                "pre-pounce#606 behaviour: universal constants, zero-filled unseeded multipliers, mu untouched",
+            ),
+        ],
+        "DELIBERATE DEVIATION FROM UPSTREAM IPOPT (pounce#606). Ipopt's warm-start initializer applies fixed pushes and floors regardless of what the caller handed it, and fills a missing multiplier block with a constant. That makes the warm start's behaviour a function of the options rather than of the iterate: an at-the-optimum restart and a stale point from a different parameter both start on the same barrier, and a caller who supplies only a primal point gets bound multipliers of warm_start_mult_bound_push -- a number chosen with no reference to the slacks it is paired against. Under `residual` the initializer instead measures the supplied point's primal residual, complementarity and stationarity residual; fills unseeded bound multipliers from mu/slack; re-derives an identically-zero equality-multiplier block from the same regularized stationarity least-squares solve the cold path uses; and raises mu to the measured average complementarity (clamped to [1e-11, 0.1]) when the supplied point cannot support the barrier mu_init asked for. Only complementarity moves mu: a warm point at a moved parameter carries primal and dual residuals of order delta-theta by construction, and raising mu to meet those discards the warm start to pay for a Newton step that was about to happen anyway -- measured at 715 -> 1129 iterations over the 27 parametric paths in benchmarks/warmstart before that term was dropped. `warm_start_target_mu` still overrides mu outright. Set to `none` to restore bit-for-bit pre-pounce#606 warm-start behaviour.",
+    )?;
 
     // ===== CGSearchDirCalculator::RegisterOptions (contrib/CGPenalty/IpCGSearchDirCalc.cpp) =====
     r.set_registering_category("CG Penalty");

--- a/crates/pounce-algorithm/tests/optimize_hs71.rs
+++ b/crates/pounce-algorithm/tests/optimize_hs71.rs
@@ -943,12 +943,17 @@ fn hs071_probing_oracle_honors_user_sigma_max() {
     );
 }
 
+/// The `Warm Start` category still parses in full — an `ipopt.opt`
+/// written for Ipopt must load unchanged — including the two flags
+/// gh#606 refuses at solve time. Parsing and honouring are separate
+/// questions; `warm_start_recentering.rs` covers the second one.
 #[test]
 fn warm_start_options_flow_through_builder() {
     let mut app = IpoptApplication::new();
     let opts = "\
         warm_start_init_point yes\n\
         warm_start_same_structure yes\n\
+        warm_start_recentering none\n\
         warm_start_bound_push 1e-2\n\
         warm_start_bound_frac 1e-2\n\
         warm_start_slack_bound_push 1e-2\n\
@@ -966,6 +971,7 @@ fn warm_start_options_flow_through_builder() {
         "warm_start_init_point",
         "warm_start_same_structure",
         "warm_start_entire_iterate",
+        "warm_start_recentering",
     ] {
         let (_, found) = app.options().get_string_value(key, "").unwrap();
         assert!(found, "{key} did not parse through the registry");

--- a/crates/pounce-algorithm/tests/warm_start_recentering.rs
+++ b/crates/pounce-algorithm/tests/warm_start_recentering.rs
@@ -1,0 +1,551 @@
+//! Residual-adaptive warm-start recentering — gh#606.
+//!
+//! Three things are asserted here.
+//!
+//! 1. **The reconstruction pays.** A caller who hands over a primal
+//!    point and no multipliers used to get bound multipliers of
+//!    `warm_start_mult_bound_push` — a constant with no relation to
+//!    the slacks it is paired against — and equality multipliers of
+//!    zero. Under `warm_start_recentering=residual` those blocks are
+//!    rebuilt from `μ̂ / slack` and from the stationarity least-squares
+//!    solve, and the re-solve is shorter for it.
+//! 2. **A stale point is recentered rather than trusted.** A warm
+//!    point whose residuals are large gets a looser barrier than
+//!    `mu_init` asked for, which is what stops it costing more than a
+//!    cold start.
+//! 3. **The two `GetWarmStartIterate` flags are refused, not
+//!    half-served.** `warm_start_same_structure` and
+//!    `warm_start_entire_iterate` parsed and set fields nothing read;
+//!    they now fail with a message. Plus the registry invariant that
+//!    would have caught that in the first place: every registered
+//!    `Warm Start` option is read by the solver or explicitly refused.
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_algorithm::init::warm_start::BlockVerdict;
+use pounce_common::types::Number;
+use pounce_nlp::return_codes::ApplicationReturnStatus;
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, NlpInfo, Solution, SparsityRequest, StartingPoint,
+    TNLP,
+};
+use std::cell::RefCell;
+use std::collections::BTreeSet;
+use std::rc::Rc;
+
+/// HS071 with a settable starting point and settable dual seeds, so a
+/// test can hand the solver exactly as much of a warm start as it
+/// wants to measure.
+#[derive(Default)]
+struct Hs071Seeded {
+    x0: Option<[Number; 4]>,
+    lambda0: Option<Vec<Number>>,
+    z_l0: Option<Vec<Number>>,
+    z_u0: Option<Vec<Number>>,
+    final_x: Option<[Number; 4]>,
+    final_obj: Option<Number>,
+    final_lambda: Option<Vec<Number>>,
+    final_z_l: Option<Vec<Number>>,
+    final_z_u: Option<Vec<Number>>,
+}
+
+impl TNLP for Hs071Seeded {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 4,
+            m: 2,
+            nnz_jac_g: 8,
+            nnz_h_lag: 10,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l.copy_from_slice(&[1.0; 4]);
+        b.x_u.copy_from_slice(&[5.0; 4]);
+        b.g_l.copy_from_slice(&[25.0, 40.0]);
+        b.g_u.copy_from_slice(&[2.0e19, 40.0]);
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        if sp.init_x {
+            sp.x.copy_from_slice(&self.x0.unwrap_or([1.0, 5.0, 5.0, 1.0]));
+        }
+        if sp.init_lambda {
+            if let Some(l) = &self.lambda0 {
+                sp.lambda.copy_from_slice(l);
+            }
+        }
+        if sp.init_z {
+            if let Some(z) = &self.z_l0 {
+                sp.z_l.copy_from_slice(z);
+            }
+            if let Some(z) = &self.z_u0 {
+                sp.z_u.copy_from_slice(z);
+            }
+        }
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some(x[0] * x[3] * (x[0] + x[1] + x[2]) + x[2])
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[3] * (2.0 * x[0] + x[1] + x[2]);
+        g[1] = x[0] * x[3];
+        g[2] = x[0] * x[3] + 1.0;
+        g[3] = x[0] * (x[0] + x[1] + x[2]);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] * x[1] * x[2] * x[3];
+        g[1] = x[0] * x[0] + x[1] * x[1] + x[2] * x[2] + x[3] * x[3];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0, 0, 0, 1, 1, 1, 1]);
+                jcol.copy_from_slice(&[0, 1, 2, 3, 0, 1, 2, 3]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_jac_g(Values) without x");
+                values[0] = x[1] * x[2] * x[3];
+                values[1] = x[0] * x[2] * x[3];
+                values[2] = x[0] * x[1] * x[3];
+                values[3] = x[0] * x[1] * x[2];
+                values[4] = 2.0 * x[0];
+                values[5] = 2.0 * x[1];
+                values[6] = 2.0 * x[2];
+                values[7] = 2.0 * x[3];
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1, 1, 2, 2, 2, 3, 3, 3, 3]);
+                jcol.copy_from_slice(&[0, 0, 1, 0, 1, 2, 0, 1, 2, 3]);
+            }
+            SparsityRequest::Values { values } => {
+                let x = x.expect("eval_h(Values) without x");
+                let lam = lambda.expect("eval_h(Values) without lambda");
+                let of = obj_factor;
+                let l0 = lam[0];
+                let l1 = lam[1];
+                values[0] = of * (2.0 * x[3]) + l1 * 2.0;
+                values[1] = of * x[3] + l0 * (x[2] * x[3]);
+                values[2] = l1 * 2.0;
+                values[3] = of * x[3] + l0 * (x[1] * x[3]);
+                values[4] = l0 * (x[0] * x[3]);
+                values[5] = l1 * 2.0;
+                values[6] = of * (2.0 * x[0] + x[1] + x[2]) + l0 * (x[1] * x[2]);
+                values[7] = of * x[0] + l0 * (x[0] * x[2]);
+                values[8] = of * x[0] + l0 * (x[0] * x[1]);
+                values[9] = l1 * 2.0;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        if sol.x.len() == 4 {
+            self.final_x = Some([sol.x[0], sol.x[1], sol.x[2], sol.x[3]]);
+        }
+        self.final_obj = Some(sol.obj_value);
+        self.final_lambda = Some(sol.lambda.to_vec());
+        self.final_z_l = Some(sol.z_l.to_vec());
+        self.final_z_u = Some(sol.z_u.to_vec());
+    }
+}
+
+struct Captured {
+    x: [Number; 4],
+    lambda: Vec<Number>,
+    z_l: Vec<Number>,
+    z_u: Vec<Number>,
+    mu: Number,
+    iters: i32,
+}
+
+fn cold_solve() -> Captured {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let concrete = Rc::new(RefCell::new(Hs071Seeded::default()));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    assert!(
+        matches!(status, ApplicationReturnStatus::SolveSucceeded),
+        "cold HS071 must solve: {status:?}"
+    );
+    let b = concrete.borrow();
+    Captured {
+        x: b.final_x.unwrap(),
+        lambda: b.final_lambda.clone().unwrap(),
+        z_l: b.final_z_l.clone().unwrap(),
+        z_u: b.final_z_u.clone().unwrap(),
+        mu: app.statistics().final_mu,
+        iters: app.statistics().iteration_count,
+    }
+}
+
+/// How much of the captured dual state a warm re-solve hands back.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Seeded {
+    /// Everything `TNLP::get_starting_point` can carry.
+    All,
+    /// The bound multipliers only — `lagrange` left out, the shape a
+    /// caller who kept `info["mult_x_L"]` but not `info["mult_g"]`
+    /// produces.
+    BoundsOnly,
+    /// The primal point and nothing else.
+    Nothing,
+}
+
+/// One warm re-solve of the same model.
+fn warm_solve(
+    seed: &Captured,
+    seeded: Seeded,
+    recentering: &str,
+    x0: Option<[Number; 4]>,
+) -> (
+    ApplicationReturnStatus,
+    i32,
+    Option<pounce_algorithm::init::warm_start::WarmStartDiagnostics>,
+) {
+    let mut app = IpoptApplication::new();
+    let o = app.options_mut();
+    o.set_integer_value("print_level", 0, true, false).unwrap();
+    o.set_string_value("warm_start_init_point", "yes", true, false)
+        .unwrap();
+    o.set_string_value("warm_start_recentering", recentering, true, false)
+        .unwrap();
+    // The recipe `docs/src/initialization.md` prescribes, and the one
+    // `pounce.WarmStart` emits: tight pushes plus the captured μ.
+    o.set_numeric_value("mu_init", seed.mu.clamp(1e-9, 1e-1), true, false)
+        .unwrap();
+    for k in [
+        "warm_start_bound_push",
+        "warm_start_bound_frac",
+        "warm_start_slack_bound_push",
+        "warm_start_slack_bound_frac",
+        "warm_start_mult_bound_push",
+    ] {
+        o.set_numeric_value(k, 1e-9, true, false).unwrap();
+    }
+    app.initialize().unwrap();
+
+    let concrete = Rc::new(RefCell::new(Hs071Seeded {
+        x0: Some(x0.unwrap_or(seed.x)),
+        lambda0: (seeded == Seeded::All).then(|| seed.lambda.clone()),
+        z_l0: (seeded != Seeded::Nothing).then(|| seed.z_l.clone()),
+        z_u0: (seeded != Seeded::Nothing).then(|| seed.z_u.clone()),
+        ..Default::default()
+    }));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    (
+        status,
+        app.statistics().iteration_count,
+        app.warm_start_diagnostics(),
+    )
+}
+
+/// The headline claim, on the block the acceptance criteria are about.
+/// An exact same-model restart hands back every multiplier the TNLP
+/// surface can carry — but not the *slack*-bound multipliers, which
+/// `TNLP::get_starting_point` has no field for and which therefore
+/// arrive as zero on every warm start there has ever been. Filling
+/// them from `warm_start_mult_bound_push` leaves a stationarity
+/// residual the solver then has to work off; reconstructing them from
+/// the seeded `y_d` does not.
+#[test]
+fn an_exact_restart_is_not_degraded_by_the_blocks_the_caller_cannot_seed() {
+    let seed = cold_solve();
+    let (st_legacy, it_legacy, _) = warm_solve(&seed, Seeded::All, "none", None);
+    let (st_resid, it_resid, diag) = warm_solve(&seed, Seeded::All, "residual", None);
+    let diag = diag.expect("a warm solve must report diagnostics");
+
+    eprintln!(
+        "HS071 exact restart: none={it_legacy} ({st_legacy:?}) \
+         residual={it_resid} ({st_resid:?}) cold={} \
+         mu {:e} -> {:e} inf_du_after={:e}",
+        seed.iters, diag.mu_in, diag.mu_out, diag.dual_residual
+    );
+    assert!(matches!(st_legacy, ApplicationReturnStatus::SolveSucceeded));
+    assert!(matches!(st_resid, ApplicationReturnStatus::SolveSucceeded));
+
+    // The equality/inequality multipliers *were* seeded, so they are
+    // kept; the slack-bound block was not, so it is rebuilt. That
+    // asymmetry is the whole content of this test.
+    assert_eq!(diag.eq_duals, BlockVerdict::Accepted);
+    assert_eq!(
+        diag.bound_duals,
+        BlockVerdict::Reconstructed,
+        "v_L/v_U have no TNLP seed field, so they must be rebuilt"
+    );
+    assert!(diag.bound_duals_reconstructed > 0);
+
+    // Reconstructed from stationarity, the supplied point *is* a KKT
+    // point, and the measured dual residual says so.
+    assert!(
+        diag.dual_residual < 1e-6,
+        "reconstruction must leave the point stationary, got {:e}",
+        diag.dual_residual
+    );
+    assert!(
+        diag.mu_out <= 1e-6,
+        "a KKT-quality point must keep a tight barrier, got mu_out={:e}",
+        diag.mu_out
+    );
+    assert!(
+        it_resid < it_legacy,
+        "an exact restart must not be degraded by the unseedable block: \
+         residual={it_resid} vs none={it_legacy} (cold={})",
+        seed.iters
+    );
+}
+
+/// The acceptance criterion's own case: a *partial* warm start, with
+/// the bound multipliers supplied and `lagrange` left out, must beat
+/// the zero-filled equality multipliers it used to get.
+///
+/// This is where the reconstruction is well-posed — the supplied
+/// blocks pin the missing one through stationarity — and it is the
+/// only place it runs.
+#[test]
+fn a_partial_warm_start_reconstructs_the_block_it_is_missing() {
+    let seed = cold_solve();
+    let (st_legacy, it_legacy, _) = warm_solve(&seed, Seeded::BoundsOnly, "none", None);
+    let (st_resid, it_resid, diag) = warm_solve(&seed, Seeded::BoundsOnly, "residual", None);
+    let diag = diag.expect("a warm solve must report diagnostics");
+
+    eprintln!(
+        "HS071 partial (bounds-only) warm start: none={it_legacy} ({st_legacy:?}) \
+         residual={it_resid} ({st_resid:?}) cold={} eq_duals={:?} inf_du_after={:e}",
+        seed.iters, diag.eq_duals, diag.dual_residual
+    );
+    assert!(matches!(st_legacy, ApplicationReturnStatus::SolveSucceeded));
+    assert!(matches!(st_resid, ApplicationReturnStatus::SolveSucceeded));
+
+    assert_eq!(
+        diag.eq_duals,
+        BlockVerdict::Reconstructed,
+        "an all-zero y block alongside real bound multipliers must go \
+         through the stationarity least-squares solve"
+    );
+    assert_eq!(diag.bound_duals, BlockVerdict::Reconstructed);
+    assert!(
+        it_resid < it_legacy,
+        "completing the seed must cost fewer iterations: residual={it_resid} \
+         vs none={it_legacy}"
+    );
+}
+
+/// A seed with *no* dual information is left alone, deliberately.
+///
+/// Reconstruction completes a partial warm start; it does not
+/// manufacture a whole one. From a primal point alone there is nothing
+/// to derive the multipliers from, and what comes out is the cold
+/// path's estimate paired with the warm path's barrier — measured over
+/// `benchmarks/warmstart` at 1102 -> 1211 iterations across 27
+/// parametric paths when it was allowed to run. The verdict says so
+/// rather than the initializer pretending it did something.
+#[test]
+fn a_primal_only_seed_is_reported_unseeded_and_left_alone() {
+    let seed = cold_solve();
+    let (st_legacy, it_legacy, _) = warm_solve(&seed, Seeded::Nothing, "none", None);
+    let (st_resid, it_resid, diag) = warm_solve(&seed, Seeded::Nothing, "residual", None);
+    let diag = diag.expect("a warm solve must report diagnostics");
+
+    eprintln!(
+        "HS071 primal-only warm start: none={it_legacy} ({st_legacy:?}) \
+         residual={it_resid} ({st_resid:?}) cold={}",
+        seed.iters
+    );
+    assert!(matches!(st_legacy, ApplicationReturnStatus::SolveSucceeded));
+    assert!(matches!(st_resid, ApplicationReturnStatus::SolveSucceeded));
+    assert_eq!(diag.bound_duals, BlockVerdict::Unseeded);
+    assert_eq!(diag.eq_duals, BlockVerdict::Unseeded);
+    assert_eq!(diag.bound_duals_reconstructed, 0);
+    assert!(!diag.stationarity_split);
+    assert_eq!(
+        it_resid, it_legacy,
+        "with nothing to reconstruct from, the trajectory must not move"
+    );
+}
+
+/// A stale point — the converged duals of this model pinned onto a
+/// primal point that is nowhere near feasible — must be recentered.
+/// `mu_init` asked for the converged barrier; the measurement
+/// overrides it, which is the mechanism that stops a stale warm start
+/// costing more than a cold one.
+#[test]
+fn a_stale_warm_point_is_recentered_above_mu_init() {
+    let seed = cold_solve();
+    let stale = [5.0, 1.0, 1.0, 5.0];
+    let (status, iters, diag) = warm_solve(&seed, Seeded::All, "residual", Some(stale));
+    let diag = diag.expect("diagnostics");
+    let (st_legacy, it_legacy, _) = warm_solve(&seed, Seeded::All, "none", Some(stale));
+    eprintln!(
+        "HS071 stale warm point: residual={iters} ({status:?}) none={it_legacy} \
+         ({st_legacy:?}) cold={} mu {:e} -> {:e} inf_pr={:e}",
+        seed.iters, diag.mu_in, diag.mu_out, diag.primal_residual
+    );
+    assert!(matches!(status, ApplicationReturnStatus::SolveSucceeded));
+    assert!(
+        diag.primal_residual > 1.0,
+        "the fixture must actually be stale: inf_pr={:e}",
+        diag.primal_residual
+    );
+    assert!(
+        diag.mu_out > diag.mu_in,
+        "a point this far off must not keep the converged barrier: \
+         mu_in={:e} mu_out={:e}",
+        diag.mu_in,
+        diag.mu_out
+    );
+}
+
+/// `warm_start_recentering=none` is the kill switch, and it has to be
+/// exactly that: with it set, nothing in gh#606 runs.
+#[test]
+fn recentering_none_leaves_every_block_alone() {
+    let seed = cold_solve();
+    let (_, _, diag) = warm_solve(&seed, Seeded::Nothing, "none", None);
+    let diag = diag.expect("diagnostics");
+    assert!(diag.recentering_disabled);
+    assert_eq!(diag.bound_duals, BlockVerdict::Absent);
+    assert_eq!(diag.eq_duals, BlockVerdict::Absent);
+    assert_eq!(diag.bound_duals_reconstructed, 0);
+    assert_eq!(
+        diag.mu_in, diag.mu_out,
+        "μ must be untouched when recentering is off"
+    );
+}
+
+/// gh#606 scope item 5, the refusal half. Both flags name Ipopt's
+/// `TNLP::GetWarmStartIterate`, which pounce does not expose; they used
+/// to parse into `WarmStartOptions` fields the initializer never read.
+#[test]
+fn the_get_warm_start_iterate_flags_are_refused_not_half_served() {
+    for name in ["warm_start_same_structure", "warm_start_entire_iterate"] {
+        let mut app = IpoptApplication::new();
+        assert_eq!(app.unimplemented_option_refusal(), None, "unset: {name}");
+
+        app.options_mut()
+            .set_string_value(name, "no", true, false)
+            .expect("upstream's default must still parse");
+        assert_eq!(
+            app.unimplemented_option_refusal(),
+            None,
+            "`{name}=no` asks for nothing and must keep working"
+        );
+
+        app.options_mut()
+            .set_string_value(name, "yes", true, false)
+            .expect("upstream's value must still parse");
+        let msg = app
+            .unimplemented_option_refusal()
+            .unwrap_or_else(|| panic!("`{name}=yes` must be refused"));
+        assert!(msg.contains(name), "{msg}");
+        assert!(msg.contains("GetWarmStartIterate"), "{msg}");
+        assert!(msg.contains("606"), "message should name the issue: {msg}");
+    }
+}
+
+/// The invariant that would have caught the two dead flags without
+/// anyone noticing them by hand: a registered `Warm Start` option is
+/// either read by the solver or explicitly refused. Mirrors
+/// `every_registered_initialization_option_is_consumed_or_refused` in
+/// `init_options_wiring.rs` (gh#604) one category over.
+#[test]
+fn every_registered_warm_start_option_is_consumed_or_refused() {
+    use pounce_algorithm::unimplemented_options::{UNIMPLEMENTED_FEATURES, UNIMPLEMENTED_VALUES};
+
+    let app = IpoptApplication::new();
+    let refused: BTreeSet<&str> = UNIMPLEMENTED_FEATURES
+        .iter()
+        .flat_map(|g| g.options.iter().copied())
+        .chain(UNIMPLEMENTED_VALUES.iter().map(|v| v.option))
+        .collect();
+    let sources = solver_sources();
+
+    let mut dangling = Vec::new();
+    for opt in app.registered_options().registered_options_in_order() {
+        if opt.category != "Warm Start" {
+            continue;
+        }
+        if refused.contains(opt.name.as_str()) {
+            continue;
+        }
+        let quoted = format!("\"{}\"", opt.name);
+        if sources.iter().any(|s| s.contains(&quoted)) {
+            continue;
+        }
+        dangling.push(opt.name.clone());
+    }
+    assert!(
+        dangling.is_empty(),
+        "these Warm Start options are registered but neither read nor \
+         refused — setting one does nothing, silently: {dangling:?}"
+    );
+
+    let n = app
+        .registered_options()
+        .registered_options_in_order()
+        .iter()
+        .filter(|o| o.category == "Warm Start")
+        .count();
+    assert!(n >= 10, "the category must be non-empty, found {n}");
+}
+
+/// Every `.rs` under the solver crates, concatenated, minus the
+/// registry itself — the same trick `init_options_wiring.rs` uses to
+/// ask "does anything read this name?".
+fn solver_sources() -> Vec<String> {
+    fn walk(dir: &std::path::Path, out: &mut Vec<String>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                walk(&p, out);
+            } else if p.extension().is_some_and(|x| x == "rs")
+                && p.file_name().is_some_and(|f| f != "upstream_options.rs")
+            {
+                if let Ok(s) = std::fs::read_to_string(&p) {
+                    out.push(s);
+                }
+            }
+        }
+    }
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/");
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    out
+}

--- a/crates/pounce-algorithm/tests/warm_start_recentering.rs
+++ b/crates/pounce-algorithm/tests/warm_start_recentering.rs
@@ -549,3 +549,385 @@ fn solver_sources() -> Vec<String> {
     walk(root, &mut out);
     out
 }
+
+// ---------------------------------------------------------------
+// gh#606 review regressions.
+//
+// The model above has one equality row and one inequality row, so
+// both `y` blocks are non-empty in every test written against it.
+// That is exactly the shape that hid the first defect below, so
+// these use a two-variable model with only *one* of the two blocks.
+// ---------------------------------------------------------------
+
+/// Which constraint block the single row lands in.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Row {
+    /// `x0 + x1 == 2` — `y_c` has one entry, `y_d` is empty.
+    Equality,
+    /// `x0 + x1 <= 2`, active at the optimum — `y_c` is empty.
+    Inequality,
+}
+
+/// `min (x0−3)² + (x1−3)²` over `0 ≤ x ≤ 10` with a single row, whose
+/// optimum sits on that row at `x = (1, 1)`.
+struct OneBlock {
+    row: Row,
+    /// With `free`, `x` has no finite bounds — so the four bound
+    /// multiplier blocks are all zero-dimension and there is nothing
+    /// for the stationarity split to rebuild.
+    free: bool,
+    x0: Option<[Number; 2]>,
+    lambda0: Option<Vec<Number>>,
+    z_l0: Option<Vec<Number>>,
+    z_u0: Option<Vec<Number>>,
+    final_x: Option<[Number; 2]>,
+    final_obj: Option<Number>,
+    final_lambda: Option<Vec<Number>>,
+    final_z_l: Option<Vec<Number>>,
+    final_z_u: Option<Vec<Number>>,
+}
+
+impl OneBlock {
+    fn new(row: Row) -> Self {
+        Self {
+            row,
+            free: false,
+            x0: None,
+            lambda0: None,
+            z_l0: None,
+            z_u0: None,
+            final_x: None,
+            final_obj: None,
+            final_lambda: None,
+            final_z_l: None,
+            final_z_u: None,
+        }
+    }
+}
+
+impl TNLP for OneBlock {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 2,
+            m: 1,
+            nnz_jac_g: 2,
+            nnz_h_lag: 2,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        if self.free {
+            b.x_l.copy_from_slice(&[-2.0e19, -2.0e19]);
+            b.x_u.copy_from_slice(&[2.0e19, 2.0e19]);
+        } else {
+            b.x_l.copy_from_slice(&[0.0, 0.0]);
+            b.x_u.copy_from_slice(&[10.0, 10.0]);
+        }
+        match self.row {
+            Row::Equality => {
+                b.g_l.copy_from_slice(&[2.0]);
+                b.g_u.copy_from_slice(&[2.0]);
+            }
+            Row::Inequality => {
+                b.g_l.copy_from_slice(&[-2.0e19]);
+                b.g_u.copy_from_slice(&[2.0]);
+            }
+        }
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        if sp.init_x {
+            sp.x.copy_from_slice(&self.x0.unwrap_or([0.5, 0.5]));
+        }
+        // Left unserved by default: the "bound multipliers kept,
+        // `lagrange` dropped" shape. The free-variable fixture is the
+        // mirror image and seeds it.
+        if sp.init_lambda {
+            if let Some(l) = &self.lambda0 {
+                sp.lambda.copy_from_slice(l);
+            }
+        }
+        if sp.init_z {
+            if let Some(z) = &self.z_l0 {
+                sp.z_l.copy_from_slice(z);
+            }
+            if let Some(z) = &self.z_u0 {
+                sp.z_u.copy_from_slice(z);
+            }
+        }
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        Some((x[0] - 3.0).powi(2) + (x[1] - 3.0).powi(2))
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = 2.0 * (x[0] - 3.0);
+        g[1] = 2.0 * (x[1] - 3.0);
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0] + x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 0]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 1.0;
+                values[1] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0, 1]);
+                jcol.copy_from_slice(&[0, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                // The row is linear, so `lambda` contributes nothing.
+                values[0] = 2.0 * obj_factor;
+                values[1] = 2.0 * obj_factor;
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, sol: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {
+        if sol.x.len() == 2 {
+            self.final_x = Some([sol.x[0], sol.x[1]]);
+        }
+        self.final_obj = Some(sol.obj_value);
+        self.final_lambda = Some(sol.lambda.to_vec());
+        self.final_z_l = Some(sol.z_l.to_vec());
+        self.final_z_u = Some(sol.z_u.to_vec());
+    }
+}
+
+/// Cold-solve a `OneBlock`, then warm-restart it from its own answer
+/// with the bound multipliers seeded and `lagrange` left out.
+fn one_block_restart(
+    row: Row,
+    mu_init: Number,
+) -> (
+    ApplicationReturnStatus,
+    pounce_algorithm::init::warm_start::WarmStartDiagnostics,
+) {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let concrete = Rc::new(RefCell::new(OneBlock::new(row)));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    assert!(
+        matches!(status, ApplicationReturnStatus::SolveSucceeded),
+        "cold OneBlock must solve: {status:?}"
+    );
+    let (x, z_l, z_u, obj) = {
+        let b = concrete.borrow();
+        (
+            b.final_x.unwrap(),
+            b.final_z_l.clone().unwrap(),
+            b.final_z_u.clone().unwrap(),
+            b.final_obj.unwrap(),
+        )
+    };
+    // The row is active at the optimum in both variants, which is what
+    // makes the missing `y` worth reconstructing.
+    assert!(
+        (x[0] + x[1] - 2.0).abs() < 1e-6,
+        "fixture must sit on its row: x={x:?} obj={obj}"
+    );
+
+    let mut app = IpoptApplication::new();
+    let o = app.options_mut();
+    o.set_integer_value("print_level", 0, true, false).unwrap();
+    o.set_string_value("warm_start_init_point", "yes", true, false)
+        .unwrap();
+    o.set_string_value("warm_start_recentering", "residual", true, false)
+        .unwrap();
+    o.set_numeric_value("mu_init", mu_init, true, false)
+        .unwrap();
+    for k in [
+        "warm_start_bound_push",
+        "warm_start_bound_frac",
+        "warm_start_slack_bound_push",
+        "warm_start_slack_bound_frac",
+        "warm_start_mult_bound_push",
+    ] {
+        o.set_numeric_value(k, 1e-9, true, false).unwrap();
+    }
+    app.initialize().unwrap();
+    let concrete = Rc::new(RefCell::new(OneBlock {
+        x0: Some(x),
+        z_l0: Some(z_l),
+        z_u0: Some(z_u),
+        ..OneBlock::new(row)
+    }));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    (
+        status,
+        app.warm_start_diagnostics()
+            .expect("a warm solve must report diagnostics"),
+    )
+}
+
+/// gh#606 review defect 1. `is_identically_zero` answered `false` for a
+/// zero-dimension block, so on a model with only equality rows (or only
+/// inequality rows) the `seeded` test short-circuited to `true`, the
+/// least-squares reconstruction never ran, and the diagnostics reported
+/// `eq_duals: Accepted` for a block nothing had seeded.
+///
+/// Equality-only and inequality-only models are most of the feature's
+/// reach, and `Hs071Seeded` cannot see this: it has one row of each.
+#[test]
+fn a_single_constraint_block_still_reaches_the_reconstruction() {
+    for row in [Row::Equality, Row::Inequality] {
+        let (status, diag) = one_block_restart(row, 1e-7);
+        let which = if row == Row::Equality { "eq" } else { "ineq" };
+        eprintln!(
+            "OneBlock {which}-only: status={status:?} eq_duals={:?} \
+             bound_duals={:?} reconstructed={} inf_du={:e} split={}",
+            diag.eq_duals,
+            diag.bound_duals,
+            diag.bound_duals_reconstructed,
+            diag.dual_residual,
+            diag.stationarity_split
+        );
+        assert!(matches!(status, ApplicationReturnStatus::SolveSucceeded));
+        assert_eq!(
+            diag.eq_duals,
+            BlockVerdict::Reconstructed,
+            "{which}-only model: the y block was never seeded, so it must \
+             be rebuilt rather than reported as kept"
+        );
+    }
+}
+
+/// gh#606 review defect 2. `final_mu` applied the `[MU_FLOOR,
+/// MU_CEILING]` clamp to the pass-through value as well as to the
+/// escalated one, so an explicit `mu_init` above the ceiling was
+/// silently lowered on every warm start — and silently, because the
+/// `wmu` info token only fires when μ goes *up*.
+///
+/// The function's own contract is "`mu_in` is a floor, never a
+/// ceiling".
+#[test]
+fn an_explicit_mu_init_above_the_ceiling_survives_when_nothing_escalates() {
+    // 1.0 is ten times `MU_CEILING`. A restart from the model's own
+    // answer measures a complementarity far below `10 · mu_in`, so no
+    // escalation fires and μ must come out exactly as it went in.
+    let (status, diag) = one_block_restart(Row::Equality, 1.0);
+    eprintln!(
+        "OneBlock mu pass-through: status={status:?} mu {:e} -> {:e} compl={:e}",
+        diag.mu_in, diag.mu_out, diag.complementarity
+    );
+    assert!(matches!(status, ApplicationReturnStatus::SolveSucceeded));
+    assert!(
+        diag.complementarity <= 10.0 * diag.mu_in,
+        "fixture must not escalate, or it tests the wrong branch: \
+         compl={:e} mu_in={:e}",
+        diag.complementarity,
+        diag.mu_in
+    );
+    assert_eq!(
+        diag.mu_out, diag.mu_in,
+        "an explicit mu_init the caller chose must not be capped: \
+         mu_in={:e} mu_out={:e}",
+        diag.mu_in, diag.mu_out
+    );
+}
+
+/// gh#606 review, the cosmetic one: `stationarity_split` was set from
+/// the fact that the split was *called*, not from whether it did
+/// anything. It returns early when there is no unseeded bound
+/// multiplier to rebuild, and claiming otherwise made
+/// `info["warm_start"]` untrue.
+///
+/// Reaching that early return takes a model with **no bound
+/// multipliers at all** and a seeded `y`: free variables make the four
+/// `z`/`v` blocks zero-dimension, and a supplied `lagrange` keeps
+/// `eq_duals` at `Accepted` so the split is still called. On HS071 it
+/// is unreachable — the slack-bound block is never seedable, so
+/// something is always rebuilt there and the flag was accidentally
+/// right.
+#[test]
+fn stationarity_split_is_reported_only_when_it_runs() {
+    let mut app = IpoptApplication::new();
+    app.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let concrete = Rc::new(RefCell::new(OneBlock {
+        free: true,
+        ..OneBlock::new(Row::Equality)
+    }));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    assert!(matches!(
+        app.optimize_tnlp(tnlp),
+        ApplicationReturnStatus::SolveSucceeded
+    ));
+    let (x, lambda) = {
+        let b = concrete.borrow();
+        (b.final_x.unwrap(), b.final_lambda.clone().unwrap())
+    };
+
+    let mut app = IpoptApplication::new();
+    let o = app.options_mut();
+    o.set_integer_value("print_level", 0, true, false).unwrap();
+    o.set_string_value("warm_start_init_point", "yes", true, false)
+        .unwrap();
+    o.set_string_value("warm_start_recentering", "residual", true, false)
+        .unwrap();
+    app.initialize().unwrap();
+    let concrete = Rc::new(RefCell::new(OneBlock {
+        free: true,
+        x0: Some(x),
+        lambda0: Some(lambda),
+        ..OneBlock::new(Row::Equality)
+    }));
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::clone(&concrete) as _;
+    let status = app.optimize_tnlp(tnlp);
+    let diag = app.warm_start_diagnostics().expect("diagnostics");
+    eprintln!(
+        "OneBlock free+seeded-y: status={status:?} bound_duals={:?} \
+         eq_duals={:?} reconstructed={} split={}",
+        diag.bound_duals, diag.eq_duals, diag.bound_duals_reconstructed, diag.stationarity_split
+    );
+    assert_eq!(
+        diag.bound_duals_reconstructed, 0,
+        "fixture must have no bound multiplier to rebuild, or it tests \
+         the wrong branch"
+    );
+    assert!(
+        !diag.stationarity_split,
+        "the flag must track the work, not the call site"
+    );
+}

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -9,6 +9,7 @@
 use numpy::{IntoPyArray, PyArray1, PyArrayMethods, PyUntypedArrayMethods};
 use pounce_algorithm::alg_builder::{LinearBackendFactory, LinearSolverChoice};
 use pounce_algorithm::application::IpoptApplication;
+use pounce_algorithm::init::warm_start::{BlockVerdict, WarmStartDiagnostics};
 use pounce_common::types::{Index, Number};
 use pounce_linsol::sparse_sym_iface::SparseSymLinearSolverInterface;
 use pounce_nlp::return_codes::ApplicationReturnStatus;
@@ -382,6 +383,7 @@ impl PyProblem {
             stats.final_unscaled_compl,
             stats.sqp_qp_solves,
             stats.sqp_qp_working_set_changes,
+            app.warm_start_diagnostics(),
         )?;
         let ws_obj: PyObject = match &self.last_working_set {
             Some(ws) => encode_working_set(py, ws).into_any().unbind(),
@@ -733,6 +735,7 @@ impl PyProblem {
             stats.final_unscaled_compl,
             stats.sqp_qp_solves,
             stats.sqp_qp_working_set_changes,
+            app.warm_start_diagnostics(),
         )?;
         info.set_item("dx", opt_vec_to_py(py, result.dx))?;
         info.set_item("dx_full", opt_vec_to_py(py, result.dx_full))?;
@@ -1087,6 +1090,18 @@ fn write_solve_report(
     Ok(())
 }
 
+/// Stable string name for a warm-start block verdict, so
+/// `info["warm_start"]` reads the same from Python as the Rust enum.
+fn verdict_name(v: BlockVerdict) -> &'static str {
+    match v {
+        BlockVerdict::Absent => "absent",
+        BlockVerdict::Accepted => "accepted",
+        BlockVerdict::Reconstructed => "reconstructed",
+        BlockVerdict::Discarded => "discarded",
+        BlockVerdict::Unseeded => "unseeded",
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn build_info_dict<'py>(
     py: Python<'py>,
@@ -1104,8 +1119,26 @@ pub(crate) fn build_info_dict<'py>(
     final_unscaled_compl: Number,
     sqp_qp_solves: i32,
     sqp_qp_working_set_changes: i32,
+    warm_start: Option<WarmStartDiagnostics>,
 ) -> PyResult<Bound<'py, PyDict>> {
     let info = PyDict::new_bound(py);
+    // gh#606: what the warm-start initializer made of the seeds this
+    // call supplied. Absent on a cold solve, so a caller can tell
+    // "warm start did nothing" from "warm start was not requested".
+    if let Some(w) = warm_start {
+        let d = PyDict::new_bound(py);
+        d.set_item("primal_residual", w.primal_residual)?;
+        d.set_item("dual_residual", w.dual_residual)?;
+        d.set_item("complementarity", w.complementarity)?;
+        d.set_item("mu_in", w.mu_in)?;
+        d.set_item("mu_out", w.mu_out)?;
+        d.set_item("bound_duals", verdict_name(w.bound_duals))?;
+        d.set_item("eq_duals", verdict_name(w.eq_duals))?;
+        d.set_item("bound_duals_reconstructed", w.bound_duals_reconstructed)?;
+        d.set_item("stationarity_split", w.stationarity_split)?;
+        d.set_item("recentering_disabled", w.recentering_disabled)?;
+        info.set_item("warm_start", d)?;
+    }
     info.set_item("status", status as i32)?;
     info.set_item("status_msg", status_message(status))?;
     info.set_item("obj_val", bridge.state.final_obj)?;

--- a/crates/pounce-py/src/solver.rs
+++ b/crates/pounce-py/src/solver.rs
@@ -147,6 +147,7 @@ impl PySolver {
             stats.final_unscaled_compl,
             stats.sqp_qp_solves,
             stats.sqp_qp_working_set_changes,
+            inner.app().warm_start_diagnostics(),
         )?;
         let x_out = bridge.borrow().state.final_x.clone().into_pyarray_bound(py);
         let _ = bridge; // alive via inner's Rc<RefCell<dyn TNLP>> clone

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -185,8 +185,13 @@ initializer instead rebuilds what it was not given:
   the same regularized least-squares augmented solve the cold path
   uses, now with real bound multipliers in its right-hand side;
 - `mu` is raised to the point's measured average complementarity when
-  that exceeds `mu_init`, so a stale seed gets a looser barrier instead
-  of being trusted. The primal and dual residuals deliberately do
+  that exceeds `mu_init` **by more than a factor of ten**, so a stale
+  seed gets a looser barrier instead of being trusted while a merely
+  imperfect one keeps the barrier it asked for. Moving `mu` reroutes
+  the whole trajectory, so a near miss is not worth what the reroute
+  costs. The measurement is clamped to `[1e-11, 0.1]`; `mu_init`
+  itself is not, so an explicit setting outside that band is a floor
+  and is never capped. The primal and dual residuals deliberately do
   **not** move `mu`: a warm point at a moved parameter carries both by
   construction, and reacting to them discards the warm start to pay for
   a Newton step that was about to happen anyway.

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -114,7 +114,9 @@ any one of them silently degrades to (roughly) a cold solve:
 2. **Lower `mu_init`.** The default `0.1` makes the solver walk the
    barrier schedule down from scratch even when started at the
    optimum. Seed it near the converged complementarity (e.g. `1e-7`
-   after a `tol=1e-8` solve).
+   after a `tol=1e-8` solve). Since #606 this is a *floor*: the solver
+   measures the point you supplied and raises `mu` above it if the
+   point cannot support that barrier (see below).
 3. **Tighten the warm-start pushes.** The warm initializer applies
    its own interior clamp with `warm_start_bound_push` / `_frac`
    (default `1e-3`), which shoves an at-the-bound solution back off
@@ -152,6 +154,71 @@ the `.nl` file's dual segment when present.
 | `warm_start_slack_bound_push` / `warm_start_slack_bound_frac` | `1e-3` | Same, for slacks. |
 | `warm_start_mult_bound_push` | `1e-3` | Floor on seeded bound multipliers (a carried-in `z = 0` must not start on the barrier's boundary). |
 | `warm_start_mult_init_max` | `1e6` | Cap on seeded equality multipliers. |
+| `warm_start_recentering` | `residual` | Reconstruct the multiplier blocks the caller did not supply, and raise `mu` when the supplied point cannot support it. `none` restores the pre-#606 constants. |
+
+### What the solver does with a partial warm start
+
+Two things about the list above are worth knowing before you tune it.
+
+**You cannot seed every multiplier block.** `TNLP::get_starting_point`
+— which is what `lagrange` / `zl` / `zu` reach — carries the equality
+multipliers and the *variable*-bound multipliers. The interior-point
+method also needs a multiplier for each inequality row's slack
+(`v_L` / `v_U` internally), and there is no field for those on any
+frontend. On every warm start ever run they arrived as zero and were
+floored at `warm_start_mult_bound_push`.
+
+**A constant is the wrong fill.** `warm_start_mult_bound_push` is a
+number chosen with no reference to the slacks it is paired against, so
+the "warm" point it produces is not a stationary point of anything.
+
+Under `warm_start_recentering=residual` (the default since #606) the
+initializer instead rebuilds what it was not given:
+
+- a bound-multiplier entry that arrives as exactly `0` (or `NaN`) is
+  not a legal barrier multiplier, so it was never a seed; it is
+  re-derived from the stationarity identity
+  `P_L z_L − P_U z_U = ∇f + J_c^T y_c + J_d^T y_d` (and its slack-block
+  twin `P_L v_L − P_U v_U = −y_d`), floored at `μ / slack` so an
+  inactive bound still gets the value complementarity implies;
+- an equality-multiplier block that is identically zero goes through
+  the same regularized least-squares augmented solve the cold path
+  uses, now with real bound multipliers in its right-hand side;
+- `mu` is raised to the point's measured average complementarity when
+  that exceeds `mu_init`, so a stale seed gets a looser barrier instead
+  of being trusted. The primal and dual residuals deliberately do
+  **not** move `mu`: a warm point at a moved parameter carries both by
+  construction, and reacting to them discards the warm start to pay for
+  a Newton step that was about to happen anyway.
+
+`warm_start_target_mu`, when set, still pins `mu` outright.
+
+What happened is reported back. From Python it is `info["warm_start"]`:
+
+```python
+x2, info2 = warm.solve(x0=x, zl=..., zu=...)
+info2["warm_start"]
+# {'primal_residual': 1.6e-09, 'dual_residual': 3.5e-10,
+#  'complementarity': 4.2e-09, 'mu_in': 2.5e-09, 'mu_out': 4.2e-09,
+#  'bound_duals': 'reconstructed', 'eq_duals': 'accepted',
+#  'bound_duals_reconstructed': 1, 'recentering_disabled': False}
+```
+
+From Rust it is `IpoptApplication::warm_start_diagnostics()`. At
+`print_level=5` the iteration line carries `wz` (bound multipliers
+rebuilt), `wy` (equality multipliers rebuilt), `wy0` (a reconstruction
+was discarded) and `wmu` (the barrier was loosened).
+
+### Two options that are refused
+
+`warm_start_same_structure` and `warm_start_entire_iterate` are
+registered — an `ipopt.opt` written for Ipopt parses unchanged — but
+both name Ipopt's `TNLP::GetWarmStartIterate` surface, which pounce
+does not expose. Setting either to `yes` used to parse, set a field
+nothing read, and change nothing at all. Since #606 it fails with a
+message instead. `warm_start_init_point=yes` is the supported route
+and carries the primal point and every multiplier block the TNLP
+surface has.
 
 Even a well-executed IPM warm start has a structural limit: the
 barrier pushes iterates off the bounds, so the active-set information

--- a/python/pounce/_warm_start.py
+++ b/python/pounce/_warm_start.py
@@ -20,6 +20,16 @@ recipe into a single argument::
 and dual iterates and sets the five enabling options; on the active-set
 SQP path (``algorithm=active-set-sqp``) it forwards the captured
 working set, which is that path's warm-start payload.
+
+Since pounce#606 the *quality* of the supplied point is the solver's
+business rather than this object's: with the default
+``recentering="residual"`` the interior-point initializer measures the
+seeded iterate's primal, dual and complementarity residuals and picks
+μ, the fills for any multiplier block the caller left out, and the
+recentering strength from that measurement. The knobs here therefore
+set a floor, not a verdict — ``mu_init`` is the barrier the caller
+would *like*, and a stale point gets a looser one. What the solver
+decided is reported back in ``info["warm_start"]``.
 """
 
 from __future__ import annotations
@@ -60,8 +70,20 @@ class WarmStart:
             at-the-bound solution essentially where it is; raise it if
             the next problem's solution may sit elsewhere.
         mu_init: Explicit ``mu_init`` override; default derives it from
-            ``mu`` (clamped to ``[1e-9, 1e-1]``).
+            ``mu`` (clamped to ``[1e-9, 1e-1]``). Under the default
+            ``recentering="residual"`` this is a **floor**, not a
+            setting: the solver measures the supplied point and raises
+            μ above it when the point cannot support that barrier
+            (pounce#606). Pass ``warm_start_target_mu`` yourself to pin
+            μ outright.
         mu_init_fallback: ``mu_init`` used when ``mu`` is unknown.
+        recentering: ``warm_start_recentering`` (pounce#606).
+            ``"residual"`` (the default) lets the solver measure the
+            supplied point's primal/dual/complementarity residuals and
+            derive μ, the unseeded bound-multiplier fills, and the
+            equality-multiplier reconstruction from them.
+            ``"none"`` restores the pre-#606 universal constants.
+            ``None`` leaves the option unset (solver default).
     """
 
     x: np.ndarray
@@ -73,6 +95,7 @@ class WarmStart:
     bound_push: float = 1e-9
     mu_init: Optional[float] = None
     mu_init_fallback: float = 1e-6
+    recentering: Optional[str] = "residual"
 
     def __post_init__(self):
         self.x = np.asarray(self.x, dtype=float).ravel()
@@ -119,6 +142,11 @@ class WarmStart:
              self.mu_init if self.mu_init is not None else np.nan,
              self.mu_init_fallback]
         )}
+        # `recentering` is a string, so it rides in its own array
+        # rather than in the numeric `_meta` row. Absent in archives
+        # written before pounce#606; `load` treats that as the default.
+        if self.recentering is not None:
+            payload["_recentering"] = np.array(self.recentering)
         for key in ("lagrange", "zl", "zu"):
             v = getattr(self, key)
             if v is not None:
@@ -135,6 +163,11 @@ class WarmStart:
             working_set = None
             if "ws_bounds" in data.files:
                 working_set = (data["ws_bounds"], data["ws_constraints"])
+            recentering = (
+                str(data["_recentering"])
+                if "_recentering" in data.files
+                else None
+            )
             return cls(
                 x=data["x"],
                 lagrange=data["lagrange"] if "lagrange" in data.files else None,
@@ -145,6 +178,7 @@ class WarmStart:
                 bound_push=float(meta[1]),
                 mu_init=None if np.isnan(meta[2]) else float(meta[2]),
                 mu_init_fallback=float(meta[3]),
+                recentering=recentering,
             )
 
     # -- application ----------------------------------------------------
@@ -164,7 +198,7 @@ class WarmStart:
         else:
             mu_init = self.mu_init_fallback
         p = self.bound_push
-        return {
+        opts = {
             "warm_start_init_point": "yes",
             "mu_init": mu_init,
             "warm_start_bound_push": p,
@@ -173,6 +207,9 @@ class WarmStart:
             "warm_start_slack_bound_frac": p,
             "warm_start_mult_bound_push": p,
         }
+        if self.recentering is not None:
+            opts["warm_start_recentering"] = self.recentering
+        return opts
 
     def solve_kwargs(self) -> dict:
         """The seed keyword arguments for :meth:`Problem.solve`."""


### PR DESCRIPTION
Fixes #606

## Problem

Two defects in the interior-point warm start, both invisible from the outside, both measured on the parent commit `70bf53de` before anything was changed.

**1. You cannot seed every multiplier block, and the block you cannot seed was filled with a constant.** `TNLP::get_starting_point` — what `lagrange` / `zl` / `zu` reach on Python, the C ABI and the `.nl` path alike — carries the constraint multipliers and the *variable*-bound multipliers. The IPM also needs a multiplier for each inequality row's slack (`v_L` / `v_U` internally), and no frontend has a field for one. On every warm start POUNCE has ever run, that block arrived as zero and was floored at `warm_start_mult_bound_push` — a number chosen with no reference to the slacks it is paired against. The "warm" point handed to the solver was therefore not a stationary point of anything.

On HS071, restarting from its own converged solution with every multiplier the TNLP surface can carry:

| | iters | measured `‖∇ₓL‖∞` after init |
|---|---|---|
| before | 2 | — (not measured) |
| after | 1 | 3.5e-10 |
| cold, same model | 8 | |

**2. `mu_init` was taken on trust.** A restart at the optimum and a stale point from a different parameter both started on exactly the barrier the caller named. On HS071 warm-started from the far corner of its box with the converged duals attached — the documented recipe from `docs/src/initialization.md`, applied to a point that has moved:

| | status | iters |
|---|---|---|
| before | **`RestorationFailed`** | 36 |
| after | `SolveSucceeded` | 43 |
| cold, same model | `SolveSucceeded` | 8 |

That is not a slowdown. The pre-#606 path *fails* on it.

**3. Two advertised options did nothing.** `warm_start_same_structure` and `warm_start_entire_iterate` parsed, set a field on `WarmStartOptions`, and were never read. Verified bit-for-bit on `70bf53de` before touching anything — a warm re-solve of `simplex_proj` with each flag, both, or neither:

| `70bf53de` | status | iters | objective | KKT error |
|---|---|---|---|---|
| neither set | 0 | 2 | 0.590398708046706 | 2.5059430435806254e-09 |
| `same_structure=yes` | 0 | 2 | 0.590398708046706 | 2.5059430435806254e-09 |
| `entire_iterate=yes` | 0 | 2 | 0.590398708046706 | 2.5059430435806254e-09 |
| both `yes` | 0 | 2 | 0.590398708046706 | 2.5059430435806254e-09 |

Identical to the last digit. The issue's claim that their "promised reuse semantics are incomplete" is generous: they were complete no-ops.

## Cause

The warm initializer (`crates/pounce-algorithm/src/init/warm_start.rs`) received `cq` and `aug_solver` and used neither — both were bound as `_cq` and `_aug_solver`. Every decision it made was a function of the options rather than of the iterate it was handed: fixed pushes, a fixed multiplier floor, a fixed `mu`. There was no measurement anywhere in it, so there was nothing for it to adapt to.

The two dead flags name Ipopt's `TNLP::GetWarmStartIterate` surface, which POUNCE does not expose at all.

## Fix

`warm_start_recentering` (new, `residual` | `none`, default `residual`) turns the initializer into a pass over the supplied point.

1. **Measure.** `inf_pr` first — it is the one residual that does not depend on the duals, so it is meaningful even when every multiplier block is missing.
2. **Reconstruct the bound multipliers.** An entry that arrives as exactly `0` or `NaN` is not a legal barrier multiplier (the barrier needs `z > 0`), so it was never a seed — and it is already special-cased today, being floored at `warm_start_mult_bound_push`. What changes is the value it takes: the stationarity identity `P_L z_L − P_U z_U = ∇f + J_c^T y_c + J_d^T y_d`, and its slack-block twin `P_L v_L − P_U v_U = −y_d`, split by sign and floored at `μ / slack` so an inactive bound still gets what complementarity implies.
3. **Reconstruct an identically-zero `y` block** through the same regularized least-squares augmented solve the cold path uses (`LeastSquareMults`), now with real bound multipliers in its right-hand side.
4. **Raise `μ`** to the point's measured average complementarity when that overshoots `mu_init` by more than 10×.

`warm_start_target_mu` still pins `μ` outright. `warm_start_recentering=none` restores pre-#606 behaviour exactly.

### Four things tried and rejected, each on a number

A future maintainer retuning this will otherwise repeat these experiments. Each is documented at its definition in the source.

**Rejected: `μ ≥ κ·max(inf_pr, inf_du)`.** This is the obvious reading of the issue's "choose `mu` … from those residuals", and it is wrong. It cost **715 → 1129 iterations** across the 27 parametric paths of `benchmarks/warmstart`. On `simplex_proj/tiny`, a re-solve that needed one iteration measured `inf_du = 2e-3`, took `μ = 2e-3`, and needed five. A warm point at a moved parameter carries a primal and a dual residual of order Δθ *by construction* — that is the premise of warm starting — and raising `μ` to meet them throws the warm start away to pay for a Newton step that was about to happen anyway. Of the three KKT residuals, complementarity is the one `μ` *is*; the other two are what the Newton step is for. `avrg_compl` on that same point read `2.6e-9`, the converged barrier, correctly recognised.

**Rejected: filling `z = μ̂/slack` with a residual-inflated `μ̂`.** The slacks reaching the initializer have already been pushed into the bound interior by `warm_start_slack_bound_push`, so on a converged point — where the true slack sits at `μ/z` and the push dominates it — `μ̂/slack` is off by exactly the push's inflation. On HS071 an 8×-inflated `μ̂` put the reconstructed slack multiplier 8× high and took an exact restart from 1 iteration to 5. The fill barrier is `mu_init`; the stationarity split, which never looks at a slack, is immune to it entirely.

**Rejected: overriding `μ` whenever the measurement disagrees.** Moving `μ` reroutes the whole trajectory, so it has to be earned. On `cresc4` (nonconvex, enters restoration on iteration 2, where perturbations compound) a measurement of `5e-7` against a `mu_init` of `1e-7` moved `μ` by half an order and the solve from **85 iterations to 206** — same status, same objective, 2.4× the work. This is the gh#544 shape exactly. Hence the 10× trigger; with it that fixture is bit-identical again, and the cases this exists for (stale seeds miss by three to six orders) still fire.

**Rejected: reconstructing from a seed with no duals at all.** Completing a *partial* warm start is well-posed — the supplied blocks pin the missing ones through stationarity. Manufacturing a whole one from a primal point is not: what comes out is the cold path's estimate wearing the warm path's barrier, and it cost **1102 → 1211 iterations** on the same corpus (`degenerate_corner` 17 → 38 at every step size). Such a seed is now reported `unseeded` and left exactly as before. The same reasoning capped the least-squares `y` estimate at `constr_mult_init_max` (1e3, the cold path's cap) rather than `warm_start_mult_init_max` (1e6): on `redundant_rows`, whose duplicated equality rows make the system singular, the looser cap let an arbitrary estimate through and cost 7 → 25 iterations.

### Scope: what was and was not done

The issue lists six items. Items 1, 2, 3, 5 and 6 are implemented.

- **Item 4** — "a genuinely complete iterate transfer (… and reusable structure/factorization where valid)" — is **not** done, and is the same missing capability as item 5's refused half: it needs the `GetWarmStartIterate` TNLP surface POUNCE does not expose, plus a factorization-reuse path that does not exist. Building it is a feature, not a line; refusing the two options that advertise it is the honest half, and is what shipped.
- **Item 2's "bound/slack pushes"** — `warm_start_bound_push` and friends are still fixed constants. Only the multiplier *floors* and `μ` became residual-derived. Making the primal push adaptive moves the primal point itself, which is a much larger trajectory risk than anything here, and nothing in the measurements pointed at it.
- The **GAMS native C link** and the **C ABI** were not touched. They reach the same core initializer, so they get the behaviour change; they get no new frontend surface for the diagnostics.

## Blast radius

Baseline for every number below: **`70bf53ded3d893cfa2da6ead5195fda5ac096f68`** (`main`, the parent of this branch). Same machine, same binaries, both directions measured with the identical script.

### Fixture sweep — three regimes

`scripts/sweep-fixtures.sh` with default options never reaches this code: `warm_start_init_point` defaults to `no`, so the warm initializer is not even constructed. That sweep is bit-identical, and it proves almost nothing. It was run anyway, and then twice more in regimes that *do* exercise the change:

| sweep | options | result |
|---|---|---|
| cold (the standard one) | defaults | **bit-identical across all 57 fixtures** |
| warm, default pushes | `warm_start_init_point=yes` | **bit-identical across all 57 fixtures** |
| warm, tightened recipe | `warm_start_init_point=yes mu_init=1e-7` + all five `warm_start_*_push`/`_frac` at `1e-9` | **3 of 57 move** |

The middle sweep is the load-bearing one: it differs from the cold sweep on 17 of 57 fixtures, so the warm initializer demonstrably runs, and the change is still a no-op there. The mechanism is exact — with no dual seeds in the `.nl` files, `any_dual_seeded` is false, so no reconstruction runs; and with the default `warm_start_mult_bound_push` of `1e-3` against `O(1)` slacks the measured complementarity is `~1e-3`, below the `mu_init` default of `0.1`, so `μ` is untouched.

The third sweep is the documented tight-push recipe, i.e. the regime the change is *for*. Every line that moves:

| fixture | before | after | status / objective |
|---|---|---|---|
| `hs13_bigstart` | it=30, obj=0.9891769904 | it=29, obj=0.9883552912 | `SolveSucceeded` both; improvement |
| `jit1_boxed` | it=16 | it=17 | `SolveSucceeded` both, obj=173345.3768 to 10 digits |
| `jit1_node` | it=19 | it=21 | `SolveSucceeded` both, obj=173345.3768 to 10 digits |

Each was attributed by running it back with `warm_start_recentering=none`, which reproduces the "before" column exactly on all three — so the mechanism is this change and nothing else, and the kill switch works. `hs13` is the known MFCQ-failure model, whose objective is tolerance-legal anywhere near 0.988–0.989; both runs sit in that band. `cresc4` moved 85 → 206 in an earlier revision and is bit-identical now (see "Rejected" above).

### Repeated-solve benchmark

`benchmarks/warmstart`, 9 families × 3 step scales = 27 parametric paths, 7 warm re-solves per path (189 warm solves per mode). Every mode sees the *same* per-step seed, so the only variable is how much of the dual state is handed back.

| seed | | iters | obj evals | jac evals |
|---|---|---|---|---|
| **full** (x, λ, z_L, z_U, μ) | before | 715 | 1207 | 994 |
| | **after** | **677** | **1068** | **950** |
| | | −5.3% | −11.5% | −4.4% |
| **partial** (bound mults kept, `lagrange` dropped) | before | 718 | 1210 | 997 |
| | **after** | **709** | **1167** | **988** |
| | | −1.3% | −3.6% | −0.9% |
| **primal only** (x and μ) | before | 1102 | 2421 | 1492 |
| | **after** | 1102 | 2421 | 1492 |
| | | *bit-identical by construction* | | |
| **cold** (reference, no seed) | before/after | 2036 | 2619 | 2199 |

`partial` is the issue's own acceptance criterion — "partial warm starts outperform zero-filled duals on a repeated-solve benchmark" — and it is met, though modestly. `full` is what `pounce.WarmStart` produces and what the docs recommend, and is where the change pays.

Only 8 of the 108 (path × mode) cells move at all. Every one:

| path | mode | before | after |
|---|---|---|---|
| `hanging_chain/tiny` | full | 49 | **14** |
| `hanging_chain/small` | full | 65 | **57** |
| `hanging_chain/large` | full | 68 | **47** |
| `rosenbrock_ring/small` | partial | 41 | **35** |
| `rosenbrock_ring/large` | partial | 40 | **37** |
| `rosenbrock_ring/tiny` | full | 28 | 37 |
| `rosenbrock_ring/small` | full | 42 | 45 |
| `rosenbrock_ring/large` | full | 36 | 50 |

`hanging_chain` is the flipping-contact family — 15 inequality rows whose slack multipliers were exactly the block nobody could seed, so it is where reconstructing them pays most. `rosenbrock_ring` is nonconvex with a single activation switch crossed along the path; the reconstructed slack multipliers reroute it, better in `partial` and worse in `full`. Net over the family: `full` +23, `partial` −9.

### Exact same-model restarts

Solve, then re-solve the identical model from its own answer. Summed over the 9 families:

| seed | before | after |
|---|---|---|
| full | 6 | **2** |
| partial | 9 | **7** |
| primal only | 17 | 17 |

No family regresses. `hanging_chain` and `rosenbrock_ring` go from 2 iterations to **0** on a full restart — the supplied point is now recognised as the KKT point it is.

### Regressions, named — now tracked as #617 and #618

Two, both on deliberately-bad seeds, both accepted here as the cost of the fix. Neither is closed by this PR.

**(a) Corrupted dual seeds cost more than they used to — #617.** Seeding the exact primal solution together with multipliers corrupted by `N(0,1e4)` noise, summed over 9 families: **18 → 71 iterations**. Per family the worst is `hanging_chain` 3 → 13; every case still converges with status `SolveSucceeded` to the same objective, and lands within ~1.4× of the cold solve (cold sum 81). Mechanism: the reconstructed slack multipliers are derived from the seeded `y`, so they inherit its corruption, where before they were discarded in favour of a constant. The pre-#606 "2 iterations" was not skill — it was throwing the bad duals away. Follow-up: reject a seeded dual block whose implied complementarity is orders away from the rest of the point, rather than reconstructing off it.

**(b) Mildly stale seeds regress slightly — #618.** Seeding each family from the far end of its own 4×-scale path: **118 → 127** iterations summed over 9 families with a full seed (`redundant_rows` 3 → 7 is the worst, `degenerate_corner` 9 → 11, `hanging_chain` 8 → 10, `moving_bound_qp` 11 → 12; the rest unchanged). These points are stale enough for the reconstruction to fire but not stale enough to trip the 10× `μ` escalation, so they get the reconstruction's trajectory change without the recentering that is supposed to pay for it. The *strongly* stale case is the opposite — HS071 from the far corner goes from `RestorationFailed` to `SolveSucceeded` — so the gap is in the middle of the staleness range. Follow-up: a second, gentler escalation band.

## Tests

`crates/pounce-algorithm/tests/warm_start_recentering.rs`, 7 tests over an HS071 whose starting point *and* dual seeds are both settable.

Four of them fail on the parent commit `70bf53de` for behavioural reasons. Verified in a `git worktree` at that commit with the assertions that need new API (`BlockVerdict`, `warm_start_diagnostics()`, the `warm_start_recentering` option itself) stripped, so the failures are behavioural and not compile errors. Exactly what they printed:

```
exact restart: none=2 residual=2 cold=8
  panicked: residual=2 vs none=2                 (assert residual < none)
partial: none=3 residual=3 cold=8
  panicked: residual=3 vs none=3                 (assert residual < none)
stale: status=RestorationFailed iters=36 cold=8
  panicked                                       (assert SolveSucceeded)
warm_start_same_structure=yes -> refusal None
  panicked                                       (assert is_some)
```

On this branch the same four read `1 vs 2`, `2 vs 3`, `SolveSucceeded in 43`, and a refusal naming `GetWarmStartIterate` and issue 606.

The remaining three pin the kill switch (`recentering=none` leaves every block alone and does not move `μ`), the deliberate non-behaviour on a primal-only seed, and a registry invariant.

**Deliberately not a regression test:** `every_registered_warm_start_option_is_consumed_or_refused` — it mirrors gh#604's `Initialization` invariant one category over, but on the parent commit the two dead flags *are* read (into fields nothing consumes), so it would have passed there. It guards the next warm-start option, not this one.

**Deliberately not pinned:** the corpus-level iteration counts above. They come from `benchmarks/warmstart`, which is a benchmark suite rather than a test, needs the Python extension built, and takes minutes. The numbers in this PR are the record; nothing in CI will notice if they drift. That gap is the same one the fixture sweep exists to cover for the cold path, and the third sweep regime above is the closest CI-shaped proxy for it.

Also run clean: `cargo fmt --all -- --check`, `cargo clippy` (no new warning categories in the changed files — 6 `unwrap_used` warnings against the baseline's 4, both new ones in `scatter`, matching the type-tested idiom already in `resolve_nan_seeds` beside it), `cargo test --workspace --exclude pounce-hsl`, the Python suite (777 passed, 34 skipped), `scripts/check-release-consistency.sh`, `scripts/check-docs-consistency.sh`.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`initialization.md`; already in `SUMMARY.md`)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the code as it stands now

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXUyBXwW7GQQAX6byMXnw4)_