### PR TITLE
Measure what crossover's Sigma growth does to a downstream sensitivity result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,37 @@ changes.
   solely to a point the never-regress gate already accepted on its
   declared-bound residuals.
 
+  What crossover does to a **downstream sensitivity result** was measured
+  rather than assumed (#653). The open worry was that putting the iterate
+  *on* a bound drives the barrier diagonal `Σ = z/s` toward infinity and
+  wrecks whatever the sensitivity path factorizes. It is the opposite: `Σ` is
+  the stiffness with which the barrier pins a bounded variable, and a reduced
+  Hessian read off the held KKT factor carries a residual error of exactly
+  `Q_aw²/Σ` — the bound block's Schur complement, i.e. the leftover of that
+  pin being finite. A larger `Σ` is a sharper pin and a better answer. On a
+  fixture with two parameters held by pin rows and a third capped by a bound
+  binding at multiplier `4.5`, crossover against the declared bounds takes
+  `Σ` from `8.1e9` to `2.5e12` and the reduced-Hessian error from `4.95e-10`
+  to `1.62e-12` — **306× more accurate**, matching the `1/Σ` law to every
+  printed digit. `Σ` never goes infinite: `CalculateSafeSlack` floors a slack
+  below `eps·min(1,μ)` up to about `μ/z`, so even an exactly-zero slack falls
+  back to the pre-crossover `Σ = z²/μ`, and the crossed-over slack measured
+  here bottoms out at `1.8e-12` without reaching the floor.
+
+  The same measurement found the reverse under a nonzero
+  `bound_relax_factor` (#654), #646's frame mismatch reaching the numerics
+  rather than the printed residuals: the crossed-over point sits exactly `δ`
+  inside the live relaxed bound, so `Σ` becomes `z/δ` instead of `z²/μ` and
+  the pin **loosens** — `4.5e8` against `8.1e9`, an `8.89e-9` reduced-Hessian
+  error where crossover-off gives `4.95e-10`. The degradation factor is
+  `z·δ/μ`, so it grows with the bound's multiplier, reaching ~400× by a
+  multiplier of `1000`. `covariance()` and `curve_fit` are unaffected — the
+  declaration-triggered solve already sets `bound_relax_factor = 0`, which
+  `classify_activity()` requires — but a `Solver` or `SensSolve` session
+  configured by hand is not. Set `bound_relax_factor = 0` when combining
+  crossover with any sensitivity result. All three directions are pinned by
+  `crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs`.
+
   Two defects surfaced while building it, both of which would have made
   the phase report the opposite of the truth:
 

--- a/crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs
+++ b/crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs
@@ -1,0 +1,300 @@
+//! What crossover's barrier diagonal `Σ = z/s` does to a *downstream*
+//! reduced Hessian (gh#653).
+//!
+//! gh#612's PR left open "what does `Σ = V/S` do at exact-zero slack",
+//! on the assumption that crossover — which puts the iterate *on* a
+//! bound — drives `Σ` toward infinity and degrades whatever the
+//! sensitivity path factorizes. Measurement inverted that. `Σ` is
+//! finite, and a larger `Σ` is a *more* accurate answer, because `Σ` is
+//! the stiffness with which the barrier pins the bounded variable and
+//! the reduced Hessian's residual error is the `O(1/Σ)` leftover of
+//! that pin being finite.
+//!
+//! # Fixture
+//!
+//! `min ½xᵀQx − qᵀx` over `x = (a, b, w)`, with `a` and `b` held by
+//! equality rows (the pins the reduced Hessian is taken over) and `w`
+//! capped by an upper bound that binds with multiplier `z ≈ 4.5` —
+//! strictly complementary, so the barrier has no excuse. `Q` is
+//! non-diagonal, which is what makes the measurement discriminating:
+//!
+//! ```text
+//! w pinned at its bound : H_R = Q_ab                = [[4, 1], [1, 3]]
+//! w free (eliminated)   : H_R = Q_ab − q_w q_wᵀ/Q_ww = [[3.2, .6], [.6, 2.8]]
+//! ```
+//!
+//! Those differ by `O(1)`, so drift toward the second is unmissable.
+//! The solver returns the first plus an error of exactly `Q_aw²/Σ_w`
+//! — the bound block's Schur complement, matched to every printed
+//! digit at both ends of a 300× range in `Σ`.
+//!
+//! `compute_reduced_hessian` returns `−H_R` under its sign convention
+//! (`−inv(H_R)` is the covariance), so every assertion here negates it.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pounce_algorithm::application::IpoptApplication;
+use pounce_common::types::{Index, Number};
+use pounce_nlp::tnlp::{
+    BoundsInfo, IndexStyle, IpoptCq, IpoptData, Linearity, NlpInfo, Solution, SparsityRequest,
+    StartingPoint, TNLP,
+};
+use pounce_sensitivity::Solver;
+
+const Q: [[Number; 3]; 3] = [[4.0, 1.0, 2.0], [1.0, 3.0, 1.0], [2.0, 1.0, 5.0]];
+/// Linear term; only `w` carries one, and it is what pushes `w` into
+/// its cap hard enough to leave a multiplier of `4.5`.
+const QV: [Number; 3] = [0.0, 0.0, 10.0];
+const A_PIN: Number = 1.0;
+const B_PIN: Number = 1.0;
+const W_CAP: Number = 0.5;
+
+/// `H_R` when the bound pins `w` exactly: the `(a, b)` block of `Q`.
+const H_PINNED: [Number; 4] = [Q[0][0], Q[1][0], Q[0][1], Q[1][1]];
+
+/// The `O(1/Σ)` error constant: the reduced Hessian's residual is
+/// `Q_aw²/Σ_w`, with `Q_aw = Q[0][2] = 2`.
+const ERR_NUMERATOR: Number = Q[0][2] * Q[0][2];
+
+struct Fixture;
+
+impl TNLP for Fixture {
+    fn get_nlp_info(&mut self) -> Option<NlpInfo> {
+        Some(NlpInfo {
+            n: 3,
+            m: 2,
+            nnz_jac_g: 2,
+            nnz_h_lag: 6,
+            index_style: IndexStyle::C,
+        })
+    }
+
+    fn get_bounds_info(&mut self, b: BoundsInfo<'_>) -> bool {
+        b.x_l[0] = -1.0e19;
+        b.x_u[0] = 1.0e19;
+        b.x_l[1] = -1.0e19;
+        b.x_u[1] = 1.0e19;
+        b.x_l[2] = -1.0e19;
+        b.x_u[2] = W_CAP;
+        b.g_l[0] = A_PIN;
+        b.g_u[0] = A_PIN;
+        b.g_l[1] = B_PIN;
+        b.g_u[1] = B_PIN;
+        true
+    }
+
+    fn get_starting_point(&mut self, sp: StartingPoint<'_>) -> bool {
+        sp.x.fill(0.0);
+        true
+    }
+
+    fn get_constraints_linearity(&mut self, t: &mut [Linearity]) -> bool {
+        t.fill(Linearity::Linear);
+        true
+    }
+
+    fn eval_f(&mut self, x: &[Number], _new_x: bool) -> Option<Number> {
+        let mut f = 0.0;
+        for i in 0..3 {
+            for j in 0..3 {
+                f += 0.5 * x[i] * Q[i][j] * x[j];
+            }
+            f -= QV[i] * x[i];
+        }
+        Some(f)
+    }
+
+    fn eval_grad_f(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        for i in 0..3 {
+            g[i] = -QV[i];
+            for j in 0..3 {
+                g[i] += Q[i][j] * x[j];
+            }
+        }
+        true
+    }
+
+    fn eval_g(&mut self, x: &[Number], _new_x: bool, g: &mut [Number]) -> bool {
+        g[0] = x[0];
+        g[1] = x[1];
+        true
+    }
+
+    fn eval_jac_g(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&[0 as Index, 1]);
+                jcol.copy_from_slice(&[0 as Index, 1]);
+            }
+            SparsityRequest::Values { values } => {
+                values[0] = 1.0;
+                values[1] = 1.0;
+            }
+        }
+        true
+    }
+
+    fn eval_h(
+        &mut self,
+        _x: Option<&[Number]>,
+        _new_x: bool,
+        obj_factor: Number,
+        _lambda: Option<&[Number]>,
+        _new_lambda: bool,
+        mode: SparsityRequest<'_>,
+    ) -> bool {
+        // Lower triangle of Q.
+        let rs: [Index; 6] = [0, 1, 1, 2, 2, 2];
+        let cs: [Index; 6] = [0, 0, 1, 0, 1, 2];
+        match mode {
+            SparsityRequest::Structure { irow, jcol } => {
+                irow.copy_from_slice(&rs);
+                jcol.copy_from_slice(&cs);
+            }
+            SparsityRequest::Values { values } => {
+                for k in 0..6 {
+                    values[k] = obj_factor * Q[rs[k] as usize][cs[k] as usize];
+                }
+            }
+        }
+        true
+    }
+
+    fn finalize_solution(&mut self, _s: Solution<'_>, _d: &IpoptData, _q: &IpoptCq) {}
+}
+
+fn app(crossover: bool, bound_relax_factor: Number) -> IpoptApplication {
+    let mut a = IpoptApplication::new();
+    a.options_mut()
+        .set_integer_value("print_level", 0, true, false)
+        .unwrap();
+    a.options_mut()
+        .set_string_value("sb", "yes", true, false)
+        .unwrap();
+    a.options_mut()
+        .set_numeric_value("bound_relax_factor", bound_relax_factor, true, false)
+        .unwrap();
+    if crossover {
+        a.options_mut()
+            .set_string_value("crossover", "yes", true, false)
+            .unwrap();
+    }
+    a.initialize().unwrap();
+    a
+}
+
+/// `|H_R − Q_ab|_inf` for one option combination, plus the solver it
+/// came from so the caller can read `Σ` off the same held state.
+fn reduced_hessian_error(crossover: bool, brf: Number) -> (Number, Solver) {
+    let tnlp: Rc<RefCell<dyn TNLP>> = Rc::new(RefCell::new(Fixture));
+    let mut solver = Solver::new(app(crossover, brf), tnlp);
+    solver.solve();
+    let hr = solver
+        .compute_reduced_hessian(&[0, 1], 1.0)
+        .expect("reduced Hessian over the two pin rows");
+    let err = (0..4)
+        .map(|k| (-hr[k] - H_PINNED[k]).abs())
+        .fold(0.0, Number::max);
+    (err, solver)
+}
+
+/// Crossover run against the bounds as declared — the combination the
+/// sensitivity docs steer users into, since `classify_activity`
+/// *requires* `bound_relax_factor = 0` — makes the downstream reduced
+/// Hessian **more** accurate, not less. This is gh#653's central
+/// finding and the one that inverted its premise.
+#[test]
+fn crossover_at_declared_bounds_sharpens_the_reduced_hessian() {
+    let (err_off, _) = reduced_hessian_error(false, 0.0);
+    let (err_on, _) = reduced_hessian_error(true, 0.0);
+
+    // Both must land on the pinned answer rather than the free one;
+    // the two differ by 0.8 in the (0,0) entry, so anything near that
+    // means the bound stopped pinning altogether.
+    assert!(
+        err_off < 1e-6 && err_on < 1e-6,
+        "both runs must reproduce the w-pinned reduced Hessian, not the \
+         free-w one (errors {err_off:e} / {err_on:e} against a 0.8 gap)",
+    );
+
+    // Measured 306x at the time of writing (4.95e-10 -> 1.62e-12). The
+    // assertion is a wide lower bound: the point is the *direction*,
+    // which is what the issue got backwards.
+    assert!(
+        err_on * 50.0 < err_off,
+        "crossover at declared bounds must sharpen the reduced Hessian by \
+         a wide margin: |err| went {err_off:e} -> {err_on:e}",
+    );
+}
+
+/// The residual is the bound block's Schur complement, `Q_aw²/Σ_w`, so
+/// it falls exactly as `Σ` rises. Pinning the *law* rather than two
+/// numbers is what makes the previous test's margin explainable
+/// instead of anecdotal — and it is the reason a growing `Σ` is a
+/// benefit rather than the conditioning hazard gh#653 assumed.
+#[test]
+fn the_reduced_hessian_error_tracks_one_over_sigma() {
+    for crossover in [false, true] {
+        let (err, solver) = reduced_hessian_error(crossover, 0.0);
+        // `classify_activity` is the public read of the barrier
+        // diagonal, and it is available here precisely because these
+        // runs use bound_relax_factor = 0.
+        let report = solver
+            .classify_activity()
+            .expect("bound_relax_factor = 0, so the classifier accepts");
+        let sigma = report.var_sigma[2];
+        let predicted = ERR_NUMERATOR / sigma;
+        assert!(
+            (err - predicted).abs() <= 0.05 * predicted,
+            "crossover={crossover}: |H_R| error {err:e} should be \
+             Q_aw^2/Sigma = {predicted:e} (Sigma = {sigma:e})",
+        );
+    }
+}
+
+/// The other half of the measurement, and a defect rather than a
+/// property: with the bound relaxation left at its default, crossover
+/// makes the same reduced Hessian **worse** than not crossing over at
+/// all.
+///
+/// Crossover parks the iterate exactly on the *declared* bound, which
+/// is a full `δ = bound_relax_factor` inside the *live* relaxed one.
+/// The slack the barrier then sees is `δ` rather than the `μ/z` an
+/// interior iterate would have carried, so `Σ = z/δ` instead of
+/// `z²/μ`, and the bound is pinned **less** stiffly. The degradation
+/// factor is `z·δ/μ` — it grows with the bound's multiplier.
+///
+/// This is gh#646's frame mismatch reaching the numerics; gh#647 fixed
+/// only the reporting half. Tracked as gh#654. The assertion records the
+/// regression in executable form so it cannot drift, or be fixed,
+/// unnoticed.
+#[test]
+fn crossover_under_bound_relaxation_loosens_the_reduced_hessian() {
+    let (err_off, _) = reduced_hessian_error(false, 1e-8);
+    let (err_on, _) = reduced_hessian_error(true, 1e-8);
+
+    // Measured 18x at the time of writing (4.95e-10 -> 8.89e-9), rising
+    // toward ~400x as the bound multiplier grows.
+    assert!(
+        err_on > err_off * 5.0,
+        "known gh#654 defect: crossover under a nonzero bound_relax_factor \
+         should LOOSEN the pin (errors {err_off:e} -> {err_on:e}). If this \
+         now fails, the frame mismatch was fixed — delete the test and say \
+         so, do not relax the bound.",
+    );
+
+    // And it is strictly worse than the same crossover run against
+    // declared bounds: the relaxation, not crossover, is the cause.
+    let (err_declared, _) = reduced_hessian_error(true, 0.0);
+    assert!(
+        err_declared < err_on,
+        "crossover at declared bounds ({err_declared:e}) must beat crossover \
+         under relaxation ({err_on:e})",
+    );
+}

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -190,6 +190,60 @@ already decided, and it applies solely to a point the never-regress gate
 accepted on its declared-bound residuals, so it cannot dress up a worse
 iterate — the reading it replaces is the artifact, not the point.
 
