### PR TITLE
Harden `WarmStart` persistence and keep warm-start options call-scoped (#607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,75 @@ changes.
 
 ## [Unreleased]
 
+- **`WarmStart` artifacts carry the model they belong to, and warm-start
+  options no longer outlive the call that asked for them** (#607). Two
+  independent silences in `pounce.WarmStart`, both of the shape gh#544
+  taught us to distrust — the answer is fine, everything else is not.
+
+  *Option scoping.* Applying a warm start called `add_option` on the
+  **persistent** `Problem`, and `add_option` is append-only, so the seven
+  enabling options (`warm_start_init_point`, `mu_init`, the four
+  `warm_start_*_push` / `_frac` and `warm_start_mult_bound_push`) stayed
+  set for every later solve on that object. Measured on HS071 at the
+  parent commit `70bf53de`: an ordinary cold solve that takes 17
+  iterations on a fresh `Problem` takes **24** on one that has served a
+  warm solve — the same objective to ten digits, 41% more iterations, and
+  nothing anywhere saying why. A warm solve that *raised* left the same
+  residue. They are now installed as a scoped overlay and taken back in a
+  `finally`, so both cases come back to 17. The overlay snapshots and
+  restores the whole option list rather than unsetting a list of names,
+  so an option added to `WarmStart.options()` later is scoped by
+  construction.
+
+  *Persistence schema.* A serialized warm start recorded arrays and four
+  floats — no dimensions, ordering, sparsity, bounds, scaling, algorithm
+  or model fingerprint — so an incompatible replay was simply attempted.
+  Replayed against the same model with its variables reordered it
+  returned objective **16.3801** where the truth is 17.0140, `x` wrong by
+  0.257, status `Error_In_Step_Computation`, no exception and no warning;
+  against a changed box, 15.8436 and `Restoration_Failed`; against a
+  different model of the same shape, a clean `Solve_Succeeded` for the
+  wrong reason. The archive schema is now versioned (v2) and carries a
+  `ProblemSignature`: dimensions, optional stable variable/constraint
+  IDs, and digests of the bound signature, declared sparsity, scaling
+  convention, algorithm/backend and the model-defining options. Capture
+  it with `WarmStart.from_info(x, info, problem=prob)`; a mismatch is
+  refused **before the solver is entered**, with a report naming every
+  facet that moved and the ways forward.
+
+  `compat="strict"` (default) raises, `"warn"` warns and proceeds,
+  `"unsafe"` skips the check. Replay is labelled `exact` or `mapped`:
+  `ws.transfer(prob, mapper)` is the explicit hook for a horizon shift or
+  a changed discretization, `ws.reindex(prob, var_ids=…)` writes the
+  mapper for you when both sides carry stable IDs, and a mapped artifact
+  is still refused on a third problem. Unmapped multiplier entries are
+  seeded `NaN`, the native "unseeded" contract, rather than fabricated.
+
+  *Migration.* Version-1 archives — everything written before this — load
+  and replay unchanged; they are *unverifiable*, not incompatible, and
+  refusing them outright would be a migration cost with no safety return.
+  What they get is a one-line `WarmStartLegacyWarning` naming
+  `ws.migrate(prob)`, plus the one check their own arrays support: the
+  dimensions. An unsigned *in-memory* `from_info(x, info)` stays silent,
+  as before. A v2 archive stays readable by a v1 loader — the new keys
+  are additive and `_meta` is untouched.
+
+  Known limitations, stated because one of them is a case the issue
+  names: a permutation of a model with a uniform box and a dense
+  jacobian leaves every structural digest bit-identical, so a reordering
+  is detectable only when the caller supplies `var_ids` on both sides.
+  And a mapped interior-point warm start is a correctness mechanism, not
+  a speed-up — on a receding-horizon fixture the transferred point costs
+  12 iterations against 7 cold, widening to 30 against 10 at horizon 40,
+  which is the barrier/active-set limit `docs/src/initialization.md`
+  already describes.
+
+  Python-side, plus four additive `Problem` accessors
+  (`options_snapshot` / `restore_options`, `get_bounds`,
+  `get_problem_scaling`, `problem_obj`); no solver step moved. The
+  fixture sweep is identical across all 57 models — status, objective and
+  iteration count.
+
 - **The cold-start initialization options are settable** (#604).
   `bound_push`, `bound_frac`, `slack_bound_push`, `slack_bound_frac`,
   `constr_mult_init_max`, `bound_mult_init_val`, `bound_mult_init_method`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,10 +67,11 @@ changes.
   jacobian leaves every structural digest bit-identical, so a reordering
   is detectable only when the caller supplies `var_ids` on both sides.
   And a mapped interior-point warm start is a correctness mechanism, not
-  a speed-up — on a receding-horizon fixture the transferred point costs
-  12 iterations against 7 cold, widening to 30 against 10 at horizon 40,
-  which is the barrier/active-set limit `docs/src/initialization.md`
-  already describes.
+  a speed-up — on a slew-limited receding-horizon fixture the transferred
+  point costs 12 iterations against 7 for a cold solve, and on a longer
+  sinusoidal track the gap widens with the horizon (12 vs 9 at horizon 5,
+  30 vs 10 at horizon 40). That is the barrier/active-set limit
+  `docs/src/initialization.md` already describes.
 
   Python-side, plus four additive `Problem` accessors
   (`options_snapshot` / `restore_options`, `get_bounds`,

--- a/crates/pounce-py/src/problem.rs
+++ b/crates/pounce-py/src/problem.rs
@@ -23,7 +23,7 @@ use pounce_solve_report::{
 };
 use pyo3::exceptions::{PyIOError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyTuple};
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -598,6 +598,99 @@ impl PyProblem {
                 .collect::<Vec<_>>()
                 .into_pyarray_bound(py)
         })
+    }
+
+    /// A snapshot of the pending option list, as the 3-tuple
+    /// `(string_opts, number_opts, integer_opts)` where each element is
+    /// a list of `(name, value)` pairs in the order `add_option`
+    /// recorded them.
+    ///
+    /// Paired with `restore_options`, this is what makes a **scoped**
+    /// option overlay possible (pounce#607). `add_option` is
+    /// append-only: there is otherwise no way to take back an option a
+    /// helper set for the duration of one solve, which is how the
+    /// Python `solve(warm_start=…)` wrapper used to leave its enabling
+    /// options behind on the Problem for every later solve.
+    fn options_snapshot<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
+        let strs = PyList::new_bound(py, self.str_opts.iter().map(|(k, v)| (k, v)));
+        let nums = PyList::new_bound(py, self.num_opts.iter().map(|(k, v)| (k, *v)));
+        let ints = PyList::new_bound(py, self.int_opts.iter().map(|(k, v)| (k, *v as i64)));
+        PyTuple::new_bound(py, [strs.into_any(), nums.into_any(), ints.into_any()])
+    }
+
+    /// Replace the pending option list wholesale with a snapshot taken
+    /// by `options_snapshot`. Every `add_option` made since the snapshot
+    /// is undone — including one that introduced a name that had never
+    /// been set, which no sequence of `add_option` calls can express.
+    fn restore_options(&mut self, snapshot: &Bound<'_, PyAny>) -> PyResult<()> {
+        let (strs, nums, ints): (
+            Vec<(String, String)>,
+            Vec<(String, Number)>,
+            Vec<(String, i64)>,
+        ) = snapshot.extract().map_err(|e| {
+            PyValueError::new_err(format!(
+                "restore_options: expected a 3-tuple from options_snapshot() \
+                 (string / number / integer option pairs): {e}"
+            ))
+        })?;
+        let mut int_opts = Vec::with_capacity(ints.len());
+        for (k, v) in ints {
+            let converted = Index::try_from(v).map_err(|_| {
+                PyValueError::new_err(format!(
+                    "restore_options({k}): integer value {v} is out of range \
+                     (must be between {} and {})",
+                    Index::MIN,
+                    Index::MAX
+                ))
+            })?;
+            int_opts.push((k, converted));
+        }
+        self.str_opts = strs;
+        self.num_opts = nums;
+        self.int_opts = int_opts;
+        Ok(())
+    }
+
+    /// The bounds this Problem was constructed with, as the 4-tuple of
+    /// float ndarrays `(lb, ub, cl, cu)`. Read-only; bounds are fixed at
+    /// construction. Used by `pounce.WarmStart` to fingerprint the box a
+    /// warm start was captured against (pounce#607).
+    fn get_bounds<'py>(&self, py: Python<'py>) -> Bound<'py, PyTuple> {
+        PyTuple::new_bound(
+            py,
+            [
+                self.x_l.clone().into_pyarray_bound(py).into_any(),
+                self.x_u.clone().into_pyarray_bound(py).into_any(),
+                self.g_l.clone().into_pyarray_bound(py).into_any(),
+                self.g_u.clone().into_pyarray_bound(py).into_any(),
+            ],
+        )
+    }
+
+    /// The user scaling installed by `set_problem_scaling`, as
+    /// `(obj_scaling, x_scaling, g_scaling)` with `None` for an axis
+    /// left unscaled, or `None` when no user scaling is installed.
+    fn get_problem_scaling<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyTuple>> {
+        self.user_scaling.as_ref().map(|s| {
+            let x: PyObject = match &s.x_scaling {
+                Some(v) => v.clone().into_pyarray_bound(py).into_any().unbind(),
+                None => py.None(),
+            };
+            let g: PyObject = match &s.g_scaling {
+                Some(v) => v.clone().into_pyarray_bound(py).into_any().unbind(),
+                None => py.None(),
+            };
+            PyTuple::new_bound(py, [s.obj.into_py(py), x, g])
+        })
+    }
+
+    /// The `problem_obj` this Problem was constructed with. Exposed so
+    /// Python-side helpers can interrogate the model's declared
+    /// structure (`jacobianstructure` / `hessianstructure`) without the
+    /// caller having to thread the object through alongside the Problem.
+    #[getter]
+    fn problem_obj(&self, py: Python<'_>) -> Py<PyAny> {
+        self.problem_obj.clone_ref(py)
     }
 
     /// Solve, then run a parametric sensitivity step at the converged

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -105,6 +105,14 @@ below, and forwards the SQP working set when the state was captured
 from that path. The rest of this section is what it does under the
 hood (and the only route from the CLI or an options file).
 
+The enabling options are **scoped to the call**: they are installed for
+that one solve and taken back afterwards, including when the solve
+raises. A warm solve therefore never changes what the next ordinary
+`solve` on the same `Problem` does. (Before pounce#607 it did, and the
+cost was invisible: on HS071 an ordinary cold solve went from 17
+iterations to 24 on a `Problem` that had served one warm solve, with the
+same objective to ten digits.)
+
 Passing a previous solution as `x0` is **not** a warm start by
 itself. The IPM warm start is a package of three things, and skipping
 any one of them silently degrades to (roughly) a cold solve:
