### PR TITLE
pounce-rs: report rejected solver options instead of discarding them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ changes.
 
 ## [Unreleased]
 
+- **`pounce-rs`: a rejected solver option is no longer silently
+  discarded** (#649).
+
+  `Nlp::solve` applied `.option_num` / `.option_int` / `.option_str`
+  through `OptionsList::set_*_value` but dropped the returned `Result`.
+  `OptionsList` validates every option against the registry — unknown
+  name, wrong value type, out-of-range value, unregistered choice — so a
+  typo like `.option_str("mu_stratgey", "adaptive")` was rejected,
+  discarded, and the solve then ran with the default still in effect.
+  Nothing in the output distinguished that from an honoured request, and
+  the failure got worse the more the option mattered: a misspelled
+  `max_iter` reported a full converged solve at the default cap.
+
+  Rejected options are now reported. New `Nlp::try_solve` returns
+  `Result<Solution, NlpError>`, with `NlpError::InvalidOption` naming the
+  option, the value, and the registry's reason; `NlpError::UnknownVariableCount`
+  and `NlpError::Initialize` cover the other two setup failures.
+  `Nlp::solve` keeps its signature and now panics on those conditions
+  rather than solving a configuration the caller did not ask for — a
+  behaviour change for callers who were passing an invalid option and
+  (knowingly or not) getting the default. A solve that runs and fails to
+  converge is unaffected: still `Ok` with `success == false`.
+
+  The two internal defaults the builder sets for itself
+  (`hessian_approximation`, `sqp_hessian`) still ignore their result;
+  both names are hardcoded and valid. Only the interior-point path
+  through `pounce-rs` was affected — the Python, batch, and C interfaces
+  already propagated these errors.
+
 - **CasADi plugin: solver diagnostics, and two defects found exposing
   them** (#634).
 

--- a/crates/pounce-rs/README.md
+++ b/crates/pounce-rs/README.md
@@ -61,7 +61,17 @@ to a limited-memory (L-BFGS) approximation. This keeps simple problems concise
 without sacrificing access to exact derivatives when needed.
 
 Solver options use the same names as upstream Ipopt
-(`option_num`, `option_int`, `option_str`).
+(`option_num`, `option_int`, `option_str`). Names, value types, ranges, and
+choices are validated against the option registry. A rejected option is
+never applied silently: `solve` panics, and `try_solve` returns
+`Err(NlpError::InvalidOption { .. })` naming the option and the reason.
+
+```rust
+let sol = Nlp::new(P)
+    .x0(&[0.0, 0.0])
+    .option_str("mu_strategy", "adaptive")
+    .try_solve()?;                        // Result<Solution, NlpError>
+```
 
 ## Result
 

--- a/crates/pounce-rs/src/builder.rs
+++ b/crates/pounce-rs/src/builder.rs
@@ -109,8 +109,56 @@ pub struct Solution {
     pub stats: SolveStatistics,
 }
 
+/// Why a solve could not be started.
+///
+/// Returned by [`Nlp::try_solve`]; [`Nlp::solve`] panics on the same
+/// conditions. Every variant here is a configuration error detected
+/// *before* the solver runs — a solve that runs and fails to converge is
+/// not an error, it comes back as a [`Solution`] with `success == false`
+/// and the reason in `status`.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum NlpError {
+    /// Neither [`var_bounds`](Nlp::var_bounds) nor [`x0`](Nlp::x0) was
+    /// called, so the number of variables is unknown.
+    UnknownVariableCount,
+    /// An option passed to [`option_num`](Nlp::option_num) /
+    /// [`option_int`](Nlp::option_int) / [`option_str`](Nlp::option_str)
+    /// was rejected by the options registry: unknown name, wrong value
+    /// type for that name, or a value outside the registered range or
+    /// set of choices.
+    InvalidOption {
+        /// The option name as passed by the caller.
+        tag: String,
+        /// The rejected value, rendered as a string.
+        value: String,
+        /// The registry's explanation.
+        reason: String,
+    },
+    /// `IpoptApplication::initialize` failed.
+    Initialize(String),
+}
+
+impl std::fmt::Display for NlpError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownVariableCount => write!(
+                f,
+                "number of variables unknown — call .var_bounds(..) or .x0(..) \
+                 to set it",
+            ),
+            Self::InvalidOption { tag, value, reason } => {
+                write!(f, "option {tag}={value} rejected: {reason}")
+            }
+            Self::Initialize(msg) => write!(f, "IpoptApplication::initialize failed: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for NlpError {}
+
 /// Builder: `Nlp::new(problem)` then `.var_bounds(..)` / `.x0(..)` (which fix
-/// the number of variables) and `.solve()`.
+/// the number of variables) and `.solve()` / `.try_solve()`.
 pub struct Nlp<P: Problem> {
     problem: P,
     n: Option<usize>, // inferred from var_bounds / x0 (must agree)
@@ -219,12 +267,47 @@ impl<P: Problem + 'static> Nlp<P> {
     /// Build the `TNLP` adapter and run the interior-point solver.
     ///
     /// # Panics
-    /// If the number of variables was never fixed (no `var_bounds` or `x0`).
+    /// If the solve could not be started: the number of variables was never
+    /// fixed (no `var_bounds` or `x0`), or an option was rejected by the
+    /// options registry. Use [`try_solve`](Self::try_solve) to handle those
+    /// as a [`Result`] instead.
     pub fn solve(self) -> Solution {
-        let n = self.n.expect(
-            "pounce_rs::Nlp: number of variables unknown — call .var_bounds(..) \
-             or .x0(..) to set it",
-        );
+        match self.try_solve() {
+            Ok(sol) => sol,
+            Err(e) => panic!("pounce_rs::Nlp: {e}"),
+        }
+    }
+
+    /// Build the `TNLP` adapter and run the interior-point solver, reporting
+    /// setup failures as an [`NlpError`] instead of panicking.
+    ///
+    /// Unlike [`solve`](Self::solve) this surfaces a rejected option — a
+    /// misspelled name, a value out of the registered range, or a value
+    /// that is not one of the registered choices — rather than letting it
+    /// pass silently and solving with the default still in effect.
+    ///
+    /// A solve that *runs* and does not converge is not an error here: it
+    /// returns `Ok` with `success == false` and the reason in `status`.
+    ///
+    /// ```
+    /// use pounce_rs::builder::{Nlp, NlpError, Problem};
+    ///
+    /// struct P;
+    /// impl Problem for P {
+    ///     fn objective(&self, x: &[f64]) -> f64 { (x[0] - 1.0).powi(2) }
+    /// }
+    ///
+    /// // "mu_stratgey" is a typo for "mu_strategy".
+    /// let err = Nlp::new(P).x0(&[0.0]).option_str("mu_stratgey", "adaptive").try_solve();
+    /// assert!(matches!(err, Err(NlpError::InvalidOption { .. })));
+    /// ```
+    ///
+    /// # Errors
+    /// [`NlpError::UnknownVariableCount`] if neither `var_bounds` nor `x0`
+    /// was called, [`NlpError::InvalidOption`] if an option was rejected, and
+    /// [`NlpError::Initialize`] if the application failed to initialize.
+    pub fn try_solve(self) -> Result<Solution, NlpError> {
+        let n = self.n.ok_or(NlpError::UnknownVariableCount)?;
         let m = self.problem.n_constraints();
         let adapter = Rc::new(RefCell::new(Adapter {
             problem: self.problem,
@@ -244,7 +327,8 @@ impl<P: Problem + 'static> Nlp<P> {
         }));
 
         let mut app = IpoptApplication::new();
-        app.initialize().expect("IpoptApplication::initialize");
+        app.initialize()
+            .map_err(|e| NlpError::Initialize(e.message))?;
         // No analytic Hessian is required from `Problem`, so default to L-BFGS.
         let _ = app.options_mut().set_string_value(
             "hessian_approximation",
@@ -260,14 +344,38 @@ impl<P: Problem + 'static> Nlp<P> {
         let _ = app
             .options_mut()
             .set_string_value("sqp_hessian", "lbfgs", true, true);
+        // User options, in contrast to the two defaults above, are reported
+        // rather than dropped: an unknown name or an out-of-range value that
+        // is silently discarded leaves the default in effect and the solve
+        // looks like it honoured the request (gh#649). `Ok(false)` is not a
+        // failure — it means an earlier no-clobber setting won — so only the
+        // `Err` arm is escalated.
         for (k, v) in &self.string {
-            let _ = app.options_mut().set_string_value(k, v, true, true);
+            app.options_mut()
+                .set_string_value(k, v, true, true)
+                .map_err(|e| NlpError::InvalidOption {
+                    tag: k.clone(),
+                    value: v.clone(),
+                    reason: e.message,
+                })?;
         }
         for (k, v) in &self.num {
-            let _ = app.options_mut().set_numeric_value(k, *v, true, true);
+            app.options_mut()
+                .set_numeric_value(k, *v, true, true)
+                .map_err(|e| NlpError::InvalidOption {
+                    tag: k.clone(),
+                    value: v.to_string(),
+                    reason: e.message,
+                })?;
         }
         for (k, v) in &self.int {
-            let _ = app.options_mut().set_integer_value(k, *v, true, true);
+            app.options_mut()
+                .set_integer_value(k, *v, true, true)
+                .map_err(|e| NlpError::InvalidOption {
+                    tag: k.clone(),
+                    value: v.to_string(),
+                    reason: e.message,
+                })?;
         }
 
         let scope = self.capture_iterations.then(|| {
@@ -279,7 +387,7 @@ impl<P: Problem + 'static> Nlp<P> {
         drop(scope);
         let stats = app.statistics();
         let a = adapter.borrow();
-        Solution {
+        Ok(Solution {
             status,
             success: matches!(
                 status,
@@ -293,7 +401,7 @@ impl<P: Problem + 'static> Nlp<P> {
             z_l: a.sol_z_l.clone(),
             z_u: a.sol_z_u.clone(),
             stats,
-        }
+        })
     }
 }
 

--- a/crates/pounce-rs/src/lib.rs
+++ b/crates/pounce-rs/src/lib.rs
@@ -225,7 +225,7 @@ pub use pounce_observability;
 
 // --- ergonomic builder API (argmin-style small trait + builder; #168) -------
 pub mod builder;
-pub use builder::{Nlp, Problem, Solution as NlpSolution};
+pub use builder::{Nlp, NlpError, Problem, Solution as NlpSolution};
 
 // --- feature-gated facets (gh #561) -----------------------------------------
 // Each path gets its own module rather than a flat re-export: `pounce-convex`
@@ -254,7 +254,7 @@ pub mod sqp;
 /// use pounce_rs::prelude::*;
 /// ```
 pub mod prelude {
-    pub use crate::builder::{Nlp, Problem};
+    pub use crate::builder::{Nlp, NlpError, Problem};
     pub use pounce_algorithm::application::IpoptApplication;
     pub use pounce_common::types::{Index, Number};
     pub use pounce_nlp::return_codes::ApplicationReturnStatus;

--- a/crates/pounce-rs/tests/option_validation.rs
+++ b/crates/pounce-rs/tests/option_validation.rs
@@ -1,0 +1,158 @@
+//! Rejected solver options must be reported, not silently dropped (gh#649).
+//!
+//! `OptionsList` already validates every option against the registry —
+//! unknown name, wrong value type, out-of-range or unregistered choice. The
+//! builder used to discard that `Result`, so a misspelled option left the
+//! default quietly in effect and the solve looked like it had honoured the
+//! request. These tests pin the reporting, and pin that valid options still
+//! reach the solver.
+
+use pounce_rs::builder::{Nlp, NlpError, Problem};
+
+/// Rosenbrock: unconstrained, converges in well under 100 iterations.
+struct Rosenbrock;
+
+impl Problem for Rosenbrock {
+    fn objective(&self, x: &[f64]) -> f64 {
+        (1.0 - x[0]).powi(2) + 100.0 * (x[1] - x[0] * x[0]).powi(2)
+    }
+}
+
+fn nlp() -> Nlp<Rosenbrock> {
+    Nlp::new(Rosenbrock).x0(&[-1.2, 1.0])
+}
+
+#[test]
+fn misspelled_string_option_is_reported() {
+    // "mu_stratgey" is the transposed spelling of "mu_strategy" from the
+    // issue report.
+    let err = nlp()
+        .option_str("mu_stratgey", "adaptive")
+        .try_solve()
+        .expect_err("misspelled option should be rejected");
+
+    match err {
+        NlpError::InvalidOption { tag, value, reason } => {
+            assert_eq!(tag, "mu_stratgey");
+            assert_eq!(value, "adaptive");
+            assert!(
+                reason.contains("Unknown option"),
+                "reason should name the failure, got: {reason}"
+            );
+        }
+        other => panic!("expected InvalidOption, got {other:?}"),
+    }
+}
+
+#[test]
+fn misspelled_numeric_option_is_reported() {
+    let err = nlp()
+        .option_num("tolerence", 1e-8)
+        .try_solve()
+        .expect_err("misspelled option should be rejected");
+    assert!(matches!(err, NlpError::InvalidOption { ref tag, .. } if tag == "tolerence"));
+}
+
+#[test]
+fn misspelled_integer_option_is_reported() {
+    let err = nlp()
+        .option_int("max_iterations", 500)
+        .try_solve()
+        .expect_err("misspelled option should be rejected");
+    assert!(matches!(err, NlpError::InvalidOption { ref tag, .. } if tag == "max_iterations"));
+}
+
+#[test]
+fn wrong_value_type_for_a_real_option_is_reported() {
+    // "max_iter" exists but is an integer option, not a string one.
+    let err = nlp()
+        .option_str("max_iter", "500")
+        .try_solve()
+        .expect_err("wrong-typed option should be rejected");
+    match err {
+        NlpError::InvalidOption { tag, reason, .. } => {
+            assert_eq!(tag, "max_iter");
+            assert!(
+                reason.contains("not a string option"),
+                "reason should name the type mismatch, got: {reason}"
+            );
+        }
+        other => panic!("expected InvalidOption, got {other:?}"),
+    }
+}
+
+#[test]
+fn unregistered_choice_for_a_real_option_is_reported() {
+    // "mu_strategy" is real; "aggressive" is not one of its choices.
+    let err = nlp()
+        .option_str("mu_strategy", "aggressive")
+        .try_solve()
+        .expect_err("unregistered choice should be rejected");
+    assert!(matches!(err, NlpError::InvalidOption { ref tag, .. } if tag == "mu_strategy"));
+}
+
+#[test]
+fn out_of_range_numeric_value_is_reported() {
+    // "tol" is registered with a strict lower bound of 0.
+    let err = nlp()
+        .option_num("tol", -1.0)
+        .try_solve()
+        .expect_err("out-of-range value should be rejected");
+    assert!(matches!(err, NlpError::InvalidOption { ref tag, .. } if tag == "tol"));
+}
+
+#[test]
+fn missing_variable_count_is_reported_not_panicked() {
+    let err = Nlp::new(Rosenbrock)
+        .try_solve()
+        .expect_err("unknown variable count should be an error");
+    assert!(matches!(err, NlpError::UnknownVariableCount));
+}
+
+#[test]
+#[should_panic(expected = "option mu_stratgey=adaptive rejected")]
+fn solve_panics_on_a_rejected_option() {
+    let _ = nlp().option_str("mu_stratgey", "adaptive").solve();
+}
+
+#[test]
+fn valid_options_still_reach_the_solver() {
+    let sol = nlp()
+        .option_num("tol", 1e-10)
+        .option_int("print_level", 0)
+        .option_str("mu_strategy", "adaptive")
+        .try_solve()
+        .expect("valid options should be accepted");
+
+    assert!(sol.success, "status: {:?}", sol.status);
+    assert!((sol.x[0] - 1.0).abs() < 1e-4);
+    assert!((sol.x[1] - 1.0).abs() < 1e-4);
+}
+
+/// The regression proper: an accepted option must *do* something. Before the
+/// fix a bogus name and a real one were indistinguishable — both ran to
+/// convergence. `max_iter=3` has to stop the solve short.
+#[test]
+fn an_accepted_option_actually_takes_effect() {
+    let capped = nlp()
+        .option_int("max_iter", 3)
+        .option_int("print_level", 0)
+        .try_solve()
+        .expect("max_iter is a valid option");
+    assert!(
+        !capped.success,
+        "max_iter=3 should not reach optimality on Rosenbrock, got {:?}",
+        capped.status
+    );
+    assert!(capped.stats.iteration_count <= 3);
+
+    let uncapped = nlp()
+        .option_int("print_level", 0)
+        .try_solve()
+        .expect("no options is valid");
+    assert!(uncapped.success, "status: {:?}", uncapped.status);
+    assert!(
+        uncapped.stats.iteration_count > 3,
+        "baseline should take more than the capped 3 iterations"
+    );
+}

--- a/docs/src/rust.md
+++ b/docs/src/rust.md
@@ -59,6 +59,24 @@ assert!((sol.x[0] - 1.0).abs() < 1e-5 && (sol.x[1] - 2.0).abs() < 1e-5);
 same names as the CLI and upstream Ipopt — `option_num`, `option_int`,
 `option_str`; see [Solver Options](options.md).
 
+Option names, value types, ranges, and choices are validated against the
+option registry, and a rejected option is never applied silently — a
+misspelled name would otherwise leave the default in effect while the solve
+looked like it had honoured the request. `solve` panics on a rejected option;
+`try_solve` returns the same conditions as `Err(NlpError)` instead:
+
+```rust
+use pounce_rs::builder::{Nlp, NlpError};
+
+let err = Nlp::new(P).x0(&[0.0, 0.0])
+    .option_str("mu_stratgey", "adaptive")   // typo
+    .try_solve();
+assert!(matches!(err, Err(NlpError::InvalidOption { .. })));
+```
+
+`try_solve` reports setup failures only. A solve that runs and does not
+converge is `Ok` with `success == false` and the reason in `status`.
+
 The returned `Solution` carries `success` / `status`, `x`, `objective`,
 `multipliers`, the constraint values `g`, the bound multipliers `z_l` / `z_u`,
 and `stats` (wall time, iteration count, evaluation counts, final


### PR DESCRIPTION
## Problem

A misspelled solver option passed to the `pounce-rs` builder was silently
dropped, and the solve then ran with the default still in effect. Nothing in
the output distinguished that from an honoured request.

```rust
Nlp::new(Rosenbrock)
    .x0(&[-1.2, 1.0])
    .option_str("mu_stratgey", "adaptive")   // typo for mu_strategy
    .option_num("tolerence", 1e-8)           // typo for tol
    .option_int("max_iterations", 3)         // wrong name for max_iter
    .solve();
```

| | options applied | status | iters | user-visible signal |
|---|---|---|---|---|
| before | 0 of 3 | `SolveSucceeded` | 51 | none |
| after | — | panics / `Err(InvalidOption)` | — | names the option and the reason |

The failure got worse the more the option mattered. The third line above is
the interesting one: had it been the real `max_iter`, the value `3` would
have capped the solve. Both spellings report a full converged solve, so
"my iteration cap is being honoured" and "my iteration cap is being ignored"
were indistinguishable from the output.

## Cause

`crates/pounce-rs/src/builder.rs` applied user options through
`OptionsList::set_*_value` but dropped the returned `Result`:

```rust
for (k, v) in &self.string { let _ = app.options_mut().set_string_value(k, v, true, true); }
```

The validation was never missing. `OptionsList` checks every option against
the registry — unknown name, wrong value type, out-of-range value,
unregistered choice (`crates/pounce-common/src/options_list.rs:106-127`) —
and correctly returned `Err`. The builder threw the answer away.

Only this crate was affected. The Python frontend
(`crates/pounce-py/src/problem.rs:949-973`), batch
(`crates/pounce-py/src/nlp_batch.rs:98`), and the C interface all already
propagated these errors.

## Fix

A new `NlpError` enum, and a new `Nlp::try_solve` holding what was previously
`solve`'s body — a `Result` yielding `Solution` on success and `NlpError` on
failure. (Written out in prose because GitHub's body sanitizer silently eats
Rust generic syntax, even inside a code fence.)

`NlpError::InvalidOption` carries the option name, the value, and the
registry's own explanation; `UnknownVariableCount` and `Initialize` cover the
other two setup failures.

`Nlp::solve` keeps its signature and delegates, panicking on `Err`. **This is
a behaviour change**: a caller passing an invalid option previously got a
silent default and now gets a panic. That is the point of the fix — solving a
configuration the caller did not ask for is the defect — but it can turn a
working-looking build into a crash on upgrade, so it is called out in the
CHANGELOG. The considered alternative was a journal warning with `solve`
otherwise unchanged; rejected because the silent-default path stays reachable
for everyone who doesn't switch to `try_solve`, which leaves the original
defect in place for the default API.

Two deliberate non-changes:

- The two internal defaults the builder sets for itself
  (`hessian_approximation`, `sqp_hessian`) still use `let _ =`. Both names
  are hardcoded and valid; there is no caller error to report.
- `Ok(false)` is not treated as a failure. It means an earlier no-clobber
  setting won, not that the option was rejected. Only the `Err` arm is
  escalated, matching what the Python frontend does.

## Blast radius

Confined to the `pounce-rs` builder path. The other three frontends already
behaved this way, so nothing converges on a new behaviour.

**Not a trajectory change, and no fixture sweep was run.** This changes only
whether an *invalid* configuration is reported; it cannot alter which
correction a valid configuration reaches for, or the order or scale of its
steps. Every pre-existing test passes unchanged, which is consistent with
that. Flagging the reasoning explicitly rather than burying it, since the
cost of being wrong about this is the gh#544 shape.

## Tests

New `crates/pounce-rs/tests/option_validation.rs` — 10 tests covering all
four rejection modes the registry distinguishes (unknown name across all
three setter types, wrong value type for a real option, unregistered choice,
out-of-range number), the `solve()` panic path, `UnknownVariableCount`, and
that valid options still reach the solver.

**How I know they bite.** Most of that file cannot compile against the parent
commit, because `try_solve` and `NlpError` do not exist there — true of any
new-API test, and not evidence of anything. The load-bearing check is
`solve_panics_on_a_rejected_option`, which uses only the pre-existing
`solve()` API. Extracted to a standalone file and run against the parent
(`dad6748`) it fails, for the stated reason:

```
test solve_panics_on_a_rejected_option - should panic ... FAILED
note: test did not panic as expected at crates/pounce-rs/tests/bite_check.rs:14:4
test result: FAILED. 0 passed; 1 failed
```

The other test that would survive a lazy implementation is
`an_accepted_option_actually_takes_effect`. Every test above would pass
against a builder that rejected *everything*; that one pins the actual defect
by proving the two cases are now distinguishable — `max_iter=3` stops the
solve short (`success == false`, ≤3 iterations) while the same problem
without it converges in more.

Verification, re-run after merging `main` (`450e5b0`) into the branch:
`cargo test -p pounce-rs --all-features` green (10 new, all pre-existing, 12
doctests), `cargo fmt --all -- --check` clean, `cargo clippy --all-targets`
exits 0 with no `correctness` or `suspicious` findings.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated (`rust.md`; no new page, no
      `SUMMARY.md` change needed)
- [x] `cargo fmt --all -- --check`, `cargo clippy`, `cargo test` clean
- [x] Every claim in this PR body and in the code comments is true of the
      code as it stands now

## On #649

Refs #649 — deliberately not a closing keyword. This fixes the concrete
defect the issue reports (the ignored `Result`), but #649 also proposes
replacing the string option layer with a typed `NlpConfig` / `SolverConfig`
across the solver core. That part is untouched here and worth its own
discussion, so the issue should stay open.

One correction for that discussion, from reading the code while fixing this:
the issue's claim that the current design "causes #551" does not really hold.
#551 is about registered-but-unread options, and two of its three sections
(missing capability, per-value refusal) are not addressable by typing at all.
Its claim that five places independently define options is also off —
`upstream_options.rs` is auto-generated by `tools/optport/gen.py` from
upstream, and `AlgorithmBuilder` is already a typed layer with real enums.