### PR TITLE
sens: decide base-bound activity once, in a table both scans read

### DIFF
--- a/crates/pounce-sensitivity/src/boundcheck.rs
+++ b/crates/pounce-sensitivity/src/boundcheck.rs
@@ -607,6 +607,59 @@ where
         backsolver.bound_rows().map(|b| b.to_vec());
     let can_release = backsolver.supports_release();
 
+    // Which bounds the factorization enforces, decided once. Active
+    // means the multiplier dominates the slack. A converged interior
+    // point never sits ON a bound: an active bound's slack is order mu
+    // over the multiplier, so testing slack against `eps` calls every
+    // active bound inactive and the path never releases anything.
+    // Complementarity splits the two sides cleanly, z of order one
+    // against slack of order mu on the active side and the reverse on
+    // the inactive, which is the same split the activity classifier
+    // draws.
+    //
+    // The split is evaluated at the BASE point, which is what makes
+    // deciding it here, before the loop, correct rather than a cache:
+    // activity of a multiplier row is a property of the factorization,
+    // whose sigma for this bound was frozen at the base, and a bound
+    // inactive there is represented by a Schur-row hold if the path
+    // reaches it, never by its multiplier row. Testing accumulated
+    // values instead let a near-bound inactive multiplier drift past
+    // its shrinking slack mid-path and "release" a bound that was
+    // never held, putting a departure in the record for a variable
+    // that was not on that bound.
+    //
+    // What stays live at every consumer is the released list: a
+    // base-active bound whose row has been released is no longer in
+    // the factorization, from that fraction on.
+    let mut base_active_row: Vec<[Option<usize>; 2]> = vec![[None, None]; n_x];
+    if let Some(rows) = bound_rows.as_ref() {
+        for br in rows {
+            if br.var_row >= n_x {
+                continue;
+            }
+            let slack_base = if br.lower {
+                x_curr[br.var_row] - lo[br.var_row]
+            } else {
+                hi[br.var_row] - x_curr[br.var_row]
+            };
+            if !slack_base.is_finite() {
+                continue;
+            }
+            if mult_nat
+                .iter()
+                .any(|m| m.row == br.row && m.base > slack_base)
+            {
+                let side = if br.lower { 0 } else { 1 };
+                base_active_row[br.var_row][side] = Some(br.row);
+            }
+        }
+    }
+    let base_active_rows: Vec<usize> = base_active_row
+        .iter()
+        .flatten()
+        .filter_map(|slot| *slot)
+        .collect();
+
     let mut acc = vec![0.0; n_full];
     let mut t = 0.0_f64;
     let mut holds: Vec<PathHold> = Vec::new();
@@ -663,32 +716,12 @@ where
             if holds.iter().any(|h| h.row == i) || changed_here.contains(&i) {
                 continue;
             }
+            // Base activity was decided once, at the table above; only
+            // the released exclusion is live, since a released bound
+            // left the factorization mid-path.
             let factor_holds = |lower_side: bool| -> bool {
-                let Some(rows) = bound_rows.as_ref() else {
-                    return false;
-                };
-                // The same base-point activity test the release scan
-                // below applies, and for the same reason: an active
-                // bound's multiplier dominates its slack. It depends
-                // only on the variable and the side, not on the
-                // multiplier row being scanned, so it is decided once
-                // here rather than inside the inner search.
-                let slack_base = if lower_side {
-                    x_curr[i] - lo[i]
-                } else {
-                    hi[i] - x_curr[i]
-                };
-                if !slack_base.is_finite() {
-                    return false;
-                }
-                rows.iter().any(|b| {
-                    b.var_row == i
-                        && b.lower == lower_side
-                        && !released.contains(&b.row)
-                        && mult_nat
-                            .iter()
-                            .any(|m| m.row == b.row && m.base > slack_base)
-                })
+                let side = if lower_side { 0 } else { 1 };
+                base_active_row[i][side].is_some_and(|r| !released.contains(&r))
             };
             let v = x_curr[i] + acc[i];
             if d[i] < 0.0 && lo[i] > NO_BOUND_LO && !factor_holds(true) {
@@ -699,46 +732,14 @@ where
             }
         }
         // A bound active at the base whose multiplier reaches zero.
