### PR TITLE
qp: abandon a homotopy path that cycles on bound re-prunes (#615)

### DIFF
--- a/crates/pounce-qp/src/homotopy.rs
+++ b/crates/pounce-qp/src/homotopy.rs
@@ -93,6 +93,40 @@ const RELAX_MARGIN: Number = 1.0;
 /// How close to `1` counts as having reached the end of the path.
 const T_EPS: Number = 1e-12;
 
+/// Bound *re*-prunes a path may spend before it is declared to be cycling and
+/// abandoned (gh #615).
+///
+/// A *re*-prune is a rank repair dropping a bound this path already dropped
+/// once — see `pruned_once` in [`ParametricActiveSetSolver::trace_path`]. One or
+/// two are ordinary: the path left a bound, came back to it, and the geometry at
+/// the second visit was genuinely different. Hundreds are the prune -> re-add
+/// cycle, and that cycle does not *fail*, which is what makes it expensive: it
+/// finishes, and hands the corrector a working set that costs more than starting
+/// from nothing.
+///
+/// The number is calibrated, not chosen. Tracing all 138 Maros-Meszaros
+/// instances through the cold arm, 127 of which start a path:
+///
+/// | re-prunes | paths | who |
+/// |-----------|-------|-----|
+/// | 0         | 72    | `AUG*`, `BOYD2`, `CONT-050`, ... |
+/// | 1..=63    | 41    | `GOULDQP2` (29), `QISRAEL` (52), `QFFFFF80` (51) |
+/// | 64..=383  | 8     | `QGROW7`, `CONT-101` (74), `QSCTAP3` (146), `QSEBA` (383) |
+/// | >= 512    | 6     | `CVXQP{1,2,3}_{M,L}` — and nothing else |
+///
+/// So the cut lands in an empty band: no path observed to complete usefully gets
+/// past 383, and the cycling family starts at 635. Be aware the band is only
+/// 1.7x wide — a path landing between 383 and 635 would be a coin flip, and this
+/// constant would need re-deriving against whatever instance produced it rather
+/// than nudged to make one problem pass.
+///
+/// Abandoning is cheap by construction: the bail returns `Ok(None)`, which is the
+/// same "the path could not be completed, run the conventional solve" exit the
+/// unbounded-relaxation and stalled cases already take. A false positive costs
+/// the path steps already spent and nothing else — no answer changes, because
+/// nothing is reported optimal on the homotopy's own authority.
+const REPRUNE_BUDGET: u32 = 512;
+
 /// Two ratio-test events are **coincident** — the same degenerate vertex, hit at
 /// the same parameter value — when their crossing points differ by no more than
 /// this. `t` lives in `[0, 1]`, so this is a rounding-scale window (~50 ulp),
@@ -369,8 +403,9 @@ fn worst_path_violation(
 /// both arms — is a benchmark sweep that has to read it back out. `exit` is one
 /// of `complete` (the path reached `t = 1`), `budget` (the step budget ran out
 /// short of it), `stalled` (the loop ended without either), `kkt` (an
-/// unrecoverable factorization failure), or `rank` (a rank repair that had
-/// nothing left to prune).
+/// unrecoverable factorization failure), `rank` (a rank repair that had nothing
+/// left to prune), or `cycle` (the bound prune -> re-add cycle of gh #615 ran
+/// past [`REPRUNE_BUDGET`]).
 fn trace_summary(
     exit: &str,
     steps: u32,
@@ -630,6 +665,23 @@ impl ParametricActiveSetSolver {
         // pruned could never come back, so the prune -> re-add cycle `tabu_cons`
         // exists to break had no bound analogue. It does now.
         let mut tabu_bounds = vec![false; n];
+        // Bounds a rank repair has already pruned once on this path (gh #615).
+        //
+        // Pruning a bound that is *already* flagged is a re-prune: the repair
+        // dropped it as dependent, the path advanced, walked straight back into
+        // the same bound, the primal ratio test re-added it, and the next
+        // factorization was deficient in the same place. That is the prune ->
+        // re-add cycle `tabu_bounds` exists to break, and `tabu_bounds` cannot
+        // break it — the tabu is scoped to the parameter value it was raised at,
+        // and this cycle advances `t` by a hair on every turn, which releases it.
+        //
+        // Breaking the cycle properly needs the exchange pivot described at the
+        // repair site: re-add the bound and drop a *different* dependent member,
+        // so the working set stops oscillating between the same two subsets.
+        // Until that exists, count the re-prunes and abandon the path when they
+        // run away; see `REPRUNE_BUDGET` for why abandoning is cheap.
+        let mut pruned_once = vec![false; n];
+        let mut repruned_total: u32 = 0;
         // Iterations actually executed. Distinct from `n_changes`: a rank repair
         // and a degenerate zero-length advance both consume a step (and a
         // factorization) without necessarily moving the working set or `t`.
@@ -646,6 +698,12 @@ impl ParametricActiveSetSolver {
         // stopped ones (gh #434).
         let mut stalled: u32 = 0;
         let mut longest_stall: u32 = 0;
+
+        if trace {
+            let ab = working.bounds.iter().filter(|b| b.is_active()).count();
+            let ac = working.constraints.iter().filter(|c| c.is_active()).count();
+            eprintln!("[hom] start: n={n} m={m} active_bounds={ab} active_cons={ac}");
+        }
 
         // Each iteration either advances `t` or changes the working set, and the
         // budget bounds the total.
@@ -763,22 +821,44 @@ impl ParametricActiveSetSolver {
                             n_changes += 1;
                         }
                     }
+                    let mut repruned_here: u32 = 0;
                     for &j in &active_bounds {
                         if !keep_b[j] {
                             working.bounds[j] = BoundStatus::Inactive;
                             lambda_x[j] = 0.0;
                             tabu_bounds[j] = true;
+                            if pruned_once[j] {
+                                repruned_here += 1;
+                                repruned_total += 1;
+                            }
+                            pruned_once[j] = true;
                             n_changes += 1;
                         }
                     }
                     if trace {
                         eprintln!(
-                            "[hom] rank repair at t={t:.6e}: {} -> {} cons, {} -> {} bounds",
+                            "[hom] rank repair at t={t:.6e}: {} -> {} cons, {} -> {} bounds, repruned={repruned_here} cum={repruned_total}",
                             active_cons.len(),
                             kc.len(),
                             active_bounds.len(),
                             kb.len()
                         );
+                    }
+                    if repruned_total > REPRUNE_BUDGET {
+                        // The path is cycling. It will not fail — it will
+                        // *finish*, and hand the corrector a working set that
+                        // costs more than starting from nothing. Give up here
+                        // instead; `Ok(None)` is the established "run the
+                        // conventional solve" exit, so a false positive costs
+                        // the path steps already spent and nothing else.
+                        if trace {
+                            eprintln!(
+                                "[hom] abandoning path at t={t:.6e}: {repruned_total} bound \
+                                 re-prunes exceeds budget {REPRUNE_BUDGET}"
+                            );
+                            trace_summary("cycle", steps, t, n_changes, n_refactor, longest_stall);
+                        }
+                        return Ok(None);
                     }
                     continue;
                 }

--- a/crates/pounce-qp/tests/homotopy.rs
+++ b/crates/pounce-qp/tests/homotopy.rs
@@ -725,3 +725,84 @@ fn solve_with_working_set_reconciles_a_stale_hint() {
         cold.obj
     );
 }
+
+/// gh #615 — a **fully bound-active box relaxation** is the structural start
+/// that sends the path into the prune -> re-add cycle, and it must still land on
+/// the conventional path's answer.
+///
+/// The CVXQP family is n≈1000 with essentially every variable bound active at
+/// `t = 0` ((active bounds + active rows)/n = 0.999–1.0 across all six members).
+/// That over-determines the working set the moment rows start binding, the rank
+/// repair prunes bounds to make room, and the primal ratio test walks straight
+/// back into them. This is that shape in miniature: `H = I` with `g` pulling the
+/// unconstrained optimum far outside a unit box, so the relaxation sits on the
+/// vertex `x = 1` with **all six** bounds active, plus three dense rows that bind
+/// on the way to `t = 1`.
+///
+/// The assertion is agreement, not iteration count. The corpus is where the
+/// cycle's *cost* is measured (`REPRUNE_BUDGET`); no instance this small
+/// re-prunes 512 times, so this test pins the correctness half — a degenerate
+/// start must not change the answer, whether or not the budget ever trips.
+#[test]
+fn fully_bound_active_start_agrees_with_conventional() {
+    let n = 6;
+    let m = 3;
+    // H = I (positive definite, so the box relaxation is bounded and the
+    // homotopy can start at all).
+    let h = (
+        (1..=n as i32).collect::<Vec<_>>(),
+        (1..=n as i32).collect::<Vec<_>>(),
+        vec![1.0; n],
+    );
+    // Unconstrained optimum is x = 10·1, far outside the box, so every bound is
+    // active at the relaxation's vertex.
+    let g = vec![-10.0; n];
+    // Three overlapping rows, each summing four of the six variables. Together
+    // with six active bounds in six dimensions they are linearly dependent the
+    // moment any of them binds — the rank repair has to prune.
+    let mut irows = Vec::new();
+    let mut jcols = Vec::new();
+    let mut vals = Vec::new();
+    // Triplets are 1-based, as everywhere else in this crate.
+    for (r, cols) in [[1, 2, 3, 4], [2, 3, 4, 5], [3, 4, 5, 6]]
+        .iter()
+        .enumerate()
+    {
+        for &c in cols {
+            irows.push(r as i32 + 1);
+            jcols.push(c);
+            vals.push(1.0);
+        }
+    }
+    let case = Case {
+        n,
+        m,
+        h,
+        g,
+        a: (irows, jcols, vals),
+        // Each row caps at 2.0 while the box alone would allow 4.0, so all three
+        // bind before t = 1.
+        bl: vec![NLP_LOWER_BOUND_INF; m],
+        bu: vec![2.0; m],
+        xl: vec![0.0; n],
+        xu: vec![1.0; n],
+    };
+
+    let (st_h, x_h, obj_h) = solve(&case, true);
+    let (st_c, x_c, obj_c) = solve(&case, false);
+
+    assert_eq!(st_h, st_c, "homotopy status disagrees with conventional");
+    assert_eq!(st_h, QpStatus::Optimal);
+    assert!(
+        (obj_h - obj_c).abs() <= 1e-9 * (1.0 + obj_c.abs()),
+        "degenerate fully-bound start: homotopy obj {obj_h} vs conventional {obj_c}"
+    );
+    for j in 0..n {
+        assert!(
+            (x_h[j] - x_c[j]).abs() <= 1e-7,
+            "degenerate fully-bound start: x[{j}] = {} vs conventional {}",
+            x_h[j],
+            x_c[j]
+        );
+    }
+}


### PR DESCRIPTION
Fixes #615

## What #614 did, and what it opened

PR #614 gave the homotopy predictor a bound-adding ratio test. That fixed a
real correctness defect — before it, the path could walk straight through a
bound and hand the corrector a working set that had lost it. The primal ratio
test can only *prevent* a crossing, never repair one; a bound crossed once
stays crossed. That fix is correct and stays.

On the CVXQP family it also opened a cycle:

1. The box relaxation at `t=0` lands on a **fully bound-active vertex** —
   `(active_bounds + active_cons)/n` is 0.999–1.0 across the CVXQP family
   (CVXQP2_M: 998 bounds + 247 rows against `n=1000`).
2. As general rows bind along the path the working set becomes
   over-determined and the rank repair prunes to restore full rank. It prunes
   **bounds**, because `independent_active_subset` (`solver.rs:3280`) orders
   general rows before bound rows so general rows win ties — 448 of 452
   repairs on the corpus are pure bound repairs.
3. `tabu_bounds` exists to stop the pruned bound from being immediately
   re-added, but it is cleared whenever `t` advances by more than
   `T_EPS = 1e-12` (`homotopy.rs:898`) — and this cycle advances `t` by a hair
   every turn.
4. So the tabu is released, #614's ratio test re-adds exactly the bound just
   pruned, the next factorization is deficient in the same place, and round it
   goes. **93% re-add rate on CVXQP2_M.**

The cycle does not *fail*. That is what makes it expensive: the path
**finishes**, and hands the corrector a working set that costs more than
starting from nothing. CVXQP2_M went 1768 iterations (pre-#614) → 9575.

## The fix

Count *re*-prunes — a rank repair dropping a bound this path already dropped
once — and abandon the path past `REPRUNE_BUDGET`. `Ok(None)` is the
established "the path could not be completed, run the conventional solve" exit
the unbounded-relaxation and stalled cases already take, so a false positive
costs the path steps already spent and nothing else. **No answer changes** —
nothing is reported optimal on the homotopy's own authority.

Alternatives weighed and rejected, in the commit and in the code comments:
persisting the tabu (skips the ratio test entirely → re-opens #614's silent box
escape); capping without adding (degenerates to zero-length steps); a
geometry-scoped tabu (same #614 defect); a predictive admission test on start
shape (the start is *not* over-determined — 998 ≤ n=1000; the over-determination
develops as rows bind). The correct cure is the **exchange pivot** the repair
site's own comments already describe — re-add the bound and drop a *different*
dependent member. That is a genuine algorithmic addition; until it exists, this
bounds the damage.

## The threshold is calibrated, not chosen

Traced all 138 Maros-Meszaros instances, 127 of which start a path:

| re-prunes | paths | who |
|-----------|-------|-----|
| 0         | 72    | `AUG*`, `BOYD2`, `CONT-050`, … |
| 1..=63    | 41    | `GOULDQP2` (29), `QISRAEL` (52), `QFFFFF80` (51) |
| 64..=383  | 8     | `QGROW7`, `CONT-101` (74), `QSCTAP3` (146), `QSEBA` (383) |
| >= 512    | 6     | `CVXQP{1,2,3}_{M,L}` — and nothing else |

512 sits in the empty band between the two populations. The band is only 1.7×
wide and the doc comment says so: a path landing between 383 and 635 needs the
constant re-derived against that instance, not nudged to make one problem pass.

An earlier 10-problem probe was rejected as insufficient — CVXQP1_S *improved*
under #614 (334 → 294) despite a 1.02 re-add rate, so **rate is not the
discriminator**; the cumulative count is.

## Measured

Paired, same binary in both arms with the budget as the only difference, all
138 instances: **136 identical, 2 moved.**

| instance | budget off | budget 512 |
|---|---|---|
| `CVXQP2_M` | 9575 it / 44.81 s | **1129 it / 8.22 s** — objective unchanged, and better than pre-#614's 1768 |
| `QSTAIR` | TIMEOUT@120 s | InternalError@118.57 s |

`QSTAIR` is **not attributable**: under a 300 s timeout both arms reach
`cum=38` re-prunes, log zero `abandoning path` lines, and report identical
`summary exit=complete` with 0 iterations. The sweep caught one arm either side
of the wall.

Correctness gate over the corpus (RTOL 1e-6 against the reference answers):
52 correct / 86 not on **both** arms, byte-identical membership.

## What this does not do

Stated plainly rather than buried: it **does not rescue the other five CVXQP
members.** `CVXQP1_M`, `CVXQP3_M` and all three `_L` time out at 120 s on both
arms — the bail fires, but the conventional solve is itself too slow at
n ≈ 10000. Separately, 20 of the 138 paths time out *inside* the homotopy.
Neither is a regression from this change, and neither is fixed by it.

## Gates

- `scripts/sweep-fixtures.sh`, all 57 CLI fixtures, against a baseline built at
  `b0cb60ff`: **empty diff.** That is the expected *and weak* result here — the
  fixtures are small NLPs and none drives a QP homotopy path near 512
  re-prunes, so the sweep confirms inertness rather than measuring the fix. The
  trajectory evidence is the paired Maros-Meszaros sweep above.
- `cargo fmt --check` clean; clippy at the pre-existing 353-warning baseline.
- `cargo test --workspace --exclude pounce-hsl --release` passes.
- New regression test `fully_bound_active_start_agrees_with_conventional`
  builds the structural start — a fully bound-active box relaxation — and
  asserts the homotopy lands on the conventional path's answer. Verified
  non-vacuous by trace: it reproduces the degenerate start
  (`active_bounds=6 active_cons=0`), the rank repair, and the absorbing
  violation, and still agrees. It asserts **agreement, not iteration count**;
  no instance small enough for a unit test re-prunes 512 times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JHddxEhFm4a5qDoNFzh4ja
