### PR TITLE
Stop CHANGELOG [Unreleased] from conflicting between queued PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,24 @@
+# Every PR prepends its entry to CHANGELOG.md's `[Unreleased]` section, so
+# any two open PRs conflict there on exactly the same lines — N queued PRs
+# produce N-1 conflicts, none of which is a disagreement about anything.
+# Measured during the 17 Aug rush (#637, #638, #639, #640, #642 open at
+# once): #637 was re-synced twice in one hour and conflicted in this file
+# both times, in the `[Unreleased]` section only.
+#
+# `merge=union` is git's built-in driver for exactly this shape: on a
+# conflicting hunk it keeps both sides' lines instead of stopping. Both
+# entries survive, in whichever order the hunks give, and the merge
+# completes.
+#
+# The trade it makes is real and worth knowing before relying on it: union
+# is not smart, it is *silent*. Two branches editing the SAME line — two
+# rewordings of one entry, say — produce both lines, one after the other,
+# with no conflict raised for anyone to adjudicate. That is a contradictory
+# changelog landing unreviewed rather than a merge that stops and asks. It
+# is the right trade only because entries here are append-only in practice:
+# a PR adds its own entry and does not edit anyone else's.
+#
+# So: still read the `[Unreleased]` seam after a merge. Union also tends to
+# eat the blank line between the two entries it joins, which is cosmetic
+# but visible in the rendered changelog.
+CHANGELOG.md merge=union


### PR DESCRIPTION
One line of `.gitattributes`. Split out of #637 because it is unrelated to that PR's subject and affects every branch.

## Problem

Every PR prepends its entry to the same place in `CHANGELOG.md`, so any two open PRs conflict on exactly the same lines. N queued PRs produce N-1 conflicts, and none of them is a disagreement about anything — both sides simply added a paragraph at the top.

Measured today, with #637, #638, #639, #640 and #642 open at once. #637 was re-synced against `main` twice within one hour:

| main moved | result |
|---|---|
| `eeca47f` → `1e8d601` (#631) | conflict in `CHANGELOG.md`, `[Unreleased]` only |
| `1e8d601` → `41e8792` (#638) | conflict in `CHANGELOG.md`, `[Unreleased]` only |

Nothing else in either merge conflicted. Each round costs a hand resolution plus a full CI cycle, and the next PR to land invalidates it.

Worth noting for anyone who tries to pre-check this: `git merge-tree` reported the first of those merges as clean. It was not. Only the real merge showed the conflict.

## Fix

`merge=union` is git's built-in driver for exactly this shape — on a conflicting hunk it keeps both sides' lines instead of stopping. Both entries survive and the merge completes.

Verified against this repository's actual CHANGELOG, not just in principle: two throwaway branches each prepending an entry to `[Unreleased]` conflict without the attribute, and with it merge clean with both entries present.

```
## [Unreleased]

- **fake entry B** (#902)
  body B
- **fake entry A** (#901)
  body A
```

## Blast radius

Merge behaviour for one file. No build, test, or runtime effect, and nothing in the solver is touched. It applies to everyone's local merges and rebases from the moment it lands.

One limit I could not verify from here: whether GitHub's **server-side** merge honours the attribute when it computes mergeability and merges a PR. Git honours it locally — that is what the evidence above shows — so the hand-resolution cost goes away for anyone merging `main` into their branch, which is where the pain actually was. If GitHub's own merge ignores it, this is neutral there rather than harmful, and the next queued pair will tell us.

## What it costs

Recorded in the file itself, because it is not obvious from the one-line diff: **union is not smart, it is silent.** Two branches editing the *same* line — two rewordings of one entry — produce both lines, one after the other, with no conflict raised for anyone to adjudicate:

```
- **shared entry** (#100)
  reworded by B
  reworded by A
```

That is a contradictory changelog landing unreviewed, where today it would stop and ask. It is an acceptable trade only because entries here are append-only in practice: a PR adds its own entry and does not edit anyone else's. If that stops being true, this attribute should go.

Two smaller notes, also in the file: the `[Unreleased]` seam still deserves a glance after a merge, and union tends to eat the blank line between the two entries it joins, which is cosmetic but shows up in the rendered changelog.

## Tests

None — there is no code here. The behaviour claims above were each reproduced by hand in this repository (with the attribute and without), and both the conflict and the silent-duplication failure mode were observed rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUXrfbxsYqpUuxpLmrBsSi

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUXrfbxsYqpUuxpLmrBsSi)_