+        // Base activity comes from the table above; which rows have
+        // since been released stays a live check.
         if can_release {
             for m in &mult_nat {
-                if released.contains(&m.row) || changed_here.contains(&m.row) {
-                    continue;
-                }
-                // Active means the multiplier dominates the slack. A
-                // converged interior point never sits ON a bound: an
-                // active bound's slack is order mu over the multiplier,
-                // so testing slack against `eps` calls every active
-                // bound inactive and the path never releases anything.
-                // Complementarity splits the two sides cleanly, z of
-                // order one against slack of order mu on the active
-                // side and the reverse on the inactive, which is the
-                // same split the activity classifier draws.
-                //
-                // The split is evaluated at the BASE point. Activity of
-                // a multiplier row is a property of the factorization,
-                // whose sigma for this bound was frozen at the base,
-                // and a bound inactive there is represented by a
-                // Schur-row hold if the path reaches it, never by this
-                // row. Testing accumulated values instead let a
-                // near-bound inactive multiplier drift past its
-                // shrinking slack mid-path and "release" a bound that
-                // was never held, putting a departure in the record for
-                // a variable that was not on that bound.
-                let Some(br) = bound_rows
-                    .as_ref()
-                    .and_then(|rows| rows.iter().find(|b| b.row == m.row))
-                else {
-                    continue;
-                };
-                if br.var_row >= n_x {
-                    continue;
-                }
-                let slack_base = if br.lower {
-                    x_curr[br.var_row] - lo[br.var_row]
-                } else {
-                    hi[br.var_row] - x_curr[br.var_row]
-                };
-                if !slack_base.is_finite() || m.base <= slack_base {
+                if released.contains(&m.row)
+                    || changed_here.contains(&m.row)
+                    || !base_active_rows.contains(&m.row)
+                {
                     continue;
                 }
                 let z_curr = m.base + acc[m.row];

--- a/pyomo-pounce/tests/test_path.py
+++ b/pyomo-pounce/tests/test_path.py
@@ -119,6 +119,21 @@ def test_path_releases_a_bound_the_perturbation_pulls_off():
     assert 0.0 < c.fraction < 1.0
 
 
+def test_a_bound_pushed_deeper_stays_and_records_nothing():
+    """The perturbation pushes x further into its active lower bound.
+    The factorization already enforces that bound, so the path must
+    not hold it again through a Schur row: the multiplier grows,
+    nothing changes hands, and the record is empty. Holding it a
+    second time would put a wrong entry in the record at fraction
+    zero and enforce the same bound twice."""
+    m = releasing()
+    assert pyo.value(m.x) == pytest.approx(0.0, abs=1e-6), "bound is active"
+    path = estimate(m, [(m.p, -3.0)], mode="path")
+    assert path[m.x] == pytest.approx(0.0, abs=1e-6)
+    assert path[m.y] == pytest.approx(1.0, abs=1e-6)
+    assert active_set_changes(m, [(m.p, -3.0)]) == []
+
+
 def test_a_release_on_an_upper_bound():
     m = pyo.ConcreteModel()
     m.p = pyo.Param(initialize=5.0, mutable=True)
@@ -176,6 +191,50 @@ def test_a_variable_reached_partway_can_leave_again():
     fracs = [c.fraction for c in rec]
     assert fracs == sorted(fracs), "the record is in path order"
     assert all(0.0 < f <= 1.0 for f in fracs)
+
+
+def returning_qp(p=0.0):
+    """A parametric QP whose solution path releases x1's upper bound
+    partway through the change and returns x1 to that same bound
+    before the target: x2 reaching its lower bound mid-path flips
+    x1's direction. Found by a random scan over QPs of this family
+    and verified against re-solves."""
+    m = pyo.ConcreteModel()
+    m.p = pyo.Param(initialize=p, mutable=True)
+    m.x1 = pyo.Var(bounds=(0.0, 1.0), initialize=0.3)
+    m.x2 = pyo.Var(bounds=(0.0, 10.0), initialize=0.3)
+    g, a0, a1, b0, b1 = -0.73, 0.48, 0.58, 0.4, -2.6
+    m.obj = pyo.Objective(
+        expr=0.5 * m.x1**2 + 0.5 * m.x2**2 + g * m.x1 * m.x2
+        - (a0 + a1 * m.p) * m.x1 - (b0 + b1 * m.p) * m.x2)
+    declare_sens_param(m.p)
+    return m
+
+
+def test_a_released_bound_can_be_reached_again():
+    """Base activity is decided once at the base point, but a released
+    row leaves the factorization at the fraction it releases, so the
+    variable can come back to that same bound and be held through a
+    Schur row. A reach scan that treated the factorization's bounds as
+    fixed for the whole path would refuse this hold and miss the
+    endpoint."""
+    m = returning_qp()
+    pyo.SolverFactory("pounce").solve(m, options={"tol": 1e-10})
+
+    exact = returning_qp(1.0)
+    pyo.SolverFactory("pounce").solve(exact, options={"tol": 1e-10})
+
+    path = estimate(m, [(m.p, 1.0)], mode="path")
+    assert path[m.x1] == pytest.approx(pyo.value(exact.x1), abs=1e-8)
+    assert path[m.x2] == pytest.approx(pyo.value(exact.x2), abs=1e-8)
+
+    rec = active_set_changes(m, [(m.p, 1.0)])
+    x1_upper = [c.action for c in rec
+                if c.var is m.x1 and c.bound == "upper"]
+    assert x1_upper == ["leaves", "reaches"], (
+        f"x1 should leave its upper bound and return to it, record: {rec}")
+    fracs = [c.fraction for c in rec]
+    assert fracs == sorted(fracs)
 
 
 def test_the_cap_falls_back_to_the_clamp_with_a_warning():


### PR DESCRIPTION
Follow-up to the merge review on #631, which left one item: the base-point activity predicate, the multiplier dominating the base slack, appeared in both `factor_holds` and the release scan, only the second carried the explanation of why it is evaluated at the base, and a future fix to one could silently miss the other. The same comment flagged `factor_holds` as `O(n_x × bound_rows × multipliers)` per path iteration.

## The change

This goes one step past the shared helper the comment suggested, because the duplication and the cost have the same root. The predicate reads `m.base`, the converged primal, and the bounds, none of which change along the path, which is exactly the base-point fact #631's activity fix established. So it is decided once, before the loop: a table with one slot per variable and side holding the bound row the factorization enforces there. Both scans read the table, the reach scan's `factor_holds` collapses to a lookup, the release scan's per-multiplier bound-row search and slack computation disappear, and the explanatory paragraph lives in one place, at the table's construction, extended to say why deciding it once is correct rather than a cache.

One thing deliberately stays live at both consumers: the released list. A base-active bound whose row has been released left the factorization at that fraction, so `factor_holds` is the lookup plus a released membership test, and the release scan keeps its released and changed-at-this-fraction exclusions. That distinction is the subtle part, and it is what the new tests pin.

## Two new tests, each shown fatal under the mutation it guards

- `test_a_released_bound_can_be_reached_again`: a QP whose path releases x1's upper bound at fraction 0.231, holds x2 at its lower bound at 0.345, which flips x1's direction, and returns x1 to the same upper bound at 0.897, with the endpoint checked against a re-solve at 1e-8 and the record asserted to read leaves then reaches for that one bound. With `factor_holds` mutated to a static lookup that ignores the released list, this test fails. No prior test covered a variable returning to a bound it released, so that mutation used to pass the whole suite.
- `test_a_bound_pushed_deeper_stays_and_records_nothing`: the perturbation pushes a variable further into its active lower bound, and the path must not hold the already-enforced bound a second time through a Schur row: the endpoint stays put and the record is empty. With the exclusion mutated away, the test fails on a wrong record entry. No prior path test exercised the exclusion under an inward direction, so that mutation also used to pass.

Both QPs were found by a random scan over the two-variable family the existing tests use, verified against direct solves at the target. With these two, each of the four behaviors in this code has a test that a targeted mutation kills: the release scan consuming the table (the walk and crossing-QP endpoints), the spurious-release guard (the added-then-dropped QP from #631), and the two above.

## Testing

All 12 rust sensitivity test files pass and clippy adds nothing. The path test file is 13 tests. The full pyomo-pounce suite is 400 passed against a rebuilt extension, the 398 on main plus the two new tests. The 400-case random QP scan reproduces its pre-refactor results exactly: endpoints at 1e-10 against direct target solves, drops firing, no hold the target solve refutes.

No CHANGELOG entry, since nothing user-visible changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