+## What it does to a downstream sensitivity result
+
+Crossover moves the iterate onto its active bounds, which changes the
+barrier diagonal `Σ = z/s` the sensitivity path factorizes. That was
+expected to be a hazard — a slack driven to zero divides badly — and it
+is the opposite. `Σ` is the stiffness with which the barrier pins a
+bounded variable, and a reduced Hessian read off the held KKT factor
+carries a residual error of exactly `O(1/Σ)`: the leftover of that pin
+being finite rather than exact. A **larger** `Σ` is a sharper pin and a
+more accurate answer.
+
+Measured on `min ½xᵀQx − qᵀx` with two parameters held by pin rows and a
+third variable capped by a bound that binds with multiplier `4.5`. The
+reduced Hessian over the pins has an `O(1)` gap between the
+bound-pinned answer and the free one, so drift is unmissable:
+
+| | `Σ` at the active bound | reduced-Hessian error |
+|---|---|---|
+| `crossover=no` | `8.1e+09` | `4.95e-10` |
+| `crossover=yes`, `bound_relax_factor=0` | `2.5e+12` | **`1.62e-12`** |
+| `crossover=yes`, default relaxation | `4.5e+08` | **`8.89e-09`** |
+
+Two things follow, and they point in opposite directions.
+
+- **Against the bounds as declared, crossover sharpens the result by
+  exactly the factor `Σ` grew** — 306× here. The error is `Q_aw²/Σ`, the
+  bound block's Schur complement, which matches the measurement to every
+  printed digit at both ends of that range. This is the combination
+  [Sensitivity Analysis](sensitivity.md) steers you into, because
+  `classify_activity()` requires `bound_relax_factor = 0` anyway.
+- **Under a nonzero `bound_relax_factor`, crossover makes it worse than
+  not crossing over at all** — 18× worse here. The crossed-over point
+  sits exactly `δ = bound_relax_factor` inside the live relaxed bound,
+  so the barrier sees a slack of `δ` where an interior iterate would
+  have carried `μ/z`. `Σ` becomes `z/δ` instead of `z²/μ`, and the pin
+  *loosens*. The degradation factor is `z·δ/μ`, so it grows with the
+  bound's multiplier — around 400× by a multiplier of 1000.
+
+This is the same frame mismatch as
+[#646](https://github.com/jkitchin/pounce/issues/646), reaching the
+numerics rather than the printed residuals; the fix there was to the
+reporting only. Tracked as
+[#654](https://github.com/jkitchin/pounce/issues/654). If you combine
+crossover with any sensitivity result — `covariance()`,
+`compute_reduced_hessian`, `parametric_step` — set
+`bound_relax_factor = 0`.
+
+`Σ` never becomes infinite along this path. `CalculateSafeSlack` floors
+a slack below `eps·min(1, μ)` up to about `μ/z`, so even a slack landing
+at exactly zero degrades gracefully back to the pre-crossover `Σ = z²/μ`
+rather than dividing by nothing. The crossed-over slack measured here
+bottoms out at `1.8e-12` — the residual of the QP step plus line search
+— and never reaches the floor at all.
+
 ## Reading the result
 
 The returned solution — `x`, the objective, `g`, and every multiplier — is

--- a/docs/src/sensitivity.md
+++ b/docs/src/sensitivity.md
@@ -525,7 +525,14 @@ convergence and returns a point at which a linearly independent set of
 constraints holds with *equality*, collapsing the ambiguity into a
 STRONGLY or WEAKLY ACTIVE verdict. It is a different remedy to the same
 problem the `bound_relax_factor = 0` rule above addresses, and the two
-compose.
+compose — but only in that order. **Crossover is a sensitivity remedy
+only when the bounds are not relaxed**, and it makes matters worse when
+they are; see [Crossover and the barrier
+diagonal](crossover.md#what-it-does-to-a-downstream-sensitivity-result)
+for the measurement. A solve routed through the declaration-triggered
+path already sets `bound_relax_factor = 0` and is on the right side of
+that; a `Solver` or `SensSolve` session you configure yourself is not,
+unless you set it.
 
 **Relation to `pounce.curve_fit`.** This uses the same
 scale-and-invert-the-reduced-Hessian recipe as


### PR DESCRIPTION
Fixes #653.

#653 asked whether the ~690× growth in the barrier diagonal `Σ = z/s`
that crossover induces moves any number the sensitivity path returns.
The premise was that it might be a conditioning hazard. It measures out
the other way: **the growth is the benefit**, and chasing that answer
surfaced two real defects, now #654 and #655.

No solver behavior changes here. This is a test, three documentation
sections, and a CHANGELOG entry.

## What `Σ` actually does downstream

A reduced Hessian read off the held KKT factor carries a residual error
of exactly `Q_aw²/Σ` — the bound block's Schur complement, i.e. the
leftover of the barrier's pin being finite rather than exact. A larger
`Σ` is a sharper pin, so the growth crossover induces is an accuracy
gain of exactly the factor `Σ` grew.

The fixture is `min ½xᵀQx − qᵀx` over `(a, b, w)` with `a`, `b` held by
pin rows and `w` capped by a bound binding at multiplier `4.5`. `Q` is
non-diagonal on purpose: the reduced Hessian over the pins differs by
`O(1)` between the bound-pinned answer `[[4,1],[1,3]]` and the free one
`[[3.2,.6],[.6,2.8]]`, so drift cannot hide. That is the "not trivially
`2I`" #653 asked for.

| | `Σ` | reduced-Hessian error | vs. no crossover |
|---|---|---|---|
| `crossover=no`, `brf=0` | `8.08e+09` | `4.95e-10` | — |
| `crossover=yes`, `brf=0` | `2.47e+12` | `1.62e-12` | **306× better** |
| `crossover=yes`, `brf=1e-8` | `4.50e+08` | `8.89e-09` | 18× worse |

The `Q_aw²/Σ` law matches to every printed digit at both ends of that
300× range — predicted `4.952e-10` / `1.617e-12`, measured `4.952e-10` /
`1.617e-12` — so it is structural, not a coincidence of one fixture.

## The third row is a defect, filed as #654

Under a nonzero `bound_relax_factor` crossover makes the answer *worse
than not crossing over*. The crossed-over point sits exactly `δ` inside
the live relaxed bound, so the barrier sees a slack of `δ` where an
interior iterate carried `μ/z`: `Σ = z/δ` instead of `z²/μ`, and the pin
loosens. The degradation factor `z·δ/μ` scales with the multiplier, and
the downstream error tracks the `Σ` ratio 1:1 across four decades:

| `z` | `Σ` ratio | error ratio |
|---|---|---|
| `4.5` | `18.0` | `18.0×` |
| `94.5` | `377.1` | `377.0×` |
| `994.5` | `396.9` | `397.2×` |
| `9994.5` | `398.8` | `409.6×` |

`covariance()` and `curve_fit` are safe — the declaration-triggered
solve sets `bound_relax_factor = 0`, which `classify_activity()`
requires — but a hand-configured `Solver` or `SensSolve` reaching
`compute_reduced_hessian` or `parametric_step` is not guarded anywhere.

Not fixed here, deliberately. Both candidate fixes have real blast
radius (un-relaxing the live bounds reverses a decision documented in
#647 and cannot be done through `Rc::get_mut` post-convergence, since
the CQ holds clones; the consumer-boundary fix needs declared bounds
plumbed into both `PdSensBacksolver` and `classify_activity`). Per
`CLAUDE.md`, a measured regression gets an issue and an owner rather
than a note in a commit message: #654.

## The `μ == 0` corner, and what replaces it

#653's second question was whether a converged solve can reach `μ == 0`,
where `CalculateSafeSlack` would pin to `f64::MIN_POSITIVE` and `Σ`
would overflow.

It cannot. Monotone floors `μ` at `max(mu_target,
certificate_safe_mu_min, min(tol, scaled_compl_inf_tol) /
(barrier_tol_factor + 1))`; adaptive clamps to `[mu_min, mu_max]`. `tol`,
`compl_inf_tol` and `mu_min` are all registered **strictly** lower-bounded
at zero, so every term is positive; `warm_start_target_mu` is guarded by
`if target_mu > 0.0`. Empirically, driving `tol` low enough to matter
exits `SearchDirectionBecomesTooSmall` and `on_converged` never fires.

But the conclusion that `Σ` is therefore bounded does not follow.
**`Σ = inf` is reachable at `μ > 0`**: `mu_strategy=adaptive`,
`tol = compl_inf_tol = 1e-306` returns `SolveSucceeded` with
`μ = 9.09e-308`, a subnormal slack of `2.02e-308`, and `max Σ = inf`.
Crossover is not involved — it reproduces with crossover off. The floor
fires and still overflows, because `f64::MIN_POSITIVE` is the wrong
floor for the purpose: the quantity that must stay finite is `z/s`, so
the floor that guarantees it is `s ≥ z/f64::MAX`. Filed as #655, and
flagged there as trajectory-touching — `calculate_safe_slack` runs every
iteration, so a fix needs the fixture sweep.

## Changes

- **`crates/pounce-sensitivity/tests/crossover_sigma_downstream.rs`**
  (new, 3 tests) — pins the 306× improvement at `brf=0`; pins the
  `err = Q_aw²/Σ` law against `classify_activity().var_sigma`; and pins
  the #654 defect in executable form, with a message telling a future
  reader to *delete the test and say so* if it starts failing, rather
  than relax the bound. Both `brf` cases also assert the error stays
  under `1e-6`, so neither can pass by landing on the free answer.
- **`docs/src/crossover.md`** — new "What it does to a downstream
  sensitivity result", with the measurement table, the `1/Σ` law, the
  `z·δ/μ` degradation, and why `Σ` stays finite on this path.
- **`docs/src/sensitivity.md`** — the AMBIGUOUS/crossover paragraph
  claimed the two "compose"; it now carries the `bound_relax_factor = 0`
  condition it was silently assuming, and says which entry points are on
  the right side of it.
- **`CHANGELOG.md`**.

## Safety

No behavior change: nothing outside `tests/` and docs is touched. The
`CLAUDE.md` trajectory rule does not apply — no solver code moves. Full
`cargo fmt --check` / `cargo test` / `cargo clippy --all-targets -D
warnings` clean.
