### PR TITLE
casadi wheel: tag it for the platform it was built for

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,6 +588,42 @@ jobs:
                 "| builds shipped:", pounce_casadi.supported_casadi_versions())
           PY
 
+      # The wheel carries a compiled plugin and the solver library, so it
+      # must not be tagged `any`. It was: setuptools sees no `ext_modules`
+      # and calls the distribution pure, so `pip install` on Linux accepted
+      # a macOS build and the user met a missing `.dylib` at import instead
+      # of a resolver error at install. `build.sh` asserts this too; the
+      # check is repeated here because CI is where a packaging regression
+      # gets noticed on a platform nobody is building on by hand.
+      - name: Wheel is platform-tagged, not `any`
+        run: |
+          cd casadi/wheel
+          whl=$(ls dist/pounce_casadi-*.whl)
+          echo "built $(basename "$whl")"
+          case "$(basename "$whl")" in
+            *-none-any.whl)
+              echo "::error::wheel is tagged py3-none-any while carrying"\
+                   "platform-specific shared libraries; it would install on"\
+                   "every platform and import on one."
+              exit 1;;
+          esac
+          python - "$whl" <<'PY'
+          import sys, zipfile
+          z = zipfile.ZipFile(sys.argv[1])
+          meta = next(n for n in z.namelist() if n.endswith(".dist-info/WHEEL"))
+          text = z.read(meta).decode()
+          print(text)
+          assert "Root-Is-Purelib: false" in text, text
+          tag = next(l.split(": ", 1)[1] for l in text.splitlines()
+                     if l.startswith("Tag: "))
+          impl, abi, plat = tag.split("-")
+          assert plat != "any", tag
+          # One build serves every Python 3 -- nothing here links the
+          # CPython ABI -- so a cp3xx tag would be wrong in the other
+          # direction and would strand users on the next Python release.
+          assert (impl, abi) == ("py3", "none"), tag
+          PY
+
       # The wheel is supposed to carry its own copy of the solver library and
       # find it beside itself, so it must keep working with the build tree
       # gone. Before the install-name fix it did work here — but only because

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ changes.
 
 ## [Unreleased]
 
