### PR TITLE
Floor the slack against z/f64::MAX so Sigma stays finite (gh#655)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,10 +192,13 @@ changes.
   binding at multiplier `4.5`, crossover against the declared bounds takes
   `Σ` from `8.1e9` to `2.5e12` and the reduced-Hessian error from `4.95e-10`
   to `1.62e-12` — **306× more accurate**, matching the `1/Σ` law to every
-  printed digit. `Σ` never goes infinite: `CalculateSafeSlack` floors a slack
-  below `eps·min(1,μ)` up to about `μ/z`, so even an exactly-zero slack falls
-  back to the pre-crossover `Σ = z²/μ`, and the crossed-over slack measured
-  here bottoms out at `1.8e-12` without reaching the floor.
+  printed digit. `Σ` never goes infinite on this path: `CalculateSafeSlack`
+  floors a slack below `eps·min(1,μ)` up to about `μ/z`, so even an
+  exactly-zero slack falls back to the pre-crossover `Σ = z²/μ`, and the
+  crossed-over slack measured here bottoms out at `1.8e-12` without reaching
+  the floor. That threshold is about the barrier term and does not mention
+  the multiplier, so it does not bound `Σ` once `μ` goes subnormal; the floor
+  that does is the `s >= max_i z_i / (f64::MAX/4)` added for #655.
 
   The same measurement found the reverse under a nonzero
   `bound_relax_factor` (#654), #646's frame mismatch reaching the numerics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,40 @@ changes.
 
 ## [Unreleased]
 
+- **`Sigma = z/s` no longer overflows to `inf` on a converged solve**
+  (#655).
+
+  At `tol = compl_inf_tol = 1e-306` with `mu_min = 5e-324`, an adaptive
+  solve converged (`SolveSucceeded`) at `mu = 9.09e-308` with a subnormal
+  slack of `2.02e-308`; against a bound multiplier of `4.5` that is a
+  `Sigma` of `2.2e308`, past `f64::MAX`, on the KKT diagonal — and from
+  there into every backsolve the sensitivity path makes.
+
+  `calculate_safe_slack`'s floor did not catch it because it is not the
+  floor for this: `eps*min(1, mu)` is `2.0e-323` at that `mu` — a
+  representable subnormal, not the `0` that would have substituted
+  `f64::MIN_POSITIVE` — so the slack cleared it and no correction fired
+  at all. The quantity that has to stay finite is `z/s`, so the floor is
+  now also `s >= max_i z_i / (f64::MAX/4)`, applied both to the trigger
+  and again after the `slack_move` bound-move cap (which can otherwise
+  cap a flagged slack back below the floor when the multipliers are
+  enormous, or when `slack_move` is `0`).
+
+  Off the overflow edge the floor sits at `z_max/4.5e307`, below every
+  slack an ordinary iterate carries: `scripts/sweep-fixtures.sh` over all
+  57 CLI fixtures is byte-identical in status, objective and iteration
+  count. Re-run under the issue's own settings, one line moves —
+  `linear_eq_collapsed_box` reported `SolveSucceeded` at a slack of
+  `4.2e-310` against `z = 84.4`, i.e. at `Σ = inf`, and now reports
+  `SearchDirectionBecomesTooSmall`. The trajectory is identical (same 20
+  iterations, same objective to the last bit, same factorizations); what
+  changed is that its complementarity is now measured on a slack that can
+  be divided by — `1.58e-304`, which does not meet the `compl_inf_tol =
+  1e-306` the caller asked for. A solve that cannot reach the requested
+  complementarity with a representable slack now says so instead of
+  claiming success, matching what the issue's own table already reported
+  one notch further down at `tol = 1e-308`.
+
 - **`pounce-rs`: a rejected solver option is no longer silently
   discarded** (#649).
 

--- a/crates/pounce-algorithm/src/ipopt_cq.rs
+++ b/crates/pounce-algorithm/src/ipopt_cq.rs
@@ -51,6 +51,18 @@ use std::rc::Rc;
 /// inside the band from either edge.
 const ROW_NOISE_KAPPA: Number = 64.0;
 
+/// Headroom on the representability floor `calculate_safe_slack` puts under a
+/// slack so that `Σ = z/s` stays inside the double range (gh#655).
+///
+/// The bare requirement is `s ≥ z/f64::MAX`, which bounds `z/s` by `f64::MAX`
+/// exactly — no room for the rounding in the divide itself, and none for the
+/// fact that `Σ_x` *sums* a lower and an upper ratio into the same diagonal
+/// entry. Dividing the floor's budget by `4` bounds each ratio by `MAX/4` and
+/// so their sum by `MAX/2`, which leaves the KKT diagonal finite with a bit
+/// to spare. The factor costs nothing anywhere it is not needed: the floor is
+/// `z_max/4.5e307`, below every slack any non-pathological iterate carries.
+const SIGMA_OVERFLOW_HEADROOM: Number = 4.0;
+
 /// Calculated-quantities object. Holds shared handles on data and the
 /// NLP; per-quantity caches live in `RefCell`s here.
 pub struct IpoptCalculatedQuantities {
@@ -224,6 +236,11 @@ impl IpoptCalculatedQuantities {
     /// is `min(max(mu/multiplier, s_min), slack_move*max(1,|bound|)+slack)`.
     /// `multiplier` and `mu` are taken from the *current* iterate, exactly
     /// as upstream does even for trial slacks.
+    ///
+    /// Deviates from upstream in one place: `s_min` also carries a
+    /// representability floor `max_i z_i / (f64::MAX/4)` so that the
+    /// `Σ = z/s` this slack feeds stays inside the double range (gh#655).
+    /// See the comments at the two sites below.
     fn calculate_safe_slack(
         &self,
         slack: &mut dyn Vector,
@@ -241,6 +258,28 @@ impl IpoptCalculatedQuantities {
         let mut s_min = f64::EPSILON * mu.min(1.0);
         if s_min == 0.0 {
             s_min = f64::MIN_POSITIVE;
+        }
+        // gh#655: `eps*min(1,mu)` floors the *barrier* term, and nothing in it
+        // mentions the multiplier — so a slack can clear it and still be small
+        // enough against its own `z` that `Σ = z/s` leaves the double range.
+        // At `mu = 9.1e-308` the threshold is `2.0e-323`; a slack of
+        // `2.0e-308` sails past it untouched, and `z = 4.5` over that slack is
+        // `2.2e308`, i.e. `inf` on the KKT diagonal under a reported
+        // `SolveSucceeded`. `f64::MIN_POSITIVE` is not the fix either: the
+        // quantity that has to stay finite is `z/s`, so the floor is
+        // `s >= z/f64::MAX` (with `SIGMA_OVERFLOW_HEADROOM` of margin), not
+        // the smallest representable positive double. Divide before
+        // multiplying so a `z` near `f64::MAX` cannot overflow the floor
+        // itself; a non-finite `z` leaves the floor alone and is caught
+        // downstream by the iterate finiteness checks.
+        //
+        // Taken over `max_i z_i` rather than componentwise so one scalar also
+        // serves the `min_slack >= s_min` trigger above. That is conservative
+        // in the harmless direction: it can only raise a flagged slack
+        // further, and raising a slack only lowers `Σ`.
+        let sigma_floor = multiplier.amax() / (f64::MAX / SIGMA_OVERFLOW_HEADROOM);
+        if sigma_floor.is_finite() && sigma_floor > s_min {
+            s_min = sigma_floor;
         }
         if min_slack >= s_min {
             return 0;
@@ -295,6 +334,16 @@ impl IpoptCalculatedQuantities {
 
         // new slack = min(target, t_max) where flagged, else slack.
         t.element_wise_min(&*t_max);
+        // gh#655, second half: re-apply the floor *after* the bound-move cap.
+        // `t_max` bounds how far a bound may be nudged, which is a policy the
+        // user sets; a finite `z/s` is not one. The cap sits below `s_min`
+        // only when `slack_move*max(1,|bound|)` does — with the default
+        // `slack_move` that needs `max_i z_i` past `6e295`, and `slack_move = 0`
+        // (the "never move a bound" setting) makes it exact — but where it
+        // does, the min above would hand back the overflowing slack it was
+        // called to repair. Components that were not flagged are `>= s_min`
+        // already, so this is a no-op for them.
+        t.element_wise_max(&*s_min_vec);
         slack.copy(&*t);
         retval
     }
@@ -3013,6 +3062,81 @@ mod tests {
         let s = dense_vals(&cq.curr_sigma_x());
         assert!((s[0] - 0.25).abs() < 1e-15);
         assert!((s[1] - 0.35).abs() < 1e-15);
+    }
+
+    /// gh#655 fixture. `x_L[0] = 0`, so the lower-bound block of `x` carries
+    /// slack `x0` against multiplier `z_l`, at barrier parameter `mu`. The
+    /// rest of the iterate is the default fixture's.
+    fn fixture_at_mu(x0: Number, z_l: Number, mu: Number) -> IpoptCalculatedQuantities {
+        let mut data = IpoptData::new();
+        data.curr_mu = mu;
+        let iv = IteratesVector::new(
+            rcv(&[x0, 3.0]),
+            rcv(&[4.0]),
+            rcv(&[1.0]),
+            rcv(&[1.0]),
+            rcv(&[z_l]),
+            rcv(&[0.7]),
+            rcv(&[0.3]),
+            rcv(&[]),
+        );
+        data.set_curr(iv);
+        let data_handle = StdRc::new(RefCell::new(data));
+        let nlp: StdRc<RefCell<dyn IpoptNlp>> = StdRc::new(RefCell::new(MockNlp::new()));
+        let mut cq = IpoptCalculatedQuantities::new(data_handle, nlp);
+        cq.kappa_d = 0.0;
+        cq
+    }
+
+    /// gh#655. The reported point, verbatim: `mu = 9.0909e-308`, a subnormal
+    /// slack of `2.0202e-308` against `z = 4.5`, reached under a
+    /// `SolveSucceeded`. The old floor never even fired here — `eps*mu` is
+    /// `2.0e-323`, still a representable subnormal rather than the `0` that
+    /// would have substituted `f64::MIN_POSITIVE`, so the slack cleared the
+    /// threshold untouched and `4.5 / 2.0202e-308 = 2.2e308` overflowed.
+    #[test]
+    fn subnormal_slack_does_not_overflow_sigma() {
+        let mu: Number = 9.0909e-308;
+        let slack: Number = 2.0202e-308;
+        let z: Number = 4.5;
+        // The premise: the barrier-side threshold does not catch this point.
+        assert!(f64::EPSILON * mu.min(1.0) > 0.0);
+        assert!(slack > f64::EPSILON * mu.min(1.0));
+        assert!(!(z / slack).is_finite());
+
+        let cq = fixture_at_mu(slack, z, mu);
+        let s = dense_vals(&cq.curr_sigma_x());
+        assert!(s[0].is_finite(), "Sigma_x[0] = {} is not finite", s[0]);
+        // Floored at z/(MAX/4), so the ratio lands at MAX/4 at worst.
+        assert!(s[0] <= f64::MAX / SIGMA_OVERFLOW_HEADROOM);
+        // The slack itself was raised to the floor, not to f64::MIN_POSITIVE.
+        assert!(dense_vals(&cq.curr_slack_x_l())[0] >= z / f64::MAX);
+        // The untouched upper block still reads (5 - 3) against z_U = 0.7.
+        assert!((s[1] - 0.35).abs() < 1e-15);
+    }
+
+    /// gh#655, the half the trigger alone does not cover: a multiplier large
+    /// enough that the bound-move cap (`slack_move*max(1,|bound|) + slack`)
+    /// sits *below* the representability floor. Capping there would hand back
+    /// a slack that still overflows, so the floor is re-applied after the cap.
+    #[test]
+    fn representability_floor_survives_the_bound_move_cap() {
+        let cq = fixture_at_mu(1e-300, 1e300, 1e-8);
+        // Premise: the cap really is the binding constraint here.
+        assert!(cq.slack_move * 1.0 + 1e-300 < 1e300 / (f64::MAX / SIGMA_OVERFLOW_HEADROOM));
+        let s = dense_vals(&cq.curr_sigma_x());
+        assert!(s[0].is_finite(), "Sigma_x[0] = {} is not finite", s[0]);
+        assert!(s[0] <= f64::MAX / SIGMA_OVERFLOW_HEADROOM);
+    }
+
+    /// The floor is `z_max/4.5e307`; a slack twelve orders of magnitude above
+    /// anything subnormal is nowhere near it, and must come back bit-identical
+    /// — the correction is meant to be invisible off the overflow edge.
+    #[test]
+    fn ordinary_small_slack_is_left_exactly_alone() {
+        let cq = fixture_at_mu(1e-20, 0.5, 1e-8);
+        assert_eq!(dense_vals(&cq.curr_slack_x_l()), vec![1e-20]);
+        assert_eq!(dense_vals(&cq.curr_sigma_x())[0], 0.5 / 1e-20);
     }
 
     #[test]

--- a/crates/pounce-cli/tests/issue_655_subnormal_slack_sigma.rs
+++ b/crates/pounce-cli/tests/issue_655_subnormal_slack_sigma.rs
@@ -1,0 +1,116 @@
+//! gh#655 end to end: a solve must not report `SolveSucceeded` at a point
+//! whose slack has underflowed far enough that `Σ = z/s` is `inf`.
+//!
+//! The reported settings — `mu_strategy=adaptive`, `tol = compl_inf_tol =
+//! 1e-306`, `mu_min = 5e-324` — reach exactly that on `linear_eq_collapsed_box`,
+//! which carries an active bound with a nonzero multiplier. Before the fix the
+//! solve stopped at iteration 20 with
+//!
+//! ```text
+//!   z          = 84.375
+//!   slack      = 4.209e-310      (subnormal)
+//!   Sigma      = z/slack         = inf
+//!   final_compl = z*slack        = 3.551e-308   ->  under compl_inf_tol
+//!   status     = SolveSucceeded
+//! ```
+//!
+//! The complementarity that cleared the tolerance was the product of a slack
+//! nothing downstream can divide by: the same `s` puts `inf` on the KKT
+//! diagonal, and from there into every backsolve the sensitivity path makes.
+//!
+//! `calculate_safe_slack` now floors `s` at `max_i z_i / (f64::MAX/4)`, so the
+//! slack at that point is `1.877e-306`, `Σ` is `4.494e307`, and the honest
+//! complementarity is `1.584e-304` — which does *not* clear a `compl_inf_tol`
+//! of `1e-306`. The solve reports the stall it actually reached rather than a
+//! success, matching the issue's own table at `tol = 1e-308`.
+//!
+//! The trajectory is untouched: same 20 iterations, same objective to the last
+//! bit, same factorization counts. Only the final verdict moves, and only under
+//! tolerances this far into the subnormal range — `scripts/sweep-fixtures.sh`
+//! at default settings is byte-identical across the whole corpus.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pounce_cli::solve_report::SolveReport;
+use pounce_nlp::ApplicationReturnStatus;
+
+/// The issue's option set, verbatim.
+const PATHOLOGICAL: &[&str] = &[
+    "mu_strategy=adaptive",
+    "tol=1e-306",
+    "compl_inf_tol=1e-306",
+    "mu_min=5e-324",
+];
+
+fn solve(extra: &[&str]) -> SolveReport {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("pounce_issue655_{}_{n}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("scratch dir");
+    let json_path = dir.join("m.json");
+    let sol_path = dir.join("m.sol");
+
+    let mut fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    fixture.push("tests/fixtures/linear_eq_collapsed_box.nl");
+
+    let mut cmd = Command::new(PathBuf::from(env!("CARGO_BIN_EXE_pounce")));
+    cmd.arg(&fixture)
+        .arg(&sol_path)
+        .arg("--json-output")
+        .arg(&json_path)
+        // Hang guard only; nothing below asserts an iteration count.
+        .arg("max_iter=200");
+    for o in extra {
+        cmd.arg(o);
+    }
+    let _ = cmd.status().expect("spawn pounce");
+    let text = std::fs::read_to_string(&json_path).expect("read json report");
+    let _ = std::fs::remove_file(&json_path);
+    let _ = std::fs::remove_file(&sol_path);
+    serde_json::from_str(&text).expect("deserialize SolveReport")
+}
+
+#[test]
+fn a_solve_that_bottoms_out_on_a_subnormal_slack_does_not_report_success() {
+    let r = solve(PATHOLOGICAL);
+
+    // The answer is the same one the pre-fix run reported; the floor moves a
+    // slack, not the iterate.
+    assert!(
+        (r.statistics.final_objective - 161.999_997_84).abs() < 1e-6,
+        "objective moved: {}",
+        r.statistics.final_objective
+    );
+
+    // The point of the fix. `final_compl` is now `z·s` on a slack that can be
+    // divided by, and at `1.6e-304` it does not meet the `1e-306` the caller
+    // asked for — so the solve may not call itself converged.
+    assert!(
+        r.statistics.final_compl > 1e-306,
+        "complementarity {} clears compl_inf_tol=1e-306, which at this point \
+         is only reachable on a slack too small to divide z by (gh#655)",
+        r.statistics.final_compl
+    );
+    assert_ne!(
+        r.solution.status,
+        ApplicationReturnStatus::SolveSucceeded,
+        "reported success with a complementarity of {} against \
+         compl_inf_tol=1e-306 (gh#655)",
+        r.statistics.final_compl
+    );
+}
+
+#[test]
+fn the_same_fixture_still_converges_at_default_tolerances() {
+    // The guard above must not have cost the ordinary solve anything: nothing
+    // in this fixture is near the overflow edge at default `tol`.
+    let r = solve(&[]);
+    assert_eq!(r.solution.status, ApplicationReturnStatus::SolveSucceeded);
+    assert!(
+        (r.statistics.final_objective - 161.999_997_84).abs() < 1e-6,
+        "objective moved: {}",
+        r.statistics.final_objective
+    );
+}

--- a/docs/src/crossover.md
+++ b/docs/src/crossover.md
@@ -179,8 +179,10 @@ places it could have been done wrong:
   crossed-over point is strictly *interior* to the relaxed box, so its
   constraint violation is zero under either reading.
 - **The slacks are raw.** The interior machinery floors a slack that falls
-  below `eps·min(1,μ)` up to about `μ/z`, which is what keeps the barrier's
-  `Σ = V/S` finite while the iteration runs. At a purified point the active
+  below `eps·min(1,μ)` up to about `μ/z`, which is part of what keeps the
+  barrier's `Σ = V/S` finite while the iteration runs (the other part is
+  the representability floor `s ≥ max_i z_i / (f64::MAX/4)`, which is what
+  covers a subnormal `μ` — see below). At a purified point the active
   slacks are *exactly* zero, and that floor would put `μ/z ≈ 1e-9` straight
   back — reintroducing as a reporting artifact the very quantity crossover
   removed. The declared-frame measurement does not apply it.
@@ -243,6 +245,20 @@ at exactly zero degrades gracefully back to the pre-crossover `Σ = z²/μ`
 rather than dividing by nothing. The crossed-over slack measured here
 bottoms out at `1.8e-12` — the residual of the QP step plus line search
 — and never reaches the floor at all.
+
+"Along this path" is doing real work in that sentence, and it is worth
+knowing which part of the floor supplies the guarantee. `eps·min(1, μ)`
+is a threshold on the *barrier* term; nothing in it mentions the
+multiplier, so it bounds `Σ` only because a normal `μ` makes `μ/z` a
+usable slack. Push `μ` into the subnormal range and it stops covering
+anything — at `μ = 9.1e-308` the threshold is `2.0e-323`, small enough
+that a slack of `2.0e-308` clears it untouched and `z/s` overflows
+([#655](https://github.com/jkitchin/pounce/issues/655)). What makes
+`Σ` finite unconditionally is the second floor `CalculateSafeSlack`
+carries, `s ≥ max_i z_i / (f64::MAX/4)`, which is stated in terms of the
+quantity that has to stay representable rather than in terms of `μ`.
+Crossover never goes near either floor; the guarantee matters for the
+solves that do.
 
 ## Reading the result
 


### PR DESCRIPTION
## Problem

At `mu_strategy=adaptive`, `tol = compl_inf_tol = 1e-306`, `mu_min = 5e-324`, a
solve on a problem with an active bound carrying a nonzero multiplier returns
`SolveSucceeded` at a point where `Sigma = z/s` is `inf` — on the KKT diagonal,
and from there into every backsolve the sensitivity path makes.

The corpus reproduces it. `linear_eq_collapsed_box` under those settings:

| | status | objective | `final_compl` | iters | slack | `z` | `Sigma` |
|---|---|---|---|---|---|---|---|
| before | `SolveSucceeded` | 161.99999784 | 3.551e-308 | 20 | 4.209e-310 | 84.375 | **`inf`** |
| after | `SearchDirectionBecomesTooSmall` | 161.99999784 | 1.584e-304 | 20 | 1.877e-306 | 84.375 | 4.494e307 |

Same objective to the last bit, same iteration count, same factorization counts
and pivots. The only thing that moves is the verdict, and it moves because the
complementarity that cleared `compl_inf_tol` was the product of a slack nothing
downstream can divide by.

## Cause

`calculate_safe_slack` never fired at that point — and the issue's write-up gets
this half wrong, which matters for choosing the fix. #655 reasoned that
`s_min = eps * min(1, mu)` underflows to `0` at `mu = 9.09e-308`, so the code
substitutes `f64::MIN_POSITIVE` and pins the slack there. It does not: `eps * mu`
is `2.0e-323`, a representable subnormal rather than `0`. The slack of
`2.02e-308` clears that threshold, `min_slack >= s_min` returns early, and no
correction happens at all. Then `4.5 / 2.02e-308 = 2.2e308` overflows.

So the floor is not mis-sized, it is measuring the wrong thing. `eps * min(1, mu)`
is a floor on the **barrier** term and nothing in it mentions the multiplier. The
quantity that has to stay finite is `z/s`, and the floor that guarantees it is
`s >= z/f64::MAX` — which is the conclusion #655 reaches, by a different route.

## Fix

`s_min` now also carries `max_i z_i / (f64::MAX/4)`.

The quarter is headroom for the rounding in the divide itself and for the fact
that `Sigma_x` *sums* a lower and an upper ratio into one diagonal entry: each
ratio is bounded by `MAX/4`, their sum by `MAX/2`. The divide is written
`z_max / (f64::MAX / 4.0)` rather than `4.0 * z_max / f64::MAX` so a `z` near
`f64::MAX` cannot overflow the floor computation; a non-finite `z` leaves the
floor alone and is caught by the existing iterate finiteness checks.

It is applied at **two** sites, and both are load-bearing:

1. On `s_min` itself, which serves the `min_slack >= s_min` trigger and the
   `max(mu/z, s_min)` target. This is what catches the reported point.
2. Again *after* the `slack_move` bound-move cap. `t_max` bounds how far a bound
   may be nudged, which is a policy the user sets; a finite `z/s` is not one.
   The cap sits below the floor only when `slack_move * max(1,|bound|)` does —
   with the default `slack_move` that needs `max_i z_i` past `6e295`, and
   `slack_move = 0` (the "never move a bound" setting) makes it exact — but
   where it does, the `min` would hand back the very slack the correction was
   called to repair.

Taken over `max_i z_i` rather than componentwise so one scalar also serves the
trigger. That is conservative in the harmless direction: it can only raise a
flagged slack further, and raising a slack only lowers `Sigma`.

**Rejected: failing loudly instead.** #655 offers "failing loudly or flooring `s`
at `z/f64::MAX`" as equally good. Flooring is strictly better here because it is
the same repair `calculate_safe_slack` already exists to perform, and it lets the
convergence check reach the honest answer on its own — which is exactly what
happens to `linear_eq_collapsed_box` below. An error path would have had to
invent a new status for a condition the existing `SearchDirectionBecomesTooSmall`
already describes.

## The doc corrections that come with it

#656 — the PR that filed this issue — has since landed, and #651 with it. Both
are merged in here, so this branch is a plain descendant of `main` again.

#656's prose attributes `Σ`'s finiteness to the `eps·min(1,μ)` threshold: the
threshold this PR shows does not bound `z/s` once `μ` goes subnormal.
**#656's measurements are unaffected and stand as written** — its crossover
slacks bottom out at `1.8e-12`, nowhere near either floor, and its three tests
pass unchanged with the floor in place. What changed is attribution, in three
places:

* `docs/src/crossover.md`, #656's new section — its claim was already scoped
  "along this path", which is true. Added a paragraph saying which part of the
  floor supplies the guarantee and which part stops covering anything at
  subnormal `μ`.
* `CHANGELOG.md`, #656's entry — this one said "`Σ` never goes infinite" with no
  path scoping, which #655 shows is false in general. Scoped, with a pointer to
  the representability floor.
* `docs/src/crossover.md`, the pre-existing "the slacks are raw" bullet — same
  single-floor attribution, in main since #646. Now names both floors.

The `[Unreleased]` seam was checked by hand after each merge: `merge=union` keeps
both sides' lines silently, so a reworded entry can land twice. It did not — one
copy of each entry, and the #656 sentence is the corrected one.

## Blast radius

`calculate_safe_slack` runs on every iteration, so this is trajectory-touching
per `CLAUDE.md` even though the new branch can only fire in the subnormal regime.
`scripts/sweep-fixtures.sh`, all 57 CLI fixtures, release build against the same
build without this branch's fix commit:

* **Default settings — bit-identical.** Same status, objective and iteration
  count on every fixture. The floor sits at `z_max/4.5e307`, below every slack an
  ordinary iterate carries, so the new branch never fires.
* **Under the issue's settings** (`mu_strategy=adaptive tol=1e-306
  compl_inf_tol=1e-306 mu_min=5e-324`, plus `max_iter=200` to bound the sweep) —
  **one line moves**, the `linear_eq_collapsed_box` row in the table above.

Measured twice, because the baseline moved under it: first against `9e9b0ac`
(the original parent), then re-run against `8ec8f45` after merging #650 in, since
#650 moves solver code. Both sweeps give the identical result stated above. For
what it is worth, `9e9b0ac` → `8ec8f45` is itself bit-identical on the corpus at
default settings, so #650 did not move the corner this touches either. The #651
and #656 merges that followed need no third sweep: between them they touch the
CasADi plugin, the C interface header, two docs pages, CHANGELOG and a new test
file — no Rust solver code.

That one line is the fix working, not a cost of it. The trajectory is identical;
the complementarity is now measured on a slack that can be divided by, and at
`1.58e-304` it does not meet the `1e-306` the caller asked for. A solve that
cannot reach the requested complementarity with a representable slack now says so
instead of claiming success — which is what #655's own table already reports one
notch further down, at `tol = 1e-308`.

## Tests

Three unit tests in `ipopt_cq`:

* `subnormal_slack_does_not_overflow_sigma` — the reported point verbatim
  (`mu = 9.0909e-308`, slack `2.0202e-308`, `z = 4.5`). It also asserts the
  premise, that the barrier-side threshold does not catch this point, so the test
  documents the corrected mechanism rather than the one in the issue text.
* `representability_floor_survives_the_bound_move_cap` — `z = 1e300` against a
  slack of `1e-300`, where the cap is the binding constraint.
* `ordinary_small_slack_is_left_exactly_alone` — a slack of `1e-20` must come
  back bit-identical, `assert_eq!` on the raw value.

Plus `crates/pounce-cli/tests/issue_655_subnormal_slack_sigma.rs`, end to end
over the fixture, pinning both the pathological-tolerance verdict and that the
default-tolerance solve still converges.

**How I know they bite.** Both new-behaviour unit tests were run against the
parent commit's logic and fail there with `Sigma_x[0] = inf is not finite` — and
they were run against each half of the fix disabled separately, each half failing
its own test, which is how I know site 2 is not redundant with site 1. The
end-to-end test fails on the parent for the stated reason too: that is the
`before` row of the table, `SolveSucceeded` at `final_compl = 3.551e-308`, which
trips both of its assertions.

CI was green on `6b1ebdc`, the last commit before the #656 merge. Locally,
`pounce-algorithm`, `pounce-cli` and `pounce-sensitivity` — including #656's
three new tests — are green on the current head, and `cargo fmt --all -- --check`
is clean.

**A gap, deliberately stated.** `cargo test --workspace` does not complete in
this container: `pounce-hsl`'s MA57 tests need `COINHSL_DIR`, and a full
workspace test build exhausts the disk allowance (linker dies with a bus error).
Neither is related to this change, but it means the crates named above are the
extent of what I ran green locally; the rest is on CI.

---

- [x] Tests fail on the parent commit for the stated reason
- [x] `CHANGELOG.md` `[Unreleased]` entry, in the user's terms
- [x] Book page under `docs/src/` updated — `crossover.md`, two attribution
      corrections described above; no new page, no `SUMMARY.md` change
- [x] `cargo fmt --all -- --check` and `cargo clippy` clean (no new warnings in
      `ipopt_cq.rs`); `cargo test` green on the crates above, with the
      workspace-run caveat stated under Tests
- [x] Every claim in this PR body and in the code comments is true of the code
      as it stands now

**Correction to an earlier revision of this body:** it said the sentence needing
repair was in `docs/src/crossover.md` as #656 wrote it. It was in #656's PR
description; the doc text was already scoped "along this path" and was not wrong.
The three edits actually made are listed above.

Fixes #655