### PR TITLE
casadi: expose POUNCE's structured solve report as a plugin option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ changes.
 
 ## [Unreleased]
 
+- **POUNCE's structured solve report is reachable from CasADi** (#644).
+  Set `solve_report` to a path and each solve writes a
+  `pounce.solve-report/v1` JSON file — the same format the `pounce`
+  CLI's `--json-output` produces, so the tools that read those read
+  this. `solve_report_detail` chooses `'summary'` (default) or
+  `'full'`, which embeds the per-iteration trajectory.
+
+  Both C entry points behind this (`IpoptEnableIterHistory`,
+  `IpoptWriteSolveReport`) already existed; what was missing was any way
+  for a CasADi caller to reach them, so the report was available to a
+  CLI user and not to this one.
+
+  Capturing the trajectory costs a retained iterate per iteration, which
+  is why `summary` is the default — and it has to be switched on before
+  the solve, since there is nothing to reconstruct it from afterwards.
+  Asking for `'full'` switches it on for you rather than making you set
+  a second option and discover the omission from an empty trajectory.
+
+  A report that cannot be written is a warning and
+  `stats()["solve_report_written"] == False`, not a failed solve: the
+  answer is already computed, and a diagnostic file is not worth an
+  exception. The file is rewritten per solve, so a solver called in a
+  loop leaves only the last one. `generate()` refuses the option by
+  name — the emitted runtime does not write reports, and dropping it
+  silently would leave you waiting for a file that never appears.
+
 - **CasADi plugin: solver diagnostics, and two defects found exposing
   them** (#634).
 

--- a/casadi/casadi_nlpsol_pounce.cpp
+++ b/casadi/casadi_nlpsol_pounce.cpp
@@ -53,6 +53,10 @@ namespace casadi {
     /// Final KKT errors, read off the problem before it is freed —
     /// `FreeIpoptProblem` takes the accessors with it.
     double final_inf_pr = 0, final_inf_du = 0, final_compl_inf = 0;
+    /// Whether the last solve's report reached disk (gh#644). Reported
+    /// through `stats()` so a script can check it without scraping the
+    /// warning, and absent when no report was asked for.
+    bool report_written = false;
     /// Linear-solver post-mortem, harvested at the same moment.
     PounceLinearSolverStats linsol{};
     bool linsol_valid = false;
@@ -131,6 +135,20 @@ namespace casadi {
     bool warm_start_from_previous_ = false;
     std::string inactive_lam_strategy_ = "reltol";
     double inactive_lam_value_ = 10;
+
+    /// Where to write POUNCE's structured solve report, and how much of
+    /// it (gh#644). Empty path means off, which is the default: the
+    /// report is a file write per solve, and `stats()` already carries
+    /// what most callers want.
+    std::string solve_report_;
+    std::string solve_report_detail_ = "summary";
+    /// `detail = "full"` embeds the per-iteration trajectory, which
+    /// POUNCE only retains when asked before the solve. Derived rather
+    /// than exposed as a third option: capturing the history has no use
+    /// here except to reach the report, so making the caller ask twice
+    /// only creates a way to ask wrong — `detail="full"` with an empty
+    /// trajectory and nothing saying why.
+    bool report_needs_iter_history() const { return solve_report_detail_ == "full"; }
 
     /// Convexification of the Lagrangian Hessian before it reaches the
     /// solver, using CasADi's own `Convexify` (the same code path its ipopt
@@ -280,6 +298,17 @@ namespace casadi {
        {OT_DOUBLE,
         "Maximum number of iterations to compute an eigenvalue decomposition "
         "(default: 200)."}},
+      {"solve_report",
+       {OT_STRING,
+        "Path to write POUNCE's structured solve report (pounce.solve-report/v1 "
+        "JSON) after each solve. Empty (the default) writes nothing. The file "
+        "is rewritten per solve, so a solver called in a loop leaves only the "
+        "last one — give each call its own path if you need to keep them."}},
+      {"solve_report_detail",
+       {OT_STRING,
+        "'summary' (default) or 'full'. 'full' embeds the per-iteration "
+        "trajectory, which costs a retained iterate per iteration and is "
+        "enabled automatically when you ask for it."}},
       {"var_string_md",
        {OT_DICT, "String metadata about variables. Accepted for ipopt-plugin "
                  "compatibility; not forwarded (POUNCE has no metadata "
@@ -346,6 +375,10 @@ namespace casadi {
         convexify_margin = op.second;
       } else if (op.first == "max_iter_eig") {
         max_iter_eig = op.second;
+      } else if (op.first == "solve_report") {
+        solve_report_ = op.second.to_string();
+      } else if (op.first == "solve_report_detail") {
+        solve_report_detail_ = op.second.to_string();
       } else if (op.first == "var_string_md") {
         var_string_md_ = op.second;
       } else if (op.first == "var_integer_md") {
@@ -360,6 +393,14 @@ namespace casadi {
         con_numeric_md_ = op.second;
       }
     }
+
+    // Reject a bad `solve_report_detail` here rather than at write time.
+    // The C API validates it too, but only when the report is written —
+    // i.e. after a solve that has already run. A typo should cost the
+    // construction of the solver, not a solve.
+    casadi_assert(solve_report_detail_ == "summary" || solve_report_detail_ == "full",
+                  "solve_report_detail must be 'summary' or 'full', got '"
+                  + solve_report_detail_ + "'.");
 
     // Do we have an exact Hessian?
     exact_hessian_ = true;
@@ -627,6 +668,7 @@ namespace casadi {
     m->alpha_du.clear();
     m->ls_trials.clear();
     m->final_inf_pr = m->final_inf_du = m->final_compl_inf = 0;
+    m->report_written = false;
     m->linsol_valid = false;
     m->resto_calls = m->resto_inner = m->resto_outer = 0;
     m->resto_secs = 0;
@@ -655,6 +697,13 @@ namespace casadi {
       &PounceInterface::cb_grad_f, &PounceInterface::cb_jac_g,
       exact_hessian_ ? &PounceInterface::cb_h : nullptr);
     casadi_assert(prob != nullptr, "POUNCE: CreateIpoptProblem failed");
+
+    // Has to precede the solve: POUNCE keeps the per-iteration trajectory
+    // only when asked beforehand, and there is no way to reconstruct it
+    // afterwards.
+    if (!solve_report_.empty() && report_needs_iter_history()) {
+      IpoptEnableIterHistory(prob);
+    }
     m->prob = prob;
 
     if (!exact_hessian_) {
@@ -778,6 +827,24 @@ namespace casadi {
     m->linsol_valid = GetPounceLinearSolverStats(prob, &m->linsol);
     GetPounceRestorationStats(prob, &m->resto_calls, &m->resto_inner,
                               &m->resto_outer, &m->resto_secs);
+    // Same window as the harvest above, and for the same reason: the
+    // report is built from the solve retained on `prob`, which the free
+    // below takes with it.
+    //
+    // A failed write is a warning, not an error. The solve succeeded and
+    // its answer is already in `m`; refusing to return it because a
+    // diagnostic file could not be written would be the wrong trade, and
+    // an unwritable path is a caller mistake that a warning names
+    // exactly. `m->report_written` records what happened so `stats()`
+    // can be asked rather than the log read.
+    if (!solve_report_.empty()) {
+      m->report_written = IpoptWriteSolveReport(prob, solve_report_.c_str(),
+                                                solve_report_detail_.c_str()) != 0;
+      if (!m->report_written) {
+        casadi_warning("POUNCE: could not write solve report to '" + solve_report_
+                       + "' (unwritable path, or no solve to report).");
+      }
+    }
     FreeIpoptProblem(prob);
     m->prob = nullptr;
 
@@ -872,6 +939,12 @@ namespace casadi {
     stats["warm_started_working_set"] = m->ws_used;
     stats["working_set_available"] = m->ws_valid;
     stats["n_eval_errors"] = m->eval_errors;
+    // Only when one was asked for: an absent key means "no report
+    // requested", which is a different thing from "the write failed".
+    if (!solve_report_.empty()) {
+      stats["solve_report"] = solve_report_;
+      stats["solve_report_written"] = m->report_written;
+    }
     // Metadata POUNCE has no channel for: given back rather than dropped, so
     // a caller that set it can at least see it survived the round trip.
     if (!var_string_md_.empty()) stats["var_string_md"] = var_string_md_;
@@ -1002,6 +1075,13 @@ namespace casadi {
                   "carries an active-set working set between calls of one "
                   "solver object, which the generated entry point has no "
                   "channel for. Pass x0/lam_g0/lam_x0 instead.");
+    casadi_assert(solve_report_.empty(),
+                  "solve_report cannot be code generated by this plugin yet. "
+                  "The generated code links the same C API and could call "
+                  "IpoptWriteSolveReport, but the emitted runtime does not, "
+                  "and silently dropping the option would leave you waiting "
+                  "for a file that is never written. Drop it, or keep this "
+                  "solver interpreted.");
     casadi_assert(jacg_sp_.size1() == 0 || jacg_sp_.nnz() > 0,
                   "A constraint Jacobian with no nonzeros is not supported by "
                   "the C API this generates against.");

--- a/casadi/test_parity.py
+++ b/casadi/test_parity.py
@@ -10,6 +10,7 @@ same model, so a failure says "the two solvers disagree", not "the
 number moved".
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -887,6 +888,98 @@ def _compile_generated(solver, workdir, stem):
     return ca.external(solver.name(), so)
 
 
+def test_solve_report_option():
+    """`solve_report` writes POUNCE's structured report (gh#644).
+
+    Both entry points (`IpoptEnableIterHistory`, `IpoptWriteSolveReport`)
+    already existed in the C interface; what was missing was any way for
+    a CasADi caller to reach them, so the report was available to a
+    `pounce` CLI user and not to this one.
+    """
+    nlp = rosenbrock_nlp()
+
+    # Off by default: no keys claiming a report, and nothing written.
+    S = ca.nlpsol("S", "pounce", nlp, QUIET_POUNCE)
+    S(x0=[0.5, 0.5], p=1.5, lbg=-ca.inf, ubg=0)
+    st = S.stats()
+    check("solve_report: absent from stats when not requested",
+          "solve_report" not in st and "solve_report_written" not in st,
+          f"keys = {sorted(k for k in st if 'report' in k)}")
+
+    with tempfile.TemporaryDirectory() as d:
+        full = os.path.join(d, "full.json")
+        F = ca.nlpsol("F", "pounce", nlp,
+                      dict(QUIET_POUNCE, solve_report=full,
+                           solve_report_detail="full"))
+        F(x0=[0.5, 0.5], p=1.5, lbg=-ca.inf, ubg=0)
+        st = F.stats()
+        check("solve_report: stats reports the write", 
+              st.get("solve_report_written") is True and st.get("solve_report") == full,
+              f"{st.get('solve_report_written')}, {st.get('solve_report')}")
+        check("solve_report: file exists", os.path.exists(full))
+        if not os.path.exists(full):
+            return
+        with open(full) as fh:
+            report = json.load(fh)
+        check("solve_report: schema is pounce.solve-report/v1",
+              report.get("schema") == "pounce.solve-report/v1",
+              str(report.get("schema")))
+
+        # `detail=full` is the whole reason `IpoptEnableIterHistory` has
+        # to be called before the solve; if that ordering were wrong the
+        # report would arrive with no trajectory and nothing saying why.
+        traj = report.get("iterations")
+        check("solve_report: full embeds the trajectory",
+              isinstance(traj, list) and len(traj) > 0,
+              f"{type(traj).__name__}, {len(traj) if isinstance(traj, list) else 0} entries")
+        # Same convention as `stats()['iterations']`: the initial point
+        # is recorded too, so the trajectory is one longer than the
+        # iteration count. A disagreement here means the two views of one
+        # solve are describing different things — the defect class #637
+        # fixed for the trace.
+        if isinstance(traj, list):
+            check("solve_report: trajectory agrees with iter_count",
+                  len(traj) == st["iter_count"] + 1,
+                  f"{len(traj)} entries vs iter_count {st['iter_count']}")
+
+        # Default detail is a summary: same report, no trajectory. Worth
+        # pinning because the cost of `full` is a retained iterate per
+        # iteration, and a default that quietly paid it would be a
+        # surprise on a long solve.
+        summary = os.path.join(d, "summary.json")
+        M = ca.nlpsol("M", "pounce", nlp, dict(QUIET_POUNCE, solve_report=summary))
+        M(x0=[0.5, 0.5], p=1.5, lbg=-ca.inf, ubg=0)
+        with open(summary) as fh:
+            sm = json.load(fh)
+        check("solve_report: summary is the default and omits the trajectory",
+              sm.get("schema") == "pounce.solve-report/v1" and not sm.get("iterations"),
+              f"iterations = {sm.get('iterations')}")
+
+        # A typo costs the construction, not a solve.
+        try:
+            ca.nlpsol("B", "pounce", nlp,
+                      dict(QUIET_POUNCE, solve_report=os.path.join(d, "b.json"),
+                           solve_report_detail="verbose"))
+            refused, detail = False, "accepted"
+        except RuntimeError as exc:
+            refused = "solve_report_detail" in str(exc)
+            detail = str(exc).strip().splitlines()[-1][:70]
+        check("solve_report: an invalid detail is refused at construction",
+              refused, detail)
+
+        # An unwritable path must not cost the answer. The solve
+        # succeeded; a diagnostic file that could not be written is a
+        # warning and a False in stats, not a failed solve.
+        bad = os.path.join(d, "no-such-dir", "r.json")
+        B = ca.nlpsol("B2", "pounce", nlp, dict(QUIET_POUNCE, solve_report=bad))
+        r = B(x0=[0.5, 0.5], p=1.5, lbg=-ca.inf, ubg=0)
+        st = B.stats()
+        check("solve_report: an unwritable path does not fail the solve",
+              st["success"] and st.get("solve_report_written") is False,
+              f"success={st['success']}, written={st.get('solve_report_written')}, "
+              f"x={r['x']}")
+
+
 def test_codegen_matches_the_interpreted_solve():
     """`solver.generate()` — the model *and* the solve, as compiled C.
 
@@ -986,6 +1079,7 @@ def test_codegen_refuses_what_it_cannot_reproduce():
         ("iteration_callback", {"iteration_callback": Noop()}),
         ("warm_start_from_previous", {"warm_start_from_previous": True}),
         ("convexify_strategy", {"convexify_strategy": "eigen-clip"}),
+        ("solve_report", {"solve_report": "report.json"}),
     ]
     with tempfile.TemporaryDirectory() as d:
         for label, opts in cases:
@@ -1040,6 +1134,7 @@ def main():
         test_restoration_stats,
         test_live_diagnostics_during_the_callback,
         test_option_types_come_from_pounce_not_the_literal,
+        test_solve_report_option,
         test_codegen_matches_the_interpreted_solve,
         test_codegen_refuses_what_it_cannot_reproduce,
     ):

--- a/docs/src/casadi.md
+++ b/docs/src/casadi.md
@@ -203,6 +203,41 @@ are **absent** rather than zero; in particular there are no phase
 timings (symbolic analysis, numeric factorization, back-solve), because
 POUNCE does not instrument those phases separately today.
 
+### The structured solve report
+
+`stats()` is the convenient view; POUNCE also writes a machine-readable
+one. Set `solve_report` to a path and each solve leaves a
+`pounce.solve-report/v1` JSON file — the same format the `pounce` CLI's
+`--json-output` produces, so the tools that read those (`diagnose`,
+`find_stalls`, `convergence_trace`) read this too.
+
+```python
+S = ca.nlpsol("S", "pounce", nlp, {
+    "solve_report": "run.json",
+    "solve_report_detail": "full",   # 'summary' (default) or 'full'
+})
+```
+
+`full` embeds the per-iteration trajectory; `summary` omits it and
+carries the problem, solution, statistics and linear-solver blocks.
+The trajectory is not free — POUNCE has to retain each iterate as it
+goes, which is why `summary` is the default and why the capture is
+switched on before the solve rather than reconstructed after it. Asking
+for `full` switches it on for you.
+
+Two things worth knowing before you wire it into a loop:
+
+- **The file is rewritten per solve.** A solver called repeatedly leaves
+  only the last report. Give each call its own path if you want to keep
+  them.
+- **A write that fails does not fail the solve.** You get a warning and
+  `stats()["solve_report_written"] == False`; the answer is still
+  returned, because a diagnostic file is not worth an exception. Check
+  that key rather than the log if a script depends on the file.
+
+`solve_report_detail` is validated when the solver is constructed, so a
+typo costs you the `nlpsol` call rather than a solve.
+
 ### Restoration
 
 `stats()["restoration"]` counts restoration-phase entries, the
@@ -609,6 +644,7 @@ refuses them by name rather than quietly dropping them:
 | `iteration_callback` | The callback is a CasADi `Function` living in this process; generated code runs without CasADi. |
 | `warm_start_from_previous` | It carries an active set between calls of one solver *object*; the generated entry point has no such channel. Pass `x0` / `lam_g0` / `lam_x0` instead. |
 | `convexify_strategy` | Not emitted yet. |
+| `solve_report` | The generated code links the same C API and could call `IpoptWriteSolveReport`, but the emitted runtime does not. Refused rather than dropped, so you are not left waiting for a file that never appears. |
 
 The runtime the plugin emits is `casadi/pounce_runtime.hpp`, the
 counterpart of CasADi's `ipopt_runtime.hpp`. Worked example:


### PR DESCRIPTION
Fixes #644.

## Problem

`IpoptEnableIterHistory` and `IpoptWriteSolveReport` have been in the C
interface for a while, and the CasADi plugin called neither. The
`pounce.solve-report/v1` JSON was reachable from the CLI and not from CasADi —
even though the data was already being collected in the same process, by the
same solve.

## Cause

Nothing broken; a gap. The plugin exposed diagnostics through `stats()` (#634)
but never the file the report tools consume, so a CasADi user could not feed
`diagnose`, `find_stalls`, or `convergence_trace` without re-running the model
through the CLI.

## Fix

Two options:

```python
S = ca.nlpsol("S", "pounce", nlp, {
    "solve_report": "run.json",
    "solve_report_detail": "full",   # 'summary' (default) or 'full'
})
```

`full` embeds the per-iteration trajectory; `summary` carries the problem,
solution, statistics and linear-solver blocks without it.

**The iteration-history switch is derived from `detail`, not exposed as a third
option.** POUNCE retains the trajectory only when asked *before* the solve —
there is nothing to reconstruct it from afterwards. Enabling that capture has no
purpose here except to reach the report, so a separate switch would only create
a way to ask wrong, and the symptom would be a `detail="full"` report with an
empty trajectory and nothing saying why. Asking for `full` switches it on.

Three choices about failure and cost, each rejecting a plausible alternative:

- **A failed write warns; it does not throw.** `stats()["solve_report_written"]`
  records what happened. The solve succeeded and its answer is in hand; refusing
  to return it because a diagnostic file could not be written is the wrong
  trade, and a bad path is a caller mistake a warning names exactly.
- **`solve_report_detail` is validated in `init`, not at write time.** The C API
  validates it too, but only after a solve has already run — so a typo would
  cost a solve rather than the `nlpsol` call.
- **`generate()` refuses `solve_report` by name**, alongside the three options
  already refused there. The generated code links the same C API and could call
  the writer, but the emitted runtime does not, and dropping the option silently
  would leave the caller waiting for a file that never appears.

The write goes in the same window as the #634 diagnostics harvest, ahead of
`FreeIpoptProblem`, which takes the retained solve with it.

## Blast radius

Narrow. Both options default off, and with `solve_report` unset the plugin
behaves exactly as before — no report keys in `stats()` either, so an absent key
means "not requested" rather than "the write failed".

No Rust change, so no trajectory implications and no fixture sweep: the report
is written after the solve, and the history capture it may switch on retains
iterates without influencing them.

Two costs worth stating, both documented in `docs/src/casadi.md`:

- `detail="full"` retains an iterate per iteration. That is why `summary` is the
  default.
- The file is rewritten per solve, so a solver called in a loop leaves only the
  last report. Callers who want to keep them need one path per call.

## Tests

New `test_solve_report_option` in `casadi/test_parity.py` (suite now 83 checks,
all green), plus `solve_report` added to the codegen-refusal cases.

They fail on parent `dad6748` with CasADi's own `Unknown option: solve_report` —
the option does not exist there at all.

Pinned: report written and `stats()` reports it; schema is
`pounce.solve-report/v1`; `full` embeds a trajectory whose length agrees with
`stats()["iter_count"] + 1` (same convention as `stats()["iterations"]` — a
disagreement would mean two views of one solve describing different things,
which is the defect class #637 fixed for the trace); `summary` is the default
and omits it; an invalid `detail` is refused at construction; an unwritable path
leaves `success == True` with `solve_report_written == False`; codegen refuses
the option by name.

All eight `casadi/examples/` scripts run.

Deliberately not pinned: the report's internal field values beyond the schema
tag and trajectory length. Those belong to `pounce-solve-report`'s own tests —
this suite pins that the plugin reaches the writer correctly, not what the
writer emits.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`casadi.md`; no new page, no
      `SUMMARY.md` change)
- [x] Parity suite and examples clean; no Rust change in this PR, so `cargo`
      checks are unaffected
- [x] Every claim in this body is true of the diff as it stands

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUXrfbxsYqpUuxpLmrBsSi)_