+- **The `pounce-casadi` wheel is tagged for the platform it was built
+  for** (#626 follow-up). It was `py3-none-any` — pip's tag for "pure
+  Python, installs anywhere" — while carrying a compiled CasADi plugin and
+  the POUNCE solver library under `pounce_casadi/_plugins/<minor>/`.
+  setuptools reaches that conclusion because the package defines no
+  `ext_modules`: it loads its payload with `ctypes`, and package data is
+  not something setuptools inspects. So a wheel built on macOS installed
+  cleanly on Linux and failed at `import pounce_casadi`, looking for a
+  `.dylib` that platform cannot load.
+
+  Measured on the wheel `build.sh` produced before this change, offered to
+  a Linux target: `pip install --platform manylinux_2_28_x86_64` accepted
+  it and unpacked `libcasadi_nlpsol_pounce.dylib` into place. After: `pip`
+  refuses it — *"not a supported wheel on this platform"* — which is where
+  that decision belongs.
+
+  Nothing was published, so no user hit this; it was a defect in the
+  release path rather than in a release.
+
+  The tag is now `py3-none-<platform>`. Platform-specific in one direction
+  and *not* CPython-specific in the other: an impure wheel defaults to
+  `cp311-cp311-…`, which would be wrong the other way round, since nothing
+  here links the CPython ABI and one build per platform serves every
+  Python 3. `POUNCE_CASADI_PLAT_NAME` overrides the platform half for
+  manylinux and macOS cross builds — worth noting that `auditwheel repair`
+  refuses a `py3-none-any` wheel outright, so the documented Linux release
+  step could not have run before this.
+
+  The CasADi axis of the matrix stays where it was, inside the wheel: no
+  wheel tag can express "built against casadi 3.7.x", so one wheel per
+  platform carries a build per supported minor and selects on
+  `casadi.__version__` at import. `POUNCE_CASADI_STAGE_ONLY=1` stages a
+  minor without building, which is what makes the documented
+  once-per-(minor × platform) release loop expressible as a script.
+
+  Three supporting changes, each for a failure that was silent:
+  `build.sh` and CI now *assert* the built tag rather than trust it, since
+  a packaging regression here shows up only on a machine the packager does
+  not have; `build.sh` treats a missing solver library as fatal instead of
+  a warning, because staging without it produces exactly the
+  installs-then-fails-at-import artefact this entry is about; and
+  `plugin_path` now distinguishes "no build for this platform" from "no
+  build for this CasADi version" — a hand-copied wheel used to report the
+  platform mismatch as a missing CasADi version, sending the reader after
+  the wrong axis.
+
 - **Pyomo initialization: scaled projection, options that reach every
   stage, and a failed block that no longer takes independent branches
   down with it** (#609). Four measurements on the parent commit

--- a/casadi/wheel/README.md
+++ b/casadi/wheel/README.md
@@ -43,13 +43,55 @@ so this package refuses to guess: it ships one build per supported minor
 version under `pounce_casadi/_plugins/<minor>/` and selects on
 `casadi.__version__`, raising a clear `ImportError` when there is no match.
 
-To publish, `build.sh` has to run once per (CasADi minor × platform) and the
-resulting `_plugins/<minor>/` trees merged into one wheel per platform:
+### The tag scheme
+
+The two axes are not symmetric, and the wheel tag only carries one of them.
+
+**Platform is in the tag.** The wheel is `py3-none-<platform>` —
+`macosx_11_0_arm64`, `manylinux_2_28_x86_64`, `win_amd64`. Not `any`: it
+carries a compiled plugin and the solver library, so a build for one
+platform must not install on another, and `pip` is the right place to say
+so. Not `cp311` either: nothing here links the CPython ABI — the payload is
+loaded with `ctypes` — so one build per platform serves every Python 3, and
+a CPython tag would strand users on the next Python release for no reason.
+`setup.py` does both halves; `build.sh` and CI assert the result rather than
+trust it, because the failure is silent at build time and only shows up on
+a machine the packager does not have.
+
+`POUNCE_CASADI_PLAT_NAME` overrides the platform half for a build whose
+host is not its target: a manylinux tag (a raw `linux_x86_64` wheel is not
+installable from PyPI, and `auditwheel repair` is the usual way to get one —
+this is the escape hatch when it is not in the loop), or a macOS cross or
+`universal2` build.
+
+**CasADi minor is not in the tag, and cannot be.** CasADi is a runtime
+dependency; there is no wheel tag that expresses "built against casadi
+3.7.x". So it is resolved inside the wheel: one build per minor under
+`_plugins/<minor>/`, selected on `casadi.__version__` at import, with a
+plain `ImportError` when there is no match. One wheel per platform carries
+every supported minor.
+
+So the matrix collapses to: run `build.sh` once per (CasADi minor ×
+platform), and per platform merge the staged `_plugins/<minor>/` trees into
+a single wheel. Within one platform the runs share this tree and the staging
+directory accumulates, so that is:
+
+```sh
+# in a platform's build image, once per supported casadi minor
+pip install 'casadi==3.6.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
+pip install 'casadi==3.7.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
+./build.sh          # one wheel carrying both
+```
+
+Per-platform build notes:
 
 - **Linux** — inside a manylinux image, `-D_GLIBCXX_USE_CXX11_ABI=0` to match
   the CasADi wheels (the Makefile's default), then `auditwheel` **excluding**
   `libcasadi` (it must resolve to the user's installed copy at runtime, not be
-  vendored).
+  vendored). `auditwheel repair` also does the manylinux retag, so
+  `POUNCE_CASADI_PLAT_NAME` is not needed when it runs — but note it *refuses*
+  a `py3-none-any` wheel outright, so before the tagging fix this step could
+  not have run at all.
 - **macOS** — x86_64 and arm64. The Makefile rewrites the plugin's reference
   to `libpounce_cinterface` to `@rpath` and adds `@loader_path`, because Rust
   stamps a cdylib's install name with its absolute *build* path; without that
@@ -59,6 +101,15 @@ resulting `_plugins/<minor>/` trees merged into one wheel per platform:
   the build tree and re-solves through the installed wheel, since a plugin
   that only *appears* relocatable passes every other test on the build
   machine.
+
+  Watch the platform tag on macOS: it takes its OS version from
+  `MACOSX_DEPLOYMENT_TARGET`, which defaults to the *building* machine's.
+  A build on macOS 26 tags `macosx_26_0_arm64` and pip then declines it on
+  every older macOS — a wheel that is correct and almost universally
+  uninstallable. Set `MACOSX_DEPLOYMENT_TARGET=11.0` (or
+  `POUNCE_CASADI_PLAT_NAME`) for a release build. CI does not catch this:
+  its runner and its test environment are the same machine, so the tag is
+  always satisfiable there.
 - **Windows** — MSVC, matching CasADi's own toolchain.
 
 CasADi minor releases are infrequent (3.6 in 2023, 3.7 in 2025), so the matrix

--- a/casadi/wheel/build.sh
+++ b/casadi/wheel/build.sh
@@ -1,17 +1,48 @@
 #!/usr/bin/env bash
 # Stage the plugin for the *installed* casadi and build a wheel.
 #
-#   ./build.sh                 # wheel for the casadi in this environment
+#   ./build.sh                      # wheel for the casadi in this environment
+#   POUNCE_CASADI_STAGE_ONLY=1 ./build.sh    # stage, do not build the wheel
+#   POUNCE_CASADI_PLAT_NAME=manylinux_2_28_x86_64 ./build.sh
 #
-# A release build runs this once per (casadi minor x platform) inside the
-# appropriate manylinux / macOS / Windows image and merges the staged
-# _plugins/<minor>/ trees into a single wheel per platform.
+# A release build runs this once per (casadi minor x platform). Within one
+# platform the runs share this tree and `_plugins/<minor>/` accumulates, so
+# the shape is: stage every minor with POUNCE_CASADI_STAGE_ONLY=1, then one
+# final run to build the single wheel that carries them all.
+#
+# The wheel is tagged `py3-none-<platform>` -- see setup.py for why that is
+# neither `any` nor `cp311`. The casadi axis is not in the tag: casadi is a
+# runtime dependency selected on `casadi.__version__` at import, and no wheel
+# tag can express it.
 set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$here/../.."
 
-ver=$(python3 -c "import casadi; print(casadi.__version__)")
-minor=$(python3 -c "import casadi; print('.'.join(casadi.__version__.split('.')[:2]))")
+# Probe casadi from a neutral directory. `python3 -c` puts the current
+# directory first on sys.path and this repository has a `casadi/` directory
+# of its own, so running build.sh from the repo root otherwise imports the
+# source tree as a namespace package -- which does not fail, it succeeds and
+# then dies on `AttributeError: module 'casadi' has no attribute
+# '__version__'`, which reads like a broken casadi install.
+probe=$(cd / && python3 - <<'PY'
+import sys
+
+try:
+    import casadi
+except ImportError:
+    sys.exit(
+        "error: casadi is not installed in this environment.\n"
+        "       pip install 'casadi>=3.7,<3.8' and re-run."
+    )
+version = getattr(casadi, "__version__", None)
+if version is None:
+    sys.exit(f"error: imported casadi from {casadi.__file__!r}, which has no "
+             "__version__; that is not the casadi package.")
+print(version, ".".join(version.split(".")[:2]))
+PY
+)
+ver=${probe%% *}
+minor=${probe##* }
 echo "building pounce-casadi for casadi $ver"
 
 cargo build --release -p pounce-cinterface --manifest-path "$root/Cargo.toml"
@@ -31,8 +62,34 @@ for f in "$root/target/release/libpounce_cinterface.so" \
   if [ -f "$f" ]; then cp "$f" "$dest/"; copied=1; fi
 done
 if [ "$copied" = 0 ]; then
-  echo "warning: no libpounce_cinterface shared library in $root/target/release" >&2
+  # Fatal, not a warning: the plugin resolves the solver beside itself, so
+  # a wheel staged without it installs and then fails at import. That is
+  # the failure mode this script exists to prevent, and it is worse when
+  # the artefact is already published.
+  echo "error: no libpounce_cinterface shared library in $root/target/release" >&2
+  exit 1
 fi
 
+if [ -n "${POUNCE_CASADI_STAGE_ONLY:-}" ]; then
+  echo "staged $dest (POUNCE_CASADI_STAGE_ONLY set; no wheel built)"
+  exit 0
+fi
+
+rm -rf "$here/dist"
 python3 -m pip wheel --no-deps -w "$here/dist" "$here"
-echo "wheel written to $here/dist"
+
+# Assert the tag rather than trust it. A wheel tagged `any` installs on
+# every platform and carries exactly one platform's shared libraries, so
+# `pip install` succeeds and `import pounce_casadi` is where the user finds
+# out. If setup.py stops being picked up -- a build frontend change, a
+# setuptools change, someone deleting it as redundant next to pyproject.toml
+# -- this is what says so, here, instead of in a bug report.
+wheel=$(ls "$here"/dist/pounce_casadi-*.whl)
+case "$(basename "$wheel")" in
+  *-none-any.whl)
+    echo "error: built $(basename "$wheel"), which claims to install on every" >&2
+    echo "       platform while carrying one platform's binaries. setup.py's" >&2
+    echo "       platform tagging did not take effect." >&2
+    exit 1;;
+esac
+echo "wheel written to $here/dist: $(basename "$wheel")"

--- a/casadi/wheel/pounce_casadi/__init__.py
+++ b/casadi/wheel/pounce_casadi/__init__.py
@@ -13,6 +13,12 @@ specific CasADi **minor** version; CasADi performs no version handshake
 of its own, and a mismatched plugin would load and then misbehave. This
 package therefore ships one build per supported minor version and
 selects on the CasADi actually installed, refusing to guess.
+
+The *platform* axis is handled the other way round, by the wheel tag
+(``py3-none-<platform>``, see ``../setup.py``): pip declines a wheel built
+for another platform, so the mismatch is caught by the resolver and never
+reaches import. A wheel copied into place by hand can still get here, which
+is what :func:`plugin_path` distinguishes when it reports a miss.
 """
 
 from __future__ import annotations
@@ -49,6 +55,16 @@ def supported_casadi_versions() -> list[str]:
     )
 
 
+def _staged_casadi_versions() -> list[str]:
+    """Minor versions with a `_plugins/<minor>/` directory, any platform."""
+    if not os.path.isdir(_PLUGIN_DIR):
+        return []
+    return sorted(
+        d for d in os.listdir(_PLUGIN_DIR)
+        if os.path.isdir(os.path.join(_PLUGIN_DIR, d))
+    )
+
+
 def plugin_path(casadi_version: str | None = None) -> str:
     """Absolute path to the plugin matching `casadi_version` (default: installed)."""
     import casadi
@@ -56,15 +72,35 @@ def plugin_path(casadi_version: str | None = None) -> str:
     version = casadi_version or casadi.__version__
     minor = ".".join(version.split(".")[:2])
     candidate = os.path.join(_PLUGIN_DIR, minor, _PLUGIN_LIB)
-    if not os.path.isfile(candidate):
-        available = supported_casadi_versions()
+    if os.path.isfile(candidate):
+        return candidate
+
+    # Two different failures reach here, and conflating them sends the
+    # reader after the wrong one. A build for this casadi that is for
+    # another platform is a *packaging* fault -- the wheel tag exists to
+    # make pip refuse it, so getting here means it was installed by hand
+    # or force-reinstalled -- and no amount of changing casadi versions
+    # will fix it.
+    staged = _staged_casadi_versions()
+    if minor in staged:
+        present = sorted(os.listdir(os.path.join(_PLUGIN_DIR, minor)))
         raise ImportError(
-            f"pounce-casadi has no plugin for casadi {version}. "
-            f"Builds available here: {', '.join(available) or 'none'}. "
-            "Install a matching casadi, upgrade pounce-casadi, or build the "
-            "plugin from the pounce repository (see casadi/README.md)."
+            f"pounce-casadi carries a build for casadi {minor}, but not for "
+            f"this platform ({sys.platform}): it has no {_PLUGIN_LIB}, only "
+            f"{', '.join(present) or 'nothing'}. This wheel was built for "
+            "another platform -- its tag should have stopped pip from "
+            "installing it here, so it was most likely copied or "
+            "force-installed. Install the wheel for this platform, or build "
+            "the plugin from the pounce repository (see casadi/README.md)."
         )
-    return candidate
+
+    available = supported_casadi_versions()
+    raise ImportError(
+        f"pounce-casadi has no plugin for casadi {version}. "
+        f"Builds available here: {', '.join(available) or 'none'}. "
+        "Install a matching casadi, upgrade pounce-casadi, or build the "
+        "plugin from the pounce repository (see casadi/README.md)."
+    )
 
 
 def register() -> None:

--- a/casadi/wheel/setup.py
+++ b/casadi/wheel/setup.py
@@ -1,0 +1,80 @@
+"""Platform tagging for the ``pounce-casadi`` wheel.
+
+Everything in this package is pure Python — it loads its payload with
+``ctypes`` and defines no extension module — but the payload itself is
+compiled: a CasADi ``nlpsol`` plugin and the POUNCE solver library, under
+``pounce_casadi/_plugins/<casadi-minor>/``. setuptools sees no
+``ext_modules``, concludes the distribution is pure, and tags the wheel
+``py3-none-any``.
+
+That tag is a promise the wheel cannot keep. ``pip`` reads it as "installs
+anywhere", so a wheel built on macOS installs happily on Linux and the user
+finds out at ``import pounce_casadi``, where the ``.dylib`` it wants is not
+the ``.so`` the platform can load. The failure should happen at install
+time, on the resolver, which is what a real platform tag buys.
+
+Two adjustments, in opposite directions:
+
+* ``root_is_pure = False`` moves the package into ``platlib`` and stamps the
+  building platform onto the tag.
+* ``get_tag`` puts the *Python* half back to ``py3``/``none``. The default
+  for an impure wheel is ``cp311-cp311-…``, which is wrong the other way:
+  nothing here is compiled against the CPython ABI, so one build genuinely
+  does serve every Python 3 on that platform, and a ``cp311`` tag would
+  make ``pip`` reject it on 3.12 for no reason.
+
+The result is ``py3-none-<platform>``: one wheel per platform, each
+carrying a build for every supported CasADi minor and choosing between
+them at import. The CasADi axis of the matrix stays inside the wheel —
+CasADi is a runtime dependency resolved by ``casadi.__version__``, and
+there is no wheel tag that could express it.
+
+``POUNCE_CASADI_PLAT_NAME`` overrides the platform half, for the two cases
+where the building machine is not the target: a manylinux build (the raw
+``linux_x86_64`` tag is not installable from PyPI — ``auditwheel repair``
+normally retags, and this is the escape hatch when it is not in the loop)
+and a macOS cross build (``macosx_11_0_universal2`` and friends).
+"""
+
+from __future__ import annotations
+
+import os
+
+from setuptools import setup
+from setuptools.dist import Distribution
+
+try:  # setuptools >= 70.1 vendors the command
+    from setuptools.command.bdist_wheel import bdist_wheel
+except ImportError:  # pragma: no cover - older setuptools
+    from wheel.bdist_wheel import bdist_wheel  # type: ignore[import-not-found]
+
+
+class BinaryDistribution(Distribution):
+    """Claim compiled content so ``bdist_wheel`` starts out impure.
+
+    ``has_ext_modules`` is what setuptools consults, and it answers on
+    ``ext_modules``, which is empty here. The compiled content is package
+    data, which it does not look at.
+    """
+
+    def has_ext_modules(self) -> bool:
+        return True
+
+
+class PlatformTaggedWheel(bdist_wheel):
+    def finalize_options(self) -> None:
+        super().finalize_options()
+        self.root_is_pure = False
+
+    def get_tag(self) -> tuple[str, str, str]:
+        _python, _abi, plat = super().get_tag()
+        override = os.environ.get("POUNCE_CASADI_PLAT_NAME")
+        if override:
+            plat = override
+        # Wheel filenames use `_` for every separator; distutils platform
+        # names arrive with `-` and `.` in them (`macosx-11.0-arm64`).
+        plat = plat.replace("-", "_").replace(".", "_")
+        return "py3", "none", plat
+
+
+setup(distclass=BinaryDistribution, cmdclass={"bdist_wheel": PlatformTaggedWheel})

--- a/docs/src/casadi.md
+++ b/docs/src/casadi.md
@@ -49,6 +49,17 @@ Importing the package loads the plugin into the process and registers it
 with CasADi directly, which leaves CasADi's own installation untouched
 and its bundled plugins — Ipopt included — loadable alongside.
 
+The wheel this produces is tagged `py3-none-<platform>`, and carries a
+build of the plugin for each supported CasADi **minor** version under
+`pounce_casadi/_plugins/<minor>/`, chosen on `casadi.__version__` at
+import. The two axes are handled at different layers deliberately: the
+platform is in the wheel tag, so `pip` refuses a wheel from the wrong
+one, while the CasADi version cannot be expressed by any tag and is
+resolved inside the package, with a plain `ImportError` when there is no
+matching build. See [`casadi/wheel/README.md`](
+https://github.com/jkitchin/pounce/blob/main/casadi/wheel/README.md) for
+the release matrix.
+
 **Or in place**, without packaging:
 
 ```bash


### PR DESCRIPTION
`pounce-casadi` shipped as `py3-none-any` — pip's tag for "pure Python,
installs anywhere" — while carrying a compiled CasADi plugin and the POUNCE
solver library under `pounce_casadi/_plugins/<minor>/`. setuptools reaches
that conclusion because the package declares no `ext_modules`: it loads its
payload with `ctypes`, and package data is not something setuptools inspects.

Follow-up to #626, which landed the plugin and flagged the published-wheel
matrix as the decision left open.

## The defect, measured

The wheel `build.sh` produced before this change, offered to a Linux target:

```console
$ pip install --no-deps --target /tmp/t --platform manylinux_2_28_x86_64 \
      --only-binary=:all: pounce_casadi-0.10.0-py3-none-any.whl
$ ls /tmp/t/pounce_casadi/_plugins/3.7/
libcasadi_nlpsol_pounce.dylib
libpounce_cinterface.dylib
```

Accepted, and a macOS `.dylib` unpacked onto a Linux target. The user meets
it at `import pounce_casadi`, not at `pip install`. After this change:

```console
ERROR: pounce_casadi-0.10.0-py3-none-macosx_11_0_arm64.whl is not a
supported wheel on this platform.
```

Nothing is published, so no user hit this — it was a defect in the release
path rather than in a release.

## The tag scheme

The two axes of the (CasADi minor × platform) matrix are not symmetric, and
only one of them can live in the tag.

**Platform is in the tag:** `py3-none-<platform>`. Not `any`, for the reason
above. Not `cp312` either — the default for an impure wheel, and wrong the
other way round: nothing here links the CPython ABI, so one build per
platform serves every Python 3, and a CPython tag would strand users on the
next Python release for nothing. `setup.py` sets `root_is_pure = False` for
the platform half and overrides `get_tag` to hold the Python half at
`py3`/`none`.

**CasADi minor is not in the tag, and cannot be** — no wheel tag expresses
"built against casadi 3.7.x". That axis was already handled correctly inside
the package: one build per minor under `_plugins/<minor>/`, selected on
`casadi.__version__` at import. One wheel per platform carries every
supported minor.

So the release loop is: stage once per minor, build once per platform.
`POUNCE_CASADI_STAGE_ONLY=1` makes that expressible as a script instead of
prose, and `POUNCE_CASADI_PLAT_NAME` overrides the platform half for
manylinux and macOS cross builds.

```sh
pip install 'casadi==3.6.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
pip install 'casadi==3.7.*' && POUNCE_CASADI_STAGE_ONLY=1 ./build.sh
./build.sh          # one wheel carrying both
```

Note `auditwheel repair` **refuses** a `py3-none-any` wheel outright, so the
Linux release step `casadi/wheel/README.md` already documented could not
have run before this.

## Verified

End to end against casadi 3.7.2 on macOS arm64, not just the packaging
metadata:

- `build.sh` builds `pounce_casadi-0.10.0-py3-none-macosx_11_0_arm64.whl`;
- it installs into a clean venv containing only casadi, registers the
  plugin, and solves Rosenbrock to `[1, 1]`;
- staging 3.6 and 3.7 then building once yields a single wheel carrying
  both (`_plugins/` → `['3.6', '3.7']`);
- the old `any` wheel installs onto a Linux target and the new one is
  refused, as above;
- the new CI gate passes the tagged wheel and fails the old one.

## Supporting changes, each for something that failed silently

- **`build.sh` and CI assert the built tag** rather than trust it. A
  regression here — `setup.py` stops being picked up, a build frontend
  changes, someone deletes it as redundant next to `pyproject.toml` — is
  invisible on the machine that builds and surfaces only on one the packager
  does not have.
- **A missing `libpounce_cinterface` is now fatal**, not a warning. Staging
  without it produces exactly the installs-then-fails-at-import artefact
  this PR is about.
- **`plugin_path` separates "no build for this platform" from "no build for
  this CasADi version".** `supported_casadi_versions` filters on *this*
  platform's library name, so a hand-copied foreign wheel reported the
  platform mismatch as a missing CasADi version — pointing the reader at the
  wrong axis entirely.

## Fixed while reproducing

`build.sh` probed `casadi.__version__` with `python3 -c` from the invoking
directory, and this repository has a `casadi/` directory. Run from the repo
root — the obvious place — the probe imported the source tree as a namespace
package, *succeeded*, and then died on `AttributeError: module 'casadi' has
no attribute '__version__'`, which reads like a broken casadi install. It
now probes from a neutral directory and says plainly when casadi is missing.

## One thing CI cannot catch

On macOS the platform tag takes its OS version from
`MACOSX_DEPLOYMENT_TARGET`, defaulting to the *building* machine's. Building
here tagged `macosx_26_0_arm64` — correct, and uninstallable on every older
macOS. A release build must set `MACOSX_DEPLOYMENT_TARGET=11.0` or
`POUNCE_CASADI_PLAT_NAME`. CI can't detect it: its runner and its test
environment are the same machine, so the tag is always satisfiable there.
The README now says so.

## Still not in scope

Publishing. This makes the artefact correct; the decision to run the matrix
and push to PyPI is still open, as #626 left it.
