### PR TITLE
Fire the iteration callback from restoration, labelled and stoppable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ changes.
 
 ## [Unreleased]
 
+- **The iteration callback now fires during feasibility restoration, and
+  can stop the solve from there** (#645).
+
+  Previously it fired only from the outer loop, so a caller went silent
+  for the whole of a restoration episode and could not interrupt one.
+  That is the phase most likely to overrun a real-time budget, which
+  makes it the phase a controller most needs to be able to abort in —
+  and it is why the C API's `alg_mod` argument was, until now, always
+  `0`: not merely untracked, but unreachable, because no fire happened
+  from anywhere that could have set it.
+
+  Restoration iterations arrive with `alg_mod = 1`
+  (`RestorationPhaseMode`), matching Ipopt, and reach CasADi as
+  `stats()["iterations"]["alg_mod"]`.
+
+  **The label is not decoration — read it before reading anything
+  beside it.** On a restoration iteration every other value describes
+  the min-‖c‖₁ *feasibility subproblem*, not your problem: the objective
+  is the constraint-violation penalty, and `inf_pr` falls to zero as the
+  subproblem converges while your own violation sits unchanged. Plotted
+  on one axis without splitting on `alg_mod`, an episode reads as the
+  objective exploding and the infeasibility being solved, and neither
+  happened.
+
+  Two deliberate silences on those fires. The `GetIpoptCurrent*`
+  inspectors report no data: the restoration iterate is a point of the
+  subproblem and does not have your problem's dimensions, so there is
+  nothing truthful to hand back. And CasADi's `iteration_callback` is
+  not called at all, because its signature is fixed at
+  `(x, f, g, lam_x, lam_g)` and a restoration iterate supplies none of
+  them; the trace still records the iteration, so nothing is hidden.
+
+  Returning `false` from a restoration fire ends the solve at the last
+  iterate accepted for **your** NLP, not at the subproblem's iterate —
+  so a caller aborting on a deadline gets back a point it can actually
+  use. The status is `User_Requested_Stop`, as from any other fire.
+
+  Existing callbacks fire more often than before on solves that enter
+  restoration. Anything counting fires, sampling for a plot, or driving
+  a progress bar will see the difference; upstream Ipopt fires from
+  restoration too, so a callback ported from it was already written
+  expecting these.
+
 - **CasADi plugin: solver diagnostics, and two defects found exposing
   them** (#634).
 

--- a/casadi/casadi_nlpsol_pounce.cpp
+++ b/casadi/casadi_nlpsol_pounce.cpp
@@ -49,7 +49,7 @@ namespace casadi {
     // per-iteration trace, mirroring casadi's ipopt `iterations` stats
     std::vector<double> inf_pr, inf_du, mu_trace, d_norm, obj_trace,
                         alpha_pr, alpha_du, regularization_size;
-    std::vector<casadi_int> ls_trials;
+    std::vector<casadi_int> ls_trials, alg_mod;
     /// Final KKT errors, read off the problem before it is freed —
     /// `FreeIpoptProblem` takes the accessors with it.
     double final_inf_pr = 0, final_inf_du = 0, final_compl_inf = 0;
@@ -205,12 +205,14 @@ namespace casadi {
     static bool cb_h(ipindex n, ipnumber* x, bool new_x, ipnumber obj_factor, ipindex m,
                      ipnumber* lambda, bool new_lambda, ipindex nele,
                      ipindex* iRow, ipindex* jCol, ipnumber* values, UserDataPtr ud);
-    /// The leading `alg_mod` is unnamed on purpose: POUNCE fires this
-    /// callback only from its outer loop and always reports
-    /// `RegularMode` (`ipopt_alg.rs`, `build_iter_stats`), so recording
-    /// it would publish a column that is constant zero and reads as
-    /// working restoration detection. `stats()['restoration']` reports
-    /// what POUNCE does measure; see gh#634.
+    /// `alg_mod` is 0 for an outer-loop iteration and 1 for one of the
+    /// feasibility-restoration subproblem (gh#645 made the second kind
+    /// fire at all; before that it was constant 0 and deliberately not
+    /// recorded). It is published in `stats()['iterations']['alg_mod']`
+    /// because without it the other columns of a restoration row are
+    /// unreadable — they describe the min-||c||_1 subproblem, not this
+    /// NLP. `stats()['restoration']` still carries the solve-level
+    /// totals; see gh#634.
     static bool cb_iter(ipindex alg_mod, ipindex iter_count, ipnumber obj_value,
                         ipnumber inf_pr, ipnumber inf_du, ipnumber mu, ipnumber d_norm,
                         ipnumber regularization_size, ipnumber alpha_du, ipnumber alpha_pr,
@@ -536,12 +538,13 @@ namespace casadi {
     return true;
   }
 
-  bool PounceInterface::cb_iter(ipindex, ipindex iter_count, ipnumber obj_value,
+  bool PounceInterface::cb_iter(ipindex alg_mod, ipindex iter_count, ipnumber obj_value,
                                 ipnumber inf_pr, ipnumber inf_du, ipnumber mu,
                                 ipnumber d_norm, ipnumber regularization_size,
                                 ipnumber alpha_du, ipnumber alpha_pr, ipindex ls_trials,
                                 UserDataPtr ud) {
     auto m = static_cast<PounceMemory*>(ud);
+    m->alg_mod.push_back(alg_mod);
     m->inf_pr.push_back(inf_pr);
     m->inf_du.push_back(inf_du);
     m->mu_trace.push_back(mu);
@@ -551,12 +554,28 @@ namespace casadi {
     m->alpha_pr.push_back(alpha_pr);
     m->alpha_du.push_back(alpha_du);
     m->ls_trials.push_back(ls_trials);
-    m->iter = iter_count;
+    // On a restoration fire `iter_count` counts the *subproblem's* inner
+    // iterations and restarts from 0 on every entry, so letting it
+    // through here would make `stats()['iter_count']` report whatever
+    // the last restoration episode happened to reach. Outer fires only.
+    if (alg_mod == 0) m->iter = iter_count;
 
     // A Ctrl-C caught in an oracle callback stops the solve here: returning
     // false is `User_Requested_Stop`, the one channel POUNCE offers for
     // "stop now" that does not involve unwinding through it.
     if (m->interrupted) return false;
+
+    // Restoration fires stop here. CasADi fixes the callback signature
+    // at `(x, f, g, lam_x, lam_g)` and a restoration iterate supplies
+    // none of them: it is a point of the min-||c||_1 subproblem, in the
+    // subproblem's own variable space, and POUNCE's `GetIpoptCurrent*`
+    // inspectors report no data for its duration by design. Handing the
+    // user's callback a stale `x` from the previous outer iteration
+    // beside a fresh restoration `f` would be worse than not calling it.
+    // The trace above still records the iteration, tagged `alg_mod = 1`,
+    // so the episode is visible in `stats()` without being fed to user
+    // code as if it were a solution estimate.
+    if (alg_mod != 0) return true;
 
     // Full callback: pull the current iterate out of POUNCE and drive
     // casadi's `iteration_callback` with it.
@@ -626,6 +645,7 @@ namespace casadi {
     m->alpha_pr.clear();
     m->alpha_du.clear();
     m->ls_trials.clear();
+    m->alg_mod.clear();
     m->final_inf_pr = m->final_inf_du = m->final_compl_inf = 0;
     m->linsol_valid = false;
     m->resto_calls = m->resto_inner = m->resto_outer = 0;
@@ -890,6 +910,9 @@ namespace casadi {
     iterations["alpha_pr"] = m->alpha_pr;
     iterations["alpha_du"] = m->alpha_du;
     iterations["ls_trials"] = m->ls_trials;
+    // 0 = outer iteration, 1 = restoration subproblem iteration. Every
+    // other vector here is only interpretable against it.
+    iterations["alg_mod"] = m->alg_mod;
     stats["iterations"] = iterations;
 
     // `stats()` is callable from inside `iteration_callback`, where the
@@ -933,10 +956,10 @@ namespace casadi {
       stats["final_inf_du"] = m->final_inf_du;
       stats["final_compl_inf"] = m->final_compl_inf;
 
-      // Restoration is reported per solve, not per iteration: POUNCE's
-      // intermediate callback always reports RegularMode, so labelling
-      // a single iteration as a restoration one is not something this
-      // plugin can honestly do yet (gh#634).
+      // Solve-level restoration totals. Per-iteration labelling now
+      // exists too — see `iterations['alg_mod']` (gh#645) — but these
+      // are the only source for the inner iteration count and the wall
+      // time, and they answer "how much restoration?" in one read.
       Dict resto;
       resto["calls"] = static_cast<casadi_int>(m->resto_calls);
       resto["inner_iters"] = static_cast<casadi_int>(m->resto_inner);

--- a/casadi/test_parity.py
+++ b/casadi/test_parity.py
@@ -10,6 +10,7 @@ same model, so a failure says "the two solvers disagree", not "the
 number moved".
 """
 
+import itertools
 import os
 import shutil
 import subprocess
@@ -663,6 +664,76 @@ def test_repeated_solves_do_not_concatenate_the_trace():
           f"pounce={lengths} ipopt={ip}")
 
 
+def test_restoration_iterations_are_labelled():
+    """`iterations['alg_mod']` separates outer rows from restoration ones.
+
+    POUNCE used to fire the intermediate callback only from its outer
+    loop, so this column would have been constant zero and #637 declined
+    to publish it. gh#645 made the restoration inner solver fire too,
+    which is what gives the column something to say — and what makes it
+    load-bearing: on a restoration row the other vectors describe the
+    min-||c||_1 feasibility subproblem, not this NLP.
+    """
+    clean = rosenbrock_nlp()
+    S = ca.nlpsol("S", "pounce", clean, QUIET_POUNCE)
+    S(x0=[0.5, 0.5], p=1.5, lbg=-ca.inf, ubg=0)
+    it = S.stats()["iterations"]
+    check("stats: iterations carries alg_mod", "alg_mod" in it,
+          f"keys = {sorted(it)}")
+    if "alg_mod" not in it:
+        return
+    check("stats: alg_mod is as long as the other traces",
+          len(it["alg_mod"]) == len(it["inf_pr"]),
+          f"{len(it['alg_mod'])} vs {len(it['inf_pr'])}")
+    check("stats: a clean solve is all regular iterations",
+          set(it["alg_mod"]) <= {0}, f"{sorted(set(it['alg_mod']))}")
+
+    # The infeasible equality from `test_restoration_stats`: this one
+    # actually restores.
+    x = ca.MX.sym("x")
+    hard = {"x": x, "f": x**2, "g": x**2 + 1}
+    R = ca.nlpsol("R", "pounce", hard, dict(QUIET_POUNCE))
+    try:
+        R(x0=0.5, lbg=0, ubg=0)
+    except RuntimeError:
+        pass
+    st = R.stats()
+    modes = st["iterations"]["alg_mod"]
+    check("stats: restoration iterations are labelled 1",
+          any(m == 1 for m in modes),
+          f"{st['return_status']}, alg_mod = {modes}")
+
+    # The column has to stay usable as an index into the others.
+    check("stats: alg_mod still aligns with the traces under restoration",
+          len(modes) == len(st["iterations"]["inf_pr"]),
+          f"{len(modes)} vs {len(st['iterations']['inf_pr'])}")
+
+    # `iter_count` must keep describing the outer solve. The inner
+    # solver restarts its own counter from zero on every restoration
+    # entry, so recording those would leave `iter_count` reporting
+    # whatever the last episode happened to reach — the same class of
+    # disagreement #637 fixed for the accumulating trace, one level down.
+    #
+    # Necessary rather than sufficient, but it is the part an outside
+    # caller can see: a clobbered `iter_count` could not exceed the
+    # longest run of restoration rows, because that run is what would
+    # have written it.
+    longest_resto_run = max((len(list(g)) for m, g in
+                             itertools.groupby(modes) if m == 1), default=0)
+    check("stats: iter_count is the outer count, not the inner one",
+          st["iter_count"] > longest_resto_run,
+          f"iter_count {st['iter_count']} vs longest restoration run "
+          f"{longest_resto_run}")
+
+    # Note for anyone reading the two side by side: `iter_count` counts
+    # more than the regular rows here (the outer counter advances across
+    # a restoration episode, as upstream's does — its `r`-suffixed rows
+    # share the same counter). That predates gh#645 and is unchanged by
+    # it; `test_repeated_solves_do_not_concatenate_the_trace` is where
+    # the exact trace/`iter_count` agreement is pinned, on solves that
+    # never restore.
+
+
 def test_final_kkt_errors_in_stats():
     """The final infeasibilities POUNCE already computes, in `stats()`."""
     nlp = rosenbrock_nlp()
@@ -1038,6 +1109,7 @@ def main():
         test_final_kkt_errors_in_stats,
         test_linear_solver_stats,
         test_restoration_stats,
+        test_restoration_iterations_are_labelled,
         test_live_diagnostics_during_the_callback,
         test_option_types_come_from_pounce_not_the_literal,
         test_codegen_matches_the_interpreted_solve,

--- a/crates/pounce-algorithm/src/ipopt_alg.rs
+++ b/crates/pounce-algorithm/src/ipopt_alg.rs
@@ -94,6 +94,26 @@ pub struct IpoptAlgorithm {
     /// view (fixed-variable elimination, c/d split) while the callback
     /// payload needs to expose the original-coordinate iterate.
     pub tnlp: Option<Rc<RefCell<dyn TNLP>>>,
+    /// Set on the *restoration* inner IPM so its callback fires report
+    /// `AlgorithmMode::RestorationPhaseMode` (gh#645). Two things hang
+    /// off it, both in [`Self::fire_intermediate`]:
+    ///
+    /// 1. the mode field of the [`IterStats`] payload, which is what
+    ///    tells a caller the numbers beside it (`obj`, `inf_pr`,
+    ///    `inf_du`, `alpha_*`) describe the min-C1-norm feasibility
+    ///    subproblem rather than the user's NLP;
+    /// 2. whether the live-inspector `IntermediateContext` is installed
+    ///    — and for a restoration fire it deliberately is **not**. The
+    ///    inner iterate is a `CompoundVector` over `(x_orig, n, p)`, so
+    ///    it does not even have the user's `n`, and the C API's
+    ///    `GetIpoptCurrent*` family checks the caller's `n`/`m` against
+    ///    the *problem's* registered dimensions rather than the
+    ///    context's. Installing this context would sail past that check
+    ///    and read a differently-shaped `cq`. The live accessors
+    ///    therefore report "no data" during restoration, which is the
+    ///    truth: there is no current iterate of the user's problem
+    ///    while the subproblem is being solved.
+    pub fires_as_restoration: bool,
     /// Search-direction calculator (`PdSearchDirCalc`). Lands once a
     /// concrete `SymLinearSolver` backend (MUMPS / FERAL) is wired
     /// through `AlgBuilder` in Phase 7's tail.
@@ -396,6 +416,7 @@ impl IpoptAlgorithm {
             bundle,
             nlp: None,
             tnlp: None,
+            fires_as_restoration: false,
             search_dir,
             restoration: None,
             kappa_sigma: 1e10,
@@ -1624,9 +1645,16 @@ impl IpoptAlgorithm {
             None => 0.0,
         };
         IterStats {
-            // alg_mod tracking (regular vs restoration) is a follow-up;
-            // every callback fire from the outer loop reports RegularMode.
-            mode: AlgorithmMode::RegularMode,
+            // Regular from the outer loop; restoration from the inner
+            // sub-IPM, which the outer driver flags at construction
+            // (gh#645). The outer loop never sets the flag, so every
+            // fire from here is still `RegularMode` — what changed is
+            // that restoration now fires at all.
+            mode: if self.fires_as_restoration {
+                AlgorithmMode::RestorationPhaseMode
+            } else {
+                AlgorithmMode::RegularMode
+            },
             iter: d.iter_count,
             obj_value: c.curr_f(),
             inf_pr: c.curr_primal_infeasibility_max(),
@@ -1653,10 +1681,17 @@ impl IpoptAlgorithm {
             return true;
         };
         let stats = self.build_iter_stats();
-        let _guard = CtxGuard::install(IntermediateContext {
-            data: Rc::clone(&self.data),
-            cq: Rc::clone(&self.cq),
-            nlp: Rc::clone(nlp),
+        // The live-inspector context is for iterates of the *user's*
+        // problem only. During restoration the iterate belongs to the
+        // feasibility subproblem and is not even the same length, so no
+        // context is installed and `GetIpoptCurrent*` reports no data
+        // for the duration. See `fires_as_restoration`.
+        let _guard = (!self.fires_as_restoration).then(|| {
+            CtxGuard::install(IntermediateContext {
+                data: Rc::clone(&self.data),
+                cq: Rc::clone(&self.cq),
+                nlp: Rc::clone(nlp),
+            })
         });
         tnlp.borrow_mut().intermediate_callback(
             stats,
@@ -3149,6 +3184,10 @@ impl IpoptAlgorithm {
         resto.set_orig_progress_check(orig_progress_cb);
         // Forward the shared debugger so it can step the inner solve.
         resto.set_debug_hook(self.debug.as_ref().map(Rc::clone));
+        // Forward the user's TNLP so the callback fires from the inner
+        // solve too (gh#645). `None` when the caller installed no
+        // callback, which keeps the whole path inert for them.
+        resto.set_intermediate_tnlp(self.tnlp.as_ref().map(Rc::clone));
         let mut pd_guard = sd.pd_solver_mut();
         let aug = pd_guard.aug_solver_mut();
         // Audit counters (pounce#12). Increment call count + outer-iter
@@ -3269,6 +3308,18 @@ impl IpoptAlgorithm {
                         IterateOutcome::Terminate(SolverReturn::RestorationFailure)
                     }
                 }
+            }
+            RestorationOutcome::UserRequestedStop => {
+                // gh#645. Same discipline as the pounce#244 deadline
+                // exit a few lines up, and for the same reason: the
+                // recovered point is staged on `data.trial` and we
+                // return without promoting it, so `data.curr` is still
+                // the last iterate accepted for the *original* NLP.
+                // That matters more than the status code to the caller
+                // this exists for — a controller that aborts on a
+                // deadline still has to apply something, and the
+                // subproblem's iterate is not a point it should apply.
+                IterateOutcome::Terminate(SolverReturn::UserRequestedStop)
             }
             RestorationOutcome::LocallyInfeasible => {
                 // Mirrors upstream's catch of `LOCALLY_INFEASIBLE` thrown

--- a/crates/pounce-algorithm/src/restoration.rs
+++ b/crates/pounce-algorithm/src/restoration.rs
@@ -58,6 +58,14 @@ pub enum RestorationOutcome {
     /// `IpRestoConvCheck.cpp:240`. Outer loop maps this to
     /// `SolverReturn::LocalInfeasibility`.
     LocallyInfeasible,
+    /// The user's intermediate callback returned `false` from a
+    /// restoration-phase fire (gh#645). Outer loop maps this to
+    /// `SolverReturn::UserRequestedStop` **without** promoting the
+    /// staged trial point, so the solve hands back the last iterate
+    /// accepted for the *original* NLP rather than a point of the
+    /// restoration subproblem — the same discipline the pounce#244
+    /// deadline exit already follows.
+    UserRequestedStop,
 }
 
 pub trait RestorationPhase {
@@ -92,6 +100,29 @@ pub trait RestorationPhase {
     fn set_debug_hook(
         &mut self,
         _hook: Option<std::rc::Rc<std::cell::RefCell<dyn crate::debug::DebugHook>>>,
+    ) {
+    }
+
+    /// Forward the user's TNLP onto the restoration inner IPM so its
+    /// `intermediate_callback` fires from the sub-solve too (gh#645).
+    /// Default no-op, like [`Self::set_debug_hook`] above, which this
+    /// deliberately mirrors — the debugger took the same route first.
+    ///
+    /// Without this the callback fires only from the outer loop, so a
+    /// caller is blind for the whole of restoration. That is the phase
+    /// most likely to overrun a control period, which makes it the
+    /// phase a real-time caller most needs to be able to abort in.
+    ///
+    /// The inner IPM iterates on the min-C1-norm feasibility
+    /// subproblem, so the stats those fires carry describe *that*
+    /// problem, not the user's NLP. `AlgorithmMode::RestorationPhaseMode`
+    /// on each such fire is what makes them interpretable, and
+    /// [`crate::ipopt_alg::IpoptAlgorithm::fires_as_restoration`] is
+    /// what sets it — see the note there on why the live-inspector
+    /// context is deliberately *not* installed for these fires.
+    fn set_intermediate_tnlp(
+        &mut self,
+        _tnlp: Option<std::rc::Rc<std::cell::RefCell<dyn pounce_nlp::tnlp::TNLP>>>,
     ) {
     }
 

--- a/crates/pounce-cinterface/include/pounce.h
+++ b/crates/pounce-cinterface/include/pounce.h
@@ -215,7 +215,24 @@ bool SetIpoptProblemScaling(
 
 /** Install (or remove, with cb == NULL) a per-iteration callback.
  *  Returning false from the callback signals
- *  ApplicationReturnStatus::User_Requested_Stop. */
+ *  ApplicationReturnStatus::User_Requested_Stop.
+ *
+ *  Fires from the outer loop with `alg_mod = 0` (RegularMode) and from
+ *  the feasibility-restoration inner solver with `alg_mod = 1`
+ *  (RestorationPhaseMode). Two things about the restoration fires:
+ *
+ *   - The scalars beside `alg_mod` (`obj_value`, `inf_pr`, `inf_du`,
+ *     `mu`, `d_norm`, `regularization_size`, `alpha_*`, `ls_trials`)
+ *     describe the min-||c||_1 feasibility subproblem, not your NLP.
+ *     `alg_mod` is what tells them apart; do not plot them on one axis
+ *     without checking it.
+ *   - The GetIpoptCurrent* inspectors report no data for the duration.
+ *     The restoration iterate is not a point of your problem, and does
+ *     not even have its dimensions.
+ *
+ *  Returning false from a restoration fire ends the solve at the last
+ *  iterate accepted for your NLP, not at the subproblem's iterate — so
+ *  a caller aborting on a deadline gets back a point it can use. */
 bool SetIntermediateCallback(
     IpoptProblem    ipopt_problem,
     Intermediate_CB intermediate_cb);
@@ -322,10 +339,12 @@ ipnumber GetIpoptComplInf(IpoptProblem ipopt_problem);
  * cumulative seconds spent there — enough to answer "did this solve
  * struggle, and how much of it was restoration?".
  *
- * This is solve-level, not per-iteration: pounce fires the intermediate
- * callback only from its outer loop and always reports
- * `RegularMode` in `alg_mod`, so a caller cannot yet label an
- * individual iteration as a restoration one.
+ * This is solve-level. Individual iterations can be labelled too — the
+ * intermediate callback fires from the restoration inner solver with
+ * `alg_mod = 1` (`RestorationPhaseMode`); see `SetIntermediateCallback`
+ * for what those fires do and do not carry. These counters remain the
+ * only source for the inner iteration count and the wall time, and the
+ * only way to ask the question without installing a callback.
  */
 void GetPounceRestorationStats(
     IpoptProblem ipopt_problem,

--- a/crates/pounce-cinterface/src/lib.rs
+++ b/crates/pounce-cinterface/src/lib.rs
@@ -1166,10 +1166,12 @@ where
 /// Restoration-phase activity in the most recent solve. Each output
 /// may be NULL to skip it; all yield zero before the first solve.
 ///
-/// Solve-level rather than per-iteration: the intermediate callback's
-/// `alg_mod` is always `RegularMode` today (see
-/// `IpoptAlgorithm::build_iter_stats`), so these counters are what a
-/// caller can honestly say about restoration.
+/// Solve-level, and still worth having now that the intermediate
+/// callback also fires from restoration with `alg_mod = 1` (gh#645):
+/// these counters answer "how much restoration did this solve do?"
+/// without the caller having to install a callback and tally fires,
+/// and they are the only source for the inner iteration count and
+/// wall time.
 ///
 /// # Safety
 ///

--- a/crates/pounce-cinterface/tests/restoration_callback.rs
+++ b/crates/pounce-cinterface/tests/restoration_callback.rs
@@ -1,0 +1,344 @@
+//! gh#645 — the intermediate callback fires from the feasibility
+//! restoration phase, labelled, and can stop the solve from there.
+//!
+//! Before this, `fire_intermediate` had two call sites, both in the
+//! outer loop, so `alg_mod` was not merely untracked but unreachable:
+//! no fire could ever legitimately report `RestorationPhaseMode`. A
+//! caller was therefore blind for the whole of restoration — the phase
+//! a real-time caller most needs to be able to abort in, because it is
+//! the one that overruns a control period.
+//!
+//! Three properties, one per test:
+//!
+//! 1. restoration fires happen and are labelled `alg_mod == 1`; a solve
+//!    that never restores never produces one;
+//! 2. the `GetIpoptCurrent*` inspectors report no data during those
+//!    fires — the iterate belongs to the min-‖c‖₁ subproblem and does
+//!    not have this problem's dimensions;
+//! 3. returning `false` from a restoration fire ends the solve at the
+//!    last iterate accepted for the *original* NLP, not at the
+//!    subproblem's iterate. A controller that aborts on a deadline has
+//!    to apply something, so which point comes back is the part that
+//!    matters to it — more than the status code.
+
+use pounce_cinterface::*;
+use std::cell::RefCell;
+use std::ffi::{CString, c_void};
+
+/// `ApplicationReturnStatus::User_Requested_Stop`. Spelled out rather
+/// than imported because an integration test sees only the crate under
+/// test and its dev-dependencies, and the enum lives in `pounce-nlp`.
+/// `return_codes.rs` pins the discriminant.
+const USER_REQUESTED_STOP: Index = 5;
+
+const N: usize = 1;
+const M: usize = 1;
+
+/// Whether the callback should ask to stop, and what it saw.
+#[derive(Default)]
+struct Seen {
+    regular_fires: usize,
+    restoration_fires: usize,
+    /// `x` at the last fire with `alg_mod == 0`, read through the
+    /// inspector — the last iterate of the user's NLP the solver
+    /// reported.
+    last_regular_x: Option<Number>,
+    /// Inspector verdicts, split by mode. `(calls, ok)`.
+    regular_inspector: (usize, usize),
+    restoration_inspector: (usize, usize),
+    /// Ask for a stop on the first restoration fire.
+    stop_on_restoration: bool,
+}
+
+thread_local! {
+    static SEEN: RefCell<Seen> = RefCell::new(Seen::default());
+}
+
+// ---------------------------------------------------------------
+// A problem whose equality constraint cannot be satisfied: with
+// `g = x² + 1` pinned to zero there is no feasible point, so the line
+// search fails to find an acceptable step and the solver enters
+// restoration. Same shape the CasADi parity suite uses to exercise the
+// solve-level restoration counters.
+// ---------------------------------------------------------------
+
+unsafe extern "C" fn ev_f(
+    _n: Index,
+    x: *const Number,
+    _new_x: Bool,
+    obj: *mut Number,
+    _u: *mut c_void,
+) -> Bool {
+    unsafe {
+        *obj = (*x) * (*x);
+        1
+    }
+}
+
+unsafe extern "C" fn ev_grad_f(
+    _n: Index,
+    x: *const Number,
+    _new_x: Bool,
+    grad: *mut Number,
+    _u: *mut c_void,
+) -> Bool {
+    unsafe {
+        *grad = 2.0 * (*x);
+        1
+    }
+}
+
+unsafe extern "C" fn ev_g(
+    _n: Index,
+    x: *const Number,
+    _new_x: Bool,
+    _m: Index,
+    gout: *mut Number,
+    _u: *mut c_void,
+) -> Bool {
+    unsafe {
+        *gout = (*x) * (*x) + 1.0;
+        1
+    }
+}
+
+unsafe extern "C" fn ev_jac_g(
+    _n: Index,
+    x: *const Number,
+    _new_x: Bool,
+    _m: Index,
+    _nele_jac: Index,
+    i_row: *mut Index,
+    j_col: *mut Index,
+    values: *mut Number,
+    _u: *mut c_void,
+) -> Bool {
+    unsafe {
+        if values.is_null() {
+            *i_row = 0;
+            *j_col = 0;
+            return 1;
+        }
+        *values = 2.0 * (*x);
+        1
+    }
+}
+
+/// Records the mode of every fire, asks both inspectors, and — when
+/// armed — requests a stop from the first restoration fire.
+#[allow(clippy::too_many_arguments)]
+unsafe extern "C" fn on_iter(
+    alg_mod: Index,
+    _iter: Index,
+    _obj: Number,
+    _inf_pr: Number,
+    _inf_du: Number,
+    _mu: Number,
+    _d_norm: Number,
+    _regu: Number,
+    _alpha_du: Number,
+    _alpha_pr: Number,
+    _ls_trials: Index,
+    user_data: *mut c_void,
+) -> Bool {
+    unsafe {
+        let prob = user_data as IpoptProblem;
+
+        let mut x = [0.0 as Number; N];
+        let mut z_l = [0.0 as Number; N];
+        let mut z_u = [0.0 as Number; N];
+        let mut g = [0.0 as Number; M];
+        let mut lambda = [0.0 as Number; M];
+        let ok = GetIpoptCurrentIterate(
+            prob,
+            0,
+            N as Index,
+            x.as_mut_ptr(),
+            z_l.as_mut_ptr(),
+            z_u.as_mut_ptr(),
+            M as Index,
+            g.as_mut_ptr(),
+            lambda.as_mut_ptr(),
+        );
+
+        SEEN.with(|s| {
+            let mut s = s.borrow_mut();
+            if alg_mod == 0 {
+                s.regular_fires += 1;
+                s.regular_inspector.0 += 1;
+                if ok != 0 {
+                    s.regular_inspector.1 += 1;
+                    s.last_regular_x = Some(x[0]);
+                }
+                1
+            } else {
+                s.restoration_fires += 1;
+                s.restoration_inspector.0 += 1;
+                if ok != 0 {
+                    s.restoration_inspector.1 += 1;
+                }
+                if s.stop_on_restoration { 0 } else { 1 }
+            }
+        })
+    }
+}
+
+/// Build the infeasible-equality problem. `feasible = true` relaxes the
+/// constraint to a satisfiable one, giving the control case.
+unsafe fn make_problem(feasible: bool) -> IpoptProblem {
+    unsafe {
+        let x_l = [-5.0 as Number; N];
+        let x_u = [5.0 as Number; N];
+        // `x² + 1 == 0` is unsatisfiable; `x² + 1 == 2` is not.
+        let (g_l, g_u) = if feasible {
+            ([2.0 as Number], [2.0 as Number])
+        } else {
+            ([0.0 as Number], [0.0 as Number])
+        };
+
+        let prob = CreateIpoptProblem(
+            N as Index,
+            x_l.as_ptr(),
+            x_u.as_ptr(),
+            M as Index,
+            g_l.as_ptr(),
+            g_u.as_ptr(),
+            N as Index,
+            0,
+            0,
+            Some(ev_f),
+            Some(ev_g),
+            Some(ev_grad_f),
+            Some(ev_jac_g),
+            None,
+        );
+        assert!(!prob.is_null(), "CreateIpoptProblem returned NULL");
+
+        let key = CString::new("hessian_approximation").unwrap();
+        let val = CString::new("limited-memory").unwrap();
+        assert_ne!(
+            AddIpoptStrOption(prob, key.as_ptr() as *mut _, val.as_ptr() as *mut _),
+            0
+        );
+        let key = CString::new("print_level").unwrap();
+        assert_ne!(AddIpoptIntOption(prob, key.as_ptr() as *mut _, 0), 0);
+        assert_ne!(SetIntermediateCallback(prob, Some(on_iter)), 0);
+        prob
+    }
+}
+
+/// Solve, returning `(status, x_returned)`. Resets the observation
+/// state first, and arms the stop-on-restoration behaviour per `stop`.
+unsafe fn solve(feasible: bool, stop: bool) -> (Index, Number) {
+    unsafe {
+        SEEN.with(|s| {
+            let mut s = s.borrow_mut();
+            *s = Seen::default();
+            s.stop_on_restoration = stop;
+        });
+        let prob = make_problem(feasible);
+        let mut x = [0.5 as Number; N];
+        let mut g = [0.0 as Number; M];
+        let mut obj = 0.0 as Number;
+        let mut mult_g = [0.0 as Number; M];
+        let mut z_l = [0.0 as Number; N];
+        let mut z_u = [0.0 as Number; N];
+        let status = IpoptSolve(
+            prob,
+            x.as_mut_ptr(),
+            g.as_mut_ptr(),
+            &mut obj,
+            mult_g.as_mut_ptr(),
+            z_l.as_mut_ptr(),
+            z_u.as_mut_ptr(),
+            prob as *mut c_void,
+        );
+        FreeIpoptProblem(prob);
+        (status as Index, x[0])
+    }
+}
+
+#[test]
+fn restoration_iterations_fire_the_callback_and_are_labelled() {
+    unsafe {
+        let (_status, _x) = solve(false, false);
+        SEEN.with(|s| {
+            let s = s.borrow();
+            assert!(s.regular_fires > 0, "no outer-loop fires at all");
+            assert!(
+                s.restoration_fires > 0,
+                "restoration ran but never fired the callback — {} regular fires only",
+                s.regular_fires
+            );
+        });
+
+        // Control: a solve that never restores must never produce a
+        // restoration fire. Without this the test above would pass on an
+        // implementation that labelled every fire as restoration.
+        let (status, _x) = solve(true, false);
+        assert_eq!(status, 0, "control problem did not solve");
+        SEEN.with(|s| {
+            let s = s.borrow();
+            assert!(s.regular_fires > 0, "no fires on the control solve");
+            assert_eq!(
+                s.restoration_fires, 0,
+                "control solve reported {} restoration fires without restoring",
+                s.restoration_fires
+            );
+        });
+    }
+}
+
+#[test]
+fn inspectors_report_no_data_during_a_restoration_fire() {
+    unsafe {
+        solve(false, false);
+        SEEN.with(|s| {
+            let s = s.borrow();
+            assert!(s.restoration_inspector.0 > 0, "no restoration fires");
+            // The restoration iterate is a compound `(x_orig, n, p)`
+            // vector of the subproblem, so there is no current iterate
+            // of *this* problem to report. Answering anyway would mean
+            // filling the caller's `n`-sized buffers from a differently
+            // shaped `cq`.
+            assert_eq!(
+                s.restoration_inspector.1, 0,
+                "GetIpoptCurrentIterate answered {} of {} restoration fires",
+                s.restoration_inspector.1, s.restoration_inspector.0
+            );
+            // ...and still answers normally outside them, which is the
+            // property `current_iterate_inspectors.rs` pins in full.
+            assert_eq!(
+                s.regular_inspector.1, s.regular_inspector.0,
+                "inspector refused an outer-loop fire"
+            );
+        });
+    }
+}
+
+#[test]
+fn stopping_from_restoration_returns_the_last_original_nlp_iterate() {
+    unsafe {
+        let (status, x_returned) = solve(false, true);
+        assert_eq!(
+            status, USER_REQUESTED_STOP,
+            "callback returned false from restoration but the solve did not stop"
+        );
+
+        let (fires, last_regular_x) =
+            SEEN.with(|s| (s.borrow().restoration_fires, s.borrow().last_regular_x));
+        // Exactly one: the stop must take effect on the fire that asked
+        // for it, not after the sub-solve runs to completion.
+        assert_eq!(
+            fires, 1,
+            "the sub-solve kept iterating after the callback asked to stop"
+        );
+
+        let expected = last_regular_x.expect("no outer-loop fire recorded an iterate");
+        assert_eq!(
+            x_returned, expected,
+            "aborting inside restoration handed back a point that is not the last \
+             iterate accepted for the original NLP (subproblem iterate leaked?)"
+        );
+    }
+}

--- a/crates/pounce-restoration/src/min_c_1nrm.rs
+++ b/crates/pounce-restoration/src/min_c_1nrm.rs
@@ -72,6 +72,18 @@ pub struct RestoSolveResult {
     /// surfaces `SolverReturn::LocalInfeasibility` instead of cycling
     /// in restoration on an unchanged iterate.
     pub locally_infeasible: bool,
+    /// `true` when the inner sub-IPM stopped because the user's
+    /// `intermediate_callback` returned `false` from a
+    /// restoration-phase fire (gh#645). Propagated by the driver as
+    /// [`RestorationOutcome::UserRequestedStop`], which the outer loop
+    /// surfaces without promoting the staged trial point.
+    ///
+    /// Checked *before* `locally_infeasible`: an aborted sub-solve has
+    /// not finished deciding anything about the original NLP's
+    /// feasibility, so reporting local infeasibility off the back of a
+    /// point the user interrupted us at would be a verdict we have not
+    /// earned.
+    pub user_requested_stop: bool,
 }
 
 /// Inner-loop driver hook. Constructs and runs the nested IPM around
@@ -103,6 +115,10 @@ pub type RestoInnerSolver = Box<
         // Shared interactive debugger, forwarded onto the inner IPM so the
         // same debugger can step the restoration sub-solve.
         Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
+        // User TNLP, forwarded onto the inner IPM so its
+        // `intermediate_callback` fires per inner iteration (gh#645).
+        // `None` when the caller installed no callback.
+        Option<Rc<RefCell<dyn pounce_nlp::tnlp::TNLP>>>,
     ) -> Option<RestoSolveResult>,
 >;
 
@@ -136,6 +152,11 @@ pub struct MinC1NormRestoration {
     /// Shared debugger forwarded onto the inner IPM (set by the outer
     /// driver via `RestorationPhase::set_debug_hook`).
     pub(crate) debug_hook: Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
+    /// User TNLP forwarded onto the inner IPM (set by the outer driver
+    /// via `RestorationPhase::set_intermediate_tnlp`) so the callback
+    /// fires during restoration too (gh#645). `None` when the caller
+    /// installed no callback.
+    pub(crate) intermediate_tnlp: Option<Rc<RefCell<dyn pounce_nlp::tnlp::TNLP>>>,
 }
 
 impl Default for MinC1NormRestoration {
@@ -147,11 +168,12 @@ impl Default for MinC1NormRestoration {
             expect_infeasible_problem: false,
             start_with_resto: false,
             eq_mult: Box::new(LeastSquareMults::new()),
-            inner_solver: Box::new(|_, _, _, _, _, _| None),
+            inner_solver: Box::new(|_, _, _, _, _, _, _| None),
             orig_progress: None,
             last_inner_iter_count: 0,
             print_iter_output: true,
             debug_hook: None,
+            intermediate_tnlp: None,
         }
     }
 }
@@ -203,6 +225,10 @@ impl RestorationPhase for MinC1NormRestoration {
         self.debug_hook = hook;
     }
 
+    fn set_intermediate_tnlp(&mut self, tnlp: Option<Rc<RefCell<dyn pounce_nlp::tnlp::TNLP>>>) {
+        self.intermediate_tnlp = tnlp;
+    }
+
     fn perform_restoration(
         &mut self,
         data: &IpoptDataHandle,
@@ -245,6 +271,7 @@ impl RestorationPhase for MinC1NormRestoration {
             cb,
             self.print_iter_output,
             self.debug_hook.clone(),
+            self.intermediate_tnlp.clone(),
         ) else {
             return RestorationOutcome::Failed;
         };
@@ -253,6 +280,17 @@ impl RestorationPhase for MinC1NormRestoration {
             let mut d = data.borrow_mut();
             d.curr_mu = saved_mu;
             d.curr_tau = saved_tau;
+        }
+
+        // 1a'. User-stop short-circuit (gh#645). Ahead of every branch
+        // below, including the locally-infeasible one: the transcription
+        // block that follows exists to hand a *recovered* iterate back
+        // to the outer loop, and there is nothing to hand back from a
+        // sub-solve the user interrupted. The outer loop leaves
+        // `data.curr` — the last iterate accepted for the original NLP —
+        // in place and terminates on it.
+        if result.user_requested_stop {
+            return RestorationOutcome::UserRequestedStop;
         }
 
         // 1b. Locally-infeasible short-circuit. The inner sub-IPM
@@ -920,7 +958,7 @@ mod tests {
             Rc::clone(&nlp),
         )));
 
-        let hook: RestoInnerSolver = Box::new(|_, _, _, _, _, _| {
+        let hook: RestoInnerSolver = Box::new(|_, _, _, _, _, _, _| {
             Some(RestoSolveResult {
                 trial_x: rcv(&[10.0, 20.0]),
                 trial_s: rcv(&[4.0]),
@@ -928,6 +966,7 @@ mod tests {
                 iters_since_header: 0,
                 last_output: 0.0,
                 locally_infeasible: false,
+                user_requested_stop: false,
             })
         });
 

--- a/crates/pounce-restoration/src/resto_inner_solver.rs
+++ b/crates/pounce-restoration/src/resto_inner_solver.rs
@@ -115,7 +115,13 @@ pub fn make_resto_inner_solver(
     mut backend_factory_factory: InnerBackendFactoryFactory,
 ) -> crate::min_c_1nrm::RestoInnerSolver {
     Box::new(
-        move |outer_data, outer_cq, outer_nlp, orig_progress_cb, print_iter_output, debug_hook| {
+        move |outer_data,
+              outer_cq,
+              outer_nlp,
+              orig_progress_cb,
+              print_iter_output,
+              debug_hook,
+              intermediate_tnlp| {
             run_inner_resto(
                 outer_data,
                 outer_cq,
@@ -126,6 +132,7 @@ pub fn make_resto_inner_solver(
                 orig_progress_cb,
                 print_iter_output,
                 debug_hook,
+                intermediate_tnlp,
             )
         },
     )
@@ -245,6 +252,7 @@ pub fn run_inner_resto(
     orig_progress_cb: Option<pounce_algorithm::restoration::OrigProgressCallback>,
     print_iter_output: bool,
     debug_hook: Option<Rc<RefCell<dyn pounce_algorithm::debug::DebugHook>>>,
+    intermediate_tnlp: Option<Rc<RefCell<dyn pounce_nlp::tnlp::TNLP>>>,
 ) -> Option<RestoSolveResult> {
     // ---- 1. Snapshot outer iterate. ---------------------------------
     let snap = build_outer_snapshot(outer_data, outer_cq)?;
@@ -568,6 +576,17 @@ pub fn run_inner_resto(
     if let Some(h) = debug_hook {
         alg = alg.with_debug_hook(h);
     }
+    // Forward the user's TNLP so `intermediate_callback` fires per inner
+    // iteration (gh#645), flagged so those fires carry
+    // `AlgorithmMode::RestorationPhaseMode` and skip the live-inspector
+    // context — the inner iterate is a compound `(x_orig, n, p)` vector,
+    // not a point of the user's NLP. Left unset when the caller
+    // installed no callback, so nothing about this path is reachable for
+    // them.
+    if let Some(t) = intermediate_tnlp {
+        alg = alg.with_tnlp(t);
+        alg.fires_as_restoration = true;
+    }
     // Forward the outer `print_level == 0` gate. Suppresses the
     // restoration `r`-suffixed iter table; the resto-of-resto level
     // also inherits the same flag (its `RestorationPhase` impl is the
@@ -598,6 +617,26 @@ pub fn run_inner_resto(
         let d = alg.data.borrow();
         (d.iter_count, d.info_iters_since_header, d.info_last_output)
     };
+
+    // gh#645: the user's callback returned `false` from a restoration
+    // fire. Return before the locally-infeasible adjudication below
+    // rather than after it: that verdict is a claim about the original
+    // NLP's feasibility, and a sub-solve the user interrupted has not
+    // finished earning it. The caller maps this to
+    // `RestorationOutcome::UserRequestedStop` and drops `trial_x` /
+    // `trial_s` on the floor — they are carried here only because the
+    // struct is shared with the success path.
+    if matches!(status, SolverReturn::UserRequestedStop) {
+        return Some(RestoSolveResult {
+            trial_x,
+            trial_s,
+            iter_count: inner_iter_count,
+            iters_since_header,
+            last_output,
+            locally_infeasible: false,
+            user_requested_stop: true,
+        });
+    }
 
     // Locally-infeasible detection. Mirrors upstream
     // `IpRestoConvCheck.cpp:208-241`: fires when the inner sub-IPM
@@ -866,6 +905,7 @@ pub fn run_inner_resto(
         iters_since_header,
         last_output,
         locally_infeasible,
+        user_requested_stop: false,
     })
 }
 

--- a/crates/pounce-restoration/tests/restoration_triggers.rs
+++ b/crates/pounce-restoration/tests/restoration_triggers.rs
@@ -134,7 +134,10 @@ fn line_search_failure_invokes_user_supplied_restoration_phase() {
 
     let factory: RestorationFactory = Box::new(move || {
         let count = Rc::clone(&count_for_factory);
-        let hook: RestoInnerSolver = Box::new(move |_, _, _, _, _, _| {
+        // Trailing arg is the user TNLP the outer driver forwards for
+        // the gh#645 restoration-phase callback fires; this fake inner
+        // solver never runs an IPM, so it has nothing to fire.
+        let hook: RestoInnerSolver = Box::new(move |_, _, _, _, _, _, _| {
             *count.borrow_mut() += 1;
             // Returning `None` makes `MinC1NormRestoration` surface
             // `RestorationOutcome::Failed`, so the outer algorithm

--- a/docs/src/casadi.md
+++ b/docs/src/casadi.md
@@ -167,7 +167,7 @@ st["iter_count"]
 st["t_solve_pounce"] # seconds inside POUNCE
 st["iterations"]     # dict of per-iteration lists:
                      #   inf_pr, inf_du, mu, d_norm, regularization_size,
-                     #   obj, alpha_pr, alpha_du, ls_trials
+                     #   obj, alpha_pr, alpha_du, ls_trials, alg_mod
 
 st["final_inf_pr"]      # final primal infeasibility
 st["final_inf_du"]      # final dual infeasibility
@@ -210,11 +210,32 @@ iterations its inner solver ran, and the seconds spent there — enough to
 answer "did this solve struggle, and how much of it was restoration?"
 without raising `print_level`.
 
-It is per solve, not per iteration. POUNCE fires the intermediate
-callback only from its outer loop and always reports `RegularMode` in
-Ipopt's `alg_mod`, so no per-iteration restoration flag is published —
-a column that is constant zero would read as working restoration
-detection.
+Individual iterations are labelled too, by
+`stats()["iterations"]["alg_mod"]`: `0` for an outer iteration, `1` for
+one of the restoration subproblem. The solve-level dict above stays
+useful alongside it — it is the only source for the inner iteration
+count and the wall time, and it answers the question in one read.
+
+**Read `alg_mod` before plotting anything else.** On a restoration row
+every other column describes the min-‖c‖₁ *feasibility subproblem*, not
+your NLP: its objective is the constraint-violation penalty, and its
+`inf_pr` falls to zero as the subproblem converges while your problem's
+violation is untouched. Plotted on one axis without splitting on
+`alg_mod`, a restoration episode looks like the objective exploding and
+the infeasibility being solved, and neither happened.
+
+```python
+it = st["iterations"]
+outer = [(i, o) for i, (o, m)
+         in enumerate(zip(it["obj"], it["alg_mod"])) if m == 0]
+```
+
+`iteration_callback` is not called for restoration iterations. CasADi
+fixes its signature at `(x, f, g, lam_x, lam_g)` and a restoration
+iterate supplies none of them — it is a point of a different problem, in
+that problem's variable space. The trace still records those iterations,
+so nothing is hidden; they simply are not handed to a callback that
+would have to interpret them as a solution estimate.
 
 `lam_p` deserves a note because its sign surprises people. CasADi's
 `Nlpsol` base class computes it — no plugin is involved, which is why
@@ -630,10 +651,11 @@ counterpart of CasADi's `ipopt_runtime.hpp`. Worked example:
   supported"* otherwise. Identical in both plugins; `eigen-clip` and
   `eigen-reflect` have no such restriction, and POUNCE's own
   inertia-correcting regularization is on by default regardless.
-- **Per-iteration restoration flags, and linear-solver phase timings.**
-  Both are reported at solve level instead (`stats()["restoration"]`,
-  `stats()["linear_solver"]`), because that is the granularity POUNCE
-  measures. See
+- **Linear-solver phase timings.** Reported at solve level only
+  (`stats()["linear_solver"]`), because that is the granularity POUNCE
+  measures — the per-phase numbers are absent rather than zero. (The
+  per-iteration restoration flag that used to sit in this bullet now
+  ships: see `iterations["alg_mod"]` above.) See
   [`dev-notes/casadi-diagnostics-and-native-builds.md`](https://github.com/jkitchin/pounce/blob/main/dev-notes/casadi-diagnostics-and-native-builds.md)
   for what each would take.
 - **Native (non-Python) plugin builds and prebuilt plugin archives.**


### PR DESCRIPTION
Fixes #645.

## Problem

A caller with an intermediate callback installed went silent for the whole of a
restoration episode, and could not stop the solve from inside one. Restoration
is the phase most likely to overrun a real-time budget, which makes it the phase
a controller most needs to be able to abort in.

Measured on a solve that enters restoration twice (the new
`crates/pounce-cinterface/tests/restoration_callback.rs` fixture):

| | fires | of which restoration | can stop from restoration |
|---|---|---|---|
| before | 8 | 0 | no |
| after | 16 | 10 | yes |

The `alg_mod` argument of the C API's `Intermediate_CB` was documented as
"always 0 (RegularMode)". That was not a tracking gap — it was unreachable.
`fire_intermediate` had exactly two call sites, both in the outer loop, so no
fire could report `RestorationPhaseMode` because no fire happened from anywhere
that could set it.

## Cause

The restoration inner IPM is a separate `IpoptAlgorithm` built by
`resto_inner_solver`, and the user's TNLP was never forwarded onto it. The
outer algorithm holds `intermediate_tnlp`; the inner one was constructed
without it, so its own `fire_intermediate` calls had nothing to fire into.

## Fix

Forward the TNLP onto the inner IPM the same way `set_debug_hook` already
forwards the interactive debugger — a new
`RestorationPhase::set_intermediate_tnlp`, defaulted to a no-op so drivers
without a nested IPM compose unchanged. `IpoptAlgorithm` carries a
`fires_as_restoration` flag that the inner solver sets, which drives the mode
field of the stats payload and the live-inspector decision below.

**The live inspectors deliberately report no data on restoration fires.** The
inner iterate is a `CompoundVector` over `(x_orig, n, p)` and does not have the
user's `n`. The C API's `GetIpoptCurrent*` family validates the caller's
dimensions against the *problem's* registered ones rather than the context's,
so installing the inner context would have sailed past that check and read a
differently shaped `cq` — a buffer-length mismatch, not a bad number. Reporting
no data is the truthful answer: there is no current iterate of the user's
problem while a subproblem is being solved. Pinned by
`inspectors_report_no_data_during_a_restoration_fire`.

**Stopping returns the outer iterate, not the subproblem's.** A new
`RestorationOutcome::UserRequestedStop` propagates the abort, checked ahead of
the locally-infeasible adjudication — that verdict is a claim about the original
NLP's feasibility, and an interrupted sub-solve has not earned it. The outer arm
returns before promoting the staged trial point, so `data.curr` is still the
last iterate accepted for the original NLP. Same discipline as the pounce#244
deadline exit, and it is the part that matters to the caller this exists for: a
controller aborting on a deadline still has to apply something, and the
subproblem's iterate is not a point it should apply.

Rejected alternative: installing the inner context and having the inspectors
map the compound iterate back onto the user's variables. The `x_orig` slice
alone would be a plausible-looking answer that is not a solution estimate of the
user's problem — it is a point of the feasibility subproblem — and the
multiplier and dual accessors have no honest counterpart at all.

## Blast radius

**Fixture sweep: bit-identical over all 57 fixtures.** Re-measured against
baseline `9e9b0ac` (current `main`) after this branch was synced past #647
(crossover) and #652 (`pounce-rs` option validation); it was also empty against
the original `dad6748`. That is a check for collateral damage rather than
evidence the feature works — the CLI installs no callback, so the whole path is
inert there. The tests are what show it works.

Behavioural change for existing embedders: a callback now fires more often on
solves that enter restoration. Anything counting fires, sampling for a plot, or
driving a progress bar sees the difference. Upstream Ipopt fires from
restoration too, so a callback ported from it was already written expecting
these. Called out in the CHANGELOG in those terms.

Two deliberate silences, both documented:

- `GetIpoptCurrent*` report no data on restoration fires (above).
- The CasADi plugin does not drive `iteration_callback` on them: its signature
  is fixed at `(x, f, g, lam_x, lam_g)` and a restoration iterate supplies none
  of them. The trace still records the iteration — `stats()["iterations"]["alg_mod"]`
  — so nothing is hidden.

The plugin also stops taking `iter_count` from restoration fires. The inner
counter restarts at zero on every entry and would otherwise clobber the outer
count — the same disagreement #637 fixed for the trace, one level down.

**Read `alg_mod` before reading anything beside it.** On a restoration row every
other column describes the min-‖c‖₁ feasibility subproblem: its objective is the
constraint-violation penalty (obj ≈ 1001 on the fixture while the user's problem
sits at 0), and its `inf_pr` falls to zero as the subproblem converges while the
user's violation is untouched. Plotted on one axis without splitting on
`alg_mod`, an episode reads as the objective exploding and the infeasibility
being solved, and neither happened. Said in `docs/src/casadi.md` and the
CHANGELOG.

## Tests

Three new tests in `crates/pounce-cinterface/tests/restoration_callback.rs`, all
failing on the pre-change parent for the right reason:

| test | failure without the fix |
|---|---|
| `restoration_iterations_fire_the_callback_and_are_labelled` | `restoration ran but never fired the callback — 8 regular fires only` |
| `inspectors_report_no_data_during_a_restoration_fire` | `no restoration fires` |
| `stopping_from_restoration_returns_the_last_original_nlp_iterate` | status 2 (`Infeasible_Problem_Detected`), expected 5 (`User_Requested_Stop`) |

The third also asserts the returned `x` is the outer iterate, which is the
property the design decision above exists to protect.

Trace recorded by the fixture: `[0,0,0,0, 1,1,1,1,1, 0, 1,1,1,1,1, 0]` — two
episodes, correctly labelled, with the outer iteration resuming after each.

CasADi side: parity suite green (`alg_mod` present in the trace, and
`iteration_callback` verified not called for restoration iterations).

Deliberately not pinned: the *number* of restoration fires on any given model.
It is a trajectory property, and pinning it here would make this suite fail on
unrelated solver work — which is what the fixture sweep is for.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`casadi.md`; no new page, no
      `SUMMARY.md` change)
- [x] `cargo fmt --all -- --check`, `cargo clippy` (CI's
      `-D clippy::correctness -D clippy::suspicious` gate), `cargo test
      --workspace --exclude pounce-hsl` all clean — re-run after each sync
- [x] Every claim in this body is true of the diff as it stands