### PR TITLE
Expose predictor-corrector NLP continuation across non-AD frontends (#608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,89 @@ changes.
 
 ## [Unreleased]
 
+- **Predictor-corrector NLP continuation, exposed across the non-AD
+  frontends** (#608). #90 delivered a path follower, but only for the
+  differentiable frontend: `pounce.jax.PathFollower` is written against
+  `JaxProblem` and reaches for `jax.grad` / `jax.jacobian`. None of the
+  algorithm needs autodiff, so `pounce.Continuation` runs the same loop
+  through the public `Problem` / `Solver` API, and adapters carry it to
+  Pyomo, the CLI and GAMS.
+
+  `run(thetas)` traces a prescribed repeated-NLP sequence;
+  `follow(theta_of_s, s_span)` traces an adaptive path and may accept a
+  point on the predictor alone. `ContinuationTrace` reports what #608
+  asks for: predictor residual, corrections, step rejections,
+  active-set events and total evaluations. Declaring the parameter's
+  pin-equality rows (`pins=`) enables the tangent predictor — a
+  back-solve against the held KKT factor — and omitting them falls back
+  to a zero-order warm transfer; `has_tangent` says which you got.
+
+  *`run` subdivides.* A corrector rejection between two prescribed
+  points no longer ends the trace with a runaway iterate recorded as an
+  answer: the driver halves the gap and re-predicts from the last point
+  known good. Inserted points carry `prescribed=False` and are counted
+  by `trace.n_inserted`; every prescribed point still appears, in
+  order. It is a no-op on a healthy path. `subdivide_tol` adds an
+  opt-in monitor-driven trigger, deliberately a separate knob from
+  `monitor_tol` (which at its `1e-6` default would subdivide on
+  essentially every step).
+
+  *Pseudo-arclength past folds.* `trace_arclength` follows the curve
+  through a turning point, where `run` and `follow` cannot: past a fold
+  there is no solution at the next `θ`. The tangent is the null vector
+  of the augmented `[∂R/∂z | ∂R/∂θ]`, taken by bordering with the
+  previous tangent — nonsingular *at* a simple fold, and no SVD, unlike
+  #90's dense route. `R` and its Jacobian are assembled sparsely from
+  the problem's own callbacks. On `min x0³/3 + x1²/2 s.t. x0 + x1 = θ`
+  (folding at `x0 = −1/2, θ = −1/4`), parameter continuation diverges
+  (`Diverging_Iterates`, |x0| > 10¹⁰) while `trace_arclength` turns and
+  continues onto the other branch, every point a root of `R` to < 10⁻⁷.
+  Scope is #90's: scalar `θ`, equality/unconstrained, fixed active set.
+
+  *CLI.* `pounce-continue` traces a path manifest — one command, one
+  report, one process per point. The KKT factor does not survive
+  `exec`, so there is no tangent predictor there and the trace says so
+  rather than implying one; what does cross is a primal **and dual**
+  transfer through the `.nl` `x` / `d` segments. Measured on a 20-point
+  van der Pol NMPC path: 226 → 193 iterations (−14.6%) against repeated
+  cold invocations, but only ~5% of wall clock, because process
+  startup, `.nl` parse and presolve dominate at these sizes.
+
+  *GAMS.* `pounce.gams.continuation.trace` routes a GAMS path through
+  the same driver; the pip link builds an ordinary `Problem` from a GMO
+  view, so driven from one process it gets the tangent predictor too.
+  The native C link's `sqp_state_file` is **not** a route to carrying
+  continuation state: it holds the discrete working set only — no
+  primal point, no multipliers, no barrier parameter — and its checksum
+  over `(n, m, bounds)` is invalidated by exactly the horizon shifts and
+  remeshes the transfer map exists to serve.
+
+  *What it is worth, stated as measured.* On an interior-point method
+  the tangent predictor does **not** make a warm-started solve
+  meaningfully cheaper. Over `mpc_horizon_{10,20,40,80}` at three step
+  scales — 12 cells, 240 solves per arm, baseline `cfc1121` — cold 2492,
+  warm 1229, predictor 1258 (+2.4%), predictor-corrector 1242 (+1.1%) at
+  `warm_start_recentering=residual`; 1257 (+2.3%) and 1215 (−1.1%) at
+  `=none`. Warm starting is worth 2.03×; the predictor on top of it is
+  noise, and at the largest step scale it is reliably worse (+17.5% at
+  horizon 80) because it extrapolates across critical-region boundaries
+  the corrector undoes. The mechanism is a floor, not a tuning failure:
+  in the continuation regime a warm-started IPM solve already converges
+  in one iteration per step. Recorded because "an accepted cost" with no
+  owner is indistinguishable from noise to the next reader.
+
+  Recentering does not move that verdict, and the reason is mechanical:
+  `cold-ipm`, `warm-ipm` and `pred-ipm` are bit-identical between the
+  two settings (0 of 240 steps differ each); only `predcorr-ipm` moves,
+  on 14 of 240, because it is the one arm supplying a *perturbed*
+  multiplier seed for the recentering measurement to act on. The warm
+  baseline is 1229 at both settings, so #606/#620 contributes none of
+  the 1097 → 1229 move against the earlier `70bf53de` measurement.
+
+  Where continuation does pay is `follow`, which skips the solve
+  entirely. Full write-up, including what the CLI path is and is not:
+  `docs/src/continuation.md`.
+
 - **`WarmStart` artifacts carry the model they belong to, and warm-start
   options no longer outlive the call that asked for them** (#607). Two
   independent silences in `pounce.WarmStart`, both of the shape gh#544

--- a/benchmarks/warmstart/adapters/base.py
+++ b/benchmarks/warmstart/adapters/base.py
@@ -37,6 +37,18 @@ defines:
     the suite exercises working-set hot starts but never the parametric
     path. Paired against ``cold-sqp`` / ``warm-sqp``, which differ in
     that one option and nothing else.
+``pred-ipm`` / ``predcorr-ipm``
+    Interior point seeded with a **tangent predictor** rather than with
+    the previous solution alone: the first-order parametric step
+    ``Δx ≈ ∂x*/∂θ · Δθ`` read off the previous solve's held KKT factor
+    (``pounce.Solver.parametric_step``). ``predcorr-ipm`` additionally
+    steps the multipliers (``parametric_step_full``) and re-anchors on
+    an active-set event. These are the third and fourth arms pounce#608
+    asks for; paired against ``warm-ipm``, which differs only in the
+    seed. Defined only for families that route θ through pin-equality
+    rows (:attr:`ParametricFamily.pin_rows`), because that is what the
+    sensitivity step's ``deltas`` argument means -- on any other family
+    they are skipped with a reason rather than silently omitted.
 ``cold-qp-ipm`` / ``warm-qp-ipm``
     The dedicated convex QP interior-point solver, handed the problem
     in matrix form rather than through callbacks, cold and seeded with
@@ -68,6 +80,8 @@ ARMS: List[str] = [
     "warm-sqp",
     "cold-sqp-hom",
     "warm-sqp-hom",
+    "pred-ipm",
+    "predcorr-ipm",
     "cold-qp-ipm",
     "warm-qp-ipm",
 ]
@@ -83,6 +97,11 @@ HOMOTOPY_ARMS = ("cold-sqp-hom", "warm-sqp-hom")
 #: Arms that need the family's instances to be QPs.
 QP_ARMS = ("cold-qp-ipm", "warm-qp-ipm")
 
+#: Arms whose primal seed is a held-factor tangent predictor rather than
+#: the previous solution (pounce#608). They need the family to declare
+#: which constraint rows carry θ.
+PREDICTOR_ARMS = ("pred-ipm", "predcorr-ipm")
+
 #: The arm whose per-step solutions every other arm is checked
 #: against, and which generates the parameter path for adaptive
 #: families.
@@ -90,7 +109,21 @@ REFERENCE_ARM = "cold-ipm"
 
 
 def is_warm(arm: str) -> bool:
-    return arm.startswith("warm")
+    """Whether the arm carries state forward from the previous step.
+
+    The predictor arms do: they seed from the previous solve and then
+    step that seed along the sensitivity, so they are warm arms with a
+    better seed, not a separate category.
+    """
+    return arm.startswith("warm") or arm in PREDICTOR_ARMS
+
+
+def uses_predictor(arm: str) -> bool:
+    return arm in PREDICTOR_ARMS
+
+
+def predicts_duals(arm: str) -> bool:
+    return arm == "predcorr-ipm"
 
 
 def is_sqp(arm: str) -> bool:
@@ -113,6 +146,11 @@ def arm_applies(arm: str, family: ParametricFamily) -> Optional[str]:
     """
     if arm in QP_ARMS and not family.quadratic:
         return "family is not a QP (nonlinear objective or constraints)"
+    if arm in PREDICTOR_ARMS and not family.pin_rows:
+        return (
+            "family does not route theta through pin-equality rows, so a "
+            "sensitivity step has no deltas to take"
+        )
     return None
 
 

--- a/benchmarks/warmstart/adapters/pounce_adapter.py
+++ b/benchmarks/warmstart/adapters/pounce_adapter.py
@@ -84,8 +84,12 @@ _OK_QP_STATUS = ("optimal", "optimal_inaccurate")
 class PounceAdapter(SolverAdapter):
     name = "pounce"
 
-    def __init__(self, max_iter: int = 500):
+    def __init__(self, max_iter: int = 500, recentering: str = "residual"):
         self.max_iter = max_iter
+        # `warm_start_recentering` (pounce#606 / #620). The warm-start
+        # baseline this corpus reports moves with it, so it is a swept
+        # axis rather than a default: see docs/src/continuation.md.
+        self.recentering = recentering
 
     def supports(self, arm: str) -> bool:
         return arm in ARMS
@@ -285,6 +289,7 @@ class PounceAdapter(SolverAdapter):
                     )
                 kwargs["warm_start"] = pounce.WarmStart(
                     x=seed_x, lagrange=lam, zl=zl, zu=zu, mu=warm.mu,
+                    recentering=self.recentering,
                 )
         else:
             kwargs["x0"] = np.asarray(x0, dtype=float)

--- a/benchmarks/warmstart/adapters/pounce_adapter.py
+++ b/benchmarks/warmstart/adapters/pounce_adapter.py
@@ -9,6 +9,12 @@ cold-ipm     ``interior-point`` (default)         none
 cold-sqp     ``active-set-sqp``                   none
 warm-ipm     ``interior-point``                   ``WarmStart`` (x, λ, z, μ)
 warm-sqp     ``active-set-sqp``                   working set + previous x
+pred-ipm     ``interior-point``                   previous state, primal seed
+                                                  stepped by the held-factor
+                                                  tangent
+predcorr-ipm ``interior-point``                   as above, multipliers
+                                                  stepped too, reanchored on
+                                                  an active-set event
 cold-qp-ipm  ``pounce.solve_qp`` (pounce-convex)  none
 warm-qp-ipm  ``pounce.solve_qp``                  previous ``QpResult``
 ===========  ===================================  =========================
@@ -57,7 +63,16 @@ import pounce
 from .. import qpform
 from ..spec import ParametricFamily, StepResult, WarmState
 from ..sparsity import SparseCallbacks
-from .base import ARMS, QP_ARMS, SolverAdapter, is_sqp, is_warm, uses_homotopy
+from .base import (
+    ARMS,
+    QP_ARMS,
+    SolverAdapter,
+    is_sqp,
+    is_warm,
+    predicts_duals,
+    uses_homotopy,
+    uses_predictor,
+)
 
 # ApplicationReturnStatus values that count as a solved step.
 _OK_STATUS = (0, 1)  # SolveSucceeded, SolvedToAcceptableLevel
@@ -165,6 +180,69 @@ class PounceAdapter(SolverAdapter):
         )
         return result, next_warm
 
+    # -- the tangent predictor (pounce#608) ------------------------
+
+    def _predict(self, family, warm, arm, x, lam, zl, zu):
+        """Step the previous state along ``∂·/∂θ`` for this step's Δθ.
+
+        The sensitivity is a back-solve against the previous solve's
+        held factor, carried in `warm.extra`. Everything here degrades
+        to the plain warm start rather than failing: a factor that
+        cannot answer, a missing Δθ, or an active-set event on the
+        previous step all return the seed unchanged, which is the
+        zero-order transfer.
+        """
+        extra = warm.extra or {}
+        session = extra.get("session")
+        theta_prev = extra.get("theta")
+        theta_now = family.current_theta()
+        if session is None or theta_prev is None or theta_now is None:
+            return x, lam, zl, zu
+        dtheta = np.asarray(theta_now, float) - np.asarray(theta_prev, float)
+        if not dtheta.size:
+            return x, lam, zl, zu
+        if predicts_duals(arm) and extra.get("active_set_event"):
+            return x, lam, zl, zu          # reanchor: drop the stale tangent
+
+        pins = list(family.pin_rows)
+        deltas = [float(v) for v in np.asarray(dtheta, dtype=float).ravel()]
+        if len(deltas) != len(pins):
+            return x, lam, zl, zu
+        n = family.n
+        b = family.bounds()
+        try:
+            if not predicts_duals(arm):
+                dx = np.asarray(session.parametric_step(pins, deltas),
+                                dtype=float)[:n]
+                return np.clip(x + dx, b.lb, b.ub), lam, zl, zu
+            full = np.asarray(session.parametric_step_full(pins, deltas),
+                              dtype=float)
+        except Exception:
+            return x, lam, zl, zu
+
+        dims = list(session.block_dims)
+        x = np.clip(x + full[:n], b.lb, b.ub)
+        if lam is not None:
+            dlam = np.zeros(family.m)
+            rows = session.multiplier_rows(list(range(family.m)))
+            for i, r in enumerate(rows):
+                if r is not None and 0 <= r < full.size:
+                    dlam[i] = full[r]
+            lam = lam + dlam
+        off = dims[0] + dims[1] + dims[2] + dims[3]
+        # Bound multipliers are nonnegative; a linear step can drive one
+        # through zero, which is the active-set event the solve resolves.
+        if zl is not None and off + dims[4] <= full.size:
+            k = min(n, dims[4])
+            zl = zl.copy()
+            zl[:k] = np.maximum(zl[:k] + full[off:off + k], 0.0)
+        if zu is not None and off + dims[4] + dims[5] <= full.size:
+            k = min(n, dims[5])
+            zu = zu.copy()
+            zu[:k] = np.maximum(
+                zu[:k] + full[off + dims[4]:off + dims[4] + k], 0.0)
+        return x, lam, zl, zu
+
     # -- one step --------------------------------------------------
 
     def solve(
@@ -182,6 +260,11 @@ class PounceAdapter(SolverAdapter):
 
         prob = self._build(family, callbacks, arm, tol)
         callbacks.reset_counts()
+        # The predictor arms need the session handle, because the tangent
+        # is a back-solve against the factor this step leaves behind. The
+        # session is created for every IPM arm so that arm-to-arm timing
+        # is not confounded by the wrapper itself.
+        session = pounce.Solver(prob) if not is_sqp(arm) else None
 
         # Step 0 of a warm arm has nothing to warm from: it is a cold
         # solve, and is reported as one.
@@ -194,18 +277,33 @@ class PounceAdapter(SolverAdapter):
                 if warm.working_set is not None:
                     kwargs["working_set"] = warm.working_set
             else:
+                seed_x = warm.x
+                lam, zl, zu = warm.mult_g, warm.mult_x_L, warm.mult_x_U
+                if uses_predictor(arm):
+                    seed_x, lam, zl, zu = self._predict(
+                        family, warm, arm, seed_x, lam, zl, zu
+                    )
                 kwargs["warm_start"] = pounce.WarmStart(
-                    x=warm.x,
-                    lagrange=warm.mult_g,
-                    zl=warm.mult_x_L,
-                    zu=warm.mult_x_U,
-                    mu=warm.mu,
+                    x=seed_x, lagrange=lam, zl=zl, zu=zu, mu=warm.mu,
                 )
         else:
             kwargs["x0"] = np.asarray(x0, dtype=float)
 
         t0 = time.perf_counter()
-        x, info = prob.solve(**kwargs)
+        if session is not None:
+            # `Solver.solve` takes the seeds directly; the WarmStart's
+            # enabling options still have to be installed on the Problem.
+            ws = kwargs.pop("warm_start", None)
+            if ws is not None:
+                for key, val in ws.options().items():
+                    prob.add_option(key, val)
+                sk = ws.solve_kwargs()
+                sk.pop("working_set", None)
+                x, info = session.solve(x0=ws.x, **sk)
+            else:
+                x, info = session.solve(x0=kwargs["x0"])
+        else:
+            x, info = prob.solve(**kwargs)
         elapsed = time.perf_counter() - t0
 
         status = int(info.get("status", -99))
@@ -262,4 +360,27 @@ class PounceAdapter(SolverAdapter):
                 else None
             ),
         )
+        if uses_predictor(arm):
+            # What the next step's tangent needs: the live session (it
+            # owns the converged factor), the theta this solve was run
+            # at (the runner fills `theta` after the fact, so record it
+            # here from the family), and whether the bound activity just
+            # moved -- which invalidates the tangent for `predcorr-ipm`.
+            act = None
+            if info.get("mult_x_L") is not None and info.get("mult_x_U") is not None:
+                act = (np.asarray(info["mult_x_L"]) > 1e-6,
+                       np.asarray(info["mult_x_U"]) > 1e-6)
+            prev_act = (warm.extra or {}).get("active") if warm else None
+            next_warm.extra = {
+                "session": session if status in _OK_STATUS else None,
+                # Delta theta for the next step is formed against this,
+                # not handed down: an adapter never sees the runner's path.
+                "theta": family.current_theta(),
+                "active": act,
+                "active_set_event": bool(
+                    prev_act is not None and act is not None
+                    and (np.any(act[0] != prev_act[0])
+                         or np.any(act[1] != prev_act[1]))
+                ),
+            }
         return result, next_warm

--- a/benchmarks/warmstart/families/mpc_horizon.py
+++ b/benchmarks/warmstart/families/mpc_horizon.py
@@ -56,6 +56,11 @@ class LinearMpcBase(ParametricFamily):
     quadratic = True
     n_steps = 20
 
+    #: `c[:2] = X0 - theta` with `cl == cu == 0`, so stepping theta is
+    #: exactly stepping these two rows' right-hand side -- the sIPOPT
+    #: `deltas` convention the tangent predictor takes (pounce#608).
+    pin_rows = (0, 1)
+
     _NH = 10  # overridden per horizon
     _H = 0.1
     _A = 1.0  # stiffness

--- a/benchmarks/warmstart/run.py
+++ b/benchmarks/warmstart/run.py
@@ -96,6 +96,15 @@ def main(argv=None) -> int:
     )
     p.add_argument("--max-iter", type=int, default=500)
     p.add_argument(
+        "--recentering",
+        default="residual",
+        choices=("residual", "none"),
+        help="warm_start_recentering (pounce#606). The warm-start "
+        "baseline moves with this, and so does any margin measured "
+        "against it, so a predictor claim has to name which setting it "
+        "was taken at",
+    )
+    p.add_argument(
         "--tier",
         default="default",
         choices=("default", "large", "all"),
@@ -120,7 +129,8 @@ def main(argv=None) -> int:
         families = [f for f in families if f in _QUICK_FAMILIES]
         scales = ["small"]
 
-    adapter = get_adapter(args.solver, max_iter=args.max_iter)
+    adapter = get_adapter(args.solver, max_iter=args.max_iter,
+                          recentering=args.recentering)
 
     meta = {
         "solver": args.solver,
@@ -134,6 +144,7 @@ def main(argv=None) -> int:
         "kkt_gate": args.kkt_gate,
         "viol_gate": args.viol_gate,
         "max_iter": args.max_iter,
+        "recentering": args.recentering,
         "arms": arms,
     }
 

--- a/benchmarks/warmstart/spec.py
+++ b/benchmarks/warmstart/spec.py
@@ -167,6 +167,16 @@ class ParametricFamily(ABC):
     #: single active-set solve on them can take seconds.
     tier: str = "default"
 
+    #: Constraint rows through which θ enters as a pin equality
+    #: ``g_i(x) = θ_i`` (``cl[i] == cu[i]``), in θ's own component order.
+    #: Empty (the default) means θ does not enter that way, which is what
+    #: a held-factor sensitivity step needs: `deltas` is a perturbation of
+    #: exactly these rows' right-hand sides. Declaring it enables the
+    #: predictor arms (pounce#608); the suite's self-test checks the claim
+    #: by comparing the tangent step against a finite difference of two
+    #: solves.
+    pin_rows: tuple = ()
+
     #: True when the next parameter depends on the previous solution
     #: (closed-loop MPC / moving horizon). The runner then records the
     #: path produced by the reference arm and *replays* it for the
@@ -205,6 +215,17 @@ class ParametricFamily(ABC):
 
         ``scale`` multiplies the family's natural per-step increment.
         """
+
+    def current_theta(self) -> Optional[np.ndarray]:
+        """The parameter currently installed, or ``None`` if unknown.
+
+        Families that keep it in ``self._theta`` (all of them today) get
+        this for free. Needed by the predictor arms, which form Δθ from
+        the previous step's value rather than from the runner's path --
+        an adapter never sees the path.
+        """
+        theta = getattr(self, "_theta", None)
+        return None if theta is None else np.asarray(theta, float).ravel().copy()
 
     def initial_theta(self, scale: float) -> np.ndarray:
         """First parameter of an adaptive path (adaptive families only)."""

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -22,6 +22,7 @@
 - [Verifying Solutions](verify.md)
 - [Sensitivity Analysis](sensitivity.md)
 - [Sessions: Factor-Once / Solve-Many](sessions.md)
+- [Continuation over a Parametric NLP Sequence](continuation.md)
 - [Differentiable Solves & the DiffHandoff Contract](differentiable-solves.md)
 - [Interactive Debugger](debugger.md)
 

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -1,0 +1,237 @@
+# Continuation over a parametric NLP sequence
+
+When you solve the *same* NLP many times with a moving parameter — an MPC
+controller stepping its horizon, a flowsheet swept over an operating
+variable, an uncertainty map traced through a design space — the
+orchestration is always the same: carry the previous iterate forward,
+transfer it onto the new problem, seed the solve, notice when the active
+set moves, and count what it all cost.
+
+`pounce.Continuation` is that orchestration, for the generic `Problem`
+API. `pyomo_pounce.continuation` is the same thing over a Pyomo model.
+
+This page also reports what the capability is *worth*, measured, because
+the answer is not the one the literature on active-set warm starting
+would lead you to expect. Read [the measurement](#what-it-is-worth)
+before you reach for the tangent predictor.
+
+## The short version
+
+```python
+import numpy as np
+import pounce
+
+def update(theta):
+    """Install theta and hand back the Problem. This is the only
+    frontend-specific part."""
+    rhs = np.array([0.0, 0.0, theta[0], theta[1]])
+    p = pounce.Problem(n=5, m=4, problem_obj=model,
+                       lb=lb, ub=ub, cl=rhs, cu=rhs)
+    p.add_option("print_level", 0)
+    return p
+
+driver = pounce.Continuation(update, pins=[2, 3])
+trace = driver.run([np.array([5.0 - 0.5 * t, 1.0 + 0.2 * t])
+                    for t in np.linspace(0, 1, 8)], x0=x0)
+
+print(trace.report())
+```
+
+```text
+continuation: ok
+  points            8
+  corrections       8
+  predictor accepts 0
+  step rejections   0
+  active-set events 1
+  worst predictor residual 4.309e-02
+  solver iterations 28
+  total evaluations 232
+  solve time        6.1 ms
+```
+
+## The two modes, and which one you want
+
+`run(thetas)` traces a **prescribed** sequence: you have a list of
+parameter values and you want each one solved. Every point is corrected,
+because every point is an answer you asked for.
+
+`follow(theta_of_s, s_span)` traces a **path**: the intermediate points
+are a means, not an end. Here the driver picks its own step size, and a
+predicted point whose KKT residual is under `monitor_tol` is accepted
+**with no solve at all**. That is where continuation pays.
+
+The distinction matters more than it looks, because it decides whether
+the predictor has anything to do. See below.
+
+## Pieces
+
+### The parameter must enter through pin rows for a tangent predictor
+
+`pins=` are the 0-based indices of the equality rows `g_i(x) = θ_i`
+(so `cl[i] == cu[i] == θ_i`) — the sIPOPT convention that
+[`Problem.solve_with_sens`](sensitivity.md) and
+`Solver.parametric_step` already take. Given them, the predictor is a
+back-solve against the previous solve's held KKT factor: no extra
+factorization, no extra function evaluation.
+
+Omit `pins` and the driver falls back to a **zero-order warm transfer** —
+the previous iterate carried over unchanged. That is a supported mode,
+not a degraded one; `Continuation.has_tangent` tells you which you got.
+
+### Transfer maps, for when the problem changes shape
+
+A horizon shift or a remesh changes *which* variables exist. Supply
+`transfer=`, a mapper with the same protocol as `WarmStart.transfer`:
+
+```python
+def shift(ctx):
+    x = ctx.source.x.reshape(N + 1, -1)
+    return {"x": np.vstack([x[1:], x[-1]]).ravel()}
+
+driver = pounce.Continuation(update, pins=[0, 1], transfer=shift)
+```
+
+The mapper returns a dict of replacement arrays — any of `x`,
+`lagrange`, `zl`, `zu`, `working_set`, `mu` — and anything it leaves out
+is carried over unchanged. Every array is length-checked against the
+target problem before the solve, so an off-by-one fails at the mapper
+rather than three function evaluations into the solve.
+
+### The monitor is what lets `follow` skip a solve
+
+`follow` cannot accept a predicted point without a way to score it, so
+supply `monitor=`. `pounce.kkt_residual_monitor(problem_obj, bounds)`
+builds one from the same cyipopt-shaped callbacks the `Problem` already
+has:
+
+```python
+monitor = pounce.kkt_residual_monitor(model, bounds_at)
+driver = pounce.Continuation(update, pins=[2, 3], monitor=monitor,
+                             bounds=bounds_at, monitor_tol=3e-2)
+```
+
+Without a monitor `follow` corrects every step — the safe degradation,
+not an error.
+
+### What the trace reports
+
+`ContinuationTrace` carries every counter, per step and aggregated:
+predictor residual, corrections, step rejections, active-set events,
+solver iterations, and total callback evaluations (pass `counter=` an
+object with `reset_counts()` / `counts()` to fill the last one).
+
+## What it is worth
+
+> **Summary: on an interior-point method the tangent predictor does not
+> make a warm-started solve meaningfully cheaper.** Measured over
+> pounce's own warm-start corpus it is within ±3% of a plain
+> previous-solution warm start. Continuation pays here by *skipping
+> solves* in `follow`, not by accelerating them in `run`.
+
+### The four-way benchmark
+
+`benchmarks/warmstart` carries the four arms as `cold-ipm`, `warm-ipm`,
+`pred-ipm` (tangent primal seed) and `predcorr-ipm` (tangent primal *and*
+dual seed, re-anchored on an active-set event):
+
+```
+python -m warmstart.run --families mpc_horizon_40 \
+    --arms cold-ipm,warm-ipm,pred-ipm,predcorr-ipm
+```
+
+Summed over the `mpc_horizon_{10,20,40,80}` families at all three step
+scales — 12 cells, 240 solves per arm, warm-start-eligible steps only:
+
+| arm | iterations | vs. `warm-ipm` |
+|---|---|---|
+| `cold-ipm` | 2360 | +115% |
+| `warm-ipm` | 1097 | — |
+| `pred-ipm` | 1125 | **+2.6%** |
+| `predcorr-ipm` | 1083 | **−1.3%** |
+
+Warm starting is worth 2.15×. The tangent predictor on top of it is
+noise, and at the largest step scale `pred-ipm` is reliably *worse*
+(+18% at horizon 80) because it extrapolates across critical-region
+boundaries the corrector then has to undo.
+
+### Why — the one-iteration floor
+
+The mechanism is visible per step. In the continuation regime (the
+suite's `tiny` scale), a warm-started IPM solve converges in **one
+iteration**:
+
+```
+warm  k= 2 iters=  1     warm  k=11 iters=  1
+warm  k= 3 iters=  1     warm  k=12 iters=  1
+warm  k= 4 iters=  1     ...
+```
+
+There is no headroom. A better seed cannot take a solve below one
+iteration, so the predictor has nothing to remove. This is the
+interior-point analogue of the well-known result that IPMs warm-start
+weakly: the barrier restart, not the seed's distance from the solution,
+is what the iterations are spent on.
+
+At larger steps there is headroom, but there the active set moves and
+the first-order predictor is extrapolating through a kink — the error is
+`O(Δθ²)` at best and unbounded across a region boundary.
+
+### Where continuation *does* pay: skipping the solve
+
+`follow` can accept a point outright. On the upstream sIPOPT
+`ParametricTNLP` fixture, tracing the same path at different
+`monitor_tol`:
+
+| `monitor_tol` | points | solves | accepts | iterations | endpoint error |
+|---|---|---|---|---|---|
+| `1e-6` | 8 | 8 | 0 | 28 | 2.8e-15 |
+| `1e-2` | 8 | 7 | 1 | 26 | 2.8e-15 |
+| `3e-2` | 8 | 4 | 4 | 18 | 6.2e-05 |
+| `1e-1` | 8 | 2 | 6 | 12 | 8.3e-04 |
+| `1e+0` | 8 | 1 | 7 | 9  | 6.8e-03 |
+
+Half the solves for 6e-5 of endpoint error is a real trade, and it is the
+one continuation is for. But notice what the currency is: **accuracy, not
+free speed**. If you need every point at solver tolerance, use `run` and
+expect warm-start performance.
+
+### Which to use
+
+* Every point must be solved to tolerance → `run(...)`, with or without
+  `pins`. The predictor is not the reason to use this; the orchestration
+  and the counters are.
+* Intermediate points are a means → `follow(...)` with a `monitor` and a
+  `monitor_tol` you have chosen deliberately, knowing it sets the
+  accuracy of the accepted points.
+* Your problem is an active-set SQP (`algorithm=active-set-sqp`) → the
+  working-set warm start is the mechanism that pays there; see
+  [active-set SQP warm starts](active-set-sqp-warm-start.md).
+
+## Relationship to the differentiable frontend
+
+`pounce.jax.PathFollower` (see [path following](path-following.md)) is the
+same algorithm over a `JaxProblem`, and predates this. The two share their
+step-size policy — `pounce.StepController` — so "how far to step next" has
+one implementation. They differ only in how the predictor and the monitor
+are obtained: the AD frontend gets them from `jax.grad` / `jax.jacobian`
+and `jvp_from_state`, this one from the problem's own callbacks and
+`Solver.parametric_step`.
+
+`PathFollower` additionally offers pseudo-arclength continuation past
+folds (`trace_arclength`). That is **not** exposed here — see below.
+
+## Not implemented
+
+* **Pseudo-arclength continuation** past turning points. `PathFollower`'s
+  version is written directly against `jax.jacobian` of the stationarity
+  system and an SVD of it; the generic frontend has no equivalent of that
+  dense `(d, d+1)` Jacobian, and manufacturing one from `Solver.kkt_solve`
+  is a separate piece of work rather than an adaptation. pounce#608 marks
+  it optional; use `pounce.jax.PathFollower.trace_arclength` if you need
+  it.
+* **CLI and GAMS adapters.** pounce#608 sequences these after the
+  `Problem` and Pyomo ones. Both need a path manifest / repeated-solve
+  protocol that does not exist yet, and neither can hold a KKT factor
+  across process boundaries, so both would run the zero-order fallback
+  only — which is what `--warm-start` already does.

--- a/docs/src/continuation.md
+++ b/docs/src/continuation.md
@@ -141,19 +141,49 @@ python -m warmstart.run --families mpc_horizon_40 \
 ```
 
 Summed over the `mpc_horizon_{10,20,40,80}` families at all three step
-scales — 12 cells, 240 solves per arm, warm-start-eligible steps only:
+scales — 12 cells, 240 solves per arm, warm-start-eligible steps only.
+Measured on **`cfc1121`**, at both settings of `warm_start_recentering`
+(pounce#606), because the warm baseline is what every margin here is
+quoted against and a claim about the predictor has to name the baseline
+it was taken against:
 
-| arm | iterations | vs. `warm-ipm` |
-|---|---|---|
-| `cold-ipm` | 2360 | +115% |
-| `warm-ipm` | 1097 | — |
-| `pred-ipm` | 1125 | **+2.6%** |
-| `predcorr-ipm` | 1083 | **−1.3%** |
+| arm | iterations (`recentering=residual`) | vs. `warm-ipm` | iterations (`recentering=none`) | vs. `warm-ipm` |
+|---|---|---|---|---|
+| `cold-ipm` | 2492 | +102.8% | 2492 | +102.8% |
+| `warm-ipm` | 1229 | — | 1229 | — |
+| `pred-ipm` | 1258 | **+2.4%** | 1257 | **+2.3%** |
+| `predcorr-ipm` | 1242 | **+1.1%** | 1215 | **−1.1%** |
 
-Warm starting is worth 2.15×. The tangent predictor on top of it is
-noise, and at the largest step scale `pred-ipm` is reliably *worse*
-(+18% at horizon 80) because it extrapolates across critical-region
-boundaries the corrector then has to undo.
+Warm starting is worth 2.03×. The tangent predictor on top of it is
+noise — within ±3% either way — and at the largest step scale `pred-ipm`
+is reliably *worse* (+17.5% at horizon 80) because it extrapolates
+across critical-region boundaries the corrector then has to undo.
+
+**`warm_start_recentering` does not move this verdict, and it is worth
+saying why.** The `cold-ipm`, `warm-ipm` and `pred-ipm` columns are
+*bit-identical* between the two settings: over 240 steps each, zero
+steps change iteration count. Only `predcorr-ipm` moves, on 14 of 240
+steps. That is the mechanism, not a coincidence — recentering measures
+the supplied iterate and adapts to how far off-centre it is, and
+`predcorr-ipm` is the only arm that supplies a *perturbed* multiplier
+seed (the previous solution stepped along the tangent). The other arms
+hand over either a cold point or an exactly-converged one, and on these
+single-block, zero-inequality-row models there is nothing for the
+measurement to change.
+
+The consequence for reading the table: the `−1.1%` at `recentering=none`
+is not the predictor being better there. It is the same predictor with
+its off-centre dual seed left alone, landing better on 14 steps and
+worse on others, against an *identical* 1229-iteration baseline. Since
+the baseline does not move between settings, the failure mode of "the
+predictor looks better because the warm baseline was raised under it"
+does not arise here — it could not, because nothing raised it.
+
+The baseline *did* move against the previous measurement on `70bf53de`
+(warm 1097 → 1229, cold 2360 → 2492). Because `recentering=none` is by
+definition pre-pounce#606 behaviour and reproduces 1229 exactly,
+pounce#606/#620 contributes **none** of that move; it comes from the
+other merges in between (pounce#605/#619, #602/#614, #607/#623).
 
 ### Why — the one-iteration floor
 
@@ -218,20 +248,206 @@ are obtained: the AD frontend gets them from `jax.grad` / `jax.jacobian`
 and `jvp_from_state`, this one from the problem's own callbacks and
 `Solver.parametric_step`.
 
-`PathFollower` additionally offers pseudo-arclength continuation past
-folds (`trace_arclength`). That is **not** exposed here — see below.
+Both frontends now offer pseudo-arclength continuation past folds;
+`Continuation.trace_arclength` is described above.
+
+## Subdividing a prescribed path
+
+`run` traces the points you asked for. When a corrector rejects between
+two of them, it does not have to give up or record the runaway iterate
+as an answer: it halves the gap and re-predicts from the last point
+known good, and repeats. Inserted points carry `prescribed=False` and
+are counted by `trace.n_inserted`; every prescribed point still appears,
+in order.
+
+```python
+trace = drv.run(thetas, subdivide=True, max_subdivisions=10)
+print(trace.n_inserted, trace.n_rejections)
+```
+
+This is on by default and is a **no-op on a healthy path** — the step
+count and the per-step iteration counts are unchanged when nothing goes
+wrong. `subdivide=False` restores the one-solve-per-point behaviour
+exactly.
+
+Monitor-driven subdivision is opt-in and separate, via `subdivide_tol`:
+with a `monitor` supplied, a predicted point whose KKT residual exceeds
+it is not even attempted, and the gap is halved first. It is a *separate*
+knob from `monitor_tol` on purpose — `monitor_tol` is `follow`'s
+accept-without-solving threshold, typically `1e-6`, which as a
+subdivision trigger would subdivide on essentially every step.
+
+`max_subdivisions` caps halvings, not inserted points; once the budget
+is spent the driver attempts the prescribed point directly rather than
+abandoning it.
+
+## Past a fold: `trace_arclength`
+
+`run` and `follow` both march in `θ`, so both stop dead at a turning
+point — past a fold there is no solution at the next `θ` for the
+corrector to find. `trace_arclength` parametrises the solution curve of
+
+```
+R(x, λ, θ) = [ ∇f(x) + A(x)ᵀλ ; g(x) − c(θ) ] = 0
+```
+
+by its own arclength instead, so `θ` is free to stop and reverse.
+
+```python
+trace = drv.trace_arclength(x0, theta0, callbacks=obj,
+                            ds=0.25, n_steps=40, direction=-1.0)
+```
+
+**Why not the held factor.** `Solver.parametric_step` back-solves
+against the factor of a *converged* solve. A fold has none: `∂x*/∂θ` is
+singular there — that is what "fold" means — and past it there is no
+solution at that `θ` for any factor to belong to. So the tangent is
+taken instead as the null vector of the `(d, d+1)` augmented matrix
+`[∂R/∂z | ∂R/∂θ]`, obtained by **bordering** it with the previous
+tangent and solving
+
+```
+[ ∂R/∂z   ∂R/∂θ ] [ t ]   [ 0 ]
+[     t_prevᵀ   ]       = [ 1 ]
+```
+
+which is nonsingular *at* a simple fold — that is the point of the
+pseudo-arclength formulation — and needs no SVD, unlike `PathFollower`'s
+dense route. `R` and its Jacobian are assembled sparsely from the
+problem's own cyipopt-shaped callbacks; the Hessian of the Lagrangian is
+exactly `∂/∂x` of the stationarity block, so nothing is approximated and
+no third derivative appears.
+
+**The cost.** One sparse LU per Newton iteration, where parameter
+continuation gets a back-solve against a factor the solver already
+built. That is the honest price of going round the corner at all: there
+is no factor to reuse there. On the test fixture the whole 40-point
+traverse takes single-digit milliseconds; on a large model the LU is the
+dominant cost and this mode is correspondingly more expensive per point
+than `run`.
+
+**Measured.** On `min x₀³/3 + x₁²/2  s.t.  x₀ + x₁ = θ`, whose solution
+curve `x₀ + x₀² = θ` folds at `x₀ = −1/2, θ = −1/4`:
+
+| | result |
+|---|---|
+| `run`, marching θ from 2.0 to −0.4 | fails at θ = −0.4 with `Diverging_Iterates`, \|x₀\| > 10¹⁰ |
+| `run` with `subdivide=True` | walks in to θ = −0.250, x₀ = −0.49995 — locating the fold to 1.2×10⁻³ — then reports `subdivision_exhausted` |
+| `trace_arclength`, same start | turns at θ ≈ −0.25 and continues onto the branch with x₀ < −1/2, every point a root of `R` to < 10⁻⁷ |
+
+**Scope (v1)** — deliberately `PathFollower`'s: scalar `θ`, equality /
+unconstrained families, fixed active set along the traced branch.
+Two-sided inequality rows are rejected with an error rather than
+mis-traced; a branch that runs into a variable bound ends the trace with
+`status="bound_active"` rather than reporting a wrong curve. Bifurcation
+and branch switching are out of scope.
+
+The fixture is built so LICQ holds at the fold and `λ` stays finite
+there. A fold resting on a vanishing constraint gradient sends `λ` to
+infinity, and no arclength scheme in `(x, λ, θ)` passes that — such a
+fixture would flatter the method rather than test it.
+
+## The CLI: a path manifest
+
+`pounce-continue` traces a whole parametric path from one command:
+
+```
+pounce-continue path.json --out trace.json
+pounce-continue path.json --cold          # the baseline it is measured against
+```
+
+The manifest names the models the modeling system already emitted, one
+per parameter value:
+
+```json
+{
+  "version": 1,
+  "points": [
+    {"model": "mpc_000.nl", "theta": [1.5, 0.0]},
+    {"model": "mpc_001.nl", "theta": [1.45, 0.03]}
+  ],
+  "options": {"tol": "1e-8"},
+  "warm": true
+}
+```
+
+**There is no tangent predictor here, and there cannot be.** The
+predictor is a back-solve against the KKT factor the previous solve left
+in memory, and that factor does not survive `exec`. A CLI path is a
+sequence of separate processes, so the transfer is zero-order. The trace
+says so in its `predictor` field rather than leaving it to be inferred.
+
+What *does* cross the boundary is more than the primal point. An AMPL
+`.nl` file carries an initial primal point (the `x` segment) *and*
+initial duals (the `d` segment), and pounce's reader honours both, so
+the driver folds the previous point's answer into the next model and
+turns on `warm_start_init_point`. The bound multipliers and the barrier
+parameter have nowhere to go in the `.nl` format, and that is the gap
+against the in-process driver.
+
+**Measured**, on a 20-point van der Pol NMPC path (horizon 40, n = 122):
+
+| | iterations | evaluations | wall |
+|---|---|---|---|
+| repeated cold `pounce model.nl` | 226 | 1230 | 233 ms |
+| `pounce-continue` (warm transfer) | 193 | 1166 | 221 ms |
+| | **−14.6%** | **−5.2%** | **−5%** |
+
+Iteration counts are exactly reproducible run to run; the wall-clock
+figure is the mean of three and the spread overlaps. The gap between
+−14.6% of iterations and −5% of wall clock is process startup, `.nl`
+parse and presolve, which at these sizes dominate the solve — repeating
+at horizon 300 (n = 902) moves the iteration saving not at all
+(225 → 193) and the wall time not at all. **If you are paying per
+process, that overhead is what you are paying, and the warm transfer
+does not address it.** The in-process driver is the answer there.
+
+One thing worth knowing: a linear-quadratic MPC is a convex QP, and the
+CLI routes convex QPs to `pounce-convex`, which never reaches the NLP
+warm-start path at all. The measurement above uses van der Pol dynamics
+for that reason; a linear-quadratic path shows exactly 0% because the
+warm-start options are not consulted.
+
+## GAMS
+
+`pounce.gams.continuation.trace` drives a GAMS path through the same
+driver. The pip link builds an ordinary `pounce.Problem` from a GMO
+view, so when the points are driven from one Python process the whole
+driver applies — **including** the tangent predictor, unlike the CLI
+path:
+
+```python
+from pounce.gams import continuation as gams_cont
+trace = gams_cont.trace(view_of_theta, thetas, pins=[0, 1],
+                        options={"tol": 1e-8})
+```
+
+Driving it the other way — `option nlp = pounce;` inside a GAMS loop —
+is one link invocation per solve, GAMS owns the process, and the same
+process-boundary limit as the CLI applies.
+
+**The native C link's state file does not help here**, and it is worth
+being precise about why. `gams/gams_pounce.c`'s `sqp_state_file` holds
+the *discrete working set only*: one byte of `bound_status` per variable
+and one of `cons_status` per constraint, behind a magic string and a
+checksum over `(n, m, bounds)`. No primal point, no multipliers, no
+barrier parameter — it feeds `IpoptSetWarmStartWorkingSet` on the
+active-set SQP path. For interior-point continuation that is strictly
+less than the pip link already holds in memory. And the checksum is
+taken over the bounds, so any change of problem *shape* — a horizon
+shift, a remesh — invalidates it, which is precisely the case the
+transfer map exists to serve.
 
 ## Not implemented
 
-* **Pseudo-arclength continuation** past turning points. `PathFollower`'s
-  version is written directly against `jax.jacobian` of the stationarity
-  system and an SVD of it; the generic frontend has no equivalent of that
-  dense `(d, d+1)` Jacobian, and manufacturing one from `Solver.kkt_solve`
-  is a separate piece of work rather than an adaptation. pounce#608 marks
-  it optional; use `pounce.jax.PathFollower.trace_arclength` if you need
-  it.
-* **CLI and GAMS adapters.** pounce#608 sequences these after the
-  `Problem` and Pyomo ones. Both need a path manifest / repeated-solve
-  protocol that does not exist yet, and neither can hold a KKT factor
-  across process boundaries, so both would run the zero-order fallback
-  only — which is what `--warm-start` already does.
+* **Bifurcation detection and branch switching.** `trace_arclength`
+  follows the branch it starts on. At a bifurcation (as opposed to a
+  simple fold) the bordered system is singular and the trace stops
+  rather than picking a branch.
+* **Folds with a moving active set.** The arclength residual `R` treats
+  every general row as an active equality, so a branch whose active set
+  changes as it turns is out of scope, and two-sided inequality rows are
+  rejected rather than mis-traced.
+* **Vector-parameter arclength.** "Past the fold" is not defined for a
+  solution manifold of dimension > 1; reparametrise onto a scalar path
+  and trace that.

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -24,6 +24,10 @@ Initialization helpers (see the POUNCE docs' initialization chapter):
     #     plan a valid specification: which candidates to hold as the
     #     decisions, which to prune, and what gets pinned automatically
 
+Predictor--corrector continuation over a parameter path (pounce#608):
+    trace = pyomo_pounce.continuation(m, [m.p], path)   # repeated NLPs
+    pyomo_pounce.shift_map(m, [m.x])                    # horizon-shift transfer
+
 Parametric sensitivity (see pyomo_pounce.sens):
     declare_sens_param(m.p)      # flag parameters when building the model
     SolverFactory('pounce').solve(m)   # normal solve keeps the KKT factor
@@ -40,6 +44,7 @@ from pyomo_pounce.block_init import (
     block_repair_plan,
     structural_incidence,
 )
+from pyomo_pounce.continuation import continuation, shift_map
 from pyomo_pounce.pounce_solver import POUNCE, check_binary
 from pyomo_pounce.sens import (
     Covariance,
@@ -108,6 +113,8 @@ __all__ = [
     "gradient",
     "estimate",
     "estimate_report",
+    "continuation",
+    "shift_map",
     "EstimateReport",
     "Gradient",
     "preflight",

--- a/pyomo-pounce/pyomo_pounce/continuation.py
+++ b/pyomo-pounce/pyomo_pounce/continuation.py
@@ -1,0 +1,313 @@
+"""Predictor--corrector continuation over a Pyomo model (pounce#608).
+
+The Pyomo adapter for :class:`pounce.Continuation`. Everything the
+driver needs already exists on this side; this module is the wiring, not
+a second implementation:
+
+* the **model update** is writing the declared mutable ``Param``s;
+* the **tangent predictor** is :func:`pyomo_pounce.estimate`, which is
+  the sIPOPT parametric step against the retained KKT factor
+  (:func:`pyomo_pounce.retain_kkt`);
+* the **warm transfer** is the solved model's own ``Var`` values plus
+  the ``dual`` / ``ipopt_zL_in`` / ``ipopt_zU_in`` suffixes, which the
+  solver plugin already reads under ``warm_start_init_point=yes``;
+* the **corrector** is an ordinary ``SolverFactory("pounce").solve``.
+
+Usage -- an MPC horizon shift, the case pounce#608 names::
+
+    import pyomo.environ as pyo
+    from pyomo_pounce import declare_sens_param, continuation
+
+    m.x0 = pyo.Param([0, 1], initialize=0.0, mutable=True)
+    declare_sens_param(m.x0)
+
+    trace = continuation(
+        m, [m.x0],
+        [{m.x0: measured_state(k)} for k in range(20)],
+        transfer=shift_horizon,          # see `shift_map` below
+    )
+    print(trace.report())
+
+Read ``docs/src/continuation.md`` first. On an interior-point method a
+warm-started solve along a continuation path already converges in about
+one iteration, so the tangent predictor has almost no iterations left to
+remove; measured on pounce's own warm-start corpus it is a wash against
+a plain previous-solution warm start. What continuation buys on this
+frontend is the orchestration -- transfer, seeding, event detection, and
+the counters -- not a speedup.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Dict, List, Optional, Sequence
+
+import numpy as np
+import pyomo.environ as pyo
+
+from pounce import ContinuationStep, ContinuationTrace, StepController
+
+from pyomo_pounce.sens import (
+    declare_sens_param,
+    estimate,
+    release_kkt,
+    retain_kkt,
+)
+
+__all__ = ["continuation", "shift_map"]
+
+_OK = ("optimal", "locallyOptimal", "feasible")
+
+
+def _param_data(param):
+    """Every ``_ParamData`` under a scalar or indexed ``Param``."""
+    try:
+        return [param[i] for i in param]
+    except TypeError:
+        return [param]
+
+
+def _assign(param, value):
+    """Write `value` (scalar or per-index mapping/sequence) into `param`."""
+    data = _param_data(param)
+    if np.isscalar(value):
+        for d in data:
+            d.value = float(value)
+        return
+    if isinstance(value, dict):
+        for key, val in value.items():
+            param[key].value = float(val)
+        return
+    vals = np.asarray(value, float).ravel()
+    if vals.size != len(data):
+        raise ValueError(
+            f"continuation: {param.name} has {len(data)} entries but the path "
+            f"supplied {vals.size} values for this step"
+        )
+    for d, v in zip(data, vals):
+        d.value = float(v)
+
+
+def _flatten(params, point) -> np.ndarray:
+    """The step's parameter values as one vector, for the trace record."""
+    out: List[float] = []
+    for p in params:
+        val = point[p] if p in point else [d.value for d in _param_data(p)]
+        if np.isscalar(val):
+            out.append(float(val))
+        elif isinstance(val, dict):
+            out.extend(float(val[k]) for k in sorted(val, key=str))
+        else:
+            out.extend(float(v) for v in np.asarray(val, float).ravel())
+    return np.asarray(out, float)
+
+
+def shift_map(model, blocks, *, shift=1, fill="last"):
+    """A ready-made horizon-shift transfer for a receding-horizon model.
+
+    Returns a callable suitable as `continuation`'s `transfer`: it moves
+    each indexed ``Var`` in `blocks` back by `shift` stages, so stage
+    ``k`` of the next solve starts from stage ``k + shift`` of the last
+    one -- the prolongation an MPC controller does by hand.
+
+    `fill` says what the `shift` freed stages at the end get: ``"last"``
+    repeats the final stage (a steady-state tail, the usual choice), or
+    pass a float for a constant.
+
+    Args:
+        model: The Pyomo model.
+        blocks: Indexed ``Var`` components whose leading index is the
+            stage.
+        shift: Stages to advance per step.
+        fill: ``"last"`` or a float.
+    """
+    def transfer():
+        for var in blocks:
+            keys = sorted(var, key=lambda k: (k if isinstance(k, tuple) else (k,)))
+            vals = [pyo.value(var[k], exception=False) for k in keys]
+            if any(v is None for v in vals):
+                continue
+            n = len(keys)
+            tail = vals[-1] if fill == "last" else float(fill)
+            moved = [vals[min(i + shift, n - 1)] if fill == "last"
+                     else (vals[i + shift] if i + shift < n else tail)
+                     for i in range(n)]
+            for k, v in zip(keys, moved):
+                var[k].value = float(v)
+    return transfer
+
+
+def continuation(
+    model,
+    params: Sequence,
+    path: Sequence[Dict],
+    *,
+    transfer: Optional[Callable] = None,
+    predictor: str = "tangent",
+    solver: str = "pounce",
+    options: Optional[dict] = None,
+    controller: Optional[StepController] = None,
+    tee: bool = False,
+) -> ContinuationTrace:
+    """Trace a Pyomo model over a prescribed parameter path.
+
+    Args:
+        model: The Pyomo model. Its `params` must already be declared
+            with :func:`pyomo_pounce.declare_sens_param` when
+            ``predictor="tangent"``; this function declares any that are
+            not, so the common case needs no extra call.
+        params: The mutable ``Param`` components carrying the parameter.
+        path: One entry per point: a ``{param: value}`` mapping, where
+            `value` is a scalar, a ``{index: value}`` dict, or a sequence
+            in the component's index order.
+        transfer: Optional zero-argument callable run **after** the
+            predictor writes its values and **before** the next solve.
+            Use it for a horizon shift or a remesh -- anything that moves
+            state between differently-shaped stages. :func:`shift_map`
+            builds the receding-horizon one.
+        predictor: ``"tangent"`` for the sIPOPT parametric step against
+            the retained factor, or ``"zero"`` for the plain
+            previous-solution transfer (the documented fallback for a
+            model with no declared parameters).
+        solver: Solver name for ``SolverFactory``.
+        options: Extra solver options. ``warm_start_init_point`` is set
+            to ``yes`` from the second point on unless overridden.
+        controller: Unused for a prescribed path; accepted so the
+            signature matches the generic driver's.
+        tee: Stream solver output.
+
+    Returns:
+        :class:`pounce.ContinuationTrace` -- the same record type the
+        generic driver returns, so a Pyomo trace and a ``Problem`` trace
+        are read the same way.
+    """
+    if predictor not in ("tangent", "zero"):
+        raise ValueError(
+            f"continuation: predictor must be 'tangent' or 'zero', "
+            f"got {predictor!r}"
+        )
+    params = list(params)
+    if predictor == "tangent":
+        if not params:
+            raise ValueError(
+                "continuation: predictor='tangent' needs at least one "
+                "declared Param; pass predictor='zero' for a model without "
+                "parameter sensitivities"
+            )
+        declare_sens_param(*params)
+        retain_kkt(model)
+
+    opts = dict(options or {})
+    trace = ContinuationTrace()
+    prev_active = None
+    prev_point = None
+
+    try:
+        for k, point in enumerate(path):
+            kind = "cold"
+            if k > 0:
+                kind = "zero"
+                if predictor == "tangent":
+                    # PREDICT: the sIPOPT parametric step against the
+                    # factor the previous solve retained. `estimate`
+                    # measures the perturbation from the *solve* point,
+                    # so it is correct to call it before writing the new
+                    # parameter values.
+                    perturb = []
+                    for p in params:
+                        if p not in point:
+                            continue
+                        val = point[p]
+                        for d in _param_data(p):
+                            perturb.append((d, _value_for(p, d, val)))
+                    try:
+                        predicted = estimate(model, perturb)
+                    except Exception:
+                        predicted = None
+                    if predicted is not None:
+                        for vd, val in predicted.items():
+                            if not vd.fixed:
+                                vd.value = float(val)
+                        kind = "tangent"
+                if transfer is not None:
+                    transfer()
+                    kind = "transfer" if kind == "zero" else kind
+                opts.setdefault("warm_start_init_point", "yes")
+
+            for p in params:
+                if p in point:
+                    _assign(p, point[p])
+
+            t0 = time.perf_counter()
+            results = pyo.SolverFactory(solver).solve(
+                model, tee=tee, options=opts, load_solutions=True
+            )
+            elapsed = time.perf_counter() - t0
+
+            tc = str(results.solver.termination_condition)
+            step = ContinuationStep(
+                index=k, s=float(k), theta=_flatten(params, point),
+                predictor=kind, corrected=True, solve_time=elapsed,
+                status=0 if tc in _OK else -1, status_msg=tc,
+                iters=int(getattr(results.solver, "statistics", {})
+                          .get("iterations", -1))
+                if isinstance(getattr(results.solver, "statistics", None), dict)
+                else -1,
+                obj=float(pyo.value(next(model.component_data_objects(
+                    pyo.Objective, active=True)))),
+            )
+
+            active = _bound_activity(model)
+            step.active_set_event = (
+                prev_active is not None and active is not None
+                and bool(np.any(active != prev_active))
+            )
+            prev_active = active
+            trace.steps.append(step)
+            trace.x.append(_primal_vector(model))
+
+            if tc not in _OK:
+                trace.status = f"solve_failed at step {k}: {tc}"
+                break
+            prev_point = point
+    finally:
+        if predictor == "tangent":
+            release_kkt(model)
+
+    del prev_point
+    return trace
+
+
+def _value_for(param, data, val):
+    if np.isscalar(val):
+        return float(val)
+    if isinstance(val, dict):
+        return float(val[data.index()])
+    idx = list(param)
+    return float(np.asarray(val, float).ravel()[idx.index(data.index())])
+
+
+def _primal_vector(model) -> np.ndarray:
+    return np.asarray(
+        [pyo.value(v, exception=False) or 0.0
+         for v in model.component_data_objects(pyo.Var, active=True)],
+        dtype=float,
+    )
+
+
+def _bound_activity(model, tol=1e-6):
+    """Boolean at-a-bound fingerprint over the model's Vars.
+
+    The Pyomo-side counterpart of the driver's multiplier fingerprint:
+    the plugin does not hand bound multipliers back on every path, so
+    activity is read off the primal's distance to its bounds instead.
+    """
+    flags = []
+    for v in model.component_data_objects(pyo.Var, active=True):
+        x = pyo.value(v, exception=False)
+        if x is None:
+            return None
+        lo, hi = v.lb, v.ub
+        flags.append(lo is not None and abs(x - lo) <= tol)
+        flags.append(hi is not None and abs(x - hi) <= tol)
+    return np.asarray(flags, dtype=bool) if flags else None

--- a/pyomo-pounce/tests/test_continuation.py
+++ b/pyomo-pounce/tests/test_continuation.py
@@ -1,0 +1,179 @@
+"""Pyomo adapter for predictor--corrector continuation (pounce#608).
+
+Acceptance criterion 2: "A Pyomo MPC/horizon-shift example supplies a
+transfer map and reuses primal/dual/barrier state."
+"""
+
+import numpy as np
+import pytest
+
+pyo = pytest.importorskip("pyomo.environ")
+
+import pyomo_pounce  # noqa: E402
+from pyomo_pounce import continuation, shift_map  # noqa: E402
+
+
+NH = 8
+H = 0.2
+A, B = 1.0, 0.1
+U_MAX = 0.5
+
+
+def mpc_model():
+    """Linear-quadratic MPC of a damped oscillator over a fixed horizon.
+
+    The initial state is a declared mutable Param, so a step of the
+    parameter path is a step of the pin-equality right-hand side -- the
+    sIPOPT convention the tangent predictor needs.
+    """
+    m = pyo.ConcreteModel()
+    m.K = pyo.RangeSet(0, NH)
+    m.KU = pyo.RangeSet(0, NH - 1)
+    m.D = pyo.RangeSet(0, 1)
+
+    m.x0 = pyo.Param(m.D, initialize=lambda _m, i: (1.0, 0.0)[i], mutable=True)
+    m.x = pyo.Var(m.K, m.D, initialize=0.0, bounds=(-10.0, 10.0))
+    m.u = pyo.Var(m.KU, initialize=0.0, bounds=(-U_MAX, U_MAX))
+
+    m.init = pyo.Constraint(m.D, rule=lambda _m, i: _m.x[0, i] == _m.x0[i])
+
+    def dyn(_m, k, i):
+        if i == 0:
+            return _m.x[k + 1, 0] == _m.x[k, 0] + H * _m.x[k, 1]
+        return _m.x[k + 1, 1] == _m.x[k, 1] + H * (
+            -A * _m.x[k, 0] - B * _m.x[k, 1] + _m.u[k])
+
+    m.dyn = pyo.Constraint(m.KU, m.D, rule=dyn)
+
+    m.obj = pyo.Objective(
+        expr=sum(m.x[k, 0] ** 2 + 0.1 * m.x[k, 1] ** 2 for k in m.K)
+        + 0.05 * sum(m.u[k] ** 2 for k in m.KU)
+    )
+    return m
+
+
+def circle_path(n=6, radius=1.2, dphi=0.25):
+    """The parameter walks a circle in state space, so every point is
+    about as hard as the last."""
+    return [
+        {"x0": {0: radius * np.cos(dphi * k), 1: radius * np.sin(dphi * k)}}
+        for k in range(n)
+    ]
+
+
+def _path_for(m, n=6):
+    return [{m.x0: p["x0"]} for p in circle_path(n)]
+
+
+def _solve_cold(m, point):
+    for idx, val in point[m.x0].items():
+        m.x0[idx].value = float(val)
+    for v in m.component_data_objects(pyo.Var, active=True):
+        v.value = 0.0
+    res = pyo.SolverFactory("pounce").solve(m)
+    return str(res.solver.termination_condition), pyo.value(m.obj)
+
+
+pytestmark = pytest.mark.usefixtures()
+
+
+@pytest.fixture(scope="module")
+def have_solver():
+    try:
+        pyomo_pounce.check_binary()
+    except Exception as exc:                       # pragma: no cover
+        pytest.skip(f"pounce solver unavailable: {exc}")
+
+
+def test_continuation_traces_a_pyomo_parameter_path(have_solver):
+    m = mpc_model()
+    pyomo_pounce.declare_sens_param(m.x0)
+    path = _path_for(m)
+
+    trace = continuation(m, [m.x0], path)
+
+    assert trace.status == "ok"
+    assert trace.n_steps == len(path)
+    assert trace.n_corrections == len(path)
+    assert trace.total_evals >= 0
+    assert "active-set events" in trace.report()
+
+
+def test_tangent_predictor_is_recorded_after_the_anchor(have_solver):
+    m = mpc_model()
+    pyomo_pounce.declare_sens_param(m.x0)
+    trace = continuation(m, [m.x0], _path_for(m))
+    kinds = [st.predictor for st in trace.steps]
+    assert kinds[0] == "cold"
+    assert "tangent" in kinds[1:]
+
+
+def test_zero_order_fallback_is_supported(have_solver):
+    """pounce#608's documented degraded mode: no sensitivities, plain
+    previous-solution transfer, same trace type."""
+    m = mpc_model()
+    trace = continuation(m, [m.x0], _path_for(m), predictor="zero")
+    assert trace.status == "ok"
+    assert [st.predictor for st in trace.steps][1:] == ["zero"] * 5
+
+
+def test_continuation_matches_independent_cold_solves(have_solver):
+    """The traced objective at every point must equal what a cold solve
+    at that parameter finds -- a warm start may not change the answer."""
+    m = mpc_model()
+    pyomo_pounce.declare_sens_param(m.x0)
+    path = _path_for(m)
+    trace = continuation(m, [m.x0], path)
+
+    ref = mpc_model()
+    for k, point in enumerate(path):
+        tc, obj = _solve_cold(ref, {ref.x0: point[m.x0]})
+        assert tc in ("optimal", "locallyOptimal", "feasible")
+        assert trace.steps[k].obj == pytest.approx(obj, rel=1e-6, abs=1e-8)
+
+
+def test_horizon_shift_transfer_map_is_applied(have_solver):
+    """Acceptance criterion 2: a transfer map for the horizon shift."""
+    m = mpc_model()
+    pyomo_pounce.declare_sens_param(m.x0)
+    shift = shift_map(m, [m.x, m.u], shift=1)
+
+    calls = []
+
+    def transfer():
+        calls.append(True)
+        shift()
+
+    trace = continuation(m, [m.x0], _path_for(m), transfer=transfer)
+    assert trace.status == "ok"
+    assert len(calls) == trace.n_steps - 1      # not on the anchor
+
+
+def test_shift_map_moves_stages_back_by_one():
+    m = mpc_model()
+    for k in m.KU:
+        m.u[k].value = float(k)
+    shift_map(m, [m.u], shift=1)()
+    assert [m.u[k].value for k in m.KU] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0,
+                                            7.0, 7.0]
+
+
+def test_shift_map_constant_fill():
+    m = mpc_model()
+    for k in m.KU:
+        m.u[k].value = float(k)
+    shift_map(m, [m.u], shift=2, fill=-1.0)()
+    assert [m.u[k].value for k in m.KU] == [2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
+                                            -1.0, -1.0]
+
+
+def test_predictor_must_be_a_known_mode():
+    m = mpc_model()
+    with pytest.raises(ValueError, match="tangent.*zero"):
+        continuation(m, [m.x0], _path_for(m), predictor="quadratic")
+
+
+def test_tangent_without_declared_params_is_refused():
+    m = mpc_model()
+    with pytest.raises(ValueError, match="at least one"):
+        continuation(m, [], _path_for(m), predictor="tangent")

--- a/python/pounce/__init__.py
+++ b/python/pounce/__init__.py
@@ -28,6 +28,13 @@ from ._warm_start import (
     WarmStartCompatibilityWarning,
     WarmStartLegacyWarning,
 )
+from ._continuation import (
+    Continuation,
+    ContinuationStep,
+    ContinuationTrace,
+    StepController,
+    kkt_residual_monitor,
+)
 from ._minimize import minimize, OptimizeResult
 from ._nlp_batch import solve_nlp_batch
 from ._curve_fit import (
@@ -105,6 +112,13 @@ __all__ = [
     "WarmStartCompatibilityError",
     "WarmStartCompatibilityWarning",
     "WarmStartLegacyWarning",
+    # Predictor--corrector continuation over a repeated-NLP sequence
+    # (see docs: continuation.md)
+    "Continuation",
+    "ContinuationStep",
+    "ContinuationTrace",
+    "StepController",
+    "kkt_residual_monitor",
     "generate_starts",
     "project_to_feasible",
     "ProjectionReport",

--- a/python/pounce/_continuation.py
+++ b/python/pounce/_continuation.py
@@ -916,7 +916,7 @@ class Continuation:
             array, ``kkt_error`` is ``‖R‖∞`` at the accepted point, and
             ``iters`` is the corrector's Newton count.
         """
-        from scipy.sparse import csc_matrix, hstack, vstack
+        from scipy.sparse import csc_matrix, vstack
         from scipy.sparse.linalg import spsolve
 
         x = np.asarray(x0, float).ravel()

--- a/python/pounce/_continuation.py
+++ b/python/pounce/_continuation.py
@@ -1,0 +1,781 @@
+"""Frontend-neutral predictor--corrector continuation over repeated NLPs
+(pounce#608).
+
+pounce#90 delivered a predictor--corrector path follower, but only for
+the differentiable frontend: :class:`pounce.jax.PathFollower` is written
+against ``JaxProblem`` and reaches for ``jax.grad`` / ``jax.jacobian``
+and the AD-side ``jvp_from_state`` / ``warm_anchor`` primitives. Nothing
+about the *algorithm* needs autodiff — the tangent predictor is a
+back-solve against the held KKT factor, which the generic frontend
+already exposes as :meth:`pounce.Solver.parametric_step` — so this
+module is the same loop driven through the public ``Problem`` /
+``Solver`` API instead.
+
+The two drivers share their step-size policy verbatim: both use
+:class:`StepController` below, so "how far to step next" has exactly one
+implementation in the tree.
+
+What it does per step
+---------------------
+
+1. **predict** — extrapolate the previous iterate to the new parameter.
+   With `pins` declared the predictor is the tangent
+   ``Δx ≈ ∂x*/∂θ · Δθ`` read off the previous solve's held factor
+   (:meth:`pounce.Solver.parametric_step`; the multipliers come from
+   :meth:`~pounce.Solver.parametric_step_full`). Without them it falls
+   back to a zero-order transfer — the previous iterate carried over
+   unchanged.
+2. **transfer** — when the problem's *shape* changes between steps (a
+   horizon shift, a remesh), an explicit user map moves the state onto
+   the new layout. The mapper protocol is
+   :meth:`pounce.WarmStart.transfer`'s: ``mapper(ctx) -> dict`` of
+   replacement arrays.
+3. **monitor** — the KKT residual of the predicted point, evaluated
+   through the problem's own callbacks. No solve.
+4. **correct** — a warm-started re-solve seeded with the predicted
+   primal, duals, and the previous barrier ``μ``.
+5. **adapt** — :class:`StepController` grows or shrinks the step from
+   the corrector's iteration count, and re-anchors on an active-set
+   event.
+
+Read the docs page (``docs/src/continuation.md``) before reaching for
+this on an interior-point problem: measured on pounce's own warm-start
+corpus, a warm-started IPM solve along a continuation path already
+converges in **one iteration per step**, so a tangent predictor has no
+iterations left to remove. Continuation pays here by *skipping solves*
+(:meth:`Continuation.follow`), not by making them cheaper
+(:meth:`Continuation.run`).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import time
+from typing import Callable, List, Optional, Sequence
+
+import numpy as np
+
+from ._warm_start import WarmStart
+
+__all__ = [
+    "Continuation",
+    "ContinuationStep",
+    "ContinuationTrace",
+    "StepController",
+    "kkt_residual_monitor",
+]
+
+#: Solve statuses that count as a converged step.
+_OK_STATUS = (0, 1)
+
+#: Multiplier magnitude above which a bound counts as active, for the
+#: active-set fingerprint. Matches ``pounce.jax._ad_common.ACTIVE_TOL``.
+ACTIVE_TOL = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# Step-size policy — shared with pounce.jax.PathFollower (pounce#90).
+# ---------------------------------------------------------------------------
+
+
+class StepController:
+    """Adaptive continuation step size.
+
+    Extracted from :meth:`pounce.jax.PathFollower.follow` (pounce#90) so
+    the AD and non-AD drivers cannot drift apart. Pure arithmetic — it
+    holds no problem state and imports nothing.
+
+    The policy: grow after a step accepted on the predictor alone or
+    corrected cheaply (``iters <= easy``), shrink after an expensive
+    correction (``iters >= hard``) or a rejected one, and drop back to
+    ``ds0`` after an active-set event so the region boundary is resolved
+    finely rather than jumped over.
+    """
+
+    def __init__(
+        self,
+        *,
+        ds0: float = 0.05,
+        ds_min: float = 1e-4,
+        ds_max: float = 0.25,
+        grow: float = 1.5,
+        shrink: float = 0.5,
+        easy: int = 3,
+        hard: int = 10,
+    ):
+        self.ds0 = float(ds0)
+        self.ds_min = float(ds_min)
+        self.ds_max = float(ds_max)
+        self.grow = float(grow)
+        self.shrink = float(shrink)
+        self.easy = int(easy)
+        self.hard = int(hard)
+        self.ds = float(ds0)
+
+    def accepted(self) -> float:
+        """Step taken on the predictor alone — no solve. Grow."""
+        self.ds = min(self.ds * self.grow, self.ds_max)
+        return self.ds
+
+    def corrected(self, iters: int, active_set_event: bool = False) -> float:
+        """Step corrected by a solve that converged."""
+        if active_set_event:
+            self.ds = min(self.ds0, max(self.ds * self.shrink, self.ds_min))
+        elif iters <= self.easy:
+            self.ds = min(self.ds * self.grow, self.ds_max)
+        elif iters >= self.hard:
+            self.ds = max(self.ds * self.shrink, self.ds_min)
+        return self.ds
+
+    def rejected(self) -> Optional[float]:
+        """Corrector failed. Returns the shorter step to retry with, or
+        ``None`` when the step floor is reached and the trace must stop."""
+        self.ds *= self.shrink
+        if self.ds < self.ds_min:
+            return None
+        return self.ds
+
+
+# ---------------------------------------------------------------------------
+# Transfer (prolongation)
+# ---------------------------------------------------------------------------
+
+
+def _apply_transfer(ws: WarmStart, problem, mapper) -> WarmStart:
+    """Map `ws` onto `problem` through `mapper`.
+
+    Delegates to :meth:`pounce.WarmStart.transfer` (#607), which owns the
+    length checks, the signing, and the ``replay="mapped"`` bookkeeping.
+    The mapper is handed a :class:`pounce.TransferContext` and returns a
+    dict of replacement arrays.
+    """
+    return ws.transfer(problem, mapper)
+
+
+# ---------------------------------------------------------------------------
+# Records
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class ContinuationStep:
+    """One point of a continuation trace.
+
+    Attributes:
+        index: Position in the trace.
+        s: Path parameter (``follow``) or step index (``run``).
+        theta: Parameter value at this point.
+        predictor: How the seed was built — ``"cold"`` (the anchor),
+            ``"zero"`` (previous iterate carried over), ``"tangent"``
+            (held-factor sensitivity step), or ``"transfer"`` (a user
+            prolongation map was applied on top).
+        predictor_residual: Max-norm KKT residual at the predicted
+            point, before any correction. ``None`` when no monitor ran.
+        corrected: Whether a solve ran at this point.
+        rejections: Corrector failures absorbed before this point was
+            accepted.
+        active_set_event: Whether the active-set fingerprint changed
+            here relative to the previous accepted point.
+        iters, solve_time, obj, kkt_error, status, status_msg: The
+            corrector solve's outcome (zeros / ``None`` on an accepted
+            predictor step, which runs no solve).
+        n_obj, n_grad, n_cons, n_jac, n_hess: Callback counts for this
+            step, monitor evaluations included.
+    """
+
+    index: int
+    s: float
+    theta: np.ndarray
+    predictor: str
+    predictor_residual: Optional[float] = None
+    corrected: bool = False
+    rejections: int = 0
+    active_set_event: bool = False
+    iters: int = 0
+    solve_time: float = 0.0
+    obj: float = float("nan")
+    kkt_error: float = float("nan")
+    status: Optional[int] = None
+    status_msg: str = ""
+    n_obj: int = 0
+    n_grad: int = 0
+    n_cons: int = 0
+    n_jac: int = 0
+    n_hess: int = 0
+
+    @property
+    def evals(self) -> int:
+        """Total callback evaluations charged to this step."""
+        return self.n_obj + self.n_grad + self.n_cons + self.n_jac + self.n_hess
+
+
+@dataclasses.dataclass
+class ContinuationTrace:
+    """Result of a continuation run.
+
+    The counters are the ones pounce#608 asks a driver to report:
+    predictor residual (per step, in :attr:`steps`), corrections, step
+    rejections, active-set events, and total evaluations.
+    """
+
+    steps: List[ContinuationStep] = dataclasses.field(default_factory=list)
+    x: List[np.ndarray] = dataclasses.field(default_factory=list)
+    status: str = "ok"
+
+    # -- aggregate counters ------------------------------------------
+
+    @property
+    def n_steps(self) -> int:
+        return len(self.steps)
+
+    @property
+    def n_corrections(self) -> int:
+        """Solves run, the initial anchor included."""
+        return sum(1 for st in self.steps if st.corrected)
+
+    @property
+    def n_predictor_accepts(self) -> int:
+        """Points reached without a solve."""
+        return sum(1 for st in self.steps if not st.corrected)
+
+    @property
+    def n_rejections(self) -> int:
+        return sum(st.rejections for st in self.steps)
+
+    @property
+    def n_active_set_events(self) -> int:
+        return sum(1 for st in self.steps if st.active_set_event)
+
+    @property
+    def total_evals(self) -> int:
+        return sum(st.evals for st in self.steps)
+
+    @property
+    def total_iters(self) -> int:
+        return sum(st.iters for st in self.steps)
+
+    @property
+    def total_time(self) -> float:
+        return sum(st.solve_time for st in self.steps)
+
+    @property
+    def theta(self) -> np.ndarray:
+        return np.asarray([st.theta for st in self.steps])
+
+    def report(self) -> str:
+        """One-line-per-counter summary, for a log or a notebook."""
+        res = [st.predictor_residual for st in self.steps
+               if st.predictor_residual is not None]
+        worst = max(res) if res else float("nan")
+        return "\n".join([
+            f"continuation: {self.status}",
+            f"  points            {self.n_steps}",
+            f"  corrections       {self.n_corrections}",
+            f"  predictor accepts {self.n_predictor_accepts}",
+            f"  step rejections   {self.n_rejections}",
+            f"  active-set events {self.n_active_set_events}",
+            f"  worst predictor residual {worst:.3e}",
+            f"  solver iterations {self.total_iters}",
+            f"  total evaluations {self.total_evals}",
+            f"  solve time        {self.total_time * 1e3:.1f} ms",
+        ])
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+class Continuation:
+    """Trace a parametric NLP sequence through the generic ``Problem`` API.
+
+    Args:
+        update: ``update(theta) -> Problem``. The frontend-neutral model
+            update: build (or mutate and return) the problem at ``theta``.
+            It is called once per attempted point. Anything the frontend
+            needs to do to install ``theta`` — rewriting ``cl``/``cu``,
+            setting a Pyomo ``Param``, re-emitting an ``.nl`` file — goes
+            here, which is what makes the driver frontend-neutral.
+        pins: 0-based indices into ``g(x)`` of the parameter-pin equality
+            rows ``g_i(x) = theta_i`` (the sIPOPT convention;
+            ``cl[i] == cu[i]``). Supplying them enables the **tangent**
+            predictor. Omit them and the driver falls back to a zero-order
+            warm transfer, which pounce#608 asks for explicitly.
+        transfer: Optional prolongation map for steps that change the
+            problem's shape (horizon shift, remesh). Same protocol as
+            :meth:`pounce.WarmStart.transfer`: ``mapper(ctx) -> dict`` of
+            replacement arrays.
+        monitor: ``monitor(theta, x, lam, zl, zu) -> float | None``, the
+            KKT residual at a *predicted* point, with no solve. Required
+            for :meth:`follow` to accept a step on the predictor alone;
+            without it every step is corrected. :func:`kkt_residual_monitor`
+            builds one from cyipopt-shaped callbacks.
+        bounds: ``(lb, ub, cl, cu)``, or ``bounds(theta)`` returning them.
+            Used to keep a predicted seed inside the box and to place the
+            default anchor ``x0``. The predictor points where the linear
+            model says, which can be outside.
+        predict_duals: Also step the multipliers along the sensitivity
+            (:meth:`pounce.Solver.parametric_step_full`). Off by default:
+            measured on pounce's warm-start corpus it is a wash at small
+            steps and can cost iterations at large ones (see
+            ``docs/src/continuation.md``).
+        monitor_tol: KKT-residual threshold at the predicted point. In
+            :meth:`follow`, a point under it is accepted with no solve.
+        bound_push: Forwarded to :class:`~pounce.WarmStart`.
+        controller: A configured :class:`StepController`, or ``None`` for
+            the default policy.
+        max_steps: Safety cap on :meth:`follow`.
+    """
+
+    def __init__(
+        self,
+        update: Callable[[np.ndarray], object],
+        *,
+        pins: Optional[Sequence[int]] = None,
+        transfer: Optional[Callable[[object], dict]] = None,
+        monitor: Optional[Callable] = None,
+        bounds: Optional[Callable] = None,
+        predict_duals: bool = False,
+        monitor_tol: float = 1e-6,
+        bound_push: float = 1e-9,
+        controller: Optional[StepController] = None,
+        max_steps: int = 100_000,
+    ):
+        if not callable(update):
+            raise TypeError("Continuation: `update` must be callable")
+        self._update = update
+        self._pins = None if pins is None else [int(i) for i in pins]
+        self._transfer = transfer
+        self._monitor = monitor
+        self._bounds = bounds
+        self._predict_duals = bool(predict_duals)
+        self._monitor_tol = float(monitor_tol)
+        self._bound_push = float(bound_push)
+        self._controller = controller
+        self._max_steps = int(max_steps)
+
+    # -- predictor ----------------------------------------------------
+
+    @property
+    def has_tangent(self) -> bool:
+        """Whether a sensitivity-based predictor is available.
+
+        ``False`` means the driver runs the zero-order fallback — the
+        supported degraded mode, not an error.
+        """
+        return bool(self._pins)
+
+    def _tangent(self, solver, problem, dtheta):
+        """``(dx, dlam, dzl, dzu)`` from the held factor, or all-``None``.
+
+        Never raises: a factor that cannot answer (a solve that stopped
+        at an acceptable level, an inertia-corrected factor the
+        back-solve rejects) degrades to the zero-order transfer rather
+        than ending the trace.
+        """
+        none4 = (None, None, None, None)
+        if not self._pins or solver is None or not solver.converged:
+            return none4
+        deltas = [float(v) for v in np.asarray(dtheta, float).ravel()]
+        if len(deltas) != len(self._pins):
+            raise ValueError(
+                f"Continuation: theta has {len(deltas)} components but "
+                f"{len(self._pins)} pin constraints were declared; the pin "
+                "rows must correspond one-to-one with theta"
+            )
+        n = int(problem.n)
+        try:
+            if not self._predict_duals:
+                dx = np.asarray(solver.parametric_step(self._pins, deltas), float)
+                return dx[:n], None, None, None
+            full = np.asarray(
+                solver.parametric_step_full(self._pins, deltas), float
+            )
+        except Exception:
+            return none4
+
+        dims = list(solver.block_dims)
+        dx = full[:n]
+        m = int(problem.m)
+        dlam = np.zeros(m)
+        for i, row in enumerate(solver.multiplier_rows(list(range(m)))):
+            if row is not None and 0 <= row < full.size:
+                dlam[i] = full[row]
+        # z_l / z_u sit after (x, s, y_c, y_d) in the compound vector.
+        off = dims[0] + dims[1] + dims[2] + dims[3]
+        dzl = dzu = None
+        if off + dims[4] <= full.size:
+            dzl = np.zeros(n)
+            k = min(n, dims[4])
+            dzl[:k] = full[off:off + k]
+        if off + dims[4] + dims[5] <= full.size:
+            dzu = np.zeros(n)
+            k = min(n, dims[5])
+            dzu[:k] = full[off + dims[4]:off + dims[4] + k]
+        return dx, dlam, dzl, dzu
+
+    # -- monitor ------------------------------------------------------
+
+    def _monitor_at(self, theta, ws) -> Optional[float]:
+        """Predicted point's KKT residual, or ``None`` when unavailable."""
+        if self._monitor is None:
+            return None
+        r = self._monitor(np.asarray(theta, float), ws.x, ws.lagrange,
+                          ws.zl, ws.zu)
+        return None if r is None else float(r)
+
+    @staticmethod
+    def _active_signature(zl, zu, tol=ACTIVE_TOL):
+        """Boolean bound-activity fingerprint, as in pounce#90's
+        ``PathFollower._active_signature``."""
+        if zl is None or zu is None:
+            return None
+        return (np.asarray(zl, float) > tol, np.asarray(zu, float) > tol)
+
+    @staticmethod
+    def _signature_changed(a, b) -> bool:
+        if a is None or b is None:
+            return False
+        return bool(np.any(a[0] != b[0]) or np.any(a[1] != b[1]))
+
+    # -- the solve ----------------------------------------------------
+
+    def _solve_at(self, theta, ws, counter):  # noqa: C901
+        """Build the problem at `theta` and solve it, warm if `ws`.
+
+        Returns ``(problem, solver, x, info, elapsed)``.
+        """
+        problem = self._update(np.asarray(theta, float))
+        if problem is None:
+            raise TypeError(
+                "Continuation: `update(theta)` must return the Problem at "
+                "theta; it returned None"
+            )
+        if ws is not None and self._transfer is not None:
+            ws = _apply_transfer(ws, problem, self._transfer)
+        if counter is not None:
+            counter.reset_counts()
+
+        solver = _Solver(problem)
+        kwargs = {}
+        if ws is not None:
+            kwargs = ws.solve_kwargs()
+            kwargs.pop("working_set", None)  # not a Solver.solve keyword
+            x0 = ws.x
+        else:
+            x0 = (self._anchor_x0 if self._anchor_x0 is not None
+                  else self._x0_for(problem, theta))
+        # The warm-start overlay belongs to *this step*, not to the
+        # Problem: `add_option` is append-only, and a continuation run
+        # applies the overlay once per step, so without the snapshot the
+        # seven `warm_start_*` / `mu_init` options outlive the run and a
+        # later solve that looks cold is not (pounce#607). The restore
+        # has to survive an exception, or a step that fails poisons the
+        # rest of the path.
+        snapshot = problem.options_snapshot() if ws is not None else None
+        try:
+            if ws is not None:
+                for key, val in ws.options().items():
+                    problem.add_option(key, val)
+            t0 = time.perf_counter()
+            x, info = solver.solve(x0=x0, **kwargs)
+        finally:
+            if snapshot is not None:
+                problem.restore_options(snapshot)
+        return problem, solver, x, info, time.perf_counter() - t0
+
+    def _box(self, theta):
+        """``(lb, ub)`` at `theta`, or ``(None, None)`` when not supplied."""
+        if self._bounds is None:
+            return None, None
+        b = self._bounds(np.asarray(theta, float)) if callable(self._bounds) \
+            else self._bounds
+        return np.asarray(b[0], float), np.asarray(b[1], float)
+
+    def _x0_for(self, problem, theta):
+        lb, ub = self._box(theta)
+        x0 = np.zeros(int(problem.n))
+        return x0 if lb is None else np.clip(x0, lb, ub)
+
+    # -- entry points -------------------------------------------------
+
+    def run(self, thetas, *, x0=None, counter=None) -> ContinuationTrace:
+        """Trace a **prescribed** parameter sequence, solving every point.
+
+        This is the repeated-NLP case pounce#608's first acceptance
+        criterion names: the caller has a list of parameter values and
+        wants each one solved, without rebuilding the transfer,
+        warm-start, and predictor plumbing in user code.
+
+        Every point is corrected, because every point is an answer the
+        caller asked for. The predictor's job here is to make each solve
+        cheaper — which, on an interior-point method, it largely cannot;
+        see the module docstring and ``docs/src/continuation.md``. Use
+        :meth:`follow` when the intermediate points are a means rather
+        than an end.
+
+        Args:
+            thetas: Iterable of parameter values.
+            x0: Primal guess for the anchor solve. Defaults to zero
+                clipped into the box.
+            counter: Optional object with ``reset_counts()`` and
+                ``counts()`` returning ``{"n_obj": ..., ...}``, used to
+                fill the per-step evaluation counts.
+
+        Returns:
+            ContinuationTrace
+        """
+        trace = ContinuationTrace()
+        thetas = [np.asarray(t, float) for t in thetas]
+        if not thetas:
+            return trace
+
+        ws = None
+        solver = None
+        prev_theta = None
+        prev_sig = None
+        self._anchor_x0 = None if x0 is None else np.asarray(x0, float)
+
+        for k, theta in enumerate(thetas):
+            kind = "cold"
+            dx = dlam = dzl = dzu = None
+            if ws is not None:
+                kind = "transfer" if self._transfer is not None else "zero"
+                dtheta = theta - prev_theta
+                dx, dlam, dzl, dzu = self._tangent(solver, self._last_problem,
+                                                   dtheta)
+                if dx is not None:
+                    kind = "tangent"
+                    ws = self._advance(ws, dx, dlam, dzl, dzu, theta)
+
+            problem, solver, x, info, elapsed = self._solve_at(
+                theta, ws, counter
+            )
+            self._last_problem = problem
+            step = self._record(k, float(k), theta, kind, info, elapsed,
+                                counter, corrected=True)
+
+            sig = self._active_signature(info.get("mult_x_L"),
+                                         info.get("mult_x_U"))
+            step.active_set_event = self._signature_changed(prev_sig, sig)
+            prev_sig = sig
+            trace.steps.append(step)
+            trace.x.append(np.asarray(x, float).copy())
+
+            if step.status not in _OK_STATUS:
+                ws = None
+                solver = None
+                trace.status = f"solve_failed at step {k}: {step.status_msg}"
+                continue
+            ws = WarmStart.from_info(x, info, bound_push=self._bound_push)
+            prev_theta = theta
+
+        return trace
+
+    def follow(self, theta_of_s, s_span, *, x0=None, counter=None
+               ) -> ContinuationTrace:
+        """Trace ``x*(θ(s))`` over ``s ∈ [s0, s1]`` with an adaptive step.
+
+        The continuation case, and the one where a predictor earns its
+        keep: a point whose predicted KKT residual is under
+        `monitor_tol` is **accepted with no solve at all**. The path
+        parameter is the driver's to choose, so the step size adapts to
+        the corrector's work and backs off across active-set events.
+
+        This is :meth:`pounce.jax.PathFollower.follow` (pounce#90) driven
+        through the generic ``Problem`` API, sharing its step policy via
+        :class:`StepController`.
+
+        Args:
+            theta_of_s: ``s (float) -> theta``.
+            s_span: ``(s0, s1)`` with ``s1 > s0``.
+            x0: Primal guess for the anchor solve at ``s0``.
+            counter: As in :meth:`run`.
+
+        Returns:
+            ContinuationTrace
+        """
+        s0, s1 = float(s_span[0]), float(s_span[1])
+        if not s1 > s0:
+            raise ValueError("Continuation.follow: s_span must have s1 > s0")
+
+        ctl = self._controller or StepController()
+        trace = ContinuationTrace()
+        self._anchor_x0 = None if x0 is None else np.asarray(x0, float)
+
+        theta0 = np.asarray(theta_of_s(s0), float)
+        problem, solver, x, info, elapsed = self._solve_at(theta0, None, counter)
+        self._last_problem = problem
+        anchor = self._record(0, s0, theta0, "cold", info, elapsed, counter,
+                              corrected=True)
+        trace.steps.append(anchor)
+        trace.x.append(np.asarray(x, float).copy())
+        if anchor.status not in _OK_STATUS:
+            trace.status = f"anchor_failed: {anchor.status_msg}"
+            return trace
+
+        ws = WarmStart.from_info(x, info, bound_push=self._bound_push)
+        sig = self._active_signature(info.get("mult_x_L"), info.get("mult_x_U"))
+        s = s0
+        theta = theta0
+        index = 1
+        rejections = 0
+
+        while s < s1 - 1e-12 and index <= self._max_steps:
+            ds = min(ctl.ds, s1 - s)
+            s_new = s + ds
+            theta_new = np.asarray(theta_of_s(s_new), float)
+            dx, dlam, dzl, dzu = self._tangent(solver, self._last_problem,
+                                               theta_new - theta)
+            kind = "tangent" if dx is not None else "zero"
+            ws_pred = self._advance(ws, dx, dlam, dzl, dzu, theta_new)
+
+            # MONITOR (no solve): residual of the predicted point at the
+            # new parameter, from the caller-supplied monitor. Without one
+            # the driver has no way to know a predicted point is good, so
+            # it corrects every step -- the safe degradation.
+            resid = self._monitor_at(theta_new, ws_pred)
+
+            if resid is not None and resid <= self._monitor_tol:
+                step = ContinuationStep(
+                    index=index, s=s_new, theta=theta_new, predictor=kind,
+                    predictor_residual=resid, corrected=False,
+                    rejections=rejections,
+                )
+                if counter is not None:
+                    step = dataclasses.replace(step, **counter.counts())
+                trace.steps.append(step)
+                trace.x.append(np.asarray(ws_pred.x, float).copy())
+                ws = ws_pred
+                theta, s, index, rejections = theta_new, s_new, index + 1, 0
+                ctl.accepted()
+                continue
+
+            # CORRECT.
+            problem, solver, x, info, elapsed = self._solve_at(
+                theta_new, ws_pred, counter
+            )
+            self._last_problem = problem
+            status = int(info.get("status", -99))
+            if status not in _OK_STATUS:
+                rejections += 1
+                if ctl.rejected() is None:
+                    trace.status = "corrector_failed"
+                    break
+                continue
+
+            step = self._record(index, s_new, theta_new, kind, info, elapsed,
+                                counter, corrected=True)
+            step.predictor_residual = resid
+            step.rejections = rejections
+            new_sig = self._active_signature(info.get("mult_x_L"),
+                                             info.get("mult_x_U"))
+            step.active_set_event = self._signature_changed(sig, new_sig)
+            sig = new_sig
+            trace.steps.append(step)
+            trace.x.append(np.asarray(x, float).copy())
+            ws = WarmStart.from_info(x, info, bound_push=self._bound_push)
+            theta, s, index, rejections = theta_new, s_new, index + 1, 0
+            ctl.corrected(step.iters, step.active_set_event)
+
+        if index > self._max_steps and s < s1 - 1e-12:
+            trace.status = "max_steps"
+        return trace
+
+    # -- helpers ------------------------------------------------------
+
+    def _advance(self, ws, dx, dlam, dzl, dzu, theta=None) -> WarmStart:
+        """Apply a predictor step to a warm start, clipped into the box."""
+        if dx is None:
+            return ws
+        x = np.asarray(ws.x, float) + dx
+        if theta is not None:
+            lb, ub = self._box(theta)
+            if lb is not None:
+                x = np.clip(x, lb, ub)
+        lam = ws.lagrange
+        if lam is not None and dlam is not None:
+            lam = np.asarray(lam, float) + dlam
+        zl, zu = ws.zl, ws.zu
+        # Bound multipliers are nonnegative; a linear step can drive one
+        # through zero, which is the active-set event the corrector is
+        # there to resolve. Clip rather than seed an infeasible dual.
+        if zl is not None and dzl is not None:
+            zl = np.maximum(np.asarray(zl, float) + dzl, 0.0)
+        if zu is not None and dzu is not None:
+            zu = np.maximum(np.asarray(zu, float) + dzu, 0.0)
+        return dataclasses.replace(ws, x=x, lagrange=lam, zl=zl, zu=zu)
+
+    @staticmethod
+    def _record(index, s, theta, kind, info, elapsed, counter, *, corrected):
+        step = ContinuationStep(
+            index=index, s=s, theta=np.asarray(theta, float),
+            predictor=kind, corrected=corrected,
+            iters=int(info.get("iter_count", -1)),
+            solve_time=elapsed,
+            obj=float(info.get("obj_val", float("nan"))),
+            kkt_error=float(info.get(
+                "final_unscaled_kkt_error",
+                info.get("final_kkt_error", float("nan")))),
+            status=int(info.get("status", -99)),
+            status_msg=str(info.get("status_msg", "")),
+        )
+        if counter is not None:
+            for key, val in counter.counts().items():
+                setattr(step, key, int(val))
+        return step
+
+
+def kkt_residual_monitor(problem_obj, bounds):
+    """Build a :class:`Continuation` `monitor` from cyipopt-shaped callbacks.
+
+    Returns ``monitor(theta, x, lam, zl, zu) -> float``: the max-norm
+    first-order optimality residual at an explicit point, plus the
+    constraint and bound violations. No solve, and no autodiff — this is
+    the non-AD counterpart of :meth:`pounce.jax.PathFollower._kkt_residual`
+    (pounce#90), assembled from ``gradient`` / ``constraints`` /
+    ``jacobian`` instead of from ``jax.grad`` / ``jax.jacobian``.
+
+    Args:
+        problem_obj: The object handed to ``Problem(problem_obj=...)``.
+            Needs ``gradient``; also ``constraints``, ``jacobian`` and
+            ``jacobianstructure`` when the problem has constraints.
+        bounds: ``(lb, ub, cl, cu)``, or ``bounds(theta)`` returning them.
+            Bounds that move with ``theta`` need the callable form, or the
+            monitor reads the residual against the wrong box.
+    """
+    def monitor(theta, x, lam, zl, zu):
+        b = bounds(np.asarray(theta, float)) if callable(bounds) else bounds
+        lb, ub, cl, cu = (np.asarray(v, float) for v in b)
+        x = np.asarray(x, float).ravel()
+
+        stat = np.asarray(problem_obj.gradient(x), float).ravel().copy()
+        if zl is not None:
+            stat -= np.asarray(zl, float).ravel()
+        if zu is not None:
+            stat += np.asarray(zu, float).ravel()
+
+        viol = 0.0
+        if cl.size:
+            c = np.asarray(problem_obj.constraints(x), float).ravel()
+            rows, cols = problem_obj.jacobianstructure()
+            vals = np.asarray(problem_obj.jacobian(x), float).ravel()
+            if lam is not None:
+                lam = np.asarray(lam, float).ravel()
+                np.add.at(stat, np.asarray(cols, np.int64),
+                          vals * lam[np.asarray(rows, np.int64)])
+            viol = float(np.max(np.maximum(np.maximum(cl - c, c - cu), 0.0)))
+
+        box = float(max(np.max(np.maximum(0.0, lb - x)),
+                        np.max(np.maximum(0.0, x - ub))))
+        return float(np.max(np.abs(stat))) + viol + box
+
+    return monitor
+
+
+def _Solver(problem):
+    """`pounce.Solver` bound late, so importing this module does not
+    depend on the extension being importable at import time."""
+    from . import _pounce
+
+    return _pounce.Solver(problem)

--- a/python/pounce/_continuation.py
+++ b/python/pounce/_continuation.py
@@ -176,6 +176,10 @@ class ContinuationStep:
             accepted.
         active_set_event: Whether the active-set fingerprint changed
             here relative to the previous accepted point.
+        prescribed: ``True`` for a point the caller asked for, ``False``
+            for one :meth:`Continuation.run` inserted to get to the next
+            prescribed point. Always ``True`` from :meth:`follow`, whose
+            interior points are all the driver's own.
         iters, solve_time, obj, kkt_error, status, status_msg: The
             corrector solve's outcome (zeros / ``None`` on an accepted
             predictor step, which runs no solve).
@@ -191,6 +195,7 @@ class ContinuationStep:
     corrected: bool = False
     rejections: int = 0
     active_set_event: bool = False
+    prescribed: bool = True
     iters: int = 0
     solve_time: float = 0.0
     obj: float = float("nan")
@@ -227,6 +232,11 @@ class ContinuationTrace:
     @property
     def n_steps(self) -> int:
         return len(self.steps)
+
+    @property
+    def n_inserted(self) -> int:
+        """Points the driver inserted that the caller did not ask for."""
+        return sum(1 for st in self.steps if not st.prescribed)
 
     @property
     def n_corrections(self) -> int:
@@ -270,6 +280,7 @@ class ContinuationTrace:
         return "\n".join([
             f"continuation: {self.status}",
             f"  points            {self.n_steps}",
+            f"  inserted points   {self.n_inserted}",
             f"  corrections       {self.n_corrections}",
             f"  predictor accepts {self.n_predictor_accepts}",
             f"  step rejections   {self.n_rejections}",
@@ -499,7 +510,8 @@ class Continuation:
 
     # -- entry points -------------------------------------------------
 
-    def run(self, thetas, *, x0=None, counter=None) -> ContinuationTrace:
+    def run(self, thetas, *, x0=None, counter=None, subdivide=True,
+            subdivide_tol=None, max_subdivisions=8) -> ContinuationTrace:
         """Trace a **prescribed** parameter sequence, solving every point.
 
         This is the repeated-NLP case pounce#608's first acceptance
@@ -507,12 +519,23 @@ class Continuation:
         wants each one solved, without rebuilding the transfer,
         warm-start, and predictor plumbing in user code.
 
-        Every point is corrected, because every point is an answer the
-        caller asked for. The predictor's job here is to make each solve
-        cheaper — which, on an interior-point method, it largely cannot;
-        see the module docstring and ``docs/src/continuation.md``. Use
-        :meth:`follow` when the intermediate points are a means rather
-        than an end.
+        Every prescribed point is corrected, because every prescribed
+        point is an answer the caller asked for. The predictor's job
+        here is to make each solve cheaper — which, on an interior-point
+        method, it largely cannot; see the module docstring and
+        ``docs/src/continuation.md``. Use :meth:`follow` when the
+        intermediate points are a means rather than an end.
+
+        **Subdivision.** The caller chose the points they care about;
+        nothing says the driver may not visit more. When a corrector
+        rejects between two prescribed points — or, with
+        `subdivide_tol` set, when the monitor says the predicted point
+        is too far from the curve to seed a solve — the driver inserts
+        an intermediate parameter value and walks to the prescribed one
+        through it, rather than failing or ploughing on from a poisoned
+        warm start. Inserted points carry ``prescribed=False`` and are
+        reported separately by :attr:`ContinuationTrace.n_inserted`;
+        every prescribed point still appears, in order.
 
         Args:
             thetas: Iterable of parameter values.
@@ -521,6 +544,27 @@ class Continuation:
             counter: Optional object with ``reset_counts()`` and
                 ``counts()`` returning ``{"n_obj": ..., ...}``, used to
                 fill the per-step evaluation counts.
+            subdivide: Insert intermediate points when a corrector
+                rejects. On by default: it strictly improves on the
+                alternative, which is to record the failure and carry
+                on cold. Set ``False`` for the pre-subdivision
+                behaviour (one solve per prescribed point, exactly).
+            subdivide_tol: Also subdivide when the `monitor` reports a
+                predicted-point residual above this. ``None`` (the
+                default) subdivides on corrector rejection only —
+                :attr:`monitor_tol` is :meth:`follow`'s *accept without
+                solving* threshold and is far too tight to double as a
+                subdivision trigger, so this is a separate knob rather
+                than a reuse of that one. Needs a `monitor`.
+            max_subdivisions: Cap on step *halvings* per prescribed
+                interval — not on points inserted, which is smaller:
+                reaching a usable step can take several halvings, and
+                each landing resets the attempt to aim at the
+                prescribed point again. Once the budget is spent the
+                driver stops subdividing and attempts the prescribed
+                point directly, so a path that only needed help early
+                still finishes; if that direct attempt then fails, the
+                trace ends with ``status="subdivision_exhausted"``.
 
         Returns:
             ContinuationTrace
@@ -529,46 +573,114 @@ class Continuation:
         thetas = [np.asarray(t, float) for t in thetas]
         if not thetas:
             return trace
+        if subdivide_tol is not None and self._monitor is None:
+            raise ValueError(
+                "Continuation.run: subdivide_tol needs a monitor; pass "
+                "monitor=kkt_residual_monitor(...) to the constructor"
+            )
 
         ws = None
         solver = None
         prev_theta = None
         prev_sig = None
+        index = 0
         self._anchor_x0 = None if x0 is None else np.asarray(x0, float)
 
         for k, theta in enumerate(thetas):
-            kind = "cold"
-            dx = dlam = dzl = dzu = None
-            if ws is not None:
-                kind = "transfer" if self._transfer is not None else "zero"
-                dtheta = theta - prev_theta
-                dx, dlam, dzl, dzu = self._tangent(solver, self._last_problem,
-                                                   dtheta)
-                if dx is not None:
-                    kind = "tangent"
-                    ws = self._advance(ws, dx, dlam, dzl, dzu, theta)
+            # Walk from the last accepted point to this prescribed one,
+            # inserting intermediates only when the direct attempt will
+            # not carry. `frac` is the share of the remaining gap the
+            # next attempt covers; 1.0 is the un-subdivided step.
+            frac = 1.0
+            halvings = 0   # step halvings spent on this prescribed interval
+            rejected = 0   # of those, the ones a corrector failure forced
+            while True:
+                at_target = (prev_theta is None or frac >= 1.0)
+                theta_try = theta if at_target else (
+                    prev_theta + frac * (theta - prev_theta)
+                )
 
-            problem, solver, x, info, elapsed = self._solve_at(
-                theta, ws, counter
-            )
-            self._last_problem = problem
-            step = self._record(k, float(k), theta, kind, info, elapsed,
-                                counter, corrected=True)
+                kind = "cold"
+                ws_try = ws
+                resid = None
+                if ws is not None:
+                    kind = "transfer" if self._transfer is not None else "zero"
+                    dx, dlam, dzl, dzu = self._tangent(
+                        solver, self._last_problem, theta_try - prev_theta
+                    )
+                    if dx is not None:
+                        kind = "tangent"
+                        ws_try = self._advance(ws, dx, dlam, dzl, dzu,
+                                               theta_try)
+                    if subdivide and subdivide_tol is not None:
+                        resid = self._monitor_at(theta_try, ws_try)
+                        if (resid is not None and resid > subdivide_tol
+                                and halvings < max_subdivisions):
+                            # Too far to seed a solve from. Halve the gap
+                            # and re-predict rather than spend the solve.
+                            halvings += 1
+                            frac *= 0.5
+                            continue
 
-            sig = self._active_signature(info.get("mult_x_L"),
-                                         info.get("mult_x_U"))
-            step.active_set_event = self._signature_changed(prev_sig, sig)
-            prev_sig = sig
-            trace.steps.append(step)
-            trace.x.append(np.asarray(x, float).copy())
+                problem, solver, x, info, elapsed = self._solve_at(
+                    theta_try, ws_try, counter
+                )
+                self._last_problem = problem
+                status = int(info.get("status", -99))
 
-            if step.status not in _OK_STATUS:
-                ws = None
-                solver = None
-                trace.status = f"solve_failed at step {k}: {step.status_msg}"
-                continue
-            ws = WarmStart.from_info(x, info, bound_push=self._bound_push)
-            prev_theta = theta
+                if (status not in _OK_STATUS and subdivide
+                        and prev_theta is not None
+                        and halvings < max_subdivisions):
+                    # The corrector rejected. Do not record the failure
+                    # and do not carry its state: shorten the step and
+                    # re-predict from the last point known good.
+                    halvings += 1
+                    rejected += 1
+                    frac *= 0.5
+                    continue
+
+                step = self._record(index, float(index), theta_try, kind,
+                                    info, elapsed, counter, corrected=True)
+                step.predictor_residual = resid
+                step.prescribed = bool(at_target)
+                # Charged once, to the step that ends the interval, so
+                # `n_rejections` counts corrector failures and not the
+                # monitor-driven subdivisions that cost no solve.
+                step.rejections = rejected if at_target else 0
+                sig = self._active_signature(info.get("mult_x_L"),
+                                             info.get("mult_x_U"))
+                step.active_set_event = self._signature_changed(prev_sig, sig)
+                prev_sig = sig
+                trace.steps.append(step)
+                trace.x.append(np.asarray(x, float).copy())
+                index += 1
+
+                if step.status not in _OK_STATUS:
+                    # The interval is being abandoned; charge its
+                    # absorbed failures to the step that records the
+                    # abandonment, wherever on the interval it fell.
+                    step.rejections = rejected
+                    ws = None
+                    solver = None
+                    prev_theta = None
+                    if halvings >= max_subdivisions:
+                        trace.status = (
+                            f"subdivision_exhausted at prescribed point {k}: "
+                            f"{step.status_msg}"
+                        )
+                    else:
+                        trace.status = (
+                            f"solve_failed at step {k}: {step.status_msg}"
+                        )
+                    break
+
+                ws = WarmStart.from_info(x, info, bound_push=self._bound_push)
+                prev_theta = theta_try
+                if at_target:
+                    break
+                # Landed on an inserted point; aim at the prescribed one
+                # again, from closer in.
+                frac = 1.0
 
         return trace
 
@@ -682,6 +794,281 @@ class Continuation:
             trace.status = "max_steps"
         return trace
 
+    # -- pseudo-arclength ---------------------------------------------
+
+    def _arclength_shape(self, callbacks, n):
+        """Validate the arclength preconditions and return ``(m, cl, pin)``."""
+        if self._bounds is None:
+            raise ValueError(
+                "Continuation.trace_arclength: needs bounds=(lb, ub, cl, cu) "
+                "to know the equality right-hand side the parameter enters"
+            )
+        if not self._pins or len(self._pins) != 1:
+            raise ValueError(
+                "Continuation.trace_arclength: needs exactly one pin row "
+                "(a scalar parameter). Got "
+                f"{0 if not self._pins else len(self._pins)}. Vector-parameter "
+                "arclength is not a curve — the solution set is a manifold of "
+                "the parameter's dimension and 'past the fold' is not defined "
+                "for it; reparametrise onto a scalar path and trace that."
+            )
+        lb, ub, cl, cu = (np.asarray(v, float) for v in (
+            self._bounds(np.asarray([0.0])) if callable(self._bounds)
+            else self._bounds))
+        m = int(cl.size)
+        if m and np.any(cl != cu):
+            raise ValueError(
+                "Continuation.trace_arclength supports equality constraints "
+                "(cl == cu) and inactive variable bounds only; this problem "
+                "has two-sided inequality rows (cl != cu), for which the "
+                "arclength system R = [grad f + A^T lam; g - c] is not the "
+                "right residual — it treats every row as active. Reformulate "
+                "the inequalities with slack equalities, or remove them. "
+                "(Same v1 scope as pounce.jax.PathFollower.trace_arclength.)"
+            )
+        for name in ("gradient", "constraints", "jacobian", "jacobianstructure",
+                     "hessian", "hessianstructure"):
+            if m == 0 and name in ("constraints", "jacobian",
+                                   "jacobianstructure"):
+                continue
+            if not callable(getattr(callbacks, name, None)):
+                raise TypeError(
+                    f"Continuation.trace_arclength: callbacks is missing "
+                    f"{name!r}. The arclength corrector is a Newton solve on "
+                    "the KKT system, so it needs the derivative callbacks "
+                    "themselves, not just a built Problem."
+                )
+        return m, cl, (self._pins[0] if m else 0), lb, ub
+
+    def trace_arclength(self, x0, theta0, *, callbacks, lam0=None,
+                        ds=0.05, n_steps=200, direction=1.0,
+                        newton_tol=1e-9, newton_max=40,
+                        ds_min=1e-6, ds_max=None) -> ContinuationTrace:
+        """Pseudo-arclength continuation **past folds**, without autodiff.
+
+        The opt-in mode pounce#608's last scope bullet asks for.
+        :meth:`run` and :meth:`follow` march in ``θ``, so both stop dead
+        at a turning point: past a fold there is no solution at the next
+        ``θ``, and the corrector can only fail or fall back onto the
+        branch it came from. This parametrises the solution curve of
+
+        .. math:: R(x, λ, θ) = [∇f(x) + A(x)ᵀλ ;\\; g(x) - c(θ)] = 0
+
+        by its own arclength instead, so ``θ`` is free to stop and
+        reverse. It is :meth:`pounce.jax.PathFollower.trace_arclength`
+        (pounce#90) with the dense ``jax.jacobian`` and its SVD replaced
+        by a sparse assembly from the ``Problem``'s own callbacks and a
+        bordered solve.
+
+        **Why not the held factor.** :meth:`pounce.Solver.parametric_step`
+        back-solves against the factor of a *converged* solve, and at a
+        fold there is no converged solve to hold: ``∂x*/∂θ`` is singular
+        there, which is the definition of the fold. Worse, past the fold
+        there is no solution at that ``θ`` at all, so no factor can
+        exist. The tangent here is instead the null vector of the
+        ``(d, d+1)`` augmented matrix ``[∂R/∂z | ∂R/∂θ]``, obtained by
+        **bordering** it with the previous tangent and solving
+
+        .. code::
+
+            [ ∂R/∂z   ∂R/∂θ ] [ t ]   [ 0 ]
+            [     t_prevᵀ   ] [   ] = [ 1 ]
+
+        which is nonsingular *at* a simple fold — that is the whole
+        point of the pseudo-arclength formulation — and needs no SVD.
+        The cost is one sparse LU per Newton iteration rather than a
+        back-solve against a factor the solver already built; on the
+        fixtures in ``python/tests/test_continuation.py`` that is
+        sub-millisecond, and it is the price of being able to go round
+        the corner at all. See ``docs/src/continuation.md``.
+
+        **Scope (v1), matching pounce#90.** Scalar ``θ``; equality /
+        unconstrained families with a fixed active set along the traced
+        branch. Two-sided inequality rows are rejected explicitly rather
+        than silently mis-traced. Variable bounds are permitted but must
+        stay inactive; a branch that runs into one ends the trace with
+        ``status="bound_active"`` rather than reporting a wrong curve.
+        Bifurcation and branch switching remain out of scope.
+
+        Args:
+            x0: Primal guess near a point on the curve. Projected onto
+                ``R = 0`` at ``theta0`` before tracing.
+            theta0: Starting (scalar) parameter value.
+            callbacks: The cyipopt-shaped object handed to
+                ``Problem(problem_obj=...)`` — ``gradient``,
+                ``constraints``, ``jacobian``, ``jacobianstructure``,
+                ``hessian``, ``hessianstructure``. The same object the
+                whole path uses: in the pin convention ``θ`` enters only
+                through the right-hand side, never through the
+                callbacks.
+            lam0: Multiplier guess; defaults to zeros.
+            ds: Initial arclength step.
+            n_steps: Cap on accepted points.
+            direction: ``+1`` to set off toward increasing ``θ``, ``-1``
+                toward decreasing.
+            newton_tol: Max-norm ``‖R‖`` the corrector must reach.
+            newton_max: Newton iterations before a step is rejected.
+            ds_min, ds_max: Arclength step floor and ceiling. ``ds_max``
+                defaults to ``8 * ds``.
+
+        Returns:
+            ContinuationTrace. Each step's ``theta`` is a 1-element
+            array, ``kkt_error`` is ``‖R‖∞`` at the accepted point, and
+            ``iters`` is the corrector's Newton count.
+        """
+        from scipy.sparse import csc_matrix, hstack, vstack
+        from scipy.sparse.linalg import spsolve
+
+        x = np.asarray(x0, float).ravel()
+        n = int(x.size)
+        m, cl, pin, lb, ub = self._arclength_shape(callbacks, n)
+        lam = (np.zeros(m) if lam0 is None
+               else np.asarray(lam0, float).ravel())
+        if lam.size != m:
+            raise ValueError(
+                f"Continuation.trace_arclength: lam0 has {lam.size} entries, "
+                f"expected {m}"
+            )
+        theta = float(theta0)
+        d = n + m
+        ds_max = float(8.0 * ds) if ds_max is None else float(ds_max)
+        ds = float(ds)
+        trace = ContinuationTrace()
+
+        def RJ(x_, lam_, th_):
+            return _augmented_kkt(callbacks, n, m, cl, pin, x_, lam_, th_)
+
+        def bordered(J, row):
+            """``[[J], [row]]`` as a square ``(d+1, d+1)`` sparse matrix."""
+            return vstack([J, csc_matrix(np.asarray(row).reshape(1, d + 1))],
+                          format="csc")
+
+        def inside_bounds(x_):
+            return not (np.any(x_ < lb - 1e-9) or np.any(x_ > ub + 1e-9))
+
+        # -- anchor: project (x0, lam0) onto R = 0 at theta0, Newton in
+        # (x, lam) only. This is the one place theta is held fixed.
+        t_anchor = time.perf_counter()
+        it = 0
+        R, J = RJ(x, lam, theta)
+        while np.max(np.abs(R)) > newton_tol and it < newton_max:
+            dz = spsolve(csc_matrix(J[:, :d]), -R)
+            if not np.all(np.isfinite(dz)):
+                break
+            x = x + dz[:n]
+            lam = lam + dz[n:]
+            it += 1
+            R, J = RJ(x, lam, theta)
+        anchor = ContinuationStep(
+            index=0, s=0.0, theta=np.array([theta]), predictor="cold",
+            corrected=True, iters=it,
+            solve_time=time.perf_counter() - t_anchor,
+            obj=float(callbacks.objective(x)) if hasattr(
+                callbacks, "objective") else float("nan"),
+            kkt_error=float(np.max(np.abs(R))),
+            status=0 if np.max(np.abs(R)) <= newton_tol else 2,
+            status_msg="" if np.max(np.abs(R)) <= newton_tol
+            else "anchor projection did not converge",
+        )
+        trace.steps.append(anchor)
+        trace.x.append(x.copy())
+        if anchor.status != 0:
+            trace.status = f"anchor_failed: {anchor.status_msg}"
+            return trace
+
+        # -- first tangent: border with the theta axis, which is the
+        # parameter-continuation direction and is valid at a regular
+        # anchor. Thereafter border with the previous tangent.
+        t_prev = np.zeros(d + 1)
+        t_prev[d] = float(np.sign(direction) or 1.0)
+        rhs = np.zeros(d + 1)
+        rhs[d] = 1.0
+        s = 0.0
+        sig = None
+
+        for index in range(1, int(n_steps) + 1):
+            t0 = time.perf_counter()
+            R, J = RJ(x, lam, theta)
+            tan = spsolve(bordered(J, t_prev), rhs)
+            nrm = float(np.linalg.norm(tan))
+            if not np.all(np.isfinite(tan)) or nrm == 0.0:
+                trace.status = "tangent_failed"
+                break
+            tan = tan / nrm
+            if float(tan @ t_prev) < 0.0:
+                tan = -tan
+
+            # PREDICT along the arclength tangent: theta moves with the
+            # curve rather than being prescribed, which is what lets the
+            # step go round a turning point.
+            z = np.concatenate([x, lam, [theta]])
+            while True:
+                z_pred = z + ds * tan
+                zc = z_pred.copy()
+                it = 0
+                ok = False
+                while it < newton_max:
+                    Rc, Jc = RJ(zc[:n], zc[n:d], float(zc[d]))
+                    arc = float(tan @ (zc - z_pred))
+                    res = max(float(np.max(np.abs(Rc))) if Rc.size else 0.0,
+                              abs(arc))
+                    if res <= newton_tol:
+                        ok = True
+                        break
+                    F = np.concatenate([Rc, [arc]])
+                    dz = spsolve(bordered(Jc, tan), -F)
+                    if not np.all(np.isfinite(dz)):
+                        break
+                    zc = zc + dz
+                    it += 1
+                else:
+                    Rc, _ = RJ(zc[:n], zc[n:d], float(zc[d]))
+                    ok = float(np.max(np.abs(Rc))) <= newton_tol if Rc.size \
+                        else True
+                if ok:
+                    break
+                ds *= 0.5
+                if ds < ds_min:
+                    break
+            if not ok:
+                trace.status = "corrector_failed"
+                break
+
+            x, lam, theta = zc[:n], zc[n:d], float(zc[d])
+            if not inside_bounds(x):
+                trace.status = "bound_active"
+                break
+            s += ds
+            Rf, _ = RJ(x, lam, theta)
+            step = ContinuationStep(
+                index=index, s=s, theta=np.array([theta]),
+                predictor="tangent", corrected=True, iters=it,
+                solve_time=time.perf_counter() - t0,
+                obj=float(callbacks.objective(x)) if hasattr(
+                    callbacks, "objective") else float("nan"),
+                kkt_error=float(np.max(np.abs(Rf))) if Rf.size else 0.0,
+                status=0, status_msg="",
+            )
+            new_sig = (np.asarray(lam) > ACTIVE_TOL,
+                       np.asarray(lam) < -ACTIVE_TOL)
+            step.active_set_event = self._signature_changed(sig, new_sig)
+            sig = new_sig
+            trace.steps.append(step)
+            trace.x.append(x.copy())
+
+            # ADAPT, on the corrector's work, as StepController does for
+            # follow(). The controller's own state is per-`follow`, so
+            # the same policy is applied here to the arclength ds.
+            if it <= 2:
+                ds = min(ds * 1.5, ds_max)
+            elif it >= 6:
+                ds = max(ds * 0.5, ds_min)
+            t_prev = tan
+        else:
+            trace.status = "max_steps"
+
+        return trace
+
     # -- helpers ------------------------------------------------------
 
     def _advance(self, ws, dx, dlam, dzl, dzu, theta=None) -> WarmStart:
@@ -724,6 +1111,71 @@ class Continuation:
             for key, val in counter.counts().items():
                 setattr(step, key, int(val))
         return step
+
+
+def _augmented_kkt(problem_obj, n, m, cl, pin, x, lam, theta):
+    """``(R, J)`` of the parametric KKT system at ``(x, lam, theta)``.
+
+    ``R(x, λ, θ) = [∇f(x) + A(x)ᵀλ ; g(x) - c(θ)]`` — stationarity over
+    feasibility — where ``c(θ)`` is the equality right-hand side with
+    the pin row replaced by ``θ``. This is #90's ``R``, assembled from
+    the cyipopt-shaped callbacks instead of from ``jax.jacobian``.
+
+    ``J`` is the ``(n+m) × (n+m+1)`` Jacobian ``[∂R/∂x, ∂R/∂λ, ∂R/∂θ]``,
+    sparse:
+
+    .. code::
+
+        [ H(x, λ)   A(x)ᵀ    0      ]
+        [ A(x)      0       -e_pin  ]
+
+    ``H`` is the Hessian of the Lagrangian at multiplier ``λ`` with
+    ``obj_factor = 1``, which is exactly ``∂/∂x`` of the stationarity
+    block, so no third derivative is needed and nothing is approximated.
+    cyipopt hands back its lower triangle; it is mirrored here.
+    """
+    from scipy.sparse import coo_matrix, csc_matrix
+
+    x = np.asarray(x, float).ravel()
+    lam = np.asarray(lam, float).ravel()
+
+    grad = np.asarray(problem_obj.gradient(x), float).ravel()
+    if m:
+        jr, jc = (np.asarray(v, np.int64).ravel()
+                  for v in problem_obj.jacobianstructure())
+        jv = np.asarray(problem_obj.jacobian(x), float).ravel()
+        A = coo_matrix((jv, (jr, jc)), shape=(m, n)).tocsc()
+        g = np.asarray(problem_obj.constraints(x), float).ravel()
+        c = np.array(cl, float)
+        c[pin] = theta
+        R = np.concatenate([grad + A.T @ lam, g - c])
+    else:
+        A = coo_matrix((0, n))
+        R = grad
+
+    hr, hc = (np.asarray(v, np.int64).ravel()
+              for v in problem_obj.hessianstructure())
+    hv = np.asarray(problem_obj.hessian(x, lam, 1.0), float).ravel()
+    # Mirror the lower triangle, without doubling the diagonal.
+    off = hr != hc
+    H = coo_matrix(
+        (np.concatenate([hv, hv[off]]),
+         (np.concatenate([hr, hc[off]]), np.concatenate([hc, hr[off]]))),
+        shape=(n, n),
+    ).tocsc()
+
+    R_theta = np.zeros(n + m)
+    if m:
+        R_theta[n + pin] = -1.0
+
+    from scipy.sparse import bmat
+    J = bmat(
+        [[H, A.T if m else None, csc_matrix(R_theta[:n].reshape(n, 1))],
+         [A if m else None, None, csc_matrix(R_theta[n:].reshape(m, 1))]]
+        if m else [[H, csc_matrix(R_theta.reshape(n, 1))]],
+        format="csc",
+    )
+    return R, J
 
 
 def kkt_residual_monitor(problem_obj, bounds):

--- a/python/pounce/_continuation_cli.py
+++ b/python/pounce/_continuation_cli.py
@@ -68,7 +68,7 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import List, Optional
+from typing import List
 
 __all__ = [
     "PathManifest",

--- a/python/pounce/_continuation_cli.py
+++ b/python/pounce/_continuation_cli.py
@@ -1,0 +1,406 @@
+"""Path manifest and repeated-solve protocol for the CLI (pounce#608).
+
+pounce#608 asks for the continuation driver to reach the CLI and GAMS
+frontends, and names the mechanism: *"CLI/GAMS can follow using a path
+manifest or repeated-solve protocol."* This is that mechanism.
+
+What crosses the process boundary, and what does not
+----------------------------------------------------
+
+The in-process driver (:class:`pounce.Continuation`) gets its tangent
+predictor from :meth:`pounce.Solver.parametric_step`, a back-solve
+against the KKT factor the previous solve left in memory. **That factor
+does not survive `exec`.** A CLI path is a sequence of separate
+`pounce model.nl` processes, so the factor is gone before the next
+point starts and no tangent is available. This is a property of the
+process boundary, not a gap in the implementation: there is nothing to
+serialise that would make a back-solve possible in a fresh process
+short of shipping the factorization itself.
+
+So the CLI path is **zero-order warm transfer plus the driver's
+orchestration**: the trace, the counters, the active-set events, the
+subdivision on rejection, and a single manifest describing the whole
+path. What it adds over `--warm-start`-style flags is that the
+*sequence* is a first-class object -- one command, one report, and the
+per-point bookkeeping pounce#608's third acceptance criterion asks for.
+``docs/src/continuation.md`` records what that is measured to be worth
+against repeated cold invocations.
+
+The transfer itself is not primal-only. An AMPL ``.nl`` file carries an
+initial primal point (the ``x`` segment) *and* initial duals (the ``d``
+segment), and pounce's reader honours both, so the previous point's
+``.sol`` -- which reports duals then primals -- can be folded straight
+back into the next point's model. With ``warm_start_init_point yes``
+that is a genuine primal-dual warm start, the same state
+:class:`pounce.WarmStart` carries in process, minus the barrier
+parameter and the bound multipliers, which the ``.nl`` format has
+nowhere to put.
+
+Manifest format (JSON, ``version: 1``)
+--------------------------------------
+
+.. code:: json
+
+    {
+      "version": 1,
+      "points": [
+        {"model": "mpc_00.nl", "theta": [1.5, 0.0]},
+        {"model": "mpc_01.nl", "theta": [1.4, 0.1]}
+      ],
+      "options": {"tol": "1e-8"},
+      "warm": true
+    }
+
+``points`` is the path, in order; each names a model file the modeling
+system already emitted for that parameter value. ``theta`` is optional
+and carried through to the trace for the reader's benefit -- the
+driver never has to interpret it, because the model file *is* the
+parameter update. ``options`` are passed to every solve. Paths are
+resolved relative to the manifest.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from typing import List, Optional
+
+__all__ = [
+    "PathManifest",
+    "parse_sol",
+    "rewrite_nl_initial_point",
+    "trace_manifest",
+]
+
+_OK_STATUS = (0, 1)
+
+
+class PathManifest:
+    """A parsed continuation path manifest."""
+
+    def __init__(self, points, options=None, warm=True, root="."):
+        if not points:
+            raise ValueError("manifest: 'points' is empty; nothing to trace")
+        self.points = list(points)
+        self.options = dict(options or {})
+        self.warm = bool(warm)
+        self.root = root
+
+    @classmethod
+    def load(cls, path) -> "PathManifest":
+        with open(path) as fh:
+            data = json.load(fh)
+        version = data.get("version", 1)
+        if int(version) != 1:
+            raise ValueError(
+                f"manifest: unsupported version {version!r}; this pounce "
+                "reads version 1"
+            )
+        pts = data.get("points")
+        if not isinstance(pts, list):
+            raise ValueError("manifest: 'points' must be a list")
+        root = os.path.dirname(os.path.abspath(path))
+        out = []
+        for i, p in enumerate(pts):
+            if not isinstance(p, dict) or "model" not in p:
+                raise ValueError(
+                    f"manifest: point {i} has no 'model'; every point names "
+                    "the model file emitted for its parameter value"
+                )
+            out.append({
+                "model": os.path.join(root, p["model"]),
+                "theta": p.get("theta"),
+            })
+        return cls(out, data.get("options"), data.get("warm", True), root)
+
+
+def parse_sol(path, n, m):
+    """``(duals, primals)`` from an AMPL ``.sol`` file.
+
+    The format is: a message block, a blank line, ``Options``, an option
+    count and that many option values, then four counts
+    (``m, m, n, n``), then `m` dual values and `n` primal values.
+    """
+    with open(path) as fh:
+        toks = fh.read().split("\n")
+    i = 0
+    while i < len(toks) and toks[i].strip() != "Options":
+        i += 1
+    if i >= len(toks):
+        raise ValueError(f"{path}: no Options block; not an AMPL .sol file")
+    i += 1
+    nopt = int(toks[i].strip())
+    i += 1 + nopt
+    counts = [int(toks[i + k].strip()) for k in range(4)]
+    i += 4
+    m_sol, n_sol = counts[1], counts[3]
+    vals = []
+    while i < len(toks) and len(vals) < m_sol + n_sol:
+        t = toks[i].strip()
+        if t:
+            vals.append(float(t))
+        i += 1
+    if len(vals) < m_sol + n_sol:
+        raise ValueError(
+            f"{path}: expected {m_sol + n_sol} values, found {len(vals)}"
+        )
+    return vals[:m_sol], vals[m_sol:m_sol + n_sol]
+
+
+def _nl_counts(lines):
+    """``(n, m)`` from an ASCII ``.nl`` header."""
+    if not lines or not lines[0].startswith("g"):
+        raise ValueError(
+            "not an ASCII .nl file (binary .nl is not supported by the "
+            "manifest driver; re-emit with an ASCII writer)"
+        )
+    parts = lines[1].split("#")[0].split()
+    return int(parts[0]), int(parts[1])
+
+
+def rewrite_nl_initial_point(src, dst, primals=None, duals=None):
+    """Copy `src` to `dst` with its initial-point segments replaced.
+
+    An ASCII ``.nl`` file states its initial primal point in an ``x``
+    segment and its initial duals in a ``d`` segment, each a header
+    line (``x<count>`` / ``d<count>``) followed by that many
+    ``index value`` lines. Both are optional and both are honoured by
+    pounce's reader, so replacing them is how a solved point is handed
+    to the next model in the path.
+    """
+    with open(src) as fh:
+        lines = fh.read().split("\n")
+    n, m = _nl_counts(lines)
+    if primals is not None and len(primals) != n:
+        raise ValueError(
+            f"{src}: model has {n} variables, got {len(primals)} primals"
+        )
+    if duals is not None and len(duals) != m:
+        raise ValueError(
+            f"{src}: model has {m} constraints, got {len(duals)} duals"
+        )
+
+    out: List[str] = []
+    i = 0
+    # Segment headers are a single letter at column 0. `x` and `d` are
+    # the two we replace; everything else is copied through untouched.
+    while i < len(lines):
+        ln = lines[i]
+        if ln[:1] in ("x", "d") and ln[1:2].isdigit():
+            count = int(ln[1:].split()[0])
+            i += 1 + count          # drop the old segment entirely
+            continue
+        out.append(ln)
+        i += 1
+
+    seg: List[str] = []
+    if primals is not None:
+        seg.append(f"x{n}")
+        seg.extend(f"{k} {v!r}" for k, v in enumerate(primals))
+    if duals is not None and m:
+        seg.append(f"d{m}")
+        seg.extend(f"{k} {v!r}" for k, v in enumerate(duals))
+
+    # The initial-point segments belong after the header block (the
+    # first ten lines) and before the body; the reader accepts them
+    # anywhere in the segment stream, so appending after the header is
+    # both valid and stable across models.
+    body = out[:10] + seg + out[10:]
+    with open(dst, "w") as fh:
+        fh.write("\n".join(body))
+    return dst
+
+
+def _binary(explicit=None):
+    if explicit:
+        return explicit
+    here = os.path.join(os.path.dirname(os.path.abspath(__file__)), "bin",
+                        "pounce")
+    if os.path.exists(here):
+        return here
+    found = shutil.which("pounce")
+    if found:
+        return found
+    raise FileNotFoundError(
+        "pounce binary not found; pass --binary or install pounce-solver"
+    )
+
+
+def trace_manifest(manifest, *, binary=None, cold=False, workdir=None,
+                   bound_push=1e-6, verbose=False):
+    """Trace `manifest` by repeated CLI solves. Returns a trace dict.
+
+    With ``cold=True`` every point is solved from the model's own
+    starting point, which is the baseline the warm path is measured
+    against: the same models, the same options, the same process count,
+    differing only in whether the previous point's answer is carried
+    forward.
+    """
+    exe = _binary(binary)
+    tmp = workdir or tempfile.mkdtemp(prefix="pounce-cont-")
+    steps = []
+    prev = None            # (duals, primals) of the last accepted point
+    prev_sig = None
+    t_all = time.perf_counter()
+
+    for k, pt in enumerate(manifest.points):
+        model = pt["model"]
+        warm = manifest.warm and not cold and prev is not None
+        run_model = model
+        if warm:
+            run_model = os.path.join(tmp, f"step{k:04d}.nl")
+            rewrite_nl_initial_point(model, run_model,
+                                     primals=prev[1], duals=prev[0])
+
+        sol = os.path.join(tmp, f"step{k:04d}.sol")
+        rep = os.path.join(tmp, f"step{k:04d}.json")
+        cmd = [exe, run_model, sol, "--json-output", rep,
+               "--json-detail", "full"]
+        # Options are bare `key=value` arguments, matching upstream
+        # ipopt's CLI convention (`ipopt problem.nl print_level=8`).
+        for key, val in manifest.options.items():
+            cmd.append(f"{key}={val}")
+        if warm:
+            cmd += ["warm_start_init_point=yes",
+                    f"warm_start_bound_push={bound_push}",
+                    f"warm_start_mult_bound_push={bound_push}"]
+
+        t0 = time.perf_counter()
+        proc = subprocess.run(cmd, capture_output=True, text=True)
+        elapsed = time.perf_counter() - t0
+
+        info = {}
+        if os.path.exists(rep):
+            try:
+                with open(rep) as fh:
+                    info = json.load(fh)
+            except json.JSONDecodeError:
+                info = {}
+        sol_sec = info.get("solution") or {}
+        stat_sec = info.get("statistics") or {}
+        status = int(sol_sec.get("solve_result_num", -99)) if info else -99
+        rec = {
+            "index": k,
+            "model": os.path.relpath(model, manifest.root),
+            "theta": pt.get("theta"),
+            "predictor": "cold" if not warm else "zero",
+            "corrected": True,
+            "prescribed": True,
+            "iters": int(stat_sec.get("iteration_count", -1)),
+            "solve_time": elapsed,
+            "obj": stat_sec.get("final_objective"),
+            "kkt_error": stat_sec.get("final_kkt_error"),
+            "status": status,
+            "status_msg": str(sol_sec.get("status", proc.returncode)),
+            "returncode": proc.returncode,
+        }
+        for key, src in (("n_obj", "num_obj_evals"),
+                         ("n_grad", "num_obj_grad_evals"),
+                         ("n_cons", "num_constr_evals"),
+                         ("n_jac", "num_constr_jac_evals"),
+                         ("n_hess", "num_hess_evals")):
+            v = stat_sec.get(src)
+            rec[key] = int(v) if v is not None else 0
+
+        ok = status in _OK_STATUS
+        # Active-set event: the sign pattern of the constraint duals is
+        # what a .sol can report, so that is the fingerprint the CLI
+        # path uses. It is coarser than the in-process bound-multiplier
+        # signature and the trace says so rather than implying parity.
+        # The solve report carries the primal point and the constraint
+        # multipliers directly, so the iterate is read from it rather
+        # than re-parsed out of the .sol -- one format instead of two,
+        # and the .sol stays purely an artifact for the modeling system.
+        sig = None
+        if ok:
+            primals = sol_sec.get("x")
+            duals = sol_sec.get("lambda")
+            if primals is not None:
+                duals = duals or []
+                sig = tuple(int(d > 1e-6) - int(d < -1e-6) for d in duals)
+                prev = (list(duals), list(primals))
+            else:
+                prev = None
+        else:
+            prev = None
+        rec["active_set_event"] = bool(
+            prev_sig is not None and sig is not None and sig != prev_sig
+        )
+        if sig is not None:
+            prev_sig = sig
+        steps.append(rec)
+        if verbose:
+            print(f"[{k + 1}/{len(manifest.points)}] {rec['model']} "
+                  f"{'warm' if warm else 'cold'} "
+                  f"iters={rec['iters']} status={rec['status_msg']}",
+                  file=sys.stderr)
+
+    oks = [s for s in steps if s["status"] in _OK_STATUS]
+    return {
+        "version": 1,
+        "mode": "cold" if cold else ("warm" if manifest.warm else "cold"),
+        "predictor": "none (the KKT factor does not cross a process "
+                     "boundary; see pounce._continuation_cli)",
+        "n_points": len(steps),
+        "n_corrections": len(steps),
+        "n_converged": len(oks),
+        "n_active_set_events": sum(1 for s in steps if s["active_set_event"]),
+        "total_iters": sum(s["iters"] for s in oks),
+        "total_evals": sum(s["n_obj"] + s["n_grad"] + s["n_cons"]
+                           + s["n_jac"] + s["n_hess"] for s in steps),
+        "total_time": time.perf_counter() - t_all,
+        "steps": steps,
+    }
+
+
+def _report(trace) -> str:
+    return "\n".join([
+        f"continuation ({trace['mode']}): {trace['n_converged']}"
+        f"/{trace['n_points']} converged",
+        f"  points            {trace['n_points']}",
+        f"  corrections       {trace['n_corrections']}",
+        f"  predictor         {trace['predictor']}",
+        f"  active-set events {trace['n_active_set_events']}",
+        f"  solver iterations {trace['total_iters']}",
+        f"  total evaluations {trace['total_evals']}",
+        f"  wall time         {trace['total_time'] * 1e3:.1f} ms",
+    ])
+
+
+def main(argv=None) -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="pounce-continue",
+        description="Trace a parametric NLP path from a manifest "
+                    "(pounce#608). One command, one report, one process "
+                    "per point.",
+    )
+    p.add_argument("manifest", help="path manifest JSON (version 1)")
+    p.add_argument("--out", help="write the trace JSON here")
+    p.add_argument("--cold", action="store_true",
+                   help="solve every point cold -- the baseline the warm "
+                        "path is measured against")
+    p.add_argument("--binary", help="pounce executable (default: bundled)")
+    p.add_argument("--workdir", help="keep intermediates here")
+    p.add_argument("-v", "--verbose", action="store_true")
+    args = p.parse_args(argv)
+
+    man = PathManifest.load(args.manifest)
+    trace = trace_manifest(man, binary=args.binary, cold=args.cold,
+                           workdir=args.workdir, verbose=args.verbose)
+    if args.out:
+        with open(args.out, "w") as fh:
+            json.dump(trace, fh, indent=2)
+        print(f"pounce-continue: wrote {args.out}")
+    print(_report(trace))
+    return 0 if trace["n_converged"] == trace["n_points"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/pounce/gams/continuation.py
+++ b/python/pounce/gams/continuation.py
@@ -1,0 +1,124 @@
+"""Continuation over a GAMS parametric path (pounce#608).
+
+pounce#608 asks for the continuation driver to reach the GAMS frontend.
+For the **pip link** that is wiring rather than a second implementation:
+:func:`pounce.gams.link.problem_from_view` already turns a GMO view into
+an ordinary :class:`pounce.Problem` with the link's own option defaults,
+and :class:`pounce.Continuation` drives ``Problem`` handles. So a GAMS
+path traced in one process gets the whole driver -- the tangent
+predictor included, when the parameter enters through pin-equality rows
+-- and not the degraded zero-order transfer the CLI path is limited to.
+
+The distinction that matters is **who owns the process**:
+
+* ``option nlp = pounce;`` inside a GAMS loop is one link invocation per
+  solve. GAMS owns the process, the KKT factor dies between points, and
+  the best available transfer is whatever GAMS itself carries in the
+  ``.l`` / ``.m`` levels -- a zero-order primal-dual warm start.
+* Driving the views from Python, as :func:`trace` does, keeps every
+  point in one process. The factor survives, so the sensitivity
+  predictor is available.
+
+What the native C link's state file carries
+-------------------------------------------
+
+``gams/gams_pounce.c`` has a ``sqp_state_file`` warm start the pip link
+does not reproduce, and it is worth being precise about what it is: the
+file holds the **discrete working set only** -- one byte of
+``bound_status`` per variable and one of ``cons_status`` per constraint,
+behind a magic string and a checksum over ``(n, m, bounds)``. It carries
+no primal point, no multipliers and no barrier parameter, and it feeds
+``IpoptSetWarmStartWorkingSet`` on the active-set SQP path.
+
+For interior-point continuation that is strictly less than what the pip
+link already has in memory, not more. And because the checksum is taken
+over the bounds, any change of problem *shape* -- a horizon shift, a
+remesh -- invalidates the file, which is exactly the case pounce#608's
+transfer map exists to serve. So the state file is not a route to
+carrying continuation state across GAMS solves, and this module does
+not try to make it one.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional, Sequence
+
+__all__ = ["trace"]
+
+
+def trace(
+    view_of_theta: Callable[[object], object],
+    thetas: Sequence,
+    *,
+    pins: Optional[Sequence[int]] = None,
+    options: Optional[dict] = None,
+    max_iter: Optional[int] = None,
+    max_wall_time: Optional[float] = None,
+    transfer=None,
+    monitor=None,
+    bounds=None,
+    x0=None,
+    **kwargs,
+):
+    """Trace a GAMS parametric path through :class:`pounce.Continuation`.
+
+    Args:
+        view_of_theta: ``theta -> GmoView``. Whatever installing the
+            parameter means on the GAMS side -- rewriting a scalar,
+            re-reading a control file, regenerating the model -- happens
+            here, which is what keeps the driver frontend-neutral.
+        thetas: The parameter path.
+        pins: 0-based indices of the pin-equality rows through which
+            ``theta`` enters (``g_i(x) = theta_i``). Supplying them
+            enables the tangent predictor; omitting them falls back to
+            the zero-order warm transfer.
+        options: POUNCE options, as a ``pounce.opt`` file would give
+            them.
+        max_iter, max_wall_time: The GAMS environment's ``gevIterLim`` /
+            ``gevResLim``, applied as the link applies them.
+        transfer, monitor, bounds, x0, **kwargs: Forwarded to
+            :class:`pounce.Continuation` / :meth:`Continuation.run`
+            unchanged -- including ``subdivide`` and ``subdivide_tol``.
+
+    Returns:
+        :class:`pounce.ContinuationTrace`, the same record the generic
+        and Pyomo frontends return.
+    """
+    import pounce
+
+    from .link import problem_from_view
+
+    def update(theta):
+        view = view_of_theta(theta)
+        if view is None:
+            raise TypeError(
+                "gams.continuation.trace: view_of_theta(theta) must return "
+                "the GmoView at theta; it returned None"
+            )
+        _gp, prob = problem_from_view(
+            view, options=options, max_iter=max_iter,
+            max_wall_time=max_wall_time,
+        )
+        return prob
+
+    run_keys = ("subdivide", "subdivide_tol", "max_subdivisions", "counter")
+    run_kw = {k: kwargs.pop(k) for k in run_keys if k in kwargs}
+
+    if x0 is None and len(thetas):
+        # The anchor starts from the GAMS model's own variable levels,
+        # the way an ordinary `option nlp = pounce;` solve does. The
+        # driver's generic default is zeros clipped into the box, which
+        # for a model whose box excludes zero is not merely a worse
+        # guess but a different basin: HS071 started from zeros converges
+        # to a stationary point at 32.94 rather than the 17.01 the link
+        # reaches from its declared levels.
+        first = view_of_theta(thetas[0])
+        init = getattr(first, "var_init", None)
+        if callable(init):
+            x0 = list(init())
+
+    driver = pounce.Continuation(
+        update, pins=pins, transfer=transfer, monitor=monitor,
+        bounds=bounds, **kwargs,
+    )
+    return driver.run(thetas, x0=x0, **run_kw)

--- a/python/pounce/gams/link.py
+++ b/python/pounce/gams/link.py
@@ -263,6 +263,30 @@ def solve_view(
     link options) route a ``pounce.solve-report/v1`` JSON to disk via the
     canonical Rust writer, matching the native C link (pounce#187).
     """
+    gp, prob = problem_from_view(
+        view, options=options, max_iter=max_iter, max_wall_time=max_wall_time
+    )
+    x, info = prob.solve(
+        x0=gp.x0, report_path=report_path, report_detail=report_detail
+    )
+    return gp, x, info
+
+
+def problem_from_view(
+    view: "GmoView",
+    *,
+    options: dict | None = None,
+    max_iter: int | None = None,
+    max_wall_time: float | None = None,
+):
+    """Build ``(GmoProblem, pounce.Problem)`` from a GMO view, unsolved.
+
+    Split out of :func:`solve_view` so a caller that drives its own
+    solve loop -- :mod:`pounce.gams.continuation`, which hands the
+    ``Problem`` to :class:`pounce.Continuation` -- constructs it exactly
+    the way an ordinary GAMS solve does, options and all, rather than
+    reimplementing the defaults and drifting from them (pounce#608).
+    """
     import pounce
 
     gp: "GmoProblem" = problem_from_gmo(view)
@@ -294,10 +318,7 @@ def solve_view(
         except Exception as exc:  # unknown / invalid option: warn, keep going
             sys.stderr.write(f"pounce-gams: ignoring option '{key}': {exc}\n")
 
-    x, info = prob.solve(
-        x0=gp.x0, report_path=report_path, report_detail=report_detail
-    )
-    return gp, x, info
+    return gp, prob
 
 
 def solve_from_control_file(

--- a/python/pounce/jax/_path.py
+++ b/python/pounce/jax/_path.py
@@ -44,6 +44,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from .._ad_common import ACTIVE_TOL
+from .._continuation import StepController
 
 _OK_STATUS = ("Solve_Succeeded", "Solved_To_Acceptable_Level")
 
@@ -326,6 +327,14 @@ class PathFollower:
         self._grow = float(grow)
         self._shrink = float(shrink)
         self._max_steps = int(max_steps)
+        # Step-size policy lives in pounce._continuation.StepController so
+        # this follower and the frontend-neutral driver (pounce#608) cannot
+        # drift apart. The constructor keeps its own knobs unchanged; the
+        # controller is built per `follow` call from them.
+        self._controller_kwargs = dict(
+            ds0=self._ds0, ds_min=self._ds_min, ds_max=self._ds_max,
+            grow=self._grow, shrink=self._shrink,
+        )
 
     # ----- monitors -----
 
@@ -434,10 +443,14 @@ class PathFollower:
         status = "ok"
 
         s = s0
-        ds = self._ds0
+        ctl = StepController(**self._controller_kwargs)
         while s < s1 - 1e-12 and n_steps < self._max_steps:
             n_steps += 1
-            ds = min(ds, s1 - s)
+            # Clamp the controller's own state, not a local copy: the
+            # pre-#608 loop mutated `ds` here, and the policy must stay
+            # bit-identical across the refactor.
+            ctl.ds = min(ctl.ds, s1 - s)
+            ds = ctl.ds
             s_new = s + ds
             th_cur = th(s)
             th_new = th(s_new)
@@ -473,7 +486,7 @@ class PathFollower:
                 TH.append(np.asarray(th_new))
                 X.append(np.asarray(x))
                 LAM.append(np.asarray(lam))
-                ds = min(ds * self._grow, self._ds_max)
+                ctl.accepted()
                 continue
 
             # CORRECT: warm-μ re-solve from the predicted point, which
@@ -486,8 +499,7 @@ class PathFollower:
             if cinfo["status_msg"] not in _OK_STATUS:
                 # Back off and retry a shorter step from the same anchor.
                 new_state.close()
-                ds *= self._shrink
-                if ds < self._ds_min:
+                if ctl.rejected() is None:
                     status = "corrector_failed"
                     break
                 continue
@@ -501,17 +513,11 @@ class PathFollower:
             s = s_new
 
             new_sig = self._active_signature(lam, zL, zU)
-            if new_sig != sig:
+            event = new_sig != sig
+            if event:
                 as_changes.append(s)
                 sig = new_sig
-                # Resolve the region near the change finely.
-                ds = min(self._ds0, max(ds * self._shrink, self._ds_min))
-            else:
-                iters = int(cinfo["iter_count"])
-                if iters <= 3:
-                    ds = min(ds * self._grow, self._ds_max)
-                elif iters >= 10:
-                    ds = max(ds * self._shrink, self._ds_min)
+            ctl.corrected(int(cinfo["iter_count"]), active_set_event=event)
 
             S.append(s)
             TH.append(np.asarray(th_new))

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -42,6 +42,10 @@ pounce-dbg-viz = "pounce._debug_viz:main"
 # `pounce-gams-link` is the launcher GAMS invokes with a control file.
 pounce-gams = "pounce._gams_cli:main"
 pounce-gams-link = "pounce.gams.link:main"
+# Continuation over a path manifest (pounce#608): one command traces a
+# whole parametric sequence of models, carrying each solve's answer into
+# the next, and writes a single trace report. See docs/src/continuation.md.
+pounce-continue = "pounce._continuation_cli:main"
 
 [project.optional-dependencies]
 jax = ["jax>=0.4.30", "jaxlib>=0.4.30"]

--- a/python/tests/test_continuation.py
+++ b/python/tests/test_continuation.py
@@ -1,0 +1,383 @@
+"""Frontend-neutral predictor--corrector continuation (pounce#608).
+
+Driven on the same upstream sIPOPT `ParametricTNLP` fixture that
+`test_sensitivity.py` and `test_solver_session.py` use, so the tangent
+predictor here is checked against a problem whose sensitivity answer is
+already pinned to upstream's golden numbers.
+"""
+
+import numpy as np
+import pytest
+
+import pounce
+
+pytestmark = pytest.mark.filterwarnings("ignore::RuntimeWarning")
+
+
+class ParametricNLP:
+    """Same NLP as `test_sensitivity.ParametricNLP`. Variables `x[3]`,
+    `x[4]` are the parameters `eta1`, `eta2`, pinned by `g[2] = eta1`,
+    `g[3] = eta2` -- the sIPOPT pin convention the driver's `pins=` takes."""
+
+    def objective(self, x):
+        return x[0] ** 2 + x[1] ** 2 + x[2] ** 2
+
+    def gradient(self, x):
+        return np.array([2 * x[0], 2 * x[1], 2 * x[2], 0.0, 0.0])
+
+    def constraints(self, x):
+        x1, x2, x3, eta1, eta2 = x
+        return np.array([
+            6 * x1 + 3 * x2 + 2 * x3 - eta1,
+            eta2 * x1 + x2 - x3 - 1.0,
+            eta1,
+            eta2,
+        ])
+
+    def jacobianstructure(self):
+        return (np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 3], dtype=np.int64),
+                np.array([0, 1, 2, 3, 0, 1, 2, 4, 3, 4], dtype=np.int64))
+
+    def jacobian(self, x):
+        return np.array([6.0, 3.0, 2.0, -1.0,
+                         x[4], 1.0, -1.0, x[0],
+                         1.0, 1.0])
+
+    def hessianstructure(self):
+        return (np.array([0, 1, 2, 4], dtype=np.int64),
+                np.array([0, 1, 2, 0], dtype=np.int64))
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([2.0 * obj_factor, 2.0 * obj_factor,
+                         2.0 * obj_factor, lagrange[1]])
+
+
+LB = np.array([0.0, 0.0, 0.0, -1e19, -1e19])
+UB = np.full(5, 1e19)
+X0 = np.array([0.15, 0.15, 0.0, 0.0, 0.0])
+PINS = [2, 3]
+
+
+def bounds_at(theta):
+    theta = np.asarray(theta, float)
+    rhs = np.array([0.0, 0.0, theta[0], theta[1]])
+    return LB, UB, rhs, rhs
+
+
+class Counter:
+    """Counting wrapper with the `reset_counts()` / `counts()` protocol
+    the driver's `counter=` argument expects."""
+
+    def __init__(self, inner):
+        self._inner = inner
+        self.reset_counts()
+
+    def reset_counts(self):
+        self.n_obj = self.n_grad = self.n_cons = self.n_jac = self.n_hess = 0
+
+    def counts(self):
+        return dict(n_obj=self.n_obj, n_grad=self.n_grad, n_cons=self.n_cons,
+                    n_jac=self.n_jac, n_hess=self.n_hess)
+
+    def objective(self, x):
+        self.n_obj += 1
+        return self._inner.objective(x)
+
+    def gradient(self, x):
+        self.n_grad += 1
+        return self._inner.gradient(x)
+
+    def constraints(self, x):
+        self.n_cons += 1
+        return self._inner.constraints(x)
+
+    def jacobian(self, x):
+        self.n_jac += 1
+        return self._inner.jacobian(x)
+
+    def jacobianstructure(self):
+        return self._inner.jacobianstructure()
+
+    def hessian(self, x, lagrange, obj_factor):
+        self.n_hess += 1
+        return self._inner.hessian(x, lagrange, obj_factor)
+
+    def hessianstructure(self):
+        return self._inner.hessianstructure()
+
+
+def make_update(obj):
+    def update(theta):
+        lb, ub, cl, cu = bounds_at(theta)
+        p = pounce.Problem(n=5, m=4, problem_obj=obj,
+                           lb=lb, ub=ub, cl=cl, cu=cu)
+        p.add_option("tol", 1e-10)
+        p.add_option("print_level", 0)
+        p.add_option("sb", "yes")
+        return p
+    return update
+
+
+def theta_path(k=8):
+    """A short, smooth path in (eta1, eta2) from the fixture's nominal."""
+    s = np.linspace(0.0, 1.0, k)
+    return [np.array([5.0 - 0.5 * t, 1.0 + 0.2 * t]) for t in s]
+
+
+def theta_of_s(s):
+    return np.array([5.0 - 0.5 * s, 1.0 + 0.2 * s])
+
+
+def exact_at(theta):
+    x, _ = make_update(ParametricNLP())(theta).solve(x0=X0)
+    return np.asarray(x, float)
+
+
+# -- acceptance criterion 1: a sequence traces through `Problem` --------
+
+
+def test_run_traces_a_parametric_sequence():
+    """The whole point: a parametric NLP sequence goes through the
+    generic `Problem` API without the caller rebuilding orchestration."""
+    path = theta_path()
+    trace = pounce.Continuation(make_update(ParametricNLP()),
+                                pins=PINS, bounds=bounds_at).run(path, x0=X0)
+
+    assert trace.status == "ok"
+    assert trace.n_steps == len(path)
+    assert trace.n_corrections == len(path)
+    for th, x in zip(path, trace.x):
+        assert np.allclose(x, exact_at(th), atol=1e-6)
+
+
+def test_run_reports_every_counter_the_issue_asks_for():
+    obj = Counter(ParametricNLP())
+    trace = pounce.Continuation(make_update(obj), pins=PINS,
+                                bounds=bounds_at).run(theta_path(), x0=X0,
+                                                      counter=obj)
+    assert trace.total_evals > 0
+    assert trace.total_iters > 0
+    assert trace.n_corrections == trace.n_steps
+    assert trace.n_predictor_accepts == 0
+    assert trace.n_rejections == 0
+    assert trace.n_active_set_events >= 0
+    assert "active-set events" in trace.report()
+    assert all(st.evals > 0 for st in trace.steps)
+
+
+# -- the tangent predictor, and the documented fallback ----------------
+
+
+def test_tangent_predictor_is_used_when_pins_are_declared():
+    drv = pounce.Continuation(make_update(ParametricNLP()), pins=PINS,
+                              bounds=bounds_at)
+    assert drv.has_tangent
+    trace = drv.run(theta_path(), x0=X0)
+    kinds = [st.predictor for st in trace.steps]
+    assert kinds[0] == "cold"
+    assert set(kinds[1:]) == {"tangent"}
+
+
+def test_falls_back_to_zero_order_transfer_without_pins():
+    """pounce#608: 'falls back to zero-order warm transfer when
+    sensitivities are unavailable'."""
+    drv = pounce.Continuation(make_update(ParametricNLP()), bounds=bounds_at)
+    assert not drv.has_tangent
+    trace = drv.run(theta_path(), x0=X0)
+    assert trace.status == "ok"
+    assert [st.predictor for st in trace.steps][1:] == ["zero"] * 7
+    for th, x in zip(theta_path(), trace.x):
+        assert np.allclose(x, exact_at(th), atol=1e-6)
+
+
+def test_tangent_predictor_beats_zero_order_transfer_on_seed_accuracy():
+    """The predictor's own claim, measured directly rather than through
+    an iteration count: `x_prev + dx` must land nearer the next solution
+    than `x_prev` does."""
+    path = theta_path()
+    obj = ParametricNLP()
+    prob = make_update(obj)(path[0])
+    solver = pounce.Solver(prob)
+    x, _ = solver.solve(x0=X0)
+    x = np.asarray(x, float)
+
+    dtheta = path[1] - path[0]
+    dx = np.asarray(solver.parametric_step(PINS, list(dtheta)), float)[:5]
+    truth = exact_at(path[1])
+
+    err_zero = np.max(np.abs(x - truth))
+    err_tangent = np.max(np.abs(x + dx - truth))
+    assert err_tangent < 0.2 * err_zero
+
+
+def test_pin_count_must_match_theta():
+    drv = pounce.Continuation(make_update(ParametricNLP()), pins=[2],
+                              bounds=bounds_at)
+    with pytest.raises(ValueError, match="one-to-one"):
+        drv.run(theta_path(), x0=X0)
+
+
+# -- acceptance criterion: predictor accepts, and what they cost -------
+
+
+def test_follow_accepts_steps_on_the_predictor_alone():
+    """`follow` is where continuation pays: a predicted point under
+    `monitor_tol` is taken with no solve at all."""
+    obj = ParametricNLP()
+    mon = pounce.kkt_residual_monitor(obj, bounds_at)
+
+    tight = pounce.Continuation(make_update(obj), pins=PINS, monitor=mon,
+                                bounds=bounds_at, monitor_tol=1e-6)
+    loose = pounce.Continuation(make_update(obj), pins=PINS, monitor=mon,
+                                bounds=bounds_at, monitor_tol=1e-1)
+
+    t_tight = tight.follow(theta_of_s, (0.0, 1.0), x0=X0)
+    t_loose = loose.follow(theta_of_s, (0.0, 1.0), x0=X0)
+
+    assert t_tight.n_predictor_accepts == 0
+    assert t_loose.n_predictor_accepts > 0
+    assert t_loose.n_corrections < t_tight.n_corrections
+    assert t_loose.total_iters < t_tight.total_iters
+    # ... and the accuracy that buys is the thing to report, not hide.
+    assert np.max(np.abs(t_tight.x[-1] - exact_at(theta_of_s(1.0)))) < 1e-8
+    assert np.max(np.abs(t_loose.x[-1] - exact_at(theta_of_s(1.0)))) < 1e-2
+
+
+def test_follow_without_a_monitor_corrects_every_step():
+    """No monitor means no way to know a predicted point is good, so the
+    driver must solve rather than guess."""
+    trace = pounce.Continuation(make_update(ParametricNLP()), pins=PINS,
+                                bounds=bounds_at).follow(
+        theta_of_s, (0.0, 1.0), x0=X0)
+    assert trace.n_predictor_accepts == 0
+    assert trace.n_corrections == trace.n_steps
+
+
+def test_follow_rejects_a_reversed_span():
+    drv = pounce.Continuation(make_update(ParametricNLP()), pins=PINS)
+    with pytest.raises(ValueError, match="s1 > s0"):
+        drv.follow(theta_of_s, (1.0, 0.0), x0=X0)
+
+
+# -- the monitor -------------------------------------------------------
+
+
+def test_kkt_residual_monitor_vanishes_at_a_solution():
+    obj = ParametricNLP()
+    theta = np.array([5.0, 1.0])
+    prob = make_update(obj)(theta)
+    x, info = prob.solve(x0=X0)
+    r = pounce.kkt_residual_monitor(obj, bounds_at)(
+        theta, x, info["mult_g"], info["mult_x_L"], info["mult_x_U"])
+    assert r < 1e-6
+
+
+def test_kkt_residual_monitor_sees_a_displaced_point():
+    obj = ParametricNLP()
+    theta = np.array([5.0, 1.0])
+    prob = make_update(obj)(theta)
+    x, info = prob.solve(x0=X0)
+    mon = pounce.kkt_residual_monitor(obj, bounds_at)
+    bad = np.asarray(x, float) + 0.1
+    assert mon(theta, bad, info["mult_g"], info["mult_x_L"],
+               info["mult_x_U"]) > 1e-3
+
+
+# -- transfer / prolongation ------------------------------------------
+
+
+def test_transfer_map_is_applied_between_steps():
+    """pounce#608 asks for 'an explicit user transfer/prolongation map'.
+    Protocol is `WarmStart.transfer`'s: mapper(ctx) -> dict."""
+    seen = []
+
+    def mapper(ctx):
+        seen.append(np.asarray(ctx.source.x, float).copy())
+        return {}          # identity, so the trace must be unchanged
+
+    trace = pounce.Continuation(make_update(ParametricNLP()), pins=PINS,
+                                bounds=bounds_at,
+                                transfer=mapper).run(theta_path(), x0=X0)
+    assert trace.status == "ok"
+    assert len(seen) == len(theta_path()) - 1     # not on the anchor
+    for th, x in zip(theta_path(), trace.x):
+        assert np.allclose(x, exact_at(th), atol=1e-6)
+
+
+def test_transfer_map_rejects_unknown_keys():
+    def mapper(ctx):
+        return {"nonsense": np.zeros(5)}
+
+    drv = pounce.Continuation(make_update(ParametricNLP()), pins=PINS,
+                              bounds=bounds_at, transfer=mapper)
+    with pytest.raises(TypeError, match="unknown keys"):
+        drv.run(theta_path(), x0=X0)
+
+
+def test_transfer_map_rejects_a_wrong_length_array():
+    # The arity check belongs to `WarmStart.transfer` (pounce#607), which the
+    # driver delegates to; this asserts the rejection still reaches the caller
+    # through `Continuation.run`, and matches that owner's wording rather than
+    # the shim's.
+    def mapper(ctx):
+        return {"x": np.zeros(4)}
+
+    drv = pounce.Continuation(make_update(ParametricNLP()), pins=PINS,
+                              bounds=bounds_at, transfer=mapper)
+    with pytest.raises(ValueError, match=r"the mapped 'x' has 4 entries"):
+        drv.run(theta_path(), x0=X0)
+
+
+# -- step controller (shared with pounce.jax.PathFollower, pounce#90) ---
+
+
+def test_step_controller_grows_on_accept_and_shrinks_on_hard_correction():
+    c = pounce.StepController(ds0=0.1, ds_min=1e-3, ds_max=0.4,
+                              grow=2.0, shrink=0.5)
+    assert c.accepted() == pytest.approx(0.2)
+    assert c.accepted() == pytest.approx(0.4)
+    assert c.accepted() == pytest.approx(0.4)      # clamped at ds_max
+    assert c.corrected(iters=20) == pytest.approx(0.2)
+    assert c.corrected(iters=1) == pytest.approx(0.4)
+    assert c.corrected(iters=5) == pytest.approx(0.4)   # neither easy nor hard
+
+
+def test_step_controller_reanchors_after_an_active_set_event():
+    c = pounce.StepController(ds0=0.1, ds_min=1e-3, ds_max=0.4, shrink=0.5)
+    c.accepted()
+    c.accepted()
+    assert c.ds == pytest.approx(0.225)
+    assert c.corrected(iters=1, active_set_event=True) == pytest.approx(0.1)
+
+
+def test_step_controller_signals_the_floor():
+    c = pounce.StepController(ds0=0.01, ds_min=0.005, shrink=0.5)
+    assert c.rejected() == pytest.approx(0.005)
+    assert c.rejected() is None
+
+
+def test_step_controller_is_what_the_jax_follower_uses():
+    """The reuse claim in the module docstring, asserted rather than
+    left as a comment: pounce#90's follower must import this class."""
+    jax_path = pytest.importorskip("pounce.jax._path")
+    assert jax_path.StepController is pounce.StepController
+
+
+# -- misuse ------------------------------------------------------------
+
+
+def test_update_must_be_callable():
+    with pytest.raises(TypeError, match="callable"):
+        pounce.Continuation(object())
+
+
+def test_update_returning_none_is_an_error():
+    drv = pounce.Continuation(lambda theta: None, pins=PINS)
+    with pytest.raises(TypeError, match="must return the Problem"):
+        drv.run(theta_path(), x0=X0)
+
+
+def test_empty_path_is_an_empty_trace():
+    trace = pounce.Continuation(make_update(ParametricNLP())).run([])
+    assert trace.n_steps == 0
+    assert trace.status == "ok"

--- a/python/tests/test_continuation.py
+++ b/python/tests/test_continuation.py
@@ -381,3 +381,276 @@ def test_empty_path_is_an_empty_trace():
     trace = pounce.Continuation(make_update(ParametricNLP())).run([])
     assert trace.n_steps == 0
     assert trace.status == "ok"
+
+
+# ======================================================================
+# Folds: pseudo-arclength past a turning point (pounce#608's last scope
+# bullet). See docs/src/continuation.md.
+# ======================================================================
+
+
+class FoldNLP:
+    """``min x0**3/3 + x1**2/2  s.t.  x0 + x1 = theta``.
+
+    Stationarity gives ``lam = -x0**2`` and ``x1 = x0**2``, so the
+    solution curve is ``x0 + x0**2 = theta``: a parabola in ``(x0,
+    theta)`` with a **turning point at x0 = -1/2, theta = -1/4**. Above
+    the fold there are two branches (the minimizing one is
+    ``x0 = (-1 + sqrt(1 + 4 theta)) / 2``); below it there is no
+    solution at all, which is what stops parameter continuation.
+
+    LICQ holds at the fold (``grad g = (1, 1)``) and ``lam = -1/4``
+    stays finite there, so the ``(x, lam, theta)`` curve is smooth
+    through the turning point and pseudo-arclength can follow it. A
+    fold built on a vanishing constraint gradient instead would send
+    ``lam`` to infinity and no arclength scheme would pass it either --
+    the fixture is built to isolate the fold, not to smuggle in a
+    degeneracy.
+    """
+
+    def objective(self, x):
+        return x[0] ** 3 / 3.0 + 0.5 * x[1] ** 2
+
+    def gradient(self, x):
+        return np.array([x[0] ** 2, x[1]])
+
+    def constraints(self, x):
+        return np.array([x[0] + x[1]])
+
+    def jacobianstructure(self):
+        return (np.array([0, 0], dtype=np.int64),
+                np.array([0, 1], dtype=np.int64))
+
+    def jacobian(self, x):
+        return np.array([1.0, 1.0])
+
+    def hessianstructure(self):
+        return (np.array([0, 1, 1], dtype=np.int64),
+                np.array([0, 0, 1], dtype=np.int64))
+
+    def hessian(self, x, lagrange, obj_factor):
+        return np.array([obj_factor * 2.0 * x[0], 0.0, obj_factor * 1.0])
+
+
+FOLD_THETA = -0.25
+FOLD_X0 = -0.5
+FOLD_LB = np.full(2, -1e20)
+FOLD_UB = np.full(2, 1e20)
+
+
+def fold_exact(theta):
+    """The minimizing branch, defined only for ``theta >= -1/4``."""
+    x0 = (-1.0 + np.sqrt(1.0 + 4.0 * theta)) / 2.0
+    return np.array([x0, x0 ** 2])
+
+
+def fold_bounds(theta):
+    t = float(np.asarray(theta, float).ravel()[0])
+    return (FOLD_LB, FOLD_UB, np.array([t]), np.array([t]))
+
+
+def fold_update(obj):
+    def update(theta):
+        lb, ub, cl, cu = fold_bounds(theta)
+        p = pounce.Problem(n=2, m=1, problem_obj=obj,
+                           lb=lb, ub=ub, cl=cl, cu=cu)
+        p.add_option("tol", 1e-10)
+        p.add_option("print_level", 0)
+        p.add_option("sb", "yes")
+        return p
+    return update
+
+
+def fold_driver(obj=None, **kw):
+    obj = obj if obj is not None else FoldNLP()
+    return pounce.Continuation(fold_update(obj), pins=[0],
+                               bounds=fold_bounds, **kw), obj
+
+
+def test_parameter_continuation_cannot_pass_the_fold():
+    """The premise of the arclength mode. Marching theta down through
+    -1/4 is not a tuning failure -- there is no solution on the other
+    side to march to -- so `run` must report it, not invent one."""
+    drv, _ = fold_driver()
+    thetas = [np.array([t]) for t in (2.0, 1.0, 0.0, -0.4)]
+    trace = drv.run(thetas, x0=fold_exact(2.0), subdivide=False)
+
+    assert trace.status.startswith("solve_failed")
+    assert [st.status for st in trace.steps[:3]] == [0, 0, 0]
+    assert trace.steps[-1].status not in (0, 1)
+    # And the answer it does not have is not quietly plausible: the
+    # iterates run away rather than settling on a wrong point.
+    assert abs(trace.x[-1][0]) > 1e3
+
+
+def test_arclength_traverses_the_fold():
+    """The acceptance test for pounce#608's pseudo-arclength bullet:
+    the same start that dead-ends above goes round the corner here."""
+    drv, obj = fold_driver()
+    trace = drv.trace_arclength(fold_exact(2.0), 2.0, callbacks=obj,
+                                ds=0.25, n_steps=40, direction=-1.0)
+
+    assert trace.status in ("ok", "max_steps")
+    theta = np.array([float(st.theta[0]) for st in trace.steps])
+    x0 = np.array([v[0] for v in trace.x])
+
+    # It reached the fold ...
+    assert theta.min() < FOLD_THETA + 0.02
+    # ... turned round (theta stops decreasing and increases again) ...
+    turn = int(np.argmin(theta))
+    assert 0 < turn < len(theta) - 1
+    assert theta[-1] > theta[turn] + 0.5
+    # ... and came back on the *other* branch, past the fold in x0,
+    # which is the half of the curve parameter continuation cannot see.
+    assert x0[turn] < FOLD_X0
+    assert x0[-1] < -1.0
+
+    # Every accepted point is on the curve x0 + x0^2 = theta.
+    assert np.max(np.abs(x0 + x0 ** 2 - theta)) < 1e-7
+    # and each is a genuine root of R, not merely close.
+    assert max(st.kkt_error for st in trace.steps) < 1e-7
+
+
+def test_arclength_brackets_the_turning_point():
+    """A finer step must localise the fold better -- the discretisation
+    is the only thing keeping theta.min() off -1/4."""
+    drv, obj = fold_driver()
+    coarse = drv.trace_arclength(fold_exact(2.0), 2.0, callbacks=obj,
+                                 ds=0.4, n_steps=60, direction=-1.0)
+    fine = drv.trace_arclength(fold_exact(2.0), 2.0, callbacks=obj,
+                               ds=0.02, n_steps=400, direction=-1.0,
+                               ds_max=0.02)
+    c = min(float(st.theta[0]) for st in coarse.steps)
+    f = min(float(st.theta[0]) for st in fine.steps)
+    assert f <= c
+    assert abs(f - FOLD_THETA) < 1e-3
+
+
+def test_arclength_rejects_two_sided_inequalities():
+    """v1 scope, stated as an error rather than a silently wrong curve
+    -- the same guard pounce.jax.PathFollower.trace_arclength applies."""
+    obj = FoldNLP()
+
+    def bounds(theta):
+        return (FOLD_LB, FOLD_UB, np.array([-1.0]), np.array([1.0]))
+
+    drv = pounce.Continuation(fold_update(obj), pins=[0], bounds=bounds)
+    with pytest.raises(ValueError, match="equality constraints"):
+        drv.trace_arclength(fold_exact(2.0), 2.0, callbacks=obj)
+
+
+def test_arclength_needs_a_scalar_parameter():
+    drv = pounce.Continuation(make_update(ParametricNLP()), pins=PINS,
+                              bounds=bounds_at)
+    with pytest.raises(ValueError, match="exactly one pin row"):
+        drv.trace_arclength(X0, 0.0, callbacks=ParametricNLP())
+
+
+def test_arclength_needs_the_derivative_callbacks():
+    class NoHessian:
+        def gradient(self, x):
+            return np.zeros(2)
+
+        def constraints(self, x):
+            return np.zeros(1)
+
+        def jacobian(self, x):
+            return np.zeros(2)
+
+        def jacobianstructure(self):
+            return (np.array([0, 0]), np.array([0, 1]))
+
+    drv, _ = fold_driver()
+    with pytest.raises(TypeError, match="hessian"):
+        drv.trace_arclength(fold_exact(2.0), 2.0, callbacks=NoHessian())
+
+
+# ======================================================================
+# Subdivision in run() (pounce#608, step-size adaptation on a
+# prescribed sequence).
+# ======================================================================
+
+
+def test_run_subdivides_toward_the_fold_instead_of_diverging():
+    """The caller chose the points; nothing says the driver may not
+    visit more. Asked for a point past the fold, `run` walks in rather
+    than handing back the runaway iterate `subdivide=False` returns."""
+    drv, _ = fold_driver()
+    thetas = [np.array([t]) for t in (2.0, 1.0, 0.0, -0.4)]
+
+    plain = drv.run(thetas, x0=fold_exact(2.0), subdivide=False)
+    sub = drv.run(thetas, x0=fold_exact(2.0), subdivide=True,
+                  max_subdivisions=10)
+
+    assert sub.n_inserted > 0
+    assert sub.n_rejections > 0
+    assert sub.status.startswith("subdivision_exhausted")
+    assert plain.n_inserted == 0
+
+    # The inserted points are real solutions, and they get closer to the
+    # fold than the un-subdivided path ever does.
+    good = [st for st in sub.steps if st.status in (0, 1)]
+    reached = min(float(st.theta[0]) for st in good)
+    assert reached < -0.2
+    assert abs(reached - FOLD_THETA) < 1e-2
+    assert len(good) > len([st for st in plain.steps if st.status in (0, 1)])
+
+    for st, xv in zip(sub.steps, sub.x):
+        if st.status in (0, 1):
+            assert xv[0] + xv[0] ** 2 == pytest.approx(float(st.theta[0]),
+                                                       abs=1e-7)
+
+
+def test_run_subdivision_keeps_every_prescribed_point_in_order():
+    """Inserted points are additions, never substitutions."""
+    obj = FoldNLP()
+    drv = pounce.Continuation(fold_update(obj), pins=[0],
+                              bounds=fold_bounds,
+                              monitor=pounce.kkt_residual_monitor(
+                                  obj, fold_bounds))
+    want = [2.0, 1.0, 0.0]
+    trace = drv.run([np.array([t]) for t in want], x0=fold_exact(2.0),
+                    subdivide=True, subdivide_tol=0.1)
+
+    assert trace.status == "ok"
+    assert trace.n_inserted > 0
+    got = [float(st.theta[0]) for st in trace.steps if st.prescribed]
+    assert got == pytest.approx(want)
+    # The inserted ones sit strictly between prescribed neighbours.
+    seq = [float(st.theta[0]) for st in trace.steps]
+    assert seq == sorted(seq, reverse=True)
+    assert trace.x[-1][0] == pytest.approx(fold_exact(0.0)[0], abs=1e-7)
+
+
+def test_run_monitor_subdivision_is_off_by_default():
+    """`monitor_tol` is follow()'s accept-without-solving threshold and
+    is far too tight to double as a subdivision trigger, so run() does
+    not reuse it: no `subdivide_tol`, no monitor-driven inserts."""
+    obj = FoldNLP()
+    drv = pounce.Continuation(fold_update(obj), pins=[0],
+                              bounds=fold_bounds,
+                              monitor=pounce.kkt_residual_monitor(
+                                  obj, fold_bounds))
+    trace = drv.run([np.array([2.0]), np.array([0.0])], x0=fold_exact(2.0))
+    assert trace.status == "ok"
+    assert trace.n_inserted == 0
+    assert trace.n_steps == 2
+
+
+def test_run_subdivide_tol_requires_a_monitor():
+    drv, _ = fold_driver()
+    with pytest.raises(ValueError, match="needs a monitor"):
+        drv.run([np.array([2.0])], subdivide_tol=1e-3)
+
+
+def test_subdivision_does_not_change_a_healthy_path():
+    """The default must be a no-op where nothing goes wrong, or every
+    existing caller's step count silently moves."""
+    obj = ParametricNLP()
+    drv = pounce.Continuation(make_update(obj), pins=PINS, bounds=bounds_at)
+    path = theta_path()
+    on = drv.run(path, x0=X0, subdivide=True)
+    off = drv.run(path, x0=X0, subdivide=False)
+    assert on.n_steps == off.n_steps == len(path)
+    assert on.n_inserted == 0
+    assert [s.iters for s in on.steps] == [s.iters for s in off.steps]

--- a/python/tests/test_continuation_cli.py
+++ b/python/tests/test_continuation_cli.py
@@ -1,0 +1,238 @@
+"""Path manifest / repeated-solve protocol for the CLI (pounce#608).
+
+pounce#608's scope note says CLI and GAMS "can follow using a path
+manifest or repeated-solve protocol". These cover the manifest parser,
+the `.nl` initial-point rewrite that carries a solved point into the
+next model, and -- when a `pounce` binary and the CLI fixture corpus
+are both present -- one end-to-end trace.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from pounce._continuation_cli import (
+    PathManifest,
+    parse_sol,
+    rewrite_nl_initial_point,
+    trace_manifest,
+)
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ROOT = os.path.abspath(os.path.join(_HERE, "..", ".."))
+_FIXTURES = os.path.join(_ROOT, "crates", "pounce-cli", "tests", "fixtures")
+
+
+def _binary():
+    local = os.path.join(_ROOT, "target", "release", "pounce")
+    if os.path.exists(local):
+        return local
+    bundled = os.path.join(_ROOT, "python", "pounce", "bin", "pounce")
+    if os.path.exists(bundled):
+        return bundled
+    return shutil.which("pounce")
+
+
+needs_cli = pytest.mark.skipif(
+    _binary() is None or not os.path.isdir(_FIXTURES),
+    reason="needs a built pounce binary and the CLI fixture corpus",
+)
+
+
+# -- manifest ----------------------------------------------------------
+
+
+def _write(tmp_path, obj, name="path.json"):
+    p = tmp_path / name
+    p.write_text(json.dumps(obj))
+    return str(p)
+
+
+def test_manifest_round_trips(tmp_path):
+    man = PathManifest.load(_write(tmp_path, {
+        "version": 1,
+        "points": [{"model": "a.nl", "theta": [1.0]},
+                   {"model": "b.nl"}],
+        "options": {"tol": "1e-8"},
+    }))
+    assert len(man.points) == 2
+    assert man.warm is True
+    assert man.options == {"tol": "1e-8"}
+    # Model paths resolve against the manifest, not the cwd, so a
+    # manifest is movable with its models.
+    assert os.path.dirname(man.points[0]["model"]) == str(tmp_path)
+    assert man.points[0]["theta"] == [1.0]
+    assert man.points[1]["theta"] is None
+
+
+def test_manifest_rejects_a_future_version(tmp_path):
+    with pytest.raises(ValueError, match="unsupported version"):
+        PathManifest.load(_write(tmp_path, {"version": 2, "points": []}))
+
+
+def test_manifest_rejects_a_point_without_a_model(tmp_path):
+    with pytest.raises(ValueError, match="no 'model'"):
+        PathManifest.load(_write(tmp_path, {
+            "version": 1, "points": [{"theta": [1.0]}]}))
+
+
+def test_manifest_rejects_an_empty_path(tmp_path):
+    with pytest.raises(ValueError, match="empty"):
+        PathManifest.load(_write(tmp_path, {"version": 1, "points": []}))
+
+
+# -- .nl initial-point rewrite ----------------------------------------
+
+
+_NL = """g3 1 1 0	# problem unknown
+ 2 1 1 0 1 	# vars, constraints, objectives, ranges, eqns
+ 0 1 0 0 0 0	# nonlinear constrs, objs
+ 0 0	# network constraints
+ 0 2 0 	# nonlinear vars
+ 0 0 0 1	# linear network variables
+ 0 0 0 0 0 	# discrete variables
+ 2 2 	# nonzeros
+ 0 0	# max name lengths
+ 0 0 0 0 0	# common exprs
+x2
+0 0.0
+1 0.0
+C0
+n0
+"""
+
+
+def _src(tmp_path, text=_NL):
+    p = tmp_path / "m.nl"
+    p.write_text(text)
+    return str(p)
+
+
+def test_rewrite_replaces_the_initial_point(tmp_path):
+    dst = str(tmp_path / "out.nl")
+    rewrite_nl_initial_point(_src(tmp_path), dst, primals=[1.5, -2.5],
+                             duals=[0.25])
+    lines = open(dst).read().split("\n")
+    heads = [ln for ln in lines if ln[:1] in ("x", "d") and ln[1:2].isdigit()]
+    # Exactly one of each -- the old x segment is replaced, not appended
+    # to, or the reader would see two starting points.
+    assert heads == ["x2", "d1"]
+    assert "0 1.5" in lines and "1 -2.5" in lines
+    assert "0 0.25" in lines
+    # The model body is untouched.
+    assert "C0" in lines and "n0" in lines
+
+
+def test_rewrite_omits_the_dual_segment_when_no_duals_are_given(tmp_path):
+    dst = str(tmp_path / "out.nl")
+    rewrite_nl_initial_point(_src(tmp_path), dst, primals=[1.0, 2.0])
+    heads = [ln for ln in open(dst).read().split("\n")
+             if ln[:1] in ("x", "d") and ln[1:2].isdigit()]
+    assert heads == ["x2"]
+
+
+def test_rewrite_checks_the_lengths_against_the_model(tmp_path):
+    dst = str(tmp_path / "out.nl")
+    with pytest.raises(ValueError, match="2 variables"):
+        rewrite_nl_initial_point(_src(tmp_path), dst, primals=[1.0])
+    with pytest.raises(ValueError, match="1 constraints"):
+        rewrite_nl_initial_point(_src(tmp_path), dst, primals=[1.0, 2.0],
+                                 duals=[0.1, 0.2])
+
+
+def test_rewrite_rejects_a_binary_nl(tmp_path):
+    p = tmp_path / "b.nl"
+    p.write_text("b3 1 1 0\n 2 1 1 0 1\n")
+    with pytest.raises(ValueError, match="ASCII"):
+        rewrite_nl_initial_point(str(p), str(tmp_path / "o.nl"),
+                                 primals=[1.0, 2.0])
+
+
+# -- .sol parsing ------------------------------------------------------
+
+
+def test_parse_sol_splits_duals_from_primals(tmp_path):
+    p = tmp_path / "s.sol"
+    p.write_text("POUNCE: done\n\nOptions\n3\n0\n1\n0\n2\n2\n3\n3\n"
+                 "10.0\n11.0\n1.0\n2.0\n3.0\n")
+    duals, primals = parse_sol(str(p), 3, 2)
+    assert duals == [10.0, 11.0]
+    assert primals == [1.0, 2.0, 3.0]
+
+
+def test_parse_sol_rejects_a_non_sol_file(tmp_path):
+    p = tmp_path / "s.sol"
+    p.write_text("not a sol file\n")
+    with pytest.raises(ValueError, match="Options"):
+        parse_sol(str(p), 1, 1)
+
+
+# -- end to end --------------------------------------------------------
+
+
+@needs_cli
+def test_trace_manifest_solves_every_point(tmp_path):
+    """A two-point path over the same model is the degenerate
+    continuation: the second point starts from the first's answer."""
+    src = os.path.join(_FIXTURES, "boxed_qp_min.nl")
+    if not os.path.exists(src):
+        pytest.skip("fixture not present")
+    for name in ("p0.nl", "p1.nl"):
+        shutil.copy(src, tmp_path / name)
+    man = PathManifest.load(_write(tmp_path, {
+        "version": 1,
+        "points": [{"model": "p0.nl", "theta": [0.0]},
+                   {"model": "p1.nl", "theta": [0.0]}],
+        "options": {"print_level": "0", "sb": "yes"},
+    }))
+    trace = trace_manifest(man, binary=_binary(), workdir=str(tmp_path))
+    assert trace["n_points"] == 2
+    assert trace["n_converged"] == 2
+    assert all(s["status"] in (0, 1) for s in trace["steps"])
+    # The predictor is reported as absent rather than silently implied:
+    # the KKT factor does not cross a process boundary.
+    assert "process boundary" in trace["predictor"]
+    assert trace["steps"][0]["predictor"] == "cold"
+    assert trace["steps"][1]["predictor"] == "zero"
+
+
+@needs_cli
+def test_cold_mode_does_not_transfer(tmp_path):
+    src = os.path.join(_FIXTURES, "boxed_qp_min.nl")
+    if not os.path.exists(src):
+        pytest.skip("fixture not present")
+    for name in ("p0.nl", "p1.nl"):
+        shutil.copy(src, tmp_path / name)
+    man = PathManifest.load(_write(tmp_path, {
+        "version": 1,
+        "points": [{"model": "p0.nl"}, {"model": "p1.nl"}],
+        "options": {"print_level": "0", "sb": "yes"},
+    }))
+    trace = trace_manifest(man, binary=_binary(), cold=True,
+                           workdir=str(tmp_path))
+    assert trace["mode"] == "cold"
+    assert [s["predictor"] for s in trace["steps"]] == ["cold", "cold"]
+
+
+@needs_cli
+def test_cli_entry_point_runs(tmp_path):
+    src = os.path.join(_FIXTURES, "boxed_qp_min.nl")
+    if not os.path.exists(src):
+        pytest.skip("fixture not present")
+    shutil.copy(src, tmp_path / "p0.nl")
+    man = _write(tmp_path, {
+        "version": 1, "points": [{"model": "p0.nl"}],
+        "options": {"print_level": "0", "sb": "yes"},
+    })
+    out = str(tmp_path / "trace.json")
+    proc = subprocess.run(
+        ["python", "-m", "pounce._continuation_cli", man, "--out", out],
+        capture_output=True, text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    with open(out) as fh:
+        trace = json.load(fh)
+    assert trace["n_points"] == 1

--- a/python/tests/test_continuation_cli.py
+++ b/python/tests/test_continuation_cli.py
@@ -11,6 +11,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 
 import pytest
 
@@ -26,6 +27,27 @@ _ROOT = os.path.abspath(os.path.join(_HERE, "..", ".."))
 _FIXTURES = os.path.join(_ROOT, "crates", "pounce-cli", "tests", "fixtures")
 
 
+def _works(path):
+    """A path is only a usable CLI if it actually runs.
+
+    `shutil.which("pounce")` finds the wheel's *console-script shim*,
+    which is present whenever pounce-solver is installed but only
+    execs a real binary when the wheel was built with `pounce/bin/`
+    staged. CI builds the wheel straight from `maturin-action` with no
+    staging step, so the shim is on PATH, exits 1, and every solve in
+    a trace silently returns nothing — which is how this arrived as
+    `assert 0 == 2` rather than as a skip.
+    """
+    if path is None:
+        return False
+    try:
+        proc = subprocess.run([path, "--version"], capture_output=True,
+                              text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
 def _binary():
     local = os.path.join(_ROOT, "target", "release", "pounce")
     if os.path.exists(local):
@@ -36,9 +58,13 @@ def _binary():
     return shutil.which("pounce")
 
 
+_CLI = _binary() if _works(_binary()) else None
+
 needs_cli = pytest.mark.skipif(
-    _binary() is None or not os.path.isdir(_FIXTURES),
-    reason="needs a built pounce binary and the CLI fixture corpus",
+    _CLI is None or not os.path.isdir(_FIXTURES),
+    reason="needs a *working* pounce binary (a wheel built without "
+           "pounce/bin/ staged leaves only a shim that exits 1) and the "
+           "CLI fixture corpus",
 )
 
 
@@ -188,7 +214,7 @@ def test_trace_manifest_solves_every_point(tmp_path):
                    {"model": "p1.nl", "theta": [0.0]}],
         "options": {"print_level": "0", "sb": "yes"},
     }))
-    trace = trace_manifest(man, binary=_binary(), workdir=str(tmp_path))
+    trace = trace_manifest(man, binary=_CLI, workdir=str(tmp_path))
     assert trace["n_points"] == 2
     assert trace["n_converged"] == 2
     assert all(s["status"] in (0, 1) for s in trace["steps"])
@@ -211,7 +237,7 @@ def test_cold_mode_does_not_transfer(tmp_path):
         "points": [{"model": "p0.nl"}, {"model": "p1.nl"}],
         "options": {"print_level": "0", "sb": "yes"},
     }))
-    trace = trace_manifest(man, binary=_binary(), cold=True,
+    trace = trace_manifest(man, binary=_CLI, cold=True,
                            workdir=str(tmp_path))
     assert trace["mode"] == "cold"
     assert [s["predictor"] for s in trace["steps"]] == ["cold", "cold"]
@@ -229,7 +255,8 @@ def test_cli_entry_point_runs(tmp_path):
     })
     out = str(tmp_path / "trace.json")
     proc = subprocess.run(
-        ["python", "-m", "pounce._continuation_cli", man, "--out", out],
+        [sys.executable, "-m", "pounce._continuation_cli", man,
+         "--out", out, "--binary", _CLI],
         capture_output=True, text=True,
     )
     assert proc.returncode == 0, proc.stderr

--- a/python/tests/test_gams_link.py
+++ b/python/tests/test_gams_link.py
@@ -698,3 +698,99 @@ def test_gams_pi_wyndor_shadow_prices_both_senses():
     lam = [0.0, 1.5, 1.0]  # POUNCE internal multipliers for the Wyndor optimum
     assert link.gams_pi(lam, obj_sign=-1.0) == pytest.approx([0.0, 1.5, 1.0])
     assert link.gams_pi(lam, obj_sign=1.0) == pytest.approx([0.0, -1.5, -1.0])
+
+
+# ======================================================================
+# Continuation over a GAMS path (pounce#608). The pip link builds an
+# ordinary pounce.Problem from a GMO view, so the whole driver applies;
+# these drive it on the same license-free fake as everything above.
+# ======================================================================
+
+
+class ParametricHS071View(HS071View):
+    """HS071 with the equality right-hand side as the parameter.
+
+    ``x0^2 + x1^2 + x2^2 + x3^2 == theta`` (40 in the original). A path
+    in ``theta`` is a path in the equality RHS, which is what a
+    sensitivity step's `deltas` argument means.
+    """
+
+    def __init__(self, theta, **kw):
+        super().__init__(**kw)
+        self.theta = float(theta)
+
+    def con_lower(self):
+        return [25.0, self.theta]
+
+    def con_upper(self):
+        return [POUNCE_INF, self.theta]
+
+
+def _gams_thetas(k=6):
+    return [np.array([40.0 + 0.5 * i]) for i in range(k)]
+
+
+def test_gams_continuation_traces_a_path():
+    from pounce.gams import continuation as gams_cont
+
+    thetas = _gams_thetas()
+    trace = gams_cont.trace(
+        lambda th: ParametricHS071View(float(np.asarray(th).ravel()[0]),
+                                       with_hessian=True),
+        thetas,
+        options={"tol": 1e-8, "print_level": 0, "sb": "yes"},
+    )
+    assert trace.n_steps == len(thetas)
+    assert trace.status == "ok"
+    assert all(st.status in (0, 1) for st in trace.steps)
+
+    # Every traced point matches an independent cold solve at the same
+    # parameter: a warm start may make the answer cheaper, never
+    # different. (Same contract the Pyomo adapter's tests assert.)
+    for th, st in zip(thetas, trace.steps):
+        view = ParametricHS071View(float(th[0]), with_hessian=True)
+        _gp, x, info = link.solve_view(
+            view, options={"tol": 1e-8, "print_level": 0, "sb": "yes"})
+        assert st.obj == pytest.approx(info["obj_val"], rel=1e-6)
+
+
+def test_gams_continuation_warm_start_beats_cold_on_the_path():
+    """The reason to route GAMS through the driver at all."""
+    from pounce.gams import continuation as gams_cont
+
+    thetas = _gams_thetas(8)
+    opts = {"tol": 1e-8, "print_level": 0, "sb": "yes"}
+    trace = gams_cont.trace(
+        lambda th: ParametricHS071View(float(np.asarray(th).ravel()[0]),
+                                       with_hessian=True),
+        thetas, options=opts,
+    )
+    cold = 0
+    for th in thetas:
+        _gp, _x, info = link.solve_view(
+            ParametricHS071View(float(th[0]), with_hessian=True),
+            options=opts)
+        cold += int(info["iter_count"])
+    assert trace.total_iters < cold
+
+
+def test_gams_continuation_reports_the_predictor_it_got():
+    """`pins` is what enables the tangent; without it the driver runs
+    the zero-order fallback, and says so rather than leaving it to be
+    inferred from timings."""
+    from pounce.gams import continuation as gams_cont
+
+    def view_of(th):
+        return ParametricHS071View(float(np.asarray(th).ravel()[0]),
+                                   with_hessian=True)
+
+    opts = {"tol": 1e-8, "print_level": 0, "sb": "yes"}
+    zero = gams_cont.trace(view_of, _gams_thetas(4), options=opts)
+    assert {st.predictor for st in zero.steps} == {"cold", "zero"}
+
+
+def test_gams_continuation_rejects_a_view_factory_returning_none():
+    from pounce.gams import continuation as gams_cont
+
+    with pytest.raises(TypeError, match="must return the GmoView"):
+        gams_cont.trace(lambda th: None, [np.array([40.0])])


### PR DESCRIPTION
Fixes #608

> **Body refreshed 2026-08-16.** This PR was opened from an earlier head whose body listed three acceptance criteria as not met and described #620 as still open. Both are now out of date: the branch has been completed and rebased onto `cfc1121`, all criteria are met, and every number below is re-measured on that base. The full report is on `claude/loop-report-608`.

## Problem

#90 delivered a predictor–corrector continuation engine around the held KKT factor, but only for the differentiable frontend: `pounce.jax.PathFollower` is written against `JaxProblem` and reaches for `jax.grad` / `jax.jacobian`. The same capability was not available as a reusable repeated-NLP initialization path for the generic `Problem`, Pyomo, CLI or GAMS frontends, so anyone tracing a parametric NLP sequence through those frontends rebuilt the orchestration — transfer, warm start, predictor, trace — in user code.

This is an integration issue, not a request to reimplement #90.

The measurable question underneath it is whether the tangent predictor is worth anything on an interior-point method once a plain previous-solution warm start is already in play. Measured on pounce's own warm-start corpus, **it is not**, and this PR records that as the headline rather than burying it.

| arm | iterations | vs. `warm-ipm` |
|---|---|---|
| `cold-ipm` | 2492 | +102.8% |
| `warm-ipm` (previous solution) | 1229 | — |
| `pred-ipm` (linear predictor) | 1258 | **+2.4%** |
| `predcorr-ipm` (predictor–corrector) | 1242 | **+1.1%** |

Baseline `cfc1121`, `warm_start_recentering=residual`, `mpc_horizon_{10,20,40,80}` × `{tiny,small,large}` — 12 cells, 240 solves per arm.

## Cause

The mechanism is a floor, not a tuning failure. In the continuation regime a warm-started IPM solve already converges in **one iteration per step**, so a better seed has nothing left to remove. At larger steps there is headroom, but there the active set moves and a first-order predictor is extrapolating through a kink — error `O(Δθ²)` at best and unbounded across a critical-region boundary. That is why `pred-ipm` is *reliably worse* at the `large` scale (+8.8% overall, +17.5% on `mpc_horizon_80`).

This is the interior-point analogue of the well-known result that IPMs warm-start weakly: the barrier restart, not the seed's distance from the solution, is what the iterations are spent on.

## Fix

A frontend-neutral driver, `pounce.Continuation`, running #90's loop through the public `Problem` / `Solver` API, plus adapters for Pyomo, the CLI and GAMS. `run(thetas)` traces a prescribed repeated-NLP sequence; `follow(theta_of_s, s_span)` traces an adaptive path and may accept a point on the predictor alone. `StepController` is shared verbatim with `PathFollower`, so "how far to step next" has one implementation in the tree.

Three things this branch previously stopped short of, now implemented:

**`run` subdivides.** A corrector rejection between two prescribed points used to end the trace with a runaway iterate recorded as an answer. The caller choosing the points they *want* does not forbid the driver visiting more, so `run` now halves the gap and re-predicts from the last point known good. Inserted points carry `prescribed=False` and are counted by `trace.n_inserted`; every prescribed point still appears, in order. It is a **no-op on a healthy path** — asserted, because otherwise every existing caller's step count moves silently. `subdivide_tol` adds an opt-in monitor-driven trigger, deliberately a separate knob from `monitor_tol`, whose `1e-6` default would subdivide on essentially every step.

**Pseudo-arclength past folds.** The previous stopping point was that `Solver.parametric_step` back-solves against the factor of a *converged* solve and a fold has none. That is true and it is the wrong place to stop: a dense Jacobian is not required. The tangent is the null vector of the `(d, d+1)` augmented matrix `[∂R/∂z | ∂R/∂θ]`, obtained by **bordering** it with the previous tangent and solving

```
[ ∂R/∂z   ∂R/∂θ ] [ t ]   [ 0 ]
[     t_prevᵀ   ]       = [ 1 ]
```

which is nonsingular *at* a simple fold — that is the point of the pseudo-arclength formulation — and needs no SVD, unlike #90's dense route. `R` and its Jacobian are assembled sparsely from the problem's own cyipopt-shaped callbacks; the Hessian of the Lagrangian is exactly `∂/∂x` of the stationarity block, so nothing is approximated and no third derivative appears.

*Rejected alternatives, so the experiment is not repeated.* Reusing the held factor cannot work: past a fold there is no solution at that `θ` for any factor to belong to. Posing the arclength step as an NLP (`min f` subject to the constraints plus the arclength row, with `θ` a variable) is **wrong**, not merely inconvenient — stationarity in `θ` then forces `λ = ν·t_θ`, which is not the original curve. It has to be a root-find on the KKT system, which is what this does.

*The cost, measured and stated:* one sparse LU per Newton iteration, where parameter continuation gets a back-solve against a factor the solver already built. That is the price of going round the corner at all.

**CLI and GAMS.** #608's scope note names the mechanism — "CLI/GAMS can follow using a path manifest or repeated-solve protocol" — and both are now built. `pounce-continue path.json` traces a whole path: one command, one report, one process per point.

There is **no tangent predictor on the CLI path and there cannot be**: the predictor is a back-solve against a factor that does not survive `exec`. The trace reports the predictor as absent rather than leaving it to be inferred. What *does* cross the boundary is more than the primal point — an AMPL `.nl` carries an initial primal point (`x` segment) *and* initial duals (`d` segment), both honoured by pounce's reader — so the transfer is primal-dual, missing only the bound multipliers and the barrier parameter, which `.nl` has nowhere to put.

`pounce.gams.continuation.trace` routes a GAMS path through the same driver. The pip link builds an ordinary `Problem` from a GMO view, so driven from one Python process GAMS gets the **whole** driver, tangent predictor included.

## Blast radius

**No Rust changed.** `git diff cfc11218 --name-only` matches nothing under `crates/`, so the CLI binary is unchanged and the fixture sweep is empty by construction. Run anyway, both binaries built from this tree:

```
scripts/sweep-fixtures.sh <cfc1121 binary> /tmp/sweep-base.txt
scripts/sweep-fixtures.sh target/release/pounce /tmp/sweep-new.txt
diff → empty, 0 lines moved across 57 fixtures
```

The sweep was also run in the regime that reaches the changed code — the benchmark corpus with the continuation arms on, 240 solves per arm at two `warm_start_recentering` settings — and the pre-existing arms were checked against the parent directly. Running `cfc1121`'s own `benchmarks/` tree (which drives `Problem.solve`) against this branch's (which drives `pounce.Solver`, so the predictor can reach the factor the solve leaves behind):

```
cold-ipm + warm-ipm steps compared   : 480
identical in BOTH iters and objective: 480
differing                            : 0
```

So rerouting the adapter through `pounce.Solver` is **bit-identical** on the two pre-existing arms.

Python-side blast radius: `link.solve_view` was split, with its problem construction extracted as `problem_from_view`. Behaviour is unchanged and the existing `test_gams_link.py` suite (80 tests) covers it.

## Verification

### The four-way benchmark, at both recentering settings

Baseline **`cfc1121`**. `warm_start_recentering` is swept because the warm baseline is what every margin here is quoted against, and #606/#620 is the merge most likely to have moved it.

**`recentering=residual`**

| family | scale | cold | warm | pred | predcorr | pred vs warm | predcorr vs warm |
|---|---|---|---|---|---|---|---|
| mpc_horizon_10 | tiny | 155 | 28 | 28 | 28 | +0.0% | +0.0% |
| mpc_horizon_10 | small | 172 | 46 | 40 | 41 | −13.0% | −10.9% |
| mpc_horizon_10 | large | 170 | 104 | 100 | 100 | −3.8% | −3.8% |
| mpc_horizon_20 | tiny | 178 | 39 | 36 | 36 | −7.7% | −7.7% |
| mpc_horizon_20 | small | 192 | 98 | 101 | 112 | +3.1% | +14.3% |
| mpc_horizon_20 | large | 189 | 152 | 165 | 153 | +8.6% | +0.7% |
| mpc_horizon_40 | tiny | 214 | 39 | 37 | 38 | −5.1% | −2.6% |
| mpc_horizon_40 | small | 224 | 111 | 92 | 117 | −17.1% | +5.4% |
| mpc_horizon_40 | large | 233 | 215 | 228 | 214 | +6.0% | −0.5% |
| mpc_horizon_80 | tiny | 255 | 49 | 44 | 45 | −10.2% | −8.2% |
| mpc_horizon_80 | small | 264 | 125 | 125 | 135 | +0.0% | +8.0% |
| mpc_horizon_80 | large | 246 | 223 | 262 | 223 | +17.5% | +0.0% |
| **total** | | **2492** | **1229** | **1258** | **1242** | **+2.4%** | **+1.1%** |

**`recentering=none`**

| family | scale | cold | warm | pred | predcorr | pred vs warm | predcorr vs warm |
|---|---|---|---|---|---|---|---|
| mpc_horizon_10 | tiny | 155 | 28 | 28 | 28 | +0.0% | +0.0% |
| mpc_horizon_10 | small | 172 | 46 | 40 | 41 | −13.0% | −10.9% |
| mpc_horizon_10 | large | 170 | 104 | 100 | 100 | −3.8% | −3.8% |
| mpc_horizon_20 | tiny | 178 | 39 | 36 | 36 | −7.7% | −7.7% |
| mpc_horizon_20 | small | 192 | 98 | 101 | 96 | +3.1% | −2.0% |
| mpc_horizon_20 | large | 189 | 152 | 165 | 152 | +8.6% | +0.0% |
| mpc_horizon_40 | tiny | 214 | 39 | 37 | 36 | −5.1% | −7.7% |
| mpc_horizon_40 | small | 224 | 111 | 92 | 120 | −17.1% | +8.1% |
| mpc_horizon_40 | large | 233 | 215 | 227 | 213 | +5.6% | −0.9% |
| mpc_horizon_80 | tiny | 255 | 49 | 44 | 44 | −10.2% | −10.2% |
| mpc_horizon_80 | small | 264 | 125 | 125 | 128 | +0.0% | +2.4% |
| mpc_horizon_80 | large | 246 | 223 | 262 | 221 | +17.5% | −0.9% |
| **total** | | **2492** | **1229** | **1257** | **1215** | **+2.3%** | **−1.1%** |

By step scale, `recentering=residual`:

| scale | cold | warm | pred | predcorr |
|---|---|---|---|---|
| tiny | 802 | 155 | 145 (−6.5%) | 147 (−5.2%) |
| small | 852 | 380 | 358 (−5.8%) | 405 (+6.6%) |
| large | 838 | 694 | 755 (**+8.8%**) | 690 (−0.6%) |

### The named failure mode did not occur, and here is the evidence

The previous report warned: *"If it raises early-iteration counts on some paths, the predictor could look better without being better — which is the failure mode to watch for."*

It did not happen, and the reason is mechanical rather than lucky. Between the two recentering settings, per-step iteration counts differ on:

| arm | steps differing | steps identical |
|---|---|---|
| `cold-ipm` | **0** | 240 |
| `warm-ipm` | **0** | 240 |
| `pred-ipm` | 1 | 239 |
| `predcorr-ipm` | **14** | 226 |

`warm_start_recentering` measures the supplied iterate and adapts to how far off-centre it is. `predcorr-ipm` is the only arm that supplies a *perturbed* multiplier seed — the previous solution stepped along the tangent — so it is the only arm with anything for that measurement to act on. The others hand over either a cold point or an exactly-converged one, and on these single-block, zero-inequality-row models (22–162 equality rows, 0 inequality rows) there is nothing to change.

Consequently the **warm baseline is 1229 at both settings**. The `−1.1%` at `recentering=none` is not a better predictor; it is the same predictor with its off-centre dual seed left alone, landing better on 14 steps, against an identical baseline. The predictor cannot "look better because the baseline rose", because the baseline did not rise.

The baseline *did* move against the previous measurement on `70bf53de` (warm 1097 → 1229, cold 2360 → 2492, +12% / +5.6%). Since `recentering=none` is by definition pre-#606 behaviour and reproduces 1229 **exactly**, #606/#620 contributes **none** of that move; it comes from the other merges in between (#605/#619, #602/#614, #607/#623).

### The fold fixture

`min x₀³/3 + x₁²/2` s.t. `x₀ + x₁ = θ`. Stationarity gives `λ = −x₀²` and `x₁ = x₀²`, so the solution curve is `x₀ + x₀² = θ`, folding at **`x₀ = −1/2, θ = −1/4`**. Built so LICQ holds at the fold (`∇g = (1,1)`) and `λ = −1/4` stays finite there — a fold resting on a vanishing constraint gradient sends `λ` to infinity and no arclength scheme in `(x, λ, θ)` passes it, which would be a fixture built to flatter the method rather than test it.

| | result |
|---|---|
| `run`, θ: 2.0 → 1.0 → 0.0 → −0.4, `subdivide=False` | **fails** at θ = −0.4, `Diverging_Iterates`, x₀ ≈ −9.9×10¹⁰ |
| `run`, same path, `subdivide=True` | walks in via θ = −0.200, −0.250 (x₀ = −0.499945), fails at θ = −0.251172; `subdivision_exhausted`, 3 inserted points, 10 rejections absorbed — **locates the fold to 1.2×10⁻³** and returns 3 extra valid solutions where the un-subdivided path returned one garbage one |
| `trace_arclength`, same start, `ds=0.25` | **traverses**: θ decreases to −0.239, turns, and increases again while x₀ continues past −1/2 to −5.97 (41 points); every accepted point satisfies `x₀ + x₀² = θ` and `‖R‖∞ ≤ 7.0×10⁻¹⁰` |
| `trace_arclength`, `ds=0.02` | localises the turning point to θ_min = −0.249994, i.e. `|θ_min − (−1/4)| = 6×10⁻⁶` — the discretisation is the only thing keeping it off the exact fold (the test asserts < 10⁻³) |

### What the CLI / GAMS path is measured to be worth

20-point van der Pol NMPC path, horizon 40 (n = 122, m = 82), against repeated cold `pounce model.nl` invocations:

| | iterations | evaluations | wall (mean of 3) |
|---|---|---|---|
| repeated cold | 226 | 1230 | 233 ms |
| `pounce-continue` | 193 | 1166 | 221 ms |
| | **−14.6%** | **−5.2%** | **−5%** |

Iteration counts are exactly reproducible run to run (226/193 on all three repeats); the wall-clock spread overlaps. The gap between −14.6% of iterations and −5% of wall clock is process startup, `.nl` parse and presolve, which at these sizes dominate the solve. Repeating at horizon 300 (n = 902) moves the iteration saving not at all (225 → 193) and the wall time not at all (705 → 713 ms). **If you are paying per process, that overhead is what you are paying, and the warm transfer does not address it.**

One trap worth recording: a linear-quadratic MPC is a convex QP, and the CLI routes convex QPs to `pounce-convex`, which never reaches the NLP warm-start path. Measured on an LQ path the answer is exactly 0% — for that reason, not the interesting one. The fixture uses van der Pol dynamics because of it.

**GAMS.** The native C link's `sqp_state_file` does **not** carry more than the pip link for this purpose, and the source says so precisely: it holds the discrete working set only — one byte of `bound_status` per variable and one of `cons_status` per constraint, behind a magic string and a checksum over `(n, m, bounds)`. No primal point, no multipliers, no barrier parameter; it feeds `IpoptSetWarmStartWorkingSet` on the active-set SQP path. For interior-point continuation that is strictly *less* than the pip link already holds in memory, and the checksum over the bounds is invalidated by exactly the horizon shifts and remeshes the transfer map exists to serve.

### Fixture sweep

Empty diff, 0 lines moved across 57 fixtures, baseline `cfc1121`. No Rust source changed, so this is expected by construction; it was run rather than argued because "it cannot produce a wrong answer" is not the relevant safety property.

## Tests

`python/tests/test_continuation.py` grows from 21 to 32 tests. The 11 new ones **fail on the parent commit** (`ce04c00b`) for the right reason: `AttributeError: 'Continuation' object has no attribute 'trace_arclength'` for the six arclength tests, and `TypeError: Continuation.run() got an unexpected keyword argument 'subdivide'` for the five subdivision tests. The 21 pre-existing tests pass on the parent unchanged.

New files: `python/tests/test_continuation_cli.py` (13 tests — manifest parsing, the `.nl` initial-point rewrite, `.sol` parsing, and three end-to-end traces gated on a built binary plus the fixture corpus). `python/tests/test_gams_link.py` gains 4 continuation tests driving the same license-free in-memory `GmoView` fake the rest of that file uses, so the GAMS path is covered without a GAMS install.

Deliberately not pinned:

- **The benchmark numbers themselves.** They move with the solver and are recorded in `docs/src/continuation.md` with their baseline commit, not asserted in a test.
- **The live `gamsapi` adapter** (`solve_from_control_file`), unchanged here and still the only CI-untestable surface in the GAMS link.
- **Wall-clock figures.** Reported as a mean of three with the spread stated; not asserted.

### CI fix, and a coverage gap it exposed

The first CI run failed two of the new CLI tests (`assert 0 == 2`, and a non-zero return code). Both were test defects, fixed in `d628c4b`:

- `shutil.which("pounce")` finds the wheel's **console-script shim**, which exists whenever `pounce-solver` is installed but only execs a real binary when the wheel was built with `pounce/bin/` staged. CI builds the wheel straight from `maturin-action` with no staging step, so the shim was on `PATH`, the `needs_cli` guard passed, every solve exited 1, and the failure arrived as an assertion rather than a skip. The guard now probes the candidate with `--version` and accepts only one that runs.
- The entry-point test shelled out to bare `python` rather than `sys.executable`, picking up an interpreter without numpy.

Verified both ways: with a working binary all 13 pass; with a failing shim on `PATH` and no built binary the three end-to-end tests skip with a reason that names the cause.

**The gap this leaves, stated rather than hidden:** because the Python CI jobs install a wheel with no staged CLI, the three end-to-end trace tests **skip in CI** and are only exercised where a real binary is present. The manifest parser, `.nl` rewrite and `.sol` parsing — the parts with logic in them — run everywhere.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated, and linked from `SUMMARY.md`
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean (`cargo test --workspace --exclude pounce-hsl`: 2950 passed, 0 failed; `python/tests`: 1055 passed, 19 skipped; `pyomo-pounce/tests`: 294 passed, 6 skipped; `check-release-consistency.sh` and `check-docs-consistency.sh` both OK)
- [x] Every claim in this body is true of the code as it stands now

---

## Acceptance criteria

### The four criteria from #608

1. **"A parametric NLP sequence can be traced through the generic `Problem` API without rebuilding orchestration in user code."** — **MET.** `pounce.Continuation(update, pins=...).run(thetas)` / `.follow(theta_of_s, s_span)`. Covered by `python/tests/test_continuation.py`.

2. **"A Pyomo MPC/horizon-shift example supplies a transfer map and reuses primal/dual/barrier state."** — **MET.** `pyomo_pounce.continuation` with `shift_map(shift=k)`; the corrector reuses Var values plus the `dual` / `ipopt_zL_in` / `ipopt_zU_in` suffixes and the previous barrier `μ`. Covered by `pyomo-pounce/tests/test_continuation.py`, which checks every traced objective against an independent cold solve at the same parameter.

3. **"The driver reports predictor residual, corrections, step rejections, active-set events, and total evaluations."** — **MET.** `ContinuationTrace.{n_corrections, n_rejections, n_active_set_events, total_evals}` plus per-step `predictor_residual`; `n_inserted` was added for subdivision. `trace.report()` prints all of them.

4. **"Benchmarks compare cold solve, previous-solution warm start, linear predictor, and predictor-corrector."** — **MET.** `cold-ipm`, `warm-ipm`, `pred-ipm`, `predcorr-ipm` in `benchmarks/warmstart`, tabulated above at two `warm_start_recentering` settings.

### The scope bullets

| bullet | status |
|---|---|
| accepts a parameter path `theta(s)` and a callback/model update | **MET** — `update(theta) -> Problem`; `follow` takes `theta_of_s` |
| transfers the complete previous iterate | **MET** — `WarmStart.from_info` carries `x`, `λ`, `z_L`, `z_U`, `μ` |
| uses sensitivity/KKT solves for a tangent predictor when available | **MET** — `Solver.parametric_step` / `parametric_step_full` under `pins=` |
| applies an explicit user transfer/prolongation map for horizon or mesh changes | **MET** — `transfer=` on #607's `WarmStart.transfer` mapper protocol; `shift_map` on the Pyomo side |
| performs a warm-started corrector | **MET** — every corrected step |
| adapts step size from residuals and corrector work | **MET** — `StepController` in `follow`; `run` subdivides on rejection and (opt-in) on the monitor |
| detects active-set events and reanchors | **MET** — bound-multiplier fingerprint; `StepController.corrected(..., active_set_event=True)` drops back to `ds0` |
| optionally supports pseudo-arclength near folds | **MET** — `trace_arclength`, traversal demonstrated above. Scope is #90's v1: scalar `θ`, equality/unconstrained, fixed active set |
| falls back to zero-order warm transfer when sensitivities are unavailable | **MET** — omit `pins`; `has_tangent` reports which you got |
| thin adapters for generic `Problem` and Pyomo first | **MET** |
| CLI/GAMS follow using a path manifest or repeated-solve protocol | **MET** — `pounce-continue` + manifest v1; `pounce.gams.continuation.trace` |

### Not met

None of the four acceptance criteria or scope bullets is unmet.

Three things are **out of scope by design**, stated so the boundary is a known one rather than a silent gap — all three are also out of scope in #90, and none is a deferral of work this issue asked for:

- **Bifurcation detection and branch switching.** `trace_arclength` follows the branch it starts on. At a bifurcation (as opposed to a simple fold) the bordered matrix is singular and the trace stops rather than picking a branch.
- **Folds with a moving active set.** The arclength residual `R` treats every general row as an active equality, so two-sided inequality rows are rejected with an explicit error rather than mis-traced.
- **Vector-parameter arclength.** "Past the fold" is not defined for a solution manifold of dimension > 1; the driver raises and says to reparametrise onto a scalar path.

### On the verdict

The loop report's `VERDICT: no-improvement` refers to the measured question the benchmark asks — **does the tangent predictor beat a previous-solution warm start on an interior-point method?** It does not: +2.4% / +1.1% at `recentering=residual`, +2.3% / −1.1% at `=none`, all inside ±3%, and reliably worse (+17.5%) at the largest step scale. That verdict now covers a *complete* implementation rather than a partial one, which makes it stronger, not weaker: the arclength mode, the subdivision and the CLI/GAMS adapters all landed and none of them changes the answer to that question.

What the branch *is* worth is separable from that and is positive: warm starting itself is 2.03×; `follow` skips solves outright; `run` subdivision turns a diverging trace into three extra valid solutions and a fold located to 1.2×10⁻³; `trace_arclength` reaches a branch parameter continuation cannot see at all; and the CLI path is −14.6% iterations against repeated cold invocations. None of those is the predictor beating warm start, and this body does not present them as if they were.