### PR TITLE
Strengthen Pyomo initialization: scaling, option propagation, and block-DAG recovery (#609)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,62 @@ changes.
 
 ## [Unreleased]
 
+- **Pyomo initialization: scaled projection, options that reach every
+  stage, and a failed block that no longer takes independent branches
+  down with it** (#609). Four measurements on the parent commit
+  `cfc11218`, each a defect the issue names:
+
+  *Options were dropped after the projection.* `initialize(...,
+  options={"max_iter": 137})` handed the dict to `project_to_feasible`
+  and to nothing else — `block_initialize` had no `options` argument at
+  all — so a tolerance tuned for the model reached the repair stage and
+  was silently dropped by every block solve that followed, which is the
+  stage that produces the starting point you actually get. There is now
+  one typed `InitOptions` object, built once per call and threaded
+  through the projection, every block solve, and every fallback solve. A
+  bare dict still means solver options and is never reinterpreted as
+  policy.
+
+  *A failed block abandoned the whole traversal.* On a model with two
+  independent branches, failing one left the other at its seeds: `q` and
+  `r` stayed at `0.0` instead of reaching `7.0` and `8.0`, and
+  `n_vars_initialized` was `0`. The block order is a DAG, and it is now
+  tracked as one (`block_analyze(...).block_dependencies`): a failure
+  skips its **descendants** and every independent branch still
+  initializes — `n_vars_initialized` `0` → `2` on that model.
+  `on_block_failure="stop"` restores the old behaviour.
+
+  *A structurally square, numerically near-singular block returned wrong
+  values and reported success.* On a 2x2 block with condition number
+  `4/eps`, initialization wrote `u = 2, v = 0, w = 2` where the exact
+  answer is `u = v = 1, w = 3` — an error of **1.0**, `report.ok` true,
+  nothing said. Blocks are now rank-checked on their *scaled* Jacobian
+  before being solved (so a mixed-units block is not mistaken for a weak
+  one), and a weak block is diagnosed and routed to a regularized
+  least-squares fallback that selects the minimum-norm solution: error
+  **1.0 → 7.5e-9**. `fallback="coupled"` merges the weak block with its
+  dependents instead; `conditioning="off"` skips the check.
+
+  *The projection merit was unscaled.* Rows: on a model pairing a
+  `1e6`-unit energy balance with a `1e-6`-unit trace balance, the trace
+  row's relative residual was `1.2e-8` against the energy row's
+  `1.5e-16`, because the solver's gradient-based rule only ever scales a
+  row *down*. Rows are now normalised two-sided through the model's own
+  `scaling_factor` Suffix — error **7.9e-9 → 0**. Variables: the merit
+  measured absolute distance, so a repair shared between a pressure at
+  `1e6` and a mole fraction at `1e-4` moved the mole fraction 20% and
+  the pressure `1.8e-12` relative, a ratio of **1.1e11**; weighting each
+  anchor by its own magnitude makes that ratio **1.000**. Your own
+  `scaling_factor` entries win over the automatic ones, and the Suffix
+  is restored exactly. `scaling="none"` restores the old merit.
+
+  `report.blocks` is the new per-block record (initialized / fallback /
+  failed / skipped, with `rcond` and `depends_on`). The single
+  whole-model incidence walk per `initialize()` call from #444 is
+  unchanged: the block DAG is read off the graph already built, and the
+  conditioning check differentiates per block rather than rebuilding it.
+  No Rust changed; the CLI fixture sweep is bit-identical.
+
 - **`WarmStart` artifacts carry the model they belong to, and warm-start
   options no longer outlive the call that asked for them** (#607). Two
   independent silences in `pounce.WarmStart`, both of the shape gh#544

--- a/docs/src/pyomo.md
+++ b/docs/src/pyomo.md
@@ -286,15 +286,18 @@ rep = pyomo_pounce.block_initialize(            # solve the equality
 `initialize_missing_values` fills each variable independently, so the
 fill can be internally inconsistent (mole fractions that do not sum to
 one); `project_to_feasible` repairs that by minimizing
-`sum((v - v0)**2)` subject to the model's active constraints and
-bounds — the full nonlinear projection, solved with POUNCE, with the
-original objective restored afterwards.
+`sum(w**2 * (v - v0)**2)` subject to the model's active constraints
+and bounds — the full nonlinear projection, solved with POUNCE, with
+the original objective restored afterwards. The weights `w` and the
+row scaling that goes with them are described under [Scaling the
+projection](#scaling-the-projection) below.
 
 Both stages guarantee that a failed solve leaves variable values
 exactly as they were: a diverged projection restores the
 pre-projection point, and a failed block solve restores that block's
-seeds and stops, so initialization can never make your starting point
-worse than it found it.
+seeds, so initialization can never make your starting point worse than
+it found it. A failed block does **not** stop the traversal — see
+[When a block fails](#when-a-block-fails).
 
 `block_initialize` is IDAES-flavored initialization without
 hand-written routines. `decisions=` holds the listed variables at
@@ -332,6 +335,116 @@ block-triangular calculation order. Use it to diagnose a large model's
 specification, or as the structural front end for tooling that decides
 *what* to specify before calling `initialize` /
 `block_initialize` to do the work.
+
+## Tuning initialization: `InitOptions`
+
+Every stage of the pipeline takes its solver options and its policy
+from one object:
+
+```python
+from pyomo_pounce import InitOptions
+
+rep = pyomo_pounce.initialize(
+    model,
+    decisions=[m.feed, m.reflux],
+    options=InitOptions(
+        solver_options={"tol": 1e-10},  # reaches EVERY solve below
+        scaling="auto",                 # projection merit + row scaling
+        cond_tol=1e-8,                  # what counts as a weak block
+        fallback="regularized",         # where a weak block is routed
+        on_block_failure="skip-dependents",
+    ),
+)
+```
+
+`solver_options` reaches the projection, every block subsystem solve,
+and any fallback solve. A bare dict still works and still means solver
+options — `options={"tol": 1e-8}` is unchanged — and is *never*
+reinterpreted as policy, because POUNCE has solver options whose names
+collide with these fields.
+
+### Scaling the projection
+
+The projection merit is `sum(w**2 * (v - v0)**2)`. With the default
+`scaling="auto"`:
+
+* **Variables** are weighted by their own magnitude (`w = 1/|v0|`), so
+  the merit measures *relative* movement. An unweighted merit measures
+  absolute distance, which across mixed units is not a distance anyone
+  wants: with a pressure at `1e6` beside a mole fraction at `1e-4`, it
+  dumps the whole repair on the mole fraction. An anchor at (or very
+  near) zero has no relative scale, so it keeps `w = 1` and stays free
+  to move, and the spread between the smallest and largest weight is
+  capped.
+* **Rows** are normalised two-sided (`1/||grad c||_inf`) through the
+  model's own `scaling_factor` Suffix. The solver's default
+  gradient-based rule only ever scales a row *down*, so a row in units
+  of `1e-6` keeps its magnitude and an absolute convergence test
+  enforces it far more loosely than a row in units of `1e6`.
+
+Entries the model already carries in its `scaling_factor` Suffix
+**win** over the automatic ones, and the Suffix is restored exactly
+afterwards (a model that declared none does not acquire one). See
+[User scaling with the `scaling_factor` Suffix](#user-scaling-with-the-scaling_factor-suffix)
+for the Suffix itself. `scaling="user"` uses only your entries;
+`scaling="none"` restores the old unweighted merit.
+
+Rescaling a row by a constant does not change the feasible set, and it
+does not move where the projection lands — to within the solver's own
+convergence tolerance, which is what sets the floor (measured: `1.2e-9`
+at the default tolerance, `2.2e-16` at `tol=1e-12`).
+
+### When a block fails
+
+`block_initialize` walks the equality blocks in calculation order, and
+that order is a DAG: `block_analyze(model).block_dependencies[k]` lists
+the blocks block `k` consumes values from. When a block fails, only its
+**descendants** are skipped; branches that do not depend on it are
+still initialized:
+
+```python
+rep = pyomo_pounce.block_initialize(model)
+rep.initialized_blocks   # solved as square systems, values kept
+rep.fallback_blocks      # weak blocks routed to a fallback
+rep.failed_blocks        # solve failed; seed values restored
+rep.skipped_blocks       # descendants of a failure (with the reason)
+```
+
+Each entry is a `BlockOutcome` carrying the block's index, size,
+leading constraint name, status, `rcond`, and `depends_on`. Pass
+`on_block_failure="stop"` to go back to abandoning the traversal at the
+first failure.
+
+### Weak blocks: structurally square is not numerically solvable
+
+Structural matching proves a block is solvable *in principle*. Whether
+its Jacobian has usable rank at the current point is a separate,
+numerical question, and a square-but-near-singular block handed to a
+Newton step lands wherever the near-null direction takes it, silently.
+
+Each block is therefore rank-checked before it is solved. The check is
+run on the **scaled** Jacobian — rows divided by their own gradient
+norm, columns multiplied by their variable's magnitude — so it answers
+a numerical question and not a units one; a mixed-units block is not
+weak. A block whose reciprocal condition number falls below `cond_tol`
+is recorded in `rep.diagnostics` and routed to `fallback`:
+
+* `"regularized"` (default) minimises the block's scaled squared
+  residuals plus `regularization` times the scaled squared step from
+  the seed, which selects the minimum-norm solution instead of an
+  arbitrary point on the near-null direction. The residual it leaves is
+  the ridge bias, so it falls linearly with `regularization` — which is
+  why the default is small (`1e-8`).
+* `"coupled"` merges the weak block with the blocks that depend
+  directly on it and regularizes the union, for a deficiency that only
+  downstream rows resolve. Its precision on the near-null direction is
+  set by `regularization` against the solver tolerance rather than by
+  the ridge bias, so a *larger* `regularization` (around `1e-6`) is the
+  better choice there.
+* `"off"` reports the diagnostic and solves the block squarely anyway.
+
+`conditioning="off"` skips the check entirely.
+
 
 ## Repairing a bad specification
 

--- a/pyomo-pounce/pyomo_pounce/__init__.py
+++ b/pyomo-pounce/pyomo_pounce/__init__.py
@@ -14,6 +14,9 @@ interface as well, carrying all of the extras below (see pyomo_pounce.v2):
 Initialization helpers (see the POUNCE docs' initialization chapter):
     report = pyomo_pounce.preflight(model)         # starting-point check
     pyomo_pounce.initialize(model, decisions=[...])  # fill -> repair -> block-solve
+    #     options=InitOptions(...) tunes every stage at once: the
+    #     projection's scaling, the block conditioning threshold and its
+    #     fallback, and what a failed block does to the traversal
     # ... or the individual stages:
     pyomo_pounce.initialize_missing_values(model)  # fill unset Var values
     pyomo_pounce.project_to_feasible(model)        # min-norm repair onto constraints
@@ -34,12 +37,14 @@ Parametric sensitivity (see pyomo_pounce.sens):
 from pyomo_pounce.block_init import (
     BlockAnalysisReport,
     BlockInitReport,
+    BlockOutcome,
     BlockRepairPlan,
     block_analyze,
     block_initialize,
     block_repair_plan,
     structural_incidence,
 )
+from pyomo_pounce.init_options import InitOptions
 from pyomo_pounce.pounce_solver import POUNCE, check_binary
 from pyomo_pounce.sens import (
     Covariance,
@@ -122,6 +127,8 @@ __all__ = [
     "BlockAnalysisReport",
     "block_repair_plan",
     "BlockRepairPlan",
+    "BlockOutcome",
+    "InitOptions",
     "information",
     "Information",
     "structural_incidence",

--- a/pyomo-pounce/pyomo_pounce/block_init.py
+++ b/pyomo-pounce/pyomo_pounce/block_init.py
@@ -54,10 +54,13 @@ Requires ``pyomo.contrib.incidence_analysis`` (needs ``networkx`` and
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from dataclasses import replace as dc_replace
 from typing import TYPE_CHECKING, List, Optional
 
 from pyomo.core.expr.numeric_expr import DivisionExpression, NegationExpression
 from pyomo.environ import value
+
+from pyomo_pounce.init_options import InitOptions
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pyomo.core.base.constraint import ConstraintData
@@ -70,11 +73,55 @@ __all__ = [
     "structural_incidence",
     "BlockAnalysisReport",
     "BlockInitReport",
+    "BlockOutcome",
     "BlockRepairPlan",
 ]
 
 #: Termination conditions under which a solve's values may be kept.
 OK_TERMINATIONS = ("optimal", "locallyOptimal", "globallyOptimal", "feasible")
+
+
+#: Per-block statuses reported by :attr:`BlockInitReport.blocks`.
+BLOCK_STATUSES = ("initialized", "fallback", "failed", "skipped")
+
+
+@dataclass
+class BlockOutcome:
+    """What happened to one block of the calculation order (gh #609).
+
+    Before gh #609 a run reported a count of initialized variables and a
+    free-text failure string, so "which blocks actually got values" was
+    not answerable -- and once a failure stopped the traversal, the
+    difference between *skipped because it depended on the failure* and
+    *skipped because the loop gave up* was not recorded at all. It is
+    now, per block.
+    """
+
+    #: Position in the block-triangular calculation order.
+    index: int
+    #: Number of variables (== number of constraints) in the block.
+    size: int
+    #: Name of the block's leading constraint -- how the block is named
+    #: in ``failures`` and in the report text.
+    constraint: str
+    #: One of :data:`BLOCK_STATUSES`.
+    status: str
+    #: Why, in the user's terms. Empty for a plain success.
+    detail: str = ""
+    #: Reciprocal condition number of the block's scaled Jacobian,
+    #: or None when the check did not run (``conditioning="off"``, or a
+    #: Jacobian that could not be built).
+    rcond: Optional[float] = None
+    #: Indices of the blocks this one consumes values from.
+    depends_on: List[int] = field(default_factory=list)
+
+    def __str__(self) -> str:
+        rc = "" if self.rcond is None else f", rcond={self.rcond:.2e}"
+        detail = f" -- {self.detail}" if self.detail else ""
+        return (
+            f"[{self.index}] {self.size}x{self.size} at {self.constraint!r}: "
+            f"{self.status}{rc}{detail}"
+        )
 
 
 @dataclass
@@ -106,10 +153,53 @@ class BlockInitReport:
     #: actually needed repair (something pruned or pinned); None when
     #: the given decisions were used as-is.
     repair: Optional["BlockRepairPlan"] = None
+    #: One :class:`BlockOutcome` per block of the calculation order, in
+    #: that order (gh #609). The structured half of this report:
+    #: ``failures`` stays the free-text half it always was.
+    blocks: List[BlockOutcome] = field(default_factory=list)
+    #: Numerical-conditioning notes: which blocks were found weak, what
+    #: their rcond was, and what they were routed to (gh #609).
+    diagnostics: List[str] = field(default_factory=list)
 
     @property
     def ok(self) -> bool:
         return not self.failures
+
+    def _by_status(self, status: str) -> List[BlockOutcome]:
+        return [b for b in self.blocks if b.status == status]
+
+    @property
+    def initialized_blocks(self) -> List[BlockOutcome]:
+        """Blocks solved as square systems and kept."""
+        return self._by_status("initialized")
+
+    @property
+    def fallback_blocks(self) -> List[BlockOutcome]:
+        """Weak blocks routed to a regularized or coupled fallback."""
+        return self._by_status("fallback")
+
+    @property
+    def failed_blocks(self) -> List[BlockOutcome]:
+        """Blocks whose solve failed; their seed values were restored."""
+        return self._by_status("failed")
+
+    @property
+    def skipped_blocks(self) -> List[BlockOutcome]:
+        """Blocks not attempted -- descendants of a failure, or, under
+        ``on_block_failure="stop"``, everything after one."""
+        return self._by_status("skipped")
+
+    @property
+    def n_fallback(self) -> int:
+        return len(self.fallback_blocks)
+
+    @property
+    def n_failed(self) -> int:
+        return len(self.failed_blocks)
+
+    @property
+    def n_skipped(self) -> int:
+        return len(self.skipped_blocks)
 
     def __str__(self) -> str:
         lines = [
@@ -150,6 +240,17 @@ class BlockInitReport:
                 "  overconstrained cons (redundant/conflicting specs): "
                 + ", ".join(self.overconstrained_constraints)
             )
+        if self.n_fallback or self.n_skipped or self.n_failed:
+            lines.append(
+                f"  block outcomes    : {len(self.initialized_blocks)} initialized, "
+                f"{self.n_fallback} fallback, {self.n_failed} failed, "
+                f"{self.n_skipped} skipped"
+            )
+        for d in self.diagnostics:
+            lines.append(f"  diagnostic: {d}")
+        for b in self.blocks:
+            if b.status != "initialized":
+                lines.append(f"  {b}")
         for f in self.failures:
             lines.append(f"  FAILED: {f}")
         return "\n".join(lines)
@@ -195,6 +296,14 @@ class BlockAnalysisReport:
     square_constraints: List[ConstraintData] = field(default_factory=list)
     variable_blocks: List[List[VarData]] = field(default_factory=list)
     constraint_blocks: List[List[ConstraintData]] = field(default_factory=list)
+    #: The block DAG (gh #609): ``block_dependencies[k]`` lists the
+    #: indices of the blocks whose variables appear in block ``k``'s
+    #: constraints, i.e. the blocks ``k`` consumes values from. Block
+    #: triangularity means every entry is ``< k``, so a block with an
+    #: empty list is the head of an independent branch. This is what
+    #: lets :func:`block_initialize` skip only a failure's *descendants*
+    #: instead of abandoning the rest of the traversal.
+    block_dependencies: List[List[int]] = field(default_factory=list)
 
     @property
     def n_extra_degrees_of_freedom(self) -> int:
@@ -769,6 +878,9 @@ def block_analyze(model, decisions=None, igraph=None) -> BlockAnalysisReport:
             )
             report.variable_blocks = [list(blk) for blk in var_blocks]
             report.constraint_blocks = [list(blk) for blk in con_blocks]
+            report.block_dependencies = _block_dependencies(
+                igraph, report.variable_blocks, report.constraint_blocks
+            )
     finally:
         for vd in fixed_by_us:
             vd.unfix()
@@ -782,8 +894,9 @@ def block_initialize(
     solver=None,
     *,
     repair: str = "auto",
-    max_list: int = 10,
+    max_list: Optional[int] = None,
     tee: bool = False,
+    options=None,
     igraph=None,
 ) -> BlockInitReport:
     """Fill ``Var.value`` by solving equality blocks in calculation order.
@@ -806,8 +919,17 @@ def block_initialize(
             decisions exactly as given — nothing pruned, nothing
             pinned, every decision needs a value, and a non-square
             system is reported (``report.square``) instead of repaired.
-        max_list: Cap on the reported name lists.
-        tee: Echo block-solver output.
+        max_list: Cap on the reported name lists. Defaults to
+            ``options.max_list``.
+        tee: Echo block-solver output. Ignored when `options` is an
+            :class:`~pyomo_pounce.InitOptions`, which carries its own.
+        options: Solver options dict handed to **every** block solve, or
+            an :class:`~pyomo_pounce.InitOptions` that also chooses the
+            conditioning, fallback, and failure-recovery policy (gh
+            #609). A bare dict is always solver options. Before gh #609
+            there was no such argument here at all, so options given to
+            :func:`~pyomo_pounce.initialize` reached the projection and
+            were dropped by every block solve.
 
     With ``repair="auto"`` the specification is checked before anything
     is held. When holding the given decisions would leave the equality
@@ -826,9 +948,26 @@ def block_initialize(
     the offending variable/constraint **names** are reported, and the
     square part is still solved best-effort. ``report.failures`` is
     non-empty when a block solve failed: the failed block's variables
-    are restored to their seed values, the loop stops there, and the
-    downstream blocks keep their seeds — a failed solve never writes
-    its values into the model.
+    are restored to their seed values — a failed solve never writes its
+    values into the model.
+
+    A failure no longer abandons the traversal (gh #609). The block DAG
+    (:attr:`BlockAnalysisReport.block_dependencies`) says which later
+    blocks consume the failed block's values; those are marked
+    ``"skipped"`` and every branch independent of the failure is still
+    initialized. ``report.blocks`` is the per-block record —
+    initialized, fallback, failed, skipped — and
+    ``options.on_block_failure="stop"`` restores the pre-gh#609
+    behaviour of stopping at the first failure.
+
+    Structurally square is not numerically solvable, so each block is
+    also rank-checked before it is solved (gh #609). A block whose
+    scaled Jacobian has a reciprocal condition number below
+    ``options.cond_tol`` is routed to a regularized least-squares
+    fallback (or, with ``options.fallback="coupled"``, solved together
+    with the blocks that depend on it) and recorded in
+    ``report.diagnostics``, rather than being handed to a Newton step
+    that will land on an arbitrary point of the near-null direction.
 
     ``igraph``, when given, is the structural incidence graph from
     :func:`structural_incidence`, built over THIS model with fixed
@@ -868,6 +1007,12 @@ def block_initialize(
         raise ValueError(
             f"block_initialize: repair must be 'auto' or 'off', got {repair!r}"
         )
+
+    opts = InitOptions.coerce(options)
+    if not isinstance(options, InitOptions) and tee:
+        opts = dc_replace(opts, tee=True)
+    if max_list is None:
+        max_list = opts.max_list
 
     report = BlockInitReport()
 
@@ -944,46 +1089,150 @@ def block_initialize(
         if n_large > 0 and solver is None:
             solver = pyo.SolverFactory("pounce")
 
+        deps = analysis.block_dependencies or [[] for _ in analysis.variable_blocks]
+
         # The block loop is ours so every solve's verdict is checked
         # before its values are kept: a failed block restores its seed
-        # values instead of poisoning the model, then the loop stops.
-        # (Later blocks typically feed on the failed one; some may be
-        # independent of it — stopping is the conservative choice.) 1x1
-        # blocks solve by Pyomo's single-constraint Newton, larger ones
-        # by `solver`; variables outside the block are held at their
-        # current values while it solves.
+        # values instead of poisoning the model. Since gh #609 a failure
+        # no longer stops the traversal: the block DAG says exactly which
+        # later blocks consumed the failed block's values, those are
+        # marked skipped, and every branch independent of the failure is
+        # still initialized. (`on_block_failure="stop"` restores the old
+        # conservative behaviour.) 1x1 blocks solve by Pyomo's
+        # single-constraint Newton, larger ones by `solver`; variables
+        # outside the block are held at their current values while it
+        # solves.
+        #
+        # Before the square solve, each block gets a numerical rank check
+        # (gh #609): structural matching proves a block is *solvable in
+        # principle*, not that its Jacobian has usable rank here. A block
+        # that is square but near-singular is routed to a regularized
+        # (or coupled) least squares, which returns a defined
+        # minimum-norm point instead of whichever end of the near-null
+        # direction the Newton step happened to fall off.
         n_done = 0
         n_sub = 0
+        skip = {}
         outer = create_subsystem_block(square_cons, square_vars)
         with TemporarySubsystemManager(to_fix=list(outer.input_vars.values())):
-            for vblk, cblk in zip(
-                analysis.variable_blocks, analysis.constraint_blocks
+            for bi, (vblk, cblk) in enumerate(
+                zip(analysis.variable_blocks, analysis.constraint_blocks)
             ):
-                snapshot = [(vd, vd.value) for vd in vblk]
+                outcome = BlockOutcome(
+                    index=bi,
+                    size=len(vblk),
+                    constraint=cblk[0].name,
+                    status="skipped",
+                    depends_on=list(deps[bi]) if bi < len(deps) else [],
+                )
+                report.blocks.append(outcome)
+                if bi in skip:
+                    outcome.detail = skip[bi]
+                    continue
+
+                rcond = None
+                if opts.conditioning == "auto":
+                    rcond = _block_rcond(cblk, vblk)
+                    outcome.rcond = rcond
+                weak = rcond is not None and rcond < opts.cond_tol
+                merged = []
+                if weak:
+                    note = (
+                        f"{len(vblk)}x{len(vblk)} block at {cblk[0].name!r} is "
+                        f"structurally square but numerically near-singular "
+                        f"(rcond {rcond:.2e} < {opts.cond_tol:.2e})"
+                    )
+                    if opts.fallback == "off":
+                        report.diagnostics.append(
+                            note + "; solved squarely anyway "
+                            "(fallback='off') -- its values may be unstable"
+                        )
+                        weak = False
+                    else:
+                        if opts.fallback == "coupled":
+                            merged = [
+                                k
+                                for k, parents in enumerate(deps)
+                                if bi in parents and k not in skip
+                            ]
+                        report.diagnostics.append(
+                            note
+                            + "; routed to the "
+                            + (
+                                f"coupled fallback with {len(merged)} "
+                                "dependent block(s)"
+                                if merged
+                                else "regularized least-squares fallback"
+                            )
+                        )
+
+                group_v = list(vblk)
+                group_c = list(cblk)
+                for k in merged:
+                    group_v += list(analysis.variable_blocks[k])
+                    group_c += list(analysis.constraint_blocks[k])
+                snapshot = [(vd, vd.value) for vd in group_v]
                 try:
-                    if len(vblk) == 1:
+                    if weak:
+                        if solver is None:
+                            solver = pyo.SolverFactory("pounce")
+                        _regularized_solve(
+                            group_c, group_v, solver, opts, ridge_vars=vblk
+                        )
+                        n_sub += 1
+                    elif len(vblk) == 1:
                         calculate_variable_from_constraint(vblk[0], cblk[0])
                     else:
                         sub = create_subsystem_block(cblk, vblk)
                         with TemporarySubsystemManager(
                             to_fix=list(sub.input_vars.values())
                         ):
-                            results = solver.solve(sub, tee=tee)
+                            results = solver.solve(sub, **opts.solver_kwargs())
                         cond = str(results.solver.termination_condition)
                         if cond not in OK_TERMINATIONS:
                             raise RuntimeError(f"termination condition {cond}")
                         n_sub += 1
-                    n_done += len(vblk)
+                    n_done += len(group_v)
+                    outcome.status = "fallback" if weak else "initialized"
+                    for k in merged:
+                        skip[k] = ""  # solved as part of this group
                 except Exception as e:  # noqa: BLE001 - report, don't raise
                     for vd, val in snapshot:
                         vd.set_value(val, skip_validation=True)
+                    outcome.status = "failed"
+                    outcome.detail = str(e)
+                    if opts.on_block_failure == "stop":
+                        doomed = set(range(bi + 1, len(analysis.variable_blocks)))
+                        reason = (
+                            f"traversal stopped at block {bi} "
+                            f"({cblk[0].name!r}); on_block_failure='stop'"
+                        )
+                    else:
+                        doomed = _descendants(deps, bi)
+                        for k in merged:
+                            doomed |= _descendants(deps, k)
+                            doomed.add(k)
+                        doomed -= {bi}
+                        reason = (
+                            f"depends on failed block {bi} ({cblk[0].name!r})"
+                        )
+                    n_lost = 0
+                    for k in sorted(doomed):
+                        if k > bi and k not in skip:
+                            skip[k] = reason
+                            n_lost += len(analysis.variable_blocks[k])
                     report.failures.append(
                         f"{len(vblk)}x{len(vblk)} block at {cblk[0].name!r} "
                         f"failed ({e}); its seed values are restored and "
-                        f"the {len(square_vars) - n_done - len(vblk)} "
-                        f"downstream variables keep their seeds"
+                        f"the {n_lost} downstream variables keep their seeds"
                     )
-                    break
+
+        # Blocks consumed by a coupled fallback are recorded as such
+        # rather than left reading "skipped" -- they did get values.
+        for k, why in skip.items():
+            if why == "" and k < len(report.blocks):
+                report.blocks[k].status = "fallback"
+                report.blocks[k].detail = "solved as part of a coupled fallback"
         report.n_subsystem_solves = n_sub
         report.n_vars_initialized = n_done
     finally:
@@ -991,6 +1240,208 @@ def block_initialize(
             vd.unfix()
 
     return report
+
+
+def _block_dependencies(igraph, variable_blocks, constraint_blocks):
+    """The block DAG: parent block indices for each block (gh #609).
+
+    Read straight off the incidence graph already in hand -- block ``k``
+    depends on block ``j`` when a variable owned by ``j`` is incident to
+    one of ``k``'s constraints. No new graph is constructed, so the
+    single-walk guarantee of gh #444 is untouched; this is a lookup over
+    edges that were built once.
+
+    Block triangularity guarantees ``j < k`` for every edge, so the
+    result is acyclic by construction and a plain reverse-reachability
+    walk is enough to find a failure's descendants.
+    """
+    owner = {}
+    for bi, blk in enumerate(variable_blocks):
+        for v in blk:
+            owner[id(v)] = bi
+    deps = []
+    for bi, cblk in enumerate(constraint_blocks):
+        parents = set()
+        for con in cblk:
+            for v in igraph.get_adjacent_to(con):
+                j = owner.get(id(v))
+                if j is not None and j != bi:
+                    parents.add(j)
+        deps.append(sorted(parents))
+    return deps
+
+
+def _descendants(deps, root):
+    """Every block that (transitively) consumes `root`'s values."""
+    children = [[] for _ in deps]
+    for k, parents in enumerate(deps):
+        for j in parents:
+            children[j].append(k)
+    out = set()
+    stack = [root]
+    while stack:
+        cur = stack.pop()
+        for k in children[cur]:
+            if k not in out:
+                out.add(k)
+                stack.append(k)
+    return out
+
+
+def _block_jacobian(cblk, vblk):
+    """Dense Jacobian ``d(cblk)/d(vblk)`` at the current point, or None.
+
+    Symbolic differentiation where Pyomo manages it; None when it does
+    not, which the caller reads as "no conditioning verdict available"
+    rather than as a well-conditioned block.
+    """
+    from pyomo.core.expr.calculus.derivatives import differentiate
+
+    rows = []
+    for con in cblk:
+        try:
+            grads = differentiate(con.body, wrt_list=list(vblk))
+        except Exception:  # noqa: BLE001 - no verdict beats a wrong one
+            return None
+        row = []
+        for g in grads:
+            try:
+                gv = float(value(g, exception=False) or 0.0)
+            except Exception:  # noqa: BLE001
+                return None
+            if gv != gv or gv in (float("inf"), float("-inf")):
+                return None
+            row.append(gv)
+        rows.append(row)
+    return rows
+
+
+def _block_rcond(cblk, vblk):
+    """Reciprocal condition number of the block's *scaled* Jacobian.
+
+    Returns None when no verdict is available -- which the caller reads
+    as "no verdict", never as "well conditioned".
+
+    The scaling is the whole point. Structural matching proves a block is
+    solvable in principle; whether its Jacobian has usable rank *here* is
+    a numerical question, and asking it of the raw Jacobian answers a
+    units question instead. So each row is divided by its own gradient
+    infinity norm (over every variable the row mentions, fixed inputs
+    included -- they set the row's magnitude just as much) and each
+    column is multiplied by its variable's magnitude. The entries are
+    then dimensionless: relative change in a row per relative change in a
+    variable, which is the quantity a condition number is meaningful for.
+
+    Column scaling by the variable's own magnitude, rather than by the
+    column norm, is deliberate: normalising columns would drive every
+    1x1 block to exactly 1.0 and silently retire the check on the blocks
+    that make up most of a calculation order.
+    """
+    from pyomo_pounce.init_scaling import SCALE_FLOOR, GRAD_FLOOR, row_scales
+
+    jac = _block_jacobian(cblk, vblk)
+    if jac is None:
+        return None
+    scales = row_scales(cblk)
+    cols = []
+    for v in vblk:
+        a = abs(float(v.value)) if v.value is not None else 0.0
+        cols.append(a if (a == a and a >= SCALE_FLOOR) else 1.0)
+    scaled = []
+    for i, con in enumerate(cblk):
+        s = scales.get(con)
+        if s is None or s <= GRAD_FLOOR:
+            # A row with no usable gradient is rank-deficient in the
+            # strongest sense available here.
+            return 0.0
+        scaled.append([jac[i][j] * cols[j] / s for j in range(len(vblk))])
+    try:
+        import numpy
+
+        sv = numpy.linalg.svd(numpy.asarray(scaled, dtype=float), compute_uv=False)
+    except Exception:  # noqa: BLE001 - numpy absent or a degenerate matrix
+        return None
+    if sv.size == 0 or not numpy.isfinite(sv).all() or sv[0] <= 0.0:
+        return 0.0 if sv.size and sv[0] <= 0.0 else None
+    return float(sv[-1] / sv[0])
+
+
+def _residual(con):
+    """``body - rhs`` for an equality row, as a Pyomo expression.
+
+    ``c.body`` alone is not the residual: Pyomo keeps ``a + b == 3`` as a
+    body of ``a + b`` with the 3 on ``c.upper``, so squaring the body
+    would minimise the wrong thing entirely.
+    """
+    rhs = con.upper if con.upper is not None else con.lower
+    return con.body if rhs is None else con.body - rhs
+
+
+def _regularized_solve(cblk, vblk, solver, opts, ridge_vars=None):
+    """Least-squares-with-a-ridge fallback for a numerically weak block.
+
+    Minimises ``sum((c_i/s_i)**2) + lambda * sum(((v - v0)/t_j)**2)`` over
+    the block's variables, with the block's rows *deactivated* -- so a
+    rank-deficient block that has no unique square solution still gets a
+    defined, stable one instead of an arbitrary point along its near-null
+    direction. The ridge is anchored at the seed, so on a consistent but
+    deficient block it picks the minimum-norm solution.
+
+    Both terms are scaled (rows by their gradient norm, variables by
+    their own magnitude), so ``lambda`` is dimensionless and a row in
+    units of 1e6 does not swamp one in units of 1e-6 -- the same
+    reasoning as the projection merit's scaling.
+
+    `ridge_vars` narrows the ridge to a subset of `vblk`, which is what
+    the coupled fallback needs: the extra rows it merges in are there to
+    *add information* about the weak block, and ridging their variables
+    too would let their pull toward the seed decide the weak block's
+    answer. Measured on the module's near-singular fixture, ridging the
+    union picked u = 2, v = 0 (the arbitrary end of the near-null
+    direction the whole fallback exists to avoid); ridging only the weak
+    block's own variables picks u = v = 1.
+
+    Raises on a failed solve, like the square path, so the caller's
+    seed-restore and DAG bookkeeping are identical either way.
+    """
+    import pyomo.environ as pyo
+
+    from pyomo.util.subsystems import (
+        TemporarySubsystemManager,
+        create_subsystem_block,
+    )
+
+    from pyomo_pounce.init_scaling import row_factors, variable_weights
+
+    if solver is None:
+        solver = pyo.SolverFactory("pounce")
+    rf = row_factors(cblk, list(vblk))
+    ridge_on = list(vblk if ridge_vars is None else ridge_vars)
+    anchors = [(v, float(v.value)) for v in ridge_on if v.value is not None]
+    vw = variable_weights(anchors)
+
+    sub = create_subsystem_block(cblk, vblk)
+    deactivated = []
+    for c in sub.component_data_objects(pyo.Constraint, active=True):
+        c.deactivate()
+        deactivated.append(c)
+    resid = sum(rf.get(c, 1.0) ** 2 * _residual(c) ** 2 for c in cblk)
+    ridge = sum(
+        vw.get(id(v), 1.0) ** 2 * (v - v0) ** 2 for v, v0 in anchors
+    )
+    sub._pounce_regularized_objective = pyo.Objective(
+        expr=resid + opts.regularization * ridge
+    )
+    try:
+        with TemporarySubsystemManager(to_fix=list(sub.input_vars.values())):
+            results = solver.solve(sub, **opts.solver_kwargs())
+        cond = str(results.solver.termination_condition)
+        if cond not in OK_TERMINATIONS:
+            raise RuntimeError(f"regularized fallback terminated {cond}")
+    finally:
+        sub.del_component(sub._pounce_regularized_objective)
+        for c in deactivated:
+            c.activate()
 
 
 def _seed_var(v) -> None:

--- a/pyomo-pounce/pyomo_pounce/init_options.py
+++ b/pyomo-pounce/pyomo_pounce/init_options.py
@@ -1,0 +1,169 @@
+"""One typed options object for the whole initialization stack (gh #609).
+
+Before this module, ``initialize(..., options=...)`` forwarded its dict to
+:func:`~pyomo_pounce.project_to_feasible` and to nothing else: the block
+solves that follow ran on solver defaults, so a `tol` or `max_iter` tuned
+for the model reached the projection and was silently dropped by every
+subsystem solve. There was also nowhere to put a knob that is *not* a
+solver option -- how the projection merit is scaled, what counts as a
+numerically weak block, what to do when a block fails -- so those knobs
+did not exist.
+
+:class:`InitOptions` is that object. It carries the solver options once,
+plus the initialization policy, and the same instance is threaded through
+every stage: projection, block solve, the regularized-least-squares
+fallback, and the coupled fallback.
+
+Back compatibility is the reason :meth:`InitOptions.coerce` exists. A
+plain mapping has always meant "solver options" at these entry points, and
+it still does::
+
+    initialize(m, options={"tol": 1e-8})            # solver options
+    initialize(m, options=InitOptions(              # solver options + policy
+        solver_options={"tol": 1e-8}, scaling="none"))
+
+A mapping is therefore *never* read as policy, however much its keys look
+like field names -- guessing there would silently reinterpret a solver
+option (POUNCE has one called ``scaling``) as an initialization policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Mapping, Optional
+
+__all__ = ["InitOptions"]
+
+#: Accepted values for :attr:`InitOptions.scaling`.
+SCALING_MODES = ("auto", "user", "none")
+#: Accepted values for :attr:`InitOptions.conditioning`.
+CONDITIONING_MODES = ("auto", "off")
+#: Accepted values for :attr:`InitOptions.fallback`.
+FALLBACK_MODES = ("regularized", "coupled", "off")
+#: Accepted values for :attr:`InitOptions.on_block_failure`.
+FAILURE_MODES = ("skip-dependents", "stop")
+
+
+@dataclass(frozen=True)
+class InitOptions:
+    """Options for one initialization call, shared by every stage.
+
+    Attributes:
+        solver_options: Options handed to **every** solve the pipeline
+            runs -- the projection, each subsystem block, and any
+            fallback solve. This is what a bare ``options={...}`` dict
+            becomes.
+        tee: Echo solver output, for every stage.
+        scaling: How the projection merit is scaled.
+
+            * ``"auto"`` (default) -- variables are weighted by their own
+              magnitude and constraint rows are normalised two-sided, so
+              a row in units of 1e6 and a row in units of 1e-6 are
+              enforced to the same *relative* accuracy. Entries in the
+              model's own ``scaling_factor`` Suffix always win over the
+              automatic value.
+            * ``"user"`` -- use the ``scaling_factor`` Suffix and nothing
+              else; rows and variables the model does not tag stay at 1.
+            * ``"none"`` -- the pre-gh#609 behaviour: an unweighted
+              ``sum((v - v0)**2)`` merit and no row scaling.
+        conditioning: ``"auto"`` (default) runs a numerical rank check on
+            each structurally square block before solving it; ``"off"``
+            skips the check, as before gh #609.
+        cond_tol: A block whose scaled Jacobian has a reciprocal
+            condition number below this is *weak* -- structurally square
+            but numerically rank-deficient -- and is routed to
+            :attr:`fallback` instead of being solved as a square system.
+        fallback: What a weak block is routed to.
+
+            * ``"regularized"`` (default) -- minimise the block's scaled
+              squared residuals plus ``regularization`` times the scaled
+              squared step from the seed. On a rank-deficient block this
+              picks the minimum-norm solution of the consistent part
+              instead of an arbitrary point on the near-null direction.
+            * ``"coupled"`` -- merge the weak block with the blocks that
+              depend directly on it and regularize the union, for a
+              deficiency that is only resolved by downstream rows.
+            * ``"off"`` -- diagnose the block and solve it squarely
+              anyway (the pre-gh#609 behaviour, but no longer silent).
+        regularization: The ``lambda`` above. Both terms are scaled, so
+            this is dimensionless.
+        on_block_failure: ``"skip-dependents"`` (default) marks the
+            failed block's DAG descendants skipped and carries on with
+            independent branches; ``"stop"`` abandons the rest of the
+            traversal, as before gh #609.
+        max_list: Cap on the reported name lists.
+    """
+
+    solver_options: Mapping[str, Any] = field(default_factory=dict)
+    tee: bool = False
+    scaling: str = "auto"
+    conditioning: str = "auto"
+    cond_tol: float = 1e-8
+    fallback: str = "regularized"
+    regularization: float = 1e-8
+    on_block_failure: str = "skip-dependents"
+    max_list: int = 10
+
+    def __post_init__(self) -> None:
+        for name, allowed in (
+            ("scaling", SCALING_MODES),
+            ("conditioning", CONDITIONING_MODES),
+            ("fallback", FALLBACK_MODES),
+            ("on_block_failure", FAILURE_MODES),
+        ):
+            got = getattr(self, name)
+            if got not in allowed:
+                raise ValueError(
+                    f"InitOptions: {name} must be one of "
+                    f"{', '.join(map(repr, allowed))}, got {got!r}"
+                )
+        if self.cond_tol <= 0.0:
+            raise ValueError(
+                f"InitOptions: cond_tol must be positive, got {self.cond_tol!r}"
+            )
+        if self.regularization < 0.0:
+            raise ValueError(
+                "InitOptions: regularization must be non-negative, got "
+                f"{self.regularization!r}"
+            )
+        # Freeze a copy: the caller's dict must not be able to change what
+        # a later stage of the same call is handed.
+        object.__setattr__(self, "solver_options", dict(self.solver_options))
+
+    @classmethod
+    def coerce(cls, options: Optional[Any]) -> "InitOptions":
+        """Normalise whatever an entry point was given into `InitOptions`.
+
+        ``None`` -> defaults. An :class:`InitOptions` -> itself. Any other
+        mapping -> ``InitOptions(solver_options=dict(options))``, which is
+        exactly what ``options={"tol": 1e-8}`` meant before gh #609.
+        """
+        if options is None:
+            return cls()
+        if isinstance(options, cls):
+            return options
+        if isinstance(options, Mapping):
+            return cls(solver_options=dict(options))
+        raise TypeError(
+            "options must be an InitOptions or a mapping of solver options, "
+            f"got {type(options).__name__}"
+        )
+
+    def solver_kwargs(self) -> Dict[str, Any]:
+        """The ``solve()`` keyword arguments every stage passes on.
+
+        One place builds them, so a stage cannot forget one of the two.
+        """
+        return {"tee": self.tee, "options": dict(self.solver_options)}
+
+    def with_solver_options(self, **extra: Any) -> "InitOptions":
+        """A copy whose solver options are these, updated with `extra`.
+
+        Used by the projection to add ``nlp_scaling_method=user-scaling``
+        without touching the caller's object -- and it never overrides a
+        key the caller set, so an explicit ``nlp_scaling_method`` wins.
+        """
+        merged = dict(self.solver_options)
+        for k, v in extra.items():
+            merged.setdefault(k, v)
+        return replace(self, solver_options=merged)

--- a/pyomo-pounce/pyomo_pounce/init_scaling.py
+++ b/pyomo-pounce/pyomo_pounce/init_scaling.py
@@ -1,0 +1,199 @@
+"""Scaling for the initialization stack's projection merit (gh #609).
+
+Two things are scaled, for two different reasons.
+
+**Rows.** :func:`~pyomo_pounce.project_to_feasible` hands the model's own
+equalities to POUNCE as hard constraints, and the solver's default
+``gradient-based`` scaling follows Ipopt's rule, ``s_i = min(1, g_max /
+||grad c_i||_inf)``: it scales a large row *down* and leaves a small row
+alone. A convergence test on the absolute residual then enforces a row in
+units of 1e6 to a relative accuracy of 1e-22 and a row in units of 1e-6
+to a relative accuracy of 1e-2 -- the "large-magnitude rows dominate
+small but important constraints" of gh #609. :func:`row_factors` computes
+a **two-sided** normalisation, ``s_i = 1 / ||grad c_i||_inf``, which
+scales small rows up as well as large rows down, so every row is enforced
+to the same relative accuracy. Measured on the module's motivating model
+(a 1e6-unit energy balance beside a 1e-6-unit trace balance) that moved
+the trace row's relative residual from 1.2e-8 to 0.
+
+The factors are delivered through the model's ``scaling_factor`` Suffix
+and ``nlp_scaling_method=user-scaling`` -- the same route Pyomo, AMPL and
+Ipopt use, already read end-to-end by :mod:`pyomo_pounce.scaling` -- so
+nothing new has to be taught to the solver, and a user entry simply wins
+over the automatic one.
+
+**Variables.** The merit was ``sum((v - v0)**2)``, an *absolute* distance.
+Across mixed units that is not a distance anyone wants: a pressure at 1e6
+and a mole fraction at 1e-4 are a decade apart in what "moving by 1e-5"
+means, and the unscaled merit dumps the entire repair onto whichever
+variable the constraint gradient happens to favour. Measured on the
+module's motivating model the mole fraction absorbed 100% of the
+correction (a 20% relative move) while the pressure moved 1.8e-12
+relative -- a ratio of 1.1e11. :func:`variable_weights` weights each
+anchor by its own magnitude, so the merit measures *relative* movement
+and the repair is shared in proportion to what each variable can afford.
+
+Both are invariant under the transformation that motivated them, which is
+the property to hold on to: rescaling a row by ``k`` scales its gradient
+by ``k`` and its factor by ``1/k``, so the solver sees the same scaled
+row. (POUNCE's own gradient-based scaling already made the *projection*
+row-rescale invariant to machine precision; what it did not do is enforce
+the rows evenly, which is the defect above. Keeping the invariance is a
+gh #609 acceptance criterion, so :func:`row_factors` is built not to
+break it.)
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Tuple
+
+__all__ = ["row_factors", "row_scales", "variable_weights"]
+
+#: |v0| below this carries no usable scale -- a variable sitting at zero
+#: has no magnitude to be relative to, so it keeps an absolute (unit)
+#: weight and stays free to move.
+SCALE_FLOOR = 1e-8
+
+#: Widest spread we will impose between the smallest and largest anchor
+#: weight. Without a cap a single anchor at 1e-8 beside one at 1e8 asks
+#: the solver for a merit with a 1e32 spread; that is not scaling, it is
+#: a fixed variable spelled badly.
+SCALE_RANGE = 1e12
+
+#: Row gradients below this are treated as absent rather than tiny: a
+#: factor of 1/1e-30 is a way to turn a rounding error into the dominant
+#: row of the problem.
+GRAD_FLOOR = 1e-30
+
+
+def _grad_inf_norm(con, variables) -> float:
+    """``||grad c||_inf`` of a constraint body at the current point.
+
+    Symbolic where Pyomo can do it, numeric where it cannot: a body with
+    an external function or a non-differentiable node must degrade to
+    "no usable gradient" (returning 0.0, i.e. an unscaled row), never
+    take the pipeline down.
+    """
+    from pyomo.core.expr.calculus.derivatives import differentiate
+    from pyomo.environ import value
+
+    body = con.body
+    try:
+        grads = differentiate(body, wrt_list=list(variables))
+    except Exception:  # noqa: BLE001 - fall back to differences
+        return _grad_inf_norm_numeric(con, variables)
+    out = 0.0
+    for g in grads:
+        try:
+            gv = abs(float(value(g, exception=False) or 0.0))
+        except Exception:  # noqa: BLE001
+            return _grad_inf_norm_numeric(con, variables)
+        if math.isfinite(gv):
+            out = max(out, gv)
+    return out
+
+
+def _grad_inf_norm_numeric(con, variables) -> float:
+    """Central-difference fallback for :func:`_grad_inf_norm`."""
+    from pyomo.environ import value
+
+    out = 0.0
+    for v in variables:
+        v0 = v.value
+        if v0 is None:
+            continue
+        h = 1e-7 * max(1.0, abs(v0))
+        try:
+            v.set_value(v0 + h, skip_validation=True)
+            hi = float(value(con.body, exception=False) or 0.0)
+            v.set_value(v0 - h, skip_validation=True)
+            lo = float(value(con.body, exception=False) or 0.0)
+        except Exception:  # noqa: BLE001
+            return 0.0
+        finally:
+            v.set_value(v0, skip_validation=True)
+        g = abs(hi - lo) / (2.0 * h)
+        if math.isfinite(g):
+            out = max(out, g)
+    return out
+
+
+def row_factors(constraints, variables=None) -> Dict[object, float]:
+    """Two-sided row normalisation: ``{ConstraintData: 1/||grad c||_inf}``.
+
+    `variables` names the columns to differentiate against; omitted, each
+    row is differentiated against the variables *it* mentions, which is
+    the only version that stays affordable on a real model -- a whole-model
+    ``wrt_list`` would differentiate every row against every column.
+
+    Rows whose gradient is unusable (zero, non-finite, or unreadable) are
+    omitted rather than given a huge factor -- an omitted row keeps the
+    factor 1.0 the Suffix defaults to.
+    """
+    from pyomo.core.expr.visitor import identify_variables
+
+    out = {}
+    for con in constraints:
+        if variables is None:
+            cols = [
+                v
+                for v in identify_variables(con.body, include_fixed=False)
+                if v.value is not None
+            ]
+            if not cols:
+                continue
+        else:
+            cols = variables
+        g = _grad_inf_norm(con, cols)
+        if not math.isfinite(g) or g <= GRAD_FLOOR:
+            continue
+        out[con] = 1.0 / g
+    return out
+
+
+def variable_weights(anchored) -> Dict[int, float]:
+    """Anchor weights for the projection merit: ``{id(VarData): w}``.
+
+    `anchored` is the ``[(VarData, v0)]`` list the merit is built over.
+    The merit is ``sum(w**2 * (v - v0)**2)``, so ``w = 1/|v0|`` makes each
+    term a squared *relative* movement. Two guards keep that robust:
+    :data:`SCALE_FLOOR` (an anchor at or near zero has no relative scale,
+    so it keeps ``w = 1`` and stays free to move) and :data:`SCALE_RANGE`
+    (the spread between the smallest and largest weight is capped, so one
+    extreme anchor cannot quietly turn the merit into a fixed variable).
+    """
+    raw = {}
+    for v, v0 in anchored:
+        a = abs(float(v0))
+        raw[id(v)] = a if (math.isfinite(a) and a >= SCALE_FLOOR) else 1.0
+    if not raw:
+        return {}
+    hi = max(raw.values())
+    lo = hi / SCALE_RANGE
+    return {k: 1.0 / min(max(r, lo), hi) for k, r in raw.items()}
+
+
+def row_scales(constraints, variables=None) -> Dict[object, float]:
+    """``{ConstraintData: ||grad c||_inf}`` -- the raw row magnitudes.
+
+    :func:`row_factors` is the reciprocal, for handing to the solver;
+    this is the same quantity for callers that want to divide by it, such
+    as the block conditioning check, which needs to keep an unusable row
+    distinguishable from a merely small one.
+    """
+    from pyomo.core.expr.visitor import identify_variables
+
+    out = {}
+    for con in constraints:
+        cols = (
+            list(identify_variables(con.body, include_fixed=True))
+            if variables is None
+            else list(variables)
+        )
+        if not cols:
+            continue
+        g = _grad_inf_norm(con, cols)
+        if math.isfinite(g):
+            out[con] = g
+    return out

--- a/pyomo-pounce/pyomo_pounce/repair.py
+++ b/pyomo-pounce/pyomo_pounce/repair.py
@@ -40,7 +40,7 @@ from pyomo_pounce.preflight import initialize_missing_values
 __all__ = ["project_to_feasible", "initialize", "InitializeReport"]
 
 
-def _install_projection_scaling(model, opts, anchored, variables):
+def _install_projection_scaling(model, opts):
     """Row scaling for one projection solve; returns ``(undo, opts)``.
 
     The factors are delivered through the model's own ``scaling_factor``
@@ -109,9 +109,17 @@ def _install_projection_scaling(model, opts, anchored, variables):
         # The NAME is what the NL writer keys on -- a Suffix called
         # anything else is emitted by nobody and read by nobody, which is
         # a silent no-op rather than an error.
-        model.add_component(
-            SUFFIX_NAME, pyo.Suffix(direction=pyo.Suffix.EXPORT)
-        )
+        try:
+            model.add_component(
+                SUFFIX_NAME, pyo.Suffix(direction=pyo.Suffix.EXPORT)
+            )
+        except Exception:  # noqa: BLE001 - the name is taken by a non-Suffix
+            # A model may already use `scaling_factor` for a Param, Var or
+            # Block of its own. Ours is not the component that gets to win
+            # a name collision on the user's model, and an unscaled
+            # projection is exactly what happened before gh #609, so
+            # degrade to it rather than taking the call down.
+            return _noop, opts
         sfx = model.component(SUFFIX_NAME)
         created = True
         restore = []
@@ -231,11 +239,16 @@ def project_to_feasible(
             weights.get(id(v), 1.0) ** 2 * (v - v0) ** 2 for v, v0 in anchored
         )
     )
-    undo_scaling, solve_opts = _install_projection_scaling(
-        model, opts, anchored, variables
-    )
+    def undo_scaling():
+        return None
+
+    solve_opts = opts
     restore = True
     try:
+        # Inside the try: everything from here on must be undone by the
+        # `finally` below, including a failure while installing the
+        # scaling itself.
+        undo_scaling, solve_opts = _install_projection_scaling(model, opts)
         results = solver.solve(model, **solve_opts.solver_kwargs())
         cond = str(results.solver.termination_condition)
         restore = cond not in OK_TERMINATIONS

--- a/pyomo-pounce/pyomo_pounce/repair.py
+++ b/pyomo-pounce/pyomo_pounce/repair.py
@@ -19,7 +19,7 @@ constraints), this solves the full nonlinear projection with POUNCE.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import List, Optional
 
 from pyomo_pounce.block_init import (
@@ -34,22 +34,126 @@ from pyomo_pounce.block_init import (
     structural_incidence,
     block_repair_plan,
 )
+from pyomo_pounce.init_options import InitOptions
 from pyomo_pounce.preflight import initialize_missing_values
 
 __all__ = ["project_to_feasible", "initialize", "InitializeReport"]
+
+
+def _install_projection_scaling(model, opts, anchored, variables):
+    """Row scaling for one projection solve; returns ``(undo, opts)``.
+
+    The factors are delivered through the model's own ``scaling_factor``
+    Suffix and ``nlp_scaling_method=user-scaling`` -- the route Pyomo's NL
+    writer already emits and :mod:`pyomo_pounce.scaling` already reads --
+    rather than by rewriting the constraints, so nothing about the model
+    the user handed us changes and the solver needs to learn nothing new.
+
+    Entries the model already carries **win**: this fills in the rows the
+    user did not tag, and an explicit ``nlp_scaling_method`` in the solver
+    options wins over turning user-scaling on at all. ``undo()`` restores
+    the Suffix exactly, entry by entry, including removing one we created.
+
+    One case is deliberately left alone: a model carrying a
+    ``scaling_factor`` Suffix that is *not* export-enabled. Those entries
+    are the user's, and the only ways to attach ours are to flip their
+    Suffix to EXPORT -- which would ship values they deliberately kept
+    local -- or to shadow the name. Neither is ours to do, so the
+    projection runs unscaled, exactly as before gh #609.
+    """
+    import pyomo.environ as pyo
+
+    from pyomo_pounce.init_scaling import row_factors
+    from pyomo_pounce.scaling import SUFFIX_NAME
+
+    def _noop():
+        return None
+
+    if opts.scaling == "none":
+        return _noop, opts
+
+    found = [
+        sfx
+        for sfx in model.component_objects(pyo.Suffix, active=True, descend_into=True)
+        if sfx.local_name == SUFFIX_NAME
+    ]
+    if found and not any(sfx.export_enabled() for sfx in found):
+        return _noop, opts
+    existing = [sfx for sfx in found if sfx.export_enabled()]
+
+    auto = {}
+    if opts.scaling == "auto":
+        tagged = set()
+        for sfx in existing:
+            for key in sfx:
+                tagged.update(id(d) for d in _suffix_members(key))
+        rows = [
+            c
+            for c in model.component_data_objects(
+                pyo.Constraint, active=True, descend_into=True
+            )
+            if id(c) not in tagged
+        ]
+        auto = row_factors(rows)
+    if not auto and not existing:
+        # "auto" with nothing to say, or "user" with no Suffix: leave the
+        # solve exactly as it would have been, rather than switching it to
+        # user-scaling and thereby declaring every row's factor to be 1.0.
+        return _noop, opts
+
+    if existing:
+        sfx = existing[0]
+        created = False
+        restore = list(sfx.items())
+    else:
+        # The NAME is what the NL writer keys on -- a Suffix called
+        # anything else is emitted by nobody and read by nobody, which is
+        # a silent no-op rather than an error.
+        model.add_component(
+            SUFFIX_NAME, pyo.Suffix(direction=pyo.Suffix.EXPORT)
+        )
+        sfx = model.component(SUFFIX_NAME)
+        created = True
+        restore = []
+    for con, factor in auto.items():
+        sfx[con] = factor
+    # The merit is a sum of squared *scaled* deviations, so it is already
+    # O(1) by construction; scaling it again would scale it twice.
+    if model._pounce_projection_objective not in sfx:
+        sfx[model._pounce_projection_objective] = 1.0
+
+    def undo():
+        if created:
+            model.del_component(sfx)
+        else:
+            sfx.clear()
+            for k, v in restore:
+                sfx[k] = v
+
+    return undo, opts.with_solver_options(nlp_scaling_method="user-scaling")
+
+
+def _suffix_members(key):
+    """Every ComponentData a Suffix key covers (itself, when scalar)."""
+    try:
+        if key.is_indexed():
+            return [key[i] for i in key]
+    except AttributeError:
+        pass
+    return [key]
 
 
 def project_to_feasible(
     model,
     solver=None,
     *,
-    options: Optional[dict] = None,
+    options=None,
     tee: bool = False,
 ) -> str:
     """Move the current point the minimum distance onto the feasible set.
 
     Temporarily replaces the model's objective with
-    ``min sum((v - v0)**2)`` over every unfixed variable that has a
+    ``min sum(w**2 * (v - v0)**2)`` over every unfixed variable that has a
     value ``v0``, solves against the model's own (active) constraints
     and bounds with POUNCE, and restores the original objective(s). The
     repaired point lands in ``Var.value``. Valueless variables get a
@@ -57,10 +161,24 @@ def project_to_feasible(
 
     Args:
         model: A Pyomo model. Modified in place: variable values only;
-            objectives/constraints are restored exactly.
+            objectives/constraints/Suffixes are restored exactly.
         solver: A Pyomo solver; default ``SolverFactory("pounce")``.
-        options: Solver options dict (e.g. ``{"tol": 1e-8}``).
-        tee: Echo solver output.
+        options: Solver options dict (e.g. ``{"tol": 1e-8}``), or an
+            :class:`~pyomo_pounce.InitOptions` to also choose the
+            scaling policy. A bare dict is always solver options.
+        tee: Echo solver output. Ignored when `options` is an
+            :class:`~pyomo_pounce.InitOptions`, which carries its own.
+
+    **Scaling** (gh #609). By default (``InitOptions.scaling="auto"``) the
+    anchor weights ``w`` are ``1/|v0|``, so the merit measures *relative*
+    movement and a repair is shared in proportion to what each variable
+    can afford rather than dumped on whichever has the smallest
+    magnitude; and every untagged constraint row is normalised two-sided
+    through the model's ``scaling_factor`` Suffix, so a row in units of
+    1e-6 is enforced to the same relative accuracy as one in units of
+    1e6. The model's own Suffix entries win over both. ``scaling="user"``
+    uses only the Suffix; ``scaling="none"`` restores the unweighted
+    pre-gh#609 merit. See :mod:`pyomo_pounce.init_scaling`.
 
     Returns the solver termination condition as a string; success is
     membership in :data:`~pyomo_pounce.block_init.OK_TERMINATIONS`
@@ -71,6 +189,12 @@ def project_to_feasible(
     anchor; run ``initialize_missing_values`` first).
     """
     import pyomo.environ as pyo
+
+    from pyomo_pounce.init_scaling import variable_weights
+
+    opts = InitOptions.coerce(options)
+    if not isinstance(options, InitOptions) and tee:
+        opts = replace(opts, tee=True)
 
     variables = [
         v
@@ -91,6 +215,11 @@ def project_to_feasible(
     if solver is None:
         solver = pyo.SolverFactory("pounce")
 
+    if opts.scaling == "none":
+        weights = {}
+    else:
+        weights = variable_weights(anchored)
+
     deactivated = []
     for obj in model.component_data_objects(
         pyo.Objective, active=True, descend_into=True
@@ -98,15 +227,21 @@ def project_to_feasible(
         obj.deactivate()
         deactivated.append(obj)
     model._pounce_projection_objective = pyo.Objective(
-        expr=sum((v - v0) ** 2 for v, v0 in anchored)
+        expr=sum(
+            weights.get(id(v), 1.0) ** 2 * (v - v0) ** 2 for v, v0 in anchored
+        )
+    )
+    undo_scaling, solve_opts = _install_projection_scaling(
+        model, opts, anchored, variables
     )
     restore = True
     try:
-        results = solver.solve(model, tee=tee, options=dict(options or {}))
+        results = solver.solve(model, **solve_opts.solver_kwargs())
         cond = str(results.solver.termination_condition)
         restore = cond not in OK_TERMINATIONS
         return cond
     finally:
+        undo_scaling()
         if restore:
             for v, val in snapshot:
                 v.set_value(val, skip_validation=True)
@@ -132,6 +267,12 @@ class InitializeReport:
     #: actually needed repair; None when the decisions were used as-is.
     repair: Optional[BlockRepairPlan] = None
     warnings: List[str] = field(default_factory=list)
+
+    @property
+    def blocks(self):
+        """The block-stage per-block record, or ``[]`` when it did not
+        run (gh #609). See :class:`~pyomo_pounce.BlockOutcome`."""
+        return [] if self.block is None else self.block.blocks
 
     @property
     def ok(self) -> bool:
@@ -171,7 +312,7 @@ def initialize(
     repair: str = "auto",
     fill: str = "midpoint",
     project: bool = True,
-    options: Optional[dict] = None,
+    options=None,
     tee: bool = False,
 ) -> InitializeReport:
     """Fill, repair, and block-solve a model's starting point.
@@ -201,13 +342,30 @@ def initialize(
        equality system in calculation order, overwriting the repaired
        values with the consistent profile.
 
+    ``options`` is a solver-options dict (``{"tol": 1e-8}``) or an
+    :class:`~pyomo_pounce.InitOptions`. Either way **one** object is
+    built here and threaded through every stage that runs — the
+    projection, each block solve, and any fallback solve (gh #609).
+    Before gh #609 the dict reached the projection and nothing else, so
+    a tolerance tuned for the model was silently dropped by the block
+    solves that produced the actual starting point. An
+    :class:`~pyomo_pounce.InitOptions` additionally chooses the
+    projection's scaling, the block conditioning threshold and its
+    fallback, and what happens to the traversal when a block fails.
+
     Returns an :class:`InitializeReport`; ``report.block.square`` and
     the name lists tell you what the model is still missing.
+    ``report.blocks`` is the per-block record of what was initialized,
+    fell back, failed, or was skipped.
     """
     if repair not in ("auto", "off"):
         raise ValueError(
             f"initialize: repair must be 'auto' or 'off', got {repair!r}"
         )
+
+    opts = InitOptions.coerce(options)
+    if not isinstance(options, InitOptions) and tee:
+        opts = replace(opts, tee=True)
 
     report = InitializeReport()
 
@@ -270,7 +428,7 @@ def initialize(
         if project:
             try:
                 report.projection = project_to_feasible(
-                    model, solver=solver, options=options, tee=tee
+                    model, solver=solver, options=opts
                 )
                 if report.projection not in OK_TERMINATIONS:
                     report.warnings.append(
@@ -289,8 +447,8 @@ def initialize(
         report.block = block_initialize(
             model,
             solver=solver,
-            tee=tee,
             repair="off",
+            options=opts,
             igraph=igraph,
         )
     finally:

--- a/pyomo-pounce/tests/test_issue_609_init_hardening.py
+++ b/pyomo-pounce/tests/test_issue_609_init_hardening.py
@@ -1,0 +1,542 @@
+"""gh #609: scaling, option propagation, block-DAG recovery, conditioning.
+
+Each test here targets one of the issue's acceptance criteria, and each
+was measured on the parent commit (cfc11218) first -- the numbers in the
+comments are those measurements, not estimates.
+"""
+
+import pyomo.environ as pyo
+import pytest
+
+import pyomo_pounce
+from pyomo_pounce import InitOptions
+
+pytest.importorskip("networkx", reason="initialize pipeline needs networkx")
+pytest.importorskip("scipy", reason="initialize pipeline needs scipy")
+
+
+@pytest.fixture(scope="module")
+def solver():
+    s = pyo.SolverFactory("pounce")
+    if not s.available(exception_flag=False):
+        pytest.skip("pounce binary not found on PATH")
+    return s
+
+
+# --------------------------------------------------------------------------
+# 1. Scaling
+# --------------------------------------------------------------------------
+
+def _mixed_units():
+    """A 1e6-unit energy balance beside a 1e-6-unit trace balance.
+
+    Both say the same thing about the solution (a + 2b == 3, a == b, so
+    a == b == 1), but Ipopt's gradient-based rule -- ``min(1, g_max /
+    ||grad c||)`` -- only ever scales a row *down*. The trace row keeps
+    its 1e-6 magnitude and an absolute convergence test then enforces it
+    to a relative accuracy eight orders of magnitude looser than the
+    energy row's.
+    """
+    m = pyo.ConcreteModel()
+    m.a = pyo.Var(initialize=0.0, bounds=(-1e3, 1e3))
+    m.b = pyo.Var(initialize=0.0, bounds=(-1e3, 1e3))
+    m.energy = pyo.Constraint(expr=1e6 * m.a + 2e6 * m.b == 3e6)
+    m.trace = pyo.Constraint(expr=1e-6 * m.a - 1e-6 * m.b == 0.0)
+    m.obj = pyo.Objective(expr=m.a)
+    return m
+
+
+def test_small_magnitude_row_is_enforced_like_a_large_one(solver):
+    """The scaled projection lands on the exact answer of a mixed-units
+    model. On the parent commit this returned a = 0.9999999921,
+    b = 1.0000000039 -- a relative residual of 1.2e-8 on the trace row
+    against 1.5e-16 on the energy row."""
+    m = _mixed_units()
+    pyomo_pounce.initialize_missing_values(m)
+    cond = pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert cond in ("optimal", "locallyOptimal")
+    a, b = pyo.value(m.a), pyo.value(m.b)
+    # Two orders tighter than the parent commit's 7.9e-9 error.
+    assert a == pytest.approx(1.0, abs=1e-11)
+    assert b == pytest.approx(1.0, abs=1e-11)
+    assert abs(a - b) / max(1.0, abs(a)) < 1e-11
+
+
+def test_scaling_none_restores_the_unscaled_merit(solver):
+    """``scaling="none"`` is the pre-gh#609 behaviour, and it is still
+    reachable -- the parent commit's looser answer comes back."""
+    m = _mixed_units()
+    pyomo_pounce.initialize_missing_values(m)
+    pyomo_pounce.project_to_feasible(
+        m, solver=solver, options=InitOptions(scaling="none")
+    )
+    a, b = pyo.value(m.a), pyo.value(m.b)
+    assert abs(a - b) > 1e-11  # the defect, deliberately reproduced
+
+
+def _two_scale_anchor():
+    """A pressure at 1e6 Pa and a mole fraction at 1e-4, coupled so that
+    each contributes 1.0 in its own units and the pair is 10% short."""
+    m = pyo.ConcreteModel()
+    m.P = pyo.Var(initialize=1.0e6)
+    m.x = pyo.Var(initialize=1.0e-4)
+    m.link = pyo.Constraint(expr=m.P / 1e6 + m.x / 1e-4 == 2.2)
+    m.obj = pyo.Objective(expr=m.P)
+    return m
+
+
+def test_merit_shares_repair_by_relative_magnitude(solver):
+    """A repair is shared in proportion to what each variable can afford.
+
+    On the parent commit the unscaled merit moved the mole fraction by
+    20% and the pressure by 1.8e-12 -- a ratio of 1.1e11 -- because an
+    absolute distance says moving a 1e-4 variable is 1e10 times cheaper
+    than moving a 1e6 one. Scaled, both move 10%."""
+    m = _two_scale_anchor()
+    cond = pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert cond in ("optimal", "locallyOptimal")
+    rel_P = abs(pyo.value(m.P) - 1.0e6) / 1.0e6
+    rel_x = abs(pyo.value(m.x) - 1.0e-4) / 1.0e-4
+    assert rel_P == pytest.approx(rel_x, rel=1e-6)
+    assert rel_P == pytest.approx(0.1, rel=1e-6)
+
+
+def _rescalable(k):
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(initialize=0.0)
+    m.y = pyo.Var(initialize=0.0)
+    m.z = pyo.Var(initialize=0.0)
+    m.big = pyo.Constraint(expr=k * 1e6 * m.x + k * 1e6 * m.y == k * 3e6)
+    m.small = pyo.Constraint(expr=1e-3 * m.x - 1e-3 * m.z == 1e-3)
+    m.c = pyo.Constraint(expr=m.y + m.z == 2.0)
+    m.obj = pyo.Objective(expr=m.x)
+    return m
+
+
+@pytest.mark.parametrize("k", [1e6, 1e-6, 1e10, 1e-10])
+def test_projection_is_invariant_under_row_rescaling(solver, k):
+    """Acceptance criterion 1. Multiplying a row by a constant does not
+    change the feasible set, so it must not change where the projection
+    lands -- to within the solver's own convergence tolerance.
+
+    Measured at the default tolerance the spread is 1.2e-9 (the solver
+    stops as soon as the *scaled* residual is inside tol, and where that
+    happens depends on the iterate path); tightening tol collapses it to
+    2.2e-16, which is what pins this as a tolerance effect rather than a
+    scaling defect."""
+    opts = InitOptions(solver_options={"tol": 1e-12})
+
+    def point(kk):
+        m = _rescalable(kk)
+        pyomo_pounce.initialize_missing_values(m)
+        assert pyomo_pounce.project_to_feasible(
+            m, solver=solver, options=opts
+        ) in ("optimal", "locallyOptimal")
+        return [pyo.value(m.x), pyo.value(m.y), pyo.value(m.z)]
+
+    base = point(1.0)
+    got = point(k)
+    assert max(abs(a - b) for a, b in zip(base, got)) < 1e-12
+
+
+def test_user_scaling_suffix_entries_win_over_the_automatic_ones(solver):
+    """Scope item 1's "user scaling suffix support": an entry the model
+    carries is used as given, and the Suffix is restored afterwards."""
+    m = _mixed_units()
+    m.scaling_factor = pyo.Suffix(direction=pyo.Suffix.EXPORT)
+    m.scaling_factor[m.trace] = 1e6
+    pyomo_pounce.initialize_missing_values(m)
+    pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert pyo.value(m.a) == pytest.approx(1.0, abs=1e-11)
+    # exactly one entry, unchanged, and nothing of ours left behind
+    assert len(m.scaling_factor) == 1
+    assert m.scaling_factor[m.trace] == 1e6
+
+
+def test_projection_leaves_no_scaling_suffix_behind(solver):
+    """A model that declared no Suffix must not acquire one."""
+    m = _mixed_units()
+    pyomo_pounce.initialize_missing_values(m)
+    pyomo_pounce.project_to_feasible(m, solver=solver)
+    assert m.component("scaling_factor") is None
+    objs = list(m.component_data_objects(pyo.Objective, descend_into=True))
+    assert len(objs) == 1 and objs[0] is m.obj
+
+
+# --------------------------------------------------------------------------
+# 2. Option propagation
+# --------------------------------------------------------------------------
+
+def _two_stage_model():
+    """A 1x1 feeding a genuinely coupled 2x2, so a subsystem solve runs."""
+    m = pyo.ConcreteModel()
+    m.a = pyo.Var(initialize=1.0)
+    m.x = pyo.Var(initialize=0.3)
+    m.y = pyo.Var(initialize=0.3)
+    m.c0 = pyo.Constraint(expr=m.a == 4.0)
+    m.c1 = pyo.Constraint(expr=m.x + m.y == m.a)
+    m.c2 = pyo.Constraint(expr=m.x * m.x - m.y == 1.0)
+    m.obj = pyo.Objective(expr=m.x)
+    return m
+
+
+def _record_stages(monkeypatch, solver, **init_kwargs):
+    seen = []
+    real = type(solver).solve
+
+    def spy(self, model, **kw):
+        stage = (
+            "projection"
+            if hasattr(model, "_pounce_projection_objective")
+            else "block_subsystem"
+        )
+        seen.append((stage, dict(kw.get("options") or {})))
+        return real(self, model, **kw)
+
+    monkeypatch.setattr(type(solver), "solve", spy)
+    m = _two_stage_model()
+    pyomo_pounce.initialize(m, solver=solver, **init_kwargs)
+    return seen
+
+
+def test_options_reach_every_stage(monkeypatch, solver):
+    """Acceptance criterion 2. On the parent commit the projection got
+    ``{"max_iter": 137}`` and the block subsystem solve got ``{}`` --
+    ``block_initialize`` had no ``options`` argument at all."""
+    seen = _record_stages(
+        monkeypatch, solver, options={"max_iter": 137, "tol": 1e-9}
+    )
+    stages = {s for s, _ in seen}
+    assert stages == {"projection", "block_subsystem"}, seen
+    for stage, opts in seen:
+        assert opts.get("max_iter") == 137, (stage, opts)
+        assert opts.get("tol") == 1e-9, (stage, opts)
+
+
+def test_init_options_object_reaches_every_stage(monkeypatch, solver):
+    seen = _record_stages(
+        monkeypatch,
+        solver,
+        options=InitOptions(solver_options={"max_iter": 41}),
+    )
+    assert seen
+    for stage, opts in seen:
+        assert opts.get("max_iter") == 41, (stage, opts)
+
+
+def test_block_initialize_takes_options_directly(monkeypatch, solver):
+    seen = []
+    real = type(solver).solve
+
+    def spy(self, model, **kw):
+        seen.append(dict(kw.get("options") or {}))
+        return real(self, model, **kw)
+
+    monkeypatch.setattr(type(solver), "solve", spy)
+    m = _two_stage_model()
+    pyomo_pounce.block_initialize(m, solver=solver, options={"max_iter": 55})
+    assert seen and all(o.get("max_iter") == 55 for o in seen)
+
+
+def test_bare_dict_is_solver_options_not_policy():
+    """A mapping is never reinterpreted as policy -- POUNCE has a solver
+    option called ``scaling``, and reading it as ``InitOptions.scaling``
+    would be a silent, wrong reinterpretation."""
+    opts = InitOptions.coerce({"scaling": "off", "tol": 1e-7})
+    assert opts.solver_options == {"scaling": "off", "tol": 1e-7}
+    assert opts.scaling == "auto"
+
+
+def test_init_options_validates_and_is_immutable():
+    with pytest.raises(ValueError, match="on_block_failure"):
+        InitOptions(on_block_failure="explode")
+    with pytest.raises(ValueError, match="cond_tol"):
+        InitOptions(cond_tol=0.0)
+    with pytest.raises(TypeError, match="InitOptions or a mapping"):
+        InitOptions.coerce(object())
+    given = {"tol": 1e-8}
+    opts = InitOptions(solver_options=given)
+    given["tol"] = 1.0  # must not reach a later stage of the same call
+    assert opts.solver_options == {"tol": 1e-8}
+
+
+# --------------------------------------------------------------------------
+# 3. Block-DAG recovery
+# --------------------------------------------------------------------------
+
+def _two_branch_model():
+    """Two branches sharing no variable: one fails, one must not."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Var(bounds=(-10.0, 0.0), initialize=-1.0)  # needs p = 2
+    m.pp = pyo.Var(initialize=1.0)
+    m.f1 = pyo.Constraint(expr=m.p + m.pp == 3.0)
+    m.f2 = pyo.Constraint(expr=m.p - m.pp == 1.0)
+    m.q = pyo.Var(initialize=0.0)
+    m.r = pyo.Var(initialize=0.0)
+    m.g1 = pyo.Constraint(expr=m.q == 7.0)
+    m.g2 = pyo.Constraint(expr=m.r == m.q + 1.0)
+    m.obj = pyo.Objective(expr=m.r)
+    return m
+
+
+def test_independent_branch_survives_a_failure(solver):
+    """Acceptance criterion 3. On the parent commit the 2x2 failure broke
+    the loop and q and r stayed at their 0.0 seeds; n_vars_initialized
+    was 0."""
+    m = _two_branch_model()
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert not report.ok  # the failure is still reported
+    assert pyo.value(m.q) == pytest.approx(7.0)
+    assert pyo.value(m.r) == pytest.approx(8.0)
+    assert report.n_vars_initialized == 2
+    assert pyo.value(m.p) == -1.0 and pyo.value(m.pp) == 1.0  # seeds kept
+
+
+def test_dependent_blocks_are_still_skipped(solver):
+    """The other half of criterion 3: a block that *does* consume the
+    failed block's values must not be run on wreckage."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var(bounds=(-10.0, 0.0), initialize=-1.0)
+    m.y = pyo.Var(initialize=1.0)
+    m.z = pyo.Var(initialize=42.0)  # downstream of the failing 2x2
+    m.c1 = pyo.Constraint(expr=m.x + m.y == 3.0)
+    m.c2 = pyo.Constraint(expr=m.x - m.y == 1.0)
+    m.c3 = pyo.Constraint(expr=m.z == m.x * m.y)
+    m.obj = pyo.Objective(expr=m.z)
+
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert not report.ok
+    assert pyo.value(m.z) == 42.0
+    skipped = report.skipped_blocks
+    assert len(skipped) == 1
+    assert "depends on failed block" in skipped[0].detail
+
+
+def test_on_block_failure_stop_restores_the_old_behaviour(solver):
+    m = _two_branch_model()
+    report = pyomo_pounce.block_initialize(
+        m, solver=solver, options=InitOptions(on_block_failure="stop")
+    )
+    assert not report.ok
+    assert pyo.value(m.q) == 0.0 and pyo.value(m.r) == 0.0
+    assert report.n_vars_initialized == 0
+    assert all("stop" in b.detail for b in report.skipped_blocks)
+
+
+def test_block_dependencies_are_reported():
+    """Scope item 3's "track the block graph explicitly"."""
+    m = pyo.ConcreteModel()
+    m.x = pyo.Var()
+    m.y = pyo.Var()
+    m.z = pyo.Var()
+    m.c1 = pyo.Constraint(expr=m.x == 2.0)
+    m.c2 = pyo.Constraint(expr=m.y == m.x + 1.0)
+    m.c3 = pyo.Constraint(expr=m.z == 5.0)  # independent branch
+    m.obj = pyo.Objective(expr=m.x)
+
+    a = pyomo_pounce.block_analyze(m)
+    assert len(a.block_dependencies) == a.n_blocks == 3
+    owner = {blk[0].name: i for i, blk in enumerate(a.variable_blocks)}
+    assert a.block_dependencies[owner["y"]] == [owner["x"]]
+    assert a.block_dependencies[owner["x"]] == []
+    assert a.block_dependencies[owner["z"]] == []
+
+
+def test_structured_report_accounts_for_every_block(solver):
+    """Scope item 5 / acceptance criterion 5: initialized, skipped,
+    failed and fallback blocks are all named."""
+    m = _two_branch_model()
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert len(report.blocks) == report.n_blocks
+    buckets = (
+        report.initialized_blocks
+        + report.fallback_blocks
+        + report.failed_blocks
+        + report.skipped_blocks
+    )
+    assert len(buckets) == len(report.blocks)
+    assert [b.constraint for b in report.failed_blocks] == ["f1"]
+    assert sorted(b.constraint for b in report.initialized_blocks) == [
+        "g1",
+        "g2",
+    ]
+    assert "failed" in str(report)
+
+
+def test_initialize_report_exposes_the_block_record(solver):
+    m = _two_stage_model()
+    report = pyomo_pounce.initialize(m, solver=solver)
+    assert report.ok, str(report)
+    assert report.blocks and all(
+        b.status == "initialized" for b in report.blocks
+    )
+
+
+# --------------------------------------------------------------------------
+# 4. Numerical conditioning
+# --------------------------------------------------------------------------
+
+def _near_singular(eps):
+    """Structurally square, numerically rank-deficient.
+
+        u +          v == 2
+        u + (1 + eps)v == 2 + eps
+
+    Exact solution u = v = 1, but the Jacobian [[1, 1], [1, 1+eps]] has a
+    condition number of about 4/eps.
+    """
+    m = pyo.ConcreteModel()
+    m.u = pyo.Var(initialize=0.0)
+    m.v = pyo.Var(initialize=0.0)
+    m.w = pyo.Var(initialize=0.0)
+    m.d1 = pyo.Constraint(expr=m.u + m.v == 2.0)
+    m.d2 = pyo.Constraint(expr=m.u + (1.0 + eps) * m.v == 2.0 + eps)
+    m.d3 = pyo.Constraint(expr=m.w == m.u + 2.0 * m.v)
+    m.obj = pyo.Objective(expr=m.w)
+    return m
+
+
+@pytest.mark.parametrize("eps", [1e-10, 1e-14])
+def test_near_singular_block_gets_a_diagnostic_and_a_fallback(solver, eps):
+    """Acceptance criterion 4. On the parent commit this reported success
+    and wrote u = 2, v = 0, w = 2 -- an error of 1.0 against the exact
+    u = v = 1, w = 3, with nothing said about it."""
+    m = _near_singular(eps)
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert report.diagnostics, str(report)
+    assert "near-singular" in report.diagnostics[0]
+    assert [b.constraint for b in report.fallback_blocks] == ["d1"]
+    weak = report.fallback_blocks[0]
+    assert weak.rcond is not None and weak.rcond < 1e-8
+    # the regularized fallback returns the minimum-norm solution
+    assert pyo.value(m.u) == pytest.approx(1.0, abs=1e-6)
+    assert pyo.value(m.v) == pytest.approx(1.0, abs=1e-6)
+    assert pyo.value(m.w) == pytest.approx(3.0, abs=1e-6)
+
+
+def test_healthy_blocks_are_not_diagnosed(solver):
+    """The check must not fire on a well-conditioned model, including on
+    a mixed-units one -- conditioning is a numerical question, not a
+    units question."""
+    m = pyo.ConcreteModel()
+    m.a = pyo.Var(initialize=0.5)
+    m.b = pyo.Var(initialize=0.5)
+    m.e = pyo.Constraint(expr=1e6 * m.a + 2e6 * m.b == 3e6)
+    m.t = pyo.Constraint(expr=1e-6 * m.a - 1e-6 * m.b == 0.0)
+    m.obj = pyo.Objective(expr=m.a)
+
+    report = pyomo_pounce.block_initialize(m, solver=solver)
+    assert report.ok, str(report)
+    assert not report.diagnostics
+    assert not report.fallback_blocks
+    assert pyo.value(m.a) == pytest.approx(1.0, abs=1e-6)
+
+
+def test_conditioning_off_restores_the_old_behaviour(solver):
+    """``conditioning="off"`` reproduces the parent commit's answer."""
+    m = _near_singular(1e-14)
+    report = pyomo_pounce.block_initialize(
+        m, solver=solver, options=InitOptions(conditioning="off")
+    )
+    assert not report.diagnostics
+    assert all(b.rcond is None for b in report.blocks)
+    assert abs(pyo.value(m.u) - 1.0) > 0.5  # the defect, deliberately kept
+
+
+def test_fallback_off_diagnoses_without_rerouting(solver):
+    m = _near_singular(1e-14)
+    report = pyomo_pounce.block_initialize(
+        m, solver=solver, options=InitOptions(fallback="off")
+    )
+    assert report.diagnostics and "fallback='off'" in report.diagnostics[0]
+    assert not report.fallback_blocks
+
+
+def test_coupled_fallback_solves_the_weak_block_with_its_dependents(solver):
+    """``fallback="coupled"`` merges the weak block with the blocks that
+    depend on it and regularizes the union.
+
+    Its precision on the near-null direction is set by ``regularization``
+    against the solver's tolerance, not by the ridge bias that governs
+    the plain regularized path: measured on this fixture the error is
+    7.4e-3 at the 1e-8 default and 7.6e-5 at 1e-6. Both are two to four
+    orders better than the parent commit's 1.0, which is the property
+    that matters -- a defined value near the minimum-norm solution rather
+    than an arbitrary end of the near-null direction.
+    """
+    m = _near_singular(1e-14)
+    report = pyomo_pounce.block_initialize(
+        m,
+        solver=solver,
+        options=InitOptions(fallback="coupled", regularization=1e-6),
+    )
+    assert "coupled fallback" in report.diagnostics[0]
+    assert sorted(b.constraint for b in report.fallback_blocks) == ["d1", "d3"]
+    assert pyo.value(m.u) == pytest.approx(1.0, abs=1e-3)
+    assert pyo.value(m.v) == pytest.approx(1.0, abs=1e-3)
+    assert pyo.value(m.w) == pytest.approx(3.0, abs=1e-3)
+
+
+def test_regularized_fallback_bias_scales_with_the_ridge(solver):
+    """The plain regularized path's error *is* the ridge bias, so it
+    falls linearly with ``regularization`` -- which is why the default is
+    1e-8 and not something larger. Measured: 7.5e-9 at 1e-8, 7.5e-5 at
+    1e-4."""
+    errs = {}
+    for lam in (1e-8, 1e-4):
+        m = _near_singular(1e-14)
+        pyomo_pounce.block_initialize(
+            m, solver=solver, options=InitOptions(regularization=lam)
+        )
+        errs[lam] = abs(pyo.value(m.u) - 1.0)
+    assert errs[1e-8] < 1e-7
+    assert errs[1e-4] < 1e-3
+    assert errs[1e-8] < errs[1e-4] / 100.0
+
+
+# --------------------------------------------------------------------------
+# 5. gh #444's incidence-plan caching is preserved
+# --------------------------------------------------------------------------
+
+def test_still_one_incidence_walk_per_initialize(monkeypatch, solver):
+    """Acceptance criterion 5's other half. The block DAG, the
+    conditioning check and the fallback all read structure, and none of
+    them may pay for a second whole-model walk: the DAG comes off the
+    graph already built, and the Jacobian is differentiated per block."""
+    import pyomo.core.base.block as _block
+    import pyomo.contrib.incidence_analysis.interface as _iface
+
+    walks = []
+    orig = _iface.IncidenceGraphInterface.__init__
+
+    def counting(self, model=None, *args, **kwargs):
+        if isinstance(model, (_block.Block, _block.BlockData)):
+            walks.append(model)
+        return orig(self, model, *args, **kwargs)
+
+    monkeypatch.setattr(_iface.IncidenceGraphInterface, "__init__", counting)
+    m = _two_stage_model()
+    report = pyomo_pounce.initialize(m, solver=solver)
+    assert report.ok, str(report)
+    assert len(walks) == 1
+
+
+def test_one_incidence_walk_even_when_a_block_fails(monkeypatch, solver):
+    """The recovery path is the new one, so it gets its own guard:
+    computing descendants must not rebuild the graph."""
+    import pyomo.core.base.block as _block
+    import pyomo.contrib.incidence_analysis.interface as _iface
+
+    walks = []
+    orig = _iface.IncidenceGraphInterface.__init__
+
+    def counting(self, model=None, *args, **kwargs):
+        if isinstance(model, (_block.Block, _block.BlockData)):
+            walks.append(model)
+        return orig(self, model, *args, **kwargs)
+
+    monkeypatch.setattr(_iface.IncidenceGraphInterface, "__init__", counting)
+    m = _two_branch_model()
+    report = pyomo_pounce.initialize(m, solver=solver, project=False)
+    assert not report.ok
+    assert len(walks) == 1

--- a/pyomo-pounce/tests/test_issue_609_init_hardening.py
+++ b/pyomo-pounce/tests/test_issue_609_init_hardening.py
@@ -10,6 +10,7 @@ import pytest
 
 import pyomo_pounce
 from pyomo_pounce import InitOptions
+from pyomo_pounce.block_init import OK_TERMINATIONS
 
 pytest.importorskip("networkx", reason="initialize pipeline needs networkx")
 pytest.importorskip("scipy", reason="initialize pipeline needs scipy")
@@ -161,6 +162,30 @@ def test_projection_leaves_no_scaling_suffix_behind(solver):
     assert m.component("scaling_factor") is None
     objs = list(m.component_data_objects(pyo.Objective, descend_into=True))
     assert len(objs) == 1 and objs[0] is m.obj
+
+
+def test_a_taken_scaling_factor_name_degrades_instead_of_raising(solver):
+    """`scaling_factor` already used by a non-Suffix component.
+
+    The projection delivers its row factors through a Suffix of that
+    name, so a model that already spends the name on a Param, Var or
+    Block leaves nowhere to put them. That is not an error the caller
+    did anything about -- the name is theirs -- so the projection runs
+    unscaled, exactly as it did before gh #609, and the model comes back
+    untouched. Before the guard this raised `RuntimeError` from
+    `add_component` *after* the original objective had been deactivated,
+    leaving the model permanently broken.
+    """
+    m = _mixed_units()
+    m.scaling_factor = pyo.Param(initialize=1.0)
+    pyomo_pounce.initialize_missing_values(m)
+
+    cond = pyomo_pounce.project_to_feasible(m, solver=solver)
+
+    assert cond in OK_TERMINATIONS
+    assert m.obj.active
+    assert m.component("_pounce_projection_objective") is None
+    assert m.component("scaling_factor") is m.scaling_factor
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #609

Baseline for every measurement below: **`cfc11218d75b1751d4bb2730be30bf35814a4016`** (tip of `main` when this branch was cut). No Rust changed.

> **Merged up before opening.** `main` has since advanced to `a44f4e8` (#608/#625, #615/#628, #627). The two conflicts this branch predicted — `pyomo_pounce/__init__.py` and `CHANGELOG.md`, both "keep both lines" — were the only ones, and are resolved in `d0c2509`. Re-verified on the merged tree: `test_issue_609_init_hardening.py` **29 passed**, full `pyomo-pounce/tests` **377 passed / 4 skipped**, and the new tests still fail on the parent. The measurements below were taken on `cfc11218` and are not re-derived; the behaviours they describe are pinned by tests that pass on the merged tree.

## Problem

The Pyomo initialization stack had four measurable gaps. Each was reproduced on the baseline before anything was written; the harness that produced these numbers is the same script run against both trees, with `PYTHONPATH` selecting which `pyomo_pounce` is imported and the same `pounce` binary (built from `cfc11218`) serving both.

### 1. Options stopped at the projection

`initialize(model, options={"max_iter": 137, "tol": 1e-9})`, with the solver's `solve` wrapped to record what each stage was handed:

| stage | baseline `cfc11218` | after |
|---|---|---|
| projection | `{max_iter: 137, tol: 1e-9}` | `{max_iter: 137, tol: 1e-9, nlp_scaling_method: user-scaling}` |
| block subsystem solve | `{}` | `{max_iter: 137, tol: 1e-9}` |
| stages dropping the option | `['block_subsystem']` | `[]` |

`block_initialize` had no `options` argument at all, so the stage that produces the starting point you actually get ran on solver defaults.

### 2. A failed block abandoned independent branches

Two branches sharing no variable: a 2x2 whose solution lies outside `p`'s bounds, and an unrelated `q -> r` chain.

| | baseline | after |
|---|---|---|
| `q` (exact 7.0) | **0.0** (seed) | 7.0 |
| `r` (exact 8.0) | **0.0** (seed) | 8.0 |
| `n_vars_initialized` | 0 | 2 |
| failed block's own seeds | restored | restored |

### 3. A near-singular square block returned wrong values, silently

`u + v == 2`, `u + (1+eps)v == 2 + eps` (Jacobian condition number ~`4/eps`), feeding `w == u + 2v`. Exact answer `u = v = 1`, `w = 3`.

| eps | baseline values | baseline error | after error | diagnostic |
|---|---|---|---|---|
| 1e-10 | `u=2, v=0, w=2` | **1.0** | 7.54e-09 | rcond 2.50e-11, routed to fallback |
| 1e-14 | `u=2, v=0, w=2` | **1.0** | 7.54e-09 | rcond 2.49e-15, routed to fallback |

The baseline reported `report.ok == True` and said nothing.

### 4. The projection merit was unscaled

**Rows.** A 1e6-unit energy balance beside a 1e-6-unit trace balance, both true at `a = b = 1`:

| | baseline | after |
|---|---|---|
| relative residual, energy row | 1.48e-16 | 0.0 |
| relative residual, trace row | **1.18e-08** | 0.0 |
| error vs exact | 7.87e-09 | **0.0** |

**Variables.** A pressure at 1e6 Pa and a mole fraction at 1e-4, coupled so each contributes 1.0 in its own units, with a 10% deficit:

| | baseline | after |
|---|---|---|
| relative move, pressure | 1.75e-12 | 0.100 |
| relative move, mole fraction | 0.200 | 0.100 |
| ratio | **1.14e+11** | **1.000** |

**Row-rescale invariance** (acceptance criterion 1) was *already met* on the baseline and is reported honestly as such — see Blast radius.

## Cause

1. `repair.initialize` called `block_initialize(model, solver=..., tee=..., repair="off", igraph=...)` — no `options`, because the parameter did not exist. There was also nowhere to put a knob that is not a solver option, so the scaling/conditioning/recovery policies did not exist.
2. The block loop `break`s on the first failed block. The comment said stopping was "the conservative choice" for blocks that "typically feed on the failed one" — but the loop had no representation of which blocks actually did, so it could not distinguish them.
3. The Dulmage–Mendelsohn partition establishes *structural* solvability. Nothing checked numerical rank, so a square block with a near-null direction went to `calculate_variable_from_constraint` / the subsystem solve and landed wherever that direction took it.
4. The merit was `sum((v - v0)**2)` — an absolute distance, so across mixed units a repair goes to whichever variable the constraint gradient favours regardless of physical meaning. And POUNCE's default gradient-based row scaling follows Ipopt's `min(1, g_max/||grad c||)`, which scales a large row **down** and leaves a small row alone; an absolute convergence test then enforces a 1e-6-unit row eight orders of magnitude more loosely than a 1e6-unit one.

## Fix

**`pyomo_pounce/init_options.py`** — `InitOptions`, frozen, validated, carrying `solver_options`, `tee`, `scaling`, `conditioning`, `cond_tol`, `fallback`, `regularization`, `on_block_failure`, `max_list`. One is built per `initialize()` call and threaded through the projection, every block solve, and every fallback solve. `InitOptions.coerce` keeps a bare mapping meaning solver options and **never** reinterprets it as policy — POUNCE has a solver option called `scaling`, so guessing would silently change a solve.

**`pyomo_pounce/init_scaling.py`** — two-sided row normalisation (`1/||grad c||_inf`) and per-anchor variable weights (`w = 1/|v0|`, with a floor so an anchor at zero stays free to move and a cap on the weight spread). Row factors are delivered through the model's own `scaling_factor` Suffix plus `nlp_scaling_method=user-scaling` — the route the NL writer already emits and `pyomo_pounce.scaling` already reads — so the solver learns nothing new, a user's own entry simply wins, and the Suffix is restored entry-by-entry afterwards (a model that declared none does not acquire one).

**`block_init.py`** — `BlockAnalysisReport.block_dependencies` is the block DAG, read off the incidence graph already in hand; a failure skips its transitive descendants via reverse reachability and other branches continue. Each block is rank-checked before solving, on a *scaled* Jacobian, and a weak one is routed to a regularized least-squares fallback. `BlockOutcome` records index/size/constraint/status/rcond/depends_on per block.

**Rejected along the way**, so nobody repeats them:

* *Rounding row factors to powers of two* to make the scaling exact in binary. Implemented, measured, removed: it did not move the residual 1.2e-9 row-rescale spread at all (1.2496e-9 → 1.2200e-9), which disproved the hypothesis that the spread came from factor rounding. It is a solver stopping-point effect — tightening `tol` to 1e-12 collapses the spread to 2.2e-16.
* *Column-normalising the Jacobian* for the conditioning check. It drives every 1x1 block to exactly rcond 1.0, retiring the check on most of a typical calculation order. Columns are scaled by their variable's magnitude instead, which keeps 1x1 blocks informative.
* *Ridging the whole merged group* in the coupled fallback. Measured: it picked `u = 2, v = 0` — precisely the arbitrary end of the near-null direction the fallback exists to avoid, because the downstream block's pull toward its own seed decided the weak block's answer. The ridge now covers only the weak block's own variables.
* *Raising the default `regularization`.* On the regularized path the error **is** the ridge bias and falls linearly with it (7.5e-9 at 1e-8, 7.5e-5 at 1e-4), so the default stays small. The coupled path is limited by the ridge gradient against the solver tolerance instead and wants a larger value (7.4e-3 at 1e-8, 7.6e-5 at 1e-6); that is documented rather than forced into one default.

## Blast radius

**Fixture sweep: empty diff, 57/57 fixtures bit-identical.** `scripts/sweep-fixtures.sh` run against a release binary built from the untouched parent `cfc11218` in a separate worktree, and against a release binary built from this branch; `diff` of the two outputs is empty. This is the expected result — the change is entirely Python-side under `pyomo-pounce/` and no Rust file, `Cargo.toml`, or `Cargo.lock` is touched (`git diff --stat -- '*.rs' Cargo.toml Cargo.lock crates/` is empty). The sweep was run anyway because a scaled projection merit changes the point later solves start from, which is exactly the trajectory class `CLAUDE.md` warns about; the corpus sweep drives the CLI on `.nl` fixtures and does not exercise `pyomo-pounce`, so it bounds the Rust side only. The Python-side trajectory change is bounded by the before/after tables above instead, which is where it is visible.

**Row-rescale invariance is preserved, and this is the one number that moved the wrong way.** Multiplying a row by a constant does not change the feasible set, so the projection must land in the same place:

| rescale factor k | baseline max deviation | after (default tol) | after (`tol=1e-12`) |
|---|---|---|---|
| 1e6 | 0.0 | 1.25e-09 | 5.6e-17 |
| 1e-6 | 0.0 | 0.0 | 0.0 |
| 1e10 | 0.0 | 1.25e-09 | 2.2e-16 |
| 1e-10 | 0.0 | 2.2e-16 | 2.2e-16 |
| nonlinear rows, worst over k ∈ {1e±6, 1e10} | 2.2e-16 | 2.2e-16 | — |

The baseline reached exact invariance; this branch reaches 1.25e-9 at the default tolerance. It is a *tolerance* effect, not a scaling defect, and the evidence is that tightening `tol` to 1e-12 collapses it to 2.2e-16 — with normalised rows the solver stops as soon as the scaled residual is inside `tol`, and where that happens depends on the iterate path. It also is not a quality regression: on the same model the baseline's "invariant" answer sits 2.8e-11 from the true projection while this branch's is exact to machine precision at k=1. The criterion says "invariant within tolerance", and 1.25e-9 is inside the default 1e-8. Recorded here rather than left for the next reader to rediscover.

**Behaviour changes for existing callers**, all opt-out:

* The projection now installs a temporary `scaling_factor` Suffix and turns on `nlp_scaling_method=user-scaling`, unless the caller set `nlp_scaling_method` themselves, the model carries a *non*-export `scaling_factor` Suffix (left strictly alone — flipping it to EXPORT would ship values the user deliberately kept local), or there is nothing to scale. `scaling="none"` restores the old merit exactly.
* The merit is weighted, so the projected point moves on any model whose anchors span magnitudes. On models whose anchors are all the same magnitude the weights are equal and the result is unchanged — the existing `test_project_repairs_inconsistent_fill` still gets 1/3 each.
* A failed block no longer stops the traversal. `on_block_failure="stop"` restores it. Dependent blocks are still skipped, so `test_failure_stops_before_downstream_blocks` is unaffected.
* Weak blocks are rerouted. `conditioning="off"` skips the check; `fallback="off"` diagnoses without rerouting.

**Conflict note.** `claude/pounce-issue-608-loop` (PR #625) conflicts with this branch in **two files**, both trivially:

* `pyomo-pounce/pyomo_pounce/__init__.py` — one hunk, adjacent import lines directly after the `block_init` import block. #608 adds `from pyomo_pounce.continuation import continuation, shift_map`; this branch adds `from pyomo_pounce.init_options import InitOptions`. Resolution is to keep both lines. The `__all__` additions (`continuation`/`shift_map` vs `BlockOutcome`/`InitOptions`) land in different parts of the list and merge cleanly.
* `CHANGELOG.md` — both add an entry at the top of `[Unreleased]`. Resolution is to keep both entries.

`repair.py` and `block_init.py` are untouched by #608, and `continuation.py` is untouched by this branch, so there is no semantic overlap — only the two textual hunks above. Verified with `git merge-tree --write-tree HEAD origin/claude/pounce-issue-608-loop`. **#625 has since merged and the resolution above was applied as described in `d0c2509`.**

## Tests

`pyomo-pounce/tests/test_issue_609_init_hardening.py`, 29 tests. Every number in their comments is a measurement on `cfc11218`.

**How they bite.** As written the module does not import on the parent at all — `InitOptions` does not exist — so collection fails there and that alone is not evidence. Re-run against the parent with the `InitOptions` import and the new-attribute assertions stripped, so only parent-era API is used, **nine fail behaviourally and for the right reason**:

| test | parent failure |
|---|---|
| `small_magnitude_row_is_enforced_like_a_large_one` | `0.9999999921 != 1.0 ± 1e-11` |
| `merit_shares_repair_by_relative_magnitude` | pressure moved `1.75e-12`, expected `0.2` |
| `user_scaling_suffix_entries_win_over_the_automatic_ones` | `0.9999999921 != 1.0 ± 1e-11` |
| `options_reach_every_stage` | `('block_subsystem', {})` — option dropped |
| `independent_branch_survives_a_failure` | `q = 0.0`, expected `7.0` |
| `near_singular_block_...[1e-10]`, `[1e-14]` | `u = 2.0`, expected `1.0` |
| `healthy_blocks_are_not_diagnosed` | `AttributeError: no attribute 'diagnostics'` |
| `block_initialize_takes_options_directly` | `TypeError: unexpected keyword argument 'options'` |

The last two are **API absence, not a behavioural bite**, and are listed as such rather than dressed up: there is no parent-era way to ask "was a diagnostic emitted" when the field does not exist.

**Two tests pass on the parent by design** — they are preservation guards, not regression tests:

* `test_projection_leaves_no_scaling_suffix_behind` holds the Suffix restoration.
* `test_still_one_incidence_walk_per_initialize` holds gh #444's single whole-model incidence walk, which is an acceptance criterion here.

Both bite when broken. Making `_block_dependencies` construct an `IncidenceGraphInterface` instead of reading the one already in hand fails **four** cache guards: the two in this file and `test_shared_graph_matches_fresh_analysis` / `test_shared_graph_zero_decision_falls_back_to_fresh` in `test_repair.py`. That was run and reverted, not assumed.

**Suite results** (Pyomo 6.10.1, so the `pyomo_pounce.v2` floor is met; the CLI binary was built and staged into `python/pounce/bin/` so the plugin resolves this checkout's build rather than falling back to PATH):

| suite | result |
|---|---|
| `pyomo-pounce/tests` | **372 passed, 0 skipped** (343 before this branch + 29 new) |
| `python/tests` | 815 passed, 36 skipped |
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --workspace --exclude pounce-hsl --all-targets` | exit 0 (pre-existing warnings only; no Rust touched) |
| `cargo test --workspace --exclude pounce-hsl` | exit 0, 226 suites green |
| `scripts/check-release-consistency.sh` | OK |
| `scripts/check-docs-consistency.sh` | OK — 44 pages, no dead links |

On the merged tree (`d0c2509`, after taking in #608/#615/#627) the same suites read **`pyomo-pounce/tests` 377 passed / 4 skipped** and `test_issue_609_init_hardening.py` **29 passed**; the extra tests and skips are #608's, not this branch's.

**Not pinned, deliberately.** The row-rescale invariance test asserts at `tol=1e-12` rather than the default, because at the default tolerance the quantity it measures is the solver's stopping behaviour and not the scaling. Pinning 1.25e-9 at the default would pin solver noise.

---

## Acceptance criteria

| # | criterion | verdict |
|---|---|---|
| 1 | Initialization is invariant within tolerance under equivalent row rescaling | **met** — 2.2e-16 at `tol=1e-12`; 1.25e-9 at the default, inside it. Already held on the baseline; kept, and now pinned by `test_projection_is_invariant_under_row_rescaling`. The deviation at default tolerance is recorded above rather than hidden. |
| 2 | The same options reach every selected initialization stage | **met** — stages dropping the option: `['block_subsystem']` → `[]` |
| 3 | A failure in one branch does not prevent initialization of independent branches | **met** — `n_vars_initialized` 0 → 2; `q, r` reach 7.0, 8.0 |
| 4 | Near-singular structurally square blocks produce a diagnostic/fallback rather than unstable values | **met** — error 1.0 → 7.5e-9, with `rcond` and a `diagnostics` entry |
| 5 | Existing incidence-plan caching from #444 is preserved | **met** — one walk per call, on the success *and* the failure path; four guards fail if broken |

## Scope items

| # | item | verdict |
|---|---|---|
| 1 | Row/variable scaling in the projection merit, user scaling suffix support, robust automatic defaults | **met** — `init_scaling.py`; suffix entries win; floor + spread cap as the robustness guards |
| 2 | One typed initialization-options object, propagated through repair, block solve, projection, and fallback | **met** — `InitOptions`, built once per call and threaded through all four |
| 3 | Track the block graph explicitly; on failure skip dependent descendants but continue independent branches | **met** — `BlockAnalysisReport.block_dependencies` + reverse reachability |
| 4 | Numerical rank/conditioning checks after structural matching; route weak blocks to regularized least squares or a coupled fallback | **met** — scaled-Jacobian rcond vs `cond_tol`; both `fallback="regularized"` and `fallback="coupled"` implemented and tested |
| 5 | Structured report of initialized, skipped, failed, and fallback blocks | **met** — `BlockOutcome` + `report.blocks` and the four bucket properties |

Nothing deferred; no follow-up issues filed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXUyBXwW7GQQAX6byMXnw4)_