### PR TITLE
Make the C API's Bool one byte, as pounce.h declares

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ changes.
 
 ## [Unreleased]
 
+- **`Bool` in the C API is one byte again, matching the header** (#624
+  follow-up). `pounce.h` declares `typedef bool Bool` — the C99 `bool`,
+  which is what Ipopt 3.14's `IpStdCInterface.h` uses and what makes the
+  header a source-level drop-in. The Rust implementation behind it used
+  `c_int`. Four bytes against one, in both directions, for every boolean
+  the C API exchanges.
+
+  Nothing observably misbehaved, and that is the uncomfortable part: on
+  x86-64 both gcc and clang zero-extend a `bool` return, so the values
+  came through. The psABI does not require it. It leaves the upper bits
+  of a `bool` return unspecified, which means a callback answering
+  `false` — *"I cannot evaluate at this point"* — was one compiler
+  decision away from being read as a nonzero, i.e. as success, and the
+  solver would accept a point it had been told was unusable instead of
+  cutting the step. The affected callers are real: the GAMS C link
+  (`static bool gams_eval_f(..., bool new_x, ...)`) and the CasADi plugin
+  both declare their callbacks with C99 `bool`, as the header instructs.
+
+  `Bool` is now `u8` — same layout as `_Bool`, but without Rust `bool`'s
+  validity invariant, so a caller arriving with something other than 0 or
+  1 (an older header where `Bool` was `int`, a hand-rolled binding) is
+  tested the way C would test it rather than being undefined behaviour.
+  The Fortran interface is unaffected; it never used this type.
+
+  `crates/pounce-cinterface/tests/header_abi.rs` now reads the typedefs
+  out of the shipped header and checks each against the implementation,
+  so editing either side alone fails the build rather than drifting. Both
+  of its tests fail on the parent commit, naming the size mismatch.
+
 - **Predictor-corrector NLP continuation, exposed across the non-AD
   frontends** (#608). #90 delivered a path follower, but only for the
   differentiable frontend: `pounce.jax.PathFollower` is written against

--- a/crates/pounce-cinterface/src/fortran.rs
+++ b/crates/pounce-cinterface/src/fortran.rs
@@ -18,7 +18,7 @@
 //! the buffer with trailing-space stripping ([`f2cstr`]).
 
 use crate::{
-    AddIpoptIntOption, AddIpoptNumOption, AddIpoptStrOption, CreateIpoptProblem, Eval_F_CB,
+    AddIpoptIntOption, AddIpoptNumOption, AddIpoptStrOption, Bool, CreateIpoptProblem, Eval_F_CB,
     Eval_G_CB, Eval_Grad_F_CB, Eval_H_CB, Eval_Jac_G_CB, FreeIpoptProblem, Index, Intermediate_CB,
     IpoptProblem, IpoptSolve, Number, SetIntermediateCallback,
 };
@@ -137,10 +137,10 @@ pub type FIntermediate_CB = unsafe extern "C" fn(
 unsafe extern "C" fn c_eval_f(
     n: Index,
     x: *const Number,
-    new_x: c_int,
+    new_x: Bool,
     obj_value: *mut Number,
     user_data: *mut c_void,
-) -> c_int {
+) -> Bool {
     unsafe {
         let fud = &mut *(user_data as *mut FortranUserData);
         let mut ierr: Index = 0;
@@ -162,10 +162,10 @@ unsafe extern "C" fn c_eval_f(
 unsafe extern "C" fn c_eval_grad_f(
     n: Index,
     x: *const Number,
-    new_x: c_int,
+    new_x: Bool,
     grad_f: *mut Number,
     user_data: *mut c_void,
-) -> c_int {
+) -> Bool {
     unsafe {
         let fud = &mut *(user_data as *mut FortranUserData);
         let mut ierr: Index = 0;
@@ -187,11 +187,11 @@ unsafe extern "C" fn c_eval_grad_f(
 unsafe extern "C" fn c_eval_g(
     n: Index,
     x: *const Number,
-    new_x: c_int,
+    new_x: Bool,
     m: Index,
     g: *mut Number,
     user_data: *mut c_void,
-) -> c_int {
+) -> Bool {
     unsafe {
         let fud = &mut *(user_data as *mut FortranUserData);
         let Some(cb) = fud.eval_g else {
@@ -218,14 +218,14 @@ unsafe extern "C" fn c_eval_g(
 unsafe extern "C" fn c_eval_jac_g(
     n: Index,
     x: *const Number,
-    new_x: c_int,
+    new_x: Bool,
     m: Index,
     nele_jac: Index,
     irow: *mut Index,
     jcol: *mut Index,
     values: *mut Number,
     user_data: *mut c_void,
-) -> c_int {
+) -> Bool {
     unsafe {
         let fud = &mut *(user_data as *mut FortranUserData);
         let Some(cb) = fud.eval_jac_g else {
@@ -265,17 +265,17 @@ unsafe extern "C" fn c_eval_jac_g(
 unsafe extern "C" fn c_eval_h(
     n: Index,
     x: *const Number,
-    new_x: c_int,
+    new_x: Bool,
     obj_factor: Number,
     m: Index,
     lambda: *const Number,
-    new_lambda: c_int,
+    new_lambda: Bool,
     nele_hess: Index,
     irow: *mut Index,
     jcol: *mut Index,
     values: *mut Number,
     user_data: *mut c_void,
-) -> c_int {
+) -> Bool {
     unsafe {
         let fud = &mut *(user_data as *mut FortranUserData);
         let Some(cb) = fud.eval_hess else {
@@ -329,7 +329,7 @@ unsafe extern "C" fn c_intermediate(
     alpha_pr: Number,
     ls_trials: Index,
     user_data: *mut c_void,
-) -> c_int {
+) -> Bool {
     unsafe {
         let fud = &mut *(user_data as *mut FortranUserData);
         let Some(cb) = fud.intermediate_cb else {
@@ -594,8 +594,7 @@ pub unsafe extern "C" fn ipsetcallback_(fproblem: *mut *mut c_void, inter_cb: FI
         }
         let fud = &mut *(*fproblem as *mut FortranUserData);
         fud.intermediate_cb = Some(inter_cb);
-        let _: Index =
-            SetIntermediateCallback(fud.problem, Some(c_intermediate as Intermediate_CB));
+        let _: Bool = SetIntermediateCallback(fud.problem, Some(c_intermediate as Intermediate_CB));
     }
 }
 
@@ -611,7 +610,7 @@ pub unsafe extern "C" fn ipunsetcallback_(fproblem: *mut *mut c_void) {
         }
         let fud = &mut *(*fproblem as *mut FortranUserData);
         fud.intermediate_cb = None;
-        let _: Index = SetIntermediateCallback(fud.problem, None);
+        let _: Bool = SetIntermediateCallback(fud.problem, None);
     }
 }
 

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -57,11 +57,43 @@ use std::rc::Rc;
 pub type Number = f64;
 /// Mirrors C `Index`.
 pub type Index = c_int;
-/// Mirrors C `Bool`.
-pub type Bool = c_int;
+/// Mirrors C `Bool`, which `pounce.h` — like Ipopt 3.14's
+/// `IpStdCInterface.h` — declares as the C99 `bool`. That is **one byte**,
+/// so this is `u8` and not `c_int`.
+///
+/// It was `c_int` until gh#624, i.e. four bytes on the Rust side against
+/// one on every C caller's, in both directions:
+///
+/// * a callback returning `false` sets only `AL`, and the x86-64 psABI
+///   leaves the rest of `EAX` unspecified — read as an `i32`, a failed
+///   evaluation could come back nonzero, which reads as *success*. The
+///   solver would then accept a point it was told it could not evaluate
+///   instead of cutting the step. gcc and clang emit `movzbl`, which is
+///   why this stayed latent rather than exploding;
+/// * an *array* of them would have been a hard stride bug, 1-byte
+///   elements read at 4-byte spacing. That is why
+///   [`IpoptSetNonlinearVariables`] takes a count plus an index list
+///   rather than the `Bool` mask gh#624 originally proposed.
+///
+/// `u8` rather than Rust's `bool` on purpose: the two have identical
+/// layout, but `bool` carries a validity invariant (it *must* hold 0 or
+/// 1), and a C caller reaching this boundary with anything else — an
+/// older header where `Bool` was `int`, a hand-rolled binding, a value
+/// that came through a `memcpy` — would be instant undefined behaviour.
+/// `u8` accepts whatever arrives and tests it the way C does, which is
+/// the same reason the entry points validate rather than trust.
+pub type Bool = u8;
 
 const TRUE: Bool = 1;
 const FALSE: Bool = 0;
+
+// The whole point of the alias. `pounce.h` says `typedef bool Bool`, so a
+// build where this stops being one byte is one where every C caller
+// disagrees with the implementation about every boolean.
+const _: () = assert!(
+    core::mem::size_of::<Bool>() == 1,
+    "Bool must be one byte to match `typedef bool Bool` in pounce.h"
+);
 
 /// Run an FFI entry-point body, converting any Rust panic into `fallback`
 /// rather than letting it unwind across the `extern "C"` boundary — which is

--- a/crates/pounce-cinterface/tests/header_abi.rs
+++ b/crates/pounce-cinterface/tests/header_abi.rs
@@ -1,0 +1,110 @@
+//! The header and the implementation must agree about the width of every
+//! scalar they exchange (gh#624).
+//!
+//! `pounce.h` is the contract: a C caller compiles against it and gets
+//! whatever it says. Nothing else checks that the Rust side agrees, and
+//! for `Bool` it did not — the header said `typedef bool Bool` (one byte,
+//! matching Ipopt 3.14) while the implementation used `c_int` (four).
+//! Both sides "worked" because x86-64 compilers zero-extend booleans in
+//! practice, but the psABI leaves the upper bits of a `bool` return
+//! unspecified, so a callback answering `false` — *"I cannot evaluate
+//! here"* — was one compiler decision away from being read as success.
+//!
+//! This test reads the typedefs out of the shipped header rather than
+//! restating them, so editing either side alone fails here.
+
+use std::collections::HashMap;
+
+/// Width of each C type the header is allowed to alias, on the platforms
+/// pounce targets (LP64 / LLP64 — `int` is 4 bytes on both).
+fn c_type_size(c_type: &str) -> Option<usize> {
+    Some(match c_type {
+        "bool" => 1,
+        "int" => 4,
+        "double" => 8,
+        "float" => 4,
+        "int64_t" => 8,
+        _ => return None,
+    })
+}
+
+/// Pull `typedef <c_type> <alias>;` pairs out of the header.
+fn header_typedefs() -> HashMap<String, String> {
+    let header = include_str!("../include/pounce.h");
+    let mut out = HashMap::new();
+    for line in header.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("typedef ") else {
+            continue;
+        };
+        let Some(decl) = rest.strip_suffix(';') else {
+            continue;
+        };
+        // `typedef ipnumber Number;` → ("ipnumber", "Number"). Skip
+        // function-pointer and struct typedefs, which have punctuation.
+        let words: Vec<&str> = decl.split_whitespace().collect();
+        if words.len() != 2 || words.iter().any(|w| w.contains(['(', ')', '*'])) {
+            continue;
+        }
+        out.insert(words[1].to_string(), words[0].to_string());
+    }
+    out
+}
+
+/// Resolve an alias chain (`Number` → `ipnumber` → `double`) to a width.
+fn declared_size(alias: &str, typedefs: &HashMap<String, String>) -> usize {
+    let mut name = alias.to_string();
+    for _ in 0..8 {
+        if let Some(size) = c_type_size(&name) {
+            return size;
+        }
+        name = typedefs
+            .get(&name)
+            .unwrap_or_else(|| panic!("`{alias}` resolves to unknown C type `{name}`"))
+            .clone();
+    }
+    panic!("typedef chain for `{alias}` does not terminate");
+}
+
+#[test]
+fn header_scalars_match_the_implementation() {
+    let typedefs = header_typedefs();
+
+    for (alias, rust_size) in [
+        ("Bool", size_of::<pounce_cinterface::Bool>()),
+        ("Index", size_of::<pounce_cinterface::Index>()),
+        ("Number", size_of::<pounce_cinterface::Number>()),
+        ("ipindex", size_of::<pounce_cinterface::Index>()),
+        ("ipnumber", size_of::<pounce_cinterface::Number>()),
+    ] {
+        let header_size = declared_size(alias, &typedefs);
+        assert_eq!(
+            header_size,
+            rust_size,
+            "pounce.h declares `{alias}` as {header_size} byte(s) via `{}`, \
+             but the implementation uses {rust_size}. Every C caller compiled \
+             against the header would disagree with this library about every \
+             `{alias}` it passes or returns.",
+            typedefs.get(alias).map(String::as_str).unwrap_or(alias),
+        );
+    }
+}
+
+/// The specific pairing gh#624 got wrong, spelled out so a future edit to
+/// either side names the reason rather than just a size.
+#[test]
+fn bool_is_the_c99_bool_the_header_promises() {
+    let typedefs = header_typedefs();
+    assert_eq!(
+        typedefs.get("Bool").map(String::as_str),
+        Some("bool"),
+        "pounce.h must keep `typedef bool Bool` — it is what Ipopt 3.14's \
+         IpStdCInterface.h declares, and source-level drop-in compatibility \
+         for cyipopt / GAMS / the CasADi plugin depends on it"
+    );
+    assert_eq!(
+        size_of::<pounce_cinterface::Bool>(),
+        1,
+        "the Rust side must be one byte to match"
+    );
+}


### PR DESCRIPTION
Found while building the CasADi plugin in #626, and deliberately kept out of it: this touches every `extern "C"` boolean in the crate and deserves to be reviewable on its own.

## Problem

`pounce.h` and the implementation disagree about the width of every boolean the C API exchanges.

```c
/* crates/pounce-cinterface/include/pounce.h */
typedef bool     Bool;          /* C99 bool — one byte */
```

```rust
// crates/pounce-cinterface/src/lib.rs
pub type Bool = c_int;          // four
```

Measured on this machine:

```
$ gcc -I crates/pounce-cinterface/include ...
C side:    sizeof(Bool)=1
Rust side: sizeof(Bool)=4
```

The header is the side that is right: Ipopt 3.14's `IpStdCInterface.h` uses C99 `bool` throughout, and matching it is what makes `pounce.h` a source-level drop-in for cyipopt / GAMS / any Ipopt C driver.

**Nothing observably misbehaves today**, and that is the uncomfortable part rather than a reason to shrug. On x86-64 both gcc and clang zero-extend a `bool` return, so values arrive intact and every existing test passes. The psABI does not require that — it leaves the upper bits of a `bool` return *unspecified*. A callback answering `false` (*"I cannot evaluate at this point"*) is therefore one compiler decision away from being read as nonzero, i.e. as **success**, at which point the solver accepts a point it was explicitly told was unusable instead of cutting the step. That is a silent-wrong-answer failure mode, not a crash.

I could not produce a miscompilation on this toolchain, and I would rather say so than imply I had.

The exposed callers are not hypothetical. Both C consumers in this repository declare their callbacks with C99 `bool`, exactly as the header instructs:

```c
/* gams/gams_pounce.c */
static bool gams_eval_f(ipindex n, ipnumber *x, bool new_x, ...)
```

and the CasADi plugin's `Eval_*_CB` implementations do the same.

It is also the reason `IpoptSetNonlinearVariables` (in #626) takes a count plus an index list rather than the `const Bool*` mask [#624](https://github.com/jkitchin/pounce/issues/624) proposed: for a scalar the mismatch is survivable, but an **array** of 1-byte values read at 4-byte stride is a hard bug, not a latent one.

## Fix

`pub type Bool = u8;`

`u8` rather than Rust's `bool`, on purpose. The two have identical layout, but `bool` carries a validity invariant — it *must* hold 0 or 1 — and a caller reaching this boundary with anything else (an older header where `Bool` was `int`, a hand-rolled binding, a value that came through a `memcpy`) would be instant undefined behaviour. `u8` accepts whatever arrives and tests it the way C does, which is the same principle the entry points already follow when they validate arguments rather than trusting them.

Existing Rust-side callers that return `1` / `0` are unaffected — the literals infer.

The Fortran interface never used this type. Its *bridge* callbacks, which are handed to `CreateIpoptProblem`, spelled the C API's booleans as `c_int`; those move to `Bool` so they keep matching the signatures they are installed into.

## Blast radius

Confined to the C API's boolean type. No algorithm, solver or numerical path is touched, so there is no trajectory question here and no fixture sweep: `cargo test -p pounce-cinterface` covers the surface that changed, and the two C/C++ consumers below exercise it end to end.

Callers who had *worked around* the old width by declaring their own callbacks with `int` would now be the mismatched ones — but that is a caller contradicting the shipped header, and the header has always said `bool`.

## Tests

- `crates/pounce-cinterface/tests/header_abi.rs` (new) reads the `typedef` lines out of the shipped header, resolves each alias chain (`Number` → `ipnumber` → `double`), and checks the width against the Rust type. Editing either side alone now fails rather than drifting apart. Both tests fail on the parent commit, naming the problem:

  ```
  assertion `left == right` failed: pounce.h declares `Bool` as 1 byte(s)
  via `bool`, but the implementation uses 4. Every C caller compiled
  against the header would disagree with this library about every `Bool`
  it passes or returns.
  ```

- A `const _: () = assert!(size_of::<Bool>() == 1)` in `lib.rs` makes the same guarantee a compile error rather than a test failure.
- `cargo test -p pounce-cinterface` — 57 tests across 4 binaries, clean. `cargo clippy` and `cargo fmt --check` clean.

Verified beyond the suite, because the point of this change is the C boundary:

- **A real C driver.** `crates/pounce-cinterface/examples/sqp_warm_start.c` compiled against the header and run: 4/4 warm-started solves succeed, `sum(x) = 1.000000000`.
- **A real C++ consumer.** The CasADi plugin from #626 rebuilt against this library and its 29-check parity suite run against CasADi's bundled Ipopt — all pass. That plugin returns C++ `bool` from every callback, so it is precisely the case this fixes.
- **The GAMS link** could not be compiled here (`gmomcc.h` is not installed in this environment), so it is verified by inspection only: its callbacks are declared `static bool ...(bool new_x, ...)`, which this change brings into agreement with the implementation rather than away from it. Worth a build by someone with GAMS before merge.

## Interaction with #626

Independent, and expected to merge cleanly in either order — #626 does not touch the typedef block. Whichever lands second, the other's plugin/tests keep working: the CasADi plugin's callbacks are C++ `bool` either way, correct after this change and accidentally-correct before it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UidFuAxfs4UMQ5LDpJu5XQ)_