@@ -152,6 +160,113 @@ the `.nl` file's dual segment when present.
 | `warm_start_slack_bound_push` / `warm_start_slack_bound_frac` | `1e-3` | Same, for slacks. |
 | `warm_start_mult_bound_push` | `1e-3` | Floor on seeded bound multipliers (a carried-in `z = 0` must not start on the barrier's boundary). |
 | `warm_start_mult_init_max` | `1e6` | Cap on seeded equality multipliers. |
+
+### Which model does this warm start belong to?
+
+A warm start is a point in *one* model's variable space, with
+multipliers in that model's constraint space. Replay it against a model
+whose variables have been reordered, whose bounds have moved, or which
+is simply a different model of the same shape, and the arrays are still
+the right *length* — so nothing objects. What comes back is a wrong
+answer, or the right answer down a much longer trajectory.
+
+Pass `problem=` when you capture, and the object records a
+**signature** of the model as well: dimensions, the bound signature, the
+declared sparsity, the scaling convention, the algorithm/backend, and
+the model-defining options.
+
+```python
+ws = pounce.WarmStart.from_info(x, info, problem=prob)
+ws.save("state.npz")
+
+# ... later, possibly in another process
+ws = pounce.WarmStart.load("state.npz")
+x2, info2 = prob.solve(warm_start=ws)     # checked before the solver runs
+```
+
+A mismatch is refused *before the solver is entered*, with a report
+naming every facet that moved:
+
+```text
+warm start is not compatible with this problem (1 mismatch,
+exact-structure replay, schema v2):
+  - bounds: captured '51e5c8cd33c97b92', target '42ae305673e91939'
+resolve it by one of:
+  - re-capture against this problem: WarmStart.from_info(x, info, problem=prob)
+  - transfer it explicitly: ws.transfer(prob, mapper) or, with stable IDs
+    on both sides, ws.reindex(prob)
+  - assert it transfers as-is: ws.migrate(prob)
+  - downgrade the check: compat='warn' or compat='unsafe'
+```
+
+`compat` picks how hard that is enforced — `"strict"` (the default)
+raises, `"warn"` emits the same report as a warning and proceeds,
+`"unsafe"` skips the comparison. Set it on the object, on `load()`, or
+per call: `prob.solve(warm_start=ws, compat="warn")`.
+`ws.describe_compatibility(prob)` returns the report as a string without
+raising, which is the dry run for a replay you are unsure of.
+
+One structural change a fingerprint cannot see is a **reordering**:
+permuting a model with a uniform box and a dense jacobian leaves every
+digest bit-identical. Ordering is knowledge only you have, so name it:
+
+```python
+ws = pounce.WarmStart.from_info(x, info, problem=prob,
+                                var_ids=names, con_ids=con_names)
+...
+prob2.solve(warm_start=ws, var_ids=names_in_prob2_order)   # refused
+```
+
+### Transferring a warm start: horizon shifts and reindexing
+
+When the model *has* changed and you know how, say so. `transfer()`
+takes a mapper and produces a **mapped** replay — labelled as such, and
+still refused on any problem other than the one it was mapped to:
+
+```python
+def shift(ctx):                       # ctx: source, target, problem
+    m = ctx.index_map("var")          # target-indexed source positions, -1 = new
+    return {"x": ..., "lagrange": ..., "zl": ..., "zu": ...}
+
+moved = ws.transfer(next_prob, shift, var_ids=next_ids, con_ids=next_con_ids)
+```
+
+With stable IDs on both sides, `reindex` writes that mapper for you —
+entries the target shares with the source move to their new positions,
+entries only the target has are left *unseeded* (`NaN`, which the warm
+initializer reads as "you decide") rather than fabricated:
+
+```python
+moved = ws.reindex(next_prob, var_ids=next_ids, con_ids=next_con_ids)
+x, info = next_prob.solve(warm_start=moved)
+```
+
+That covers both cases: a reordering, where the ID sets are equal, and a
+receding horizon, where they overlap. Note what it does *not* buy you —
+a transferred interior-point start is about validity, not speed. On a
+slew-limited tracking model the mapped point costs 12 iterations against
+7 for a cold solve, and 30 against 10 at horizon 40; that is the same
+barrier/active-set limit described just below, and the reason the SQP
+path exists.
+
+### Artifacts written before pounce#607
+
+Archives from earlier releases carry no signature. They are
+*unverifiable*, not incompatible, so they still load and still replay;
+what you get is one `WarmStartLegacyWarning` and a dimension check
+(the only facet their own arrays witness). Two ways to clear it:
+
+```python
+ws = pounce.WarmStart.load("old.npz")      # warns on replay
+ws = ws.migrate(prob)                      # re-sign it against this problem
+ws.save("old.npz")                         # ... and it is a v2 artifact now
+```
+
+`migrate` is an **assertion**, not a conversion: it re-signs the arrays
+without touching them, so use it only when they really do belong to this
+problem. When they need rearranging, that is `reindex` / `transfer`. An
+unsigned warm start held only in memory — `from_info(x, info)` with no
+`problem=` — behaves exactly as it always has, and says nothing.
 
 Even a well-executed IPM warm start has a structural limit: the
 barrier pushes iterates off the bounds, so the active-set information

--- a/docs/src/initialization.md
+++ b/docs/src/initialization.md
@@ -245,7 +245,8 @@ That covers both cases: a reordering, where the ID sets are equal, and a
 receding horizon, where they overlap. Note what it does *not* buy you —
 a transferred interior-point start is about validity, not speed. On a
 slew-limited tracking model the mapped point costs 12 iterations against
-7 for a cold solve, and 30 against 10 at horizon 40; that is the same
+7 for a cold solve; on a longer sinusoidal track the gap widens with the
+horizon (12 vs 9 at horizon 5, 30 vs 10 at horizon 40). That is the same
 barrier/active-set limit described just below, and the reason the SQP
 path exists.
 

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -20,7 +20,14 @@ from ._pounce import (
 )
 # Installs the Problem.solve(warm_start=...) wrapper as an import side
 # effect — keep this import directly after ._pounce.
-from ._warm_start import WarmStart
+from ._warm_start import (
+    WarmStart,
+    TransferContext,
+    ProblemSignature,
+    WarmStartCompatibilityError,
+    WarmStartCompatibilityWarning,
+    WarmStartLegacyWarning,
+)
 from ._minimize import minimize, OptimizeResult
 from ._nlp_batch import solve_nlp_batch
 from ._curve_fit import (
@@ -88,6 +95,11 @@ __all__ = [
     "preflight",
     "PreflightReport",
     "WarmStart",
+    "TransferContext",
+    "ProblemSignature",
+    "WarmStartCompatibilityError",
+    "WarmStartCompatibilityWarning",
+    "WarmStartLegacyWarning",
     "generate_starts",
     "project_to_feasible",
     "race_starts",

--- a/python/pounce/_warm_start.py
+++ b/python/pounce/_warm_start.py
@@ -15,6 +15,20 @@ recipe into a single argument::
     ws.save("state.npz")                            # ... and across processes
     ws = pounce.WarmStart.load("state.npz")
 
+A warm start is a point in *one* model's variable space. Pass
+``problem=`` to :meth:`WarmStart.from_info` and the object also carries
+a :class:`~pounce._warm_start_schema.ProblemSignature` — dimensions,
+bound and sparsity signatures, scaling convention, algorithm, and the
+model-defining options — which is checked before the solver is entered
+and refuses a replay against a model that has moved underneath it
+(pounce#607). :meth:`WarmStart.transfer` / :meth:`WarmStart.reindex` are
+the explicit way across a reordering or a horizon shift.
+
+Applying a warm start is **scoped**: the enabling options below are
+installed for the duration of that one call and taken back afterwards,
+including when the solve raises, so a warm solve never changes what the
+next ordinary ``solve`` on the same :class:`Problem` does.
+
 ``warm_start=`` is accepted by :meth:`pounce.Problem.solve` and
 :func:`pounce.minimize`. On the interior-point path it seeds the primal
 and dual iterates and sets the five enabling options; on the active-set
@@ -25,13 +39,31 @@ working set, which is that path's warm-start payload.
 from __future__ import annotations
 
 import dataclasses
-from typing import Optional, Tuple
+import warnings
+from typing import Callable, Optional, Tuple
 
 import numpy as np
 
 from . import _pounce
+from ._warm_start_schema import (
+    COMPAT_MODES,
+    WARM_START_SCHEMA_VERSION,
+    ProblemSignature,
+    WarmStartCompatibilityError,
+    WarmStartCompatibilityWarning,
+    WarmStartLegacyWarning,
+    compare,
+    format_report,
+)
 
-__all__ = ["WarmStart"]
+__all__ = [
+    "WarmStart",
+    "TransferContext",
+    "ProblemSignature",
+    "WarmStartCompatibilityError",
+    "WarmStartCompatibilityWarning",
+    "WarmStartLegacyWarning",
+]
 
 
 def _opt_array(v) -> Optional[np.ndarray]:
@@ -62,6 +94,27 @@ class WarmStart:
         mu_init: Explicit ``mu_init`` override; default derives it from
             ``mu`` (clamped to ``[1e-9, 1e-1]``).
         mu_init_fallback: ``mu_init`` used when ``mu`` is unknown.
+        signature: The :class:`ProblemSignature` this state was captured
+            against, or ``None`` for an unsigned state (which is what
+            ``from_info`` produces when no ``problem=`` is given, and
+            what every archive written before pounce#607 holds).
+        compat: Replay compatibility mode — ``"strict"`` (default),
+            ``"warn"``, or ``"unsafe"``. See
+            :meth:`check_compatible`.
+        replay: ``"exact"`` for a state captured directly from the
+            problem being replayed on, ``"mapped"`` for one produced by
+            :meth:`transfer` / :meth:`reindex`.
+        source_signature: For a mapped state, the signature it was
+            mapped *from*. Provenance only; not compared.
+        schema_version: Artifact schema this state came from.
+            :data:`~pounce._warm_start_schema.WARM_START_SCHEMA_VERSION`
+            for anything this build created, ``1`` for a legacy archive.
+        origin: ``"memory"`` for a state captured in this process,
+            ``"file"`` for one read back by :meth:`load`. Only the
+            second kind warns when it turns out to be unsigned: an
+            in-memory state that the caller chose not to sign is the
+            pre-#607 behaviour and stays silent, whereas an *artifact*
+            with no verifiable metadata is the case the issue is about.
     """
 
     x: np.ndarray
@@ -73,8 +126,23 @@ class WarmStart:
     bound_push: float = 1e-9
     mu_init: Optional[float] = None
     mu_init_fallback: float = 1e-6
+    signature: Optional[ProblemSignature] = None
+    compat: str = "strict"
+    replay: str = "exact"
+    source_signature: Optional[ProblemSignature] = None
+    schema_version: int = WARM_START_SCHEMA_VERSION
+    origin: str = "memory"
 
     def __post_init__(self):
+        if self.compat not in COMPAT_MODES:
+            raise ValueError(
+                f"WarmStart(compat={self.compat!r}): expected one of "
+                + ", ".join(repr(m) for m in COMPAT_MODES)
+            )
+        if self.replay not in ("exact", "mapped"):
+            raise ValueError(
+                f"WarmStart(replay={self.replay!r}): expected 'exact' or 'mapped'"
+            )
         self.x = np.asarray(self.x, dtype=float).ravel()
         self.lagrange = _opt_array(self.lagrange)
         self.zl = _opt_array(self.zl)
@@ -89,15 +157,35 @@ class WarmStart:
     # -- construction --------------------------------------------------
 
     @classmethod
-    def from_info(cls, x, info, **overrides) -> "WarmStart":
+    def from_info(
+        cls, x, info, problem=None, var_ids=None, con_ids=None, **overrides
+    ) -> "WarmStart":
         """Capture a warm start from a solve's ``(x, info)`` result.
 
         Works with :meth:`Problem.solve`'s ``info`` dict and with
         :func:`pounce.minimize`'s ``result.info``. Keyword overrides
         (e.g. ``bound_push=1e-6``) are forwarded to the constructor.
+
+        Pass ``problem=`` — the :class:`Problem` that produced the
+        result — to fingerprint the model as well, which is what lets a
+        later replay be checked instead of merely attempted
+        (pounce#607). ``var_ids`` / ``con_ids`` are optional stable
+        identifiers for the variables and constraints; supply them and
+        :meth:`reindex` can carry the state across a reordering or a
+        horizon shift.
         """
         mu = info.get("mu")
         mu = float(mu) if mu is not None and float(mu) > 0.0 else None
+        if problem is not None:
+            overrides.setdefault(
+                "signature",
+                ProblemSignature.from_problem(problem, var_ids, con_ids),
+            )
+        elif var_ids is not None or con_ids is not None:
+            raise TypeError(
+                "WarmStart.from_info: var_ids / con_ids identify a model, so "
+                "they need problem= as well"
+            )
         return cls(
             x=np.asarray(x, dtype=float),
             lagrange=info.get("mult_g"),
@@ -125,11 +213,63 @@ class WarmStart:
                 payload[key] = v
         if self.working_set is not None:
             payload["ws_bounds"], payload["ws_constraints"] = self.working_set
+        payload.update(self._schema_payload())
         np.savez(path, **payload)
 
+    def _schema_payload(self) -> dict:
+        """The schema-v2 keys (pounce#607), as their own block.
+
+        Kept out of :meth:`save` so the two evolve independently: the
+        array payload is the warm start, this is the metadata that says
+        which model it belongs to. Everything here is a plain string or
+        integer array, so archives stay ``allow_pickle=False``-loadable.
+        """
+        out = {"_schema": np.array(WARM_START_SCHEMA_VERSION, dtype=np.int64),
+               "_compat": np.array(self.compat),
+               "_replay": np.array(self.replay)}
+        if self.signature is not None:
+            out["_signature"] = np.array(self.signature.to_json())
+        if self.source_signature is not None:
+            out["_source_signature"] = np.array(self.source_signature.to_json())
+        return out
+
+    @staticmethod
+    def _schema_fields(data) -> dict:
+        """Inverse of :meth:`_schema_payload`.
+
+        A version-1 archive has none of these keys. It loads as an
+        unsigned, legacy-marked state rather than failing: refusing to
+        read an artifact that a user wrote last week and that replays
+        correctly on the model it came from would be a migration cost
+        with no safety return. What version 1 *does* forfeit is the
+        checking — :meth:`check_compatible` says so once, out loud, and
+        points at :meth:`migrate`.
+        """
+        files = data.files
+        if "_schema" not in files:
+            return {"schema_version": 1, "origin": "file"}
+        out = {
+            "origin": "file",
+            "schema_version": int(data["_schema"]),
+            "compat": str(data["_compat"]),
+            "replay": str(data["_replay"]),
+        }
+        if "_signature" in files:
+            out["signature"] = ProblemSignature.from_json(str(data["_signature"]))
+        if "_source_signature" in files:
+            out["source_signature"] = ProblemSignature.from_json(
+                str(data["_source_signature"])
+            )
+        return out
+
     @classmethod
-    def load(cls, path) -> "WarmStart":
-        """Inverse of :meth:`save`."""
+    def load(cls, path, compat=None) -> "WarmStart":
+        """Inverse of :meth:`save`.
+
+        `compat` overrides the mode stored in the archive; pass
+        ``"warn"`` or ``"unsafe"`` to relax the check on an artifact you
+        know transfers.
+        """
         with np.load(path, allow_pickle=False) as data:
             meta = data["_meta"]
             working_set = None
@@ -145,7 +285,15 @@ class WarmStart:
                 bound_push=float(meta[1]),
                 mu_init=None if np.isnan(meta[2]) else float(meta[2]),
                 mu_init_fallback=float(meta[3]),
+                **cls._schema_overrides(data, compat),
             )
+
+    @classmethod
+    def _schema_overrides(cls, data, compat) -> dict:
+        fields = cls._schema_fields(data)
+        if compat is not None:
+            fields["compat"] = compat
+        return fields
 
     # -- application ----------------------------------------------------
 
@@ -187,6 +335,415 @@ class WarmStart:
             kw["working_set"] = self.working_set
         return kw
 
+    # -- compatibility ---------------------------------------------------
+
+    def check_compatible(
+        self, problem, compat=None, var_ids=None, con_ids=None
+    ) -> list:
+        """Validate this state against `problem` and act on the verdict.
+
+        Returns the list of
+        :class:`~pounce._warm_start_schema.Mismatch` found (empty when
+        the replay is clean). What happens when it is *not* empty is the
+        mode's business:
+
+        * ``strict`` (the default) raises
+          :class:`WarmStartCompatibilityError` carrying the full report,
+          before the solver is entered;
+        * ``warn`` emits the same report as a
+          :class:`WarmStartCompatibilityWarning` and proceeds;
+        * ``unsafe`` skips the comparison entirely.
+
+        Dimensions are checked against the *arrays* whether or not this
+        state is signed, so even a legacy artifact cannot be replayed at
+        the wrong size. Everything else needs a signature. An unsigned
+        state read back from a *file* warns
+        (:class:`WarmStartLegacyWarning`) that the rest is unverifiable
+        and names :meth:`migrate`; an unsigned state built in this
+        process is the pre-#607 usage and stays silent.
+
+        `var_ids` / `con_ids` name `problem`'s variables and constraints
+        in the vocabulary this state was captured with. Supply them to
+        catch a **reordering**: a permutation is the one structural
+        change a fingerprint cannot see on its own, because permuting a
+        model with a uniform box and a dense jacobian leaves the bound
+        and sparsity digests bit-identical. Ordering is knowledge only
+        the caller has; the digests cover everything else.
+        """
+        mode = self.compat if compat is None else compat
+        if mode not in COMPAT_MODES:
+            raise ValueError(
+                f"check_compatible(compat={mode!r}): expected one of "
+                + ", ".join(repr(m) for m in COMPAT_MODES)
+            )
+        if mode == "unsafe":
+            return []
+
+        mismatches = self._mismatches(problem, var_ids, con_ids)
+        if self.signature is None and self.origin == "file" and not mismatches:
+            # A *persisted* artifact with nothing to check it against.
+            # Refusing outright would break every archive written before
+            # pounce#607 while it still replays correctly on the model it
+            # came from — a migration cost with no safety return. Saying
+            # so, with the two ways to fix it, is the middle ground the
+            # issue's "legacy artifact migration" asks for.
+            warnings.warn(
+                f"warm start loaded from a schema v{self.schema_version} "
+                "archive carries no model signature, so only its dimensions "
+                "could be checked against this problem. Re-capture with "
+                "WarmStart.from_info(x, info, problem=prob) and re-save, or "
+                "call ws.migrate(prob) to sign this one against the problem "
+                "you are replaying it on.",
+                WarmStartLegacyWarning,
+                stacklevel=3,
+            )
+
+        if mismatches:
+            report = format_report(
+                mismatches,
+                replay=self.replay,
+                schema_version=self.schema_version,
+                source=self.source_signature,
+            )
+            if mode == "strict":
+                raise WarmStartCompatibilityError(report)
+            warnings.warn(report, WarmStartCompatibilityWarning, stacklevel=3)
+        return mismatches
+
+    def describe_compatibility(self, problem, var_ids=None, con_ids=None) -> str:
+        """The mismatch report against `problem` as a string, without
+        raising or warning. The dry run for a replay you are unsure of.
+        """
+        mismatches = self._mismatches(problem, var_ids, con_ids)
+        if not mismatches:
+            return "warm start is compatible with this problem"
+        return format_report(
+            mismatches,
+            replay=self.replay,
+            schema_version=self.schema_version,
+            source=self.source_signature,
+        )
+
+    def _mismatches(self, problem, var_ids=None, con_ids=None) -> list:
+        """The facets on which this state and `problem` disagree.
+
+        A signed state is compared facet by facet. An unsigned one is
+        compared on the only facets its own arrays witness — the
+        dimensions — which is what keeps a legacy artifact from being
+        replayed at the wrong size.
+        """
+        if self.signature is not None:
+            return compare(
+                self.signature,
+                ProblemSignature.from_problem(problem, var_ids, con_ids),
+            )
+        if var_ids is not None or con_ids is not None:
+            raise WarmStartCompatibilityError(
+                "this warm start carries no model signature, so there is "
+                "nothing to compare the supplied var_ids / con_ids against. "
+                "Capture it with WarmStart.from_info(x, info, problem=prob, "
+                "var_ids=…)."
+            )
+        arrays = self._array_signature()
+        # When the state carries no constraint-space array at all there
+        # is nothing for `m` to be wrong about, so do not manufacture an
+        # unverifiable facet out of the target's `m`. (An unconstrained
+        # solve reports an empty `mult_g`, which `_opt_array` normalizes
+        # to None — that is the common case here, not an exotic one.)
+        return compare(
+            arrays,
+            ProblemSignature(
+                n=int(problem.n),
+                m=int(problem.m) if arrays.m is not None else None,
+            ),
+        )
+
+    def _array_signature(self) -> ProblemSignature:
+        """The dimensions this state's own arrays imply.
+
+        ``lagrange`` is the only witness to `m`; when it was not
+        captured (an unconstrained solve, or a caller who dropped it)
+        `m` is left unrecorded rather than guessed, and
+        :func:`~pounce._warm_start_schema.compare` reports the facet as
+        unverifiable rather than inventing agreement.
+        """
+        n = int(self.x.size)
+        for name, arr in (("zl", self.zl), ("zu", self.zu)):
+            if arr is not None and arr.size != n:
+                raise ValueError(
+                    f"WarmStart: x has {n} entries but {name} has {arr.size}; "
+                    "the state is internally inconsistent"
+                )
+        m = None
+        if self.lagrange is not None:
+            m = int(self.lagrange.size)
+        elif self.working_set is not None:
+            m = int(self.working_set[1].size)
+        return ProblemSignature(n=n, m=m)
+
+    def migrate(self, problem, var_ids=None, con_ids=None) -> "WarmStart":
+        """Re-sign this state against `problem`, as-is.
+
+        The migration path for a legacy (schema v1) archive, and the
+        escape hatch for a signed one whose model changed in a way the
+        caller knows is immaterial. It is an **assertion**, not a
+        conversion: no array is touched, so use it only when the arrays
+        really do belong to this problem. When they need rearranging,
+        that is :meth:`reindex` or :meth:`transfer`.
+        """
+        target = ProblemSignature.from_problem(problem, var_ids, con_ids)
+        if int(problem.n) != self.x.size:
+            raise WarmStartCompatibilityError(
+                f"migrate: this problem has {int(problem.n)} variables but the "
+                f"warm start's x has {self.x.size}; migrate re-signs a state, "
+                "it does not resize one — use transfer() with a mapper"
+            )
+        if self.lagrange is not None and int(problem.m) != self.lagrange.size:
+            raise WarmStartCompatibilityError(
+                f"migrate: this problem has {int(problem.m)} constraints but "
+                f"the warm start's lagrange has {self.lagrange.size}; use "
+                "transfer() with a mapper"
+            )
+        return dataclasses.replace(
+            self,
+            signature=target,
+            replay="exact",
+            source_signature=self.signature,
+            schema_version=WARM_START_SCHEMA_VERSION,
+            origin="memory",
+        )
+
+    # -- transfer --------------------------------------------------------
+
+    def transfer(
+        self,
+        problem,
+        mapper: Optional[Callable[["TransferContext"], dict]] = None,
+        var_ids=None,
+        con_ids=None,
+        fill_x=None,
+    ) -> "WarmStart":
+        """Map this state onto `problem`, producing a *mapped* replay.
+
+        `mapper` is called with a :class:`TransferContext` and returns a
+        dict of replacement arrays — any of ``x``, ``lagrange``, ``zl``,
+        ``zu``, ``working_set``, ``mu``. Anything it leaves out is
+        carried over unchanged, and every array it returns is
+        length-checked against `problem` before the result is built, so
+        a mapper with an off-by-one fails here rather than three
+        function evaluations into the solve.
+
+        This is the hook for a horizon shift or a changed
+        discretization: the arrays are yours to rearrange, interpolate,
+        or prolong. When both sides carry stable IDs and the only change
+        is *which* variables are present and in what order,
+        :meth:`reindex` writes the mapper for you.
+
+        The result is signed against `problem` with ``replay="mapped"``
+        and remembers where it came from, so replaying it on a *third*
+        problem is refused exactly like an unmapped one.
+        """
+        target = ProblemSignature.from_problem(problem, var_ids, con_ids)
+        n, m = target.n, target.m
+        if mapper is None:
+            mapper = _reindex_mapper(fill_x)
+        elif fill_x is not None:
+            raise TypeError(
+                "transfer: fill_x is the default mapper's policy for "
+                "variables the target has and the source does not; it means "
+                "nothing alongside an explicit mapper"
+            )
+        ctx = TransferContext(source=self, target=target, problem=problem)
+        payload = mapper(ctx)
+        if payload is None:
+            payload = {}
+        if not isinstance(payload, dict):
+            raise TypeError(
+                "transfer: the mapper must return a dict of replacement "
+                f"arrays (x / lagrange / zl / zu / working_set / mu), got "
+                f"{type(payload).__name__}"
+            )
+        unknown = sorted(set(payload) - {"x", "lagrange", "zl", "zu",
+                                         "working_set", "mu"})
+        if unknown:
+            raise TypeError(
+                f"transfer: the mapper returned unknown keys {unknown}; "
+                "expected any of x / lagrange / zl / zu / working_set / mu"
+            )
+        out = dataclasses.replace(
+            self,
+            x=payload.get("x", self.x),
+            lagrange=payload.get("lagrange", self.lagrange),
+            zl=payload.get("zl", self.zl),
+            zu=payload.get("zu", self.zu),
+            working_set=payload.get("working_set", self.working_set),
+            mu=payload.get("mu", self.mu),
+            signature=target,
+            replay="mapped",
+            source_signature=self.signature,
+            schema_version=WARM_START_SCHEMA_VERSION,
+            origin="memory",
+        )
+        _check_lengths(out, n, m)
+        return out
+
+    def reindex(self, problem, var_ids, con_ids=None, fill_x=None) -> "WarmStart":
+        """Transfer by matching stable identifiers.
+
+        `var_ids` / `con_ids` name `problem`'s variables and
+        constraints in the same vocabulary this state was captured with
+        (``from_info(..., problem=prob, var_ids=…)``). Entries the
+        target shares with the source are carried across to their new
+        positions; entries the target has and the source does not are
+        *unseeded* — ``NaN`` in the multiplier blocks, which is the
+        native warm-start contract for "you decide", and `fill_x`
+        (default: zero clipped into the variable's box) in ``x``.
+
+        That covers the two cases the issue names: a reordering, where
+        the ID sets are equal, and a horizon shift, where they overlap.
+        """
+        if self.signature is None or self.signature.var_ids is None:
+            raise WarmStartCompatibilityError(
+                "reindex: this warm start carries no variable identifiers, so "
+                "there is nothing to match the target's against. Capture it "
+                "with WarmStart.from_info(x, info, problem=prob, "
+                "var_ids=…), or use transfer() with an explicit mapper."
+            )
+        return self.transfer(
+            problem, None, var_ids=var_ids, con_ids=con_ids, fill_x=fill_x
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class TransferContext:
+    """What a :meth:`WarmStart.transfer` mapper is given.
+
+    Attributes:
+        source: The :class:`WarmStart` being mapped (arrays included).
+        target: The :class:`ProblemSignature` of the problem being
+            mapped onto.
+        problem: The target :class:`Problem` itself, for anything the
+            signature does not carry (bounds, the model object).
+    """
+
+    source: "WarmStart"
+    target: ProblemSignature
+    problem: object
+
+    def index_map(self, axis="var"):
+        """Target-indexed array of source positions, ``-1`` where the
+        target entry has no counterpart in the source.
+
+        Requires stable IDs on both sides for `axis` (``"var"`` or
+        ``"con"``); returns ``None`` when either side lacks them.
+        """
+        key = "var_ids" if axis == "var" else "con_ids"
+        src = getattr(self.source.signature, key, None) if self.source.signature else None
+        dst = getattr(self.target, key)
+        if src is None or dst is None:
+            return None
+        where = {name: i for i, name in enumerate(src)}
+        return np.array([where.get(name, -1) for name in dst], dtype=np.int64)
+
+    def bounds(self):
+        """``(lb, ub, cl, cu)`` of the target problem."""
+        return self.problem.get_bounds()
+
+
+def _gather(src, idx, fill):
+    """`src[idx]`, with `fill` wherever `idx` is -1. `src` may be None."""
+    if src is None:
+        return None
+    out = np.full(idx.size, fill, dtype=float)
+    hit = idx >= 0
+    out[hit] = np.asarray(src, dtype=float)[idx[hit]]
+    return out
+
+
+def _reindex_mapper(fill_x):
+    """The default :meth:`WarmStart.transfer` mapper: match stable IDs.
+
+    Unmatched multiplier entries become NaN, which the native warm-start
+    initializer reads as "unseeded" and fills with its own resolved
+    default — so a prolonged horizon does not carry a fabricated
+    multiplier into the new block.
+    """
+
+    def mapper(ctx: TransferContext) -> dict:
+        vmap = ctx.index_map("var")
+        if vmap is None:
+            raise WarmStartCompatibilityError(
+                "transfer: no mapper was given and stable variable IDs are "
+                "not present on both sides, so there is no way to know which "
+                "of the target's variables the captured point refers to. "
+                "Pass var_ids= for the target (and capture the source with "
+                "var_ids=), or supply an explicit mapper."
+            )
+        lb, ub, _, _ = ctx.bounds()
+        if fill_x is None:
+            base = np.clip(0.0, np.asarray(lb, dtype=float), np.asarray(ub, dtype=float))
+        else:
+            base = np.asarray(fill_x, dtype=float).ravel()
+            if base.size == 1:
+                base = np.full(vmap.size, float(base[0]))
+            if base.size != vmap.size:
+                raise ValueError(
+                    f"transfer: fill_x has {base.size} entries, expected "
+                    f"{vmap.size} (or a scalar)"
+                )
+        x = np.asarray(ctx.source.x, dtype=float)
+        new_x = base.astype(float, copy=True)
+        hit = vmap >= 0
+        new_x[hit] = x[vmap[hit]]
+        out = {
+            "x": new_x,
+            "zl": _gather(ctx.source.zl, vmap, np.nan),
+            "zu": _gather(ctx.source.zu, vmap, np.nan),
+        }
+        cmap = ctx.index_map("con")
+        if cmap is not None:
+            out["lagrange"] = _gather(ctx.source.lagrange, cmap, np.nan)
+        elif ctx.source.lagrange is not None and ctx.target.m != ctx.source.lagrange.size:
+            raise WarmStartCompatibilityError(
+                "transfer: the constraint count changed "
+                f"({ctx.source.lagrange.size} -> {ctx.target.m}) but no "
+                "constraint IDs were supplied, so the captured multipliers "
+                "cannot be placed. Pass con_ids= on both sides, or supply an "
+                "explicit mapper."
+            )
+        if ctx.source.working_set is not None:
+            b, c = ctx.source.working_set
+            wb = _gather(b, vmap, 0.0)
+            wc = c if cmap is None else _gather(c, cmap, 0.0)
+            out["working_set"] = (
+                np.asarray(wb, dtype=np.int8),
+                np.asarray(wc, dtype=np.int8),
+            )
+        return out
+
+    return mapper
+
+
+def _check_lengths(ws: "WarmStart", n: int, m: int) -> None:
+    for name, arr, want in (
+        ("x", ws.x, n),
+        ("lagrange", ws.lagrange, m),
+        ("zl", ws.zl, n),
+        ("zu", ws.zu, n),
+    ):
+        if arr is not None and arr.size != want:
+            raise ValueError(
+                f"transfer: the mapped '{name}' has {arr.size} entries, but "
+                f"the target problem wants {want}"
+            )
+    if ws.working_set is not None:
+        b, c = ws.working_set
+        if b.size != n or c.size != m:
+            raise ValueError(
+                f"transfer: the mapped working set is ({b.size}, {c.size}), "
+                f"but the target problem wants ({n}, {m})"
+            )
+
 
 # ---------------------------------------------------------------------------
 # Problem.solve(warm_start=...) — wrap the native method once at import.
@@ -206,12 +763,22 @@ def _solve_with_warm_start(
     zu=None,
     working_set=None,
     warm_start: Optional[WarmStart] = None,
+    compat: Optional[str] = None,
+    var_ids=None,
+    con_ids=None,
     **kwargs,
 ):
     # **kwargs forwards any other native solve keywords untouched
     # (e.g. report_path / report_detail), so this wrapper never lags
     # the native signature.
     if warm_start is None:
+        for name, val in (("compat", compat), ("var_ids", var_ids),
+                          ("con_ids", con_ids)):
+            if val is not None:
+                raise TypeError(
+                    f"Problem.solve(): {name}= describes how to replay a warm "
+                    "start and means nothing without warm_start="
+                )
         if x0 is None:
             raise TypeError("Problem.solve() missing required argument: 'x0'")
         return _native_solve(
@@ -224,8 +791,10 @@ def _solve_with_warm_start(
             **kwargs,
         )
     ws = warm_start
-    for k, v in ws.options().items():
-        self.add_option(k, v)
+    # Refuse an incompatible replay here, before any solver state exists
+    # (pounce#607). Doing it first also means the option overlay below is
+    # never installed for a call that was never going to run.
+    ws.check_compatible(self, compat=compat, var_ids=var_ids, con_ids=con_ids)
     kw = ws.solve_kwargs()
     # Explicit per-call seeds win over the WarmStart's captured ones.
     for key, val in (
@@ -236,7 +805,21 @@ def _solve_with_warm_start(
     ):
         if val is not None:
             kw[key] = val
-    return _native_solve(self, x0=ws.x if x0 is None else x0, **kw, **kwargs)
+    # Scoped overlay: the enabling options belong to *this call*, not to
+    # the Problem. `add_option` is append-only, so taking them back needs
+    # the snapshot/restore pair — and the restore has to survive an
+    # exception, or a warm solve that fails leaves the next ordinary
+    # solve running someone else's mu_init (pounce#607). Nothing here
+    # enumerates option names: whatever `ws.options()` returns is what
+    # gets scoped, so an option added to that recipe later is covered by
+    # construction.
+    snapshot = self.options_snapshot()
+    try:
+        for k, v in ws.options().items():
+            self.add_option(k, v)
+        return _native_solve(self, x0=ws.x if x0 is None else x0, **kw, **kwargs)
+    finally:
+        self.restore_options(snapshot)
 
 
 _solve_with_warm_start.__name__ = "solve"
@@ -246,10 +829,22 @@ _solve_with_warm_start.__doc__ = (_native_solve.__doc__ or "") + (
     "warm_start : pounce.WarmStart, optional\n"
     "    A captured solve state (see ``WarmStart.from_info``). Applies the\n"
     "    enabling options (``warm_start_init_point=yes``, ``mu_init``, the\n"
-    "    tightened ``warm_start_*`` pushes — note they persist on this\n"
-    "    Problem like any ``add_option``), seeds the duals, forwards the\n"
-    "    SQP working set when present, and defaults ``x0`` to the captured\n"
-    "    point. Explicit ``x0``/seed arguments override the captured ones.\n"
+    "    tightened ``warm_start_*`` pushes) as a **scoped overlay** — they\n"
+    "    are installed for this call and taken back afterwards, including\n"
+    "    when the solve raises, so they do not change what the next\n"
+    "    ordinary ``solve`` on this Problem does. Seeds the duals, forwards\n"
+    "    the SQP working set when present, and defaults ``x0`` to the\n"
+    "    captured point. Explicit ``x0``/seed arguments override the\n"
+    "    captured ones. A warm start carrying a model signature is checked\n"
+    "    against this Problem first, and an incompatible one is refused\n"
+    "    before the solver is entered.\n"
+    "compat : {'strict', 'warn', 'unsafe'}, optional\n"
+    "    Override the warm start's own compatibility mode for this call.\n"
+    "var_ids, con_ids : sequence, optional\n"
+    "    Stable identifiers for *this* Problem's variables / constraints,\n"
+    "    in the vocabulary the warm start was captured with. Supply them to\n"
+    "    catch a reordering, which the structural digests cannot see on\n"
+    "    their own.\n"
 )
 
 _pounce.Problem.solve = _solve_with_warm_start

--- a/python/pounce/_warm_start_schema.py
+++ b/python/pounce/_warm_start_schema.py
@@ -1,0 +1,457 @@
+"""Model fingerprinting and replay-compatibility rules for ``WarmStart``.
+
+A warm start is a *point in a specific model's variable space*, plus
+multipliers in that model's constraint space. Replay it against a model
+whose variables have been reordered, whose bounds have moved, or which
+is simply a different model with the same dimensions, and the arrays are
+still the right *shape* — so nothing downstream objects. What comes back
+is a wrong answer, or the right answer down a much longer trajectory,
+and in neither case does anything say so (pounce#607; the same class of
+silence as gh#544).
+
+This module carries the metadata that makes that detectable:
+
+* :class:`ProblemSignature` — dimensions, variable/constraint ordering
+  or stable IDs, sparsity signature, bound signature, scaling
+  convention, algorithm/backend, and the model-defining option
+  fingerprint, captured from a live :class:`pounce.Problem`.
+* :func:`compare` — a facet-by-facet mismatch report.
+* :class:`WarmStartCompatibilityError` /
+  :class:`WarmStartCompatibilityWarning` — the strict / warn outcomes.
+
+It is deliberately separate from ``_warm_start.py``: the fingerprinting
+rules change for reasons that have nothing to do with the warm-start
+object's own fields.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+
+__all__ = [
+    "WARM_START_SCHEMA_VERSION",
+    "ProblemSignature",
+    "Mismatch",
+    "WarmStartCompatibilityError",
+    "WarmStartCompatibilityWarning",
+    "WarmStartLegacyWarning",
+    "compare",
+    "COMPAT_MODES",
+    "MODEL_OPTIONS",
+]
+
+#: Version of the on-disk ``WarmStart`` artifact schema.
+#:
+#: ``1`` is the implicit version of every archive written before
+#: pounce#607: ``x`` / ``lagrange`` / ``zl`` / ``zu`` / ``ws_*`` arrays
+#: and a 4-wide numeric ``_meta`` row, with no model metadata at all.
+#: ``2`` adds ``_schema`` and the JSON ``_signature`` / ``_provenance``
+#: blobs. Version 2 archives stay readable by a version-1 loader
+#: (``np.load`` ignores keys it is not asked for), so the format change
+#: is backward *and* forward compatible at the array level; what a
+#: version-1 loader cannot do is check anything.
+WARM_START_SCHEMA_VERSION = 2
+
+#: The three compatibility modes, in decreasing order of safety.
+#:
+#: ``strict``  — any mismatch, and any facet that cannot be verified on a
+#:               signed artifact, raises before the solver is entered.
+#: ``warn``    — the same report is emitted as a warning and the solve
+#:               proceeds.
+#: ``unsafe``  — no checking at all. The escape hatch for a caller who
+#:               knows the artifact transfers and does not want the cost
+#:               or the noise.
+COMPAT_MODES = ("strict", "warn", "unsafe")
+
+#: Options that change *the model being solved* or its representation,
+#: as opposed to how hard the solver works at it. Only these enter the
+#: fingerprint: a warm start stays valid across a changed ``max_iter``
+#: or ``print_level``, and must not across a changed
+#: ``fixed_variable_treatment``.
+#:
+#: ``nlp_scaling_method`` / ``obj_scaling_factor`` /
+#: ``nlp_scaling_max_gradient`` are fingerprinted separately, as the
+#: "scaling convention" facet, because they decide what units the
+#: captured multipliers are in.
+MODEL_OPTIONS = (
+    "bound_relax_factor",
+    "fixed_variable_treatment",
+    "hessian_approximation",
+    "hessian_constant",
+    "honor_original_bounds",
+    "jac_c_constant",
+    "jac_d_constant",
+)
+
+_SCALING_OPTIONS = (
+    "nlp_scaling_method",
+    "nlp_scaling_max_gradient",
+    "obj_scaling_factor",
+)
+
+_ALGORITHM_OPTIONS = ("algorithm", "linear_solver", "sqp_hessian")
+
+
+class WarmStartCompatibilityError(ValueError):
+    """A warm start does not match the problem it is being replayed on.
+
+    Raised before the solver is entered, under ``compat="strict"``.
+    """
+
+
+class WarmStartCompatibilityWarning(UserWarning):
+    """``compat="warn"`` counterpart of
+    :class:`WarmStartCompatibilityError`."""
+
+
+class WarmStartLegacyWarning(UserWarning):
+    """A schema-version-1 archive was replayed.
+
+    Version-1 archives carry no model metadata, so only the facets that
+    can be recovered from the arrays themselves (the dimensions) are
+    checked. See :meth:`pounce.WarmStart.migrate`.
+    """
+
+
+# ---------------------------------------------------------------------------
+# digests
+# ---------------------------------------------------------------------------
+
+
+def _digest(*parts: Any) -> str:
+    """A short, stable, platform-independent digest of `parts`.
+
+    Floats go in as their exact IEEE-754 bytes (``repr`` round-trips but
+    is locale-free only by luck), integers as int64, everything else via
+    a canonical JSON encoding. Truncated to 16 hex chars — long enough
+    that an accidental collision between two models is not a thing that
+    happens, short enough to print in a mismatch report.
+    """
+    h = hashlib.blake2b(digest_size=8)
+    for p in parts:
+        if isinstance(p, np.ndarray):
+            a = np.ascontiguousarray(p)
+            h.update(str(a.dtype.str).encode())
+            h.update(str(a.shape).encode())
+            h.update(a.tobytes())
+        else:
+            h.update(json.dumps(p, sort_keys=True, default=str).encode())
+        h.update(b"\x00")
+    return h.hexdigest()
+
+
+def _sorted_pairs(pairs: Sequence[Tuple[str, Any]], keys: Sequence[str]) -> list:
+    """`pairs` filtered to `keys`, last-write-wins, sorted by name.
+
+    ``Problem`` records options as an append-only list, and applies them
+    in order, so the *effective* value of a name is its last occurrence.
+    """
+    eff: Dict[str, Any] = {}
+    for k, v in pairs:
+        if k in keys:
+            eff[k] = v
+    return sorted(eff.items())
+
+
+def _effective_options(problem) -> List[Tuple[str, Any]]:
+    """The flat option list of `problem`, in the order the solver
+    applies it (strings, then numbers, then integers — see
+    ``PyProblem::prepare``)."""
+    try:
+        strs, nums, ints = problem.options_snapshot()
+    except AttributeError:  # pragma: no cover - pre-#607 extension
+        return []
+    return [(k, v) for k, v in strs] + [(k, v) for k, v in nums] + [
+        (k, v) for k, v in ints
+    ]
+
+
+def _structure_digest(problem) -> Optional[str]:
+    """Digest of the model's *declared* sparsity.
+
+    ``None`` when the model does not declare one (a dense-jacobian
+    ``problem_obj``, or an object this build cannot reach), which makes
+    the facet unverifiable rather than silently equal.
+    """
+    try:
+        obj = problem.problem_obj
+    except AttributeError:  # pragma: no cover - pre-#607 extension
+        return None
+    parts: List[Any] = []
+    for name in ("jacobianstructure", "hessianstructure"):
+        fn = getattr(obj, name, None)
+        if fn is None:
+            parts.append(None)
+            continue
+        try:
+            rows, cols = fn()
+        except Exception:  # noqa: BLE001 - a structure query must never
+            # take down the fingerprint; an unreadable facet is reported
+            # as unverifiable, which is what it is.
+            return None
+        parts.append(name)
+        parts.append(np.asarray(rows, dtype=np.int64).ravel())
+        parts.append(np.asarray(cols, dtype=np.int64).ravel())
+    if all(p is None for p in parts):
+        return None
+    return _digest(*parts)
+
+
+def _scaling_digest(problem, opts: Sequence[Tuple[str, Any]]) -> str:
+    """Digest of the scaling convention: the scaling options plus any
+    user scaling vectors installed via ``set_problem_scaling``.
+
+    This is a facet in its own right because it decides what units the
+    captured multipliers are expressed in — a warm start captured under
+    ``gradient-based`` scaling is not a warm start for the same model
+    under ``none``.
+    """
+    parts: List[Any] = [_sorted_pairs(opts, _SCALING_OPTIONS)]
+    user = None
+    try:
+        user = problem.get_problem_scaling()
+    except AttributeError:  # pragma: no cover - pre-#607 extension
+        pass
+    if user is None:
+        parts.append(None)
+    else:
+        obj_s, x_s, g_s = user
+        parts.append(float(obj_s))
+        parts.append(None if x_s is None else np.asarray(x_s, dtype=float))
+        parts.append(None if g_s is None else np.asarray(g_s, dtype=float))
+    return _digest(*parts)
+
+
+def _ids_tuple(ids, n: int, what: str) -> Optional[Tuple[str, ...]]:
+    if ids is None:
+        return None
+    out = tuple(str(v) for v in ids)
+    if len(out) != n:
+        raise ValueError(
+            f"{what}: expected {n} identifiers to match the problem's "
+            f"dimension, got {len(out)}"
+        )
+    if len(set(out)) != len(out):
+        raise ValueError(f"{what}: identifiers must be unique")
+    return out
+
+
+# ---------------------------------------------------------------------------
+# the signature
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class ProblemSignature:
+    """What a :class:`pounce.WarmStart` has to match to be replayable.
+
+    Every field is either a value or ``None``. ``None`` means *not
+    recorded* — an unverifiable facet, which is reported as a mismatch
+    under ``compat="strict"`` rather than quietly passing.
+
+    Attributes:
+        n / m: Dimensions.
+        var_ids / con_ids: Caller-supplied stable identifiers for the
+            variables and constraints, when the caller has them. These
+            are what make a *reordered* model recoverable rather than
+            merely detectable — see :meth:`pounce.WarmStart.reindex`.
+        bounds: Digest of ``(lb, ub, cl, cu)``.
+        sparsity: Digest of the declared jacobian / Hessian structure.
+        scaling: Digest of the scaling convention.
+        algorithm: Digest of the algorithm / backend selection.
+        model: Digest of the model-defining options (:data:`MODEL_OPTIONS`).
+    """
+
+    n: int
+    m: int
+    var_ids: Optional[Tuple[str, ...]] = None
+    con_ids: Optional[Tuple[str, ...]] = None
+    bounds: Optional[str] = None
+    sparsity: Optional[str] = None
+    scaling: Optional[str] = None
+    algorithm: Optional[str] = None
+    model: Optional[str] = None
+
+    #: Facets compared by :func:`compare`, in report order. Dimensions
+    #: come first: they are the one facet recoverable from a legacy
+    #: artifact, and the one whose mismatch the native layer would
+    #: otherwise report from deep inside solve preparation.
+    FACETS = ("n", "m", "var_ids", "con_ids", "bounds", "sparsity",
+              "scaling", "algorithm", "model")
+
+    #: Facets compared only when *both* sides recorded them. Stable IDs
+    #: are the transfer key, not a verification requirement: a live
+    #: ``Problem`` has no idea what its variables are called, so a target
+    #: signature almost never carries them, and treating that absence as
+    #: unverifiable would make signing an artifact with IDs strictly
+    #: worse than signing it without.
+    OPTIONAL_FACETS = ("var_ids", "con_ids")
+
+    # -- construction ---------------------------------------------------
+
+    @classmethod
+    def from_problem(cls, problem, var_ids=None, con_ids=None) -> "ProblemSignature":
+        """Fingerprint a live :class:`pounce.Problem`.
+
+        `var_ids` / `con_ids` are optional stable identifiers (any
+        sequence of `n` / `m` unique values; they are stringified).
+        Supplying them is what lets :meth:`pounce.WarmStart.reindex`
+        transfer a warm start across a reordering or a horizon shift
+        instead of only refusing it.
+        """
+        n, m = int(problem.n), int(problem.m)
+        opts = _effective_options(problem)
+        try:
+            lb, ub, cl, cu = problem.get_bounds()
+            bounds = _digest(
+                np.asarray(lb, dtype=float), np.asarray(ub, dtype=float),
+                np.asarray(cl, dtype=float), np.asarray(cu, dtype=float),
+            )
+        except AttributeError:  # pragma: no cover - pre-#607 extension
+            bounds = None
+        return cls(
+            n=n,
+            m=m,
+            var_ids=_ids_tuple(var_ids, n, "var_ids"),
+            con_ids=_ids_tuple(con_ids, m, "con_ids"),
+            bounds=bounds,
+            sparsity=_structure_digest(problem),
+            scaling=_scaling_digest(problem, opts),
+            algorithm=_digest(_sorted_pairs(opts, _ALGORITHM_OPTIONS)),
+            model=_digest(_sorted_pairs(opts, MODEL_OPTIONS)),
+        )
+
+    # -- persistence ----------------------------------------------------
+
+    def to_json(self) -> str:
+        d = dataclasses.asdict(self)
+        for k in ("var_ids", "con_ids"):
+            if d[k] is not None:
+                d[k] = list(d[k])
+        return json.dumps(d, sort_keys=True)
+
+    @classmethod
+    def from_json(cls, text: str) -> "ProblemSignature":
+        d = json.loads(text)
+        for k in ("var_ids", "con_ids"):
+            if d.get(k) is not None:
+                d[k] = tuple(str(v) for v in d[k])
+        known = {f.name for f in dataclasses.fields(cls)}
+        unknown = sorted(set(d) - known)
+        if unknown:
+            # A newer pounce wrote facets this build does not know about.
+            # Dropping them silently would turn a stricter artifact into a
+            # weaker one, so say so; the caller still gets a usable object.
+            raise ValueError(
+                "warm-start signature carries facets this build does not "
+                f"understand ({', '.join(unknown)}); upgrade pounce, or "
+                "re-capture the warm start"
+            )
+        return cls(**{k: v for k, v in d.items() if k in known})
+
+
+@dataclasses.dataclass(frozen=True)
+class Mismatch:
+    """One facet on which an artifact and a target problem disagree."""
+
+    facet: str
+    captured: Any
+    target: Any
+    #: True when the disagreement is "one side did not record this",
+    #: rather than two recorded values differing.
+    unverifiable: bool = False
+
+    def __str__(self) -> str:
+        if self.facet in ("var_ids", "con_ids") and not self.unverifiable:
+            return (
+                f"{self.facet}: identifiers differ "
+                f"(captured {_preview(self.captured)}, "
+                f"target {_preview(self.target)})"
+            )
+        if self.unverifiable:
+            side = "the artifact" if self.captured is None else "this problem"
+            return (
+                f"{self.facet}: not recorded by {side}, so it cannot be "
+                "verified"
+            )
+        return f"{self.facet}: captured {self.captured!r}, target {self.target!r}"
+
+
+def _preview(ids) -> str:
+    if ids is None:
+        return "none"
+    ids = list(ids)
+    head = ", ".join(ids[:4])
+    return f"[{head}{', …' if len(ids) > 4 else ''}] ({len(ids)})"
+
+
+def compare(captured: ProblemSignature, target: ProblemSignature) -> List[Mismatch]:
+    """Facet-by-facet comparison, most structural facet first.
+
+    A facet neither side recorded is skipped — there is nothing to
+    disagree about. A facet exactly one side recorded is reported as
+    *unverifiable*, which strict mode treats as a mismatch: a signed
+    artifact whose bound signature cannot be checked against the target
+    is exactly as unsafe as one whose bound signature differs. The
+    exception is :data:`ProblemSignature.OPTIONAL_FACETS`, compared only
+    when both sides have them.
+    """
+    out: List[Mismatch] = []
+    for facet in ProblemSignature.FACETS:
+        a = getattr(captured, facet)
+        b = getattr(target, facet)
+        if a is None and b is None:
+            continue
+        if a is None or b is None:
+            if facet in ProblemSignature.OPTIONAL_FACETS:
+                continue
+            out.append(Mismatch(facet, a, b, unverifiable=True))
+        elif a != b:
+            out.append(Mismatch(facet, a, b))
+    return out
+
+
+def format_report(
+    mismatches: Sequence[Mismatch],
+    *,
+    replay: str,
+    schema_version: Optional[int],
+    source: Optional[ProblemSignature] = None,
+) -> str:
+    """The human-facing mismatch report.
+
+    Names every facet that disagrees, says which is which, and — this is
+    the part that makes it worth printing — names the two ways forward
+    (re-capture, or transfer) rather than only the way that is blocked.
+    """
+    kind = "mapped" if replay == "mapped" else "exact-structure"
+    lines = [
+        f"warm start is not compatible with this problem "
+        f"({len(mismatches)} mismatch"
+        f"{'es' if len(mismatches) != 1 else ''}, {kind} replay"
+        + (f", schema v{schema_version}" if schema_version else "")
+        + "):",
+    ]
+    lines += [f"  - {m}" for m in mismatches]
+    if source is not None:
+        lines.append(
+            f"  (this artifact was transferred from a {source.n}x{source.m} "
+            "problem; a mapped warm start is valid only for the problem it "
+            "was mapped to)"
+        )
+    lines += [
+        "resolve it by one of:",
+        "  - re-capture against this problem: "
+        "WarmStart.from_info(x, info, problem=prob)",
+        "  - transfer it explicitly: ws.transfer(prob, mapper) or, with "
+        "stable IDs on both sides, ws.reindex(prob)",
+        "  - assert it transfers as-is: ws.migrate(prob) (re-signs the "
+        "artifact against this problem)",
+        "  - downgrade the check: compat='warn' or compat='unsafe'",
+    ]
+    return "\n".join(lines)

--- a/python/tests/test_warm_start_schema.py
+++ b/python/tests/test_warm_start_schema.py
@@ -1,0 +1,608 @@
+"""pounce#607 — warm-start artifacts carry the model they belong to, and
+warm-start options are scoped to the call that asked for them.
+
+Two independent failures lived in `python/pounce/_warm_start.py`:
+
+1. Applying a warm start called `add_option` on the *persistent* Problem.
+   `add_option` is append-only, so the seven enabling options stayed set
+   for every later `solve` on that object. On the HS071 fixture below
+   that took an ordinary cold solve from 17 iterations to 24 — the right
+   answer down a longer trajectory, which is precisely the class of
+   regression gh#544 shipped and the fixture sweep exists to catch.
+
+2. A serialized `WarmStart` recorded arrays and four floats. Replayed
+   against a model whose variables had been reordered it produced
+   objective 16.3801 where the truth is 17.0140, with nothing raised
+   and nothing warned.
+
+The tests here pin both, plus the migration path for artifacts written
+before the schema existed.
+"""
+
+import dataclasses
+import os
+
+os.environ.setdefault("RUST_LOG", "off")
+
+import numpy as np
+import pytest
+
+import pounce
+from pounce import (
+    WarmStart,
+    WarmStartCompatibilityError,
+    WarmStartCompatibilityWarning,
+    WarmStartLegacyWarning,
+)
+
+
+# ---------------------------------------------------------------------------
+# HS071 and structural variants of it
+# ---------------------------------------------------------------------------
+class HS071:
+    """min x0*x3*(x0+x1+x2) + x2  s.t. prod(x) >= 25, |x|^2 == 40.
+
+    `perm[k]` is the index in the canonical ordering that sits at
+    position k here, so `HS071(perm=[2, 0, 3, 1])` is the same
+    mathematics with its variables shuffled.
+    """
+
+    def __init__(self, perm=None):
+        self.perm = np.arange(4) if perm is None else np.asarray(perm)
+        self.inv = np.argsort(self.perm)
+
+    def _orig(self, x):
+        return np.asarray(x)[self.inv]
+
+    def objective(self, x):
+        y = self._orig(x)
+        return y[0] * y[3] * (y[0] + y[1] + y[2]) + y[2]
+
+    def gradient(self, x):
+        y = self._orig(x)
+        g = np.array([
+            y[0] * y[3] + y[3] * (y[0] + y[1] + y[2]),
+            y[0] * y[3],
+            y[0] * y[3] + 1.0,
+            y[0] * (y[0] + y[1] + y[2]),
+        ])
+        return g[self.perm]
+
+    def constraints(self, x):
+        y = self._orig(x)
+        return np.array([np.prod(y), np.dot(y, y)])
+
+    def jacobianstructure(self):
+        return (np.repeat([0, 1], 4), np.tile([0, 1, 2, 3], 2))
+
+    def jacobian(self, x):
+        y = self._orig(x)
+        j = np.array([
+            y[1] * y[2] * y[3], y[0] * y[2] * y[3],
+            y[0] * y[1] * y[3], y[0] * y[1] * y[2],
+        ])
+        return np.concatenate([j[self.perm], (2 * y)[self.perm]])
+
+
+class HS071ExtraNonzero(HS071):
+    """Same mathematics, one extra declared structural entry."""
+
+    def jacobianstructure(self):
+        rows, cols = super().jacobianstructure()
+        return (np.append(rows, 0), np.append(cols, 0))
+
+    def jacobian(self, x):
+        return np.append(super().jacobian(x), 0.0)
+
+
+X0 = np.array([1.0, 5.0, 5.0, 1.0])
+X0_FAR = np.array([4.9, 4.9, 4.9, 4.9])
+VAR_IDS = ["v0", "v1", "v2", "v3"]
+CON_IDS = ["prod", "sumsq"]
+
+
+def make(obj=None, ub=5.0, n=4, **opts):
+    p = pounce.Problem(
+        n=n, m=2, problem_obj=HS071() if obj is None else obj,
+        lb=[1.0] * n, ub=[ub] * n, cl=[25.0, 40.0], cu=[2e19, 40.0],
+    )
+    p.add_option("tol", 1e-8)
+    p.add_option("print_level", 0)
+    for k, v in opts.items():
+        p.add_option(k, v)
+    return p
+
+
+def cold():
+    p = make()
+    x, info = p.solve(x0=X0)
+    return p, x, info
+
+
+def signed(**kw):
+    p, x, info = cold()
+    return WarmStart.from_info(x, info, problem=p, **kw)
+
+
+# ---------------------------------------------------------------------------
+# 1. warm-start options are scoped to the call
+# ---------------------------------------------------------------------------
+def test_warm_options_do_not_leak_into_the_next_ordinary_solve():
+    ws = signed()
+    _, pristine = make().solve(x0=X0_FAR)
+
+    reused = make()
+    reused.solve(warm_start=ws)
+    _, after = reused.solve(x0=X0_FAR)
+
+    assert after["iter_count"] == pristine["iter_count"]
+    assert after["obj_val"] == pytest.approx(pristine["obj_val"])
+
+
+def test_warm_options_are_restored_even_when_the_solve_raises():
+    ws = signed()
+    _, pristine = make().solve(x0=X0_FAR)
+
+    p = make()
+    with pytest.raises(ValueError):
+        # A wrong-length explicit seed fails inside solve preparation,
+        # after the overlay is installed. Without the `finally` restore
+        # the options survive the failed call.
+        p.solve(warm_start=ws, lagrange=np.zeros(99))
+    _, after = p.solve(x0=X0_FAR)
+
+    assert after["iter_count"] == pristine["iter_count"]
+
+
+def test_overlay_restores_the_exact_option_list():
+    """The overlay is a snapshot/restore of the whole option list, not a
+    hand-maintained list of names to unset — so an option the warm start
+    introduces is removed, and one the caller had set is put back at its
+    own value."""
+    ws = signed()
+    p = make()
+    p.add_option("mu_init", 0.5)          # caller's own value for a key
+    p.add_option("max_iter", 300)         # the warm start does not touch
+    before = p.options_snapshot()
+
+    p.solve(warm_start=ws)
+
+    assert p.options_snapshot() == before
+    strs, nums, ints = p.options_snapshot()
+    assert dict(nums)["mu_init"] == 0.5
+    assert dict(ints)["max_iter"] == 300
+    assert "warm_start_init_point" not in dict(strs)
+
+
+def test_scoped_overlay_covers_whatever_options_returns():
+    """Nothing in the wrapper enumerates option names, so a key added to
+    the recipe later is scoped by construction."""
+    ws = signed()
+    ws_opts = dict(ws.options())
+    p = make()
+    empty = p.options_snapshot()
+
+    class Extra(WarmStart):
+        def options(self):
+            out = dict(super().options())
+            out["bound_mult_init_val"] = 2.0
+            return out
+
+    extra = Extra(**{f.name: getattr(ws, f.name) for f in dataclasses.fields(ws)})
+    assert "bound_mult_init_val" not in ws_opts
+    p.solve(warm_start=extra)
+    assert p.options_snapshot() == empty
+
+
+# ---------------------------------------------------------------------------
+# 2. a compatible round trip stays lossless
+# ---------------------------------------------------------------------------
+def test_round_trip_is_lossless_and_still_warm(tmp_path):
+    p, cold_x, cold_info = cold()
+    ws = WarmStart.from_info(cold_x, cold_info, problem=p,
+                             var_ids=VAR_IDS, con_ids=CON_IDS,
+                             bound_push=1e-8)
+    path = tmp_path / "state.npz"
+    ws.save(path)
+    back = WarmStart.load(path)
+
+    for name in ("x", "lagrange", "zl", "zu"):
+        np.testing.assert_array_equal(getattr(back, name), getattr(ws, name))
+    assert back.mu == ws.mu
+    assert back.bound_push == 1e-8
+    assert back.signature == ws.signature
+    assert back.signature.var_ids == tuple(VAR_IDS)
+    assert back.compat == "strict"
+    assert back.replay == "exact"
+    assert back.schema_version == 2
+
+    warm_x, warm_info = make().solve(warm_start=back)
+    assert warm_info["iter_count"] < cold_info["iter_count"]
+    np.testing.assert_allclose(warm_x, cold_x, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 3. incompatible replays are refused with a report, before the solver
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("facet,factory", [
+    ("bounds", lambda: make(ub=4.0)),
+    ("sparsity", lambda: make(obj=HS071ExtraNonzero())),
+    ("scaling", lambda: make(nlp_scaling_method="none")),
+    ("algorithm", lambda: make(algorithm="active-set-sqp")),
+    ("model", lambda: make(fixed_variable_treatment="make_constraint")),
+])
+def test_incompatible_replay_is_refused(facet, factory):
+    ws = signed()
+    with pytest.raises(WarmStartCompatibilityError) as e:
+        factory().solve(warm_start=ws)
+    report = str(e.value)
+    assert f"  - {facet}:" in report
+    assert "re-capture against this problem" in report
+    assert "ws.reindex(prob)" in report
+
+
+def test_dimension_mismatch_is_refused_before_the_solver():
+    ws = signed()
+    with pytest.raises(WarmStartCompatibilityError) as e:
+        make(n=5).solve(x0=np.full(5, 2.0), warm_start=ws)
+    assert "n: captured 4, target 5" in str(e.value)
+
+
+def test_reordered_variables_are_refused_when_ids_are_supplied():
+    """A permutation of a model with a uniform box and a dense jacobian
+    leaves every structural digest bit-identical — ordering is knowledge
+    only the caller has. Replaying through it produced objective
+    16.3801 against a true 17.0140 before pounce#607."""
+    perm = [2, 0, 3, 1]
+    ws = signed(var_ids=VAR_IDS, con_ids=CON_IDS)
+    target = make(obj=HS071(perm=perm))
+
+    # Without the ordering, nothing can see the permutation...
+    assert ws.check_compatible(target) == []
+    # ...but the caller who knows it gets a refusal.
+    with pytest.raises(WarmStartCompatibilityError) as e:
+        target.solve(warm_start=ws,
+                     var_ids=[VAR_IDS[i] for i in perm], con_ids=CON_IDS)
+    assert "var_ids: identifiers differ" in str(e.value)
+
+
+def test_a_different_model_with_the_same_shape_is_refused():
+    class Other(HS071):
+        def objective(self, x):
+            return float(np.sum((np.asarray(x) - 2.0) ** 2))
+
+        def gradient(self, x):
+            return 2.0 * (np.asarray(x) - 2.0)
+
+    # Same n, m, bounds and declared sparsity; different bounds digest is
+    # not what catches it, so make the boxes identical and lean on the
+    # model facet by changing an option that redefines the model.
+    ws = signed()
+    with pytest.raises(WarmStartCompatibilityError):
+        make(obj=Other(), bound_relax_factor=0.0).solve(warm_start=ws)
+
+
+def test_describe_compatibility_reports_without_raising():
+    ws = signed()
+    assert "compatible" in ws.describe_compatibility(make())
+    report = ws.describe_compatibility(make(ub=4.0))
+    assert "bounds:" in report and "resolve it by one of" in report
+
+
+# ---------------------------------------------------------------------------
+# 4. strict / warn / unsafe
+# ---------------------------------------------------------------------------
+def test_warn_mode_reports_and_proceeds():
+    ws = signed()
+    with pytest.warns(WarmStartCompatibilityWarning, match="bounds:"):
+        make(ub=4.0).solve(warm_start=ws, compat="warn")
+
+
+def test_unsafe_mode_is_silent():
+    import warnings as _w
+
+    ws = signed()
+    with _w.catch_warnings():
+        _w.simplefilter("error")
+        make(ub=4.0).solve(warm_start=ws, compat="unsafe")
+
+
+def test_mode_stored_on_the_artifact_is_honored(tmp_path):
+    p, x, info = cold()
+    ws = WarmStart.from_info(x, info, problem=p, compat="warn")
+    path = tmp_path / "warn.npz"
+    ws.save(path)
+    with pytest.warns(WarmStartCompatibilityWarning):
+        make(ub=4.0).solve(warm_start=WarmStart.load(path))
+    # ...and `load(compat=...)` overrides it.
+    with pytest.raises(WarmStartCompatibilityError):
+        make(ub=4.0).solve(warm_start=WarmStart.load(path, compat="strict"))
+
+
+def test_unknown_mode_is_rejected():
+    with pytest.raises(ValueError, match="compat"):
+        WarmStart(x=np.zeros(4), compat="lenient")
+
+
+def test_replay_kwargs_need_a_warm_start():
+    for kw in ({"compat": "warn"}, {"var_ids": VAR_IDS}, {"con_ids": CON_IDS}):
+        with pytest.raises(TypeError, match="warm_start="):
+            make().solve(x0=X0, **kw)
+
+
+# ---------------------------------------------------------------------------
+# 5. legacy artifacts
+# ---------------------------------------------------------------------------
+def _write_v1(path, ws):
+    """Exactly what `save` wrote before pounce#607: arrays and a 4-wide
+    numeric `_meta` row, no schema key."""
+    payload = {"x": ws.x, "_meta": np.array([ws.mu, ws.bound_push,
+                                             np.nan, ws.mu_init_fallback])}
+    for key in ("lagrange", "zl", "zu"):
+        v = getattr(ws, key)
+        if v is not None:
+            payload[key] = v
+    np.savez(path, **payload)
+
+
+def test_legacy_artifact_loads_replays_and_says_it_is_unverified(tmp_path):
+    p, cold_x, cold_info = cold()
+    path = tmp_path / "legacy.npz"
+    _write_v1(path, WarmStart.from_info(cold_x, cold_info))
+
+    ws = WarmStart.load(path)
+    assert ws.schema_version == 1
+    assert ws.signature is None
+    assert ws.origin == "file"
+
+    with pytest.warns(WarmStartLegacyWarning, match="schema v1"):
+        warm_x, warm_info = make().solve(warm_start=ws)
+    # It still warm-starts: the migration is about provenance, not payload.
+    assert warm_info["iter_count"] < cold_info["iter_count"]
+    np.testing.assert_allclose(warm_x, cold_x, atol=1e-6)
+
+
+def test_legacy_artifact_still_cannot_be_replayed_at_the_wrong_size(tmp_path):
+    p, cold_x, cold_info = cold()
+    path = tmp_path / "legacy.npz"
+    _write_v1(path, WarmStart.from_info(cold_x, cold_info))
+    with pytest.raises(WarmStartCompatibilityError, match="n: captured 4"):
+        make(n=5).solve(x0=np.full(5, 2.0), warm_start=WarmStart.load(path))
+
+
+def test_migrate_signs_a_legacy_artifact(tmp_path):
+    p, cold_x, cold_info = cold()
+    path = tmp_path / "legacy.npz"
+    _write_v1(path, WarmStart.from_info(cold_x, cold_info))
+    legacy = WarmStart.load(path)
+
+    target = make()
+    migrated = legacy.migrate(target, var_ids=VAR_IDS, con_ids=CON_IDS)
+    assert migrated.schema_version == 2
+    assert migrated.signature.var_ids == tuple(VAR_IDS)
+    assert migrated.source_signature is None
+
+    import warnings as _w
+    with _w.catch_warnings():
+        _w.simplefilter("error")           # no legacy warning any more
+        target.solve(warm_start=migrated)
+    # ...and it is now a real signature, so it still refuses a bad target.
+    with pytest.raises(WarmStartCompatibilityError):
+        make(ub=4.0).solve(warm_start=migrated)
+
+
+def test_migrate_refuses_to_resize():
+    ws = signed()
+    with pytest.raises(WarmStartCompatibilityError, match="does not resize"):
+        ws.migrate(make(n=5))
+
+
+def test_in_memory_unsigned_state_stays_silent():
+    """The pre-#607 call — `from_info(x, info)` with no problem — keeps
+    working, unchanged and unnagged. Only a *persisted* artifact with no
+    metadata gets the migration notice."""
+    import warnings as _w
+
+    _, x, info = cold()
+    ws = WarmStart.from_info(x, info)
+    assert ws.signature is None and ws.origin == "memory"
+    with _w.catch_warnings():
+        _w.simplefilter("error")
+        make().solve(warm_start=ws)
+
+
+def test_v2_archive_is_still_loadable_by_a_v1_reader(tmp_path):
+    """The schema keys are additive, so the array payload a pre-#607
+    loader asks for is untouched."""
+    p, x, info = cold()
+    path = tmp_path / "v2.npz"
+    WarmStart.from_info(x, info, problem=p).save(path)
+    with np.load(path, allow_pickle=False) as data:
+        assert {"x", "lagrange", "zl", "zu", "_meta"} <= set(data.files)
+        assert data["_meta"].shape == (4,)
+        assert int(data["_schema"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# 6. transfer: horizon shift and explicit mappers
+# ---------------------------------------------------------------------------
+class Chain:
+    """A tiny receding-horizon model: track `targets` under a slew limit.
+
+    min sum_k (x_k - t_k)^2   s.t.  |x_{k+1} - x_k| <= 0.5,  0 <= x <= 10.
+    """
+
+    def __init__(self, targets):
+        self.t = np.asarray(targets, dtype=float)
+        self.nv = self.t.size
+
+    def objective(self, x):
+        return float(np.sum((np.asarray(x) - self.t) ** 2))
+
+    def gradient(self, x):
+        return 2.0 * (np.asarray(x) - self.t)
+
+    def constraints(self, x):
+        y = np.asarray(x)
+        return y[1:] - y[:-1]
+
+    def jacobianstructure(self):
+        k = self.nv - 1
+        rows = np.repeat(np.arange(k), 2)
+        cols = np.column_stack([np.arange(k), np.arange(1, k + 1)]).ravel()
+        return rows, cols
+
+    def jacobian(self, x):
+        return np.tile([-1.0, 1.0], self.nv - 1)
+
+
+TRACK = np.array([1.0, 3.0, 5.0, 4.0, 2.0, 6.0, 7.0])
+HORIZON = 5
+
+
+def window(start):
+    """The horizon starting at `start`, plus its stable IDs."""
+    t = TRACK[start:start + HORIZON]
+    p = pounce.Problem(
+        n=HORIZON, m=HORIZON - 1, problem_obj=Chain(t),
+        lb=[0.0] * HORIZON, ub=[10.0] * HORIZON,
+        cl=[-0.5] * (HORIZON - 1), cu=[0.5] * (HORIZON - 1),
+    )
+    p.add_option("tol", 1e-8)
+    p.add_option("print_level", 0)
+    var_ids = [f"x{start + i}" for i in range(HORIZON)]
+    con_ids = [f"c{start + i}" for i in range(HORIZON - 1)]
+    return p, var_ids, con_ids
+
+
+def test_horizon_shift_transfers_and_replays():
+    p0, v0, c0 = window(0)
+    x0, info0 = p0.solve(x0=np.full(HORIZON, 3.0))
+    ws = WarmStart.from_info(x0, info0, problem=p0, var_ids=v0, con_ids=c0)
+
+    p1, v1, c1 = window(1)
+    # Replaying the un-shifted artifact is refused: the objective's
+    # targets moved, so the bound/model digests no longer match... and
+    # where they would match, the IDs do.
+    with pytest.raises(WarmStartCompatibilityError):
+        p1.solve(warm_start=ws, var_ids=v1, con_ids=c1)
+
+    moved = ws.reindex(p1, var_ids=v1, con_ids=c1)
+    assert moved.replay == "mapped"
+    assert moved.source_signature == ws.signature
+    # x1..x4 carried across; the freshly-entered stage is unseeded.
+    np.testing.assert_allclose(moved.x[:HORIZON - 1], x0[1:])
+    assert np.isnan(moved.zl[-1]) and np.isnan(moved.zu[-1])
+    assert np.isnan(moved.lagrange[-1])
+
+    warm_x, warm_info = p1.solve(warm_start=moved)
+    cold_x, cold_info = window(1)[0].solve(x0=np.full(HORIZON, 3.0))
+    assert warm_info["status_msg"] == "Solve_Succeeded"
+    np.testing.assert_allclose(warm_x, cold_x, atol=1e-6)
+    # Deliberately no assertion that the mapped replay is *cheaper*. On
+    # this family it is not: measured on the parent commit's solver, the
+    # shifted point costs 12 iterations against 7 cold at HORIZON=5, and
+    # the gap widens with the horizon (22 vs 9 at 20, 30 vs 10 at 40).
+    # That is the structural limit docs/src/initialization.md already
+    # states — the barrier pushes iterates off their bounds, so a
+    # converged interior point's active-set information does not survive
+    # the transfer — and it is what pounce#606 attacks on the Rust side.
+    # The transfer hook's job here is that the replay is *valid* and
+    # *labelled*, not that it is fast.
+
+
+def test_mapped_artifact_is_still_refused_on_a_third_problem():
+    p0, v0, c0 = window(0)
+    x0, info0 = p0.solve(x0=np.full(HORIZON, 3.0))
+    ws = WarmStart.from_info(x0, info0, problem=p0, var_ids=v0, con_ids=c0)
+    p1, v1, c1 = window(1)
+    moved = ws.reindex(p1, var_ids=v1, con_ids=c1)
+
+    p2, v2, c2 = window(2)
+    with pytest.raises(WarmStartCompatibilityError) as e:
+        p2.solve(warm_start=moved, var_ids=v2, con_ids=c2)
+    assert "mapped replay" in str(e.value)
+
+
+def test_reindex_needs_ids_on_the_source():
+    ws = signed()                     # signed, but with no identifiers
+    with pytest.raises(WarmStartCompatibilityError, match="no variable identifiers"):
+        ws.reindex(make(), var_ids=VAR_IDS)
+
+
+def test_explicit_mapper_gets_the_context_and_is_length_checked():
+    p0, v0, c0 = window(0)
+    x0, info0 = p0.solve(x0=np.full(HORIZON, 3.0))
+    ws = WarmStart.from_info(x0, info0, problem=p0, var_ids=v0, con_ids=c0)
+    p1, v1, c1 = window(1)
+
+    seen = {}
+
+    def mapper(ctx):
+        seen["n"] = ctx.target.n
+        seen["map"] = ctx.index_map("var")
+        lb, ub, _, _ = ctx.bounds()
+        assert lb.size == ctx.target.n == ub.size
+        return {"x": np.roll(ctx.source.x, -1), "lagrange": None,
+                "zl": None, "zu": None}
+
+    moved = ws.transfer(p1, mapper, var_ids=v1, con_ids=c1)
+    assert seen["n"] == HORIZON
+    np.testing.assert_array_equal(seen["map"], [1, 2, 3, 4, -1])
+    assert moved.replay == "mapped"
+    p1.solve(warm_start=moved)
+
+    def bad(ctx):
+        return {"x": np.zeros(HORIZON + 2)}
+
+    with pytest.raises(ValueError, match="the target problem wants"):
+        ws.transfer(p1, bad, var_ids=v1, con_ids=c1)
+
+    def wrong_key(ctx):
+        return {"primal": np.zeros(HORIZON)}
+
+    with pytest.raises(TypeError, match="unknown keys"):
+        ws.transfer(p1, wrong_key, var_ids=v1, con_ids=c1)
+
+
+def test_transfer_without_ids_or_mapper_explains_itself():
+    ws = signed()
+    with pytest.raises(WarmStartCompatibilityError, match="stable variable IDs"):
+        ws.transfer(make())
+
+
+# ---------------------------------------------------------------------------
+# 7. signature bookkeeping
+# ---------------------------------------------------------------------------
+def test_signature_records_the_named_facets():
+    p = make()
+    sig = pounce.ProblemSignature.from_problem(p, VAR_IDS, CON_IDS)
+    assert (sig.n, sig.m) == (4, 2)
+    assert sig.var_ids == tuple(VAR_IDS) and sig.con_ids == tuple(CON_IDS)
+    for facet in ("bounds", "sparsity", "scaling", "algorithm", "model"):
+        assert getattr(sig, facet) is not None
+    assert pounce.ProblemSignature.from_json(sig.to_json()) == sig
+
+
+def test_ids_must_match_the_dimension_and_be_unique():
+    p = make()
+    with pytest.raises(ValueError, match="expected 4 identifiers"):
+        pounce.ProblemSignature.from_problem(p, ["a", "b"])
+    with pytest.raises(ValueError, match="unique"):
+        pounce.ProblemSignature.from_problem(p, ["a", "a", "b", "c"])
+
+
+def test_ids_without_a_problem_is_a_typeerror():
+    _, x, info = cold()
+    with pytest.raises(TypeError, match="problem="):
+        WarmStart.from_info(x, info, var_ids=VAR_IDS)
+
+
+def test_non_model_options_do_not_change_the_signature():
+    """A warm start stays valid across a changed iteration cap; it must
+    not across a changed model definition."""
+    base = pounce.ProblemSignature.from_problem(make())
+    assert pounce.ProblemSignature.from_problem(make(max_iter=17)) == base
+    assert pounce.ProblemSignature.from_problem(make(print_level=5)) == base
+    assert pounce.ProblemSignature.from_problem(
+        make(bound_relax_factor=0.0)) != base

--- a/python/tests/test_warm_start_schema.py
+++ b/python/tests/test_warm_start_schema.py
@@ -500,9 +500,12 @@ def test_horizon_shift_transfers_and_replays():
     assert warm_info["status_msg"] == "Solve_Succeeded"
     np.testing.assert_allclose(warm_x, cold_x, atol=1e-6)
     # Deliberately no assertion that the mapped replay is *cheaper*. On
-    # this family it is not: measured on the parent commit's solver, the
-    # shifted point costs 12 iterations against 7 cold at HORIZON=5, and
-    # the gap widens with the horizon (22 vs 9 at 20, 30 vs 10 at 40).
+    # this family it is not: the shifted point costs 12 iterations here
+    # against 7 for a cold solve, and on a longer sinusoidal track the
+    # gap widens with the horizon -- 12 vs 9 at HORIZON=5, 15 vs 11 at
+    # 10, 22 vs 9 at 20, 30 vs 10 at 40. Neither dropping the carried mu
+    # nor loosening it nor loosening bound_push moves it (11-13 across
+    # six variants).
     # That is the structural limit docs/src/initialization.md already
     # states — the barrier pushes iterates off their bounds, so a
     # converged interior point's active-set information does not survive


### PR DESCRIPTION
Fixes #607

## Problem

Two independent silences in `python/pounce/_warm_start.py`. Both are the
gh#544 shape: the answer is fine, everything else is not.

All numbers below are measured on the parent commit
**`70bf53ded3d893cfa2da6ead5195fda5ac096f68`** ("Register and validate the
cold-start initialization options (#604) (#613)") and on this branch, with
the same harness, the same HS071 fixture, and release builds of both.

**1. Warm-start options leaked into every later solve.** Applying a warm
start called `add_option` on the *persistent* `Problem`, and `add_option`
is append-only, so all seven enabling options stayed set for good.

| HS071, ordinary cold solve from `x0 = [4.9]*4` | status | objective | iters |
|---|---|---|---|
| pristine `Problem` (both commits) | `Solve_Succeeded` | 17.0140171452 | **17** |
| after one warm solve — parent | `Solve_Succeeded` | 17.0140171452 | **24** |
| after one warm solve — this branch | `Solve_Succeeded` | 17.0140171452 | **17** |
| after a warm solve that *raised* — parent | `Solve_Succeeded` | 17.0140171452 | **24** |
| after a warm solve that *raised* — this branch | `Solve_Succeeded` | 17.0140171452 | **17** |

41% more iterations, identical objective to ten digits, nothing anywhere
saying why. The harness confirms the mechanism rather than assuming it:
hand-applying `ws.options()` to a pristine `Problem` reproduces the 24
exactly on the parent, and no longer matches on this branch.

**2. A persisted `WarmStart` could not tell what model it belonged to.**
It recorded arrays and a four-wide float row — no dimensions, ordering,
sparsity, bounds, scaling, algorithm or model fingerprint — so an
incompatible replay was simply attempted. The true optimum is
**17.0140171452**.

| Replay of a saved artifact | parent commit | this branch (signed artifact) |
|---|---|---|
| same problem (control) | 2 iters, 17.0140171449 | 2 iters, 17.0140171449 |
| **variables reordered** | solved, `Error_In_Step_Computation`, obj **16.3801074993**, `x` off by **0.257**, 44 iters | refused — `var_ids: identifiers differ` (see limitation below) |
| **upper bound 5 → 4** | solved, `Restoration_Failed`, obj **15.8435942123**, 7 iters | refused — `bounds:` facet |
| **declared sparsity changed** | solved silently, `Solve_Succeeded`, 2 iters | refused — `sparsity:` facet |
| **different model, same n/m/box/sparsity** | solved silently, `Solve_Succeeded`, 9 iters | refused — `bounds:` facet |
| **n 4 → 5** | `ValueError: x0: expected length 5, got 4` from solve preparation | refused before the solver — `n: captured 4, target 5` |
| **n 4 → 5, explicit right-length `x0`** | `ValueError: zl: expected length 5, got 4` | same refusal, same place |
| **`nlp_scaling_method` changed** | solved silently, `Solve_Succeeded`, 2 iters | refused — `scaling:` facet |
| **`algorithm` changed to SQP** | solved silently, `Solve_Succeeded`, 2 iters | refused — `algorithm:` facet |

Control, both commits: a compatible round trip is lossless — `x`,
`lagrange`, `zl`, `zu` compare bit-identical after `save`/`load`, and the
reloaded state still takes the re-solve from 11 iterations cold to 3.

## Cause

`add_option` pushes onto three `Vec`s that `PyProblem::prepare` replays at
every `solve()`. There was no removal operation, so the wrapper could not
have scoped its options even if it had wanted to; the docstring
acknowledged the leak ("note they persist on this Problem like any
`add_option`") rather than fixing it. And nothing in the wrapper ran
inside a `try`, so a raising solve left the overlay behind too.

For persistence, `save()` wrote `x`, the optional dual arrays, an optional
working set, and `_meta = [mu, bound_push, mu_init, mu_init_fallback]`.
Every array in a warm start is indexed by a *model* — variables in one
order, constraints in another — and none of that indexing was recorded, so
the only thing a replay could check was array length, and only
incidentally, deep inside solve preparation.

## Fix

**Rust (`crates/pounce-py/src/problem.rs`), four additive accessors.**
`options_snapshot()` / `restore_options()` are the snapshot-restore pair
that makes a scoped overlay expressible — restore undoes intervening
`add_option` calls including ones that introduced a name that had never
been set, which no sequence of `add_option` can express. `get_bounds()`,
`get_problem_scaling()` and the `problem_obj` getter are read-only views of
state the `Problem` already holds, following the `set_`/`clear_`/`get_`
convention of `set_ordering` / `set_kkt_schur_block` beside them.

**Scoping.** The wrapper now snapshots, applies, and restores in a
`finally`. It never enumerates option names — whatever `ws.options()`
returns is what gets scoped — so a key added to that recipe later is
covered by construction. This is not a hypothetical: it is exactly what
makes #620's `warm_start_recentering` scope correctly with no change on
either side (verified, see the conflict note).

**Schema.** Archives are versioned (v2) and carry a `ProblemSignature`:
dimensions, optional stable variable/constraint IDs, and digests of the
bound signature, the declared jacobian/Hessian structure, the scaling
convention, the algorithm/backend, and the model-defining options.
Fingerprinting rules live in a separate module, `_warm_start_schema.py`:
they change for reasons that have nothing to do with the warm-start
object's own fields.

`compat` is `"strict"` (raise) / `"warn"` (report and proceed) /
`"unsafe"` (skip), settable on the object, on `load()`, or per call.
Replay is labelled `exact` or `mapped`; `transfer(prob, mapper)` is the
hook for a horizon shift or a changed discretization, `reindex(prob,
var_ids=…)` writes the mapper when both sides carry stable IDs, and a
mapped artifact is still refused on a third problem. Unmatched multiplier
entries are seeded `NaN` — the native "unseeded" contract — rather than
fabricated.

**The compatibility decision, stated deliberately.** Strict is the
default. Strict on a *signed* artifact means any differing or unverifiable
facet raises. Strict on a **legacy (v1) artifact** means: load it, replay
it, check the one facet its own arrays witness (the dimensions), and warn
once with the migration path. Refusing v1 outright would break every
archive written before this change *while it still replays correctly on
the model it came from* — a migration cost with no safety return, which is
not what #518 and #613 refuse things for. Those refuse operations that
silently do nothing; a legacy warm start silently does the right thing on
the right model. The migration is `ws.migrate(prob)` (re-sign as-is) or
re-capture with `problem=` and re-save. An unsigned *in-memory*
`from_info(x, info)` — the pre-#607 call — is silent and unchanged.

**Rejected:** maintaining a Python-side shadow of the option list instead
of the Rust pair. It cannot remove an option that was not previously set,
so a warm solve on a `Problem` that had never seen `mu_init` would still
leak it — the exact measured case above.

**Rejected:** deriving the fingerprint inside `solve` so capture is
automatic. That is the same region of `problem.rs` #620 rewrites, it costs
every solve, and it makes signing non-optional. `from_info(x, info,
problem=prob)` keeps it opt-in and keeps the diff off #620's hunks.

## Blast radius

**Fixture sweep: bit-identical across all 57 models** — status, objective
*and* iteration count — `scripts/sweep-fixtures.sh` run against a release
binary built from the untouched parent `70bf53de` in a separate worktree,
diffed against a release binary from this branch. Expected: the change is
Python-side plus four accessors the solver never calls, and no solver step
moved. Reported because "it cannot produce a wrong answer" is not the
relevant safety property here.

Behaviour changes a user can see:

- A warm solve no longer leaves options on the `Problem`. Code that
  *relied* on the leak — one warm solve to configure a series — now gets
  the cold defaults. That is the bug being fixed, but it is a behaviour
  change, and the CHANGELOG says so with the numbers.
- Replaying a v1 archive emits one `WarmStartLegacyWarning`. Under `-W
  error` that is a new failure; `compat="unsafe"`, `migrate()`, or
  re-capturing clears it.
- Signed artifacts are new, so nothing existing can be refused by the
  strict check.

## Known limitations

Stated because one of them is a case the issue names by name.

- **A pure reordering is invisible to the digests.** Permuting a model
  with a uniform box and a dense jacobian leaves the bound and sparsity
  digests bit-identical — measured, not assumed: `ws.check_compatible()`
  returns no mismatch for the reordered HS071 above. Ordering is knowledge
  only the caller has, so it is caught only when `var_ids` is supplied on
  both sides. Alternatives were worse: making a missing target `var_ids`
  an unverifiable-facet mismatch would mean signing an artifact *with* IDs
  is strictly worse than signing it without, since a live `Problem` has no
  idea what its variables are called.
- **A mapped interior-point warm start is a correctness mechanism, not a
  speed-up.** On the slew-limited receding-horizon fixture in the test
  file the transferred point costs 12 iterations against 7 for a cold
  solve; on a longer sinusoidal track the gap widens with the horizon —
  12 vs 9 at horizon 5, 15 vs 11 at 10, 22 vs 9 at 20, 30 vs 10 at 40.
  Dropping the carried `mu`, or loosening it, or loosening `bound_push`,
  changes none of that (11–13 iterations across six variants on the test
  fixture). This is the barrier/active-set limit
  `docs/src/initialization.md` already describes, and it is what #620
  attacks on the Rust side. The horizon test therefore asserts the answer
  and the labelling, and explicitly does not assert an iteration win — the
  numbers are in the test comment so the next reader does not re-run the
  experiment.
- The `model` fingerprint is an explicit allowlist of options that
  redefine the problem, not a digest of everything. A warm start stays
  valid across a changed `max_iter` (verified) and must not across a
  changed `fixed_variable_treatment` (verified). A future model-defining
  option has to be added to the list.

## Tests

`python/tests/test_warm_start_schema.py`, 34 tests, covering every case
the issue names: reordered variables, changed bounds, changed sparsity,
horizon transfer, the exception path, and legacy artifact migration —
plus strict/warn/unsafe, mapped-artifact provenance, mapper length
checking, and v1↔v2 format compatibility in both directions.

**They fail on the parent commit, and behaviourally.** Three of them
reduce to the pre-existing API only, so the failure is "the parent behaves
wrongly", not "the parent will not import". Run against a release build of
`70bf53de`:

```
FAILED test_warm_options_do_not_leak_into_the_next_ordinary_solve
    assert after["iter_count"] == pristine["iter_count"]
E   assert 24 == 17
FAILED test_warm_options_are_restored_even_when_the_solve_raises
    assert after["iter_count"] == pristine["iter_count"]
E   assert 24 == 17
FAILED test_legacy_artifact_replay_says_it_is_unverified
    with pytest.warns(UserWarning):
E   Failed: DID NOT WARN. No warnings of type (<class 'UserWarning'>,)
    were emitted. Emitted warnings: [].
3 failed in 0.75s
```

The same three pass on this branch. The compatibility half is a *new
capability* with no old-API expression, so its tests cannot be reduced
that way — on the parent they fail at collection with `ImportError: cannot
import name 'WarmStartCompatibilityError' from 'pounce'`. That gap is
stated rather than papered over.

Green on this branch: `cargo fmt --all -- --check` (clean), `cargo clippy
--workspace --exclude pounce-hsl --all-targets` (no new warnings; the
pre-existing `pounce-restoration` ones are untouched), `cargo test
--workspace --exclude pounce-hsl` (2926 passed, 0 failed), the Python
suite (807 passed, 38 skipped — 773 before, 34 new),
`scripts/check-release-consistency.sh` and
`scripts/check-docs-consistency.sh` (both OK).

## Conflict note — PR #620 (issue #606), branch `claude/pounce-issue-606-loop`

#620 is open and unmerged and edits `python/pounce/_warm_start.py`. This
branch was developed against `main` so #607 is measured in isolation, and
#620's branch was **not** merged in and is not depended on. A trial merge
was run to characterize the conflict; the resolution below was then
applied, built, and tested for real.

**`git merge` of #620 into this branch: 4 conflicts, all pure
"both-added", none semantic.** `crates/pounce-py/src/problem.rs` and
`docs/src/initialization.md` auto-merge — #620's `problem.rs` edits are in
`solve` / `solve_with_sens` / `build_info_dict`, and this branch's are a
new `#[pymethods]` block next to `get_kkt_schur_block`.

| file | conflict | resolution |
|---|---|---|
| `_warm_start.py` | dataclass docstring: #620 adds `recentering:`, this branch adds `signature:` / `compat:` / `replay:` / `source_signature:` / `schema_version:` / `origin:` at the same anchor | keep both, `recentering` first to match field order |
| `_warm_start.py` | field list: same anchor, same reason | keep both, `recentering` first |
| `_warm_start.py` | `load()`: #620 adds `recentering=recentering,` as the last kwarg, this branch adds `**cls._schema_overrides(data, compat),` | keep both lines |
| `CHANGELOG.md` | both add a bullet at the top of `[Unreleased]` | keep both bullets |

Everything else merges clean *by construction*, and that was a design
constraint, not luck:

- `WarmStart.options()` is **untouched** here, so #620's
  `warm_start_recentering` entry merges without a conflict — and, more
  importantly, is scoped correctly with no change on either side, because
  the overlay snapshots the option list rather than naming keys.
- The v2 persistence keys are added through one line in `save()`
  (`payload.update(self._schema_payload())`, after the working-set block)
  and one in `load()`, away from #620's `_recentering` hunks.
- The bulk of the new code is in a new file, `_warm_start_schema.py`, and
  a new test file, neither of which #620 touches.

**The resolution was verified, not assumed.** With the four conflicts
resolved as above, the merged tree builds and the full Python suite passes
— 807 passed, 38 skipped, the union of both branches' tests. And the
interaction that mattered was checked directly on the merged tree:

```
#606 options() includes: ['warm_start_recentering']
option list restored exactly: True
warm_start_recentering left behind: False
pristine iters=17   after-warm iters=17
```

Suggested merge order: either way round works. If #620 lands first, this
branch rebases onto it with the four hunks above; if this lands first,
#620 does the same.

## Follow-ups filed

Both are gaps this branch measured and deliberately did not close. Neither has
an owner yet.

- **#621 — a reordered warm start is not refused unless the caller supplies
  `var_ids`.** The "Known limitations" note above, filed. #607's acceptance
  criteria ask for an incompatible replay to be refused; a pure permutation of
  a uniform-box, dense-jacobian model is the one incompatible case the digests
  cannot see.
- **#622 — a transferred (mapped) warm start is slower than a cold solve, and
  the gap widens with horizon** (12 vs 7 on the slew-limited fixture, 30 vs 10
  at horizon 40). The horizon-transfer table above, filed, with the note that
  #620 is the thing most likely to close it and that the table should be
  re-measured once it lands.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`initialization.md`; no new page,
      so no `SUMMARY.md` change — `check-docs-consistency.sh` is OK)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this body and in the code comments is true of the code
      as it stands now. The before/after numbers are all from
      `70bf53ded3d893cfa2da6ead5195fda5ac096f68` and this branch's head,
      taken with the same harness in the same session; the sweep was run
      against a release binary built from that commit in a separate
      worktree.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXUyBXwW7GQQAX6byMXnw4)_